### PR TITLE
Support width and humanized formatting in --out-format renderer

### DIFF
--- a/crates/cli/src/frontend/out_format/parser.rs
+++ b/crates/cli/src/frontend/out_format/parser.rs
@@ -3,11 +3,64 @@
 //! Parser for command-line supplied `--out-format` specifications.
 
 use std::ffi::OsStr;
+use std::iter::Peekable;
+use std::str::Chars;
 
 use rsync_core::message::{Message, Role};
 use rsync_core::rsync_error;
 
-use super::tokens::{OutFormat, OutFormatPlaceholder, OutFormatToken};
+use super::tokens::{
+    HumanizeMode, MAX_PLACEHOLDER_WIDTH, OutFormat, OutFormatPlaceholder, OutFormatToken,
+    PlaceholderAlignment, PlaceholderFormat, PlaceholderToken,
+};
+
+fn parse_placeholder_format(chars: &mut Peekable<Chars<'_>>) -> PlaceholderFormat {
+    let mut apostrophes = 0usize;
+    while matches!(chars.peek(), Some('\'')) {
+        apostrophes += 1;
+        chars.next();
+    }
+
+    let mut align = PlaceholderAlignment::Right;
+    if matches!(chars.peek(), Some('-')) {
+        align = PlaceholderAlignment::Left;
+        chars.next();
+    }
+
+    let mut width_value: usize = 0;
+    let mut saw_width = false;
+    while let Some(peeked) = chars.peek().copied() {
+        if let Some(digit) = peeked.to_digit(10) {
+            saw_width = true;
+            width_value = width_value
+                .saturating_mul(10)
+                .saturating_add(digit as usize);
+            chars.next();
+        } else {
+            break;
+        }
+    }
+
+    while matches!(chars.peek(), Some('\'')) {
+        apostrophes += 1;
+        chars.next();
+    }
+
+    let width = if saw_width {
+        Some(width_value.min(MAX_PLACEHOLDER_WIDTH))
+    } else {
+        None
+    };
+
+    let humanize = match apostrophes {
+        0 => HumanizeMode::None,
+        1 => HumanizeMode::Separator,
+        2 => HumanizeMode::DecimalUnits,
+        _ => HumanizeMode::BinaryUnits,
+    };
+
+    PlaceholderFormat::new(width, align, humanize)
+}
 
 /// Parses a command-line supplied `--out-format` specification into tokens.
 pub(crate) fn parse_out_format(value: &OsStr) -> Result<OutFormat, Message> {
@@ -18,187 +71,66 @@ pub(crate) fn parse_out_format(value: &OsStr) -> Result<OutFormat, Message> {
 
     let mut tokens = Vec::new();
     let mut literal = String::new();
-    let mut chars = text.chars();
+    let mut chars = text.chars().peekable();
+
     while let Some(ch) = chars.next() {
-        match ch {
-            '%' => {
-                let Some(next) = chars.next() else {
-                    return Err(rsync_error!(1, "--out-format value may not end with '%'")
-                        .with_role(Role::Client));
-                };
-                match next {
-                    '%' => literal.push('%'),
-                    'n' => {
-                        if !literal.is_empty() {
-                            tokens.push(OutFormatToken::Literal(std::mem::take(&mut literal)));
-                        }
-                        tokens.push(OutFormatToken::Placeholder(OutFormatPlaceholder::FileName));
-                    }
-                    'N' => {
-                        if !literal.is_empty() {
-                            tokens.push(OutFormatToken::Literal(std::mem::take(&mut literal)));
-                        }
-                        tokens.push(OutFormatToken::Placeholder(
-                            OutFormatPlaceholder::FileNameWithSymlinkTarget,
-                        ));
-                    }
-                    'f' => {
-                        if !literal.is_empty() {
-                            tokens.push(OutFormatToken::Literal(std::mem::take(&mut literal)));
-                        }
-                        tokens.push(OutFormatToken::Placeholder(OutFormatPlaceholder::FullPath));
-                    }
-                    'i' => {
-                        if !literal.is_empty() {
-                            tokens.push(OutFormatToken::Literal(std::mem::take(&mut literal)));
-                        }
-                        tokens.push(OutFormatToken::Placeholder(
-                            OutFormatPlaceholder::ItemizedChanges,
-                        ));
-                    }
-                    'l' => {
-                        if !literal.is_empty() {
-                            tokens.push(OutFormatToken::Literal(std::mem::take(&mut literal)));
-                        }
-                        tokens.push(OutFormatToken::Placeholder(
-                            OutFormatPlaceholder::FileLength,
-                        ));
-                    }
-                    'b' => {
-                        if !literal.is_empty() {
-                            tokens.push(OutFormatToken::Literal(std::mem::take(&mut literal)));
-                        }
-                        tokens.push(OutFormatToken::Placeholder(
-                            OutFormatPlaceholder::BytesTransferred,
-                        ));
-                    }
-                    'c' => {
-                        if !literal.is_empty() {
-                            tokens.push(OutFormatToken::Literal(std::mem::take(&mut literal)));
-                        }
-                        tokens.push(OutFormatToken::Placeholder(
-                            OutFormatPlaceholder::ChecksumBytes,
-                        ));
-                    }
-                    'o' => {
-                        if !literal.is_empty() {
-                            tokens.push(OutFormatToken::Literal(std::mem::take(&mut literal)));
-                        }
-                        tokens.push(OutFormatToken::Placeholder(OutFormatPlaceholder::Operation));
-                    }
-                    'M' => {
-                        if !literal.is_empty() {
-                            tokens.push(OutFormatToken::Literal(std::mem::take(&mut literal)));
-                        }
-                        tokens.push(OutFormatToken::Placeholder(
-                            OutFormatPlaceholder::ModifyTime,
-                        ));
-                    }
-                    'B' => {
-                        if !literal.is_empty() {
-                            tokens.push(OutFormatToken::Literal(std::mem::take(&mut literal)));
-                        }
-                        tokens.push(OutFormatToken::Placeholder(
-                            OutFormatPlaceholder::PermissionString,
-                        ));
-                    }
-                    'L' => {
-                        if !literal.is_empty() {
-                            tokens.push(OutFormatToken::Literal(std::mem::take(&mut literal)));
-                        }
-                        tokens.push(OutFormatToken::Placeholder(
-                            OutFormatPlaceholder::SymlinkTarget,
-                        ));
-                    }
-                    't' => {
-                        if !literal.is_empty() {
-                            tokens.push(OutFormatToken::Literal(std::mem::take(&mut literal)));
-                        }
-                        tokens.push(OutFormatToken::Placeholder(
-                            OutFormatPlaceholder::CurrentTime,
-                        ));
-                    }
-                    'u' => {
-                        if !literal.is_empty() {
-                            tokens.push(OutFormatToken::Literal(std::mem::take(&mut literal)));
-                        }
-                        tokens.push(OutFormatToken::Placeholder(OutFormatPlaceholder::OwnerName));
-                    }
-                    'g' => {
-                        if !literal.is_empty() {
-                            tokens.push(OutFormatToken::Literal(std::mem::take(&mut literal)));
-                        }
-                        tokens.push(OutFormatToken::Placeholder(OutFormatPlaceholder::GroupName));
-                    }
-                    'U' => {
-                        if !literal.is_empty() {
-                            tokens.push(OutFormatToken::Literal(std::mem::take(&mut literal)));
-                        }
-                        tokens.push(OutFormatToken::Placeholder(OutFormatPlaceholder::OwnerUid));
-                    }
-                    'G' => {
-                        if !literal.is_empty() {
-                            tokens.push(OutFormatToken::Literal(std::mem::take(&mut literal)));
-                        }
-                        tokens.push(OutFormatToken::Placeholder(OutFormatPlaceholder::OwnerGid));
-                    }
-                    'p' => {
-                        if !literal.is_empty() {
-                            tokens.push(OutFormatToken::Literal(std::mem::take(&mut literal)));
-                        }
-                        tokens.push(OutFormatToken::Placeholder(OutFormatPlaceholder::ProcessId));
-                    }
-                    'h' => {
-                        if !literal.is_empty() {
-                            tokens.push(OutFormatToken::Literal(std::mem::take(&mut literal)));
-                        }
-                        tokens.push(OutFormatToken::Placeholder(
-                            OutFormatPlaceholder::RemoteHost,
-                        ));
-                    }
-                    'a' => {
-                        if !literal.is_empty() {
-                            tokens.push(OutFormatToken::Literal(std::mem::take(&mut literal)));
-                        }
-                        tokens.push(OutFormatToken::Placeholder(
-                            OutFormatPlaceholder::RemoteAddress,
-                        ));
-                    }
-                    'm' => {
-                        if !literal.is_empty() {
-                            tokens.push(OutFormatToken::Literal(std::mem::take(&mut literal)));
-                        }
-                        tokens.push(OutFormatToken::Placeholder(
-                            OutFormatPlaceholder::ModuleName,
-                        ));
-                    }
-                    'P' => {
-                        if !literal.is_empty() {
-                            tokens.push(OutFormatToken::Literal(std::mem::take(&mut literal)));
-                        }
-                        tokens.push(OutFormatToken::Placeholder(
-                            OutFormatPlaceholder::ModulePath,
-                        ));
-                    }
-                    'C' => {
-                        if !literal.is_empty() {
-                            tokens.push(OutFormatToken::Literal(std::mem::take(&mut literal)));
-                        }
-                        tokens.push(OutFormatToken::Placeholder(
-                            OutFormatPlaceholder::FullChecksum,
-                        ));
-                    }
-                    other => {
-                        return Err(rsync_error!(
-                            1,
-                            format!("unsupported --out-format placeholder '%{other}'"),
-                        )
-                        .with_role(Role::Client));
-                    }
-                }
-            }
-            _ => literal.push(ch),
+        if ch != '%' {
+            literal.push(ch);
+            continue;
         }
+
+        let format_spec = parse_placeholder_format(&mut chars);
+        let Some(next) = chars.next() else {
+            return Err(
+                rsync_error!(1, "--out-format value may not end with '%'").with_role(Role::Client)
+            );
+        };
+
+        if next == '%' {
+            literal.push('%');
+            continue;
+        }
+
+        if !literal.is_empty() {
+            tokens.push(OutFormatToken::Literal(std::mem::take(&mut literal)));
+        }
+
+        let placeholder = match next {
+            'n' => OutFormatPlaceholder::FileName,
+            'N' => OutFormatPlaceholder::FileNameWithSymlinkTarget,
+            'f' => OutFormatPlaceholder::FullPath,
+            'i' => OutFormatPlaceholder::ItemizedChanges,
+            'l' => OutFormatPlaceholder::FileLength,
+            'b' => OutFormatPlaceholder::BytesTransferred,
+            'c' => OutFormatPlaceholder::ChecksumBytes,
+            'o' => OutFormatPlaceholder::Operation,
+            'M' => OutFormatPlaceholder::ModifyTime,
+            'B' => OutFormatPlaceholder::PermissionString,
+            'L' => OutFormatPlaceholder::SymlinkTarget,
+            't' => OutFormatPlaceholder::CurrentTime,
+            'u' => OutFormatPlaceholder::OwnerName,
+            'g' => OutFormatPlaceholder::GroupName,
+            'U' => OutFormatPlaceholder::OwnerUid,
+            'G' => OutFormatPlaceholder::OwnerGid,
+            'p' => OutFormatPlaceholder::ProcessId,
+            'h' => OutFormatPlaceholder::RemoteHost,
+            'a' => OutFormatPlaceholder::RemoteAddress,
+            'm' => OutFormatPlaceholder::ModuleName,
+            'P' => OutFormatPlaceholder::ModulePath,
+            'C' => OutFormatPlaceholder::FullChecksum,
+            other => {
+                return Err(rsync_error!(
+                    1,
+                    format!("unsupported --out-format placeholder '%{other}'"),
+                )
+                .with_role(Role::Client));
+            }
+        };
+
+        tokens.push(OutFormatToken::Placeholder(PlaceholderToken::new(
+            placeholder,
+            format_spec,
+        )));
     }
 
     if !literal.is_empty() {

--- a/crates/cli/src/frontend/out_format/tokens.rs
+++ b/crates/cli/src/frontend/out_format/tokens.rs
@@ -2,6 +2,9 @@
 
 //! Token definitions backing `--out-format` parsing and rendering.
 
+/// Maximum width accepted for placeholder formatting.
+pub(super) const MAX_PLACEHOLDER_WIDTH: usize = 4096;
+
 /// Parsed representation of an `--out-format` specification.
 #[derive(Clone, Debug)]
 pub(crate) struct OutFormat {
@@ -29,9 +32,26 @@ impl OutFormat {
 #[derive(Clone, Debug)]
 pub(super) enum OutFormatToken {
     Literal(String),
-    Placeholder(OutFormatPlaceholder),
+    Placeholder(PlaceholderToken),
 }
 
+/// Parsed placeholder together with formatting metadata.
+#[derive(Clone, Copy, Debug)]
+pub(super) struct PlaceholderToken {
+    /// Kind of placeholder rendered by the format specification.
+    pub(super) kind: OutFormatPlaceholder,
+    /// Formatting controls applied to the rendered value.
+    pub(super) format: PlaceholderFormat,
+}
+
+impl PlaceholderToken {
+    /// Creates a new [`PlaceholderToken`] from the supplied components.
+    pub(super) const fn new(kind: OutFormatPlaceholder, format: PlaceholderFormat) -> Self {
+        Self { kind, format }
+    }
+}
+
+/// Placeholder kinds supported by `--out-format`.
 #[derive(Clone, Copy, Debug)]
 pub(super) enum OutFormatPlaceholder {
     FileName,
@@ -56,6 +76,71 @@ pub(super) enum OutFormatPlaceholder {
     ModuleName,
     ModulePath,
     FullChecksum,
+}
+
+/// Formatting controls associated with a placeholder.
+#[derive(Clone, Copy, Debug)]
+pub(super) struct PlaceholderFormat {
+    width: Option<usize>,
+    align: PlaceholderAlignment,
+    humanize: HumanizeMode,
+}
+
+impl PlaceholderFormat {
+    /// Constructs a [`PlaceholderFormat`] from its individual components.
+    pub(super) const fn new(
+        width: Option<usize>,
+        align: PlaceholderAlignment,
+        humanize: HumanizeMode,
+    ) -> Self {
+        Self {
+            width,
+            align,
+            humanize,
+        }
+    }
+
+    /// Returns the configured width, when provided.
+    #[must_use]
+    pub(super) const fn width(&self) -> Option<usize> {
+        self.width
+    }
+
+    /// Reports whether the rendered value should be left-aligned.
+    #[must_use]
+    pub(super) const fn align(&self) -> PlaceholderAlignment {
+        self.align
+    }
+
+    /// Returns the humanisation strategy associated with the placeholder.
+    #[must_use]
+    pub(super) const fn humanize(&self) -> HumanizeMode {
+        self.humanize
+    }
+}
+
+/// Alignment applied to width-constrained placeholders.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(super) enum PlaceholderAlignment {
+    /// Right-align the rendered value (default).
+    #[default]
+    Right,
+    /// Left-align the rendered value.
+    Left,
+}
+
+/// Human-readable formatting applied to numeric placeholders.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(super) enum HumanizeMode {
+    /// Render the value without any additional formatting.
+    #[default]
+    None,
+    /// Insert locale-style thousands separators.
+    Separator,
+    /// Render the value using decimal (base-1000) units.
+    DecimalUnits,
+    /// Render the value using binary (base-1024) units.
+    BinaryUnits,
 }
 
 /// Context values used when rendering `--out-format` placeholders.


### PR DESCRIPTION
## Summary
- expose the shared placeholder width limit to both the parser and renderer
- honor width, alignment, and humanization metadata when rendering `--out-format` placeholders
- add regression coverage for padding and humanized numeric formats

## Testing
- cargo test -p rsync-cli out_format_respects_width_alignment_and_humanization_controls

------