### PR TITLE
Short-circuit unsupported protocol numbers

### DIFF
--- a/crates/protocol/src/version.rs
+++ b/crates/protocol/src/version.rs
@@ -296,6 +296,10 @@ impl ProtocolVersion {
     /// directly without triggering a runtime negotiation.
     #[must_use]
     pub const fn is_supported_protocol_number(value: u8) -> bool {
+        if value < Self::OLDEST.as_u8() || value > Self::NEWEST.as_u8() {
+            return false;
+        }
+
         let mut index = 0usize;
         while index < SUPPORTED_PROTOCOL_COUNT {
             if SUPPORTED_PROTOCOLS[index] == value {


### PR DESCRIPTION
## Summary
- return early from `ProtocolVersion::is_supported_protocol_number` when the input falls outside the known protocol range

## Testing
- cargo test

------