### PR TITLE
Use dist profile for packaging outputs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,12 @@ rsync-daemon = { path = "crates/daemon" }
 assert_cmd = "2.0"
 rsync-core = { path = "crates/core" }
 
+[profile.dist]
+inherits = "release"
+lto = "thin"
+codegen-units = 1
+strip = "debuginfo"
+
 [target.'cfg(all(windows, target_env = "gnu"))'.dependencies]
 rsync-windows-gnu-eh = { path = "crates/windows-gnu-eh" }
 
@@ -108,10 +114,10 @@ depends = "libc6 (>= 2.34), libgcc-s1"
 extended-description = "Pure-Rust implementation of rsync-compatible client and daemon binaries. Ships oc-rsync compatibility wrappers for environments that still rely on the legacy branding."
 features = ["legacy-binaries"]
 assets = [
-    ["target/release/rsync", "/usr/libexec/oc-rsync/rsync", "755"],
-    ["target/release/rsyncd", "/usr/libexec/oc-rsync/rsyncd", "755"],
-    ["target/release/oc-rsync", "/usr/bin/oc-rsync", "755"],
-    ["target/release/oc-rsyncd", "/usr/bin/oc-rsyncd", "755"],
+    ["target/dist/rsync", "/usr/libexec/oc-rsync/rsync", "755"],
+    ["target/dist/rsyncd", "/usr/libexec/oc-rsync/rsyncd", "755"],
+    ["target/dist/oc-rsync", "/usr/bin/oc-rsync", "755"],
+    ["target/dist/oc-rsyncd", "/usr/bin/oc-rsyncd", "755"],
     ["packaging/systemd/oc-rsyncd.service", "/lib/systemd/system/oc-rsyncd.service", "644"],
     ["packaging/etc/oc-rsyncd/oc-rsyncd.conf", "/etc/oc-rsyncd/oc-rsyncd.conf", "644"],
     ["packaging/etc/oc-rsyncd/oc-rsyncd.secrets", "/etc/oc-rsyncd/oc-rsyncd.secrets", "600"],
@@ -291,7 +297,8 @@ fi
 '''
 
 [package.metadata.rpm.cargo]
-buildflags = ["--release", "--features", "legacy-binaries"]
+profile = "dist"
+buildflags = ["--profile", "dist", "--features", "legacy-binaries"]
 
 [package.metadata.rpm.targets]
 rsync = { path = "/usr/libexec/oc-rsync/rsync", mode = "0755" }

--- a/xtask/src/commands/package/args.rs
+++ b/xtask/src/commands/package/args.rs
@@ -2,6 +2,9 @@ use crate::error::{TaskError, TaskResult};
 use crate::util::is_help_flag;
 use std::ffi::OsString;
 
+/// Optimised cargo profile used for release packaging.
+pub const DIST_PROFILE: &str = "dist";
+
 /// Options accepted by the `package` command.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct PackageOptions {
@@ -16,13 +19,14 @@ pub struct PackageOptions {
 }
 
 impl PackageOptions {
-    /// Returns package options that build all release artifacts.
+    /// Returns package options that build all release artifacts using the
+    /// optimised distribution profile.
     pub fn release_all() -> Self {
         Self {
             build_deb: true,
             build_rpm: true,
             build_tarball: true,
-            profile: Some(OsString::from("release")),
+            profile: Some(OsString::from(DIST_PROFILE)),
         }
     }
 }
@@ -36,7 +40,7 @@ where
     let mut build_deb = false;
     let mut build_rpm = false;
     let mut build_tarball = false;
-    let mut profile = Some(OsString::from("release"));
+    let mut profile = Some(OsString::from(DIST_PROFILE));
     let mut profile_explicit = false;
 
     while let Some(arg) = args.next() {
@@ -63,7 +67,7 @@ where
             set_profile_option(
                 &mut profile,
                 &mut profile_explicit,
-                Some(OsString::from("release")),
+                Some(OsString::from(DIST_PROFILE)),
             )?;
             continue;
         }
@@ -138,7 +142,7 @@ fn set_profile_option(
 /// Returns usage text for the command.
 pub fn usage() -> String {
     String::from(
-        "Usage: cargo xtask package [OPTIONS]\n\nOptions:\n  --deb            Build only the Debian package\n  --rpm            Build only the RPM package\n  --tarball        Build only the Linux tar.gz distributions\n  --release        Build using the release profile (default)\n  --debug          Build using the debug profile\n  --profile NAME   Build using the named cargo profile\n  --no-profile     Do not override the cargo profile\n  -h, --help       Show this help message",
+        "Usage: cargo xtask package [OPTIONS]\n\nOptions:\n  --deb            Build only the Debian package\n  --rpm            Build only the RPM package\n  --tarball        Build only the Linux tar.gz distributions\n  --release        Build using the dist profile (default)\n  --debug          Build using the debug profile\n  --profile NAME   Build using the named cargo profile\n  --no-profile     Do not override the cargo profile\n  -h, --help       Show this help message",
     )
 }
 
@@ -193,17 +197,17 @@ mod tests {
                 build_deb: false,
                 build_rpm: false,
                 build_tarball: true,
-                profile: Some(OsString::from("release")),
+                profile: Some(OsString::from(DIST_PROFILE)),
             }
         );
     }
 
     #[test]
-    fn release_all_returns_release_profile_with_all_targets() {
+    fn release_all_returns_dist_profile_with_all_targets() {
         let options = PackageOptions::release_all();
         assert!(options.build_deb);
         assert!(options.build_rpm);
         assert!(options.build_tarball);
-        assert_eq!(options.profile, Some(OsString::from("release")));
+        assert_eq!(options.profile, Some(OsString::from(DIST_PROFILE)));
     }
 }

--- a/xtask/src/commands/package/mod.rs
+++ b/xtask/src/commands/package/mod.rs
@@ -2,7 +2,7 @@ mod args;
 mod build;
 mod tarball;
 
-pub use args::{PackageOptions, parse_args};
+pub use args::{DIST_PROFILE, PackageOptions, parse_args};
 pub use build::execute;
 #[cfg(test)]
 mod tests;

--- a/xtask/src/commands/package/tests.rs
+++ b/xtask/src/commands/package/tests.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 use super::build::cross_compiler_program_for_target;
-use super::{PackageOptions, execute};
+use super::{DIST_PROFILE, PackageOptions, execute};
 use crate::error::TaskError;
 use std::env;
 use std::ffi::{OsStr, OsString};
@@ -99,7 +99,7 @@ fn execute_reports_missing_cargo_deb_tool() {
             build_deb: true,
             build_rpm: false,
             build_tarball: false,
-            profile: Some(OsString::from("release")),
+            profile: Some(OsString::from(DIST_PROFILE)),
         },
     )
     .unwrap_err();
@@ -155,7 +155,7 @@ fn execute_reports_missing_rpmbuild_tool() {
             build_deb: false,
             build_rpm: true,
             build_tarball: false,
-            profile: Some(OsString::from("release")),
+            profile: Some(OsString::from(DIST_PROFILE)),
         },
     )
     .unwrap_err();
@@ -187,7 +187,7 @@ fn execute_reports_missing_cross_compiler() {
 
     let error = super::build::build_workspace_binaries(
         workspace_root(),
-        &Some(OsString::from("release")),
+        &Some(OsString::from(DIST_PROFILE)),
         Some("aarch64-unknown-linux-gnu"),
     )
     .unwrap_err();

--- a/xtask/src/commands/release/upload.rs
+++ b/xtask/src/commands/release/upload.rs
@@ -1,3 +1,4 @@
+use crate::commands::package::DIST_PROFILE;
 use crate::error::{TaskError, TaskResult};
 use crate::util::ensure_command_available;
 use crate::workspace::WorkspaceBranding;
@@ -126,7 +127,7 @@ fn collect_debian_packages(workspace: &Path, artifacts: &mut Vec<PathBuf>) -> Ta
 }
 
 fn collect_rpm_packages(workspace: &Path, artifacts: &mut Vec<PathBuf>) -> TaskResult<()> {
-    for profile in ["release", "debug"] {
+    for profile in [DIST_PROFILE, "release", "debug"] {
         let rpms_dir = workspace
             .join("target")
             .join(profile)
@@ -364,7 +365,9 @@ mod tests {
             .join("target/debian")
             .join("oc-rsync_3.4.1-rust_amd64.deb");
         let rpm = workspace
-            .join("target/release/rpmbuild/RPMS/x86_64")
+            .join("target")
+            .join(DIST_PROFILE)
+            .join("rpmbuild/RPMS/x86_64")
             .join("oc-rsync-3.4.1-1.x86_64.rpm");
 
         for path in [&tarball, &deb, &rpm] {
@@ -393,7 +396,9 @@ mod tests {
             .join("target/debian")
             .join("oc-rsync_3.4.1-rust_amd64.deb");
         let rpm = workspace
-            .join("target/release/rpmbuild/RPMS/x86_64")
+            .join("target")
+            .join(DIST_PROFILE)
+            .join("rpmbuild/RPMS/x86_64")
             .join("oc-rsync-3.4.1-1.x86_64.rpm");
 
         for path in [&tarball, &deb, &rpm] {

--- a/xtask/src/util.rs
+++ b/xtask/src/util.rs
@@ -99,6 +99,16 @@ pub fn run_cargo_tool(
     display: &str,
     install_hint: &str,
 ) -> TaskResult<()> {
+    run_cargo_tool_with_env(workspace, args, &[], display, install_hint)
+}
+
+pub fn run_cargo_tool_with_env(
+    workspace: &std::path::Path,
+    args: Vec<OsString>,
+    env: &[(OsString, OsString)],
+    display: &str,
+    install_hint: &str,
+) -> TaskResult<()> {
     if should_simulate_missing_tool(display) {
         return Err(tool_missing_error(display, install_hint));
     }
@@ -107,6 +117,10 @@ pub fn run_cargo_tool(
     let output = Command::new(cargo)
         .current_dir(workspace)
         .args(&args)
+        .envs(
+            env.iter()
+                .map(|(key, value)| (key.as_os_str(), value.as_os_str())),
+        )
         .output()
         .map_err(|error| map_command_error(error, display, install_hint))?;
 


### PR DESCRIPTION
## Summary
- add a dedicated `dist` cargo profile and point Debian/RPM packaging to the new output directory
- default `cargo xtask package` to the dist profile and ensure cross builds use the correct linker
- update release upload helpers to collect RPM artifacts from the dist profile as well

## Testing
- cargo test -p xtask
- cargo --locked run -p xtask -- package

------