### PR TITLE
Propagate --connect-program through CLI parsing

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -11,7 +11,7 @@
 //! `--delete`/`--delete-excluded`, `--filter` (supporting `+`/`-` actions, the
 //! `!` clear directive, and `merge FILE` directives), `--files-from`, `--from0`,
 //! `--compare-dest`, `--copy-dest`, `--link-dest`, `--bwlimit`,
-//! `--append`/`--append-verify`, `--remote-option`, and `--sparse`) and delegates local copy operations to
+//! `--append`/`--append-verify`, `--remote-option`, `--connect-program`, and `--sparse`) and delegates local copy operations to
 //! [`rsync_core::client::run_client`]. Daemon invocations are forwarded to
 //! [`rsync_daemon::run`], while `--server` sessions immediately spawn the
 //! system `rsync` binary (controlled by the `OC_RSYNC_FALLBACK` environment
@@ -131,6 +131,7 @@ const HELP_TEXT: &str = concat!(
     "  -V, --version    Output version information and exit.\n",
     "  -e, --rsh=COMMAND  Use remote shell COMMAND for remote transfers.\n",
     "      --rsync-path=PROGRAM  Use PROGRAM as the remote rsync executable during remote transfers.\n",
+    "      --connect-program=COMMAND  Execute COMMAND to reach rsync:// daemons (supports %H and %P placeholders).\n",
     "  -M, --remote-option=OPTION  Forward OPTION to the remote rsync command.\n",
     "  -s, --protect-args  Protect remote shell arguments from expansion.\n",
     "      --no-protect-args  Allow the remote shell to expand wildcard arguments.\n",
@@ -252,7 +253,7 @@ const HELP_TEXT: &str = concat!(
     "covers permissions, timestamps, and optional ownership metadata.\n",
 );
 
-const SUPPORTED_OPTIONS_LIST: &str = "--help, --human-readable/-h, --no-human-readable, --version/-V, --daemon, --dry-run/-n, --list-only, --archive/-a, --delete/--del, --delete-before, --delete-during, --delete-delay, --delete-after, --max-delete, --checksum/-c, --size-only, --ignore-existing, --delay-updates, --exclude, --exclude-from, --include, --include-from, --compare-dest, --copy-dest, --link-dest, --filter (including exclude-if-present=FILE) and -F, --files-from, --password-file, --no-motd, --from0, --bwlimit, --timeout, --contimeout, --protocol, --rsync-path, --remote-option/-M, --ipv4, --ipv6, --compress/-z, --no-compress, --compress-level, --info, --debug, --verbose/-v, --progress, --no-progress, --msgs2stderr, --itemize-changes/-i, --out-format, --stats, --partial, --partial-dir, --no-partial, --remove-source-files, --remove-sent-files, --inplace, --no-inplace, --whole-file/-W, --no-whole-file, -P, --sparse/-S, --no-sparse, --copy-links/-L, --no-copy-links, --copy-dirlinks/-k, --keep-dirlinks/-K, --no-keep-dirlinks, -D, --devices, --no-devices, --specials, --no-specials, --owner, --no-owner, --group, --no-group, --chown, --chmod, --perms/-p, --no-perms, --times/-t, --no-times, --omit-dir-times, --no-omit-dir-times, --omit-link-times, --no-omit-link-times, --acls/-A, --no-acls, --xattrs/-X, --no-xattrs, --numeric-ids, and --no-numeric-ids";
+const SUPPORTED_OPTIONS_LIST: &str = "--help, --human-readable/-h, --no-human-readable, --version/-V, --daemon, --dry-run/-n, --list-only, --archive/-a, --delete/--del, --delete-before, --delete-during, --delete-delay, --delete-after, --max-delete, --checksum/-c, --size-only, --ignore-existing, --delay-updates, --exclude, --exclude-from, --include, --include-from, --compare-dest, --copy-dest, --link-dest, --filter (including exclude-if-present=FILE) and -F, --files-from, --password-file, --no-motd, --from0, --bwlimit, --timeout, --contimeout, --protocol, --rsync-path, --connect-program, --remote-option/-M, --ipv4, --ipv6, --compress/-z, --no-compress, --compress-level, --info, --debug, --verbose/-v, --progress, --no-progress, --msgs2stderr, --itemize-changes/-i, --out-format, --stats, --partial, --partial-dir, --no-partial, --remove-source-files, --remove-sent-files, --inplace, --no-inplace, --whole-file/-W, --no-whole-file, -P, --sparse/-S, --no-sparse, --copy-links/-L, --no-copy-links, --copy-dirlinks/-k, --keep-dirlinks/-K, --no-keep-dirlinks, -D, --devices, --no-devices, --specials, --no-specials, --owner, --no-owner, --group, --no-group, --chown, --chmod, --perms/-p, --no-perms, --times/-t, --no-times, --omit-dir-times, --no-omit-dir-times, --omit-link-times, --no-omit-link-times, --acls/-A, --no-acls, --xattrs/-X, --no-xattrs, --numeric-ids, and --no-numeric-ids";
 
 const ITEMIZE_CHANGES_FORMAT: &str = "%i %n%L";
 /// Default patterns excluded by `--cvs-exclude`.
@@ -854,6 +855,7 @@ struct ParsedArgs {
     dry_run: bool,
     list_only: bool,
     remote_shell: Option<OsString>,
+    connect_program: Option<OsString>,
     remote_options: Vec<OsString>,
     rsync_path: Option<OsString>,
     protect_args: Option<bool>,
@@ -1037,6 +1039,18 @@ fn clap_command() -> ClapCommand {
                 .help("Use PROGRAM as the remote rsync executable during remote transfers.")
                 .num_args(1)
                 .action(ArgAction::Set)
+                .value_parser(OsStringValueParser::new()),
+        )
+        .arg(
+            Arg::new("connect-program")
+                .long("connect-program")
+                .value_name("COMMAND")
+                .help(
+                    "Execute COMMAND to reach rsync:// daemons (supports %H and %P placeholders).",
+                )
+                .num_args(1)
+                .action(ArgAction::Set)
+                .allow_hyphen_values(true)
                 .value_parser(OsStringValueParser::new()),
         )
         .arg(
@@ -1895,6 +1909,9 @@ where
     let rsync_path = matches
         .remove_one::<OsString>("rsync-path")
         .filter(|value| !value.is_empty());
+    let connect_program = matches
+        .remove_one::<OsString>("connect-program")
+        .filter(|value| !value.is_empty());
     let remote_options = matches
         .remove_many::<OsString>("remote-option")
         .map(|values| values.collect())
@@ -2243,6 +2260,7 @@ where
         dry_run,
         list_only,
         remote_shell,
+        connect_program,
         remote_options,
         rsync_path,
         protect_args,
@@ -2631,6 +2649,7 @@ where
         dry_run,
         list_only,
         remote_shell,
+        connect_program,
         remote_options,
         rsync_path,
         protect_args,
@@ -3077,7 +3096,8 @@ where
 
                 let list_options = ModuleListOptions::default()
                     .suppress_motd(no_motd)
-                    .with_address_mode(address_mode);
+                    .with_address_mode(address_mode)
+                    .with_connect_program(connect_program.clone());
                 return match run_module_list_with_password_and_options(
                     request,
                     list_options,
@@ -3152,6 +3172,7 @@ where
             list_only,
             remote_shell: remote_shell.clone(),
             remote_options: remote_options.clone(),
+            connect_program: connect_program.clone(),
             protect_args,
             human_readable: human_readable_setting,
             archive,
@@ -3303,6 +3324,21 @@ where
             }
             return 1;
         }
+
+        if connect_program.is_some() {
+            let message = rsync_error!(
+                1,
+                "the --connect-program option may only be used when accessing an rsync daemon"
+            )
+            .with_role(Role::Client);
+            if write_message(&message, stderr).is_err() {
+                let _ = writeln!(
+                    stderr.writer_mut(),
+                    "the --connect-program option may only be used when accessing an rsync daemon"
+                );
+            }
+            return 1;
+        }
     }
 
     let mut transfer_operands = Vec::with_capacity(file_list_operands.len() + remainder.len());
@@ -3369,6 +3405,7 @@ where
     let mut builder = ClientConfig::builder()
         .transfer_args(transfer_operands)
         .address_mode(address_mode)
+        .connect_program(connect_program.clone())
         .dry_run(dry_run)
         .list_only(list_only)
         .delete(delete_mode.is_enabled() || delete_excluded || max_delete_limit.is_some())
@@ -11463,6 +11500,34 @@ exit 99
     }
 
     #[test]
