### PR TITLE
Track file list size in stats output

### DIFF
--- a/crates/cli/src/frontend/tests/stats.rs
+++ b/crates/cli/src/frontend/tests/stats.rs
@@ -99,7 +99,7 @@ fn stats_transfer_renders_summary_block() {
     assert!(rendered.contains(&format!("Total file size: {expected_size} bytes")));
     assert!(rendered.contains(&format!("Literal data: {expected_size} bytes")));
     assert!(rendered.contains("Matched data: 0 bytes"));
-    assert!(rendered.contains("File list size: 0"));
+    assert!(rendered.contains("File list size: 10"));
     assert!(rendered.contains("File list generation time:"));
     assert!(rendered.contains("File list transfer time:"));
     assert!(rendered.contains(&format!("Total bytes sent: {expected_size}")));

--- a/crates/engine/src/local_copy/executor/directory.rs
+++ b/crates/engine/src/local_copy/executor/directory.rs
@@ -279,6 +279,7 @@ pub(crate) fn copy_directory_recursive(
             Some(base) => base.join(Path::new(&file_name)),
             None => PathBuf::from(Path::new(&file_name)),
         };
+        context.record_file_list_entry(non_empty_path(relative_path.as_path()));
 
         let mut keep_name = true;
 

--- a/crates/engine/src/local_copy/executor/sources.rs
+++ b/crates/engine/src/local_copy/executor/sources.rs
@@ -114,6 +114,16 @@ pub(crate) fn copy_sources(
                     }
                 };
                 context.record_file_list_generation(metadata_start.elapsed());
+                let record_relative = if metadata.file_type().is_dir() && source.copy_contents() {
+                    None
+                } else if let Some(root) = relative_root.as_ref() {
+                    non_empty_path(root.as_path()).map(Path::to_path_buf)
+                } else {
+                    source_path
+                        .file_name()
+                        .map(|name| PathBuf::from(Path::new(name)))
+                };
+                context.record_file_list_entry(record_relative.as_deref());
                 let file_type = metadata.file_type();
                 let metadata_options = context.metadata_options();
 

--- a/crates/engine/src/local_copy/plan/summary.rs
+++ b/crates/engine/src/local_copy/plan/summary.rs
@@ -211,6 +211,10 @@ impl LocalCopySummary {
         self.file_list_size
     }
 
+    pub(in crate::local_copy) fn record_file_list_entry(&mut self, entry_size: usize) {
+        self.file_list_size = self.file_list_size.saturating_add(entry_size as u64);
+    }
+
     /// Returns the time spent enumerating the file list.
     #[must_use]
     pub const fn file_list_generation_time(&self) -> Duration {


### PR DESCRIPTION
## Summary
- accumulate file-list entry sizes while walking sources so --stats reports real values
- expose a helper for counting encoded path lengths across platforms
- update the CLI stats test to assert the new non-zero file-list size

## Testing
- cargo test

------
[Codex Task](