### PR TITLE
Normalize version banner tests to branding constants

### DIFF
--- a/crates/core/src/version/metadata.rs
+++ b/crates/core/src/version/metadata.rs
@@ -22,13 +22,13 @@ use super::constants::{
 /// # Examples
 ///
 /// ```
-/// use core::version::{version_metadata, RUST_VERSION, SOURCE_URL};
+/// use core::version::{version_metadata, PROGRAM_NAME, RUST_VERSION, SOURCE_URL};
 ///
 /// let metadata = version_metadata();
 /// let banner = metadata.standard_banner();
 ///
 /// assert!(banner.starts_with(&format!(
-///     "oc-rsync  version {} ",
+///     "{PROGRAM_NAME}  version {} ",
 ///     RUST_VERSION
 /// )));
 /// assert!(banner.contains("protocol version 32"));

--- a/crates/core/src/version/report/renderer.rs
+++ b/crates/core/src/version/report/renderer.rs
@@ -93,13 +93,13 @@ impl VersionInfoReport {
     ///
     /// ```rust
     /// use core::branding::Brand;
-    /// use core::version::VersionInfoReport;
+    /// use core::version::{VersionInfoReport, PROGRAM_NAME};
     ///
     /// let report = VersionInfoReport::for_client_brand(Brand::Oc);
     /// assert!(report
     ///     .metadata()
     ///     .standard_banner()
-    ///     .starts_with("oc-rsync  version"));
+    ///     .starts_with(&format!("{PROGRAM_NAME}  version")));
     /// ```
     #[must_use]
     pub fn for_client_brand(brand: Brand) -> Self {
@@ -113,13 +113,13 @@ impl VersionInfoReport {
     ///
     /// ```rust
     /// use core::branding::Brand;
-    /// use core::version::VersionInfoReport;
+    /// use core::version::{VersionInfoReport, DAEMON_PROGRAM_NAME};
     ///
     /// let report = VersionInfoReport::for_daemon_brand(Brand::Oc);
     /// assert!(report
     ///     .metadata()
     ///     .standard_banner()
-    ///     .starts_with("oc-rsync  version"));
+    ///     .starts_with(&format!("{DAEMON_PROGRAM_NAME}  version")));
     /// ```
     #[must_use]
     pub fn for_daemon_brand(brand: Brand) -> Self {

--- a/crates/core/src/version/tests/metadata.rs
+++ b/crates/core/src/version/tests/metadata.rs
@@ -70,11 +70,10 @@ fn version_metadata_renders_standard_banner() {
         .expect("writing to String cannot fail");
 
     let expected = format!(
-        concat!(
-            "oc-rsync  version {rust_version} (revision/build #{build_revision})  protocol version {protocol}\n",
-            "Copyright {copyright}\n",
-            "Source: {source_url}\n"
-        ),
+        "{program}  version {rust_version} (revision/build #{build_revision})  protocol version {protocol}\n\
+Copyright {copyright}\n\
+Source: {source_url}\n",
+        program = PROGRAM_NAME,
         rust_version = RUST_VERSION,
         build_revision = build_revision(),
         protocol = ProtocolVersion::NEWEST.as_u8(),

--- a/crates/core/src/version/tests/report.rs
+++ b/crates/core/src/version/tests/report.rs
@@ -16,7 +16,7 @@ fn version_info_report_renders_default_report() {
     let bit_inums = mem::size_of::<ino_t>() * 8;
     let bit_timestamps = mem::size_of::<time_t>() * 8;
     let bit_long_ints = mem::size_of::<i64>() * 8;
-    assert!(actual.starts_with(&format!("oc-rsync  version {RUST_VERSION}")));
+    assert!(actual.starts_with(&format!("{PROGRAM_NAME}  version {RUST_VERSION}")));
     assert!(actual.contains(&format!(
         "    {bit_files}-bit files, {bit_inums}-bit inums, {bit_timestamps}-bit timestamps, {bit_long_ints}-bit long ints,"
     )));
@@ -102,7 +102,7 @@ fn version_info_report_with_program_name_updates_banner() {
         .metadata()
         .standard_banner();
 
-    assert!(oc_banner.starts_with("oc-rsync  version"));
+    assert!(oc_banner.starts_with(&format!("{DAEMON_PROGRAM_NAME}  version")));
 }
 
 #[test]
@@ -110,7 +110,7 @@ fn version_info_report_with_client_brand_updates_banner() {
     let report = VersionInfoReport::new(VersionInfoConfig::default()).with_client_brand(Brand::Oc);
     let banner = report.metadata().standard_banner();
 
-    assert!(banner.starts_with("oc-rsync  version"));
+    assert!(banner.starts_with(&format!("{PROGRAM_NAME}  version")));
 }
 
 #[test]
@@ -118,7 +118,7 @@ fn version_info_report_with_daemon_brand_updates_banner() {
     let report = VersionInfoReport::new(VersionInfoConfig::default()).with_daemon_brand(Brand::Oc);
     let banner = report.metadata().standard_banner();
 
-    assert!(banner.starts_with("oc-rsync  version"));
+    assert!(banner.starts_with(&format!("{DAEMON_PROGRAM_NAME}  version")));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- replace hard-coded version banner strings in the core version metadata/report tests with branded program name constants
- update doctests to import the branded constants so the documentation examples respect workspace branding metadata

## Testing
- cargo test -p core version::tests::metadata::version_metadata_renders_standard_banner

------
[Codex Task](