### PR TITLE
Fix clippy lint for unexpected ACL entry result

### DIFF
--- a/crates/meta/src/acl_support.rs
+++ b/crates/meta/src/acl_support.rs
@@ -200,10 +200,9 @@ impl PosixAcl {
             0 => Ok(true),
             1 => Ok(false),
             -1 => Err(io::Error::last_os_error()),
-            value => Err(io::Error::new(
-                io::ErrorKind::Other,
-                format!("unexpected acl_get_entry result {value}"),
-            )),
+            value => Err(io::Error::other(format!(
+                "unexpected acl_get_entry result {value}"
+            ))),
         }
     }
 }


### PR DESCRIPTION
## Summary
- use `io::Error::other` when reporting unexpected `acl_get_entry` values to satisfy clippy

## Testing
- cargo clippy --workspace --all-targets --all-features --locked -- -Dwarnings

------