### PR TITLE
Handle legacy daemon CAP capability announcements

### DIFF
--- a/crates/protocol/src/legacy/bytes.rs
+++ b/crates/protocol/src/legacy/bytes.rs
@@ -135,6 +135,16 @@ mod tests {
     }
 
     #[test]
+    fn parse_legacy_daemon_message_bytes_handles_capabilities() {
+        let message =
+            parse_legacy_daemon_message_bytes(b"@RSYNCD: CAP 0x1f 0x2\n").expect("keyword");
+        assert_eq!(
+            message,
+            LegacyDaemonMessage::Capabilities { flags: "0x1f 0x2" }
+        );
+    }
+
+    #[test]
     fn parse_legacy_daemon_greeting_bytes_details_captures_digest_list() {
         let greeting = parse_legacy_daemon_greeting_bytes_details(b"@RSYNCD: 31.0 md4 md5\n")
             .expect("digest list should parse");

--- a/crates/transport/src/negotiation.rs
+++ b/crates/transport/src/negotiation.rs
@@ -5569,6 +5569,22 @@ mod tests {
     }
 
     #[test]
+    fn read_and_parse_legacy_daemon_message_routes_capabilities() {
+        let mut stream = sniff_bytes(b"@RSYNCD: CAP 0x1f 0x2\n").expect("sniff succeeds");
+        let mut line = Vec::new();
+        match stream
+            .read_and_parse_legacy_daemon_message(&mut line)
+            .expect("message parses")
+        {
+            LegacyDaemonMessage::Capabilities { flags } => {
+                assert_eq!(flags, "0x1f 0x2");
+            }
+            other => panic!("unexpected message: {other:?}"),
+        }
+        assert_eq!(line, b"@RSYNCD: CAP 0x1f 0x2\n");
+    }
+
+    #[test]
     fn read_and_parse_legacy_daemon_message_routes_versions() {
         let mut stream = sniff_bytes(b"@RSYNCD: 29.0\n").expect("sniff succeeds");
         let mut line = Vec::new();


### PR DESCRIPTION
## Summary
- parse `@RSYNCD: CAP` legacy daemon messages into a dedicated `Capabilities` variant
- update the string and byte parsers to normalize capability payloads and reject malformed inputs
- extend the transport negotiation tests to cover capability advertisements round-tripping through the stream helpers

## Testing
- cargo test

------