### PR TITLE
Wire CLI progress output to client event reporting

### DIFF
--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -69,5 +69,6 @@
 pub mod local_copy;
 
 pub use local_copy::{
-    LocalCopyArgumentError, LocalCopyError, LocalCopyErrorKind, LocalCopyOptions, LocalCopyPlan,
+    LocalCopyAction, LocalCopyArgumentError, LocalCopyError, LocalCopyErrorKind, LocalCopyOptions,
+    LocalCopyPlan, LocalCopyRecord, LocalCopyReport,
 };


### PR DESCRIPTION
## Summary
- add event collection hooks to the local copy engine and expose records through ClientSummary
- teach the CLI to emit verbose and progress output using the collected events and handle new flags
- extend tests to cover verbose/progress scenarios and ensure partial copies commit correctly

## Testing
- cargo test

------