### PR TITLE
Default client builder to recursive transfers

### DIFF
--- a/crates/core/src/client/config/client/mod.rs
+++ b/crates/core/src/client/config/client/mod.rs
@@ -211,7 +211,7 @@ impl ClientConfig {
     /// Creates a new [`ClientConfigBuilder`].
     #[must_use]
     pub fn builder() -> ClientConfigBuilder {
-        ClientConfigBuilder::default()
+        ClientConfigBuilder::default().recursive(true)
     }
 
     /// Returns the configured iconv setting.


### PR DESCRIPTION
## Summary
- ensure `ClientConfig::builder()` enables recursive traversal by default so local directory copies behave as expected

## Testing
- not run (build dependency compilation exceeds session limits)

------
[Codex Task](