### PR TITLE
Expose digest token iterator for legacy greetings

### DIFF
--- a/crates/protocol/src/legacy/mod.rs
+++ b/crates/protocol/src/legacy/mod.rs
@@ -33,9 +33,9 @@ pub use bytes::{
 #[allow(unused_imports)]
 pub use greeting::write_legacy_daemon_greeting;
 pub use greeting::{
-    LegacyDaemonGreeting, LegacyDaemonGreetingOwned, format_legacy_daemon_greeting,
-    parse_legacy_daemon_greeting, parse_legacy_daemon_greeting_details,
-    parse_legacy_daemon_greeting_owned,
+    DigestListTokens, LegacyDaemonGreeting, LegacyDaemonGreetingOwned,
+    format_legacy_daemon_greeting, parse_legacy_daemon_greeting,
+    parse_legacy_daemon_greeting_details, parse_legacy_daemon_greeting_owned,
 };
 pub use lines::{
     LegacyDaemonMessage, parse_legacy_daemon_message, parse_legacy_error_message,

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -139,7 +139,7 @@ pub use envelope::{
 };
 pub use error::NegotiationError;
 pub use legacy::{
-    LEGACY_DAEMON_PREFIX, LEGACY_DAEMON_PREFIX_BYTES, LEGACY_DAEMON_PREFIX_LEN,
+    DigestListTokens, LEGACY_DAEMON_PREFIX, LEGACY_DAEMON_PREFIX_BYTES, LEGACY_DAEMON_PREFIX_LEN,
     LegacyDaemonGreeting, LegacyDaemonGreetingOwned, LegacyDaemonMessage,
     format_legacy_daemon_greeting, parse_legacy_daemon_greeting,
     parse_legacy_daemon_greeting_bytes, parse_legacy_daemon_greeting_bytes_details,


### PR DESCRIPTION
## Summary
- add a `DigestListTokens` iterator to traverse legacy daemon digest lists in order
- expose the iterator from both borrowed and owned greeting types and re-export it for callers
- cover the new API with unit and public API tests, ensuring empty lists behave as expected

## Testing
- cargo test

------