### PR TITLE
Deduplicate negotiation prefix helpers

### DIFF
--- a/crates/protocol/src/negotiation/sniffer.rs
+++ b/crates/protocol/src/negotiation/sniffer.rs
@@ -252,58 +252,6 @@ impl NegotiationPrologueSniffer {
         Ok(prefix_len)
     }
 
-    /// Copies the sniffed negotiation prefix into a caller-provided slice while preserving any
-    /// buffered remainder.
-    ///
-    /// The helper mirrors [`take_sniffed_prefix_into`](Self::take_sniffed_prefix_into) but avoids
-    /// heap allocations when the caller already owns stack-allocated scratch space. When the
-    /// prefix is still incomplete (for example because more bytes need to be read to finish the
-    /// canonical `@RSYNCD:` marker) the method performs no work and returns `Ok(0)`. If the slice
-    /// is too small to hold the fully sniffed prefix a [`BufferedPrefixTooSmall`] error is
-    /// returned and neither the caller's buffer nor the internal state are modified, mirroring the
-    /// failure semantics of [`take_buffered_into_slice`](Self::take_buffered_into_slice).
-    #[must_use = "negotiation prefix length is required to replay the handshake"]
-    pub fn take_sniffed_prefix_into_slice(
-        &mut self,
-        target: &mut [u8],
-    ) -> Result<usize, BufferedPrefixTooSmall> {
-        if self.requires_more_data() {
-            return Ok(0);
-        }
-
-        let prefix_len = self.sniffed_prefix_len();
-        if prefix_len == 0 {
-            return Ok(0);
-        }
-
-        if target.len() < prefix_len {
-            return Err(BufferedPrefixTooSmall::new(prefix_len, target.len()));
-        }
-
-        target[..prefix_len].copy_from_slice(&self.buffered[..prefix_len]);
-        self.buffered.drain(..prefix_len);
-        self.prefix_bytes_retained = 0;
-
-        Ok(prefix_len)
-    }
-
-    /// Copies the sniffed negotiation prefix into a caller-provided array while preserving any
-    /// buffered remainder.
-    ///
-    /// This convenience wrapper mirrors
-    /// [`take_sniffed_prefix_into_slice`](Self::take_sniffed_prefix_into_slice) but accepts a
-    /// fixed-size array directly so call sites that keep a stack-allocated
-    /// `LEGACY_DAEMON_PREFIX_LEN` scratch buffer can avoid manual slice conversions. On success the
-    /// prefix bytes are removed from the internal buffer while the buffered remainder stays queued
-    /// for later processing.
-    #[must_use = "negotiation prefix length is required to replay the handshake"]
-    pub fn take_sniffed_prefix_into_array<const N: usize>(
-        &mut self,
-        target: &mut [u8; N],
-    ) -> Result<usize, BufferedPrefixTooSmall> {
-        self.take_sniffed_prefix_into_slice(target.as_mut_slice())
-    }
-
     /// Returns the sniffed negotiation prefix as an owned vector while preserving any buffered
     /// remainder.
     ///

--- a/crates/protocol/src/negotiation/tests.rs
+++ b/crates/protocol/src/negotiation/tests.rs
@@ -1878,60 +1878,6 @@ fn prologue_sniffer_take_sniffed_prefix_into_slice_preserves_remainder() {
 }
 
 #[test]
-fn prologue_sniffer_take_sniffed_prefix_into_slice_reports_small_buffer() {
-    let mut sniffer = NegotiationPrologueSniffer::new();
-    sniffer
-        .observe(LEGACY_DAEMON_PREFIX.as_bytes())
-        .expect("buffer reservation succeeds");
-
-    let mut scratch = [0u8; LEGACY_DAEMON_PREFIX_LEN - 1];
-    let err = sniffer
-        .take_sniffed_prefix_into_slice(&mut scratch)
-        .expect_err("slice too small should report error");
-    assert_eq!(err.required(), LEGACY_DAEMON_PREFIX_LEN);
-    assert_eq!(err.available(), LEGACY_DAEMON_PREFIX_LEN - 1);
-    assert_eq!(sniffer.sniffed_prefix(), LEGACY_DAEMON_PREFIX.as_bytes());
-}
-
-#[test]
-fn prologue_sniffer_take_sniffed_prefix_into_array_preserves_remainder() {
-    let mut sniffer = NegotiationPrologueSniffer::new();
-    let mut reader = Cursor::new(LEGACY_DAEMON_PREFIX_BYTES.to_vec());
-    let decision = sniffer
-        .read_from(&mut reader)
-        .expect("legacy negotiation detection succeeds");
-    assert_eq!(decision, NegotiationPrologue::LegacyAscii);
-
-    let tail = b"payload";
-    sniffer.buffered_storage_mut().extend_from_slice(tail);
-
-    let mut scratch = [0u8; LEGACY_DAEMON_PREFIX_LEN];
-    let copied = sniffer
-        .take_sniffed_prefix_into_array(&mut scratch)
-        .expect("copying sniffed prefix into array succeeds");
-    assert_eq!(copied, LEGACY_DAEMON_PREFIX_LEN);
-    assert_eq!(scratch.as_slice(), LEGACY_DAEMON_PREFIX.as_bytes());
-    assert_eq!(sniffer.sniffed_prefix_len(), 0);
-    assert_eq!(sniffer.buffered(), tail);
-}
-
-#[test]
-fn prologue_sniffer_take_sniffed_prefix_into_array_reports_small_buffer() {
-    let mut sniffer = NegotiationPrologueSniffer::new();
-    sniffer
-        .observe(LEGACY_DAEMON_PREFIX.as_bytes())
-        .expect("buffer reservation succeeds");
-
-    let mut scratch = [0u8; LEGACY_DAEMON_PREFIX_LEN - 2];
-    let err = sniffer
-        .take_sniffed_prefix_into_array(&mut scratch)
-        .expect_err("array too small should report error");
-    assert_eq!(err.required(), LEGACY_DAEMON_PREFIX_LEN);
-    assert_eq!(err.available(), LEGACY_DAEMON_PREFIX_LEN - 2);
-    assert_eq!(sniffer.sniffed_prefix(), LEGACY_DAEMON_PREFIX.as_bytes());
-}
-
-#[test]
 fn prologue_sniffer_take_sniffed_prefix_into_writer_preserves_remainder() {
     let mut sniffer = NegotiationPrologueSniffer::new();
     let mut reader = Cursor::new(LEGACY_DAEMON_PREFIX_BYTES.to_vec());


### PR DESCRIPTION
## Summary
- remove the duplicate `take_sniffed_prefix_into_{slice,array}` implementations that caused compilation to fail
- drop the redundant sniffer tests that referenced the removed copies while keeping full coverage

## Testing
- cargo test

------