### PR TITLE
Add canonical legacy daemon message rendering helpers

### DIFF
--- a/crates/protocol/src/legacy/mod.rs
+++ b/crates/protocol/src/legacy/mod.rs
@@ -32,14 +32,16 @@ pub use bytes::{
 };
 #[allow(unused_imports)]
 pub use greeting::write_legacy_daemon_greeting;
+#[allow(unused_imports)]
 pub use greeting::{
     DigestListTokens, LegacyDaemonGreeting, LegacyDaemonGreetingOwned,
     format_legacy_daemon_greeting, parse_legacy_daemon_greeting,
     parse_legacy_daemon_greeting_details, parse_legacy_daemon_greeting_owned,
 };
+#[allow(unused_imports)]
 pub use lines::{
-    LegacyDaemonMessage, parse_legacy_daemon_message, parse_legacy_error_message,
-    parse_legacy_warning_message,
+    LegacyDaemonMessage, format_legacy_daemon_message, parse_legacy_daemon_message,
+    parse_legacy_error_message, parse_legacy_warning_message, write_legacy_daemon_message,
 };
 
 pub(super) fn malformed_legacy_greeting(trimmed: &str) -> NegotiationError {

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -141,13 +141,13 @@ pub use error::NegotiationError;
 pub use legacy::{
     DigestListTokens, LEGACY_DAEMON_PREFIX, LEGACY_DAEMON_PREFIX_BYTES, LEGACY_DAEMON_PREFIX_LEN,
     LegacyDaemonGreeting, LegacyDaemonGreetingOwned, LegacyDaemonMessage,
-    format_legacy_daemon_greeting, parse_legacy_daemon_greeting,
+    format_legacy_daemon_greeting, format_legacy_daemon_message, parse_legacy_daemon_greeting,
     parse_legacy_daemon_greeting_bytes, parse_legacy_daemon_greeting_bytes_details,
     parse_legacy_daemon_greeting_bytes_owned, parse_legacy_daemon_greeting_details,
     parse_legacy_daemon_greeting_owned, parse_legacy_daemon_message,
     parse_legacy_daemon_message_bytes, parse_legacy_error_message,
     parse_legacy_error_message_bytes, parse_legacy_warning_message,
-    parse_legacy_warning_message_bytes, write_legacy_daemon_greeting,
+    parse_legacy_warning_message_bytes, write_legacy_daemon_greeting, write_legacy_daemon_message,
 };
 pub use multiplex::{
     BorrowedMessageFrame, BorrowedMessageFrames, MessageFrame, recv_msg, recv_msg_into, send_frame,


### PR DESCRIPTION
## Summary
- add `write_legacy_daemon_message` and `format_legacy_daemon_message` to render canonical `@RSYNCD:` responses with whitespace normalization
- extend the legacy message test suite to cover canonical formatting for each variant
- re-export the new helpers from the legacy module and crate root for downstream consumers

## Testing
- cargo test

------