### PR TITLE
Support mutable protocol advertisements in negotiation

### DIFF
--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -34,8 +34,5 @@ pub use negotiation::{
     detect_negotiation_prologue,
 };
 pub use version::{
-    ProtocolVersion,
-    ProtocolVersionAdvertisement,
-    SUPPORTED_PROTOCOLS,
-    select_highest_mutual,
+    ProtocolVersion, ProtocolVersionAdvertisement, SUPPORTED_PROTOCOLS, select_highest_mutual,
 };

--- a/crates/protocol/src/version.rs
+++ b/crates/protocol/src/version.rs
@@ -25,8 +25,12 @@ pub struct ProtocolVersion(NonZeroU8);
 /// forwarding buffers. Exposing a small conversion trait keeps the public
 /// helper flexible without forcing callers to allocate temporary vectors,
 /// normalize wrappers, or clone data solely to satisfy the type signature.
+/// Implementations are provided for primitive integers, [`ProtocolVersion`],
+/// and both shared and mutable references so iterator adapters such as
+/// [`core::slice::iter`](core::slice::iter) and
+/// [`core::slice::iter_mut`](core::slice::iter_mut) can be forwarded directly.
 #[doc(hidden)]
-pub trait ProtocolVersionAdvertisement: Copy {
+pub trait ProtocolVersionAdvertisement {
     /// Returns the numeric representation expected by the negotiation logic.
     ///
     /// Implementations for integer types wider than `u8` saturate to
@@ -49,6 +53,14 @@ macro_rules! impl_protocol_version_advertisement {
             }
 
             impl ProtocolVersionAdvertisement for &$ty {
+                #[inline]
+                fn into_advertised_version(self) -> u8 {
+                    let convert = $into;
+                    convert(*self)
+                }
+            }
+
+            impl ProtocolVersionAdvertisement for &mut $ty {
                 #[inline]
                 fn into_advertised_version(self) -> u8 {
                     let convert = $into;

--- a/crates/protocol/src/version/tests.rs
+++ b/crates/protocol/src/version/tests.rs
@@ -110,6 +110,14 @@ fn select_highest_mutual_accepts_slice_iterators() {
 }
 
 #[test]
+fn select_highest_mutual_accepts_mut_slice_iterators() {
+    let mut peers = [31u8, 29, 32];
+    let negotiated = select_highest_mutual(peers.iter_mut()).expect("mut slice iter works");
+    assert_eq!(negotiated, ProtocolVersion::NEWEST);
+    assert_eq!(peers, [31u8, 29, 32]);
+}
+
+#[test]
 fn select_highest_mutual_accepts_protocol_version_references() {
     let peers = ProtocolVersion::supported_versions();
     let negotiated = select_highest_mutual(peers.iter()).expect("refs work");

--- a/crates/protocol/tests/public_api.rs
+++ b/crates/protocol/tests/public_api.rs
@@ -1,10 +1,6 @@
 #![allow(clippy::needless_pass_by_value)]
 
-use rsync_protocol::{
-    select_highest_mutual,
-    ProtocolVersion,
-    ProtocolVersionAdvertisement,
-};
+use rsync_protocol::{ProtocolVersion, ProtocolVersionAdvertisement, select_highest_mutual};
 
 #[derive(Clone, Copy)]
 struct CustomAdvertised(u8);


### PR DESCRIPTION
## Summary
- allow `ProtocolVersionAdvertisement` to cover mutable references in addition to owned and shared values
- document the expanded conversions and extend the helper macro so iterators like `slice::iter_mut` can be forwarded without copies
- add a regression test that negotiates successfully from a mutable slice iterator

## Testing
- cargo test

------