### PR TITLE
Document protocol negotiation helpers with usage examples

### DIFF
--- a/crates/protocol/src/version.rs
+++ b/crates/protocol/src/version.rs
@@ -446,6 +446,22 @@ impl PartialEq<ProtocolVersion> for NonZeroU8 {
 /// value, matching upstream tolerance for future releases. Duplicate peer entries and
 /// out-of-order announcements are tolerated. If no mutual protocol exists,
 /// [`NegotiationError::NoMutualProtocol`] is returned with the filtered peer list for context.
+///
+/// # Examples
+///
+/// ```
+/// use rsync_protocol::{select_highest_mutual, ProtocolVersion};
+///
+/// let negotiated = select_highest_mutual([
+///     ProtocolVersion::NEWEST,
+///     ProtocolVersion::from_supported(31).expect("31 is within the supported range"),
+/// ])
+/// .expect("newest protocol should be accepted");
+/// assert_eq!(negotiated, ProtocolVersion::NEWEST);
+///
+/// let err = select_highest_mutual([27u8]).unwrap_err();
+/// assert!(matches!(err, rsync_protocol::NegotiationError::UnsupportedVersion(27)));
+/// ```
 #[must_use = "the negotiation outcome must be checked"]
 pub fn select_highest_mutual<I, T>(peer_versions: I) -> Result<ProtocolVersion, NegotiationError>
 where


### PR DESCRIPTION
## Summary
- expand the protocol crate documentation with runnable examples for prologue detection and version selection
- add doctests to `select_highest_mutual` illustrating successful negotiation and unsupported peers

## Testing
- cargo test

------