### PR TITLE
Improve CLI protocol parsing diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -556,6 +556,7 @@ dependencies = [
  "rsync-daemon",
  "rsync-filters",
  "rsync-logging",
+ "rsync-protocol",
  "rustix 0.38.44",
  "tempfile",
  "xattr",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -15,6 +15,7 @@ clap = { version = "4.5.17", features = ["std"] }
 rsync-core = { path = "../core" }
 rsync-logging = { path = "../logging" }
 rsync-daemon = { path = "../daemon" }
+rsync-protocol = { path = "../protocol" }
 
 [dev-dependencies]
 filetime = "0.2"


### PR DESCRIPTION
## Summary
- parse `--protocol` values with the shared `ProtocolVersion` parser so leading plus signs and surrounding whitespace are accepted
- emit detailed diagnostics for invalid protocol arguments while keeping the supported protocol list in the message
- cover the new acceptance and error paths with targeted unit tests

## Testing
- cargo test

------