### PR TITLE
Fix Windows cross-compilation by gating unix-only user lookups

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -28,6 +28,8 @@ rsync-meta = { path = "../meta" }
 rsync-checksums = { path = "../checksums" }
 time = { version = "0.3", default-features = false, features = ["formatting", "macros"] }
 tempfile = "3.10"
+
+[target.'cfg(unix)'.dependencies]
 users = "0.11"
 
 [dev-dependencies]

--- a/crates/cli/src/out_format/render.rs
+++ b/crates/cli/src/out_format/render.rs
@@ -9,6 +9,7 @@ use std::time::SystemTime;
 use rsync_checksums::strong::Md5;
 use rsync_core::client::{ClientEntryKind, ClientEntryMetadata, ClientEvent, ClientEventKind};
 use time::OffsetDateTime;
+#[cfg(unix)]
 use users::{get_group_by_gid, get_user_by_uid, gid_t, uid_t};
 
 use crate::{LIST_TIMESTAMP_FORMAT, describe_event_kind, format_list_permissions};
@@ -226,6 +227,7 @@ fn format_group_name(metadata: Option<&ClientEntryMetadata>) -> String {
         .unwrap_or_else(|| "0".to_string())
 }
 
+#[cfg(unix)]
 fn resolve_user_name(uid: u32) -> String {
     get_user_by_uid(uid as uid_t)
         .map(|user| user.name().to_string_lossy().into_owned())
@@ -233,11 +235,22 @@ fn resolve_user_name(uid: u32) -> String {
         .unwrap_or_else(|| uid.to_string())
 }
 
+#[cfg(not(unix))]
+fn resolve_user_name(uid: u32) -> String {
+    uid.to_string()
+}
+
+#[cfg(unix)]
 fn resolve_group_name(gid: u32) -> String {
     get_group_by_gid(gid as gid_t)
         .map(|group| group.name().to_string_lossy().into_owned())
         .filter(|name| !name.is_empty())
         .unwrap_or_else(|| gid.to_string())
+}
+
+#[cfg(not(unix))]
+fn resolve_group_name(gid: u32) -> String {
+    gid.to_string()
 }
 
 fn format_current_timestamp() -> String {


### PR DESCRIPTION
## Summary
- gate the `users` dependency for the CLI behind `cfg(unix)`
- fall back to numeric-only owner/group resolution for non-Unix targets
- render owner and group names as numeric identifiers when lookups are unavailable

## Testing
- cargo check -p rsync-cli

------