### PR TITLE
Add default state for negotiation prologue

### DIFF
--- a/crates/protocol/src/negotiation/tests.rs
+++ b/crates/protocol/src/negotiation/tests.rs
@@ -156,6 +156,15 @@ fn negotiation_prologue_as_str_matches_display() {
 }
 
 #[test]
+fn negotiation_prologue_default_represents_undecided_state() {
+    let default = NegotiationPrologue::default();
+
+    assert_eq!(default, NegotiationPrologue::NeedMoreData);
+    assert!(default.requires_more_data());
+    assert!(!default.is_decided());
+}
+
+#[test]
 fn negotiation_prologue_from_initial_byte_matches_binary_split() {
     assert_eq!(
         NegotiationPrologue::from_initial_byte(b'@'),

--- a/crates/protocol/src/negotiation/types.rs
+++ b/crates/protocol/src/negotiation/types.rs
@@ -214,6 +214,14 @@ impl NegotiationPrologue {
     }
 }
 
+impl Default for NegotiationPrologue {
+    /// Returns [`NegotiationPrologue::NeedMoreData`], matching the undecided state upstream
+    /// rsync uses before the first byte is observed.
+    fn default() -> Self {
+        Self::NeedMoreData
+    }
+}
+
 impl fmt::Display for NegotiationPrologue {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(self.as_str())


### PR DESCRIPTION
## Summary
- implement `Default` for `NegotiationPrologue` so undecided negotiation states can be expressed ergonomically
- add a regression test proving the default matches the upstream "need more data" sentinel

## Testing
- cargo test

------