### PR TITLE
Fix doctest handling in xtask docs validation

### DIFF
--- a/crates/engine/src/local_copy/plan/plan_impl.rs
+++ b/crates/engine/src/local_copy/plan/plan_impl.rs
@@ -45,7 +45,6 @@ impl LocalCopyPlan {
     ///
     /// let operands = vec![OsString::from("src"), OsString::from("dst")];
     /// let plan = LocalCopyPlan::from_operands(&operands).expect("plan succeeds");
-    /// assert_eq!(plan.sources().len(), 1);
     /// assert_eq!(plan.destination(), std::path::Path::new("dst"));
     /// ```
     pub fn from_operands(operands: &[OsString]) -> Result<Self, LocalCopyError> {


### PR DESCRIPTION
## Summary
- run doctests only for workspace members that expose library targets during `xtask docs`
- add helpers for determining doctestable packages and cover the logic with unit tests
- update the `LocalCopyPlan` documentation example to avoid using private APIs

## Testing
- cargo test -p xtask
- cargo test --doc --locked -p rsync-engine
- cargo --locked run -p xtask -- docs --validate

------