### PR TITLE
Prevent --remove-source-files from deleting unchanged inputs

### DIFF
--- a/crates/core/src/client.rs
+++ b/crates/core/src/client.rs
@@ -2187,6 +2187,34 @@ mod tests {
     }
 
     #[test]
+    fn run_client_remove_source_files_preserves_matched_source() {
+        use filetime::{FileTime, set_file_times};
+
+        let tmp = tempdir().expect("tempdir");
+        let source = tmp.path().join("source.txt");
+        let destination = tmp.path().join("dest.txt");
+        let payload = b"stable";
+        fs::write(&source, payload).expect("write source");
+        fs::write(&destination, payload).expect("write destination");
+
+        let timestamp = FileTime::from_unix_time(1_700_000_000, 0);
+        set_file_times(&source, timestamp, timestamp).expect("set source times");
+        set_file_times(&destination, timestamp, timestamp).expect("set dest times");
+
+        let config = ClientConfig::builder()
+            .transfer_args([source.clone(), destination.clone()])
+            .remove_source_files(true)
+            .times(true)
+            .build();
+
+        let summary = run_client(config).expect("transfer succeeds");
+
+        assert_eq!(summary.sources_removed(), 0, "unchanged sources remain");
+        assert!(source.exists(), "matched source should not be removed");
+        assert_eq!(fs::read(&destination).expect("read dest"), payload);
+    }
+
+    #[test]
     fn run_client_dry_run_skips_copy() {
         let tmp = tempdir().expect("tempdir");
         let source = tmp.path().join("source.txt");

--- a/crates/engine/src/local_copy.rs
+++ b/crates/engine/src/local_copy.rs
@@ -3922,12 +3922,6 @@ fn copy_file(
                 Duration::default(),
                 Some(LocalCopyMetadata::from_metadata(metadata)),
             ));
-            remove_source_entry_if_requested(
-                context,
-                source,
-                Some(record_path.as_path()),
-                file_type,
-            )?;
             return Ok(());
         }
     }
@@ -5284,6 +5278,42 @@ mod tests {
         assert_eq!(summary.sources_removed(), 1);
         assert!(!source.exists(), "source should be removed");
         assert_eq!(fs::read(destination).expect("read dest"), b"move me");
+    }
+
+    #[test]
+    fn execute_with_remove_source_files_preserves_unchanged_source() {
+        use filetime::{FileTime, set_file_times};
+
+        let temp = tempdir().expect("tempdir");
+        let source = temp.path().join("source.txt");
+        let destination = temp.path().join("dest.txt");
+        let payload = b"stable";
+        fs::write(&source, payload).expect("write source");
+        fs::write(&destination, payload).expect("write destination");
+
+        let timestamp = FileTime::from_unix_time(1_700_000_000, 0);
+        set_file_times(&source, timestamp, timestamp).expect("set source times");
+        set_file_times(&destination, timestamp, timestamp).expect("set dest times");
+
+        let operands = vec![
+            source.clone().into_os_string(),
+            destination.clone().into_os_string(),
+        ];
+        let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+
+        let summary = plan
+            .execute_with_options(
+                LocalCopyExecution::Apply,
+                LocalCopyOptions::default()
+                    .remove_source_files(true)
+                    .times(true),
+            )
+            .expect("execution succeeds");
+
+        assert_eq!(summary.sources_removed(), 0, "unchanged sources remain");
+        assert!(source.exists(), "source should remain when unchanged");
+        assert!(destination.exists(), "destination remains present");
+        assert_eq!(summary.files_copied(), 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- avoid removing source entries when the local copy engine reuses destination metadata instead of copying data
- add unit tests in both the engine and core layers to ensure up-to-date sources are kept

## Testing
- cargo test

------