### PR TITLE
Update production scope doc to reference oc-rsync branding

### DIFF
--- a/docs/production_scope_p1.md
+++ b/docs/production_scope_p1.md
@@ -1,11 +1,11 @@
 # Production Scope P1 (Ship Bar)
 
-This document freezes the mandatory scope that must reach green status before the Rust rsync implementation can be considered production ready. The entries mirror upstream rsync 3.4.1 (protocol 32) behavior and are verified exclusively through observed parity with the upstream project while tracking the branded **rsync 3.4.1-rust** release line.
+This document freezes the mandatory scope that must reach green status before the Rust implementation can be considered production ready. The entries mirror upstream rsync 3.4.1 (protocol 32) behavior and are verified exclusively through observed parity with the upstream project while tracking the branded **oc-rsync 3.4.1-rust** release line.
 
 > **Binary naming note**: The production scope targets the canonical
-> `rsync` and `rsyncd` binaries. Compatibility symlinks may still be
-> shipped for downstream tooling, but the native Rust executables own the
-> canonical names.
+> `oc-rsync` client and `oc-rsyncd` daemon binaries. Compatibility
+> symlinks may still be shipped for downstream tooling, but the native
+> Rust executables own the canonical names and configuration layout.
 
 ## Platforms
 - Linux x86_64
@@ -62,7 +62,7 @@ This document freezes the mandatory scope that must reach green status before th
 
 ## User-Facing Messages
 - `--help` output
-- `--version` output (including `3.4.1-rust` branding and compiled feature list)
+- `--version` output (including `oc-rsync 3.4.1-rust` branding and compiled feature list)
 - Error and progress messages with byte-for-byte parity
 
 ## Interoperability
@@ -77,8 +77,8 @@ This document freezes the mandatory scope that must reach green status before th
 ## Packaging & Artifacts
 - Debian package via `cargo-deb`
 - RPM package via `cargo-rpm`
-- Systemd `rsyncd.service` unit (ships with an alias for legacy unit names when required)
-- Default daemon configuration installed at `/etc/rsyncd.conf` with secrets stored in `/etc/rsyncd.secrets`
+- Systemd `oc-rsyncd.service` unit (ships with an alias for legacy unit names when required)
+- Default daemon configuration installed at `/etc/oc-rsyncd/oc-rsyncd.conf` with secrets stored in `/etc/oc-rsyncd/oc-rsyncd.secrets`
 - CycloneDX SBOM at `target/sbom/rsync.cdx.json`
 - Cross-compiled release binaries for Linux (x86_64, aarch64), macOS (x86_64, aarch64), and Windows (x86_64) produced by the CI matrix (Windows x86/aarch64 targets remain disabled to avoid conflicting toolchains)
 


### PR DESCRIPTION
## Summary
- align the production scope overview with the oc-rsync/oc-rsyncd branding and metadata paths
- update packaging requirements to call out the oc-rsyncd systemd unit and configuration directory
- refresh version messaging to name the oc-rsync 3.4.1-rust release line

## Testing
- cargo --locked run -p xtask -- docs --validate

------