### PR TITLE
Clarify compiled feature iterator usage

### DIFF
--- a/crates/core/src/version.rs
+++ b/crates/core/src/version.rs
@@ -459,7 +459,7 @@ impl CompiledFeaturesDisplay {
     /// assert_eq!(iter.next(), Some(&CompiledFeature::Acl));
     /// assert!(iter.next().is_none());
     /// ```
-    #[must_use]
+    #[must_use = "inspect the iterator to observe compiled feature ordering"]
     pub fn iter(&self) -> std::slice::Iter<'_, CompiledFeature> {
         self.features.iter()
     }


### PR DESCRIPTION
## Summary
- add an explicit must_use message to CompiledFeaturesDisplay::iter so the attribute carries diagnostic guidance for callers

## Testing
- cargo clippy
- cargo test

------