### PR TITLE
Fix branding helpers for canonical names

### DIFF
--- a/crates/core/src/branding.rs
+++ b/crates/core/src/branding.rs
@@ -78,34 +78,16 @@ pub const fn upstream_daemon_program_name() -> &'static str {
     UPSTREAM_DAEMON_PROGRAM_NAME
 }
 
-/// Returns the branded client program name (`oc-rsync`).
-#[must_use]
-pub const fn oc_client_program_name() -> &'static str {
-    OC_CLIENT_PROGRAM_NAME
-}
-
-/// Returns the branded daemon program name (`oc-rsyncd`).
-#[must_use]
-pub const fn oc_daemon_program_name() -> &'static str {
-    OC_DAEMON_PROGRAM_NAME
-}
-
-/// Returns the canonical configuration path used by `oc-rsyncd`.
-#[must_use]
-pub fn oc_daemon_config_path() -> &'static Path {
-    Path::new(OC_DAEMON_CONFIG_PATH)
-}
-
 /// Returns the canonical client program name for upstream-compatible binaries.
 #[must_use]
 pub const fn client_program_name() -> &'static str {
-    CLIENT_PROGRAM_NAME
+    upstream_client_program_name()
 }
 
 /// Returns the canonical daemon program name for upstream-compatible binaries.
 #[must_use]
 pub const fn daemon_program_name() -> &'static str {
-    DAEMON_PROGRAM_NAME
+    upstream_daemon_program_name()
 }
 
 /// Returns the branded client program name exposed as `oc-rsync`.
@@ -118,6 +100,12 @@ pub const fn oc_client_program_name() -> &'static str {
 #[must_use]
 pub const fn oc_daemon_program_name() -> &'static str {
     OC_DAEMON_PROGRAM_NAME
+}
+
+/// Returns the canonical configuration path used by `oc-rsyncd`.
+#[must_use]
+pub fn oc_daemon_config_path() -> &'static Path {
+    Path::new(OC_DAEMON_CONFIG_PATH)
 }
 
 /// Returns the canonical secrets path used by `oc-rsyncd`.
@@ -144,8 +132,8 @@ mod tests {
 
     #[test]
     fn program_names_are_consistent() {
-        assert_eq!(client_program_name(), CLIENT_PROGRAM_NAME);
-        assert_eq!(daemon_program_name(), DAEMON_PROGRAM_NAME);
+        assert_eq!(client_program_name(), upstream_client_program_name());
+        assert_eq!(daemon_program_name(), upstream_daemon_program_name());
         assert_eq!(oc_client_program_name(), OC_CLIENT_PROGRAM_NAME);
         assert_eq!(oc_daemon_program_name(), OC_DAEMON_PROGRAM_NAME);
     }

--- a/crates/core/src/version.rs
+++ b/crates/core/src/version.rs
@@ -349,25 +349,25 @@ impl Default for VersionMetadata {
 #[doc(alias = "--version")]
 #[must_use]
 pub const fn version_metadata() -> VersionMetadata {
-    version_metadata_for_program(client_program_name())
+    version_metadata_for_program(branding::client_program_name())
 }
 
 /// Returns metadata configured for the upstream-compatible `rsync` daemon banner.
 #[must_use]
 pub const fn daemon_version_metadata() -> VersionMetadata {
-    version_metadata_for_program(daemon_program_name())
+    version_metadata_for_program(branding::daemon_program_name())
 }
 
 /// Returns metadata configured for the branded `oc-rsync` client banner.
 #[must_use]
 pub const fn oc_version_metadata() -> VersionMetadata {
-    version_metadata_for_program(oc_client_program_name())
+    version_metadata_for_program(branding::oc_client_program_name())
 }
 
 /// Returns metadata configured for the branded `oc-rsyncd` daemon banner.
 #[must_use]
 pub const fn oc_daemon_version_metadata() -> VersionMetadata {
-    version_metadata_for_program(oc_daemon_program_name())
+    version_metadata_for_program(branding::oc_daemon_program_name())
 }
 
 /// Returns version metadata that renders a banner for the supplied program name.


### PR DESCRIPTION
## Summary
- ensure the core branding facade exposes upstream program names via the canonical helpers without duplicate functions
- restore the branded configuration path helpers used by oc-rsyncd
- have the version metadata accessors delegate to the branding module for consistency

## Testing
- cargo test -p rsync-core branding -- --nocapture

------