### PR TITLE
Fix Clause import for chmod apply on Windows

### DIFF
--- a/crates/meta/src/chmod/apply.rs
+++ b/crates/meta/src/chmod/apply.rs
@@ -1,5 +1,7 @@
+use super::spec::Clause;
+
 #[cfg(unix)]
-use super::spec::{Clause, ClauseKind, Operation, PermSpec, SymbolicClause};
+use super::spec::{ClauseKind, Operation, PermSpec, SymbolicClause};
 
 #[cfg(unix)]
 pub(crate) fn apply_clauses(


### PR DESCRIPTION
## Summary
- import `Clause` unconditionally in `chmod::apply` so it is available on non-Unix targets
- gate the remaining Unix-specific types behind `cfg(unix)`

## Testing
- cargo check -p rsync-meta

------