### PR TITLE
Fix rustdoc links in SSH transport module

### DIFF
--- a/crates/transport/src/ssh/mod.rs
+++ b/crates/transport/src/ssh/mod.rs
@@ -6,8 +6,8 @@
 //! system `ssh` (or compatible) binary.  The struct follows a builder pattern:
 //! callers configure authentication parameters, additional command-line
 //! options, and the remote command to execute before requesting a
-//! [`SshConnection`].  The resulting connection implements [`Read`] and
-//! [`Write`], allowing higher layers to treat the remote shell exactly like any
+//! [`SshConnection`].  The resulting connection implements [`std::io::Read`] and
+//! [`std::io::Write`], allowing higher layers to treat the remote shell exactly like any
 //! other byte stream when negotiating rsync sessions.
 //!
 //! # Design


### PR DESCRIPTION
## Summary
- update the SSH transport module documentation to reference `std::io::Read`/`Write` explicitly so rustdoc can resolve the links

## Testing
- cargo doc --workspace --no-deps

------