### PR TITLE
Fix fsync CLI plumbing

### DIFF
--- a/crates/cli/src/frontend/execution/drive/workflow/mod.rs
+++ b/crates/cli/src/frontend/execution/drive/workflow/mod.rs
@@ -142,6 +142,7 @@ where
         stats,
         partial,
         preallocate,
+        fsync,
         delay_updates,
         partial_dir,
         temp_dir,
@@ -435,6 +436,7 @@ where
         stats,
         partial,
         preallocate,
+        fsync,
         delay_updates,
         partial_dir: partial_dir.as_ref(),
         temp_dir: temp_dir.as_ref(),
@@ -583,6 +585,7 @@ where
     } = metadata;
 
     let prune_empty_dirs_flag = prune_empty_dirs.unwrap_or(false);
+    let fsync_flag = fsync.unwrap_or(false);
     let inplace_enabled = inplace.unwrap_or(false);
     let append_enabled = append.unwrap_or(false);
     let whole_file_enabled = whole_file_option.unwrap_or(true);
@@ -653,6 +656,7 @@ where
         debug_flags_list,
         partial,
         preallocate,
+        fsync: fsync_flag,
         partial_dir: partial_dir.clone(),
         temp_dir: temp_dir.clone(),
         delay_updates,

--- a/crates/engine/src/local_copy/tests/execute_fsync.rs
+++ b/crates/engine/src/local_copy/tests/execute_fsync.rs
@@ -1,0 +1,51 @@
+use crate::local_copy::{
+    test_support::take_fsync_call_count, LocalCopyExecution, LocalCopyOptions, LocalCopyPlan,
+};
+
+#[test]
+fn execute_performs_fsync_when_requested() {
+    let temp = tempdir().expect("tempdir");
+    let source = temp.path().join("source.txt");
+    let destination = temp.path().join("dest.txt");
+    fs::write(&source, b"payload").expect("write source");
+
+    let operands = vec![
+        source.into_os_string(),
+        destination.clone().into_os_string(),
+    ];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+
+    // Clear any previous instrumentation counts.
+    take_fsync_call_count();
+
+    let options = LocalCopyOptions::default().fsync(true);
+    plan
+        .execute_with_options(LocalCopyExecution::Apply, options)
+        .expect("copy succeeds");
+
+    assert_eq!(take_fsync_call_count(), 1);
+    assert!(destination.exists());
+}
+
+#[test]
+fn execute_skips_fsync_when_not_requested() {
+    let temp = tempdir().expect("tempdir");
+    let source = temp.path().join("source.txt");
+    let destination = temp.path().join("dest.txt");
+    fs::write(&source, b"payload").expect("write source");
+
+    let operands = vec![
+        source.into_os_string(),
+        destination.clone().into_os_string(),
+    ];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+
+    take_fsync_call_count();
+
+    plan
+        .execute_with_options(LocalCopyExecution::Apply, LocalCopyOptions::default())
+        .expect("copy succeeds");
+
+    assert_eq!(take_fsync_call_count(), 0);
+    assert!(destination.exists());
+}


### PR DESCRIPTION
## Summary
- plumb the parsed `--fsync` flag into both the remote fallback context and the config builder
- add local copy regression tests that assert fsync instrumentation is toggled by the option

## Testing
- cargo fmt
- cargo test --workspace --all-features *(fails: existing oc-rsync-cli integration tests unrelated to fsync wiring remain red)*

------
[Codex Task](