### PR TITLE
Handle whitespace merge directives requiring arguments

### DIFF
--- a/crates/cli/src/frontend/filter_rules/merge.rs
+++ b/crates/cli/src/frontend/filter_rules/merge.rs
@@ -232,8 +232,16 @@ pub(crate) fn process_merge_directive(
 }
 
 fn merge_directive_requires_argument(keyword: &str) -> bool {
+    if keyword.contains('=') {
+        return false;
+    }
+
     matches!(
         keyword,
-        "merge" | "include" | "exclude" | "show" | "hide" | "protect"
-    ) || keyword.starts_with("dir-merge")
+        "include" | "exclude" | "show" | "hide" | "protect" | "risk" | "exclude-if-present"
+    ) || keyword.starts_with("merge")
+        || keyword.starts_with("dir-merge")
+        || keyword.starts_with("per-dir")
+        || keyword == "."
+        || keyword == ":"
 }

--- a/crates/cli/src/frontend/tests/merge.rs
+++ b/crates/cli/src/frontend/tests/merge.rs
@@ -24,6 +24,66 @@ fn merge_directive_options_inherit_parent_configuration() {
 }
 
 #[test]
+fn apply_merge_directive_parses_whitespace_risk_and_exclude_if_present() {
+    use std::collections::HashSet;
+    use tempfile::tempdir;
+
+    let temp = tempdir().expect("tempdir");
+    let merge_file = temp.path().join("rules.txt");
+    std::fs::write(
+        &merge_file,
+        "risk logs/** exclude-if-present marker exclude-if-present=.skip\n",
+    )
+    .expect("write merge rules");
+
+    let options = DirMergeOptions::default().use_whitespace();
+    let directive =
+        MergeDirective::new(merge_file.clone().into_os_string(), None).with_options(options);
+
+    let mut rules = Vec::new();
+    let mut visited = HashSet::new();
+    apply_merge_directive(directive, temp.path(), &mut rules, &mut visited).expect("apply merge");
+
+    assert!(visited.is_empty());
+    assert!(
+        rules
+            .iter()
+            .any(|rule| { rule.kind() == FilterRuleKind::Risk && rule.pattern() == "logs/**" })
+    );
+    assert!(rules.iter().any(|rule| {
+        rule.kind() == FilterRuleKind::ExcludeIfPresent && rule.pattern() == "marker"
+    }));
+    assert!(rules.iter().any(|rule| {
+        rule.kind() == FilterRuleKind::ExcludeIfPresent && rule.pattern() == ".skip"
+    }));
+}
+
+#[test]
+fn apply_merge_directive_parses_whitespace_per_dir_alias() {
+    use std::collections::HashSet;
+    use tempfile::tempdir;
+
+    let temp = tempdir().expect("tempdir");
+    let merge_file = temp.path().join("rules.txt");
+    std::fs::write(&merge_file, "per-dir .rsync-filter\n").expect("write merge rules");
+
+    let options = DirMergeOptions::default().use_whitespace();
+    let directive =
+        MergeDirective::new(merge_file.clone().into_os_string(), None).with_options(options);
+
+    let mut rules = Vec::new();
+    let mut visited = HashSet::new();
+    apply_merge_directive(directive, temp.path(), &mut rules, &mut visited).expect("apply merge");
+
+    assert!(visited.is_empty());
+    let dir_merge_rule = rules
+        .iter()
+        .find(|rule| rule.kind() == FilterRuleKind::DirMerge)
+        .expect("dir-merge rule present");
+    assert_eq!(dir_merge_rule.pattern(), ".rsync-filter");
+}
+
+#[test]
 fn merge_directive_options_respect_child_overrides() {
     let base = DirMergeOptions::default()
         .inherit(false)


### PR DESCRIPTION
## Summary
- ensure whitespace-parsed merge directives consume their required pattern tokens for risk, exclude-if-present, per-dir, and short aliases
- add regression tests covering whitespace merge files that rely on these directives

## Testing
- cargo test -p rsync-cli apply_merge_directive_parses_whitespace_risk_and_exclude_if_present
- cargo test -p rsync-cli apply_merge_directive_parses_whitespace_per_dir_alias

------
[Codex Task](