### PR TITLE
Fix stale enforce-limits override

### DIFF
--- a/tools/line_limits.toml
+++ b/tools/line_limits.toml
@@ -73,11 +73,6 @@ max_lines = 1745
 warn_lines = 1645
 
 [[overrides]]
-path = "crates/checksums/src/rolling.rs"
-max_lines = 1689
-warn_lines = 1589
-
-[[overrides]]
 path = "crates/protocol/src/version.rs"
 max_lines = 1651
 warn_lines = 1551


### PR DESCRIPTION
## Summary
- remove the outdated line-limit override that referenced `crates/checksums/src/rolling.rs`
- allow the enforce-limits task to validate the rolling checksum module files that now live under `crates/checksums/src/rolling/`

## Testing
- cargo run -p xtask -- enforce-limits

------