### PR TITLE
Handle hard link failures by falling back to regular copies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -453,6 +453,7 @@ name = "rsync-engine"
 version = "0.0.0"
 dependencies = [
  "filetime",
+ "libc",
  "rsync-meta",
  "rustix 0.38.44",
  "tempfile",

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -11,6 +11,9 @@ repository = "https://github.com/oferchen/rsync"
 [dependencies]
 rsync-meta = { path = "../meta" }
 
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
 [dev-dependencies]
 filetime = "0.2"
 tempfile = "3.10"


### PR DESCRIPTION
## Summary
- allow local copy to fall back to a regular copy when hard-link creation fails for unsupported scenarios
- add a helper to recognize platform-specific hard-link errors and cover it with tests
- depend on libc on Unix so errno values can be inspected during fallback decisions

## Testing
- cargo test -p rsync-engine fallback_to_regular_copy

------