### PR TITLE
Add clone support for negotiation handshakes

### DIFF
--- a/crates/transport/src/binary.rs
+++ b/crates/transport/src/binary.rs
@@ -16,7 +16,12 @@ use std::io::{self, Read, Write};
 /// while retaining the replaying stream so higher layers can continue the
 /// exchange without losing buffered bytes consumed during negotiation
 /// detection.
-#[derive(Debug)]
+///
+/// When the underlying transport implements [`Clone`], the handshake can be
+/// cloned to stage multiple views of the same negotiated session. The cloned
+/// value retains the replay buffer and metadata so both instances continue in
+/// lockstep without rereading from the transport.
+#[derive(Clone, Debug)]
 pub struct BinaryHandshake<R> {
     stream: NegotiatedStream<R>,
     remote_advertised: u32,

--- a/crates/transport/src/daemon.rs
+++ b/crates/transport/src/daemon.rs
@@ -58,8 +58,13 @@ impl FmtWrite for LegacyGreetingBuffer {
 /// The structure exposes the negotiated protocol version together with the
 /// parsed greeting metadata while retaining the replaying stream so higher
 /// layers can continue consuming control messages or file lists.
+///
+/// When the underlying transport implements [`Clone`], the handshake can be
+/// cloned to stage multiple consumers for the same negotiated session. The
+/// replay buffer, greeting, and negotiated protocol are duplicated so both
+/// instances progress independently without rereading from the transport.
 #[doc(alias = "@RSYNCD")]
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct LegacyDaemonHandshake<R> {
     stream: NegotiatedStream<R>,
     server_greeting: LegacyDaemonGreetingOwned,

--- a/crates/transport/src/session/handshake.rs
+++ b/crates/transport/src/session/handshake.rs
@@ -20,7 +20,13 @@ use super::parts::SessionHandshakeParts;
 /// the negotiated style without re-sniffing the transport. Conversions are
 /// provided via [`From`] and [`TryFrom`] so variant-specific wrappers can be
 /// promoted or recovered ergonomically.
-#[derive(Debug)]
+///
+/// When the underlying transport implements [`Clone`], the session wrapper can
+/// also be cloned. The clone retains the negotiated metadata and replay buffer
+/// so both instances may continue processing without interfering with each
+/// other—useful for tooling that needs to inspect the transcript while keeping
+/// the original session active.
+#[derive(Clone, Debug)]
 pub enum SessionHandshake<R> {
     /// Binary remote-shell style negotiation (protocols ≥ 30).
     Binary(BinaryHandshake<R>),


### PR DESCRIPTION
## Summary
- document and derive `Clone` for the transport negotiation stream and handshake wrappers so replay state can be duplicated safely
- add regression tests that confirm cloned streams and handshakes preserve buffered bytes and metadata

## Testing
- cargo test

------