### PR TITLE
Optimize MessageSegments buffer reservation

### DIFF
--- a/crates/core/src/message.rs
+++ b/crates/core/src/message.rs
@@ -544,8 +544,9 @@ impl<'a> MessageSegments<'a> {
         let required = self.len();
         let spare = buffer.capacity().saturating_sub(buffer.len());
         if spare < required {
+            let additional = required - spare;
             buffer
-                .try_reserve_exact(required)
+                .try_reserve_exact(additional)
                 .map_err(map_message_reserve_error)?;
             debug_assert!(
                 buffer.capacity().saturating_sub(buffer.len()) >= required,


### PR DESCRIPTION
## Summary
- ensure MessageSegments::extend_vec only reserves the additional capacity actually required

## Testing
- cargo test -p rsync-core

## Red → Green count
- 0 (maintenance efficiency improvement)

## Upstream parity rationale
- Matches upstream behaviour while reducing excess allocator growth; no user-visible changes

------