### PR TITLE
docs: align binary names with oc branding

### DIFF
--- a/docs/differences.md
+++ b/docs/differences.md
@@ -8,7 +8,7 @@ referenced functionality ships and parity is verified by tests or goldens.
 ## Blocking Differences
 
 - **No client or daemon binaries**
-  - *Impact*: Users cannot execute transfers because `bin/rsync` and `bin/rsyncd`
+  - *Impact*: Users cannot execute transfers because `bin/oc-rsync` and `bin/oc-rsyncd`
     are absent.
   - *Removal plan*: Introduce the `cli` and `daemon` crates described in the
     workspace layout, ensure they invoke the shared `core` facade, and verify

--- a/docs/feature_matrix.md
+++ b/docs/feature_matrix.md
@@ -18,9 +18,9 @@ binary so documentation never overstates parity.
 | Checksums | Rolling checksum (`rsum`) implementation | Implemented | Streaming `RollingChecksum` mirrors upstream `sum1`/`sum2` semantics and exposes safe rolling updates. | `crates/checksums/src/rolling.rs` |
 | Checksums | Strong digests (MD4/MD5/XXH64) | Implemented | Streaming wrappers over RustCrypto hashes and `xxhash-rust` provide the strong checksum variants negotiated by rsync. | `crates/checksums/src/strong/` |
 | Core | Centralised message formatting with role/version trailers | Implemented | `core::message::Message` reproduces upstream `rsync error:`/`rsync warning:` prefixes, normalises source paths to repo-relative form, and appends `[role=3.4.1-rust]` trailers. | `crates/core/src/message.rs` |
-| Workspace | CLI front-end (`bin/rsync`) | Missing | No CLI crate or binary exists yet; command-line parsing and help parity are outstanding. | _n/a_ |
+| Workspace | CLI front-end (`bin/oc-rsync`) | Missing | No CLI crate or binary exists yet; command-line parsing and help parity are outstanding. | _n/a_ |
 | Transport | Binary negotiation orchestration | Implemented | `binary::negotiate_binary_session` drives the remote-shell handshake, clamps the negotiated protocol, and returns the replaying stream together with the peer advertisement. | `crates/transport/src/binary.rs` |
-| Workspace | Daemon server (`bin/rsyncd`) | Missing | Daemon crate, config parser, and transport loop have not been implemented. | _n/a_ |
+| Workspace | Daemon server (`bin/oc-rsyncd`) | Missing | Daemon crate, config parser, and transport loop have not been implemented. | _n/a_ |
 | Workspace | Core transfer orchestration plus engine/meta/filter/compress crates | Missing | The `core` crate currently only provides message formatting. The transfer engine, metadata (`meta`), filtering, and compression crates are not implemented, leaving delta transfer and metadata application unavailable. | _n/a_ |
 | Quality | Golden parity harness & interop tests | Missing | The repository does not yet build or execute the upstream rsync comparison matrix. | _n/a_ |
 | Quality | Packaging (deb/rpm), SBOM, systemd unit | Missing | Packaging artifacts are absent pending higher-layer implementation. | _n/a_ |


### PR DESCRIPTION
## Summary
- update documentation to reference the oc-rsync and oc-rsyncd binary names instead of the upstream rsync placeholders

## Testing
- cargo test

------