### PR TITLE
Add negotiation style helpers and tests

### DIFF
--- a/crates/transport/src/session/handshake.rs
+++ b/crates/transport/src/session/handshake.rs
@@ -46,6 +46,25 @@ impl<R> SessionHandshake<R> {
         }
     }
 
+    /// Reports whether the session negotiated the binary remote-shell protocol.
+    ///
+    /// The helper mirrors [`NegotiationPrologue::is_binary`], allowing callers
+    /// to branch on the handshake style without matching on [`Self`]
+    /// explicitly. Binary negotiations correspond to protocols 30 and newer.
+    #[must_use]
+    pub const fn is_binary(&self) -> bool {
+        matches!(self, Self::Binary(_))
+    }
+
+    /// Reports whether the session negotiated the legacy ASCII daemon protocol.
+    ///
+    /// The helper mirrors [`NegotiationPrologue::is_legacy`] and returns `true`
+    /// when the handshake flowed through the `@RSYNCD:` daemon exchange.
+    #[must_use]
+    pub const fn is_legacy(&self) -> bool {
+        matches!(self, Self::Legacy(_))
+    }
+
     /// Returns the negotiated protocol version after applying the caller cap.
     #[must_use]
     pub fn negotiated_protocol(&self) -> ProtocolVersion {

--- a/crates/transport/src/session/parts.rs
+++ b/crates/transport/src/session/parts.rs
@@ -38,6 +38,25 @@ impl<R> SessionHandshakeParts<R> {
         }
     }
 
+    /// Reports whether the extracted handshake originated from a binary negotiation.
+    ///
+    /// The helper mirrors [`SessionHandshake::is_binary`], keeping the
+    /// convenience available even after the handshake has been decomposed into
+    /// its parts.
+    #[must_use]
+    pub const fn is_binary(&self) -> bool {
+        matches!(self, SessionHandshakeParts::Binary(_))
+    }
+
+    /// Reports whether the extracted handshake originated from the legacy ASCII negotiation.
+    ///
+    /// This mirrors [`SessionHandshake::is_legacy`] and returns `true` when the
+    /// parts were produced from a legacy `@RSYNCD:` daemon exchange.
+    #[must_use]
+    pub const fn is_legacy(&self) -> bool {
+        matches!(self, SessionHandshakeParts::Legacy(_))
+    }
+
     /// Returns the negotiated protocol version retained by the parts structure.
     #[must_use]
     pub fn negotiated_protocol(&self) -> ProtocolVersion {

--- a/crates/transport/src/session/tests.rs
+++ b/crates/transport/src/session/tests.rs
@@ -66,6 +66,8 @@ fn negotiate_session_detects_binary_transport() {
         negotiate_session(transport, ProtocolVersion::NEWEST).expect("binary handshake succeeds");
 
     assert_eq!(handshake.decision(), NegotiationPrologue::Binary);
+    assert!(handshake.is_binary());
+    assert!(!handshake.is_legacy());
     assert_eq!(handshake.negotiated_protocol(), remote_version);
     assert_eq!(handshake.remote_protocol(), remote_version);
     assert_eq!(
@@ -98,6 +100,8 @@ fn negotiate_session_detects_legacy_transport() {
         negotiate_session(transport, ProtocolVersion::NEWEST).expect("legacy handshake succeeds");
 
     assert_eq!(handshake.decision(), NegotiationPrologue::LegacyAscii);
+    assert!(handshake.is_legacy());
+    assert!(!handshake.is_binary());
     assert_eq!(
         handshake.negotiated_protocol(),
         ProtocolVersion::from_supported(31).expect("protocol 31 supported"),
@@ -181,6 +185,8 @@ fn negotiate_session_parts_exposes_binary_metadata() {
         negotiate_session_parts(transport, ProtocolVersion::NEWEST).expect("binary parts succeed");
 
     assert_eq!(parts.decision(), NegotiationPrologue::Binary);
+    assert!(parts.is_binary());
+    assert!(!parts.is_legacy());
     assert_eq!(parts.remote_protocol(), remote_version);
     assert_eq!(parts.negotiated_protocol(), remote_version);
     assert!(!parts.remote_protocol_was_clamped());
@@ -293,6 +299,8 @@ fn negotiate_session_parts_exposes_legacy_metadata() {
         negotiate_session_parts(transport, ProtocolVersion::NEWEST).expect("legacy parts succeed");
 
     assert_eq!(parts.decision(), NegotiationPrologue::LegacyAscii);
+    assert!(parts.is_legacy());
+    assert!(!parts.is_binary());
     assert_eq!(
         parts.remote_protocol(),
         ProtocolVersion::from_supported(31).expect("protocol 31 supported"),


### PR DESCRIPTION
## Summary
- add `is_binary`/`is_legacy` helpers to the negotiated stream and session handshake types
- extend transport tests to cover the new helpers for both binary and legacy exchanges

## Testing
- `cargo test`

------