### PR TITLE
Ensure zig-provided dlltool is in PATH for cross builds

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustc-wrapper = "tools/cross/rustc-with-zig.sh"

--- a/tools/cross/bin/i686-w64-mingw32-dlltool
+++ b/tools/cross/bin/i686-w64-mingw32-dlltool
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -eu
+ZIG_BIN=${ZIG:-zig}
+if ! command -v "$ZIG_BIN" >/dev/null 2>&1; then
+    echo "error: zig is required to emulate i686-w64-mingw32-dlltool" >&2
+    exit 1
+fi
+exec "$ZIG_BIN" dlltool "$@"

--- a/tools/cross/bin/x86_64-w64-mingw32-dlltool
+++ b/tools/cross/bin/x86_64-w64-mingw32-dlltool
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -eu
+ZIG_BIN=${ZIG:-zig}
+if ! command -v "$ZIG_BIN" >/dev/null 2>&1; then
+    echo "error: zig is required to emulate x86_64-w64-mingw32-dlltool" >&2
+    exit 1
+fi
+exec "$ZIG_BIN" dlltool "$@"

--- a/tools/cross/rustc-with-zig.sh
+++ b/tools/cross/rustc-with-zig.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -eu
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+CROSS_BIN="${SCRIPT_DIR}/bin"
+case ":$PATH:" in
+    *:"${CROSS_BIN}":*) ;;
+    *) PATH="${CROSS_BIN}:$PATH" ;;
+esac
+exec "$@"


### PR DESCRIPTION
## Summary
- add a rustc wrapper that injects the cross bin directory into PATH so cargo can find our helper tools
- provide zig-backed i686/x86_64 dlltool shims to satisfy windows-gnu link requirements during cross compilation

## Testing
- cargo build

------