### PR TITLE
Make legacy wrappers optional and tighten packaging checks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ name = "oc-rsyncd"
 path = "src/bin/oc-rsyncd.rs"
 
 [features]
-default = ["legacy-binaries"]
+default = []
 legacy-binaries = []
 sd-notify = ["rsync-daemon/sd-notify"]
 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@
 oc-rsync is a pure-Rust reimplementation of the rsync protocol (version 32) that
 tracks upstream rsync 3.4.1 while publishing the branded release string
 `3.4.1-rust`. The workspace ships the canonical client/daemon binaries
-`oc-rsync` and `oc-rsyncd` together with compatibility wrappers `rsync` and
-`rsyncd`, so existing deployments can switch between the legacy and branded
+`oc-rsync` and `oc-rsyncd`. The optional `legacy-binaries` feature (enabled for
+packaged releases) additionally builds compatibility wrappers `rsync` and
+`rsyncd`, letting existing deployments switch between the legacy and branded
 entry points without changing behaviour.
 
 The authoritative source repository is hosted at

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -10,7 +10,14 @@ ci = "github"
 # The installers to generate for each app
 installers = ["shell"]
 # Target platforms to build apps for (Rust target-triple syntax)
-targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu"]
+targets = [
+    "aarch64-apple-darwin",
+    "aarch64-unknown-linux-gnu",
+    "aarch64-pc-windows-msvc",
+    "x86_64-apple-darwin",
+    "x86_64-unknown-linux-gnu",
+    "x86_64-pc-windows-msvc",
+]
 # Path that installers should place binaries in
 install-path = "CARGO_HOME"
 # Whether to install an updater program

--- a/xtask/src/commands/package/build.rs
+++ b/xtask/src/commands/package/build.rs
@@ -139,6 +139,10 @@ pub(super) fn build_workspace_binaries(
     linker_override: Option<&LinkerOverride>,
     include_legacy: bool,
 ) -> TaskResult<()> {
+    if let Some(target) = target {
+        ensure_rust_target_installed(target)?;
+    }
+
     if env::var_os("OC_RSYNC_PACKAGE_SKIP_BUILD").is_some() {
         println!("Skipping workspace binary build because OC_RSYNC_PACKAGE_SKIP_BUILD is set");
         return Ok(());
@@ -160,7 +164,6 @@ pub(super) fn build_workspace_binaries(
     let mut env_overrides: Vec<(OsString, OsString)> = Vec::new();
 
     if let Some(target) = target {
-        ensure_rust_target_installed(target)?;
         args.push(OsString::from("--target"));
         args.push(OsString::from(target));
         if let Some(linker) = linker_override {

--- a/xtask/src/commands/package/tarball.rs
+++ b/xtask/src/commands/package/tarball.rs
@@ -170,15 +170,14 @@ pub(super) fn tarball_specs(
         )));
     };
 
-    let host_arch = env::consts::ARCH;
     let filtered: Vec<_> = specs
         .into_iter()
-        .filter(|spec| spec.platform == host_platform && spec.metadata_arch == host_arch)
+        .filter(|spec| spec.platform == host_platform)
         .collect();
 
     if filtered.is_empty() {
         return Err(TaskError::Validation(format!(
-            "no tarball specifications available for host platform {} ({host_arch})",
+            "no tarball specifications available for host platform {}",
             host_platform.archive_tag(),
         )));
     }


### PR DESCRIPTION
## Summary
- disable the legacy rsync/rsyncd wrappers by default so the branded binaries can coexist with upstream installs
- document the optional feature, update tests to skip wrapper checks when they are not built, and extend dist metadata for linux/macos/windows targets
- require packaging to validate the requested Rust targets even when build steps are skipped

## Testing
- cargo test

------