### PR TITLE
Fix rsync-walk doc intra-doc links

### DIFF
--- a/crates/walk/src/lib.rs
+++ b/crates/walk/src/lib.rs
@@ -37,8 +37,9 @@
 //! # Errors
 //!
 //! Traversal emits [`WalkError`] when filesystem metadata cannot be queried or
-//! when reading directory contents fails. Callers can downcast to [`io::Error`]
-//! using [`WalkError::source`] to inspect the original failure.
+//! when reading directory contents fails. Callers can downcast to
+//! [`std::io::Error`] using [`std::error::Error::source`] to inspect the original
+//! failure.
 //!
 //! # Examples
 //!


### PR DESCRIPTION
## Summary
- update rsync-walk crate documentation to reference std::io::Error and std::error::Error::source
- ensure intra-doc links resolve correctly under cargo doc

## Testing
- cargo doc --workspace --no-deps

------