### PR TITLE
Address clippy warnings in core and checksum helpers

### DIFF
--- a/crates/checksums/src/rolling.rs
+++ b/crates/checksums/src/rolling.rs
@@ -50,6 +50,21 @@ impl RollingSliceError {
         self.len
     }
 
+    /// Reports whether the provided slice was empty when the error occurred.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rsync_checksums::{RollingDigest, RollingSliceError};
+    ///
+    /// let err = RollingDigest::from_le_slice(&[], 0).unwrap_err();
+    /// assert!(err.is_empty());
+    /// ```
+    #[must_use]
+    pub const fn is_empty(self) -> bool {
+        self.len == 0
+    }
+
     /// Number of bytes required to decode a rolling checksum digest.
     pub const EXPECTED_LEN: usize = 4;
 }

--- a/crates/core/src/message.rs
+++ b/crates/core/src/message.rs
@@ -541,10 +541,10 @@ impl fmt::Display for Message {
 /// The input string must already be normalised via [`normalize_path`]. When the path lives outside
 /// the workspace root (or the root is unknown), the original string is returned unchanged.
 fn strip_workspace_prefix_owned(normalized_path: String) -> String {
-    if let Some(root) = normalized_workspace_root() {
-        if let Some(stripped) = strip_normalized_workspace_prefix(&normalized_path, root) {
-            return stripped;
-        }
+    if let Some(root) = normalized_workspace_root()
+        && let Some(stripped) = strip_normalized_workspace_prefix(&normalized_path, root)
+    {
+        return stripped;
     }
 
     normalized_path

--- a/crates/core/src/message/strings.rs
+++ b/crates/core/src/message/strings.rs
@@ -91,7 +91,7 @@ impl ExitCodeMessage {
     }
 
     /// Converts the template into a [`Message`] that mirrors upstream output.
-    #[must_use]
+    #[must_use = "the constructed Message should be rendered so the exit-code diagnostic reaches the user"]
     pub fn to_message(self) -> Message {
         match self.severity {
             Severity::Info => Message::info(self.text).with_code(self.code),


### PR DESCRIPTION
## Summary
- add an explicit `#[must_use]` message on `ExitCodeMessage::to_message` to satisfy clippy while documenting the diagnostic requirement
- collapse the nested workspace-prefix stripping check using a let-chain for clearer control flow
- extend `RollingSliceError` with an `is_empty` helper and doctest to balance its public API

## Testing
- cargo clippy
- cargo test

------