### PR TITLE
Add missing byte reporting for negotiation prefix buffers

### DIFF
--- a/crates/protocol/src/multiplex.rs
+++ b/crates/protocol/src/multiplex.rs
@@ -3,9 +3,7 @@ use std::collections::TryReserveError;
 use std::io::{self, IoSlice, Read, Write};
 use std::slice;
 
-use crate::envelope::{
-    EnvelopeError, HEADER_LEN, MAX_PAYLOAD_LENGTH, MessageCode, MessageHeader,
-};
+use crate::envelope::{EnvelopeError, HEADER_LEN, MAX_PAYLOAD_LENGTH, MessageCode, MessageHeader};
 
 /// A decoded multiplexed message consisting of the tag and payload bytes.
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/crates/protocol/src/negotiation/tests.rs
+++ b/crates/protocol/src/negotiation/tests.rs
@@ -16,6 +16,7 @@ fn buffered_prefix_too_small_converts_to_io_error_with_context() {
     let message = err.to_string();
     let required = err.required();
     let available = err.available();
+    let missing = err.missing();
 
     let io_err: io::Error = err.into();
 
@@ -28,6 +29,16 @@ fn buffered_prefix_too_small_converts_to_io_error_with_context() {
         .expect("io::Error must retain BufferedPrefixTooSmall source");
     assert_eq!(source.required(), required);
     assert_eq!(source.available(), available);
+    assert_eq!(source.missing(), missing);
+}
+
+#[test]
+fn buffered_prefix_too_small_reports_missing_bytes() {
+    let err = BufferedPrefixTooSmall::new(LEGACY_DAEMON_PREFIX_LEN, LEGACY_DAEMON_PREFIX_LEN - 3);
+    assert_eq!(err.missing(), 3);
+
+    let saturated = BufferedPrefixTooSmall::new(4, 8);
+    assert_eq!(saturated.missing(), 0);
 }
 
 struct InterruptedOnceReader {

--- a/crates/protocol/src/negotiation/types.rs
+++ b/crates/protocol/src/negotiation/types.rs
@@ -29,6 +29,20 @@ impl BufferedPrefixTooSmall {
     pub const fn available(self) -> usize {
         self.available
     }
+
+    /// Returns how many additional bytes are required to hold the buffered prefix.
+    ///
+    /// When callers supply a scratch buffer that is too small to receive the sniffed
+    /// negotiation prefix, upstream rsync reports the exact deficit so operators can
+    /// size their allocations appropriately. Mirroring that behavior keeps diagnostics
+    /// consistent across implementations and allows higher layers to surface actionable
+    /// guidance without reimplementing the subtraction logic. The value is saturated at
+    /// zero to tolerate defensive checks that may construct the error even when the
+    /// provided capacity already exceeds the requirement.
+    #[must_use]
+    pub const fn missing(self) -> usize {
+        self.required.saturating_sub(self.available)
+    }
 }
 
 impl fmt::Display for BufferedPrefixTooSmall {


### PR DESCRIPTION
## Summary
- add `BufferedPrefixTooSmall::missing` so callers can surface the byte deficit when replaying negotiation prefixes
- extend negotiation unit tests to assert the new helper is preserved through `io::Error` conversions and covers saturation cases
- run rustfmt on the protocol crate, normalizing grouped imports in the multiplex module

## Testing
- cargo test

------