### PR TITLE
Split local copy error definitions into dedicated module

### DIFF
--- a/crates/engine/src/local_copy.rs
+++ b/crates/engine/src/local_copy.rs
@@ -49,16 +49,17 @@
 //! assert_eq!(summary.files_copied(), 1);
 //! ```
 
+mod error;
 mod filter_program;
 mod overrides;
 mod skip_compress;
 
+pub use self::error::{LocalCopyArgumentError, LocalCopyError, LocalCopyErrorKind};
 pub use skip_compress::{SkipCompressList, SkipCompressParseError};
 
 use self::filter_program::{
     DirMergeParser, ExcludeIfPresentLayers, ExcludeIfPresentStack, FilterContext, FilterSegment,
-    FilterSegmentLayers, FilterSegmentStack, INVALID_OPERAND_EXIT_CODE, MAX_DELETE_EXIT_CODE,
-    MISSING_OPERANDS_EXIT_CODE, TIMEOUT_EXIT_CODE, directory_has_marker,
+    FilterSegmentLayers, FilterSegmentStack, directory_has_marker,
 };
 use std::cell::{Cell, RefCell};
 use std::cmp::Ordering;
@@ -4873,227 +4874,6 @@ fn sync_acls_if_requested(
         sync_acls(source, destination, follow_symlinks).map_err(map_metadata_error)?;
     }
     Ok(())
