### PR TITLE
Extend daemon test connection retry timeout

### DIFF
--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -9241,17 +9241,18 @@ mod tests {
     }
 
     fn connect_with_retries(port: u16) -> TcpStream {
-        for attempt in 0..100 {
+        let deadline = Instant::now() + Duration::from_secs(5);
+
+        loop {
             match TcpStream::connect((Ipv4Addr::LOCALHOST, port)) {
                 Ok(stream) => return stream,
                 Err(error) => {
-                    if attempt == 99 {
-                        panic!("failed to connect to daemon: {error}");
+                    if Instant::now() >= deadline {
+                        panic!("failed to connect to daemon within timeout: {error}");
                     }
                     thread::sleep(Duration::from_millis(20));
                 }
             }
         }
-        unreachable!("loop exits via return or panic");
     }
 }


### PR DESCRIPTION
## Summary
- give `connect_with_retries` a deadline-based loop so daemon tests can wait for startup

## Testing
- cargo test --package rsync-daemon binary_session_delegates_to_configured_fallback
- cargo test --package rsync-daemon run_daemon_handles_parallel_sessions

------