### PR TITLE
Accept 128-bit protocol advertisements

### DIFF
--- a/crates/protocol/src/version.rs
+++ b/crates/protocol/src/version.rs
@@ -62,11 +62,13 @@ impl_protocol_version_advertisement!(
     u16 => |value: u16| value.min(u16::from(u8::MAX)) as u8,
     u32 => |value: u32| value.min(u32::from(u8::MAX)) as u8,
     u64 => |value: u64| value.min(u64::from(u8::MAX)) as u8,
+    u128 => |value: u128| value.min(u128::from(u8::MAX)) as u8,
     usize => |value: usize| value.min(usize::from(u8::MAX)) as u8,
     i8 => |value: i8| value.clamp(0, i8::MAX) as u8,
     i16 => |value: i16| value.clamp(0, i16::from(u8::MAX)) as u8,
     i32 => |value: i32| value.clamp(0, i32::from(u8::MAX)) as u8,
     i64 => |value: i64| value.clamp(0, i64::from(u8::MAX)) as u8,
+    i128 => |value: i128| value.clamp(0, i128::from(u8::MAX)) as u8,
     isize => |value: isize| value.clamp(0, isize::from(u8::MAX)) as u8,
 );
 

--- a/crates/protocol/src/version/tests.rs
+++ b/crates/protocol/src/version/tests.rs
@@ -144,12 +144,20 @@ fn select_highest_mutual_saturates_large_signed_advertisements() {
     let peers = [i32::MAX];
     let negotiated = select_highest_mutual(peers).expect("large signed values clamp to newest");
     assert_eq!(negotiated, ProtocolVersion::NEWEST);
+
+    let peers = [i128::MAX];
+    let negotiated = select_highest_mutual(peers).expect("i128 advertisements clamp");
+    assert_eq!(negotiated, ProtocolVersion::NEWEST);
 }
 
 #[test]
 fn select_highest_mutual_saturates_wider_integer_advertisements() {
     let peers = [u32::MAX];
     let negotiated = select_highest_mutual(peers).expect("future versions clamp");
+    assert_eq!(negotiated, ProtocolVersion::NEWEST);
+
+    let peers = [u128::MAX];
+    let negotiated = select_highest_mutual(peers).expect("u128 advertisements clamp");
     assert_eq!(negotiated, ProtocolVersion::NEWEST);
 }
 


### PR DESCRIPTION
## Summary
- allow `ProtocolVersionAdvertisement` to accept `u128` and `i128` advertisements by clamping them to the supported range
- extend protocol negotiation tests to cover 128-bit advertisement inputs

## Testing
- cargo test

------