### PR TITLE
Streamline CI run commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,13 +119,10 @@ jobs:
         run: cargo nextest run --workspace --no-fail-fast --features "cli nightly"
 
       - name: Run CLI version tests without ACL/iconv support
-        run: >-
-          cargo test -p rsync-cli --test version --no-default-features --features "xattr zlib zstd"
+        run: cargo test -p rsync-cli --test version --no-default-features --features 'xattr zlib zstd'
 
       - name: Test with coverage (95% lines & functions)
-        run: >-
-          cargo llvm-cov nextest --workspace --features "cli nightly" --fail-under-lines 95
-          --fail-under-functions 95 --lcov --output-path coverage.lcov -- --no-fail-fast
+        run: cargo llvm-cov nextest --workspace --features 'cli nightly' --fail-under-lines 95 --fail-under-functions 95 --lcov --output-path coverage.lcov -- --no-fail-fast
 
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v4
@@ -248,9 +245,7 @@ jobs:
 
       - name: Generate target SBOM
         if: ${{ !contains(matrix.target, 'windows') }}
-        run: >-
-          cargo run -p xtask -- sbom --output
-          target/${{ matrix.target }}/release/oc-rsync-${{ matrix.name }}-sbom.json
+        run: cargo run -p xtask -- sbom --output target/${{ matrix.target }}/release/oc-rsync-${{ matrix.name }}-sbom.json
 
       - name: Upload oc-rsync artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- ensure GitHub Actions run steps avoid multiline shell scripts by using single-line cargo invocations
- keep coverage, CLI version, and SBOM steps aligned with branding and packaging metadata expectations

## Testing
- not run (workflow-only change)

------