### PR TITLE
Improve daemon unknown option diagnostics

### DIFF
--- a/crates/daemon/src/daemon/runtime_options.rs
+++ b/crates/daemon/src/daemon/runtime_options.rs
@@ -182,7 +182,7 @@ impl RuntimeOptions {
                 options.modules.push(module);
                 options.inline_modules = true;
             } else {
-                return Err(unsupported_option(argument.clone()));
+                return Err(unsupported_option(argument.clone(), brand));
             }
         }
 

--- a/crates/daemon/src/daemon/sections/module_parsing.rs
+++ b/crates/daemon/src/daemon/sections/module_parsing.rs
@@ -427,9 +427,12 @@ fn config_bwlimit_error(
     config_parse_error(path, line, detail)
 }
 
-fn unsupported_option(option: OsString) -> DaemonError {
+fn unsupported_option(option: OsString, brand: Brand) -> DaemonError {
     let option = option.to_string_lossy();
-    let text = format!("unsupported daemon argument '{option}'");
+    let program = brand.daemon_program_name();
+    let text = format!(
+        "unknown option '{option}': run '{program} --help' to review supported daemon flags"
+    );
     config_error(text)
 }
 

--- a/crates/daemon/src/tests/chunks/chunk_175.rs
+++ b/crates/daemon/src/tests/chunks/chunk_175.rs
@@ -7,11 +7,14 @@ fn run_daemon_rejects_unknown_argument() {
 
     let error = run_daemon(config).expect_err("unknown argument should fail");
     assert_eq!(error.exit_code(), FEATURE_UNAVAILABLE_EXIT_CODE);
+    let rendered = error.message().to_string();
     assert!(
-        error
-            .message()
-            .to_string()
-            .contains("unsupported daemon argument")
+        rendered.contains("unknown option"),
+        "diagnostic should classify unknown daemon flags"
+    );
+    assert!(
+        rendered.contains("--help"),
+        "diagnostic should point operators to the help output"
     );
 }
 


### PR DESCRIPTION
## Summary
- update the daemon runtime parser to emit a brand-aware "unknown option" diagnostic that points operators to the help output
- adjust the corresponding unit test to cover the new wording

## Testing
- cargo test --all-features daemon_rejects_unknown_flag
- cargo test -p rsync-daemon --all-features

------
[Codex Task](