### PR TITLE
Add slice draining helper for negotiation prefix

### DIFF
--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -61,8 +61,8 @@ pub use legacy::{
 };
 pub use multiplex::{MessageFrame, recv_msg, recv_msg_into, send_msg};
 pub use negotiation::{
-    NegotiationPrologue, NegotiationPrologueDetector, NegotiationPrologueSniffer,
-    detect_negotiation_prologue,
+    BufferedPrefixTooSmall, NegotiationPrologue, NegotiationPrologueDetector,
+    NegotiationPrologueSniffer, detect_negotiation_prologue,
 };
 pub use version::{
     ProtocolVersion, ProtocolVersionAdvertisement, SUPPORTED_PROTOCOL_COUNT, SUPPORTED_PROTOCOLS,


### PR DESCRIPTION
## Summary
- add a `BufferedPrefixTooSmall` error type and expose it through the crate root
- refactor the negotiation prologue sniffer buffer reuse and add a slice-based drain helper with coverage tests

## Testing
- cargo test

------