### PR TITLE
Optimize compiled feature count initialization

### DIFF
--- a/crates/core/src/version.rs
+++ b/crates/core/src/version.rs
@@ -189,10 +189,11 @@ pub struct CompiledFeaturesIter {
 
 impl CompiledFeaturesIter {
     fn new() -> Self {
-        let remaining = CompiledFeature::ALL
-            .iter()
-            .filter(|feature| feature.is_enabled())
-            .count();
+        let remaining = usize::from(CompiledFeature::Acl.is_enabled())
+            + usize::from(CompiledFeature::Xattr.is_enabled())
+            + usize::from(CompiledFeature::Zstd.is_enabled())
+            + usize::from(CompiledFeature::Iconv.is_enabled())
+            + usize::from(CompiledFeature::SdNotify.is_enabled());
 
         Self {
             index: 0,


### PR DESCRIPTION
## Summary
- avoid repeatedly scanning the feature list when seeding `CompiledFeaturesIter`

## Testing
- cargo test --lib rsync-core

Red → Green count: 0 → 0 (no goldens affected)

------