### PR TITLE
Add structured rustdoc overviews to crate roots

### DIFF
--- a/crates/checksums/src/lib.rs
+++ b/crates/checksums/src/lib.rs
@@ -2,11 +2,80 @@
 #![deny(missing_docs)]
 #![deny(rustdoc::broken_intra_doc_links)]
 
-//! Checksum primitives mirroring upstream rsync algorithms.
+//! # Overview
 //!
-//! The crate exposes the rolling weak checksum (`rsum`) together with strong
-//! digests backed by MD4, MD5, and XXH64. These building blocks are wired into
-//! higher layers by the `core` facade once the transfer engine is implemented.
+//! `rsync_checksums` provides the rolling and strong checksum primitives used by
+//! the Rust `rsync` implementation. The algorithms are byte-for-byte compatible
+//! with upstream rsync 3.4.1 so delta-transfer heuristics and compatibility
+//! checks remain interchangeable with the C reference.
+//!
+//! # Design
+//!
+//! The crate currently offers two modules:
+//!
+//! - [`rolling`] implements the Adler-32–style weak checksum (`rsum`) used for
+//!   block matching during delta transfers.
+//! - [`strong`] exposes MD4, MD5, and XXH64 digests that higher layers select
+//!   according to the negotiated protocol version.
+//!
+//! The modules are intentionally small, allowing the workspace to enforce strict
+//! layering while keeping checksum-specific optimisations in one place.
+//!
+//! # Invariants
+//!
+//! - `RollingChecksum` truncates both state components to 16 bits after every
+//!   update, matching upstream rsync's behaviour.
+//! - Rolling updates reject mismatched slice lengths and empty windows so the
+//!   caller never observes silent state corruption.
+//! - Strong digests stream data incrementally and never panic; they surface
+//!   failures through the standard digest traits.
+//!
+//! # Errors
+//!
+//! [`RollingError`] reports invalid rolling operations (empty windows, window
+//! lengths that overflow `u32`, or mismatched slice lengths) and implements
+//! [`std::error::Error`] so the failure can be forwarded to user-facing
+//! diagnostics.
+//!
+//! # Examples
+//!
+//! Compute a rolling checksum for a block and then advance the window.
+//!
+//! ```
+//! use rsync_checksums::RollingChecksum;
+//!
+//! let mut rolling = RollingChecksum::new();
+//! rolling.update(b"abcd");
+//! assert_eq!(rolling.len(), 4);
+//!
+//! // Replace the first byte with `e` and observe that the helper succeeds.
+//! rolling.roll(b'a', b'e').unwrap();
+//! assert_eq!(rolling.len(), 4);
+//! ```
+//!
+//! Calculate a strong checksum using the MD5 wrapper.
+//!
+//! ```
+//! use rsync_checksums::strong::Md5;
+//!
+//! let mut md5 = Md5::new();
+//! md5.update(b"hello");
+//! let digest = md5.finalize();
+//! assert_eq!(
+//!     digest,
+//!     [
+//!         0x5d, 0x41, 0x40, 0x2a, 0xbc, 0x4b, 0x2a, 0x76,
+//!         0xb9, 0x71, 0x9d, 0x91, 0x10, 0x17, 0xc5, 0x92,
+//!     ]
+//! );
+//! ```
+//!
+//! # See also
+//!
+//! - [`rsync_protocol`] for the protocol version logic that selects the strong
+//!   checksum variant used during negotiation.
+//! - [`rsync_core`] for message formatting utilities that surface checksum
+//!   mismatches to the user.
 
 mod rolling;
 pub mod strong;

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -2,12 +2,57 @@
 #![deny(missing_docs)]
 #![deny(rustdoc::broken_intra_doc_links)]
 
-//! Core utilities shared by the Rust rsync implementation.
+//! # Overview
 //!
-//! The crate provides foundational building blocks that are reused by the
-//! client, daemon, and transport layers. Only functionality that already
-//! exists in this repository is documented here to keep the mission brief's
-//! "code is truth" requirement intact.
+//! `rsync_core` exposes workspace-wide facilities that are shared between the
+//! client, daemon, and transport binaries. The crate focuses on user-visible
+//! message formatting and source-location remapping so diagnostics match
+//! upstream rsync while referencing the Rust sources.
+//!
+//! # Design
+//!
+//! The current surface consists of the [`message`] module. It implements
+//! [`Message`] together with helpers such as [`message::message_source`] for
+//! capturing repo-relative source locations. Higher layers construct messages
+//! through this API to ensure trailer roles and version suffixes are formatted
+//! consistently.
+//!
+//! # Invariants
+//!
+//! - Message trailers always include the `3.4.1-rust` version string.
+//! - Source locations are normalised to repo-relative POSIX-style paths, even on
+//!   Windows builds.
+//! - Errors never allocate excessively: formatting a [`Message`] touches only
+//!   the stored payload and metadata.
+//!
+//! # Errors
+//!
+//! The crate does not define new error types. Instead, it provides utilities
+//! that propagate upstream rsync error codes via [`Message::error`].
+//!
+//! # Examples
+//!
+//! Create an error message using the helper APIs and render it into the
+//! canonical user-facing form.
+//!
+//! ```
+//! use rsync_core::{message::Message, message::Role, message_source};
+//!
+//! let rendered = Message::error(23, "delta-transfer failure")
+//!     .with_role(Role::Sender)
+//!     .with_source(message_source!())
+//!     .to_string();
+//!
+//! assert!(rendered.contains("rsync error: delta-transfer failure (code 23)"));
+//! assert!(rendered.contains("[sender=3.4.1-rust]"));
+//! ```
+//!
+//! # See also
+//!
+//! - [`rsync_protocol`] for the negotiation helpers that feed protocol numbers
+//!   into user-facing diagnostics.
+//! - [`rsync_transport`] for replaying transport wrappers that emit these
+//!   messages when negotiation fails.
 
 /// Message formatting utilities shared across workspace binaries.
 pub mod message;


### PR DESCRIPTION
## Summary
- rewrite the crate-level documentation for the protocol, checksums, core, and transport crates to follow the required section layout
- add runnable examples and cross-links that document the currently implemented APIs without speculation

## Testing
- cargo test

------