### PR TITLE
ci: validate documentation via xtask

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,11 +86,8 @@ jobs:
       - name: Enforce line count limits
         run: cargo --locked run -p xtask -- enforce-limits
 
-      - name: Build documentation
-        run: cargo --locked doc --workspace --no-deps
-
-      - name: Run doctests
-        run: cargo --locked test --doc --workspace
+      - name: Build and validate documentation
+        run: cargo --locked run -p xtask -- docs --validate
 
       - name: Ensure no placeholders remain
         run: cargo --locked run -p xtask -- no-placeholders


### PR DESCRIPTION
## Summary
- replace the manual documentation build and doctest steps with the existing `cargo xtask docs --validate` helper so lint enforces branding checks alongside rustdoc

## Testing
- cargo test -p xtask

------