### PR TITLE
Force abort panics on Windows GNU builds

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,5 @@
 [build]
 rustc-wrapper = "tools/cross/rustc-with-zig.sh"
+
+[target.i686-pc-windows-gnu]
+rustflags = ["-C", "panic=abort"]


### PR DESCRIPTION
## Summary
- ensure Windows GNU cross-compiles build with aborting panics to avoid missing libgcc registration symbols

## Testing
- cargo build --release --target i686-pc-windows-gnu -p oc-rsync-bin *(fails: zig is unavailable in the local container)*

------