### PR TITLE
Add amd64 tarball artifact and guard packaging alternatives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -968,6 +968,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1350,8 +1361,10 @@ name = "xtask"
 version = "3.4.1-rust"
 dependencies = [
  "cargo_metadata",
+ "flate2",
  "serde",
  "serde_json",
+ "tar",
  "tempfile",
  "toml",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -171,9 +171,23 @@ detect_alternatives() {
     fi
 }
 
+rpm_upstream_rsync_installed() {
+    if command -v rpm >/dev/null 2>&1; then
+        if rpm -q rsync >/dev/null 2>&1; then
+            return 0
+        fi
+    fi
+
+    return 1
+}
+
 register_alternatives() {
     detect_alternatives
     if [ -z "$ALT_TOOL" ]; then
+        return 0
+    fi
+
+    if rpm_upstream_rsync_installed; then
         return 0
     fi
 

--- a/packaging/deb/postinst
+++ b/packaging/deb/postinst
@@ -13,15 +13,30 @@ have_update_alternatives() {
     command -v update-alternatives >/dev/null 2>&1
 }
 
+upstream_rsync_installed() {
+    if command -v dpkg-query >/dev/null 2>&1; then
+        if dpkg-query -W -f='${Status}' rsync 2>/dev/null | grep -q 'install ok installed'; then
+            return 0
+        fi
+    fi
+
+    return 1
+}
+
 register_alternatives() {
     if ! have_update_alternatives; then
         return 0
     fi
 
+    if upstream_rsync_installed; then
+        # Preserve the upstream package's rsync binary. Administrators can
+        # opt-in to update-alternatives manually if they prefer the Rust
+        # implementation as the system default.
+        return 0
+    fi
+
     if [ -e "${ALT_MASTER}" ] && [ ! -L "${ALT_MASTER}" ]; then
         if ! update-alternatives --display "${ALT_NAME}" >/dev/null 2>&1; then
-            # The upstream rsync package owns /usr/bin/rsync as a regular file.
-            # Respect the existing binary so both packages can coexist.
             return 0
         fi
     fi

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -12,6 +12,8 @@ toml = "0.8"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 cargo_metadata = "0.18"
+flate2 = "1.0.28"
+tar = "0.4"
 
 [dev-dependencies]
 tempfile = "3"

--- a/xtask/src/commands/package.rs
+++ b/xtask/src/commands/package.rs
@@ -1,9 +1,16 @@
 use crate::error::{TaskError, TaskResult};
 use crate::util::{is_help_flag, run_cargo_tool};
-use crate::workspace::load_workspace_branding;
+use crate::workspace::{WorkspaceBranding, load_workspace_branding};
+use flate2::Compression;
+use flate2::write::GzEncoder;
 use std::env;
 use std::ffi::OsString;
-use std::path::Path;
+use std::fs::{self, File};
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use tar::{Builder, EntryType, Header, HeaderMode};
+
+const AMD64_TARBALL_TARGET: &str = "x86_64-unknown-linux-gnu";
 
 /// Options accepted by the `package` command.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -12,6 +19,8 @@ pub struct PackageOptions {
     pub build_deb: bool,
     /// Whether to build the RPM package.
     pub build_rpm: bool,
+    /// Whether to build the amd64 tarball distribution.
+    pub build_tarball: bool,
     /// Optional profile override.
     pub profile: Option<OsString>,
 }
@@ -24,6 +33,7 @@ where
     let mut args = args.into_iter();
     let mut build_deb = false;
     let mut build_rpm = false;
+    let mut build_tarball = false;
     let mut profile = Some(OsString::from("release"));
     let mut profile_explicit = false;
 
@@ -39,6 +49,11 @@ where
 
         if arg == "--rpm" {
             build_rpm = true;
+            continue;
+        }
+
+        if arg == "--tarball" {
+            build_tarball = true;
             continue;
         }
 
@@ -88,14 +103,16 @@ where
         )));
     }
 
