### PR TITLE
Expose rsync log code mapping alongside multiplex tags

### DIFF
--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -17,8 +17,8 @@ mod negotiation;
 mod version;
 
 pub use envelope::{
-    EnvelopeError, HEADER_LEN as MESSAGE_HEADER_LEN, MAX_PAYLOAD_LENGTH, MessageCode,
-    MessageHeader, ParseMessageCodeError,
+    EnvelopeError, HEADER_LEN as MESSAGE_HEADER_LEN, LogCode, MAX_PAYLOAD_LENGTH, MessageCode,
+    MessageHeader, ParseLogCodeError, ParseMessageCodeError,
 };
 pub use error::NegotiationError;
 pub use legacy::{


### PR DESCRIPTION
## Summary
- add a `LogCode` enum with parity to upstream `enum logcode`, plus parsing helpers
- connect multiplex `MessageCode` values to their log classifications and expand unit tests
- re-export the new log code types from the protocol crate API

## Testing
- cargo test

------