### PR TITLE
Unify daemon session handling entry point

### DIFF
--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -2062,7 +2062,7 @@ fn serve_connections(options: RuntimeOptions) -> Result<(), DaemonError> {
                 let handle = thread::spawn(move || {
                     let modules_vec = modules.as_ref();
                     let motd_vec = motd_lines.as_ref();
-                    handle_session_with_log(
+                    handle_session(
                         stream,
                         peer_addr,
                         modules_vec.as_slice(),
@@ -2149,16 +2149,6 @@ fn configure_stream(stream: &TcpStream) -> io::Result<()> {
 }
 
 fn handle_session(
-    stream: TcpStream,
-    peer_addr: SocketAddr,
-    modules: &[ModuleRuntime],
-    motd_lines: &[String],
-    daemon_limit: Option<NonZeroU64>,
-) -> io::Result<()> {
-    handle_session_with_log(stream, peer_addr, modules, motd_lines, daemon_limit, None)
-}
-
-fn handle_session_with_log(
     stream: TcpStream,
     peer_addr: SocketAddr,
     modules: &[ModuleRuntime],


### PR DESCRIPTION
## Summary
- remove the unused `handle_session` wrapper and make the logging-capable variant the sole entry point
- update the worker spawning logic to call the unified handler so builds remain warning-free under `-D warnings`

## Testing
- cargo test

------