### PR TITLE
Fix merge directive enforced kind accessor duplication

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -3742,10 +3742,6 @@ impl MergeDirective {
         self
     }
 
-    fn enforced_kind(&self) -> Option<FilterRuleKind> {
-        self.enforced_kind.clone()
-    }
-
     fn source(&self) -> &OsStr {
         self.source.as_os_str()
     }
@@ -4310,7 +4306,6 @@ fn apply_merge_directive(
     })();
     visited.pop();
     if result.is_ok() && options.excludes_self() && !is_stdin {
-        let original_source_text = os_string_to_pattern(directive.source().to_os_string());
         let mut rule = FilterRuleSpec::exclude(original_source_text);
         rule.apply_dir_merge_overrides(&options);
         destination.push(rule);


### PR DESCRIPTION
## Summary
- remove the duplicate `MergeDirective::enforced_kind` implementation so the CLI crate builds
- reuse the precomputed merge source text when generating self-excluding rules to avoid redundant work

## Testing
- cargo test

------