### PR TITLE
Add const usize accessor for protocol versions

### DIFF
--- a/crates/protocol/src/version.rs
+++ b/crates/protocol/src/version.rs
@@ -809,6 +809,29 @@ impl ProtocolVersion {
         self.0.get()
     }
 
+    /// Returns the numeric protocol value as a [`usize`].
+    ///
+    /// Upstream rsync frequently indexes tables using protocol numbers. Rust's
+    /// [`From`] conversions for integer types are not `const`, which makes it
+    /// awkward to perform the same calculation when constructing compile-time
+    /// lookup tables. Exposing a dedicated helper keeps higher layers in parity
+    /// while enabling array indexing and other arithmetic in constant contexts
+    /// without re-implementing the cast at each call site.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rsync_protocol::ProtocolVersion;
+    ///
+    /// const NEWEST_INDEX: usize = ProtocolVersion::NEWEST.as_usize();
+    /// assert_eq!(NEWEST_INDEX, ProtocolVersion::NEWEST.as_u8() as usize);
+    /// ```
+    #[must_use]
+    #[inline]
+    pub const fn as_usize(self) -> usize {
+        self.as_u8() as usize
+    }
+
     /// Returns the non-zero byte representation used in protocol negotiation.
     ///
     /// Upstream rsync frequently stores negotiated protocol versions in

--- a/crates/protocol/src/version/tests.rs
+++ b/crates/protocol/src/version/tests.rs
@@ -201,6 +201,7 @@ fn protocol_version_converts_to_wider_unsigned_primitives() {
         assert_eq!(u64::from(version), u64::from(expected));
         assert_eq!(u128::from(version), u128::from(expected));
         assert_eq!(usize::from(version), usize::from(expected));
+        assert_eq!(version.as_usize(), usize::from(expected));
     }
 }
 

--- a/crates/protocol/tests/public_api.rs
+++ b/crates/protocol/tests/public_api.rs
@@ -8,6 +8,9 @@ use rsync_protocol::{
 };
 use std::iter::FusedIterator;
 
+const NEWEST_AS_USIZE: usize = ProtocolVersion::NEWEST.as_usize();
+const OLDEST_AS_USIZE: usize = ProtocolVersion::OLDEST.as_usize();
+
 #[derive(Clone, Copy)]
 struct CustomAdvertised(u8);
 
@@ -138,6 +141,16 @@ fn protocol_version_offsets_track_supported_ordering() {
 
     for (descending_index, version) in ProtocolVersion::supported_versions().iter().enumerate() {
         assert_eq!(version.offset_from_newest(), descending_index);
+    }
+}
+
+#[test]
+fn protocol_version_as_usize_exposes_const_index() {
+    assert_eq!(NEWEST_AS_USIZE, ProtocolVersion::NEWEST.as_u8() as usize);
+    assert_eq!(OLDEST_AS_USIZE, ProtocolVersion::OLDEST.as_u8() as usize);
+
+    for version in ProtocolVersion::supported_versions_iter() {
+        assert_eq!(version.as_usize(), version.as_u8() as usize);
     }
 }
 


### PR DESCRIPTION
## Summary
- add ProtocolVersion::as_usize to provide a const-friendly conversion for table indexing
- extend unit and public API tests to cover the new helper and ensure conversions stay aligned

## Testing
- cargo test

------