### PR TITLE
Simplify message path normalization and clean up transport tests

### DIFF
--- a/crates/core/src/message.rs
+++ b/crates/core/src/message.rs
@@ -272,11 +272,9 @@ fn normalize_path(path: PathBuf) -> String {
             }
             Component::CurDir => {}
             Component::ParentDir => {
-                if let Some(last) = segments.last() {
-                    if last != ".." {
-                        segments.pop();
-                        continue;
-                    }
+                if segments.last().is_some_and(|last| last != "..") {
+                    segments.pop();
+                    continue;
                 }
 
                 if !is_absolute {
@@ -293,15 +291,14 @@ fn normalize_path(path: PathBuf) -> String {
         normalized.push_str(&prefix.to_string_lossy().replace('\\', "/"));
     }
 
-    if is_absolute {
-        if !normalized.ends_with('/') {
-            normalized.push('/');
-        }
+    if is_absolute && !normalized.ends_with('/') {
+        normalized.push('/');
     }
 
     for (index, segment) in segments.iter().enumerate() {
-        if !normalized.is_empty()
-            && !(normalized.ends_with('/') || (index == 0 && normalized.ends_with(':')))
+        if !(normalized.is_empty()
+            || normalized.ends_with('/')
+            || (index == 0 && normalized.ends_with(':')))
         {
             normalized.push('/');
         }

--- a/crates/transport/src/binary.rs
+++ b/crates/transport/src/binary.rs
@@ -546,7 +546,7 @@ mod tests {
         let err = handshake
             .try_map_stream_inner(
                 |inner| -> Result<InstrumentedTransport, (io::Error, MemoryTransport)> {
-                    Err((io::Error::new(io::ErrorKind::Other, "boom"), inner))
+                    Err((io::Error::other("boom"), inner))
                 },
             )
             .expect_err("mapping fails");
@@ -624,7 +624,7 @@ mod tests {
     #[test]
     fn negotiate_binary_session_rejects_out_of_range_version() {
         let mut bytes = [0u8; 4];
-        bytes.copy_from_slice(&u32::from(27u32).to_le_bytes());
+        bytes.copy_from_slice(&27u32.to_le_bytes());
         let transport = MemoryTransport::new(&bytes);
         let err = negotiate_binary_session(transport, ProtocolVersion::NEWEST)
             .expect_err("unsupported protocol must fail");

--- a/crates/transport/src/daemon.rs
+++ b/crates/transport/src/daemon.rs
@@ -531,7 +531,7 @@ mod tests {
         let err = handshake
             .try_map_stream_inner(
                 |inner| -> Result<InstrumentedTransport, (io::Error, MemoryTransport)> {
-                    Err((io::Error::new(io::ErrorKind::Other, "boom"), inner))
+                    Err((io::Error::other("boom"), inner))
                 },
             )
             .expect_err("mapping fails");

--- a/crates/transport/src/negotiation.rs
+++ b/crates/transport/src/negotiation.rs
@@ -1164,7 +1164,7 @@ mod tests {
         let err = stream
             .try_map_inner(
                 |cursor| -> Result<RecordingTransport, (io::Error, Cursor<Vec<u8>>)> {
-                    Err((io::Error::new(io::ErrorKind::Other, "boom"), cursor))
+                    Err((io::Error::other("boom"), cursor))
                 },
             )
             .expect_err("mapping fails");
@@ -1207,7 +1207,7 @@ mod tests {
         let err = parts
             .try_map_inner(
                 |cursor| -> Result<RecordingTransport, (io::Error, Cursor<Vec<u8>>)> {
-                    Err((io::Error::new(io::ErrorKind::Other, "boom"), cursor))
+                    Err((io::Error::other("boom"), cursor))
                 },
             )
             .expect_err("mapping fails");
@@ -1229,7 +1229,7 @@ mod tests {
         let err = parts
             .try_map_inner(
                 |cursor| -> Result<RecordingTransport, (io::Error, Cursor<Vec<u8>>)> {
-                    Err((io::Error::new(io::ErrorKind::Other, "boom"), cursor))
+                    Err((io::Error::other("boom"), cursor))
                 },
             )
             .expect_err("mapping fails");

--- a/crates/transport/src/session/tests.rs
+++ b/crates/transport/src/session/tests.rs
@@ -322,7 +322,7 @@ fn try_map_stream_inner_preserves_original_handshake_on_error() {
     let err = handshake
         .try_map_stream_inner(
             |inner| -> Result<InstrumentedTransport, (io::Error, MemoryTransport)> {
-                Err((io::Error::new(io::ErrorKind::Other, "boom"), inner))
+                Err((io::Error::other("boom"), inner))
             },
         )
         .expect_err("mapping fails");
@@ -481,7 +481,7 @@ fn session_handshake_parts_try_map_preserves_original_on_error() {
     let err = parts
         .try_map_stream_inner(
             |inner| -> Result<InstrumentedTransport, (io::Error, MemoryTransport)> {
-                Err((io::Error::new(io::ErrorKind::Other, "boom"), inner))
+                Err((io::Error::other("boom"), inner))
             },
         )
         .expect_err("mapping fails");


### PR DESCRIPTION
## Summary
- simplify the message path normalization helper to avoid nested conditionals flagged by clippy
- switch transport tests to use `io::Error::other` and drop redundant conversions

## Testing
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test

------