### PR TITLE
Inline protocol table validation const

### DIFF
--- a/crates/protocol/src/version/protocol_version.rs
+++ b/crates/protocol/src/version/protocol_version.rs
@@ -70,9 +70,6 @@ pub const SUPPORTED_PROTOCOL_BITMAP: u64 = {
 
     bitmap
 };
-
-const _: () = super::select::validate_protocol_tables();
-
 impl ProtocolVersion {
     pub(crate) const fn new_const(value: u8) -> Self {
         match NonZeroU8::new(value) {

--- a/crates/protocol/src/version/select.rs
+++ b/crates/protocol/src/version/select.rs
@@ -68,8 +68,9 @@ where
     })
 }
 
-/// Ensures compile-time guards stay aligned with the advertised protocol list.
-pub(crate) const fn validate_protocol_tables() {
+// Evaluate the validation routine at compile time to guard against drift between
+// the advertised protocol list and the supporting constants.
+const _: () = {
     let protocols = super::SUPPORTED_PROTOCOLS;
     let Some(&declared_newest) = protocols.first() else {
         panic!("supported protocol list must not be empty");
@@ -192,10 +193,4 @@ pub(crate) const fn validate_protocol_tables() {
         range_oldest == upstream_oldest && range_newest == upstream_newest,
         "supported protocol range must match upstream rsync's protocol span",
     );
-}
-
-// Evaluate the validation routine at compile time to guard against drift between
-// the advertised protocol list and the supporting constants.
-const _: () = {
-    validate_protocol_tables();
 };


### PR DESCRIPTION
## Summary
- inline the protocol table validation into a module-level const expression
- drop the unused helper reference from `protocol_version`

## Testing
- cargo clippy --workspace --all-targets --all-features --locked -- -Dwarnings

------