### PR TITLE
Expose legacy negotiation prefix constants

### DIFF
--- a/crates/protocol/src/legacy/mod.rs
+++ b/crates/protocol/src/legacy/mod.rs
@@ -1,7 +1,25 @@
 use crate::error::NegotiationError;
 
-pub(crate) const LEGACY_DAEMON_PREFIX: &str = "@RSYNCD:";
-pub(crate) const LEGACY_DAEMON_PREFIX_LEN: usize = LEGACY_DAEMON_PREFIX.len();
+/// Canonical ASCII prefix that identifies the legacy `@RSYNCD:` negotiation style.
+///
+/// Upstream rsync emits this exact marker (including the trailing colon) before sending
+/// the daemon greeting when a peer is limited to protocols older than 30. Exposing the
+/// constant allows higher layers to reference the prefix without duplicating the literal,
+/// keeping diagnostics and buffer sizing in sync with the canonical value.
+pub const LEGACY_DAEMON_PREFIX: &str = "@RSYNCD:";
+
+/// Number of bytes in [`LEGACY_DAEMON_PREFIX`].
+///
+/// The length matches the canonical prefix observed on the wire and is exported so
+/// transports can size temporary buffers without recomputing it at runtime.
+pub const LEGACY_DAEMON_PREFIX_LEN: usize = LEGACY_DAEMON_PREFIX.len();
+
+/// Canonical byte representation of [`LEGACY_DAEMON_PREFIX`].
+///
+/// Legacy negotiation helpers frequently need to work with the ASCII prefix as raw bytes.
+/// Publishing the array keeps those call-sites allocation-free and avoids repeated
+/// conversions via [`str::as_bytes`].
+pub const LEGACY_DAEMON_PREFIX_BYTES: &[u8; LEGACY_DAEMON_PREFIX_LEN] = b"@RSYNCD:";
 
 mod bytes;
 mod greeting;

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -53,6 +53,7 @@ pub use envelope::{
 };
 pub use error::NegotiationError;
 pub use legacy::{
+    LEGACY_DAEMON_PREFIX, LEGACY_DAEMON_PREFIX_BYTES, LEGACY_DAEMON_PREFIX_LEN,
     LegacyDaemonMessage, format_legacy_daemon_greeting, parse_legacy_daemon_greeting,
     parse_legacy_daemon_greeting_bytes, parse_legacy_daemon_message,
     parse_legacy_daemon_message_bytes, parse_legacy_error_message,

--- a/crates/protocol/src/negotiation.rs
+++ b/crates/protocol/src/negotiation.rs
@@ -2,7 +2,7 @@ use core::{fmt, mem, slice};
 use std::collections::TryReserveError;
 use std::io::{self, Read, Write};
 
-use crate::legacy::{LEGACY_DAEMON_PREFIX, LEGACY_DAEMON_PREFIX_LEN};
+use crate::legacy::{LEGACY_DAEMON_PREFIX_BYTES, LEGACY_DAEMON_PREFIX_LEN};
 
 /// Error returned when the caller-provided slice cannot hold the buffered negotiation prefix.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -600,7 +600,7 @@ impl NegotiationPrologueDetector {
             return self.decided.unwrap_or(NegotiationPrologue::NeedMoreData);
         }
 
-        let prefix = LEGACY_DAEMON_PREFIX.as_bytes();
+        let prefix = LEGACY_DAEMON_PREFIX_BYTES.as_slice();
         let mut decision = None;
 
         for &byte in chunk {
@@ -783,6 +783,7 @@ fn map_reserve_error_for_io(err: TryReserveError) -> io::Error {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::legacy::LEGACY_DAEMON_PREFIX;
     use proptest::prelude::*;
     use std::io::{self, Cursor, Read};
 

--- a/crates/protocol/tests/public_api.rs
+++ b/crates/protocol/tests/public_api.rs
@@ -63,6 +63,13 @@ fn supported_protocol_exports_cover_range() {
 }
 
 #[test]
+fn legacy_daemon_prefix_constants_are_public() {
+    assert_eq!(rsync_protocol::LEGACY_DAEMON_PREFIX, "@RSYNCD:");
+    assert_eq!(rsync_protocol::LEGACY_DAEMON_PREFIX_LEN, 8);
+    assert_eq!(rsync_protocol::LEGACY_DAEMON_PREFIX_BYTES, b"@RSYNCD:");
+}
+
+#[test]
 fn log_code_round_trips_between_numeric_and_name() {
     for (index, &code) in LogCode::all().iter().enumerate() {
         let numeric = u8::from(code);


### PR DESCRIPTION
## Summary
- expose the canonical `@RSYNCD:` prefix and length as public constants for downstream callers
- reuse the exported byte slice in the negotiation detector to avoid repeated conversions
- add a public API test that asserts the constants are available through the crate re-exports

## Testing
- cargo test
- cargo clippy

------