### PR TITLE
Apply inline format argument syntax across workspace

### DIFF
--- a/crates/bandwidth/src/parse/tests.rs
+++ b/crates/bandwidth/src/parse/tests.rs
@@ -492,7 +492,7 @@ fn parse_bandwidth_limit_rejects_missing_burst_value() {
 proptest! {
     #[test]
     fn parse_round_trips_when_limit_is_multiple_of_1024(value in 1u64..1_000_000u64) {
-        let text = format!("{}K", value);
+        let text = format!("{value}K");
         let parsed = parse_bandwidth_argument(&text).expect("parse succeeds");
         let expected = NonZeroU64::new(value * 1024).expect("non-zero");
         prop_assert_eq!(parsed, Some(expected));

--- a/crates/checksums/src/strong/md4.rs
+++ b/crates/checksums/src/strong/md4.rs
@@ -68,7 +68,7 @@ mod tests {
 
         let mut out = String::with_capacity(bytes.len() * 2);
         for byte in bytes {
-            write!(&mut out, "{:02x}", byte).expect("write! to String cannot fail");
+            write!(&mut out, "{byte:02x}").expect("write! to String cannot fail");
         }
         out
     }

--- a/crates/checksums/src/strong/md5.rs
+++ b/crates/checksums/src/strong/md5.rs
@@ -68,7 +68,7 @@ mod tests {
 
         let mut out = String::with_capacity(bytes.len() * 2);
         for byte in bytes {
-            write!(&mut out, "{:02x}", byte).expect("write! to String cannot fail");
+            write!(&mut out, "{byte:02x}").expect("write! to String cannot fail");
         }
         out
     }

--- a/crates/cli/src/frontend/execution/drive/messages.rs
+++ b/crates/cli/src/frontend/execution/drive/messages.rs
@@ -13,7 +13,7 @@ pub(super) fn emit_message_with_fallback<Err>(
     Err: Write,
 {
     if write_message(message, stderr).is_err() {
-        let _ = writeln!(stderr.writer_mut(), "{}", fallback);
+        let _ = writeln!(stderr.writer_mut(), "{fallback}");
     }
 }
 

--- a/crates/cli/src/frontend/execution/drive/metadata.rs
+++ b/crates/cli/src/frontend/execution/drive/metadata.rs
@@ -128,8 +128,7 @@ pub(crate) fn compute_metadata_settings(
             }
             Err(error) => {
                 let formatted = format!(
-                    "failed to parse --chmod specification '{}': {}",
-                    spec_text, error
+                    "failed to parse --chmod specification '{spec_text}': {error}"
                 );
                 return Err(rsync_core::rsync_error!(1, formatted)
                     .with_role(rsync_core::message::Role::Client));

--- a/crates/cli/src/frontend/execution/drive/module_listing.rs
+++ b/crates/cli/src/frontend/execution/drive/module_listing.rs
@@ -60,7 +60,7 @@ where
         Ok(None) => return None,
         Err(error) => {
             if write_message(error.message(), stderr).is_err() {
-                let _ = writeln!(stderr.writer_mut(), "{}", error);
+                let _ = writeln!(stderr.writer_mut(), "{error}");
             }
             return Some(error.exit_code());
         }
@@ -77,7 +77,7 @@ where
         Err(message) => {
             if write_message(&message, stderr).is_err() {
                 let fallback = message.to_string();
-                let _ = writeln!(stderr.writer_mut(), "{}", fallback);
+                let _ = writeln!(stderr.writer_mut(), "{fallback}");
             }
             return Some(1);
         }
@@ -105,10 +105,10 @@ where
         }
         Err(error) => {
             if write_message(error.message(), stderr).is_err() {
+                let exit_code = error.exit_code();
                 let _ = writeln!(
                     stderr.writer_mut(),
-                    "rsync error: daemon functionality is unavailable in this build (code {})",
-                    error.exit_code()
+                    "rsync error: daemon functionality is unavailable in this build (code {exit_code})"
                 );
             }
             Some(error.exit_code())

--- a/crates/cli/src/frontend/execution/module_list.rs
+++ b/crates/cli/src/frontend/execution/module_list.rs
@@ -9,12 +9,12 @@ pub(crate) fn render_module_list<W: Write, E: Write>(
     suppress_motd: bool,
 ) -> io::Result<()> {
     for warning in list.warnings() {
-        writeln!(stderr, "@WARNING: {}", warning)?;
+        writeln!(stderr, "@WARNING: {warning}")?;
     }
 
     if !suppress_motd {
         for line in list.motd_lines() {
-            writeln!(stdout, "{}", line)?;
+            writeln!(stdout, "{line}")?;
         }
     }
 

--- a/crates/cli/src/frontend/execution/operands.rs
+++ b/crates/cli/src/frontend/execution/operands.rs
@@ -22,17 +22,15 @@ impl UnsupportedOption {
     pub(crate) fn to_message(&self) -> Message {
         let option = self.option.to_string_lossy();
         let text = format!(
-            "unsupported option '{}': this build currently supports only {}",
-            option, SUPPORTED_OPTIONS_LIST
+            "unsupported option '{option}': this build currently supports only {SUPPORTED_OPTIONS_LIST}"
         );
         rsync_error!(1, text).with_role(Role::Client)
     }
 
     pub(crate) fn fallback_text(&self) -> String {
+        let option = self.option.to_string_lossy();
         format!(
-            "unsupported option '{}': this build currently supports only {}",
-            self.option.to_string_lossy(),
-            SUPPORTED_OPTIONS_LIST
+            "unsupported option '{option}': this build currently supports only {SUPPORTED_OPTIONS_LIST}"
         )
     }
 }
@@ -81,7 +79,7 @@ pub(crate) fn parse_bind_address_argument(value: &OsStr) -> Result<BindAddress, 
     match resolve_bind_address(trimmed) {
         Ok(socket) => Ok(BindAddress::new(value.to_os_string(), socket)),
         Err(error) => {
-            let formatted = format!("failed to resolve --address value '{}': {}", trimmed, error);
+            let formatted = format!("failed to resolve --address value '{trimmed}': {error}");
             Err(rsync_error!(1, formatted).with_role(Role::Client))
         }
     }

--- a/crates/cli/src/frontend/execution/options.rs
+++ b/crates/cli/src/frontend/execution/options.rs
@@ -38,15 +38,14 @@ pub(crate) fn parse_protocol_version_arg(value: &OsStr) -> Result<ProtocolVersio
                 ParseProtocolVersionErrorKind::UnsupportedRange(value) => {
                     let (oldest, newest) = ProtocolVersion::supported_range_bounds();
                     format!(
-                        "protocol version {} is outside the supported range {}-{}",
-                        value, oldest, newest
+                        "protocol version {value} is outside the supported range {oldest}-{newest}"
                     )
                 }
             };
             if !detail.is_empty() {
                 detail.push_str("; ");
             }
-            detail.push_str(&format!("supported protocols are {}", supported));
+            detail.push_str(&format!("supported protocols are {supported}"));
 
             Err(rsync_error!(
                 1,

--- a/crates/cli/src/frontend/filter_rules/sources.rs
+++ b/crates/cli/src/frontend/filter_rules/sources.rs
@@ -43,20 +43,21 @@ pub(crate) fn load_filter_file_patterns(path: &Path) -> Result<Vec<String>, Mess
 
     let path_display = path.display().to_string();
     let file = File::open(path).map_err(|error| {
-        let text = format!("failed to read filter file '{}': {}", path_display, error);
+        let text = format!("failed to read filter file '{path_display}': {error}");
         rsync_error!(1, text).with_role(Role::Client)
     })?;
 
     let mut reader = BufReader::new(file);
     read_filter_patterns(&mut reader).map_err(|error| {
-        let text = format!("failed to read filter file '{}': {}", path_display, error);
+        let text = format!("failed to read filter file '{path_display}': {error}");
         rsync_error!(1, text).with_role(Role::Client)
     })
 }
 
 pub(super) fn read_merge_file(path: &Path) -> Result<String, Message> {
+    let path_display = path.display();
     fs::read_to_string(path).map_err(|error| {
-        let text = format!("failed to read filter file '{}': {}", path.display(), error);
+        let text = format!("failed to read filter file '{path_display}': {error}");
         rsync_error!(1, text).with_role(Role::Client)
     })
 }
@@ -66,8 +67,7 @@ pub(super) fn read_merge_from_standard_input() -> Result<String, Message> {
     if let Some(data) = take_filter_stdin_input() {
         return String::from_utf8(data).map_err(|error| {
             let text = format!(
-                "failed to read filter patterns from standard input: {}",
-                error
+                "failed to read filter patterns from standard input: {error}"
             );
             rsync_error!(1, text).with_role(Role::Client)
         });
@@ -76,8 +76,7 @@ pub(super) fn read_merge_from_standard_input() -> Result<String, Message> {
     let mut buffer = String::new();
     io::stdin().read_to_string(&mut buffer).map_err(|error| {
         let text = format!(
-            "failed to read filter patterns from standard input: {}",
-            error
+            "failed to read filter patterns from standard input: {error}"
         );
         rsync_error!(1, text).with_role(Role::Client)
     })?;
@@ -90,8 +89,7 @@ pub(crate) fn read_filter_patterns_from_standard_input() -> Result<Vec<String>, 
         let mut cursor = io::Cursor::new(data);
         return read_filter_patterns(&mut cursor).map_err(|error| {
             let text = format!(
-                "failed to read filter patterns from standard input: {}",
-                error
+                "failed to read filter patterns from standard input: {error}"
             );
             rsync_error!(1, text).with_role(Role::Client)
         });
@@ -101,8 +99,7 @@ pub(crate) fn read_filter_patterns_from_standard_input() -> Result<Vec<String>, 
     let mut reader = stdin.lock();
     read_filter_patterns(&mut reader).map_err(|error| {
         let text = format!(
-            "failed to read filter patterns from standard input: {}",
-            error
+            "failed to read filter patterns from standard input: {error}"
         );
         rsync_error!(1, text).with_role(Role::Client)
     })

--- a/crates/cli/src/frontend/mod.rs
+++ b/crates/cli/src/frontend/mod.rs
@@ -233,7 +233,7 @@ where
             let mut message = rsync_error!(1, "{}", error);
             message = message.with_role(Role::Client);
             if write_message(&message, &mut stderr_sink).is_err() {
-                let _ = writeln!(stderr_sink.writer_mut(), "{}", error);
+                let _ = writeln!(stderr_sink.writer_mut(), "{error}");
             }
             1
         }

--- a/crates/cli/src/frontend/progress/live.rs
+++ b/crates/cli/src/frontend/progress/live.rs
@@ -88,7 +88,7 @@ impl<'a> ClientProgressObserver for LiveProgress<'a> {
                 let size_field =
                     format!("{:>15}", format_progress_bytes(bytes, self.human_readable));
                 let percent = format_progress_percent(bytes, update.total_bytes());
-                let percent_field = format!("{:>4}", percent);
+                let percent_field = format!("{percent:>4}");
                 let rate_field = format!(
                     "{:>12}",
                     format_progress_rate(bytes, event.elapsed(), self.human_readable)

--- a/crates/cli/src/frontend/server.rs
+++ b/crates/cli/src/frontend/server.rs
@@ -269,6 +269,6 @@ fn write_server_fallback_error<Err: Write>(stderr: &mut Err, text: impl fmt::Dis
     let mut message = rsync_error!(1, "{}", text);
     message = message.with_role(Role::Client);
     if super::write_message(&message, &mut sink).is_err() {
-        let _ = writeln!(sink.writer_mut(), "{}", text);
+        let _ = writeln!(sink.writer_mut(), "{text}");
     }
 }

--- a/crates/cli/src/frontend/tests/server.rs
+++ b/crates/cli/src/frontend/tests/server.rs
@@ -116,9 +116,9 @@ fn server_mode_reports_disabled_fallback_override() {
 
     assert_eq!(exit_code, 1);
     let stderr_text = String::from_utf8(stderr).expect("stderr utf8");
+    let env = CLIENT_FALLBACK_ENV;
     assert!(stderr_text.contains(&format!(
-        "remote server mode is unavailable because {env} is disabled",
-        env = CLIENT_FALLBACK_ENV,
+        "remote server mode is unavailable because {env} is disabled"
     )));
 }
 

--- a/crates/core/src/client/config/enums.rs
+++ b/crates/core/src/client/config/enums.rs
@@ -144,11 +144,9 @@ impl fmt::Display for HumanReadableModeParseError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Empty => f.write_str("human-readable level must not be empty"),
-            Self::Invalid { value } => write!(
-                f,
-                "invalid human-readable level '{}': expected 0, 1, or 2",
-                value
-            ),
+            Self::Invalid { value } => {
+                write!(f, "invalid human-readable level '{value}': expected 0, 1, or 2")
+            }
         }
     }
 }

--- a/crates/core/src/client/error.rs
+++ b/crates/core/src/client/error.rs
@@ -87,8 +87,7 @@ pub(crate) fn map_local_copy_error(error: LocalCopyError) -> ClientError {
         LocalCopyErrorKind::DeleteLimitExceeded { skipped } => {
             let noun = if skipped == 1 { "entry" } else { "entries" };
             let text = format!(
-                "Deletions stopped due to --max-delete limit ({} {noun} skipped)",
-                skipped
+                "Deletions stopped due to --max-delete limit ({skipped} {noun} skipped)"
             );
             let message = rsync_error!(MAX_DELETE_EXIT_CODE, text).with_role(Role::Client);
             ClientError::new(MAX_DELETE_EXIT_CODE, message)
@@ -97,18 +96,14 @@ pub(crate) fn map_local_copy_error(error: LocalCopyError) -> ClientError {
 }
 
 pub(crate) fn compile_filter_error(pattern: &str, error: &dyn fmt::Display) -> ClientError {
-    let text = format!("failed to compile filter pattern '{}': {error}", pattern);
+    let text = format!("failed to compile filter pattern '{pattern}': {error}");
     let message = rsync_error!(FEATURE_UNAVAILABLE_EXIT_CODE, text).with_role(Role::Client);
     ClientError::new(FEATURE_UNAVAILABLE_EXIT_CODE, message)
 }
 
 pub(crate) fn io_error(action: &str, path: &Path, error: io::Error) -> ClientError {
-    let text = format!(
-        "failed to {action} '{path}': {error}",
-        action = action,
-        path = path.display(),
-        error = error
-    );
+    let path_display = path.display();
+    let text = format!("failed to {action} '{path_display}': {error}");
     let message = rsync_error!(PARTIAL_TRANSFER_EXIT_CODE, text).with_role(Role::Client);
     ClientError::new(PARTIAL_TRANSFER_EXIT_CODE, message)
 }

--- a/crates/core/src/client/fallback/runner/command_builder.rs
+++ b/crates/core/src/client/fallback/runner/command_builder.rs
@@ -547,9 +547,9 @@ pub(crate) fn prepare_invocation(
     } else {
         match fallback_override(CLIENT_FALLBACK_ENV) {
             Some(FallbackOverride::Disabled) => {
+                let env = CLIENT_FALLBACK_ENV;
                 return Err(fallback_error(format!(
-                    "remote transfers are unavailable because {env} is disabled; set {env} to point to an upstream rsync binary",
-                    env = CLIENT_FALLBACK_ENV
+                    "remote transfers are unavailable because {env} is disabled; set {env} to point to an upstream rsync binary"
                 )));
             }
             Some(other) => other
@@ -562,9 +562,9 @@ pub(crate) fn prepare_invocation(
     if !fallback_binary_available(binary.as_os_str()) {
         let diagnostic =
             describe_missing_fallback_binary(binary.as_os_str(), &[CLIENT_FALLBACK_ENV]);
+        let display = Path::new(binary.as_os_str()).display();
         return Err(fallback_error(format!(
-            "failed to launch fallback rsync binary '{}': {diagnostic}",
-            Path::new(binary.as_os_str()).display()
+            "failed to launch fallback rsync binary '{display}': {diagnostic}"
         )));
     }
 

--- a/crates/core/src/client/tests/fallback_controls.rs
+++ b/crates/core/src/client/tests/fallback_controls.rs
@@ -254,9 +254,9 @@ fn remote_fallback_reports_disabled_override() {
 
     assert_eq!(error.exit_code(), 1);
     let message = format!("{error}");
+    let env = CLIENT_FALLBACK_ENV;
     assert!(message.contains(&format!(
-        "remote transfers are unavailable because {env} is disabled",
-        env = CLIENT_FALLBACK_ENV,
+        "remote transfers are unavailable because {env} is disabled"
     )));
 }
 
@@ -280,7 +280,7 @@ fn run_client_reports_missing_operands() {
     let rendered = error.message().to_string();
     assert!(rendered.contains("missing source operands"));
     assert!(
-        rendered.contains(&format!("[client={}]", RUST_VERSION)),
+        rendered.contains(&format!("[client={RUST_VERSION}]")),
         "expected missing operands error to include client trailer"
     );
 }

--- a/crates/core/src/client/tests/fallback_invocation.rs
+++ b/crates/core/src/client/tests/fallback_invocation.rs
@@ -431,8 +431,7 @@ fn remote_fallback_forwards_reference_directory_flags() {
             lines
                 .windows(2)
                 .any(|window| window[0] == flag && window[1] == path),
-            "missing pair {flag} {path} in {:?}",
-            lines
+            "missing pair {flag} {path} in {lines:?}"
         );
     }
 }

--- a/crates/core/src/fallback/binary.rs
+++ b/crates/core/src/fallback/binary.rs
@@ -77,20 +77,26 @@ pub fn describe_missing_fallback_binary(binary: &OsStr, env_vars: &[&str]) -> St
     let display = Path::new(binary).display();
     let directive = match env_vars.len() {
         0 => String::from("set an override environment variable to an explicit path"),
-        1 => format!("set {} to an explicit path", env_vars[0]),
-        2 => format!("set {} or {} to an explicit path", env_vars[0], env_vars[1]),
+        1 => {
+            let env = env_vars[0];
+            format!("set {env} to an explicit path")
+        }
+        2 => {
+            let first = env_vars[0];
+            let second = env_vars[1];
+            format!("set {first} or {second} to an explicit path")
+        }
         _ => {
             let (head, tail) = env_vars.split_at(env_vars.len() - 1);
             let mut joined = head.join(", ");
             joined.push_str(", or ");
             joined.push_str(tail[0]);
-            format!("set {} to an explicit path", joined)
+            format!("set {joined} to an explicit path")
         }
     };
 
     format!(
-        "fallback rsync binary '{}' is not available on PATH or is not executable; install upstream rsync or {}",
-        display, directive
+        "fallback rsync binary '{display}' is not available on PATH or is not executable; install upstream rsync or {directive}"
     )
 }
 
@@ -303,9 +309,7 @@ mod tests {
             candidates
                 .iter()
                 .any(|candidate| candidate == &expected_path),
-            "expected candidate {:?} missing from {:?}",
-            expected_path,
-            candidates
+            "expected candidate {expected_path:?} missing from {candidates:?}"
         );
 
         let occurrences = candidates

--- a/crates/core/src/message/tests/part3.rs
+++ b/crates/core/src/message/tests/part3.rs
@@ -381,6 +381,6 @@ fn render_line_to_appends_newline() {
         .render_line_to(&mut rendered)
         .expect("rendering into a string never fails");
 
-    assert_eq!(rendered, format!("{}\n", message));
+    assert_eq!(rendered, format!("{message}\n"));
 }
 

--- a/crates/core/src/message/tests/part4.rs
+++ b/crates/core/src/message/tests/part4.rs
@@ -76,7 +76,7 @@ fn render_line_to_writer_appends_newline() {
         .render_line_to_writer(&mut buffer)
         .expect("writing into a vector never fails");
 
-    assert_eq!(buffer, format!("{}\n", message).into_bytes());
+    assert_eq!(buffer, format!("{message}\n").into_bytes());
 }
 
 #[test]

--- a/crates/core/src/version/report/renderer.rs
+++ b/crates/core/src/version/report/renderer.rs
@@ -209,10 +209,10 @@ impl VersionInfoReport {
             match item {
                 InfoItem::Section(name) => {
                     if !buffer.is_empty() {
-                        writeln!(writer, "   {}", buffer)?;
+                        writeln!(writer, "   {buffer}")?;
                         buffer.clear();
                     }
-                    writeln!(writer, "{}:", name)?;
+                    writeln!(writer, "{name}:")?;
                 }
                 InfoItem::Entry(text) => {
                     let needs_comma = matches!(items.peek(), Some(InfoItem::Entry(_)));
@@ -224,7 +224,7 @@ impl VersionInfoReport {
                     }
 
                     if !buffer.is_empty() && buffer.len() + formatted.len() >= 75 {
-                        writeln!(writer, "   {}", buffer)?;
+                        writeln!(writer, "   {buffer}")?;
                         buffer.clear();
                     }
 
@@ -234,7 +234,7 @@ impl VersionInfoReport {
         }
 
         if !buffer.is_empty() {
-            writeln!(writer, "   {}", buffer)?;
+            writeln!(writer, "   {buffer}")?;
         }
 
         Ok(())
@@ -246,7 +246,7 @@ impl VersionInfoReport {
         name: &str,
         entries: &[Cow<'static, str>],
     ) -> fmt::Result {
-        writeln!(writer, "{}:", name)?;
+        writeln!(writer, "{name}:")?;
 
         if entries.is_empty() {
             writeln!(writer, "    none")
@@ -365,13 +365,13 @@ enum InfoItem {
 
 fn bits_entry<T>(label: &'static str) -> InfoItem {
     let bits = mem::size_of::<T>() * 8;
-    InfoItem::Entry(Cow::Owned(format!("{}-bit {}", bits, label)))
+    InfoItem::Entry(Cow::Owned(format!("{bits}-bit {label}")))
 }
 
 fn capability_entry(label: &'static str, supported: bool) -> InfoItem {
     if supported {
         InfoItem::Entry(Cow::Borrowed(label))
     } else {
-        InfoItem::Entry(Cow::Owned(format!("no {}", label)))
+        InfoItem::Entry(Cow::Owned(format!("no {label}")))
     }
 }

--- a/crates/core/src/version/tests/report.rs
+++ b/crates/core/src/version/tests/report.rs
@@ -24,7 +24,7 @@ fn version_info_report_renders_default_report() {
     };
 
     let build_info = build_info_line();
-    assert!(actual.starts_with(&format!("rsync  version {}", RUST_VERSION)));
+    assert!(actual.starts_with(&format!("rsync  version {RUST_VERSION}")));
     assert!(actual.contains(&format!(
         "    {bit_files}-bit files, {bit_inums}-bit inums, {bit_timestamps}-bit timestamps, {bit_long_ints}-bit long ints,"
     )));
@@ -36,23 +36,23 @@ fn version_info_report_renders_default_report() {
     assert!(!actual.contains("no hardlinks"));
     assert!(actual.contains("IPv6, atimes"));
     assert!(actual.contains("optional secluded-args"));
-    let compiled_line = format!("Compiled features:\n    {}\n", compiled_features_text);
+    let compiled_line = format!("Compiled features:\n    {compiled_features_text}\n");
     assert!(actual.contains(&compiled_line));
-    let build_info_line = format!("Build info:\n    {}\n", build_info);
+    let build_info_line = format!("Build info:\n    {build_info}\n");
     assert!(actual.contains(&build_info_line));
     let checksum_algorithms = default_checksum_algorithms()
         .iter()
         .map(|algo| algo.as_ref())
         .collect::<Vec<_>>()
         .join(" ");
-    assert!(actual.contains(&format!("Checksum list:\n    {}\n", checksum_algorithms)));
+    assert!(actual.contains(&format!("Checksum list:\n    {checksum_algorithms}\n")));
 
     let compress_algorithms = default_compress_algorithms()
         .iter()
         .map(|algo| algo.as_ref())
         .collect::<Vec<_>>()
         .join(" ");
-    assert!(actual.contains(&format!("Compress list:\n    {}\n", compress_algorithms)));
+    assert!(actual.contains(&format!("Compress list:\n    {compress_algorithms}\n")));
 
     let daemon_auth_algorithms = default_daemon_auth_algorithms()
         .iter()
@@ -60,8 +60,7 @@ fn version_info_report_renders_default_report() {
         .collect::<Vec<_>>()
         .join(" ");
     assert!(actual.contains(&format!(
-        "Daemon auth list:\n    {}\n",
-        daemon_auth_algorithms
+        "Daemon auth list:\n    {daemon_auth_algorithms}\n"
     )));
     assert!(actual.ends_with(
         "rsync comes with ABSOLUTELY NO WARRANTY.  This is free software, and you\nare welcome to redistribute it under certain conditions.  See the GNU\nGeneral Public Licence for details.\n"
@@ -82,7 +81,7 @@ fn version_info_report_allows_custom_lists() {
     assert!(rendered.contains("Daemon auth list:\n    gamma\n"));
     assert!(rendered.contains("Compiled features:\n"));
     let build_info = build_info_line();
-    assert!(rendered.contains(&format!("Build info:\n    {}\n", build_info)));
+    assert!(rendered.contains(&format!("Build info:\n    {build_info}\n")));
 }
 
 #[test]
@@ -156,12 +155,12 @@ fn version_info_report_includes_compiled_feature_section() {
     let expected_line = if compiled_features_display.is_empty() {
         "Compiled features:\n    none\n".to_owned()
     } else {
-        format!("Compiled features:\n    {}\n", compiled_features_display)
+        format!("Compiled features:\n    {compiled_features_display}\n")
     };
 
     assert!(rendered.contains(&expected_line));
     let build_info = build_info_line();
-    assert!(rendered.contains(&format!("Build info:\n    {}\n", build_info)));
+    assert!(rendered.contains(&format!("Build info:\n    {build_info}\n")));
 }
 
 #[test]

--- a/crates/daemon/src/daemon/sections/auth_helpers.rs
+++ b/crates/daemon/src/daemon/sections/auth_helpers.rs
@@ -17,8 +17,7 @@ fn log_module_bandwidth_change(
         LimiterChange::Unchanged => return,
         LimiterChange::Disabled => {
             let text = format!(
-                "removed bandwidth limit for module '{}' requested from {} ({})",
-                module_display, display, peer_ip,
+                "removed bandwidth limit for module '{module_display}' requested from {display} ({peer_ip})"
             );
             rsync_info!(text).with_role(Role::Daemon)
         }
@@ -37,8 +36,7 @@ fn log_module_bandwidth_change(
                 LimiterChange::Disabled | LimiterChange::Unchanged => unreachable!(),
             };
             let text = format!(
-                "{action} bandwidth limit {limit}{burst} for module '{}' requested from {} ({})",
-                module_display, display, peer_ip,
+                "{action} bandwidth limit {limit}{burst} for module '{module_display}' requested from {display} ({peer_ip})"
             );
             rsync_info!(text).with_role(Role::Daemon)
         }
@@ -49,14 +47,14 @@ fn log_module_bandwidth_change(
 
 fn log_connection(log: &SharedLogSink, host: Option<&str>, peer_addr: SocketAddr) {
     let display = format_host(host, peer_addr.ip());
-    let text = format!("connect from {} ({})", display, peer_addr.ip());
+    let text = format!("connect from {display} ({})", peer_addr.ip());
     let message = rsync_info!(text).with_role(Role::Daemon);
     log_message(log, &message);
 }
 
 fn log_list_request(log: &SharedLogSink, host: Option<&str>, peer_addr: SocketAddr) {
     let display = format_host(host, peer_addr.ip());
-    let text = format!("list request from {} ({})", display, peer_addr.ip());
+    let text = format!("list request from {display} ({})", peer_addr.ip());
     let message = rsync_info!(text).with_role(Role::Daemon);
     log_message(log, &message);
 }
@@ -65,8 +63,7 @@ fn log_module_request(log: &SharedLogSink, host: Option<&str>, peer_ip: IpAddr, 
     let display = format_host(host, peer_ip);
     let module_display = sanitize_module_identifier(module);
     let text = format!(
-        "module '{}' requested from {} ({})",
-        module_display, display, peer_ip
+        "module '{module_display}' requested from {display} ({peer_ip})"
     );
     let message = rsync_info!(text).with_role(Role::Daemon);
     log_message(log, &message);
@@ -82,8 +79,7 @@ fn log_module_limit(
     let display = format_host(host, peer_ip);
     let module_display = sanitize_module_identifier(module);
     let text = format!(
-        "refusing module '{}' from {} ({}): max connections {}",
-        module_display, display, peer_ip, limit,
+        "refusing module '{module_display}' from {display} ({peer_ip}): max connections {limit}"
     );
     let message = rsync_info!(text).with_role(Role::Daemon);
     log_message(log, &message);
@@ -99,8 +95,7 @@ fn log_module_lock_error(
     let display = format_host(host, peer_ip);
     let module_display = sanitize_module_identifier(module);
     let text = format!(
-        "failed to update lock for module '{}' requested from {} ({}): {}",
-        module_display, display, peer_ip, error
+        "failed to update lock for module '{module_display}' requested from {display} ({peer_ip}): {error}"
     );
     let message = rsync_error!(FEATURE_UNAVAILABLE_EXIT_CODE, text).with_role(Role::Daemon);
     log_message(log, &message);
@@ -116,8 +111,7 @@ fn log_module_refused_option(
     let display = format_host(host, peer_ip);
     let module_display = sanitize_module_identifier(module);
     let text = format!(
-        "refusing option '{}' for module '{}' from {} ({})",
-        refused, module_display, display, peer_ip,
+        "refusing option '{refused}' for module '{module_display}' from {display} ({peer_ip})"
     );
     let message = rsync_info!(text).with_role(Role::Daemon);
     log_message(log, &message);
@@ -127,8 +121,7 @@ fn log_module_auth_failure(log: &SharedLogSink, host: Option<&str>, peer_ip: IpA
     let display = format_host(host, peer_ip);
     let module_display = sanitize_module_identifier(module);
     let text = format!(
-        "authentication failed for module '{}' from {} ({})",
-        module_display, display, peer_ip,
+        "authentication failed for module '{module_display}' from {display} ({peer_ip})"
     );
     let message = rsync_info!(text).with_role(Role::Daemon);
     log_message(log, &message);
@@ -138,8 +131,7 @@ fn log_module_auth_success(log: &SharedLogSink, host: Option<&str>, peer_ip: IpA
     let display = format_host(host, peer_ip);
     let module_display = sanitize_module_identifier(module);
     let text = format!(
-        "authentication succeeded for module '{}' from {} ({})",
-        module_display, display, peer_ip,
+        "authentication succeeded for module '{module_display}' from {display} ({peer_ip})"
     );
     let message = rsync_info!(text).with_role(Role::Daemon);
     log_message(log, &message);
@@ -149,8 +141,7 @@ fn log_module_unavailable(log: &SharedLogSink, host: Option<&str>, peer_ip: IpAd
     let display = format_host(host, peer_ip);
     let module_display = sanitize_module_identifier(module);
     let text = format!(
-        "module '{}' transfers unavailable for {} ({})",
-        module_display, display, peer_ip,
+        "module '{module_display}' transfers unavailable for {display} ({peer_ip})"
     );
     let message = rsync_info!(text).with_role(Role::Daemon);
     log_message(log, &message);
@@ -160,8 +151,7 @@ fn log_module_denied(log: &SharedLogSink, host: Option<&str>, peer_ip: IpAddr, m
     let display = format_host(host, peer_ip);
     let module_display = sanitize_module_identifier(module);
     let text = format!(
-        "access denied to module '{}' from {} ({})",
-        module_display, display, peer_ip,
+        "access denied to module '{module_display}' from {display} ({peer_ip})"
     );
     let message = rsync_info!(text).with_role(Role::Daemon);
     log_message(log, &message);
@@ -171,8 +161,7 @@ fn log_unknown_module(log: &SharedLogSink, host: Option<&str>, peer_ip: IpAddr, 
     let display = format_host(host, peer_ip);
     let module_display = sanitize_module_identifier(module);
     let text = format!(
-        "unknown module '{}' requested from {} ({})",
-        module_display, display, peer_ip,
+        "unknown module '{module_display}' requested from {display} ({peer_ip})"
     );
     let message = rsync_info!(text).with_role(Role::Daemon);
     log_message(log, &message);

--- a/crates/daemon/src/daemon/sections/config_parsing.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing.rs
@@ -279,8 +279,7 @@ fn parse_config_modules_inner(
                             path,
                             line_number,
                             format!(
-                                "duplicate 'refuse options' directive in global section (previously defined on line {})",
-                                existing_line
+                                "duplicate 'refuse options' directive in global section (previously defined on line {existing_line})"
                             ),
                         ));
                     }
@@ -420,7 +419,7 @@ fn parse_config_modules_inner(
                         config_parse_error(
                             path,
                             line_number,
-                            format!("invalid boolean value '{}' for 'reverse lookup'", value),
+                            format!("invalid boolean value '{value}' for 'reverse lookup'"),
                         )
                     })?;
 
@@ -435,8 +434,8 @@ fn parse_config_modules_inner(
                                 path,
                                 line_number,
                                 format!(
-                                    "duplicate 'reverse lookup' directive in global section (previously defined on line {})",
-                                    existing_origin.line
+                                    "duplicate 'reverse lookup' directive in global section (previously defined on line {line})",
+                                    line = existing_origin.line
                                 ),
                             ));
                         }

--- a/crates/daemon/src/daemon/sections/module_access.rs
+++ b/crates/daemon/src/daemon/sections/module_access.rs
@@ -324,7 +324,7 @@ fn respond_with_module_request(
             }
 
             if let Some(refused) = refused_option(module, options) {
-                let payload = format!("@ERROR: The server is configured to refuse {}", refused);
+                let payload = format!("@ERROR: The server is configured to refuse {refused}");
                 let stream = reader.get_mut();
                 write_limited(stream, limiter, payload.as_bytes())?;
                 write_limited(stream, limiter, b"\n")?;
@@ -518,7 +518,7 @@ fn format_bandwidth_rate(value: NonZeroU64) -> String {
     } else if bytes.is_multiple_of(KIB) {
         format!("{} KiB/s", bytes / KIB)
     } else {
-        format!("{} bytes/s", bytes)
+        format!("{bytes} bytes/s")
     }
 }
 

--- a/crates/daemon/src/daemon/sections/module_parsing.rs
+++ b/crates/daemon/src/daemon/sections/module_parsing.rs
@@ -138,8 +138,7 @@ fn parse_module_definition(
 
     if module.use_chroot && !module.path.is_absolute() {
         return Err(config_error(format!(
-            "module path '{}' must be absolute when 'use chroot' is enabled",
-            path_text
+            "module path '{path_text}' must be absolute when 'use chroot' is enabled"
         )));
     }
 
@@ -403,12 +402,11 @@ fn parse_config_bwlimit(
 
 fn runtime_bwlimit_error(value: &str, error: BandwidthParseError) -> DaemonError {
     let text = match error {
-        BandwidthParseError::Invalid => format!("--bwlimit={} is invalid", value),
+        BandwidthParseError::Invalid => format!("--bwlimit={value} is invalid"),
         BandwidthParseError::TooSmall => format!(
-            "--bwlimit={} is too small (min: 512 or 0 for unlimited)",
-            value
+            "--bwlimit={value} is too small (min: 512 or 0 for unlimited)"
         ),
-        BandwidthParseError::TooLarge => format!("--bwlimit={} is too large", value),
+        BandwidthParseError::TooLarge => format!("--bwlimit={value} is too large"),
     };
     config_error(text)
 }
@@ -430,7 +428,8 @@ fn config_bwlimit_error(
 }
 
 fn unsupported_option(option: OsString) -> DaemonError {
-    let text = format!("unsupported daemon argument '{}'", option.to_string_lossy());
+    let option = option.to_string_lossy();
+    let text = format!("unsupported daemon argument '{option}'");
     config_error(text)
 }
 

--- a/crates/daemon/src/daemon/sections/server_runtime.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime.rs
@@ -1,6 +1,6 @@
 fn log_sd_notify_failure(log: Option<&SharedLogSink>, context: &str, error: &io::Error) {
     if let Some(sink) = log {
-        let payload = format!("failed to notify systemd about {}: {}", context, error);
+        let payload = format!("failed to notify systemd about {context}: {error}");
         let message = rsync_warning!(payload).with_role(Role::Daemon);
         log_message(sink, &message);
     }
@@ -92,15 +92,14 @@ fn serve_connections(options: RuntimeOptions) -> Result<(), DaemonError> {
     let local_addr = listener.local_addr().unwrap_or(requested_addr);
 
     let notifier = systemd::ServiceNotifier::new();
-    let ready_status = format!("Listening on {}", local_addr);
+    let ready_status = format!("Listening on {local_addr}");
     if let Err(error) = notifier.ready(Some(&ready_status)) {
         log_sd_notify_failure(log_sink.as_ref(), "service readiness", &error);
     }
 
     if let Some(log) = log_sink.as_ref() {
         let text = format!(
-            "rsyncd version {} starting, listening on port {}",
-            version,
+            "rsyncd version {version} starting, listening on port {}",
             local_addr.port()
         );
         let message = rsync_info!(text).with_role(Role::Daemon);
@@ -197,7 +196,7 @@ fn serve_connections(options: RuntimeOptions) -> Result<(), DaemonError> {
     }
 
     if let Some(log) = log_sink.as_ref() {
-        let text = format!("rsyncd version {} shutting down", version);
+        let text = format!("rsyncd version {version} shutting down");
         let message = rsync_info!(text).with_role(Role::Daemon);
         log_message(log, &message);
     }

--- a/crates/engine/src/local_copy/dir_merge/parse/dir_merge.rs
+++ b/crates/engine/src/local_copy/dir_merge/parse/dir_merge.rs
@@ -42,8 +42,7 @@ pub(super) fn parse_dir_merge_directive(
             '-' => {
                 if saw_plus {
                     let message = format!(
-                        "dir-merge directive '{}' cannot combine '+' and '-' modifiers",
-                        text
+                        "dir-merge directive '{text}' cannot combine '+' and '-' modifiers"
                     );
                     return Err(FilterParseError::new(message));
                 }
@@ -53,8 +52,7 @@ pub(super) fn parse_dir_merge_directive(
             '+' => {
                 if saw_minus {
                     let message = format!(
-                        "dir-merge directive '{}' cannot combine '+' and '-' modifiers",
-                        text
+                        "dir-merge directive '{text}' cannot combine '+' and '-' modifiers"
                     );
                     return Err(FilterParseError::new(message));
                 }
@@ -90,8 +88,7 @@ pub(super) fn parse_dir_merge_directive(
             }
             _ => {
                 let message = format!(
-                    "dir-merge directive '{}' uses unsupported modifier '{}'",
-                    text, modifier
+                    "dir-merge directive '{text}' uses unsupported modifier '{modifier}'"
                 );
                 return Err(FilterParseError::new(message));
             }
@@ -102,7 +99,7 @@ pub(super) fn parse_dir_merge_directive(
         if used_cvs_default {
             ".cvsignore"
         } else {
-            let message = format!("dir-merge directive '{}' is missing a file name", text);
+            let message = format!("dir-merge directive '{text}' is missing a file name");
             return Err(FilterParseError::new(message));
         }
     } else {

--- a/crates/engine/src/local_copy/dir_merge/parse/line.rs
+++ b/crates/engine/src/local_copy/dir_merge/parse/line.rs
@@ -155,7 +155,6 @@ pub(crate) fn parse_filter_directive_line(
     }
 
     Err(FilterParseError::new(format!(
-        "unsupported filter directive '{}'",
-        trimmed
+        "unsupported filter directive '{trimmed}'"
     )))
 }

--- a/crates/engine/src/local_copy/dir_merge/parse/merge.rs
+++ b/crates/engine/src/local_copy/dir_merge/parse/merge.rs
@@ -87,13 +87,11 @@ pub(super) fn parse_short_merge_directive_line(
             ".cvsignore"
         } else if allow_extended {
             return Err(FilterParseError::new(format!(
-                "dir-merge directive '{}' is missing a file name",
-                text
+                "dir-merge directive '{text}' is missing a file name"
             )));
         } else {
             return Err(FilterParseError::new(format!(
-                "merge directive '{}' is missing a file path",
-                text
+                "merge directive '{text}' is missing a file path"
             )));
         }
     } else {

--- a/crates/engine/src/local_copy/dir_merge/parse/modifiers.rs
+++ b/crates/engine/src/local_copy/dir_merge/parse/modifiers.rs
@@ -61,8 +61,7 @@ pub(super) fn parse_merge_modifiers(
             '-' => {
                 if saw_include {
                     let message = format!(
-                        "{label} directive '{}' cannot combine '+' and '-' modifiers",
-                        directive
+                        "{label} directive '{directive}' cannot combine '+' and '-' modifiers"
                     );
 
                     return Err(FilterParseError::new(message));
@@ -73,8 +72,7 @@ pub(super) fn parse_merge_modifiers(
             '+' => {
                 if saw_exclude {
                     let message = format!(
-                        "{label} directive '{}' cannot combine '+' and '-' modifiers",
-                        directive
+                        "{label} directive '{directive}' cannot combine '+' and '-' modifiers"
                     );
                     return Err(FilterParseError::new(message));
                 }
@@ -84,8 +82,7 @@ pub(super) fn parse_merge_modifiers(
             'c' => {
                 if saw_include {
                     let message = format!(
-                        "{label} directive '{}' cannot combine 'C' with '+' or '-'",
-                        directive
+                        "{label} directive '{directive}' cannot combine 'C' with '+' or '-'"
                     );
                     return Err(FilterParseError::new(message));
                 }
@@ -103,8 +100,7 @@ pub(super) fn parse_merge_modifiers(
                     options = options.exclude_filter_file(true);
                 } else {
                     let message = format!(
-                        "merge directive '{}' uses unsupported modifier '{}'",
-                        directive, modifier
+                        "merge directive '{directive}' uses unsupported modifier '{modifier}'"
                     );
                     return Err(FilterParseError::new(message));
                 }
@@ -114,8 +110,7 @@ pub(super) fn parse_merge_modifiers(
                     options = options.inherit(false);
                 } else {
                     let message = format!(
-                        "merge directive '{}' uses unsupported modifier '{}'",
-                        directive, modifier
+                        "merge directive '{directive}' uses unsupported modifier '{modifier}'"
                     );
                     return Err(FilterParseError::new(message));
                 }
@@ -125,8 +120,7 @@ pub(super) fn parse_merge_modifiers(
                     options = options.use_whitespace().allow_comments(false);
                 } else {
                     let message = format!(
-                        "merge directive '{}' uses unsupported modifier '{}'",
-                        directive, modifier
+                        "merge directive '{directive}' uses unsupported modifier '{modifier}'"
                     );
                     return Err(FilterParseError::new(message));
                 }
@@ -136,8 +130,7 @@ pub(super) fn parse_merge_modifiers(
                     options = options.sender_modifier();
                 } else {
                     let message = format!(
-                        "merge directive '{}' uses unsupported modifier '{}'",
-                        directive, modifier
+                        "merge directive '{directive}' uses unsupported modifier '{modifier}'"
                     );
                     return Err(FilterParseError::new(message));
                 }
@@ -147,8 +140,7 @@ pub(super) fn parse_merge_modifiers(
                     options = options.receiver_modifier();
                 } else {
                     let message = format!(
-                        "merge directive '{}' uses unsupported modifier '{}'",
-                        directive, modifier
+                        "merge directive '{directive}' uses unsupported modifier '{modifier}'"
                     );
                     return Err(FilterParseError::new(message));
                 }
@@ -158,16 +150,14 @@ pub(super) fn parse_merge_modifiers(
                     options = options.anchor_root(true);
                 } else {
                     let message = format!(
-                        "merge directive '{}' uses unsupported modifier '{}'",
-                        directive, modifier
+                        "merge directive '{directive}' uses unsupported modifier '{modifier}'"
                     );
                     return Err(FilterParseError::new(message));
                 }
             }
             _ => {
                 let message = format!(
-                    "{label} directive '{}' uses unsupported modifier '{}'",
-                    directive, modifier
+                    "{label} directive '{directive}' uses unsupported modifier '{modifier}'"
                 );
                 return Err(FilterParseError::new(message));
             }

--- a/crates/engine/src/local_copy/error.rs
+++ b/crates/engine/src/local_copy/error.rs
@@ -93,7 +93,8 @@ impl fmt::Display for LocalCopyError {
                 path,
                 source,
             } => {
-                write!(f, "failed to {action} '{}': {source}", path.display())
+                let display = path.display();
+                write!(f, "failed to {action} '{display}': {source}")
             }
             LocalCopyErrorKind::Timeout { duration } => {
                 write!(
@@ -106,8 +107,7 @@ impl fmt::Display for LocalCopyError {
                 let noun = if *skipped == 1 { "entry" } else { "entries" };
                 write!(
                     f,
-                    "Deletions stopped due to --max-delete limit ({} {noun} skipped)",
-                    skipped
+                    "Deletions stopped due to --max-delete limit ({skipped} {noun} skipped)"
                 )
             }
         }

--- a/crates/engine/src/local_copy/executor/file/paths.rs
+++ b/crates/engine/src/local_copy/executor/file/paths.rs
@@ -10,7 +10,7 @@ pub(crate) fn partial_destination_path(destination: &Path) -> PathBuf {
         .file_name()
         .map(|name| name.to_string_lossy().to_string())
         .unwrap_or_else(|| "partial".to_string());
-    let partial_name = format!(".rsync-partial-{}", file_name);
+    let partial_name = format!(".rsync-partial-{file_name}");
     destination.with_file_name(partial_name)
 }
 

--- a/crates/engine/src/local_copy/filter_program/segments.rs
+++ b/crates/engine/src/local_copy/filter_program/segments.rs
@@ -166,7 +166,7 @@ impl CompiledRule {
         let mut direct_patterns = HashSet::new();
         direct_patterns.insert(core_pattern.clone());
         if !anchored {
-            direct_patterns.insert(format!("**/{}", core_pattern));
+            direct_patterns.insert(format!("**/{core_pattern}"));
         }
 
         let mut descendant_patterns = HashSet::new();
@@ -176,9 +176,9 @@ impl CompiledRule {
                 FilterAction::Exclude | FilterAction::Protect | FilterAction::Risk
             )
         {
-            descendant_patterns.insert(format!("{}/**", core_pattern));
+            descendant_patterns.insert(format!("{core_pattern}/**"));
             if !anchored {
-                descendant_patterns.insert(format!("**/{}/**", core_pattern));
+                descendant_patterns.insert(format!("**/{core_pattern}/**"));
             }
         }
 

--- a/crates/engine/src/local_copy/tests/bandwidth.rs
+++ b/crates/engine/src/local_copy/tests/bandwidth.rs
@@ -34,17 +34,13 @@ fn execute_with_bandwidth_limit_records_sleep() {
     let diff = total.abs_diff(expected);
     assert!(
         diff <= Duration::from_millis(50),
-        "expected sleep duration near {:?}, got {:?}",
-        expected,
-        total
+        "expected sleep duration near {expected:?}, got {total:?}"
     );
     let summary_sleep = summary.bandwidth_sleep();
     let summary_diff = summary_sleep.abs_diff(total);
     assert!(
         summary_diff <= Duration::from_millis(50),
-        "summary recorded {:?} of throttling while sleeps totalled {:?}",
-        summary_sleep,
-        total
+        "summary recorded {summary_sleep:?} of throttling while sleeps totalled {total:?}"
     );
     assert_eq!(summary.files_copied(), 1);
 }
@@ -250,22 +246,15 @@ fn execute_with_compression_limits_post_compress_bandwidth() {
     let tolerance = expected_compressed * 0.2 + 0.2;
     assert!(
         (total_sleep_secs - expected_compressed).abs() <= tolerance,
-        "sleep {:?}s deviates too far from compressed expectation {:?}s",
-        total_sleep_secs,
-        expected_compressed,
+        "sleep {total_sleep_secs:?}s deviates too far from compressed expectation {expected_compressed:?}s"
     );
     assert!(
         (summary_secs - total_sleep_secs).abs() <= tolerance,
-        "summary tracked {:?}s while recordings totalled {:?}s",
-        summary_secs,
-        total_sleep_secs,
+        "summary tracked {summary_secs:?}s while recordings totalled {total_sleep_secs:?}s"
     );
     assert!(
         (total_sleep_secs - expected_compressed).abs()
             < (total_sleep_secs - expected_uncompressed).abs(),
-        "sleep {:?}s should align with compressed bytes ({:?}s) rather than uncompressed ({:?}s)",
-        total_sleep_secs,
-        expected_compressed,
-        expected_uncompressed,
+        "sleep {total_sleep_secs:?}s should align with compressed bytes ({expected_compressed:?}s) rather than uncompressed ({expected_uncompressed:?}s)"
     );
 }

--- a/crates/engine/src/local_copy/tests/execute_directories.rs
+++ b/crates/engine/src/local_copy/tests/execute_directories.rs
@@ -409,7 +409,7 @@ fn execute_with_dry_run_detects_directory_conflict() {
         LocalCopyErrorKind::InvalidArgument(reason) => {
             assert_eq!(reason, LocalCopyArgumentError::ReplaceDirectoryWithFile);
         }
-        other => panic!("unexpected error kind: {:?}", other),
+        other => panic!("unexpected error kind: {other:?}"),
     }
 }
 

--- a/crates/engine/src/local_copy/tests/execute_hardlinks.rs
+++ b/crates/engine/src/local_copy/tests/execute_hardlinks.rs
@@ -45,8 +45,7 @@ fn execute_with_delay_updates_preserves_hard_links() {
         let name = name.to_string_lossy();
         assert!(
             !name.starts_with(".rsync-tmp-") && !name.starts_with(".rsync-partial-"),
-            "unexpected temporary file left behind: {}",
-            name
+            "unexpected temporary file left behind: {name}"
         );
     }
 }

--- a/crates/engine/src/local_copy/tests/filters.rs
+++ b/crates/engine/src/local_copy/tests/filters.rs
@@ -3,7 +3,7 @@
 fn parse_filter_directive_show_is_sender_only() {
     let rule = match parse_filter_directive_line("show images/**").expect("parse") {
         Some(ParsedFilterDirective::Rule(rule)) => rule,
-        other => panic!("expected rule, got {:?}", other),
+        other => panic!("expected rule, got {other:?}"),
     };
 
     assert!(rule.applies_to_sender());
@@ -14,7 +14,7 @@ fn parse_filter_directive_show_is_sender_only() {
 fn parse_filter_directive_hide_is_sender_only() {
     let rule = match parse_filter_directive_line("hide *.tmp").expect("parse") {
         Some(ParsedFilterDirective::Rule(rule)) => rule,
-        other => panic!("expected rule, got {:?}", other),
+        other => panic!("expected rule, got {other:?}"),
     };
 
     assert!(rule.applies_to_sender());
@@ -25,7 +25,7 @@ fn parse_filter_directive_hide_is_sender_only() {
 fn parse_filter_directive_shorthand_show_is_sender_only() {
     let rule = match parse_filter_directive_line("S logs/**").expect("parse") {
         Some(ParsedFilterDirective::Rule(rule)) => rule,
-        other => panic!("expected rule, got {:?}", other),
+        other => panic!("expected rule, got {other:?}"),
     };
 
     assert!(rule.applies_to_sender());
@@ -36,7 +36,7 @@ fn parse_filter_directive_shorthand_show_is_sender_only() {
 fn parse_filter_directive_shorthand_hide_is_sender_only() {
     let rule = match parse_filter_directive_line("H *.bak").expect("parse") {
         Some(ParsedFilterDirective::Rule(rule)) => rule,
-        other => panic!("expected rule, got {:?}", other),
+        other => panic!("expected rule, got {other:?}"),
     };
 
     assert!(rule.applies_to_sender());
@@ -47,7 +47,7 @@ fn parse_filter_directive_shorthand_hide_is_sender_only() {
 fn parse_filter_directive_shorthand_protect_requires_receiver() {
     let rule = match parse_filter_directive_line("P cache/**").expect("parse") {
         Some(ParsedFilterDirective::Rule(rule)) => rule,
-        other => panic!("expected rule, got {:?}", other),
+        other => panic!("expected rule, got {other:?}"),
     };
 
     assert!(!rule.applies_to_sender());
@@ -58,7 +58,7 @@ fn parse_filter_directive_shorthand_protect_requires_receiver() {
 fn parse_filter_directive_risk_requires_receiver() {
     let rule = match parse_filter_directive_line("risk cache/**").expect("parse") {
         Some(ParsedFilterDirective::Rule(rule)) => rule,
-        other => panic!("expected rule, got {:?}", other),
+        other => panic!("expected rule, got {other:?}"),
     };
 
     assert!(!rule.applies_to_sender());
@@ -69,7 +69,7 @@ fn parse_filter_directive_risk_requires_receiver() {
 fn parse_filter_directive_shorthand_risk_requires_receiver() {
     let rule = match parse_filter_directive_line("R cache/**").expect("parse") {
         Some(ParsedFilterDirective::Rule(rule)) => rule,
-        other => panic!("expected rule, got {:?}", other),
+        other => panic!("expected rule, got {other:?}"),
     };
 
     assert!(!rule.applies_to_sender());
@@ -98,7 +98,7 @@ fn parse_filter_directive_exclude_if_present_support() {
         ParsedFilterDirective::ExcludeIfPresent(rule) => {
             assert_eq!(rule.marker_path(Path::new(".")), PathBuf::from("./.git"));
         }
-        other => panic!("expected exclude-if-present directive, got {:?}", other),
+        other => panic!("expected exclude-if-present directive, got {other:?}"),
     }
 }
 
@@ -110,7 +110,7 @@ fn parse_filter_directive_dir_merge_without_modifiers() {
 
     let (path, options) = match directive {
         ParsedFilterDirective::Merge { path, options } => (path, options),
-        other => panic!("expected dir-merge directive, got {:?}", other),
+        other => panic!("expected dir-merge directive, got {other:?}"),
     };
 
     assert_eq!(path, PathBuf::from(".rsync-filter"));
@@ -129,7 +129,7 @@ fn parse_filter_directive_dir_merge_with_modifiers() {
 
     let (path, options) = match directive {
         ParsedFilterDirective::Merge { path, options } => (path, options),
-        other => panic!("expected dir-merge directive, got {:?}", other),
+        other => panic!("expected dir-merge directive, got {other:?}"),
     };
 
     assert_eq!(path, PathBuf::from("rules/filter.txt"));
@@ -147,7 +147,7 @@ fn parse_filter_directive_dir_merge_cvs_default_path() {
 
     let (path, options) = match directive {
         ParsedFilterDirective::Merge { path, options } => (path, options),
-        other => panic!("expected dir-merge directive, got {:?}", other),
+        other => panic!("expected dir-merge directive, got {other:?}"),
     };
 
     assert_eq!(path, PathBuf::from(".cvsignore"));
@@ -166,7 +166,7 @@ fn parse_filter_directive_short_merge_inherits_context() {
 
     let (path, options) = match directive {
         ParsedFilterDirective::Merge { path, options } => (path, options),
-        other => panic!("expected merge directive, got {:?}", other),
+        other => panic!("expected merge directive, got {other:?}"),
     };
 
     assert_eq!(path, PathBuf::from("per-dir"));
@@ -181,7 +181,7 @@ fn parse_filter_directive_short_merge_cvs_defaults() {
 
     let (path, options) = match directive {
         ParsedFilterDirective::Merge { path, options } => (path, options),
-        other => panic!("expected merge directive, got {:?}", other),
+        other => panic!("expected merge directive, got {other:?}"),
     };
 
     assert_eq!(path, PathBuf::from(".cvsignore"));
@@ -199,7 +199,7 @@ fn parse_filter_directive_short_dir_merge_with_modifiers() {
 
     let (path, options) = match directive {
         ParsedFilterDirective::Merge { path, options } => (path, options),
-        other => panic!("expected dir-merge directive, got {:?}", other),
+        other => panic!("expected dir-merge directive, got {other:?}"),
     };
 
     assert_eq!(path, PathBuf::from("per-dir"));
@@ -215,7 +215,7 @@ fn parse_filter_directive_merge_with_modifiers() {
 
     let (path, options) = match directive {
         ParsedFilterDirective::Merge { path, options } => (path, options),
-        other => panic!("expected merge directive, got {:?}", other),
+        other => panic!("expected merge directive, got {other:?}"),
     };
 
     assert_eq!(path, PathBuf::from("rules"));

--- a/crates/engine/src/signature.rs
+++ b/crates/engine/src/signature.rs
@@ -291,8 +291,7 @@ impl fmt::Display for SignatureError {
                 requested,
             } => write!(
                 f,
-                "requested strong checksum length {} exceeds {:?} digest width",
-                requested, algorithm
+                "requested strong checksum length {requested} exceeds {algorithm:?} digest width"
             ),
             SignatureError::TrailingData { bytes } => write!(
                 f,

--- a/crates/logging/src/sink/tests.rs
+++ b/crates/logging/src/sink/tests.rs
@@ -6,7 +6,7 @@ use std::io::{self, Cursor, Write};
 #[test]
 fn debug_representation_mentions_writer_and_line_mode() {
     let sink = MessageSink::with_line_mode(Vec::<u8>::new(), LineMode::WithoutNewline);
-    let rendered = format!("{:?}", sink);
+    let rendered = format!("{sink:?}");
     assert!(rendered.starts_with("MessageSink"));
     assert!(
         rendered.contains("writer: []"),

--- a/crates/protocol/src/envelope/tests/codes.rs
+++ b/crates/protocol/src/envelope/tests/codes.rs
@@ -75,8 +75,7 @@ fn message_code_all_is_sorted_by_numeric_value() {
         let second = window[1];
         assert!(
             first.as_u8() <= second.as_u8(),
-            "MessageCode::all() is not sorted: {:?}",
-            all
+            "MessageCode::all() is not sorted: {all:?}"
         );
     }
 }

--- a/crates/protocol/src/negotiation/tests/detector.rs
+++ b/crates/protocol/src/negotiation/tests/detector.rs
@@ -336,15 +336,13 @@ fn assert_detector_matches_across_partitions(data: &[u8]) {
             {
                 assert!(
                     detector.is_legacy(),
-                    "detector should cache legacy decision for {:?}",
-                    data
+                    "detector should cache legacy decision for {data:?}"
                 );
                 assert!(detector.requires_more_data());
             } else {
                 assert_eq!(
                     result, expected,
-                    "segmented detection mismatch for {:?} with splits ({}, {})",
-                    data, first_end, second_end
+                    "segmented detection mismatch for {data:?} with splits ({first_end}, {second_end})"
                 );
             }
 
@@ -393,26 +391,22 @@ fn prologue_detector_observe_byte_matches_slice_behavior() {
 
         assert_eq!(
             byte_result, slice_result,
-            "decision mismatch for {:?}",
-            data
+            "decision mismatch for {data:?}"
         );
         assert_eq!(
             byte_detector.decision(),
             slice_detector.decision(),
-            "cached decision mismatch for {:?}",
-            data
+            "cached decision mismatch for {data:?}"
         );
         assert_eq!(
             byte_detector.legacy_prefix_complete(),
             slice_detector.legacy_prefix_complete(),
-            "prefix completion mismatch for {:?}",
-            data
+            "prefix completion mismatch for {data:?}"
         );
         assert_eq!(
             byte_detector.buffered_prefix(),
             slice_detector.buffered_prefix(),
-            "buffered prefix mismatch for {:?}",
-            data
+            "buffered prefix mismatch for {data:?}"
         );
     }
 

--- a/crates/protocol/src/varint.rs
+++ b/crates/protocol/src/varint.rs
@@ -212,7 +212,7 @@ mod tests {
         for (value, expected_hex) in cases {
             let mut encoded = Vec::new();
             encode_varint_to_vec(value, &mut encoded);
-            let actual: String = encoded.iter().map(|byte| format!("{:02x}", byte)).collect();
+            let actual: String = encoded.iter().map(|byte| format!("{byte:02x}")).collect();
             assert_eq!(actual, expected_hex);
         }
     }

--- a/crates/protocol/src/version/tests/protocol/style.rs
+++ b/crates/protocol/src/version/tests/protocol/style.rs
@@ -42,24 +42,20 @@ fn negotiation_style_helpers_match_protocol_cutoff() {
         if version.as_u8() >= ProtocolVersion::BINARY_NEGOTIATION_INTRODUCED.as_u8() {
             assert!(
                 version.uses_binary_negotiation(),
-                "version {} should be binary",
-                version
+                "version {version} should be binary"
             );
             assert!(
                 !version.uses_legacy_ascii_negotiation(),
-                "version {} should not be legacy",
-                version
+                "version {version} should not be legacy"
             );
         } else {
             assert!(
                 !version.uses_binary_negotiation(),
-                "version {} should not be binary",
-                version
+                "version {version} should not be binary"
             );
             assert!(
                 version.uses_legacy_ascii_negotiation(),
-                "version {} should be legacy",
-                version
+                "version {version} should be legacy"
             );
         }
     }

--- a/xtask/src/commands/branding/mod.rs
+++ b/xtask/src/commands/branding/mod.rs
@@ -96,7 +96,7 @@ windows = ["x86_64", "aarch64"]
                         .contains("failed to read workspace manifest")
                 );
             }
-            other => panic!("unexpected error: {:?}", other),
+            other => panic!("unexpected error: {other:?}"),
         }
     }
 }

--- a/xtask/src/commands/no_binaries.rs
+++ b/xtask/src/commands/no_binaries.rs
@@ -70,7 +70,7 @@ mod tests {
             .args(["init", "--quiet"])
             .status()
             .expect("git init runs");
-        assert!(status.success(), "git init failed: {:?}", status);
+        assert!(status.success(), "git init failed: {status:?}");
     }
 
     fn git_add(path: &std::path::Path, file: &std::path::Path) {
@@ -83,9 +83,7 @@ mod tests {
             .expect("git add runs");
         assert!(
             status.success(),
-            "git add failed for {:?}: {:?}",
-            relative,
-            status
+            "git add failed for {relative:?}: {status:?}"
         );
     }
 
@@ -139,7 +137,7 @@ mod tests {
             TaskError::BinaryFiles(paths) => {
                 assert_eq!(paths, vec![std::path::PathBuf::from("artifacts/blob.bin")]);
             }
-            other => panic!("unexpected error: {:?}", other),
+            other => panic!("unexpected error: {other:?}"),
         }
     }
 }

--- a/xtask/src/commands/no_placeholders.rs
+++ b/xtask/src/commands/no_placeholders.rs
@@ -450,8 +450,7 @@ mod tests {
         let path = unique_temp_path("panic_multiline");
         let todo = ["TO", "DO"].concat();
         let content = format!(
-            "fn explode() {{\n    panic!(\n        \"{}: revisit\"\n    );\n}}\n",
-            todo
+            "fn explode() {{\n    panic!(\n        \"{todo}: revisit\"\n    );\n}}\n"
         );
         fs::write(&path, content).expect("write sample");
         let findings = scan_rust_file_for_placeholders(&path).expect("scan succeeds");

--- a/xtask/src/commands/package/build.rs
+++ b/xtask/src/commands/package/build.rs
@@ -185,7 +185,7 @@ pub(super) fn build_workspace_binaries(
 fn linker_env_var_name(target: &str) -> OsString {
     let mut normalized = target.replace('-', "_");
     normalized.make_ascii_uppercase();
-    OsString::from(format!("CARGO_TARGET_{}_LINKER", normalized))
+    OsString::from(format!("CARGO_TARGET_{normalized}_LINKER"))
 }
 
 #[derive(Clone, Debug)]

--- a/xtask/src/commands/package/tarball.rs
+++ b/xtask/src/commands/package/tarball.rs
@@ -341,7 +341,7 @@ pub(super) fn build_tarball(
             continue;
         }
 
-        let file_name = format!("{}{}", name, extension);
+        let file_name = format!("{name}{extension}");
         let path = target_dir.join(&file_name);
         ensure_tarball_source(&path)?;
         let destination = format!("{root_name}/{relative}");

--- a/xtask/src/commands/preflight/validation.rs
+++ b/xtask/src/commands/preflight/validation.rs
@@ -205,8 +205,7 @@ pub(crate) fn validate_workspace_package_rust_version(manifest: &Value) -> TaskR
     ensure(
         rust_version == "1.88",
         format!(
-            "workspace.package.rust-version must match CI toolchain 1.88; found {:?}",
-            rust_version
+            "workspace.package.rust-version must match CI toolchain 1.88; found {rust_version:?}"
         ),
     )
 }
@@ -294,16 +293,17 @@ pub(crate) fn validate_documentation(
             .filter(|snippet| !snippet.is_empty() && !contents.contains(snippet))
             .collect();
 
+        let relative_path = check.relative_path;
+        let missing_snippets = missing
+            .iter()
+            .map(|snippet| format!("'{snippet}'"))
+            .collect::<Vec<_>>()
+            .join(", ");
+
         ensure(
             missing.is_empty(),
             format!(
-                "{} missing required documentation snippets: {}",
-                check.relative_path,
-                missing
-                    .iter()
-                    .map(|snippet| format!("'{}'", snippet))
-                    .collect::<Vec<_>>()
-                    .join(", ")
+                "{relative_path} missing required documentation snippets: {missing_snippets}"
             ),
         )?;
     }

--- a/xtask/src/commands/release/upload.rs
+++ b/xtask/src/commands/release/upload.rs
@@ -314,7 +314,7 @@ fn run_upload_command(
     let status = command.status().map_err(|error| {
         TaskError::Io(io::Error::new(
             error.kind(),
-            format!("failed to invoke {}: {error}", display),
+            format!("failed to invoke {display}: {error}"),
         ))
     })?;
 
@@ -322,7 +322,7 @@ fn run_upload_command(
         Ok(())
     } else {
         Err(TaskError::CommandFailed {
-            program: format!("{} release upload", display),
+            program: format!("{display} release upload"),
             status,
         })
     }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -68,11 +68,11 @@ fn main() -> ExitCode {
     match run_with_args(env::args_os().skip(1)) {
         Ok(()) => ExitCode::SUCCESS,
         Err(TaskError::Help(text)) => {
-            println!("{}", text);
+            println!("{text}");
             ExitCode::SUCCESS
         }
         Err(error) => {
-            eprintln!("{}", error);
+            eprintln!("{error}");
             if let TaskError::Usage(_) = error {
                 eprintln!("{}", top_level_usage());
             }

--- a/xtask/src/util.rs
+++ b/xtask/src/util.rs
@@ -203,7 +203,7 @@ pub fn probe_cargo_tool(
         Err(tool_missing_error(display, install_hint))
     } else {
         Err(TaskError::CommandFailed {
-            program: format!("{} (probe)", display),
+            program: format!("{display} (probe)"),
             status: output.status,
         })
     }

--- a/xtask/src/workspace.rs
+++ b/xtask/src/workspace.rs
@@ -241,8 +241,7 @@ source = "https://github.com/oferchen/rsync"
 
 [workspace.metadata.oc_rsync.cross_compile]
 {entries}
-"#,
-            entries = entries
+"#
         )
     }
 

--- a/xtask/tests/main_cli.rs
+++ b/xtask/tests/main_cli.rs
@@ -5,7 +5,7 @@ fn run_xtask(args: &[&str]) -> std::process::Output {
     Command::new(env!("CARGO_BIN_EXE_xtask"))
         .args(args)
         .output()
-        .unwrap_or_else(|error| panic!("failed to run xtask: {}", error))
+        .unwrap_or_else(|error| panic!("failed to run xtask: {error}"))
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- update formatting calls across the workspace to use inline format arguments and new-style panic messages
- align error reporting helpers in core, daemon, cli, and engine modules with the modern formatting syntax
- refresh related tests to expect the updated strings and continue covering behaviour

## Testing
- cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings

------