### PR TITLE
Refine dry-run handling and reduce CLI lint warnings

### DIFF
--- a/crates/cli/src/frontend/execution/drive/config.rs
+++ b/crates/cli/src/frontend/execution/drive/config.rs
@@ -116,7 +116,7 @@ pub(crate) fn build_base_config(mut inputs: ConfigInputs) -> ClientConfigBuilder
         .backup(inputs.backup)
         .backup_directory(inputs.backup_dir.clone())
         .backup_suffix(inputs.backup_suffix.clone())
-        .bandwidth_limit(inputs.bandwidth_limit.clone())
+        .bandwidth_limit(inputs.bandwidth_limit.take())
         .compression_setting(inputs.compression_setting)
         .compress(inputs.compress)
         .compression_level(inputs.compression_level_override)

--- a/crates/cli/src/frontend/execution/drive/fallback.rs
+++ b/crates/cli/src/frontend/execution/drive/fallback.rs
@@ -254,9 +254,9 @@ where
         rsync_path: inputs.rsync_path,
         remainder: inputs.remainder,
         #[cfg(feature = "acl")]
-        acls: inputs.acls,
+        acls: inputs.acls.then_some(true),
         #[cfg(feature = "xattr")]
-        xattrs: inputs.xattrs,
+        xattrs: inputs.xattrs.then_some(true),
         itemize_changes: inputs.itemize_changes,
     };
 

--- a/crates/cli/src/frontend/execution/drive/metadata.rs
+++ b/crates/cli/src/frontend/execution/drive/metadata.rs
@@ -26,28 +26,53 @@ pub(crate) struct MetadataSettings {
     pub(crate) chmod_modifiers: Option<ChmodModifiers>,
 }
 
