### PR TITLE
Add multi-digest daemon authentication support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -782,6 +782,7 @@ dependencies = [
  "md4",
  "proptest",
  "sha1",
+ "sha2",
  "xxhash-rust",
 ]
 
@@ -1057,6 +1058,17 @@ name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",

--- a/crates/checksums/Cargo.toml
+++ b/crates/checksums/Cargo.toml
@@ -15,6 +15,7 @@ md4 = { version = "0.10", default-features = false, features = ["std"] }
 md-5 = { version = "0.10", default-features = false, features = ["std"] }
 digest = { version = "0.10", default-features = false, features = ["std"] }
 sha1 = { version = "0.10", default-features = false, features = ["std"] }
+sha2 = { version = "0.10", default-features = false, features = ["std"] }
 xxhash-rust = { version = "0.8", default-features = false, features = ["xxh64", "xxh3"] }
 
 [dev-dependencies]

--- a/crates/checksums/src/strong/mod.rs
+++ b/crates/checksums/src/strong/mod.rs
@@ -8,11 +8,15 @@
 mod md4;
 mod md5;
 mod sha1;
+mod sha256;
+mod sha512;
 mod xxhash;
 
 pub use md4::Md4;
 pub use md5::Md5;
 pub use sha1::Sha1;
+pub use sha256::Sha256;
+pub use sha512::Sha512;
 pub use xxhash::{Xxh3, Xxh3_128, Xxh64};
 
 /// Trait implemented by strong checksum algorithms used by rsync.
