### PR TITLE
Disable sparse writes when preallocating destinations

### DIFF
--- a/crates/engine/src/local_copy/executor/file/copy/mod.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/mod.rs
@@ -124,7 +124,11 @@ pub(crate) fn copy_file(
         return Ok(());
     }
 
-    let use_sparse_writes = context.sparse_enabled();
+    // Upstream rsync disables sparse writes whenever `--preallocate` is active
+    // because the preallocation request must materialise every range in the
+    // destination file.  Keep the same behaviour by refusing to punch holes
+    // when preallocation is enabled.
+    let use_sparse_writes = context.sparse_enabled() && !context.preallocate_enabled();
     let partial_enabled = context.partial_enabled();
     let inplace_enabled = context.inplace_enabled();
     let checksum_enabled = context.checksum_enabled();


### PR DESCRIPTION
## Summary
- disable sparse-hole punching when --preallocate is active so the destination remains dense
- align sparse/preallocate behaviour with upstream by deriving the sparse flag from both options

## Testing
- cargo test -p cli --all-features transfer_request_with_sparse_and_preallocate_allocates_dense

------
[Codex Task](