### PR TITLE
Fix NegotiatedStreamParts map_inner buffer handling

### DIFF
--- a/crates/transport/src/negotiation.rs
+++ b/crates/transport/src/negotiation.rs
@@ -259,17 +259,13 @@ impl<R> NegotiatedStreamParts<R> {
     {
         let Self {
             decision,
-            sniffed_prefix_len,
-            buffered_pos,
-            buffered,
+            buffer,
             inner,
         } = self;
 
         NegotiatedStreamParts {
             decision,
-            sniffed_prefix_len,
-            buffered_pos,
-            buffered,
+            buffer,
             inner: map(inner),
         }
     }


### PR DESCRIPTION
## Summary
- fix NegotiatedStreamParts::map_inner to move the existing negotiation buffer
- ensure mapping inner reader preserves sniffed prefix bookkeeping

## Testing
- cargo test

------