### PR TITLE
Add focused tests for CI matrix helper utilities

### DIFF
--- a/xtask/src/commands/docs/validation/ci/matrix/tests/mod.rs
+++ b/xtask/src/commands/docs/validation/ci/matrix/tests/mod.rs
@@ -57,4 +57,5 @@ mod extract;
 mod mismatched_fields;
 mod missing_entries;
 mod parallelism;
+mod platform_names;
 mod unexpected_entries;

--- a/xtask/src/commands/docs/validation/ci/matrix/tests/platform_names.rs
+++ b/xtask/src/commands/docs/validation/ci/matrix/tests/platform_names.rs
@@ -1,0 +1,63 @@
+use super::*;
+use std::collections::BTreeSet;
+
+#[test]
+fn collect_matrix_platform_names_extracts_expected_entries() {
+    let yaml = r#"jobs:
+  cross-compile:
+    strategy:
+      matrix:
+        platform:
+          - name: linux-x86_64
+            target: x86_64-unknown-linux-gnu
+          - name: linux-aarch64
+            target: aarch64-unknown-linux-gnu
+        include:
+          - name: ignored
+            something: else
+"#;
+
+    let names = collect_matrix_platform_names(yaml);
+    assert_eq!(
+        names,
+        vec![String::from("linux-x86_64"), String::from("linux-aarch64"),],
+    );
+}
+
+#[test]
+fn check_for_unexpected_matrix_entries_reports_all_issues() {
+    let names = vec![
+        String::from("linux-x86_64"),
+        String::from("linux-x86_64"),
+        String::from("windows-x86_64"),
+        String::from("unexpected"),
+    ];
+    let expected_entries = BTreeSet::from([
+        String::from("linux-x86_64"),
+        String::from("linux-aarch64"),
+        String::from("windows-x86_64"),
+    ]);
+    let mut failures = Vec::new();
+
+    check_for_unexpected_matrix_entries(
+        ".github/workflows/ci.yml",
+        &names,
+        &expected_entries,
+        &mut failures,
+    );
+
+    assert_eq!(
+        failures,
+        vec![
+            String::from(
+                ".github/workflows/ci.yml: duplicate cross-compilation entry 'linux-x86_64'",
+            ),
+            String::from(
+                ".github/workflows/ci.yml: unexpected cross-compilation entry 'unexpected'",
+            ),
+            String::from(
+                ".github/workflows/ci.yml: missing cross-compilation entry 'linux-aarch64'",
+            ),
+        ],
+    );
+}


### PR DESCRIPTION
## Summary
- add unit tests for `collect_matrix_platform_names` and `check_for_unexpected_matrix_entries`
- register the new helper tests with the CI matrix validation suite

## Testing
- cargo test -p xtask

------