### PR TITLE
Expose session handshake legacy greeting accessor

### DIFF
--- a/crates/transport/src/session.rs
+++ b/crates/transport/src/session.rs
@@ -70,6 +70,17 @@ impl<R> SessionHandshake<R> {
         }
     }
 
+    /// Returns the parsed legacy daemon greeting when the negotiation used the legacy ASCII handshake.
+    ///
+    /// Binary negotiations do not exchange a greeting, so the method returns [`None`] in that case.
+    #[must_use]
+    pub fn server_greeting(&self) -> Option<&LegacyDaemonGreetingOwned> {
+        match self {
+            Self::Binary(_) => None,
+            Self::Legacy(handshake) => Some(handshake.server_greeting()),
+        }
+    }
+
     /// Returns a shared reference to the replaying stream regardless of variant.
     #[must_use]
     pub fn stream(&self) -> &NegotiatedStream<R> {


### PR DESCRIPTION
## Summary
- add a SessionHandshake::server_greeting accessor to surface the legacy daemon greeting without manual matching
- extend the session transport tests to cover the new accessor on legacy handshakes and ensure binary handshakes return None

## Testing
- cargo test

------