### PR TITLE
Scope MPLEX_BASE import to test builds

### DIFF
--- a/crates/protocol/src/multiplex.rs
+++ b/crates/protocol/src/multiplex.rs
@@ -4,8 +4,11 @@ use std::io::{self, IoSlice, Read, Write};
 use std::slice;
 
 use crate::envelope::{
-    EnvelopeError, HEADER_LEN, MAX_PAYLOAD_LENGTH, MessageCode, MessageHeader, MPLEX_BASE,
+    EnvelopeError, HEADER_LEN, MAX_PAYLOAD_LENGTH, MessageCode, MessageHeader,
 };
+
+#[cfg(test)]
+use crate::envelope::MPLEX_BASE;
 
 /// A decoded multiplexed message consisting of the tag and payload bytes.
 #[derive(Clone, Debug, Eq, PartialEq)]


### PR DESCRIPTION
## Summary
- restrict the MPLEX_BASE constant import in the multiplex module to test builds so release builds avoid unused import warnings

## Testing
- cargo test

------