### PR TITLE
Add coverage for whitespace-prefixed legacy version banners

### DIFF
--- a/crates/protocol/src/legacy/bytes.rs
+++ b/crates/protocol/src/legacy/bytes.rs
@@ -198,6 +198,16 @@ mod tests {
     }
 
     #[test]
+    fn parse_legacy_daemon_message_bytes_tolerates_leading_whitespace_before_version_digits() {
+        let message = parse_legacy_daemon_message_bytes(b"@RSYNCD:    28.0  \r\n")
+            .expect("version with padding");
+        assert_eq!(
+            message,
+            LegacyDaemonMessage::Version(ProtocolVersion::new_const(28))
+        );
+    }
+
+    #[test]
     fn rejects_non_utf8_legacy_greetings() {
         let err = parse_legacy_daemon_greeting_bytes(b"@RSYNCD: 31.0\xff\n").unwrap_err();
         match err {

--- a/crates/protocol/src/legacy/lines.rs
+++ b/crates/protocol/src/legacy/lines.rs
@@ -241,6 +241,16 @@ mod tests {
     }
 
     #[test]
+    fn parse_legacy_daemon_message_tolerates_leading_whitespace_before_version_digits() {
+        let message =
+            parse_legacy_daemon_message("@RSYNCD:    29.0  \r\n").expect("version with padding");
+        assert_eq!(
+            message,
+            LegacyDaemonMessage::Version(ProtocolVersion::new_const(29))
+        );
+    }
+
+    #[test]
     fn parse_legacy_daemon_message_rejects_missing_prefix() {
         let err = parse_legacy_daemon_message("RSYNCD: AUTHREQD module\n").unwrap_err();
         assert!(matches!(


### PR DESCRIPTION
## Summary
- add regression tests that ensure legacy @RSYNCD version lines continue to parse when extra leading and trailing spaces are present
- cover both the string-based and byte-based parsers so transports relying on raw buffers keep consistent behavior

## Testing
- cargo test

------