### PR TITLE
Scope runtime lock-file accessor to tests

### DIFF
--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -1053,6 +1053,7 @@ impl RuntimeOptions {
         self.reverse_lookup
     }
 
+    #[cfg(test)]
     fn lock_file(&self) -> Option<&Path> {
         self.lock_file.as_deref()
     }


### PR DESCRIPTION
## Summary
- gate the RuntimeOptions::lock_file accessor behind cfg(test) to eliminate dead-code warnings in the daemon crate

## Testing
- cargo test --lib rsync-daemon

------