### PR TITLE
Fix duplicate assert helper in transport handshake tests

### DIFF
--- a/crates/transport/src/handshake_util.rs
+++ b/crates/transport/src/handshake_util.rs
@@ -309,12 +309,6 @@ mod tests {
         }
     }
 
-    const fn assert_const(condition: bool, message: &str) {
-        if !condition {
-            panic!("{}", message);
-        }
-    }
-
     fn negotiated_version_strategy() -> impl Strategy<Value = ProtocolVersion> {
         let versions: Vec<ProtocolVersion> = ProtocolVersion::supported_versions_array().to_vec();
         prop::sample::select(versions)


### PR DESCRIPTION
## Summary
- remove the duplicate `assert_const` helper definition in the transport handshake tests

## Testing
- cargo clippy --workspace --all-targets -- -Dwarnings

------