### PR TITLE
Honor RSYNC_PARTIAL_DIR defaults in CLI parsing

### DIFF
--- a/crates/cli/src/frontend/tests/parse_args_recognises_partial.rs
+++ b/crates/cli/src/frontend/tests/parse_args_recognises_partial.rs
@@ -1,5 +1,7 @@
 use super::common::*;
 use super::*;
+use std::ffi::OsStr;
+use std::path::Path;
 
 #[test]
 fn parse_args_recognises_partial_dir_and_enables_partial() {
@@ -16,4 +18,53 @@ fn parse_args_recognises_partial_dir_and_enables_partial() {
         parsed.partial_dir.as_deref(),
         Some(Path::new(".rsync-partial"))
     );
+}
+
+#[test]
+fn parse_args_uses_rsync_partial_dir_env() {
+    let _guard = EnvGuard::set("RSYNC_PARTIAL_DIR", OsStr::new(".env-partial"));
+
+    let parsed = parse_args([
+        OsString::from(RSYNC),
+        OsString::from("source"),
+        OsString::from("dest"),
+    ])
+    .expect("parse");
+
+    assert!(parsed.partial);
+    assert_eq!(
+        parsed.partial_dir.as_deref(),
+        Some(Path::new(".env-partial"))
+    );
+}
+
+#[test]
+fn parse_args_no_partial_overrides_rsync_partial_dir_env() {
+    let _guard = EnvGuard::set("RSYNC_PARTIAL_DIR", OsStr::new(".env-partial"));
+
+    let parsed = parse_args([
+        OsString::from(RSYNC),
+        OsString::from("--no-partial"),
+        OsString::from("source"),
+        OsString::from("dest"),
+    ])
+    .expect("parse");
+
+    assert!(!parsed.partial);
+    assert!(parsed.partial_dir.is_none());
+}
+
+#[test]
+fn parse_args_ignores_empty_rsync_partial_dir_env() {
+    let _guard = EnvGuard::set("RSYNC_PARTIAL_DIR", OsStr::new(""));
+
+    let parsed = parse_args([
+        OsString::from(RSYNC),
+        OsString::from("source"),
+        OsString::from("dest"),
+    ])
+    .expect("parse");
+
+    assert!(!parsed.partial);
+    assert!(parsed.partial_dir.is_none());
 }


### PR DESCRIPTION
## Summary
- teach the CLI parser to source a default partial directory from RSYNC_PARTIAL_DIR when the flag is omitted and `--no-partial` is not set
- add regression tests covering the environment default, explicit opt-out, and empty values

## Testing
- cargo test -p oc-rsync-cli parse_args_recognises_partial

------
[Codex Task](