### PR TITLE
Add property test verifying negotiation sniffer matches detector

### DIFF
--- a/crates/protocol/src/negotiation.rs
+++ b/crates/protocol/src/negotiation.rs
@@ -1088,6 +1088,72 @@ mod tests {
         }
     }
 
+    proptest! {
+        #[test]
+        fn prologue_sniffer_stays_in_lockstep_with_detector(
+            chunks in prop::collection::vec(
+                prop::collection::vec(any::<u8>(), 0..=LEGACY_DAEMON_PREFIX_LEN + 2),
+                0..=6
+            )
+        ) {
+            let mut detector = NegotiationPrologueDetector::new();
+            let mut sniffer = NegotiationPrologueSniffer::new();
+
+            for chunk in &chunks {
+                let (sniffer_decision, consumed) = sniffer.observe(chunk);
+                prop_assert!(consumed <= chunk.len());
+
+                let detector_decision = if consumed != 0 {
+                    detector.observe(&chunk[..consumed])
+                } else {
+                    detector
+                        .decision()
+                        .unwrap_or(NegotiationPrologue::NeedMoreData)
+                };
+
+                prop_assert_eq!(sniffer_decision, detector_decision);
+
+                let detector_buffer = detector.buffered_prefix();
+                prop_assert!(sniffer.buffered().starts_with(detector_buffer));
+                prop_assert!(sniffer.buffered_len() >= detector.buffered_len());
+
+                match sniffer_decision {
+                    NegotiationPrologue::LegacyAscii => {
+                        if detector.legacy_prefix_complete() {
+                            prop_assert!(sniffer.legacy_prefix_complete());
+                            prop_assert_eq!(sniffer.legacy_prefix_remaining(), None);
+                            prop_assert_eq!(detector.legacy_prefix_remaining(), None);
+                        } else {
+                            prop_assert!(!sniffer.legacy_prefix_complete());
+                            prop_assert_eq!(
+                                sniffer.legacy_prefix_remaining(),
+                                detector.legacy_prefix_remaining()
+                            );
+                        }
+                    }
+                    NegotiationPrologue::Binary => {
+                        prop_assert!(!sniffer.legacy_prefix_complete());
+                        prop_assert!(!detector.legacy_prefix_complete());
+                        prop_assert_eq!(sniffer.legacy_prefix_remaining(), None);
+                        prop_assert_eq!(detector.legacy_prefix_remaining(), None);
+                    }
+                    NegotiationPrologue::NeedMoreData => {
+                        prop_assert_eq!(
+                            sniffer.legacy_prefix_complete(),
+                            detector.legacy_prefix_complete()
+                        );
+                        prop_assert_eq!(
+                            sniffer.legacy_prefix_remaining(),
+                            detector.legacy_prefix_remaining()
+                        );
+                    }
+                }
+            }
+
+            prop_assert_eq!(sniffer.decision(), detector.decision());
+        }
+    }
+
     #[test]
     fn prologue_sniffer_reports_binary_negotiation() {
         let mut sniffer = NegotiationPrologueSniffer::new();


### PR DESCRIPTION
## Summary
- add a proptest that drives random chunk partitions through the negotiation sniffer and detector
- assert shared state invariants covering buffered prefixes, legacy prefix tracking, and classification parity

## Testing
- cargo test

------