### PR TITLE
Stabilize package tool missing detection

### DIFF
--- a/xtask/src/util.rs
+++ b/xtask/src/util.rs
@@ -42,7 +42,8 @@ pub fn run_cargo_tool(
     display: &str,
     install_hint: &str,
 ) -> TaskResult<()> {
-    let output = Command::new("cargo")
+    let cargo = env::var_os("CARGO").unwrap_or_else(|| OsString::from("cargo"));
+    let output = Command::new(cargo)
         .current_dir(workspace)
         .args(&args)
         .output()


### PR DESCRIPTION
## Summary
- allow xtask's cargo invocations to honour the `CARGO` environment override
- exercise the package command's missing-tool paths with a deterministic fake cargo shim

## Testing
- cargo fmt
- cargo test -p xtask execute_reports_missing_cargo_deb_tool
- cargo test -p xtask execute_reports_missing_cargo_rpm_tool

------