### PR TITLE
Handle local delta transfers without remote fallback

### DIFF
--- a/crates/engine/src/signature.rs
+++ b/crates/engine/src/signature.rs
@@ -150,6 +150,15 @@ impl SignatureAlgorithm {
             SignatureAlgorithm::Xxh3_128 { seed } => Xxh3_128::digest(seed, data).as_ref().to_vec(),
         }
     }
+
+    /// Computes a strong digest truncated to `len` bytes.
+    pub(crate) fn compute_truncated(self, data: &[u8], len: usize) -> Vec<u8> {
+        let mut digest = self.compute_full(data);
+        if len < digest.len() {
+            digest.truncate(len);
+        }
+        digest
+    }
 }
 
 /// Describes a single block within a file signature.


### PR DESCRIPTION
## Summary
- execute local delta transfers without forcing the remote fallback path in the CLI
- propagate the `whole_file` flag into local copy execution and update client tests for the new behaviour
- keep the delta signature helper in sync by exposing a truncated strong checksum routine for reuse

## Testing
- cargo test

------