### PR TITLE
Improve rpm packaging error reporting

### DIFF
--- a/xtask/src/commands/package/build.rs
+++ b/xtask/src/commands/package/build.rs
@@ -1,6 +1,6 @@
 use super::{AMD64_TARBALL_TARGET, PackageOptions, tarball};
 use crate::error::TaskResult;
-use crate::util::run_cargo_tool;
+use crate::util::{ensure_command_available, run_cargo_tool};
 use crate::workspace::load_workspace_branding;
 use std::env;
 use std::ffi::OsString;
@@ -32,6 +32,10 @@ pub fn execute(workspace: &Path, options: PackageOptions) -> TaskResult<()> {
 
     if options.build_rpm {
         println!("Building RPM package with cargo rpm build");
+        ensure_command_available(
+            "rpmbuild",
+            "install the rpmbuild tooling (for example, `dnf install rpm-build` or `apt install rpm`)",
+        )?;
         let mut rpm_args = vec![OsString::from("rpm"), OsString::from("build")];
         if let Some(profile) = &options.profile {
             rpm_args.push(OsString::from("--profile"));

--- a/xtask/src/commands/package/tests.rs
+++ b/xtask/src/commands/package/tests.rs
@@ -19,66 +19,52 @@ fn env_lock() -> &'static std::sync::Mutex<()> {
     LOCK.get_or_init(|| std::sync::Mutex::new(()))
 }
 
-struct EnvGuards {
+struct ScopedEnv {
     previous: Vec<(&'static str, Option<OsString>)>,
+    _lock: std::sync::MutexGuard<'static, ()>,
 }
 
-struct EnvGuard {
-    key: &'static str,
-    previous: Option<OsString>,
-}
-
-impl EnvGuards {
-    #[allow(unsafe_code)]
-    fn set_many(pairs: &[(&'static str, &str)]) -> Self {
+impl ScopedEnv {
+    fn new(keys: &[&'static str]) -> Self {
         let lock = env_lock().lock().unwrap();
-        let mut previous = Vec::with_capacity(pairs.len());
-        for (key, value) in pairs {
+        let mut previous = Vec::with_capacity(keys.len());
+        for key in keys {
             previous.push((*key, env::var_os(key)));
-            unsafe { env::set_var(key, value) };
         }
-        drop(lock);
-        Self { previous }
+        Self {
+            previous,
+            _lock: lock,
+        }
+    }
+
+    fn ensure_tracked(&mut self, key: &'static str) {
+        if self.previous.iter().any(|(existing, _)| existing == &key) {
+            return;
+        }
+
+        self.previous.push((key, env::var_os(key)));
+    }
+
+    #[allow(unsafe_code)]
+    fn set_os(&mut self, key: &'static str, value: &OsStr) {
+        self.ensure_tracked(key);
+        unsafe { env::set_var(key, value) };
+    }
+
+    fn set_str(&mut self, key: &'static str, value: &str) {
+        self.set_os(key, OsStr::new(value));
     }
 }
 
-impl Drop for EnvGuards {
+impl Drop for ScopedEnv {
     #[allow(unsafe_code)]
     fn drop(&mut self) {
-        let _lock = env_lock().lock().unwrap();
         for (key, previous) in self.previous.drain(..).rev() {
             if let Some(value) = previous {
                 unsafe { env::set_var(key, value) };
             } else {
                 unsafe { env::remove_var(key) };
             }
-        }
-    }
-}
-
-impl EnvGuard {
-    fn set(key: &'static str, value: &str) -> Self {
-        Self::set_os(key, OsStr::new(value))
-    }
-
-    #[allow(unsafe_code)]
-    fn set_os(key: &'static str, value: &OsStr) -> Self {
-        let lock = env_lock().lock().unwrap();
-        let previous = env::var_os(key);
-        unsafe { env::set_var(key, value) };
-        drop(lock);
-        Self { key, previous }
-    }
-}
-
-impl Drop for EnvGuard {
-    #[allow(unsafe_code)]
-    fn drop(&mut self) {
-        let _lock = env_lock().lock().unwrap();
-        if let Some(previous) = self.previous.take() {
-            unsafe { env::set_var(self.key, previous) };
-        } else {
-            unsafe { env::remove_var(self.key) };
         }
     }
 }
@@ -99,13 +85,12 @@ fn execute_with_no_targets_returns_success() {
 
 #[test]
 fn execute_reports_missing_cargo_deb_tool() {
-    let _env = EnvGuards::set_many(&[
-        ("OC_RSYNC_PACKAGE_SKIP_BUILD", "1"),
-        ("OC_RSYNC_FORCE_MISSING_CARGO_TOOLS", "cargo deb"),
+    let mut env = ScopedEnv::new(&[
+        "OC_RSYNC_PACKAGE_SKIP_BUILD",
+        "OC_RSYNC_FORCE_MISSING_CARGO_TOOLS",
     ]);
-    let _env = EnvGuard::set("OC_RSYNC_PACKAGE_SKIP_BUILD", "1");
-    let (_fake_cargo_dir, fake_cargo) = fake_cargo_path();
-    let _cargo = EnvGuard::set_os("CARGO", fake_cargo.as_os_str());
+    env.set_str("OC_RSYNC_PACKAGE_SKIP_BUILD", "1");
+    env.set_str("OC_RSYNC_FORCE_MISSING_CARGO_TOOLS", "cargo deb");
     let error = execute(
         workspace_root(),
         PackageOptions {
@@ -124,13 +109,20 @@ fn execute_reports_missing_cargo_deb_tool() {
 
 #[test]
 fn execute_reports_missing_cargo_rpm_tool() {
-    let _env = EnvGuards::set_many(&[
-        ("OC_RSYNC_PACKAGE_SKIP_BUILD", "1"),
-        ("OC_RSYNC_FORCE_MISSING_CARGO_TOOLS", "cargo rpm build"),
+    let mut env = ScopedEnv::new(&[
+        "OC_RSYNC_PACKAGE_SKIP_BUILD",
+        "OC_RSYNC_FORCE_MISSING_CARGO_TOOLS",
+        "PATH",
     ]);
-    let _env = EnvGuard::set("OC_RSYNC_PACKAGE_SKIP_BUILD", "1");
-    let (_fake_cargo_dir, fake_cargo) = fake_cargo_path();
-    let _cargo = EnvGuard::set_os("CARGO", fake_cargo.as_os_str());
+    env.set_str("OC_RSYNC_PACKAGE_SKIP_BUILD", "1");
+    env.set_str("OC_RSYNC_FORCE_MISSING_CARGO_TOOLS", "cargo rpm build");
+    let (fake_rpmbuild_dir, _fake_rpmbuild) = fake_rpmbuild_path();
+    let mut path_entries = vec![fake_rpmbuild_dir.path().to_path_buf()];
+    if let Some(existing) = env::var_os("PATH") {
+        path_entries.extend(env::split_paths(&existing));
+    }
+    let joined_path = env::join_paths(path_entries).expect("compose PATH with fake rpmbuild");
+    env.set_os("PATH", joined_path.as_os_str());
     let error = execute(
         workspace_root(),
         PackageOptions {
@@ -147,29 +139,57 @@ fn execute_reports_missing_cargo_rpm_tool() {
     ));
 }
 
-fn fake_cargo_path() -> (tempfile::TempDir, PathBuf) {
-    let dir = tempfile::tempdir().expect("create temp directory for fake cargo");
-    let cargo_name = if cfg!(windows) { "cargo.cmd" } else { "cargo" };
-    let cargo_path = dir.path().join(cargo_name);
+#[test]
+fn execute_reports_missing_rpmbuild_tool() {
+    let mut env = ScopedEnv::new(&[
+        "OC_RSYNC_PACKAGE_SKIP_BUILD",
+        "OC_RSYNC_FORCE_MISSING_CARGO_TOOLS",
+    ]);
+    env.set_str("OC_RSYNC_PACKAGE_SKIP_BUILD", "1");
+    env.set_str("OC_RSYNC_FORCE_MISSING_CARGO_TOOLS", "rpmbuild");
+    let error = execute(
+        workspace_root(),
+        PackageOptions {
+            build_deb: false,
+            build_rpm: true,
+            build_tarball: false,
+            profile: Some(OsString::from("release")),
+        },
+    )
+    .unwrap_err();
+    assert!(matches!(
+        error,
+        TaskError::ToolMissing(message) if message.contains("rpmbuild")
+    ));
+}
+
+fn fake_rpmbuild_path() -> (tempfile::TempDir, PathBuf) {
+    let dir = tempfile::tempdir().expect("create temp directory for fake rpmbuild");
+    let rpmbuild_name = if cfg!(windows) {
+        "rpmbuild.cmd"
+    } else {
+        "rpmbuild"
+    };
+    let rpmbuild_path = dir.path().join(rpmbuild_name);
 
     #[cfg(windows)]
-    let script =
-        b"@echo off\r\necho error: no such subcommand: %1 1>&2\r\nexit /b 101\r\n".to_vec();
+    let script = b"@echo off\r\nexit /b 0\r\n".to_vec();
 
     #[cfg(not(windows))]
-    let script = b"#!/bin/sh\necho 'error: no such subcommand: '\"$1\" >&2\nexit 101\n".to_vec();
+    let script = b"#!/bin/sh\nexit 0\n".to_vec();
 
-    std::fs::write(&cargo_path, script).expect("write fake cargo script");
+    std::fs::write(&rpmbuild_path, script).expect("write fake rpmbuild script");
 
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        let mut permissions = std::fs::metadata(&cargo_path)
-            .expect("read fake cargo metadata")
+        let mut permissions = std::fs::metadata(&rpmbuild_path)
+            .expect("read fake rpmbuild metadata")
             .permissions();
         permissions.set_mode(0o755);
-        std::fs::set_permissions(&cargo_path, permissions).expect("make fake cargo executable");
+        std::fs::set_permissions(&rpmbuild_path, permissions)
+            .expect("make fake rpmbuild executable");
     }
 
-    (dir, cargo_path)
+    (dir, rpmbuild_path)
 }


### PR DESCRIPTION
## Summary
- check for `rpmbuild` before invoking `cargo rpm build` and surface a helpful hint when missing
- add an environment guard helper for packaging tests and cover the new rpmbuild check
- provide a reusable `ensure_command_available` utility used by the packaging workflow

## Testing
- cargo test -p xtask

------