### PR TITLE
Fix stale enforce-limits override entry

### DIFF
--- a/tools/line_limits.toml
+++ b/tools/line_limits.toml
@@ -143,11 +143,6 @@ max_lines = 1010
 warn_lines = 910
 
 [[overrides]]
-path = "crates/transport/src/session/handshake.rs"
-max_lines = 897
-warn_lines = 797
-
-[[overrides]]
 path = "crates/protocol/src/legacy/lines.rs"
 max_lines = 827
 warn_lines = 727


### PR DESCRIPTION
## Summary
- remove the stale enforce-limits override that referenced the old transport handshake source path

## Testing
- bash tools/enforce_limits.sh

------