### PR TITLE
Add hashing support for protocol enums

### DIFF
--- a/crates/protocol/src/envelope.rs
+++ b/crates/protocol/src/envelope.rs
@@ -20,7 +20,7 @@ const PAYLOAD_MASK: u32 = 0x00FF_FFFF;
 /// by upstream traces. While only a subset of log codes flow over the
 /// multiplexed stream, the complete enum is provided for parity (including
 /// `FNONE`, which upstream reserves for internal use).
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 #[repr(u8)]
 pub enum LogCode {
     /// Placeholder that is never transmitted on the wire (`FNONE`).
@@ -160,7 +160,7 @@ impl std::error::Error for ParseLogCodeError {}
 /// Rust and C identifiers. Values that alias upstream `enum logcode`
 /// definitions retain their historic numbering to ensure interoperability with
 /// existing daemons.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 #[repr(u8)]
 pub enum MessageCode {
     /// Raw file data written to the multiplexed stream.
@@ -626,6 +626,26 @@ mod tests {
         const ENCODED: [u8; HEADER_LEN] = HEADER.encode();
 
         assert_eq!(ENCODED, HEADER.encode());
+    }
+
+    #[test]
+    fn log_codes_are_hashable() {
+        use std::collections::HashSet;
+
+        let mut set = HashSet::new();
+        assert!(set.insert(LogCode::Info));
+        assert!(set.contains(&LogCode::Info));
+        assert!(!set.insert(LogCode::Info));
+    }
+
+    #[test]
+    fn message_codes_are_hashable() {
+        use std::collections::HashSet;
+
+        let mut set = HashSet::new();
+        assert!(set.insert(MessageCode::Data));
+        assert!(set.contains(&MessageCode::Data));
+        assert!(!set.insert(MessageCode::Data));
     }
 
     #[test]

--- a/crates/protocol/src/version.rs
+++ b/crates/protocol/src/version.rs
@@ -10,7 +10,7 @@ use crate::error::NegotiationError;
 const UPSTREAM_PROTOCOL_RANGE: RangeInclusive<u8> = 28..=32;
 
 /// A single negotiated rsync protocol version.
-#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct ProtocolVersion(NonZeroU8);
 
 /// Types that can be interpreted as peer-advertised protocol versions.
@@ -542,5 +542,15 @@ mod tests {
     fn protocol_version_display_matches_numeric_value() {
         let version = ProtocolVersion::try_from(32).expect("valid");
         assert_eq!(version.to_string(), "32");
+    }
+
+    #[test]
+    fn protocol_versions_are_hashable() {
+        use std::collections::HashSet;
+
+        let mut set = HashSet::new();
+        assert!(set.insert(ProtocolVersion::NEWEST));
+        assert!(set.contains(&ProtocolVersion::NEWEST));
+        assert!(!set.insert(ProtocolVersion::NEWEST));
     }
 }


### PR DESCRIPTION
## Summary
- derive `Hash` for the protocol-facing enums so they can be used in hashed collections without extra wrappers
- add regression tests that exercise `ProtocolVersion`, `LogCode`, and `MessageCode` inside `HashSet`

## Testing
- cargo test

------