### PR TITLE
Respect last occurrence for tri-state toggles

### DIFF
--- a/crates/cli/src/frontend/tests/parse_args_recognises_perms.rs
+++ b/crates/cli/src/frontend/tests/parse_args_recognises_perms.rs
@@ -36,3 +36,28 @@ fn parse_args_recognises_perms_and_times_flags() {
     assert_eq!(parsed.omit_dir_times, Some(false));
     assert_eq!(parsed.omit_link_times, Some(false));
 }
+
+#[test]
+fn parse_args_prefers_last_perms_toggle() {
+    let parsed = parse_args([
+        OsString::from(RSYNC),
+        OsString::from("--perms"),
+        OsString::from("--no-perms"),
+        OsString::from("source"),
+        OsString::from("dest"),
+    ])
+    .expect("parse conflicting perms");
+
+    assert_eq!(parsed.perms, Some(false));
+
+    let parsed = parse_args([
+        OsString::from(RSYNC),
+        OsString::from("--no-perms"),
+        OsString::from("--perms"),
+        OsString::from("source"),
+        OsString::from("dest"),
+    ])
+    .expect("parse overriding perms");
+
+    assert_eq!(parsed.perms, Some(true));
+}

--- a/crates/cli/src/frontend/tests/parse_args_recognises_recursive.rs
+++ b/crates/cli/src/frontend/tests/parse_args_recognises_recursive.rs
@@ -75,3 +75,28 @@ fn parse_args_recognises_no_dirs_flag() {
 
     assert_eq!(parsed.dirs, Some(false));
 }
+
+#[test]
+fn parse_args_prefers_last_dirs_toggle() {
+    let parsed = parse_args([
+        OsString::from(RSYNC),
+        OsString::from("--dirs"),
+        OsString::from("--no-dirs"),
+        OsString::from("source"),
+        OsString::from("dest"),
+    ])
+    .expect("parse dirs then no-dirs");
+
+    assert_eq!(parsed.dirs, Some(false));
+
+    let parsed = parse_args([
+        OsString::from(RSYNC),
+        OsString::from("--no-dirs"),
+        OsString::from("--dirs"),
+        OsString::from("source"),
+        OsString::from("dest"),
+    ])
+    .expect("parse no-dirs then dirs");
+
+    assert_eq!(parsed.dirs, Some(true));
+}


### PR DESCRIPTION
## Summary
- ensure the CLI tri-state helpers compare argument indices so the last toggle wins, matching rsync
- add regression coverage that mixes `--perms`/`--no-perms` and `--dirs`/`--no-dirs` to lock down the precedence

## Testing
- cargo test -p oc-rsync-cli parse_args_prefers_last_perms_toggle -- --nocapture
- cargo test -p oc-rsync-cli parse_args_prefers_last_dirs_toggle -- --nocapture
- cargo test -p oc-rsync-cli parse_args_recognises_perms_and_times_flags -- --nocapture

------
[Codex Task](