### PR TITLE
Refactor daemon configuration and error types into dedicated modules

### DIFF
--- a/crates/daemon/src/config.rs
+++ b/crates/daemon/src/config.rs
@@ -1,0 +1,109 @@
+#![deny(unsafe_code)]
+
+//! Daemon configuration builders.
+//!
+//! This module encapsulates the immutable configuration handed to the daemon
+//! runtime together with a builder that callers can use to assemble the final
+//! argument vector. Keeping the types isolated from the main runtime keeps the
+//! large daemon state machine manageable while enforcing consistent branding
+//! and default-path behaviour across the workspace.
+
+use std::ffi::OsString;
+
+use rsync_core::branding::Brand;
+
+/// Configuration describing the requested daemon operation.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DaemonConfig {
+    brand: Brand,
+    arguments: Vec<OsString>,
+    load_default_paths: bool,
+}
+
+impl DaemonConfig {
+    /// Creates a new [`DaemonConfigBuilder`].
+    #[must_use]
+    pub fn builder() -> DaemonConfigBuilder {
+        DaemonConfigBuilder::default()
+    }
+
+    /// Returns the raw arguments supplied to the daemon.
+    #[must_use]
+    pub fn arguments(&self) -> &[OsString] {
+        &self.arguments
+    }
+
+    /// Returns the branding profile associated with the daemon invocation.
+    #[must_use]
+    pub const fn brand(&self) -> Brand {
+        self.brand
+    }
+
+    /// Indicates whether default configuration and secrets paths should be
+    /// consulted when parsing runtime options.
+    #[must_use]
+    pub const fn load_default_paths(&self) -> bool {
+        self.load_default_paths
+    }
+
+    /// Reports whether any daemon-specific arguments were provided.
+    #[must_use]
+    pub fn has_runtime_request(&self) -> bool {
+        !self.arguments.is_empty()
+    }
+}
+
+/// Builder used to assemble a [`DaemonConfig`].
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DaemonConfigBuilder {
+    brand: Brand,
+    arguments: Vec<OsString>,
+    load_default_paths: bool,
+}
+
+impl Default for DaemonConfigBuilder {
+    fn default() -> Self {
+        Self {
+            brand: Brand::Oc,
+            arguments: Vec::new(),
+            load_default_paths: true,
+        }
+    }
+}
+
+impl DaemonConfigBuilder {
+    /// Selects the branding profile that should be used for this configuration.
+    #[must_use]
+    pub fn brand(mut self, brand: Brand) -> Self {
+        self.brand = brand;
+        self
+    }
+
+    /// Supplies the arguments that should be forwarded to the daemon loop once implemented.
+    #[must_use]
+    pub fn arguments<I, S>(mut self, arguments: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<OsString>,
+    {
+        self.arguments = arguments.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Skips discovery of default configuration and secrets paths.
+    #[must_use]
+    pub fn disable_default_paths(mut self) -> Self {
+        self.load_default_paths = false;
+        self
+    }
+
+    /// Finalises the builder and constructs the [`DaemonConfig`].
+    #[must_use]
+    pub fn build(self) -> DaemonConfig {
+        DaemonConfig {
+            brand: self.brand,
+            arguments: self.arguments,
+            load_default_paths: self.load_default_paths,
+        }
+    }
+}

--- a/crates/daemon/src/error.rs
+++ b/crates/daemon/src/error.rs
@@ -1,0 +1,47 @@
+#![deny(unsafe_code)]
+
+//! Daemon error reporting helpers.
+//!
+//! The [`DaemonError`] type centralises exit-code handling and formatted
+//! diagnostics for the daemon entry points. Keeping the implementation in a
+//! dedicated module allows the sprawling runtime logic in `lib.rs` to focus on
+//! protocol and configuration handling while still constructing consistent
+//! messages that honour workspace branding conventions.
+
+use std::error::Error;
+use std::fmt;
+
+use rsync_core::message::Message;
+
+/// Error returned when daemon orchestration fails.
+#[derive(Clone, Debug)]
+pub struct DaemonError {
+    exit_code: i32,
+    message: Message,
+}
+
+impl DaemonError {
+    /// Creates a new [`DaemonError`] from the supplied message and exit code.
+    pub(crate) fn new(exit_code: i32, message: Message) -> Self {
+        Self { exit_code, message }
+    }
+
+    /// Returns the exit code associated with this error.
+    #[must_use]
+    pub const fn exit_code(&self) -> i32 {
+        self.exit_code
+    }
+
+    /// Returns the formatted diagnostic message that should be emitted.
+    pub fn message(&self) -> &Message {
+        &self.message
+    }
+}
+
+impl fmt::Display for DaemonError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.message.fmt(f)
+    }
+}
+
+impl Error for DaemonError {}


### PR DESCRIPTION
## Summary
- extract the daemon configuration structures into a dedicated `config` module and re-export them from the crate root
- move the daemon error type into an `error` module so the sprawling runtime stays focused on orchestration
- update `lib.rs` to wire the new modules while keeping the public API unchanged

## Testing
- cargo test -p rsync-daemon --lib

------