### PR TITLE
Add defaults for strong digests and simplify newline detection

### DIFF
--- a/crates/checksums/src/rolling.rs
+++ b/crates/checksums/src/rolling.rs
@@ -197,6 +197,12 @@ impl RollingDigest {
         self.len
     }
 
+    /// Returns whether the digest was computed from zero bytes.
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
     /// Returns the checksum in rsync's packed 32-bit representation.
     #[must_use]
     pub const fn value(&self) -> u32 {

--- a/crates/checksums/src/strong/md4.rs
+++ b/crates/checksums/src/strong/md4.rs
@@ -6,6 +6,12 @@ pub struct Md4 {
     inner: md4::Md4,
 }
 
+impl Default for Md4 {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Md4 {
     /// Creates a hasher with an empty state.
     #[must_use]

--- a/crates/checksums/src/strong/md5.rs
+++ b/crates/checksums/src/strong/md5.rs
@@ -6,6 +6,12 @@ pub struct Md5 {
     inner: md5::Md5,
 }
 
+impl Default for Md5 {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Md5 {
     /// Creates a hasher with an empty state.
     #[must_use]

--- a/crates/transport/src/negotiation.rs
+++ b/crates/transport/src/negotiation.rs
@@ -363,7 +363,7 @@ impl<R: Read> NegotiatedStream<R> {
                     line.try_reserve(observed.len())
                         .map_err(map_line_reserve_error_for_io)?;
                     line.extend_from_slice(observed);
-                    if observed.iter().any(|&value| value == b'\n') {
+                    if observed.contains(&b'\n') {
                         return Ok(());
                     }
                 }


### PR DESCRIPTION
## Summary
- add an `is_empty` convenience on `RollingDigest`
- implement `Default` for the MD4 and MD5 strong checksum wrappers
- replace manual newline scans with `contains` in legacy negotiation reads

## Testing
- cargo fmt
- cargo clippy
- cargo test

------