### PR TITLE
Fix RPM artifact paths and cargo xtask alias

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -7,3 +7,6 @@ ar = "tools/cross/bin/aarch64-unknown-linux-gnu-ar"
 
 [target.i686-pc-windows-gnu]
 rustflags = ["-C", "panic=abort"]
+
+[alias]
+xtask = "run --package xtask --"

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -151,7 +151,7 @@ jobs:
           set -euo pipefail
           rpmbuild --version
           cargo rpm build -v --target ${{ matrix.platform.target }}
-          RPM_DIR="target/${{ matrix.platform.target }}/release/rpmbuild/RPMS"
+          RPM_DIR="target/${{ matrix.platform.target }}/dist/rpmbuild/RPMS"
           mkdir -p dist/${{ matrix.platform.name }}
           find "$RPM_DIR" -type f -name '*.rpm' -exec cp -v {} dist/${{ matrix.platform.name }}/ \;
 

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -146,5 +146,6 @@ jobs:
 
       - name: sccache stats (best-effort)
         if: always()
+        shell: bash
         run: |
           command -v sccache >/dev/null 2>&1 && sccache --show-stats || true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -283,7 +283,7 @@ jobs:
         run: |
           set -euo pipefail
           cargo rpm build --target ${{ matrix.platform.target }}
-          RPM_DIR="target/${{ matrix.platform.target }}/release/rpmbuild/RPMS"
+          RPM_DIR="target/${{ matrix.platform.target }}/dist/rpmbuild/RPMS"
           mkdir -p dist/${{ matrix.platform.name }}
           find "$RPM_DIR" -type f -name '*.rpm' -exec cp {} dist/${{ matrix.platform.name }}/ \;
       - name: Upload .rpm


### PR DESCRIPTION
## Summary
- update Linux and release workflows to collect RPM artifacts from the dist profile output
- teach the release uploader to scan per-target RPM directories and adjust its test coverage
- add a cargo xtask alias and make the Windows sccache stats step run under bash

## Testing
- cargo test -p xtask

------