### PR TITLE
Allow upstream coexistence and add amd64 tarball artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -366,11 +366,8 @@ jobs:
       - name: Display workspace metadata
         run: cargo --locked run -p xtask -- branding
 
-      - name: Build Debian package
-        run: cargo --locked deb -v
-
-      - name: Build RPM package
-        run: cargo --locked rpm build -v
+      - name: Build Debian, RPM, and amd64 tarball artifacts
+        run: cargo --locked run -p xtask -- package
 
       - name: Generate SBOM
         run: cargo --locked run -p xtask -- sbom
@@ -383,5 +380,6 @@ jobs:
             target/release/oc-rsyncd*
             target/debian/*.deb
             target/release/rpmbuild/RPMS/**/*.rpm
+            target/dist/*.tar.gz
             target/sbom/oc-rsync.cdx.json
           if-no-files-found: error

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -171,23 +171,9 @@ detect_alternatives() {
     fi
 }
 
-rpm_upstream_rsync_installed() {
-    if command -v rpm >/dev/null 2>&1; then
-        if rpm -q rsync >/dev/null 2>&1; then
-            return 0
-        fi
-    fi
-
-    return 1
-}
-
 register_alternatives() {
     detect_alternatives
     if [ -z "$ALT_TOOL" ]; then
-        return 0
-    fi
-
-    if rpm_upstream_rsync_installed; then
         return 0
     fi
 

--- a/packaging/deb/postinst
+++ b/packaging/deb/postinst
@@ -13,25 +13,8 @@ have_update_alternatives() {
     command -v update-alternatives >/dev/null 2>&1
 }
 
-upstream_rsync_installed() {
-    if command -v dpkg-query >/dev/null 2>&1; then
-        if dpkg-query -W -f='${Status}' rsync 2>/dev/null | grep -q 'install ok installed'; then
-            return 0
-        fi
-    fi
-
-    return 1
-}
-
 register_alternatives() {
     if ! have_update_alternatives; then
-        return 0
-    fi
-
-    if upstream_rsync_installed; then
-        # Preserve the upstream package's rsync binary. Administrators can
-        # opt-in to update-alternatives manually if they prefer the Rust
-        # implementation as the system default.
         return 0
     fi
 


### PR DESCRIPTION
## Summary
- stop the Debian and RPM maintainer scripts from short-circuiting when a system rsync package is installed so oc-rsync can participate in update-alternatives without blocking co-installation
- update the Linux packaging workflow to invoke `cargo xtask package`, producing the Debian package, RPM, and a new amd64 tarball; upload the tarball alongside the existing artifacts

## Testing
- cargo --locked run -p xtask -- package --help

------