### PR TITLE
Gate legacy wrappers behind optional feature for side-by-side installs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,12 @@ autobins = false
 [[bin]]
 name = "rsync"
 path = "src/bin/rsync.rs"
+required-features = ["legacy-binaries"]
 
 [[bin]]
 name = "rsyncd"
 path = "src/bin/rsyncd.rs"
+required-features = ["legacy-binaries"]
 
 [[bin]]
 name = "oc-rsync"
@@ -27,6 +29,7 @@ path = "src/bin/oc-rsyncd.rs"
 
 [features]
 default = []
+legacy-binaries = []
 sd-notify = ["rsync-daemon/sd-notify"]
 
 [dependencies]
@@ -103,6 +106,7 @@ priority = "optional"
 maintainer = "Ofer Chen <skewers.irises.3b@icloud.com>"
 depends = "libc6 (>= 2.34), libgcc-s1"
 extended-description = "Pure-Rust implementation of rsync-compatible client and daemon binaries. Ships oc-rsync compatibility wrappers for environments that still rely on the legacy branding."
+features = ["legacy-binaries"]
 assets = [
     ["target/release/rsync", "/usr/libexec/oc-rsync/rsync", "755"],
     ["target/release/rsyncd", "/usr/libexec/oc-rsync/rsyncd", "755"],
@@ -248,7 +252,7 @@ fi
 '''
 
 [package.metadata.rpm.cargo]
-buildflags = ["--release"]
+buildflags = ["--release", "--features", "legacy-binaries"]
 
 [package.metadata.rpm.targets]
 rsync = { path = "/usr/libexec/oc-rsync/rsync", mode = "0755" }

--- a/xtask/src/commands/package.rs
+++ b/xtask/src/commands/package.rs
@@ -179,6 +179,9 @@ fn build_workspace_binaries(workspace: &Path, profile: &Option<OsString>) -> Tas
         OsString::from("--locked"),
     ];
 
+    args.push(OsString::from("--features"));
+    args.push(OsString::from("legacy-binaries"));
+
     if let Some(profile) = profile {
         args.push(OsString::from("--profile"));
         args.push(profile.clone());


### PR DESCRIPTION
## Summary
- gate the legacy `rsync`/`rsyncd` compatibility wrappers behind a new `legacy-binaries` feature so they are omitted from default builds
- ensure Debian and RPM packaging explicitly enable the feature while invoking `cargo build` with it through `xtask package`

## Testing
- cargo check
- cargo check --features legacy-binaries

------