### PR TITLE
Fix unused merge directive source string conversion

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -4227,10 +4227,6 @@ fn apply_merge_directive(
     let options = directive.options().clone();
     let original_source_text = os_string_to_pattern(directive.source().to_os_string());
     let is_stdin = directive.source() == OsStr::new("-");
-    let original_source_text = directive
-        .source()
-        .to_string_lossy()
-        .into_owned();
     let (resolved_path, display, canonical_path) = if is_stdin {
         (PathBuf::from("-"), String::from("-"), None)
     } else {


### PR DESCRIPTION
## Summary
- reuse the precomputed merge directive source string when generating exclude-self rules to avoid redundant lossy conversions
- this keeps the recorded pattern identical to the original directive text while eliminating the build warning

## Parity Impact
- Red → Green count: 0 → 0 (warning-only cleanup)
- Affected goldens: None
- Upstream reference: mirrors upstream handling of `merge` directives by preserving the caller-provided pattern text when `--filter=':C'` emits an implicit exclude

## Testing
- cargo fmt
- cargo test -p rsync-cli --lib

------