### PR TITLE
Add consistency regression test for protocol helper outputs

### DIFF
--- a/crates/protocol/src/version/tests.rs
+++ b/crates/protocol/src/version/tests.rs
@@ -201,6 +201,29 @@ fn select_highest_mutual_clamps_negative_non_zero_signed_advertisements() {
 }
 
 #[test]
+fn supported_protocol_helpers_remain_consistent() {
+    let numbers_slice = ProtocolVersion::supported_protocol_numbers();
+    assert_eq!(numbers_slice, &SUPPORTED_PROTOCOLS);
+
+    let numbers_from_iter: Vec<u8> =
+        ProtocolVersion::supported_protocol_numbers_iter().collect();
+    assert_eq!(numbers_from_iter, SUPPORTED_PROTOCOLS);
+
+    let versions_slice = ProtocolVersion::supported_versions();
+    let versions_slice_numbers: Vec<u8> =
+        versions_slice.iter().map(|version| version.as_u8()).collect();
+    assert_eq!(versions_slice_numbers, SUPPORTED_PROTOCOLS);
+
+    let versions_from_iter: Vec<u8> =
+        ProtocolVersion::supported_versions_iter().map(|version| version.as_u8()).collect();
+    assert_eq!(versions_from_iter, SUPPORTED_PROTOCOLS);
+
+    let range = ProtocolVersion::supported_range();
+    assert_eq!(*range.start(), ProtocolVersion::OLDEST.as_u8());
+    assert_eq!(*range.end(), ProtocolVersion::NEWEST.as_u8());
+}
+
+#[test]
 fn select_highest_mutual_accepts_wider_integer_advertisements() {
     let peers = [u16::from(ProtocolVersion::NEWEST.as_u8()), 0u16];
     let negotiated = select_highest_mutual(peers).expect("wider integers supported");


### PR DESCRIPTION
## Summary
- add a regression test that cross-checks the supported protocol helper APIs against the canonical list

## Testing
- cargo test -p rsync-protocol

------