### PR TITLE
Wire prune-empty-dirs through CLI, fallback, and engine

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -173,6 +173,8 @@ const HELP_TEXT: &str = concat!(
     "      --no-relative  Disable preservation of source path components.\n",
     "      --implied-dirs  Create parent directories implied by source paths.\n",
     "      --no-implied-dirs  Disable creation of parent directories implied by source paths.\n",
+    "  -m, --prune-empty-dirs  Skip creating directories that remain empty after filters.\n",
+    "      --no-prune-empty-dirs  Disable pruning of empty directories.\n",
     "      --progress   Show progress information during transfers.\n",
     "      --no-progress  Disable progress reporting.\n",
     "      --msgs2stderr  Route informational messages to standard error.\n",
@@ -849,6 +851,7 @@ struct ParsedArgs {
     relative: Option<bool>,
     implied_dirs: Option<bool>,
     mkpath: bool,
+    prune_empty_dirs: Option<bool>,
     verbosity: u8,
     progress: ProgressSetting,
     name_level: NameOutputLevel,
@@ -1017,6 +1020,21 @@ fn clap_command() -> ClapCommand {
                 .long("mkpath")
                 .help("Create destination's path component.")
                 .action(ArgAction::SetTrue),
+        )
+        .arg(
+            Arg::new("prune-empty-dirs")
+                .long("prune-empty-dirs")
+                .short('m')
+                .help("Skip creating directories that remain empty after filters.")
+                .action(ArgAction::SetTrue)
+                .overrides_with("no-prune-empty-dirs"),
+        )
+        .arg(
+            Arg::new("no-prune-empty-dirs")
+                .long("no-prune-empty-dirs")
+                .help("Disable pruning of empty directories.")
+                .action(ArgAction::SetTrue)
+                .overrides_with("prune-empty-dirs"),
         )
         .arg(
             Arg::new("archive")
@@ -1651,6 +1669,13 @@ where
     let mut dry_run = matches.get_flag("dry-run");
     let list_only = matches.get_flag("list-only");
     let mkpath = matches.get_flag("mkpath");
+    let prune_empty_dirs = if matches.get_flag("no-prune-empty-dirs") {
+        Some(false)
+    } else if matches.get_flag("prune-empty-dirs") {
+        Some(true)
+    } else {
+        None
+    };
     if list_only {
         dry_run = true;
     }
@@ -2001,6 +2026,7 @@ where
         relative,
         implied_dirs,
         mkpath,
+        prune_empty_dirs,
         verbosity,
         progress: progress_setting,
         name_level,
@@ -2247,6 +2273,7 @@ where
         relative,
         implied_dirs,
         mkpath,
+        prune_empty_dirs,
         verbosity,
         progress: initial_progress,
         name_level: initial_name_level,
@@ -2698,6 +2725,7 @@ where
             relative,
             implied_dirs: implied_dirs_option,
             mkpath,
+            prune_empty_dirs,
             verbosity,
             progress: progress_mode.is_some(),
             stats,
@@ -2857,6 +2885,7 @@ where
         .relative_paths(relative)
         .implied_dirs(implied_dirs)
         .mkpath(mkpath)
+        .prune_empty_dirs(prune_empty_dirs.unwrap_or(false))
         .verbosity(verbosity)
         .progress(progress_mode.is_some())
         .stats(stats)
@@ -7640,6 +7669,29 @@ mod tests {
     }
 
     #[test]
+    fn parse_args_recognises_prune_empty_dirs_flags() {
+        let parsed = parse_args([
+            OsString::from("oc-rsync"),
+            OsString::from("--prune-empty-dirs"),
+            OsString::from("source"),
+            OsString::from("dest"),
+        ])
+        .expect("parse");
+
+        assert_eq!(parsed.prune_empty_dirs, Some(true));
+
+        let parsed = parse_args([
+            OsString::from("oc-rsync"),
+            OsString::from("--no-prune-empty-dirs"),
+            OsString::from("source"),
+            OsString::from("dest"),
+        ])
+        .expect("parse");
+
+        assert_eq!(parsed.prune_empty_dirs, Some(false));
+    }
+
+    #[test]
     fn parse_args_recognises_inplace_flags() {
         let parsed = parse_args([
             OsString::from("oc-rsync"),
@@ -11191,6 +11243,63 @@ exit 0
         let args: Vec<&str> = recorded.lines().collect();
         assert!(args.contains(&"--implied-dirs"));
         assert!(!args.contains(&"--no-implied-dirs"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn remote_fallback_forwards_prune_empty_dirs_flags() {
+        use tempfile::tempdir;
+
+        let _env_lock = ENV_LOCK.lock().expect("env lock");
+        let _rsh_guard = clear_rsync_rsh();
+        let temp = tempdir().expect("tempdir");
+        let script_path = temp.path().join("fallback.sh");
+        let args_path = temp.path().join("args.txt");
+
+        let script = r#"#!/bin/sh
+printf "%s\n" "$@" > "$ARGS_FILE"
+exit 0
+"#;
+        write_executable_script(&script_path, script);
+
+        let _fallback_guard = EnvGuard::set("OC_RSYNC_FALLBACK", script_path.as_os_str());
+        let _args_guard = EnvGuard::set("ARGS_FILE", args_path.as_os_str());
+
+        let destination = temp.path().join("dest");
+
+        let (code, stdout, stderr) = run_with_args([
+            OsString::from("oc-rsync"),
+            OsString::from("--prune-empty-dirs"),
+            OsString::from("remote::module"),
+            destination.clone().into_os_string(),
+        ]);
+
+        assert_eq!(code, 0);
+        assert!(stdout.is_empty());
+        assert!(stderr.is_empty());
+
+        let recorded = std::fs::read_to_string(&args_path).expect("read args file");
+        let args: Vec<&str> = recorded.lines().collect();
+        assert!(args.contains(&"--prune-empty-dirs"));
+        assert!(!args.contains(&"--no-prune-empty-dirs"));
+
+        std::fs::write(&args_path, b"").expect("truncate args file");
+
+        let (code, stdout, stderr) = run_with_args([
+            OsString::from("oc-rsync"),
+            OsString::from("--no-prune-empty-dirs"),
+            OsString::from("remote::module"),
+            destination.into_os_string(),
+        ]);
+
+        assert_eq!(code, 0);
+        assert!(stdout.is_empty());
+        assert!(stderr.is_empty());
+
+        let recorded = std::fs::read_to_string(&args_path).expect("read args file");
+        let args: Vec<&str> = recorded.lines().collect();
+        assert!(args.contains(&"--no-prune-empty-dirs"));
+        assert!(!args.contains(&"--prune-empty-dirs"));
     }
 
     #[cfg(unix)]

--- a/crates/core/src/client.rs
+++ b/crates/core/src/client.rs
@@ -389,6 +389,7 @@ pub struct ClientConfig {
     relative_paths: bool,
     implied_dirs: bool,
     mkpath: bool,
+    prune_empty_dirs: bool,
     verbosity: u8,
     progress: bool,
     stats: bool,
@@ -445,6 +446,7 @@ impl Default for ClientConfig {
             relative_paths: false,
             implied_dirs: true,
             mkpath: false,
+            prune_empty_dirs: false,
             verbosity: 0,
             progress: false,
             stats: false,
@@ -788,6 +790,14 @@ impl ClientConfig {
         self.mkpath
     }
 
+    /// Returns whether empty directories should be pruned after filtering.
+    #[must_use]
+    #[doc(alias = "--prune-empty-dirs")]
+    #[doc(alias = "-m")]
+    pub const fn prune_empty_dirs(&self) -> bool {
+        self.prune_empty_dirs
+    }
+
     /// Returns the requested verbosity level.
     #[must_use]
     #[doc(alias = "--verbose")]
@@ -906,6 +916,7 @@ pub struct ClientConfigBuilder {
     relative_paths: bool,
     implied_dirs: Option<bool>,
     mkpath: bool,
+    prune_empty_dirs: bool,
     verbosity: u8,
     progress: bool,
     stats: bool,
@@ -1297,6 +1308,15 @@ impl ClientConfigBuilder {
         self
     }
 
+    /// Enables or disables pruning of empty directories after filters apply.
+    #[must_use]
+    #[doc(alias = "--prune-empty-dirs")]
+    #[doc(alias = "-m")]
+    pub const fn prune_empty_dirs(mut self, prune: bool) -> Self {
+        self.prune_empty_dirs = prune;
+        self
+    }
+
     /// Sets the verbosity level requested by the caller.
     #[must_use]
     #[doc(alias = "--verbose")]
@@ -1499,6 +1519,7 @@ impl ClientConfigBuilder {
             relative_paths: self.relative_paths,
             implied_dirs: self.implied_dirs.unwrap_or(true),
             mkpath: self.mkpath,
+            prune_empty_dirs: self.prune_empty_dirs,
             verbosity: self.verbosity,
             progress: self.progress,
             stats: self.stats,
@@ -2067,6 +2088,8 @@ pub struct RemoteFallbackArgs {
     pub implied_dirs: Option<bool>,
     /// Enables `--mkpath`.
     pub mkpath: bool,
+    /// Controls pruning of empty directories via `--prune-empty-dirs`.
+    pub prune_empty_dirs: Option<bool>,
     /// Verbosity level translated into repeated `-v` flags.
     pub verbosity: u8,
     /// Enables `--progress`.
@@ -2245,6 +2268,7 @@ where
         relative,
         implied_dirs,
         mkpath,
+        prune_empty_dirs,
         verbosity,
         progress,
         stats,
@@ -2382,6 +2406,12 @@ where
     if mkpath {
         command_args.push(OsString::from("--mkpath"));
     }
+    push_toggle(
+        &mut command_args,
+        "--prune-empty-dirs",
+        "--no-prune-empty-dirs",
+        prune_empty_dirs,
+    );
     push_toggle(&mut command_args, "--inplace", "--no-inplace", inplace);
     #[cfg(feature = "acl")]
     push_toggle(&mut command_args, "--acls", "--no-acls", acls);
@@ -3447,6 +3477,7 @@ fn build_local_copy_options(
         .relative_paths(config.relative_paths())
         .implied_dirs(config.implied_dirs())
         .mkpath(config.mkpath())
+        .prune_empty_dirs(config.prune_empty_dirs())
         .inplace(config.inplace())
         .append(config.append())
         .append_verify(config.append_verify())
@@ -3605,6 +3636,7 @@ exit 42
             relative: None,
             implied_dirs: None,
             mkpath: false,
+            prune_empty_dirs: None,
             verbosity: 0,
             progress: false,
             stats: false,


### PR DESCRIPTION
## Summary
- add CLI flag handling and help text for --prune-empty-dirs/--no-prune-empty-dirs while threading the option into client configuration and remote fallback arguments
- ensure the core fallback launcher forwards prune-empty-dirs toggles to the legacy binary
- teach the local copy engine to prune empty directories when requested and cover the behaviour with unit tests

## Testing
- cargo test --package rsync-cli --lib
- cargo test --package rsync-engine --lib

------