### PR TITLE
Propagate one-file-system option to local copy engine

### DIFF
--- a/crates/core/src/client/run.rs
+++ b/crates/core/src/client/run.rs
@@ -232,6 +232,7 @@ pub fn build_local_copy_options(
         .safe_links(config.safe_links())
         .devices(config.preserve_devices())
         .specials(config.preserve_specials())
+        .one_file_system(config.one_file_system())
         .relative_paths(config.relative_paths())
         .dirs(config.dirs())
         .implied_dirs(config.implied_dirs())

--- a/crates/core/src/client/tests/builder_compress.rs
+++ b/crates/core/src/client/tests/builder_compress.rs
@@ -412,6 +412,26 @@ fn local_copy_options_honour_temp_directory_setting() {
 }
 
 #[test]
+fn local_copy_options_respect_one_file_system_setting() {
+    let enabled = ClientConfig::builder()
+        .transfer_args([OsString::from("src"), OsString::from("dst")])
+        .one_file_system(true)
+        .build();
+
+    let enabled_options = build_local_copy_options(&enabled, None);
+    assert!(enabled.one_file_system());
+    assert!(enabled_options.one_file_system_enabled());
+
+    let default = ClientConfig::builder()
+        .transfer_args([OsString::from("src"), OsString::from("dst")])
+        .build();
+
+    let default_options = build_local_copy_options(&default, None);
+    assert!(!default.one_file_system());
+    assert!(!default_options.one_file_system_enabled());
+}
+
+#[test]
 fn resolve_connect_timeout_prefers_explicit_setting() {
     let explicit = TransferTimeout::Seconds(NonZeroU64::new(5).unwrap());
     let resolved =


### PR DESCRIPTION
## Summary
- plumb the `--one-file-system` toggle from the client configuration into the local copy plan so local transfers respect the flag
- add a focused unit test covering the translation of the option into `LocalCopyOptions`

## Testing
- cargo test -p oc-rsync-core local_copy_options_respect_one_file_system_setting

------
[Codex Task](