### PR TITLE
Add helper for supported protocol range bounds

### DIFF
--- a/crates/protocol/src/error.rs
+++ b/crates/protocol/src/error.rs
@@ -30,12 +30,11 @@ impl fmt::Display for NegotiationError {
                 )
             }
             Self::UnsupportedVersion(version) => {
+                let (oldest, newest) = crate::version::ProtocolVersion::supported_range_bounds();
                 write!(
                     f,
                     "peer advertised unsupported rsync protocol version {} (valid range {}-{})",
-                    version,
-                    crate::version::ProtocolVersion::OLDEST.as_u8(),
-                    crate::version::ProtocolVersion::NEWEST.as_u8()
+                    version, oldest, newest,
                 )
             }
             Self::MalformedLegacyGreeting { input } => {

--- a/crates/protocol/src/version.rs
+++ b/crates/protocol/src/version.rs
@@ -237,6 +237,19 @@ impl ProtocolVersion {
         Self::OLDEST.as_u8()..=Self::NEWEST.as_u8()
     }
 
+    /// Returns the inclusive supported range as a tuple of `(oldest, newest)`.
+    ///
+    /// Higher layers frequently need to mention both bounds in diagnostics
+    /// without necessarily constructing a [`RangeInclusive`]. Centralizing the
+    /// numeric pair keeps those call sites in sync with the canonical
+    /// [`ProtocolVersion::OLDEST`] and [`ProtocolVersion::NEWEST`] constants,
+    /// avoiding duplicate literals that could drift if upstream changes the
+    /// supported span.
+    #[must_use]
+    pub const fn supported_range_bounds() -> (u8, u8) {
+        (Self::OLDEST.as_u8(), Self::NEWEST.as_u8())
+    }
+
     /// Returns an iterator over the supported protocol versions in
     /// newest-to-oldest order.
     ///

--- a/crates/protocol/src/version/tests.rs
+++ b/crates/protocol/src/version/tests.rs
@@ -372,6 +372,13 @@ fn supported_range_matches_upstream_bounds() {
 }
 
 #[test]
+fn supported_range_bounds_match_upstream_constants() {
+    let (oldest, newest) = ProtocolVersion::supported_range_bounds();
+    assert_eq!(oldest, ProtocolVersion::OLDEST.as_u8());
+    assert_eq!(newest, ProtocolVersion::NEWEST.as_u8());
+}
+
+#[test]
 fn detects_supported_versions() {
     for version in SUPPORTED_PROTOCOLS {
         assert!(ProtocolVersion::is_supported(version));


### PR DESCRIPTION
## Summary
- add `ProtocolVersion::supported_range_bounds()` to expose the oldest/newest protocol numbers without duplicating literals
- update `NegotiationError` formatting to rely on the shared helper
- extend the version tests to cover the new helper

## Testing
- cargo test

------