### PR TITLE
Fix local copy docs and clean clippy warnings

### DIFF
--- a/crates/cli/src/frontend/arguments.rs
+++ b/crates/cli/src/frontend/arguments.rs
@@ -471,10 +471,7 @@ where
         .remove_many::<OsString>("link-dest")
         .map(|values| values.collect())
         .unwrap_or_default();
-    let link_dests = link_dest_args
-        .iter()
-        .map(|value| PathBuf::from(value))
-        .collect();
+    let link_dests = link_dest_args.iter().map(PathBuf::from).collect();
     let link_destinations = link_dest_args;
     let remove_source_files =
         matches.get_flag("remove-source-files") || matches.get_flag("remove-sent-files");

--- a/crates/core/src/client/fallback/runner/command_builder.rs
+++ b/crates/core/src/client/fallback/runner/command_builder.rs
@@ -644,7 +644,7 @@ fn candidate_is_executable(path: &Path) -> bool {
         use std::os::unix::fs::PermissionsExt;
 
         let mode = metadata.permissions().mode();
-        return mode & 0o111 != 0;
+        mode & 0o111 != 0
     }
 
     #[cfg(not(unix))]

--- a/crates/daemon/src/daemon.rs
+++ b/crates/daemon/src/daemon.rs
@@ -29,9 +29,6 @@ use std::sync::{
 use std::thread;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-#[cfg(test)]
-use std::time::Instant;
-
 use std::process::{ChildStdin, Command as ProcessCommand, Stdio};
 
 use base64::Engine as _;

--- a/crates/daemon/src/daemon/module_state.rs
+++ b/crates/daemon/src/daemon/module_state.rs
@@ -60,16 +60,6 @@ impl ModuleDefinition {
         self.max_connections
     }
 
-    #[cfg(test)]
-    fn auth_users(&self) -> &[String] {
-        &self.auth_users
-    }
-
-    #[cfg(test)]
-    fn secrets_file(&self) -> Option<&Path> {
-        self.secrets_file.as_deref()
-    }
-
     fn bandwidth_limit(&self) -> Option<NonZeroU64> {
         self.bandwidth_limit
     }
@@ -90,55 +80,58 @@ impl ModuleDefinition {
         self.bandwidth_limit_configured
     }
 
-    #[cfg(test)]
-    fn name(&self) -> &str {
-        &self.name
-    }
-
-    #[cfg(test)]
-    fn refused_options(&self) -> &[String] {
-        &self.refuse_options
-    }
-
-    #[cfg(test)]
-    fn read_only(&self) -> bool {
-        self.read_only
-    }
-
-    #[cfg(test)]
-    fn numeric_ids(&self) -> bool {
-        self.numeric_ids
-    }
-
-    #[cfg(test)]
-    fn uid(&self) -> Option<u32> {
-        self.uid
-    }
-
-    #[cfg(test)]
-    fn gid(&self) -> Option<u32> {
-        self.gid
-    }
-
-    #[cfg(test)]
-    fn timeout(&self) -> Option<NonZeroU64> {
-        self.timeout
-    }
-
-    #[cfg(test)]
-    fn listable(&self) -> bool {
-        self.listable
-    }
-
-    #[cfg(test)]
-    fn use_chroot(&self) -> bool {
-        self.use_chroot
-    }
-
     fn inherit_refuse_options(&mut self, options: &[String]) {
         if self.refuse_options.is_empty() {
             self.refuse_options = options.to_vec();
         }
+    }
+}
+
+#[cfg(test)]
+#[allow(dead_code)]
+impl ModuleDefinition {
+    pub(super) fn auth_users(&self) -> &[String] {
+        &self.auth_users
+    }
+
+    pub(super) fn secrets_file(&self) -> Option<&Path> {
+        self.secrets_file.as_deref()
+    }
+
+    pub(super) fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub(super) fn refused_options(&self) -> &[String] {
+        &self.refuse_options
+    }
+
+    pub(super) fn read_only(&self) -> bool {
+        self.read_only
+    }
+
+    pub(super) fn numeric_ids(&self) -> bool {
+        self.numeric_ids
+    }
+
+    pub(super) fn uid(&self) -> Option<u32> {
+        self.uid
+    }
+
+    pub(super) fn gid(&self) -> Option<u32> {
+        self.gid
+    }
+
+    pub(super) fn timeout(&self) -> Option<NonZeroU64> {
+        self.timeout
+    }
+
+    pub(super) fn listable(&self) -> bool {
+        self.listable
+    }
+
+    pub(super) fn use_chroot(&self) -> bool {
+        self.use_chroot
     }
 }
 
