### PR TITLE
Fix cargo-rpm metadata and add packaging spec

### DIFF
--- a/.rpm/etc/default/oc-rsyncd
+++ b/.rpm/etc/default/oc-rsyncd
@@ -1,0 +1,1 @@
+../../../packaging/default/oc-rsyncd

--- a/.rpm/etc/oc-rsyncd/oc-rsyncd.conf
+++ b/.rpm/etc/oc-rsyncd/oc-rsyncd.conf
@@ -1,0 +1,1 @@
+../../../packaging/etc/oc-rsyncd/oc-rsyncd.conf

--- a/.rpm/etc/oc-rsyncd/oc-rsyncd.secrets
+++ b/.rpm/etc/oc-rsyncd/oc-rsyncd.secrets
@@ -1,0 +1,1 @@
+../../../packaging/etc/oc-rsyncd/oc-rsyncd.secrets

--- a/.rpm/oc-rsync.spec
+++ b/.rpm/oc-rsync.spec
@@ -1,0 +1,49 @@
+%define __spec_install_post %{nil}
+%define __os_install_post %{_dbpath}/brp-compress
+%define debug_package %{nil}
+
+Name: oc-rsync
+Summary: Rust implementation of rsync-compatible client and daemon (includes oc-rsync compatibility wrappers)
+Version: @@VERSION@@
+Release: @@RELEASE@@%{?dist}
+License: GPL-3.0-or-later
+URL: https://github.com/oferchen/rsync
+Group: Applications/System
+Source0: %{name}-%{version}.tar.gz
+Requires: glibc, libgcc
+
+BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
+
+%description
+Pure-Rust implementation of rsync-compatible client and daemon binaries. Ships oc-rsync compatibility wrappers for environments that still rely on the legacy branding.
+
+%prep
+%setup -q
+
+%install
+rm -rf %{buildroot}
+mkdir -p %{buildroot}
+cp -a * %{buildroot}
+
+%clean
+rm -rf %{buildroot}
+
+%post
+%systemd_post oc-rsyncd.service
+
+%preun
+%systemd_preun oc-rsyncd.service
+
+%postun
+%systemd_postun_with_restart oc-rsyncd.service
+
+%files
+%defattr(-,root,root,-)
+%{_bindir}/oc-rsync
+%{_bindir}/oc-rsyncd
+%{_bindir}/rsync
+%{_bindir}/rsyncd
+%{_unitdir}/oc-rsyncd.service
+%config(noreplace) %{_sysconfdir}/oc-rsyncd/oc-rsyncd.conf
+%config(noreplace) %{_sysconfdir}/oc-rsyncd/oc-rsyncd.secrets
+%config(noreplace) %{_sysconfdir}/default/oc-rsyncd

--- a/.rpm/usr/lib/systemd/system/oc-rsyncd.service
+++ b/.rpm/usr/lib/systemd/system/oc-rsyncd.service
@@ -1,0 +1,1 @@
+../../../../../packaging/systemd/oc-rsyncd.service

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,14 +122,19 @@ conf-files = [
 [package.metadata.rpm]
 package = "oc-rsync"
 summary = "Rust implementation of rsync-compatible client and daemon (includes oc-rsync compatibility wrappers)"
-requires = ["glibc", "libgcc"]
-assets = [
-    { path = "target/release/rsync", dest = "/usr/bin/rsync", mode = "0755" },
-    { path = "target/release/rsyncd", dest = "/usr/bin/rsyncd", mode = "0755" },
-    { path = "target/release/oc-rsync", dest = "/usr/bin/oc-rsync", mode = "0755" },
-    { path = "target/release/oc-rsyncd", dest = "/usr/bin/oc-rsyncd", mode = "0755" },
-    { path = "packaging/systemd/oc-rsyncd.service", dest = "/usr/lib/systemd/system/oc-rsyncd.service", mode = "0644" },
-    { path = "packaging/etc/oc-rsyncd/oc-rsyncd.conf", dest = "/etc/oc-rsyncd/oc-rsyncd.conf", mode = "0644", config = true },
-    { path = "packaging/etc/oc-rsyncd/oc-rsyncd.secrets", dest = "/etc/oc-rsyncd/oc-rsyncd.secrets", mode = "0600", config = true },
-    { path = "packaging/default/oc-rsyncd", dest = "/etc/default/oc-rsyncd", mode = "0644", config = true },
-]
+
+[package.metadata.rpm.cargo]
+buildflags = ["--release"]
+
+[package.metadata.rpm.targets]
+rsync = { path = "/usr/bin/rsync", mode = "0755" }
+rsyncd = { path = "/usr/bin/rsyncd", mode = "0755" }
+"oc-rsync" = { path = "/usr/bin/oc-rsync", mode = "0755" }
+"oc-rsyncd" = { path = "/usr/bin/oc-rsyncd", mode = "0755" }
+
+[package.metadata.rpm.files]
+"usr/lib/systemd/system/oc-rsyncd.service" = { path = "/usr/lib/systemd/system/oc-rsyncd.service", mode = "0644" }
+"etc/oc-rsyncd/oc-rsyncd.conf" = { path = "/etc/oc-rsyncd/oc-rsyncd.conf", mode = "0644" }
+"etc/oc-rsyncd/oc-rsyncd.secrets" = { path = "/etc/oc-rsyncd/oc-rsyncd.secrets", mode = "0600" }
+"etc/default/oc-rsyncd" = { path = "/etc/default/oc-rsyncd", mode = "0644" }
+


### PR DESCRIPTION
## Summary
- update the RPM metadata in `Cargo.toml` to the modern `targets`/`files` schema and ensure the release profile is used when packaging
- add an `.rpm` directory with the generated spec file and symlinks to existing packaging assets so `cargo rpm` can stage the service and config files

## Testing
- `cargo --locked rpm build -v` *(fails: `rpmbuild` is not available in the container)*

------