### PR TITLE
Fix rustdoc warnings from private and redundant links

### DIFF
--- a/crates/bandwidth/src/limiter.rs
+++ b/crates/bandwidth/src/limiter.rs
@@ -822,7 +822,7 @@ impl BandwidthLimiter {
     /// Records a completed write and sleeps if the limiter accumulated debt.
     ///
     /// Each call adds the supplied byte count to the outstanding debt. When the
-    /// debt implies a sleep shorter than [`MINIMUM_SLEEP_MICROS`], the limiter
+    /// debt implies a sleep shorter than `MINIMUM_SLEEP_MICROS`, the limiter
     /// defers the pause and tracks the deficit so subsequent writes aggregate the
     /// debt until the threshold is crossed. This mirrors upstream rsync, where
     /// bursts of small writes eventually trigger a sleep that covers the accrued

--- a/crates/checksums/README.md
+++ b/crates/checksums/README.md
@@ -9,7 +9,7 @@ interchangeable with the C reference implementation.
 
 The crate currently offers two modules:
 
-- [`crate::rolling`] implements the Adler-32–style weak checksum (`rsum`) used
+- The `rolling` module implements the Adler-32–style weak checksum (`rsum`) used
   for block matching during delta transfers.
 - [`crate::strong`] exposes MD4, MD5, XXH64, and XXH3 (64- and 128-bit) digests
   together with the [`crate::strong::StrongDigest`] trait that higher layers use

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -43,7 +43,7 @@
 //! - Version output is delegated to [`rsync_core::version::VersionInfoReport`]
 //!   so the CLI remains byte-identical with the canonical banner used by other
 //!   workspace components.
-//! - Help output is rendered by [`render_help`] using a static snapshot that
+//! - Help output is rendered by a dedicated helper using a static snapshot that
 //!   documents the currently supported subset. The helper substitutes the
 //!   invoked program name so wrappers like `oc-rsync` display branded banners
 //!   while the full upstream-compatible renderer is implemented.

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -51,8 +51,8 @@
 //!   challenge, verifies the client's response against the configured secrets
 //!   file using MD5, and only then reports that transfers are unavailable while
 //!   the data path is under construction.
-//! - [`render_help`] returns a deterministic description of the limited daemon
-//!   capabilities available today, keeping the help text aligned with actual
+//! - A dedicated help renderer returns a deterministic description of the limited
+//!   daemon capabilities available today, keeping the help text aligned with actual
 //!   behaviour until the parity help renderer is implemented.
 //!
 //! # Invariants

--- a/crates/engine/src/delta/mod.rs
+++ b/crates/engine/src/delta/mod.rs
@@ -18,7 +18,7 @@
 //! Rust's type system to surface invalid inputs as structured errors. The helper
 //! takes a [`ProtocolVersion`] so call-sites do not need to translate negotiated
 //! versions into ad-hoc integers, and the checksum length uses
-//! [`NonZeroU8`](core::num::NonZeroU8) to reflect upstream's guarantee that the
+//! [`NonZeroU8`] to reflect upstream's guarantee that the
 //! value never reaches zero. Intermediate calculations use [`u128`] to avoid
 //! overflow when comparing `block_length^2` against large file sizes. Overflow
 //! scenarios—such as a block count that exceeds [`i32::MAX`]—are reported via

--- a/crates/engine/src/signature.rs
+++ b/crates/engine/src/signature.rs
@@ -12,7 +12,7 @@
 //! # Design
 //!
 //! - [`generate_file_signature`] accepts an input reader, the
-//!   [`SignatureLayout`](crate::delta::SignatureLayout) obtained from
+//!   [`SignatureLayout`] obtained from
 //!   [`crate::delta::calculate_signature_layout`], and a [`SignatureAlgorithm`]
 //!   describing the strong checksum strategy. The helper reads each block in
 //!   sequence, computes the weak and strong digests, and returns a


### PR DESCRIPTION
## Summary
- remove redundant intra-doc link targets in the engine crate
- avoid rustdoc warnings by stopping links to private helpers in CLI, daemon, bandwidth, and checksums docs

## Testing
- cargo doc --workspace --no-deps

------