### PR TITLE
Fix clippy diagnostics in logging and transport tests

### DIFF
--- a/crates/core/src/message.rs
+++ b/crates/core/src/message.rs
@@ -3974,10 +3974,7 @@ mod tests {
         fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
             self.vectored_calls += 1;
 
-            if bufs
-                .first()
-                .map_or(false, |slice| slice.as_ref().is_empty())
-            {
+            if bufs.first().is_some_and(|slice| slice.as_ref().is_empty()) {
                 return Ok(0);
             }
 
@@ -4062,7 +4059,7 @@ mod tests {
         let mut segments = message.as_segments(&mut scratch, false);
 
         let original_count = segments.count;
-        assert!(original_count + 1 <= MAX_MESSAGE_SEGMENTS);
+        assert!(original_count < MAX_MESSAGE_SEGMENTS);
 
         for index in (0..original_count).rev() {
             segments.segments[index + 1] = segments.segments[index];

--- a/crates/core/src/version.rs
+++ b/crates/core/src/version.rs
@@ -514,15 +514,18 @@ mod tests {
     #[test]
     fn compiled_features_match_cfg_flags() {
         let features = compiled_features();
+        let mut bitmap_from_features = 0u8;
+
+        for feature in &features {
+            bitmap_from_features |= feature.bit();
+            assert!(feature.is_enabled());
+        }
 
         for feature in CompiledFeature::ALL {
             assert_eq!(features.contains(&feature), feature.is_enabled());
-            assert_eq!(
-                (COMPILED_FEATURE_BITMAP & feature.bit()) != 0,
-                feature.is_enabled()
-            );
         }
 
+        assert_eq!(bitmap_from_features, COMPILED_FEATURE_BITMAP);
         assert_eq!(
             features.len(),
             COMPILED_FEATURE_BITMAP.count_ones() as usize

--- a/crates/logging/src/lib.rs
+++ b/crates/logging/src/lib.rs
@@ -751,7 +751,7 @@ mod tests {
         }
 
         fn flush(&mut self) -> io::Result<()> {
-            Err(io::Error::new(io::ErrorKind::Other, "flush failed"))
+            Err(io::Error::other("flush failed"))
         }
     }
 

--- a/crates/transport/src/handshake_util.rs
+++ b/crates/transport/src/handshake_util.rs
@@ -173,6 +173,12 @@ mod tests {
     use super::*;
     use proptest::prelude::*;
 
+    struct ConstAssert<const COND: bool>;
+
+    impl ConstAssert<true> {
+        const VALUE: () = ();
+    }
+
     fn negotiated_version_strategy() -> impl Strategy<Value = ProtocolVersion> {
         let versions: Vec<ProtocolVersion> = ProtocolVersion::supported_versions_array().to_vec();
         prop::sample::select(versions)
@@ -212,15 +218,23 @@ mod tests {
             ProtocolVersion::V30,
         );
 
-        assert!(CLAMPED);
-        assert!(!NOT_CLAMPED);
-        assert!(matches!(FUTURE, RemoteProtocolAdvertisement::Future(40)));
+        const _: () = ConstAssert::<{ CLAMPED }>::VALUE;
+        const _: () = ConstAssert::<{ !NOT_CLAMPED }>::VALUE;
+
+        let clamped = CLAMPED;
+        let not_clamped = NOT_CLAMPED;
+        let future = FUTURE;
+        let supported = SUPPORTED;
+
+        assert!(clamped);
+        assert!(!not_clamped);
+        assert!(matches!(future, RemoteProtocolAdvertisement::Future(40)));
         assert!(matches!(
-            SUPPORTED,
+            supported,
             RemoteProtocolAdvertisement::Supported(ProtocolVersion::V30)
         ));
-        assert_eq!(FUTURE.negotiated(), ProtocolVersion::NEWEST);
-        assert_eq!(SUPPORTED.negotiated(), ProtocolVersion::V30);
+        assert_eq!(future.negotiated(), ProtocolVersion::NEWEST);
+        assert_eq!(supported.negotiated(), ProtocolVersion::V30);
     }
 
     #[test]
@@ -230,8 +244,14 @@ mod tests {
         const NOT_CAPPED: bool =
             local_cap_reduced_protocol(ProtocolVersion::V29, ProtocolVersion::V29);
 
-        assert!(WAS_CAPPED);
-        assert!(!NOT_CAPPED);
+        const _: () = ConstAssert::<{ WAS_CAPPED }>::VALUE;
+        const _: () = ConstAssert::<{ !NOT_CAPPED }>::VALUE;
+
+        let was_capped = WAS_CAPPED;
+        let not_capped = NOT_CAPPED;
+
+        assert!(was_capped);
+        assert!(!not_capped);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- replace the remaining `io::ErrorKind::Other` construction in the logging tests with the idiomatic `io::Error::other`
- tidy message and version test helpers so clippy no longer reports lint warnings
- add compile-time assertions in the transport handshake tests without triggering clippy

## Testing
- cargo clippy --all-targets
- cargo test

------