### PR TITLE
Fix stable builds by removing let chains

### DIFF
--- a/crates/core/src/client.rs
+++ b/crates/core/src/client.rs
@@ -4614,8 +4614,10 @@ where
                     )
                 ) || matches!(error.kind(), LocalCopyErrorKind::MissingSourceOperands);
 
-            if requires_fallback && let Some(ctx) = fallback.take() {
-                return invoke_fallback(ctx);
+            if requires_fallback {
+                if let Some(ctx) = fallback.take() {
+                    return invoke_fallback(ctx);
+                }
             }
 
             return Err(map_local_copy_error(error));
@@ -9318,11 +9320,10 @@ fn legacy_daemon_error_payload(line: &str) -> Option<String> {
     let trimmed = line.trim_matches(['\r', '\n']).trim_start();
     let remainder = strip_prefix_ignore_ascii_case(trimmed, "@ERROR")?;
 
-    if let Some(ch) = remainder.chars().next()
-        && ch != ':'
-        && !ch.is_ascii_whitespace()
-    {
-        return None;
+    if let Some(ch) = remainder.chars().next() {
+        if ch != ':' && !ch.is_ascii_whitespace() {
+            return None;
+        }
     }
 
     let payload = remainder
@@ -9685,21 +9686,21 @@ fn split_daemon_host_module(input: &str) -> Result<Option<(&str, &str)>, ClientE
                 previous_colon = None;
             }
             ':' if !in_brackets => {
-                if let Some(prev) = previous_colon
-                    && prev + 1 == idx
-                {
-                    let host = &input[..prev];
-                    if !host.contains('[') {
-                        let colon_count = host.chars().filter(|&ch| ch == ':').count();
-                        if colon_count > 1 {
-                            return Err(daemon_error(
-                                "IPv6 daemon addresses must be enclosed in brackets",
-                                FEATURE_UNAVAILABLE_EXIT_CODE,
-                            ));
+                if let Some(prev) = previous_colon {
+                    if prev + 1 == idx {
+                        let host = &input[..prev];
+                        if !host.contains('[') {
+                            let colon_count = host.chars().filter(|&ch| ch == ':').count();
+                            if colon_count > 1 {
+                                return Err(daemon_error(
+                                    "IPv6 daemon addresses must be enclosed in brackets",
+                                    FEATURE_UNAVAILABLE_EXIT_CODE,
+                                ));
+                            }
                         }
+                        let module = &input[idx + 1..];
+                        return Ok(Some((host, module)));
                     }
-                    let module = &input[idx + 1..];
-                    return Ok(Some((host, module)));
                 }
                 previous_colon = Some(idx);
             }

--- a/crates/core/src/message.rs
+++ b/crates/core/src/message.rs
@@ -2544,10 +2544,10 @@ impl fmt::Display for Message {
 /// The input string must already be normalised via [`normalize_path`]. When the path lives outside
 /// the workspace root (or the root is unknown), the original string is returned unchanged.
 fn strip_workspace_prefix_owned(normalized_path: String) -> String {
-    if let Some(root) = normalized_workspace_root()
-        && let Some(stripped) = strip_normalized_workspace_prefix(&normalized_path, root)
-    {
-        return stripped;
+    if let Some(root) = normalized_workspace_root() {
+        if let Some(stripped) = strip_normalized_workspace_prefix(&normalized_path, root) {
+            return stripped;
+        }
     }
 
     normalized_path

--- a/crates/transport/src/handshake_util.rs
+++ b/crates/transport/src/handshake_util.rs
@@ -303,12 +303,6 @@ mod tests {
     use super::*;
     use proptest::prelude::*;
 
-    struct ConstAssert<const COND: bool>;
-
-    impl ConstAssert<true> {
-        const VALUE: () = ();
-    }
-
     fn negotiated_version_strategy() -> impl Strategy<Value = ProtocolVersion> {
         let versions: Vec<ProtocolVersion> = ProtocolVersion::supported_versions_array().to_vec();
         prop::sample::select(versions)
@@ -350,10 +344,10 @@ mod tests {
         const FUTURE_CLAMPED: bool = FUTURE.was_clamped();
         const SUPPORTED_CLAMPED: bool = SUPPORTED.was_clamped();
 
-        const _: () = ConstAssert::<{ CLAMPED }>::VALUE;
-        const _: () = ConstAssert::<{ !NOT_CLAMPED }>::VALUE;
-        const _: () = ConstAssert::<{ FUTURE_CLAMPED }>::VALUE;
-        const _: () = ConstAssert::<{ !SUPPORTED_CLAMPED }>::VALUE;
+        const _: () = assert!(CLAMPED);
+        const _: () = assert!(!NOT_CLAMPED);
+        const _: () = assert!(FUTURE_CLAMPED);
+        const _: () = assert!(!SUPPORTED_CLAMPED);
 
         let clamped = CLAMPED;
         let not_clamped = NOT_CLAMPED;
@@ -386,8 +380,8 @@ mod tests {
         const NOT_CAPPED: bool =
             local_cap_reduced_protocol(ProtocolVersion::V29, ProtocolVersion::V29);
 
-        const _: () = ConstAssert::<{ WAS_CAPPED }>::VALUE;
-        const _: () = ConstAssert::<{ !NOT_CAPPED }>::VALUE;
+        const _: () = assert!(WAS_CAPPED);
+        const _: () = assert!(!NOT_CAPPED);
 
         let was_capped = WAS_CAPPED;
         let not_capped = NOT_CAPPED;


### PR DESCRIPTION
## Summary
- replace unstable let-chain syntax in the client with nested conditionals for stable compatibility
- simplify workspace path stripping helper to avoid chained let expressions
- switch handshake const-evaluation tests to use standard const assertions and drop unused helpers

## Testing
- cargo check

------