### PR TITLE
Stabilize human-readable stats tests

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -8343,6 +8343,9 @@ mod tests {
     fn stats_human_readable_formats_totals() {
         use tempfile::tempdir;
 
+        let _env_lock = ENV_LOCK.lock().expect("env lock");
+        let _rsh_guard = clear_rsync_rsh();
+
         let tmp = tempdir().expect("tempdir");
         let source = tmp.path().join("file.bin");
         std::fs::write(&source, vec![0u8; 1_536]).expect("write source");
@@ -8380,6 +8383,9 @@ mod tests {
     #[test]
     fn stats_human_readable_combined_formats_totals() {
         use tempfile::tempdir;
+
+        let _env_lock = ENV_LOCK.lock().expect("env lock");
+        let _rsh_guard = clear_rsync_rsh();
 
         let tmp = tempdir().expect("tempdir");
         let source = tmp.path().join("file.bin");


### PR DESCRIPTION
## Summary
- guard the human-readable stats tests with the shared environment lock
- clear RSYNC_RSH while the tests run to avoid leaked fallback overrides

## Testing
- cargo test tests::stats_human_readable_combined_formats_totals -- --nocapture

------