### PR TITLE
Document test-support gating for bandwidth helpers

### DIFF
--- a/crates/bandwidth/src/lib.rs
+++ b/crates/bandwidth/src/lib.rs
@@ -9,6 +9,7 @@ mod parse;
 
 pub use crate::limiter::{BandwidthLimiter, LimiterChange, apply_effective_limit};
 #[cfg(any(test, feature = "test-support"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "test-support")))]
 pub use crate::limiter::{RecordedSleepSession, recorded_sleep_session};
 pub use crate::parse::{
     BandwidthLimitComponents, BandwidthParseError, parse_bandwidth_argument, parse_bandwidth_limit,

--- a/crates/bandwidth/src/limiter.rs
+++ b/crates/bandwidth/src/limiter.rs
@@ -27,6 +27,7 @@ fn recorded_sleep_session_lock() -> &'static Mutex<()> {
 }
 
 #[cfg(any(test, feature = "test-support"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "test-support")))]
 /// Guard that provides exclusive access to the recorded sleep durations.
 ///
 /// Tests obtain a [`RecordedSleepSession`] at the start of a scenario, call
@@ -93,6 +94,7 @@ impl<'a> RecordedSleepSession<'a> {
 }
 
 #[cfg(any(test, feature = "test-support"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "test-support")))]
 /// Obtains a guard that serialises access to recorded sleep durations.
 #[must_use]
 pub fn recorded_sleep_session() -> RecordedSleepSession<'static> {


### PR DESCRIPTION
## Summary
- annotate the bandwidth test-support re-exports with doc(cfg) so docs.rs shows the feature gate
- mark the RecordedSleepSession guard and helper with the same doc(cfg) attribute

## Testing
- cargo test -p rsync-bandwidth

------