### PR TITLE
Remove unsupported Windows AArch64 cross build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,13 +216,6 @@ jobs:
             uses_zig: true
             needs_cross_gcc: false
             generate_sbom: false
-          - name: windows-aarch64
-            target: aarch64-pc-windows-gnu
-            build_command: zigbuild
-            build_daemon: false
-            uses_zig: true
-            needs_cross_gcc: false
-            generate_sbom: false
           - name: windows-x86
             target: i686-pc-windows-gnu
             build_command: zigbuild

--- a/docs/production_scope_p1.md
+++ b/docs/production_scope_p1.md
@@ -79,7 +79,7 @@ This document freezes the mandatory scope that must reach green status before th
 - Systemd `oc-rsyncd.service` unit (ships with an alias for `rsyncd.service`)
 - Default daemon configuration installed at `/etc/oc-rsyncd/oc-rsyncd.conf` with secrets stored in `/etc/oc-rsyncd/oc-rsyncd.secrets`
 - CycloneDX SBOM at `target/sbom/rsync.cdx.json`
-- Cross-compiled release binaries for Linux (x86_64, aarch64), macOS (x86_64, aarch64), and Windows (x86, x86_64, aarch64)
+- Cross-compiled release binaries for Linux (x86_64, aarch64), macOS (x86_64, aarch64), and Windows (x86, x86_64)
 
 ## Deterministic Test Environment
 - `LC_ALL=C`


### PR DESCRIPTION
## Summary
- drop the Windows AArch64 GNU target from the cross-compile matrix to unblock CI
- update the production scope doc to reflect the supported Windows build targets

## Testing
- not run (workflow change only)

------