### PR TITLE
Centralize program name constants

### DIFF
--- a/crates/core/src/branding.rs
+++ b/crates/core/src/branding.rs
@@ -26,6 +26,14 @@
 
 use std::path::Path;
 
+/// Canonical program name used by upstream `rsync` releases.
+#[doc(alias = "rsync")]
+pub const UPSTREAM_CLIENT_PROGRAM_NAME: &str = "rsync";
+
+/// Canonical program name used by upstream `rsyncd` daemon releases.
+#[doc(alias = "rsyncd")]
+pub const UPSTREAM_DAEMON_PROGRAM_NAME: &str = "rsyncd";
+
 /// Canonical binary name exposed by the client wrapper packaged as `oc-rsync`.
 #[doc(alias = "oc-rsync")]
 pub const OC_CLIENT_PROGRAM_NAME: &str = "oc-rsync";
@@ -53,6 +61,30 @@ pub const LEGACY_DAEMON_CONFIG_PATH: &str = "/etc/rsyncd.conf";
 /// Legacy secrets file path supported for backwards compatibility with upstream deployments.
 #[doc(alias = "/etc/rsyncd.secrets")]
 pub const LEGACY_DAEMON_SECRETS_PATH: &str = "/etc/rsyncd.secrets";
+
+/// Returns the canonical upstream client program name (`rsync`).
+#[must_use]
+pub const fn upstream_client_program_name() -> &'static str {
+    UPSTREAM_CLIENT_PROGRAM_NAME
+}
+
+/// Returns the canonical upstream daemon program name (`rsyncd`).
+#[must_use]
+pub const fn upstream_daemon_program_name() -> &'static str {
+    UPSTREAM_DAEMON_PROGRAM_NAME
+}
+
+/// Returns the branded client program name (`oc-rsync`).
+#[must_use]
+pub const fn oc_client_program_name() -> &'static str {
+    OC_CLIENT_PROGRAM_NAME
+}
+
+/// Returns the branded daemon program name (`oc-rsyncd`).
+#[must_use]
+pub const fn oc_daemon_program_name() -> &'static str {
+    OC_DAEMON_PROGRAM_NAME
+}
 
 /// Returns the canonical configuration path used by `oc-rsyncd`.
 #[must_use]

--- a/crates/core/src/version.rs
+++ b/crates/core/src/version.rs
@@ -66,6 +66,7 @@
 //!   [`VersionInfoReport`] to mirror upstream `--version` capability listings
 //!   while advertising the Rust-branded binary name.
 
+use crate::branding;
 use core::{
     fmt::{self, Write as FmtWrite},
     iter::{FromIterator, FusedIterator},
@@ -120,16 +121,16 @@ pub const COMPILED_FEATURE_BITMAP: u8 = {
 };
 
 /// Program name rendered by the `rsync` client when displaying version banners.
-pub const PROGRAM_NAME: &str = "rsync";
+pub const PROGRAM_NAME: &str = branding::UPSTREAM_CLIENT_PROGRAM_NAME;
 
 /// Program name rendered by the `rsyncd` daemon when displaying version banners.
-pub const DAEMON_PROGRAM_NAME: &str = "rsyncd";
+pub const DAEMON_PROGRAM_NAME: &str = branding::UPSTREAM_DAEMON_PROGRAM_NAME;
 
 /// Program name used by the standalone `oc-rsync` client wrapper.
-pub const OC_PROGRAM_NAME: &str = "oc-rsync";
+pub const OC_PROGRAM_NAME: &str = branding::OC_CLIENT_PROGRAM_NAME;
 
 /// Program name used by the standalone `oc-rsyncd` daemon wrapper.
-pub const OC_DAEMON_PROGRAM_NAME: &str = "oc-rsyncd";
+pub const OC_DAEMON_PROGRAM_NAME: &str = branding::OC_DAEMON_PROGRAM_NAME;
 
 /// First copyright year advertised by the Rust implementation.
 pub const COPYRIGHT_START_YEAR: &str = "2025";


### PR DESCRIPTION
## Summary
- add upstream and oc-branded program name constants and helpers to the core branding facade
- reuse the branding constants inside the version metadata module to prevent divergent program strings

## Testing
- cargo test -p rsync-core branding::

------