### PR TITLE
Expose brand labels and display formatting

### DIFF
--- a/crates/core/src/branding/tests.rs
+++ b/crates/core/src/branding/tests.rs
@@ -211,3 +211,15 @@ fn brand_from_str_rejects_unknown_values() {
     assert!(Brand::from_str("unknown").is_err());
     assert!(Brand::from_str("ocrsync").is_err());
 }
+
+#[test]
+fn brand_label_matches_expected() {
+    assert_eq!(Brand::Oc.label(), "oc");
+    assert_eq!(Brand::Upstream.label(), "upstream");
+}
+
+#[test]
+fn brand_display_renders_label() {
+    assert_eq!(Brand::Oc.to_string(), "oc");
+    assert_eq!(Brand::Upstream.to_string(), "upstream");
+}

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -5549,10 +5549,8 @@ mod tests {
         let dir = tempdir().expect("tempdir");
         let missing_primary = dir.path().join("missing-primary.conf");
         let missing_legacy = dir.path().join("missing-legacy.conf");
-        let result = first_existing_config_path([
-            missing_primary.as_path(),
-            missing_legacy.as_path(),
-        ]);
+        let result =
+            first_existing_config_path([missing_primary.as_path(), missing_legacy.as_path()]);
 
         assert!(result.is_none());
     }


### PR DESCRIPTION
## Summary
- add a canonical label accessor for `Brand` and use it from the parser
- implement `Display` for `Brand` so reporting code can reuse the shared label
- extend branding tests and format the daemon config-path test accordingly

## Testing
- `cargo test -p rsync-core brand_label_matches_expected`
- `cargo test -p rsync-core brand_display_renders_label`

------