### PR TITLE
Add numeric-id aware metadata preservation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -535,6 +535,7 @@ name = "rsync-meta"
 version = "0.0.0"
 dependencies = [
  "filetime",
+ "libc",
  "rustix 0.38.44",
  "tempfile",
 ]

--- a/crates/core/src/client.rs
+++ b/crates/core/src/client.rs
@@ -468,7 +468,8 @@ pub fn run_client(config: ClientConfig) -> Result<(), ClientError> {
         .group(config.preserve_group())
         .permissions(config.preserve_permissions())
         .times(config.preserve_times())
-        .filters(filter_set);
+        .filters(filter_set)
+        .numeric_ids(config.numeric_ids());
     let mode = if config.dry_run() {
         LocalCopyExecution::DryRun
     } else {

--- a/crates/meta/Cargo.toml
+++ b/crates/meta/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/oferchen/rsync"
 [dependencies]
 filetime = "0.2"
 rustix = { version = "0.38", features = ["fs", "process"] }
+libc = "0.2"
 
 [dev-dependencies]
 tempfile = "3.10"


### PR DESCRIPTION
## Summary
- add numeric-id aware preservation controls to rsync_meta::MetadataOptions and implement safe libc-backed UID/GID remapping helpers
- propagate the numeric-id flag through the local copy pipeline so LocalCopyOptions and CopyContext request numeric handling when configured
- extend tests to cover numeric-id propagation and UID/GID remapping behaviour

## Testing
- cargo test

------