### PR TITLE
Gate alternatives registration and centralize tarball target metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,6 +93,7 @@ legacy_daemon_config_dir = "/etc"
 legacy_daemon_config = "/etc/rsyncd.conf"
 legacy_daemon_secrets = "/etc/rsyncd.secrets"
 source = "https://github.com/oferchen/rsync"
+tarball_target = "x86_64-unknown-linux-gnu"
 
 [workspace.metadata.oc_rsync.cross_compile]
 linux = ["x86_64", "aarch64"]
@@ -203,6 +204,10 @@ detect_alternatives() {
 }
 
 register_alternatives() {
+    if ! should_register_alternatives; then
+        return 0
+    fi
+
     detect_alternatives
     if [ -z "$ALT_TOOL" ]; then
         return 0

--- a/packaging/deb/postinst
+++ b/packaging/deb/postinst
@@ -25,8 +25,32 @@ have_update_alternatives() {
     command -v update-alternatives >/dev/null 2>&1
 }
 
+should_register_alternatives() {
+    if [ -n "${OC_RSYNC_PACKAGE_REGISTER_ALTERNATIVES:-}" ]; then
+        if is_truthy "${OC_RSYNC_PACKAGE_REGISTER_ALTERNATIVES}"; then
+            return 0
+        fi
+        return 1
+    fi
+
+    if [ -r "${DEFAULTS_FILE}" ]; then
+        # shellcheck disable=SC1090
+        . "${DEFAULTS_FILE}"
+    fi
+
+    if is_truthy "${OC_RSYNC_REGISTER_ALTERNATIVES:-}"; then
+        return 0
+    fi
+
+    return 1
+}
+
 register_alternatives() {
     if ! have_update_alternatives; then
+        return 0
+    fi
+
+    if ! should_register_alternatives; then
         return 0
     fi
 

--- a/xtask/src/commands/branding/mod.rs
+++ b/xtask/src/commands/branding/mod.rs
@@ -54,6 +54,7 @@ legacy_daemon_config_dir = "/etc"
 legacy_daemon_config = "/etc/rsyncd.conf"
 legacy_daemon_secrets = "/etc/rsyncd.secrets"
 source = "https://example.invalid/demo"
+tarball_target = "x86_64-unknown-linux-gnu"
 [workspace.metadata.oc_rsync.cross_compile]
 linux = ["x86_64", "aarch64"]
 macos = ["x86_64", "aarch64"]

--- a/xtask/src/commands/branding/render.rs
+++ b/xtask/src/commands/branding/render.rs
@@ -33,6 +33,7 @@ fn render_branding_text(branding: &WorkspaceBranding) -> String {
             "  legacy_daemon_config: {}\n",
             "  legacy_daemon_secrets: {}\n",
             "  source: {}\n",
+            "  tarball_target: {}\n",
             "  cross_compile: {}"
         ),
         branding.brand,
@@ -50,6 +51,7 @@ fn render_branding_text(branding: &WorkspaceBranding) -> String {
         branding.legacy_daemon_config.display(),
         branding.legacy_daemon_secrets.display(),
         branding.source,
+        branding.tarball_target,
         format_cross_compile_summary(&branding.cross_compile),
     )
 }
@@ -86,6 +88,7 @@ fn render_branding_json(branding: &WorkspaceBranding) -> TaskResult<String> {
             .display()
             .to_string(),
         "source": branding.source,
+        "tarball_target": branding.tarball_target,
         "cross_compile": cross_compile,
     });
 
