### PR TITLE
Allow merge filter list clearing and pass dir-merge modifiers

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -3948,6 +3948,9 @@ fn parse_merge_modifiers(
     }
 
     options = options.with_enforced_kind(enforced);
+    if !allow_extended && !options.list_clear_allowed() {
+        options = options.allow_list_clearing(true);
+    }
     Ok((options, assume_cvsignore))
 }
 
@@ -4096,7 +4099,7 @@ fn parse_filter_directive(argument: &OsStr) -> Result<FilterDirective, Message> 
             remainder = split.next().unwrap_or("").trim_start();
         }
 
-        let (options, assume_cvsignore) = parse_merge_modifiers(modifiers, trimmed)?;
+        let (options, assume_cvsignore) = parse_merge_modifiers(modifiers, trimmed, true)?;
 
         let mut path_text = remainder.trim();
         if path_text.is_empty() {


### PR DESCRIPTION
## Summary
- default merge filter directives now allow list-clearing rules without requiring CVS modifiers
- fix dir-merge parsing to pass the extended-modifier flag so advanced options remain available

## Testing
- cargo test

------