### PR TITLE
Fix intra-doc links for NegotiatedStream parts

### DIFF
--- a/crates/transport/src/negotiation/parts/stream_parts/access.rs
+++ b/crates/transport/src/negotiation/parts/stream_parts/access.rs
@@ -38,7 +38,7 @@ impl<R> NegotiatedStreamParts<R> {
     ///
     /// The helper mirrors [`Self::buffered`] but allocates a new vector sized for the captured
     /// transcript. Allocation failures propagate as [`TryReserveError`], matching the semantics of
-    /// [`NegotiatedStream::buffered_to_vec`].
+    /// [`crate::negotiation::NegotiatedStream::buffered_to_vec`].
     #[must_use = "the owned buffer contains the negotiation transcript"]
     pub fn buffered_to_vec(&self) -> Result<Vec<u8>, TryReserveError> {
         NegotiationBufferAccess::buffered_to_vec(self)
@@ -70,7 +70,7 @@ impl<R> NegotiatedStreamParts<R> {
 
     /// Returns the sniffed negotiation prefix together with any buffered remainder.
     ///
-    /// The tuple mirrors [`NegotiatedStream::buffered_split`], giving callers convenient access
+    /// The tuple mirrors [`crate::negotiation::NegotiatedStream::buffered_split`], giving callers convenient access
     /// to both slices when rebuilding replay buffers without cloning the stored negotiation
     /// bytes.
     #[must_use]
@@ -86,7 +86,7 @@ impl<R> NegotiatedStreamParts<R> {
 
     /// Returns how many buffered bytes had already been replayed when the stream was decomposed.
     ///
-    /// The counter mirrors [`NegotiatedStream::buffered_consumed`], allowing callers to observe the
+    /// The counter mirrors [`crate::negotiation::NegotiatedStream::buffered_consumed`], allowing callers to observe the
     /// replay position without reconstructing the wrapper. It is useful when higher layers need to
     /// resume consumption from the point where the stream was split into parts.
     ///
@@ -112,7 +112,7 @@ impl<R> NegotiatedStreamParts<R> {
 
     /// Returns the portion of the buffered negotiation transcript that had already been replayed.
     ///
-    /// This mirrors [`NegotiatedStream::buffered_consumed_slice`] but operates on the decomposed
+    /// This mirrors [`crate::negotiation::NegotiatedStream::buffered_consumed_slice`] but operates on the decomposed
     /// parts, allowing diagnostics to print the consumed prefix without rebuilding the stream.
     #[must_use]
     pub fn buffered_consumed_slice(&self) -> &[u8] {
@@ -128,7 +128,7 @@ impl<R> NegotiatedStreamParts<R> {
     /// Returns the portion of the buffered negotiation data that has not been consumed yet.
     ///
     /// The slice starts at the current replay cursor and mirrors what would be produced next if the
-    /// parts were turned back into a [`NegotiatedStream`] and read from. This is useful when the
+    /// parts were turned back into a [`crate::negotiation::NegotiatedStream`] and read from. This is useful when the
     /// parts are temporarily inspected for diagnostics without rebuilding the wrapper.
     #[must_use]
     pub fn buffered_remaining_slice(&self) -> &[u8] {
@@ -149,9 +149,9 @@ impl<R> NegotiatedStreamParts<R> {
 
     /// Returns how many bytes from the sniffed negotiation prefix remain buffered.
     ///
-    /// This mirrors [`NegotiatedStream::sniffed_prefix_remaining`], giving callers
+    /// This mirrors [`crate::negotiation::NegotiatedStream::sniffed_prefix_remaining`], giving callers
     /// access to the replay position after extracting the parts without
-    /// reconstructing a [`NegotiatedStream`].
+    /// reconstructing a [`crate::negotiation::NegotiatedStream`].
     #[must_use]
     pub fn sniffed_prefix_remaining(&self) -> usize {
         NegotiationBufferAccess::sniffed_prefix_remaining(self)
@@ -159,7 +159,7 @@ impl<R> NegotiatedStreamParts<R> {
 
     /// Reports whether the canonical legacy negotiation prefix has been fully buffered.
     ///
-    /// The method mirrors [`NegotiatedStream::legacy_prefix_complete`], making it possible to query
+    /// The method mirrors [`crate::negotiation::NegotiatedStream::legacy_prefix_complete`], making it possible to query
     /// the sniffed prefix state even after the stream has been decomposed into parts. It is `true`
     /// for legacy ASCII negotiations once the entire `@RSYNCD:` marker has been captured and `false`
     /// otherwise (including for binary sessions).

--- a/crates/transport/src/negotiation/parts/stream_parts/copy.rs
+++ b/crates/transport/src/negotiation/parts/stream_parts/copy.rs
@@ -44,7 +44,7 @@ impl<R> NegotiatedStreamParts<R> {
 
     /// Appends the buffered negotiation data to a caller-provided vector without consuming it.
     ///
-    /// The helper mirrors [`NegotiatedStream::extend_buffered_into_vec`] but operates on decomposed
+    /// The helper mirrors [`crate::negotiation::NegotiatedStream::extend_buffered_into_vec`] but operates on decomposed
     /// stream parts. Callers that temporarily separate the components can therefore continue to
     /// accumulate handshake transcripts inside pre-existing log buffers. Additional capacity is
     /// reserved via [`Vec::try_reserve`]; on success the appended length matches the buffered
@@ -65,7 +65,7 @@ impl<R> NegotiatedStreamParts<R> {
 
     /// Copies the buffered negotiation bytes into the destination vector without consuming them.
     ///
-    /// This mirrors [`NegotiatedStream::copy_buffered_into`], allowing callers that temporarily
+    /// This mirrors [`crate::negotiation::NegotiatedStream::copy_buffered_into`], allowing callers that temporarily
     /// decompose the stream into parts to observe the sniffed prefix and remainder while preserving
     /// the replay state. The destination is cleared before data is appended; if additional capacity
     /// is required a [`TryReserveError`] is returned and the original contents remain untouched.

--- a/crates/transport/src/negotiation/parts/stream_parts/mod.rs
+++ b/crates/transport/src/negotiation/parts/stream_parts/mod.rs
@@ -6,7 +6,7 @@ use rsync_protocol::NegotiationPrologue;
 
 use super::super::{NegotiationBuffer, NegotiationBufferAccess};
 
-/// Components extracted from a [`NegotiatedStream`].
+/// Components extracted from a [`crate::negotiation::NegotiatedStream`].
 ///
 /// # Examples
 ///
@@ -72,7 +72,7 @@ impl<R> NegotiatedStreamParts<R> {
 
     /// Reports whether the decomposed stream originated from a binary negotiation.
     ///
-    /// This mirrors [`NegotiatedStream::is_binary`], allowing callers that work
+    /// This mirrors [`crate::negotiation::NegotiatedStream::is_binary`], allowing callers that work
     /// with [`NegotiatedStreamParts`] to branch on the handshake style without
     /// reconstructing the wrapper or inspecting [`Self::decision`] manually.
     #[must_use]
@@ -82,7 +82,7 @@ impl<R> NegotiatedStreamParts<R> {
 
     /// Reports whether the decomposed stream originated from the legacy ASCII negotiation.
     ///
-    /// The helper mirrors [`NegotiatedStream::is_legacy`], exposing the same
+    /// The helper mirrors [`crate::negotiation::NegotiatedStream::is_legacy`], exposing the same
     /// convenience for code that operates on [`NegotiatedStreamParts`]. It
     /// returns `true` when the captured negotiation began with the canonical
     /// `@RSYNCD:` prefix.


### PR DESCRIPTION
## Summary
- fully qualify intra-doc links in the transport negotiation parts to reference `NegotiatedStream`

## Testing
- cargo --locked run -p xtask -- docs --validate

------