### PR TITLE
Add StrongDigest trait for strong checksum wrappers

### DIFF
--- a/crates/checksums/src/lib.rs
+++ b/crates/checksums/src/lib.rs
@@ -15,8 +15,9 @@
 //!
 //! - [`rolling`] implements the Adler-32–style weak checksum (`rsum`) used for
 //!   block matching during delta transfers.
-//! - [`strong`] exposes MD4, MD5, and XXH64 digests that higher layers select
-//!   according to the negotiated protocol version.
+//! - [`strong`] exposes MD4, MD5, and XXH64 digests together with the
+//!   [`strong::StrongDigest`] trait that higher layers use to abstract over the
+//!   negotiated algorithm.
 //!
 //! The modules are intentionally small, allowing the workspace to enforce strict
 //! layering while keeping checksum-specific optimisations in one place.

--- a/crates/checksums/src/strong/md4.rs
+++ b/crates/checksums/src/strong/md4.rs
@@ -1,5 +1,7 @@
 use digest::Digest;
 
+use super::StrongDigest;
+
 /// Streaming MD4 hasher mirroring upstream rsync's default strong checksum.
 #[derive(Clone, Debug)]
 pub struct Md4 {
@@ -35,9 +37,25 @@ impl Md4 {
     /// Convenience helper that computes the MD4 digest for `data` in one shot.
     #[must_use]
     pub fn digest(data: &[u8]) -> [u8; 16] {
-        let mut hasher = Self::new();
-        hasher.update(data);
-        hasher.finalize()
+        <Self as StrongDigest>::digest(data)
+    }
+}
+
+impl StrongDigest for Md4 {
+    type Seed = ();
+    type Digest = [u8; 16];
+    const DIGEST_LEN: usize = 16;
+
+    fn with_seed((): Self::Seed) -> Self {
+        Md4::new()
+    }
+
+    fn update(&mut self, data: &[u8]) {
+        self.inner.update(data);
+    }
+
+    fn finalize(self) -> Self::Digest {
+        self.inner.finalize().into()
     }
 }
 

--- a/crates/checksums/src/strong/md5.rs
+++ b/crates/checksums/src/strong/md5.rs
@@ -1,5 +1,7 @@
 use digest::Digest;
 
+use super::StrongDigest;
+
 /// Streaming MD5 hasher used by rsync when backward compatibility demands it.
 #[derive(Clone, Debug)]
 pub struct Md5 {
@@ -35,9 +37,25 @@ impl Md5 {
     /// Convenience helper that computes the MD5 digest for `data` in one shot.
     #[must_use]
     pub fn digest(data: &[u8]) -> [u8; 16] {
-        let mut hasher = Self::new();
-        hasher.update(data);
-        hasher.finalize()
+        <Self as StrongDigest>::digest(data)
+    }
+}
+
+impl StrongDigest for Md5 {
+    type Seed = ();
+    type Digest = [u8; 16];
+    const DIGEST_LEN: usize = 16;
+
+    fn with_seed((): Self::Seed) -> Self {
+        Md5::new()
+    }
+
+    fn update(&mut self, data: &[u8]) {
+        self.inner.update(data);
+    }
+
+    fn finalize(self) -> Self::Digest {
+        self.inner.finalize().into()
     }
 }
 

--- a/crates/checksums/src/strong/mod.rs
+++ b/crates/checksums/src/strong/mod.rs
@@ -12,3 +12,101 @@ mod xxhash;
 pub use md4::Md4;
 pub use md5::Md5;
 pub use xxhash::Xxh64;
+
+/// Trait implemented by strong checksum algorithms used by rsync.
+///
+/// Implementors provide a streaming interface that mirrors upstream rsync's
+/// usage: callers feed data incrementally via [`Self::update`] and then obtain
+/// the final digest through [`Self::finalize`]. The associated
+/// [`DIGEST_LEN`](Self::DIGEST_LEN) constant exposes the byte width of the
+/// resulting hash so higher layers can size buffers without hard-coding
+/// algorithm-specific knowledge.
+///
+/// # Examples
+///
+/// Compute an MD5 digest through the trait without depending on the concrete
+/// hasher type.
+///
+/// ```
+/// use rsync_checksums::strong::{Md5, StrongDigest};
+///
+/// let mut hasher = Md5::new();
+/// hasher.update(b"example");
+/// let digest = hasher.finalize();
+/// assert_eq!(digest.as_ref().len(), Md5::DIGEST_LEN);
+/// ```
+pub trait StrongDigest: Sized {
+    /// Type used to parameterise a new digest instance.
+    type Seed: Default;
+
+    /// Type returned when finalising the digest.
+    type Digest: AsRef<[u8]> + Copy;
+
+    /// Length of the final digest in bytes.
+    const DIGEST_LEN: usize;
+
+    /// Creates a new hasher with an empty state.
+    fn new() -> Self {
+        Self::with_seed(Default::default())
+    }
+
+    /// Creates a new hasher using the provided seed value.
+    fn with_seed(seed: Self::Seed) -> Self;
+
+    /// Feeds additional bytes into the digest state.
+    fn update(&mut self, data: &[u8]);
+
+    /// Finalises the digest and returns the resulting hash.
+    fn finalize(self) -> Self::Digest;
+
+    /// Convenience helper that hashes `data` in a single call.
+    fn digest(data: &[u8]) -> Self::Digest {
+        Self::digest_with_seed(Default::default(), data)
+    }
+
+    /// Convenience helper that hashes `data` using an explicit seed value.
+    fn digest_with_seed(seed: Self::Seed, data: &[u8]) -> Self::Digest {
+        let mut hasher = Self::with_seed(seed);
+        hasher.update(data);
+        hasher.finalize()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Md4, Md5, StrongDigest, Xxh64};
+
+    #[test]
+    fn md5_trait_round_trip_matches_inherent_api() {
+        let input = b"trait-check";
+
+        let mut via_trait = Md5::new();
+        via_trait.update(input);
+        let trait_digest = via_trait.finalize();
+
+        assert_eq!(trait_digest.as_ref(), Md5::digest(input).as_ref());
+    }
+
+    #[test]
+    fn md4_trait_digest_matches_inherent_helper() {
+        let input = b"weak-md4";
+
+        let digest = Md4::digest(input);
+        assert_eq!(
+            digest.as_ref(),
+            <Md4 as StrongDigest>::digest(input).as_ref()
+        );
+    }
+
+    #[test]
+    fn xxh64_trait_supports_seeds() {
+        let seed = 123_u64;
+        let input = b"seeded";
+
+        let digest = Xxh64::digest(seed, input);
+        assert_eq!(
+            digest.as_ref(),
+            <Xxh64 as StrongDigest>::digest_with_seed(seed, input).as_ref()
+        );
+    }
+}

--- a/crates/checksums/src/strong/xxhash.rs
+++ b/crates/checksums/src/strong/xxhash.rs
@@ -1,3 +1,5 @@
+use super::StrongDigest;
+
 /// Streaming XXH64 hasher used by rsync when negotiated by newer protocols.
 #[derive(Clone)]
 pub struct Xxh64 {
@@ -27,9 +29,25 @@ impl Xxh64 {
     /// Convenience helper that computes the XXH64 digest for `data` in one shot.
     #[must_use]
     pub fn digest(seed: u64, data: &[u8]) -> [u8; 8] {
-        let mut hasher = Self::new(seed);
-        hasher.update(data);
-        hasher.finalize()
+        <Self as StrongDigest>::digest_with_seed(seed, data)
+    }
+}
+
+impl StrongDigest for Xxh64 {
+    type Seed = u64;
+    type Digest = [u8; 8];
+    const DIGEST_LEN: usize = 8;
+
+    fn with_seed(seed: Self::Seed) -> Self {
+        Xxh64::new(seed)
+    }
+
+    fn update(&mut self, data: &[u8]) {
+        self.inner.update(data);
+    }
+
+    fn finalize(self) -> Self::Digest {
+        self.inner.digest().to_le_bytes()
     }
 }
 


### PR DESCRIPTION
## Summary
- introduce a StrongDigest trait that exposes a common streaming interface for MD4, MD5, and XXH64 strong checksums
- update the individual strong checksum wrappers to implement the shared trait and delegate their one-shot helpers to it
- expand checksum documentation and tests to cover the new trait-based workflow

## Testing
- cargo test

------