### PR TITLE
Expose strongly typed protocol version range helpers

### DIFF
--- a/crates/protocol/src/version.rs
+++ b/crates/protocol/src/version.rs
@@ -525,6 +525,30 @@ impl ProtocolVersion {
         SUPPORTED_PROTOCOL_BOUNDS
     }
 
+    /// Returns the oldest and newest supported protocol versions as strongly typed values.
+    ///
+    /// Higher layers that operate on [`ProtocolVersion`] values instead of raw bytes can
+    /// use this helper to remain in sync with the canonical bounds without re-encoding the
+    /// numeric range. The pair mirrors the information exposed by
+    /// [`ProtocolVersion::supported_range_bounds`] while preserving type safety for code that
+    /// stores negotiated versions in strongly typed structures.
+    #[must_use]
+    pub const fn supported_version_bounds() -> (ProtocolVersion, ProtocolVersion) {
+        (Self::OLDEST, Self::NEWEST)
+    }
+
+    /// Returns the inclusive range of supported protocol versions using strongly typed values.
+    ///
+    /// The range mirrors [`ProtocolVersion::supported_range`] but yields
+    /// [`ProtocolVersion`] instances so callers can iterate without converting between the raw
+    /// byte representation and the wrapper type. This is particularly useful when constructing
+    /// lookup tables keyed by [`ProtocolVersion`] or when rendering diagnostics that already work
+    /// with the strongly typed representation.
+    #[must_use]
+    pub fn supported_version_range() -> RangeInclusive<ProtocolVersion> {
+        Self::OLDEST..=Self::NEWEST
+    }
+
     /// Returns an iterator over the supported protocol versions in
     /// newest-to-oldest order.
     ///

--- a/crates/protocol/src/version/tests.rs
+++ b/crates/protocol/src/version/tests.rs
@@ -602,6 +602,13 @@ fn supported_range_bounds_match_upstream_constants() {
 }
 
 #[test]
+fn supported_version_bounds_match_constants() {
+    let (oldest, newest) = ProtocolVersion::supported_version_bounds();
+    assert_eq!(oldest, ProtocolVersion::OLDEST);
+    assert_eq!(newest, ProtocolVersion::NEWEST);
+}
+
+#[test]
 fn supported_protocol_range_constant_matches_bounds() {
     assert_eq!(
         *SUPPORTED_PROTOCOL_RANGE.start(),
@@ -626,6 +633,13 @@ fn supported_protocol_bounds_constant_matches_helpers() {
         SUPPORTED_PROTOCOL_BOUNDS,
         ProtocolVersion::supported_range_bounds()
     );
+}
+
+#[test]
+fn supported_version_range_matches_bounds() {
+    let range = ProtocolVersion::supported_version_range();
+    assert_eq!(range.start(), &ProtocolVersion::OLDEST);
+    assert_eq!(range.end(), &ProtocolVersion::NEWEST);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add strongly typed helpers on `ProtocolVersion` for retrieving the oldest/newest supported versions and the inclusive range
- extend the protocol version test suite to cover the new helpers and ensure they mirror the numeric constants

## Testing
- cargo test

------