### PR TITLE
Add metadata special file handling tests

### DIFF
--- a/crates/meta/src/special.rs
+++ b/crates/meta/src/special.rs
@@ -238,3 +238,95 @@ fn invalid_mode_error(context: &'static str, destination: &Path) -> MetadataErro
         ),
     )
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::io;
+    use std::path::Path;
+    use tempfile::tempdir;
+
+    #[cfg(all(
+        unix,
+        not(any(
+            target_os = "ios",
+            target_os = "macos",
+            target_os = "tvos",
+            target_os = "watchos"
+        ))
+    ))]
+    #[test]
+    fn create_fifo_applies_metadata_permissions() {
+        use std::os::unix::fs::{FileTypeExt, PermissionsExt};
+
+        let temp = tempdir().expect("create tempdir");
+        let source_path = temp.path().join("source");
+        fs::File::create(&source_path).expect("create metadata source");
+
+        let mut permissions = fs::metadata(&source_path)
+            .expect("metadata")
+            .permissions();
+        permissions.set_mode(0o640);
+        fs::set_permissions(&source_path, permissions).expect("set permissions");
+        let metadata = fs::metadata(&source_path).expect("metadata after permissions");
+
+        let fifo_path = temp.path().join("fifo");
+        create_fifo(&fifo_path, &metadata).expect("create fifo");
+
+        let fifo_metadata = fs::symlink_metadata(&fifo_path).expect("fifo metadata");
+        assert!(fifo_metadata.file_type().is_fifo());
+
+        let requested = metadata.permissions().mode() & 0o777;
+        let created = fifo_metadata.permissions().mode() & 0o777;
+        assert_ne!(created, 0, "fifo permissions should preserve some bits");
+        assert_eq!(created & requested, created, "created permissions must not exceed requested");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn create_device_node_rejects_non_device_metadata() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempdir().expect("create tempdir");
+        let source_path = temp.path().join("regular");
+        fs::File::create(&source_path).expect("create regular file");
+
+        let mut permissions = fs::metadata(&source_path)
+            .expect("metadata")
+            .permissions();
+        permissions.set_mode(0o600);
+        fs::set_permissions(&source_path, permissions).expect("set permissions");
+        let metadata = fs::metadata(&source_path).expect("metadata after permissions");
+
+        let device_path = temp.path().join("device");
+        let error = create_device_node(&device_path, &metadata).expect_err("non-device metadata should fail");
+
+        assert_eq!(error.context(), "create device");
+        assert_eq!(error.path(), device_path.as_path());
+        assert_eq!(error.source_error().kind(), io::ErrorKind::InvalidInput);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn permissions_mode_masks_high_bits() {
+        let mode = permissions_mode("test", Path::new("/tmp/target"), 0o777_777)
+            .expect("mode conversion succeeds");
+        assert_eq!(mode, 0o177_777);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn invalid_mode_error_carries_context_and_path() {
+        let path = Path::new("/tmp/example");
+        let error = invalid_mode_error("example", path);
+
+        assert_eq!(error.context(), "example");
+        assert_eq!(error.path(), path);
+        assert_eq!(error.source_error().kind(), io::ErrorKind::InvalidInput);
+        assert!(error
+            .source_error()
+            .to_string()
+            .contains("mode value exceeds platform limits"));
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests for FIFO creation to validate metadata-driven permissions
- exercise create_device_node error handling on non-device metadata
- cover helper utilities to ensure mode masking and error context propagation

## Testing
- cargo test -p rsync-meta

------