### PR TITLE
Add iterator length invariants for supported protocol helpers

### DIFF
--- a/crates/protocol/src/version/tests.rs
+++ b/crates/protocol/src/version/tests.rs
@@ -496,6 +496,48 @@ fn supported_protocol_numbers_iter_is_sorted_descending() {
 }
 
 #[test]
+fn supported_versions_iter_reports_length() {
+    let mut iter = ProtocolVersion::supported_versions_iter();
+
+    assert_eq!(iter.len(), SUPPORTED_PROTOCOL_COUNT);
+    assert_eq!(
+        iter.size_hint(),
+        (SUPPORTED_PROTOCOL_COUNT, Some(SUPPORTED_PROTOCOL_COUNT))
+    );
+
+    assert_eq!(iter.next(), Some(ProtocolVersion::NEWEST));
+    assert_eq!(iter.len(), SUPPORTED_PROTOCOL_COUNT - 1);
+    assert_eq!(
+        iter.size_hint(),
+        (
+            SUPPORTED_PROTOCOL_COUNT - 1,
+            Some(SUPPORTED_PROTOCOL_COUNT - 1)
+        )
+    );
+}
+
+#[test]
+fn supported_protocol_numbers_iter_reports_length() {
+    let mut iter = ProtocolVersion::supported_protocol_numbers_iter();
+
+    assert_eq!(iter.len(), SUPPORTED_PROTOCOL_COUNT);
+    assert_eq!(
+        iter.size_hint(),
+        (SUPPORTED_PROTOCOL_COUNT, Some(SUPPORTED_PROTOCOL_COUNT))
+    );
+
+    assert_eq!(iter.next(), Some(ProtocolVersion::NEWEST.as_u8()));
+    assert_eq!(iter.len(), SUPPORTED_PROTOCOL_COUNT - 1);
+    assert_eq!(
+        iter.size_hint(),
+        (
+            SUPPORTED_PROTOCOL_COUNT - 1,
+            Some(SUPPORTED_PROTOCOL_COUNT - 1)
+        )
+    );
+}
+
+#[test]
 fn supported_range_matches_upstream_bounds() {
     assert_eq!(ProtocolVersion::supported_range(), SUPPORTED_PROTOCOL_RANGE);
     assert_eq!(SUPPORTED_PROTOCOL_RANGE, UPSTREAM_PROTOCOL_RANGE);

--- a/crates/protocol/tests/public_api.rs
+++ b/crates/protocol/tests/public_api.rs
@@ -40,11 +40,8 @@ fn message_header_constants_match_upstream_definition() {
     assert_eq!(rsync_protocol::MESSAGE_HEADER_LEN, 4);
     assert_eq!(rsync_protocol::MAX_PAYLOAD_LENGTH, 0x00FF_FFFF);
 
-    let header = rsync_protocol::MessageHeader::new(
-        rsync_protocol::MessageCode::Info,
-        0,
-    )
-    .expect("zero-length payloads are valid");
+    let header = rsync_protocol::MessageHeader::new(rsync_protocol::MessageCode::Info, 0)
+        .expect("zero-length payloads are valid");
     assert_eq!(header.encode().len(), rsync_protocol::MESSAGE_HEADER_LEN);
 }
 


### PR DESCRIPTION
## Summary
- add regression tests that assert the length and size_hint invariants of the protocol-version iterators
- reformat the public API snapshot test to keep MessageHeader construction on one line after rustfmt changes

## Testing
- cargo test

------