### PR TITLE
Fix clippy io::Error warning in xtask tests

### DIFF
--- a/xtask/src/error.rs
+++ b/xtask/src/error.rs
@@ -86,7 +86,7 @@ mod tests {
         );
         assert_eq!(TaskError::ToolMissing("tool".into()).to_string(), "tool");
 
-        let io_error = TaskError::from(io::Error::new(io::ErrorKind::Other, "io"));
+        let io_error = TaskError::from(io::Error::other("io"));
         assert_eq!(io_error.to_string(), "io");
 
         let binary = TaskError::BinaryFiles(vec![PathBuf::from("bin/artifact")]).to_string();


### PR DESCRIPTION
## Summary
- replace manual io::Error construction in the xtask error tests with the helper constructor

## Testing
- cargo clippy --workspace --all-targets --all-features -- -Dwarnings

------