### PR TITLE
Add conversion error for log/message code mappings

### DIFF
--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -48,8 +48,8 @@ mod negotiation;
 mod version;
 
 pub use envelope::{
-    EnvelopeError, HEADER_LEN as MESSAGE_HEADER_LEN, LogCode, MAX_PAYLOAD_LENGTH, MessageCode,
-    MessageHeader, ParseLogCodeError, ParseMessageCodeError,
+    EnvelopeError, HEADER_LEN as MESSAGE_HEADER_LEN, LogCode, LogCodeConversionError,
+    MAX_PAYLOAD_LENGTH, MessageCode, MessageHeader, ParseLogCodeError, ParseMessageCodeError,
 };
 pub use error::NegotiationError;
 pub use legacy::{


### PR DESCRIPTION
## Summary
- add `LogCodeConversionError` to capture conversion failures between log and message codes
- implement `TryFrom` conversions for `LogCode`/`MessageCode` and expose the error via the crate facade
- extend unit and public API tests to cover the new conversions and diagnostics

## Testing
- cargo test

------