### PR TITLE
Expand documentation branding validation coverage

### DIFF
--- a/docs/resume_note.md
+++ b/docs/resume_note.md
@@ -1,7 +1,7 @@
 # Resume Notes
 
 ## Status
-- Workspace implements the branded **oc-rsync 3.4.1-rust** binaries with a deterministic local copy engine, message formatting, and protocol negotiation scaffolding that already mirrors upstream interfaces for local execution.
+- Workspace implements the branded **oc-rsync 3.4.1-rust** and **oc-rsyncd 3.4.1-rust** binaries with a deterministic local copy engine, message formatting, and protocol negotiation scaffolding that already mirrors upstream interfaces for local execution.
 - Remote transfers still delegate to the system `rsync` binary while the native transport and delta pipeline are being integrated; remaining observable gaps are tracked in `docs/differences.md` and scoped by `docs/production_scope_p1.md`.
 - Documentation, branding, and CI guardrails (lint, coverage, packaging, cross-compilation) are established and enforced via the consolidated `ci.yml` workflow.
 


### PR DESCRIPTION
## Summary
- extend the `cargo xtask docs --validate` checks to cover all branding-sensitive markdown files via structured document requirements
- ensure the resume note calls out both oc-rsync and oc-rsyncd so validation succeeds

## Testing
- cargo test -p xtask

------