### PR TITLE
Add context accessors to NegotiationError

### DIFF
--- a/crates/protocol/tests/public_api.rs
+++ b/crates/protocol/tests/public_api.rs
@@ -1,10 +1,9 @@
 #![allow(clippy::needless_pass_by_value)]
 
 use rsync_protocol::{
-    LogCode, LogCodeConversionError, MessageCode, NegotiationPrologue,
-    NegotiationPrologueSniffer, ParseLogCodeError, ProtocolVersion,
-    ProtocolVersionAdvertisement, LEGACY_DAEMON_PREFIX_BYTES, LEGACY_DAEMON_PREFIX_LEN,
-    select_highest_mutual,
+    LEGACY_DAEMON_PREFIX_BYTES, LEGACY_DAEMON_PREFIX_LEN, LogCode, LogCodeConversionError,
+    MessageCode, NegotiationError, NegotiationPrologue, NegotiationPrologueSniffer,
+    ParseLogCodeError, ProtocolVersion, ProtocolVersionAdvertisement, select_highest_mutual,
 };
 
 #[derive(Clone, Copy)]
@@ -161,4 +160,14 @@ fn negotiation_prologue_sniffer_reports_buffered_length() {
 
     assert_eq!(sniffer.buffered_len(), 0);
     assert!(sniffer.buffered().is_empty());
+}
+
+#[test]
+fn negotiation_error_accessors_are_public() {
+    let err = NegotiationError::NoMutualProtocol {
+        peer_versions: vec![30, 31],
+    };
+    assert_eq!(err.peer_versions(), Some(&[30, 31][..]));
+    assert_eq!(err.unsupported_version(), None);
+    assert_eq!(err.malformed_legacy_greeting(), None);
 }


### PR DESCRIPTION
## Summary
- expose borrowed accessors on `NegotiationError` so callers can inspect peer versions, unsupported bytes, or malformed greetings without pattern matching
- extend unit and public API tests to cover the new helpers

## Testing
- cargo test

------