### PR TITLE
Fix xtask branding test for windows x86_64

### DIFF
--- a/xtask/src/workspace.rs
+++ b/xtask/src/workspace.rs
@@ -323,7 +323,7 @@ source = "https://github.com/oferchen/rsync"
                 (String::from("linux-x86_64"), true),
                 (String::from("windows-aarch64"), false),
                 (String::from("windows-x86"), false),
-                (String::from("windows-x86_64"), false),
+                (String::from("windows-x86_64"), true),
             ]),
         };
         assert_eq!(branding, expected);


### PR DESCRIPTION
## Summary
- update the branding metadata test to expect the enabled Windows x86_64 matrix entry

## Testing
- cargo test -p xtask workspace::tests::parse_workspace_branding_extracts_fields

------