### PR TITLE
Clarify must_use semantics for negotiation prefix copy helper

### DIFF
--- a/crates/protocol/src/negotiation/detector.rs
+++ b/crates/protocol/src/negotiation/detector.rs
@@ -251,7 +251,7 @@ impl NegotiationPrologueDetector {
     /// borrowing it directly. When the destination slice is too small to hold
     /// the buffered prefix, a [`BufferedPrefixTooSmall`] error is returned and no
     /// data is written to the provided slice.
-    #[must_use]
+    #[must_use = "process the copy result so the buffered prefix can be replayed or the size error handled"]
     pub fn copy_buffered_prefix_into(
         &self,
         target: &mut [u8],


### PR DESCRIPTION
## Summary
- add an explicit must_use message to the negotiation detector prefix copy helper to document the required handling and satisfy clippy's double_must_use lint

## Testing
- cargo clippy

------