### PR TITLE
Fix dir-merge exclude-self rule source text handling

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -3746,10 +3746,7 @@ impl MergeDirective {
     }
 }
 
-fn merge_directive_options(
-    _base: &DirMergeOptions,
-    directive: &MergeDirective,
-) -> DirMergeOptions {
+fn merge_directive_options(_base: &DirMergeOptions, directive: &MergeDirective) -> DirMergeOptions {
     directive.options().clone()
 }
 
@@ -4224,6 +4221,7 @@ fn apply_merge_directive(
     visited: &mut Vec<PathBuf>,
 ) -> Result<(), Message> {
     let options = directive.options().clone();
+    let original_source_text = os_string_to_pattern(directive.source().to_os_string());
     let is_stdin = directive.source() == OsStr::new("-");
     let (resolved_path, display, canonical_path) = if is_stdin {
         (PathBuf::from("-"), String::from("-"), None)


### PR DESCRIPTION
## Summary
- ensure dir-merge exclude-self creates the exclusion rule from the directive's original source text

## Testing
- cargo test

------