### PR TITLE
Add buffer-reusing multiplex receive helper

### DIFF
--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -27,7 +27,7 @@ pub use legacy::{
     parse_legacy_error_message_bytes, parse_legacy_warning_message,
     parse_legacy_warning_message_bytes,
 };
-pub use multiplex::{MessageFrame, recv_msg, send_msg};
+pub use multiplex::{MessageFrame, recv_msg, recv_msg_into, send_msg};
 pub use negotiation::{
     NegotiationPrologue, NegotiationPrologueDetector, detect_negotiation_prologue,
 };


### PR DESCRIPTION
## Summary
- add a `recv_msg_into` helper that reads multiplexed payloads into a caller-provided buffer
- share header decoding between receive helpers and re-export the new API from the crate root

## Testing
- cargo test

------