### PR TITLE
Ensure usage banner precedes missing operand error

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ This document defines the internal actors (“agents”), their responsibilities
   - Parse CLI (Clap v4) and render upstream-parity help/misuse.
   - Build `CoreConfig` via Builder and call `core::run_client()`.
   - Route `--msgs2stderr`, `--out-format`, `--info/--debug` to `logging`.
-  - When invoked without transfer operands, emit the usage banner before surfacing the canonical "missing source operands" error so tests remain deterministic.
+  - When invoked without transfer operands, emit the usage banner to **stdout** before surfacing the canonical "missing source operands" error so tests remain deterministic and compatible with scripts that expect upstream ordering.
 - **Invariants**:
   - Never access protocol/engine directly; only via `core`.
   - `--version` reflects feature gates and prints `3.4.1-rust`.

--- a/crates/cli/src/frontend/execution.rs
+++ b/crates/cli/src/frontend/execution.rs
@@ -885,21 +885,21 @@ where
     transfer_operands.extend(remainder);
 
     if transfer_operands.is_empty() {
+        let usage = clap_command(program_name.as_str())
+            .render_usage()
+            .to_string();
+        if writeln!(stdout, "{usage}").is_err() {
+            let _ = writeln!(stderr.writer_mut(), "{usage}");
+        }
+
         let message = rsync_error!(
             1,
             "missing source operands: supply at least one source and a destination"
         )
         .with_role(Role::Client);
+        let fallback = message.to_string();
         if write_message(&message, stderr).is_err() {
-            let fallback = message.to_string();
             let _ = writeln!(stderr.writer_mut(), "{fallback}");
-        }
-
-        let usage = clap_command(program_name.as_str())
-            .render_usage()
-            .to_string();
-        if writeln!(stderr.writer_mut(), "{usage}").is_err() {
-            let _ = writeln!(stdout, "{usage}");
         }
         return 1;
     }

--- a/crates/cli/src/frontend/tests/transfer_request_reports.rs
+++ b/crates/cli/src/frontend/tests/transfer_request_reports.rs
@@ -6,7 +6,9 @@ fn transfer_request_reports_missing_operands() {
     let (code, stdout, stderr) = run_with_args([OsString::from(RSYNC)]);
 
     assert_eq!(code, 1);
-    assert!(stdout.is_empty());
+    let stdout_rendered = String::from_utf8(stdout).expect("usage banner utf8");
+    let expected_usage = format!("{}\n", clap_command(RSYNC).render_usage());
+    assert_eq!(stdout_rendered, expected_usage);
 
     let rendered = String::from_utf8(stderr).expect("diagnostic is valid UTF-8");
     assert!(rendered.contains("missing source operands"));


### PR DESCRIPTION
## Summary
- emit the usage banner to stdout before raising the missing source operands diagnostic
- document the stdout requirement for usage ordering in internal docs guidance
- update the CLI test suite to assert the usage banner contents

## Testing
- cargo test -p rsync-cli

------