### PR TITLE
Align packaging metadata with oc-rsync naming

### DIFF
--- a/bin/oc-rsync/Cargo.toml
+++ b/bin/oc-rsync/Cargo.toml
@@ -13,3 +13,31 @@ path = "src/main.rs"
 
 [dependencies]
 rsync-cli = { path = "../../crates/cli" }
+
+[package.metadata.deb]
+name = "oc-rsync"
+section = "utils"
+priority = "optional"
+maintainer = "Ofer Chen <skewers.irises.3b@icloud.com>"
+depends = "libc6 (>= 2.34), libgcc-s1"
+extended-description = "Pure-Rust implementation of oc-rsync-compatible client and daemon binaries."
+assets = [
+    ["../../target/release/oc-rsync", "/usr/bin/oc-rsync", "755"],
+    ["../../target/release/oc-rsyncd", "/usr/bin/oc-rsyncd", "755"],
+    ["../../packaging/systemd/rsyncd.service", "/lib/systemd/system/rsyncd.service", "644"],
+    ["../../packaging/etc/rsyncd.conf", "/etc/rsyncd.conf", "644"],
+    ["../../packaging/default/rsyncd", "/etc/default/rsyncd", "644"],
+]
+conf-files = ["etc/rsyncd.conf", "etc/default/rsyncd"]
+
+[package.metadata.rpm]
+package = "oc-rsync"
+summary = "Rust implementation of oc-rsync-compatible client and daemon"
+requires = ["glibc", "libgcc"]
+assets = [
+    { path = "../../target/release/oc-rsync", dest = "/usr/bin/oc-rsync", mode = "0755" },
+    { path = "../../target/release/oc-rsyncd", dest = "/usr/bin/oc-rsyncd", mode = "0755" },
+    { path = "../../packaging/systemd/rsyncd.service", dest = "/usr/lib/systemd/system/rsyncd.service", mode = "0644" },
+    { path = "../../packaging/etc/rsyncd.conf", dest = "/etc/rsyncd.conf", mode = "0644", config = true },
+    { path = "../../packaging/default/rsyncd", dest = "/etc/default/rsyncd", mode = "0644", config = true },
+]

--- a/bin/oc-rsyncd/Cargo.toml
+++ b/bin/oc-rsyncd/Cargo.toml
@@ -11,5 +11,9 @@ description = "Rust implementation of the oc-rsyncd daemon binary"
 name = "oc-rsyncd"
 path = "src/main.rs"
 
+[features]
+default = []
+sd-notify = ["rsync-daemon/sd-notify"]
+
 [dependencies]
 rsync-daemon = { path = "../../crates/daemon" }

--- a/packaging/default/rsyncd
+++ b/packaging/default/rsyncd
@@ -1,8 +1,8 @@
-# Additional environment customisations for rsyncd.
+# Additional environment customisations for oc-rsyncd.
 #
 # Uncomment and adjust the variables below to pass extra arguments to the
 # daemon or to point at an alternate configuration file. Values are consumed
-# by the systemd unit installed with the rsync packages.
+# by the systemd unit installed with the oc-rsync packages.
 #
 # RSYNCD_CONFIG=/etc/rsyncd.conf
 # RSYNCD_ARGS="--max-sessions 16"

--- a/packaging/systemd/rsyncd.service
+++ b/packaging/systemd/rsyncd.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=rsync daemon providing rsync protocol services
+Description=oc-rsyncd daemon providing rsync protocol services
 Documentation=https://github.com/oferchen/rsync
 After=network.target
 
@@ -7,7 +7,7 @@ After=network.target
 Type=simple
 Environment="RSYNCD_CONFIG=/etc/rsyncd.conf"
 EnvironmentFile=-/etc/default/rsyncd
-ExecStart=/usr/bin/rsyncd --config ${RSYNCD_CONFIG} $RSYNCD_ARGS
+ExecStart=/usr/bin/oc-rsyncd --config ${RSYNCD_CONFIG} $RSYNCD_ARGS
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=on-failure
 RestartSec=5s


### PR DESCRIPTION
## Summary
- add DEB/RPM metadata to the oc-rsync binary crate so packages install the oc-rsync and oc-rsyncd executables
- expose the sd-notify feature toggle on the oc-rsyncd binary crate
- update packaging templates to reference the oc-rsyncd binary name in the systemd unit and default environment file

## Testing
- not run (packaging changes only)

------