### PR TITLE
Centralize transport protocol cap detection

### DIFF
--- a/crates/transport/src/binary.rs
+++ b/crates/transport/src/binary.rs
@@ -1,4 +1,4 @@
-use crate::handshake_util::remote_advertisement_was_clamped;
+use crate::handshake_util::{local_cap_reduced_protocol, remote_advertisement_was_clamped};
 use crate::negotiation::{
     NegotiatedStream, NegotiatedStreamParts, TryMapInnerError, sniff_negotiation_stream,
     sniff_negotiation_stream_with_sniffer,
@@ -143,7 +143,7 @@ impl<R> BinaryHandshakeParts<R> {
     /// parts structure is inspected before reconstructing the full handshake.
     #[must_use]
     pub fn local_protocol_was_capped(&self) -> bool {
-        self.negotiated_protocol() < self.remote_protocol()
+        local_cap_reduced_protocol(self.remote_protocol(), self.negotiated_protocol())
     }
 
     /// Returns the replaying stream parts captured during negotiation.
@@ -457,7 +457,7 @@ impl<R> BinaryHandshake<R> {
     /// parity with the C implementation.
     #[must_use]
     pub fn local_protocol_was_capped(&self) -> bool {
-        self.negotiated_protocol < self.remote_protocol
+        local_cap_reduced_protocol(self.remote_protocol, self.negotiated_protocol)
     }
 
     /// Returns a shared reference to the replaying stream.

--- a/crates/transport/src/daemon.rs
+++ b/crates/transport/src/daemon.rs
@@ -1,4 +1,4 @@
-use crate::handshake_util::remote_advertisement_was_clamped;
+use crate::handshake_util::{local_cap_reduced_protocol, remote_advertisement_was_clamped};
 use crate::negotiation::{
     NegotiatedStream, NegotiatedStreamParts, TryMapInnerError, sniff_negotiation_stream,
     sniff_negotiation_stream_with_sniffer,
@@ -197,7 +197,7 @@ impl<R> LegacyDaemonHandshakeParts<R> {
     /// inspect the parts structure before reconstructing the handshake.
     #[must_use]
     pub fn local_protocol_was_capped(&self) -> bool {
-        self.negotiated_protocol() < self.server_protocol()
+        local_cap_reduced_protocol(self.server_protocol(), self.negotiated_protocol())
     }
 
     /// Returns the replaying stream parts captured during negotiation.
@@ -511,7 +511,7 @@ impl<R> LegacyDaemonHandshake<R> {
     /// condition so higher layers can render matching diagnostics.
     #[must_use]
     pub fn local_protocol_was_capped(&self) -> bool {
-        self.negotiated_protocol < self.server_greeting.protocol()
+        local_cap_reduced_protocol(self.server_greeting.protocol(), self.negotiated_protocol)
     }
 
     /// Returns a shared reference to the replaying stream.


### PR DESCRIPTION
## Summary
- add a shared helper that reports when a caller-imposed protocol cap lowered the negotiated version
- route both binary and legacy daemon handshakes through the shared helper so diagnostics stay consistent
- extend the handshake utility property tests to cover the new helper

## Testing
- cargo test

## Red → Green
- Red → Green count: 0 (refinement of shared transport helpers)
- Affected goldens: N/A
- Upstream parity: Centralized helper mirrors the upstream `--protocol` cap logic for both handshake styles.

------