### PR TITLE
Add support for --no-from0 alias

### DIFF
--- a/crates/cli/src/frontend/arguments/parser.rs
+++ b/crates/cli/src/frontend/arguments/parser.rs
@@ -393,6 +393,8 @@ where
         .map(|values| values.collect())
         .unwrap_or_default();
     let from0 = matches.get_flag("from0");
+    let disable_from0 = matches.get_flag("no-from0");
+    let from0 = from0 && !disable_from0;
     let info = matches
         .remove_many::<OsString>("info")
         .map(|values| values.collect())

--- a/crates/cli/src/frontend/command_builder/sections/transfer_behavior_options.rs
+++ b/crates/cli/src/frontend/command_builder/sections/transfer_behavior_options.rs
@@ -364,7 +364,15 @@ pub(crate) fn add_transfer_behavior_options(command: ClapCommand) -> ClapCommand
                 Arg::new("from0")
                     .long("from0")
                     .help("Treat file list entries as NUL-terminated records.")
-                    .action(ArgAction::SetTrue),
+                    .action(ArgAction::SetTrue)
+                    .overrides_with("no-from0"),
+            )
+            .arg(
+                Arg::new("no-from0")
+                    .long("no-from0")
+                    .help("Disable NUL-terminated file list handling.")
+                    .action(ArgAction::SetTrue)
+                    .overrides_with("from0"),
             )
             .arg(
                 Arg::new("owner")

--- a/crates/cli/src/frontend/defaults.rs
+++ b/crates/cli/src/frontend/defaults.rs
@@ -13,7 +13,7 @@ pub(super) const SUPPORTED_OPTIONS_LIST: &str = concat!(
     "--ignore-missing-args, --delete-missing-args, --update/-u, --modify-window, --exclude, --exclude-from, ",
     "--include, --include-from, --compare-dest, --copy-dest, --link-dest, --hard-links/-H, --no-hard-links, ",
     "--cvs-exclude/-C, --filter/-F (including exclude-if-present=FILE), --files-from, --password-file, --no-motd, ",
-    "--from0, --bwlimit, --no-bwlimit, --timeout, --contimeout, --stop-after/--time-limit, --stop-at, --sockopts, ",
+    "--from0, --no-from0, --bwlimit, --no-bwlimit, --timeout, --contimeout, --stop-after/--time-limit, --stop-at, --sockopts, ",
     "--blocking-io, --no-blocking-io, --protocol, --compress/-z, --no-compress, --compress-level, --compress-choice, ",
     "--skip-compress, --open-noatime, --no-open-noatime, --iconv, --no-iconv, --info, --debug, --verbose/-v, ",
     "--relative/-R, --no-relative, --one-file-system/-x, --no-one-file-system, --implied-dirs, --no-implied-dirs, ",

--- a/crates/cli/src/frontend/help.rs
+++ b/crates/cli/src/frontend/help.rs
@@ -80,6 +80,7 @@ pub(super) fn help_text(program_name: ProgramName) -> String {
             "      --password-file=FILE  Read daemon passwords from FILE when contacting rsync:// daemons.\n",
             "      --no-motd    Suppress daemon MOTD lines when listing rsync:// modules.\n",
             "      --from0      Treat file list entries as NUL-terminated records.\n",
+            "      --no-from0  Disable NUL-terminated file list handling.\n",
             "      --bwlimit=RATE[:BURST]  Limit I/O bandwidth (supports decimal, binary,\n",
             "                              and IEC units; optional :BURST caps the token\n",
             "                              bucket; 0 disables the limit).\n",

--- a/crates/cli/src/frontend/tests/parse_args_sets.rs
+++ b/crates/cli/src/frontend/tests/parse_args_sets.rs
@@ -73,6 +73,20 @@ fn parse_args_sets_from0_flag() {
 }
 
 #[test]
+fn parse_args_resets_from0_with_no_from0_flag() {
+    let parsed = parse_args([
+        OsString::from(RSYNC),
+        OsString::from("--from0"),
+        OsString::from("--no-from0"),
+        OsString::from("source"),
+        OsString::from("dest"),
+    ])
+    .expect("parse");
+
+    assert!(!parsed.from0);
+}
+
+#[test]
 fn parse_args_sets_compress_flag() {
     let parsed = parse_args([
         OsString::from(RSYNC),

--- a/crates/cli/src/frontend/tests/remote_fallback_preserves.rs
+++ b/crates/cli/src/frontend/tests/remote_fallback_preserves.rs
@@ -59,3 +59,47 @@ exit 0
     let copied = std::fs::read(&files_copy_path).expect("read copied file list");
     assert_eq!(copied, b"first\0second\0");
 }
+
+#[cfg(unix)]
+#[test]
+fn remote_fallback_resets_from0_with_no_from0_flag() {
+    use tempfile::tempdir;
+
+    let _env_lock = ENV_LOCK.lock().expect("env lock");
+    let _rsh_guard = clear_rsync_rsh();
+    let temp = tempdir().expect("tempdir");
+    let list_path = temp.path().join("file-list.txt");
+    std::fs::write(&list_path, b"first\nsecond\n").expect("write list");
+
+    let script_path = temp.path().join("fallback.sh");
+    let args_path = temp.path().join("args.txt");
+
+    let script = r#"#!/bin/sh
+printf "%s\n" "$@" > "$ARGS_FILE"
+exit 0
+"#;
+    write_executable_script(&script_path, script);
+
+    let _fallback_guard = EnvGuard::set(CLIENT_FALLBACK_ENV, script_path.as_os_str());
+    let _args_guard = EnvGuard::set("ARGS_FILE", args_path.as_os_str());
+
+    let dest_path = temp.path().join("dest");
+
+    let (code, stdout, stderr) = run_with_args([
+        OsString::from(RSYNC),
+        OsString::from("--from0"),
+        OsString::from("--no-from0"),
+        OsString::from(format!("--files-from={}", list_path.display())),
+        OsString::from("remote::module"),
+        dest_path.clone().into_os_string(),
+    ]);
+
+    assert_eq!(code, 0);
+    assert!(stdout.is_empty());
+    assert!(stderr.is_empty());
+
+    let recorded = std::fs::read_to_string(&args_path).expect("read args file");
+    assert!(recorded.contains("--files-from"));
+    assert!(!recorded.contains("--from0"));
+    assert!(recorded.contains(&dest_path.display().to_string()));
+}

--- a/docs/parity-options.md
+++ b/docs/parity-options.md
@@ -22,8 +22,8 @@ workspace.
 
 | status | count |
 |---|---:|
-| implemented | 155 |
-| missing | 96 |
+| implemented | 156 |
+| missing | 95 |
 
 `missing` entries denote upstream flags that are absent from the current
 `oc-rsync` help surface. Many of these are `--no-*` aliases that suppress a
@@ -37,7 +37,7 @@ must be closed before we can claim full compatibility.
 | connection | 12 | 3 |
 | daemon | 3 | 2 |
 | deletion | 13 | 0 |
-| filters | 8 | 1 |
+| filters | 9 | 0 |
 | general | 48 | 74 |
 | logging | 7 | 3 |
 | metadata | 23 | 4 |
@@ -55,8 +55,7 @@ options such as `--config`, etc.).
   --address, --no-contimeout, --no-timeout
 - **daemon** (2):
   --config, --motd
-- **filters** (1):
-  --no-from0
+- **filters** (0): (none)
 - **general** (74):
   --8-bit-output, --cc, --copy-as, --detach, --dparam, --early-input, --executability,
   --fake-super, --force, --fuzzy, --i-d, --i-r, --ignore-errors, --ignore-non-existing,

--- a/docs/parity-options.yml
+++ b/docs/parity-options.yml
@@ -1182,11 +1182,11 @@ options:
     status: implemented
     notes: ""
   - option: --no-from0
-    short: 
+    short:
     category: filters
     upstream_default: disabled by default
-    status: missing
-    notes: Negates the corresponding positive option.
+    status: implemented
+    notes: ""
   - option: --old-args
     short: 
     category: general


### PR DESCRIPTION
## Summary
- add CLI support for the upstream --no-from0 alias and expose it in help/default listings
- ensure parser, fallback forwarding, and tests honour the alias semantics
- update the parity option inventory to mark the alias as implemented

## Testing
- cargo test --all-features --workspace

------
[Codex Task](