### PR TITLE
Prefer Cargo workspace env for message source root

### DIFF
--- a/crates/core/build.rs
+++ b/crates/core/build.rs
@@ -2,6 +2,17 @@ use std::env;
 use std::path::{Path, PathBuf};
 
 fn workspace_root(manifest_dir: &Path) -> PathBuf {
+    if let Some(workspace_dir) = env::var_os("CARGO_WORKSPACE_DIR") {
+        let mut candidate: PathBuf = workspace_dir.into();
+        if !candidate.is_absolute() {
+            candidate = manifest_dir.join(candidate);
+        }
+
+        if candidate.is_dir() {
+            return candidate;
+        }
+    }
+
     for ancestor in manifest_dir.ancestors() {
         let candidate = ancestor.join("Cargo.lock");
         if candidate.is_file() {
@@ -13,6 +24,9 @@ fn workspace_root(manifest_dir: &Path) -> PathBuf {
 }
 
 fn main() {
+    println!("cargo:rerun-if-env-changed=CARGO_WORKSPACE_DIR");
+    println!("cargo:rerun-if-env-changed=CARGO_MANIFEST_DIR");
+
     let manifest_dir =
         env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR is always set by Cargo");
     let manifest_dir = PathBuf::from(manifest_dir);


### PR DESCRIPTION
## Summary
- derive `RSYNC_WORKSPACE_ROOT` from `CARGO_WORKSPACE_DIR` when available so message source formatting follows the canonical workspace path
- fall back to the existing `Cargo.lock` ancestor search and add env-change rebuild triggers to keep the build script in sync with workspace moves

## Testing
- cargo test

## Red → Green
- Red → Green count: 0
- Affected goldens: None (infrastructure-only change)
- Upstream parity rationale: the build script now prefers Cargo's canonical workspace directory when present, matching the path layout used by upstream builds while retaining the prior `Cargo.lock` fallback to preserve behavior when the env var is absent.

------