### PR TITLE
Allow co-installation with upstream rsync packages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -160,6 +160,37 @@ ALT_SLAVE_NAME=rsyncd
 ALT_SLAVE_LINK=/usr/bin/rsyncd
 ALT_SLAVE_IMPL=/usr/libexec/oc-rsync/rsyncd
 ALT_PRIORITY=30
+DEFAULTS_FILE=/etc/default/oc-rsyncd
+
+is_truthy() {
+    case "$1" in
+        [Yy][Ee][Ss]|[Tt][Rr][Uu][Ee]|1)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+should_register_alternatives() {
+    if [ -n "${OC_RSYNC_PACKAGE_REGISTER_ALTERNATIVES:-}" ]; then
+        if is_truthy "${OC_RSYNC_PACKAGE_REGISTER_ALTERNATIVES}"; then
+            return 0
+        fi
+        return 1
+    fi
+
+    if [ -r "${DEFAULTS_FILE}" ]; then
+        . "${DEFAULTS_FILE}"
+    fi
+
+    if is_truthy "${OC_RSYNC_REGISTER_ALTERNATIVES:-}"; then
+        return 0
+    fi
+
+    return 1
+}
 
 detect_alternatives() {
     if command -v update-alternatives >/dev/null 2>&1; then
@@ -184,6 +215,11 @@ rpm_upstream_rsync_installed() {
 register_alternatives() {
     detect_alternatives
     if [ -z "$ALT_TOOL" ]; then
+        return 0
+    fi
+
+    if ! should_register_alternatives; then
+        printf '%s\n' "Skipping update-alternatives registration for oc-rsync; set OC_RSYNC_PACKAGE_REGISTER_ALTERNATIVES=1 or enable OC_RSYNC_REGISTER_ALTERNATIVES in /etc/default/oc-rsyncd to opt in." >&2
         return 0
     fi
 

--- a/README.md
+++ b/README.md
@@ -160,6 +160,22 @@ Generate a CycloneDX SBOM for packaging via the workspace helper:
 cargo run -p xtask -- sbom
 ```
 
+## Packaging
+
+The workspace `package` task builds Debian and RPM packages alongside an amd64
+tarball distribution:
+
+```bash
+cargo run -p xtask -- package
+```
+
+The command produces `target/dist/oc-rsync-<version>-x86_64-unknown-linux-gnu.tar.gz`
+in addition to the package formats. The install scripts deliberately skip
+`update-alternatives` registration so upstream `rsync` packages can remain
+installed side by side; opt in by setting `OC_RSYNC_PACKAGE_REGISTER_ALTERNATIVES=1`
+during installation or by defining `OC_RSYNC_REGISTER_ALTERNATIVES=yes` in
+`/etc/default/oc-rsyncd` before reconfiguring the package.
+
 Collect code coverage reports (enforced at ≥95% line coverage in CI) by first
 installing the `cargo-llvm-cov` subcommand and the LLVM tooling component. The
 binary name is **`cargo-llvm-cov`**, not `llvm-cov`:

--- a/docs/production_scope_p1.md
+++ b/docs/production_scope_p1.md
@@ -78,7 +78,11 @@ This document freezes the mandatory scope that must reach green status before th
 ## Packaging & Artifacts
 - Debian package via `cargo-deb`
 - RPM package via `cargo-rpm`
+- amd64 (`x86_64-unknown-linux-gnu`) tarball at `target/dist/oc-rsync-<version>-x86_64-unknown-linux-gnu.tar.gz`
 - Systemd `oc-rsyncd.service` unit that avoids legacy aliases so upstream packages can coexist on the same host
+- Packaging scripts skip update-alternatives registration unless explicitly
+  enabled, allowing upstream `rsync` packages to remain installed alongside
+  oc-rsync without file conflicts
 - Default daemon configuration installed at `/etc/oc-rsyncd/oc-rsyncd.conf` with secrets stored in `/etc/oc-rsyncd/oc-rsyncd.secrets`
 - CycloneDX SBOM at `target/sbom/rsync.cdx.json`
 - Cross-compiled release binaries for Linux (x86_64, aarch64), macOS (x86_64, aarch64), and Windows (x86_64) produced by the CI matrix (Windows x86/aarch64 targets remain disabled to avoid conflicting toolchains)

--- a/packaging/deb/postinst
+++ b/packaging/deb/postinst
@@ -8,9 +8,41 @@ ALT_SLAVE_NAME="rsyncd"
 ALT_SLAVE_LINK="/usr/bin/rsyncd"
 ALT_SLAVE_IMPL="/usr/libexec/oc-rsync/rsyncd"
 ALT_PRIORITY=30
+DEFAULTS_FILE="/etc/default/oc-rsyncd"
+
+is_truthy() {
+    case "$1" in
+        [Yy][Ee][Ss]|[Tt][Rr][Uu][Ee]|1)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
 
 have_update_alternatives() {
     command -v update-alternatives >/dev/null 2>&1
+}
+
+should_register_alternatives() {
+    if [ -n "${OC_RSYNC_PACKAGE_REGISTER_ALTERNATIVES:-}" ]; then
+        if is_truthy "${OC_RSYNC_PACKAGE_REGISTER_ALTERNATIVES}"; then
+            return 0
+        fi
+        return 1
+    fi
+
+    if [ -r "${DEFAULTS_FILE}" ]; then
+        # shellcheck source=/etc/default/oc-rsyncd
+        . "${DEFAULTS_FILE}"
+    fi
+
+    if is_truthy "${OC_RSYNC_REGISTER_ALTERNATIVES:-}"; then
+        return 0
+    fi
+
+    return 1
 }
 
 upstream_rsync_installed() {
@@ -25,6 +57,11 @@ upstream_rsync_installed() {
 
 register_alternatives() {
     if ! have_update_alternatives; then
+        return 0
+    fi
+
+    if ! should_register_alternatives; then
+        printf '%s\n' "Skipping update-alternatives registration for oc-rsync; set OC_RSYNC_PACKAGE_REGISTER_ALTERNATIVES=1 or enable OC_RSYNC_REGISTER_ALTERNATIVES in /etc/default/oc-rsyncd to opt in." >&2
         return 0
     fi
 

--- a/packaging/default/oc-rsyncd
+++ b/packaging/default/oc-rsyncd
@@ -9,3 +9,9 @@
 # OC_RSYNC_SECRETS=/etc/oc-rsyncd/oc-rsyncd.secrets
 # RSYNCD_SECRETS=/etc/oc-rsyncd/oc-rsyncd.secrets
 # RSYNCD_ARGS="--max-sessions 16"
+
+# Set this to "yes" (or export OC_RSYNC_PACKAGE_REGISTER_ALTERNATIVES=1 while
+# installing) to register oc-rsync with update-alternatives. The packaging
+# scripts skip registration by default so the upstream rsync binaries can
+# remain in place when both packages are installed.
+# OC_RSYNC_REGISTER_ALTERNATIVES=yes


### PR DESCRIPTION
## Summary
- gate Debian and RPM update-alternatives registration behind an explicit opt-in to support co-installation with upstream rsync
- document the opt-in flow and the amd64 tarball artifact in the README and production scope
- note the new toggle in the default environment file used by the packaging scripts

## Testing
- not run (packaging scripts and documentation updates only)

------