### PR TITLE
Fix compatibility decoder clippy lint

### DIFF
--- a/crates/protocol/src/compatibility.rs
+++ b/crates/protocol/src/compatibility.rs
@@ -553,7 +553,7 @@ impl CompatibilityFlags {
     /// assert_eq!(slice, &[0x7F]);
     /// ```
     pub fn decode_from_slice_mut(bytes: &mut &[u8]) -> io::Result<Self> {
-        match Self::decode_from_slice(*bytes) {
+        match Self::decode_from_slice(bytes) {
             Ok((flags, remainder)) => {
                 *bytes = remainder;
                 Ok(flags)


### PR DESCRIPTION
## Summary
- let `CompatibilityFlags::decode_from_slice_mut` rely on auto-deref so clippy no longer reports `explicit_auto_deref`
- keeps the protocol crate clean under `cargo clippy`

## Testing
- cargo clippy
- cargo test -p rsync-protocol compatibility::tests::decode_from_slice_mut_advances_input_on_success

------