### PR TITLE
Fix Homebrew formula to install oc binaries

### DIFF
--- a/Formula/oc-rsync.rb
+++ b/Formula/oc-rsync.rb
@@ -11,10 +11,9 @@ class OcRsync < Formula
   depends_on "rust" => :build
 
   def install
-    system "cargo", "build", "--release", "--locked", "--bin", "oc-rsync"
+    system "cargo", "build", "--release", "--locked", "--bin", "oc-rsync", "--bin", "oc-rsyncd"
     bin.install "target/release/oc-rsync"
-
-    bin.install "packaging/bin/oc-rsyncd"
+    bin.install "target/release/oc-rsyncd"
 
     (etc/"oc-rsyncd").install "packaging/etc/oc-rsyncd/oc-rsyncd.conf"
     (etc/"oc-rsyncd").install "packaging/etc/oc-rsyncd/oc-rsyncd.secrets"


### PR DESCRIPTION
## Summary
- ensure the Homebrew formula builds both oc-rsync and oc-rsyncd via cargo
- install the oc-rsyncd binary from the cargo build output instead of the wrapper script

## Testing
- ./tools/verify-brew-formula.sh Formula/oc-rsync.rb

------
[Codex Task](