### PR TITLE
Handle forced missing cargo tools in packaging tests

### DIFF
--- a/xtask/src/commands/package.rs
+++ b/xtask/src/commands/package.rs
@@ -258,33 +258,36 @@ mod tests {
         LOCK.get_or_init(|| std::sync::Mutex::new(()))
     }
 
-    struct EnvGuard {
-        key: &'static str,
-        previous: Option<OsString>,
+    struct EnvGuards {
+        previous: Vec<(&'static str, Option<OsString>)>,
         _lock: std::sync::MutexGuard<'static, ()>,
     }
 
-    impl EnvGuard {
+    impl EnvGuards {
         #[allow(unsafe_code)]
-        fn set(key: &'static str, value: &str) -> Self {
+        fn set_many(pairs: &[(&'static str, &str)]) -> Self {
             let guard = env_lock().lock().unwrap();
-            let previous = env::var_os(key);
-            unsafe { env::set_var(key, value) };
+            let mut previous = Vec::with_capacity(pairs.len());
+            for (key, value) in pairs {
+                previous.push((*key, env::var_os(key)));
+                unsafe { env::set_var(key, value) };
+            }
             Self {
-                key,
                 previous,
                 _lock: guard,
             }
         }
     }
 
-    impl Drop for EnvGuard {
+    impl Drop for EnvGuards {
         #[allow(unsafe_code)]
         fn drop(&mut self) {
-            if let Some(previous) = self.previous.take() {
-                unsafe { env::set_var(self.key, previous) };
-            } else {
-                unsafe { env::remove_var(self.key) };
+            for (key, value) in self.previous.iter_mut().rev() {
+                if let Some(previous) = value.take() {
+                    unsafe { env::set_var(*key, previous) };
+                } else {
+                    unsafe { env::remove_var(*key) };
+                }
             }
         }
     }
@@ -304,7 +307,10 @@ mod tests {
 
     #[test]
     fn execute_reports_missing_cargo_deb_tool() {
-        let _env = EnvGuard::set("OC_RSYNC_PACKAGE_SKIP_BUILD", "1");
+        let _env = EnvGuards::set_many(&[
+            ("OC_RSYNC_PACKAGE_SKIP_BUILD", "1"),
+            ("OC_RSYNC_FORCE_MISSING_CARGO_TOOLS", "cargo deb"),
+        ]);
         let error = execute(
             workspace_root(),
             PackageOptions {
@@ -319,7 +325,10 @@ mod tests {
 
     #[test]
     fn execute_reports_missing_cargo_rpm_tool() {
-        let _env = EnvGuard::set("OC_RSYNC_PACKAGE_SKIP_BUILD", "1");
+        let _env = EnvGuards::set_many(&[
+            ("OC_RSYNC_PACKAGE_SKIP_BUILD", "1"),
+            ("OC_RSYNC_FORCE_MISSING_CARGO_TOOLS", "cargo rpm build"),
+        ]);
         let error = execute(
             workspace_root(),
             PackageOptions {


### PR DESCRIPTION
## Summary
- allow tests to simulate missing cargo subcommands via the OC_RSYNC_FORCE_MISSING_CARGO_TOOLS environment variable
- update package command tests to scope multiple environment overrides safely while exercising the new hook
- cover the forced-missing path with a dedicated unit test

## Testing
- cargo test -p xtask execute_reports_missing_cargo
- cargo test -p xtask run_cargo_tool_honours_forced_missing_configuration
- cargo fmt

------