### PR TITLE
Fix clippy unused import in readme version command

### DIFF
--- a/xtask/src/commands/readme_version.rs
+++ b/xtask/src/commands/readme_version.rs
@@ -14,7 +14,7 @@ use crate::util::is_help_flag;
 use crate::workspace::load_workspace_branding;
 use std::ffi::OsString;
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 /// Options accepted by the `readme-version` command.
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -87,6 +87,7 @@ pub fn usage() -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::PathBuf;
 
     #[test]
     fn parse_args_accepts_default_configuration() {


### PR DESCRIPTION
## Summary
- scope Path import in `readme_version` command to avoid an unused import warning
- reintroduce PathBuf for tests behind `cfg(test)`

## Testing
- cargo clippy --workspace --all-targets --all-features --locked -- -Dwarnings

------