### PR TITLE
Add daemon module parsing tests and fix local copy test imports

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,11 @@ This document defines the internal actors (“agents”), their responsibilities
   library and well-supported crates that are actively maintained. Avoid
   deprecated APIs, pseudo-code, or placeholder logic; every change must ship
   production-ready behaviour with comprehensive tests or parity checks.
+- **Environment guardrails for tests**: When exercising fallback overrides or
+  other environment-sensitive logic in unit tests, use the existing
+  `EnvGuard` helpers (for example, `crates/daemon/src/tests/support.rs` or the
+  scoped guard in `crates/daemon/src/daemon/sections/tests.rs`) so variables
+  are restored even if the test panics.
 - **CI workflow contract**: `.github/workflows/ci.yml` runs the primary test
   job (`test-linux`) exclusively on Linux and a dedicated cross-compilation
   matrix covering Linux (x86_64/aarch64), macOS (x86_64/aarch64), and Windows

--- a/crates/daemon/src/daemon/sections/tests.rs
+++ b/crates/daemon/src/daemon/sections/tests.rs
@@ -1,0 +1,96 @@
+#![allow(unsafe_code)]
+
+use super::*;
+use rsync_core::branding::Brand;
+use rsync_core::fallback::{CLIENT_FALLBACK_ENV, DAEMON_FALLBACK_ENV};
+use std::env;
+use std::ffi::{OsStr, OsString};
+
+struct EnvGuard {
+    key: OsString,
+    original: Option<OsString>,
+}
+
+impl EnvGuard {
+    fn unset<K>(key: K) -> Self
+    where
+        K: Into<OsString>,
+    {
+        let key = key.into();
+        let original = env::var_os(&key);
+        unsafe {
+            env::remove_var(&key);
+        }
+        Self { key, original }
+    }
+
+    fn set<K, V>(key: K, value: V) -> Self
+    where
+        K: Into<OsString>,
+        V: Into<OsString>,
+    {
+        let key = key.into();
+        let original = env::var_os(&key);
+        unsafe {
+            env::set_var(&key, value.into());
+        }
+        Self { key, original }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        if let Some(value) = self.original.as_ref() {
+            unsafe {
+                env::set_var(&self.key, value);
+            }
+        } else {
+            unsafe {
+                env::remove_var(&self.key);
+            }
+        }
+    }
+}
+
+#[test]
+fn parse_daemon_option_extracts_option_payload() {
+    assert_eq!(parse_daemon_option("OPTION --list"), Some("--list"));
+    assert_eq!(parse_daemon_option("option --max-verbosity"), Some("--max-verbosity"));
+}
+
+#[test]
+fn parse_daemon_option_rejects_invalid_values() {
+    assert!(parse_daemon_option("HELLO there").is_none());
+    assert!(parse_daemon_option("OPTION   ").is_none());
+}
+
+#[test]
+fn canonical_option_trims_prefix_and_normalises_case() {
+    assert_eq!(canonical_option("--Delete"), "delete");
+    assert_eq!(canonical_option(" -P --info"), "p");
+    assert_eq!(canonical_option("   CHECKSUM=md5"), "checksum");
+}
+
+#[test]
+fn configured_fallback_binary_defaults_to_upstream_branding() {
+    let _daemon_guard = EnvGuard::unset(DAEMON_FALLBACK_ENV);
+    let _client_guard = EnvGuard::unset(CLIENT_FALLBACK_ENV);
+    let expected = OsString::from(Brand::Upstream.client_program_name());
+    assert_eq!(configured_fallback_binary(), Some(expected));
+}
+
+#[test]
+fn configured_fallback_binary_prefers_daemon_override() {
+    let override_path = OsString::from("/opt/oc-rsync");
+    let _client_guard = EnvGuard::unset(CLIENT_FALLBACK_ENV);
+    let _daemon_guard = EnvGuard::set(DAEMON_FALLBACK_ENV, &override_path);
+    assert_eq!(configured_fallback_binary(), Some(override_path));
+}
+
+#[test]
+fn configured_fallback_binary_allows_default_keyword() {
+    let _daemon_guard = EnvGuard::unset(DAEMON_FALLBACK_ENV);
+    let _client_guard = EnvGuard::set(CLIENT_FALLBACK_ENV, OsStr::new("default"));
+    let expected = OsString::from(Brand::Upstream.client_program_name());
+    assert_eq!(configured_fallback_binary(), Some(expected));
+}

