### PR TITLE
Add remote protocol advertisement classification utilities

### DIFF
--- a/crates/transport/src/lib.rs
+++ b/crates/transport/src/lib.rs
@@ -76,6 +76,7 @@ pub use daemon::{
     LegacyDaemonHandshake, LegacyDaemonHandshakeParts, negotiate_legacy_daemon_session,
     negotiate_legacy_daemon_session_from_stream, negotiate_legacy_daemon_session_with_sniffer,
 };
+pub use handshake_util::RemoteProtocolAdvertisement;
 pub use negotiation::{
     BufferedCopyTooSmall, NegotiatedStream, NegotiatedStreamParts, TryMapInnerError,
     sniff_negotiation_stream, sniff_negotiation_stream_with_sniffer,

--- a/crates/transport/src/session/handshake.rs
+++ b/crates/transport/src/session/handshake.rs
@@ -1,5 +1,6 @@
 use crate::binary::{BinaryHandshake, negotiate_binary_session_from_stream};
 use crate::daemon::{LegacyDaemonHandshake, negotiate_legacy_daemon_session_from_stream};
+use crate::handshake_util::RemoteProtocolAdvertisement;
 use crate::negotiation::{
     NegotiatedStream, TryMapInnerError, sniff_negotiation_stream,
     sniff_negotiation_stream_with_sniffer,
@@ -89,6 +90,15 @@ impl<R> SessionHandshake<R> {
         match self {
             Self::Binary(handshake) => handshake.remote_advertised_protocol(),
             Self::Legacy(handshake) => handshake.remote_advertised_protocol(),
+        }
+    }
+
+    /// Returns the classification of the peer's protocol advertisement.
+    #[must_use]
+    pub fn remote_advertisement(&self) -> RemoteProtocolAdvertisement {
+        match self {
+            Self::Binary(handshake) => handshake.remote_advertisement(),
+            Self::Legacy(handshake) => handshake.remote_advertisement(),
         }
     }
 

--- a/crates/transport/src/session/parts.rs
+++ b/crates/transport/src/session/parts.rs
@@ -1,5 +1,6 @@
 use crate::binary::{BinaryHandshake, BinaryHandshakeParts};
 use crate::daemon::{LegacyDaemonHandshake, LegacyDaemonHandshakeParts};
+use crate::handshake_util::RemoteProtocolAdvertisement;
 use crate::negotiation::{NegotiatedStream, NegotiatedStreamParts, TryMapInnerError};
 use rsync_protocol::{
     LegacyDaemonGreetingOwned, NegotiationPrologue, NegotiationPrologueSniffer, ProtocolVersion,
@@ -81,6 +82,15 @@ impl<R> SessionHandshakeParts<R> {
         match self {
             SessionHandshakeParts::Binary(parts) => parts.remote_advertised_protocol(),
             SessionHandshakeParts::Legacy(parts) => parts.remote_advertised_protocol(),
+        }
+    }
+
+    /// Returns the classification of the peer's protocol advertisement.
+    #[must_use]
+    pub fn remote_advertisement(&self) -> RemoteProtocolAdvertisement {
+        match self {
+            SessionHandshakeParts::Binary(parts) => parts.remote_advertisement(),
+            SessionHandshakeParts::Legacy(parts) => parts.remote_advertisement(),
         }
     }
 


### PR DESCRIPTION
## Summary
- introduce RemoteProtocolAdvertisement to classify peer protocol announcements
- expose convenience helpers on handshake wrappers and session facades to retrieve the classification
- extend existing tests to assert the new API and update transport docs to re-export the helper

## Testing
- cargo test

------