### PR TITLE
Fix clippy regressions across protocol and transport tests

### DIFF
--- a/crates/protocol/src/legacy/greeting/tests.rs
+++ b/crates/protocol/src/legacy/greeting/tests.rs
@@ -309,8 +309,12 @@ fn parses_large_future_version_numbers_by_clamping() {
 
 #[test]
 fn rejects_future_versions_beyond_cap() {
-    let err = parse_legacy_daemon_greeting("@RSYNCD: 999999999999.0\n").unwrap_err();
-    assert_eq!(err, NegotiationError::UnsupportedVersion(999999999999));
+    let future_version = u32::MAX;
+    let err = parse_legacy_daemon_greeting(&format!(
+        "@RSYNCD: {future_version}.0\n"
+    ))
+    .unwrap_err();
+    assert_eq!(err, NegotiationError::UnsupportedVersion(future_version));
 }
 
 #[test]

--- a/crates/protocol/tests/public_api.rs
+++ b/crates/protocol/tests/public_api.rs
@@ -22,8 +22,8 @@ struct CustomAdvertised(u8);
 
 impl ProtocolVersionAdvertisement for CustomAdvertised {
     #[inline]
-    fn into_advertised_version(self) -> u8 {
-        self.0
+    fn into_advertised_version(self) -> u32 {
+        u32::from(self.0)
     }
 }
 

--- a/crates/transport/src/session/tests/basics.rs
+++ b/crates/transport/src/session/tests/basics.rs
@@ -162,6 +162,7 @@ fn negotiate_session_parts_exposes_binary_metadata() {
         remote_protocol,
         local_advertised,
         negotiated_protocol,
+        _remote_flags,
         _stream_parts_tuple,
     ) = tuple_parts;
     assert_eq!(remote_advertised, u32::from(remote_version.as_u8()));
@@ -418,7 +419,14 @@ fn negotiate_session_parts_with_sniffer_supports_reuse() {
     assert_eq!(parts1.decision(), NegotiationPrologue::Binary);
     assert_eq!(parts1.remote_protocol(), remote_version);
 
-    let (_remote_advertised, _remote_protocol, _local_advertised, _negotiated, stream_parts) =
+    let (
+        _remote_advertised,
+        _remote_protocol,
+        _local_advertised,
+        _negotiated,
+        _remote_flags,
+        stream_parts,
+    ) =
         parts1.into_binary().expect("binary parts");
     let transport1 = stream_parts.into_stream().into_inner();
     assert_eq!(

--- a/crates/transport/src/session/tests/clones.rs
+++ b/crates/transport/src/session/tests/clones.rs
@@ -392,7 +392,14 @@ fn session_handshake_parts_from_binary_components_round_trips() {
 
     let parts = negotiate_session_parts(transport, ProtocolVersion::NEWEST)
         .expect("binary negotiation succeeds");
-    let (remote_advertised, remote_protocol, local_advertised, negotiated, stream_parts) = parts
+    let (
+        remote_advertised,
+        remote_protocol,
+        local_advertised,
+        negotiated,
+        remote_flags,
+        stream_parts,
+    ) = parts
         .clone()
         .into_binary()
         .expect("binary components available");
@@ -402,6 +409,7 @@ fn session_handshake_parts_from_binary_components_round_trips() {
         remote_protocol,
         local_advertised,
         negotiated,
+        remote_flags,
         stream_parts,
     );
 

--- a/xtask/src/commands/branding/validate.rs
+++ b/xtask/src/commands/branding/validate.rs
@@ -189,15 +189,13 @@ fn ensure_binary_name(name: &str, label: &str) -> TaskResult<()> {
 
     if name.chars().any(char::is_whitespace) {
         return Err(TaskError::Validation(format!(
-            "{label} '{}' must not contain whitespace",
-            name
+            "{label} '{name}' must not contain whitespace"
         )));
     }
 
     if name.chars().any(std::path::is_separator) {
         return Err(TaskError::Validation(format!(
-            "{label} '{}' must not include path separators",
-            name
+            "{label} '{name}' must not include path separators"
         )));
     }
 


### PR DESCRIPTION
## Summary
- update the custom protocol advertisement test type to return the u32 expected by the trait
- refresh transport session tests to account for the compatibility flag component exposed by `into_binary`
- modernize branding validation error formatting and keep oversized legacy greeting tests within the supported numeric range

## Testing
- cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings

------
[Codex Task](