### PR TITLE
Add explicit test for supported protocol order

### DIFF
--- a/crates/protocol/tests/public_api.rs
+++ b/crates/protocol/tests/public_api.rs
@@ -26,3 +26,8 @@ fn supported_protocol_exports_remain_consistent() {
         rsync_protocol::SUPPORTED_PROTOCOLS.len(),
     );
 }
+
+#[test]
+fn supported_protocols_match_upstream_order() {
+    assert_eq!(rsync_protocol::SUPPORTED_PROTOCOLS, [32, 31, 30, 29, 28]);
+}


### PR DESCRIPTION
## Summary
- add a regression test that ensures the exported protocol list matches the upstream ordering

## Testing
- cargo test -p rsync-protocol

------