### PR TITLE
Format Windows whitespace matcher

### DIFF
--- a/crates/core/src/fallback/binary.rs
+++ b/crates/core/src/fallback/binary.rs
@@ -186,10 +186,7 @@ fn is_windows_whitespace(unit: u16) -> bool {
     const NEWLINE: u16 = b'\n' as u16;
     const CARRIAGE_RETURN: u16 = b'\r' as u16;
 
-    matches!(
-        unit,
-        SPACE | TAB | NEWLINE | CARRIAGE_RETURN
-    )
+    matches!(unit, SPACE | TAB | NEWLINE | CARRIAGE_RETURN)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- simplify the matches! invocation in the Windows whitespace helper to align with rustfmt output

## Testing
- cargo fmt --all -- --check

------