### PR TITLE
Split bandwidth parser into focused modules

### DIFF
--- a/crates/bandwidth/proptest-regressions/parse/tests.txt
+++ b/crates/bandwidth/proptest-regressions/parse/tests.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 2656a422f3a1f888a98cdb87bf082e1c645c449512fefead95e4dd98673f1903 # shrinks to value = 1

--- a/crates/bandwidth/src/parse/argument.rs
+++ b/crates/bandwidth/src/parse/argument.rs
@@ -1,269 +1,8 @@
-use std::error::Error;
-use std::fmt;
 use std::num::NonZeroU64;
 use std::str::FromStr;
 
-use crate::limiter::{BandwidthLimiter, LimiterChange, apply_effective_limit};
-
-/// Parsed `--bwlimit` components consisting of an optional rate and burst size.
-///
-/// In addition to the negotiated byte-per-second rate, the structure records
-/// whether the user explicitly supplied the limit. This allows callers to
-/// distinguish between inherited defaults and requests such as `--bwlimit=0`
-/// that disable throttling while remaining user-driven decisions.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct BandwidthLimitComponents {
-    rate: Option<NonZeroU64>,
-    burst: Option<NonZeroU64>,
-    limit_specified: bool,
-    burst_specified: bool,
-}
-
-impl BandwidthLimitComponents {
-    /// Constructs a new component set from the provided parts.
-    ///
-    /// When the rate is `None` the combination represents an unlimited
-    /// configuration. Upstream rsync ignores any burst component in that case,
-    /// so the helper mirrors that behaviour by discarding the supplied burst.
-    #[must_use]
-    pub const fn new(rate: Option<NonZeroU64>, burst: Option<NonZeroU64>) -> Self {
-        Self::new_internal(rate, burst, rate.is_some(), burst.is_some())
-    }
-
-    /// Constructs a component set while explicitly controlling the specification flags.
-    ///
-    /// The helper mirrors upstream precedence rules where callers may need to
-    /// distinguish between inherited defaults and user-supplied overrides.  It
-    /// preserves explicit burst components even when the limit is unlimited so
-    /// daemon modules can override the negotiated burst while keeping the
-    /// existing limiter active.  When a rate is provided, the combination always
-    /// records that a limit was specified to reflect the caller's intent.
-    #[must_use]
-    pub const fn new_with_flags(
-        rate: Option<NonZeroU64>,
-        burst: Option<NonZeroU64>,
-        limit_specified: bool,
-        burst_specified: bool,
-    ) -> Self {
-        let has_rate = rate.is_some();
-        let effective_limit_specified = if has_rate { true } else { limit_specified };
-        let effective_burst = if burst_specified { burst } else { None };
-        let effective_burst_specified = if has_rate {
-            burst_specified
-        } else {
-            effective_burst.is_some() && burst_specified
-        };
-
-        Self {
-            rate,
-            burst: effective_burst,
-            limit_specified: effective_limit_specified,
-            burst_specified: effective_burst_specified,
-        }
-    }
-
-    /// Returns a component set that disables throttling.
-    ///
-    /// Upstream rsync treats `--bwlimit=0` as unlimited, ignoring any optional
-    /// burst parameter. Providing an explicit constructor avoids sprinkling
-    /// `None` pairs throughout the codebase while making the intent of
-    /// "unlimited" limits clear at the call site. The helper is `const` so it
-    /// can be used in static initialisers and default values.
-    #[must_use]
-    pub const fn unlimited() -> Self {
-        Self::new_internal(None, None, false, false)
-    }
-
-    /// Constructs a new component set and records whether the burst component
-    /// was explicitly supplied.
-    #[must_use]
-    pub const fn new_with_specified(
-        rate: Option<NonZeroU64>,
-        burst: Option<NonZeroU64>,
-        burst_specified: bool,
-    ) -> Self {
-        Self::new_internal(rate, burst, rate.is_some(), burst_specified)
-    }
-
-    const fn new_internal(
-        rate: Option<NonZeroU64>,
-        burst: Option<NonZeroU64>,
-        limit_specified: bool,
-        burst_specified: bool,
-    ) -> Self {
-        let has_rate = rate.is_some();
-        let effective_limit_specified = if has_rate { true } else { limit_specified };
-        let effective_burst = if has_rate { burst } else { None };
-        let effective_burst_specified = if has_rate { burst_specified } else { false };
-
-        Self {
-            rate,
-            burst: effective_burst,
-            limit_specified: effective_limit_specified,
-            burst_specified: effective_burst_specified,
-        }
-    }
-
-    /// Returns the configured byte-per-second rate, if any.
-    #[must_use]
-    pub const fn rate(&self) -> Option<NonZeroU64> {
-        self.rate
-    }
-
-    /// Returns the configured burst size in bytes, if any.
-    #[must_use]
-    pub const fn burst(&self) -> Option<NonZeroU64> {
-        self.burst
-    }
-
-    /// Indicates whether a burst component was explicitly specified.
-    #[must_use]
-    pub const fn burst_specified(&self) -> bool {
-        self.burst_specified
-    }
-
-    /// Indicates whether the rate component was explicitly specified.
-    #[must_use]
-    pub const fn limit_specified(&self) -> bool {
-        self.limit_specified
-    }
-
-    /// Indicates whether the limit disables throttling.
-    #[must_use]
-    pub const fn is_unlimited(self) -> bool {
-        self.rate.is_none()
-    }
-
-    /// Converts the parsed components into a [`BandwidthLimiter`].
-    ///
-    /// When the rate component is absent (representing an unlimited
-    /// configuration), the method returns `None`. Otherwise the limiter mirrors
-    /// upstream rsync's token bucket by honouring the optional burst size.
-    #[must_use]
-    pub fn to_limiter(&self) -> Option<BandwidthLimiter> {
-        self.rate()
-            .map(|rate| BandwidthLimiter::with_burst(rate, self.burst()))
-    }
-
-    /// Consumes the components and constructs a [`BandwidthLimiter`].
-    ///
-    /// The behaviour matches [`Self::to_limiter`]; the by-value variant avoids
-    /// cloning when the caller wishes to move ownership of the parsed
-    /// components.
-    #[must_use]
-    pub fn into_limiter(self) -> Option<BandwidthLimiter> {
-        self.rate
-            .map(|rate| BandwidthLimiter::with_burst(rate, self.burst))
-    }
-
-    /// Applies the component set to an existing limiter, mirroring rsync's precedence rules.
-    ///
-    /// The helper forwards to [`apply_effective_limit`] so higher layers do not
-    /// have to thread individual specification flags through their call sites.
-    /// It returns the resulting [`LimiterChange`], allowing callers to surface
-    /// diagnostics or skip follow-up work when no adjustments were required.
-    pub fn apply_to_limiter(&self, limiter: &mut Option<BandwidthLimiter>) -> LimiterChange {
-        apply_effective_limit(
-            limiter,
-            self.rate,
-            self.limit_specified,
-            self.burst,
-            self.burst_specified,
-        )
-    }
-
-    /// Returns a new component set that applies an overriding cap to the current configuration.
-    ///
-    /// The method mirrors upstream rsync's precedence rules when a daemon module defines its own
-    /// `bwlimit`. The strictest byte-per-second rate wins while explicitly configured burst sizes
-    /// take effect. When the override disables throttling altogether (for example `bwlimit = 0`)
-    /// the resulting component becomes unlimited, even if the caller previously supplied a rate.
-    /// This allows higher layers to reason about the effective limiter without materialising a
-    /// [`BandwidthLimiter`] instance solely to combine configuration sources.
-    #[must_use]
-    pub fn constrained_by(&self, override_components: &Self) -> Self {
-        let mut rate = self.rate;
-        let mut burst = self.burst;
-        let limit_specified = self.limit_specified || override_components.limit_specified;
-        let mut burst_specified = self.burst_specified;
-        let had_limit = self.rate.is_some();
-
-        if override_components.limit_specified {
-            match override_components.rate {
-                Some(override_rate) => {
-                    rate = match rate {
-                        Some(existing) => Some(existing.min(override_rate)),
-                        None => Some(override_rate),
-                    };
-
-                    if override_components.burst_specified {
-                        burst = override_components.burst;
-                        burst_specified = true;
-                    } else if !had_limit {
-                        burst = None;
-                        burst_specified = false;
-                    }
-                }
-                None => {
-                    rate = None;
-                    burst = None;
-                    burst_specified = false;
-                }
-            }
-        }
-
-        if override_components.burst_specified
-            && !override_components.limit_specified
-            && rate.is_some()
-        {
-            burst = override_components.burst;
-            burst_specified = true;
-        }
-
-        Self::new_internal(rate, burst, limit_specified, burst_specified)
-    }
-}
-
-impl FromStr for BandwidthLimitComponents {
-    type Err = BandwidthParseError;
-
-    fn from_str(text: &str) -> Result<Self, Self::Err> {
-        parse_bandwidth_limit(text)
-    }
-}
-
-impl Default for BandwidthLimitComponents {
-    fn default() -> Self {
-        Self::unlimited()
-    }
-}
-
-/// Errors returned when parsing a bandwidth limit fails.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum BandwidthParseError {
-    /// The argument did not follow rsync's recognised syntax.
-    Invalid,
-    /// The requested rate was too small (less than 512 bytes per second).
-    TooSmall,
-    /// The requested rate overflowed the supported range.
-    TooLarge,
-}
-
-impl fmt::Display for BandwidthParseError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let description = match self {
-            BandwidthParseError::Invalid => "invalid bandwidth limit syntax",
-            BandwidthParseError::TooSmall => {
-                "bandwidth limit is below the minimum of 512 bytes per second"
-            }
-            BandwidthParseError::TooLarge => "bandwidth limit exceeds the supported range",
-        };
-
-        f.write_str(description)
-    }
-}
-
-impl Error for BandwidthParseError {}
+use super::components::BandwidthLimitComponents;
+use super::error::BandwidthParseError;
 
 /// Parses a `--bwlimit` style argument into an optional byte-per-second limit.
 #[doc(alias = "--bwlimit")]
