### PR TITLE
Add release validation xtask command

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,12 @@ Rebuild the API documentation and run doctests via the workspace helper:
 cargo run -p xtask -- docs
 ```
 
+Run the aggregated release-readiness checks before cutting a build:
+
+```bash
+cargo run -p xtask -- release
+```
+
 Generate a CycloneDX SBOM for packaging via the workspace helper:
 
 ```bash

--- a/xtask/src/commands/mod.rs
+++ b/xtask/src/commands/mod.rs
@@ -6,4 +6,5 @@ pub mod no_placeholders;
 pub mod package;
 pub mod preflight;
 pub mod readme_version;
+pub mod release;
 pub mod sbom;

--- a/xtask/src/commands/preflight/validation.rs
+++ b/xtask/src/commands/preflight/validation.rs
@@ -5,6 +5,7 @@ use serde_json::Value as JsonValue;
 use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
+use toml::Value;
 
 mod packaging;
 

--- a/xtask/src/commands/preflight/validation/packaging.rs
+++ b/xtask/src/commands/preflight/validation/packaging.rs
@@ -5,7 +5,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use toml::{Value, value::Table as TomlTable};
 
-pub(super) fn validate_packaging_assets(
+pub(crate) fn validate_packaging_assets(
     workspace: &Path,
     branding: &WorkspaceBranding,
 ) -> TaskResult<()> {

--- a/xtask/src/commands/release.rs
+++ b/xtask/src/commands/release.rs
@@ -1,0 +1,189 @@
+use crate::commands::{
+    docs::{self, DocsOptions},
+    enforce_limits::{self, EnforceLimitsOptions},
+    no_binaries::{self, NoBinariesOptions},
+    no_placeholders::{self, NoPlaceholdersOptions},
+    preflight::{self, PreflightOptions},
+    readme_version::{self, ReadmeVersionOptions},
+};
+use crate::error::{TaskError, TaskResult};
+use crate::util::is_help_flag;
+use std::ffi::OsString;
+use std::path::Path;
+
+/// Options accepted by the `release` command.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct ReleaseOptions {
+    /// Skip rebuilding API documentation and doctests.
+    pub skip_docs: bool,
+    /// Skip source line-count enforcement checks.
+    pub skip_hygiene: bool,
+    /// Skip placeholder scans for Rust sources.
+    pub skip_placeholder_scan: bool,
+    /// Skip auditing the git index for tracked binary artifacts.
+    pub skip_binary_scan: bool,
+}
+
+/// Parses CLI arguments for the `release` command.
+pub fn parse_args<I>(args: I) -> TaskResult<ReleaseOptions>
+where
+    I: IntoIterator<Item = OsString>,
+{
+    let mut options = ReleaseOptions::default();
+
+    for arg in args.into_iter() {
+        if is_help_flag(&arg) {
+            return Err(TaskError::Help(usage()));
+        }
+
+        match arg.to_string_lossy().as_ref() {
+            "--skip-docs" => {
+                ensure_flag_unused(options.skip_docs, "--skip-docs")?;
+                options.skip_docs = true;
+            }
+            "--skip-hygiene" => {
+                ensure_flag_unused(options.skip_hygiene, "--skip-hygiene")?;
+                options.skip_hygiene = true;
+            }
+            "--skip-placeholder-scan" => {
+                ensure_flag_unused(options.skip_placeholder_scan, "--skip-placeholder-scan")?;
+                options.skip_placeholder_scan = true;
+            }
+            "--skip-binary-scan" => {
+                ensure_flag_unused(options.skip_binary_scan, "--skip-binary-scan")?;
+                options.skip_binary_scan = true;
+            }
+            other => {
+                return Err(TaskError::Usage(format!(
+                    "unrecognised argument '{other}' for release command"
+                )));
+            }
+        }
+    }
+
+    Ok(options)
+}
+
+fn ensure_flag_unused(already_set: bool, flag: &str) -> TaskResult<()> {
+    if already_set {
+        Err(TaskError::Usage(format!(
+            "{flag} was specified multiple times"
+        )))
+    } else {
+        Ok(())
+    }
+}
+
+/// Executes the `release` command.
+pub fn execute(workspace: &Path, options: ReleaseOptions) -> TaskResult<()> {
+    let mut executed_steps = Vec::new();
+    let mut skipped_steps = Vec::new();
+
+    if options.skip_binary_scan {
+        skipped_steps.push("no-binaries");
+    } else {
+        no_binaries::execute(workspace, NoBinariesOptions)?;
+        executed_steps.push("no-binaries");
+    }
+
+    preflight::execute(workspace, PreflightOptions)?;
+    executed_steps.push("preflight");
+
+    readme_version::execute(workspace, ReadmeVersionOptions)?;
+    executed_steps.push("readme-version");
+
+    if options.skip_docs {
+        skipped_steps.push("docs");
+    } else {
+        docs::execute(workspace, DocsOptions::default())?;
+        executed_steps.push("docs");
+    }
+
+    if options.skip_hygiene {
+        skipped_steps.push("enforce-limits");
+    } else {
+        enforce_limits::execute(workspace, EnforceLimitsOptions::default())?;
+        executed_steps.push("enforce-limits");
+    }
+
+    if options.skip_placeholder_scan {
+        skipped_steps.push("no-placeholders");
+    } else {
+        no_placeholders::execute(workspace, NoPlaceholdersOptions)?;
+        executed_steps.push("no-placeholders");
+    }
+
+    if skipped_steps.is_empty() {
+        println!(
+            "Release validation complete. Executed steps: {}.",
+            executed_steps.join(", ")
+        );
+    } else {
+        println!(
+            "Release validation complete. Executed: {}; skipped: {}.",
+            executed_steps.join(", "),
+            skipped_steps.join(", ")
+        );
+    }
+
+    Ok(())
+}
+
+/// Returns usage text for the command.
+pub fn usage() -> String {
+    String::from(
+        "Usage: cargo xtask release [OPTIONS]\n\nOptions:\n  --skip-docs                Skip building docs and running doctests\n  --skip-hygiene            Skip enforce-limits line-count checks\n  --skip-placeholder-scan   Skip placeholder detection scans\n  --skip-binary-scan        Skip checking the git index for binary files\n  -h, --help                Show this help message",
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::workspace;
+
+    #[test]
+    fn parse_args_accepts_default_configuration() {
+        let options = parse_args(std::iter::empty()).expect("parse succeeds");
+        assert_eq!(options, ReleaseOptions::default());
+    }
+
+    #[test]
+    fn parse_args_recognises_all_skip_flags() {
+        let args = [
+            OsString::from("--skip-docs"),
+            OsString::from("--skip-hygiene"),
+            OsString::from("--skip-placeholder-scan"),
+            OsString::from("--skip-binary-scan"),
+        ];
+        let options = parse_args(args).expect("parse succeeds");
+        assert!(options.skip_docs);
+        assert!(options.skip_hygiene);
+        assert!(options.skip_placeholder_scan);
+        assert!(options.skip_binary_scan);
+    }
+
+    #[test]
+    fn parse_args_rejects_duplicate_flags() {
+        let args = [OsString::from("--skip-docs"), OsString::from("--skip-docs")];
+        let error = parse_args(args).unwrap_err();
+        assert!(matches!(error, TaskError::Usage(message) if message.contains("skip-docs")));
+    }
+
+    #[test]
+    fn parse_args_reports_help_request() {
+        let error = parse_args([OsString::from("--help")]).unwrap_err();
+        assert!(matches!(error, TaskError::Help(message) if message == usage()));
+    }
+
+    #[test]
+    fn execute_runs_core_checks_when_optional_steps_skipped() {
+        let workspace = workspace::workspace_root().expect("workspace root");
+        let options = ReleaseOptions {
+            skip_docs: true,
+            skip_hygiene: true,
+            skip_placeholder_scan: true,
+            skip_binary_scan: true,
+        };
+        execute(&workspace, options).expect("release validation succeeds");
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -55,7 +55,7 @@ mod workspace;
 
 use crate::commands::{
     branding, docs, enforce_limits, no_binaries, no_placeholders, package, preflight,
-    readme_version, sbom,
+    readme_version, release, sbom,
 };
 use crate::error::TaskError;
 use crate::util::is_help_flag;
@@ -129,6 +129,11 @@ where
             let workspace = workspace_root()?;
             preflight::execute(&workspace, options)
         }
+        "release" => {
+            let options = release::parse_args(args)?;
+            let workspace = workspace_root()?;
+            release::execute(&workspace, options)
+        }
         "sbom" => {
             let options = sbom::parse_args(args)?;
             let workspace = workspace_root()?;
@@ -160,6 +165,7 @@ fn top_level_usage() -> String {
         "  no-placeholders  Ensure Rust sources are free from placeholder code\n",
         "  package         Build distribution artifacts (deb/rpm)\n",
         "  preflight        Run packaging preflight validation\n",
+        "  release         Run aggregated release-readiness checks\n",
         "  readme-version   Ensure README versions match workspace metadata\n",
         "  sbom             Generate a CycloneDX SBOM for the workspace\n",
         "  help             Show this help message\n\n",
@@ -175,5 +181,6 @@ mod tests {
         let usage = top_level_usage();
         assert!(usage.contains("enforce-limits"));
         assert!(usage.contains("readme-version"));
+        assert!(usage.contains("release"));
     }
 }


### PR DESCRIPTION
## Summary
- add a `cargo xtask release` helper that orchestrates documentation, packaging, hygiene, and placeholder checks
- expose the release helper through the main xtask entry point and document it in the README
- adjust preflight validation imports to keep packaging checks accessible after the new command reuse

## Testing
- `cargo test -p xtask`

------