### PR TITLE
Ensure release workflow uploads architecture-specific assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,5 +161,6 @@ jobs:
       - name: Upload release assets
         uses: softprops/action-gh-release@v1
         with:
-          files: dist/*
+          files: |
+            dist/**/*
           


### PR DESCRIPTION
## Summary
- expand the release asset glob so nested per-target outputs are included when publishing

## Testing
- not run

------