### PR TITLE
Integrate MessageSink into CLI and daemon diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -414,6 +414,7 @@ version = "0.0.0"
 dependencies = [
  "clap",
  "rsync-core",
+ "rsync-logging",
  "tempfile",
 ]
 
@@ -436,6 +437,7 @@ version = "0.0.0"
 dependencies = [
  "clap",
  "rsync-core",
+ "rsync-logging",
  "rsync-protocol",
 ]
 

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -9,6 +9,7 @@ license.workspace = true
 [dependencies]
 clap = { version = "4.5.17", features = ["std"] }
 rsync-core = { path = "../core" }
+rsync-logging = { path = "../logging" }
 
 [dev-dependencies]
 tempfile = "3.10"

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -11,3 +11,4 @@ publish = false
 clap = { version = "4.5.49", features = ["std"] }
 rsync-core = { path = "../core" }
 rsync-protocol = { path = "../protocol" }
+rsync-logging = { path = "../logging" }


### PR DESCRIPTION
## Summary
- integrate `rsync_logging::MessageSink` into the CLI so stderr diagnostics reuse the shared logging infrastructure
- wire the daemon CLI through `MessageSink` and add the logging crate as a dependency in both binaries

## Testing
- cargo test

------