### PR TITLE
Add rsync_exit_code macro for exit code diagnostics

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -53,6 +53,9 @@
 //!
 //! - [`rsync_core::message::strings`] exposes upstream-aligned exit-code wording
 //!   so higher layers render identical diagnostics.
+//! - [`rsync_exit_code!`] constructs canonical exit-code diagnostics while recording
+//!   the caller's source location, keeping message provenance consistent across the
+//!   workspace.
 //! - [`rsync_protocol`] for the negotiation helpers that feed protocol numbers
 //!   into user-facing diagnostics.
 //! - [`rsync_transport`] for replaying transport wrappers that emit these


### PR DESCRIPTION
## Summary
- add an `rsync_exit_code!` macro that wraps `Message::from_exit_code` and records the caller location
- extend the core message test suite with coverage for the new macro and track-caller behaviour
- document the macro in the crate overview so downstream users can discover it

## Testing
- cargo test

------