### PR TITLE
Handle daemon refusal banners before module list

### DIFF
--- a/crates/core/src/client/error.rs
+++ b/crates/core/src/client/error.rs
@@ -165,3 +165,14 @@ pub(crate) fn daemon_access_denied_error(reason: &str) -> ClientError {
 
     daemon_error(detail, PARTIAL_TRANSFER_EXIT_CODE)
 }
+
+pub(crate) fn daemon_listing_unavailable_error(reason: &str) -> ClientError {
+    let trimmed = reason.trim();
+    let detail = if trimmed.is_empty() {
+        "daemon refused module listing".to_string()
+    } else {
+        format!("daemon refused module listing: {trimmed}")
+    };
+
+    daemon_error(detail, FEATURE_UNAVAILABLE_EXIT_CODE)
+}

--- a/crates/core/src/client/mod.rs
+++ b/crates/core/src/client/mod.rs
@@ -125,7 +125,7 @@ use std::time::Duration;
 pub(crate) use self::error::{
     MAX_DELETE_EXIT_CODE, PROTOCOL_INCOMPATIBLE_EXIT_CODE, daemon_access_denied_error,
     daemon_authentication_failed_error, daemon_authentication_required_error, daemon_error,
-    daemon_protocol_error, socket_error,
+    daemon_listing_unavailable_error, daemon_protocol_error, socket_error,
 };
 pub(crate) const DAEMON_SOCKET_TIMEOUT: Duration = Duration::from_secs(10);
 pub(crate) const MAX_EXIT_CODE: i32 = u8::MAX as i32;


### PR DESCRIPTION
## Summary
- collect legacy @RSYNCD banners sent before acknowledgement as daemon diagnostics
- surface a feature-unavailable client error that reports the daemon's refusal message
- add a regression test that exercises the "--daemon not enabled--" banner

## Testing
- cargo test -p rsync-core run_module_list_reports_daemon_listing_unavailable

------