+pub(crate) struct MetadataInputs<'a> {
+    pub(crate) archive: bool,
+    pub(crate) parsed_chown: Option<&'a ParsedChown>,
+    pub(crate) owner: Option<bool>,
+    pub(crate) group: Option<bool>,
+    pub(crate) perms: Option<bool>,
+    pub(crate) super_mode: Option<bool>,
+    pub(crate) times: Option<bool>,
+    pub(crate) omit_dir_times: Option<bool>,
+    pub(crate) omit_link_times: Option<bool>,
+    pub(crate) devices: Option<bool>,
+    pub(crate) specials: Option<bool>,
+    pub(crate) hard_links: Option<bool>,
+    pub(crate) sparse: Option<bool>,
+    pub(crate) copy_links: Option<bool>,
+    pub(crate) copy_unsafe_links: Option<bool>,
+    pub(crate) keep_dirlinks: Option<bool>,
+    pub(crate) relative: Option<bool>,
+    pub(crate) one_file_system: Option<bool>,
+    pub(crate) chmod: &'a [OsString],
+}
+
 /// Computes metadata preservation flags according to upstream semantics.
 pub(crate) fn compute_metadata_settings(
-    archive: bool,
-    parsed_chown: Option<&ParsedChown>,
-    owner: Option<bool>,
-    group: Option<bool>,
-    perms: Option<bool>,
-    super_mode: Option<bool>,
-    times: Option<bool>,
-    omit_dir_times: Option<bool>,
-    omit_link_times: Option<bool>,
-    devices: Option<bool>,
-    specials: Option<bool>,
-    hard_links: Option<bool>,
-    sparse: Option<bool>,
-    copy_links: Option<bool>,
-    copy_unsafe_links: Option<bool>,
-    keep_dirlinks: Option<bool>,
-    relative: Option<bool>,
-    one_file_system: Option<bool>,
-    chmod: &[OsString],
+    inputs: MetadataInputs<'_>,
 ) -> Result<MetadataSettings, rsync_core::message::Message> {
+    let MetadataInputs {
+        archive,
+        parsed_chown,
+        owner,
+        group,
+        perms,
+        super_mode,
+        times,
+        omit_dir_times,
+        omit_link_times,
+        devices,
+        specials,
+        hard_links,
+        sparse,
+        copy_links,
+        copy_unsafe_links,
+        keep_dirlinks,
+        relative,
+        one_file_system,
+        chmod,
+    } = inputs;
     let preserve_owner = if parsed_chown.and_then(|value| value.owner()).is_some() {
         true
     } else if let Some(value) = owner {

--- a/crates/cli/src/frontend/execution/drive/module_listing.rs
+++ b/crates/cli/src/frontend/execution/drive/module_listing.rs
@@ -13,25 +13,43 @@ use crate::frontend::{
     execution::render_module_list, password::load_optional_password, write_message,
 };
 
+pub(super) struct ModuleListingInputs<'a> {
+    pub file_list_operands: &'a [OsString],
+    pub remainder: &'a [OsString],
+    pub daemon_port: Option<u16>,
+    pub desired_protocol: Option<ProtocolVersion>,
+    pub password_file: Option<&'a Path>,
+    pub no_motd: bool,
+    pub address_mode: AddressMode,
+    pub bind_address: Option<&'a BindAddress>,
+    pub connect_program: Option<&'a OsString>,
+    pub timeout_setting: TransferTimeout,
+    pub connect_timeout_setting: TransferTimeout,
+}
+
 pub(super) fn maybe_handle_module_listing<Out, Err>(
-    file_list_operands: &[OsString],
-    remainder: &[OsString],
-    daemon_port: Option<u16>,
-    desired_protocol: Option<ProtocolVersion>,
-    password_file: Option<&Path>,
-    no_motd: bool,
-    address_mode: AddressMode,
-    bind_address: Option<&BindAddress>,
-    connect_program: Option<&OsString>,
-    timeout_setting: TransferTimeout,
-    connect_timeout_setting: TransferTimeout,
     stdout: &mut Out,
     stderr: &mut MessageSink<Err>,
+    inputs: ModuleListingInputs<'_>,
 ) -> Option<i32>
 where
     Out: Write,
     Err: Write,
 {
+    let ModuleListingInputs {
+        file_list_operands,
+        remainder,
+        daemon_port,
+        desired_protocol,
+        password_file,
+        no_motd,
+        address_mode,
+        bind_address,
+        connect_program,
+        timeout_setting,
+        connect_timeout_setting,
+    } = inputs;
+
     if !file_list_operands.is_empty() {
         return None;
     }

--- a/crates/cli/src/frontend/execution/drive/options.rs
+++ b/crates/cli/src/frontend/execution/drive/options.rs
@@ -73,7 +73,7 @@ pub(crate) struct DerivedSettings {
 /// Outcome of parsing additional execution settings.
 pub(crate) enum SettingsOutcome {
     /// Parsing produced fully-resolved settings.
-    Proceed(DerivedSettings),
+    Proceed(Box<DerivedSettings>),
     /// Parsing requested an early exit with the supplied exit code.
     Exit(i32),
 }
@@ -274,7 +274,7 @@ where
         }
     }
 
-    SettingsOutcome::Proceed(DerivedSettings {
+    SettingsOutcome::Proceed(Box::new(DerivedSettings {
         out_format_template,
         fallback_out_format,
         progress_setting,
@@ -295,5 +295,5 @@ where
         compress_level_cli,
         skip_compress_list,
         compression_setting,
-    })
+    }))
 }

