### PR TITLE
Remove redundant delay_updates builder call

### DIFF
--- a/crates/cli/src/frontend/execution.rs
+++ b/crates/cli/src/frontend/execution.rs
@@ -1034,7 +1034,6 @@ where
         .debug_flags(debug_flags_list.clone())
         .partial(partial)
         .preallocate(preallocate)
-        .delay_updates(delay_updates)
         .partial_directory(partial_dir.clone())
         .temp_directory(temp_dir.clone())
         .delay_updates(delay_updates)


### PR DESCRIPTION
## Summary
- remove the duplicate `delay_updates` setter while constructing the client configuration to avoid redundant work during local execution

## Testing
- not run (not requested)

------