### PR TITLE
Fix CLI default program name when arguments are missing

### DIFF
--- a/crates/cli/src/frontend/mod.rs
+++ b/crates/cli/src/frontend/mod.rs
@@ -245,7 +245,7 @@ where
 {
     let mut args: Vec<OsString> = arguments.into_iter().map(Into::into).collect();
     if args.is_empty() {
-        args.push(OsString::from(ProgramName::Rsync.as_str()));
+        args.push(OsString::from(ProgramName::OcRsync.as_str()));
     }
 
     let detected = detect_program_name(args.first().map(|arg| arg.as_os_str()));


### PR DESCRIPTION
## Summary
- default the CLI argument shim to the oc-rsync program name so usage and diagnostics use the branded banner

## Testing
- cargo test -p oc-rsync --bin oc-rsync client::tests::empty_argument_list_defaults_to_usage_error

------
[Codex Task](