### PR TITLE
Add %N out-format placeholder support

### DIFF
--- a/crates/core/src/client.rs
+++ b/crates/core/src/client.rs
@@ -3727,10 +3727,12 @@ exit 42
         let error = ModuleListRequest::from_operands(&operands)
             .expect_err("unbracketed IPv6 host should be rejected");
         assert_eq!(error.exit_code(), FEATURE_UNAVAILABLE_EXIT_CODE);
-        assert!(error
-            .message()
-            .to_string()
-            .contains("IPv6 daemon addresses must be enclosed in brackets"));
+        assert!(
+            error
+                .message()
+                .to_string()
+                .contains("IPv6 daemon addresses must be enclosed in brackets")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add support for the `%N` placeholder in --out-format rendering so filenames include symlink targets like upstream rsync
- extend the parser/test matrix to accept the new placeholder and cover it with an integration-style unit test
- run rustfmt on touched assertions to keep formatting consistent

## Testing
- cargo test -p rsync-cli

------