### PR TITLE
Fix ProtocolVersion parsing for multiple leading signs

### DIFF
--- a/crates/protocol/src/version.rs
+++ b/crates/protocol/src/version.rs
@@ -1139,24 +1139,30 @@ impl FromStr for ProtocolVersion {
         }
 
         let mut digits = trimmed;
-        if let Some(rest) = digits.strip_prefix('+') {
-            digits = rest;
-        }
+        let mut saw_negative = false;
 
-        if let Some(rest) = digits.strip_prefix('-') {
-            if rest.chars().all(|ch| ch.is_ascii_digit()) {
-                return Err(ParseProtocolVersionError::new(
-                    ParseProtocolVersionErrorKind::Negative,
-                ));
+        if let Some(first) = digits.as_bytes().first().copied() {
+            match first {
+                b'+' => {
+                    digits = &digits[1..];
+                }
+                b'-' => {
+                    saw_negative = true;
+                    digits = &digits[1..];
+                }
+                _ => {}
             }
-            return Err(ParseProtocolVersionError::new(
-                ParseProtocolVersionErrorKind::InvalidDigit,
-            ));
         }
 
         if digits.is_empty() || !digits.chars().all(|ch| ch.is_ascii_digit()) {
             return Err(ParseProtocolVersionError::new(
                 ParseProtocolVersionErrorKind::InvalidDigit,
+            ));
+        }
+
+        if saw_negative {
+            return Err(ParseProtocolVersionError::new(
+                ParseProtocolVersionErrorKind::Negative,
             ));
         }
 

--- a/crates/protocol/src/version/tests.rs
+++ b/crates/protocol/src/version/tests.rs
@@ -1093,6 +1093,12 @@ fn protocol_version_from_str_reports_error_kinds() {
     let invalid = ProtocolVersion::from_str("abc").unwrap_err();
     assert_eq!(invalid.kind(), ParseProtocolVersionErrorKind::InvalidDigit);
 
+    let double_sign = ProtocolVersion::from_str("+-31").unwrap_err();
+    assert_eq!(
+        double_sign.kind(),
+        ParseProtocolVersionErrorKind::InvalidDigit
+    );
+
     let negative = ProtocolVersion::from_str("-31").unwrap_err();
     assert_eq!(negative.kind(), ParseProtocolVersionErrorKind::Negative);
 


### PR DESCRIPTION
## Summary
- ensure the protocol version parser rejects inputs with multiple leading sign characters rather than misclassifying them as negatives
- update the parsing tests to cover the double-sign case and guard against regressions

## Testing
- cargo test

------