### PR TITLE
Expose internal client helpers for testing

### DIFF
--- a/crates/core/src/client/run.rs
+++ b/crates/core/src/client/run.rs
@@ -143,7 +143,13 @@ where
         .map_err(map_local_copy_error)
 }
 
-pub(crate) fn build_local_copy_options(
+/// Builds [`LocalCopyOptions`] reflecting the provided client configuration and optional filter
+/// program.
+///
+/// This helper mirrors the internal wiring used by [`run_client`](super::run_client) so that unit
+/// tests can validate the translation layer without re-invoking the entire transfer engine.
+#[doc(hidden)]
+pub fn build_local_copy_options(
     config: &ClientConfig,
     filter_program: Option<FilterProgram>,
 ) -> LocalCopyOptions {

--- a/crates/core/src/client/summary.rs
+++ b/crates/core/src/client/summary.rs
@@ -415,7 +415,12 @@ impl ClientEvent {
         self.destination_path.clone()
     }
 
-    pub(crate) fn resolve_destination_path(destination_root: &Path, relative: &Path) -> PathBuf {
+    /// Resolves a destination path for the provided relative component under the supplied root.
+    ///
+    /// Exposed for testing so unit suites can assert how the summary logic expands candidate
+    /// destinations without executing a full transfer.
+    #[doc(hidden)]
+    pub fn resolve_destination_path(destination_root: &Path, relative: &Path) -> PathBuf {
         let candidate = destination_root.join(relative);
         if candidate.exists() {
             return candidate;


### PR DESCRIPTION
## Summary
- expose the client helper that constructs LocalCopyOptions so tests can validate configuration mapping without invoking the engine
- make ClientEvent::resolve_destination_path visible for tests and document its intent while keeping it hidden from public docs

## Testing
- cargo test -p rsync-core --lib --tests --no-fail-fast

------