### PR TITLE
Add show/hide helpers for filter rules

### DIFF
--- a/crates/engine/src/local_copy.rs
+++ b/crates/engine/src/local_copy.rs
@@ -3586,7 +3586,7 @@ fn parse_filter_directive_line(
         if remainder.is_empty() {
             return Err(FilterParseError::new("filter directive missing pattern"));
         }
-        let rule = FilterRule::include(remainder.to_string()).with_receiver(false);
+        let rule = FilterRule::show(remainder.to_string());
         return Ok(Some(ParsedFilterDirective::Rule(rule)));
     }
 
@@ -3594,7 +3594,7 @@ fn parse_filter_directive_line(
         if remainder.is_empty() {
             return Err(FilterParseError::new("filter directive missing pattern"));
         }
-        let rule = FilterRule::exclude(remainder.to_string()).with_receiver(false);
+        let rule = FilterRule::hide(remainder.to_string());
         return Ok(Some(ParsedFilterDirective::Rule(rule)));
     }
 


### PR DESCRIPTION
## Summary
- add dedicated `FilterRule::show` and `FilterRule::hide` constructors so sender-only filters mirror rsync's `show`/`hide` directives
- update the local copy filter parser to rely on the new helpers and extend unit coverage for their semantics

## Testing
- `cargo test -p rsync-filters`
- `cargo test -p rsync-engine`

------