### PR TITLE
Fix clippy warnings across workspace

### DIFF
--- a/crates/cli/src/frontend/execution/compression.rs
+++ b/crates/cli/src/frontend/execution/compression.rs
@@ -128,8 +128,7 @@ fn render_compress_choice_error(err: CompressionAlgorithmParseError, trimmed: &s
     }
     let supported_list = supported.join(", ");
     let rendered = format!(
-        "invalid compression algorithm '{}': supported values include {}",
-        display, supported_list
+        "invalid compression algorithm '{display}': supported values include {supported_list}"
     );
     rsync_error!(1, rendered).with_role(Role::Client)
 }

--- a/crates/cli/src/frontend/execution/drive/metadata.rs
+++ b/crates/cli/src/frontend/execution/drive/metadata.rs
@@ -88,29 +88,27 @@ pub(crate) fn compute_metadata_settings(
         Some(value) => Some(parse_group_mapping(value, parsed_chown)?),
         None => None,
     };
-    let preserve_owner = if parsed_chown.and_then(|value| value.owner()).is_some() {
-        true
-    } else if user_mapping.is_some() {
-        true
-    } else if let Some(value) = owner {
-        value
-    } else if super_mode == Some(true) {
-        true
-    } else {
-        archive
-    };
+    let preserve_owner =
+        if parsed_chown.and_then(|value| value.owner()).is_some() || user_mapping.is_some() {
+            true
+        } else if let Some(value) = owner {
+            value
+        } else if super_mode == Some(true) {
+            true
+        } else {
+            archive
+        };
 
