### PR TITLE
Refactor CLI out-format module into focused submodules

### DIFF
--- a/crates/cli/src/out_format/mod.rs
+++ b/crates/cli/src/out_format/mod.rs
@@ -1,0 +1,9 @@
+#![deny(unsafe_code)]
+
+mod parser;
+mod render;
+mod tokens;
+
+pub(crate) use parser::parse_out_format;
+pub(crate) use render::emit_out_format;
+pub(crate) use tokens::{OutFormat, OutFormatContext};

--- a/crates/cli/src/out_format/parser.rs
+++ b/crates/cli/src/out_format/parser.rs
@@ -1,0 +1,209 @@
+#![deny(unsafe_code)]
+
+//! Parser for command-line supplied `--out-format` specifications.
+
+use std::ffi::OsStr;
+
+use rsync_core::message::{Message, Role};
+use rsync_core::rsync_error;
+
+use super::tokens::{OutFormat, OutFormatPlaceholder, OutFormatToken};
+
+/// Parses a command-line supplied `--out-format` specification into tokens.
+pub(crate) fn parse_out_format(value: &OsStr) -> Result<OutFormat, Message> {
+    let text = value.to_string_lossy();
+    if text.is_empty() {
+        return Err(rsync_error!(1, "--out-format value must not be empty").with_role(Role::Client));
+    }
+
+    let mut tokens = Vec::new();
+    let mut literal = String::new();
+    let mut chars = text.chars();
+    while let Some(ch) = chars.next() {
+        match ch {
+            '%' => {
+                let Some(next) = chars.next() else {
+                    return Err(rsync_error!(1, "--out-format value may not end with '%'")
+                        .with_role(Role::Client));
+                };
+                match next {
+                    '%' => literal.push('%'),
+                    'n' => {
+                        if !literal.is_empty() {
+                            tokens.push(OutFormatToken::Literal(std::mem::take(&mut literal)));
+                        }
+                        tokens.push(OutFormatToken::Placeholder(OutFormatPlaceholder::FileName));
+                    }
+                    'N' => {
+                        if !literal.is_empty() {
+                            tokens.push(OutFormatToken::Literal(std::mem::take(&mut literal)));
+                        }
+                        tokens.push(OutFormatToken::Placeholder(
+                            OutFormatPlaceholder::FileNameWithSymlinkTarget,
+                        ));
+                    }
+                    'f' => {
+                        if !literal.is_empty() {
+                            tokens.push(OutFormatToken::Literal(std::mem::take(&mut literal)));
+                        }
+                        tokens.push(OutFormatToken::Placeholder(OutFormatPlaceholder::FullPath));
+                    }
+                    'i' => {
+                        if !literal.is_empty() {
+                            tokens.push(OutFormatToken::Literal(std::mem::take(&mut literal)));
+                        }
+                        tokens.push(OutFormatToken::Placeholder(
+                            OutFormatPlaceholder::ItemizedChanges,
+                        ));
+                    }
+                    'l' => {
+                        if !literal.is_empty() {
+                            tokens.push(OutFormatToken::Literal(std::mem::take(&mut literal)));
+                        }
+                        tokens.push(OutFormatToken::Placeholder(
+                            OutFormatPlaceholder::FileLength,
+                        ));
+                    }
+                    'b' => {
+                        if !literal.is_empty() {
+                            tokens.push(OutFormatToken::Literal(std::mem::take(&mut literal)));
+                        }
+                        tokens.push(OutFormatToken::Placeholder(
+                            OutFormatPlaceholder::BytesTransferred,
+                        ));
+                    }
+                    'c' => {
+                        if !literal.is_empty() {
+                            tokens.push(OutFormatToken::Literal(std::mem::take(&mut literal)));
+                        }
+                        tokens.push(OutFormatToken::Placeholder(
+                            OutFormatPlaceholder::ChecksumBytes,
+                        ));
+                    }
+                    'o' => {
+                        if !literal.is_empty() {
+                            tokens.push(OutFormatToken::Literal(std::mem::take(&mut literal)));
+                        }
+                        tokens.push(OutFormatToken::Placeholder(OutFormatPlaceholder::Operation));
+                    }
+                    'M' => {
+                        if !literal.is_empty() {
+                            tokens.push(OutFormatToken::Literal(std::mem::take(&mut literal)));
+                        }
+                        tokens.push(OutFormatToken::Placeholder(
+                            OutFormatPlaceholder::ModifyTime,
+                        ));
+                    }
+                    'B' => {
+                        if !literal.is_empty() {
+                            tokens.push(OutFormatToken::Literal(std::mem::take(&mut literal)));
+                        }
+                        tokens.push(OutFormatToken::Placeholder(
+                            OutFormatPlaceholder::PermissionString,
+                        ));
+                    }
+                    'L' => {
+                        if !literal.is_empty() {
+                            tokens.push(OutFormatToken::Literal(std::mem::take(&mut literal)));
+                        }
+                        tokens.push(OutFormatToken::Placeholder(
+                            OutFormatPlaceholder::SymlinkTarget,
+                        ));
+                    }
+                    't' => {
+                        if !literal.is_empty() {
+                            tokens.push(OutFormatToken::Literal(std::mem::take(&mut literal)));
+                        }
+                        tokens.push(OutFormatToken::Placeholder(
+                            OutFormatPlaceholder::CurrentTime,
+                        ));
+                    }
+                    'u' => {
+                        if !literal.is_empty() {
+                            tokens.push(OutFormatToken::Literal(std::mem::take(&mut literal)));
+                        }
+                        tokens.push(OutFormatToken::Placeholder(OutFormatPlaceholder::OwnerName));
+                    }
+                    'g' => {
+                        if !literal.is_empty() {
+                            tokens.push(OutFormatToken::Literal(std::mem::take(&mut literal)));
+                        }
+                        tokens.push(OutFormatToken::Placeholder(OutFormatPlaceholder::GroupName));
+                    }
+                    'U' => {
+                        if !literal.is_empty() {
+                            tokens.push(OutFormatToken::Literal(std::mem::take(&mut literal)));
+                        }
+                        tokens.push(OutFormatToken::Placeholder(OutFormatPlaceholder::OwnerUid));
+                    }
+                    'G' => {
+                        if !literal.is_empty() {
+                            tokens.push(OutFormatToken::Literal(std::mem::take(&mut literal)));
+                        }
+                        tokens.push(OutFormatToken::Placeholder(OutFormatPlaceholder::OwnerGid));
+                    }
+                    'p' => {
+                        if !literal.is_empty() {
+                            tokens.push(OutFormatToken::Literal(std::mem::take(&mut literal)));
+                        }
+                        tokens.push(OutFormatToken::Placeholder(OutFormatPlaceholder::ProcessId));
+                    }
+                    'h' => {
+                        if !literal.is_empty() {
+                            tokens.push(OutFormatToken::Literal(std::mem::take(&mut literal)));
+                        }
+                        tokens.push(OutFormatToken::Placeholder(
+                            OutFormatPlaceholder::RemoteHost,
+                        ));
+                    }
+                    'a' => {
+                        if !literal.is_empty() {
+                            tokens.push(OutFormatToken::Literal(std::mem::take(&mut literal)));
+                        }
+                        tokens.push(OutFormatToken::Placeholder(
+                            OutFormatPlaceholder::RemoteAddress,
+                        ));
+                    }
+                    'm' => {
+                        if !literal.is_empty() {
+                            tokens.push(OutFormatToken::Literal(std::mem::take(&mut literal)));
+                        }
+                        tokens.push(OutFormatToken::Placeholder(
+                            OutFormatPlaceholder::ModuleName,
+                        ));
+                    }
+                    'P' => {
+                        if !literal.is_empty() {
+                            tokens.push(OutFormatToken::Literal(std::mem::take(&mut literal)));
+                        }
+                        tokens.push(OutFormatToken::Placeholder(
+                            OutFormatPlaceholder::ModulePath,
+                        ));
+                    }
+                    'C' => {
+                        if !literal.is_empty() {
+                            tokens.push(OutFormatToken::Literal(std::mem::take(&mut literal)));
+                        }
+                        tokens.push(OutFormatToken::Placeholder(
+                            OutFormatPlaceholder::FullChecksum,
+                        ));
+                    }
+                    other => {
+                        return Err(rsync_error!(
+                            1,
+                            format!("unsupported --out-format placeholder '%{other}'"),
+                        )
+                        .with_role(Role::Client));
+                    }
+                }
+            }
+            _ => literal.push(ch),
+        }
+    }
+
+    if !literal.is_empty() {
+        tokens.push(OutFormatToken::Literal(literal));
+    }
+
+    Ok(OutFormat::new(tokens))
+}

