### PR TITLE
Add helpers for formatting bwlimit fallback arguments

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -3299,8 +3299,8 @@ where
     };
 
     let fallback_bwlimit = match (bandwidth_limit.as_ref(), bwlimit.as_ref()) {
-        (Some(limit), _) => Some(OsString::from(limit.bytes_per_second().get().to_string())),
-        (None, Some(_)) => Some(OsString::from("0")),
+        (Some(limit), _) => Some(limit.fallback_argument()),
+        (None, Some(_)) => Some(BandwidthLimit::fallback_unlimited_argument()),
         (None, None) => None,
     };
 


### PR DESCRIPTION
## Summary
- add helper methods on `BandwidthLimit` for generating fallback `--bwlimit` arguments
- reuse the shared helpers in the CLI fallback wiring
- extend the core tests to cover the new helpers

## Testing
- cargo test -p rsync-core bandwidth_limit_fallback_argument_returns_bytes_per_second
- cargo test -p rsync-core bandwidth_limit_fallback_unlimited_argument_returns_zero
- cargo test -p rsync-cli remote_fallback_sanitises_bwlimit_argument

------