### PR TITLE
Fix rustdoc intra-doc link for workspace metadata

### DIFF
--- a/crates/core/src/workspace/mod.rs
+++ b/crates/core/src/workspace/mod.rs
@@ -8,7 +8,8 @@
 //! keeps the binary front-ends and supporting crates free from duplicated string
 //! literals. Callers should prefer these helpers instead of hard-coding program
 //! names or configuration paths. Consumers that need the entire metadata set can
-//! use [`metadata()`] to obtain a snapshot that mirrors the manifest entries.
+//! use [`metadata()`](crate::workspace::metadata) to obtain a snapshot that mirrors
+//! the manifest entries.
 
 mod constants;
 mod metadata;


### PR DESCRIPTION
## Summary
- ensure the workspace module documentation links to the public `metadata()` helper using an explicit path so rustdoc resolves it correctly

## Testing
- cargo doc --workspace --no-deps

------