### PR TITLE
Handle allocation failures when restoring sniffer capacity

### DIFF
--- a/crates/protocol/src/negotiation/sniffer.rs
+++ b/crates/protocol/src/negotiation/sniffer.rs
@@ -640,7 +640,9 @@ impl NegotiationPrologueSniffer {
             // allocations even when the previous buffer had already shrunk below the target size.
             let required = LEGACY_DAEMON_PREFIX_LEN.saturating_sub(self.buffered.len());
             if required > 0 {
-                self.buffered.reserve_exact(required);
+                // Allocation failures surface through the later `try_reserve` calls that precede
+                // actual writes; preallocation here is a best-effort optimisation.
+                let _ = self.buffered.try_reserve_exact(required);
             }
         }
     }


### PR DESCRIPTION
## Summary
- update the negotiation prologue sniffer to use `try_reserve_exact` when replenishing its scratch buffer
- treat the preallocation as a best-effort optimisation so allocation failures surface through existing fallible paths instead of panicking

## Testing
- cargo test

------