+    fn module_list_uses_connect_program_option() {
+        let _env_lock = ENV_LOCK.lock().expect("env lock");
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let script_path = temp.path().join("connect-program.sh");
+        let script = r#"#!/bin/sh
+set -eu
+printf "@RSYNCD: 31.0\n"
+read _greeting
+printf "@RSYNCD: OK\n"
+read _request
+printf "example\tvia connect program\n@RSYNCD: EXIT\n"
+"#;
+        write_executable_script(&script_path, script);
+
+        let (code, stdout, stderr) = run_with_args([
+            OsString::from("oc-rsync"),
+            OsString::from(format!("--connect-program={}", script_path.display())),
+            OsString::from("rsync://example/"),
+        ]);
+
+        assert_eq!(code, 0);
+        assert!(stderr.is_empty());
+        let rendered = String::from_utf8(stdout).expect("module listing is UTF-8");
+        assert!(rendered.contains("example\tvia connect program"));
+    }
+
+    #[test]
     fn module_list_username_prefix_legacy_syntax_is_accepted() {
         let (addr, handle) =
             spawn_stub_daemon(vec!["@RSYNCD: OK\n", "module\n", "@RSYNCD: EXIT\n"]);
@@ -14022,6 +14087,42 @@ exit 0
     }
 
     #[test]
