### PR TITLE
Preserve legacy negotiation leftovers during sniffing

### DIFF
--- a/crates/protocol/src/negotiation/sniffer.rs
+++ b/crates/protocol/src/negotiation/sniffer.rs
@@ -423,7 +423,13 @@ impl NegotiationPrologueSniffer {
                 Ok(read) => {
                     let observed = &scratch[..read];
                     let (decision, consumed) = self.observe(observed);
-                    debug_assert_eq!(consumed, observed.len());
+                    debug_assert!(
+                        consumed <= observed.len(),
+                        "sniffer must not consume more bytes than were observed"
+                    );
+                    if consumed < observed.len() {
+                        self.buffered.extend_from_slice(&observed[consumed..]);
+                    }
                     let needs_more_prefix_bytes = self.needs_more_legacy_prefix_bytes(decision);
                     if decision != NegotiationPrologue::NeedMoreData && !needs_more_prefix_bytes {
                         return Ok(decision);

--- a/crates/protocol/src/negotiation/tests.rs
+++ b/crates/protocol/src/negotiation/tests.rs
@@ -1053,6 +1053,29 @@ fn prologue_sniffer_limits_legacy_reads_to_required_bytes() {
 }
 
 #[test]
+fn prologue_sniffer_read_from_preserves_bytes_after_malformed_prefix() {
+    let mut sniffer = NegotiationPrologueSniffer::new();
+    let malformed_banner = b"@XFAIL!\n".to_vec();
+    let mut cursor = Cursor::new(malformed_banner.clone());
+
+    let decision = sniffer
+        .read_from(&mut cursor)
+        .expect("malformed legacy negotiation should still classify as legacy");
+
+    assert_eq!(decision, NegotiationPrologue::LegacyAscii);
+    assert!(sniffer.legacy_prefix_complete());
+    assert_eq!(sniffer.legacy_prefix_remaining(), None);
+    assert_eq!(sniffer.buffered(), malformed_banner.as_slice());
+    assert_eq!(cursor.position(), malformed_banner.len() as u64);
+
+    let mut replay = Vec::new();
+    sniffer
+        .take_buffered_into(&mut replay)
+        .expect("replaying malformed prefix should succeed");
+    assert_eq!(replay, malformed_banner);
+}
+
+#[test]
 fn prologue_sniffer_take_buffered_drains_accumulated_prefix() {
     let mut sniffer = NegotiationPrologueSniffer::new();
     let (decision, consumed) = sniffer.observe(LEGACY_DAEMON_PREFIX.as_bytes());


### PR DESCRIPTION
## Summary
- ensure the negotiation sniffer retains bytes read beyond the deciding prefix so malformed legacy banners are replayed intact
- add regression coverage that exercises read_from on malformed prefixes to confirm buffered bytes survive

## Testing
- cargo test

------