### PR TITLE
Expose cached JSON metadata for branding manifest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -679,6 +679,8 @@ dependencies = [
  "rsync-meta",
  "rsync-protocol",
  "rsync-transport",
+ "serde",
+ "serde_json",
  "socket2",
  "tempfile",
  "toml",

--- a/README.md
+++ b/README.md
@@ -97,6 +97,19 @@ shared branding facade, ensuring help text, diagnostics, and configuration
 searches remain consistent across entry points regardless of the executable
 name that launched the process.
 
+Automation can serialise the same snapshot without reimplementing parsing
+logic by calling [`rsync_core::branding::manifest_json`] or the pretty-printed
+variant [`rsync_core::branding::manifest_json_pretty`]:
+
+```rust
+let json = rsync_core::branding::manifest_json_pretty();
+assert!(json.contains("\"rust_version\": \"3.4.1-rust\""));
+```
+
+Both helpers cache their output for the lifetime of the process, keeping
+command-line tooling lightweight while guaranteeing that downstream consumers
+observe the same metadata as the binaries themselves.
+
 Workspace automation consumes the same identifiers via the
 `[workspace.metadata.oc_rsync]` section in the top-level `Cargo.toml`. The
 metadata records the canonical program names, configuration locations, source

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -27,6 +27,8 @@ base64 = "0.22"
 rsync-checksums = { path = "../checksums" }
 tempfile = "3.10"
 socket2 = "0.4"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 
 [features]
 default = []

--- a/crates/core/src/branding/brand.rs
+++ b/crates/core/src/branding/brand.rs
@@ -4,8 +4,6 @@ use core::str::FromStr;
 use std::fmt;
 use std::path::Path;
 
-use crate::workspace;
-
 use super::constants::{
     OC_CLIENT_PROGRAM_NAME, OC_DAEMON_PROGRAM_NAME, UPSTREAM_CLIENT_PROGRAM_NAME,
     UPSTREAM_DAEMON_PROGRAM_NAME,
@@ -14,6 +12,8 @@ use super::profile::{
     BrandProfile, config_path_candidate_strs, config_path_candidates, oc_profile,
     secrets_path_candidate_strs, secrets_path_candidates, upstream_profile,
 };
+use crate::workspace;
+use serde::ser::{Serialize, Serializer};
 
 /// Identifies the brand associated with an executable name.
 ///
@@ -189,6 +189,15 @@ pub fn default_brand() -> Brand {
 impl fmt::Display for Brand {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(self.label())
+    }
+}
+
+impl Serialize for Brand {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(self.label())
     }
 }
 

--- a/crates/core/src/branding/json.rs
+++ b/crates/core/src/branding/json.rs
@@ -1,0 +1,79 @@
+#![allow(clippy::module_name_repetitions)]
+
+//! JSON serialisation helpers for workspace branding metadata.
+//!
+//! The [`manifest_json`] and [`manifest_json_pretty`] helpers expose cached JSON
+//! renderings of the [`BrandManifest`][super::manifest::BrandManifest]. Emitting
+//! the serialised form directly from the branding module keeps automation and
+//! packaging tooling aligned with the canonical runtime metadata without
+//! re-parsing `Cargo.toml` or re-implementing serialisation logic in
+//! higher-level crates.
+
+use std::sync::OnceLock;
+
+use super::manifest::manifest;
+
+fn render_manifest_json(pretty: bool) -> String {
+    let manifest = manifest();
+
+    if pretty {
+        serde_json::to_string_pretty(manifest)
+            .expect("failed to serialise branding manifest as pretty JSON")
+    } else {
+        serde_json::to_string(manifest).expect("failed to serialise branding manifest as JSON")
+    }
+}
+
+/// Returns the cached JSON representation of the workspace branding manifest.
+///
+/// The returned string is cached for the lifetime of the process and reflects
+/// the data exposed by [`manifest`]. Callers that need structured metadata can
+/// parse the JSON into their preferred representation without duplicating the
+/// serialisation logic.
+///
+/// ```
+/// let json = rsync_core::branding::manifest_json();
+/// assert!(json.contains("\"client_program_name\":\"oc-rsync\""));
+/// ```
+#[must_use]
+pub fn manifest_json() -> &'static str {
+    static JSON: OnceLock<String> = OnceLock::new();
+    JSON.get_or_init(|| render_manifest_json(false)).as_str()
+}
+
+/// Returns the cached pretty-printed JSON representation of the branding
+/// manifest.
+///
+/// This helper mirrors [`manifest_json`] but emits human-readable output with
+/// indentation so configuration management systems can store the manifest
+/// snapshot directly.
+///
+/// ```
+/// let json = rsync_core::branding::manifest_json_pretty();
+/// assert!(json.lines().any(|line| line.contains("\"daemon_program_name\"")));
+/// ```
+#[must_use]
+pub fn manifest_json_pretty() -> &'static str {
+    static JSON_PRETTY: OnceLock<String> = OnceLock::new();
+    JSON_PRETTY
+        .get_or_init(|| render_manifest_json(true))
+        .as_str()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn manifest_json_matches_direct_serialisation() {
+        let expected = serde_json::to_string(manifest()).expect("failed to serialise manifest");
+        assert_eq!(manifest_json(), expected);
+    }
+
+    #[test]
+    fn manifest_json_pretty_matches_direct_serialisation() {
+        let expected =
+            serde_json::to_string_pretty(manifest()).expect("failed to serialise manifest");
+        assert_eq!(manifest_json_pretty(), expected);
+    }
+}

