### PR TITLE
transport: allow sniffing with reusable detector

### DIFF
--- a/crates/transport/src/lib.rs
+++ b/crates/transport/src/lib.rs
@@ -12,4 +12,7 @@
 
 mod negotiation;
 
-pub use negotiation::{NegotiatedStream, NegotiatedStreamParts, sniff_negotiation_stream};
+pub use negotiation::{
+    NegotiatedStream, NegotiatedStreamParts, sniff_negotiation_stream,
+    sniff_negotiation_stream_with_sniffer,
+};


### PR DESCRIPTION
## Summary
- add a transport-level helper that reuses a caller supplied `NegotiationPrologueSniffer` to sniff new sessions without reallocating the prefix buffer
- re-export the new helper from the transport facade and extend the unit suite to cover the reuse path

## Testing
- cargo test -p rsync-transport

Red → Green count: 0 → 0 (no goldens affected)
Affected goldens: none

------