### PR TITLE
Allow whitespace in bandwidth limit arguments

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -8519,6 +8519,14 @@ mod tests {
     }
 
     #[test]
+    fn bwlimit_argument_trims_whitespace() {
+        let limit = parse_bandwidth_limit(OsStr::new(" 1M \t"))
+            .expect("parse succeeds")
+            .expect("limit available");
+        assert_eq!(limit.bytes_per_second().get(), 1_048_576);
+    }
+
+    #[test]
     fn compress_level_invalid_value_reports_error() {
         let (code, stdout, stderr) = run_with_args([
             OsString::from("oc-rsync"),

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -3611,7 +3611,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::ffi::OsStr;
+    use std::ffi::{OsStr, OsString};
     use std::fs;
     use std::io::{BufRead, BufReader, Read, Write};
     use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, TcpListener, TcpStream};
@@ -4666,6 +4666,19 @@ mod tests {
     fn runtime_options_parse_bwlimit_argument() {
         let options = RuntimeOptions::parse(&[OsString::from("--bwlimit"), OsString::from("8M")])
             .expect("parse bwlimit");
+
+        assert_eq!(
+            options.bandwidth_limit(),
+            Some(NonZeroU64::new(8 * 1024 * 1024).unwrap())
+        );
+        assert!(options.bandwidth_limit_configured());
+    }
+
+    #[test]
+    fn runtime_options_trim_bwlimit_argument() {
+        let options =
+            RuntimeOptions::parse(&[OsString::from("--bwlimit"), OsString::from(" 8M \n")])
+                .expect("parse bwlimit");
 
         assert_eq!(
             options.bandwidth_limit(),


### PR DESCRIPTION
## Summary
- trim ASCII whitespace around bandwidth limit specifications before parsing
- ensure the CLI and daemon accept `--bwlimit` values with surrounding whitespace and cover the behaviour with tests

## Testing
- cargo test -p rsync-bandwidth
- cargo test -p rsync-cli bwlimit_argument_trims_whitespace
- cargo test -p rsync-daemon runtime_options_trim_bwlimit_argument

------