### PR TITLE
Add tests for legacy negotiation helpers

### DIFF
--- a/crates/protocol/src/legacy/mod.rs
+++ b/crates/protocol/src/legacy/mod.rs
@@ -31,3 +31,29 @@ pub(super) fn lossy_trimmed_input(bytes: &[u8]) -> String {
     }
     owned
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lossy_trimmed_input_drops_trailing_newlines() {
+        assert_eq!(lossy_trimmed_input(b"@RSYNCD: OK\r\n"), "@RSYNCD: OK");
+    }
+
+    #[test]
+    fn lossy_trimmed_input_replaces_invalid_utf8() {
+        assert_eq!(lossy_trimmed_input(b"@RSYNCD: AUTHREQD\xff\n"), "@RSYNCD: AUTHREQD\u{fffd}");
+    }
+
+    #[test]
+    fn malformed_legacy_greeting_preserves_trimmed_input() {
+        let err = malformed_legacy_greeting("@RSYNCD: ???");
+        assert_eq!(
+            err,
+            NegotiationError::MalformedLegacyGreeting {
+                input: "@RSYNCD: ???".to_owned(),
+            }
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests for the lossy legacy input helper to cover newline trimming and invalid UTF-8
- verify malformed legacy greeting errors retain the trimmed banner text

## Testing
- cargo test

------