### PR TITLE
Add tests for lowercase legacy negotiation banners

### DIFF
--- a/crates/protocol/src/legacy/bytes.rs
+++ b/crates/protocol/src/legacy/bytes.rs
@@ -100,6 +100,17 @@ mod tests {
     }
 
     #[test]
+    fn parse_legacy_daemon_message_bytes_rejects_lowercase_prefix() {
+        let err = parse_legacy_daemon_message_bytes(b"@rsyncd: OK\n").unwrap_err();
+        match err {
+            NegotiationError::MalformedLegacyGreeting { input } => {
+                assert_eq!(input, "@rsyncd: OK");
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[test]
     fn rejects_non_utf8_legacy_daemon_message_bytes() {
         let err = parse_legacy_daemon_message_bytes(b"@RSYNCD: AUTHREQD\xff\r\n").unwrap_err();
         match err {

--- a/crates/protocol/src/legacy/greeting.rs
+++ b/crates/protocol/src/legacy/greeting.rs
@@ -191,6 +191,17 @@ mod tests {
     }
 
     #[test]
+    fn rejects_greeting_with_lowercase_prefix() {
+        let err = parse_legacy_daemon_greeting("@rsyncd: 31.0\n").unwrap_err();
+        match err {
+            NegotiationError::MalformedLegacyGreeting { input } => {
+                assert_eq!(input, "@rsyncd: 31.0");
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[test]
     fn formats_legacy_daemon_greeting_for_newest_protocol() {
         let rendered = format_legacy_daemon_greeting(ProtocolVersion::NEWEST);
         assert_eq!(rendered, "@RSYNCD: 32.0\n");

--- a/crates/protocol/src/legacy/lines.rs
+++ b/crates/protocol/src/legacy/lines.rs
@@ -154,6 +154,17 @@ mod tests {
     }
 
     #[test]
+    fn parse_legacy_daemon_message_rejects_lowercase_prefix() {
+        let err = parse_legacy_daemon_message("@rsyncd: OK\n").unwrap_err();
+        match err {
+            NegotiationError::MalformedLegacyGreeting { input } => {
+                assert_eq!(input, "@rsyncd: OK");
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[test]
     fn parse_legacy_daemon_message_accepts_exit_with_trailing_whitespace() {
         let message =
             parse_legacy_daemon_message("@RSYNCD: EXIT   \n").expect("keyword with padding");


### PR DESCRIPTION
## Summary
- add regression tests ensuring lowercase @rsyncd prefixes are rejected consistently across string and byte parsers

## Testing
- cargo test

------