### PR TITLE
Fix release automation and packaging gating for oc-rsync

### DIFF
--- a/.github/scripts/make-tarball.sh
+++ b/.github/scripts/make-tarball.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 TARGET="$1"
 OUTNAME="$2"
-BINARIES="${3:-oc-rsync oc-rsyncd}"
+BINARIES="${3:-oc-rsync}"
 
 OUTDIR="dist/${TARGET}"
 mkdir -p "${OUTDIR}"

--- a/.github/scripts/package-linux.sh
+++ b/.github/scripts/package-linux.sh
@@ -7,6 +7,15 @@ TARGET="$1"
 cargo install cargo-deb --locked
 cargo install cargo-generate-rpm --locked
 
+# stage the canonical binary for packagers
+BIN_PATH="target/${TARGET}/release/oc-rsync"
+if [ ! -f "${BIN_PATH}" ]; then
+  echo "expected ${BIN_PATH} to exist; build step must run first" >&2
+  exit 1
+fi
+
+install -Dm755 "${BIN_PATH}" "target/dist/oc-rsync"
+
 # build deb without rebuilding the binary (we already built it)
 cargo deb --target "${TARGET}" --no-build
 

--- a/.github/workflows/brew.yml
+++ b/.github/workflows/brew.yml
@@ -72,7 +72,6 @@ jobs:
             echo
             echo "  def install"
             echo "    bin.install \"oc-rsync\""
-            echo "    bin.install \"oc-rsyncd\""
             echo "  end"
             echo
             echo "  test do"

--- a/.github/workflows/build-cross.yml
+++ b/.github/workflows/build-cross.yml
@@ -12,7 +12,6 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: "-D warnings"
-#  BINARIES: "oc-rsync oc-rsyncd"
   BINARIES: "oc-rsync"
 
 jobs:
@@ -50,10 +49,11 @@ jobs:
       - name: Install system deps (OpenSSL, ACL, cross toolchain)
         run: |
           set -euo pipefail
-          sudo dpkg --add-architecture arm64
           sudo apt-get update
           sudo apt-get install -y pkg-config libssl-dev libacl1-dev
           if [ "${{ matrix.cross }}" = "true" ]; then
+            sudo dpkg --add-architecture arm64
+            sudo apt-get update
             sudo apt-get install -y \
               gcc-aarch64-linux-gnu \
               libssl-dev:arm64 \
@@ -76,6 +76,7 @@ jobs:
         run: .github/scripts/make-tarball.sh ${{ matrix.target }} oc-rsync-${{ matrix.os-arch }}.tar.gz "$BINARIES"
 
       - name: Package Linux (.deb, .rpm)
+        if: matrix.cross == false
         run: .github/scripts/package-linux.sh ${{ matrix.target }}
 
       - name: Upload artifact (tar.gz)
@@ -85,12 +86,14 @@ jobs:
           path: oc-rsync-${{ matrix.os-arch }}.tar.gz
 
       - name: Upload .deb
+        if: matrix.cross == false
         uses: actions/upload-artifact@v4
         with:
           name: deb-${{ matrix.os-arch }}
           path: target/${{ matrix.target }}/debian/*.deb
 
       - name: Upload .rpm
+        if: matrix.cross == false
         uses: actions/upload-artifact@v4
         with:
           name: rpm-${{ matrix.os-arch }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,15 +11,17 @@ permissions:
 
 jobs:
   upload-to-release:
+    if: |
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
+      startsWith(github.event.workflow_run.head_branch, 'v')
     name: Upload build artifacts to release
     runs-on: ubuntu-latest
 
     steps:
-      - name: Check workflow conclusion
-        if: ${{ github.event.workflow_run.conclusion != 'success' }}
-        run: |
-          echo "Build-cross did not succeed, skipping release upload."
-          exit 1
+      - name: Capture release tag
+        id: release
+        run: echo "tag=${{ github.event.workflow_run.head_branch }}" >> "$GITHUB_OUTPUT"
 
       - name: Download artifacts from Build-cross
         uses: dawidd6/action-download-artifact@v6
@@ -40,6 +42,8 @@ jobs:
             dist/**/*.deb
             dist/**/*.rpm
             dist/**/*.zip
+          tag_name: ${{ steps.release.outputs.tag }}
+          name: ${{ steps.release.outputs.tag }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           

--- a/crates/metadata/build.rs
+++ b/crates/metadata/build.rs
@@ -4,6 +4,10 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 fn main() {
+    if !cfg!(unix) {
+        return;
+    }
+
     if env::var_os("CARGO_FEATURE_ACL").is_none() {
         return;
     }


### PR DESCRIPTION
## Summary
- ensure the build/tarball scripts and Homebrew formula treat oc-rsync as the sole shipped binary
- restrict Linux packaging and release jobs to tag pushes with successful builds
- short-circuit the metadata ACL build script on non-Unix targets so Windows builds skip libacl probing

## Testing
- cargo check

------
[Codex Task](