### PR TITLE
Fix protocol compile-time guards and docs

### DIFF
--- a/crates/protocol/src/compatibility/iter.rs
+++ b/crates/protocol/src/compatibility/iter.rs
@@ -8,7 +8,7 @@ use super::known::KnownCompatibilityFlag;
 /// [`Iterator::next`] yields flags in ascending bit order (lowest bit first) so
 /// callers observe the same ordering exposed by [`CompatibilityFlags::iter_known`].
 /// The iterator also implements [`DoubleEndedIterator`], allowing reverse
-/// traversal via [`Iterator::next_back`] without allocating intermediate
+/// traversal via [`DoubleEndedIterator::next_back`] without allocating intermediate
 /// collections.
 #[derive(Clone, Debug)]
 pub struct KnownCompatibilityFlagsIter {

--- a/crates/protocol/src/version/select.rs
+++ b/crates/protocol/src/version/select.rs
@@ -71,20 +71,20 @@ where
 /// Ensures compile-time guards stay aligned with the advertised protocol list.
 pub(crate) const fn validate_protocol_tables() {
     let protocols = super::SUPPORTED_PROTOCOLS;
-    assert!(
-        !protocols.is_empty(),
-        "supported protocol list must not be empty"
-    );
+    let Some(&declared_newest) = protocols.first() else {
+        panic!("supported protocol list must not be empty");
+    };
     assert!(
         protocols.len() == SUPPORTED_PROTOCOL_COUNT,
         "supported protocol count must match list length",
     );
     assert!(
-        protocols[0] == ProtocolVersion::NEWEST.as_u8(),
+        declared_newest == ProtocolVersion::NEWEST.as_u8(),
         "newest supported protocol must lead the list",
     );
+    let declared_oldest = protocols[protocols.len() - 1];
     assert!(
-        protocols[protocols.len() - 1] == ProtocolVersion::OLDEST.as_u8(),
+        declared_oldest == ProtocolVersion::OLDEST.as_u8(),
         "oldest supported protocol must terminate the list",
     );
 


### PR DESCRIPTION
## Summary
- guard the protocol metadata validation against empty tables without triggering constant assertions
- fix the `KnownCompatibilityFlagsIter` documentation link to the correct trait method

## Testing
- cargo clippy --workspace --all-targets --all-features --locked -- -Dwarnings
- cargo doc --workspace --no-deps

------