### PR TITLE
Fix Clippy warning for legacy negotiation reserve errors

### DIFF
--- a/crates/protocol/src/negotiation.rs
+++ b/crates/protocol/src/negotiation.rs
@@ -757,10 +757,9 @@ impl Default for NegotiationPrologueDetector {
 }
 
 fn map_reserve_error_for_io(err: TryReserveError) -> io::Error {
-    io::Error::new(
-        io::ErrorKind::Other,
-        format!("failed to reserve memory for legacy negotiation buffer: {err}"),
-    )
+    io::Error::other(format!(
+        "failed to reserve memory for legacy negotiation buffer: {err}"
+    ))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- use `io::Error::other` when mapping allocation failures in the legacy negotiation buffer helper to align with Clippy guidance

## Testing
- cargo clippy
- cargo test

------