### PR TITLE
Add helper to read legacy daemon greeting

### DIFF
--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -62,7 +62,7 @@ pub use legacy::{
 pub use multiplex::{MessageFrame, recv_msg, recv_msg_into, send_msg};
 pub use negotiation::{
     BufferedPrefixTooSmall, NegotiationPrologue, NegotiationPrologueDetector,
-    NegotiationPrologueSniffer, detect_negotiation_prologue,
+    NegotiationPrologueSniffer, detect_negotiation_prologue, read_legacy_daemon_line,
 };
 pub use version::{
     ProtocolVersion, ProtocolVersionAdvertisement, SUPPORTED_PROTOCOL_COUNT,


### PR DESCRIPTION
## Summary
- add a public helper that drains the sniffed @RSYNCD: prefix and reads the rest of the legacy daemon line
- expose the helper from the crate root alongside the other negotiation utilities
- cover the new functionality with unit tests, including error handling scenarios

## Testing
- `cargo test`

------