### PR TITLE
Fix local copy outcome conversion and report plumbing

### DIFF
--- a/crates/core/src/client.rs
+++ b/crates/core/src/client.rs
@@ -731,7 +731,7 @@ pub fn run_client(config: ClientConfig) -> Result<ClientSummary, ClientError> {
 
     if collect_events {
         plan.execute_with_report(mode, options.collect_events(true))
-            .map(|(summary, report)| ClientSummary::from_report(summary, report))
+            .map(ClientSummary::from_report)
             .map_err(map_local_copy_error)
     } else {
         plan.execute_with_options(mode, options)


### PR DESCRIPTION
## Summary
- ensure `LocalCopyPlan` converts `CopyOutcome` into summaries and reports directly
- return `CopyOutcome` from `copy_sources` and keep event collection helpers in `CopyContext`
- update the client summary path to consume `LocalCopyReport` without tuple handling

## Testing
- cargo test

------