### PR TITLE
Avoid unstable metadata API on Windows

### DIFF
--- a/crates/engine/src/local_copy.rs
+++ b/crates/engine/src/local_copy.rs
@@ -234,13 +234,12 @@ fn device_identifier(path: &Path, metadata: &fs::Metadata) -> Option<u64> {
         }
 
         let absolute = normalize_path(path);
-        let device_from_metadata = metadata.volume_serial_number() as u64;
+        // The standard library's `MetadataExt::volume_serial_number` accessor is currently
+        // unstable on Windows, so fall back to deriving the device identifier from the path
+        // components instead.
+        let _ = metadata;
 
-        if device_from_metadata != 0 {
-            Some(device_from_metadata)
-        } else {
-            device_from_components(absolute.as_ref())
-        }
+        device_from_components(absolute.as_ref())
     }
 
     #[cfg(not(any(unix, windows)))]


### PR DESCRIPTION
## Summary
- derive Windows device identifiers from normalized path components when metadata access is unstable
- document the rationale for the fallback

## Testing
- cargo check -p rsync-engine

------