### PR TITLE
Follow-up: avoid using skipped files as hard-link targets

### DIFF
--- a/crates/engine/src/local_copy.rs
+++ b/crates/engine/src/local_copy.rs
@@ -3817,7 +3817,6 @@ fn copy_file(
 
     if context.ignore_existing_enabled() && existing_metadata.is_some() {
         context.summary_mut().record_regular_file_ignored_existing();
-        context.hard_links.record(metadata, destination);
         context.record(LocalCopyRecord::new(
             record_path.clone(),
             LocalCopyAction::SkippedExisting,


### PR DESCRIPTION
## Summary
- add the `--ignore-existing` flag to the CLI help, parser, and verbose output
- plumb the new option through the core client configuration and event reporting
- teach the local copy engine to skip existing files, update statistics, and cover the behavior with tests while documenting the flag in the feature matrix
- avoid registering skipped destinations as hard-link candidates so they cannot be reused for future transfers

## Testing
- cargo test

------