### PR TITLE
Handle cargo-rpm absence before profile validation

### DIFF
--- a/xtask/src/commands/package/build.rs
+++ b/xtask/src/commands/package/build.rs
@@ -1,6 +1,6 @@
 use super::{AMD64_TARBALL_TARGET, PackageOptions, tarball};
 use crate::error::TaskResult;
-use crate::util::{ensure_command_available, run_cargo_tool};
+use crate::util::{ensure_command_available, probe_cargo_tool, run_cargo_tool};
 use crate::workspace::load_workspace_branding;
 use std::env;
 use std::ffi::OsString;
@@ -38,6 +38,12 @@ pub fn execute(workspace: &Path, options: PackageOptions) -> TaskResult<()> {
         )?;
         if let Some(profile) = options.profile.as_deref() {
             if profile != "release" {
+                probe_cargo_tool(
+                    workspace,
+                    &["rpm", "--help"],
+                    "cargo rpm build",
+                    "install the cargo-rpm subcommand (cargo install cargo-rpm)",
+                )?;
                 return Err(crate::util::validation_error(format!(
                     "cargo rpm build does not support overriding the cargo profile (requested '{}'); adjust [package.metadata.rpm.cargo].buildflags instead",
                     profile.to_string_lossy()


### PR DESCRIPTION
## Summary
- add a reusable helper to probe cargo subcommands and unify tool-missing diagnostics
- ensure the RPM packaging path reports a missing cargo-rpm tool before rejecting unsupported profiles

## Testing
- cargo test -p xtask commands::package::tests::execute_reports_missing_cargo_rpm_tool

------