### PR TITLE
Use const initializer for thread-local message scratch buffer

### DIFF
--- a/crates/core/src/message.rs
+++ b/crates/core/src/message.rs
@@ -56,7 +56,7 @@ impl Default for MessageScratch {
 }
 
 thread_local! {
-    static THREAD_LOCAL_SCRATCH: RefCell<MessageScratch> = RefCell::new(MessageScratch::new());
+    static THREAD_LOCAL_SCRATCH: RefCell<MessageScratch> = const { RefCell::new(MessageScratch::new()) };
 }
 
 fn with_thread_local_scratch<F, R>(f: F) -> R


### PR DESCRIPTION
## Summary
- switch the THREAD_LOCAL_SCRATCH initializer to a const block so the thread-local storage can be constructed at compile time

## Testing
- cargo clippy
- cargo test -p rsync-core

Red → Green count: 0 (lint cleanup)
Affected goldens: none
Parity justification: const-initializing the scratch buffer does not alter runtime behavior or observable output; it only satisfies the clippy lint while preserving upstream-compatible rendering.

------