### PR TITLE
Add successor and predecessor helpers for ProtocolVersion

### DIFF
--- a/crates/protocol/src/version.rs
+++ b/crates/protocol/src/version.rs
@@ -625,6 +625,40 @@ impl ProtocolVersion {
         (Self::NEWEST.as_u8() - self.as_u8()) as usize
     }
 
+    /// Returns the next newer protocol version within the supported range, if any.
+    ///
+    /// Upstream rsync frequently iterates across protocol numbers while
+    /// comparing capabilities. Providing a strongly typed successor keeps those
+    /// loops ergonomic without forcing callers to perform manual bounds checks
+    /// or convert the version back into a raw integer. When the current value
+    /// already equals [`ProtocolVersion::NEWEST`], the method yields `None` to
+    /// mirror the behavior of reaching the end of the range.
+    #[must_use]
+    pub const fn next_newer(self) -> Option<Self> {
+        if self.as_u8() >= Self::NEWEST.as_u8() {
+            None
+        } else {
+            Some(Self::new_const(self.as_u8() + 1))
+        }
+    }
+
+    /// Returns the next older protocol version within the supported range, if any.
+    ///
+    /// The helper mirrors [`ProtocolVersion::next_newer`] but walks towards the
+    /// lower bound. Callers that need to inspect predecessor versions can rely
+    /// on the function to remain inside the negotiated span without manually
+    /// checking for underflow. When invoked on [`ProtocolVersion::OLDEST`] the
+    /// method returns `None`, signalling that there is no older supported
+    /// protocol.
+    #[must_use]
+    pub const fn next_older(self) -> Option<Self> {
+        if self.as_u8() <= Self::OLDEST.as_u8() {
+            None
+        } else {
+            Some(Self::new_const(self.as_u8() - 1))
+        }
+    }
+
     /// Returns the raw numeric value represented by this version.
     #[must_use]
     #[inline]

--- a/crates/protocol/src/version/tests.rs
+++ b/crates/protocol/src/version/tests.rs
@@ -571,6 +571,36 @@ fn offset_from_newest_matches_descending_index() {
 }
 
 #[test]
+fn next_newer_walks_towards_newest_within_bounds() {
+    let mut current = ProtocolVersion::OLDEST;
+    let mut expected = ProtocolVersion::OLDEST.as_u8();
+
+    while let Some(next) = current.next_newer() {
+        expected += 1;
+        assert_eq!(next.as_u8(), expected);
+        current = next;
+    }
+
+    assert_eq!(current, ProtocolVersion::NEWEST);
+    assert!(ProtocolVersion::NEWEST.next_newer().is_none());
+}
+
+#[test]
+fn next_older_walks_towards_oldest_within_bounds() {
+    let mut current = ProtocolVersion::NEWEST;
+    let mut expected = ProtocolVersion::NEWEST.as_u8();
+
+    while let Some(next) = current.next_older() {
+        expected -= 1;
+        assert_eq!(next.as_u8(), expected);
+        current = next;
+    }
+
+    assert_eq!(current, ProtocolVersion::OLDEST);
+    assert!(ProtocolVersion::OLDEST.next_older().is_none());
+}
+
+#[test]
 fn supported_versions_iter_reports_length() {
     let mut iter = ProtocolVersion::supported_versions_iter();
 


### PR DESCRIPTION
## Summary
- add `ProtocolVersion::next_newer` and `ProtocolVersion::next_older` for range-aware iteration
- cover the new helpers with unit tests that walk across the supported protocol span

## Testing
- cargo test

------