### PR TITLE
Fix cfg handling for chmod metadata

### DIFF
--- a/crates/meta/src/apply.rs
+++ b/crates/meta/src/apply.rs
@@ -136,6 +136,8 @@ fn set_owner_like(
 
     #[cfg(not(unix))]
     {
+        let _ = metadata;
+        let _ = follow_symlinks;
         if options.owner()
             || options.group()
             || options.owner_override().is_some()

--- a/crates/meta/src/chmod/apply.rs
+++ b/crates/meta/src/chmod/apply.rs
@@ -1,3 +1,4 @@
+#[cfg(unix)]
 use super::spec::{Clause, ClauseKind, Operation, PermSpec, SymbolicClause};
 
 #[cfg(unix)]

--- a/crates/meta/src/chmod/mod.rs
+++ b/crates/meta/src/chmod/mod.rs
@@ -16,6 +16,7 @@ mod spec;
 
 use std::fmt;
 
+#[cfg(unix)]
 use apply::apply_clauses;
 use parse::parse_spec;
 use spec::Clause;


### PR DESCRIPTION
## Summary
- gate the chmod clause evaluator import behind a Unix cfg to avoid missing symbol errors
- guard Unix-only imports and parameters so non-Unix builds do not trigger unused warnings

## Testing
- cargo check

------