### PR TITLE
Optimize supported protocol iterator to avoid array copies

### DIFF
--- a/crates/protocol/tests/public_api.rs
+++ b/crates/protocol/tests/public_api.rs
@@ -43,8 +43,7 @@ fn supported_protocol_exports_cover_range() {
         &rsync_protocol::SUPPORTED_PROTOCOLS,
     );
     assert!(
-        ProtocolVersion::supported_protocol_numbers_iter()
-            .eq(rsync_protocol::SUPPORTED_PROTOCOLS)
+        ProtocolVersion::supported_protocol_numbers_iter().eq(rsync_protocol::SUPPORTED_PROTOCOLS)
     );
 
     let exported_range = rsync_protocol::SUPPORTED_PROTOCOL_RANGE.clone();


### PR DESCRIPTION
## Summary
- return a borrowing iterator from `ProtocolVersion::supported_protocol_numbers_iter` so repeated traversals avoid copying the protocol table
- document the reuse behavior on the slice-backed helpers and keep the public API snapshot test formatted by rustfmt

## Testing
- cargo test
- cargo clippy

------