### PR TITLE
Fix ClientConfig compression setters missing closures

### DIFF
--- a/crates/core/src/client.rs
+++ b/crates/core/src/client.rs
@@ -397,6 +397,8 @@ impl ClientConfig {
     #[doc(alias = "--compress-level")]
     pub const fn compression_setting(&self) -> CompressionSetting {
         self.compression_setting
+    }
+
     /// Reports whether whole-file transfers should be used.
     #[must_use]
     #[doc(alias = "--whole-file")]
@@ -669,6 +671,9 @@ impl ClientConfigBuilder {
     #[doc(alias = "--compress-level")]
     pub const fn compression_setting(mut self, setting: CompressionSetting) -> Self {
         self.compression_setting = setting;
+        self
+    }
+
     /// Requests that whole-file transfers be used instead of the delta algorithm.
     #[must_use]
     #[doc(alias = "--whole-file")]


### PR DESCRIPTION
## Summary
- restore the missing closing braces for `ClientConfig::compression_setting`
- ensure `ClientConfigBuilder::compression_setting` returns `self` so chaining works

## Testing
- cargo check -p rsync-core
- cargo test -p rsync-core --lib

------