### PR TITLE
Normalize message source paths via workspace root

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -6,5 +6,6 @@ authors = ["rsync rust port contributors"]
 license = "GPL-3.0-or-later"
 description = "Core utilities shared by the Rust rsync implementation"
 repository = "https://github.com/oferchen/rsync"
+build = "build.rs"
 
 [dependencies]

--- a/crates/core/build.rs
+++ b/crates/core/build.rs
@@ -1,0 +1,22 @@
+use std::env;
+use std::path::{Path, PathBuf};
+
+fn workspace_root(manifest_dir: &Path) -> PathBuf {
+    for ancestor in manifest_dir.ancestors() {
+        let candidate = ancestor.join("Cargo.lock");
+        if candidate.is_file() {
+            return ancestor.to_path_buf();
+        }
+    }
+
+    manifest_dir.to_path_buf()
+}
+
+fn main() {
+    let manifest_dir =
+        env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR is always set by Cargo");
+    let manifest_dir = PathBuf::from(manifest_dir);
+    let root = workspace_root(&manifest_dir);
+
+    println!("cargo:rustc-env=RSYNC_WORKSPACE_ROOT={}", root.display());
+}


### PR DESCRIPTION
## Summary
- add a build script that exports the workspace root for the core crate
- normalize message source locations so error trailers show repo-relative paths

## Testing
- cargo test

------