### PR TITLE
Align no-operand usage banner with upstream

### DIFF
--- a/crates/cli/src/frontend/execution/drive/mod.rs
+++ b/crates/cli/src/frontend/execution/drive/mod.rs
@@ -16,6 +16,14 @@ use std::io::Write;
 
 pub(crate) use workflow::execute;
 
+#[cfg(test)]
+use super::super::arguments::ProgramName;
+
+#[cfg(test)]
+pub(crate) fn render_missing_operands_stdout(program_name: ProgramName) -> String {
+    workflow::render_missing_operands_stdout(program_name)
+}
+
 pub(crate) fn with_output_writer<'a, Out, Err, R>(
     stdout: &'a mut Out,
     stderr: &'a mut MessageSink<Err>,

--- a/crates/cli/src/frontend/execution/drive/workflow/mod.rs
+++ b/crates/cli/src/frontend/execution/drive/workflow/mod.rs
@@ -6,6 +6,8 @@ mod preflight;
 
 use fallback_plan::{FallbackArgumentsContext, build_fallback_arguments};
 use operands::ensure_transfer_operands_present;
+#[cfg(test)]
+pub(crate) use operands::render_missing_operands_stdout;
 use preflight::{
     maybe_print_help_or_version, resolve_bind_address, resolve_desired_protocol, resolve_timeout,
     validate_feature_support, validate_stdin_sources_conflict,

--- a/crates/cli/src/frontend/execution/mod.rs
+++ b/crates/cli/src/frontend/execution/mod.rs
@@ -9,6 +9,8 @@ mod options;
 
 pub(super) use drive::execute;
 
+#[cfg(test)]
+use super::arguments::ProgramName;
 pub(crate) use chown::parse_chown_argument;
 pub(crate) use compression::{
     CompressLevelArg, parse_bandwidth_limit, parse_compress_level, parse_compress_level_argument,
@@ -33,3 +35,8 @@ pub(crate) use options::{
     parse_modify_window_argument, parse_protocol_version_arg, parse_size_limit_argument,
     parse_timeout_argument,
 };
+
+#[cfg(test)]
+pub(crate) fn render_missing_operands_stdout(program_name: ProgramName) -> String {
+    drive::render_missing_operands_stdout(program_name)
+}

--- a/crates/cli/src/frontend/tests/transfer_request_reports.rs
+++ b/crates/cli/src/frontend/tests/transfer_request_reports.rs
@@ -1,5 +1,6 @@
 use super::common::*;
 use super::*;
+use crate::frontend::execution::render_missing_operands_stdout;
 
 #[test]
 fn transfer_request_reports_missing_operands() {
@@ -7,11 +8,11 @@ fn transfer_request_reports_missing_operands() {
 
     assert_eq!(code, 1);
     let stdout_rendered = String::from_utf8(stdout).expect("usage banner utf8");
-    let expected_usage = format!("{}\n", clap_command(RSYNC).render_usage());
+    let expected_usage = render_missing_operands_stdout(ProgramName::Rsync);
     assert_eq!(stdout_rendered, expected_usage);
 
     let rendered = String::from_utf8(stderr).expect("diagnostic is valid UTF-8");
-    assert!(rendered.contains("missing source operands"));
+    assert!(rendered.contains("syntax or usage error"));
     assert_contains_client_trailer(&rendered);
 }
 


### PR DESCRIPTION
## Summary
- render the no-argument banner with the full version report and synopsis that upstream rsync prints
- reuse the shared renderer from integration tests to keep the missing-operand stdout deterministic
- update the CLI test harness to expect the canonical syntax-or-usage diagnostic

## Testing
- cargo check
- cargo test -p rsync-cli transfer_request_reports_missing_operands -- --nocapture

------