### PR TITLE
Add signed ProtocolVersion conversions

### DIFF
--- a/crates/protocol/src/version.rs
+++ b/crates/protocol/src/version.rs
@@ -675,6 +675,28 @@ macro_rules! impl_from_protocol_version_for_unsigned {
 
 impl_from_protocol_version_for_unsigned!(u16, u32, u64, u128, usize);
 
+impl From<ProtocolVersion> for i8 {
+    #[inline]
+    fn from(version: ProtocolVersion) -> Self {
+        i8::try_from(version.as_u8()).expect("protocol versions fit within i8")
+    }
+}
+
+macro_rules! impl_from_protocol_version_for_signed {
+    ($($ty:ty),+ $(,)?) => {
+        $(
+            impl From<ProtocolVersion> for $ty {
+                #[inline]
+                fn from(version: ProtocolVersion) -> Self {
+                    <$ty as From<u8>>::from(version.as_u8())
+                }
+            }
+        )+
+    };
+}
+
+impl_from_protocol_version_for_signed!(i16, i32, i64, i128, isize);
+
 macro_rules! impl_from_protocol_version_for_nonzero_unsigned {
     ($($ty:ty => $base:ty),+ $(,)?) => {
         $(
@@ -695,6 +717,36 @@ impl_from_protocol_version_for_nonzero_unsigned!(
     NonZeroU64 => u64,
     NonZeroU128 => u128,
     NonZeroUsize => usize,
+);
+
+impl From<ProtocolVersion> for NonZeroI8 {
+    #[inline]
+    fn from(version: ProtocolVersion) -> Self {
+        NonZeroI8::new(i8::try_from(version.as_u8()).expect("protocol versions fit within i8"))
+            .expect("protocol versions are always non-zero")
+    }
+}
+
+macro_rules! impl_from_protocol_version_for_nonzero_signed {
+    ($($ty:ty => $base:ty),+ $(,)?) => {
+        $(
+            impl From<ProtocolVersion> for $ty {
+                #[inline]
+                fn from(version: ProtocolVersion) -> Self {
+                    <$ty>::new(<$base as From<u8>>::from(version.as_u8()))
+                        .expect("protocol versions are always non-zero")
+                }
+            }
+        )+
+    };
+}
+
+impl_from_protocol_version_for_nonzero_signed!(
+    NonZeroI16 => i16,
+    NonZeroI32 => i32,
+    NonZeroI64 => i64,
+    NonZeroI128 => i128,
+    NonZeroIsize => isize,
 );
 
 impl TryFrom<u8> for ProtocolVersion {

--- a/crates/protocol/src/version/tests.rs
+++ b/crates/protocol/src/version/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use core::convert::TryFrom;
 use core::num::{
     NonZeroI8, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI128, NonZeroIsize, NonZeroU8,
     NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU128, NonZeroUsize, Wrapping,
@@ -733,6 +734,57 @@ fn converts_protocol_version_to_u8() {
     let version = ProtocolVersion::try_from(32).expect("valid");
     let value: u8 = version.into();
     assert_eq!(value, 32);
+}
+
+#[test]
+fn converts_protocol_version_to_signed_integers() {
+    let newest = ProtocolVersion::NEWEST;
+    let oldest = ProtocolVersion::OLDEST;
+
+    let newest_i8: i8 = newest.into();
+    assert_eq!(newest_i8, i8::try_from(newest.as_u8()).expect("fits in i8"));
+
+    let newest_i16: i16 = newest.into();
+    assert_eq!(newest_i16, i16::from(newest.as_u8()));
+
+    let oldest_i32: i32 = oldest.into();
+    assert_eq!(oldest_i32, i32::from(oldest.as_u8()));
+
+    let newest_i64: i64 = newest.into();
+    assert_eq!(newest_i64, i64::from(newest.as_u8()));
+
+    let oldest_i128: i128 = oldest.into();
+    assert_eq!(oldest_i128, i128::from(oldest.as_u8()));
+
+    let newest_isize: isize = newest.into();
+    assert_eq!(newest_isize, isize::from(newest.as_u8()));
+}
+
+#[test]
+fn converts_protocol_version_to_non_zero_signed_integers() {
+    let newest = ProtocolVersion::NEWEST;
+    let oldest = ProtocolVersion::OLDEST;
+
+    let newest_i8: NonZeroI8 = newest.into();
+    assert_eq!(
+        newest_i8.get(),
+        i8::try_from(newest.as_u8()).expect("fits in i8")
+    );
+
+    let newest_i16: NonZeroI16 = newest.into();
+    assert_eq!(newest_i16.get(), i16::from(newest.as_u8()));
+
+    let oldest_i32: NonZeroI32 = oldest.into();
+    assert_eq!(oldest_i32.get(), i32::from(oldest.as_u8()));
+
+    let newest_i64: NonZeroI64 = newest.into();
+    assert_eq!(newest_i64.get(), i64::from(newest.as_u8()));
+
+    let oldest_i128: NonZeroI128 = oldest.into();
+    assert_eq!(oldest_i128.get(), i128::from(oldest.as_u8()));
+
+    let newest_isize: NonZeroIsize = newest.into();
+    assert_eq!(newest_isize.get(), isize::from(newest.as_u8()));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add `From<ProtocolVersion>` implementations for signed integer and non-zero signed types
- cover the new conversions with unit tests to ensure parity with unsigned helpers

## Testing
- cargo test

------