### PR TITLE
Fix remote fallback toggles for ACL and xattr flags

### DIFF
--- a/crates/cli/src/frontend/execution/drive/fallback.rs
+++ b/crates/cli/src/frontend/execution/drive/fallback.rs
@@ -116,9 +116,9 @@ pub(crate) struct FallbackInputs {
     pub(crate) rsync_path: Option<OsString>,
     pub(crate) remainder: Vec<OsString>,
     #[cfg(feature = "acl")]
-    pub(crate) acls: bool,
+    pub(crate) acls: Option<bool>,
     #[cfg(feature = "xattr")]
-    pub(crate) xattrs: bool,
+    pub(crate) xattrs: Option<bool>,
     pub(crate) itemize_changes: bool,
 }
 
@@ -254,9 +254,9 @@ where
         rsync_path: inputs.rsync_path,
         remainder: inputs.remainder,
         #[cfg(feature = "acl")]
-        acls: inputs.acls.then_some(true),
+        acls: inputs.acls,
         #[cfg(feature = "xattr")]
-        xattrs: inputs.xattrs.then_some(true),
+        xattrs: inputs.xattrs,
         itemize_changes: inputs.itemize_changes,
     };
 

--- a/crates/cli/src/frontend/execution/drive/workflow/fallback_plan.rs
+++ b/crates/cli/src/frontend/execution/drive/workflow/fallback_plan.rs
@@ -111,9 +111,9 @@ pub(crate) struct FallbackArgumentsContext<'a> {
     pub(crate) rsync_path: Option<&'a OsString>,
     pub(crate) remainder: &'a [OsString],
     #[cfg(feature = "acl")]
-    pub(crate) preserve_acls: bool,
+    pub(crate) acls: Option<bool>,
     #[cfg(feature = "xattr")]
-    pub(crate) xattrs: bool,
+    pub(crate) xattrs: Option<bool>,
     pub(crate) itemize_changes: bool,
 }
 
@@ -237,7 +237,7 @@ where
         rsync_path: context.rsync_path.cloned(),
         remainder: context.remainder.to_vec(),
         #[cfg(feature = "acl")]
-        acls: context.preserve_acls,
+        acls: context.acls,
         #[cfg(feature = "xattr")]
         xattrs: context.xattrs,
         itemize_changes: context.itemize_changes,

--- a/crates/cli/src/frontend/execution/drive/workflow/mod.rs
+++ b/crates/cli/src/frontend/execution/drive/workflow/mod.rs
@@ -382,9 +382,9 @@ where
         rsync_path: rsync_path.as_ref(),
         remainder: &remainder,
         #[cfg(feature = "acl")]
-        preserve_acls,
+        acls,
         #[cfg(feature = "xattr")]
-        xattrs: xattrs.unwrap_or(false),
+        xattrs,
         itemize_changes,
     };
     let fallback_args = match build_fallback_arguments(fallback_context, stderr) {


### PR DESCRIPTION
## Summary
- preserve the caller-provided ACL toggle when constructing remote fallback arguments
- treat the xattr toggle identically so future `--no-xattrs` forwarding works as expected

## Testing
- cargo test --package rsync-cli --features acl frontend::tests::remote_fallback_forwards_no_tests::remote_fallback_forwards_no_acls_toggle
- cargo test --package rsync-cli --features acl frontend::tests::remote_fallback_forwards_acls_tests::remote_fallback_forwards_acls_toggle

------