### PR TITLE
Support co-installation with upstream rsync via alternatives

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,6 +140,109 @@ mode = "0600"
 path = "/etc/default/oc-rsyncd"
 mode = "0644"
 
+
+[package.metadata.rpm.scripts]
+post = '''
+set -e
+
+ALT_NAME=rsync
+ALT_MASTER=/usr/bin/rsync
+ALT_IMPL=/usr/libexec/oc-rsync/rsync
+ALT_SLAVE_NAME=rsyncd
+ALT_SLAVE_LINK=/usr/bin/rsyncd
+ALT_SLAVE_IMPL=/usr/libexec/oc-rsync/rsyncd
+ALT_PRIORITY=30
+
+detect_alternatives() {
+    if command -v update-alternatives >/dev/null 2>&1; then
+        ALT_TOOL=update-alternatives
+    elif command -v alternatives >/dev/null 2>&1; then
+        ALT_TOOL=alternatives
+    else
+        ALT_TOOL=
+    fi
+}
+
+register_alternatives() {
+    detect_alternatives
+    if [ -z "$ALT_TOOL" ]; then
+        return 0
+    fi
+
+    if [ -e "$ALT_MASTER" ] && [ ! -L "$ALT_MASTER" ]; then
+        if ! "$ALT_TOOL" --display "$ALT_NAME" >/dev/null 2>&1; then
+            return 0
+        fi
+    fi
+
+    "$ALT_TOOL" --install "$ALT_MASTER" "$ALT_NAME" "$ALT_IMPL" "$ALT_PRIORITY" --slave "$ALT_SLAVE_LINK" "$ALT_SLAVE_NAME" "$ALT_SLAVE_IMPL" >/dev/null
+}
+
+register_alternatives
+'''
+preun = '''
+set -e
+
+ALT_NAME=rsync
+ALT_IMPL=/usr/libexec/oc-rsync/rsync
+
+detect_alternatives() {
+    if command -v update-alternatives >/dev/null 2>&1; then
+        ALT_TOOL=update-alternatives
+    elif command -v alternatives >/dev/null 2>&1; then
+        ALT_TOOL=alternatives
+    else
+        ALT_TOOL=
+    fi
+}
+
+remove_alternatives() {
+    detect_alternatives
+    if [ -z "$ALT_TOOL" ]; then
+        return 0
+    fi
+
+    if "$ALT_TOOL" --display "$ALT_NAME" >/dev/null 2>&1; then
+        "$ALT_TOOL" --remove "$ALT_NAME" "$ALT_IMPL" >/dev/null || true
+    fi
+}
+
+if [ "$1" -eq 0 ]; then
+    remove_alternatives
+fi
+'''
+postun = '''
+set -e
+
+ALT_NAME=rsync
+ALT_IMPL=/usr/libexec/oc-rsync/rsync
+
+detect_alternatives() {
+    if command -v update-alternatives >/dev/null 2>&1; then
+        ALT_TOOL=update-alternatives
+    elif command -v alternatives >/dev/null 2>&1; then
+        ALT_TOOL=alternatives
+    else
+        ALT_TOOL=
+    fi
+}
+
+remove_alternatives() {
+    detect_alternatives
+    if [ -z "$ALT_TOOL" ]; then
+        return 0
+    fi
+
+    if "$ALT_TOOL" --display "$ALT_NAME" >/dev/null 2>&1; then
+        "$ALT_TOOL" --remove "$ALT_NAME" "$ALT_IMPL" >/dev/null || true
+    fi
+}
+
+if [ "$1" -eq 0 ]; then
+    remove_alternatives
+fi
+'''
+
 [package.metadata.rpm.cargo]
 buildflags = ["--release"]
 

--- a/packaging/deb/postinst
+++ b/packaging/deb/postinst
@@ -1,8 +1,47 @@
 #!/bin/sh
 set -e
 
