### PR TITLE
Fix clippy doc lint and tidy helper utilities

### DIFF
--- a/crates/bandwidth/src/limiter.rs
+++ b/crates/bandwidth/src/limiter.rs
@@ -70,7 +70,7 @@ impl<'a> RecordedSleepSession<'a> {
     #[inline]
     fn with_recorded_sleeps_mut<R>(&self, op: impl FnOnce(&mut Vec<Duration>) -> R) -> R {
         let mut guard = lock_recorded_sleeps();
-        op(&mut *guard)
+        op(guard.as_mut())
     }
 
     /// Removes any previously recorded durations.

--- a/crates/protocol/README.md
+++ b/crates/protocol/README.md
@@ -112,6 +112,6 @@ assert_eq!(
 ## See also
 
 - [`rsync_transport`](https://docs.rs/rsync-transport) for transport wrappers that reuse
-the sniffers and parsers exposed here.
+  the sniffers and parsers exposed here.
 - [`rsync_core`](https://docs.rs/rsync-core) for message formatting utilities that rely on
-negotiated protocol numbers.
+  negotiated protocol numbers.

--- a/crates/transport/src/ssh/mod.rs
+++ b/crates/transport/src/ssh/mod.rs
@@ -308,13 +308,13 @@ fn host_is_bracketed(host: &OsStr) -> bool {
     #[cfg(unix)]
     {
         let bytes = host.as_bytes();
-        return bytes.len() >= 2 && bytes.first() == Some(&b'[') && bytes.last() == Some(&b']');
+        bytes.len() >= 2 && bytes.first() == Some(&b'[') && bytes.last() == Some(&b']')
     }
 
     #[cfg(not(unix))]
     {
         let text = host.to_string_lossy();
-        return text.starts_with('[') && text.ends_with(']');
+        text.starts_with('[') && text.ends_with(']')
     }
 }
 


### PR DESCRIPTION
## Summary
- indent continuation lines in the protocol README bullet list to satisfy clippy's doc formatting lint
- simplify the recorded sleep guard helper to avoid an explicit auto-deref warning
- drop needless `return` statements from the SSH host bracket helper for clippy compliance

## Testing
- cargo clippy --workspace --all-targets -- -Dwarnings *(fails: existing clippy findings in rsync-engine/local_copy)*

------