### PR TITLE
Preserve burst specification when forwarding --bwlimit

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -14692,7 +14692,7 @@ exit 0
         while let Some(line) = lines.next() {
             if line == "--bwlimit" {
                 let value = lines.next().expect("bwlimit value recorded");
-                assert_eq!(value, "1048576");
+                assert_eq!(value, "1048576:65536");
                 return;
             }
         }


### PR DESCRIPTION
## Summary
- track whether a bandwidth limit includes an explicit burst and surface the information through `BandwidthLimit`
- ensure fallback argument formatting propagates burst values, including `:0`, and cover the behaviour with unit tests
- update the CLI fallback test to expect the burst-aware `--bwlimit` argument forwarded to the legacy helper

## Testing
- cargo test

------