### PR TITLE
Ensure protocol membership checks use canonical list

### DIFF
--- a/crates/protocol/src/version.rs
+++ b/crates/protocol/src/version.rs
@@ -722,7 +722,7 @@ impl ProtocolVersion {
     /// ```
     #[must_use]
     pub const fn from_supported(value: u8) -> Option<Self> {
-        if value >= Self::OLDEST.as_u8() && value <= Self::NEWEST.as_u8() {
+        if Self::is_supported_protocol_number(value) {
             Some(Self::new_const(value))
         } else {
             None
@@ -736,7 +736,7 @@ impl ProtocolVersion {
     #[must_use]
     #[inline]
     pub const fn is_supported(value: u8) -> bool {
-        Self::from_supported(value).is_some()
+        Self::is_supported_protocol_number(value)
     }
 
     /// Returns the zero-based offset from [`ProtocolVersion::OLDEST`] when iterating

--- a/crates/protocol/src/version/tests.rs
+++ b/crates/protocol/src/version/tests.rs
@@ -787,6 +787,30 @@ fn from_supported_rejects_values_outside_range() {
 }
 
 #[test]
+fn from_supported_matches_supported_protocol_list() {
+    let supported = ProtocolVersion::supported_protocol_numbers();
+
+    for value in 0..=u8::MAX {
+        let parsed = ProtocolVersion::from_supported(value);
+        let expected = supported.contains(&value);
+
+        assert_eq!(
+            parsed.is_some(),
+            expected,
+            "value {value} should match membership"
+        );
+
+        if let Some(version) = parsed {
+            assert_eq!(
+                version.as_u8(),
+                value,
+                "returned version must preserve numeric value"
+            );
+        }
+    }
+}
+
+#[test]
 fn converts_from_non_zero_u8() {
     let value = NonZeroU8::new(31).expect("non-zero");
     let version = ProtocolVersion::try_from(value).expect("valid");


### PR DESCRIPTION
## Summary
- guard ProtocolVersion::from_supported and is_supported with the canonical supported protocol bitmap
- add regression coverage asserting from_supported only accepts advertised protocol numbers

## Testing
- cargo test

------