### PR TITLE
Fix multiplex MPLEX_BASE import

### DIFF
--- a/crates/protocol/src/multiplex.rs
+++ b/crates/protocol/src/multiplex.rs
@@ -3,7 +3,9 @@ use std::collections::TryReserveError;
 use std::io::{self, IoSlice, Read, Write};
 use std::slice;
 
-use crate::envelope::{EnvelopeError, HEADER_LEN, MAX_PAYLOAD_LENGTH, MessageCode, MessageHeader};
+use crate::envelope::{
+    EnvelopeError, HEADER_LEN, MAX_PAYLOAD_LENGTH, MessageCode, MessageHeader, MPLEX_BASE,
+};
 
 /// A decoded multiplexed message consisting of the tag and payload bytes.
 #[derive(Clone, Debug, Eq, PartialEq)]


### PR DESCRIPTION
## Summary
- bring the MPLEX_BASE constant into the multiplex module so the test suite can compile

## Testing
- cargo test

------