### PR TITLE
CI: remove unsupported windows aarch64 target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,11 +205,6 @@ jobs:
             target: i686-pc-windows-gnu
             build_command: zigbuild
             build_daemon: false
-          - os: windows
-            arch: aarch64
-            target: aarch64-pc-windows-gnu
-            build_command: zigbuild
-            build_daemon: false
     env:
       CC_aarch64_unknown_linux_gnu: ${{ matrix.target == 'aarch64-unknown-linux-gnu' && 'aarch64-linux-gnu-gcc' || '' }}
       CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: ${{ matrix.target == 'aarch64-unknown-linux-gnu' && 'aarch64-linux-gnu-gcc' || '' }}


### PR DESCRIPTION
## Summary
- remove the Windows aarch64 GNU target from the cross-compile job to avoid failing toolchain installs

## Testing
- not run (workflow-only change)

------