### PR TITLE
Fix duplicate users imports in CLI modules

### DIFF
--- a/crates/cli/src/frontend.rs
+++ b/crates/cli/src/frontend.rs
@@ -112,14 +112,6 @@ use rsync_core::{
 use rsync_logging::MessageSink;
 use rsync_meta::ChmodModifiers;
 use rsync_protocol::{ParseProtocolVersionErrorKind, ProtocolVersion};
-#[cfg(unix)]
-use users::{get_group_by_name, get_user_by_name, gid_t, uid_t};
-
-#[cfg(not(unix))]
-type uid_t = u32;
-#[cfg(not(unix))]
-type gid_t = u32;
-
 #[path = "defaults.rs"]
 mod defaults;
 #[path = "help.rs"]

--- a/crates/cli/src/out_format/render.rs
+++ b/crates/cli/src/out_format/render.rs
@@ -9,9 +9,6 @@ use std::time::SystemTime;
 use rsync_checksums::strong::Md5;
 use rsync_core::client::{ClientEntryKind, ClientEntryMetadata, ClientEvent, ClientEventKind};
 use time::OffsetDateTime;
-#[cfg(unix)]
-use users::{get_group_by_gid, get_user_by_uid, gid_t, uid_t};
-
 use crate::{LIST_TIMESTAMP_FORMAT, describe_event_kind, format_list_permissions, platform};
 
 use super::tokens::{OutFormat, OutFormatContext, OutFormatPlaceholder, OutFormatToken};


### PR DESCRIPTION
## Summary
- remove direct `users` crate imports from the CLI frontend to prevent duplicate type definitions
- drop redundant `users` imports from the out-format renderer so the platform facade handles lookups

## Testing
- cargo check -p rsync-cli

------