### PR TITLE
Add version info report for --version output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,6 +278,7 @@ dependencies = [
 name = "rsync-core"
 version = "0.0.0"
 dependencies = [
+ "libc",
  "rsync-protocol",
 ]
 

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -10,6 +10,7 @@ build = "build.rs"
 
 [dependencies]
 rsync-protocol = { path = "../protocol" }
+libc = "0.2"
 
 [features]
 default = []


### PR DESCRIPTION
## Summary
- add a `VersionInfoReport` facade that renders the complete `--version` text with upstream-compatible wrapping
- provide configuration and helper structures for capability toggles and algorithm lists
- cover the new behaviour with unit tests and pull in libc for platform bit-width detection

## Testing
- cargo test

------