### PR TITLE
Fix CLI compression handling and remote fallback parity

### DIFF
--- a/crates/engine/src/local_copy.rs
+++ b/crates/engine/src/local_copy.rs
@@ -1467,7 +1467,7 @@ impl LocalCopyOptions {
 
     /// Applies a filter set using the legacy builder name for compatibility.
     #[must_use]
-    pub fn filters(mut self, filters: Option<FilterSet>) -> Self {
+    pub fn filters(self, filters: Option<FilterSet>) -> Self {
         self.with_filters(filters)
     }
 


### PR DESCRIPTION
## Summary
- ensure the CLI retains --compress-level inputs, honours --no-compress, and forwards the effective compression state to remote fallbacks
- update remote fallback construction to emit the correct --compress-level/--no-compress/--no-whole-file flags and prune duplicated tests
- remove redundant SUPPORTED_OPTIONS_LIST constants and tidy the engine filter convenience method

## Testing
- cargo test

------