### PR TITLE
Gate special file helpers on supported Unix targets

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -8389,7 +8389,18 @@ mod tests {
         assert!(rendered.contains("Total bytes sent: 1.54K (1,536)"));
     }
 
-    #[cfg(unix)]
+    #[cfg(all(
+        unix,
+        not(any(
+            target_os = "espidf",
+            target_os = "ios",
+            target_os = "macos",
+            target_os = "tvos",
+            target_os = "vita",
+            target_os = "wasi",
+            target_os = "watchos",
+        ))
+    ))]
     #[test]
     fn verbose_transfer_reports_skipped_specials() {
         use rustix::fs::{CWD, FileType, Mode, makedev, mknodat};
@@ -8642,7 +8653,18 @@ mod tests {
         );
     }
 
-    #[cfg(unix)]
+    #[cfg(all(
+        unix,
+        not(any(
+            target_os = "espidf",
+            target_os = "ios",
+            target_os = "macos",
+            target_os = "tvos",
+            target_os = "vita",
+            target_os = "wasi",
+            target_os = "watchos",
+        ))
+    ))]
     #[test]
     fn progress_reports_unknown_totals_with_placeholder() {
         use rustix::fs::{CWD, FileType, Mode, makedev, mknodat};
@@ -8680,7 +8702,18 @@ mod tests {
         assert!(metadata.file_type().is_fifo());
     }
 
-    #[cfg(unix)]
+    #[cfg(all(
+        unix,
+        not(any(
+            target_os = "espidf",
+            target_os = "ios",
+            target_os = "macos",
+            target_os = "tvos",
+            target_os = "vita",
+            target_os = "wasi",
+            target_os = "watchos",
+        ))
+    ))]
     #[test]
     fn info_progress2_enables_progress_output() {
         use rustix::fs::{CWD, FileType, Mode, makedev, mknodat};

--- a/crates/engine/src/local_copy.rs
+++ b/crates/engine/src/local_copy.rs
@@ -11909,7 +11909,18 @@ mod tests {
         assert_eq!(summary.files_copied(), 1);
     }
 
-    #[cfg(unix)]
+    #[cfg(all(
+        unix,
+        not(any(
+            target_os = "espidf",
+            target_os = "ios",
+            target_os = "macos",
+            target_os = "tvos",
+            target_os = "vita",
+            target_os = "wasi",
+            target_os = "watchos",
+        ))
+    ))]
     #[test]
     fn execute_copies_fifo() {
         use filetime::{FileTime, set_file_times};
@@ -11968,7 +11979,18 @@ mod tests {
         assert_eq!(summary.fifos_created(), 1);
     }
 
-    #[cfg(unix)]
+    #[cfg(all(
+        unix,
+        not(any(
+            target_os = "espidf",
+            target_os = "ios",
+            target_os = "macos",
+            target_os = "tvos",
+            target_os = "vita",
+            target_os = "wasi",
+            target_os = "watchos",
+        ))
+    ))]
     #[test]
     fn execute_copies_fifo_within_directory() {
         use filetime::{FileTime, set_file_times};
@@ -12031,7 +12053,18 @@ mod tests {
         assert_eq!(summary.fifos_created(), 1);
     }
 
-    #[cfg(unix)]
+    #[cfg(all(
+        unix,
+        not(any(
+            target_os = "espidf",
+            target_os = "ios",
+            target_os = "macos",
+            target_os = "tvos",
+            target_os = "vita",
+            target_os = "wasi",
+            target_os = "watchos",
+        ))
+    ))]
     #[test]
     fn execute_without_specials_skips_fifo() {
         use rustix::fs::{CWD, FileType, Mode, makedev, mknodat};
@@ -12062,7 +12095,18 @@ mod tests {
         assert!(fs::symlink_metadata(&destination_fifo).is_err());
     }
 
-    #[cfg(unix)]
+    #[cfg(all(
+        unix,
+        not(any(
+            target_os = "espidf",
+            target_os = "ios",
+            target_os = "macos",
+            target_os = "tvos",
+            target_os = "vita",
+            target_os = "wasi",
+            target_os = "watchos",
+        ))
+    ))]
     #[test]
     fn execute_without_specials_records_skip_event() {
         use rustix::fs::{CWD, FileType, Mode, makedev, mknodat};


### PR DESCRIPTION
## Summary
- make FIFO and device creation use fallible conversions and only compile on Unix targets that expose `mknodat`
- return explicit unsupported errors when special files are not available
- limit FIFO-focused tests in `engine` and `cli` to the same target set

## Testing
- cargo check -p rsync-meta
- cargo check -p rsync-cli

------