### PR TITLE
Fix cross-platform release packaging

### DIFF
--- a/.github/scripts/make-tarball.sh
+++ b/.github/scripts/make-tarball.sh
@@ -6,6 +6,7 @@ OUTNAME="$2"
 BINARIES="${3:-oc-rsync}"
 
 OUTDIR="dist/${TARGET}"
+rm -rf "${OUTDIR}"
 mkdir -p "${OUTDIR}"
 
 for bin in $BINARIES; do
@@ -20,5 +21,7 @@ for bin in $BINARIES; do
   cp "${SRC}" "${OUTDIR}/"
 done
 
-tar -czf "${OUTNAME}" -C "${OUTDIR}" .
+ARCHIVE_PATH="dist/${OUTNAME}"
+mkdir -p "$(dirname "${ARCHIVE_PATH}")"
+tar -czf "${ARCHIVE_PATH}" -C "${OUTDIR}" .
 

--- a/.github/workflows/build-cross.yml
+++ b/.github/workflows/build-cross.yml
@@ -83,7 +83,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: oc-rsync-${{ matrix.os-arch }}.tar.gz
-          path: oc-rsync-${{ matrix.os-arch }}.tar.gz
+          path: dist/oc-rsync-${{ matrix.os-arch }}.tar.gz
 
       - name: Upload .deb
         if: matrix.cross == false
@@ -147,7 +147,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: oc-rsync-${{ matrix.os-arch }}.tar.gz
-          path: oc-rsync-${{ matrix.os-arch }}.tar.gz
+          path: dist/oc-rsync-${{ matrix.os-arch }}.tar.gz
 
   # --------------------------------------------------
   # Windows builds on windows-latest
@@ -192,16 +192,22 @@ jobs:
       - name: Build
         shell: pwsh
         run: |
-          cargo build --release --target ${{ matrix.target }} --bin oc-rsync
+          cargo build --release --target ${{ matrix.target }} --bin oc-rsync --no-default-features --features "zstd lz4 iconv"
 
       - name: Package
         shell: pwsh
         run: |
-          New-Item -ItemType Directory -Force -Path dist | Out-Null
-          Copy-Item "target\${{ matrix.target }}\release\oc-rsync.exe" dist\
+          $dist = Join-Path (Get-Location) "dist"
+          New-Item -ItemType Directory -Force -Path $dist | Out-Null
+          $artifact = Join-Path $dist "oc-rsync-${{ matrix.os-arch }}.zip"
+          $binary = "target\${{ matrix.target }}\release\oc-rsync.exe"
+          if (-not (Test-Path $binary)) {
+            Write-Error "expected binary '$binary' to exist"
+          }
+          Compress-Archive -Path $binary -DestinationPath $artifact -Force
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: oc-rsync-${{ matrix.os-arch }}.zip
-          path: dist\
+          path: dist\oc-rsync-${{ matrix.os-arch }}.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,14 +14,26 @@ jobs:
     if: |
       github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.event == 'push' &&
-      startsWith(github.event.workflow_run.head_branch, 'v')
+      (github.event.workflow_run.head_branch == '' || startsWith(github.event.workflow_run.head_branch, 'v'))
     name: Upload build artifacts to release
     runs-on: ubuntu-latest
 
     steps:
-      - name: Capture release tag
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Determine release tag
         id: release
-        run: echo "tag=${{ github.event.workflow_run.head_branch }}" >> "$GITHUB_OUTPUT"
+        run: |
+          set -euo pipefail
+          git fetch --tags --force
+          TAGS="$(git tag --points-at "${{ github.event.workflow_run.head_sha }}")"
+          if [ -z "${TAGS}" ]; then
+            echo "::error::No tag found for commit ${{ github.event.workflow_run.head_sha }}" >&2
+            exit 1
+          fi
+          TAG="$(printf '%s\n' "${TAGS}" | head -n1)"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
 
       - name: Download artifacts from Build-cross
         uses: dawidd6/action-download-artifact@v6

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,15 +98,14 @@ source = "https://github.com/oferchen/rsync"
 [workspace.metadata.oc_rsync.cross_compile]
 linux = ["x86_64", "aarch64"]
 macos = ["x86_64", "aarch64"]
-windows = ["x86_64", "aarch64"]
+windows = ["x86_64"]
 
 [workspace.metadata.oc_rsync.cross_compile_matrix]
 "linux-x86_64" = true
-"linux-aarch64" = false
-"darwin-x86_64" = false
-"darwin-aarch64" = false
-"windows-x86_64" = false
-"windows-aarch64" = false
+"linux-aarch64" = true
+"darwin-x86_64" = true
+"darwin-aarch64" = true
+"windows-x86_64" = true
 "windows-x86" = false
 
 [package.metadata.deb]


### PR DESCRIPTION
## Summary
- write cross-platform build artifacts into the dist/ tree so the release workflow can upload them
- scope Windows cross-compilation metadata to the supported x86_64 target and enable the remaining matrix entries
- have the release workflow derive the tag from the workflow_run commit before uploading the assets

## Testing
- not run (workflow-only changes)

------
[Codex Task](