### PR TITLE
Fix DocsOptions initialization in release xtask command

### DIFF
--- a/xtask/src/commands/release.rs
+++ b/xtask/src/commands/release.rs
@@ -95,8 +95,10 @@ pub fn execute(workspace: &Path, options: ReleaseOptions) -> TaskResult<()> {
     if options.skip_docs {
         skipped_steps.push("docs");
     } else {
-        let mut docs_options = DocsOptions::default();
-        docs_options.validate = true;
+        let docs_options = DocsOptions {
+            validate: true,
+            ..DocsOptions::default()
+        };
         docs::execute(workspace, docs_options)?;
         executed_steps.push("docs");
     }


### PR DESCRIPTION
## Summary
- initialize the docs validation flag with a struct update to avoid field reassignment after `Default`

## Testing
- cargo clippy --workspace --all-targets --all-features --locked -- -Dwarnings

------