### PR TITLE
Add daemon hostname allow/deny support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,6 +207,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "dns-lookup"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53ecafc952c4528d9b51a458d1a8904b81783feff9fde08ab6ed2545ff396872"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "socket2",
+ "winapi",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -619,6 +631,7 @@ version = "0.0.0"
 dependencies = [
  "base64",
  "clap",
+ "dns-lookup",
  "rsync-checksums",
  "rsync-core",
  "rsync-logging",
@@ -776,6 +789,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
+name = "socket2"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -889,6 +912,28 @@ checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
  "wit-bindgen",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 [dependencies]
 clap = { version = "4.5.49", features = ["std"] }
 base64 = "0.22"
+dns-lookup = "1.0"
 rsync-core = { path = "../core" }
 rsync-protocol = { path = "../protocol" }
 rsync-logging = { path = "../logging" }


### PR DESCRIPTION
## Summary
- add reverse-DNS hostname resolution and caching to daemon host filtering
- extend HostPattern parsing with literal, suffix, and wildcard hostname support
- cover hostname matching in unit tests and wire dns-lookup into the daemon crate

## Testing
- `cargo test -p rsync-daemon`

## Red → Green
- Red → Green count: 0 (new coverage)
- Affected goldens: none
- Parity rationale: mirrors rsyncd hostname pattern semantics verified against upstream documentation

------