### PR TITLE
Ensure nextest failures fail the Linux test workflow

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -53,7 +53,7 @@ jobs:
         run: cargo build --workspace --all-features --locked
 
       - name: Unit tests (nextest)
-        run: cargo nextest run --workspace --all-features --no-capture --locked || true
+        run: cargo nextest run --workspace --all-features --no-capture --locked
 
       - name: sccache stats (best-effort)
         if: always()


### PR DESCRIPTION
## Summary
- ensure the Linux test workflow respects `cargo nextest` failures by removing the unconditional success guard

## Testing
- cargo test --locked

------