### PR TITLE
Ensure fallback error mentions launch failure

### DIFF
--- a/crates/core/src/client/fallback/runner/command_builder.rs
+++ b/crates/core/src/client/fallback/runner/command_builder.rs
@@ -1,4 +1,5 @@
 use std::ffi::{OsStr, OsString};
+use std::path::Path;
 
 use tempfile::NamedTempFile;
 
@@ -561,7 +562,10 @@ pub(crate) fn prepare_invocation(
     if !fallback_binary_available(binary.as_os_str()) {
         let diagnostic =
             describe_missing_fallback_binary(binary.as_os_str(), &[CLIENT_FALLBACK_ENV]);
-        return Err(fallback_error(diagnostic));
+        return Err(fallback_error(format!(
+            "failed to launch fallback rsync binary '{}': {diagnostic}",
+            Path::new(binary.as_os_str()).display()
+        )));
     }
 
     Ok(PreparedInvocation {


### PR DESCRIPTION
## Summary
- ensure remote fallback availability errors mention the launch failure while preserving diagnostic context

## Testing
- cargo test --package rsync-cli -- frontend::tests::remote_tests::remote_operand_reports_launch_failure_when_fallback_missing --nocapture

------