### PR TITLE
Enforce upstream protocol advertisement limits

### DIFF
--- a/crates/daemon/src/daemon/sections/session_runtime.rs
+++ b/crates/daemon/src/daemon/sections/session_runtime.rs
@@ -256,8 +256,7 @@ fn handle_binary_session_internal(
     let mut client_bytes = [0u8; 4];
     stream.read_exact(&mut client_bytes)?;
     let client_raw = u32::from_be_bytes(client_bytes);
-    let client_byte = client_raw.min(u32::from(u8::MAX)) as u8;
-    ProtocolVersion::from_peer_advertisement(client_byte).map_err(|_| {
+    ProtocolVersion::from_peer_advertisement(client_raw).map_err(|_| {
         io::Error::new(
             io::ErrorKind::InvalidData,
             "binary negotiation protocol identifier outside supported range",

--- a/crates/protocol/src/error.rs
+++ b/crates/protocol/src/error.rs
@@ -12,7 +12,7 @@ pub enum NegotiationError {
         peer_versions: Vec<u8>,
     },
     /// The peer advertised a protocol version outside the upstream supported range.
-    UnsupportedVersion(u8),
+    UnsupportedVersion(u32),
     /// A legacy ASCII daemon greeting could not be parsed.
     MalformedLegacyGreeting {
         /// The raw greeting text without trailing newlines.
@@ -41,7 +41,7 @@ impl NegotiationError {
     /// offending byte directly in the diagnostic. The accessor allows callers to recover that
     /// value without pattern matching on [`NegotiationError::UnsupportedVersion`].
     #[must_use]
-    pub const fn unsupported_version(&self) -> Option<u8> {
+    pub const fn unsupported_version(&self) -> Option<u32> {
         match self {
             Self::UnsupportedVersion(version) => Some(*version),
             _ => None,

--- a/crates/protocol/src/legacy/greeting/parse.rs
+++ b/crates/protocol/src/legacy/greeting/parse.rs
@@ -112,8 +112,7 @@ pub fn parse_legacy_daemon_greeting_details(
         Some(digest_list)
     };
 
-    let negotiated = advertised_protocol.min(u32::from(u8::MAX)) as u8;
-    let protocol = ProtocolVersion::from_peer_advertisement(negotiated)?;
+    let protocol = ProtocolVersion::from_peer_advertisement(advertised_protocol)?;
 
     Ok(LegacyDaemonGreeting::new(
         protocol,

--- a/crates/protocol/src/legacy/greeting/types.rs
+++ b/crates/protocol/src/legacy/greeting/types.rs
@@ -285,8 +285,7 @@ impl LegacyDaemonGreetingOwned {
             return Err(NegotiationError::MalformedLegacyGreeting { input: rendered });
         }
 
-        let negotiated_byte = advertised_protocol.min(u32::from(u8::MAX)) as u8;
-        let protocol = ProtocolVersion::from_peer_advertisement(negotiated_byte)?;
+        let protocol = ProtocolVersion::from_peer_advertisement(advertised_protocol)?;
 
         Ok(Self {
             protocol,

--- a/crates/protocol/src/version/advertisement.rs
+++ b/crates/protocol/src/version/advertisement.rs
@@ -17,7 +17,7 @@ use super::ProtocolVersion;
 #[doc(hidden)]
 pub trait ProtocolVersionAdvertisement {
     /// Returns the numeric representation expected by the negotiation logic.
-    fn into_advertised_version(self) -> u8;
+    fn into_advertised_version(self) -> u32;
 }
 
 macro_rules! impl_protocol_version_advertisement {
@@ -25,7 +25,7 @@ macro_rules! impl_protocol_version_advertisement {
         $(
             impl ProtocolVersionAdvertisement for $ty {
                 #[inline]
-                fn into_advertised_version(self) -> u8 {
+                fn into_advertised_version(self) -> u32 {
                     let convert = $into;
                     convert(self)
                 }
@@ -33,7 +33,7 @@ macro_rules! impl_protocol_version_advertisement {
 
             impl ProtocolVersionAdvertisement for &$ty {
                 #[inline]
-                fn into_advertised_version(self) -> u8 {
+                fn into_advertised_version(self) -> u32 {
                     let convert = $into;
                     convert(*self)
                 }
@@ -41,7 +41,7 @@ macro_rules! impl_protocol_version_advertisement {
 
             impl ProtocolVersionAdvertisement for &mut $ty {
                 #[inline]
-                fn into_advertised_version(self) -> u8 {
+                fn into_advertised_version(self) -> u32 {
                     let convert = $into;
                     convert(*self)
                 }
@@ -51,41 +51,71 @@ macro_rules! impl_protocol_version_advertisement {
 }
 
 impl_protocol_version_advertisement!(
-    u8 => |value: u8| value,
-    NonZeroU8 => NonZeroU8::get,
-    ProtocolVersion => ProtocolVersion::as_u8,
-    u16 => |value: u16| value.min(u16::from(u8::MAX)) as u8,
-    u32 => |value: u32| value.min(u32::from(u8::MAX)) as u8,
-    u64 => |value: u64| value.min(u64::from(u8::MAX)) as u8,
-    u128 => |value: u128| value.min(u128::from(u8::MAX)) as u8,
-    usize => |value: usize| value.min(usize::from(u8::MAX)) as u8,
-    NonZeroU16 => |value: NonZeroU16| value.get().min(u16::from(u8::MAX)) as u8,
-    NonZeroU32 => |value: NonZeroU32| value.get().min(u32::from(u8::MAX)) as u8,
-    NonZeroU64 => |value: NonZeroU64| value.get().min(u64::from(u8::MAX)) as u8,
-    NonZeroU128 => |value: NonZeroU128| value.get().min(u128::from(u8::MAX)) as u8,
-    NonZeroUsize => |value: NonZeroUsize| value.get().min(usize::from(u8::MAX)) as u8,
-    Wrapping<u8> => |value: Wrapping<u8>| value.0,
-    Wrapping<u16> => |value: Wrapping<u16>| value.0.min(u16::from(u8::MAX)) as u8,
-    Wrapping<u32> => |value: Wrapping<u32>| value.0.min(u32::from(u8::MAX)) as u8,
-    Wrapping<u64> => |value: Wrapping<u64>| value.0.min(u64::from(u8::MAX)) as u8,
-    Wrapping<u128> => |value: Wrapping<u128>| value.0.min(u128::from(u8::MAX)) as u8,
-    Wrapping<usize> => |value: Wrapping<usize>| value.0.min(usize::from(u8::MAX)) as u8,
-    i8 => |value: i8| value.clamp(0, i8::MAX) as u8,
-    i16 => |value: i16| value.clamp(0, i16::from(u8::MAX)) as u8,
-    i32 => |value: i32| value.clamp(0, i32::from(u8::MAX)) as u8,
-    i64 => |value: i64| value.clamp(0, i64::from(u8::MAX)) as u8,
-    i128 => |value: i128| value.clamp(0, i128::from(u8::MAX)) as u8,
-    isize => |value: isize| value.clamp(0, isize::from(u8::MAX)) as u8,
-    NonZeroI8 => |value: NonZeroI8| value.get().clamp(0, i8::MAX) as u8,
-    NonZeroI16 => |value: NonZeroI16| value.get().clamp(0, i16::from(u8::MAX)) as u8,
-    NonZeroI32 => |value: NonZeroI32| value.get().clamp(0, i32::from(u8::MAX)) as u8,
-    NonZeroI64 => |value: NonZeroI64| value.get().clamp(0, i64::from(u8::MAX)) as u8,
-    NonZeroI128 => |value: NonZeroI128| value.get().clamp(0, i128::from(u8::MAX)) as u8,
-    NonZeroIsize => |value: NonZeroIsize| value.get().clamp(0, isize::from(u8::MAX)) as u8,
-    Wrapping<i8> => |value: Wrapping<i8>| value.0.clamp(0, i8::MAX) as u8,
-    Wrapping<i16> => |value: Wrapping<i16>| value.0.clamp(0, i16::from(u8::MAX)) as u8,
-    Wrapping<i32> => |value: Wrapping<i32>| value.0.clamp(0, i32::from(u8::MAX)) as u8,
-    Wrapping<i64> => |value: Wrapping<i64>| value.0.clamp(0, i64::from(u8::MAX)) as u8,
-    Wrapping<i128> => |value: Wrapping<i128>| value.0.clamp(0, i128::from(u8::MAX)) as u8,
-    Wrapping<isize> => |value: Wrapping<isize>| value.0.clamp(0, isize::from(u8::MAX)) as u8,
+    u8 => |value: u8| u32::from(value),
+    NonZeroU8 => |value: NonZeroU8| u32::from(value.get()),
+    ProtocolVersion => |value: ProtocolVersion| u32::from(value.as_u8()),
+    u16 => |value: u16| u32::from(value),
+    u32 => |value: u32| value,
+    u64 => |value: u64| value.min(u64::from(u32::MAX)) as u32,
+    u128 => |value: u128| value.min(u128::from(u32::MAX)) as u32,
+    usize => |value: usize| {
+        let cap = u32::MAX as usize;
+        if value > cap {
+            u32::MAX
+        } else {
+            value as u32
+        }
+    },
+    NonZeroU16 => |value: NonZeroU16| u32::from(value.get()),
+    NonZeroU32 => |value: NonZeroU32| value.get(),
+    NonZeroU64 => |value: NonZeroU64| value.get().min(u64::from(u32::MAX)) as u32,
+    NonZeroU128 => |value: NonZeroU128| value.get().min(u128::from(u32::MAX)) as u32,
+    NonZeroUsize => |value: NonZeroUsize| {
+        let cap = u32::MAX as usize;
+        if value.get() > cap {
+            u32::MAX
+        } else {
+            value.get() as u32
+        }
+    },
+    Wrapping<u8> => |value: Wrapping<u8>| u32::from(value.0),
+    Wrapping<u16> => |value: Wrapping<u16>| u32::from(value.0),
+    Wrapping<u32> => |value: Wrapping<u32>| value.0,
+    Wrapping<u64> => |value: Wrapping<u64>| value.0.min(u64::from(u32::MAX)) as u32,
+    Wrapping<u128> => |value: Wrapping<u128>| value.0.min(u128::from(u32::MAX)) as u32,
+    Wrapping<usize> => |value: Wrapping<usize>| {
+        let cap = u32::MAX as usize;
+        if value.0 > cap {
+            u32::MAX
+        } else {
+            value.0 as u32
+        }
+    },
+    i8 => |value: i8| u32::from((value.clamp(0, i8::MAX)) as u8),
+    i16 => |value: i16| u32::from((value.clamp(0, i16::MAX)) as u16),
+    i32 => |value: i32| value.clamp(0, i32::MAX) as u32,
+    i64 => |value: i64| value.clamp(0, i64::from(u32::MAX)) as u32,
+    i128 => |value: i128| value.clamp(0, i128::from(u32::MAX)) as u32,
+    isize => |value: isize| {
+        let clamped = (value as i128).clamp(0, i128::from(u32::MAX));
+        clamped as u32
+    },
+    NonZeroI8 => |value: NonZeroI8| u32::from((value.get().clamp(0, i8::MAX)) as u8),
+    NonZeroI16 => |value: NonZeroI16| u32::from((value.get().clamp(0, i16::MAX)) as u16),
+    NonZeroI32 => |value: NonZeroI32| value.get().clamp(0, i32::MAX) as u32,
+    NonZeroI64 => |value: NonZeroI64| value.get().clamp(0, i64::from(u32::MAX)) as u32,
+    NonZeroI128 => |value: NonZeroI128| value.get().clamp(0, i128::from(u32::MAX)) as u32,
+    NonZeroIsize => |value: NonZeroIsize| {
+        let clamped = (value.get() as i128).clamp(0, i128::from(u32::MAX));
+        clamped as u32
+    },
+    Wrapping<i8> => |value: Wrapping<i8>| u32::from((value.0.clamp(0, i8::MAX)) as u8),
+    Wrapping<i16> => |value: Wrapping<i16>| u32::from((value.0.clamp(0, i16::MAX)) as u16),
+    Wrapping<i32> => |value: Wrapping<i32>| value.0.clamp(0, i32::MAX) as u32,
+    Wrapping<i64> => |value: Wrapping<i64>| value.0.clamp(0, i64::from(u32::MAX)) as u32,
+    Wrapping<i128> => |value: Wrapping<i128>| value.0.clamp(0, i128::from(u32::MAX)) as u32,
+    Wrapping<isize> => |value: Wrapping<isize>| {
+        let clamped = (value.0 as i128).clamp(0, i128::from(u32::MAX));
+        clamped as u32
+    },
 );

--- a/crates/protocol/src/version/constants.rs
+++ b/crates/protocol/src/version/constants.rs
@@ -9,6 +9,11 @@ pub(crate) const OLDEST_SUPPORTED_PROTOCOL: u8 = 28;
 pub(crate) const NEWEST_SUPPORTED_PROTOCOL: u8 = 32;
 /// Protocol revision that introduced the binary negotiation handshake.
 pub(crate) const FIRST_BINARY_NEGOTIATION_PROTOCOL: u8 = 30;
+/// Highest protocol version upstream rsync 3.4.1 tolerates from a peer advertisement.
+///
+/// Mirrors `MAX_PROTOCOL_VERSION` from `rsync.h` so future protocol announcements that fall
+/// within upstream's guard range are accepted and clamped to the newest supported revision.
+pub const MAXIMUM_PROTOCOL_ADVERTISEMENT: u8 = 40;
 
 /// Inclusive range of protocol versions that upstream rsync 3.4.1 understands.
 pub(crate) const UPSTREAM_PROTOCOL_RANGE: RangeInclusive<u8> =

--- a/crates/protocol/src/version/mod.rs
+++ b/crates/protocol/src/version/mod.rs
@@ -9,7 +9,10 @@ mod recognized;
 mod select;
 
 pub use advertisement::ProtocolVersionAdvertisement;
-pub use constants::{SUPPORTED_PROTOCOL_BOUNDS, SUPPORTED_PROTOCOL_RANGE};
+#[allow(unused_imports)]
+pub use constants::{
+    MAXIMUM_PROTOCOL_ADVERTISEMENT, SUPPORTED_PROTOCOL_BOUNDS, SUPPORTED_PROTOCOL_RANGE,
+};
 pub use iter::{SupportedProtocolNumbersIter, SupportedVersionsIter};
 pub use parse::{ParseProtocolVersionError, ParseProtocolVersionErrorKind};
 pub use protocol_version::{

--- a/crates/protocol/src/version/select.rs
+++ b/crates/protocol/src/version/select.rs
@@ -15,7 +15,7 @@ where
 {
     let mut supported_bitmap: u64 = 0;
     let mut recognized_versions = RecognizedVersions::new();
-    let mut oldest_rejection: Option<u8> = None;
+    let mut oldest_rejection: Option<u32> = None;
 
     for version in peer_versions {
         let advertised = version.into_advertised_version();
@@ -39,7 +39,7 @@ where
                 }
             }
             Err(NegotiationError::UnsupportedVersion(value))
-                if value < ProtocolVersion::OLDEST.as_u8() =>
+                if value < u32::from(ProtocolVersion::OLDEST.as_u8()) =>
             {
                 if oldest_rejection.is_none_or(|current| value < current) {
                     oldest_rejection = Some(value);

--- a/crates/protocol/src/version/tests/advertisement.rs
+++ b/crates/protocol/src/version/tests/advertisement.rs
@@ -15,6 +15,12 @@ fn rejects_peer_advertisements_older_than_supported_range() {
 }
 
 #[test]
+fn rejects_peer_advertisements_beyond_upstream_cap() {
+    let err = ProtocolVersion::from_peer_advertisement(41).unwrap_err();
+    assert_eq!(err, NegotiationError::UnsupportedVersion(41));
+}
+
+#[test]
 fn rejects_zero_peer_advertisement() {
     let err = ProtocolVersion::from_peer_advertisement(0).unwrap_err();
     assert_eq!(err, NegotiationError::UnsupportedVersion(0));

--- a/crates/protocol/src/version/tests/property.rs
+++ b/crates/protocol/src/version/tests/property.rs
@@ -6,7 +6,8 @@ use super::select_highest_mutual;
 proptest! {
     #[test]
     fn select_highest_mutual_matches_reference(peer_versions in proptest::collection::vec(0u8..=255, 0..=16)) {
-        let expected = reference_negotiation(&peer_versions);
+        let advertised = collect_advertised(peer_versions.iter().copied());
+        let expected = reference_negotiation(&advertised);
         let actual = select_highest_mutual(peer_versions.iter().copied());
         prop_assert_eq!(actual, expected);
     }

--- a/crates/transport/src/binary/negotiate.rs
+++ b/crates/transport/src/binary/negotiate.rs
@@ -94,15 +94,10 @@ where
     stream.read_exact(&mut remote_buf)?;
     let remote_advertised = u32::from_be_bytes(remote_buf);
 
-    let remote_byte = remote_advertised.min(u32::from(u8::MAX)) as u8;
-
-    let remote_protocol = match ProtocolVersion::from_peer_advertisement(remote_byte) {
+    let remote_protocol = match ProtocolVersion::from_peer_advertisement(remote_advertised) {
         Ok(protocol) => protocol,
-        Err(_) => {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                "binary negotiation protocol identifier outside supported range",
-            ));
+        Err(err) => {
+            return Err(io::Error::from(err));
         }
     };
     let negotiated_protocol = cmp::min(desired_protocol, remote_protocol);


### PR DESCRIPTION
## Summary
- clamp rsync protocol advertisements to the upstream MAX_PROTOCOL_VERSION guard
- treat NegotiationError::UnsupportedVersion as a u32 so diagnostics preserve oversized values
- update binary/daemon handshakes and legacy greeting parsing to reject advertisements beyond the upstream cap while keeping future-within-cap support and tests in sync

## Testing
- cargo test

------
[Codex Task](