### PR TITLE
Fix clippy lints in recorded sleep helpers

### DIFF
--- a/crates/bandwidth/src/limiter.rs
+++ b/crates/bandwidth/src/limiter.rs
@@ -51,7 +51,7 @@ impl<'a> RecordedSleepSession<'a> {
     #[inline]
     fn with_recorded_sleeps_mut<R>(&self, op: impl FnOnce(&mut Vec<Duration>) -> R) -> R {
         let mut guard = recorded_sleeps().lock().expect("lock recorded sleeps");
-        op(&mut *guard)
+        op(&mut guard)
     }
 
     /// Removes any previously recorded durations.
@@ -77,7 +77,7 @@ impl<'a> RecordedSleepSession<'a> {
     /// Drains the recorded sleep durations, returning ownership of the vector.
     #[inline]
     pub fn take(&mut self) -> Vec<Duration> {
-        self.with_recorded_sleeps_mut(|durations| mem::take(durations))
+        self.with_recorded_sleeps_mut(mem::take)
     }
 
     /// Consumes the session and returns the recorded durations.


### PR DESCRIPTION
## Summary
- address clippy warnings in the recorded sleep helpers by letting auto-deref handle the mutex guard and reusing `mem::take` directly

## Testing
- cargo clippy -p rsync-bandwidth --all-targets -- -Dwarnings
- cargo test -p rsync-bandwidth

------