### PR TITLE
Refine copy dry-run and CLI execution helpers

### DIFF
--- a/crates/cli/src/frontend/execution/drive/config.rs
+++ b/crates/cli/src/frontend/execution/drive/config.rs
@@ -116,7 +116,7 @@ pub(crate) fn build_base_config(mut inputs: ConfigInputs) -> ClientConfigBuilder
         .backup(inputs.backup)
         .backup_directory(inputs.backup_dir.clone())
         .backup_suffix(inputs.backup_suffix.clone())
-        .bandwidth_limit(inputs.bandwidth_limit.clone())
+        .bandwidth_limit(inputs.bandwidth_limit)
         .compression_setting(inputs.compression_setting)
         .compress(inputs.compress)
         .compression_level(inputs.compression_level_override)

--- a/crates/cli/src/frontend/execution/drive/fallback.rs
+++ b/crates/cli/src/frontend/execution/drive/fallback.rs
@@ -116,9 +116,9 @@ pub(crate) struct FallbackInputs {
     pub(crate) rsync_path: Option<OsString>,
     pub(crate) remainder: Vec<OsString>,
     #[cfg(feature = "acl")]
-    pub(crate) acls: bool,
+    pub(crate) acls: Option<bool>,
     #[cfg(feature = "xattr")]
-    pub(crate) xattrs: bool,
+    pub(crate) xattrs: Option<bool>,
     pub(crate) itemize_changes: bool,
 }
 

--- a/crates/cli/src/frontend/execution/drive/metadata.rs
+++ b/crates/cli/src/frontend/execution/drive/metadata.rs
@@ -26,28 +26,54 @@ pub(crate) struct MetadataSettings {
     pub(crate) chmod_modifiers: Option<ChmodModifiers>,
 }
 
+#[allow(clippy::struct_excessive_bools)]
+pub(crate) struct MetadataSettingsInputs<'a> {
+    pub(crate) archive: bool,
+    pub(crate) parsed_chown: Option<&'a ParsedChown>,
+    pub(crate) owner: Option<bool>,
+    pub(crate) group: Option<bool>,
+    pub(crate) perms: Option<bool>,
+    pub(crate) super_mode: Option<bool>,
+    pub(crate) times: Option<bool>,
+    pub(crate) omit_dir_times: Option<bool>,
+    pub(crate) omit_link_times: Option<bool>,
+    pub(crate) devices: Option<bool>,
+    pub(crate) specials: Option<bool>,
+    pub(crate) hard_links: Option<bool>,
+    pub(crate) sparse: Option<bool>,
+    pub(crate) copy_links: Option<bool>,
+    pub(crate) copy_unsafe_links: Option<bool>,
+    pub(crate) keep_dirlinks: Option<bool>,
+    pub(crate) relative: Option<bool>,
+    pub(crate) one_file_system: Option<bool>,
+    pub(crate) chmod: &'a [OsString],
+}
+
 /// Computes metadata preservation flags according to upstream semantics.
 pub(crate) fn compute_metadata_settings(
-    archive: bool,
-    parsed_chown: Option<&ParsedChown>,
-    owner: Option<bool>,
-    group: Option<bool>,
-    perms: Option<bool>,
-    super_mode: Option<bool>,
-    times: Option<bool>,
-    omit_dir_times: Option<bool>,
-    omit_link_times: Option<bool>,
-    devices: Option<bool>,
-    specials: Option<bool>,
-    hard_links: Option<bool>,
-    sparse: Option<bool>,
-    copy_links: Option<bool>,
-    copy_unsafe_links: Option<bool>,
-    keep_dirlinks: Option<bool>,
-    relative: Option<bool>,
-    one_file_system: Option<bool>,
-    chmod: &[OsString],
+    inputs: MetadataSettingsInputs<'_>,
 ) -> Result<MetadataSettings, rsync_core::message::Message> {
+    let MetadataSettingsInputs {
+        archive,
+        parsed_chown,
+        owner,
+        group,
+        perms,
+        super_mode,
+        times,
+        omit_dir_times,
+        omit_link_times,
+        devices,
+        specials,
+        hard_links,
+        sparse,
+        copy_links,
+        copy_unsafe_links,
+        keep_dirlinks,
+        relative,
+        one_file_system,
+        chmod,
+    } = inputs;
     let preserve_owner = if parsed_chown.and_then(|value| value.owner()).is_some() {
         true
     } else if let Some(value) = owner {

--- a/crates/cli/src/frontend/execution/drive/module_listing.rs
+++ b/crates/cli/src/frontend/execution/drive/module_listing.rs
@@ -13,25 +13,43 @@ use crate::frontend::{
     execution::render_module_list, password::load_optional_password, write_message,
 };
 
+pub(super) struct ModuleListingInputs<'a> {
+    pub(crate) file_list_operands: &'a [OsString],
+    pub(crate) remainder: &'a [OsString],
+    pub(crate) daemon_port: Option<u16>,
+    pub(crate) desired_protocol: Option<ProtocolVersion>,
+    pub(crate) password_file: Option<&'a Path>,
+    pub(crate) no_motd: bool,
+    pub(crate) address_mode: AddressMode,
+    pub(crate) bind_address: Option<&'a BindAddress>,
+    pub(crate) connect_program: Option<&'a OsString>,
+    pub(crate) timeout_setting: TransferTimeout,
+    pub(crate) connect_timeout_setting: TransferTimeout,
+}
+
 pub(super) fn maybe_handle_module_listing<Out, Err>(
-    file_list_operands: &[OsString],
-    remainder: &[OsString],
-    daemon_port: Option<u16>,
-    desired_protocol: Option<ProtocolVersion>,
-    password_file: Option<&Path>,
-    no_motd: bool,
-    address_mode: AddressMode,
-    bind_address: Option<&BindAddress>,
-    connect_program: Option<&OsString>,
-    timeout_setting: TransferTimeout,
-    connect_timeout_setting: TransferTimeout,
     stdout: &mut Out,
     stderr: &mut MessageSink<Err>,
+    inputs: ModuleListingInputs<'_>,
 ) -> Option<i32>
 where
     Out: Write,
     Err: Write,
 {
+    let ModuleListingInputs {
+        file_list_operands,
+        remainder,
+        daemon_port,
+        desired_protocol,
+        password_file,
+        no_motd,
+        address_mode,
+        bind_address,
+        connect_program,
+        timeout_setting,
+        connect_timeout_setting,
+    } = inputs;
+
     if !file_list_operands.is_empty() {
         return None;
     }

--- a/crates/cli/src/frontend/execution/drive/options.rs
+++ b/crates/cli/src/frontend/execution/drive/options.rs
@@ -73,7 +73,7 @@ pub(crate) struct DerivedSettings {
 /// Outcome of parsing additional execution settings.
 pub(crate) enum SettingsOutcome {
     /// Parsing produced fully-resolved settings.
-    Proceed(DerivedSettings),
+    Proceed(Box<DerivedSettings>),
     /// Parsing requested an early exit with the supplied exit code.
     Exit(i32),
 }
@@ -274,7 +274,7 @@ where
         }
     }
 
-    SettingsOutcome::Proceed(DerivedSettings {
+    SettingsOutcome::Proceed(Box::new(DerivedSettings {
         out_format_template,
         fallback_out_format,
         progress_setting,
@@ -295,5 +295,5 @@ where
         compress_level_cli,
         skip_compress_list,
         compression_setting,
-    })
+    }))
 }

