### PR TITLE
Deduplicate connect-program validation message

### DIFF
--- a/crates/cli/src/frontend/execution/drive/mod.rs
+++ b/crates/cli/src/frontend/execution/drive/mod.rs
@@ -7,6 +7,8 @@ mod module_listing;
 mod options;
 mod summary;
 mod validation;
+#[cfg(test)]
+pub(crate) use validation::CONNECT_PROGRAM_DAEMON_ONLY_MESSAGE;
 mod workflow;
 
 use rsync_logging::MessageSink;

--- a/crates/cli/src/frontend/execution/drive/validation.rs
+++ b/crates/cli/src/frontend/execution/drive/validation.rs
@@ -8,6 +8,17 @@ use rsync_protocol::ProtocolVersion;
 
 use crate::frontend::write_message;
 
+pub(crate) const RSYNC_PATH_REMOTE_ONLY_MESSAGE: &str =
+    "the --rsync-path option may only be used with remote connections";
+pub(crate) const REMOTE_OPTION_REMOTE_ONLY_MESSAGE: &str =
+    "the --remote-option option may only be used with remote connections";
+pub(crate) const PROTOCOL_DAEMON_ONLY_MESSAGE: &str =
+    "the --protocol option may only be used when accessing an rsync daemon";
+pub(crate) const PASSWORD_FILE_DAEMON_ONLY_MESSAGE: &str =
+    "the --password-file option may only be used when accessing an rsync daemon";
+pub(crate) const CONNECT_PROGRAM_DAEMON_ONLY_MESSAGE: &str =
+    "the --connect-program option may only be used when accessing an rsync daemon";
+
 pub(super) fn validate_local_only_options<Err>(
     fallback_required: bool,
     desired_protocol: Option<ProtocolVersion>,
@@ -25,75 +36,47 @@ where
     }
 
     if rsync_path.is_some() {
-        let message = rsync_error!(
-            1,
-            "the --rsync-path option may only be used with remote connections"
-        )
-        .with_role(Role::Client);
+        let message = rsync_error!(1, "{}", RSYNC_PATH_REMOTE_ONLY_MESSAGE).with_role(Role::Client);
         if write_message(&message, stderr).is_err() {
-            let _ = writeln!(
-                stderr.writer_mut(),
-                "the --rsync-path option may only be used with remote connections"
-            );
+            let _ = writeln!(stderr.writer_mut(), "{}", RSYNC_PATH_REMOTE_ONLY_MESSAGE);
         }
         return Some(1);
     }
 
     if !remote_options.is_empty() {
-        let message = rsync_error!(
-            1,
-            "the --remote-option option may only be used with remote connections"
-        )
-        .with_role(Role::Client);
+        let message =
+            rsync_error!(1, "{}", REMOTE_OPTION_REMOTE_ONLY_MESSAGE).with_role(Role::Client);
         if write_message(&message, stderr).is_err() {
-            let _ = writeln!(
-                stderr.writer_mut(),
-                "the --remote-option option may only be used with remote connections"
-            );
+            let _ = writeln!(stderr.writer_mut(), "{}", REMOTE_OPTION_REMOTE_ONLY_MESSAGE);
         }
         return Some(1);
     }
 
     if desired_protocol.is_some() {
-        let message = rsync_error!(
-            1,
-            "the --protocol option may only be used when accessing an rsync daemon"
-        )
-        .with_role(Role::Client);
+        let message = rsync_error!(1, "{}", PROTOCOL_DAEMON_ONLY_MESSAGE).with_role(Role::Client);
         if write_message(&message, stderr).is_err() {
-            let _ = writeln!(
-                stderr.writer_mut(),
-                "the --protocol option may only be used when accessing an rsync daemon"
-            );
+            let _ = writeln!(stderr.writer_mut(), "{}", PROTOCOL_DAEMON_ONLY_MESSAGE);
         }
         return Some(1);
     }
 
     if password_file.is_some() {
-        let message = rsync_error!(
-            1,
-            "the --password-file option may only be used when accessing an rsync daemon"
-        )
-        .with_role(Role::Client);
+        let message =
+            rsync_error!(1, "{}", PASSWORD_FILE_DAEMON_ONLY_MESSAGE).with_role(Role::Client);
         if write_message(&message, stderr).is_err() {
-            let _ = writeln!(
-                stderr.writer_mut(),
-                "the --password-file option may only be used when accessing an rsync daemon"
-            );
+            let _ = writeln!(stderr.writer_mut(), "{}", PASSWORD_FILE_DAEMON_ONLY_MESSAGE);
         }
         return Some(1);
     }
 
     if connect_program.is_some() {
-        let message = rsync_error!(
-            1,
-            "the --connect-program option may only be used when accessing an rsync daemon"
-        )
-        .with_role(Role::Client);
+        let message =
+            rsync_error!(1, "{}", CONNECT_PROGRAM_DAEMON_ONLY_MESSAGE).with_role(Role::Client);
         if write_message(&message, stderr).is_err() {
             let _ = writeln!(
                 stderr.writer_mut(),
-                "the --connect-program option may only be used when accessing an rsync daemon"
+                "{}",
+                CONNECT_PROGRAM_DAEMON_ONLY_MESSAGE
             );
         }
         return Some(1);

--- a/crates/cli/src/frontend/execution/mod.rs
+++ b/crates/cli/src/frontend/execution/mod.rs
@@ -14,6 +14,8 @@ pub(crate) use compression::{
     CompressLevelArg, parse_bandwidth_limit, parse_compress_level, parse_compress_level_argument,
 };
 #[cfg(test)]
+pub(crate) use drive::CONNECT_PROGRAM_DAEMON_ONLY_MESSAGE;
+#[cfg(test)]
 pub(crate) use file_list::read_file_list_from_reader;
 pub(crate) use file_list::{load_file_list_operands, transfer_requires_remote};
 pub(crate) use flags::{

--- a/crates/cli/src/frontend/tests/connect.rs
+++ b/crates/cli/src/frontend/tests/connect.rs
@@ -1,5 +1,6 @@
 use super::common::*;
 use super::*;
+use crate::frontend::execution::CONNECT_PROGRAM_DAEMON_ONLY_MESSAGE;
 
 #[test]
 fn connect_program_requires_remote_operands() {
@@ -20,10 +21,6 @@ fn connect_program_requires_remote_operands() {
     assert_eq!(code, 1);
     assert!(stdout.is_empty());
     let message = String::from_utf8(stderr).expect("stderr utf8");
-    assert!(
-        message.contains(
-            "the --connect-program option may only be used when accessing an rsync daemon"
-        )
-    );
+    assert!(message.contains(CONNECT_PROGRAM_DAEMON_ONLY_MESSAGE));
     assert!(!dest.exists());
 }


### PR DESCRIPTION
## Summary
- centralize the remote-only validation message strings in `validation.rs`
- reuse the connect-program message in the unit test via a shared constant

## Testing
- cargo test -p rsync-cli frontend::tests::connect_tests::connect_program_requires_remote_operands -- --nocapture
- cargo test -p rsync-cli --doc

------