### PR TITLE
Fix bandwidth limiter burst clearing semantics

### DIFF
--- a/crates/bandwidth/src/parse.rs
+++ b/crates/bandwidth/src/parse.rs
@@ -48,7 +48,11 @@ impl BandwidthLimitComponents {
         let has_rate = rate.is_some();
         let effective_limit_specified = if has_rate { true } else { limit_specified };
         let effective_burst = if burst_specified { burst } else { None };
-        let effective_burst_specified = effective_burst.is_some() && burst_specified;
+        let effective_burst_specified = if has_rate {
+            burst_specified
+        } else {
+            effective_burst.is_some() && burst_specified
+        };
 
         Self {
             rate,

--- a/crates/bandwidth/src/parse/tests.rs
+++ b/crates/bandwidth/src/parse/tests.rs
@@ -302,6 +302,16 @@ fn new_with_flags_forces_limit_specified_when_rate_present() {
 }
 
 #[test]
+fn new_with_flags_tracks_explicit_burst_clearing_with_rate() {
+    let limit = NonZeroU64::new(4096).expect("limit");
+    let components = BandwidthLimitComponents::new_with_flags(Some(limit), None, false, true);
+
+    assert!(components.limit_specified());
+    assert!(components.burst_specified());
+    assert!(components.burst().is_none());
+}
+
+#[test]
 fn components_into_limiter_returns_none_when_unlimited() {
     let components = BandwidthLimitComponents::new(None, NonZeroU64::new(4096));
     assert!(components.into_limiter().is_none());

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -209,7 +209,7 @@ use rsync_checksums::strong::Md5;
 use rsync_core::{
     bandwidth::{
         BandwidthLimitComponents, BandwidthLimiter, BandwidthParseError, LimiterChange,
-        apply_effective_limit, parse_bandwidth_limit,
+        parse_bandwidth_limit,
     },
     branding::{self, Brand, manifest},
     fallback::{


### PR DESCRIPTION
## Summary
- ensure `BandwidthLimitComponents::new_with_flags` preserves explicit burst clearing requests when a rate is provided
- add a regression test covering the burst-clearing scenario
- drop the now-unused daemon import of `apply_effective_limit`

## Testing
- cargo test -p rsync-daemon module_bwlimit_zero_burst_clears_existing_burst
- cargo clippy -p rsync-daemon --all-targets -- -Dwarnings

------