### PR TITLE
Centralize oc branding profiles

### DIFF
--- a/crates/core/src/branding.rs
+++ b/crates/core/src/branding.rs
@@ -30,6 +30,91 @@
 
 use std::path::Path;
 
+/// Describes the public-facing identity used by a binary distribution.
+///
+/// The structure captures the canonical client and daemon program names
+/// together with the configuration and secrets paths that ship with the
+/// distribution. Higher layers select the appropriate [`BrandProfile`] to
+/// render banners, locate configuration files, or display diagnostic
+/// messages without duplicating string literals across the codebase. The
+/// profiles are intentionally lightweight and `Copy` so they can be used in
+/// constant contexts such as rustdoc examples and compile-time assertions.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct BrandProfile {
+    client_program_name: &'static str,
+    daemon_program_name: &'static str,
+    daemon_config_path: &'static str,
+    daemon_secrets_path: &'static str,
+}
+
+impl BrandProfile {
+    /// Creates a new [`BrandProfile`] describing a branded distribution.
+    #[must_use]
+    pub const fn new(
+        client_program_name: &'static str,
+        daemon_program_name: &'static str,
+        daemon_config_path: &'static str,
+        daemon_secrets_path: &'static str,
+    ) -> Self {
+        Self {
+            client_program_name,
+            daemon_program_name,
+            daemon_config_path,
+            daemon_secrets_path,
+        }
+    }
+
+    /// Returns the client program name associated with the profile.
+    #[must_use]
+    pub const fn client_program_name(&self) -> &'static str {
+        self.client_program_name
+    }
+
+    /// Returns the daemon program name associated with the profile.
+    #[must_use]
+    pub const fn daemon_program_name(&self) -> &'static str {
+        self.daemon_program_name
+    }
+
+    /// Returns the daemon configuration path as a string slice.
+    #[must_use]
+    pub const fn daemon_config_path_str(&self) -> &'static str {
+        self.daemon_config_path
+    }
+
+    /// Returns the daemon secrets path as a string slice.
+    #[must_use]
+    pub const fn daemon_secrets_path_str(&self) -> &'static str {
+        self.daemon_secrets_path
+    }
+
+    /// Returns the daemon configuration path as a [`Path`].
+    #[must_use]
+    pub fn daemon_config_path(&self) -> &'static Path {
+        Path::new(self.daemon_config_path)
+    }
+
+    /// Returns the daemon secrets path as a [`Path`].
+    #[must_use]
+    pub fn daemon_secrets_path(&self) -> &'static Path {
+        Path::new(self.daemon_secrets_path)
+    }
+}
+
+const UPSTREAM_PROFILE: BrandProfile = BrandProfile::new(
+    UPSTREAM_CLIENT_PROGRAM_NAME,
+    UPSTREAM_DAEMON_PROGRAM_NAME,
+    LEGACY_DAEMON_CONFIG_PATH,
+    LEGACY_DAEMON_SECRETS_PATH,
+);
+
+const OC_PROFILE: BrandProfile = BrandProfile::new(
+    OC_CLIENT_PROGRAM_NAME,
+    OC_DAEMON_PROGRAM_NAME,
+    OC_DAEMON_CONFIG_PATH,
+    OC_DAEMON_SECRETS_PATH,
+);
+
 /// Canonical program name used by upstream `rsync` releases.
 #[doc(alias = "rsync")]
 pub const UPSTREAM_CLIENT_PROGRAM_NAME: &str = "rsync";
@@ -69,73 +154,85 @@ pub const LEGACY_DAEMON_SECRETS_PATH: &str = "/etc/rsyncd.secrets";
 /// Returns the canonical upstream client program name (`rsync`).
 #[must_use]
 pub const fn upstream_client_program_name() -> &'static str {
