### PR TITLE
Ensure feature matrix documentation stays branded

### DIFF
--- a/xtask/src/commands/preflight.rs
+++ b/xtask/src/commands/preflight.rs
@@ -345,6 +345,16 @@ fn validate_documentation(workspace: &Path, branding: &WorkspaceBranding) -> Tas
                 branding.daemon_config.as_str(),
             ],
         },
+        DocumentationCheck {
+            relative_path: "docs/feature_matrix.md",
+            required_snippets: vec![
+                branding.client_bin.as_str(),
+                branding.daemon_bin.as_str(),
+                branding.rust_version.as_str(),
+                branding.daemon_config.as_str(),
+                branding.daemon_secrets.as_str(),
+            ],
+        },
     ];
 
     for check in checks {


### PR DESCRIPTION
## Summary
- extend the `cargo xtask preflight` documentation guard to cover `docs/feature_matrix.md`

## Testing
- cargo fmt
- cargo test -p xtask
- cargo run -p xtask -- preflight

------