### PR TITLE
Stop using deprecated cargo_bin helper in CLI tests

### DIFF
--- a/tests/cli_binaries.rs
+++ b/tests/cli_binaries.rs
@@ -1,16 +1,15 @@
-use assert_cmd::prelude::*;
 use rsync_core::version::{
     DAEMON_PROGRAM_NAME, OC_DAEMON_PROGRAM_NAME, OC_PROGRAM_NAME, PROGRAM_NAME,
 };
+use std::env;
+use std::path::PathBuf;
 use std::process::{Command, Output};
 
 const CLIENT_BINARIES: &[&str] = &[PROGRAM_NAME, OC_PROGRAM_NAME];
 const DAEMON_BINARIES: &[&str] = &[DAEMON_PROGRAM_NAME, OC_DAEMON_PROGRAM_NAME];
 
 fn binary_output(name: &str, args: &[&str]) -> Output {
-    #[allow(deprecated)]
-    let mut command =
-        Command::cargo_bin(name).unwrap_or_else(|error| panic!("failed to locate {name}: {error}"));
+    let mut command = binary_command(name);
     command.args(args);
     command
         .output()
@@ -77,4 +76,54 @@ fn daemon_rejects_unknown_flag() {
         let combined = combined_utf8(&output);
         assert!(combined.contains("unknown option"));
     }
+}
+
+fn binary_command(name: &str) -> Command {
+    let binary = binary_path(name);
+    if !binary.is_file() {
+        panic!("failed to locate {name}: {}", binary.display());
+    }
+
+    if let Some(mut runner) = cargo_target_runner() {
+        let runner_binary = runner
+            .get(0)
+            .cloned()
+            .unwrap_or_else(|| panic!("{name} runner command is empty"));
+        runner.remove(0);
+        let mut command = Command::new(runner_binary);
+        command.args(runner);
+        command.arg(&binary);
+        command
+    } else {
+        Command::new(binary)
+    }
+}
+
+fn binary_path(name: &str) -> PathBuf {
+    let env_var = format!("CARGO_BIN_EXE_{name}");
+    if let Some(path) = env::var_os(&env_var) {
+        return PathBuf::from(path);
+    }
+
+    let mut target_dir = env::current_exe().expect("current_exe should be available");
+    target_dir.pop();
+    if target_dir.ends_with("deps") {
+        target_dir.pop();
+    }
+    target_dir.push(format!("{name}{}", std::env::consts::EXE_SUFFIX));
+    target_dir
+}
+
+fn cargo_target_runner() -> Option<Vec<String>> {
+    let target = env::var("TARGET").ok()?;
+    let runner_env = format!(
+        "CARGO_TARGET_{}_RUNNER",
+        target.replace('-', "_").to_uppercase()
+    );
+    let runner = env::var(&runner_env).ok()?;
+    if runner.is_empty() {
+        return None;
+    }
+
+    Some(runner.split(' ').map(str::to_string).collect())
 }


### PR DESCRIPTION
## Summary
- replace Command::cargo_bin usage in the CLI binary tests with a local helper that resolves the binary path without deprecated APIs
- add runner-aware command construction so cross-target setups keep working when invoking the test binaries

## Testing
- cargo test --test cli_binaries

------