### PR TITLE
Expose protocol count constant

### DIFF
--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -34,5 +34,6 @@ pub use negotiation::{
     detect_negotiation_prologue,
 };
 pub use version::{
-    ProtocolVersion, ProtocolVersionAdvertisement, SUPPORTED_PROTOCOLS, select_highest_mutual,
+    ProtocolVersion, ProtocolVersionAdvertisement, SUPPORTED_PROTOCOLS,
+    SUPPORTED_PROTOCOL_COUNT, select_highest_mutual,
 };

--- a/crates/protocol/tests/public_api.rs
+++ b/crates/protocol/tests/public_api.rs
@@ -18,3 +18,11 @@ fn custom_advertised_types_can_participate_in_negotiation() {
     let negotiated = select_highest_mutual(peers).expect("should negotiate successfully");
     assert_eq!(negotiated, ProtocolVersion::NEWEST);
 }
+
+#[test]
+fn supported_protocol_exports_remain_consistent() {
+    assert_eq!(
+        rsync_protocol::SUPPORTED_PROTOCOL_COUNT,
+        rsync_protocol::SUPPORTED_PROTOCOLS.len(),
+    );
+}


### PR DESCRIPTION
## Summary
- re-export `SUPPORTED_PROTOCOL_COUNT` from the protocol crate so consumers can determine the negotiated span without touching internals
- add a public API test that guards the exported constant against drifting from the protocol list

## Testing
- cargo test

------