@@ -460,6 +453,7 @@ pub(super) struct TestSecretsEnvOverride {
 }
 
 #[cfg(test)]
+#[allow(dead_code)]
 fn set_test_hostname_override(addr: IpAddr, hostname: Option<&str>) {
     TEST_HOSTNAME_OVERRIDES.with(|map| {
         map.borrow_mut()
@@ -468,6 +462,7 @@ fn set_test_hostname_override(addr: IpAddr, hostname: Option<&str>) {
 }
 
 #[cfg(test)]
+#[allow(dead_code)]
 fn clear_test_hostname_overrides() {
     TEST_HOSTNAME_OVERRIDES.with(|map| map.borrow_mut().clear());
 }

--- a/crates/daemon/src/daemon/runtime_options.rs
+++ b/crates/daemon/src/daemon/runtime_options.rs
@@ -57,6 +57,7 @@ impl Default for RuntimeOptions {
 
 impl RuntimeOptions {
     #[cfg(test)]
+    #[allow(dead_code)]
     fn parse(arguments: &[OsString]) -> Result<Self, DaemonError> {
         Self::parse_with_brand(arguments, Brand::Oc, true)
     }
@@ -385,61 +386,6 @@ impl RuntimeOptions {
         Ok(())
     }
 
-    #[cfg(test)]
-    fn modules(&self) -> &[ModuleDefinition] {
-        &self.modules
-    }
-
-    #[cfg(test)]
-    fn bandwidth_limit(&self) -> Option<NonZeroU64> {
-        self.bandwidth_limit
-    }
-
-    #[cfg(test)]
-    fn bandwidth_burst(&self) -> Option<NonZeroU64> {
-        self.bandwidth_burst
-    }
-
-    #[cfg(test)]
-    fn bandwidth_limit_configured(&self) -> bool {
-        self.bandwidth_limit_configured
-    }
-
-    #[cfg(test)]
-    fn bind_address(&self) -> IpAddr {
-        self.bind_address
-    }
-
-    #[cfg(test)]
-    fn address_family(&self) -> Option<AddressFamily> {
-        self.address_family
-    }
-
-    #[cfg(test)]
-    fn motd_lines(&self) -> &[String] {
-        &self.motd_lines
-    }
-
-    #[cfg(test)]
-    fn log_file(&self) -> Option<&PathBuf> {
-        self.log_file.as_ref()
-    }
-
-    #[cfg(test)]
-    fn pid_file(&self) -> Option<&Path> {
-        self.pid_file.as_deref()
-    }
-
-    #[cfg(test)]
-    fn reverse_lookup(&self) -> bool {
-        self.reverse_lookup
-    }
-
-    #[cfg(test)]
-    fn lock_file(&self) -> Option<&Path> {
-        self.lock_file.as_deref()
-    }
-
     fn inherit_global_refuse_options(
         &mut self,
         options: Vec<String>,
@@ -575,6 +521,54 @@ impl RuntimeOptions {
             .trim_matches(['\r', '\n'])
             .to_string();
         self.motd_lines.push(line);
+    }
+}
+
+#[cfg(test)]
+#[allow(dead_code)]
+impl RuntimeOptions {
+    pub(super) fn modules(&self) -> &[ModuleDefinition] {
+        &self.modules
+    }
+
+    pub(super) fn bandwidth_limit(&self) -> Option<NonZeroU64> {
+        self.bandwidth_limit
+    }
+
+    pub(super) fn bandwidth_burst(&self) -> Option<NonZeroU64> {
+        self.bandwidth_burst
+    }
+
+    pub(super) fn bandwidth_limit_configured(&self) -> bool {
+        self.bandwidth_limit_configured
+    }
+
+    pub(super) fn bind_address(&self) -> IpAddr {
+        self.bind_address
+    }
+
+    pub(super) fn address_family(&self) -> Option<AddressFamily> {
+        self.address_family
+    }
+
+    pub(super) fn motd_lines(&self) -> &[String] {
+        &self.motd_lines
+    }
+
+    pub(super) fn log_file(&self) -> Option<&PathBuf> {
+        self.log_file.as_ref()
+    }
+
+    pub(super) fn pid_file(&self) -> Option<&Path> {
+        self.pid_file.as_deref()
+    }
+
+    pub(super) fn reverse_lookup(&self) -> bool {
+        self.reverse_lookup
+    }
+
+    pub(super) fn lock_file(&self) -> Option<&Path> {
+        self.lock_file.as_deref()
     }
 }
 

--- a/crates/daemon/src/daemon/sections/cli_args.rs
+++ b/crates/daemon/src/daemon/sections/cli_args.rs
@@ -30,7 +30,6 @@ fn detect_program_name(program: Option<&OsStr>) -> ProgramName {
 }
 
 /// Parsed command produced by [`parse_args`].
-/// Parsed command produced by [`parse_args`].
 pub(crate) struct ParsedArgs {
     pub(crate) program_name: ProgramName,
     pub(crate) show_help: bool,
@@ -39,8 +38,7 @@ pub(crate) struct ParsedArgs {
     pub(crate) remainder: Vec<OsString>,
 }
 
-/// Parsed command produced by [`parse_args`].
-
+/// Internal helper constructing the clap command used by [`parse_args`].
 fn clap_command(program_name: &'static str) -> Command {
     Command::new(program_name)
         .disable_help_flag(true)

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -63,7 +63,7 @@
 //! - `run` never panics. I/O failures propagate as exit code `1` with the
 //!   original error rendered verbatim.
 //! - [`DaemonError::exit_code`] always matches the exit code embedded within the
-//!   associated [`Message`].
+//!   associated [`rsync_core::message::Message`].
 //! - `run_daemon` configures read and write timeouts on accepted sockets so
 //!   handshake deadlocks are avoided, mirroring upstream rsync's timeout
 //!   handling expectations.

--- a/crates/daemon/src/tests.rs
+++ b/crates/daemon/src/tests.rs
@@ -10,7 +10,7 @@ use std::num::{NonZeroU32, NonZeroU64};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Barrier};
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tempfile::{NamedTempFile, tempdir};
 
 mod support;

--- a/crates/engine/src/local_copy/executor/directory.rs
+++ b/crates/engine/src/local_copy/executor/directory.rs
@@ -9,6 +9,10 @@ use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
 use crate::local_copy::overrides::device_identifier;
+#[cfg(feature = "acl")]
+use crate::local_copy::sync_acls_if_requested;
+#[cfg(feature = "xattr")]
+use crate::local_copy::sync_xattrs_if_requested;
 use crate::local_copy::{
     CopyContext, CreatedEntryKind, DeleteTiming, LocalCopyAction, LocalCopyArgumentError,
     LocalCopyError, LocalCopyMetadata, LocalCopyRecord, copy_device, copy_fifo, copy_file,

--- a/crates/engine/src/local_copy/plan/plan_impl.rs
+++ b/crates/engine/src/local_copy/plan/plan_impl.rs
@@ -33,9 +33,9 @@ impl LocalCopyPlan {
     ///
     /// # Errors
     ///
-    /// Returns [`LocalCopyErrorKind::MissingSourceOperands`] when fewer than two
+    /// Returns [`crate::local_copy::LocalCopyErrorKind::MissingSourceOperands`] when fewer than two
     /// operands are supplied. Empty operands and invalid destination states are
-    /// reported via [`LocalCopyErrorKind::InvalidArgument`].
+    /// reported via [`crate::local_copy::LocalCopyErrorKind::InvalidArgument`].
     ///
     /// # Examples
     ///


### PR DESCRIPTION
## Summary
- restore conditional imports for local copy metadata sync helpers so doc builds compile without feature flags
- clarify intra-doc links for local copy planning docs and daemon crate invariants
- clean clippy findings across CLI, fallback runner, and daemon modules while isolating test-only helpers

## Testing
- cargo clippy --workspace --all-targets --all-features --locked -- -Dwarnings
- cargo doc --workspace --no-deps

------