### PR TITLE
Add iterator support for recorded sleep sessions

### DIFF
--- a/crates/bandwidth/src/limiter/tests.rs
+++ b/crates/bandwidth/src/limiter/tests.rs
@@ -136,6 +136,24 @@ fn recorded_sleep_session_into_vec_consumes_guard() {
 }
 
 #[test]
+fn recorded_sleep_session_into_iter_collects_durations() {
+    let mut session = recorded_sleep_session();
+    session.clear();
+
+    sleep_for(Duration::from_micros(MINIMUM_SLEEP_MICROS as u64));
+
+    let durations: Vec<_> = session.into_iter().collect();
+    assert_eq!(
+        durations,
+        [Duration::from_micros(MINIMUM_SLEEP_MICROS as u64)]
+    );
+
+    let mut follow_up = recorded_sleep_session();
+    assert!(follow_up.is_empty());
+    let _ = follow_up.take();
+}
+
+#[test]
 fn recorded_sleep_session_snapshot_preserves_buffer() {
     let mut session = recorded_sleep_session();
     session.clear();


### PR DESCRIPTION
## Summary
- implement `IntoIterator` for `RecordedSleepSession` so pacing tests can consume durations idiomatically
- extend the limiter test suite to cover iteration semantics and guard hand-off

## Testing
- cargo test -p rsync-bandwidth

------