### PR TITLE
Preserve legacy negotiation prefix bytes read during sniffing

### DIFF
--- a/crates/protocol/src/negotiation/sniffer.rs
+++ b/crates/protocol/src/negotiation/sniffer.rs
@@ -423,7 +423,11 @@ impl NegotiationPrologueSniffer {
                 Ok(read) => {
                     let observed = &scratch[..read];
                     let (decision, consumed) = self.observe(observed);
-                    debug_assert_eq!(consumed, observed.len());
+                    debug_assert!(consumed <= observed.len());
+
+                    if consumed < observed.len() {
+                        self.buffered.extend_from_slice(&observed[consumed..]);
+                    }
                     let needs_more_prefix_bytes = self.needs_more_legacy_prefix_bytes(decision);
                     if decision != NegotiationPrologue::NeedMoreData && !needs_more_prefix_bytes {
                         return Ok(decision);

--- a/crates/protocol/src/negotiation/tests.rs
+++ b/crates/protocol/src/negotiation/tests.rs
@@ -1413,6 +1413,24 @@ fn read_legacy_daemon_line_handles_interrupted_reads() {
 }
 
 #[test]
+fn read_legacy_daemon_line_preserves_bytes_consumed_during_detection() {
+    let mut sniffer = NegotiationPrologueSniffer::new();
+    let mut reader = Cursor::new(b"@RZYNCD: 31.0\n".to_vec());
+
+    let decision = sniffer
+        .read_from(&mut reader)
+        .expect("negotiation sniffing should succeed");
+    assert_eq!(decision, NegotiationPrologue::LegacyAscii);
+    assert_eq!(sniffer.buffered(), b"@RZYNCD:");
+
+    let mut line = Vec::new();
+    read_legacy_daemon_line(&mut sniffer, &mut reader, &mut line)
+        .expect("legacy greeting should include the bytes read during detection");
+
+    assert_eq!(line, b"@RZYNCD: 31.0\n");
+}
+
+#[test]
 fn read_legacy_daemon_line_rejects_incomplete_legacy_prefix() {
     let mut sniffer = NegotiationPrologueSniffer::new();
     let (decision, consumed) = sniffer.observe(b"@");


### PR DESCRIPTION
## Summary
- ensure the negotiation sniffer retains any bytes read while deciding a legacy handshake
- add a regression test that exercises truncated legacy prefixes to confirm the full line is preserved

## Testing
- cargo test

------