### PR TITLE
Add unit coverage for metadata and exit code helpers

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -26,3 +26,24 @@ pub(crate) use frontend::{
     LIST_TIMESTAMP_FORMAT, OutFormat, OutFormatContext, describe_event_kind, emit_out_format,
     format_list_permissions, parse_out_format,
 };
+
+#[cfg(test)]
+mod tests {
+    use super::exit_code_from;
+    use std::process::ExitCode;
+
+    #[test]
+    fn exit_code_from_clamps_negative_values() {
+        assert_eq!(exit_code_from(-5), ExitCode::from(0));
+    }
+
+    #[test]
+    fn exit_code_from_clamps_large_values() {
+        assert_eq!(exit_code_from(1_000), ExitCode::from(u8::MAX));
+    }
+
+    #[test]
+    fn exit_code_from_preserves_valid_values() {
+        assert_eq!(exit_code_from(42), ExitCode::from(42));
+    }
+}

--- a/crates/core/tests/workspace_metadata.rs
+++ b/crates/core/tests/workspace_metadata.rs
@@ -1,0 +1,106 @@
+use rsync_core::branding::{
+    BRAND_OVERRIDE_ENV, LEGACY_DAEMON_CONFIG_DIR, LEGACY_DAEMON_CONFIG_PATH,
+    LEGACY_DAEMON_SECRETS_PATH, OC_CLIENT_PROGRAM_NAME, OC_DAEMON_CONFIG_DIR,
+    OC_DAEMON_CONFIG_PATH, OC_DAEMON_PROGRAM_NAME, OC_DAEMON_SECRETS_PATH,
+    UPSTREAM_CLIENT_PROGRAM_NAME, UPSTREAM_DAEMON_PROGRAM_NAME, brand_override_env_var,
+};
+use rsync_core::workspace::{
+    self, CLIENT_PROGRAM_NAME, DAEMON_CONFIG_DIR, DAEMON_CONFIG_PATH, DAEMON_PROGRAM_NAME,
+    DAEMON_SECRETS_PATH, LEGACY_CLIENT_PROGRAM_NAME, LEGACY_DAEMON_PROGRAM_NAME, PROTOCOL_VERSION,
+    RUST_VERSION, SOURCE_URL, UPSTREAM_VERSION,
+};
+use std::path::Path;
+
+#[test]
+fn workspace_metadata_matches_constants() {
+    let metadata = workspace::metadata();
+
+    assert_eq!(metadata.brand(), workspace::brand());
+    assert_eq!(metadata.brand(), workspace::BRAND);
+    assert_eq!(metadata.upstream_version(), UPSTREAM_VERSION);
+    assert_eq!(metadata.rust_version(), RUST_VERSION);
+    assert_eq!(metadata.protocol_version(), PROTOCOL_VERSION);
+    assert_eq!(metadata.client_program_name(), CLIENT_PROGRAM_NAME);
+    assert_eq!(metadata.daemon_program_name(), DAEMON_PROGRAM_NAME);
+    assert_eq!(
+        metadata.legacy_client_program_name(),
+        LEGACY_CLIENT_PROGRAM_NAME
+    );
+    assert_eq!(
+        metadata.legacy_daemon_program_name(),
+        LEGACY_DAEMON_PROGRAM_NAME
+    );
+    assert_eq!(metadata.daemon_config_dir(), DAEMON_CONFIG_DIR);
+    assert_eq!(metadata.daemon_config_path(), DAEMON_CONFIG_PATH);
+    assert_eq!(metadata.daemon_secrets_path(), DAEMON_SECRETS_PATH);
+    assert_eq!(
+        metadata.legacy_daemon_config_dir(),
+        workspace::LEGACY_DAEMON_CONFIG_DIR
+    );
+    assert_eq!(
+        metadata.legacy_daemon_config_path(),
+        workspace::LEGACY_DAEMON_CONFIG_PATH
+    );
+    assert_eq!(
+        metadata.legacy_daemon_secrets_path(),
+        workspace::LEGACY_DAEMON_SECRETS_PATH
+    );
+    assert_eq!(metadata.source_url(), SOURCE_URL);
+}
+
+#[test]
+fn branding_constants_align_with_workspace_metadata() {
+    let metadata = workspace::metadata();
+
+    assert_eq!(
+        UPSTREAM_CLIENT_PROGRAM_NAME,
+        metadata.legacy_client_program_name()
+    );
+    assert_eq!(
+        UPSTREAM_DAEMON_PROGRAM_NAME,
+        metadata.legacy_daemon_program_name()
+    );
+    assert_eq!(OC_CLIENT_PROGRAM_NAME, metadata.client_program_name());
+    assert_eq!(OC_DAEMON_PROGRAM_NAME, metadata.daemon_program_name());
+    assert_eq!(OC_DAEMON_CONFIG_DIR, metadata.daemon_config_dir());
+    assert_eq!(OC_DAEMON_CONFIG_PATH, metadata.daemon_config_path());
+    assert_eq!(OC_DAEMON_SECRETS_PATH, metadata.daemon_secrets_path());
+    assert_eq!(
+        LEGACY_DAEMON_CONFIG_DIR,
+        metadata.legacy_daemon_config_dir()
+    );
+    assert_eq!(
+        LEGACY_DAEMON_CONFIG_PATH,
+        metadata.legacy_daemon_config_path()
+    );
+    assert_eq!(
+        LEGACY_DAEMON_SECRETS_PATH,
+        metadata.legacy_daemon_secrets_path()
+    );
+    assert_eq!(brand_override_env_var(), BRAND_OVERRIDE_ENV);
+}
+
+#[test]
+fn workspace_path_helpers_return_expected_paths() {
+    assert_eq!(workspace::daemon_config_dir(), Path::new(DAEMON_CONFIG_DIR));
+    assert_eq!(
+        workspace::daemon_config_path(),
+        Path::new(DAEMON_CONFIG_PATH)
+    );
+    assert_eq!(
+        workspace::daemon_secrets_path(),
+        Path::new(DAEMON_SECRETS_PATH)
+    );
+    assert_eq!(
+        workspace::legacy_daemon_config_dir(),
+        Path::new(workspace::LEGACY_DAEMON_CONFIG_DIR)
+    );
+    assert_eq!(
+        workspace::legacy_daemon_config_path(),
+        Path::new(workspace::LEGACY_DAEMON_CONFIG_PATH)
+    );
+    assert_eq!(
+        workspace::legacy_daemon_secrets_path(),
+        Path::new(workspace::LEGACY_DAEMON_SECRETS_PATH)
+    );
+}

