### PR TITLE
Fix RPM packaging config asset metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,6 +122,16 @@ conf-files = [
 [package.metadata.rpm]
 package = "oc-rsync"
 summary = "Rust implementation of rsync-compatible client and daemon (includes oc-rsync compatibility wrappers)"
+assets = [
+    { path = "target/release/rsync", dest = "/usr/bin/rsync", mode = "0755" },
+    { path = "target/release/rsyncd", dest = "/usr/bin/rsyncd", mode = "0755" },
+    { path = "target/release/oc-rsync", dest = "/usr/bin/oc-rsync", mode = "0755" },
+    { path = "target/release/oc-rsyncd", dest = "/usr/bin/oc-rsyncd", mode = "0755" },
+    { path = "packaging/systemd/oc-rsyncd.service", dest = "/usr/lib/systemd/system/oc-rsyncd.service", mode = "0644" },
+    { path = "packaging/etc/oc-rsyncd/oc-rsyncd.conf", dest = "/etc/oc-rsyncd/oc-rsyncd.conf", mode = "0644", config = true },
+    { path = "packaging/etc/oc-rsyncd/oc-rsyncd.secrets", dest = "/etc/oc-rsyncd/oc-rsyncd.secrets", mode = "0600", config = true },
+    { path = "packaging/default/oc-rsyncd", dest = "/etc/default/oc-rsyncd", mode = "0644", config = true },
+]
 
 [package.metadata.rpm.cargo]
 buildflags = ["--release"]
@@ -131,10 +141,4 @@ rsync = { path = "/usr/bin/rsync", mode = "0755" }
 rsyncd = { path = "/usr/bin/rsyncd", mode = "0755" }
 "oc-rsync" = { path = "/usr/bin/oc-rsync", mode = "0755" }
 "oc-rsyncd" = { path = "/usr/bin/oc-rsyncd", mode = "0755" }
-
-[package.metadata.rpm.files]
-"usr/lib/systemd/system/oc-rsyncd.service" = { path = "/usr/lib/systemd/system/oc-rsyncd.service", mode = "0644" }
-"etc/oc-rsyncd/oc-rsyncd.conf" = { path = "/etc/oc-rsyncd/oc-rsyncd.conf", mode = "0644" }
-"etc/oc-rsyncd/oc-rsyncd.secrets" = { path = "/etc/oc-rsyncd/oc-rsyncd.secrets", mode = "0600" }
-"etc/default/oc-rsyncd" = { path = "/etc/default/oc-rsyncd", mode = "0644" }
 


### PR DESCRIPTION
## Summary
- migrate the RPM metadata to the `assets` array expected by the preflight validator
- mark the daemon configuration, secrets, and default environment files as config assets so packaging preserves local edits

## Testing
- cargo --locked run -p xtask -- preflight

------