### PR TITLE
Add CLI and core bind address support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -644,6 +644,7 @@ dependencies = [
  "rsync-meta",
  "rsync-protocol",
  "rsync-transport",
+ "socket2",
  "tempfile",
 ]
 

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -20,6 +20,7 @@ libc = "0.2"
 base64 = "0.22"
 rsync-checksums = { path = "../checksums" }
 tempfile = "3.10"
+socket2 = "0.4"
 
 [features]
 default = []


### PR DESCRIPTION
## Summary
- parse `--address` in the CLI, forward the bind address to module listings and fallback invocations, and pass it into the client builder
- extend `ClientConfig` and the daemon connection helpers to carry an optional bind address and respect it when opening sockets
- add socket binding utilities, tests for the new options, and wire up the socket2 dependency

## Testing
- cargo test -p rsync-cli
- cargo test -p rsync-core

------