### PR TITLE
Tighten documentation branding validation

### DIFF
--- a/docs/differences.md
+++ b/docs/differences.md
@@ -2,8 +2,11 @@
 
 This document captures observable gaps between the Rust workspace and upstream
 rsync 3.4.1. Each entry describes the user-visible impact today and outlines
-what must land to eliminate the difference. Items remain in this list until the
-referenced functionality ships and parity is verified by tests or goldens.
+what must land to eliminate the difference. The branded binaries ship as
+**oc-rsync 3.4.1-rust** and **oc-rsyncd 3.4.1-rust**; references below use the
+prefixed names to match the distribution artefacts. Items remain in this list
+until the referenced functionality ships and parity is verified by tests or
+goldens.
 
 ## Blocking Differences
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -782,6 +782,22 @@ fn validate_documentation(workspace: &Path, branding: &WorkspaceBranding) -> Res
                 branding.daemon_secrets.as_str(),
             ],
         },
+        DocumentationCheck {
+            relative_path: "docs/differences.md",
+            required_snippets: vec![
+                branding.client_bin.as_str(),
+                branding.daemon_bin.as_str(),
+                branding.rust_version.as_str(),
+            ],
+        },
+        DocumentationCheck {
+            relative_path: "docs/gaps.md",
+            required_snippets: vec![
+                branding.client_bin.as_str(),
+                branding.daemon_bin.as_str(),
+                branding.rust_version.as_str(),
+            ],
+        },
     ];
 
     for check in checks {


### PR DESCRIPTION
## Summary
- extend the preflight documentation audit to cover the differences and gaps references so branded identifiers stay in sync
- document the oc-rsync 3.4.1-rust naming in docs/differences.md to satisfy the stricter checks

## Testing
- cargo fmt
- cargo test -p xtask

------