### PR TITLE
Support legacy negative option aliases

### DIFF
--- a/crates/cli/src/frontend/command_builder/sections/build_base_command.rs
+++ b/crates/cli/src/frontend/command_builder/sections/build_base_command.rs
@@ -259,6 +259,7 @@ pub(crate) fn build_base_command(program_name: &'static str) -> ClapCommand {
             .arg(
                 Arg::new("no-dirs")
                     .long("no-dirs")
+                    .visible_alias("no-d")
                     .help("Skip directory entries when recursion is disabled.")
                     .action(ArgAction::SetTrue)
                     .overrides_with("dirs"),
@@ -416,6 +417,7 @@ pub(crate) fn build_base_command(program_name: &'static str) -> ClapCommand {
             .arg(
                 Arg::new("no-hard-links")
                     .long("no-hard-links")
+                    .visible_alias("no-H")
                     .help("Disable hard link preservation.")
                     .action(ArgAction::SetTrue)
                     .conflicts_with("hard-links"),
@@ -525,6 +527,7 @@ pub(crate) fn build_base_command(program_name: &'static str) -> ClapCommand {
             .arg(
                 Arg::new("no-relative")
                     .long("no-relative")
+                    .visible_alias("no-R")
                     .help("Disable preservation of source path components.")
                     .action(ArgAction::SetTrue)
                     .overrides_with("relative"),
@@ -547,6 +550,7 @@ pub(crate) fn build_base_command(program_name: &'static str) -> ClapCommand {
             .arg(
                 Arg::new("implied-dirs")
                     .long("implied-dirs")
+                    .visible_alias("i-d")
                     .help("Create parent directories implied by source paths.")
                     .action(ArgAction::SetTrue)
                     .overrides_with("no-implied-dirs"),
@@ -554,6 +558,7 @@ pub(crate) fn build_base_command(program_name: &'static str) -> ClapCommand {
             .arg(
                 Arg::new("no-implied-dirs")
                     .long("no-implied-dirs")
+                    .visible_alias("no-i-d")
                     .help("Disable creation of parent directories implied by source paths.")
                     .action(ArgAction::SetTrue)
                     .overrides_with("implied-dirs"),

--- a/crates/cli/src/frontend/command_builder/sections/transfer_behavior_options.rs
+++ b/crates/cli/src/frontend/command_builder/sections/transfer_behavior_options.rs
@@ -393,6 +393,7 @@ pub(crate) fn add_transfer_behavior_options(command: ClapCommand) -> ClapCommand
             .arg(
                 Arg::new("no-owner")
                     .long("no-owner")
+                    .visible_alias("no-o")
                     .help("Disable ownership preservation.")
                     .action(ArgAction::SetTrue)
                     .overrides_with("owner"),
@@ -408,6 +409,7 @@ pub(crate) fn add_transfer_behavior_options(command: ClapCommand) -> ClapCommand
             .arg(
                 Arg::new("no-group")
                     .long("no-group")
+                    .visible_alias("no-g")
                     .help("Disable group preservation.")
                     .action(ArgAction::SetTrue)
                     .overrides_with("group"),
@@ -455,6 +457,7 @@ pub(crate) fn add_transfer_behavior_options(command: ClapCommand) -> ClapCommand
             .arg(
                 Arg::new("no-perms")
                     .long("no-perms")
+                    .visible_alias("no-p")
                     .help("Disable permission preservation.")
                     .action(ArgAction::SetTrue)
                     .overrides_with("perms"),
@@ -470,6 +473,7 @@ pub(crate) fn add_transfer_behavior_options(command: ClapCommand) -> ClapCommand
             .arg(
                 Arg::new("no-times")
                     .long("no-times")
+                    .visible_alias("no-t")
                     .help("Disable modification time preservation.")
                     .action(ArgAction::SetTrue)
                     .overrides_with("times"),
@@ -485,6 +489,7 @@ pub(crate) fn add_transfer_behavior_options(command: ClapCommand) -> ClapCommand
             .arg(
                 Arg::new("no-omit-dir-times")
                     .long("no-omit-dir-times")
+                    .visible_alias("no-O")
                     .help("Preserve directory modification times.")
                     .action(ArgAction::SetTrue)
                     .overrides_with("omit-dir-times"),
@@ -499,6 +504,7 @@ pub(crate) fn add_transfer_behavior_options(command: ClapCommand) -> ClapCommand
             .arg(
                 Arg::new("no-omit-link-times")
                     .long("no-omit-link-times")
+                    .visible_alias("no-J")
                     .help("Preserve symlink modification times.")
                     .action(ArgAction::SetTrue)
                     .overrides_with("omit-link-times"),
@@ -514,6 +520,7 @@ pub(crate) fn add_transfer_behavior_options(command: ClapCommand) -> ClapCommand
             .arg(
                 Arg::new("no-acls")
                     .long("no-acls")
+                    .visible_alias("no-A")
                     .help("Disable POSIX ACL preservation.")
                     .action(ArgAction::SetTrue)
                     .overrides_with("acls"),
@@ -529,6 +536,7 @@ pub(crate) fn add_transfer_behavior_options(command: ClapCommand) -> ClapCommand
             .arg(
                 Arg::new("no-xattrs")
                     .long("no-xattrs")
+                    .visible_alias("no-X")
                     .help("Disable extended attribute preservation.")
                     .action(ArgAction::SetTrue)
                     .overrides_with("xattrs"),

--- a/crates/cli/src/frontend/tests/parse_args_recognises_no.rs
+++ b/crates/cli/src/frontend/tests/parse_args_recognises_no.rs
@@ -160,3 +160,51 @@ fn parse_args_stderr_alias_routes_messages_to_stderr() {
 
     assert_eq!(parsed.msgs_to_stderr, Some(true));
 }
+
+#[test]
+fn parse_args_negative_aliases_disable_flags() {
+    let parsed = parse_args([
+        OsString::from(RSYNC),
+        OsString::from("--no-d"),
+        OsString::from("--no-p"),
+        OsString::from("--no-A"),
+        OsString::from("--no-X"),
+        OsString::from("--no-t"),
+        OsString::from("--no-O"),
+        OsString::from("--no-J"),
+        OsString::from("--no-o"),
+        OsString::from("--no-g"),
+        OsString::from("--no-H"),
+        OsString::from("--no-R"),
+        OsString::from("--no-i-d"),
+        OsString::from("source"),
+        OsString::from("dest"),
+    ])
+    .expect("parse negative aliases");
+
+    assert_eq!(parsed.dirs, Some(false));
+    assert_eq!(parsed.perms, Some(false));
+    assert_eq!(parsed.acls, Some(false));
+    assert_eq!(parsed.xattrs, Some(false));
+    assert_eq!(parsed.times, Some(false));
+    assert_eq!(parsed.omit_dir_times, Some(false));
+    assert_eq!(parsed.omit_link_times, Some(false));
+    assert_eq!(parsed.owner, Some(false));
+    assert_eq!(parsed.group, Some(false));
+    assert_eq!(parsed.hard_links, Some(false));
+    assert_eq!(parsed.relative, Some(false));
+    assert_eq!(parsed.implied_dirs, Some(false));
+}
+
+#[test]
+fn parse_args_positive_implied_dirs_alias_enables_flag() {
+    let parsed = parse_args([
+        OsString::from(RSYNC),
+        OsString::from("--i-d"),
+        OsString::from("source"),
+        OsString::from("dest"),
+    ])
+    .expect("parse positive alias");
+
+    assert_eq!(parsed.implied_dirs, Some(true));
+}

--- a/docs/parity-options.yml
+++ b/docs/parity-options.yml
@@ -168,10 +168,10 @@ options:
     status: implemented
     notes: Negates the corresponding positive option.
   - option: --no-d
-    short: 
+    short:
     category: general
     upstream_default: enabled by default (-1)
-    status: missing
+    status: implemented
     notes: Negates the corresponding positive option.; Alias maintained for compatibility.
   - option: --old-dirs
     short: 
@@ -198,10 +198,10 @@ options:
     status: implemented
     notes: Negates the corresponding positive option.
   - option: --no-p
-    short: 
+    short:
     category: general
     upstream_default: disabled by default
-    status: missing
+    status: implemented
     notes: Negates the corresponding positive option.; Alias maintained for compatibility.
   - option: --executability
     short: E
@@ -222,10 +222,10 @@ options:
     status: implemented
     notes: Negates the corresponding positive option.
   - option: --no-A
-    short: 
+    short:
     category: general
     upstream_default: disabled by default
-    status: missing
+    status: implemented
     notes: Negates the corresponding positive option.
   - option: --xattrs
     short: X
@@ -240,10 +240,10 @@ options:
     status: implemented
     notes: Negates the corresponding positive option.
   - option: --no-X
-    short: 
+    short:
     category: general
     upstream_default: disabled by default
-    status: missing
+    status: implemented
     notes: Negates the corresponding positive option.
   - option: --times
     short: t
@@ -258,10 +258,10 @@ options:
     status: implemented
     notes: Negates the corresponding positive option.
   - option: --no-t
-    short: 
+    short:
     category: general
     upstream_default: disabled by default
-    status: missing
+    status: implemented
     notes: Negates the corresponding positive option.
   - option: --atimes
     short: U
@@ -324,10 +324,10 @@ options:
     status: implemented
     notes: Negates the corresponding positive option.
   - option: --no-O
-    short: 
+    short:
     category: general
     upstream_default: disabled by default
-    status: missing
+    status: implemented
     notes: Negates the corresponding positive option.
   - option: --omit-link-times
     short: J
@@ -342,10 +342,10 @@ options:
     status: implemented
     notes: Negates the corresponding positive option.
   - option: --no-J
-    short: 
+    short:
     category: general
     upstream_default: disabled by default
-    status: missing
+    status: implemented
     notes: Negates the corresponding positive option.
   - option: --modify-window
     short: @
@@ -384,10 +384,10 @@ options:
     status: implemented
     notes: Negates the corresponding positive option.
   - option: --no-o
-    short: 
+    short:
     category: general
     upstream_default: disabled by default
-    status: missing
+    status: implemented
     notes: Negates the corresponding positive option.; Alias maintained for compatibility.
   - option: --group
     short: g
@@ -402,10 +402,10 @@ options:
     status: implemented
     notes: Negates the corresponding positive option.
   - option: --no-g
-    short: 
+    short:
     category: general
     upstream_default: disabled by default
-    status: missing
+    status: implemented
     notes: Negates the corresponding positive option.; Alias maintained for compatibility.
   - option: -D (short-only)
     short: D
@@ -534,10 +534,10 @@ options:
     status: implemented
     notes: Negates the corresponding positive option.
   - option: --no-H
-    short: 
+    short:
     category: general
     upstream_default: disabled by default
-    status: missing
+    status: implemented
     notes: Negates the corresponding positive option.
   - option: --relative
     short: R
@@ -552,10 +552,10 @@ options:
     status: implemented
     notes: Negates the corresponding positive option.
   - option: --no-R
-    short: 
+    short:
     category: general
     upstream_default: enabled by default (-1)
-    status: missing
+    status: implemented
     notes: Negates the corresponding positive option.
   - option: --implied-dirs
     short: 
@@ -570,16 +570,16 @@ options:
     status: implemented
     notes: Negates the corresponding positive option.
   - option: --i-d
-    short: 
+    short:
     category: general
     upstream_default: default 1
-    status: missing
+    status: implemented
     notes: ""
   - option: --no-i-d
-    short: 
+    short:
     category: general
     upstream_default: enabled by default (1)
-    status: missing
+    status: implemented
     notes: Negates the corresponding positive option.
   - option: --chmod
     short: 


### PR DESCRIPTION
## Summary
- add clap visible aliases for legacy negative flags such as `--no-d`, `--no-p`, `--no-H`, and the implied-dirs shorthands
- extend parsing tests to cover the new alias handling
- mark the affected options as implemented in the parity tracking document

## Testing
- cargo test -p cli parse_args_recognises_no -- --nocapture

------
[Codex Task](