### PR TITLE
Centralize crate version metadata to 3.4.1-rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -430,14 +430,14 @@ dependencies = [
 
 [[package]]
 name = "oc-rsync-bin"
-version = "0.0.0"
+version = "3.4.1-rust"
 dependencies = [
  "rsync-cli",
 ]
 
 [[package]]
 name = "oc-rsyncd-bin"
-version = "0.0.0"
+version = "3.4.1-rust"
 dependencies = [
  "rsync-daemon",
 ]
@@ -591,14 +591,14 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "rsync-bandwidth"
-version = "0.0.0"
+version = "3.4.1-rust"
 dependencies = [
  "proptest",
 ]
 
 [[package]]
 name = "rsync-checksums"
-version = "0.0.0"
+version = "3.4.1-rust"
 dependencies = [
  "digest",
  "md-5",
@@ -609,7 +609,7 @@ dependencies = [
 
 [[package]]
 name = "rsync-cli"
-version = "0.0.0"
+version = "3.4.1-rust"
 dependencies = [
  "base64",
  "clap",
@@ -631,14 +631,14 @@ dependencies = [
 
 [[package]]
 name = "rsync-compress"
-version = "0.0.0"
+version = "3.4.1-rust"
 dependencies = [
  "flate2",
 ]
 
 [[package]]
 name = "rsync-core"
-version = "0.0.0"
+version = "3.4.1-rust"
 dependencies = [
  "base64",
  "filetime",
@@ -657,7 +657,7 @@ dependencies = [
 
 [[package]]
 name = "rsync-daemon"
-version = "0.0.0"
+version = "3.4.1-rust"
 dependencies = [
  "base64",
  "clap",
@@ -674,7 +674,7 @@ dependencies = [
 
 [[package]]
 name = "rsync-engine"
-version = "0.0.0"
+version = "3.4.1-rust"
 dependencies = [
  "filetime",
  "globset",
@@ -691,21 +691,21 @@ dependencies = [
 
 [[package]]
 name = "rsync-filters"
-version = "0.0.0"
+version = "3.4.1-rust"
 dependencies = [
  "globset",
 ]
 
 [[package]]
 name = "rsync-logging"
-version = "0.0.0"
+version = "3.4.1-rust"
 dependencies = [
  "rsync-core",
 ]
 
 [[package]]
 name = "rsync-meta"
-version = "0.0.0"
+version = "3.4.1-rust"
 dependencies = [
  "filetime",
  "libc",
@@ -716,14 +716,14 @@ dependencies = [
 
 [[package]]
 name = "rsync-protocol"
-version = "0.0.0"
+version = "3.4.1-rust"
 dependencies = [
  "proptest",
 ]
 
 [[package]]
 name = "rsync-transport"
-version = "0.0.0"
+version = "3.4.1-rust"
 dependencies = [
  "proptest",
  "rsync-protocol",
@@ -731,7 +731,7 @@ dependencies = [
 
 [[package]]
 name = "rsync-walk"
-version = "0.0.0"
+version = "3.4.1-rust"
 dependencies = [
  "tempfile",
 ]
@@ -1161,7 +1161,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.0.0"
+version = "3.4.1-rust"
 
 [[package]]
 name = "xxhash-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,4 @@ edition = "2024"
 rust-version = "1.85"
 authors = ["Ofer Chen <skewers.irises.3b@icloud.com>"]
 license = "GPL-3.0-or-later"
+version = "3.4.1-rust"

--- a/bin/oc-rsync/Cargo.toml
+++ b/bin/oc-rsync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oc-rsync-bin"
-version = "0.0.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/bin/oc-rsyncd/Cargo.toml
+++ b/bin/oc-rsyncd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oc-rsyncd-bin"
-version = "0.0.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/bandwidth/Cargo.toml
+++ b/crates/bandwidth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsync-bandwidth"
-version = "0.0.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/checksums/Cargo.toml
+++ b/crates/checksums/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsync-checksums"
-version = "0.0.0"
+version.workspace = true
 edition = "2024"
 license = "GPL-3.0-or-later"
 

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsync-cli"
-version = "0.0.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/compress/Cargo.toml
+++ b/crates/compress/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsync-compress"
-version = "0.0.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsync-core"
-version = "0.0.0"
+version.workspace = true
 edition = "2024"
 authors = ["Ofer Chen <skewers.irises.3b@icloud.com>"]
 license = "GPL-3.0-or-later"

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsync-daemon"
-version = "0.0.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsync-engine"
-version = "0.0.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/filters/Cargo.toml
+++ b/crates/filters/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsync-filters"
-version = "0.0.0"
+version.workspace = true
 edition = "2024"
 authors = ["Ofer Chen <skewers.irises.3b@icloud.com>"]
 license = "GPL-3.0-or-later"

--- a/crates/logging/Cargo.toml
+++ b/crates/logging/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsync-logging"
-version = "0.0.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/meta/Cargo.toml
+++ b/crates/meta/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsync-meta"
-version = "0.0.0"
+version.workspace = true
 edition = "2024"
 authors = ["Ofer Chen <skewers.irises.3b@icloud.com>"]
 license = "GPL-3.0-or-later"

--- a/crates/protocol/Cargo.toml
+++ b/crates/protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsync-protocol"
-version = "0.0.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/transport/Cargo.toml
+++ b/crates/transport/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsync-transport"
-version = "0.0.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/walk/Cargo.toml
+++ b/crates/walk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsync-walk"
-version = "0.0.0"
+version.workspace = true
 edition = "2024"
 authors = ["Ofer Chen <skewers.irises.3b@icloud.com>"]
 license = "GPL-3.0-or-later"

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xtask"
-version = "0.0.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true


### PR DESCRIPTION
## Summary
- add the workspace package version 3.4.1-rust and reuse it from every crate
- regenerate Cargo.lock so all packages advertise the release version

## Testing
- cargo test

------