### PR TITLE
Handle undecided negotiation prologues gracefully

### DIFF
--- a/crates/transport/src/negotiation.rs
+++ b/crates/transport/src/negotiation.rs
@@ -30,7 +30,7 @@ pub struct NegotiatedStream<R> {
     buffer: NegotiationBuffer,
 }
 
-const NEGOTIATION_PROLOGUE_UNDETERMINED_MSG: &str =
+pub(crate) const NEGOTIATION_PROLOGUE_UNDETERMINED_MSG: &str =
     "connection closed before rsync negotiation prologue was determined";
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
## Summary
- re-export the canonical negotiation error message so session helpers can reuse it
- return the upstream-style UnexpectedEof error when the prologue remains undecided
- exercise the regression path with a dedicated transport test

## Testing
- cargo test

------