-    if !build_deb && !build_rpm {
+    if !build_deb && !build_rpm && !build_tarball {
         build_deb = true;
         build_rpm = true;
+        build_tarball = true;
     }
 
     Ok(PackageOptions {
         build_deb,
         build_rpm,
+        build_tarball,
         profile,
     })
 }
@@ -122,7 +139,7 @@ pub fn execute(workspace: &Path, options: PackageOptions) -> TaskResult<()> {
     println!("Preparing {}", branding.summary());
 
     if options.build_deb || options.build_rpm {
-        build_workspace_binaries(workspace, &options.profile)?;
+        build_workspace_binaries(workspace, &options.profile, None)?;
     }
 
     if options.build_deb {
@@ -155,17 +172,26 @@ pub fn execute(workspace: &Path, options: PackageOptions) -> TaskResult<()> {
         )?;
     }
 
+    if options.build_tarball {
+        build_workspace_binaries(workspace, &options.profile, Some(AMD64_TARBALL_TARGET))?;
+        build_amd64_tarball(workspace, &branding, &options.profile)?;
+    }
+
     Ok(())
 }
 
 /// Returns usage text for the command.
 pub fn usage() -> String {
     String::from(
-        "Usage: cargo xtask package [OPTIONS]\n\nOptions:\n  --deb            Build only the Debian package\n  --rpm            Build only the RPM package\n  --release        Build using the release profile (default)\n  --debug          Build using the debug profile\n  --profile NAME   Build using the named cargo profile\n  --no-profile     Do not override the cargo profile\n  -h, --help       Show this help message",
+        "Usage: cargo xtask package [OPTIONS]\n\nOptions:\n  --deb            Build only the Debian package\n  --rpm            Build only the RPM package\n  --tarball        Build only the amd64 tarball distribution\n  --release        Build using the release profile (default)\n  --debug          Build using the debug profile\n  --profile NAME   Build using the named cargo profile\n  --no-profile     Do not override the cargo profile\n  -h, --help       Show this help message",
     )
 }
 
