### PR TITLE
Expose transport handshakes for pre-sniffed streams

### DIFF
--- a/crates/transport/src/binary.rs
+++ b/crates/transport/src/binary.rs
@@ -285,7 +285,22 @@ where
     negotiate_binary_session_from_stream(stream, desired_protocol)
 }
 
-pub(crate) fn negotiate_binary_session_from_stream<R>(
+/// Performs the binary negotiation using a pre-sniffed [`NegotiatedStream`].
+///
+/// Callers that already invoked [`sniff_negotiation_stream`] or supplied their
+/// own [`NegotiationPrologueSniffer`] can reuse the captured
+/// [`NegotiatedStream`] instead of repeating the prologue detection. The helper
+/// validates that the buffered prefix corresponds to the binary handshake,
+/// writes the caller's desired protocol advertisement, reads the peer's
+/// response, and returns the resulting [`BinaryHandshake`].
+///
+/// # Errors
+///
+/// - [`io::ErrorKind::InvalidData`] if the supplied stream represents a
+///   legacy ASCII negotiation or if the peer advertises a protocol outside the
+///   supported range.
+/// - Any I/O error reported while exchanging the protocol advertisements.
+pub fn negotiate_binary_session_from_stream<R>(
     mut stream: NegotiatedStream<R>,
     desired_protocol: ProtocolVersion,
 ) -> io::Result<BinaryHandshake<R>>

--- a/crates/transport/src/daemon.rs
+++ b/crates/transport/src/daemon.rs
@@ -313,7 +313,21 @@ where
     negotiate_legacy_daemon_session_from_stream(stream, desired_protocol)
 }
 
-pub(crate) fn negotiate_legacy_daemon_session_from_stream<R>(
+/// Performs the legacy ASCII negotiation using a pre-sniffed [`NegotiatedStream`].
+///
+/// This helper accepts the [`NegotiatedStream`] produced by
+/// [`sniff_negotiation_stream`] (or its sniffer-backed counterpart) and drives
+/// the remainder of the daemon handshake without repeating the prologue
+/// detection. The stream is verified to contain the `@RSYNCD:` prefix before the
+/// greeting is parsed and echoed back to the server.
+///
+/// # Errors
+///
+/// - [`io::ErrorKind::InvalidData`] if the supplied stream does not represent a
+///   legacy daemon negotiation or if formatting the client banner fails.
+/// - Any I/O error reported while exchanging the greeting with the daemon.
+#[doc(alias = "@RSYNCD")]
+pub fn negotiate_legacy_daemon_session_from_stream<R>(
     mut stream: NegotiatedStream<R>,
     desired_protocol: ProtocolVersion,
 ) -> io::Result<LegacyDaemonHandshake<R>>

--- a/crates/transport/src/lib.rs
+++ b/crates/transport/src/lib.rs
@@ -69,17 +69,18 @@ mod negotiation;
 mod session;
 
 pub use binary::{
-    BinaryHandshake, negotiate_binary_session, negotiate_binary_session_with_sniffer,
+    BinaryHandshake, negotiate_binary_session, negotiate_binary_session_from_stream,
+    negotiate_binary_session_with_sniffer,
 };
 pub use daemon::{
     LegacyDaemonHandshake, negotiate_legacy_daemon_session,
-    negotiate_legacy_daemon_session_with_sniffer,
+    negotiate_legacy_daemon_session_from_stream, negotiate_legacy_daemon_session_with_sniffer,
 };
 pub use negotiation::{
     NegotiatedStream, NegotiatedStreamParts, TryMapInnerError, sniff_negotiation_stream,
     sniff_negotiation_stream_with_sniffer,
 };
 pub use session::{
-    SessionHandshake, SessionHandshakeParts, negotiate_session, negotiate_session_parts,
-    negotiate_session_parts_with_sniffer, negotiate_session_with_sniffer,
+    SessionHandshake, SessionHandshakeParts, negotiate_session, negotiate_session_from_stream,
+    negotiate_session_parts, negotiate_session_parts_with_sniffer, negotiate_session_with_sniffer,
 };

--- a/crates/transport/src/session/handshake.rs
+++ b/crates/transport/src/session/handshake.rs
@@ -403,7 +403,20 @@ where
         .map(SessionHandshake::into_stream_parts)
 }
 
-fn negotiate_session_from_stream<R>(
+/// Negotiates an rsync session using a pre-sniffed [`NegotiatedStream`].
+///
+/// Callers that already possess the [`NegotiatedStream`] returned by
+/// [`sniff_negotiation_stream`](crate::sniff_negotiation_stream) (or its
+/// sniffer-backed variant) can use this helper to complete the handshake without
+/// repeating the prologue detection. The function dispatches to the binary or
+/// legacy negotiation path based on the recorded decision and returns the
+/// corresponding [`SessionHandshake`].
+///
+/// # Errors
+///
+/// Propagates any I/O error reported while driving the variant-specific
+/// negotiation helper.
+pub fn negotiate_session_from_stream<R>(
     stream: NegotiatedStream<R>,
     desired_protocol: ProtocolVersion,
 ) -> io::Result<SessionHandshake<R>>

--- a/crates/transport/src/session/mod.rs
+++ b/crates/transport/src/session/mod.rs
@@ -11,7 +11,7 @@ mod handshake;
 mod parts;
 
 pub use handshake::{
-    SessionHandshake, negotiate_session, negotiate_session_parts,
+    SessionHandshake, negotiate_session, negotiate_session_from_stream, negotiate_session_parts,
     negotiate_session_parts_with_sniffer, negotiate_session_with_sniffer,
 };
 pub use parts::SessionHandshakeParts;


### PR DESCRIPTION
## Summary
- expose public helpers for binary, daemon, and session negotiation using an existing `NegotiatedStream`
- document the new APIs and re-export them from the transport crate facade for reuse by higher layers

## Testing
- cargo test

------