### PR TITLE
Switch Windows cross-compilation to native cargo builds

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -24,9 +24,9 @@ jobs:
             enabled: true
             runner: windows-latest
             target: x86_64-pc-windows-msvc
-            build_command: zigbuild
+            build_command: build
             build_daemon: false
-            uses_zig: true
+            uses_zig: false
             needs_cross_gcc: false
             package_linux: false
             generate_sbom: false
@@ -34,9 +34,9 @@ jobs:
             enabled: false
             runner: windows-latest
             target: aarch64-pc-windows-msvc
-            build_command: zigbuild
+            build_command: build
             build_daemon: false
-            uses_zig: true
+            uses_zig: false
             needs_cross_gcc: false
             package_linux: false
             generate_sbom: false
@@ -44,9 +44,9 @@ jobs:
             enabled: false
             runner: windows-latest
             target: i686-pc-windows-msvc
-            build_command: zigbuild
+            build_command: build
             build_daemon: false
-            uses_zig: true
+            uses_zig: false
             needs_cross_gcc: false
             package_linux: false
             generate_sbom: false

--- a/xtask/src/commands/docs/validation/ci/matrix.rs
+++ b/xtask/src/commands/docs/validation/ci/matrix.rs
@@ -110,9 +110,9 @@ fn validate_platform_workflow(
             MatrixExpectations {
                 enabled: matrix_expected_enabled(branding, "windows", "x86"),
                 target: expected_target("windows", "x86"),
-                build_command: Some("zigbuild"),
+                build_command: Some("build"),
                 build_daemon: Some(false),
-                uses_zig: Some(true),
+                uses_zig: Some(false),
                 generate_sbom: Some(false),
                 needs_cross_gcc: Some(false),
             },
@@ -456,8 +456,8 @@ fn expected_target(os: &str, arch: &str) -> Option<&'static str> {
 
 fn expected_build_command(os: &str) -> &'static str {
     match os {
-        "linux" => "build",
-        "macos" | "windows" => "zigbuild",
+        "linux" | "windows" => "build",
+        "macos" => "zigbuild",
         _ => "build",
     }
 }
@@ -467,7 +467,7 @@ fn expected_build_daemon(os: &str, _arch: &str) -> bool {
 }
 
 fn expected_uses_zig(os: &str) -> bool {
-    matches!(os, "macos" | "windows")
+    matches!(os, "macos")
 }
 
 fn expected_generate_sbom(os: &str) -> bool {

--- a/xtask/src/commands/docs/validation/ci/matrix/tests/extract.rs
+++ b/xtask/src/commands/docs/validation/ci/matrix/tests/extract.rs
@@ -14,9 +14,9 @@ fn extract_matrix_entry_parses_enabled_flag() {
       - name: windows-x86
         enabled: false
         target: i686-pc-windows-msvc
-        build_command: zigbuild
+        build_command: build
         build_daemon: false
-        uses_zig: true
+        uses_zig: false
         needs_cross_gcc: false
         generate_sbom: false
     "#;
@@ -33,9 +33,9 @@ fn extract_matrix_entry_parses_enabled_flag() {
     let windows = extract_matrix_entry(contents, "windows-x86").expect("windows entry");
     assert_eq!(windows.enabled, Some(false));
     assert_eq!(windows.target.as_deref(), Some("i686-pc-windows-msvc"));
-    assert_eq!(windows.build_command.as_deref(), Some("zigbuild"));
+    assert_eq!(windows.build_command.as_deref(), Some("build"));
     assert_eq!(windows.build_daemon, Some(false));
-    assert_eq!(windows.uses_zig, Some(true));
+    assert_eq!(windows.uses_zig, Some(false));
     assert_eq!(windows.needs_cross_gcc, Some(false));
     assert_eq!(windows.generate_sbom, Some(false));
 }

--- a/xtask/src/commands/docs/validation/ci/matrix/tests/missing_entries.rs
+++ b/xtask/src/commands/docs/validation/ci/matrix/tests/missing_entries.rs
@@ -28,9 +28,9 @@ jobs:
             enabled: false
             runner: windows-latest
             target: aarch64-pc-windows-msvc
-            build_command: zigbuild
+            build_command: build
             build_daemon: false
-            uses_zig: true
+            uses_zig: false
             needs_cross_gcc: false
             package_linux: false
             generate_sbom: false
@@ -38,9 +38,9 @@ jobs:
             enabled: false
             runner: windows-latest
             target: i686-pc-windows-msvc
-            build_command: zigbuild
+            build_command: build
             build_daemon: false
-            uses_zig: true
+            uses_zig: false
             needs_cross_gcc: false
             package_linux: false
             generate_sbom: false

--- a/xtask/src/commands/docs/validation/ci/matrix/tests/mod.rs
+++ b/xtask/src/commands/docs/validation/ci/matrix/tests/mod.rs
@@ -178,9 +178,9 @@ jobs:
             enabled: false
             runner: windows-latest
             target: x86_64-pc-windows-msvc
-            build_command: zigbuild
+            build_command: build
             build_daemon: false
-            uses_zig: true
+            uses_zig: false
             needs_cross_gcc: false
             package_linux: false
             generate_sbom: false
@@ -188,9 +188,9 @@ jobs:
             enabled: false
             runner: windows-latest
             target: aarch64-pc-windows-msvc
-            build_command: zigbuild
+            build_command: build
             build_daemon: false
-            uses_zig: true
+            uses_zig: false
             needs_cross_gcc: false
             package_linux: false
             generate_sbom: false
@@ -198,9 +198,9 @@ jobs:
             enabled: false
             runner: windows-latest
             target: i686-pc-windows-msvc
-            build_command: zigbuild
+            build_command: build
             build_daemon: false
-            uses_zig: true
+            uses_zig: false
             needs_cross_gcc: false
             package_linux: false
             generate_sbom: false


### PR DESCRIPTION
## Summary
- run Windows cross-compilation jobs with `cargo build` instead of `cargo zigbuild`
- update CI validation helpers and tests to expect native cargo builds and no Zig usage on Windows entries

## Testing
- `cargo test -p xtask`

------