### PR TITLE
Avoid allocating recorded sleep buffer when unused

### DIFF
--- a/crates/bandwidth/src/limiter.rs
+++ b/crates/bandwidth/src/limiter.rs
@@ -207,7 +207,7 @@ fn sleep_for(duration: Duration) {
     let mut remaining = duration;
 
     #[cfg(any(test, feature = "test-support"))]
-    let mut recorded_chunks = Vec::new();
+    let mut recorded_chunks: Option<Vec<Duration>> = None;
 
     while !remaining.is_zero() {
         let chunk = remaining.min(MAX_SLEEP_DURATION);
@@ -218,7 +218,7 @@ fn sleep_for(duration: Duration) {
 
         #[cfg(any(test, feature = "test-support"))]
         {
-            recorded_chunks.push(chunk);
+            recorded_chunks.get_or_insert_with(Vec::new).push(chunk);
         }
 
         #[cfg(not(any(test, feature = "test-support")))]
@@ -230,8 +230,8 @@ fn sleep_for(duration: Duration) {
     }
 
     #[cfg(any(test, feature = "test-support"))]
-    if !recorded_chunks.is_empty() {
-        lock_recorded_sleeps().extend(recorded_chunks);
+    if let Some(chunks) = recorded_chunks {
+        lock_recorded_sleeps().extend(chunks);
     }
 }
 


### PR DESCRIPTION
## Summary
- avoid allocating the test-only sleep recorder buffer when the limiter performs no sleep operations

## Testing
- cargo test -p rsync-bandwidth

------