### PR TITLE
Serialize branding env override tests

### DIFF
--- a/crates/core/src/branding.rs
+++ b/crates/core/src/branding.rs
@@ -528,6 +528,18 @@ mod tests {
     use super::*;
     use std::env;
     use std::ffi::{OsStr, OsString};
+    use std::sync::{Mutex, MutexGuard, OnceLock};
+
+    fn env_lock() -> &'static Mutex<()> {
+        static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        ENV_LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    fn acquire_env_lock() -> MutexGuard<'static, ()> {
+        env_lock()
+            .lock()
+            .expect("environment lock poisoned during test")
+    }
 
     #[allow(unsafe_code)]
     fn set_env_var(key: &'static str, value: impl AsRef<OsStr>) {
@@ -546,6 +558,7 @@ mod tests {
     struct EnvGuard {
         key: &'static str,
         previous: Option<OsString>,
+        _lock: MutexGuard<'static, ()>,
     }
 
     impl EnvGuard {
@@ -553,15 +566,25 @@ mod tests {
         where
             V: AsRef<OsStr>,
         {
+            let lock = acquire_env_lock();
             let previous = env::var_os(key);
             set_env_var(key, value);
-            Self { key, previous }
+            Self {
+                key,
+                previous,
+                _lock: lock,
+            }
         }
 
         fn remove(key: &'static str) -> Self {
+            let lock = acquire_env_lock();
             let previous = env::var_os(key);
             remove_env_var(key);
-            Self { key, previous }
+            Self {
+                key,
+                previous,
+                _lock: lock,
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- guard the branding override environment variable access in tests with a global mutex
- ensure the EnvGuard helper holds the mutex while mutating and restoring the environment

## Testing
- cargo test -p rsync-core --lib branding::tests::detect_brand -- --nocapture

------