--- a/crates/engine/src/local_copy/dir_merge/parse.rs
+++ b/crates/engine/src/local_copy/dir_merge/parse.rs
@@ -6,6 +6,7 @@ use std::error::Error;
 use std::fmt;
 use std::path::PathBuf;
 
+#[derive(Debug)]
 pub(crate) enum ParsedFilterDirective {
     Rule(FilterRule),
     Merge {

--- a/crates/engine/src/local_copy/executor/file.rs
+++ b/crates/engine/src/local_copy/executor/file.rs
@@ -1102,7 +1102,7 @@ impl DestinationWriteGuard {
         }
     }
 
-    fn staging_path(&self) -> &Path {
+    pub(crate) fn staging_path(&self) -> &Path {
         &self.temp_path
     }
 
@@ -1135,7 +1135,7 @@ impl DestinationWriteGuard {
         Ok(())
     }
 
-    fn final_path(&self) -> &Path {
+    pub(crate) fn final_path(&self) -> &Path {
         &self.final_path
     }
 

--- a/crates/engine/src/local_copy/mod.rs
+++ b/crates/engine/src/local_copy/mod.rs
@@ -103,6 +103,8 @@ pub use filter_program::{
     DirMergeEnforcedKind, DirMergeOptions, DirMergeRule, ExcludeIfPresentRule, FilterProgram,
     FilterProgramEntry, FilterProgramError,
 };
+#[cfg(test)]
+pub(crate) use filter_program::{FilterContext, FilterSegment};
 
 use std::sync::atomic::AtomicUsize;
 
@@ -121,7 +123,7 @@ const CROSS_DEVICE_ERROR_CODE: i32 = 18;
 #[cfg(test)]
 pub(crate) fn with_hard_link_override<F, R>(override_fn: F, action: impl FnOnce() -> R) -> R
 where
-    F: Fn(&Path, &Path) -> std::io::Result<()> + 'static,
+    F: Fn(&std::path::Path, &std::path::Path) -> std::io::Result<()> + 'static,
 {
     overrides::with_hard_link_override(override_fn, action)
 }
@@ -129,7 +131,7 @@ where
 #[cfg(test)]
 pub(crate) fn with_device_id_override<F, R>(override_fn: F, action: impl FnOnce() -> R) -> R
 where
-    F: Fn(&Path, &fs::Metadata) -> Option<u64> + 'static,
+    F: Fn(&std::path::Path, &std::fs::Metadata) -> Option<u64> + 'static,
 {
     overrides::with_device_id_override(override_fn, action)
 }

--- a/crates/engine/src/local_copy/tests/dest_guard.rs
+++ b/crates/engine/src/local_copy/tests/dest_guard.rs
@@ -10,7 +10,7 @@ fn destination_write_guard_uses_custom_partial_directory() {
     let (guard, mut file) =
         DestinationWriteGuard::new(destination.as_path(), true, Some(partial_dir), None)
             .expect("guard");
-    let temp_path = guard.temp_path.clone();
+    let temp_path = guard.staging_path().to_path_buf();
     file.write_all(b"partial payload").expect("write partial");
     drop(file);
 
@@ -37,7 +37,7 @@ fn destination_write_guard_commit_moves_from_partial_directory() {
         None,
     )
     .expect("guard");
-    let temp_path = guard.temp_path.clone();
+    let temp_path = guard.staging_path().to_path_buf();
     file.write_all(b"committed payload").expect("write payload");
     drop(file);
 

--- a/crates/engine/src/local_copy/tests/mod.rs
+++ b/crates/engine/src/local_copy/tests/mod.rs
@@ -1,10 +1,15 @@
 use super::*;
+use crate::signature::SignatureAlgorithm;
 use filetime::{FileTime, set_file_mtime, set_file_times};
-use std::ffi::OsString;
+use rsync_bandwidth::BandwidthLimiter;
+use rsync_compress::zlib::CompressionLevel;
+use rsync_filters::{FilterRule, FilterSet};
+use rsync_meta::{ChmodModifiers, MetadataOptions};
+use std::ffi::{OsStr, OsString};
 use std::fs;
 use std::io::{self, Seek, SeekFrom, Write};
 use std::num::{NonZeroU8, NonZeroU64};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::thread;
 use std::time::Duration;
 use tempfile::tempdir;


### PR DESCRIPTION
## Summary
- derive `Debug` for parsed filter directives so the local copy tests can snapshot filter parsing
- expose destination guard accessors and adjust engine tests to use the public helpers
- add daemon module parsing and fallback unit tests and document the shared environment guard pattern

## Testing
- cargo test --locked -p rsync-engine --lib
- cargo test --locked -p rsync-daemon --lib

------