### PR TITLE
Remove legacy binary crates from lockfile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -597,13 +597,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rsync-bin"
-version = "0.0.0"
-dependencies = [
- "rsync-cli",
-]
-
-[[package]]
 name = "rsync-checksums"
 version = "0.0.0"
 dependencies = [
@@ -741,13 +734,6 @@ name = "rsync-walk"
 version = "0.0.0"
 dependencies = [
  "tempfile",
-]
-
-[[package]]
-name = "rsyncd-bin"
-version = "0.0.0"
-dependencies = [
- "rsync-daemon",
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- remove the obsolete `rsync-bin` and `rsyncd-bin` package entries from Cargo.lock so the lockfile matches the current workspace layout

## Testing
- cargo check

------