### PR TITLE
Add helpers for distinguishing binary and legacy negotiation protocols

### DIFF
--- a/crates/protocol/src/version/tests.rs
+++ b/crates/protocol/src/version/tests.rs
@@ -1002,6 +1002,43 @@ fn protocol_versions_are_hashable() {
     assert!(!set.insert(ProtocolVersion::NEWEST));
 }
 
+#[test]
+fn binary_negotiation_threshold_matches_protocol_30() {
+    let expected = ProtocolVersion::from_supported(30).expect("protocol 30 is supported");
+    assert_eq!(ProtocolVersion::BINARY_NEGOTIATION_INTRODUCED, expected);
+    assert!(ProtocolVersion::BINARY_NEGOTIATION_INTRODUCED.uses_binary_negotiation());
+    assert!(!ProtocolVersion::BINARY_NEGOTIATION_INTRODUCED.uses_legacy_ascii_negotiation());
+}
+
+#[test]
+fn negotiation_style_helpers_match_protocol_cutoff() {
+    for version in ProtocolVersion::supported_versions() {
+        if version.as_u8() >= ProtocolVersion::BINARY_NEGOTIATION_INTRODUCED.as_u8() {
+            assert!(
+                version.uses_binary_negotiation(),
+                "version {} should be binary",
+                version
+            );
+            assert!(
+                !version.uses_legacy_ascii_negotiation(),
+                "version {} should not be legacy",
+                version
+            );
+        } else {
+            assert!(
+                !version.uses_binary_negotiation(),
+                "version {} should not be binary",
+                version
+            );
+            assert!(
+                version.uses_legacy_ascii_negotiation(),
+                "version {} should be legacy",
+                version
+            );
+        }
+    }
+}
+
 proptest! {
     #[test]
     fn select_highest_mutual_matches_reference(peer_versions in proptest::collection::vec(0u8..=255, 0..=16)) {


### PR DESCRIPTION
## Summary
- add an explicit protocol constant for the binary-handshake cutoff and helper methods to check the negotiation style
- extend the compile-time guard to validate the cutoff and keep it inside the supported span
- cover the new APIs with unit tests that assert the cutoff remains tied to protocol 30

## Testing
- cargo test

------