### PR TITLE
Align bwlimit whitespace tests with parser rejection

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -12641,11 +12641,11 @@ mod tests {
     }
 
     #[test]
-    fn bwlimit_argument_trims_whitespace() {
-        let limit = parse_bandwidth_limit(OsStr::new(" 1M \t"))
-            .expect("parse succeeds")
-            .expect("limit available");
-        assert_eq!(limit.bytes_per_second().get(), 1_048_576);
+    fn bwlimit_rejects_whitespace_wrapped_argument() {
+        let error = parse_bandwidth_limit(OsStr::new(" 1M \t"))
+            .expect_err("whitespace-wrapped bwlimit should fail");
+        let rendered = format!("{error}");
+        assert!(rendered.contains("--bwlimit= 1M \t is invalid"));
     }
 
     #[test]

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -6685,17 +6685,16 @@ mod tests {
     }
 
     #[test]
-    fn runtime_options_trim_bwlimit_argument() {
-        let options =
-            RuntimeOptions::parse(&[OsString::from("--bwlimit"), OsString::from(" 8M \n")])
-                .expect("parse bwlimit");
+    fn runtime_options_reject_whitespace_wrapped_bwlimit_argument() {
+        let error = RuntimeOptions::parse(&[OsString::from("--bwlimit"), OsString::from(" 8M \n")])
+            .expect_err("whitespace-wrapped bwlimit should fail");
 
-        assert_eq!(
-            options.bandwidth_limit(),
-            Some(NonZeroU64::new(8 * 1024 * 1024).unwrap())
+        assert!(
+            error
+                .message()
+                .to_string()
+                .contains("--bwlimit= 8M \n is invalid")
         );
-        assert!(options.bandwidth_burst().is_none());
-        assert!(options.bandwidth_limit_configured());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- update the CLI bwlimit test to expect whitespace-wrapped values to be rejected
- update the daemon runtime options test to assert the whitespace-wrapped bwlimit diagnostic

## Testing
- cargo test --package rsync-cli -- bwlimit_rejects_whitespace_wrapped_argument
- cargo test --package rsync-daemon -- runtime_options_reject_whitespace_wrapped_bwlimit_argument

------