### PR TITLE
Mark message builder modifiers as must-use

### DIFF
--- a/crates/core/src/message.rs
+++ b/crates/core/src/message.rs
@@ -300,12 +300,14 @@ impl Message {
     }
 
     /// Attaches a role trailer to the message.
+    #[must_use]
     pub fn with_role(mut self, role: Role) -> Self {
         self.role = Some(role);
         self
     }
 
     /// Attaches a source location to the message.
+    #[must_use]
     pub fn with_source(mut self, source: SourceLocation) -> Self {
         self.source = Some(source);
         self


### PR DESCRIPTION
## Summary
- mark `Message::with_role` and `Message::with_source` as `#[must_use]` to prevent silently discarding trailer metadata during chaining

## Testing
- cargo test -p rsync-core

## Parity
- Red → Green count: 0 (non-functional change)
- Affected goldens: N/A
- Upstream reference: no behavior change; builder now enforces existing usage contract.

------