### PR TITLE
Fix aarch64 cross-linking with zig shims

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,9 @@
 [build]
 rustc-wrapper = "tools/cross/rustc-with-zig.sh"
 
+[target.aarch64-unknown-linux-gnu]
+linker = "aarch64-unknown-linux-gnu-gcc"
+ar = "aarch64-unknown-linux-gnu-ar"
+
 [target.i686-pc-windows-gnu]
 rustflags = ["-C", "panic=abort"]

--- a/tools/cross/bin/aarch64-unknown-linux-gnu-ar
+++ b/tools/cross/bin/aarch64-unknown-linux-gnu-ar
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -eu
+ZIG_BIN=${ZIG:-zig}
+if ! command -v "$ZIG_BIN" >/dev/null 2>&1; then
+    echo "error: zig is required to emulate aarch64-unknown-linux-gnu-ar" >&2
+    echo "hint: install zig or set the ZIG environment variable to its path" >&2
+    exit 127
+fi
+exec "$ZIG_BIN" ar "$@"

--- a/tools/cross/bin/aarch64-unknown-linux-gnu-gcc
+++ b/tools/cross/bin/aarch64-unknown-linux-gnu-gcc
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -eu
+ZIG_BIN=${ZIG:-zig}
+if ! command -v "$ZIG_BIN" >/dev/null 2>&1; then
+    echo "error: zig is required to emulate aarch64-unknown-linux-gnu-gcc" >&2
+    echo "hint: install zig or set the ZIG environment variable to its path" >&2
+    exit 127
+fi
+exec "$ZIG_BIN" cc -target aarch64-linux-gnu "$@"


### PR DESCRIPTION
## Summary
- configure the workspace to use zig-provided linker and archiver shims for the aarch64-unknown-linux-gnu target
- add zig-based gcc/ar compatibility scripts that surface a helpful error when zig is unavailable

## Testing
- cargo build -p oc-rsync

------