### PR TITLE
Align version banners with binary names

### DIFF
--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -955,7 +955,8 @@ where
     }
 
     if parsed.show_version && parsed.remainder.is_empty() {
-        let report = VersionInfoReport::default();
+        let report = VersionInfoReport::default()
+            .with_program_name(rsync_core::version::DAEMON_PROGRAM_NAME);
         let banner = report.human_readable();
         if stdout.write_all(banner.as_bytes()).is_err() {
             return 1;
@@ -1281,7 +1282,9 @@ mod tests {
         assert_eq!(code, 0);
         assert!(stderr.is_empty());
 
-        let expected = VersionInfoReport::default().human_readable();
+        let expected = VersionInfoReport::default()
+            .with_program_name(rsync_core::version::DAEMON_PROGRAM_NAME)
+            .human_readable();
         assert_eq!(stdout, expected.into_bytes());
     }
 


### PR DESCRIPTION
## Summary
- extend the core version helpers so reports carry explicit version metadata and allow overriding the program name
- update the daemon frontend to render `oc-rsyncd` in its banner and adjust expectations to match
- add unit coverage for the new metadata helpers to keep documentation and doctests in sync

## Testing
- `cargo test`

Red → Green: 0 → 0 (no golden updates required)

------