### PR TITLE
Highlight fallback path for remote operands

### DIFF
--- a/crates/core/src/client.rs
+++ b/crates/core/src/client.rs
@@ -3718,6 +3718,7 @@ exit 42
                 .to_string()
                 .contains("remote operands are not supported")
         );
+        assert!(error.message().to_string().contains("OC_RSYNC_FALLBACK"));
     }
 
     #[test]
@@ -4395,7 +4396,10 @@ fn daemon_access_denied_error(reason: &str) -> ClientError {
 
 fn remote_operands_unsupported() -> ClientError {
     daemon_error(
-        "remote operands are not supported: this build handles local filesystem copies only",
+        concat!(
+            "remote operands are not supported: this build handles local filesystem copies only; ",
+            "set OC_RSYNC_FALLBACK to point to an upstream rsync binary for remote transfers",
+        ),
         PARTIAL_TRANSFER_EXIT_CODE,
     )
 }

--- a/crates/engine/src/local_copy.rs
+++ b/crates/engine/src/local_copy.rs
@@ -3260,9 +3260,10 @@ impl LocalCopyArgumentError {
             Self::ReplaceNonDirectoryWithDirectory => {
                 "cannot replace non-directory destination with directory"
             }
-            Self::RemoteOperandUnsupported => {
-                "remote operands are not supported: this build handles local filesystem copies only"
-            }
+            Self::RemoteOperandUnsupported => concat!(
+                "remote operands are not supported: this build handles local filesystem copies only; ",
+                "set OC_RSYNC_FALLBACK to point to an upstream rsync binary for remote transfers",
+            ),
         }
     }
 }


### PR DESCRIPTION
## Summary
- mention OC_RSYNC_FALLBACK in the client diagnostic raised for remote operands so users learn how to delegate to upstream rsync
- propagate the improved wording through the local copy error helper to keep diagnostics consistent
- extend the module listing test to assert that the fallback hint is present

## Testing
- cargo test -p rsync-core module_list_request_rejects_ipv6_module_transfer

------