### PR TITLE
Cache CLI supported protocol list formatting

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -86,7 +86,7 @@ use std::num::{IntErrorKind, NonZeroU8, NonZeroU64};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::str::FromStr;
-use std::sync::mpsc;
+use std::sync::{OnceLock, mpsc};
 use std::thread;
 use std::time::{Duration, SystemTime};
 
@@ -5149,12 +5149,17 @@ fn parse_protocol_version_arg(value: &OsStr) -> Result<ProtocolVersion, Message>
     }
 }
 
-fn supported_protocols_list() -> String {
-    let values: Vec<String> = ProtocolVersion::supported_protocol_numbers()
-        .iter()
-        .map(|value| value.to_string())
-        .collect();
-    values.join(", ")
+fn supported_protocols_list() -> &'static str {
+    static SUPPORTED_PROTOCOLS: OnceLock<String> = OnceLock::new();
+    SUPPORTED_PROTOCOLS
+        .get_or_init(|| {
+            ProtocolVersion::supported_protocol_numbers()
+                .iter()
+                .map(|value| value.to_string())
+                .collect::<Vec<_>>()
+                .join(", ")
+        })
+        .as_str()
 }
 
 fn parse_timeout_argument(value: &OsStr) -> Result<TransferTimeout, Message> {


### PR DESCRIPTION
## Summary
- avoid rebuilding the supported-protocol list for every CLI parse error by caching the formatted string
- expose the cached list through a `OnceLock` so repeated diagnostics re-use the same allocation

## Testing
- cargo fmt
- cargo test -p rsync-cli parse_protocol_version_arg

------