### PR TITLE
Accelerate sparse writes with SIMD-aware zero detection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,9 +49,14 @@ This document defines the internal actors (“agents”), their responsibilities
   and extend the parity tests (`avx2_accumulate_matches_scalar_reference`,
   `sse2_accumulate_matches_scalar_reference`, and
   `neon_accumulate_matches_scalar_reference`) whenever new optimisations are
-  introduced. Additional CPU offloading should follow the same pattern of
-  runtime feature detection (where applicable) paired with deterministic tests
-  that compare against the scalar reference implementation.
+  introduced. The sparse-writer fast path in
+  `crates/engine/src/local_copy/executor/file/sparse.rs` uses the
+  `memchr` crate to delegate zero-byte detection to the CPU's SIMD
+  instructions on all supported platforms; changes to that routine must
+  preserve the single seek-per-zero-run invariant and keep coverage tests for
+  sparse file handling green. Additional CPU offloading should follow the same
+  pattern of runtime feature detection (where applicable) paired with
+  deterministic tests that compare against the scalar reference implementation.
 - **Environment guardrails for tests**: When exercising fallback overrides or
   other environment-sensitive logic in unit tests, use the existing
   `EnvGuard` helpers (for example, `crates/daemon/src/tests/support.rs` or the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -789,6 +789,7 @@ dependencies = [
  "filetime",
  "globset",
  "libc",
+ "memchr",
  "rsync-bandwidth",
  "rsync-checksums",
  "rsync-compress",

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -24,6 +24,7 @@ rsync-bandwidth = { path = "../bandwidth" }
 globset = "0.4"
 rustix = { version = "0.38", features = ["fs", "process"] }
 libc = { version = "0.2", optional = true }
+memchr = "2.7"
 
 [features]
 default = []

--- a/crates/engine/src/local_copy/executor/file/sparse.rs
+++ b/crates/engine/src/local_copy/executor/file/sparse.rs
@@ -3,42 +3,57 @@ use std::io::{Seek, SeekFrom, Write};
 use std::path::Path;
 
 use crate::local_copy::LocalCopyError;
+use memchr::memchr;
 
 pub(crate) fn write_sparse_chunk(
     writer: &mut fs::File,
     chunk: &[u8],
     destination: &Path,
 ) -> Result<usize, LocalCopyError> {
-    let mut index = 0usize;
+    let mut offset = 0usize;
     let mut written = 0usize;
 
-    while index < chunk.len() {
-        if chunk[index] == 0 {
-            let start = index;
-            while index < chunk.len() && chunk[index] == 0 {
-                index += 1;
+    while offset < chunk.len() {
+        match memchr(0, &chunk[offset..]) {
+            Some(rel_zero) => {
+                let zero_index = offset + rel_zero;
+
+                if rel_zero > 0 {
+                    writer
+                        .write_all(&chunk[offset..zero_index])
+                        .map_err(|error| {
+                            LocalCopyError::io("copy file", destination.to_path_buf(), error)
+                        })?;
+                    written = written.saturating_add(rel_zero);
+                }
+
+                let mut zero_end = zero_index + 1;
+                while zero_end < chunk.len() && chunk[zero_end] == 0 {
+                    zero_end += 1;
+                }
+
+                let span = zero_end - zero_index;
+                if span > 0 {
+                    writer
+                        .seek(SeekFrom::Current(span as i64))
+                        .map_err(|error| {
+                            LocalCopyError::io(
+                                "seek in destination file",
+                                destination.to_path_buf(),
+                                error,
+                            )
+                        })?;
+                }
+
+                offset = zero_end;
             }
-            let span = index - start;
-            if span > 0 {
-                writer
-                    .seek(SeekFrom::Current(span as i64))
-                    .map_err(|error| {
-                        LocalCopyError::io(
-                            "seek in destination file",
-                            destination.to_path_buf(),
-                            error,
-                        )
-                    })?;
+            None => {
+                writer.write_all(&chunk[offset..]).map_err(|error| {
+                    LocalCopyError::io("copy file", destination.to_path_buf(), error)
+                })?;
+                written = written.saturating_add(chunk.len() - offset);
+                break;
             }
-        } else {
-            let start = index;
-            while index < chunk.len() && chunk[index] != 0 {
-                index += 1;
-            }
-            writer.write_all(&chunk[start..index]).map_err(|error| {
-                LocalCopyError::io("copy file", destination.to_path_buf(), error)
-            })?;
-            written = written.saturating_add(index - start);
         }
     }
 


### PR DESCRIPTION
## Summary
- accelerate the sparse chunk writer by delegating zero detection to `memchr`'s SIMD fast paths
- document the sparse writer CPU offload policy in `internal docs`
- add the shared `memchr` dependency to the engine crate and lockfile

## Testing
- cargo check -p rsync-engine
- cargo test -p rsync-engine --lib

------