### PR TITLE
Add Default implementation for recorded sleep session guard

### DIFF
--- a/crates/bandwidth/README.md
+++ b/crates/bandwidth/README.md
@@ -52,7 +52,8 @@ Enabling the `test-support` feature exposes helpers that record sleep requests
 instead of calling [`std::thread::sleep`]. Tests obtain a
 [`recorded_sleep_session`](crate::recorded_sleep_session) guard to serialise
 access to the captured durations, ensuring race-free assertions when scenarios
-run in parallel. Convenience accessors such as
+run in parallel. The guard also implements [`Default`], making it easy to embed
+inside helper structs without additional boilerplate. Convenience accessors such as
 [`snapshot`](crate::RecordedSleepSession::snapshot),
 [`last_duration`](crate::RecordedSleepSession::last_duration), and
 [`total_duration`](crate::RecordedSleepSession::total_duration) let tests

--- a/crates/bandwidth/src/limiter.rs
+++ b/crates/bandwidth/src/limiter.rs
@@ -330,10 +330,28 @@ impl FusedIterator for RecordedSleepIter<'_> {}
 #[cfg(any(test, feature = "test-support"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "test-support")))]
 /// Obtains a guard that serialises access to recorded sleep durations.
+///
+/// Callers can invoke this helper directly or rely on the [`Default`]
+/// implementation for [`RecordedSleepSession`] when constructing helper structs.
 #[must_use]
 pub fn recorded_sleep_session() -> RecordedSleepSession<'static> {
     RecordedSleepSession {
         _guard: lock_recorded_sleep_session(),
+    }
+}
+
+#[cfg(any(test, feature = "test-support"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "test-support")))]
+impl Default for RecordedSleepSession<'static> {
+    /// Returns a [`RecordedSleepSession`] guard that serialises access to the
+    /// shared sleep buffer.
+    ///
+    /// The implementation forwards to [`recorded_sleep_session()`], ensuring
+    /// idiomatic construction via [`Default::default`]. Holding the returned
+    /// guard provides exclusive access to the recorded durations until it is
+    /// dropped.
+    fn default() -> Self {
+        recorded_sleep_session()
     }
 }
 

--- a/crates/bandwidth/src/limiter/tests.rs
+++ b/crates/bandwidth/src/limiter/tests.rs
@@ -1,6 +1,7 @@
 use super::{
     BandwidthLimiter, LimiterChange, MAX_SLEEP_DURATION, MINIMUM_SLEEP_MICROS,
-    apply_effective_limit, duration_from_microseconds, recorded_sleep_session, sleep_for,
+    RecordedSleepSession, apply_effective_limit, duration_from_microseconds,
+    recorded_sleep_session, sleep_for,
 };
 use std::num::NonZeroU64;
 use std::panic::{AssertUnwindSafe, catch_unwind};
@@ -233,6 +234,19 @@ fn recorded_sleep_session_total_duration_reports_sum_without_draining() {
             Duration::from_micros(MINIMUM_SLEEP_MICROS as u64),
             Duration::from_micros((MINIMUM_SLEEP_MICROS / 2) as u64),
         ]
+    );
+}
+
+#[test]
+fn recorded_sleep_session_default_acquires_guard() {
+    let mut session = RecordedSleepSession::default();
+    session.clear();
+
+    sleep_for(Duration::from_micros(MINIMUM_SLEEP_MICROS as u64));
+
+    assert_eq!(
+        session.take(),
+        [Duration::from_micros(MINIMUM_SLEEP_MICROS as u64)]
     );
 }
 


### PR DESCRIPTION
## Summary
- add a `Default` implementation for the recorded sleep session guard to streamline helper construction
- document the new ergonomics and provide a regression test covering the default path

## Testing
- `cargo test -p rsync-bandwidth`

------