### PR TITLE
Centralize workspace branding metadata

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -39,6 +39,7 @@ sd-notify = []
 [dev-dependencies]
 filetime = "0.2"
 tempfile = "3.10"
+toml = "0.8"
 
 [build-dependencies]
 toml = "0.8"

--- a/crates/core/src/branding.rs
+++ b/crates/core/src/branding.rs
@@ -375,43 +375,43 @@ const OC_PROFILE: BrandProfile = BrandProfile::new(
 
 /// Canonical program name used by upstream `rsync` releases.
 #[doc(alias = "rsync")]
-pub const UPSTREAM_CLIENT_PROGRAM_NAME: &str = workspace::LEGACY_CLIENT_PROGRAM_NAME;
+pub const UPSTREAM_CLIENT_PROGRAM_NAME: &str = workspace::metadata().legacy_client_program_name();
 
 /// Canonical program name used by upstream `rsyncd` daemon releases.
 #[doc(alias = "rsyncd")]
-pub const UPSTREAM_DAEMON_PROGRAM_NAME: &str = workspace::LEGACY_DAEMON_PROGRAM_NAME;
+pub const UPSTREAM_DAEMON_PROGRAM_NAME: &str = workspace::metadata().legacy_daemon_program_name();
 
 /// Canonical binary name exposed by the client wrapper packaged as `oc-rsync`.
 #[doc(alias = "oc-rsync")]
-pub const OC_CLIENT_PROGRAM_NAME: &str = workspace::CLIENT_PROGRAM_NAME;
+pub const OC_CLIENT_PROGRAM_NAME: &str = workspace::metadata().client_program_name();
 
 /// Canonical binary name exposed by the branded daemon wrapper packaged as `oc-rsyncd`.
 #[doc(alias = "oc-rsyncd")]
-pub const OC_DAEMON_PROGRAM_NAME: &str = workspace::DAEMON_PROGRAM_NAME;
+pub const OC_DAEMON_PROGRAM_NAME: &str = workspace::metadata().daemon_program_name();
 
 /// Directory that packages install for daemon configuration snippets.
 #[doc(alias = "/etc/oc-rsyncd")]
-pub const OC_DAEMON_CONFIG_DIR: &str = workspace::DAEMON_CONFIG_DIR;
+pub const OC_DAEMON_CONFIG_DIR: &str = workspace::metadata().daemon_config_dir();
 
 /// Default configuration file path consumed by the daemon when no override is provided.
 #[doc(alias = "/etc/oc-rsyncd/oc-rsyncd.conf")]
-pub const OC_DAEMON_CONFIG_PATH: &str = workspace::DAEMON_CONFIG_PATH;
+pub const OC_DAEMON_CONFIG_PATH: &str = workspace::metadata().daemon_config_path();
 
 /// Default secrets file path consumed by the daemon when no override is provided.
 #[doc(alias = "/etc/oc-rsyncd/oc-rsyncd.secrets")]
-pub const OC_DAEMON_SECRETS_PATH: &str = workspace::DAEMON_SECRETS_PATH;
+pub const OC_DAEMON_SECRETS_PATH: &str = workspace::metadata().daemon_secrets_path();
 
 /// Legacy configuration file path supported for backwards compatibility with upstream deployments.
 #[doc(alias = "/etc/rsyncd.conf")]
-pub const LEGACY_DAEMON_CONFIG_PATH: &str = workspace::LEGACY_DAEMON_CONFIG_PATH;
+pub const LEGACY_DAEMON_CONFIG_PATH: &str = workspace::metadata().legacy_daemon_config_path();
 
 /// Legacy configuration directory that hosts upstream-compatible configuration files.
 #[doc(alias = "/etc")]
-pub const LEGACY_DAEMON_CONFIG_DIR: &str = workspace::LEGACY_DAEMON_CONFIG_DIR;
+pub const LEGACY_DAEMON_CONFIG_DIR: &str = workspace::metadata().legacy_daemon_config_dir();
 
 /// Legacy secrets file path supported for backwards compatibility with upstream deployments.
 #[doc(alias = "/etc/rsyncd.secrets")]
-pub const LEGACY_DAEMON_SECRETS_PATH: &str = workspace::LEGACY_DAEMON_SECRETS_PATH;
+pub const LEGACY_DAEMON_SECRETS_PATH: &str = workspace::metadata().legacy_daemon_secrets_path();
 
 /// Returns the canonical upstream client program name (`rsync`).
 #[must_use]


### PR DESCRIPTION
## Summary
- expose a `workspace::Metadata` snapshot so crates can consume branded program names and paths from one source
- reuse the new metadata accessors inside the branding facade to avoid hard-coded strings
- add a manifest-parity test and the `toml` dev-dependency that powers it

## Testing
- `cargo test -p rsync-core workspace::tests::metadata_matches_manifest`

------