### PR TITLE
Add coverage-driving integration tests for CLI entrypoints

### DIFF
--- a/tests/cli_binaries.rs
+++ b/tests/cli_binaries.rs
@@ -1,0 +1,56 @@
+use std::process::Command;
+
+fn binary_output(path: &str, args: &[&str]) -> std::process::Output {
+    Command::new(path)
+        .args(args)
+        .output()
+        .unwrap_or_else(|error| panic!("failed to run {}: {}", path, error))
+}
+
+fn combined_utf8(output: &std::process::Output) -> String {
+    let mut data = output.stdout.clone();
+    data.extend_from_slice(&output.stderr);
+    String::from_utf8(data).expect("binary output should be valid UTF-8")
+}
+
+#[test]
+fn oc_rsync_help_lists_usage() {
+    let output = binary_output(env!("CARGO_BIN_EXE_oc-rsync"), &["--help"]);
+    assert!(output.status.success(), "--help should succeed");
+    assert!(output.stderr.is_empty(), "help output should not write to stderr");
+    let stdout = String::from_utf8(output.stdout).expect("stdout is UTF-8");
+    assert!(stdout.contains("Usage:"));
+    assert!(stdout.contains("oc-rsync"));
+}
+
+#[test]
+fn oc_rsync_without_operands_shows_usage() {
+    let output = binary_output(env!("CARGO_BIN_EXE_oc-rsync"), &[]);
+    assert!(
+        !output.status.success(),
+        "running without operands should fail so the caller sees the usage"
+    );
+    let combined = combined_utf8(&output);
+    assert!(combined.contains("Usage:"));
+}
+
+#[test]
+fn oc_rsyncd_help_lists_usage() {
+    let output = binary_output(env!("CARGO_BIN_EXE_oc-rsyncd"), &["--help"]);
+    assert!(output.status.success(), "--help should succeed");
+    assert!(output.stderr.is_empty(), "help output should not write to stderr");
+    let stdout = String::from_utf8(output.stdout).expect("stdout is UTF-8");
+    assert!(stdout.contains("Usage:"));
+    assert!(stdout.contains("oc-rsyncd"));
+}
+
+#[test]
+fn oc_rsyncd_rejects_unknown_flag() {
+    let output = binary_output(env!("CARGO_BIN_EXE_oc-rsyncd"), &["--definitely-not-a-flag"]);
+    assert!(
+        !output.status.success(),
+        "unexpected flags should return a failure exit status"
+    );
+    let combined = combined_utf8(&output);
+    assert!(combined.contains("unknown option"));
+}

--- a/xtask/tests/main_cli.rs
+++ b/xtask/tests/main_cli.rs
@@ -1,0 +1,49 @@
+use std::process::Command;
+use std::str;
+
+fn run_xtask(args: &[&str]) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_xtask"))
+        .args(args)
+        .output()
+        .unwrap_or_else(|error| panic!("failed to run xtask: {}", error))
+}
+
+#[test]
+fn xtask_without_arguments_reports_usage() {
+    let output = run_xtask(&[]);
+    assert!(
+        !output.status.success(),
+        "missing command should be reported as a usage failure"
+    );
+
+    let stderr = str::from_utf8(&output.stderr).expect("stderr is UTF-8");
+    assert!(stderr.contains("missing command"));
+    assert!(stderr.contains("Usage:"));
+}
+
+#[test]
+fn xtask_help_command_prints_usage_to_stdout() {
+    let output = run_xtask(&["help"]);
+    assert!(output.status.success(), "help command should succeed");
+    assert!(
+        output.stderr.is_empty(),
+        "help output should not write to stderr"
+    );
+
+    let stdout = str::from_utf8(&output.stdout).expect("stdout is UTF-8");
+    assert!(stdout.contains("Usage:"));
+    assert!(stdout.contains("sbom"));
+}
+
+#[test]
+fn xtask_unknown_command_reports_error() {
+    let output = run_xtask(&["definitely-not-a-command"]);
+    assert!(
+        !output.status.success(),
+        "unknown commands should fail so callers see the diagnostic"
+    );
+
+    let stderr = str::from_utf8(&output.stderr).expect("stderr is UTF-8");
+    assert!(stderr.contains("unrecognised command"));
+    assert!(stderr.contains("Usage:"));
+}


### PR DESCRIPTION
## Summary
- add workspace-level integration tests that exercise oc-rsync and oc-rsyncd binaries via the compiled artifacts
- add xtask integration tests to cover help, usage, and error flows in the main entry point

## Testing
- cargo test --tests

------