### PR TITLE
Align compatibility flag tests and fix Clippy

### DIFF
--- a/crates/protocol/src/legacy/greeting/tests.rs
+++ b/crates/protocol/src/legacy/greeting/tests.rs
@@ -309,8 +309,8 @@ fn parses_large_future_version_numbers_by_clamping() {
 
 #[test]
 fn rejects_future_versions_beyond_cap() {
-    let err = parse_legacy_daemon_greeting("@RSYNCD: 999999999999.0\n").unwrap_err();
-    assert_eq!(err, NegotiationError::UnsupportedVersion(999999999999));
+    let err = parse_legacy_daemon_greeting("@RSYNCD: 4294967295.0\n").unwrap_err();
+    assert_eq!(err, NegotiationError::UnsupportedVersion(u32::MAX));
 }
 
 #[test]

--- a/crates/protocol/tests/public_api.rs
+++ b/crates/protocol/tests/public_api.rs
@@ -22,8 +22,8 @@ struct CustomAdvertised(u8);
 
 impl ProtocolVersionAdvertisement for CustomAdvertised {
     #[inline]
-    fn into_advertised_version(self) -> u8 {
-        self.0
+    fn into_advertised_version(self) -> u32 {
+        u32::from(self.0)
     }
 }
 

--- a/crates/transport/src/binary/parts.rs
+++ b/crates/transport/src/binary/parts.rs
@@ -373,6 +373,7 @@ impl<R> BinaryHandshakeParts<R> {
     ///     let expected_remote = parts.remote_protocol();
     ///     let expected_local = parts.local_advertised_protocol();
     ///     let expected_negotiated = parts.negotiated_protocol();
+    ///     let expected_flags = parts.remote_compatibility_flags();
     ///     let (
     ///         remote_advertised,
     ///         remote_protocol,
@@ -387,7 +388,7 @@ impl<R> BinaryHandshakeParts<R> {
     ///     assert_eq!(remote_protocol, expected_remote);
     ///     assert_eq!(local_advertised, expected_local);
     ///     assert_eq!(negotiated_protocol, expected_negotiated);
-    ///     assert_eq!(remote_flags, parts.remote_compatibility_flags());
+    ///     assert_eq!(remote_flags, expected_flags);
     ///     assert_eq!(
     ///         stream_parts.decision(),
     ///         protocol::NegotiationPrologue::Binary

--- a/crates/transport/src/session/tests/basics.rs
+++ b/crates/transport/src/session/tests/basics.rs
@@ -162,12 +162,14 @@ fn negotiate_session_parts_exposes_binary_metadata() {
         remote_protocol,
         local_advertised,
         negotiated_protocol,
+        remote_flags,
         _stream_parts_tuple,
     ) = tuple_parts;
     assert_eq!(remote_advertised, u32::from(remote_version.as_u8()));
     assert_eq!(remote_protocol, remote_version);
     assert_eq!(local_advertised, ProtocolVersion::NEWEST);
     assert_eq!(negotiated_protocol, remote_version);
+    assert!(remote_flags.is_empty());
 
     let binary_parts = BinaryHandshakeParts::try_from(parts).expect("binary parts conversion");
     assert_eq!(binary_parts.remote_protocol(), remote_version);
@@ -176,6 +178,7 @@ fn negotiate_session_parts_exposes_binary_metadata() {
         binary_parts.local_advertised_protocol(),
         ProtocolVersion::NEWEST
     );
+    assert!(binary_parts.remote_compatibility_flags().is_empty());
 
     let stream_parts = binary_parts.into_stream_parts();
     let transport = stream_parts.into_stream().into_inner();
@@ -418,8 +421,14 @@ fn negotiate_session_parts_with_sniffer_supports_reuse() {
     assert_eq!(parts1.decision(), NegotiationPrologue::Binary);
     assert_eq!(parts1.remote_protocol(), remote_version);
 
-    let (_remote_advertised, _remote_protocol, _local_advertised, _negotiated, stream_parts) =
-        parts1.into_binary().expect("binary parts");
+    let (
+        _remote_advertised,
+        _remote_protocol,
+        _local_advertised,
+        _negotiated,
+        _remote_flags,
+        stream_parts,
+    ) = parts1.into_binary().expect("binary parts");
     let transport1 = stream_parts.into_stream().into_inner();
     assert_eq!(
         transport1.writes(),

--- a/crates/transport/src/session/tests/clones.rs
+++ b/crates/transport/src/session/tests/clones.rs
@@ -392,7 +392,14 @@ fn session_handshake_parts_from_binary_components_round_trips() {
 
     let parts = negotiate_session_parts(transport, ProtocolVersion::NEWEST)
         .expect("binary negotiation succeeds");
-    let (remote_advertised, remote_protocol, local_advertised, negotiated, stream_parts) = parts
+    let (
+        remote_advertised,
+        remote_protocol,
+        local_advertised,
+        negotiated,
+        remote_flags,
+        stream_parts,
+    ) = parts
         .clone()
         .into_binary()
         .expect("binary components available");
@@ -402,6 +409,7 @@ fn session_handshake_parts_from_binary_components_round_trips() {
         remote_protocol,
         local_advertised,
         negotiated,
+        remote_flags,
         stream_parts,
     );
 

--- a/xtask/src/commands/branding/validate.rs
+++ b/xtask/src/commands/branding/validate.rs
@@ -153,8 +153,8 @@ fn ensure_under_dir(
 fn ensure_has_file_name(path: &Path, label: &str) -> TaskResult<()> {
     if path.file_name().is_none() {
         return Err(TaskError::Validation(format!(
-            "{label} '{}' must include a file name",
-            path.display()
+            "{label} '{path}' must include a file name",
+            path = path.display()
         )));
     }
 
@@ -167,15 +167,15 @@ fn ensure_named_file(path: &Path, expected: &str, label: &str) -> TaskResult<()>
         .and_then(|value| value.to_str())
         .ok_or_else(|| {
             TaskError::Validation(format!(
-                "{label} '{}' must include a file name",
-                path.display()
+                "{label} '{path}' must include a file name",
+                path = path.display()
             ))
         })?;
 
     if name != expected {
         return Err(TaskError::Validation(format!(
-            "{label} '{}' must be named '{expected}'",
-            path.display()
+            "{label} '{path}' must be named '{expected}'",
+            path = path.display()
         )));
     }
 
@@ -189,15 +189,13 @@ fn ensure_binary_name(name: &str, label: &str) -> TaskResult<()> {
 
     if name.chars().any(char::is_whitespace) {
         return Err(TaskError::Validation(format!(
-            "{label} '{}' must not contain whitespace",
-            name
+            "{label} '{name}' must not contain whitespace"
         )));
     }
 
     if name.chars().any(std::path::is_separator) {
         return Err(TaskError::Validation(format!(
-            "{label} '{}' must not include path separators",
-            name
+            "{label} '{name}' must not include path separators"
         )));
     }
 


### PR DESCRIPTION
## Summary
- update protocol tests to accept u32 protocol advertisements and cover the new maximum range behaviour
- extend transport handshake tests and docs to exercise remote compatibility flags and legacy error handling
- fix xtask branding validation format! usage to satisfy Clippy

## Testing
- cargo clippy --workspace --all-targets
- cargo test -p transport

------
[Codex Task](