### PR TITLE
Fix MessageSegments reserve calculation

### DIFF
--- a/crates/core/src/message.rs
+++ b/crates/core/src/message.rs
@@ -545,8 +545,12 @@ impl<'a> MessageSegments<'a> {
         let spare = buffer.capacity().saturating_sub(buffer.len());
         if spare < required {
             buffer
-                .try_reserve_exact(required - spare)
+                .try_reserve_exact(required)
                 .map_err(map_message_reserve_error)?;
+            debug_assert!(
+                buffer.capacity().saturating_sub(buffer.len()) >= required,
+                "MessageSegments::extend_vec must reserve enough capacity for the entire message",
+            );
         }
 
         let start = buffer.len();


### PR DESCRIPTION
## Summary
- ensure `MessageSegments::extend_vec` reserves capacity for the entire rendered message before appending
- add a debug assertion that captures the reservation invariant during development builds

## Testing
- `cargo test`

------