### PR TITLE
Run cargo fmt for formatting compliance

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -631,8 +631,7 @@ impl OutFormat {
                                     | OutFormatPlaceholder::FileNameWithSymlinkTarget
                             ),
                         );
-                        if matches!(placeholder, OutFormatPlaceholder::FileNameWithSymlinkTarget)
-                        {
+                        if matches!(placeholder, OutFormatPlaceholder::FileNameWithSymlinkTarget) {
                             if let Some(metadata) = event.metadata() {
                                 if let Some(target) = metadata.symlink_target() {
                                     buffer.push_str(" -> ");

--- a/crates/transport/src/handshake_util.rs
+++ b/crates/transport/src/handshake_util.rs
@@ -349,7 +349,10 @@ mod tests {
         );
         const _: () = assert_const(CLAMPED, "remote advertisements must be clamped");
         const _: () = assert_const(!NOT_CLAMPED, "remote advertisement unexpectedly clamped");
-        const _: () = assert_const(FUTURE.was_clamped(), "future advertisement should be clamped");
+        const _: () = assert_const(
+            FUTURE.was_clamped(),
+            "future advertisement should be clamped",
+        );
         const _: () = assert_const(
             !SUPPORTED.was_clamped(),
             "supported advertisement should not be clamped",


### PR DESCRIPTION
## Summary
- apply `cargo fmt` to align code with formatting conventions

## Testing
- cargo fmt --all -- --check

------