### PR TITLE
Add aliases for session handshake part conversions

### DIFF
--- a/crates/transport/src/session/handshake.rs
+++ b/crates/transport/src/session/handshake.rs
@@ -401,8 +401,16 @@ impl<R> SessionHandshake<R> {
     /// negotiated metadata without matching on [`SessionHandshake`] immediately. This is useful
     /// when temporary ownership of the underlying transport is required (for example to wrap it
     /// with instrumentation) before resuming the rsync protocol exchange.
+    /// Decomposes the handshake into variant-specific metadata and replaying stream parts.
+    ///
+    /// The returned [`SessionHandshakeParts`] mirrors the helpers exposed by the
+    /// variant-specific handshakes while allowing higher layers to stage the
+    /// buffered negotiation bytes and negotiated metadata without matching on
+    /// [`SessionHandshake`] immediately. This is useful when temporary ownership
+    /// of the underlying transport is required (for example to wrap it with
+    /// instrumentation) before resuming the rsync protocol exchange.
     #[must_use]
-    pub fn into_stream_parts(self) -> SessionHandshakeParts<R> {
+    pub fn into_parts(self) -> SessionHandshakeParts<R> {
         match self {
             SessionHandshake::Binary(handshake) => {
                 SessionHandshakeParts::Binary(handshake.into_parts())
@@ -413,15 +421,27 @@ impl<R> SessionHandshake<R> {
         }
     }
 
-    /// Reassembles a [`SessionHandshake`] from the variant-specific stream parts previously
-    /// extracted via [`Self::into_stream_parts`].
+    /// Decomposes the handshake into variant-specific metadata and replaying stream parts.
     ///
-    /// Callers can invoke this helper directly or rely on the [`From`] conversion implemented
-    /// for [`SessionHandshakeParts`], which internally delegates to this constructor. The explicit
+    /// This is an alias for [`SessionHandshake::into_parts`] retained for historical parity with
+    /// earlier drafts of the transport API where the method carried the `into_stream_parts` name.
+    /// Keeping the shim avoids churn for downstream users while allowing the documentation and
+    /// examples to reference the more succinct terminology shared by variant-specific handshakes.
+    #[must_use]
+    #[doc(alias = "into_parts")]
+    pub fn into_stream_parts(self) -> SessionHandshakeParts<R> {
+        self.into_parts()
+    }
+
+    /// Reassembles a [`SessionHandshake`] from the variant-specific parts previously extracted via
+    /// [`Self::into_parts`].
+    ///
+    /// Callers can invoke this helper directly or rely on the [`From`] conversion implemented for
+    /// [`SessionHandshakeParts`], which internally delegates to this constructor. The explicit
     /// method remains available for situations where type inference benefits from naming the
     /// conversion target.
     #[must_use]
-    pub fn from_stream_parts(parts: SessionHandshakeParts<R>) -> Self {
+    pub fn from_parts(parts: SessionHandshakeParts<R>) -> Self {
         match parts {
             SessionHandshakeParts::Binary(parts) => {
                 SessionHandshake::Binary(BinaryHandshake::from_parts(parts))
@@ -431,11 +451,23 @@ impl<R> SessionHandshake<R> {
             }
         }
     }
+
+    /// Reassembles a [`SessionHandshake`] from the variant-specific stream parts previously
+    /// extracted via [`Self::into_stream_parts`].
+    ///
+    /// This method aliases [`SessionHandshake::from_parts`]; it remains available for symmetry with
+    /// older code that referred to the split representation as "stream parts". New call sites should
+    /// prefer [`SessionHandshake::from_parts`] for consistency with the variant-specific helpers.
+    #[must_use]
+    #[doc(alias = "from_parts")]
+    pub fn from_stream_parts(parts: SessionHandshakeParts<R>) -> Self {
+        SessionHandshake::from_parts(parts)
+    }
 }
 
 impl<R> From<SessionHandshakeParts<R>> for SessionHandshake<R> {
     fn from(parts: SessionHandshakeParts<R>) -> Self {
-        SessionHandshake::from_stream_parts(parts)
+        SessionHandshake::from_parts(parts)
     }
 }
 

--- a/crates/transport/src/session/tests.rs
+++ b/crates/transport/src/session/tests.rs
@@ -1231,6 +1231,43 @@ fn session_handshake_into_conversion_matches_method_for_binary() {
 }
 
 #[test]
+fn session_handshake_into_parts_aliases_method_for_binary() {
+    let remote_version = ProtocolVersion::from_supported(31).expect("protocol 31 supported");
+    let transport = MemoryTransport::new(&binary_handshake_bytes(remote_version));
+
+    let handshake =
+        negotiate_session(transport, ProtocolVersion::NEWEST).expect("binary handshake succeeds");
+
+    let via_alias = handshake.clone().into_parts();
+    let via_method = handshake.into_stream_parts();
+
+    assert_eq!(via_alias.decision(), NegotiationPrologue::Binary);
+    assert_eq!(via_alias.decision(), via_method.decision());
+    assert_eq!(
+        via_alias.negotiated_protocol(),
+        via_method.negotiated_protocol()
+    );
+    assert_eq!(via_alias.remote_protocol(), via_method.remote_protocol());
+    assert_eq!(
+        via_alias.remote_advertised_protocol(),
+        via_method.remote_advertised_protocol()
+    );
+    assert_eq!(
+        via_alias.local_advertised_protocol(),
+        via_method.local_advertised_protocol()
+    );
+    assert_eq!(via_alias.server_greeting(), via_method.server_greeting());
+    assert_eq!(
+        via_alias.stream().buffered(),
+        via_method.stream().buffered()
+    );
+    assert_eq!(
+        via_alias.stream().sniffed_prefix_len(),
+        via_method.stream().sniffed_prefix_len()
+    );
+}
+
+#[test]
 fn session_handshake_parts_clone_preserves_legacy_stream_state() {
     let transport = MemoryTransport::new(b"@RSYNCD: 31.0\n");
 
@@ -1318,6 +1355,42 @@ fn session_handshake_into_conversion_matches_method_for_legacy() {
     assert_eq!(reconstructed.decision(), NegotiationPrologue::LegacyAscii);
     assert_eq!(reconstructed.negotiated_protocol(), negotiated);
     assert!(reconstructed.server_greeting().is_some());
+}
+
+#[test]
+fn session_handshake_into_parts_aliases_method_for_legacy() {
+    let transport = MemoryTransport::new(b"@RSYNCD: 31.0\n");
+
+    let handshake =
+        negotiate_session(transport, ProtocolVersion::NEWEST).expect("legacy handshake succeeds");
+
+    let via_alias = handshake.clone().into_parts();
+    let via_method = handshake.into_stream_parts();
+
+    assert_eq!(via_alias.decision(), NegotiationPrologue::LegacyAscii);
+    assert_eq!(via_alias.decision(), via_method.decision());
+    assert_eq!(
+        via_alias.negotiated_protocol(),
+        via_method.negotiated_protocol()
+    );
+    assert_eq!(via_alias.remote_protocol(), via_method.remote_protocol());
+    assert_eq!(
+        via_alias.remote_advertised_protocol(),
+        via_method.remote_advertised_protocol()
+    );
+    assert_eq!(
+        via_alias.local_advertised_protocol(),
+        via_method.local_advertised_protocol()
+    );
+    assert_eq!(via_alias.server_greeting(), via_method.server_greeting());
+    assert_eq!(
+        via_alias.stream().buffered(),
+        via_method.stream().buffered()
+    );
+    assert_eq!(
+        via_alias.stream().sniffed_prefix_len(),
+        via_method.stream().sniffed_prefix_len()
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add `SessionHandshake::into_parts` and `SessionHandshake::from_parts` so the aggregated session helper mirrors the variant-specific API shape
- keep the legacy `into_stream_parts`/`from_stream_parts` entry points as thin aliases to maintain backwards compatibility
- add focused tests ensuring the new aliases behave identically for binary and legacy negotiations

## Testing
- cargo test -q -p rsync-transport session_handshake_into_parts_aliases_method_for_binary
- cargo test -q -p rsync-transport session_handshake_into_parts_aliases_method_for_legacy

------