### PR TITLE
Enable legacy wrapper binaries by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ name = "oc-rsyncd"
 path = "src/bin/oc-rsyncd.rs"
 
 [features]
-default = []
+default = ["legacy-binaries"]
 legacy-binaries = []
 sd-notify = ["rsync-daemon/sd-notify"]
 


### PR DESCRIPTION
## Summary
- enable the legacy binary wrappers feature by default so rsync/rsyncd are always built

## Testing
- cargo test --test cli_binaries

------