### PR TITLE
Fix clippy lint for doc comments and redundant must_use

### DIFF
--- a/crates/core/src/message.rs
+++ b/crates/core/src/message.rs
@@ -123,7 +123,6 @@ impl<'a> MessageSegments<'a> {
     ///
     /// assert_eq!(rendered, message.to_line_bytes().unwrap());
     /// ```
-    #[must_use]
     pub fn iter(&self) -> slice::Iter<'_, IoSlice<'a>> {
         self.as_slices().iter()
     }

--- a/crates/protocol/src/version.rs
+++ b/crates/protocol/src/version.rs
@@ -657,7 +657,7 @@ impl ProtocolVersion {
     /// assert!(ProtocolVersion::V30.uses_binary_negotiation());
     /// assert!(!ProtocolVersion::V29.uses_binary_negotiation());
     /// ```
-
+    ///
     /// Reports whether this protocol version still relies on the legacy ASCII
     /// daemon negotiation.
     ///
@@ -680,7 +680,7 @@ impl ProtocolVersion {
     /// assert!(ProtocolVersion::V28.uses_legacy_ascii_negotiation());
     /// assert!(!ProtocolVersion::V30.uses_legacy_ascii_negotiation());
     /// ```
-
+    ///
     /// Returns the numeric protocol identifiers supported by this
     /// implementation in newest-to-oldest order.
     ///


### PR DESCRIPTION
## Summary
- keep doc comment blank lines inside the comment blocks for `ProtocolVersion`
- drop the redundant `#[must_use]` on `MessageSegments::iter` to avoid the double_must_use lint

## Testing
- cargo clippy
- cargo test

------