### PR TITLE
Fix message scratch borrowing and brand propagation

### DIFF
--- a/crates/cli/src/frontend/execution/drive/messages.rs
+++ b/crates/cli/src/frontend/execution/drive/messages.rs
@@ -21,7 +21,8 @@ pub(super) fn fail_with_message<Err>(message: Message, stderr: &mut MessageSink<
 where
     Err: Write,
 {
-    let fallback = message.to_string();
+    let brand = stderr.brand();
+    let fallback = message.clone().with_brand(brand).to_string();
     emit_message_with_fallback(&message, &fallback, stderr);
     message.code().unwrap_or(1)
 }

--- a/crates/cli/src/frontend/mod.rs
+++ b/crates/cli/src/frontend/mod.rs
@@ -218,6 +218,9 @@ where
         args.push(OsString::from(ProgramName::Rsync.as_str()));
     }
 
+    let detected = detect_program_name(args.first().map(|arg| arg.as_os_str()));
+    let brand = detected.brand();
+
     if server::server_mode_requested(&args) {
         return server::run_server_mode(&args, stdout, stderr);
     }
@@ -226,7 +229,7 @@ where
         return server::run_daemon_mode(daemon_args, stdout, stderr);
     }
 
-    let mut stderr_sink = MessageSink::new(stderr);
+    let mut stderr_sink = MessageSink::with_brand(stderr, brand);
     match parse_args(args) {
         Ok(parsed) => execute(parsed, stdout, &mut stderr_sink),
         Err(error) => {

--- a/crates/core/src/branding/brand.rs
+++ b/crates/core/src/branding/brand.rs
@@ -30,7 +30,7 @@ use serde::ser::{Serialize, Serializer};
 /// [`OC_RSYNC_BRAND`][super::brand_override_env_var] to accept human-readable aliases.
 /// The parser tolerates ASCII case differences, leading/trailing whitespace, and
 /// versioned program names.
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum Brand {
     /// Upstream-compatible binaries (`rsync` and `rsyncd`).
     Upstream,

--- a/crates/core/src/message/message_impl/constructors.rs
+++ b/crates/core/src/message/message_impl/constructors.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
 use super::{Message, Severity};
-use crate::message::strings;
+use crate::{branding::Brand, message::strings};
 
 impl Message {
     /// Creates a message with the provided severity and payload.
@@ -22,6 +22,7 @@ impl Message {
             text: text.into(),
             role: None,
             source: None,
+            brand: Brand::Upstream,
         }
     }
 

--- a/crates/core/src/message/message_impl/mutators.rs
+++ b/crates/core/src/message/message_impl/mutators.rs
@@ -1,6 +1,7 @@
 use std::borrow::Cow;
 
 use super::{Message, Role, Severity, SourceLocation};
+use crate::branding::Brand;
 
 impl Message {
     /// Replaces the message payload with the provided text.
@@ -65,5 +66,20 @@ impl Message {
     pub fn without_code(mut self) -> Self {
         self.code = None;
         self
+    }
+
+    /// Applies a brand to the message, adjusting rendered prefixes accordingly.
+    #[inline]
+    #[must_use = "the updated message must be emitted to observe the applied brand"]
+    pub fn with_brand(mut self, brand: Brand) -> Self {
+        self.brand = brand;
+        self
+    }
+
+    /// Returns the brand associated with the message.
+    #[inline]
+    #[must_use]
+    pub const fn brand(&self) -> Brand {
+        self.brand
     }
 }

--- a/crates/core/src/message/scratch.rs
+++ b/crates/core/src/message/scratch.rs
@@ -32,6 +32,7 @@ use std::cell::RefCell;
 pub struct MessageScratch {
     pub(super) code_digits: [u8; 20],
     pub(super) line_digits: [u8; 20],
+    pub(super) prefix_buffer: [u8; 48],
 }
 
 impl MessageScratch {
@@ -42,7 +43,16 @@ impl MessageScratch {
         Self {
             code_digits: [0; 20],
             line_digits: [0; 20],
+            prefix_buffer: [0; 48],
         }
+    }
+
+    pub(super) fn prefix_buffer(&self) -> &[u8; 48] {
+        &self.prefix_buffer
+    }
+
+    pub(super) fn prefix_buffer_mut(&mut self) -> &mut [u8; 48] {
+        &mut self.prefix_buffer
     }
 
     /// Executes a closure with the thread-local scratch buffer.

--- a/crates/logging/src/sink/message_sink/accessors.rs
+++ b/crates/logging/src/sink/message_sink/accessors.rs
@@ -1,7 +1,7 @@
 use super::MessageSink;
-use crate::LineModeGuard;
 use crate::line_mode::LineMode;
-use rsync_core::message::MessageScratch;
+use crate::LineModeGuard;
+use rsync_core::{branding::Brand, message::MessageScratch};
 
 impl<W> MessageSink<W> {
     /// Returns a shared reference to the underlying writer.
@@ -85,5 +85,16 @@ impl<W> MessageSink<W> {
     /// between sinks that share a scratch instance.
     pub fn scratch_mut(&mut self) -> &mut MessageScratch {
         &mut self.scratch
+    }
+
+    /// Returns the brand used to render message prefixes.
+    #[must_use]
+    pub const fn brand(&self) -> Brand {
+        self.brand
+    }
+
+    /// Updates the brand used to render subsequent messages.
+    pub fn set_brand(&mut self, brand: Brand) {
+        self.brand = brand;
     }
 }

--- a/crates/logging/src/sink/message_sink/constructors.rs
+++ b/crates/logging/src/sink/message_sink/constructors.rs
@@ -1,18 +1,30 @@
 use super::MessageSink;
 use crate::line_mode::LineMode;
-use rsync_core::message::MessageScratch;
+use rsync_core::{branding::Brand, message::MessageScratch};
 
 impl<W> MessageSink<W> {
     /// Creates a new sink that appends a newline after each rendered message.
     #[must_use]
     pub fn new(writer: W) -> Self {
-        Self::with_line_mode(writer, LineMode::WithNewline)
+        Self::with_line_mode_and_brand(writer, LineMode::WithNewline, Brand::Upstream)
+    }
+
+    /// Creates a sink that appends a newline after each message while using `brand` when rendering.
+    #[must_use]
+    pub fn with_brand(writer: W, brand: Brand) -> Self {
+        Self::with_line_mode_and_brand(writer, LineMode::WithNewline, brand)
     }
 
     /// Creates a sink with the provided [`LineMode`].
     #[must_use]
     pub fn with_line_mode(writer: W, line_mode: LineMode) -> Self {
-        Self::with_parts(writer, MessageScratch::new(), line_mode)
+        Self::with_line_mode_and_brand(writer, line_mode, Brand::Upstream)
+    }
+
+    /// Creates a sink with the provided [`LineMode`] and [`Brand`].
+    #[must_use]
+    pub fn with_line_mode_and_brand(writer: W, line_mode: LineMode, brand: Brand) -> Self {
+        Self::with_parts_and_brand(writer, MessageScratch::new(), line_mode, brand)
     }
 
     /// Creates a sink from an explicit [`MessageScratch`] and [`LineMode`].
@@ -24,10 +36,22 @@ impl<W> MessageSink<W> {
     /// allocations.
     #[must_use]
     pub fn with_parts(writer: W, scratch: MessageScratch, line_mode: LineMode) -> Self {
+        Self::with_parts_and_brand(writer, scratch, line_mode, Brand::Upstream)
+    }
+
+    /// Creates a sink from explicit [`MessageScratch`], [`LineMode`], and [`Brand`].
+    #[must_use]
+    pub fn with_parts_and_brand(
+        writer: W,
+        scratch: MessageScratch,
+        line_mode: LineMode,
+        brand: Brand,
+    ) -> Self {
         Self {
             writer,
             scratch,
             line_mode,
+            brand,
         }
     }
 
@@ -43,8 +67,8 @@ impl<W> MessageSink<W> {
     /// [`MessageSink`] via [`with_parts`](Self::with_parts), avoiding repeated
     /// zeroing of scratch storage when logging contexts are recycled.
     #[must_use]
-    pub fn into_parts(self) -> (W, MessageScratch, LineMode) {
-        (self.writer, self.scratch, self.line_mode)
+    pub fn into_parts(self) -> (W, MessageScratch, LineMode, Brand) {
+        (self.writer, self.scratch, self.line_mode, self.brand)
     }
 }
 

--- a/crates/logging/src/sink/message_sink/mapping.rs
+++ b/crates/logging/src/sink/message_sink/mapping.rs
@@ -19,8 +19,9 @@ impl<W> MessageSink<W> {
             writer,
             scratch,
             line_mode,
+            brand,
         } = self;
-        MessageSink::with_parts(f(writer), scratch, line_mode)
+        MessageSink::with_parts_and_brand(f(writer), scratch, line_mode, brand)
     }
 
     /// Attempts to map the sink's writer into a different type, preserving the original sink on failure.
@@ -37,12 +38,15 @@ impl<W> MessageSink<W> {
             writer,
             scratch,
             line_mode,
+            brand,
         } = self;
 
         match f(writer) {
-            Ok(mapped) => Ok(MessageSink::with_parts(mapped, scratch, line_mode)),
+            Ok(mapped) => Ok(MessageSink::with_parts_and_brand(
+                mapped, scratch, line_mode, brand,
+            )),
             Err((writer, error)) => Err(TryMapWriterError::new(
-                MessageSink::with_parts(writer, scratch, line_mode),
+                MessageSink::with_parts_and_brand(writer, scratch, line_mode, brand),
                 error,
             )),
         }

--- a/crates/logging/src/sink/message_sink/mod.rs
+++ b/crates/logging/src/sink/message_sink/mod.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
 use crate::line_mode::LineMode;
-use rsync_core::message::MessageScratch;
+use rsync_core::{branding::Brand, message::MessageScratch};
 
 /// Streaming sink that renders [`rsync_core::message::Message`] values into an
 /// [`std::io::Write`] target.
@@ -52,7 +52,8 @@ use rsync_core::message::MessageScratch;
 ///
 /// let mut sink = MessageSink::with_parts(Vec::new(), MessageScratch::new(), LineMode::WithoutNewline);
 /// sink.write(Message::info("phase one"))?;
-/// let (writer, scratch, mode) = sink.into_parts();
+/// let (writer, scratch, mode, brand) = sink.into_parts();
+/// assert_eq!(brand, rsync_core::branding::Brand::Upstream);
 /// assert_eq!(mode, LineMode::WithoutNewline);
 ///
 /// let mut sink = MessageSink::with_parts(writer, scratch, LineMode::WithNewline);
@@ -67,6 +68,7 @@ pub struct MessageSink<W> {
     writer: W,
     scratch: MessageScratch,
     line_mode: LineMode,
+    brand: Brand,
 }
 
 mod accessors;
@@ -82,6 +84,7 @@ where
         f.debug_struct("MessageSink")
             .field("writer", &self.writer)
             .field("line_mode", &self.line_mode)
+            .field("brand", &self.brand)
             .finish()
     }
 }

--- a/crates/logging/src/sink/message_sink/writing.rs
+++ b/crates/logging/src/sink/message_sink/writing.rs
@@ -27,7 +27,8 @@ where
     where
         M: Borrow<Message>,
     {
-        self.render_message(message.borrow(), self.line_mode.append_newline())
+        let branded = message.borrow().clone().with_brand(self.brand);
+        self.render_message(&branded, self.line_mode.append_newline())
     }
 
     /// Writes `message` using an explicit [`LineMode`] without mutating the sink.
@@ -41,7 +42,8 @@ where
     where
         M: Borrow<Message>,
     {
-        self.render_message(message.borrow(), line_mode.append_newline())
+        let branded = message.borrow().clone().with_brand(self.brand);
+        self.render_message(&branded, line_mode.append_newline())
     }
 
     /// Streams pre-rendered [`MessageSegments`] into the underlying writer.
@@ -100,7 +102,8 @@ where
     {
         let append_newline = self.line_mode.append_newline();
         for message in messages {
-            self.render_message(message.borrow(), append_newline)?;
+            let branded = message.borrow().clone().with_brand(self.brand);
+            self.render_message(&branded, append_newline)?;
         }
         Ok(())
     }
@@ -119,7 +122,8 @@ where
     {
         let append_newline = line_mode.append_newline();
         for message in messages {
-            self.render_message(message.borrow(), append_newline)?;
+            let branded = message.borrow().clone().with_brand(self.brand);
+            self.render_message(&branded, append_newline)?;
         }
         Ok(())
     }

--- a/crates/logging/src/sink/tests.rs
+++ b/crates/logging/src/sink/tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::LineMode;
-use rsync_core::message::{Message, MessageScratch};
+use rsync_core::{branding::Brand, message::{Message, MessageScratch}};
 use std::io::{self, Cursor, Write};
 
 #[test]
@@ -443,8 +443,9 @@ fn into_parts_allows_reusing_scratch() {
         MessageSink::with_parts(Vec::new(), MessageScratch::new(), LineMode::WithoutNewline);
     sink.write(Message::info("first")).expect("write succeeds");
 
-    let (writer, scratch, mode) = sink.into_parts();
+    let (writer, scratch, mode, brand) = sink.into_parts();
     assert_eq!(mode, LineMode::WithoutNewline);
+    assert_eq!(brand, Brand::Upstream);
 
     let mut sink = MessageSink::with_parts(writer, scratch, LineMode::WithNewline);
     sink.write(Message::warning("second"))

--- a/src/bin/client.rs
+++ b/src/bin/client.rs
@@ -113,4 +113,29 @@ mod tests {
             "diagnostic should include the branded role trailer"
         );
     }
+
+    #[test]
+    fn oc_brand_reports_usage_with_branded_prefix() {
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+        let exit = run_with([OsString::from(OC_PROGRAM_NAME)], &mut stdout, &mut stderr);
+
+        assert_eq!(exit, ExitCode::FAILURE);
+
+        let stderr_text = String::from_utf8(stderr).expect("stderr is UTF-8");
+        assert!(
+            stderr_text.contains("oc-rsync error: syntax or usage error (code 1)"),
+            "oc-branded binary should render diagnostics using the oc-rsync prefix"
+        );
+        assert!(
+            stderr_text.contains("[client=3.4.1-rust]"),
+            "diagnostic should include the branded role trailer"
+        );
+
+        let stdout_text = String::from_utf8(stdout).expect("stdout is UTF-8");
+        assert!(
+            stdout_text.starts_with(&format!("{OC_PROGRAM_NAME}  version")),
+            "oc-branded binary should render usage banner with oc prefix"
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- refactor message rendering to avoid conflicting borrows while keeping scratch buffers reusable
- expose immutable access to the prefix scratch buffer and propagate brand metadata through message sinks
- brand daemon/server diagnostics by detecting the invoked program before parsing arguments

## Testing
- `cargo test`

------