### PR TITLE
Fix client helper visibility for tests

### DIFF
--- a/crates/core/src/client/run.rs
+++ b/crates/core/src/client/run.rs
@@ -143,7 +143,7 @@ where
         .map_err(map_local_copy_error)
 }
 
-fn build_local_copy_options(
+pub(crate) fn build_local_copy_options(
     config: &ClientConfig,
     filter_program: Option<FilterProgram>,
 ) -> LocalCopyOptions {

--- a/crates/core/src/client/summary.rs
+++ b/crates/core/src/client/summary.rs
@@ -261,7 +261,8 @@ pub enum ClientEventKind {
 }
 
 impl ClientEventKind {
-    pub(crate) const fn is_progress(&self) -> bool {
+    /// Returns whether the event kind represents progress-worthy activity.
+    pub const fn is_progress(&self) -> bool {
         matches!(
             self,
             Self::DataCopied
@@ -414,7 +415,7 @@ impl ClientEvent {
         self.destination_path.clone()
     }
 
-    fn resolve_destination_path(destination_root: &Path, relative: &Path) -> PathBuf {
+    pub(crate) fn resolve_destination_path(destination_root: &Path, relative: &Path) -> PathBuf {
         let candidate = destination_root.join(relative);
         if candidate.exists() {
             return candidate;

--- a/crates/core/src/client/tests.rs
+++ b/crates/core/src/client/tests.rs
@@ -5,15 +5,17 @@ use super::module_list::{
     map_daemon_handshake_error, parse_proxy_spec, resolve_connect_timeout,
     resolve_daemon_addresses, set_test_daemon_password,
 };
+use super::run::build_local_copy_options;
 use super::*;
 use crate::bandwidth;
 use crate::client::fallback::write_daemon_password;
 use crate::fallback::CLIENT_FALLBACK_ENV;
 use crate::version::RUST_VERSION;
 use rsync_compress::zlib::CompressionLevel;
-use rsync_engine::{SkipCompressList, signature::SignatureAlgorithm};
+use rsync_engine::{LocalCopyError, SkipCompressList, signature::SignatureAlgorithm};
 use rsync_meta::ChmodModifiers;
 use rsync_protocol::{NegotiationError, ProtocolVersion};
+use std::env;
 use std::ffi::{OsStr, OsString};
 use std::fs;
 use std::io::{self, BufRead, BufReader, Read, Seek, SeekFrom, Write};


### PR DESCRIPTION
## Summary
- expose the client local copy option builder so crate tests can exercise it directly
- allow external crates to query whether a client event kind represents progress and reuse the destination resolver in tests
- adjust client tests to import the helper and required engine and std items

## Testing
- cargo test

------