### PR TITLE
test: centralize branding metadata in xtask tests

### DIFF
--- a/xtask/src/commands/branding/render.rs
+++ b/xtask/src/commands/branding/render.rs
@@ -126,69 +126,51 @@ fn format_cross_compile_summary(matrix: &BTreeMap<String, Vec<String>>) -> Strin
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::collections::BTreeMap;
-    use std::path::PathBuf;
-
+    use crate::test_support;
     fn sample_branding() -> WorkspaceBranding {
-        WorkspaceBranding {
-            brand: String::from("oc"),
-            upstream_version: String::from("3.4.1"),
-            rust_version: String::from("3.4.1-rust"),
-            protocol: 32,
-            client_bin: String::from("oc-rsync"),
-            daemon_bin: String::from("oc-rsync"),
-            legacy_client_bin: String::from("rsync"),
-            legacy_daemon_bin: String::from("rsyncd"),
-            daemon_config_dir: PathBuf::from("/etc/oc-rsyncd"),
-            daemon_config: PathBuf::from("/etc/oc-rsyncd/oc-rsyncd.conf"),
-            daemon_secrets: PathBuf::from("/etc/oc-rsyncd/oc-rsyncd.secrets"),
-            legacy_daemon_config_dir: PathBuf::from("/etc"),
-            legacy_daemon_config: PathBuf::from("/etc/rsyncd.conf"),
-            legacy_daemon_secrets: PathBuf::from("/etc/rsyncd.secrets"),
-            source: String::from("https://example.invalid/rsync"),
-            cross_compile: BTreeMap::from([
-                (
-                    String::from("linux"),
-                    vec![String::from("x86_64"), String::from("aarch64")],
-                ),
-                (
-                    String::from("macos"),
-                    vec![String::from("x86_64"), String::from("aarch64")],
-                ),
-                (String::from("windows"), vec![String::from("x86_64")]),
-            ]),
-            cross_compile_matrix: BTreeMap::from([
-                (String::from("linux-x86_64"), true),
-                (String::from("linux-aarch64"), true),
-                (String::from("darwin-x86_64"), true),
-                (String::from("darwin-aarch64"), true),
-                (String::from("windows-x86_64"), true),
-            ]),
-        }
+        test_support::workspace_branding_snapshot()
     }
 
     #[test]
     fn render_text_matches_expected_layout() {
         let branding = sample_branding();
         let rendered = render_branding_text(&branding);
-        let expected = concat!(
-            "Workspace branding summary:\n",
-            "  brand: oc\n",
-            "  upstream_version: 3.4.1\n",
-            "  rust_version: 3.4.1-rust\n",
-            "  protocol: 32\n",
-            "  client_bin: oc-rsync\n",
-            "  daemon_bin: oc-rsync\n",
-            "  legacy_client_bin: rsync\n",
-            "  legacy_daemon_bin: rsyncd\n",
-            "  daemon_config_dir: /etc/oc-rsyncd\n",
-            "  daemon_config: /etc/oc-rsyncd/oc-rsyncd.conf\n",
-            "  daemon_secrets: /etc/oc-rsyncd/oc-rsyncd.secrets\n",
-            "  legacy_daemon_config_dir: /etc\n",
-            "  legacy_daemon_config: /etc/rsyncd.conf\n",
-            "  legacy_daemon_secrets: /etc/rsyncd.secrets\n",
-            "  source: https://example.invalid/rsync\n",
-            "  cross_compile: Linux: x86_64, aarch64; macOS: x86_64, aarch64; Windows: x86_64"
+        let expected = format!(
+            concat!(
+                "Workspace branding summary:\n",
+                "  brand: {}\n",
+                "  upstream_version: {}\n",
+                "  rust_version: {}\n",
+                "  protocol: {}\n",
+                "  client_bin: {}\n",
+                "  daemon_bin: {}\n",
+                "  legacy_client_bin: {}\n",
+                "  legacy_daemon_bin: {}\n",
+                "  daemon_config_dir: {}\n",
+                "  daemon_config: {}\n",
+                "  daemon_secrets: {}\n",
+                "  legacy_daemon_config_dir: {}\n",
+                "  legacy_daemon_config: {}\n",
+                "  legacy_daemon_secrets: {}\n",
+                "  source: {}\n",
+                "  cross_compile: {}"
+            ),
+            branding.brand,
+            branding.upstream_version,
+            branding.rust_version,
+            branding.protocol,
+            branding.client_bin,
+            branding.daemon_bin,
+            branding.legacy_client_bin,
+            branding.legacy_daemon_bin,
+            branding.daemon_config_dir.display(),
+            branding.daemon_config.display(),
+            branding.daemon_secrets.display(),
+            branding.legacy_daemon_config_dir.display(),
+            branding.legacy_daemon_config.display(),
+            branding.legacy_daemon_secrets.display(),
+            branding.source,
+            format_cross_compile_summary(&branding.cross_compile)
         );
         assert_eq!(rendered, expected);
     }
@@ -198,8 +180,8 @@ mod tests {
         let branding = sample_branding();
         let rendered = render_branding_json(&branding).expect("json output");
         let parsed: serde_json::Value = serde_json::from_str(&rendered).expect("parse json");
-        assert_eq!(parsed["brand"], "oc");
-        assert_eq!(parsed["protocol"], 32);
+        assert_eq!(parsed["brand"], branding.brand);
+        assert_eq!(parsed["protocol"], branding.protocol);
     }
 
     #[test]

--- a/xtask/src/commands/branding/tests.rs
+++ b/xtask/src/commands/branding/tests.rs
@@ -2,41 +2,13 @@ use super::args::{BrandingOptions, BrandingOutputFormat, parse_args, usage};
 use super::render::{render_branding, render_branding_json, render_branding_text};
 use super::validate::validate_branding;
 use crate::error::TaskError;
+use crate::test_support;
 use crate::workspace::{WorkspaceBranding, parse_workspace_branding};
-use std::collections::BTreeMap;
 use std::ffi::OsString;
 use std::path::PathBuf;
 
 fn sample_branding() -> WorkspaceBranding {
-    WorkspaceBranding {
-        brand: String::from("oc"),
-        upstream_version: String::from("3.4.1"),
-        rust_version: String::from("3.4.1-rust"),
-        protocol: 32,
-        client_bin: String::from("oc-rsync"),
-        daemon_bin: String::from("oc-rsync"),
-        legacy_client_bin: String::from("rsync"),
-        legacy_daemon_bin: String::from("rsyncd"),
-        daemon_config_dir: PathBuf::from("/etc/oc-rsyncd"),
-        daemon_config: PathBuf::from("/etc/oc-rsyncd/oc-rsyncd.conf"),
-        daemon_secrets: PathBuf::from("/etc/oc-rsyncd/oc-rsyncd.secrets"),
-        legacy_daemon_config_dir: PathBuf::from("/etc"),
-        legacy_daemon_config: PathBuf::from("/etc/rsyncd.conf"),
-        legacy_daemon_secrets: PathBuf::from("/etc/rsyncd.secrets"),
-        source: String::from("https://example.invalid/rsync"),
-        cross_compile: BTreeMap::from([
-            (String::from("linux"), vec![String::from("x86_64"), String::from("aarch64")]),
-            (String::from("macos"), vec![String::from("x86_64"), String::from("aarch64")]),
-            (String::from("windows"), vec![String::from("x86_64")]),
-        ]),
-        cross_compile_matrix: BTreeMap::from([
-            (String::from("linux-x86_64"), true),
-            (String::from("linux-aarch64"), true),
-            (String::from("darwin-x86_64"), true),
-            (String::from("darwin-aarch64"), true),
-            (String::from("windows-x86_64"), true),
-        ]),
-    }
+    test_support::workspace_branding_snapshot()
 }
 
 fn manifest_branding() -> WorkspaceBranding {
@@ -83,24 +55,61 @@ fn parse_args_rejects_unknown_argument() {
 fn render_text_matches_expected_layout() {
     let branding = sample_branding();
     let rendered = render_branding_text(&branding);
-    let expected = concat!(
-        "Workspace branding summary:\n",
-        "  brand: oc\n",
-        "  upstream_version: 3.4.1\n",
-        "  rust_version: 3.4.1-rust\n",
-        "  protocol: 32\n",
-        "  client_bin: oc-rsync\n",
-        "  daemon_bin: oc-rsync\n",
-        "  legacy_client_bin: rsync\n",
-        "  legacy_daemon_bin: rsyncd\n",
-        "  daemon_config_dir: /etc/oc-rsyncd\n",
-        "  daemon_config: /etc/oc-rsyncd/oc-rsyncd.conf\n",
-        "  daemon_secrets: /etc/oc-rsyncd/oc-rsyncd.secrets\n",
-        "  legacy_daemon_config_dir: /etc\n",
-        "  legacy_daemon_config: /etc/rsyncd.conf\n",
-        "  legacy_daemon_secrets: /etc/rsyncd.secrets\n",
-        "  source: https://example.invalid/rsync\n",
-        "  cross_compile: Linux: x86_64, aarch64; macOS: x86_64, aarch64; Windows: x86_64"
+    let cross_compile_summary = branding
+        .cross_compile
+        .iter()
+        .map(|(os, archs)| {
+            let label = match os.as_str() {
+                "linux" => "Linux",
+                "macos" => "macOS",
+                "windows" => "Windows",
+                other => other,
+            };
+            if archs.is_empty() {
+                format!("{label}: (none)")
+            } else {
+                format!("{label}: {}", archs.join(", "))
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("; ");
+
+    let expected = format!(
+        concat!(
+            "Workspace branding summary:\n",
+            "  brand: {}\n",
+            "  upstream_version: {}\n",
+            "  rust_version: {}\n",
+            "  protocol: {}\n",
+            "  client_bin: {}\n",
+            "  daemon_bin: {}\n",
+            "  legacy_client_bin: {}\n",
+            "  legacy_daemon_bin: {}\n",
+            "  daemon_config_dir: {}\n",
+            "  daemon_config: {}\n",
+            "  daemon_secrets: {}\n",
+            "  legacy_daemon_config_dir: {}\n",
+            "  legacy_daemon_config: {}\n",
+            "  legacy_daemon_secrets: {}\n",
+            "  source: {}\n",
+            "  cross_compile: {}"
+        ),
+        branding.brand,
+        branding.upstream_version,
+        branding.rust_version,
+        branding.protocol,
+        branding.client_bin,
+        branding.daemon_bin,
+        branding.legacy_client_bin,
+        branding.legacy_daemon_bin,
+        branding.daemon_config_dir.display(),
+        branding.daemon_config.display(),
+        branding.daemon_secrets.display(),
+        branding.legacy_daemon_config_dir.display(),
+        branding.legacy_daemon_config.display(),
+        branding.legacy_daemon_secrets.display(),
+        branding.source,
+        cross_compile_summary
     );
     assert_eq!(rendered, expected);
 }
@@ -110,8 +119,8 @@ fn render_json_produces_expected_structure() {
     let branding = sample_branding();
     let rendered = render_branding_json(&branding).expect("json output");
     let parsed: serde_json::Value = serde_json::from_str(&rendered).expect("parse json");
-    assert_eq!(parsed["brand"], "oc");
-    assert_eq!(parsed["protocol"], 32);
+    assert_eq!(parsed["brand"], branding.brand);
+    assert_eq!(parsed["protocol"], branding.protocol);
 }
 
 #[test]

--- a/xtask/src/commands/branding/validate.rs
+++ b/xtask/src/commands/branding/validate.rs
@@ -210,46 +210,12 @@ fn ensure_named_file(path: &Path, expected: &str, label: &str) -> TaskResult<()>
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_support;
     use crate::workspace::parse_workspace_branding;
-    use std::collections::BTreeMap;
     use std::path::{Path, PathBuf};
 
     fn sample_branding() -> WorkspaceBranding {
-        WorkspaceBranding {
-            brand: String::from("oc"),
-            upstream_version: String::from("3.4.1"),
-            rust_version: String::from("3.4.1-rust"),
-            protocol: 32,
-            client_bin: String::from("oc-rsync"),
-            daemon_bin: String::from("oc-rsync"),
-            legacy_client_bin: String::from("rsync"),
-            legacy_daemon_bin: String::from("rsyncd"),
-            daemon_config_dir: PathBuf::from("/etc/oc-rsyncd"),
-            daemon_config: PathBuf::from("/etc/oc-rsyncd/oc-rsyncd.conf"),
-            daemon_secrets: PathBuf::from("/etc/oc-rsyncd/oc-rsyncd.secrets"),
-            legacy_daemon_config_dir: PathBuf::from("/etc"),
-            legacy_daemon_config: PathBuf::from("/etc/rsyncd.conf"),
-            legacy_daemon_secrets: PathBuf::from("/etc/rsyncd.secrets"),
-            source: String::from("https://example.invalid/rsync"),
-            cross_compile: BTreeMap::from([
-                (
-                    String::from("linux"),
-                    vec![String::from("x86_64"), String::from("aarch64")],
-                ),
-                (
-                    String::from("macos"),
-                    vec![String::from("x86_64"), String::from("aarch64")],
-                ),
-                (String::from("windows"), vec![String::from("x86_64")]),
-            ]),
-            cross_compile_matrix: BTreeMap::from([
-                (String::from("linux-x86_64"), true),
-                (String::from("linux-aarch64"), true),
-                (String::from("darwin-x86_64"), true),
-                (String::from("darwin-aarch64"), true),
-                (String::from("windows-x86_64"), true),
-            ]),
-        }
+        test_support::workspace_branding_snapshot()
     }
 
     fn manifest_branding() -> WorkspaceBranding {

--- a/xtask/src/commands/docs/validation/branding.rs
+++ b/xtask/src/commands/docs/validation/branding.rs
@@ -181,34 +181,10 @@ fn display_os_name(os: &str) -> &str {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_support;
     use crate::workspace::load_workspace_branding;
     use std::fs;
     use std::time::{SystemTime, UNIX_EPOCH};
-
-    const MANIFEST_SNIPPET: &str = r#"[workspace]
-members = []
-[workspace.metadata]
-[workspace.metadata.oc_rsync]
-brand = "oc"
-upstream_version = "3.4.1"
-rust_version = "3.4.1-rust"
-protocol = 32
-client_bin = "oc-rsync"
-daemon_bin = "oc-rsync"
-legacy_client_bin = "rsync"
-legacy_daemon_bin = "rsyncd"
-daemon_config_dir = "/etc/oc-rsyncd"
-daemon_config = "/etc/oc-rsyncd/oc-rsyncd.conf"
-daemon_secrets = "/etc/oc-rsyncd/oc-rsyncd.secrets"
-legacy_daemon_config_dir = "/etc"
-legacy_daemon_config = "/etc/rsyncd.conf"
-legacy_daemon_secrets = "/etc/rsyncd.secrets"
-source = "https://github.com/oferchen/rsync"
-[workspace.metadata.oc_rsync.cross_compile]
-linux = ["x86_64", "aarch64"]
-macos = ["x86_64", "aarch64"]
-windows = ["x86_64", "aarch64"]
-"#;
 
     #[test]
     fn validate_branding_documents_reports_missing_content() {
@@ -223,7 +199,8 @@ windows = ["x86_64", "aarch64"]
         fs::create_dir(&workspace).expect("create workspace");
         fs::create_dir(workspace.join("docs")).expect("create docs directory");
 
-        fs::write(workspace.join("Cargo.toml"), MANIFEST_SNIPPET).expect("write manifest");
+        let manifest = test_support::manifest_snippet();
+        fs::write(workspace.join("Cargo.toml"), manifest).expect("write manifest");
         fs::write(workspace.join("README.md"), "placeholder").expect("write README");
         fs::write(
             workspace.join("docs").join("production_scope_p1.md"),

--- a/xtask/src/commands/docs/validation/ci/matrix/tests/mod.rs
+++ b/xtask/src/commands/docs/validation/ci/matrix/tests/mod.rs
@@ -1,48 +1,17 @@
 use super::*;
+use crate::test_support;
 use crate::workspace::load_workspace_branding;
 use std::fs;
 use std::path::Path;
 use std::time::{SystemTime, UNIX_EPOCH};
-
-const MANIFEST_SNIPPET: &str = r#"[workspace]
-members = []
-[workspace.metadata]
-[workspace.metadata.oc_rsync]
-brand = "oc"
-upstream_version = "3.4.1"
-rust_version = "3.4.1-rust"
-protocol = 32
-client_bin = "oc-rsync"
-daemon_bin = "oc-rsync"
-legacy_client_bin = "rsync"
-legacy_daemon_bin = "rsyncd"
-daemon_config_dir = "/etc/oc-rsyncd"
-daemon_config = "/etc/oc-rsyncd/oc-rsyncd.conf"
-daemon_secrets = "/etc/oc-rsyncd/oc-rsyncd.secrets"
-legacy_daemon_config_dir = "/etc"
-legacy_daemon_config = "/etc/rsyncd.conf"
-legacy_daemon_secrets = "/etc/rsyncd.secrets"
-source = "https://github.com/oferchen/rsync"
-[workspace.metadata.oc_rsync.cross_compile]
-linux = ["x86_64", "aarch64"]
-macos = ["x86_64", "aarch64"]
-windows = ["x86_64", "aarch64"]
-[workspace.metadata.oc_rsync.cross_compile_matrix]
-"linux-x86_64" = true
-"linux-aarch64" = true
-"darwin-x86_64" = true
-"darwin-aarch64" = true
-"windows-x86_64" = false
-"windows-aarch64" = false
-"windows-x86" = false
-"#;
 
 fn write_manifest(workspace: &Path) {
     if !workspace.exists() {
         fs::create_dir_all(workspace).expect("create workspace root");
     }
 
-    fs::write(workspace.join("Cargo.toml"), MANIFEST_SNIPPET).expect("write manifest");
+    let manifest = test_support::manifest_snippet();
+    fs::write(workspace.join("Cargo.toml"), manifest).expect("write manifest");
 }
 
 fn write_workflow_file(workspace: &Path, name: &str, contents: &str) {

--- a/xtask/src/commands/docs/validation/ci/orchestrator.rs
+++ b/xtask/src/commands/docs/validation/ci/orchestrator.rs
@@ -181,33 +181,9 @@ fn display_path(workspace: &Path, path: &Path) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_support;
     use std::fs;
     use std::time::{SystemTime, UNIX_EPOCH};
-
-    const MANIFEST_SNIPPET: &str = r#"[workspace]
-members = []
-[workspace.metadata]
-[workspace.metadata.oc_rsync]
-brand = "oc"
-upstream_version = "3.4.1"
-rust_version = "3.4.1-rust"
-protocol = 32
-client_bin = "oc-rsync"
-daemon_bin = "oc-rsync"
-legacy_client_bin = "rsync"
-legacy_daemon_bin = "rsyncd"
-daemon_config_dir = "/etc/oc-rsyncd"
-daemon_config = "/etc/oc-rsyncd/oc-rsyncd.conf"
-daemon_secrets = "/etc/oc-rsyncd/oc-rsyncd.secrets"
-legacy_daemon_config_dir = "/etc"
-legacy_daemon_config = "/etc/rsyncd.conf"
-legacy_daemon_secrets = "/etc/rsyncd.secrets"
-source = "https://github.com/oferchen/rsync"
-[workspace.metadata.oc_rsync.cross_compile]
-linux = ["x86_64", "aarch64"]
-macos = ["x86_64", "aarch64"]
-windows = ["x86_64", "aarch64"]
-"#;
 
     fn unique_workspace(prefix: &str) -> PathBuf {
         let suffix = SystemTime::now()
@@ -221,7 +197,8 @@ windows = ["x86_64", "aarch64"]
         if !workspace.exists() {
             fs::create_dir_all(workspace).expect("create workspace root");
         }
-        fs::write(workspace.join("Cargo.toml"), MANIFEST_SNIPPET).expect("write manifest");
+        let manifest = test_support::manifest_snippet();
+        fs::write(workspace.join("Cargo.toml"), manifest).expect("write manifest");
     }
 
     fn write_ci_file(workspace: &Path, contents: &str) {

--- a/xtask/src/commands/docs/validation/ci/test_job/mod.rs
+++ b/xtask/src/commands/docs/validation/ci/test_job/mod.rs
@@ -52,34 +52,10 @@ pub(super) fn validate_ci_test_job(workspace: &Path, failures: &mut Vec<String>)
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_support;
     use std::fs;
     use std::path::Path;
     use std::time::{SystemTime, UNIX_EPOCH};
-
-    const MANIFEST_SNIPPET: &str = r#"[workspace]
-members = []
-[workspace.metadata]
-[workspace.metadata.oc_rsync]
-brand = "oc"
-upstream_version = "3.4.1"
-rust_version = "3.4.1-rust"
-protocol = 32
-client_bin = "oc-rsync"
-daemon_bin = "oc-rsync"
-legacy_client_bin = "rsync"
-legacy_daemon_bin = "rsyncd"
-daemon_config_dir = "/etc/oc-rsyncd"
-daemon_config = "/etc/oc-rsyncd/oc-rsyncd.conf"
-daemon_secrets = "/etc/oc-rsyncd/oc-rsyncd.secrets"
-legacy_daemon_config_dir = "/etc"
-legacy_daemon_config = "/etc/rsyncd.conf"
-legacy_daemon_secrets = "/etc/rsyncd.secrets"
-source = "https://github.com/oferchen/rsync"
-[workspace.metadata.oc_rsync.cross_compile]
-linux = ["x86_64", "aarch64"]
-macos = ["x86_64", "aarch64"]
-windows = ["x86_64", "aarch64"]
-"#;
 
     fn unique_workspace(prefix: &str) -> std::path::PathBuf {
         let unique_suffix = SystemTime::now()
@@ -94,7 +70,8 @@ windows = ["x86_64", "aarch64"]
             std::fs::create_dir_all(workspace).expect("create workspace root");
         }
 
-        std::fs::write(workspace.join("Cargo.toml"), MANIFEST_SNIPPET).expect("write manifest");
+        let manifest = test_support::manifest_snippet();
+        std::fs::write(workspace.join("Cargo.toml"), manifest).expect("write manifest");
     }
 
     fn write_ci_file(workspace: &Path, contents: &str) {

--- a/xtask/src/commands/package/tarball.rs
+++ b/xtask/src/commands/package/tarball.rs
@@ -438,8 +438,8 @@ fn append_file_entry<W: Write>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_support;
     use std::collections::BTreeMap;
-    use std::path::PathBuf;
 
     fn branding_with_cross_compile(
         linux_arches: &[&str],
@@ -460,25 +460,10 @@ mod tests {
             windows_arches.iter().map(|arch| arch.to_string()).collect(),
         );
 
-        WorkspaceBranding {
-            brand: String::from("oc"),
-            upstream_version: String::from("3.4.1"),
-            rust_version: String::from("3.4.1-rust"),
-            protocol: 32,
-            client_bin: String::from("oc-rsync"),
-            daemon_bin: String::from("oc-rsync"),
-            legacy_client_bin: String::from("rsync"),
-            legacy_daemon_bin: String::from("rsyncd"),
-            daemon_config_dir: PathBuf::from("/etc/oc-rsyncd"),
-            daemon_config: PathBuf::from("/etc/oc-rsyncd/oc-rsyncd.conf"),
-            daemon_secrets: PathBuf::from("/etc/oc-rsyncd/oc-rsyncd.secrets"),
-            legacy_daemon_config_dir: PathBuf::from("/etc"),
-            legacy_daemon_config: PathBuf::from("/etc/rsyncd.conf"),
-            legacy_daemon_secrets: PathBuf::from("/etc/rsyncd.secrets"),
-            source: String::from("https://example.invalid"),
-            cross_compile,
-            cross_compile_matrix: BTreeMap::new(),
-        }
+        let mut branding = test_support::workspace_branding_snapshot();
+        branding.cross_compile = cross_compile;
+        branding.cross_compile_matrix = BTreeMap::new();
+        branding
     }
 
     #[test]

--- a/xtask/src/commands/preflight/validation/packaging.rs
+++ b/xtask/src/commands/preflight/validation/packaging.rs
@@ -334,30 +334,16 @@ fn rpm_assets_include(table: &TomlTable, destination: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_support;
     use std::collections::BTreeMap;
     use std::fs;
     use tempfile::tempdir;
 
     fn sample_branding() -> WorkspaceBranding {
-        WorkspaceBranding {
-            brand: String::from("oc"),
-            upstream_version: String::from("3.4.1"),
-            rust_version: String::from("3.4.1-rust"),
-            protocol: 32,
-            client_bin: String::from("oc-rsync"),
-            daemon_bin: String::from("oc-rsync"),
-            legacy_client_bin: String::from("rsync"),
-            legacy_daemon_bin: String::from("rsyncd"),
-            daemon_config_dir: PathBuf::from("/etc/oc-rsyncd"),
-            daemon_config: PathBuf::from("/etc/oc-rsyncd/oc-rsyncd.conf"),
-            daemon_secrets: PathBuf::from("/etc/oc-rsyncd/oc-rsyncd.secrets"),
-            legacy_daemon_config_dir: PathBuf::from("/etc"),
-            legacy_daemon_config: PathBuf::from("/etc/rsyncd.conf"),
-            legacy_daemon_secrets: PathBuf::from("/etc/rsyncd.secrets"),
-            source: String::from("https://example.invalid/oc-rsync"),
-            cross_compile: BTreeMap::new(),
-            cross_compile_matrix: BTreeMap::new(),
-        }
+        let mut branding = test_support::workspace_branding_snapshot();
+        branding.cross_compile = BTreeMap::new();
+        branding.cross_compile_matrix = BTreeMap::new();
+        branding
     }
 
     fn write_unit_file(root: &Path, branding: &WorkspaceBranding, documentation: &str) {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -50,6 +50,8 @@
 
 mod commands;
 mod error;
+#[cfg(test)]
+mod test_support;
 mod util;
 mod workspace;
 

--- a/xtask/src/test_support.rs
+++ b/xtask/src/test_support.rs
@@ -1,0 +1,142 @@
+use crate::workspace::{self, WorkspaceBranding};
+use std::fmt::Write;
+
+/// Returns a [`WorkspaceBranding`] snapshot loaded from the repository manifest.
+#[must_use]
+pub(crate) fn workspace_branding_snapshot() -> WorkspaceBranding {
+    let workspace = workspace::workspace_root().expect("workspace root available");
+    workspace::load_workspace_branding(&workspace).expect("load workspace branding")
+}
+
+/// Renders a minimal workspace manifest snippet mirroring the active branding configuration.
+#[must_use]
+pub(crate) fn manifest_snippet() -> String {
+    manifest_snippet_from_branding(&workspace_branding_snapshot())
+}
+
+/// Renders a workspace manifest snippet for the provided branding configuration.
+#[must_use]
+pub(crate) fn manifest_snippet_from_branding(branding: &WorkspaceBranding) -> String {
+    let mut snippet = String::new();
+    writeln!(&mut snippet, "[workspace]").expect("write workspace header");
+    writeln!(&mut snippet, "members = []").expect("write workspace members");
+    snippet.push('\n');
+    writeln!(&mut snippet, "[workspace.metadata]").expect("write metadata header");
+    snippet.push('\n');
+    writeln!(&mut snippet, "[workspace.metadata.oc_rsync]").expect("write branding header");
+    push_string(&mut snippet, "brand", &branding.brand);
+    push_string(&mut snippet, "upstream_version", &branding.upstream_version);
+    push_string(&mut snippet, "rust_version", &branding.rust_version);
+    writeln!(&mut snippet, "protocol = {}", branding.protocol).expect("write protocol");
+    push_string(&mut snippet, "client_bin", &branding.client_bin);
+    push_string(&mut snippet, "daemon_bin", &branding.daemon_bin);
+    push_string(
+        &mut snippet,
+        "legacy_client_bin",
+        &branding.legacy_client_bin,
+    );
+    push_string(
+        &mut snippet,
+        "legacy_daemon_bin",
+        &branding.legacy_daemon_bin,
+    );
+    push_path(
+        &mut snippet,
+        "daemon_config_dir",
+        &branding.daemon_config_dir,
+    );
+    push_path(&mut snippet, "daemon_config", &branding.daemon_config);
+    push_path(&mut snippet, "daemon_secrets", &branding.daemon_secrets);
+    push_path(
+        &mut snippet,
+        "legacy_daemon_config_dir",
+        &branding.legacy_daemon_config_dir,
+    );
+    push_path(
+        &mut snippet,
+        "legacy_daemon_config",
+        &branding.legacy_daemon_config,
+    );
+    push_path(
+        &mut snippet,
+        "legacy_daemon_secrets",
+        &branding.legacy_daemon_secrets,
+    );
+    push_string(&mut snippet, "source", &branding.source);
+
+    if !branding.cross_compile.is_empty() {
+        snippet.push('\n');
+        writeln!(&mut snippet, "[workspace.metadata.oc_rsync.cross_compile]")
+            .expect("write cross compile header");
+        for (os, targets) in &branding.cross_compile {
+            writeln!(&mut snippet, "{os} = {}", format_array(targets))
+                .expect("write cross compile entry");
+        }
+    }
+
+    if !branding.cross_compile_matrix.is_empty() {
+        snippet.push('\n');
+        writeln!(
+            &mut snippet,
+            "[workspace.metadata.oc_rsync.cross_compile_matrix]"
+        )
+        .expect("write cross compile matrix header");
+        for (platform, enabled) in &branding.cross_compile_matrix {
+            writeln!(&mut snippet, "\"{platform}\" = {}", enabled).expect("write matrix entry");
+        }
+    }
+
+    snippet
+}
+
+fn push_string(buffer: &mut String, key: &str, value: &str) {
+    writeln!(buffer, "{key} = {}", toml::Value::String(value.to_owned()))
+        .expect("write string entry");
+}
+
+fn push_path(buffer: &mut String, key: &str, value: &std::path::Path) {
+    let rendered = value.display().to_string();
+    push_string(buffer, key, &rendered);
+}
+
+fn format_array(values: &[String]) -> String {
+    if values.is_empty() {
+        return String::from("[]");
+    }
+
+    let quoted: Vec<String> = values
+        .iter()
+        .map(|value| toml::Value::String(value.clone()).to_string())
+        .collect();
+    format!("[{}]", quoted.join(", "))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn manifest_snippet_round_trips_branding() {
+        let branding = workspace_branding_snapshot();
+        let snippet = manifest_snippet_from_branding(&branding);
+        let parsed = crate::workspace::parse_workspace_branding(&snippet)
+            .expect("parsed branding from snippet");
+        assert_eq!(branding.brand, parsed.brand);
+        assert_eq!(branding.client_bin, parsed.client_bin);
+        assert_eq!(branding.daemon_bin, parsed.daemon_bin);
+        assert_eq!(branding.source, parsed.source);
+        assert_eq!(branding.protocol, parsed.protocol);
+        assert_eq!(branding.cross_compile, parsed.cross_compile);
+        assert_eq!(branding.cross_compile_matrix, parsed.cross_compile_matrix);
+    }
+
+    #[test]
+    fn format_array_handles_empty_values() {
+        assert_eq!(format_array(&[]), "[]");
+        assert_eq!(format_array(&[String::from("x86_64")]), "[\"x86_64\"]");
+        assert_eq!(
+            format_array(&[String::from("x86_64"), String::from("aarch64")]),
+            "[\"x86_64\", \"aarch64\"]"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add a shared xtask test support module that materializes workspace branding metadata and manifest snippets on demand
- switch the documentation and CI validation tests to consume the shared manifest helper instead of embedding branded literals
- drive release packaging tests from the shared branding data while constraining their expectations to the linux x86_64 artifacts they create

## Testing
- cargo test -p xtask

------
[Codex Task](