### PR TITLE
Fix module bandwidth limiter precedence

### DIFF
--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -358,6 +358,10 @@ impl ModuleDefinition {
         self.bandwidth_burst_specified
     }
 
+    fn bandwidth_limit_configured(&self) -> bool {
+        self.bandwidth_limit_configured
+    }
+
     #[cfg(test)]
     fn name(&self) -> &str {
         &self.name
@@ -3742,6 +3746,7 @@ fn apply_module_bandwidth_limit(
     module_limit_specified: bool,
     module_burst: Option<NonZeroU64>,
     module_burst_specified: bool,
+    module_limit_configured: bool,
 ) {
     let limit_specified =
         module_limit_specified || (module_limit_configured && module_limit.is_some());
@@ -3776,6 +3781,7 @@ fn respond_with_module_request(
             module.bandwidth_limit_specified(),
             module.bandwidth_burst(),
             module.bandwidth_burst_specified(),
+            module.bandwidth_limit_configured(),
         );
 
         let mut hostname_cache: Option<Option<String>> = None;
@@ -7852,6 +7858,7 @@ mod tests {
             true,
             Some(NonZeroU64::new(256 * 1024).unwrap()),
             true,
+            true,
         );
 
         let limiter = limiter.expect("limiter remains configured");
@@ -7892,6 +7899,7 @@ mod tests {
             false,
             Some(NonZeroU64::new(256 * 1024).unwrap()),
             true,
+            true,
         );
         let limiter = limiter.expect("limiter preserved");
         assert_eq!(
@@ -7909,7 +7917,7 @@ mod tests {
         let limit = NonZeroU64::new(3 * 1024 * 1024).unwrap();
         let mut limiter = Some(BandwidthLimiter::new(limit));
 
-        apply_module_bandwidth_limit(&mut limiter, None, false, None, false);
+        apply_module_bandwidth_limit(&mut limiter, None, false, None, false, false);
 
         let limiter = limiter.expect("limiter remains in effect");
         assert_eq!(limiter.limit_bytes(), limit);
@@ -7927,6 +7935,7 @@ mod tests {
             NonZeroU64::new(4 * 1024 * 1024),
             true,
             Some(NonZeroU64::new(512 * 1024).unwrap()),
+            true,
             true,
         );
 


### PR DESCRIPTION
## Summary
- add a ModuleDefinition accessor that exposes whether a module configured bwlimit
- pass the configuration flag through to `apply_module_bandwidth_limit` and use it
- extend module bandwidth limiter tests to cover the configuration flag

## Testing
- cargo test -p rsync-daemon --lib

------