### PR TITLE
Route CLI fallback through core orchestration

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -88,11 +88,10 @@ use rsync_core::{
     bandwidth::BandwidthParseError,
     client::{
         BandwidthLimit, ClientConfig, ClientEntryKind, ClientEntryMetadata, ClientEvent,
-        ClientEventKind, ClientProgressObserver, ClientProgressUpdate, ClientSummary,
-        CompressionSetting, DirMergeEnforcedKind, DirMergeOptions, FilterRuleKind, FilterRuleSpec,
-        ModuleListRequest, RemoteFallbackArgs, TransferTimeout,
-        run_client_with_observer as run_core_client_with_observer, run_module_list_with_password,
-        run_remote_transfer_fallback,
+        ClientEventKind, ClientOutcome, ClientProgressObserver, ClientProgressUpdate,
+        ClientSummary, CompressionSetting, DirMergeEnforcedKind, DirMergeOptions, FilterRuleKind,
+        FilterRuleSpec, ModuleListRequest, RemoteFallbackArgs, RemoteFallbackContext,
+        TransferTimeout, run_client_or_fallback, run_module_list_with_password,
     },
     message::{Message, Role},
     rsync_error,
@@ -1763,8 +1762,11 @@ where
     let implied_dirs_option = implied_dirs;
     let implied_dirs = implied_dirs_option.unwrap_or(true);
     let requires_delta_fallback = whole_file_option == Some(false);
-    if requires_delta_fallback || transfer_requires_remote(&remainder, &file_list_operands) {
-        let fallback_args = RemoteFallbackArgs {
+    let requires_remote_fallback = transfer_requires_remote(&remainder, &file_list_operands);
+    let fallback_required = requires_delta_fallback || requires_remote_fallback;
+
+    let fallback_args = if fallback_required {
+        Some(RemoteFallbackArgs {
             dry_run,
             list_only,
             archive,
@@ -1795,14 +1797,14 @@ where
             inplace,
             msgs_to_stderr,
             whole_file: whole_file_option,
-            bwlimit,
-            excludes,
-            includes,
-            exclude_from,
-            include_from,
-            filters,
+            bwlimit: bwlimit.clone(),
+            excludes: excludes.clone(),
+            includes: includes.clone(),
+            exclude_from: exclude_from.clone(),
+            include_from: include_from.clone(),
+            filters: filters.clone(),
             files_from_used,
-            file_list_entries: file_list_operands,
+            file_list_entries: file_list_operands.clone(),
             from0,
             password_file: password_file.clone(),
             protocol: desired_protocol,
@@ -1810,58 +1812,48 @@ where
             out_format: out_format.clone(),
             no_motd,
             fallback_binary: None,
-            remainder,
+            remainder: remainder.clone(),
             #[cfg(feature = "acl")]
             acls,
             #[cfg(feature = "xattr")]
             xattrs,
-        };
-        let fallback_result = {
-            let mut stderr_writer = stderr.writer_mut();
-            run_remote_transfer_fallback(stdout, &mut stderr_writer, fallback_args)
-        };
-        return match fallback_result {
-            Ok(code) => code,
-            Err(error) => {
-                if write_message(error.message(), stderr).is_err() {
-                    let fallback = error.message().to_string();
-                    let _ = writeln!(stderr.writer_mut(), "{}", fallback);
-                }
-                error.exit_code()
-            }
-        };
-    }
+        })
+    } else {
+        None
+    };
 
     let numeric_ids = numeric_ids_option.unwrap_or(false);
 
-    if desired_protocol.is_some() {
-        let message = rsync_error!(
-            1,
-            "the --protocol option may only be used when accessing an rsync daemon"
-        )
-        .with_role(Role::Client);
-        if write_message(&message, stderr).is_err() {
-            let _ = writeln!(
-                stderr.writer_mut(),
+    if !fallback_required {
+        if desired_protocol.is_some() {
+            let message = rsync_error!(
+                1,
                 "the --protocol option may only be used when accessing an rsync daemon"
-            );
+            )
+            .with_role(Role::Client);
+            if write_message(&message, stderr).is_err() {
+                let _ = writeln!(
+                    stderr.writer_mut(),
+                    "the --protocol option may only be used when accessing an rsync daemon"
+                );
+            }
+            return 1;
         }
-        return 1;
-    }
 
-    if password_file.is_some() {
-        let message = rsync_error!(
-            1,
-            "the --password-file option may only be used when accessing an rsync daemon"
-        )
-        .with_role(Role::Client);
-        if write_message(&message, stderr).is_err() {
-            let _ = writeln!(
-                stderr.writer_mut(),
+        if password_file.is_some() {
+            let message = rsync_error!(
+                1,
                 "the --password-file option may only be used when accessing an rsync daemon"
-            );
+            )
+            .with_role(Role::Client);
+            if write_message(&message, stderr).is_err() {
+                let _ = writeln!(
+                    stderr.writer_mut(),
+                    "the --password-file option may only be used when accessing an rsync daemon"
+                );
+            }
+            return 1;
         }
-        return 1;
     }
 
     let mut transfer_operands = Vec::with_capacity(file_list_operands.len() + remainder.len());
@@ -1983,6 +1975,31 @@ where
 
     let config = builder.build();
 
+    if let Some(args) = fallback_args {
+        let outcome = {
+            let mut stderr_writer = stderr.writer_mut();
+            run_client_or_fallback(
+                config,
+                None,
+                Some(RemoteFallbackContext::new(stdout, &mut stderr_writer, args)),
+            )
+        };
+
+        return match outcome {
+            Ok(ClientOutcome::Fallback(summary)) => summary.exit_code(),
+            Ok(ClientOutcome::Local(_)) => {
+                unreachable!("local outcome returned without fallback context")
+            }
+            Err(error) => {
+                if write_message(error.message(), stderr).is_err() {
+                    let fallback = error.message().to_string();
+                    let _ = writeln!(stderr.writer_mut(), "{}", fallback);
+                }
+                error.exit_code()
+            }
+        };
+    }
+
     let mut live_progress = if progress {
         Some(with_output_writer(
             stdout,
@@ -1998,11 +2015,11 @@ where
         let observer = live_progress
             .as_mut()
             .map(|observer| observer as &mut dyn ClientProgressObserver);
-        run_core_client_with_observer(config, observer)
+        run_client_or_fallback::<io::Sink, io::Sink>(config, observer, None)
     };
 
     match result {
-        Ok(summary) => {
+        Ok(ClientOutcome::Local(summary)) => {
             let progress_rendered_live = live_progress.as_ref().is_some_and(LiveProgress::rendered);
 
             if let Some(observer) = live_progress {
@@ -2033,6 +2050,9 @@ where
                 });
             }
             0
+        }
+        Ok(ClientOutcome::Fallback(_)) => {
+            unreachable!("fallback outcome returned without fallback args")
         }
         Err(error) => {
             if let Some(observer) = live_progress {
@@ -5370,7 +5390,12 @@ mod tests {
             .force_event_collection(true)
             .build();
 
-        let summary = run_core_client_with_observer(config, None).expect("run client");
+        let outcome =
+            run_client_or_fallback::<io::Sink, io::Sink>(config, None, None).expect("run client");
+        let summary = match outcome {
+            ClientOutcome::Local(summary) => summary,
+            ClientOutcome::Fallback(_) => panic!("unexpected fallback outcome"),
+        };
         let event = summary
             .events()
             .iter()
@@ -5426,7 +5451,12 @@ mod tests {
             .force_event_collection(true)
             .build();
 
-        let summary = run_core_client_with_observer(config, None).expect("run client");
+        let outcome =
+            run_client_or_fallback::<io::Sink, io::Sink>(config, None, None).expect("run client");
+        let summary = match outcome {
+            ClientOutcome::Local(summary) => summary,
+            ClientOutcome::Fallback(_) => panic!("unexpected fallback outcome"),
+        };
         let event = summary
             .events()
             .iter()
@@ -8039,7 +8069,12 @@ exit 0
             .force_event_collection(true)
             .build();
 
-        let summary = run_core_client_with_observer(config, None).expect("run client");
+        let outcome =
+            run_client_or_fallback::<io::Sink, io::Sink>(config, None, None).expect("run client");
+        let summary = match outcome {
+            ClientOutcome::Local(summary) => summary,
+            ClientOutcome::Fallback(_) => panic!("unexpected fallback outcome"),
+        };
         let event = summary
             .events()
             .iter()
@@ -8081,7 +8116,12 @@ exit 0
             .force_event_collection(true)
             .build();
 
-        let summary = run_core_client_with_observer(config, None).expect("run client");
+        let outcome =
+            run_client_or_fallback::<io::Sink, io::Sink>(config, None, None).expect("run client");
+        let summary = match outcome {
+            ClientOutcome::Local(summary) => summary,
+            ClientOutcome::Fallback(_) => panic!("unexpected fallback outcome"),
+        };
         let event = summary
             .events()
             .iter()

--- a/crates/core/src/client.rs
+++ b/crates/core/src/client.rs
@@ -99,9 +99,9 @@ use rsync_compress::zlib::{CompressionLevel, CompressionLevelError};
 pub use rsync_engine::local_copy::{DirMergeEnforcedKind, DirMergeOptions};
 use rsync_engine::local_copy::{
     DirMergeRule, ExcludeIfPresentRule, FilterProgram, FilterProgramEntry, LocalCopyAction,
-    LocalCopyError, LocalCopyErrorKind, LocalCopyExecution, LocalCopyFileKind, LocalCopyMetadata,
-    LocalCopyOptions, LocalCopyPlan, LocalCopyProgress, LocalCopyRecord, LocalCopyRecordHandler,
-    LocalCopyReport, LocalCopySummary,
+    LocalCopyArgumentError, LocalCopyError, LocalCopyErrorKind, LocalCopyExecution,
+    LocalCopyFileKind, LocalCopyMetadata, LocalCopyOptions, LocalCopyPlan, LocalCopyProgress,
+    LocalCopyRecord, LocalCopyRecordHandler, LocalCopyReport, LocalCopySummary,
 };
 use rsync_filters::FilterRule as EngineFilterRule;
 use rsync_protocol::{
@@ -1432,6 +1432,43 @@ impl ClientSummary {
     }
 }
 
+/// Outcome returned when executing [`run_client_or_fallback`].
+#[derive(Debug)]
+pub enum ClientOutcome {
+    /// The transfer was handled by the local copy engine.
+    Local(ClientSummary),
+    /// The transfer was delegated to an upstream `rsync` binary.
+    Fallback(FallbackSummary),
+}
+
+impl ClientOutcome {
+    /// Returns the contained [`ClientSummary`] when the outcome represents a local execution.
+    pub fn into_local(self) -> Option<ClientSummary> {
+        match self {
+            Self::Local(summary) => Some(summary),
+            Self::Fallback(_) => None,
+        }
+    }
+}
+
+/// Summary describing the result of a fallback invocation.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct FallbackSummary {
+    exit_code: i32,
+}
+
+impl FallbackSummary {
+    const fn new(exit_code: i32) -> Self {
+        Self { exit_code }
+    }
+
+    /// Returns the exit code reported by the fallback process.
+    #[must_use]
+    pub const fn exit_code(self) -> i32 {
+        self.exit_code
+    }
+}
+
 /// Arguments used to spawn the legacy `rsync` binary when remote operands are present.
 ///
 /// The fallback path preserves the command-line semantics of upstream rsync while the
@@ -1541,6 +1578,42 @@ pub struct RemoteFallbackArgs {
     /// Controls xattr forwarding (`--xattrs`/`--no-xattrs`).
     #[cfg(feature = "xattr")]
     pub xattrs: Option<bool>,
+}
+
+/// Writer references and arguments required to invoke the fallback binary.
+pub struct RemoteFallbackContext<'a, Out, Err>
+where
+    Out: Write + 'a,
+    Err: Write + 'a,
+{
+    stdout: &'a mut Out,
+    stderr: &'a mut Err,
+    args: RemoteFallbackArgs,
+}
+
+impl<'a, Out, Err> RemoteFallbackContext<'a, Out, Err>
+where
+    Out: Write + 'a,
+    Err: Write + 'a,
+{
+    /// Creates a new context that streams output into the supplied writers.
+    #[must_use]
+    pub fn new(stdout: &'a mut Out, stderr: &'a mut Err, args: RemoteFallbackArgs) -> Self {
+        Self {
+            stdout,
+            stderr,
+            args,
+        }
+    }
+
+    fn split(self) -> (&'a mut Out, &'a mut Err, RemoteFallbackArgs) {
+        let Self {
+            stdout,
+            stderr,
+            args,
+        } = self;
+        (stdout, stderr, args)
+    }
 }
 
 /// Spawns the fallback `rsync` binary with arguments derived from [`RemoteFallbackArgs`].
@@ -2401,7 +2474,11 @@ impl<'a> LocalCopyRecordHandler for ClientProgressForwarder<'a> {
 /// delta compression remain works in progress, while remote operands delegate to
 /// the system `rsync` binary until the native network engine is available.
 pub fn run_client(config: ClientConfig) -> Result<ClientSummary, ClientError> {
-    run_client_with_observer(config, None)
+    match run_client_internal::<io::Sink, io::Sink>(config, None, None) {
+        Ok(ClientOutcome::Local(summary)) => Ok(summary),
+        Ok(ClientOutcome::Fallback(_)) => unreachable!("fallback unavailable without context"),
+        Err(error) => Err(error),
+    }
 }
 
 /// Runs the client orchestration while forwarding progress updates to the provided observer.
@@ -2409,16 +2486,68 @@ pub fn run_client_with_observer(
     config: ClientConfig,
     observer: Option<&mut dyn ClientProgressObserver>,
 ) -> Result<ClientSummary, ClientError> {
+    match run_client_internal::<io::Sink, io::Sink>(config, observer, None) {
+        Ok(ClientOutcome::Local(summary)) => Ok(summary),
+        Ok(ClientOutcome::Fallback(_)) => unreachable!("fallback unavailable without context"),
+        Err(error) => Err(error),
+    }
+}
+
+/// Executes the client flow, delegating to a fallback `rsync` binary when provided.
+pub fn run_client_or_fallback<Out, Err>(
+    config: ClientConfig,
+    observer: Option<&mut dyn ClientProgressObserver>,
+    fallback: Option<RemoteFallbackContext<'_, Out, Err>>,
+) -> Result<ClientOutcome, ClientError>
+where
+    Out: Write,
+    Err: Write,
+{
+    run_client_internal(config, observer, fallback)
+}
+
+fn run_client_internal<Out, Err>(
+    config: ClientConfig,
+    observer: Option<&mut dyn ClientProgressObserver>,
+    fallback: Option<RemoteFallbackContext<'_, Out, Err>>,
+) -> Result<ClientOutcome, ClientError>
+where
+    Out: Write,
+    Err: Write,
+{
     if !config.has_transfer_request() {
         return Err(missing_operands_error());
     }
 
+    let mut fallback = fallback;
+
     if !config.whole_file() {
+        if let Some(ctx) = fallback.take() {
+            return invoke_fallback(ctx);
+        }
         return Err(delta_transfer_unsupported());
     }
 
-    let plan =
-        LocalCopyPlan::from_operands(config.transfer_args()).map_err(map_local_copy_error)?;
+    let plan = match LocalCopyPlan::from_operands(config.transfer_args()) {
+        Ok(plan) => plan,
+        Err(error) => {
+            let requires_fallback =
+                matches!(
+                    error.kind(),
+                    LocalCopyErrorKind::InvalidArgument(
+                        LocalCopyArgumentError::RemoteOperandUnsupported,
+                    )
+                ) || matches!(error.kind(), LocalCopyErrorKind::MissingSourceOperands);
+
+            if requires_fallback {
+                if let Some(ctx) = fallback.take() {
+                    return invoke_fallback(ctx);
+                }
+            }
+
+            return Err(map_local_copy_error(error));
+        }
+    };
 
     let filter_program = compile_filter_program(config.filter_rules())?;
 
@@ -2475,7 +2604,7 @@ pub fn run_client_with_observer(
         .map(|observer| ClientProgressForwarder::new(observer, &plan, options.clone()))
         .transpose()?;
 
-    if collect_events {
+    let summary = if collect_events {
         plan.execute_with_report_and_handler(
             mode,
             options,
@@ -2484,7 +2613,6 @@ pub fn run_client_with_observer(
                 .map(ClientProgressForwarder::as_handler_mut),
         )
         .map(ClientSummary::from_report)
-        .map_err(map_local_copy_error)
     } else {
         plan.execute_with_options_and_handler(
             mode,
@@ -2494,8 +2622,23 @@ pub fn run_client_with_observer(
                 .map(ClientProgressForwarder::as_handler_mut),
         )
         .map(ClientSummary::from_summary)
+    };
+
+    summary
+        .map(ClientOutcome::Local)
         .map_err(map_local_copy_error)
-    }
+}
+
+fn invoke_fallback<Out, Err>(
+    ctx: RemoteFallbackContext<'_, Out, Err>,
+) -> Result<ClientOutcome, ClientError>
+where
+    Out: Write,
+    Err: Write,
+{
+    let (stdout, stderr, args) = ctx.split();
+    run_remote_transfer_fallback(stdout, stderr, args)
+        .map(|code| ClientOutcome::Fallback(FallbackSummary::new(code)))
 }
 
 #[cfg(test)]
@@ -2986,6 +3129,93 @@ exit 42
         assert_eq!(
             String::from_utf8(stdout).expect("stdout utf8"),
             "alpha\nbeta\nfallback stdout\n"
+        );
+        assert_eq!(
+            String::from_utf8(stderr).expect("stderr utf8"),
+            "fallback stderr\n"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn run_client_or_fallback_uses_fallback_for_remote_operands() {
+        let _lock = env_lock().lock().expect("env mutex poisoned");
+        let temp = tempdir().expect("tempdir created");
+        let script = write_fallback_script(temp.path());
+
+        let config = ClientConfig::builder()
+            .transfer_args([OsString::from("remote::module"), OsString::from("/tmp/dst")])
+            .build();
+
+        let mut args = baseline_fallback_args();
+        args.remainder = vec![OsString::from("remote::module"), OsString::from("/tmp/dst")];
+        args.fallback_binary = Some(script.into_os_string());
+
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+        let context = RemoteFallbackContext::new(&mut stdout, &mut stderr, args);
+
+        let outcome = run_client_or_fallback(config, None, Some(context))
+            .expect("fallback invocation succeeds");
+
+        match outcome {
+            ClientOutcome::Fallback(summary) => {
+                assert_eq!(summary.exit_code(), 42);
+            }
+            ClientOutcome::Local(_) => panic!("expected fallback outcome"),
+        }
+
+        assert_eq!(
+            String::from_utf8(stdout).expect("stdout utf8"),
+            "fallback stdout\n"
+        );
+        assert_eq!(
+            String::from_utf8(stderr).expect("stderr utf8"),
+            "fallback stderr\n"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn run_client_or_fallback_uses_fallback_for_delta_mode() {
+        let _lock = env_lock().lock().expect("env mutex poisoned");
+        let temp = tempdir().expect("tempdir created");
+        let script = write_fallback_script(temp.path());
+
+        let source_path = temp.path().join("source.txt");
+        let dest_path = temp.path().join("dest.txt");
+        fs::write(&source_path, b"delta-test").expect("source created");
+
+        let source = OsString::from(source_path.as_os_str());
+        let dest = OsString::from(dest_path.as_os_str());
+
+        let config = ClientConfig::builder()
+            .transfer_args([source.clone(), dest.clone()])
+            .whole_file(false)
+            .build();
+
+        let mut args = baseline_fallback_args();
+        args.remainder = vec![source, dest];
+        args.whole_file = Some(false);
+        args.fallback_binary = Some(script.into_os_string());
+
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+        let context = RemoteFallbackContext::new(&mut stdout, &mut stderr, args);
+
+        let outcome = run_client_or_fallback(config, None, Some(context))
+            .expect("fallback invocation succeeds");
+
+        match outcome {
+            ClientOutcome::Fallback(summary) => {
+                assert_eq!(summary.exit_code(), 42);
+            }
+            ClientOutcome::Local(_) => panic!("expected fallback outcome"),
+        }
+
+        assert_eq!(
+            String::from_utf8(stdout).expect("stdout utf8"),
+            "fallback stdout\n"
         );
         assert_eq!(
             String::from_utf8(stderr).expect("stderr utf8"),


### PR DESCRIPTION
## Summary
- integrate the CLI with `core::run_client_or_fallback`, cloning parsed arguments for reuse, and defer daemon-only option errors when a remote or delta fallback is required
- extend the core client facade with `ClientOutcome`, `FallbackSummary`, and `RemoteFallbackContext`, ensuring fallback execution for remote operands or delta mode and adding unit coverage for those paths

## Testing
- cargo test

------