### PR TITLE
Add send_frame helper for multiplexed messages

### DIFF
--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -60,7 +60,7 @@ pub use legacy::{
     parse_legacy_error_message_bytes, parse_legacy_warning_message,
     parse_legacy_warning_message_bytes,
 };
-pub use multiplex::{MessageFrame, recv_msg, recv_msg_into, send_msg};
+pub use multiplex::{MessageFrame, recv_msg, recv_msg_into, send_frame, send_msg};
 pub use negotiation::{
     BufferedPrefixTooSmall, NegotiationPrologue, NegotiationPrologueDetector,
     NegotiationPrologueSniffer, detect_negotiation_prologue, read_legacy_daemon_line,


### PR DESCRIPTION
## Summary
- add a `send_frame` helper that reuses the existing vectored envelope encoding to send previously constructed `MessageFrame` instances
- re-export the helper from the crate root and add unit tests covering empty payloads and parity with `send_msg`

## Testing
- cargo test

------