### PR TITLE
Add Write support to negotiated transport stream

### DIFF
--- a/crates/transport/src/daemon.rs
+++ b/crates/transport/src/daemon.rs
@@ -103,11 +103,8 @@ where
     let negotiated_protocol = cmp::min(desired_protocol, server_greeting.protocol());
 
     let banner = format_legacy_daemon_greeting(negotiated_protocol);
-    {
-        let inner = stream.inner_mut();
-        inner.write_all(banner.as_bytes())?;
-        inner.flush()?;
-    }
+    stream.write_all(banner.as_bytes())?;
+    stream.flush()?;
 
     Ok(LegacyDaemonHandshake {
         stream,


### PR DESCRIPTION
## Summary
- implement `std::io::Write` for `NegotiatedStream` so callers can emit data without grabbing the inner transport directly
- extend the negotiation transport tests with a duplex in-memory transport that verifies writes, vectored writes, and flush propagation
- use the new `Write` implementation inside the legacy daemon handshake when sending the client banner

## Testing
- cargo test

------