### PR TITLE
Rename root crate and align branding validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -626,18 +626,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "oc-rsync"
-version = "3.4.1-rust"
-dependencies = [
- "assert_cmd",
- "libc",
- "rsync-cli",
- "rsync-core",
- "rsync-daemon",
- "rsync-windows-gnu-eh",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -886,6 +874,18 @@ version = "3.4.1-rust"
 dependencies = [
  "memchr",
  "proptest",
+]
+
+[[package]]
+name = "rsync-bin"
+version = "3.4.1-rust"
+dependencies = [
+ "assert_cmd",
+ "libc",
+ "rsync-cli",
+ "rsync-core",
+ "rsync-daemon",
+ "rsync-windows-gnu-eh",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "oc-rsync"
+name = "rsync-bin"
 version = "3.4.1-rust"
 edition = "2024"
 rust-version = "1.88"

--- a/crates/branding/build.rs
+++ b/crates/branding/build.rs
@@ -36,7 +36,7 @@ fn main() {
 }
 
 fn determine_build_revision(manifest_dir: &Path) -> String {
-    if let Some(override_revision) = env::var("OC_RSYNC_BUILD_OVERRIDE").ok() {
+    if let Ok(override_revision) = env::var("OC_RSYNC_BUILD_OVERRIDE") {
         let trimmed = override_revision.trim();
         if !trimmed.is_empty() {
             return trimmed.to_owned();
@@ -148,7 +148,7 @@ fn load_workspace_metadata(workspace_root: &Path) -> WorkspaceMetadata {
     }
 }
 
-fn str_field<'a>(table: &'a Table, key: &str) -> String {
+fn str_field(table: &Table, key: &str) -> String {
     table
         .get(key)
         .and_then(toml::Value::as_str)

--- a/crates/branding/src/branding/brand.rs
+++ b/crates/branding/src/branding/brand.rs
@@ -187,7 +187,7 @@ fn resolve_default_brand(label: &str) -> Brand {
 fn oc_daemon_alias() -> &'static str {
     static ALIAS: OnceLock<String> = OnceLock::new();
     ALIAS
-        .get_or_init(|| format!("{}d", OC_CLIENT_PROGRAM_NAME))
+        .get_or_init(|| format!("{OC_CLIENT_PROGRAM_NAME}d"))
         .as_str()
 }
 

--- a/xtask/src/commands/preflight/validation.rs
+++ b/xtask/src/commands/preflight/validation.rs
@@ -1,6 +1,6 @@
 use crate::error::{TaskError, TaskResult};
 use crate::util::{cargo_metadata_json, ensure, validation_error};
-use crate::workspace::WorkspaceBranding;
+use crate::workspace::{self, WorkspaceBranding};
 use serde_json::Value as JsonValue;
 use std::collections::HashMap;
 use std::fs;
@@ -169,8 +169,8 @@ pub(crate) fn validate_package_versions(
         versions.insert(name.to_string(), version.to_string());
     }
 
-    let crate_name = "oc-rsync";
-    let version = versions.get(crate_name).ok_or_else(|| {
+    let crate_name = workspace::root_package_name(workspace)?;
+    let version = versions.get(&crate_name).ok_or_else(|| {
         validation_error(format!("crate {crate_name} missing from cargo metadata"))
     })?;
     ensure(

--- a/xtask/src/util/env.rs
+++ b/xtask/src/util/env.rs
@@ -10,7 +10,7 @@ pub(crate) fn should_simulate_missing_tool(display: &str) -> bool {
     };
 
     entries
-        .split(|ch| matches!(ch, ',' | ';' | '|'))
+        .split([',', ';', '|'])
         .map(str::trim)
         .any(|value| !value.is_empty() && value == display)
 }

--- a/xtask/src/util/git.rs
+++ b/xtask/src/util/git.rs
@@ -25,7 +25,7 @@ pub fn list_tracked_files(workspace: &Path) -> TaskResult<Vec<PathBuf>> {
         });
     }
 
-    Ok(parse_null_separated_paths(&output.stdout)?)
+    parse_null_separated_paths(&output.stdout)
 }
 
 /// Returns all Rust sources tracked or untracked within the repository via git.


### PR DESCRIPTION
## Summary
- rename the workspace package to `rsync-bin` so no crates retain the `oc-` prefix
- tighten branding helpers to satisfy clippy and reuse metadata-driven values, including xtask validations
- adjust xtask utilities and tests to accept the new package name and quiet previous lint findings

## Testing
- cargo clippy -p rsync-branding --all-targets --all-features -- -Dwarnings
- cargo clippy -p xtask --all-targets --all-features -- -Dwarnings
- cargo test -p rsync-branding --all-features
- cargo test -p xtask --all-features

------
[Codex Task](