### PR TITLE
Add negotiation sniffer test for legacy prefix mismatches

### DIFF
--- a/crates/protocol/src/negotiation.rs
+++ b/crates/protocol/src/negotiation.rs
@@ -1107,6 +1107,26 @@ mod tests {
     }
 
     #[test]
+    fn prologue_sniffer_observe_handles_prefix_mismatches() {
+        let mut sniffer = NegotiationPrologueSniffer::new();
+
+        let (decision, consumed) = sniffer.observe(b"@X remainder");
+        assert_eq!(decision, NegotiationPrologue::LegacyAscii);
+        assert_eq!(consumed, 2);
+        assert_eq!(sniffer.buffered(), b"@X");
+        assert!(sniffer.legacy_prefix_complete());
+        assert_eq!(sniffer.legacy_prefix_remaining(), None);
+
+        let (decision, consumed) = sniffer.observe(b"anything else");
+        assert_eq!(decision, NegotiationPrologue::LegacyAscii);
+        assert_eq!(consumed, 0);
+        assert_eq!(sniffer.buffered(), b"@X");
+
+        let replay = sniffer.into_buffered();
+        assert_eq!(replay, b"@X");
+    }
+
+    #[test]
     fn prologue_sniffer_observe_returns_need_more_data_for_empty_chunk() {
         let mut sniffer = NegotiationPrologueSniffer::new();
 


### PR DESCRIPTION
## Summary
- add a unit test that exercises `NegotiationPrologueSniffer` when the legacy prefix diverges mid-stream
- verify the sniffer keeps the buffered prefix stable and marks the legacy prefix as complete after a mismatch

## Testing
- cargo test

------