### PR TITLE
Fix consumed offset when falling back to sequential writes

### DIFF
--- a/crates/core/src/message.rs
+++ b/crates/core/src/message.rs
@@ -272,6 +272,16 @@ impl<'a> MessageSegments<'a> {
 
         let mut consumed = self.len() - remaining;
 
+        if start > 0 {
+            let consumed_prefix = slices[..start]
+                .iter()
+                .map(|slice| slice.len())
+                .sum::<usize>();
+
+            debug_assert!(consumed >= consumed_prefix);
+            consumed -= consumed_prefix;
+        }
+
         for slice in &slices[start..] {
             let bytes = slice.as_ref();
 


### PR DESCRIPTION
## Summary
- adjust the sequential fallback to subtract bytes consumed by fully flushed slices before iterating the remaining ones

## Testing
- cargo test -p rsync-core message

------