### PR TITLE
Add JSON support for branding xtask output

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,10 @@ metadata records the canonical program names, configuration locations, source
 URL, and supported protocol version so packaging tasks and CI workflows can
 validate branding before producing release artifacts. CI now invokes
 `cargo xtask branding` to surface the metadata without relying on external
-tools, and local operators can run the same command to confirm that binaries,
-documentation, and packaging assets share a consistent brand profile.
+tools. Pass `--json` to emit the same information in machine-readable form,
+allowing release automation to consume the data directly. Local operators can
+run the command in either mode to confirm that binaries, documentation, and
+packaging assets share a consistent brand profile.
 
 Higher-level crates such as `daemon` remain under development. The new engine
 module powers the local copy mode shipped by `oc-rsync` (and therefore any

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -51,7 +51,7 @@
 //! - [`cargo-cyclonedx`](https://github.com/CycloneDX/cyclonedx-rust-cargo) —
 //!   upstream documentation for the SBOM generator invoked by this task.
 
-use serde_json::Value as JsonValue;
+use serde_json::{Value as JsonValue, json};
 use std::collections::HashMap;
 use std::env;
 use std::ffi::OsString;
@@ -284,8 +284,35 @@ fn is_help_flag(value: &OsString) -> bool {
     value == "--help" || value == "-h"
 }
 
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
-struct BrandingOptions;
+/// Output format supported by the `branding` command.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum BrandingOutputFormat {
+    /// Human-readable text report.
+    Text,
+    /// Structured JSON report suitable for automation.
+    Json,
+}
+
+impl Default for BrandingOutputFormat {
+    fn default() -> Self {
+        BrandingOutputFormat::Text
+    }
+}
+
+/// Options accepted by the `branding` command.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct BrandingOptions {
+    /// Desired output format.
+    format: BrandingOutputFormat,
+}
+
+impl Default for BrandingOptions {
+    fn default() -> Self {
+        BrandingOptions {
+            format: BrandingOutputFormat::default(),
+        }
+    }
+}
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct SbomOptions {
@@ -324,20 +351,39 @@ fn parse_branding_args<I>(args: I) -> Result<BrandingOptions, TaskError>
 where
     I: IntoIterator<Item = OsString>,
 {
-    let mut args = args.into_iter();
+    let mut options = BrandingOptions::default();
 
-    if let Some(arg) = args.next() {
+    for arg in args {
         if is_help_flag(&arg) {
             return Err(TaskError::Help(branding_usage()));
         }
 
-        return Err(TaskError::Usage(format!(
-            "unrecognised argument '{}' for branding command",
-            arg.to_string_lossy()
-        )));
+        let Some(raw) = arg.to_str() else {
+            return Err(TaskError::Usage(String::from(
+                "branding command arguments must be valid UTF-8",
+            )));
+        };
+
+        match raw {
+            "--json" => {
+                if !matches!(options.format, BrandingOutputFormat::Text) {
+                    return Err(TaskError::Usage(String::from(
+                        "--json specified multiple times",
+                    )));
+                }
+
+                options.format = BrandingOutputFormat::Json;
+            }
+            _ => {
+                return Err(TaskError::Usage(format!(
+                    "unrecognised argument '{}' for branding command",
+                    raw
+                )));
+            }
+        }
     }
 
-    Ok(BrandingOptions)
+    Ok(options)
 }
 
 fn parse_docs_args<I>(args: I) -> Result<DocsOptions, TaskError>
@@ -571,33 +617,87 @@ fn execute_sbom(workspace: &Path, options: SbomOptions) -> Result<(), TaskError>
     )
 }
 