-}
-
-/// Error produced when planning or executing a local copy fails.
-#[derive(Debug)]
-pub struct LocalCopyError {
-    kind: LocalCopyErrorKind,
-}
-
-impl LocalCopyError {
-    fn new(kind: LocalCopyErrorKind) -> Self {
-        Self { kind }
-    }
-
-    /// Constructs an error representing missing operands.
-    #[must_use]
-    pub fn missing_operands() -> Self {
-        Self::new(LocalCopyErrorKind::MissingSourceOperands)
-    }
-
-    /// Constructs an invalid-argument error.
-    #[must_use]
-    pub fn invalid_argument(reason: LocalCopyArgumentError) -> Self {
-        Self::new(LocalCopyErrorKind::InvalidArgument(reason))
-    }
-
-    /// Constructs an error indicating that the deletion limit was exceeded.
-    #[must_use]
-    pub fn delete_limit_exceeded(skipped: u64) -> Self {
-        Self::new(LocalCopyErrorKind::DeleteLimitExceeded { skipped })
-    }
-
-    /// Constructs an I/O error with action context.
-    #[must_use]
-    pub fn io(action: &'static str, path: PathBuf, source: io::Error) -> Self {
-        Self::new(LocalCopyErrorKind::Io {
-            action,
-            path,
-            source,
-        })
-    }
-
-    /// Constructs an error representing an inactivity timeout.
-    #[must_use]
-    pub fn timeout(duration: Duration) -> Self {
-        Self::new(LocalCopyErrorKind::Timeout { duration })
-    }
-
-    /// Returns the exit code that mirrors upstream rsync's behaviour.
-    #[must_use]
-    pub const fn exit_code(&self) -> i32 {
-        match self.kind {
-            LocalCopyErrorKind::MissingSourceOperands => MISSING_OPERANDS_EXIT_CODE,
-            LocalCopyErrorKind::InvalidArgument(_) | LocalCopyErrorKind::Io { .. } => {
-                INVALID_OPERAND_EXIT_CODE
-            }
-            LocalCopyErrorKind::Timeout { .. } => TIMEOUT_EXIT_CODE,
-            LocalCopyErrorKind::DeleteLimitExceeded { .. } => MAX_DELETE_EXIT_CODE,
-        }
-    }
-
-    /// Provides access to the underlying error kind.
-    #[must_use]
-    pub fn kind(&self) -> &LocalCopyErrorKind {
-        &self.kind
-    }
-
-    /// Consumes the error and returns its kind.
-    #[must_use]
-    pub fn into_kind(self) -> LocalCopyErrorKind {
-        self.kind
-    }
-}
-
-impl fmt::Display for LocalCopyError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match &self.kind {
-            LocalCopyErrorKind::MissingSourceOperands => {
-                write!(
-                    f,
-                    "missing source operands: supply at least one source and a destination"
-                )
-            }
-            LocalCopyErrorKind::InvalidArgument(reason) => write!(f, "{}", reason.message()),
-            LocalCopyErrorKind::Io {
-                action,
-                path,
-                source,
-            } => {
-                write!(f, "failed to {action} '{}': {source}", path.display())
-            }
-            LocalCopyErrorKind::Timeout { duration } => {
-                write!(
-                    f,
-                    "transfer timed out after {:.3} seconds without progress",
-                    duration.as_secs_f64()
-                )
-            }
-            LocalCopyErrorKind::DeleteLimitExceeded { skipped } => {
-                let noun = if *skipped == 1 { "entry" } else { "entries" };
-                write!(
-                    f,
-                    "Deletions stopped due to --max-delete limit ({} {noun} skipped)",
-                    skipped
-                )
-            }
-        }
-    }
-}
-
-impl Error for LocalCopyError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        match &self.kind {
-            LocalCopyErrorKind::Io { source, .. } => Some(source),
-            _ => None,
-        }
-    }
-}
-
-/// Classification of local copy failures.
-#[derive(Debug)]
-pub enum LocalCopyErrorKind {
-    /// No operands were supplied.
-    MissingSourceOperands,
-    /// Operands were invalid.
-    InvalidArgument(LocalCopyArgumentError),
-    /// Filesystem interaction failed.
-    Io {
-        /// Action being performed.
-        action: &'static str,
-        /// Path involved in the failure.
-        path: PathBuf,
-        /// Underlying error.
-        source: io::Error,
-    },
-    /// The transfer exceeded the configured inactivity timeout.
-    Timeout {
-        /// Duration of inactivity that triggered the timeout.
-        duration: Duration,
-    },
-    /// Deletions were halted because the configured limit was exceeded.
-    DeleteLimitExceeded {
-        /// Number of entries that were skipped after reaching the limit.
-        skipped: u64,
-    },
-}
-
-impl LocalCopyErrorKind {
-    /// Returns the action, path, and source error for [`LocalCopyErrorKind::Io`] values.
-    #[must_use]
-    pub fn as_io(&self) -> Option<(&'static str, &Path, &io::Error)> {
-        match self {
-            Self::Io {
-                action,
-                path,
-                source,
-            } => Some((action, path.as_path(), source)),
-            Self::Timeout { .. } => None,
-            _ => None,
-        }
-    }
-}
-
-/// Detailed reason for operand validation failures.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum LocalCopyArgumentError {
-    /// A source operand was empty.
-    EmptySourceOperand,
-    /// The destination operand was empty.
-    EmptyDestinationOperand,
-    /// Multiple sources targeted a non-directory destination.
-    DestinationMustBeDirectory,
-    /// Unable to determine the directory name from the source operand.
-    DirectoryNameUnavailable,
-    /// Unable to determine the file name from the source operand.
-    FileNameUnavailable,
-    /// Unable to determine the link name from the source operand.
-    LinkNameUnavailable,
-    /// Encountered a file type that is unsupported.
-    UnsupportedFileType,
-    /// Attempted to replace an existing directory with a symbolic link.
-    ReplaceDirectoryWithSymlink,
-    /// Attempted to replace an existing directory with a regular file.
-    ReplaceDirectoryWithFile,
-    /// Attempted to replace an existing directory with a special file.
-    ReplaceDirectoryWithSpecial,
-    /// Attempted to replace a non-directory with a directory.
-    ReplaceNonDirectoryWithDirectory,
-    /// Encountered an operand that refers to a remote host or module.
-    RemoteOperandUnsupported,
-}
-
-impl LocalCopyArgumentError {
-    /// Returns the canonical diagnostic message associated with the error.
-    #[must_use]
-    pub const fn message(self) -> &'static str {
-        match self {
-            Self::EmptySourceOperand => "source operands must be non-empty",
-            Self::EmptyDestinationOperand => "destination operand must be non-empty",
-            Self::DestinationMustBeDirectory => {
-                "destination must be an existing directory when copying multiple sources"
-            }
-            Self::DirectoryNameUnavailable => "cannot determine directory name",
-            Self::FileNameUnavailable => "cannot determine file name",
-            Self::LinkNameUnavailable => "cannot determine link name",
-            Self::UnsupportedFileType => "unsupported file type encountered",
-            Self::ReplaceDirectoryWithSymlink => {
-                "cannot replace existing directory with symbolic link"
-            }
-            Self::ReplaceDirectoryWithFile => "cannot replace existing directory with regular file",
-            Self::ReplaceDirectoryWithSpecial => {
-                "cannot replace existing directory with special file"
-            }
-            Self::ReplaceNonDirectoryWithDirectory => {
-                "cannot replace non-directory destination with directory"
-            }
-            Self::RemoteOperandUnsupported => concat!(
-                "remote operands are not supported: this build handles local filesystem copies only; ",
-                "set OC_RSYNC_FALLBACK to point to an upstream rsync binary for remote transfers",
-            ),
-        }
-    }
 }
 
 /// Source operand within a [`LocalCopyPlan`].

