### PR TITLE
Expose module list internals for client unit tests

### DIFF
--- a/crates/core/src/client/mod.rs
+++ b/crates/core/src/client/mod.rs
@@ -127,9 +127,6 @@ use rsync_engine::local_copy::{
     ReferenceDirectoryKind as EngineReferenceDirectoryKind,
 };
 use rsync_filters::FilterRule as EngineFilterRule;
-#[cfg(test)]
-use std::cell::RefCell;
-
 /// Exit code returned when client functionality is unavailable.
 const FEATURE_UNAVAILABLE_EXIT_CODE: i32 = 1;
 /// Exit code used when a copy partially or wholly fails.

--- a/crates/core/src/client/module_list.rs
+++ b/crates/core/src/client/module_list.rs
@@ -37,7 +37,7 @@ fn legacy_daemon_error_payload(line: &str) -> Option<String> {
     Some(payload.to_string())
 }
 
-fn map_daemon_handshake_error(error: io::Error, addr: &DaemonAddress) -> ClientError {
+pub(super) fn map_daemon_handshake_error(error: io::Error, addr: &DaemonAddress) -> ClientError {
     if let Some(mapped) = handshake_error_to_client_error(&error) {
         mapped
     } else {
@@ -119,7 +119,7 @@ impl DaemonAddress {
         self.port
     }
 
-    fn socket_addr_display(&self) -> SocketAddrDisplay<'_> {
+    pub(super) fn socket_addr_display(&self) -> SocketAddrDisplay<'_> {
         SocketAddrDisplay {
             host: &self.host,
             port: self.port,
@@ -127,7 +127,7 @@ impl DaemonAddress {
     }
 }
 
-struct SocketAddrDisplay<'a> {
+pub(super) struct SocketAddrDisplay<'a> {
     host: &'a str,
     port: u16,
 }
@@ -149,9 +149,9 @@ impl fmt::Display for SocketAddrDisplay<'_> {
 /// current module listing implementation performs anonymous queries.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ModuleListRequest {
-    address: DaemonAddress,
-    username: Option<String>,
-    protocol: ProtocolVersion,
+    pub(super) address: DaemonAddress,
+    pub(super) username: Option<String>,
+    pub(super) protocol: ProtocolVersion,
 }
 
 impl ModuleListRequest {
@@ -695,7 +695,7 @@ fn open_daemon_stream(
     Ok(DaemonStream::tcp(stream))
 }
 
-fn connect_direct(
+pub(super) fn connect_direct(
     addr: &DaemonAddress,
     connect_timeout: Option<Duration>,
     io_timeout: Option<Duration>,
@@ -727,7 +727,7 @@ fn connect_direct(
     Err(socket_error("connect to", candidate, error))
 }
 
-fn resolve_daemon_addresses(
+pub(super) fn resolve_daemon_addresses(
     addr: &DaemonAddress,
     mode: AddressMode,
 ) -> Result<Vec<SocketAddr>, ClientError> {
@@ -828,7 +828,7 @@ fn connect_with_optional_bind(
     }
 }
 
-fn connect_via_proxy(
+pub(super) fn connect_via_proxy(
     addr: &DaemonAddress,
     proxy: &ProxyConfig,
     connect_timeout: Option<Duration>,
@@ -882,7 +882,7 @@ fn connect_via_proxy(
     Ok(stream)
 }
 
-fn establish_proxy_tunnel(
+pub(super) fn establish_proxy_tunnel(
     stream: &mut TcpStream,
     addr: &DaemonAddress,
     proxy: &ProxyConfig,
@@ -1064,13 +1064,13 @@ impl Write for DaemonStream {
     }
 }
 
-struct ConnectProgramConfig {
+pub(super) struct ConnectProgramConfig {
     template: OsString,
     shell: Option<OsString>,
 }
 
 impl ConnectProgramConfig {
-    fn new(template: OsString, shell: Option<OsString>) -> Result<Self, String> {
+    pub(super) fn new(template: OsString, shell: Option<OsString>) -> Result<Self, String> {
         if template.is_empty() {
             return Err("RSYNC_CONNECT_PROG must not be empty".to_string());
         }
@@ -1082,7 +1082,7 @@ impl ConnectProgramConfig {
         Ok(Self { template, shell })
     }
 
-    fn shell(&self) -> Option<&OsString> {
+    pub(super) fn shell(&self) -> Option<&OsString> {
         self.shell.as_ref()
     }
 
@@ -1090,7 +1090,7 @@ impl ConnectProgramConfig {
     ///
     /// `%H` is replaced with the daemon host, `%P` with the decimal TCP port, and `%%`
     /// yields a literal percent sign.
-    fn format_command(&self, host: &str, port: u16) -> Result<OsString, String> {
+    pub(super) fn format_command(&self, host: &str, port: u16) -> Result<OsString, String> {
         #[cfg(unix)]
         {
             let template = self.template.as_bytes();
@@ -1188,10 +1188,10 @@ impl Drop for ConnectProgramStream {
     }
 }
 
-struct ProxyConfig {
-    host: String,
-    port: u16,
-    credentials: Option<ProxyCredentials>,
+pub(super) struct ProxyConfig {
+    pub(super) host: String,
+    pub(super) port: u16,
+    pub(super) credentials: Option<ProxyCredentials>,
 }
 
 impl ProxyConfig {
@@ -1202,14 +1202,14 @@ impl ProxyConfig {
         }
     }
 
-    fn authorization_header(&self) -> Option<String> {
+    pub(super) fn authorization_header(&self) -> Option<String> {
         self.credentials
             .as_ref()
             .map(ProxyCredentials::authorization_value)
     }
 }
 
-struct ProxyCredentials {
+pub(super) struct ProxyCredentials {
     username: String,
     password: String,
 }
@@ -1244,7 +1244,7 @@ fn load_daemon_proxy() -> Result<Option<ProxyConfig>, ClientError> {
     }
 }
 
-fn parse_proxy_spec(spec: &str) -> Result<ProxyConfig, ClientError> {
+pub(super) fn parse_proxy_spec(spec: &str) -> Result<ProxyConfig, ClientError> {
     let trimmed = spec.trim();
     if trimmed.is_empty() {
         return Err(proxy_configuration_error(
@@ -1655,7 +1655,7 @@ pub fn run_module_list_with_password_and_options(
 
 /// Derives the socket connect timeout from the explicit connection setting and
 /// the general transfer timeout.
-fn resolve_connect_timeout(
+pub(super) fn resolve_connect_timeout(
     connect_timeout: TransferTimeout,
     fallback: TransferTimeout,
     default: Duration,
@@ -1671,50 +1671,50 @@ fn resolve_connect_timeout(
     }
 }
 
-struct DaemonAuthContext {
+pub(super) struct DaemonAuthContext {
     username: String,
     secret: SensitiveBytes,
 }
 
 impl DaemonAuthContext {
-    fn new(username: String, secret: Vec<u8>) -> Self {
+    pub(super) fn new(username: String, secret: Vec<u8>) -> Self {
         Self {
             username,
             secret: SensitiveBytes::new(secret),
         }
     }
 
-    fn secret(&self) -> &[u8] {
+    pub(super) fn secret(&self) -> &[u8] {
         self.secret.as_slice()
     }
 }
 
 #[cfg(test)]
 impl DaemonAuthContext {
-    fn into_zeroized_secret(self) -> Vec<u8> {
+    pub(super) fn into_zeroized_secret(self) -> Vec<u8> {
         self.secret.into_zeroized_vec()
     }
 }
 
-struct SensitiveBytes(Vec<u8>);
+pub(super) struct SensitiveBytes(Vec<u8>);
 
 impl SensitiveBytes {
-    fn new(bytes: Vec<u8>) -> Self {
+    pub(super) fn new(bytes: Vec<u8>) -> Self {
         Self(bytes)
     }
 
-    fn to_vec(&self) -> Vec<u8> {
+    pub(super) fn to_vec(&self) -> Vec<u8> {
         self.0.clone()
     }
 
-    fn as_slice(&self) -> &[u8] {
+    pub(super) fn as_slice(&self) -> &[u8] {
         &self.0
     }
 }
 
 #[cfg(test)]
 impl SensitiveBytes {
-    fn into_zeroized_vec(mut self) -> Vec<u8> {
+    pub(super) fn into_zeroized_vec(mut self) -> Vec<u8> {
         for byte in &mut self.0 {
             *byte = 0;
         }
@@ -1764,7 +1764,7 @@ thread_local! {
 }
 
 #[cfg(test)]
-fn set_test_daemon_password(password: Option<Vec<u8>>) {
+pub(crate) fn set_test_daemon_password(password: Option<Vec<u8>>) {
     TEST_PASSWORD_OVERRIDE.with(|slot| *slot.borrow_mut() = password);
 }
 
@@ -1789,7 +1789,7 @@ fn load_daemon_password() -> Option<Vec<u8>> {
     })
 }
 
-fn compute_daemon_auth_response(secret: &[u8], challenge: &str) -> String {
+pub(super) fn compute_daemon_auth_response(secret: &[u8], challenge: &str) -> String {
     let mut hasher = Md5::new();
     hasher.update(secret);
     hasher.update(challenge.as_bytes());
@@ -1823,6 +1823,8 @@ fn is_motd_payload(payload: &str) -> bool {
 
     matches!(bytes[4], b' ' | b'\t' | b'\r' | b'\n' | b':')
 }
+#[cfg(test)]
+use std::cell::RefCell;
 use std::env::{self, VarError};
 use std::ffi::{OsStr, OsString};
 use std::fmt;

--- a/crates/core/src/client/tests.rs
+++ b/crates/core/src/client/tests.rs
@@ -1,3 +1,9 @@
+use super::module_list::{
+    ConnectProgramConfig, DaemonAuthContext, ProxyConfig, SensitiveBytes,
+    compute_daemon_auth_response, connect_direct, connect_via_proxy, establish_proxy_tunnel,
+    map_daemon_handshake_error, parse_proxy_spec, resolve_connect_timeout,
+    resolve_daemon_addresses,
+};
 use super::*;
 use crate::bandwidth;
 use crate::client::fallback::write_daemon_password;
@@ -6,9 +12,10 @@ use crate::version::RUST_VERSION;
 use rsync_compress::zlib::CompressionLevel;
 use rsync_engine::{SkipCompressList, signature::SignatureAlgorithm};
 use rsync_meta::ChmodModifiers;
+use rsync_protocol::{NegotiationError, ProtocolVersion};
 use std::ffi::{OsStr, OsString};
 use std::fs;
-use std::io::{self, BufRead, BufReader, Seek, SeekFrom, Write};
+use std::io::{self, BufRead, BufReader, Read, Seek, SeekFrom, Write};
 use std::net::{Shutdown, TcpListener, TcpStream};
 use std::num::{NonZeroU8, NonZeroU64};
 use std::path::{Path, PathBuf};


### PR DESCRIPTION
## Summary
- expose the module_list helpers and supporting types to the parent client module when building tests
- update the client test module to import the exposed helpers and required traits
- drop the unused RefCell import from the client module

## Testing
- cargo fmt
- cargo test -p rsync-core --lib client::tests -- --nocapture

------