### PR TITLE
Expose whole-file option through CLI and client config

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -153,6 +153,8 @@ const HELP_TEXT: &str = concat!(
     "      --stats      Output transfer statistics after completion.\n",
     "      --partial    Keep partially transferred files on errors.\n",
     "      --no-partial Discard partially transferred files on errors.\n",
+    "  -W, --whole-file  Copy files without using the delta-transfer algorithm.\n",
+    "      --no-whole-file  Enable the delta-transfer algorithm (disable whole-file copies).\n",
     "      --remove-source-files  Remove source files after a successful transfer.\n",
     "      --remove-sent-files   Alias of --remove-source-files.\n",
     "      --inplace    Write updated data directly to destination files.\n",
@@ -186,7 +188,7 @@ const HELP_TEXT: &str = concat!(
 );
 
 /// Human-readable list of the options recognised by this development build.
-const SUPPORTED_OPTIONS_LIST: &str = "--help/-h, --version/-V, --daemon, --dry-run/-n, --list-only, --archive/-a, --delete, --checksum/-c, --size-only, --ignore-existing, --exclude, --exclude-from, --include, --include-from, --filter (including exclude-if-present=FILE), --files-from, --password-file, --no-motd, --from0, --bwlimit, --timeout, --protocol, --compress/-z, --no-compress, --verbose/-v, --progress, --no-progress, --stats, --partial, --no-partial, --remove-source-files, --remove-sent-files, --inplace, --no-inplace, -P, --sparse/-S, --no-sparse, -D, --devices, --no-devices, --specials, --no-specials, --owner, --no-owner, --group, --no-group, --perms/-p, --no-perms, --times/-t, --no-times, --acls/-A, --no-acls, --xattrs/-X, --no-xattrs, --numeric-ids, and --no-numeric-ids";
+const SUPPORTED_OPTIONS_LIST: &str = "--help/-h, --version/-V, --daemon, --dry-run/-n, --list-only, --archive/-a, --delete, --checksum/-c, --size-only, --ignore-existing, --exclude, --exclude-from, --include, --include-from, --filter (including exclude-if-present=FILE), --files-from, --password-file, --no-motd, --from0, --bwlimit, --timeout, --protocol, --compress/-z, --no-compress, --verbose/-v, --progress, --no-progress, --stats, --partial, --no-partial, --remove-source-files, --remove-sent-files, --inplace, --no-inplace, --whole-file/-W, --no-whole-file, -P, --sparse/-S, --no-sparse, -D, --devices, --no-devices, --specials, --no-specials, --owner, --no-owner, --group, --no-group, --perms/-p, --no-perms, --times/-t, --no-times, --acls/-A, --no-acls, --xattrs/-X, --no-xattrs, --numeric-ids, and --no-numeric-ids";
 
 /// Timestamp format used for `--list-only` output.
 const LIST_TIMESTAMP_FORMAT: &[FormatItem<'static>] = format_description!(
@@ -226,6 +228,7 @@ struct ParsedArgs {
     partial: bool,
     remove_source_files: bool,
     inplace: Option<bool>,
+    whole_file: Option<bool>,
     excludes: Vec<OsString>,
     includes: Vec<OsString>,
     exclude_from: Vec<OsString>,
@@ -410,6 +413,21 @@ fn clap_command() -> ClapCommand {
                 .help("Discard partially transferred files on error.")
                 .action(ArgAction::SetTrue)
                 .overrides_with("partial"),
+        )
+        .arg(
+            Arg::new("whole-file")
+                .long("whole-file")
+                .short('W')
+                .help("Copy files without using the delta-transfer algorithm.")
+                .action(ArgAction::SetTrue)
+                .overrides_with("no-whole-file"),
+        )
+        .arg(
+            Arg::new("no-whole-file")
+                .long("no-whole-file")
+                .help("Enable the delta-transfer algorithm (disable whole-file copies).")
+                .action(ArgAction::SetTrue)
+                .overrides_with("whole-file"),
         )
         .arg(
             Arg::new("remove-source-files")
@@ -813,6 +831,13 @@ where
     } else {
         None
     };
+    let whole_file = if matches.get_flag("whole-file") {
+        Some(true)
+    } else if matches.get_flag("no-whole-file") {
+        Some(false)
+    } else {
+        None
+    };
     let remainder = matches
         .remove_many::<OsString>("args")
         .map(|values| values.collect())
@@ -885,6 +910,7 @@ where
         partial,
         remove_source_files,
         inplace,
+        whole_file,
         excludes,
         includes,
         exclude_from,
@@ -1029,6 +1055,7 @@ where
         partial,
         remove_source_files,
         inplace,
+        whole_file,
         xattrs,
         no_motd,
         password_file,
@@ -1109,6 +1136,7 @@ where
     };
 
     let numeric_ids_option = numeric_ids;
+    let whole_file_option = whole_file;
 
     #[allow(unused_variables)]
     let preserve_acls = acls.unwrap_or(false);
@@ -1231,6 +1259,7 @@ where
             partial,
             remove_source_files,
             inplace,
+            whole_file: whole_file_option,
             bwlimit,
             excludes,
             includes,
@@ -1323,6 +1352,7 @@ where
         .partial(partial)
         .remove_source_files(remove_source_files)
         .inplace(inplace.unwrap_or(false))
+        .whole_file(whole_file_option.unwrap_or(true))
         .timeout(timeout_setting);
     #[cfg(feature = "xattr")]
     {
@@ -2924,6 +2954,7 @@ struct RemoteFallbackArgs {
     partial: bool,
     remove_source_files: bool,
     inplace: Option<bool>,
+    whole_file: Option<bool>,
     bwlimit: Option<OsString>,
     excludes: Vec<OsString>,
     includes: Vec<OsString>,
@@ -2976,6 +3007,7 @@ where
         partial,
         remove_source_files,
         inplace,
+        whole_file,
         bwlimit,
         excludes,
         includes,
@@ -3038,6 +3070,12 @@ where
     push_toggle(&mut command_args, "--specials", "--no-specials", specials);
     push_toggle(&mut command_args, "--relative", "--no-relative", relative);
     push_toggle(&mut command_args, "--inplace", "--no-inplace", inplace);
+    push_toggle(
+        &mut command_args,
+        "--whole-file",
+        "--no-whole-file",
+        whole_file,
+    );
     #[cfg(feature = "xattr")]
     push_toggle(&mut command_args, "--xattrs", "--no-xattrs", xattrs);
 
@@ -4651,6 +4689,29 @@ mod tests {
         .expect("parse");
 
         assert_eq!(parsed.inplace, Some(false));
+    }
+
+    #[test]
+    fn parse_args_recognises_whole_file_flags() {
+        let parsed = parse_args([
+            OsString::from("oc-rsync"),
+            OsString::from("-W"),
+            OsString::from("source"),
+            OsString::from("dest"),
+        ])
+        .expect("parse");
+
+        assert_eq!(parsed.whole_file, Some(true));
+
+        let parsed = parse_args([
+            OsString::from("oc-rsync"),
+            OsString::from("--no-whole-file"),
+            OsString::from("source"),
+            OsString::from("dest"),
+        ])
+        .expect("parse");
+
+        assert_eq!(parsed.whole_file, Some(false));
     }
 
     #[test]
@@ -6504,6 +6565,59 @@ exit 0
 
         let copied = std::fs::read(&files_copy_path).expect("read copied file list");
         assert_eq!(copied, b"first\0second\0");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn remote_fallback_forwards_whole_file_flags() {
+        use tempfile::tempdir;
+
+        let _env_lock = ENV_LOCK.lock().expect("env lock");
+        let temp = tempdir().expect("tempdir");
+        let script_path = temp.path().join("fallback.sh");
+        let args_path = temp.path().join("args.txt");
+
+        let script = r#"#!/bin/sh
+printf "%s\n" "$@" > "$ARGS_FILE"
+exit 0
+"#;
+        write_executable_script(&script_path, script);
+
+        let _fallback_guard = EnvGuard::set("OC_RSYNC_FALLBACK", script_path.as_os_str());
+        let _args_guard = EnvGuard::set("ARGS_FILE", args_path.as_os_str());
+
+        let dest_path = temp.path().join("dest");
+
+        let (code, stdout, stderr) = run_with_args([
+            OsString::from("oc-rsync"),
+            OsString::from("-W"),
+            OsString::from("remote::module"),
+            dest_path.clone().into_os_string(),
+        ]);
+
+        assert_eq!(code, 0);
+        assert!(stdout.is_empty());
+        assert!(stderr.is_empty());
+
+        let recorded = std::fs::read_to_string(&args_path).expect("read args file");
+        let args: Vec<&str> = recorded.lines().collect();
+        assert!(args.contains(&"--whole-file"));
+        assert!(!args.contains(&"--no-whole-file"));
+
+        let (code, stdout, stderr) = run_with_args([
+            OsString::from("oc-rsync"),
+            OsString::from("--no-whole-file"),
+            OsString::from("remote::module"),
+            dest_path.clone().into_os_string(),
+        ]);
+
+        assert_eq!(code, 0);
+        assert!(stdout.is_empty());
+        assert!(stderr.is_empty());
+
+        let recorded = std::fs::read_to_string(&args_path).expect("read args file");
+        let args: Vec<&str> = recorded.lines().collect();
+        assert!(args.contains(&"--no-whole-file"));
     }
 
     #[cfg(unix)]

--- a/crates/core/src/client.rs
+++ b/crates/core/src/client.rs
@@ -184,6 +184,7 @@ pub struct ClientConfig {
     preserve_permissions: bool,
     preserve_times: bool,
     compress: bool,
+    whole_file: bool,
     checksum: bool,
     size_only: bool,
     ignore_existing: bool,
@@ -314,6 +315,15 @@ impl ClientConfig {
     #[doc(alias = "-z")]
     pub const fn compress(&self) -> bool {
         self.compress
+    }
+
+    /// Reports whether whole-file transfers should be used.
+    #[must_use]
+    #[doc(alias = "--whole-file")]
+    #[doc(alias = "-W")]
+    #[doc(alias = "--no-whole-file")]
+    pub const fn whole_file(&self) -> bool {
+        self.whole_file
     }
 
     /// Reports whether extended attributes should be preserved.
@@ -447,6 +457,7 @@ pub struct ClientConfigBuilder {
     preserve_permissions: bool,
     preserve_times: bool,
     compress: bool,
+    whole_file: Option<bool>,
     checksum: bool,
     size_only: bool,
     ignore_existing: bool,
@@ -569,6 +580,16 @@ impl ClientConfigBuilder {
     #[doc(alias = "-z")]
     pub const fn compress(mut self, compress: bool) -> Self {
         self.compress = compress;
+        self
+    }
+
+    /// Requests that whole-file transfers be used instead of the delta algorithm.
+    #[must_use]
+    #[doc(alias = "--whole-file")]
+    #[doc(alias = "-W")]
+    #[doc(alias = "--no-whole-file")]
+    pub fn whole_file(mut self, whole_file: bool) -> Self {
+        self.whole_file = Some(whole_file);
         self
     }
 
@@ -743,6 +764,7 @@ impl ClientConfigBuilder {
             preserve_permissions: self.preserve_permissions,
             preserve_times: self.preserve_times,
             compress: self.compress,
+            whole_file: self.whole_file.unwrap_or(true),
             checksum: self.checksum,
             size_only: self.size_only,
             ignore_existing: self.ignore_existing,


### PR DESCRIPTION
## Summary
- plumb the --whole-file/--no-whole-file toggles through the CLI parser, help, and remote fallback shim
- store the whole-file preference on ClientConfig with builder accessors and default behaviour mirroring upstream
- extend parsing and remote fallback tests to cover the new option

## Testing
- `cargo test`

------