### PR TITLE
Fix release workflow rustfmt installation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,9 +24,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: 1.87
+          components: rustfmt,clippy
           override: true
       - uses: Swatinem/rust-cache@v2
       - name: Install system dependencies
@@ -69,10 +70,10 @@ jobs:
             target: x86_64-pc-windows-msvc
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: 1.87
-          target: ${{ matrix.target }}
+          targets: ${{ matrix.target }}
           override: true
       - uses: Swatinem/rust-cache@v2
       - name: Install system dependencies


### PR DESCRIPTION
## Summary
- switch the release lint pipeline to use the maintained setup-rust-toolchain action
- install the rustfmt and clippy components so the formatting and lint steps succeed
- align the build job with the same action so all targets use the maintained installer

## Testing
- not run

------