### PR TITLE
Fix doctest std-core collisions

### DIFF
--- a/crates/core/src/message/segments/buffer.rs
+++ b/crates/core/src/message/segments/buffer.rs
@@ -23,13 +23,11 @@ impl<'a> MessageSegments<'a> {
     /// # Examples
     ///
     /// ```
-    /// # use std::collections::TryReserveError;
     /// use core::{
     ///     message::{Message, MessageScratch, Role},
     ///     message_source,
     /// };
     ///
-    /// # fn demo() -> Result<(), TryReserveError> {
     /// let mut scratch = MessageScratch::new();
     /// let message = Message::error(23, "delta-transfer failure")
     ///     .with_role(Role::Sender)
@@ -38,14 +36,14 @@ impl<'a> MessageSegments<'a> {
     /// let segments = message.as_segments(&mut scratch, false);
     /// let mut buffer = b"prefix: ".to_vec();
     /// let prefix_len = buffer.len();
-    /// let appended = segments.try_extend_vec(&mut buffer)?;
+    /// let appended = segments
+    ///     .try_extend_vec(&mut buffer)
+    ///     .expect("buffer extension succeeds");
     ///
+    /// let rendered = message.to_bytes().unwrap();
     /// assert_eq!(&buffer[..prefix_len], b"prefix: ");
-    /// assert_eq!(&buffer[prefix_len..], message.to_bytes().unwrap().as_slice());
-    /// assert_eq!(appended, message.to_bytes().unwrap().len());
-    /// # Ok(())
-    /// # }
-    /// # demo().unwrap();
+    /// assert_eq!(&buffer[prefix_len..], rendered.as_slice());
+    /// assert_eq!(appended, rendered.len());
     /// ```
     #[must_use = "buffer extension reserves memory and may fail; handle allocation errors and inspect the appended length"]
     pub fn try_extend_vec(&self, buffer: &mut Vec<u8>) -> Result<usize, TryReserveError> {
@@ -113,11 +111,12 @@ impl<'a> MessageSegments<'a> {
     /// let segments = message.as_segments(&mut scratch, false);
     ///
     /// let mut buffer = vec![0u8; segments.len()];
-    /// let copied = segments.copy_to_slice(&mut buffer)?;
+    /// let copied = segments
+    ///     .copy_to_slice(&mut buffer)
+    ///     .expect("slice has sufficient capacity");
     ///
     /// assert_eq!(copied, segments.len());
     /// assert_eq!(buffer, message.to_bytes().unwrap());
-    /// # Ok::<(), core::message::CopyToSliceError>(())
     /// ```
     #[must_use = "callers should handle the number of copied bytes or the returned error"]
     pub fn copy_to_slice(&self, dest: &mut [u8]) -> Result<usize, CopyToSliceError> {

--- a/crates/core/src/version/features.rs
+++ b/crates/core/src/version/features.rs
@@ -1,6 +1,6 @@
-use ::core::fmt;
-use ::core::iter::{FromIterator, FusedIterator};
-use ::core::str::FromStr;
+use std::fmt;
+use std::iter::{FromIterator, FusedIterator};
+use std::str::FromStr;
 use std::vec::Vec;
 
 const COMPILED_FEATURE_COUNT: usize = CompiledFeature::ALL.len();

--- a/crates/core/src/version/metadata.rs
+++ b/crates/core/src/version/metadata.rs
@@ -28,11 +28,11 @@ use super::constants::{
 /// let banner = metadata.standard_banner();
 ///
 /// assert!(banner.starts_with(&format!(
-///     "{PROGRAM_NAME}  version {} ",
+///     "{PROGRAM_NAME} v{} (revision #",
 ///     RUST_VERSION
 /// )));
 /// assert!(banner.contains("protocol version 32"));
-/// assert!(banner.contains("revision/build #"));
+/// assert!(banner.contains("revision #"));
 /// assert!(banner.contains(&format!("Source: {}", SOURCE_URL)));
 /// ```
 #[doc(alias = "--version")]

--- a/crates/core/src/version/report/renderer.rs
+++ b/crates/core/src/version/report/renderer.rs
@@ -99,7 +99,7 @@ impl VersionInfoReport {
     /// assert!(report
     ///     .metadata()
     ///     .standard_banner()
-    ///     .starts_with(&format!("{PROGRAM_NAME}  version")));
+    ///     .starts_with(&format!("{PROGRAM_NAME} v")));
     /// ```
     #[must_use]
     pub fn for_client_brand(brand: Brand) -> Self {
@@ -119,7 +119,7 @@ impl VersionInfoReport {
     /// assert!(report
     ///     .metadata()
     ///     .standard_banner()
-    ///     .starts_with(&format!("{DAEMON_PROGRAM_NAME}  version")));
+    ///     .starts_with(&format!("{DAEMON_PROGRAM_NAME} v")));
     /// ```
     #[must_use]
     pub fn for_daemon_brand(brand: Brand) -> Self {

--- a/crates/core/src/version/secluded_args.rs
+++ b/crates/core/src/version/secluded_args.rs
@@ -1,5 +1,5 @@
-use ::core::fmt;
-use ::core::str::FromStr;
+use std::fmt;
+use std::str::FromStr;
 
 /// Describes how secluded argument mode is advertised in `--version` output.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/crates/logging/src/sink/guard.rs
+++ b/crates/logging/src/sink/guard.rs
@@ -50,16 +50,15 @@ impl<'a, W> LineModeGuard<'a, W> {
     ///     let sink = sink
     ///         .scoped_line_mode(LineMode::WithoutNewline)
     ///         .into_inner();
-    ///     sink.write(Message::info("phase one"))?;
+    ///     sink.write(Message::info("phase one")).expect("write succeeds");
     /// }
     ///
-    /// sink.write(Message::info("phase two"))?;
+    /// sink.write(Message::info("phase two")).expect("write succeeds");
     /// assert_eq!(sink.line_mode(), LineMode::WithoutNewline);
     /// assert_eq!(
     ///     sink.into_inner(),
     ///     b"rsync info: phase onersync info: phase two".to_vec()
     /// );
-    /// # Ok::<(), std::io::Error>(())
     /// ```
     pub fn into_inner(mut self) -> &'a mut MessageSink<W> {
         self.sink

--- a/crates/logging/src/sink/message_sink/mod.rs
+++ b/crates/logging/src/sink/message_sink/mod.rs
@@ -23,12 +23,13 @@ use core::{branding::Brand, message::MessageScratch};
 ///
 /// let mut sink = MessageSink::new(Vec::new());
 ///
-/// sink.write(Message::warning("vanished"))?;
-/// sink.write(Message::error(23, "partial"))?;
+/// sink.write(Message::warning("vanished")).expect("write warning");
+/// sink
+///     .write(Message::error(23, "partial"))
+///     .expect("write error");
 ///
 /// let output = String::from_utf8(sink.into_inner()).unwrap();
 /// assert!(output.ends_with('\n'));
-/// # Ok::<(), std::io::Error>(())
 /// ```
 ///
 /// Render a message without appending a newline:
@@ -38,10 +39,11 @@ use core::{branding::Brand, message::MessageScratch};
 /// use logging::{LineMode, MessageSink};
 ///
 /// let mut sink = MessageSink::with_line_mode(Vec::new(), LineMode::WithoutNewline);
-/// sink.write(Message::info("ready"))?;
+/// sink
+///     .write(Message::info("ready"))
+///     .expect("write info");
 ///
 /// assert_eq!(sink.into_inner(), b"rsync info: ready".to_vec());
-/// # Ok::<(), std::io::Error>(())
 /// ```
 ///
 /// Reuse an existing [`MessageScratch`] when constructing a new sink:
@@ -51,16 +53,19 @@ use core::{branding::Brand, message::MessageScratch};
 /// use logging::{LineMode, MessageSink};
 ///
 /// let mut sink = MessageSink::with_parts(Vec::new(), MessageScratch::new(), LineMode::WithoutNewline);
-/// sink.write(Message::info("phase one"))?;
+/// sink
+///     .write(Message::info("phase one"))
+///     .expect("write phase one");
 /// let (writer, scratch, mode, brand) = sink.into_parts();
 /// assert_eq!(brand, core::branding::Brand::Upstream);
 /// assert_eq!(mode, LineMode::WithoutNewline);
 ///
 /// let mut sink = MessageSink::with_parts(writer, scratch, LineMode::WithNewline);
-/// sink.write(Message::warning("phase two"))?;
+/// sink
+///     .write(Message::warning("phase two"))
+///     .expect("write phase two");
 /// let output = String::from_utf8(sink.into_inner()).unwrap();
 /// assert!(output.contains("phase two"));
-/// # Ok::<(), std::io::Error>(())
 /// ```
 #[doc(alias = "--msgs2stderr")]
 #[derive(Clone)]


### PR DESCRIPTION
## Summary
- switch doctest-sensitive modules to use `std::` imports rather than `::core`
- update message segment and logging doctest examples to avoid implicit `?` usage
- align version banner doctest assertions with the actual rendered banner format

## Testing
- RUST_TEST_THREADS=1 cargo test --all-features --workspace

------
[Codex Task](