@@ -486,6 +225,7 @@ pub fn parse_bandwidth_argument(text: &str) -> Result<Option<NonZeroU64>, Bandwi
         .ok_or(BandwidthParseError::TooLarge)?;
 
     let bytes_u64 = u64::try_from(rounded_bytes).map_err(|_| BandwidthParseError::TooLarge)?;
+
     NonZeroU64::new(bytes_u64)
         .ok_or(BandwidthParseError::TooSmall)
         .map(Some)
@@ -520,7 +260,17 @@ pub fn parse_bandwidth_limit(text: &str) -> Result<BandwidthLimitComponents, Ban
     }
 }
 
-fn parse_decimal_with_exponent(text: &str) -> Result<(u128, u128, u128, i32), BandwidthParseError> {
+impl FromStr for BandwidthLimitComponents {
+    type Err = BandwidthParseError;
+
+    fn from_str(text: &str) -> Result<Self, Self::Err> {
+        parse_bandwidth_limit(text)
+    }
+}
+
+pub(super) fn parse_decimal_with_exponent(
+    text: &str,
+) -> Result<(u128, u128, u128, i32), BandwidthParseError> {
     let (mantissa_text, exponent_text) = if let Some(position) = text.find(['e', 'E']) {
         let (mantissa, exponent) = text.split_at(position);
         let exponent = &exponent[1..];
@@ -547,7 +297,9 @@ fn parse_decimal_with_exponent(text: &str) -> Result<(u128, u128, u128, i32), Ba
     Ok((integer, fraction, denominator, exponent))
 }
 
-fn parse_decimal_mantissa(text: &str) -> Result<(u128, u128, u128), BandwidthParseError> {
+pub(super) fn parse_decimal_mantissa(
+    text: &str,
+) -> Result<(u128, u128, u128), BandwidthParseError> {
     let mut integer = 0u128;
     let mut fraction = 0u128;
     let mut denominator = 1u128;
@@ -585,7 +337,7 @@ fn parse_decimal_mantissa(text: &str) -> Result<(u128, u128, u128), BandwidthPar
     Ok((integer, fraction, denominator))
 }
 
-fn pow_u128(base: u32, exponent: u32) -> Result<u128, BandwidthParseError> {
+pub(super) fn pow_u128(base: u32, exponent: u32) -> Result<u128, BandwidthParseError> {
     let mut result = 1u128;
     let mut factor = u128::from(base);
     let mut exp = exponent;
@@ -607,6 +359,3 @@ fn pow_u128(base: u32, exponent: u32) -> Result<u128, BandwidthParseError> {
 
     Ok(result)
 }
-
-#[cfg(test)]
-mod tests;

--- a/crates/bandwidth/src/parse/components.rs
+++ b/crates/bandwidth/src/parse/components.rs
@@ -1,0 +1,228 @@
+use std::num::NonZeroU64;
+
+use crate::limiter::{BandwidthLimiter, LimiterChange, apply_effective_limit};
+
+/// Parsed `--bwlimit` components consisting of an optional rate and burst size.
+///
+/// In addition to the negotiated byte-per-second rate, the structure records
+/// whether the user explicitly supplied the limit. This allows callers to
+/// distinguish between inherited defaults and requests such as `--bwlimit=0`
+/// that disable throttling while remaining user-driven decisions.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct BandwidthLimitComponents {
+    rate: Option<NonZeroU64>,
+    burst: Option<NonZeroU64>,
+    limit_specified: bool,
+    burst_specified: bool,
+}
+
+impl BandwidthLimitComponents {
+    /// Constructs a new component set from the provided parts.
+    ///
+    /// When the rate is `None` the combination represents an unlimited
+    /// configuration. Upstream rsync ignores any burst component in that case,
+    /// so the helper mirrors that behaviour by discarding the supplied burst.
+    #[must_use]
+    pub const fn new(rate: Option<NonZeroU64>, burst: Option<NonZeroU64>) -> Self {
+        Self::new_internal(rate, burst, rate.is_some(), burst.is_some())
+    }
+
+    /// Constructs a component set while explicitly controlling the specification flags.
+    ///
+    /// The helper mirrors upstream precedence rules where callers may need to
+    /// distinguish between inherited defaults and user-supplied overrides.  It
+    /// preserves explicit burst components even when the limit is unlimited so
+    /// daemon modules can override the negotiated burst while keeping the
+    /// existing limiter active.  When a rate is provided, the combination always
+    /// records that a limit was specified to reflect the caller's intent.
+    #[must_use]
+    pub const fn new_with_flags(
+        rate: Option<NonZeroU64>,
+        burst: Option<NonZeroU64>,
+        limit_specified: bool,
+        burst_specified: bool,
+    ) -> Self {
+        let has_rate = rate.is_some();
+        let effective_limit_specified = if has_rate { true } else { limit_specified };
+        let effective_burst = if burst_specified { burst } else { None };
+        let effective_burst_specified = if has_rate {
+            burst_specified
+        } else {
+            effective_burst.is_some() && burst_specified
+        };
+
+        Self {
+            rate,
+            burst: effective_burst,
+            limit_specified: effective_limit_specified,
+            burst_specified: effective_burst_specified,
+        }
+    }
+
+    /// Returns a component set that disables throttling.
+    ///
+    /// Upstream rsync treats `--bwlimit=0` as unlimited, ignoring any optional
+    /// burst parameter. Providing an explicit constructor avoids sprinkling
+    /// `None` pairs throughout the codebase while making the intent of
+    /// "unlimited" limits clear at the call site. The helper is `const` so it
+    /// can be used in static initialisers and default values.
+    #[must_use]
+    pub const fn unlimited() -> Self {
+        Self::new_internal(None, None, false, false)
+    }
+
+    /// Constructs a new component set and records whether the burst component
+    /// was explicitly supplied.
+    #[must_use]
+    pub const fn new_with_specified(
+        rate: Option<NonZeroU64>,
+        burst: Option<NonZeroU64>,
+        burst_specified: bool,
+    ) -> Self {
+        Self::new_internal(rate, burst, rate.is_some(), burst_specified)
+    }
+
+    pub(super) const fn new_internal(
+        rate: Option<NonZeroU64>,
+        burst: Option<NonZeroU64>,
+        limit_specified: bool,
+        burst_specified: bool,
+    ) -> Self {
+        let has_rate = rate.is_some();
+        let effective_limit_specified = if has_rate { true } else { limit_specified };
+        let effective_burst = if has_rate { burst } else { None };
+        let effective_burst_specified = if has_rate { burst_specified } else { false };
+
+        Self {
+            rate,
+            burst: effective_burst,
+            limit_specified: effective_limit_specified,
+            burst_specified: effective_burst_specified,
+        }
+    }
+
+    /// Returns the configured byte-per-second rate, if any.
+    #[must_use]
+    pub const fn rate(&self) -> Option<NonZeroU64> {
+        self.rate
+    }
+
+    /// Returns the configured burst size in bytes, if any.
+    #[must_use]
+    pub const fn burst(&self) -> Option<NonZeroU64> {
+        self.burst
+    }
+
+    /// Indicates whether a burst component was explicitly specified.
+    #[must_use]
+    pub const fn burst_specified(&self) -> bool {
+        self.burst_specified
+    }
+
+    /// Indicates whether the rate component was explicitly specified.
+    #[must_use]
+    pub const fn limit_specified(&self) -> bool {
+        self.limit_specified
+    }
+
+    /// Indicates whether the limit disables throttling.
+    #[must_use]
+    pub const fn is_unlimited(self) -> bool {
+        self.rate.is_none()
+    }
+
+    /// Converts the parsed components into a [`BandwidthLimiter`].
+    ///
+    /// When the rate component is absent (representing an unlimited
+    /// configuration), the method returns `None`. Otherwise the limiter mirrors
+    /// upstream rsync's token bucket by honouring the optional burst size.
+    #[must_use]
+    pub fn to_limiter(&self) -> Option<BandwidthLimiter> {
+        self.rate()
+            .map(|rate| BandwidthLimiter::with_burst(rate, self.burst()))
+    }
+
+    /// Consumes the components and constructs a [`BandwidthLimiter`].
+    ///
+    /// The behaviour matches [`Self::to_limiter`]; the by-value variant avoids
+    /// cloning when the caller wishes to move ownership of the parsed
+    /// components.
+    #[must_use]
+    pub fn into_limiter(self) -> Option<BandwidthLimiter> {
+        self.rate
+            .map(|rate| BandwidthLimiter::with_burst(rate, self.burst))
+    }
+
+    /// Applies the component set to an existing limiter, mirroring rsync's precedence rules.
+    ///
+    /// The helper forwards to [`apply_effective_limit`] so higher layers do not
+    /// have to thread individual specification flags through their call sites.
+    /// It returns the resulting [`LimiterChange`], allowing callers to surface
+    /// diagnostics or skip follow-up work when no adjustments were required.
+    pub fn apply_to_limiter(&self, limiter: &mut Option<BandwidthLimiter>) -> LimiterChange {
+        apply_effective_limit(
+            limiter,
+            self.rate,
+            self.limit_specified,
+            self.burst,
+            self.burst_specified,
+        )
+    }
+
+    /// Returns a new component set that applies an overriding cap to the current configuration.
+    ///
+    /// The method mirrors upstream rsync's precedence rules when a daemon module defines its own
+    /// `bwlimit`. The strictest byte-per-second rate wins while explicitly configured burst sizes
+    /// take effect. When the override disables throttling altogether (for example `bwlimit = 0`)
+    /// the resulting component becomes unlimited, even if the caller previously supplied a rate.
+    /// This allows higher layers to reason about the effective limiter without materialising a
+    /// [`BandwidthLimiter`] instance solely to combine configuration sources.
+    #[must_use]
+    pub fn constrained_by(&self, override_components: &Self) -> Self {
+        let mut rate = self.rate;
+        let mut burst = self.burst;
+        let limit_specified = self.limit_specified || override_components.limit_specified;
+        let mut burst_specified = self.burst_specified;
+        let had_limit = self.rate.is_some();
+
+        if override_components.limit_specified {
+            match override_components.rate {
+                Some(override_rate) => {
+                    rate = match rate {
+                        Some(existing) => Some(existing.min(override_rate)),
+                        None => Some(override_rate),
+                    };
+
+                    if override_components.burst_specified {
+                        burst = override_components.burst;
+                        burst_specified = true;
+                    } else if !had_limit {
+                        burst = None;
+                        burst_specified = false;
+                    }
+                }
+                None => {
+                    rate = None;
+                    burst = None;
+                    burst_specified = false;
+                }
+            }
+        }
+
+        if override_components.burst_specified
+            && !override_components.limit_specified
+            && rate.is_some()
+        {
+            burst = override_components.burst;
+            burst_specified = true;
+        }
+
+        Self::new_internal(rate, burst, limit_specified, burst_specified)
+    }
+}
+
+impl Default for BandwidthLimitComponents {
+    fn default() -> Self {
+        Self::unlimited()
+    }
+}

--- a/crates/bandwidth/src/parse/error.rs
+++ b/crates/bandwidth/src/parse/error.rs
@@ -1,0 +1,29 @@
+use std::error::Error;
+use std::fmt;
+
+/// Errors returned when parsing a bandwidth limit fails.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum BandwidthParseError {
+    /// The argument did not follow rsync's recognised syntax.
+    Invalid,
+    /// The requested rate was too small (less than 512 bytes per second).
+    TooSmall,
+    /// The requested rate overflowed the supported range.
+    TooLarge,
+}
+
+impl fmt::Display for BandwidthParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let description = match self {
+            BandwidthParseError::Invalid => "invalid bandwidth limit syntax",
+            BandwidthParseError::TooSmall => {
+                "bandwidth limit is below the minimum of 512 bytes per second"
+            }
+            BandwidthParseError::TooLarge => "bandwidth limit exceeds the supported range",
+        };
+
+        f.write_str(description)
+    }
+}
+
+impl Error for BandwidthParseError {}

--- a/crates/bandwidth/src/parse/mod.rs
+++ b/crates/bandwidth/src/parse/mod.rs
@@ -1,0 +1,10 @@
+mod argument;
+mod components;
+mod error;
+
+pub use argument::{parse_bandwidth_argument, parse_bandwidth_limit};
+pub use components::BandwidthLimitComponents;
+pub use error::BandwidthParseError;
+
+#[cfg(test)]
+mod tests;

--- a/crates/bandwidth/src/parse/tests.rs
+++ b/crates/bandwidth/src/parse/tests.rs
@@ -1,6 +1,6 @@
+use super::argument::pow_u128;
 use super::{
     BandwidthLimitComponents, BandwidthParseError, parse_bandwidth_argument, parse_bandwidth_limit,
-    pow_u128,
 };
 use crate::limiter::{BandwidthLimiter, LimiterChange};
 use proptest::prelude::*;


### PR DESCRIPTION
## Summary
- split the bandwidth parsing logic into dedicated `argument`, `components`, and `error` modules to keep each source below the hygiene limits while preserving documentation
- keep the existing parsing behaviour intact by re-exporting the same public API from `parse::mod` and centralising helper visibility for intra-module cooperation
- record the failing proptest seed encountered during the refactor so the regression harness exercises it on future runs

## Testing
- cargo test -p rsync-bandwidth

------