### PR TITLE
Align oc-rsync branding and metadata

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ pub fn main() -> ExitCode {
 
 ---
 
-### 2) Daemon (rsyncd)
+### 2) Daemon (oc-rsyncd)
 
 * **Binary**: `bin/oc-rsyncd`
 * **Depends on**: `daemon`, `core`, `transport`, `logging`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,5 +18,5 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 rust-version = "1.85"
-authors = ["rsync rust port contributors"]
+authors = ["Ofer Chen"]
 license = "GPL-3.0-or-later"

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
-# rsync (Rust reimplementation)
+# oc-rsync (Rust reimplementation of rsync 3.4.1)
 
 This workspace hosts a from-scratch Rust port of rsync 3.4.1 (protocol 32)
-with the long-term goal of matching upstream behaviour byte-for-byte. The
-project follows the requirements outlined in the repository's Codex Mission
-Brief and implements modules as cohesive crates so both the future CLI and
-rsync daemon reuse the same core logic.
+branded as **oc-rsync**. The long-term goal is byte-for-byte parity with the
+original tool while modernising the implementation in Rust. The project follows
+the requirements outlined in the repository's Codex Mission Brief and
+implements modules as cohesive crates so both the `oc-rsync` CLI and the
+`oc-rsyncd` daemon reuse the same core logic.
 
 ## Repository layout
 

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -4,7 +4,7 @@
 
 //! # Overview
 //!
-//! `rsync_cli` implements the thin command-line front-end for the Rust `rsync`
+//! `rsync_cli` implements the thin command-line front-end for the Rust `oc-rsync`
 //! workspace. The crate is intentionally small: it recognises the subset of
 //! command-line switches that are currently supported (`--help`/`-h`,
 //! `--version`/`-V`, and `--dry-run`/`-n`) and delegates local copy operations to

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rsync-core"
 version = "0.0.0"
 edition = "2024"
-authors = ["rsync rust port contributors"]
+authors = ["Ofer Chen"]
 license = "GPL-3.0-or-later"
 description = "Core utilities shared by the Rust rsync implementation"
 repository = "https://github.com/oferchen/rsync"

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -4,7 +4,7 @@
 
 //! # Overview
 //!
-//! `rsync_daemon` provides the thin command-line front-end for the Rust `rsyncd`
+//! `rsync_daemon` provides the thin command-line front-end for the Rust `oc-rsyncd`
 //! binary. The crate now exposes a deterministic daemon loop capable of
 //! accepting sequential legacy (`@RSYNCD:`) TCP connections, greeting each peer
 //! with protocol `32`, serving `#list` requests from an in-memory module table,

--- a/crates/meta/Cargo.toml
+++ b/crates/meta/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rsync-meta"
 version = "0.0.0"
 edition = "2024"
-authors = ["rsync rust port contributors"]
+authors = ["Ofer Chen"]
 license = "GPL-3.0-or-later"
 description = "Metadata preservation helpers for the Rust rsync implementation"
 repository = "https://github.com/oferchen/rsync"

--- a/crates/protocol/src/version.rs
+++ b/crates/protocol/src/version.rs
@@ -114,8 +114,8 @@ impl std::error::Error for ParseProtocolVersionError {}
 
 /// A single negotiated rsync protocol version.
 ///
-/// The value typically originates from the [`--protocol`](https://download.samba.org/pub/rsync/rsync.1#opt--protocol)
-/// command-line flag or the protocol byte exchanged during the initial
+/// The value typically originates from the `--protocol` command-line flag or the
+/// protocol byte exchanged during the initial
 /// handshake.
 ///
 /// # Examples

--- a/crates/walk/Cargo.toml
+++ b/crates/walk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rsync-walk"
 version = "0.0.0"
 edition = "2024"
-authors = ["rsync rust port contributors"]
+authors = ["Ofer Chen"]
 license = "GPL-3.0-or-later"
 description = "Deterministic filesystem walker for the Rust rsync implementation"
 repository = "https://github.com/oferchen/rsync"

--- a/docs/differences.md
+++ b/docs/differences.md
@@ -19,7 +19,7 @@ referenced functionality ships and parity is verified by tests or goldens.
     comprehensive metadata handling, and validate the resulting behaviour via
     the parity harness.
 - **Daemon functionality incomplete**
-  - *Impact*: The `rsyncd` binary binds a TCP listener, performs the legacy
+  - *Impact*: The `oc-rsyncd` binary binds a TCP listener, performs the legacy
     `@RSYNCD:` handshake, and lists modules defined via `--module` arguments or
     a subset of `rsyncd.conf` supplied through `--config` before explaining that
     transfers are unavailable. Authentication, authorization, real module

--- a/docs/production_scope_p1.md
+++ b/docs/production_scope_p1.md
@@ -72,7 +72,7 @@ This document freezes the mandatory scope that must reach green status before th
 ## Packaging & Artifacts
 - Debian package via `cargo-deb`
 - RPM package via `cargo-rpm`
-- Systemd `rsyncd.service` unit
+- Systemd `oc-rsyncd.service` unit
 - CycloneDX SBOM at `target/sbom/rsync.cdx.json`
 
 ## Deterministic Test Environment


### PR DESCRIPTION
## Summary
- update repository docs to consistently refer to the oc-rsync and oc-rsyncd binaries and adjust packaging references
- set workspace crate authorship to Ofer Chen and remove the external samba.org link from protocol documentation

## Testing
- cargo test

------