### PR TITLE
Add test-only helpers for negotiation sniffer observation

### DIFF
--- a/crates/protocol/src/negotiation/sniffer.rs
+++ b/crates/protocol/src/negotiation/sniffer.rs
@@ -420,6 +420,21 @@ impl NegotiationPrologueSniffer {
         Ok(decision)
     }
 
+    #[cfg(test)]
+    pub(crate) fn observe_ok(
+        &mut self,
+        chunk: &[u8],
+    ) -> (NegotiationPrologue, usize) {
+        self.observe(chunk)
+            .expect("negotiation observation should not fail in tests")
+    }
+
+    #[cfg(test)]
+    pub(crate) fn observe_byte_ok(&mut self, byte: u8) -> NegotiationPrologue {
+        self.observe_byte(byte)
+            .expect("negotiation observation should not fail in tests")
+    }
+
     /// Clears the buffered prefix and resets the negotiation detector so the
     /// sniffer can be reused for another connection attempt.
     ///


### PR DESCRIPTION
## Summary
- add test-only wrappers on the negotiation prologue sniffer so tests can unwrap observation results without duplicating error handling

## Testing
- cargo test

------