--- a/crates/cli/src/frontend/execution/drive/summary.rs
+++ b/crates/cli/src/frontend/execution/drive/summary.rs
@@ -19,27 +19,46 @@ use crate::frontend::{
 use super::messages::emit_message_with_fallback;
 use super::with_output_writer;
 
+pub(crate) struct TransferExecutionInputs<'a> {
+    pub(crate) config: ClientConfig,
+    pub(crate) fallback_args: Option<RemoteFallbackArgs>,
+    pub(crate) msgs_to_stderr: bool,
+    pub(crate) progress_mode: Option<ProgressMode>,
+    pub(crate) human_readable_mode: HumanReadableMode,
+    pub(crate) itemize_changes: bool,
+    pub(crate) stats: bool,
+    pub(crate) verbosity: u8,
+    pub(crate) list_only: bool,
+    pub(crate) out_format_template: Option<&'a crate::frontend::out_format::OutFormat>,
+    pub(crate) name_level: NameOutputLevel,
+    pub(crate) name_overridden: bool,
+}
+
 /// Drives the client transfer, handling optional fallback execution and final summaries.
 pub(crate) fn execute_transfer<Out, Err>(
-    config: ClientConfig,
-    fallback_args: Option<RemoteFallbackArgs>,
     stdout: &mut Out,
     stderr: &mut MessageSink<Err>,
-    msgs_to_stderr: bool,
-    progress_mode: Option<ProgressMode>,
-    human_readable_mode: HumanReadableMode,
-    itemize_changes: bool,
-    stats: bool,
-    verbosity: u8,
-    list_only: bool,
-    out_format_template: Option<&crate::frontend::out_format::OutFormat>,
-    name_level: NameOutputLevel,
-    name_overridden: bool,
+    inputs: TransferExecutionInputs<'_>,
 ) -> i32
 where
     Out: Write,
     Err: Write,
 {
+    let TransferExecutionInputs {
+        config,
+        fallback_args,
+        msgs_to_stderr,
+        progress_mode: requested_progress_mode,
+        human_readable_mode,
+        itemize_changes,
+        stats,
+        verbosity,
+        list_only,
+        out_format_template,
+        name_level,
+        name_overridden,
+    } = inputs;
+
     if let Some(args) = fallback_args {
         let outcome = {
             let mut stderr_writer = stderr.writer_mut();
@@ -64,7 +83,7 @@ where
         };
     }
 
-    let mut live_progress = progress_mode.map(|mode| {
+    let mut live_progress = requested_progress_mode.map(|mode| {
         with_output_writer(stdout, stderr, msgs_to_stderr, |writer| {
             LiveProgress::new(writer, mode, human_readable_mode)
         })
@@ -96,7 +115,7 @@ where
                 emit_transfer_summary(
                     &summary,
                     verbosity,
-                    progress_mode,
+                    requested_progress_mode,
                     stats,
                     progress_rendered_live,
                     list_only,

--- a/crates/cli/src/frontend/execution/drive/validation.rs
+++ b/crates/cli/src/frontend/execution/drive/validation.rs
@@ -8,7 +8,7 @@ use rsync_protocol::ProtocolVersion;
 
 use crate::frontend::write_message;
 
-pub(super) fn validate_local_only_options<Err: Write>(
+pub(super) fn validate_local_only_options<Err>(
     fallback_required: bool,
     desired_protocol: Option<ProtocolVersion>,
     password_file: Option<&PathBuf>,

--- a/crates/cli/src/frontend/execution/drive/workflow/preflight.rs
+++ b/crates/cli/src/frontend/execution/drive/workflow/preflight.rs
@@ -16,7 +16,9 @@ use std::path::{Path, PathBuf};
 use super::super::super::{
     parse_bind_address_argument, parse_protocol_version_arg, parse_timeout_argument,
 };
-use super::super::messages::{fail_with_custom_fallback, fail_with_message};
+#[cfg(any(not(feature = "acl"), not(feature = "xattr")))]
+use super::super::messages::fail_with_custom_fallback;
+use super::super::messages::fail_with_message;
 
 pub(crate) fn validate_stdin_sources_conflict<Err>(
     password_file: &Option<PathBuf>,
@@ -130,6 +132,7 @@ pub(crate) fn validate_feature_support<Err>(
 where
     Err: Write,
 {
+    let _ = stderr;
     #[cfg(not(feature = "acl"))]
     if preserve_acls {
         let message =

--- a/crates/cli/src/frontend/execution/mod.rs
+++ b/crates/cli/src/frontend/execution/mod.rs
@@ -13,6 +13,8 @@ pub(crate) use chown::parse_chown_argument;
 pub(crate) use compression::{
     CompressLevelArg, parse_bandwidth_limit, parse_compress_level, parse_compress_level_argument,
 };
+#[cfg(test)]
+pub(crate) use file_list::read_file_list_from_reader;
 pub(crate) use file_list::{load_file_list_operands, transfer_requires_remote};
 pub(crate) use flags::{
     DEBUG_HELP_TEXT, INFO_HELP_TEXT, info_flags_include_progress, parse_debug_flags,
@@ -20,6 +22,8 @@ pub(crate) use flags::{
 };
 pub(crate) use module_list::render_module_list;
 pub(crate) use operands::{extract_operands, parse_bind_address_argument};
+#[cfg(test)]
+pub(crate) use options::{SizeParseError, pow_u128_for_size};
 pub(crate) use options::{
     parse_checksum_seed_argument, parse_human_readable_level, parse_max_delete_argument,
     parse_modify_window_argument, parse_protocol_version_arg, parse_size_limit_argument,

--- a/crates/engine/src/local_copy/executor/file/copy/dry_run.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/dry_run.rs
@@ -9,17 +9,28 @@ use crate::local_copy::{
 
 use super::super::append::{AppendMode, determine_append_mode};
 
+pub(super) struct DryRunRequest<'a> {
+    pub source: &'a Path,
+    pub destination: &'a Path,
+    pub metadata: &'a fs::Metadata,
+    pub record_path: &'a Path,
+    pub existing_metadata: Option<&'a fs::Metadata>,
+}
+
 pub(super) fn handle_dry_run(
     context: &mut CopyContext,
-    source: &Path,
-    destination: &Path,
-    metadata: &fs::Metadata,
-    record_path: &Path,
-    existing_metadata: Option<&fs::Metadata>,
-    destination_previously_existed: bool,
-    file_size: u64,
-    file_type: fs::FileType,
+    request: DryRunRequest<'_>,
 ) -> Result<(), LocalCopyError> {
+    let DryRunRequest {
+        source,
+        destination,
+        metadata,
+        record_path,
+        existing_metadata,
+    } = request;
+    let destination_previously_existed = existing_metadata.is_some();
+    let file_size = metadata.len();
+    let file_type = metadata.file_type();
     if context.update_enabled() {
         if let Some(existing) = existing_metadata {
             if super::super::comparison::destination_is_newer(metadata, existing) {

--- a/crates/engine/src/local_copy/executor/file/copy/mod.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/mod.rs
@@ -78,14 +78,13 @@ pub(crate) fn copy_file(
     if mode.is_dry_run() {
         dry_run::handle_dry_run(
             context,
-            source,
-            destination,
-            metadata,
-            record_path.as_path(),
-            existing_metadata.as_ref(),
-            destination_previously_existed,
-            file_size,
-            file_type,
+            dry_run::DryRunRequest {
+                source,
+                destination,
+                metadata,
+                record_path: record_path.as_path(),
+                existing_metadata: existing_metadata.as_ref(),
+            },
         )?;
         return Ok(());
     }

--- a/crates/engine/src/local_copy/executor/file/mod.rs
+++ b/crates/engine/src/local_copy/executor/file/mod.rs
@@ -18,7 +18,5 @@ pub(crate) use guard::{DestinationWriteGuard, remove_existing_destination};
 #[cfg(test)]
 pub(crate) use paths::partial_destination_path;
 #[cfg(test)]
-pub(crate) use paths::partial_directory_destination_path;
-#[cfg(test)]
 pub(crate) use preallocate::maybe_preallocate_destination;
 pub(crate) use sparse::write_sparse_chunk;


### PR DESCRIPTION
## Summary
- replace multi-argument dry run helper with a request struct and stop re-exporting unused path helpers
- restructure CLI drive helpers to pass context structs, box large enum variants, and tighten fallback toggles
- expose additional execution utilities for tests and clean up clippy warnings

## Testing
- cargo fmt
- cargo clippy --workspace --all-targets --all-features --locked -- -Dwarnings

------