### PR TITLE
Align packaging with side-by-side installs and amd64 tarball naming

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -203,6 +203,10 @@ detect_alternatives() {
 }
 
 register_alternatives() {
+    if ! should_register_alternatives; then
+        return 0
+    fi
+
     detect_alternatives
     if [ -z "$ALT_TOOL" ]; then
         return 0

--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ without hard-coding values by invoking:
 cargo run -p xtask -- branding --json
 ```
 
+System packages install the daemon configuration at
+`/etc/oc-rsyncd/oc-rsyncd.conf`, with authentication secrets kept in
+`/etc/oc-rsyncd/oc-rsyncd.secrets`. The same layout is mirrored inside the
+release tarball so branded (`oc-rsync`, `oc-rsyncd`) and legacy (`rsync`,
+`rsyncd`) entry points can operate side by side on the same host.
+
 ## License
 
 This project is available under the GPL-3.0-or-later license. See `LICENSE` for

--- a/xtask/src/commands/package/mod.rs
+++ b/xtask/src/commands/package/mod.rs
@@ -6,6 +6,7 @@ pub use args::{PackageOptions, parse_args};
 pub use build::execute;
 
 pub(crate) const AMD64_TARBALL_TARGET: &str = "x86_64-unknown-linux-gnu";
+pub(crate) const AMD64_TARBALL_ARCH: &str = "amd64";
 
 #[cfg(test)]
 mod tests;

--- a/xtask/src/commands/package/tarball.rs
+++ b/xtask/src/commands/package/tarball.rs
@@ -1,4 +1,4 @@
-use super::AMD64_TARBALL_TARGET;
+use super::{AMD64_TARBALL_ARCH, AMD64_TARBALL_TARGET};
 use crate::error::{TaskError, TaskResult};
 use crate::workspace::WorkspaceBranding;
 use flate2::Compression;
@@ -37,7 +37,7 @@ pub(super) fn build_amd64_tarball(
 
     let root_name = format!(
         "{}-{}-{}",
-        branding.client_bin, branding.rust_version, AMD64_TARBALL_TARGET
+        branding.client_bin, branding.rust_version, AMD64_TARBALL_ARCH
     );
     let tarball_path = dist_dir.join(format!("{root_name}.tar.gz"));
     println!(


### PR DESCRIPTION
## Summary
- gate RPM alternative registration behind the same opt-in guard used for Debian packages so upstream rsync can remain active when both are installed
- expose a dedicated amd64 architecture label for release tarballs and use it when naming the archive root
- document the daemon configuration locations that ship with the packages so preflight checks pass and users can confirm coexistence paths

## Testing
- cargo test -p xtask

------