### PR TITLE
Fix local delta copy when identical timestamps

### DIFF
--- a/crates/engine/src/local_copy/executor/file/comparison.rs
+++ b/crates/engine/src/local_copy/executor/file/comparison.rs
@@ -115,6 +115,11 @@ pub(crate) fn should_skip_copy(params: CopyComparison<'_>) -> bool {
                 return false;
             }
 
+            if !checksum && !size_only && modify_window.is_zero() && src == dst {
+                return files_checksum_match(source_path, destination_path, checksum_algorithm)
+                    .unwrap_or(false);
+            }
+
             true
         }
         _ => false,


### PR DESCRIPTION
## Summary
- ensure the local copy skip logic verifies content when metadata matches so delta copies still run when data diverges

## Testing
- cargo test -p oc-rsync-engine local_copy::tests::execute_delta_copy_reuses_existing_blocks -- --nocapture
- cargo test -p oc-rsync-engine should_skip_copy_detects_content_changes_with_identical_timestamps -- --nocapture

------
[Codex Task](