### PR TITLE
Clarify daemon lock file handling

### DIFF
--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -510,6 +510,7 @@ impl ConnectionLimiter {
 
         let file = OpenOptions::new()
             .create(true)
+            .truncate(false)
             .read(true)
             .write(true)
             .open(&path)
@@ -5522,6 +5523,19 @@ mod tests {
         drop(third);
         drop(first);
         assert!(limiter.acquire("docs", limit).is_ok());
+    }
+
+    #[test]
+    fn connection_limiter_open_preserves_existing_counts() {
+        let temp = tempdir().expect("lock dir");
+        let lock_path = temp.path().join("daemon.lock");
+        fs::write(&lock_path, b"docs 1\nother 2\n").expect("seed lock file");
+
+        let limiter = ConnectionLimiter::open(lock_path.clone()).expect("open lock file");
+        drop(limiter);
+
+        let contents = fs::read_to_string(&lock_path).expect("read lock file");
+        assert_eq!(contents, "docs 1\nother 2\n");
     }
 
     #[test]

--- a/crates/engine/src/local_copy.rs
+++ b/crates/engine/src/local_copy.rs
@@ -9683,6 +9683,7 @@ mod tests {
         let path = temp.path().join("prealloc.bin");
         let mut file = fs::OpenOptions::new()
             .create(true)
+            .truncate(true)
             .write(true)
             .open(&path)
             .expect("create file");


### PR DESCRIPTION
## Summary
- ensure the daemon connection limiter keeps existing lock bookkeeping when opening its file
- add a regression test that verifies `ConnectionLimiter::open` preserves prior counts
- tighten the preallocation test by truncating its scratch file before writing

## Testing
- cargo test

------