### PR TITLE
Add oc-rsyncd secrets template to packaging

### DIFF
--- a/bin/oc-rsync/Cargo.toml
+++ b/bin/oc-rsync/Cargo.toml
@@ -26,9 +26,14 @@ assets = [
     ["../../target/release/oc-rsyncd", "/usr/bin/oc-rsyncd", "755"],
     ["../../packaging/systemd/oc-rsyncd.service", "/lib/systemd/system/oc-rsyncd.service", "644"],
     ["../../packaging/etc/oc-rsyncd/oc-rsyncd.conf", "/etc/oc-rsyncd/oc-rsyncd.conf", "644"],
+    ["../../packaging/etc/oc-rsyncd/oc-rsyncd.secrets", "/etc/oc-rsyncd/oc-rsyncd.secrets", "600"],
     ["../../packaging/default/oc-rsyncd", "/etc/default/oc-rsyncd", "644"],
 ]
-conf-files = ["etc/oc-rsyncd/oc-rsyncd.conf", "etc/default/oc-rsyncd"]
+conf-files = [
+    "etc/oc-rsyncd/oc-rsyncd.conf",
+    "etc/oc-rsyncd/oc-rsyncd.secrets",
+    "etc/default/oc-rsyncd",
+]
 
 [package.metadata.rpm]
 package = "oc-rsync"
@@ -39,5 +44,6 @@ assets = [
     { path = "../../target/release/oc-rsyncd", dest = "/usr/bin/oc-rsyncd", mode = "0755" },
     { path = "../../packaging/systemd/oc-rsyncd.service", dest = "/usr/lib/systemd/system/oc-rsyncd.service", mode = "0644" },
     { path = "../../packaging/etc/oc-rsyncd/oc-rsyncd.conf", dest = "/etc/oc-rsyncd/oc-rsyncd.conf", mode = "0644", config = true },
+    { path = "../../packaging/etc/oc-rsyncd/oc-rsyncd.secrets", dest = "/etc/oc-rsyncd/oc-rsyncd.secrets", mode = "0600", config = true },
     { path = "../../packaging/default/oc-rsyncd", dest = "/etc/default/oc-rsyncd", mode = "0644", config = true },
 ]

--- a/packaging/etc/oc-rsyncd/oc-rsyncd.secrets
+++ b/packaging/etc/oc-rsyncd/oc-rsyncd.secrets
@@ -1,0 +1,10 @@
+# Example secrets file for oc-rsyncd modules.
+#
+# Lines use the format "username:password" and must be stored with
+# filesystem permissions restricted to the daemon user. Packaging
+# installs this template with mode 0600 so only the owner can read it.
+#
+# Replace the credentials below with your own values before enabling
+# authentication in /etc/oc-rsyncd/oc-rsyncd.conf.
+#
+# backup:supersecret


### PR DESCRIPTION
## Summary
- add an oc-rsyncd secrets template so packaged installs include a correctly permissioned file
- register the template as a configuration asset in the deb and rpm metadata so it ships with mode 0600

## Testing
- not run (packaging metadata update only)

------