### PR TITLE
Add CLI ACL option handling

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -9,6 +9,7 @@ license.workspace = true
 [features]
 default = []
 xattr = ["rsync-core/xattr"]
+acl = ["rsync-core/acl"]
 
 [dependencies]
 clap = { version = "4.5.17", features = ["std"] }


### PR DESCRIPTION
## Summary
- add `--acls`/`--no-acls` parsing and help text to the CLI front-end
- gate ACL preservation behind a build feature and emit a parity error when unsupported
- forward the ACL feature flag and add a regression test covering the client diagnostic

## Testing
- `cargo test`

------