### PR TITLE
Refine const handshake assertions

### DIFF
--- a/crates/transport/src/handshake_util.rs
+++ b/crates/transport/src/handshake_util.rs
@@ -303,6 +303,12 @@ mod tests {
     use super::*;
     use proptest::prelude::*;
 
+    const fn assert_const(condition: bool, message: &'static str) {
+        if !condition {
+            panic!("{}", message);
+        }
+    }
+
     fn negotiated_version_strategy() -> impl Strategy<Value = ProtocolVersion> {
         let versions: Vec<ProtocolVersion> = ProtocolVersion::supported_versions_array().to_vec();
         prop::sample::select(versions)
@@ -344,22 +350,13 @@ mod tests {
         const FUTURE_CLAMPED: bool = FUTURE.was_clamped();
         const SUPPORTED_CLAMPED: bool = SUPPORTED.was_clamped();
 
-        const _: () = match CLAMPED {
-            true => (),
-            false => panic!("remote advertisements must be clamped"),
-        };
-        const _: () = match NOT_CLAMPED {
-            false => (),
-            true => panic!("remote advertisement unexpectedly clamped"),
-        };
-        const _: () = match FUTURE_CLAMPED {
-            true => (),
-            false => panic!("future advertisement should be clamped"),
-        };
-        const _: () = match SUPPORTED_CLAMPED {
-            false => (),
-            true => panic!("supported advertisement should not be clamped"),
-        };
+        const _: () = assert_const(CLAMPED, "remote advertisements must be clamped");
+        const _: () = assert_const(!NOT_CLAMPED, "remote advertisement unexpectedly clamped");
+        const _: () = assert_const(FUTURE_CLAMPED, "future advertisement should be clamped");
+        const _: () = assert_const(
+            !SUPPORTED_CLAMPED,
+            "supported advertisement should not be clamped",
+        );
 
         let clamped = CLAMPED;
         let not_clamped = NOT_CLAMPED;
@@ -392,14 +389,8 @@ mod tests {
         const NOT_CAPPED: bool =
             local_cap_reduced_protocol(ProtocolVersion::V29, ProtocolVersion::V29);
 
-        const _: () = match WAS_CAPPED {
-            true => (),
-            false => panic!("local cap reduction must be detected"),
-        };
-        const _: () = match NOT_CAPPED {
-            false => (),
-            true => panic!("local cap should not be detected"),
-        };
+        const _: () = assert_const(WAS_CAPPED, "local cap reduction must be detected");
+        const _: () = assert_const(!NOT_CAPPED, "local cap should not be detected");
 
         let was_capped = WAS_CAPPED;
         let not_capped = NOT_CAPPED;


### PR DESCRIPTION
## Summary
- add a dedicated `assert_const` helper for compile-time handshake checks in tests
- refactor transport handshake tests to use the helper instead of manual matches

## Testing
- cargo fmt --all
- cargo clippy --workspace --all-targets -- -Dwarnings

------