-fn build_workspace_binaries(workspace: &Path, profile: &Option<OsString>) -> TaskResult<()> {
+fn build_workspace_binaries(
+    workspace: &Path,
+    profile: &Option<OsString>,
+    target: Option<&str>,
+) -> TaskResult<()> {
     if env::var_os("OC_RSYNC_PACKAGE_SKIP_BUILD").is_some() {
         println!("Skipping workspace binary build because OC_RSYNC_PACKAGE_SKIP_BUILD is set");
         return Ok(());
@@ -182,6 +208,11 @@ fn build_workspace_binaries(workspace: &Path, profile: &Option<OsString>) -> Tas
     args.push(OsString::from("--features"));
     args.push(OsString::from("legacy-binaries"));
 
+    if let Some(target) = target {
+        args.push(OsString::from("--target"));
+        args.push(OsString::from(target));
+    }
+
     if let Some(profile) = profile {
         args.push(OsString::from("--profile"));
         args.push(profile.clone());
@@ -193,6 +224,216 @@ fn build_workspace_binaries(workspace: &Path, profile: &Option<OsString>) -> Tas
         "cargo build",
         "use `cargo build` to compile the workspace binaries",
     )
+}
+
+fn build_amd64_tarball(
+    workspace: &Path,
+    branding: &WorkspaceBranding,
+    profile: &Option<OsString>,
+) -> TaskResult<()> {
+    let profile_name = tarball_profile_name(profile);
+    let target_dir = workspace
+        .join("target")
+        .join(AMD64_TARBALL_TARGET)
+        .join(&profile_name);
+
+    let binaries = [
+        (branding.client_bin.as_str(), 0o755),
+        (branding.daemon_bin.as_str(), 0o755),
+        (branding.legacy_client_bin.as_str(), 0o755),
+        (branding.legacy_daemon_bin.as_str(), 0o755),
+    ];
+
+    for (name, _) in &binaries {
+        let path = target_dir.join(name);
+        ensure_tarball_source(&path)?;
+    }
+
+    let dist_dir = workspace.join("target").join("dist");
+    fs::create_dir_all(&dist_dir)?;
+
+    let root_name = format!(
+        "{}-{}-{}",
+        branding.client_bin, branding.rust_version, AMD64_TARBALL_TARGET
+    );
+    let tarball_path = dist_dir.join(format!("{root_name}.tar.gz"));
+    println!(
+        "Building amd64 tarball distribution at {}",
+        tarball_path.display()
+    );
+
+    let tarball_file = File::create(&tarball_path).map_err(|error| {
+        TaskError::Io(io::Error::new(
+            error.kind(),
+            format!(
+                "failed to create tarball at {}: {error}",
+                tarball_path.display()
+            ),
+        ))
+    })?;
+    let encoder = GzEncoder::new(tarball_file, Compression::default());
+    let mut builder = Builder::new(encoder);
+    builder.mode(HeaderMode::Deterministic);
+
+    let directories = [
+        root_name.clone(),
+        format!("{root_name}/bin"),
+        format!("{root_name}/libexec"),
+        format!("{root_name}/libexec/oc-rsync"),
+        format!("{root_name}/lib"),
+        format!("{root_name}/lib/systemd"),
+        format!("{root_name}/lib/systemd/system"),
+        format!("{root_name}/etc"),
+        format!("{root_name}/etc/oc-rsyncd"),
+        format!("{root_name}/etc/default"),
+    ];
+
+    for directory in &directories {
+        append_directory_entry(&mut builder, directory, 0o755)?;
+    }
+
+    let packaging_entries: Vec<(PathBuf, &str, u32)> = vec![
+        (
+            workspace.join("packaging/systemd/oc-rsyncd.service"),
+            "lib/systemd/system/oc-rsyncd.service",
+            0o644,
+        ),
+        (
+            workspace.join("packaging/etc/oc-rsyncd/oc-rsyncd.conf"),
+            "etc/oc-rsyncd/oc-rsyncd.conf",
+            0o644,
+        ),
+        (
+            workspace.join("packaging/etc/oc-rsyncd/oc-rsyncd.secrets"),
+            "etc/oc-rsyncd/oc-rsyncd.secrets",
+            0o600,
+        ),
+        (
+            workspace.join("packaging/default/oc-rsyncd"),
+            "etc/default/oc-rsyncd",
+            0o644,
+        ),
+        (workspace.join("LICENSE"), "LICENSE", 0o644),
+        (workspace.join("README.md"), "README.md", 0o644),
+    ];
+
+    for (source, _, _) in &packaging_entries {
+        ensure_tarball_source(source)?;
+    }
+
+    let mut append_binary = |name: &str, relative: &str, mode: u32| -> TaskResult<()> {
+        let source = target_dir.join(name);
+        let destination = format!("{root_name}/{relative}");
+        append_file_entry(&mut builder, &destination, &source, mode)
+    };
+
+    append_binary(
+        branding.client_bin.as_str(),
+        &format!("bin/{}", branding.client_bin),
+        0o755,
+    )?;
+    append_binary(
+        branding.daemon_bin.as_str(),
+        &format!("bin/{}", branding.daemon_bin),
+        0o755,
+    )?;
+    append_binary(
+        branding.legacy_client_bin.as_str(),
+        &format!("libexec/oc-rsync/{}", branding.legacy_client_bin),
+        0o755,
+    )?;
+    append_binary(
+        branding.legacy_daemon_bin.as_str(),
+        &format!("libexec/oc-rsync/{}", branding.legacy_daemon_bin),
+        0o755,
+    )?;
+
+    for (source, relative, mode) in &packaging_entries {
+        let destination = format!("{root_name}/{relative}");
+        append_file_entry(&mut builder, &destination, source, *mode)?;
+    }
+
+    let encoder = builder.into_inner()?;
+    encoder.finish()?;
+
+    Ok(())
+}
+
+fn tarball_profile_name(profile: &Option<OsString>) -> String {
+    profile
+        .as_ref()
+        .map(|value| value.to_string_lossy().into_owned())
+        .unwrap_or_else(|| String::from("debug"))
+}
+
+fn ensure_tarball_source(path: &Path) -> TaskResult<()> {
+    if path.is_file() {
+        return Ok(());
+    }
+
+    Err(TaskError::Validation(format!(
+        "tarball source file missing: {}",
+        path.display()
+    )))
+}
+
+fn append_directory_entry<W: Write>(
+    builder: &mut Builder<W>,
+    path: &str,
+    mode: u32,
+) -> TaskResult<()> {
+    let mut header = Header::new_gnu();
+    header.set_entry_type(EntryType::Directory);
+    header.set_mode(mode);
+    header.set_uid(0);
+    header.set_gid(0);
+    header.set_mtime(0);
+    header.set_size(0);
+    header.set_path(path)?;
+    header.set_cksum();
+    builder.append(&header, io::empty())?;
+    Ok(())
+}
+
+fn append_file_entry<W: Write>(
+    builder: &mut Builder<W>,
+    destination: &str,
+    source: &Path,
+    mode: u32,
+) -> TaskResult<()> {
+    let metadata = fs::metadata(source).map_err(|error| {
+        TaskError::Io(io::Error::new(
+            error.kind(),
+            format!("failed to read metadata for {}: {error}", source.display()),
+        ))
+    })?;
+
+    if !metadata.is_file() {
+        return Err(TaskError::Validation(format!(
+            "expected regular file for tarball entry: {}",
+            source.display()
+        )));
+    }
+
+    let mut file = File::open(source).map_err(|error| {
+        TaskError::Io(io::Error::new(
+            error.kind(),
+            format!("failed to open {}: {error}", source.display()),
+        ))
+    })?;
+
+    let mut header = Header::new_gnu();
+    header.set_entry_type(EntryType::Regular);
+    header.set_mode(mode);
+    header.set_uid(0);
+    header.set_gid(0);
+    header.set_mtime(0);
+    header.set_size(metadata.len());
+    header.set_path(destination)?;
+    header.set_cksum();
+    builder.append(&header, &mut file)?;
+
+    Ok(())
 }
 
 #[cfg(test)]
@@ -210,6 +451,7 @@ mod tests {
             PackageOptions {
                 build_deb: true,
                 build_rpm: true,
+                build_tarball: true,
                 profile: Some(OsString::from("release")),
             }
         );
@@ -245,6 +487,20 @@ mod tests {
     fn parse_args_rejects_unknown_argument() {
         let error = parse_args([OsString::from("--unknown")]).unwrap_err();
         assert!(matches!(error, TaskError::Usage(message) if message.contains("package")));
+    }
+
+    #[test]
+    fn parse_args_supports_tarball_only() {
+        let options = parse_args([OsString::from("--tarball")]).expect("parse succeeds");
+        assert_eq!(
+            options,
+            PackageOptions {
+                build_deb: false,
+                build_rpm: false,
+                build_tarball: true,
+                profile: Some(OsString::from("release")),
+            }
+        );
     }
 
     fn workspace_root() -> &'static Path {
@@ -333,6 +589,7 @@ mod tests {
             PackageOptions {
                 build_deb: false,
                 build_rpm: false,
+                build_tarball: false,
                 profile: None,
             },
         )
@@ -353,6 +610,7 @@ mod tests {
             PackageOptions {
                 build_deb: true,
                 build_rpm: false,
+                build_tarball: false,
                 profile: Some(OsString::from("release")),
             },
         )
@@ -374,6 +632,7 @@ mod tests {
             PackageOptions {
                 build_deb: false,
                 build_rpm: true,
+                build_tarball: false,
                 profile: Some(OsString::from("debug")),
             },
         )


### PR DESCRIPTION
## Summary
- skip update-alternatives registration in Debian/RPM packaging when the upstream rsync package is present so both packages can coexist
- extend the xtask packaging command to build an amd64 tarball, including new tar/flate2 helpers and tests

## Testing
- RUST_TEST_THREADS=1 cargo test -p xtask

------