### PR TITLE
Fix branding references in binary docs

### DIFF
--- a/src/bin/client.rs
+++ b/src/bin/client.rs
@@ -6,8 +6,8 @@ use std::process::ExitCode;
 /// Runs the shared client entry point for every branded executable.
 ///
 /// Both branded binaries—the upstream-compatible client exposed as
-/// [`rsync_core::version::PROGRAM_NAME`] and the oc-branded wrapper
-/// published as [`rsync_core::version::OC_PROGRAM_NAME`]—call into this
+/// `rsync_core::version::PROGRAM_NAME` and the oc-branded wrapper
+/// published as `rsync_core::version::OC_PROGRAM_NAME`—call into this
 /// helper. Centralising the logic keeps tests, packaging, and telemetry
 /// focused on a single execution path. The helper forwards its arguments
 /// and I/O handles to the CLI crate and normalises the returned status via

--- a/src/bin/daemon.rs
+++ b/src/bin/daemon.rs
@@ -6,8 +6,8 @@ use std::process::ExitCode;
 /// Runs the shared daemon entry point for every branded executable.
 ///
 /// Both daemon brands—the upstream-compatible service identified by
-/// [`rsync_core::version::DAEMON_PROGRAM_NAME`] and the oc-branded
-/// wrapper published as [`rsync_core::version::OC_DAEMON_PROGRAM_NAME`]—
+/// `rsync_core::version::DAEMON_PROGRAM_NAME` and the oc-branded
+/// wrapper published as `rsync_core::version::OC_DAEMON_PROGRAM_NAME`—
 /// call into this helper, keeping argument dispatch and status mapping
 /// consistent across binaries.
 #[must_use]


### PR DESCRIPTION
## Summary
- switch the client and daemon binary docs to reference the branding constants without broken intra-doc links

## Testing
- cargo --locked run -p xtask -- docs --validate
- cargo doc --no-deps

------