### PR TITLE
Fix CLI dir-merge modifier parsing

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -3790,7 +3790,11 @@ fn parse_merge_modifiers(
     directive: &str,
     allow_extended: bool,
 ) -> Result<(DirMergeOptions, bool), Message> {
-    let mut options = DirMergeOptions::default();
+    let mut options = if allow_extended {
+        DirMergeOptions::default()
+    } else {
+        DirMergeOptions::default().allow_list_clearing(true)
+    };
     let mut enforced: Option<DirMergeEnforcedKind> = None;
     let mut saw_include = false;
     let mut saw_exclude = false;
@@ -4096,7 +4100,7 @@ fn parse_filter_directive(argument: &OsStr) -> Result<FilterDirective, Message> 
             remainder = split.next().unwrap_or("").trim_start();
         }
 
-        let (options, assume_cvsignore) = parse_merge_modifiers(modifiers, trimmed)?;
+        let (options, assume_cvsignore) = parse_merge_modifiers(modifiers, trimmed, true)?;
 
         let mut path_text = remainder.trim();
         if path_text.is_empty() {


### PR DESCRIPTION
## Summary
- propagate the allow_extended flag when parsing `dir-merge` directives so extended modifiers remain available
- default merge directives to allow list-clearing rules while keeping `dir-merge` defaults unchanged

## Testing
- cargo test

Red → Green count: 3 → 0 (CLI dir-merge merge/filter tests)
Affected goldens: none
Parity justification: merge directives now accept list-clearing `!` like upstream rsync while `dir-merge` retains its stricter defaults.

------