### PR TITLE
Add targeted tests for core workspace protocol and client filters

### DIFF
--- a/crates/core/src/client/config/client/filters.rs
+++ b/crates/core/src/client/config/client/filters.rs
@@ -14,3 +14,35 @@ impl ClientConfig {
         &self.debug_flags
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::OsString;
+    use crate::client::config::filters::FilterRuleKind;
+
+    #[test]
+    fn filter_rules_preserve_builder_order() {
+        let config = ClientConfig::builder()
+            .add_filter_rule(FilterRuleSpec::include("*.rs"))
+            .add_filter_rule(FilterRuleSpec::exclude("*.tmp"))
+            .build();
+
+        let rules = config.filter_rules();
+        assert_eq!(rules.len(), 2);
+        assert_eq!(rules[0].pattern(), "*.rs");
+        assert_eq!(rules[0].kind(), FilterRuleKind::Include);
+        assert_eq!(rules[1].pattern(), "*.tmp");
+        assert_eq!(rules[1].kind(), FilterRuleKind::Exclude);
+    }
+
+    #[test]
+    fn debug_flags_expose_supplied_values() {
+        let config = ClientConfig::builder()
+            .debug_flags([OsString::from("io"), OsString::from("stats")])
+            .build();
+
+        let flags = config.debug_flags();
+        assert_eq!(flags, &[OsString::from("io"), OsString::from("stats")]);
+    }
+}

--- a/crates/core/src/workspace/protocol.rs
+++ b/crates/core/src/workspace/protocol.rs
@@ -73,3 +73,38 @@ const fn parse_u32(input: &str) -> u32 {
     }
     value
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::panic;
+
+    #[test]
+    fn parse_u32_accepts_decimal_digits() {
+        assert_eq!(parse_u32("0"), 0);
+        assert_eq!(parse_u32("32"), 32);
+        assert_eq!(parse_u32("0010"), 10);
+    }
+
+    #[test]
+    fn parse_u32_rejects_empty_strings() {
+        let result = panic::catch_unwind(|| parse_u32(""));
+        assert!(result.is_err(), "empty input must trigger a panic");
+    }
+
+    #[test]
+    fn parse_u32_rejects_non_ascii_digits() {
+        let result = panic::catch_unwind(|| parse_u32("3a"));
+        assert!(result.is_err(), "non-digit input must trigger a panic");
+    }
+
+    #[test]
+    fn protocol_accessors_match_metadata_protocol() {
+        let snapshot = metadata();
+        assert_eq!(protocol_version_u8() as u32, snapshot.protocol_version());
+        assert_eq!(
+            protocol_version_nonzero_u8().get() as u32,
+            snapshot.protocol_version()
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests for the workspace protocol helpers, including parse and metadata validation
- cover client filter accessor behavior for rule ordering and debug flag propagation

## Testing
- cargo test -p rsync-core workspace::protocol
- cargo test -p rsync-core client::config::client::filters

------