### PR TITLE
Document negotiation buffer invariants before reserving capacity

### DIFF
--- a/crates/protocol/src/negotiation/sniffer.rs
+++ b/crates/protocol/src/negotiation/sniffer.rs
@@ -228,13 +228,14 @@ impl NegotiationPrologueSniffer {
             // turn panics on allocation failure instead of surfacing a
             // `TryReserveError` to the caller. Reserving relative to the vector's
             // length guarantees the resulting capacity can hold the replayed prefix
-            // without further allocations. Using `saturating_sub` keeps the helper
-            // resilient if future call sites accidentally invoke it with a vector
-            // whose length already exceeds the buffered prefix; in that scenario we
-            // simply skip the reservation instead of panicking on an underflowing
-            // subtraction.
-            debug_assert!(target.len() < required);
-            let additional = required.saturating_sub(target.len());
+            // without further allocations. The `debug_assert!` documents the
+            // relationship enforced by the branch so release builds can rely on the
+            // subtraction without needing saturating arithmetic.
+            debug_assert!(
+                target.len() < required,
+                "destination length must be smaller than the buffered prefix when reserving"
+            );
+            let additional = required - target.len();
             if additional > 0 {
                 target.try_reserve_exact(additional)?;
             }


### PR DESCRIPTION
## Summary
- document the expected relationship between buffered prefix length and the caller-supplied vector in `take_buffered_into`
- rely on the invariant to reserve additional capacity without saturating arithmetic while keeping the existing error path intact

## Testing
- cargo test
- cargo fmt --check

------