### PR TITLE
Fix duplicate imports in daemon tests

### DIFF
--- a/crates/daemon/src/tests.rs
+++ b/crates/daemon/src/tests.rs
@@ -12,8 +12,6 @@ use std::sync::Mutex;
 use std::sync::{Arc, Barrier};
 use std::thread;
 use std::time::Duration;
-use rsync_core::fallback::DAEMON_AUTO_DELEGATE_ENV;
-use rsync_core::version::VersionInfoReport;
 use tempfile::{NamedTempFile, tempdir};
 
 #[cfg(unix)]


### PR DESCRIPTION
## Summary
- remove duplicated `rsync_core` imports in the daemon test module to resolve formatting failures

## Testing
- cargo fmt --all -- --check

------