### PR TITLE
Respect daemon brand when resolving config defaults

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -2749,14 +2749,8 @@ fn render_help(program_name: ProgramName) -> String {
     help = help.replacen("Usage: rsync", &usage, 1);
 
     if program_name == ProgramName::OcRsync {
-        let upstream_delegation = format!(
-            "(delegates to {})",
-            branding::daemon_program_name()
-        );
-        let branded_delegation = format!(
-            "(delegates to {})",
-            branding::oc_daemon_program_name()
-        );
+        let upstream_delegation = format!("(delegates to {})", branding::daemon_program_name());
+        let branded_delegation = format!("(delegates to {})", branding::oc_daemon_program_name());
         help = help.replacen(&upstream_delegation, &branded_delegation, 1);
     }
 
@@ -7992,14 +7986,8 @@ mod tests {
         assert!(stderr.is_empty());
 
         let rendered = String::from_utf8(stdout).expect("valid UTF-8");
-        let upstream = format!(
-            "delegates to {}",
-            branding::daemon_program_name()
-        );
-        let branded = format!(
-            "delegates to {}",
-            branding::oc_daemon_program_name()
-        );
+        let upstream = format!("delegates to {}", branding::daemon_program_name());
+        let branded = format!("delegates to {}", branding::oc_daemon_program_name());
         assert!(rendered.contains(&branded));
         assert!(!rendered.contains(&upstream));
     }


### PR DESCRIPTION
## Summary
- propagate the daemon brand through `DaemonConfig` so runtime parsing can distinguish between oc-rsyncd and the rsyncd shim when resolving default config paths
- add brand-aware default config path ordering and unit tests that cover both branding directions as well as the builder override
- tidy the CLI help delegation formatting so the oc-rsync help snapshot keeps using centrally managed branding helpers

## Testing
- cargo test -p rsync-daemon

------