### PR TITLE
Add PartialEq support for ProtocolVersion with NonZeroU8

### DIFF
--- a/crates/protocol/src/version.rs
+++ b/crates/protocol/src/version.rs
@@ -400,6 +400,18 @@ impl PartialEq<ProtocolVersion> for u8 {
     }
 }
 
+impl PartialEq<NonZeroU8> for ProtocolVersion {
+    fn eq(&self, other: &NonZeroU8) -> bool {
+        self.as_non_zero() == *other
+    }
+}
+
+impl PartialEq<ProtocolVersion> for NonZeroU8 {
+    fn eq(&self, other: &ProtocolVersion) -> bool {
+        *self == other.as_non_zero()
+    }
+}
+
 /// Selects the highest mutual protocol version between the Rust implementation and a peer.
 ///
 /// The caller provides the list of protocol versions advertised by the peer in any order.

--- a/crates/protocol/src/version/tests.rs
+++ b/crates/protocol/src/version/tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 use core::num::{
-    NonZeroI8, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI128, NonZeroIsize, NonZeroU16,
-    NonZeroU32, NonZeroU64, NonZeroU128, NonZeroUsize,
+    NonZeroI8, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI128, NonZeroIsize, NonZeroU8,
+    NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU128, NonZeroUsize,
 };
 use proptest::prelude::*;
 
@@ -451,6 +451,17 @@ fn exposes_non_zero_protocol_byte() {
 
     let via_from: NonZeroU8 = version.into();
     assert_eq!(via_from, non_zero);
+}
+
+#[test]
+fn compares_protocol_version_with_non_zero_u8() {
+    let newest = NonZeroU8::new(ProtocolVersion::NEWEST.as_u8()).expect("non-zero");
+    assert_eq!(ProtocolVersion::NEWEST, newest);
+    assert_eq!(newest, ProtocolVersion::NEWEST);
+
+    let oldest = NonZeroU8::new(ProtocolVersion::OLDEST.as_u8()).expect("non-zero");
+    assert_ne!(ProtocolVersion::NEWEST, oldest);
+    assert_ne!(oldest, ProtocolVersion::NEWEST);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- allow `ProtocolVersion` to compare directly with `NonZeroU8` wrappers for parity with upstream numeric checks
- cover the new equality semantics in the protocol version test suite

## Testing
- cargo test

------