### PR TITLE
Document ProtocolVersion clamping behavior

### DIFF
--- a/crates/protocol/src/version.rs
+++ b/crates/protocol/src/version.rs
@@ -829,7 +829,28 @@ impl ProtocolVersion {
     /// understands by clamping the negotiated value to its newest supported
     /// protocol. Versions older than [`ProtocolVersion::OLDEST`] remain
     /// unsupported.
+    /// # Examples
+    ///
+    /// Clamp future protocol advertisements down to the newest supported
+    /// version while rejecting values that predate the supported range.
+    ///
+    /// ```
+    /// use rsync_protocol::{NegotiationError, ProtocolVersion};
+    ///
+    /// let newest = ProtocolVersion::from_peer_advertisement(40)
+    ///     .expect("future versions clamp to the newest supported value");
+    /// assert_eq!(newest, ProtocolVersion::NEWEST);
+    ///
+    /// let too_old = ProtocolVersion::from_peer_advertisement(27)
+    ///     .expect_err("older protocols are rejected");
+    /// assert_eq!(too_old, NegotiationError::UnsupportedVersion(27));
+    ///
+    /// let zero = ProtocolVersion::from_peer_advertisement(0)
+    ///     .expect_err("protocol 0 is reserved for negotiation failures");
+    /// assert_eq!(zero, NegotiationError::UnsupportedVersion(0));
+    /// ```
     #[must_use = "the negotiated protocol version must be handled"]
+    #[inline]
     pub fn from_peer_advertisement(value: u8) -> Result<Self, NegotiationError> {
         if value < Self::OLDEST.as_u8() {
             return Err(NegotiationError::UnsupportedVersion(value));

--- a/crates/protocol/src/version/tests.rs
+++ b/crates/protocol/src/version/tests.rs
@@ -441,6 +441,12 @@ fn rejects_peer_advertisements_older_than_supported_range() {
 }
 
 #[test]
+fn rejects_zero_peer_advertisement() {
+    let err = ProtocolVersion::from_peer_advertisement(0).unwrap_err();
+    assert_eq!(err, NegotiationError::UnsupportedVersion(0));
+}
+
+#[test]
 fn clamps_future_peer_versions_in_selection() {
     let negotiated = select_highest_mutual([35, 31]).expect("must clamp to newest");
     assert_eq!(negotiated, ProtocolVersion::NEWEST);


### PR DESCRIPTION
## Summary
- document `ProtocolVersion::from_peer_advertisement` with an inline example covering clamping and rejection semantics
- add a regression test ensuring zero-valued peer advertisements are rejected with the expected negotiation error

## Testing
- cargo test -p rsync-protocol

------