### PR TITLE
Add delete mode selection and engine scheduling

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -89,8 +89,8 @@ use rsync_core::{
     client::{
         BandwidthLimit, ClientConfig, ClientEntryKind, ClientEntryMetadata, ClientEvent,
         ClientEventKind, ClientProgressObserver, ClientProgressUpdate, ClientSummary,
-        CompressionSetting, DirMergeEnforcedKind, DirMergeOptions, FilterRuleKind, FilterRuleSpec,
-        ModuleListRequest, RemoteFallbackArgs, TransferTimeout,
+        CompressionSetting, DeleteMode, DirMergeEnforcedKind, DirMergeOptions, FilterRuleKind,
+        FilterRuleSpec, ModuleListRequest, RemoteFallbackArgs, TransferTimeout,
         run_client_with_observer as run_core_client_with_observer, run_module_list_with_password,
         run_remote_transfer_fallback,
     },
@@ -122,6 +122,8 @@ const HELP_TEXT: &str = concat!(
     "      --list-only  List files without performing a transfer.\n",
     "  -a, --archive    Enable archive mode (implies --owner, --group, --perms, --times, --devices, and --specials).\n",
     "      --delete     Remove destination files that are absent from the source.\n",
+    "      --delete-before  Remove destination files that are absent from the source before transfers start.\n",
+    "      --delete-during  Remove destination files while processing directories.\n",
     "      --delete-after  Remove destination files after transfers complete.\n",
     "      --delete-excluded  Remove excluded destination files during deletion sweeps.\n",
     "  -c, --checksum   Skip updates for files that already match by checksum.\n",
@@ -190,7 +192,7 @@ const HELP_TEXT: &str = concat!(
 );
 
 /// Human-readable list of the options recognised by this development build.
-const SUPPORTED_OPTIONS_LIST: &str = "--help/-h, --version/-V, --daemon, --dry-run/-n, --list-only, --archive/-a, --delete, --delete-after, --checksum/-c, --size-only, --ignore-existing, --exclude, --exclude-from, --include, --include-from, --filter (including exclude-if-present=FILE), --files-from, --password-file, --no-motd, --from0, --bwlimit, --timeout, --protocol, --compress/-z, --no-compress, --compress-level, --verbose/-v, --progress, --no-progress, --msgs2stderr, --out-format, --stats, --partial, --no-partial, --remove-source-files, --remove-sent-files, --inplace, --no-inplace, --whole-file/-W, --no-whole-file, -P, --sparse/-S, --no-sparse, -D, --devices, --no-devices, --specials, --no-specials, --owner, --no-owner, --group, --no-group, --perms/-p, --no-perms, --times/-t, --no-times, --acls/-A, --no-acls, --xattrs/-X, --no-xattrs, --numeric-ids, and --no-numeric-ids";
+const SUPPORTED_OPTIONS_LIST: &str = "--help/-h, --version/-V, --daemon, --dry-run/-n, --list-only, --archive/-a, --delete, --delete-before, --delete-during, --delete-after, --checksum/-c, --size-only, --ignore-existing, --exclude, --exclude-from, --include, --include-from, --filter (including exclude-if-present=FILE), --files-from, --password-file, --no-motd, --from0, --bwlimit, --timeout, --protocol, --compress/-z, --no-compress, --compress-level, --verbose/-v, --progress, --no-progress, --msgs2stderr, --out-format, --stats, --partial, --no-partial, --remove-source-files, --remove-sent-files, --inplace, --no-inplace, --whole-file/-W, --no-whole-file, -P, --sparse/-S, --no-sparse, -D, --devices, --no-devices, --specials, --no-specials, --owner, --no-owner, --group, --no-group, --perms/-p, --no-perms, --times/-t, --no-times, --acls/-A, --no-acls, --xattrs/-X, --no-xattrs, --numeric-ids, and --no-numeric-ids";
 
 /// Timestamp format used for `--list-only` output.
 const LIST_TIMESTAMP_FORMAT: &[FormatItem<'static>] = format_description!(
@@ -559,8 +561,7 @@ struct ParsedArgs {
     dry_run: bool,
     list_only: bool,
     archive: bool,
-    delete: bool,
-    delete_after: bool,
+    delete_mode: DeleteMode,
     delete_excluded: bool,
     checksum: bool,
     size_only: bool,
@@ -862,6 +863,18 @@ fn clap_command() -> ClapCommand {
                 .action(ArgAction::SetTrue),
         )
         .arg(
+            Arg::new("delete-before")
+                .long("delete-before")
+                .help("Remove destination files that are absent from the source before transfers start.")
+                .action(ArgAction::SetTrue),
+        )
+        .arg(
+            Arg::new("delete-during")
+                .long("delete-during")
+                .help("Remove destination files that are absent from the source during directory traversal.")
+                .action(ArgAction::SetTrue),
+        )
+        .arg(
             Arg::new("delete-after")
                 .long("delete-after")
                 .help("Remove destination files after transfers complete.")
@@ -1127,11 +1140,36 @@ where
         dry_run = true;
     }
     let archive = matches.get_flag("archive");
-    let mut delete = matches.get_flag("delete");
-    let delete_after = matches.get_flag("delete-after");
+    let delete_flag = matches.get_flag("delete");
+    let delete_before_flag = matches.get_flag("delete-before");
+    let delete_during_flag = matches.get_flag("delete-during");
+    let delete_after_flag = matches.get_flag("delete-after");
     let delete_excluded = matches.get_flag("delete-excluded");
-    if delete_after || delete_excluded {
-        delete = true;
+
+    let delete_mode_conflicts = [delete_before_flag, delete_during_flag, delete_after_flag]
+        .into_iter()
+        .filter(|flag| *flag)
+        .count();
+
+    if delete_mode_conflicts > 1 {
+        return Err(clap::Error::raw(
+            clap::error::ErrorKind::ArgumentConflict,
+            "--delete-before, --delete-during, and --delete-after are mutually exclusive",
+        ));
+    }
+
+    let mut delete_mode = if delete_before_flag {
+        DeleteMode::Before
+    } else if delete_after_flag {
+        DeleteMode::After
+    } else if delete_during_flag || delete_flag {
+        DeleteMode::During
+    } else {
+        DeleteMode::Disabled
+    };
+
+    if delete_excluded && !delete_mode.is_enabled() {
+        delete_mode = DeleteMode::During;
     }
     let compress_flag = matches.get_flag("compress");
     let no_compress = matches.get_flag("no-compress");
@@ -1308,8 +1346,7 @@ where
         dry_run,
         list_only,
         archive,
-        delete,
-        delete_after,
+        delete_mode,
         delete_excluded,
         checksum,
         size_only,
@@ -1469,8 +1506,7 @@ where
         dry_run,
         list_only,
         archive,
-        delete,
-        delete_after,
+        delete_mode,
         delete_excluded,
         checksum,
         size_only,
@@ -1764,12 +1800,13 @@ where
     let implied_dirs = implied_dirs_option.unwrap_or(true);
     let requires_delta_fallback = whole_file_option == Some(false);
     if requires_delta_fallback || transfer_requires_remote(&remainder, &file_list_operands) {
+        let delete_for_fallback = delete_mode.is_enabled() || delete_excluded;
         let fallback_args = RemoteFallbackArgs {
             dry_run,
             list_only,
             archive,
-            delete,
-            delete_after,
+            delete: delete_for_fallback,
+            delete_mode,
             delete_excluded,
             checksum,
             size_only,
@@ -1881,8 +1918,7 @@ where
         .transfer_args(transfer_operands)
         .dry_run(dry_run)
         .list_only(list_only)
-        .delete(delete)
-        .delete_after(delete_after)
+        .delete(delete_mode.is_enabled() || delete_excluded)
         .delete_excluded(delete_excluded)
         .bandwidth_limit(bandwidth_limit)
         .compression_setting(compression_setting)
@@ -1918,6 +1954,12 @@ where
     {
         builder = builder.xattrs(xattrs.unwrap_or(false));
     }
+
+    builder = match delete_mode {
+        DeleteMode::Before => builder.delete_before(true),
+        DeleteMode::After => builder.delete_after(true),
+        DeleteMode::During | DeleteMode::Disabled => builder,
+    };
 
     builder = builder.force_event_collection(out_format_template.is_some());
 
@@ -6928,7 +6970,7 @@ mod tests {
         ])
         .expect("parse succeeds");
 
-        assert!(parsed.delete);
+        assert_eq!(parsed.delete_mode, DeleteMode::During);
         assert!(!parsed.delete_excluded);
     }
 
@@ -6942,8 +6984,35 @@ mod tests {
         ])
         .expect("parse succeeds");
 
-        assert!(parsed.delete);
-        assert!(parsed.delete_after);
+        assert_eq!(parsed.delete_mode, DeleteMode::After);
+        assert!(!parsed.delete_excluded);
+    }
+
+    #[test]
+    fn delete_before_flag_is_parsed() {
+        let parsed = super::parse_args([
+            OsString::from("oc-rsync"),
+            OsString::from("--delete-before"),
+            OsString::from("source"),
+            OsString::from("dest"),
+        ])
+        .expect("parse succeeds");
+
+        assert_eq!(parsed.delete_mode, DeleteMode::Before);
+        assert!(!parsed.delete_excluded);
+    }
+
+    #[test]
+    fn delete_during_flag_is_parsed() {
+        let parsed = super::parse_args([
+            OsString::from("oc-rsync"),
+            OsString::from("--delete-during"),
+            OsString::from("source"),
+            OsString::from("dest"),
+        ])
+        .expect("parse succeeds");
+
+        assert_eq!(parsed.delete_mode, DeleteMode::During);
         assert!(!parsed.delete_excluded);
     }
 
@@ -6957,7 +7026,7 @@ mod tests {
         ])
         .expect("parse succeeds");
 
-        assert!(parsed.delete);
+        assert!(parsed.delete_mode.is_enabled());
         assert!(parsed.delete_excluded);
     }
 
@@ -7564,6 +7633,82 @@ exit 0
         let args: Vec<&str> = recorded.lines().collect();
         assert!(args.contains(&"--delete"));
         assert!(args.contains(&"--delete-after"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn remote_fallback_forwards_delete_before_flag() {
+        use tempfile::tempdir;
+
+        let _env_lock = ENV_LOCK.lock().expect("env lock");
+        let temp = tempdir().expect("tempdir");
+        let script_path = temp.path().join("fallback.sh");
+        let args_path = temp.path().join("args.txt");
+
+        let script = r#"#!/bin/sh
+printf "%s\n" "$@" > "$ARGS_FILE"
+exit 0
+"#;
+        write_executable_script(&script_path, script);
+
+        let _fallback_guard = EnvGuard::set("OC_RSYNC_FALLBACK", script_path.as_os_str());
+        let _args_guard = EnvGuard::set("ARGS_FILE", args_path.as_os_str());
+
+        let destination = temp.path().join("dest");
+        let (code, stdout, stderr) = run_with_args([
+            OsString::from("oc-rsync"),
+            OsString::from("--delete-before"),
+            OsString::from("remote::module"),
+            destination.into_os_string(),
+        ]);
+
+        assert_eq!(code, 0);
+        assert!(stdout.is_empty());
+        assert!(stderr.is_empty());
+
+        let recorded = std::fs::read_to_string(&args_path).expect("read args file");
+        let args: Vec<&str> = recorded.lines().collect();
+        assert!(args.contains(&"--delete"));
+        assert!(args.contains(&"--delete-before"));
+        assert!(!args.contains(&"--delete-after"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn remote_fallback_forwards_delete_during_flag() {
+        use tempfile::tempdir;
+
+        let _env_lock = ENV_LOCK.lock().expect("env lock");
+        let temp = tempdir().expect("tempdir");
+        let script_path = temp.path().join("fallback.sh");
+        let args_path = temp.path().join("args.txt");
+
+        let script = r#"#!/bin/sh
+printf "%s\n" "$@" > "$ARGS_FILE"
+exit 0
+"#;
+        write_executable_script(&script_path, script);
+
+        let _fallback_guard = EnvGuard::set("OC_RSYNC_FALLBACK", script_path.as_os_str());
+        let _args_guard = EnvGuard::set("ARGS_FILE", args_path.as_os_str());
+
+        let destination = temp.path().join("dest");
+        let (code, stdout, stderr) = run_with_args([
+            OsString::from("oc-rsync"),
+            OsString::from("--delete-during"),
+            OsString::from("remote::module"),
+            destination.into_os_string(),
+        ]);
+
+        assert_eq!(code, 0);
+        assert!(stdout.is_empty());
+        assert!(stderr.is_empty());
+
+        let recorded = std::fs::read_to_string(&args_path).expect("read args file");
+        let args: Vec<&str> = recorded.lines().collect();
+        assert!(args.contains(&"--delete"));
+        assert!(!args.contains(&"--delete-before"));
+        assert!(!args.contains(&"--delete-after"));
     }
 
     #[cfg(unix)]

--- a/crates/core/src/client.rs
+++ b/crates/core/src/client.rs
@@ -253,13 +253,39 @@ impl From<CompressionLevel> for CompressionSetting {
     }
 }
 
+/// Deletion scheduling selected by the caller.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum DeleteMode {
+    /// Do not remove extraneous destination entries.
+    Disabled,
+    /// Remove extraneous entries before transferring file data.
+    Before,
+    /// Remove extraneous entries while processing directory contents (upstream default).
+    During,
+    /// Remove extraneous entries after the transfer completes.
+    After,
+}
+
+impl DeleteMode {
+    /// Returns `true` when deletion sweeps are enabled.
+    #[must_use]
+    pub const fn is_enabled(self) -> bool {
+        !matches!(self, Self::Disabled)
+    }
+}
+
+impl Default for DeleteMode {
+    fn default() -> Self {
+        Self::Disabled
+    }
+}
+
 /// Configuration describing the requested client operation.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ClientConfig {
     transfer_args: Vec<OsString>,
     dry_run: bool,
-    delete: bool,
-    delete_after: bool,
+    delete_mode: DeleteMode,
     delete_excluded: bool,
     remove_source_files: bool,
     bandwidth_limit: Option<BandwidthLimit>,
@@ -301,8 +327,7 @@ impl Default for ClientConfig {
         Self {
             transfer_args: Vec::new(),
             dry_run: false,
-            delete: false,
-            delete_after: false,
+            delete_mode: DeleteMode::Disabled,
             delete_excluded: false,
             remove_source_files: false,
             bandwidth_limit: None,
@@ -388,18 +413,31 @@ impl ClientConfig {
         self.dry_run
     }
 
+    /// Returns the configured deletion mode.
+    #[must_use]
+    pub const fn delete_mode(&self) -> DeleteMode {
+        self.delete_mode
+    }
+
     /// Returns whether extraneous destination files should be removed.
     #[must_use]
     #[doc(alias = "--delete")]
     pub const fn delete(&self) -> bool {
-        self.delete
+        self.delete_mode.is_enabled()
+    }
+
+    /// Returns whether extraneous entries should be removed before the transfer begins.
+    #[must_use]
+    #[doc(alias = "--delete-before")]
+    pub const fn delete_before(&self) -> bool {
+        matches!(self.delete_mode, DeleteMode::Before)
     }
 
     /// Returns whether extraneous entries should be removed after the transfer completes.
     #[must_use]
     #[doc(alias = "--delete-after")]
     pub const fn delete_after(&self) -> bool {
-        self.delete_after
+        matches!(self.delete_mode, DeleteMode::After)
     }
 
     /// Returns whether excluded destination entries should also be deleted.
@@ -627,8 +665,7 @@ impl ClientConfig {
 pub struct ClientConfigBuilder {
     transfer_args: Vec<OsString>,
     dry_run: bool,
-    delete: bool,
-    delete_after: bool,
+    delete_mode: DeleteMode,
     delete_excluded: bool,
     remove_source_files: bool,
     bandwidth_limit: Option<BandwidthLimit>,
@@ -698,7 +735,31 @@ impl ClientConfigBuilder {
     #[must_use]
     #[doc(alias = "--delete")]
     pub const fn delete(mut self, delete: bool) -> Self {
-        self.delete = delete;
+        self.delete_mode = if delete {
+            DeleteMode::During
+        } else {
+            DeleteMode::Disabled
+        };
+        self
+    }
+
+    /// Requests deletion of extraneous entries before the transfer begins.
+    #[must_use]
+    #[doc(alias = "--delete-before")]
+    pub const fn delete_before(mut self, delete_before: bool) -> Self {
+        if delete_before {
+            self.delete_mode = DeleteMode::Before;
+        } else if matches!(self.delete_mode, DeleteMode::Before) {
+            self.delete_mode = DeleteMode::Disabled;
+        }
+        self
+    }
+
+    /// Requests deletion of extraneous entries while directories are processed.
+    #[must_use]
+    #[doc(alias = "--delete-during")]
+    pub const fn delete_during(mut self) -> Self {
+        self.delete_mode = DeleteMode::During;
         self
     }
 
@@ -707,9 +768,10 @@ impl ClientConfigBuilder {
     #[doc(alias = "--delete-after")]
     pub const fn delete_after(mut self, delete_after: bool) -> Self {
         if delete_after {
-            self.delete = true;
+            self.delete_mode = DeleteMode::After;
+        } else if matches!(self.delete_mode, DeleteMode::After) {
+            self.delete_mode = DeleteMode::Disabled;
         }
-        self.delete_after = delete_after;
         self
     }
 
@@ -994,8 +1056,7 @@ impl ClientConfigBuilder {
         ClientConfig {
             transfer_args: self.transfer_args,
             dry_run: self.dry_run,
-            delete: self.delete,
-            delete_after: self.delete_after,
+            delete_mode: self.delete_mode,
             delete_excluded: self.delete_excluded,
             remove_source_files: self.remove_source_files,
             bandwidth_limit: self.bandwidth_limit,
@@ -1448,8 +1509,8 @@ pub struct RemoteFallbackArgs {
     pub archive: bool,
     /// Enables `--delete`.
     pub delete: bool,
-    /// Enables `--delete-after`.
-    pub delete_after: bool,
+    /// Selects the deletion timing to forward to the fallback binary.
+    pub delete_mode: DeleteMode,
     /// Enables `--delete-excluded`.
     pub delete_excluded: bool,
     /// Enables `--checksum`.
@@ -1562,7 +1623,7 @@ where
         list_only,
         archive,
         delete,
-        delete_after,
+        delete_mode,
         delete_excluded,
         checksum,
         size_only,
@@ -1622,9 +1683,11 @@ where
     }
     if delete {
         command_args.push(OsString::from("--delete"));
-    }
-    if delete_after {
-        command_args.push(OsString::from("--delete-after"));
+        match delete_mode {
+            DeleteMode::Before => command_args.push(OsString::from("--delete-before")),
+            DeleteMode::After => command_args.push(OsString::from("--delete-after")),
+            DeleteMode::During | DeleteMode::Disabled => {}
+        }
     }
     if delete_excluded {
         command_args.push(OsString::from("--delete-excluded"));
@@ -2423,9 +2486,16 @@ pub fn run_client_with_observer(
     let filter_program = compile_filter_program(config.filter_rules())?;
 
     let mut options = {
-        let options = LocalCopyOptions::default()
-            .delete(config.delete() || config.delete_excluded() || config.delete_after())
-            .delete_after(config.delete_after())
+        let mut options = LocalCopyOptions::default();
+        if config.delete_mode().is_enabled() || config.delete_excluded() {
+            options = options.delete(true);
+        }
+        options = match config.delete_mode() {
+            DeleteMode::Before => options.delete_before(true),
+            DeleteMode::After => options.delete_after(true),
+            DeleteMode::During | DeleteMode::Disabled => options,
+        };
+        options = options
             .delete_excluded(config.delete_excluded())
             .remove_source_files(config.remove_source_files())
             .bandwidth_limit(
@@ -2568,7 +2638,7 @@ exit 42
             list_only: false,
             archive: false,
             delete: false,
-            delete_after: false,
+            delete_mode: DeleteMode::Disabled,
             delete_excluded: false,
             checksum: false,
             size_only: false,
@@ -2686,6 +2756,7 @@ exit 42
             .build();
 
         assert!(config.delete());
+        assert_eq!(config.delete_mode(), DeleteMode::During);
     }
 
     #[test]
@@ -2697,6 +2768,19 @@ exit 42
 
         assert!(config.delete());
         assert!(config.delete_after());
+        assert_eq!(config.delete_mode(), DeleteMode::After);
+    }
+
+    #[test]
+    fn builder_enables_delete_before() {
+        let config = ClientConfig::builder()
+            .transfer_args([OsString::from("src"), OsString::from("dst")])
+            .delete_before(true)
+            .build();
+
+        assert!(config.delete());
+        assert!(config.delete_before());
+        assert_eq!(config.delete_mode(), DeleteMode::Before);
     }
 
     #[test]

--- a/crates/engine/src/local_copy.rs
+++ b/crates/engine/src/local_copy.rs
@@ -1321,11 +1321,28 @@ where
     }
 }
 
+/// Controls when deletion sweeps run relative to content transfers.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum DeleteTiming {
+    /// Remove extraneous entries before copying new content.
+    Before,
+    /// Remove extraneous entries as directories are processed.
+    During,
+    /// Remove extraneous entries after the full transfer completes.
+    After,
+}
+
+impl DeleteTiming {
+    const fn default() -> Self {
+        Self::During
+    }
+}
+
 /// Options that influence how a [`LocalCopyPlan`] is executed.
 #[derive(Clone, Debug)]
 pub struct LocalCopyOptions {
     delete: bool,
-    delete_after: bool,
+    delete_timing: DeleteTiming,
     delete_excluded: bool,
     remove_source_files: bool,
     bandwidth_limit: Option<NonZeroU64>,
@@ -1364,7 +1381,7 @@ impl LocalCopyOptions {
     pub const fn new() -> Self {
         Self {
             delete: false,
-            delete_after: false,
+            delete_timing: DeleteTiming::default(),
             delete_excluded: false,
             remove_source_files: false,
             bandwidth_limit: None,
@@ -1403,6 +1420,9 @@ impl LocalCopyOptions {
     #[doc(alias = "--delete")]
     pub const fn delete(mut self, delete: bool) -> Self {
         self.delete = delete;
+        if delete {
+            self.delete_timing = DeleteTiming::During;
+        }
         self
     }
 
@@ -1412,8 +1432,38 @@ impl LocalCopyOptions {
     pub const fn delete_after(mut self, delete_after: bool) -> Self {
         if delete_after {
             self.delete = true;
+            self.delete_timing = DeleteTiming::After;
+        } else if self.delete && matches!(self.delete_timing, DeleteTiming::After) {
+            self.delete = false;
+            self.delete_timing = DeleteTiming::default();
         }
-        self.delete_after = delete_after;
+        self
+    }
+
+    /// Requests that extraneous destination files be removed before the transfer begins.
+    #[must_use]
+    #[doc(alias = "--delete-before")]
+    pub const fn delete_before(mut self, delete_before: bool) -> Self {
+        if delete_before {
+            self.delete = true;
+            self.delete_timing = DeleteTiming::Before;
+        } else if self.delete && matches!(self.delete_timing, DeleteTiming::Before) {
+            self.delete = false;
+            self.delete_timing = DeleteTiming::default();
+        }
+        self
+    }
+
+    /// Requests that extraneous destination files be removed while processing directories.
+    #[must_use]
+    #[doc(alias = "--delete-during")]
+    pub const fn delete_during(mut self) -> Self {
+        if self.delete {
+            self.delete_timing = DeleteTiming::During;
+        } else {
+            self.delete = true;
+            self.delete_timing = DeleteTiming::During;
+        }
         self
     }
 
@@ -1668,10 +1718,32 @@ impl LocalCopyOptions {
         self.delete
     }
 
+    /// Returns the configured deletion timing when deletion sweeps are enabled.
+    #[must_use]
+    pub const fn delete_timing(&self) -> Option<DeleteTiming> {
+        if self.delete {
+            Some(self.delete_timing)
+        } else {
+            None
+        }
+    }
+
+    /// Reports whether deletions should occur before content transfers.
+    #[must_use]
+    pub const fn delete_before_enabled(&self) -> bool {
+        matches!(self.delete_timing, DeleteTiming::Before) && self.delete
+    }
+
     /// Reports whether deletions should occur after transfers instead of immediately.
     #[must_use]
     pub const fn delete_after_enabled(&self) -> bool {
-        self.delete_after
+        matches!(self.delete_timing, DeleteTiming::After) && self.delete
+    }
+
+    /// Reports whether deletions should occur while processing directory entries.
+    #[must_use]
+    pub const fn delete_during_enabled(&self) -> bool {
+        matches!(self.delete_timing, DeleteTiming::During) && self.delete
     }
 
     /// Reports whether excluded paths should also be removed during deletion sweeps.
@@ -2312,8 +2384,8 @@ impl<'a> CopyContext<'a> {
         &self.options
     }
 
-    fn delete_after_enabled(&self) -> bool {
-        self.options.delete_after_enabled()
+    fn delete_timing(&self) -> Option<DeleteTiming> {
+        self.options.delete_timing()
     }
 
     fn metadata_options(&self) -> MetadataOptions {
@@ -3986,96 +4058,177 @@ fn copy_directory_recursive(
         }
     }
 
-    let mut keep_names = Vec::new();
+    #[derive(Clone, Copy)]
+    enum EntryAction {
+        SkipExcluded,
+        SkipNonRegular,
+        CopyDirectory,
+        CopyFile,
+        CopySymlink,
+        CopyFifo,
+        CopyDevice,
+    }
+
+    struct PlannedEntry<'a> {
+        entry: &'a DirectoryEntry,
+        relative: PathBuf,
+        action: EntryAction,
+    }
+
+    let deletion_enabled = context.options().delete_extraneous();
+    let delete_timing = context.delete_timing();
+    let mut keep_names = if deletion_enabled {
+        Vec::with_capacity(entries.len())
+    } else {
+        Vec::new()
+    };
+    let mut planned_entries = Vec::with_capacity(entries.len());
 
     for entry in entries.iter() {
         context.enforce_timeout()?;
         context.register_progress();
-        let file_name = &entry.file_name;
-        let entry_path = &entry.path;
+
+        let file_name = entry.file_name.clone();
         let entry_metadata = &entry.metadata;
         let entry_type = entry_metadata.file_type();
-        let target_path = destination.join(Path::new(file_name));
-        let metadata_options = context.metadata_options();
-
-        let entry_relative = match relative {
-            Some(base) => base.join(Path::new(file_name)),
-            None => PathBuf::from(Path::new(file_name)),
+        let relative_path = match relative {
+            Some(base) => base.join(Path::new(&file_name)),
+            None => PathBuf::from(Path::new(&file_name)),
         };
 
-        if !context.allows(&entry_relative, entry_type.is_dir()) {
-            keep_names.push(file_name.clone());
-            continue;
-        }
+        let mut keep_name = true;
 
-        keep_names.push(file_name.clone());
-
-        if entry_type.is_dir() {
-            copy_directory_recursive(
-                context,
-                entry_path,
-                &target_path,
-                entry_metadata,
-                Some(entry_relative.as_path()),
-            )?;
+        let action = if !context.allows(&relative_path, entry_type.is_dir()) {
+            // Skip excluded entries while ensuring they are preserved during deletion sweeps.
+            EntryAction::SkipExcluded
+        } else if entry_type.is_dir() {
+            EntryAction::CopyDirectory
         } else if entry_type.is_file() {
-            copy_file(
-                context,
-                entry_path,
-                &target_path,
-                entry_metadata,
-                Some(entry_relative.as_path()),
-            )?;
+            EntryAction::CopyFile
         } else if entry_type.is_symlink() {
-            copy_symlink(
-                context,
-                entry_path,
-                &target_path,
-                entry_metadata,
-                metadata_options,
-                Some(entry_relative.as_path()),
-            )?;
+            EntryAction::CopySymlink
         } else if is_fifo(&entry_type) {
-            if !context.specials_enabled() {
-                context.record_skipped_non_regular(Some(entry_relative.as_path()));
-                keep_names.pop();
-                continue;
+            if context.specials_enabled() {
+                EntryAction::CopyFifo
+            } else {
+                keep_name = false;
+                EntryAction::SkipNonRegular
             }
-            copy_fifo(
-                context,
-                entry_path,
-                &target_path,
-                entry_metadata,
-                metadata_options,
-                Some(entry_relative.as_path()),
-            )?;
         } else if is_device(&entry_type) {
-            if !context.devices_enabled() {
-                context.record_skipped_non_regular(Some(entry_relative.as_path()));
-                keep_names.pop();
-                continue;
+            if context.devices_enabled() {
+                EntryAction::CopyDevice
+            } else {
+                keep_name = false;
+                EntryAction::SkipNonRegular
             }
-            copy_device(
-                context,
-                entry_path,
-                &target_path,
-                entry_metadata,
-                metadata_options,
-                Some(entry_relative.as_path()),
-            )?;
         } else {
             return Err(LocalCopyError::invalid_argument(
                 LocalCopyArgumentError::UnsupportedFileType,
             ));
+        };
+
+        if deletion_enabled && keep_name {
+            let preserve_name = match delete_timing {
+                Some(DeleteTiming::Before) => matches!(
+                    action,
+                    EntryAction::CopyDirectory | EntryAction::SkipExcluded
+                ),
+                _ => true,
+            };
+
+            if preserve_name {
+                keep_names.push(file_name.clone());
+            }
+        }
+
+        planned_entries.push(PlannedEntry {
+            entry,
+            relative: relative_path,
+            action,
+        });
+    }
+
+    if deletion_enabled && matches!(delete_timing, Some(DeleteTiming::Before)) {
+        delete_extraneous_entries(context, destination, relative, &keep_names)?;
+    }
+
+    for planned in planned_entries {
+        let file_name = &planned.entry.file_name;
+        let target_path = destination.join(Path::new(file_name));
+        let entry_metadata = &planned.entry.metadata;
+        let record_relative = non_empty_path(planned.relative.as_path());
+
+        match planned.action {
+            EntryAction::SkipExcluded => {}
+            EntryAction::SkipNonRegular => {
+                context.record_skipped_non_regular(record_relative);
+            }
+            EntryAction::CopyDirectory => {
+                copy_directory_recursive(
+                    context,
+                    planned.entry.path.as_path(),
+                    &target_path,
+                    entry_metadata,
+                    Some(planned.relative.as_path()),
+                )?;
+            }
+            EntryAction::CopyFile => {
+                copy_file(
+                    context,
+                    planned.entry.path.as_path(),
+                    &target_path,
+                    entry_metadata,
+                    Some(planned.relative.as_path()),
+                )?;
+            }
+            EntryAction::CopySymlink => {
+                let metadata_options = context.metadata_options();
+                copy_symlink(
+                    context,
+                    planned.entry.path.as_path(),
+                    &target_path,
+                    entry_metadata,
+                    metadata_options,
+                    Some(planned.relative.as_path()),
+                )?;
+            }
+            EntryAction::CopyFifo => {
+                let metadata_options = context.metadata_options();
+                copy_fifo(
+                    context,
+                    planned.entry.path.as_path(),
+                    &target_path,
+                    entry_metadata,
+                    metadata_options,
+                    Some(planned.relative.as_path()),
+                )?;
+            }
+            EntryAction::CopyDevice => {
+                let metadata_options = context.metadata_options();
+                copy_device(
+                    context,
+                    planned.entry.path.as_path(),
+                    &target_path,
+                    entry_metadata,
+                    metadata_options,
+                    Some(planned.relative.as_path()),
+                )?;
+            }
         }
     }
 
-    if context.options().delete_extraneous() {
-        if context.delete_after_enabled() {
-            let relative_owned = relative.map(Path::to_path_buf);
-            context.defer_deletion(destination.to_path_buf(), relative_owned, keep_names);
-        } else {
-            delete_extraneous_entries(context, destination, relative, &keep_names)?;
+    if deletion_enabled {
+        match delete_timing.unwrap_or(DeleteTiming::During) {
+            DeleteTiming::Before => {
+                // Deletions already performed prior to copying.
+            }
+            DeleteTiming::During => {
+                delete_extraneous_entries(context, destination, relative, &keep_names)?;
+            }
+            DeleteTiming::After => {
+                let relative_owned = relative.map(Path::to_path_buf);
+                context.defer_deletion(destination.to_path_buf(), relative_owned, keep_names);
+            }
         }
     }
 
@@ -6795,6 +6948,33 @@ mod tests {
         assert!(!dest_root.join("extra.txt").exists());
         assert_eq!(summary.files_copied(), 1);
         assert_eq!(summary.items_deleted(), 1);
+    }
+
+    #[test]
+    fn execute_with_delete_before_removes_conflicting_entries() {
+        let temp = tempdir().expect("tempdir");
+        let source_root = temp.path().join("source");
+        fs::create_dir_all(&source_root).expect("create source root");
+        fs::write(source_root.join("file"), b"fresh").expect("write source file");
+
+        let dest_root = temp.path().join("dest");
+        fs::create_dir_all(dest_root.join("file")).expect("create conflicting directory");
+
+        let mut source_operand = source_root.clone().into_os_string();
+        source_operand.push(std::path::MAIN_SEPARATOR.to_string());
+        let operands = vec![source_operand, dest_root.clone().into_os_string()];
+        let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+        let options = LocalCopyOptions::default().delete_before(true);
+
+        let summary = plan
+            .execute_with_options(LocalCopyExecution::Apply, options)
+            .expect("copy succeeds with delete-before");
+
+        let target = dest_root.join("file");
+        assert_eq!(fs::read(&target).expect("read copied file"), b"fresh");
+        assert!(target.is_file());
+        assert_eq!(summary.files_copied(), 1);
+        assert!(summary.items_deleted() >= 1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add client configuration support for selecting delete timing and parse `--delete-before`/`--delete-during`
- extend the local copy engine with a configurable delete timing pipeline and delete-before conflict handling
- update CLI help text and supported option listings for the new deletion modes

## Testing
- cargo test -p rsync-cli
- cargo test -p rsync-core
- cargo test -p rsync-engine

------