### PR TITLE
Add documentation branding validation to xtask docs command

### DIFF
--- a/xtask/src/commands/docs.rs
+++ b/xtask/src/commands/docs.rs
@@ -1,6 +1,9 @@
 use crate::error::{TaskError, TaskResult};
 use crate::util::{is_help_flag, run_cargo_tool};
+use crate::workspace::load_workspace_branding;
 use std::ffi::OsString;
+use std::fs;
+use std::io;
 use std::path::Path;
 
 /// Options accepted by the `docs` command.
@@ -8,6 +11,8 @@ use std::path::Path;
 pub struct DocsOptions {
     /// Whether to open the generated documentation in a browser.
     pub open: bool,
+    /// Whether to validate documentation snippets against workspace branding metadata.
+    pub validate: bool,
 }
 
 /// Parses CLI arguments for the `docs` command.
@@ -29,6 +34,16 @@ where
                 )));
             }
             options.open = true;
+            continue;
+        }
+
+        if arg == "--validate" {
+            if options.validate {
+                return Err(TaskError::Usage(String::from(
+                    "--validate specified multiple times",
+                )));
+            }
+            options.validate = true;
             continue;
         }
 
@@ -74,19 +89,139 @@ pub fn execute(workspace: &Path, options: DocsOptions) -> TaskResult<()> {
         test_args,
         "cargo test --doc",
         "ensure the Rust toolchain is installed",
-    )
+    )?;
+
+    if options.validate {
+        println!("Validating documentation branding");
+        validate_documents(workspace)?;
+    }
+
+    Ok(())
 }
 
 /// Returns usage text for the command.
 pub fn usage() -> String {
     String::from(
-        "Usage: cargo xtask docs [--open]\n\nOptions:\n  --open          Open documentation after building\n  -h, --help      Show this help message",
+        "Usage: cargo xtask docs [--open] [--validate]\n\nOptions:\n  --open          Open documentation after building\n  --validate     Validate branding references in Markdown documents\n  -h, --help      Show this help message",
     )
+}
+
+fn validate_documents(workspace: &Path) -> TaskResult<()> {
+    let branding = load_workspace_branding(workspace)?;
+
+    let readme_path = workspace.join("README.md");
+    let readme = read_file(&readme_path)?;
+    let production_scope_path = workspace.join("docs").join("production_scope_p1.md");
+    let production_scope = read_file(&production_scope_path)?;
+
+    let mut failures = Vec::new();
+    ensure_contains(
+        workspace,
+        &mut failures,
+        &readme_path,
+        &readme,
+        &branding.rust_version,
+        "Rust-branded version string",
+    );
+    ensure_contains(
+        workspace,
+        &mut failures,
+        &readme_path,
+        &readme,
+        &branding.client_bin,
+        "client binary name",
+    );
+    ensure_contains(
+        workspace,
+        &mut failures,
+        &readme_path,
+        &readme,
+        &branding.daemon_bin,
+        "daemon binary name",
+    );
+    ensure_contains(
+        workspace,
+        &mut failures,
+        &readme_path,
+        &readme,
+        &branding.source,
+        "source repository URL",
+    );
+
+    ensure_contains(
+        workspace,
+        &mut failures,
+        &production_scope_path,
+        &production_scope,
+        &branding.client_bin,
+        "client binary name",
+    );
+    ensure_contains(
+        workspace,
+        &mut failures,
+        &production_scope_path,
+        &production_scope,
+        &branding.daemon_bin,
+        "daemon binary name",
+    );
+    ensure_contains(
+        workspace,
+        &mut failures,
+        &production_scope_path,
+        &production_scope,
+        &branding.daemon_config,
+        "daemon configuration path",
+    );
+    ensure_contains(
+        workspace,
+        &mut failures,
+        &production_scope_path,
+        &production_scope,
+        &branding.daemon_secrets,
+        "daemon secrets path",
+    );
+
+    if failures.is_empty() {
+        Ok(())
+    } else {
+        Err(TaskError::Validation(format!(
+            "documentation validation failed:\n{}",
+            failures.join("\n")
+        )))
+    }
+}
+
+fn read_file(path: &Path) -> TaskResult<String> {
+    fs::read_to_string(path).map_err(|error| {
+        let message = format!("failed to read {}: {}", path.display(), error);
+        TaskError::Io(io::Error::new(error.kind(), message))
+    })
+}
+
+fn ensure_contains(
+    workspace: &Path,
+    failures: &mut Vec<String>,
+    path: &Path,
+    contents: &str,
+    needle: &str,
+    description: &str,
+) {
+    if !contents.contains(needle) {
+        let display_path = path
+            .strip_prefix(workspace)
+            .map(|relative| relative.display().to_string())
+            .unwrap_or_else(|_| path.display().to_string());
+        failures.push(format!(
+            "{display_path}: missing {description} ('{needle}')"
+        ));
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
+    use std::time::{SystemTime, UNIX_EPOCH};
 
     #[test]
     fn parse_args_accepts_default_configuration() {
@@ -107,8 +242,82 @@ mod tests {
     }
 
     #[test]
+    fn parse_args_accepts_validate_flag() {
+        let options =
+            parse_args([OsString::from("--validate")]).expect("parse succeeds with validate");
+        assert!(options.validate);
+        assert!(!options.open);
+    }
+
+    #[test]
+    fn parse_args_rejects_duplicate_validate_flags() {
+        let error =
+            parse_args([OsString::from("--validate"), OsString::from("--validate")]).unwrap_err();
+        assert!(matches!(error, TaskError::Usage(message) if message.contains("--validate")));
+    }
+
+    #[test]
     fn parse_args_rejects_unknown_argument() {
         let error = parse_args([OsString::from("--unknown")]).unwrap_err();
         assert!(matches!(error, TaskError::Usage(message) if message.contains("--unknown")));
+    }
+
+    #[test]
+    fn validate_documents_accepts_workspace_branding() {
+        let workspace = crate::workspace::workspace_root().expect("workspace root");
+        validate_documents(&workspace).expect("documents validate");
+    }
+
+    #[test]
+    fn validate_documents_reports_missing_branding() {
+        let unique_suffix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("time")
+            .as_nanos();
+        let workspace = std::env::temp_dir().join(format!("xtask_docs_validate_{unique_suffix}"));
+        if workspace.exists() {
+            fs::remove_dir_all(&workspace).expect("cleanup stale workspace");
+        }
+        fs::create_dir(&workspace).expect("create workspace");
+        fs::create_dir(workspace.join("docs")).expect("create docs directory");
+
+        let manifest = r#"[workspace]
+members = []
+[workspace.metadata]
+[workspace.metadata.oc_rsync]
+brand = "oc"
+upstream_version = "3.4.1"
+rust_version = "3.4.1-rust"
+protocol = 32
+client_bin = "oc-rsync"
+daemon_bin = "oc-rsyncd"
+legacy_client_bin = "rsync"
+legacy_daemon_bin = "rsyncd"
+daemon_config_dir = "/etc/oc-rsyncd"
+daemon_config = "/etc/oc-rsyncd/oc-rsyncd.conf"
+daemon_secrets = "/etc/oc-rsyncd/oc-rsyncd.secrets"
+legacy_daemon_config_dir = "/etc"
+legacy_daemon_config = "/etc/rsyncd.conf"
+legacy_daemon_secrets = "/etc/rsyncd.secrets"
+source = "https://github.com/oferchen/rsync"
+"#;
+        fs::write(workspace.join("Cargo.toml"), manifest).expect("write manifest");
+        fs::write(workspace.join("README.md"), "placeholder").expect("write README");
+        fs::write(
+            workspace.join("docs").join("production_scope_p1.md"),
+            "placeholder",
+        )
+        .expect("write production scope");
+
+        let error = validate_documents(&workspace).expect_err("validation should fail");
+        match error {
+            TaskError::Validation(message) => {
+                assert!(message.contains("README.md"), "{message}");
+                assert!(message.contains("production_scope_p1.md"), "{message}");
+            }
+            other => panic!("unexpected error: {other}"),
+        }
+
+        fs::remove_dir_all(&workspace).expect("cleanup workspace");
     }
 }


### PR DESCRIPTION
## Summary
- extend `cargo xtask docs` with a `--validate` flag that enforces README and production scope documents reference the configured branding metadata
- add helpers that check required strings against workspace metadata and report actionable validation errors
- cover the new behaviour with unit tests, including failure scenarios for missing branding references

## Testing
- cargo test -p xtask

------