### PR TITLE
Add iterator support for compatibility flags

### DIFF
--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -131,7 +131,7 @@ mod negotiation;
 mod varint;
 mod version;
 
-pub use compatibility::CompatibilityFlags;
+pub use compatibility::{CompatibilityFlags, KnownCompatibilityFlag};
 pub use envelope::{
     EnvelopeError, HEADER_LEN as MESSAGE_HEADER_LEN, LogCode, LogCodeConversionError,
     MAX_PAYLOAD_LENGTH, MPLEX_BASE, MessageCode, MessageHeader, ParseLogCodeError,


### PR DESCRIPTION
## Summary
- add `FromIterator` and `Extend` implementations to build `CompatibilityFlags` values from known flag iterators
- document iterator-based construction and expose `KnownCompatibilityFlag` at the crate root for downstream use
- cover the new APIs with unit tests to confirm duplicate handling and union semantics

## Testing
- cargo test -p rsync-protocol

------