### PR TITLE
Forward --delete-during to fallback rsync

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -8043,6 +8043,7 @@ exit 0
         let recorded = std::fs::read_to_string(&args_path).expect("read args file");
         let args: Vec<&str> = recorded.lines().collect();
         assert!(args.contains(&"--delete"));
+        assert!(args.contains(&"--delete-during"));
         assert!(!args.contains(&"--delete-before"));
         assert!(!args.contains(&"--delete-after"));
     }

--- a/crates/core/src/client.rs
+++ b/crates/core/src/client.rs
@@ -1803,7 +1803,8 @@ where
         match delete_mode {
             DeleteMode::Before => command_args.push(OsString::from("--delete-before")),
             DeleteMode::After => command_args.push(OsString::from("--delete-after")),
-            DeleteMode::During | DeleteMode::Disabled => {}
+            DeleteMode::During => command_args.push(OsString::from("--delete-during")),
+            DeleteMode::Disabled => {}
         }
     }
     if delete_excluded {


### PR DESCRIPTION
## Summary
- ensure the fallback rsync invocation passes `--delete-during` when the caller requested mid-transfer deletions
- extend the CLI regression test to confirm the forwarded arguments include the new flag

## Testing
- cargo test

------