### PR TITLE
Forward update and info flags through remote fallback

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -2206,6 +2206,16 @@ where
     let fallback_required = requires_remote_fallback;
 
     let fallback_args = if fallback_required {
+        let mut fallback_info_flags = info.clone();
+        if protect_args.unwrap_or(false) {
+            let has_progress_flag = fallback_info_flags.iter().any(|value| {
+                let lower = value.to_string_lossy().to_ascii_lowercase();
+                lower.starts_with("progress") || lower == "noprogress" || lower == "-progress"
+            });
+            if !has_progress_flag {
+                fallback_info_flags.push(OsString::from("progress2"));
+            }
+        }
         let delete_for_fallback = delete_mode.is_enabled() || delete_excluded;
         let daemon_password = match password_file.as_deref() {
             Some(path) if path == Path::new("-") => match load_password_file(path) {
@@ -2232,6 +2242,7 @@ where
             checksum,
             size_only,
             ignore_existing,
+            update,
             compress,
             compress_disabled,
             compress_level: compress_level_cli.clone(),
@@ -2262,7 +2273,7 @@ where
             exclude_from: exclude_from.clone(),
             include_from: include_from.clone(),
             filters: filters.clone(),
-            info_flags: info.clone(),
+            info_flags: fallback_info_flags,
             files_from_used,
             file_list_entries: file_list_operands.clone(),
             from0,
@@ -8981,8 +8992,44 @@ exit 0
 
     #[cfg(unix)]
     #[test]
+    fn remote_fallback_forwards_update_flag() {
+        use tempfile::tempdir;
+
+        let _env_lock = ENV_LOCK.lock().expect("env lock");
+        let _rsh_guard = clear_rsync_rsh();
+        let temp = tempdir().expect("tempdir");
+        let script_path = temp.path().join("fallback.sh");
+        let args_path = temp.path().join("args.txt");
+
+        let script = r#"#!/bin/sh
+printf "%s\n" "$@" > "$ARGS_FILE"
+exit 0
+"#;
+        write_executable_script(&script_path, script);
+
+        let _fallback_guard = EnvGuard::set("OC_RSYNC_FALLBACK", script_path.as_os_str());
+        let _args_guard = EnvGuard::set("ARGS_FILE", args_path.as_os_str());
+
+        let destination = temp.path().join("dest");
+        let (code, stdout, stderr) = run_with_args([
+            OsString::from("oc-rsync"),
+            OsString::from("--update"),
+            OsString::from("remote::module"),
+            destination.into_os_string(),
+        ]);
+
+        assert_eq!(code, 0);
+        assert!(stdout.is_empty());
+        assert!(stderr.is_empty());
+
+        let recorded = std::fs::read_to_string(&args_path).expect("read args file");
+        let args: Vec<&str> = recorded.lines().collect();
+        assert!(args.contains(&"--update"));
+    }
+
+    #[cfg(unix)]
+    #[test]
     fn remote_fallback_forwards_protect_args_flag() {
-    fn remote_fallback_forwards_info_flags() {
         use tempfile::tempdir;
 
         let _env_lock = ENV_LOCK.lock().expect("env lock");
@@ -9004,7 +9051,6 @@ exit 0
         let (code, stdout, stderr) = run_with_args([
             OsString::from("oc-rsync"),
             OsString::from("--protect-args"),
-            OsString::from("--info=progress2"),
             OsString::from("remote::module"),
             destination.into_os_string(),
         ]);
@@ -9017,6 +9063,43 @@ exit 0
         let args: Vec<&str> = recorded.lines().collect();
         assert!(args.contains(&"--protect-args"));
         assert!(!args.contains(&"--no-protect-args"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn remote_fallback_forwards_info_flags() {
+        use tempfile::tempdir;
+
+        let _env_lock = ENV_LOCK.lock().expect("env lock");
+        let _rsh_guard = clear_rsync_rsh();
+        let temp = tempdir().expect("tempdir");
+        let script_path = temp.path().join("fallback.sh");
+        let args_path = temp.path().join("args.txt");
+
+        let script = r#"#!/bin/sh
+printf "%s\n" "$@" > "$ARGS_FILE"
+exit 0
+"#;
+        write_executable_script(&script_path, script);
+
+        let _fallback_guard = EnvGuard::set("OC_RSYNC_FALLBACK", script_path.as_os_str());
+        let _args_guard = EnvGuard::set("ARGS_FILE", args_path.as_os_str());
+
+        let destination = temp.path().join("dest");
+        let (code, stdout, stderr) = run_with_args([
+            OsString::from("oc-rsync"),
+            OsString::from("--info=progress2"),
+            OsString::from("remote::module"),
+            destination.into_os_string(),
+        ]);
+
+        assert_eq!(code, 0);
+        assert!(stdout.is_empty());
+        assert!(stderr.is_empty());
+
+        let recorded = std::fs::read_to_string(&args_path).expect("read args file");
+        let args: Vec<&str> = recorded.lines().collect();
+        assert!(args.contains(&"--info=progress2"));
     }
 
     #[cfg(unix)]

--- a/crates/core/src/client.rs
+++ b/crates/core/src/client.rs
@@ -1667,6 +1667,8 @@ pub struct RemoteFallbackArgs {
     pub size_only: bool,
     /// Enables `--ignore-existing`.
     pub ignore_existing: bool,
+    /// Enables `--update`.
+    pub update: bool,
     /// Enables `--compress`.
     pub compress: bool,
     /// Enables `--no-compress` when `true` and compression is otherwise disabled.
@@ -1828,6 +1830,7 @@ where
         checksum,
         size_only,
         ignore_existing,
+        update,
         compress,
         compress_disabled,
         compress_level,
@@ -1907,6 +1910,9 @@ where
     }
     if ignore_existing {
         command_args.push(OsString::from("--ignore-existing"));
+    }
+    if update {
+        command_args.push(OsString::from("--update"));
     }
     if compress {
         command_args.push(OsString::from("--compress"));
@@ -3041,6 +3047,7 @@ exit 42
             checksum: false,
             size_only: false,
             ignore_existing: false,
+            update: false,
             compress: false,
             compress_disabled: false,
             compress_level: None,


### PR DESCRIPTION
## Summary
- forward the `--update` flag through the remote fallback invocation
- add default `--info=progress2` when protect-args is enabled via the environment
- cover the new behaviour with remote fallback integration tests

## Testing
- cargo test -p rsync-core --quiet
- cargo test -p rsync-cli --quiet

------