### PR TITLE
Support filter shorthand directives in merge files

### DIFF
--- a/crates/engine/src/local_copy.rs
+++ b/crates/engine/src/local_copy.rs
@@ -3715,6 +3715,30 @@ fn parse_filter_directive_line(
         ))))
     };
 
+    if keyword.len() == 1 {
+        let shorthand = keyword.chars().next().unwrap().to_ascii_lowercase();
+        match shorthand {
+            'p' => {
+                return handle_keyword(remainder, FilterRule::protect);
+            }
+            's' => {
+                if remainder.is_empty() {
+                    return Err(FilterParseError::new("filter directive missing pattern"));
+                }
+                let rule = FilterRule::show(remainder.to_string());
+                return Ok(Some(ParsedFilterDirective::Rule(rule)));
+            }
+            'h' => {
+                if remainder.is_empty() {
+                    return Err(FilterParseError::new("filter directive missing pattern"));
+                }
+                let rule = FilterRule::hide(remainder.to_string());
+                return Ok(Some(ParsedFilterDirective::Rule(rule)));
+            }
+            _ => {}
+        }
+    }
+
     if keyword.eq_ignore_ascii_case("include") {
         return handle_keyword(remainder, FilterRule::include);
     }
@@ -6740,6 +6764,39 @@ mod tests {
 
         assert!(rule.applies_to_sender());
         assert!(!rule.applies_to_receiver());
+    }
+
+    #[test]
+    fn parse_filter_directive_shorthand_show_is_sender_only() {
+        let rule = match parse_filter_directive_line("S logs/**").expect("parse") {
+            Some(ParsedFilterDirective::Rule(rule)) => rule,
+            other => panic!("expected rule, got {:?}", other),
+        };
+
+        assert!(rule.applies_to_sender());
+        assert!(!rule.applies_to_receiver());
+    }
+
+    #[test]
+    fn parse_filter_directive_shorthand_hide_is_sender_only() {
+        let rule = match parse_filter_directive_line("H *.bak").expect("parse") {
+            Some(ParsedFilterDirective::Rule(rule)) => rule,
+            other => panic!("expected rule, got {:?}", other),
+        };
+
+        assert!(rule.applies_to_sender());
+        assert!(!rule.applies_to_receiver());
+    }
+
+    #[test]
+    fn parse_filter_directive_shorthand_protect_requires_receiver() {
+        let rule = match parse_filter_directive_line("P cache/**").expect("parse") {
+            Some(ParsedFilterDirective::Rule(rule)) => rule,
+            other => panic!("expected rule, got {:?}", other),
+        };
+
+        assert!(!rule.applies_to_sender());
+        assert!(rule.applies_to_receiver());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- extend the `.rsync-filter` parser to recognize the `P`, `H`, and `S` shorthand directives so merge files match upstream filter grammar
- add unit tests that cover the shorthand protect/hide/show behaviour to ensure sender/receiver semantics stay correct

## Testing
- cargo test

------