### PR TITLE
Normalize test shard source locations

### DIFF
--- a/crates/core/src/message/tests/part1.rs
+++ b/crates/core/src/message/tests/part1.rs
@@ -265,6 +265,15 @@ fn normalizes_redundant_segments() {
 }
 
 #[test]
+fn include_shards_map_to_virtual_tests_entry_point() {
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    let source = SourceLocation::from_parts(manifest_dir, "src/message/tests/part3.rs", 11);
+
+    assert_eq!(source.path(), "crates/core/src/message/tests.rs");
+    assert_eq!(source.line(), 11);
+}
+
+#[test]
 fn retains_absolute_paths_outside_workspace() {
     let manifest_dir = env!("CARGO_MANIFEST_DIR");
     let source = SourceLocation::from_parts(manifest_dir, "/tmp/outside.rs", 42);


### PR DESCRIPTION
## Summary
- normalize message source paths so test shards report the virtual tests.rs entry point
- add a regression test covering the include!-based shard paths

## Testing
- cargo test -p rsync-core message::tests::formats_error_with_code_role_and_source -- --nocapture
- cargo test -p rsync-core message::tests::include_shards_map_to_virtual_tests_entry_point

------