### PR TITLE
Clarify negotiation iterator must_use guidance

### DIFF
--- a/crates/transport/src/negotiation.rs
+++ b/crates/transport/src/negotiation.rs
@@ -112,7 +112,7 @@ impl<'a> NegotiationBufferedSlices<'a> {
     }
 
     /// Returns an iterator over the populated slices.
-    #[must_use]
+    #[must_use = "callers must iterate to observe the buffered slices"]
     pub fn iter(&self) -> slice::Iter<'_, IoSlice<'a>> {
         self.as_slices().iter()
     }


### PR DESCRIPTION
## Summary
- document the intent of `NegotiationBufferedSlices::iter` with an explicit `#[must_use]` message to satisfy clippy's double_must_use lint

## Testing
- cargo clippy
- cargo test

------