### PR TITLE
Gate checksums OpenSSL feature on Windows targets

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -27,12 +27,17 @@ daemon = { path = "../daemon" }
 protocol = { path = "../protocol" }
 compress = { path = "../compress" }
 metadata = { path = "../metadata" }
-checksums = { path = "../checksums" }
 time = { version = "0.3", default-features = false, features = ["formatting", "macros", "local-offset", "std"] }
 tempfile = "3.10"
 
 [target.'cfg(unix)'.dependencies]
 users = "0.11"
+
+[target.'cfg(not(windows))'.dependencies]
+checksums = { path = "../checksums" }
+
+[target.'cfg(windows)'.dependencies]
+checksums = { path = "../checksums", default-features = false }
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -26,10 +26,15 @@ libc = "0.2"
 nix = { version = "0.29", default-features = false, features = ["user"] }
 rustix = { version = "0.38", features = ["process"] }
 base64 = "0.22"
-checksums = { path = "../checksums" }
 tempfile = "3.10"
 socket2 = "0.4"
 branding = { path = "../branding" }
+
+[target.'cfg(not(windows))'.dependencies]
+checksums = { path = "../checksums" }
+
+[target.'cfg(windows)'.dependencies]
+checksums = { path = "../checksums", default-features = false }
 
 [features]
 default = ["zstd", "lz4", "acl", "xattr", "iconv"]

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -24,9 +24,14 @@ dns-lookup = "1.0"
 core = { path = "../core" }
 protocol = { path = "../protocol" }
 logging = { path = "../logging" }
-checksums = { path = "../checksums" }
 fs2 = "0.4"
 sd-notify = { version = "0.4.5", optional = true }
+
+[target.'cfg(not(windows))'.dependencies]
+checksums = { path = "../checksums" }
+
+[target.'cfg(windows)'.dependencies]
+checksums = { path = "../checksums", default-features = false }
 
 [dev-dependencies]
 tempfile = "3.10"

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -17,7 +17,6 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 metadata = { path = "../metadata", default-features = false }
 filters = { path = "../filters" }
-checksums = { path = "../checksums" }
 compress = { path = "../compress" }
 protocol = { path = "../protocol" }
 bandwidth = { path = "../bandwidth" }
@@ -25,6 +24,12 @@ globset = "0.4"
 rustix = { version = "0.38", features = ["fs", "process"] }
 libc = { version = "0.2", optional = true }
 memchr = "2.7"
+
+[target.'cfg(not(windows))'.dependencies]
+checksums = { path = "../checksums" }
+
+[target.'cfg(windows)'.dependencies]
+checksums = { path = "../checksums", default-features = false }
 
 [features]
 default = ["zstd", "lz4", "acl", "xattr"]


### PR DESCRIPTION
## Summary
- disable the default OpenSSL-vendored checksums dependency when targeting Windows so cross-compiles no longer attempt to build OpenSSL from source

## Testing
- cargo check

------
[Codex Task](