### PR TITLE
Add bandwidth limiter configuration update helper

### DIFF
--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -3637,7 +3637,7 @@ fn apply_module_bandwidth_limit(
             Some(existing) => {
                 let target_burst = module_burst.or(existing.burst_bytes());
                 if limit < existing.limit_bytes() || module_burst.is_some() {
-                    *existing = BandwidthLimiter::with_burst(limit, target_burst);
+                    existing.update_configuration(limit, target_burst);
                 }
             }
             None => {
@@ -3646,7 +3646,7 @@ fn apply_module_bandwidth_limit(
         }
     } else if let Some(burst) = module_burst {
         if let Some(existing) = limiter {
-            *existing = BandwidthLimiter::with_burst(existing.limit_bytes(), Some(burst));
+            existing.update_configuration(existing.limit_bytes(), Some(burst));
         }
     }
 }


### PR DESCRIPTION
## Summary
- add `BandwidthLimiter::update_configuration` so rate and burst changes reset pacing state in one place
- update the daemon's module limit handling to reuse existing limiters when caps change and cover the new behaviour with tests

## Testing
- cargo test -p rsync-bandwidth
- cargo test -p rsync-daemon

------