### PR TITLE
Add Windows GNU unwind compatibility shim

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -459,6 +459,7 @@ name = "oc-rsync-bin"
 version = "3.4.1-rust"
 dependencies = [
  "rsync-cli",
+ "rsync-windows-gnu-eh",
 ]
 
 [[package]]
@@ -466,6 +467,7 @@ name = "oc-rsyncd-bin"
 version = "3.4.1-rust"
 dependencies = [
  "rsync-daemon",
+ "rsync-windows-gnu-eh",
 ]
 
 [[package]]
@@ -768,6 +770,10 @@ version = "3.4.1-rust"
 dependencies = [
  "tempfile",
 ]
+
+[[package]]
+name = "rsync-windows-gnu-eh"
+version = "3.4.1-rust"
 
 [[package]]
 name = "rustix"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
     "crates/protocol",
     "crates/walk",
     "crates/transport",
+    "crates/windows-gnu-eh",
     "xtask",
     "crates/apple-fs",
 ]

--- a/bin/oc-rsync/Cargo.toml
+++ b/bin/oc-rsync/Cargo.toml
@@ -14,6 +14,9 @@ path = "src/main.rs"
 [dependencies]
 rsync-cli = { path = "../../crates/cli" }
 
+[target.'cfg(all(windows, target_env = "gnu"))'.dependencies]
+rsync-windows-gnu-eh = { path = "../../crates/windows-gnu-eh" }
+
 [package.metadata.deb]
 name = "oc-rsync"
 section = "utils"

--- a/bin/oc-rsync/src/main.rs
+++ b/bin/oc-rsync/src/main.rs
@@ -3,6 +3,9 @@
 use std::{env, io, process::ExitCode};
 
 fn main() -> ExitCode {
+    #[cfg(all(target_os = "windows", target_env = "gnu"))]
+    rsync_windows_gnu_eh::force_link();
+
     let mut stdout = io::stdout().lock();
     let mut stderr = io::stderr().lock();
     let status = rsync_cli::run(env::args_os(), &mut stdout, &mut stderr);

--- a/bin/oc-rsyncd/Cargo.toml
+++ b/bin/oc-rsyncd/Cargo.toml
@@ -17,3 +17,6 @@ sd-notify = ["rsync-daemon/sd-notify"]
 
 [dependencies]
 rsync-daemon = { path = "../../crates/daemon" }
+
+[target.'cfg(all(windows, target_env = "gnu"))'.dependencies]
+rsync-windows-gnu-eh = { path = "../../crates/windows-gnu-eh" }

--- a/bin/oc-rsyncd/src/main.rs
+++ b/bin/oc-rsyncd/src/main.rs
@@ -3,6 +3,9 @@
 use std::{env, io, process::ExitCode};
 
 fn main() -> ExitCode {
+    #[cfg(all(target_os = "windows", target_env = "gnu"))]
+    rsync_windows_gnu_eh::force_link();
+
     let mut stdout = io::stdout().lock();
     let mut stderr = io::stderr().lock();
     let status = rsync_daemon::run(env::args_os(), &mut stdout, &mut stderr);

--- a/crates/windows-gnu-eh/Cargo.toml
+++ b/crates/windows-gnu-eh/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "rsync-windows-gnu-eh"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+description = "Compatibility shims for Windows GNU unwinding symbols required by rustc rsbegin"
+
+[lib]
+path = "src/lib.rs"

--- a/crates/windows-gnu-eh/src/lib.rs
+++ b/crates/windows-gnu-eh/src/lib.rs
@@ -1,0 +1,53 @@
+#![deny(rustdoc::broken_intra_doc_links)]
+#![deny(clippy::undocumented_unsafe_blocks)]
+
+//! Compatibility helpers for the Windows GNU target.
+//!
+//! When cross-compiling with `cargo-zigbuild` the Windows GNU toolchain linked
+//! by Zig omits the legacy libgcc entry points `___register_frame_info` and
+//! `___deregister_frame_info` that Rust's startup object (`rsbegin.o`)
+//! references when DWARF unwind data is present. We forward these requests to
+//! the modern `__register_frame_info`/`__deregister_frame_info` symbols shipped
+//! with libunwind so stack unwinding remains fully functional.
+
+#[cfg(all(target_os = "windows", target_env = "gnu"))]
+mod windows_gnu {
+    use core::ffi::c_void;
+
+    extern "C" {
+        fn __register_frame_info(eh_frame: *const u8, object: *mut c_void);
+        fn __deregister_frame_info(eh_frame: *const u8);
+    }
+
+    /// Forwards `rsbegin`'s registration hook to libunwind.
+    #[no_mangle]
+    pub unsafe extern "C" fn ___register_frame_info(
+        eh_frame: *const u8,
+        object: *mut c_void,
+    ) {
+        __register_frame_info(eh_frame, object);
+    }
+
+    /// Forwards `rsbegin`'s deregistration hook to libunwind.
+    #[no_mangle]
+    pub unsafe extern "C" fn ___deregister_frame_info(eh_frame: *const u8) {
+        __deregister_frame_info(eh_frame);
+    }
+
+    /// No-op helper invoked by dependants to ensure the crate remains linked.
+    #[inline(always)]
+    pub fn force_link() {}
+}
+
+#[cfg(not(all(target_os = "windows", target_env = "gnu")))]
+mod not_windows_gnu {
+    /// No-op helper invoked by dependants to keep linkage symmetric across targets.
+    #[inline(always)]
+    pub fn force_link() {}
+}
+
+#[cfg(all(target_os = "windows", target_env = "gnu"))]
+pub use windows_gnu::force_link;
+
+#[cfg(not(all(target_os = "windows", target_env = "gnu")))]
+pub use not_windows_gnu::force_link;


### PR DESCRIPTION
## Summary
- add a `rsync-windows-gnu-eh` compatibility crate that forwards the legacy libgcc unwind hooks to libunwind on windows-gnu
- depend on the shim from the client and daemon binaries when building for the windows-gnu target so the symbols are linked
- register the new crate in the workspace manifest

## Testing
- cargo check

------