### PR TITLE
Preserve clamped protocol in remote advertisement classification

### DIFF
--- a/crates/transport/src/binary.rs
+++ b/crates/transport/src/binary.rs
@@ -1240,7 +1240,7 @@ mod tests {
         assert_eq!(handshake.remote_advertised_protocol(), future_version);
         assert_eq!(
             handshake.remote_advertisement(),
-            RemoteProtocolAdvertisement::Future(future_version)
+            RemoteProtocolAdvertisement::from_raw(future_version, ProtocolVersion::NEWEST)
         );
 
         let parts = handshake.into_parts();
@@ -1251,7 +1251,7 @@ mod tests {
         assert!(parts.local_protocol_was_capped());
         assert_eq!(
             parts.remote_advertisement(),
-            RemoteProtocolAdvertisement::Future(future_version)
+            RemoteProtocolAdvertisement::from_raw(future_version, ProtocolVersion::NEWEST)
         );
 
         let transport = parts.into_handshake().into_stream().into_inner();
@@ -1273,7 +1273,7 @@ mod tests {
         assert!(!handshake.local_protocol_was_capped());
         assert_eq!(
             handshake.remote_advertisement(),
-            RemoteProtocolAdvertisement::Future(future_version)
+            RemoteProtocolAdvertisement::from_raw(future_version, ProtocolVersion::NEWEST)
         );
     }
 
@@ -1291,7 +1291,7 @@ mod tests {
         assert!(!handshake.local_protocol_was_capped());
         assert_eq!(
             handshake.remote_advertisement(),
-            RemoteProtocolAdvertisement::Future(u32::MAX)
+            RemoteProtocolAdvertisement::from_raw(u32::MAX, ProtocolVersion::NEWEST)
         );
     }
 

--- a/crates/transport/src/daemon.rs
+++ b/crates/transport/src/daemon.rs
@@ -1103,7 +1103,7 @@ mod tests {
         assert!(!handshake.local_protocol_was_capped());
         assert_eq!(
             handshake.remote_advertisement(),
-            RemoteProtocolAdvertisement::Future(40)
+            RemoteProtocolAdvertisement::from_raw(40, ProtocolVersion::NEWEST)
         );
 
         let parts = handshake.into_parts();
@@ -1111,7 +1111,7 @@ mod tests {
         assert!(!parts.local_protocol_was_capped());
         assert_eq!(
             parts.remote_advertisement(),
-            RemoteProtocolAdvertisement::Future(40)
+            RemoteProtocolAdvertisement::from_raw(40, ProtocolVersion::NEWEST)
         );
 
         let transport = parts.into_handshake().into_stream().into_inner();
@@ -1132,7 +1132,7 @@ mod tests {
         assert!(!handshake.local_protocol_was_capped());
         assert_eq!(
             handshake.remote_advertisement(),
-            RemoteProtocolAdvertisement::Future(999)
+            RemoteProtocolAdvertisement::from_raw(999, ProtocolVersion::NEWEST)
         );
 
         let parts = handshake.into_parts();
@@ -1140,7 +1140,7 @@ mod tests {
         assert!(!parts.local_protocol_was_capped());
         assert_eq!(
             parts.remote_advertisement(),
-            RemoteProtocolAdvertisement::Future(999)
+            RemoteProtocolAdvertisement::from_raw(999, ProtocolVersion::NEWEST)
         );
 
         let transport = parts.into_handshake().into_stream().into_inner();
@@ -1161,7 +1161,7 @@ mod tests {
         assert!(!handshake.local_protocol_was_capped());
         assert_eq!(
             handshake.remote_advertisement(),
-            RemoteProtocolAdvertisement::Future(u32::MAX)
+            RemoteProtocolAdvertisement::from_raw(u32::MAX, ProtocolVersion::NEWEST)
         );
 
         let parts = handshake.into_parts();

--- a/crates/transport/src/negotiation.rs
+++ b/crates/transport/src/negotiation.rs
@@ -2477,10 +2477,7 @@ impl NegotiationBuffer {
     }
 
     #[inline]
-    fn copy_bytes_into_vec(
-        target: &mut Vec<u8>,
-        bytes: &[u8],
-    ) -> Result<usize, TryReserveError> {
+    fn copy_bytes_into_vec(target: &mut Vec<u8>, bytes: &[u8]) -> Result<usize, TryReserveError> {
         let len = target.len();
         target.try_reserve(bytes.len().saturating_sub(len))?;
         target.clear();
@@ -2493,10 +2490,7 @@ impl NegotiationBuffer {
     }
 
     #[inline]
-    fn extend_bytes_into_vec(
-        target: &mut Vec<u8>,
-        bytes: &[u8],
-    ) -> Result<usize, TryReserveError> {
+    fn extend_bytes_into_vec(target: &mut Vec<u8>, bytes: &[u8]) -> Result<usize, TryReserveError> {
         if bytes.is_empty() {
             return Ok(0);
         }

--- a/crates/transport/src/session/tests.rs
+++ b/crates/transport/src/session/tests.rs
@@ -718,7 +718,7 @@ fn session_reports_clamped_binary_future_version() {
     assert!(!handshake.local_protocol_was_capped());
     assert_eq!(
         handshake.remote_advertisement(),
-        RemoteProtocolAdvertisement::Future(future_version)
+        RemoteProtocolAdvertisement::from_raw(future_version, ProtocolVersion::NEWEST)
     );
 
     let parts = handshake.into_stream_parts();
@@ -729,7 +729,7 @@ fn session_reports_clamped_binary_future_version() {
     assert!(!parts.local_protocol_was_capped());
     assert_eq!(
         parts.remote_advertisement(),
-        RemoteProtocolAdvertisement::Future(future_version)
+        RemoteProtocolAdvertisement::from_raw(future_version, ProtocolVersion::NEWEST)
     );
 }
 


### PR DESCRIPTION
## Summary
- retain the upstream-clamped protocol in `RemoteProtocolAdvertisement` so consumers can inspect the negotiated version even when the peer advertised a future release
- clarify documentation examples to use the public struct variant and adjust doctests accordingly
- update transport unit tests to assert against the new classification helper

## Testing
- cargo test

------