### PR TITLE
Align cross-compile matrix with build_daemon metadata

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -25,6 +25,7 @@ jobs:
             runner: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             build_command: build
+            build_daemon: true
             uses_zig: false
             needs_cross_gcc: false
             package_linux: false
@@ -35,6 +36,7 @@ jobs:
             runner: ubuntu-latest
             target: aarch64-unknown-linux-gnu
             build_command: build
+            build_daemon: true
             uses_zig: false
             needs_cross_gcc: true
             package_linux: false

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -25,6 +25,7 @@ jobs:
             runner: macos-14
             target: x86_64-apple-darwin
             build_command: zigbuild
+            build_daemon: true
             uses_zig: true
             needs_cross_gcc: false
             package_linux: false
@@ -35,6 +36,7 @@ jobs:
             runner: macos-14
             target: aarch64-apple-darwin
             build_command: zigbuild
+            build_daemon: true
             uses_zig: true
             needs_cross_gcc: false
             package_linux: false

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -25,6 +25,7 @@ jobs:
             runner: windows-latest
             target: x86_64-pc-windows-msvc
             build_command: build
+            build_daemon: false
             uses_zig: false
             needs_cross_gcc: false
             package_linux: false
@@ -35,6 +36,7 @@ jobs:
             runner: windows-latest
             target: aarch64-pc-windows-msvc
             build_command: build
+            build_daemon: false
             uses_zig: false
             needs_cross_gcc: false
             package_linux: false
@@ -45,6 +47,7 @@ jobs:
             runner: windows-latest
             target: i686-pc-windows-msvc
             build_command: build
+            build_daemon: false
             uses_zig: false
             needs_cross_gcc: false
             package_linux: false


### PR DESCRIPTION
## Summary
- add explicit build_daemon flags to each Linux, macOS, and Windows cross-compile matrix entry
- ensure CI metadata matches the expectations enforced by xtask validators

## Testing
- cargo test -p xtask validate_ci_cross_compile_matrix_accepts_workspace_configuration
- cargo test -p xtask validate_documents_accepts_workspace_branding

------
[Codex Task](