### PR TITLE
Fix doc links in message module

### DIFF
--- a/crates/core/src/message/macros.rs
+++ b/crates/core/src/message/macros.rs
@@ -6,7 +6,8 @@ macro_rules! message_source {
     };
 }
 
-/// Builds a [`SourceLocation`] from an explicit [`std::panic::Location`].
+/// Builds a [`SourceLocation`](crate::message::SourceLocation) from an explicit
+/// [`std::panic::Location`].
 ///
 /// This macro is useful when the caller already captured a location through
 /// `#[track_caller]` and wishes to convert it into the repo-relative form used
@@ -33,7 +34,8 @@ macro_rules! message_source_from {
     }};
 }
 
-/// Captures a [`SourceLocation`] that honours `#[track_caller]` propagation.
+/// Captures a [`SourceLocation`](crate::message::SourceLocation) that honours
+/// `#[track_caller]` propagation.
 ///
 /// Unlike [`macro@message_source`], this macro calls [`std::panic::Location::caller`]
 /// so that helper functions annotated with `#[track_caller]` report the
@@ -57,14 +59,17 @@ macro_rules! tracked_message_source {
     () => {{ $crate::message_source_from!(::std::panic::Location::caller()) }};
 }
 
-/// Constructs an error [`Message`] with the provided exit code and payload.
+/// Constructs an error [`Message`](crate::message::Message) with the provided
+/// exit code and payload.
 ///
 /// The macro mirrors upstream diagnostics by automatically attaching the
-/// call-site [`SourceLocation`] using [`macro@crate::tracked_message_source`]. It
+/// call-site [`SourceLocation`](crate::message::SourceLocation) using
+/// [`macro@crate::tracked_message_source`]. It
 /// accepts either a
 /// string literal/`Cow<'static, str>` payload or a [`format!`] style template.
-/// Callers can further customise the returned [`Message`] by chaining helpers
-/// such as [`Message::with_role`].
+/// Callers can further customise the returned
+/// [`Message`](crate::message::Message) by chaining helpers such as
+/// [`Message::with_role`](crate::message::Message::with_role).
 ///
 /// # Examples
 ///
@@ -104,13 +109,15 @@ macro_rules! rsync_error {
     }};
 }
 
-/// Constructs a warning [`Message`] from the provided payload.
+/// Constructs a warning [`Message`](crate::message::Message) from the provided
+/// payload.
 ///
 /// Like [`macro@rsync_error`], the macro records the call-site source location so
 /// diagnostics include repo-relative paths. The macro relies on
 /// [`macro@crate::tracked_message_source`], meaning callers annotated with
 /// `#[track_caller]` automatically propagate their invocation site. Additional
-/// context, such as exit codes, can be attached using [`Message::with_code`].
+/// context, such as exit codes, can be attached using
+/// [`Message::with_code`](crate::message::Message::with_code).
 ///
 /// # Examples
 ///
@@ -136,9 +143,11 @@ macro_rules! rsync_warning {
     }};
 }
 
-/// Constructs an informational [`Message`] from the provided payload.
+/// Constructs an informational [`Message`](crate::message::Message) from the
+/// provided payload.
 ///
-/// The macro is a convenience wrapper around [`Message::info`] that automatically
+/// The macro is a convenience wrapper around
+/// [`Message::info`](crate::message::Message::info) that automatically
 /// attaches the call-site source location. Upstream rsync typically omits source
 /// locations for informational output, but retaining the metadata simplifies
 /// debugging and keeps the API consistent across severities. As with the other
@@ -167,9 +176,12 @@ macro_rules! rsync_info {
     }};
 }
 
-/// Constructs a [`Message`] using the canonical wording for a known exit code.
+/// Constructs a [`Message`](crate::message::Message) using the canonical
+/// wording for a known exit code.
 ///
-/// The macro delegates to [`Message::from_exit_code`] and attaches the caller's
+/// The macro delegates to
+/// [`Message::from_exit_code`](crate::message::Message::from_exit_code) and
+/// attaches the caller's
 /// source location via [`macro@crate::tracked_message_source`]. Returning an
 /// [`Option`] mirrors the underlying helper:
 /// upstream rsync only assigns stock diagnostics to a fixed set of exit codes. Callers can use

