### PR TITLE
Restrict CI testing to Linux and fix packaging artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,6 @@ env:
   LC_ALL: C
   TZ: UTC
   COLUMNS: 80
-  TZ: UTC
 
 jobs:
   no-binaries:
@@ -122,45 +121,6 @@ jobs:
         with:
           name: coverage-lcov
           path: coverage.lcov
-
-
-  test-windows:
-    needs: lint
-    runs-on: windows-2022
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup Rust (1.87)
-        uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          toolchain: 1.87
-          cache: true
-
-      - name: Run Windows-specific tests
-        shell: pwsh
-        run: |
-          cargo test --test windows
-          cargo test --test daemon_windows_integration
-
-  test-bsd:
-    needs: lint
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Run FreeBSD daemon integration tests
-        uses: vmactions/freebsd-vm@v1
-        with:
-          release: '14.1'
-          copyback: false
-          envs: 'RUSTFLAGS=-Dwarnings CARGO_TERM_COLOR=always LC_ALL=C COLUMNS=80'
-          prepare: |
-            pkg install -y rust pkgconf
-          run: |
-            cd /workspace
-            cargo test --test daemon_bsd_integration
-
-
   interop:
     needs: test-linux
     runs-on: ubuntu-latest
@@ -207,6 +167,9 @@ jobs:
           - name: windows-x86_64
             os: windows-latest
             target: x86_64-pc-windows-msvc
+          - name: windows-x86
+            os: windows-latest
+            target: i686-pc-windows-msvc
           - name: windows-aarch64
             os: windows-2022
             target: aarch64-pc-windows-msvc
@@ -314,7 +277,7 @@ PY
 
       - name: Build packages
         run: |
-          cargo deb -p oc-rsync
+          cargo deb -p oc-rsync-bin
           cargo rpm build --release
 
       - name: Generate SBOM
@@ -326,5 +289,7 @@ PY
         with:
           name: oc-rsync-packages
           path: |
-            target/${{ matrix.target }}/release/oc-rsync*
-            target/${{ matrix.target }}/release/oc-rsyncd*
+            target/release/oc-rsync*
+            target/release/oc-rsyncd*
+            target/debian/*.deb
+            target/release/rpmbuild/RPMS/**/*.rpm


### PR DESCRIPTION
## Summary
- ensure the CI workflow only executes the test suite on Linux runners
- retain cross-compilation builds for Linux, macOS, and Windows targets (including 32-bit Windows) while uploading checksum artifacts
- fix the packaging job to use the oc-rsync-bin crate, and attach the produced packages and binaries

## Testing
- not run (workflow change only)

------