### PR TITLE
Ensure apply_effective_limit test maintains configured rate

### DIFF
--- a/crates/bandwidth/src/limiter.rs
+++ b/crates/bandwidth/src/limiter.rs
@@ -597,14 +597,14 @@ mod tests {
 
     #[test]
     fn apply_effective_limit_updates_burst_when_specified() {
-        let mut limiter = Some(BandwidthLimiter::new(
-            NonZeroU64::new(4 * 1024 * 1024).unwrap(),
-        ));
+        let limit = NonZeroU64::new(4 * 1024 * 1024).unwrap();
+        let mut limiter = Some(BandwidthLimiter::new(limit));
         let burst = NonZeroU64::new(2048).unwrap();
 
-        apply_effective_limit(&mut limiter, Some(burst), true, Some(burst), true);
+        apply_effective_limit(&mut limiter, Some(limit), true, Some(burst), true);
 
         let limiter = limiter.expect("limiter should remain active");
+        assert_eq!(limiter.limit_bytes(), limit);
         assert_eq!(limiter.burst_bytes(), Some(burst));
     }
 


### PR DESCRIPTION
## Summary
- update the apply_effective_limit burst override test to reuse the configured rate when asserting burst changes
- add an assertion that the limiter's rate remains unchanged when only the burst is updated

## Testing
- cargo test -p rsync-bandwidth

------