### PR TITLE
Ensure metadata-preservation tests opt into new toggles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,6 +419,7 @@ name = "rsync-cli"
 version = "0.0.0"
 dependencies = [
  "clap",
+ "filetime",
  "rsync-core",
  "rsync-logging",
  "tempfile",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -12,4 +12,5 @@ rsync-core = { path = "../core" }
 rsync-logging = { path = "../logging" }
 
 [dev-dependencies]
+filetime = "0.2"
 tempfile = "3.10"


### PR DESCRIPTION
## Summary
- update client metadata tests to enable the new permissions/times builder toggles and verify source attributes before transfer
- adjust local copy FIFO tests to opt into metadata preservation options and assert source metadata state prior to execution

## Testing
- cargo test

------