### PR TITLE
Add helpers for branded daemon configuration directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,11 @@ module directly to discover the canonical installation paths:
 ```rust
 use std::path::Path;
 
+let config_dir = rsync_core::branding::oc_daemon_config_dir();
 let config = rsync_core::branding::oc_daemon_config_path();
 let secrets = rsync_core::branding::oc_daemon_secrets_path();
 
+assert_eq!(config_dir, Path::new("/etc/oc-rsyncd"));
 assert_eq!(config, Path::new("/etc/oc-rsyncd/oc-rsyncd.conf"));
 assert_eq!(secrets, Path::new("/etc/oc-rsyncd/oc-rsyncd.secrets"));
 ```


### PR DESCRIPTION
## Summary
- expose accessor methods for the branded and upstream daemon configuration directories via the core branding facade
- extend BrandProfile and associated tests to carry directory metadata alongside configuration and secrets paths
- document the new oc-rsyncd configuration directory helper in the README example for consumers

## Testing
- cargo test -p rsync-core branding::tests::

------