### PR TITLE
Add session handshake parts helper

### DIFF
--- a/crates/transport/src/binary.rs
+++ b/crates/transport/src/binary.rs
@@ -497,8 +497,8 @@ mod tests {
         let remote_version = ProtocolVersion::from_supported(31).expect("31 supported");
         let transport = CountingTransport::new(&handshake_bytes(remote_version));
 
-        let handshake =
-            negotiate_binary_session(transport, ProtocolVersion::NEWEST).expect("handshake succeeds");
+        let handshake = negotiate_binary_session(transport, ProtocolVersion::NEWEST)
+            .expect("handshake succeeds");
 
         let (remote, negotiated, parts) = handshake.into_stream_parts();
         assert_eq!(remote, remote_version);
@@ -515,10 +515,7 @@ mod tests {
             .stream_mut()
             .write_all(b"payload")
             .expect("write propagates");
-        rehydrated
-            .stream_mut()
-            .flush()
-            .expect("flush propagates");
+        rehydrated.stream_mut().flush().expect("flush propagates");
 
         let transport = rehydrated.into_stream().into_inner();
         assert_eq!(transport.flushes(), 2);

--- a/crates/transport/src/daemon.rs
+++ b/crates/transport/src/daemon.rs
@@ -468,21 +468,20 @@ mod tests {
         let greeting_clone = greeting.clone();
         assert_eq!(parts.decision(), NegotiationPrologue::LegacyAscii);
 
-        let mut rehydrated =
-            LegacyDaemonHandshake::from_stream_parts(greeting, negotiated, parts);
+        let mut rehydrated = LegacyDaemonHandshake::from_stream_parts(greeting, negotiated, parts);
 
         assert_eq!(rehydrated.negotiated_protocol(), negotiated);
         assert_eq!(rehydrated.server_greeting(), &greeting_clone);
-        assert_eq!(rehydrated.stream().decision(), NegotiationPrologue::LegacyAscii);
+        assert_eq!(
+            rehydrated.stream().decision(),
+            NegotiationPrologue::LegacyAscii
+        );
 
         rehydrated
             .stream_mut()
             .write_all(b"@RSYNCD: OK\n")
             .expect("write propagates");
-        rehydrated
-            .stream_mut()
-            .flush()
-            .expect("flush propagates");
+        rehydrated.stream_mut().flush().expect("flush propagates");
 
         let transport = rehydrated.into_stream().into_inner();
         assert_eq!(transport.flushes(), 2);


### PR DESCRIPTION
## Summary
- add a `SessionHandshakeParts` helper to expose variant metadata together with the replaying stream
- allow reconstructing `SessionHandshake` values from stored parts and provide ergonomic accessors
- extend transport session tests to cover the new helper and keep transport test formatting consistent

## Testing
- cargo test

------