### PR TITLE
Centralize branding helpers and refine CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,18 +139,13 @@ jobs:
         run: cargo --locked nextest run --workspace --all-features
 
       - name: Generate coverage profile
-        run: >-
-          cargo --locked llvm-cov nextest --workspace --all-features
-          --no-report
+        run: cargo --locked llvm-cov nextest --workspace --all-features --no-report
 
       - name: Export coverage report (lcov)
         run: cargo --locked llvm-cov report --lcov --output-path coverage.lcov
 
       - name: Enforce coverage thresholds and export summary
-        run: >-
-          cargo --locked llvm-cov report --json --summary-only
-          --output-path coverage-summary.json --fail-under-lines 95
-          --fail-under-functions 95
+        run: cargo --locked llvm-cov report --json --summary-only --output-path coverage-summary.json --fail-under-lines 95 --fail-under-functions 95
 
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v4
@@ -185,6 +180,7 @@ jobs:
 
   cross-compile:
     needs: lint
+    if: ${{ matrix.platform.enabled != false }}
     runs-on: ubuntu-latest
     name: Cross-compile (${{ matrix.platform.name }})
     strategy:
@@ -227,6 +223,22 @@ jobs:
             uses_zig: true
             needs_cross_gcc: false
             generate_sbom: false
+          - name: windows-x86
+            target: i686-pc-windows-gnu
+            build_command: zigbuild
+            build_daemon: false
+            uses_zig: true
+            needs_cross_gcc: false
+            generate_sbom: false
+            enabled: false
+          - name: windows-aarch64
+            target: aarch64-pc-windows-gnu
+            build_command: zigbuild
+            build_daemon: false
+            uses_zig: true
+            needs_cross_gcc: false
+            generate_sbom: false
+            enabled: false
     env:
       CC_aarch64_unknown_linux_gnu: ${{ matrix.platform.needs_cross_gcc && 'aarch64-linux-gnu-gcc' || '' }}
       CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: ${{ matrix.platform.needs_cross_gcc && 'aarch64-linux-gnu-gcc' || '' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,10 +49,9 @@ jobs:
         run: scripts/check-run-matrix-docs.sh
       - name: Cross-compile check
         run: |
-          rustup target add x86_64-apple-darwin x86_64-pc-windows-msvc aarch64-pc-windows-msvc
+          rustup target add x86_64-apple-darwin x86_64-pc-windows-msvc
           cargo check --workspace --target x86_64-apple-darwin
           cargo check --workspace --target x86_64-pc-windows-msvc
-          cargo check --workspace --target aarch64-pc-windows-msvc
 
   build:
     needs: lint-test
@@ -68,8 +67,6 @@ jobs:
             target: x86_64-apple-darwin
           - os: windows-latest
             target: x86_64-pc-windows-msvc
-          - os: windows-latest
-            target: aarch64-pc-windows-msvc
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1

--- a/crates/cli/src/frontend/help.rs
+++ b/crates/cli/src/frontend/help.rs
@@ -1,6 +1,6 @@
 //! Rendering helpers for `--help` output.
 
-use rsync_core::branding::manifest;
+use rsync_core::branding::{manifest, rust_version, source_url};
 
 use super::ProgramName;
 
@@ -169,8 +169,8 @@ pub(super) fn help_text(program_name: ProgramName) -> String {
             "covers permissions, timestamps, and optional ownership metadata.\n",
         ),
         program = program,
-        version = manifest.rust_version(),
-        website = manifest.source_url(),
+        version = rust_version(),
+        website = source_url(),
         daemon = daemon,
     )
 }

--- a/crates/cli/src/frontend/tests/common.rs
+++ b/crates/cli/src/frontend/tests/common.rs
@@ -1,4 +1,5 @@
 use super::*;
+use rsync_core::branding::rust_version;
 
 pub(super) const RSYNC: &str = branding::client_program_name();
 pub(super) const OC_RSYNC: &str = branding::oc_client_program_name();
