### PR TITLE
Fix clippy lints in CLI binary tests

### DIFF
--- a/crates/core/src/fallback/binary.rs
+++ b/crates/core/src/fallback/binary.rs
@@ -181,7 +181,10 @@ fn push_segment(segment: &[u16], exts: &mut Vec<OsString>) {
 
 #[cfg(windows)]
 fn is_windows_whitespace(unit: u16) -> bool {
-    matches!(unit, b' ' as u16 | b'\t' as u16 | b'\n' as u16 | b'\r' as u16)
+    matches!(
+        unit,
+        b' ' as u16 | b'\t' as u16 | b'\n' as u16 | b'\r' as u16
+    )
 }
 
 #[cfg(test)]

--- a/tests/cli_binaries.rs
+++ b/tests/cli_binaries.rs
@@ -84,14 +84,13 @@ fn binary_command(name: &str) -> Command {
         panic!("failed to locate {name}: {}", binary.display());
     }
 
-    if let Some(mut runner) = cargo_target_runner() {
-        let runner_binary = runner
-            .get(0)
-            .cloned()
+    if let Some(runner) = cargo_target_runner() {
+        let mut runner_iter = runner.into_iter();
+        let runner_binary = runner_iter
+            .next()
             .unwrap_or_else(|| panic!("{name} runner command is empty"));
-        runner.remove(0);
         let mut command = Command::new(runner_binary);
-        command.args(runner);
+        command.args(runner_iter);
         command.arg(&binary);
         command
     } else {
@@ -251,17 +250,17 @@ mod split_shell_words_tests {
 
     #[test]
     fn detects_unterminated_single_quotes() {
-        assert!(matches!(split_shell_words("cmd 'unterminated"), Err(_)));
+        assert!(split_shell_words("cmd 'unterminated").is_err());
     }
 
     #[test]
     fn detects_unterminated_double_quotes() {
-        assert!(matches!(split_shell_words("cmd \"unterminated"), Err(_)));
+        assert!(split_shell_words("cmd \"unterminated").is_err());
     }
 
     #[test]
     fn detects_trailing_backslash() {
         let input = format!("cmd {}", '\\');
-        assert!(matches!(split_shell_words(&input), Err(_)));
+        assert!(split_shell_words(&input).is_err());
     }
 }


### PR DESCRIPTION
## Summary
- avoid `Vec::get(0)` in the CLI runner helper to satisfy clippy::get-first
- simplify shell-splitting error assertions to use `is_err()`
- reformat Windows whitespace matcher after running rustfmt

## Testing
- cargo clippy --workspace --all-targets -- -Dwarnings
- cargo test

------