### PR TITLE
Fix clippy regressions in branding and local copy tests

### DIFF
--- a/crates/core/src/branding/brand.rs
+++ b/crates/core/src/branding/brand.rs
@@ -273,12 +273,7 @@ fn version_suffix_is_allowed(suffix: &str) -> bool {
 
     const WINDOWS_EXECUTABLE_EXTENSIONS: [&[u8]; 4] = [b".exe", b".com", b".bat", b".cmd"];
     WINDOWS_EXECUTABLE_EXTENSIONS.iter().any(|ext| {
-        bytes.len() >= ext.len()
-            && bytes[bytes.len() - ext.len()..].iter().zip(ext.iter()).all(
-                |(candidate, expected)| {
-                    candidate.to_ascii_lowercase() == expected.to_ascii_lowercase()
-                },
-            )
+        bytes.len() >= ext.len() && bytes[bytes.len() - ext.len()..].eq_ignore_ascii_case(ext)
     })
 }
 

--- a/crates/core/src/branding/detection.rs
+++ b/crates/core/src/branding/detection.rs
@@ -36,10 +36,10 @@ fn classify_program_name(program: &str) -> Option<Brand> {
 }
 
 fn brand_for_program_path(path: &Path) -> Option<Brand> {
-    if let Some(name) = path.file_name().and_then(|name| name.to_str()) {
-        if let Some(brand) = classify_program_name(name) {
-            return Some(brand);
-        }
+    if let Some(name) = path.file_name().and_then(|name| name.to_str())
+        && let Some(brand) = classify_program_name(name)
+    {
+        return Some(brand);
     }
 
     path.file_stem()

--- a/crates/engine/src/local_copy/tests.rs
+++ b/crates/engine/src/local_copy/tests.rs
@@ -1,5 +1,3 @@
-#![cfg(test)]
-
 use super::*;
 use filetime::{FileTime, set_file_mtime, set_file_times};
 use std::ffi::OsString;


### PR DESCRIPTION
## Summary
- remove the redundant inner `cfg(test)` gate from the local copy tests module
- use `eq_ignore_ascii_case` for Windows extension checks in brand detection utilities
- collapse nested option matching in `brand_for_program_path`

## Testing
- cargo clippy --workspace --all-targets --all-features --locked -- -Dwarnings

------