### PR TITLE
Mark CLI README example as no_run

### DIFF
--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -26,7 +26,7 @@ compiled-in features.
 
 The crate is primarily consumed by the `oc-rsync` binary:
 
-```rust
+```rust,no_run
 use std::{env, io, process::ExitCode};
 
 fn main() -> ExitCode {


### PR DESCRIPTION
## Summary
- prevent the README.rs example main wrapper from executing during doctests by marking the snippet as `no_run`

## Testing
- cargo test -p rsync-cli --doc

------