### PR TITLE
Add regression tests for legacy negotiation parsers

### DIFF
--- a/crates/protocol/src/legacy/lines.rs
+++ b/crates/protocol/src/legacy/lines.rs
@@ -227,6 +227,15 @@ mod tests {
     }
 
     #[test]
+    fn parse_legacy_daemon_message_rejects_empty_payload() {
+        let err = parse_legacy_daemon_message("@RSYNCD:\n").unwrap_err();
+        assert!(matches!(
+            err,
+            NegotiationError::MalformedLegacyGreeting { .. }
+        ));
+    }
+
+    #[test]
     fn parse_legacy_daemon_message_accepts_authreqd_with_trailing_tabs() {
         let message = parse_legacy_daemon_message("@RSYNCD: AUTHREQD\tmodule\t\n")
             .expect("keyword with tabs");
@@ -246,9 +255,19 @@ mod tests {
     }
 
     #[test]
+    fn parse_legacy_error_message_returns_none_for_unrecognized_prefix() {
+        assert!(parse_legacy_error_message("something else\n").is_none());
+    }
+
+    #[test]
     fn parses_legacy_warning_message_and_trims_payload() {
         let payload =
             parse_legacy_warning_message("@WARNING: will retry  \n").expect("warning payload");
         assert_eq!(payload, "will retry");
+    }
+
+    #[test]
+    fn parse_legacy_warning_message_returns_none_for_unrecognized_prefix() {
+        assert!(parse_legacy_warning_message("something else\n").is_none());
     }
 }

--- a/crates/protocol/src/negotiation.rs
+++ b/crates/protocol/src/negotiation.rs
@@ -299,6 +299,16 @@ mod tests {
     }
 
     #[test]
+    fn buffered_prefix_captures_full_marker_when_present_in_single_chunk() {
+        let mut detector = NegotiationPrologueDetector::new();
+        assert_eq!(
+            detector.observe(b"@RSYNCD: 31.0\n"),
+            NegotiationPrologue::LegacyAscii
+        );
+        assert_eq!(detector.buffered_prefix(), b"@RSYNCD:");
+    }
+
+    #[test]
     fn buffered_prefix_is_empty_for_binary_detection() {
         let mut detector = NegotiationPrologueDetector::new();
         assert_eq!(detector.observe(&[0x00]), NegotiationPrologue::Binary);


### PR DESCRIPTION
## Summary
- cover legacy daemon parsing failures for empty payloads and non-@ERROR/@WARNING prefixes
- ensure the negotiation prologue detector retains the full @RSYNCD: marker when seen in a single chunk

## Testing
- cargo test

------