### PR TITLE
Clean up unused MPLEX_BASE import in multiplex module

### DIFF
--- a/crates/protocol/src/multiplex.rs
+++ b/crates/protocol/src/multiplex.rs
@@ -7,9 +7,6 @@ use crate::envelope::{
     EnvelopeError, HEADER_LEN, MAX_PAYLOAD_LENGTH, MessageCode, MessageHeader,
 };
 
-#[cfg(test)]
-use crate::envelope::MPLEX_BASE;
-
 /// A decoded multiplexed message consisting of the tag and payload bytes.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct MessageFrame {


### PR DESCRIPTION
## Summary
- remove the cfg(test) MPLEX_BASE import from the multiplex module, letting the module rely on the test-only import inside the tests submodule

## Testing
- cargo test

------