### PR TITLE
Harden bandwidth limiter component handling for daemon overrides

### DIFF
--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -4255,13 +4255,13 @@ fn apply_module_bandwidth_limit(
     let burst_specified =
         module_burst_specified && (module_limit_configured || module_limit_specified);
 
-    apply_effective_limit(
-        limiter,
+    BandwidthLimitComponents::new_with_flags(
         module_limit,
-        limit_specified,
         module_burst,
+        limit_specified,
         burst_specified,
     )
+    .apply_to_limiter(limiter)
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/xtask/src/commands/branding.rs
+++ b/xtask/src/commands/branding.rs
@@ -104,7 +104,10 @@ fn validate_branding(branding: &WorkspaceBranding) -> TaskResult<()> {
         )));
     }
 
-    if !branding.rust_version.starts_with(&branding.upstream_version) {
+    if !branding
+        .rust_version
+        .starts_with(&branding.upstream_version)
+    {
         return Err(TaskError::Validation(format!(
             "rust_version '{}' must include upstream_version '{}' prefix",
             branding.rust_version, branding.upstream_version


### PR DESCRIPTION
## Summary
- add `BandwidthLimitComponents::new_with_flags` and `apply_to_limiter` so callers can forward specification flags without duplicating limiter logic
- extend the bandwidth parser tests to cover unlimited burst overrides and explicit flag propagation
- reuse the new helper when applying daemon module `bwlimit` directives and format the branding validator consistently

## Testing
- cargo test -p rsync-bandwidth

------