### PR TITLE
Remove redundant cfg attribute in branding tests

### DIFF
--- a/crates/core/src/branding/tests.rs
+++ b/crates/core/src/branding/tests.rs
@@ -1,5 +1,3 @@
-#![cfg(test)]
-
 use super::*;
 use core::str::FromStr;
 use std::env;


### PR DESCRIPTION
## Summary
- remove the redundant crate-level cfg(test) attribute from the branding tests module

## Testing
- cargo clippy --workspace --all-targets -- -Dwarnings

------