### PR TITLE
Add doc aliases for legacy daemon helpers

### DIFF
--- a/crates/protocol/src/legacy/greeting.rs
+++ b/crates/protocol/src/legacy/greeting.rs
@@ -161,12 +161,14 @@ impl<'a> From<LegacyDaemonGreeting<'a>> for LegacyDaemonGreetingOwned {
 /// negotiated [`ProtocolVersion`]. Callers that need access to the advertised
 /// protocol number, subprotocol suffix, or digest list should use
 /// [`parse_legacy_daemon_greeting_details`].
+#[doc(alias = "@RSYNCD")]
 #[must_use = "legacy daemon greeting parsing errors must be handled"]
 pub fn parse_legacy_daemon_greeting(line: &str) -> Result<ProtocolVersion, NegotiationError> {
     parse_legacy_daemon_greeting_details(line).map(LegacyDaemonGreeting::protocol)
 }
 
 /// Parses a legacy daemon greeting and returns a structured representation.
+#[doc(alias = "@RSYNCD")]
 #[must_use = "legacy daemon greeting parsing errors must be handled"]
 pub fn parse_legacy_daemon_greeting_details(
     line: &str,

--- a/crates/protocol/src/legacy/lines.rs
+++ b/crates/protocol/src/legacy/lines.rs
@@ -11,6 +11,7 @@ use super::{
 /// the ASCII-based negotiation path. These lines reuse the same prefix as the
 /// version greeting, so higher level code benefits from a typed representation
 /// to avoid stringly-typed comparisons while still mirroring upstream behavior.
+#[doc(alias = "@RSYNCD")]
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum LegacyDaemonMessage<'a> {
     /// A protocol version announcement such as `@RSYNCD: 30.0`.
@@ -46,6 +47,7 @@ pub enum LegacyDaemonMessage<'a> {
 /// variants and all remaining inputs yield [`LegacyDaemonMessage::Other`],
 /// allowing callers to gracefully handle extensions without guessing upstream's
 /// future strings.
+#[doc(alias = "@RSYNCD")]
 #[must_use = "the parsed legacy daemon message must be handled"]
 pub fn parse_legacy_daemon_message(
     line: &str,
@@ -110,6 +112,7 @@ pub fn parse_legacy_daemon_message(
 /// payload following `@ERROR:` is returned with surrounding ASCII whitespace
 /// removed, allowing callers to surface the daemon's diagnostic verbatim while
 /// still matching upstream trimming behavior.
+#[doc(alias = "@ERROR")]
 #[must_use]
 pub fn parse_legacy_error_message(line: &str) -> Option<&str> {
     parse_prefixed_payload(line, "@ERROR:")
@@ -120,6 +123,7 @@ pub fn parse_legacy_error_message(line: &str) -> Option<&str> {
 /// The returned payload mirrors [`parse_legacy_error_message`], enabling higher
 /// layers to surface warning text emitted by older daemons without guessing the
 /// exact formatting nuances.
+#[doc(alias = "@WARNING")]
 #[must_use]
 pub fn parse_legacy_warning_message(line: &str) -> Option<&str> {
     parse_prefixed_payload(line, "@WARNING:")

--- a/crates/transport/src/daemon.rs
+++ b/crates/transport/src/daemon.rs
@@ -57,6 +57,7 @@ impl FmtWrite for LegacyGreetingBuffer {
 /// The structure exposes the negotiated protocol version together with the
 /// parsed greeting metadata while retaining the replaying stream so higher
 /// layers can continue consuming control messages or file lists.
+#[doc(alias = "@RSYNCD")]
 #[derive(Debug)]
 pub struct LegacyDaemonHandshake<R> {
     stream: NegotiatedStream<R>,
@@ -256,6 +257,7 @@ impl<R> LegacyDaemonHandshake<R> {
 ///   binary handshake, which is handled by different transports.
 /// - Any I/O error reported while sniffing the prologue, reading the greeting,
 ///   writing the client's banner, or flushing the stream.
+#[doc(alias = "@RSYNCD")]
 pub fn negotiate_legacy_daemon_session<R>(
     reader: R,
     desired_protocol: ProtocolVersion,
@@ -287,6 +289,7 @@ where
 /// allocations when establishing many daemon sessions. The sniffer is reset
 /// before any bytes are observed so state from previous negotiations is fully
 /// cleared. Behaviour otherwise matches [`negotiate_legacy_daemon_session`].
+#[doc(alias = "@RSYNCD")]
 pub fn negotiate_legacy_daemon_session_with_sniffer<R>(
     reader: R,
     desired_protocol: ProtocolVersion,

--- a/crates/transport/src/negotiation.rs
+++ b/crates/transport/src/negotiation.rs
@@ -357,6 +357,7 @@ impl<R: Read> NegotiatedStream<R> {
     /// - [`io::ErrorKind::UnexpectedEof`] if the underlying stream closes before a newline is
     ///   observed.
     /// - [`io::ErrorKind::OutOfMemory`] when reserving space for the output buffer fails.
+    #[doc(alias = "@RSYNCD")]
     pub fn read_legacy_daemon_line(&mut self, line: &mut Vec<u8>) -> io::Result<()> {
         self.read_legacy_line(line, true)
     }
@@ -367,6 +368,7 @@ impl<R: Read> NegotiatedStream<R> {
     /// [`rsync_protocol::parse_legacy_daemon_greeting_bytes`]. On success the negotiated
     /// [`ProtocolVersion`] is returned while leaving any bytes after the newline buffered for
     /// subsequent reads.
+    #[doc(alias = "@RSYNCD")]
     pub fn read_and_parse_legacy_daemon_greeting(
         &mut self,
         line: &mut Vec<u8>,
@@ -380,6 +382,7 @@ impl<R: Read> NegotiatedStream<R> {
     /// This mirrors [`Self::read_and_parse_legacy_daemon_greeting`] but exposes the structured
     /// [`LegacyDaemonGreeting`] used by higher layers to inspect the advertised protocol number,
     /// subprotocol, and digest list.
+    #[doc(alias = "@RSYNCD")]
     pub fn read_and_parse_legacy_daemon_greeting_details<'a>(
         &mut self,
         line: &'a mut Vec<u8>,
@@ -394,6 +397,7 @@ impl<R: Read> NegotiatedStream<R> {
     /// replaying transport wrapper so callers can continue using [`Read`] after the buffered
     /// negotiation prefix has been replayed. The returned [`LegacyDaemonMessage`] borrows the
     /// supplied buffer, matching the lifetime semantics of the parser from the protocol crate.
+    #[doc(alias = "@RSYNCD")]
     pub fn read_and_parse_legacy_daemon_message<'a>(
         &mut self,
         line: &'a mut Vec<u8>,
@@ -407,6 +411,7 @@ impl<R: Read> NegotiatedStream<R> {
     /// Empty payloads are returned as `Some("")`, mirroring the behaviour of
     /// [`rsync_protocol::parse_legacy_error_message_bytes`]. Any parsing failure is converted into
     /// [`io::ErrorKind::InvalidData`], matching the conversion performed by the protocol crate.
+    #[doc(alias = "@ERROR")]
     pub fn read_and_parse_legacy_daemon_error_message<'a>(
         &mut self,
         line: &'a mut Vec<u8>,
@@ -416,6 +421,7 @@ impl<R: Read> NegotiatedStream<R> {
     }
 
     /// Reads and parses a legacy daemon warning line of the form `@WARNING: ...`.
+    #[doc(alias = "@WARNING")]
     pub fn read_and_parse_legacy_daemon_warning_message<'a>(
         &mut self,
         line: &'a mut Vec<u8>,

--- a/crates/transport/src/session/handshake.rs
+++ b/crates/transport/src/session/handshake.rs
@@ -22,6 +22,7 @@ pub enum SessionHandshake<R> {
     /// Binary remote-shell style negotiation (protocols ≥ 30).
     Binary(BinaryHandshake<R>),
     /// Legacy `@RSYNCD:` daemon negotiation.
+    #[doc(alias = "@RSYNCD")]
     Legacy(LegacyDaemonHandshake<R>),
 }
 


### PR DESCRIPTION
## Summary
- add `@RSYNCD` doc aliases to legacy greeting parsers and negotiation structs for easier rustdoc discovery
- tag legacy error and warning helpers with `@ERROR`/`@WARNING` aliases so docs surface historical daemon banners

## Testing
- cargo test

------