### PR TITLE
Add snapshot helper for recorded sleep sessions

### DIFF
--- a/crates/bandwidth/src/limiter/tests.rs
+++ b/crates/bandwidth/src/limiter/tests.rs
@@ -106,6 +106,19 @@ fn recorded_sleep_session_into_vec_consumes_guard() {
 }
 
 #[test]
+fn recorded_sleep_session_snapshot_preserves_buffer() {
+    let mut session = recorded_sleep_session();
+    session.clear();
+
+    sleep_for(Duration::from_micros(MINIMUM_SLEEP_MICROS as u64));
+
+    let snapshot = session.snapshot();
+    assert_eq!(snapshot, session.snapshot());
+    assert_eq!(session.len(), snapshot.len());
+    assert_eq!(session.take(), snapshot);
+}
+
+#[test]
 fn recorded_sleep_session_recovers_from_mutex_poisoning() {
     let _ = catch_unwind(AssertUnwindSafe(|| {
         let _session = recorded_sleep_session();


### PR DESCRIPTION
## Summary
- add a non-destructive snapshot helper to `RecordedSleepSession`
- add a regression test that exercises the new helper and preserves the shared buffer contents

## Testing
- cargo test -p rsync-bandwidth

------