### PR TITLE
Fix rustdoc intra-doc links across crates

### DIFF
--- a/crates/bandwidth/README.md
+++ b/crates/bandwidth/README.md
@@ -19,22 +19,22 @@ daemon share identical validation and throttling behaviour.
 
 ### Parsing helpers
 
-[`parse::parse_bandwidth_argument`](crate::parse::parse_bandwidth_argument)
+[`crate::parse::parse_bandwidth_argument`]
 accepts textual bandwidth specifications and returns either an optional byte
-limit or a [`BandwidthParseError`](crate::parse::BandwidthParseError). The
+limit or a [`crate::parse::BandwidthParseError`]. The
 helper trims ASCII whitespace, validates suffixes, applies the `+1` / `-1`
 adjustments accepted by upstream rsync, and rounds to the nearest 1024 bytes per
 second as the C implementation does.
 
-[`parse::parse_bandwidth_limit`](crate::parse::parse_bandwidth_limit) extends the
+[`crate::parse::parse_bandwidth_limit`] extends the
 behaviour to parse daemon-style `RATE[:BURST]` combinations. The returned
-[`BandwidthLimitComponents`](crate::parse::BandwidthLimitComponents) struct can
-be converted into a [`BandwidthLimiter`](crate::BandwidthLimiter) or stored for
+[`crate::parse::BandwidthLimitComponents`] struct can
+be converted into a [`crate::BandwidthLimiter`] or stored for
 later negotiation.
 
 ### Pacing helpers
 
-[`BandwidthLimiter`](crate::BandwidthLimiter) implements the token-bucket
+[`crate::BandwidthLimiter`] implements the token-bucket
 scheduler used by the transfer engine and daemon. It tracks accumulated debt,
 limits write sizes, and sleeps long enough to honour the configured rate. When
 the optional burst parameter is supplied the limiter caps the debt to the burst
@@ -43,21 +43,18 @@ size, mirroring upstream behaviour.
 `apply_effective_limit` merges daemon-imposed caps with pre-existing limiter
 configuration. The helper ensures precedence rules match upstream rsync by
 keeping the strictest rate while allowing burst overrides when explicitly
-requested, and returns a [`LimiterChange`](crate::LimiterChange) describing
+requested, and returns a [`crate::LimiterChange`] describing
 whether throttling was enabled, updated, disabled, or left untouched.
 
 ### Test support
 
 Enabling the `test-support` feature exposes helpers that record sleep requests
-instead of calling [`std::thread::sleep`]. Tests obtain a
-[`recorded_sleep_session`](crate::recorded_sleep_session) guard to serialise
-access to the captured durations, ensuring race-free assertions when scenarios
-run in parallel. The guard also implements [`Default`], making it easy to embed
-inside helper structs without additional boilerplate. Convenience accessors such as
-[`snapshot`](crate::RecordedSleepSession::snapshot),
-[`last_duration`](crate::RecordedSleepSession::last_duration), and
-[`total_duration`](crate::RecordedSleepSession::total_duration) let tests
-inspect the pacing history without draining it.
+instead of calling [`std::thread::sleep`]. Tests obtain a `recorded_sleep_session`
+guard to serialise access to the captured durations, ensuring race-free
+assertions when scenarios run in parallel. The guard also implements
+[`Default`], making it easy to embed inside helper structs without additional
+boilerplate. Convenience accessors such as `snapshot`, `last_duration`, and
+`total_duration` let tests inspect the pacing history without draining it.
 
 ## Example
 

--- a/crates/compress/src/lib.rs
+++ b/crates/compress/src/lib.rs
@@ -32,7 +32,8 @@
 //! # Errors
 //!
 //! The encoder and decoder functions return [`std::io::Result`]. When zlib
-//! reports an error the helper wraps it in [`io::ErrorKind::Other`]. Callers can
+//! reports an error the helper wraps it in
+//! [`std::io::ErrorKind::Other`]. Callers can
 //! surface these diagnostics via the central message facade in `rsync-core`.
 //!
 //! # Examples
@@ -60,6 +61,6 @@
 //! # See also
 //!
 //! - [`zlib`] for the encoder/decoder implementation and API surface.
-//! - [`rsync_engine`] for the transfer pipeline that integrates these helpers.
+//! - `rsync_engine` for the transfer pipeline that integrates these helpers.
 
 pub mod zlib;

--- a/crates/core/src/client.rs
+++ b/crates/core/src/client.rs
@@ -12,11 +12,13 @@
 //!
 //! # Design
 //!
-//! - [`ClientConfig`] encapsulates the caller-provided transfer arguments. A
+//! - [`ClientConfig`](crate::client::ClientConfig) encapsulates the caller-provided
+//!   transfer arguments. A
 //!   builder is offered so future options (e.g. logging verbosity) can be wired
 //!   through without breaking call sites. Today it exposes toggles for dry-run
 //!   validation (`--dry-run`) and extraneous-destination cleanup (`--delete`).
