### PR TITLE
Centralize human-readable level parsing

### DIFF
--- a/crates/cli/src/frontend/execution/options.rs
+++ b/crates/cli/src/frontend/execution/options.rs
@@ -111,32 +111,8 @@ pub(crate) fn parse_timeout_argument(value: &OsStr) -> Result<TransferTimeout, M
 
 pub(crate) fn parse_human_readable_level(value: &OsStr) -> Result<HumanReadableMode, clap::Error> {
     let text = value.to_string_lossy();
-    let trimmed = text.trim_matches(|ch: char| ch.is_ascii_whitespace());
-    let display = if trimmed.is_empty() {
-        text.as_ref()
-    } else {
-        trimmed
-    };
-
-    if trimmed.is_empty() {
-        return Err(clap::Error::raw(
-            clap::error::ErrorKind::InvalidValue,
-            "human-readable level must not be empty",
-        ));
-    }
-
-    match trimmed {
-        "0" => Ok(HumanReadableMode::Disabled),
-        "1" => Ok(HumanReadableMode::Enabled),
-        "2" => Ok(HumanReadableMode::Combined),
-        _ => Err(clap::Error::raw(
-            clap::error::ErrorKind::InvalidValue,
-            format!(
-                "invalid human-readable level '{}': expected 0, 1, or 2",
-                display
-            ),
-        )),
-    }
+    HumanReadableMode::parse(text.as_ref())
+        .map_err(|error| clap::Error::raw(clap::error::ErrorKind::InvalidValue, error.to_string()))
 }
 
 pub(crate) fn parse_max_delete_argument(value: &OsStr) -> Result<u64, Message> {

--- a/crates/core/src/client/config/mod.rs
+++ b/crates/core/src/client/config/mod.rs
@@ -21,8 +21,8 @@ pub use bandwidth::BandwidthLimit;
 pub use builder::ClientConfigBuilder;
 pub use client::ClientConfig;
 pub use enums::{
-    AddressMode, CompressionSetting, DeleteMode, HumanReadableMode, StrongChecksumAlgorithm,
-    StrongChecksumChoice, TransferTimeout,
+    AddressMode, CompressionSetting, DeleteMode, HumanReadableMode, HumanReadableModeParseError,
+    StrongChecksumAlgorithm, StrongChecksumChoice, TransferTimeout,
 };
 pub use filters::{FilterRuleKind, FilterRuleSpec};
 pub use network::BindAddress;

--- a/crates/core/src/client/mod.rs
+++ b/crates/core/src/client/mod.rs
@@ -97,8 +97,9 @@ mod summary;
 pub use self::config::{
     AddressMode, BandwidthLimit, BindAddress, ClientConfig, ClientConfigBuilder,
     CompressionSetting, DeleteMode, FilterRuleKind, FilterRuleSpec, HumanReadableMode,
-    ReferenceDirectory, ReferenceDirectoryKind, StrongChecksumAlgorithm, StrongChecksumChoice,
-    TransferTimeout, parse_skip_compress_list, skip_compress_from_env,
+    HumanReadableModeParseError, ReferenceDirectory, ReferenceDirectoryKind,
+    StrongChecksumAlgorithm, StrongChecksumChoice, TransferTimeout, parse_skip_compress_list,
+    skip_compress_from_env,
 };
 pub use self::error::{
     ClientError, FEATURE_UNAVAILABLE_EXIT_CODE, PARTIAL_TRANSFER_EXIT_CODE, SOCKET_IO_EXIT_CODE,

--- a/crates/core/src/client/tests/human_readable_mode.rs
+++ b/crates/core/src/client/tests/human_readable_mode.rs
@@ -1,0 +1,45 @@
+use crate::client::{HumanReadableMode, HumanReadableModeParseError};
+use std::str::FromStr;
+
+#[test]
+fn human_readable_mode_parses_numeric_levels() {
+    assert_eq!(HumanReadableMode::parse("0").unwrap(), HumanReadableMode::Disabled);
+    assert_eq!(HumanReadableMode::parse("1").unwrap(), HumanReadableMode::Enabled);
+    assert_eq!(HumanReadableMode::parse("2").unwrap(), HumanReadableMode::Combined);
+}
+
+#[test]
+fn human_readable_mode_trims_ascii_whitespace() {
+    assert_eq!(
+        HumanReadableMode::parse(" 1 \t").unwrap(),
+        HumanReadableMode::Enabled
+    );
+    assert_eq!(
+        HumanReadableMode::from_str("\n 2  \r").unwrap(),
+        HumanReadableMode::Combined
+    );
+}
+
+#[test]
+fn human_readable_mode_rejects_empty_values() {
+    let error = HumanReadableMode::parse("   ").unwrap_err();
+    assert_eq!(error, HumanReadableModeParseError::Empty);
+    assert_eq!(error.to_string(), "human-readable level must not be empty");
+    assert_eq!(error.invalid_value(), None);
+}
+
+#[test]
+fn human_readable_mode_reports_invalid_values() {
+    let error = HumanReadableMode::parse(" 9 ").unwrap_err();
+    assert_eq!(
+        error,
+        HumanReadableModeParseError::Invalid {
+            value: String::from("9"),
+        }
+    );
+    assert_eq!(
+        error.to_string(),
+        "invalid human-readable level '9': expected 0, 1, or 2"
+    );
+    assert_eq!(error.invalid_value(), Some("9"));
+}

--- a/crates/core/src/client/tests/mod.rs
+++ b/crates/core/src/client/tests/mod.rs
@@ -1,6 +1,7 @@
 include!("client_event.rs");
 include!("builder_compress.rs");
 include!("builder_metadata.rs");
+include!("human_readable_mode.rs");
 include!("network_getters.rs");
 include!("fallback_invocation.rs");
 include!("fallback_controls.rs");


### PR DESCRIPTION
## Summary
- add a shared parser and error type for `--human-readable` levels in the core crate
- reuse the new helper from the CLI options parser to keep diagnostics consistent
- cover the parser with unit tests for valid, invalid, and whitespace-trimmed inputs

## Testing
- cargo test -p rsync-core

------