--- a/crates/cli/src/frontend/execution/drive/summary.rs
+++ b/crates/cli/src/frontend/execution/drive/summary.rs
@@ -19,27 +19,44 @@ use crate::frontend::{
 use super::messages::emit_message_with_fallback;
 use super::with_output_writer;
 
+pub(crate) struct TransferExecutionOptions<'a> {
+    pub(crate) msgs_to_stderr: bool,
+    pub(crate) progress_mode: Option<ProgressMode>,
+    pub(crate) human_readable_mode: HumanReadableMode,
+    pub(crate) itemize_changes: bool,
+    pub(crate) stats: bool,
+    pub(crate) verbosity: u8,
+    pub(crate) list_only: bool,
+    pub(crate) out_format_template: Option<&'a crate::frontend::out_format::OutFormat>,
+    pub(crate) name_level: NameOutputLevel,
+    pub(crate) name_overridden: bool,
+}
+
 /// Drives the client transfer, handling optional fallback execution and final summaries.
 pub(crate) fn execute_transfer<Out, Err>(
     config: ClientConfig,
     fallback_args: Option<RemoteFallbackArgs>,
     stdout: &mut Out,
     stderr: &mut MessageSink<Err>,
-    msgs_to_stderr: bool,
-    progress_mode: Option<ProgressMode>,
-    human_readable_mode: HumanReadableMode,
-    itemize_changes: bool,
-    stats: bool,
-    verbosity: u8,
-    list_only: bool,
-    out_format_template: Option<&crate::frontend::out_format::OutFormat>,
-    name_level: NameOutputLevel,
-    name_overridden: bool,
+    options: TransferExecutionOptions<'_>,
 ) -> i32
 where
     Out: Write,
     Err: Write,
 {
+    let TransferExecutionOptions {
+        msgs_to_stderr,
+        progress_mode,
+        human_readable_mode,
+        itemize_changes,
+        stats,
+        verbosity,
+        list_only,
+        out_format_template,
+        name_level,
+        name_overridden,
+    } = options;
+
     if let Some(args) = fallback_args {
         let outcome = {
             let mut stderr_writer = stderr.writer_mut();

--- a/crates/cli/src/frontend/execution/drive/validation.rs
+++ b/crates/cli/src/frontend/execution/drive/validation.rs
@@ -8,7 +8,7 @@ use rsync_protocol::ProtocolVersion;
 
 use crate::frontend::write_message;
 
-pub(super) fn validate_local_only_options<Err: Write>(
+pub(super) fn validate_local_only_options<Err>(
     fallback_required: bool,
     desired_protocol: Option<ProtocolVersion>,
     password_file: Option<&PathBuf>,

--- a/crates/cli/src/frontend/execution/drive/workflow/fallback_plan.rs
+++ b/crates/cli/src/frontend/execution/drive/workflow/fallback_plan.rs
@@ -111,9 +111,9 @@ pub(crate) struct FallbackArgumentsContext<'a> {
     pub(crate) rsync_path: Option<&'a OsString>,
     pub(crate) remainder: &'a [OsString],
     #[cfg(feature = "acl")]
-    pub(crate) preserve_acls: bool,
+    pub(crate) preserve_acls: Option<bool>,
     #[cfg(feature = "xattr")]
-    pub(crate) xattrs: bool,
+    pub(crate) xattrs: Option<bool>,
     pub(crate) itemize_changes: bool,
 }
 

--- a/crates/cli/src/frontend/execution/mod.rs
+++ b/crates/cli/src/frontend/execution/mod.rs
@@ -13,6 +13,8 @@ pub(crate) use chown::parse_chown_argument;
 pub(crate) use compression::{
     CompressLevelArg, parse_bandwidth_limit, parse_compress_level, parse_compress_level_argument,
 };
+#[cfg(test)]
+pub(crate) use file_list::read_file_list_from_reader;
 pub(crate) use file_list::{load_file_list_operands, transfer_requires_remote};
 pub(crate) use flags::{
     DEBUG_HELP_TEXT, INFO_HELP_TEXT, info_flags_include_progress, parse_debug_flags,
@@ -20,6 +22,8 @@ pub(crate) use flags::{
 };
 pub(crate) use module_list::render_module_list;
 pub(crate) use operands::{extract_operands, parse_bind_address_argument};
+#[cfg(test)]
+pub(crate) use options::{SizeParseError, pow_u128_for_size};
 pub(crate) use options::{
     parse_checksum_seed_argument, parse_human_readable_level, parse_max_delete_argument,
     parse_modify_window_argument, parse_protocol_version_arg, parse_size_limit_argument,

--- a/crates/engine/src/local_copy/executor/file/copy/dry_run.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/dry_run.rs
@@ -17,9 +17,9 @@ pub(super) fn handle_dry_run(
     record_path: &Path,
     existing_metadata: Option<&fs::Metadata>,
     destination_previously_existed: bool,
-    file_size: u64,
-    file_type: fs::FileType,
 ) -> Result<(), LocalCopyError> {
+    let file_size = metadata.len();
+    let file_type = metadata.file_type();
     if context.update_enabled() {
         if let Some(existing) = existing_metadata {
             if super::super::comparison::destination_is_newer(metadata, existing) {

--- a/crates/engine/src/local_copy/executor/file/copy/mod.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/mod.rs
@@ -84,8 +84,6 @@ pub(crate) fn copy_file(
             record_path.as_path(),
             existing_metadata.as_ref(),
             destination_previously_existed,
-            file_size,
-            file_type,
         )?;
         return Ok(());
     }

--- a/crates/engine/src/local_copy/executor/file/mod.rs
+++ b/crates/engine/src/local_copy/executor/file/mod.rs
@@ -18,7 +18,5 @@ pub(crate) use guard::{DestinationWriteGuard, remove_existing_destination};
 #[cfg(test)]
 pub(crate) use paths::partial_destination_path;
 #[cfg(test)]
-pub(crate) use paths::partial_directory_destination_path;
-#[cfg(test)]
 pub(crate) use preallocate::maybe_preallocate_destination;
 pub(crate) use sparse::write_sparse_chunk;


### PR DESCRIPTION
## Summary
- streamline the file copy dry-run path by computing metadata locally and removing unused test-only exports
- refactor CLI execution helpers to bundle parameters into dedicated structs, adjust fallback option types, and box large derived settings for clippy compliance
- re-export internal helpers for tests when building all targets under clippy

## Testing
- cargo clippy --workspace --all-targets --all-features --locked -- -Dwarnings

------