### PR TITLE
Add tests for future-only protocol advertisements

### DIFF
--- a/crates/protocol/src/negotiation.rs
+++ b/crates/protocol/src/negotiation.rs
@@ -600,7 +600,11 @@ mod tests {
                 last
             };
 
-            assert_eq!(byte_result, slice_result, "decision mismatch for {:?}", data);
+            assert_eq!(
+                byte_result, slice_result,
+                "decision mismatch for {:?}",
+                data
+            );
             assert_eq!(
                 byte_detector.decision(),
                 slice_detector.decision(),

--- a/crates/protocol/src/version.rs
+++ b/crates/protocol/src/version.rs
@@ -378,6 +378,19 @@ mod tests {
     }
 
     #[test]
+    fn select_highest_mutual_accepts_only_future_versions() {
+        let negotiated = select_highest_mutual([40]).expect("future-only handshake clamps");
+        assert_eq!(negotiated, ProtocolVersion::NEWEST);
+    }
+
+    #[test]
+    fn select_highest_mutual_prefers_newest_when_future_and_too_old_mix() {
+        let negotiated = select_highest_mutual([0, 40])
+            .expect("unsupported low versions must not mask clamped future ones");
+        assert_eq!(negotiated, ProtocolVersion::NEWEST);
+    }
+
+    #[test]
     fn converts_protocol_version_to_non_zero_u8() {
         let value = NonZeroU8::new(28).expect("non-zero");
         let version = ProtocolVersion::try_from(value).expect("valid");


### PR DESCRIPTION
## Summary
- add regression tests that ensure `select_highest_mutual` clamps future-only peers to protocol 32 and ignores unsupported lows when a mutual version exists
- apply the corresponding rustfmt adjustment in the negotiation parity tests

## Testing
- cargo test

------