### PR TITLE
Ensure packaging workflows install rust-src and keep RPM alternatives optional

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -82,6 +82,11 @@ jobs:
         with:
           version: 0.11.0
 
+      - name: Install rust-src component
+        if: ${{ matrix.platform.enabled && matrix.platform.uses_zig }}
+        shell: bash
+        run: rustup component add rust-src
+
       - name: Install cargo-zigbuild
         if: ${{ matrix.platform.enabled && matrix.platform.uses_zig }}
         uses: taiki-e/install-action@v2

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -92,6 +92,11 @@ jobs:
         with:
           version: 0.11.0
 
+      - name: Install rust-src component
+        if: ${{ matrix.platform.enabled && matrix.platform.uses_zig }}
+        shell: bash
+        run: rustup component add rust-src
+
       - name: Install cargo-zigbuild
         if: ${{ matrix.platform.enabled && matrix.platform.uses_zig }}
         uses: taiki-e/install-action@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,6 +149,11 @@ jobs:
         with:
           version: 0.11.0
 
+      - name: Install rust-src component
+        if: ${{ matrix.platform.enabled && matrix.platform.uses_zig }}
+        shell: bash
+        run: rustup component add rust-src
+
       - name: Install cargo-zigbuild
         if: ${{ matrix.platform.enabled && matrix.platform.uses_zig }}
         uses: taiki-e/install-action@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -164,6 +164,12 @@ mode = "0644"
 post = '''
 set -e
 
+ALT_NAME=rsync
+ALT_MASTER=/usr/bin/rsync
+ALT_IMPL=/usr/libexec/oc-rsync/rsync
+ALT_SLAVE_NAME=rsyncd
+ALT_SLAVE_LINK=/usr/bin/rsyncd
+ALT_SLAVE_IMPL=/usr/libexec/oc-rsync/rsyncd
 ALT_PRIORITY=30
 DEFAULTS_FILE=/etc/default/oc-rsyncd
 
@@ -235,6 +241,13 @@ register_alternatives
 preun = '''
 set -e
 
