### PR TITLE
Add MessageCode FromStr support for mnemonic parsing

### DIFF
--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -17,7 +17,8 @@ mod negotiation;
 mod version;
 
 pub use envelope::{
-    EnvelopeError, HEADER_LEN as MESSAGE_HEADER_LEN, MAX_PAYLOAD_LENGTH, MessageCode, MessageHeader,
+    EnvelopeError, HEADER_LEN as MESSAGE_HEADER_LEN, MAX_PAYLOAD_LENGTH, MessageCode,
+    MessageHeader, ParseMessageCodeError,
 };
 pub use error::NegotiationError;
 pub use legacy::{


### PR DESCRIPTION
## Summary
- add a ParseMessageCodeError type and FromStr implementation so MessageCode can be parsed from MSG_* mnemonics
- re-export the new error type from the protocol crate root and exercise the parser with unit tests

## Testing
- cargo test

------