### PR TITLE
Fix stable-compatible control flow in client and message helpers

### DIFF
--- a/crates/core/src/message.rs
+++ b/crates/core/src/message.rs
@@ -2544,8 +2544,8 @@ impl fmt::Display for Message {
 /// The input string must already be normalised via [`normalize_path`]. When the path lives outside
 /// the workspace root (or the root is unknown), the original string is returned unchanged.
 fn strip_workspace_prefix_owned(normalized_path: String) -> String {
-    if let Some(root) = normalized_workspace_root()
-        && let Some(stripped) = strip_normalized_workspace_prefix(&normalized_path, root)
+    if let Some(stripped) = normalized_workspace_root()
+        .and_then(|root| strip_normalized_workspace_prefix(&normalized_path, root))
     {
         return stripped;
     }

--- a/crates/transport/src/handshake_util.rs
+++ b/crates/transport/src/handshake_util.rs
@@ -303,10 +303,12 @@ mod tests {
     use super::*;
     use proptest::prelude::*;
 
-    const fn assert_const(condition: bool, message: &'static str) {
-        if !condition {
-            panic!("{}", message);
-        }
+    macro_rules! const_assert {
+        ($condition:expr, $message:expr) => {{
+            if !$condition {
+                panic!("{}", $message);
+            }
+        }};
     }
 
     fn negotiated_version_strategy() -> impl Strategy<Value = ProtocolVersion> {
@@ -347,16 +349,24 @@ mod tests {
             ProtocolVersion::V30.as_u8() as u32,
             ProtocolVersion::V30,
         );
-        const _: () = assert_const(CLAMPED, "remote advertisements must be clamped");
-        const _: () = assert_const(!NOT_CLAMPED, "remote advertisement unexpectedly clamped");
-        const _: () = assert_const(
-            FUTURE.was_clamped(),
-            "future advertisement should be clamped",
-        );
-        const _: () = assert_const(
-            !SUPPORTED.was_clamped(),
-            "supported advertisement should not be clamped",
-        );
+        const _: () = {
+            const_assert!(CLAMPED, "remote advertisements must be clamped");
+        };
+        const _: () = {
+            const_assert!(!NOT_CLAMPED, "remote advertisement unexpectedly clamped");
+        };
+        const _: () = {
+            const_assert!(
+                FUTURE.was_clamped(),
+                "future advertisement should be clamped"
+            );
+        };
+        const _: () = {
+            const_assert!(
+                !SUPPORTED.was_clamped(),
+                "supported advertisement should not be clamped"
+            );
+        };
 
         let clamped = CLAMPED;
         let not_clamped = NOT_CLAMPED;
@@ -389,8 +399,12 @@ mod tests {
         const NOT_CAPPED: bool =
             local_cap_reduced_protocol(ProtocolVersion::V29, ProtocolVersion::V29);
 
-        const _: () = assert_const(WAS_CAPPED, "local cap reduction must be detected");
-        const _: () = assert_const(!NOT_CAPPED, "local cap should not be detected");
+        const _: () = {
+            const_assert!(WAS_CAPPED, "local cap reduction must be detected");
+        };
+        const _: () = {
+            const_assert!(!NOT_CAPPED, "local cap should not be detected");
+        };
 
         let was_capped = WAS_CAPPED;
         let not_capped = NOT_CAPPED;


### PR DESCRIPTION
## Summary
- replace unstable let-chain expressions in the client facade with stable option combinators
- update message path normalization to avoid unstable syntax while keeping workspace stripping intact
- rework transport const-evaluable assertions using a macro so tests continue compiling without dead code warnings

## Testing
- `cargo clippy --workspace --all-targets -- -Dwarnings`

------