### PR TITLE
Handle files-from relative entries with explicit source directory

### DIFF
--- a/crates/cli/src/frontend/execution/drive/workflow/mod.rs
+++ b/crates/cli/src/frontend/execution/drive/workflow/mod.rs
@@ -12,7 +12,8 @@ use preflight::{
 };
 
 use super::super::{
-    extract_operands, load_file_list_operands, parse_chown_argument, transfer_requires_remote,
+    extract_operands, load_file_list_operands, parse_chown_argument, resolve_file_list_entries,
+    transfer_requires_remote,
 };
 use super::messages::{fail_with_custom_fallback, fail_with_message};
 use super::module_listing::{ModuleListingInputs, maybe_handle_module_listing};
@@ -258,6 +259,12 @@ where
         Ok(operands) => operands,
         Err(message) => return fail_with_message(message, stderr),
     };
+
+    resolve_file_list_entries(
+        &mut file_list_operands,
+        &remainder,
+        relative.unwrap_or(false),
+    );
 
     if let Some(exit_code) = maybe_handle_module_listing(
         stdout,

--- a/crates/cli/src/frontend/execution/mod.rs
+++ b/crates/cli/src/frontend/execution/mod.rs
@@ -17,7 +17,9 @@ pub(crate) use compression::{
 pub(crate) use drive::CONNECT_PROGRAM_DAEMON_ONLY_MESSAGE;
 #[cfg(test)]
 pub(crate) use file_list::read_file_list_from_reader;
-pub(crate) use file_list::{load_file_list_operands, transfer_requires_remote};
+pub(crate) use file_list::{
+    load_file_list_operands, resolve_file_list_entries, transfer_requires_remote,
+};
 pub(crate) use flags::{
     DEBUG_HELP_TEXT, INFO_HELP_TEXT, info_flags_include_progress, parse_debug_flags,
     parse_info_flags,

--- a/crates/cli/src/frontend/tests/mod.rs
+++ b/crates/cli/src/frontend/tests/mod.rs
@@ -336,6 +336,8 @@ mod transfer_request_with_cvs_tests;
 mod transfer_request_with_delete_tests;
 #[path = "transfer_request_with_exclude.rs"]
 mod transfer_request_with_exclude_tests;
+#[path = "transfer_request_with_files_from.rs"]
+mod transfer_request_with_files_from_tests;
 #[path = "transfer_request_with_files.rs"]
 mod transfer_request_with_files_tests;
 #[path = "transfer_request_with_filter.rs"]

--- a/crates/cli/src/frontend/tests/transfer_request_with_files_from.rs
+++ b/crates/cli/src/frontend/tests/transfer_request_with_files_from.rs
@@ -1,0 +1,41 @@
+use super::common::*;
+use super::*;
+
+#[test]
+fn transfer_request_with_files_from_uses_source_directory_for_relative_entries() {
+    use tempfile::tempdir;
+
+    let tmp = tempdir().expect("tempdir");
+    let source_dir = tmp.path().join("files-from-source");
+    std::fs::create_dir(&source_dir).expect("create source");
+    let nested = source_dir.join("nested");
+    std::fs::create_dir(&nested).expect("create nested");
+
+    let alpha_path = source_dir.join("alpha.txt");
+    let beta_path = nested.join("beta.txt");
+    std::fs::write(&alpha_path, b"alpha").expect("write alpha");
+    std::fs::write(&beta_path, b"beta").expect("write beta");
+
+    let list_path = tmp.path().join("files-from-relative.list");
+    std::fs::write(&list_path, "alpha.txt\nnested/beta.txt\n").expect("write list");
+
+    let dest_dir = tmp.path().join("files-from-dest");
+    std::fs::create_dir(&dest_dir).expect("create dest");
+
+    let (code, stdout, stderr) = run_with_args([
+        OsString::from(RSYNC),
+        OsString::from(format!("--files-from={}", list_path.display())),
+        source_dir.clone().into_os_string(),
+        dest_dir.clone().into_os_string(),
+    ]);
+
+    assert_eq!(code, 0);
+    assert!(stdout.is_empty());
+    assert!(stderr.is_empty());
+
+    let copied_alpha = dest_dir.join("alpha.txt");
+    let copied_beta = dest_dir.join("beta.txt");
+
+    assert_eq!(std::fs::read(&copied_alpha).expect("read alpha"), b"alpha");
+    assert_eq!(std::fs::read(&copied_beta).expect("read beta"), b"beta");
+}


### PR DESCRIPTION
## Summary
- adjust the file-list loader to prefix relative `--files-from` entries with the explicit source operand before constructing the transfer plan
- export and invoke the helper in the workflow so module listings and fallback arguments see the resolved paths
- add regression coverage for local `--files-from` usage with relative paths

## Testing
- cargo test

------