### PR TITLE
Add docs.rs metadata to library crates

### DIFF
--- a/crates/bandwidth/Cargo.toml
+++ b/crates/bandwidth/Cargo.toml
@@ -9,6 +9,12 @@ description = "Bandwidth parsing and pacing utilities for the Rust rsync impleme
 repository = "https://github.com/oferchen/rsync"
 publish = false
 
+[package.metadata.docs.rs]
+all-features = true
+no-default-features = false
+rustdoc-args = ["--cfg", "docsrs", "-D", "rustdoc::broken_intra_doc_links"]
+targets = ["x86_64-unknown-linux-gnu"]
+
 [features]
 default = []
 test-support = []

--- a/crates/checksums/Cargo.toml
+++ b/crates/checksums/Cargo.toml
@@ -4,6 +4,12 @@ version = "0.0.0"
 edition = "2024"
 license = "GPL-3.0-or-later"
 
+[package.metadata.docs.rs]
+all-features = true
+no-default-features = false
+rustdoc-args = ["--cfg", "docsrs", "-D", "rustdoc::broken_intra_doc_links"]
+targets = ["x86_64-unknown-linux-gnu"]
+
 [dependencies]
 md4 = { version = "0.10", default-features = false, features = ["std"] }
 md-5 = { version = "0.10", default-features = false, features = ["std"] }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -6,6 +6,12 @@ rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 
+[package.metadata.docs.rs]
+all-features = true
+no-default-features = false
+rustdoc-args = ["--cfg", "docsrs", "-D", "rustdoc::broken_intra_doc_links"]
+targets = ["x86_64-unknown-linux-gnu"]
+
 [features]
 default = []
 xattr = ["rsync-core/xattr"]

--- a/crates/compress/Cargo.toml
+++ b/crates/compress/Cargo.toml
@@ -8,5 +8,11 @@ license.workspace = true
 description = "Compression primitives for the Rust rsync implementation"
 repository = "https://github.com/oferchen/rsync"
 
+[package.metadata.docs.rs]
+all-features = true
+no-default-features = false
+rustdoc-args = ["--cfg", "docsrs", "-D", "rustdoc::broken_intra_doc_links"]
+targets = ["x86_64-unknown-linux-gnu"]
+
 [dependencies]
 flate2 = { version = "1.0", default-features = false, features = ["zlib"] }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -8,6 +8,12 @@ description = "Core utilities shared by the Rust rsync implementation"
 repository = "https://github.com/oferchen/rsync"
 build = "build.rs"
 
+[package.metadata.docs.rs]
+all-features = true
+no-default-features = false
+rustdoc-args = ["--cfg", "docsrs", "-D", "rustdoc::broken_intra_doc_links"]
+targets = ["x86_64-unknown-linux-gnu"]
+
 [dependencies]
 rsync-protocol = { path = "../protocol" }
 rsync-meta = { path = "../meta", default-features = false }

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -7,6 +7,12 @@ authors.workspace = true
 license.workspace = true
 publish = false
 
+[package.metadata.docs.rs]
+all-features = true
+no-default-features = false
+rustdoc-args = ["--cfg", "docsrs", "-D", "rustdoc::broken_intra_doc_links"]
+targets = ["x86_64-unknown-linux-gnu"]
+
 [features]
 default = []
 sd-notify = ["dep:sd-notify", "rsync-core/sd-notify"]

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -8,6 +8,12 @@ license.workspace = true
 description = "Transfer engine components for the Rust rsync implementation"
 repository = "https://github.com/oferchen/rsync"
 
+[package.metadata.docs.rs]
+all-features = true
+no-default-features = false
+rustdoc-args = ["--cfg", "docsrs", "-D", "rustdoc::broken_intra_doc_links"]
+targets = ["x86_64-unknown-linux-gnu"]
+
 [dependencies]
 rsync-meta = { path = "../meta", default-features = false }
 rsync-filters = { path = "../filters" }

