### PR TITLE
Use branding constants for delegation help text

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -2749,7 +2749,15 @@ fn render_help(program_name: ProgramName) -> String {
     help = help.replacen("Usage: rsync", &usage, 1);
 
     if program_name == ProgramName::OcRsync {
-        help = help.replacen("(delegates to rsyncd)", "(delegates to oc-rsyncd)", 1);
+        let upstream_delegation = format!(
+            "(delegates to {})",
+            branding::daemon_program_name()
+        );
+        let branded_delegation = format!(
+            "(delegates to {})",
+            branding::oc_daemon_program_name()
+        );
+        help = help.replacen(&upstream_delegation, &branded_delegation, 1);
     }
 
     help
@@ -7984,8 +7992,16 @@ mod tests {
         assert!(stderr.is_empty());
 
         let rendered = String::from_utf8(stdout).expect("valid UTF-8");
-        assert!(rendered.contains("delegates to oc-rsyncd"));
-        assert!(!rendered.contains("delegates to rsyncd"));
+        let upstream = format!(
+            "delegates to {}",
+            branding::daemon_program_name()
+        );
+        let branded = format!(
+            "delegates to {}",
+            branding::oc_daemon_program_name()
+        );
+        assert!(rendered.contains(&branded));
+        assert!(!rendered.contains(&upstream));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- replace the hard-coded oc-rsyncd delegation string in the help renderer with values from the shared branding module
- update the help snapshot test to assert against the branding-aware strings so it follows future rebranding changes automatically

## Testing
- cargo test -p rsync-cli

------