+    fn remote_fallback_forwards_connect_program_option() {
+        use tempfile::tempdir;
+
+        let _env_lock = ENV_LOCK.lock().expect("env lock");
+        let _rsh_guard = clear_rsync_rsh();
+        let temp = tempdir().expect("tempdir");
+        let script_path = temp.path().join("fallback.sh");
+        let args_path = temp.path().join("args.txt");
+
+        let script = r#"#!/bin/sh
+printf "%s\n" "$@" > "$ARGS_FILE"
+exit 0
+"#;
+        write_executable_script(&script_path, script);
+
+        let _fallback_guard = EnvGuard::set("OC_RSYNC_FALLBACK", script_path.as_os_str());
+        let _args_guard = EnvGuard::set("ARGS_FILE", args_path.as_os_str());
+
+        let dest_path = temp.path().join("dest");
+        let (code, stdout, stderr) = run_with_args([
+            OsString::from("oc-rsync"),
+            OsString::from("--connect-program=nc %H %P"),
+            OsString::from("remote::module"),
+            dest_path.clone().into_os_string(),
+        ]);
+
+        assert_eq!(code, 0);
+        assert!(stdout.is_empty());
+        assert!(stderr.is_empty());
+
+        let recorded = std::fs::read_to_string(&args_path).expect("read args file");
+        assert!(recorded.lines().any(|line| line == "--connect-program"));
+        assert!(recorded.lines().any(|line| line == "nc %H %P"));
+    }
+
+    #[test]
     fn remote_fallback_forwards_remote_option() {
         use tempfile::tempdir;
 
@@ -14194,6 +14295,31 @@ exit 0
         assert!(
             message.contains("the --rsync-path option may only be used with remote connections")
         );
+        assert!(!dest.exists());
+    }
+
+    #[test]
+    fn connect_program_requires_remote_operands() {
+        use tempfile::tempdir;
+
+        let temp = tempdir().expect("tempdir");
+        let source = temp.path().join("source.txt");
+        let dest = temp.path().join("dest.txt");
+        std::fs::write(&source, b"content").expect("write source");
+
+        let (code, stdout, stderr) = run_with_args([
+            OsString::from("oc-rsync"),
+            OsString::from("--connect-program=/usr/bin/nc %H %P"),
+            source.clone().into_os_string(),
+            dest.clone().into_os_string(),
+        ]);
+
+        assert_eq!(code, 1);
+        assert!(stdout.is_empty());
+        let message = String::from_utf8(stderr).expect("stderr utf8");
+        assert!(message.contains(
+            "the --connect-program option may only be used when accessing an rsync daemon"
+        ));
         assert!(!dest.exists());
     }
 

