### PR TITLE
Document CI workflow contract and slim Linux tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,11 +117,6 @@ jobs:
       - name: Pre-flight check
         run: cargo --locked run -p xtask -- preflight
 
-      - name: Install cargo-zigbuild
-        uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-zigbuild
-
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@v2
         with:
@@ -235,6 +230,7 @@ jobs:
             uses_zig: true
             needs_cross_gcc: false
             generate_sbom: false
+            # Kept in the matrix for future enablement once toolchains stabilise.
           - name: windows-aarch64
             enabled: false
             target: aarch64-pc-windows-msvc
@@ -243,6 +239,7 @@ jobs:
             uses_zig: true
             needs_cross_gcc: false
             generate_sbom: false
+            # Kept in the matrix for future enablement once toolchains stabilise.
     env:
       CC_aarch64_unknown_linux_gnu: ${{ matrix.platform.needs_cross_gcc && 'aarch64-linux-gnu-gcc' || '' }}
       CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: ${{ matrix.platform.needs_cross_gcc && 'aarch64-linux-gnu-gcc' || '' }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,17 @@ This document defines the internal actors (“agents”), their responsibilities
   `cargo nextest run` executes the entire workspace without additional flags.
   Contributors must keep this file in sync with any future profile
   adjustments so local invocations match CI coverage.
+- **Standard-library-first implementations**: Prefer the Rust standard
+  library and well-supported crates that are actively maintained. Avoid
+  deprecated APIs, pseudo-code, or placeholder logic; every change must ship
+  production-ready behaviour with comprehensive tests or parity checks.
+- **CI workflow contract**: `.github/workflows/ci.yml` runs the primary test
+  job (`test-linux`) exclusively on Linux and a dedicated cross-compilation
+  matrix covering Linux (x86_64/aarch64), macOS (x86_64/aarch64), and Windows
+  (x86_64). The Windows x86 and Windows aarch64 entries remain in the matrix
+  but stay disabled for future enablement. Automation inside CI steps must rely
+  on Rust tooling (`cargo`, `cargo xtask`) rather than ad-hoc shell or Python
+  scripts.
 
 ---
 


### PR DESCRIPTION
## Summary
- extend internal docs with standard-library-first expectations and the CI workflow contract
- remove the unused cargo-zigbuild install from the Linux test job so the step stays lean
- annotate the disabled Windows targets in the cross-compilation matrix for future re-enablement

## Testing
- not run (not requested)

------