### PR TITLE
Fix clippy warnings across workspace

### DIFF
--- a/crates/bandwidth/src/parse/tests.rs
+++ b/crates/bandwidth/src/parse/tests.rs
@@ -219,7 +219,7 @@ fn constrained_by_initialises_limiter_when_unlimited() {
 
     let combined = client.constrained_by(&module);
 
-    assert_eq!(combined.rate().map(NonZeroU64::get), Some(1 * 1024 * 1024));
+    assert_eq!(combined.rate().map(NonZeroU64::get), Some(1024 * 1024));
     assert_eq!(combined.burst().map(NonZeroU64::get), Some(32 * 1024));
     assert!(combined.burst_specified());
     assert!(combined.limit_specified());

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -3564,14 +3564,8 @@ where
         None => None,
     };
 
-    let owner_override_value = parsed_chown
-        .as_ref()
-        .and_then(|value| value.owner)
-        .map(u32::from);
-    let group_override_value = parsed_chown
-        .as_ref()
-        .and_then(|value| value.group)
-        .map(u32::from);
+    let owner_override_value = parsed_chown.as_ref().and_then(|value| value.owner);
+    let group_override_value = parsed_chown.as_ref().and_then(|value| value.group);
     let chown_spec = parsed_chown.as_ref().map(|value| value.spec.clone());
 
     #[cfg(not(feature = "xattr"))]
@@ -6214,11 +6208,11 @@ fn parse_filter_shorthand(
         return Some(Err(message));
     }
 
-    let first_non_space = remainder
+    if !remainder
         .chars()
         .next()
-        .filter(|ch| ch.is_ascii_whitespace() || *ch == '_');
-    if first_non_space.is_none() {
+        .is_some_and(|ch| ch.is_ascii_whitespace() || ch == '_')
+    {
         return None;
     }
 
@@ -15515,7 +15509,7 @@ exit 0
         let recorded = std::fs::read_to_string(&args_path).expect("read args file");
         let args: Vec<&str> = recorded.lines().collect();
         assert!(args.contains(&"--delete"));
-        assert!(args.iter().any(|value| *value == "--max-delete=5"));
+        assert!(args.contains(&"--max-delete=5"));
     }
 
     #[cfg(unix)]
@@ -15590,8 +15584,8 @@ exit 0
 
         let recorded = std::fs::read_to_string(&args_path).expect("read args file");
         let args: Vec<&str> = recorded.lines().collect();
-        assert!(args.iter().any(|value| *value == "--min-size=1.5K"));
-        assert!(args.iter().any(|value| *value == "--max-size=2M"));
+        assert!(args.contains(&"--min-size=1.5K"));
+        assert!(args.contains(&"--max-size=2M"));
     }
 
     #[cfg(unix)]

--- a/crates/compress/src/zlib.rs
+++ b/crates/compress/src/zlib.rs
@@ -453,7 +453,7 @@ mod tests {
     #[test]
     fn counting_encoder_supports_write_trait() {
         let mut encoder = CountingZlibEncoder::new(CompressionLevel::Default);
-        write!(&mut encoder, "{}", "payload").expect("write via trait");
+        write!(&mut encoder, "payload").expect("write via trait");
         encoder.flush().expect("flush encoder");
         let compressed = encoder.finish().expect("finish stream");
         assert!(compressed > 0);

--- a/crates/core/src/version.rs
+++ b/crates/core/src/version.rs
@@ -173,10 +173,7 @@ fn sanitize_build_revision(raw: Option<&'static str>) -> &'static str {
         return "unknown";
     }
 
-    let head = trimmed
-        .split(|ch| matches!(ch, '\r' | '\n'))
-        .next()
-        .unwrap_or("");
+    let head = trimmed.split(['\r', '\n']).next().unwrap_or("");
     let cleaned = head.trim();
 
     if cleaned.is_empty() || cleaned.chars().any(char::is_control) {

--- a/crates/engine/src/local_copy/skip_compress.rs
+++ b/crates/engine/src/local_copy/skip_compress.rs
@@ -69,7 +69,7 @@ impl SkipCompressList {
         }
 
         let mut patterns = Vec::new();
-        for part in spec.split(|ch| matches!(ch, '/' | ',')) {
+        for part in spec.split(['/', ',']) {
             let trimmed = part.trim();
             if trimmed.is_empty() {
                 continue;
@@ -135,7 +135,7 @@ impl SkipCompressPattern {
                 '[' => {
                     let mut class = Vec::new();
                     let mut terminated = false;
-                    while let Some(item) = chars.next() {
+                    for item in chars.by_ref() {
                         if item == ']' {
                             terminated = true;
                             break;

--- a/crates/walk/src/lib.rs
+++ b/crates/walk/src/lib.rs
@@ -590,9 +590,9 @@ mod tests {
     use std::fs;
     use std::path::Path;
 
-    fn collect_relative_paths(mut walker: Walker) -> Vec<PathBuf> {
+    fn collect_relative_paths(walker: Walker) -> Vec<PathBuf> {
         let mut paths = Vec::new();
-        while let Some(entry) = walker.next() {
+        for entry in walker {
             let entry = entry.expect("walker entry");
             if entry.is_root() {
                 continue;


### PR DESCRIPTION
## Summary
- refactor engine local copy helpers and associated tests to satisfy new Clippy diagnostics
- simplify CLI, daemon, walk, and xtask utilities and reuse shared constants in core tests
- clean up assorted tests and helpers across crates to eliminate remaining lint failures

## Testing
- cargo clippy --workspace --all-targets -- -Dwarnings

------