### PR TITLE
Cache reusable legacy daemon responses

### DIFF
--- a/crates/daemon/src/daemon.rs
+++ b/crates/daemon/src/daemon.rs
@@ -146,6 +146,8 @@ pub(crate) fn write_message<W: Write>(
     sink.write(message)
 }
 
+include!("daemon/sections/legacy_messages.rs");
+
 include!("daemon/sections/server_runtime.rs");
 
 include!("daemon/sections/session_runtime.rs");

--- a/crates/daemon/src/daemon/sections/delegation.rs
+++ b/crates/daemon/src/daemon/sections/delegation.rs
@@ -181,9 +181,13 @@ fn read_trimmed_line<R: BufRead>(reader: &mut R) -> io::Result<Option<String>> {
     Ok(Some(line))
 }
 
-fn advertise_capabilities(stream: &mut TcpStream, modules: &[ModuleRuntime]) -> io::Result<()> {
+fn advertise_capabilities(
+    stream: &mut TcpStream,
+    modules: &[ModuleRuntime],
+    messages: &LegacyMessageCache,
+) -> io::Result<()> {
     for payload in advertised_capability_lines(modules) {
-        let message = format_legacy_daemon_message(LegacyDaemonMessage::Capabilities {
+        let message = messages.render(LegacyDaemonMessage::Capabilities {
             flags: payload.as_str(),
         });
         stream.write_all(message.as_bytes())?;

--- a/crates/daemon/src/daemon/sections/legacy_messages.rs
+++ b/crates/daemon/src/daemon/sections/legacy_messages.rs
@@ -1,0 +1,80 @@
+/// Caches frequently emitted legacy daemon messages to avoid repeated
+/// allocations while serving clients.
+///
+/// The helper implements a small flyweight that retains canonical
+/// representations of the `@RSYNCD: OK` and `@RSYNCD: EXIT` responses. Dynamic
+/// messages fall back to [`format_legacy_daemon_message`], ensuring formatting
+/// parity with upstream rsync without duplicating string construction logic.
+#[derive(Debug)]
+struct LegacyMessageCache {
+    ok: Box<[u8]>,
+    exit: Box<[u8]>,
+}
+
+impl Default for LegacyMessageCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl LegacyMessageCache {
+    fn new() -> Self {
+        let ok = format_legacy_daemon_message(LegacyDaemonMessage::Ok)
+            .into_boxed_str()
+            .into_boxed_bytes();
+        let exit = format_legacy_daemon_message(LegacyDaemonMessage::Exit)
+            .into_boxed_str()
+            .into_boxed_bytes();
+        Self { ok, exit }
+    }
+
+    fn render(&self, message: LegacyDaemonMessage<'_>) -> LegacyMessage<'_> {
+        match message {
+            LegacyDaemonMessage::Ok => LegacyMessage::Borrowed(&self.ok),
+            LegacyDaemonMessage::Exit => LegacyMessage::Borrowed(&self.exit),
+            other => LegacyMessage::Owned(format_legacy_daemon_message(other)),
+        }
+    }
+
+    fn write(
+        &self,
+        stream: &mut TcpStream,
+        limiter: &mut Option<BandwidthLimiter>,
+        message: LegacyDaemonMessage<'_>,
+    ) -> io::Result<()> {
+        let rendered = self.render(message);
+        write_limited(stream, limiter, rendered.as_bytes())
+    }
+
+    fn write_ok(
+        &self,
+        stream: &mut TcpStream,
+        limiter: &mut Option<BandwidthLimiter>,
+    ) -> io::Result<()> {
+        write_limited(stream, limiter, &self.ok)
+    }
+
+    fn write_exit(
+        &self,
+        stream: &mut TcpStream,
+        limiter: &mut Option<BandwidthLimiter>,
+    ) -> io::Result<()> {
+        write_limited(stream, limiter, &self.exit)
+    }
+}
+
+/// Borrowed or owned representation of a formatted legacy daemon message.
+#[derive(Debug)]
+enum LegacyMessage<'a> {
+    Borrowed(&'a [u8]),
+    Owned(String),
+}
+
+impl LegacyMessage<'_> {
+    fn as_bytes(&self) -> &[u8] {
+        match self {
+            LegacyMessage::Borrowed(bytes) => bytes,
+            LegacyMessage::Owned(text) => text.as_bytes(),
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a LegacyMessageCache flyweight so the daemon reuses formatted @RSYNCD: OK/EXIT banners
- refactor legacy session and module handlers to write legacy responses through the cache helpers
- update capability advertising to share the cached formatter and avoid repeated allocations

## Testing
- cargo clippy --workspace --all-targets --all-features
- cargo test -p rsync-daemon

------
[Codex Task](