### PR TITLE
Capture merge directive source for exclude-self rule

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -4225,6 +4225,10 @@ fn apply_merge_directive(
 ) -> Result<(), Message> {
     let options = directive.options().clone();
     let is_stdin = directive.source() == OsStr::new("-");
+    let original_source_text = directive
+        .source()
+        .to_string_lossy()
+        .into_owned();
     let (resolved_path, display, canonical_path) = if is_stdin {
         (PathBuf::from("-"), String::from("-"), None)
     } else {


### PR DESCRIPTION
## Summary
- preserve the original merge directive text when applying merge directives so exclude-self options can append the correct rule after parsing

## Testing
- cargo test

Red → Green count: 1 → 0 (cargo test compile failure)
Affected goldens: N/A

------