### PR TITLE
Refresh existing directory metadata during local copies

### DIFF
--- a/crates/core/src/client.rs
+++ b/crates/core/src/client.rs
@@ -443,6 +443,54 @@ mod tests {
         assert_eq!(dest_mtime, mtime);
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn run_client_updates_existing_directory_metadata() {
+        use filetime::{FileTime, set_file_times};
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = tempdir().expect("tempdir");
+        let source_dir = tmp.path().join("source-tree");
+        let source_nested = source_dir.join("nested");
+        fs::create_dir_all(&source_nested).expect("create source tree");
+
+        let source_mode = 0o745;
+        fs::set_permissions(&source_nested, PermissionsExt::from_mode(source_mode))
+            .expect("set source nested permissions");
+        let source_atime = FileTime::from_unix_time(1_700_030_000, 1_000_000);
+        let source_mtime = FileTime::from_unix_time(1_700_040_000, 2_000_000);
+        set_file_times(&source_nested, source_atime, source_mtime)
+            .expect("set source nested timestamps");
+
+        let dest_root = tmp.path().join("dest-root");
+        fs::create_dir(&dest_root).expect("create dest root");
+        let dest_dir = dest_root.join("source-tree");
+        let dest_nested = dest_dir.join("nested");
+        fs::create_dir_all(&dest_nested).expect("pre-create destination tree");
+
+        let dest_mode = 0o711;
+        fs::set_permissions(&dest_nested, PermissionsExt::from_mode(dest_mode))
+            .expect("set dest nested permissions");
+        let dest_atime = FileTime::from_unix_time(1_600_000_000, 0);
+        let dest_mtime = FileTime::from_unix_time(1_600_100_000, 0);
+        set_file_times(&dest_nested, dest_atime, dest_mtime).expect("set dest nested timestamps");
+
+        let config = ClientConfig::builder()
+            .transfer_args([source_dir.clone(), dest_root.clone()])
+            .build();
+
+        run_client(config).expect("directory copy succeeds");
+
+        let copied_nested = dest_root.join("source-tree").join("nested");
+        let copied_metadata = fs::metadata(&copied_nested).expect("dest metadata");
+        assert!(copied_metadata.is_dir());
+        assert_eq!(copied_metadata.permissions().mode() & 0o777, source_mode);
+        let copied_atime = FileTime::from_last_access_time(&copied_metadata);
+        let copied_mtime = FileTime::from_last_modification_time(&copied_metadata);
+        assert_eq!(copied_atime, source_atime);
+        assert_eq!(copied_mtime, source_mtime);
+    }
+
     #[test]
     fn run_client_merges_directory_contents_when_trailing_separator_present() {
         let tmp = tempdir().expect("tempdir");

--- a/crates/engine/src/local_copy.rs
+++ b/crates/engine/src/local_copy.rs
@@ -530,8 +530,6 @@ fn copy_directory_recursive(
     metadata: &fs::Metadata,
     mode: LocalCopyExecution,
 ) -> Result<(), LocalCopyError> {
-    let mut destination_preexisted = false;
-
     match fs::symlink_metadata(destination) {
         Ok(existing) => {
             if !existing.file_type().is_dir() {
@@ -539,7 +537,6 @@ fn copy_directory_recursive(
                     LocalCopyArgumentError::ReplaceNonDirectoryWithDirectory,
                 ));
             }
-            destination_preexisted = true;
         }
         Err(error) if error.kind() == io::ErrorKind::NotFound => {
             if !mode.is_dry_run() {
@@ -581,7 +578,7 @@ fn copy_directory_recursive(
         }
     }
 
-    if !destination_preexisted && !mode.is_dry_run() {
+    if !mode.is_dry_run() {
         apply_directory_metadata(destination, metadata).map_err(map_metadata_error)?;
     }
 


### PR DESCRIPTION
## Summary
- ensure local copy execution reapplies metadata to destination directories even when they pre-exist
- add regression coverage for directory metadata refresh when syncing into an existing tree

## Testing
- cargo test

------