### PR TITLE
Fix formatting of non-unix chmod apply_clauses

### DIFF
--- a/crates/meta/src/chmod/apply.rs
+++ b/crates/meta/src/chmod/apply.rs
@@ -31,11 +31,7 @@ pub(crate) fn apply_clauses(
 }
 
 #[cfg(not(unix))]
-pub(crate) fn apply_clauses(
-    _clauses: &[Clause],
-    mode: u32,
-    _file_type: std::fs::FileType,
-) -> u32 {
+pub(crate) fn apply_clauses(_clauses: &[Clause], mode: u32, _file_type: std::fs::FileType) -> u32 {
     mode
 }
 


### PR DESCRIPTION
## Summary
- collapse the non-Unix `apply_clauses` function signature onto a single line to satisfy rustfmt

## Testing
- cargo fmt --all -- --check

------