### PR TITLE
Add tests and documentation for daemon log file support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,6 +419,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -648,6 +657,7 @@ dependencies = [
  "rsync-logging",
  "rsync-protocol",
  "tempfile",
+ "time",
 ]
 
 [[package]]
@@ -848,7 +858,9 @@ checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
 dependencies = [
  "deranged",
  "itoa",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
  "serde",
  "time-core",

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -15,6 +15,7 @@ rsync-core = { path = "../core" }
 rsync-protocol = { path = "../protocol" }
 rsync-logging = { path = "../logging" }
 rsync-checksums = { path = "../checksums" }
+time = { version = "0.3", default-features = false, features = ["formatting", "local-offset", "macros", "std"] }
 
 [dev-dependencies]
 tempfile = "3.10"


### PR DESCRIPTION
## Summary
- add the `time` dependency and logging handle to write timestamped daemon log entries
- document the `--log-file` flag in the static help output
- add unit and integration tests covering log-file parsing plus legacy and binary session logging

## Testing
- cargo test -p rsync-daemon

------