### PR TITLE
Remove redundant test cfg attributes

### DIFF
--- a/crates/core/src/client/tests.rs
+++ b/crates/core/src/client/tests.rs
@@ -1,5 +1,3 @@
-#![cfg(test)]
-
 use super::*;
 use crate::client::fallback::write_daemon_password;
 use crate::fallback::CLIENT_FALLBACK_ENV;

--- a/crates/daemon/src/tests.rs
+++ b/crates/daemon/src/tests.rs
@@ -1,5 +1,3 @@
-#![cfg(test)]
-
 use super::*;
 use std::borrow::Cow;
 use std::ffi::{OsStr, OsString};

--- a/crates/transport/src/negotiation/tests.rs
+++ b/crates/transport/src/negotiation/tests.rs
@@ -1,5 +1,3 @@
-#![cfg(test)]
-
 use super::*;
 
 use std::{


### PR DESCRIPTION
## Summary
- remove redundant crate-level `#![cfg(test)]` attributes from module test files to avoid duplicated attribute warnings

## Testing
- cargo clippy --workspace --all-targets --all-features --locked -- -Dwarnings

------