### PR TITLE
Report SIMD checksum support in version output

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,7 +83,11 @@ This document defines the internal actors (“agents”), their responsibilities
   the scalar `roll` path for exotic slice lengths. Future optimisations must
   preserve the aggregated arithmetic and extend the long-sequence regression
   test (`roll_many_matches_single_rolls_for_long_sequences`) so both code paths
-  remain in parity.
+  remain in parity. The `VersionInfoConfig::with_runtime_capabilities` helper
+  surfaces the SIMD detection result (via
+  `rsync_checksums::simd_acceleration_available`) so `--version` output tracks
+  the acceleration active at runtime; update the helper whenever new
+  architecture-specific paths are introduced.
 - **Environment guardrails for tests**: When exercising fallback overrides or
   other environment-sensitive logic in unit tests, use the existing
   `EnvGuard` helpers (for example, `crates/daemon/src/tests/support.rs` or the

--- a/crates/checksums/src/lib.rs
+++ b/crates/checksums/src/lib.rs
@@ -7,4 +7,6 @@
 mod rolling;
 pub mod strong;
 
-pub use rolling::{RollingChecksum, RollingDigest, RollingError, RollingSliceError};
+pub use rolling::{
+    RollingChecksum, RollingDigest, RollingError, RollingSliceError, simd_acceleration_available,
+};

--- a/crates/checksums/src/rolling/mod.rs
+++ b/crates/checksums/src/rolling/mod.rs
@@ -2,7 +2,7 @@ mod checksum;
 mod digest;
 mod error;
 
-pub use checksum::RollingChecksum;
+pub use checksum::{RollingChecksum, simd_acceleration_available};
 pub use digest::RollingDigest;
 pub use error::{RollingError, RollingSliceError};
 

--- a/crates/checksums/src/rolling/tests/checksum.rs
+++ b/crates/checksums/src/rolling/tests/checksum.rs
@@ -208,6 +208,27 @@ fn saturating_increment_total_handles_large_usize_values() {
     }
 }
 
+#[test]
+fn simd_availability_matches_architecture_capabilities() {
+    let available = simd_acceleration_available();
+
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64"))]
+    {
+        assert!(
+            available,
+            "SIMD acceleration should be reported on architectures with dedicated fast paths"
+        );
+    }
+
+    #[cfg(not(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64")))]
+    {
+        assert!(
+            !available,
+            "SIMD acceleration must be disabled on unsupported architectures"
+        );
+    }
+}
+
 struct InterruptingReader<'a> {
     inner: Cursor<&'a [u8]>,
     interrupted: bool,

--- a/crates/core/src/version/report/config.rs
+++ b/crates/core/src/version/report/config.rs
@@ -104,6 +104,19 @@ impl VersionInfoConfig {
     pub const fn to_builder(self) -> VersionInfoConfigBuilder {
         VersionInfoConfigBuilder::from_config(self)
     }
+
+    /// Returns a configuration that reflects runtime-detected capabilities.
+    ///
+    /// The helper starts from [`VersionInfoConfig::new`] and toggles fields that
+    /// depend on CPU feature detection (currently SIMD rolling checksums) so the
+    /// rendered version report advertises the same optimisations that the
+    /// transfer engine selects.
+    #[must_use]
+    pub fn with_runtime_capabilities() -> Self {
+        let mut config = Self::new();
+        config.supports_simd_roll = rsync_checksums::simd_acceleration_available();
+        config
+    }
 }
 
 impl Default for VersionInfoConfig {

--- a/crates/core/src/version/report/renderer.rs
+++ b/crates/core/src/version/report/renderer.rs
@@ -31,7 +31,7 @@ pub struct VersionInfoReport {
 
 impl Default for VersionInfoReport {
     fn default() -> Self {
-        Self::new(VersionInfoConfig::default())
+        Self::new(VersionInfoConfig::with_runtime_capabilities())
     }
 }
 

--- a/crates/core/src/version/tests/report.rs
+++ b/crates/core/src/version/tests/report.rs
@@ -111,8 +111,8 @@ fn version_info_report_with_daemon_brand_updates_banner() {
 
 #[test]
 fn version_info_report_for_client_brand_matches_builder() {
-    let expected =
-        VersionInfoReport::new(VersionInfoConfig::default()).with_client_brand(Brand::Oc);
+    let expected = VersionInfoReport::new(VersionInfoConfig::with_runtime_capabilities())
+        .with_client_brand(Brand::Oc);
     let actual = VersionInfoReport::for_client_brand(Brand::Oc);
 
     assert_eq!(actual.human_readable(), expected.human_readable());
@@ -120,8 +120,8 @@ fn version_info_report_for_client_brand_matches_builder() {
 
 #[test]
 fn version_info_report_for_daemon_brand_matches_builder() {
-    let expected =
-        VersionInfoReport::new(VersionInfoConfig::default()).with_daemon_brand(Brand::Oc);
+    let expected = VersionInfoReport::new(VersionInfoConfig::with_runtime_capabilities())
+        .with_daemon_brand(Brand::Oc);
     let actual = VersionInfoReport::for_daemon_brand(Brand::Oc);
 
     assert_eq!(actual.human_readable(), expected.human_readable());


### PR DESCRIPTION
## Summary
- expose a public helper to report SIMD rolling-checksum availability and surface it through crate re-exports
- advertise the detected SIMD capability in VersionInfoConfig and default VersionInfoReport construction while documenting the requirement for future accelerations
- cover the new detection with unit tests and align existing expectations

## Testing
- cargo test -p rsync-checksums
- cargo test -p rsync-core version::tests::report

------