### PR TITLE
Ensure delete mode verifies file content

### DIFF
--- a/crates/engine/src/local_copy/executor/file/copy/transfer.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer.rs
@@ -13,7 +13,7 @@ use libc::{self, EACCES, EINVAL, ENOTSUP, EPERM, EROFS};
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use crate::local_copy::{
-    CopyContext, CreatedEntryKind, DeferredUpdate, DeleteTiming, FinalizeMetadataParams,
+    CopyContext, CreatedEntryKind, DeferredUpdate, FinalizeMetadataParams,
     LocalCopyAction, LocalCopyChangeSet, LocalCopyError, LocalCopyExecution, LocalCopyMetadata,
     LocalCopyRecord,
 };
@@ -82,10 +82,7 @@ pub(super) fn execute_transfer(
             let requires_content_verification = existing.is_file()
                 && !checksum_enabled
                 && (context.options().backup_enabled()
-                    || matches!(
-                        context.delete_timing(),
-                        Some(DeleteTiming::After | DeleteTiming::Delay)
-                    ));
+                    || context.delete_timing().is_some());
 
             if requires_content_verification {
                 skip = match files_checksum_match(


### PR DESCRIPTION
## Summary
- require checksum verification whenever a deletion mode is enabled before reusing an existing destination file
- drop an unused DeleteTiming import after the verification rule change

## Testing
- cargo test -p oc-rsync-engine execute_with_delete_removes_extraneous_entries -- --nocapture

------
[Codex Task](