### PR TITLE
Accelerate rolling checksum dispatch with AVX2 fast path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,12 +41,13 @@ This document defines the internal actors (“agents”), their responsibilities
   deprecated APIs, pseudo-code, or placeholder logic; every change must ship
   production-ready behaviour with comprehensive tests or parity checks.
 - **CPU-accelerated hot paths**: The rolling checksum pipeline uses
-  architecture-specific SIMD fast paths (SSE2 on `x86_64`, NEON on
+  architecture-specific SIMD fast paths (AVX2 and SSE2 on `x86_64`, NEON on
   `aarch64`) that fall back to the scalar implementation for other targets.
   Any updates to `crates/checksums`—especially
   `rolling::checksum::accumulate_chunk`—must keep the SIMD and scalar
   implementations in lockstep, reuse the shared scalar helper for edge cases,
-  and extend the parity tests (`sse2_accumulate_matches_scalar_reference` and
+  and extend the parity tests (`avx2_accumulate_matches_scalar_reference`,
+  `sse2_accumulate_matches_scalar_reference`, and
   `neon_accumulate_matches_scalar_reference`) whenever new optimisations are
   introduced. Additional CPU offloading should follow the same pattern of
   runtime feature detection (where applicable) paired with deterministic tests

--- a/crates/checksums/src/rolling/tests/checksum.rs
+++ b/crates/checksums/src/rolling/tests/checksum.rs
@@ -448,6 +448,44 @@ fn sse2_accumulate_matches_scalar_reference() {
     }
 }
 
+#[cfg(target_arch = "x86_64")]
+#[test]
+fn avx2_accumulate_matches_scalar_reference() {
+    if !std::arch::is_x86_feature_detected!("avx2") {
+        return;
+    }
+
+    use crate::rolling::checksum::accumulate_chunk_scalar_for_tests;
+    use crate::rolling::checksum::x86::accumulate_chunk_avx2_for_tests;
+
+    let sizes = [32usize, 33, 47, 64, 95, 128, 1024, 4096];
+    let seeds = [
+        (0u32, 0u32, 0usize),
+        (0x1234u32, 0x5678u32, 7usize),
+        (0x0fffu32, 0x7fffu32, 1024usize),
+        (0xffffu32, 0xffffu32, usize::MAX - 64),
+    ];
+
+    for &(seed_s1, seed_s2, seed_len) in &seeds {
+        for &size in &sizes {
+            let mut data = vec![0u8; size];
+            for (idx, byte) in data.iter_mut().enumerate() {
+                *byte = (idx as u8)
+                    .wrapping_mul(17)
+                    .wrapping_add((size as u8).wrapping_mul(5));
+            }
+
+            let scalar = accumulate_chunk_scalar_for_tests(seed_s1, seed_s2, seed_len, &data);
+            let simd = accumulate_chunk_avx2_for_tests(seed_s1, seed_s2, seed_len, &data);
+
+            assert_eq!(
+                scalar, simd,
+                "AVX2 mismatch for size {size} with seeds {seed_s1:#x}/{seed_s2:#x}/{seed_len}",
+            );
+        }
+    }
+}
+
 #[cfg(target_arch = "aarch64")]
 #[test]
 fn neon_accumulate_matches_scalar_reference() {


### PR DESCRIPTION
## Summary
- add an AVX2-accelerated implementation of the rolling checksum accumulator with SSE2 and scalar fallbacks
- extend the checksum parity tests to cover the AVX2 path alongside existing SSE2/NEON checks
- document the new SIMD coverage requirements in internal docs

## Testing
- cargo test -p rsync-checksums

------