### PR TITLE
Avoid infinite reads when copying devices as files

### DIFF
--- a/crates/engine/src/local_copy/context_impl/transfer.rs
+++ b/crates/engine/src/local_copy/context_impl/transfer.rs
@@ -269,8 +269,12 @@ impl<'a> CopyContext<'a> {
         let mut literal_bytes: u64 = 0;
         let mut compressor = self.start_compressor(compress, source)?;
         let mut compressed_progress: u64 = 0;
+        let expected_remaining = total_size.saturating_sub(initial_bytes);
 
         loop {
+            if total_bytes >= expected_remaining {
+                break;
+            }
             self.enforce_timeout()?;
             let chunk_len = if let Some(limiter) = self.limiter.as_ref() {
                 limiter.recommended_read_size(buffer.len())


### PR DESCRIPTION
## Summary
- stop local copy transfers from reading more bytes than the recorded source size
- ensure device nodes treated as regular files exit the copy loop immediately when their reported length is zero

## Testing
- cargo test --all-features -p oc-rsync-engine execute_copies_devices_as_regular_files_when_requested

------
[Codex Task](