### PR TITLE
Add oc-rsync binary wrappers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -429,6 +429,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "oc-rsync-bin"
+version = "0.0.0"
+dependencies = [
+ "rsync-cli",
+]
+
+[[package]]
+name = "oc-rsyncd-bin"
+version = "0.0.0"
+dependencies = [
+ "rsync-daemon",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,7 @@
 [workspace]
 members = [
+    "bin/oc-rsync",
+    "bin/oc-rsyncd",
     "bin/rsync",
     "bin/rsyncd",
     "crates/cli",

--- a/bin/oc-rsync/Cargo.toml
+++ b/bin/oc-rsync/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "oc-rsync-bin"
+version = "0.0.0"
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+description = "Rust implementation of the oc-rsync client binary"
+
+[[bin]]
+name = "oc-rsync"
+path = "src/main.rs"
+
+[dependencies]
+rsync-cli = { path = "../../crates/cli" }

--- a/bin/oc-rsync/src/main.rs
+++ b/bin/oc-rsync/src/main.rs
@@ -1,0 +1,10 @@
+#![deny(unsafe_code)]
+
+use std::{env, io, process::ExitCode};
+
+fn main() -> ExitCode {
+    let mut stdout = io::stdout().lock();
+    let mut stderr = io::stderr().lock();
+    let status = rsync_cli::run(env::args_os(), &mut stdout, &mut stderr);
+    rsync_cli::exit_code_from(status)
+}

--- a/bin/oc-rsyncd/Cargo.toml
+++ b/bin/oc-rsyncd/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "oc-rsyncd-bin"
+version = "0.0.0"
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+description = "Rust implementation of the oc-rsyncd daemon binary"
+
+[[bin]]
+name = "oc-rsyncd"
+path = "src/main.rs"
+
+[dependencies]
+rsync-daemon = { path = "../../crates/daemon" }

--- a/bin/oc-rsyncd/src/main.rs
+++ b/bin/oc-rsyncd/src/main.rs
@@ -1,0 +1,10 @@
+#![deny(unsafe_code)]
+
+use std::{env, io, process::ExitCode};
+
+fn main() -> ExitCode {
+    let mut stdout = io::stdout().lock();
+    let mut stderr = io::stderr().lock();
+    let status = rsync_daemon::run(env::args_os(), &mut stdout, &mut stderr);
+    rsync_daemon::exit_code_from(status)
+}


### PR DESCRIPTION
## Summary
- add workspace members for oc-rsync and oc-rsyncd that reuse the existing CLI and daemon entry points
- wire the new binaries into the workspace manifest and lockfile so they build alongside the existing rsync tooling

## Testing
- cargo check -p oc-rsync-bin -p oc-rsyncd-bin

------