### PR TITLE
Align version report capabilities with implemented features

### DIFF
--- a/crates/core/src/version/report/config.rs
+++ b/crates/core/src/version/report/config.rs
@@ -71,7 +71,7 @@ impl VersionInfoConfig {
             supports_atimes: true,
             supports_batchfiles: false,
             supports_inplace: true,
-            supports_append: false,
+            supports_append: true,
             supports_acls: cfg!(feature = "acl"),
             supports_xattrs: cfg!(feature = "xattr"),
             secluded_args_mode: SecludedArgsMode::Optional,

--- a/crates/core/src/version/report/renderer.rs
+++ b/crates/core/src/version/report/renderer.rs
@@ -331,6 +331,7 @@ pub(crate) fn default_checksum_algorithms() -> Vec<Cow<'static, str>> {
         Cow::Borrowed("xxh128"),
         Cow::Borrowed("xxh3"),
         Cow::Borrowed("xxh64"),
+        Cow::Borrowed("(xxhash)"),
         Cow::Borrowed("md5"),
         Cow::Borrowed("md4"),
         Cow::Borrowed("sha1"),


### PR DESCRIPTION
## Summary
- advertise append support in the version info configuration so the capability list reflects the existing append/append-verify flows
- include the `(xxhash)` marker in the checksum list to match upstream rsync's version banner formatting

## Testing
- cargo test

------