### PR TITLE
Fix multiplex recv payload handling

### DIFF
--- a/crates/protocol/src/legacy/mod.rs
+++ b/crates/protocol/src/legacy/mod.rs
@@ -43,7 +43,10 @@ mod tests {
 
     #[test]
     fn lossy_trimmed_input_replaces_invalid_utf8() {
-        assert_eq!(lossy_trimmed_input(b"@RSYNCD: AUTHREQD\xff\n"), "@RSYNCD: AUTHREQD\u{fffd}");
+        assert_eq!(
+            lossy_trimmed_input(b"@RSYNCD: AUTHREQD\xff\n"),
+            "@RSYNCD: AUTHREQD\u{fffd}"
+        );
     }
 
     #[test]

--- a/crates/protocol/src/multiplex.rs
+++ b/crates/protocol/src/multiplex.rs
@@ -77,13 +77,16 @@ pub fn recv_msg<R: Read>(reader: &mut R) -> io::Result<MessageFrame> {
     let header = read_header(reader)?;
     let len = header.payload_len() as usize;
 
-    buffer.clear();
+    let mut payload = Vec::with_capacity(len);
     if len != 0 {
-        buffer.resize(len, 0);
-        reader.read_exact(buffer)?;
+        payload.resize(len, 0);
+        reader.read_exact(&mut payload)?;
     }
 
-    Ok(header.code())
+    Ok(MessageFrame {
+        code: header.code(),
+        payload,
+    })
 }
 
 /// Receives the next multiplexed message into a caller-provided buffer.


### PR DESCRIPTION
## Summary
- ensure `recv_msg` allocates a payload buffer and reads data before returning a frame
- run `cargo fmt` to keep formatting consistent across touched files

## Testing
- `cargo test`

------