### PR TITLE
Add borrowed multiplex frame decoder

### DIFF
--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -148,7 +148,9 @@ pub use legacy::{
     parse_legacy_error_message_bytes, parse_legacy_warning_message,
     parse_legacy_warning_message_bytes,
 };
-pub use multiplex::{MessageFrame, recv_msg, recv_msg_into, send_frame, send_msg};
+pub use multiplex::{
+    BorrowedMessageFrame, MessageFrame, recv_msg, recv_msg_into, send_frame, send_msg,
+};
 pub use negotiation::{
     BufferedPrefixTooSmall, NegotiationPrologue, NegotiationPrologueDetector,
     NegotiationPrologueSniffer, ParseNegotiationPrologueError, ParseNegotiationPrologueErrorKind,


### PR DESCRIPTION
## Summary
- add `BorrowedMessageFrame` for zero-copy decoding of multiplex frames
- reuse a shared slice parser for both borrowed and owned decoding paths
- cover the borrowed decoder with unit tests and re-export it from the crate root

## Testing
- cargo test

------