### PR TITLE
Refine compression override handling

### DIFF
--- a/crates/compress/src/zlib.rs
+++ b/crates/compress/src/zlib.rs
@@ -61,28 +61,14 @@ impl CompressionLevel {
     /// Returns [`CompressionLevelError`] when `level` falls outside the inclusive
     /// range `1..=9` accepted by zlib.
     pub fn from_numeric(level: u32) -> Result<Self, CompressionLevelError> {
-        if (1..=9).contains(&level) {
-            // SAFETY: the range check above guarantees `level` is non-zero and fits in a `u8`.
-            let precise = NonZeroU8::new(level as u8).expect("validated non-zero level");
-            Ok(Self::Precise(precise))
-        } else {
-            Err(CompressionLevelError::new(level))
-        }
-    }
-
-    /// Constructs a [`CompressionLevel::Precise`] variant from the provided zlib level.
-    #[must_use]
-    pub const fn precise(level: NonZeroU8) -> Self {
-        Self::Precise(level)
-    }
-}
         if !(1..=9).contains(&level) {
             return Err(CompressionLevelError::new(level));
         }
 
-        let as_u8 = u8::try_from(level).map_err(|_| CompressionLevelError::new(level))?;
-        let value = NonZeroU8::new(as_u8).ok_or_else(|| CompressionLevelError::new(level))?;
-        Ok(Self::Precise(value))
+        // SAFETY: the range check above guarantees the conversion never produces
+        // zero and always fits inside a `u8`.
+        let precise = NonZeroU8::new(level as u8).expect("validated non-zero level");
+        Ok(Self::Precise(precise))
     }
 
     /// Constructs a [`CompressionLevel::Precise`] variant from the provided zlib level.
@@ -265,7 +251,6 @@ mod tests {
     fn numeric_level_constructor_accepts_valid_range() {
         for level in 1..=9 {
             let precise = CompressionLevel::from_numeric(level).expect("valid level");
-            let expected = NonZeroU8::new(level as u8).expect("validated");
             let expected = NonZeroU8::new(level as u8).expect("range checked");
             assert_eq!(precise, CompressionLevel::Precise(expected));
         }

--- a/crates/engine/src/local_copy.rs
+++ b/crates/engine/src/local_copy.rs
@@ -1313,7 +1313,6 @@ pub struct LocalCopyOptions {
     compress: bool,
     compression_level_override: Option<CompressionLevel>,
     compression_level: CompressionLevel,
-    compression_override: Option<CompressionLevel>,
     preserve_owner: bool,
     preserve_group: bool,
     preserve_permissions: bool,
@@ -1348,7 +1347,6 @@ impl LocalCopyOptions {
             compress: false,
             compression_level_override: None,
             compression_level: CompressionLevel::Default,
-            compression_override: None,
             preserve_owner: false,
             preserve_group: false,
             preserve_permissions: false,
@@ -1439,8 +1437,13 @@ impl LocalCopyOptions {
     #[doc(alias = "--compress-level")]
     pub const fn with_compression_level(mut self, level: CompressionLevel) -> Self {
         self.compression_level_override = Some(level);
+        self
+    }
+
+    /// Applies an explicit compression override supplied by higher layers.
+    #[must_use]
     pub const fn with_compression_override(mut self, level: Option<CompressionLevel>) -> Self {
-        self.compression_override = level;
+        self.compression_level_override = level;
         self
     }
 
@@ -1485,7 +1488,7 @@ impl LocalCopyOptions {
 
     /// Applies a filter set using the legacy builder name for compatibility.
     #[must_use]
-    pub fn filters(mut self, filters: Option<FilterSet>) -> Self {
+    pub fn filters(self, filters: Option<FilterSet>) -> Self {
         self.with_filters(filters)
     }
 
@@ -1637,28 +1640,22 @@ impl LocalCopyOptions {
         self.compression_level_override
     }
 
-    /// Returns the compression level that should be used when compression is enabled.
+    /// Returns the compression level that should be used for the transfer.
     #[must_use]
     pub const fn compression_level(&self) -> CompressionLevel {
         match self.compression_level_override {
             Some(level) => level,
-            None => CompressionLevel::Default,
+            None => self.compression_level,
+        }
+    }
+
     /// Returns the explicit compression override when compression is enabled.
     #[must_use]
     pub const fn compression_override(&self) -> Option<CompressionLevel> {
         if self.compress {
-            self.compression_override
+            self.compression_level_override
         } else {
             None
-        }
-    }
-
-    /// Returns the compression level that should be used for the transfer.
-    #[must_use]
-    pub const fn compression_level(&self) -> CompressionLevel {
-        match self.compression_override {
-            Some(level) => level,
-            None => self.compression_level,
         }
     }
 
@@ -2419,7 +2416,6 @@ impl<'a> CopyContext<'a> {
     ) -> Result<Option<u64>, LocalCopyError> {
         let mut total_bytes: u64 = 0;
         let mut compressor = if compress {
-            Some(CountingZlibEncoder::new(level))
             Some(CountingZlibEncoder::new(self.compression_level()))
         } else {
             None
@@ -5021,34 +5017,42 @@ mod tests {
     }
 
     #[test]
-    fn local_copy_options_compression_override_round_trip() {
-        let level = NonZeroU8::new(5).expect("level");
+    fn local_copy_options_compression_level_override_round_trip() {
+        let level = NonZeroU8::new(4).expect("level");
         let override_level = CompressionLevel::precise(level);
+
         let options = LocalCopyOptions::default()
             .compress(true)
-            .with_compression_level_override(Some(CompressionLevel::precise(level)));
-        assert_eq!(
-            options.compression_level_override(),
-            Some(CompressionLevel::precise(level))
-        );
-        assert_eq!(
-            options.compression_level(),
-            CompressionLevel::precise(level)
-        );
+            .with_compression_level_override(Some(override_level));
+        assert_eq!(options.compression_level_override(), Some(override_level));
+        assert_eq!(options.compression_level(), override_level);
 
         let disabled = LocalCopyOptions::default()
-            .with_compression_level_override(Some(CompressionLevel::precise(level)))
+            .with_compression_level_override(Some(override_level))
             .compress(false);
         assert_eq!(disabled.compression_level_override(), None);
         assert_eq!(disabled.compression_level(), CompressionLevel::Default);
+    }
+
+    #[test]
+    fn local_copy_options_compression_override_round_trip() {
+        let level = NonZeroU8::new(5).expect("level");
+        let override_level = CompressionLevel::precise(level);
+
+        let options = LocalCopyOptions::default()
+            .compress(true)
             .with_compression_override(Some(override_level));
         assert_eq!(options.compression_override(), Some(override_level));
+        assert_eq!(options.compression_level_override(), Some(override_level));
+        assert_eq!(options.compression_level(), override_level);
         assert_eq!(options.effective_compression_level(), Some(override_level));
 
         let disabled = LocalCopyOptions::default()
             .with_compression_override(Some(override_level))
             .compress(false);
         assert_eq!(disabled.compression_override(), None);
+        assert_eq!(disabled.compression_level_override(), None);
+        assert_eq!(disabled.compression_level(), CompressionLevel::Default);
         assert_eq!(disabled.effective_compression_level(), None);
     }
 


### PR DESCRIPTION
## Summary
- simplify `CompressionLevel::from_numeric` by reusing the validated `NonZeroU8` conversion and clean up the associated unit test
- collapse `LocalCopyOptions`' compression override state into a single field and provide helper methods that keep overrides in sync with the compression toggle
- extend the compression override tests to cover both level overrides and automatic clearing when compression is disabled

## Testing
- cargo test

------