### PR TITLE
Fix unused io import under Windows for preallocation

### DIFF
--- a/crates/engine/src/local_copy/executor/file/preallocate.rs
+++ b/crates/engine/src/local_copy/executor/file/preallocate.rs
@@ -1,4 +1,5 @@
 use std::fs;
+#[cfg(unix)]
 use std::io;
 use std::path::Path;
 


### PR DESCRIPTION
## Summary
- gate the `std::io` import in the file preallocation helper behind `cfg(unix)` so Windows builds no longer warn

## Testing
- cargo fmt --all
- cargo --locked zigbuild --release --target x86_64-pc-windows-gnu --bin oc-rsync *(fails: cargo command `zigbuild` is not installed in the environment)*

------