### PR TITLE
test(transport): cover stream parts mutation paths

### DIFF
--- a/crates/transport/src/binary/tests/mod.rs
+++ b/crates/transport/src/binary/tests/mod.rs
@@ -4,3 +4,4 @@ mod handshake;
 mod helpers;
 mod mapping;
 mod negotiation;
+mod parts;

--- a/crates/transport/src/binary/tests/parts.rs
+++ b/crates/transport/src/binary/tests/parts.rs
@@ -1,0 +1,38 @@
+use super::helpers::{handshake_bytes, MemoryTransport};
+use crate::RemoteProtocolAdvertisement;
+use rsync_protocol::ProtocolVersion;
+use std::io::Write;
+
+#[test]
+fn parts_stream_parts_mut_exposes_inner_transport() {
+    let remote_version = ProtocolVersion::from_supported(31).expect("protocol 31 supported");
+    let transport = MemoryTransport::new(&handshake_bytes(remote_version));
+
+    let mut parts = super::negotiate_binary_session(transport, ProtocolVersion::NEWEST)
+        .expect("binary handshake succeeds")
+        .into_parts();
+
+    {
+        let stream_parts = parts.stream_parts_mut();
+        assert!(stream_parts.decision().is_binary());
+        stream_parts
+            .inner_mut()
+            .write_all(b"payload")
+            .expect("write propagates to inner transport");
+        stream_parts
+            .inner_mut()
+            .flush()
+            .expect("flush propagates to inner transport");
+    }
+
+    assert_eq!(
+        parts.remote_advertisement(),
+        RemoteProtocolAdvertisement::Supported(remote_version)
+    );
+    assert_eq!(parts.negotiated_protocol(), remote_version);
+
+    let inner = parts.into_handshake().into_stream().into_inner();
+    let mut expected = handshake_bytes(ProtocolVersion::NEWEST).to_vec();
+    expected.extend_from_slice(b"payload");
+    assert_eq!(inner.written(), expected.as_slice());
+}

--- a/crates/transport/src/daemon/tests/mod.rs
+++ b/crates/transport/src/daemon/tests/mod.rs
@@ -1,3 +1,4 @@
 mod common;
 mod mapping;
 mod negotiation;
+mod parts;

--- a/crates/transport/src/daemon/tests/parts.rs
+++ b/crates/transport/src/daemon/tests/parts.rs
@@ -1,0 +1,42 @@
+use super::super::*;
+use super::common::MemoryTransport;
+use crate::RemoteProtocolAdvertisement;
+use rsync_protocol::ProtocolVersion;
+use std::io::Write;
+
+#[test]
+fn parts_stream_parts_mut_allows_inner_mutation() {
+    let transport = MemoryTransport::new(b"@RSYNCD: 31.0\n");
+
+    let mut parts = negotiate_legacy_daemon_session(transport, ProtocolVersion::NEWEST)
+        .expect("legacy handshake succeeds")
+        .into_parts();
+
+    {
+        let stream_parts = parts.stream_parts_mut();
+        assert!(stream_parts.decision().is_legacy());
+        stream_parts
+            .inner_mut()
+            .write_all(b"@RSYNCD: OK\n")
+            .expect("write propagates to inner transport");
+        stream_parts
+            .inner_mut()
+            .flush()
+            .expect("flush propagates to inner transport");
+    }
+
+    assert_eq!(
+        parts.remote_advertisement(),
+        RemoteProtocolAdvertisement::Supported(
+            ProtocolVersion::from_supported(31).expect("protocol 31 supported"),
+        )
+    );
+    assert_eq!(
+        parts.local_advertised_protocol(),
+        parts.negotiated_protocol()
+    );
+
+    let inner = parts.into_handshake().into_stream().into_inner();
+    assert_eq!(inner.flushes(), 2);
+    assert_eq!(inner.written(), b"@RSYNCD: 31.0\n@RSYNCD: OK\n");
+}


### PR DESCRIPTION
## Summary
- add binary handshake parts coverage that mutates the replay stream through `stream_parts_mut`
- add legacy daemon handshake parts coverage verifying inner writes and flush propagation

## Testing
- cargo test -p rsync-transport parts_stream_parts_mut

------