### PR TITLE
Use xtask branding report in packaging workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -298,7 +298,7 @@ jobs:
           tool: cyclonedx-rust-cargo
 
       - name: Display workspace metadata
-        run: cargo metadata --format-version 1 --no-deps | jq '.workspace_metadata.oc_rsync'
+        run: cargo run -p xtask -- branding
 
       - name: Build Debian package
         run: cargo deb -p oc-rsync-bin

--- a/README.md
+++ b/README.md
@@ -87,7 +87,10 @@ Workspace automation consumes the same identifiers via the
 `[workspace.metadata.oc_rsync]` section in the top-level `Cargo.toml`. The
 metadata records the canonical program names, configuration locations, source
 URL, and supported protocol version so packaging tasks and CI workflows can
-validate branding before producing release artifacts.
+validate branding before producing release artifacts. CI now invokes
+`cargo xtask branding` to surface the metadata without relying on external
+tools, and local operators can run the same command to confirm that binaries,
+documentation, and packaging assets share a consistent brand profile.
 
 Higher-level crates such as `daemon` remain under development. The new engine
 module powers the local copy mode shipped by `oc-rsync` (and therefore any


### PR DESCRIPTION
## Summary
- switch the packaging workflow metadata step to `cargo xtask branding` so CI relies on the existing Rust helper
- note the `cargo xtask branding` command in the README for operators validating brand configuration

## Testing
- not run (workflow and documentation only)

------