### PR TITLE
Rename local copy partial directory setter

### DIFF
--- a/crates/core/src/client.rs
+++ b/crates/core/src/client.rs
@@ -2955,7 +2955,7 @@ where
             .implied_dirs(config.implied_dirs())
             .inplace(config.inplace())
             .partial(config.partial())
-            .partial_directory(config.partial_directory().map(|path| path.to_path_buf()));
+            .with_partial_directory(config.partial_directory().map(|path| path.to_path_buf()));
         #[cfg(feature = "acl")]
         let options = options.acls(config.preserve_acls());
         #[cfg(feature = "xattr")]

--- a/crates/engine/src/local_copy.rs
+++ b/crates/engine/src/local_copy.rs
@@ -1726,7 +1726,7 @@ impl LocalCopyOptions {
     /// Selects the directory used to retain partial files when transfers fail.
     #[must_use]
     #[doc(alias = "--partial-dir")]
-    pub fn partial_directory<P: Into<PathBuf>>(mut self, directory: Option<P>) -> Self {
+    pub fn with_partial_directory<P: Into<PathBuf>>(mut self, directory: Option<P>) -> Self {
         self.partial_dir = directory.map(Into::into);
         if self.partial_dir.is_some() {
             self.partial = true;


### PR DESCRIPTION
## Summary
- rename the LocalCopyOptions builder method for partial directories to avoid clashing with the accessor
- update the core client bridge to call the renamed helper

## Testing
- cargo test

------