### PR TITLE
Add IPv4/IPv6 address selection support

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -94,8 +94,8 @@ use rsync_compress::zlib::CompressionLevel;
 use rsync_core::{
     bandwidth::BandwidthParseError,
     client::{
-        BandwidthLimit, ClientConfig, ClientEntryKind, ClientEntryMetadata, ClientEvent,
-        ClientEventKind, ClientOutcome, ClientProgressObserver, ClientProgressUpdate,
+        AddressMode, BandwidthLimit, ClientConfig, ClientEntryKind, ClientEntryMetadata,
+        ClientEvent, ClientEventKind, ClientOutcome, ClientProgressObserver, ClientProgressUpdate,
         ClientSummary, CompressionSetting, DeleteMode, DirMergeEnforcedKind, DirMergeOptions,
         FilterRuleKind, FilterRuleSpec, ModuleListOptions, ModuleListRequest, RemoteFallbackArgs,
         RemoteFallbackContext, TransferTimeout, run_client_or_fallback,
@@ -131,6 +131,8 @@ const HELP_TEXT: &str = concat!(
     "      --no-protect-args  Allow the remote shell to expand wildcard arguments.\n",
     "      --secluded-args  Alias of --protect-args.\n",
     "      --no-secluded-args  Alias of --no-protect-args.\n",
+    "      --ipv4          Prefer IPv4 when connecting to remote hosts.\n",
+    "      --ipv6          Prefer IPv6 when connecting to remote hosts.\n",
     "      --daemon    Run as an rsync daemon (delegates to oc-rsyncd).\n",
     "  -n, --dry-run    Validate transfers without modifying the destination.\n",
     "      --list-only  List files without performing a transfer.\n",
@@ -223,7 +225,7 @@ const HELP_TEXT: &str = concat!(
     "covers permissions, timestamps, and optional ownership metadata.\n",
 );
 
-const SUPPORTED_OPTIONS_LIST: &str = "--help/-h, --version/-V, --daemon, --dry-run/-n, --list-only, --archive/-a, --delete/--del, --delete-before, --delete-during, --delete-delay, --delete-after, --checksum/-c, --size-only, --ignore-existing, --exclude, --exclude-from, --include, --include-from, --compare-dest, --copy-dest, --link-dest, --filter (including exclude-if-present=FILE), --files-from, --password-file, --no-motd, --from0, --bwlimit, --timeout, --protocol, --rsync-path, --compress/-z, --no-compress, --compress-level, --info, --debug, --verbose/-v, --progress, --no-progress, --msgs2stderr, --itemize-changes/-i, --out-format, --stats, --partial, --partial-dir, --no-partial, --remove-source-files, --remove-sent-files, --inplace, --no-inplace, --whole-file/-W, --no-whole-file, -P, --sparse/-S, --no-sparse, --copy-links/-L, --copy-dirlinks/-k, --no-copy-links, -D, --devices, --no-devices, --specials, --no-specials, --owner, --no-owner, --group, --no-group, --chown, --perms/-p, --no-perms, --times/-t, --no-times, --acls/-A, --no-acls, --xattrs/-X, --no-xattrs, --numeric-ids, and --no-numeric-ids";
+const SUPPORTED_OPTIONS_LIST: &str = "--help/-h, --version/-V, --daemon, --dry-run/-n, --list-only, --archive/-a, --delete/--del, --delete-before, --delete-during, --delete-delay, --delete-after, --checksum/-c, --size-only, --ignore-existing, --exclude, --exclude-from, --include, --include-from, --compare-dest, --copy-dest, --link-dest, --filter (including exclude-if-present=FILE), --files-from, --password-file, --no-motd, --from0, --bwlimit, --timeout, --protocol, --rsync-path, --ipv4, --ipv6, --compress/-z, --no-compress, --compress-level, --info, --debug, --verbose/-v, --progress, --no-progress, --msgs2stderr, --itemize-changes/-i, --out-format, --stats, --partial, --partial-dir, --no-partial, --remove-source-files, --remove-sent-files, --inplace, --no-inplace, --whole-file/-W, --no-whole-file, -P, --sparse/-S, --no-sparse, --copy-links/-L, --copy-dirlinks/-k, --no-copy-links, -D, --devices, --no-devices, --specials, --no-specials, --owner, --no-owner, --group, --no-group, --chown, --perms/-p, --no-perms, --times/-t, --no-times, --acls/-A, --no-acls, --xattrs/-X, --no-xattrs, --numeric-ids, and --no-numeric-ids";
 
 const ITEMIZE_CHANGES_FORMAT: &str = "%i %n%L";
 /// Default patterns excluded by `--cvs-exclude`.
@@ -815,6 +817,7 @@ struct ParsedArgs {
     remote_shell: Option<OsString>,
     rsync_path: Option<OsString>,
     protect_args: Option<bool>,
+    address_mode: AddressMode,
     archive: bool,
     delete_mode: DeleteMode,
     delete_excluded: bool,
@@ -976,6 +979,20 @@ fn clap_command() -> ClapCommand {
                 .help("Allow the remote shell to expand wildcard arguments.")
                 .action(ArgAction::SetTrue)
                 .overrides_with("protect-args"),
+        )
+        .arg(
+            Arg::new("ipv4")
+                .long("ipv4")
+                .help("Prefer IPv4 when contacting remote hosts.")
+                .action(ArgAction::SetTrue)
+                .conflicts_with("ipv6"),
+        )
+        .arg(
+            Arg::new("ipv6")
+                .long("ipv6")
+                .help("Prefer IPv6 when contacting remote hosts.")
+                .action(ArgAction::SetTrue)
+                .conflicts_with("ipv4"),
         )
         .arg(
             Arg::new("dry-run")
@@ -1632,6 +1649,13 @@ where
     } else {
         env_protect_args_default()
     };
+    let address_mode = if matches.get_flag("ipv4") {
+        AddressMode::Ipv4
+    } else if matches.get_flag("ipv6") {
+        AddressMode::Ipv6
+    } else {
+        AddressMode::Default
+    };
     let archive = matches.get_flag("archive");
     let delete_flag = matches.get_flag("delete");
     let delete_before_flag = matches.get_flag("delete-before");
@@ -1918,6 +1942,7 @@ where
         remote_shell,
         rsync_path,
         protect_args,
+        address_mode,
         archive,
         delete_mode,
         delete_excluded,
@@ -2147,6 +2172,7 @@ where
         remote_shell,
         rsync_path,
         protect_args,
+        address_mode,
         archive,
         delete_mode,
         delete_excluded,
@@ -2536,7 +2562,9 @@ where
                     }
                 };
 
-                let list_options = ModuleListOptions::default().suppress_motd(no_motd);
+                let list_options = ModuleListOptions::default()
+                    .suppress_motd(no_motd)
+                    .with_address_mode(address_mode);
                 return match run_module_list_with_password_and_options(
                     request,
                     list_options,
@@ -2608,7 +2636,6 @@ where
             dry_run,
             list_only,
             remote_shell: remote_shell.clone(),
-            rsync_path: rsync_path.clone(),
             protect_args,
             archive,
             delete: delete_for_fallback,
@@ -2668,7 +2695,9 @@ where
             timeout: timeout_setting,
             out_format: fallback_out_format.clone(),
             no_motd,
+            address_mode,
             fallback_binary: None,
+            rsync_path: rsync_path.clone(),
             remainder: remainder.clone(),
             #[cfg(feature = "acl")]
             acls,
@@ -2762,6 +2791,7 @@ where
 
     let mut builder = ClientConfig::builder()
         .transfer_args(transfer_operands)
+        .address_mode(address_mode)
         .dry_run(dry_run)
         .list_only(list_only)
         .delete(delete_mode.is_enabled() || delete_excluded)
@@ -7047,6 +7077,32 @@ mod tests {
     }
 
     #[test]
+    fn parse_args_sets_ipv4_address_mode() {
+        let parsed = parse_args([
+            OsString::from("oc-rsync"),
+            OsString::from("--ipv4"),
+            OsString::from("source"),
+            OsString::from("dest"),
+        ])
+        .expect("parse");
+
+        assert_eq!(parsed.address_mode, AddressMode::Ipv4);
+    }
+
+    #[test]
+    fn parse_args_sets_ipv6_address_mode() {
+        let parsed = parse_args([
+            OsString::from("oc-rsync"),
+            OsString::from("--ipv6"),
+            OsString::from("source"),
+            OsString::from("dest"),
+        ])
+        .expect("parse");
+
+        assert_eq!(parsed.address_mode, AddressMode::Ipv6);
+    }
+
+    #[test]
     fn parse_args_recognises_group_overrides() {
         let parsed = parse_args([
             OsString::from("oc-rsync"),
@@ -10163,6 +10219,80 @@ exit 7
         assert!(recorded.contains("--dry-run"));
         assert!(recorded.contains("remote::module/path"));
         assert!(recorded.contains("dest"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn remote_fallback_includes_ipv4_flag() {
+        use tempfile::tempdir;
+
+        let _env_lock = ENV_LOCK.lock().expect("env lock");
+        let _rsh_guard = clear_rsync_rsh();
+        let temp = tempdir().expect("tempdir");
+        let script_path = temp.path().join("fallback.sh");
+        let args_path = temp.path().join("args.txt");
+        std::fs::File::create(&args_path).expect("create args file");
+
+        let script = r#"#!/bin/sh
+printf "%s\n" "$@" > "$ARGS_FILE"
+exit 0
+"#;
+        write_executable_script(&script_path, script);
+
+        let _fallback_guard = EnvGuard::set("OC_RSYNC_FALLBACK", script_path.as_os_str());
+        let _args_guard = EnvGuard::set("ARGS_FILE", args_path.as_os_str());
+
+        let (code, stdout, stderr) = run_with_args([
+            OsString::from("oc-rsync"),
+            OsString::from("--ipv4"),
+            OsString::from("remote::module"),
+            OsString::from("dest"),
+        ]);
+
+        assert_eq!(code, 0);
+        assert!(stdout.is_empty());
+        assert!(stderr.is_empty());
+
+        let recorded = std::fs::read_to_string(&args_path).expect("read args file");
+        assert!(recorded.contains("--ipv4"));
+        assert!(!recorded.contains("--ipv6"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn remote_fallback_includes_ipv6_flag() {
+        use tempfile::tempdir;
+
+        let _env_lock = ENV_LOCK.lock().expect("env lock");
+        let _rsh_guard = clear_rsync_rsh();
+        let temp = tempdir().expect("tempdir");
+        let script_path = temp.path().join("fallback.sh");
+        let args_path = temp.path().join("args.txt");
+        std::fs::File::create(&args_path).expect("create args file");
+
+        let script = r#"#!/bin/sh
+printf "%s\n" "$@" > "$ARGS_FILE"
+exit 0
+"#;
+        write_executable_script(&script_path, script);
+
+        let _fallback_guard = EnvGuard::set("OC_RSYNC_FALLBACK", script_path.as_os_str());
+        let _args_guard = EnvGuard::set("ARGS_FILE", args_path.as_os_str());
+
+        let (code, stdout, stderr) = run_with_args([
+            OsString::from("oc-rsync"),
+            OsString::from("--ipv6"),
+            OsString::from("remote::module"),
+            OsString::from("dest"),
+        ]);
+
+        assert_eq!(code, 0);
+        assert!(stdout.is_empty());
+        assert!(stderr.is_empty());
+
+        let recorded = std::fs::read_to_string(&args_path).expect("read args file");
+        assert!(recorded.contains("--ipv6"));
+        assert!(!recorded.contains("--ipv4"));
     }
 
     #[cfg(unix)]

--- a/crates/core/src/client.rs
+++ b/crates/core/src/client.rs
@@ -85,7 +85,8 @@ use std::env::VarError;
 use std::ffi::{OsStr, OsString};
 use std::fmt;
 use std::io::{self, BufRead, BufReader, Read, Write};
-use std::net::TcpStream;
+use std::net::ToSocketAddrs;
+use std::net::{SocketAddr, TcpStream};
 use std::num::NonZeroU64;
 use std::path::{Path, PathBuf};
 use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
@@ -179,6 +180,30 @@ impl TransferTimeout {
 }
 
 impl Default for TransferTimeout {
+    fn default() -> Self {
+        Self::Default
+    }
+}
+
+/// Selects the preferred address family for daemon and remote-shell connections.
+///
+/// When [`AddressMode::Ipv4`] or [`AddressMode::Ipv6`] is selected, network
+/// operations restrict socket resolution to the requested family, mirroring
+/// upstream rsync's `--ipv4` and `--ipv6` flags. The default mode allows the
+/// operating system to pick whichever address family resolves first.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[doc(alias = "--ipv4")]
+#[doc(alias = "--ipv6")]
+pub enum AddressMode {
+    /// Allow the operating system to pick the address family.
+    Default,
+    /// Restrict resolution and connections to IPv4 addresses.
+    Ipv4,
+    /// Restrict resolution and connections to IPv6 addresses.
+    Ipv6,
+}
+
+impl Default for AddressMode {
     fn default() -> Self {
         Self::Default
     }
@@ -376,6 +401,7 @@ pub struct ClientConfig {
     preserve_devices: bool,
     preserve_specials: bool,
     list_only: bool,
+    address_mode: AddressMode,
     timeout: TransferTimeout,
     reference_directories: Vec<ReferenceDirectory>,
     #[cfg(feature = "acl")]
@@ -429,6 +455,7 @@ impl Default for ClientConfig {
             preserve_devices: false,
             preserve_specials: false,
             list_only: false,
+            address_mode: AddressMode::Default,
             timeout: TransferTimeout::Default,
             reference_directories: Vec::new(),
             #[cfg(feature = "acl")]
@@ -467,6 +494,14 @@ impl ClientConfig {
     #[doc(alias = "--list-only")]
     pub const fn list_only(&self) -> bool {
         self.list_only
+    }
+
+    /// Returns the preferred address family used for daemon or remote-shell connections.
+    #[must_use]
+    #[doc(alias = "--ipv4")]
+    #[doc(alias = "--ipv6")]
+    pub const fn address_mode(&self) -> AddressMode {
+        self.address_mode
     }
 
     /// Reports whether a transfer was explicitly requested.
@@ -865,6 +900,7 @@ pub struct ClientConfigBuilder {
     preserve_devices: bool,
     preserve_specials: bool,
     list_only: bool,
+    address_mode: AddressMode,
     timeout: TransferTimeout,
     reference_directories: Vec<ReferenceDirectory>,
     #[cfg(feature = "acl")]
@@ -1375,6 +1411,15 @@ impl ClientConfigBuilder {
         self
     }
 
+    /// Selects the preferred address family for network operations.
+    #[must_use]
+    #[doc(alias = "--ipv4")]
+    #[doc(alias = "--ipv6")]
+    pub const fn address_mode(mut self, mode: AddressMode) -> Self {
+        self.address_mode = mode;
+        self
+    }
+
     /// Finalises the builder and constructs a [`ClientConfig`].
     #[must_use]
     pub fn build(self) -> ClientConfig {
@@ -1421,6 +1466,7 @@ impl ClientConfigBuilder {
             preserve_devices: self.preserve_devices,
             preserve_specials: self.preserve_specials,
             list_only: self.list_only,
+            address_mode: self.address_mode,
             timeout: self.timeout,
             reference_directories: self.reference_directories,
             #[cfg(feature = "acl")]
@@ -2029,6 +2075,8 @@ pub struct RemoteFallbackArgs {
     pub out_format: Option<OsString>,
     /// Enables `--no-motd`.
     pub no_motd: bool,
+    /// Preferred address family forwarded via `--ipv4`/`--ipv6`.
+    pub address_mode: AddressMode,
     /// Optional override for the fallback executable path.
     ///
     /// When unspecified the helper consults the `OC_RSYNC_FALLBACK` environment variable and
@@ -2164,6 +2212,7 @@ where
         timeout,
         out_format,
         no_motd,
+        address_mode,
         fallback_binary,
         rsync_path,
         mut remainder,
@@ -2421,6 +2470,12 @@ where
     if let Some(shell) = remote_shell {
         command_args.push(OsString::from("-e"));
         command_args.push(shell);
+    }
+
+    match address_mode {
+        AddressMode::Default => {}
+        AddressMode::Ipv4 => command_args.push(OsString::from("--ipv4")),
+        AddressMode::Ipv6 => command_args.push(OsString::from("--ipv6")),
     }
 
     if let Some(path) = rsync_path {
@@ -3444,6 +3499,7 @@ exit 42
             list_only: false,
             remote_shell: None,
             protect_args: None,
+            address_mode: AddressMode::Default,
             archive: false,
             delete: false,
             delete_mode: DeleteMode::Disabled,
@@ -5258,6 +5314,46 @@ exit 42
     }
 
     #[test]
+    fn module_list_options_reports_address_mode() {
+        let options = ModuleListOptions::default().with_address_mode(AddressMode::Ipv6);
+        assert_eq!(options.address_mode(), AddressMode::Ipv6);
+
+        let default_options = ModuleListOptions::default();
+        assert_eq!(default_options.address_mode(), AddressMode::Default);
+    }
+
+    #[test]
+    fn resolve_daemon_addresses_filters_ipv4_mode() {
+        let address = DaemonAddress::new(String::from("127.0.0.1"), 873).expect("address");
+        let addresses = resolve_daemon_addresses(&address, AddressMode::Ipv4)
+            .expect("ipv4 resolution succeeds");
+
+        assert!(!addresses.is_empty());
+        assert!(addresses.iter().all(std::net::SocketAddr::is_ipv4));
+    }
+
+    #[test]
+    fn resolve_daemon_addresses_rejects_missing_ipv6_addresses() {
+        let address = DaemonAddress::new(String::from("127.0.0.1"), 873).expect("address");
+        let error = resolve_daemon_addresses(&address, AddressMode::Ipv6)
+            .expect_err("IPv6 filtering should fail for IPv4-only host");
+
+        assert_eq!(error.exit_code(), SOCKET_IO_EXIT_CODE);
+        let rendered = error.message().to_string();
+        assert!(rendered.contains("does not have IPv6 addresses"));
+    }
+
+    #[test]
+    fn resolve_daemon_addresses_filters_ipv6_mode() {
+        let address = DaemonAddress::new(String::from("::1"), 873).expect("address");
+        let addresses = resolve_daemon_addresses(&address, AddressMode::Ipv6)
+            .expect("ipv6 resolution succeeds");
+
+        assert!(!addresses.is_empty());
+        assert!(addresses.iter().all(std::net::SocketAddr::is_ipv6));
+    }
+
+    #[test]
     fn module_list_request_rejects_truncated_percent_encoding() {
         let operands = vec![OsString::from("rsync://example%2/")];
         let error = ModuleListRequest::from_operands(&operands)
@@ -5577,11 +5673,8 @@ exit 42
     fn run_module_list_accepts_lowercase_proxy_status_line() {
         let responses = vec!["@RSYNCD: OK\n", "kappa\n", "@RSYNCD: EXIT\n"];
         let (daemon_addr, daemon_handle) = spawn_stub_daemon(responses);
-        let (proxy_addr, _request_rx, proxy_handle) = spawn_stub_proxy(
-            daemon_addr,
-            None,
-            LOWERCASE_PROXY_STATUS_LINE,
-        );
+        let (proxy_addr, _request_rx, proxy_handle) =
+            spawn_stub_proxy(daemon_addr, None, LOWERCASE_PROXY_STATUS_LINE);
 
         let _env_lock = env_lock().lock().expect("env mutex poisoned");
         let _guard = EnvGuard::set(
@@ -6707,6 +6800,7 @@ impl ModuleListRequest {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct ModuleListOptions {
     suppress_motd: bool,
+    address_mode: AddressMode,
 }
 
 impl ModuleListOptions {
@@ -6715,6 +6809,7 @@ impl ModuleListOptions {
     pub const fn new() -> Self {
         Self {
             suppress_motd: false,
+            address_mode: AddressMode::Default,
         }
     }
 
@@ -6729,6 +6824,21 @@ impl ModuleListOptions {
     #[must_use]
     pub const fn suppresses_motd(self) -> bool {
         self.suppress_motd
+    }
+
+    /// Configures the preferred address family for the daemon connection.
+    #[must_use]
+    #[doc(alias = "--ipv4")]
+    #[doc(alias = "--ipv6")]
+    pub const fn with_address_mode(mut self, mode: AddressMode) -> Self {
+        self.address_mode = mode;
+        self
+    }
+
+    /// Returns the preferred address family.
+    #[must_use]
+    pub const fn address_mode(&self) -> AddressMode {
+        self.address_mode
     }
 }
 
@@ -7099,6 +7209,7 @@ pub fn run_module_list(request: ModuleListRequest) -> Result<ModuleList, ClientE
 fn open_daemon_stream(
     addr: &DaemonAddress,
     timeout: Option<Duration>,
+    address_mode: AddressMode,
 ) -> Result<DaemonStream, ClientError> {
     if let Some(program) = load_daemon_connect_program()? {
         return connect_via_program(addr, &program);
@@ -7106,7 +7217,7 @@ fn open_daemon_stream(
 
     let stream = match load_daemon_proxy()? {
         Some(proxy) => connect_via_proxy(addr, &proxy, timeout)?,
-        None => connect_direct(addr, timeout)?,
+        None => connect_direct(addr, timeout, address_mode)?,
     };
 
     Ok(DaemonStream::tcp(stream))
@@ -7115,20 +7226,96 @@ fn open_daemon_stream(
 fn connect_direct(
     addr: &DaemonAddress,
     timeout: Option<Duration>,
+    address_mode: AddressMode,
 ) -> Result<TcpStream, ClientError> {
-    let stream = TcpStream::connect((addr.host.as_str(), addr.port))
-        .map_err(|error| socket_error("connect to", addr.socket_addr_display(), error))?;
+    let addresses = resolve_daemon_addresses(addr, address_mode)?;
+    let mut last_error: Option<(SocketAddr, io::Error)> = None;
 
-    if let Some(duration) = timeout {
-        stream
-            .set_read_timeout(Some(duration))
-            .map_err(|error| socket_error("configure", addr.socket_addr_display(), error))?;
-        stream
-            .set_write_timeout(Some(duration))
-            .map_err(|error| socket_error("configure", addr.socket_addr_display(), error))?;
+    for candidate in addresses {
+        let attempt = if let Some(duration) = timeout {
+            TcpStream::connect_timeout(&candidate, duration)
+        } else {
+            TcpStream::connect(candidate)
+        };
+
+        match attempt {
+            Ok(stream) => {
+                if let Some(duration) = timeout {
+                    stream.set_read_timeout(Some(duration)).map_err(|error| {
+                        socket_error("set read timeout on", addr.socket_addr_display(), error)
+                    })?;
+                    stream.set_write_timeout(Some(duration)).map_err(|error| {
+                        socket_error("set write timeout on", addr.socket_addr_display(), error)
+                    })?;
+                }
+
+                return Ok(stream);
+            }
+            Err(error) => last_error = Some((candidate, error)),
+        }
     }
 
-    Ok(stream)
+    let (candidate, error) = last_error.expect("no addresses available for daemon connection");
+    Err(socket_error("connect to", candidate, error))
+}
+
+fn resolve_daemon_addresses(
+    addr: &DaemonAddress,
+    mode: AddressMode,
+) -> Result<Vec<SocketAddr>, ClientError> {
+    let iterator = (addr.host.as_str(), addr.port)
+        .to_socket_addrs()
+        .map_err(|error| {
+            socket_error(
+                "resolve daemon address for",
+                addr.socket_addr_display(),
+                error,
+            )
+        })?;
+
+    let addresses: Vec<SocketAddr> = iterator.collect();
+
+    if addresses.is_empty() {
+        return Err(daemon_error(
+            format!(
+                "daemon host '{}' did not resolve to any addresses",
+                addr.host()
+            ),
+            SOCKET_IO_EXIT_CODE,
+        ));
+    }
+
+    let filtered = match mode {
+        AddressMode::Default => addresses,
+        AddressMode::Ipv4 => {
+            let retain: Vec<SocketAddr> = addresses
+                .into_iter()
+                .filter(|candidate| candidate.is_ipv4())
+                .collect();
+            if retain.is_empty() {
+                return Err(daemon_error(
+                    format!("daemon host '{}' does not have IPv4 addresses", addr.host()),
+                    SOCKET_IO_EXIT_CODE,
+                ));
+            }
+            retain
+        }
+        AddressMode::Ipv6 => {
+            let retain: Vec<SocketAddr> = addresses
+                .into_iter()
+                .filter(|candidate| candidate.is_ipv6())
+                .collect();
+            if retain.is_empty() {
+                return Err(daemon_error(
+                    format!("daemon host '{}' does not have IPv6 addresses", addr.host()),
+                    SOCKET_IO_EXIT_CODE,
+                ));
+            }
+            retain
+        }
+    };
+
+    Ok(filtered)
 }
 
 fn connect_via_proxy(
@@ -7158,12 +7345,7 @@ fn establish_proxy_tunnel(
     addr: &DaemonAddress,
     proxy: &ProxyConfig,
 ) -> Result<(), ClientError> {
-    let mut request = String::new();
-    request.push_str("CONNECT ");
-    request.push_str(addr.host());
-    request.push(':');
-    request.push_str(&addr.port().to_string());
-    request.push_str(" HTTP/1.0\r\n");
+    let mut request = format!("CONNECT {} HTTP/1.0\r\n", addr.socket_addr_display());
 
     if let Some(header) = proxy.authorization_header() {
         request.push_str("Proxy-Authorization: Basic ");
@@ -7748,9 +7930,10 @@ pub fn run_module_list_with_password_and_options(
     let mut auth_attempted = false;
     let mut auth_context: Option<DaemonAuthContext> = None;
     let suppress_motd = options.suppresses_motd();
+    let address_mode = options.address_mode();
 
     let effective_timeout = timeout.effective(DAEMON_SOCKET_TIMEOUT);
-    let stream = open_daemon_stream(addr, effective_timeout)?;
+    let stream = open_daemon_stream(addr, effective_timeout, address_mode)?;
 
     let handshake = negotiate_legacy_daemon_session(stream, request.protocol())
         .map_err(|error| map_daemon_handshake_error(error, addr))?;


### PR DESCRIPTION
## Summary
- extend the CLI to expose --ipv4/--ipv6 flags, thread the parsed address mode through module listing and fallback invocation, and update tests to cover the new arguments
- teach the core client to filter resolved daemon addresses by the requested family, plumb the address mode through ModuleListOptions/RemoteFallbackArgs, and add unit coverage for the resolver

## Testing
- `cargo test`

------