### PR TITLE
Centralize repository metadata in workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ rust-version = "1.88"
 authors = ["Ofer Chen <skewers.irises.3b@icloud.com>"]
 license = "GPL-3.0-or-later"
 description = "Pure-Rust implementation of the rsync client and daemon entrypoints installed as a single oc-rsync binary for side-by-side deployment"
-repository = "https://github.com/oferchen/rsync"
+repository.workspace = true
 publish = true
 autobins = false
 
@@ -64,6 +64,7 @@ rust-version = "1.88"
 authors = ["Ofer Chen <skewers.irises.3b@icloud.com>"]
 license = "GPL-3.0-or-later"
 version = "3.4.1-rust"
+repository = "https://github.com/oferchen/rsync"
 
 [workspace.metadata.docs.rs]
 all-features = true

--- a/crates/bandwidth/Cargo.toml
+++ b/crates/bandwidth/Cargo.toml
@@ -6,7 +6,7 @@ rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 description = "Bandwidth parsing and pacing utilities for the Rust rsync implementation"
-repository = "https://github.com/oferchen/rsync"
+repository.workspace = true
 readme = "README.md"
 publish = false
 

--- a/crates/compress/Cargo.toml
+++ b/crates/compress/Cargo.toml
@@ -6,7 +6,7 @@ rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 description = "Compression primitives for the Rust rsync implementation"
-repository = "https://github.com/oferchen/rsync"
+repository.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 authors = ["Ofer Chen <skewers.irises.3b@icloud.com>"]
 license = "GPL-3.0-or-later"
 description = "Core utilities shared by the Rust rsync implementation"
-repository = "https://github.com/oferchen/rsync"
+repository.workspace = true
 build = "build.rs"
 
 [package.metadata.docs.rs]

--- a/crates/embedding/Cargo.toml
+++ b/crates/embedding/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 authors = ["Ofer Chen <skewers.irises.3b@icloud.com>"]
 license = "GPL-3.0-or-later"
 description = "Programmatic entry points for the oc-rsync client and daemon"
-repository = "https://github.com/oferchen/rsync"
+repository.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -6,7 +6,7 @@ rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 description = "Transfer engine components for the Rust rsync implementation"
-repository = "https://github.com/oferchen/rsync"
+repository.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/logging/Cargo.toml
+++ b/crates/logging/Cargo.toml
@@ -6,7 +6,7 @@ rust-version.workspace = true
 license.workspace = true
 authors.workspace = true
 description = "Logging utilities for the Rust rsync implementation"
-repository = "https://github.com/oferchen/rsync"
+repository.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/meta/Cargo.toml
+++ b/crates/meta/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 authors = ["Ofer Chen <skewers.irises.3b@icloud.com>"]
 license = "GPL-3.0-or-later"
 description = "Metadata preservation helpers for the Rust rsync implementation"
-repository = "https://github.com/oferchen/rsync"
+repository.workspace = true
 build = "build.rs"
 
 [package.metadata.docs.rs]

--- a/crates/walk/Cargo.toml
+++ b/crates/walk/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 authors = ["Ofer Chen <skewers.irises.3b@icloud.com>"]
 license = "GPL-3.0-or-later"
 description = "Deterministic filesystem walker for the Rust rsync implementation"
-repository = "https://github.com/oferchen/rsync"
+repository.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
## Summary
- point every crate's `repository` field at the shared workspace value
- expose the canonical repository URL through `[workspace.package]`
- let the root crate inherit the workspace-level repository metadata

## Testing
- `cargo metadata --format-version 1 --no-deps`

------
[Codex Task](