### PR TITLE
Fix Apple platform ACL and group handling

### DIFF
--- a/crates/core/src/fallback/binary.rs
+++ b/crates/core/src/fallback/binary.rs
@@ -325,11 +325,56 @@ impl UnixProcessIdentity {
     }
 }
 
-#[cfg(unix)]
+#[cfg(all(
+    unix,
+    not(any(
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "tvos",
+        target_os = "watchos",
+    ))
+))]
 fn collect_supplementary_groups() -> Vec<u32> {
     match nix::unistd::getgroups() {
         Ok(groups) => groups.into_iter().map(|gid| gid.as_raw()).collect(),
         Err(_) => Vec::new(),
+    }
+}
+
+#[cfg(all(
+    unix,
+    any(
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "tvos",
+        target_os = "watchos",
+    )
+))]
+fn collect_supplementary_groups() -> Vec<u32> {
+    use std::convert::TryFrom;
+
+    unsafe {
+        let count = libc::getgroups(0, std::ptr::null_mut());
+        if count <= 0 {
+            return Vec::new();
+        }
+
+        let Ok(buffer_len) = usize::try_from(count) else {
+            return Vec::new();
+        };
+
+        let mut groups = vec![0 as libc::gid_t; buffer_len];
+        let written = libc::getgroups(count, groups.as_mut_ptr());
+        if written <= 0 {
+            return Vec::new();
+        }
+
+        let Ok(actual_len) = usize::try_from(written) else {
+            return Vec::new();
+        };
+
+        groups.truncate(actual_len);
+        groups.into_iter().map(|gid| gid as u32).collect()
     }
 }
 

--- a/crates/meta/src/acl_stub.rs
+++ b/crates/meta/src/acl_stub.rs
@@ -1,0 +1,26 @@
+#![cfg(all(
+    feature = "acl",
+    any(
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "tvos",
+        target_os = "watchos",
+    )
+))]
+
+use crate::MetadataError;
+use std::path::Path;
+
+/// Stub ACL synchronisation for Apple platforms.
+///
+/// Apple's libSystem lacks the Linux-specific `acl_from_mode` helper, so the
+/// ACL preservation feature is effectively unavailable. The stub mirrors the
+/// behaviour of builds compiled without ACL support by performing no work.
+pub fn sync_acls(
+    source: &Path,
+    destination: &Path,
+    follow_symlinks: bool,
+) -> Result<(), MetadataError> {
+    let _ = (source, destination, follow_symlinks);
+    Ok(())
+}

--- a/crates/meta/src/lib.rs
+++ b/crates/meta/src/lib.rs
@@ -68,7 +68,25 @@
 //! - `rsync_core::client` integrates these helpers for local filesystem copies.
 //! - [`filetime`] for lower-level timestamp manipulation utilities.
 
-#[cfg(feature = "acl")]
+#[cfg(all(
+    feature = "acl",
+    any(
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "tvos",
+        target_os = "watchos",
+    )
+))]
+mod acl_stub;
+#[cfg(all(
+    feature = "acl",
+    not(any(
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "tvos",
+        target_os = "watchos",
+    ))
+))]
 mod acl_support;
 mod apply;
 mod chmod;
@@ -82,7 +100,25 @@ mod special;
 #[cfg(feature = "xattr")]
 mod xattr;
 
-#[cfg(feature = "acl")]
+#[cfg(all(
+    feature = "acl",
+    any(
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "tvos",
+        target_os = "watchos",
+    )
+))]
+pub use acl_stub::sync_acls;
+#[cfg(all(
+    feature = "acl",
+    not(any(
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "tvos",
+        target_os = "watchos",
+    ))
+))]
 pub use acl_support::sync_acls;
 pub use apply::{
     apply_directory_metadata, apply_directory_metadata_with_options, apply_file_metadata,


### PR DESCRIPTION
## Summary
- adjust supplementary group discovery on Apple targets to use libc
- gate ACL synchronization behind an Apple-specific stub to avoid missing libacl symbols

## Testing
- cargo test --workspace --all-features --no-run

------