### PR TITLE
Add comprehensive xtask test coverage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1332,6 +1332,7 @@ dependencies = [
  "cargo_metadata",
  "serde",
  "serde_json",
+ "tempfile",
  "toml",
 ]
 

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -12,3 +12,6 @@ toml = "0.8"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 cargo_metadata = "0.18"
+
+[dev-dependencies]
+tempfile = "3"


### PR DESCRIPTION
## Summary
- add `tempfile` as an xtask dev-dependency to support temporary workspaces in tests
- add broad xtask test coverage for utility helpers, command execution, and configuration resolution
- enhance the enforce-limits test environment guard to manage multiple variables safely

## Testing
- cargo test -p xtask -- --test-threads=1
- cargo test -p xtask

------