### PR TITLE
Fix unused imports in daemon crate

### DIFF
--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -211,12 +211,9 @@ use rsync_core::{
         parse_bandwidth_limit,
     },
     branding::{self, Brand, manifest},
-    fallback::{
-        CLIENT_FALLBACK_ENV, DAEMON_AUTO_DELEGATE_ENV, DAEMON_FALLBACK_ENV, fallback_override,
-    },
+    fallback::{CLIENT_FALLBACK_ENV, DAEMON_FALLBACK_ENV, fallback_override},
     message::{Message, Role},
     rsync_error, rsync_info, rsync_warning,
-    version::VersionInfoReport,
 };
 use rsync_logging::MessageSink;
 use rsync_protocol::{


### PR DESCRIPTION
## Summary
- remove unused daemon fallback and version info imports in the daemon library to satisfy `-D warnings`

## Testing
- cargo check -p rsync-daemon

------