### PR TITLE
Fix intra-doc link in rsync_meta documentation

### DIFF
--- a/crates/meta/src/lib.rs
+++ b/crates/meta/src/lib.rs
@@ -60,8 +60,7 @@
 //!
 //! # See also
 //!
-//! - [`rsync_core::client`] integrates these helpers for local filesystem
-//!   copies.
+//! - The core client integrates these helpers for local filesystem copies.
 //! - [`filetime`] for lower-level timestamp manipulation utilities.
 
 use std::fmt;


### PR DESCRIPTION
## Summary
- update the rsync_meta crate-level documentation to avoid an unresolved link to rsync_core

## Testing
- cargo doc -p rsync-meta

------