### PR TITLE
Add coverage tests for CLI failure paths and client network getters

### DIFF
--- a/bin/oc-rsync/src/main.rs
+++ b/bin/oc-rsync/src/main.rs
@@ -26,6 +26,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::run_with;
+    use std::ffi::OsString;
     use std::process::ExitCode;
 
     #[test]
@@ -36,5 +37,26 @@ mod tests {
         assert_eq!(exit, ExitCode::SUCCESS);
         assert!(!stdout.is_empty(), "version output should not be empty");
         assert!(stderr.is_empty(), "version flag should not write to stderr");
+    }
+
+    #[test]
+    fn unknown_flag_reports_failure() {
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+        let exit = run_with(
+            [
+                OsString::from("oc-rsync"),
+                OsString::from("--definitely-invalid-option"),
+            ],
+            &mut stdout,
+            &mut stderr,
+        );
+
+        assert_eq!(exit, ExitCode::FAILURE);
+        assert!(stdout.is_empty(), "unexpected stdout for invalid flag: {:?}", stdout);
+        assert!(
+            !stderr.is_empty(),
+            "invalid flag should emit diagnostics to stderr"
+        );
     }
 }

--- a/bin/oc-rsyncd/src/main.rs
+++ b/bin/oc-rsyncd/src/main.rs
@@ -26,6 +26,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::run_with;
+    use std::ffi::OsString;
     use std::process::ExitCode;
 
     #[test]
@@ -36,5 +37,26 @@ mod tests {
         assert_eq!(exit, ExitCode::SUCCESS);
         assert!(!stdout.is_empty(), "version output should not be empty");
         assert!(stderr.is_empty(), "version flag should not write to stderr");
+    }
+
+    #[test]
+    fn daemon_unknown_flag_reports_failure() {
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+        let exit = run_with(
+            [
+                OsString::from("oc-rsyncd"),
+                OsString::from("--definitely-invalid-option"),
+            ],
+            &mut stdout,
+            &mut stderr,
+        );
+
+        assert_eq!(exit, ExitCode::FAILURE);
+        assert!(stdout.is_empty(), "unexpected stdout for invalid flag: {:?}", stdout);
+        assert!(
+            !stderr.is_empty(),
+            "invalid flag should emit diagnostics to stderr"
+        );
     }
 }

--- a/crates/core/src/client/tests/mod.rs
+++ b/crates/core/src/client/tests/mod.rs
@@ -1,6 +1,7 @@
 include!("client_event.rs");
 include!("builder_compress.rs");
 include!("builder_metadata.rs");
+include!("network_getters.rs");
 include!("fallback_invocation.rs");
 include!("fallback_controls.rs");
 include!("client_transfer.rs");

--- a/crates/core/src/client/tests/network_getters.rs
+++ b/crates/core/src/client/tests/network_getters.rs
@@ -1,0 +1,39 @@
+#[test]
+fn builder_records_connect_program_and_address_mode() {
+    let connect_program = std::ffi::OsString::from("/usr/bin/ssh");
+    let config = super::ClientConfig::builder()
+        .connect_program(Some(connect_program.clone()))
+        .address_mode(super::AddressMode::Ipv6)
+        .build();
+
+    assert_eq!(config.address_mode(), super::AddressMode::Ipv6);
+    assert_eq!(
+        config
+            .connect_program()
+            .map(|value| value.to_os_string()),
+        Some(connect_program),
+    );
+}
+
+#[test]
+fn builder_records_bandwidth_limit_and_timeouts() {
+    let rate = std::num::NonZeroU64::new(2_048).expect("non-zero rate");
+    let burst = std::num::NonZeroU64::new(4_096).expect("non-zero burst");
+    let limit = super::BandwidthLimit::from_rate_and_burst(rate, Some(burst));
+    let transfer_timeout = super::TransferTimeout::Seconds(
+        std::num::NonZeroU64::new(30).expect("transfer timeout"),
+    );
+    let connect_timeout = super::TransferTimeout::Seconds(
+        std::num::NonZeroU64::new(5).expect("connect timeout"),
+    );
+
+    let config = super::ClientConfig::builder()
+        .bandwidth_limit(Some(limit))
+        .timeout(transfer_timeout)
+        .connect_timeout(connect_timeout)
+        .build();
+
+    assert_eq!(config.bandwidth_limit(), Some(limit));
+    assert_eq!(config.timeout(), transfer_timeout);
+    assert_eq!(config.connect_timeout(), connect_timeout);
+}


### PR DESCRIPTION
## Summary
- add regression tests covering failure exits for oc-rsync and oc-rsyncd binaries
- exercise client configuration network getters to keep bandwidth and timeout logic under test

## Testing
- cargo test

------