### PR TITLE
Fix Windows device detection and stabilize message source test

### DIFF
--- a/crates/core/src/message/tests/part2.rs
+++ b/crates/core/src/message/tests/part2.rs
@@ -180,7 +180,17 @@ fn tracked_message_source_propagates_caller_location() {
 
     let helper_location = untracked_source();
     assert_ne!(helper_location.line(), expected_line);
-    assert_eq!(helper_location.path(), location.path());
+    let helper_path = normalize_tests_module_path(helper_location.path());
+    let tracked_path = normalize_tests_module_path(location.path());
+    assert_eq!(helper_path, tracked_path);
+}
+
+fn normalize_tests_module_path(path: &str) -> std::borrow::Cow<'_, str> {
+    if let Some(stripped) = path.strip_suffix("tests.rs") {
+        std::borrow::Cow::Owned(format!("{stripped}tests/mod.rs"))
+    } else {
+        std::borrow::Cow::Borrowed(path)
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- derive Windows device identifiers from path prefixes to avoid unstable metadata APIs
- adjust Windows trailing separator detection to iterate without requiring double-ended iterators
- normalize expected test paths so tracked source tests tolerate the split module layout

## Testing
- cargo check -p rsync-engine
- cargo test -p rsync-core message::tests::tracked_message_source_propagates_caller_location

------