### PR TITLE
Handle remote module operands via fallback

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -7141,6 +7141,41 @@ exit 7
 
     #[cfg(unix)]
     #[test]
+    fn remote_rsync_url_invokes_fallback_binary() {
+        use tempfile::tempdir;
+
+        let _env_lock = ENV_LOCK.lock().expect("env lock");
+        let temp = tempdir().expect("tempdir");
+        let script_path = temp.path().join("fallback.sh");
+        let args_path = temp.path().join("args.txt");
+        std::fs::File::create(&args_path).expect("create args file");
+
+        let script = r#"#!/bin/sh
+printf "%s\n" "$@" > "$ARGS_FILE"
+exit 0
+"#;
+        write_executable_script(&script_path, script);
+
+        let _fallback_guard = EnvGuard::set("OC_RSYNC_FALLBACK", script_path.as_os_str());
+        let _args_guard = EnvGuard::set("ARGS_FILE", args_path.as_os_str());
+
+        let (code, stdout, stderr) = run_with_args([
+            OsString::from("oc-rsync"),
+            OsString::from("--list-only"),
+            OsString::from("rsync://example.com/module"),
+        ]);
+
+        assert_eq!(code, 0);
+        assert!(stdout.is_empty());
+        assert!(stderr.is_empty());
+
+        let recorded = std::fs::read_to_string(&args_path).expect("read args file");
+        assert!(recorded.contains("--list-only"));
+        assert!(recorded.contains("rsync://example.com/module"));
+    }
+
+    #[cfg(unix)]
+    #[test]
     fn remote_fallback_forwards_files_from_entries() {
         use tempfile::tempdir;
 

--- a/crates/core/src/client.rs
+++ b/crates/core/src/client.rs
@@ -3641,9 +3641,8 @@ exit 42
     #[test]
     fn module_list_request_rejects_remote_transfer() {
         let operands = vec![OsString::from("rsync://example.com/module")];
-        let error = ModuleListRequest::from_operands(&operands)
-            .expect_err("module transfer should be rejected");
-        assert!(error.message().to_string().contains("remote operands"));
+        let request = ModuleListRequest::from_operands(&operands).expect("parse succeeds");
+        assert!(request.is_none());
     }
 
     #[test]
@@ -3709,16 +3708,8 @@ exit 42
     #[test]
     fn module_list_request_rejects_ipv6_module_transfer() {
         let operands = vec![OsString::from("[fe80::1]::module")];
-        let error = ModuleListRequest::from_operands(&operands)
-            .expect_err("module transfers should be rejected");
-        assert_eq!(error.exit_code(), PARTIAL_TRANSFER_EXIT_CODE);
-        assert!(
-            error
-                .message()
-                .to_string()
-                .contains("remote operands are not supported")
-        );
-        assert!(error.message().to_string().contains("OC_RSYNC_FALLBACK"));
+        let request = ModuleListRequest::from_operands(&operands).expect("parse succeeds");
+        assert!(request.is_none());
     }
 
     #[test]
@@ -4394,16 +4385,6 @@ fn daemon_access_denied_error(reason: &str) -> ClientError {
     daemon_error(detail, PARTIAL_TRANSFER_EXIT_CODE)
 }
 
-fn remote_operands_unsupported() -> ClientError {
-    daemon_error(
-        concat!(
-            "remote operands are not supported: this build handles local filesystem copies only; ",
-            "set OC_RSYNC_FALLBACK to point to an upstream rsync binary for remote transfers",
-        ),
-        PARTIAL_TRANSFER_EXIT_CODE,
-    )
-}
-
 fn delta_transfer_unsupported() -> ClientError {
     let message = rsync_error!(
         FEATURE_UNAVAILABLE_EXIT_CODE,
@@ -4512,7 +4493,7 @@ impl ModuleListRequest {
         let text = operand.to_string_lossy();
 
         if let Some(rest) = strip_prefix_ignore_ascii_case(&text, "rsync://") {
-            return parse_rsync_url(rest).map(Some);
+            return parse_rsync_url(rest);
         }
 
         if let Some((host_part, module_part)) = split_daemon_host_module(&text) {
@@ -4520,7 +4501,7 @@ impl ModuleListRequest {
                 let target = parse_host_port(host_part)?;
                 return Ok(Some(Self::new(target.address, target.username)));
             }
-            return Err(remote_operands_unsupported());
+            return Ok(None);
         }
 
         Ok(None)
@@ -4560,17 +4541,20 @@ impl ModuleListRequest {
     }
 }
 
-fn parse_rsync_url(rest: &str) -> Result<ModuleListRequest, ClientError> {
+fn parse_rsync_url(rest: &str) -> Result<Option<ModuleListRequest>, ClientError> {
     let mut parts = rest.splitn(2, '/');
     let host_port = parts.next().unwrap_or("");
     let remainder = parts.next();
 
     if remainder.is_some_and(|path| !path.is_empty()) {
-        return Err(remote_operands_unsupported());
+        return Ok(None);
     }
 
     let target = parse_host_port(host_port)?;
-    Ok(ModuleListRequest::new(target.address, target.username))
+    Ok(Some(ModuleListRequest::new(
+        target.address,
+        target.username,
+    )))
 }
 
 struct ParsedDaemonTarget {


### PR DESCRIPTION
## Summary
- treat remote module operands as non-module-listing requests so the CLI can delegate to the fallback rsync binary
- allow `parse_rsync_url` to skip module requests with explicit paths instead of raising an error
- add a regression test that ensures `rsync://` module operands trigger the fallback shim

## Testing
- `cargo test`
- `cargo test -p rsync-core --lib`

------