### PR TITLE
Implement --one-file-system support

### DIFF
--- a/crates/core/src/client.rs
+++ b/crates/core/src/client.rs
@@ -4232,6 +4232,7 @@ fn build_local_copy_options(
         .safe_links(config.safe_links())
         .devices(config.preserve_devices())
         .specials(config.preserve_specials())
+        .one_file_system(config.one_file_system())
         .relative_paths(config.relative_paths())
         .implied_dirs(config.implied_dirs())
         .mkpath(config.mkpath())


### PR DESCRIPTION
## Summary
- add CLI parsing, help text, fallback wiring, and tests for the --one-file-system/-x toggles
- teach the local copy engine to detect cross-filesystem directories, skip mount points when requested, and record the new event
- plumb the new toggle through the core fallback command builder and document the CLI capability
- ensure client-side local copy options propagate the one-file-system toggle into the engine

## Testing
- cargo test -p rsync-core --lib -- remote_fallback_forwards_one_file_system_toggle

------