### PR TITLE
Expand negotiation proptests for wide integer advertisements

### DIFF
--- a/crates/protocol/src/version/tests.rs
+++ b/crates/protocol/src/version/tests.rs
@@ -839,10 +839,50 @@ proptest! {
     }
 
     #[test]
+    fn select_highest_mutual_matches_reference_for_widest_unsigned(
+        peer_versions in proptest::collection::vec(any::<u128>(), 0..=16)
+    ) {
+        let advertised = collect_advertised(peer_versions.iter().copied());
+        let expected = reference_negotiation(&advertised);
+        let actual = select_highest_mutual(peer_versions);
+        prop_assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn select_highest_mutual_matches_reference_for_native_usize(
+        peer_versions in proptest::collection::vec(any::<usize>(), 0..=16)
+    ) {
+        let advertised = collect_advertised(peer_versions.iter().copied());
+        let expected = reference_negotiation(&advertised);
+        let actual = select_highest_mutual(peer_versions);
+        prop_assert_eq!(actual, expected);
+    }
+
+    #[test]
     fn select_highest_mutual_matches_reference_for_signed(
         peer_versions in proptest::collection::vec(any::<i16>(), 0..=16)
     ) {
         let advertised = collect_advertised(peer_versions.clone());
+        let expected = reference_negotiation(&advertised);
+        let actual = select_highest_mutual(peer_versions);
+        prop_assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn select_highest_mutual_matches_reference_for_widest_signed(
+        peer_versions in proptest::collection::vec(any::<i128>(), 0..=16)
+    ) {
+        let advertised = collect_advertised(peer_versions.iter().copied());
+        let expected = reference_negotiation(&advertised);
+        let actual = select_highest_mutual(peer_versions);
+        prop_assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn select_highest_mutual_matches_reference_for_native_isize(
+        peer_versions in proptest::collection::vec(any::<isize>(), 0..=16)
+    ) {
+        let advertised = collect_advertised(peer_versions.iter().copied());
         let expected = reference_negotiation(&advertised);
         let actual = select_highest_mutual(peer_versions);
         prop_assert_eq!(actual, expected);


### PR DESCRIPTION
## Summary
- add proptests that feed u128, usize, i128, and isize protocol advertisements through `select_highest_mutual`
- verify the negotiated result matches the reference implementation across the newly covered integer widths

## Testing
- cargo test

------