### PR TITLE
Expose ProtocolVersionAdvertisement in protocol crate

### DIFF
--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -33,4 +33,9 @@ pub use negotiation::{
     NegotiationPrologue, NegotiationPrologueDetector, NegotiationPrologueSniffer,
     detect_negotiation_prologue,
 };
-pub use version::{ProtocolVersion, SUPPORTED_PROTOCOLS, select_highest_mutual};
+pub use version::{
+    ProtocolVersion,
+    ProtocolVersionAdvertisement,
+    SUPPORTED_PROTOCOLS,
+    select_highest_mutual,
+};

--- a/crates/protocol/tests/public_api.rs
+++ b/crates/protocol/tests/public_api.rs
@@ -1,0 +1,24 @@
+#![allow(clippy::needless_pass_by_value)]
+
+use rsync_protocol::{
+    select_highest_mutual,
+    ProtocolVersion,
+    ProtocolVersionAdvertisement,
+};
+
+#[derive(Clone, Copy)]
+struct CustomAdvertised(u8);
+
+impl ProtocolVersionAdvertisement for CustomAdvertised {
+    #[inline]
+    fn into_advertised_version(self) -> u8 {
+        self.0
+    }
+}
+
+#[test]
+fn custom_advertised_types_can_participate_in_negotiation() {
+    let peers = [CustomAdvertised(31), CustomAdvertised(32)];
+    let negotiated = select_highest_mutual(peers).expect("should negotiate successfully");
+    assert_eq!(negotiated, ProtocolVersion::NEWEST);
+}


### PR DESCRIPTION
## Summary
- re-export `ProtocolVersionAdvertisement` from the protocol crate root so downstream crates can rely on it
- add an integration test that implements the trait for a custom type to prove the public API works

## Testing
- cargo test

------