### PR TITLE
Fix enforce-limits override path

### DIFF
--- a/tools/line_limits.toml
+++ b/tools/line_limits.toml
@@ -48,11 +48,6 @@ max_lines = 6400
 warn_lines = 6300
 
 [[overrides]]
-path = "crates/transport/src/negotiation/stream.rs"
-max_lines = 1100
-warn_lines = 1000
-
-[[overrides]]
 path = "crates/protocol/src/negotiation/tests/buffered_prefix.rs"
 max_lines = 580
 warn_lines = 540


### PR DESCRIPTION
## Summary
- remove the stale line-limit override that referenced a deleted transport file

## Testing
- cargo --locked run -p xtask -- enforce-limits

------