### PR TITLE
Add brand-aware version report builders

### DIFF
--- a/crates/cli/src/frontend.rs
+++ b/crates/cli/src/frontend.rs
@@ -2196,7 +2196,7 @@ where
     }
 
     if show_version {
-        let report = VersionInfoReport::default().with_client_brand(program_name.brand());
+        let report = VersionInfoReport::for_client_brand(program_name.brand());
         let banner = report.human_readable();
         if stdout.write_all(banner.as_bytes()).is_err() {
             return 1;

--- a/crates/cli/src/tests.rs
+++ b/crates/cli/src/tests.rs
@@ -147,7 +147,7 @@ fn version_flag_renders_report() {
     assert_eq!(code, 0);
     assert!(stderr.is_empty());
 
-    let expected = VersionInfoReport::default().human_readable();
+    let expected = VersionInfoReport::for_client_brand(Brand::Upstream).human_readable();
     assert_eq!(stdout, expected.into_bytes());
 }
 
@@ -158,9 +158,7 @@ fn oc_version_flag_renders_oc_banner() {
     assert_eq!(code, 0);
     assert!(stderr.is_empty());
 
-    let expected = VersionInfoReport::default()
-        .with_client_brand(Brand::Oc)
-        .human_readable();
+    let expected = VersionInfoReport::for_client_brand(Brand::Oc).human_readable();
     assert_eq!(stdout, expected.into_bytes());
 }
 
@@ -171,7 +169,7 @@ fn short_version_flag_renders_report() {
     assert_eq!(code, 0);
     assert!(stderr.is_empty());
 
-    let expected = VersionInfoReport::default().human_readable();
+    let expected = VersionInfoReport::for_client_brand(Brand::Upstream).human_readable();
     assert_eq!(stdout, expected.into_bytes());
 }
 

--- a/crates/core/src/version/report/renderer.rs
+++ b/crates/core/src/version/report/renderer.rs
@@ -87,6 +87,60 @@ impl VersionInfoReport {
         self.with_program_name(brand.daemon_program_name())
     }
 
+    /// Creates a report for the client binary associated with `brand` using the
+    /// default [`VersionInfoConfig`].
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use rsync_core::branding::Brand;
+    /// use rsync_core::version::VersionInfoReport;
+    ///
+    /// let report = VersionInfoReport::for_client_brand(Brand::Oc);
+    /// assert!(report
+    ///     .metadata()
+    ///     .standard_banner()
+    ///     .starts_with("oc-rsync  version"));
+    /// ```
+    #[must_use]
+    pub fn for_client_brand(brand: Brand) -> Self {
+        Self::default().with_client_brand(brand)
+    }
+
+    /// Creates a report for the daemon binary associated with `brand` using the
+    /// default [`VersionInfoConfig`].
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use rsync_core::branding::Brand;
+    /// use rsync_core::version::VersionInfoReport;
+    ///
+    /// let report = VersionInfoReport::for_daemon_brand(Brand::Oc);
+    /// assert!(report
+    ///     .metadata()
+    ///     .standard_banner()
+    ///     .starts_with("oc-rsyncd  version"));
+    /// ```
+    #[must_use]
+    pub fn for_daemon_brand(brand: Brand) -> Self {
+        Self::default().with_daemon_brand(brand)
+    }
+
+    /// Creates a report for the client binary associated with `brand` using an
+    /// explicit [`VersionInfoConfig`].
+    #[must_use]
+    pub fn for_client_brand_with_config(config: VersionInfoConfig, brand: Brand) -> Self {
+        Self::new(config).with_client_brand(brand)
+    }
+
+    /// Creates a report for the daemon binary associated with `brand` using an
+    /// explicit [`VersionInfoConfig`].
+    #[must_use]
+    pub fn for_daemon_brand_with_config(config: VersionInfoConfig, brand: Brand) -> Self {
+        Self::new(config).with_daemon_brand(brand)
+    }
+
     /// Replaces the checksum algorithm list used in the rendered report.
     #[must_use]
     pub fn with_checksum_algorithms<I, S>(mut self, algorithms: I) -> Self

--- a/crates/core/src/version/tests/report.rs
+++ b/crates/core/src/version/tests/report.rs
@@ -111,6 +111,39 @@ fn version_info_report_with_daemon_brand_updates_banner() {
 }
 
 #[test]
+fn version_info_report_for_client_brand_matches_builder() {
+    let expected =
+        VersionInfoReport::new(VersionInfoConfig::default()).with_client_brand(Brand::Oc);
+    let actual = VersionInfoReport::for_client_brand(Brand::Oc);
+
+    assert_eq!(actual.human_readable(), expected.human_readable());
+}
+
+#[test]
+fn version_info_report_for_daemon_brand_matches_builder() {
+    let expected =
+        VersionInfoReport::new(VersionInfoConfig::default()).with_daemon_brand(Brand::Oc);
+    let actual = VersionInfoReport::for_daemon_brand(Brand::Oc);
+
+    assert_eq!(actual.human_readable(), expected.human_readable());
+}
+
+#[test]
+fn version_info_report_for_brand_with_config_matches_builder() {
+    let mut config = VersionInfoConfig::default();
+    config.supports_ipv6 = false;
+    config.supports_symlinks = false;
+    let expected = VersionInfoReport::new(config).with_client_brand(Brand::Upstream);
+
+    let mut alternate = VersionInfoConfig::default();
+    alternate.supports_ipv6 = false;
+    alternate.supports_symlinks = false;
+    let actual = VersionInfoReport::for_client_brand_with_config(alternate, Brand::Upstream);
+
+    assert_eq!(actual.human_readable(), expected.human_readable());
+}
+
+#[test]
 fn version_info_report_includes_compiled_feature_section() {
     let report = VersionInfoReport::new(VersionInfoConfig::default());
     let rendered = report.human_readable();

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -5284,7 +5284,7 @@ where
     }
 
     if parsed.show_version && parsed.remainder.is_empty() {
-        let report = VersionInfoReport::default().with_daemon_brand(parsed.program_name.brand());
+        let report = VersionInfoReport::for_daemon_brand(parsed.program_name.brand());
         let banner = report.human_readable();
         if stdout.write_all(banner.as_bytes()).is_err() {
             return 1;

--- a/crates/daemon/src/tests.rs
+++ b/crates/daemon/src/tests.rs
@@ -4386,9 +4386,7 @@ fn version_flag_renders_report() {
     assert_eq!(code, 0);
     assert!(stderr.is_empty());
 
-    let expected = VersionInfoReport::default()
-        .with_daemon_brand(Brand::Upstream)
-        .human_readable();
+    let expected = VersionInfoReport::for_daemon_brand(Brand::Upstream).human_readable();
     assert_eq!(stdout, expected.into_bytes());
 }
 
@@ -4399,9 +4397,7 @@ fn oc_version_flag_renders_report() {
     assert_eq!(code, 0);
     assert!(stderr.is_empty());
 
-    let expected = VersionInfoReport::default()
-        .with_daemon_brand(Brand::Oc)
-        .human_readable();
+    let expected = VersionInfoReport::for_daemon_brand(Brand::Oc).human_readable();
     assert_eq!(stdout, expected.into_bytes());
 }
 


### PR DESCRIPTION
## Summary
- add convenience constructors on `VersionInfoReport` for client and daemon brands
- update the CLI and daemon to use the new helpers and refresh the associated tests
- extend the version-report test suite to cover the new constructors and custom configuration paths

## Testing
- cargo test -p rsync-core version::tests::report
- cargo test -p rsync-cli version_flag_renders_report
- cargo test -p rsync-cli oc_version_flag_renders_oc_banner

------