### PR TITLE
Add rust-toolchain manifest with required cross targets

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,16 @@
+[toolchain]
+channel = "1.87.0"
+profile = "minimal"
+components = [
+    "rustfmt",
+    "clippy",
+    "rust-src",
+    "llvm-tools-preview",
+]
+targets = [
+    "aarch64-unknown-linux-gnu",
+    "x86_64-apple-darwin",
+    "aarch64-apple-darwin",
+    "x86_64-pc-windows-gnu",
+    "i686-pc-windows-gnu",
+]


### PR DESCRIPTION
## Summary
- add a `rust-toolchain.toml` manifest that pins Rust 1.87.0 for the workspace
- install the components and targets needed by coverage and cross-compilation jobs so std is available during CI builds

## Testing
- not run (configuration change only)

------