### PR TITLE
Add client summary events and CLI reporting

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -777,7 +777,12 @@ where
 
     match run_core_client(config) {
         Ok(summary) => {
-            let _ = summary;
+            if let Err(error) = emit_transfer_summary(&summary, verbosity, progress, stdout) {
+                let _ = writeln!(
+                    stdout,
+                    "warning: failed to render transfer summary: {error}"
+                );
+            }
             0
         }
         Err(error) => {


### PR DESCRIPTION
## Summary
- extend the local copy engine to track transfer events and expose a `LocalCopyReport`
- return a richer `ClientSummary` with transfer counts and events, enabling progress/verbose output
- emit CLI transfer summaries using the recorded events when verbosity or progress is requested

## Testing
- `cargo test`

------