### PR TITLE
Format tests to satisfy rustfmt

### DIFF
--- a/crates/core/src/message/errors.rs
+++ b/crates/core/src/message/errors.rs
@@ -45,7 +45,7 @@ pub(super) fn map_message_reserve_error(err: TryReserveError) -> io::Error {
 
 #[cfg(test)]
 mod tests {
-    use super::{map_message_reserve_error, MessageBufferReserveError};
+    use super::{MessageBufferReserveError, map_message_reserve_error};
     use std::error::Error as _;
 
     #[test]

--- a/crates/meta/src/error.rs
+++ b/crates/meta/src/error.rs
@@ -66,9 +66,9 @@ impl std::error::Error for MetadataError {
 #[cfg(test)]
 mod tests {
     use super::MetadataError;
+    use std::error::Error as _;
     use std::io;
     use std::path::Path;
-    use std::error::Error as _;
 
     #[test]
     fn metadata_error_exposes_contextual_information() {

--- a/xtask/src/error.rs
+++ b/xtask/src/error.rs
@@ -80,7 +80,10 @@ mod tests {
         assert_eq!(TaskError::Usage("usage".into()).to_string(), "usage");
         assert_eq!(TaskError::Help("help".into()).to_string(), "help");
         assert_eq!(TaskError::Metadata("meta".into()).to_string(), "meta");
-        assert_eq!(TaskError::Validation("invalid".into()).to_string(), "invalid");
+        assert_eq!(
+            TaskError::Validation("invalid".into()).to_string(),
+            "invalid"
+        );
         assert_eq!(TaskError::ToolMissing("tool".into()).to_string(), "tool");
 
         let io_error = TaskError::from(io::Error::new(io::ErrorKind::Other, "io"));


### PR DESCRIPTION
## Summary
- reorder test module imports to match rustfmt expectations
- reflow long assertion in xtask tests for fmt compliance

## Testing
- cargo fmt --all -- --check

------