### PR TITLE
Add CLI aliases for motd/stderr and no-* compatibility flags

### DIFF
--- a/crates/cli/src/frontend/arguments/parser.rs
+++ b/crates/cli/src/frontend/arguments/parser.rs
@@ -420,7 +420,10 @@ where
     let stop_at_option = matches.remove_one::<OsString>("stop-at");
     let out_format = matches.remove_one::<OsString>("out-format");
     let itemize_changes = itemize_changes_flag && !no_itemize_changes_flag;
-    let no_motd = matches.get_flag("no-motd");
+    let mut no_motd = matches.get_flag("no-motd");
+    if matches.get_flag("motd") {
+        no_motd = false;
+    }
 
     Ok(ParsedArgs {
         program_name,

--- a/crates/cli/src/frontend/command_builder/sections/build_base_command.rs
+++ b/crates/cli/src/frontend/command_builder/sections/build_base_command.rs
@@ -29,6 +29,7 @@ pub(crate) fn build_base_command(program_name: &'static str) -> ClapCommand {
             .arg(
                 Arg::new("no-human-readable")
                     .long("no-human-readable")
+                    .visible_alias("no-h")
                     .help("Disable human-readable number formatting.")
                     .action(ArgAction::SetTrue)
                     .overrides_with("human-readable"),
@@ -36,6 +37,7 @@ pub(crate) fn build_base_command(program_name: &'static str) -> ClapCommand {
             .arg(
                 Arg::new("msgs2stderr")
                     .long("msgs2stderr")
+                    .visible_alias("stderr")
                     .help("Route informational messages to standard error.")
                     .action(ArgAction::SetTrue)
                     .overrides_with("no-msgs2stderr"),
@@ -43,6 +45,7 @@ pub(crate) fn build_base_command(program_name: &'static str) -> ClapCommand {
             .arg(
                 Arg::new("no-msgs2stderr")
                     .long("no-msgs2stderr")
+                    .visible_alias("no-stderr")
                     .help("Route informational messages to standard output.")
                     .action(ArgAction::SetTrue)
                     .overrides_with("msgs2stderr"),
@@ -226,6 +229,7 @@ pub(crate) fn build_base_command(program_name: &'static str) -> ClapCommand {
             .arg(
                 Arg::new("no-recursive")
                     .long("no-recursive")
+                    .visible_alias("no-r")
                     .help("Do not recurse into directories when processing source operands.")
                     .action(ArgAction::SetTrue)
                     .overrides_with("recursive"),
@@ -483,6 +487,7 @@ pub(crate) fn build_base_command(program_name: &'static str) -> ClapCommand {
             .arg(
                 Arg::new("no-verbose")
                     .long("no-verbose")
+                    .visible_alias("no-v")
                     .help("Disable verbosity (equivalent to --quiet).")
                     .action(ArgAction::SetTrue)
                     .overrides_with("verbose"),

--- a/crates/cli/src/frontend/command_builder/sections/transfer_behavior_options.rs
+++ b/crates/cli/src/frontend/command_builder/sections/transfer_behavior_options.rs
@@ -355,10 +355,18 @@ pub(crate) fn add_transfer_behavior_options(command: ClapCommand) -> ClapCommand
                     .action(ArgAction::Set),
             )
             .arg(
+                Arg::new("motd")
+                    .long("motd")
+                    .help("Display daemon MOTD lines when listing rsync:// modules.")
+                    .action(ArgAction::SetTrue)
+                    .overrides_with("no-motd"),
+            )
+            .arg(
                 Arg::new("no-motd")
                     .long("no-motd")
                     .help("Suppress daemon MOTD lines when listing rsync:// modules.")
-                    .action(ArgAction::SetTrue),
+                    .action(ArgAction::SetTrue)
+                    .overrides_with("motd"),
             )
             .arg(
                 Arg::new("from0")

--- a/crates/cli/src/frontend/tests/parse_args_recognises_no.rs
+++ b/crates/cli/src/frontend/tests/parse_args_recognises_no.rs
@@ -93,3 +93,70 @@ fn parse_args_recognises_no_motd_flag() {
 
     assert!(parsed.no_motd);
 }
+
+#[test]
+fn parse_args_motd_flag_reenables_motd() {
+    let parsed = parse_args([
+        OsString::from(RSYNC),
+        OsString::from("--no-motd"),
+        OsString::from("--motd"),
+        OsString::from("rsync://example/"),
+    ])
+    .expect("parse");
+
+    assert!(!parsed.no_motd);
+}
+
+#[test]
+fn parse_args_no_v_alias_disables_verbosity() {
+    let parsed = parse_args([
+        OsString::from(RSYNC),
+        OsString::from("-vv"),
+        OsString::from("--no-v"),
+        OsString::from("source"),
+        OsString::from("dest"),
+    ])
+    .expect("parse");
+
+    assert_eq!(parsed.verbosity, 0);
+}
+
+#[test]
+fn parse_args_no_h_alias_disables_human_readable() {
+    let parsed = parse_args([
+        OsString::from(RSYNC),
+        OsString::from("--no-h"),
+        OsString::from("source"),
+        OsString::from("dest"),
+    ])
+    .expect("parse");
+
+    assert_eq!(parsed.human_readable, Some(HumanReadableMode::Disabled));
+}
+
+#[test]
+fn parse_args_no_r_alias_disables_recursion() {
+    let parsed = parse_args([
+        OsString::from(RSYNC),
+        OsString::from("--no-r"),
+        OsString::from("source"),
+        OsString::from("dest"),
+    ])
+    .expect("parse");
+
+    assert!(!parsed.recursive);
+    assert_eq!(parsed.recursive_override, Some(false));
+}
+
+#[test]
+fn parse_args_stderr_alias_routes_messages_to_stderr() {
+    let parsed = parse_args([
+        OsString::from(RSYNC),
+        OsString::from("--stderr"),
+        OsString::from("source"),
+        OsString::from("dest"),
+    ])
+    .expect("parse");
+
+    assert_eq!(parsed.msgs_to_stderr, Some(true));
+}

--- a/docs/parity-options.yml
+++ b/docs/parity-options.yml
@@ -18,16 +18,16 @@ options:
     status: implemented
     notes: ""
   - option: --no-verbose
-    short: 
+    short:
     category: logging
     upstream_default: n/a
-    status: missing
+    status: implemented
     notes: Negates the corresponding positive option.
   - option: --no-v
-    short: 
+    short:
     category: general
     upstream_default: n/a
-    status: missing
+    status: implemented
     notes: Negates the corresponding positive option.
   - option: --info
     short: 
@@ -42,10 +42,10 @@ options:
     status: implemented
     notes: ""
   - option: --stderr
-    short: 
+    short:
     category: general
     upstream_default: n/a
-    status: missing
+    status: implemented
     notes: ""
   - option: --msgs2stderr
     short: 
@@ -63,13 +63,13 @@ options:
     short: q
     category: general
     upstream_default: n/a
-    status: missing
+    status: implemented
     notes: ""
   - option: --motd
-    short: 
+    short:
     category: daemon
     upstream_default: default 1
-    status: missing
+    status: implemented
     notes: ""
   - option: --no-motd
     short: 
@@ -96,10 +96,10 @@ options:
     status: implemented
     notes: Negates the corresponding positive option.
   - option: --no-h
-    short: 
+    short:
     category: general
     upstream_default: enabled by default (1)
-    status: missing
+    status: implemented
     notes: Negates the corresponding positive option.
   - option: --dry-run
     short: n
@@ -126,10 +126,10 @@ options:
     status: implemented
     notes: Negates the corresponding positive option.
   - option: --no-r
-    short: 
+    short:
     category: general
     upstream_default: disabled by default
-    status: missing
+    status: implemented
     notes: Negates the corresponding positive option.; Alias maintained for compatibility.
   - option: --inc-recursive
     short: 


### PR DESCRIPTION
## Summary
- expose the legacy --motd toggle and --stderr alias through the clap command builder
- add visible aliases for the --no-h/--no-r/--no-v compatibility forms and wire the parser to clear --no-motd when --motd is present
- cover the new flags with frontend parser tests and mark the documented parity options as implemented

## Testing
- cargo test -p cli parse_args_recognises_no

------
[Codex Task](