### PR TITLE
Share InstrumentedTransport helper across session tests

### DIFF
--- a/crates/transport/src/session/tests/clones.rs
+++ b/crates/transport/src/session/tests/clones.rs
@@ -459,37 +459,4 @@ fn session_handshake_parts_from_legacy_components_round_trips() {
     assert_eq!(transport.flushes(), 1);
 }
 
-#[derive(Debug)]
-struct InstrumentedTransport {
-    inner: MemoryTransport,
-}
-
-impl InstrumentedTransport {
-    fn new(inner: MemoryTransport) -> Self {
-        Self { inner }
-    }
-
-    fn writes(&self) -> &[u8] {
-        self.inner.writes()
-    }
-
-    fn flushes(&self) -> usize {
-        self.inner.flushes()
-    }
-}
-
-impl Read for InstrumentedTransport {
-    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        self.inner.read(buf)
-    }
-}
-
-impl Write for InstrumentedTransport {
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.inner.write(buf)
-    }
-
-    fn flush(&mut self) -> io::Result<()> {
-        self.inner.flush()
-    }
-}
+// InstrumentedTransport is provided by the support module.

--- a/crates/transport/src/session/tests/support.rs
+++ b/crates/transport/src/session/tests/support.rs
@@ -43,6 +43,41 @@ impl Write for MemoryTransport {
     }
 }
 
+#[derive(Debug)]
+pub(crate) struct InstrumentedTransport {
+    inner: MemoryTransport,
+}
+
+impl InstrumentedTransport {
+    pub(crate) fn new(inner: MemoryTransport) -> Self {
+        Self { inner }
+    }
+
+    pub(crate) fn writes(&self) -> &[u8] {
+        self.inner.writes()
+    }
+
+    pub(crate) fn flushes(&self) -> usize {
+        self.inner.flushes()
+    }
+}
+
+impl Read for InstrumentedTransport {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.inner.read(buf)
+    }
+}
+
+impl Write for InstrumentedTransport {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.inner.write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.inner.flush()
+    }
+}
+
 pub(crate) fn binary_handshake_bytes(version: ProtocolVersion) -> [u8; 4] {
     u32::from(version.as_u8()).to_be_bytes()
 }


### PR DESCRIPTION
## Summary
- move the InstrumentedTransport test helper into the shared support module
- reuse the shared helper in the session test suites that require it

## Testing
- cargo test -p rsync-transport --lib

------