### PR TITLE
Fix brand detection to avoid unstable let chains

### DIFF
--- a/crates/core/src/branding/detection.rs
+++ b/crates/core/src/branding/detection.rs
@@ -36,8 +36,10 @@ fn classify_program_name(program: &str) -> Option<Brand> {
 }
 
 fn brand_for_program_path(path: &Path) -> Option<Brand> {
-    if let Some(name) = path.file_name().and_then(|name| name.to_str())
-        && let Some(brand) = classify_program_name(name)
+    if let Some(brand) = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .and_then(classify_program_name)
     {
         return Some(brand);
     }


### PR DESCRIPTION
## Summary
- avoid unstable let-chain usage in brand detection by folding the checks into an Option chain compatible with stable Rust

## Testing
- cargo clippy --workspace --all-targets --all-features --locked -- -Dwarnings

------