### PR TITLE
Optimize sequential fallback in MessageSegments::write_to

### DIFF
--- a/crates/core/src/message.rs
+++ b/crates/core/src/message.rs
@@ -272,7 +272,7 @@ impl<'a> MessageSegments<'a> {
 
         let mut consumed = self.len() - remaining;
 
-        for slice in slices {
+        for slice in &slices[start..] {
             let bytes = slice.as_ref();
 
             if consumed >= bytes.len() {


### PR DESCRIPTION
## Summary
- avoid re-iterating message segments that were already flushed via vectored I/O when `MessageSegments::write_to` falls back to sequential writes

## Testing
- cargo test

------