### PR TITLE
Fix enforce-limits override for transport session tests module

### DIFF
--- a/tools/line_limits.toml
+++ b/tools/line_limits.toml
@@ -63,11 +63,6 @@ max_lines = 3350
 warn_lines = 3330
 
 [[overrides]]
-path = "crates/transport/src/session/tests.rs"
-max_lines = 1700
-warn_lines = 1650
-
-[[overrides]]
 path = "crates/transport/src/binary.rs"
 max_lines = 1700
 warn_lines = 1650


### PR DESCRIPTION
## Summary
- remove the stale line-limit override pointing to the deleted `crates/transport/src/session/tests.rs`
- keep enforce-limits working now that the session tests live in a module directory

## Testing
- cargo run -p xtask -- enforce-limits

------