-fn execute_branding(workspace: &Path, _options: BrandingOptions) -> Result<(), TaskError> {
+fn execute_branding(workspace: &Path, options: BrandingOptions) -> Result<(), TaskError> {
     let branding = load_workspace_branding(workspace)?;
+    let output = render_branding(&branding, options.format)?;
 
-    println!("Workspace branding summary:");
-    println!("  brand: {}", branding.brand);
-    println!("  upstream_version: {}", branding.upstream_version);
-    println!("  rust_version: {}", branding.rust_version);
-    println!("  protocol: {}", branding.protocol);
-    println!("  client_bin: {}", branding.client_bin);
-    println!("  daemon_bin: {}", branding.daemon_bin);
-    println!("  legacy_client_bin: {}", branding.legacy_client_bin);
-    println!("  legacy_daemon_bin: {}", branding.legacy_daemon_bin);
-    println!("  daemon_config_dir: {}", branding.daemon_config_dir);
-    println!("  daemon_config: {}", branding.daemon_config);
-    println!("  daemon_secrets: {}", branding.daemon_secrets);
-    println!(
-        "  legacy_daemon_config_dir: {}",
-        branding.legacy_daemon_config_dir
-    );
-    println!("  legacy_daemon_config: {}", branding.legacy_daemon_config);
-    println!(
-        "  legacy_daemon_secrets: {}",
-        branding.legacy_daemon_secrets
-    );
-    println!("  source: {}", branding.source);
+    println!("{output}");
 
     Ok(())
+}
+
+fn render_branding(
+    branding: &WorkspaceBranding,
+    format: BrandingOutputFormat,
+) -> Result<String, TaskError> {
+    match format {
+        BrandingOutputFormat::Text => Ok(render_branding_text(branding)),
+        BrandingOutputFormat::Json => render_branding_json(branding),
+    }
+}
+
+fn render_branding_text(branding: &WorkspaceBranding) -> String {
+    format!(
+        concat!(
+            "Workspace branding summary:\n",
+            "  brand: {}\n",
+            "  upstream_version: {}\n",
+            "  rust_version: {}\n",
+            "  protocol: {}\n",
+            "  client_bin: {}\n",
+            "  daemon_bin: {}\n",
+            "  legacy_client_bin: {}\n",
+            "  legacy_daemon_bin: {}\n",
+            "  daemon_config_dir: {}\n",
+            "  daemon_config: {}\n",
+            "  daemon_secrets: {}\n",
+            "  legacy_daemon_config_dir: {}\n",
+            "  legacy_daemon_config: {}\n",
+            "  legacy_daemon_secrets: {}\n",
+            "  source: {}"
+        ),
+        branding.brand,
+        branding.upstream_version,
+        branding.rust_version,
+        branding.protocol,
+        branding.client_bin,
+        branding.daemon_bin,
+        branding.legacy_client_bin,
+        branding.legacy_daemon_bin,
+        branding.daemon_config_dir,
+        branding.daemon_config,
+        branding.daemon_secrets,
+        branding.legacy_daemon_config_dir,
+        branding.legacy_daemon_config,
+        branding.legacy_daemon_secrets,
+        branding.source,
+    )
+}
+
+fn render_branding_json(branding: &WorkspaceBranding) -> Result<String, TaskError> {
+    let value = json!({
+        "brand": branding.brand,
+        "upstream_version": branding.upstream_version,
+        "rust_version": branding.rust_version,
+        "protocol": branding.protocol,
+        "client_bin": branding.client_bin,
+        "daemon_bin": branding.daemon_bin,
+        "legacy_client_bin": branding.legacy_client_bin,
+        "legacy_daemon_bin": branding.legacy_daemon_bin,
+        "daemon_config_dir": branding.daemon_config_dir,
+        "daemon_config": branding.daemon_config,
+        "daemon_secrets": branding.daemon_secrets,
+        "legacy_daemon_config_dir": branding.legacy_daemon_config_dir,
+        "legacy_daemon_config": branding.legacy_daemon_config,
+        "legacy_daemon_secrets": branding.legacy_daemon_secrets,
+        "source": branding.source,
+    });
+
+    serde_json::to_string_pretty(&value).map_err(|error| {
+        TaskError::Metadata(format!(
+            "failed to serialise branding metadata as JSON: {error}"
+        ))
+    })
 }
 
 fn execute_docs(workspace: &Path, options: DocsOptions) -> Result<(), TaskError> {
@@ -1231,7 +1331,7 @@ fn docs_usage() -> String {
 
 fn branding_usage() -> String {
     String::from(
-        "Usage: cargo xtask branding\n\nOptions:\n  -h, --help      Show this help message",
+        "Usage: cargo xtask branding\n\nOptions:\n  -h, --help      Show this help message\n  --json         Emit branding metadata as JSON",
     )
 }
 
@@ -2121,23 +2221,45 @@ fn execute_package(workspace: &Path, options: PackageOptions) -> Result<(), Task
 #[cfg(test)]
 mod tests {
     use super::{
-        BrandingOptions, DocsOptions, EnforceLimitsOptions, NoBinariesOptions,
-        NoPlaceholdersOptions, PackageOptions, PreflightOptions, SbomOptions, TaskError,
-        WorkspaceBranding, branding_usage, docs_usage, enforce_limits_usage, no_binaries_usage,
-        no_placeholders_usage, package_usage, parse_branding_args, parse_docs_args,
-        parse_enforce_limits_args, parse_line_limits_config, parse_no_binaries_args,
-        parse_no_placeholders_args, parse_package_args, parse_preflight_args, parse_sbom_args,
-        parse_workspace_branding, preflight_usage, sbom_usage, scan_rust_file_for_placeholders,
-        top_level_usage,
+        BrandingOptions, BrandingOutputFormat, DocsOptions, EnforceLimitsOptions,
+        NoBinariesOptions, NoPlaceholdersOptions, PackageOptions, PreflightOptions, SbomOptions,
+        TaskError, WorkspaceBranding, branding_usage, docs_usage, enforce_limits_usage,
+        no_binaries_usage, no_placeholders_usage, package_usage, parse_branding_args,
+        parse_docs_args, parse_enforce_limits_args, parse_line_limits_config,
+        parse_no_binaries_args, parse_no_placeholders_args, parse_package_args,
+        parse_preflight_args, parse_sbom_args, parse_workspace_branding, preflight_usage,
+        render_branding, render_branding_json, render_branding_text, sbom_usage,
+        scan_rust_file_for_placeholders, top_level_usage,
     };
+    use serde_json::Value as JsonValue;
     use std::ffi::OsString;
     use std::fs;
     use std::path::{Path, PathBuf};
 
+    fn sample_branding() -> WorkspaceBranding {
+        WorkspaceBranding {
+            brand: String::from("oc"),
+            upstream_version: String::from("3.4.1"),
+            rust_version: String::from("3.4.1-rust"),
+            protocol: 32,
+            client_bin: String::from("oc-rsync"),
+            daemon_bin: String::from("oc-rsyncd"),
+            legacy_client_bin: String::from("rsync"),
+            legacy_daemon_bin: String::from("rsyncd"),
+            daemon_config_dir: String::from("/etc/oc-rsyncd"),
+            daemon_config: String::from("/etc/oc-rsyncd/oc-rsyncd.conf"),
+            daemon_secrets: String::from("/etc/oc-rsyncd/oc-rsyncd.secrets"),
+            legacy_daemon_config_dir: String::from("/etc"),
+            legacy_daemon_config: String::from("/etc/rsyncd.conf"),
+            legacy_daemon_secrets: String::from("/etc/rsyncd.secrets"),
+            source: String::from("https://example.invalid/rsync"),
+        }
+    }
+
     #[test]
     fn parse_branding_args_accepts_default_configuration() {
         let options = parse_branding_args(std::iter::empty()).expect("parse succeeds");
-        assert_eq!(options, BrandingOptions);
+        assert_eq!(options, BrandingOptions::default());
     }
 
     #[test]
@@ -2147,9 +2269,86 @@ mod tests {
     }
 
     #[test]
+    fn parse_branding_args_enables_json_output() {
+        let options = parse_branding_args([OsString::from("--json")]).expect("parse succeeds");
+        assert_eq!(
+            options,
+            BrandingOptions {
+                format: BrandingOutputFormat::Json,
+            }
+        );
+    }
+
+    #[test]
+    fn parse_branding_args_rejects_duplicate_json_flags() {
+        let error =
+            parse_branding_args([OsString::from("--json"), OsString::from("--json")]).unwrap_err();
+        assert!(matches!(error, TaskError::Usage(message) if message.contains("--json")));
+    }
+
+    #[test]
     fn parse_branding_args_rejects_unknown_argument() {
         let error = parse_branding_args([OsString::from("--unknown")]).unwrap_err();
         assert!(matches!(error, TaskError::Usage(message) if message.contains("--unknown")));
+    }
+
+    #[test]
+    fn render_branding_text_matches_expected_layout() {
+        let branding = sample_branding();
+        let rendered = render_branding_text(&branding);
+        let expected = concat!(
+            "Workspace branding summary:\n",
+            "  brand: oc\n",
+            "  upstream_version: 3.4.1\n",
+            "  rust_version: 3.4.1-rust\n",
+            "  protocol: 32\n",
+            "  client_bin: oc-rsync\n",
+            "  daemon_bin: oc-rsyncd\n",
+            "  legacy_client_bin: rsync\n",
+            "  legacy_daemon_bin: rsyncd\n",
+            "  daemon_config_dir: /etc/oc-rsyncd\n",
+            "  daemon_config: /etc/oc-rsyncd/oc-rsyncd.conf\n",
+            "  daemon_secrets: /etc/oc-rsyncd/oc-rsyncd.secrets\n",
+            "  legacy_daemon_config_dir: /etc\n",
+            "  legacy_daemon_config: /etc/rsyncd.conf\n",
+            "  legacy_daemon_secrets: /etc/rsyncd.secrets\n",
+            "  source: https://example.invalid/rsync"
+        );
+        assert_eq!(rendered, expected);
+    }
+
+    #[test]
+    fn render_branding_json_produces_expected_structure() {
+        let branding = sample_branding();
+        let rendered = render_branding_json(&branding).expect("json output");
+        let value: JsonValue = serde_json::from_str(&rendered).expect("valid json");
+
+        assert_eq!(value["brand"], "oc");
+        assert_eq!(value["upstream_version"], "3.4.1");
+        assert_eq!(value["rust_version"], "3.4.1-rust");
+        assert_eq!(value["protocol"], 32);
+        assert_eq!(value["client_bin"], "oc-rsync");
+        assert_eq!(value["daemon_bin"], "oc-rsyncd");
+        assert_eq!(value["legacy_client_bin"], "rsync");
+        assert_eq!(value["legacy_daemon_bin"], "rsyncd");
+        assert_eq!(value["daemon_config_dir"], "/etc/oc-rsyncd");
+        assert_eq!(value["daemon_config"], "/etc/oc-rsyncd/oc-rsyncd.conf");
+        assert_eq!(value["daemon_secrets"], "/etc/oc-rsyncd/oc-rsyncd.secrets");
+        assert_eq!(value["legacy_daemon_config_dir"], "/etc");
+        assert_eq!(value["legacy_daemon_config"], "/etc/rsyncd.conf");
+        assert_eq!(value["legacy_daemon_secrets"], "/etc/rsyncd.secrets");
+        assert_eq!(value["source"], "https://example.invalid/rsync");
+    }
+
+    #[test]
+    fn render_branding_respects_selected_format() {
+        let branding = sample_branding();
+        let text = render_branding(&branding, BrandingOutputFormat::Text).expect("text");
+        assert_eq!(text, render_branding_text(&branding));
+
+        let json = render_branding(&branding, BrandingOutputFormat::Json).expect("json");
+        let expected = render_branding_json(&branding).expect("json");
+        assert_eq!(json, expected);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- allow `cargo xtask branding --json` to emit branding metadata as JSON while reusing a shared formatter
- extend xtask unit coverage for branding output formats and update help text
- document the machine-readable branding option in the README

## Testing
- cargo test -p xtask

------