### PR TITLE
Fix feature flag detection to satisfy clippy

### DIFF
--- a/crates/core/src/version.rs
+++ b/crates/core/src/version.rs
@@ -163,7 +163,10 @@ impl CompiledFeature {
     /// Reports whether the feature was compiled into the current build.
     #[must_use]
     pub const fn is_enabled(self) -> bool {
-        (COMPILED_FEATURE_BITMAP & self.bit()) != 0
+        match COMPILED_FEATURE_BITMAP {
+            0 => false,
+            bitmap => (bitmap & self.bit()) != 0,
+        }
     }
 
     /// Returns a human-readable description of the feature for tooling output.


### PR DESCRIPTION
## Summary
- ensure CompiledFeature::is_enabled short-circuits when no optional features are compiled
- keep the bitmap logic while avoiding clippy's bad_bit_mask lint on zero-valued builds

## Testing
- cargo clippy
- cargo test

------