### PR TITLE
Fix intra-doc links in MessageSink documentation

### DIFF
--- a/crates/logging/src/sink/message_sink/mod.rs
+++ b/crates/logging/src/sink/message_sink/mod.rs
@@ -3,7 +3,8 @@ use std::fmt;
 use crate::line_mode::LineMode;
 use rsync_core::message::MessageScratch;
 
-/// Streaming sink that renders [`Message`] values into an [`io::Write`] target.
+/// Streaming sink that renders [`rsync_core::message::Message`] values into an
+/// [`std::io::Write`] target.
 ///
 /// The sink owns the underlying writer together with a reusable
 /// [`MessageScratch`] buffer. Each call to [`write`](Self::write) renders the


### PR DESCRIPTION
## Summary
- fix the MessageSink module docs to reference fully-qualified types

## Testing
- cargo doc --workspace --no-deps

------