### PR TITLE
Propagate dir-merge modifiers to nested filters

### DIFF
--- a/crates/engine/src/local_copy.rs
+++ b/crates/engine/src/local_copy.rs
@@ -240,6 +240,22 @@ impl DirMergeOptions {
         self
     }
 
+    /// Overrides the sender/receiver applicability flags without inferring defaults.
+    #[must_use]
+    pub fn with_side_overrides(mut self, sender: Option<bool>, receiver: Option<bool>) -> Self {
+        self.sender_side = match sender {
+            Some(true) => SideState::Enabled,
+            Some(false) => SideState::Disabled,
+            None => SideState::Unspecified,
+        };
+        self.receiver_side = match receiver {
+            Some(true) => SideState::Enabled,
+            Some(false) => SideState::Disabled,
+            None => SideState::Unspecified,
+        };
+        self
+    }
+
     /// Requests that patterns within the filter file be anchored to the transfer root.
     #[must_use]
     pub const fn anchor_root(mut self, anchor: bool) -> Self {


### PR DESCRIPTION
## Summary
- merge parent dir-merge options with nested directives so inherited modifiers persist
- add targeted tests covering inherited and overridden dir-merge options
- expose a helper on `DirMergeOptions` for setting explicit sender/receiver overrides

## Testing
- `cargo test -p rsync-cli merge_directive -- --nocapture`
- `cargo test -p rsync-engine --lib filter`

------