### PR TITLE
Ensure protocol table validation runs at compile time

### DIFF
--- a/crates/protocol/src/version/select.rs
+++ b/crates/protocol/src/version/select.rs
@@ -193,3 +193,9 @@ pub(crate) const fn validate_protocol_tables() {
         "supported protocol range must match upstream rsync's protocol span",
     );
 }
+
+// Evaluate the validation routine at compile time to guard against drift between
+// the advertised protocol list and the supporting constants.
+const _: () = {
+    validate_protocol_tables();
+};


### PR DESCRIPTION
## Summary
- invoke the existing protocol table validation function in a const context to keep compile-time guards active

## Testing
- cargo clippy --workspace --all-targets --all-features --locked -- -Dwarnings

------