### PR TITLE
Fix clippy warnings

### DIFF
--- a/crates/daemon/src/systemd.rs
+++ b/crates/daemon/src/systemd.rs
@@ -41,10 +41,10 @@ impl ServiceNotifier {
         #[cfg(feature = "sd-notify")]
         {
             if let Some(text) = status {
-                return self.send_states(&[NotifyState::Ready, NotifyState::Status(text)]);
+                self.send_states(&[NotifyState::Ready, NotifyState::Status(text)])
+            } else {
+                self.send_states(&[NotifyState::Ready])
             }
-
-            return self.send_states(&[NotifyState::Ready]);
         }
 
         #[cfg(not(feature = "sd-notify"))]
@@ -58,7 +58,7 @@ impl ServiceNotifier {
     pub(crate) fn status(&self, status: &str) -> io::Result<()> {
         #[cfg(feature = "sd-notify")]
         {
-            return self.send_states(&[NotifyState::Status(status)]);
+            self.send_states(&[NotifyState::Status(status)])
         }
 
         #[cfg(not(feature = "sd-notify"))]
@@ -72,7 +72,7 @@ impl ServiceNotifier {
     pub(crate) fn stopping(&self) -> io::Result<()> {
         #[cfg(feature = "sd-notify")]
         {
-            return self.send_states(&[NotifyState::Stopping]);
+            self.send_states(&[NotifyState::Stopping])
         }
 
         #[cfg(not(feature = "sd-notify"))]

--- a/crates/daemon/src/test_env.rs
+++ b/crates/daemon/src/test_env.rs
@@ -1,5 +1,3 @@
-#![cfg(test)]
-
 //! Shared helpers for manipulating environment variables within daemon tests.
 //! The helpers centralise the unsafe interactions with `std::env` so individual
 //! tests can remain focused on their specific assertions while ensuring the

--- a/xtask/src/util.rs
+++ b/xtask/src/util.rs
@@ -35,7 +35,7 @@ fn should_simulate_missing_tool(display: &str) -> bool {
     };
 
     entries
-        .split(|ch| matches!(ch, ',' | ';' | '|'))
+        .split(|ch| [',', ';', '|'].contains(&ch))
         .map(str::trim)
         .any(|value| !value.is_empty() && value == display)
 }


### PR DESCRIPTION
## Summary
- replace the manual delimiter comparison in the xtask split helper with an array check
- remove redundant early returns in the systemd notifier helpers
- drop the duplicated crate-level cfg attribute in the daemon test environment utilities

## Testing
- cargo clippy --workspace --all-targets --all-features --locked -- -Dwarnings

------