### PR TITLE
Fix missing imports in daemon tests

### DIFF
--- a/crates/daemon/src/tests.rs
+++ b/crates/daemon/src/tests.rs
@@ -1,4 +1,6 @@
 use super::*;
+use rsync_core::fallback::DAEMON_AUTO_DELEGATE_ENV;
+use rsync_core::version::VersionInfoReport;
 use std::borrow::Cow;
 use std::ffi::{OsStr, OsString};
 use std::fs;


### PR DESCRIPTION
## Summary
- import the DAEMON_AUTO_DELEGATE_ENV constant so daemon fallback tests compile
- bring VersionInfoReport into scope for daemon version reporting tests

## Testing
- cargo test -p rsync-daemon --lib --no-run

------