### PR TITLE
Derive version metadata from Cargo configuration

### DIFF
--- a/crates/core/src/message.rs
+++ b/crates/core/src/message.rs
@@ -1264,7 +1264,10 @@ macro_rules! tracked_message_source {
 ///     .to_string();
 ///
 /// assert!(rendered.contains("rsync error: delta-transfer failure (code 23)"));
-/// assert!(rendered.contains("[sender=3.4.1-rust]"));
+/// assert!(rendered.contains(&format!(
+///     "[sender={}]",
+///     rsync_core::version::RUST_VERSION
+/// )));
 /// ```
 ///
 /// Formatting arguments are forwarded to [`format!`]:
@@ -1404,7 +1407,10 @@ macro_rules! rsync_exit_code {
 ///
 /// let rendered = message.to_string();
 /// assert!(rendered.contains("delta-transfer failure"));
-/// assert!(rendered.contains("[sender=3.4.1-rust]"));
+/// assert!(rendered.contains(&format!(
+///     "[sender={}]",
+///     rsync_core::version::RUST_VERSION
+/// )));
 /// ```
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 #[must_use = "messages must be formatted or emitted to reach users"]
@@ -2119,7 +2125,10 @@ impl Message {
     ///     .unwrap();
     ///
     /// assert!(rendered.contains("rsync error: example (code 12)"));
-    /// assert!(rendered.contains("[sender=3.4.1-rust]"));
+    /// assert!(rendered.contains(&format!(
+    ///     "[sender={}]",
+    ///     rsync_core::version::RUST_VERSION
+    /// )));
     /// ```
     #[inline]
     #[must_use = "formatter writes can fail; propagate errors to preserve upstream diagnostics"]
@@ -2147,7 +2156,10 @@ impl Message {
     ///     .unwrap();
     ///
     /// assert!(rendered.ends_with('\n'));
-    /// assert!(rendered.contains("[generator=3.4.1-rust]"));
+    /// assert!(rendered.contains(&format!(
+    ///     "[generator={}]",
+    ///     rsync_core::version::RUST_VERSION
+    /// )));
     /// ```
     #[inline]
     #[must_use = "newline rendering can fail; handle formatting errors to retain diagnostics"]
@@ -2176,7 +2188,8 @@ impl Message {
     ///     .expect("Vec<u8> writes are infallible");
     ///
     /// assert!(bytes.starts_with(b"rsync error:"));
-    /// assert!(bytes.ends_with(b"[sender=3.4.1-rust]"));
+    /// let trailer = format!("[sender={}]", rsync_core::version::RUST_VERSION);
+    /// assert!(bytes.ends_with(trailer.as_bytes()));
     /// ```
     #[inline]
     #[must_use = "collecting rendered bytes allocates; handle potential I/O or allocation failures"]
@@ -2232,7 +2245,10 @@ impl Message {
     ///
     /// let rendered = String::from_utf8(output).unwrap();
     /// assert!(rendered.contains("rsync error: delta-transfer failure (code 23)"));
-    /// assert!(rendered.contains("[sender=3.4.1-rust]"));
+    /// assert!(rendered.contains(&format!(
+    ///     "[sender={}]",
+    ///     rsync_core::version::RUST_VERSION
+    /// )));
     /// ```
     #[inline]
     #[must_use = "rsync diagnostics must report I/O failures when streaming to writers"]
@@ -2262,7 +2278,10 @@ impl Message {
     ///
     /// let rendered = String::from_utf8(output).unwrap();
     /// assert!(rendered.ends_with('\n'));
-    /// assert!(rendered.contains("[receiver=3.4.1-rust]"));
+    /// assert!(rendered.contains(&format!(
+    ///     "[receiver={}]",
+    ///     rsync_core::version::RUST_VERSION
+    /// )));
     /// ```
     #[inline]
     #[must_use = "rsync diagnostics must report I/O failures when streaming to writers"]
@@ -2293,7 +2312,8 @@ impl Message {
     ///     .append_to_vec(&mut buffer)?;
     ///
     /// assert!(buffer.starts_with(b"rsync error:"));
-    /// assert!(buffer.ends_with(b"[sender=3.4.1-rust]"));
+    /// let trailer = format!("[sender={}]", rsync_core::version::RUST_VERSION);
+    /// assert!(buffer.ends_with(trailer.as_bytes()));
     /// assert_eq!(appended, buffer.len());
     /// # Ok::<(), std::io::Error>(())
     /// ```
@@ -3014,7 +3034,7 @@ mod tests {
         let formatted = message.to_string();
 
         assert!(formatted.starts_with("rsync error: delta-transfer failure (code 23) at "));
-        assert!(formatted.contains("[sender=3.4.1-rust]"));
+        assert!(formatted.contains(&format!("[sender={}]", crate::version::RUST_VERSION)));
         assert!(formatted.contains("src/message.rs"));
     }
 

--- a/crates/core/src/message/strings.rs
+++ b/crates/core/src/message/strings.rs
@@ -47,7 +47,10 @@
 //!
 //! assert!(rendered.contains("rsync warning: some files vanished"));
 //! assert!(rendered.contains("(code 24)"));
-//! assert!(rendered.contains("[receiver=3.4.1-rust]"));
+//! assert!(rendered.contains(&format!(
+//!     "[receiver={}]",
+//!     rsync_core::version::RUST_VERSION
+//! )));
 //! ```
 //!
 //! Convert a template directly into a [`Message`] without calling

--- a/crates/core/src/version.rs
+++ b/crates/core/src/version.rs
@@ -50,7 +50,7 @@
 //! ```
 //! use rsync_core::version::{compiled_features, CompiledFeature, RUST_VERSION};
 //!
-//! assert_eq!(RUST_VERSION, "3.4.1-rust");
+//! assert_eq!(RUST_VERSION, env!("CARGO_PKG_VERSION"));
 //! let features = compiled_features();
 //! #[cfg(feature = "xattr")]
 //! assert!(features.contains(&CompiledFeature::Xattr));
@@ -142,10 +142,10 @@ pub const LATEST_COPYRIGHT_YEAR: &str = "2025";
 pub const COPYRIGHT_NOTICE: &str = "(C) 2025 by Ofer Chen.";
 
 /// Web site advertised by `rsync` in `--version` output.
-pub const WEB_SITE: &str = "https://github.com/oferchen/rsync";
+pub const WEB_SITE: &str = env!("CARGO_PKG_REPOSITORY");
 
 /// Repository URL advertised by version banners and documentation.
-pub const SOURCE_URL: &str = "https://github.com/oferchen/rsync";
+pub const SOURCE_URL: &str = WEB_SITE;
 
 /// Human-readable toolchain description rendered in `--version` output.
 pub const BUILD_TOOLCHAIN: &str = "Built in Rust 2024";
@@ -207,7 +207,7 @@ pub const UPSTREAM_BASE_VERSION: &str = "3.4.1";
 
 /// Full version string rendered by user-visible banners.
 #[doc(alias = "3.4.1-rust")]
-pub const RUST_VERSION: &str = "3.4.1-rust";
+pub const RUST_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 /// Highest protocol version supported by this build.
 pub const HIGHEST_PROTOCOL_VERSION: u8 = ProtocolVersion::NEWEST.as_u8();
@@ -223,12 +223,15 @@ pub const HIGHEST_PROTOCOL_VERSION: u8 = ProtocolVersion::NEWEST.as_u8();
 /// # Examples
 ///
 /// ```
-/// use rsync_core::version::version_metadata;
+/// use rsync_core::version::{version_metadata, RUST_VERSION};
 ///
 /// let metadata = version_metadata();
 /// let banner = metadata.standard_banner();
 ///
-/// assert!(banner.starts_with("rsync  version 3.4.1-rust"));
+/// assert!(banner.starts_with(&format!(
+///     "rsync  version {} ",
+///     RUST_VERSION
+/// )));
 /// assert!(banner.contains("protocol version 32"));
 /// assert!(banner.contains("revision/build #"));
 /// assert!(banner.contains("https://github.com/oferchen/rsync"));
@@ -2003,11 +2006,15 @@ mod tests {
 
         let expected = format!(
             concat!(
-                "rsync  version 3.4.1-rust (revision/build #{build_revision})  protocol version 32\n",
-                "Copyright (C) 2025 by Ofer Chen.\n",
-                "Web site: https://github.com/oferchen/rsync\n"
+                "rsync  version {rust_version} (revision/build #{build_revision})  protocol version {protocol}\n",
+                "Copyright {copyright}\n",
+                "Web site: {web_site}\n"
             ),
+            rust_version = RUST_VERSION,
             build_revision = build_revision(),
+            protocol = ProtocolVersion::NEWEST.as_u8(),
+            copyright = COPYRIGHT_NOTICE,
+            web_site = WEB_SITE,
         );
 
         assert_eq!(rendered, expected);
@@ -2090,7 +2097,7 @@ mod tests {
         };
 
         let build_info = build_info_line();
-        assert!(actual.starts_with("rsync  version 3.4.1-rust"));
+        assert!(actual.starts_with(&format!("rsync  version {}", RUST_VERSION)));
         assert!(actual.contains(&format!(
             "    {bit_files}-bit files, {bit_inums}-bit inums, {bit_timestamps}-bit timestamps, {bit_long_ints}-bit long ints,"
         )));


### PR DESCRIPTION
## Summary
- derive the published version and repository URL from Cargo metadata so the banner tracks package updates
- refresh version-related doctests to rely on the shared constants instead of hard-coded strings
- update message doctests and unit tests to format trailers using the central Rust version identifier

## Testing
- cargo test -p rsync-core

------