### PR TITLE
Add FromIterator support for LimiterChange aggregation

### DIFF
--- a/crates/bandwidth/src/limiter.rs
+++ b/crates/bandwidth/src/limiter.rs
@@ -234,6 +234,21 @@ impl LimiterChange {
     /// ]);
     /// assert_eq!(summary, LimiterChange::Enabled);
     /// ```
+    ///
+    /// The helper also powers [`Iterator::collect`], allowing callers to gather
+    /// a sequence of changes directly into a consolidated [`LimiterChange`]:
+    ///
+    /// ```
+    /// use rsync_bandwidth::LimiterChange;
+    ///
+    /// let summary: LimiterChange = [
+    ///     LimiterChange::Updated,
+    ///     LimiterChange::Disabled,
+    /// ]
+    /// .into_iter()
+    /// .collect();
+    /// assert_eq!(summary, LimiterChange::Disabled);
+    /// ```
     pub fn combine_all<I>(changes: I) -> Self
     where
         I: IntoIterator<Item = Self>,
@@ -289,6 +304,14 @@ impl Ord for LimiterChange {
 impl PartialOrd for LimiterChange {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
+    }
+}
+
+impl FromIterator<LimiterChange> for LimiterChange {
+    /// Collapses an iterator of [`LimiterChange`] values into a single
+    /// representative variant.
+    fn from_iter<I: IntoIterator<Item = LimiterChange>>(iter: I) -> Self {
+        Self::combine_all(iter)
     }
 }
 

--- a/crates/bandwidth/src/limiter/tests/configuration.rs
+++ b/crates/bandwidth/src/limiter/tests/configuration.rs
@@ -211,6 +211,22 @@ fn limiter_change_combine_all_matches_folded_combination() {
 }
 
 #[test]
+fn limiter_change_collect_collapses_iterator() {
+    let aggregated: LimiterChange = [
+        LimiterChange::Unchanged,
+        LimiterChange::Updated,
+        LimiterChange::Disabled,
+    ]
+    .into_iter()
+    .collect();
+
+    assert_eq!(aggregated, LimiterChange::Disabled);
+
+    let empty: LimiterChange = std::iter::empty().collect();
+    assert_eq!(empty, LimiterChange::Unchanged);
+}
+
+#[test]
 fn limiter_write_max_enforces_minimum_threshold() {
     let limiter = BandwidthLimiter::new(NonZeroU64::new(128).unwrap());
 


### PR DESCRIPTION
## Summary
- allow `LimiterChange` values to be collected from iterators by delegating to the existing `combine_all` helper
- document the new iterator support with a doctest that shows `Iterator::collect`
- exercise the collection behaviour in the limiter configuration tests, including the empty iterator case

## Testing
- cargo test -p rsync-bandwidth limiter_change_collect_collapses_iterator

------