### PR TITLE
Fix partial directory accessor naming collision

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -9182,10 +9182,7 @@ exit 0
 
         let (code, stdout, stderr) = run_with_args([
             OsString::from("oc-rsync"),
-            OsString::from(format!(
-                "--partial-dir={}",
-                partial_dir.display()
-            )),
+            OsString::from(format!("--partial-dir={}", partial_dir.display())),
             OsString::from("remote::module"),
             dest_path.clone().into_os_string(),
         ]);
@@ -9197,14 +9194,18 @@ exit 0
         let recorded = std::fs::read_to_string(&args_path).expect("read args file");
         assert!(recorded.lines().any(|line| line == "--partial"));
         assert!(recorded.lines().any(|line| line == "--partial-dir"));
-        assert!(recorded
-            .lines()
-            .any(|line| line == partial_dir.display().to_string()));
+        assert!(
+            recorded
+                .lines()
+                .any(|line| line == partial_dir.display().to_string())
+        );
 
         // Ensure destination operand still forwarded correctly alongside partial dir args.
-        assert!(recorded
-            .lines()
-            .any(|line| line == dest_path.display().to_string()));
+        assert!(
+            recorded
+                .lines()
+                .any(|line| line == dest_path.display().to_string())
+        );
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## Summary
- rename `LocalCopyOptions::partial_directory` accessor to `partial_directory_path` to avoid conflicts with the builder
- update the local copy execution path to use the new helper and streamline partial directory creation
- rustfmt the CLI partial-dir fallback test after the accessor change

## Testing
- cargo test

------