### PR TITLE
Enable SIMD rolling checksums on x86

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ This document defines the internal actors (“agents”), their responsibilities
   deprecated APIs, pseudo-code, or placeholder logic; every change must ship
   production-ready behaviour with comprehensive tests or parity checks.
 - **CPU-accelerated hot paths**: The rolling checksum pipeline uses
-  architecture-specific SIMD fast paths (AVX2 and SSE2 on `x86_64`, NEON on
+  architecture-specific SIMD fast paths (AVX2 and SSE2 on `x86`/`x86_64`, NEON on
   `aarch64`) that fall back to the scalar implementation for other targets.
   Any updates to `crates/checksums`—especially
   `rolling::checksum::accumulate_chunk`—must keep the SIMD and scalar

--- a/crates/checksums/src/rolling/checksum.rs
+++ b/crates/checksums/src/rolling/checksum.rs
@@ -296,13 +296,13 @@ fn accumulate_chunk_arch(s1: u32, s2: u32, len: usize, chunk: &[u8]) -> Option<(
     Some(neon::accumulate_chunk(s1, s2, len, chunk))
 }
 
-#[cfg(target_arch = "x86_64")]
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 #[inline]
 fn accumulate_chunk_arch(s1: u32, s2: u32, len: usize, chunk: &[u8]) -> Option<(u32, u32, usize)> {
     x86::try_accumulate_chunk(s1, s2, len, chunk)
 }
 
-#[cfg(not(any(target_arch = "aarch64", target_arch = "x86_64")))]
+#[cfg(not(any(target_arch = "aarch64", target_arch = "x86_64", target_arch = "x86")))]
 #[inline]
 fn accumulate_chunk_arch(
     _s1: u32,
@@ -362,11 +362,20 @@ pub(crate) fn accumulate_chunk_scalar_for_tests(
     accumulate_chunk_scalar_raw(s1, s2, len, chunk)
 }
 
-#[cfg(target_arch = "x86_64")]
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 #[allow(unsafe_code)]
 #[allow(unsafe_op_in_unsafe_fn)]
 pub(crate) mod x86 {
     use super::accumulate_chunk_scalar_raw;
+    #[cfg(target_arch = "x86")]
+    use core::arch::x86::{
+        __m128i, __m256i, _mm_loadu_si128, _mm_mullo_epi16, _mm_sad_epu8, _mm_set_epi16,
+        _mm_setzero_si128, _mm_storeu_si128, _mm_unpackhi_epi8, _mm_unpacklo_epi8,
+        _mm256_add_epi32, _mm256_castsi256_si128, _mm256_cvtepu8_epi16, _mm256_extracti128_si256,
+        _mm256_loadu_si256, _mm256_madd_epi16, _mm256_sad_epu8, _mm256_set_epi16,
+        _mm256_setzero_si256, _mm256_storeu_si256,
+    };
+    #[cfg(target_arch = "x86_64")]
     use core::arch::x86_64::{
         __m128i, __m256i, _mm_loadu_si128, _mm_mullo_epi16, _mm_sad_epu8, _mm_set_epi16,
         _mm_setzero_si128, _mm_storeu_si128, _mm_unpackhi_epi8, _mm_unpacklo_epi8,

--- a/crates/checksums/src/rolling/tests/checksum.rs
+++ b/crates/checksums/src/rolling/tests/checksum.rs
@@ -457,7 +457,7 @@ fn roll_many_matches_single_rolls_for_long_sequences() {
     assert_eq!(batched.value(), reference.value());
 }
 
-#[cfg(target_arch = "x86_64")]
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 #[test]
 fn sse2_accumulate_matches_scalar_reference() {
     if !std::arch::is_x86_feature_detected!("sse2") {
@@ -495,7 +495,7 @@ fn sse2_accumulate_matches_scalar_reference() {
     }
 }
 
-#[cfg(target_arch = "x86_64")]
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 #[test]
 fn avx2_accumulate_matches_scalar_reference() {
     if !std::arch::is_x86_feature_detected!("avx2") {


### PR DESCRIPTION
## Summary
- enable the existing SIMD rolling-checksum implementation on 32-bit x86 targets by wiring the architecture dispatcher to the shared fast path
- share the x86 SSE2/AVX2 intrinsics between x86 and x86_64 and extend the parity tests to cover both targets
- document the broader CPU coverage in internal docs

## Testing
- cargo test

------