### PR TITLE
Fix macOS getgroups lookup and ACL test linking

### DIFF
--- a/crates/core/src/fallback/binary.rs
+++ b/crates/core/src/fallback/binary.rs
@@ -325,11 +325,55 @@ impl UnixProcessIdentity {
     }
 }
 
-#[cfg(unix)]
+#[cfg(all(unix, not(target_vendor = "apple")))]
 fn collect_supplementary_groups() -> Vec<u32> {
     match nix::unistd::getgroups() {
         Ok(groups) => groups.into_iter().map(|gid| gid.as_raw()).collect(),
         Err(_) => Vec::new(),
+    }
+}
+
+#[cfg(all(unix, target_vendor = "apple"))]
+fn collect_supplementary_groups() -> Vec<u32> {
+    use std::convert::TryFrom;
+
+    unsafe {
+        let mut size = libc::getgroups(0, std::ptr::null_mut());
+        if size <= 0 {
+            return Vec::new();
+        }
+
+        let mut buffer = match usize::try_from(size) {
+            Ok(len) => vec![0 as libc::gid_t; len],
+            Err(_) => return Vec::new(),
+        };
+
+        loop {
+            let read = libc::getgroups(size, buffer.as_mut_ptr());
+            if read < 0 {
+                return Vec::new();
+            }
+
+            if read <= size {
+                let used = match usize::try_from(read) {
+                    Ok(value) => value,
+                    Err(_) => return Vec::new(),
+                };
+                buffer.truncate(used);
+                break;
+            }
+
+            size = read;
+            match usize::try_from(size) {
+                Ok(len) => buffer.resize(len, 0 as libc::gid_t),
+                Err(_) => return Vec::new(),
+            }
+        }
+
+        buffer
+            .into_iter()
+            .filter_map(|gid| u32::try_from(gid).ok())
+            .collect()
     }
 }
 

--- a/crates/engine/src/local_copy/tests/mod.rs
+++ b/crates/engine/src/local_copy/tests/mod.rs
@@ -79,7 +79,7 @@ mod acl_sys {
 
     pub const ACL_TYPE_ACCESS: AclType = 0x8000;
 
-    #[link(name = "acl")]
+    #[cfg_attr(not(target_vendor = "apple"), link(name = "acl"))]
     unsafe extern "C" {
         pub fn acl_get_file(path_p: *const c_char, ty: AclType) -> AclHandle;
         pub fn acl_set_file(path_p: *const c_char, ty: AclType, acl: AclHandle) -> c_int;


### PR DESCRIPTION
## Summary
- use libc::getgroups on Apple targets to collect supplementary groups for fallback validation
- avoid forcing a libacl link dependency in ACL-related tests when building on macOS

## Testing
- cargo check --all-features

------