### PR TITLE
Fix clippy and rustdoc regressions

### DIFF
--- a/crates/filters/src/lib.rs
+++ b/crates/filters/src/lib.rs
@@ -25,7 +25,7 @@
 //!   deduplicating equivalent glob expressions. Protect rules are tracked in a
 //!   dedicated list so deletion checks can honour them without affecting copy
 //!   decisions.
-//! - Matching occurs against relative paths using native [`Path`] semantics so
+//! - Matching occurs against relative paths using native [`std::path::Path`] semantics so
 //!   callers can operate directly on `std::path::PathBuf` instances without
 //!   additional conversions.
 //!

--- a/crates/protocol/src/legacy/greeting/tests.rs
+++ b/crates/protocol/src/legacy/greeting/tests.rs
@@ -1,5 +1,3 @@
-#![cfg(test)]
-
 //! Tests for legacy daemon greeting parsing and formatting.
 
 use super::*;

--- a/crates/protocol/src/legacy/greeting/tokens.rs
+++ b/crates/protocol/src/legacy/greeting/tokens.rs
@@ -5,8 +5,10 @@ use std::str::SplitAsciiWhitespace;
 
 /// Iterator over whitespace-separated digest tokens advertised by a legacy daemon.
 ///
-/// Instances of this iterator are created via [`LegacyDaemonGreeting::digest_tokens`] or
-/// [`LegacyDaemonGreetingOwned::digest_tokens`]. The iterator yields each digest exactly once in the
+/// Instances of this iterator are created via
+/// [`crate::legacy::greeting::LegacyDaemonGreeting::digest_tokens`] or
+/// [`crate::legacy::greeting::LegacyDaemonGreetingOwned::digest_tokens`]. The iterator yields each
+/// digest exactly once in the
 /// order received from the peer, matching upstream rsync's processing of the challenge/response list.
 #[derive(Clone, Debug)]
 pub struct DigestListTokens<'a> {


### PR DESCRIPTION
## Summary
- remove the redundant `cfg(test)` attribute from the legacy greeting tests
- qualify intra-doc links for filter path semantics and digest iterators to satisfy rustdoc

## Testing
- cargo clippy --workspace --all-targets -- -Dwarnings
- cargo doc --workspace --no-deps

------