### PR TITLE
Align stats output with upstream format

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -3246,7 +3246,6 @@ fn emit_stats<W: Write + ?Sized>(summary: &ClientSummary, stdout: &mut W) -> io:
     let devices_total = summary.devices_total();
     let fifos = summary.fifos_created();
     let fifos_total = summary.fifos_total();
-    let hard_links = summary.hard_links_created();
     let deleted = summary.items_deleted();
     let literal_bytes = summary.bytes_copied();
     let transferred_size = summary.transferred_file_size();
@@ -3288,7 +3287,6 @@ fn emit_stats<W: Write + ?Sized>(summary: &ClientSummary, stdout: &mut W) -> io:
     )?;
     writeln!(stdout, "Number of deleted files: {deleted}")?;
     writeln!(stdout, "Number of regular files transferred: {files}")?;
-    writeln!(stdout, "Number of hard links: {hard_links}")?;
     writeln!(stdout, "Total file size: {total_size} bytes")?;
     writeln!(
         stdout,
@@ -5763,7 +5761,7 @@ mod tests {
         assert!(rendered.contains("Number of created files: 1 (reg: 1)"));
         assert!(rendered.contains("Number of regular files transferred: 1"));
         assert!(!rendered.contains("Number of regular files matched"));
-        assert!(rendered.contains("Number of hard links: 0"));
+        assert!(!rendered.contains("Number of hard links"));
         assert!(rendered.contains(&format!("Total file size: {expected_size} bytes")));
         assert!(rendered.contains(&format!("Literal data: {expected_size} bytes")));
         assert!(rendered.contains("Matched data: 0 bytes"));


### PR DESCRIPTION
## Summary
- drop the extra "Number of hard links" line from `--stats` output so the summary matches upstream rsync
- update the CLI stats test to assert the new formatting

## Testing
- cargo test --package rsync-cli

------