### PR TITLE
Fix ACL test helpers and feature builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -701,6 +701,7 @@ version = "3.4.1-rust"
 dependencies = [
  "filetime",
  "globset",
+ "libc",
  "rsync-bandwidth",
  "rsync-checksums",
  "rsync-compress",

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -7766,9 +7766,6 @@ mod tests {
     #[cfg(unix)]
     use std::os::unix::{ffi::OsStrExt, fs::PermissionsExt};
 
-    #[cfg(feature = "xattr")]
-    use xattr;
-
     const RSYNC: &str = branding::client_program_name();
     const OC_RSYNC: &str = branding::oc_client_program_name();
     const RSYNCD: &str = branding::daemon_program_name();

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -23,11 +23,12 @@ rsync-protocol = { path = "../protocol" }
 rsync-bandwidth = { path = "../bandwidth" }
 globset = "0.4"
 rustix = { version = "0.38", features = ["fs", "process"] }
+libc = { version = "0.2", optional = true }
 
 [features]
 default = []
 xattr = ["rsync-meta/xattr"]
-acl = ["rsync-meta/acl"]
+acl = ["rsync-meta/acl", "dep:libc"]
 
 [dev-dependencies]
 filetime = "0.2"

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(unsafe_code)]
+#![cfg_attr(not(feature = "acl"), deny(unsafe_code))]
 #![deny(missing_docs)]
 #![deny(rustdoc::broken_intra_doc_links)]
 


### PR DESCRIPTION
## Summary
- add an optional `libc` dependency for the ACL feature and conditionally relax the crate-wide `unsafe` lint
- provide scoped libacl FFI shims for ACL-related engine tests and reuse them when validating ACL copies
- remove a redundant `xattr` import in CLI tests

## Testing
- cargo clippy --workspace --all-targets -- -Dwarnings
- cargo clippy --workspace --all-targets --features xattr,acl -- -Dwarnings

------