### PR TITLE
Restrict limiter test-only re-export

### DIFF
--- a/crates/bandwidth/src/limiter/mod.rs
+++ b/crates/bandwidth/src/limiter/mod.rs
@@ -22,7 +22,9 @@ mod test_support;
 #[cfg(any(test, feature = "test-support"))]
 pub use self::test_support::{RecordedSleepIter, RecordedSleepSession, recorded_sleep_session};
 #[cfg(any(test, feature = "test-support"))]
-pub(super) use self::test_support::{append_recorded_sleeps, recorded_sleeps};
+pub(super) use self::test_support::append_recorded_sleeps;
+#[cfg(test)]
+pub(super) use self::test_support::recorded_sleeps;
 
 #[cfg(test)]
 mod tests;


### PR DESCRIPTION
## Summary
- restrict the `recorded_sleeps` re-export in the bandwidth limiter to test-only builds to avoid unused import warnings

## Testing
- cargo clippy --workspace --all-targets --all-features --locked -- -Dwarnings

------