### PR TITLE
Coalesce sparse zero runs across chunks

### DIFF
--- a/crates/engine/src/local_copy/context.rs
+++ b/crates/engine/src/local_copy/context.rs
@@ -25,7 +25,7 @@ use super::{
     LocalCopyArgumentError, LocalCopyError, LocalCopyErrorKind, LocalCopyExecution,
     LocalCopyMetadata, LocalCopyOptions, LocalCopyProgress, LocalCopyRecord,
     LocalCopyRecordHandler, LocalCopyReport, LocalCopySummary, ReferenceDirectory,
-    compute_backup_path, copy_entry_to_backup, delete_extraneous_entries,
+    SparseWriteState, compute_backup_path, copy_entry_to_backup, delete_extraneous_entries,
     filter_program_local_error, follow_symlink_metadata, load_dir_merge_rules_recursive,
     map_metadata_error, remove_source_entry_if_requested, resolve_dir_merge_path, should_skip_copy,
     write_sparse_chunk,

--- a/crates/engine/src/local_copy/executor/file/mod.rs
+++ b/crates/engine/src/local_copy/executor/file/mod.rs
@@ -21,4 +21,4 @@ pub(crate) use guard::{DestinationWriteGuard, remove_existing_destination};
 pub(crate) use paths::partial_destination_path;
 #[cfg(test)]
 pub(crate) use preallocate::maybe_preallocate_destination;
-pub(crate) use sparse::write_sparse_chunk;
+pub(crate) use sparse::{SparseWriteState, write_sparse_chunk};

--- a/crates/engine/src/local_copy/executor/mod.rs
+++ b/crates/engine/src/local_copy/executor/mod.rs
@@ -14,8 +14,9 @@ pub(crate) use directory::{copy_directory_recursive, is_device, is_fifo};
 #[allow(unused_imports)]
 pub(crate) use file::take_fsync_call_count;
 pub(crate) use file::{
-    CopyComparison, DestinationWriteGuard, compute_backup_path, copy_entry_to_backup, copy_file,
-    remove_existing_destination, should_skip_copy, write_sparse_chunk,
+    CopyComparison, DestinationWriteGuard, SparseWriteState, compute_backup_path,
+    copy_entry_to_backup, copy_file, remove_existing_destination, should_skip_copy,
+    write_sparse_chunk,
 };
 #[cfg(test)]
 pub(crate) use file::{


### PR DESCRIPTION
## Summary
- introduce a `SparseWriteState` helper that tracks pending zero spans so sparse writes coalesce contiguous holes instead of seeking per buffer
- update both the regular and delta transfer paths to use the new sparse state and flush pending zeros before final truncation
- extend the sparse writer unit tests to cover multi-chunk zero runs and trailing zero holes

## Testing
- cargo check

------
[Codex Task](