### PR TITLE
Add ProtocolVersion offset helpers for table indexing

### DIFF
--- a/crates/protocol/src/version.rs
+++ b/crates/protocol/src/version.rs
@@ -598,6 +598,33 @@ impl ProtocolVersion {
         Self::from_supported(value).is_some()
     }
 
+    /// Returns the zero-based offset from [`ProtocolVersion::OLDEST`] when iterating
+    /// protocol versions in ascending order.
+    ///
+    /// Upstream rsync often indexes lookup tables by subtracting the oldest supported
+    /// protocol value from the negotiated byte. Exposing the same arithmetic keeps the
+    /// Rust implementation in sync while avoiding ad-hoc calculations (and the risk of
+    /// off-by-one mistakes) in higher layers. The helper can be used in const contexts,
+    /// making it suitable for compile-time table initialisation.
+    #[must_use]
+    #[inline]
+    pub const fn offset_from_oldest(self) -> usize {
+        (self.as_u8() - Self::OLDEST.as_u8()) as usize
+    }
+
+    /// Returns the zero-based offset from [`ProtocolVersion::NEWEST`] when iterating
+    /// protocol versions in the descending order used by [`SUPPORTED_PROTOCOLS`].
+    ///
+    /// This index matches the position of the version within [`SUPPORTED_PROTOCOLS`]
+    /// and [`ProtocolVersion::SUPPORTED_VERSIONS`], allowing lookup tables keyed by the
+    /// canonical newest-to-oldest order to perform constant-time indexing without
+    /// recomputing differences at every call site.
+    #[must_use]
+    #[inline]
+    pub const fn offset_from_newest(self) -> usize {
+        (Self::NEWEST.as_u8() - self.as_u8()) as usize
+    }
+
     /// Returns the raw numeric value represented by this version.
     #[must_use]
     #[inline]

--- a/crates/protocol/src/version/tests.rs
+++ b/crates/protocol/src/version/tests.rs
@@ -548,6 +548,29 @@ fn supported_protocol_numbers_iter_is_sorted_descending() {
 }
 
 #[test]
+fn offset_from_oldest_counts_up_across_supported_versions() {
+    for (expected_offset, &version) in ProtocolVersion::supported_versions()
+        .iter()
+        .rev()
+        .enumerate()
+    {
+        assert_eq!(version.offset_from_oldest(), expected_offset);
+    }
+}
+
+#[test]
+fn offset_from_newest_matches_descending_index() {
+    for (index, &version) in ProtocolVersion::supported_versions().iter().enumerate() {
+        assert_eq!(version.offset_from_newest(), index);
+        assert_eq!(
+            version.offset_from_oldest() + version.offset_from_newest(),
+            SUPPORTED_PROTOCOL_COUNT - 1,
+            "offsets should mirror the supported protocol span",
+        );
+    }
+}
+
+#[test]
 fn supported_versions_iter_reports_length() {
     let mut iter = ProtocolVersion::supported_versions_iter();
 

--- a/crates/protocol/tests/public_api.rs
+++ b/crates/protocol/tests/public_api.rs
@@ -100,6 +100,21 @@ fn supported_protocol_bitmap_matches_helpers() {
 }
 
 #[test]
+fn protocol_version_offsets_track_supported_ordering() {
+    for (ascending_index, version) in ProtocolVersion::supported_versions()
+        .iter()
+        .rev()
+        .enumerate()
+    {
+        assert_eq!(version.offset_from_oldest(), ascending_index);
+    }
+
+    for (descending_index, version) in ProtocolVersion::supported_versions().iter().enumerate() {
+        assert_eq!(version.offset_from_newest(), descending_index);
+    }
+}
+
+#[test]
 fn legacy_daemon_prefix_constants_are_public() {
     assert_eq!(rsync_protocol::LEGACY_DAEMON_PREFIX, "@RSYNCD:");
     assert_eq!(rsync_protocol::LEGACY_DAEMON_PREFIX_LEN, 8);


### PR DESCRIPTION
## Summary
- add `ProtocolVersion::offset_from_oldest` and `offset_from_newest` to surface canonical table indices
- cover the new helpers with unit tests that verify both ascending and descending orderings
- extend the public API tests to exercise the offset helpers from an external crate

## Testing
- cargo test -p rsync-protocol

------