### PR TITLE
Align sparse writer with upstream semantics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -460,7 +460,6 @@ dependencies = [
  "filters",
  "globset",
  "libc",
- "memchr",
  "metadata",
  "protocol",
  "rustix 0.38.44",

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -23,7 +23,6 @@ bandwidth = { path = "../bandwidth" }
 globset = "0.4"
 rustix = { version = "0.38", features = ["fs", "process"] }
 libc = { version = "0.2", optional = true }
-memchr = "2.7"
 
 [target.'cfg(not(windows))'.dependencies]
 checksums = { path = "../checksums" }


### PR DESCRIPTION
## Summary
- mirror upstream sparse handling by limiting hole creation to leading/trailing zero runs while keeping the single-seek invariant
- add scalar/optimized helpers for trailing zero detection together with targeted tests
- drop the unused `memchr` dependency from the engine crate and update the lockfile

## Testing
- attempted `cargo test -p engine sparse_writer_accumulates_zero_runs_across_chunks` (build pending in container)

------
[Codex Task](