### PR TITLE
Remove redundant must_use attribute from bandwidth limiter helper

### DIFF
--- a/crates/bandwidth/src/limiter.rs
+++ b/crates/bandwidth/src/limiter.rs
@@ -270,7 +270,6 @@ impl LimiterChange {
 /// let limiter = limiter.expect("limiter remains active");
 /// assert_eq!(limiter.limit_bytes().get(), 512);
 /// ```
-#[must_use]
 pub fn apply_effective_limit(
     limiter: &mut Option<BandwidthLimiter>,
     limit: Option<NonZeroU64>,


### PR DESCRIPTION
## Summary
- remove the function-level `#[must_use]` attribute from `apply_effective_limit` to satisfy `clippy::double_must_use`
- rely on the `LimiterChange` return type's own `#[must_use]` marker to keep callers checking configuration updates

## Testing
- cargo clippy -p rsync-bandwidth -- -Dwarnings
- cargo test -p rsync-bandwidth

------