### PR TITLE
Fix formatting in tests to satisfy rustfmt

### DIFF
--- a/crates/daemon/src/tests.rs
+++ b/crates/daemon/src/tests.rs
@@ -126,8 +126,8 @@ fn allocate_test_port() -> u16 {
 
 #[test]
 fn parse_auth_user_list_trims_and_deduplicates_case_insensitively() {
-    let users = parse_auth_user_list(" alice,BOB, alice ,  Carol ")
-        .expect("parse non-empty user list");
+    let users =
+        parse_auth_user_list(" alice,BOB, alice ,  Carol ").expect("parse non-empty user list");
     assert_eq!(users, ["alice", "BOB", "Carol"]);
 
     let err = parse_auth_user_list(" , ,  ").expect_err("blank list rejected");
@@ -182,10 +182,7 @@ fn parse_max_connections_directive_handles_zero_and_positive() {
     assert_eq!(parse_max_connections_directive("0"), Some(None));
 
     let expected = NonZeroU32::new(25).expect("non-zero");
-    assert_eq!(
-        parse_max_connections_directive("25"),
-        Some(Some(expected))
-    );
+    assert_eq!(parse_max_connections_directive("25"), Some(Some(expected)));
 
     assert_eq!(parse_max_connections_directive("-1"), None);
     assert_eq!(parse_max_connections_directive("invalid"), None);

--- a/crates/transport/src/ssh/parse.rs
+++ b/crates/transport/src/ssh/parse.rs
@@ -261,8 +261,8 @@ mod tests {
 
     #[test]
     fn parser_retains_backslash_inside_single_quotes() {
-        let parsed = parse_remote_shell(OsStr::new("ssh -o'Proxy\\Command'"))
-            .expect("parse succeeds");
+        let parsed =
+            parse_remote_shell(OsStr::new("ssh -o'Proxy\\Command'")).expect("parse succeeds");
 
         assert_eq!(parsed[0], OsString::from("ssh"));
         assert_eq!(parsed[1], OsString::from("-oProxy\\Command"));
@@ -270,10 +270,8 @@ mod tests {
 
     #[test]
     fn parser_honours_double_quote_escape_rules() {
-        let parsed = parse_remote_shell(OsStr::new(
-            r#"ssh -o"ProxyCommand=echo \$HOME \a""#,
-        ))
-        .expect("parse succeeds");
+        let parsed = parse_remote_shell(OsStr::new(r#"ssh -o"ProxyCommand=echo \$HOME \a""#))
+            .expect("parse succeeds");
 
         assert_eq!(parsed[0], OsString::from("ssh"));
         assert_eq!(parsed[1], OsString::from("-oProxyCommand=echo $HOME \\a"));
@@ -281,10 +279,8 @@ mod tests {
 
     #[test]
     fn parser_strips_newline_after_escape_sequence() {
-        let parsed = parse_remote_shell(OsStr::new(
-            "ssh -oProxyCommand=echo\\\nbar",
-        ))
-        .expect("parse succeeds");
+        let parsed = parse_remote_shell(OsStr::new("ssh -oProxyCommand=echo\\\nbar"))
+            .expect("parse succeeds");
 
         assert_eq!(parsed[1], OsString::from("-oProxyCommand=echobar"));
     }


### PR DESCRIPTION
## Summary
- reformat daemon and SSH parse tests to match `rustfmt` expectations

## Testing
- cargo fmt --all -- --check

------