### PR TITLE
Allow whitespace around bwlimit suffixes

### DIFF
--- a/crates/bandwidth/src/parse.rs
+++ b/crates/bandwidth/src/parse.rs
@@ -206,7 +206,8 @@ pub fn parse_bandwidth_argument(text: &str) -> Result<Option<NonZeroU64>, Bandwi
     }
 
     let numeric_part = &unsigned[..numeric_end];
-    let remainder = &unsigned[numeric_end..];
+    let mut remainder = &unsigned[numeric_end..];
+    remainder = remainder.trim_start_matches(|ch: char| ch.is_ascii_whitespace());
 
     if !digits_seen || numeric_part == "." || numeric_part == "," {
         return Err(BandwidthParseError::Invalid);
@@ -222,6 +223,9 @@ pub fn parse_bandwidth_argument(text: &str) -> Result<Option<NonZeroU64>, Bandwi
             let ch = chars.next().unwrap();
             (ch, chars.as_str())
         };
+
+    remainder_after_suffix =
+        remainder_after_suffix.trim_start_matches(|ch: char| ch.is_ascii_whitespace());
 
     let repetitions = match suffix.to_ascii_lowercase() {
         'b' => 0,
@@ -258,6 +262,9 @@ pub fn parse_bandwidth_argument(text: &str) -> Result<Option<NonZeroU64>, Bandwi
         }
     }
 
+    remainder_after_suffix =
+        remainder_after_suffix.trim_start_matches(|ch: char| ch.is_ascii_whitespace());
+
     let mut adjust = 0i8;
     if !remainder_after_suffix.is_empty() {
         if remainder_after_suffix == "+1" && numeric_end > 0 {
@@ -268,6 +275,9 @@ pub fn parse_bandwidth_argument(text: &str) -> Result<Option<NonZeroU64>, Bandwi
             remainder_after_suffix = "";
         }
     }
+
+    remainder_after_suffix =
+        remainder_after_suffix.trim_start_matches(|ch: char| ch.is_ascii_whitespace());
 
     if !remainder_after_suffix.is_empty() {
         return Err(BandwidthParseError::Invalid);

--- a/crates/bandwidth/src/parse/tests.rs
+++ b/crates/bandwidth/src/parse/tests.rs
@@ -18,6 +18,12 @@ fn parse_bandwidth_accepts_decimal_units() {
 }
 
 #[test]
+fn parse_bandwidth_accepts_space_between_value_and_suffix() {
+    let limit = parse_bandwidth_argument("1 M").expect("parse succeeds");
+    assert_eq!(limit, NonZeroU64::new(1_048_576));
+}
+
+#[test]
 fn parse_bandwidth_accepts_iec_suffixes() {
     let limit = parse_bandwidth_argument("1MiB").expect("parse succeeds");
     assert_eq!(limit, NonZeroU64::new(1_048_576));
@@ -165,6 +171,12 @@ fn parse_bandwidth_limit_records_explicit_burst_presence() {
 #[test]
 fn parse_bandwidth_accepts_positive_adjustment() {
     let limit = parse_bandwidth_argument("1K+1").expect("parse succeeds");
+    assert_eq!(limit, NonZeroU64::new(1024));
+}
+
+#[test]
+fn parse_bandwidth_accepts_whitespace_before_adjustment() {
+    let limit = parse_bandwidth_argument("1K +1").expect("parse succeeds");
     assert_eq!(limit, NonZeroU64::new(1024));
 }
 


### PR DESCRIPTION
## Summary
- allow the bandwidth parser to skip ASCII whitespace between the numeric portion, suffix, and adjustment when decoding --bwlimit arguments
- add regression tests covering whitespace around suffixes and adjustments

## Testing
- cargo test -p rsync-bandwidth

------