--- a/crates/core/src/branding/manifest.rs
+++ b/crates/core/src/branding/manifest.rs
@@ -12,6 +12,7 @@
 //! first use from [`crate::workspace::metadata()`] and cached for the lifetime of
 //! the process so callers can obtain references to the data at negligible cost.
 
+use serde::Serialize;
 use std::sync::OnceLock;
 
 use super::brand::{self, Brand};
@@ -20,7 +21,7 @@ use crate::version::{self, BUILD_TOOLCHAIN};
 use crate::workspace;
 
 /// Cached branding snapshot derived from the workspace manifest.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
 pub struct BrandManifest {
     default_brand: Brand,
     oc: BrandProfile,

--- a/crates/core/src/branding/mod.rs
+++ b/crates/core/src/branding/mod.rs
@@ -16,6 +16,7 @@
 mod brand;
 mod constants;
 mod detection;
+mod json;
 mod manifest;
 mod override_env;
 mod profile;
@@ -31,6 +32,7 @@ pub use constants::{
     UPSTREAM_CLIENT_PROGRAM_NAME, UPSTREAM_DAEMON_PROGRAM_NAME, brand_override_env_var,
 };
 pub use detection::{brand_for_program_name, detect_brand, resolve_brand_profile};
+pub use json::{manifest_json, manifest_json_pretty};
 pub use manifest::{BrandManifest, manifest};
 pub use profile::{
     BrandProfile, client_program_name, client_program_name_os_str, daemon_program_name,

--- a/crates/core/src/branding/profile.rs
+++ b/crates/core/src/branding/profile.rs
@@ -1,5 +1,6 @@
 //! Branding profiles encapsulating canonical program names and filesystem paths.
 
+use serde::Serialize;
 use std::ffi::OsStr;
 use std::path::Path;
 
@@ -19,7 +20,7 @@ use super::constants::{
 /// codebase. The profiles are intentionally lightweight and `Copy` so they can
 /// be used in constant contexts such as rustdoc examples and compile-time
 /// assertions.
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct BrandProfile {
     client_program_name: &'static str,
     daemon_program_name: &'static str,


### PR DESCRIPTION
## Summary
- add serde-based serialisation to branding profiles and manifest data
- expose cached JSON and pretty-printed JSON helpers via a new branding::json module
- document the JSON helpers for automation consumers

## Testing
- cargo fmt
- cargo test -p rsync-core manifest_json -- --nocapture

------