### PR TITLE
Log daemon bandwidth limiter changes

### DIFF
--- a/crates/bandwidth/src/parse.rs
+++ b/crates/bandwidth/src/parse.rs
@@ -164,7 +164,9 @@ impl BandwidthLimitComponents {
             }
         }
 
-        if override_components.burst_specified && !override_components.limit_specified && rate.is_some()
+        if override_components.burst_specified
+            && !override_components.limit_specified
+            && rate.is_some()
         {
             burst = override_components.burst;
             burst_specified = true;


### PR DESCRIPTION
## Summary
- log module-specific bandwidth limiter updates so daemon sessions surface applied caps
- add focused tests exercising enabled, disabled, and unchanged limiter transitions
- normalize bandwidth parser formatting to satisfy style checks

## Testing
- cargo test -p rsync-daemon log_module_bandwidth_change

------