### PR TITLE
Simplify library package filtering in docs executor

### DIFF
--- a/xtask/src/commands/docs/executor.rs
+++ b/xtask/src/commands/docs/executor.rs
@@ -71,7 +71,7 @@ fn library_packages(workspace: &Path) -> TaskResult<Vec<String>> {
         .packages
         .into_iter()
         .filter(|package| members.contains(&package.id))
-        .filter(|package| has_library_target(package))
+        .filter(has_library_target)
         .map(|package| package.name)
         .collect();
 


### PR DESCRIPTION
## Summary
- use `has_library_target` directly when filtering workspace packages for doctests

## Testing
- cargo clippy --workspace --all-targets --all-features --locked -- -Dwarnings

------