--- a/crates/core/src/message/role.rs
+++ b/crates/core/src/message/role.rs
@@ -51,7 +51,8 @@ impl Role {
     ///
     /// The returned string matches the suffix rendered by upstream rsync. Keeping the
     /// mapping here allows higher layers to reuse the canonical spelling when
-    /// constructing out-of-band logs or telemetry derived from [`Message`] instances.
+    /// constructing out-of-band logs or telemetry derived from
+    /// [`Message`](crate::message::Message) instances.
     ///
     /// # Examples
     ///

--- a/crates/core/src/message/scratch.rs
+++ b/crates/core/src/message/scratch.rs
@@ -2,7 +2,8 @@ use std::cell::RefCell;
 
 /// Scratch buffers used when producing vectored message segments.
 ///
-/// Instances of this type are supplied to [`Message::as_segments`] so the helper can encode
+/// Instances of this type are supplied to [`Message::as_segments`](crate::message::Message::as_segments)
+/// so the helper can encode
 /// decimal exit codes and line numbers without allocating temporary [`String`] values. The
 /// buffers are stack-allocated and reusable, making it cheap for higher layers to render
 /// multiple messages in succession without paying repeated allocation costs. Because
@@ -10,7 +11,8 @@ use std::cell::RefCell;
 /// thread caches or passing scratch buffers between helper functions without incurring
 /// additional allocations. When managing scratch storage manually is inconvenient, use
 /// [`MessageScratch::with_thread_local`] to borrow the thread-local buffer that backs
-/// [`Message::to_bytes`], [`Message::render_to`], and related helpers.
+/// [`Message::to_bytes`](crate::message::Message::to_bytes),
+/// [`Message::render_to`](crate::message::Message::render_to), and related helpers.
 ///
 /// # Examples
 ///
@@ -49,7 +51,9 @@ impl MessageScratch {
     /// multiple messages without explicitly storing a [`MessageScratch`]. When the thread-local
     /// instance is temporarily unavailable—such as when the current thread already borrowed it—the
     /// function transparently falls back to a fresh buffer. This mirrors the strategy used by
-    /// [`Message::render_to`] and [`Message::to_bytes`], ensuring consistent performance semantics
+    /// [`Message::render_to`](crate::message::Message::render_to) and
+    /// [`Message::to_bytes`](crate::message::Message::to_bytes), ensuring consistent performance
+    /// semantics
     /// across the workspace.
     ///
     /// # Examples

--- a/crates/core/src/message/segments.rs
+++ b/crates/core/src/message/segments.rs
@@ -6,10 +6,11 @@ use std::slice;
 
 use super::{MAX_MESSAGE_SEGMENTS, OVERREPORTED_BYTES_ERROR, errors::map_message_reserve_error};
 
-/// Collection of slices that jointly render an [`Message`].
+/// Collection of slices that jointly render a [`Message`](crate::message::Message).
 ///
 /// The segments reference the message payload together with optional exit codes, source
-/// locations, and role trailers. Callers obtain the structure through [`Message::as_segments`]
+/// locations, and role trailers. Callers obtain the structure through
+/// [`Message::as_segments`](crate::message::Message::as_segments)
 /// and can then stream the slices into vectored writers, aggregate statistics, or reuse the
 /// layout when constructing custom buffers. `MessageSegments` implements [`AsRef`] so the
 /// collected [`IoSlice`] values can be passed directly to APIs such as

--- a/crates/core/src/message/severity.rs
+++ b/crates/core/src/message/severity.rs
@@ -16,7 +16,7 @@ impl Severity {
     /// Returns the lowercase label used when rendering the severity.
     ///
     /// The strings mirror upstream rsync's diagnostics and therefore feed directly into
-    /// the formatting helpers implemented by [`Message`]. Exposing the label keeps
+    /// the formatting helpers implemented by [`Message`](crate::message::Message). Exposing the label keeps
     /// external crates from duplicating the canonical wording while still allowing
     /// call sites to branch on the textual representation when building structured
     /// logs or integration tests.
@@ -43,7 +43,8 @@ impl Severity {
     ///
     /// The string mirrors upstream rsync's output, combining the constant
     /// `"rsync"` banner with the lowercase severity label and trailing
-    /// colon. Centralising the prefix ensures [`Message::as_segments`]
+    /// colon. Centralising the prefix ensures
+    /// [`Message::as_segments`](crate::message::Message::as_segments)
     /// doesn't need to assemble the pieces manually, which avoids
     /// additional vectored segments and keeps rendering logic in sync with
     /// upstream expectations.


### PR DESCRIPTION
## Summary
- qualify intra-doc links in message role, severity, segments, and scratch modules
- ensure message macros reference Message and SourceLocation explicitly for rustdoc

## Testing
- cargo doc --workspace --no-deps

------