### PR TITLE
Expose brand-specific config helpers

### DIFF
--- a/crates/core/src/branding.rs
+++ b/crates/core/src/branding.rs
@@ -153,6 +153,23 @@ impl Brand {
         self.profile().daemon_config_dir()
     }
 
+    /// Returns the canonical daemon configuration path for this brand.
+    ///
+    /// The value reflects the configuration file packaged with the binary
+    /// distribution. Branded invocations (`oc-rsyncd`) resolve to
+    /// `/etc/oc-rsyncd/oc-rsyncd.conf` while upstream-compatible invocations
+    /// default to `/etc/rsyncd.conf`.
+    #[must_use]
+    pub const fn daemon_config_path_str(self) -> &'static str {
+        self.profile().daemon_config_path_str()
+    }
+
+    /// Returns the canonical daemon configuration path as a [`Path`].
+    #[must_use]
+    pub fn daemon_config_path(self) -> &'static Path {
+        self.profile().daemon_config_path()
+    }
+
     /// Returns the preferred daemon configuration search order for this brand.
     ///
     /// The branded `oc-` binaries consult `/etc/oc-rsyncd/oc-rsyncd.conf`
@@ -186,6 +203,21 @@ impl Brand {
             Self::Oc => [OC_DAEMON_SECRETS_PATH, LEGACY_DAEMON_SECRETS_PATH],
             Self::Upstream => [LEGACY_DAEMON_SECRETS_PATH, OC_DAEMON_SECRETS_PATH],
         }
+    }
+
+    /// Returns the canonical daemon secrets path for this brand.
+    ///
+    /// Branded invocations resolve to `/etc/oc-rsyncd/oc-rsyncd.secrets` while
+    /// upstream-compatible invocations default to `/etc/rsyncd.secrets`.
+    #[must_use]
+    pub const fn daemon_secrets_path_str(self) -> &'static str {
+        self.profile().daemon_secrets_path_str()
+    }
+
+    /// Returns the canonical daemon secrets path as a [`Path`].
+    #[must_use]
+    pub fn daemon_secrets_path(self) -> &'static Path {
+        self.profile().daemon_secrets_path()
     }
 
     /// Returns the preferred secrets-file search order as [`Path`]s.
@@ -784,6 +816,23 @@ mod tests {
     }
 
     #[test]
+    fn config_paths_match_brand_profiles() {
+        assert_eq!(
+            Brand::Oc.daemon_config_path(),
+            Path::new(OC_DAEMON_CONFIG_PATH)
+        );
+        assert_eq!(Brand::Oc.daemon_config_path_str(), OC_DAEMON_CONFIG_PATH);
+        assert_eq!(
+            Brand::Upstream.daemon_config_path(),
+            Path::new(LEGACY_DAEMON_CONFIG_PATH)
+        );
+        assert_eq!(
+            Brand::Upstream.daemon_config_path_str(),
+            LEGACY_DAEMON_CONFIG_PATH
+        );
+    }
+
+    #[test]
     fn secrets_search_orders_match_brand_expectations() {
         assert_eq!(
             Brand::Oc.secrets_path_candidate_strs(),
@@ -800,6 +849,20 @@ mod tests {
         let upstream_paths = Brand::Upstream.secrets_path_candidates();
         assert_eq!(upstream_paths[0], Path::new(LEGACY_DAEMON_SECRETS_PATH));
         assert_eq!(upstream_paths[1], Path::new(OC_DAEMON_SECRETS_PATH));
+
+        assert_eq!(
+            Brand::Oc.daemon_secrets_path(),
+            Path::new(OC_DAEMON_SECRETS_PATH)
+        );
+        assert_eq!(Brand::Oc.daemon_secrets_path_str(), OC_DAEMON_SECRETS_PATH);
+        assert_eq!(
+            Brand::Upstream.daemon_secrets_path(),
+            Path::new(LEGACY_DAEMON_SECRETS_PATH)
+        );
+        assert_eq!(
+            Brand::Upstream.daemon_secrets_path_str(),
+            LEGACY_DAEMON_SECRETS_PATH
+        );
     }
 
     #[test]

--- a/crates/core/src/branding/tests.rs
+++ b/crates/core/src/branding/tests.rs
@@ -142,6 +142,26 @@ fn config_directories_match_brand_profiles() {
 }
 
 #[test]
+fn config_paths_match_brand_profiles() {
+    assert_eq!(
+        Brand::Oc.daemon_config_path(),
+        Path::new(OC_DAEMON_CONFIG_PATH)
+    );
+    assert_eq!(
+        Brand::Oc.daemon_config_path_str(),
+        OC_DAEMON_CONFIG_PATH
+    );
+    assert_eq!(
+        Brand::Upstream.daemon_config_path(),
+        Path::new(LEGACY_DAEMON_CONFIG_PATH)
+    );
+    assert_eq!(
+        Brand::Upstream.daemon_config_path_str(),
+        LEGACY_DAEMON_CONFIG_PATH
+    );
+}
+
+#[test]
 fn secrets_search_orders_match_brand_expectations() {
     assert_eq!(
         Brand::Oc.secrets_path_candidate_strs(),
@@ -158,6 +178,23 @@ fn secrets_search_orders_match_brand_expectations() {
     let upstream_paths = Brand::Upstream.secrets_path_candidates();
     assert_eq!(upstream_paths[0], Path::new(LEGACY_DAEMON_SECRETS_PATH));
     assert_eq!(upstream_paths[1], Path::new(OC_DAEMON_SECRETS_PATH));
+
+    assert_eq!(
+        Brand::Oc.daemon_secrets_path(),
+        Path::new(OC_DAEMON_SECRETS_PATH)
+    );
+    assert_eq!(
+        Brand::Oc.daemon_secrets_path_str(),
+        OC_DAEMON_SECRETS_PATH
+    );
+    assert_eq!(
+        Brand::Upstream.daemon_secrets_path(),
+        Path::new(LEGACY_DAEMON_SECRETS_PATH)
+    );
+    assert_eq!(
+        Brand::Upstream.daemon_secrets_path_str(),
+        LEGACY_DAEMON_SECRETS_PATH
+    );
 }
 
 #[test]

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -255,9 +255,8 @@ const LEGACY_HANDSHAKE_DIGESTS: &[&str] = &["sha512", "sha256", "sha1", "md5", "
 /// symlinks and the canonical `oc-rsyncd` binary emit brand-appropriate help
 /// output.
 fn help_text(brand: Brand) -> String {
-    let profile = brand.profile();
-    let program = profile.daemon_program_name();
-    let default_config = profile.daemon_config_path_str();
+    let program = brand.daemon_program_name();
+    let default_config = brand.daemon_config_path_str();
 
     format!(
         concat!(


### PR DESCRIPTION
## Summary
- add `Brand` helpers that return canonical daemon config and secrets paths
- update brand test suites to cover the new helpers and keep oc/upstream expectations synced
- teach the daemon help renderer to rely on the shared brand accessors instead of manual profile plumbing

## Testing
- `cargo test -p rsync-core branding::tests::config_paths_match_brand_profiles -- --exact`
- `cargo test -p rsync-core branding::tests::secrets_search_orders_match_brand_expectations -- --exact`

------