### PR TITLE
feat: add portable sha256 helper for brew tooling

### DIFF
--- a/tools/compute_sha256.py
+++ b/tools/compute_sha256.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Utility helpers for computing SHA-256 digests.
+
+This module provides a small CLI used by packaging scripts to compute
+cryptographic checksums without depending on platform-specific shell utilities
+such as ``sha256sum``. The :func:`compute_sha256` helper is also imported by the
+unit tests under ``tools/tests`` so the implementation remains well exercised.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import sys
+from pathlib import Path
+from typing import Iterable
+
+# Default chunk size used while reading files from disk. The value strikes a
+# balance between minimising system calls and keeping memory usage modest even
+# when hashing large release archives.
+_DEFAULT_CHUNK_SIZE = 1 << 20  # 1 MiB
+
+
+def compute_sha256(path: Path, *, chunk_size: int = _DEFAULT_CHUNK_SIZE) -> str:
+    """Return the hexadecimal SHA-256 digest for ``path``.
+
+    Parameters
+    ----------
+    path:
+        The filesystem location of the file to hash.
+    chunk_size:
+        The number of bytes read per iteration while streaming the file.
+
+    Returns
+    -------
+    str
+        The lowercase hexadecimal SHA-256 digest.
+
+    Raises
+    ------
+    FileNotFoundError
+        If ``path`` does not exist or is not a regular file.
+    ValueError
+        If ``chunk_size`` is not a positive integer.
+    OSError
+        Propagated for underlying I/O errors encountered while reading the
+        file.
+    """
+
+    if chunk_size <= 0:
+        raise ValueError("chunk_size must be a positive integer")
+
+    if not path.is_file():
+        raise FileNotFoundError(path)
+
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while True:
+            data = handle.read(chunk_size)
+            if not data:
+                break
+            digest.update(data)
+    return digest.hexdigest()
+
+
+def _positive_int(value: str) -> int:
+    number = int(value, 10)
+    if number <= 0:
+        raise argparse.ArgumentTypeError("chunk size must be a positive integer")
+    return number
+
+
+def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
+    """Parse CLI arguments for the checksum helper."""
+
+    parser = argparse.ArgumentParser(
+        description=(
+            "Compute the SHA-256 digest for a file without relying on platform-"
+            "specific utilities."
+        )
+    )
+    parser.add_argument("path", type=Path, help="Path to the file to hash")
+    parser.add_argument(
+        "--chunk-size",
+        type=_positive_int,
+        default=_DEFAULT_CHUNK_SIZE,
+        metavar="BYTES",
+        help="Read BYTES per iteration while hashing (default: %(default)s)",
+    )
+    return parser.parse_args(list(argv) if argv is not None else None)
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    """Entry point used by ``__main__`` and shell scripts."""
+
+    try:
+        options = parse_args(argv)
+        digest = compute_sha256(options.path, chunk_size=options.chunk_size)
+    except FileNotFoundError as error:
+        print(f"error: file not found: {error}", file=sys.stderr)
+        return 1
+    except ValueError as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+    except OSError as error:
+        print(f"error: failed to read {error.filename}: {error.strerror}", file=sys.stderr)
+        return 1
+
+    print(digest)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/test_compute_sha256.py
+++ b/tools/tests/test_compute_sha256.py
@@ -1,0 +1,67 @@
+"""Unit tests for the SHA-256 helper script used by packaging automation."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from tools.compute_sha256 import compute_sha256
+
+
+class ComputeSha256Tests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tempdir = tempfile.TemporaryDirectory()
+        self.temp_path = Path(self._tempdir.name)
+
+    def tearDown(self) -> None:
+        self._tempdir.cleanup()
+
+    def _write_file(self, name: str, data: bytes) -> Path:
+        path = self.temp_path / name
+        path.write_bytes(data)
+        return path
+
+    def test_compute_sha256_matches_hashlib_for_random_payload(self) -> None:
+        payload = os.urandom(4096)
+        path = self._write_file("payload.bin", payload)
+        expected = hashlib.sha256(payload).hexdigest()
+        self.assertEqual(expected, compute_sha256(path))
+
+    def test_compute_sha256_supports_empty_files(self) -> None:
+        path = self._write_file("empty.bin", b"")
+        self.assertEqual(hashlib.sha256(b"").hexdigest(), compute_sha256(path))
+
+    def test_compute_sha256_rejects_missing_file(self) -> None:
+        missing = self.temp_path / "missing.bin"
+        with self.assertRaises(FileNotFoundError):
+            compute_sha256(missing)
+
+    def test_compute_sha256_rejects_invalid_chunk_size(self) -> None:
+        path = self._write_file("small.bin", b"test-data")
+        with self.assertRaises(ValueError):
+            compute_sha256(path, chunk_size=0)
+
+    def test_cli_outputs_digest(self) -> None:
+        payload = b"cli-digest-check"
+        path = self._write_file("cli.bin", payload)
+        expected = hashlib.sha256(payload).hexdigest()
+
+        result = subprocess.run(
+            [sys.executable, str(Path("tools/compute_sha256.py").resolve()), str(path)],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+
+        self.assertEqual("", result.stderr)
+        self.assertEqual(f"{expected}\n", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/update-brew-formula.sh
+++ b/tools/update-brew-formula.sh
@@ -139,7 +139,10 @@ if ! curl -fsSL "${TARBALL_URL}" -o "${TARBALL_PATH}"; then
   echo "[ERROR] Failed to download ${TARBALL_URL}. Ensure the tag exists and is publicly accessible." >&2
   exit 1
 fi
-TARBALL_SHA256=$(sha256sum "${TARBALL_PATH}" | awk '{print $1}')
+if ! TARBALL_SHA256=$(python3 "${SCRIPT_DIR}/compute_sha256.py" "${TARBALL_PATH}"); then
+  echo "[ERROR] Failed to compute sha256 for ${TARBALL_PATH}" >&2
+  exit 1
+fi
 
 if [[ -z "${TARBALL_SHA256}" ]]; then
   echo "[ERROR] Failed to compute sha256 for ${TARBALL_PATH}" >&2


### PR DESCRIPTION
## Summary
- add a Python helper that computes release tarball SHA-256 digests without relying on platform-specific utilities
- update the Homebrew formula updater to use the new helper
- cover the helper with unit tests to validate hashing behaviour and CLI output

## Testing
- python -m pytest tools/tests/test_compute_sha256.py

------