### PR TITLE
Add copy_to_slice helper for negotiation buffered slices

### DIFF
--- a/crates/transport/src/lib.rs
+++ b/crates/transport/src/lib.rs
@@ -78,8 +78,8 @@ pub use daemon::{
 };
 pub use handshake_util::{RemoteProtocolAdvertisement, local_cap_reduced_protocol};
 pub use negotiation::{
-    BufferedCopyTooSmall, NegotiatedStream, NegotiatedStreamParts, TryMapInnerError,
-    sniff_negotiation_stream, sniff_negotiation_stream_with_sniffer,
+    BufferedCopyTooSmall, CopyToSliceError, NegotiatedStream, NegotiatedStreamParts,
+    TryMapInnerError, sniff_negotiation_stream, sniff_negotiation_stream_with_sniffer,
 };
 pub use session::{
     SessionHandshake, SessionHandshakeParts, negotiate_session, negotiate_session_from_stream,


### PR DESCRIPTION
## Summary
- add `NegotiationBufferedSlices::copy_to_slice` for efficient replay into caller-managed buffers
- expose the associated `CopyToSliceError` and expand tests to cover copying success, underflow, and empty transcripts
- re-export `CopyToSliceError` from `rsync_transport` so doctests and downstream crates can use the new helper

## Testing
- `cargo test -p rsync-transport`

## Red → Green
- Red → Green count: 0
- Affected goldens: N/A

------