### PR TITLE
Fix platform lookup usage in CLI

### DIFF
--- a/crates/cli/src/out_format/render.rs
+++ b/crates/cli/src/out_format/render.rs
@@ -224,24 +224,12 @@ fn format_group_name(metadata: Option<&ClientEntryMetadata>) -> String {
         .unwrap_or_else(|| "0".to_string())
 }
 
-#[cfg(unix)]
 fn resolve_user_name(uid: u32) -> String {
     platform::display_user_name(uid).unwrap_or_else(|| uid.to_string())
 }
 
-#[cfg(not(unix))]
-fn resolve_user_name(uid: u32) -> String {
-    uid.to_string()
-}
-
-#[cfg(unix)]
 fn resolve_group_name(gid: u32) -> String {
     platform::display_group_name(gid).unwrap_or_else(|| gid.to_string())
-}
-
-#[cfg(not(unix))]
-fn resolve_group_name(gid: u32) -> String {
-    gid.to_string()
 }
 
 fn format_current_timestamp() -> String {

--- a/crates/cli/src/platform.rs
+++ b/crates/cli/src/platform.rs
@@ -21,9 +21,15 @@ pub(crate) type gid_t = u32;
 pub(crate) type uid_t = u32;
 
 /// Indicates whether the platform supports resolving user names.
-pub(crate) const SUPPORTS_USER_NAME_LOOKUP: bool = cfg!(unix);
+#[inline]
+pub(crate) fn supports_user_name_lookup() -> bool {
+    cfg!(unix)
+}
 /// Indicates whether the platform supports resolving group names.
-pub(crate) const SUPPORTS_GROUP_NAME_LOOKUP: bool = cfg!(unix);
+#[inline]
+pub(crate) fn supports_group_name_lookup() -> bool {
+    cfg!(unix)
+}
 
 #[cfg(unix)]
 fn to_owned<C>(value: C) -> Option<String>


### PR DESCRIPTION
## Summary
- unify `--chown` resolution logic across targets so platform helpers are exercised on all builds
- expose capability checks as functions and reuse them in user/group lookups
- simplify owner/group name formatting to rely on shared platform accessors

## Testing
- cargo check -p rsync-cli

------