### PR TITLE
Eliminate expect usage from protocol envelope conversions

### DIFF
--- a/crates/protocol/src/envelope.rs
+++ b/crates/protocol/src/envelope.rs
@@ -198,11 +198,9 @@ impl MessageHeader {
             });
         }
 
-        let raw = u32::from_le_bytes(
-            bytes[..HEADER_LEN]
-                .try_into()
-                .expect("slice length checked"),
-        );
+        let mut encoded = [0u8; HEADER_LEN];
+        encoded.copy_from_slice(&bytes[..HEADER_LEN]);
+        let raw = u32::from_le_bytes(encoded);
         let tag = (raw >> 24) as u8;
         if tag < MPLEX_BASE {
             return Err(EnvelopeError::InvalidTag(tag));

--- a/crates/protocol/src/multiplex.rs
+++ b/crates/protocol/src/multiplex.rs
@@ -17,8 +17,8 @@ impl MessageFrame {
             return Err(invalid_len_error(len));
         }
 
-        let len = u32::try_from(len).expect("checked against MAX_PAYLOAD_LENGTH");
-        MessageHeader::new(code, len).map_err(map_envelope_error_for_input)?;
+        let payload_len = len as u32;
+        MessageHeader::new(code, payload_len).map_err(map_envelope_error_for_input)?;
         Ok(Self { code, payload })
     }
 
@@ -62,8 +62,8 @@ pub fn send_msg<W: Write>(writer: &mut W, code: MessageCode, payload: &[u8]) -> 
         return Err(invalid_len_error(len));
     }
 
-    let len = u32::try_from(len).expect("checked against MAX_PAYLOAD_LENGTH");
-    let header = MessageHeader::new(code, len).map_err(map_envelope_error_for_input)?;
+    let payload_len = len as u32;
+    let header = MessageHeader::new(code, payload_len).map_err(map_envelope_error_for_input)?;
     writer.write_all(&header.encode())?;
     writer.write_all(payload)?;
     Ok(())


### PR DESCRIPTION
## Summary
- replace expect-based header decoding with an explicit copy during multiplex header decoding
- swap expect-based payload length conversions for direct casts after bounds checking

## Testing
- cargo test

------