### PR TITLE
Explicitly disable Windows x86/aarch64 cross targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,6 +188,7 @@ jobs:
       matrix:
         platform:
           - name: linux-x86_64
+            enabled: true
             target: x86_64-unknown-linux-gnu
             build_command: build
             build_daemon: true
@@ -195,6 +196,7 @@ jobs:
             needs_cross_gcc: false
             generate_sbom: true
           - name: linux-aarch64
+            enabled: true
             target: aarch64-unknown-linux-gnu
             build_command: build
             build_daemon: true
@@ -202,6 +204,7 @@ jobs:
             needs_cross_gcc: true
             generate_sbom: true
           - name: darwin-x86_64
+            enabled: true
             target: x86_64-apple-darwin
             build_command: zigbuild
             build_daemon: true
@@ -209,6 +212,7 @@ jobs:
             needs_cross_gcc: false
             generate_sbom: true
           - name: darwin-aarch64
+            enabled: true
             target: aarch64-apple-darwin
             build_command: zigbuild
             build_daemon: true
@@ -216,7 +220,24 @@ jobs:
             needs_cross_gcc: false
             generate_sbom: true
           - name: windows-x86_64
+            enabled: true
             target: x86_64-pc-windows-gnu
+            build_command: zigbuild
+            build_daemon: false
+            uses_zig: true
+            needs_cross_gcc: false
+            generate_sbom: false
+          - name: windows-x86
+            enabled: false
+            target: i686-pc-windows-gnu
+            build_command: zigbuild
+            build_daemon: false
+            uses_zig: true
+            needs_cross_gcc: false
+            generate_sbom: false
+          - name: windows-aarch64
+            enabled: false
+            target: aarch64-pc-windows-msvc
             build_command: zigbuild
             build_daemon: false
             uses_zig: true
@@ -226,9 +247,15 @@ jobs:
       CC_aarch64_unknown_linux_gnu: ${{ matrix.platform.needs_cross_gcc && 'aarch64-linux-gnu-gcc' || '' }}
       CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: ${{ matrix.platform.needs_cross_gcc && 'aarch64-linux-gnu-gcc' || '' }}
     steps:
+      - name: Skip disabled target
+        if: ${{ !matrix.platform.enabled }}
+        run: echo "Platform '${{ matrix.platform.name }}' is disabled for this release line."
+
       - uses: actions/checkout@v4
+        if: ${{ matrix.platform.enabled }}
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1
+        if: ${{ matrix.platform.enabled }}
         with:
           toolchain: 1.87
           components: rust-src
@@ -236,54 +263,59 @@ jobs:
           cache: true
 
       - name: Ensure target std is installed
+        if: ${{ matrix.platform.enabled }}
         run: rustup target add ${{ matrix.platform.target }}
 
       - uses: Swatinem/rust-cache@v2
+        if: ${{ matrix.platform.enabled }}
         with:
           shared-key: cross-${{ matrix.platform.name }}
           target: ${{ matrix.platform.target }}
 
       - uses: awalsh128/cache-apt-pkgs-action@v1
+        if: ${{ matrix.platform.enabled }}
         with:
           packages: build-essential libzstd-dev zlib1g-dev libacl1-dev attr acl libxxhash-dev rpm
           version: 1
 
       - uses: awalsh128/cache-apt-pkgs-action@v1
-        if: ${{ matrix.platform.needs_cross_gcc }}
+        if: ${{ matrix.platform.enabled && matrix.platform.needs_cross_gcc }}
         with:
           packages: gcc-aarch64-linux-gnu
           version: 1
 
       - name: Install Zig toolchain
-        if: ${{ matrix.platform.uses_zig }}
+        if: ${{ matrix.platform.enabled && matrix.platform.uses_zig }}
         uses: mlugg/setup-zig@v1
         with:
           version: 0.13.0
 
       - name: Install cargo-zigbuild
-        if: ${{ matrix.platform.uses_zig }}
+        if: ${{ matrix.platform.enabled && matrix.platform.uses_zig }}
         uses: taiki-e/install-action@v2
         with:
           tool: cargo-zigbuild
 
       - name: Install cargo-cyclonedx
-        if: ${{ matrix.platform.generate_sbom }}
+        if: ${{ matrix.platform.enabled && matrix.platform.generate_sbom }}
         uses: taiki-e/install-action@v2
         with:
           tool: cargo-cyclonedx
 
       - name: Build oc-rsync
+        if: ${{ matrix.platform.enabled }}
         run: cargo --locked ${{ matrix.platform.build_command }} --release --target ${{ matrix.platform.target }} --bin oc-rsync
 
       - name: Build oc-rsyncd
-        if: ${{ matrix.platform.build_daemon }}
+        if: ${{ matrix.platform.enabled && matrix.platform.build_daemon }}
         run: cargo --locked ${{ matrix.platform.build_command }} --release --target ${{ matrix.platform.target }} --bin oc-rsyncd
 
       - name: Generate target SBOM
-        if: ${{ matrix.platform.generate_sbom }}
+        if: ${{ matrix.platform.enabled && matrix.platform.generate_sbom }}
         run: cargo --locked run -p xtask -- sbom --output target/${{ matrix.platform.target }}/release/oc-rsync-${{ matrix.platform.name }}-sbom.json
 
       - name: Upload oc-rsync artifact
+        if: ${{ matrix.platform.enabled }}
         uses: actions/upload-artifact@v4
         with:
           name: oc-rsync-${{ matrix.platform.name }}
@@ -291,7 +323,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload oc-rsyncd artifact
-        if: ${{ matrix.platform.build_daemon }}
+        if: ${{ matrix.platform.enabled && matrix.platform.build_daemon }}
         uses: actions/upload-artifact@v4
         with:
           name: oc-rsyncd-${{ matrix.platform.name }}


### PR DESCRIPTION
## Summary
- add explicit `enabled` markers to every cross-compilation target in the CI matrix
- keep linux, macOS, and Windows x86_64 builds while cleanly skipping the disabled Windows x86 and Windows aarch64 targets

## Testing
- not run (workflow-only change)

------