--- a/crates/cli/src/out_format/tokens.rs
+++ b/crates/cli/src/out_format/tokens.rs
@@ -1,0 +1,68 @@
+#![deny(unsafe_code)]
+
+//! Token definitions backing `--out-format` parsing and rendering.
+
+/// Parsed representation of an `--out-format` specification.
+#[derive(Clone, Debug)]
+pub(crate) struct OutFormat {
+    tokens: Vec<OutFormatToken>,
+}
+
+impl OutFormat {
+    /// Constructs a new [`OutFormat`] from parsed tokens.
+    pub(super) fn new(tokens: Vec<OutFormatToken>) -> Self {
+        Self { tokens }
+    }
+
+    /// Returns an iterator over the parsed tokens.
+    pub(super) fn tokens(&self) -> impl Iterator<Item = &OutFormatToken> {
+        self.tokens.iter()
+    }
+
+    /// Returns `true` when no tokens were parsed from the format string.
+    #[cfg(test)]
+    pub(crate) fn is_empty(&self) -> bool {
+        self.tokens.is_empty()
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(super) enum OutFormatToken {
+    Literal(String),
+    Placeholder(OutFormatPlaceholder),
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(super) enum OutFormatPlaceholder {
+    FileName,
+    FileNameWithSymlinkTarget,
+    FullPath,
+    ItemizedChanges,
+    FileLength,
+    BytesTransferred,
+    ChecksumBytes,
+    Operation,
+    ModifyTime,
+    PermissionString,
+    CurrentTime,
+    SymlinkTarget,
+    OwnerName,
+    GroupName,
+    OwnerUid,
+    OwnerGid,
+    ProcessId,
+    RemoteHost,
+    RemoteAddress,
+    ModuleName,
+    ModulePath,
+    FullChecksum,
+}
+
+/// Context values used when rendering `--out-format` placeholders.
+#[derive(Clone, Debug, Default)]
+pub(crate) struct OutFormatContext {
+    pub(super) remote_host: Option<String>,
+    pub(super) remote_address: Option<String>,
+    pub(super) module_name: Option<String>,
+    pub(super) module_path: Option<String>,
+}


### PR DESCRIPTION
## Summary
- split the `--out-format` implementation into dedicated parser, token, and renderer modules to keep files well under the hygiene limit
- adjusted visibility so callers continue to access parsing and emission helpers through the existing crate re-exports

## Testing
- `cargo test -p rsync-cli --lib`

------