### PR TITLE
Add named protocol version constants and tests

### DIFF
--- a/crates/protocol/src/version.rs
+++ b/crates/protocol/src/version.rs
@@ -551,6 +551,21 @@ impl ProtocolVersion {
     pub const BINARY_NEGOTIATION_INTRODUCED: ProtocolVersion =
         ProtocolVersion::new_const(FIRST_BINARY_NEGOTIATION_PROTOCOL);
 
+    /// Protocol version 32, the newest revision advertised by upstream rsync 3.4.1.
+    pub const V32: ProtocolVersion = ProtocolVersion::NEWEST;
+
+    /// Protocol version 31, used by upstream rsync 3.1.x releases.
+    pub const V31: ProtocolVersion = ProtocolVersion::new_const(31);
+
+    /// Protocol version 30, the first release that adopted the binary negotiation handshake.
+    pub const V30: ProtocolVersion = ProtocolVersion::new_const(30);
+
+    /// Protocol version 29, the newest legacy `@RSYNCD:` ASCII negotiation revision.
+    pub const V29: ProtocolVersion = ProtocolVersion::new_const(29);
+
+    /// Protocol version 28, the oldest revision still supported for interoperability.
+    pub const V28: ProtocolVersion = ProtocolVersion::OLDEST;
+
     /// Array of protocol versions supported by the Rust implementation,
     /// ordered from newest to oldest.
     pub const SUPPORTED_VERSIONS: [ProtocolVersion; SUPPORTED_PROTOCOL_COUNT] =

--- a/crates/protocol/src/version/tests.rs
+++ b/crates/protocol/src/version/tests.rs
@@ -128,6 +128,31 @@ fn select_highest_mutual_accepts_protocol_version_references() {
 }
 
 #[test]
+fn named_version_constants_match_supported_protocols() {
+    let expected = [
+        ProtocolVersion::V32,
+        ProtocolVersion::V31,
+        ProtocolVersion::V30,
+        ProtocolVersion::V29,
+        ProtocolVersion::V28,
+    ];
+
+    assert_eq!(
+        expected,
+        *ProtocolVersion::supported_versions_array(),
+        "named constants must match the canonical supported ordering",
+    );
+
+    let expected_numbers: Vec<u8> = expected.iter().map(|version| version.as_u8()).collect();
+    assert_eq!(
+        expected_numbers,
+        ProtocolVersion::supported_protocol_numbers(),
+        "named constants must mirror the exported numeric list",
+    );
+    assert_eq!(expected.len(), SUPPORTED_PROTOCOL_COUNT);
+}
+
+#[test]
 fn select_highest_mutual_accepts_non_zero_u8_advertisements() {
     let peers = [
         NonZeroU8::new(32).expect("non-zero"),

--- a/crates/protocol/tests/public_api.rs
+++ b/crates/protocol/tests/public_api.rs
@@ -45,6 +45,27 @@ fn supported_protocols_match_upstream_order() {
 }
 
 #[test]
+fn named_protocol_version_constants_are_exposed() {
+    assert_eq!(ProtocolVersion::V32.as_u8(), 32);
+    assert_eq!(ProtocolVersion::V31.as_u8(), 31);
+    assert_eq!(ProtocolVersion::V30.as_u8(), 30);
+    assert_eq!(ProtocolVersion::V29.as_u8(), 29);
+    assert_eq!(ProtocolVersion::V28.as_u8(), 28);
+
+    assert_eq!(ProtocolVersion::V32, ProtocolVersion::NEWEST);
+    assert_eq!(ProtocolVersion::V28, ProtocolVersion::OLDEST);
+
+    let expected = [
+        ProtocolVersion::V32,
+        ProtocolVersion::V31,
+        ProtocolVersion::V30,
+        ProtocolVersion::V29,
+        ProtocolVersion::V28,
+    ];
+    assert_eq!(expected, *ProtocolVersion::supported_versions_array());
+}
+
+#[test]
 fn message_header_constants_match_upstream_definition() {
     assert_eq!(rsync_protocol::MESSAGE_HEADER_LEN, 4);
     assert_eq!(rsync_protocol::MAX_PAYLOAD_LENGTH, 0x00FF_FFFF);


### PR DESCRIPTION
## Summary
- expose strongly typed constants for each supported protocol revision
- ensure the new constants stay in sync with the negotiated protocol list via unit and public API tests

## Testing
- cargo test

------