### PR TITLE
Fix RPM packaging configuration

### DIFF
--- a/.rpm/oc-rsync.spec
+++ b/.rpm/oc-rsync.spec
@@ -1,6 +1,7 @@
 %define __spec_install_post %{nil}
 %define __os_install_post %{_dbpath}/brp-compress
 %define debug_package %{nil}
+%{!?_unitdir:%global _unitdir %{_prefix}/lib/systemd/system}
 
 Name: oc-rsync
 Summary: Rust implementation of rsync-compatible client and daemon (includes oc-rsync compatibility wrappers)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,16 +122,22 @@ conf-files = [
 [package.metadata.rpm]
 package = "oc-rsync"
 summary = "Rust implementation of rsync-compatible client and daemon (includes oc-rsync compatibility wrappers)"
-assets = [
-    { path = "target/release/rsync", dest = "/usr/bin/rsync", mode = "0755" },
-    { path = "target/release/rsyncd", dest = "/usr/bin/rsyncd", mode = "0755" },
-    { path = "target/release/oc-rsync", dest = "/usr/bin/oc-rsync", mode = "0755" },
-    { path = "target/release/oc-rsyncd", dest = "/usr/bin/oc-rsyncd", mode = "0755" },
-    { path = "packaging/systemd/oc-rsyncd.service", dest = "/usr/lib/systemd/system/oc-rsyncd.service", mode = "0644" },
-    { path = "packaging/etc/oc-rsyncd/oc-rsyncd.conf", dest = "/etc/oc-rsyncd/oc-rsyncd.conf", mode = "0644", config = true },
-    { path = "packaging/etc/oc-rsyncd/oc-rsyncd.secrets", dest = "/etc/oc-rsyncd/oc-rsyncd.secrets", mode = "0600", config = true },
-    { path = "packaging/default/oc-rsyncd", dest = "/etc/default/oc-rsyncd", mode = "0644", config = true },
-]
+
+[package.metadata.rpm.files."../packaging/systemd/oc-rsyncd.service"]
+path = "/usr/lib/systemd/system/oc-rsyncd.service"
+mode = "0644"
+
+[package.metadata.rpm.files."../packaging/etc/oc-rsyncd/oc-rsyncd.conf"]
+path = "/etc/oc-rsyncd/oc-rsyncd.conf"
+mode = "0644"
+
+[package.metadata.rpm.files."../packaging/etc/oc-rsyncd/oc-rsyncd.secrets"]
+path = "/etc/oc-rsyncd/oc-rsyncd.secrets"
+mode = "0600"
+
+[package.metadata.rpm.files."../packaging/default/oc-rsyncd"]
+path = "/etc/default/oc-rsyncd"
+mode = "0644"
 
 [package.metadata.rpm.cargo]
 buildflags = ["--release"]


### PR DESCRIPTION
## Summary
- ensure the RPM spec defines a fallback `_unitdir` so systemd paths are absolute
- package the service and configuration files via `package.metadata.rpm.files` so cargo-rpm bundles them into the archive

## Testing
- `cargo --locked rpm build -v` *(fails: rpmbuild not available in container)*

------