### PR TITLE
Avoid clearing target buffer prematurely in legacy negotiation reader

### DIFF
--- a/crates/protocol/src/negotiation/sniffer.rs
+++ b/crates/protocol/src/negotiation/sniffer.rs
@@ -537,7 +537,6 @@ pub fn read_legacy_daemon_line<R: Read>(
         }
     }
 
-    line.clear();
     sniffer
         .take_buffered_into(line)
         .map_err(map_reserve_error_for_io)?;


### PR DESCRIPTION
## Summary
- avoid clearing the caller-provided vector before replaying the legacy negotiation prefix
- rely on the sniffer helper to clear the buffer so allocation failures leave prior contents untouched

## Testing
- cargo test

------