### PR TITLE
Fix broken transport documentation links

### DIFF
--- a/crates/transport/src/binary/parts.rs
+++ b/crates/transport/src/binary/parts.rs
@@ -107,7 +107,7 @@ impl<R> BinaryHandshakeParts<R> {
     /// Upstream rsync writes the caller's desired protocol (after applying any `--protocol` cap) to the
     /// transport before reading the remote advertisement. Capturing the value here allows higher layers
     /// to surface diagnostics such as "client requested protocol 32 but server replied with 30" without
-    /// having to retain the original argument passed to [`negotiate_binary_session`].
+    /// having to retain the original argument passed to [`crate::negotiate_binary_session`].
     #[doc(alias = "--protocol")]
     #[must_use]
     pub const fn local_advertised_protocol(&self) -> ProtocolVersion {

--- a/crates/transport/src/negotiation/parts/try_map_error.rs
+++ b/crates/transport/src/negotiation/parts/try_map_error.rs
@@ -8,7 +8,7 @@ use std::fmt;
 /// negotiation bytes are not lost when a transformation cannot be completed. The type implements
 /// [`Clone`] when both captured components support it and provides [`From`] conversions for
 /// `(error, original)` tuples, making it straightforward to shuttle the preserved pieces of state
-/// between APIs without spelling out [`TryMapInnerError::new`].
+/// between APIs without spelling out `TryMapInnerError::new`.
 ///
 /// # Examples
 ///
@@ -233,7 +233,7 @@ impl<T, E> TryMapInnerError<T, E> {
     /// Maps the preserved error into another type while retaining the original value.
     ///
     /// This mirrors [`Self::map_original`] but transforms the stored error instead. It is useful when
-    /// callers need to downgrade rich error types (for example to [`io::ErrorKind`]) without losing the
+    /// callers need to downgrade rich error types (for example to [`std::io::ErrorKind`]) without losing the
     /// buffered transport state captured by [`TryMapInnerError`].
     #[must_use]
     pub fn map_error<E2, F>(self, map: F) -> TryMapInnerError<T, E2>


### PR DESCRIPTION
## Summary
- fix the BinaryHandshakeParts documentation to link to the public negotiate helper
- update TryMapInnerError docs to avoid private links and reference std::io::ErrorKind explicitly

## Testing
- cargo --locked run -p xtask -- docs --validate

------