### PR TITLE
Fix clippy io::Error::new warnings in core tests

### DIFF
--- a/crates/core/src/client/tests/error_helpers.rs
+++ b/crates/core/src/client/tests/error_helpers.rs
@@ -74,7 +74,7 @@ mod error_helper_tests {
         let source = LocalCopyError::io(
             "copy file",
             PathBuf::from("dest"),
-            io::Error::new(io::ErrorKind::Other, "disk full"),
+            io::Error::other("disk full"),
         );
         let mapped = map_local_copy_error(source);
         let rendered = render(&mapped);
@@ -114,7 +114,7 @@ mod error_helper_tests {
         let error = io_error(
             "write file",
             Path::new("/tmp/data"),
-            io::Error::new(io::ErrorKind::Other, "access denied"),
+            io::Error::other("access denied"),
         );
         let rendered = render(&error);
 


### PR DESCRIPTION
## Summary
- replace the test-only uses of `io::Error::new(ErrorKind::Other, ..)` with the more idiomatic `io::Error::other`

## Testing
- cargo clippy --workspace --all-targets --all-features --locked -- -Dwarnings

------