### PR TITLE
Add `%C` checksum rendering and destination path tracking

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -19,6 +19,7 @@ rsync-daemon = { path = "../daemon" }
 rsync-protocol = { path = "../protocol" }
 rsync-compress = { path = "../compress" }
 rsync-meta = { path = "../meta" }
+rsync-checksums = { path = "../checksums" }
 time = { version = "0.3", default-features = false, features = ["formatting", "macros"] }
 tempfile = "3.10"
 users = "0.11"
@@ -29,5 +30,4 @@ tempfile = "3.10"
 rsync-filters = { path = "../filters" }
 xattr = "1.6"
 rustix = { version = "0.38", features = ["fs"] }
-rsync-checksums = { path = "../checksums" }
 base64 = "0.22"

--- a/crates/core/src/client.rs
+++ b/crates/core/src/client.rs
@@ -90,7 +90,10 @@ use std::net::{SocketAddr, TcpStream};
 use std::num::NonZeroU64;
 use std::path::{Path, PathBuf};
 use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
-use std::sync::mpsc::{self, Sender};
+use std::sync::{
+    Arc,
+    mpsc::{self, Sender},
+};
 use std::thread;
 use std::time::{Duration, Instant, SystemTime};
 use std::{env, error::Error};
@@ -2182,10 +2185,11 @@ pub struct ClientSummary {
 impl ClientSummary {
     fn from_report(report: LocalCopyReport) -> Self {
         let stats = *report.summary();
+        let destination_root = Arc::new(report.destination_root().to_path_buf());
         let events = report
             .records()
             .iter()
-            .map(ClientEvent::from_record)
+            .map(|record| ClientEvent::from_record(record, Arc::clone(&destination_root)))
             .collect();
         Self { stats, events }
     }
@@ -3448,10 +3452,12 @@ pub struct ClientEvent {
     elapsed: Duration,
     metadata: Option<ClientEntryMetadata>,
     created: bool,
+    destination_root: Arc<PathBuf>,
+    destination_path: PathBuf,
 }
 
 impl ClientEvent {
-    fn from_record(record: &LocalCopyRecord) -> Self {
+    fn from_record(record: &LocalCopyRecord, destination_root: Arc<PathBuf>) -> Self {
         let kind = match record.action() {
             LocalCopyAction::DataCopied => ClientEventKind::DataCopied,
             LocalCopyAction::MetadataReused => ClientEventKind::MetadataReused,
@@ -3482,6 +3488,8 @@ impl ClientEvent {
             | LocalCopyAction::EntryDeleted
             | LocalCopyAction::SourceRemoved => false,
         };
+        let destination_path =
+            Self::resolve_destination_path(&destination_root, record.relative_path());
         Self {
             relative_path: record.relative_path().to_path_buf(),
             kind,
@@ -3492,6 +3500,8 @@ impl ClientEvent {
                 .metadata()
                 .map(ClientEntryMetadata::from_local_copy_metadata),
             created,
+            destination_root,
+            destination_path,
         }
     }
 
@@ -3500,7 +3510,9 @@ impl ClientEvent {
         bytes_transferred: u64,
         total_bytes: Option<u64>,
         elapsed: Duration,
+        destination_root: Arc<PathBuf>,
     ) -> Self {
+        let destination_path = Self::resolve_destination_path(&destination_root, relative);
         Self {
             relative_path: relative.to_path_buf(),
             kind: ClientEventKind::DataCopied,
@@ -3509,6 +3521,8 @@ impl ClientEvent {
             elapsed,
             metadata: None,
             created: false,
+            destination_root,
+            destination_path,
         }
     }
 
@@ -3552,6 +3566,33 @@ impl ClientEvent {
     #[must_use]
     pub const fn was_created(&self) -> bool {
         self.created
+    }
+
+    /// Returns the root directory of the destination tree.
+    #[must_use]
+    pub fn destination_root(&self) -> &Path {
+        &self.destination_root
+    }
+
+    /// Returns the absolute destination path associated with this event.
+    #[must_use]
+    pub fn destination_path(&self) -> PathBuf {
+        self.destination_path.clone()
+    }
+
+    fn resolve_destination_path(destination_root: &Path, relative: &Path) -> PathBuf {
+        let candidate = destination_root.join(relative);
+        if candidate.exists() {
+            return candidate;
+        }
+
+        if let Some(file_name) = destination_root.file_name() {
+            if relative == Path::new(file_name) {
+                return destination_root.to_path_buf();
+            }
+        }
+
+        candidate
     }
 }
 
@@ -3787,6 +3828,7 @@ struct ClientProgressForwarder<'a> {
     overall_transferred: u64,
     overall_start: Instant,
     in_flight: HashMap<PathBuf, u64>,
+    destination_root: Arc<PathBuf>,
 }
 
 impl<'a> ClientProgressForwarder<'a> {
@@ -3803,13 +3845,12 @@ impl<'a> ClientProgressForwarder<'a> {
             .execute_with_report(LocalCopyExecution::DryRun, options.clone())
             .map_err(map_local_copy_error)?;
 
+        let destination_root = Arc::new(preview_report.destination_root().to_path_buf());
         let total = preview_report
             .records()
             .iter()
-            .filter(|record| {
-                let event = ClientEvent::from_record(record);
-                event.kind().is_progress()
-            })
+            .map(|record| ClientEvent::from_record(record, Arc::clone(&destination_root)))
+            .filter(|event| event.kind().is_progress())
             .count();
 
         let summary = preview_report.summary();
@@ -3823,6 +3864,7 @@ impl<'a> ClientProgressForwarder<'a> {
             overall_transferred: 0,
             overall_start: Instant::now(),
             in_flight: HashMap::new(),
+            destination_root,
         })
     }
 
@@ -3833,7 +3875,7 @@ impl<'a> ClientProgressForwarder<'a> {
 
 impl<'a> LocalCopyRecordHandler for ClientProgressForwarder<'a> {
     fn handle(&mut self, record: LocalCopyRecord) {
-        let event = ClientEvent::from_record(&record);
+        let event = ClientEvent::from_record(&record, Arc::clone(&self.destination_root));
         if !event.kind().is_progress() {
             return;
         }
@@ -3882,6 +3924,7 @@ impl<'a> LocalCopyRecordHandler for ClientProgressForwarder<'a> {
             progress.bytes_transferred(),
             progress.total_bytes(),
             progress.elapsed(),
+            Arc::clone(&self.destination_root),
         );
 
         let entry = self
@@ -4148,7 +4191,7 @@ mod tests {
     use std::io::{self, BufRead, BufReader, Seek, SeekFrom, Write};
     use std::net::{Shutdown, TcpListener, TcpStream};
     use std::num::{NonZeroU8, NonZeroU64};
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
     use std::sync::{Mutex, OnceLock};
     use std::thread;
     use std::time::Duration;
@@ -4170,8 +4213,44 @@ mod tests {
         assert!(zeroed.iter().all(|&byte| byte == 0));
     }
 
-    #[cfg(unix)]
-    use std::path::Path;
+    #[test]
+    fn resolve_destination_path_returns_existing_candidate() {
+        let temp = tempdir().expect("tempdir");
+        let root = temp.path().join("dest");
+        fs::create_dir_all(&root).expect("create dest root");
+        let subdir = root.join("sub");
+        fs::create_dir_all(&subdir).expect("create subdir");
+        let file_path = subdir.join("file.txt");
+        fs::write(&file_path, b"payload").expect("write file");
+
+        let relative = Path::new("sub").join("file.txt");
+        let resolved = ClientEvent::resolve_destination_path(root.as_path(), relative.as_path());
+
+        assert_eq!(resolved, file_path);
+    }
+
+    #[test]
+    fn resolve_destination_path_returns_root_for_file_destination() {
+        let temp = tempdir().expect("tempdir");
+        let root = temp.path().join("target.bin");
+        let relative = Path::new("target.bin");
+
+        let resolved = ClientEvent::resolve_destination_path(root.as_path(), relative);
+
+        assert_eq!(resolved, root);
+    }
+
+    #[test]
+    fn resolve_destination_path_preserves_missing_entries() {
+        let temp = tempdir().expect("tempdir");
+        let root = temp.path().join("dest");
+        fs::create_dir_all(&root).expect("create destination root");
+        let relative = Path::new("missing.bin");
+
+        let resolved = ClientEvent::resolve_destination_path(root.as_path(), relative);
+
+        assert_eq!(resolved, root.join(relative));
+    }
 
     #[cfg(unix)]
     use std::os::unix::fs::PermissionsExt;

--- a/crates/engine/src/local_copy.rs
+++ b/crates/engine/src/local_copy.rs
@@ -1445,11 +1445,20 @@ impl<'a> LocalCopyProgress<'a> {
 pub struct LocalCopyReport {
     summary: LocalCopySummary,
     records: Vec<LocalCopyRecord>,
+    destination_root: PathBuf,
 }
 
 impl LocalCopyReport {
-    fn new(summary: LocalCopySummary, records: Vec<LocalCopyRecord>) -> Self {
-        Self { summary, records }
+    fn new(
+        summary: LocalCopySummary,
+        records: Vec<LocalCopyRecord>,
+        destination_root: PathBuf,
+    ) -> Self {
+        Self {
+            summary,
+            records,
+            destination_root,
+        }
     }
 
     /// Returns the high-level summary collected during execution.
@@ -1474,6 +1483,12 @@ impl LocalCopyReport {
     #[must_use]
     pub fn into_records(self) -> Vec<LocalCopyRecord> {
         self.records
+    }
+
+    /// Returns the destination root path used during execution.
+    #[must_use]
+    pub fn destination_root(&self) -> &Path {
+        &self.destination_root
     }
 }
 
@@ -3077,6 +3092,7 @@ impl LocalCopySummary {
 struct CopyOutcome {
     summary: LocalCopySummary,
     events: Option<Vec<LocalCopyRecord>>,
+    destination_root: PathBuf,
 }
 
 impl CopyOutcome {
@@ -3087,7 +3103,10 @@ impl CopyOutcome {
     fn into_summary_and_report(self) -> (LocalCopySummary, LocalCopyReport) {
         let summary = self.summary;
         let records = self.events.unwrap_or_default();
-        (summary, LocalCopyReport::new(summary, records))
+        (
+            summary,
+            LocalCopyReport::new(summary, records, self.destination_root),
+        )
     }
 }
 
@@ -4458,6 +4477,7 @@ impl<'a> CopyContext<'a> {
         CopyOutcome {
             summary: self.summary,
             events: self.events,
+            destination_root: self.destination_root,
         }
     }
 


### PR DESCRIPTION
## Summary
- track the destination root in local copy reports and client events so formatting helpers can resolve absolute targets
- implement the `%C` out-format placeholder with MD5 rendering and whitespace fallback for non-file entries
- extend the CLI and core test suites to cover checksum output and destination-path resolution

## Testing
- cargo test -p rsync-cli
- cargo test -p rsync-core

------