### PR TITLE
Add coverage for bandwidth timing helpers

### DIFF
--- a/crates/bandwidth/src/limiter.rs
+++ b/crates/bandwidth/src/limiter.rs
@@ -391,7 +391,8 @@ impl BandwidthLimiter {
 #[cfg(test)]
 mod tests {
     use super::{
-        BandwidthLimiter, MINIMUM_SLEEP_MICROS, apply_effective_limit, recorded_sleep_session,
+        BandwidthLimiter, MINIMUM_SLEEP_MICROS, apply_effective_limit, duration_from_microseconds,
+        recorded_sleep_session, sleep_for,
     };
     use std::num::NonZeroU64;
     use std::time::Duration;
@@ -701,5 +702,37 @@ mod tests {
         let limiter = limiter.expect("limiter should be created");
         assert_eq!(limiter.limit_bytes(), limit);
         assert!(limiter.burst_bytes().is_none());
+    }
+
+    #[test]
+    fn duration_from_microseconds_returns_zero_for_zero_input() {
+        assert_eq!(duration_from_microseconds(0), Duration::ZERO);
+    }
+
+    #[test]
+    fn duration_from_microseconds_converts_fractional_seconds() {
+        let micros = super::MICROS_PER_SECOND + 123;
+        let duration = duration_from_microseconds(micros);
+        assert_eq!(duration.as_secs(), 1);
+        assert_eq!(duration.subsec_nanos(), 123_000);
+    }
+
+    #[test]
+    fn duration_from_microseconds_saturates_to_duration_max() {
+        let micros = u128::from(u64::MAX)
+            .saturating_mul(super::MICROS_PER_SECOND)
+            .saturating_add(1);
+        assert_eq!(duration_from_microseconds(micros), Duration::MAX);
+    }
+
+    #[test]
+    fn sleep_for_zero_duration_skips_recording() {
+        let mut session = recorded_sleep_session();
+        session.clear();
+
+        sleep_for(Duration::ZERO);
+
+        assert!(session.is_empty());
+        let _ = session.take();
     }
 }


### PR DESCRIPTION
## Summary
- add unit tests covering `duration_from_microseconds` conversions and saturation behaviour
- assert that zero-duration sleeps are ignored by the test sleep recorder

## Testing
- cargo test -p rsync-bandwidth

------