### PR TITLE
Add shared daemon test environment helpers

### DIFF
--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -165,6 +165,9 @@ mod daemon;
 mod error;
 mod systemd;
 
+#[cfg(test)]
+mod test_env;
+
 pub use cli::{exit_code_from, run};
 pub use config::{DaemonConfig, DaemonConfigBuilder};
 pub use daemon::run_daemon;

--- a/crates/daemon/src/systemd.rs
+++ b/crates/daemon/src/systemd.rs
@@ -94,43 +94,11 @@ impl ServiceNotifier {
 #[cfg(test)]
 mod tests {
     use super::ServiceNotifier;
-    use std::env;
-    use std::ffi::OsString;
-
-    #[allow(unsafe_code)]
-    struct EnvGuard {
-        key: &'static str,
-        previous: Option<OsString>,
-    }
-
-    #[allow(unsafe_code)]
-    impl EnvGuard {
-        fn remove(key: &'static str) -> Self {
-            let previous = env::var_os(key);
-            unsafe {
-                env::remove_var(key);
-            }
-            Self { key, previous }
-        }
-    }
-
-    #[allow(unsafe_code)]
-    impl Drop for EnvGuard {
-        fn drop(&mut self) {
-            if let Some(ref value) = self.previous {
-                unsafe {
-                    env::set_var(self.key, value);
-                }
-            } else {
-                unsafe {
-                    env::remove_var(self.key);
-                }
-            }
-        }
-    }
+    use crate::test_env::{ENV_LOCK, EnvGuard};
 
     #[test]
     fn notifier_behaves_as_noop_without_notify_socket() {
+        let _env_lock = ENV_LOCK.lock().expect("lock environment guard");
         let _guard = EnvGuard::remove("NOTIFY_SOCKET");
 
         let notifier = ServiceNotifier::new();

--- a/crates/daemon/src/test_env.rs
+++ b/crates/daemon/src/test_env.rs
@@ -1,0 +1,72 @@
+#![cfg(test)]
+
+//! Shared helpers for manipulating environment variables within daemon tests.
+//! The helpers centralise the unsafe interactions with `std::env` so individual
+//! tests can remain focused on their specific assertions while ensuring the
+//! environment is restored even when panics occur.
+
+use std::env;
+use std::ffi::{OsStr, OsString};
+use std::sync::Mutex;
+
+/// Global mutex guarding environment mutations performed by daemon tests.
+///
+/// Tests in this crate adjust environment variables such as
+/// `OC_RSYNC_FALLBACK` and `RSYNC_PROXY`. Acquiring the mutex before applying
+/// overrides ensures the environment remains consistent even when tests run in
+/// parallel.
+pub(crate) static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+/// Scoped helper that applies an environment change and restores the previous
+/// value when dropped.
+#[allow(unsafe_code)]
+#[derive(Debug)]
+pub(crate) struct EnvGuard {
+    key: OsString,
+    previous: Option<OsString>,
+}
+
+impl EnvGuard {
+    /// Sets `key` to `value` for the duration of the guard.
+    #[allow(dead_code, unsafe_code)]
+    pub(crate) fn set(key: &'static str, value: &OsStr) -> Self {
+        let key_os = OsString::from(key);
+        let previous = env::var_os(&key_os);
+        unsafe {
+            env::set_var(&key_os, value);
+        }
+        Self {
+            key: key_os,
+            previous,
+        }
+    }
+
+    /// Removes `key` for the duration of the guard.
+    #[allow(unsafe_code)]
+    pub(crate) fn remove(key: &'static str) -> Self {
+        let key_os = OsString::from(key);
+        let previous = env::var_os(&key_os);
+        unsafe {
+            env::remove_var(&key_os);
+        }
+        Self {
+            key: key_os,
+            previous,
+        }
+    }
+}
+
+#[allow(unsafe_code)]
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        if let Some(ref value) = self.previous {
+            unsafe {
+                env::set_var(&self.key, value);
+            }
+        } else {
+            unsafe {
+                env::remove_var(&self.key);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a dedicated `test_env` module that centralises the daemon test environment lock and guard
- update the systemd notifier test to use the shared helpers instead of an ad-hoc implementation
- make the daemon crate expose the helpers during tests so other suites can reuse them

## Testing
- cargo test -p rsync-daemon

------