### PR TITLE
Fix doc links in transport negotiation docs

### DIFF
--- a/crates/transport/src/negotiation/buffer/errors.rs
+++ b/crates/transport/src/negotiation/buffer/errors.rs
@@ -112,7 +112,8 @@ impl BufferedCopyTooSmall {
     /// Returns how many additional bytes would have been required for the copy to succeed.
     ///
     /// The difference is calculated with saturation to guard against inconsistent inputs. When the
-    /// error originates from helpers such as [`super::NegotiatedStream::copy_buffered_into_slice`], the
+    /// error originates from helpers such as
+    /// [`crate::negotiation::NegotiatedStream::copy_buffered_into_slice`], the
     /// return value matches `required - provided`, mirroring the missing capacity reported by
     /// upstream rsync diagnostics.
     ///

--- a/crates/transport/src/negotiation/stream.rs
+++ b/crates/transport/src/negotiation/stream.rs
@@ -262,7 +262,8 @@ impl<R> NegotiatedStream<R> {
 
     /// Returns the sniffed negotiation prefix together with any buffered remainder.
     ///
-    /// The tuple mirrors the view exposed by [`NegotiationPrologueSniffer::buffered_split`],
+    /// The tuple mirrors the view exposed by
+    /// [`rsync_protocol::NegotiationPrologueSniffer::buffered_split`],
     /// allowing higher layers to borrow both slices simultaneously when staging replay
     /// buffers. The first element contains the portion of the canonical prefix that has not
     /// yet been replayed, while the second slice exposes any additional payload that
@@ -729,7 +730,7 @@ impl<R: Read> NegotiatedStream<R> {
     /// Reads the legacy daemon greeting line after the negotiation prefix has been sniffed.
     ///
     /// The method mirrors [`rsync_protocol::read_legacy_daemon_line`] but operates on the
-    /// replaying stream wrapper instead of a [`NegotiationPrologueSniffer`]. It expects the
+    /// replaying stream wrapper instead of a [`rsync_protocol::NegotiationPrologueSniffer`]. It expects the
     /// negotiation to have been classified as legacy ASCII and the canonical `@RSYNCD:` prefix
     /// to remain fully buffered. Consuming any of the replay bytes before invoking the helper
     /// results in an [`io::ErrorKind::InvalidInput`] error so higher layers cannot accidentally


### PR DESCRIPTION
## Summary
- fix broken intra-doc links in transport negotiation buffer and stream docs
- point references at the exported NegotiatedStream and protocol sniffer types to keep rustdoc happy

## Testing
- cargo --locked run -p xtask -- docs --validate

------