### PR TITLE
Derive defaults for branding options

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -285,33 +285,20 @@ fn is_help_flag(value: &OsString) -> bool {
 }
 
 /// Output format supported by the `branding` command.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 enum BrandingOutputFormat {
     /// Human-readable text report.
+    #[default]
     Text,
     /// Structured JSON report suitable for automation.
     Json,
 }
 
-impl Default for BrandingOutputFormat {
-    fn default() -> Self {
-        BrandingOutputFormat::Text
-    }
-}
-
 /// Options accepted by the `branding` command.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 struct BrandingOptions {
     /// Desired output format.
     format: BrandingOutputFormat,
-}
-
-impl Default for BrandingOptions {
-    fn default() -> Self {
-        BrandingOptions {
-            format: BrandingOutputFormat::default(),
-        }
-    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]


### PR DESCRIPTION
## Summary
- derive `Default` for `BrandingOutputFormat` and mark the text variant as the default
- derive `Default` for `BrandingOptions` to remove the manual implementation

## Testing
- cargo clippy --workspace --all-targets -- -Dwarnings

------