### PR TITLE
Allow sniffer test to tolerate legacy prefix buffering

### DIFF
--- a/crates/protocol/src/negotiation.rs
+++ b/crates/protocol/src/negotiation.rs
@@ -1487,7 +1487,18 @@ mod tests {
                         .unwrap_or(NegotiationPrologue::NeedMoreData)
                 };
 
-                prop_assert_eq!(sniffer_decision, detector_decision);
+                if sniffer_decision == NegotiationPrologue::NeedMoreData
+                    && detector_decision == NegotiationPrologue::LegacyAscii
+                    && !detector.legacy_prefix_complete()
+                {
+                    // The sniffer intentionally reports `NeedMoreData` while it finishes buffering
+                    // the canonical legacy prefix even though the detector has already classified
+                    // the exchange as legacy ASCII. Higher layers rely on
+                    // `legacy_prefix_remaining`/`legacy_prefix_complete` to decide when to replay
+                    // the buffered bytes, so the differing intermediate decision is expected.
+                } else {
+                    prop_assert_eq!(sniffer_decision, detector_decision);
+                }
 
                 let detector_buffer = detector.buffered_prefix();
                 prop_assert!(sniffer.buffered().starts_with(detector_buffer));


### PR DESCRIPTION
## Summary
- relax the prologue sniffer lockstep property test to accept the expected NeedMoreData result while buffering the legacy prefix
- document the intentional divergence between the sniffer and detector decisions during prefix accumulation

## Testing
- cargo test

------