### PR TITLE
Modularize local copy overrides and streamline cross builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,13 +235,9 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: 1.87
+          components: rust-src
           targets: ${{ matrix.platform.target }}
           cache: true
-
-      - name: Install Rust target support
-        run: |
-          rustup target add ${{ matrix.platform.target }}
-          rustup component add rust-src
 
       - uses: Swatinem/rust-cache@v2
         with:

--- a/crates/engine/src/local_copy.rs
+++ b/crates/engine/src/local_copy.rs
@@ -49,6 +49,7 @@
 //! assert_eq!(summary.files_copied(), 1);
 //! ```
 
+mod overrides;
 mod skip_compress;
 
 pub use skip_compress::{SkipCompressList, SkipCompressParseError};
@@ -101,153 +102,9 @@ use crate::signature::{
 const COPY_BUFFER_SIZE: usize = 128 * 1024;
 static NEXT_TEMP_FILE_ID: AtomicUsize = AtomicUsize::new(0);
 
+use overrides::{create_hard_link, device_identifier};
 #[cfg(test)]
-type HardLinkOverrideFn = dyn Fn(&Path, &Path) -> io::Result<()> + 'static;
-
-#[cfg(test)]
-type DeviceIdOverrideFn = dyn Fn(&Path, &fs::Metadata) -> Option<u64> + 'static;
-
-#[cfg(test)]
-thread_local! {
-    static HARD_LINK_OVERRIDE: RefCell<Option<Box<HardLinkOverrideFn>>> =
-        const { RefCell::new(None) };
-}
-
-#[cfg(test)]
-fn with_hard_link_override<F, R>(override_fn: F, action: impl FnOnce() -> R) -> R
-where
-    F: Fn(&Path, &Path) -> io::Result<()> + 'static,
-{
-    struct ResetGuard;
-
-    impl Drop for ResetGuard {
-        fn drop(&mut self) {
-            HARD_LINK_OVERRIDE.with(|cell| {
-                cell.replace(None);
-            });
-        }
-    }
-
-    HARD_LINK_OVERRIDE.with(|cell| {
-        cell.replace(Some(Box::new(override_fn)));
-    });
-    let guard = ResetGuard;
-    let result = action();
-    drop(guard);
-    result
-}
-
-fn create_hard_link(source: &Path, destination: &Path) -> io::Result<()> {
-    #[cfg(test)]
-    if let Some(result) = HARD_LINK_OVERRIDE.with(|cell| {
-        cell.borrow()
-            .as_ref()
-            .map(|override_fn| override_fn(source, destination))
-    }) {
-        return result;
-    }
-
-    fs::hard_link(source, destination)
-}
-
-#[cfg(test)]
-thread_local! {
-    static DEVICE_ID_OVERRIDE: RefCell<Option<Box<DeviceIdOverrideFn>>> =
-        const { RefCell::new(None) };
-}
-
-#[cfg(test)]
-fn with_device_id_override<F, R>(override_fn: F, action: impl FnOnce() -> R) -> R
-where
-    F: Fn(&Path, &fs::Metadata) -> Option<u64> + 'static,
-{
-    struct ResetGuard;
-
-    impl Drop for ResetGuard {
-        fn drop(&mut self) {
-            DEVICE_ID_OVERRIDE.with(|cell| {
-                cell.replace(None);
-            });
-        }
-    }
-
-    DEVICE_ID_OVERRIDE.with(|cell| {
-        cell.replace(Some(Box::new(override_fn)));
-    });
-    let guard = ResetGuard;
-    let result = action();
-    drop(guard);
-    result
-}
-
-fn device_identifier(path: &Path, metadata: &fs::Metadata) -> Option<u64> {
-    #[cfg(test)]
-    if let Some(value) = DEVICE_ID_OVERRIDE.with(|cell| {
-        cell.borrow()
-            .as_ref()
-            .and_then(|override_fn| override_fn(path, metadata))
-    }) {
-        return Some(value);
-    }
-
-    #[cfg(not(test))]
-    let _ = path;
-
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::MetadataExt;
-        Some(metadata.dev())
-    }
-
-    #[cfg(windows)]
-    {
-        use std::borrow::Cow;
-        use std::hash::{Hash, Hasher};
-        use std::path::{Component, Prefix};
-
-        fn normalize_path<'a>(path: &'a Path) -> Cow<'a, Path> {
-            if path.is_absolute() {
-                Cow::Borrowed(path)
-            } else {
-                std::env::current_dir()
-                    .map(|cwd| Cow::Owned(cwd.join(path)))
-                    .unwrap_or_else(|_| Cow::Borrowed(path))
-            }
-        }
-
-        fn device_from_components(path: &Path) -> Option<u64> {
-            let mut components = path.components();
-            match components.next()? {
-                Component::Prefix(prefix) => match prefix.kind() {
-                    Prefix::Disk(letter) | Prefix::VerbatimDisk(letter) => Some(letter as u64),
-                    Prefix::UNC(server, share) | Prefix::VerbatimUNC(server, share) => {
-                        let mut hasher = std::collections::hash_map::DefaultHasher::new();
-                        server.hash(&mut hasher);
-                        share.hash(&mut hasher);
-                        Some(hasher.finish())
-                    }
-                    _ => None,
-                },
-                _ => None,
-            }
-        }
-
-        let absolute = normalize_path(path);
-        // The standard library's `MetadataExt::volume_serial_number` accessor is currently
-        // unstable on Windows, so fall back to deriving the device identifier from the path
-        // components instead.
-        let _ = metadata;
-
-        device_from_components(absolute.as_ref())
-    }
-
-    #[cfg(not(any(unix, windows)))]
-    {
-        let _ = path;
-        let _ = metadata;
-        None
-    }
-}
+pub(crate) use overrides::{with_device_id_override, with_hard_link_override};
 
 #[cfg(unix)]
 const CROSS_DEVICE_ERROR_CODE: i32 = 18;

