### PR TITLE
Expose supported protocol range constant

### DIFF
--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -65,6 +65,6 @@ pub use negotiation::{
     NegotiationPrologueSniffer, detect_negotiation_prologue,
 };
 pub use version::{
-    ProtocolVersion, ProtocolVersionAdvertisement, SUPPORTED_PROTOCOL_COUNT, SUPPORTED_PROTOCOLS,
-    select_highest_mutual,
+    ProtocolVersion, ProtocolVersionAdvertisement, SUPPORTED_PROTOCOL_COUNT,
+    SUPPORTED_PROTOCOL_RANGE, SUPPORTED_PROTOCOLS, select_highest_mutual,
 };

--- a/crates/protocol/src/version.rs
+++ b/crates/protocol/src/version.rs
@@ -9,8 +9,23 @@ use core::ops::RangeInclusive;
 
 use crate::error::NegotiationError;
 
+const OLDEST_SUPPORTED_PROTOCOL: u8 = 28;
+const NEWEST_SUPPORTED_PROTOCOL: u8 = 32;
+
 /// Inclusive range of protocol versions that upstream rsync 3.4.1 understands.
-const UPSTREAM_PROTOCOL_RANGE: RangeInclusive<u8> = 28..=32;
+const UPSTREAM_PROTOCOL_RANGE: RangeInclusive<u8> =
+    OLDEST_SUPPORTED_PROTOCOL..=NEWEST_SUPPORTED_PROTOCOL;
+
+/// Inclusive range of protocol versions supported by the Rust implementation.
+///
+/// Upstream rsync communicates the supported span in several diagnostics and
+/// negotiation helpers. Exposing the same range ensures higher layers can
+/// render parity messages without hard-coding protocol boundaries. The value is
+/// kept in sync with [`ProtocolVersion::OLDEST`] and
+/// [`ProtocolVersion::NEWEST`], so the compile-time guards later in this file
+/// will fail if the literals ever drift.
+pub const SUPPORTED_PROTOCOL_RANGE: RangeInclusive<u8> =
+    OLDEST_SUPPORTED_PROTOCOL..=NEWEST_SUPPORTED_PROTOCOL;
 
 /// A single negotiated rsync protocol version.
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
@@ -184,10 +199,10 @@ impl ProtocolVersion {
     }
 
     /// The newest protocol version supported by upstream rsync 3.4.1.
-    pub const NEWEST: ProtocolVersion = ProtocolVersion::new_const(32);
+    pub const NEWEST: ProtocolVersion = ProtocolVersion::new_const(NEWEST_SUPPORTED_PROTOCOL);
 
     /// The oldest protocol version supported by upstream rsync 3.4.1.
-    pub const OLDEST: ProtocolVersion = ProtocolVersion::new_const(28);
+    pub const OLDEST: ProtocolVersion = ProtocolVersion::new_const(OLDEST_SUPPORTED_PROTOCOL);
 
     /// Array of protocol versions supported by the Rust implementation,
     /// ordered from newest to oldest.

--- a/crates/protocol/src/version/tests.rs
+++ b/crates/protocol/src/version/tests.rs
@@ -404,7 +404,8 @@ fn supported_protocol_numbers_iter_is_sorted_descending() {
 
 #[test]
 fn supported_range_matches_upstream_bounds() {
-    assert_eq!(ProtocolVersion::supported_range(), UPSTREAM_PROTOCOL_RANGE);
+    assert_eq!(ProtocolVersion::supported_range(), SUPPORTED_PROTOCOL_RANGE);
+    assert_eq!(SUPPORTED_PROTOCOL_RANGE, UPSTREAM_PROTOCOL_RANGE);
 }
 
 #[test]
@@ -412,6 +413,18 @@ fn supported_range_bounds_match_upstream_constants() {
     let (oldest, newest) = ProtocolVersion::supported_range_bounds();
     assert_eq!(oldest, ProtocolVersion::OLDEST.as_u8());
     assert_eq!(newest, ProtocolVersion::NEWEST.as_u8());
+}
+
+#[test]
+fn supported_protocol_range_constant_matches_bounds() {
+    assert_eq!(
+        *SUPPORTED_PROTOCOL_RANGE.start(),
+        ProtocolVersion::OLDEST.as_u8()
+    );
+    assert_eq!(
+        *SUPPORTED_PROTOCOL_RANGE.end(),
+        ProtocolVersion::NEWEST.as_u8()
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- expose the supported protocol range as a public constant derived from the negotiated bounds
- re-export the range and extend the version tests to cover the new constant and its invariants

## Testing
- cargo test

------