### PR TITLE
Clarify must_use guidance for message segment iterators

### DIFF
--- a/crates/core/src/message.rs
+++ b/crates/core/src/message.rs
@@ -246,7 +246,7 @@ impl<'a> MessageSegments<'a> {
     /// assert_eq!(total, segments.len());
     /// ```
     #[inline]
-    #[must_use]
+    #[must_use = "iterate over the slices to observe the rendered message segments"]
     pub fn iter(&self) -> slice::Iter<'_, IoSlice<'a>> {
         self.as_slices().iter()
     }
@@ -321,7 +321,7 @@ impl<'a> MessageSegments<'a> {
     /// }
     /// ```
     #[inline]
-    #[must_use]
+    #[must_use = "consume the iterator to mutate the in-place segment descriptors"]
     pub fn iter_mut(&mut self) -> slice::IterMut<'_, IoSlice<'a>> {
         self.as_slices_mut().iter_mut()
     }


### PR DESCRIPTION
## Summary
- add explicit #[must_use] guidance on `MessageSegments::iter` and `MessageSegments::iter_mut` so the intent is preserved without triggering clippy's `double_must_use`

## Testing
- cargo clippy
- cargo test

------