### PR TITLE
Add support for --delete-excluded in local copy engine

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -7,8 +7,8 @@
 //! `rsync_cli` implements the thin command-line front-end for the Rust `oc-rsync`
 //! workspace. The crate is intentionally small: it recognises the subset of
 //! command-line switches that are currently supported (`--help`/`-h`,
-//! `--version`/`-V`, `--dry-run`/`-n`, `--delete`, `--filter` (supporting
-//! `+`/`-` actions and `merge FILE` directives), `--files-from`,
+//! `--version`/`-V`, `--dry-run`/`-n`, `--delete`/`--delete-excluded`, `--filter` (supporting
+//! `+`/`-` actions, the `!` clear directive, and `merge FILE` directives), `--files-from`,
 //! `--from0`, `--bwlimit`, and `--sparse`) and delegates local copy operations to
 //! [`rsync_core::client::run_client`]. Higher layers will eventually extend the
 //! parser to cover the full upstream surface (remote modules, incremental
@@ -23,6 +23,7 @@
 //! mirroring the approach used by upstream rsync. Internally a
 //! [`clap`](https://docs.rs/clap/) command definition performs a light-weight
 //! parse that recognises `--help`, `--version`, `--dry-run`, `--delete`,
+//! `--delete-excluded`,
 //! `--filter`, `--files-from`, `--from0`, and `--bwlimit` flags while treating all other
 //! tokens as transfer arguments. When a transfer is requested, the function
 //! delegates to [`rsync_core::client::run_client`], which currently implements a
