### PR TITLE
Centralize oc branding constants and reuse in daemon

### DIFF
--- a/crates/core/README.md
+++ b/crates/core/README.md
@@ -13,6 +13,8 @@ at the Rust implementation.
   for capturing repo-relative source locations. Higher layers construct
   diagnostics through this API so trailer roles and version suffixes remain
   consistent.
+- [`branding`](src/branding.rs) centralises branded program names alongside the
+  default configuration and secrets paths installed by the packaging tooling.
 - [`version`](src/version.rs) holds the canonical `3.4.1-rust` identifier and the
   compiled feature set consumed by the CLI when rendering `--version` output.
 - [`client`](src/client.rs) defines configuration builders and entry points used

--- a/crates/core/src/branding.rs
+++ b/crates/core/src/branding.rs
@@ -1,0 +1,79 @@
+#![deny(unsafe_code)]
+
+//! Branding constants shared across the workspace.
+//!
+//! The `branding` module centralises the branded program names and filesystem
+//! locations that the workspace exposes publicly. Higher-level crates rely on
+//! these constants when rendering banners or searching for configuration files
+//! so that packaging, documentation, and runtime behaviour remain aligned. By
+//! funnelling branding details through this module we keep string literals out
+//! of business logic and make it trivial to update paths or names in one place.
+//!
+//! # Examples
+//!
+//! Retrieve the canonical daemon configuration and secrets paths that
+//! `oc-rsyncd` uses when launched without explicit overrides:
+//!
+//! ```rust
+//! use std::path::Path;
+//!
+//! let config = rsync_core::branding::oc_daemon_config_path();
+//! let secrets = rsync_core::branding::oc_daemon_secrets_path();
+//!
+//! assert_eq!(config, Path::new("/etc/oc-rsyncd/oc-rsyncd.conf"));
+//! assert_eq!(secrets, Path::new("/etc/oc-rsyncd/oc-rsyncd.secrets"));
+//! ```
+
+use std::path::Path;
+
+/// Canonical binary name exposed by the client wrapper packaged as `oc-rsync`.
+#[doc(alias = "oc-rsync")]
+pub const OC_CLIENT_PROGRAM_NAME: &str = "oc-rsync";
+
+/// Canonical binary name exposed by the daemon wrapper packaged as `oc-rsyncd`.
+#[doc(alias = "oc-rsyncd")]
+pub const OC_DAEMON_PROGRAM_NAME: &str = "oc-rsyncd";
+
+/// Directory that packages install for daemon configuration snippets.
+#[doc(alias = "/etc/oc-rsyncd")]
+pub const OC_DAEMON_CONFIG_DIR: &str = "/etc/oc-rsyncd";
+
+/// Default configuration file path consumed by the daemon when no override is provided.
+#[doc(alias = "/etc/oc-rsyncd/oc-rsyncd.conf")]
+pub const OC_DAEMON_CONFIG_PATH: &str = "/etc/oc-rsyncd/oc-rsyncd.conf";
+
+/// Default secrets file path consumed by the daemon when no override is provided.
+#[doc(alias = "/etc/oc-rsyncd/oc-rsyncd.secrets")]
+pub const OC_DAEMON_SECRETS_PATH: &str = "/etc/oc-rsyncd/oc-rsyncd.secrets";
+
+/// Legacy configuration file path supported for backwards compatibility with upstream deployments.
+#[doc(alias = "/etc/rsyncd.conf")]
+pub const LEGACY_DAEMON_CONFIG_PATH: &str = "/etc/rsyncd.conf";
+
+/// Legacy secrets file path supported for backwards compatibility with upstream deployments.
+#[doc(alias = "/etc/rsyncd.secrets")]
+pub const LEGACY_DAEMON_SECRETS_PATH: &str = "/etc/rsyncd.secrets";
+
+/// Returns the canonical configuration path used by `oc-rsyncd`.
+#[must_use]
+pub fn oc_daemon_config_path() -> &'static Path {
+    Path::new(OC_DAEMON_CONFIG_PATH)
+}
+
+/// Returns the canonical secrets path used by `oc-rsyncd`.
+#[must_use]
+pub fn oc_daemon_secrets_path() -> &'static Path {
+    Path::new(OC_DAEMON_SECRETS_PATH)
+}
+
+/// Returns the legacy configuration path recognised for compatibility with upstream deployments.
+#[must_use]
+pub fn legacy_daemon_config_path() -> &'static Path {
+    Path::new(LEGACY_DAEMON_CONFIG_PATH)
+}
+
+/// Returns the legacy secrets path recognised for compatibility with upstream deployments.
+#[must_use]
+pub fn legacy_daemon_secrets_path() -> &'static Path {
+    Path::new(LEGACY_DAEMON_SECRETS_PATH)
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -6,6 +6,8 @@
 
 /// Bandwidth parsing utilities shared by CLI and daemon entry points.
 pub mod bandwidth;
