### PR TITLE
Add optional region and branch coverage thresholds

### DIFF
--- a/tools/check_coverage.py
+++ b/tools/check_coverage.py
@@ -76,6 +76,18 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--min-functions", type=float, default=95.0, help="Minimum function coverage percentage"
     )
+    parser.add_argument(
+        "--min-regions",
+        type=float,
+        default=None,
+        help="Minimum region coverage percentage (if provided)",
+    )
+    parser.add_argument(
+        "--min-branches",
+        type=float,
+        default=None,
+        help="Minimum branch coverage percentage (if provided)",
+    )
     return parser.parse_args()
 
 
@@ -83,7 +95,11 @@ def main() -> int:
     args = parse_args()
     metrics = load_metrics(args.summary)
     print_metrics(metrics.values())
-    requirements = {"lines": args.min_lines, "functions": args.min_functions}
+    requirements: dict[str, float] = {"lines": args.min_lines, "functions": args.min_functions}
+    if args.min_regions is not None:
+        requirements["regions"] = args.min_regions
+    if args.min_branches is not None:
+        requirements["branches"] = args.min_branches
     return enforce_thresholds(metrics, requirements)
 
 

--- a/tools/tests/test_check_coverage.py
+++ b/tools/tests/test_check_coverage.py
@@ -1,0 +1,51 @@
+"""Unit tests for the coverage gate helper."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from tools.check_coverage import enforce_thresholds, load_metrics
+
+
+class CheckCoverageTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tempdir = tempfile.TemporaryDirectory()
+        self.summary_path = Path(self._tempdir.name, "summary.json")
+        self.summary_path.write_text(
+            json.dumps(
+                {
+                    "data": [
+                        {
+                            "totals": {
+                                "lines": {"count": 200, "covered": 190, "percent": 95.0},
+                                "functions": {"count": 40, "covered": 39, "percent": 97.5},
+                                "regions": {"count": 10, "covered": 8, "percent": 80.0},
+                            }
+                        }
+                    ]
+                }
+            )
+        )
+
+    def tearDown(self) -> None:
+        self._tempdir.cleanup()
+
+    def test_load_metrics_extracts_percentages(self) -> None:
+        metrics = load_metrics(self.summary_path)
+        self.assertIn("lines", metrics)
+        self.assertIn("functions", metrics)
+        self.assertAlmostEqual(metrics["lines"].percent, 95.0)
+        self.assertEqual(metrics["regions"].covered, 8.0)
+
+    def test_enforce_thresholds_handles_success_and_failure(self) -> None:
+        metrics = load_metrics(self.summary_path)
+        self.assertEqual(0, enforce_thresholds(metrics, {"lines": 90.0, "functions": 95.0}))
+        self.assertEqual(1, enforce_thresholds(metrics, {"branches": 10.0}))
+        self.assertEqual(1, enforce_thresholds(metrics, {"regions": 85.0}))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- extend the coverage gate CLI with optional region and branch thresholds
- add unit tests validating metric parsing and threshold enforcement behaviour

## Testing
- python3 -m unittest discover -s tools/tests

------