### PR TITLE
Mark SessionHandshake::map_stream_inner as must_use

### DIFF
--- a/crates/protocol/src/version/tests.rs
+++ b/crates/protocol/src/version/tests.rs
@@ -1130,16 +1130,17 @@ fn parse_protocol_version_error_display_matches_variants() {
     assert_eq!(negative.to_string(), "protocol version cannot be negative");
 
     let overflow = ParseProtocolVersionError::new(ParseProtocolVersionErrorKind::Overflow);
-    assert_eq!(overflow.to_string(), "protocol version value exceeds u8::MAX");
+    assert_eq!(
+        overflow.to_string(),
+        "protocol version value exceeds u8::MAX"
+    );
 
     let (oldest, newest) = ProtocolVersion::supported_range_bounds();
     let unsupported =
         ParseProtocolVersionError::new(ParseProtocolVersionErrorKind::UnsupportedRange(27));
     assert_eq!(
         unsupported.to_string(),
-        format!(
-            "protocol version 27 is outside the supported range {oldest}-{newest}"
-        )
+        format!("protocol version 27 is outside the supported range {oldest}-{newest}")
     );
 }
 

--- a/crates/transport/src/session/handshake.rs
+++ b/crates/transport/src/session/handshake.rs
@@ -132,6 +132,9 @@ impl<R> SessionHandshake<R> {
     }
 
     /// Maps the inner transport while preserving the negotiated metadata.
+    ///
+    /// The returned handshake replaces `self`; callers must use the value to
+    /// retain access to the negotiated stream and metadata.
     #[must_use]
     pub fn map_stream_inner<F, T>(self, map: F) -> SessionHandshake<T>
     where


### PR DESCRIPTION
## Summary
- mark `SessionHandshake::map_stream_inner` as `#[must_use]` and document that callers must retain the returned handshake
- apply `cargo fmt` to keep protocol version error display tests consistent

## Testing
- cargo test -p rsync-transport

------