### PR TITLE
Brand version banner and embed git build metadata

### DIFF
--- a/crates/core/build.rs
+++ b/crates/core/build.rs
@@ -1,44 +1,79 @@
 use std::env;
-use std::fs;
 use std::path::{Path, PathBuf};
-
-fn canonicalize_or_fallback(path: PathBuf) -> PathBuf {
-    match fs::canonicalize(&path) {
-        Ok(resolved) => resolved,
-        Err(_) => path,
-    }
-}
-
-fn workspace_root(manifest_dir: &Path) -> PathBuf {
-    if let Some(workspace_dir) = env::var_os("CARGO_WORKSPACE_DIR") {
-        let mut candidate: PathBuf = workspace_dir.into();
-        if !candidate.is_absolute() {
-            candidate = manifest_dir.join(candidate);
-        }
-
-        if candidate.is_dir() {
-            return canonicalize_or_fallback(candidate);
-        }
-    }
-
-    for ancestor in manifest_dir.ancestors() {
-        let candidate = ancestor.join("Cargo.lock");
-        if candidate.is_file() {
-            return canonicalize_or_fallback(ancestor.to_path_buf());
-        }
-    }
-
-    canonicalize_or_fallback(manifest_dir.to_path_buf())
-}
+use std::process::Command;
 
 fn main() {
+    let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR"));
+
     println!("cargo:rerun-if-env-changed=CARGO_WORKSPACE_DIR");
     println!("cargo:rerun-if-env-changed=CARGO_MANIFEST_DIR");
+    println!("cargo:rerun-if-env-changed=OC_RSYNC_BUILD_OVERRIDE");
 
-    let manifest_dir =
-        env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR is always set by Cargo");
-    let manifest_dir = PathBuf::from(manifest_dir);
-    let root = workspace_root(&manifest_dir);
+    if let Some(git_dir) = git_directory(&manifest_dir) {
+        emit_rerun_if_exists(&git_dir.join("HEAD"));
+        emit_rerun_if_exists(&git_dir.join("refs/heads"));
+        emit_rerun_if_exists(&git_dir.join("refs/remotes"));
+        emit_rerun_if_exists(&git_dir.join("packed-refs"));
+    }
 
-    println!("cargo:rustc-env=RSYNC_WORKSPACE_ROOT={}", root.display());
+    let workspace_root = workspace_root(&manifest_dir).unwrap_or_else(|| manifest_dir.clone());
+    println!(
+        "cargo:rustc-env=RSYNC_WORKSPACE_ROOT={}",
+        workspace_root.display()
+    );
+
+    let build_id = env::var("OC_RSYNC_BUILD_OVERRIDE")
+        .ok()
+        .map(|value| value.trim().to_owned())
+        .filter(|value| !value.is_empty())
+        .or_else(|| git_revision(&manifest_dir))
+        .unwrap_or_else(|| "unknown".to_owned());
+
+    println!("cargo:rustc-env=OC_RSYNC_BUILD_REV={build_id}");
+}
+
+fn git_revision(manifest_dir: &Path) -> Option<String> {
+    run_git(manifest_dir, &["rev-parse", "--short", "HEAD"])
+}
+
+fn git_directory(manifest_dir: &Path) -> Option<PathBuf> {
+    run_git(manifest_dir, &["rev-parse", "--git-dir"]).map(|output| {
+        let path = PathBuf::from(output);
+        if path.is_relative() {
+            manifest_dir.join(path)
+        } else {
+            path
+        }
+    })
+}
+
+fn workspace_root(manifest_dir: &Path) -> Option<PathBuf> {
+    run_git(manifest_dir, &["rev-parse", "--show-toplevel"]).map(PathBuf::from)
+}
+
+fn run_git(manifest_dir: &Path, args: &[&str]) -> Option<String> {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(manifest_dir)
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let text = String::from_utf8(output.stdout).ok()?;
+    let trimmed = text.trim();
+
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_owned())
+    }
+}
+
+fn emit_rerun_if_exists(path: &Path) {
+    if path.exists() {
+        println!("cargo:rerun-if-changed={}", path.display());
+    }
 }


### PR DESCRIPTION
## Summary
- derive the workspace root and git revision during build to expose RSYNC_WORKSPACE_ROOT and OC_RSYNC_BUILD_REV for downstream consumers
- rebrand the version metadata for oc-rsync, emit the git build number in the banner, and update the build-info section and tests accordingly

## Testing
- cargo test

------