### PR TITLE
Add helper to read and parse legacy daemon greetings

### DIFF
--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -101,7 +101,8 @@ pub use legacy::{
 pub use multiplex::{MessageFrame, recv_msg, recv_msg_into, send_frame, send_msg};
 pub use negotiation::{
     BufferedPrefixTooSmall, NegotiationPrologue, NegotiationPrologueDetector,
-    NegotiationPrologueSniffer, detect_negotiation_prologue, read_legacy_daemon_line,
+    NegotiationPrologueSniffer, detect_negotiation_prologue, read_and_parse_legacy_daemon_greeting,
+    read_legacy_daemon_line,
 };
 pub use version::{
     ParseProtocolVersionError, ParseProtocolVersionErrorKind, ProtocolVersion,

--- a/crates/protocol/src/negotiation/mod.rs
+++ b/crates/protocol/src/negotiation/mod.rs
@@ -3,7 +3,9 @@ mod sniffer;
 mod types;
 
 pub use detector::NegotiationPrologueDetector;
-pub use sniffer::{NegotiationPrologueSniffer, read_legacy_daemon_line};
+pub use sniffer::{
+    NegotiationPrologueSniffer, read_and_parse_legacy_daemon_greeting, read_legacy_daemon_line,
+};
 pub use types::{BufferedPrefixTooSmall, NegotiationPrologue, detect_negotiation_prologue};
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- add `read_and_parse_legacy_daemon_greeting` convenience helper and export it through the protocol facade
- extend legacy negotiation tests to cover the combined read-and-parse flow and error paths

## Testing
- cargo test

------