--- a/crates/core/src/client.rs
+++ b/crates/core/src/client.rs
@@ -455,6 +455,9 @@ pub struct ClientConfig {
     connect_timeout: TransferTimeout,
     link_dest_paths: Vec<PathBuf>,
     reference_directories: Vec<ReferenceDirectory>,
+    /// Optional command executed to reach rsync:// daemons.
+    #[doc(alias = "--connect-program")]
+    connect_program: Option<OsString>,
     #[cfg(feature = "acl")]
     preserve_acls: bool,
     #[cfg(feature = "xattr")]
@@ -524,6 +527,7 @@ impl Default for ClientConfig {
             connect_timeout: TransferTimeout::Default,
             link_dest_paths: Vec::new(),
             reference_directories: Vec::new(),
+            connect_program: None,
             #[cfg(feature = "acl")]
             preserve_acls: false,
             #[cfg(feature = "xattr")]
@@ -568,6 +572,13 @@ impl ClientConfig {
     #[doc(alias = "--ipv6")]
     pub const fn address_mode(&self) -> AddressMode {
         self.address_mode
+    }
+
+    /// Returns the configured connect program, if any.
+    #[must_use]
+    #[doc(alias = "--connect-program")]
+    pub fn connect_program(&self) -> Option<&OsStr> {
+        self.connect_program.as_deref()
     }
 
     /// Reports whether a transfer was explicitly requested.
@@ -1089,6 +1100,7 @@ pub struct ClientConfigBuilder {
     connect_timeout: TransferTimeout,
     link_dest_paths: Vec<PathBuf>,
     reference_directories: Vec<ReferenceDirectory>,
+    connect_program: Option<OsString>,
     #[cfg(feature = "acl")]
     preserve_acls: bool,
     #[cfg(feature = "xattr")]
@@ -1734,6 +1746,14 @@ impl ClientConfigBuilder {
         self
     }
 
+    /// Configures the command used to reach rsync:// daemons.
+    #[must_use]
+    #[doc(alias = "--connect-program")]
+    pub fn connect_program(mut self, program: Option<OsString>) -> Self {
+        self.connect_program = program;
+        self
+    }
+
     /// Selects the preferred address family for network operations.
     #[must_use]
     #[doc(alias = "--ipv4")]
@@ -1807,6 +1827,7 @@ impl ClientConfigBuilder {
             connect_timeout: self.connect_timeout,
             link_dest_paths: self.link_dest_paths,
             reference_directories: self.reference_directories,
+            connect_program: self.connect_program,
             #[cfg(feature = "acl")]
             preserve_acls: self.preserve_acls,
             #[cfg(feature = "xattr")]
@@ -2343,6 +2364,8 @@ pub struct RemoteFallbackArgs {
     pub remote_shell: Option<OsString>,
     /// Additional options forwarded to the remote rsync invocation via `--remote-option`/`-M`.
     pub remote_options: Vec<OsString>,
+    /// Optional command executed to reach rsync:// daemons.
+    pub connect_program: Option<OsString>,
     /// Controls whether remote shell arguments are protected from expansion.
     ///
     /// When `Some(true)` the fallback command receives `--protect-args`,
@@ -2585,6 +2608,7 @@ where
         list_only,
         remote_shell,
         remote_options,
+        connect_program,
         protect_args,
         human_readable: human_readable_mode,
         archive,
@@ -2995,6 +3019,11 @@ where
     for option in remote_options {
         command_args.push(OsString::from("--remote-option"));
         command_args.push(option);
+    }
+
+    if let Some(program) = connect_program {
+        command_args.push(OsString::from("--connect-program"));
+        command_args.push(program);
     }
 
     if let Some(shell) = remote_shell {
@@ -4084,6 +4113,7 @@ exit 42
             list_only: false,
             remote_shell: None,
             remote_options: Vec::new(),
+            connect_program: None,
             protect_args: None,
             human_readable: None,
             address_mode: AddressMode::Default,
@@ -8010,10 +8040,11 @@ impl ModuleListRequest {
 }
 
 /// Configuration toggles that influence daemon module listings.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ModuleListOptions {
     suppress_motd: bool,
     address_mode: AddressMode,
+    connect_program: Option<OsString>,
 }
 
 impl ModuleListOptions {
@@ -8023,6 +8054,7 @@ impl ModuleListOptions {
         Self {
             suppress_motd: false,
             address_mode: AddressMode::Default,
+            connect_program: None,
         }
     }
 
@@ -8035,7 +8067,7 @@ impl ModuleListOptions {
 
     /// Returns whether MOTD lines should be suppressed.
     #[must_use]
-    pub const fn suppresses_motd(self) -> bool {
+    pub const fn suppresses_motd(&self) -> bool {
         self.suppress_motd
     }
 
@@ -8052,6 +8084,20 @@ impl ModuleListOptions {
     #[must_use]
     pub const fn address_mode(&self) -> AddressMode {
         self.address_mode
+    }
+
+    /// Supplies an explicit connect program command.
+    #[must_use]
+    #[doc(alias = "--connect-program")]
+    pub fn with_connect_program(mut self, program: Option<OsString>) -> Self {
+        self.connect_program = program;
+        self
+    }
+
+    /// Returns the configured connect program command, if any.
+    #[must_use]
+    pub fn connect_program(&self) -> Option<&OsStr> {
+        self.connect_program.as_deref()
     }
 }
 
@@ -8424,8 +8470,9 @@ fn open_daemon_stream(
     connect_timeout: Option<Duration>,
     io_timeout: Option<Duration>,
     address_mode: AddressMode,
+    connect_program: Option<&OsStr>,
 ) -> Result<DaemonStream, ClientError> {
-    if let Some(program) = load_daemon_connect_program()? {
+    if let Some(program) = load_daemon_connect_program(connect_program)? {
         return connect_via_program(addr, &program);
     }
 
@@ -8700,7 +8747,22 @@ fn connect_via_program(
     )))
 }
 
-fn load_daemon_connect_program() -> Result<Option<ConnectProgramConfig>, ClientError> {
+fn load_daemon_connect_program(
+    override_template: Option<&OsStr>,
+) -> Result<Option<ConnectProgramConfig>, ClientError> {
+    if let Some(template) = override_template {
+        if template.is_empty() {
+            return Err(connect_program_configuration_error(
+                "the --connect-program option requires a non-empty command",
+            ));
+        }
+
+        let shell = env::var_os("RSYNC_SHELL").filter(|value| !value.is_empty());
+        return ConnectProgramConfig::new(OsString::from(template), shell)
+            .map(Some)
+            .map_err(connect_program_configuration_error);
+    }
+
     let Some(template) = env::var_os("RSYNC_CONNECT_PROG") else {
         return Ok(None);
     };
@@ -9201,7 +9263,13 @@ pub fn run_module_list_with_password_and_options(
     let effective_timeout = timeout.effective(DAEMON_SOCKET_TIMEOUT);
     let connect_duration = resolve_connect_timeout(connect_timeout, timeout, DAEMON_SOCKET_TIMEOUT);
 
-    let stream = open_daemon_stream(addr, connect_duration, effective_timeout, address_mode)?;
+    let stream = open_daemon_stream(
+        addr,
+        connect_duration,
+        effective_timeout,
+        address_mode,
+        options.connect_program(),
+    )?;
 
     let handshake = negotiate_legacy_daemon_session(stream, request.protocol())
         .map_err(|error| map_daemon_handshake_error(error, addr))?;


### PR DESCRIPTION
## Summary
- persist the parsed --connect-program option within ParsedArgs for later use
- forward the stored connect-program value through module listing, remote fallback, and daemon connection helpers

## Testing
- cargo test

------