### PR TITLE
Fix zlib encoder vectored write import

### DIFF
--- a/crates/compress/src/zlib.rs
+++ b/crates/compress/src/zlib.rs
@@ -49,7 +49,7 @@
 
 use std::{
     fmt,
-    io::{self, Read, Write},
+    io::{self, IoSlice, Read, Write},
     num::NonZeroU8,
 };
 


### PR DESCRIPTION
## Summary
- import `IoSlice` for the zlib encoder so its `Write` implementation compiles on stable

## Testing
- cargo test

------