### PR TITLE
Fix CLI binary tests to run under nextest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,6 +68,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_cmd"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcbb6924530aa9e0432442af08bbcafdad182db80d2e560da42a6d442535bf85"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -116,6 +131,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
 dependencies = [
  "memchr",
+ "regex-automata",
  "serde",
 ]
 
@@ -217,6 +233,12 @@ checksum = "a41953f86f8a05768a6cda24def994fd2f424b04ec5c719cf89989779f199071"
 dependencies = [
  "powerfmt",
 ]
+
+[[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "digest"
@@ -458,6 +480,7 @@ dependencies = [
 name = "oc-rsync"
 version = "3.4.1-rust"
 dependencies = [
+ "assert_cmd",
  "rsync-cli",
  "rsync-daemon",
  "rsync-windows-gnu-eh",
@@ -488,6 +511,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "predicates"
+version = "3.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
+dependencies = [
+ "predicates-core",
+ "termtree",
 ]
 
 [[package]]
@@ -928,6 +978,12 @@ dependencies = [
  "rustix 1.1.2",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,9 @@ sd-notify = ["rsync-daemon/sd-notify"]
 rsync-cli = { path = "crates/cli" }
 rsync-daemon = { path = "crates/daemon" }
 
+[dev-dependencies]
+assert_cmd = "2.0"
+
 [target.'cfg(all(windows, target_env = "gnu"))'.dependencies]
 rsync-windows-gnu-eh = { path = "crates/windows-gnu-eh" }
 

--- a/tests/cli_binaries.rs
+++ b/tests/cli_binaries.rs
@@ -1,20 +1,14 @@
-use std::{
-    env,
-    path::{Path, PathBuf},
-    process::Command,
-};
+use assert_cmd::prelude::*;
+use std::process::{Command, Output};
 
-fn binary_path(var_name: &str) -> PathBuf {
-    env::var(var_name)
-        .unwrap_or_else(|error| panic!("environment variable {var_name} not set: {error}"))
-        .into()
-}
-
-fn binary_output(path: &Path, args: &[&str]) -> std::process::Output {
-    Command::new(path)
-        .args(args)
+fn binary_output(name: &str, args: &[&str]) -> Output {
+    #[allow(deprecated)]
+    let mut command =
+        Command::cargo_bin(name).unwrap_or_else(|error| panic!("failed to locate {name}: {error}"));
+    command.args(args);
+    command
         .output()
-        .unwrap_or_else(|error| panic!("failed to run {}: {error}", path.display()))
+        .unwrap_or_else(|error| panic!("failed to run {name}: {error}"))
 }
 
 fn combined_utf8(output: &std::process::Output) -> String {
@@ -25,8 +19,7 @@ fn combined_utf8(output: &std::process::Output) -> String {
 
 #[test]
 fn oc_rsync_help_lists_usage() {
-    let binary = binary_path("CARGO_BIN_EXE_oc-rsync");
-    let output = binary_output(&binary, &["--help"]);
+    let output = binary_output("oc-rsync", &["--help"]);
     assert!(output.status.success(), "--help should succeed");
     assert!(
         output.stderr.is_empty(),
@@ -39,8 +32,7 @@ fn oc_rsync_help_lists_usage() {
 
 #[test]
 fn oc_rsync_without_operands_shows_usage() {
-    let binary = binary_path("CARGO_BIN_EXE_oc-rsync");
-    let output = binary_output(&binary, &[]);
+    let output = binary_output("oc-rsync", &[]);
     assert!(
         !output.status.success(),
         "running without operands should fail so the caller sees the usage"
@@ -51,8 +43,7 @@ fn oc_rsync_without_operands_shows_usage() {
 
 #[test]
 fn oc_rsyncd_help_lists_usage() {
-    let binary = binary_path("CARGO_BIN_EXE_oc-rsyncd");
-    let output = binary_output(&binary, &["--help"]);
+    let output = binary_output("oc-rsyncd", &["--help"]);
     assert!(output.status.success(), "--help should succeed");
     assert!(
         output.stderr.is_empty(),
@@ -65,8 +56,7 @@ fn oc_rsyncd_help_lists_usage() {
 
 #[test]
 fn oc_rsyncd_rejects_unknown_flag() {
-    let binary = binary_path("CARGO_BIN_EXE_oc-rsyncd");
-    let output = binary_output(&binary, &["--definitely-not-a-flag"]);
+    let output = binary_output("oc-rsyncd", &["--definitely-not-a-flag"]);
     assert!(
         !output.status.success(),
         "unexpected flags should return a failure exit status"


### PR DESCRIPTION
## Summary
- resolve CLI binary paths via `assert_cmd` so the tests no longer depend on runtime env vars
- add `assert_cmd` as a dev-dependency for the integration test harness

## Testing
- cargo test

------