### PR TITLE
Improve fallback binary availability caching

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,11 +30,13 @@ This document defines the internal actors (“agents”), their responsibilities
   set `OC_RSYNC_FALLBACK` appropriately. Use the shared
   `rsync_core::fallback::fallback_binary_available` and
   `rsync_core::fallback::describe_missing_fallback_binary` helpers to keep the
-  guard rails consistent across binaries. The availability helper now caches
-  its result for each `(binary, PATH[, PATHEXT])` tuple to avoid repeated
-  filesystem scans; any updates must preserve this memoisation and ensure
-  tests adjust environment variables via the existing `EnvGuard` utilities so
-  cache entries stay coherent.
+  guard rails consistent across binaries. The availability helper memoises the
+  lookup for each `(binary, PATH[, PATHEXT])` tuple while storing the resolved
+  executable path so cached hits are revalidated when the file disappears, and
+  negative entries expire after a short TTL to pick up newly installed
+  binaries. Any updates must preserve this behaviour and ensure tests adjust
+  environment variables via the existing `EnvGuard` utilities so cache entries
+  stay coherent.
 - **Workspace-wide nextest configuration**: `.config/nextest.toml` pins
   `[profile.default.package] graph = "workspace"` so a bare
   `cargo nextest run` executes the entire workspace without additional flags.


### PR DESCRIPTION
## Summary
- rework the fallback binary availability cache to track the matched executable path and expire stale entries
- add a regression test that verifies the cache invalidates when the fallback executable disappears
- document the updated memoisation and invalidation behaviour in `internal docs`

## Testing
- cargo test -p rsync-core fallback_binary_available_detects_removal

------