### PR TITLE
Expose workspace metadata JSON renderings

### DIFF
--- a/crates/core/src/workspace/json.rs
+++ b/crates/core/src/workspace/json.rs
@@ -1,0 +1,80 @@
+//! JSON serialisation helpers for [`crate::workspace`] metadata.
+//!
+//! The workspace exposes compile-time metadata via [`metadata`](super::metadata),
+//! which higher layers use to render banners and locate configuration files.
+//! Packaging automation and documentation tooling often require the same data
+//! in a structured format, so this module publishes cached JSON renderings
+//! derived from the canonical [`Metadata`](super::Metadata) snapshot. Keeping
+//! the serialisation logic here prevents callers from re-implementing it and
+//! guarantees the output stays in sync with the compile-time constants emitted
+//! by the build script.
+
+use std::sync::OnceLock;
+
+use super::{Metadata, metadata};
+
+fn render_metadata_json(pretty: bool) -> String {
+    let snapshot: Metadata = metadata();
+
+    if pretty {
+        serde_json::to_string_pretty(&snapshot)
+            .expect("failed to serialise workspace metadata as pretty JSON")
+    } else {
+        serde_json::to_string(&snapshot).expect("failed to serialise workspace metadata as JSON")
+    }
+}
+
+/// Returns the cached JSON representation of the workspace metadata snapshot.
+///
+/// The returned string mirrors [`metadata()`](super::metadata) and is cached
+/// for the lifetime of the process. Callers that only need a structured view of
+/// the branding and version details can parse the JSON without duplicating the
+/// serialisation logic.
+///
+/// ```
+/// let json = rsync_core::workspace::metadata_json();
+/// assert!(json.contains("\"brand\":\"oc\""));
+/// assert!(json.contains("\"rust_version\":\"3.4.1-rust\""));
+/// ```
+#[must_use]
+pub fn metadata_json() -> &'static str {
+    static JSON: OnceLock<String> = OnceLock::new();
+    JSON.get_or_init(|| render_metadata_json(false)).as_str()
+}
+
+/// Returns the cached pretty-printed JSON representation of the workspace
+/// metadata snapshot.
+///
+/// This helper mirrors [`metadata_json`] but renders human-friendly output with
+/// indentation so configuration validation and documentation generation can
+/// consume the data directly.
+///
+/// ```
+/// let json = rsync_core::workspace::metadata_json_pretty();
+/// assert!(json.lines().any(|line| line.contains("\"daemon_program_name\"")));
+/// ```
+#[must_use]
+pub fn metadata_json_pretty() -> &'static str {
+    static JSON_PRETTY: OnceLock<String> = OnceLock::new();
+    JSON_PRETTY
+        .get_or_init(|| render_metadata_json(true))
+        .as_str()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn metadata_json_matches_direct_serialisation() {
+        let expected = serde_json::to_string(&metadata()).expect("failed to serialise metadata");
+        assert_eq!(metadata_json(), expected);
+    }
+
+    #[test]
+    fn metadata_json_pretty_matches_direct_serialisation() {
+        let expected =
+            serde_json::to_string_pretty(&metadata()).expect("failed to serialise metadata");
+        assert_eq!(metadata_json_pretty(), expected);
+    }
+}

--- a/crates/core/src/workspace/metadata.rs
+++ b/crates/core/src/workspace/metadata.rs
@@ -5,9 +5,10 @@ use super::constants::{
     RUST_VERSION, SOURCE_URL, UPSTREAM_VERSION,
 };
 use super::protocol::PROTOCOL_VERSION;
