### PR TITLE
Ensure nextest builds binaries for CLI tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,2 +1,5 @@
+[profile.default]
+build-bins = true
+
 [profile.default.package]
 graph = "workspace"


### PR DESCRIPTION
## Summary
- update the default nextest profile to build binary targets before running tests

## Testing
- cargo test --tests client_help_lists_usage -- --nocapture

------