### PR TITLE
Expose array view of supported protocol numbers

### DIFF
--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -65,6 +65,6 @@ pub use negotiation::{
     detect_negotiation_prologue,
 };
 pub use version::{
-    ProtocolVersion, ProtocolVersionAdvertisement, SUPPORTED_PROTOCOLS,
-    SUPPORTED_PROTOCOL_COUNT, select_highest_mutual,
+    ProtocolVersion, ProtocolVersionAdvertisement, SUPPORTED_PROTOCOL_COUNT, SUPPORTED_PROTOCOLS,
+    select_highest_mutual,
 };

--- a/crates/protocol/src/version.rs
+++ b/crates/protocol/src/version.rs
@@ -240,6 +240,18 @@ impl ProtocolVersion {
         &SUPPORTED_PROTOCOLS
     }
 
+    /// Returns the numeric protocol identifiers as a fixed-size array reference.
+    ///
+    /// Some compile-time contexts require access to the concrete array type
+    /// instead of a slice—mirroring upstream code that embeds protocol tables in
+    /// static data structures. Providing this helper keeps those call sites in
+    /// sync with the canonical [`SUPPORTED_PROTOCOLS`] constant without
+    /// re-exporting the array in multiple locations.
+    #[must_use]
+    pub const fn supported_protocol_numbers_array() -> &'static [u8; SUPPORTED_PROTOCOL_COUNT] {
+        &SUPPORTED_PROTOCOLS
+    }
+
     /// Returns an iterator over the numeric protocol identifiers supported by this implementation.
     ///
     /// Upstream rsync often iterates over the protocol list while negotiating with peers,

--- a/crates/protocol/src/version/tests.rs
+++ b/crates/protocol/src/version/tests.rs
@@ -375,6 +375,14 @@ fn supported_protocol_numbers_matches_constant_slice() {
 }
 
 #[test]
+fn supported_protocol_numbers_array_matches_constant_slice() {
+    assert_eq!(
+        ProtocolVersion::supported_protocol_numbers_array(),
+        &SUPPORTED_PROTOCOLS
+    );
+}
+
+#[test]
 fn supported_versions_iterator_matches_constants() {
     let via_iterator: Vec<u8> = ProtocolVersion::supported_versions_iter()
         .map(ProtocolVersion::as_u8)


### PR DESCRIPTION
## Summary
- add `ProtocolVersion::supported_protocol_numbers_array()` to expose the canonical protocol list as a fixed-size array reference
- extend the protocol version tests to cover the new helper and keep the slice-based assertions
- tidy the protocol re-exports to keep constants grouped together

## Testing
- cargo test

------