### PR TITLE
Avoid checksum comparisons when timestamps match

### DIFF
--- a/crates/engine/src/local_copy/executor/file/comparison.rs
+++ b/crates/engine/src/local_copy/executor/file/comparison.rs
@@ -115,11 +115,6 @@ pub(crate) fn should_skip_copy(params: CopyComparison<'_>) -> bool {
                 return false;
             }
 
-            if !checksum && !size_only && modify_window.is_zero() && src == dst {
-                return files_checksum_match(source_path, destination_path, checksum_algorithm)
-                    .unwrap_or(false);
-            }
-
             true
         }
         _ => false,


### PR DESCRIPTION
## Summary
- align the local copy skip decision with upstream behavior by relying on timestamps alone when checksum comparisons are not requested

## Testing
- cargo test -p oc-rsync-cli transfer_request_with_ignore_times_forces_copy_despite_matching_timestamps

------
[Codex Task](