### PR TITLE
Align oc-rsync packaging with oc-specific config paths

### DIFF
--- a/bin/oc-rsync/Cargo.toml
+++ b/bin/oc-rsync/Cargo.toml
@@ -25,10 +25,10 @@ assets = [
     ["../../target/release/oc-rsync", "/usr/bin/oc-rsync", "755"],
     ["../../target/release/oc-rsyncd", "/usr/bin/oc-rsyncd", "755"],
     ["../../packaging/systemd/rsyncd.service", "/lib/systemd/system/rsyncd.service", "644"],
-    ["../../packaging/etc/rsyncd.conf", "/etc/rsyncd.conf", "644"],
-    ["../../packaging/default/rsyncd", "/etc/default/rsyncd", "644"],
+    ["../../packaging/etc/oc-rsyncd/oc-rsyncd.conf", "/etc/oc-rsyncd/oc-rsyncd.conf", "644"],
+    ["../../packaging/default/oc-rsyncd", "/etc/default/oc-rsyncd", "644"],
 ]
-conf-files = ["etc/rsyncd.conf", "etc/default/rsyncd"]
+conf-files = ["etc/oc-rsyncd/oc-rsyncd.conf", "etc/default/oc-rsyncd"]
 
 [package.metadata.rpm]
 package = "oc-rsync"
@@ -38,6 +38,6 @@ assets = [
     { path = "../../target/release/oc-rsync", dest = "/usr/bin/oc-rsync", mode = "0755" },
     { path = "../../target/release/oc-rsyncd", dest = "/usr/bin/oc-rsyncd", mode = "0755" },
     { path = "../../packaging/systemd/rsyncd.service", dest = "/usr/lib/systemd/system/rsyncd.service", mode = "0644" },
-    { path = "../../packaging/etc/rsyncd.conf", dest = "/etc/rsyncd.conf", mode = "0644", config = true },
-    { path = "../../packaging/default/rsyncd", dest = "/etc/default/rsyncd", mode = "0644", config = true },
+    { path = "../../packaging/etc/oc-rsyncd/oc-rsyncd.conf", dest = "/etc/oc-rsyncd/oc-rsyncd.conf", mode = "0644", config = true },
+    { path = "../../packaging/default/oc-rsyncd", dest = "/etc/default/oc-rsyncd", mode = "0644", config = true },
 ]

--- a/bin/rsync/Cargo.toml
+++ b/bin/rsync/Cargo.toml
@@ -25,10 +25,10 @@ assets = [
     ["../../target/release/rsync", "/usr/bin/rsync", "755"],
     ["../../target/release/rsyncd", "/usr/bin/rsyncd", "755"],
     ["../../packaging/systemd/rsyncd.service", "/lib/systemd/system/rsyncd.service", "644"],
-    ["../../packaging/etc/rsyncd.conf", "/etc/rsyncd.conf", "644"],
-    ["../../packaging/default/rsyncd", "/etc/default/rsyncd", "644"],
+    ["../../packaging/etc/oc-rsyncd/oc-rsyncd.conf", "/etc/oc-rsyncd/oc-rsyncd.conf", "644"],
+    ["../../packaging/default/oc-rsyncd", "/etc/default/oc-rsyncd", "644"],
 ]
-conf-files = ["etc/rsyncd.conf", "etc/default/rsyncd"]
+conf-files = ["etc/oc-rsyncd/oc-rsyncd.conf", "etc/default/oc-rsyncd"]
 
 [package.metadata.rpm]
 package = "rsync"
@@ -38,6 +38,6 @@ assets = [
     { path = "../../target/release/rsync", dest = "/usr/bin/rsync", mode = "0755" },
     { path = "../../target/release/rsyncd", dest = "/usr/bin/rsyncd", mode = "0755" },
     { path = "../../packaging/systemd/rsyncd.service", dest = "/usr/lib/systemd/system/rsyncd.service", mode = "0644" },
-    { path = "../../packaging/etc/rsyncd.conf", dest = "/etc/rsyncd.conf", mode = "0644", config = true },
-    { path = "../../packaging/default/rsyncd", dest = "/etc/default/rsyncd", mode = "0644", config = true },
+    { path = "../../packaging/etc/oc-rsyncd/oc-rsyncd.conf", dest = "/etc/oc-rsyncd/oc-rsyncd.conf", mode = "0644", config = true },
+    { path = "../../packaging/default/oc-rsyncd", dest = "/etc/default/oc-rsyncd", mode = "0644", config = true },
 ]

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -238,6 +238,10 @@ const MODULE_LOCK_ERROR_PAYLOAD: &str =
     "@ERROR: failed to update module connection lock; please try again later";
 /// Digest algorithms advertised during the legacy daemon greeting.
 const LEGACY_HANDSHAKE_DIGESTS: &[&str] = &["sha512", "sha256", "sha1", "md5", "md4"];
