### PR TITLE
Simplify client option toggles and workspace prefix stripping

### DIFF
--- a/crates/core/src/client.rs
+++ b/crates/core/src/client.rs
@@ -1694,10 +1694,8 @@ impl ClientConfigBuilder {
     #[doc(alias = "-z")]
     pub const fn compress(mut self, compress: bool) -> Self {
         self.compress = compress;
-        if compress {
-            if self.compression_setting.is_disabled() {
-                self.compression_setting = CompressionSetting::level(CompressionLevel::Default);
-            }
+        if compress && self.compression_setting.is_disabled() {
+            self.compression_setting = CompressionSetting::level(CompressionLevel::Default);
         } else {
             self.compression_setting = CompressionSetting::disabled();
             self.compression_level = None;
@@ -3570,11 +3568,12 @@ where
     }
 
     if let Some(enabled) = protect_args {
-        if enabled {
-            command_args.push(OsString::from("--protect-args"));
+        let flag = if enabled {
+            "--protect-args"
         } else {
-            command_args.push(OsString::from("--no-protect-args"));
-        }
+            "--no-protect-args"
+        };
+        command_args.push(OsString::from(flag));
     }
 
     push_human_readable(&mut command_args, human_readable_mode);

--- a/crates/core/src/message.rs
+++ b/crates/core/src/message.rs
@@ -2570,15 +2570,12 @@ fn strip_normalized_workspace_prefix(path: &str, root: &str) -> Option<String> {
     }
 
     if !root.ends_with('/') {
-        if !suffix.starts_with('/') {
-            return None;
-        }
-
-        suffix = &suffix[1..];
-
-        if suffix.is_empty() {
+        let stripped_suffix = suffix.strip_prefix('/')?;
+        if stripped_suffix.is_empty() {
             return Some(String::from("."));
         }
+
+        suffix = stripped_suffix;
     }
 
     Some(suffix.to_owned())


### PR DESCRIPTION
## Summary
- avoid nested conditionals when defaulting compression settings
- streamline protect-args flag selection
- reuse `strip_prefix` to remove redundant branching in workspace prefix stripping

## Testing
- cargo clippy --workspace --all-targets -- -Dwarnings

------