### PR TITLE
Fix cargo zig installation in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,10 +117,10 @@ jobs:
       - name: Pre-flight check
         run: cargo --locked run -p xtask -- preflight
 
-      - name: Install cargo-zig
+      - name: Install cargo-zigbuild
         uses: taiki-e/install-action@v2
         with:
-          tool: cargo-zig
+          tool: cargo-zigbuild
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@v2


### PR DESCRIPTION
## Summary
- update the CI workflow to install the published cargo-zigbuild crate instead of the non-existent cargo-zig package

## Testing
- not run

------