### PR TITLE
Use char pattern for exponent detection

### DIFF
--- a/crates/bandwidth/src/parse.rs
+++ b/crates/bandwidth/src/parse.rs
@@ -414,7 +414,7 @@ pub fn parse_bandwidth_limit(text: &str) -> Result<BandwidthLimitComponents, Ban
 
 fn parse_decimal_with_exponent(text: &str) -> Result<(u128, u128, u128, i32), BandwidthParseError> {
     let (mantissa_text, exponent_text) =
-        if let Some(position) = text.find(|ch: char| matches!(ch, 'e' | 'E')) {
+        if let Some(position) = text.find(['e', 'E']) {
             let (mantissa, exponent) = text.split_at(position);
             let exponent = &exponent[1..];
             (mantissa, Some(exponent))


### PR DESCRIPTION
## Summary
- replace the manual closure used to find the scientific-notation marker with a character pattern so clippy stays quiet

## Testing
- cargo clippy -p rsync-bandwidth
- cargo test -p rsync-bandwidth

------