### PR TITLE
Centralize invocation brand detection

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -976,14 +976,10 @@ impl ProgramName {
 }
 
 fn detect_program_name(program: Option<&OsStr>) -> ProgramName {
-    program
-        .and_then(|arg| Path::new(arg).file_stem())
-        .and_then(|stem| stem.to_str())
-        .map(|stem| match branding::brand_for_program_name(stem) {
-            Brand::Oc => ProgramName::OcRsync,
-            Brand::Upstream => ProgramName::Rsync,
-        })
-        .unwrap_or(ProgramName::Rsync)
+    match branding::detect_brand(program) {
+        Brand::Oc => ProgramName::OcRsync,
+        Brand::Upstream => ProgramName::Rsync,
+    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -2848,14 +2848,10 @@ impl ProgramName {
 }
 
 fn detect_program_name(program: Option<&OsStr>) -> ProgramName {
-    program
-        .and_then(|arg| Path::new(arg).file_stem())
-        .and_then(|stem| stem.to_str())
-        .map(|stem| match branding::brand_for_program_name(stem) {
-            Brand::Oc => ProgramName::OcRsyncd,
-            Brand::Upstream => ProgramName::Rsyncd,
-        })
-        .unwrap_or(ProgramName::Rsyncd)
+    match branding::detect_brand(program) {
+        Brand::Oc => ProgramName::OcRsyncd,
+        Brand::Upstream => ProgramName::Rsyncd,
+    }
 }
 
 struct ParsedArgs {


### PR DESCRIPTION
## Summary
- add a helper in `rsync_core::branding` that derives the runtime brand from argv[0]
- exercise the helper in a focused unit test
- reuse the helper inside the client and daemon front-ends to keep brand detection consistent

## Testing
- `cargo test -p rsync-core branding::tests::detect_brand_matches_invocation_argument`

------