### PR TITLE
Improve local stats reporting for transfers

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -3119,10 +3119,11 @@ fn emit_stats<W: Write + ?Sized>(summary: &ClientSummary, stdout: &mut W) -> io:
     let fifos_total = summary.fifos_total();
     let hard_links = summary.hard_links_created();
     let deleted = summary.items_deleted();
-    let transferred = summary.bytes_copied();
-    let compressed = summary.compressed_bytes().unwrap_or(transferred);
+    let literal_bytes = summary.bytes_copied();
+    let transferred_size = summary.transferred_file_size();
+    let compressed = summary.compressed_bytes().unwrap_or(literal_bytes);
     let total_size = summary.total_source_bytes();
-    let matched_bytes = total_size.saturating_sub(transferred);
+    let matched_bytes = transferred_size.saturating_sub(literal_bytes);
     let file_list_size = summary.file_list_size();
     let file_list_generation = summary.file_list_generation_time().as_secs_f64();
     let file_list_transfer = summary.file_list_transfer_time().as_secs_f64();
@@ -3160,8 +3161,11 @@ fn emit_stats<W: Write + ?Sized>(summary: &ClientSummary, stdout: &mut W) -> io:
     writeln!(stdout, "Number of regular files transferred: {files}")?;
     writeln!(stdout, "Number of hard links: {hard_links}")?;
     writeln!(stdout, "Total file size: {total_size} bytes")?;
-    writeln!(stdout, "Total transferred file size: {transferred} bytes")?;
-    writeln!(stdout, "Literal data: {transferred} bytes")?;
+    writeln!(
+        stdout,
+        "Total transferred file size: {transferred_size} bytes"
+    )?;
+    writeln!(stdout, "Literal data: {literal_bytes} bytes")?;
     writeln!(stdout, "Matched data: {matched_bytes} bytes")?;
     writeln!(stdout, "File list size: {file_list_size}")?;
     writeln!(

--- a/crates/core/src/client.rs
+++ b/crates/core/src/client.rs
@@ -1580,6 +1580,12 @@ impl ClientSummary {
         self.stats.bytes_copied()
     }
 
+    /// Returns the aggregate size of files that were rewritten or created.
+    #[must_use]
+    pub fn transferred_file_size(&self) -> u64 {
+        self.stats.transferred_file_size()
+    }
+
     /// Returns the number of bytes that would be sent after applying compression.
     #[must_use]
     pub fn compressed_bytes(&self) -> Option<u64> {


### PR DESCRIPTION
## Summary
- track the full size of rewritten files separately from literal bytes in `LocalCopySummary`
- return literal/compressed byte counts from copy operations and expose them via `ClientSummary`
- update the CLI `--stats` renderer to use the new counters for literal and matched data output

## Testing
- `cargo test`

------