### PR TITLE
Centralize negotiation decision validation

### DIFF
--- a/crates/transport/src/binary.rs
+++ b/crates/transport/src/binary.rs
@@ -264,18 +264,10 @@ pub(crate) fn negotiate_binary_session_from_stream<R>(
 where
     R: Read + Write,
 {
-    match stream.decision() {
-        NegotiationPrologue::Binary => {}
-        NegotiationPrologue::LegacyAscii => {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                "binary negotiation requires binary prologue",
-            ));
-        }
-        NegotiationPrologue::NeedMoreData => {
-            unreachable!("sniffer fully classifies the negotiation prologue");
-        }
-    }
+    stream.ensure_decision(
+        NegotiationPrologue::Binary,
+        "binary negotiation requires binary prologue",
+    )?;
 
     let mut advertisement = [0u8; 4];
     let desired = desired_protocol.as_u8();


### PR DESCRIPTION
## Summary
- add `NegotiatedStream::ensure_decision` so transport users share the same negotiation validation logic
- reuse the new helper inside the binary and legacy daemon handshakes to eliminate duplicate decision checks

## Testing
- cargo test

------