### PR TITLE
Fix clippy needless return in connect program formatter

### DIFF
--- a/crates/core/src/client/module_list/connect/program.rs
+++ b/crates/core/src/client/module_list/connect/program.rs
@@ -142,7 +142,7 @@ impl ConnectProgramConfig {
                 }
             }
 
-            return Ok(OsString::from_vec(rendered));
+            Ok(OsString::from_vec(rendered))
         }
 
         #[cfg(not(unix))]


### PR DESCRIPTION
## Summary
- remove the redundant return in the Unix connect program formatter to satisfy clippy

## Testing
- cargo clippy --workspace --all-targets --all-features --locked -- -Dwarnings

------