### PR TITLE
Optimize supported protocol iterators

### DIFF
--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -107,5 +107,6 @@ pub use negotiation::{
 pub use version::{
     ParseProtocolVersionError, ParseProtocolVersionErrorKind, ProtocolVersion,
     ProtocolVersionAdvertisement, SUPPORTED_PROTOCOL_BITMAP, SUPPORTED_PROTOCOL_BOUNDS,
-    SUPPORTED_PROTOCOL_COUNT, SUPPORTED_PROTOCOL_RANGE, SUPPORTED_PROTOCOLS, select_highest_mutual,
+    SUPPORTED_PROTOCOL_COUNT, SUPPORTED_PROTOCOL_RANGE, SUPPORTED_PROTOCOLS,
+    SupportedProtocolNumbersIter, SupportedVersionsIter, select_highest_mutual,
 };

--- a/crates/protocol/src/negotiation/tests.rs
+++ b/crates/protocol/src/negotiation/tests.rs
@@ -1,9 +1,7 @@
 use super::sniffer::map_reserve_error_for_io;
 use super::*;
 use crate::NegotiationError;
-use crate::legacy::{
-    LEGACY_DAEMON_PREFIX, LEGACY_DAEMON_PREFIX_BYTES, LEGACY_DAEMON_PREFIX_LEN,
-};
+use crate::legacy::{LEGACY_DAEMON_PREFIX, LEGACY_DAEMON_PREFIX_BYTES, LEGACY_DAEMON_PREFIX_LEN};
 use proptest::prelude::*;
 use std::{
     collections::TryReserveError,

--- a/crates/protocol/src/version/tests.rs
+++ b/crates/protocol/src/version/tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 use core::convert::TryFrom;
+use core::iter::FusedIterator;
 use core::num::{
     NonZeroI8, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI128, NonZeroIsize, NonZeroU8,
     NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU128, NonZeroUsize, Wrapping,
@@ -622,6 +623,29 @@ fn supported_versions_iter_reports_length() {
 }
 
 #[test]
+fn supported_versions_iter_supports_double_ended_iteration() {
+    let mut iter = ProtocolVersion::supported_versions_iter();
+
+    assert_eq!(iter.next_back(), Some(ProtocolVersion::OLDEST));
+    assert_eq!(iter.next(), Some(ProtocolVersion::NEWEST));
+    assert_eq!(iter.len(), SUPPORTED_PROTOCOL_COUNT.saturating_sub(2));
+    assert_eq!(
+        iter.size_hint(),
+        (
+            SUPPORTED_PROTOCOL_COUNT.saturating_sub(2),
+            Some(SUPPORTED_PROTOCOL_COUNT.saturating_sub(2)),
+        )
+    );
+}
+
+#[test]
+fn supported_versions_iter_is_fused() {
+    fn assert_fused<I: FusedIterator>(_iter: I) {}
+
+    assert_fused(ProtocolVersion::supported_versions_iter());
+}
+
+#[test]
 fn supported_protocol_numbers_iter_reports_length() {
     let mut iter = ProtocolVersion::supported_protocol_numbers_iter();
 
@@ -640,6 +664,29 @@ fn supported_protocol_numbers_iter_reports_length() {
             Some(SUPPORTED_PROTOCOL_COUNT - 1)
         )
     );
+}
+
+#[test]
+fn supported_protocol_numbers_iter_supports_double_ended_iteration() {
+    let mut iter = ProtocolVersion::supported_protocol_numbers_iter();
+
+    assert_eq!(iter.next_back(), Some(ProtocolVersion::OLDEST.as_u8()));
+    assert_eq!(iter.next(), Some(ProtocolVersion::NEWEST.as_u8()));
+    assert_eq!(iter.len(), SUPPORTED_PROTOCOL_COUNT.saturating_sub(2));
+    assert_eq!(
+        iter.size_hint(),
+        (
+            SUPPORTED_PROTOCOL_COUNT.saturating_sub(2),
+            Some(SUPPORTED_PROTOCOL_COUNT.saturating_sub(2)),
+        )
+    );
+}
+
+#[test]
+fn supported_protocol_numbers_iter_is_fused() {
+    fn assert_fused<I: FusedIterator>(_iter: I) {}
+
+    assert_fused(ProtocolVersion::supported_protocol_numbers_iter());
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- replace array-consuming protocol iterators with reusable iterator structs that avoid copying the backing tables
- re-export the iterator types and extend public API tests to assert their trait coverage
- add focused unit tests that exercise the new iterator capabilities and ensure fused/double-ended behaviour

## Testing
- cargo test

------