### PR TITLE
Fix docs.rs workspace metadata location

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ authors = ["Ofer Chen <skewers.irises.3b@icloud.com>"]
 license = "GPL-3.0-or-later"
 version = "3.4.1-rust"
 
-[workspace.package.metadata.docs.rs]
+[workspace.metadata.docs.rs]
 all-features = true
 no-default-features = false
 rustdoc-args = ["--cfg", "docsrs", "-D", "rustdoc::broken_intra_doc_links"]


### PR DESCRIPTION
## Summary
- move the docs.rs configuration out of the workspace package table into the dedicated workspace.metadata table to avoid cargo warnings

## Testing
- cargo metadata --no-deps --format-version 1

------