### PR TITLE
Add documentation outlining current parity gaps

### DIFF
--- a/docs/differences.md
+++ b/docs/differences.md
@@ -1,0 +1,32 @@
+# Known Differences vs Upstream rsync 3.4.1
+
+This document captures observable gaps between the Rust workspace and upstream
+rsync 3.4.1. Each entry describes the user-visible impact today and outlines
+what must land to eliminate the difference. Items remain in this list until the
+referenced functionality ships and parity is verified by tests or goldens.
+
+## Blocking Differences
+
+- **No client or daemon binaries**
+  - *Impact*: Users cannot execute transfers because `bin/rsync` and `bin/rsyncd`
+    are absent.
+  - *Removal plan*: Introduce the `cli` and `daemon` crates described in the
+    workspace layout, ensure they invoke the shared `core` facade, and verify
+    CLI/daemon parity via snapshot and interop tests.
+- **Transfer engine and metadata pipeline missing**
+  - *Impact*: Delta transfer, metadata preservation, filters, and compression are
+    unavailable; only negotiation helpers compile today.
+  - *Removal plan*: Implement the `engine`, `meta`, `filters`, and `compress`
+    crates with exhaustive unit/integration coverage, then connect them through
+    the `core` facade before re-running the parity harness.
+- **No interop or packaging automation**
+  - *Impact*: There is no exit-code oracle, goldens, CI interop matrix, or
+    packaging artifacts, preventing validation against upstream and distribution
+    deliverables.
+  - *Removal plan*: Stand up the parity harness (`tests/goldens`), CI workflows,
+    and packaging targets (deb/rpm, SBOM, systemd unit) defined in the mission
+    brief once higher-level crates are available.
+
+All remaining behaviour currently matches the limited scope implemented in the
+`protocol` crate; additional differences will be documented here as they are
+observed.

--- a/docs/feature_matrix.md
+++ b/docs/feature_matrix.md
@@ -1,0 +1,23 @@
+# Feature Matrix — Rust rsync vs Upstream 3.4.1
+
+The table below enumerates the major capability areas described in the
+`Codex Mission Brief` and records the current implementation status in this
+repository. Every entry is backed by code that exists today; missing
+functionality explicitly calls out the absence of the relevant crate or
+binary so documentation never overstates parity.
+
+| Area | Feature | Status | Notes | Source |
+|------|---------|--------|-------|--------|
+| Protocol | Protocol version constants, selection helpers, and iteration utilities | Implemented | `ProtocolVersion` exposes `SUPPORTED_PROTOCOLS`, range helpers, and mutual selection logic used for negotiation parity. | `crates/protocol/src/version.rs` |
+| Protocol | Legacy ASCII daemon greeting parsing (`@RSYNCD:`) | Implemented | Structured parsers cover banners, authentication prompts, and error/warning lines with exhaustive tests. | `crates/protocol/src/legacy/` |
+| Protocol | Multiplexed message envelope (MSG_* tags, vectored writes) | Implemented | Envelope encoding/decoding mirrors upstream layouts and is fuzz/property tested. | `crates/protocol/src/envelope.rs`, `crates/protocol/src/multiplex.rs` |
+| Protocol | Negotiation prologue sniffing (legacy vs binary) | Implemented | `NegotiationPrologueDetector` and sniffer utilities reconstruct buffered prefixes for replay. | `crates/protocol/src/negotiation/` |
+| Workspace | CLI front-end (`bin/rsync`) | Missing | No CLI crate or binary exists yet; command-line parsing and help parity are outstanding. | _n/a_ |
+| Workspace | Daemon server (`bin/rsyncd`) | Missing | Daemon crate, config parser, and transport loop have not been implemented. | _n/a_ |
+| Workspace | Core transfer/engine/meta/filter/compress crates | Missing | No crates beyond `protocol` exist; delta transfer, metadata application, and compression remain to be written. | _n/a_ |
+| Quality | Golden parity harness & interop tests | Missing | The repository does not yet build or execute the upstream rsync comparison matrix. | _n/a_ |
+| Quality | Packaging (deb/rpm), SBOM, systemd unit | Missing | Packaging artifacts are absent pending higher-layer implementation. | _n/a_ |
+
+Status legend: **Implemented** — behavior is present and backed by tests in this
+repository. **Missing** — code has not been written yet; entries remain until the
+corresponding crates/binaries land and parity is verified.


### PR DESCRIPTION
## Summary
- add a feature matrix that records which protocol components exist today and which major workspace layers are still missing
- describe the observable differences versus upstream rsync 3.4.1 along with concrete removal plans for each gap

## Testing
- not run (documentation-only change)

------