### PR TITLE
Add unit tests for error handling utilities

### DIFF
--- a/crates/apple-fs/src/lib.rs
+++ b/crates/apple-fs/src/lib.rs
@@ -56,3 +56,60 @@ pub fn mknod(_path: &Path, _mode: ModeType, _device: DeviceType) -> io::Result<(
         "mknod is only implemented on Unix platforms",
     ))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::env;
+    use std::fs;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[cfg(unix)]
+    fn unique_path(prefix: &str) -> std::path::PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("time went backwards")
+            .as_nanos();
+        env::temp_dir().join(format!("{prefix}_{unique}"))
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn mkfifo_creates_named_pipe() -> io::Result<()> {
+        use std::os::unix::fs::FileTypeExt;
+
+        let path = unique_path("rsync_fifo");
+        mkfifo(&path, 0o600)?;
+        let metadata = fs::metadata(&path)?;
+        assert!(metadata.file_type().is_fifo());
+        fs::remove_file(&path)?;
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn mknod_creates_fifo_when_requested() -> io::Result<()> {
+        use std::os::unix::fs::FileTypeExt;
+
+        let path = unique_path("rsync_mknod");
+        mknod(&path, libc::S_IFIFO | 0o600, 0)?;
+        let metadata = fs::metadata(&path)?;
+        assert!(metadata.file_type().is_fifo());
+        fs::remove_file(&path)?;
+        Ok(())
+    }
+
+    #[cfg(not(unix))]
+    #[test]
+    fn non_unix_platforms_report_unsupported_operations() {
+        let path = Path::new("nonexistent");
+        assert_eq!(
+            mkfifo(path, 0).unwrap_err().kind(),
+            io::ErrorKind::Unsupported
+        );
+        assert_eq!(
+            mknod(path, 0, 0).unwrap_err().kind(),
+            io::ErrorKind::Unsupported
+        );
+    }
+}

--- a/crates/checksums/src/rolling/error.rs
+++ b/crates/checksums/src/rolling/error.rs
@@ -86,3 +86,38 @@ impl fmt::Display for RollingSliceError {
 }
 
 impl std::error::Error for RollingSliceError {}
+
+#[cfg(test)]
+mod tests {
+    use super::{RollingError, RollingSliceError};
+
+    #[test]
+    fn rolling_error_display_messages_are_descriptive() {
+        let empty = RollingError::EmptyWindow.to_string();
+        assert!(empty.contains("non-empty"));
+
+        let too_large = RollingError::WindowTooLarge { len: 1 << 20 }.to_string();
+        assert!(too_large.contains("exceeds"));
+        assert!(too_large.contains("1048576"));
+
+        let mismatched = RollingError::MismatchedSliceLength {
+            outgoing: 2,
+            incoming: 1,
+        }
+        .to_string();
+        assert!(mismatched.contains("outgoing (2)"));
+        assert!(mismatched.contains("incoming (1)"));
+    }
+
+    #[test]
+    fn rolling_slice_error_reports_length_information() {
+        let err = RollingSliceError::new(2);
+        assert_eq!(err.len(), 2);
+        assert!(!err.is_empty());
+        assert_eq!(RollingSliceError::EXPECTED_LEN, 4);
+        assert!(err.to_string().contains("received 2"));
+
+        let empty_err = RollingSliceError::new(0);
+        assert!(empty_err.is_empty());
+    }
+}

--- a/crates/core/src/message/errors.rs
+++ b/crates/core/src/message/errors.rs
@@ -42,3 +42,31 @@ pub(super) fn map_message_reserve_error(err: TryReserveError) -> io::Error {
         MessageBufferReserveError::new(err),
     )
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{map_message_reserve_error, MessageBufferReserveError};
+    use std::error::Error as _;
+
+    #[test]
+    fn mapped_error_wraps_original_try_reserve_error() {
+        let mut buffer: Vec<u8> = Vec::new();
+        let err = buffer.try_reserve(usize::MAX).unwrap_err();
+        let io_error = map_message_reserve_error(err);
+
+        assert_eq!(io_error.kind(), std::io::ErrorKind::OutOfMemory);
+        assert!(io_error.to_string().contains("failed to reserve memory"));
+
+        let source = io_error.source().expect("wrapped error");
+        let try_reserve = source
+            .downcast_ref::<std::collections::TryReserveError>()
+            .expect("inner TryReserveError");
+        assert!(try_reserve.to_string().contains("memory"));
+
+        let message_error = io_error
+            .get_ref()
+            .and_then(|err| err.downcast_ref::<MessageBufferReserveError>())
+            .expect("MessageBufferReserveError in chain");
+        assert!(message_error.to_string().contains("rsync message"));
+    }
+}

