### PR TITLE
Remove needless lifetimes from compatibility iterators

### DIFF
--- a/crates/protocol/src/compatibility.rs
+++ b/crates/protocol/src/compatibility.rs
@@ -426,7 +426,7 @@ impl IntoIterator for CompatibilityFlags {
     }
 }
 
-impl<'a> IntoIterator for &'a CompatibilityFlags {
+impl IntoIterator for &CompatibilityFlags {
     type Item = KnownCompatibilityFlag;
     type IntoIter = KnownCompatibilityFlagsIter;
 
@@ -435,7 +435,7 @@ impl<'a> IntoIterator for &'a CompatibilityFlags {
     }
 }
 
-impl<'a> IntoIterator for &'a mut CompatibilityFlags {
+impl IntoIterator for &mut CompatibilityFlags {
     type Item = KnownCompatibilityFlag;
     type IntoIter = KnownCompatibilityFlagsIter;
 


### PR DESCRIPTION
## Summary
- remove redundant explicit lifetimes from the `CompatibilityFlags` reference iterators to satisfy `clippy::needless_lifetimes`

## Testing
- cargo clippy
- cargo test

Red → Green count: 0 → 0 (clippy warnings removed, no failing tests)
Affected goldens: None
Upstream parity: Iterator behavior is unchanged; lifetime elision preserves the same reference semantics exposed by upstream-compatible helpers.

------