### PR TITLE
Wrap environment mutation helpers in unsafe blocks

### DIFF
--- a/xtask/src/commands/enforce_limits/mod.rs
+++ b/xtask/src/commands/enforce_limits/mod.rs
@@ -282,12 +282,15 @@ mod tests {
     }
 
     impl EnvGuard {
+        #[allow(unsafe_code)]
         fn remove_many<const N: usize>(keys: [&'static str; N]) -> Self {
             let guard = env_lock().lock().unwrap();
             let mut previous = Vec::with_capacity(N);
             for key in keys {
                 previous.push((key, env::var_os(key)));
-                env::remove_var(key);
+                unsafe {
+                    env::remove_var(key);
+                }
             }
             Self {
                 previous,
@@ -297,12 +300,17 @@ mod tests {
     }
 
     impl Drop for EnvGuard {
+        #[allow(unsafe_code)]
         fn drop(&mut self) {
             while let Some((key, value)) = self.previous.pop() {
                 if let Some(value) = value {
-                    env::set_var(key, value);
+                    unsafe {
+                        env::set_var(key, value);
+                    }
                 } else {
-                    env::remove_var(key);
+                    unsafe {
+                        env::remove_var(key);
+                    }
                 }
             }
         }

--- a/xtask/src/commands/package/tests.rs
+++ b/xtask/src/commands/package/tests.rs
@@ -48,9 +48,12 @@ impl ScopedEnv {
         self.previous.push((key, env::var_os(key)));
     }
 
+    #[allow(unsafe_code)]
     fn set_os(&mut self, key: &'static str, value: &OsStr) {
         self.ensure_tracked(key);
-        env::set_var(key, value);
+        unsafe {
+            env::set_var(key, value);
+        }
     }
 
     fn set_str(&mut self, key: &'static str, value: &str) {
@@ -59,12 +62,17 @@ impl ScopedEnv {
 }
 
 impl Drop for ScopedEnv {
+    #[allow(unsafe_code)]
     fn drop(&mut self) {
         for (key, previous) in self.previous.drain(..).rev() {
             if let Some(value) = previous {
-                env::set_var(key, value);
+                unsafe {
+                    env::set_var(key, value);
+                }
             } else {
-                env::remove_var(key);
+                unsafe {
+                    env::remove_var(key);
+                }
             }
         }
     }

--- a/xtask/src/commands/release/upload.rs
+++ b/xtask/src/commands/release/upload.rs
@@ -390,21 +390,29 @@ mod tests {
             }
         }
 
+        #[allow(unsafe_code)]
         fn set(&mut self, key: &'static str, value: OsString) {
             if self.previous.iter().all(|(existing, _)| existing != &key) {
                 self.previous.push((key, env::var_os(key)));
             }
-            env::set_var(key, &value);
+            unsafe {
+                env::set_var(key, &value);
+            }
         }
     }
 
     impl Drop for ScopedEnv {
+        #[allow(unsafe_code)]
         fn drop(&mut self) {
             for (key, value) in self.previous.drain(..).rev() {
                 if let Some(value) = value {
-                    env::set_var(key, value);
+                    unsafe {
+                        env::set_var(key, value);
+                    }
                 } else {
-                    env::remove_var(key);
+                    unsafe {
+                        env::remove_var(key);
+                    }
                 }
             }
         }

--- a/xtask/src/util.rs
+++ b/xtask/src/util.rs
@@ -487,10 +487,13 @@ mod tests {
     }
 
     impl EnvGuard {
+        #[allow(unsafe_code)]
         fn set(key: &'static str, value: &str) -> Self {
             let guard = env_lock().lock().unwrap();
             let previous = env::var_os(key);
-            env::set_var(key, value);
+            unsafe {
+                env::set_var(key, value);
+            }
             Self {
                 key,
                 previous,
@@ -498,10 +501,13 @@ mod tests {
             }
         }
 
+        #[allow(unsafe_code)]
         fn remove(key: &'static str) -> Self {
             let guard = env_lock().lock().unwrap();
             let previous = env::var_os(key);
-            env::remove_var(key);
+            unsafe {
+                env::remove_var(key);
+            }
             Self {
                 key,
                 previous,
@@ -511,11 +517,16 @@ mod tests {
     }
 
     impl Drop for EnvGuard {
+        #[allow(unsafe_code)]
         fn drop(&mut self) {
             if let Some(previous) = self.previous.take() {
-                env::set_var(self.key, previous);
+                unsafe {
+                    env::set_var(self.key, previous);
+                }
             } else {
-                env::remove_var(self.key);
+                unsafe {
+                    env::remove_var(self.key);
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- wrap environment mutation helpers used in tests and xtask utilities with explicit `unsafe` blocks now required by `std::env`
- annotate guard helpers with `#[allow(unsafe_code)]` and continue to restore prior values under the shared environment mutexes

## Testing
- cargo test

------
[Codex Task](