### PR TITLE
Add regression test for legacy prefix validation

### DIFF
--- a/crates/protocol/src/legacy/bytes.rs
+++ b/crates/protocol/src/legacy/bytes.rs
@@ -88,6 +88,18 @@ mod tests {
     }
 
     #[test]
+    fn parse_legacy_daemon_message_bytes_rejects_missing_prefix() {
+        let err = parse_legacy_daemon_message_bytes(b"RSYNCD: AUTHREQD module\n").unwrap_err();
+
+        match err {
+            NegotiationError::MalformedLegacyGreeting { input } => {
+                assert_eq!(input, "RSYNCD: AUTHREQD module");
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[test]
     fn rejects_non_utf8_legacy_daemon_message_bytes() {
         let err = parse_legacy_daemon_message_bytes(b"@RSYNCD: AUTHREQD\xff\r\n").unwrap_err();
         match err {


### PR DESCRIPTION
## Summary
- add a test ensuring byte-oriented legacy daemon messages without the @RSYNCD: prefix return a malformed greeting error

## Testing
- cargo test

------