### PR TITLE
Fix CycloneDX plugin installation in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,11 +228,11 @@ jobs:
         with:
           tool: cargo-zigbuild
 
-      - name: Install cyclonedx-rust-cargo
+      - name: Install cargo-cyclonedx
         if: ${{ !contains(matrix.target, 'windows') }}
         uses: taiki-e/install-action@v2
         with:
-          tool: cyclonedx-rust-cargo
+          tool: cargo-cyclonedx
 
       - name: Build oc-rsync
         run: cargo ${{ matrix.build_command }} --release --target ${{ matrix.target }} --bin oc-rsync
@@ -291,10 +291,10 @@ jobs:
         with:
           tool: cargo-rpm
 
-      - name: Install cyclonedx-rust-cargo
+      - name: Install cargo-cyclonedx
         uses: taiki-e/install-action@v2
         with:
-          tool: cyclonedx-rust-cargo
+          tool: cargo-cyclonedx
 
       - name: Display workspace metadata
         run: cargo run -p xtask -- branding


### PR DESCRIPTION
## Summary
- update CI jobs to install the cargo-cyclonedx crate via taiki-e/install-action
- ensure SBOM generation uses the maintained CycloneDX cargo plugin during packaging

## Testing
- not run (workflow change only)

------