### PR TITLE
Use rustix for macOS supplementary group lookup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -887,6 +887,7 @@ dependencies = [
  "rsync-meta",
  "rsync-protocol",
  "rsync-transport",
+ "rustix 0.38.44",
  "serde",
  "serde_json",
  "socket2",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -24,6 +24,7 @@ rsync-filters = { path = "../filters" }
 rsync-compress = { path = "../compress" }
 libc = "0.2"
 nix = { version = "0.29", default-features = false, features = ["user"] }
+rustix = { version = "0.38", features = ["process"] }
 base64 = "0.22"
 rsync-checksums = { path = "../checksums" }
 tempfile = "3.10"


### PR DESCRIPTION
## Summary
- replace the macOS supplementary group enumeration with rustix::process::getgroups
- add the rustix process feature as a safe dependency for rsync-core

## Testing
- cargo check -p rsync-core

------
[Codex Task](