### PR TITLE
Align help banners with canonical source metadata

### DIFF
--- a/crates/cli/src/frontend/help.rs
+++ b/crates/cli/src/frontend/help.rs
@@ -1,6 +1,6 @@
 //! Rendering helpers for `--help` output.
 
-use oc_rsync_core::branding::{manifest, rust_version, source_url};
+use oc_rsync_core::branding::{manifest, rust_version, source_line};
 
 use super::ProgramName;
 
@@ -17,7 +17,7 @@ pub(super) fn help_text(program_name: ProgramName) -> String {
     format!(
         concat!(
             "{program} {version}\n",
-            "{website}\n",
+            "{source_line}\n",
             "\n",
             "Usage: {program} [-h] [-V] [--daemon] [-n] [-a] [-S] [-z] [-e COMMAND] [--delete] [--bwlimit=RATE[:BURST]] SOURCE... DEST\n",
             "\n",
@@ -191,7 +191,7 @@ pub(super) fn help_text(program_name: ProgramName) -> String {
         ),
         program = program,
         version = rust_version(),
-        website = source_url(),
+        source_line = source_line(),
         daemon = daemon,
     )
 }

--- a/crates/core/src/branding/mod.rs
+++ b/crates/core/src/branding/mod.rs
@@ -14,6 +14,8 @@
 //! funnelling branding details through this module we keep string literals out
 //! of business logic and make it trivial to update paths or names in one place.
 
+use std::sync::OnceLock;
+
 mod brand;
 mod constants;
 mod detection;
@@ -67,6 +69,15 @@ pub fn protocol_version() -> u32 {
 #[must_use]
 pub fn source_url() -> &'static str {
     manifest().source_url()
+}
+
+/// Returns the canonical `Source:` line rendered by user-facing banners.
+#[must_use]
+pub fn source_line() -> &'static str {
+    static SOURCE_LINE: OnceLock<String> = OnceLock::new();
+    SOURCE_LINE
+        .get_or_init(|| format!("Source: {}", manifest().source_url()))
+        .as_str()
 }
 
 /// Returns the sanitized build revision baked into the binaries.

--- a/crates/core/src/branding/tests.rs
+++ b/crates/core/src/branding/tests.rs
@@ -220,6 +220,7 @@ fn helper_accessors_forward_to_manifest() {
     assert_eq!(upstream_version(), manifest.upstream_version());
     assert_eq!(protocol_version(), manifest.protocol_version());
     assert_eq!(source_url(), manifest.source_url());
+    assert_eq!(source_line(), format!("Source: {}", manifest.source_url()));
     assert_eq!(build_revision(), manifest.build_revision());
     assert_eq!(build_toolchain(), manifest.build_toolchain());
     assert_eq!(oc_summary(), manifest.oc_summary());

--- a/crates/daemon/src/daemon/help.rs
+++ b/crates/daemon/src/daemon/help.rs
@@ -1,4 +1,4 @@
-use oc_rsync_core::branding::{Brand, manifest};
+use oc_rsync_core::branding::{Brand, manifest, source_line};
 
 /// Renders the deterministic daemon help text for the supplied branding profile.
 pub(crate) fn help_text(brand: Brand) -> String {
@@ -9,7 +9,7 @@ pub(crate) fn help_text(brand: Brand) -> String {
     format!(
         concat!(
             "{program} {version}\n",
-            "{web_site}\n",
+            "{source_line}\n",
             "\n",
             "Usage: {program} [--help] [--version] [--delegate-system-rsync] [ARGS...]\n",
             "\n",
@@ -39,7 +39,7 @@ pub(crate) fn help_text(brand: Brand) -> String {
         ),
         program = program,
         version = manifest.rust_version(),
-        web_site = manifest.source_url(),
+        source_line = source_line(),
         default_config = default_config,
     )
 }


### PR DESCRIPTION
## Summary
- add a cached `source_line` helper to `oc_rsync_core::branding` so user-visible banners share the canonical Source line formatting
- switch the client and daemon help renderers to use the shared helper, keeping the help banner aligned with the version banner output
- extend the branding test suite to cover the new helper and ensure it stays in sync with workspace metadata

## Testing
- cargo test -p oc-rsync-core --lib branding::tests::helper_accessors_forward_to_manifest
- cargo test --workspace --all-features *(fails: local_copy::tests::execute_copies_devices_as_regular_files_when_requested: No space left on device)*

------
[Codex Task](