### PR TITLE
Clarify must_use rationale for compatibility flag parser

### DIFF
--- a/crates/protocol/src/compatibility.rs
+++ b/crates/protocol/src/compatibility.rs
@@ -215,7 +215,7 @@ impl KnownCompatibilityFlag {
     /// assert_eq!(parsed, KnownCompatibilityFlag::IncRecurse);
     /// assert!(KnownCompatibilityFlag::from_str("CF_UNKNOWN").is_err());
     /// ```
-    #[must_use]
+    #[must_use = "discarding the parsed flag would drop potential parse errors"]
     pub fn from_name(name: &str) -> Result<Self, ParseKnownCompatibilityFlagError> {
         Self::from_str(name)
     }


### PR DESCRIPTION
## Summary
- explain why the KnownCompatibilityFlag::from_name helper has a #[must_use] justification to retain parse failures

## Testing
- cargo clippy
- cargo test

------