### PR TITLE
Clarify protocol negotiation style boundaries

### DIFF
--- a/crates/protocol/src/version/tests.rs
+++ b/crates/protocol/src/version/tests.rs
@@ -185,6 +185,19 @@ fn named_version_constants_match_supported_protocols() {
 }
 
 #[test]
+fn negotiation_style_predicates_match_protocol_boundaries() {
+    assert!(ProtocolVersion::V32.uses_binary_negotiation());
+    assert!(ProtocolVersion::V31.uses_binary_negotiation());
+    assert!(ProtocolVersion::V30.uses_binary_negotiation());
+
+    assert!(ProtocolVersion::V29.uses_legacy_ascii_negotiation());
+    assert!(ProtocolVersion::V28.uses_legacy_ascii_negotiation());
+
+    assert!(!ProtocolVersion::V29.uses_binary_negotiation());
+    assert!(!ProtocolVersion::V28.uses_binary_negotiation());
+}
+
+#[test]
 fn select_highest_mutual_accepts_non_zero_u8_advertisements() {
     let peers = [
         NonZeroU8::new(32).expect("non-zero"),


### PR DESCRIPTION
## Summary
- expand the documentation attached to `ProtocolVersion::uses_binary_negotiation` and `uses_legacy_ascii_negotiation` so the binary/legacy split is tied directly to upstream protocol 30 behaviour
- add a regression test that exercises both predicates across the supported protocol span to guard the boundary

## Testing
- cargo test

## Red → Green
- Red → Green: 0 → 0 (documentation and unit-test additions only)
- Affected goldens: None (unit-test change)
- Upstream parity: Clarifies the existing binary-vs-legacy split defined by upstream rsync and locks it in with explicit coverage.

------