### PR TITLE
Add documentation example for negotiation sniffer

### DIFF
--- a/crates/protocol/src/negotiation.rs
+++ b/crates/protocol/src/negotiation.rs
@@ -140,6 +140,22 @@ pub fn detect_negotiation_prologue(buffer: &[u8]) -> NegotiationPrologue {
 /// transient `EINTR` interruptions. This helper mirrors upstream behavior while
 /// providing a higher level interface that owns the buffered prefix so callers
 /// can replay the bytes into the legacy greeting parser without reallocating.
+///
+/// # Examples
+///
+/// ```
+/// use rsync_protocol::{NegotiationPrologue, NegotiationPrologueSniffer};
+/// use std::io::Cursor;
+///
+/// let mut sniffer = NegotiationPrologueSniffer::new();
+/// let mut reader = Cursor::new(&b"@RSYNCD: 31.0\n"[..]);
+/// let decision = sniffer
+///     .read_from(&mut reader)
+///     .expect("legacy negotiation detection succeeds");
+///
+/// assert_eq!(decision, NegotiationPrologue::LegacyAscii);
+/// assert_eq!(sniffer.buffered(), b"@RSYNCD:");
+/// ```
 #[derive(Debug)]
 pub struct NegotiationPrologueSniffer {
     detector: NegotiationPrologueDetector,

--- a/crates/protocol/tests/public_api.rs
+++ b/crates/protocol/tests/public_api.rs
@@ -43,8 +43,7 @@ fn supported_protocol_exports_cover_range() {
         &rsync_protocol::SUPPORTED_PROTOCOLS,
     );
     assert!(
-        ProtocolVersion::supported_protocol_numbers_iter()
-            .eq(rsync_protocol::SUPPORTED_PROTOCOLS)
+        ProtocolVersion::supported_protocol_numbers_iter().eq(rsync_protocol::SUPPORTED_PROTOCOLS)
     );
 
     let exported_range = rsync_protocol::SUPPORTED_PROTOCOL_RANGE.clone();


### PR DESCRIPTION
## Summary
- document how to use `NegotiationPrologueSniffer::read_from` with a concrete doctest example
- refresh formatting in the public API coverage test after running rustfmt

## Testing
- `cargo test`

------