### PR TITLE
Add support for --no-msgs2stderr toggle

### DIFF
--- a/crates/cli/src/frontend/arguments/parsed_args.rs
+++ b/crates/cli/src/frontend/arguments/parsed_args.rs
@@ -110,7 +110,7 @@ pub(crate) struct ParsedArgs {
     pub(crate) inplace: Option<bool>,
     pub(crate) append: Option<bool>,
     pub(crate) append_verify: bool,
-    pub(crate) msgs_to_stderr: bool,
+    pub(crate) msgs_to_stderr: Option<bool>,
     pub(crate) outbuf: Option<OsString>,
     pub(crate) itemize_changes: bool,
     pub(crate) whole_file: Option<bool>,

--- a/crates/cli/src/frontend/arguments/parser.rs
+++ b/crates/cli/src/frontend/arguments/parser.rs
@@ -239,7 +239,7 @@ where
     let one_file_system =
         tri_state_flag_positive_first(&matches, "one-file-system", "no-one-file-system");
     let implied_dirs = tri_state_flag_positive_first(&matches, "implied-dirs", "no-implied-dirs");
-    let msgs_to_stderr = matches.get_flag("msgs2stderr");
+    let msgs_to_stderr = tri_state_flag_positive_first(&matches, "msgs2stderr", "no-msgs2stderr");
     let outbuf = matches.remove_one::<OsString>("outbuf");
     let stats = matches.get_flag("stats");
     let partial_flag = matches.get_flag("partial") || matches.get_count("partial-progress") > 0;

--- a/crates/cli/src/frontend/command_builder/sections/build_base_command.rs
+++ b/crates/cli/src/frontend/command_builder/sections/build_base_command.rs
@@ -37,7 +37,15 @@ pub(crate) fn build_base_command(program_name: &'static str) -> ClapCommand {
                 Arg::new("msgs2stderr")
                     .long("msgs2stderr")
                     .help("Route informational messages to standard error.")
-                    .action(ArgAction::SetTrue),
+                    .action(ArgAction::SetTrue)
+                    .overrides_with("no-msgs2stderr"),
+            )
+            .arg(
+                Arg::new("no-msgs2stderr")
+                    .long("no-msgs2stderr")
+                    .help("Route informational messages to standard output.")
+                    .action(ArgAction::SetTrue)
+                    .overrides_with("msgs2stderr"),
             )
             .arg(
                 Arg::new("outbuf")

--- a/crates/cli/src/frontend/defaults.rs
+++ b/crates/cli/src/frontend/defaults.rs
@@ -17,7 +17,7 @@ pub(super) const SUPPORTED_OPTIONS_LIST: &str = concat!(
     "--blocking-io, --no-blocking-io, --protocol, --compress/-z, --no-compress, --compress-level, --compress-choice, ",
     "--skip-compress, --open-noatime, --no-open-noatime, --iconv, --no-iconv, --info, --debug, --verbose/-v, ",
     "--relative/-R, --no-relative, --one-file-system/-x, --no-one-file-system, --implied-dirs, --no-implied-dirs, ",
-    "--mkpath, --prune-empty-dirs/-m, --no-prune-empty-dirs, --progress, --no-progress, --msgs2stderr, --outbuf, ",
+    "--mkpath, --prune-empty-dirs/-m, --no-prune-empty-dirs, --progress, --no-progress, --msgs2stderr, --no-msgs2stderr, --outbuf, ",
     "--itemize-changes/-i, --out-format, --stats, --partial, --no-partial, --partial-dir, --temp-dir, --log-file, ",
     "--log-file-format, --delay-updates, --no-delay-updates, --whole-file/-W, --no-whole-file, --remove-source-files, ",
     "--remove-sent-files, --append, --no-append, --append-verify, --preallocate, --fsync, --inplace, --no-inplace, ",

--- a/crates/cli/src/frontend/execution/drive/fallback.rs
+++ b/crates/cli/src/frontend/execution/drive/fallback.rs
@@ -109,7 +109,7 @@ pub(crate) struct FallbackInputs {
     pub(crate) append: Option<bool>,
     pub(crate) append_verify: bool,
     pub(crate) inplace: Option<bool>,
-    pub(crate) msgs_to_stderr: bool,
+    pub(crate) msgs_to_stderr: Option<bool>,
     pub(crate) outbuf: Option<OsString>,
     pub(crate) whole_file_option: Option<bool>,
     pub(crate) fallback_bwlimit: Option<OsString>,

--- a/crates/cli/src/frontend/execution/drive/workflow/fallback_plan.rs
+++ b/crates/cli/src/frontend/execution/drive/workflow/fallback_plan.rs
@@ -104,7 +104,7 @@ pub(crate) struct FallbackArgumentsContext<'a> {
     pub(crate) append: Option<bool>,
     pub(crate) append_verify: bool,
     pub(crate) inplace: Option<bool>,
-    pub(crate) msgs_to_stderr: bool,
+    pub(crate) msgs_to_stderr: Option<bool>,
     pub(crate) outbuf: Option<&'a OsString>,
     pub(crate) whole_file_option: Option<bool>,
     pub(crate) fallback_bwlimit: Option<&'a OsString>,

--- a/crates/cli/src/frontend/execution/drive/workflow/run.rs
+++ b/crates/cli/src/frontend/execution/drive/workflow/run.rs
@@ -155,7 +155,7 @@ where
         inplace,
         append,
         append_verify,
-        msgs_to_stderr,
+        msgs_to_stderr: msgs_to_stderr_option,
         outbuf,
         itemize_changes,
         whole_file,
@@ -175,6 +175,7 @@ where
     let human_readable_setting = human_readable;
     let human_readable_mode = human_readable_setting.unwrap_or(HumanReadableMode::Disabled);
     let human_readable_enabled = human_readable_mode.is_enabled();
+    let msgs_to_stderr_enabled = msgs_to_stderr_option.unwrap_or(false);
 
     if let Err(code) = validate_stdin_sources_conflict(&password_file, &files_from, stderr) {
         return code;
@@ -455,7 +456,7 @@ where
         append,
         append_verify,
         inplace,
-        msgs_to_stderr,
+        msgs_to_stderr: msgs_to_stderr_option,
         outbuf: outbuf.as_ref(),
         whole_file_option,
         fallback_bwlimit: fallback_bwlimit.as_ref(),
@@ -724,7 +725,7 @@ where
         summary::TransferExecutionInputs {
             config,
             fallback_args,
-            msgs_to_stderr,
+            msgs_to_stderr: msgs_to_stderr_enabled,
             progress_mode,
             human_readable_mode,
             itemize_changes,

--- a/crates/cli/src/frontend/help.rs
+++ b/crates/cli/src/frontend/help.rs
@@ -114,6 +114,7 @@ pub(super) fn help_text(program_name: ProgramName) -> String {
             "      --progress   Show progress information during transfers.\n",
             "      --no-progress  Disable progress reporting.\n",
             "      --msgs2stderr  Route informational messages to standard error.\n",
+            "      --no-msgs2stderr  Route informational messages to standard output.\n",
             "      --outbuf=N|L|B  Set stdout buffering to None, Line, or Block.\n",
             "  -i, --itemize-changes  Output a change summary for each updated entry.\n",
             "      --out-format=FORMAT  Customise transfer output using FORMAT.\n",

--- a/crates/cli/src/frontend/tests/parse_args_recognises_msgs2stderr.rs
+++ b/crates/cli/src/frontend/tests/parse_args_recognises_msgs2stderr.rs
@@ -11,5 +11,18 @@ fn parse_args_recognises_msgs2stderr_flag() {
     ])
     .expect("parse");
 
-    assert!(parsed.msgs_to_stderr);
+    assert_eq!(parsed.msgs_to_stderr, Some(true));
+}
+
+#[test]
+fn parse_args_recognises_no_msgs2stderr_flag() {
+    let parsed = parse_args([
+        OsString::from(RSYNC),
+        OsString::from("--no-msgs2stderr"),
+        OsString::from("source"),
+        OsString::from("dest"),
+    ])
+    .expect("parse");
+
+    assert_eq!(parsed.msgs_to_stderr, Some(false));
 }

--- a/crates/core/src/client/fallback/args.rs
+++ b/crates/core/src/client/fallback/args.rs
@@ -193,8 +193,8 @@ pub struct RemoteFallbackArgs {
     pub append_verify: bool,
     /// Optional `--inplace`/`--no-inplace` toggle.
     pub inplace: Option<bool>,
-    /// Routes daemon messages to standard error via `--msgs2stderr`.
-    pub msgs_to_stderr: bool,
+    /// Routes daemon messages via `--msgs2stderr` / `--no-msgs2stderr` when specified.
+    pub msgs_to_stderr: Option<bool>,
     /// Optional `--outbuf` value forwarded to the fallback binary.
     pub outbuf: Option<OsString>,
     /// Optional `--whole-file`/`--no-whole-file` toggle.

--- a/crates/core/src/client/fallback/runner/command_builder.rs
+++ b/crates/core/src/client/fallback/runner/command_builder.rs
@@ -487,9 +487,12 @@ pub(crate) fn prepare_invocation(
     } else {
         push_toggle(&mut command_args, "--append", "--no-append", append);
     }
-    if msgs_to_stderr {
-        command_args.push(OsString::from("--msgs2stderr"));
-    }
+    push_toggle(
+        &mut command_args,
+        "--msgs2stderr",
+        "--no-msgs2stderr",
+        msgs_to_stderr,
+    );
     if let Some(mode) = outbuf {
         let mut arg = OsString::from("--outbuf=");
         arg.push(mode);

--- a/crates/core/src/client/tests/client_event.rs
+++ b/crates/core/src/client/tests/client_event.rs
@@ -339,7 +339,7 @@ fn baseline_fallback_args() -> RemoteFallbackArgs {
         append: None,
         append_verify: false,
         inplace: None,
-        msgs_to_stderr: false,
+        msgs_to_stderr: None,
         outbuf: None,
         whole_file: None,
         bwlimit: None,

--- a/docs/parity-options.md
+++ b/docs/parity-options.md
@@ -67,8 +67,8 @@ options such as `--config`, etc.).
   --no-x, --no-y, --no-z, --old-args, --old-d, --only-write-batch, --qsort, --quiet,
   --read-batch, --sender, --server, --stderr, --stop-after, --stop-at, --time-limit,
   --trust-sender, --write-batch, --write-devices, --zc, --zl
-- **logging** (3):
-  --no-itemize-changes, --no-msgs2stderr, --no-verbose
+- **logging** (2):
+  --no-itemize-changes, --no-verbose
 - **metadata** (4):
   --atimes, --crtimes, --no-atimes, --no-crtimes
 - **transfer** (5):

--- a/docs/parity-options.yml
+++ b/docs/parity-options.yml
@@ -54,10 +54,10 @@ options:
     status: implemented
     notes: ""
   - option: --no-msgs2stderr
-    short: 
+    short:
     category: logging
     upstream_default: enabled by default (2)
-    status: missing
+    status: implemented
     notes: Negates the corresponding positive option.
   - option: --quiet
     short: q


### PR DESCRIPTION
## Summary
- add the `--no-msgs2stderr` flag to the CLI command builder, help text, and defaults
- parse the new negated flag via a tri-state toggle and carry it through workflow, fallback planning, and remote fallback arguments
- update docs and tests so `--no-msgs2stderr` is covered and documented as implemented

## Testing
- cargo test -p cli parse_args_recognises_msgs2stderr

------
[Codex Task](