### PR TITLE
Lock connect test environment

### DIFF
--- a/crates/cli/src/frontend/tests/connect.rs
+++ b/crates/cli/src/frontend/tests/connect.rs
@@ -4,6 +4,7 @@ use crate::frontend::execution::CONNECT_PROGRAM_DAEMON_ONLY_MESSAGE;
 
 #[test]
 fn connect_program_requires_remote_operands() {
+    let _env_lock = ENV_LOCK.lock().expect("env lock");
     use tempfile::tempdir;
 
     let temp = tempdir().expect("tempdir");


### PR DESCRIPTION
## Summary
- serialize frontend connect test execution with other environment-mutating tests by acquiring the shared ENV_LOCK

## Testing
- cargo test -p rsync-cli --lib

------