### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/superlinter.yml
+++ b/.github/workflows/superlinter.yml
@@ -1,4 +1,6 @@
 name: Super-Linter
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/oferchen/rsync/security/code-scanning/1](https://github.com/oferchen/rsync/security/code-scanning/1)

The fix is to add a `permissions` block with the minimum required privileges. In this case, unless the workflow makes changes to the repository (such as pushing code, managing issues or PRs), the minimal permission is usually `contents: read`. The `permissions` block should be placed at the top level (immediately after the `name`, before `on:`), to apply to all jobs (unless any job needs more permissions). This edit is limited to adding the following lines to .github/workflows/superlinter.yml:

```
permissions:
  contents: read
```

No imports or further definitions are required; just this YAML addition.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
