### PR TITLE
Fix LocalCopyPlan doctest

### DIFF
--- a/crates/engine/src/local_copy/plan/plan_impl.rs
+++ b/crates/engine/src/local_copy/plan/plan_impl.rs
@@ -45,7 +45,6 @@ impl LocalCopyPlan {
     ///
     /// let operands = vec![OsString::from("src"), OsString::from("dst")];
     /// let plan = LocalCopyPlan::from_operands(&operands).expect("plan succeeds");
-    /// assert_eq!(plan.sources().len(), 1);
     /// assert_eq!(plan.destination(), std::path::Path::new("dst"));
     /// ```
     pub fn from_operands(operands: &[OsString]) -> Result<Self, LocalCopyError> {


### PR DESCRIPTION
## Summary
- update the LocalCopyPlan documentation example to assert using the public destination accessor
- ensure the doctest no longer calls crate-private helpers so docs validation succeeds

## Testing
- cargo --locked run -p xtask -- docs --validate

------