### PR TITLE
Forward copy-links flag to fallback rsync

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -2014,6 +2014,7 @@ where
             perms,
             times,
             numeric_ids: numeric_ids_option,
+            copy_links,
             sparse,
             devices,
             specials,


### PR DESCRIPTION
## Summary
- extend the CLI's fallback argument construction to forward explicit --copy-links/--no-copy-links requests
- add RemoteFallbackArgs plumbing and tests so fallback invocations include the correct copy-links toggle

## Testing
- `cargo test`

------