### PR TITLE
Tighten CI cargo invocations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
           shared-key: no-binaries
 
       - name: Audit repository for tracked binary artifacts
-        run: cargo run -p xtask -- no-binaries
+        run: cargo --locked run -p xtask -- no-binaries
 
   lint:
     runs-on: ubuntu-latest
@@ -64,19 +64,19 @@ jobs:
         run: cargo fmt --all -- --check
 
       - name: Lint with clippy
-        run: cargo clippy --workspace --all-targets -- -Dwarnings
+        run: cargo clippy --workspace --all-targets --all-features --locked -- -Dwarnings
 
       - name: Enforce line count limits
-        run: cargo run -p xtask -- enforce-limits
+        run: cargo --locked run -p xtask -- enforce-limits
 
       - name: Build documentation
-        run: cargo doc --workspace --no-deps
+        run: cargo --locked doc --workspace --no-deps
 
       - name: Run doctests
-        run: cargo test --doc --workspace
+        run: cargo --locked test --doc --workspace
 
       - name: Ensure no placeholders remain
-        run: cargo run -p xtask -- no-placeholders
+        run: cargo --locked run -p xtask -- no-placeholders
 
   test-linux:
     needs: lint
@@ -101,7 +101,7 @@ jobs:
           version: 1
 
       - name: Pre-flight check
-        run: cargo run -p xtask -- preflight
+        run: cargo --locked run -p xtask -- preflight
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@v2
@@ -114,13 +114,13 @@ jobs:
           tool: cargo-nextest
 
       - name: Run tests
-        run: cargo nextest run --workspace
+        run: cargo --locked nextest run --workspace
 
       - name: Run tests (extended features)
-        run: cargo nextest run --workspace --all-features
+        run: cargo --locked nextest run --workspace --all-features
 
       - name: Test with coverage (95% lines & functions)
-        run: cargo llvm-cov nextest --workspace --all-features --fail-under-lines 95 --fail-under-functions 95 --lcov --output-path coverage.lcov
+        run: cargo --locked llvm-cov nextest --workspace --all-features --fail-under-lines 95 --fail-under-functions 95 --lcov --output-path coverage.lcov
 
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v4
@@ -151,7 +151,7 @@ jobs:
           version: 1
 
       - name: Run tests (all features)
-        run: cargo test --workspace --all-features
+        run: cargo --locked test --workspace --all-features
 
   build-matrix:
     needs: lint
@@ -235,15 +235,15 @@ jobs:
           tool: cargo-cyclonedx
 
       - name: Build oc-rsync
-        run: cargo ${{ matrix.build_command }} --release --target ${{ matrix.target }} --bin oc-rsync
+        run: cargo --locked ${{ matrix.build_command }} --release --target ${{ matrix.target }} --bin oc-rsync
 
       - name: Build oc-rsyncd
         if: matrix.build_daemon
-        run: cargo ${{ matrix.build_command }} --release --target ${{ matrix.target }} --bin oc-rsyncd
+        run: cargo --locked ${{ matrix.build_command }} --release --target ${{ matrix.target }} --bin oc-rsyncd
 
       - name: Generate target SBOM
         if: ${{ !contains(matrix.target, 'windows') }}
-        run: cargo run -p xtask -- sbom --output target/${{ matrix.target }}/release/oc-rsync-${{ matrix.name }}-sbom.json
+        run: cargo --locked run -p xtask -- sbom --output target/${{ matrix.target }}/release/oc-rsync-${{ matrix.name }}-sbom.json
 
       - name: Upload oc-rsync artifact
         uses: actions/upload-artifact@v4
@@ -297,16 +297,16 @@ jobs:
           tool: cargo-cyclonedx
 
       - name: Display workspace metadata
-        run: cargo run -p xtask -- branding
+        run: cargo --locked run -p xtask -- branding
 
       - name: Build Debian package
-        run: cargo deb -p oc-rsync-bin
+        run: cargo --locked deb -p oc-rsync-bin
 
       - name: Build RPM package
-        run: cargo rpm build --release
+        run: cargo --locked rpm build --release
 
       - name: Generate SBOM
-        run: cargo run -p xtask -- sbom
+        run: cargo --locked run -p xtask -- sbom
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary
- ensure all CI cargo invocations use `--locked` so dependency resolution is deterministic in every job
- run `cargo clippy` with `--all-features` to lint every configuration alongside existing all-target checks

## Testing
- not run (workflow-only change)

------