### PR TITLE
Document logging crate capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ The workspace currently contains the following published crates:
 - `crates/core` — shared infrastructure such as the centralized message
   formatting utilities that attach role trailers and normalized source
   locations to user-facing diagnostics.
+- `crates/logging` — newline-aware message sinks that reuse
+  `MessageScratch` buffers when streaming diagnostics into arbitrary
+  writers, mirroring upstream `rsync`'s logging pipeline.
 
 Higher-level crates such as `cli`, `daemon`, `engine`, and `meta` have not been
 implemented yet. The `core` crate currently focuses on message formatting and

--- a/docs/COMPARE.md
+++ b/docs/COMPARE.md
@@ -42,6 +42,11 @@ layers (CLI, core, engine, daemon) land.
   a writer reports a partial write. Unit tests cover the path normalisation,
   newline handling, and vectored-write fallback to guarantee parity for the
   current diagnostic surface.【F:crates/core/src/message.rs†L99-L209】【F:crates/core/src/message.rs†L569-L708】【F:crates/core/src/message.rs†L940-L1261】
+- **Streaming sinks** – `rsync_logging::MessageSink` wraps arbitrary writers,
+  reuses `MessageScratch` buffers, and exposes newline controls that mirror
+  upstream logging behaviour. Batch helpers keep newline policy stable while
+  emitting progress updates or mixed severities, with tests exercising
+  owned/borrowed message batches and explicit mode overrides.【F:crates/logging/src/lib.rs†L163-L220】【F:crates/logging/src/lib.rs†L994-L1078】
 
 ## Outstanding Areas
 


### PR DESCRIPTION
## Summary
- add the logging crate to the repository layout overview in the README
- record the MessageSink streaming sink evidence in docs/COMPARE.md alongside existing diagnostic checkpoints

## Testing
- cargo test

------