### PR TITLE
Centralize branded program identifiers

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -63,7 +63,14 @@
 //!
 //! let mut stdout = Vec::new();
 //! let mut stderr = Vec::new();
-//! let exit_code = run(["rsync", "--version"], &mut stdout, &mut stderr);
+//! let exit_code = run(
+//!     [
+//!         rsync_core::branding::client_program_name(),
+//!         "--version",
+//!     ],
+//!     &mut stdout,
+//!     &mut stderr,
+//! );
 //!
 //! assert_eq!(exit_code, 0);
 //! assert!(!stdout.is_empty());
@@ -7686,6 +7693,11 @@ mod tests {
     #[cfg(feature = "xattr")]
     use xattr;
 
+    const RSYNC: &str = branding::client_program_name();
+    const OC_RSYNC: &str = branding::oc_client_program_name();
+    const RSYNCD: &str = branding::daemon_program_name();
+    const OC_RSYNC_D: &str = branding::oc_daemon_program_name();
+
     const LEGACY_DAEMON_GREETING: &str = "@RSYNCD: 32.0 sha512 sha256 sha1 md5 md4\n";
 
     fn assert_contains_client_trailer(rendered: &str) {
@@ -7755,7 +7767,7 @@ mod tests {
 
     #[test]
     fn version_flag_renders_report() {
-        let (code, stdout, stderr) = run_with_args([OsStr::new("rsync"), OsStr::new("--version")]);
+        let (code, stdout, stderr) = run_with_args([OsStr::new(RSYNC), OsStr::new("--version")]);
 
         assert_eq!(code, 0);
         assert!(stderr.is_empty());
@@ -7766,8 +7778,7 @@ mod tests {
 
     #[test]
     fn oc_version_flag_renders_oc_banner() {
-        let (code, stdout, stderr) =
-            run_with_args([OsStr::new("oc-rsync"), OsStr::new("--version")]);
+        let (code, stdout, stderr) = run_with_args([OsStr::new(OC_RSYNC), OsStr::new("--version")]);
 
         assert_eq!(code, 0);
         assert!(stderr.is_empty());
@@ -7780,7 +7791,7 @@ mod tests {
 
     #[test]
     fn short_version_flag_renders_report() {
-        let (code, stdout, stderr) = run_with_args([OsStr::new("rsync"), OsStr::new("-V")]);
+        let (code, stdout, stderr) = run_with_args([OsStr::new(RSYNC), OsStr::new("-V")]);
 
         assert_eq!(code, 0);
         assert!(stderr.is_empty());
@@ -7802,7 +7813,7 @@ mod tests {
         std::fs::write(&source, b"payload").expect("write source");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("-z"),
             source.clone().into_os_string(),
             destination.clone().into_os_string(),
@@ -7827,7 +7838,7 @@ mod tests {
         std::fs::write(&source, b"payload").expect("write source");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             source.clone().into_os_string(),
             destination.clone().into_os_string(),
         ]);
@@ -7841,7 +7852,7 @@ mod tests {
 
     #[test]
     fn oc_short_version_flag_renders_oc_banner() {
-        let (code, stdout, stderr) = run_with_args([OsStr::new("oc-rsync"), OsStr::new("-V")]);
+        let (code, stdout, stderr) = run_with_args([OsStr::new(OC_RSYNC), OsStr::new("-V")]);
 
         assert_eq!(code, 0);
         assert!(stderr.is_empty());
@@ -7855,7 +7866,7 @@ mod tests {
     #[test]
     fn version_flag_ignores_additional_operands() {
         let (code, stdout, stderr) = run_with_args([
-            OsStr::new("rsync"),
+            OsStr::new(RSYNC),
             OsStr::new("--version"),
             OsStr::new("source"),
         ]);
@@ -7870,7 +7881,7 @@ mod tests {
     #[test]
     fn short_version_flag_ignores_additional_operands() {
         let (code, stdout, stderr) = run_with_args([
-            OsStr::new("rsync"),
+            OsStr::new(RSYNC),
             OsStr::new("-V"),
             OsStr::new("source"),
             OsStr::new("dest"),
@@ -7888,7 +7899,7 @@ mod tests {
         let mut expected_stdout = Vec::new();
         let mut expected_stderr = Vec::new();
         let expected_code = daemon_cli::run(
-            [OsStr::new("rsyncd"), OsStr::new("--help")],
+            [OsStr::new(RSYNCD), OsStr::new("--help")],
             &mut expected_stdout,
             &mut expected_stderr,
         );
@@ -7897,7 +7908,7 @@ mod tests {
         assert!(expected_stderr.is_empty());
 
         let (code, stdout, stderr) = run_with_args([
-            OsStr::new("rsync"),
+            OsStr::new(RSYNC),
             OsStr::new("--daemon"),
             OsStr::new("--help"),
         ]);
@@ -7912,7 +7923,7 @@ mod tests {
         let mut expected_stdout = Vec::new();
         let mut expected_stderr = Vec::new();
         let expected_code = daemon_cli::run(
-            [OsStr::new("rsyncd"), OsStr::new("--version")],
+            [OsStr::new(RSYNCD), OsStr::new("--version")],
             &mut expected_stdout,
             &mut expected_stderr,
         );
@@ -7921,7 +7932,7 @@ mod tests {
         assert!(expected_stderr.is_empty());
 
         let (code, stdout, stderr) = run_with_args([
-            OsStr::new("rsync"),
+            OsStr::new(RSYNC),
             OsStr::new("--daemon"),
             OsStr::new("--version"),
         ]);
@@ -7936,7 +7947,7 @@ mod tests {
         let mut expected_stdout = Vec::new();
         let mut expected_stderr = Vec::new();
         let expected_code = daemon_cli::run(
-            [OsStr::new("oc-rsyncd"), OsStr::new("--version")],
+            [OsStr::new(OC_RSYNC_D), OsStr::new("--version")],
             &mut expected_stdout,
             &mut expected_stderr,
         );
@@ -7945,7 +7956,7 @@ mod tests {
         assert!(expected_stderr.is_empty());
 
         let (code, stdout, stderr) = run_with_args([
-            OsStr::new("oc-rsync"),
+            OsStr::new(OC_RSYNC),
             OsStr::new("--daemon"),
             OsStr::new("--version"),
         ]);
@@ -7958,7 +7969,7 @@ mod tests {
     #[test]
     fn daemon_mode_arguments_ignore_operands_after_double_dash() {
         let args = vec![
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--"),
             OsString::from("--daemon"),
             OsString::from("dest"),
@@ -7969,7 +7980,7 @@ mod tests {
 
     #[test]
     fn help_flag_renders_static_help_snapshot() {
-        let (code, stdout, stderr) = run_with_args([OsStr::new("rsync"), OsStr::new("--help")]);
+        let (code, stdout, stderr) = run_with_args([OsStr::new(RSYNC), OsStr::new("--help")]);
 
         assert_eq!(code, 0);
         assert!(stderr.is_empty());
@@ -7980,7 +7991,7 @@ mod tests {
 
     #[test]
     fn oc_help_flag_uses_wrapped_program_name() {
-        let (code, stdout, stderr) = run_with_args([OsStr::new("oc-rsync"), OsStr::new("--help")]);
+        let (code, stdout, stderr) = run_with_args([OsStr::new(OC_RSYNC), OsStr::new("--help")]);
 
         assert_eq!(code, 0);
         assert!(stderr.is_empty());
@@ -7991,7 +8002,7 @@ mod tests {
 
     #[test]
     fn oc_help_mentions_oc_rsyncd_delegation() {
-        let (code, stdout, stderr) = run_with_args([OsStr::new("oc-rsync"), OsStr::new("--help")]);
+        let (code, stdout, stderr) = run_with_args([OsStr::new(OC_RSYNC), OsStr::new("--help")]);
 
         assert_eq!(code, 0);
         assert!(stderr.is_empty());
@@ -8005,7 +8016,7 @@ mod tests {
 
     #[test]
     fn oc_help_mentions_branded_daemon_phrase() {
-        let (code, stdout, stderr) = run_with_args([OsStr::new("oc-rsync"), OsStr::new("--help")]);
+        let (code, stdout, stderr) = run_with_args([OsStr::new(OC_RSYNC), OsStr::new("--help")]);
 
         assert_eq!(code, 0);
         assert!(stderr.is_empty());
@@ -8020,7 +8031,7 @@ mod tests {
     #[test]
     fn short_h_flag_enables_human_readable_mode() {
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("-h"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -8032,7 +8043,7 @@ mod tests {
 
     #[test]
     fn transfer_request_reports_missing_operands() {
-        let (code, stdout, stderr) = run_with_args([OsString::from("rsync")]);
+        let (code, stdout, stderr) = run_with_args([OsString::from(RSYNC)]);
 
         assert_eq!(code, 1);
         assert!(stdout.is_empty());
@@ -8052,7 +8063,7 @@ mod tests {
         std::fs::write(&source, b"data").expect("write source");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--chmod=a+q"),
             source.into_os_string(),
             destination.into_os_string(),
@@ -8074,7 +8085,7 @@ mod tests {
         std::fs::write(&source, b"cli copy").expect("write source");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             source.clone().into_os_string(),
             destination.clone().into_os_string(),
         ]);
@@ -8106,7 +8117,7 @@ mod tests {
         std::fs::write(dest_root.join("file.txt"), b"old data").expect("seed dest");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--backup"),
             source_dir.clone().into_os_string(),
             dest_dir.clone().into_os_string(),
@@ -8142,7 +8153,7 @@ mod tests {
         std::fs::write(dest_dir.join("source/nested/file.txt"), b"previous").expect("seed dest");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--backup-dir"),
             OsString::from("backups"),
             source_dir.clone().into_os_string(),
@@ -8181,7 +8192,7 @@ mod tests {
         std::fs::write(dest_root.join("file.txt"), b"stale").expect("seed dest");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--suffix"),
             OsString::from(".bak"),
             source_dir.clone().into_os_string(),
@@ -8210,7 +8221,7 @@ mod tests {
         std::fs::write(&source, b"verbose").expect("write source");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("-v"),
             source.clone().into_os_string(),
             destination.clone().into_os_string(),
@@ -8240,7 +8251,7 @@ mod tests {
 
         let dest_default = tmp.path().join("default");
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--stats"),
             source.clone().into_os_string(),
             dest_default.into_os_string(),
@@ -8254,7 +8265,7 @@ mod tests {
 
         let dest_human = tmp.path().join("human");
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--stats"),
             OsString::from("--human-readable"),
             source.into_os_string(),
@@ -8278,7 +8289,7 @@ mod tests {
 
         let dest_combined = tmp.path().join("combined");
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--stats"),
             OsString::from("--human-readable=2"),
             source.into_os_string(),
@@ -8311,7 +8322,7 @@ mod tests {
 
         let destination = tmp.path().join("dest.pipe");
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("-v"),
             source_fifo.clone().into_os_string(),
             destination.clone().into_os_string(),
@@ -8335,7 +8346,7 @@ mod tests {
 
         let dest_default = tmp.path().join("default.bin");
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("-vv"),
             source.clone().into_os_string(),
             dest_default.into_os_string(),
@@ -8348,7 +8359,7 @@ mod tests {
 
         let dest_human = tmp.path().join("human.bin");
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("-vv"),
             OsString::from("--human-readable"),
             source.into_os_string(),
@@ -8371,7 +8382,7 @@ mod tests {
 
         let destination = tmp.path().join("combined.bin");
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("-vv"),
             OsString::from("--human-readable=2"),
             source.into_os_string(),
@@ -8394,7 +8405,7 @@ mod tests {
         std::fs::write(&source, b"progress").expect("write source");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--progress"),
             source.clone().into_os_string(),
             destination.clone().into_os_string(),
@@ -8423,7 +8434,7 @@ mod tests {
 
         let destination_default = tmp.path().join("default-progress.bin");
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--progress"),
             source.clone().into_os_string(),
             destination_default.into_os_string(),
@@ -8437,7 +8448,7 @@ mod tests {
 
         let destination_human = tmp.path().join("human-progress.out");
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--progress"),
             OsString::from("--human-readable"),
             source.into_os_string(),
@@ -8461,7 +8472,7 @@ mod tests {
 
         let destination = tmp.path().join("combined-progress.out");
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--progress"),
             OsString::from("--human-readable=2"),
             source.into_os_string(),
@@ -8485,7 +8496,7 @@ mod tests {
         std::fs::write(&source, b"stderr-progress").expect("write source");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--progress"),
             OsString::from("--msgs2stderr"),
             source.clone().into_os_string(),
@@ -8524,7 +8535,7 @@ mod tests {
         std::fs::write(&source, &payload).expect("write large source");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--progress"),
             source.clone().into_os_string(),
             destination.clone().into_os_string(),
@@ -8565,7 +8576,7 @@ mod tests {
 
         let destination = tmp.path().join("fifo.out");
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--progress"),
             OsString::from("--specials"),
             source.clone().into_os_string(),
@@ -8603,7 +8614,7 @@ mod tests {
 
         let destination = tmp.path().join("info-fifo.out");
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--info=progress2"),
             OsString::from("--specials"),
             source.clone().into_os_string(),
@@ -8631,7 +8642,7 @@ mod tests {
         std::fs::write(&source, b"progress").expect("write source");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--progress"),
             OsString::from("-v"),
             source.clone().into_os_string(),
@@ -8659,7 +8670,7 @@ mod tests {
         std::fs::write(&source, payload).expect("write source");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--stats"),
             source.clone().into_os_string(),
             destination.clone().into_os_string(),
@@ -8702,7 +8713,7 @@ mod tests {
         std::fs::write(&source, payload).expect("write source");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--info=stats"),
             source.clone().into_os_string(),
             destination.clone().into_os_string(),
@@ -8734,7 +8745,7 @@ mod tests {
         std::fs::write(&source, b"payload").expect("write source");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--progress"),
             OsString::from("--info=none"),
             source.clone().into_os_string(),
@@ -8750,8 +8761,7 @@ mod tests {
 
     #[test]
     fn info_help_lists_supported_flags() {
-        let (code, stdout, stderr) =
-            run_with_args([OsStr::new("rsync"), OsStr::new("--info=help")]);
+        let (code, stdout, stderr) = run_with_args([OsStr::new(RSYNC), OsStr::new("--info=help")]);
 
         assert_eq!(code, 0);
         assert!(stderr.is_empty());
@@ -8760,8 +8770,7 @@ mod tests {
 
     #[test]
     fn debug_help_lists_supported_flags() {
-        let (code, stdout, stderr) =
-            run_with_args([OsStr::new("rsync"), OsStr::new("--debug=help")]);
+        let (code, stdout, stderr) = run_with_args([OsStr::new(RSYNC), OsStr::new("--debug=help")]);
 
         assert_eq!(code, 0);
         assert!(stderr.is_empty());
@@ -8771,7 +8780,7 @@ mod tests {
     #[test]
     fn info_rejects_unknown_flag() {
         let (code, stdout, stderr) =
-            run_with_args([OsStr::new("rsync"), OsStr::new("--info=unknown")]);
+            run_with_args([OsStr::new(RSYNC), OsStr::new("--info=unknown")]);
 
         assert_eq!(code, 1);
         assert!(stdout.is_empty());
@@ -8823,7 +8832,7 @@ mod tests {
         std::fs::write(&source, b"name-info").expect("write source");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--info=name"),
             source.clone().into_os_string(),
             destination.clone().into_os_string(),
@@ -8850,7 +8859,7 @@ mod tests {
         std::fs::write(&source, b"quiet").expect("write source");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("-v"),
             OsString::from("--info=name0"),
             source.clone().into_os_string(),
@@ -8874,7 +8883,7 @@ mod tests {
         std::fs::write(&source, b"unchanged").expect("write source");
 
         let initial = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             source.clone().into_os_string(),
             destination.clone().into_os_string(),
         ]);
@@ -8883,7 +8892,7 @@ mod tests {
         assert!(initial.2.is_empty());
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--info=name2"),
             source.into_os_string(),
             destination.into_os_string(),
@@ -8905,7 +8914,7 @@ mod tests {
         std::fs::write(&source, b"archive").expect("write source");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("-a"),
             source.clone().into_os_string(),
             destination.clone().into_os_string(),
@@ -8930,7 +8939,7 @@ mod tests {
         std::fs::write(&source, b"move me").expect("write source");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--remove-source-files"),
             source.clone().into_os_string(),
             destination.clone().into_os_string(),
@@ -8956,7 +8965,7 @@ mod tests {
         std::fs::write(&source, b"alias move").expect("write source");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--remove-sent-files"),
             source.clone().into_os_string(),
             destination.clone().into_os_string(),
@@ -8982,7 +8991,7 @@ mod tests {
         std::fs::write(&source, b"limited").expect("write source");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--bwlimit=2048"),
             source.clone().into_os_string(),
             destination.clone().into_os_string(),
@@ -9007,7 +9016,7 @@ mod tests {
         std::fs::write(&source, b"unlimited").expect("write source");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--no-bwlimit"),
             source.clone().into_os_string(),
             destination.clone().into_os_string(),
@@ -9033,7 +9042,7 @@ mod tests {
         std::fs::write(&source, b"format").expect("write source");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--out-format=%f %b"),
             source.clone().into_os_string(),
             dest_dir.clone().into_os_string(),
@@ -9061,7 +9070,7 @@ mod tests {
         std::fs::write(&source, b"itemized").expect("write source");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--itemize-changes"),
             source.clone().into_os_string(),
             dest_dir.clone().into_os_string(),
@@ -9092,7 +9101,7 @@ mod tests {
         std::fs::write(&destination, b"original").expect("write destination");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--ignore-existing"),
             source.clone().into_os_string(),
             destination.clone().into_os_string(),
@@ -9117,7 +9126,7 @@ mod tests {
         std::fs::write(&destination, b"existing").expect("write destination");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--ignore-missing-args"),
             missing.clone().into_os_string(),
             destination.clone().into_os_string(),
@@ -9151,7 +9160,7 @@ mod tests {
             .join("relative.txt");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--relative"),
             operand.into_os_string(),
             destination_root.clone().into_os_string(),
@@ -9190,7 +9199,7 @@ mod tests {
         let sparse_dest = tmp.path().join("sparse.bin");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             source.clone().into_os_string(),
             dense_dest.clone().into_os_string(),
         ]);
@@ -9199,7 +9208,7 @@ mod tests {
         assert!(stderr.is_empty());
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--sparse"),
             source.into_os_string(),
             sparse_dest.clone().into_os_string(),
@@ -9233,7 +9242,7 @@ mod tests {
         std::fs::create_dir(&dest_dir).expect("create dest");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from(format!("--files-from={}", list_path.display())),
             dest_dir.clone().into_os_string(),
         ]);
@@ -9276,7 +9285,7 @@ mod tests {
         std::fs::create_dir(&dest_dir).expect("create dest");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from(format!("--files-from={}", list_path.display())),
             dest_dir.clone().into_os_string(),
         ]);
@@ -9313,7 +9322,7 @@ mod tests {
         std::fs::create_dir(&dest_dir).expect("create dest");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--from0"),
             OsString::from(format!("--files-from={}", list_path.display())),
             dest_dir.clone().into_os_string(),
@@ -9347,7 +9356,7 @@ mod tests {
         std::fs::create_dir(&dest_dir).expect("create dest");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--from0"),
             OsString::from(format!("--files-from={}", list_path.display())),
             dest_dir.clone().into_os_string(),
@@ -9374,7 +9383,7 @@ mod tests {
         std::fs::create_dir(&dest_dir).expect("create dest");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from(format!("--files-from={}", missing.display())),
             dest_dir.into_os_string(),
         ]);
@@ -9430,7 +9439,7 @@ mod tests {
         std::fs::write(&source, b"metadata").expect("write source");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--owner"),
             OsString::from("--group"),
             source.clone().into_os_string(),
@@ -9463,7 +9472,7 @@ mod tests {
         std::fs::set_permissions(&source, PermissionsExt::from_mode(0o640)).expect("set perms");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--perms"),
             OsString::from("--times"),
             source.clone().into_os_string(),
@@ -9493,7 +9502,7 @@ mod tests {
         std::fs::set_permissions(&source, PermissionsExt::from_mode(0o600)).expect("set perms");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("-a"),
             OsString::from("--no-perms"),
             source.clone().into_os_string(),
@@ -9511,7 +9520,7 @@ mod tests {
     #[test]
     fn parse_args_recognises_perms_and_times_flags() {
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--perms"),
             OsString::from("--times"),
             OsString::from("--omit-dir-times"),
@@ -9527,7 +9536,7 @@ mod tests {
         assert_eq!(parsed.omit_link_times, Some(true));
 
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("-a"),
             OsString::from("--no-perms"),
             OsString::from("--no-times"),
@@ -9547,7 +9556,7 @@ mod tests {
     #[test]
     fn parse_args_recognises_super_flag() {
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--super"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -9560,7 +9569,7 @@ mod tests {
     #[test]
     fn parse_args_recognises_no_super_flag() {
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--no-super"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -9573,7 +9582,7 @@ mod tests {
     #[test]
     fn parse_args_collects_chmod_values() {
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--chmod=Du+rwx"),
             OsString::from("--chmod"),
             OsString::from("Fgo-w"),
@@ -9591,7 +9600,7 @@ mod tests {
     #[test]
     fn parse_args_recognises_update_flag() {
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--update"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -9604,7 +9613,7 @@ mod tests {
     #[test]
     fn parse_args_recognises_modify_window() {
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--modify-window=5"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -9617,7 +9626,7 @@ mod tests {
     #[test]
     fn parse_args_recognises_checksum_choice() {
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--checksum-choice=XXH128"),
         ])
         .expect("parse");
@@ -9630,7 +9639,7 @@ mod tests {
     #[test]
     fn parse_args_rejects_invalid_checksum_choice() {
         let error = match parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--checksum-choice=invalid"),
         ]) {
             Ok(_) => panic!("parse should fail"),
@@ -9648,7 +9657,7 @@ mod tests {
     #[test]
     fn parse_args_recognises_owner_overrides() {
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--owner"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -9659,7 +9668,7 @@ mod tests {
         assert_eq!(parsed.group, None);
 
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("-a"),
             OsString::from("--no-owner"),
             OsString::from("source"),
@@ -9674,7 +9683,7 @@ mod tests {
     #[test]
     fn parse_args_recognises_chown_option() {
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--chown=user:group"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -9687,22 +9696,22 @@ mod tests {
     #[test]
     fn parse_args_sets_protect_args_flag() {
         let parsed =
-            parse_args([OsString::from("rsync"), OsString::from("--protect-args")]).expect("parse");
+            parse_args([OsString::from(RSYNC), OsString::from("--protect-args")]).expect("parse");
 
         assert_eq!(parsed.protect_args, Some(true));
     }
 
     #[test]
     fn parse_args_sets_protect_args_alias() {
-        let parsed = parse_args([OsString::from("rsync"), OsString::from("--secluded-args")])
-            .expect("parse");
+        let parsed =
+            parse_args([OsString::from(RSYNC), OsString::from("--secluded-args")]).expect("parse");
 
         assert_eq!(parsed.protect_args, Some(true));
     }
 
     #[test]
     fn parse_args_sets_no_protect_args_flag() {
-        let parsed = parse_args([OsString::from("rsync"), OsString::from("--no-protect-args")])
+        let parsed = parse_args([OsString::from(RSYNC), OsString::from("--no-protect-args")])
             .expect("parse");
 
         assert_eq!(parsed.protect_args, Some(false));
@@ -9710,11 +9719,8 @@ mod tests {
 
     #[test]
     fn parse_args_sets_no_protect_args_alias() {
-        let parsed = parse_args([
-            OsString::from("rsync"),
-            OsString::from("--no-secluded-args"),
-        ])
-        .expect("parse");
+        let parsed = parse_args([OsString::from(RSYNC), OsString::from("--no-secluded-args")])
+            .expect("parse");
 
         assert_eq!(parsed.protect_args, Some(false));
     }
@@ -9722,7 +9728,7 @@ mod tests {
     #[test]
     fn parse_args_sets_ipv4_address_mode() {
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--ipv4"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -9735,7 +9741,7 @@ mod tests {
     #[test]
     fn parse_args_sets_ipv6_address_mode() {
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--ipv6"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -9748,7 +9754,7 @@ mod tests {
     #[test]
     fn parse_args_recognises_group_overrides() {
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--group"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -9759,7 +9765,7 @@ mod tests {
         assert_eq!(parsed.owner, None);
 
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("-a"),
             OsString::from("--no-group"),
             OsString::from("source"),
@@ -9776,7 +9782,7 @@ mod tests {
         let _env_lock = ENV_LOCK.lock().expect("env lock");
         let _guard = EnvGuard::set("RSYNC_PROTECT_ARGS", OsStr::new("1"));
 
-        let parsed = parse_args([OsString::from("rsync")]).expect("parse");
+        let parsed = parse_args([OsString::from(RSYNC)]).expect("parse");
 
         assert_eq!(parsed.protect_args, Some(true));
     }
@@ -9786,7 +9792,7 @@ mod tests {
         let _env_lock = ENV_LOCK.lock().expect("env lock");
         let _guard = EnvGuard::set("RSYNC_PROTECT_ARGS", OsStr::new("0"));
 
-        let parsed = parse_args([OsString::from("rsync")]).expect("parse");
+        let parsed = parse_args([OsString::from(RSYNC)]).expect("parse");
 
         assert_eq!(parsed.protect_args, Some(false));
     }
@@ -9794,7 +9800,7 @@ mod tests {
     #[test]
     fn parse_args_recognises_numeric_ids_flags() {
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--numeric-ids"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -9804,7 +9810,7 @@ mod tests {
         assert_eq!(parsed.numeric_ids, Some(true));
 
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--no-numeric-ids"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -9817,7 +9823,7 @@ mod tests {
     #[test]
     fn parse_args_recognises_sparse_flags() {
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--sparse"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -9827,7 +9833,7 @@ mod tests {
         assert_eq!(parsed.sparse, Some(true));
 
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--no-sparse"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -9840,7 +9846,7 @@ mod tests {
     #[test]
     fn parse_args_recognises_copy_links_flags() {
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--copy-links"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -9850,7 +9856,7 @@ mod tests {
         assert_eq!(parsed.copy_links, Some(true));
 
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--no-copy-links"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -9860,7 +9866,7 @@ mod tests {
         assert_eq!(parsed.copy_links, Some(false));
 
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("-L"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -9873,7 +9879,7 @@ mod tests {
     #[test]
     fn parse_args_recognises_copy_unsafe_links_flags() {
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--copy-unsafe-links"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -9884,7 +9890,7 @@ mod tests {
         assert!(parsed.safe_links);
 
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--no-copy-unsafe-links"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -9897,7 +9903,7 @@ mod tests {
     #[test]
     fn parse_args_recognises_hard_links_flags() {
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--hard-links"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -9907,7 +9913,7 @@ mod tests {
         assert_eq!(parsed.hard_links, Some(true));
 
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--no-hard-links"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -9917,7 +9923,7 @@ mod tests {
         assert_eq!(parsed.hard_links, Some(false));
 
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("-H"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -9930,7 +9936,7 @@ mod tests {
     #[test]
     fn parse_args_recognises_copy_dirlinks_flag() {
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--copy-dirlinks"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -9940,7 +9946,7 @@ mod tests {
         assert!(parsed.copy_dirlinks);
 
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("-k"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -9953,7 +9959,7 @@ mod tests {
     #[test]
     fn parse_args_recognises_keep_dirlinks_flags() {
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--keep-dirlinks"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -9963,7 +9969,7 @@ mod tests {
         assert_eq!(parsed.keep_dirlinks, Some(true));
 
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--no-keep-dirlinks"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -9973,7 +9979,7 @@ mod tests {
         assert_eq!(parsed.keep_dirlinks, Some(false));
 
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("-K"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -9986,7 +9992,7 @@ mod tests {
     #[test]
     fn parse_args_recognises_safe_links_flag() {
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--safe-links"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -9999,7 +10005,7 @@ mod tests {
     #[test]
     fn parse_args_recognises_cvs_exclude_flag() {
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--cvs-exclude"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -10009,7 +10015,7 @@ mod tests {
         assert!(parsed.cvs_exclude);
 
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("-C"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -10022,7 +10028,7 @@ mod tests {
     #[test]
     fn parse_args_recognises_partial_dir_and_enables_partial() {
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--partial-dir=.rsync-partial"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -10039,7 +10045,7 @@ mod tests {
     #[test]
     fn parse_args_recognises_temp_dir_flag() {
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--temp-dir=.rsync-tmp"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -10052,7 +10058,7 @@ mod tests {
     #[test]
     fn parse_args_resets_delay_updates_with_no_delay_updates() {
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--delay-updates"),
             OsString::from("--no-delay-updates"),
             OsString::from("source"),
@@ -10066,7 +10072,7 @@ mod tests {
     #[test]
     fn parse_args_allows_no_partial_to_clear_partial_dir() {
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--partial-dir=.rsync-partial"),
             OsString::from("--no-partial"),
             OsString::from("source"),
@@ -10081,7 +10087,7 @@ mod tests {
     #[test]
     fn parse_args_recognises_delay_updates_flag() {
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--delay-updates"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -10094,7 +10100,7 @@ mod tests {
     #[test]
     fn parse_args_recognises_no_delay_updates_flag() {
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--delay-updates"),
             OsString::from("--no-delay-updates"),
             OsString::from("source"),
@@ -10108,7 +10114,7 @@ mod tests {
     #[test]
     fn parse_args_collects_link_dest_paths() {
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--link-dest=baseline"),
             OsString::from("--link-dest=/var/cache"),
             OsString::from("source"),
@@ -10125,7 +10131,7 @@ mod tests {
     #[test]
     fn parse_args_recognises_devices_flags() {
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--devices"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -10135,7 +10141,7 @@ mod tests {
         assert_eq!(parsed.devices, Some(true));
 
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--no-devices"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -10148,7 +10154,7 @@ mod tests {
     #[test]
     fn parse_args_recognises_remove_sent_files_alias() {
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--remove-sent-files"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -10161,7 +10167,7 @@ mod tests {
     #[test]
     fn parse_args_recognises_specials_flags() {
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--specials"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -10171,7 +10177,7 @@ mod tests {
         assert_eq!(parsed.specials, Some(true));
 
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--no-specials"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -10184,7 +10190,7 @@ mod tests {
     #[test]
     fn parse_args_recognises_archive_devices_combo() {
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("-D"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -10198,7 +10204,7 @@ mod tests {
     #[test]
     fn parse_args_recognises_relative_flags() {
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--relative"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -10208,7 +10214,7 @@ mod tests {
         assert_eq!(parsed.relative, Some(true));
 
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--no-relative"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -10221,7 +10227,7 @@ mod tests {
     #[test]
     fn parse_args_recognises_one_file_system_flags() {
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--one-file-system"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -10231,7 +10237,7 @@ mod tests {
         assert_eq!(parsed.one_file_system, Some(true));
 
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--no-one-file-system"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -10241,7 +10247,7 @@ mod tests {
         assert_eq!(parsed.one_file_system, Some(false));
 
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("-x"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -10254,7 +10260,7 @@ mod tests {
     #[test]
     fn parse_args_recognises_implied_dirs_flags() {
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--implied-dirs"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -10264,7 +10270,7 @@ mod tests {
         assert_eq!(parsed.implied_dirs, Some(true));
 
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--no-implied-dirs"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -10277,7 +10283,7 @@ mod tests {
     #[test]
     fn parse_args_recognises_prune_empty_dirs_flags() {
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--prune-empty-dirs"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -10287,7 +10293,7 @@ mod tests {
         assert_eq!(parsed.prune_empty_dirs, Some(true));
 
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--no-prune-empty-dirs"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -10300,7 +10306,7 @@ mod tests {
     #[test]
     fn parse_args_recognises_inplace_flags() {
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--inplace"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -10310,7 +10316,7 @@ mod tests {
         assert_eq!(parsed.inplace, Some(true));
 
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--no-inplace"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -10323,7 +10329,7 @@ mod tests {
     #[test]
     fn parse_args_recognises_append_flags() {
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--append"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -10334,7 +10340,7 @@ mod tests {
         assert!(!parsed.append_verify);
 
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--no-append"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -10348,7 +10354,7 @@ mod tests {
     #[test]
     fn parse_args_captures_skip_compress_value() {
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--skip-compress=gz/mp3"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -10361,7 +10367,7 @@ mod tests {
     #[test]
     fn parse_args_recognises_append_verify_flag() {
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--append-verify"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -10375,7 +10381,7 @@ mod tests {
     #[test]
     fn parse_args_recognises_preallocate_flag() {
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--preallocate"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -10385,7 +10391,7 @@ mod tests {
         assert!(parsed.preallocate);
 
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("source"),
             OsString::from("dest"),
         ])
@@ -10397,7 +10403,7 @@ mod tests {
     #[test]
     fn parse_args_recognises_whole_file_flags() {
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("-W"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -10407,7 +10413,7 @@ mod tests {
         assert_eq!(parsed.whole_file, Some(true));
 
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--no-whole-file"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -10420,7 +10426,7 @@ mod tests {
     #[test]
     fn parse_args_recognises_stats_flag() {
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--stats"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -10433,7 +10439,7 @@ mod tests {
     #[test]
     fn parse_args_recognises_human_readable_flag() {
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--human-readable"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -10446,7 +10452,7 @@ mod tests {
     #[test]
     fn parse_args_recognises_no_human_readable_flag() {
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--no-human-readable"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -10459,7 +10465,7 @@ mod tests {
     #[test]
     fn parse_args_recognises_human_readable_level_two() {
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--human-readable=2"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -10472,7 +10478,7 @@ mod tests {
     #[test]
     fn parse_args_recognises_msgs2stderr_flag() {
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--msgs2stderr"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -10485,7 +10491,7 @@ mod tests {
     #[test]
     fn parse_args_collects_out_format_value() {
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--out-format=%f %b"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -10498,7 +10504,7 @@ mod tests {
     #[test]
     fn parse_args_recognises_itemize_changes_flag() {
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--itemize-changes"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -10511,7 +10517,7 @@ mod tests {
     #[test]
     fn parse_args_recognises_port_value() {
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--port=10873"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -10524,7 +10530,7 @@ mod tests {
     #[test]
     fn parse_args_recognises_list_only_flag() {
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--list-only"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -10538,7 +10544,7 @@ mod tests {
     #[test]
     fn parse_args_recognises_mkpath_flag() {
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--mkpath"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -10551,7 +10557,7 @@ mod tests {
     #[test]
     fn parse_args_recognises_no_bwlimit_flag() {
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--no-bwlimit"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -10564,7 +10570,7 @@ mod tests {
     #[test]
     fn parse_args_no_bwlimit_overrides_bwlimit_value() {
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--bwlimit=2M"),
             OsString::from("--no-bwlimit"),
             OsString::from("source"),
@@ -10578,7 +10584,7 @@ mod tests {
     #[test]
     fn parse_args_collects_filter_patterns() {
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--exclude"),
             OsString::from("*.tmp"),
             OsString::from("--include"),
@@ -10598,7 +10604,7 @@ mod tests {
     #[test]
     fn parse_args_collects_filter_files() {
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--exclude-from"),
             OsString::from("excludes.txt"),
             OsString::from("--include-from"),
@@ -10615,7 +10621,7 @@ mod tests {
     #[test]
     fn parse_args_collects_reference_destinations() {
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--compare-dest"),
             OsString::from("compare"),
             OsString::from("--copy-dest"),
@@ -10635,7 +10641,7 @@ mod tests {
     #[test]
     fn parse_args_collects_files_from_paths() {
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--files-from"),
             OsString::from("list-a"),
             OsString::from("--files-from"),
@@ -10654,7 +10660,7 @@ mod tests {
     #[test]
     fn parse_args_sets_from0_flag() {
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--from0"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -10667,7 +10673,7 @@ mod tests {
     #[test]
     fn parse_args_recognises_password_file() {
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--password-file"),
             OsString::from("secret.txt"),
             OsString::from("source"),
@@ -10678,7 +10684,7 @@ mod tests {
         assert_eq!(parsed.password_file, Some(OsString::from("secret.txt")));
 
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--password-file=secrets.d"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -10710,7 +10716,7 @@ mod tests {
     #[test]
     fn parse_args_recognises_no_motd_flag() {
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--no-motd"),
             OsString::from("rsync://example/"),
         ])
@@ -10722,7 +10728,7 @@ mod tests {
     #[test]
     fn parse_args_collects_protocol_value() {
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--protocol=30"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -10735,7 +10741,7 @@ mod tests {
     #[test]
     fn parse_args_collects_timeout_value() {
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--timeout=90"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -10748,7 +10754,7 @@ mod tests {
     #[test]
     fn parse_args_collects_contimeout_value() {
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--contimeout=45"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -10761,7 +10767,7 @@ mod tests {
     #[test]
     fn parse_args_collects_max_delete_value() {
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--max-delete=12"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -10774,7 +10780,7 @@ mod tests {
     #[test]
     fn parse_args_collects_checksum_seed_value() {
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--checksum-seed=42"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -10787,7 +10793,7 @@ mod tests {
     #[test]
     fn parse_args_collects_min_max_size_values() {
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--min-size=1.5K"),
             OsString::from("--max-size=2M"),
             OsString::from("source"),
@@ -11457,7 +11463,7 @@ mod tests {
     #[test]
     fn parse_args_sets_compress_flag() {
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("-z"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -11470,7 +11476,7 @@ mod tests {
     #[test]
     fn parse_args_no_compress_overrides_compress_flag() {
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("-z"),
             OsString::from("--no-compress"),
             OsString::from("source"),
@@ -11485,7 +11491,7 @@ mod tests {
     #[test]
     fn parse_args_records_compress_level_value() {
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--compress-level=5"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -11498,7 +11504,7 @@ mod tests {
     #[test]
     fn parse_args_compress_level_zero_records_disable() {
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--compress-level=0"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -11511,7 +11517,7 @@ mod tests {
     #[test]
     fn parse_args_recognises_compress_level_flag() {
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--compress-level=5"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -11525,7 +11531,7 @@ mod tests {
     #[test]
     fn parse_args_compress_level_zero_disables_compress() {
         let parsed = parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--compress-level=0"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -12065,7 +12071,7 @@ mod tests {
         set_file_times(&source, mtime, mtime).expect("set times");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--times"),
             source.clone().into_os_string(),
             destination.clone().into_os_string(),
@@ -12093,7 +12099,7 @@ mod tests {
         std::fs::write(source_root.join("skip.tmp"), b"skip").expect("write skip");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--filter"),
             OsString::from("- *.tmp"),
             source_root.clone().into_os_string(),
@@ -12122,7 +12128,7 @@ mod tests {
         std::fs::write(source_root.join("skip.tmp"), b"skip").expect("write skip");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--filter"),
             OsString::from("- *.tmp"),
             OsString::from("--filter"),
@@ -12158,7 +12164,7 @@ mod tests {
         let filter_arg = OsString::from(format!("merge {}", filter_file.display()));
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--filter"),
             filter_arg,
             source_root.clone().into_os_string(),
@@ -12193,7 +12199,7 @@ mod tests {
         let filter_arg = OsString::from(format!("merge {}", filter_file.display()));
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--filter"),
             filter_arg,
             source_root.clone().into_os_string(),
@@ -12225,7 +12231,7 @@ mod tests {
         std::fs::write(dest_subdir.join("keep.txt"), b"keep").expect("write dest keep");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--delete"),
             OsString::from("--filter"),
             OsString::from("protect keep.txt"),
@@ -12257,7 +12263,7 @@ mod tests {
         std::fs::write(dest_subdir.join("skip.log"), b"skip").expect("write excluded file");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--delete-excluded"),
             OsString::from("--exclude=*.log"),
             source_root.clone().into_os_string(),
@@ -12290,7 +12296,7 @@ mod tests {
         let filter_arg = OsString::from(format!("merge {}", filter_file.display()));
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--filter"),
             filter_arg,
             source_root.into_os_string(),
@@ -12319,7 +12325,7 @@ mod tests {
         std::fs::write(&exclude_file, "# comment\n\n*.tmp\n").expect("write filters");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--exclude-from"),
             exclude_file.as_os_str().to_os_string(),
             source_root.clone().into_os_string(),
@@ -12355,7 +12361,7 @@ mod tests {
         std::fs::write(git_dir.join("config"), b"git").expect("write git config");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--cvs-exclude"),
             source_root.clone().into_os_string(),
             dest_root.clone().into_os_string(),
@@ -12389,7 +12395,7 @@ mod tests {
         std::fs::write(source_root.join(".cvsignore"), b"skip.log\n").expect("write cvsignore");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--cvs-exclude"),
             source_root.clone().into_os_string(),
             dest_root.clone().into_os_string(),
@@ -12421,7 +12427,7 @@ mod tests {
         std::fs::write(source_root.join("skip.tmp"), b"skip").expect("write skip");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--cvs-exclude"),
             source_root.clone().into_os_string(),
             dest_root.clone().into_os_string(),
@@ -12479,7 +12485,7 @@ mod tests {
         source_operand.push(std::path::MAIN_SEPARATOR.to_string());
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--exclude"),
             OsString::from("*"),
             OsString::from("--include-from"),
@@ -12499,7 +12505,7 @@ mod tests {
     #[test]
     fn transfer_request_reports_filter_file_errors() {
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--exclude-from"),
             OsString::from("missing.txt"),
             OsString::from("src"),
@@ -12719,7 +12725,7 @@ mod tests {
         set_file_times(&source, mtime, mtime).expect("set times");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("-a"),
             OsString::from("--no-times"),
             source.clone().into_os_string(),
@@ -12754,7 +12760,7 @@ mod tests {
         set_file_times(&source_file, dir_mtime, dir_mtime).expect("set file times");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("-a"),
             OsString::from("--omit-dir-times"),
             source_root.clone().into_os_string(),
@@ -12800,7 +12806,7 @@ mod tests {
         set_symlink_file_times(&source_link, timestamp, timestamp).expect("set symlink times");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("-a"),
             OsString::from("--omit-link-times"),
             source_root.clone().into_os_string(),
@@ -12834,7 +12840,7 @@ mod tests {
         std::fs::write(&source, b"payload").expect("write source");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--no-times"),
             source.clone().into_os_string(),
             destination.clone().into_os_string(),
@@ -12848,7 +12854,7 @@ mod tests {
         set_file_mtime(&destination, preserved).expect("set destination mtime");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--checksum"),
             OsString::from("--no-times"),
             source.into_os_string(),
@@ -12882,7 +12888,7 @@ mod tests {
 
         super::set_filter_stdin_input(b"*.tmp\n".to_vec());
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--exclude-from"),
             OsString::from("-"),
             source_root.clone().into_os_string(),
@@ -12901,7 +12907,7 @@ mod tests {
     #[test]
     fn bwlimit_invalid_value_reports_error() {
         let (code, stdout, stderr) =
-            run_with_args([OsString::from("rsync"), OsString::from("--bwlimit=oops")]);
+            run_with_args([OsString::from(RSYNC), OsString::from("--bwlimit=oops")]);
 
         assert_eq!(code, 1);
         assert!(stdout.is_empty());
@@ -12913,7 +12919,7 @@ mod tests {
     #[test]
     fn bwlimit_rejects_small_fractional_values() {
         let (code, stdout, stderr) =
-            run_with_args([OsString::from("rsync"), OsString::from("--bwlimit=0.4")]);
+            run_with_args([OsString::from(RSYNC), OsString::from("--bwlimit=0.4")]);
 
         assert_eq!(code, 1);
         assert!(stdout.is_empty());
@@ -12974,7 +12980,7 @@ mod tests {
     #[test]
     fn bwlimit_rejects_negative_values() {
         let (code, stdout, stderr) =
-            run_with_args([OsString::from("rsync"), OsString::from("--bwlimit=-1")]);
+            run_with_args([OsString::from(RSYNC), OsString::from("--bwlimit=-1")]);
 
         assert_eq!(code, 1);
         assert!(stdout.is_empty());
@@ -12985,7 +12991,7 @@ mod tests {
     #[test]
     fn compress_level_invalid_value_reports_error() {
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--compress-level=fast"),
         ]);
 
@@ -12997,10 +13003,8 @@ mod tests {
 
     #[test]
     fn compress_level_out_of_range_reports_error() {
-        let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
-            OsString::from("--compress-level=12"),
-        ]);
+        let (code, stdout, stderr) =
+            run_with_args([OsString::from(RSYNC), OsString::from("--compress-level=12")]);
 
         assert_eq!(code, 1);
         assert!(stdout.is_empty());
@@ -13011,7 +13015,7 @@ mod tests {
     #[test]
     fn skip_compress_invalid_reports_error() {
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--skip-compress=mp[]"),
         ]);
 
@@ -13030,7 +13034,7 @@ mod tests {
         let _fallback_guard = EnvGuard::set(CLIENT_FALLBACK_ENV, missing.as_os_str());
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("remote::module"),
             OsString::from("dest"),
         ]);
@@ -13054,7 +13058,7 @@ mod tests {
         ]);
 
         let url = format!("rsync://{}:{}/", addr.ip(), addr.port());
-        let (code, stdout, stderr) = run_with_args([OsString::from("rsync"), OsString::from(url)]);
+        let (code, stdout, stderr) = run_with_args([OsString::from(RSYNC), OsString::from(url)]);
 
         assert_eq!(code, 0);
         assert!(stderr.is_empty());
@@ -13078,7 +13082,7 @@ mod tests {
 
         let url = format!("rsync://{}:{}/", addr.ip(), addr.port());
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--no-motd"),
             OsString::from(url),
         ]);
@@ -13117,7 +13121,7 @@ exit 99
         let _marker_guard = EnvGuard::set("MARKER_FILE", marker_path.as_os_str());
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--rsync-path=/opt/custom/rsync"),
             OsString::from(url.clone()),
         ]);
@@ -13140,7 +13144,7 @@ exit 99
 
         let url = format!("rsync://{}:{}/", addr.ip(), addr.port());
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--protocol=29"),
             OsString::from(url),
         ]);
@@ -13164,7 +13168,7 @@ exit 99
         ]);
 
         let url = format!("rsync://{}:{}/", addr.ip(), addr.port());
-        let (code, stdout, stderr) = run_with_args([OsString::from("rsync"), OsString::from(url)]);
+        let (code, stdout, stderr) = run_with_args([OsString::from(RSYNC), OsString::from(url)]);
 
         assert_eq!(code, 0);
         assert!(
@@ -13184,7 +13188,7 @@ exit 99
         let (addr, handle) = spawn_stub_daemon(vec!["@ERROR: unavailable\n", "@RSYNCD: EXIT\n"]);
 
         let url = format!("rsync://{}:{}/", addr.ip(), addr.port());
-        let (code, stdout, stderr) = run_with_args([OsString::from("rsync"), OsString::from(url)]);
+        let (code, stdout, stderr) = run_with_args([OsString::from(RSYNC), OsString::from(url)]);
 
         assert_eq!(code, 23);
         assert!(stdout.is_empty());
@@ -13204,7 +13208,7 @@ exit 99
         ]);
 
         let url = format!("rsync://user@{}:{}/", addr.ip(), addr.port());
-        let (code, stdout, stderr) = run_with_args([OsString::from("rsync"), OsString::from(url)]);
+        let (code, stdout, stderr) = run_with_args([OsString::from(RSYNC), OsString::from(url)]);
 
         assert_eq!(code, 0);
         assert!(stderr.is_empty());
@@ -13232,7 +13236,7 @@ printf "example\tvia connect program\n@RSYNCD: EXIT\n"
         write_executable_script(&script_path, script);
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from(format!("--connect-program={}", script_path.display())),
             OsString::from("rsync://example/"),
         ]);
@@ -13249,7 +13253,7 @@ printf "example\tvia connect program\n@RSYNCD: EXIT\n"
             spawn_stub_daemon(vec!["@RSYNCD: OK\n", "module\n", "@RSYNCD: EXIT\n"]);
 
         let url = format!("user@[{}]:{}::", addr.ip(), addr.port());
-        let (code, stdout, stderr) = run_with_args([OsString::from("rsync"), OsString::from(url)]);
+        let (code, stdout, stderr) = run_with_args([OsString::from(RSYNC), OsString::from(url)]);
 
         assert_eq!(code, 0);
         assert!(stderr.is_empty());
@@ -13300,7 +13304,7 @@ printf "example\tvia connect program\n@RSYNCD: EXIT\n"
 
         let url = format!("rsync://user@{}:{}/", addr.ip(), addr.port());
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from(format!("--password-file={}", password_path.display())),
             OsString::from(url),
         ]);
@@ -13340,7 +13344,7 @@ printf "example\tvia connect program\n@RSYNCD: EXIT\n"
 
         let url = format!("rsync://user@{}:{}/", addr.ip(), addr.port());
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--password-file=-"),
             OsString::from(url),
         ]);
@@ -13373,7 +13377,7 @@ printf "example\tvia connect program\n@RSYNCD: EXIT\n"
 
         let url = String::from("rsync://user@127.0.0.1:873/");
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from(format!("--password-file={}", password_path.display())),
             OsString::from(url),
         ]);
@@ -13410,7 +13414,7 @@ printf "example\tvia connect program\n@RSYNCD: EXIT\n"
         std::fs::write(&source, b"data").expect("write source");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from(format!("--password-file={}", password_path.display())),
             source.clone().into_os_string(),
             destination.clone().into_os_string(),
@@ -13427,7 +13431,7 @@ printf "example\tvia connect program\n@RSYNCD: EXIT\n"
     #[test]
     fn password_file_dash_conflicts_with_files_from_dash() {
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--files-from=-"),
             OsString::from("--password-file=-"),
             OsString::from("/tmp/dest"),
@@ -13449,7 +13453,7 @@ printf "example\tvia connect program\n@RSYNCD: EXIT\n"
         std::fs::write(&source, b"data").expect("write source");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--protocol=30"),
             source.clone().into_os_string(),
             destination.clone().into_os_string(),
@@ -13466,7 +13470,7 @@ printf "example\tvia connect program\n@RSYNCD: EXIT\n"
     #[test]
     fn invalid_protocol_value_reports_error() {
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--protocol=27"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -13482,7 +13486,7 @@ printf "example\tvia connect program\n@RSYNCD: EXIT\n"
     #[test]
     fn non_numeric_protocol_value_reports_error() {
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--protocol=abc"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -13530,7 +13534,7 @@ printf "example\tvia connect program\n@RSYNCD: EXIT\n"
         let mut stdout = Vec::new();
         let mut stderr = Vec::new();
         let status = run(
-            [OsString::from("rsync"), OsString::from("--version=extra")],
+            [OsString::from(RSYNC), OsString::from("--version=extra")],
             &mut stdout,
             &mut stderr,
         );
@@ -13545,7 +13549,7 @@ printf "example\tvia connect program\n@RSYNCD: EXIT\n"
     #[test]
     fn delete_flag_is_parsed() {
         let parsed = super::parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--delete"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -13559,7 +13563,7 @@ printf "example\tvia connect program\n@RSYNCD: EXIT\n"
     #[test]
     fn delete_alias_del_is_parsed() {
         let parsed = super::parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--del"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -13573,7 +13577,7 @@ printf "example\tvia connect program\n@RSYNCD: EXIT\n"
     #[test]
     fn delete_after_flag_is_parsed() {
         let parsed = super::parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--delete-after"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -13587,7 +13591,7 @@ printf "example\tvia connect program\n@RSYNCD: EXIT\n"
     #[test]
     fn delete_before_flag_is_parsed() {
         let parsed = super::parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--delete-before"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -13601,7 +13605,7 @@ printf "example\tvia connect program\n@RSYNCD: EXIT\n"
     #[test]
     fn delete_during_flag_is_parsed() {
         let parsed = super::parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--delete-during"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -13615,7 +13619,7 @@ printf "example\tvia connect program\n@RSYNCD: EXIT\n"
     #[test]
     fn delete_delay_flag_is_parsed() {
         let parsed = super::parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--delete-delay"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -13629,7 +13633,7 @@ printf "example\tvia connect program\n@RSYNCD: EXIT\n"
     #[test]
     fn delete_excluded_flag_implies_delete() {
         let parsed = super::parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--delete-excluded"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -13643,7 +13647,7 @@ printf "example\tvia connect program\n@RSYNCD: EXIT\n"
     #[test]
     fn archive_flag_is_parsed() {
         let parsed = super::parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("-a"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -13658,7 +13662,7 @@ printf "example\tvia connect program\n@RSYNCD: EXIT\n"
     #[test]
     fn long_archive_flag_is_parsed() {
         let parsed = super::parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--archive"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -13671,7 +13675,7 @@ printf "example\tvia connect program\n@RSYNCD: EXIT\n"
     #[test]
     fn checksum_flag_is_parsed() {
         let parsed = super::parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--checksum"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -13684,7 +13688,7 @@ printf "example\tvia connect program\n@RSYNCD: EXIT\n"
     #[test]
     fn size_only_flag_is_parsed() {
         let parsed = super::parse_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--size-only"),
             OsString::from("source"),
             OsString::from("dest"),
@@ -13704,7 +13708,7 @@ printf "example\tvia connect program\n@RSYNCD: EXIT\n"
         std::fs::write(&source, b"combo").expect("write source");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("-av"),
             source.clone().into_os_string(),
             destination.clone().into_os_string(),
@@ -13731,7 +13735,7 @@ printf "example\tvia connect program\n@RSYNCD: EXIT\n"
         std::fs::write(&source, b"compressed").expect("write source");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("-z"),
             source.clone().into_os_string(),
             destination.clone().into_os_string(),
@@ -13756,7 +13760,7 @@ printf "example\tvia connect program\n@RSYNCD: EXIT\n"
         std::fs::write(&source, b"payload").expect("write source");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--compress-level=6"),
             source.clone().into_os_string(),
             destination.clone().into_os_string(),
@@ -13781,7 +13785,7 @@ printf "example\tvia connect program\n@RSYNCD: EXIT\n"
         std::fs::write(&source, b"payload").expect("write source");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--compress-level=0"),
             OsString::from("-z"),
             source.clone().into_os_string(),
@@ -13835,7 +13839,7 @@ exit 37
         let mut stderr = io::sink();
         let exit_code = run(
             [
-                OsString::from("rsync"),
+                OsString::from(RSYNC),
                 OsString::from("--server"),
                 OsString::from("--sender"),
                 OsString::from("."),
@@ -13873,7 +13877,7 @@ exit 0
         let mut stderr = Vec::new();
         let exit_code = run(
             [
-                OsString::from("rsync"),
+                OsString::from(RSYNC),
                 OsString::from("--server"),
                 OsString::from("--sender"),
                 OsString::from("."),
@@ -13900,7 +13904,7 @@ exit 0
         let mut stderr = Vec::new();
         let exit_code = run(
             [
-                OsString::from("rsync"),
+                OsString::from(RSYNC),
                 OsString::from("--server"),
                 OsString::from("--sender"),
                 OsString::from("."),
@@ -13942,7 +13946,7 @@ exit 7
         let _args_guard = EnvGuard::set("ARGS_FILE", args_path.as_os_str());
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--dry-run"),
             OsString::from("remote::module/path"),
             OsString::from("dest"),
@@ -13986,7 +13990,7 @@ exit 0
         let _args_guard = EnvGuard::set("ARGS_FILE", args_path.as_os_str());
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--ipv4"),
             OsString::from("remote::module"),
             OsString::from("dest"),
@@ -14023,7 +14027,7 @@ exit 0
         let _args_guard = EnvGuard::set("ARGS_FILE", args_path.as_os_str());
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--ipv6"),
             OsString::from("remote::module"),
             OsString::from("dest"),
@@ -14060,7 +14064,7 @@ exit 0
         let _args_guard = EnvGuard::set("ARGS_FILE", args_path.as_os_str());
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("-F"),
             OsString::from("remote::module"),
             OsString::from("dest"),
@@ -14097,7 +14101,7 @@ exit 0
         let _args_guard = EnvGuard::set("ARGS_FILE", args_path.as_os_str());
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("-FF"),
             OsString::from("remote::module"),
             OsString::from("dest"),
@@ -14134,7 +14138,7 @@ exit 0
         let _args_guard = EnvGuard::set("ARGS_FILE", args_path.as_os_str());
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--list-only"),
             OsString::from("rsync://example.com/module"),
         ]);
@@ -14186,7 +14190,7 @@ exit 0
         let _files_guard = EnvGuard::set("FILES_COPY", files_copy_path.as_os_str());
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from(format!("--files-from={}", list_path.display())),
             OsString::from("remote::module"),
             dest_path.clone().into_os_string(),
@@ -14230,7 +14234,7 @@ exit 0
         let dest_path = temp.path().join("dest");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from(format!("--partial-dir={}", partial_dir.display())),
             OsString::from("remote::module"),
             dest_path.clone().into_os_string(),
@@ -14281,7 +14285,7 @@ exit 0
         let dest_path = temp.path().join("dest");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from(format!("--temp-dir={}", temp_dir.display())),
             OsString::from("remote::module"),
             dest_path.clone().into_os_string(),
@@ -14328,7 +14332,7 @@ exit 0
         let dest_path = temp.path().join("dest");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--backup"),
             OsString::from("remote::module"),
             dest_path.clone().into_os_string(),
@@ -14347,7 +14351,7 @@ exit 0
         std::fs::write(&args_path, b"").expect("truncate args file");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--backup-dir"),
             OsString::from("backups"),
             OsString::from("remote::module"),
@@ -14367,7 +14371,7 @@ exit 0
         std::fs::write(&args_path, b"").expect("truncate args file");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--suffix"),
             OsString::from(".bak"),
             OsString::from("remote::module"),
@@ -14408,7 +14412,7 @@ exit 0
         let dest_path = temp.path().join("dest");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--link-dest"),
             OsString::from("baseline"),
             OsString::from("--link-dest"),
@@ -14465,7 +14469,7 @@ exit 0
         let dest_path = temp.path().join("dest");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--link-dest=baseline"),
             OsString::from("--link-dest=/var/cache"),
             OsString::from("--compare-dest=compare"),
@@ -14515,7 +14519,7 @@ exit 0
         let _args_guard = EnvGuard::set("ARGS_FILE", args_path.as_os_str());
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--compress-level=7"),
             OsString::from("remote::module"),
             OsString::from("dest"),
@@ -14552,7 +14556,7 @@ exit 0
         let _args_guard = EnvGuard::set("ARGS_FILE", args_path.as_os_str());
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--skip-compress=gz/mp3"),
             OsString::from("remote::module"),
             OsString::from("dest"),
@@ -14570,7 +14574,7 @@ exit 0
         );
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--skip-compress="),
             OsString::from("remote::module"),
             OsString::from("dest"),
@@ -14605,7 +14609,7 @@ exit 0
         let _args_guard = EnvGuard::set("ARGS_FILE", args_path.as_os_str());
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--compress-level=0"),
             OsString::from("remote::module"),
             OsString::from("dest"),
@@ -14641,7 +14645,7 @@ exit 0
         let _fallback_guard = EnvGuard::set(CLIENT_FALLBACK_ENV, script_path.as_os_str());
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("remote::module"),
             OsString::from("dest"),
         ]);
@@ -14689,7 +14693,7 @@ exit 0
         let _files_guard = EnvGuard::set("FILES_COPY", files_copy_path.as_os_str());
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--from0"),
             OsString::from(format!("--files-from={}", list_path.display())),
             OsString::from("remote::module"),
@@ -14733,7 +14737,7 @@ exit 0
         let dest_path = temp.path().join("dest");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("-W"),
             OsString::from("remote::module"),
             dest_path.clone().into_os_string(),
@@ -14755,7 +14759,7 @@ exit 0
         std::fs::write(&args_path, b"").expect("truncate args file");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--no-whole-file"),
             OsString::from("remote::module"),
             dest_path.into_os_string(),
@@ -14794,7 +14798,7 @@ exit 0
         let dest_path = temp.path().join("dest");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--hard-links"),
             OsString::from("remote::module"),
             dest_path.clone().into_os_string(),
@@ -14812,7 +14816,7 @@ exit 0
         std::fs::write(&args_path, b"").expect("truncate args file");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--no-hard-links"),
             OsString::from("remote::module"),
             dest_path.into_os_string(),
@@ -14851,7 +14855,7 @@ exit 0
         let dest_path = temp.path().join("dest");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--append"),
             OsString::from("remote::module"),
             dest_path.clone().into_os_string(),
@@ -14870,7 +14874,7 @@ exit 0
         std::fs::write(&args_path, b"").expect("truncate args file");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--no-append"),
             OsString::from("remote::module"),
             dest_path.clone().into_os_string(),
@@ -14889,7 +14893,7 @@ exit 0
         std::fs::write(&args_path, b"").expect("truncate args file");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--append-verify"),
             OsString::from("remote::module"),
             dest_path.into_os_string(),
@@ -14929,7 +14933,7 @@ exit 0
         let dest_path = temp.path().join("dest");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--preallocate"),
             OsString::from("remote::module"),
             dest_path.clone().into_os_string(),
@@ -14946,7 +14950,7 @@ exit 0
         std::fs::write(&args_path, b"").expect("truncate args file");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("remote::module"),
             dest_path.into_os_string(),
         ]);
@@ -14981,7 +14985,7 @@ exit 0
         let _args_guard = EnvGuard::set("ARGS_FILE", args_path.as_os_str());
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--bwlimit=1M:64K"),
             OsString::from("remote::module"),
             OsString::from("dest"),
@@ -15029,7 +15033,7 @@ exit 0
         let _args_guard = EnvGuard::set("ARGS_FILE", args_path.as_os_str());
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--no-bwlimit"),
             OsString::from("remote::module"),
             OsString::from("dest"),
@@ -15075,7 +15079,7 @@ exit 0
         let dest_path = temp.path().join("dest");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--safe-links"),
             OsString::from("remote::module"),
             dest_path.clone().into_os_string(),
@@ -15092,7 +15096,7 @@ exit 0
         std::fs::write(&args_path, b"").expect("truncate args file");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("remote::module"),
             dest_path.into_os_string(),
         ]);
@@ -15127,7 +15131,7 @@ exit 0
 
         let destination = temp.path().join("dest");
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--no-implied-dirs"),
             OsString::from("remote::module"),
             destination.clone().into_os_string(),
@@ -15145,7 +15149,7 @@ exit 0
         std::fs::write(&args_path, b"").expect("truncate args file");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--implied-dirs"),
             OsString::from("remote::module"),
             destination.into_os_string(),
@@ -15184,7 +15188,7 @@ exit 0
         let destination = temp.path().join("dest");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--prune-empty-dirs"),
             OsString::from("remote::module"),
             destination.clone().into_os_string(),
@@ -15202,7 +15206,7 @@ exit 0
         std::fs::write(&args_path, b"").expect("truncate args file");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--no-prune-empty-dirs"),
             OsString::from("remote::module"),
             destination.into_os_string(),
@@ -15240,7 +15244,7 @@ exit 0
 
         let destination = temp.path().join("dest");
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--delete-after"),
             OsString::from("remote::module"),
             destination.into_os_string(),
@@ -15279,7 +15283,7 @@ exit 0
 
         let destination = temp.path().join("dest");
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--delete-before"),
             OsString::from("remote::module"),
             destination.into_os_string(),
@@ -15318,7 +15322,7 @@ exit 0
 
         let destination = temp.path().join("dest");
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--delete-during"),
             OsString::from("remote::module"),
             destination.into_os_string(),
@@ -15359,7 +15363,7 @@ exit 0
 
         let destination = temp.path().join("dest");
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--delete-delay"),
             OsString::from("remote::module"),
             destination.into_os_string(),
@@ -15400,7 +15404,7 @@ exit 0
 
         let destination = temp.path().join("dest");
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--max-delete=5"),
             OsString::from("remote::module"),
             destination.into_os_string(),
@@ -15438,7 +15442,7 @@ exit 0
 
         let destination = temp.path().join("dest");
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--modify-window=5"),
             OsString::from("remote::module"),
             destination.into_os_string(),
@@ -15475,7 +15479,7 @@ exit 0
 
         let destination = temp.path().join("dest");
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--min-size=1.5K"),
             OsString::from("--max-size=2M"),
             OsString::from("remote::module"),
@@ -15514,7 +15518,7 @@ exit 0
 
         let destination = temp.path().join("dest");
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--update"),
             OsString::from("remote::module"),
             destination.into_os_string(),
@@ -15551,7 +15555,7 @@ exit 0
 
         let destination = temp.path().join("dest");
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--debug=io,events"),
             OsString::from("remote::module"),
             destination.into_os_string(),
@@ -15589,7 +15593,7 @@ exit 0
 
         let destination = temp.path().join("dest");
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--protect-args"),
             OsString::from("remote::module"),
             destination.into_os_string(),
@@ -15627,7 +15631,7 @@ exit 0
 
         let destination = temp.path().join("dest");
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--human-readable"),
             OsString::from("remote::module"),
             destination.into_os_string(),
@@ -15666,7 +15670,7 @@ exit 0
 
         let destination = temp.path().join("dest");
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--no-human-readable"),
             OsString::from("remote::module"),
             destination.into_os_string(),
@@ -15705,7 +15709,7 @@ exit 0
 
         let destination = temp.path().join("dest");
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--human-readable=2"),
             OsString::from("remote::module"),
             destination.into_os_string(),
@@ -15744,7 +15748,7 @@ exit 0
 
         let destination = temp.path().join("dest");
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--super"),
             OsString::from("remote::module"),
             destination.into_os_string(),
@@ -15781,7 +15785,7 @@ exit 0
 
         let destination = temp.path().join("dest");
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--no-super"),
             OsString::from("remote::module"),
             destination.into_os_string(),
@@ -15819,7 +15823,7 @@ exit 0
 
         let destination = temp.path().join("dest");
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--info=progress2"),
             OsString::from("remote::module"),
             destination.into_os_string(),
@@ -15856,7 +15860,7 @@ exit 0
 
         let destination = temp.path().join("dest");
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--no-secluded-args"),
             OsString::from("remote::module"),
             destination.into_os_string(),
@@ -15895,7 +15899,7 @@ exit 0
 
         let destination = temp.path().join("dest");
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("remote::module"),
             destination.into_os_string(),
         ]);
@@ -15931,7 +15935,7 @@ exit 0
         let _args_guard = EnvGuard::set("ARGS_FILE", args_path.as_os_str());
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--compress-level=0"),
             OsString::from("remote::module"),
             OsString::from("dest"),
@@ -15977,7 +15981,7 @@ exit 0
         std::fs::write(&source, b"contents").expect("write source");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--no-whole-file"),
             source.clone().into_os_string(),
             destination.clone().into_os_string(),
@@ -16024,7 +16028,7 @@ exit 0
 
         let dest_path = temp.path().join("dest");
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from(format!("--password-file={}", password_path.display())),
             OsString::from("--protocol=30"),
             OsString::from("--timeout=120"),
@@ -16073,7 +16077,7 @@ exit 0
 
         let dest_path = temp.path().join("dest");
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("-e"),
             OsString::from("ssh -p 2222"),
             OsString::from("remote::module"),
@@ -16110,7 +16114,7 @@ exit 0
 
         let dest_path = temp.path().join("dest");
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--rsync-path=/opt/custom/rsync"),
             OsString::from("remote::module"),
             dest_path.clone().into_os_string(),
@@ -16146,7 +16150,7 @@ exit 0
 
         let dest_path = temp.path().join("dest");
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--connect-program=nc %H %P"),
             OsString::from("remote::module"),
             dest_path.clone().into_os_string(),
@@ -16182,7 +16186,7 @@ exit 0
 
         let dest_path = temp.path().join("dest");
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--port=10873"),
             OsString::from("remote::module"),
             dest_path.clone().into_os_string(),
@@ -16217,7 +16221,7 @@ exit 0
 
         let dest_path = temp.path().join("dest");
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--remote-option=--log-file=/tmp/rsync.log"),
             OsString::from("remote::module"),
             dest_path.clone().into_os_string(),
@@ -16257,7 +16261,7 @@ exit 0
 
         let dest_path = temp.path().join("dest");
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("-M"),
             OsString::from("--log-format=%n"),
             OsString::from("remote::module"),
@@ -16295,7 +16299,7 @@ exit 0
 
         let dest_path = temp.path().join("dest");
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("remote::module"),
             dest_path.clone().into_os_string(),
         ]);
@@ -16331,7 +16335,7 @@ exit 0
 
         let dest_path = temp.path().join("dest");
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("-e"),
             OsString::from("ssh -p 2222"),
             OsString::from("remote::module"),
@@ -16357,7 +16361,7 @@ exit 0
         std::fs::write(&source, b"content").expect("write source");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--rsync-path=/opt/custom/rsync"),
             source.clone().into_os_string(),
             dest.clone().into_os_string(),
@@ -16382,7 +16386,7 @@ exit 0
         std::fs::write(&source, b"content").expect("write source");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--connect-program=/usr/bin/nc %H %P"),
             source.clone().into_os_string(),
             dest.clone().into_os_string(),
@@ -16407,7 +16411,7 @@ exit 0
         std::fs::write(&source, b"content").expect("write source");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--remote-option=--log-file=/tmp/rsync.log"),
             source.clone().into_os_string(),
             dest.clone().into_os_string(),
@@ -16444,7 +16448,7 @@ exit 0
 
         let dest_path = temp.path().join("dest");
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--acls"),
             OsString::from("remote::module"),
             dest_path.clone().into_os_string(),
@@ -16480,7 +16484,7 @@ exit 0
 
         let dest_path = temp.path().join("dest");
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--omit-dir-times"),
             OsString::from("remote::module"),
             dest_path.clone().into_os_string(),
@@ -16516,7 +16520,7 @@ exit 0
 
         let dest_path = temp.path().join("dest");
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--omit-link-times"),
             OsString::from("remote::module"),
             dest_path.clone().into_os_string(),
@@ -16553,7 +16557,7 @@ exit 0
 
         let dest_path = temp.path().join("dest");
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--no-acls"),
             OsString::from("remote::module"),
             dest_path.clone().into_os_string(),
@@ -16588,7 +16592,7 @@ exit 0
 
         let dest_path = temp.path().join("dest");
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--no-omit-dir-times"),
             OsString::from("remote::module"),
             dest_path.clone().into_os_string(),
@@ -16623,7 +16627,7 @@ exit 0
 
         let dest_path = temp.path().join("dest");
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--no-omit-link-times"),
             OsString::from("remote::module"),
             dest_path.clone().into_os_string(),
@@ -16658,7 +16662,7 @@ exit 0
 
         let dest_path = temp.path().join("dest");
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--one-file-system"),
             OsString::from("remote::module"),
             dest_path.clone().into_os_string(),
@@ -16672,7 +16676,7 @@ exit 0
         assert!(recorded.contains("--one-file-system"));
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--no-one-file-system"),
             OsString::from("remote::module"),
             dest_path.into_os_string(),
@@ -16697,7 +16701,7 @@ exit 0
         let destination = tmp.path().join("dest.txt");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--dry-run"),
             source.clone().into_os_string(),
             destination.clone().into_os_string(),
@@ -16730,7 +16734,7 @@ exit 0
         fs::create_dir(&destination_dir).expect("create dest dir");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--list-only"),
             source_dir.clone().into_os_string(),
             destination_dir.clone().into_os_string(),
@@ -16759,7 +16763,7 @@ exit 0
         fs::create_dir(&dest_dir).expect("create dest dir");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--list-only"),
             source_dir.clone().into_os_string(),
             dest_dir.into_os_string(),
@@ -16807,7 +16811,7 @@ exit 0
         source_arg.push(std::path::MAIN_SEPARATOR.to_string());
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--list-only"),
             source_arg,
             dest_dir.clone().into_os_string(),
@@ -16839,7 +16843,7 @@ exit 0
         source_arg.push(std::path::MAIN_SEPARATOR.to_string());
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--list-only"),
             OsString::from("--human-readable"),
             source_arg,
@@ -16892,7 +16896,7 @@ exit 0
         source_arg.push(std::path::MAIN_SEPARATOR.to_string());
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--list-only"),
             source_arg,
             dest_dir.clone().into_os_string(),
@@ -16943,7 +16947,7 @@ exit 0
         let destination = tmp.path().join("dest.txt");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("-n"),
             source.clone().into_os_string(),
             destination.clone().into_os_string(),
@@ -16974,7 +16978,7 @@ exit 0
         fs::create_dir(&destination_dir).expect("create dest dir");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("-av"),
             source_dir.clone().into_os_string(),
             destination_dir.clone().into_os_string(),
@@ -17091,7 +17095,7 @@ exit 0
         fs::write(&source, b"dash source").expect("write source");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--"),
             source.clone().into_os_string(),
             destination.clone().into_os_string(),
@@ -17255,7 +17259,7 @@ exit 0
         std::fs::write(&source, b"data").expect("write source");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--acls"),
             source.into_os_string(),
             destination.into_os_string(),
@@ -17279,7 +17283,7 @@ exit 0
         std::fs::write(&source, b"data").expect("write source");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--xattrs"),
             source.into_os_string(),
             destination.into_os_string(),
@@ -17304,7 +17308,7 @@ exit 0
         xattr::set(&source, "user.test", b"value").expect("set xattr");
 
         let (code, stdout, stderr) = run_with_args([
-            OsString::from("rsync"),
+            OsString::from(RSYNC),
             OsString::from("--xattrs"),
             source.clone().into_os_string(),
             destination.clone().into_os_string(),

--- a/crates/core/src/branding.rs
+++ b/crates/core/src/branding.rs
@@ -367,10 +367,27 @@ pub const fn client_program_name() -> &'static str {
     upstream_client_program_name()
 }
 
+/// Returns the canonical client program name as an [`OsStr`].
+///
+/// The helper avoids repeating `OsStr::new(client_program_name())` at call sites,
+/// keeping conversions centralised alongside the raw string constant. The
+/// returned slice borrows the compile-time string and therefore lives for the
+/// duration of the program.
+#[must_use]
+pub fn client_program_name_os_str() -> &'static OsStr {
+    OsStr::new(client_program_name())
+}
+
 /// Returns the canonical daemon program name for upstream-compatible binaries.
 #[must_use]
 pub const fn daemon_program_name() -> &'static str {
     upstream_daemon_program_name()
+}
+
+/// Returns the canonical daemon program name as an [`OsStr`].
+#[must_use]
+pub fn daemon_program_name_os_str() -> &'static OsStr {
+    OsStr::new(daemon_program_name())
 }
 
 /// Returns the branded client program name exposed as `oc-rsync`.
@@ -379,10 +396,22 @@ pub const fn oc_client_program_name() -> &'static str {
     OC_CLIENT_PROGRAM_NAME
 }
 
+/// Returns the branded client program name as an [`OsStr`].
+#[must_use]
+pub fn oc_client_program_name_os_str() -> &'static OsStr {
+    OsStr::new(oc_client_program_name())
+}
+
 /// Returns the branded daemon program name exposed as `oc-rsyncd`.
 #[must_use]
 pub const fn oc_daemon_program_name() -> &'static str {
     OC_DAEMON_PROGRAM_NAME
+}
+
+/// Returns the branded daemon program name as an [`OsStr`].
+#[must_use]
+pub fn oc_daemon_program_name_os_str() -> &'static OsStr {
+    OsStr::new(oc_daemon_program_name())
 }
 
 /// Returns the canonical configuration directory used by `oc-rsyncd`.

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -79,7 +79,14 @@
 //!
 //! let mut stdout = Vec::new();
 //! let mut stderr = Vec::new();
-//! let status = run(["rsyncd", "--version"], &mut stdout, &mut stderr);
+//! let status = run(
+//!     [
+//!         rsync_core::branding::daemon_program_name(),
+//!         "--version",
+//!     ],
+//!     &mut stdout,
+//!     &mut stderr,
+//! );
 //!
 //! assert_eq!(status, 0);
 //! assert!(stderr.is_empty());
@@ -5327,6 +5334,9 @@ mod tests {
     #[cfg(unix)]
     use std::os::unix::fs::PermissionsExt;
 
+    const RSYNCD: &str = branding::daemon_program_name();
+    const OC_RSYNC_D: &str = branding::oc_daemon_program_name();
+
     fn base_module(name: &str) -> ModuleDefinition {
         ModuleDefinition {
             name: String::from(name),
@@ -5798,7 +5808,7 @@ mod tests {
         let _guard = EnvGuard::set(DAEMON_FALLBACK_ENV, script_path.as_os_str());
 
         let (code, _stdout, stderr) = run_with_args([
-            OsStr::new("rsyncd"),
+            OsStr::new(RSYNCD),
             OsStr::new("--delegate-system-rsync"),
             OsStr::new("--config"),
             OsStr::new(branding::OC_DAEMON_CONFIG_PATH),
@@ -5822,7 +5832,7 @@ mod tests {
         let _guard = EnvGuard::set(DAEMON_FALLBACK_ENV, script_path.as_os_str());
 
         let (code, _stdout, stderr) =
-            run_with_args([OsStr::new("rsyncd"), OsStr::new("--delegate-system-rsync")]);
+            run_with_args([OsStr::new(RSYNCD), OsStr::new("--delegate-system-rsync")]);
 
         assert_eq!(code, 7);
         let stderr_str = String::from_utf8_lossy(&stderr);
@@ -5841,7 +5851,7 @@ mod tests {
         let _guard = EnvGuard::set(CLIENT_FALLBACK_ENV, script_path.as_os_str());
 
         let (code, _stdout, stderr) = run_with_args([
-            OsStr::new("rsyncd"),
+            OsStr::new(RSYNCD),
             OsStr::new("--delegate-system-rsync"),
             OsStr::new("--port"),
             OsStr::new("1234"),
@@ -5866,7 +5876,7 @@ mod tests {
         let _auto = EnvGuard::set(DAEMON_AUTO_DELEGATE_ENV, OsStr::new("1"));
 
         let (code, _stdout, stderr) = run_with_args([
-            OsStr::new("rsyncd"),
+            OsStr::new(RSYNCD),
             OsStr::new("--config"),
             OsStr::new(branding::OC_DAEMON_CONFIG_PATH),
         ]);
@@ -6075,7 +6085,7 @@ mod tests {
         let _fallback = EnvGuard::set(CLIENT_FALLBACK_ENV, script_path.as_os_str());
 
         let (code, _stdout, stderr) = run_with_args([
-            OsStr::new("rsyncd"),
+            OsStr::new(RSYNCD),
             OsStr::new("--config"),
             OsStr::new(branding::OC_DAEMON_CONFIG_PATH),
         ]);
@@ -6099,7 +6109,7 @@ mod tests {
         let _fallback = EnvGuard::set(DAEMON_FALLBACK_ENV, script_path.as_os_str());
 
         let (code, _stdout, stderr) = run_with_args([
-            OsStr::new("rsyncd"),
+            OsStr::new(RSYNCD),
             OsStr::new("--config"),
             OsStr::new(branding::OC_DAEMON_CONFIG_PATH),
         ]);
@@ -6123,7 +6133,7 @@ mod tests {
         let _fallback = EnvGuard::set(DAEMON_FALLBACK_ENV, script_path.as_os_str());
         let _auto = EnvGuard::set(DAEMON_AUTO_DELEGATE_ENV, OsStr::new("0"));
 
-        let (code, stdout, _stderr) = run_with_args([OsStr::new("rsyncd"), OsStr::new("--help")]);
+        let (code, stdout, _stderr) = run_with_args([OsStr::new(RSYNCD), OsStr::new("--help")]);
 
         assert_eq!(code, 0);
         assert!(!stdout.is_empty());
@@ -9513,7 +9523,7 @@ mod tests {
 
     #[test]
     fn version_flag_renders_report() {
-        let (code, stdout, stderr) = run_with_args([OsStr::new("rsyncd"), OsStr::new("--version")]);
+        let (code, stdout, stderr) = run_with_args([OsStr::new(RSYNCD), OsStr::new("--version")]);
 
         assert_eq!(code, 0);
         assert!(stderr.is_empty());
@@ -9527,7 +9537,7 @@ mod tests {
     #[test]
     fn oc_version_flag_renders_report() {
         let (code, stdout, stderr) =
-            run_with_args([OsStr::new("oc-rsyncd"), OsStr::new("--version")]);
+            run_with_args([OsStr::new(OC_RSYNC_D), OsStr::new("--version")]);
 
         assert_eq!(code, 0);
         assert!(stderr.is_empty());
@@ -9540,7 +9550,7 @@ mod tests {
 
     #[test]
     fn help_flag_renders_static_help_snapshot() {
-        let (code, stdout, stderr) = run_with_args([OsStr::new("rsyncd"), OsStr::new("--help")]);
+        let (code, stdout, stderr) = run_with_args([OsStr::new(RSYNCD), OsStr::new("--help")]);
 
         assert_eq!(code, 0);
         assert!(stderr.is_empty());
@@ -9551,7 +9561,7 @@ mod tests {
 
     #[test]
     fn oc_help_flag_renders_branded_snapshot() {
-        let (code, stdout, stderr) = run_with_args([OsStr::new("oc-rsyncd"), OsStr::new("--help")]);
+        let (code, stdout, stderr) = run_with_args([OsStr::new(OC_RSYNC_D), OsStr::new("--help")]);
 
         assert_eq!(code, 0);
         assert!(stderr.is_empty());
@@ -9642,7 +9652,7 @@ mod tests {
         let mut stdout = Vec::new();
         let mut stderr = Vec::new();
         let status = run(
-            [OsString::from("rsyncd"), OsString::from("--version=extra")],
+            [OsString::from(RSYNCD), OsString::from("--version=extra")],
             &mut stdout,
             &mut stderr,
         );


### PR DESCRIPTION
## Summary
- expose OsStr accessors for upstream and oc-branded program names in the branding module
- update CLI and daemon documentation/examples and tests to consume the centralized identifiers
- replace hard-coded binary names in CLI/daemon test suites with constants derived from branding

## Testing
- cargo test

------