### PR TITLE
Implement portable POSIX ACL bindings

### DIFF
--- a/crates/core/src/client.rs
+++ b/crates/core/src/client.rs
@@ -4688,9 +4688,13 @@ fn build_local_copy_options(
                 .map(|seconds| Duration::from_secs(seconds.get())),
         );
     #[cfg(feature = "acl")]
-    let options = options.acls(config.preserve_acls());
+    {
+        options = options.acls(config.preserve_acls());
+    }
     #[cfg(feature = "xattr")]
-    let options = options.xattrs(config.preserve_xattrs());
+    {
+        options = options.xattrs(config.preserve_xattrs());
+    }
 
     if !config.reference_directories().is_empty() {
         let references = config.reference_directories().iter().map(|reference| {

--- a/crates/engine/src/local_copy.rs
+++ b/crates/engine/src/local_copy.rs
@@ -8452,6 +8452,8 @@ fn copy_fifo(
     let file_type = metadata.file_type();
     #[cfg(feature = "xattr")]
     let preserve_xattrs = context.xattrs_enabled();
+    #[cfg(feature = "acl")]
+    let preserve_acls = context.acls_enabled();
     let record_path = relative
         .map(Path::to_path_buf)
         .or_else(|| destination.file_name().map(PathBuf::from));
@@ -8587,6 +8589,8 @@ fn copy_device(
     let file_type = metadata.file_type();
     #[cfg(feature = "xattr")]
     let preserve_xattrs = context.xattrs_enabled();
+    #[cfg(feature = "acl")]
+    let preserve_acls = context.acls_enabled();
     let record_path = relative
         .map(Path::to_path_buf)
         .or_else(|| destination.file_name().map(PathBuf::from));
@@ -8939,6 +8943,8 @@ fn copy_symlink(
     let file_type = metadata.file_type();
     #[cfg(feature = "xattr")]
     let preserve_xattrs = context.xattrs_enabled();
+    #[cfg(feature = "acl")]
+    let preserve_acls = context.acls_enabled();
     let record_path = relative
         .map(Path::to_path_buf)
         .or_else(|| destination.file_name().map(PathBuf::from));

--- a/crates/meta/src/acl_support.rs
+++ b/crates/meta/src/acl_support.rs
@@ -65,6 +65,34 @@ use std::path::Path;
 
 use crate::MetadataError;
 
+mod sys {
+    #![allow(unsafe_code)]
+    #![allow(non_camel_case_types)]
+
+    #[cfg(test)]
+    use libc::ssize_t;
+    use libc::{c_char, c_int, c_void, mode_t};
+
+    pub type acl_t = *mut c_void;
+    pub type acl_type_t = c_int;
+
+    pub const ACL_TYPE_ACCESS: acl_type_t = 0x8000;
+    pub const ACL_TYPE_DEFAULT: acl_type_t = 0x4000;
+
+    unsafe extern "C" {
+        pub fn acl_get_file(path_p: *const c_char, ty: acl_type_t) -> acl_t;
+        pub fn acl_set_file(path_p: *const c_char, ty: acl_type_t, acl: acl_t) -> c_int;
+        pub fn acl_dup(acl: acl_t) -> acl_t;
+        pub fn acl_free(obj_p: *mut c_void) -> c_int;
+        pub fn acl_from_mode(mode: mode_t) -> acl_t;
+        pub fn acl_delete_def_file(path_p: *const c_char) -> c_int;
+        #[cfg(test)]
+        pub fn acl_to_text(acl: acl_t, len_p: *mut ssize_t) -> *mut c_char;
+        #[cfg(test)]
+        pub fn acl_from_text(buf_p: *const c_char) -> acl_t;
+    }
+}
+
 /// Synchronises the POSIX ACLs from `source` to `destination`.
 ///
 /// The helper copies both the access ACL and, when present, the default ACL used by directories.
@@ -107,12 +135,12 @@ pub fn sync_acls(
         return Ok(());
     }
 
-    let access = match fetch_acl(source, libc::ACL_TYPE_ACCESS) {
+    let access = match fetch_acl(source, sys::ACL_TYPE_ACCESS) {
         Ok(value) => value,
         Err(error) => return Err(MetadataError::new("read ACL", source, error)),
     };
 
-    let default = match fetch_acl(source, libc::ACL_TYPE_DEFAULT) {
+    let default = match fetch_acl(source, sys::ACL_TYPE_DEFAULT) {
         Ok(value) => value,
         Err(error) => return Err(MetadataError::new("read default ACL", source, error)),
     };
@@ -128,20 +156,20 @@ pub fn sync_acls(
     Ok(())
 }
 
-struct PosixAcl(libc::acl_t);
+struct PosixAcl(sys::acl_t);
 
 impl PosixAcl {
-    fn as_ptr(&self) -> libc::acl_t {
+    fn as_ptr(&self) -> sys::acl_t {
         self.0
     }
 
-    fn from_raw(raw: libc::acl_t) -> Self {
+    fn from_raw(raw: sys::acl_t) -> Self {
         Self(raw)
     }
 
     fn clone(&self) -> io::Result<Self> {
         // Safety: `acl_dup` returns a new reference when provided with a valid ACL pointer.
-        let duplicated = unsafe { libc::acl_dup(self.0) };
+        let duplicated = unsafe { sys::acl_dup(self.0) };
         if duplicated.is_null() {
             Err(io::Error::last_os_error())
         } else {
@@ -155,16 +183,16 @@ impl Drop for PosixAcl {
         if !self.0.is_null() {
             // Safety: the ACL pointer originates from libacl allocation APIs.
             unsafe {
-                libc::acl_free(self.0 as *mut _);
+                sys::acl_free(self.0);
             }
         }
     }
 }
 
-fn fetch_acl(path: &Path, ty: libc::acl_type_t) -> io::Result<Option<PosixAcl>> {
+fn fetch_acl(path: &Path, ty: sys::acl_type_t) -> io::Result<Option<PosixAcl>> {
     let c_path = CString::new(path.as_os_str().as_bytes())?;
     // Safety: the pointer remains valid for the duration of the call.
-    let acl = unsafe { libc::acl_get_file(c_path.as_ptr(), ty) };
+    let acl = unsafe { sys::acl_get_file(c_path.as_ptr(), ty) };
     if acl.is_null() {
         let error = io::Error::last_os_error();
         match error.raw_os_error() {
@@ -180,15 +208,15 @@ fn fetch_acl(path: &Path, ty: libc::acl_type_t) -> io::Result<Option<PosixAcl>> 
 
 fn apply_access_acl(path: &Path, acl: Option<&PosixAcl>) -> io::Result<()> {
     match acl {
-        Some(value) => set_acl(path, libc::ACL_TYPE_ACCESS, value.clone()?),
+        Some(value) => set_acl(path, sys::ACL_TYPE_ACCESS, value.clone()?),
         None => reset_access_acl(path),
     }
 }
 
-fn set_acl(path: &Path, ty: libc::acl_type_t, acl: PosixAcl) -> io::Result<()> {
+fn set_acl(path: &Path, ty: sys::acl_type_t, acl: PosixAcl) -> io::Result<()> {
     let c_path = CString::new(path.as_os_str().as_bytes())?;
     // Safety: arguments are valid pointers and libacl owns the ACL data.
-    let result = unsafe { libc::acl_set_file(c_path.as_ptr(), ty, acl.as_ptr()) };
+    let result = unsafe { sys::acl_set_file(c_path.as_ptr(), ty, acl.as_ptr()) };
     if result == 0 {
         Ok(())
     } else {
@@ -200,18 +228,18 @@ fn reset_access_acl(path: &Path) -> io::Result<()> {
     let metadata = fs::symlink_metadata(path)?;
     let mode = metadata.mode() & 0o777;
     // Safety: acl_from_mode allocates a new ACL from the provided bitmask.
-    let acl = unsafe { libc::acl_from_mode(mode as libc::mode_t) };
+    let acl = unsafe { sys::acl_from_mode(mode as libc::mode_t) };
     if acl.is_null() {
         return Err(io::Error::last_os_error());
     }
 
     let acl = PosixAcl::from_raw(acl);
-    set_acl(path, libc::ACL_TYPE_ACCESS, acl)
+    set_acl(path, sys::ACL_TYPE_ACCESS, acl)
 }
 
 fn apply_default_acl(path: &Path, acl: Option<&PosixAcl>) -> io::Result<()> {
     match acl {
-        Some(value) => set_acl(path, libc::ACL_TYPE_DEFAULT, value.clone()?),
+        Some(value) => set_acl(path, sys::ACL_TYPE_DEFAULT, value.clone()?),
         None => clear_default_acl(path),
     }
 }
@@ -219,7 +247,7 @@ fn apply_default_acl(path: &Path, acl: Option<&PosixAcl>) -> io::Result<()> {
 fn clear_default_acl(path: &Path) -> io::Result<()> {
     let c_path = CString::new(path.as_os_str().as_bytes())?;
     // Safety: the call removes the default ACL when present.
-    let result = unsafe { libc::acl_delete_def_file(c_path.as_ptr()) };
+    let result = unsafe { sys::acl_delete_def_file(c_path.as_ptr()) };
     if result == 0 {
         Ok(())
     } else {
@@ -233,39 +261,40 @@ fn clear_default_acl(path: &Path) -> io::Result<()> {
 
 #[cfg(test)]
 mod tests {
+    use super::sys;
     use super::*;
     use std::os::unix::ffi::OsStrExt;
     use tempfile::tempdir;
 
-    fn acl_to_text(path: &Path, ty: libc::acl_type_t) -> Option<String> {
+    fn acl_to_text(path: &Path, ty: sys::acl_type_t) -> Option<String> {
         let c_path = CString::new(path.as_os_str().as_bytes()).expect("cstring");
-        let acl = unsafe { libc::acl_get_file(c_path.as_ptr(), ty) };
+        let acl = unsafe { sys::acl_get_file(c_path.as_ptr(), ty) };
         if acl.is_null() {
             return None;
         }
         let mut len = 0;
-        let text_ptr = unsafe { libc::acl_to_text(acl, &mut len) };
+        let text_ptr = unsafe { sys::acl_to_text(acl, &mut len) };
         if text_ptr.is_null() {
-            unsafe { libc::acl_free(acl as *mut _) };
+            unsafe { sys::acl_free(acl) };
             return None;
         }
         let slice = unsafe { std::slice::from_raw_parts(text_ptr.cast::<u8>(), len as usize) };
         let text = String::from_utf8_lossy(slice).trim().to_string();
         unsafe {
-            libc::acl_free(text_ptr as *mut _);
-            libc::acl_free(acl as *mut _);
+            sys::acl_free(text_ptr.cast());
+            sys::acl_free(acl);
         }
         Some(text)
     }
 
-    fn set_acl_from_text(path: &Path, text: &str, ty: libc::acl_type_t) {
+    fn set_acl_from_text(path: &Path, text: &str, ty: sys::acl_type_t) {
         let c_path = CString::new(path.as_os_str().as_bytes()).expect("cstring");
         let c_text = CString::new(text).expect("text");
-        let acl = unsafe { libc::acl_from_text(c_text.as_ptr()) };
+        let acl = unsafe { sys::acl_from_text(c_text.as_ptr()) };
         assert!(!acl.is_null(), "acl_from_text");
-        let result = unsafe { libc::acl_set_file(c_path.as_ptr(), ty, acl) };
+        let result = unsafe { sys::acl_set_file(c_path.as_ptr(), ty, acl) };
         unsafe {
-            libc::acl_free(acl as *mut _);
+            sys::acl_free(acl);
         }
         assert_eq!(result, 0, "acl_set_file failed");
     }
@@ -281,20 +310,20 @@ mod tests {
         set_acl_from_text(
             &source,
             "user::rwx\ngroup::r-x\nother::r-x\n",
-            libc::ACL_TYPE_ACCESS,
+            sys::ACL_TYPE_ACCESS,
         );
         set_acl_from_text(
             &source,
             "user::rwx\ngroup::r-x\nother::r-x\n",
-            libc::ACL_TYPE_DEFAULT,
+            sys::ACL_TYPE_DEFAULT,
         );
 
         sync_acls(&source, &destination, true).expect("sync acls");
 
-        let access = acl_to_text(&destination, libc::ACL_TYPE_ACCESS).expect("access acl");
+        let access = acl_to_text(&destination, sys::ACL_TYPE_ACCESS).expect("access acl");
         assert!(access.contains("user::rwx"));
 
-        let default = acl_to_text(&destination, libc::ACL_TYPE_DEFAULT).expect("default acl");
+        let default = acl_to_text(&destination, sys::ACL_TYPE_DEFAULT).expect("default acl");
         assert!(default.contains("default:user::rwx") || default.contains("user::rwx"));
     }
 
@@ -309,12 +338,12 @@ mod tests {
         set_acl_from_text(
             &destination,
             "user::rwx\ngroup::r-x\nother::r-x\n",
-            libc::ACL_TYPE_DEFAULT,
+            sys::ACL_TYPE_DEFAULT,
         );
-        assert!(acl_to_text(&destination, libc::ACL_TYPE_DEFAULT).is_some());
+        assert!(acl_to_text(&destination, sys::ACL_TYPE_DEFAULT).is_some());
 
         sync_acls(&source, &destination, true).expect("sync acls");
 
-        assert!(acl_to_text(&destination, libc::ACL_TYPE_DEFAULT).is_none());
+        assert!(acl_to_text(&destination, sys::ACL_TYPE_DEFAULT).is_none());
     }
 }


### PR DESCRIPTION
## Summary
- replace the missing libc ACL constants by adding a dedicated libacl FFI shim and guard test-only helpers
- propagate the ACL preservation flag when copying FIFOs, devices, and symlinks in the local engine
- fix client option building so ACL/xattr toggles mutate the existing options builder safely

## Testing
- cargo build --all-features --release --bins

------