### PR TITLE
Add coverage-focused tests for xtask no-binaries command

### DIFF
--- a/xtask/src/commands/no_binaries.rs
+++ b/xtask/src/commands/no_binaries.rs
@@ -59,6 +59,35 @@ pub fn usage() -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::ffi::OsString;
+    use std::fs;
+    use std::process::Command;
+    use tempfile::tempdir;
+
+    fn init_git_repo(path: &std::path::Path) {
+        let status = Command::new("git")
+            .current_dir(path)
+            .args(["init", "--quiet"])
+            .status()
+            .expect("git init runs");
+        assert!(status.success(), "git init failed: {:?}", status);
+    }
+
+    fn git_add(path: &std::path::Path, file: &std::path::Path) {
+        let relative = file.strip_prefix(path).expect("file inside repo");
+        let status = Command::new("git")
+            .current_dir(path)
+            .arg("add")
+            .arg(relative)
+            .status()
+            .expect("git add runs");
+        assert!(
+            status.success(),
+            "git add failed for {:?}: {:?}",
+            relative,
+            status
+        );
+    }
 
     #[test]
     fn parse_args_accepts_default_configuration() {
@@ -76,5 +105,41 @@ mod tests {
     fn parse_args_rejects_unknown_argument() {
         let error = parse_args([OsString::from("--unknown")]).unwrap_err();
         assert!(matches!(error, TaskError::Usage(message) if message.contains("no-binaries")));
+    }
+
+    #[test]
+    fn execute_succeeds_when_all_tracked_files_are_textual() {
+        let temp = tempdir().expect("tempdir");
+        init_git_repo(temp.path());
+
+        let source = temp.path().join("src/lib.rs");
+        fs::create_dir_all(source.parent().unwrap()).expect("create src dir");
+        fs::write(&source, "fn main() {}\n").expect("write source file");
+        git_add(temp.path(), &source);
+
+        execute(temp.path(), NoBinariesOptions).expect("no binary files detected");
+    }
+
+    #[test]
+    fn execute_reports_detected_binary_files() {
+        let temp = tempdir().expect("tempdir");
+        init_git_repo(temp.path());
+
+        let text_file = temp.path().join("README.md");
+        fs::write(&text_file, "workspace docs\n").expect("write text file");
+        git_add(temp.path(), &text_file);
+
+        let binary_file = temp.path().join("artifacts/blob.bin");
+        fs::create_dir_all(binary_file.parent().unwrap()).expect("create dir");
+        fs::write(&binary_file, [0_u8, 1, 2, 3, 4]).expect("write binary file");
+        git_add(temp.path(), &binary_file);
+
+        let error = execute(temp.path(), NoBinariesOptions).unwrap_err();
+        match error {
+            TaskError::BinaryFiles(paths) => {
+                assert_eq!(paths, vec![std::path::PathBuf::from("artifacts/blob.bin")]);
+            }
+            other => panic!("unexpected error: {:?}", other),
+        }
     }
 }

--- a/xtask/src/util.rs
+++ b/xtask/src/util.rs
@@ -376,6 +376,23 @@ mod tests {
     }
 
     #[test]
+    fn validation_error_constructs_validation_variant() {
+        let error = validation_error("invalid");
+        assert!(matches!(error, TaskError::Validation(message) if message == "invalid"));
+    }
+
+    #[test]
+    fn run_cargo_tool_succeeds_for_version_query() {
+        run_cargo_tool(
+            workspace_root(),
+            vec![OsString::from("--version")],
+            "cargo --version",
+            "install cargo",
+        )
+        .expect("cargo --version succeeds");
+    }
+
+    #[test]
     fn run_cargo_tool_maps_missing_subcommand_to_tool_missing() {
         let err = run_cargo_tool(
             workspace_root(),


### PR DESCRIPTION
## Summary
- add unit tests that exercise the xtask no-binaries command across success and binary-detection paths
- extend util.rs coverage by asserting validation_error behavior and ensuring run_cargo_tool succeeds for --version

## Testing
- cargo test -p xtask

------