### PR TITLE
Refactor xtask branding command into modular components

### DIFF
--- a/xtask/src/commands/branding/args.rs
+++ b/xtask/src/commands/branding/args.rs
@@ -1,0 +1,105 @@
+use crate::error::{TaskError, TaskResult};
+use crate::util::is_help_flag;
+use std::ffi::OsString;
+
+/// Output format supported by the `branding` command.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum BrandingOutputFormat {
+    /// Human-readable text report.
+    #[default]
+    Text,
+    /// Structured JSON report suitable for automation.
+    Json,
+}
+
+/// Options accepted by the `branding` command.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct BrandingOptions {
+    /// Desired output format.
+    pub format: BrandingOutputFormat,
+}
+
+/// Parses CLI arguments for the `branding` command.
+pub fn parse_args<I>(args: I) -> TaskResult<BrandingOptions>
+where
+    I: IntoIterator<Item = OsString>,
+{
+    let mut options = BrandingOptions::default();
+
+    for arg in args.into_iter() {
+        if is_help_flag(&arg) {
+            return Err(TaskError::Help(usage()));
+        }
+
+        let Some(raw) = arg.to_str() else {
+            return Err(TaskError::Usage(String::from(
+                "branding command arguments must be valid UTF-8",
+            )));
+        };
+
+        match raw {
+            "--json" => {
+                if !matches!(options.format, BrandingOutputFormat::Text) {
+                    return Err(TaskError::Usage(String::from(
+                        "--json specified multiple times",
+                    )));
+                }
+                options.format = BrandingOutputFormat::Json;
+            }
+            _ => {
+                return Err(TaskError::Usage(format!(
+                    "unrecognised argument '{raw}' for branding command",
+                )));
+            }
+        }
+    }
+
+    Ok(options)
+}
+
+/// Returns usage text for the command.
+pub fn usage() -> String {
+    String::from(
+        "Usage: cargo xtask branding [--json]\n\nOptions:\n  --json          Emit branding metadata in JSON format\n  -h, --help      Show this help message",
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_args_accepts_default_configuration() {
+        let options = parse_args(std::iter::empty()).expect("parse succeeds");
+        assert_eq!(options, BrandingOptions::default());
+    }
+
+    #[test]
+    fn parse_args_reports_help_request() {
+        let error = parse_args([OsString::from("--help")]).unwrap_err();
+        assert!(matches!(error, TaskError::Help(message) if message == usage()));
+    }
+
+    #[test]
+    fn parse_args_enables_json_output() {
+        let options = parse_args([OsString::from("--json")]).expect("parse succeeds");
+        assert_eq!(
+            options,
+            BrandingOptions {
+                format: BrandingOutputFormat::Json,
+            }
+        );
+    }
+
+    #[test]
+    fn parse_args_rejects_duplicate_json_flags() {
+        let error = parse_args([OsString::from("--json"), OsString::from("--json")]).unwrap_err();
+        assert!(matches!(error, TaskError::Usage(message) if message.contains("--json")));
+    }
+
+    #[test]
+    fn parse_args_rejects_unknown_argument() {
+        let error = parse_args([OsString::from("--unknown")]).unwrap_err();
+        assert!(matches!(error, TaskError::Usage(message) if message.contains("--unknown")));
+    }
+}

--- a/xtask/src/commands/branding/mod.rs
+++ b/xtask/src/commands/branding/mod.rs
@@ -1,0 +1,55 @@
+//! Branding metadata inspection command.
+//!
+//! This module exposes the `cargo xtask branding` command which validates the
+//! workspace branding configuration and renders it either as human-readable
+//! text or JSON. The implementation is split across dedicated modules so the
+//! parsing, validation, and rendering logic remain focused and individually
+//! testable.
+
+mod args;
+mod render;
+mod validate;
+
+pub use args::{BrandingOptions, BrandingOutputFormat, parse_args};
+pub use render::render_branding;
+pub use validate::validate_branding;
+
+use crate::error::TaskResult;
+use crate::workspace::load_workspace_branding;
+use std::path::Path;
+
+/// Executes the `branding` command.
+pub fn execute(workspace: &Path, options: BrandingOptions) -> TaskResult<()> {
+    let branding = load_workspace_branding(workspace)?;
+    validate_branding(&branding)?;
+    let output = render_branding(&branding, options.format)?;
+    println!("{output}");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::workspace::parse_workspace_branding;
+
+    #[test]
+    fn execute_renders_branding_metadata() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let manifest = tempdir.path().join("Cargo.toml");
+        std::fs::write(&manifest, include_str!("../../../../Cargo.toml")).expect("write manifest");
+
+        let workspace = tempdir.path();
+        let branding = load_workspace_branding(workspace).expect("load branding");
+        validate_branding(&branding).expect("validate branding");
+
+        let output = render_branding(&branding, BrandingOutputFormat::Text).expect("render text");
+        assert!(output.contains("Workspace branding summary:"));
+    }
+
+    #[test]
+    fn manifest_branding_is_valid() {
+        let manifest = include_str!("../../../../Cargo.toml");
+        let branding = parse_workspace_branding(manifest).expect("workspace branding parses");
+        validate_branding(&branding).expect("validation succeeds");
+    }
+}

