### PR TITLE
Remove unused negotiation sniffer test helpers

### DIFF
--- a/crates/protocol/src/negotiation/sniffer.rs
+++ b/crates/protocol/src/negotiation/sniffer.rs
@@ -420,21 +420,6 @@ impl NegotiationPrologueSniffer {
         Ok(decision)
     }
 
-    #[cfg(test)]
-    pub(crate) fn observe_ok(
-        &mut self,
-        chunk: &[u8],
-    ) -> (NegotiationPrologue, usize) {
-        self.observe(chunk)
-            .expect("negotiation observation should not fail in tests")
-    }
-
-    #[cfg(test)]
-    pub(crate) fn observe_byte_ok(&mut self, byte: u8) -> NegotiationPrologue {
-        self.observe_byte(byte)
-            .expect("negotiation observation should not fail in tests")
-    }
-
     /// Clears the buffered prefix and resets the negotiation detector so the
     /// sniffer can be reused for another connection attempt.
     ///


### PR DESCRIPTION
## Summary
- remove the unused `observe_ok` and `observe_byte_ok` helpers from the negotiation sniffer to avoid dead-code warnings during tests

## Testing
- cargo test

------