-    UPSTREAM_CLIENT_PROGRAM_NAME
+    UPSTREAM_PROFILE.client_program_name()
 }
 
 /// Returns the canonical upstream daemon program name (`rsyncd`).
 #[must_use]
 pub const fn upstream_daemon_program_name() -> &'static str {
-    UPSTREAM_DAEMON_PROGRAM_NAME
+    UPSTREAM_PROFILE.daemon_program_name()
 }
 
 /// Returns the branded client program name (`oc-rsync`).
 #[must_use]
 pub const fn oc_client_program_name() -> &'static str {
-    OC_CLIENT_PROGRAM_NAME
+    OC_PROFILE.client_program_name()
 }
 
 /// Returns the branded daemon program name (`oc-rsyncd`).
 #[must_use]
 pub const fn oc_daemon_program_name() -> &'static str {
-    OC_DAEMON_PROGRAM_NAME
+    OC_PROFILE.daemon_program_name()
 }
 
 /// Returns the canonical configuration path used by `oc-rsyncd`.
 #[must_use]
 pub fn oc_daemon_config_path() -> &'static Path {
-    Path::new(OC_DAEMON_CONFIG_PATH)
+    OC_PROFILE.daemon_config_path()
 }
 
 /// Returns the canonical client program name for upstream-compatible binaries.
 #[must_use]
 pub const fn client_program_name() -> &'static str {
-    CLIENT_PROGRAM_NAME
+    upstream_client_program_name()
 }
 
 /// Returns the canonical daemon program name for upstream-compatible binaries.
 #[must_use]
 pub const fn daemon_program_name() -> &'static str {
-    DAEMON_PROGRAM_NAME
-}
-
-/// Returns the branded client program name exposed as `oc-rsync`.
-#[must_use]
-pub const fn oc_client_program_name() -> &'static str {
-    OC_CLIENT_PROGRAM_NAME
-}
-
-/// Returns the branded daemon program name exposed as `oc-rsyncd`.
-#[must_use]
-pub const fn oc_daemon_program_name() -> &'static str {
-    OC_DAEMON_PROGRAM_NAME
+    upstream_daemon_program_name()
 }
 
 /// Returns the canonical secrets path used by `oc-rsyncd`.
 #[must_use]
 pub fn oc_daemon_secrets_path() -> &'static Path {
-    Path::new(OC_DAEMON_SECRETS_PATH)
+    OC_PROFILE.daemon_secrets_path()
 }
 
 /// Returns the legacy configuration path recognised for compatibility with upstream deployments.
 #[must_use]
 pub fn legacy_daemon_config_path() -> &'static Path {
-    Path::new(LEGACY_DAEMON_CONFIG_PATH)
+    UPSTREAM_PROFILE.daemon_config_path()
 }
 
 /// Returns the legacy secrets path recognised for compatibility with upstream deployments.
 #[must_use]
 pub fn legacy_daemon_secrets_path() -> &'static Path {
-    Path::new(LEGACY_DAEMON_SECRETS_PATH)
+    UPSTREAM_PROFILE.daemon_secrets_path()
+}
+
+/// Returns the upstream-compatible branding profile used by compatibility wrappers.
+#[must_use]
+pub const fn upstream_profile() -> BrandProfile {
+    UPSTREAM_PROFILE
+}
+
+/// Returns the oc-branded profile used by the canonical binaries.
+///
+/// # Examples
+///
+/// ```
+/// use rsync_core::branding;
+///
+/// let profile = branding::oc_profile();
+/// assert_eq!(profile.client_program_name(), "oc-rsync");
+/// assert_eq!(profile.daemon_program_name(), "oc-rsyncd");
+/// assert_eq!(profile.daemon_config_path(), branding::oc_daemon_config_path());
+/// assert_eq!(profile.daemon_secrets_path(), branding::oc_daemon_secrets_path());
+/// ```
+#[must_use]
+pub const fn oc_profile() -> BrandProfile {
+    OC_PROFILE
 }
 
 #[cfg(test)]
