### PR TITLE
Expose daemon wrapper metadata to wrappers

### DIFF
--- a/crates/core/src/branding/brand.rs
+++ b/crates/core/src/branding/brand.rs
@@ -120,6 +120,12 @@ impl Brand {
         self.profile().daemon_program_name()
     }
 
+    /// Returns the compatibility wrapper program name, if available.
+    #[must_use]
+    pub const fn daemon_wrapper_program_name(self) -> Option<&'static str> {
+        self.profile().daemon_wrapper_program_name()
+    }
+
     /// Returns the preferred daemon configuration directory as a [`Path`].
     #[must_use]
     pub fn daemon_config_dir(self) -> &'static Path {

--- a/crates/core/src/branding/manifest.rs
+++ b/crates/core/src/branding/manifest.rs
@@ -39,7 +39,8 @@ pub struct BrandManifest {
 ///
 /// Instances of this structure are produced via
 /// [`BrandManifest::summary_for`] and expose the canonical program names,
-/// configuration paths, and version metadata associated with a given brand.
+/// configuration paths, version metadata, and optional compatibility wrapper
+/// names associated with a given brand.
 /// The summary keeps branding details and release identifiers in one place so
 /// packaging automation, documentation generators, and entry points can surface
 /// consistent human-readable descriptions without duplicating string literals.
@@ -57,6 +58,7 @@ pub struct BrandManifest {
 pub struct BrandSummary {
     brand: Brand,
     profile: BrandProfile,
+    daemon_wrapper_program_name: Option<&'static str>,
     rust_version: &'static str,
     upstream_version: &'static str,
     protocol_version: u32,
@@ -171,6 +173,7 @@ impl BrandManifest {
         BrandSummary {
             brand,
             profile: self.profile_for(brand),
+            daemon_wrapper_program_name: self.profile_for(brand).daemon_wrapper_program_name(),
             rust_version: self.rust_version,
             upstream_version: self.upstream_version,
             protocol_version: self.protocol_version,
@@ -235,6 +238,12 @@ impl BrandSummary {
         self.profile.daemon_program_name()
     }
 
+    /// Returns the compatibility wrapper program name, if one exists.
+    #[must_use]
+    pub const fn daemon_wrapper_program_name(self) -> Option<&'static str> {
+        self.daemon_wrapper_program_name
+    }
+
     /// Returns the canonical daemon configuration directory for the brand.
     #[must_use]
     pub const fn daemon_config_dir(self) -> &'static str {
@@ -292,12 +301,17 @@ impl BrandSummary {
 
 impl fmt::Display for BrandSummary {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let wrapper = self
+            .daemon_wrapper_program_name()
+            .unwrap_or_else(|| self.daemon_program_name());
+
         write!(
             f,
-            "brand={} client={} daemon={} config={} secrets={} version={} (upstream {}) protocol={} source={} revision={} toolchain={}",
+            "brand={} client={} daemon={} wrapper={} config={} secrets={} version={} (upstream {}) protocol={} source={} revision={} toolchain={}",
             self.brand.label(),
             self.client_program_name(),
             self.daemon_program_name(),
+            wrapper,
             self.daemon_config_path(),
             self.daemon_secrets_path(),
             self.rust_version(),
@@ -336,6 +350,14 @@ mod tests {
         assert_eq!(
             manifest.daemon_program_name_for(Brand::Upstream),
             metadata.legacy_daemon_program_name()
+        );
+        assert_eq!(
+            manifest.oc().daemon_wrapper_program_name(),
+            Some(metadata.daemon_wrapper_program_name())
+        );
+        assert_eq!(
+            manifest.upstream().daemon_wrapper_program_name(),
+            Some(metadata.legacy_daemon_program_name())
         );
         assert_eq!(
             manifest.daemon_config_dir_for(Brand::Oc),
@@ -385,6 +407,7 @@ mod tests {
         assert_eq!(summary.brand(), Brand::Oc);
         assert_eq!(summary.client_program_name(), "oc-rsync");
         assert_eq!(summary.daemon_program_name(), "oc-rsync");
+        assert_eq!(summary.daemon_wrapper_program_name(), Some("oc-rsyncd"));
         assert_eq!(
             summary.daemon_config_path(),
             "/etc/oc-rsyncd/oc-rsyncd.conf"
@@ -414,9 +437,19 @@ mod tests {
         assert_eq!(summary.brand(), Brand::Upstream);
         assert_eq!(summary.client_program_name(), "rsync");
         assert_eq!(summary.daemon_program_name(), "rsyncd");
+        assert_eq!(summary.daemon_wrapper_program_name(), Some("rsyncd"));
         assert_eq!(summary.daemon_config_path(), "/etc/rsyncd.conf");
         assert_eq!(summary.daemon_secrets_path(), "/etc/rsyncd.secrets");
         assert_eq!(summary.rust_version(), manifest.rust_version());
         assert_eq!(summary.upstream_version(), manifest.upstream_version());
+    }
+
+    #[test]
+    fn summary_display_includes_wrapper_alias() {
+        let manifest = manifest();
+        let summary = manifest.oc_summary();
+        let rendered = summary.to_string();
+
+        assert!(rendered.contains("wrapper=oc-rsyncd"));
     }
 }

--- a/crates/core/src/branding/profile.rs
+++ b/crates/core/src/branding/profile.rs
@@ -14,8 +14,9 @@ use super::constants::{
 /// Describes the public-facing identity used by a binary distribution.
 ///
 /// The structure captures the canonical client and daemon program names
-/// together with the configuration directory, configuration file, and secrets
-/// file that ship with the distribution. Higher layers select the appropriate
+/// together with the optional compatibility wrapper name, configuration
+/// directory, configuration file, and secrets file that ship with the
+/// distribution. Higher layers select the appropriate
 /// [`BrandProfile`] to render banners, locate configuration files, or display
 /// diagnostic messages without duplicating string literals across the
 /// codebase. The profiles are intentionally lightweight and `Copy` so they can
@@ -25,6 +26,7 @@ use super::constants::{
 pub struct BrandProfile {
     client_program_name: &'static str,
     daemon_program_name: &'static str,
+    daemon_wrapper_program_name: Option<&'static str>,
     daemon_config_dir: &'static str,
     daemon_config_path: &'static str,
     daemon_secrets_path: &'static str,
@@ -36,6 +38,7 @@ impl BrandProfile {
     pub const fn new(
         client_program_name: &'static str,
         daemon_program_name: &'static str,
+        daemon_wrapper_program_name: Option<&'static str>,
         daemon_config_dir: &'static str,
         daemon_config_path: &'static str,
         daemon_secrets_path: &'static str,
@@ -43,6 +46,7 @@ impl BrandProfile {
         Self {
             client_program_name,
             daemon_program_name,
+            daemon_wrapper_program_name,
             daemon_config_dir,
             daemon_config_path,
             daemon_secrets_path,
@@ -59,6 +63,12 @@ impl BrandProfile {
     #[must_use]
     pub const fn daemon_program_name(&self) -> &'static str {
         self.daemon_program_name
+    }
+
+    /// Returns the compatibility wrapper program name, if one is provided.
+    #[must_use]
+    pub const fn daemon_wrapper_program_name(&self) -> Option<&'static str> {
+        self.daemon_wrapper_program_name
     }
 
     /// Returns the daemon configuration directory as a string slice.
@@ -101,6 +111,7 @@ impl BrandProfile {
 const UPSTREAM_PROFILE: BrandProfile = BrandProfile::new(
     UPSTREAM_CLIENT_PROGRAM_NAME,
     UPSTREAM_DAEMON_PROGRAM_NAME,
+    Some(UPSTREAM_DAEMON_PROGRAM_NAME),
     LEGACY_DAEMON_CONFIG_DIR,
     LEGACY_DAEMON_CONFIG_PATH,
     LEGACY_DAEMON_SECRETS_PATH,
@@ -109,6 +120,7 @@ const UPSTREAM_PROFILE: BrandProfile = BrandProfile::new(
 const OC_PROFILE: BrandProfile = BrandProfile::new(
     OC_CLIENT_PROGRAM_NAME,
     OC_DAEMON_PROGRAM_NAME,
+    Some(OC_DAEMON_WRAPPER_PROGRAM_NAME),
     OC_DAEMON_CONFIG_DIR,
     OC_DAEMON_CONFIG_PATH,
     OC_DAEMON_SECRETS_PATH,

--- a/src/bin/oc-rsyncd.rs
+++ b/src/bin/oc-rsyncd.rs
@@ -28,6 +28,9 @@ where
     Out: Write,
     Err: Write,
 {
-    let forwarded = daemon_wrapper::wrap_daemon_arguments(args, Brand::Oc.daemon_program_name());
+    let fallback_program = Brand::Oc
+        .daemon_wrapper_program_name()
+        .unwrap_or_else(|| Brand::Oc.daemon_program_name());
+    let forwarded = daemon_wrapper::wrap_daemon_arguments(args, fallback_program);
     client::run_with(forwarded, stdout, stderr)
 }

--- a/src/bin/rsyncd.rs
+++ b/src/bin/rsyncd.rs
@@ -28,7 +28,9 @@ where
     Out: Write,
     Err: Write,
 {
-    let forwarded =
-        daemon_wrapper::wrap_daemon_arguments(args, Brand::Upstream.daemon_program_name());
+    let fallback_program = Brand::Upstream
+        .daemon_wrapper_program_name()
+        .unwrap_or_else(|| Brand::Upstream.daemon_program_name());
+    let forwarded = daemon_wrapper::wrap_daemon_arguments(args, fallback_program);
     client::run_with(forwarded, stdout, stderr)
 }


### PR DESCRIPTION
## Summary
- extend the branding profile and manifest to surface optional daemon wrapper names directly from the workspace metadata
- expose a `Brand::daemon_wrapper_program_name` accessor and include wrapper aliases in `BrandSummary`
- ensure the oc-rsyncd/rsyncd entrypoints rely on the branded wrapper name when synthesising daemon invocations

## Testing
- cargo test --package oc-rsync-core --lib

------
[Codex Task](