### PR TITLE
Expose negotiation detector role helpers

### DIFF
--- a/crates/protocol/src/negotiation/detector.rs
+++ b/crates/protocol/src/negotiation/detector.rs
@@ -137,6 +137,31 @@ impl NegotiationPrologueDetector {
         matches!(self.decided, Some(decision) if decision.is_decided())
     }
 
+    /// Reports whether the detector has determined that the peer selected the legacy
+    /// ASCII negotiation.
+    ///
+    /// The helper mirrors [`NegotiationPrologue::is_legacy`] while accounting for the
+    /// possibility that a decision has not yet been cached. Higher layers that only need
+    /// a boolean view of the cached state can therefore rely on this method instead of
+    /// matching on [`Self::decision`]. The predicate remains `true` even when additional
+    /// prefix bytes still need to be buffered, matching upstream rsync's behavior where
+    /// the legacy decision is sticky once the initial `@` byte has been observed.
+    #[must_use = "check whether the detector classified the exchange as legacy ASCII"]
+    pub const fn is_legacy(&self) -> bool {
+        matches!(self.decided, Some(decision) if decision.is_legacy())
+    }
+
+    /// Reports whether the detector has determined that the peer selected the binary
+    /// negotiation path.
+    ///
+    /// The helper mirrors [`NegotiationPrologue::is_binary`] while tolerating undecided
+    /// states. It becomes `true` as soon as the first byte rules out the legacy ASCII
+    /// negotiation, allowing call sites to react immediately without awaiting further I/O.
+    #[must_use = "check whether the detector classified the exchange as binary"]
+    pub const fn is_binary(&self) -> bool {
+        matches!(self.decided, Some(decision) if decision.is_binary())
+    }
+
     /// Reports whether additional bytes must be read before the negotiation prologue is
     /// fully understood.
     ///

--- a/crates/protocol/src/negotiation/sniffer.rs
+++ b/crates/protocol/src/negotiation/sniffer.rs
@@ -270,9 +270,7 @@ impl NegotiationPrologueSniffer {
     /// as soon as the leading `@` byte is observed.
     #[must_use]
     pub fn is_legacy(&self) -> bool {
-        self.detector
-            .decision()
-            .is_some_and(NegotiationPrologue::is_legacy)
+        self.detector.is_legacy()
     }
 
     /// Returns `true` when the sniffer has determined that the peer selected the binary
@@ -284,9 +282,7 @@ impl NegotiationPrologueSniffer {
     /// I/O.
     #[must_use]
     pub fn is_binary(&self) -> bool {
-        self.detector
-            .decision()
-            .is_some_and(NegotiationPrologue::is_binary)
+        self.detector.is_binary()
     }
 
     /// Observes bytes that have already been read from the transport while tracking how

--- a/crates/protocol/src/negotiation/tests.rs
+++ b/crates/protocol/src/negotiation/tests.rs
@@ -225,10 +225,14 @@ fn prologue_detector_reports_decision_state_helpers() {
 
     assert!(!detector.is_decided());
     assert!(detector.requires_more_data());
+    assert!(!detector.is_legacy());
+    assert!(!detector.is_binary());
 
     assert_eq!(detector.observe(b"@"), NegotiationPrologue::LegacyAscii);
     assert!(detector.is_decided());
     assert!(detector.requires_more_data());
+    assert!(detector.is_legacy());
+    assert!(!detector.is_binary());
 
     let remainder = &LEGACY_DAEMON_PREFIX.as_bytes()[1..];
     assert_eq!(
@@ -237,14 +241,20 @@ fn prologue_detector_reports_decision_state_helpers() {
     );
     assert!(detector.is_decided());
     assert!(!detector.requires_more_data());
+    assert!(detector.is_legacy());
+    assert!(!detector.is_binary());
 
     detector.reset();
     assert!(!detector.is_decided());
     assert!(detector.requires_more_data());
+    assert!(!detector.is_legacy());
+    assert!(!detector.is_binary());
 
     assert_eq!(detector.observe(&[0x00]), NegotiationPrologue::Binary);
     assert!(detector.is_decided());
     assert!(!detector.requires_more_data());
+    assert!(!detector.is_legacy());
+    assert!(detector.is_binary());
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add cached-state helpers on `NegotiationPrologueDetector` so higher layers can check whether legacy or binary negotiation was selected without pattern matching
- update `NegotiationPrologueSniffer` to delegate to the new helpers and extend the detector state tests to cover the additional accessors

## Testing
- cargo test

------