### PR TITLE
Centralize branding metadata via cached manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,20 @@ assert_eq!(config, Path::new("/etc/oc-rsyncd/oc-rsyncd.conf"));
 assert_eq!(secrets, Path::new("/etc/oc-rsyncd/oc-rsyncd.secrets"));
 ```
 
+For callers that need a complete snapshot, the
+[`rsync_core::branding::manifest()`](crates/core/src/branding/manifest.rs)
+helper caches the branded and upstream profiles together with the workspace
+version metadata:
+
+```rust
+let manifest = rsync_core::branding::manifest();
+
+assert_eq!(manifest.oc().daemon_program_name(), "oc-rsyncd");
+assert_eq!(manifest.upstream().daemon_program_name(), "rsyncd");
+assert_eq!(manifest.rust_version(), "3.4.1-rust");
+assert_eq!(manifest.source_url(), "https://github.com/oferchen/rsync");
+```
+
 The packaging metadata installs example files at the same locations so new
 deployments pick up sane defaults out of the box. The binaries rely on the
 shared branding facade, ensuring help text, diagnostics, and configuration

--- a/crates/core/src/branding/manifest.rs
+++ b/crates/core/src/branding/manifest.rs
@@ -1,0 +1,113 @@
+#![deny(unsafe_code)]
+
+//! Workspace branding manifest exposed as a cached snapshot.
+//!
+//! The [`manifest()`] accessor returns a [`BrandManifest`] struct that captures
+//! the canonical program names, configuration paths, and version metadata for
+//! the workspace. Higher layers use the manifest to render banners, build help
+//! text, and locate configuration files without duplicating string literals or
+//! re-parsing the workspace manifest at runtime. The manifest is constructed on
+//! first use from [`crate::workspace::metadata()`] and cached for the lifetime of
+//! the process so callers can obtain references to the data at negligible cost.
+
+use std::sync::OnceLock;
+
+use super::brand::{self, Brand};
+use super::profile::{BrandProfile, oc_profile, upstream_profile};
+use crate::workspace;
+
+/// Cached branding snapshot derived from the workspace manifest.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct BrandManifest {
+    default_brand: Brand,
+    oc: BrandProfile,
+    upstream: BrandProfile,
+    rust_version: &'static str,
+    upstream_version: &'static str,
+    protocol_version: u32,
+    source_url: &'static str,
+}
+
+impl BrandManifest {
+    /// Returns the default [`Brand`] configured for this workspace build.
+    #[must_use]
+    pub const fn default_brand(self) -> Brand {
+        self.default_brand
+    }
+
+    /// Returns the branded [`BrandProfile`] used by the canonical binaries.
+    #[must_use]
+    pub const fn oc(self) -> BrandProfile {
+        self.oc
+    }
+
+    /// Returns the upstream-compatible [`BrandProfile`].
+    #[must_use]
+    pub const fn upstream(self) -> BrandProfile {
+        self.upstream
+    }
+
+    /// Returns the Rust-branded version string advertised by binaries.
+    #[must_use]
+    pub const fn rust_version(self) -> &'static str {
+        self.rust_version
+    }
+
+    /// Returns the upstream base version targeted by this build.
+    #[must_use]
+    pub const fn upstream_version(self) -> &'static str {
+        self.upstream_version
+    }
+
+    /// Returns the highest rsync protocol version supported by the workspace.
+    #[must_use]
+    pub const fn protocol_version(self) -> u32 {
+        self.protocol_version
+    }
+
+    /// Returns the source repository URL advertised by `--version` output.
+    #[must_use]
+    pub const fn source_url(self) -> &'static str {
+        self.source_url
+    }
+}
+
+fn build_manifest() -> BrandManifest {
+    let metadata = workspace::metadata();
+
+    BrandManifest {
+        default_brand: brand::default_brand(),
+        oc: oc_profile(),
+        upstream: upstream_profile(),
+        rust_version: metadata.rust_version(),
+        upstream_version: metadata.upstream_version(),
+        protocol_version: metadata.protocol_version(),
+        source_url: metadata.source_url(),
+    }
+}
+
+/// Returns the cached [`BrandManifest`] describing this workspace build.
+#[must_use]
+pub fn manifest() -> &'static BrandManifest {
+    static MANIFEST: OnceLock<BrandManifest> = OnceLock::new();
+    MANIFEST.get_or_init(build_manifest)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn manifest_matches_workspace_metadata() {
+        let manifest = manifest();
+        let metadata = workspace::metadata();
+
+        assert_eq!(manifest.default_brand(), brand::default_brand());
+        assert_eq!(manifest.oc(), oc_profile());
+        assert_eq!(manifest.upstream(), upstream_profile());
+        assert_eq!(manifest.rust_version(), metadata.rust_version());
+        assert_eq!(manifest.upstream_version(), metadata.upstream_version());
+        assert_eq!(manifest.protocol_version(), metadata.protocol_version());
+        assert_eq!(manifest.source_url(), metadata.source_url());
+    }
+}

--- a/crates/core/src/branding/mod.rs
+++ b/crates/core/src/branding/mod.rs
@@ -16,6 +16,7 @@
 mod brand;
 mod constants;
 mod detection;
+mod manifest;
 mod override_env;
 mod profile;
 
@@ -30,6 +31,7 @@ pub use constants::{
     UPSTREAM_CLIENT_PROGRAM_NAME, UPSTREAM_DAEMON_PROGRAM_NAME, brand_override_env_var,
 };
 pub use detection::{brand_for_program_name, detect_brand, resolve_brand_profile};
+pub use manifest::{BrandManifest, manifest};
 pub use profile::{
     BrandProfile, client_program_name, client_program_name_os_str, daemon_program_name,
     daemon_program_name_os_str, legacy_daemon_config_dir, legacy_daemon_config_path,

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -211,13 +211,13 @@ use rsync_core::{
         BandwidthLimitComponents, BandwidthLimiter, BandwidthParseError, LimiterChange,
         apply_effective_limit, parse_bandwidth_limit,
     },
-    branding::{self, Brand},
+    branding::{self, Brand, manifest},
     fallback::{
         CLIENT_FALLBACK_ENV, DAEMON_AUTO_DELEGATE_ENV, DAEMON_FALLBACK_ENV, fallback_override,
     },
     message::{Message, Role},
     rsync_error, rsync_info, rsync_warning,
-    version::{RUST_VERSION, VersionInfoReport, WEB_SITE},
+    version::VersionInfoReport,
 };
 use rsync_logging::MessageSink;
 use rsync_protocol::{
@@ -270,6 +270,7 @@ const LEGACY_HANDSHAKE_DIGESTS: &[&str] = &["sha512", "sha256", "sha1", "md5", "
 /// symlinks and the canonical `oc-rsyncd` binary emit brand-appropriate help
 /// output.
 fn help_text(brand: Brand) -> String {
+    let manifest = manifest();
     let program = brand.daemon_program_name();
     let default_config = brand.daemon_config_path_str();
 
@@ -305,8 +306,8 @@ fn help_text(brand: Brand) -> String {
             "replies with an @ERROR diagnostic while full module support is implemented.\n",
         ),
         program = program,
-        version = RUST_VERSION,
-        web_site = WEB_SITE,
+        version = manifest.rust_version(),
+        web_site = manifest.source_url(),
         default_config = default_config,
     )
 }
@@ -3254,6 +3255,8 @@ fn format_connection_status(active: usize) -> String {
 }
 
 fn serve_connections(options: RuntimeOptions) -> Result<(), DaemonError> {
+    let manifest = manifest();
+    let version = manifest.rust_version();
     let RuntimeOptions {
         bind_address,
         port,
@@ -3318,7 +3321,7 @@ fn serve_connections(options: RuntimeOptions) -> Result<(), DaemonError> {
     if let Some(log) = log_sink.as_ref() {
         let text = format!(
             "rsyncd version {} starting, listening on port {}",
-            RUST_VERSION,
+            version,
             local_addr.port()
         );
         let message = rsync_info!(text).with_role(Role::Daemon);
@@ -3415,7 +3418,7 @@ fn serve_connections(options: RuntimeOptions) -> Result<(), DaemonError> {
     }
 
     if let Some(log) = log_sink.as_ref() {
-        let text = format!("rsyncd version {} shutting down", RUST_VERSION);
+        let text = format!("rsyncd version {} shutting down", version);
         let message = rsync_info!(text).with_role(Role::Daemon);
         log_message(log, &message);
     }


### PR DESCRIPTION
## Summary
- add a cached `BrandManifest` snapshot so binaries and tooling can share the same brand/version metadata
- update the CLI and daemon front-ends to render help and diagnostics through the new manifest API
- document the manifest helper in the README and extend tests to cover the new entry point

## Testing
- cargo test -p rsync-core manifest_matches_workspace_metadata -- --nocapture

------