### PR TITLE
Fix Clippy warnings in transport and walk tests

### DIFF
--- a/crates/transport/src/negotiation/errors.rs
+++ b/crates/transport/src/negotiation/errors.rs
@@ -41,8 +41,7 @@ mod tests {
     fn trigger_try_reserve_error() -> TryReserveError {
         Vec::<u8>::new()
             .try_reserve(usize::MAX)
-            .err()
-            .expect("overflow should produce a TryReserveError")
+            .expect_err("overflow should produce a TryReserveError")
     }
 
     #[test]

--- a/crates/walk/src/error.rs
+++ b/crates/walk/src/error.rs
@@ -178,7 +178,7 @@ mod tests {
     use super::*;
 
     fn io_failure() -> io::Error {
-        io::Error::new(io::ErrorKind::Other, "synthetic failure")
+        io::Error::other("synthetic failure")
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- replace a deprecated `.err().expect()` pattern in the transport negotiation tests with `expect_err`
- adjust the walk error tests to use `io::Error::other` in accordance with Clippy guidance

## Testing
- `cargo clippy --workspace --all-targets --all-features --locked -- -Dwarnings`

------