### PR TITLE
Add support for daemon uid/gid/timeout directives

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -82,10 +82,9 @@ use rsync_core::{
     bandwidth::BandwidthParseError,
     client::{
         BandwidthLimit, ClientConfig, ClientEvent, ClientEventKind, ClientProgressObserver,
-        ClientProgressUpdate, ClientSummary, DirMergeEnforcedKind, DirMergeOptions,
-        FilterRuleKind, FilterRuleSpec, ModuleListRequest,
-        run_client_with_observer as run_core_client_with_observer,
-        run_module_list_with_password,
+        ClientProgressUpdate, ClientSummary, DirMergeEnforcedKind, DirMergeOptions, FilterRuleKind,
+        FilterRuleSpec, ModuleListRequest,
+        run_client_with_observer as run_core_client_with_observer, run_module_list_with_password,
     },
     message::{Message, Role},
     rsync_error,


### PR DESCRIPTION
## Summary
- parse `read only`, `numeric ids`, `uid`, `gid`, and `timeout` directives from `rsyncd.conf` modules
- apply module timeouts to accepted connections and surface the parsed values for future integration
- extend the daemon test suite to cover the new directives and validation errors

## Testing
- cargo test

------