### PR TITLE
Align version banner web site with upstream

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,6 +102,7 @@ legacy_daemon_config_dir = "/etc"
 legacy_daemon_config = "/etc/rsyncd.conf"
 legacy_daemon_secrets = "/etc/rsyncd.secrets"
 source = "https://github.com/oferchen/rsync"
+web_site = "https://rsync.samba.org/"
 
 [workspace.metadata.oc_rsync.cross_compile]
 linux = ["x86_64", "aarch64"]

--- a/crates/core/src/version/constants.rs
+++ b/crates/core/src/version/constants.rs
@@ -32,10 +32,10 @@ pub const LATEST_COPYRIGHT_YEAR: &str = "2025";
 pub const COPYRIGHT_NOTICE: &str = "(C) 2025 by Ofer Chen.";
 
 /// Web site advertised by `rsync` in `--version` output.
-pub const WEB_SITE: &str = workspace::SOURCE_URL;
+pub const WEB_SITE: &str = workspace::WEB_SITE;
 
 /// Repository URL advertised by version banners and documentation.
-pub const SOURCE_URL: &str = WEB_SITE;
+pub const SOURCE_URL: &str = workspace::SOURCE_URL;
 
 /// Human-readable toolchain description rendered in `--version` output.
 pub const BUILD_TOOLCHAIN: &str = "Built in Rust 2024";

--- a/crates/core/src/version/metadata.rs
+++ b/crates/core/src/version/metadata.rs
@@ -33,7 +33,7 @@ use super::constants::{
 /// )));
 /// assert!(banner.contains("protocol version 32"));
 /// assert!(banner.contains("revision/build #"));
-/// assert!(banner.contains("https://github.com/oferchen/rsync"));
+/// assert!(banner.contains("https://rsync.samba.org/"));
 /// ```
 #[doc(alias = "--version")]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/crates/core/src/workspace/constants.rs
+++ b/crates/core/src/workspace/constants.rs
@@ -186,3 +186,20 @@ pub const SOURCE_URL: &str = env!("OC_RSYNC_WORKSPACE_SOURCE");
 pub const fn source_url() -> &'static str {
     SOURCE_URL
 }
+
+/// Canonical project web site advertised by version banners.
+pub const WEB_SITE: &str = env!("OC_RSYNC_WORKSPACE_WEB_SITE");
+
+/// Returns the canonical project web site advertised by version banners.
+///
+/// # Examples
+///
+/// ```
+/// use oc_rsync_core::workspace;
+///
+/// assert_eq!(workspace::web_site(), workspace::metadata().web_site());
+/// ```
+#[must_use]
+pub const fn web_site() -> &'static str {
+    WEB_SITE
+}

--- a/crates/core/src/workspace/metadata.rs
+++ b/crates/core/src/workspace/metadata.rs
@@ -2,7 +2,7 @@ use super::constants::{
     BRAND, CLIENT_PROGRAM_NAME, DAEMON_CONFIG_DIR, DAEMON_CONFIG_PATH, DAEMON_PROGRAM_NAME,
     DAEMON_SECRETS_PATH, LEGACY_CLIENT_PROGRAM_NAME, LEGACY_DAEMON_CONFIG_DIR,
     LEGACY_DAEMON_CONFIG_PATH, LEGACY_DAEMON_PROGRAM_NAME, LEGACY_DAEMON_SECRETS_PATH,
-    RUST_VERSION, SOURCE_URL, UPSTREAM_VERSION,
+    RUST_VERSION, SOURCE_URL, UPSTREAM_VERSION, WEB_SITE,
 };
 use super::protocol::PROTOCOL_VERSION;
 use serde::Serialize;
@@ -25,6 +25,7 @@ pub struct Metadata {
     legacy_daemon_config_path: &'static str,
     legacy_daemon_secrets_path: &'static str,
     source_url: &'static str,
+    web_site: &'static str,
 }
 
 impl Metadata {
@@ -117,6 +118,12 @@ impl Metadata {
     pub const fn source_url(self) -> &'static str {
         self.source_url
     }
+
+    /// Returns the canonical project web site advertised by version banners.
+    #[must_use]
+    pub const fn web_site(self) -> &'static str {
+        self.web_site
+    }
 }
 
 const WORKSPACE_METADATA: Metadata = Metadata {
@@ -135,6 +142,7 @@ const WORKSPACE_METADATA: Metadata = Metadata {
     legacy_daemon_config_path: LEGACY_DAEMON_CONFIG_PATH,
     legacy_daemon_secrets_path: LEGACY_DAEMON_SECRETS_PATH,
     source_url: SOURCE_URL,
+    web_site: WEB_SITE,
 };
 
 /// Returns an immutable snapshot of the workspace branding and packaging metadata.

--- a/crates/core/src/workspace/mod.rs
+++ b/crates/core/src/workspace/mod.rs
@@ -21,9 +21,9 @@ pub use constants::{
     BRAND, CLIENT_PROGRAM_NAME, DAEMON_CONFIG_DIR, DAEMON_CONFIG_PATH, DAEMON_PROGRAM_NAME,
     DAEMON_SECRETS_PATH, LEGACY_CLIENT_PROGRAM_NAME, LEGACY_DAEMON_CONFIG_DIR,
     LEGACY_DAEMON_CONFIG_PATH, LEGACY_DAEMON_PROGRAM_NAME, LEGACY_DAEMON_SECRETS_PATH,
-    RUST_VERSION, SOURCE_URL, UPSTREAM_VERSION, brand, client_program_name, daemon_program_name,
-    legacy_client_program_name, legacy_daemon_program_name, rust_version, source_url,
-    upstream_version,
+    RUST_VERSION, SOURCE_URL, UPSTREAM_VERSION, WEB_SITE, brand, client_program_name,
+    daemon_program_name, legacy_client_program_name, legacy_daemon_program_name, rust_version,
+    source_url, upstream_version, web_site,
 };
 pub use json::{metadata_json, metadata_json_pretty};
 pub use metadata::{Metadata, metadata};

--- a/crates/core/src/workspace/tests.rs
+++ b/crates/core/src/workspace/tests.rs
@@ -41,7 +41,6 @@ fn const_accessors_match_metadata() {
         legacy_daemon_program_name(),
         snapshot.legacy_daemon_program_name()
     );
-    assert_eq!(source_url(), snapshot.source_url());
     assert_eq!(
         legacy_daemon_config_dir(),
         Path::new(snapshot.legacy_daemon_config_dir())
@@ -54,6 +53,8 @@ fn const_accessors_match_metadata() {
         legacy_daemon_secrets_path(),
         Path::new(snapshot.legacy_daemon_secrets_path())
     );
+    assert_eq!(source_url(), snapshot.source_url());
+    assert_eq!(web_site(), snapshot.web_site());
 }
 
 #[test]
@@ -137,5 +138,9 @@ fn metadata_matches_manifest() {
     assert_eq!(
         snapshot.source_url(),
         oc["source"].as_str().expect("source")
+    );
+    assert_eq!(
+        snapshot.web_site(),
+        oc["web_site"].as_str().expect("web_site")
     );
 }


### PR DESCRIPTION
## Summary
- add a dedicated web_site entry to the workspace metadata and propagate it through the build script
- expose the new constant via the workspace facade so version metadata can advertise the upstream rsync web site
- keep the repository source URL for build-info reporting while aligning `--version` output with upstream banners

## Testing
- cargo test -p oc-rsync-core
- cargo run --bin oc-rsync -- --version | head -n 6

------
[Codex Task](