### PR TITLE
Support iterating recorded sleep sessions by reference

### DIFF
--- a/crates/bandwidth/src/limiter.rs
+++ b/crates/bandwidth/src/limiter.rs
@@ -295,6 +295,44 @@ impl<'a> IntoIterator for RecordedSleepSession<'a> {
 
 #[cfg(any(test, feature = "test-support"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "test-support")))]
+impl<'session, 'iter> IntoIterator for &'iter RecordedSleepSession<'session>
+where
+    'session: 'iter,
+{
+    type Item = Duration;
+    type IntoIter = RecordedSleepIter<'iter>;
+
+    /// Iterates over the recorded durations without consuming the guard.
+    ///
+    /// The implementation forwards to [`RecordedSleepSession::iter`], keeping
+    /// the shared buffer intact so callers can perform multiple passes while
+    /// still holding the session lock.
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+#[cfg(any(test, feature = "test-support"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "test-support")))]
+impl<'session, 'iter> IntoIterator for &'iter mut RecordedSleepSession<'session>
+where
+    'session: 'iter,
+{
+    type Item = Duration;
+    type IntoIter = RecordedSleepIter<'iter>;
+
+    /// Iterates over the recorded durations without consuming the guard.
+    ///
+    /// The implementation forwards to [`RecordedSleepSession::iter`], keeping
+    /// the shared buffer intact so callers can perform multiple passes while
+    /// still holding the session lock.
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+#[cfg(any(test, feature = "test-support"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "test-support")))]
 /// Iterator over the durations captured by a [`RecordedSleepSession`].
 ///
 /// The iterator keeps the underlying buffer intact, allowing tests to inspect

--- a/crates/bandwidth/src/limiter/tests.rs
+++ b/crates/bandwidth/src/limiter/tests.rs
@@ -184,6 +184,52 @@ fn recorded_sleep_session_iter_preserves_buffer_and_reports_length() {
 }
 
 #[test]
+fn recorded_sleep_session_reference_into_iter_preserves_buffer() {
+    let mut session = recorded_sleep_session();
+    session.clear();
+
+    let expected = vec![
+        Duration::from_micros(MINIMUM_SLEEP_MICROS as u64),
+        Duration::from_micros((MINIMUM_SLEEP_MICROS / 2) as u64),
+    ];
+
+    for duration in &expected {
+        sleep_for(*duration);
+    }
+
+    let collected: Vec<_> = (&session).into_iter().collect();
+    assert_eq!(collected, expected);
+    assert_eq!(session.len(), expected.len());
+    assert_eq!(session.take(), expected);
+}
+
+#[test]
+fn recorded_sleep_session_mut_reference_into_iter_preserves_buffer() {
+    let mut session = recorded_sleep_session();
+    session.clear();
+
+    let expected = vec![
+        Duration::from_micros(MINIMUM_SLEEP_MICROS as u64),
+        Duration::from_micros((MINIMUM_SLEEP_MICROS / 2) as u64),
+    ];
+
+    for duration in &expected {
+        sleep_for(*duration);
+    }
+
+    let mut observed = Vec::new();
+    {
+        for chunk in &mut session {
+            observed.push(chunk);
+        }
+    }
+
+    assert_eq!(observed, expected);
+    assert_eq!(session.len(), expected.len());
+    assert_eq!(session.take(), expected);
+}
+
+#[test]
 fn recorded_sleep_session_snapshot_preserves_buffer() {
     let mut session = recorded_sleep_session();
     session.clear();


### PR DESCRIPTION
## Summary
- add `IntoIterator` implementations for shared and mutable references to `RecordedSleepSession`
- cover the new iteration shorthands with unit tests to confirm the recorded buffer stays intact

## Testing
- cargo test -p rsync-bandwidth

------