### PR TITLE
Add workspace metadata helpers and parallelize cross builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,7 +154,7 @@ jobs:
         run: cargo test --workspace --all-features
 
   build-matrix:
-    needs: test-linux
+    needs: lint
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/crates/core/src/workspace.rs
+++ b/crates/core/src/workspace.rs
@@ -17,13 +17,67 @@ use std::path::Path;
 #[doc(alias = "oc")]
 pub const BRAND: &str = env!("OC_RSYNC_WORKSPACE_BRAND");
 
+/// Returns the canonical brand identifier configured for this distribution.
+///
+/// This helper avoids exposing the raw environment variable constant to callers
+/// while still participating in constant evaluation. Code that only needs the
+/// brand string can call [`brand()`] directly instead of materialising the full
+/// [`Metadata`] snapshot.
+///
+/// # Examples
+///
+/// ```
+/// use rsync_core::workspace;
+///
+/// assert_eq!(workspace::brand(), workspace::metadata().brand());
+/// ```
+#[must_use]
+pub const fn brand() -> &'static str {
+    BRAND
+}
+
 /// Upstream rsync base version targeted by this build.
 #[doc(alias = "3.4.1")]
 pub const UPSTREAM_VERSION: &str = env!("OC_RSYNC_WORKSPACE_UPSTREAM_VERSION");
 
+/// Returns the upstream rsync base version targeted by this build.
+///
+/// The value matches the upstream release string rendered in `--version`
+/// output and documentation banners. Callers that only need the version text
+/// can rely on this helper instead of reading it through [`Metadata`].
+///
+/// # Examples
+///
+/// ```
+/// use rsync_core::workspace;
+///
+/// assert_eq!(workspace::upstream_version(), workspace::metadata().upstream_version());
+/// ```
+#[must_use]
+pub const fn upstream_version() -> &'static str {
+    UPSTREAM_VERSION
+}
+
 /// Full Rust-branded version string advertised by binaries.
 #[doc(alias = "3.4.1-rust")]
 pub const RUST_VERSION: &str = env!("OC_RSYNC_WORKSPACE_RUST_VERSION");
+
+/// Returns the Rust-branded version string advertised by binaries.
+///
+/// The helper is used by banner renderers that need the branded identifier
+/// without constructing a [`Metadata`] snapshot.
+///
+/// # Examples
+///
+/// ```
+/// use rsync_core::workspace;
+///
+/// assert_eq!(workspace::rust_version(), workspace::metadata().rust_version());
+/// ```
+#[must_use]
+pub const fn rust_version() -> &'static str {
+    RUST_VERSION
+}
 
 /// Highest protocol version supported by the workspace.
 pub const PROTOCOL_VERSION: u32 = parse_u32(env!("OC_RSYNC_WORKSPACE_PROTOCOL"));
@@ -32,17 +86,76 @@ pub const PROTOCOL_VERSION: u32 = parse_u32(env!("OC_RSYNC_WORKSPACE_PROTOCOL"))
 #[doc(alias = "oc-rsync")]
 pub const CLIENT_PROGRAM_NAME: &str = env!("OC_RSYNC_WORKSPACE_CLIENT_BIN");
 
+/// Returns the canonical client binary name shipped with the distribution.
+///
+/// This helper mirrors [`Metadata::client_program_name`] while remaining
+/// `const`, which simplifies usage from static contexts.
+///
+/// # Examples
+///
+/// ```
+/// use rsync_core::workspace;
+///
+/// assert_eq!(workspace::client_program_name(), workspace::metadata().client_program_name());
+/// ```
+#[must_use]
+pub const fn client_program_name() -> &'static str {
+    CLIENT_PROGRAM_NAME
+}
+
 /// Canonical daemon binary name shipped with the distribution.
 #[doc(alias = "oc-rsyncd")]
 pub const DAEMON_PROGRAM_NAME: &str = env!("OC_RSYNC_WORKSPACE_DAEMON_BIN");
