### PR TITLE
Preserve hard links for special file copies

### DIFF
--- a/crates/core/src/version/report/config.rs
+++ b/crates/core/src/version/report/config.rs
@@ -69,7 +69,7 @@ impl VersionInfoConfig {
             supports_symlinks: cfg!(unix),
             supports_symtimes: cfg!(unix),
             supports_hardlinks: cfg!(unix),
-            supports_hardlink_specials: false,
+            supports_hardlink_specials: cfg!(unix),
             supports_hardlink_symlinks: false,
             supports_ipv6: true,
             supports_atimes: true,


### PR DESCRIPTION
## Summary
- reuse previously copied hard link targets when recreating FIFOs and device nodes so duplicates become hard links instead of standalone copies
- record these special-file hard links in the transfer summary and advertise hardlink-specials support in the version report
- add a regression test that verifies FIFO hard links survive local copy execution

## Testing
- `cargo test -p rsync-engine execute_preserves_fifo_hard_links`
- `cargo test -p rsync-core version_info_config_builder_supports_chaining`

------