### PR TITLE
Add Debian/RPM packaging metadata and service assets

### DIFF
--- a/bin/oc-rsync/Cargo.toml
+++ b/bin/oc-rsync/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
+description = "Rust implementation of the oc-rsync client and daemon binaries"
 
 [[bin]]
 name = "oc-rsync"
@@ -12,3 +13,31 @@ path = "src/main.rs"
 
 [dependencies]
 rsync-cli = { path = "../../crates/cli" }
+
+[package.metadata.deb]
+name = "oc-rsync"
+section = "utils"
+priority = "optional"
+maintainer = "Ofer Chen <skewers.irises.3b@icloud.com>"
+depends = "libc6 (>= 2.34), libgcc-s1"
+extended-description = "Pure-Rust implementation of rsync-compatible client and daemon binaries."
+assets = [
+    ["../../target/release/oc-rsync", "/usr/bin/oc-rsync", "755"],
+    ["../../target/release/oc-rsyncd", "/usr/bin/oc-rsyncd", "755"],
+    ["../../packaging/systemd/oc-rsyncd.service", "/lib/systemd/system/oc-rsyncd.service", "644"],
+    ["../../packaging/etc/oc-rsyncd.conf", "/etc/oc-rsyncd.conf", "644"],
+    ["../../packaging/default/oc-rsyncd", "/etc/default/oc-rsyncd", "644"],
+]
+conf-files = ["etc/oc-rsyncd.conf", "etc/default/oc-rsyncd"]
+
+[package.metadata.rpm]
+package = "oc-rsync"
+summary = "Rust implementation of rsync-compatible client and daemon"
+requires = ["glibc", "libgcc"]
+assets = [
+    { path = "../../target/release/oc-rsync", dest = "/usr/bin/oc-rsync", mode = "0755" },
+    { path = "../../target/release/oc-rsyncd", dest = "/usr/bin/oc-rsyncd", mode = "0755" },
+    { path = "../../packaging/systemd/oc-rsyncd.service", dest = "/usr/lib/systemd/system/oc-rsyncd.service", mode = "0644" },
+    { path = "../../packaging/etc/oc-rsyncd.conf", dest = "/etc/oc-rsyncd.conf", mode = "0644", config = true },
+    { path = "../../packaging/default/oc-rsyncd", dest = "/etc/default/oc-rsyncd", mode = "0644", config = true },
+]

--- a/docs/differences.md
+++ b/docs/differences.md
@@ -47,13 +47,14 @@ referenced functionality ships and parity is verified by tests or goldens.
     from `rsync_meta`.
     Wire the resulting pipeline into both client and daemon orchestration and
     validate it via the parity harness.
-- **No interop or packaging automation**
-  - *Impact*: There is no exit-code oracle, goldens, CI interop matrix, or
-    packaging artifacts, preventing validation against upstream and distribution
-    deliverables.
+- **Interop harness and packaging automation incomplete**
+  - *Impact*: There is still no exit-code oracle, goldens, or CI interop matrix.
+    Packaging metadata for `cargo-deb`/`cargo-rpm` now installs both binaries, a
+    hardened systemd unit, and example configuration files, but SBOM generation
+    and CI validation remain pending.
   - *Removal plan*: Stand up the parity harness (`tests/goldens`), CI workflows,
-    and packaging targets (deb/rpm, SBOM, systemd unit) defined in the mission
-    brief once higher-level crates are available.
+    and finish the packaging pipeline by wiring SBOM generation and automated
+    install tests once higher-level crates are available.
 
 All remaining behaviour currently matches the limited scope implemented in the
 `protocol` crate; additional differences will be documented here as they are

