### PR TITLE
Fix const assertions in transport tests and workspace check

### DIFF
--- a/crates/core/src/version.rs
+++ b/crates/core/src/version.rs
@@ -88,15 +88,13 @@ const ZSTD_FEATURE_BIT: u8 = 1 << 2;
 const ICONV_FEATURE_BIT: u8 = 1 << 3;
 const SD_NOTIFY_FEATURE_BIT: u8 = 1 << 4;
 
-const fn assert_workspace_protocol_alignment() {
+const _: () = {
     let workspace_version = workspace::metadata().protocol_version();
     let crate_version = ProtocolVersion::NEWEST.as_u8() as u32;
     if workspace_version != crate_version {
         panic!("workspace protocol version must match ProtocolVersion::NEWEST");
     }
-}
-
-const _: () = assert_workspace_protocol_alignment();
+};
 
 /// Bitmap describing the optional features compiled into this build.
 ///

--- a/crates/transport/src/handshake_util.rs
+++ b/crates/transport/src/handshake_util.rs
@@ -311,6 +311,12 @@ mod tests {
         }};
     }
 
+    const fn assert_const(condition: bool, message: &str) {
+        if !condition {
+            panic!("{}", message);
+        }
+    }
+
     fn negotiated_version_strategy() -> impl Strategy<Value = ProtocolVersion> {
         let versions: Vec<ProtocolVersion> = ProtocolVersion::supported_versions_array().to_vec();
         prop::sample::select(versions)


### PR DESCRIPTION
## Summary
- ensure the workspace protocol alignment check runs in a const block instead of an unused helper
- add a dedicated const assertion helper for handshake tests so const evaluation succeeds

## Testing
- cargo clippy --workspace --all-targets -- -Dwarnings

------