### PR TITLE
Align branding references in entry point docs

### DIFF
--- a/src/bin/client.rs
+++ b/src/bin/client.rs
@@ -5,11 +5,13 @@ use std::process::ExitCode;
 
 /// Runs the shared client entry point for every branded executable.
 ///
-/// Both the canonical `rsync` binary and the compatibility `oc-rsync`
-/// wrapper call into this helper so tests and packaging only need to
-/// validate a single execution path. The helper forwards its arguments
-/// and I/O handles to the CLI crate and normalises the returned status
-/// via the shared exit-code mapper.
+/// Both branded binaries—the upstream-compatible client exposed as
+/// [`rsync_core::version::PROGRAM_NAME`] and the oc-branded wrapper
+/// published as [`rsync_core::version::OC_PROGRAM_NAME`]—call into this
+/// helper. Centralising the logic keeps tests, packaging, and telemetry
+/// focused on a single execution path. The helper forwards its arguments
+/// and I/O handles to the CLI crate and normalises the returned status via
+/// the shared exit-code mapper.
 #[must_use]
 pub fn run_with<I, Out, Err>(args: I, stdout: &mut Out, stderr: &mut Err) -> ExitCode
 where

--- a/src/bin/daemon.rs
+++ b/src/bin/daemon.rs
@@ -5,9 +5,11 @@ use std::process::ExitCode;
 
 /// Runs the shared daemon entry point for every branded executable.
 ///
-/// The canonical `rsyncd` binary and the `oc-rsyncd` compatibility
-/// wrapper both forward to this helper so argument dispatch and status
-/// mapping stay consistent across brands.
+/// Both daemon brands—the upstream-compatible service identified by
+/// [`rsync_core::version::DAEMON_PROGRAM_NAME`] and the oc-branded
+/// wrapper published as [`rsync_core::version::OC_DAEMON_PROGRAM_NAME`]—
+/// call into this helper, keeping argument dispatch and status mapping
+/// consistent across binaries.
 #[must_use]
 pub fn run_with<I, Out, Err>(args: I, stdout: &mut Out, stderr: &mut Err) -> ExitCode
 where


### PR DESCRIPTION
## Summary
- update the client wrapper documentation to reference the shared branding constants
- document the daemon wrapper using the same metadata-driven terminology for both binary names

## Testing
- not run (docs only)

------