### PR TITLE
Add owner/group name support to --out-format placeholders

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -607,6 +607,7 @@ dependencies = [
  "rustix 0.38.44",
  "tempfile",
  "time",
+ "users",
  "xattr",
 ]
 
@@ -888,6 +889,16 @@ name = "unicode-ident"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
+
+[[package]]
+name = "users"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24cc0f6d6f267b73e5a2cadf007ba8f9bc39c6a6f9666f8cf25ea809a153b032"
+dependencies = [
+ "libc",
+ "log",
+]
 
 [[package]]
 name = "utf8parse"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -20,6 +20,7 @@ rsync-protocol = { path = "../protocol" }
 rsync-compress = { path = "../compress" }
 time = { version = "0.3", default-features = false, features = ["formatting", "macros"] }
 tempfile = "3.10"
+users = "0.11"
 
 [dev-dependencies]
 filetime = "0.2"


### PR DESCRIPTION
## Summary
- add `%u`/`%g` owner and group name placeholders to the `--out-format` renderer using system account lookups
- reduce redundant string cloning while tokenising the user-defined format string

## Testing
- cargo test -p rsync-cli out_format

------