### PR TITLE
Fix daemon auth test environment race

### DIFF
--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -6990,6 +6990,8 @@ mod tests {
 
     #[test]
     fn run_daemon_accepts_valid_credentials() {
+        let _lock = ENV_LOCK.lock().expect("env lock");
+
         let dir = tempdir().expect("config dir");
         let module_dir = dir.path().join("module");
         fs::create_dir_all(&module_dir).expect("module dir");


### PR DESCRIPTION
## Summary
- guard the daemon auth acceptance test with the shared environment mutex
- prevent fallback delegation overrides from leaking into the credential test during parallel execution

## Testing
- cargo test -p rsync-daemon run_daemon_accepts_valid_credentials -- --nocapture
- cargo test -p rsync-daemon

------