### PR TITLE
Fix clippy regressions in change tracking and fallback tests

### DIFF
--- a/crates/cli/src/frontend/tests/remote_fallback_forwards_compress.rs
+++ b/crates/cli/src/frontend/tests/remote_fallback_forwards_compress.rs
@@ -71,9 +71,8 @@ exit 0
     assert!(stderr.is_empty());
 
     let recorded = std::fs::read_to_string(&args_path).expect("read args file");
-    let mut lines = recorded.lines();
     let mut seen_choice = false;
-    while let Some(line) = lines.next() {
+    for line in recorded.lines() {
         if line == "--compress-choice=zlib" {
             seen_choice = true;
             break;

--- a/crates/engine/src/local_copy/plan/change_set.rs
+++ b/crates/engine/src/local_copy/plan/change_set.rs
@@ -217,10 +217,10 @@ impl LocalCopyChangeSet {
             wrote_data,
         ));
 
-        if metadata_options.permissions() {
-            if permissions_changed(metadata, existing, destination_previously_existed) {
-                change_set = change_set.with_permissions_changed(true);
-            }
+        if metadata_options.permissions()
+            && permissions_changed(metadata, existing, destination_previously_existed)
+        {
+            change_set = change_set.with_permissions_changed(true);
         }
 
         if metadata_options.chmod().is_some() {
@@ -318,9 +318,7 @@ fn owner_changed(
     destination_previously_existed: bool,
 ) -> bool {
     if let Some(override_uid) = metadata_options.owner_override() {
-        return existing
-            .and_then(metadata_uid)
-            .map_or(true, |uid| uid != override_uid);
+        return existing.and_then(metadata_uid) != Some(override_uid);
     }
 
     if !metadata_options.owner() {
@@ -346,9 +344,7 @@ fn group_changed(
     destination_previously_existed: bool,
 ) -> bool {
     if let Some(override_gid) = metadata_options.group_override() {
-        return existing
-            .and_then(metadata_gid)
-            .map_or(true, |gid| gid != override_gid);
+        return existing.and_then(metadata_gid) != Some(override_gid);
     }
 
     if !metadata_options.group() {


### PR DESCRIPTION
## Summary
- collapse the nested permission check and simplify override comparisons in the change set builder to satisfy new clippy lints
- update the CLI fallback compress test to iterate with a `for` loop per clippy guidance

## Testing
- cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings

------
[Codex Task](