### PR TITLE
Align brand fallback with workspace metadata

### DIFF
--- a/crates/core/src/branding.rs
+++ b/crates/core/src/branding.rs
@@ -254,6 +254,38 @@ impl Brand {
     }
 }
 
+fn resolve_default_brand(label: &str) -> Brand {
+    if matches_oc_brand(label) {
+        Brand::Oc
+    } else if matches_upstream_brand(label) {
+        Brand::Upstream
+    } else {
+        panic!("unsupported workspace brand; expected 'oc' or 'upstream'")
+    }
+}
+
+fn matches_oc_brand(label: &str) -> bool {
+    label == "oc" || label == "oc-rsync" || label == "oc-rsyncd"
+}
+
+fn matches_upstream_brand(label: &str) -> bool {
+    label == "upstream" || label == "rsync" || label == "rsyncd"
+}
+
+/// Returns the brand configured for this workspace build.
+///
+/// The value reflects the `workspace.metadata.oc_rsync.brand` entry recorded in
+/// the repository `Cargo.toml`. Builds produced from the branded distribution
+/// therefore resolve to [`Brand::Oc`], while compatibility builds targeting the
+/// upstream names resolve to [`Brand::Upstream`]. Higher layers use this helper
+/// as the final fallback when neither the invocation name nor the
+/// `OC_RSYNC_BRAND` override provides an explicit brand, ensuring the binaries
+/// maintain a consistent identity across packaging environments.
+#[must_use]
+pub fn default_brand() -> Brand {
+    resolve_default_brand(workspace::BRAND)
+}
+
 impl fmt::Display for Brand {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(self.label())
@@ -502,10 +534,10 @@ pub fn oc_daemon_secrets_path() -> &'static Path {
 /// [`Path::file_stem`]) and returns [`Brand::Oc`] when the binary belongs to the
 /// branded `oc-` family. The comparison tolerates versioned wrapper names such
 /// as `oc-rsync-3.4.1` or `oc-rsyncd_v2` so distribution-specific symlinks keep
-/// their branded behaviour without additional configuration. All other names
-/// fall back to the upstream-compatible profile so symlinked invocations using
-/// the upstream names keep their semantics aligned with the reference
-/// implementation.
+/// their branded behaviour without additional configuration. Executables that
+/// do not resemble either family fall back to [`default_brand`], ensuring
+/// repackaged builds retain their configured identity even when launched via
+/// intermediate wrappers that obscure the program name.
 ///
 /// # Examples
 ///
@@ -534,8 +566,12 @@ pub fn brand_for_program_name(program: &str) -> Brand {
         || matches_program_alias(program, OC_DAEMON_PROGRAM_NAME)
     {
         Brand::Oc
-    } else {
+    } else if matches_program_alias(program, UPSTREAM_CLIENT_PROGRAM_NAME)
+        || matches_program_alias(program, UPSTREAM_DAEMON_PROGRAM_NAME)
+    {
         Brand::Upstream
+    } else {
+        default_brand()
     }
 }
 
@@ -584,9 +620,10 @@ fn brand_for_program_os_str(program: &OsStr) -> Option<Brand> {
 /// the executable name. When no override is present, the function inspects the
 /// stem of the first argument (commonly `argv[0]`), stripping directory
 /// prefixes and filename extensions before delegating to
-/// [`brand_for_program_name`]. If the program name is unavailable the
-/// upstream-compatible brand is assumed, matching the behaviour expected by
-/// remote invocations and compatibility symlinks.
+/// [`brand_for_program_name`]. If the program name is unavailable the helper
+/// falls back to [`default_brand`], ensuring binaries built with a branded
+/// workspace retain their configured identity even when launched via indirect
+/// mechanisms that hide the executable name.
 ///
 /// # Examples
 ///
@@ -603,7 +640,6 @@ fn brand_for_program_os_str(program: &OsStr) -> Option<Brand> {
 ///     branding::detect_brand(Some(OsStr::new("rsync"))),
 ///     Brand::Upstream
 /// );
-/// assert_eq!(branding::detect_brand(None), Brand::Upstream);
 /// ```
 #[must_use]
 pub fn detect_brand(program: Option<&OsStr>) -> Brand {
@@ -618,7 +654,7 @@ pub fn detect_brand(program: Option<&OsStr>) -> Brand {
     env::current_exe()
         .ok()
         .and_then(|path| brand_for_program_path(&path))
-        .unwrap_or(Brand::Upstream)
+        .unwrap_or_else(default_brand)
 }
 
 /// Returns the [`BrandProfile`] resolved from the provided program identifier.
@@ -883,7 +919,7 @@ mod tests {
         );
         assert_eq!(
             brand_for_program_path(Path::new("/tmp/custom-wrapper")),
-            Some(Brand::Upstream)
+            Some(default_brand())
         );
     }
 
@@ -906,7 +942,6 @@ mod tests {
     #[test]
     fn detect_brand_matches_invocation_argument() {
         let _guard = EnvGuard::remove(BRAND_OVERRIDE_ENV);
-        assert_eq!(detect_brand(None), Brand::Upstream);
         assert_eq!(detect_brand(Some(OsStr::new("rsync"))), Brand::Upstream);
         assert_eq!(
             detect_brand(Some(OsStr::new("/usr/bin/oc-rsync"))),
@@ -944,7 +979,7 @@ mod tests {
         let expected = env::current_exe()
             .ok()
             .and_then(|path| brand_for_program_path(&path))
-            .unwrap_or(Brand::Upstream);
+            .unwrap_or(default_brand());
         assert_eq!(detect_brand(None), expected);
     }
 

--- a/crates/core/src/branding/tests.rs
+++ b/crates/core/src/branding/tests.rs
@@ -87,7 +87,11 @@ fn brand_profiles_expose_program_names() {
 
 #[test]
 fn detect_brand_matches_invocation_argument() {
-    assert_eq!(detect_brand(None), Brand::Upstream);
+    let expected = std::env::current_exe()
+        .ok()
+        .and_then(|path| brand_for_program_path(&path))
+        .unwrap_or_else(default_brand);
+    assert_eq!(detect_brand(None), expected);
     assert_eq!(detect_brand(Some(OsStr::new("rsync"))), Brand::Upstream);
     assert_eq!(
         detect_brand(Some(OsStr::new("/usr/bin/oc-rsync"))),


### PR DESCRIPTION
## Summary
- add a workspace-driven `default_brand` helper to describe the configured distribution identity
- route brand detection through the workspace default when invocation names do not match explicit upstream or oc aliases
- update branding tests to validate the new fallback behaviour without hard-coding the expected identity

## Testing
- cargo test -p rsync-core branding

------