### PR TITLE
Add conversion helpers for negotiation prologue identifiers

### DIFF
--- a/crates/protocol/src/negotiation/tests.rs
+++ b/crates/protocol/src/negotiation/tests.rs
@@ -4,7 +4,7 @@ use crate::NegotiationError;
 use crate::legacy::{LEGACY_DAEMON_PREFIX, LEGACY_DAEMON_PREFIX_BYTES, LEGACY_DAEMON_PREFIX_LEN};
 use proptest::prelude::*;
 use std::{
-    collections::TryReserveError,
+    collections::{HashSet, TryReserveError},
     error::Error as _,
     io::{self, Cursor, Read, Write},
     ptr, slice,
@@ -153,6 +153,25 @@ fn negotiation_prologue_as_str_matches_display() {
     assert_eq!(legacy.to_string(), "legacy-ascii");
     assert_eq!(binary.to_string(), "binary");
     assert_eq!(undecided.to_string(), "need-more-data");
+}
+
+#[test]
+fn negotiation_prologue_converts_into_static_str() {
+    let legacy: &'static str = NegotiationPrologue::LegacyAscii.into();
+    let binary: &'static str = NegotiationPrologue::Binary.into();
+    let undecided: &'static str = NegotiationPrologue::NeedMoreData.into();
+
+    assert_eq!(legacy, "legacy-ascii");
+    assert_eq!(binary, "binary");
+    assert_eq!(undecided, "need-more-data");
+
+    let mut set = HashSet::new();
+    set.insert(NegotiationPrologue::Binary);
+    set.insert(NegotiationPrologue::LegacyAscii);
+    set.insert(NegotiationPrologue::NeedMoreData);
+
+    assert_eq!(set.len(), 3);
+    assert!(set.contains(&NegotiationPrologue::Binary));
 }
 
 #[test]

--- a/crates/protocol/src/negotiation/types.rs
+++ b/crates/protocol/src/negotiation/types.rs
@@ -134,7 +134,7 @@ impl From<BufferedPrefixTooSmall> for io::Error {
 /// assert!(legacy.is_legacy());
 /// # Ok::<_, ParseNegotiationPrologueError>(())
 /// ```
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum NegotiationPrologue {
     /// There is not enough buffered data to determine the negotiation style.
     NeedMoreData,
@@ -211,6 +211,12 @@ impl NegotiationPrologue {
         } else {
             Self::Binary
         }
+    }
+}
+
+impl From<NegotiationPrologue> for &'static str {
+    fn from(prologue: NegotiationPrologue) -> Self {
+        prologue.as_str()
     }
 }
 


### PR DESCRIPTION
## Summary
- derive `Hash` for `NegotiationPrologue` and expose a conversion into the canonical identifier string
- cover the new API surface with unit tests to ensure formatting and hashing behavior remain stable

## Testing
- cargo test

------