### PR TITLE
Track client protocol advertisement in binary handshake

### DIFF
--- a/crates/transport/src/daemon.rs
+++ b/crates/transport/src/daemon.rs
@@ -202,6 +202,17 @@ impl<R> LegacyDaemonHandshakeParts<R> {
         self.negotiated_protocol
     }
 
+    /// Returns the protocol version the client advertised to the daemon.
+    ///
+    /// For the legacy handshake the client echoes the final negotiated protocol back to the server, so
+    /// the value mirrors [`Self::negotiated_protocol`] but is exposed explicitly to keep the API shape
+    /// aligned with the binary negotiation helpers.
+    #[doc(alias = "--protocol")]
+    #[must_use]
+    pub const fn local_advertised_protocol(&self) -> ProtocolVersion {
+        self.negotiated_protocol
+    }
+
     /// Reports whether the daemon advertised a protocol newer than the supported range.
     ///
     /// The helper mirrors [`LegacyDaemonHandshake::remote_protocol_was_clamped`] so callers that
@@ -538,6 +549,17 @@ impl<R> LegacyDaemonHandshake<R> {
     /// Returns the negotiated protocol version after applying the caller's cap.
     #[must_use]
     pub const fn negotiated_protocol(&self) -> ProtocolVersion {
+        self.negotiated_protocol
+    }
+
+    /// Returns the protocol version the client advertised to the daemon.
+    ///
+    /// For the legacy exchange the client echoes the final negotiated protocol back to the server, so
+    /// this value mirrors [`Self::negotiated_protocol`] while exposing the same API surface as the
+    /// binary handshake helpers that track the client's advertisement explicitly.
+    #[doc(alias = "--protocol")]
+    #[must_use]
+    pub const fn local_advertised_protocol(&self) -> ProtocolVersion {
         self.negotiated_protocol
     }
 

--- a/crates/transport/src/session/handshake.rs
+++ b/crates/transport/src/session/handshake.rs
@@ -93,6 +93,16 @@ impl<R> SessionHandshake<R> {
         }
     }
 
+    /// Returns the protocol version advertised by the local peer before the negotiation settled.
+    #[doc(alias = "--protocol")]
+    #[must_use]
+    pub fn local_advertised_protocol(&self) -> ProtocolVersion {
+        match self {
+            Self::Binary(handshake) => handshake.local_advertised_protocol(),
+            Self::Legacy(handshake) => handshake.local_advertised_protocol(),
+        }
+    }
+
     /// Returns the classification of the peer's protocol advertisement.
     #[must_use]
     pub fn remote_advertisement(&self) -> RemoteProtocolAdvertisement {

--- a/crates/transport/src/session/parts.rs
+++ b/crates/transport/src/session/parts.rs
@@ -85,6 +85,16 @@ impl<R> SessionHandshakeParts<R> {
         }
     }
 
+    /// Returns the protocol version advertised by the local peer before the negotiation settled.
+    #[doc(alias = "--protocol")]
+    #[must_use]
+    pub fn local_advertised_protocol(&self) -> ProtocolVersion {
+        match self {
+            SessionHandshakeParts::Binary(parts) => parts.local_advertised_protocol(),
+            SessionHandshakeParts::Legacy(parts) => parts.local_advertised_protocol(),
+        }
+    }
+
     /// Returns the classification of the peer's protocol advertisement.
     #[must_use]
     pub fn remote_advertisement(&self) -> RemoteProtocolAdvertisement {
@@ -247,15 +257,22 @@ impl<R> SessionHandshakeParts<R> {
             u32,
             ProtocolVersion,
             ProtocolVersion,
+            ProtocolVersion,
             NegotiatedStreamParts<R>,
         ),
         SessionHandshakeParts<R>,
     > {
         match self {
             SessionHandshakeParts::Binary(parts) => {
-                let (remote_advertised, remote_protocol, negotiated, stream) =
+                let (remote_advertised, remote_protocol, local_advertised, negotiated, stream) =
                     parts.into_components();
-                Ok((remote_advertised, remote_protocol, negotiated, stream))
+                Ok((
+                    remote_advertised,
+                    remote_protocol,
+                    local_advertised,
+                    negotiated,
+                    stream,
+                ))
             }
             SessionHandshakeParts::Legacy(parts) => Err(SessionHandshakeParts::Legacy(parts)),
         }


### PR DESCRIPTION
## Summary
- record the client-advertised protocol in the binary handshake metadata and expose a `local_advertised_protocol` accessor that survives conversions
- add matching helpers for the legacy daemon handshake and surface the value through the session wrappers
- extend the binary/session tests to assert the newly tracked advertisement information

## Testing
- cargo test

------