### PR TITLE
Run cargo fmt

### DIFF
--- a/bin/oc-rsync/src/main.rs
+++ b/bin/oc-rsync/src/main.rs
@@ -53,7 +53,11 @@ mod tests {
         );
 
         assert_eq!(exit, ExitCode::FAILURE);
-        assert!(stdout.is_empty(), "unexpected stdout for invalid flag: {:?}", stdout);
+        assert!(
+            stdout.is_empty(),
+            "unexpected stdout for invalid flag: {:?}",
+            stdout
+        );
         assert!(
             !stderr.is_empty(),
             "invalid flag should emit diagnostics to stderr"

--- a/bin/oc-rsyncd/src/main.rs
+++ b/bin/oc-rsyncd/src/main.rs
@@ -53,7 +53,11 @@ mod tests {
         );
 
         assert_eq!(exit, ExitCode::FAILURE);
-        assert!(stdout.is_empty(), "unexpected stdout for invalid flag: {:?}", stdout);
+        assert!(
+            stdout.is_empty(),
+            "unexpected stdout for invalid flag: {:?}",
+            stdout
+        );
         assert!(
             !stderr.is_empty(),
             "invalid flag should emit diagnostics to stderr"

--- a/crates/transport/src/binary/tests/parts.rs
+++ b/crates/transport/src/binary/tests/parts.rs
@@ -1,4 +1,4 @@
-use super::helpers::{handshake_bytes, MemoryTransport};
+use super::helpers::{MemoryTransport, handshake_bytes};
 use crate::RemoteProtocolAdvertisement;
 use rsync_protocol::ProtocolVersion;
 use std::io::Write;


### PR DESCRIPTION
## Summary
- apply rustfmt formatting updates to binary tests in oc-rsync and oc-rsyncd
- reorder helper imports in binary transport tests per rustfmt

## Testing
- cargo fmt --all -- --check

------