### PR TITLE
Add helper for canonical exit-code messages

### DIFF
--- a/crates/core/src/message/strings.rs
+++ b/crates/core/src/message/strings.rs
@@ -78,6 +78,7 @@
 //! # See also
 //!
 //! - [`crate::message`] for the `Message` type used to render the output.
+//! - [`crate::message::Message::from_exit_code`] builds the canonical diagnostic directly.
 
 use super::{Message, Severity};
 


### PR DESCRIPTION
## Summary
- add `Message::from_exit_code` to construct canonical diagnostics for known rsync exit codes
- extend message tests and rustdoc to cover the new helper and cross-reference it from the exit-code string table

## Testing
- cargo test

------