### PR TITLE
Add xtask branding command and correct CI CLI test target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
         run: cargo nextest run --workspace --no-fail-fast --features "cli nightly"
       - name: Run CLI version tests without ACL/iconv support
         if: steps.install_nextest.outcome == 'success'
-        run: cargo test -p oc-rsync-cli --test version --no-default-features --features "xattr zlib zstd"
+        run: cargo test -p rsync-cli --test version --no-default-features --features "xattr zlib zstd"
       - name: Test with coverage (95% lines & functions)
         if: steps.install_nextest.outcome == 'success' && steps.install_llvm_cov.outcome == 'success'
         run: |


### PR DESCRIPTION
## Summary
- fix the CI workflow so the CLI version test runs against the rsync-cli crate
- add a `cargo xtask branding` command that prints the central branding metadata and document it in the xtask usage text, with parsing tests

## Testing
- cargo test

------