### PR TITLE
Propagate client timeout to local copy options

### DIFF
--- a/crates/core/src/client.rs
+++ b/crates/core/src/client.rs
@@ -2918,56 +2918,7 @@ where
 
     let filter_program = compile_filter_program(config.filter_rules())?;
 
-    let mut options = {
-        let mut options = LocalCopyOptions::default();
-        if config.delete_mode().is_enabled() || config.delete_excluded() {
-            options = options.delete(true);
-        }
-        options = match config.delete_mode() {
-            DeleteMode::Before => options.delete_before(true),
-            DeleteMode::After => options.delete_after(true),
-            DeleteMode::Delay => options.delete_after(true),
-            DeleteMode::During | DeleteMode::Disabled => options,
-        };
-        options = options
-            .delete_excluded(config.delete_excluded())
-            .remove_source_files(config.remove_source_files())
-            .bandwidth_limit(
-                config
-                    .bandwidth_limit()
-                    .map(|limit| limit.bytes_per_second()),
-            )
-            .with_default_compression_level(config.compression_setting().level_or_default())
-            .whole_file(config.whole_file())
-            .compress(config.compress())
-            .with_compression_level_override(config.compression_level())
-            .owner(config.preserve_owner())
-            .group(config.preserve_group())
-            .permissions(config.preserve_permissions())
-            .times(config.preserve_times())
-            .omit_dir_times(config.omit_dir_times())
-            .checksum(config.checksum())
-            .size_only(config.size_only())
-            .ignore_existing(config.ignore_existing())
-            .update(config.update())
-            .with_filter_program(filter_program.clone())
-            .numeric_ids(config.numeric_ids())
-            .sparse(config.sparse())
-            .copy_links(config.copy_links())
-            .copy_dirlinks(config.copy_dirlinks())
-            .devices(config.preserve_devices())
-            .specials(config.preserve_specials())
-            .relative_paths(config.relative_paths())
-            .implied_dirs(config.implied_dirs())
-            .inplace(config.inplace())
-            .partial(config.partial())
-            .with_partial_directory(config.partial_directory().map(|path| path.to_path_buf()));
-        #[cfg(feature = "acl")]
-        let options = options.acls(config.preserve_acls());
-        #[cfg(feature = "xattr")]
-        let options = options.xattrs(config.preserve_xattrs());
-        options
-    };
+    let mut options = build_local_copy_options(&config, filter_program);
     let mode = if config.dry_run() || config.list_only() {
         LocalCopyExecution::DryRun
     } else {
@@ -3007,6 +2958,66 @@ where
     summary
         .map(|summary| ClientOutcome::Local(Box::new(summary)))
         .map_err(map_local_copy_error)
+}
+
+fn build_local_copy_options(
+    config: &ClientConfig,
+    filter_program: Option<FilterProgram>,
+) -> LocalCopyOptions {
+    let mut options = LocalCopyOptions::default();
+    if config.delete_mode().is_enabled() || config.delete_excluded() {
+        options = options.delete(true);
+    }
+    options = match config.delete_mode() {
+        DeleteMode::Before => options.delete_before(true),
+        DeleteMode::After => options.delete_after(true),
+        DeleteMode::Delay => options.delete_after(true),
+        DeleteMode::During | DeleteMode::Disabled => options,
+    };
+    options = options
+        .delete_excluded(config.delete_excluded())
+        .remove_source_files(config.remove_source_files())
+        .bandwidth_limit(
+            config
+                .bandwidth_limit()
+                .map(|limit| limit.bytes_per_second()),
+        )
+        .with_default_compression_level(config.compression_setting().level_or_default())
+        .whole_file(config.whole_file())
+        .compress(config.compress())
+        .with_compression_level_override(config.compression_level())
+        .owner(config.preserve_owner())
+        .group(config.preserve_group())
+        .permissions(config.preserve_permissions())
+        .times(config.preserve_times())
+        .omit_dir_times(config.omit_dir_times())
+        .checksum(config.checksum())
+        .size_only(config.size_only())
+        .ignore_existing(config.ignore_existing())
+        .update(config.update())
+        .with_filter_program(filter_program)
+        .numeric_ids(config.numeric_ids())
+        .sparse(config.sparse())
+        .copy_links(config.copy_links())
+        .copy_dirlinks(config.copy_dirlinks())
+        .devices(config.preserve_devices())
+        .specials(config.preserve_specials())
+        .relative_paths(config.relative_paths())
+        .implied_dirs(config.implied_dirs())
+        .inplace(config.inplace())
+        .partial(config.partial())
+        .with_partial_directory(config.partial_directory().map(|path| path.to_path_buf()))
+        .with_timeout(
+            config
+                .timeout()
+                .as_seconds()
+                .map(|seconds| Duration::from_secs(seconds.get())),
+        );
+    #[cfg(feature = "acl")]
+    let options = options.acls(config.preserve_acls());
+    #[cfg(feature = "xattr")]
+    let options = options.xattrs(config.preserve_xattrs());
+    options
 }
 
 fn invoke_fallback<Out, Err>(
@@ -3380,6 +3391,28 @@ exit 42
 
         assert_eq!(config.timeout(), timeout);
         assert_eq!(ClientConfig::default().timeout(), TransferTimeout::Default);
+    }
+
+    #[test]
+    fn local_copy_options_apply_explicit_timeout() {
+        let timeout = TransferTimeout::Seconds(NonZeroU64::new(5).unwrap());
+        let config = ClientConfig::builder()
+            .transfer_args([OsString::from("src"), OsString::from("dst")])
+            .timeout(timeout)
+            .build();
+
+        let options = build_local_copy_options(&config, None);
+        assert_eq!(options.timeout(), Some(Duration::from_secs(5)));
+    }
+
+    #[test]
+    fn local_copy_options_omit_timeout_when_unset() {
+        let config = ClientConfig::builder()
+            .transfer_args([OsString::from("src"), OsString::from("dst")])
+            .build();
+
+        let options = build_local_copy_options(&config, None);
+        assert!(options.timeout().is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- refactor local copy option assembly into a helper and reuse it from the client orchestration
- propagate the configured transfer timeout into the local copy engine so --timeout affects local runs
- add regression tests that cover explicit and default timeout handling

## Testing
- cargo test -p rsync-core local_copy_options_apply_explicit_timeout
- cargo test -p rsync-core local_copy_options_omit_timeout_when_unset

------