### PR TITLE
Align decimal --bwlimit rounding with upstream behaviour

### DIFF
--- a/crates/bandwidth/src/parse.rs
+++ b/crates/bandwidth/src/parse.rs
@@ -259,12 +259,14 @@ pub fn parse_bandwidth_argument(text: &str) -> Result<Option<NonZeroU64>, Bandwi
     };
 
     let mut base: u32 = 1024;
+    let mut alignment: u128 = 1024;
 
     if !remainder_after_suffix.is_empty() {
         let bytes = remainder_after_suffix.as_bytes();
         match bytes[0] {
             b'b' | b'B' => {
                 base = 1000;
+                alignment = 1000;
                 remainder_after_suffix = &remainder_after_suffix[1..];
             }
             b'i' | b'I' => {
@@ -354,11 +356,11 @@ pub fn parse_bandwidth_argument(text: &str) -> Result<Option<NonZeroU64>, Bandwi
     }
 
     let rounded = bytes
-        .checked_add(512)
+        .checked_add(alignment / 2)
         .ok_or(BandwidthParseError::TooLarge)?
-        / 1024;
+        / alignment;
     let rounded_bytes = rounded
-        .checked_mul(1024)
+        .checked_mul(alignment)
         .ok_or(BandwidthParseError::TooLarge)?;
 
     let bytes_u64 = u64::try_from(rounded_bytes).map_err(|_| BandwidthParseError::TooLarge)?;

--- a/crates/bandwidth/src/parse/tests.rs
+++ b/crates/bandwidth/src/parse/tests.rs
@@ -14,7 +14,7 @@ fn parse_bandwidth_accepts_binary_units() {
 #[test]
 fn parse_bandwidth_accepts_decimal_units() {
     let limit = parse_bandwidth_argument("12MB").expect("parse succeeds");
-    assert_eq!(limit, NonZeroU64::new(12_000_256));
+    assert_eq!(limit, NonZeroU64::new(12_000_000));
 }
 
 #[test]

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -12619,7 +12619,7 @@ mod tests {
         let limit = parse_bandwidth_limit(OsStr::new("10KB"))
             .expect("parse succeeds")
             .expect("limit available");
-        assert_eq!(limit.bytes_per_second().get(), 10_240);
+        assert_eq!(limit.bytes_per_second().get(), 10_000);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- track decimal suffix alignment in the bandwidth parser so MB/KB arguments round to decimal multiples instead of binary multiples
- adjust unit tests in the bandwidth crate and CLI to assert the corrected decimal results

## Testing
- cargo test -p rsync-bandwidth
- cargo test -p rsync-cli -- --test-threads=1 --quiet
- cargo test -p rsync-core bandwidth_limit -- --nocapture
- cargo test -p rsync-daemon bwlimit -- --nocapture

------