### PR TITLE
Expose multiplex base constant

### DIFF
--- a/crates/protocol/src/envelope.rs
+++ b/crates/protocol/src/envelope.rs
@@ -10,7 +10,15 @@ pub const HEADER_LEN: usize = 4;
 /// Maximum payload length representable in a multiplexed header.
 pub const MAX_PAYLOAD_LENGTH: u32 = 0x00FF_FFFF;
 
-const MPLEX_BASE: u8 = 7;
+/// Base offset added to multiplexed message codes when encoding headers.
+///
+/// Upstream rsync defines `MPLEX_BASE` as the separation point between raw data
+/// and control messages flowing over the multiplexed stream. Tags transmitted on
+/// the wire add this offset to the numeric [`MessageCode`] value so the high
+/// header byte can be inspected quickly. Exposing the constant keeps the Rust
+/// implementation in sync with the C reference and avoids duplicating the magic
+/// value across crates that need to reason about multiplexed tags.
+pub const MPLEX_BASE: u8 = 7;
 const PAYLOAD_MASK: u32 = 0x00FF_FFFF;
 
 /// Log classification used by upstream rsync's `enum logcode` table.

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -87,7 +87,8 @@ mod version;
 
 pub use envelope::{
     EnvelopeError, HEADER_LEN as MESSAGE_HEADER_LEN, LogCode, LogCodeConversionError,
-    MAX_PAYLOAD_LENGTH, MessageCode, MessageHeader, ParseLogCodeError, ParseMessageCodeError,
+    MAX_PAYLOAD_LENGTH, MPLEX_BASE, MessageCode, MessageHeader, ParseLogCodeError,
+    ParseMessageCodeError,
 };
 pub use error::NegotiationError;
 pub use legacy::{

--- a/crates/protocol/tests/public_api.rs
+++ b/crates/protocol/tests/public_api.rs
@@ -52,6 +52,11 @@ fn message_header_constants_match_upstream_definition() {
 }
 
 #[test]
+fn multiplex_base_constant_matches_upstream_definition() {
+    assert_eq!(rsync_protocol::MPLEX_BASE, 7);
+}
+
+#[test]
 fn supported_protocol_exports_cover_range() {
     assert_eq!(
         ProtocolVersion::supported_protocol_numbers(),


### PR DESCRIPTION
## Summary
- expose the MPLEX_BASE constant from the protocol envelope module and re-export it at the crate root
- update multiplexing tests to rely on the shared constant and cover public API surface

## Testing
- cargo test

------