### PR TITLE
Fix CopyToSliceError test to use public API

### DIFF
--- a/crates/core/src/message/tests.rs
+++ b/crates/core/src/message/tests.rs
@@ -906,7 +906,14 @@ fn message_segments_copy_to_slice_accepts_empty_inputs() {
 
 #[test]
 fn message_copy_to_slice_error_converts_into_io_error() {
-    let err = CopyToSliceError::new(16, 8);
+    let message = Message::info("ready");
+    let mut scratch = MessageScratch::new();
+    let segments = message.as_segments(&mut scratch, false);
+
+    let mut undersized = vec![0u8; segments.len().saturating_sub(1)];
+    let err = segments
+        .copy_to_slice(&mut undersized)
+        .expect_err("buffer is intentionally undersized");
     let io_err: io::Error = err.into();
 
     assert_eq!(io_err.kind(), io::ErrorKind::InvalidInput);


### PR DESCRIPTION
## Summary
- update `message_copy_to_slice_error_converts_into_io_error` to construct `CopyToSliceError` via `MessageSegments::copy_to_slice`
- avoid relying on the error type's private constructor while preserving existing assertions

## Testing
- cargo test -p rsync-core

------