### PR TITLE
Add itemize-changes CLI support and remote fallback forwarding

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -166,6 +166,7 @@ const HELP_TEXT: &str = concat!(
     "      --progress   Show progress information during transfers.\n",
     "      --no-progress  Disable progress reporting.\n",
     "      --msgs2stderr  Route informational messages to standard error.\n",
+    "  -i, --itemize-changes  Output a change summary for each updated entry.\n",
     "      --out-format=FORMAT  Customise transfer output using FORMAT.\n",
     "      --stats      Output transfer statistics after completion.\n",
     "      --partial    Keep partially transferred files on errors.\n",
@@ -210,7 +211,9 @@ const HELP_TEXT: &str = concat!(
     "covers permissions, timestamps, and optional ownership metadata.\n",
 );
 
-const SUPPORTED_OPTIONS_LIST: &str = "--help/-h, --version/-V, --daemon, --dry-run/-n, --list-only, --archive/-a, --delete, --delete-before, --delete-during, --delete-delay, --delete-after, --checksum/-c, --size-only, --ignore-existing, --exclude, --exclude-from, --include, --include-from, --filter (including exclude-if-present=FILE), --files-from, --password-file, --no-motd, --from0, --bwlimit, --timeout, --protocol, --compress/-z, --no-compress, --compress-level, --info, --verbose/-v, --progress, --no-progress, --msgs2stderr, --out-format, --stats, --partial, --partial-dir, --no-partial, --remove-source-files, --remove-sent-files, --inplace, --no-inplace, --whole-file/-W, --no-whole-file, -P, --sparse/-S, --no-sparse, --copy-links/-L, --copy-dirlinks/-k, --no-copy-links, -D, --devices, --no-devices, --specials, --no-specials, --owner, --no-owner, --group, --no-group, --perms/-p, --no-perms, --times/-t, --no-times, --acls/-A, --no-acls, --xattrs/-X, --no-xattrs, --numeric-ids, and --no-numeric-ids";
+const SUPPORTED_OPTIONS_LIST: &str = "--help/-h, --version/-V, --daemon, --dry-run/-n, --list-only, --archive/-a, --delete, --delete-before, --delete-during, --delete-delay, --delete-after, --checksum/-c, --size-only, --ignore-existing, --exclude, --exclude-from, --include, --include-from, --filter (including exclude-if-present=FILE), --files-from, --password-file, --no-motd, --from0, --bwlimit, --timeout, --protocol, --compress/-z, --no-compress, --compress-level, --info, --verbose/-v, --progress, --no-progress, --msgs2stderr, --itemize-changes/-i, --out-format, --stats, --partial, --partial-dir, --no-partial, --remove-source-files, --remove-sent-files, --inplace, --no-inplace, --whole-file/-W, --no-whole-file, -P, --sparse/-S, --no-sparse, --copy-links/-L, --copy-dirlinks/-k, --no-copy-links, -D, --devices, --no-devices, --specials, --no-specials, --owner, --no-owner, --group, --no-group, --perms/-p, --no-perms, --times/-t, --no-times, --acls/-A, --no-acls, --xattrs/-X, --no-xattrs, --numeric-ids, and --no-numeric-ids";
+
+const ITEMIZE_CHANGES_FORMAT: &str = "%i %n%L";
 
 /// Timestamp format used for `--list-only` output.
 const LIST_TIMESTAMP_FORMAT: &[FormatItem<'static>] = format_description!(
@@ -797,6 +800,7 @@ struct ParsedArgs {
     remove_source_files: bool,
     inplace: Option<bool>,
     msgs_to_stderr: bool,
+    itemize_changes: bool,
     whole_file: Option<bool>,
     excludes: Vec<OsString>,
     includes: Vec<OsString>,
@@ -853,6 +857,13 @@ fn clap_command() -> ClapCommand {
             Arg::new("msgs2stderr")
                 .long("msgs2stderr")
                 .help("Route informational messages to standard error.")
+                .action(ArgAction::SetTrue),
+        )
+        .arg(
+            Arg::new("itemize-changes")
+                .long("itemize-changes")
+                .short('i')
+                .help("Output a change summary for each updated entry.")
                 .action(ArgAction::SetTrue),
         )
         .arg(
@@ -1719,6 +1730,7 @@ where
     let protocol = matches.remove_one::<OsString>("protocol");
     let timeout = matches.remove_one::<OsString>("timeout");
     let out_format = matches.remove_one::<OsString>("out-format");
+    let itemize_changes = matches.get_flag("itemize-changes");
     let no_motd = matches.get_flag("no-motd");
 
     Ok(ParsedArgs {
@@ -1764,6 +1776,7 @@ where
         remove_source_files,
         inplace,
         msgs_to_stderr,
+        itemize_changes,
         whole_file,
         excludes,
         includes,
@@ -1992,6 +2005,7 @@ where
         remove_source_files,
         inplace,
         msgs_to_stderr,
+        itemize_changes,
         whole_file,
         xattrs,
         no_motd,
@@ -2030,7 +2044,7 @@ where
         None => TransferTimeout::Default,
     };
 
-    let out_format_template = match out_format.as_ref() {
+    let mut out_format_template = match out_format.as_ref() {
         Some(value) => match parse_out_format(value.as_os_str()) {
             Ok(template) => Some(template),
             Err(message) => {
@@ -2043,6 +2057,20 @@ where
         },
         None => None,
     };
+
+    let mut fallback_out_format = out_format.clone();
+
+    if itemize_changes {
+        if fallback_out_format.is_none() {
+            fallback_out_format = Some(OsString::from(ITEMIZE_CHANGES_FORMAT));
+        }
+        if out_format_template.is_none() {
+            out_format_template = Some(
+                parse_out_format(OsStr::new(ITEMIZE_CHANGES_FORMAT))
+                    .expect("default itemize-changes format parses"),
+            );
+        }
+    }
 
     if show_help {
         let help = render_help();
@@ -2363,7 +2391,7 @@ where
             daemon_password,
             protocol: desired_protocol,
             timeout: timeout_setting,
-            out_format: out_format.clone(),
+            out_format: fallback_out_format.clone(),
             no_motd,
             fallback_binary: None,
             remainder: remainder.clone(),
@@ -2371,6 +2399,7 @@ where
             acls,
             #[cfg(feature = "xattr")]
             xattrs,
+            itemize_changes,
         })
     } else {
         None
@@ -2478,8 +2507,9 @@ where
         DeleteMode::During | DeleteMode::Disabled => builder,
     };
 
-    let force_event_collection =
-        out_format_template.is_some() || !matches!(name_level, NameOutputLevel::Disabled);
+    let force_event_collection = itemize_changes
+        || out_format_template.is_some()
+        || !matches!(name_level, NameOutputLevel::Disabled);
     builder = builder.force_event_collection(force_event_collection);
 
     let mut filter_rules = Vec::new();
@@ -5826,6 +5856,37 @@ mod tests {
     }
 
     #[test]
+    fn transfer_request_with_itemize_changes_renders_itemized_output() {
+        use tempfile::tempdir;
+
+        let tmp = tempdir().expect("tempdir");
+        let source = tmp.path().join("source.txt");
+        let dest_dir = tmp.path().join("dest");
+        std::fs::create_dir(&dest_dir).expect("create dest dir");
+        std::fs::write(&source, b"itemized").expect("write source");
+
+        let (code, stdout, stderr) = run_with_args([
+            OsString::from("oc-rsync"),
+            OsString::from("--itemize-changes"),
+            source.clone().into_os_string(),
+            dest_dir.clone().into_os_string(),
+        ]);
+
+        assert_eq!(code, 0);
+        assert!(stderr.is_empty());
+        assert_eq!(
+            String::from_utf8(stdout).expect("utf8"),
+            ">fcst...... source.txt\n"
+        );
+
+        let destination = dest_dir.join("source.txt");
+        assert_eq!(
+            std::fs::read(destination).expect("read destination"),
+            b"itemized"
+        );
+    }
+
+    #[test]
     fn transfer_request_with_ignore_existing_leaves_destination_unchanged() {
         use tempfile::tempdir;
 
@@ -6721,6 +6782,19 @@ mod tests {
         .expect("parse");
 
         assert_eq!(parsed.out_format, Some(OsString::from("%f %b")));
+    }
+
+    #[test]
+    fn parse_args_recognises_itemize_changes_flag() {
+        let parsed = parse_args([
+            OsString::from("oc-rsync"),
+            OsString::from("--itemize-changes"),
+            OsString::from("source"),
+            OsString::from("dest"),
+        ])
+        .expect("parse");
+
+        assert!(parsed.itemize_changes);
     }
 
     #[test]

--- a/crates/core/src/client.rs
+++ b/crates/core/src/client.rs
@@ -1771,6 +1771,8 @@ pub struct RemoteFallbackArgs {
     pub progress: bool,
     /// Enables `--stats`.
     pub stats: bool,
+    /// Enables `--itemize-changes` on the fallback command line.
+    pub itemize_changes: bool,
     /// Enables `--partial`.
     pub partial: bool,
     /// Optional directory forwarded via `--partial-dir`.
@@ -1917,6 +1919,7 @@ where
         verbosity,
         progress,
         stats,
+        itemize_changes,
         partial,
         partial_dir,
         remove_source_files,
@@ -2053,6 +2056,9 @@ where
     }
     if stats {
         command_args.push(OsString::from("--stats"));
+    }
+    if itemize_changes {
+        command_args.push(OsString::from("--itemize-changes"));
     }
     if partial {
         command_args.push(OsString::from("--partial"));
@@ -3170,6 +3176,7 @@ exit 42
             verbosity: 0,
             progress: false,
             stats: false,
+            itemize_changes: false,
             partial: false,
             partial_dir: None,
             remove_source_files: false,
@@ -3911,6 +3918,46 @@ exit 42
         assert!(captured.lines().any(|line| line == "--partial"));
         assert!(captured.lines().any(|line| line == "--partial-dir"));
         assert!(captured.lines().any(|line| line == ".rsync-partial"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn remote_fallback_forwards_itemize_changes_flag() {
+        let _lock = env_lock().lock().expect("env mutex poisoned");
+        let temp = tempdir().expect("tempdir created");
+        let capture_path = temp.path().join("args.txt");
+        let script_path = temp.path().join("capture.sh");
+        let script_contents = format!(
+            "#!/bin/sh\nset -eu\nOUTPUT=\"\"\nfor arg in \"$@\"; do\n  case \"$arg\" in\n    CAPTURE=*)\n      OUTPUT=\"${{arg#CAPTURE=}}\"\n      ;;\n  esac\ndone\n: \"${{OUTPUT:?}}\"\n: > \"$OUTPUT\"\nfor arg in \"$@\"; do\n  case \"$arg\" in\n    CAPTURE=*)\n      ;;\n    *)\n      printf '%s\\n' \"$arg\" >> \"$OUTPUT\"\n      ;;\n  esac\ndone\n"
+        );
+        fs::write(&script_path, script_contents).expect("script written");
+        let metadata = fs::metadata(&script_path).expect("script metadata");
+        let mut permissions = metadata.permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&script_path, permissions).expect("script permissions set");
+
+        const ITEMIZE_FORMAT: &str = "%i %n%L";
+
+        let mut args = baseline_fallback_args();
+        args.fallback_binary = Some(script_path.clone().into_os_string());
+        args.itemize_changes = true;
+        args.out_format = Some(OsString::from(ITEMIZE_FORMAT));
+        args.remainder = vec![OsString::from(format!(
+            "CAPTURE={}",
+            capture_path.display()
+        ))];
+
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+        run_remote_transfer_fallback(&mut stdout, &mut stderr, args)
+            .expect("fallback invocation succeeds");
+
+        assert!(stdout.is_empty());
+        assert!(stderr.is_empty());
+        let captured = fs::read_to_string(&capture_path).expect("capture contents");
+        assert!(captured.lines().any(|line| line == "--itemize-changes"));
+        assert!(captured.lines().any(|line| line == "--out-format"));
+        assert!(captured.lines().any(|line| line == ITEMIZE_FORMAT));
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## Summary
- add `--itemize-changes` (`-i`) to the CLI help text and parser, wiring it to the default `%i %n%L` format when no custom `--out-format` is supplied
- ensure the remote fallback command line forwards `--itemize-changes` along with the derived `--out-format` arguments
- extend unit tests covering CLI parsing, local execution output, and remote fallback forwarding of the new flag

## Testing
- cargo test

------