### PR TITLE
Handle configured unlimited module bandwidth caps

### DIFF
--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -3749,6 +3749,11 @@ fn apply_module_bandwidth_limit(
     module_burst: Option<NonZeroU64>,
     module_burst_specified: bool,
 ) {
+    if module_limit_configured && module_limit.is_none() && !module_burst_specified {
+        *limiter = None;
+        return;
+    }
+
     let limit_specified =
         module_limit_specified || (module_limit_configured && module_limit.is_some());
     let burst_specified =
@@ -7986,6 +7991,17 @@ mod tests {
         ));
 
         apply_module_bandwidth_limit(&mut limiter, None, true, true, None, false);
+
+        assert!(limiter.is_none());
+    }
+
+    #[test]
+    fn module_bwlimit_configured_unlimited_without_specified_flag_clears_daemon_cap() {
+        let mut limiter = Some(BandwidthLimiter::new(
+            NonZeroU64::new(2 * 1024 * 1024).unwrap(),
+        ));
+
+        apply_module_bandwidth_limit(&mut limiter, None, false, true, None, false);
 
         assert!(limiter.is_none());
     }


### PR DESCRIPTION
## Summary
- ensure module bandwidth directives that configure an unlimited rate always clear the active limiter, even when the caller omits the `limit_specified` flag
- cover the regression with a dedicated unit test that mirrors the flag combination

## Testing
- cargo test -p rsync-daemon module_bwlimit_configured_unlimited_without_specified_flag_clears_daemon_cap

------