### PR TITLE
Expose BufferedCopyTooSmall in transport API

### DIFF
--- a/crates/transport/src/lib.rs
+++ b/crates/transport/src/lib.rs
@@ -77,8 +77,8 @@ pub use daemon::{
     negotiate_legacy_daemon_session_from_stream, negotiate_legacy_daemon_session_with_sniffer,
 };
 pub use negotiation::{
-    NegotiatedStream, NegotiatedStreamParts, TryMapInnerError, sniff_negotiation_stream,
-    sniff_negotiation_stream_with_sniffer,
+    BufferedCopyTooSmall, NegotiatedStream, NegotiatedStreamParts, TryMapInnerError,
+    sniff_negotiation_stream, sniff_negotiation_stream_with_sniffer,
 };
 pub use session::{
     SessionHandshake, SessionHandshakeParts, negotiate_session, negotiate_session_from_stream,

--- a/crates/transport/src/negotiation.rs
+++ b/crates/transport/src/negotiation.rs
@@ -1978,10 +1978,16 @@ mod tests {
             combined.extend_from_slice(remainder_slice);
             combined
         };
-        assert_eq!(parts.buffered_remaining_slice(), expected_remaining.as_slice());
+        assert_eq!(
+            parts.buffered_remaining_slice(),
+            expected_remaining.as_slice()
+        );
 
         let rebuilt = parts.into_stream();
-        assert_eq!(rebuilt.buffered_remaining_slice(), expected_remaining.as_slice());
+        assert_eq!(
+            rebuilt.buffered_remaining_slice(),
+            expected_remaining.as_slice()
+        );
     }
 
     #[test]

--- a/crates/transport/tests/public_api.rs
+++ b/crates/transport/tests/public_api.rs
@@ -1,4 +1,4 @@
-use rsync_transport::{NegotiatedStreamParts, SessionHandshakeParts};
+use rsync_transport::{BufferedCopyTooSmall, NegotiatedStreamParts, SessionHandshakeParts};
 use std::io::Cursor;
 
 fn assert_type_visible<T>() {}
@@ -11,4 +11,9 @@ fn session_handshake_parts_is_publicly_visible() {
 #[test]
 fn negotiated_stream_parts_remains_accessible() {
     assert_type_visible::<NegotiatedStreamParts<Cursor<Vec<u8>>>>();
+}
+
+#[test]
+fn buffered_copy_too_small_is_publicly_visible() {
+    assert_type_visible::<BufferedCopyTooSmall>();
 }


### PR DESCRIPTION
## Summary
- re-export `BufferedCopyTooSmall` from the transport crate root so callers can name the error returned by negotiation helpers
- extend the public API test suite to cover the new re-export and refresh formatting around existing assertions

## Testing
- cargo test

------