--- a/docs/feature_matrix.md
+++ b/docs/feature_matrix.md
@@ -27,7 +27,7 @@ binary so documentation never overstates parity.
 | Workspace | Core transfer orchestration plus engine/meta/filter/compress crates | Partial | `core::client::run_client` now delegates to [`LocalCopyPlan`](../crates/engine/src/local_copy.rs) for deterministic local filesystem copies preserving permissions, timestamps, optional owner/group metadata, and extended attributes when enabled, and, when requested, deletes destination entries that are absent from the source. Delta-transfer logic, ACL handling, comprehensive filter merging, compression, and remote transport orchestration remain pending. | `crates/core/src/client.rs`, `crates/engine/src/local_copy.rs`, `crates/meta/src/lib.rs` |
 | Workspace | Deterministic filesystem walker | Implemented | `rsync_walk` provides a depth-first iterator that yields lexicographically ordered entries, enforces root-relative paths, and optionally follows directory symlinks while preventing cycles. | `crates/walk/src/lib.rs` |
 | Quality | Golden parity harness & interop tests | Missing | The repository does not yet build or execute the upstream rsync comparison matrix. | _n/a_ |
-| Quality | Packaging (deb/rpm), SBOM, systemd unit | Missing | Packaging artifacts are absent pending higher-layer implementation. | _n/a_ |
+| Quality | Packaging (deb/rpm), SBOM, systemd unit | Partial | `cargo-deb`/`cargo-rpm` metadata install both binaries together with a hardened systemd unit, environment defaults, and a sample configuration; SBOM automation remains pending. | `bin/oc-rsync/Cargo.toml`, `packaging/systemd/oc-rsyncd.service` |
 
 Status legend: **Implemented** — behavior is present and backed by tests in this
 repository. **Partial** — functionality exists but key capabilities are

--- a/packaging/default/oc-rsyncd
+++ b/packaging/default/oc-rsyncd
@@ -1,0 +1,8 @@
+# Additional environment customisations for oc-rsyncd.
+#
+# Uncomment and adjust the variables below to pass extra arguments to the
+# daemon or to point at an alternate configuration file. Values are consumed
+# by the systemd unit installed with the oc-rsync packages.
+#
+# OC_RSYNCD_CONFIG=/etc/oc-rsyncd.conf
+# OC_RSYNCD_ARGS="--max-sessions 16"

--- a/packaging/etc/oc-rsyncd.conf
+++ b/packaging/etc/oc-rsyncd.conf
@@ -1,0 +1,24 @@
+# oc-rsyncd example configuration
+#
+# The daemon mirrors upstream rsyncd.conf semantics. Uncomment and adjust the
+# directives below to enable modules. By default no modules are exported.
+# See rsyncd.conf(5) for comprehensive documentation of the available
+# directives and security considerations.
+
+# Global settings
+# uid = nobody
+# gid = nogroup
+# use chroot = no
+# max connections = 4
+# timeout = 600
+
+# Example module definition
+# [data]
+#     path = /srv/rsync/data
+#     comment = Public data mirror
+#     read only = yes
+#     list = yes
+#     auth users = backup
+#     secrets file = /etc/oc-rsyncd.secrets
+#     hosts allow = 192.0.2.0/24,2001:db8::/32
+#     refuse options = delete

--- a/packaging/systemd/oc-rsyncd.service
+++ b/packaging/systemd/oc-rsyncd.service
@@ -1,0 +1,30 @@
+[Unit]
+Description=oc-rsync daemon providing rsync protocol services
+Documentation=https://github.com/oferchen/rsync
+After=network.target
+
+[Service]
+Type=simple
+Environment="OC_RSYNCD_CONFIG=/etc/oc-rsyncd.conf"
+EnvironmentFile=-/etc/default/oc-rsyncd
+ExecStart=/usr/bin/oc-rsyncd --config ${OC_RSYNCD_CONFIG} $OC_RSYNCD_ARGS
+ExecReload=/bin/kill -HUP $MAINPID
+Restart=on-failure
+RestartSec=5s
+TimeoutStopSec=15s
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=full
+ProtectHome=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+LockPersonality=true
+MemoryDenyWriteExecute=true
+CapabilityBoundingSet=CAP_CHOWN CAP_DAC_OVERRIDE CAP_FOWNER CAP_FSETID CAP_MKNOD CAP_NET_BIND_SERVICE
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+LimitNOFILE=16384
+UMask=0077
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- add cargo-deb and cargo-rpm metadata so oc-rsync and oc-rsyncd ship together
- provide hardened systemd unit, environment defaults, and example configuration for oc-rsyncd
- document the new packaging capabilities in the feature matrix and differences log

## Testing
- cargo check -p rsync-bin

------