### PR TITLE
Use io::Error::other for message segment copy failures

### DIFF
--- a/crates/core/src/message.rs
+++ b/crates/core/src/message.rs
@@ -499,7 +499,7 @@ impl<'a> MessageSegments<'a> {
             }
             Err(err) => {
                 buffer.truncate(start);
-                Err(io::Error::new(io::ErrorKind::Other, err))
+                Err(io::Error::other(err))
             }
         }
     }


### PR DESCRIPTION
## Summary
- emit `std::io::Error::other` when `MessageSegments::extend_vec` falls back from a failed copy operation to address Clippy's `io_other_error` lint

## Testing
- cargo clippy
- cargo test

------