### PR TITLE
Fix nextest invocations in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,13 +114,13 @@ jobs:
           tool: cargo-nextest
 
       - name: Run tests
-        run: cargo nextest run --workspace --no-fail-fast
+        run: cargo nextest run --workspace
 
       - name: Run tests (extended features)
-        run: cargo nextest run --workspace --no-fail-fast --all-features
+        run: cargo nextest run --workspace --all-features
 
       - name: Test with coverage (95% lines & functions)
-        run: cargo llvm-cov nextest --workspace --all-features --fail-under-lines 95 --fail-under-functions 95 --lcov --output-path coverage.lcov -- --no-fail-fast
+        run: cargo llvm-cov nextest --workspace --all-features --fail-under-lines 95 --fail-under-functions 95 --lcov --output-path coverage.lcov
 
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- remove the unsupported `--no-fail-fast` flag from the CI nextest runs
- update the coverage job to rely on nextest's default non-fail-fast behavior

## Testing
- not run (workflow-only change)

------