### PR TITLE
Ensure packages coexist with upstream rsync

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,8 +113,12 @@ priority = "optional"
 maintainer = "Ofer Chen <skewers.irises.3b@icloud.com>"
 depends = "libc6 (>= 2.34), libgcc-s1"
 extended-description = "Pure-Rust implementation of rsync-compatible client and daemon binaries. Ships oc-rsync compatibility wrappers for environments that still rely on the legacy branding."
-features = []
+features = ["legacy-binaries"]
 assets = [
+    ["target/dist/oc-rsync", "/usr/bin/oc-rsync", "755"],
+    ["target/dist/oc-rsyncd", "/usr/bin/oc-rsyncd", "755"],
+    ["target/dist/rsync", "/usr/libexec/oc-rsync/rsync", "755"],
+    ["target/dist/rsyncd", "/usr/libexec/oc-rsync/rsyncd", "755"],
     ["packaging/systemd/oc-rsyncd.service", "/lib/systemd/system/oc-rsyncd.service", "644"],
     ["packaging/etc/oc-rsyncd/oc-rsyncd.conf", "/etc/oc-rsyncd/oc-rsyncd.conf", "644"],
     ["packaging/etc/oc-rsyncd/oc-rsyncd.secrets", "/etc/oc-rsyncd/oc-rsyncd.secrets", "600"],
@@ -285,9 +289,11 @@ fi
 
 [package.metadata.rpm.cargo]
 profile = "dist"
-buildflags = ["--profile", "dist", "--bins"]
+buildflags = ["--profile", "dist", "--bins", "--features", "legacy-binaries"]
 
 [package.metadata.rpm.targets]
 "oc-rsync" = { path = "/usr/bin/oc-rsync", mode = "0755" }
 "oc-rsyncd" = { path = "/usr/bin/oc-rsyncd", mode = "0755" }
+"rsync" = { path = "/usr/libexec/oc-rsync/rsync", mode = "0755" }
+"rsyncd" = { path = "/usr/libexec/oc-rsync/rsyncd", mode = "0755" }
 

--- a/xtask/src/commands/package/build.rs
+++ b/xtask/src/commands/package/build.rs
@@ -1,7 +1,8 @@
 use super::{DIST_PROFILE, PackageOptions, tarball};
 use crate::error::{TaskError, TaskResult};
 use crate::util::{
-    ensure_command_available, probe_cargo_tool, run_cargo_tool, run_cargo_tool_with_env,
+    ensure_command_available, ensure_rust_target_installed, probe_cargo_tool, run_cargo_tool,
+    run_cargo_tool_with_env,
 };
 use crate::workspace::load_workspace_branding;
 use std::env;
@@ -19,7 +20,7 @@ pub fn execute(workspace: &Path, options: PackageOptions) -> TaskResult<()> {
     println!("Preparing {}", branding.summary());
 
     if options.build_deb || options.build_rpm {
-        build_workspace_binaries(workspace, &options.profile, None, None, false)?;
+        build_workspace_binaries(workspace, &options.profile, None, None, true)?;
     }
 
     if options.build_deb {
@@ -159,6 +160,7 @@ pub(super) fn build_workspace_binaries(
     let mut env_overrides: Vec<(OsString, OsString)> = Vec::new();
 
     if let Some(target) = target {
+        ensure_rust_target_installed(target)?;
         args.push(OsString::from("--target"));
         args.push(OsString::from(target));
         if let Some(linker) = linker_override {


### PR DESCRIPTION
## Summary
- ship oc-rsync/oc-rsyncd and legacy wrappers from explicit packaging assets so Debian/RPM installs can sit beside upstream rsync
- ensure packaging builds legacy binaries and checks for installed rustup targets before cross-compiling
- cover the new rustup target helper with xtask unit tests

## Testing
- cargo test -p xtask

------