### PR TITLE
Add keep-dirlinks support across CLI, core, and engine

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -198,8 +198,10 @@ const HELP_TEXT: &str = concat!(
     "  -S, --sparse    Preserve sparse files by creating holes in the destination.\n",
     "      --no-sparse Disable sparse file handling.\n",
     "  -L, --copy-links     Transform symlinks into referent files/directories.\n",
-    "  -k, --copy-dirlinks  Transform symlinked directories into referent directories.\n",
     "      --no-copy-links  Preserve symlinks instead of following them.\n",
+    "  -k, --copy-dirlinks  Transform symlinked directories into referent directories.\n",
+    "  -K, --keep-dirlinks  Treat destination symlinks to directories as directories.\n",
+    "      --no-keep-dirlinks  Disable --keep-dirlinks semantics.\n",
     "  -D              Equivalent to --devices --specials.\n",
     "      --devices   Preserve device files.\n",
     "      --no-devices  Disable device file preservation.\n",
@@ -228,7 +230,7 @@ const HELP_TEXT: &str = concat!(
     "covers permissions, timestamps, and optional ownership metadata.\n",
 );
 
-const SUPPORTED_OPTIONS_LIST: &str = "--help/-h, --version/-V, --daemon, --dry-run/-n, --list-only, --archive/-a, --delete/--del, --delete-before, --delete-during, --delete-delay, --delete-after, --checksum/-c, --size-only, --ignore-existing, --delay-updates, --exclude, --exclude-from, --include, --include-from, --compare-dest, --copy-dest, --link-dest, --filter (including exclude-if-present=FILE), --files-from, --password-file, --no-motd, --from0, --bwlimit, --timeout, --protocol, --rsync-path, --ipv4, --ipv6, --compress/-z, --no-compress, --compress-level, --info, --debug, --verbose/-v, --progress, --no-progress, --msgs2stderr, --itemize-changes/-i, --out-format, --stats, --partial, --partial-dir, --no-partial, --remove-source-files, --remove-sent-files, --inplace, --no-inplace, --whole-file/-W, --no-whole-file, -P, --sparse/-S, --no-sparse, --copy-links/-L, --copy-dirlinks/-k, --no-copy-links, -D, --devices, --no-devices, --specials, --no-specials, --owner, --no-owner, --group, --no-group, --chown, --perms/-p, --no-perms, --times/-t, --no-times, --acls/-A, --no-acls, --xattrs/-X, --no-xattrs, --numeric-ids, and --no-numeric-ids";
+const SUPPORTED_OPTIONS_LIST: &str = "--help/-h, --version/-V, --daemon, --dry-run/-n, --list-only, --archive/-a, --delete/--del, --delete-before, --delete-during, --delete-delay, --delete-after, --checksum/-c, --size-only, --ignore-existing, --delay-updates, --exclude, --exclude-from, --include, --include-from, --compare-dest, --copy-dest, --link-dest, --filter (including exclude-if-present=FILE), --files-from, --password-file, --no-motd, --from0, --bwlimit, --timeout, --protocol, --rsync-path, --ipv4, --ipv6, --compress/-z, --no-compress, --compress-level, --info, --debug, --verbose/-v, --progress, --no-progress, --msgs2stderr, --itemize-changes/-i, --out-format, --stats, --partial, --partial-dir, --no-partial, --remove-source-files, --remove-sent-files, --inplace, --no-inplace, --whole-file/-W, --no-whole-file, -P, --sparse/-S, --no-sparse, --copy-links/-L, --no-copy-links, --copy-dirlinks/-k, --keep-dirlinks/-K, --no-keep-dirlinks, -D, --devices, --no-devices, --specials, --no-specials, --owner, --no-owner, --group, --no-group, --chown, --perms/-p, --no-perms, --times/-t, --no-times, --acls/-A, --no-acls, --xattrs/-X, --no-xattrs, --numeric-ids, and --no-numeric-ids";
 
 const ITEMIZE_CHANGES_FORMAT: &str = "%i %n%L";
 /// Default patterns excluded by `--cvs-exclude`.
@@ -844,6 +846,7 @@ struct ParsedArgs {
     sparse: Option<bool>,
     copy_links: Option<bool>,
     copy_dirlinks: bool,
+    keep_dirlinks: Option<bool>,
     devices: Option<bool>,
     specials: Option<bool>,
     relative: Option<bool>,
@@ -1082,11 +1085,26 @@ fn clap_command() -> ClapCommand {
                 .action(ArgAction::SetTrue),
         )
         .arg(
+            Arg::new("keep-dirlinks")
+                .long("keep-dirlinks")
+                .short('K')
+                .help("Treat existing destination symlinks to directories as directories.")
+                .action(ArgAction::SetTrue)
+                .conflicts_with("no-keep-dirlinks"),
+        )
+        .arg(
             Arg::new("no-copy-links")
                 .long("no-copy-links")
                 .help("Preserve symlinks instead of following them.")
                 .action(ArgAction::SetTrue)
                 .conflicts_with("copy-links"),
+        )
+        .arg(
+            Arg::new("no-keep-dirlinks")
+                .long("no-keep-dirlinks")
+                .help("Disable treating destination symlinks to directories as directories.")
+                .action(ArgAction::SetTrue)
+                .conflicts_with("keep-dirlinks"),
         )
         .arg(
             Arg::new("archive-devices")
@@ -1796,6 +1814,13 @@ where
         None
     };
     let copy_dirlinks = matches.get_flag("copy-dirlinks");
+    let keep_dirlinks = if matches.get_flag("no-keep-dirlinks") {
+        Some(false)
+    } else if matches.get_flag("keep-dirlinks") {
+        Some(true)
+    } else {
+        None
+    };
     let archive_devices = matches.get_flag("archive-devices");
     let devices = if matches.get_flag("no-devices") {
         Some(false)
@@ -1996,6 +2021,7 @@ where
         sparse,
         copy_links,
         copy_dirlinks,
+        keep_dirlinks,
         devices,
         specials,
         relative,
@@ -2242,6 +2268,7 @@ where
         sparse,
         copy_links,
         copy_dirlinks,
+        keep_dirlinks,
         devices,
         specials,
         relative,
@@ -2692,6 +2719,7 @@ where
             numeric_ids: numeric_ids_option,
             copy_links,
             copy_dirlinks,
+            keep_dirlinks,
             sparse,
             devices,
             specials,
@@ -2824,6 +2852,7 @@ where
     let preserve_specials = specials.unwrap_or(archive);
     let sparse = sparse.unwrap_or(false);
     let copy_links = copy_links.unwrap_or(false);
+    let keep_dirlinks_flag = keep_dirlinks.unwrap_or(false);
     let relative = relative.unwrap_or(false);
 
     let mut builder = ClientConfig::builder()
@@ -2854,6 +2883,7 @@ where
         .sparse(sparse)
         .copy_links(copy_links)
         .copy_dirlinks(copy_dirlinks)
+        .keep_dirlinks(keep_dirlinks_flag)
         .relative_paths(relative)
         .implied_dirs(implied_dirs)
         .mkpath(mkpath)
@@ -7405,6 +7435,39 @@ mod tests {
         .expect("parse");
 
         assert!(parsed.copy_dirlinks);
+    }
+
+    #[test]
+    fn parse_args_recognises_keep_dirlinks_flags() {
+        let parsed = parse_args([
+            OsString::from("oc-rsync"),
+            OsString::from("--keep-dirlinks"),
+            OsString::from("source"),
+            OsString::from("dest"),
+        ])
+        .expect("parse");
+
+        assert_eq!(parsed.keep_dirlinks, Some(true));
+
+        let parsed = parse_args([
+            OsString::from("oc-rsync"),
+            OsString::from("--no-keep-dirlinks"),
+            OsString::from("source"),
+            OsString::from("dest"),
+        ])
+        .expect("parse");
+
+        assert_eq!(parsed.keep_dirlinks, Some(false));
+
+        let parsed = parse_args([
+            OsString::from("oc-rsync"),
+            OsString::from("-K"),
+            OsString::from("source"),
+            OsString::from("dest"),
+        ])
+        .expect("parse");
+
+        assert_eq!(parsed.keep_dirlinks, Some(true));
     }
 
     #[test]

--- a/crates/core/src/client.rs
+++ b/crates/core/src/client.rs
@@ -386,6 +386,7 @@ pub struct ClientConfig {
     sparse: bool,
     copy_links: bool,
     copy_dirlinks: bool,
+    keep_dirlinks: bool,
     relative_paths: bool,
     implied_dirs: bool,
     mkpath: bool,
@@ -442,6 +443,7 @@ impl Default for ClientConfig {
             sparse: false,
             copy_links: false,
             copy_dirlinks: false,
+            keep_dirlinks: false,
             relative_paths: false,
             implied_dirs: true,
             mkpath: false,
@@ -528,6 +530,13 @@ impl ClientConfig {
     #[doc(alias = "-k")]
     pub const fn copy_dirlinks(&self) -> bool {
         self.copy_dirlinks
+    }
+
+    /// Returns whether existing destination directory symlinks should be preserved.
+    #[must_use]
+    #[doc(alias = "--keep-dirlinks")]
+    pub const fn keep_dirlinks(&self) -> bool {
+        self.keep_dirlinks
     }
 
     /// Returns the ordered list of filter rules supplied by the caller.
@@ -903,6 +912,7 @@ pub struct ClientConfigBuilder {
     sparse: bool,
     copy_links: bool,
     copy_dirlinks: bool,
+    keep_dirlinks: bool,
     relative_paths: bool,
     implied_dirs: Option<bool>,
     mkpath: bool,
@@ -1255,6 +1265,14 @@ impl ClientConfigBuilder {
         self
     }
 
+    /// Preserves existing destination symlinks that refer to directories.
+    #[must_use]
+    #[doc(alias = "--keep-dirlinks")]
+    pub const fn keep_dirlinks(mut self, keep_dirlinks: bool) -> Self {
+        self.keep_dirlinks = keep_dirlinks;
+        self
+    }
+
     /// Enables or disables copying of device nodes during the transfer.
     #[must_use]
     #[doc(alias = "--devices")]
@@ -1496,6 +1514,7 @@ impl ClientConfigBuilder {
             sparse: self.sparse,
             copy_links: self.copy_links,
             copy_dirlinks: self.copy_dirlinks,
+            keep_dirlinks: self.keep_dirlinks,
             relative_paths: self.relative_paths,
             implied_dirs: self.implied_dirs.unwrap_or(true),
             mkpath: self.mkpath,
@@ -2055,6 +2074,8 @@ pub struct RemoteFallbackArgs {
     pub copy_links: Option<bool>,
     /// Enables `--copy-dirlinks` when `true`.
     pub copy_dirlinks: bool,
+    /// Optional `--keep-dirlinks`/`--no-keep-dirlinks` toggle.
+    pub keep_dirlinks: Option<bool>,
     /// Optional `--sparse`/`--no-sparse` toggle.
     pub sparse: Option<bool>,
     /// Optional `--devices`/`--no-devices` toggle.
@@ -2239,6 +2260,7 @@ where
         numeric_ids,
         copy_links,
         copy_dirlinks,
+        keep_dirlinks,
         sparse,
         devices,
         specials,
@@ -2369,6 +2391,12 @@ where
     if copy_dirlinks {
         command_args.push(OsString::from("--copy-dirlinks"));
     }
+    push_toggle(
+        &mut command_args,
+        "--keep-dirlinks",
+        "--no-keep-dirlinks",
+        keep_dirlinks,
+    );
     push_toggle(&mut command_args, "--sparse", "--no-sparse", sparse);
     push_toggle(&mut command_args, "--devices", "--no-devices", devices);
     push_toggle(&mut command_args, "--specials", "--no-specials", specials);
@@ -3442,6 +3470,7 @@ fn build_local_copy_options(
         .sparse(config.sparse())
         .copy_links(config.copy_links())
         .copy_dirlinks(config.copy_dirlinks())
+        .keep_dirlinks(config.keep_dirlinks())
         .devices(config.preserve_devices())
         .specials(config.preserve_specials())
         .relative_paths(config.relative_paths())
@@ -3599,6 +3628,7 @@ exit 42
             numeric_ids: None,
             copy_links: None,
             copy_dirlinks: false,
+            keep_dirlinks: None,
             sparse: None,
             devices: None,
             specials: None,
@@ -4167,6 +4197,22 @@ exit 42
     }
 
     #[test]
+    fn builder_sets_keep_dirlinks() {
+        let enabled = ClientConfig::builder()
+            .transfer_args([OsString::from("src"), OsString::from("dst")])
+            .keep_dirlinks(true)
+            .build();
+
+        assert!(enabled.keep_dirlinks());
+
+        let disabled = ClientConfig::builder()
+            .transfer_args([OsString::from("src"), OsString::from("dst")])
+            .build();
+
+        assert!(!disabled.keep_dirlinks());
+    }
+
+    #[test]
     fn builder_enables_stats() {
         let enabled = ClientConfig::builder()
             .transfer_args([OsString::from("src"), OsString::from("dst")])
@@ -4350,6 +4396,55 @@ exit 42
         assert!(stderr.is_empty());
         let captured = fs::read_to_string(&capture_path).expect("capture contents");
         assert!(captured.lines().any(|line| line == "--copy-dirlinks"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn remote_fallback_forwards_keep_dirlinks_flags() {
+        let _lock = env_lock().lock().expect("env mutex poisoned");
+        let temp = tempdir().expect("tempdir created");
+        let capture_path = temp.path().join("args.txt");
+        let script_path = temp.path().join("capture.sh");
+        let script_contents = format!(
+            "#!/bin/sh\nset -eu\nOUTPUT=\"\"\nfor arg in \"$@\"; do\n  case \"$arg\" in\n    CAPTURE=*)\n      OUTPUT=\"${{arg#CAPTURE=}}\"\n      ;;\n  esac\ndone\n: \"${{OUTPUT:?}}\"\n: > \"$OUTPUT\"\nfor arg in \"$@\"; do\n  case \"$arg\" in\n    CAPTURE=*)\n      ;;\n    *)\n      printf '%s\\n' \"$arg\" >> \"$OUTPUT\"\n      ;;\n  esac\ndone\n"
+        );
+        fs::write(&script_path, script_contents).expect("script written");
+        let metadata = fs::metadata(&script_path).expect("script metadata");
+        let mut permissions = metadata.permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&script_path, permissions).expect("script permissions set");
+
+        let mut args = baseline_fallback_args();
+        args.fallback_binary = Some(script_path.clone().into_os_string());
+        args.keep_dirlinks = Some(true);
+        args.remainder = vec![OsString::from(format!(
+            "CAPTURE={}",
+            capture_path.display()
+        ))];
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+        run_remote_transfer_fallback(&mut stdout, &mut stderr, args)
+            .expect("fallback invocation succeeds");
+        assert!(stdout.is_empty());
+        assert!(stderr.is_empty());
+        let captured = fs::read_to_string(&capture_path).expect("capture contents");
+        assert!(captured.lines().any(|line| line == "--keep-dirlinks"));
+
+        let mut args = baseline_fallback_args();
+        args.fallback_binary = Some(script_path.into_os_string());
+        args.keep_dirlinks = Some(false);
+        args.remainder = vec![OsString::from(format!(
+            "CAPTURE={}",
+            capture_path.display()
+        ))];
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+        run_remote_transfer_fallback(&mut stdout, &mut stderr, args)
+            .expect("fallback invocation succeeds");
+        assert!(stdout.is_empty());
+        assert!(stderr.is_empty());
+        let captured = fs::read_to_string(&capture_path).expect("capture contents");
+        assert!(captured.lines().any(|line| line == "--no-keep-dirlinks"));
     }
 
     #[cfg(unix)]

--- a/crates/engine/src/local_copy.rs
+++ b/crates/engine/src/local_copy.rs
@@ -1507,6 +1507,7 @@ pub struct LocalCopyOptions {
     whole_file: bool,
     copy_links: bool,
     copy_dirlinks: bool,
+    keep_dirlinks: bool,
     preserve_owner: bool,
     preserve_group: bool,
     preserve_permissions: bool,
@@ -1559,6 +1560,7 @@ impl LocalCopyOptions {
             whole_file: true,
             copy_links: false,
             copy_dirlinks: false,
+            keep_dirlinks: false,
             preserve_owner: false,
             preserve_group: false,
             preserve_permissions: false,
@@ -1729,6 +1731,14 @@ impl LocalCopyOptions {
     #[doc(alias = "--copy-dirlinks")]
     pub const fn copy_dirlinks(mut self, copy: bool) -> Self {
         self.copy_dirlinks = copy;
+        self
+    }
+
+    /// Keeps existing destination symlinks that point to directories.
+    #[must_use]
+    #[doc(alias = "--keep-dirlinks")]
+    pub const fn keep_dirlinks(mut self, keep: bool) -> Self {
+        self.keep_dirlinks = keep;
         self
     }
 
@@ -2137,6 +2147,12 @@ impl LocalCopyOptions {
     #[must_use]
     pub const fn copy_dirlinks_enabled(&self) -> bool {
         self.copy_dirlinks
+    }
+
+    /// Reports whether existing destination directory symlinks should be preserved.
+    #[must_use]
+    pub const fn keep_dirlinks_enabled(&self) -> bool {
+        self.keep_dirlinks
     }
 
     /// Returns the effective compression level when compression is enabled.
@@ -3082,6 +3098,10 @@ impl<'a> CopyContext<'a> {
         self.options.copy_dirlinks_enabled()
     }
 
+    fn keep_dirlinks_enabled(&self) -> bool {
+        self.options.keep_dirlinks_enabled()
+    }
+
     fn whole_file_enabled(&self) -> bool {
         self.options.whole_file_enabled()
     }
@@ -3127,22 +3147,35 @@ impl<'a> CopyContext<'a> {
         self.options.omit_dir_times_enabled()
     }
 
-    fn prepare_parent_directory(&self, parent: &Path) -> Result<(), LocalCopyError> {
+    fn prepare_parent_directory(&mut self, parent: &Path) -> Result<(), LocalCopyError> {
         if parent.as_os_str().is_empty() {
             return Ok(());
         }
 
         let allow_creation = self.implied_dirs_enabled() || self.mkpath_enabled();
+        let keep_dirlinks = self.keep_dirlinks_enabled();
 
         if self.mode.is_dry_run() {
             match fs::symlink_metadata(parent) {
                 Ok(existing) => {
-                    if !existing.file_type().is_dir() {
-                        return Err(LocalCopyError::invalid_argument(
+                    let ty = existing.file_type();
+                    if ty.is_dir() {
+                        Ok(())
+                    } else if keep_dirlinks && ty.is_symlink() {
+                        follow_symlink_metadata(parent).and_then(|metadata| {
+                            if metadata.file_type().is_dir() {
+                                Ok(())
+                            } else {
+                                Err(LocalCopyError::invalid_argument(
+                                    LocalCopyArgumentError::ReplaceNonDirectoryWithDirectory,
+                                ))
+                            }
+                        })
+                    } else {
+                        Err(LocalCopyError::invalid_argument(
                             LocalCopyArgumentError::ReplaceNonDirectoryWithDirectory,
-                        ));
+                        ))
                     }
-                    Ok(())
                 }
                 Err(error) if error.kind() == io::ErrorKind::NotFound => {
                     if allow_creation {
@@ -3162,18 +3195,62 @@ impl<'a> CopyContext<'a> {
                 )),
             }
         } else if allow_creation {
-            fs::create_dir_all(parent).map_err(|error| {
-                LocalCopyError::io("create parent directory", parent.to_path_buf(), error)
-            })
-        } else {
             match fs::symlink_metadata(parent) {
                 Ok(existing) => {
-                    if !existing.file_type().is_dir() {
+                    let ty = existing.file_type();
+                    if ty.is_dir() {
+                        Ok(())
+                    } else if keep_dirlinks && ty.is_symlink() {
+                        let metadata = follow_symlink_metadata(parent)?;
+                        if metadata.file_type().is_dir() {
+                            Ok(())
+                        } else {
+                            Err(LocalCopyError::invalid_argument(
+                                LocalCopyArgumentError::ReplaceNonDirectoryWithDirectory,
+                            ))
+                        }
+                    } else {
                         Err(LocalCopyError::invalid_argument(
                             LocalCopyArgumentError::ReplaceNonDirectoryWithDirectory,
                         ))
-                    } else {
+                    }
+                }
+                Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                    fs::create_dir_all(parent).map_err(|error| {
+                        LocalCopyError::io(
+                            "create parent directory",
+                            parent.to_path_buf(),
+                            error,
+                        )
+                    })?;
+                    self.register_progress();
+                    Ok(())
+                }
+                Err(error) => Err(LocalCopyError::io(
+                    "create parent directory",
+                    parent.to_path_buf(),
+                    error,
+                )),
+            }
+        } else {
+            match fs::symlink_metadata(parent) {
+                Ok(existing) => {
+                    let ty = existing.file_type();
+                    if ty.is_dir() {
                         Ok(())
+                    } else if keep_dirlinks && ty.is_symlink() {
+                        let metadata = follow_symlink_metadata(parent)?;
+                        if metadata.file_type().is_dir() {
+                            Ok(())
+                        } else {
+                            Err(LocalCopyError::invalid_argument(
+                                LocalCopyArgumentError::ReplaceNonDirectoryWithDirectory,
+                            ))
+                        }
+                    } else {
+                        Err(LocalCopyError::invalid_argument(
+                            LocalCopyArgumentError::ReplaceNonDirectoryWithDirectory,
+                        ))
                     }
                 }
                 Err(error) => Err(LocalCopyError::io(
@@ -4766,6 +4843,7 @@ fn detect_relative_prefix_components(operand: &OsStr) -> Option<usize> {
 struct DestinationState {
     exists: bool,
     is_dir: bool,
+    symlink_to_dir: bool,
 }
 
 #[derive(Debug)]
@@ -4970,6 +5048,9 @@ fn copy_sources(
             let multiple_sources = plan.sources.len() > 1;
             let destination_path = plan.destination.path();
             let mut destination_state = query_destination_state(destination_path)?;
+            if context.keep_dirlinks_enabled() && destination_state.symlink_to_dir {
+                destination_state.is_dir = true;
+            }
 
             if plan.destination.force_directory() {
                 ensure_destination_directory(
@@ -5209,9 +5290,18 @@ fn query_destination_state(path: &Path) -> Result<DestinationState, LocalCopyErr
     match fs::symlink_metadata(path) {
         Ok(metadata) => {
             let file_type = metadata.file_type();
+            let symlink_to_dir = if file_type.is_symlink() {
+                follow_symlink_metadata(path)
+                    .map(|target| target.file_type().is_dir())
+                    .unwrap_or(false)
+            } else {
+                false
+            };
+
             Ok(DestinationState {
                 exists: true,
                 is_dir: file_type.is_dir(),
+                symlink_to_dir,
             })
         }
         Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(DestinationState::default()),
@@ -5237,9 +5327,21 @@ fn copy_directory_recursive(
     let preserve_acls = context.acls_enabled();
     let mut destination_missing = false;
 
+    let keep_dirlinks = context.keep_dirlinks_enabled();
+
     match fs::symlink_metadata(destination) {
         Ok(existing) => {
-            if !existing.file_type().is_dir() {
+            let file_type = existing.file_type();
+            if file_type.is_dir() {
+                // Directory already present; nothing to do.
+            } else if file_type.is_symlink() && keep_dirlinks {
+                let target_metadata = follow_symlink_metadata(destination)?;
+                if !target_metadata.file_type().is_dir() {
+                    return Err(LocalCopyError::invalid_argument(
+                        LocalCopyArgumentError::ReplaceNonDirectoryWithDirectory,
+                    ));
+                }
+            } else {
                 return Err(LocalCopyError::invalid_argument(
                     LocalCopyArgumentError::ReplaceNonDirectoryWithDirectory,
                 ));
@@ -8863,6 +8965,80 @@ mod tests {
         assert_eq!(summary.symlinks_copied(), 1);
         let copied = fs::read_link(&dest).expect("read link");
         assert_eq!(copied, target_file);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn execute_with_keep_dirlinks_allows_destination_directory_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempdir().expect("tempdir");
+        let source_dir = temp.path().join("src-dir");
+        fs::create_dir(&source_dir).expect("create source dir");
+        fs::write(source_dir.join("file.txt"), b"payload").expect("write source file");
+
+        let actual_destination = temp.path().join("actual-destination");
+        fs::create_dir(&actual_destination).expect("create destination dir");
+        let destination_link = temp.path().join("dest-link");
+        symlink(&actual_destination, &destination_link).expect("create destination link");
+
+        let operands = vec![
+            source_dir.clone().into_os_string(),
+            destination_link.clone().into_os_string(),
+        ];
+        let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+
+        let summary = plan
+            .execute_with_options(
+                LocalCopyExecution::Apply,
+                LocalCopyOptions::default().keep_dirlinks(true),
+            )
+            .expect("copy succeeds");
+
+        let copied_file = actual_destination.join("src-dir").join("file.txt");
+        assert_eq!(fs::read(&copied_file).expect("read copied file"), b"payload");
+        assert!(fs::symlink_metadata(&destination_link)
+            .expect("destination link metadata")
+            .file_type()
+            .is_symlink());
+        assert!(summary.directories_created() >= 1);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn execute_without_keep_dirlinks_rejects_destination_directory_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempdir().expect("tempdir");
+        let source_dir = temp.path().join("src-dir");
+        fs::create_dir(&source_dir).expect("create source dir");
+        fs::write(source_dir.join("file.txt"), b"payload").expect("write source file");
+
+        let actual_destination = temp.path().join("actual-destination");
+        fs::create_dir(&actual_destination).expect("create destination dir");
+        let destination_link = temp.path().join("dest-link");
+        symlink(&actual_destination, &destination_link).expect("create destination link");
+
+        let operands = vec![source_dir.into_os_string(), destination_link.clone().into_os_string()];
+        let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+
+        let result = plan.execute_with_options(
+            LocalCopyExecution::Apply,
+            LocalCopyOptions::default(),
+        );
+
+        let error = result.expect_err("keep-dirlinks disabled should reject destination symlink");
+        assert!(matches!(
+            error.kind(),
+            LocalCopyErrorKind::InvalidArgument(
+                LocalCopyArgumentError::ReplaceNonDirectoryWithDirectory
+            )
+        ));
+        assert!(fs::symlink_metadata(&destination_link)
+            .expect("destination link metadata")
+            .file_type()
+            .is_symlink());
+        assert!(!actual_destination.join("src-dir").join("file.txt").exists());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add the --keep-dirlinks/--no-keep-dirlinks flags to the CLI help, parser, and configuration wiring
- plumb keep-dirlinks through the client configuration, remote fallback argument generation, and tests
- teach the engine to honor keep-dirlinks for destination directory symlinks and cover the behaviour with unit tests

## Testing
- cargo test -p rsync-engine
- cargo test -p rsync-cli

------