### PR TITLE
Add reusable negotiation sniffer buffer constructor

### DIFF
--- a/crates/protocol/src/negotiation/tests.rs
+++ b/crates/protocol/src/negotiation/tests.rs
@@ -193,6 +193,56 @@ fn detect_negotiation_prologue_flags_malformed_ascii_as_legacy() {
 }
 
 #[test]
+fn prologue_sniffer_with_buffer_reuses_canonical_allocation() {
+    let mut buffer = Vec::with_capacity(LEGACY_DAEMON_PREFIX_LEN);
+    buffer.extend_from_slice(b"junk");
+    let ptr = buffer.as_ptr();
+
+    let sniffer = NegotiationPrologueSniffer::with_buffer(buffer);
+
+    assert_eq!(sniffer.decision(), None, "fresh sniffer must be undecided");
+    assert!(sniffer.buffered().is_empty(), "buffer must start empty");
+    assert_eq!(
+        sniffer.buffered_storage().capacity(),
+        LEGACY_DAEMON_PREFIX_LEN,
+        "capacity should match canonical prefix length"
+    );
+    assert!(
+        ptr::eq(sniffer.buffered_storage().as_ptr(), ptr),
+        "canonical capacity should be reused without reallocating"
+    );
+}
+
+#[test]
+fn prologue_sniffer_with_buffer_trims_oversized_allocations() {
+    let buffer = vec![0u8; LEGACY_DAEMON_PREFIX_LEN * 4];
+
+    let sniffer = NegotiationPrologueSniffer::with_buffer(buffer);
+
+    assert!(sniffer.buffered().is_empty());
+    assert_eq!(sniffer.decision(), None);
+    assert_eq!(
+        sniffer.buffered_storage().capacity(),
+        LEGACY_DAEMON_PREFIX_LEN,
+        "oversized buffers should shrink to canonical prefix length"
+    );
+}
+
+#[test]
+fn prologue_sniffer_with_buffer_grows_small_allocations() {
+    let buffer = Vec::with_capacity(1);
+
+    let sniffer = NegotiationPrologueSniffer::with_buffer(buffer);
+
+    assert!(sniffer.buffered().is_empty());
+    assert_eq!(sniffer.decision(), None);
+    assert!(
+        sniffer.buffered_storage().capacity() >= LEGACY_DAEMON_PREFIX_LEN,
+        "small buffers must grow to hold the canonical prefix"
+    );
+}
+
+#[test]
 fn detect_negotiation_prologue_detects_binary() {
     assert_eq!(
         detect_negotiation_prologue(&[0x00, 0x20, 0x00, 0x00]),


### PR DESCRIPTION
## Summary
- add `NegotiationPrologueSniffer::with_buffer` so callers can recycle prefix buffers while keeping canonical capacity
- exercise the new constructor with regression tests that cover canonical, oversized, and undersized allocations

## Testing
- cargo test

------