### PR TITLE
Fix ignore-times handling for identical timestamps

### DIFF
--- a/crates/core/src/client/tests/ignore_times.rs
+++ b/crates/core/src/client/tests/ignore_times.rs
@@ -1,0 +1,28 @@
+#[test]
+fn sequential_runs_respect_ignore_times() {
+    use filetime::{set_file_times, FileTime};
+
+    let temp = tempdir().expect("tempdir");
+    let source = temp.path().join("source.txt");
+    let destination = temp.path().join("destination.txt");
+    fs::write(&source, b"newdata").expect("write source");
+    fs::write(&destination, b"olddata").expect("write destination");
+
+    let timestamp = std::time::UNIX_EPOCH + Duration::from_secs(1_700_200_000);
+    let filetime = FileTime::from_system_time(timestamp);
+    set_file_times(&source, filetime, filetime).expect("source times");
+    set_file_times(&destination, filetime, filetime).expect("dest times");
+
+    let operands = vec![source.clone().into_os_string(), destination.clone().into_os_string()];
+
+    let baseline_config = ClientConfig::builder().transfer_args(operands.clone()).build();
+    run_client(baseline_config).expect("baseline run");
+    assert_eq!(fs::read(&destination).expect("read dest"), b"olddata");
+
+    let ignore_config = ClientConfig::builder()
+        .transfer_args(operands)
+        .ignore_times(true)
+        .build();
+    run_client(ignore_config).expect("ignore run");
+    assert_eq!(fs::read(&destination).expect("read dest"), b"newdata");
+}

--- a/crates/core/src/client/tests/mod.rs
+++ b/crates/core/src/client/tests/mod.rs
@@ -12,3 +12,4 @@ include!("module_list_auth.rs");
 include!("module_list_listing.rs");
 include!("module_list_socket_options.rs");
 include!("error_helpers.rs");
+include!("ignore_times.rs");

--- a/crates/engine/src/local_copy/executor/file/comparison.rs
+++ b/crates/engine/src/local_copy/executor/file/comparison.rs
@@ -115,10 +115,6 @@ pub(crate) fn should_skip_copy(params: CopyComparison<'_>) -> bool {
                 return false;
             }
 
-            if src == dst && source.is_file() && destination.is_file() {
-                return files_content_matches(source_path, destination_path).unwrap_or(false);
-            }
-
             true
         }
         _ => false,
@@ -203,16 +199,6 @@ pub(crate) fn files_checksum_match(
     }
 
     Ok(source_hasher.finalize() == destination_hasher.finalize())
-}
-
-pub(crate) fn files_content_matches(source: &Path, destination: &Path) -> io::Result<bool> {
-    compare_files_lockstep(source, destination, |src_chunk, dst_chunk| {
-        if src_chunk == dst_chunk {
-            LockstepCheck::Continue
-        } else {
-            LockstepCheck::Diverged
-        }
-    })
 }
 
 enum LockstepCheck {


### PR DESCRIPTION
## Summary
- update the local copy comparator to skip content-based equality checks when mtimes already match so we mirror upstream ignore-times behaviour
- add a core-level regression test for sequential runs and register it in the client test suite

## Testing
- cargo test -p oc-rsync-cli transfer_request_with_ignore_times_forces_copy_despite_matching_timestamps
- cargo test -p oc-rsync-core sequential_runs_respect_ignore_times

------
[Codex Task](