### PR TITLE
Make Debian alternatives opt-in and clarify amd64 tarball distribution

### DIFF
--- a/packaging/deb/postinst
+++ b/packaging/deb/postinst
@@ -25,8 +25,36 @@ have_update_alternatives() {
     command -v update-alternatives >/dev/null 2>&1
 }
 
+load_defaults() {
+    if [ -r "${DEFAULTS_FILE}" ]; then
+        # shellcheck disable=SC1090 # configuration file is installed alongside the package
+        . "${DEFAULTS_FILE}"
+    fi
+}
+
+should_register_alternatives() {
+    if [ -n "${OC_RSYNC_PACKAGE_REGISTER_ALTERNATIVES:-}" ]; then
+        if is_truthy "${OC_RSYNC_PACKAGE_REGISTER_ALTERNATIVES}"; then
+            return 0
+        fi
+        return 1
+    fi
+
+    load_defaults
+
+    if is_truthy "${OC_RSYNC_REGISTER_ALTERNATIVES:-}"; then
+        return 0
+    fi
+
+    return 1
+}
+
 register_alternatives() {
     if ! have_update_alternatives; then
+        return 0
+    fi
+
+    if ! should_register_alternatives; then
         return 0
     fi
 

--- a/xtask/src/commands/package/args.rs
+++ b/xtask/src/commands/package/args.rs
@@ -126,7 +126,7 @@ fn set_profile_option(
 /// Returns usage text for the command.
 pub fn usage() -> String {
     String::from(
-        "Usage: cargo xtask package [OPTIONS]\n\nOptions:\n  --deb            Build only the Debian package\n  --rpm            Build only the RPM package\n  --tarball        Build only the amd64 tarball distribution\n  --release        Build using the release profile (default)\n  --debug          Build using the debug profile\n  --profile NAME   Build using the named cargo profile\n  --no-profile     Do not override the cargo profile\n  -h, --help       Show this help message",
+        "Usage: cargo xtask package [OPTIONS]\n\nOptions:\n  --deb            Build only the Debian package\n  --rpm            Build only the RPM package\n  --tarball        Build only the amd64 tar.gz distribution\n  --release        Build using the release profile (default)\n  --debug          Build using the debug profile\n  --profile NAME   Build using the named cargo profile\n  --no-profile     Do not override the cargo profile\n  -h, --help       Show this help message",
     )
 }
 

--- a/xtask/src/commands/package/tarball.rs
+++ b/xtask/src/commands/package/tarball.rs
@@ -41,7 +41,7 @@ pub(super) fn build_amd64_tarball(
     );
     let tarball_path = dist_dir.join(format!("{root_name}.tar.gz"));
     println!(
-        "Building amd64 tarball distribution at {}",
+        "Building amd64 tar.gz distribution at {}",
         tarball_path.display()
     );
 


### PR DESCRIPTION
## Summary
- gate the Debian post-install alternatives registration behind opt-in defaults/env checks so upstream rsync packages can coexist
- clarify the xtask package help/output to highlight the amd64 tar.gz distribution artifact

## Testing
- not run (not requested)

------