### PR TITLE
Add brand-aware helpers for version banners

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -973,6 +973,14 @@ impl ProgramName {
             Self::OcRsync => Brand::Oc.client_program_name(),
         }
     }
+
+    #[inline]
+    const fn brand(self) -> Brand {
+        match self {
+            Self::Rsync => Brand::Upstream,
+            Self::OcRsync => Brand::Oc,
+        }
+    }
 }
 
 fn detect_program_name(program: Option<&OsStr>) -> ProgramName {
@@ -3268,7 +3276,7 @@ where
     }
 
     if show_version {
-        let report = VersionInfoReport::default().with_program_name(program_name.as_str());
+        let report = VersionInfoReport::default().with_client_brand(program_name.brand());
         let banner = report.human_readable();
         if stdout.write_all(banner.as_bytes()).is_err() {
             return 1;
@@ -7756,7 +7764,7 @@ mod tests {
         assert!(stderr.is_empty());
 
         let expected = VersionInfoReport::default()
-            .with_program_name(Brand::Oc.client_program_name())
+            .with_client_brand(Brand::Oc)
             .human_readable();
         assert_eq!(stdout, expected.into_bytes());
     }
@@ -7830,7 +7838,7 @@ mod tests {
         assert!(stderr.is_empty());
 
         let expected = VersionInfoReport::default()
-            .with_program_name(Brand::Oc.client_program_name())
+            .with_client_brand(Brand::Oc)
             .human_readable();
         assert_eq!(stdout, expected.into_bytes());
     }

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -2845,6 +2845,14 @@ impl ProgramName {
             Self::OcRsyncd => Brand::Oc.daemon_program_name(),
         }
     }
+
+    #[inline]
+    const fn brand(self) -> Brand {
+        match self {
+            Self::Rsyncd => Brand::Upstream,
+            Self::OcRsyncd => Brand::Oc,
+        }
+    }
 }
 
 fn detect_program_name(program: Option<&OsStr>) -> ProgramName {
@@ -4933,7 +4941,7 @@ where
     }
 
     if parsed.show_version && parsed.remainder.is_empty() {
-        let report = VersionInfoReport::default().with_program_name(parsed.program_name.as_str());
+        let report = VersionInfoReport::default().with_daemon_brand(parsed.program_name.brand());
         let banner = report.human_readable();
         if stdout.write_all(banner.as_bytes()).is_err() {
             return 1;
@@ -9028,7 +9036,7 @@ mod tests {
         assert!(stderr.is_empty());
 
         let expected = VersionInfoReport::default()
-            .with_program_name(Brand::Upstream.daemon_program_name())
+            .with_daemon_brand(Brand::Upstream)
             .human_readable();
         assert_eq!(stdout, expected.into_bytes());
     }
@@ -9042,7 +9050,7 @@ mod tests {
         assert!(stderr.is_empty());
 
         let expected = VersionInfoReport::default()
-            .with_program_name(Brand::Oc.daemon_program_name())
+            .with_daemon_brand(Brand::Oc)
             .human_readable();
         assert_eq!(stdout, expected.into_bytes());
     }


### PR DESCRIPTION
## Summary
- add brand-aware helpers to `VersionInfoReport` so version banners use the correct client or daemon branding
- update the CLI and daemon front-ends to rely on the new helpers for oc-* binaries and expand coverage
- extend unit tests across core, cli, and daemon crates to verify branded banners render the expected program names

## Testing
- cargo test -p rsync-core version -- --nocapture
- cargo test -p rsync-cli -- --nocapture
- cargo test -p rsync-daemon

------