### PR TITLE
Add allocation-free legacy greeting formatter

### DIFF
--- a/crates/protocol/src/legacy/mod.rs
+++ b/crates/protocol/src/legacy/mod.rs
@@ -30,6 +30,8 @@ pub use bytes::{
     parse_legacy_daemon_message_bytes, parse_legacy_error_message_bytes,
     parse_legacy_warning_message_bytes,
 };
+#[allow(unused_imports)]
+pub use greeting::write_legacy_daemon_greeting;
 pub use greeting::{
     LegacyDaemonGreeting, format_legacy_daemon_greeting, parse_legacy_daemon_greeting,
     parse_legacy_daemon_greeting_details,


### PR DESCRIPTION
## Summary
- add a write_legacy_daemon_greeting helper that emits the @RSYNCD banner without allocating
- reuse the new helper in format_legacy_daemon_greeting and expand coverage for error propagation
- re-export the writer helper from the legacy module for downstream consumers

## Testing
- cargo test

------