### PR TITLE
Tighten docs validation with branded compare checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,11 @@ This document defines the internal actors (“agents”), their responsibilities
   matrix entry advertises the expected `target`, `build_command`,
   `build_daemon`, `uses_zig`, `needs_cross_gcc`, and `generate_sbom` values for
   its platform. Contributors must update both the manifest metadata and CI
-  matrix together so the validation continues to pass.
+  matrix together so the validation continues to pass. The same validation pass
+  also enforces that `docs/COMPARE.md` references the branded `oc-rsync`
+  binaries, daemon configuration path (`/etc/oc-rsyncd/oc-rsyncd.conf`), and
+  published version string (`3.4.1-rust`) sourced from workspace metadata so
+  release documentation remains consistent with packaged artifacts.
 
 ---
 

--- a/xtask/src/commands/docs.rs
+++ b/xtask/src/commands/docs.rs
@@ -143,6 +143,18 @@ fn validate_documents(workspace: &Path) -> TaskResult<()> {
             [(branding.daemon_bin.as_str(), "daemon binary name")],
         ),
         DocumentCheck::new(
+            docs_dir.join("COMPARE.md"),
+            [
+                (
+                    branding.rust_version.as_str(),
+                    "Rust-branded version string",
+                ),
+                (branding.client_bin.as_str(), "client binary name"),
+                (branding.daemon_bin.as_str(), "daemon binary name"),
+                (daemon_config.as_str(), "daemon configuration path"),
+            ],
+        ),
+        DocumentCheck::new(
             docs_dir.join("gaps.md"),
             [
                 (branding.client_bin.as_str(), "client binary name"),
@@ -968,6 +980,8 @@ windows = ["x86_64"]
         .expect("write feature matrix");
         fs::write(workspace.join("docs").join("differences.md"), "placeholder")
             .expect("write differences");
+        fs::write(workspace.join("docs").join("COMPARE.md"), "placeholder")
+            .expect("write compare log");
         fs::write(workspace.join("docs").join("gaps.md"), "placeholder").expect("write gaps");
         fs::write(workspace.join("docs").join("resume_note.md"), "placeholder")
             .expect("write resume note");
@@ -1007,6 +1021,7 @@ windows = ["x86_64"]
                 assert!(message.contains("feature_matrix.md"), "{message}");
                 assert!(message.contains("differences.md"), "{message}");
                 assert!(message.contains("gaps.md"), "{message}");
+                assert!(message.contains("COMPARE.md"), "{message}");
                 assert!(message.contains("resume_note.md"), "{message}");
                 assert!(message.contains("AGENTS.md"), "{message}");
             }


### PR DESCRIPTION
## Summary
- extend `cargo xtask docs --validate` so it verifies `docs/COMPARE.md` references the branded binaries, daemon configuration path, and published version string
- update `internal docs` to document the new branding enforcement for the parity log
- adjust the documentation validation tests to include the new requirement

## Testing
- cargo test -p xtask

------