### PR TITLE
Avoid host ACL library for cross builds

### DIFF
--- a/crates/meta/build.rs
+++ b/crates/meta/build.rs
@@ -12,6 +12,11 @@ fn main() {
         return;
     }
 
+    if target_triplet_mismatch() {
+        println!("cargo:rustc-link-lib=dylib=acl");
+        return;
+    }
+
     if let Some(path) = locate_libacl() {
         if let Some(out_dir) = env::var_os("OUT_DIR") {
             let out_dir = PathBuf::from(out_dir);
@@ -30,6 +35,13 @@ fn main() {
     }
 
     println!("cargo:rustc-link-lib=dylib=acl");
+}
+
+fn target_triplet_mismatch() -> bool {
+    match (env::var("HOST"), env::var("TARGET")) {
+        (Ok(host), Ok(target)) => host != target,
+        _ => false,
+    }
 }
 
 fn target_exposes_acl_via_libsystem() -> bool {


### PR DESCRIPTION
## Summary
- skip host-side ACL discovery when the cargo host and target differ
- always fall back to the target toolchain’s default ACL search path during cross builds

## Testing
- `cargo --locked build --profile dist --target aarch64-unknown-linux-gnu --bin oc-rsync` *(fails: zstd-sys/openssl-sys need Zig download in container)*

------
[Codex Task](