### PR TITLE
Derive Hash for protocol data structures

### DIFF
--- a/crates/protocol/src/envelope.rs
+++ b/crates/protocol/src/envelope.rs
@@ -17,7 +17,7 @@ const PAYLOAD_MASK: u32 = 0x00FF_FFFF;
 /// Rust and C identifiers. Values that alias upstream `enum logcode`
 /// definitions retain their historic numbering to ensure interoperability with
 /// existing daemons.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 #[repr(u8)]
 pub enum MessageCode {
     /// Raw file data written to the multiplexed stream.
@@ -97,7 +97,7 @@ impl TryFrom<u8> for MessageCode {
 }
 
 /// Failures encountered while parsing or constructing multiplexed message headers.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub enum EnvelopeError {
     /// Fewer than [`HEADER_LEN`] bytes were provided when attempting to decode a
     /// header.
@@ -141,7 +141,7 @@ impl fmt::Display for EnvelopeError {
 impl std::error::Error for EnvelopeError {}
 
 /// A fully decoded multiplexed message header.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct MessageHeader {
     code: MessageCode,
     payload_len: u32,

--- a/crates/protocol/src/legacy.rs
+++ b/crates/protocol/src/legacy.rs
@@ -95,7 +95,7 @@ fn malformed_legacy_greeting(trimmed: &str) -> NegotiationError {
 /// the ASCII-based negotiation path. These lines reuse the same prefix as the
 /// version greeting, so higher level code benefits from a typed representation
 /// to avoid stringly-typed comparisons while still mirroring upstream behavior.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub enum LegacyDaemonMessage<'a> {
     /// A protocol version announcement such as `@RSYNCD: 30.0`.
     Version(ProtocolVersion),

--- a/crates/protocol/src/multiplex.rs
+++ b/crates/protocol/src/multiplex.rs
@@ -4,7 +4,7 @@ use std::io::{self, Read, Write};
 use crate::envelope::{EnvelopeError, HEADER_LEN, MessageCode, MessageHeader};
 
 /// A decoded multiplexed message consisting of the tag and payload bytes.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct MessageFrame {
     code: MessageCode,
     payload: Vec<u8>,

--- a/crates/protocol/src/negotiation.rs
+++ b/crates/protocol/src/negotiation.rs
@@ -13,7 +13,7 @@ use crate::legacy::{LEGACY_DAEMON_PREFIX, LEGACY_DAEMON_PREFIX_LEN};
 /// later validation). Otherwise the exchange proceeds in binary mode. When the
 /// caller has not yet accumulated enough bytes to decide, the helper reports
 /// [`NegotiationPrologue::NeedMoreData`].
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum NegotiationPrologue {
     /// There is not enough buffered data to determine the negotiation style.
     NeedMoreData,

--- a/crates/protocol/src/version.rs
+++ b/crates/protocol/src/version.rs
@@ -14,7 +14,7 @@ pub const SUPPORTED_PROTOCOLS: [u8; 5] = [32, 31, 30, 29, 28];
 const UPSTREAM_PROTOCOL_RANGE: RangeInclusive<u8> = 28..=32;
 
 /// A single negotiated rsync protocol version.
-#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct ProtocolVersion(NonZeroU8);
 
 impl ProtocolVersion {


### PR DESCRIPTION
## Summary
- derive `Hash` for protocol enums and structs that participate in negotiation and multiplexing so they can be stored in hashed collections without manual wrappers

## Testing
- cargo test

------