### PR TITLE
Add tests for empty legacy daemon error and warning payloads

### DIFF
--- a/crates/protocol/src/legacy/bytes.rs
+++ b/crates/protocol/src/legacy/bytes.rs
@@ -119,6 +119,12 @@ mod tests {
     }
 
     #[test]
+    fn parse_legacy_error_message_bytes_allows_empty_payload() {
+        let payload = parse_legacy_error_message_bytes(b"@ERROR:\r\n").expect("parse");
+        assert_eq!(payload, Some(""));
+    }
+
+    #[test]
     fn rejects_non_utf8_legacy_error_message_bytes() {
         let err = parse_legacy_error_message_bytes(b"@ERROR: denied\xff\r\n").unwrap_err();
         match err {
@@ -140,6 +146,12 @@ mod tests {
     fn parse_legacy_warning_message_bytes_returns_none_for_unrecognized_prefix() {
         let payload = parse_legacy_warning_message_bytes(b"another prefix\n").expect("parse");
         assert_eq!(payload, None);
+    }
+
+    #[test]
+    fn parse_legacy_warning_message_bytes_allows_empty_payload() {
+        let payload = parse_legacy_warning_message_bytes(b"@WARNING:\n").expect("parse");
+        assert_eq!(payload, Some(""));
     }
 
     #[test]

--- a/crates/protocol/src/legacy/lines.rs
+++ b/crates/protocol/src/legacy/lines.rs
@@ -267,6 +267,12 @@ mod tests {
     }
 
     #[test]
+    fn parse_legacy_error_message_allows_empty_payload() {
+        let payload = parse_legacy_error_message("@ERROR:\n").expect("empty payload");
+        assert_eq!(payload, "");
+    }
+
+    #[test]
     fn parse_legacy_error_message_returns_none_for_unrecognized_prefix() {
         assert!(parse_legacy_error_message("something else\n").is_none());
     }
@@ -276,6 +282,12 @@ mod tests {
         let payload =
             parse_legacy_warning_message("@WARNING: will retry  \n").expect("warning payload");
         assert_eq!(payload, "will retry");
+    }
+
+    #[test]
+    fn parse_legacy_warning_message_allows_empty_payload() {
+        let payload = parse_legacy_warning_message("@WARNING:\r\n").expect("empty payload");
+        assert_eq!(payload, "");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- cover empty @ERROR/@WARNING payloads in the legacy ASCII line parser
- verify the byte-level helpers return empty payloads for the same banners

## Testing
- cargo test -p rsync-protocol

------