### PR TITLE
Remove redundant must_use attribute from rolling digest helper

### DIFF
--- a/crates/checksums/src/rolling/digest.rs
+++ b/crates/checksums/src/rolling/digest.rs
@@ -142,7 +142,6 @@ impl RollingDigest {
     /// # Errors
     ///
     /// Returns [`RollingSliceError`] when the slice does not contain exactly four bytes.
-    #[must_use]
     pub fn from_le_slice(bytes: &[u8], len: usize) -> Result<Self, RollingSliceError> {
         if bytes.len() != RollingSliceError::EXPECTED_LEN {
             return Err(RollingSliceError::new(bytes.len()));


### PR DESCRIPTION
## Summary
- remove the redundant #[must_use] attribute from `RollingDigest::from_le_slice` to satisfy clippy's double_must_use lint

## Testing
- cargo clippy --workspace --all-targets --all-features --locked -- -Dwarnings

------