### PR TITLE
Address Clippy lints in negotiation module

### DIFF
--- a/crates/protocol/src/negotiation/detector.rs
+++ b/crates/protocol/src/negotiation/detector.rs
@@ -50,10 +50,8 @@ impl NegotiationPrologueDetector {
             Some(NegotiationPrologue::LegacyAscii) if !self.prefix_complete
         );
 
-        if let Some(decided) = self.decided {
-            if !needs_more_prefix_bytes {
-                return decided;
-            }
+        if let Some(decided) = self.decided.filter(|_| !needs_more_prefix_bytes) {
+            return decided;
         }
 
         if chunk.is_empty() {

--- a/crates/protocol/src/negotiation/tests.rs
+++ b/crates/protocol/src/negotiation/tests.rs
@@ -1543,14 +1543,14 @@ struct FailingWriter {
 impl FailingWriter {
     fn new() -> Self {
         Self {
-            error: io::Error::new(io::ErrorKind::Other, "simulated write failure"),
+            error: io::Error::other("simulated write failure"),
         }
     }
 }
 
 impl Write for FailingWriter {
     fn write(&mut self, _buf: &[u8]) -> io::Result<usize> {
-        Err(io::Error::new(self.error.kind(), self.error.to_string()))
+        Err(io::Error::other(self.error.to_string()))
     }
 
     fn flush(&mut self) -> io::Result<()> {


### PR DESCRIPTION
## Summary
- collapse the cached-decision fast path in `NegotiationPrologueDetector::observe` to follow Clippy’s guidance
- update the failing writer test helper to use `io::Error::other` instead of manual `ErrorKind::Other`

## Testing
- cargo clippy --all-targets
- cargo test

------