@@ -107,13 +108,14 @@ const HELP_TEXT: &str = concat!(
     "  -n, --dry-run    Validate transfers without modifying the destination.\n",
     "  -a, --archive    Enable archive mode (implies --owner, --group, --perms, --times, --devices, and --specials).\n",
     "      --delete     Remove destination files that are absent from the source.\n",
+    "      --delete-excluded  Remove excluded destination files during deletion sweeps.\n",
     "  -c, --checksum   Skip updates for files that already match by checksum.\n",
     "      --size-only  Skip files whose size matches the destination, ignoring timestamps.\n",
     "      --exclude=PATTERN  Skip files matching PATTERN.\n",
     "      --exclude-from=FILE  Read exclude patterns from FILE.\n",
     "      --include=PATTERN  Re-include files matching PATTERN after exclusions.\n",
     "      --include-from=FILE  Read include patterns from FILE.\n",
-    "      --filter=RULE  Apply filter RULE (supports '+' include, '-' exclude, 'include PATTERN', 'exclude PATTERN', 'show PATTERN', 'hide PATTERN', 'protect PATTERN', and 'merge FILE').\n",
+    "      --filter=RULE  Apply filter RULE (supports '+' include, '-' exclude, '!' clear, 'include PATTERN', 'exclude PATTERN', 'show PATTERN', 'hide PATTERN', 'protect PATTERN', 'merge FILE', and 'dir-merge[,MODS] FILE').\n",
     "      --files-from=FILE  Read additional source operands from FILE.\n",
     "      --from0      Treat file list entries as NUL-terminated records.\n",
     "      --bwlimit    Limit I/O bandwidth in KiB/s (0 disables the limit).\n",
@@ -156,7 +158,7 @@ const HELP_TEXT: &str = concat!(
 );
 
 /// Human-readable list of the options recognised by this development build.
-const SUPPORTED_OPTIONS_LIST: &str = "--help/-h, --version/-V, --dry-run/-n, --archive/-a, --delete, --checksum/-c, --size-only, --exclude, --exclude-from, --include, --include-from, --filter, --files-from, --from0, --bwlimit, --compress/-z, --no-compress, --verbose/-v, --progress, --no-progress, --stats, --partial, --no-partial, --inplace, --no-inplace, -P, --sparse/-S, --no-sparse, -D, --devices, --no-devices, --specials, --no-specials, --owner, --no-owner, --group, --no-group, --perms/-p, --no-perms, --times/-t, --no-times, --xattrs/-X, --no-xattrs, --numeric-ids, and --no-numeric-ids";
+const SUPPORTED_OPTIONS_LIST: &str = "--help/-h, --version/-V, --dry-run/-n, --archive/-a, --delete, --delete-excluded, --checksum/-c, --size-only, --exclude, --exclude-from, --include, --include-from, --filter, --files-from, --from0, --bwlimit, --compress/-z, --no-compress, --verbose/-v, --progress, --no-progress, --stats, --partial, --no-partial, --inplace, --no-inplace, -P, --sparse/-S, --no-sparse, -D, --devices, --no-devices, --specials, --no-specials, --owner, --no-owner, --group, --no-group, --perms/-p, --no-perms, --times/-t, --no-times, --xattrs/-X, --no-xattrs, --numeric-ids, and --no-numeric-ids";
 
 /// Parsed command produced by [`parse_args`].
 #[derive(Debug, Default)]
@@ -166,6 +168,7 @@ struct ParsedArgs {
     dry_run: bool,
     archive: bool,
     delete: bool,
+    delete_excluded: bool,
     checksum: bool,
     size_only: bool,
     remainder: Vec<OsString>,
@@ -376,6 +379,12 @@ fn clap_command() -> Command {
                 .action(ArgAction::SetTrue),
         )
         .arg(
+            Arg::new("delete-excluded")
+                .long("delete-excluded")
+                .help("Remove excluded destination files during deletion sweeps.")
+                .action(ArgAction::SetTrue),
+        )
+        .arg(
             Arg::new("exclude")
                 .long("exclude")
                 .value_name("PATTERN")
@@ -411,7 +420,7 @@ fn clap_command() -> Command {
             Arg::new("filter")
                 .long("filter")
                 .value_name("RULE")
-                .help("Apply filter RULE (supports '+' include, '-' exclude, 'protect PATTERN', and 'merge FILE').")
+                .help("Apply filter RULE (supports '+' include, '-' exclude, '!' clear, 'protect PATTERN', 'merge FILE', and 'dir-merge[,MODS] FILE').")
                 .value_parser(OsStringValueParser::new())
                 .action(ArgAction::Append),
         )
@@ -570,7 +579,11 @@ where
     let show_version = matches.get_flag("version");
     let dry_run = matches.get_flag("dry-run");
     let archive = matches.get_flag("archive");
-    let delete = matches.get_flag("delete");
+    let mut delete = matches.get_flag("delete");
+    let delete_excluded = matches.get_flag("delete-excluded");
+    if delete_excluded {
+        delete = true;
+    }
     let mut compress = matches.get_flag("compress");
     if matches.get_flag("no-compress") {
         compress = false;
@@ -715,6 +728,7 @@ where
         dry_run,
         archive,
         delete,
+        delete_excluded,
         checksum,
         size_only,
         remainder,
@@ -793,6 +807,7 @@ where
         dry_run,
         archive,
         delete,
+        delete_excluded,
         checksum,
         size_only,
         remainder: raw_remainder,
@@ -941,6 +956,7 @@ where
         .transfer_args(transfer_operands)
         .dry_run(dry_run)
         .delete(delete)
+        .delete_excluded(delete_excluded)
         .bandwidth_limit(bandwidth_limit)
         .compress(compress)
         .owner(preserve_owner)
@@ -1007,6 +1023,7 @@ where
                     return 1;
                 }
             }
+            Ok(FilterDirective::Clear) => filter_rules.clear(),
             Err(message) => {
                 if write_message(&message, stderr).is_err() {
                     let _ = writeln!(stderr.writer_mut(), "{}", message);
@@ -1389,6 +1406,7 @@ fn os_string_to_pattern(value: OsString) -> String {
 enum FilterDirective {
     Rule(FilterRuleSpec),
     Merge(OsString),
+    Clear,
 }
 
 fn parse_filter_directive(argument: &OsStr) -> Result<FilterDirective, Message> {
@@ -1425,9 +1443,16 @@ fn parse_filter_directive(argument: &OsStr) -> Result<FilterDirective, Message> 
     let trimmed = trimmed_leading.trim_end();
 
     if trimmed.is_empty() {
-        let message = rsync_error!(1, "filter rule is empty: supply '+', '-', or 'merge FILE'")
-            .with_role(Role::Client);
+        let message = rsync_error!(
+            1,
+            "filter rule is empty: supply '+', '-', '!', or 'merge FILE'"
+        )
+        .with_role(Role::Client);
         return Err(message);
+    }
+
+    if trimmed == "!" {
+        return Ok(FilterDirective::Clear);
     }
 
     if let Some(remainder) = trimmed.strip_prefix('+') {
@@ -1529,7 +1554,7 @@ fn parse_filter_directive(argument: &OsStr) -> Result<FilterDirective, Message> 
 
     let message = rsync_error!(
         1,
-        "unsupported filter rule '{trimmed}': this build currently supports only '+' (include), '-' (exclude), 'include PATTERN', 'exclude PATTERN', 'show PATTERN', 'hide PATTERN', 'protect PATTERN', 'merge FILE', and 'dir-merge[,MODS] FILE' directives"
+        "unsupported filter rule '{trimmed}': this build currently supports only '+' (include), '-' (exclude), '!' (clear), 'include PATTERN', 'exclude PATTERN', 'show PATTERN', 'hide PATTERN', 'protect PATTERN', 'merge FILE', and 'dir-merge[,MODS] FILE' directives"
     )
     .with_role(Role::Client);
     Err(message)
@@ -1615,6 +1640,7 @@ fn apply_merge_directive(
                         .with_role(Role::Client)
                     })?;
                 }
+                Ok(FilterDirective::Clear) => destination.clear(),
                 Err(error) => {
                     let detail = error.to_string();
                     return Err(
@@ -2459,7 +2485,10 @@ mod tests {
         assert!(stderr.is_empty());
 
         let copied = dest_dir.join(comment_named.file_name().expect("file name"));
-        assert_eq!(std::fs::read(&copied).expect("read copied"), b"from0-comment");
+        assert_eq!(
+            std::fs::read(&copied).expect("read copied"),
+            b"from0-comment"
+        );
     }
 
     #[test]
@@ -3002,6 +3031,16 @@ mod tests {
     }
 
     #[test]
+    fn parse_filter_directive_accepts_clear_directive() {
+        let clear = parse_filter_directive(OsStr::new("!")).expect("clear directive parses");
+        assert_eq!(clear, FilterDirective::Clear);
+
+        let clear_with_whitespace =
+            parse_filter_directive(OsStr::new("  !   ")).expect("clear with whitespace parses");
+        assert_eq!(clear_with_whitespace, FilterDirective::Clear);
+    }
+
+    #[test]
     fn parse_filter_directive_rejects_missing_pattern() {
         let error =
             parse_filter_directive(OsStr::new("+   ")).expect_err("missing pattern should error");
@@ -3116,6 +3155,37 @@ mod tests {
     }
 
     #[test]
+    fn transfer_request_with_filter_clear_resets_rules() {
+        use tempfile::tempdir;
+
+        let tmp = tempdir().expect("tempdir");
+        let source_root = tmp.path().join("source");
+        let dest_root = tmp.path().join("dest");
+        std::fs::create_dir_all(&source_root).expect("create source root");
+        std::fs::create_dir_all(&dest_root).expect("create dest root");
+        std::fs::write(source_root.join("keep.txt"), b"keep").expect("write keep");
+        std::fs::write(source_root.join("skip.tmp"), b"skip").expect("write skip");
+
+        let (code, stdout, stderr) = run_with_args([
+            OsString::from("oc-rsync"),
+            OsString::from("--filter"),
+            OsString::from("- *.tmp"),
+            OsString::from("--filter"),
+            OsString::from("!"),
+            source_root.clone().into_os_string(),
+            dest_root.clone().into_os_string(),
+        ]);
+
+        assert_eq!(code, 0);
+        assert!(stdout.is_empty());
+        assert!(stderr.is_empty());
+
+        let copied_root = dest_root.join("source");
+        assert!(copied_root.join("keep.txt").exists());
+        assert!(copied_root.join("skip.tmp").exists());
+    }
+
+    #[test]
     fn transfer_request_with_filter_merge_applies_rules() {
         use tempfile::tempdir;
 
@@ -3150,6 +3220,42 @@ mod tests {
     }
 
     #[test]
+    fn transfer_request_with_filter_merge_clear_resets_rules() {
+        use tempfile::tempdir;
+
+        let tmp = tempdir().expect("tempdir");
+        let source_root = tmp.path().join("source");
+        let dest_root = tmp.path().join("dest");
+        std::fs::create_dir_all(&source_root).expect("create source root");
+        std::fs::create_dir_all(&dest_root).expect("create dest root");
+        std::fs::write(source_root.join("keep.txt"), b"keep").expect("write keep");
+        std::fs::write(source_root.join("skip.tmp"), b"skip").expect("write tmp");
+        std::fs::write(source_root.join("skip.log"), b"log").expect("write log");
+
+        let filter_file = tmp.path().join("filters.txt");
+        std::fs::write(&filter_file, "- *.tmp\n!\n- *.log\n").expect("write filter file");
+
+        let filter_arg = OsString::from(format!("merge {}", filter_file.display()));
+
+        let (code, stdout, stderr) = run_with_args([
+            OsString::from("oc-rsync"),
+            OsString::from("--filter"),
+            filter_arg,
+            source_root.clone().into_os_string(),
+            dest_root.clone().into_os_string(),
+        ]);
+
+        assert_eq!(code, 0);
+        assert!(stdout.is_empty());
+        assert!(stderr.is_empty());
+
+        let copied_root = dest_root.join("source");
+        assert!(copied_root.join("keep.txt").exists());
+        assert!(copied_root.join("skip.tmp").exists());
+        assert!(!copied_root.join("skip.log").exists());
+    }
+
+    #[test]
     fn transfer_request_with_filter_protect_preserves_destination_entry() {
         use tempfile::tempdir;
 
@@ -3178,6 +3284,38 @@ mod tests {
 
         let copied_root = dest_root.join("source");
         assert!(copied_root.join("keep.txt").exists());
+    }
+
+    #[test]
+    fn transfer_request_with_delete_excluded_prunes_filtered_entries() {
+        use tempfile::tempdir;
+
+        let tmp = tempdir().expect("tempdir");
+        let source_root = tmp.path().join("source");
+        let dest_root = tmp.path().join("dest");
+        std::fs::create_dir_all(&source_root).expect("create source root");
+        std::fs::create_dir_all(&dest_root).expect("create dest root");
+        std::fs::write(source_root.join("keep.txt"), b"keep").expect("write keep");
+
+        let dest_subdir = dest_root.join("source");
+        std::fs::create_dir_all(&dest_subdir).expect("create destination contents");
+        std::fs::write(dest_subdir.join("skip.log"), b"skip").expect("write excluded file");
+
+        let (code, stdout, stderr) = run_with_args([
+            OsString::from("oc-rsync"),
+            OsString::from("--delete-excluded"),
+            OsString::from("--exclude=*.log"),
+            source_root.clone().into_os_string(),
+            dest_root.clone().into_os_string(),
+        ]);
+
+        assert_eq!(code, 0);
+        assert!(stdout.is_empty());
+        assert!(stderr.is_empty());
+
+        let copied_root = dest_root.join("source");
+        assert!(copied_root.join("keep.txt").exists());
+        assert!(!copied_root.join("skip.log").exists());
     }
 
     #[test]
@@ -3664,6 +3802,21 @@ mod tests {
         .expect("parse succeeds");
 
         assert!(parsed.delete);
+        assert!(!parsed.delete_excluded);
+    }
+
+    #[test]
+    fn delete_excluded_flag_implies_delete() {
+        let parsed = super::parse_args([
+            OsString::from("oc-rsync"),
+            OsString::from("--delete-excluded"),
+            OsString::from("source"),
+            OsString::from("dest"),
+        ])
+        .expect("parse succeeds");
+
+        assert!(parsed.delete);
+        assert!(parsed.delete_excluded);
     }
 
     #[test]

--- a/crates/filters/src/lib.rs
+++ b/crates/filters/src/lib.rs
@@ -231,6 +231,14 @@ impl FilterSet {
     pub fn allows_deletion(&self, path: &Path, is_dir: bool) -> bool {
         self.inner.decision(path, is_dir).allows_deletion()
     }
+
+    /// Determines whether the path may be removed when excluded entries are purged.
+    #[must_use]
+    pub fn allows_deletion_when_excluded_removed(&self, path: &Path, is_dir: bool) -> bool {
+        self.inner
+            .decision(path, is_dir)
+            .allows_deletion_when_excluded_removed()
+    }
 }
 
 #[derive(Debug, Default)]
@@ -272,6 +280,10 @@ impl FilterDecision {
 
     const fn allows_deletion(self) -> bool {
         self.transfer_allowed && !self.protected
+    }
+
+    const fn allows_deletion_when_excluded_removed(self) -> bool {
+        !self.protected
     }
 }
 


### PR DESCRIPTION
## Summary
- extend the CLI, client configuration, and local copy engine to honour --delete-excluded alongside --delete
- ensure filter evaluation deletes excluded paths while still respecting protect rules
- add comprehensive unit and integration tests covering the new option and update help/docs to advertise it

## Testing
- cargo test

------