### PR TITLE
Fix duplicate info flag assignment in remote fallback args

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -2281,7 +2281,6 @@ where
             include_from: include_from.clone(),
             filters: filters.clone(),
             info_flags: fallback_info_flags,
-            info_flags,
             files_from_used,
             file_list_entries: file_list_operands.clone(),
             from0,


### PR DESCRIPTION
## Summary
- ensure the remote fallback argument builder only forwards a single `info_flags` value so the CLI compiles again

## Testing
- cargo test

## Red → Green
- Red → Green count: 0 (compile failure resolved; no goldens affected)
- Affected goldens: none
- Parity rationale: remote fallback continues to receive the same info flags as upstream rsync would when protect-args is active.

------