### PR TITLE
Add tests for client outcome and deletion builder

### DIFF
--- a/crates/core/src/client/config/builder/deletion.rs
+++ b/crates/core/src/client/config/builder/deletion.rs
@@ -73,3 +73,74 @@ impl ClientConfigBuilder {
         self
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn build(builder: ClientConfigBuilder) -> ClientConfig {
+        builder.build()
+    }
+
+    #[test]
+    fn delete_sets_during_and_resets_to_disabled() {
+        let config = build(ClientConfigBuilder::default().delete(true));
+        assert_eq!(config.delete_mode(), DeleteMode::During);
+        assert!(config.delete());
+
+        let config = build(ClientConfigBuilder::default().delete(true).delete(false));
+        assert_eq!(config.delete_mode(), DeleteMode::Disabled);
+        assert!(!config.delete());
+    }
+
+    #[test]
+    fn delete_before_toggles_mode() {
+        let config = build(ClientConfigBuilder::default().delete_before(true));
+        assert!(config.delete_before());
+        assert_eq!(config.delete_mode(), DeleteMode::Before);
+
+        let config = build(ClientConfigBuilder::default().delete_before(true).delete_before(false));
+        assert!(!config.delete_before());
+        assert_eq!(config.delete_mode(), DeleteMode::Disabled);
+    }
+
+    #[test]
+    fn delete_after_toggles_mode() {
+        let config = build(ClientConfigBuilder::default().delete_after(true));
+        assert!(config.delete_after());
+        assert_eq!(config.delete_mode(), DeleteMode::After);
+
+        let config = build(ClientConfigBuilder::default().delete_after(true).delete_after(false));
+        assert!(!config.delete_after());
+        assert_eq!(config.delete_mode(), DeleteMode::Disabled);
+    }
+
+    #[test]
+    fn delete_delay_toggles_mode() {
+        let config = build(ClientConfigBuilder::default().delete_delay(true));
+        assert!(config.delete_delay());
+        assert_eq!(config.delete_mode(), DeleteMode::Delay);
+
+        let config = build(ClientConfigBuilder::default().delete_delay(true).delete_delay(false));
+        assert!(!config.delete_delay());
+        assert_eq!(config.delete_mode(), DeleteMode::Disabled);
+    }
+
+    #[test]
+    fn delete_excluded_mirrors_builder_setting() {
+        let config = build(ClientConfigBuilder::default().delete_excluded(true));
+        assert!(config.delete_excluded());
+
+        let config = build(ClientConfigBuilder::default().delete_excluded(false));
+        assert!(!config.delete_excluded());
+    }
+
+    #[test]
+    fn max_delete_propagates_limit() {
+        let config = build(ClientConfigBuilder::default().max_delete(Some(128)));
+        assert_eq!(config.max_delete(), Some(128));
+
+        let config = build(ClientConfigBuilder::default().max_delete(None));
+        assert_eq!(config.max_delete(), None);
+    }
+}

--- a/crates/core/src/client/outcome.rs
+++ b/crates/core/src/client/outcome.rs
@@ -20,6 +20,41 @@ impl ClientOutcome {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rsync_engine::LocalCopySummary;
+
+    fn empty_summary() -> ClientSummary {
+        ClientSummary::from_summary(LocalCopySummary::default())
+    }
+
+    #[test]
+    fn into_local_returns_summary_for_local_execution() {
+        let summary = empty_summary();
+        let outcome = ClientOutcome::Local(Box::new(summary));
+
+        let extracted = outcome.into_local().expect("local outcome should yield a summary");
+
+        assert_eq!(extracted.files_copied(), 0);
+        assert!(extracted.events().is_empty());
+    }
+
+    #[test]
+    fn into_local_returns_none_for_fallback_execution() {
+        let outcome = ClientOutcome::Fallback(FallbackSummary::new(23));
+
+        assert!(outcome.into_local().is_none());
+    }
+
+    #[test]
+    fn fallback_summary_reports_exit_code() {
+        let summary = FallbackSummary::new(42);
+
+        assert_eq!(summary.exit_code(), 42);
+    }
+}
+
 /// Summary describing the result of a fallback invocation.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct FallbackSummary {


### PR DESCRIPTION
## Summary
- add unit tests covering client outcome behaviour when extracting summaries and reporting fallback exit codes
- add builder tests that verify delete mode toggles, exclusion handling, and max-delete propagation

## Testing
- cargo test -p rsync-core

------