### PR TITLE
Fix duplicate ProtocolVersionAdvertisement implementations

### DIFF
--- a/crates/protocol/src/version.rs
+++ b/crates/protocol/src/version.rs
@@ -69,20 +69,6 @@ impl ProtocolVersionAdvertisement for &ProtocolVersion {
     }
 }
 
-impl ProtocolVersionAdvertisement for NonZeroU8 {
-    #[inline]
-    fn into_advertised_version(self) -> u8 {
-        self.get()
-    }
-}
-
-impl ProtocolVersionAdvertisement for &NonZeroU8 {
-    #[inline]
-    fn into_advertised_version(self) -> u8 {
-        self.get()
-    }
-}
-
 macro_rules! declare_supported_protocols {
     ($($ver:literal),+ $(,)?) => {
         #[doc = "Protocol versions supported by the Rust implementation, ordered from"]


### PR DESCRIPTION
## Summary
- remove the duplicate `ProtocolVersionAdvertisement` implementations for `NonZeroU8`

## Testing
- cargo test

------