### PR TITLE
Enforce coverage thresholds in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,8 +138,11 @@ jobs:
       - name: Run tests (extended features)
         run: cargo --locked nextest run --workspace --all-features
 
-      - name: Test with coverage (95% lines & functions)
-        run: cargo --locked llvm-cov nextest --workspace --all-features --lcov --output-path coverage.lcov
+      - name: Test with coverage (enforce ≥95% lines & functions)
+        run: >-
+          cargo --locked llvm-cov nextest --workspace --all-features
+          --fail-under-lines 95 --fail-under-functions 95
+          --lcov --output-path coverage.lcov
 
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- require cargo llvm-cov to fail if coverage drops below 95% for lines or functions
- update the workflow step name to reflect the enforced threshold

## Testing
- not run (workflow change only)

------