### PR TITLE
Add helper for indexing supported protocol versions

### DIFF
--- a/crates/protocol/src/version.rs
+++ b/crates/protocol/src/version.rs
@@ -739,6 +739,24 @@ impl ProtocolVersion {
         SupportedVersionsIter::new(Self::supported_versions())
     }
 
+    /// Returns the protocol version at the given index within the canonical newest-to-oldest list
+    /// of supported versions.
+    ///
+    /// The helper keeps higher layers from duplicating index-to-version lookup logic when they
+    /// store data keyed by the ordering exposed through [`SUPPORTED_PROTOCOLS`]. Returning an
+    /// [`Option`] mirrors the slice indexing semantics used throughout the standard library:
+    /// out-of-range indices yield `None` instead of panicking. Because the method is `const`, lookup
+    /// tables can perform compile-time validation of their indices when built from the canonical
+    /// ordering.
+    #[must_use]
+    pub const fn from_supported_index(index: usize) -> Option<Self> {
+        if index < SUPPORTED_PROTOCOL_COUNT {
+            Some(Self::SUPPORTED_VERSIONS[index])
+        } else {
+            None
+        }
+    }
+
     /// Attempts to construct a [`ProtocolVersion`] from a byte that is known to be within the
     /// range supported by upstream rsync 3.4.1.
     ///

--- a/crates/protocol/src/version/tests.rs
+++ b/crates/protocol/src/version/tests.rs
@@ -218,6 +218,19 @@ fn protocol_version_converts_to_nonzero_wider_unsigned_primitives() {
 }
 
 #[test]
+fn protocol_version_lookup_by_supported_index() {
+    for (index, &expected) in ProtocolVersion::supported_versions().iter().enumerate() {
+        assert_eq!(ProtocolVersion::from_supported_index(index), Some(expected));
+    }
+
+    assert_eq!(
+        ProtocolVersion::from_supported_index(SUPPORTED_PROTOCOL_COUNT),
+        None,
+    );
+    assert_eq!(ProtocolVersion::from_supported_index(usize::MAX), None);
+}
+
+#[test]
 fn select_highest_mutual_accepts_wrapping_unsigned_advertisements() {
     let negotiated = select_highest_mutual([
         Wrapping::<u16>(u16::from(ProtocolVersion::NEWEST.as_u8())),

--- a/crates/protocol/tests/public_api.rs
+++ b/crates/protocol/tests/public_api.rs
@@ -136,6 +136,17 @@ fn supported_protocol_bitmap_matches_helpers() {
 }
 
 #[test]
+fn supported_version_lookup_by_index_matches_slice() {
+    for (index, &version) in ProtocolVersion::supported_versions().iter().enumerate() {
+        assert_eq!(ProtocolVersion::from_supported_index(index), Some(version));
+    }
+
+    assert!(
+        ProtocolVersion::from_supported_index(rsync_protocol::SUPPORTED_PROTOCOL_COUNT).is_none()
+    );
+}
+
+#[test]
 fn protocol_version_offsets_track_supported_ordering() {
     for (ascending_index, version) in ProtocolVersion::supported_versions()
         .iter()


### PR DESCRIPTION
## Summary
- add `ProtocolVersion::from_supported_index` to expose safe indexed access to the canonical protocol ordering
- extend unit and public API tests to cover the new helper and ensure the lookup stays in sync with exported constants

## Testing
- cargo test

------