### PR TITLE
Allow cross-compile workflow entries to be disabled

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,6 +100,15 @@ linux = ["x86_64", "aarch64"]
 macos = ["x86_64", "aarch64"]
 windows = ["x86_64", "aarch64"]
 
+[workspace.metadata.oc_rsync.cross_compile_matrix]
+"linux-x86_64" = true
+"linux-aarch64" = true
+"darwin-x86_64" = true
+"darwin-aarch64" = true
+"windows-x86_64" = false
+"windows-aarch64" = false
+"windows-x86" = false
+
 [package.metadata.deb]
 name = "oc-rsync"
 section = "utils"

--- a/README.md
+++ b/README.md
@@ -44,6 +44,13 @@
 
 ---
 
+## Status
+
+- **Compatibility**: Mirrors upstream rsync 3.4.1 (protocol 32) with Rust-branded release `3.4.1-rust`.
+- **Daemon defaults**: Ships `/etc/oc-rsyncd/oc-rsyncd.conf` as the primary configuration file, matching packaging and systemd units.
+
+---
+
 ## Project Structure
 
 ```

--- a/xtask/src/commands/branding/render.rs
+++ b/xtask/src/commands/branding/render.rs
@@ -61,6 +61,12 @@ fn render_branding_json(branding: &WorkspaceBranding) -> TaskResult<String> {
         .map(|(os, archs)| (os.clone(), archs.clone()))
         .collect();
 
+    let cross_compile_matrix: BTreeMap<_, _> = branding
+        .cross_compile_matrix
+        .iter()
+        .map(|(platform, enabled)| (platform.clone(), *enabled))
+        .collect();
+
     let value = json!({
         "brand": branding.brand,
         "upstream_version": branding.upstream_version,
@@ -87,6 +93,7 @@ fn render_branding_json(branding: &WorkspaceBranding) -> TaskResult<String> {
             .to_string(),
         "source": branding.source,
         "cross_compile": cross_compile,
+        "cross_compile_matrix": cross_compile_matrix,
     });
 
     serde_json::to_string_pretty(&value).map_err(|error| {
@@ -149,6 +156,13 @@ mod tests {
                     vec![String::from("x86_64"), String::from("aarch64")],
                 ),
                 (String::from("windows"), vec![String::from("x86_64")]),
+            ]),
+            cross_compile_matrix: BTreeMap::from([
+                (String::from("linux-x86_64"), true),
+                (String::from("linux-aarch64"), true),
+                (String::from("darwin-x86_64"), true),
+                (String::from("darwin-aarch64"), true),
+                (String::from("windows-x86_64"), true),
             ]),
         }
     }

--- a/xtask/src/commands/branding/tests.rs
+++ b/xtask/src/commands/branding/tests.rs
@@ -29,6 +29,13 @@ fn sample_branding() -> WorkspaceBranding {
             (String::from("macos"), vec![String::from("x86_64"), String::from("aarch64")]),
             (String::from("windows"), vec![String::from("x86_64")]),
         ]),
+        cross_compile_matrix: BTreeMap::from([
+            (String::from("linux-x86_64"), true),
+            (String::from("linux-aarch64"), true),
+            (String::from("darwin-x86_64"), true),
+            (String::from("darwin-aarch64"), true),
+            (String::from("windows-x86_64"), true),
+        ]),
     }
 }
 

--- a/xtask/src/commands/branding/validate.rs
+++ b/xtask/src/commands/branding/validate.rs
@@ -235,6 +235,13 @@ mod tests {
                 ),
                 (String::from("windows"), vec![String::from("x86_64")]),
             ]),
+            cross_compile_matrix: BTreeMap::from([
+                (String::from("linux-x86_64"), true),
+                (String::from("linux-aarch64"), true),
+                (String::from("darwin-x86_64"), true),
+                (String::from("darwin-aarch64"), true),
+                (String::from("windows-x86_64"), true),
+            ]),
         }
     }
 

--- a/xtask/src/commands/docs/validation/ci/matrix.rs
+++ b/xtask/src/commands/docs/validation/ci/matrix.rs
@@ -81,7 +81,7 @@ fn validate_platform_workflow(
                 &section,
                 &name,
                 MatrixExpectations {
-                    enabled: Some(true),
+                    enabled: matrix_expected_enabled(branding, spec.os, arch),
                     target: expected_target(spec.os, arch),
                     build_command: Some(expected_build_command(spec.os)),
                     build_daemon: Some(expected_build_daemon(spec.os, arch)),
@@ -108,7 +108,7 @@ fn validate_platform_workflow(
             &section,
             "windows-x86",
             MatrixExpectations {
-                enabled: Some(false),
+                enabled: matrix_expected_enabled(branding, "windows", "x86"),
                 target: expected_target("windows", "x86"),
                 build_command: Some("zigbuild"),
                 build_daemon: Some(false),
@@ -426,6 +426,19 @@ fn expected_matrix_name(os: &str, arch: &str) -> Option<String> {
         "windows" => Some(format!("windows-{arch}")),
         _ => None,
     }
+}
+
+fn matrix_expected_enabled(branding: &WorkspaceBranding, os: &str, arch: &str) -> Option<bool> {
+    let name = expected_matrix_name(os, arch)?;
+    if let Some(enabled) = branding.cross_compile_matrix.get(&name) {
+        return Some(*enabled);
+    }
+
+    if os == "windows" && arch == "x86" {
+        return Some(false);
+    }
+
+    Some(true)
 }
 
 fn expected_target(os: &str, arch: &str) -> Option<&'static str> {

--- a/xtask/src/commands/docs/validation/ci/matrix/tests/missing_entries.rs
+++ b/xtask/src/commands/docs/validation/ci/matrix/tests/missing_entries.rs
@@ -25,7 +25,7 @@ jobs:
       matrix:
         platform:
           - name: windows-aarch64
-            enabled: true
+            enabled: false
             runner: windows-latest
             target: aarch64-pc-windows-msvc
             build_command: zigbuild

--- a/xtask/src/commands/docs/validation/ci/matrix/tests/mod.rs
+++ b/xtask/src/commands/docs/validation/ci/matrix/tests/mod.rs
@@ -27,6 +27,14 @@ source = "https://github.com/oferchen/rsync"
 linux = ["x86_64", "aarch64"]
 macos = ["x86_64", "aarch64"]
 windows = ["x86_64", "aarch64"]
+[workspace.metadata.oc_rsync.cross_compile_matrix]
+"linux-x86_64" = true
+"linux-aarch64" = true
+"darwin-x86_64" = true
+"darwin-aarch64" = true
+"windows-x86_64" = false
+"windows-aarch64" = false
+"windows-x86" = false
 "#;
 
 fn write_manifest(workspace: &Path) {
@@ -167,7 +175,7 @@ jobs:
       matrix:
         platform:
           - name: windows-x86_64
-            enabled: true
+            enabled: false
             runner: windows-latest
             target: x86_64-pc-windows-msvc
             build_command: zigbuild
@@ -177,7 +185,7 @@ jobs:
             package_linux: false
             generate_sbom: false
           - name: windows-aarch64
-            enabled: true
+            enabled: false
             runner: windows-latest
             target: aarch64-pc-windows-msvc
             build_command: zigbuild

--- a/xtask/src/commands/package/tarball.rs
+++ b/xtask/src/commands/package/tarball.rs
@@ -472,6 +472,7 @@ mod tests {
             legacy_daemon_secrets: PathBuf::from("/etc/rsyncd.secrets"),
             source: String::from("https://example.invalid"),
             cross_compile,
+            cross_compile_matrix: BTreeMap::new(),
         }
     }
 

--- a/xtask/src/commands/release/upload.rs
+++ b/xtask/src/commands/release/upload.rs
@@ -434,6 +434,11 @@ mod tests {
                 (String::from("macos"), vec![String::from("x86_64")]),
                 (String::from("windows"), vec![String::from("x86_64")]),
             ]),
+            cross_compile_matrix: BTreeMap::from([
+                (String::from("linux-x86_64"), true),
+                (String::from("darwin-x86_64"), true),
+                (String::from("windows-x86_64"), true),
+            ]),
         }
     }
 


### PR DESCRIPTION
## Summary
- add a cross_compile_matrix manifest table so CI validation can honour disabled platforms
- update xtask branding helpers and docs to expose the matrix overrides and document the packaged defaults

## Testing
- cargo test -p xtask

------