### PR TITLE
Ensure copy skip heuristics verify file content

### DIFF
--- a/crates/engine/src/local_copy/context_impl/state.rs
+++ b/crates/engine/src/local_copy/context_impl/state.rs
@@ -164,7 +164,6 @@ impl<'a> CopyContext<'a> {
         relative: &Path,
         source: &Path,
         metadata: &fs::Metadata,
-        _metadata_options: &MetadataOptions,
         size_only: bool,
         ignore_times: bool,
         checksum: bool,

--- a/crates/engine/src/local_copy/executor/file/comparison.rs
+++ b/crates/engine/src/local_copy/executor/file/comparison.rs
@@ -115,7 +115,7 @@ pub(crate) fn should_skip_copy(params: CopyComparison<'_>) -> bool {
                 return false;
             }
 
-            true
+            files_contents_identical(source_path, destination_path).unwrap_or(false)
         }
         _ => false,
     }
@@ -237,6 +237,16 @@ where
     }
 
     Ok(true)
+}
+
+fn files_contents_identical(source: &Path, destination: &Path) -> io::Result<bool> {
+    compare_files_lockstep(source, destination, |source_chunk, destination_chunk| {
+        if source_chunk == destination_chunk {
+            LockstepCheck::Continue
+        } else {
+            LockstepCheck::Diverged
+        }
+    })
 }
 
 #[cfg(test)]

--- a/crates/engine/src/local_copy/executor/file/copy/links.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/links.rs
@@ -52,7 +52,6 @@ pub(super) fn process_links(
         relative_for_link,
         source,
         metadata,
-        &metadata_options,
         size_only_enabled,
         ignore_times_enabled,
         checksum_enabled,


### PR DESCRIPTION
## Summary
- prevent should_skip_copy from skipping files whose metadata matches but contents differ
- share the content comparison helper for copy decisions used by link-dest lookups
- satisfy clippy by trimming unused link-dest parameters

## Testing
- cargo test -p oc-rsync-engine --lib
- cargo clippy --workspace --all-targets --all-features -- -D warnings

------
[Codex Task](