### PR TITLE
Add oc binary names to version banners

### DIFF
--- a/crates/core/src/version.rs
+++ b/crates/core/src/version.rs
@@ -125,6 +125,12 @@ pub const PROGRAM_NAME: &str = "rsync";
 /// Program name rendered by the `rsyncd` daemon when displaying version banners.
 pub const DAEMON_PROGRAM_NAME: &str = "rsyncd";
 
+/// Program name used by the standalone `oc-rsync` client wrapper.
+pub const OC_PROGRAM_NAME: &str = "oc-rsync";
+
+/// Program name used by the standalone `oc-rsyncd` daemon wrapper.
+pub const OC_DAEMON_PROGRAM_NAME: &str = "oc-rsyncd";
+
 /// First copyright year advertised by the Rust implementation.
 pub const COPYRIGHT_START_YEAR: &str = "2025";
 

--- a/crates/walk/src/lib.rs
+++ b/crates/walk/src/lib.rs
@@ -578,10 +578,7 @@ mod tests {
             Err(error) => error,
         };
         assert!(matches!(error.kind(), WalkErrorKind::RootMetadata { .. }));
-        assert_eq!(
-            error.path(),
-            Path::new("/nonexistent/path/for/walker")
-        );
+        assert_eq!(error.path(), Path::new("/nonexistent/path/for/walker"));
         assert_eq!(
             error.kind().path(),
             Path::new("/nonexistent/path/for/walker")


### PR DESCRIPTION
## Summary
- detect the oc-rsync wrapper name when parsing CLI arguments and feed it into the version banner logic
- share program-name constants so both the client and daemon wrappers render wrapper-specific banners
- extend tests to cover oc-rsync and oc-rsyncd while keeping clap diagnostics aligned with each binary

## Testing
- cargo test -p rsync-cli
- cargo test -p rsync-daemon

------