### PR TITLE
Derive Default for PanicState

### DIFF
--- a/xtask/src/commands/no_placeholders.rs
+++ b/xtask/src/commands/no_placeholders.rs
@@ -244,8 +244,9 @@ struct PanicTracker {
     state: PanicState,
 }
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Default, Eq, PartialEq)]
 enum PanicState {
+    #[default]
     Inactive,
     AwaitingDelimiter {
         block_comment_depth: u32,
@@ -254,12 +255,6 @@ enum PanicState {
         delimiter: PanicDelimiter,
         depth: i32,
     },
-}
-
-impl Default for PanicState {
-    fn default() -> Self {
-        PanicState::Inactive
-    }
 }
 
 impl PanicTracker {


### PR DESCRIPTION
## Summary
- derive `Default` for `PanicState` and mark the inactive variant as the default to satisfy clippy

## Testing
- `cargo clippy --workspace --all-targets --all-features --locked -- -Dwarnings`

------