### PR TITLE
Add parity test for sparse with preallocate

### DIFF
--- a/crates/cli/src/frontend/tests/transfer_request_with_sparse.rs
+++ b/crates/cli/src/frontend/tests/transfer_request_with_sparse.rs
@@ -45,3 +45,49 @@ fn transfer_request_with_sparse_preserves_holes() {
     assert_eq!(dense_meta.len(), sparse_meta.len());
     assert!(sparse_meta.blocks() < dense_meta.blocks());
 }
+
+#[cfg(unix)]
+#[test]
+fn transfer_request_with_sparse_and_preallocate_allocates_dense() {
+    use std::os::unix::fs::MetadataExt;
+    use tempfile::tempdir;
+
+    let tmp = tempdir().expect("tempdir");
+    let source = tmp.path().join("source.bin");
+    let mut source_file = std::fs::File::create(&source).expect("create source");
+    source_file.write_all(&[0x10]).expect("write leading byte");
+    source_file
+        .seek(SeekFrom::Start(1024 * 1024))
+        .expect("seek to hole");
+    source_file.write_all(&[0x20]).expect("write trailing byte");
+    source_file.set_len(3 * 1024 * 1024).expect("extend source");
+
+    let dense_dest = tmp.path().join("dense.bin");
+    let prealloc_dest = tmp.path().join("sparse-prealloc.bin");
+
+    let (code, stdout, stderr) = run_with_args([
+        OsString::from(RSYNC),
+        source.clone().into_os_string(),
+        dense_dest.clone().into_os_string(),
+    ]);
+    assert_eq!(code, 0);
+    assert!(stdout.is_empty());
+    assert!(stderr.is_empty());
+
+    let (code, stdout, stderr) = run_with_args([
+        OsString::from(RSYNC),
+        OsString::from("--sparse"),
+        OsString::from("--preallocate"),
+        source.into_os_string(),
+        prealloc_dest.clone().into_os_string(),
+    ]);
+    assert_eq!(code, 0);
+    assert!(stdout.is_empty());
+    assert!(stderr.is_empty());
+
+    let dense_meta = std::fs::metadata(&dense_dest).expect("dense metadata");
+    let prealloc_meta = std::fs::metadata(&prealloc_dest).expect("prealloc metadata");
+
+    assert_eq!(dense_meta.len(), prealloc_meta.len());
+    assert_eq!(prealloc_meta.blocks(), dense_meta.blocks());
+}


### PR DESCRIPTION
## Summary
- add a CLI frontend test that exercises `--sparse` together with `--preallocate`
- verify that the combination keeps dense allocation to match upstream behaviour

## Testing
- cargo test -p cli transfer_request_with_sparse_tests -- --nocapture

------
[Codex Task](