### PR TITLE
Fix clippy complaints in transport and core tests

### DIFF
--- a/crates/core/src/client.rs
+++ b/crates/core/src/client.rs
@@ -4614,10 +4614,8 @@ where
                     )
                 ) || matches!(error.kind(), LocalCopyErrorKind::MissingSourceOperands);
 
-            if requires_fallback {
-                if let Some(ctx) = fallback.take() {
-                    return invoke_fallback(ctx);
-                }
+            if requires_fallback && let Some(ctx) = fallback.take() {
+                return invoke_fallback(ctx);
             }
 
             return Err(map_local_copy_error(error));
@@ -9320,10 +9318,11 @@ fn legacy_daemon_error_payload(line: &str) -> Option<String> {
     let trimmed = line.trim_matches(['\r', '\n']).trim_start();
     let remainder = strip_prefix_ignore_ascii_case(trimmed, "@ERROR")?;
 
-    if let Some(ch) = remainder.chars().next() {
-        if ch != ':' && !ch.is_ascii_whitespace() {
-            return None;
-        }
+    if let Some(ch) = remainder.chars().next()
+        && ch != ':'
+        && !ch.is_ascii_whitespace()
+    {
+        return None;
     }
 
     let payload = remainder
@@ -9686,21 +9685,21 @@ fn split_daemon_host_module(input: &str) -> Result<Option<(&str, &str)>, ClientE
                 previous_colon = None;
             }
             ':' if !in_brackets => {
-                if let Some(prev) = previous_colon {
-                    if prev + 1 == idx {
-                        let host = &input[..prev];
-                        if !host.contains('[') {
-                            let colon_count = host.chars().filter(|&ch| ch == ':').count();
-                            if colon_count > 1 {
-                                return Err(daemon_error(
-                                    "IPv6 daemon addresses must be enclosed in brackets",
-                                    FEATURE_UNAVAILABLE_EXIT_CODE,
-                                ));
-                            }
+                if let Some(prev) = previous_colon
+                    && prev + 1 == idx
+                {
+                    let host = &input[..prev];
+                    if !host.contains('[') {
+                        let colon_count = host.chars().filter(|&ch| ch == ':').count();
+                        if colon_count > 1 {
+                            return Err(daemon_error(
+                                "IPv6 daemon addresses must be enclosed in brackets",
+                                FEATURE_UNAVAILABLE_EXIT_CODE,
+                            ));
                         }
-                        let module = &input[idx + 1..];
-                        return Ok(Some((host, module)));
                     }
+                    let module = &input[idx + 1..];
+                    return Ok(Some((host, module)));
                 }
                 previous_colon = Some(idx);
             }

--- a/crates/core/src/message.rs
+++ b/crates/core/src/message.rs
@@ -2544,10 +2544,10 @@ impl fmt::Display for Message {
 /// The input string must already be normalised via [`normalize_path`]. When the path lives outside
 /// the workspace root (or the root is unknown), the original string is returned unchanged.
 fn strip_workspace_prefix_owned(normalized_path: String) -> String {
-    if let Some(root) = normalized_workspace_root() {
-        if let Some(stripped) = strip_normalized_workspace_prefix(&normalized_path, root) {
-            return stripped;
-        }
+    if let Some(root) = normalized_workspace_root()
+        && let Some(stripped) = strip_normalized_workspace_prefix(&normalized_path, root)
+    {
+        return stripped;
     }
 
     normalized_path

--- a/crates/transport/src/handshake_util.rs
+++ b/crates/transport/src/handshake_util.rs
@@ -344,10 +344,22 @@ mod tests {
         const FUTURE_CLAMPED: bool = FUTURE.was_clamped();
         const SUPPORTED_CLAMPED: bool = SUPPORTED.was_clamped();
 
-        const _: () = assert!(CLAMPED);
-        const _: () = assert!(!NOT_CLAMPED);
-        const _: () = assert!(FUTURE_CLAMPED);
-        const _: () = assert!(!SUPPORTED_CLAMPED);
+        const _: () = match CLAMPED {
+            true => (),
+            false => panic!("remote advertisements must be clamped"),
+        };
+        const _: () = match NOT_CLAMPED {
+            false => (),
+            true => panic!("remote advertisement unexpectedly clamped"),
+        };
+        const _: () = match FUTURE_CLAMPED {
+            true => (),
+            false => panic!("future advertisement should be clamped"),
+        };
+        const _: () = match SUPPORTED_CLAMPED {
+            false => (),
+            true => panic!("supported advertisement should not be clamped"),
+        };
 
         let clamped = CLAMPED;
         let not_clamped = NOT_CLAMPED;
@@ -380,8 +392,14 @@ mod tests {
         const NOT_CAPPED: bool =
             local_cap_reduced_protocol(ProtocolVersion::V29, ProtocolVersion::V29);
 
-        const _: () = assert!(WAS_CAPPED);
-        const _: () = assert!(!NOT_CAPPED);
+        const _: () = match WAS_CAPPED {
+            true => (),
+            false => panic!("local cap reduction must be detected"),
+        };
+        const _: () = match NOT_CAPPED {
+            false => (),
+            true => panic!("local cap should not be detected"),
+        };
 
         let was_capped = WAS_CAPPED;
         let not_capped = NOT_CAPPED;


### PR DESCRIPTION
## Summary
- replace const assertions on known true values with match-based const checks so clippy accepts them while keeping compile-time validation
- collapse nested `if` conditions in the client and message modules per clippy suggestions to keep control flow concise

## Testing
- cargo fmt
- cargo clippy --workspace --all-targets -- -Dwarnings

------