### PR TITLE
Add README version consistency check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,23 @@ jobs:
       - name: Audit repository for tracked binary artifacts
         run: cargo --locked run -p xtask -- no-binaries
 
+  readme-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: 1.87
+          cache: true
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: readme-version
+
+      - name: Verify README version alignment
+        run: cargo --locked run -p xtask -- readme-version
+
   lint:
     runs-on: ubuntu-latest
     steps:
@@ -79,7 +96,7 @@ jobs:
         run: cargo --locked run -p xtask -- no-placeholders
 
   test-linux:
-    needs: lint
+    needs: [lint, readme-version]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/xtask/src/commands/mod.rs
+++ b/xtask/src/commands/mod.rs
@@ -5,4 +5,5 @@ pub mod no_binaries;
 pub mod no_placeholders;
 pub mod package;
 pub mod preflight;
+pub mod readme_version;
 pub mod sbom;

--- a/xtask/src/commands/readme_version.rs
+++ b/xtask/src/commands/readme_version.rs
@@ -1,0 +1,134 @@
+#![deny(unsafe_code)]
+
+//! README version consistency check command.
+//!
+//! The `readme-version` command validates that the workspace `README.md`
+//! mentions both the upstream rsync release targeted by this build and the
+//! Rust-branded version string advertised by the shipping binaries. Keeping the
+//! documentation in lock-step with the binaries avoids stale marketing
+//! materials and ensures downstream packagers can rely on the README as the
+//! canonical human-readable reference for the supported release line.
+
+use crate::error::{TaskError, TaskResult};
+use crate::util::is_help_flag;
+use crate::workspace::load_workspace_branding;
+use std::ffi::OsString;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Options accepted by the `readme-version` command.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct ReadmeVersionOptions;
+
+/// Parses CLI arguments for the `readme-version` command.
+pub fn parse_args<I>(args: I) -> TaskResult<ReadmeVersionOptions>
+where
+    I: IntoIterator<Item = OsString>,
+{
+    let mut args = args.into_iter();
+
+    if let Some(arg) = args.next() {
+        if is_help_flag(&arg) {
+            return Err(TaskError::Help(usage()));
+        }
+
+        return Err(TaskError::Usage(format!(
+            "unrecognised argument '{}' for readme-version command",
+            arg.to_string_lossy()
+        )));
+    }
+
+    Ok(ReadmeVersionOptions)
+}
+
+/// Executes the `readme-version` command.
+pub fn execute(workspace: &Path, _options: ReadmeVersionOptions) -> TaskResult<()> {
+    let branding = load_workspace_branding(workspace)?;
+    let readme_path = workspace.join("README.md");
+    let readme = readme_contents(&readme_path)?;
+
+    validate_contains(&readme, &branding.rust_version, "Rust-branded version")?;
+    validate_contains(&readme, &branding.upstream_version, "upstream version")?;
+
+    println!(
+        "README.md references versions '{}' and '{}'",
+        branding.rust_version, branding.upstream_version
+    );
+
+    Ok(())
+}
+
+fn readme_contents(path: &Path) -> TaskResult<String> {
+    fs::read_to_string(path).map_err(|error| {
+        TaskError::Io(std::io::Error::new(
+            error.kind(),
+            format!("failed to read README at {}: {error}", path.display()),
+        ))
+    })
+}
+
+fn validate_contains(readme: &str, needle: &str, label: &str) -> TaskResult<()> {
+    if readme.contains(needle) {
+        Ok(())
+    } else {
+        Err(TaskError::Validation(format!(
+            "README.md is missing {label} '{needle}'"
+        )))
+    }
+}
+
+/// Returns usage text for the command.
+pub fn usage() -> String {
+    String::from(
+        "Usage: cargo xtask readme-version\n\nOptions:\n  -h, --help      Show this help message",
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_args_accepts_default_configuration() {
+        let options = parse_args(std::iter::empty()).expect("parse succeeds");
+        assert_eq!(options, ReadmeVersionOptions);
+    }
+
+    #[test]
+    fn parse_args_reports_help_request() {
+        let error = parse_args([OsString::from("--help")]).unwrap_err();
+        assert!(matches!(error, TaskError::Help(message) if message == usage()));
+    }
+
+    #[test]
+    fn parse_args_rejects_unknown_argument() {
+        let error = parse_args([OsString::from("--unknown")]).unwrap_err();
+        assert!(matches!(error, TaskError::Usage(message) if message.contains("readme-version")));
+    }
+
+    #[test]
+    fn validate_contains_accepts_present_version() {
+        validate_contains("rsync 3.4.1-rust", "3.4.1-rust", "rust version")
+            .expect("validation succeeds");
+    }
+
+    #[test]
+    fn validate_contains_rejects_missing_version() {
+        let error = validate_contains("rsync", "3.4.1", "upstream version").unwrap_err();
+        assert!(matches!(error, TaskError::Validation(message) if message.contains("README.md")));
+    }
+
+    #[test]
+    fn execute_reports_versions_present() {
+        let workspace = workspace::workspace_root().expect("resolve workspace root");
+        execute(&workspace, ReadmeVersionOptions).expect("workspace README matches versions");
+    }
+
+    mod workspace {
+        use super::*;
+
+        pub fn workspace_root() -> TaskResult<PathBuf> {
+            crate::workspace::workspace_root()
+        }
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -56,7 +56,8 @@ mod util;
 mod workspace;
 
 use crate::commands::{
-    branding, docs, enforce_limits, no_binaries, no_placeholders, package, preflight, sbom,
+    branding, docs, enforce_limits, no_binaries, no_placeholders, package, preflight,
+    readme_version, sbom,
 };
 use crate::error::TaskError;
 use crate::util::is_help_flag;
@@ -135,6 +136,11 @@ where
             let workspace = workspace_root()?;
             sbom::execute(&workspace, options)
         }
+        "readme-version" => {
+            let options = readme_version::parse_args(args)?;
+            let workspace = workspace_root()?;
+            readme_version::execute(&workspace, options)
+        }
         "package" => {
             let options = package::parse_args(args)?;
             let workspace = workspace_root()?;
@@ -147,9 +153,20 @@ where
 }
 
 fn top_level_usage() -> String {
-    String::from(
-        "Usage: cargo xtask <command>\n\nCommands:\n  branding         Validate workspace branding metadata\n  docs             Build API docs and run doctests\n  enforce-limits   Enforce source line and comment hygiene limits\n  no-binaries      Assert the git index contains no binary artifacts\n  no-placeholders  Ensure Rust sources are free from placeholder code\n  package          Build distribution artifacts (deb/rpm)\n  preflight        Run packaging preflight validation\n  sbom             Generate a CycloneDX SBOM for the workspace\n  help             Show this help message\n\nRun `cargo xtask <command> --help` for command-specific options.",
-    )
+    String::from(concat!(
+        "Usage: cargo xtask <command>\n\nCommands:\n",
+        "  branding         Validate workspace branding metadata\n",
+        "  docs            Build API docs and run doctests\n",
+        "  enforce-limits   Enforce source line and comment hygiene limits\n",
+        "  no-binaries      Assert the git index contains no binary artifacts\n",
+        "  no-placeholders  Ensure Rust sources are free from placeholder code\n",
+        "  package         Build distribution artifacts (deb/rpm)\n",
+        "  preflight        Run packaging preflight validation\n",
+        "  readme-version   Ensure README versions match workspace metadata\n",
+        "  sbom             Generate a CycloneDX SBOM for the workspace\n",
+        "  help             Show this help message\n\n",
+        "Run `cargo xtask <command> --help` for command-specific options."
+    ))
 }
 #[cfg(test)]
 mod tests {
@@ -159,5 +176,6 @@ mod tests {
     fn top_level_usage_mentions_enforce_limits_command() {
         let usage = top_level_usage();
         assert!(usage.contains("enforce-limits"));
+        assert!(usage.contains("readme-version"));
     }
 }


### PR DESCRIPTION
## Summary
- add an xtask `readme-version` command that validates the README lists the branded and upstream versions from workspace metadata
- expose the new command through the xtask dispatcher/help text with coverage in unit tests
- add a CI job that runs the README version check and gate the Linux test job on its result

## Testing
- cargo test -p xtask

------