### PR TITLE
Fix enforce-limits configuration for protocol multiplex tests

### DIFF
--- a/tools/line_limits.toml
+++ b/tools/line_limits.toml
@@ -48,14 +48,14 @@ max_lines = 2783
 warn_lines = 2683
 
 [[overrides]]
+path = "crates/protocol/src/multiplex/tests.rs"
+max_lines = 1338
+warn_lines = 1238
+
+[[overrides]]
 path = "xtask/src/main.rs"
 max_lines = 2850
 warn_lines = 2750
-
-[[overrides]]
-path = "crates/protocol/src/multiplex.rs"
-max_lines = 2169
-warn_lines = 2069
 
 [[overrides]]
 path = "crates/transport/src/session/tests.rs"


### PR DESCRIPTION
## Summary
- update the enforce-limits override to track the multiplex test module's current path
- remove the stale multiplex override that referenced a deleted file

## Testing
- cargo run -p xtask -- enforce-limits

------