### PR TITLE
Set workspace rust-version metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,5 +6,6 @@ resolver = "2"
 
 [workspace.package]
 edition = "2024"
+rust-version = "1.85"
 authors = ["rsync rust port contributors"]
 license = "GPL-3.0-or-later"

--- a/crates/protocol/Cargo.toml
+++ b/crates/protocol/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
 name = "rsync-protocol"
 version = "0.0.0"
-edition = "2024"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
 description = "Protocol negotiation utilities for the Rust rsync reimplementation"
-license = "GPL-3.0-or-later"
-authors = ["rsync rust port contributors"]
 
 [dependencies]
 


### PR DESCRIPTION
## Summary
- declare the minimum supported Rust toolchain for the workspace
- reuse shared edition, license, author, and rust-version metadata in the protocol crate manifest

## Testing
- cargo test

------