### PR TITLE
Add brand parsing regression tests

### DIFF
--- a/crates/core/src/branding.rs
+++ b/crates/core/src/branding.rs
@@ -705,6 +705,7 @@ pub const fn oc_profile() -> BrandProfile {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use core::str::FromStr;
     use std::env;
     use std::ffi::{OsStr, OsString};
     use std::sync::{Mutex, MutexGuard, OnceLock};
@@ -1024,6 +1025,21 @@ mod tests {
     fn detect_brand_ignores_invalid_override_environment_variable() {
         let _guard = EnvGuard::set(BRAND_OVERRIDE_ENV, OsStr::new("invalid"));
         assert_eq!(detect_brand(Some(OsStr::new("oc-rsync"))), Brand::Oc);
+    }
+
+    #[test]
+    fn brand_from_str_accepts_aliases() {
+        assert_eq!(Brand::from_str("oc").unwrap(), Brand::Oc);
+        assert_eq!(Brand::from_str("OC-RSYNCD").unwrap(), Brand::Oc);
+        assert_eq!(Brand::from_str(" rsync-3.4.1 ").unwrap(), Brand::Upstream);
+        assert_eq!(Brand::from_str("RSYNCD").unwrap(), Brand::Upstream);
+    }
+
+    #[test]
+    fn brand_from_str_rejects_unknown_values() {
+        assert!(Brand::from_str("").is_err());
+        assert!(Brand::from_str("unknown").is_err());
+        assert!(Brand::from_str("ocrsync").is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add explicit tests exercising Brand::from_str with accepted aliases
- assert that malformed brand identifiers return errors

## Testing
- cargo test -p rsync-core brand_from_str_accepts_aliases -- --nocapture

------