### PR TITLE
Add const guard for supported protocol numbers

### DIFF
--- a/crates/protocol/src/version.rs
+++ b/crates/protocol/src/version.rs
@@ -202,6 +202,27 @@ impl ProtocolVersion {
         &Self::SUPPORTED_VERSIONS
     }
 
+    /// Reports whether the provided numeric protocol identifier is supported
+    /// by this implementation.
+    ///
+    /// The helper mirrors the [`ProtocolVersion::is_supported`] guard but
+    /// operates on the raw byte without attempting to construct a
+    /// [`ProtocolVersion`]. This is useful in const contexts where callers need
+    /// to validate literals or table entries that embed protocol numbers
+    /// directly without triggering a runtime negotiation.
+    #[must_use]
+    pub const fn is_supported_protocol_number(value: u8) -> bool {
+        let mut index = 0usize;
+        while index < SUPPORTED_PROTOCOLS.len() {
+            if SUPPORTED_PROTOCOLS[index] == value {
+                return true;
+            }
+            index += 1;
+        }
+
+        false
+    }
+
     /// Returns the numeric protocol identifiers supported by this
     /// implementation in newest-to-oldest order.
     ///

--- a/crates/protocol/src/version/tests.rs
+++ b/crates/protocol/src/version/tests.rs
@@ -339,6 +339,16 @@ fn supported_versions_method_matches_constant_slice() {
 }
 
 #[test]
+fn supported_protocol_number_guard_matches_constants() {
+    for &value in &SUPPORTED_PROTOCOLS {
+        assert!(ProtocolVersion::is_supported_protocol_number(value));
+    }
+
+    assert!(!ProtocolVersion::is_supported_protocol_number(ProtocolVersion::OLDEST.as_u8() - 1));
+    assert!(!ProtocolVersion::is_supported_protocol_number(ProtocolVersion::NEWEST.as_u8() + 1));
+}
+
+#[test]
 fn supported_protocol_numbers_matches_constant_slice() {
     assert_eq!(
         ProtocolVersion::supported_protocol_numbers(),


### PR DESCRIPTION
## Summary
- add a const helper to check whether a numeric protocol identifier is supported
- cover the helper with unit tests to ensure it matches the SUPPORTED_PROTOCOLS list

## Testing
- cargo test

------