@@ -139,6 +142,7 @@ mod tests {
             legacy_daemon_config: PathBuf::from("/etc/rsyncd.conf"),
             legacy_daemon_secrets: PathBuf::from("/etc/rsyncd.secrets"),
             source: String::from("https://example.invalid/rsync"),
+            tarball_target: String::from("x86_64-unknown-linux-gnu"),
             cross_compile: BTreeMap::from([
                 (
                     String::from("linux"),
@@ -174,6 +178,7 @@ mod tests {
             "  legacy_daemon_config: /etc/rsyncd.conf\n",
             "  legacy_daemon_secrets: /etc/rsyncd.secrets\n",
             "  source: https://example.invalid/rsync\n",
+            "  tarball_target: x86_64-unknown-linux-gnu\n",
             "  cross_compile: Linux: x86_64, aarch64; macOS: x86_64, aarch64; Windows: x86_64"
         );
         assert_eq!(rendered, expected);
@@ -186,6 +191,7 @@ mod tests {
         let parsed: serde_json::Value = serde_json::from_str(&rendered).expect("parse json");
         assert_eq!(parsed["brand"], "oc");
         assert_eq!(parsed["protocol"], 32);
+        assert_eq!(parsed["tarball_target"], "x86_64-unknown-linux-gnu");
     }
 
     #[test]

--- a/xtask/src/commands/branding/tests.rs
+++ b/xtask/src/commands/branding/tests.rs
@@ -24,6 +24,7 @@ fn sample_branding() -> WorkspaceBranding {
         legacy_daemon_config: PathBuf::from("/etc/rsyncd.conf"),
         legacy_daemon_secrets: PathBuf::from("/etc/rsyncd.secrets"),
         source: String::from("https://example.invalid/rsync"),
+        tarball_target: String::from("x86_64-unknown-linux-gnu"),
         cross_compile: BTreeMap::from([
             (String::from("linux"), vec![String::from("x86_64"), String::from("aarch64")]),
             (String::from("macos"), vec![String::from("x86_64"), String::from("aarch64")]),
@@ -93,6 +94,7 @@ fn render_text_matches_expected_layout() {
         "  legacy_daemon_config: /etc/rsyncd.conf\n",
         "  legacy_daemon_secrets: /etc/rsyncd.secrets\n",
         "  source: https://example.invalid/rsync\n",
+        "  tarball_target: x86_64-unknown-linux-gnu\n",
         "  cross_compile: Linux: x86_64, aarch64; macOS: x86_64, aarch64; Windows: x86_64"
     );
     assert_eq!(rendered, expected);
@@ -207,6 +209,18 @@ fn validate_branding_rejects_incorrect_legacy_names() {
     assert!(matches!(
         daemon_error,
         TaskError::Validation(message) if message.contains("legacy daemon binary")
+    ));
+}
+
+#[test]
+fn validate_branding_rejects_unexpected_tarball_target() {
+    let mut branding = sample_branding();
+    branding.tarball_target = String::from("amd64-unknown-linux-musl");
+    let error = validate_branding(&branding).unwrap_err();
+    assert!(matches!(
+        error,
+        TaskError::Validation(message)
+            if message.contains("tarball_target 'amd64-unknown-linux-musl'")
     ));
 }
 

--- a/xtask/src/commands/branding/validate.rs
+++ b/xtask/src/commands/branding/validate.rs
@@ -141,6 +141,13 @@ pub fn validate_branding(branding: &WorkspaceBranding) -> TaskResult<()> {
         "legacy_daemon_config_dir",
     )?;
 
+    if branding.tarball_target != "x86_64-unknown-linux-gnu" {
+        return Err(TaskError::Validation(format!(
+            "tarball_target '{}' must be 'x86_64-unknown-linux-gnu'",
+            branding.tarball_target
+        )));
+    }
+
     Ok(())
 }
 
@@ -224,6 +231,7 @@ mod tests {
             legacy_daemon_config: PathBuf::from("/etc/rsyncd.conf"),
             legacy_daemon_secrets: PathBuf::from("/etc/rsyncd.secrets"),
             source: String::from("https://example.invalid/rsync"),
+            tarball_target: String::from("x86_64-unknown-linux-gnu"),
             cross_compile: BTreeMap::from([
                 (
                     String::from("linux"),

--- a/xtask/src/commands/docs/validation/branding.rs
+++ b/xtask/src/commands/docs/validation/branding.rs
@@ -204,6 +204,7 @@ legacy_daemon_config_dir = "/etc"
 legacy_daemon_config = "/etc/rsyncd.conf"
 legacy_daemon_secrets = "/etc/rsyncd.secrets"
 source = "https://github.com/oferchen/rsync"
+tarball_target = "x86_64-unknown-linux-gnu"
 [workspace.metadata.oc_rsync.cross_compile]
 linux = ["x86_64", "aarch64"]
 macos = ["x86_64", "aarch64"]

--- a/xtask/src/commands/docs/validation/ci/matrix/tests/mod.rs
+++ b/xtask/src/commands/docs/validation/ci/matrix/tests/mod.rs
@@ -23,6 +23,7 @@ legacy_daemon_config_dir = "/etc"
 legacy_daemon_config = "/etc/rsyncd.conf"
 legacy_daemon_secrets = "/etc/rsyncd.secrets"
 source = "https://github.com/oferchen/rsync"
+tarball_target = "x86_64-unknown-linux-gnu"
 [workspace.metadata.oc_rsync.cross_compile]
 linux = ["x86_64", "aarch64"]
 macos = ["x86_64", "aarch64"]

--- a/xtask/src/commands/docs/validation/ci/test_job/mod.rs
+++ b/xtask/src/commands/docs/validation/ci/test_job/mod.rs
@@ -72,6 +72,7 @@ legacy_daemon_config_dir = "/etc"
 legacy_daemon_config = "/etc/rsyncd.conf"
 legacy_daemon_secrets = "/etc/rsyncd.secrets"
 source = "https://github.com/oferchen/rsync"
+tarball_target = "x86_64-unknown-linux-gnu"
 [workspace.metadata.oc_rsync.cross_compile]
 linux = ["x86_64", "aarch64"]
 macos = ["x86_64", "aarch64"]

--- a/xtask/src/commands/package.rs
+++ b/xtask/src/commands/package.rs
@@ -10,8 +10,6 @@ use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use tar::{Builder, EntryType, Header, HeaderMode};
 
-const AMD64_TARBALL_TARGET: &str = "x86_64-unknown-linux-gnu";
-
 /// Options accepted by the `package` command.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct PackageOptions {
@@ -173,7 +171,11 @@ pub fn execute(workspace: &Path, options: PackageOptions) -> TaskResult<()> {
     }
 
     if options.build_tarball {
-        build_workspace_binaries(workspace, &options.profile, Some(AMD64_TARBALL_TARGET))?;
+        build_workspace_binaries(
+            workspace,
+            &options.profile,
+            Some(branding.tarball_target.as_str()),
+        )?;
         build_amd64_tarball(workspace, &branding, &options.profile)?;
     }
 
@@ -234,7 +236,7 @@ fn build_amd64_tarball(
     let profile_name = tarball_profile_name(profile);
     let target_dir = workspace
         .join("target")
-        .join(AMD64_TARBALL_TARGET)
+        .join(&branding.tarball_target)
         .join(&profile_name);
 
     let binaries = [
@@ -254,7 +256,7 @@ fn build_amd64_tarball(
 
     let root_name = format!(
         "{}-{}-{}",
-        branding.client_bin, branding.rust_version, AMD64_TARBALL_TARGET
+        branding.client_bin, branding.rust_version, branding.tarball_target
     );
     let tarball_path = dist_dir.join(format!("{root_name}.tar.gz"));
     println!(

--- a/xtask/src/workspace.rs
+++ b/xtask/src/workspace.rs
@@ -40,13 +40,15 @@ pub struct WorkspaceBranding {
     pub source: String,
     /// Cross-compilation targets grouped by operating system.
     pub cross_compile: BTreeMap<String, Vec<String>>,
+    /// Target triple used for the amd64 tarball distribution.
+    pub tarball_target: String,
 }
 
 impl WorkspaceBranding {
     /// Returns a concise human-readable summary.
     pub fn summary(&self) -> String {
         format!(
-            "brand={} rust_version={} protocol={} client={} daemon={} config_dir={} config={} secrets={}",
+            "brand={} rust_version={} protocol={} client={} daemon={} config_dir={} config={} secrets={} tarball_target={}",
             self.brand,
             self.rust_version,
             self.protocol,
@@ -54,7 +56,8 @@ impl WorkspaceBranding {
             self.daemon_bin,
             self.daemon_config_dir.display(),
             self.daemon_config.display(),
-            self.daemon_secrets.display()
+            self.daemon_secrets.display(),
+            self.tarball_target
         )
     }
 }
@@ -138,6 +141,7 @@ pub fn parse_workspace_branding_from_value(value: &Value) -> TaskResult<Workspac
         legacy_daemon_secrets: metadata_path(oc, "legacy_daemon_secrets")?,
         source: metadata_str(oc, "source")?,
         cross_compile: metadata_cross_compile(oc)?,
+        tarball_target: metadata_str(oc, "tarball_target")?,
     })
 }
 
@@ -238,6 +242,7 @@ legacy_daemon_config_dir = "/etc"
 legacy_daemon_config = "/etc/rsyncd.conf"
 legacy_daemon_secrets = "/etc/rsyncd.secrets"
 source = "https://github.com/oferchen/rsync"
+tarball_target = "x86_64-unknown-linux-gnu"
 
 [workspace.metadata.oc_rsync.cross_compile]
 {entries}
@@ -277,6 +282,7 @@ source = "https://github.com/oferchen/rsync"
                 ),
                 (String::from("windows"), vec![String::from("x86_64")]),
             ]),
+            tarball_target: String::from("x86_64-unknown-linux-gnu"),
         };
         assert_eq!(branding, expected);
     }


### PR DESCRIPTION
## Summary
- gate the Debian postinst and RPM scripts behind optional update-alternatives registration so upstream rsync can stay installed alongside oc-rsync by default
- surface the amd64 tarball target in workspace metadata and propagate it through xtask branding/package tooling and tests
- extend branding validations, renderers, and docs checks to cover the new tarball target field

## Testing
- cargo test -p xtask

------