### PR TITLE
Fix missing IoSlice import in zlib module

### DIFF
--- a/crates/compress/src/zlib.rs
+++ b/crates/compress/src/zlib.rs
@@ -49,7 +49,7 @@
 
 use std::{
     fmt,
-    io::{self, Read, Write},
+    io::{self, IoSlice, Read, Write},
     num::NonZeroU8,
 };
 


### PR DESCRIPTION
## Summary
- import `std::io::IoSlice` for the zlib encoder write implementation

## Testing
- cargo test

------