--- a/crates/filters/Cargo.toml
+++ b/crates/filters/Cargo.toml
@@ -6,5 +6,11 @@ authors = ["Ofer Chen <skewers.irises.3b@icloud.com>"]
 license = "GPL-3.0-or-later"
 description = "Pattern filtering helpers for the Rust rsync workspace"
 
+[package.metadata.docs.rs]
+all-features = true
+no-default-features = false
+rustdoc-args = ["--cfg", "docsrs", "-D", "rustdoc::broken_intra_doc_links"]
+targets = ["x86_64-unknown-linux-gnu"]
+
 [dependencies]
 globset = "0.4"

--- a/crates/logging/Cargo.toml
+++ b/crates/logging/Cargo.toml
@@ -8,5 +8,11 @@ authors.workspace = true
 description = "Logging utilities for the Rust rsync implementation"
 repository = "https://github.com/oferchen/rsync"
 
+[package.metadata.docs.rs]
+all-features = true
+no-default-features = false
+rustdoc-args = ["--cfg", "docsrs", "-D", "rustdoc::broken_intra_doc_links"]
+targets = ["x86_64-unknown-linux-gnu"]
+
 [dependencies]
 rsync-core = { path = "../core" }

--- a/crates/meta/Cargo.toml
+++ b/crates/meta/Cargo.toml
@@ -8,6 +8,12 @@ description = "Metadata preservation helpers for the Rust rsync implementation"
 repository = "https://github.com/oferchen/rsync"
 build = "build.rs"
 
+[package.metadata.docs.rs]
+all-features = true
+no-default-features = false
+rustdoc-args = ["--cfg", "docsrs", "-D", "rustdoc::broken_intra_doc_links"]
+targets = ["x86_64-unknown-linux-gnu"]
+
 [dependencies]
 filetime = "0.2"
 rustix = { version = "0.38", features = ["fs", "process"] }

--- a/crates/protocol/Cargo.toml
+++ b/crates/protocol/Cargo.toml
@@ -7,6 +7,12 @@ license.workspace = true
 authors.workspace = true
 description = "Protocol negotiation utilities for the Rust rsync implementation"
 
+[package.metadata.docs.rs]
+all-features = true
+no-default-features = false
+rustdoc-args = ["--cfg", "docsrs", "-D", "rustdoc::broken_intra_doc_links"]
+targets = ["x86_64-unknown-linux-gnu"]
+
 [dependencies]
 
 [dev-dependencies]

--- a/crates/transport/Cargo.toml
+++ b/crates/transport/Cargo.toml
@@ -7,6 +7,12 @@ license.workspace = true
 authors.workspace = true
 description = "Transport helpers for the Rust rsync implementation"
 
+[package.metadata.docs.rs]
+all-features = true
+no-default-features = false
+rustdoc-args = ["--cfg", "docsrs", "-D", "rustdoc::broken_intra_doc_links"]
+targets = ["x86_64-unknown-linux-gnu"]
+
 [dependencies]
 rsync-protocol = { path = "../protocol" }
 

--- a/crates/walk/Cargo.toml
+++ b/crates/walk/Cargo.toml
@@ -7,6 +7,12 @@ license = "GPL-3.0-or-later"
 description = "Deterministic filesystem walker for the Rust rsync implementation"
 repository = "https://github.com/oferchen/rsync"
 
+[package.metadata.docs.rs]
+all-features = true
+no-default-features = false
+rustdoc-args = ["--cfg", "docsrs", "-D", "rustdoc::broken_intra_doc_links"]
+targets = ["x86_64-unknown-linux-gnu"]
+
 [dependencies]
 
 [dev-dependencies]


### PR DESCRIPTION
## Summary
- add the standard docs.rs configuration to each library crate so published documentation uses the same strict rustdoc settings as CI

## Testing
- cargo metadata --format-version 1

------