### PR TITLE
Add helpers for legacy daemon configuration paths

### DIFF
--- a/crates/core/src/workspace.rs
+++ b/crates/core/src/workspace.rs
@@ -404,6 +404,75 @@ pub fn daemon_secrets_path() -> &'static Path {
     Path::new(DAEMON_SECRETS_PATH)
 }
 
+/// Returns the upstream-compatible daemon configuration directory as a [`Path`].
+///
+/// The helper mirrors [`metadata().legacy_daemon_config_dir()`](Metadata::legacy_daemon_config_dir)
+/// so callers that need to reference the historical installation layout (for
+/// example, when validating compatibility symlinks or scanning legacy
+/// configuration locations) can do so without repeating string literals. The
+/// return value is derived from the workspace metadata populated by
+/// `build.rs`, ensuring the Rust binaries, packaging assets, and documentation
+/// remain aligned.
+///
+/// # Examples
+///
+/// ```
+/// use rsync_core::workspace;
+///
+/// assert_eq!(
+///     workspace::legacy_daemon_config_dir(),
+///     std::path::Path::new(workspace::metadata().legacy_daemon_config_dir())
+/// );
+/// ```
+#[must_use]
+pub fn legacy_daemon_config_dir() -> &'static Path {
+    Path::new(LEGACY_DAEMON_CONFIG_DIR)
+}
+
+/// Returns the upstream-compatible daemon configuration file as a [`Path`].
+///
+/// The workspace still honours `/etc/rsyncd.conf` for operators that rely on
+/// the historical location. Exposing the value through this helper keeps the
+/// string centralised so tests, packaging validation, and documentation can
+/// reference the path without duplicating literals.
+///
+/// # Examples
+///
+/// ```
+/// use rsync_core::workspace;
+///
+/// assert_eq!(
+///     workspace::legacy_daemon_config_path(),
+///     std::path::Path::new(workspace::metadata().legacy_daemon_config_path())
+/// );
+/// ```
+#[must_use]
+pub fn legacy_daemon_config_path() -> &'static Path {
+    Path::new(LEGACY_DAEMON_CONFIG_PATH)
+}
+
+/// Returns the upstream-compatible daemon secrets file as a [`Path`].
+///
+/// Packaging still installs a legacy secrets file for deployments that expect
+/// the upstream layout. Centralising the path avoids drift between the
+/// workspace metadata, runtime lookups, and the packaged configuration
+/// templates.
+///
+/// # Examples
+///
+/// ```
+/// use rsync_core::workspace;
+///
+/// assert_eq!(
+///     workspace::legacy_daemon_secrets_path(),
+///     std::path::Path::new(workspace::metadata().legacy_daemon_secrets_path())
+/// );
+/// ```
+#[must_use]
+pub fn legacy_daemon_secrets_path() -> &'static Path {
+    Path::new(LEGACY_DAEMON_SECRETS_PATH)
+}
+
 /// Parses an ASCII decimal integer at compile time.
 const fn parse_u32(input: &str) -> u32 {
     let bytes = input.as_bytes();
@@ -435,6 +504,18 @@ mod tests {
         assert_eq!(daemon_config_dir(), Path::new(DAEMON_CONFIG_DIR));
         assert_eq!(daemon_config_path(), Path::new(DAEMON_CONFIG_PATH));
         assert_eq!(daemon_secrets_path(), Path::new(DAEMON_SECRETS_PATH));
+        assert_eq!(
+            legacy_daemon_config_dir(),
+            Path::new(LEGACY_DAEMON_CONFIG_DIR)
+        );
+        assert_eq!(
+            legacy_daemon_config_path(),
+            Path::new(LEGACY_DAEMON_CONFIG_PATH)
+        );
+        assert_eq!(
+            legacy_daemon_secrets_path(),
+            Path::new(LEGACY_DAEMON_SECRETS_PATH)
+        );
     }
 
     #[test]
@@ -455,6 +536,18 @@ mod tests {
             snapshot.legacy_daemon_program_name()
         );
         assert_eq!(source_url(), snapshot.source_url());
+        assert_eq!(
+            legacy_daemon_config_dir(),
+            Path::new(snapshot.legacy_daemon_config_dir())
+        );
+        assert_eq!(
+            legacy_daemon_config_path(),
+            Path::new(snapshot.legacy_daemon_config_path())
+        );
+        assert_eq!(
+            legacy_daemon_secrets_path(),
+            Path::new(snapshot.legacy_daemon_secrets_path())
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add workspace helpers exposing the legacy daemon configuration and secrets paths as `Path` values
- extend the workspace unit tests to validate the new helpers against the manifest metadata

## Testing
- cargo test -p rsync-core workspace::

------