### PR TITLE
Fix version operand tests for upstream branding

### DIFF
--- a/crates/cli/src/frontend/tests/version.rs
+++ b/crates/cli/src/frontend/tests/version.rs
@@ -45,7 +45,7 @@ fn version_flag_ignores_additional_operands() {
     assert_eq!(code, 0);
     assert!(stderr.is_empty());
 
-    let expected = VersionInfoReport::default().human_readable();
+    let expected = VersionInfoReport::for_client_brand(Brand::Upstream).human_readable();
     assert_eq!(stdout, expected.into_bytes());
 }
 
@@ -61,6 +61,6 @@ fn short_version_flag_ignores_additional_operands() {
     assert_eq!(code, 0);
     assert!(stderr.is_empty());
 
-    let expected = VersionInfoReport::default().human_readable();
+    let expected = VersionInfoReport::for_client_brand(Brand::Upstream).human_readable();
     assert_eq!(stdout, expected.into_bytes());
 }


### PR DESCRIPTION
## Summary
- update the version flag regression tests to expect the upstream-branded banner when invoking the binary via the legacy `rsync` alias
- keep the behaviour of `--version` and `-V` parity when extra operands are present

## Testing
- `cargo test -p oc-rsync-cli version_flag_ignores_additional_operands`

------
[Codex Task](