### PR TITLE
Clarify must_use guidance for handshake remapping

### DIFF
--- a/crates/transport/src/binary.rs
+++ b/crates/transport/src/binary.rs
@@ -348,7 +348,7 @@ impl<R> BinaryHandshakeParts<R> {
     /// let restored = err.into_original().into_handshake();
     /// assert_eq!(restored.remote_protocol(), remote);
     /// ```
-    #[must_use]
+    #[must_use = "handle the mapped handshake or propagate the error to preserve negotiation state"]
     pub fn try_map_stream_inner<F, T, E>(
         self,
         map: F,

--- a/crates/transport/src/daemon.rs
+++ b/crates/transport/src/daemon.rs
@@ -421,7 +421,7 @@ impl<R> LegacyDaemonHandshakeParts<R> {
     /// let restored = err.into_original().into_handshake();
     /// assert_eq!(restored.server_protocol(), ProtocolVersion::from_supported(31).unwrap());
     /// ```
-    #[must_use]
+    #[must_use = "handle the mapped handshake or propagate the error to preserve negotiation state"]
     pub fn try_map_stream_inner<F, T, E>(
         self,
         map: F,


### PR DESCRIPTION
## Summary
- document the intent of the `#[must_use]` contract on `BinaryHandshakeParts::try_map_stream_inner`
- apply the same explicit guidance to the daemon handshake variant so both avoid clippy's `double_must_use` lint

## Testing
- cargo clippy
- cargo test

------