### PR TITLE
Fix packaging asset paths and legacy binaries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ name = "oc-rsyncd"
 path = "src/bin/oc-rsyncd.rs"
 
 [features]
-default = []
+default = ["legacy-binaries"]
 legacy-binaries = []
 sd-notify = ["rsync-daemon/sd-notify"]
 
@@ -112,10 +112,10 @@ conflicts = []
 replaces = []
 
 assets = [
-    ["target/@TARGET@/@PROFILE@/oc-rsync", "usr/bin/oc-rsync", "755"],
-    ["target/@TARGET@/@PROFILE@/oc-rsyncd", "usr/bin/oc-rsyncd", "755"],
-    ["target/@TARGET@/@PROFILE@/rsync", "usr/libexec/oc-rsync/rsync", "755"],
-    ["target/@TARGET@/@PROFILE@/rsyncd", "usr/libexec/oc-rsync/rsyncd", "755"],
+    ["target/release/oc-rsync", "usr/bin/oc-rsync", "755"],
+    ["target/release/oc-rsyncd", "usr/bin/oc-rsyncd", "755"],
+    ["target/release/rsync", "usr/libexec/oc-rsync/rsync", "755"],
+    ["target/release/rsyncd", "usr/libexec/oc-rsync/rsyncd", "755"],
     ["LICENSE", "usr/share/doc/oc-rsync/LICENSE", "644"],
     ["packaging/systemd/oc-rsyncd.service", "/lib/systemd/system/oc-rsyncd.service", "644"],
     ["packaging/etc/oc-rsyncd/oc-rsyncd.conf", "/etc/oc-rsyncd/oc-rsyncd.conf", "644"],
@@ -133,10 +133,10 @@ maintainer-scripts = "packaging/deb"
 package = "oc-rsync"
 summary = "Rust implementation of rsync-compatible client and daemon (includes oc-rsync compatibility wrappers)"
 assets = [
-    { source = "target/@TARGET@/@PROFILE@/oc-rsync", dest = "/usr/bin/oc-rsync", mode = "0755" },
-    { source = "target/@TARGET@/@PROFILE@/oc-rsyncd", dest = "/usr/bin/oc-rsyncd", mode = "0755" },
-    { source = "target/@TARGET@/@PROFILE@/rsync", dest = "/usr/libexec/oc-rsync/rsync", mode = "0755" },
-    { source = "target/@TARGET@/@PROFILE@/rsyncd", dest = "/usr/libexec/oc-rsync/rsyncd", mode = "0755" },
+    { source = "target/release/oc-rsync", dest = "/usr/bin/oc-rsync", mode = "0755" },
+    { source = "target/release/oc-rsyncd", dest = "/usr/bin/oc-rsyncd", mode = "0755" },
+    { source = "target/release/rsync", dest = "/usr/libexec/oc-rsync/rsync", mode = "0755" },
+    { source = "target/release/rsyncd", dest = "/usr/libexec/oc-rsync/rsyncd", mode = "0755" },
     { source = "packaging/systemd/oc-rsyncd.service", dest = "/usr/lib/systemd/system/oc-rsyncd.service", mode = "0644" },
     { source = "packaging/etc/oc-rsyncd/oc-rsyncd.conf", dest = "/etc/oc-rsyncd/oc-rsyncd.conf", mode = "0644", config = true },
     { source = "packaging/etc/oc-rsyncd/oc-rsyncd.secrets", dest = "/etc/oc-rsyncd/oc-rsyncd.secrets", mode = "0600", config = true },


### PR DESCRIPTION
## Summary
- enable the legacy compatibility binaries by default so the integration suite can exercise them
- point the Debian and RPM asset lists at the canonical target/release paths so cargo-deb resolves the actual build output

## Testing
- cargo test

------