### PR TITLE
Add safe-links handling and tests

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -207,6 +207,7 @@ const HELP_TEXT: &str = concat!(
     "      --no-sparse Disable sparse file handling.\n",
     "  -L, --copy-links     Transform symlinks into referent files/directories.\n",
     "      --no-copy-links  Preserve symlinks instead of following them.\n",
+    "      --safe-links     Skip symlinks that point outside the transfer root.\n",
     "  -k, --copy-dirlinks  Transform symlinked directories into referent directories.\n",
     "  -K, --keep-dirlinks  Treat destination symlinks to directories as directories.\n",
     "      --no-keep-dirlinks  Disable --keep-dirlinks semantics.\n",
@@ -239,7 +240,7 @@ const HELP_TEXT: &str = concat!(
     "covers permissions, timestamps, and optional ownership metadata.\n",
 );
 
-const SUPPORTED_OPTIONS_LIST: &str = "--help/-h, --version/-V, --daemon, --dry-run/-n, --list-only, --archive/-a, --delete/--del, --delete-before, --delete-during, --delete-delay, --delete-after, --checksum/-c, --size-only, --ignore-existing, --delay-updates, --exclude, --exclude-from, --include, --include-from, --compare-dest, --copy-dest, --link-dest, --filter (including exclude-if-present=FILE), --files-from, --password-file, --no-motd, --from0, --bwlimit, --timeout, --protocol, --rsync-path, --remote-option/-M, --ipv4, --ipv6, --compress/-z, --no-compress, --compress-level, --info, --debug, --verbose/-v, --progress, --no-progress, --msgs2stderr, --itemize-changes/-i, --out-format, --stats, --partial, --partial-dir, --no-partial, --remove-source-files, --remove-sent-files, --inplace, --no-inplace, --whole-file/-W, --no-whole-file, -P, --sparse/-S, --no-sparse, --copy-links/-L, --no-copy-links, --copy-dirlinks/-k, --keep-dirlinks/-K, --no-keep-dirlinks, -D, --devices, --no-devices, --specials, --no-specials, --owner, --no-owner, --group, --no-group, --chown, --chmod, --perms/-p, --no-perms, --times/-t, --no-times, --acls/-A, --no-acls, --xattrs/-X, --no-xattrs, --numeric-ids, and --no-numeric-ids";
+const SUPPORTED_OPTIONS_LIST: &str = "--help/-h, --version/-V, --daemon, --dry-run/-n, --list-only, --archive/-a, --delete/--del, --delete-before, --delete-during, --delete-delay, --delete-after, --checksum/-c, --size-only, --ignore-existing, --delay-updates, --exclude, --exclude-from, --include, --include-from, --compare-dest, --copy-dest, --link-dest, --filter (including exclude-if-present=FILE), --files-from, --password-file, --no-motd, --from0, --bwlimit, --timeout, --protocol, --rsync-path, --remote-option/-M, --ipv4, --ipv6, --compress/-z, --no-compress, --compress-level, --info, --debug, --verbose/-v, --progress, --no-progress, --msgs2stderr, --itemize-changes/-i, --out-format, --stats, --partial, --partial-dir, --no-partial, --remove-source-files, --remove-sent-files, --inplace, --no-inplace, --whole-file/-W, --no-whole-file, -P, --sparse/-S, --no-sparse, --copy-links/-L, --no-copy-links, --safe-links, --copy-dirlinks/-k, --keep-dirlinks/-K, --no-keep-dirlinks, -D, --devices, --no-devices, --specials, --no-specials, --owner, --no-owner, --group, --no-group, --chown, --chmod, --perms/-p, --no-perms, --times/-t, --no-times, --acls/-A, --no-acls, --xattrs/-X, --no-xattrs, --numeric-ids, and --no-numeric-ids";
 
 const ITEMIZE_CHANGES_FORMAT: &str = "%i %n%L";
 /// Default patterns excluded by `--cvs-exclude`.
@@ -745,7 +746,11 @@ fn format_itemized_changes(event: &ClientEvent) -> String {
 
     fields[0] = match event.kind() {
         DataCopied => '>',
-        MetadataReused | SkippedExisting | SkippedNewerDestination | SkippedNonRegular => '.',
+        MetadataReused
+        | SkippedExisting
+        | SkippedNewerDestination
+        | SkippedNonRegular
+        | SkippedUnsafeSymlink => '.',
         HardLink => 'h',
         DirectoryCreated | SymlinkCopied | FifoCopied | DeviceCopied | SourceRemoved => 'c',
         _ => '.',
@@ -865,6 +870,7 @@ struct ParsedArgs {
     copy_links: Option<bool>,
     copy_dirlinks: bool,
     keep_dirlinks: Option<bool>,
+    safe_links: bool,
     devices: Option<bool>,
     specials: Option<bool>,
     relative: Option<bool>,
@@ -1144,6 +1150,12 @@ fn clap_command() -> ClapCommand {
                 .help("Preserve symlinks instead of following them.")
                 .action(ArgAction::SetTrue)
                 .conflicts_with("copy-links"),
+        )
+        .arg(
+            Arg::new("safe-links")
+                .long("safe-links")
+                .help("Skip symlinks that point outside the transfer root.")
+                .action(ArgAction::SetTrue),
         )
         .arg(
             Arg::new("no-keep-dirlinks")
@@ -1896,6 +1908,7 @@ where
     } else {
         None
     };
+    let safe_links = matches.get_flag("safe-links");
     let archive_devices = matches.get_flag("archive-devices");
     let devices = if matches.get_flag("no-devices") {
         Some(false)
@@ -2100,6 +2113,7 @@ where
         copy_links,
         copy_dirlinks,
         keep_dirlinks,
+        safe_links,
         devices,
         specials,
         relative,
@@ -2492,6 +2506,7 @@ where
         copy_links,
         copy_dirlinks,
         keep_dirlinks,
+        safe_links,
         devices,
         specials,
         relative,
@@ -2947,6 +2962,7 @@ where
             copy_links,
             copy_dirlinks,
             keep_dirlinks,
+            safe_links,
             sparse,
             devices,
             specials,
@@ -3156,6 +3172,7 @@ where
         .copy_links(copy_links)
         .copy_dirlinks(copy_dirlinks)
         .keep_dirlinks(keep_dirlinks_flag)
+        .safe_links(safe_links)
         .relative_paths(relative)
         .implied_dirs(implied_dirs)
         .mkpath(mkpath)
@@ -4038,6 +4055,20 @@ fn emit_verbose<W: Write + ?Sized>(
                 )?;
                 continue;
             }
+            ClientEventKind::SkippedUnsafeSymlink => {
+                let mut rendered = format!(
+                    "ignoring unsafe symlink \"{}\"",
+                    event.relative_path().display()
+                );
+                if let Some(metadata) = event.metadata()
+                    && let Some(target) = metadata.symlink_target()
+                {
+                    rendered.push_str(" -> ");
+                    rendered.push_str(&target.to_string_lossy());
+                }
+                writeln!(stdout, "{rendered}")?;
+                continue;
+            }
             _ => {}
         }
 
@@ -4113,6 +4144,7 @@ fn describe_event_kind(kind: &ClientEventKind) -> &'static str {
         ClientEventKind::DirectoryCreated => "directory",
         ClientEventKind::SkippedExisting => "skipped existing file",
         ClientEventKind::SkippedNonRegular => "skipped non-regular file",
+        ClientEventKind::SkippedUnsafeSymlink => "skipped unsafe symlink",
         ClientEventKind::SkippedNewerDestination => "skipped newer destination file",
         ClientEventKind::EntryDeleted => "deleted",
         ClientEventKind::SourceRemoved => "source removed",
@@ -7782,6 +7814,19 @@ mod tests {
         .expect("parse");
 
         assert_eq!(parsed.keep_dirlinks, Some(true));
+    }
+
+    #[test]
+    fn parse_args_recognises_safe_links_flag() {
+        let parsed = parse_args([
+            OsString::from("oc-rsync"),
+            OsString::from("--safe-links"),
+            OsString::from("source"),
+            OsString::from("dest"),
+        ])
+        .expect("parse");
+
+        assert!(parsed.safe_links);
     }
 
     #[test]
@@ -11661,6 +11706,59 @@ exit 0
 
         let recorded = std::fs::read_to_string(&args_path).expect("read args file");
         assert!(!recorded.lines().any(|line| line == "--preallocate"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn remote_fallback_forwards_safe_links_flag() {
+        use tempfile::tempdir;
+
+        let _env_lock = ENV_LOCK.lock().expect("env lock");
+        let _rsh_guard = clear_rsync_rsh();
+        let temp = tempdir().expect("tempdir");
+        let script_path = temp.path().join("fallback.sh");
+        let args_path = temp.path().join("args.txt");
+
+        let script = r#"#!/bin/sh
+printf "%s\n" "$@" > "$ARGS_FILE"
+exit 0
+"#;
+        write_executable_script(&script_path, script);
+
+        let _fallback_guard = EnvGuard::set("OC_RSYNC_FALLBACK", script_path.as_os_str());
+        let _args_guard = EnvGuard::set("ARGS_FILE", args_path.as_os_str());
+
+        let dest_path = temp.path().join("dest");
+
+        let (code, stdout, stderr) = run_with_args([
+            OsString::from("oc-rsync"),
+            OsString::from("--safe-links"),
+            OsString::from("remote::module"),
+            dest_path.clone().into_os_string(),
+        ]);
+
+        assert_eq!(code, 0);
+        assert!(stdout.is_empty());
+        assert!(stderr.is_empty());
+
+        let recorded = std::fs::read_to_string(&args_path).expect("read args file");
+        let args: Vec<&str> = recorded.lines().collect();
+        assert!(args.contains(&"--safe-links"));
+
+        std::fs::write(&args_path, b"").expect("truncate args file");
+
+        let (code, stdout, stderr) = run_with_args([
+            OsString::from("oc-rsync"),
+            OsString::from("remote::module"),
+            dest_path.into_os_string(),
+        ]);
+
+        assert_eq!(code, 0);
+        assert!(stdout.is_empty());
+        assert!(stderr.is_empty());
+
+        let recorded = std::fs::read_to_string(&args_path).expect("read args file");
+        assert!(!recorded.lines().any(|line| line == "--safe-links"));
     }
 
     #[cfg(unix)]

--- a/crates/core/src/client.rs
+++ b/crates/core/src/client.rs
@@ -390,6 +390,7 @@ pub struct ClientConfig {
     copy_links: bool,
     copy_dirlinks: bool,
     keep_dirlinks: bool,
+    safe_links: bool,
     relative_paths: bool,
     implied_dirs: bool,
     mkpath: bool,
@@ -450,6 +451,7 @@ impl Default for ClientConfig {
             copy_links: false,
             copy_dirlinks: false,
             keep_dirlinks: false,
+            safe_links: false,
             relative_paths: false,
             implied_dirs: true,
             mkpath: false,
@@ -544,6 +546,13 @@ impl ClientConfig {
     #[doc(alias = "--keep-dirlinks")]
     pub const fn keep_dirlinks(&self) -> bool {
         self.keep_dirlinks
+    }
+
+    /// Reports whether unsafe symlinks should be ignored (`--safe-links`).
+    #[must_use]
+    #[doc(alias = "--safe-links")]
+    pub const fn safe_links(&self) -> bool {
+        self.safe_links
     }
 
     /// Returns the ordered list of filter rules supplied by the caller.
@@ -943,6 +952,7 @@ pub struct ClientConfigBuilder {
     copy_links: bool,
     copy_dirlinks: bool,
     keep_dirlinks: bool,
+    safe_links: bool,
     relative_paths: bool,
     implied_dirs: Option<bool>,
     mkpath: bool,
@@ -1320,6 +1330,14 @@ impl ClientConfigBuilder {
         self
     }
 
+    /// Enables or disables skipping unsafe symlinks.
+    #[must_use]
+    #[doc(alias = "--safe-links")]
+    pub const fn safe_links(mut self, safe_links: bool) -> Self {
+        self.safe_links = safe_links;
+        self
+    }
+
     /// Enables or disables copying of device nodes during the transfer.
     #[must_use]
     #[doc(alias = "--devices")]
@@ -1573,6 +1591,7 @@ impl ClientConfigBuilder {
             copy_links: self.copy_links,
             copy_dirlinks: self.copy_dirlinks,
             keep_dirlinks: self.keep_dirlinks,
+            safe_links: self.safe_links,
             relative_paths: self.relative_paths,
             implied_dirs: self.implied_dirs.unwrap_or(true),
             mkpath: self.mkpath,
@@ -2172,6 +2191,8 @@ pub struct RemoteFallbackArgs {
     pub copy_dirlinks: bool,
     /// Optional `--keep-dirlinks`/`--no-keep-dirlinks` toggle.
     pub keep_dirlinks: Option<bool>,
+    /// Enables `--safe-links` when `true`.
+    pub safe_links: bool,
     /// Optional `--sparse`/`--no-sparse` toggle.
     pub sparse: Option<bool>,
     /// Optional `--devices`/`--no-devices` toggle.
@@ -2363,6 +2384,7 @@ where
         copy_links,
         copy_dirlinks,
         keep_dirlinks,
+        safe_links,
         sparse,
         devices,
         specials,
@@ -2506,6 +2528,9 @@ where
         "--no-keep-dirlinks",
         keep_dirlinks,
     );
+    if safe_links {
+        command_args.push(OsString::from("--safe-links"));
+    }
     push_toggle(&mut command_args, "--sparse", "--no-sparse", sparse);
     push_toggle(&mut command_args, "--devices", "--no-devices", devices);
     push_toggle(&mut command_args, "--specials", "--no-specials", specials);
@@ -2981,6 +3006,8 @@ pub enum ClientEventKind {
     SkippedNewerDestination,
     /// A non-regular entry was skipped because support was disabled.
     SkippedNonRegular,
+    /// A symbolic link was skipped because it was deemed unsafe.
+    SkippedUnsafeSymlink,
     /// An entry was deleted due to `--delete`.
     EntryDeleted,
     /// A source entry was removed after a successful transfer.
@@ -3012,6 +3039,7 @@ impl ClientEvent {
             LocalCopyAction::SkippedExisting => ClientEventKind::SkippedExisting,
             LocalCopyAction::SkippedNewerDestination => ClientEventKind::SkippedNewerDestination,
             LocalCopyAction::SkippedNonRegular => ClientEventKind::SkippedNonRegular,
+            LocalCopyAction::SkippedUnsafeSymlink => ClientEventKind::SkippedUnsafeSymlink,
             LocalCopyAction::EntryDeleted => ClientEventKind::EntryDeleted,
             LocalCopyAction::SourceRemoved => ClientEventKind::SourceRemoved,
         };
@@ -3026,6 +3054,7 @@ impl ClientEvent {
             | LocalCopyAction::SkippedExisting
             | LocalCopyAction::SkippedNewerDestination
             | LocalCopyAction::SkippedNonRegular
+            | LocalCopyAction::SkippedUnsafeSymlink
             | LocalCopyAction::EntryDeleted
             | LocalCopyAction::SourceRemoved => false,
         };
@@ -3624,6 +3653,7 @@ fn build_local_copy_options(
         .copy_links(config.copy_links())
         .copy_dirlinks(config.copy_dirlinks())
         .keep_dirlinks(config.keep_dirlinks())
+        .safe_links(config.safe_links())
         .devices(config.preserve_devices())
         .specials(config.preserve_specials())
         .relative_paths(config.relative_paths())
@@ -3785,6 +3815,7 @@ exit 42
             copy_links: None,
             copy_dirlinks: false,
             keep_dirlinks: None,
+            safe_links: false,
             sparse: None,
             devices: None,
             specials: None,
@@ -3875,6 +3906,18 @@ exit 42
         let disabled = ClientConfig::builder().append(false).build();
         assert!(!disabled.append());
         assert!(!disabled.append_verify());
+    }
+
+    #[test]
+    fn builder_safe_links_round_trip() {
+        let enabled = ClientConfig::builder().safe_links(true).build();
+        assert!(enabled.safe_links());
+
+        let disabled = ClientConfig::builder().safe_links(false).build();
+        assert!(!disabled.safe_links());
+
+        let default_config = ClientConfig::builder().build();
+        assert!(!default_config.safe_links());
     }
 
     #[test]
@@ -4614,6 +4657,55 @@ exit 42
         assert!(stderr.is_empty());
         let captured = fs::read_to_string(&capture_path).expect("capture contents");
         assert!(captured.lines().any(|line| line == "--no-keep-dirlinks"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn remote_fallback_forwards_safe_links_flag() {
+        let _lock = env_lock().lock().expect("env mutex poisoned");
+        let temp = tempdir().expect("tempdir created");
+        let capture_path = temp.path().join("args.txt");
+        let script_path = temp.path().join("capture.sh");
+        let script_contents = format!(
+            "#!/bin/sh\nset -eu\nOUTPUT=\"\"\nfor arg in \"$@\"; do\n  case \"$arg\" in\n    CAPTURE=*)\n      OUTPUT=\"${{arg#CAPTURE=}}\"\n      ;;\n  esac\ndone\n: \"${{OUTPUT:?}}\"\n: > \"$OUTPUT\"\nfor arg in \"$@\"; do\n  case \"$arg\" in\n    CAPTURE=*)\n      ;;\n    *)\n      printf '%s\\n' \"$arg\" >> \"$OUTPUT\"\n      ;;\n  esac\ndone\n"
+        );
+        fs::write(&script_path, script_contents).expect("script written");
+        let metadata = fs::metadata(&script_path).expect("script metadata");
+        let mut permissions = metadata.permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&script_path, permissions).expect("script permissions set");
+
+        let mut args = baseline_fallback_args();
+        args.fallback_binary = Some(script_path.clone().into_os_string());
+        args.safe_links = true;
+        args.remainder = vec![OsString::from(format!(
+            "CAPTURE={}",
+            capture_path.display()
+        ))];
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+        run_remote_transfer_fallback(&mut stdout, &mut stderr, args)
+            .expect("fallback invocation succeeds");
+        assert!(stdout.is_empty());
+        assert!(stderr.is_empty());
+        let captured = fs::read_to_string(&capture_path).expect("capture contents");
+        assert!(captured.lines().any(|line| line == "--safe-links"));
+
+        let mut args = baseline_fallback_args();
+        args.fallback_binary = Some(script_path.into_os_string());
+        args.safe_links = false;
+        args.remainder = vec![OsString::from(format!(
+            "CAPTURE={}",
+            capture_path.display()
+        ))];
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+        run_remote_transfer_fallback(&mut stdout, &mut stderr, args)
+            .expect("fallback invocation succeeds");
+        assert!(stdout.is_empty());
+        assert!(stderr.is_empty());
+        let captured = fs::read_to_string(&capture_path).expect("capture contents");
+        assert!(!captured.lines().any(|line| line == "--safe-links"));
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## Summary
- wire the `--safe-links` flag through the CLI configuration and remote fallback arguments
- ensure the core fallback launcher and client events honour skipped unsafe symlinks
- cover safe symlink acceptance and rejection in the engine's local copy tests

## Testing
- cargo test -p rsync-cli
- cargo test -p rsync-core
- cargo test -p rsync-engine --lib

------