### PR TITLE
Add xtask docs command for documentation validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,12 @@ unsafe code across all crates. To run the existing unit and property tests:
 cargo test
 ```
 
+Rebuild the API documentation and run doctests via the workspace helper:
+
+```bash
+cargo run -p xtask -- docs
+```
+
 Generate a CycloneDX SBOM for packaging via the workspace helper:
 
 ```bash


### PR DESCRIPTION
## Summary
- add a new `docs` command to `cargo xtask` that builds API docs and runs doctests, with an optional `--open` flag
- update the README to document the helper for rebuilding documentation

## Testing
- `cargo test -p xtask`

------