### PR TITLE
Add ProtocolVersion conversions to wider integer types

### DIFF
--- a/crates/protocol/src/version.rs
+++ b/crates/protocol/src/version.rs
@@ -481,6 +481,43 @@ impl From<ProtocolVersion> for NonZeroU8 {
     }
 }
 
+macro_rules! impl_from_protocol_version_for_unsigned {
+    ($($ty:ty),+ $(,)?) => {
+        $(
+            impl From<ProtocolVersion> for $ty {
+                #[inline]
+                fn from(version: ProtocolVersion) -> Self {
+                    <$ty as From<u8>>::from(version.as_u8())
+                }
+            }
+        )+
+    };
+}
+
+impl_from_protocol_version_for_unsigned!(u16, u32, u64, u128, usize);
+
+macro_rules! impl_from_protocol_version_for_nonzero_unsigned {
+    ($($ty:ty => $base:ty),+ $(,)?) => {
+        $(
+            impl From<ProtocolVersion> for $ty {
+                #[inline]
+                fn from(version: ProtocolVersion) -> Self {
+                    <$ty>::new(<$base as From<u8>>::from(version.as_u8()))
+                        .expect("protocol versions are always non-zero")
+                }
+            }
+        )+
+    };
+}
+
+impl_from_protocol_version_for_nonzero_unsigned!(
+    NonZeroU16 => u16,
+    NonZeroU32 => u32,
+    NonZeroU64 => u64,
+    NonZeroU128 => u128,
+    NonZeroUsize => usize,
+);
+
 impl TryFrom<u8> for ProtocolVersion {
     type Error = NegotiationError;
 

--- a/crates/protocol/src/version/tests.rs
+++ b/crates/protocol/src/version/tests.rs
@@ -190,6 +190,30 @@ fn select_highest_mutual_accepts_non_zero_signed_advertisements() {
 }
 
 #[test]
+fn protocol_version_converts_to_wider_unsigned_primitives() {
+    for version in ProtocolVersion::supported_versions_iter() {
+        let expected = version.as_u8();
+        assert_eq!(u16::from(version), u16::from(expected));
+        assert_eq!(u32::from(version), u32::from(expected));
+        assert_eq!(u64::from(version), u64::from(expected));
+        assert_eq!(u128::from(version), u128::from(expected));
+        assert_eq!(usize::from(version), usize::from(expected));
+    }
+}
+
+#[test]
+fn protocol_version_converts_to_nonzero_wider_unsigned_primitives() {
+    for version in ProtocolVersion::supported_versions_iter() {
+        let expected = version.as_u8();
+        assert_eq!(NonZeroU16::from(version).get(), u16::from(expected));
+        assert_eq!(NonZeroU32::from(version).get(), u32::from(expected));
+        assert_eq!(NonZeroU64::from(version).get(), u64::from(expected));
+        assert_eq!(NonZeroU128::from(version).get(), u128::from(expected));
+        assert_eq!(NonZeroUsize::from(version).get(), usize::from(expected));
+    }
+}
+
+#[test]
 fn select_highest_mutual_accepts_wrapping_unsigned_advertisements() {
     let negotiated = select_highest_mutual([
         Wrapping::<u16>(u16::from(ProtocolVersion::NEWEST.as_u8())),


### PR DESCRIPTION
## Summary
- add blanket conversions from `ProtocolVersion` to wider unsigned primitives
- provide `NonZero*` conversions so callers can reuse typed handles without manual checks
- cover the new conversion surface with unit tests exercising every supported protocol byte

## Testing
- cargo test

------