### PR TITLE
Refactor Linux cross-build workflow for packaging

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -14,64 +14,26 @@ env:
 
 jobs:
   build:
-    name: build ${{ matrix.platform.name }} (${{ matrix.platform.target }})
-    strategy:
-      fail-fast: false
-      max-parallel: 2
-      matrix:
-        platform:
-          - name: linux-x86_64
-            enabled: true
-            runner: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
-            build_command: build
-            build_daemon: true
-            uses_zig: false
-            needs_cross_gcc: false
-            package_linux: false
-            package_brew: false
-            generate_sbom: true
-          - name: linux-aarch64
-            enabled: true
-            runner: ubuntu-latest
-            target: aarch64-unknown-linux-gnu
-            build_command: build
-            build_daemon: true
-            uses_zig: false
-            needs_cross_gcc: true
-            package_linux: false
-            package_brew: false
-            generate_sbom: true
-
-    runs-on: ${{ matrix.platform.runner }}
+    runs-on: ubuntu-latest
 
     steps:
-      - name: Skip disabled target
-        if: ${{ !matrix.platform.enabled }}
-        run: echo "Platform '${{ matrix.platform.name }}' is disabled."
-
       - uses: actions/checkout@v4
-        if: ${{ matrix.platform.enabled }}
 
       - name: Setup Rust toolchain
-        if: ${{ matrix.platform.enabled }}
         uses: dtolnay/rust-toolchain@stable
         with:
-          targets: ${{ matrix.platform.target }}
+          targets: x86_64-unknown-linux-gnu,aarch64-unknown-linux-gnu
 
       - uses: mozilla-actions/sccache-action@v0.0.4
-        if: ${{ matrix.platform.enabled }}
         continue-on-error: true
 
       - name: Configure local sccache dir
-        if: ${{ matrix.platform.enabled }}
         shell: bash
         run: |
           echo "SCCACHE_GHA_ENABLED=false" >> "$GITHUB_ENV"
           echo "SCCACHE_DIR=$RUNNER_TEMP/.sccache" >> "$GITHUB_ENV"
 
       - name: Enable sccache wrapper if available (non-fatal)
-        if: ${{ matrix.platform.enabled }}
         shell: bash
         run: |
           if command -v sccache >/dev/null 2>&1; then
@@ -79,109 +41,54 @@ jobs:
           fi
 
       - name: Install Ubuntu build deps
-        if: ${{ matrix.platform.enabled && startsWith(matrix.platform.runner, 'ubuntu') }}
         uses: awalsh128/cache-apt-pkgs-action@v1
         with:
-          packages: build-essential libzstd-dev zlib1g-dev libacl1-dev attr acl libxxhash-dev rpm fakeroot openssl libssl-dev
+          packages: >-
+            build-essential libzstd-dev zlib1g-dev libacl1-dev attr acl
+            libxxhash-dev rpm fakeroot openssl libssl-dev gcc-aarch64-linux-gnu
           version: 1
 
-      - name: Install cross GCC for aarch64 (Ubuntu)
-        if: ${{ matrix.platform.enabled && startsWith(matrix.platform.runner, 'ubuntu') && matrix.platform.needs_cross_gcc }}
-        uses: awalsh128/cache-apt-pkgs-action@v1
-        with:
-          packages: gcc-aarch64-linux-gnu
-          version: 1
-
-      - name: Install cargo-deb & cargo-rpm
-        if: ${{ matrix.platform.enabled && matrix.platform.package_linux }}
+      - name: Install cargo-deb, cargo-rpm, and cargo-cyclonedx
         uses: taiki-e/install-action@v2
         with:
-          tool: cargo-deb,cargo-rpm
+          tool: cargo-deb,cargo-rpm,cargo-cyclonedx
 
-      - name: Install cargo-cyclonedx (SBOM)
-        if: ${{ matrix.platform.enabled && matrix.platform.generate_sbom }}
-        uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-cyclonedx
-
-      - name: Build oc-rsync (dist, locked)
-        if: ${{ matrix.platform.enabled }}
-        shell: bash
-        run: |
-          cargo --locked ${{ matrix.platform.build_command }} --profile dist --target ${{ matrix.platform.target }} --bin oc-rsync
-
-      - name: Build .deb (cargo-deb)
-        if: ${{ matrix.platform.enabled && matrix.platform.package_linux }}
+      - name: Build Linux artifacts
         shell: bash
         run: |
           set -euo pipefail