--- a/crates/filters/src/action.rs
+++ b/crates/filters/src/action.rs
@@ -26,3 +26,23 @@ impl fmt::Display for FilterAction {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::FilterAction;
+
+    #[test]
+    fn display_variants_matches_expected_tokens() {
+        let cases = [
+            (FilterAction::Include, "include"),
+            (FilterAction::Exclude, "exclude"),
+            (FilterAction::Protect, "protect"),
+            (FilterAction::Risk, "risk"),
+            (FilterAction::Clear, "clear"),
+        ];
+
+        for (action, expected) in cases {
+            assert_eq!(action.to_string(), expected);
+        }
+    }
+}

--- a/crates/filters/src/error.rs
+++ b/crates/filters/src/error.rs
@@ -35,3 +35,21 @@ impl std::error::Error for FilterError {
         Some(&self.source)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::FilterError;
+    use globset::GlobBuilder;
+    use std::error::Error as _;
+
+    #[test]
+    fn filter_error_preserves_pattern_and_source() {
+        let glob_err = GlobBuilder::new("[").build().unwrap_err();
+        let error = FilterError::new("[".into(), glob_err.clone());
+
+        assert_eq!(error.pattern(), "[");
+        assert!(error.to_string().contains("failed to compile"));
+        assert!(error.source().is_some());
+        assert_eq!(error.source().unwrap().to_string(), glob_err.to_string());
+    }
+}

--- a/xtask/src/error.rs
+++ b/xtask/src/error.rs
@@ -68,3 +68,50 @@ impl From<io::Error> for TaskError {
         TaskError::Io(error)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{TaskError, TaskResult};
+    use std::io;
+    use std::path::PathBuf;
+
+    #[test]
+    fn display_messages_match_variant_contents() {
+        assert_eq!(TaskError::Usage("usage".into()).to_string(), "usage");
+        assert_eq!(TaskError::Help("help".into()).to_string(), "help");
+        assert_eq!(TaskError::Metadata("meta".into()).to_string(), "meta");
+        assert_eq!(TaskError::Validation("invalid".into()).to_string(), "invalid");
+        assert_eq!(TaskError::ToolMissing("tool".into()).to_string(), "tool");
+
+        let io_error = TaskError::from(io::Error::new(io::ErrorKind::Other, "io"));
+        assert_eq!(io_error.to_string(), "io");
+
+        let binary = TaskError::BinaryFiles(vec![PathBuf::from("bin/artifact")]).to_string();
+        assert!(binary.contains("binary files detected"));
+        assert!(binary.contains("bin/artifact"));
+
+        #[cfg(unix)]
+        {
+            let status = std::process::Command::new("/bin/sh")
+                .arg("-c")
+                .arg("exit 3")
+                .status()
+                .expect("shell exit");
+            let message = TaskError::CommandFailed {
+                program: "sh".into(),
+                status,
+            }
+            .to_string();
+            assert!(message.contains("status code 3"));
+        }
+    }
+
+    #[test]
+    fn task_result_type_alias_is_convenient() {
+        fn helper() -> TaskResult<()> {
+            Err(TaskError::Usage("bad".into()))
+        }
+
+        assert!(matches!(helper(), Err(TaskError::Usage(message)) if message == "bad"));
+    }
+}


### PR DESCRIPTION
## Summary
- add unit coverage for rolling checksum and filter error helpers
- exercise core message reserve errors and metadata error reporting paths
- validate apple-fs wrappers and xtask TaskError formatting with new tests

## Testing
- cargo test

------