### PR TITLE
Address review feedback for extraneous entry filtering

### DIFF
--- a/crates/engine/src/local_copy.rs
+++ b/crates/engine/src/local_copy.rs
@@ -1391,8 +1391,6 @@ fn delete_extraneous_entries(
             if !filters.allows(entry_relative.as_path(), file_type.is_dir()) {
                 continue;
             }
-
-            entry_relative = Some(relative_path);
         }
 
         if mode.is_dry_run() {


### PR DESCRIPTION
## Summary
- remove the invalid reassignment of `entry_relative` now that it stores a `PathBuf`

## Testing
- cargo test

------