### PR TITLE
Refactor daemon test helpers into a support module

### DIFF
--- a/crates/daemon/src/tests/support.rs
+++ b/crates/daemon/src/tests/support.rs
@@ -1,0 +1,238 @@
+use super::*;
+use std::env;
+use std::ffi::{OsStr, OsString};
+use std::fs::{self, OpenOptions};
+use std::io::{Read, Seek, SeekFrom, Write};
+use std::net::{Ipv4Addr, SocketAddr, TcpListener, TcpStream};
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+use std::thread;
+use std::time::{Duration, Instant};
+
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+
+pub(super) const RSYNCD: &str = branding::daemon_program_name();
+pub(super) const OC_RSYNC_D: &str = branding::oc_daemon_program_name();
+
+pub(super) static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+pub(super) fn base_module(name: &str) -> ModuleDefinition {
+    ModuleDefinition {
+        name: String::from(name),
+        path: PathBuf::from("/srv/module"),
+        comment: None,
+        hosts_allow: Vec::new(),
+        hosts_deny: Vec::new(),
+        auth_users: Vec::new(),
+        secrets_file: None,
+        bandwidth_limit: None,
+        bandwidth_limit_specified: false,
+        bandwidth_burst: None,
+        bandwidth_burst_specified: false,
+        bandwidth_limit_configured: false,
+        refuse_options: Vec::new(),
+        read_only: true,
+        numeric_ids: false,
+        uid: None,
+        gid: None,
+        timeout: None,
+        listable: true,
+        use_chroot: true,
+        max_connections: None,
+    }
+}
+
+pub(super) fn module_with_host_patterns(allow: &[&str], deny: &[&str]) -> ModuleDefinition {
+    ModuleDefinition {
+        name: String::from("module"),
+        path: PathBuf::from("/srv/module"),
+        comment: None,
+        hosts_allow: allow
+            .iter()
+            .map(|pattern| HostPattern::parse(pattern).expect("parse allow pattern"))
+            .collect(),
+        hosts_deny: deny
+            .iter()
+            .map(|pattern| HostPattern::parse(pattern).expect("parse deny pattern"))
+            .collect(),
+        auth_users: Vec::new(),
+        secrets_file: None,
+        bandwidth_limit: None,
+        bandwidth_limit_specified: false,
+        bandwidth_burst: None,
+        bandwidth_burst_specified: false,
+        bandwidth_limit_configured: false,
+        refuse_options: Vec::new(),
+        read_only: true,
+        numeric_ids: false,
+        uid: None,
+        gid: None,
+        timeout: None,
+        listable: true,
+        use_chroot: true,
+        max_connections: None,
+    }
+}
+
+pub(super) fn with_test_secrets_candidates<F, R>(candidates: Vec<PathBuf>, func: F) -> R
+where
+    F: FnOnce() -> R,
+{
+    TEST_SECRETS_CANDIDATES.with(|cell| {
+        let previous = cell.replace(Some(candidates));
+        let result = func();
+        cell.replace(previous);
+        result
+    })
+}
+
+pub(super) fn with_test_secrets_env<F, R>(
+    override_value: Option<TestSecretsEnvOverride>,
+    func: F,
+) -> R
+where
+    F: FnOnce() -> R,
+{
+    TEST_SECRETS_ENV.with(|cell| {
+        let previous = cell.replace(override_value);
+        let result = func();
+        cell.replace(previous);
+        result
+    })
+}
+
+pub(super) fn allocate_test_port() -> u16 {
+    const START: u16 = 40_000;
+    const RANGE: u32 = 20_000;
+    const STATE_SIZE: u64 = 4;
+
+    let mut path = std::env::temp_dir();
+    path.push("rsync-daemon-test-port.lock");
+
+    let mut file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(&path)
+        .expect("open port allocator state");
+
+    file.lock_exclusive().expect("lock port allocator state");
+    file.seek(SeekFrom::Start(0))
+        .expect("rewind port allocator state");
+
+    let mut counter_bytes = [0u8; STATE_SIZE as usize];
+    let read = file
+        .read(&mut counter_bytes)
+        .expect("read port allocator state");
+    let mut counter = if read == counter_bytes.len() {
+        u32::from_le_bytes(counter_bytes)
+    } else {
+        0
+    };
+
+    for _ in 0..RANGE {
+        let offset = (counter % RANGE) as u16;
+        counter = counter.wrapping_add(1);
+
+        file.seek(SeekFrom::Start(0))
+            .expect("rewind port allocator state");
+        file.write_all(&counter.to_le_bytes())
+            .expect("persist port allocator state");
+        file.set_len(STATE_SIZE)
+            .expect("truncate port allocator state");
+        file.flush().expect("flush port allocator state");
+
+        let candidate = START + offset;
+        if let Ok(listener) = TcpListener::bind((Ipv4Addr::LOCALHOST, candidate)) {
+            drop(listener);
+            return candidate;
+        }
+    }
+
+    panic!("failed to allocate a free test port");
+}
+
+pub(super) fn run_with_args<I, S>(args: I) -> (i32, Vec<u8>, Vec<u8>)
+where
+    I: IntoIterator<Item = S>,
+    S: Into<OsString>,
+{
+    let mut stdout = Vec::new();
+    let mut stderr = Vec::new();
+    let code = run(args, &mut stdout, &mut stderr);
+    (code, stdout, stderr)
+}
+
+#[cfg(unix)]
+pub(super) fn write_executable_script(path: &Path, contents: &str) {
+    fs::write(path, contents).expect("write script");
+    let mut permissions = fs::metadata(path).expect("script metadata").permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(path, permissions).expect("set script permissions");
+}
+
+#[allow(unsafe_code)]
+pub(super) struct EnvGuard {
+    key: &'static str,
+    previous: Option<OsString>,
+}
+
+#[allow(unsafe_code)]
+impl EnvGuard {
+    pub(super) fn set(key: &'static str, value: &OsStr) -> Self {
+        let previous = env::var_os(key);
+        unsafe {
+            env::set_var(key, value);
+        }
+        Self { key, previous }
+    }
+
+    pub(super) fn remove(key: &'static str) -> Self {
+        let previous = env::var_os(key);
+        unsafe {
+            env::remove_var(key);
+        }
+        Self { key, previous }
+    }
+}
+
+#[allow(unsafe_code)]
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        if let Some(value) = self.previous.take() {
+            unsafe {
+                env::set_var(self.key, value);
+            }
+        } else {
+            unsafe {
+                env::remove_var(self.key);
+            }
+        }
+    }
+}
+
+pub(super) fn connect_with_retries(port: u16) -> TcpStream {
+    const INITIAL_BACKOFF: Duration = Duration::from_millis(20);
+    const MAX_BACKOFF: Duration = Duration::from_millis(200);
+    const TIMEOUT: Duration = Duration::from_secs(15);
+
+    let target = SocketAddr::from((Ipv4Addr::LOCALHOST, port));
+    let deadline = Instant::now() + TIMEOUT;
+    let mut backoff = INITIAL_BACKOFF;
+
+    loop {
+        match TcpStream::connect_timeout(&target, backoff) {
+            Ok(stream) => return stream,
+            Err(error) => {
+                if Instant::now() >= deadline {
+                    panic!("failed to connect to daemon within timeout: {error}");
+                }
+
+                thread::sleep(backoff);
+                backoff = (backoff.saturating_mul(2)).min(MAX_BACKOFF);
+            }
+        }
+    }
+}

