### PR TITLE
Align filters config test imports with rustfmt

### DIFF
--- a/crates/core/src/client/config/client/filters.rs
+++ b/crates/core/src/client/config/client/filters.rs
@@ -18,8 +18,8 @@ impl ClientConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::ffi::OsString;
     use crate::client::config::filters::FilterRuleKind;
+    use std::ffi::OsString;
 
     #[test]
     fn filter_rules_preserve_builder_order() {


### PR DESCRIPTION
## Summary
- reorder the test module imports in the client config filters tests to match rustfmt expectations

## Testing
- cargo fmt --all -- --check

------