### PR TITLE
Track bandwidth limiter sleep durations

### DIFF
--- a/crates/bandwidth/README.md
+++ b/crates/bandwidth/README.md
@@ -67,7 +67,7 @@ let limit = parse_bandwidth_argument("8M").expect("valid limit")
 let mut limiter = BandwidthLimiter::new(limit);
 let chunk = limiter.recommended_read_size(1 << 20);
 assert!(chunk <= 1 << 20);
-limiter.register(chunk);
+let _sleep = limiter.register(chunk);
 ```
 
 The example mirrors how higher layers throttle outgoing writes. The limiter

--- a/crates/bandwidth/src/lib.rs
+++ b/crates/bandwidth/src/lib.rs
@@ -7,7 +7,7 @@
 mod limiter;
 mod parse;
 
-pub use crate::limiter::{BandwidthLimiter, LimiterChange, apply_effective_limit};
+pub use crate::limiter::{BandwidthLimiter, LimiterChange, LimiterSleep, apply_effective_limit};
 #[cfg(any(test, feature = "test-support"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "test-support")))]
 pub use crate::limiter::{RecordedSleepIter, RecordedSleepSession, recorded_sleep_session};

--- a/crates/bandwidth/src/limiter/test_support.rs
+++ b/crates/bandwidth/src/limiter/test_support.rs
@@ -97,7 +97,7 @@ impl<'a> RecordedSleepSession<'a> {
     /// session.clear();
     ///
     /// let mut limiter = BandwidthLimiter::new(NonZeroU64::new(1024).unwrap());
-    /// limiter.register(2048);
+    /// let _ = limiter.register(2048);
     ///
     /// let snapshot = session.snapshot();
     /// assert!(!snapshot.is_empty());
@@ -129,7 +129,7 @@ impl<'a> RecordedSleepSession<'a> {
     /// session.clear();
     ///
     /// let mut limiter = BandwidthLimiter::new(NonZeroU64::new(1024).unwrap());
-    /// limiter.register(2048);
+    /// let _ = limiter.register(2048);
     ///
     /// assert!(session.last_duration().is_some());
     /// assert_eq!(session.last_duration(), session.snapshot().last().copied());
@@ -162,7 +162,7 @@ impl<'a> RecordedSleepSession<'a> {
     /// session.clear();
     ///
     /// let mut limiter = BandwidthLimiter::new(NonZeroU64::new(1024).unwrap());
-    /// limiter.register(2048);
+    /// let _ = limiter.register(2048);
     ///
     /// assert_eq!(session.total_duration(), Duration::from_secs(2));
     /// assert_eq!(session.total_duration(), Duration::from_secs(2));
@@ -221,7 +221,7 @@ impl<'a> RecordedSleepSession<'a> {
     /// session.clear();
     ///
     /// let mut limiter = BandwidthLimiter::new(NonZeroU64::new(1024).unwrap());
-    /// limiter.register(2048);
+    /// let _ = limiter.register(2048);
     ///
     /// let durations: Vec<_> = session.iter().collect();
     /// assert_eq!(durations, session.take());
@@ -260,7 +260,7 @@ impl<'a> RecordedSleepSession<'a> {
 /// let mut limiter = BandwidthLimiter::new(NonZeroU64::new(1024).unwrap());
 /// let mut session = recorded_sleep_session();
 /// session.clear();
-/// limiter.register(1024);
+/// let _ = limiter.register(1024);
 ///
 /// let durations: Vec<_> = session.into_iter().collect();
 /// assert_eq!(durations.len(), 1);

--- a/crates/bandwidth/src/limiter/tests/recording.rs
+++ b/crates/bandwidth/src/limiter/tests/recording.rs
@@ -12,7 +12,7 @@ fn recorded_sleep_session_into_vec_consumes_guard() {
     session.clear();
 
     let mut limiter = BandwidthLimiter::new(NonZeroU64::new(1024).unwrap());
-    limiter.register(2048);
+    let _ = limiter.register(2048);
 
     let recorded = session.into_vec();
     assert!(!recorded.is_empty());

--- a/crates/core/src/client/mod.rs
+++ b/crates/core/src/client/mod.rs
@@ -2885,6 +2885,13 @@ impl ClientSummary {
         self.stats.total_elapsed()
     }
 
+    /// Returns the cumulative duration spent sleeping due to bandwidth throttling.
+    #[must_use]
+    #[doc(alias = "--bwlimit")]
+    pub fn bandwidth_sleep(&self) -> Duration {
+        self.stats.bandwidth_sleep()
+    }
+
     /// Returns the number of bytes that would be transmitted for the file list.
     #[must_use]
     pub fn file_list_size(&self) -> u64 {

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -3653,7 +3653,7 @@ fn write_limited(
         while !remaining.is_empty() {
             let chunk_len = limiter.recommended_read_size(remaining.len());
             stream.write_all(&remaining[..chunk_len])?;
-            limiter.register(chunk_len);
+            let _ = limiter.register(chunk_len);
             remaining = &remaining[chunk_len..];
         }
         Ok(())


### PR DESCRIPTION
## Summary
- add a LimiterSleep record returned by the bandwidth limiter and expose it to callers
- accumulate total throttling sleep in LocalCopySummary/ClientSummary and validate via tests
- adjust documentation and tests to account for the new API and recorded durations

## Testing
- cargo test -p rsync-bandwidth
- cargo test -p rsync-engine --lib local_copy

------