### PR TITLE
Support wrapping integers in protocol negotiation

### DIFF
--- a/crates/protocol/src/version.rs
+++ b/crates/protocol/src/version.rs
@@ -3,7 +3,7 @@ use core::convert::TryFrom;
 use core::fmt;
 use core::num::{
     NonZeroI8, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI128, NonZeroIsize, NonZeroU8,
-    NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU128, NonZeroUsize,
+    NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU128, NonZeroUsize, Wrapping,
 };
 use core::ops::RangeInclusive;
 
@@ -100,6 +100,12 @@ impl_protocol_version_advertisement!(
     NonZeroU64 => |value: NonZeroU64| value.get().min(u64::from(u8::MAX)) as u8,
     NonZeroU128 => |value: NonZeroU128| value.get().min(u128::from(u8::MAX)) as u8,
     NonZeroUsize => |value: NonZeroUsize| value.get().min(usize::from(u8::MAX)) as u8,
+    Wrapping<u8> => |value: Wrapping<u8>| value.0,
+    Wrapping<u16> => |value: Wrapping<u16>| value.0.min(u16::from(u8::MAX)) as u8,
+    Wrapping<u32> => |value: Wrapping<u32>| value.0.min(u32::from(u8::MAX)) as u8,
+    Wrapping<u64> => |value: Wrapping<u64>| value.0.min(u64::from(u8::MAX)) as u8,
+    Wrapping<u128> => |value: Wrapping<u128>| value.0.min(u128::from(u8::MAX)) as u8,
+    Wrapping<usize> => |value: Wrapping<usize>| value.0.min(usize::from(u8::MAX)) as u8,
     i8 => |value: i8| value.clamp(0, i8::MAX) as u8,
     i16 => |value: i16| value.clamp(0, i16::from(u8::MAX)) as u8,
     i32 => |value: i32| value.clamp(0, i32::from(u8::MAX)) as u8,
@@ -112,6 +118,12 @@ impl_protocol_version_advertisement!(
     NonZeroI64 => |value: NonZeroI64| value.get().clamp(0, i64::from(u8::MAX)) as u8,
     NonZeroI128 => |value: NonZeroI128| value.get().clamp(0, i128::from(u8::MAX)) as u8,
     NonZeroIsize => |value: NonZeroIsize| value.get().clamp(0, isize::from(u8::MAX)) as u8,
+    Wrapping<i8> => |value: Wrapping<i8>| value.0.clamp(0, i8::MAX) as u8,
+    Wrapping<i16> => |value: Wrapping<i16>| value.0.clamp(0, i16::from(u8::MAX)) as u8,
+    Wrapping<i32> => |value: Wrapping<i32>| value.0.clamp(0, i32::from(u8::MAX)) as u8,
+    Wrapping<i64> => |value: Wrapping<i64>| value.0.clamp(0, i64::from(u8::MAX)) as u8,
+    Wrapping<i128> => |value: Wrapping<i128>| value.0.clamp(0, i128::from(u8::MAX)) as u8,
+    Wrapping<isize> => |value: Wrapping<isize>| value.0.clamp(0, isize::from(u8::MAX)) as u8,
 );
 
 macro_rules! declare_supported_protocols {

--- a/crates/protocol/src/version/tests.rs
+++ b/crates/protocol/src/version/tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 use core::num::{
     NonZeroI8, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI128, NonZeroIsize, NonZeroU8,
-    NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU128, NonZeroUsize,
+    NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU128, NonZeroUsize, Wrapping,
 };
 use proptest::prelude::*;
 
@@ -187,6 +187,90 @@ fn select_highest_mutual_accepts_non_zero_signed_advertisements() {
     let future = NonZeroI128::new(200).expect("non-zero");
     let negotiated = select_highest_mutual([future]).expect("future values clamp");
     assert_eq!(negotiated, ProtocolVersion::NEWEST);
+}
+
+#[test]
+fn select_highest_mutual_accepts_wrapping_unsigned_advertisements() {
+    let negotiated = select_highest_mutual([
+        Wrapping::<u16>(u16::from(ProtocolVersion::NEWEST.as_u8())),
+        Wrapping::<u16>(u16::from(ProtocolVersion::OLDEST.as_u8())),
+    ])
+    .expect("wrapping u16 works");
+    assert_eq!(negotiated, ProtocolVersion::NEWEST);
+
+    let negotiated = select_highest_mutual([
+        Wrapping::<u32>(u32::from(ProtocolVersion::NEWEST.as_u8())),
+        Wrapping::<u32>(u32::from(ProtocolVersion::OLDEST.as_u8())),
+    ])
+    .expect("wrapping u32 works");
+    assert_eq!(negotiated, ProtocolVersion::NEWEST);
+
+    let negotiated = select_highest_mutual([
+        Wrapping::<u64>(u64::from(ProtocolVersion::NEWEST.as_u8())),
+        Wrapping::<u64>(u64::from(ProtocolVersion::OLDEST.as_u8())),
+    ])
+    .expect("wrapping u64 works");
+    assert_eq!(negotiated, ProtocolVersion::NEWEST);
+
+    let negotiated = select_highest_mutual([
+        Wrapping::<u128>(u128::from(ProtocolVersion::NEWEST.as_u8())),
+        Wrapping::<u128>(u128::from(ProtocolVersion::OLDEST.as_u8())),
+    ])
+    .expect("wrapping u128 works");
+    assert_eq!(negotiated, ProtocolVersion::NEWEST);
+
+    let negotiated = select_highest_mutual([
+        Wrapping::<usize>(usize::from(ProtocolVersion::NEWEST.as_u8())),
+        Wrapping::<usize>(usize::from(ProtocolVersion::OLDEST.as_u8())),
+    ])
+    .expect("wrapping usize works");
+    assert_eq!(negotiated, ProtocolVersion::NEWEST);
+
+    let future = Wrapping::<u128>(200);
+    let negotiated = select_highest_mutual([future]).expect("wrapping future clamps");
+    assert_eq!(negotiated, ProtocolVersion::NEWEST);
+}
+
+#[test]
+fn select_highest_mutual_accepts_wrapping_signed_advertisements() {
+    let negotiated = select_highest_mutual([
+        Wrapping::<i16>(i16::from(ProtocolVersion::NEWEST.as_u8())),
+        Wrapping::<i16>(i16::from(ProtocolVersion::OLDEST.as_u8())),
+    ])
+    .expect("wrapping i16 works");
+    assert_eq!(negotiated, ProtocolVersion::NEWEST);
+
+    let negotiated = select_highest_mutual([
+        Wrapping::<i32>(i32::from(ProtocolVersion::NEWEST.as_u8())),
+        Wrapping::<i32>(i32::from(ProtocolVersion::OLDEST.as_u8())),
+    ])
+    .expect("wrapping i32 works");
+    assert_eq!(negotiated, ProtocolVersion::NEWEST);
+
+    let negotiated = select_highest_mutual([
+        Wrapping::<i64>(i64::from(ProtocolVersion::NEWEST.as_u8())),
+        Wrapping::<i64>(i64::from(ProtocolVersion::OLDEST.as_u8())),
+    ])
+    .expect("wrapping i64 works");
+    assert_eq!(negotiated, ProtocolVersion::NEWEST);
+
+    let negotiated = select_highest_mutual([
+        Wrapping::<i128>(i128::from(ProtocolVersion::NEWEST.as_u8())),
+        Wrapping::<i128>(i128::from(ProtocolVersion::OLDEST.as_u8())),
+    ])
+    .expect("wrapping i128 works");
+    assert_eq!(negotiated, ProtocolVersion::NEWEST);
+
+    let negotiated = select_highest_mutual([
+        Wrapping::<isize>(isize::from(ProtocolVersion::NEWEST.as_u8())),
+        Wrapping::<isize>(isize::from(ProtocolVersion::OLDEST.as_u8())),
+    ])
+    .expect("wrapping isize works");
+    assert_eq!(negotiated, ProtocolVersion::NEWEST);
+
+    let negative = Wrapping::<i64>(-12);
+    let err = select_highest_mutual([negative]).unwrap_err();
+    assert_eq!(err, NegotiationError::UnsupportedVersion(0));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- allow `ProtocolVersionAdvertisement` to accept `core::num::Wrapping` wrappers for signed and unsigned integers
- extend the negotiation test suite to cover wrapping inputs and negative handling

## Testing
- cargo test

------