### PR TITLE
Expose SessionHandshakeParts via transport facade

### DIFF
--- a/crates/transport/src/lib.rs
+++ b/crates/transport/src/lib.rs
@@ -26,4 +26,6 @@ pub use negotiation::{
     NegotiatedStream, NegotiatedStreamParts, TryMapInnerError, sniff_negotiation_stream,
     sniff_negotiation_stream_with_sniffer,
 };
-pub use session::{SessionHandshake, negotiate_session, negotiate_session_with_sniffer};
+pub use session::{
+    SessionHandshake, SessionHandshakeParts, negotiate_session, negotiate_session_with_sniffer,
+};

--- a/crates/transport/tests/public_api.rs
+++ b/crates/transport/tests/public_api.rs
@@ -1,0 +1,14 @@
+use rsync_transport::{NegotiatedStreamParts, SessionHandshakeParts};
+use std::io::Cursor;
+
+fn assert_type_visible<T>() {}
+
+#[test]
+fn session_handshake_parts_is_publicly_visible() {
+    assert_type_visible::<SessionHandshakeParts<Cursor<Vec<u8>>>>();
+}
+
+#[test]
+fn negotiated_stream_parts_remains_accessible() {
+    assert_type_visible::<NegotiatedStreamParts<Cursor<Vec<u8>>>>();
+}


### PR DESCRIPTION
## Summary
- re-export `SessionHandshakeParts` from the transport facade so downstream crates can work with `SessionHandshake::into_stream_parts`
- add a public API integration test that ensures the handshake parts type remains reachable through the crate root

## Testing
- cargo test

------