### PR TITLE
Guard daemon fallback tests with env lock

### DIFF
--- a/crates/daemon/src/daemon/sections/tests.rs
+++ b/crates/daemon/src/daemon/sections/tests.rs
@@ -1,56 +1,10 @@
 #![allow(unsafe_code)]
 
 use super::*;
+use crate::test_env::{EnvGuard, ENV_LOCK};
 use rsync_core::branding::Brand;
 use rsync_core::fallback::{CLIENT_FALLBACK_ENV, DAEMON_FALLBACK_ENV};
-use std::env;
 use std::ffi::{OsStr, OsString};
-
-struct EnvGuard {
-    key: OsString,
-    original: Option<OsString>,
-}
-
-impl EnvGuard {
-    fn unset<K>(key: K) -> Self
-    where
-        K: Into<OsString>,
-    {
-        let key = key.into();
-        let original = env::var_os(&key);
-        unsafe {
-            env::remove_var(&key);
-        }
-        Self { key, original }
-    }
-
-    fn set<K, V>(key: K, value: V) -> Self
-    where
-        K: Into<OsString>,
-        V: Into<OsString>,
-    {
-        let key = key.into();
-        let original = env::var_os(&key);
-        unsafe {
-            env::set_var(&key, value.into());
-        }
-        Self { key, original }
-    }
-}
-
-impl Drop for EnvGuard {
-    fn drop(&mut self) {
-        if let Some(value) = self.original.as_ref() {
-            unsafe {
-                env::set_var(&self.key, value);
-            }
-        } else {
-            unsafe {
-                env::remove_var(&self.key);
-            }
-        }
-    }
-}
 
 #[test]
 fn parse_daemon_option_extracts_option_payload() {
@@ -73,23 +27,26 @@ fn canonical_option_trims_prefix_and_normalises_case() {
 
 #[test]
 fn configured_fallback_binary_defaults_to_upstream_branding() {
-    let _daemon_guard = EnvGuard::unset(DAEMON_FALLBACK_ENV);
-    let _client_guard = EnvGuard::unset(CLIENT_FALLBACK_ENV);
+    let _env_lock = ENV_LOCK.lock().expect("env lock");
+    let _daemon_guard = EnvGuard::remove(DAEMON_FALLBACK_ENV);
+    let _client_guard = EnvGuard::remove(CLIENT_FALLBACK_ENV);
     let expected = OsString::from(Brand::Upstream.client_program_name());
     assert_eq!(configured_fallback_binary(), Some(expected));
 }
 
 #[test]
 fn configured_fallback_binary_prefers_daemon_override() {
+    let _env_lock = ENV_LOCK.lock().expect("env lock");
     let override_path = OsString::from("/opt/oc-rsync");
-    let _client_guard = EnvGuard::unset(CLIENT_FALLBACK_ENV);
+    let _client_guard = EnvGuard::remove(CLIENT_FALLBACK_ENV);
     let _daemon_guard = EnvGuard::set(DAEMON_FALLBACK_ENV, &override_path);
     assert_eq!(configured_fallback_binary(), Some(override_path));
 }
 
 #[test]
 fn configured_fallback_binary_allows_default_keyword() {
-    let _daemon_guard = EnvGuard::unset(DAEMON_FALLBACK_ENV);
+    let _env_lock = ENV_LOCK.lock().expect("env lock");
+    let _daemon_guard = EnvGuard::remove(DAEMON_FALLBACK_ENV);
     let _client_guard = EnvGuard::set(CLIENT_FALLBACK_ENV, OsStr::new("default"));
     let expected = OsString::from(Brand::Upstream.client_program_name());
     assert_eq!(configured_fallback_binary(), Some(expected));


### PR DESCRIPTION
## Summary
- reuse the shared daemon EnvGuard helper in `sections` tests
- serialize environment mutations in fallback binary tests with the global lock

## Testing
- cargo test -p rsync-daemon configured_fallback_binary_prefers_daemon_override

------