+use serde::Serialize;
 
 /// Immutable snapshot of workspace metadata loaded from `Cargo.toml`.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
 pub struct Metadata {
     brand: &'static str,
     upstream_version: &'static str,

--- a/crates/core/src/workspace/mod.rs
+++ b/crates/core/src/workspace/mod.rs
@@ -12,6 +12,7 @@
 //! the manifest entries.
 
 mod constants;
+mod json;
 mod metadata;
 mod paths;
 mod protocol;
@@ -24,6 +25,7 @@ pub use constants::{
     legacy_client_program_name, legacy_daemon_program_name, rust_version, source_url,
     upstream_version,
 };
+pub use json::{metadata_json, metadata_json_pretty};
 pub use metadata::{Metadata, metadata};
 pub use paths::{
     daemon_config_dir, daemon_config_path, daemon_secrets_path, legacy_daemon_config_dir,

--- a/crates/daemon/src/tests.rs
+++ b/crates/daemon/src/tests.rs
@@ -126,8 +126,8 @@ fn allocate_test_port() -> u16 {
 
 #[test]
 fn parse_auth_user_list_trims_and_deduplicates_case_insensitively() {
-    let users = parse_auth_user_list(" alice,BOB, alice ,  Carol ")
-        .expect("parse non-empty user list");
+    let users =
+        parse_auth_user_list(" alice,BOB, alice ,  Carol ").expect("parse non-empty user list");
     assert_eq!(users, ["alice", "BOB", "Carol"]);
 
     let err = parse_auth_user_list(" , ,  ").expect_err("blank list rejected");
@@ -182,10 +182,7 @@ fn parse_max_connections_directive_handles_zero_and_positive() {
     assert_eq!(parse_max_connections_directive("0"), Some(None));
 
     let expected = NonZeroU32::new(25).expect("non-zero");
-    assert_eq!(
-        parse_max_connections_directive("25"),
-        Some(Some(expected))
-    );
+    assert_eq!(parse_max_connections_directive("25"), Some(Some(expected)));
 
     assert_eq!(parse_max_connections_directive("-1"), None);
     assert_eq!(parse_max_connections_directive("invalid"), None);

--- a/crates/transport/src/ssh/parse.rs
+++ b/crates/transport/src/ssh/parse.rs
@@ -261,8 +261,8 @@ mod tests {
 
     #[test]
     fn parser_retains_backslash_inside_single_quotes() {
-        let parsed = parse_remote_shell(OsStr::new("ssh -o'Proxy\\Command'"))
-            .expect("parse succeeds");
+        let parsed =
+            parse_remote_shell(OsStr::new("ssh -o'Proxy\\Command'")).expect("parse succeeds");
 
         assert_eq!(parsed[0], OsString::from("ssh"));
         assert_eq!(parsed[1], OsString::from("-oProxy\\Command"));
@@ -270,10 +270,8 @@ mod tests {
 
     #[test]
     fn parser_honours_double_quote_escape_rules() {
-        let parsed = parse_remote_shell(OsStr::new(
-            r#"ssh -o"ProxyCommand=echo \$HOME \a""#,
-        ))
-        .expect("parse succeeds");
+        let parsed = parse_remote_shell(OsStr::new(r#"ssh -o"ProxyCommand=echo \$HOME \a""#))
+            .expect("parse succeeds");
 
         assert_eq!(parsed[0], OsString::from("ssh"));
         assert_eq!(parsed[1], OsString::from("-oProxyCommand=echo $HOME \\a"));
@@ -281,10 +279,8 @@ mod tests {
 
     #[test]
     fn parser_strips_newline_after_escape_sequence() {
-        let parsed = parse_remote_shell(OsStr::new(
-            "ssh -oProxyCommand=echo\\\nbar",
-        ))
-        .expect("parse succeeds");
+        let parsed = parse_remote_shell(OsStr::new("ssh -oProxyCommand=echo\\\nbar"))
+            .expect("parse succeeds");
 
         assert_eq!(parsed[1], OsString::from("-oProxyCommand=echobar"));
     }


### PR DESCRIPTION
## Summary
- derive `serde::Serialize` for the workspace metadata snapshot and add cached JSON renderers
- re-export the metadata JSON helpers so other crates can rely on centralised branding/version data
- apply rustfmt cleanups in existing daemon and transport tests

## Testing
- cargo test -p rsync-core metadata_json -- --nocapture

------