### PR TITLE
Add Windows aarch64 coverage to CI and release workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,6 +216,13 @@ jobs:
             uses_zig: true
             needs_cross_gcc: false
             generate_sbom: false
+          - name: windows-aarch64
+            target: aarch64-pc-windows-gnu
+            build_command: zigbuild
+            build_daemon: false
+            uses_zig: true
+            needs_cross_gcc: false
+            generate_sbom: false
           - name: windows-x86
             target: i686-pc-windows-gnu
             build_command: zigbuild

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,9 +49,10 @@ jobs:
         run: scripts/check-run-matrix-docs.sh
       - name: Cross-compile check
         run: |
-          rustup target add x86_64-apple-darwin x86_64-pc-windows-msvc
+          rustup target add x86_64-apple-darwin x86_64-pc-windows-msvc aarch64-pc-windows-msvc
           cargo check --workspace --target x86_64-apple-darwin
           cargo check --workspace --target x86_64-pc-windows-msvc
+          cargo check --workspace --target aarch64-pc-windows-msvc
 
   build:
     needs: lint-test
@@ -67,6 +68,8 @@ jobs:
             target: x86_64-apple-darwin
           - os: windows-latest
             target: x86_64-pc-windows-msvc
+          - os: windows-latest
+            target: aarch64-pc-windows-msvc
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1

--- a/docs/production_scope_p1.md
+++ b/docs/production_scope_p1.md
@@ -79,7 +79,7 @@ This document freezes the mandatory scope that must reach green status before th
 - Systemd `oc-rsyncd.service` unit (ships with an alias for `rsyncd.service`)
 - Default daemon configuration installed at `/etc/oc-rsyncd/oc-rsyncd.conf` with secrets stored in `/etc/oc-rsyncd/oc-rsyncd.secrets`
 - CycloneDX SBOM at `target/sbom/rsync.cdx.json`
-- Cross-compiled release binaries for Linux (x86_64, aarch64), macOS (x86_64, aarch64), and Windows (x86, x86_64)
+- Cross-compiled release binaries for Linux (x86_64, aarch64), macOS (x86_64, aarch64), and Windows (x86, x86_64, aarch64)
 
 ## Deterministic Test Environment
 - `LC_ALL=C`


### PR DESCRIPTION
## Summary
- add Windows aarch64 to the continuous integration cross-compilation matrix so release artifacts are produced for every Windows architecture we target
- extend the tagged release workflow to build and check the new Windows aarch64 target alongside the existing platforms
- refresh the production scope documentation to spell out the expanded Windows packaging requirement

## Testing
- not run (not run)

------