### PR TITLE
Fix stable Rust compatibility issues

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -632,12 +632,13 @@ impl OutFormat {
                             ),
                         );
                         if matches!(placeholder, OutFormatPlaceholder::FileNameWithSymlinkTarget)
-                            && let Some(target) = event
-                                .metadata()
-                                .and_then(ClientEntryMetadata::symlink_target)
                         {
-                            buffer.push_str(" -> ");
-                            buffer.push_str(&target.to_string_lossy());
+                            if let Some(metadata) = event.metadata() {
+                                if let Some(target) = metadata.symlink_target() {
+                                    buffer.push_str(" -> ");
+                                    buffer.push_str(&target.to_string_lossy());
+                                }
+                            }
                         }
                     }
                     OutFormatPlaceholder::ItemizedChanges => {
@@ -5055,12 +5056,13 @@ fn emit_verbose<W: Write + ?Sized>(
             }
 
             let mut rendered = event.relative_path().to_string_lossy().into_owned();
-            if let Some(metadata) = event.metadata()
-                && matches!(kind, ClientEventKind::SymlinkCopied)
-                && let Some(target) = metadata.symlink_target()
-            {
-                rendered.push_str(" -> ");
-                rendered.push_str(&target.to_string_lossy());
+            if matches!(kind, ClientEventKind::SymlinkCopied) {
+                if let Some(metadata) = event.metadata() {
+                    if let Some(target) = metadata.symlink_target() {
+                        rendered.push_str(" -> ");
+                        rendered.push_str(&target.to_string_lossy());
+                    }
+                }
             }
             writeln!(stdout, "{rendered}")?;
             continue;
@@ -5100,11 +5102,11 @@ fn emit_verbose<W: Write + ?Sized>(
                     "ignoring unsafe symlink \"{}\"",
                     event.relative_path().display()
                 );
-                if let Some(metadata) = event.metadata()
-                    && let Some(target) = metadata.symlink_target()
-                {
-                    rendered.push_str(" -> ");
-                    rendered.push_str(&target.to_string_lossy());
+                if let Some(metadata) = event.metadata() {
+                    if let Some(target) = metadata.symlink_target() {
+                        rendered.push_str(" -> ");
+                        rendered.push_str(&target.to_string_lossy());
+                    }
                 }
                 writeln!(stdout, "{rendered}")?;
                 continue;
@@ -5121,12 +5123,13 @@ fn emit_verbose<W: Write + ?Sized>(
         }
 
         let mut rendered = event.relative_path().to_string_lossy().into_owned();
-        if let Some(metadata) = event.metadata()
-            && matches!(kind, ClientEventKind::SymlinkCopied)
-            && let Some(target) = metadata.symlink_target()
-        {
-            rendered.push_str(" -> ");
-            rendered.push_str(&target.to_string_lossy());
+        if matches!(kind, ClientEventKind::SymlinkCopied) {
+            if let Some(metadata) = event.metadata() {
+                if let Some(target) = metadata.symlink_target() {
+                    rendered.push_str(" -> ");
+                    rendered.push_str(&target.to_string_lossy());
+                }
+            }
         }
 
         if verbosity == 1 {

--- a/crates/core/src/client.rs
+++ b/crates/core/src/client.rs
@@ -4613,8 +4613,10 @@ where
                     )
                 ) || matches!(error.kind(), LocalCopyErrorKind::MissingSourceOperands);
 
-            if requires_fallback && let Some(ctx) = fallback.take() {
-                return invoke_fallback(ctx);
+            if requires_fallback {
+                if let Some(ctx) = fallback.take() {
+                    return invoke_fallback(ctx);
+                }
             }
 
             return Err(map_local_copy_error(error));
@@ -9317,11 +9319,10 @@ fn legacy_daemon_error_payload(line: &str) -> Option<String> {
     let trimmed = line.trim_matches(['\r', '\n']).trim_start();
     let remainder = strip_prefix_ignore_ascii_case(trimmed, "@ERROR")?;
 
-    if let Some(ch) = remainder.chars().next()
-        && ch != ':'
-        && !ch.is_ascii_whitespace()
-    {
-        return None;
+    if let Some(ch) = remainder.chars().next() {
+        if ch != ':' && !ch.is_ascii_whitespace() {
+            return None;
+        }
     }
 
     let payload = remainder
@@ -9684,21 +9685,21 @@ fn split_daemon_host_module(input: &str) -> Result<Option<(&str, &str)>, ClientE
                 previous_colon = None;
             }
             ':' if !in_brackets => {
-                if let Some(prev) = previous_colon
-                    && prev + 1 == idx
-                {
-                    let host = &input[..prev];
-                    if !host.contains('[') {
-                        let colon_count = host.chars().filter(|&ch| ch == ':').count();
-                        if colon_count > 1 {
-                            return Err(daemon_error(
-                                "IPv6 daemon addresses must be enclosed in brackets",
-                                FEATURE_UNAVAILABLE_EXIT_CODE,
-                            ));
+                if let Some(prev) = previous_colon {
+                    if prev + 1 == idx {
+                        let host = &input[..prev];
+                        if !host.contains('[') {
+                            let colon_count = host.chars().filter(|&ch| ch == ':').count();
+                            if colon_count > 1 {
+                                return Err(daemon_error(
+                                    "IPv6 daemon addresses must be enclosed in brackets",
+                                    FEATURE_UNAVAILABLE_EXIT_CODE,
+                                ));
+                            }
                         }
+                        let module = &input[idx + 1..];
+                        return Ok(Some((host, module)));
                     }
-                    let module = &input[idx + 1..];
-                    return Ok(Some((host, module)));
                 }
                 previous_colon = Some(idx);
             }

--- a/crates/core/src/message.rs
+++ b/crates/core/src/message.rs
@@ -2544,10 +2544,10 @@ impl fmt::Display for Message {
 /// The input string must already be normalised via [`normalize_path`]. When the path lives outside
 /// the workspace root (or the root is unknown), the original string is returned unchanged.
 fn strip_workspace_prefix_owned(normalized_path: String) -> String {
-    if let Some(root) = normalized_workspace_root()
-        && let Some(stripped) = strip_normalized_workspace_prefix(&normalized_path, root)
-    {
-        return stripped;
+    if let Some(root) = normalized_workspace_root() {
+        if let Some(stripped) = strip_normalized_workspace_prefix(&normalized_path, root) {
+            return stripped;
+        }
     }
 
     normalized_path

--- a/crates/transport/src/handshake_util.rs
+++ b/crates/transport/src/handshake_util.rs
@@ -347,14 +347,11 @@ mod tests {
             ProtocolVersion::V30.as_u8() as u32,
             ProtocolVersion::V30,
         );
-        const FUTURE_CLAMPED: bool = FUTURE.was_clamped();
-        const SUPPORTED_CLAMPED: bool = SUPPORTED.was_clamped();
-
         const _: () = assert_const(CLAMPED, "remote advertisements must be clamped");
         const _: () = assert_const(!NOT_CLAMPED, "remote advertisement unexpectedly clamped");
-        const _: () = assert_const(FUTURE_CLAMPED, "future advertisement should be clamped");
+        const _: () = assert_const(FUTURE.was_clamped(), "future advertisement should be clamped");
         const _: () = assert_const(
-            !SUPPORTED_CLAMPED,
+            !SUPPORTED.was_clamped(),
             "supported advertisement should not be clamped",
         );
 


### PR DESCRIPTION
## Summary
- avoid unstable conditional let chains throughout the client and CLI logic
- simplify transport handshake tests to drop unused consts
- keep message path normalization stable-compatible

## Testing
- `cargo check --workspace`

------