+#[cfg(test)]
+const DEFAULT_CONFIG_PATH: &str = "/etc/oc-rsyncd/oc-rsyncd.conf";
+#[cfg(test)]
+const DEFAULT_SECRETS_PATH: &str = "/etc/oc-rsyncd/oc-rsyncd.secrets";
 
 /// Deterministic help text describing the currently supported daemon surface.
 const HELP_TEXT: &str = concat!(
@@ -256,7 +260,7 @@ const HELP_TEXT: &str = concat!(
     "  --port PORT         Listen on the supplied TCP port (default 873).\n",
     "  --once              Accept a single connection and exit.\n",
     "  --max-sessions N    Accept N connections before exiting (N > 0).\n",
-    "  --config FILE      Load module definitions from FILE (rsyncd.conf subset).\n",
+    "  --config FILE      Load module definitions from FILE (packages install /etc/oc-rsyncd/oc-rsyncd.conf).\n",
     "  --module SPEC      Register an in-memory module (NAME=PATH[,COMMENT]).\n",
     "  --motd-file FILE   Append MOTD lines from FILE before module listings.\n",
     "  --motd-line TEXT   Append TEXT as an additional MOTD line.\n",
@@ -5311,7 +5315,7 @@ mod tests {
             OsStr::new("rsyncd"),
             OsStr::new("--delegate-system-rsync"),
             OsStr::new("--config"),
-            OsStr::new("/etc/rsyncd.conf"),
+            OsStr::new(DEFAULT_CONFIG_PATH),
         ]);
 
         assert_eq!(code, 0);
@@ -5319,7 +5323,7 @@ mod tests {
         let recorded = fs::read_to_string(&log_path).expect("read invocation log");
         assert!(recorded.contains("--daemon"));
         assert!(recorded.contains("--no-detach"));
-        assert!(recorded.contains("--config /etc/rsyncd.conf"));
+        assert!(recorded.contains(&format!("--config {}", DEFAULT_CONFIG_PATH)));
     }
 
     #[cfg(unix)]
@@ -5378,14 +5382,14 @@ mod tests {
         let (code, _stdout, stderr) = run_with_args([
             OsStr::new("rsyncd"),
             OsStr::new("--config"),
-            OsStr::new("/etc/rsyncd.conf"),
+            OsStr::new(DEFAULT_CONFIG_PATH),
         ]);
 
         assert_eq!(code, 0);
         assert!(stderr.is_empty());
         let recorded = fs::read_to_string(&log_path).expect("read invocation log");
         assert!(recorded.contains("--daemon"));
-        assert!(recorded.contains("--config /etc/rsyncd.conf"));
+        assert!(recorded.contains(&format!("--config {}", DEFAULT_CONFIG_PATH)));
     }
 
     #[cfg(unix)]
@@ -5589,14 +5593,14 @@ mod tests {
         let (code, _stdout, stderr) = run_with_args([
             OsStr::new("rsyncd"),
             OsStr::new("--config"),
-            OsStr::new("/etc/rsyncd.conf"),
+            OsStr::new(DEFAULT_CONFIG_PATH),
         ]);
 
         assert_eq!(code, 0);
         assert!(stderr.is_empty());
         let recorded = fs::read_to_string(&log_path).expect("read invocation log");
         assert!(recorded.contains("--daemon"));
-        assert!(recorded.contains("--config /etc/rsyncd.conf"));
+        assert!(recorded.contains(&format!("--config {}", DEFAULT_CONFIG_PATH)));
     }
 
     #[cfg(unix)]
@@ -5613,14 +5617,14 @@ mod tests {
         let (code, _stdout, stderr) = run_with_args([
             OsStr::new("rsyncd"),
             OsStr::new("--config"),
-            OsStr::new("/etc/rsyncd.conf"),
+            OsStr::new(DEFAULT_CONFIG_PATH),
         ]);
 
         assert_eq!(code, 0);
         assert!(stderr.is_empty());
         let recorded = fs::read_to_string(&log_path).expect("read invocation log");
         assert!(recorded.contains("--daemon"));
-        assert!(recorded.contains("--config /etc/rsyncd.conf"));
+        assert!(recorded.contains(&format!("--config {}", DEFAULT_CONFIG_PATH)));
     }
 
     #[cfg(unix)]
@@ -5821,7 +5825,7 @@ mod tests {
         let options = RuntimeOptions::parse(&[
             OsString::from("--module"),
             OsString::from(
-                "mirror=./data;use-chroot=no;read-only=yes;list=no;numeric-ids=yes;hosts-allow=192.0.2.0/24;auth-users=alice,bob;secrets-file=/etc/rsyncd.secrets;bwlimit=1m;refuse-options=compress;uid=1000;gid=2000;timeout=600;max-connections=5",
+                "mirror=./data;use-chroot=no;read-only=yes;list=no;numeric-ids=yes;hosts-allow=192.0.2.0/24;auth-users=alice,bob;secrets-file=/etc/oc-rsyncd/oc-rsyncd.secrets;bwlimit=1m;refuse-options=compress;uid=1000;gid=2000;timeout=600;max-connections=5",
             ),
         ])
         .expect("parse module with inline options");
@@ -5847,7 +5851,7 @@ mod tests {
             module
                 .secrets_file()
                 .map(|path| path.to_string_lossy().into_owned()),
-            Some(String::from("/etc/rsyncd.secrets"))
+            Some(String::from(DEFAULT_SECRETS_PATH))
         );
         assert_eq!(
             module.bandwidth_limit().map(NonZeroU64::get),

--- a/packaging/default/oc-rsyncd
+++ b/packaging/default/oc-rsyncd
@@ -4,5 +4,5 @@
 # daemon or to point at an alternate configuration file. Values are consumed
 # by the systemd unit installed with the oc-rsync packages.
 #
-# RSYNCD_CONFIG=/etc/rsyncd.conf
+# RSYNCD_CONFIG=/etc/oc-rsyncd/oc-rsyncd.conf
 # RSYNCD_ARGS="--max-sessions 16"

--- a/packaging/etc/oc-rsyncd/oc-rsyncd.conf
+++ b/packaging/etc/oc-rsyncd/oc-rsyncd.conf
@@ -1,9 +1,13 @@
-# rsyncd example configuration
+# oc-rsyncd example configuration
 #
 # The daemon mirrors upstream rsyncd.conf semantics. Uncomment and adjust the
 # directives below to enable modules. By default no modules are exported.
 # See rsyncd.conf(5) for comprehensive documentation of the available
 # directives and security considerations.
+#
+# This file is installed to /etc/oc-rsyncd/oc-rsyncd.conf by the oc-rsync
+# packages. Secrets should be stored alongside it as
+# /etc/oc-rsyncd/oc-rsyncd.secrets with permissions 0600.
 
 # Global settings
 # uid = nobody
@@ -19,6 +23,6 @@
 #     read only = yes
 #     list = yes
 #     auth users = backup
-#     secrets file = /etc/rsyncd.secrets
+#     secrets file = /etc/oc-rsyncd/oc-rsyncd.secrets
 #     hosts allow = 192.0.2.0/24,2001:db8::/32
 #     refuse options = delete

--- a/packaging/systemd/rsyncd.service
+++ b/packaging/systemd/rsyncd.service
@@ -5,8 +5,8 @@ After=network.target
 
 [Service]
 Type=simple
-Environment="RSYNCD_CONFIG=/etc/rsyncd.conf"
-EnvironmentFile=-/etc/default/rsyncd
+Environment="RSYNCD_CONFIG=/etc/oc-rsyncd/oc-rsyncd.conf"
+EnvironmentFile=-/etc/default/oc-rsyncd
 ExecStart=/usr/bin/oc-rsyncd --config ${RSYNCD_CONFIG} $RSYNCD_ARGS
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=on-failure


### PR DESCRIPTION
## Summary
- install the packaged oc-rsyncd configuration and defaults under /etc/oc-rsyncd
- update daemon help text and tests to reference the oc-rsyncd config and secrets locations
- refresh the sample configuration and systemd unit to match the new paths

## Testing
- cargo test -p rsync-daemon

------