### PR TITLE
Expose array accessor for cached protocol versions

### DIFF
--- a/crates/protocol/src/version.rs
+++ b/crates/protocol/src/version.rs
@@ -235,6 +235,18 @@ impl ProtocolVersion {
         &Self::SUPPORTED_VERSIONS
     }
 
+    /// Returns the cached list of supported protocol versions as a fixed-size array reference.
+    ///
+    /// Some compile-time contexts require access to the concrete array type instead of a slice,
+    /// mirroring helpers such as [`ProtocolVersion::supported_protocol_numbers_array`]. Exposing
+    /// the array keeps those call sites in sync with the canonical
+    /// [`ProtocolVersion::SUPPORTED_VERSIONS`] cache while avoiding duplicate literals.
+    #[must_use]
+    pub const fn supported_versions_array() -> &'static [ProtocolVersion; SUPPORTED_PROTOCOL_COUNT]
+    {
+        &Self::SUPPORTED_VERSIONS
+    }
+
     /// Reports whether the provided numeric protocol identifier is supported
     /// by this implementation.
     ///

--- a/crates/protocol/src/version/tests.rs
+++ b/crates/protocol/src/version/tests.rs
@@ -420,6 +420,10 @@ fn supported_versions_method_matches_constant_slice() {
         ProtocolVersion::supported_versions(),
         ProtocolVersion::SUPPORTED_VERSIONS.as_slice()
     );
+    assert_eq!(
+        ProtocolVersion::supported_versions_array(),
+        &ProtocolVersion::SUPPORTED_VERSIONS,
+    );
 }
 
 #[test]
@@ -447,6 +451,11 @@ fn supported_protocol_count_matches_helpers() {
         SUPPORTED_PROTOCOL_COUNT,
         ProtocolVersion::supported_versions().len(),
         "count constant must match cached ProtocolVersion list",
+    );
+    assert_eq!(
+        SUPPORTED_PROTOCOL_COUNT,
+        ProtocolVersion::supported_versions_array().len(),
+        "count constant must match cached ProtocolVersion array",
     );
 }
 

--- a/crates/protocol/tests/public_api.rs
+++ b/crates/protocol/tests/public_api.rs
@@ -42,6 +42,10 @@ fn supported_protocol_exports_cover_range() {
         ProtocolVersion::supported_protocol_numbers_array(),
         &rsync_protocol::SUPPORTED_PROTOCOLS,
     );
+    assert_eq!(
+        ProtocolVersion::supported_versions_array(),
+        &ProtocolVersion::SUPPORTED_VERSIONS,
+    );
     assert!(
         ProtocolVersion::supported_protocol_numbers_iter().eq(rsync_protocol::SUPPORTED_PROTOCOLS)
     );


### PR DESCRIPTION
## Summary
- add `ProtocolVersion::supported_versions_array()` to provide a fixed-size view of the cached version table
- extend unit and public API tests to validate the new accessor alongside the existing helpers

## Testing
- cargo test

------