### PR TITLE
Handle Windows path prefixes in remote operand detection

### DIFF
--- a/crates/engine/src/local_copy.rs
+++ b/crates/engine/src/local_copy.rs
@@ -9296,6 +9296,49 @@ fn is_device(file_type: &fs::FileType) -> bool {
     }
 }
 
+#[cfg(windows)]
+fn operand_has_windows_prefix(path: &OsStr) -> bool {
+    use std::os::windows::ffi::OsStrExt;
+
+    const COLON: u16 = b':' as u16;
+    const QUESTION: u16 = b'?' as u16;
+    const DOT: u16 = b'.' as u16;
+    const SLASH: u16 = b'/' as u16;
+    const BACKSLASH: u16 = b'\\' as u16;
+
+    fn is_ascii_alpha(unit: u16) -> bool {
+        (unit >= b'a' as u16 && unit <= b'z' as u16) || (unit >= b'A' as u16 && unit <= b'Z' as u16)
+    }
+
+    fn is_separator(unit: u16) -> bool {
+        unit == SLASH || unit == BACKSLASH
+    }
+
+    let units: Vec<u16> = path.encode_wide().collect();
+    if units.is_empty() {
+        return false;
+    }
+
+    if units.len() >= 4
+        && is_separator(units[0])
+        && is_separator(units[1])
+        && (units[2] == QUESTION || units[2] == DOT)
+        && is_separator(units[3])
+    {
+        return true;
+    }
+
+    if units.len() >= 2 && is_separator(units[0]) && is_separator(units[1]) {
+        return true;
+    }
+
+    if units.len() >= 2 && is_ascii_alpha(units[0]) && units[1] == COLON {
+        return true;
+    }
+
+    false
+}
+
 fn operand_is_remote(path: &OsStr) -> bool {
     let text = path.to_string_lossy();
 
@@ -9308,6 +9351,11 @@ fn operand_is_remote(path: &OsStr) -> bool {
     }
 
     if let Some(colon_index) = text.find(':') {
+        #[cfg(windows)]
+        if operand_has_windows_prefix(path) {
+            return false;
+        }
+
         let after = &text[colon_index + 1..];
         if after.starts_with(':') {
             return true;
@@ -9326,6 +9374,43 @@ fn operand_is_remote(path: &OsStr) -> bool {
     }
 
     false
+}
+
+#[cfg(all(test, windows))]
+mod windows_operand_detection {
+    use super::operand_is_remote;
+    use std::ffi::OsStr;
+
+    #[test]
+    fn drive_letter_paths_are_local() {
+        assert!(!operand_is_remote(OsStr::new(r"C:\\tmp\\file.txt")));
+        assert!(!operand_is_remote(OsStr::new(r"d:relative\\path")));
+    }
+
+    #[test]
+    fn extended_prefixes_are_local() {
+        assert!(!operand_is_remote(OsStr::new(r"\\\\?\\C:\\tmp\\file.txt")));
+        assert!(!operand_is_remote(OsStr::new(
+            r"\\\\?\\UNC\\server\\share\\file.txt"
+        )));
+        assert!(!operand_is_remote(OsStr::new(r"\\\\.\\pipe\\rsync")));
+    }
+
+    #[test]
+    fn unc_and_forward_slash_paths_are_local() {
+        assert!(!operand_is_remote(OsStr::new(
+            r"\\\\server\\share\\file.txt"
+        )));
+        assert!(!operand_is_remote(OsStr::new("//server/share/file.txt")));
+    }
+
+    #[test]
+    fn remote_operands_remain_remote() {
+        assert!(operand_is_remote(OsStr::new("host:path")));
+        assert!(operand_is_remote(OsStr::new("user@host:path")));
+        assert!(operand_is_remote(OsStr::new("host::module")));
+        assert!(operand_is_remote(OsStr::new("rsync://example.com/module")));
+    }
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
## Summary
- treat Windows drive, UNC, and verbatim prefixes as local operands when checking for remote transfers
- add Windows-only coverage for the remote operand detector in both the CLI and engine crates

## Testing
- cargo test tests::stats_human_readable_formats_totals -- --nocapture
- cargo test tests::stats_human_readable_combined_formats_totals -- --nocapture

------