### PR TITLE
Use fallback constants for env override parsing

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -2857,7 +2857,7 @@ where
 
     let upstream_program = Brand::Upstream.client_program_name();
     let upstream_program_os = OsStr::new(upstream_program);
-    let fallback = match fallback_override("OC_RSYNC_FALLBACK") {
+    let fallback = match fallback_override(CLIENT_FALLBACK_ENV) {
         Some(FallbackOverride::Disabled) => {
             let text = format!(
                 "remote server mode is unavailable because OC_RSYNC_FALLBACK is disabled; set OC_RSYNC_FALLBACK to point to an upstream {upstream_program} binary"

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -5019,11 +5019,11 @@ fn auto_delegate_system_rsync_enabled() -> bool {
 }
 
 fn configured_fallback_binary() -> Option<OsString> {
-    if let Some(selection) = fallback_override("OC_RSYNC_DAEMON_FALLBACK") {
+    if let Some(selection) = fallback_override(DAEMON_FALLBACK_ENV) {
         return selection.resolve_or_default(OsStr::new(Brand::Upstream.client_program_name()));
     }
 
-    if let Some(selection) = fallback_override("OC_RSYNC_FALLBACK") {
+    if let Some(selection) = fallback_override(CLIENT_FALLBACK_ENV) {
         return selection.resolve_or_default(OsStr::new(Brand::Upstream.client_program_name()));
     }
 


### PR DESCRIPTION
## Summary
- replace the hard-coded OC_RSYNC_FALLBACK and OC_RSYNC_DAEMON_FALLBACK strings in the CLI and daemon with the shared constants from `rsync_core::fallback`
- import the shared constants directly so both crates build without unused-import warnings during tests

## Testing
- cargo test -p rsync-cli --locked
- cargo test -p rsync-daemon --locked

------