### PR TITLE
Derive supported protocol display string from canonical constants

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -77,7 +77,7 @@
 use std::collections::{HashSet, VecDeque};
 use std::env;
 use std::ffi::{OsStr, OsString};
-use std::fmt::{self, Write as _};
+use std::fmt;
 use std::fs::{self, File};
 use std::io::ErrorKind;
 use std::io::{self, BufRead, BufReader, Read, Write};
@@ -86,7 +86,7 @@ use std::num::{IntErrorKind, NonZeroU8, NonZeroU64};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::str::FromStr;
-use std::sync::{OnceLock, mpsc};
+use std::sync::mpsc;
 use std::thread;
 use std::time::{Duration, SystemTime};
 
@@ -5182,24 +5182,7 @@ fn parse_protocol_version_arg(value: &OsStr) -> Result<ProtocolVersion, Message>
 }
 
 fn supported_protocols_list() -> &'static str {
-    static SUPPORTED_PROTOCOLS: OnceLock<String> = OnceLock::new();
-    SUPPORTED_PROTOCOLS
-        .get_or_init(|| {
-            let mut iter = ProtocolVersion::supported_protocol_numbers_iter();
-            let mut formatted = String::with_capacity(iter.len().saturating_mul(4));
-
-            if let Some(first) = iter.next() {
-                let _ = write!(&mut formatted, "{}", first);
-
-                for value in iter {
-                    formatted.push_str(", ");
-                    let _ = write!(&mut formatted, "{}", value);
-                }
-            }
-
-            formatted
-        })
-        .as_str()
+    ProtocolVersion::supported_protocol_numbers_display()
 }
 
 fn parse_timeout_argument(value: &OsStr) -> Result<TransferTimeout, Message> {

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -164,5 +164,6 @@ pub use version::{
     ParseProtocolVersionError, ParseProtocolVersionErrorKind, ProtocolVersion,
     ProtocolVersionAdvertisement, SUPPORTED_PROTOCOL_BITMAP, SUPPORTED_PROTOCOL_BOUNDS,
     SUPPORTED_PROTOCOL_COUNT, SUPPORTED_PROTOCOL_RANGE, SUPPORTED_PROTOCOLS,
-    SupportedProtocolNumbersIter, SupportedVersionsIter, select_highest_mutual,
+    SUPPORTED_PROTOCOLS_DISPLAY, SupportedProtocolNumbersIter, SupportedVersionsIter,
+    select_highest_mutual,
 };

--- a/crates/protocol/src/version/tests.rs
+++ b/crates/protocol/src/version/tests.rs
@@ -410,6 +410,16 @@ fn supported_protocol_helpers_remain_consistent() {
     let range = ProtocolVersion::supported_range();
     assert_eq!(*range.start(), ProtocolVersion::OLDEST.as_u8());
     assert_eq!(*range.end(), ProtocolVersion::NEWEST.as_u8());
+
+    let expected_display = SUPPORTED_PROTOCOLS
+        .iter()
+        .map(|value| value.to_string())
+        .collect::<Vec<_>>()
+        .join(", ");
+    assert_eq!(
+        ProtocolVersion::supported_protocol_numbers_display(),
+        expected_display
+    );
 }
 
 #[test]

--- a/crates/protocol/tests/public_api.rs
+++ b/crates/protocol/tests/public_api.rs
@@ -97,6 +97,10 @@ fn supported_protocol_exports_cover_range() {
         ProtocolVersion::supported_versions_array(),
         &ProtocolVersion::SUPPORTED_VERSIONS,
     );
+    assert_eq!(
+        rsync_protocol::SUPPORTED_PROTOCOLS_DISPLAY,
+        ProtocolVersion::supported_protocol_numbers_display(),
+    );
     assert!(
         ProtocolVersion::supported_protocol_numbers_iter().eq(rsync_protocol::SUPPORTED_PROTOCOLS)
     );


### PR DESCRIPTION
## Summary
- expose a compile-time `SUPPORTED_PROTOCOLS_DISPLAY` string alongside the existing protocol constants
- add `ProtocolVersion::supported_protocol_numbers_display()` so callers reuse the canonical formatting without allocation
- simplify the CLI helper to use the shared string and extend tests to cover the exported constant

## Testing
- cargo test -p rsync-protocol
- cargo test -p rsync-cli protocol_option_requires_daemon_operands

------