### PR TITLE
Fix unused Windows metadata import in local copy module

### DIFF
--- a/crates/engine/src/local_copy.rs
+++ b/crates/engine/src/local_copy.rs
@@ -203,7 +203,6 @@ fn device_identifier(path: &Path, metadata: &fs::Metadata) -> Option<u64> {
     {
         use std::borrow::Cow;
         use std::hash::{Hash, Hasher};
-        use std::os::windows::fs::MetadataExt;
         use std::path::{Component, Prefix};
 
         fn normalize_path<'a>(path: &'a Path) -> Cow<'a, Path> {


### PR DESCRIPTION
## Summary
- remove the unused `std::os::windows::fs::MetadataExt` import from `device_identifier`
- keep the Windows-specific code path free from denied warnings

## Testing
- cargo check -p rsync-engine

------