### PR TITLE
Mark message constructors as must_use

### DIFF
--- a/crates/core/src/message.rs
+++ b/crates/core/src/message.rs
@@ -374,6 +374,7 @@ pub struct Message {
 
 impl Message {
     /// Creates an informational message.
+    #[must_use]
     pub fn info<T: Into<Cow<'static, str>>>(text: T) -> Self {
         Self {
             severity: Severity::Info,
@@ -385,6 +386,7 @@ impl Message {
     }
 
     /// Creates a warning message.
+    #[must_use]
     pub fn warning<T: Into<Cow<'static, str>>>(text: T) -> Self {
         Self {
             severity: Severity::Warning,
@@ -396,6 +398,7 @@ impl Message {
     }
 
     /// Creates an error message with the provided exit code.
+    #[must_use]
     pub fn error<T: Into<Cow<'static, str>>>(code: i32, text: T) -> Self {
         Self {
             severity: Severity::Error,


### PR DESCRIPTION
## Summary
- mark the `Message::info`, `Message::warning`, and `Message::error` constructors as `#[must_use]` so dropped values surface compiler diagnostics
- ensure that message builders continue to surface rsync-style diagnostics without being accidentally ignored

## Testing
- cargo test -p rsync-core message::tests::formats_error_with_code_role_and_source -- --nocapture

------