### PR TITLE
Fix clippy warning in sparse executor test

### DIFF
--- a/crates/engine/src/local_copy/executor/file/sparse.rs
+++ b/crates/engine/src/local_copy/executor/file/sparse.rs
@@ -104,8 +104,7 @@ mod tests {
             assert_eq!(
                 zero_run_length(case),
                 zero_run_length_scalar(case),
-                "zero-run length mismatch for {:?}",
-                case
+                "zero-run length mismatch for {case:?}"
             );
         }
 


### PR DESCRIPTION
## Summary
- update the sparse executor zero-run length test assertion to use inline format arguments compatible with clippy

## Testing
- cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings

------