### PR TITLE
Add rolling digest slice parsing support

### DIFF
--- a/crates/checksums/src/lib.rs
+++ b/crates/checksums/src/lib.rs
@@ -36,6 +36,8 @@
 //! lengths that overflow `u32`, or mismatched slice lengths) and implements
 //! [`std::error::Error`] so the failure can be forwarded to user-facing
 //! diagnostics.
+//! [`RollingSliceError`] signals that a digest could not be reconstructed from a
+//! byte slice because the input length differed from the expected four bytes.
 //!
 //! # Examples
 //!
@@ -80,4 +82,4 @@
 mod rolling;
 pub mod strong;
 
-pub use rolling::{RollingChecksum, RollingDigest, RollingError};
+pub use rolling::{RollingChecksum, RollingDigest, RollingError, RollingSliceError};


### PR DESCRIPTION
## Summary
- add `RollingSliceError` and `RollingDigest::from_le_slice` to validate little-endian slice decoding
- tag rolling checksum helpers with upstream doc aliases and expose the new error from the crate root
- extend unit tests covering the slice decoder and document the new error in crate-level docs

## Testing
- cargo test

------