-# No post-install actions are required when co-installing alongside
-# upstream rsync packages. The oc-rsync binaries ship under unique
-# names so they can coexist without touching /usr/bin/rsync.
+ALT_NAME="rsync"
+ALT_MASTER="/usr/bin/rsync"
+ALT_IMPL="/usr/libexec/oc-rsync/rsync"
+ALT_SLAVE_NAME="rsyncd"
+ALT_SLAVE_LINK="/usr/bin/rsyncd"
+ALT_SLAVE_IMPL="/usr/libexec/oc-rsync/rsyncd"
+ALT_PRIORITY=30
+
+have_update_alternatives() {
+    command -v update-alternatives >/dev/null 2>&1
+}
+
+register_alternatives() {
+    if ! have_update_alternatives; then
+        return 0
+    fi
+
+    if [ -e "${ALT_MASTER}" ] && [ ! -L "${ALT_MASTER}" ]; then
+        if ! update-alternatives --display "${ALT_NAME}" >/dev/null 2>&1; then
+            # The upstream rsync package owns /usr/bin/rsync as a regular file.
+            # Respect the existing binary so both packages can coexist.
+            return 0
+        fi
+    fi
+
+    update-alternatives \
+        --install "${ALT_MASTER}" "${ALT_NAME}" "${ALT_IMPL}" "${ALT_PRIORITY}" \
+        --slave "${ALT_SLAVE_LINK}" "${ALT_SLAVE_NAME}" "${ALT_SLAVE_IMPL}" \
+        >/dev/null
+}
+
+case "$1" in
+    configure)
+        register_alternatives
+        ;;
+    abort-upgrade|abort-remove|abort-deconfigure)
+        :
+        ;;
+    *)
+        :
+        ;;
+esac
 
 exit 0

--- a/packaging/deb/postrm
+++ b/packaging/deb/postrm
@@ -1,7 +1,33 @@
 #!/bin/sh
 set -e
 
-# No purge-time cleanup is required; oc-rsync does not register
-# system-wide alternatives when removed.
+ALT_NAME="rsync"
+ALT_IMPL="/usr/libexec/oc-rsync/rsync"
+
+have_update_alternatives() {
+    command -v update-alternatives >/dev/null 2>&1
+}
+
+remove_alternatives_if_present() {
+    if ! have_update_alternatives; then
+        return 0
+    fi
+
+    if update-alternatives --display "${ALT_NAME}" >/dev/null 2>&1; then
+        update-alternatives --remove "${ALT_NAME}" "${ALT_IMPL}" >/dev/null || true
+    fi
+}
+
+case "$1" in
+    purge)
+        remove_alternatives_if_present
+        ;;
+    remove|upgrade|failed-upgrade|abort-install|abort-upgrade|disappear)
+        :
+        ;;
+    *)
+        :
+        ;;
+esac
 
 exit 0

--- a/packaging/deb/prerm
+++ b/packaging/deb/prerm
@@ -1,7 +1,33 @@
 #!/bin/sh
 set -e
 
-# No special handling is necessary during removal; the package no longer
-# registers alternatives that could collide with upstream rsync.
+ALT_NAME="rsync"
+ALT_IMPL="/usr/libexec/oc-rsync/rsync"
+
+have_update_alternatives() {
+    command -v update-alternatives >/dev/null 2>&1
+}
+
+remove_alternatives() {
+    if ! have_update_alternatives; then
+        return 0
+    fi
+
+    if update-alternatives --display "${ALT_NAME}" >/dev/null 2>&1; then
+        update-alternatives --remove "${ALT_NAME}" "${ALT_IMPL}" >/dev/null || true
+    fi
+}
+
+case "$1" in
+    remove|deconfigure)
+        remove_alternatives
+        ;;
+    upgrade|failed-upgrade)
+        :
+        ;;
+    *)
+        :
+        ;;
+esac
 
 exit 0


### PR DESCRIPTION
## Summary
- teach the Debian maintainer scripts to register the oc-rsync binaries with update-alternatives only when the upstream rsync binary is not already owning /usr/bin/rsync
- ensure the Debian prerm/postrm hooks drop the oc-rsync entries from update-alternatives during removal or purge
- add RPM scriptlets that manage the same alternatives entries using the platform-provided alternatives tool so both packages can co-exist

## Testing
- not run (packaging change only)

------