### PR TITLE
Reject whitespace-wrapped bwlimit arguments

### DIFF
--- a/crates/bandwidth/src/parse.rs
+++ b/crates/bandwidth/src/parse.rs
@@ -372,6 +372,10 @@ pub fn parse_bandwidth_argument(text: &str) -> Result<Option<NonZeroU64>, Bandwi
 pub fn parse_bandwidth_limit(text: &str) -> Result<BandwidthLimitComponents, BandwidthParseError> {
     let trimmed = text.trim_matches(|ch: char| ch.is_ascii_whitespace());
 
+    if trimmed.len() != text.len() {
+        return Err(BandwidthParseError::Invalid);
+    }
+
     if let Some((rate_text, burst_text)) = trimmed.split_once(':') {
         let rate = parse_bandwidth_argument(rate_text)?;
         if rate.is_none() {

--- a/crates/bandwidth/src/parse/tests.rs
+++ b/crates/bandwidth/src/parse/tests.rs
@@ -152,6 +152,12 @@ fn parse_bandwidth_rejects_surrounding_whitespace() {
 }
 
 #[test]
+fn parse_bandwidth_limit_rejects_surrounding_whitespace() {
+    let error = parse_bandwidth_limit(" 1M ").unwrap_err();
+    assert_eq!(error, BandwidthParseError::Invalid);
+}
+
+#[test]
 fn components_into_limiter_respects_rate_and_burst() {
     let components = BandwidthLimitComponents::new(NonZeroU64::new(1024), NonZeroU64::new(4096));
     let limiter = components.into_limiter().expect("limiter");


### PR DESCRIPTION
## Summary
- reject `--bwlimit` limits that include surrounding whitespace so the high-level helper mirrors `parse_size_arg`
- add targeted coverage that exercises the whitespace rejection path

## Testing
- cargo test -p rsync-bandwidth

------