--- a/xtask/src/commands/branding/render.rs
+++ b/xtask/src/commands/branding/render.rs
@@ -1,0 +1,157 @@
+use super::BrandingOutputFormat;
+use crate::error::{TaskError, TaskResult};
+use crate::workspace::WorkspaceBranding;
+use serde_json::json;
+
+pub fn render_branding(
+    branding: &WorkspaceBranding,
+    format: BrandingOutputFormat,
+) -> TaskResult<String> {
+    match format {
+        BrandingOutputFormat::Text => Ok(render_branding_text(branding)),
+        BrandingOutputFormat::Json => render_branding_json(branding),
+    }
+}
+
+fn render_branding_text(branding: &WorkspaceBranding) -> String {
+    format!(
+        concat!(
+            "Workspace branding summary:\n",
+            "  brand: {}\n",
+            "  upstream_version: {}\n",
+            "  rust_version: {}\n",
+            "  protocol: {}\n",
+            "  client_bin: {}\n",
+            "  daemon_bin: {}\n",
+            "  legacy_client_bin: {}\n",
+            "  legacy_daemon_bin: {}\n",
+            "  daemon_config_dir: {}\n",
+            "  daemon_config: {}\n",
+            "  daemon_secrets: {}\n",
+            "  legacy_daemon_config_dir: {}\n",
+            "  legacy_daemon_config: {}\n",
+            "  legacy_daemon_secrets: {}\n",
+            "  source: {}"
+        ),
+        branding.brand,
+        branding.upstream_version,
+        branding.rust_version,
+        branding.protocol,
+        branding.client_bin,
+        branding.daemon_bin,
+        branding.legacy_client_bin,
+        branding.legacy_daemon_bin,
+        branding.daemon_config_dir.display(),
+        branding.daemon_config.display(),
+        branding.daemon_secrets.display(),
+        branding.legacy_daemon_config_dir.display(),
+        branding.legacy_daemon_config.display(),
+        branding.legacy_daemon_secrets.display(),
+        branding.source,
+    )
+}
+
+fn render_branding_json(branding: &WorkspaceBranding) -> TaskResult<String> {
+    let value = json!({
+        "brand": branding.brand,
+        "upstream_version": branding.upstream_version,
+        "rust_version": branding.rust_version,
+        "protocol": branding.protocol,
+        "client_bin": branding.client_bin,
+        "daemon_bin": branding.daemon_bin,
+        "legacy_client_bin": branding.legacy_client_bin,
+        "legacy_daemon_bin": branding.legacy_daemon_bin,
+        "daemon_config_dir": branding.daemon_config_dir.display().to_string(),
+        "daemon_config": branding.daemon_config.display().to_string(),
+        "daemon_secrets": branding.daemon_secrets.display().to_string(),
+        "legacy_daemon_config_dir": branding
+            .legacy_daemon_config_dir
+            .display()
+            .to_string(),
+        "legacy_daemon_config": branding
+            .legacy_daemon_config
+            .display()
+            .to_string(),
+        "legacy_daemon_secrets": branding
+            .legacy_daemon_secrets
+            .display()
+            .to_string(),
+        "source": branding.source,
+    });
+
+    serde_json::to_string_pretty(&value).map_err(|error| {
+        TaskError::Metadata(format!(
+            "failed to serialise branding metadata as JSON: {error}"
+        ))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn sample_branding() -> WorkspaceBranding {
+        WorkspaceBranding {
+            brand: String::from("oc"),
+            upstream_version: String::from("3.4.1"),
+            rust_version: String::from("3.4.1-rust"),
+            protocol: 32,
+            client_bin: String::from("oc-rsync"),
+            daemon_bin: String::from("oc-rsyncd"),
+            legacy_client_bin: String::from("rsync"),
+            legacy_daemon_bin: String::from("rsyncd"),
+            daemon_config_dir: PathBuf::from("/etc/oc-rsyncd"),
+            daemon_config: PathBuf::from("/etc/oc-rsyncd/oc-rsyncd.conf"),
+            daemon_secrets: PathBuf::from("/etc/oc-rsyncd/oc-rsyncd.secrets"),
+            legacy_daemon_config_dir: PathBuf::from("/etc"),
+            legacy_daemon_config: PathBuf::from("/etc/rsyncd.conf"),
+            legacy_daemon_secrets: PathBuf::from("/etc/rsyncd.secrets"),
+            source: String::from("https://example.invalid/rsync"),
+        }
+    }
+
+    #[test]
+    fn render_text_matches_expected_layout() {
+        let branding = sample_branding();
+        let rendered = render_branding_text(&branding);
+        let expected = concat!(
+            "Workspace branding summary:\n",
+            "  brand: oc\n",
+            "  upstream_version: 3.4.1\n",
+            "  rust_version: 3.4.1-rust\n",
+            "  protocol: 32\n",
+            "  client_bin: oc-rsync\n",
+            "  daemon_bin: oc-rsyncd\n",
+            "  legacy_client_bin: rsync\n",
+            "  legacy_daemon_bin: rsyncd\n",
+            "  daemon_config_dir: /etc/oc-rsyncd\n",
+            "  daemon_config: /etc/oc-rsyncd/oc-rsyncd.conf\n",
+            "  daemon_secrets: /etc/oc-rsyncd/oc-rsyncd.secrets\n",
+            "  legacy_daemon_config_dir: /etc\n",
+            "  legacy_daemon_config: /etc/rsyncd.conf\n",
+            "  legacy_daemon_secrets: /etc/rsyncd.secrets\n",
+            "  source: https://example.invalid/rsync"
+        );
+        assert_eq!(rendered, expected);
+    }
+
+    #[test]
+    fn render_json_produces_expected_structure() {
+        let branding = sample_branding();
+        let rendered = render_branding_json(&branding).expect("json output");
+        let parsed: serde_json::Value = serde_json::from_str(&rendered).expect("parse json");
+        assert_eq!(parsed["brand"], "oc");
+        assert_eq!(parsed["protocol"], 32);
+    }
+
+    #[test]
+    fn render_branding_respects_selected_format() {
+        let branding = sample_branding();
+        let text = render_branding(&branding, BrandingOutputFormat::Text).expect("text");
+        assert_eq!(text, render_branding_text(&branding));
+        let json = render_branding(&branding, BrandingOutputFormat::Json).expect("json");
+        let expected = render_branding_json(&branding).expect("json");
+        assert_eq!(json, expected);
+    }
+}


### PR DESCRIPTION
## Summary
- split the xtask branding command into args, render, and validate modules to enforce the line-count policy while keeping responsibilities focused
- keep the execute helper thin and update the unit tests to exercise the new module boundaries

## Testing
- cargo test -p xtask

------