-    let preserve_group = if parsed_chown.and_then(|value| value.group()).is_some() {
-        true
-    } else if group_mapping.is_some() {
-        true
-    } else if let Some(value) = group {
-        value
-    } else if super_mode == Some(true) {
-        true
-    } else {
-        archive
-    };
+    let preserve_group =
+        if parsed_chown.and_then(|value| value.group()).is_some() || group_mapping.is_some() {
+            true
+        } else if let Some(value) = group {
+            value
+        } else if super_mode == Some(true) {
+            true
+        } else {
+            archive
+        };
 
     let preserve_permissions = if let Some(value) = perms {
         value

--- a/crates/cli/src/frontend/execution/drive/summary.rs
+++ b/crates/cli/src/frontend/execution/drive/summary.rs
@@ -146,16 +146,16 @@ where
             }
 
             if let Some(mut log) = log_file {
-                if let Err(error) = emit_log_output(
-                    &summary,
-                    &mut log,
+                if let Err(error) = emit_log_output(EmitLogOutputParams {
+                    summary: &summary,
+                    log: &mut log,
                     verbosity,
                     stats,
                     list_only,
                     name_level,
                     name_overridden,
                     human_readable_mode,
-                ) {
+                }) {
                     let _ = with_output_writer(stdout, stderr, msgs_to_stderr, |writer| {
                         writeln!(writer, "warning: failed to append to log file: {error}")
                     });
@@ -186,16 +186,28 @@ where
     }
 }
 
-fn emit_log_output(
-    summary: &ClientSummary,
-    log: &mut LogFileConfig,
+struct EmitLogOutputParams<'a> {
+    summary: &'a ClientSummary,
+    log: &'a mut LogFileConfig,
     verbosity: u8,
     stats: bool,
     list_only: bool,
     name_level: NameOutputLevel,
     name_overridden: bool,
     human_readable_mode: HumanReadableMode,
-) -> io::Result<()> {
+}
+
+fn emit_log_output(params: EmitLogOutputParams<'_>) -> io::Result<()> {
+    let EmitLogOutputParams {
+        summary,
+        log,
+        verbosity,
+        stats,
+        list_only,
+        name_level,
+        name_overridden,
+        human_readable_mode,
+    } = params;
     let context = OutFormatContext::default();
     emit_transfer_summary(
         summary,

--- a/crates/cli/src/frontend/execution/stop.rs
+++ b/crates/cli/src/frontend/execution/stop.rs
@@ -173,9 +173,6 @@ fn parse_stop_at_internal(input: &str) -> Result<SystemTime, StopAtError> {
     }
 
     let now = OffsetDateTime::now_local().map_err(|_| StopAtError::LocalOffset)?;
-    let mut tm_year = tm_year;
-    let mut tm_mon = tm_mon;
-    let mut tm_mday = tm_mday;
     let original_tm_year = tm_year;
     let original_tm_mon = tm_mon;
     let original_tm_mday = tm_mday;
@@ -218,7 +215,11 @@ fn parse_stop_at_internal(input: &str) -> Result<SystemTime, StopAtError> {
         repeat_seconds = 60 * 60;
     }
 
-    if tm_hour > 23 || tm_min > 59 || tm_mon < 0 || tm_mon >= 12 || tm_mday < 1 || tm_mday > 31 {
+    if !(0..=23).contains(&tm_hour)
+        || !(0..=59).contains(&tm_min)
+        || !(0..12).contains(&tm_mon)
+        || !(1..=31).contains(&tm_mday)
+    {
         return Err(StopAtError::InvalidFormat);
     }
 
@@ -332,7 +333,7 @@ fn offset_datetime_to_system_time(datetime: OffsetDateTime) -> Result<SystemTime
     if seconds < 0 {
         return Err(StopAtError::InvalidFormat);
     }
-    let nanos = u32::from(datetime.nanosecond());
+    let nanos = datetime.nanosecond();
     let base = SystemTime::UNIX_EPOCH
         .checked_add(Duration::from_secs(seconds as u64))
         .ok_or(StopAtError::InvalidFormat)?;

--- a/crates/cli/src/frontend/out_format/render.rs
+++ b/crates/cli/src/frontend/out_format/render.rs
@@ -187,27 +187,15 @@ fn format_with_units(value: i64, base: i64) -> Option<String> {
         magnitude = -magnitude;
     }
 
-    let units = if magnitude < base as f64 {
-        'K'
-    } else if {
+    const UNITS: [char; 5] = ['K', 'M', 'G', 'T', 'P'];
+    let mut units = 'P';
+    for (index, candidate) in UNITS.iter().enumerate() {
+        units = *candidate;
+        if magnitude < base as f64 || index == UNITS.len() - 1 {
+            break;
+        }
         magnitude /= base as f64;
-        magnitude < base as f64
-    } {
-        'M'
-    } else if {
-        magnitude /= base as f64;
-        magnitude < base as f64
-    } {
-        'G'
-    } else if {
-        magnitude /= base as f64;
-        magnitude < base as f64
-    } {
-        'T'
-    } else {
-        magnitude /= base as f64;
-        'P'
-    };
+    }
 
     if negative {
         magnitude = -magnitude;

--- a/crates/cli/src/frontend/tests/remote_fallback_forwards_compress.rs
+++ b/crates/cli/src/frontend/tests/remote_fallback_forwards_compress.rs
@@ -73,6 +73,6 @@ exit 0
 
     let recorded = std::fs::read_to_string(&args_path).expect("read args file");
     let lines: Vec<&str> = recorded.lines().collect();
-    assert!(lines.iter().any(|line| *line == "--no-compress"));
-    assert!(!lines.iter().any(|line| *line == "--compress"));
+    assert!(lines.contains(&"--no-compress"));
+    assert!(!lines.contains(&"--compress"));
 }

--- a/crates/cli/src/frontend/tests/remote_fallback_forwards_outbuf.rs
+++ b/crates/cli/src/frontend/tests/remote_fallback_forwards_outbuf.rs
@@ -37,7 +37,7 @@ exit 0
     let recorded = std::fs::read_to_string(&args_path).expect("read args file");
     let args: Vec<&str> = recorded.lines().collect();
     assert!(
-        args.iter().any(|&arg| arg == "--outbuf=B"),
+        args.contains(&"--outbuf=B"),
         "args missing --outbuf=B flag: {args:?}"
     );
 }

--- a/crates/compress/src/lz4.rs
+++ b/crates/compress/src/lz4.rs
@@ -52,9 +52,7 @@ where
 
     /// Appends data to the compression stream.
     pub fn write(&mut self, input: &[u8]) -> io::Result<()> {
-        self.inner
-            .write_all(input)
-            .map_err(|error| io::Error::new(io::ErrorKind::Other, error))
+        self.inner.write_all(input).map_err(io::Error::other)
     }
 
     /// Returns the number of compressed bytes produced so far.
@@ -77,10 +75,7 @@ where
 
     /// Completes the stream and returns the sink together with the number of compressed bytes.
     pub fn finish_into_inner(self) -> io::Result<(W, u64)> {
-        let writer = self
-            .inner
-            .finish()
-            .map_err(|error| io::Error::new(io::ErrorKind::Other, error))?;
+        let writer = self.inner.finish().map_err(io::Error::other)?;
         Ok(writer.into_parts())
     }
 }
@@ -153,12 +148,8 @@ where
 pub fn compress_to_vec(input: &[u8], level: CompressionLevel) -> io::Result<Vec<u8>> {
     let frame_info = frame_info_for_level(level);
     let mut encoder = FrameEncoder::with_frame_info(frame_info, Vec::new());
-    encoder
-        .write_all(input)
-        .map_err(|error| io::Error::new(io::ErrorKind::Other, error))?;
-    encoder
-        .finish()
-        .map_err(|error| io::Error::new(io::ErrorKind::Other, error))
+    encoder.write_all(input).map_err(io::Error::other)?;
+    encoder.finish().map_err(io::Error::other)
 }
 
 /// Decompresses `input` into a new [`Vec`].

--- a/crates/core/src/auth/mod.rs
+++ b/crates/core/src/auth/mod.rs
@@ -119,7 +119,7 @@ pub fn parse_daemon_digest_list(list: Option<&str>) -> Vec<DaemonAuthDigest> {
 #[must_use]
 pub fn select_daemon_digest(advertised: &[DaemonAuthDigest]) -> DaemonAuthDigest {
     for preferred in SUPPORTED_DAEMON_DIGESTS.iter().copied() {
-        if advertised.iter().any(|candidate| *candidate == preferred) {
+        if advertised.contains(&preferred) {
             return preferred;
         }
     }

--- a/crates/core/src/fallback/binary.rs
+++ b/crates/core/src/fallback/binary.rs
@@ -327,21 +327,14 @@ impl UnixProcessIdentity {
 
 #[cfg(all(unix, not(target_vendor = "apple")))]
 fn collect_supplementary_groups() -> Vec<u32> {
-    use std::convert::TryFrom;
-
     match nix::unistd::getgroups() {
-        Ok(groups) => groups
-            .into_iter()
-            .filter_map(|gid| u32::try_from(gid.as_raw()).ok())
-            .collect(),
+        Ok(groups) => groups.into_iter().map(|gid| gid.as_raw()).collect(),
         Err(_) => Vec::new(),
     }
 }
 
 #[cfg(all(unix, target_vendor = "apple"))]
 fn collect_supplementary_groups() -> Vec<u32> {
-    use std::convert::TryFrom;
-
     const INITIAL_CAPACITY: usize = 32;
     const MAX_CAPACITY: usize = 1 << 12;
 
@@ -357,10 +350,7 @@ fn collect_supplementary_groups() -> Vec<u32> {
                 groups.set_len(len);
             }
 
-            return groups
-                .into_iter()
-                .filter_map(|gid| u32::try_from(gid).ok())
-                .collect();
+            return groups.into_iter().map(|gid| gid as u32).collect();
         }
 
         let errno = std::io::Error::last_os_error()

--- a/crates/daemon/src/daemon/sections/module_access.rs
+++ b/crates/daemon/src/daemon/sections/module_access.rs
@@ -145,10 +145,10 @@ fn verify_secret_response(
         }
 
         if let Some((user, secret)) = line.split_once(':') {
-            if user == username {
-                if verify_daemon_auth_response(secret.as_bytes(), challenge, response) {
-                    return Ok(true);
-                }
+            if user == username
+                && verify_daemon_auth_response(secret.as_bytes(), challenge, response)
+            {
+                return Ok(true);
             }
         }
     }

--- a/crates/engine/src/local_copy/executor/file/comparison.rs
+++ b/crates/engine/src/local_copy/executor/file/comparison.rs
@@ -168,30 +168,6 @@ pub(crate) fn files_match(source: &Path, destination: &Path) -> bool {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::io::Write;
-    use tempfile::tempdir;
-
-    #[test]
-    fn build_delta_signature_honours_block_size_override() {
-        let temp = tempdir().expect("tempdir");
-        let path = temp.path().join("data.bin");
-        let mut file = fs::File::create(&path).expect("create file");
-        file.write_all(&vec![0u8; 16384]).expect("write data");
-        drop(file);
-
-        let metadata = fs::metadata(&path).expect("metadata");
-        let override_size = NonZeroU32::new(2048).unwrap();
-        let index = build_delta_signature(&path, &metadata, Some(override_size))
-            .expect("signature")
-            .expect("index");
-
-        assert_eq!(index.block_length(), override_size.get() as usize);
-    }
-}
-
 pub(crate) enum StrongHasher {
     Md4(Md4),
     Md5(Md5),
@@ -267,4 +243,28 @@ pub(crate) fn files_checksum_match(
     }
 
     Ok(source_hasher.finalize() == destination_hasher.finalize())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::tempdir;
+
+    #[test]
+    fn build_delta_signature_honours_block_size_override() {
+        let temp = tempdir().expect("tempdir");
+        let path = temp.path().join("data.bin");
+        let mut file = fs::File::create(&path).expect("create file");
+        file.write_all(&vec![0u8; 16384]).expect("write data");
+        drop(file);
+
+        let metadata = fs::metadata(&path).expect("metadata");
+        let override_size = NonZeroU32::new(2048).unwrap();
+        let index = build_delta_signature(&path, &metadata, Some(override_size))
+            .expect("signature")
+            .expect("index");
+
+        assert_eq!(index.block_length(), override_size.get() as usize);
+    }
 }

--- a/crates/meta/src/mapping.rs
+++ b/crates/meta/src/mapping.rs
@@ -112,7 +112,7 @@ impl MappingTarget {
                 Some(uid) => Ok(uid),
                 None => Err(io::Error::new(
                     io::ErrorKind::NotFound,
-                    format!("Unknown --usermap name on receiver: {}", name),
+                    format!("Unknown --usermap name on receiver: {name}"),
                 )),
             },
         }
@@ -125,7 +125,7 @@ impl MappingTarget {
                 Some(gid) => Ok(gid),
                 None => Err(io::Error::new(
                     io::ErrorKind::NotFound,
-                    format!("Unknown --groupmap name on receiver: {}", name),
+                    format!("Unknown --groupmap name on receiver: {name}"),
                 )),
             },
         }
@@ -232,13 +232,13 @@ impl NameMapping {
     }
 
     fn map_uid(&self, uid: RawUid) -> io::Result<Option<RawUid>> {
-        self.resolve_rule(uid as u32)?
+        self.resolve_rule(uid)?
             .map(|rule| rule.target.resolve_uid())
             .transpose()
     }
 
     fn map_gid(&self, gid: RawGid) -> io::Result<Option<RawGid>> {
-        self.resolve_rule(gid as u32)?
+        self.resolve_rule(gid)?
             .map(|rule| rule.target.resolve_gid())
             .transpose()
     }


### PR DESCRIPTION
## Summary
- replace manual io::ErrorKind::Other constructions and remove redundant annotations to satisfy clippy in compression, metadata, and core helpers
- streamline CLI option handling, logging, formatting, and tests to eliminate redundant logic flagged by clippy
- collapse conditional logic and reposition engine tests so code structure follows lint expectations

## Testing
- cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings

------
[Codex Task](