### PR TITLE
Fix clippy double must_use lint in negotiation sniffer

### DIFF
--- a/crates/protocol/src/negotiation/sniffer/observe.rs
+++ b/crates/protocol/src/negotiation/sniffer/observe.rs
@@ -61,7 +61,6 @@ impl NegotiationPrologueSniffer {
     }
 
     /// Observes a single byte that has already been read from the transport.
-    #[must_use]
     #[inline]
     pub fn observe_byte(&mut self, byte: u8) -> Result<NegotiationPrologue, TryReserveError> {
         let (decision, consumed) = self.observe(slice::from_ref(&byte))?;


### PR DESCRIPTION
## Summary
- remove the redundant `#[must_use]` attribute from `observe_byte` to satisfy Clippy's `double_must_use` lint

## Testing
- cargo clippy --workspace --all-targets --all-features --locked -- -Dwarnings

------