### PR TITLE
Add Default implementation for negotiation detector

### DIFF
--- a/crates/protocol/src/multiplex.rs
+++ b/crates/protocol/src/multiplex.rs
@@ -3,9 +3,9 @@ use std::collections::TryReserveError;
 use std::io::{self, IoSlice, Read, Write};
 use std::slice;
 
-use crate::envelope::{
-    EnvelopeError, HEADER_LEN, MAX_PAYLOAD_LENGTH, MessageCode, MessageHeader, MPLEX_BASE,
-};
+#[cfg(test)]
+use crate::envelope::MPLEX_BASE;
+use crate::envelope::{EnvelopeError, HEADER_LEN, MAX_PAYLOAD_LENGTH, MessageCode, MessageHeader};
 
 /// A decoded multiplexed message consisting of the tag and payload bytes.
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/crates/protocol/src/negotiation/detector.rs
+++ b/crates/protocol/src/negotiation/detector.rs
@@ -22,6 +22,10 @@ pub struct NegotiationPrologueDetector {
 
 impl NegotiationPrologueDetector {
     /// Creates a fresh detector that has not yet observed any bytes.
+    ///
+    /// This constructor is equivalent to [`Self::default()`] but remains available
+    /// as a `const` so compile-time contexts—such as other `const fn` initialisers—
+    /// can instantiate detectors without going through trait dispatch.
     #[must_use]
     pub const fn new() -> Self {
         Self {

--- a/crates/protocol/src/negotiation/tests.rs
+++ b/crates/protocol/src/negotiation/tests.rs
@@ -159,6 +159,26 @@ fn negotiation_prologue_from_initial_byte_matches_binary_split() {
 }
 
 #[test]
+fn negotiation_prologue_detector_default_matches_new() {
+    let from_new = NegotiationPrologueDetector::new();
+    let from_default = NegotiationPrologueDetector::default();
+
+    assert_eq!(from_default.decision(), from_new.decision());
+    assert_eq!(from_default.buffered_len(), from_new.buffered_len());
+    assert_eq!(
+        from_default.requires_more_data(),
+        from_new.requires_more_data()
+    );
+    assert_eq!(from_default.is_decided(), from_new.is_decided());
+    assert_eq!(from_default.is_legacy(), from_new.is_legacy());
+    assert_eq!(from_default.is_binary(), from_new.is_binary());
+    assert_eq!(
+        from_default.legacy_prefix_complete(),
+        from_new.legacy_prefix_complete()
+    );
+}
+
+#[test]
 fn detect_negotiation_prologue_delegates_to_initial_byte_helper() {
     for byte in 0u8..=u8::MAX {
         assert_eq!(


### PR DESCRIPTION
## Summary
- document that `NegotiationPrologueDetector::new` is const-equivalent to `Default`
- implement the `Default` trait via the existing constructor and add coverage for it
- scope the `MPLEX_BASE` import to tests to keep builds warning-free

## Testing
- cargo test -p rsync-protocol negotiation_prologue_detector_default_matches_new

------