### PR TITLE
Ensure compatibility wrapper packages ship oc secrets template

### DIFF
--- a/bin/rsync/Cargo.toml
+++ b/bin/rsync/Cargo.toml
@@ -26,9 +26,14 @@ assets = [
     ["../../target/release/rsyncd", "/usr/bin/rsyncd", "755"],
     ["../../packaging/systemd/oc-rsyncd.service", "/lib/systemd/system/rsyncd.service", "644"],
     ["../../packaging/etc/oc-rsyncd/oc-rsyncd.conf", "/etc/oc-rsyncd/oc-rsyncd.conf", "644"],
+    ["../../packaging/etc/oc-rsyncd/oc-rsyncd.secrets", "/etc/oc-rsyncd/oc-rsyncd.secrets", "600"],
     ["../../packaging/default/oc-rsyncd", "/etc/default/oc-rsyncd", "644"],
 ]
-conf-files = ["etc/oc-rsyncd/oc-rsyncd.conf", "etc/default/oc-rsyncd"]
+conf-files = [
+    "etc/oc-rsyncd/oc-rsyncd.conf",
+    "etc/oc-rsyncd/oc-rsyncd.secrets",
+    "etc/default/oc-rsyncd",
+]
 
 [package.metadata.rpm]
 package = "rsync"
@@ -39,5 +44,6 @@ assets = [
     { path = "../../target/release/rsyncd", dest = "/usr/bin/rsyncd", mode = "0755" },
     { path = "../../packaging/systemd/oc-rsyncd.service", dest = "/usr/lib/systemd/system/rsyncd.service", mode = "0644" },
     { path = "../../packaging/etc/oc-rsyncd/oc-rsyncd.conf", dest = "/etc/oc-rsyncd/oc-rsyncd.conf", mode = "0644", config = true },
+    { path = "../../packaging/etc/oc-rsyncd/oc-rsyncd.secrets", dest = "/etc/oc-rsyncd/oc-rsyncd.secrets", mode = "0600", config = true },
     { path = "../../packaging/default/oc-rsyncd", dest = "/etc/default/oc-rsyncd", mode = "0644", config = true },
 ]


### PR DESCRIPTION
## Summary
- include the oc-rsyncd secrets sample in the compatibility rsync packaging manifests so both deb and rpm installs are consistent with the branded packages

## Testing
- not run

------