@@ -144,10 +241,13 @@ mod tests {
 
     #[test]
     fn program_names_are_consistent() {
-        assert_eq!(client_program_name(), CLIENT_PROGRAM_NAME);
-        assert_eq!(daemon_program_name(), DAEMON_PROGRAM_NAME);
-        assert_eq!(oc_client_program_name(), OC_CLIENT_PROGRAM_NAME);
-        assert_eq!(oc_daemon_program_name(), OC_DAEMON_PROGRAM_NAME);
+        let upstream = upstream_profile();
+        assert_eq!(upstream.client_program_name(), UPSTREAM_CLIENT_PROGRAM_NAME);
+        assert_eq!(upstream.daemon_program_name(), UPSTREAM_DAEMON_PROGRAM_NAME);
+
+        let oc = oc_profile();
+        assert_eq!(oc.client_program_name(), OC_CLIENT_PROGRAM_NAME);
+        assert_eq!(oc.daemon_program_name(), OC_DAEMON_PROGRAM_NAME);
     }
 
     #[test]
@@ -161,6 +261,30 @@ mod tests {
         assert_eq!(
             legacy_daemon_secrets_path(),
             Path::new(LEGACY_DAEMON_SECRETS_PATH)
+        );
+    }
+
+    #[test]
+    fn profile_helpers_align_with_functions() {
+        assert_eq!(
+            upstream_profile().client_program_name(),
+            upstream_client_program_name()
+        );
+        assert_eq!(
+            upstream_profile().daemon_program_name(),
+            upstream_daemon_program_name()
+        );
+        assert_eq!(oc_profile().client_program_name(), oc_client_program_name());
+        assert_eq!(oc_profile().daemon_program_name(), oc_daemon_program_name());
+        assert_eq!(oc_profile().daemon_config_path(), oc_daemon_config_path());
+        assert_eq!(oc_profile().daemon_secrets_path(), oc_daemon_secrets_path());
+        assert_eq!(
+            upstream_profile().daemon_config_path(),
+            legacy_daemon_config_path()
+        );
+        assert_eq!(
+            upstream_profile().daemon_secrets_path(),
+            legacy_daemon_secrets_path()
         );
     }
 }

--- a/crates/core/src/version.rs
+++ b/crates/core/src/version.rs
@@ -349,25 +349,25 @@ impl Default for VersionMetadata {
 #[doc(alias = "--version")]
 #[must_use]
 pub const fn version_metadata() -> VersionMetadata {
-    version_metadata_for_program(client_program_name())
+    version_metadata_for_program(branding::client_program_name())
 }
 
 /// Returns metadata configured for the upstream-compatible `rsync` daemon banner.
 #[must_use]
 pub const fn daemon_version_metadata() -> VersionMetadata {
-    version_metadata_for_program(daemon_program_name())
+    version_metadata_for_program(branding::daemon_program_name())
 }
 
 /// Returns metadata configured for the branded `oc-rsync` client banner.
 #[must_use]
 pub const fn oc_version_metadata() -> VersionMetadata {
-    version_metadata_for_program(oc_client_program_name())
+    version_metadata_for_program(branding::oc_client_program_name())
 }
 
 /// Returns metadata configured for the branded `oc-rsyncd` daemon banner.
 #[must_use]
 pub const fn oc_daemon_version_metadata() -> VersionMetadata {
-    version_metadata_for_program(oc_daemon_program_name())
+    version_metadata_for_program(branding::oc_daemon_program_name())
 }
 
 /// Returns version metadata that renders a banner for the supplied program name.


### PR DESCRIPTION
## Summary
- add a `BrandProfile` descriptor to keep upstream and oc program names plus config paths in one place
- expose upstream/oc profile helpers with doctested examples and update unit tests to cover the new API
- route version metadata helpers through the branding facade so CLI banners stay aligned with central branding

## Testing
- cargo test -p rsync-core branding::tests

------