--- a/crates/engine/src/local_copy/overrides.rs
+++ b/crates/engine/src/local_copy/overrides.rs
@@ -1,0 +1,154 @@
+use std::fs;
+use std::io;
+use std::path::Path;
+
+#[cfg(test)]
+use std::cell::RefCell;
+
+#[cfg(test)]
+type HardLinkOverrideFn = dyn Fn(&Path, &Path) -> io::Result<()> + 'static;
+
+#[cfg(test)]
+type DeviceIdOverrideFn = dyn Fn(&Path, &fs::Metadata) -> Option<u64> + 'static;
+
+#[cfg(test)]
+thread_local! {
+    static HARD_LINK_OVERRIDE: RefCell<Option<Box<HardLinkOverrideFn>>> =
+        const { RefCell::new(None) };
+}
+
+#[cfg(test)]
+pub(super) fn with_hard_link_override<F, R>(override_fn: F, action: impl FnOnce() -> R) -> R
+where
+    F: Fn(&Path, &Path) -> io::Result<()> + 'static,
+{
+    struct ResetGuard;
+
+    impl Drop for ResetGuard {
+        fn drop(&mut self) {
+            HARD_LINK_OVERRIDE.with(|cell| {
+                cell.replace(None);
+            });
+        }
+    }
+
+    HARD_LINK_OVERRIDE.with(|cell| {
+        cell.replace(Some(Box::new(override_fn)));
+    });
+    let guard = ResetGuard;
+    let result = action();
+    drop(guard);
+    result
+}
+
+pub(super) fn create_hard_link(source: &Path, destination: &Path) -> io::Result<()> {
+    #[cfg(test)]
+    if let Some(result) = HARD_LINK_OVERRIDE.with(|cell| {
+        cell.borrow()
+            .as_ref()
+            .map(|override_fn| override_fn(source, destination))
+    }) {
+        return result;
+    }
+
+    fs::hard_link(source, destination)
+}
+
+#[cfg(test)]
+thread_local! {
+    static DEVICE_ID_OVERRIDE: RefCell<Option<Box<DeviceIdOverrideFn>>> =
+        const { RefCell::new(None) };
+}
+
+#[cfg(test)]
+pub(super) fn with_device_id_override<F, R>(override_fn: F, action: impl FnOnce() -> R) -> R
+where
+    F: Fn(&Path, &fs::Metadata) -> Option<u64> + 'static,
+{
+    struct ResetGuard;
+
+    impl Drop for ResetGuard {
+        fn drop(&mut self) {
+            DEVICE_ID_OVERRIDE.with(|cell| {
+                cell.replace(None);
+            });
+        }
+    }
+
+    DEVICE_ID_OVERRIDE.with(|cell| {
+        cell.replace(Some(Box::new(override_fn)));
+    });
+    let guard = ResetGuard;
+    let result = action();
+    drop(guard);
+    result
+}
+
+pub(super) fn device_identifier(path: &Path, metadata: &fs::Metadata) -> Option<u64> {
+    #[cfg(test)]
+    if let Some(value) = DEVICE_ID_OVERRIDE.with(|cell| {
+        cell.borrow()
+            .as_ref()
+            .and_then(|override_fn| override_fn(path, metadata))
+    }) {
+        return Some(value);
+    }
+
+    #[cfg(not(test))]
+    let _ = path;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        Some(metadata.dev())
+    }
+
+    #[cfg(windows)]
+    {
+        use std::borrow::Cow;
+        use std::hash::{Hash, Hasher};
+        use std::path::{Component, Prefix};
+
+        fn normalize_path<'a>(path: &'a Path) -> Cow<'a, Path> {
+            if path.is_absolute() {
+                Cow::Borrowed(path)
+            } else {
+                std::env::current_dir()
+                    .map(|cwd| Cow::Owned(cwd.join(path)))
+                    .unwrap_or_else(|_| Cow::Borrowed(path))
+            }
+        }
+
+        fn device_from_components(path: &Path) -> Option<u64> {
+            let mut components = path.components();
+            match components.next()? {
+                Component::Prefix(prefix) => match prefix.kind() {
+                    Prefix::Disk(letter) | Prefix::VerbatimDisk(letter) => Some(letter as u64),
+                    Prefix::UNC(server, share) | Prefix::VerbatimUNC(server, share) => {
+                        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+                        server.hash(&mut hasher);
+                        share.hash(&mut hasher);
+                        Some(hasher.finish())
+                    }
+                    _ => None,
+                },
+                _ => None,
+            }
+        }
+
+        let absolute = normalize_path(path);
+        // The standard library's `MetadataExt::volume_serial_number` accessor is currently
+        // unstable on Windows, so fall back to deriving the device identifier from the path
+        // components instead.
+        let _ = metadata;
+
+        device_from_components(absolute.as_ref())
+    }
+
+    #[cfg(not(any(unix, windows)))]
+    {
+        let _ = path;
+        let _ = metadata;
+        None
+    }
+}


### PR DESCRIPTION
## Summary
- extract the local copy hard-link and device identifier overrides into `local_copy::overrides` so the main module stays leaner while keeping test hooks intact
- re-export the extracted helpers for test modules and update the primary implementation to use the shared utilities
- simplify the cross-compile job by letting `setup-rust-toolchain` install the target and `rust-src` component instead of invoking `rustup` manually

## Testing
- cargo check -p rsync-engine

------