### PR TITLE
Add smoke tests for binaries and platform lookup helpers

### DIFF
--- a/bin/oc-rsync/src/main.rs
+++ b/bin/oc-rsync/src/main.rs
@@ -1,5 +1,6 @@
 #![deny(unsafe_code)]
 
+use std::io::Write;
 use std::{env, io, process::ExitCode};
 
 fn main() -> ExitCode {
@@ -8,6 +9,32 @@ fn main() -> ExitCode {
 
     let mut stdout = io::stdout().lock();
     let mut stderr = io::stderr().lock();
-    let status = rsync_cli::run(env::args_os(), &mut stdout, &mut stderr);
+    run_with(env::args_os(), &mut stdout, &mut stderr)
+}
+
+fn run_with<I, Out, Err>(args: I, stdout: &mut Out, stderr: &mut Err) -> ExitCode
+where
+    I: IntoIterator,
+    I::Item: Into<std::ffi::OsString>,
+    Out: Write,
+    Err: Write,
+{
+    let status = rsync_cli::run(args, stdout, stderr);
     rsync_cli::exit_code_from(status)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::run_with;
+    use std::process::ExitCode;
+
+    #[test]
+    fn version_flag_reports_success() {
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+        let exit = run_with(["oc-rsync", "--version"], &mut stdout, &mut stderr);
+        assert_eq!(exit, ExitCode::SUCCESS);
+        assert!(!stdout.is_empty(), "version output should not be empty");
+        assert!(stderr.is_empty(), "version flag should not write to stderr");
+    }
 }

--- a/bin/oc-rsyncd/src/main.rs
+++ b/bin/oc-rsyncd/src/main.rs
@@ -1,5 +1,6 @@
 #![deny(unsafe_code)]
 
+use std::io::Write;
 use std::{env, io, process::ExitCode};
 
 fn main() -> ExitCode {
@@ -8,6 +9,32 @@ fn main() -> ExitCode {
 
     let mut stdout = io::stdout().lock();
     let mut stderr = io::stderr().lock();
-    let status = rsync_daemon::run(env::args_os(), &mut stdout, &mut stderr);
+    run_with(env::args_os(), &mut stdout, &mut stderr)
+}
+
+fn run_with<I, Out, Err>(args: I, stdout: &mut Out, stderr: &mut Err) -> ExitCode
+where
+    I: IntoIterator,
+    I::Item: Into<std::ffi::OsString>,
+    Out: Write,
+    Err: Write,
+{
+    let status = rsync_daemon::run(args, stdout, stderr);
     rsync_daemon::exit_code_from(status)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::run_with;
+    use std::process::ExitCode;
+
+    #[test]
+    fn daemon_version_flag_reports_success() {
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+        let exit = run_with(["oc-rsyncd", "--version"], &mut stdout, &mut stderr);
+        assert_eq!(exit, ExitCode::SUCCESS);
+        assert!(!stdout.is_empty(), "version output should not be empty");
+        assert!(stderr.is_empty(), "version flag should not write to stderr");
+    }
 }


### PR DESCRIPTION
## Summary
- refactor the oc-rsync and oc-rsyncd binaries to expose a reusable `run_with` helper for tests
- add smoke tests that exercise the `--version` flows for both binaries
- cover the user and group lookup helpers on Unix and non-Unix platforms

## Testing
- cargo fmt --all
- cargo test -p oc-rsync-bin
- cargo test -p oc-rsyncd-bin
- cargo test -p rsync-cli --lib platform::tests::support_flags_match_platform
- cargo test -p rsync-cli --lib platform::tests::user_lookup_round_trip_matches_current_identity
- cargo test -p rsync-cli --lib platform::tests::group_lookup_round_trip_matches_current_identity

------