### PR TITLE
Clarify must_use messaging for message constructors

### DIFF
--- a/crates/core/src/message.rs
+++ b/crates/core/src/message.rs
@@ -443,7 +443,7 @@ pub struct Message {
 
 impl Message {
     /// Creates an informational message.
-    #[must_use]
+    #[must_use = "constructed messages must be emitted to reach users"]
     pub fn info<T: Into<Cow<'static, str>>>(text: T) -> Self {
         Self {
             severity: Severity::Info,
@@ -455,7 +455,7 @@ impl Message {
     }
 
     /// Creates a warning message.
-    #[must_use]
+    #[must_use = "constructed messages must be emitted to reach users"]
     pub fn warning<T: Into<Cow<'static, str>>>(text: T) -> Self {
         Self {
             severity: Severity::Warning,
@@ -467,7 +467,7 @@ impl Message {
     }
 
     /// Creates an error message with the provided exit code.
-    #[must_use]
+    #[must_use = "constructed messages must be emitted to reach users"]
     pub fn error<T: Into<Cow<'static, str>>>(code: i32, text: T) -> Self {
         Self {
             severity: Severity::Error,


### PR DESCRIPTION
## Summary
- add explicit `#[must_use]` messages to the message constructors so clippy no longer emits `double_must_use`

## Testing
- cargo clippy
- cargo test

------