### PR TITLE
Fix link-dest parsing and close CopyContext block

### DIFF
--- a/crates/engine/src/local_copy.rs
+++ b/crates/engine/src/local_copy.rs
@@ -2897,6 +2897,8 @@ impl<'a> CopyContext<'a> {
         }
 
         Ok(None)
+    }
+
     fn reference_directories(&self) -> &[ReferenceDirectory] {
         self.options.reference_directories()
     }


### PR DESCRIPTION
## Summary
- deduplicate the CLI's supported option list and remove the redundant link-dest flag definition
- ensure link-dest values populate both OsString and PathBuf collections and expand the remote fallback coverage to include space-separated arguments
- close the CopyContext::link_dest_target body so the surrounding impl compiles cleanly

## Testing
- cargo test

------