### PR TITLE
Enforce internal docs branding metadata validation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,15 @@ This document defines the internal actors (“agents”), their responsibilities
 
 ## Global Conventions
 
+- **Canonical branding metadata** is sourced from `[workspace.metadata.oc_rsync]`
+  in `Cargo.toml`. The branded binaries are **`oc-rsync`** and **`oc-rsyncd`**,
+  the daemon configuration lives under `/etc/oc-rsyncd/` (for example
+  `/etc/oc-rsyncd/oc-rsyncd.conf` and `/etc/oc-rsyncd/oc-rsyncd.secrets`), the
+  published version string is `3.4.1-rust`, and the authoritative source
+  repository URL is <https://github.com/oferchen/rsync>. Any user-facing surface
+  (rustdoc examples, CLI help, documentation, packaging manifests, CI logs) must
+  derive these values from the shared metadata via the `xtask branding` helpers
+  or equivalent library APIs rather than hard-coding constants.
 - **Error Message Suffix (C→Rust remap)**:
   Format: `... (code N) at <repo-rel-path>:<line> [<role>=3.4.1-rust]`
   Implemented in `crates/core/src/message.rs` via:
@@ -36,10 +45,11 @@ This document defines the internal actors (“agents”), their responsibilities
 - **CI workflow contract**: `.github/workflows/ci.yml` runs the primary test
   job (`test-linux`) exclusively on Linux and a dedicated cross-compilation
   matrix covering Linux (x86_64/aarch64), macOS (x86_64/aarch64), and Windows
-  (x86_64). The Windows x86 and Windows aarch64 entries remain in the matrix
-  but stay disabled for future enablement. Automation inside CI steps must rely
-  on Rust tooling (`cargo`, `cargo xtask`) rather than ad-hoc shell or Python
-  scripts.
+  (x86_64). The Windows x86 and Windows aarch64 entries remain in the matrix as
+  disabled placeholders for future enablement. Automation inside CI steps must
+  rely on Rust tooling (`cargo`, `cargo xtask`) rather than ad-hoc shell or
+  Python scripts, and additional validation/packaging logic should be surfaced
+  via `xtask` subcommands so both local and CI runs stay in sync.
 
 ---
 

--- a/xtask/src/commands/docs.rs
+++ b/xtask/src/commands/docs.rs
@@ -160,6 +160,19 @@ fn validate_documents(workspace: &Path) -> TaskResult<()> {
                 (branding.daemon_bin.as_str(), "daemon binary name"),
             ],
         ),
+        DocumentCheck::new(
+            workspace.join("AGENTS.md"),
+            [
+                (
+                    branding.rust_version.as_str(),
+                    "Rust-branded version string",
+                ),
+                (branding.client_bin.as_str(), "client binary name"),
+                (branding.daemon_bin.as_str(), "daemon binary name"),
+                (daemon_config.as_str(), "daemon configuration path"),
+                (branding.source.as_str(), "source repository URL"),
+            ],
+        ),
     ];
 
     let mut failures = Vec::new();
@@ -392,6 +405,7 @@ windows = ["x86_64"]
         fs::write(workspace.join("docs").join("gaps.md"), "placeholder").expect("write gaps");
         fs::write(workspace.join("docs").join("resume_note.md"), "placeholder")
             .expect("write resume note");
+        fs::write(workspace.join("AGENTS.md"), "placeholder").expect("write agents");
 
         let error = validate_documents(&workspace).expect_err("validation should fail");
         match error {
@@ -402,6 +416,7 @@ windows = ["x86_64"]
                 assert!(message.contains("differences.md"), "{message}");
                 assert!(message.contains("gaps.md"), "{message}");
                 assert!(message.contains("resume_note.md"), "{message}");
+                assert!(message.contains("AGENTS.md"), "{message}");
             }
             other => panic!("unexpected error: {other}"),
         }


### PR DESCRIPTION
## Summary
- document the shared branding contract in internal docs so contributors reuse the workspace metadata for binaries, config paths, and source URL
- extend the xtask docs validator to assert internal docs carries the expected branding fragments alongside the existing Markdown checks
- cover the new validation path with unit tests to ensure failures surface the internal docs file when metadata is missing

## Testing
- cargo test -p xtask

------