### PR TITLE
Use negotiation sniffer helper methods in tests

### DIFF
--- a/crates/protocol/src/negotiation/tests.rs
+++ b/crates/protocol/src/negotiation/tests.rs
@@ -1106,7 +1106,7 @@ fn prologue_sniffer_sniffed_prefix_handles_binary_negotiation() {
 #[test]
 fn prologue_sniffer_sniffed_prefix_exposes_partial_legacy_bytes() {
     let mut sniffer = NegotiationPrologueSniffer::new();
-    let (decision, consumed) = sniffer.observe(b"@R").expect("buffer reservation succeeds");
+    let (decision, consumed) = sniffer.observe_ok(b"@R");
 
     assert_eq!(decision, NegotiationPrologue::NeedMoreData);
     assert_eq!(consumed, 2);
@@ -1171,7 +1171,7 @@ fn prologue_sniffer_reports_buffered_length() {
     assert_eq!(consumed, 3);
     assert_eq!(sniffer.buffered_len(), 3);
 
-    let (decision, consumed) = sniffer.observe(b"YN").expect("buffer reservation succeeds");
+    let (decision, consumed) = sniffer.observe_ok(b"YN");
     assert_eq!(decision, NegotiationPrologue::NeedMoreData);
     assert_eq!(consumed, 2);
     assert_eq!(sniffer.buffered_len(), 5);
@@ -1246,13 +1246,9 @@ fn prologue_sniffer_observe_byte_matches_slice_behavior() {
     let stream = b"@RSYNCD: 31.0\n";
 
     for &byte in stream {
-        let (expected, consumed) = slice_sniffer
-            .observe(slice::from_ref(&byte))
-            .expect("buffer reservation succeeds");
+        let (expected, consumed) = slice_sniffer.observe_ok(slice::from_ref(&byte));
         assert!(consumed <= 1);
-        let observed = byte_sniffer
-            .observe_byte(byte)
-            .expect("buffer reservation succeeds");
+        let observed = byte_sniffer.observe_byte_ok(byte);
         assert_eq!(observed, expected);
         assert_eq!(byte_sniffer.buffered(), slice_sniffer.buffered());
         assert_eq!(
@@ -1272,13 +1268,13 @@ fn prologue_sniffer_observe_byte_matches_slice_behavior() {
 fn prologue_sniffer_observe_returns_need_more_data_for_empty_chunk() {
     let mut sniffer = NegotiationPrologueSniffer::new();
 
-    let (decision, consumed) = sniffer.observe(b"").expect("buffer reservation succeeds");
+    let (decision, consumed) = sniffer.observe_ok(b"");
     assert_eq!(decision, NegotiationPrologue::NeedMoreData);
     assert_eq!(consumed, 0);
     assert!(sniffer.buffered().is_empty());
     assert_eq!(sniffer.decision(), None);
 
-    let (decision, consumed) = sniffer.observe(b"").expect("buffer reservation succeeds");
+    let (decision, consumed) = sniffer.observe_ok(b"");
     assert_eq!(decision, NegotiationPrologue::NeedMoreData);
     assert_eq!(consumed, 0);
     assert!(sniffer.buffered().is_empty());
@@ -1803,7 +1799,7 @@ fn read_legacy_daemon_line_uses_buffered_newline_without_additional_io() {
 #[test]
 fn read_legacy_daemon_line_rejects_incomplete_legacy_prefix() {
     let mut sniffer = NegotiationPrologueSniffer::new();
-    let (decision, consumed) = sniffer.observe(b"@").expect("buffer reservation succeeds");
+    let (decision, consumed) = sniffer.observe_ok(b"@");
     assert_eq!(decision, NegotiationPrologue::NeedMoreData);
     assert_eq!(consumed, 1);
     assert_eq!(


### PR DESCRIPTION
## Summary
- replace repeated expect chains in negotiation sniffer tests with helper helpers for the negotiation prologue sniffer
- exercise the SnifferTestExt extension trait to eliminate the dead code warning emitted during cargo test

## Testing
- cargo test

------