### PR TITLE
Add ProtocolVersion FromStr parsing support

### DIFF
--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -66,6 +66,7 @@ pub use negotiation::{
     NegotiationPrologueSniffer, detect_negotiation_prologue, read_legacy_daemon_line,
 };
 pub use version::{
-    ProtocolVersion, ProtocolVersionAdvertisement, SUPPORTED_PROTOCOL_BOUNDS,
-    SUPPORTED_PROTOCOL_COUNT, SUPPORTED_PROTOCOL_RANGE, SUPPORTED_PROTOCOLS, select_highest_mutual,
+    ParseProtocolVersionError, ParseProtocolVersionErrorKind, ProtocolVersion,
+    ProtocolVersionAdvertisement, SUPPORTED_PROTOCOL_BOUNDS, SUPPORTED_PROTOCOL_COUNT,
+    SUPPORTED_PROTOCOL_RANGE, SUPPORTED_PROTOCOLS, select_highest_mutual,
 };


### PR DESCRIPTION
## Summary
- add a dedicated ParseProtocolVersionError/Kind pair and implement `FromStr` for `ProtocolVersion`
- expose the new parser types through the public crate facade
- cover the parser with targeted unit tests and documentation examples to validate accepted inputs and error kinds

## Testing
- cargo test

------