### PR TITLE
Fix daemon module bwlimit precedence handling

### DIFF
--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -3741,12 +3741,17 @@ fn apply_module_bandwidth_limit(
     module_burst_specified: bool,
     module_limit_configured: bool,
 ) {
+    let limit_specified =
+        module_limit_specified || (module_limit_configured && module_limit.is_some());
+    let burst_specified =
+        module_burst_specified && (module_limit_configured || module_limit_specified);
+
     apply_effective_limit(
         limiter,
         module_limit,
-        module_limit_specified,
+        limit_specified,
         module_burst,
-        module_burst_specified,
+        burst_specified,
     );
 }
 
@@ -4448,6 +4453,7 @@ fn apply_inline_module_options(
                 module.bandwidth_limit = components.rate();
                 module.bandwidth_burst = components.burst();
                 module.bandwidth_burst_specified = components.burst_specified();
+                module.bandwidth_limit_specified = true;
                 module.bandwidth_limit_configured = true;
             }
             "refuse options" | "refuse-options" => {
@@ -7802,6 +7808,7 @@ mod tests {
             true,
             None,
             false,
+            true,
         );
 
         let limiter = limiter.expect("limiter remains configured");
@@ -7824,6 +7831,7 @@ mod tests {
             true,
             None,
             false,
+            true,
         );
 
         let limiter = limiter.expect("limiter remains configured");
@@ -7867,6 +7875,7 @@ mod tests {
             true,
             None,
             false,
+            true,
         );
 
         let limiter = limiter.expect("limiter configured by module");
@@ -7901,7 +7910,7 @@ mod tests {
         let limit = NonZeroU64::new(3 * 1024 * 1024).unwrap();
         let mut limiter = Some(BandwidthLimiter::new(limit));
 
-        apply_module_bandwidth_limit(&mut limiter, None, None, false, false);
+        apply_module_bandwidth_limit(&mut limiter, None, false, None, false, false);
 
         let limiter = limiter.expect("limiter remains in effect");
         assert_eq!(limiter.limit_bytes(), limit);
@@ -7947,6 +7956,7 @@ mod tests {
             true,
             None,
             true,
+            true,
         );
 
         let limiter = limiter.expect("limiter remains configured");
@@ -7963,7 +7973,7 @@ mod tests {
             NonZeroU64::new(2 * 1024 * 1024).unwrap(),
         ));
 
-        apply_module_bandwidth_limit(&mut limiter, None, true, None, false);
+        apply_module_bandwidth_limit(&mut limiter, None, true, None, false, true);
 
         assert!(limiter.is_none());
     }
@@ -7972,7 +7982,7 @@ mod tests {
     fn module_bwlimit_unlimited_is_noop_when_no_cap() {
         let mut limiter: Option<BandwidthLimiter> = None;
 
-        apply_module_bandwidth_limit(&mut limiter, None, true, None, false);
+        apply_module_bandwidth_limit(&mut limiter, None, true, None, false, true);
 
         assert!(limiter.is_none());
     }
@@ -7983,7 +7993,7 @@ mod tests {
             NonZeroU64::new(2 * 1024 * 1024).unwrap(),
         ));
 
-        apply_module_bandwidth_limit(&mut limiter, None, false, None, false);
+        apply_module_bandwidth_limit(&mut limiter, None, false, None, false, false);
 
         let limiter = limiter.expect("daemon cap should remain active");
         assert_eq!(


### PR DESCRIPTION
## Summary
- ensure apply_module_bandwidth_limit respects module-level bwlimit configuration when computing effective caps
- treat inline module bwlimit directives as explicit specifications to restore unlimited handling
- update daemon module bwlimit tests for the expanded precedence logic

## Testing
- cargo test

------