### PR TITLE
Fix clippy warnings in tests and transport helpers

### DIFF
--- a/crates/protocol/src/version/tests.rs
+++ b/crates/protocol/src/version/tests.rs
@@ -753,7 +753,7 @@ fn supported_versions_iter_supports_nth_and_nth_back() {
 
     let penultimate = ProtocolVersion::from_supported_index(SUPPORTED_PROTOCOL_COUNT - 2)
         .expect("penultimate supported protocol should exist");
-    assert_eq!(iter.last(), Some(penultimate));
+    assert_eq!(iter.next_back(), Some(penultimate));
 }
 
 #[test]
@@ -813,7 +813,7 @@ fn supported_protocol_numbers_iter_supports_nth_and_nth_back() {
     );
 
     assert_eq!(
-        iter.last(),
+        iter.next_back(),
         Some(SUPPORTED_PROTOCOLS[SUPPORTED_PROTOCOL_COUNT - 2])
     );
 }

--- a/crates/transport/src/binary.rs
+++ b/crates/transport/src/binary.rs
@@ -1089,7 +1089,7 @@ mod tests {
         let err = parts
             .try_map_stream_inner(
                 |inner| -> Result<InstrumentedTransport, (io::Error, MemoryTransport)> {
-                    Err((io::Error::new(io::ErrorKind::Other, "wrap failed"), inner))
+                    Err((io::Error::other("wrap failed"), inner))
                 },
             )
             .expect_err("mapping fails");

--- a/crates/transport/src/daemon.rs
+++ b/crates/transport/src/daemon.rs
@@ -1255,7 +1255,7 @@ mod tests {
         let err = parts
             .try_map_stream_inner(
                 |inner| -> Result<InstrumentedTransport, (io::Error, MemoryTransport)> {
-                    Err((io::Error::new(io::ErrorKind::Other, "wrap failed"), inner))
+                    Err((io::Error::other("wrap failed"), inner))
                 },
             )
             .expect_err("mapping fails");

--- a/crates/transport/src/handshake_util.rs
+++ b/crates/transport/src/handshake_util.rs
@@ -47,10 +47,7 @@ mod tests {
     use proptest::prelude::*;
 
     fn negotiated_version_strategy() -> impl Strategy<Value = ProtocolVersion> {
-        let versions: Vec<ProtocolVersion> = ProtocolVersion::supported_versions_array()
-            .iter()
-            .copied()
-            .collect();
+        let versions: Vec<ProtocolVersion> = ProtocolVersion::supported_versions_array().to_vec();
         prop::sample::select(versions)
     }
 


### PR DESCRIPTION
## Summary
- scope message segment tests so borrows drop naturally without manual `drop`
- use `io::Error::other` and direct `to_vec` helpers that clippy recommends
- switch double-ended iterator tests to `next_back` to avoid needless iteration

## Testing
- cargo clippy --all-targets
- cargo test --lib

------