### PR TITLE
Remove unnecessary unsafe env mutations

### DIFF
--- a/tests/cli_binaries.rs
+++ b/tests/cli_binaries.rs
@@ -367,10 +367,10 @@ mod locate_binary_tests {
     impl EnvVarGuard {
         fn set(key: &'static str, value: OsString) -> Self {
             let original = env::var_os(key);
-            // SAFETY: We guard environment mutations with a process-wide mutex to
-            // avoid concurrent changes across tests, matching the guidance in
+            // We guard environment mutations with a process-wide mutex to avoid
+            // concurrent changes across tests, matching the guidance in
             // `std::env` documentation for multi-threaded programs.
-            unsafe { env::set_var(key, &value) };
+            env::set_var(key, &value);
             Self { key, original }
         }
     }
@@ -378,12 +378,12 @@ mod locate_binary_tests {
     impl Drop for EnvVarGuard {
         fn drop(&mut self) {
             if let Some(original) = self.original.as_ref() {
-                // SAFETY: The global mutex ensures no other thread performs an
+                // The global mutex ensures no other thread performs an
                 // environment mutation while we restore the prior value.
-                unsafe { env::set_var(self.key, original) };
+                env::set_var(self.key, original);
             } else {
-                // SAFETY: Protected by the same mutex as other mutations.
-                unsafe { env::remove_var(self.key) };
+                // Protected by the same mutex as other mutations.
+                env::remove_var(self.key);
             }
         }
     }

--- a/xtask/src/commands/enforce_limits/mod.rs
+++ b/xtask/src/commands/enforce_limits/mod.rs
@@ -282,13 +282,12 @@ mod tests {
     }
 
     impl EnvGuard {
-        #[allow(unsafe_code)]
         fn remove_many<const N: usize>(keys: [&'static str; N]) -> Self {
             let guard = env_lock().lock().unwrap();
             let mut previous = Vec::with_capacity(N);
             for key in keys {
                 previous.push((key, env::var_os(key)));
-                unsafe { env::remove_var(key) };
+                env::remove_var(key);
             }
             Self {
                 previous,
@@ -298,13 +297,12 @@ mod tests {
     }
 
     impl Drop for EnvGuard {
-        #[allow(unsafe_code)]
         fn drop(&mut self) {
             while let Some((key, value)) = self.previous.pop() {
                 if let Some(value) = value {
-                    unsafe { env::set_var(key, value) };
+                    env::set_var(key, value);
                 } else {
-                    unsafe { env::remove_var(key) };
+                    env::remove_var(key);
                 }
             }
         }

--- a/xtask/src/commands/package/tests.rs
+++ b/xtask/src/commands/package/tests.rs
@@ -48,10 +48,9 @@ impl ScopedEnv {
         self.previous.push((key, env::var_os(key)));
     }
 
-    #[allow(unsafe_code)]
     fn set_os(&mut self, key: &'static str, value: &OsStr) {
         self.ensure_tracked(key);
-        unsafe { env::set_var(key, value) };
+        env::set_var(key, value);
     }
 
     fn set_str(&mut self, key: &'static str, value: &str) {
@@ -60,13 +59,12 @@ impl ScopedEnv {
 }
 
 impl Drop for ScopedEnv {
-    #[allow(unsafe_code)]
     fn drop(&mut self) {
         for (key, previous) in self.previous.drain(..).rev() {
             if let Some(value) = previous {
-                unsafe { env::set_var(key, value) };
+                env::set_var(key, value);
             } else {
-                unsafe { env::remove_var(key) };
+                env::remove_var(key);
             }
         }
     }

--- a/xtask/src/commands/release/upload.rs
+++ b/xtask/src/commands/release/upload.rs
@@ -390,23 +390,21 @@ mod tests {
             }
         }
 
-        #[allow(unsafe_code)]
         fn set(&mut self, key: &'static str, value: OsString) {
             if self.previous.iter().all(|(existing, _)| existing != &key) {
                 self.previous.push((key, env::var_os(key)));
             }
-            unsafe { env::set_var(key, &value) };
+            env::set_var(key, &value);
         }
     }
 
-    #[allow(unsafe_code)]
     impl Drop for ScopedEnv {
         fn drop(&mut self) {
             for (key, value) in self.previous.drain(..).rev() {
                 if let Some(value) = value {
-                    unsafe { env::set_var(key, value) };
+                    env::set_var(key, value);
                 } else {
-                    unsafe { env::remove_var(key) };
+                    env::remove_var(key);
                 }
             }
         }

--- a/xtask/src/util.rs
+++ b/xtask/src/util.rs
@@ -487,11 +487,10 @@ mod tests {
     }
 
     impl EnvGuard {
-        #[allow(unsafe_code)]
         fn set(key: &'static str, value: &str) -> Self {
             let guard = env_lock().lock().unwrap();
             let previous = env::var_os(key);
-            unsafe { env::set_var(key, value) };
+            env::set_var(key, value);
             Self {
                 key,
                 previous,
@@ -499,11 +498,10 @@ mod tests {
             }
         }
 
-        #[allow(unsafe_code)]
         fn remove(key: &'static str) -> Self {
             let guard = env_lock().lock().unwrap();
             let previous = env::var_os(key);
-            unsafe { env::remove_var(key) };
+            env::remove_var(key);
             Self {
                 key,
                 previous,
@@ -513,12 +511,11 @@ mod tests {
     }
 
     impl Drop for EnvGuard {
-        #[allow(unsafe_code)]
         fn drop(&mut self) {
             if let Some(previous) = self.previous.take() {
-                unsafe { env::set_var(self.key, previous) };
+                env::set_var(self.key, previous);
             } else {
-                unsafe { env::remove_var(self.key) };
+                env::remove_var(self.key);
             }
         }
     }


### PR DESCRIPTION
## Summary
- replace superfluous `unsafe` blocks around environment mutations in test helpers
- update xtask environment guards to rely on safe `std::env` APIs

## Testing
- cargo fmt
- cargo check -p xtask

------
[Codex Task](