### PR TITLE
Support `--daemon` delegation through oc-rsync CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -484,6 +484,7 @@ dependencies = [
  "filetime",
  "rsync-checksums",
  "rsync-core",
+ "rsync-daemon",
  "rsync-filters",
  "rsync-logging",
  "rustix 0.38.44",

--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ The workspace currently contains the following published crates:
 
 - `bin/oc-rsync` — thin wrapper that locks standard streams and invokes
   [`rsync_cli::run`](crates/cli/src/lib.rs) before converting the resulting exit
-  status into `std::process::ExitCode`.
+  status into `std::process::ExitCode`. Supplying `--daemon` delegates argument
+  parsing to the daemon front-end so `oc-rsync --daemon ...` behaves like
+  invoking the dedicated `oc-rsyncd` binary.
 - `bin/oc-rsyncd` — daemon wrapper that binds the requested TCP socket,
   performs the legacy `@RSYNCD:` handshake, lists configured in-memory modules
   for `#list` requests, and reports that full module transfers are still under

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -14,6 +14,7 @@ xattr = ["rsync-core/xattr"]
 clap = { version = "4.5.17", features = ["std"] }
 rsync-core = { path = "../core" }
 rsync-logging = { path = "../logging" }
+rsync-daemon = { path = "../daemon" }
 
 [dev-dependencies]
 filetime = "0.2"


### PR DESCRIPTION
## Summary
- detect the `--daemon` flag in the oc-rsync front-end and forward to the daemon runner when present
- surface the delegated mode in the CLI help snapshot and workspace README
- cover the new flow with targeted unit tests and dependency wiring

## Testing
- cargo test

------