### PR TITLE
Handle reentrant message rendering with scratch fallback

### DIFF
--- a/crates/core/src/message.rs
+++ b/crates/core/src/message.rs
@@ -64,8 +64,13 @@ where
     F: FnOnce(&mut MessageScratch) -> R,
 {
     THREAD_LOCAL_SCRATCH.with(|scratch| {
-        let mut scratch = scratch.borrow_mut();
-        f(&mut scratch)
+        match scratch.try_borrow_mut() {
+            Ok(mut scratch) => f(&mut scratch),
+            Err(_) => {
+                let mut fallback = MessageScratch::new();
+                f(&mut fallback)
+            }
+        }
     })
 }
 


### PR DESCRIPTION
## Summary
- guard the thread-local scratch borrow and fall back to a fresh buffer when it is already borrowed

## Testing
- cargo test

------