### PR TITLE
Make CLI user lookup portable

### DIFF
--- a/crates/apple-fs/src/lib.rs
+++ b/crates/apple-fs/src/lib.rs
@@ -1,6 +1,11 @@
 use std::io;
 use std::path::Path;
 
+#[cfg(not(unix))]
+type ModeType = libc::c_uint;
+#[cfg(not(unix))]
+type DeviceType = libc::c_uint;
+
 #[cfg(unix)]
 mod unix {
     use super::{Path, io};
@@ -37,7 +42,7 @@ mod unix {
 pub use unix::{mkfifo, mknod};
 
 #[cfg(not(unix))]
-pub fn mkfifo(_path: &Path, _mode: libc::mode_t) -> io::Result<()> {
+pub fn mkfifo(_path: &Path, _mode: ModeType) -> io::Result<()> {
     Err(io::Error::new(
         io::ErrorKind::Unsupported,
         "mkfifo is only implemented on Unix platforms",
@@ -45,7 +50,7 @@ pub fn mkfifo(_path: &Path, _mode: libc::mode_t) -> io::Result<()> {
 }
 
 #[cfg(not(unix))]
-pub fn mknod(_path: &Path, _mode: libc::mode_t, _device: libc::dev_t) -> io::Result<()> {
+pub fn mknod(_path: &Path, _mode: ModeType, _device: DeviceType) -> io::Result<()> {
     Err(io::Error::new(
         io::ErrorKind::Unsupported,
         "mknod is only implemented on Unix platforms",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -28,6 +28,8 @@ rsync-meta = { path = "../meta" }
 rsync-checksums = { path = "../checksums" }
 time = { version = "0.3", default-features = false, features = ["formatting", "macros"] }
 tempfile = "3.10"
+
+[target.'cfg(unix)'.dependencies]
 users = "0.11"
 
 [dev-dependencies]

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -15,6 +15,7 @@
 //! hygiene policy.
 
 mod frontend;
+mod platform;
 
 pub use frontend::{exit_code_from, run};
 

--- a/crates/cli/src/out_format/render.rs
+++ b/crates/cli/src/out_format/render.rs
@@ -9,9 +9,8 @@ use std::time::SystemTime;
 use rsync_checksums::strong::Md5;
 use rsync_core::client::{ClientEntryKind, ClientEntryMetadata, ClientEvent, ClientEventKind};
 use time::OffsetDateTime;
-use users::{get_group_by_gid, get_user_by_uid, gid_t, uid_t};
 
-use crate::{LIST_TIMESTAMP_FORMAT, describe_event_kind, format_list_permissions};
+use crate::{LIST_TIMESTAMP_FORMAT, describe_event_kind, format_list_permissions, platform};
 
 use super::tokens::{OutFormat, OutFormatContext, OutFormatPlaceholder, OutFormatToken};
 
@@ -227,17 +226,11 @@ fn format_group_name(metadata: Option<&ClientEntryMetadata>) -> String {
 }
 
 fn resolve_user_name(uid: u32) -> String {
-    get_user_by_uid(uid as uid_t)
-        .map(|user| user.name().to_string_lossy().into_owned())
-        .filter(|name| !name.is_empty())
-        .unwrap_or_else(|| uid.to_string())
+    platform::display_user_name(uid).unwrap_or_else(|| uid.to_string())
 }
 
 fn resolve_group_name(gid: u32) -> String {
-    get_group_by_gid(gid as gid_t)
-        .map(|group| group.name().to_string_lossy().into_owned())
-        .filter(|name| !name.is_empty())
-        .unwrap_or_else(|| gid.to_string())
+    platform::display_group_name(gid).unwrap_or_else(|| gid.to_string())
 }
 
 fn format_current_timestamp() -> String {

--- a/crates/cli/src/platform.rs
+++ b/crates/cli/src/platform.rs
@@ -1,0 +1,87 @@
+//! Platform-specific helpers for user and group identity lookups.
+
+#[cfg(unix)]
+use users::{
+    get_group_by_gid, get_group_by_name, get_user_by_name, get_user_by_uid, gid_t as UsersGid,
+    uid_t as UsersUid,
+};
+
+#[cfg(unix)]
+#[allow(non_camel_case_types)]
+pub(crate) type gid_t = UsersGid;
+#[cfg(unix)]
+#[allow(non_camel_case_types)]
+pub(crate) type uid_t = UsersUid;
+
+#[cfg(not(unix))]
+#[allow(non_camel_case_types)]
+pub(crate) type gid_t = u32;
+#[cfg(not(unix))]
+#[allow(non_camel_case_types)]
+pub(crate) type uid_t = u32;
+
+/// Indicates whether the platform supports resolving user names.
+pub(crate) const SUPPORTS_USER_NAME_LOOKUP: bool = cfg!(unix);
+/// Indicates whether the platform supports resolving group names.
+pub(crate) const SUPPORTS_GROUP_NAME_LOOKUP: bool = cfg!(unix);
+
+#[cfg(unix)]
+fn to_owned<C>(value: C) -> Option<String>
+where
+    C: AsRef<std::ffi::OsStr>,
+{
+    let value = value.as_ref();
+    if value.is_empty() {
+        None
+    } else {
+        Some(value.to_string_lossy().into_owned())
+    }
+}
+
+#[cfg(unix)]
+#[inline]
+pub(crate) fn lookup_user_by_name(name: &str) -> Option<uid_t> {
+    get_user_by_name(name).map(|user| user.uid())
+}
+
+#[cfg(not(unix))]
+#[inline]
+pub(crate) fn lookup_user_by_name(_name: &str) -> Option<uid_t> {
+    None
+}
+
+#[cfg(unix)]
+#[inline]
+pub(crate) fn lookup_group_by_name(name: &str) -> Option<gid_t> {
+    get_group_by_name(name).map(|group| group.gid())
+}
+
+#[cfg(not(unix))]
+#[inline]
+pub(crate) fn lookup_group_by_name(_name: &str) -> Option<gid_t> {
+    None
+}
+
+#[cfg(unix)]
+#[inline]
+pub(crate) fn display_user_name(uid: u32) -> Option<String> {
+    get_user_by_uid(uid as uid_t).and_then(|user| to_owned(user.name()))
+}
+
+#[cfg(not(unix))]
+#[inline]
+pub(crate) fn display_user_name(_uid: u32) -> Option<String> {
+    None
+}
+
+#[cfg(unix)]
+#[inline]
+pub(crate) fn display_group_name(gid: u32) -> Option<String> {
+    get_group_by_gid(gid as gid_t).and_then(|group| to_owned(group.name()))
+}
+
+#[cfg(not(unix))]
+#[inline]
+pub(crate) fn display_group_name(_gid: u32) -> Option<String> {
+    None
+}


### PR DESCRIPTION
## Summary
- add a platform abstraction for UID/GID lookups so Windows builds no longer depend on the unix-only `users` crate
- guard the CLI's use of username/group resolution and fall back to numeric IDs when lookups are unsupported
- fix the Apple filesystem helper so non-Unix targets compile by stubbing the expected libc types

## Testing
- cargo check
- cargo check --target i686-pc-windows-gnu

------