@@ -76,7 +80,7 @@ pub trait StrongDigest: Sized {
 
 #[cfg(test)]
 mod tests {
-    use super::{Md4, Md5, Sha1, StrongDigest, Xxh3, Xxh3_128, Xxh64};
+    use super::{Md4, Md5, Sha1, Sha256, Sha512, StrongDigest, Xxh3, Xxh3_128, Xxh64};
 
     #[test]
     fn md5_trait_round_trip_matches_inherent_api() {
@@ -148,5 +152,27 @@ mod tests {
         let trait_digest = via_trait.finalize();
 
         assert_eq!(trait_digest.as_ref(), Sha1::digest(input).as_ref());
+    }
+
+    #[test]
+    fn sha256_trait_matches_inherent_api() {
+        let input = b"sha256-check";
+
+        let mut via_trait = Sha256::new();
+        via_trait.update(input);
+        let trait_digest = via_trait.finalize();
+
+        assert_eq!(trait_digest.as_ref(), Sha256::digest(input).as_ref());
+    }
+
+    #[test]
+    fn sha512_trait_matches_inherent_api() {
+        let input = b"sha512-check";
+
+        let mut via_trait = Sha512::new();
+        via_trait.update(input);
+        let trait_digest = via_trait.finalize();
+
+        assert_eq!(trait_digest.as_ref(), Sha512::digest(input).as_ref());
     }
 }

--- a/crates/checksums/src/strong/sha256.rs
+++ b/crates/checksums/src/strong/sha256.rs
@@ -1,0 +1,105 @@
+use digest::Digest;
+
+use super::StrongDigest;
+
+/// Streaming SHA-256 hasher used by rsync when peers negotiate stronger daemon authentication digests.
+#[derive(Clone, Debug)]
+pub struct Sha256 {
+    inner: sha2::Sha256,
+}
+
+impl Default for Sha256 {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Sha256 {
+    /// Creates a hasher with an empty state.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            inner: sha2::Sha256::new(),
+        }
+    }
+
+    /// Feeds additional bytes into the digest state.
+    pub fn update(&mut self, data: &[u8]) {
+        self.inner.update(data);
+    }
+
+    /// Finalises the digest and returns the 256-bit SHA-256 output.
+    #[must_use]
+    pub fn finalize(self) -> [u8; 32] {
+        self.inner.finalize().into()
+    }
+
+    /// Convenience helper that computes the SHA-256 digest for `data` in one shot.
+    #[must_use]
+    pub fn digest(data: &[u8]) -> [u8; 32] {
+        <Self as StrongDigest>::digest(data)
+    }
+}
+
+impl StrongDigest for Sha256 {
+    type Seed = ();
+    type Digest = [u8; 32];
+    const DIGEST_LEN: usize = 32;
+
+    fn with_seed((): Self::Seed) -> Self {
+        Sha256::new()
+    }
+
+    fn update(&mut self, data: &[u8]) {
+        self.inner.update(data);
+    }
+
+    fn finalize(self) -> Self::Digest {
+        self.inner.finalize().into()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn to_hex(bytes: &[u8]) -> String {
+        use std::fmt::Write as _;
+
+        let mut out = String::with_capacity(bytes.len() * 2);
+        for byte in bytes {
+            write!(&mut out, "{byte:02x}").expect("write! to String cannot fail");
+        }
+        out
+    }
+
+    #[test]
+    fn sha256_streaming_matches_rfc_vectors() {
+        let vectors = [
+            (
+                b"".as_slice(),
+                "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            ),
+            (
+                b"abc".as_slice(),
+                "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+            ),
+            (
+                b"message digest".as_slice(),
+                "f7846f55cf23e14eebeab5b4e1550cad5b509e3348fbc4efa3a1413d393cb650",
+            ),
+        ];
+
+        for (input, expected_hex) in vectors {
+            let mut hasher = Sha256::new();
+            let mid = input.len() / 2;
+            hasher.update(&input[..mid]);
+            hasher.update(&input[mid..]);
+            let digest = hasher.finalize();
+            assert_eq!(to_hex(&digest), expected_hex);
+
+            let one_shot = Sha256::digest(input);
+            assert_eq!(to_hex(&one_shot), expected_hex);
+        }
+    }
+}

--- a/crates/checksums/src/strong/sha512.rs
+++ b/crates/checksums/src/strong/sha512.rs
@@ -1,0 +1,105 @@
+use digest::Digest;
+
+use super::StrongDigest;
+
+/// Streaming SHA-512 hasher used by rsync when peers negotiate the strongest daemon authentication digest.
+#[derive(Clone, Debug)]
+pub struct Sha512 {
+    inner: sha2::Sha512,
+}
+
+impl Default for Sha512 {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Sha512 {
+    /// Creates a hasher with an empty state.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            inner: sha2::Sha512::new(),
+        }
+    }
+
+    /// Feeds additional bytes into the digest state.
+    pub fn update(&mut self, data: &[u8]) {
+        self.inner.update(data);
+    }
+
+    /// Finalises the digest and returns the 512-bit SHA-512 output.
+    #[must_use]
+    pub fn finalize(self) -> [u8; 64] {
+        self.inner.finalize().into()
+    }
+
+    /// Convenience helper that computes the SHA-512 digest for `data` in one shot.
+    #[must_use]
+    pub fn digest(data: &[u8]) -> [u8; 64] {
+        <Self as StrongDigest>::digest(data)
+    }
+}
+
+impl StrongDigest for Sha512 {
+    type Seed = ();
+    type Digest = [u8; 64];
+    const DIGEST_LEN: usize = 64;
+
+    fn with_seed((): Self::Seed) -> Self {
+        Sha512::new()
+    }
+
+    fn update(&mut self, data: &[u8]) {
+        self.inner.update(data);
+    }
+
+    fn finalize(self) -> Self::Digest {
+        self.inner.finalize().into()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn to_hex(bytes: &[u8]) -> String {
+        use std::fmt::Write as _;
+
+        let mut out = String::with_capacity(bytes.len() * 2);
+        for byte in bytes {
+            write!(&mut out, "{byte:02x}").expect("write! to String cannot fail");
+        }
+        out
+    }
+
+    #[test]
+    fn sha512_streaming_matches_rfc_vectors() {
+        let vectors = [
+            (
+                b"".as_slice(),
+                "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e",
+            ),
+            (
+                b"abc".as_slice(),
+                "ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f",
+            ),
+            (
+                b"message digest".as_slice(),
+                "107dbf389d9e9f71a3a95f6c055b9251bc5268c2be16d6c13492ea45b0199f3309e16455ab1e96118e8a905d5597b72038ddb372a89826046de66687bb420e7c",
+            ),
+        ];
+
+        for (input, expected_hex) in vectors {
+            let mut hasher = Sha512::new();
+            let mid = input.len() / 2;
+            hasher.update(&input[..mid]);
+            hasher.update(&input[mid..]);
+            let digest = hasher.finalize();
+            assert_eq!(to_hex(&digest), expected_hex);
+
+            let one_shot = Sha512::digest(input);
+            assert_eq!(to_hex(&one_shot), expected_hex);
+        }
+    }
+}

--- a/crates/core/src/auth/mod.rs
+++ b/crates/core/src/auth/mod.rs
@@ -1,0 +1,214 @@
+//! Shared helpers for daemon authentication digests.
+//!
+//! The rsync daemon supports multiple challenge/response hash algorithms that are negotiated via
+//! the legacy `@RSYNCD:` greeting. Both the client and daemon use this module to select the
+//! strongest mutually supported digest, compute base64-encoded responses, and validate incoming
+//! credentials without duplicating algorithm tables across crates.
+
+use base64::Engine as _;
+use base64::engine::general_purpose::STANDARD_NO_PAD;
+use rsync_checksums::strong::{Md4, Md5, Sha1, Sha256, Sha512};
+
+/// Digest algorithms supported for daemon challenge/response authentication.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum DaemonAuthDigest {
+    /// SHA-512, the strongest algorithm supported by upstream rsync.
+    Sha512,
+    /// SHA-256, preferred when SHA-512 is unavailable.
+    Sha256,
+    /// SHA-1, retained for compatibility with older daemons.
+    Sha1,
+    /// MD5, the historical default.
+    Md5,
+    /// MD4, accepted for compatibility with very old clients.
+    Md4,
+}
+
+impl DaemonAuthDigest {
+    /// Returns the canonical token used in daemon greetings for this digest.
+    #[must_use]
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::Sha512 => "sha512",
+            Self::Sha256 => "sha256",
+            Self::Sha1 => "sha1",
+            Self::Md5 => "md5",
+            Self::Md4 => "md4",
+        }
+    }
+
+    /// Returns the expected length of the base64-encoded digest without padding.
+    #[must_use]
+    pub const fn base64_len(self) -> usize {
+        match self {
+            Self::Sha512 => 86,
+            Self::Sha256 => 43,
+            Self::Sha1 => 27,
+            Self::Md5 | Self::Md4 => 22,
+        }
+    }
+
+    /// Computes the raw digest bytes for the provided secret and challenge.
+    fn digest_bytes(self, secret: &[u8], challenge: &[u8]) -> Vec<u8> {
+        match self {
+            Self::Sha512 => {
+                let mut hasher = Sha512::new();
+                hasher.update(secret);
+                hasher.update(challenge);
+                hasher.finalize().to_vec()
+            }
+            Self::Sha256 => {
+                let mut hasher = Sha256::new();
+                hasher.update(secret);
+                hasher.update(challenge);
+                hasher.finalize().to_vec()
+            }
+            Self::Sha1 => {
+                let mut hasher = Sha1::new();
+                hasher.update(secret);
+                hasher.update(challenge);
+                hasher.finalize().to_vec()
+            }
+            Self::Md5 => {
+                let mut hasher = Md5::new();
+                hasher.update(secret);
+                hasher.update(challenge);
+                hasher.finalize().to_vec()
+            }
+            Self::Md4 => {
+                let mut hasher = Md4::new();
+                hasher.update(secret);
+                hasher.update(challenge);
+                hasher.finalize().to_vec()
+            }
+        }
+    }
+}
+
+/// Ordered list of authentication digests supported by this implementation.
+///
+/// The order reflects preference from strongest to weakest.
+pub const SUPPORTED_DAEMON_DIGESTS: &[DaemonAuthDigest; 5] = &[
+    DaemonAuthDigest::Sha512,
+    DaemonAuthDigest::Sha256,
+    DaemonAuthDigest::Sha1,
+    DaemonAuthDigest::Md5,
+    DaemonAuthDigest::Md4,
+];
+
+/// Parses the whitespace-separated digest list advertised by a daemon greeting.
+#[must_use]
+pub fn parse_daemon_digest_list(list: Option<&str>) -> Vec<DaemonAuthDigest> {
+    let Some(list) = list else {
+        return Vec::new();
+    };
+
+    list.split_whitespace()
+        .filter_map(|token| match token.to_ascii_lowercase().as_str() {
+            "sha512" => Some(DaemonAuthDigest::Sha512),
+            "sha256" => Some(DaemonAuthDigest::Sha256),
+            "sha1" => Some(DaemonAuthDigest::Sha1),
+            "md5" => Some(DaemonAuthDigest::Md5),
+            "md4" => Some(DaemonAuthDigest::Md4),
+            _ => None,
+        })
+        .collect()
+}
+
+/// Selects the strongest mutually supported digest between the local implementation and the advertised list.
+#[must_use]
+pub fn select_daemon_digest(advertised: &[DaemonAuthDigest]) -> DaemonAuthDigest {
+    for preferred in SUPPORTED_DAEMON_DIGESTS.iter().copied() {
+        if advertised.iter().any(|candidate| *candidate == preferred) {
+            return preferred;
+        }
+    }
+
+    // No explicit match; fall back to the historical default so older daemons without an
+    // advertised list continue working.
+    DaemonAuthDigest::Md5
+}
+
+/// Computes the base64-encoded daemon authentication response using the provided digest.
+#[must_use]
+pub fn compute_daemon_auth_response(
+    secret: &[u8],
+    challenge: &str,
+    digest: DaemonAuthDigest,
+) -> String {
+    let bytes = digest.digest_bytes(secret, challenge.as_bytes());
+    STANDARD_NO_PAD.encode(bytes)
+}
+
+/// Returns the supported digest candidates that match the supplied response length.
+#[must_use]
+pub fn digests_for_response(response: &str) -> &'static [DaemonAuthDigest] {
+    match response.len() {
+        len if len == DaemonAuthDigest::Sha512.base64_len() => SHA512_ONLY,
+        len if len == DaemonAuthDigest::Sha256.base64_len() => SHA256_ONLY,
+        len if len == DaemonAuthDigest::Sha1.base64_len() => SHA1_ONLY,
+        len if len == DaemonAuthDigest::Md5.base64_len() => MD_LEGACY,
+        _ => &[],
+    }
+}
+
+const SHA512_ONLY: &[DaemonAuthDigest] = &[DaemonAuthDigest::Sha512];
+const SHA256_ONLY: &[DaemonAuthDigest] = &[DaemonAuthDigest::Sha256];
+const SHA1_ONLY: &[DaemonAuthDigest] = &[DaemonAuthDigest::Sha1];
+const MD_LEGACY: &[DaemonAuthDigest] = &[DaemonAuthDigest::Md5, DaemonAuthDigest::Md4];
+
+/// Verifies whether the supplied daemon authentication response matches the secret and challenge.
+#[must_use]
+pub fn verify_daemon_auth_response(secret: &[u8], challenge: &str, response: &str) -> bool {
+    digests_for_response(response)
+        .iter()
+        .filter(|digest| SUPPORTED_DAEMON_DIGESTS.contains(digest))
+        .any(|digest| compute_daemon_auth_response(secret, challenge, *digest) == response)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn advertised_list_preserves_order_and_filters_unknown() {
+        let list = parse_daemon_digest_list(Some("sha512 sponge sha1 md5"));
+        assert_eq!(
+            list,
+            [
+                DaemonAuthDigest::Sha512,
+                DaemonAuthDigest::Sha1,
+                DaemonAuthDigest::Md5
+            ]
+        );
+    }
+
+    #[test]
+    fn selection_prefers_strongest_supported_digest() {
+        let digests = [
+            DaemonAuthDigest::Md5,
+            DaemonAuthDigest::Sha1,
+            DaemonAuthDigest::Sha256,
+        ];
+        assert_eq!(select_daemon_digest(&digests), DaemonAuthDigest::Sha256);
+    }
+
+    #[test]
+    fn selection_falls_back_to_md5_when_list_empty() {
+        assert_eq!(select_daemon_digest(&[]), DaemonAuthDigest::Md5);
+    }
+
+    #[test]
+    fn compute_and_verify_round_trip_for_sha512() {
+        let secret = b"secret";
+        let challenge = "challenge";
+        let response = compute_daemon_auth_response(secret, challenge, DaemonAuthDigest::Sha512);
+        assert!(verify_daemon_auth_response(secret, challenge, &response));
+    }
+
+    #[test]
+    fn digests_for_response_disambiguates_md4_and_md5() {
+        let len = DaemonAuthDigest::Md5.base64_len();
+        assert_eq!(digests_for_response(&"A".repeat(len)), MD_LEGACY);
+    }
+}

