### PR TITLE
Add multi-arch tarballs and harden alternatives opt-out

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -174,6 +174,10 @@ is_truthy() {
 }
 
 should_register_alternatives() {
+    if is_truthy "${OC_RSYNC_PACKAGE_DISABLE_ALTERNATIVES:-}"; then
+        return 1
+    fi
+
     if [ -n "${OC_RSYNC_PACKAGE_REGISTER_ALTERNATIVES:-}" ]; then
         if is_truthy "${OC_RSYNC_PACKAGE_REGISTER_ALTERNATIVES}"; then
             return 0

--- a/packaging/deb/postinst
+++ b/packaging/deb/postinst
@@ -33,6 +33,10 @@ load_defaults() {
 }
 
 should_register_alternatives() {
+    if is_truthy "${OC_RSYNC_PACKAGE_DISABLE_ALTERNATIVES:-}"; then
+        return 1
+    fi
+
     if [ -n "${OC_RSYNC_PACKAGE_REGISTER_ALTERNATIVES:-}" ]; then
         if is_truthy "${OC_RSYNC_PACKAGE_REGISTER_ALTERNATIVES}"; then
             return 0

--- a/packaging/default/oc-rsyncd
+++ b/packaging/default/oc-rsyncd
@@ -13,5 +13,7 @@
 # Set this to "yes" (or export OC_RSYNC_PACKAGE_REGISTER_ALTERNATIVES=1 while
 # installing) to register oc-rsync with update-alternatives. The packaging
 # scripts skip registration by default so the upstream rsync binaries can
-# remain in place when both packages are installed.
+# remain in place when both packages are installed. Set
+# OC_RSYNC_PACKAGE_DISABLE_ALTERNATIVES=1 to force registration to remain
+# disabled even if the configuration below requests it.
 # OC_RSYNC_REGISTER_ALTERNATIVES=yes

--- a/xtask/src/commands/package/args.rs
+++ b/xtask/src/commands/package/args.rs
@@ -9,7 +9,7 @@ pub struct PackageOptions {
     pub build_deb: bool,
     /// Whether to build the RPM package.
     pub build_rpm: bool,
-    /// Whether to build the amd64 tarball distribution.
+    /// Whether to build the Linux tarball distributions.
     pub build_tarball: bool,
     /// Optional profile override.
     pub profile: Option<OsString>,
@@ -138,7 +138,7 @@ fn set_profile_option(
 /// Returns usage text for the command.
 pub fn usage() -> String {
     String::from(
-        "Usage: cargo xtask package [OPTIONS]\n\nOptions:\n  --deb            Build only the Debian package\n  --rpm            Build only the RPM package\n  --tarball        Build only the amd64 tar.gz distribution\n  --release        Build using the release profile (default)\n  --debug          Build using the debug profile\n  --profile NAME   Build using the named cargo profile\n  --no-profile     Do not override the cargo profile\n  -h, --help       Show this help message",
+        "Usage: cargo xtask package [OPTIONS]\n\nOptions:\n  --deb            Build only the Debian package\n  --rpm            Build only the RPM package\n  --tarball        Build only the Linux tar.gz distributions\n  --release        Build using the release profile (default)\n  --debug          Build using the debug profile\n  --profile NAME   Build using the named cargo profile\n  --no-profile     Do not override the cargo profile\n  -h, --help       Show this help message",
     )
 }
 

--- a/xtask/src/commands/package/build.rs
+++ b/xtask/src/commands/package/build.rs
@@ -1,4 +1,4 @@
-use super::{AMD64_TARBALL_TARGET, PackageOptions, tarball};
+use super::{PackageOptions, tarball};
 use crate::error::TaskResult;
 use crate::util::{ensure_command_available, probe_cargo_tool, run_cargo_tool};
 use crate::workspace::load_workspace_branding;
@@ -60,8 +60,11 @@ pub fn execute(workspace: &Path, options: PackageOptions) -> TaskResult<()> {
     }
 
     if options.build_tarball {
-        build_workspace_binaries(workspace, &options.profile, Some(AMD64_TARBALL_TARGET))?;
-        tarball::build_amd64_tarball(workspace, &branding, &options.profile)?;
+        let specs = tarball::linux_tarball_specs(&branding)?;
+        for spec in &specs {
+            build_workspace_binaries(workspace, &options.profile, Some(spec.target_triple))?;
+            tarball::build_tarball(workspace, &branding, &options.profile, spec)?;
+        }
     }
 
     Ok(())

--- a/xtask/src/commands/package/mod.rs
+++ b/xtask/src/commands/package/mod.rs
@@ -4,9 +4,5 @@ mod tarball;
 
 pub use args::{PackageOptions, parse_args};
 pub use build::execute;
-
-pub(crate) const AMD64_TARBALL_TARGET: &str = "x86_64-unknown-linux-gnu";
-pub(crate) const AMD64_TARBALL_ARCH: &str = "amd64";
-
 #[cfg(test)]
 mod tests;


### PR DESCRIPTION
## Summary
- add an explicit OC_RSYNC_PACKAGE_DISABLE_ALTERNATIVES guard to keep upstream rsync binaries in place unless operators opt in to update-alternatives
- extend the packaging defaults to document the new guard
- teach the packaging xtask to build Linux tar.gz distributions for every declared architecture and cover the behaviour with unit tests

## Testing
- cargo test -p xtask

------