### PR TITLE
Document apple filesystem helpers

### DIFF
--- a/crates/apple-fs/README.md
+++ b/crates/apple-fs/README.md
@@ -1,0 +1,16 @@
+# rsync-apple-fs
+
+Utilities that provide the small set of filesystem primitives required by
+`oc-rsync` when interacting with Apple platforms.
+
+The upstream `rsync` implementation relies on the `mkfifo(3)` and `mknod(2)`
+syscalls when creating named pipes or other special files while synchronising
+directories.  The Rust standard library does not expose safe wrappers for these
+operations, so this crate offers minimal bindings that mirror the behaviour of
+the C routines while integrating with the rest of the Rust-based
+implementation.
+
+The public API intentionally remains tiny.  Consumers should prefer the higher
+level abstractions in `rsync-core` wherever possible and use these helpers only
+when direct access to the underlying syscalls is required.
+

--- a/crates/apple-fs/src/lib.rs
+++ b/crates/apple-fs/src/lib.rs
@@ -1,3 +1,9 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![deny(missing_docs)]
+#![deny(rustdoc::broken_intra_doc_links)]
+#![deny(clippy::undocumented_unsafe_blocks)]
+#![doc = include_str!("../README.md")]
+
 use std::io;
 use std::path::Path;
 
@@ -17,8 +23,9 @@ mod unix {
             .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "path contains interior NUL"))
     }
 
-    pub fn mkfifo(path: &Path, mode: libc::mode_t) -> io::Result<()> {
+    pub(super) fn mkfifo(path: &Path, mode: libc::mode_t) -> io::Result<()> {
         let c_path = path_to_c(path)?;
+        // SAFETY: `c_path` is a valid, NUL-terminated representation of `path`.
         let result = unsafe { libc::mkfifo(c_path.as_ptr(), mode) };
         if result == 0 {
             Ok(())
@@ -27,8 +34,9 @@ mod unix {
         }
     }
 
-    pub fn mknod(path: &Path, mode: libc::mode_t, device: libc::dev_t) -> io::Result<()> {
+    pub(super) fn mknod(path: &Path, mode: libc::mode_t, device: libc::dev_t) -> io::Result<()> {
         let c_path = path_to_c(path)?;
+        // SAFETY: `c_path` is a valid, NUL-terminated representation of `path`.
         let result = unsafe { libc::mknod(c_path.as_ptr(), mode, device) };
         if result == 0 {
             Ok(())
@@ -39,9 +47,89 @@ mod unix {
 }
 
 #[cfg(unix)]
-pub use unix::{mkfifo, mknod};
+#[cfg_attr(docsrs, doc(cfg(unix)))]
+/// Creates a FIFO special file at `path` using the requested `mode`.
+///
+/// The helper mirrors the behaviour of `mkfifo(3)` and is only available on
+/// Unix platforms. The function returns an error when the path cannot be
+/// represented as a C string or when the underlying syscall fails.
+///
+/// # Errors
+///
+/// Returns [`io::ErrorKind::InvalidInput`] if the provided path contains an
+/// interior NUL byte. Other error kinds bubble up from the `mkfifo(3)` call,
+/// such as [`io::ErrorKind::AlreadyExists`] or [`io::ErrorKind::PermissionDenied`].
+///
+/// # Examples
+///
+/// ```rust
+/// # #[cfg(unix)] {
+/// use std::env;
+/// use std::fs;
+/// use std::os::unix::fs::FileTypeExt;
+/// use std::time::{SystemTime, UNIX_EPOCH};
+///
+/// let unique = SystemTime::now()
+///     .duration_since(UNIX_EPOCH)
+///     .unwrap()
+///     .as_nanos();
+/// let path = env::temp_dir().join(format!("rsync_fifo_{unique}"));
+/// # let _ = fs::remove_file(&path);
+/// rsync_apple_fs::mkfifo(&path, 0o600).unwrap();
+/// let metadata = fs::metadata(&path).unwrap();
+/// assert!(metadata.file_type().is_fifo());
+/// fs::remove_file(&path).unwrap();
+/// # }
+/// ```
+pub fn mkfifo(path: &Path, mode: libc::mode_t) -> io::Result<()> {
+    unix::mkfifo(path, mode)
+}
+
+#[cfg(unix)]
+#[cfg_attr(docsrs, doc(cfg(unix)))]
+/// Creates a filesystem node at `path` with the supplied `mode` and `device`.
+///
+/// This wrapper exposes the subset of `mknod(2)` used by the rsync
+/// implementation. Passing `libc::S_IFIFO` as the mode creates a named pipe.
+///
+/// # Errors
+///
+/// Returns [`io::ErrorKind::InvalidInput`] if the path cannot be converted to a
+/// C string. Other failures surface directly from the `mknod(2)` syscall.
+///
+/// # Examples
+///
+/// ```rust
+/// # #[cfg(unix)] {
+/// use std::env;
+/// use std::fs;
+/// use std::os::unix::fs::FileTypeExt;
+/// use std::time::{SystemTime, UNIX_EPOCH};
+///
+/// let unique = SystemTime::now()
+///     .duration_since(UNIX_EPOCH)
+///     .unwrap()
+///     .as_nanos();
+/// let path = env::temp_dir().join(format!("rsync_mknod_{unique}"));
+/// # let _ = fs::remove_file(&path);
+/// rsync_apple_fs::mknod(&path, libc::S_IFIFO | 0o600, 0).unwrap();
+/// let metadata = fs::metadata(&path).unwrap();
+/// assert!(metadata.file_type().is_fifo());
+/// fs::remove_file(&path).unwrap();
+/// # }
+/// ```
+pub fn mknod(path: &Path, mode: libc::mode_t, device: libc::dev_t) -> io::Result<()> {
+    unix::mknod(path, mode, device)
+}
 
 #[cfg(not(unix))]
+/// Stub implementation that reports the lack of FIFO support on non-Unix
+/// platforms.
+///
+/// # Errors
+///
+/// Always returns an [`io::ErrorKind::Unsupported`] error to mirror the
+/// behaviour of upstream rsync on unsupported targets.
 pub fn mkfifo(_path: &Path, _mode: ModeType) -> io::Result<()> {
     Err(io::Error::new(
         io::ErrorKind::Unsupported,
@@ -50,6 +138,12 @@ pub fn mkfifo(_path: &Path, _mode: ModeType) -> io::Result<()> {
 }
 
 #[cfg(not(unix))]
+/// Stub implementation that reports the lack of `mknod` support on non-Unix
+/// platforms.
+///
+/// # Errors
+///
+/// Always returns an [`io::ErrorKind::Unsupported`] error.
 pub fn mknod(_path: &Path, _mode: ModeType, _device: DeviceType) -> io::Result<()> {
     Err(io::Error::new(
         io::ErrorKind::Unsupported,


### PR DESCRIPTION
## Summary
- add a README for the rsync-apple-fs helper crate and enable the shared rustdoc lints
- document the mkfifo and mknod wrappers with executable examples

## Testing
- cargo test -p rsync-apple-fs

------