### PR TITLE
Allow oc-rsync packages to coexist with upstream rsync installs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -149,17 +149,3 @@ rsyncd = { path = "/usr/libexec/oc-rsync/rsyncd", mode = "0755" }
 "oc-rsync" = { path = "/usr/bin/oc-rsync", mode = "0755" }
 "oc-rsyncd" = { path = "/usr/bin/oc-rsyncd", mode = "0755" }
 
-[package.metadata.rpm.scripts]
-post = """
-if command -v alternatives >/dev/null 2>&1; then
-    alternatives --install /usr/bin/rsync rsync /usr/libexec/oc-rsync/rsync 50
-    alternatives --install /usr/bin/rsyncd rsyncd /usr/libexec/oc-rsync/rsyncd 50
-fi
-"""
-preun = """
-if [ "$1" -eq 0 ] && command -v alternatives >/dev/null 2>&1; then
-    alternatives --remove rsync /usr/libexec/oc-rsync/rsync || true
-    alternatives --remove rsyncd /usr/libexec/oc-rsync/rsyncd || true
-fi
-"""
-

--- a/packaging/deb/postinst
+++ b/packaging/deb/postinst
@@ -1,9 +1,8 @@
 #!/bin/sh
 set -e
 
-if command -v update-alternatives >/dev/null 2>&1; then
-    update-alternatives --install /usr/bin/rsync rsync /usr/libexec/oc-rsync/rsync 50
-    update-alternatives --install /usr/bin/rsyncd rsyncd /usr/libexec/oc-rsync/rsyncd 50
-fi
+# No post-install actions are required when co-installing alongside
+# upstream rsync packages. The oc-rsync binaries ship under unique
+# names so they can coexist without touching /usr/bin/rsync.
 
 exit 0

--- a/packaging/deb/postrm
+++ b/packaging/deb/postrm
@@ -1,9 +1,7 @@
 #!/bin/sh
 set -e
 
-if [ "$1" = "purge" ] && command -v update-alternatives >/dev/null 2>&1; then
-    update-alternatives --remove rsync /usr/libexec/oc-rsync/rsync 2>/dev/null || true
-    update-alternatives --remove rsyncd /usr/libexec/oc-rsync/rsyncd 2>/dev/null || true
-fi
+# No purge-time cleanup is required; oc-rsync does not register
+# system-wide alternatives when removed.
 
 exit 0

--- a/packaging/deb/prerm
+++ b/packaging/deb/prerm
@@ -1,17 +1,7 @@
 #!/bin/sh
 set -e
 
-case "$1" in
-    remove|deconfigure)
-        if command -v update-alternatives >/dev/null 2>&1; then
-            update-alternatives --remove rsync /usr/libexec/oc-rsync/rsync || true
-            update-alternatives --remove rsyncd /usr/libexec/oc-rsync/rsyncd || true
-        fi
-        ;;
-    upgrade|failed-upgrade)
-        ;;
-    *)
-        ;;
-esac
+# No special handling is necessary during removal; the package no longer
+# registers alternatives that could collide with upstream rsync.
 
 exit 0

--- a/packaging/systemd/oc-rsyncd.service
+++ b/packaging/systemd/oc-rsyncd.service
@@ -31,4 +31,3 @@ UMask=0077
 
 [Install]
 WantedBy=multi-user.target
-Alias=rsyncd.service


### PR DESCRIPTION
## Summary
- remove Debian maintainer scripts that registered oc-rsync as the /usr/bin/rsync alternative
- drop RPM alternative registration and the rsyncd.service alias so upstream rsync packages can stay installed

## Testing
- not run (packaging-only changes)

------