--- a/crates/transport/src/ssh/parse.rs
+++ b/crates/transport/src/ssh/parse.rs
@@ -261,8 +261,8 @@ mod tests {
 
     #[test]
     fn parser_retains_backslash_inside_single_quotes() {
-        let parsed = parse_remote_shell(OsStr::new("ssh -o'Proxy\\Command'"))
-            .expect("parse succeeds");
+        let parsed =
+            parse_remote_shell(OsStr::new("ssh -o'Proxy\\Command'")).expect("parse succeeds");
 
         assert_eq!(parsed[0], OsString::from("ssh"));
         assert_eq!(parsed[1], OsString::from("-oProxy\\Command"));
@@ -270,10 +270,8 @@ mod tests {
 
     #[test]
     fn parser_honours_double_quote_escape_rules() {
-        let parsed = parse_remote_shell(OsStr::new(
-            r#"ssh -o"ProxyCommand=echo \$HOME \a""#,
-        ))
-        .expect("parse succeeds");
+        let parsed = parse_remote_shell(OsStr::new(r#"ssh -o"ProxyCommand=echo \$HOME \a""#))
+            .expect("parse succeeds");
 
         assert_eq!(parsed[0], OsString::from("ssh"));
         assert_eq!(parsed[1], OsString::from("-oProxyCommand=echo $HOME \\a"));
@@ -281,10 +279,8 @@ mod tests {
 
     #[test]
     fn parser_strips_newline_after_escape_sequence() {
-        let parsed = parse_remote_shell(OsStr::new(
-            "ssh -oProxyCommand=echo\\\nbar",
-        ))
-        .expect("parse succeeds");
+        let parsed = parse_remote_shell(OsStr::new("ssh -oProxyCommand=echo\\\nbar"))
+            .expect("parse succeeds");
 
         assert_eq!(parsed[1], OsString::from("-oProxyCommand=echobar"));
     }


### PR DESCRIPTION
## Summary
- extract shared helper utilities from `crates/daemon/src/tests.rs` into a dedicated `tests/support.rs`
- update the daemon test module to import the new helpers and trim unused imports after the move
- format the SSH parser tests touched by `cargo fmt`

## Testing
- cargo test -p rsync-daemon --lib -- --nocapture

------