### PR TITLE
Add NonZeroU8 comparisons for ProtocolVersion

### DIFF
--- a/crates/protocol/src/version.rs
+++ b/crates/protocol/src/version.rs
@@ -400,6 +400,18 @@ impl PartialEq<ProtocolVersion> for u8 {
     }
 }
 
+impl PartialEq<NonZeroU8> for ProtocolVersion {
+    fn eq(&self, other: &NonZeroU8) -> bool {
+        self.as_non_zero() == *other
+    }
+}
+
+impl PartialEq<ProtocolVersion> for NonZeroU8 {
+    fn eq(&self, other: &ProtocolVersion) -> bool {
+        *self == other.as_non_zero()
+    }
+}
+
 /// Selects the highest mutual protocol version between the Rust implementation and a peer.
 ///
 /// The caller provides the list of protocol versions advertised by the peer in any order.

--- a/crates/protocol/src/version/tests.rs
+++ b/crates/protocol/src/version/tests.rs
@@ -468,6 +468,19 @@ fn compares_directly_with_u8() {
 }
 
 #[test]
+fn compares_directly_with_non_zero_u8() {
+    let version = ProtocolVersion::try_from(31).expect("valid");
+    let non_zero = NonZeroU8::new(31).expect("non-zero");
+
+    assert_eq!(version, non_zero);
+    assert_eq!(non_zero, version);
+
+    let different = NonZeroU8::new(ProtocolVersion::OLDEST.as_u8()).expect("non-zero");
+    assert_ne!(version, different);
+    assert_ne!(different, version);
+}
+
+#[test]
 fn supported_versions_are_sorted_descending() {
     let mut sorted = SUPPORTED_PROTOCOLS;
     sorted.sort_by(|a, b| b.cmp(a));


### PR DESCRIPTION
## Summary
- allow comparing ProtocolVersion values directly with NonZeroU8 wrappers
- cover the new comparisons with targeted unit tests

## Testing
- cargo test

------