### PR TITLE
Fix missing core imports in daemon tests

### DIFF
--- a/crates/daemon/src/tests.rs
+++ b/crates/daemon/src/tests.rs
@@ -10,6 +10,8 @@ use std::sync::Mutex;
 use std::sync::{Arc, Barrier};
 use std::thread;
 use std::time::Duration;
+use rsync_core::fallback::DAEMON_AUTO_DELEGATE_ENV;
+use rsync_core::version::VersionInfoReport;
 use tempfile::{NamedTempFile, tempdir};
 
 #[cfg(unix)]


### PR DESCRIPTION
## Summary
- import the daemon auto delegate env constant from rsync-core for tests
- add the version info report import required by version flag tests

## Testing
- `cargo test -p rsync-daemon --tests`

------