+
+/// Returns the canonical daemon binary name shipped with the distribution.
+///
+/// # Examples
+///
+/// ```
+/// use rsync_core::workspace;
+///
+/// assert_eq!(workspace::daemon_program_name(), workspace::metadata().daemon_program_name());
+/// ```
+#[must_use]
+pub const fn daemon_program_name() -> &'static str {
+    DAEMON_PROGRAM_NAME
+}
 
 /// Upstream-compatible client binary name used for compatibility symlinks.
 #[doc(alias = "rsync")]
 pub const LEGACY_CLIENT_PROGRAM_NAME: &str = env!("OC_RSYNC_WORKSPACE_LEGACY_CLIENT_BIN");
 
+/// Returns the upstream-compatible client binary name used for compatibility symlinks.
+///
+/// # Examples
+///
+/// ```
+/// use rsync_core::workspace;
+///
+/// assert_eq!(workspace::legacy_client_program_name(), workspace::metadata().legacy_client_program_name());
+/// ```
+#[must_use]
+pub const fn legacy_client_program_name() -> &'static str {
+    LEGACY_CLIENT_PROGRAM_NAME
+}
+
 /// Upstream-compatible daemon binary name used for compatibility symlinks.
 #[doc(alias = "rsyncd")]
 pub const LEGACY_DAEMON_PROGRAM_NAME: &str = env!("OC_RSYNC_WORKSPACE_LEGACY_DAEMON_BIN");
+
+/// Returns the upstream-compatible daemon binary name used for compatibility symlinks.
+///
+/// # Examples
+///
+/// ```
+/// use rsync_core::workspace;
+///
+/// assert_eq!(workspace::legacy_daemon_program_name(), workspace::metadata().legacy_daemon_program_name());
+/// ```
+#[must_use]
+pub const fn legacy_daemon_program_name() -> &'static str {
+    LEGACY_DAEMON_PROGRAM_NAME
+}
 
 /// Configuration directory installed alongside the branded daemon.
 #[doc(alias = "/etc/oc-rsyncd")]
@@ -70,6 +183,20 @@ pub const LEGACY_DAEMON_SECRETS_PATH: &str = env!("OC_RSYNC_WORKSPACE_LEGACY_DAE
 
 /// Source repository URL advertised by `--version` output.
 pub const SOURCE_URL: &str = env!("OC_RSYNC_WORKSPACE_SOURCE");
+
+/// Returns the source repository URL advertised by version banners.
+///
+/// # Examples
+///
+/// ```
+/// use rsync_core::workspace;
+///
+/// assert_eq!(workspace::source_url(), workspace::metadata().source_url());
+/// ```
+#[must_use]
+pub const fn source_url() -> &'static str {
+    SOURCE_URL
+}
 
 /// Immutable snapshot of workspace metadata loaded from `Cargo.toml`.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -284,6 +411,26 @@ mod tests {
         assert_eq!(daemon_config_dir(), Path::new(DAEMON_CONFIG_DIR));
         assert_eq!(daemon_config_path(), Path::new(DAEMON_CONFIG_PATH));
         assert_eq!(daemon_secrets_path(), Path::new(DAEMON_SECRETS_PATH));
+    }
+
+    #[test]
+    fn const_accessors_match_metadata() {
+        let snapshot = metadata();
+
+        assert_eq!(brand(), snapshot.brand());
+        assert_eq!(upstream_version(), snapshot.upstream_version());
+        assert_eq!(rust_version(), snapshot.rust_version());
+        assert_eq!(client_program_name(), snapshot.client_program_name());
+        assert_eq!(daemon_program_name(), snapshot.daemon_program_name());
+        assert_eq!(
+            legacy_client_program_name(),
+            snapshot.legacy_client_program_name()
+        );
+        assert_eq!(
+            legacy_daemon_program_name(),
+            snapshot.legacy_daemon_program_name()
+        );
+        assert_eq!(source_url(), snapshot.source_url());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add const-returning helpers in `rsync_core::workspace` so branding and version data can be reused without materialising the metadata snapshot
- document the new helpers with doctests and cover them via unit tests to keep the branding surface verifiable
- allow the cross-compilation matrix to run immediately after linting so Linux tests and cross builds execute in parallel

## Testing
- `cargo test -p rsync-core workspace::tests::const_accessors_match_metadata`

------