### PR TITLE
Silence chmod warnings on non-unix builds

### DIFF
--- a/crates/meta/src/chmod/apply.rs
+++ b/crates/meta/src/chmod/apply.rs
@@ -33,6 +33,7 @@ pub(crate) fn apply_clauses(
 }
 
 #[cfg(not(unix))]
+#[allow(dead_code)]
 pub(crate) fn apply_clauses(_clauses: &[Clause], mode: u32, _file_type: std::fs::FileType) -> u32 {
     mode
 }

--- a/crates/meta/src/chmod/spec.rs
+++ b/crates/meta/src/chmod/spec.rs
@@ -16,6 +16,7 @@ impl TargetSelector {
     }
 
     #[cfg(not(unix))]
+    #[allow(dead_code)]
     pub(crate) fn matches(self, _file_type: std::fs::FileType) -> bool {
         matches!(self, TargetSelector::All | TargetSelector::Files)
     }
@@ -40,18 +41,22 @@ impl WhoMask {
         Self { user, group, other }
     }
 
+    #[cfg_attr(not(unix), allow(dead_code))]
     pub(crate) fn includes_user(self) -> bool {
         self.user
     }
 
+    #[cfg_attr(not(unix), allow(dead_code))]
     pub(crate) fn includes_group(self) -> bool {
         self.group
     }
 
+    #[cfg_attr(not(unix), allow(dead_code))]
     pub(crate) fn includes_other(self) -> bool {
         self.other
     }
 
+    #[cfg_attr(not(unix), allow(dead_code))]
     pub(crate) fn covers_all(self) -> bool {
         self.user && self.group && self.other
     }


### PR DESCRIPTION
## Summary
- suppress dead-code warnings for non-Unix chmod helpers by gating with cfg_attr
- ensure the Windows stub of apply_clauses is annotated to avoid unused warnings

## Testing
- cargo check

------