### PR TITLE
Add multiplexed message envelope utilities

### DIFF
--- a/crates/protocol/src/envelope.rs
+++ b/crates/protocol/src/envelope.rs
@@ -1,0 +1,247 @@
+use core::convert::TryFrom;
+use core::fmt;
+
+/// Number of bytes in a multiplexed rsync message header.
+pub const HEADER_LEN: usize = 4;
+
+/// Maximum payload length representable in a multiplexed header.
+pub const MAX_PAYLOAD_LENGTH: u32 = 0x00FF_FFFF;
+
+const MPLEX_BASE: u8 = 7;
+const PAYLOAD_MASK: u32 = 0x00FF_FFFF;
+
+/// Tags used for multiplexed messages flowing over the rsync protocol stream.
+///
+/// The numeric values mirror the upstream `enum msgcode` definitions so that
+/// higher layers can reason about message semantics without translating between
+/// Rust and C identifiers. Values that alias upstream `enum logcode`
+/// definitions retain their historic numbering to ensure interoperability with
+/// existing daemons.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u8)]
+pub enum MessageCode {
+    /// Raw file data written to the multiplexed stream.
+    Data = 0,
+    /// Fatal transfer error (`FERROR_XFER`).
+    ErrorXfer = 1,
+    /// Informational log message (`FINFO`).
+    Info = 2,
+    /// Non-fatal error (`FERROR`).
+    Error = 3,
+    /// Warning message (`FWARNING`).
+    Warning = 4,
+    /// Error emitted by the sibling process over the receiver/generator pipe
+    /// (`FERROR_SOCKET`).
+    ErrorSocket = 5,
+    /// Log message only written to the daemon logs (`FLOG`).
+    Log = 6,
+    /// Client-only message (`FCLIENT`).
+    Client = 7,
+    /// UTF-8 conversion problem reported by a sibling (`FERROR_UTF8`).
+    ErrorUtf8 = 8,
+    /// Request to reprocess a specific file-list index.
+    Redo = 9,
+    /// Transfer statistics destined for the generator.
+    Stats = 10,
+    /// Sender encountered an I/O error while accessing the source tree.
+    IoError = 22,
+    /// Daemon communicating its timeout to the peer.
+    IoTimeout = 33,
+    /// Legacy no-op message (protocol 30 compatibility).
+    NoOp = 42,
+    /// Synchronizes an error exit across processes (protocol ≥ 31).
+    ErrorExit = 86,
+    /// Receiver reports a successfully updated file.
+    Success = 100,
+    /// Receiver reports a deleted file.
+    Deleted = 101,
+    /// Sender failed to open a requested file.
+    NoSend = 102,
+}
+
+impl MessageCode {
+    /// Returns the numeric representation expected on the wire.
+    #[must_use]
+    #[inline]
+    pub const fn as_u8(self) -> u8 {
+        self as u8
+    }
+}
+
+impl TryFrom<u8> for MessageCode {
+    type Error = EnvelopeError;
+
+    fn try_from(value: u8) -> Result<Self, EnvelopeError> {
+        match value {
+            0 => Ok(Self::Data),
+            1 => Ok(Self::ErrorXfer),
+            2 => Ok(Self::Info),
+            3 => Ok(Self::Error),
+            4 => Ok(Self::Warning),
+            5 => Ok(Self::ErrorSocket),
+            6 => Ok(Self::Log),
+            7 => Ok(Self::Client),
+            8 => Ok(Self::ErrorUtf8),
+            9 => Ok(Self::Redo),
+            10 => Ok(Self::Stats),
+            22 => Ok(Self::IoError),
+            33 => Ok(Self::IoTimeout),
+            42 => Ok(Self::NoOp),
+            86 => Ok(Self::ErrorExit),
+            100 => Ok(Self::Success),
+            101 => Ok(Self::Deleted),
+            102 => Ok(Self::NoSend),
+            other => Err(EnvelopeError::UnknownMessageCode(other)),
+        }
+    }
+}
+
+/// Failures encountered while parsing or constructing multiplexed message headers.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum EnvelopeError {
+    /// Fewer than [`HEADER_LEN`] bytes were provided when attempting to decode a
+    /// header.
+    TruncatedHeader {
+        /// Number of bytes that were available when decoding began.
+        actual: usize,
+    },
+    /// The high tag byte did not include the required [`MPLEX_BASE`] offset.
+    InvalidTag(u8),
+    /// The encoded message code is not understood by rsync 3.4.1.
+    UnknownMessageCode(u8),
+    /// The payload length exceeded the representable range.
+    OversizedPayload(u32),
+}
+
+impl fmt::Display for EnvelopeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::TruncatedHeader { actual } => {
+                write!(
+                    f,
+                    "multiplexed header truncated: expected {HEADER_LEN} bytes, got {actual}"
+                )
+            }
+            Self::InvalidTag(tag) => {
+                write!(f, "multiplexed header contained invalid tag byte {tag}")
+            }
+            Self::UnknownMessageCode(code) => {
+                write!(f, "unknown multiplexed message code {code}")
+            }
+            Self::OversizedPayload(len) => {
+                write!(
+                    f,
+                    "multiplexed payload length {len} exceeds maximum {MAX_PAYLOAD_LENGTH}"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for EnvelopeError {}
+
+/// A fully decoded multiplexed message header.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct MessageHeader {
+    code: MessageCode,
+    payload_len: u32,
+}
+
+impl MessageHeader {
+    /// Creates a new header for `code` with the provided payload length.
+    pub fn new(code: MessageCode, payload_len: u32) -> Result<Self, EnvelopeError> {
+        if payload_len > MAX_PAYLOAD_LENGTH {
+            return Err(EnvelopeError::OversizedPayload(payload_len));
+        }
+
+        Ok(Self { code, payload_len })
+    }
+
+    /// Parses a header from the beginning of `bytes`.
+    pub fn decode(bytes: &[u8]) -> Result<Self, EnvelopeError> {
+        if bytes.len() < HEADER_LEN {
+            return Err(EnvelopeError::TruncatedHeader {
+                actual: bytes.len(),
+            });
+        }
+
+        let raw = u32::from_le_bytes(
+            bytes[..HEADER_LEN]
+                .try_into()
+                .expect("slice length checked"),
+        );
+        let tag = (raw >> 24) as u8;
+        if tag < MPLEX_BASE {
+            return Err(EnvelopeError::InvalidTag(tag));
+        }
+
+        let code_value = tag - MPLEX_BASE;
+        let code = MessageCode::try_from(code_value)?;
+        let payload_len = raw & PAYLOAD_MASK;
+
+        Self::new(code, payload_len)
+    }
+
+    /// Encodes this header into the little-endian format used on the wire.
+    #[must_use]
+    pub fn encode(self) -> [u8; HEADER_LEN] {
+        let tag = u32::from(MPLEX_BASE) + u32::from(self.code.as_u8());
+        let raw = (tag << 24) | (self.payload_len & PAYLOAD_MASK);
+        raw.to_le_bytes()
+    }
+
+    /// Returns the decoded message code.
+    #[must_use]
+    #[inline]
+    pub const fn code(self) -> MessageCode {
+        self.code
+    }
+
+    /// Returns the payload length encoded in the header.
+    #[must_use]
+    #[inline]
+    pub const fn payload_len(self) -> u32 {
+        self.payload_len
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn header_round_trips_for_info_message() {
+        let header = MessageHeader::new(MessageCode::Info, 123).expect("constructible header");
+        let encoded = header.encode();
+        let decoded = MessageHeader::decode(&encoded).expect("decode succeeds");
+        assert_eq!(decoded, header);
+    }
+
+    #[test]
+    fn decode_rejects_truncated_header() {
+        let err = MessageHeader::decode(&[0u8; 2]).unwrap_err();
+        assert_eq!(err, EnvelopeError::TruncatedHeader { actual: 2 });
+    }
+
+    #[test]
+    fn decode_rejects_tag_without_base_offset() {
+        let raw = (u32::from(MPLEX_BASE - 1) << 24) | 1;
+        let err = MessageHeader::decode(&raw.to_le_bytes()).unwrap_err();
+        assert_eq!(err, EnvelopeError::InvalidTag(MPLEX_BASE - 1));
+    }
+
+    #[test]
+    fn decode_rejects_unknown_message_codes() {
+        let unknown_code = 11u8;
+        let tag = u32::from(MPLEX_BASE) + u32::from(unknown_code);
+        let raw = (tag << 24) | 5;
+        let err = MessageHeader::decode(&raw.to_le_bytes()).unwrap_err();
+        assert_eq!(err, EnvelopeError::UnknownMessageCode(unknown_code));
+    }
+
+    #[test]
+    fn new_rejects_oversized_payloads() {
+        let err = MessageHeader::new(MessageCode::Info, MAX_PAYLOAD_LENGTH + 1).unwrap_err();
+        assert_eq!(err, EnvelopeError::OversizedPayload(MAX_PAYLOAD_LENGTH + 1));
+    }
+}

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -9,11 +9,16 @@
 //! agnostic to the internal layout while benefitting from the reduced file
 //! sizes required by the workspace style guide.
 
+mod envelope;
 mod error;
 mod legacy;
+mod multiplex;
 mod negotiation;
 mod version;
 
+pub use envelope::{
+    EnvelopeError, HEADER_LEN as MESSAGE_HEADER_LEN, MAX_PAYLOAD_LENGTH, MessageCode, MessageHeader,
+};
 pub use error::NegotiationError;
 pub use legacy::{
     LegacyDaemonMessage, format_legacy_daemon_greeting, parse_legacy_daemon_greeting,
@@ -22,6 +27,7 @@ pub use legacy::{
     parse_legacy_error_message_bytes, parse_legacy_warning_message,
     parse_legacy_warning_message_bytes,
 };
+pub use multiplex::{MessageFrame, recv_msg, send_msg};
 pub use negotiation::{
     NegotiationPrologue, NegotiationPrologueDetector, detect_negotiation_prologue,
 };

--- a/crates/protocol/src/multiplex.rs
+++ b/crates/protocol/src/multiplex.rs
@@ -1,0 +1,140 @@
+use std::convert::TryFrom;
+use std::io::{self, Read, Write};
+
+use crate::envelope::{EnvelopeError, HEADER_LEN, MessageCode, MessageHeader};
+
+/// A decoded multiplexed message consisting of the tag and payload bytes.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MessageFrame {
+    code: MessageCode,
+    payload: Vec<u8>,
+}
+
+impl MessageFrame {
+    /// Constructs a frame from a message code and owned payload bytes.
+    pub fn new(code: MessageCode, payload: Vec<u8>) -> Result<Self, io::Error> {
+        let len = u32::try_from(payload.len()).map_err(|_| invalid_len_error())?;
+        MessageHeader::new(code, len).map_err(map_envelope_error_for_input)?;
+        Ok(Self { code, payload })
+    }
+
+    /// Returns the message code associated with the frame.
+    #[must_use]
+    pub const fn code(&self) -> MessageCode {
+        self.code
+    }
+
+    /// Returns the raw payload bytes carried by the frame.
+    #[must_use]
+    pub fn payload(&self) -> &[u8] {
+        &self.payload
+    }
+
+    /// Consumes the frame and returns the owned payload bytes.
+    #[must_use]
+    pub fn into_payload(self) -> Vec<u8> {
+        self.payload
+    }
+}
+
+/// Sends a multiplexed message to `writer` using the upstream rsync envelope format.
+///
+/// The payload length is validated against [`MAX_PAYLOAD_LENGTH`], mirroring the
+/// 24-bit limit imposed by the C implementation. Violations result in
+/// [`io::ErrorKind::InvalidInput`].
+pub fn send_msg<W: Write>(writer: &mut W, code: MessageCode, payload: &[u8]) -> io::Result<()> {
+    let len = u32::try_from(payload.len()).map_err(|_| invalid_len_error())?;
+    let header = MessageHeader::new(code, len).map_err(map_envelope_error_for_input)?;
+    writer.write_all(&header.encode())?;
+    writer.write_all(payload)?;
+    Ok(())
+}
+
+/// Receives the next multiplexed message from `reader`.
+///
+/// The function blocks until the full header and payload are read or an I/O
+/// error occurs. Invalid headers surface as [`io::ErrorKind::InvalidData`].
+pub fn recv_msg<R: Read>(reader: &mut R) -> io::Result<MessageFrame> {
+    let mut header_bytes = [0u8; HEADER_LEN];
+    reader.read_exact(&mut header_bytes)?;
+    let header = MessageHeader::decode(&header_bytes).map_err(map_envelope_error)?;
+    let len = header.payload_len() as usize;
+
+    let mut payload = vec![0u8; len];
+    reader.read_exact(&mut payload)?;
+
+    Ok(MessageFrame {
+        code: header.code(),
+        payload,
+    })
+}
+
+fn map_envelope_error(err: EnvelopeError) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, err)
+}
+
+fn map_envelope_error_for_input(err: EnvelopeError) -> io::Error {
+    match err {
+        EnvelopeError::OversizedPayload(_) => io::Error::new(io::ErrorKind::InvalidInput, err),
+        other => map_envelope_error(other),
+    }
+}
+
+fn invalid_len_error() -> io::Error {
+    io::Error::new(
+        io::ErrorKind::InvalidInput,
+        "multiplexed payload length exceeds representable range",
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::envelope::MAX_PAYLOAD_LENGTH;
+
+    #[test]
+    fn send_and_receive_round_trip_info_message() {
+        let mut buffer = Vec::new();
+        send_msg(&mut buffer, MessageCode::Info, b"hello world").expect("send succeeds");
+
+        let mut cursor = io::Cursor::new(buffer);
+        let frame = recv_msg(&mut cursor).expect("receive succeeds");
+        assert_eq!(frame.code(), MessageCode::Info);
+        assert_eq!(frame.payload(), b"hello world");
+    }
+
+    #[test]
+    fn recv_msg_reports_truncated_payload() {
+        let header = MessageHeader::new(MessageCode::Warning, 4)
+            .expect("header")
+            .encode();
+        let mut buffer = header.to_vec();
+        buffer.extend_from_slice(&[1, 2]);
+
+        let err = recv_msg(&mut io::Cursor::new(buffer)).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::UnexpectedEof);
+    }
+
+    #[test]
+    fn recv_msg_rejects_unknown_message_codes() {
+        let unknown_code = 11u8;
+        let tag = u32::from(7u8) + u32::from(unknown_code); // MPLEX_BASE + unknown code
+        let raw = (tag << 24).to_le_bytes();
+        let err = recv_msg(&mut io::Cursor::new(raw)).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn send_msg_rejects_oversized_payload() {
+        let payload = vec![0u8; (MAX_PAYLOAD_LENGTH + 1) as usize];
+        let err = send_msg(&mut io::sink(), MessageCode::Error, &payload).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+    }
+
+    #[test]
+    fn message_frame_new_validates_payload_length() {
+        let frame = MessageFrame::new(MessageCode::Stats, b"stats".to_vec()).expect("frame");
+        assert_eq!(frame.code(), MessageCode::Stats);
+        assert_eq!(frame.payload(), b"stats");
+    }
+}


### PR DESCRIPTION
## Summary
- add a protocol envelope module that mirrors rsync's multiplexed message codes and header encoding
- add send/receive helpers for multiplexed frames with validation and tests, re-exported through the protocol facade

## Testing
- cargo test

------