### PR TITLE
Fix dir-merge merge handling for filter clears

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -4096,7 +4096,8 @@ fn parse_filter_directive(argument: &OsStr) -> Result<FilterDirective, Message> 
             remainder = split.next().unwrap_or("").trim_start();
         }
 
-        let (options, assume_cvsignore) = parse_merge_modifiers(modifiers, trimmed)?;
+        let (options, assume_cvsignore) =
+            parse_merge_modifiers(modifiers, trimmed, true)?;
 
         let mut path_text = remainder.trim();
         if path_text.is_empty() {

--- a/crates/engine/src/local_copy.rs
+++ b/crates/engine/src/local_copy.rs
@@ -145,8 +145,8 @@ pub struct DirMergeOptions {
 }
 
 impl DirMergeOptions {
-    /// Creates default merge options: inherited rules, line-based parsing, and
-    /// comment support.
+    /// Creates default merge options: inherited rules, line-based parsing,
+    /// comment support, and permission for list-clearing directives.
     #[must_use]
     pub const fn new() -> Self {
         Self {
@@ -156,7 +156,7 @@ impl DirMergeOptions {
                 enforce_kind: None,
                 allow_comments: true,
             },
-            allow_list_clear: false,
+            allow_list_clear: true,
             sender_side: SideState::Unspecified,
             receiver_side: SideState::Unspecified,
             anchor_root: false,


### PR DESCRIPTION
## Summary
- allow dir-merge parsing to pass the extended-modifier flag so workspace supports the complete modifier set
- enable list-clearing directives in default directory merge options and document the behaviour

## Testing
- cargo test

------