### PR TITLE
Add negotiation writer drain helper and tests

### DIFF
--- a/crates/protocol/tests/public_api.rs
+++ b/crates/protocol/tests/public_api.rs
@@ -1,7 +1,8 @@
 #![allow(clippy::needless_pass_by_value)]
 
 use rsync_protocol::{
-    LogCode, ParseLogCodeError, ProtocolVersion, ProtocolVersionAdvertisement, select_highest_mutual,
+    LogCode, ParseLogCodeError, ProtocolVersion, ProtocolVersionAdvertisement,
+    select_highest_mutual,
 };
 
 #[derive(Clone, Copy)]
@@ -64,7 +65,10 @@ fn supported_protocol_exports_cover_range() {
 fn log_code_round_trips_between_numeric_and_name() {
     for (index, &code) in LogCode::all().iter().enumerate() {
         let numeric = u8::from(code);
-        assert_eq!(numeric, index as u8, "numeric order must match upstream table");
+        assert_eq!(
+            numeric, index as u8,
+            "numeric order must match upstream table"
+        );
 
         let parsed_from_numeric = LogCode::try_from(numeric).expect("numeric value should parse");
         assert_eq!(parsed_from_numeric, code);
@@ -90,7 +94,9 @@ fn parse_log_code_error_reports_invalid_numeric_values() {
 
 #[test]
 fn parse_log_code_error_reports_invalid_names() {
-    let err = "NOTREAL".parse::<LogCode>().expect_err("unknown name must fail");
+    let err = "NOTREAL"
+        .parse::<LogCode>()
+        .expect_err("unknown name must fail");
 
     match &err {
         ParseLogCodeError::InvalidName(name) => {


### PR DESCRIPTION
## Summary
- add a `take_buffered_into_writer` helper so the negotiation sniffer can stream its prefix directly into any `Write`
- cover the new helper with success and error propagation tests, and ensure formatting stays rustfmt clean

## Testing
- cargo test -p rsync-protocol

------