### PR TITLE
Collapse nested filter capacity check

### DIFF
--- a/crates/protocol/src/version.rs
+++ b/crates/protocol/src/version.rs
@@ -194,11 +194,9 @@ where
         match ProtocolVersion::from_peer_advertisement(version) {
             Ok(proto) => {
                 let value = proto.as_u8();
-                if !filtered[..filtered_len].contains(&value) {
-                    if filtered_len < filtered.len() {
-                        filtered[filtered_len] = value;
-                        filtered_len += 1;
-                    }
+                if !filtered[..filtered_len].contains(&value) && filtered_len < filtered.len() {
+                    filtered[filtered_len] = value;
+                    filtered_len += 1;
                 }
             }
             Err(NegotiationError::UnsupportedVersion(value))


### PR DESCRIPTION
## Summary
- collapse the nested deduplication and capacity guard in `select_highest_mutual` for clarity

## Testing
- cargo fmt
- cargo clippy
- cargo test

------