### PR TITLE
Add brand summary helper for release metadata

### DIFF
--- a/crates/core/src/branding/mod.rs
+++ b/crates/core/src/branding/mod.rs
@@ -33,7 +33,7 @@ pub use constants::{
 };
 pub use detection::{brand_for_program_name, detect_brand, resolve_brand_profile};
 pub use json::{manifest_json, manifest_json_pretty};
-pub use manifest::{BrandManifest, manifest};
+pub use manifest::{BrandManifest, BrandSummary, manifest};
 pub use profile::{
     BrandProfile, client_program_name, client_program_name_os_str, daemon_program_name,
     daemon_program_name_os_str, legacy_daemon_config_dir, legacy_daemon_config_path,


### PR DESCRIPTION
## Summary
- add a `BrandSummary` view that exposes client/daemon names, config paths, and release identifiers for a given brand
- expose the summary helper through the branding module so tooling can render consistent release descriptions

## Testing
- cargo test -p rsync-core manifest:: -- --test-threads=1

------