### PR TITLE
Derive default for xtask panic state tracker

### DIFF
--- a/crates/core/src/fallback/binary.rs
+++ b/crates/core/src/fallback/binary.rs
@@ -186,10 +186,7 @@ fn is_windows_whitespace(unit: u16) -> bool {
     const NEWLINE: u16 = b'\n' as u16;
     const CARRIAGE_RETURN: u16 = b'\r' as u16;
 
-    matches!(
-        unit,
-        SPACE | TAB | NEWLINE | CARRIAGE_RETURN
-    )
+    matches!(unit, SPACE | TAB | NEWLINE | CARRIAGE_RETURN)
 }
 
 #[cfg(test)]

--- a/xtask/src/commands/no_placeholders.rs
+++ b/xtask/src/commands/no_placeholders.rs
@@ -244,8 +244,9 @@ struct PanicTracker {
     state: PanicState,
 }
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Default, Eq, PartialEq)]
 enum PanicState {
+    #[default]
     Inactive,
     AwaitingDelimiter {
         block_comment_depth: u32,
@@ -254,12 +255,6 @@ enum PanicState {
         delimiter: PanicDelimiter,
         depth: i32,
     },
-}
-
-impl Default for PanicState {
-    fn default() -> Self {
-        PanicState::Inactive
-    }
 }
 
 impl PanicTracker {


### PR DESCRIPTION
## Summary
- derive `Default` for the xtask panic state enum and mark its default variant
- rerun rustfmt which simplified the Windows whitespace matcher in the fallback helper

## Testing
- cargo clippy --workspace --all-targets -- -Dwarnings
- cargo test -p xtask

------