### PR TITLE
Add coverage for protocol version parse error display text

### DIFF
--- a/crates/protocol/src/version/tests.rs
+++ b/crates/protocol/src/version/tests.rs
@@ -1116,6 +1116,34 @@ fn protocol_version_from_str_reports_error_kinds() {
 }
 
 #[test]
+fn parse_protocol_version_error_display_matches_variants() {
+    let empty = ParseProtocolVersionError::new(ParseProtocolVersionErrorKind::Empty);
+    assert_eq!(empty.to_string(), "protocol version string is empty");
+
+    let invalid = ParseProtocolVersionError::new(ParseProtocolVersionErrorKind::InvalidDigit);
+    assert_eq!(
+        invalid.to_string(),
+        "protocol version must be an unsigned integer"
+    );
+
+    let negative = ParseProtocolVersionError::new(ParseProtocolVersionErrorKind::Negative);
+    assert_eq!(negative.to_string(), "protocol version cannot be negative");
+
+    let overflow = ParseProtocolVersionError::new(ParseProtocolVersionErrorKind::Overflow);
+    assert_eq!(overflow.to_string(), "protocol version value exceeds u8::MAX");
+
+    let (oldest, newest) = ProtocolVersion::supported_range_bounds();
+    let unsupported =
+        ParseProtocolVersionError::new(ParseProtocolVersionErrorKind::UnsupportedRange(27));
+    assert_eq!(
+        unsupported.to_string(),
+        format!(
+            "protocol version 27 is outside the supported range {oldest}-{newest}"
+        )
+    );
+}
+
+#[test]
 fn protocol_versions_are_hashable() {
     use std::collections::HashSet;
 


### PR DESCRIPTION
## Summary
- add a regression test that exercises the `ParseProtocolVersionError` display output for every error variant to guard message parity

## Testing
- cargo test -p rsync-protocol parse_protocol_version_error_display_matches_variants
- cargo test

------