-//! - [`run_client`] executes the client flow. The helper delegates to
+//! - [`run_client`](crate::client::run_client) executes the client flow. The helper
+//!   delegates to
 //!   [`rsync_engine::local_copy`] to mirror a simplified subset of upstream
 //!   behaviour by copying files, directories, and symbolic links on the local
 //!   filesystem while preserving permissions, timestamps, optional
@@ -29,25 +31,28 @@
 //!   the helper removes destination entries that are absent from the source tree
 //!   before applying metadata and prunes excluded entries when explicitly
 //!   requested.
-//! - [`ModuleListRequest`] parses daemon-style operands (`rsync://host/` or
-//!   `host::`) and [`run_module_list`] connects to the remote daemon using the
-//!   legacy `@RSYNCD:` negotiation to retrieve the advertised module table.
-//! - [`ClientError`] carries the exit code and fully formatted
-//!   [`Message`](crate::message::Message) so binaries can surface diagnostics via
-//!   the central rendering helpers.
+//! - [`ModuleListRequest`](crate::client::ModuleListRequest) parses
+//!   daemon-style operands (`rsync://host/` or `host::`) and
+//!   [`run_module_list`](crate::client::run_module_list) connects to the remote
+//!   daemon using the legacy `@RSYNCD:` negotiation to retrieve the advertised
+//!   module table.
+//! - [`ClientError`](crate::client::ClientError) carries the exit code and fully
+//!   formatted [`crate::message::Message`] so binaries can surface diagnostics
+//!   via the central rendering helpers.
 //!
 //! # Invariants
 //!
 //! - `ClientError::exit_code` always matches the exit code embedded in the
-//!   [`Message`].
+//!   [`crate::message::Message`].
 //! - `run_client` never panics and preserves the provided configuration even
 //!   when reporting unsupported functionality.
 //!
 //! # Errors
 //!
-//! All failures are routed through [`ClientError`]. The structure implements
-//! [`std::error::Error`], allowing integration with higher-level error handling
-//! stacks without losing access to the formatted diagnostic.
+//! All failures are routed through [`ClientError`](crate::client::ClientError).
+//! The structure implements [`std::error::Error`], allowing integration with
+//! higher-level error handling stacks without losing access to the formatted
+//! diagnostic.
 //!
 //! # Examples
 //!
@@ -2254,7 +2259,8 @@ pub fn parse_skip_compress_list(value: &OsStr) -> Result<SkipCompressList, Messa
     })
 }
 
-/// Parses the [`RSYNC_SKIP_COMPRESS`] environment variable into a [`SkipCompressList`].
+/// Parses the `RSYNC_SKIP_COMPRESS` environment variable into a
+/// [`SkipCompressList`].
 ///
 /// Returning [`Ok(None)`] indicates that the variable was unset, allowing
 /// callers to retain their default skip-compress configuration. When the
@@ -2521,7 +2527,8 @@ impl BandwidthLimit {
         Self::new_internal(bytes_per_second, burst, burst.is_some())
     }
 
-    /// Converts parsed [`BandwidthLimitComponents`] into a [`BandwidthLimit`].
+    /// Converts parsed [`bandwidth::BandwidthLimitComponents`] into a
+    /// [`BandwidthLimit`].
     ///
     /// Returning `None` mirrors upstream rsync's interpretation of `0` as an
     /// unlimited rate. Callers that parse `--bwlimit` arguments can therefore
@@ -2563,7 +2570,8 @@ impl BandwidthLimit {
         self.burst_specified
     }
 
-    /// Produces the shared [`BandwidthLimitComponents`] representation for this limit.
+    /// Produces the shared [`bandwidth::BandwidthLimitComponents`] representation
+    /// for this limit.
     ///
     /// The conversion retains both the byte-per-second rate and the optional burst
     /// component so higher layers can forward the configuration to helpers that
@@ -2579,7 +2587,8 @@ impl BandwidthLimit {
         )
     }
 
-    /// Consumes the limit and returns the [`BandwidthLimitComponents`] representation.
+    /// Consumes the limit and returns the
+    /// [`bandwidth::BandwidthLimitComponents`] representation.
     ///
     /// This by-value variant mirrors [`Self::components`] for callers that want
     /// to forward the components without keeping the original [`BandwidthLimit`]
