### PR TITLE
Align protect/risk filter defaults with receiver semantics

### DIFF
--- a/crates/core/src/client/config/filters.rs
+++ b/crates/core/src/client/config/filters.rs
@@ -75,7 +75,7 @@ impl FilterRuleSpec {
             kind: FilterRuleKind::Protect,
             pattern: pattern.into(),
             dir_merge_options: None,
-            applies_to_sender: true,
+            applies_to_sender: false,
             applies_to_receiver: true,
         }
     }
@@ -87,7 +87,7 @@ impl FilterRuleSpec {
             kind: FilterRuleKind::Risk,
             pattern: pattern.into(),
             dir_merge_options: None,
-            applies_to_sender: true,
+            applies_to_sender: false,
             applies_to_receiver: true,
         }
     }
@@ -195,5 +195,34 @@ impl FilterRuleSpec {
         if let Some(receiver) = options.receiver_side_override() {
             self.applies_to_receiver = receiver;
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn protect_defaults_to_receiver_side_only() {
+        let rule = FilterRuleSpec::protect("keep");
+        assert!(!rule.applies_to_sender());
+        assert!(rule.applies_to_receiver());
+    }
+
+    #[test]
+    fn risk_defaults_to_receiver_side_only() {
+        let rule = FilterRuleSpec::risk("keep");
+        assert!(!rule.applies_to_sender());
+        assert!(rule.applies_to_receiver());
+    }
+
+    #[test]
+    fn dir_merge_sender_override_enables_sender_rules() {
+        let mut rule = FilterRuleSpec::protect("keep");
+        let options = DirMergeOptions::new().sender_modifier();
+        rule.apply_dir_merge_overrides(&options);
+
+        assert!(rule.applies_to_sender());
+        assert!(!rule.applies_to_receiver());
     }
 }

--- a/src/bin/daemon_wrapper.rs
+++ b/src/bin/daemon_wrapper.rs
@@ -34,11 +34,14 @@ mod tests {
 
     #[test]
     fn wrap_daemon_arguments_inserts_flag_and_preserves_rest() {
-        let wrapped = wrap_daemon_arguments([
-            OsString::from("oc-rsyncd"),
-            OsString::from("--config"),
-            OsString::from("/tmp/conf"),
-        ], "oc-rsyncd");
+        let wrapped = wrap_daemon_arguments(
+            [
+                OsString::from("oc-rsyncd"),
+                OsString::from("--config"),
+                OsString::from("/tmp/conf"),
+            ],
+            "oc-rsyncd",
+        );
 
         assert_eq!(wrapped[0], OsString::from("oc-rsyncd"));
         assert_eq!(wrapped[1], OsString::from("--daemon"));
@@ -49,6 +52,9 @@ mod tests {
     #[test]
     fn wrap_daemon_arguments_uses_fallback_when_empty() {
         let wrapped = wrap_daemon_arguments::<[OsString; 0], _>([], "rsyncd");
-        assert_eq!(wrapped, vec![OsString::from("rsyncd"), OsString::from("--daemon")]);
+        assert_eq!(
+            wrapped,
+            vec![OsString::from("rsyncd"), OsString::from("--daemon")]
+        );
     }
 }

--- a/src/bin/oc-rsyncd.rs
+++ b/src/bin/oc-rsyncd.rs
@@ -2,9 +2,9 @@
 
 #[path = "client.rs"]
 mod client;
-mod support;
 #[path = "daemon_wrapper.rs"]
 mod daemon_wrapper;
+mod support;
 
 use std::ffi::OsString;
 use std::io::Write;
@@ -31,4 +31,3 @@ where
     let forwarded = daemon_wrapper::wrap_daemon_arguments(args, Brand::Oc.daemon_program_name());
     client::run_with(forwarded, stdout, stderr)
 }
-

--- a/src/bin/rsyncd.rs
+++ b/src/bin/rsyncd.rs
@@ -2,9 +2,9 @@
 
 #[path = "client.rs"]
 mod client;
-mod support;
 #[path = "daemon_wrapper.rs"]
 mod daemon_wrapper;
+mod support;
 
 use std::ffi::OsString;
 use std::io::Write;
@@ -28,6 +28,7 @@ where
     Out: Write,
     Err: Write,
 {
-    let forwarded = daemon_wrapper::wrap_daemon_arguments(args, Brand::Upstream.daemon_program_name());
+    let forwarded =
+        daemon_wrapper::wrap_daemon_arguments(args, Brand::Upstream.daemon_program_name());
     client::run_with(forwarded, stdout, stderr)
 }


### PR DESCRIPTION
## Summary
- ensure `FilterRuleSpec::protect` and `FilterRuleSpec::risk` default to receiver-side applicability so protection only guards deletion passes
- add unit coverage confirming the new defaults and dir-merge sender overrides
- refresh rustfmt output for the daemon wrapper helpers to keep module ordering consistent

## Testing
- cargo test

------