### PR TITLE
Derive daemon alias from workspace branding metadata

### DIFF
--- a/crates/core/src/branding/brand.rs
+++ b/crates/core/src/branding/brand.rs
@@ -3,6 +3,7 @@
 use core::str::FromStr;
 use std::fmt;
 use std::path::Path;
+use std::sync::OnceLock;
 
 use super::constants::{
     OC_CLIENT_PROGRAM_NAME, OC_DAEMON_PROGRAM_NAME, UPSTREAM_CLIENT_PROGRAM_NAME,
@@ -70,8 +71,7 @@ impl FromStr for Brand {
             return Ok(Self::Oc);
         }
 
-        const OC_LEGACY_DAEMON_ALIAS: &str = "oc-rsyncd";
-        if matches_program_alias(s, OC_LEGACY_DAEMON_ALIAS) {
+        if matches_program_alias(s, oc_daemon_alias()) {
             return Ok(Self::Oc);
         }
 
@@ -182,6 +182,13 @@ fn resolve_default_brand(label: &str) -> Brand {
     label.parse::<Brand>().unwrap_or_else(|_| {
         panic!("unsupported workspace brand '{label}'; expected 'oc' or 'upstream' aliases")
     })
+}
+
+fn oc_daemon_alias() -> &'static str {
+    static ALIAS: OnceLock<String> = OnceLock::new();
+    ALIAS
+        .get_or_init(|| format!("{}d", OC_CLIENT_PROGRAM_NAME))
+        .as_str()
 }
 
 /// Returns the brand configured for this workspace build.

--- a/crates/core/src/branding/tests.rs
+++ b/crates/core/src/branding/tests.rs
@@ -208,11 +208,12 @@ fn detect_brand_recognises_debug_suffixes_without_digits() {
 
 #[test]
 fn matches_program_alias_accepts_windows_extensions() {
+    let alias = format!("{}d", oc_client_program_name());
     assert!(matches_program_alias("rsync.exe", "rsync"));
     assert!(matches_program_alias("RSYNCD.EXE", "rsyncd"));
     assert!(matches_program_alias("oc-rsync.EXE", "oc-rsync"));
-    assert!(matches_program_alias("OC-RSYNCD.EXE", "oc-rsyncd"));
-    assert!(!matches_program_alias("rsyncd.exe", "oc-rsyncd"));
+    assert!(matches_program_alias("OC-RSYNCD.EXE", &alias));
+    assert!(!matches_program_alias("rsyncd.exe", &alias));
 }
 
 #[test]
@@ -372,8 +373,10 @@ fn detect_brand_ignores_invalid_override_environment_variable() {
 
 #[test]
 fn brand_from_str_accepts_aliases() {
+    let daemon_alias = format!("{}d", oc_client_program_name());
+    let upper_daemon_alias = daemon_alias.to_ascii_uppercase();
     assert_eq!(Brand::from_str("oc").unwrap(), Brand::Oc);
-    assert_eq!(Brand::from_str("OC-RSYNCD").unwrap(), Brand::Oc);
+    assert_eq!(Brand::from_str(&upper_daemon_alias).unwrap(), Brand::Oc);
     assert_eq!(Brand::from_str("oc_rsync").unwrap(), Brand::Oc);
     assert_eq!(Brand::from_str("OC.RSYNC").unwrap(), Brand::Oc);
     assert_eq!(Brand::from_str(" rsync-3.4.1 ").unwrap(), Brand::Upstream);


### PR DESCRIPTION
## Summary
- derive the daemon alias used by Brand::from_str from the workspace branding metadata so non-oc brands reuse the same single-binary alias pattern
- update branding tests to calculate alias expectations dynamically from the canonical client name

## Testing
- cargo test -p oc-rsync-core

------
[Codex Task](