### PR TITLE
Add whitespace rejection tests for bandwidth parser

### DIFF
--- a/crates/bandwidth/tests/parse_whitespace.rs
+++ b/crates/bandwidth/tests/parse_whitespace.rs
@@ -1,0 +1,44 @@
+use rsync_bandwidth::{
+    parse_bandwidth_argument, parse_bandwidth_limit, BandwidthParseError,
+};
+
+fn assert_invalid_argument(text: &str) {
+    let err = parse_bandwidth_argument(text).expect_err("argument should be invalid");
+    assert_eq!(err, BandwidthParseError::Invalid);
+}
+
+fn assert_invalid_limit(text: &str) {
+    let err = parse_bandwidth_limit(text).expect_err("limit should be invalid");
+    assert_eq!(err, BandwidthParseError::Invalid);
+}
+
+#[test]
+fn rejects_leading_whitespace_argument() {
+    assert_invalid_argument(" 1024");
+}
+
+#[test]
+fn rejects_trailing_whitespace_argument() {
+    assert_invalid_argument("1024 ");
+}
+
+#[test]
+fn rejects_internal_whitespace_argument() {
+    assert_invalid_argument("10 24");
+}
+
+#[test]
+fn rejects_limit_with_leading_whitespace() {
+    assert_invalid_limit(" 2048");
+}
+
+#[test]
+fn rejects_limit_with_trailing_whitespace() {
+    assert_invalid_limit("2048 ");
+}
+
+#[test]
+fn rejects_limit_with_whitespace_around_separator() {
+    assert_invalid_limit("2048 :1024");
+    assert_invalid_limit("2048: 1024");
+}


### PR DESCRIPTION
## Summary
- add integration tests ensuring bandwidth argument and limit parsers reject surrounding or internal whitespace

## Testing
- cargo test -p rsync-bandwidth

------