### PR TITLE
Align daemon module list visibility with upstream

### DIFF
--- a/crates/engine/src/local_copy.rs
+++ b/crates/engine/src/local_copy.rs
@@ -3186,8 +3186,7 @@ mod tests {
             b"root"
         );
         assert_eq!(
-            fs::read(dest_root.join("dir").join("child.txt"))
-                .expect("read nested copy"),
+            fs::read(dest_root.join("dir").join("child.txt")).expect("read nested copy"),
             b"child"
         );
         assert!(


### PR DESCRIPTION
## Summary
- ensure the legacy daemon lists every configured module during `#list` handling regardless of host ACLs so the output matches upstream rsync
- update the integration test to cover the new listing behaviour for restricted modules
- run rustfmt, keeping local copy tests formatted consistently

## Testing
- cargo test -p rsync-daemon
- cargo test -p rsync-engine --lib local_copy::tests::execute_copies_directory_tree

------