### PR TITLE
Ensure cross jobs install Rust targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,6 +238,11 @@ jobs:
           targets: ${{ matrix.platform.target }}
           cache: true
 
+      - name: Install Rust target support
+        run: |
+          rustup target add ${{ matrix.platform.target }}
+          rustup component add rust-src
+
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: cross-${{ matrix.platform.name }}


### PR DESCRIPTION
## Summary
- explicitly install the requested Rust compilation target in the cross-compile matrix
- add rust-src so zigbuild-based targets can build the standard library

## Testing
- not run (workflow-only change)

------