### PR TITLE
Consolidate delayed update handling

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -857,7 +857,6 @@ struct ParsedArgs {
     partial: bool,
     delay_updates: bool,
     partial_dir: Option<PathBuf>,
-    delay_updates: bool,
     link_dests: Vec<PathBuf>,
     remove_source_files: bool,
     inplace: Option<bool>,
@@ -1214,20 +1213,6 @@ fn clap_command() -> ClapCommand {
                 .help("Store partially transferred files in DIR.")
                 .value_parser(OsStringValueParser::new())
                 .overrides_with("no-partial"),
-        )
-        .arg(
-            Arg::new("delay-updates")
-                .long("delay-updates")
-                .help("Delay moving updated files into place until transfers finish.")
-                .action(ArgAction::SetTrue)
-                .overrides_with("no-delay-updates"),
-        )
-        .arg(
-            Arg::new("no-delay-updates")
-                .long("no-delay-updates")
-                .help("Disable delayed updates.")
-                .action(ArgAction::SetTrue)
-                .overrides_with("delay-updates"),
         )
         .arg(
             Arg::new("whole-file")
@@ -1880,9 +1865,6 @@ where
             progress_setting = ProgressSetting::PerFile;
         }
     }
-    if matches.get_flag("no-delay-updates") {
-        delay_updates = false;
-    }
     let link_dests: Vec<PathBuf> = matches
         .remove_many::<OsString>("link-dest")
         .map(|values| {
@@ -2027,7 +2009,6 @@ where
         partial,
         delay_updates,
         partial_dir,
-        delay_updates,
         link_dests,
         remove_source_files,
         inplace,
@@ -2274,7 +2255,6 @@ where
         partial,
         delay_updates,
         partial_dir,
-        delay_updates,
         link_dests,
         remove_source_files,
         inplace,
@@ -2724,7 +2704,6 @@ where
             partial,
             delay_updates,
             partial_dir: partial_dir.clone(),
-            delay_updates,
             link_dests: link_dests.clone(),
             remove_source_files,
             append: append_for_fallback,
@@ -7466,19 +7445,6 @@ mod tests {
             parsed.partial_dir.as_deref(),
             Some(Path::new(".rsync-partial"))
         );
-    }
-
-    #[test]
-    fn parse_args_recognises_delay_updates_flag() {
-        let parsed = parse_args([
-            OsString::from("oc-rsync"),
-            OsString::from("--delay-updates"),
-            OsString::from("source"),
-            OsString::from("dest"),
-        ])
-        .expect("parse");
-
-        assert!(parsed.delay_updates);
     }
 
     #[test]

--- a/crates/core/src/client.rs
+++ b/crates/core/src/client.rs
@@ -832,13 +832,6 @@ impl ClientConfig {
         self.partial_dir.as_deref()
     }
 
-    /// Reports whether destination updates should be staged and committed after the transfer.
-    #[must_use]
-    #[doc(alias = "--delay-updates")]
-    pub const fn delay_updates(&self) -> bool {
-        self.delay_updates
-    }
-
     /// Returns the ordered list of link-destination directories supplied by the caller.
     #[must_use]
     #[doc(alias = "--link-dest")]
@@ -2088,8 +2081,6 @@ pub struct RemoteFallbackArgs {
     pub delay_updates: bool,
     /// Optional directory forwarded via `--partial-dir`.
     pub partial_dir: Option<PathBuf>,
-    /// Enables `--delay-updates`.
-    pub delay_updates: bool,
     /// Directories forwarded via repeated `--link-dest` flags.
     pub link_dests: Vec<PathBuf>,
     /// Enables `--remove-source-files`.
@@ -2261,7 +2252,6 @@ where
         partial,
         delay_updates,
         partial_dir,
-        delay_updates,
         link_dests,
         remove_source_files,
         append,
@@ -3622,7 +3612,6 @@ exit 42
             partial: false,
             delay_updates: false,
             partial_dir: None,
-            delay_updates: false,
             link_dests: Vec::new(),
             remove_source_files: false,
             append: None,


### PR DESCRIPTION
## Summary
- extend the local copy deferred update record with full context so delayed updates can be committed through a single queue
- expose commit and registration helpers for deferred updates and adjust file copy logic to use the unified flow
- drop duplicate `--delay-updates` flag/field definitions and redundant tests so the CLI and core config no longer register the option twice

## Testing
- cargo test *(fails: numerous existing integration tests expect full rsync feature parity and still report exit 23/Clap conflicts outside this change)*

------