### PR TITLE
Cache NEON feature detection for rolling checksum

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,8 @@ This document defines the internal actors (“agents”), their responsibilities
   architecture-specific SIMD fast paths (AVX2 and SSE2 on `x86`/`x86_64`, NEON on
   `aarch64`) that fall back to the scalar implementation for other targets.
   Runtime feature detection is cached via `OnceLock` so repeated checksum calls
-  avoid the overhead of re-querying `is_x86_feature_detected!`, and any updates
+  avoid the overhead of re-querying `is_x86_feature_detected!`/
+  `is_aarch64_feature_detected!`, and any updates
   must preserve that memoisation alongside the scalar fallback. Any updates to
   `crates/checksums`—especially `rolling::checksum::accumulate_chunk`—must keep
   the SIMD and scalar implementations in lockstep, reuse the shared scalar


### PR DESCRIPTION
## Summary
- cache NEON feature detection for the rolling checksum SIMD path and reuse the result across calls
- fall back to the scalar accumulator when NEON is unavailable while keeping parity tests intact
- document the broadened runtime feature detection requirements for SIMD acceleration in `internal docs`

## Testing
- cargo test -p rsync-checksums

------