### PR TITLE
Fix clippy warnings for CLI tests and xtask

### DIFF
--- a/crates/cli/src/frontend/command_builder/mod.rs
+++ b/crates/cli/src/frontend/command_builder/mod.rs
@@ -5,6 +5,5 @@ pub(super) use clap::{Arg, ArgAction, Command as ClapCommand, builder::OsStringV
 pub(super) fn clap_command(program_name: &'static str) -> ClapCommand {
     let command = sections::section_01(program_name);
     let command = sections::section_02(command);
-    let command = sections::section_03(command);
-    command
+    sections::section_03(command)
 }

--- a/crates/cli/src/frontend/mod.rs
+++ b/crates/cli/src/frontend/mod.rs
@@ -299,7 +299,6 @@ fn env_protect_args_default() -> Option<bool> {
 }
 
 /// Builds the `clap` command used for parsing.
-
 /// Parses command-line arguments into a [`ParsedArgs`] structure.
 fn parse_args<I, S>(arguments: I) -> Result<ParsedArgs, clap::Error>
 where

--- a/xtask/src/commands/preflight/validation.rs
+++ b/xtask/src/commands/preflight/validation.rs
@@ -171,18 +171,17 @@ pub(crate) fn validate_package_versions(
         versions.insert(name.to_string(), version.to_string());
     }
 
-    for crate_name in ["oc-rsync"] {
-        let version = versions.get(crate_name).ok_or_else(|| {
-            validation_error(format!("crate {crate_name} missing from cargo metadata"))
-        })?;
-        ensure(
-            version == &branding.rust_version,
-            format!(
-                "crate {crate_name} version {version} does not match {}",
-                branding.rust_version
-            ),
-        )?;
-    }
+    let crate_name = "oc-rsync";
+    let version = versions.get(crate_name).ok_or_else(|| {
+        validation_error(format!("crate {crate_name} missing from cargo metadata"))
+    })?;
+    ensure(
+        version == &branding.rust_version,
+        format!(
+            "crate {crate_name} version {version} does not match {}",
+            branding.rust_version
+        ),
+    )?;
 
     Ok(())
 }


### PR DESCRIPTION
## Summary
- eliminate single-element loop in the preflight validation step
- clean up CLI command builder and documentation comments to satisfy clippy
- resolve cli_binaries test env var handling using runtime lookups

## Testing
- cargo clippy --workspace --all-targets --all-features --locked -- -Dwarnings

------