### PR TITLE
Handle plaintext daemon MOTD lines before module list ack

### DIFF
--- a/crates/core/src/client/module_list/listing.rs
+++ b/crates/core/src/client/module_list/listing.rs
@@ -219,10 +219,19 @@ pub fn run_module_list_with_password_and_options(
             continue;
         }
 
+        if !acknowledged && !line.starts_with(LEGACY_DAEMON_PREFIX) {
+            pre_ack_messages.push(line.clone());
+            if !suppress_motd {
+                motd.push(line);
+            }
+            continue;
+        }
+
         if line.starts_with(LEGACY_DAEMON_PREFIX) {
             match parse_legacy_daemon_message(&line) {
                 Ok(LegacyDaemonMessage::Ok) => {
                     acknowledged = true;
+                    pre_ack_messages.clear();
                     continue;
                 }
                 Ok(LegacyDaemonMessage::Exit) => break,

--- a/crates/core/src/client/tests/mod.rs
+++ b/crates/core/src/client/tests/mod.rs
@@ -9,4 +9,5 @@ include!("client_transfer.rs");
 include!("module_list_request.rs");
 include!("module_list_proxy.rs");
 include!("module_list_auth.rs");
+include!("module_list_listing.rs");
 include!("error_helpers.rs");

--- a/crates/core/src/client/tests/module_list_listing.rs
+++ b/crates/core/src/client/tests/module_list_listing.rs
@@ -1,0 +1,53 @@
+#[test]
+fn run_module_list_accepts_plaintext_motd_before_acknowledgment() {
+    let responses = vec![
+        "-----\n",
+        "Welcome to the stub rsync service\n",
+        "@RSYNCD: OK\n",
+        "public\tExample module\n",
+        "@RSYNCD: EXIT\n",
+    ];
+    let (addr, handle) = spawn_stub_daemon(responses);
+
+    let request = ModuleListRequest::from_components(
+        DaemonAddress::new(addr.ip().to_string(), addr.port()).expect("address"),
+        None,
+        ProtocolVersion::NEWEST,
+    );
+
+    let list = run_module_list(request).expect("module list succeeds");
+
+    assert_eq!(list.motd_lines(), ["-----", "Welcome to the stub rsync service"]);
+    assert_eq!(list.entries().len(), 1);
+    assert_eq!(list.entries()[0].name(), "public");
+    assert_eq!(list.entries()[0].comment(), Some("Example module"));
+
+    handle.join().expect("daemon thread completes");
+}
+
+#[test]
+fn run_module_list_suppresses_plaintext_motd_when_requested() {
+    let responses = vec![
+        "Banner headline\n",
+        "@RSYNCD: OK\n",
+        "archive\tRotating snapshots\n",
+        "@RSYNCD: EXIT\n",
+    ];
+    let (addr, handle) = spawn_stub_daemon(responses);
+
+    let request = ModuleListRequest::from_components(
+        DaemonAddress::new(addr.ip().to_string(), addr.port()).expect("address"),
+        None,
+        ProtocolVersion::NEWEST,
+    );
+
+    let options = ModuleListOptions::default().suppress_motd(true);
+    let list = run_module_list_with_options(request, options).expect("module list succeeds");
+
+    assert!(list.motd_lines().is_empty());
+    assert_eq!(list.entries().len(), 1);
+    assert_eq!(list.entries()[0].name(), "archive");
+    assert_eq!(list.entries()[0].comment(), Some("Rotating snapshots"));
+
+    handle.join().expect("daemon thread completes");
+}


### PR DESCRIPTION
## Summary
- treat plaintext daemon lines before acknowledgment as MOTD rather than protocol errors
- clear buffered pre-acknowledgment messages once the daemon confirms the listing
- cover plaintext MOTD handling with and without `--no-motd`

## Testing
- cargo test -p rsync-core run_module_list_accepts_plaintext_motd_before_acknowledgment
- cargo test -p rsync-core run_module_list_suppresses_plaintext_motd_when_requested

------