@@ -3148,7 +3157,9 @@ pub struct RemoteFallbackArgs {
     pub address_mode: AddressMode,
     /// Optional override for the fallback executable path.
     ///
-    /// When unspecified the helper consults the [`CLIENT_FALLBACK_ENV`](crate::fallback::CLIENT_FALLBACK_ENV) environment variable (`OC_RSYNC_FALLBACK`) and
+    /// When unspecified the helper consults the
+    /// [`crate::fallback::CLIENT_FALLBACK_ENV`] environment variable
+    /// (`OC_RSYNC_FALLBACK`) and
     /// defaults to `rsync` if the override is missing or empty.
     pub fallback_binary: Option<OsString>,
     /// Optional override for the remote rsync executable.
@@ -9459,7 +9470,8 @@ impl ModuleListRequest {
         Self::from_operands_with_port(operands, Self::DEFAULT_PORT)
     }
 
-    /// Equivalent to [`from_operands`] but allows overriding the default daemon port.
+    /// Equivalent to [`Self::from_operands`] but allows overriding the default
+    /// daemon port.
     pub fn from_operands_with_port(
         operands: &[OsString],
         default_port: u16,

--- a/crates/core/src/fallback.rs
+++ b/crates/core/src/fallback.rs
@@ -13,13 +13,16 @@
 //!
 //! # Design
 //!
-//! The module exposes [`fallback_override`] to decode a single environment
-//! variable into a [`FallbackOverride`]. Callers can chain multiple invocations
-//! to honour primary and secondary environment names before deciding whether a
-//! delegation binary is available. The [`FallbackOverride::resolve_or_default`]
-//! helper converts the parsed override into an [`OsString`] when delegation is
-//! enabled, falling back to the supplied default executable (`rsync`) when the
-//! override is `auto` or unspecified.
+//! The module exposes [`fallback_override`](crate::fallback::fallback_override)
+//! to decode a single environment variable into a
+//! [`FallbackOverride`](crate::fallback::FallbackOverride). Callers can chain
+//! multiple invocations to honour primary and secondary environment names
+//! before deciding whether a delegation binary is available. The
+//! [`crate::fallback::FallbackOverride::resolve_or_default`] helper converts the
+//! parsed override into an [`std::ffi::OsString`] when delegation is enabled,
+//! falling back to the
+//! supplied default executable (`rsync`) when the override is `auto` or
+//! unspecified.
 //!
 //! # Invariants
 //!
@@ -32,16 +35,19 @@
 //!
 //! # Errors
 //!
-//! The helpers do not construct [`Message`](crate::message::Message) instances
+//! The helpers do not construct [`crate::message::Message`] instances
 //! because callers must decide how to report disabled delegation. Instead, the
 //! parsing functions return [`None`] when an override is not present or
-//! [`FallbackOverride::Disabled`] when delegation is explicitly turned off.
+//! [`crate::fallback::FallbackOverride::Disabled`] when delegation is explicitly
+//! turned off.
 //!
 //! # Examples
 //!
 //! Construct overrides directly and resolve them to executable paths. In real
-//! usage call [`fallback_override`] to parse environment variables into the
-//! [`FallbackOverride`] enum before invoking [`FallbackOverride::resolve_or_default`].
+//! usage call [`fallback_override`](crate::fallback::fallback_override) to parse
+//! environment variables into the [`FallbackOverride`](crate::fallback::FallbackOverride)
+//! enum before invoking
+//! [`crate::fallback::FallbackOverride::resolve_or_default`].
 //!
 //! ```
 //! use rsync_core::fallback::FallbackOverride;
@@ -62,9 +68,9 @@
 //!
 //! # See also
 //!
-//! - [`rsync_core::client::run_remote_transfer_fallback`] for the primary
-//!   consumer of these helpers on the client side.
-//! - [`rsync_daemon::run`] for daemon-side delegation.
+//! - [`crate::client::run_remote_transfer_fallback`] for the primary consumer of
+//!   these helpers on the client side.
+//! - `rsync_daemon::run` for daemon-side delegation.
 
 use std::env;
 use std::ffi::{OsStr, OsString};

--- a/crates/core/src/message.rs
+++ b/crates/core/src/message.rs
@@ -1176,8 +1176,8 @@ impl fmt::Display for SourceLocation {
 ///
 /// This macro expands at the call-site and therefore records the location of the
 /// expansion. When the caller is a helper annotated with `#[track_caller]`,
-/// consider using [`tracked_message_source!`] to surface the original
-/// invocation location instead.
+/// consider using [`macro@crate::tracked_message_source`] to surface the
+/// original invocation location instead.
 ///
 /// # Examples
 ///
@@ -1249,7 +1249,8 @@ macro_rules! tracked_message_source {
 /// Constructs an error [`Message`] with the provided exit code and payload.
 ///
 /// The macro mirrors upstream diagnostics by automatically attaching the
-/// call-site [`SourceLocation`] using [`macro@tracked_message_source`]. It accepts either a
+/// call-site [`SourceLocation`] using [`macro@crate::tracked_message_source`]. It
+/// accepts either a
 /// string literal/`Cow<'static, str>` payload or a [`format!`] style template.
 /// Callers can further customise the returned [`Message`] by chaining helpers
 /// such as [`Message::with_role`].
@@ -1296,7 +1297,7 @@ macro_rules! rsync_error {
 ///
 /// Like [`macro@rsync_error`], the macro records the call-site source location so
 /// diagnostics include repo-relative paths. The macro relies on
-/// [`macro@tracked_message_source`], meaning callers annotated with
+/// [`macro@crate::tracked_message_source`], meaning callers annotated with
 /// `#[track_caller]` automatically propagate their invocation site. Additional
 /// context, such as exit codes, can be attached using [`Message::with_code`].
 ///
@@ -1330,8 +1331,9 @@ macro_rules! rsync_warning {
 /// attaches the call-site source location. Upstream rsync typically omits source
 /// locations for informational output, but retaining the metadata simplifies
 /// debugging and keeps the API consistent across severities. As with the other
-/// message macros, [`macro@tracked_message_source`] ensures `#[track_caller]`
-/// annotations propagate the original invocation site into diagnostics.
+/// message macros, [`macro@crate::tracked_message_source`] ensures
+/// `#[track_caller]` annotations propagate the original invocation site into
+/// diagnostics.
 ///
 /// # Examples
 ///
@@ -1356,13 +1358,15 @@ macro_rules! rsync_info {
 
 /// Constructs a [`Message`] using the canonical wording for a known exit code.
 ///
-/// The macro delegates to [`Message::from_exit_code`] and attaches the caller's source location
-/// via [`macro@tracked_message_source`]. Returning an [`Option`] mirrors the underlying helper:
+/// The macro delegates to [`Message::from_exit_code`] and attaches the caller's
+/// source location via [`macro@crate::tracked_message_source`]. Returning an
+/// [`Option`] mirrors the underlying helper:
 /// upstream rsync only assigns stock diagnostics to a fixed set of exit codes. Callers can use
 /// [`Option::unwrap_or_else`] to supply bespoke text when the exit code is not recognised.
 ///
-/// Because the macro relies on [`macro@tracked_message_source`], functions annotated with
-/// `#[track_caller]` propagate their call-site into the rendered diagnostic just like the other
+/// Because the macro relies on [`macro@crate::tracked_message_source`], functions
+/// annotated with `#[track_caller]` propagate their call-site into the rendered
+/// diagnostic just like the other
 /// `rsync_*` macros.
 ///
 /// # Examples
@@ -1427,7 +1431,8 @@ impl Message {
     ///
     /// The helper exposes the same slices used internally when emitting the message into an
     /// [`io::Write`] implementor. Callers that need to integrate with custom buffered pipelines can
-    /// reuse the returned segments with [`Write::write_vectored`], avoiding redundant allocations or
+    /// reuse the returned segments with [`std::io::Write::write_vectored`],
+    /// avoiding redundant allocations or
     /// per-segment formatting logic.
     ///
     /// # Examples
@@ -2294,7 +2299,8 @@ impl Message {
     /// Appends the rendered message into the provided byte buffer.
     ///
     /// The helper mirrors [`Self::render_to_writer`] but avoids the overhead of
-    /// constructing a temporary [`Vec`] or going through the [`Write`] trait for
+    /// constructing a temporary [`Vec`] or going through the
+    /// [`std::io::Write`] trait for
     /// `Vec<u8>`. Callers that batch multiple diagnostics can therefore reuse
     /// an output buffer across invocations without repeated allocations or
     /// trait-object dispatch. The buffer is grown exactly enough to hold the

--- a/crates/core/src/version.rs
+++ b/crates/core/src/version.rs
@@ -12,34 +12,43 @@
 //!
 //! The module publishes lightweight enums and helper functions:
 //!
-//! - [`RUST_VERSION`] holds the `3.4.1-rust` identifier rendered by
+//! - [`RUST_VERSION`](crate::version::RUST_VERSION) holds the `3.4.1-rust`
+//!   identifier rendered by
 //!   user-visible banners.
-//! - [`compiled_features`] inspects Cargo feature flags and returns the set of
-//!   optional capabilities enabled at build time.
-//! - [`compiled_features_static`] exposes a zero-allocation view for repeated
+//! - [`compiled_features`](crate::version::compiled_features) inspects Cargo
+//!   feature flags and returns the set of optional capabilities enabled at build
+//!   time.
+//! - [`compiled_features_static`](crate::version::compiled_features_static)
+//!   exposes a zero-allocation view for repeated
 //!   inspections of the compiled feature set.
-//! - [`CompiledFeature`] enumerates optional capabilities and provides label
-//!   helpers such as [`CompiledFeature::label`] and
-//!   [`CompiledFeature::from_label`] for parsing user-provided strings.
-//! - [`VersionInfoReport`] renders the full `--version` text, including
-//!   capability sections and checksum/compressor listings, so the CLI can
-//!   display upstream-identical banners branded for `rsync`.
+//! - [`CompiledFeature`](crate::version::CompiledFeature) enumerates optional
+//!   capabilities and provides label helpers such as
+//!   [`crate::version::CompiledFeature::label`] and
+//!   [`crate::version::CompiledFeature::from_label`] for parsing user-provided
+//!   strings.
+//! - [`VersionInfoReport`](crate::version::VersionInfoReport) renders the full
+//!   `--version` text, including capability sections and checksum/compressor
+//!   listings, so the CLI can display upstream-identical banners branded for
+//!   `rsync`.
 //!
 //! This structure keeps other crates free of conditional compilation logic
 //! while avoiding string duplication across the workspace.
 //!
 //! # Invariants
 //!
-//! - [`RUST_VERSION`] always embeds the upstream base release so diagnostics and
+//! - [`RUST_VERSION`](crate::version::RUST_VERSION) always embeds the upstream
+//!   base release so diagnostics and
 //!   CLI output remain aligned with rsync 3.4.1.
-//! - [`compiled_features`] never invents capabilities: it only reports flags
-//!   that were explicitly enabled when compiling `rsync-core`.
+//! - [`compiled_features`](crate::version::compiled_features) never invents
+//!   capabilities: it only reports flags that were explicitly enabled when
+//!   compiling `rsync-core`.
 //!
 //! # Errors
 //!
-//! The module exposes [`ParseCompiledFeatureError`] when parsing a
-//! [`CompiledFeature`] from a string fails. All other helpers return constants
-//! or eagerly evaluate into owned collections.
+//! The module exposes
+//! [`ParseCompiledFeatureError`](crate::version::ParseCompiledFeatureError)
+//! when parsing a [`crate::version::CompiledFeature`] from a string fails. All
+//! other helpers return constants or eagerly evaluate into owned collections.
 //!
 //! # Examples
 //!
@@ -60,11 +69,11 @@
 //!
 //! # See also
 //!
-//! - [`rsync_core::message`] uses [`RUST_VERSION`] when rendering error
-//!   trailers.
-//! - Future CLI modules rely on [`compiled_features`] and
-//!   [`VersionInfoReport`] to mirror upstream `--version` capability listings
-//!   while advertising the Rust-branded binary name.
+//! - [`crate::message`] uses [`crate::version::RUST_VERSION`] when rendering
+//!   error trailers.
+//! - Future CLI modules rely on [`crate::version::compiled_features`] and
+//!   [`crate::version::VersionInfoReport`] to mirror upstream `--version`
+//!   capability listings while advertising the Rust-branded binary name.
 
 use crate::{
     branding::{self, Brand},

--- a/crates/core/src/workspace.rs
+++ b/crates/core/src/workspace.rs
@@ -8,7 +8,8 @@
 //! keeps the binary front-ends and supporting crates free from duplicated string
 //! literals. Callers should prefer these helpers instead of hard-coding program
 //! names or configuration paths. Consumers that need the entire metadata set can
-//! use [`metadata`] to obtain a snapshot that mirrors the manifest entries.
+//! use [`crate::workspace::metadata`] to obtain a snapshot that mirrors the
+//! manifest entries.
 
 use std::path::Path;
 

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -12,7 +12,7 @@
 //! # Design
 //!
 //! Functionality is decomposed into focused modules. The [`local_copy`] module
-//! exposes [`LocalCopyPlan`](local_copy::LocalCopyPlan) which performs
+//! exposes [`local_copy::LocalCopyPlan`] which performs
 //! recursive copies of regular files, directories, symbolic links, and FIFOs
 //! while preserving permissions and timestamps through the [`rsync_meta`]
 //! helpers. The [`delta`] module mirrors upstream rsync's signature layout
@@ -64,7 +64,7 @@
 //!
 //! # See also
 //!
-//! - [`rsync_core::client`] integrates the plan builder to power the `rsync`
+//! - `rsync_core::client` integrates the plan builder to power the `rsync`
 //!   binary's local copy mode.
 //! - [`delta`] exposes block-size and checksum heuristics that will be wired into
 //!   the delta-transfer engine.

--- a/crates/filters/src/lib.rs
+++ b/crates/filters/src/lib.rs
@@ -71,7 +71,7 @@
 //!
 //! # See also
 //!
-//! - [`rsync_engine::local_copy`] integrates [`FilterSet`] to prune directory
+//! - `rsync_engine::local_copy` integrates [`FilterSet`] to prune directory
 //!   traversals during deterministic local copies.
 //! - [`globset`] for the glob matching primitives used internally.
 

--- a/crates/logging/src/lib.rs
+++ b/crates/logging/src/lib.rs
@@ -5,16 +5,16 @@
 //! # Overview
 //!
 //! `rsync_logging` provides reusable logging primitives that operate on the
-//! [`Message`](rsync_core::message::Message) type shared across the Rust rsync
+//! [`rsync_core::message::Message`] type shared across the Rust rsync
 //! workspace. The initial focus is on streaming diagnostics to arbitrary writers
-//! while reusing [`MessageScratch`](rsync_core::message::MessageScratch)
+//! while reusing [`rsync_core::message::MessageScratch`]
 //! instances so higher layers avoid repeated buffer initialisation when printing
 //! large batches of messages.
 //!
 //! # Design
 //!
 //! The crate exposes [`MessageSink`], a lightweight wrapper around an
-//! [`io::Write`](std::io::Write) implementor. Each sink stores a
+//! [`std::io::Write`] implementor. Each sink stores a
 //! [`MessageScratch`] scratch buffer that is reused whenever a message is
 //! rendered, matching upstream rsync's approach of keeping stack-allocated
 //! buffers alive for the duration of a logging session. Callers can control
@@ -827,7 +827,8 @@ where
     ///
     /// The method accepts borrowed or owned [`Message`] values via
     /// [`Borrow<Message>`], allowing call sites to forward diagnostics without
-    /// cloning. This matches the flexibility offered by [`write_all`], making it
+    /// cloning. This matches the flexibility offered by
+    /// [`std::io::Write::write_all`], making it
     /// inexpensive to reuse the same sink for ad-hoc or batched message
     /// emission.
     ///

--- a/crates/meta/src/lib.rs
+++ b/crates/meta/src/lib.rs
@@ -65,8 +65,7 @@
 //!
 //! # See also
 //!
-//! - [`rsync_core::client`] integrates these helpers for local filesystem
-//!   copies.
+//! - `rsync_core::client` integrates these helpers for local filesystem copies.
 //! - [`filetime`] for lower-level timestamp manipulation utilities.
 
 use std::fmt;

--- a/crates/protocol/README.md
+++ b/crates/protocol/README.md
@@ -9,18 +9,18 @@ multiplexed frames without depending on the original C sources.
 
 The crate is decomposed into small modules that map onto the upstream architecture:
 
-- [`version`](crate::version) exposes [`ProtocolVersion`](crate::ProtocolVersion) and
+- `version` exposes [`ProtocolVersion`] and
   helpers for selecting the highest mutually supported protocol between peers.
-- [`legacy`](crate::legacy) provides parsers for ASCII daemon handshakes such as
+- `legacy` provides parsers for ASCII daemon handshakes such as
   `@RSYNCD: 31.0` and the follow-up control messages emitted by rsync daemons prior to
   protocol 30.
-- [`negotiation`](crate::negotiation) contains incremental sniffers that classify the
+- `negotiation` contains incremental sniffers that classify the
   handshake style (binary vs. legacy ASCII) without losing buffered bytes.
-- [`multiplex`](crate::multiplex) and [`envelope`](crate::envelope) re-create the
+- `multiplex` and `envelope` re-create the
   control/data framing used once a session has been negotiated.
-- [`compatibility`](crate::compatibility) models the post-negotiation compatibility flags
+- `compatibility` models the post-negotiation compatibility flags
   shared by peers and exposes typed helpers for working with individual bits.
-- [`varint`](crate::varint) reproduces rsync's variable-length integer codec so other
+- `varint` reproduces rsync's variable-length integer codec so other
   modules can serialise the compatibility flags and future protocol values.
 
 Each module satisfies the workspace style guide, while the crate root re-exports the
@@ -28,7 +28,7 @@ stable APIs consumed by the higher-level transport, core, and daemon layers.
 
 ## Invariants
 
-- [`SUPPORTED_PROTOCOLS`](crate::SUPPORTED_PROTOCOLS) always lists protocol numbers in
+- [`SUPPORTED_PROTOCOLS`] always lists protocol numbers in
   descending order (`32` through `28`).
 - Legacy negotiation helpers never drop or duplicate bytes: sniffed prefixes can be
   replayed verbatim into the parsing routines.
@@ -39,7 +39,7 @@ stable APIs consumed by the higher-level transport, core, and daemon layers.
 
 Parsing helpers surface rich error types that carry enough context to reproduce upstream
 diagnostics. For example,
-[`NegotiationError`](crate::NegotiationError) distinguishes between malformed greetings,
+[`NegotiationError`] distinguishes between malformed greetings,
 unsupported protocol ranges, and truncated payloads. All error types implement
 [`std::error::Error`] and convert into [`std::io::Error`] where appropriate so they
 integrate naturally with transport code.
@@ -75,7 +75,7 @@ assert_eq!(negotiated, ProtocolVersion::NEWEST);
 
 When a peer selects the legacy ASCII negotiation, the bytes that triggered the decision
 must be replayed into the greeting parser so the full `@RSYNCD:` line can be
-reconstructed. [`NegotiationPrologueSniffer`](crate::NegotiationPrologueSniffer) owns the
+reconstructed. [`NegotiationPrologueSniffer`] owns the
 buffered prefix, allowing callers to reuse it without copying more data than upstream
 rsync would have consumed.
 

--- a/crates/protocol/src/compatibility.rs
+++ b/crates/protocol/src/compatibility.rs
@@ -204,8 +204,8 @@ impl KnownCompatibilityFlag {
     /// The parser accepts the exact `CF_*` names emitted by upstream rsync and returned by
     /// [`Self::name`]. Any other input is rejected, ensuring higher layers avoid silently mapping
     /// unknown identifiers to a default value. When parsing fails, the returned
-    /// [`ParseKnownCompatibilityFlagError`] exposes the offending identifier via
-    /// [`ParseKnownCompatibilityFlagError::identifier`], making it trivial for
+    /// `ParseKnownCompatibilityFlagError` exposes the offending identifier via
+    /// `ParseKnownCompatibilityFlagError::identifier`, making it trivial for
     /// callers to surface actionable diagnostics or log messages that mirror
     /// upstream wording.
     ///
@@ -359,7 +359,7 @@ impl DoubleEndedIterator for KnownCompatibilityFlagsIter {
 /// Upstream rsync uses the compatibility flag exchange to signal optional
 /// behaviours that depend on both peers supporting protocol features introduced
 /// after version 30. The flags are transmitted using the variable-length
-/// integer codec implemented in [`crate::varint`], making the bitfield compact
+/// integer codec implemented in the `varint` module, making the bitfield compact
 /// while retaining forward compatibility when new bits are defined.
 #[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Default)]
 pub struct CompatibilityFlags {

--- a/crates/protocol/src/negotiation/detector.rs
+++ b/crates/protocol/src/negotiation/detector.rs
@@ -204,9 +204,8 @@ impl NegotiationPrologueDetector {
     /// the prefix handling as complete once the canonical marker is buffered or
     /// a divergence is detected. This helper mirrors that behavior so higher
     /// layers can determine when it is safe to hand the accumulated bytes to
-    /// [`parse_legacy_daemon_greeting_bytes`]
-    /// (`crate::legacy::parse_legacy_daemon_greeting_bytes`) without peeking at
-    /// the detector's internal fields.
+    /// [`crate::parse_legacy_daemon_greeting_bytes`] without peeking at the
+    /// detector's internal fields.
     #[must_use]
     pub const fn legacy_prefix_complete(&self) -> bool {
         matches!(self.decided, Some(NegotiationPrologue::LegacyAscii)) && self.prefix_complete
@@ -247,7 +246,7 @@ impl NegotiationPrologueDetector {
     /// prefix. Callers of this Rust implementation can mirror that behavior by
     /// reading the buffered prefix through this accessor instead of re-reading
     /// from the underlying transport. The buffer continues to grow across
-    /// subsequent [`observe`] calls until the canonical `@RSYNCD:` prefix has
+    /// subsequent [`Self::observe`] calls until the canonical `@RSYNCD:` prefix has
     /// been captured or a mismatch forces the legacy classification. For binary
     /// negotiations, no bytes are retained and this method returns an empty
     /// slice.
@@ -307,7 +306,7 @@ impl NegotiationPrologueDetector {
     /// been selected the buffer remains empty. Higher layers that want to
     /// mirror upstream rsync's peek logic can query this helper to decide how
     /// many bytes should be replayed into the legacy greeting parser without
-    /// inspecting the raw slice returned by [`buffered_prefix`].
+    /// inspecting the raw slice returned by [`Self::buffered_prefix`].
     #[must_use]
     #[inline]
     pub const fn buffered_len(&self) -> usize {

--- a/crates/protocol/src/negotiation/sniffer.rs
+++ b/crates/protocol/src/negotiation/sniffer.rs
@@ -257,17 +257,16 @@ impl NegotiationPrologueSniffer {
     /// decision recorded during an earlier call to [`read_from`](Self::read_from)
     /// without performing additional I/O. It mirrors the state that would have
     /// been produced by sniffing the same bytes and calling
-    /// [`take_buffered`](Self::take_buffered), making it possible for higher
-    /// layers to store the negotiation replay data separately (for example
-    /// inside [`NegotiatedStreamParts`](crate::negotiation::NegotiatedStreamParts))
+    /// [`Self::take_buffered`], making it possible for higher layers to store
+    /// the negotiation replay data separately (for example inside a
+    /// transport-layer `NegotiatedStreamParts` value)
     /// and later rebuild a sniffer for further parsing.
     ///
     /// `decision` must reflect the negotiated style (`Binary`, `LegacyAscii`, or
     /// `NeedMoreData`). `sniffed_prefix_len` indicates how many of the buffered
     /// bytes were required to classify the negotiation. Any additional payload
     /// in `buffered` is preserved so helpers like
-    /// [`read_legacy_daemon_line`](Self::read_legacy_daemon_line) can replay it
-    /// verbatim.
+    /// [`crate::negotiation::read_legacy_daemon_line`] can replay it verbatim.
     ///
     /// # Errors
     ///
@@ -317,7 +316,7 @@ impl NegotiationPrologueSniffer {
     /// The returned allocation is trimmed to the canonical legacy prefix
     /// length so callers never inherit oversized buffers that may have been
     /// required while parsing malformed greetings. This mirrors the
-    /// shrink-to-fit behavior provided by [`take_buffered`](Self::take_buffered)
+    /// shrink-to-fit behavior provided by [`Self::take_buffered`]
     /// and keeps the helper suitable for long-lived connection pools.
     #[must_use = "the drained negotiation prefix must be replayed"]
     pub fn into_buffered(mut self) -> Vec<u8> {
@@ -546,7 +545,7 @@ impl NegotiationPrologueSniffer {
     /// Drains the buffered bytes (including any remainder beyond the detection prefix) into an
     /// existing vector supplied by the caller.
     ///
-    /// The helper mirrors [`take_buffered`] but avoids allocating a new vector when the
+    /// The helper mirrors [`Self::take_buffered`] but avoids allocating a new vector when the
     /// caller already owns a reusable buffer. When the destination lacks sufficient capacity the
     /// helper transfers ownership of the sniffer's allocation to `target`, avoiding a redundant
     /// copy before the destination inevitably reallocates. Otherwise the buffered bytes (prefix
@@ -595,7 +594,7 @@ impl NegotiationPrologueSniffer {
     /// Drains the buffered bytes (prefix and any captured remainder) into the caller-provided
     /// slice without allocating.
     ///
-    /// The helper mirrors [`take_buffered_into`] but writes the buffered bytes directly into
+    /// The helper mirrors [`Self::take_buffered_into`] but writes the buffered bytes directly into
     /// `target`, allowing callers with stack-allocated storage to replay the negotiation prologue
     /// and forward any remainder captured in the same read without constructing a temporary
     /// [`Vec`]. When `target` is too small to hold the buffered contents a

--- a/crates/transport/src/lib.rs
+++ b/crates/transport/src/lib.rs
@@ -13,16 +13,16 @@
 //!
 //! The public modules mirror upstream rsync's layering:
 //!
-//! - [`negotiation`] implements [`sniff_negotiation_stream`] and
-//!   [`NegotiatedStream`], which classify the prologue without losing buffered
-//!   data.
-//! - [`binary`] and [`daemon`] wrap the protocol helpers to perform client and
-//!   daemon handshakes.
-//! - [`ssh`] spawns a subprocess (typically the system `ssh` binary) and
-//!   exposes its standard I/O handles through a [`Read`]/[`Write`] pair so the
-//!   negotiation layer can treat remote-shell sessions like any other stream.
-//! - [`session`] builds on top of both flows to expose a high-level session
-//!   negotiation entry point.
+//! - [`sniff_negotiation_stream`] and [`NegotiatedStream`] classify the prologue
+//!   without losing buffered data.
+//! - [`negotiate_binary_session`] and [`negotiate_legacy_daemon_session`] wrap
+//!   the protocol helpers to perform client and daemon handshakes.
+//! - [`parse_remote_shell`] spawns a subprocess (typically the system `ssh`
+//!   binary) and exposes its standard I/O handles through a [`std::io::Read`]
+//!   /[`std::io::Write`] pair so the negotiation layer can treat remote-shell
+//!   sessions like any other stream.
+//! - [`SessionHandshake`] builds on top of both flows to expose a high-level
+//!   session negotiation entry point.
 //!
 //! Each module is structured as a facade over the `rsync_protocol` crate, making
 //! it possible to slot different transports (SSH stdio vs TCP daemon) behind the
@@ -62,7 +62,7 @@
 //! # See also
 //!
 //! - [`rsync_protocol`] for the negotiation parsers that back these adapters.
-//! - [`rsync_core`] for the message helpers used when transport-level errors are
+//! - `rsync_core` for the message helpers used when transport-level errors are
 //!   reported to the user.
 
 mod binary;

--- a/crates/transport/src/negotiation.rs
+++ b/crates/transport/src/negotiation.rs
@@ -364,7 +364,7 @@ impl<'a> IntoIterator for NegotiationBufferedSlices<'a> {
     }
 }
 
-/// Error returned when [`NegotiationBufferedSlices::copy_to_slice`] receives an undersized buffer.
+/// Error returned when `NegotiationBufferedSlices::copy_to_slice` receives an undersized buffer.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct CopyToSliceError {
     required: usize,
@@ -394,7 +394,7 @@ impl CopyToSliceError {
     /// method remains robust even if the error is constructed with inconsistent inputs. Callers
     /// that surface diagnostics to users can therefore embed the `missing` count directly in their
     /// messages without worrying about underflow. When produced by
-    /// [`NegotiationBufferedSlices::copy_to_slice`], the return value matches `required - provided`,
+    /// `NegotiationBufferedSlices::copy_to_slice`, the return value matches `required - provided`,
     /// mirroring the conventions used by upstream rsync when reporting undersized scratch buffers.
     #[must_use]
     pub const fn missing(self) -> usize {
@@ -1663,7 +1663,7 @@ pub struct NegotiatedStreamParts<R> {
 /// negotiation bytes are not lost when a transformation cannot be completed. The type implements
 /// [`Clone`] when both captured components support it and provides [`From`] conversions for
 /// `(error, original)` tuples, making it straightforward to shuttle the preserved pieces of state
-/// between APIs without spelling out [`TryMapInnerError::new`].
+/// between APIs without spelling out `TryMapInnerError::new`.
 ///
 /// # Examples
 ///

--- a/crates/transport/src/session/handshake.rs
+++ b/crates/transport/src/session/handshake.rs
@@ -18,7 +18,8 @@ use super::parts::SessionHandshakeParts;
 ///
 /// The enum wraps either the binary remote-shell handshake or the legacy ASCII
 /// daemon negotiation while exposing convenience accessors that mirror the
-/// per-variant helpers. Higher layers can match on the [`decision`] to branch on
+/// per-variant helpers. Higher layers can match on the
+/// [`SessionHandshake::decision`] to branch on
 /// the negotiated style without re-sniffing the transport. Conversions are
 /// provided via [`From`] and [`TryFrom`] so variant-specific wrappers can be
 /// promoted or recovered ergonomically.

--- a/crates/transport/src/ssh/mod.rs
+++ b/crates/transport/src/ssh/mod.rs
@@ -51,7 +51,7 @@
 //!
 //! # See also
 //!
-//! - [`crate::session`] for the negotiation façade that consumes
+//! - [`crate::negotiate_session`] for the negotiation façade that consumes
 //!   [`SshConnection`] streams.
 
 use std::ffi::{OsStr, OsString};


### PR DESCRIPTION
## Summary
- update transport and core module documentation to reference exported symbols instead of private modules
- adjust protocol negotiation docs and README links to avoid unresolved intra-doc references
- clean up supporting crate docs (bandwidth, compress, filters, logging, meta, workspace) to use stable paths and std identifiers

## Testing
- cargo doc --workspace --no-deps

------