### PR TITLE
Add session part negotiation helpers

### DIFF
--- a/crates/transport/src/lib.rs
+++ b/crates/transport/src/lib.rs
@@ -27,5 +27,6 @@ pub use negotiation::{
     sniff_negotiation_stream_with_sniffer,
 };
 pub use session::{
-    SessionHandshake, SessionHandshakeParts, negotiate_session, negotiate_session_with_sniffer,
+    SessionHandshake, SessionHandshakeParts, negotiate_session, negotiate_session_parts,
+    negotiate_session_parts_with_sniffer, negotiate_session_with_sniffer,
 };


### PR DESCRIPTION
## Summary
- add helpers to negotiate session handshakes directly into `SessionHandshakeParts`
- expose the new APIs from the transport crate so higher layers can reuse them
- extend session negotiation tests to cover the parts helpers and sniffer reuse

## Testing
- cargo test

------