### PR TITLE
Track bytes sent in local copy stats

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -6381,8 +6381,8 @@ mod tests {
         let rendered = String::from_utf8(stdout).expect("verbose output is UTF-8");
         assert!(rendered.contains("file.txt"));
         assert!(!rendered.contains("Total transferred"));
-        assert!(rendered.contains("sent 0 bytes  received 7 bytes"));
-        assert!(rendered.contains("total size is 7  speedup is 1.00"));
+        assert!(rendered.contains("sent 7 bytes  received 7 bytes"));
+        assert!(rendered.contains("total size is 7  speedup is 0.50"));
         assert_eq!(
             std::fs::read(destination).expect("read destination"),
             b"verbose"
@@ -6657,6 +6657,7 @@ mod tests {
         assert!(rendered.contains("File list size: 0"));
         assert!(rendered.contains("File list generation time:"));
         assert!(rendered.contains("File list transfer time:"));
+        assert!(rendered.contains(&format!("Total bytes sent: {expected_size}")));
         assert!(rendered.contains(&format!("Total bytes received: {expected_size}")));
         assert!(rendered.contains("\n\nsent"));
         assert!(rendered.contains("total size is"));

--- a/crates/core/src/client.rs
+++ b/crates/core/src/client.rs
@@ -1985,8 +1985,8 @@ impl ClientSummary {
 
     /// Returns the aggregate number of bytes sent during the transfer.
     #[must_use]
-    pub const fn bytes_sent(&self) -> u64 {
-        0
+    pub fn bytes_sent(&self) -> u64 {
+        self.stats.bytes_sent()
     }
 
     /// Returns the aggregate size of files that were rewritten or created.

--- a/crates/engine/src/local_copy.rs
+++ b/crates/engine/src/local_copy.rs
@@ -2556,6 +2556,7 @@ pub struct LocalCopySummary {
     sources_removed: u64,
     transferred_file_size: u64,
     bytes_copied: u64,
+    bytes_sent: u64,
     bytes_received: u64,
     compressed_bytes: u64,
     compression_used: bool,
@@ -2669,6 +2670,12 @@ impl LocalCopySummary {
         self.bytes_copied
     }
 
+    /// Returns the aggregate number of bytes that were sent to the peer.
+    #[must_use]
+    pub const fn bytes_sent(&self) -> u64 {
+        self.bytes_sent
+    }
+
     /// Returns the aggregate number of bytes received during the transfer.
     #[must_use]
     pub const fn bytes_received(&self) -> u64 {
@@ -2727,8 +2734,9 @@ impl LocalCopySummary {
         self.files_copied = self.files_copied.saturating_add(1);
         self.transferred_file_size = self.transferred_file_size.saturating_add(file_size);
         self.bytes_copied = self.bytes_copied.saturating_add(literal_bytes);
-        let received = compressed.unwrap_or(literal_bytes);
-        self.bytes_received = self.bytes_received.saturating_add(received);
+        let transmitted = compressed.unwrap_or(literal_bytes);
+        self.bytes_sent = self.bytes_sent.saturating_add(transmitted);
+        self.bytes_received = self.bytes_received.saturating_add(transmitted);
         if let Some(compressed_bytes) = compressed {
             self.compression_used = true;
             self.compressed_bytes = self.compressed_bytes.saturating_add(compressed_bytes);
@@ -10893,6 +10901,31 @@ mod tests {
         let compressed = summary.compressed_bytes();
         assert!(compressed > 0);
         assert!(compressed <= summary.bytes_copied());
+        assert_eq!(summary.bytes_sent(), summary.bytes_received());
+        assert_eq!(summary.bytes_sent(), compressed);
+    }
+
+    #[test]
+    fn execute_records_transmitted_bytes_for_uncompressed_copy() {
+        let temp = tempdir().expect("tempdir");
+        let source = temp.path().join("source.txt");
+        let destination = temp.path().join("dest.txt");
+        let payload = b"payload";
+        fs::write(&source, payload).expect("write source");
+
+        let operands = vec![
+            source.into_os_string(),
+            destination.clone().into_os_string(),
+        ];
+        let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+
+        let summary = plan.execute().expect("copy succeeds");
+
+        assert_eq!(fs::read(destination).expect("read dest"), payload);
+        let expected = payload.len() as u64;
+        assert_eq!(summary.bytes_copied(), expected);
+        assert_eq!(summary.bytes_sent(), expected);
+        assert_eq!(summary.bytes_received(), expected);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- track bytes sent in LocalCopySummary and expose it through ClientSummary
- ensure stats output reports a non-zero sent total and adjust verbose summary expectations
- add coverage for transmitted byte accounting in compressed and uncompressed local copies

## Testing
- cargo test

------