+/// Branding constants shared across binaries and packaging layers.
+pub mod branding;
 /// Client orchestration helpers consumed by the CLI binary.
 pub mod client;
 /// Helpers for interpreting fallback environment overrides shared across crates.

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -200,6 +200,7 @@ use rsync_core::{
         BandwidthLimitComponents, BandwidthLimiter, BandwidthParseError, LimiterChange,
         apply_effective_limit, parse_bandwidth_limit,
     },
+    branding,
     fallback::fallback_override,
     message::{Message, Role},
     rsync_error, rsync_info, rsync_warning,
@@ -244,10 +245,10 @@ const MODULE_LOCK_ERROR_PAYLOAD: &str =
     "@ERROR: failed to update module connection lock; please try again later";
 /// Digest algorithms advertised during the legacy daemon greeting.
 const LEGACY_HANDSHAKE_DIGESTS: &[&str] = &["sha512", "sha256", "sha1", "md5", "md4"];
-const DEFAULT_CONFIG_PATH: &str = "/etc/oc-rsyncd/oc-rsyncd.conf";
-const LEGACY_CONFIG_PATH: &str = "/etc/rsyncd.conf";
+const DEFAULT_CONFIG_PATH: &str = branding::OC_DAEMON_CONFIG_PATH;
+const LEGACY_CONFIG_PATH: &str = branding::LEGACY_DAEMON_CONFIG_PATH;
 #[cfg(test)]
-const DEFAULT_SECRETS_PATH: &str = "/etc/oc-rsyncd/oc-rsyncd.secrets";
+const DEFAULT_SECRETS_PATH: &str = branding::OC_DAEMON_SECRETS_PATH;
 
 /// Deterministic help text describing the currently supported daemon surface.
 const HELP_TEXT: &str = concat!(
@@ -266,7 +267,9 @@ const HELP_TEXT: &str = concat!(
     "  --port PORT         Listen on the supplied TCP port (default 873).\n",
     "  --once              Accept a single connection and exit.\n",
     "  --max-sessions N    Accept N connections before exiting (N > 0).\n",
-    "  --config FILE      Load module definitions from FILE (packages install /etc/oc-rsyncd/oc-rsyncd.conf).\n",
+    "  --config FILE      Load module definitions from FILE (packages install ",
+    DEFAULT_CONFIG_PATH,
+    ").\n",
     "  --module SPEC      Register an in-memory module (NAME=PATH[,COMMENT]).\n",
     "  --motd-file FILE   Append MOTD lines from FILE before module listings.\n",
     "  --motd-line TEXT   Append TEXT as an additional MOTD line.\n",


### PR DESCRIPTION
## Summary
- add a `rsync-core::branding` module that centralizes oc-rsync program names and default configuration paths
- document the new module in the core crate overview and expose it from the public API
- switch the daemon to pull its default config and secrets paths from the shared branding constants, keeping help text in sync

## Testing
- cargo test -p rsync-core

------