### PR TITLE
Fix merge directive helpers in CLI filter parsing

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -3737,10 +3737,6 @@ impl MergeDirective {
         self
     }
 
-    fn enforced_kind(&self) -> Option<FilterRuleKind> {
-        self.enforced_kind.clone()
-    }
-
     fn source(&self) -> &OsStr {
         self.source.as_os_str()
     }
@@ -3748,10 +3744,13 @@ impl MergeDirective {
     fn options(&self) -> &DirMergeOptions {
         &self.options
     }
+}
 
-    fn enforced_kind(&self) -> Option<FilterRuleKind> {
-        self.enforced_kind
-    }
+fn merge_directive_options(
+    _base: &DirMergeOptions,
+    directive: &MergeDirective,
+) -> DirMergeOptions {
+    directive.options().clone()
 }
 
 fn parse_filter_shorthand(
@@ -4225,9 +4224,7 @@ fn apply_merge_directive(
     visited: &mut Vec<PathBuf>,
 ) -> Result<(), Message> {
     let options = directive.options().clone();
-    let original_source_text = os_string_to_pattern(directive.source().to_os_string());
     let is_stdin = directive.source() == OsStr::new("-");
-    let original_source_text = os_string_to_pattern(directive.source().to_os_string());
     let (resolved_path, display, canonical_path) = if is_stdin {
         (PathBuf::from("-"), String::from("-"), None)
     } else {


### PR DESCRIPTION
## Summary
- remove the stale `MergeDirective::enforced_kind` helper that referenced a non-existent field
- add the missing `merge_directive_options` helper and clean up redundant state when applying merge directives

## Testing
- cargo test

------