--- a/crates/engine/src/local_copy/error.rs
+++ b/crates/engine/src/local_copy/error.rs
@@ -1,0 +1,229 @@
+use super::filter_program::{
+    INVALID_OPERAND_EXIT_CODE, MAX_DELETE_EXIT_CODE, MISSING_OPERANDS_EXIT_CODE, TIMEOUT_EXIT_CODE,
+};
+use std::error::Error;
+use std::fmt;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+/// Error produced when planning or executing a local copy fails.
+#[derive(Debug)]
+pub struct LocalCopyError {
+    kind: LocalCopyErrorKind,
+}
+
+impl LocalCopyError {
+    fn new(kind: LocalCopyErrorKind) -> Self {
+        Self { kind }
+    }
+
+    /// Constructs an error representing missing operands.
+    #[must_use]
+    pub fn missing_operands() -> Self {
+        Self::new(LocalCopyErrorKind::MissingSourceOperands)
+    }
+
+    /// Constructs an invalid-argument error.
+    #[must_use]
+    pub fn invalid_argument(reason: LocalCopyArgumentError) -> Self {
+        Self::new(LocalCopyErrorKind::InvalidArgument(reason))
+    }
+
+    /// Constructs an error indicating that the deletion limit was exceeded.
+    #[must_use]
+    pub fn delete_limit_exceeded(skipped: u64) -> Self {
+        Self::new(LocalCopyErrorKind::DeleteLimitExceeded { skipped })
+    }
+
+    /// Constructs an I/O error with action context.
+    #[must_use]
+    pub fn io(action: &'static str, path: PathBuf, source: io::Error) -> Self {
+        Self::new(LocalCopyErrorKind::Io {
+            action,
+            path,
+            source,
+        })
+    }
+
+    /// Constructs an error representing an inactivity timeout.
+    #[must_use]
+    pub fn timeout(duration: Duration) -> Self {
+        Self::new(LocalCopyErrorKind::Timeout { duration })
+    }
+
+    /// Returns the exit code that mirrors upstream rsync's behaviour.
+    #[must_use]
+    pub const fn exit_code(&self) -> i32 {
+        match self.kind {
+            LocalCopyErrorKind::MissingSourceOperands => MISSING_OPERANDS_EXIT_CODE,
+            LocalCopyErrorKind::InvalidArgument(_) | LocalCopyErrorKind::Io { .. } => {
+                INVALID_OPERAND_EXIT_CODE
+            }
+            LocalCopyErrorKind::Timeout { .. } => TIMEOUT_EXIT_CODE,
+            LocalCopyErrorKind::DeleteLimitExceeded { .. } => MAX_DELETE_EXIT_CODE,
+        }
+    }
+
+    /// Provides access to the underlying error kind.
+    #[must_use]
+    pub fn kind(&self) -> &LocalCopyErrorKind {
+        &self.kind
+    }
+
+    /// Consumes the error and returns its kind.
+    #[must_use]
+    pub fn into_kind(self) -> LocalCopyErrorKind {
+        self.kind
+    }
+}
+
+impl fmt::Display for LocalCopyError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.kind {
+            LocalCopyErrorKind::MissingSourceOperands => {
+                write!(
+                    f,
+                    "missing source operands: supply at least one source and a destination"
+                )
+            }
+            LocalCopyErrorKind::InvalidArgument(reason) => write!(f, "{}", reason.message()),
+            LocalCopyErrorKind::Io {
+                action,
+                path,
+                source,
+            } => {
+                write!(f, "failed to {action} '{}': {source}", path.display())
+            }
+            LocalCopyErrorKind::Timeout { duration } => {
+                write!(
+                    f,
+                    "transfer timed out after {:.3} seconds without progress",
+                    duration.as_secs_f64()
+                )
+            }
+            LocalCopyErrorKind::DeleteLimitExceeded { skipped } => {
+                let noun = if *skipped == 1 { "entry" } else { "entries" };
+                write!(
+                    f,
+                    "Deletions stopped due to --max-delete limit ({} {noun} skipped)",
+                    skipped
+                )
+            }
+        }
+    }
+}
+
+impl Error for LocalCopyError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match &self.kind {
+            LocalCopyErrorKind::Io { source, .. } => Some(source),
+            _ => None,
+        }
+    }
+}
+
+/// Classification of local copy failures.
+#[derive(Debug)]
+pub enum LocalCopyErrorKind {
+    /// No operands were supplied.
+    MissingSourceOperands,
+    /// Operands were invalid.
+    InvalidArgument(LocalCopyArgumentError),
+    /// Filesystem interaction failed.
+    Io {
+        /// Action being performed.
+        action: &'static str,
+        /// Path involved in the failure.
+        path: PathBuf,
+        /// Underlying error.
+        source: io::Error,
+    },
+    /// The transfer exceeded the configured inactivity timeout.
+    Timeout {
+        /// Duration of inactivity that triggered the timeout.
+        duration: Duration,
+    },
+    /// Deletions were halted because the configured limit was exceeded.
+    DeleteLimitExceeded {
+        /// Number of entries that were skipped after reaching the limit.
+        skipped: u64,
+    },
+}
+
+impl LocalCopyErrorKind {
+    /// Returns the action, path, and source error for [`LocalCopyErrorKind::Io`] values.
+    #[must_use]
+    pub fn as_io(&self) -> Option<(&'static str, &Path, &io::Error)> {
+        match self {
+            Self::Io {
+                action,
+                path,
+                source,
+            } => Some((action, path.as_path(), source)),
+            Self::Timeout { .. } => None,
+            _ => None,
+        }
+    }
+}
+
+/// Detailed reason for operand validation failures.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum LocalCopyArgumentError {
+    /// A source operand was empty.
+    EmptySourceOperand,
+    /// The destination operand was empty.
+    EmptyDestinationOperand,
+    /// Multiple sources targeted a non-directory destination.
+    DestinationMustBeDirectory,
+    /// Unable to determine the directory name from the source operand.
+    DirectoryNameUnavailable,
+    /// Unable to determine the file name from the source operand.
+    FileNameUnavailable,
+    /// Unable to determine the link name from the source operand.
+    LinkNameUnavailable,
+    /// Encountered a file type that is unsupported.
+    UnsupportedFileType,
+    /// Attempted to replace an existing directory with a symbolic link.
+    ReplaceDirectoryWithSymlink,
+    /// Attempted to replace an existing directory with a regular file.
+    ReplaceDirectoryWithFile,
+    /// Attempted to replace an existing directory with a special file.
+    ReplaceDirectoryWithSpecial,
+    /// Attempted to replace a non-directory with a directory.
+    ReplaceNonDirectoryWithDirectory,
+    /// Encountered an operand that refers to a remote host or module.
+    RemoteOperandUnsupported,
+}
+
+impl LocalCopyArgumentError {
+    /// Returns the canonical diagnostic message associated with the error.
+    #[must_use]
+    pub const fn message(self) -> &'static str {
+        match self {
+            Self::EmptySourceOperand => "source operands must be non-empty",
+            Self::EmptyDestinationOperand => "destination operand must be non-empty",
+            Self::DestinationMustBeDirectory => {
+                "destination must be an existing directory when copying multiple sources"
+            }
+            Self::DirectoryNameUnavailable => "cannot determine directory name",
+            Self::FileNameUnavailable => "cannot determine file name",
+            Self::LinkNameUnavailable => "cannot determine link name",
+            Self::UnsupportedFileType => "unsupported file type encountered",
+            Self::ReplaceDirectoryWithSymlink => {
+                "cannot replace existing directory with symbolic link"
+            }
+            Self::ReplaceDirectoryWithFile => "cannot replace existing directory with regular file",
+            Self::ReplaceDirectoryWithSpecial => {
+                "cannot replace existing directory with special file"
+            }
+            Self::ReplaceNonDirectoryWithDirectory => {
+                "cannot replace non-directory destination with directory"
+            }
+            Self::RemoteOperandUnsupported => concat!(
+                "remote operands are not supported: this build handles local filesystem copies only; ",
+                "set OC_RSYNC_FALLBACK to point to an upstream rsync binary for remote transfers",
+            ),
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- extract local copy error handling types into a dedicated module to start decomposing the oversized local_copy implementation
- re-export the error types from the main module and clean up unused imports

## Testing
- cargo check -p rsync-engine

------