### PR TITLE
Fix rustdoc links across workspace

### DIFF
--- a/crates/bandwidth/README.md
+++ b/crates/bandwidth/README.md
@@ -1,63 +1,35 @@
 # rsync-bandwidth
 
-`rsync-bandwidth` centralises the parsing and pacing logic that backs
-[`rsync`'s `--bwlimit` option](https://download.samba.org/pub/rsync/rsync.html).
-Higher level crates reuse the utilities exposed here so both the client and
-daemon share identical validation and throttling behaviour.
+`rsync-bandwidth` centralises the parsing and pacing logic used by the Rust
+`rsync` implementation when honouring `--bwlimit`. Higher level crates reuse
+these helpers so both client and daemon roles share identical validation and
+throttling behaviour.
 
 ## Features
 
 - Textual limit parsing with upstream-compatible syntax including
   binary/decimal suffixes, fractional values, leading signs, and optional
-  `+1` / `-1` adjustments.
-- Token-bucket pacing that mirrors upstream rsync's shape, including
+  `+1`/`-1` adjustments.
+- Token-bucket pacing that mirrors upstream rsync's behaviour, including
   burst-handling and minimum sleep intervals.
-- Deterministic testing support that records requested sleep durations in lieu
+- Deterministic testing support that records requested sleep durations instead
   of touching the system clock, keeping unit tests fast and reproducible.
 
-## Design Overview
+## Design overview
 
-### Parsing helpers
+Parsing helpers accept textual bandwidth specifications and return either an
+optional byte limit or a parse error. Daemon-style `RATE[:BURST]` combinations
+are handled as well, producing structures that can be forwarded to pacing
+components.
 
-[`parse::parse_bandwidth_argument`](crate::parse::parse_bandwidth_argument)
-accepts textual bandwidth specifications and returns either an optional byte
-limit or a [`BandwidthParseError`](crate::parse::BandwidthParseError). The
-helper trims ASCII whitespace, validates suffixes, applies the `+1` / `-1`
-adjustments accepted by upstream rsync, and rounds to the nearest 1024 bytes per
-second as the C implementation does.
+The pacing helpers implement the token-bucket scheduler used by the transfer
+engine. They track accumulated debt, cap burst sizes, and sleep long enough to
+honour the configured rate. Optional burst parameters clamp the debt just like
+upstream rsync.
 
-[`parse::parse_bandwidth_limit`](crate::parse::parse_bandwidth_limit) extends the
-behaviour to parse daemon-style `RATE[:BURST]` combinations. The returned
-[`BandwidthLimitComponents`](crate::parse::BandwidthLimitComponents) struct can
-be converted into a [`BandwidthLimiter`](crate::BandwidthLimiter) or stored for
-later negotiation.
-
-### Pacing helpers
-
-[`BandwidthLimiter`](crate::BandwidthLimiter) implements the token-bucket
-scheduler used by the transfer engine and daemon. It tracks accumulated debt,
-limits write sizes, and sleeps long enough to honour the configured rate. When
-the optional burst parameter is supplied the limiter caps the debt to the burst
-size, mirroring upstream behaviour.
-
-`apply_effective_limit` merges daemon-imposed caps with pre-existing limiter
-configuration. The helper ensures precedence rules match upstream rsync by
-keeping the strictest rate while allowing burst overrides when explicitly
-requested, and returns a [`LimiterChange`](crate::LimiterChange) describing
-whether throttling was enabled, updated, disabled, or left untouched.
-
-### Test support
-
-Enabling the `test-support` feature exposes helpers that record sleep requests
-instead of calling [`std::thread::sleep`]. Tests obtain a
-[`recorded_sleep_session`](crate::recorded_sleep_session) guard to serialise
-access to the captured durations, ensuring race-free assertions when scenarios
-run in parallel. The guard also implements [`Default`], making it easy to embed
-inside helper structs without additional boilerplate. Convenience accessors such as
-[`snapshot`](crate::RecordedSleepSession::snapshot),
-[`last_duration`](crate::RecordedSleepSession::last_duration), and
-[`total_duration`](crate::RecordedSleepSession::total_duration) let tests
-inspect the pacing history without draining it.
+With the `test-support` feature enabled, helper functions record sleep requests
+rather than calling `std::thread::sleep`. Tests can snapshot, inspect, and reset
+captured durations while running in parallel without races.
 
 ## Example
 
@@ -79,8 +51,6 @@ chunks to reduce context switches.
 
 ## See also
 
-- [`rsync-core`](https://docs.rs/rsync-core/) and
-  [`rsync-daemon`](https://docs.rs/rsync-daemon/) for integration points that
-  orchestrate parsing, transport, and pacing.
-- [`rsync-protocol`](https://docs.rs/rsync-protocol/) for message framing and
-  version negotiation.
+- `rsync-core` and `rsync-daemon` for integration points that orchestrate
+  parsing, transport, and pacing.
+- `rsync-protocol` for message framing and version negotiation.

--- a/crates/compress/src/lib.rs
+++ b/crates/compress/src/lib.rs
@@ -32,8 +32,9 @@
 //! # Errors
 //!
 //! The encoder and decoder functions return [`std::io::Result`]. When zlib
-//! reports an error the helper wraps it in [`io::ErrorKind::Other`]. Callers can
-//! surface these diagnostics via the central message facade in `rsync-core`.
+//! reports an error the helper wraps it in [`std::io::ErrorKind::Other`].
+//! Callers can surface these diagnostics via the central message facade in the
+//! `rsync-core` crate.
 //!
 //! # Examples
 //!
@@ -60,6 +61,7 @@
 //! # See also
 //!
 //! - [`zlib`] for the encoder/decoder implementation and API surface.
-//! - [`rsync_engine`] for the transfer pipeline that integrates these helpers.
+//! - The `rsync-engine` crate for the transfer pipeline that integrates these
+//!   helpers.
 
 pub mod zlib;

--- a/crates/core/README.md
+++ b/crates/core/README.md
@@ -1,49 +1,47 @@
 # rsync-core
 
-`rsync-core` centralises workspace-wide facilities that are reused by the
-`rsync` and `rsyncd` binaries together with supporting transport crates. The
-crate focuses on user-visible message formatting, source-location remapping, and
-shared configuration types so diagnostics mirror upstream rsync while pointing
-at the Rust implementation.
+`rsync-core` centralises workspace-wide facilities reused by the `rsync` and
+`rsyncd` binaries together with supporting transport crates. The crate focuses on
+user-visible message formatting, source-location remapping, and shared
+configuration types so diagnostics mirror upstream rsync while pointing at the
+Rust implementation.
 
 ## Design
 
-- [`message`](src/message.rs) exposes [`Message`](src/message/struct.Message.html)
-  alongside helpers such as [`message_source!`](src/message/macro.message_source.html)
-  for capturing repo-relative source locations. Higher layers construct
-  diagnostics through this API so trailer roles and version suffixes remain
-  consistent.
-- [`branding`](src/branding.rs) centralises branded program names alongside the
-  default configuration and secrets paths installed by the packaging tooling.
-- [`version`](src/version.rs) holds the canonical `3.4.1-rust` identifier and the
+- The `message` module exposes the `Message` type alongside helpers such as the
+  `message_source!` macro for capturing repo-relative source locations. Higher
+  layers construct diagnostics through this API so trailer roles and version
+  suffixes remain consistent.
+- The `branding` module centralises branded program names alongside the default
+  configuration and secrets paths installed by the packaging tooling.
+- The `version` module holds the canonical `3.4.1-rust` identifier and the
   compiled feature set consumed by the CLI when rendering `--version` output.
-- [`client`](src/client.rs) defines configuration builders and entry points used
-  by the CLI wrapper. Today the facade orchestrates the local copy pipeline and
+- The `client` module defines configuration builders and entry points used by
+  the CLI wrapper. Today the facade orchestrates the local copy pipeline and
   falls back to the system `rsync` binary for remote transfers while the native
   delta engine is completed.
-- [`fallback`](src/fallback.rs) interprets delegation overrides shared by the
-  CLI and daemon binaries.
-- [`bandwidth`](src/bandwidth.rs) re-exports the [`rsync-bandwidth`](../bandwidth/README.md)
-  crate so callers share the same parsing and pacing primitives.
+- The `fallback` module interprets delegation overrides shared by the CLI and
+  daemon binaries.
+- The `bandwidth` module re-exports the `rsync-bandwidth` crate so callers share
+  the same parsing and pacing primitives.
 
 ## Invariants
 
-- [`client::run_client`](src/client.rs) reports the delta-transfer engine gap
-  using the same wording that the CLI emits when delegation occurs.
+- The `client::run_client` helper reports the delta-transfer engine gap using
+  the same wording that the CLI emits when delegation occurs.
 - Message trailers always include the `3.4.1-rust` version string and reference
   the caller's role (sender, receiver, generator, server, or daemon).
 - Source locations are normalised to repo-relative POSIX-style paths, keeping
   diagnostics stable across platforms.
-- Formatting a [`Message`](src/message/struct.Message.html) touches only the
-  stored payload and metadata so diagnostics avoid unnecessary allocations.
+- Formatting a `Message` touches only the stored payload and metadata so
+  diagnostics avoid unnecessary allocations.
 
 ## Error Handling
 
 The crate does not define new error types. Instead, it supplies builders that
-attach upstream error codes to [`Message`](src/message/struct.Message.html)
-values via [`Message::error`](src/message/struct.Message.html#method.error). The
+attach upstream error codes to `Message` values via `Message::error`. The
 resulting diagnostics can be rendered directly or wrapped in higher level error
-structures such as [`client::ClientError`](src/client/struct.ClientError.html).
+structures such as `client::ClientError`.
 
 ## Example
 
@@ -64,14 +62,13 @@ assert!(rendered.contains("[sender=3.4.1-rust]"));
 
 ## See also
 
-- [`rsync_core::message::strings`](src/message/strings.rs) exposes upstream-aligned
-  exit-code wording so higher layers render identical diagnostics.
-- [`client::ClientConfig`](src/client/struct.ClientConfig.html) mirrors the
-  structure populated by the CLI before invoking the transfer engine.
-- [`client::ModuleListRequest`](src/client/struct.ModuleListRequest.html) parses
-  daemon operands and retrieves module listings via the legacy `@RSYNCD:`
-  handshake.
-- [`fallback::fallback_override`](src/fallback/fn.fallback_override.html)
-  interprets shared delegation overrides for CLI and daemon wrappers.
-- [`rsync_exit_code!`](src/message/macro.rsync_exit_code.html) constructs
-  canonical exit-code diagnostics while capturing the caller's source location.
+- The `rsync_core::message::strings` module exposes upstream-aligned exit-code
+  wording so higher layers render identical diagnostics.
+- `client::ClientConfig` mirrors the structure populated by the CLI before
+  invoking the transfer engine.
+- `client::ModuleListRequest` parses daemon operands and retrieves module
+  listings via the legacy `@RSYNCD:` handshake.
+- `fallback::fallback_override` interprets shared delegation overrides for CLI
+  and daemon wrappers.
+- The `rsync_exit_code!` macro constructs canonical exit-code diagnostics while
+  capturing the caller's source location.

--- a/crates/core/src/fallback.rs
+++ b/crates/core/src/fallback.rs
@@ -13,11 +13,11 @@
 //!
 //! # Design
 //!
-//! The module exposes [`fallback_override`] to decode a single environment
-//! variable into a [`FallbackOverride`]. Callers can chain multiple invocations
+//! The module exposes [`crate::fallback::fallback_override`] to decode a single environment
+//! variable into a [`crate::fallback::FallbackOverride`]. Callers can chain multiple invocations
 //! to honour primary and secondary environment names before deciding whether a
-//! delegation binary is available. The [`FallbackOverride::resolve_or_default`]
-//! helper converts the parsed override into an [`OsString`] when delegation is
+//! delegation binary is available. The [`crate::fallback::FallbackOverride::resolve_or_default`]
+//! helper converts the parsed override into an [`std::ffi::OsString`] when delegation is
 //! enabled, falling back to the supplied default executable (`rsync`) when the
 //! override is `auto` or unspecified.
 //!
@@ -35,13 +35,14 @@
 //! The helpers do not construct [`Message`](crate::message::Message) instances
 //! because callers must decide how to report disabled delegation. Instead, the
 //! parsing functions return [`None`] when an override is not present or
-//! [`FallbackOverride::Disabled`] when delegation is explicitly turned off.
+//! [`crate::fallback::FallbackOverride::Disabled`] when delegation is explicitly turned off.
 //!
 //! # Examples
 //!
 //! Construct overrides directly and resolve them to executable paths. In real
-//! usage call [`fallback_override`] to parse environment variables into the
-//! [`FallbackOverride`] enum before invoking [`FallbackOverride::resolve_or_default`].
+//! usage call [`crate::fallback::fallback_override`] to parse environment variables into the
+//! [`crate::fallback::FallbackOverride`] enum before invoking
+//! [`crate::fallback::FallbackOverride::resolve_or_default`].
 //!
 //! ```
 //! use rsync_core::fallback::FallbackOverride;
@@ -62,9 +63,9 @@
 //!
 //! # See also
 //!
-//! - [`rsync_core::client::run_remote_transfer_fallback`] for the primary
+//! - The `rsync_core::client::run_remote_transfer_fallback` helper is the primary
 //!   consumer of these helpers on the client side.
-//! - [`rsync_daemon::run`] for daemon-side delegation.
+//! - The `rsync_daemon::run` entry point handles daemon-side delegation.
 
 use std::env;
 use std::ffi::{OsStr, OsString};

--- a/crates/core/src/message.rs
+++ b/crates/core/src/message.rs
@@ -1176,7 +1176,7 @@ impl fmt::Display for SourceLocation {
 ///
 /// This macro expands at the call-site and therefore records the location of the
 /// expansion. When the caller is a helper annotated with `#[track_caller]`,
-/// consider using [`tracked_message_source!`] to surface the original
+/// consider using [`macro@crate::tracked_message_source`] to surface the original
 /// invocation location instead.
 ///
 /// # Examples
@@ -1249,7 +1249,7 @@ macro_rules! tracked_message_source {
 /// Constructs an error [`Message`] with the provided exit code and payload.
 ///
 /// The macro mirrors upstream diagnostics by automatically attaching the
-/// call-site [`SourceLocation`] using [`macro@tracked_message_source`]. It accepts either a
+/// call-site [`SourceLocation`] using [`macro@crate::tracked_message_source`]. It accepts either a
 /// string literal/`Cow<'static, str>` payload or a [`format!`] style template.
 /// Callers can further customise the returned [`Message`] by chaining helpers
 /// such as [`Message::with_role`].
@@ -1296,7 +1296,7 @@ macro_rules! rsync_error {
 ///
 /// Like [`macro@rsync_error`], the macro records the call-site source location so
 /// diagnostics include repo-relative paths. The macro relies on
-/// [`macro@tracked_message_source`], meaning callers annotated with
+/// [`macro@crate::tracked_message_source`], meaning callers annotated with
 /// `#[track_caller]` automatically propagate their invocation site. Additional
 /// context, such as exit codes, can be attached using [`Message::with_code`].
 ///
@@ -1330,7 +1330,7 @@ macro_rules! rsync_warning {
 /// attaches the call-site source location. Upstream rsync typically omits source
 /// locations for informational output, but retaining the metadata simplifies
 /// debugging and keeps the API consistent across severities. As with the other
-/// message macros, [`macro@tracked_message_source`] ensures `#[track_caller]`
+/// message macros, [`macro@crate::tracked_message_source`] ensures `#[track_caller]`
 /// annotations propagate the original invocation site into diagnostics.
 ///
 /// # Examples
@@ -1357,11 +1357,11 @@ macro_rules! rsync_info {
 /// Constructs a [`Message`] using the canonical wording for a known exit code.
 ///
 /// The macro delegates to [`Message::from_exit_code`] and attaches the caller's source location
-/// via [`macro@tracked_message_source`]. Returning an [`Option`] mirrors the underlying helper:
+/// via [`macro@crate::tracked_message_source`]. Returning an [`Option`] mirrors the underlying helper:
 /// upstream rsync only assigns stock diagnostics to a fixed set of exit codes. Callers can use
 /// [`Option::unwrap_or_else`] to supply bespoke text when the exit code is not recognised.
 ///
-/// Because the macro relies on [`macro@tracked_message_source`], functions annotated with
+/// Because the macro relies on [`macro@crate::tracked_message_source`], functions annotated with
 /// `#[track_caller]` propagate their call-site into the rendered diagnostic just like the other
 /// `rsync_*` macros.
 ///
@@ -1426,8 +1426,8 @@ impl Message {
     /// Returns the vectored representation of the rendered message.
     ///
     /// The helper exposes the same slices used internally when emitting the message into an
-    /// [`io::Write`] implementor. Callers that need to integrate with custom buffered pipelines can
-    /// reuse the returned segments with [`Write::write_vectored`], avoiding redundant allocations or
+    /// [`std::io::Write`] implementor. Callers that need to integrate with custom buffered pipelines can
+    /// reuse the returned segments with [`std::io::Write::write_vectored`], avoiding redundant allocations or
     /// per-segment formatting logic.
     ///
     /// # Examples
@@ -2294,7 +2294,7 @@ impl Message {
     /// Appends the rendered message into the provided byte buffer.
     ///
     /// The helper mirrors [`Self::render_to_writer`] but avoids the overhead of
-    /// constructing a temporary [`Vec`] or going through the [`Write`] trait for
+    /// constructing a temporary [`Vec`] or going through the [`std::io::Write`] trait for
     /// `Vec<u8>`. Callers that batch multiple diagnostics can therefore reuse
     /// an output buffer across invocations without repeated allocations or
     /// trait-object dispatch. The buffer is grown exactly enough to hold the

--- a/crates/core/src/version.rs
+++ b/crates/core/src/version.rs
@@ -12,34 +12,34 @@
 //!
 //! The module publishes lightweight enums and helper functions:
 //!
-//! - [`RUST_VERSION`] holds the `3.4.1-rust` identifier rendered by
+//! - The `RUST_VERSION` constant holds the `3.4.1-rust` identifier rendered by
 //!   user-visible banners.
-//! - [`compiled_features`] inspects Cargo feature flags and returns the set of
+//! - The `compiled_features` helper inspects Cargo feature flags and returns the set of
 //!   optional capabilities enabled at build time.
-//! - [`compiled_features_static`] exposes a zero-allocation view for repeated
+//! - The `compiled_features_static` helper exposes a zero-allocation view for repeated
 //!   inspections of the compiled feature set.
-//! - [`CompiledFeature`] enumerates optional capabilities and provides label
-//!   helpers such as [`CompiledFeature::label`] and
-//!   [`CompiledFeature::from_label`] for parsing user-provided strings.
-//! - [`VersionInfoReport`] renders the full `--version` text, including
-//!   capability sections and checksum/compressor listings, so the CLI can
-//!   display upstream-identical banners branded for `rsync`.
+//! - The `CompiledFeature` enum enumerates optional capabilities and provides label
+//!   helpers such as `CompiledFeature::label` and `CompiledFeature::from_label`
+//!   for parsing user-provided strings.
+//! - The `VersionInfoReport` structure renders the full `--version` text,
+//!   including capability sections and checksum/compressor listings, so the CLI
+//!   can display upstream-identical banners branded for `rsync`.
 //!
 //! This structure keeps other crates free of conditional compilation logic
 //! while avoiding string duplication across the workspace.
 //!
 //! # Invariants
 //!
-//! - [`RUST_VERSION`] always embeds the upstream base release so diagnostics and
+//! - `RUST_VERSION` always embeds the upstream base release so diagnostics and
 //!   CLI output remain aligned with rsync 3.4.1.
-//! - [`compiled_features`] never invents capabilities: it only reports flags
-//!   that were explicitly enabled when compiling `rsync-core`.
+//! - `compiled_features` never invents capabilities: it only reports flags that
+//!   were explicitly enabled when compiling `rsync-core`.
 //!
 //! # Errors
 //!
-//! The module exposes [`ParseCompiledFeatureError`] when parsing a
-//! [`CompiledFeature`] from a string fails. All other helpers return constants
-//! or eagerly evaluate into owned collections.
+//! The module exposes the `ParseCompiledFeatureError` type when parsing a
+//! `CompiledFeature` from a string fails. All other helpers return constants or
+//! eagerly evaluate into owned collections.
 //!
 //! # Examples
 //!
@@ -60,11 +60,11 @@
 //!
 //! # See also
 //!
-//! - [`rsync_core::message`] uses [`RUST_VERSION`] when rendering error
+//! - The `rsync_core::message` module uses `RUST_VERSION` when rendering error
 //!   trailers.
-//! - Future CLI modules rely on [`compiled_features`] and
-//!   [`VersionInfoReport`] to mirror upstream `--version` capability listings
-//!   while advertising the Rust-branded binary name.
+//! - Future CLI modules rely on `compiled_features` and `VersionInfoReport` to
+//!   mirror upstream `--version` capability listings while advertising the
+//!   Rust-branded binary name.
 
 use crate::{
     branding::{self, Brand},

--- a/crates/core/src/workspace.rs
+++ b/crates/core/src/workspace.rs
@@ -8,7 +8,7 @@
 //! keeps the binary front-ends and supporting crates free from duplicated string
 //! literals. Callers should prefer these helpers instead of hard-coding program
 //! names or configuration paths. Consumers that need the entire metadata set can
-//! use [`metadata`] to obtain a snapshot that mirrors the manifest entries.
+//! use the [`metadata()`](crate::workspace::metadata) helper to obtain a snapshot that mirrors the manifest entries.
 
 use std::path::Path;
 

--- a/crates/engine/src/delta/mod.rs
+++ b/crates/engine/src/delta/mod.rs
@@ -18,7 +18,7 @@
 //! Rust's type system to surface invalid inputs as structured errors. The helper
 //! takes a [`ProtocolVersion`] so call-sites do not need to translate negotiated
 //! versions into ad-hoc integers, and the checksum length uses
-//! [`NonZeroU8`](core::num::NonZeroU8) to reflect upstream's guarantee that the
+//! [`core::num::NonZeroU8`] to reflect upstream's guarantee that the
 //! value never reaches zero. Intermediate calculations use [`u128`] to avoid
 //! overflow when comparing `block_length^2` against large file sizes. Overflow
 //! scenarios—such as a block count that exceeds [`i32::MAX`]—are reported via

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -12,7 +12,7 @@
 //! # Design
 //!
 //! Functionality is decomposed into focused modules. The [`local_copy`] module
-//! exposes [`LocalCopyPlan`](local_copy::LocalCopyPlan) which performs
+//! exposes [`LocalCopyPlan`] which performs
 //! recursive copies of regular files, directories, symbolic links, and FIFOs
 //! while preserving permissions and timestamps through the [`rsync_meta`]
 //! helpers. The [`delta`] module mirrors upstream rsync's signature layout
@@ -64,8 +64,8 @@
 //!
 //! # See also
 //!
-//! - [`rsync_core::client`] integrates the plan builder to power the `rsync`
-//!   binary's local copy mode.
+//! - The `rsync_core::client` module integrates the plan builder to power the
+//!   `rsync` binary's local copy mode.
 //! - [`delta`] exposes block-size and checksum heuristics that will be wired into
 //!   the delta-transfer engine.
 //! - [`signature`] generates rolling and strong checksum pairs from those

--- a/crates/engine/src/signature.rs
+++ b/crates/engine/src/signature.rs
@@ -12,7 +12,7 @@
 //! # Design
 //!
 //! - [`generate_file_signature`] accepts an input reader, the
-//!   [`SignatureLayout`](crate::delta::SignatureLayout) obtained from
+//!   [`SignatureLayout`] obtained from
 //!   [`crate::delta::calculate_signature_layout`], and a [`SignatureAlgorithm`]
 //!   describing the strong checksum strategy. The helper reads each block in
 //!   sequence, computes the weak and strong digests, and returns a

--- a/crates/filters/src/lib.rs
+++ b/crates/filters/src/lib.rs
@@ -71,8 +71,8 @@
 //!
 //! # See also
 //!
-//! - [`rsync_engine::local_copy`] integrates [`FilterSet`] to prune directory
-//!   traversals during deterministic local copies.
+//! - The `rsync_engine::local_copy` module integrates [`FilterSet`] to prune
+//!   directory traversals during deterministic local copies.
 //! - [`globset`] for the glob matching primitives used internally.
 
 use std::collections::HashSet;

--- a/crates/logging/src/lib.rs
+++ b/crates/logging/src/lib.rs
@@ -5,16 +5,16 @@
 //! # Overview
 //!
 //! `rsync_logging` provides reusable logging primitives that operate on the
-//! [`Message`](rsync_core::message::Message) type shared across the Rust rsync
+//! [`rsync_core::message::Message`] type shared across the Rust rsync
 //! workspace. The initial focus is on streaming diagnostics to arbitrary writers
-//! while reusing [`MessageScratch`](rsync_core::message::MessageScratch)
+//! while reusing [`rsync_core::message::MessageScratch`]
 //! instances so higher layers avoid repeated buffer initialisation when printing
 //! large batches of messages.
 //!
 //! # Design
 //!
 //! The crate exposes [`MessageSink`], a lightweight wrapper around an
-//! [`io::Write`](std::io::Write) implementor. Each sink stores a
+//! [`std::io::Write`] implementor. Each sink stores a
 //! [`MessageScratch`] scratch buffer that is reused whenever a message is
 //! rendered, matching upstream rsync's approach of keeping stack-allocated
 //! buffers alive for the duration of a logging session. Callers can control
@@ -827,7 +827,7 @@ where
     ///
     /// The method accepts borrowed or owned [`Message`] values via
     /// [`Borrow<Message>`], allowing call sites to forward diagnostics without
-    /// cloning. This matches the flexibility offered by [`write_all`], making it
+    /// cloning. This matches the flexibility offered by [`std::io::Write::write_all`], making it
     /// inexpensive to reuse the same sink for ad-hoc or batched message
     /// emission.
     ///

--- a/crates/meta/src/lib.rs
+++ b/crates/meta/src/lib.rs
@@ -65,7 +65,7 @@
 //!
 //! # See also
 //!
-//! - [`rsync_core::client`] integrates these helpers for local filesystem
+//! - The `rsync-core` client integrates these helpers for local filesystem
 //!   copies.
 //! - [`filetime`] for lower-level timestamp manipulation utilities.
 

--- a/crates/protocol/README.md
+++ b/crates/protocol/README.md
@@ -1,54 +1,50 @@
-# `rsync_protocol`
+# rsync-protocol
 
-`rsync_protocol` implements the negotiation and multiplexing primitives required by the
-Rust `rsync` implementation. The crate mirrors upstream rsync 3.4.1 behaviour so higher
-layers can negotiate protocol versions, interpret legacy daemon banners, and exchange
-multiplexed frames without depending on the original C sources.
+`rsync-protocol` implements the negotiation and multiplexing primitives required
+by the Rust `rsync` implementation. The crate mirrors upstream rsync 3.4.1
+behaviour so higher layers can negotiate protocol versions, interpret legacy
+daemon banners, and exchange multiplexed frames without depending on the
+original C sources.
 
 ## Design
 
-The crate is decomposed into small modules that map onto the upstream architecture:
+The crate is decomposed into small modules that track the upstream layout:
 
-- [`version`](crate::version) exposes [`ProtocolVersion`](crate::ProtocolVersion) and
-  helpers for selecting the highest mutually supported protocol between peers.
-- [`legacy`](crate::legacy) provides parsers for ASCII daemon handshakes such as
-  `@RSYNCD: 31.0` and the follow-up control messages emitted by rsync daemons prior to
-  protocol 30.
-- [`negotiation`](crate::negotiation) contains incremental sniffers that classify the
-  handshake style (binary vs. legacy ASCII) without losing buffered bytes.
-- [`multiplex`](crate::multiplex) and [`envelope`](crate::envelope) re-create the
-  control/data framing used once a session has been negotiated.
-- [`compatibility`](crate::compatibility) models the post-negotiation compatibility flags
-  shared by peers and exposes typed helpers for working with individual bits.
-- [`varint`](crate::varint) reproduces rsync's variable-length integer codec so other
-  modules can serialise the compatibility flags and future protocol values.
+- The `version` module exposes the protocol enumeration and helpers for
+  selecting the highest mutually supported protocol between peers.
+- The `legacy` module provides parsers for ASCII daemon handshakes and the
+  follow-up control messages emitted by classic rsync daemons.
+- The `negotiation` module contains incremental sniffers that classify the
+  handshake style without losing buffered bytes.
+- The `multiplex` and `envelope` modules recreate the control/data framing used
+  once a session has been negotiated.
+- The `compatibility` module models post-negotiation compatibility flags and
+  exposes typed helpers for working with individual bits.
+- The `varint` module reproduces rsync's variable-length integer codec so other
+  modules can serialise compatibility flags and protocol values.
 
-Each module satisfies the workspace style guide, while the crate root re-exports the
-stable APIs consumed by the higher-level transport, core, and daemon layers.
+The crate root re-exports the stable APIs consumed by the higher-level
+transport, core, and daemon layers.
 
 ## Invariants
 
-- [`SUPPORTED_PROTOCOLS`](crate::SUPPORTED_PROTOCOLS) always lists protocol numbers in
-  descending order (`32` through `28`).
-- Legacy negotiation helpers never drop or duplicate bytes: sniffed prefixes can be
-  replayed verbatim into the parsing routines.
-- Multiplexed message headers clamp payload lengths to the 24-bit limit used by upstream
-  rsync.
+- Supported protocol numbers are listed in descending order (`32` through `28`).
+- Legacy negotiation helpers never drop or duplicate bytes, allowing sniffed
+  prefixes to be replayed verbatim into the parsing routines.
+- Multiplexed message headers clamp payload lengths to the 24-bit limit used by
+  upstream rsync.
 
 ## Errors
 
-Parsing helpers surface rich error types that carry enough context to reproduce upstream
-diagnostics. For example,
-[`NegotiationError`](crate::NegotiationError) distinguishes between malformed greetings,
-unsupported protocol ranges, and truncated payloads. All error types implement
-[`std::error::Error`] and convert into [`std::io::Error`] where appropriate so they
-integrate naturally with transport code.
+Parsing helpers surface error types that carry enough context to reproduce
+upstream diagnostics. Errors implement `std::error::Error` and convert into
+`std::io::Error` where appropriate so they integrate naturally with transport
+code.
 
 ## Examples
 
-Determine whether a buffered prologue belongs to the legacy ASCII greeting or the binary
-negotiation. The helper behaves exactly like upstream rsync's `io.c:check_protok` logic by
-classifying the session based on the first byte.
+Determine whether a buffered prologue belongs to the legacy ASCII greeting or
+binary negotiation:
 
 ```rust
 use rsync_protocol::{detect_negotiation_prologue, NegotiationPrologue};
@@ -63,55 +59,9 @@ assert_eq!(
 );
 ```
 
-Once the negotiation style is known, the highest mutually supported protocol can be
-derived from the peer advertisement.
-
-```rust
-use rsync_protocol::{select_highest_mutual, ProtocolVersion};
-
-let negotiated = select_highest_mutual([32, 31]).expect("mutual version exists");
-assert_eq!(negotiated, ProtocolVersion::NEWEST);
-```
-
-When a peer selects the legacy ASCII negotiation, the bytes that triggered the decision
-must be replayed into the greeting parser so the full `@RSYNCD:` line can be
-reconstructed. [`NegotiationPrologueSniffer`](crate::NegotiationPrologueSniffer) owns the
-buffered prefix, allowing callers to reuse it without copying more data than upstream
-rsync would have consumed.
-
-```rust
-use rsync_protocol::{
-    NegotiationPrologue, NegotiationPrologueSniffer, parse_legacy_daemon_greeting,
-};
-use std::io::{Cursor, Read};
-
-let mut reader = Cursor::new(&b"@RSYNCD: 31.0\n"[..]);
-let mut sniffer = NegotiationPrologueSniffer::new();
-
-let decision = sniffer
-    .read_from(&mut reader)
-    .expect("sniffing never fails for in-memory data");
-assert_eq!(decision, NegotiationPrologue::LegacyAscii);
-
-let mut prefix = Vec::new();
-sniffer
-    .take_buffered_into(&mut prefix)
-    .expect("the vector has enough capacity for @RSYNCD:");
-assert_eq!(prefix, b"@RSYNCD:");
-
-let mut full_line = prefix;
-reader.read_to_end(&mut full_line).expect("cursor read cannot fail");
-assert_eq!(full_line, b"@RSYNCD: 31.0\n");
-assert_eq!(
-    parse_legacy_daemon_greeting(std::str::from_utf8(&full_line).unwrap())
-        .expect("banner is well-formed"),
-    rsync_protocol::ProtocolVersion::from_supported(31).unwrap()
-);
-```
-
 ## See also
 
-- [`rsync_transport`](https://docs.rs/rsync-transport) for transport wrappers that reuse
-  the sniffers and parsers exposed here.
-- [`rsync_core`](https://docs.rs/rsync-core) for message formatting utilities that rely on
-  negotiated protocol numbers.
+- `rsync-transport` for wrappers that reuse the sniffers and parsers exposed
+  here.
+- `rsync-core` for message formatting utilities that rely on negotiated
+  protocol numbers.

--- a/crates/protocol/src/negotiation/detector.rs
+++ b/crates/protocol/src/negotiation/detector.rs
@@ -204,8 +204,7 @@ impl NegotiationPrologueDetector {
     /// the prefix handling as complete once the canonical marker is buffered or
     /// a divergence is detected. This helper mirrors that behavior so higher
     /// layers can determine when it is safe to hand the accumulated bytes to
-    /// [`parse_legacy_daemon_greeting_bytes`]
-    /// (`crate::legacy::parse_legacy_daemon_greeting_bytes`) without peeking at
+    /// [`crate::legacy::parse_legacy_daemon_greeting_bytes`] without peeking at
     /// the detector's internal fields.
     #[must_use]
     pub const fn legacy_prefix_complete(&self) -> bool {
@@ -247,7 +246,7 @@ impl NegotiationPrologueDetector {
     /// prefix. Callers of this Rust implementation can mirror that behavior by
     /// reading the buffered prefix through this accessor instead of re-reading
     /// from the underlying transport. The buffer continues to grow across
-    /// subsequent [`observe`] calls until the canonical `@RSYNCD:` prefix has
+    /// subsequent [`Self::observe`] calls until the canonical `@RSYNCD:` prefix has
     /// been captured or a mismatch forces the legacy classification. For binary
     /// negotiations, no bytes are retained and this method returns an empty
     /// slice.
@@ -307,7 +306,7 @@ impl NegotiationPrologueDetector {
     /// been selected the buffer remains empty. Higher layers that want to
     /// mirror upstream rsync's peek logic can query this helper to decide how
     /// many bytes should be replayed into the legacy greeting parser without
-    /// inspecting the raw slice returned by [`buffered_prefix`].
+    /// inspecting the raw slice returned by [`Self::buffered_prefix`].
     #[must_use]
     #[inline]
     pub const fn buffered_len(&self) -> usize {

--- a/crates/protocol/src/negotiation/sniffer.rs
+++ b/crates/protocol/src/negotiation/sniffer.rs
@@ -259,14 +259,14 @@ impl NegotiationPrologueSniffer {
     /// been produced by sniffing the same bytes and calling
     /// [`take_buffered`](Self::take_buffered), making it possible for higher
     /// layers to store the negotiation replay data separately (for example
-    /// inside [`NegotiatedStreamParts`](crate::negotiation::NegotiatedStreamParts))
-    /// and later rebuild a sniffer for further parsing.
+    /// inside transport-layer `NegotiatedStreamParts` structures) and later
+    /// rebuild a sniffer for further parsing.
     ///
     /// `decision` must reflect the negotiated style (`Binary`, `LegacyAscii`, or
     /// `NeedMoreData`). `sniffed_prefix_len` indicates how many of the buffered
     /// bytes were required to classify the negotiation. Any additional payload
     /// in `buffered` is preserved so helpers like
-    /// [`read_legacy_daemon_line`](Self::read_legacy_daemon_line) can replay it
+    /// [`read_legacy_daemon_line`](super::read_legacy_daemon_line) can replay it
     /// verbatim.
     ///
     /// # Errors
@@ -546,7 +546,7 @@ impl NegotiationPrologueSniffer {
     /// Drains the buffered bytes (including any remainder beyond the detection prefix) into an
     /// existing vector supplied by the caller.
     ///
-    /// The helper mirrors [`take_buffered`] but avoids allocating a new vector when the
+    /// The helper mirrors [`Self::take_buffered`] but avoids allocating a new vector when the
     /// caller already owns a reusable buffer. When the destination lacks sufficient capacity the
     /// helper transfers ownership of the sniffer's allocation to `target`, avoiding a redundant
     /// copy before the destination inevitably reallocates. Otherwise the buffered bytes (prefix
@@ -595,7 +595,7 @@ impl NegotiationPrologueSniffer {
     /// Drains the buffered bytes (prefix and any captured remainder) into the caller-provided
     /// slice without allocating.
     ///
-    /// The helper mirrors [`take_buffered_into`] but writes the buffered bytes directly into
+    /// The helper mirrors [`Self::take_buffered_into`] but writes the buffered bytes directly into
     /// `target`, allowing callers with stack-allocated storage to replay the negotiation prologue
     /// and forward any remainder captured in the same read without constructing a temporary
     /// [`Vec`]. When `target` is too small to hold the buffered contents a

--- a/crates/transport/src/lib.rs
+++ b/crates/transport/src/lib.rs
@@ -13,16 +13,17 @@
 //!
 //! The public modules mirror upstream rsync's layering:
 //!
-//! - [`negotiation`] implements [`sniff_negotiation_stream`] and
+//! - The `negotiation` module implements [`sniff_negotiation_stream`] and
 //!   [`NegotiatedStream`], which classify the prologue without losing buffered
 //!   data.
-//! - [`binary`] and [`daemon`] wrap the protocol helpers to perform client and
-//!   daemon handshakes.
+//! - The `binary` and `daemon` modules wrap the protocol helpers to perform
+//!   client and daemon handshakes.
 //! - [`ssh`] spawns a subprocess (typically the system `ssh` binary) and
-//!   exposes its standard I/O handles through a [`Read`]/[`Write`] pair so the
+//!   exposes its standard I/O handles through a [`std::io::Read`]/[`std::io::Write`]
+//!   pair so the
 //!   negotiation layer can treat remote-shell sessions like any other stream.
-//! - [`session`] builds on top of both flows to expose a high-level session
-//!   negotiation entry point.
+//! - The `session` module builds on top of both flows to expose a high-level
+//!   session negotiation entry point.
 //!
 //! Each module is structured as a facade over the `rsync_protocol` crate, making
 //! it possible to slot different transports (SSH stdio vs TCP daemon) behind the
@@ -62,8 +63,8 @@
 //! # See also
 //!
 //! - [`rsync_protocol`] for the negotiation parsers that back these adapters.
-//! - [`rsync_core`] for the message helpers used when transport-level errors are
-//!   reported to the user.
+//! - The `rsync-core` crate for the message helpers used when transport-level
+//!   errors are reported to the user.
 
 mod binary;
 mod daemon;

--- a/crates/transport/src/session/handshake.rs
+++ b/crates/transport/src/session/handshake.rs
@@ -18,7 +18,7 @@ use super::parts::SessionHandshakeParts;
 ///
 /// The enum wraps either the binary remote-shell handshake or the legacy ASCII
 /// daemon negotiation while exposing convenience accessors that mirror the
-/// per-variant helpers. Higher layers can match on the [`decision`] to branch on
+/// per-variant helpers. Higher layers can match on [`SessionHandshake::decision`] to branch on
 /// the negotiated style without re-sniffing the transport. Conversions are
 /// provided via [`From`] and [`TryFrom`] so variant-specific wrappers can be
 /// promoted or recovered ergonomically.


### PR DESCRIPTION
## Summary
- replace README cross-links in rsync-core, rsync-protocol, and rsync-bandwidth with neutral text that does not reference private items
- fix intra-doc links throughout transport, core, logging, meta, engine, filters, and protocol modules so rustdoc builds cleanly
- clarify negotiation helpers to reference the correct functions or self methods when replaying buffered prefixes

## Testing
- cargo doc --workspace --no-deps

------