### PR TITLE
Optimize bandwidth parser ASCII scan

### DIFF
--- a/crates/bandwidth/src/parse/tests.rs
+++ b/crates/bandwidth/src/parse/tests.rs
@@ -53,6 +53,14 @@ fn parse_bandwidth_rejects_invalid_suffix() {
 }
 
 #[test]
+fn parse_bandwidth_rejects_non_ascii_characters() {
+    for text in ["10µ", "\u{FF11}\u{FF12}M"] {
+        let error = parse_bandwidth_argument(text).unwrap_err();
+        assert_eq!(error, BandwidthParseError::Invalid);
+    }
+}
+
+#[test]
 fn parse_bandwidth_handles_fractional_values() {
     let limit = parse_bandwidth_argument("0.5M").expect("parse succeeds");
     assert_eq!(limit, NonZeroU64::new(512 * 1024));

--- a/crates/bandwidth/tests/parse_whitespace.rs
+++ b/crates/bandwidth/tests/parse_whitespace.rs
@@ -1,6 +1,4 @@
-use rsync_bandwidth::{
-    parse_bandwidth_argument, parse_bandwidth_limit, BandwidthParseError,
-};
+use rsync_bandwidth::{BandwidthParseError, parse_bandwidth_argument, parse_bandwidth_limit};
 
 fn assert_invalid_argument(text: &str) {
     let err = parse_bandwidth_argument(text).expect_err("argument should be invalid");


### PR DESCRIPTION
## Summary
- rewrite `parse_bandwidth_argument` to operate directly on ASCII bytes for lower overhead while preserving upstream-compatible validation
- tighten suffix parsing to reject non-ASCII modifiers up-front and extend unit coverage for those inputs
- refresh bandwidth whitespace tests after rustfmt reordered imports

## Testing
- cargo test -p rsync-bandwidth

------