### PR TITLE
Fix Clippy lint in negotiation detector

### DIFF
--- a/crates/protocol/src/negotiation.rs
+++ b/crates/protocol/src/negotiation.rs
@@ -116,7 +116,7 @@ impl NegotiationPrologueDetector {
             self.buffer[self.len] = byte;
             self.len += 1;
 
-            if &self.buffer[..self.len] == &prefix[..self.len] {
+            if self.buffer[..self.len] == prefix[..self.len] {
                 if self.len == LEGACY_DAEMON_PREFIX_LEN {
                     return self.decide(NegotiationPrologue::LegacyAscii);
                 }


### PR DESCRIPTION
## Summary
- remove redundant reference comparisons when checking the legacy greeting prefix in the negotiation prologue detector to satisfy clippy::op_ref

## Testing
- cargo test
- cargo clippy

------