### PR TITLE
Centralize fallback override environment names

### DIFF
--- a/crates/core/src/fallback.rs
+++ b/crates/core/src/fallback.rs
@@ -69,6 +69,22 @@
 use std::env;
 use std::ffi::{OsStr, OsString};
 
+/// Name of the client fallback override environment variable.
+///
+/// The `OC_RSYNC_FALLBACK` variable matches the historical environment knob
+/// used by packaging to control remote-shell delegation. Exposing the name as
+/// a constant keeps binaries and tests in sync when future rebranding requires
+/// updating the identifier in one place.
+pub const CLIENT_FALLBACK_ENV: &str = "OC_RSYNC_FALLBACK";
+
+/// Name of the daemon-specific fallback override environment variable.
+///
+/// When present, the value controls whether `oc-rsyncd` should delegate module
+/// sessions to the upstream `rsync` binary. The helper mirrors the
+/// workspace-wide client override ([`CLIENT_FALLBACK_ENV`]) while allowing
+/// operators to toggle delegation independently for the daemon process.
+pub const DAEMON_FALLBACK_ENV: &str = "OC_RSYNC_DAEMON_FALLBACK";
+
 /// Represents the parsed interpretation of a fallback environment override.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum FallbackOverride {
@@ -170,6 +186,12 @@ mod tests {
             }
             Self { key, original }
         }
+    }
+
+    #[test]
+    fn fallback_env_constants_match_expected() {
+        assert_eq!(CLIENT_FALLBACK_ENV, "OC_RSYNC_FALLBACK");
+        assert_eq!(DAEMON_FALLBACK_ENV, "OC_RSYNC_DAEMON_FALLBACK");
     }
 
     impl Drop for EnvVarGuard {


### PR DESCRIPTION
## Summary
- define shared `CLIENT_FALLBACK_ENV` and `DAEMON_FALLBACK_ENV` constants in the core fallback module and cover them with a unit test
- switch the client facade, CLI frontend, and daemon to use the shared constants and format diagnostics with the resolved names
- update the associated tests so their environment guards and assertions reference the new constants

## Testing
- `cargo test -p rsync-core client::tests::remote_fallback_reports_disabled_override -- --exact`
- `cargo test -p rsync-cli tests::server_mode_reports_disabled_fallback_override -- --exact`
- `cargo test -p rsync-daemon tests::configured_fallback_binary_respects_primary_disable -- --exact`

------