### PR TITLE
Remove expect usage in transport try_map helpers

### DIFF
--- a/crates/transport/src/daemon.rs
+++ b/crates/transport/src/daemon.rs
@@ -127,17 +127,15 @@ impl<R> LegacyDaemonHandshake<R> {
             negotiated_protocol,
         } = self;
 
-        let mut greeting = Some(server_greeting);
-
         match stream.try_map_inner(map) {
             Ok(stream) => Ok(LegacyDaemonHandshake {
                 stream,
-                server_greeting: greeting.take().expect("greeting available"),
+                server_greeting,
                 negotiated_protocol,
             }),
             Err(err) => Err(err.map_original(|stream| LegacyDaemonHandshake {
                 stream,
-                server_greeting: greeting.take().expect("greeting available"),
+                server_greeting,
                 negotiated_protocol,
             })),
         }

--- a/crates/transport/src/session.rs
+++ b/crates/transport/src/session.rs
@@ -424,21 +424,18 @@ impl<R> SessionHandshakeParts<R> {
                 server_greeting,
                 negotiated_protocol,
                 stream,
-            } => {
-                let mut greeting = Some(server_greeting);
-                match stream.try_map_inner(map) {
-                    Ok(stream) => Ok(SessionHandshakeParts::Legacy {
-                        server_greeting: greeting.take().expect("greeting available"),
-                        negotiated_protocol,
-                        stream,
-                    }),
-                    Err(err) => Err(err.map_original(|stream| SessionHandshakeParts::Legacy {
-                        server_greeting: greeting.take().expect("greeting available"),
-                        negotiated_protocol,
-                        stream,
-                    })),
-                }
-            }
+            } => match stream.try_map_inner(map) {
+                Ok(stream) => Ok(SessionHandshakeParts::Legacy {
+                    server_greeting,
+                    negotiated_protocol,
+                    stream,
+                }),
+                Err(err) => Err(err.map_original(|stream| SessionHandshakeParts::Legacy {
+                    server_greeting,
+                    negotiated_protocol,
+                    stream,
+                })),
+            },
         }
     }
 


### PR DESCRIPTION
## Summary
- remove `expect` usage from `LegacyDaemonHandshake::try_map_stream_inner` so the legacy path never panics when mapping transports
- simplify `SessionHandshakeParts::try_map_stream_inner` for the legacy variant to avoid panicking expectations and keep the logic symmetric with the binary path

## Testing
- cargo test

------