### PR TITLE
Clarify must_use handling when decoding multiplex headers

### DIFF
--- a/crates/protocol/src/envelope.rs
+++ b/crates/protocol/src/envelope.rs
@@ -664,7 +664,7 @@ impl MessageHeader {
     ///
     /// assert_eq!(decoded, original);
     /// ```
-    #[must_use]
+    #[must_use = "Discard the decoded header only after handling potential validation errors"]
     #[inline]
     pub const fn from_raw(raw: u32) -> Result<Self, EnvelopeError> {
         let tag = (raw >> 24) as u8;


### PR DESCRIPTION
## Summary
- add a descriptive `#[must_use]` message to `MessageHeader::from_raw` so callers handle decode results instead of silently ignoring validation errors

## Testing
- cargo clippy
- cargo test

------