### PR TITLE
Fix oc-rsyncd test config section

### DIFF
--- a/tools/ci/run_interop.sh
+++ b/tools/ci/run_interop.sh
@@ -95,6 +95,7 @@ write_rust_daemon_conf() {
 
   cat >"$path" <<CONF
 [daemon]
+path = ${dest}
 pid file = ${pid_file}
 port = ${port}
 use chroot = false


### PR DESCRIPTION
## Summary
- add the required path directive to the oc-rsyncd interop configuration template so the module section parses correctly

## Testing
- `bash tools/ci/run_interop.sh` *(fails: current oc-rsyncd still rejects `--daemon`)*

------