### PR TITLE
Clarify must_use guidance for negotiation buffered slices

### DIFF
--- a/crates/transport/src/negotiation.rs
+++ b/crates/transport/src/negotiation.rs
@@ -179,7 +179,7 @@ impl<'a> NegotiationBufferedSlices<'a> {
     /// assert_eq!(replay, stream.buffered());
     /// # Ok::<(), std::collections::TryReserveError>(())
     /// ```
-    #[must_use]
+    #[must_use = "the returned vector owns the buffered negotiation transcript"]
     pub fn to_vec(&self) -> Result<Vec<u8>, TryReserveError> {
         let mut buffer = Vec::new();
         self.extend_vec(&mut buffer)?;


### PR DESCRIPTION
## Summary
- add an explicit #[must_use] message to NegotiationBufferedSlices::to_vec so the intent of the annotation is clear
- keep the transport crate clippy-clean by avoiding double_must_use warnings

## Testing
- cargo clippy
- cargo test

------