### PR TITLE
Fix oc-rsyncd help text generation with branded config path

### DIFF
--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -251,37 +251,6 @@ const LEGACY_CONFIG_PATH: &str = branding::LEGACY_DAEMON_CONFIG_PATH;
 const DEFAULT_SECRETS_PATH: &str = branding::OC_DAEMON_SECRETS_PATH;
 
 /// Deterministic help text describing the currently supported daemon surface.
-const HELP_TEXT: &str = concat!(
-    "rsyncd 3.4.1-rust\n",
-    "https://github.com/oferchen/rsync\n",
-    "\n",
-    "Usage: rsyncd [--help] [--version] [--delegate-system-rsync] [ARGS...]\n",
-    "\n",
-    "Daemon mode is under active development. This build recognises:\n",
-    "  --help        Show this help message and exit.\n",
-    "  --version     Output version information and exit.\n",
-    "  --delegate-system-rsync  Launch the system rsync daemon with the supplied arguments.\n",
-    "  --bind ADDR         Bind to the supplied IPv4/IPv6 address (default 0.0.0.0).\n",
-    "  --ipv4             Restrict the listener to IPv4 sockets.\n",
-    "  --ipv6             Restrict the listener to IPv6 sockets (defaults to :: when no bind address is provided).\n",
-    "  --port PORT         Listen on the supplied TCP port (default 873).\n",
-    "  --once              Accept a single connection and exit.\n",
-    "  --max-sessions N    Accept N connections before exiting (N > 0).\n",
-    "  --config FILE      Load module definitions from FILE (packages install ",
-    DEFAULT_CONFIG_PATH,
-    ").\n",
-    "  --module SPEC      Register an in-memory module (NAME=PATH[,COMMENT]).\n",
-    "  --motd-file FILE   Append MOTD lines from FILE before module listings.\n",
-    "  --motd-line TEXT   Append TEXT as an additional MOTD line.\n",
-    "  --lock-file FILE   Track module connection limits across processes using FILE.\n",
-    "  --pid-file FILE    Write the daemon PID to FILE for process supervision.\n",
-    "  --bwlimit=RATE     Limit per-connection bandwidth in KiB/s (0 = unlimited).\n",
-    "  --no-bwlimit       Remove any per-connection bandwidth limit configured so far.\n",
-    "\n",
-    "The listener accepts legacy @RSYNCD: connections sequentially, reports the\n",
-    "negotiated protocol as 32, lists configured modules for #list requests, and\n",
-    "replies with an @ERROR diagnostic while full module support is implemented.\n",
-);
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct ModuleDefinition {
@@ -2932,7 +2901,38 @@ where
 }
 
 fn render_help() -> String {
-    HELP_TEXT.to_string()
+    format!(
+        concat!(
+            "rsyncd 3.4.1-rust\n",
+            "https://github.com/oferchen/rsync\n",
+            "\n",
+            "Usage: rsyncd [--help] [--version] [--delegate-system-rsync] [ARGS...]\n",
+            "\n",
+            "Daemon mode is under active development. This build recognises:\n",
+            "  --help        Show this help message and exit.\n",
+            "  --version     Output version information and exit.\n",
+            "  --delegate-system-rsync  Launch the system rsync daemon with the supplied arguments.\n",
+            "  --bind ADDR         Bind to the supplied IPv4/IPv6 address (default 0.0.0.0).\n",
+            "  --ipv4             Restrict the listener to IPv4 sockets.\n",
+            "  --ipv6             Restrict the listener to IPv6 sockets (defaults to :: when no bind address is provided).\n",
+            "  --port PORT         Listen on the supplied TCP port (default 873).\n",
+            "  --once              Accept a single connection and exit.\n",
+            "  --max-sessions N    Accept N connections before exiting (N > 0).\n",
+            "  --config FILE      Load module definitions from FILE (packages install {config}).\n",
+            "  --module SPEC      Register an in-memory module (NAME=PATH[,COMMENT]).\n",
+            "  --motd-file FILE   Append MOTD lines from FILE before module listings.\n",
+            "  --motd-line TEXT   Append TEXT as an additional MOTD line.\n",
+            "  --lock-file FILE   Track module connection limits across processes using FILE.\n",
+            "  --pid-file FILE    Write the daemon PID to FILE for process supervision.\n",
+            "  --bwlimit=RATE     Limit per-connection bandwidth in KiB/s (0 = unlimited).\n",
+            "  --no-bwlimit       Remove any per-connection bandwidth limit configured so far.\n",
+            "\n",
+            "The listener accepts legacy @RSYNCD: connections sequentially, reports the\n",
+            "negotiated protocol as 32, lists configured modules for #list requests, and\n",
+            "replies with an @ERROR diagnostic while full module support is implemented.\n",
+        ),
+        config = branding::OC_DAEMON_CONFIG_PATH,
+    )
 }
 
 fn write_message<W: Write>(message: &Message, sink: &mut MessageSink<W>) -> io::Result<()> {


### PR DESCRIPTION
## Summary
- replace the daemon help text constant with a formatted helper
- keep the branded configuration path sourced from rsync_core::branding when rendering help output

## Testing
- cargo test

------