### PR TITLE
Optimize buffer reservation for vector extensions

### DIFF
--- a/crates/core/src/message.rs
+++ b/crates/core/src/message.rs
@@ -381,9 +381,10 @@ impl<'a> MessageSegments<'a> {
         }
 
         let required = self.len();
-        if buffer.capacity().saturating_sub(buffer.len()) < required {
+        let spare = buffer.capacity().saturating_sub(buffer.len());
+        if spare < required {
             buffer
-                .try_reserve_exact(required)
+                .try_reserve_exact(required - spare)
                 .map_err(map_message_reserve_error)?;
         }
 

--- a/crates/transport/src/negotiation.rs
+++ b/crates/transport/src/negotiation.rs
@@ -156,8 +156,9 @@ impl<'a> NegotiationBufferedSlices<'a> {
         }
 
         let additional = self.total_len;
-        if buffer.capacity().saturating_sub(buffer.len()) < additional {
-            buffer.try_reserve_exact(additional)?;
+        let spare = buffer.capacity().saturating_sub(buffer.len());
+        if spare < additional {
+            buffer.try_reserve_exact(additional - spare)?;
         }
 
         for slice in self.as_slices() {


### PR DESCRIPTION
## Summary
- reserve only the missing capacity when extending message segment buffers
- apply the same precise reservation strategy to negotiation buffered slices to avoid excess allocations

## Testing
- cargo test -p rsync-core
- cargo test -p rsync-transport

------