--- a/crates/core/src/client/module_list/mod.rs
+++ b/crates/core/src/client/module_list/mod.rs
@@ -13,12 +13,12 @@ pub use listing::{
 pub use request::{ModuleListOptions, ModuleListRequest};
 pub use types::DaemonAddress;
 
+#[allow(unused_imports)]
+pub(super) use crate::auth::{DaemonAuthDigest, compute_daemon_auth_response};
 #[cfg(test)]
 pub(super) use auth::set_test_daemon_password;
 #[allow(unused_imports)]
-pub(super) use auth::{
-    DaemonAuthContext, SensitiveBytes, compute_daemon_auth_response, send_daemon_auth_credentials,
-};
+pub(super) use auth::{DaemonAuthContext, SensitiveBytes, send_daemon_auth_credentials};
 #[allow(unused_imports)]
 pub(super) use connect::{
     ConnectProgramConfig, ProxyConfig, ProxyCredentials, connect_direct, connect_via_proxy,

--- a/crates/core/src/client/tests/client_event.rs
+++ b/crates/core/src/client/tests/client_event.rs
@@ -1,6 +1,6 @@
 use super::error::{MAX_DELETE_EXIT_CODE, PROTOCOL_INCOMPATIBLE_EXIT_CODE, map_local_copy_error};
 use super::module_list::{
-    ConnectProgramConfig, DaemonAuthContext, ProxyConfig, SensitiveBytes,
+    ConnectProgramConfig, DaemonAuthContext, DaemonAuthDigest, ProxyConfig, SensitiveBytes,
     compute_daemon_auth_response, connect_direct, connect_via_proxy, establish_proxy_tunnel,
     map_daemon_handshake_error, parse_proxy_spec, resolve_connect_timeout,
     resolve_daemon_addresses, set_test_daemon_password,
@@ -87,7 +87,11 @@ fn sensitive_bytes_zeroizes_on_drop() {
 
 #[test]
 fn daemon_auth_context_zeroizes_secret_on_drop() {
-    let context = DaemonAuthContext::new("user".to_string(), b"supersecret".to_vec());
+    let context = DaemonAuthContext::new(
+        "user".to_string(),
+        b"supersecret".to_vec(),
+        DaemonAuthDigest::Sha512,
+    );
     let zeroed = context.into_zeroized_secret();
     assert!(zeroed.iter().all(|&byte| byte == 0));
 }

--- a/crates/core/src/client/tests/module_list_auth.rs
+++ b/crates/core/src/client/tests/module_list_auth.rs
@@ -3,7 +3,8 @@ fn run_module_list_reports_authentication_failure() {
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind auth daemon");
     let addr = listener.local_addr().expect("local addr");
     let challenge = "abcdef";
-    let expected = compute_daemon_auth_response(b"secret", challenge);
+    let expected =
+        compute_daemon_auth_response(b"secret", challenge, DaemonAuthDigest::Sha512);
 
     let handle = thread::spawn(move || {
         if let Ok((mut stream, _)) = listener.accept() {

--- a/crates/core/src/client/tests/module_list_proxy.rs
+++ b/crates/core/src/client/tests/module_list_proxy.rs
@@ -343,7 +343,8 @@ fn run_module_list_authenticates_with_credentials() {
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind auth daemon");
     let addr = listener.local_addr().expect("local addr");
     let challenge = "abc123";
-    let expected = compute_daemon_auth_response(b"secret", challenge);
+    let expected =
+        compute_daemon_auth_response(b"secret", challenge, DaemonAuthDigest::Sha512);
 
     let handle = thread::spawn(move || {
         if let Ok((mut stream, _)) = listener.accept() {
@@ -411,7 +412,11 @@ fn run_module_list_authenticates_with_password_override() {
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind override daemon");
     let addr = listener.local_addr().expect("local addr");
     let challenge = "override";
-    let expected = compute_daemon_auth_response(b"override-secret", challenge);
+    let expected = compute_daemon_auth_response(
+        b"override-secret",
+        challenge,
+        DaemonAuthDigest::Sha512,
+    );
 
     let handle = thread::spawn(move || {
         if let Ok((mut stream, _)) = listener.accept() {
@@ -484,7 +489,8 @@ fn run_module_list_authenticates_with_split_challenge() {
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind split auth daemon");
     let addr = listener.local_addr().expect("local addr");
     let challenge = "split123";
-    let expected = compute_daemon_auth_response(b"secret", challenge);
+    let expected =
+        compute_daemon_auth_response(b"secret", challenge, DaemonAuthDigest::Sha512);
 
     let handle = thread::spawn(move || {
         if let Ok((mut stream, _)) = listener.accept() {

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -4,6 +4,8 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc = include_str!("../README.md")]
 
+/// Shared daemon authentication helpers.
+pub mod auth;
 /// Bandwidth parsing utilities shared by CLI and daemon entry points.
 pub mod bandwidth;
 /// Branding constants shared across binaries and packaging layers.

--- a/crates/core/src/version/report/renderer.rs
+++ b/crates/core/src/version/report/renderer.rs
@@ -1,3 +1,4 @@
+use crate::auth::SUPPORTED_DAEMON_DIGESTS;
 use crate::branding::Brand;
 use crate::version::{VersionMetadata, version_metadata, version_metadata_for_program};
 use libc::{ino_t, off_t, time_t};
@@ -357,7 +358,10 @@ pub(crate) fn default_compress_algorithms() -> Vec<Cow<'static, str>> {
 /// `--version` output.
 #[must_use]
 pub(crate) fn default_daemon_auth_algorithms() -> Vec<Cow<'static, str>> {
-    vec![Cow::Borrowed("md5"), Cow::Borrowed("md4")]
+    SUPPORTED_DAEMON_DIGESTS
+        .iter()
+        .map(|digest| Cow::Borrowed(digest.name()))
+        .collect()
 }
 
 #[derive(Clone, Debug)]

--- a/crates/daemon/src/daemon.rs
+++ b/crates/daemon/src/daemon.rs
@@ -41,6 +41,7 @@ use std::os::unix::fs::PermissionsExt;
 use clap::{Arg, ArgAction, Command, builder::OsStringValueParser};
 use rsync_checksums::strong::Md5;
 use rsync_core::{
+    auth::{SUPPORTED_DAEMON_DIGESTS, verify_daemon_auth_response},
     bandwidth::{
         BandwidthLimitComponents, BandwidthLimiter, BandwidthParseError, LimiterChange,
         parse_bandwidth_limit,
@@ -99,8 +100,6 @@ const MODULE_MAX_CONNECTIONS_PAYLOAD: &str =
 /// Error payload returned when updating the connection lock file fails.
 const MODULE_LOCK_ERROR_PAYLOAD: &str =
     "@ERROR: failed to update module connection lock; please try again later";
-/// Digest algorithms advertised during the legacy daemon greeting.
-const LEGACY_HANDSHAKE_DIGESTS: &[&str] = &["sha512", "sha256", "sha1", "md5", "md4"];
 // Deterministic help text describing the currently supported daemon surface.
 //
 // The snapshot adjusts the banner, usage line, and default configuration path

--- a/crates/daemon/src/daemon/sections/delegation.rs
+++ b/crates/daemon/src/daemon/sections/delegation.rs
@@ -157,9 +157,9 @@ fn legacy_daemon_greeting() -> String {
     debug_assert!(greeting.ends_with('\n'));
     greeting.pop();
 
-    for digest in LEGACY_HANDSHAKE_DIGESTS {
+    for digest in SUPPORTED_DAEMON_DIGESTS {
         greeting.push(' ');
-        greeting.push_str(digest);
+        greeting.push_str(digest.name());
     }
 
     greeting.push('\n');

--- a/crates/daemon/src/daemon/sections/module_access.rs
+++ b/crates/daemon/src/daemon/sections/module_access.rs
@@ -146,21 +146,14 @@ fn verify_secret_response(
 
         if let Some((user, secret)) = line.split_once(':') {
             if user == username {
-                let expected = compute_auth_response(secret, challenge);
-                return Ok(expected == response);
+                if verify_daemon_auth_response(secret.as_bytes(), challenge, response) {
+                    return Ok(true);
+                }
             }
         }
     }
 
     Ok(false)
-}
-
-fn compute_auth_response(secret: &str, challenge: &str) -> String {
-    let mut hasher = Md5::new();
-    hasher.update(secret.as_bytes());
-    hasher.update(challenge.as_bytes());
-    let digest = hasher.finalize();
-    STANDARD_NO_PAD.encode(digest)
 }
 
 fn deny_module(


### PR DESCRIPTION
## Summary
- add SHA-256 and SHA-512 strong digest implementations for the checksum crate and expose them via the version report
- introduce a shared daemon authentication helper module that negotiates, computes, and verifies multi-algorithm challenge responses
- update the client and daemon to select the strongest common digest, advertise the accurate list, and verify responses accordingly

## Testing
- cargo test -p rsync-checksums
- cargo test -p rsync-core
- cargo test -p rsync-daemon

------