### PR TITLE
Centralize remote protocol clamp detection in transport handshakes

### DIFF
--- a/crates/transport/src/binary.rs
+++ b/crates/transport/src/binary.rs
@@ -1,3 +1,4 @@
+use crate::handshake_util::remote_advertisement_was_clamped;
 use crate::negotiation::{
     NegotiatedStream, NegotiatedStreamParts, TryMapInnerError, sniff_negotiation_stream,
     sniff_negotiation_stream_with_sniffer,
@@ -46,9 +47,7 @@ impl<R> BinaryHandshake<R> {
     /// Reports whether the remote peer advertised a protocol newer than we support.
     #[must_use]
     pub fn remote_protocol_was_clamped(&self) -> bool {
-        let advertised = self.remote_advertised_protocol();
-        let advertised_byte = u8::try_from(advertised).unwrap_or(u8::MAX);
-        advertised_byte > self.remote_protocol.as_u8()
+        remote_advertisement_was_clamped(self.remote_advertised_protocol(), self.remote_protocol())
     }
 
     /// Reports whether the caller's desired cap reduced the negotiated protocol version.

--- a/crates/transport/src/daemon.rs
+++ b/crates/transport/src/daemon.rs
@@ -1,3 +1,4 @@
+use crate::handshake_util::remote_advertisement_was_clamped;
 use crate::negotiation::{
     NegotiatedStream, NegotiatedStreamParts, TryMapInnerError, sniff_negotiation_stream,
     sniff_negotiation_stream_with_sniffer,
@@ -93,10 +94,7 @@ impl<R> LegacyDaemonHandshake<R> {
     /// Reports whether the remote daemon advertised a protocol newer than we support.
     #[must_use]
     pub fn remote_protocol_was_clamped(&self) -> bool {
-        let advertised = self.remote_advertised_protocol();
-        let negotiated = u32::from(self.server_protocol().as_u8());
-
-        advertised > negotiated
+        remote_advertisement_was_clamped(self.remote_advertised_protocol(), self.server_protocol())
     }
 
     /// Reports whether the caller's desired cap reduced the negotiated protocol version.

--- a/crates/transport/src/handshake_util.rs
+++ b/crates/transport/src/handshake_util.rs
@@ -1,0 +1,50 @@
+#![allow(clippy::module_name_repetitions)]
+
+//! Shared helpers for transport handshakes.
+//!
+//! This module centralises small pieces of logic used by both the binary and
+//! legacy ASCII negotiation flows so they agree on how to interpret remote
+//! protocol advertisements. Keeping the helpers in one place avoids subtle
+//! drift between handshake wrappers and ensures that tests exercising one code
+//! path also validate the other.
+
+use core::convert::TryFrom;
+use rsync_protocol::ProtocolVersion;
+
+/// Reports whether a remote protocol advertisement was clamped to a supported value.
+///
+/// Upstream rsync accepts peers that announce protocol numbers newer than it
+/// understands by clamping the negotiated value to its newest implementation.
+/// Handshake wrappers rely on this helper to detect that condition so they can
+/// surface diagnostics that match the C implementation. Values outside the
+/// byte range are treated as future protocols and therefore considered clamped.
+#[must_use]
+pub(crate) fn remote_advertisement_was_clamped(
+    advertised: u32,
+    negotiated: ProtocolVersion,
+) -> bool {
+    let advertised_byte = u8::try_from(advertised).unwrap_or(u8::MAX);
+    advertised_byte > negotiated.as_u8()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_future_versions_encoded_in_u32() {
+        let negotiated = ProtocolVersion::NEWEST;
+        assert!(remote_advertisement_was_clamped(40, negotiated));
+        assert!(remote_advertisement_was_clamped(0x0001_0200, negotiated));
+    }
+
+    #[test]
+    fn ignores_advertisements_within_supported_range() {
+        let negotiated = ProtocolVersion::from_supported(30).expect("protocol 30 supported");
+        assert!(!remote_advertisement_was_clamped(30, negotiated));
+        assert!(!remote_advertisement_was_clamped(
+            ProtocolVersion::OLDEST.as_u8().into(),
+            negotiated
+        ));
+    }
+}

--- a/crates/transport/src/lib.rs
+++ b/crates/transport/src/lib.rs
@@ -64,6 +64,7 @@
 
 mod binary;
 mod daemon;
+mod handshake_util;
 mod negotiation;
 mod session;
 

--- a/crates/transport/src/session/parts.rs
+++ b/crates/transport/src/session/parts.rs
@@ -1,5 +1,6 @@
 use crate::binary::BinaryHandshake;
 use crate::daemon::LegacyDaemonHandshake;
+use crate::handshake_util::remote_advertisement_was_clamped;
 use crate::negotiation::{NegotiatedStream, NegotiatedStreamParts, TryMapInnerError};
 use rsync_protocol::{LegacyDaemonGreetingOwned, NegotiationPrologue, ProtocolVersion};
 use std::convert::TryFrom;
@@ -260,7 +261,7 @@ impl<R> SessionHandshakeParts<R> {
     /// Reports whether the remote advertisement had to be clamped to the supported range.
     #[must_use]
     pub fn remote_protocol_was_clamped(&self) -> bool {
-        advertisement_was_clamped(self.remote_advertised_protocol(), self.remote_protocol())
+        remote_advertisement_was_clamped(self.remote_advertised_protocol(), self.remote_protocol())
     }
 
     /// Reports whether the negotiated protocol was reduced due to the caller's desired cap.
@@ -274,11 +275,6 @@ impl<R> SessionHandshakeParts<R> {
     pub fn into_handshake(self) -> SessionHandshake<R> {
         SessionHandshake::from_stream_parts(self)
     }
-}
-
-fn advertisement_was_clamped(advertised: u32, protocol: ProtocolVersion) -> bool {
-    let advertised_byte = u8::try_from(advertised).unwrap_or(u8::MAX);
-    advertised_byte > protocol.as_u8()
 }
 
 impl<R> From<BinaryHandshake<R>> for SessionHandshakeParts<R> {


### PR DESCRIPTION
## Summary
- add a shared `remote_advertisement_was_clamped` helper for transport handshakes
- update binary, legacy, and session wrappers to use the shared clamp detection logic

## Testing
- cargo test

------