### PR TITLE
Clarify -avP aggregation in production scope doc

### DIFF
--- a/docs/production_scope_p1.md
+++ b/docs/production_scope_p1.md
@@ -12,9 +12,7 @@ This document freezes the mandatory scope that must reach green status before th
 - `rsync://` TCP daemon transport
 
 ## Core Command-Line Flags
-- `-a`
-- `-v`
-- `-P`
+- `-avP` (including the aggregation of `-a`, `-v`, and progress `-P` exactly as upstream renders it)
 - `--delete`
 - `--exclude`, `--include`, `--filter`
 - `--partial`


### PR DESCRIPTION
## Summary
- align the CT-1 production scope document with the mandated `-avP` aggregation wording from the mission brief

## Testing
- cargo test

------