### PR TITLE
Expose supported protocol bitmap

### DIFF
--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -67,6 +67,6 @@ pub use negotiation::{
 };
 pub use version::{
     ParseProtocolVersionError, ParseProtocolVersionErrorKind, ProtocolVersion,
-    ProtocolVersionAdvertisement, SUPPORTED_PROTOCOL_BOUNDS, SUPPORTED_PROTOCOL_COUNT,
-    SUPPORTED_PROTOCOL_RANGE, SUPPORTED_PROTOCOLS, select_highest_mutual,
+    ProtocolVersionAdvertisement, SUPPORTED_PROTOCOL_BITMAP, SUPPORTED_PROTOCOL_BOUNDS,
+    SUPPORTED_PROTOCOL_COUNT, SUPPORTED_PROTOCOL_RANGE, SUPPORTED_PROTOCOLS, select_highest_mutual,
 };

--- a/crates/protocol/src/version/tests.rs
+++ b/crates/protocol/src/version/tests.rs
@@ -335,6 +335,32 @@ fn supported_protocol_helpers_remain_consistent() {
 }
 
 #[test]
+fn supported_protocol_bitmap_matches_expected_bits() {
+    let bitmap = ProtocolVersion::supported_protocol_bitmap();
+    assert_eq!(bitmap, SUPPORTED_PROTOCOL_BITMAP);
+    assert_eq!(bitmap.count_ones() as usize, SUPPORTED_PROTOCOL_COUNT);
+
+    for &version in &SUPPORTED_PROTOCOLS {
+        let mask = 1u64 << version;
+        assert_ne!(bitmap & mask, 0, "bit for protocol {version} must be set");
+    }
+
+    let lower_mask = (1u64 << ProtocolVersion::OLDEST.as_u8()) - 1;
+    assert_eq!(
+        bitmap & lower_mask,
+        0,
+        "bitmap must not contain bits below oldest"
+    );
+
+    let upper_shift = usize::from(ProtocolVersion::NEWEST.as_u8()) + 1;
+    assert_eq!(
+        bitmap >> upper_shift,
+        0,
+        "bitmap must not contain bits above newest"
+    );
+}
+
+#[test]
 fn select_highest_mutual_accepts_wider_integer_advertisements() {
     let peers = [u16::from(ProtocolVersion::NEWEST.as_u8()), 0u16];
     let negotiated = select_highest_mutual(peers).expect("wider integers supported");


### PR DESCRIPTION
## Summary
- add a SUPPORTED_PROTOCOL_BITMAP constant derived from the canonical protocol list
- expose a `ProtocolVersion::supported_protocol_bitmap()` helper and re-export the bitmap at the crate root
- extend unit and integration tests to assert the bitmap stays in sync with the supported protocol range

## Testing
- cargo test

------