### PR TITLE
Fix CLI argument tests for blocking I/O and sockopts

### DIFF
--- a/crates/cli/src/frontend/tests/parse_args_recognises_blocking.rs
+++ b/crates/cli/src/frontend/tests/parse_args_recognises_blocking.rs
@@ -4,10 +4,12 @@ use super::*;
 #[test]
 fn parse_args_recognises_blocking_io_flag() {
     let parsed = parse_args([
+        OsString::from(RSYNC),
         OsString::from("--blocking-io"),
         OsString::from("src"),
         OsString::from("dest"),
-    ]);
+    ])
+    .expect("parse");
 
     assert_eq!(parsed.blocking_io, Some(true));
 }
@@ -15,10 +17,12 @@ fn parse_args_recognises_blocking_io_flag() {
 #[test]
 fn parse_args_recognises_no_blocking_io_flag() {
     let parsed = parse_args([
+        OsString::from(RSYNC),
         OsString::from("--no-blocking-io"),
         OsString::from("src"),
         OsString::from("dest"),
-    ]);
+    ])
+    .expect("parse");
 
     assert_eq!(parsed.blocking_io, Some(false));
 }

--- a/crates/cli/src/frontend/tests/parse_args_recognises_sockopts.rs
+++ b/crates/cli/src/frontend/tests/parse_args_recognises_sockopts.rs
@@ -4,10 +4,12 @@ use super::*;
 #[test]
 fn parse_args_recognises_sockopts_option() {
     let parsed = parse_args([
+        OsString::from(RSYNC),
         OsString::from("--sockopts=SO_SNDBUF=8192"),
         OsString::from("src"),
         OsString::from("dest"),
-    ]);
+    ])
+    .expect("parse");
 
     assert_eq!(parsed.sockopts, Some(OsString::from("SO_SNDBUF=8192")));
 }


### PR DESCRIPTION
## Summary
- ensure the blocking-io flag tests pass the program name and unwrap the parser result
- update the sockopts test to provide the program name and check the parsed value

## Testing
- cargo test -p oc-rsync-cli parse_args_recognises_blocking -- --nocapture
- cargo test -p oc-rsync-cli parse_args_recognises_sockopts -- --nocapture

------
[Codex Task](