### PR TITLE
Unify compression level parsing to avoid inconsistent handling

### DIFF
--- a/crates/cli/src/frontend/execution/compression.rs
+++ b/crates/cli/src/frontend/execution/compression.rs
@@ -1,6 +1,7 @@
 use std::ffi::OsStr;
 use std::num::NonZeroU8;
 
+use rsync_compress::zlib::CompressionLevel;
 use rsync_core::{
     bandwidth::BandwidthParseError,
     client::{BandwidthLimit, CompressionSetting},
@@ -13,27 +14,78 @@ pub(crate) enum CompressLevelArg {
     Level(NonZeroU8),
 }
 
-pub(crate) fn parse_compress_level(argument: &OsStr) -> Result<CompressLevelArg, Message> {
-    let text = argument.to_string_lossy();
-    let trimmed = text.trim();
+enum CompressionLevelParseError {
+    Empty { original: String },
+    Invalid { original: String, trimmed: String },
+    OutOfRange { trimmed: String, value: i32 },
+}
 
-    if trimmed.is_empty() {
-        return Err(rsync_error!(1, "--compress-level={} is invalid", text).with_role(Role::Client));
+impl CompressionLevelParseError {
+    fn into_flag_message(self) -> Message {
+        match self {
+            Self::Empty { original } | Self::Invalid { original, .. } => {
+                rsync_error!(1, "--compress-level={} is invalid", original).with_role(Role::Client)
+            }
+            Self::OutOfRange { trimmed, .. } => {
+                rsync_error!(1, "--compress-level={} must be between 0 and 9", trimmed)
+                    .with_role(Role::Client)
+            }
+        }
     }
 
-    match trimmed.parse::<i32>() {
+    fn into_argument_message(self) -> Message {
+        match self {
+            Self::Empty { .. } => rsync_error!(
+                1,
+                "compression level value must not be empty"
+            )
+            .with_role(Role::Client),
+            Self::Invalid { trimmed, .. } => rsync_error!(
+                1,
+                format!(
+                    "invalid compression level '{trimmed}': compression level must be an integer between 0 and 9"
+                )
+            )
+            .with_role(Role::Client),
+            Self::OutOfRange { trimmed, value } => rsync_error!(
+                1,
+                format!(
+                    "invalid compression level '{trimmed}': compression level {value} is outside the supported range 0-9"
+                )
+            )
+            .with_role(Role::Client),
+        }
+    }
+}
+
+fn parse_compress_level_value(
+    argument: &OsStr,
+) -> Result<CompressLevelArg, CompressionLevelParseError> {
+    let original = argument.to_string_lossy().into_owned();
+    let trimmed_owned = original.trim().to_owned();
+
+    if trimmed_owned.is_empty() {
+        return Err(CompressionLevelParseError::Empty { original });
+    }
+
+    match trimmed_owned.parse::<i32>() {
         Ok(0) => Ok(CompressLevelArg::Disable),
         Ok(value @ 1..=9) => Ok(CompressLevelArg::Level(
             NonZeroU8::new(value as u8).expect("range guarantees non-zero"),
         )),
-        Ok(_) => Err(
-            rsync_error!(1, "--compress-level={} must be between 0 and 9", trimmed)
-                .with_role(Role::Client),
-        ),
-        Err(_) => {
-            Err(rsync_error!(1, "--compress-level={} is invalid", text).with_role(Role::Client))
-        }
+        Ok(value) => Err(CompressionLevelParseError::OutOfRange {
+            trimmed: trimmed_owned,
+            value,
+        }),
+        Err(_) => Err(CompressionLevelParseError::Invalid {
+            original,
+            trimmed: trimmed_owned,
+        }),
     }
+}
+
+pub(crate) fn parse_compress_level(argument: &OsStr) -> Result<CompressLevelArg, Message> {
+    parse_compress_level_value(argument).map_err(CompressionLevelParseError::into_flag_message)
 }
 
 pub(crate) fn parse_bandwidth_limit(argument: &OsStr) -> Result<Option<BandwidthLimit>, Message> {
@@ -57,44 +109,11 @@ pub(crate) fn parse_bandwidth_limit(argument: &OsStr) -> Result<Option<Bandwidth
 }
 
 pub(crate) fn parse_compress_level_argument(value: &OsStr) -> Result<CompressionSetting, Message> {
-    let text = value.to_string_lossy();
-    let trimmed = text.trim();
-    if trimmed.is_empty() {
-        return Err(
-            rsync_error!(1, "compression level value must not be empty").with_role(Role::Client)
-        );
+    match parse_compress_level_value(value) {
+        Ok(CompressLevelArg::Disable) => Ok(CompressionSetting::disabled()),
+        Ok(CompressLevelArg::Level(level)) => {
+            Ok(CompressionSetting::level(CompressionLevel::precise(level)))
+        }
+        Err(error) => Err(error.into_argument_message()),
     }
-
-    if !trimmed.chars().all(|ch| ch.is_ascii_digit()) {
-        return Err(
-            rsync_error!(
-                1,
-                format!(
-                    "invalid compression level '{trimmed}': compression level must be an integer between 0 and 9"
-                )
-            )
-            .with_role(Role::Client),
-        );
-    }
-
-    let level: u32 = trimmed.parse().map_err(|_| {
-        rsync_error!(
-            1,
-            format!(
-                "invalid compression level '{trimmed}': compression level must be an integer between 0 and 9"
-            )
-        )
-        .with_role(Role::Client)
-    })?;
-
-    CompressionSetting::try_from_numeric(level).map_err(|error| {
-        rsync_error!(
-            1,
-            format!(
-                "invalid compression level '{trimmed}': compression level {} is outside the supported range 0-9",
-                error.level()
-            )
-        )
-        .with_role(Role::Client)
-    })
 }


### PR DESCRIPTION
## Summary
- introduce a shared parsing helper for --compress-level values so CLI and argument code agree on accepted formats
- reuse the helper to produce consistent diagnostics and compression settings when the level disables compression

## Testing
- cargo test -p rsync-cli

------