### PR TITLE
Expose local protocol cap helper

### DIFF
--- a/crates/transport/src/handshake_util.rs
+++ b/crates/transport/src/handshake_util.rs
@@ -175,9 +175,9 @@ pub(crate) const fn remote_advertisement_was_clamped(advertised: u32) -> bool {
 /// Clamp the negotiated protocol to 29 even though the peer advertised 31, mirroring
 /// `rsync --protocol=29` against a newer daemon.
 ///
-/// ```rust,ignore
+/// ```
 /// use rsync_protocol::ProtocolVersion;
-/// use rsync_transport::handshake_util::local_cap_reduced_protocol;
+/// use rsync_transport::local_cap_reduced_protocol;
 ///
 /// let remote = ProtocolVersion::from_supported(31).unwrap();
 /// let negotiated = ProtocolVersion::from_supported(29).unwrap();
@@ -186,7 +186,7 @@ pub(crate) const fn remote_advertisement_was_clamped(advertised: u32) -> bool {
 /// ```
 #[doc(alias = "--protocol")]
 #[must_use]
-pub(crate) const fn local_cap_reduced_protocol(
+pub const fn local_cap_reduced_protocol(
     remote: ProtocolVersion,
     negotiated: ProtocolVersion,
 ) -> bool {

--- a/crates/transport/src/lib.rs
+++ b/crates/transport/src/lib.rs
@@ -76,7 +76,7 @@ pub use daemon::{
     LegacyDaemonHandshake, LegacyDaemonHandshakeParts, negotiate_legacy_daemon_session,
     negotiate_legacy_daemon_session_from_stream, negotiate_legacy_daemon_session_with_sniffer,
 };
-pub use handshake_util::RemoteProtocolAdvertisement;
+pub use handshake_util::{RemoteProtocolAdvertisement, local_cap_reduced_protocol};
 pub use negotiation::{
     BufferedCopyTooSmall, NegotiatedStream, NegotiatedStreamParts, TryMapInnerError,
     sniff_negotiation_stream, sniff_negotiation_stream_with_sniffer,

--- a/crates/transport/tests/public_api.rs
+++ b/crates/transport/tests/public_api.rs
@@ -1,4 +1,7 @@
-use rsync_transport::{BufferedCopyTooSmall, NegotiatedStreamParts, SessionHandshakeParts};
+use rsync_protocol::ProtocolVersion;
+use rsync_transport::{
+    BufferedCopyTooSmall, NegotiatedStreamParts, SessionHandshakeParts, local_cap_reduced_protocol,
+};
 use std::io::Cursor;
 
 fn assert_type_visible<T>() {}
@@ -16,4 +19,12 @@ fn negotiated_stream_parts_remains_accessible() {
 #[test]
 fn buffered_copy_too_small_is_publicly_visible() {
     assert_type_visible::<BufferedCopyTooSmall>();
+}
+
+#[test]
+fn local_cap_helper_is_public() {
+    assert!(local_cap_reduced_protocol(
+        ProtocolVersion::V31,
+        ProtocolVersion::V29,
+    ));
 }


### PR DESCRIPTION
## Summary
- make `local_cap_reduced_protocol` part of the public transport API with a runnable example
- re-export the helper from the crate root so higher layers can reuse the shared logic
- ensure the public API harness covers the helper's visibility

## Testing
- cargo test

------