### PR TITLE
Accelerate bandwidth parser ASCII scanning

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,11 @@ This document defines the internal actors (“agents”), their responsibilities
   `memchr` crate to delegate zero-byte detection to the CPU's SIMD
   instructions on all supported platforms; changes to that routine must
   preserve the single seek-per-zero-run invariant and keep coverage tests for
-  sparse file handling green. Additional CPU offloading should follow the same
+  sparse file handling green. The bandwidth parser in `crates/bandwidth`
+  likewise leans on `memchr` to locate decimal separators and exponent markers
+  so ASCII scans stay vectorised; updates must keep the byte-oriented fast path
+  aligned with the exhaustive parser tests. Additional CPU offloading should
+  follow the same
   pattern of runtime feature detection (where applicable) paired with
   deterministic tests that compare against the scalar reference implementation.
   The vectored rolling checksum updater coalesces small `IoSlice` buffers into

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -699,6 +699,7 @@ dependencies = [
 name = "rsync-bandwidth"
 version = "3.4.1-rust"
 dependencies = [
+ "memchr",
  "proptest",
 ]
 

--- a/crates/bandwidth/Cargo.toml
+++ b/crates/bandwidth/Cargo.toml
@@ -20,5 +20,8 @@ targets = ["x86_64-unknown-linux-gnu"]
 default = []
 test-support = []
 
+[dependencies]
+memchr = "2.7"
+
 [dev-dependencies]
 proptest = "1.8"

--- a/crates/bandwidth/src/parse/numeric.rs
+++ b/crates/bandwidth/src/parse/numeric.rs
@@ -1,11 +1,13 @@
 use super::BandwidthParseError;
+use memchr::memchr2;
 
 pub(crate) fn parse_decimal_with_exponent(
     text: &str,
 ) -> Result<(u128, u128, u128, i32), BandwidthParseError> {
-    let (mantissa_text, exponent_text) = if let Some(position) = text.find(['e', 'E']) {
-        let (mantissa, exponent) = text.split_at(position);
-        let exponent = &exponent[1..];
+    let bytes = text.as_bytes();
+    let (mantissa_text, exponent_text) = if let Some(position) = memchr2(b'e', b'E', bytes) {
+        let mantissa = &text[..position];
+        let exponent = &text[position + 1..];
         (mantissa, Some(exponent))
     } else {
         (text, None)
@@ -53,39 +55,54 @@ pub(crate) fn pow_u128(base: u32, exponent: u32) -> Result<u128, BandwidthParseE
 }
 
 fn parse_decimal_mantissa(text: &str) -> Result<(u128, u128, u128), BandwidthParseError> {
-    let mut integer = 0u128;
-    let mut fraction = 0u128;
-    let mut denominator = 1u128;
-    let mut saw_decimal = false;
+    let bytes = text.as_bytes();
 
-    for ch in text.chars() {
-        match ch {
-            '0'..='9' => {
-                let digit = u128::from(ch as u8 - b'0');
-                if saw_decimal {
-                    denominator = denominator
-                        .checked_mul(10)
-                        .ok_or(BandwidthParseError::TooLarge)?;
-                    fraction = fraction
-                        .checked_mul(10)
-                        .and_then(|value| value.checked_add(digit))
-                        .ok_or(BandwidthParseError::TooLarge)?;
-                } else {
-                    integer = integer
-                        .checked_mul(10)
-                        .and_then(|value| value.checked_add(digit))
-                        .ok_or(BandwidthParseError::TooLarge)?;
-                }
-            }
-            '.' | ',' => {
-                if saw_decimal {
-                    return Err(BandwidthParseError::Invalid);
-                }
-                saw_decimal = true;
-            }
-            _ => return Err(BandwidthParseError::Invalid),
+    if let Some(position) = memchr2(b'.', b',', bytes) {
+        let (integer_bytes, fractional_with_sep) = bytes.split_at(position);
+        let fractional_bytes = &fractional_with_sep[1..];
+
+        if memchr2(b'.', b',', fractional_bytes).is_some() {
+            return Err(BandwidthParseError::Invalid);
         }
+
+        let integer = parse_digits(integer_bytes)?;
+        let mut denominator = 1u128;
+        let mut fraction = 0u128;
+
+        for &byte in fractional_bytes {
+            if !byte.is_ascii_digit() {
+                return Err(BandwidthParseError::Invalid);
+            }
+
+            denominator = denominator
+                .checked_mul(10)
+                .ok_or(BandwidthParseError::TooLarge)?;
+            fraction = fraction
+                .checked_mul(10)
+                .and_then(|value| value.checked_add(u128::from(byte - b'0')))
+                .ok_or(BandwidthParseError::TooLarge)?;
+        }
+
+        return Ok((integer, fraction, denominator));
     }
 
-    Ok((integer, fraction, denominator))
+    let integer = parse_digits(bytes)?;
+    Ok((integer, 0, 1))
+}
+
+fn parse_digits(bytes: &[u8]) -> Result<u128, BandwidthParseError> {
+    let mut value = 0u128;
+
+    for &byte in bytes {
+        if !byte.is_ascii_digit() {
+            return Err(BandwidthParseError::Invalid);
+        }
+
+        value = value
+            .checked_mul(10)
+            .and_then(|acc| acc.checked_add(u128::from(byte - b'0')))
+            .ok_or(BandwidthParseError::TooLarge)?;
+    }
+
+    Ok(value)
 }


### PR DESCRIPTION
## Summary
- reuse memchr to locate exponent and decimal separators in the bandwidth parser for SIMD-backed scanning
- add the new dependency and document the memchr fast path in internal docs

## Testing
- cargo test -p rsync-bandwidth

------