### PR TITLE
Add local copy timeout handling and client error reporting

### DIFF
--- a/crates/core/src/client.rs
+++ b/crates/core/src/client.rs
@@ -4287,6 +4287,14 @@ fn map_local_copy_error(error: LocalCopyError) -> ClientError {
             path,
             source,
         } => io_error(action, &path, source),
+        LocalCopyErrorKind::Timeout { duration } => {
+            let text = format!(
+                "transfer timed out after {:.3} seconds without progress",
+                duration.as_secs_f64()
+            );
+            let message = rsync_error!(exit_code, text).with_role(Role::Client);
+            ClientError::new(exit_code, message)
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- add inactivity timeout configuration to `LocalCopyOptions` and propagate enforcement through the local copy pipeline
- track progress updates so inactivity triggers `LocalCopyErrorKind::Timeout` with accompanying test coverage
- surface timeout failures in the client by mapping them to rsync-style diagnostics and exit code 30

## Testing
- cargo test -p rsync-core --lib
- cargo test -p rsync-engine local_copy_options_timeout_round_trip

------