### PR TITLE
Fix Clippy collapsible if warnings in core

### DIFF
--- a/crates/core/src/message.rs
+++ b/crates/core/src/message.rs
@@ -2544,10 +2544,10 @@ impl fmt::Display for Message {
 /// The input string must already be normalised via [`normalize_path`]. When the path lives outside
 /// the workspace root (or the root is unknown), the original string is returned unchanged.
 fn strip_workspace_prefix_owned(normalized_path: String) -> String {
-    if let Some(root) = normalized_workspace_root() {
-        if let Some(stripped) = strip_normalized_workspace_prefix(&normalized_path, root) {
-            return stripped;
-        }
+    if let Some(root) = normalized_workspace_root()
+        && let Some(stripped) = strip_normalized_workspace_prefix(&normalized_path, root)
+    {
+        return stripped;
     }
 
     normalized_path


### PR DESCRIPTION
## Summary
- collapse nested fallback handling in the client to satisfy clippy
- simplify daemon parsing logic by combining nested conditional checks
- collapse nested workspace normalization checks in message rendering

## Testing
- cargo clippy --workspace --all-targets -- -Dwarnings

------