### PR TITLE
test(cli): assert usage diagnostics without operands

### DIFF
--- a/crates/cli/src/frontend/tests/run.rs
+++ b/crates/cli/src/frontend/tests/run.rs
@@ -22,3 +22,37 @@ fn run_reports_invalid_chmod_specification() {
     let rendered = String::from_utf8(stderr).expect("diagnostic utf8");
     assert!(rendered.contains("failed to parse --chmod specification"));
 }
+
+#[test]
+fn run_without_operands_emits_usage_for_oc_rsync() {
+    let (code, stdout, stderr) = run_with_args([OsString::from(OC_RSYNC)]);
+
+    assert_eq!(code, 1);
+
+    let stdout_text = String::from_utf8(stdout).expect("stdout utf8");
+    assert_eq!(
+        stdout_text,
+        render_missing_operands_stdout(ProgramName::OcRsync)
+    );
+
+    let stderr_text = String::from_utf8(stderr).expect("stderr utf8");
+    assert!(stderr_text.contains("syntax or usage error"));
+    assert_contains_client_trailer(&stderr_text);
+}
+
+#[test]
+fn run_without_operands_emits_usage_for_legacy_rsync() {
+    let (code, stdout, stderr) = run_with_args([OsString::from(RSYNC)]);
+
+    assert_eq!(code, 1);
+
+    let stdout_text = String::from_utf8(stdout).expect("stdout utf8");
+    assert_eq!(
+        stdout_text,
+        render_missing_operands_stdout(ProgramName::Rsync)
+    );
+
+    let stderr_text = String::from_utf8(stderr).expect("stderr utf8");
+    assert!(stderr_text.contains("syntax or usage error"));
+    assert_contains_client_trailer(&stderr_text);
+}


### PR DESCRIPTION
## Summary
- add regression coverage ensuring oc-rsync reports the branded usage banner when no operands are provided
- mirror the same check for the legacy rsync compatibility entry point

## Testing
- cargo test --package rsync-cli run_without_operands_emits_usage_for_

------