### PR TITLE
Add stream mapping helpers for handshake parts

### DIFF
--- a/crates/core/src/message.rs
+++ b/crates/core/src/message.rs
@@ -241,7 +241,7 @@ impl<'a> MessageSegments<'a> {
                 match writer.write_vectored(&slices[start..count]) {
                     Ok(0) => {
                         return Err(io::Error::from(io::ErrorKind::WriteZero));
-                    },
+                    }
                     Ok(written) => {
                         debug_assert!(written <= remaining);
                         remaining -= written;


### PR DESCRIPTION
## Summary
- extend `BinaryHandshakeParts` and `LegacyDaemonHandshakeParts` with `map_stream_inner`/`try_map_stream_inner` helpers that mirror the top-level handshake APIs and document their usage with runnable examples
- expand the transport test suites to cover the new helpers, ensuring both success and error paths preserve negotiated metadata and buffered transcripts
- run rustfmt, picking up a small formatting correction in `core::message`

## Testing
- `cargo test`

------