### PR TITLE
Implement remote shell specification parsing for SSH transport

### DIFF
--- a/crates/transport/src/lib.rs
+++ b/crates/transport/src/lib.rs
@@ -90,4 +90,4 @@ pub use session::{
     negotiate_session_parts, negotiate_session_parts_from_stream,
     negotiate_session_parts_with_sniffer, negotiate_session_with_sniffer,
 };
-pub use ssh::{SshCommand, SshConnection};
+pub use ssh::{RemoteShellParseError, SshCommand, SshConnection, parse_remote_shell};

--- a/crates/transport/src/ssh/parse.rs
+++ b/crates/transport/src/ssh/parse.rs
@@ -1,0 +1,259 @@
+#![allow(clippy::module_name_repetitions)]
+
+//! Helpers for parsing remote shell specifications supplied via `-e/--rsh`.
+
+use std::borrow::Cow;
+use std::error::Error;
+use std::ffi::{OsStr, OsString};
+use std::fmt;
+
+#[cfg(unix)]
+use std::os::unix::ffi::{OsStrExt, OsStringExt};
+
+/// Errors returned when parsing remote shell specifications fails.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum RemoteShellParseError {
+    /// The specification was empty or consisted solely of whitespace.
+    Empty,
+    /// A backslash escape reached the end of the specification.
+    UnterminatedEscape,
+    /// A single-quoted string was not terminated.
+    UnterminatedSingleQuote,
+    /// A double-quoted string was not terminated.
+    UnterminatedDoubleQuote,
+    /// The specification contained an interior NUL byte.
+    InteriorNull,
+    /// Non-Unicode data was supplied on a platform that requires Unicode.
+    InvalidEncoding,
+}
+
+impl fmt::Display for RemoteShellParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Empty => f.write_str("remote shell specification is empty"),
+            Self::UnterminatedEscape => {
+                f.write_str("remote shell specification ended after escape")
+            }
+            Self::UnterminatedSingleQuote => {
+                f.write_str("remote shell specification has an unterminated single quote")
+            }
+            Self::UnterminatedDoubleQuote => {
+                f.write_str("remote shell specification has an unterminated double quote")
+            }
+            Self::InteriorNull => f.write_str("remote shell specification contains a NUL byte"),
+            Self::InvalidEncoding => {
+                f.write_str("remote shell specification contains invalid Unicode for this platform")
+            }
+        }
+    }
+}
+
+impl Error for RemoteShellParseError {}
+
+/// Parses a remote shell specification using rsync's quoting rules.
+#[must_use]
+pub fn parse_remote_shell(specification: &OsStr) -> Result<Vec<OsString>, RemoteShellParseError> {
+    let bytes = specification_bytes(specification)?;
+    let mut args = Vec::new();
+    let mut current = Vec::new();
+    let mut token_started = false;
+    let mut in_single = false;
+    let mut in_double = false;
+    let mut i = 0;
+
+    while i < bytes.len() {
+        let byte = bytes[i];
+        if byte == b'\0' {
+            return Err(RemoteShellParseError::InteriorNull);
+        }
+
+        if !in_single && !in_double && is_ascii_whitespace(byte) {
+            if token_started {
+                finish_token(&mut args, &mut current, &mut token_started);
+            }
+            i += 1;
+            while i < bytes.len() && is_ascii_whitespace(bytes[i]) {
+                i += 1;
+            }
+            continue;
+        }
+
+        match byte {
+            b'\'' => {
+                if in_double {
+                    current.push(byte);
+                } else {
+                    in_single = !in_single;
+                }
+                token_started = true;
+                i += 1;
+            }
+            b'"' => {
+                if in_single {
+                    current.push(byte);
+                } else {
+                    in_double = !in_double;
+                }
+                token_started = true;
+                i += 1;
+            }
+            b'\\' => {
+                if in_single {
+                    current.push(byte);
+                    token_started = true;
+                    i += 1;
+                    continue;
+                }
+
+                i += 1;
+                if i == bytes.len() {
+                    return Err(RemoteShellParseError::UnterminatedEscape);
+                }
+
+                let next = bytes[i];
+                if next == b'\0' {
+                    return Err(RemoteShellParseError::InteriorNull);
+                }
+
+                if next == b'\n' {
+                    i += 1;
+                    continue;
+                }
+
+                if in_double {
+                    match next {
+                        b'"' | b'\\' | b'$' | b'`' => {
+                            current.push(next);
+                        }
+                        _ => {
+                            current.push(b'\\');
+                            current.push(next);
+                        }
+                    }
+                } else {
+                    current.push(next);
+                }
+                token_started = true;
+                i += 1;
+            }
+            _ => {
+                current.push(byte);
+                token_started = true;
+                i += 1;
+            }
+        }
+    }
+
+    if in_single {
+        return Err(RemoteShellParseError::UnterminatedSingleQuote);
+    }
+    if in_double {
+        return Err(RemoteShellParseError::UnterminatedDoubleQuote);
+    }
+
+    if token_started {
+        finish_token(&mut args, &mut current, &mut token_started);
+    }
+
+    if args.is_empty() {
+        return Err(RemoteShellParseError::Empty);
+    }
+
+    Ok(args)
+}
+
+fn finish_token(args: &mut Vec<OsString>, current: &mut Vec<u8>, token_started: &mut bool) {
+    args.push(os_string_from_bytes(std::mem::take(current)));
+    *token_started = false;
+}
+
+fn is_ascii_whitespace(byte: u8) -> bool {
+    matches!(byte, b' ' | b'\t' | b'\n' | b'\r')
+}
+
+fn specification_bytes(spec: &OsStr) -> Result<Cow<'_, [u8]>, RemoteShellParseError> {
+    #[cfg(unix)]
+    {
+        Ok(Cow::Borrowed(spec.as_bytes()))
+    }
+
+    #[cfg(not(unix))]
+    {
+        spec.to_str()
+            .map(|s| Cow::Owned(s.as_bytes().to_vec()))
+            .ok_or(RemoteShellParseError::InvalidEncoding)
+    }
+}
+
+fn os_string_from_bytes(bytes: Vec<u8>) -> OsString {
+    #[cfg(unix)]
+    {
+        OsString::from_vec(bytes)
+    }
+
+    #[cfg(not(unix))]
+    {
+        OsString::from(String::from_utf8(bytes).expect("validated UTF-8"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{RemoteShellParseError, parse_remote_shell};
+    use std::ffi::{OsStr, OsString};
+
+    #[test]
+    fn parses_basic_remote_shell_sequence() {
+        let parsed =
+            parse_remote_shell(OsStr::new("ssh -l backup -p 2222")).expect("parse succeeds");
+        assert_eq!(
+            parsed,
+            vec![
+                OsString::from("ssh"),
+                OsString::from("-l"),
+                OsString::from("backup"),
+                OsString::from("-p"),
+                OsString::from("2222"),
+            ]
+        );
+    }
+
+    #[test]
+    fn parses_remote_shell_with_quotes_and_escapes() {
+        let parsed = parse_remote_shell(OsStr::new(
+            r#"ssh -oProxyCommand="ssh -W %h:%p gateway" -i'/path/to key'"#,
+        ))
+        .expect("parse succeeds");
+
+        assert_eq!(parsed[0], OsString::from("ssh"));
+        assert_eq!(
+            parsed[1],
+            OsString::from("-oProxyCommand=ssh -W %h:%p gateway")
+        );
+        assert_eq!(parsed[2], OsString::from("-i/path/to key"));
+    }
+
+    #[test]
+    fn parser_rejects_unterminated_single_quote() {
+        let error = parse_remote_shell(OsStr::new("ssh -o'ProxyCommand")).unwrap_err();
+        assert_eq!(error, RemoteShellParseError::UnterminatedSingleQuote);
+    }
+
+    #[test]
+    fn parser_rejects_unterminated_double_quote() {
+        let error = parse_remote_shell(OsStr::new("ssh -o\"ProxyCommand")).unwrap_err();
+        assert_eq!(error, RemoteShellParseError::UnterminatedDoubleQuote);
+    }
+
+    #[test]
+    fn parser_rejects_trailing_escape() {
+        let error = parse_remote_shell(OsStr::new("ssh -oProxyCommand=\\")).unwrap_err();
+        assert_eq!(error, RemoteShellParseError::UnterminatedEscape);
+    }
+
+    #[test]
+    fn parser_rejects_empty_specification() {
+        let error = parse_remote_shell(OsStr::new("   ")).unwrap_err();
+        assert_eq!(error, RemoteShellParseError::Empty);
+    }
+}


### PR DESCRIPTION
## Summary
- add a dedicated remote shell parser module that mirrors rsync's -e/--rsh quoting rules and export it from the transport crate
- teach `SshCommand` to configure its program/options from a remote shell specification and re-export the new helpers
- extend the SSH test suite with coverage for the parser and builder integration

## Testing
- cargo test -p rsync-transport

------