### PR TITLE
docs: move bandwidth crate overview into README

### DIFF
--- a/crates/bandwidth/Cargo.toml
+++ b/crates/bandwidth/Cargo.toml
@@ -7,6 +7,7 @@ authors.workspace = true
 license.workspace = true
 description = "Bandwidth parsing and pacing utilities for the Rust rsync implementation"
 repository = "https://github.com/oferchen/rsync"
+readme = "README.md"
 publish = false
 
 [package.metadata.docs.rs]

--- a/crates/bandwidth/README.md
+++ b/crates/bandwidth/README.md
@@ -1,0 +1,80 @@
+# rsync-bandwidth
+
+`rsync-bandwidth` centralises the parsing and pacing logic that backs
+[`rsync`'s `--bwlimit` option](https://download.samba.org/pub/rsync/rsync.html).
+Higher level crates reuse the utilities exposed here so both the client and
+daemon share identical validation and throttling behaviour.
+
+## Features
+
+- Textual limit parsing with upstream-compatible syntax including
+  binary/decimal suffixes, fractional values, leading signs, and optional
+  `+1` / `-1` adjustments.
+- Token-bucket pacing that mirrors upstream rsync's shape, including
+  burst-handling and minimum sleep intervals.
+- Deterministic testing support that records requested sleep durations in lieu
+  of touching the system clock, keeping unit tests fast and reproducible.
+
+## Design Overview
+
+### Parsing helpers
+
+[`parse::parse_bandwidth_argument`](crate::parse::parse_bandwidth_argument)
+accepts textual bandwidth specifications and returns either an optional byte
+limit or a [`BandwidthParseError`](crate::parse::BandwidthParseError). The
+helper trims ASCII whitespace, validates suffixes, applies the `+1` / `-1`
+adjustments accepted by upstream rsync, and rounds to the nearest 1024 bytes per
+second as the C implementation does.
+
+[`parse::parse_bandwidth_limit`](crate::parse::parse_bandwidth_limit) extends the
+behaviour to parse daemon-style `RATE[:BURST]` combinations. The returned
+[`BandwidthLimitComponents`](crate::parse::BandwidthLimitComponents) struct can
+be converted into a [`BandwidthLimiter`](crate::BandwidthLimiter) or stored for
+later negotiation.
+
+### Pacing helpers
+
+[`BandwidthLimiter`](crate::BandwidthLimiter) implements the token-bucket
+scheduler used by the transfer engine and daemon. It tracks accumulated debt,
+limits write sizes, and sleeps long enough to honour the configured rate. When
+the optional burst parameter is supplied the limiter caps the debt to the burst
+size, mirroring upstream behaviour.
+
+`apply_effective_limit` merges daemon-imposed caps with pre-existing limiter
+configuration. The helper ensures precedence rules match upstream rsync by
+keeping the strictest rate while allowing burst overrides when explicitly
+requested.
+
+### Test support
+
+Enabling the `test-support` feature exposes helpers that record sleep requests
+instead of calling [`std::thread::sleep`]. Tests obtain a
+[`recorded_sleep_session`](crate::recorded_sleep_session) guard to serialise
+access to the captured durations, ensuring race-free assertions when scenarios
+run in parallel.
+
+## Example
+
+```rust
+use rsync_bandwidth::{parse_bandwidth_argument, BandwidthLimiter};
+use std::num::NonZeroU64;
+
+let limit = parse_bandwidth_argument("8M").expect("valid limit")
+    .expect("non-zero limit");
+let mut limiter = BandwidthLimiter::new(limit);
+let chunk = limiter.recommended_read_size(1 << 20);
+assert!(chunk <= 1 << 20);
+limiter.register(chunk);
+```
+
+The example mirrors how higher layers throttle outgoing writes. The limiter
+keeps the observed throughput at or below 8 MiB/s while coalescing smaller
+chunks to reduce context switches.
+
+## See also
+
+- [`rsync-core`](https://docs.rs/rsync-core/) and
+  [`rsync-daemon`](https://docs.rs/rsync-daemon/) for integration points that
+  orchestrate parsing, transport, and pacing.
+- [`rsync-protocol`](https://docs.rs/rsync-protocol/) for message framing and
+  version negotiation.

--- a/crates/bandwidth/src/lib.rs
+++ b/crates/bandwidth/src/lib.rs
@@ -1,58 +1,8 @@
+#![doc = include_str!("../README.md")]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![deny(unsafe_code)]
-#![deny(rustdoc::broken_intra_doc_links)]
 #![deny(missing_docs)]
-
-//! # Overview
-//!
-//! `rsync_bandwidth` centralises parsing and pacing logic for rsync's
-//! `--bwlimit` option. The crate exposes helpers for decoding user supplied
-//! bandwidth limits together with a [`BandwidthLimiter`] state machine that
-//! mirrors upstream rsync's token bucket. Higher level crates reuse these
-//! utilities to share validation and throttling behaviour between the client,
-//! daemon, and future transport layers.
-//!
-//! # Design
-//!
-//! - [`parse::parse_bandwidth_argument`] accepts textual rate specifications using the
-//!   same syntax as upstream rsync (binary/decimal suffixes, fractional values,
-//!   and optional `+1`/`-1` adjustments) and returns either an optional limit in
-//!   bytes per second or a [`BandwidthParseError`].
-//! - [`BandwidthLimiter`] implements the pacing algorithm used by the local copy
-//!   engine and daemon. It keeps track of the accumulated byte debt and sleeps
-//!   long enough to honour the configured limit while coalescing short bursts to
-//!   avoid excessive context switches.
-//!
-//! # Invariants
-//!
-//! - Parsed rates are always rounded to the nearest multiple of 1024 bytes per
-//!   second, matching upstream rsync.
-//! - The limiter never sleeps for intervals shorter than 100ms to align with the
-//!   behaviour of the C implementation.
-//! - When the optional `test-support` feature is enabled (used by unit tests),
-//!   sleep requests are recorded instead of reaching `std::thread::sleep`,
-//!   keeping the tests deterministic and fast.
-//!
-//! # Examples
-//!
-//! Parse textual input and construct a limiter that bounds writes to 8 MiB/s.
-//!
-//! ```
-//! use rsync_bandwidth::{parse_bandwidth_argument, BandwidthLimiter};
-//! use std::num::NonZeroU64;
-//!
-//! let limit = parse_bandwidth_argument("8M").expect("valid limit")
-//!     .expect("non-zero limit");
-//! let mut limiter = BandwidthLimiter::new(limit);
-//! let chunk = limiter.recommended_read_size(1 << 20);
-//! assert!(chunk <= 1 << 20);
-//! limiter.register(chunk);
-//! ```
-//!
-//! # See also
-//!
-//! - [`rsync_core::client`](https://docs.rs/rsync-core/) and
-//!   [`rsync_daemon`](https://docs.rs/rsync-daemon/) which reuse these helpers
-//!   for CLI and daemon orchestration.
+#![deny(rustdoc::broken_intra_doc_links)]
 
 mod limiter;
 mod parse;


### PR DESCRIPTION
## Summary
- add a README for `rsync-bandwidth` and use it as the crate-level documentation via `include_str!`
- gate docs.rs builds with `cfg_attr(docsrs, feature(doc_cfg))` and keep lint denies at the crate root
- reference the new README from the crate manifest so the documentation shows up on crates.io/doc builds

## Testing
- cargo test -p rsync-bandwidth

------