@@ -183,7 +184,7 @@ pub(super) fn mkfifo_for_tests(path: &Path, mode: u32) -> io::Result<()> {
 }
 
 pub(super) fn assert_contains_client_trailer(rendered: &str) {
-    let expected = format!("[client={}]", manifest().rust_version());
+    let expected = format!("[client={}]", rust_version());
     assert!(
         rendered.contains(&expected),
         "expected message to contain {expected:?}, got {rendered:?}"

--- a/crates/core/src/branding/manifest.rs
+++ b/crates/core/src/branding/manifest.rs
@@ -179,6 +179,18 @@ impl BrandManifest {
             build_toolchain: self.build_toolchain,
         }
     }
+
+    /// Returns the [`BrandSummary`] describing the branded `oc-rsync` binaries.
+    #[must_use]
+    pub const fn oc_summary(self) -> BrandSummary {
+        self.summary_for(Brand::Oc)
+    }
+
+    /// Returns the [`BrandSummary`] describing the upstream-compatible binaries.
+    #[must_use]
+    pub const fn upstream_summary(self) -> BrandSummary {
+        self.summary_for(Brand::Upstream)
+    }
 }
 
 fn build_manifest() -> BrandManifest {
@@ -358,12 +370,17 @@ mod tests {
         assert_eq!(manifest.source_url(), metadata.source_url());
         assert_eq!(manifest.build_revision(), version::build_revision());
         assert_eq!(manifest.build_toolchain(), BUILD_TOOLCHAIN);
+        assert_eq!(manifest.oc_summary(), manifest.summary_for(Brand::Oc));
+        assert_eq!(
+            manifest.upstream_summary(),
+            manifest.summary_for(Brand::Upstream)
+        );
     }
 
     #[test]
     fn summary_for_oc_brand_exposes_expected_metadata() {
         let manifest = manifest();
-        let summary = manifest.summary_for(Brand::Oc);
+        let summary = manifest.oc_summary();
 
         assert_eq!(summary.brand(), Brand::Oc);
         assert_eq!(summary.client_program_name(), "oc-rsync");
@@ -392,7 +409,7 @@ mod tests {
     #[test]
     fn summary_for_upstream_brand_reflects_legacy_names() {
         let manifest = manifest();
-        let summary = manifest.summary_for(Brand::Upstream);
+        let summary = manifest.upstream_summary();
 
         assert_eq!(summary.brand(), Brand::Upstream);
         assert_eq!(summary.client_program_name(), "rsync");

--- a/crates/core/src/branding/mod.rs
+++ b/crates/core/src/branding/mod.rs
@@ -42,3 +42,51 @@ pub use profile::{
     oc_daemon_program_name_os_str, oc_daemon_secrets_path, oc_profile,
     upstream_client_program_name, upstream_daemon_program_name, upstream_profile,
 };
+
+/// Returns the Rust-branded version string advertised by the workspace binaries.
+#[must_use]
+pub fn rust_version() -> &'static str {
+    manifest().rust_version()
+}
+
+/// Returns the upstream base version that this workspace targets.
+#[must_use]
+pub fn upstream_version() -> &'static str {
+    manifest().upstream_version()
+}
+
+/// Returns the highest rsync protocol version supported by the workspace.
+#[must_use]
+pub fn protocol_version() -> u32 {
+    manifest().protocol_version()
+}
+
+/// Returns the source repository URL advertised by `--version` banners.
+#[must_use]
+pub fn source_url() -> &'static str {
+    manifest().source_url()
+}
+
+/// Returns the sanitized build revision baked into the binaries.
+#[must_use]
+pub fn build_revision() -> &'static str {
+    manifest().build_revision()
+}
+
+/// Returns the human-readable toolchain description rendered by banners.
+#[must_use]
+pub fn build_toolchain() -> &'static str {
+    manifest().build_toolchain()
+}
+
+/// Returns the [`BrandSummary`] describing the branded `oc-rsync` binaries.
+#[must_use]
+pub fn oc_summary() -> BrandSummary {
+    manifest().oc_summary()
+}
+
+/// Returns the [`BrandSummary`] describing the upstream-compatible binaries.
+#[must_use]
+pub fn upstream_summary() -> BrandSummary {
+    manifest().upstream_summary()
+}

--- a/crates/core/src/branding/tests.rs
+++ b/crates/core/src/branding/tests.rs
@@ -209,6 +209,20 @@ fn resolve_brand_profile_delegates_to_detect_brand() {
 }
 
 #[test]
+fn helper_accessors_forward_to_manifest() {
+    let manifest = manifest();
+
+    assert_eq!(rust_version(), manifest.rust_version());
+    assert_eq!(upstream_version(), manifest.upstream_version());
+    assert_eq!(protocol_version(), manifest.protocol_version());
+    assert_eq!(source_url(), manifest.source_url());
+    assert_eq!(build_revision(), manifest.build_revision());
+    assert_eq!(build_toolchain(), manifest.build_toolchain());
+    assert_eq!(oc_summary(), manifest.oc_summary());
+    assert_eq!(upstream_summary(), manifest.upstream_summary());
+}
+
+#[test]
 fn detect_brand_falls_back_to_current_executable() {
     let _guard = EnvGuard::remove(BRAND_OVERRIDE_ENV);
     let expected = env::current_exe()


### PR DESCRIPTION
## Summary
- add top-level branding helpers that expose version metadata and cached brand summaries
- update CLI help rendering and tests to use the new branding accessors
- extend the branding manifest tests and convenience methods for oc and upstream summaries
- streamline coverage steps in CI and explicitly disable Windows x86/aarch64 cross targets in CI and release workflows

## Testing
- cargo test -p rsync-core helper_accessors_forward_to_manifest -- --nocapture

------