### PR TITLE
Improve fallback executable permission checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,6 +190,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "clap"
 version = "4.5.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -524,6 +530,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -785,6 +803,7 @@ dependencies = [
  "base64",
  "filetime",
  "libc",
+ "nix",
  "rsync-bandwidth",
  "rsync-checksums",
  "rsync-compress",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -23,6 +23,7 @@ rsync-transport = { path = "../transport" }
 rsync-filters = { path = "../filters" }
 rsync-compress = { path = "../compress" }
 libc = "0.2"
+nix = { version = "0.29", default-features = false, features = ["user"] }
 base64 = "0.22"
 rsync-checksums = { path = "../checksums" }
 tempfile = "3.10"


### PR DESCRIPTION
## Summary
- ensure Unix fallback availability checks validate the current user's execute permissions instead of only testing mode bits
- add targeted unit tests covering owner, group, other, and root execution cases for the new helper
- reuse nix's safe user/group helpers to obtain effective ids and supplementary group memberships

## Testing
- cargo test -p rsync-core fallback_binary_available

------