--- a/crates/daemon/src/cli.rs
+++ b/crates/daemon/src/cli.rs
@@ -204,3 +204,131 @@ where
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rsync_core::fallback::{CLIENT_FALLBACK_ENV, DAEMON_FALLBACK_ENV};
+    use std::env;
+    use std::ffi::OsString;
+    use std::sync::{Mutex, MutexGuard, OnceLock};
+
+    const TEST_FLAG: &str = "OC_RSYNC_DAEMON_TEST_FLAG";
+
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    struct EnvSnapshot {
+        entries: Vec<(&'static str, Option<OsString>)>,
+        _guard: MutexGuard<'static, ()>,
+    }
+
+    impl EnvSnapshot {
+        fn new(keys: &'static [&'static str]) -> Self {
+            let guard = env_lock()
+                .lock()
+                .expect("environment lock poisoned during test");
+            let entries = keys
+                .iter()
+                .map(|&key| (key, env::var_os(key)))
+                .collect::<Vec<_>>();
+            Self {
+                entries,
+                _guard: guard,
+            }
+        }
+
+        #[allow(unsafe_code)]
+        fn set(&self, key: &'static str, value: &str) {
+            debug_assert!(self.entries.iter().any(|(candidate, _)| *candidate == key));
+            let owned = OsString::from(value);
+            unsafe {
+                env::set_var(key, &owned);
+            }
+        }
+
+        #[allow(unsafe_code)]
+        fn remove(&self, key: &'static str) {
+            debug_assert!(self.entries.iter().any(|(candidate, _)| *candidate == key));
+            unsafe {
+                env::remove_var(key);
+            }
+        }
+    }
+
+    impl Drop for EnvSnapshot {
+        #[allow(unsafe_code)]
+        fn drop(&mut self) {
+            for (key, value) in &self.entries {
+                if let Some(original) = value {
+                    unsafe {
+                        env::set_var(key, original);
+                    }
+                } else {
+                    unsafe {
+                        env::remove_var(key);
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn exit_code_from_clamps_values() {
+        assert_eq!(exit_code_from(-1), std::process::ExitCode::from(0));
+        assert_eq!(exit_code_from(42), std::process::ExitCode::from(42));
+        assert_eq!(exit_code_from(9_999), std::process::ExitCode::from(u8::MAX));
+    }
+
+    #[test]
+    fn env_flag_interprets_common_values() {
+        let snapshot = EnvSnapshot::new(&[TEST_FLAG]);
+
+        snapshot.remove(TEST_FLAG);
+        assert_eq!(env_flag(TEST_FLAG), None);
+
+        snapshot.set(TEST_FLAG, "false");
+        assert_eq!(env_flag(TEST_FLAG), Some(false));
+
+        snapshot.set(TEST_FLAG, "  ");
+        assert_eq!(env_flag(TEST_FLAG), Some(true));
+
+        snapshot.set(TEST_FLAG, "YES");
+        assert_eq!(env_flag(TEST_FLAG), Some(true));
+
+        snapshot.set(TEST_FLAG, "off");
+        assert_eq!(env_flag(TEST_FLAG), Some(false));
+    }
+
+    #[test]
+    fn auto_delegate_system_rsync_enabled_reads_environment() {
+        let snapshot = EnvSnapshot::new(&[DAEMON_AUTO_DELEGATE_ENV]);
+
+        snapshot.remove(DAEMON_AUTO_DELEGATE_ENV);
+        assert!(!auto_delegate_system_rsync_enabled());
+
+        snapshot.set(DAEMON_AUTO_DELEGATE_ENV, "1");
+        assert!(auto_delegate_system_rsync_enabled());
+
+        snapshot.set(DAEMON_AUTO_DELEGATE_ENV, "0");
+        assert!(!auto_delegate_system_rsync_enabled());
+    }
+
+    #[test]
+    fn fallback_binary_configured_accounts_for_disabling_overrides() {
+        let snapshot = EnvSnapshot::new(&[DAEMON_FALLBACK_ENV, CLIENT_FALLBACK_ENV]);
+
+        snapshot.remove(DAEMON_FALLBACK_ENV);
+        snapshot.remove(CLIENT_FALLBACK_ENV);
+        assert!(fallback_binary_configured());
+
+        snapshot.set(DAEMON_FALLBACK_ENV, "0");
+        assert!(!fallback_binary_configured());
+
+        snapshot.remove(DAEMON_FALLBACK_ENV);
+        snapshot.set(CLIENT_FALLBACK_ENV, "0");
+        assert!(!fallback_binary_configured());
+    }
+}

--- a/crates/windows-gnu-eh/src/lib.rs
+++ b/crates/windows-gnu-eh/src/lib.rs
@@ -167,3 +167,18 @@ pub use windows_gnu::force_link;
 
 #[cfg(not(all(target_os = "windows", target_env = "gnu")))]
 pub use not_windows_gnu::force_link;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn force_link_is_a_no_op() {
+        // The helper intentionally performs no work on non-Windows targets and
+        // exists purely to keep linkage symmetric across platforms. Exercising
+        // the function ensures its signature remains callable from dependants
+        // and guards against accidental regressions that would introduce side
+        // effects.
+        force_link();
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests for exit code clamping logic in the CLI and daemon frontends
- exercise walk error constructors and the Windows GNU force_link helper
- verify workspace metadata and branding constants through a new integration test

## Testing
- cargo test

------