### PR TITLE
Mark CLI README doctest as no_run

### DIFF
--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -26,7 +26,7 @@ compiled-in features.
 
 The crate is primarily consumed by the `oc-rsync` binary:
 
-```rust
+```rust,no_run
 use std::{env, io, process::ExitCode};
 
 fn main() -> ExitCode {


### PR DESCRIPTION
## Summary
- prevent the CLI README example from executing during doctests so it no longer triggers missing operand errors

## Testing
- `cargo test -p rsync-cli --doc`

------