### PR TITLE
Add recorded sleep session helper for latest pacing sample

### DIFF
--- a/crates/bandwidth/README.md
+++ b/crates/bandwidth/README.md
@@ -52,7 +52,11 @@ Enabling the `test-support` feature exposes helpers that record sleep requests
 instead of calling [`std::thread::sleep`]. Tests obtain a
 [`recorded_sleep_session`](crate::recorded_sleep_session) guard to serialise
 access to the captured durations, ensuring race-free assertions when scenarios
-run in parallel.
+run in parallel. Convenience accessors such as
+[`snapshot`](crate::RecordedSleepSession::snapshot),
+[`last_duration`](crate::RecordedSleepSession::last_duration), and
+[`total_duration`](crate::RecordedSleepSession::total_duration) let tests
+inspect the pacing history without draining it.
 
 ## Example
 

--- a/crates/bandwidth/src/limiter/tests.rs
+++ b/crates/bandwidth/src/limiter/tests.rs
@@ -167,6 +167,23 @@ fn recorded_sleep_session_snapshot_preserves_buffer() {
 }
 
 #[test]
+fn recorded_sleep_session_last_duration_observes_latest_sample() {
+    let mut session = recorded_sleep_session();
+    session.clear();
+
+    assert!(session.last_duration().is_none());
+
+    let first = Duration::from_micros(MINIMUM_SLEEP_MICROS as u64);
+    sleep_for(first);
+    assert_eq!(session.last_duration(), Some(first));
+
+    let second = Duration::from_micros((MINIMUM_SLEEP_MICROS / 2) as u64);
+    sleep_for(second);
+    assert_eq!(session.last_duration(), Some(second));
+    assert_eq!(session.len(), 2);
+}
+
+#[test]
 fn recorded_sleep_session_total_duration_reports_sum_without_draining() {
     let mut session = recorded_sleep_session();
     session.clear();


### PR DESCRIPTION
## Summary
- add a `RecordedSleepSession::last_duration` accessor to inspect the newest recorded sleep without draining the buffer
- cover the helper with unit tests alongside the existing pacing assertions
- document the additional inspection helpers available when the `test-support` feature is enabled

## Testing
- cargo test -p rsync-bandwidth

------