### PR TITLE
Simplify thread-local scratch reuse and fix clippy warnings

### DIFF
--- a/crates/protocol/src/compatibility.rs
+++ b/crates/protocol/src/compatibility.rs
@@ -761,8 +761,8 @@ mod tests {
         encoded.extend_from_slice(&[0x42]);
         let mut slice: &[u8] = &encoded;
 
-        let decoded = CompatibilityFlags::decode_from_slice_mut(&mut slice)
-            .expect("decoding should succeed");
+        let decoded =
+            CompatibilityFlags::decode_from_slice_mut(&mut slice).expect("decoding should succeed");
 
         assert_eq!(decoded, flags);
         assert_eq!(slice, &[0x42]);


### PR DESCRIPTION
## Summary
- collapse nested conditionals in `with_thread_local_scratch` to avoid redundant RefCell plumbing and reuse the thread-local buffer more directly
- tighten a unit test assertion to use `is_empty` instead of a manual length comparison to satisfy lint expectations
- reformat a protocol compatibility test after `cargo fmt`

## Testing
- cargo clippy --all-targets
- cargo test

------