### PR TITLE
Fix remote protocol clamp detection

### DIFF
--- a/crates/transport/src/binary.rs
+++ b/crates/transport/src/binary.rs
@@ -134,7 +134,7 @@ impl<R> BinaryHandshakeParts<R> {
     /// the same diagnostics without rebuilding the wrapper first.
     #[must_use]
     pub fn remote_protocol_was_clamped(&self) -> bool {
-        remote_advertisement_was_clamped(self.remote_advertised_protocol(), self.remote_protocol())
+        remote_advertisement_was_clamped(self.remote_advertised_protocol())
     }
 
     /// Reports whether the negotiated protocol was reduced by the caller-specified cap.
@@ -430,7 +430,7 @@ impl<R> BinaryHandshake<R> {
     /// Reports whether the remote peer advertised a protocol newer than we support.
     #[must_use]
     pub fn remote_protocol_was_clamped(&self) -> bool {
-        remote_advertisement_was_clamped(self.remote_advertised_protocol(), self.remote_protocol())
+        remote_advertisement_was_clamped(self.remote_advertised_protocol())
     }
 
     /// Reports whether the caller's desired cap reduced the negotiated protocol version.

--- a/crates/transport/src/daemon.rs
+++ b/crates/transport/src/daemon.rs
@@ -209,7 +209,7 @@ impl<R> LegacyDaemonHandshakeParts<R> {
     /// wrapper first.
     #[must_use]
     pub fn remote_protocol_was_clamped(&self) -> bool {
-        remote_advertisement_was_clamped(self.remote_advertised_protocol(), self.server_protocol())
+        remote_advertisement_was_clamped(self.remote_advertised_protocol())
     }
 
     /// Reports whether the negotiated protocol was reduced by the caller-provided cap.
@@ -550,7 +550,7 @@ impl<R> LegacyDaemonHandshake<R> {
     /// Reports whether the remote daemon advertised a protocol newer than we support.
     #[must_use]
     pub fn remote_protocol_was_clamped(&self) -> bool {
-        remote_advertisement_was_clamped(self.remote_advertised_protocol(), self.server_protocol())
+        remote_advertisement_was_clamped(self.remote_advertised_protocol())
     }
 
     /// Reports whether the caller's desired cap reduced the negotiated protocol version.

--- a/crates/transport/src/handshake_util.rs
+++ b/crates/transport/src/handshake_util.rs
@@ -8,23 +8,23 @@
 //! drift between handshake wrappers and ensures that tests exercising one code
 //! path also validate the other.
 
-use core::convert::TryFrom;
 use rsync_protocol::ProtocolVersion;
 
-/// Reports whether a remote protocol advertisement was clamped to a supported value.
+/// Reports whether a remote protocol advertisement was clamped to the newest supported value.
 ///
 /// Upstream rsync accepts peers that announce protocol numbers newer than it
 /// understands by clamping the negotiated value to its newest implementation.
 /// Handshake wrappers rely on this helper to detect that condition so they can
-/// surface diagnostics that match the C implementation. Values outside the
-/// byte range are treated as future protocols and therefore considered clamped.
+/// surface diagnostics that match the C implementation. The detection only
+/// fires when the peer announced a protocol strictly newer than
+/// [`ProtocolVersion::NEWEST`]; locally capping the negotiation via
+/// `--protocol` never triggers this path because the peer still spoke a
+/// supported version. Values outside the byte range are treated as future
+/// protocols and therefore considered clamped.
 #[must_use]
-pub(crate) fn remote_advertisement_was_clamped(
-    advertised: u32,
-    negotiated: ProtocolVersion,
-) -> bool {
-    let advertised_byte = u8::try_from(advertised).unwrap_or(u8::MAX);
-    advertised_byte > negotiated.as_u8()
+pub(crate) fn remote_advertisement_was_clamped(advertised: u32) -> bool {
+    let newest_supported = u32::from(ProtocolVersion::NEWEST.as_u8());
+    advertised > newest_supported
 }
 
 /// Reports whether the caller capped the negotiated protocol below the value announced by the peer.
@@ -56,30 +56,39 @@ mod tests {
 
     #[test]
     fn detects_future_versions_encoded_in_u32() {
-        let negotiated = ProtocolVersion::NEWEST;
-        assert!(remote_advertisement_was_clamped(40, negotiated));
-        assert!(remote_advertisement_was_clamped(0x0001_0200, negotiated));
+        assert!(remote_advertisement_was_clamped(40));
+        assert!(remote_advertisement_was_clamped(0x0001_0200));
     }
 
     #[test]
     fn ignores_advertisements_within_supported_range() {
-        let negotiated = ProtocolVersion::from_supported(30).expect("protocol 30 supported");
-        assert!(!remote_advertisement_was_clamped(30, negotiated));
+        assert!(!remote_advertisement_was_clamped(30));
         assert!(!remote_advertisement_was_clamped(
-            ProtocolVersion::OLDEST.as_u8().into(),
-            negotiated
+            ProtocolVersion::OLDEST.as_u8().into()
         ));
+    }
+
+    #[test]
+    fn local_cap_reductions_do_not_appear_as_remote_clamps() {
+        let remote = ProtocolVersion::NEWEST.as_u8();
+
+        assert!(!remote_advertisement_was_clamped(u32::from(remote)));
+    }
+
+    #[test]
+    fn future_remote_versions_are_detected_even_with_local_caps() {
+        assert!(remote_advertisement_was_clamped(40));
     }
 
     proptest! {
         #[test]
         fn within_byte_range_matches_direct_comparison(
             advertised in 0u32..=u8::MAX as u32,
-            negotiated in negotiated_version_strategy(),
         ) {
-            let expected = (advertised as u8) > negotiated.as_u8();
+            let newest = u32::from(ProtocolVersion::NEWEST.as_u8());
+            let expected = advertised > newest;
             prop_assert_eq!(
-                remote_advertisement_was_clamped(advertised, negotiated),
+                remote_advertisement_was_clamped(advertised),
                 expected
             );
         }
@@ -87,9 +96,8 @@ mod tests {
         #[test]
         fn out_of_range_values_always_report_clamp(
             advertised in (u8::MAX as u32 + 1)..=u32::MAX,
-            negotiated in negotiated_version_strategy(),
         ) {
-            prop_assert!(remote_advertisement_was_clamped(advertised, negotiated));
+            prop_assert!(remote_advertisement_was_clamped(advertised));
         }
 
         #[test]


### PR DESCRIPTION
## Summary
- treat remote protocol clamp detection as a check against the newest supported version so local caps do not trigger it
- update binary and daemon handshake helpers to use the revised clamp logic
- extend unit and property tests covering remote clamp scenarios and local caps

## Testing
- cargo test

------