### PR TITLE
Report socketpair support in version output

### DIFF
--- a/crates/core/src/version/tests/report.rs
+++ b/crates/core/src/version/tests/report.rs
@@ -128,6 +128,21 @@ fn version_info_report_for_daemon_brand_matches_builder() {
 }
 
 #[test]
+fn runtime_capabilities_reflect_socketpair_support() {
+    let config = VersionInfoConfig::with_runtime_capabilities();
+
+    #[cfg(unix)]
+    {
+        assert!(config.supports_socketpairs);
+    }
+
+    #[cfg(not(unix))]
+    {
+        assert!(!config.supports_socketpairs);
+    }
+}
+
+#[test]
 fn version_info_report_for_brand_with_config_matches_builder() {
     let config = VersionInfoConfig {
         supports_ipv6: false,


### PR DESCRIPTION
## Summary
- detect socketpair availability at runtime so the version report advertises socketpair support when available
- add regression coverage to ensure the runtime configuration reflects socketpair detection

## Testing
- cargo test -p rsync-core version::tests::report

------