### PR TITLE
Ensure interop harness fails when .deb extraction fails

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,7 +1,5 @@
 
 ## compression encapsulation using identical algorthms as upstream, validate hashing use the same algo as upstream. 
-## ci interop exit code is omitted using || true
-
 ## UPSTREAM-CONSISTENT DAEMON MODEL
 
 **Upstream model:** one binary (`rsync`) enters daemon mode with `--daemon`; supports standalone listen or inetd/systemd socket activation; configured via `rsyncd.conf(5)`. We must mirror this exactly. :contentReference[oaicite:10]{index=10}

--- a/tools/ci/run_interop.sh
+++ b/tools/ci/run_interop.sh
@@ -113,17 +113,26 @@ try_fetch_deb() {
   fi
 
   mkdir -p "${install_dir}"
-  (
+  if ! (
     cd "${install_dir}"
-    ar x "$tmp_deb" >/dev/null 2>&1 || true
+    if ! ar x "$tmp_deb" >/dev/null 2>&1; then
+      echo "failed to extract archive payload from ${tmp_deb}" >&2
+      exit 1
+    fi
     if [[ -f data.tar.xz ]]; then
       tar -xf data.tar.xz
       rm -f data.tar.xz
     elif [[ -f data.tar.gz ]]; then
       tar -xzf data.tar.gz
       rm -f data.tar.gz
+    else
+      echo "unexpected .deb layout: missing data.tar archive" >&2
+      exit 1
     fi
-  )
+  ); then
+    rm -f "$tmp_deb"
+    return 1
+  fi
   rm -f "$tmp_deb"
 
   if [[ -x "${install_dir}/usr/bin/rsync" ]]; then
@@ -176,17 +185,26 @@ try_fetch_deb_generic() {
         return 1
       fi
       mkdir -p "${install_dir}"
-      (
+      if ! (
         cd "${install_dir}"
-        ar x "$tmp_deb" >/dev/null 2>&1 || true
+        if ! ar x "$tmp_deb" >/dev/null 2>&1; then
+          echo "failed to extract archive payload from ${tmp_deb}" >&2
+          exit 1
+        fi
         if [[ -f data.tar.xz ]]; then
           tar -xf data.tar.xz
           rm -f data.tar.xz
         elif [[ -f data.tar.gz ]]; then
           tar -xzf data.tar.gz
           rm -f data.tar.gz
+        else
+          echo "unexpected .deb layout: missing data.tar archive" >&2
+          exit 1
         fi
-      )
+      ); then
+        rm -f "$tmp_deb"
+        return 1
+      fi
       rm -f "$tmp_deb"
       if [[ -x "${install_dir}/usr/bin/rsync" ]]; then
         mkdir -p "${install_dir}/bin"


### PR DESCRIPTION
## Summary
- stop masking `ar` extraction failures in the interop harness so the job fails fast when a .deb payload cannot be unpacked
- drop the resolved TODO entry that tracked the swallowed exit status

## Testing
- bash -n tools/ci/run_interop.sh

------