### PR TITLE
Remove stale branding override from enforce limits config

### DIFF
--- a/tools/line_limits.toml
+++ b/tools/line_limits.toml
@@ -108,11 +108,6 @@ max_lines = 1429
 warn_lines = 1329
 
 [[overrides]]
-path = "crates/core/src/branding.rs"
-max_lines = 1395
-warn_lines = 1295
-
-[[overrides]]
 path = "crates/protocol/src/compatibility.rs"
 max_lines = 1303
 warn_lines = 1203


### PR DESCRIPTION
## Summary
- remove the stale enforce-limits override for crates/core/src/branding.rs so the task can locate all configured paths

## Testing
- cargo run -p xtask -- enforce-limits

------