### PR TITLE
Mark legacy parsers as must_use

### DIFF
--- a/crates/protocol/src/legacy/bytes.rs
+++ b/crates/protocol/src/legacy/bytes.rs
@@ -31,6 +31,7 @@ where
 /// sequences are rejected with [`NegotiationError::MalformedLegacyGreeting`]
 /// containing a lossy rendering of the offending bytes, matching the
 /// diagnostics emitted by upstream rsync when echoing unexpected banners.
+#[must_use = "the parsed legacy daemon message must be handled"]
 pub fn parse_legacy_daemon_message_bytes(
     line: &[u8],
 ) -> Result<LegacyDaemonMessage<'_>, NegotiationError> {
@@ -42,6 +43,7 @@ pub fn parse_legacy_daemon_message_bytes(
 /// Invalid UTF-8 input is rejected with
 /// [`NegotiationError::MalformedLegacyGreeting`], mirroring
 /// [`parse_legacy_daemon_message_bytes`].
+#[must_use = "legacy daemon error diagnostics must be handled"]
 pub fn parse_legacy_error_message_bytes(line: &[u8]) -> Result<Option<&str>, NegotiationError> {
     parse_lossy_ascii_bytes(line, |text| Ok(parse_legacy_error_message(text)))
 }
@@ -50,6 +52,7 @@ pub fn parse_legacy_error_message_bytes(line: &[u8]) -> Result<Option<&str>, Neg
 ///
 /// Invalid UTF-8 input is rejected with the same diagnostics as
 /// [`parse_legacy_error_message_bytes`].
+#[must_use = "legacy daemon warning diagnostics must be handled"]
 pub fn parse_legacy_warning_message_bytes(line: &[u8]) -> Result<Option<&str>, NegotiationError> {
     parse_lossy_ascii_bytes(line, |text| Ok(parse_legacy_warning_message(text)))
 }
@@ -64,6 +67,7 @@ pub fn parse_legacy_warning_message_bytes(line: &[u8]) -> Result<Option<&str>, N
 /// [`NegotiationError::MalformedLegacyGreeting`] that captures the lossy string
 /// representation for diagnostics, mirroring upstream behavior where the raw
 /// greeting is echoed back to the user.
+#[must_use = "legacy daemon greeting parsing errors must be handled"]
 pub fn parse_legacy_daemon_greeting_bytes(
     line: &[u8],
 ) -> Result<ProtocolVersion, NegotiationError> {

--- a/crates/protocol/src/legacy/greeting.rs
+++ b/crates/protocol/src/legacy/greeting.rs
@@ -9,6 +9,7 @@ use super::{LEGACY_DAEMON_PREFIX, malformed_legacy_greeting};
 /// implementation accepts optional fractional suffixes (e.g. `.0`) but only the
 /// integer component participates in protocol negotiation. Any trailing carriage
 /// returns or line feeds are ignored.
+#[must_use = "legacy daemon greeting parsing errors must be handled"]
 pub fn parse_legacy_daemon_greeting(line: &str) -> Result<ProtocolVersion, NegotiationError> {
     let trimmed = line.trim_end_matches(['\r', '\n']);
     let malformed = || malformed_legacy_greeting(trimmed);

--- a/crates/protocol/src/legacy/lines.rs
+++ b/crates/protocol/src/legacy/lines.rs
@@ -46,6 +46,7 @@ pub enum LegacyDaemonMessage<'a> {
 /// variants and all remaining inputs yield [`LegacyDaemonMessage::Other`],
 /// allowing callers to gracefully handle extensions without guessing upstream's
 /// future strings.
+#[must_use = "the parsed legacy daemon message must be handled"]
 pub fn parse_legacy_daemon_message(
     line: &str,
 ) -> Result<LegacyDaemonMessage<'_>, NegotiationError> {


### PR DESCRIPTION
## Summary
- add `#[must_use]` annotations to legacy daemon parsing helpers so ignored results surface warnings

## Testing
- cargo test

------