### PR TITLE
Fix clippy warnings in protocol crate tests

### DIFF
--- a/crates/protocol/src/envelope.rs
+++ b/crates/protocol/src/envelope.rs
@@ -840,7 +840,7 @@ mod tests {
         ];
 
         for &code in MessageCode::all() {
-            let expected = LOGGING_CODES.iter().any(|candidate| *candidate == code);
+            let expected = LOGGING_CODES.contains(&code);
             assert_eq!(code.is_logging(), expected, "mismatch for code {code:?}");
         }
     }

--- a/crates/protocol/src/multiplex.rs
+++ b/crates/protocol/src/multiplex.rs
@@ -588,7 +588,7 @@ mod tests {
     fn message_frame_as_ref_exposes_payload_slice() {
         let frame = MessageFrame::new(MessageCode::Warning, b"slice".to_vec()).expect("frame");
         assert_eq!(AsRef::<[u8]>::as_ref(&frame), b"slice");
-        let deref: &[u8] = &*frame;
+        let deref: &[u8] = &frame;
         assert_eq!(deref, b"slice");
     }
 
@@ -599,7 +599,7 @@ mod tests {
         payload.copy_from_slice(b"PATCH");
         assert_eq!(frame.payload(), b"PATCH");
         {
-            let deref: &mut [u8] = &mut *frame;
+            let deref: &mut [u8] = &mut frame;
             deref.copy_from_slice(b"lower");
         }
         assert_eq!(frame.payload(), b"lower");
@@ -747,7 +747,7 @@ mod tests {
 
         impl Write for FailingWriter {
             fn write(&mut self, _buf: &[u8]) -> io::Result<usize> {
-                Err(io::Error::new(io::ErrorKind::Other, "injected failure"))
+                Err(io::Error::other("injected failure"))
             }
 
             fn flush(&mut self) -> io::Result<()> {

--- a/crates/protocol/src/version.rs
+++ b/crates/protocol/src/version.rs
@@ -342,7 +342,7 @@ mod tests {
             }
         }
 
-        if let Some(&newest) = recognized.iter().rev().next() {
+        if let Some(&newest) = recognized.iter().next_back() {
             return Ok(ProtocolVersion::new_const(newest));
         }
 


### PR DESCRIPTION
## Summary
- replace the logging classification assertion helper with the idiomatic `contains` call
- rely on Rust's auto-deref in payload slice tests and use `io::Error::other` in the write failure stub
- tighten the reference negotiation helper by switching to `next_back` for the newest protocol lookup

## Testing
- cargo clippy --all-targets
- cargo test

------