### PR TITLE
Fix delete-excluded handling for filtered entries

### DIFF
--- a/crates/filters/src/lib.rs
+++ b/crates/filters/src/lib.rs
@@ -418,7 +418,7 @@ impl FilterDecision {
     }
 
     const fn allows_deletion_when_excluded_removed(self) -> bool {
-        !self.protected
+        !self.transfer_allowed && !self.protected
     }
 
     fn protect(&mut self) {
@@ -721,6 +721,14 @@ mod tests {
         let set = FilterSet::from_rules(rules).expect("compiled");
         assert!(set.allows_deletion(Path::new("backup/snap/info"), false));
         assert!(set.allows_deletion(Path::new("sub/backup/snap"), true));
+    }
+
+    #[test]
+    fn delete_excluded_only_removes_excluded_matches() {
+        let rules = [FilterRule::include("keep/**"), FilterRule::exclude("*.tmp")];
+        let set = FilterSet::from_rules(rules).expect("compiled");
+        assert!(set.allows_deletion_when_excluded_removed(Path::new("skip.tmp"), false));
+        assert!(!set.allows_deletion_when_excluded_removed(Path::new("keep/file.txt"), false));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- ensure filter decisions only permit delete-excluded sweeps for paths rejected by the filters
- skip retaining excluded source entries when delete-excluded is enabled so destination copies are removed
- add regression coverage for filter deletion semantics and matching source files

## Testing
- cargo test

------