### PR TITLE
Improve local copy progress reporting

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -3214,7 +3214,10 @@ fn emit_progress<W: Write + ?Sized>(events: &[ClientEvent], stdout: &mut W) -> i
 
         let bytes = event.bytes_transferred();
         let size_field = format!("{:>15}", format_progress_bytes(bytes));
-        let percent_hint = matches!(event.kind(), ClientEventKind::DataCopied).then_some(bytes);
+        let percent_hint = match event.kind() {
+            ClientEventKind::DataCopied => event.total_bytes(),
+            _ => None,
+        };
         let percent_field = format!("{:>4}", format_progress_percent(bytes, percent_hint));
         let rate_field = format!("{:>12}", format_progress_rate(bytes, event.elapsed()));
         let elapsed_field = format!("{:>11}", format_progress_elapsed(event.elapsed()));

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -5460,7 +5460,9 @@ mod tests {
         stream.flush().expect("flush credentials");
 
         line.clear();
-        reader.read_line(&mut line).expect("post-auth acknowledgement");
+        reader
+            .read_line(&mut line)
+            .expect("post-auth acknowledgement");
         assert_eq!(line, "@RSYNCD: OK\n");
 
         line.clear();


### PR DESCRIPTION
## Summary
- track the total expected byte count for each local copy record and expose it through `ClientEvent`
- use the recorded totals when rendering stored progress events so percentage output reflects the full file size

## Testing
- `cargo test`

------