### PR TITLE
Guard binary negotiation threshold against oldest protocol

### DIFF
--- a/crates/protocol/src/version.rs
+++ b/crates/protocol/src/version.rs
@@ -388,6 +388,10 @@ const _: () = {
         "binary negotiation threshold must classify as binary",
     );
     assert!(
+        binary_intro > ProtocolVersion::OLDEST.as_u8(),
+        "binary negotiation threshold must exceed oldest supported version",
+    );
+    assert!(
         ProtocolVersion::new_const(binary_intro - 1).uses_legacy_ascii_negotiation(),
         "protocol immediately preceding binary threshold must use legacy negotiation",
     );

--- a/crates/protocol/src/version/tests.rs
+++ b/crates/protocol/src/version/tests.rs
@@ -1201,6 +1201,21 @@ fn binary_negotiation_threshold_matches_protocol_30() {
 }
 
 #[test]
+fn binary_negotiation_threshold_exceeds_oldest_supported_version() {
+    let threshold = ProtocolVersion::BINARY_NEGOTIATION_INTRODUCED.as_u8();
+    let oldest = ProtocolVersion::OLDEST.as_u8();
+
+    assert!(
+        threshold > oldest,
+        "binary negotiation threshold must be newer than the oldest supported protocol",
+    );
+
+    let preceding = ProtocolVersion::from_supported(threshold - 1)
+        .expect("protocol immediately preceding the binary threshold is supported");
+    assert!(preceding.uses_legacy_ascii_negotiation());
+}
+
+#[test]
 fn negotiation_style_helpers_match_protocol_cutoff() {
     for version in ProtocolVersion::supported_versions() {
         if version.as_u8() >= ProtocolVersion::BINARY_NEGOTIATION_INTRODUCED.as_u8() {


### PR DESCRIPTION
## Summary
- add a compile-time guard that ensures the binary negotiation threshold is newer than the oldest supported protocol
- cover the invariant with a dedicated unit test that also verifies the legacy negotiation behavior of the preceding version

## Testing
- cargo test -p rsync-protocol

------