### PR TITLE
Fix clippy question mark lint in rewrite_test_shard

### DIFF
--- a/crates/core/src/message/source.rs
+++ b/crates/core/src/message/source.rs
@@ -136,9 +136,7 @@ fn rewrite_test_shard(path: &str) -> Option<String> {
     }
 
     let last = segments[segments.len() - 1];
-    let Some(digits) = last.strip_prefix("part")?.strip_suffix(".rs") else {
-        return None;
-    };
+    let digits = last.strip_prefix("part")?.strip_suffix(".rs")?;
 
     if digits.is_empty() || !digits.chars().all(|ch| ch.is_ascii_digit()) {
         return None;


### PR DESCRIPTION
## Summary
- simplify the rewrite_test_shard helper to use the question mark operator instead of let-else

## Testing
- cargo clippy --workspace --all-targets --all-features --locked -- -Dwarnings

------