### PR TITLE
Fix duplicate NonZeroU8 advertisement impls

### DIFF
--- a/crates/protocol/src/version.rs
+++ b/crates/protocol/src/version.rs
@@ -48,24 +48,13 @@ impl ProtocolVersionAdvertisement for ProtocolVersion {
     }
 }
 
-impl ProtocolVersionAdvertisement for &u8 {
+impl<'a, T> ProtocolVersionAdvertisement for &'a T
+where
+    T: ProtocolVersionAdvertisement,
+{
     #[inline]
     fn into_advertised_version(self) -> u8 {
-        *self
-    }
-}
-
-impl ProtocolVersionAdvertisement for &NonZeroU8 {
-    #[inline]
-    fn into_advertised_version(self) -> u8 {
-        self.get()
-    }
-}
-
-impl ProtocolVersionAdvertisement for &ProtocolVersion {
-    #[inline]
-    fn into_advertised_version(self) -> u8 {
-        self.as_u8()
+        (*self).into_advertised_version()
     }
 }
 


### PR DESCRIPTION
## Summary
- replace the duplicate `ProtocolVersionAdvertisement` implementations for reference types with a single blanket implementation to avoid coherence conflicts

## Testing
- cargo test -p rsync-protocol

------