### PR TITLE
Fix byte suffix handling in bandwidth parser

### DIFF
--- a/crates/bandwidth/src/parse.rs
+++ b/crates/bandwidth/src/parse.rs
@@ -270,7 +270,8 @@ pub fn parse_bandwidth_argument(text: &str) -> Result<Option<NonZeroU64>, Bandwi
             (first, &remainder[1..])
         };
 
-    let repetitions = match suffix.to_ascii_lowercase() {
+    let normalized_suffix = suffix.to_ascii_lowercase();
+    let repetitions = match normalized_suffix {
         b'b' => 0,
         b'k' => 1,
         b'm' => 2,
@@ -281,7 +282,7 @@ pub fn parse_bandwidth_argument(text: &str) -> Result<Option<NonZeroU64>, Bandwi
     };
 
     let mut base: u32 = 1024;
-    let mut alignment: u128 = 1024;
+    let mut alignment: u128 = if normalized_suffix == b'b' { 1 } else { 1024 };
 
     if !remainder_after_suffix.is_empty() {
         let bytes = remainder_after_suffix.as_bytes();

--- a/crates/bandwidth/src/parse/tests.rs
+++ b/crates/bandwidth/src/parse/tests.rs
@@ -18,6 +18,18 @@ fn parse_bandwidth_accepts_decimal_units() {
 }
 
 #[test]
+fn parse_bandwidth_accepts_explicit_byte_suffix() {
+    let limit = parse_bandwidth_argument("512b").expect("parse succeeds");
+    assert_eq!(limit, NonZeroU64::new(512));
+
+    let uppercase = parse_bandwidth_argument("512B").expect("parse succeeds");
+    assert_eq!(uppercase, limit);
+
+    let too_small = parse_bandwidth_argument("10b").unwrap_err();
+    assert_eq!(too_small, BandwidthParseError::TooSmall);
+}
+
+#[test]
 fn parse_bandwidth_rejects_space_between_value_and_suffix() {
     let error = parse_bandwidth_argument("1 M").unwrap_err();
     assert_eq!(error, BandwidthParseError::Invalid);


### PR DESCRIPTION
## Summary
- ensure explicit byte suffixes no longer round to zero by skipping kib-aligned rounding
- cover the behaviour with unit tests including minimum accepted rate and too-small rejection

## Testing
- cargo test -p rsync-bandwidth

------