### PR TITLE
Expose RemoteProtocolAdvertisement clamp flag across transport handshakes

### DIFF
--- a/crates/transport/src/binary.rs
+++ b/crates/transport/src/binary.rs
@@ -1,6 +1,4 @@
-use crate::handshake_util::{
-    RemoteProtocolAdvertisement, local_cap_reduced_protocol, remote_advertisement_was_clamped,
-};
+use crate::handshake_util::{RemoteProtocolAdvertisement, local_cap_reduced_protocol};
 use crate::negotiation::{
     NegotiatedStream, NegotiatedStreamParts, TryMapInnerError, sniff_negotiation_stream,
     sniff_negotiation_stream_with_sniffer,
@@ -136,7 +134,7 @@ impl<R> BinaryHandshakeParts<R> {
     /// the same diagnostics without rebuilding the wrapper first.
     #[must_use]
     pub const fn remote_protocol_was_clamped(&self) -> bool {
-        remote_advertisement_was_clamped(self.remote_advertised_protocol())
+        self.remote_advertisement().was_clamped()
     }
 
     /// Returns the classification of the peer's protocol advertisement.
@@ -451,7 +449,7 @@ impl<R> BinaryHandshake<R> {
     /// Reports whether the remote peer advertised a protocol newer than we support.
     #[must_use]
     pub const fn remote_protocol_was_clamped(&self) -> bool {
-        remote_advertisement_was_clamped(self.remote_advertised_protocol())
+        self.remote_advertisement().was_clamped()
     }
 
     /// Returns the classification of the peer's protocol advertisement.

--- a/crates/transport/src/daemon.rs
+++ b/crates/transport/src/daemon.rs
@@ -1,6 +1,4 @@
-use crate::handshake_util::{
-    RemoteProtocolAdvertisement, local_cap_reduced_protocol, remote_advertisement_was_clamped,
-};
+use crate::handshake_util::{RemoteProtocolAdvertisement, local_cap_reduced_protocol};
 use crate::negotiation::{
     NegotiatedStream, NegotiatedStreamParts, TryMapInnerError, sniff_negotiation_stream,
     sniff_negotiation_stream_with_sniffer,
@@ -211,7 +209,7 @@ impl<R> LegacyDaemonHandshakeParts<R> {
     /// wrapper first.
     #[must_use]
     pub const fn remote_protocol_was_clamped(&self) -> bool {
-        remote_advertisement_was_clamped(self.remote_advertised_protocol())
+        self.remote_advertisement().was_clamped()
     }
 
     /// Returns the classification of the daemon's protocol advertisement.
@@ -564,7 +562,7 @@ impl<R> LegacyDaemonHandshake<R> {
     /// Reports whether the remote daemon advertised a protocol newer than we support.
     #[must_use]
     pub const fn remote_protocol_was_clamped(&self) -> bool {
-        remote_advertisement_was_clamped(self.remote_advertised_protocol())
+        self.remote_advertisement().was_clamped()
     }
 
     /// Returns the classification of the daemon's protocol advertisement.


### PR DESCRIPTION
## Summary
- add `RemoteProtocolAdvertisement::was_clamped` so transports can query clamp status without reimplementing the classification
- update the binary and legacy handshake wrappers to reuse the shared helper when reporting whether a peer advertised a future protocol
- extend the unit and property tests to exercise the new API and const-evaluable paths

## Testing
- cargo test

------