### PR TITLE
Add textual parsing for negotiation prologue identifiers

### DIFF
--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -102,8 +102,8 @@ pub use legacy::{
 pub use multiplex::{MessageFrame, recv_msg, recv_msg_into, send_frame, send_msg};
 pub use negotiation::{
     BufferedPrefixTooSmall, NegotiationPrologue, NegotiationPrologueDetector,
-    NegotiationPrologueSniffer, detect_negotiation_prologue, read_and_parse_legacy_daemon_greeting,
-    read_legacy_daemon_line,
+    NegotiationPrologueSniffer, ParseNegotiationPrologueError, ParseNegotiationPrologueErrorKind,
+    detect_negotiation_prologue, read_and_parse_legacy_daemon_greeting, read_legacy_daemon_line,
 };
 pub use version::{
     ParseProtocolVersionError, ParseProtocolVersionErrorKind, ProtocolVersion,

--- a/crates/protocol/src/multiplex.rs
+++ b/crates/protocol/src/multiplex.rs
@@ -3,9 +3,7 @@ use std::collections::TryReserveError;
 use std::io::{self, IoSlice, Read, Write};
 use std::slice;
 
-use crate::envelope::{
-    EnvelopeError, HEADER_LEN, MAX_PAYLOAD_LENGTH, MessageCode, MessageHeader,
-};
+use crate::envelope::{EnvelopeError, HEADER_LEN, MAX_PAYLOAD_LENGTH, MessageCode, MessageHeader};
 
 /// A decoded multiplexed message consisting of the tag and payload bytes.
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/crates/protocol/src/negotiation/mod.rs
+++ b/crates/protocol/src/negotiation/mod.rs
@@ -6,7 +6,10 @@ pub use detector::NegotiationPrologueDetector;
 pub use sniffer::{
     NegotiationPrologueSniffer, read_and_parse_legacy_daemon_greeting, read_legacy_daemon_line,
 };
-pub use types::{BufferedPrefixTooSmall, NegotiationPrologue, detect_negotiation_prologue};
+pub use types::{
+    BufferedPrefixTooSmall, NegotiationPrologue, ParseNegotiationPrologueError,
+    ParseNegotiationPrologueErrorKind, detect_negotiation_prologue,
+};
 
 #[cfg(test)]
 mod tests;

--- a/crates/protocol/tests/public_api.rs
+++ b/crates/protocol/tests/public_api.rs
@@ -3,7 +3,8 @@
 use rsync_protocol::{
     LEGACY_DAEMON_PREFIX_BYTES, LEGACY_DAEMON_PREFIX_LEN, LogCode, LogCodeConversionError,
     MessageCode, NegotiationError, NegotiationPrologue, NegotiationPrologueSniffer,
-    ParseLogCodeError, ProtocolVersion, ProtocolVersionAdvertisement, SUPPORTED_PROTOCOL_BITMAP,
+    ParseLogCodeError, ParseNegotiationPrologueError, ParseNegotiationPrologueErrorKind,
+    ProtocolVersion, ProtocolVersionAdvertisement, SUPPORTED_PROTOCOL_BITMAP,
     SupportedProtocolNumbersIter, SupportedVersionsIter, select_highest_mutual,
 };
 use std::iter::FusedIterator;
@@ -250,6 +251,17 @@ fn negotiation_prologue_sniffer_reports_buffered_length() {
     assert_eq!(sniffer.buffered_len(), 0);
     assert_eq!(sniffer.sniffed_prefix_len(), 0);
     assert!(sniffer.buffered().is_empty());
+}
+
+#[test]
+fn negotiation_prologue_from_str_is_part_of_public_api() {
+    let parsed: NegotiationPrologue = "binary".parse().expect("identifier should parse");
+    assert!(parsed.is_binary());
+
+    let err: ParseNegotiationPrologueError = "unknown"
+        .parse::<NegotiationPrologue>()
+        .expect_err("unknown value should fail");
+    assert_eq!(err.kind(), ParseNegotiationPrologueErrorKind::Invalid);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add `NegotiationPrologue` string parsing with a dedicated error type and documentation example
- re-export the new parser types for downstream consumers and extend parity tests accordingly

## Testing
- cargo test

------