### PR TITLE
Remove stale enforce-limits override

### DIFF
--- a/tools/line_limits.toml
+++ b/tools/line_limits.toml
@@ -73,11 +73,6 @@ max_lines = 1400
 warn_lines = 1350
 
 [[overrides]]
-path = "crates/protocol/src/compatibility.rs"
-max_lines = 1200
-warn_lines = 1150
-
-[[overrides]]
 path = "crates/protocol/src/envelope/tests.rs"
 max_lines = 600
 warn_lines = 580


### PR DESCRIPTION
## Summary
- drop the obsolete line-count override for crates/protocol/src/compatibility.rs so the hygiene check matches the current module layout

## Testing
- bash tools/enforce_limits.sh

------