### PR TITLE
Add session parts negotiation from pre-sniffed streams

### DIFF
--- a/crates/transport/src/lib.rs
+++ b/crates/transport/src/lib.rs
@@ -83,5 +83,6 @@ pub use negotiation::{
 };
 pub use session::{
     SessionHandshake, SessionHandshakeParts, negotiate_session, negotiate_session_from_stream,
-    negotiate_session_parts, negotiate_session_parts_with_sniffer, negotiate_session_with_sniffer,
+    negotiate_session_parts, negotiate_session_parts_from_stream,
+    negotiate_session_parts_with_sniffer, negotiate_session_with_sniffer,
 };

--- a/crates/transport/src/session/mod.rs
+++ b/crates/transport/src/session/mod.rs
@@ -12,7 +12,8 @@ mod parts;
 
 pub use handshake::{
     SessionHandshake, negotiate_session, negotiate_session_from_stream, negotiate_session_parts,
-    negotiate_session_parts_with_sniffer, negotiate_session_with_sniffer,
+    negotiate_session_parts_from_stream, negotiate_session_parts_with_sniffer,
+    negotiate_session_with_sniffer,
 };
 pub use parts::SessionHandshakeParts;
 


### PR DESCRIPTION
## Summary
- add a public helper that produces `SessionHandshakeParts` directly from a pre-sniffed `NegotiatedStream`
- reuse the new helper in the existing `negotiate_session_parts*` flows and re-export it at the crate root
- cover both binary and legacy negotiations with unit tests and document the new API with a runnable example

## Testing
- cargo test

------