### PR TITLE
Fix Windows GNU EH shim exports

### DIFF
--- a/crates/windows-gnu-eh/src/lib.rs
+++ b/crates/windows-gnu-eh/src/lib.rs
@@ -131,7 +131,7 @@ mod windows_gnu {
     }
 
     /// Forwards `rsbegin`'s registration hook to libunwind.
-    #[unsafe(no_mangle)]
+    #[no_mangle]
     pub unsafe extern "C" fn ___register_frame_info(eh_frame: *const u8, object: *mut c_void) {
         if let Some(register) = unsafe { resolve_register() } {
             unsafe {
@@ -141,7 +141,7 @@ mod windows_gnu {
     }
 
     /// Forwards `rsbegin`'s deregistration hook to libunwind.
-    #[unsafe(no_mangle)]
+    #[no_mangle]
     pub unsafe extern "C" fn ___deregister_frame_info(eh_frame: *const u8) {
         if let Some(deregister) = unsafe { resolve_deregister() } {
             unsafe {


### PR DESCRIPTION
## Summary
- export the Windows GNU unwinding compatibility shims with `#[no_mangle]` so rustc can link them

## Testing
- `cargo build -p oc-rsync-bin --target i686-pc-windows-gnu --release` *(fails: zig is required to emulate i686-w64-mingw32-dlltool)*

------