### PR TITLE
Handle buffered legacy greetings without extra reads

### DIFF
--- a/crates/protocol/src/negotiation/sniffer.rs
+++ b/crates/protocol/src/negotiation/sniffer.rs
@@ -542,6 +542,14 @@ pub fn read_legacy_daemon_line<R: Read>(
         .take_buffered_into(line)
         .map_err(map_reserve_error_for_io)?;
 
+    if let Some(newline_index) = line.iter().position(|&byte| byte == b'\n') {
+        let remainder = line.split_off(newline_index + 1);
+        if !remainder.is_empty() {
+            sniffer.buffered.extend_from_slice(&remainder);
+        }
+        return Ok(());
+    }
+
     let mut byte = [0u8; 1];
     loop {
         match reader.read(&mut byte) {

--- a/crates/protocol/src/negotiation/tests.rs
+++ b/crates/protocol/src/negotiation/tests.rs
@@ -1583,6 +1583,30 @@ fn read_legacy_daemon_line_preserves_bytes_consumed_during_detection() {
 }
 
 #[test]
+fn read_legacy_daemon_line_uses_buffered_newline_without_additional_io() {
+    let mut sniffer = NegotiationPrologueSniffer::new();
+    let (decision, consumed) = sniffer.observe(LEGACY_DAEMON_PREFIX.as_bytes());
+    assert_eq!(decision, NegotiationPrologue::LegacyAscii);
+    assert_eq!(consumed, LEGACY_DAEMON_PREFIX_LEN);
+    assert!(sniffer.legacy_prefix_complete());
+
+    sniffer
+        .buffered_storage_mut()
+        .extend_from_slice(b" 28.0\nNEXT");
+
+    let mut reader = Cursor::new(b"unused".to_vec());
+    let mut line = Vec::new();
+
+    read_legacy_daemon_line(&mut sniffer, &mut reader, &mut line)
+        .expect("buffered newline should avoid extra reads");
+
+    assert_eq!(line, b"@RSYNCD: 28.0\n");
+    assert_eq!(reader.position(), 0);
+    assert_eq!(sniffer.buffered(), b"NEXT");
+    assert_eq!(sniffer.decision(), Some(NegotiationPrologue::LegacyAscii));
+}
+
+#[test]
 fn read_legacy_daemon_line_rejects_incomplete_legacy_prefix() {
     let mut sniffer = NegotiationPrologueSniffer::new();
     let (decision, consumed) = sniffer.observe(b"@");


### PR DESCRIPTION
## Summary
- avoid additional reads in `read_legacy_daemon_line` when the newline was already captured and keep buffered remainder available for later parsing
- add a regression test that exercises newline handling when extra data follows the greeting

## Testing
- cargo test

------