-          cargo deb --profile dist --locked --target ${{ matrix.platform.target }} --no-strip
-          mkdir -p dist/${{ matrix.platform.name }}
-          cp -v target/${{ matrix.platform.target }}/debian/*.deb dist/${{ matrix.platform.name }}/
+          for platform in aarch64 amd64; do
+            for package in tar.gz rpm deb; do
+              echo "\n==> Packaging $package for $platform"
+              ./create_package "$platform" "$package"
+            done
+          done
 
-      - name: Upload .deb artifact
-        if: ${{ matrix.platform.enabled && matrix.platform.package_linux }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: deb-${{ matrix.platform.name }}
-          path: dist/${{ matrix.platform.name }}/*.deb
-          if-no-files-found: error
-          retention-days: 10
-
-      - name: Build .rpm (cargo-rpm)
-        if: ${{ matrix.platform.enabled && matrix.platform.package_linux }}
+      - name: Generate SBOMs
         shell: bash
         run: |
           set -euo pipefail
-          rpmbuild --version
-          cargo rpm build -v --target ${{ matrix.platform.target }}
-          RPM_DIR="target/${{ matrix.platform.target }}/dist/rpmbuild/RPMS"
-          mkdir -p dist/${{ matrix.platform.name }}
-          find "$RPM_DIR" -type f -name '*.rpm' -exec cp -v {} dist/${{ matrix.platform.name }}/ \;
+          cargo cyclonedx --format json --all-features --output target/dist/oc-rsync-sbom.json
+          install -D target/dist/oc-rsync-sbom.json target/aarch64-unknown-linux-gnu/dist/oc-rsync-linux-aarch64-sbom.json
+          install -D target/dist/oc-rsync-sbom.json target/x86_64-unknown-linux-gnu/dist/oc-rsync-linux-amd64-sbom.json
 
-      - name: Upload .rpm artifact
-        if: ${{ matrix.platform.enabled && matrix.platform.package_linux }}
+      - name: Upload linux-aarch64 artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: rpm-${{ matrix.platform.name }}
-          path: dist/${{ matrix.platform.name }}/*.rpm
+          name: oc-rsync-linux-aarch64
+          path: |
+            dist/linux-aarch64/*
+            target/aarch64-unknown-linux-gnu/dist/oc-rsync-linux-aarch64-sbom.json
           if-no-files-found: error
           retention-days: 10
 
-      - name: Build tarball
-        if: ${{ matrix.platform.enabled }}
-        shell: bash
-        env:
-          OC_RSYNC_PACKAGE_SKIP_BUILD: "1"
-        run: |
-          rm -f target/dist/*.tar.gz
-          cargo xtask package --tarball --release --tarball-target ${{ matrix.platform.target }}
-
-      - name: Upload tarball artifact
-        if: ${{ matrix.platform.enabled }}
+      - name: Upload linux-amd64 artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: tar-${{ matrix.platform.name }}
-          path: target/dist/*.tar.gz
-          if-no-files-found: error
-          retention-days: 10
-
-      - name: Generate target SBOM (best-effort)
-        if: ${{ matrix.platform.enabled && matrix.platform.generate_sbom }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          if cargo cyclonedx --help >/dev/null 2>&1; then
-            cargo cyclonedx --format json --all-features \
-              --output target/${{ matrix.platform.target }}/dist/oc-rsync-${{ matrix.platform.name }}-sbom.json || true
-          fi
-
-      - name: Upload oc-rsync artifact
-        if: ${{ matrix.platform.enabled }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: oc-rsync-${{ matrix.platform.name }}
-          path: target/${{ matrix.platform.target }}/dist/oc-rsync*
+          name: oc-rsync-linux-amd64
+          path: |
+            dist/linux-amd64/*
+            target/x86_64-unknown-linux-gnu/dist/oc-rsync-linux-amd64-sbom.json
           if-no-files-found: error
           retention-days: 10
 

--- a/create_package
+++ b/create_package
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "usage: $0 <platform> <package>" >&2
+  exit 1
+fi
+
+platform="$1"
+package="$2"
+
+declare target=""
+declare dist_dir=""
+declare arch_label=""
+
+case "$platform" in
+  aarch64)
+    target="aarch64-unknown-linux-gnu"
+    dist_dir="dist/linux-aarch64"
+    arch_label="aarch64"
+    ;;
+  amd64|x86_64)
+    target="x86_64-unknown-linux-gnu"
+    dist_dir="dist/linux-amd64"
+    arch_label="amd64"
+    ;;
+  *)
+    echo "unsupported platform '$platform'" >&2
+    exit 1
+    ;;
+esac
+
+mkdir -p "$dist_dir"
+
+if [[ ! -f "target/$target/dist/oc-rsync" ]]; then
+  echo "Building oc-rsync binary for $target"
+  cargo --locked build --profile dist --target "$target" --bin oc-rsync
+fi
+
+copy_artifacts() {
+  local pattern="$1"
+  local source_dir="$2"
+  local found=false
+
+  if [[ -d "$source_dir" ]]; then
+    while IFS= read -r -d '' artifact; do
+      found=true
+      echo "Copying $(basename "$artifact") to $dist_dir"
+      cp -v "$artifact" "$dist_dir/"
+    done < <(find "$source_dir" -type f -name "$pattern" -print0)
+  fi
+
+  if [[ "$found" == false ]]; then
+    echo "no artifacts matching '$pattern' were produced in $source_dir" >&2
+    exit 1
+  fi
+}
+
+case "$package" in
+  tar.gz)
+    echo "Building tarball for $target"
+    OC_RSYNC_PACKAGE_SKIP_BUILD=1 cargo xtask package --release --tarball --tarball-target "$target"
+    copy_artifacts "oc-rsync-*${target}.tar.gz" "target/dist"
+    ;;
+  deb)
+    echo "Building Debian package for $target"
+    cargo deb --profile dist --locked --target "$target" --no-strip
+    copy_artifacts "*.deb" "target/$target/debian"
+    ;;
+  rpm)
+    echo "Building RPM package for $target"
+    cargo rpm build -v --target "$target"
+    copy_artifacts "*.rpm" "target/$target/dist/rpmbuild/RPMS"
+    ;;
+  *)
+    echo "unsupported package '$package'" >&2
+    exit 1
+    ;;
+esac
+
+if [[ -f "target/$target/dist/oc-rsync" ]]; then
+  cp -v "target/$target/dist/oc-rsync" "$dist_dir/oc-rsync-$arch_label"
+fi


### PR DESCRIPTION
## Summary
- add a reusable `create_package` helper that builds tarballs, Debian packages, and RPMs for amd64 and aarch64
- collapse the Linux cross-compilation workflow into a single job that loops over package types with the helper script
- ensure SBOMs and artifacts are uploaded for both linux-amd64 and linux-aarch64 builds without provisioning extra runners

## Testing
- Not run (workflow change only)

------
[Codex Task](