### PR TITLE
Fix overflow in filter shortcut counting

### DIFF
--- a/crates/cli/src/frontend/arguments/parsed_args.rs
+++ b/crates/cli/src/frontend/arguments/parsed_args.rs
@@ -122,7 +122,7 @@ pub(crate) struct ParsedArgs {
     pub(crate) include_from: Vec<OsString>,
     pub(crate) filters: Vec<OsString>,
     pub(crate) cvs_exclude: bool,
-    pub(crate) rsync_filter_shortcuts: u8,
+    pub(crate) rsync_filter_shortcuts: usize,
     pub(crate) files_from: Vec<OsString>,
     pub(crate) from0: bool,
     pub(crate) info: Vec<OsString>,

--- a/crates/cli/src/frontend/arguments/parser.rs
+++ b/crates/cli/src/frontend/arguments/parser.rs
@@ -385,7 +385,7 @@ where
         .remove_many::<OsString>("filter")
         .map(|values| values.collect())
         .unwrap_or_default();
-    let rsync_filter_shortcuts = rsync_filter_indices.len() as u8;
+    let rsync_filter_shortcuts = rsync_filter_indices.len();
     let filter_args = collect_filter_arguments(&filters, &filter_indices, &rsync_filter_indices);
     let cvs_exclude = matches.get_flag("cvs-exclude");
     let files_from = matches

--- a/crates/cli/src/frontend/execution/drive/fallback.rs
+++ b/crates/cli/src/frontend/execution/drive/fallback.rs
@@ -117,7 +117,7 @@ pub(crate) struct FallbackInputs {
     pub(crate) exclude_from: Vec<OsString>,
     pub(crate) include_from: Vec<OsString>,
     pub(crate) filters: Vec<OsString>,
-    pub(crate) rsync_filter_shortcuts: u8,
+    pub(crate) rsync_filter_shortcuts: usize,
     pub(crate) compare_destinations: Vec<OsString>,
     pub(crate) copy_destinations: Vec<OsString>,
     pub(crate) link_destinations: Vec<OsString>,

--- a/crates/cli/src/frontend/execution/drive/workflow/fallback_plan.rs
+++ b/crates/cli/src/frontend/execution/drive/workflow/fallback_plan.rs
@@ -112,7 +112,7 @@ pub(crate) struct FallbackArgumentsContext<'a> {
     pub(crate) exclude_from: &'a [OsString],
     pub(crate) include_from: &'a [OsString],
     pub(crate) filters: &'a [OsString],
-    pub(crate) rsync_filter_shortcuts: u8,
+    pub(crate) rsync_filter_shortcuts: usize,
     pub(crate) compare_destinations: &'a [OsString],
     pub(crate) copy_destinations: &'a [OsString],
     pub(crate) link_destinations: &'a [OsString],

--- a/crates/core/src/client/fallback/args.rs
+++ b/crates/core/src/client/fallback/args.rs
@@ -214,7 +214,7 @@ pub struct RemoteFallbackArgs {
     /// Raw filter directives forwarded via repeated `--filter` flags.
     pub filters: Vec<OsString>,
     /// Number of times the `-F` shortcut was supplied.
-    pub rsync_filter_shortcuts: u8,
+    pub rsync_filter_shortcuts: usize,
     /// Reference directories forwarded via repeated `--compare-dest` flags.
     pub compare_destinations: Vec<OsString>,
     /// Reference directories forwarded via repeated `--copy-dest` flags.


### PR DESCRIPTION
## Summary
- store the count of `-F` shortcuts as a `usize` throughout CLI parsing and fallback argument plumbing
- avoid truncating large shortcut counts by removing the lossy cast in the filter argument collector

## Testing
- cargo test -p oc-rsync-cli parse_args_collects_filter_patterns -- --nocapture

------
[Codex Task](