### PR TITLE
Add conversions and clone support for TryMapInnerError

### DIFF
--- a/crates/core/src/version.rs
+++ b/crates/core/src/version.rs
@@ -464,10 +464,7 @@ mod tests {
         let from_ref: Vec<_> = (&display).into_iter().copied().collect();
         assert_eq!(from_ref, display.features());
 
-        let from_mut: Vec<_> = (&mut display)
-            .into_iter()
-            .map(|feature| *feature)
-            .collect();
+        let from_mut: Vec<_> = (&mut display).into_iter().map(|feature| *feature).collect();
         assert_eq!(from_mut, display.features());
 
         let owned: Vec<_> = display.clone().into_iter().collect();


### PR DESCRIPTION
## Summary
- derive `Clone` for `TryMapInnerError` and add tuple conversions to simplify handing preserved transports
- extend the negotiation tests to cover the new conversions and cloning behavior
- run `cargo fmt`, which also cleaned up a small test expression in `version.rs`

## Testing
- cargo test

------