### PR TITLE
Refine filter diagnostics and iconv handling

### DIFF
--- a/crates/cli/src/frontend/execution/drive/workflow/mod.rs
+++ b/crates/cli/src/frontend/execution/drive/workflow/mod.rs
@@ -209,11 +209,10 @@ where
         None
     };
 
-    let iconv_setting =
-        match resolve_iconv_setting(iconv.as_ref().map(|value| value.as_os_str()), no_iconv) {
-            Ok(setting) => setting,
-            Err(message) => return fail_with_message(message, stderr),
-        };
+    let iconv_setting = match resolve_iconv_setting(iconv.as_deref(), no_iconv) {
+        Ok(setting) => setting,
+        Err(message) => return fail_with_message(message, stderr),
+    };
 
     if let Some(code) = maybe_print_help_or_version(show_help, show_version, program_name, stdout) {
         return code;

--- a/crates/cli/src/frontend/filter_rules/parsing.rs
+++ b/crates/cli/src/frontend/filter_rules/parsing.rs
@@ -582,10 +582,8 @@ pub(crate) fn parse_filter_directive(argument: &OsStr) -> Result<FilterDirective
             if assume_cvsignore {
                 path_text = ".cvsignore";
             } else {
-                let text = format!(
-                    "filter rule '{trimmed}' is missing a file name after '{}'",
-                    label
-                );
+                let text =
+                    format!("filter rule '{trimmed}' is missing a file name after '{label}'");
                 return Err(rsync_error!(1, text).with_role(Role::Client));
             }
         }

--- a/crates/engine/src/local_copy/executor/file/copy/transfer.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer.rs
@@ -348,7 +348,7 @@ fn try_open_noatime(path: &Path) -> io::Result<Option<fs::File>> {
     match options.open(path) {
         Ok(file) => Ok(Some(file)),
         Err(error) => match error.raw_os_error() {
-            Some(code) if matches!(code, EPERM | EACCES | EINVAL | ENOTSUP | EROFS) => Ok(None),
+            Some(EPERM | EACCES | EINVAL | ENOTSUP | EROFS) => Ok(None),
             _ => Err(error),
         },
     }


### PR DESCRIPTION
## Summary
- centralize filter modifier error handling to keep messaging consistent and satisfy clippy
- simplify CLI iconv option resolution by leveraging `Option::as_deref`
- tighten the `O_NOATIME` helper and update filter parsing diagnostics for inline format arguments

## Testing
- `cargo fmt`
- `cargo clippy --workspace --all-targets --all-features`
- `cargo test --workspace --all-features` *(fails: existing frontend transfer/filter parity gaps)*

------
[Codex Task](