### PR TITLE
Expose supported protocol bounds constant

### DIFF
--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -65,6 +65,6 @@ pub use negotiation::{
     NegotiationPrologueSniffer, detect_negotiation_prologue, read_legacy_daemon_line,
 };
 pub use version::{
-    ProtocolVersion, ProtocolVersionAdvertisement, SUPPORTED_PROTOCOL_COUNT,
-    SUPPORTED_PROTOCOL_RANGE, SUPPORTED_PROTOCOLS, select_highest_mutual,
+    ProtocolVersion, ProtocolVersionAdvertisement, SUPPORTED_PROTOCOL_BOUNDS,
+    SUPPORTED_PROTOCOL_COUNT, SUPPORTED_PROTOCOL_RANGE, SUPPORTED_PROTOCOLS, select_highest_mutual,
 };

--- a/crates/protocol/src/version.rs
+++ b/crates/protocol/src/version.rs
@@ -28,6 +28,17 @@ const UPSTREAM_PROTOCOL_RANGE: RangeInclusive<u8> =
 pub const SUPPORTED_PROTOCOL_RANGE: RangeInclusive<u8> =
     OLDEST_SUPPORTED_PROTOCOL..=NEWEST_SUPPORTED_PROTOCOL;
 
+/// Inclusive `(oldest, newest)` tuple describing the protocol span supported by the Rust
+/// implementation.
+///
+/// Upstream rsync surfaces the lowest and highest negotiated versions in many diagnostics. Exporting
+/// the tuple keeps higher layers from duplicating the literal bounds while guaranteeing parity with
+/// [`SUPPORTED_PROTOCOL_RANGE`]. The helper mirrors the information exposed by
+/// [`ProtocolVersion::supported_range_bounds`] without requiring callers to depend on the
+/// [`ProtocolVersion`] type.
+pub const SUPPORTED_PROTOCOL_BOUNDS: (u8, u8) =
+    (OLDEST_SUPPORTED_PROTOCOL, NEWEST_SUPPORTED_PROTOCOL);
+
 /// A single negotiated rsync protocol version.
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct ProtocolVersion(NonZeroU8);
@@ -315,7 +326,7 @@ impl ProtocolVersion {
     /// numeric literals.
     #[must_use]
     pub const fn supported_range() -> RangeInclusive<u8> {
-        Self::OLDEST.as_u8()..=Self::NEWEST.as_u8()
+        SUPPORTED_PROTOCOL_RANGE
     }
 
     /// Returns the inclusive supported range as a tuple of `(oldest, newest)`.
@@ -328,7 +339,7 @@ impl ProtocolVersion {
     /// supported span.
     #[must_use]
     pub const fn supported_range_bounds() -> (u8, u8) {
-        (Self::OLDEST.as_u8(), Self::NEWEST.as_u8())
+        SUPPORTED_PROTOCOL_BOUNDS
     }
 
     /// Returns an iterator over the supported protocol versions in

--- a/crates/protocol/src/version/tests.rs
+++ b/crates/protocol/src/version/tests.rs
@@ -521,6 +521,21 @@ fn supported_protocol_range_constant_matches_bounds() {
 }
 
 #[test]
+fn supported_protocol_bounds_constant_matches_helpers() {
+    assert_eq!(
+        SUPPORTED_PROTOCOL_BOUNDS,
+        (
+            ProtocolVersion::OLDEST.as_u8(),
+            ProtocolVersion::NEWEST.as_u8()
+        )
+    );
+    assert_eq!(
+        SUPPORTED_PROTOCOL_BOUNDS,
+        ProtocolVersion::supported_range_bounds()
+    );
+}
+
+#[test]
 fn detects_supported_versions() {
     for version in SUPPORTED_PROTOCOLS {
         assert!(ProtocolVersion::is_supported(version));

--- a/crates/protocol/tests/public_api.rs
+++ b/crates/protocol/tests/public_api.rs
@@ -1,7 +1,8 @@
 #![allow(clippy::needless_pass_by_value)]
 
 use rsync_protocol::{
-    LogCode, ParseLogCodeError, ProtocolVersion, ProtocolVersionAdvertisement, select_highest_mutual,
+    LogCode, ParseLogCodeError, ProtocolVersion, ProtocolVersionAdvertisement,
+    select_highest_mutual,
 };
 
 #[derive(Clone, Copy)]
@@ -58,13 +59,17 @@ fn supported_protocol_exports_cover_range() {
     let (oldest, newest) = ProtocolVersion::supported_range_bounds();
     assert_eq!(oldest, *exported_range.start());
     assert_eq!(newest, *exported_range.end());
+    assert_eq!(rsync_protocol::SUPPORTED_PROTOCOL_BOUNDS, (oldest, newest));
 }
 
 #[test]
 fn log_code_round_trips_between_numeric_and_name() {
     for (index, &code) in LogCode::all().iter().enumerate() {
         let numeric = u8::from(code);
-        assert_eq!(numeric, index as u8, "numeric order must match upstream table");
+        assert_eq!(
+            numeric, index as u8,
+            "numeric order must match upstream table"
+        );
 
         let parsed_from_numeric = LogCode::try_from(numeric).expect("numeric value should parse");
         assert_eq!(parsed_from_numeric, code);
@@ -90,7 +95,9 @@ fn parse_log_code_error_reports_invalid_numeric_values() {
 
 #[test]
 fn parse_log_code_error_reports_invalid_names() {
-    let err = "NOTREAL".parse::<LogCode>().expect_err("unknown name must fail");
+    let err = "NOTREAL"
+        .parse::<LogCode>()
+        .expect_err("unknown name must fail");
 
     match &err {
         ParseLogCodeError::InvalidName(name) => {


### PR DESCRIPTION
## Summary
- expose a SUPPORTED_PROTOCOL_BOUNDS tuple describing the oldest/newest supported protocol
- reuse the shared tuple inside ProtocolVersion helpers and cover the constant in API tests

## Testing
- cargo test

------