+ALT_NAME=rsync
+ALT_MASTER=/usr/bin/rsync
+ALT_IMPL=/usr/libexec/oc-rsync/rsync
+ALT_SLAVE_NAME=rsyncd
+ALT_SLAVE_LINK=/usr/bin/rsyncd
+ALT_SLAVE_IMPL=/usr/libexec/oc-rsync/rsyncd
+
 detect_alternatives() {
     if command -v update-alternatives >/dev/null 2>&1; then
         ALT_TOOL=update-alternatives
@@ -262,6 +275,13 @@ fi
 '''
 postun = '''
 set -e
+
+ALT_NAME=rsync
+ALT_MASTER=/usr/bin/rsync
+ALT_IMPL=/usr/libexec/oc-rsync/rsync
+ALT_SLAVE_NAME=rsyncd
+ALT_SLAVE_LINK=/usr/bin/rsyncd
+ALT_SLAVE_IMPL=/usr/libexec/oc-rsync/rsyncd
 
 detect_alternatives() {
     if command -v update-alternatives >/dev/null 2>&1; then

--- a/packaging/rpm/oc-rsync.post
+++ b/packaging/rpm/oc-rsync.post
@@ -1,4 +1,86 @@
 #!/bin/sh
-/usr/sbin/alternatives --install /usr/bin/rsync rsync /usr/bin/oc-rsync 10 || true
-/usr/sbin/alternatives --install /usr/bin/rsyncd rsyncd /usr/bin/oc-rsyncd 10 || true
+set -e
+
+ALT_NAME="rsync"
+ALT_MASTER="/usr/bin/rsync"
+ALT_IMPL="/usr/libexec/oc-rsync/rsync"
+ALT_SLAVE_NAME="rsyncd"
+ALT_SLAVE_LINK="/usr/bin/rsyncd"
+ALT_SLAVE_IMPL="/usr/libexec/oc-rsync/rsyncd"
+ALT_PRIORITY=30
+DEFAULTS_FILE="/etc/default/oc-rsyncd"
+
+is_truthy() {
+    case "$1" in
+        [Yy][Ee][Ss]|[Tt][Rr][Uu][Ee]|1)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+load_defaults() {
+    if [ -r "${DEFAULTS_FILE}" ]; then
+        # shellcheck disable=SC1090 # configuration file is provided by the package
+        . "${DEFAULTS_FILE}"
+    fi
+}
+
+detect_alternatives() {
+    if command -v update-alternatives >/dev/null 2>&1; then
+        ALT_TOOL=update-alternatives
+    elif command -v alternatives >/dev/null 2>&1; then
+        ALT_TOOL=alternatives
+    else
+        ALT_TOOL=
+    fi
+}
+
+should_register_alternatives() {
+    if is_truthy "${OC_RSYNC_PACKAGE_DISABLE_ALTERNATIVES:-}"; then
+        return 1
+    fi
+
+    if [ -n "${OC_RSYNC_PACKAGE_REGISTER_ALTERNATIVES:-}" ]; then
+        if is_truthy "${OC_RSYNC_PACKAGE_REGISTER_ALTERNATIVES}"; then
+            return 0
+        fi
+        return 1
+    fi
+
+    load_defaults
+
+    if is_truthy "${OC_RSYNC_REGISTER_ALTERNATIVES:-}"; then
+        return 0
+    fi
+
+    return 1
+}
+
+register_alternatives() {
+    detect_alternatives
+
+    if [ -z "${ALT_TOOL}" ]; then
+        return 0
+    fi
+
+    if ! should_register_alternatives; then
+        return 0
+    fi
+
+    if [ -e "${ALT_MASTER}" ] && [ ! -L "${ALT_MASTER}" ]; then
+        if ! "${ALT_TOOL}" --display "${ALT_NAME}" >/dev/null 2>&1; then
+            return 0
+        fi
+    fi
+
+    "${ALT_TOOL}" \
+        --install "${ALT_MASTER}" "${ALT_NAME}" "${ALT_IMPL}" "${ALT_PRIORITY}" \
+        --slave "${ALT_SLAVE_LINK}" "${ALT_SLAVE_NAME}" "${ALT_SLAVE_IMPL}" \
+        >/dev/null
+}
+
+register_alternatives
 exit 0

--- a/packaging/rpm/oc-rsync.preun
+++ b/packaging/rpm/oc-rsync.preun
@@ -1,4 +1,34 @@
 #!/bin/sh
-/usr/sbin/alternatives --remove rsync /usr/bin/oc-rsync || true
-/usr/sbin/alternatives --remove rsyncd /usr/bin/oc-rsyncd || true
+set -e
+
+ALT_NAME="rsync"
+ALT_MASTER="/usr/bin/rsync"
+ALT_IMPL="/usr/libexec/oc-rsync/rsync"
+
+detect_alternatives() {
+    if command -v update-alternatives >/dev/null 2>&1; then
+        ALT_TOOL=update-alternatives
+    elif command -v alternatives >/dev/null 2>&1; then
+        ALT_TOOL=alternatives
+    else
+        ALT_TOOL=
+    fi
+}
+
+remove_alternatives() {
+    detect_alternatives
+
+    if [ -z "${ALT_TOOL}" ]; then
+        return 0
+    fi
+
+    if "${ALT_TOOL}" --display "${ALT_NAME}" >/dev/null 2>&1; then
+        "${ALT_TOOL}" --remove "${ALT_NAME}" "${ALT_IMPL}" >/dev/null || true
+    fi
+}
+
+if [ "$1" -eq 0 ]; then
+    remove_alternatives
+fi
+
 exit 0


### PR DESCRIPTION
## Summary
- install the rust-src component before invoking cargo-zigbuild in the macOS, Windows, and release build workflows
- teach the xtask packaging helpers to auto-install missing Rust targets and extend coverage for the new behaviour
- align the RPM scripts and metadata so update-alternatives registration is opt-in, keeping oc-rsync side by side with upstream rsync

## Testing
- cargo test -p xtask

------