### PR TITLE
Optimize legacy daemon greeting formatting

### DIFF
--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -146,7 +146,7 @@ pub use legacy::{
     parse_legacy_daemon_greeting_details, parse_legacy_daemon_message,
     parse_legacy_daemon_message_bytes, parse_legacy_error_message,
     parse_legacy_error_message_bytes, parse_legacy_warning_message,
-    parse_legacy_warning_message_bytes,
+    parse_legacy_warning_message_bytes, write_legacy_daemon_greeting,
 };
 pub use multiplex::{
     BorrowedMessageFrame, MessageFrame, recv_msg, recv_msg_into, send_frame, send_msg,


### PR DESCRIPTION
## Summary
- render the legacy daemon greeting directly into a stack-resident buffer and reuse it when negotiating daemon sessions
- expose `write_legacy_daemon_greeting` from `rsync_protocol` so callers can format greetings without heap allocations
- cover the new helper with unit tests that validate the rendered bytes and overflow handling

## Testing
- cargo test

------