### PR TITLE
Clarify multiplex buffer reservation semantics

### DIFF
--- a/crates/protocol/src/multiplex.rs
+++ b/crates/protocol/src/multiplex.rs
@@ -211,6 +211,10 @@ fn ensure_payload_length(len: usize) -> io::Result<u32> {
 
 fn reserve_payload(buffer: &mut Vec<u8>, len: usize) -> io::Result<()> {
     if buffer.capacity() < len {
+        // `Vec::try_reserve_exact` interprets the requested amount relative to the current length
+        // of the vector rather than its spare capacity. Using the difference between the target
+        // length and the existing length therefore guarantees that the resulting capacity can
+        // hold `len` bytes without resorting to temporary `unsafe` length adjustments.
         let additional = len.saturating_sub(buffer.len());
         debug_assert!(
             additional > 0,


### PR DESCRIPTION
## Summary
- document why `reserve_payload` bases its reservation on the current vector length
- ensure future changes avoid unsafe length manipulation when reserving payload buffers

## Testing
- cargo test -p rsync-protocol

------