### PR TITLE
Add xtask binary audit and integrate with CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Ensure no binary files are tracked
-        run: test -z "$(git ls-files -z | xargs -0 file --mime | grep -vE 'text/|application/json')"
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: 1.87
+          cache: true
+      - name: Audit repository for tracked binary artifacts
+        uses: actions-rs/cargo@v1
+        with:
+          command: run
+          args: -p xtask -- no-binaries
 
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- add a `cargo xtask no-binaries` command that walks tracked files and errors on probable binary data
- cover the new command with argument parsing and detector unit tests while updating the top-level help text
- run the binary audit in CI via the Rust toolchain instead of an inline shell one-liner

## Testing
- cargo test -p xtask

------