### PR TITLE
Ensure module bwlimit=0 disables daemon cap even with burst override

### DIFF
--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -3807,7 +3807,7 @@ fn apply_module_bandwidth_limit(
     module_burst: Option<NonZeroU64>,
     module_burst_specified: bool,
 ) {
-    if module_limit_configured && module_limit.is_none() && !module_burst_specified {
+    if module_limit_configured && module_limit.is_none() {
         *limiter = None;
         return;
     }
@@ -8142,12 +8142,34 @@ mod tests {
     }
 
     #[test]
+    fn module_bwlimit_unlimited_with_burst_override_clears_daemon_cap() {
+        let mut limiter = Some(BandwidthLimiter::new(
+            NonZeroU64::new(2 * 1024 * 1024).unwrap(),
+        ));
+
+        apply_module_bandwidth_limit(&mut limiter, None, true, true, None, true);
+
+        assert!(limiter.is_none());
+    }
+
+    #[test]
     fn module_bwlimit_configured_unlimited_without_specified_flag_clears_daemon_cap() {
         let mut limiter = Some(BandwidthLimiter::new(
             NonZeroU64::new(2 * 1024 * 1024).unwrap(),
         ));
 
         apply_module_bandwidth_limit(&mut limiter, None, false, true, None, false);
+
+        assert!(limiter.is_none());
+    }
+
+    #[test]
+    fn module_bwlimit_configured_unlimited_with_burst_override_clears_daemon_cap() {
+        let mut limiter = Some(BandwidthLimiter::new(
+            NonZeroU64::new(2 * 1024 * 1024).unwrap(),
+        ));
+
+        apply_module_bandwidth_limit(&mut limiter, None, false, true, None, true);
 
         assert!(limiter.is_none());
     }


### PR DESCRIPTION
## Summary
- clear the inherited bandwidth limiter whenever a module configures an unlimited bwlimit
- add coverage for modules that pair bwlimit=0 with an explicit burst override

## Testing
- cargo test -p rsync-daemon module_bwlimit_unlimited_with_burst_override_clears_daemon_cap
- cargo test -p rsync-daemon module_bwlimit_configured_unlimited_with_burst_override_clears_daemon_cap

------