### PR TITLE
Expose module list helpers for client tests

### DIFF
--- a/crates/core/src/client/mod.rs
+++ b/crates/core/src/client/mod.rs
@@ -97,12 +97,19 @@ pub use self::config::{
 };
 pub use self::fallback::{RemoteFallbackArgs, RemoteFallbackContext, run_remote_transfer_fallback};
 #[cfg(test)]
-pub(crate) use self::module_list::set_test_daemon_password;
+pub(crate) use self::module_list::{
+    ConnectProgramConfig, DaemonAuthContext, ProxyConfig, SensitiveBytes,
+    compute_daemon_auth_response, connect_direct, connect_via_proxy, establish_proxy_tunnel,
+    map_daemon_handshake_error, parse_proxy_spec, resolve_connect_timeout,
+    resolve_daemon_addresses, set_test_daemon_password,
+};
 pub use self::module_list::{
     DaemonAddress, ModuleList, ModuleListEntry, ModuleListOptions, ModuleListRequest,
     run_module_list, run_module_list_with_options, run_module_list_with_password,
     run_module_list_with_password_and_options,
 };
+#[cfg(test)]
+pub(crate) use rsync_protocol::{NegotiationError, ProtocolVersion};
 
 use std::collections::HashMap;
 use std::ffi::OsStr;
@@ -127,9 +134,6 @@ use rsync_engine::local_copy::{
     ReferenceDirectoryKind as EngineReferenceDirectoryKind,
 };
 use rsync_filters::FilterRule as EngineFilterRule;
-#[cfg(test)]
-use std::cell::RefCell;
-
 /// Exit code returned when client functionality is unavailable.
 const FEATURE_UNAVAILABLE_EXIT_CODE: i32 = 1;
 /// Exit code used when a copy partially or wholly fails.


### PR DESCRIPTION
## Summary
- expose module_list internals such as handshake mapping, connection helpers, and auth utilities so they can be reused in crate tests
- re-export the newly public module_list items and protocol enums from the client module when testing
- update client tests to use the new helper constructor and required trait imports

## Testing
- cargo test

------