### PR TITLE
Add fallible transport mapping across negotiation helpers

### DIFF
--- a/crates/transport/src/lib.rs
+++ b/crates/transport/src/lib.rs
@@ -23,7 +23,7 @@ pub use daemon::{
     negotiate_legacy_daemon_session_with_sniffer,
 };
 pub use negotiation::{
-    NegotiatedStream, NegotiatedStreamParts, sniff_negotiation_stream,
+    NegotiatedStream, NegotiatedStreamParts, TryMapInnerError, sniff_negotiation_stream,
     sniff_negotiation_stream_with_sniffer,
 };
 pub use session::{SessionHandshake, negotiate_session, negotiate_session_with_sniffer};


### PR DESCRIPTION
## Summary
- add a reusable `TryMapInnerError` to expose fallible transport mapping for negotiated streams
- expose fallible `try_map_stream_inner` helpers on binary/legacy/session handshakes and their parts
- extend unit tests to cover both successful remapping and error recovery for the new APIs

## Testing
- cargo test

------