### PR TITLE
Clean up lint warnings across the workspace

### DIFF
--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -1249,7 +1249,7 @@ impl ModuleDefinitionBuilder {
             ));
         }
 
-        if self.auth_users.as_ref().map_or(false, Vec::is_empty) {
+        if self.auth_users.as_ref().is_some_and(Vec::is_empty) {
             return Err(config_parse_error(
                 config_path,
                 self.declaration_line,
@@ -1738,7 +1738,6 @@ impl DaemonError {
     }
 
     /// Returns the formatted diagnostic message that should be emitted.
-    #[must_use]
     pub fn message(&self) -> &Message {
         &self.message
     }
@@ -1933,7 +1932,7 @@ fn join_worker(handle: thread::JoinHandle<WorkerResult>) -> Result<(), DaemonErr
                     Err(_) => "worker thread panicked".to_string(),
                 },
             };
-            let error = io::Error::new(io::ErrorKind::Other, description);
+            let error = io::Error::other(description);
             Err(stream_error(None, "serve legacy handshake", error))
         }
     }
@@ -2040,7 +2039,7 @@ fn handle_legacy_session(
                 continue;
             }
             Ok(LegacyDaemonMessage::Other(payload)) => {
-                if let Some(option) = parse_daemon_option(&payload) {
+                if let Some(option) = parse_daemon_option(payload) {
                     refused_options.push(option.to_string());
                     continue;
                 }
@@ -2476,7 +2475,7 @@ fn canonical_option(text: &str) -> String {
     let token = text
         .trim()
         .trim_start_matches('-')
-        .split(|ch| matches!(ch, ' ' | '\t' | '='))
+        .split([' ', '\t', '='])
         .next()
         .unwrap_or("");
     token.to_ascii_lowercase()

--- a/crates/engine/src/local_copy.rs
+++ b/crates/engine/src/local_copy.rs
@@ -648,6 +648,9 @@ impl FilterSegment {
     }
 }
 
+type FilterSegmentLayers = Vec<Vec<FilterSegment>>;
+type FilterSegmentStack = Vec<Vec<(usize, FilterSegment)>>;
+
 #[derive(Clone, Copy, Debug)]
 struct FilterOutcome {
     transfer_allowed: bool,
@@ -1127,7 +1130,7 @@ impl LocalCopyMetadata {
                 Some(metadata.mode()),
                 Some(metadata.uid()),
                 Some(metadata.gid()),
-                Some(u64::from(metadata.nlink())),
+                Some(metadata.nlink()),
             )
         };
 
@@ -1155,6 +1158,12 @@ impl LocalCopyMetadata {
     #[must_use]
     pub const fn len(&self) -> u64 {
         self.len
+    }
+
+    /// Returns whether the metadata describes an empty entry.
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.len == 0
     }
 
     /// Returns the recorded modification time, when available.
@@ -2026,9 +2035,9 @@ struct CopyContext<'a> {
     summary: LocalCopySummary,
     events: Option<Vec<LocalCopyRecord>>,
     filter_program: Option<FilterProgram>,
-    dir_merge_layers: Rc<RefCell<Vec<Vec<FilterSegment>>>>,
+    dir_merge_layers: Rc<RefCell<FilterSegmentLayers>>,
     observer: Option<&'a mut dyn LocalCopyRecordHandler>,
-    dir_merge_ephemeral: Rc<RefCell<Vec<Vec<(usize, FilterSegment)>>>>,
+    dir_merge_ephemeral: Rc<RefCell<FilterSegmentStack>>,
 }
 
 impl<'a> CopyContext<'a> {
@@ -2308,6 +2317,7 @@ impl<'a> CopyContext<'a> {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn copy_file_contents(
         &mut self,
         reader: &mut fs::File,
@@ -2425,8 +2435,8 @@ impl<'a> CopyContext<'a> {
 }
 
 struct DirectoryFilterGuard {
-    layers: Rc<RefCell<Vec<Vec<FilterSegment>>>>,
-    ephemeral: Rc<RefCell<Vec<Vec<(usize, FilterSegment)>>>>,
+    layers: Rc<RefCell<FilterSegmentLayers>>,
+    ephemeral: Rc<RefCell<FilterSegmentStack>>,
     indices: Vec<usize>,
     ephemeral_active: bool,
     excluded: bool,
@@ -2434,8 +2444,8 @@ struct DirectoryFilterGuard {
 
 impl DirectoryFilterGuard {
     fn new(
-        layers: Rc<RefCell<Vec<Vec<FilterSegment>>>>,
-        ephemeral: Rc<RefCell<Vec<Vec<(usize, FilterSegment)>>>>,
+        layers: Rc<RefCell<FilterSegmentLayers>>,
+        ephemeral: Rc<RefCell<FilterSegmentStack>>,
         indices: Vec<usize>,
         ephemeral_active: bool,
         excluded: bool,
@@ -2563,15 +2573,12 @@ fn load_dir_merge_rules_recursive(
 
                 let mut directive = token.to_string();
                 let lower = directive.to_ascii_lowercase();
-                if matches!(
+                let needs_argument = matches!(
                     lower.as_str(),
                     "merge" | "include" | "exclude" | "show" | "hide" | "protect"
-                ) {
-                    if let Some(next) = iter.next() {
-                        directive.push(' ');
-                        directive.push_str(next);
-                    }
-                } else if lower.starts_with("dir-merge") {
+                ) || lower.starts_with("dir-merge");
+
+                if needs_argument {
                     if let Some(next) = iter.next() {
                         directive.push(' ');
                         directive.push_str(next);
@@ -3632,7 +3639,7 @@ fn copy_file(
             destination
                 .file_name()
                 .map(PathBuf::from)
-                .unwrap_or_else(PathBuf::new)
+                .unwrap_or_default()
         });
     let file_size = metadata.len();
     context.summary_mut().record_regular_file_total();
@@ -4746,7 +4753,7 @@ fn compare_file_names(left: &OsStr, right: &OsStr) -> Ordering {
     {
         use std::os::unix::ffi::OsStrExt;
 
-        return left.as_bytes().cmp(right.as_bytes());
+        left.as_bytes().cmp(right.as_bytes())
     }
 
     #[cfg(windows)]
@@ -4755,12 +4762,12 @@ fn compare_file_names(left: &OsStr, right: &OsStr) -> Ordering {
 
         let left_wide: Vec<u16> = left.encode_wide().collect();
         let right_wide: Vec<u16> = right.encode_wide().collect();
-        return left_wide.cmp(&right_wide);
+        left_wide.cmp(&right_wide)
     }
 
     #[cfg(not(any(unix, windows)))]
     {
-        return left.to_string_lossy().cmp(&right.to_string_lossy());
+        left.to_string_lossy().cmp(&right.to_string_lossy())
     }
 }
 
@@ -4770,7 +4777,7 @@ fn has_trailing_separator(path: &OsStr) -> bool {
         use std::os::unix::ffi::OsStrExt;
 
         let bytes = path.as_bytes();
-        !bytes.is_empty() && bytes.ends_with(&[b'/'])
+        !bytes.is_empty() && bytes.ends_with(b"/")
     }
 
     #[cfg(windows)]
@@ -4795,7 +4802,7 @@ fn is_fifo(file_type: &fs::FileType) -> bool {
     {
         use std::os::unix::fs::FileTypeExt;
 
-        return file_type.is_fifo();
+        file_type.is_fifo()
     }
 
     #[cfg(not(unix))]
@@ -4810,7 +4817,7 @@ fn is_device(file_type: &fs::FileType) -> bool {
     {
         use std::os::unix::fs::FileTypeExt;
 
-        return file_type.is_char_device() || file_type.is_block_device();
+        file_type.is_char_device() || file_type.is_block_device()
     }
 
     #[cfg(not(unix))]

--- a/crates/filters/src/lib.rs
+++ b/crates/filters/src/lib.rs
@@ -424,10 +424,8 @@ impl CompiledRule {
 
     fn matches(&self, path: &Path, is_dir: bool) -> bool {
         for matcher in &self.direct_matchers {
-            if matcher.is_match(path) {
-                if !self.directory_only || is_dir {
-                    return true;
-                }
+            if matcher.is_match(path) && (!self.directory_only || is_dir) {
+                return true;
             }
         }
 

--- a/crates/meta/src/lib.rs
+++ b/crates/meta/src/lib.rs
@@ -659,7 +659,6 @@ mod id_lookup {
     #![allow(unsafe_code)]
 
     use super::{CStr, CString, MaybeUninit, RawGid, RawUid, io, ownership};
-    use libc;
     use rustix::fs::{Gid, Uid};
     use std::ptr;
 

--- a/crates/walk/src/lib.rs
+++ b/crates/walk/src/lib.rs
@@ -253,10 +253,7 @@ impl Iterator for Walker {
 
         loop {
             let (full_path, relative_path, depth) = {
-                let state = match self.stack.last_mut() {
-                    Some(state) => state,
-                    None => return None,
-                };
+                let state = self.stack.last_mut()?;
 
                 if let Some(name) = state.next_name() {
                     let full_path = state.fs_path.join(&name);


### PR DESCRIPTION
## Summary
- simplify the CLI flag handling by collapsing duplicate branches, removing redundant conversions, and tightening progress rendering helpers
- make the client/daemon orchestration more idiomatic by trimming redundant attributes, using `Option::is_some_and`, and improving error construction and parsing helpers
- address clippy feedback in shared crates (engine, filters, meta, walk) by introducing type aliases, adding small accessors, and avoiding needless temporary values

## Testing
- cargo clippy
- cargo test

------