### PR TITLE
Forward --info flags to fallback

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -2206,6 +2206,7 @@ where
             exclude_from: exclude_from.clone(),
             include_from: include_from.clone(),
             filters: filters.clone(),
+            info_flags: info.clone(),
             files_from_used,
             file_list_entries: file_list_operands.clone(),
             from0,
@@ -8859,6 +8860,43 @@ exit 0
         assert!(!args.contains(&"--delete-before"));
         assert!(!args.contains(&"--delete-after"));
         assert!(!args.contains(&"--delete-during"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn remote_fallback_forwards_info_flags() {
+        use tempfile::tempdir;
+
+        let _env_lock = ENV_LOCK.lock().expect("env lock");
+        let _rsh_guard = clear_rsync_rsh();
+        let temp = tempdir().expect("tempdir");
+        let script_path = temp.path().join("fallback.sh");
+        let args_path = temp.path().join("args.txt");
+
+        let script = r#"#!/bin/sh
+printf "%s\n" "$@" > "$ARGS_FILE"
+exit 0
+"#;
+        write_executable_script(&script_path, script);
+
+        let _fallback_guard = EnvGuard::set("OC_RSYNC_FALLBACK", script_path.as_os_str());
+        let _args_guard = EnvGuard::set("ARGS_FILE", args_path.as_os_str());
+
+        let destination = temp.path().join("dest");
+        let (code, stdout, stderr) = run_with_args([
+            OsString::from("oc-rsync"),
+            OsString::from("--info=progress2"),
+            OsString::from("remote::module"),
+            destination.into_os_string(),
+        ]);
+
+        assert_eq!(code, 0);
+        assert!(stdout.is_empty());
+        assert!(stderr.is_empty());
+
+        let recorded = std::fs::read_to_string(&args_path).expect("read args file");
+        let args: Vec<&str> = recorded.lines().collect();
+        assert!(args.contains(&"--info=progress2"));
     }
 
     #[cfg(unix)]

--- a/crates/core/src/client.rs
+++ b/crates/core/src/client.rs
@@ -1721,6 +1721,8 @@ pub struct RemoteFallbackArgs {
     pub include_from: Vec<OsString>,
     /// Raw filter directives forwarded via repeated `--filter` flags.
     pub filters: Vec<OsString>,
+    /// Values forwarded to the fallback binary via repeated `--info=FLAGS` occurrences.
+    pub info_flags: Vec<OsString>,
     /// Whether the original invocation used `--files-from`.
     pub files_from_used: bool,
     /// Entries collected from `--files-from` operands.
@@ -1849,6 +1851,7 @@ where
         exclude_from,
         include_from,
         filters,
+        info_flags,
         files_from_used,
         file_list_entries,
         from0,
@@ -2006,6 +2009,12 @@ where
     for filter in filters {
         command_args.push(OsString::from("--filter"));
         command_args.push(filter);
+    }
+
+    for flag in info_flags {
+        let mut arg = OsString::from("--info=");
+        arg.push(&flag);
+        command_args.push(arg);
     }
 
     let files_from_temp =
@@ -3046,6 +3055,7 @@ exit 42
             exclude_from: Vec::new(),
             include_from: Vec::new(),
             filters: Vec::new(),
+            info_flags: Vec::new(),
             files_from_used: false,
             file_list_entries: Vec::new(),
             from0: false,


### PR DESCRIPTION
## Summary
- forward any --info flags to the fallback rsync invocation so remote transfers preserve user-configured informational output
- extend RemoteFallbackArgs with the new info flag list and update the fallback command builder to emit --info=FLAG arguments
- add a regression test that verifies oc-rsync passes --info options through when invoking the fallback binary

## Testing
- cargo test remote_fallback_forwards_info_flags

------