### PR TITLE
Serialise RSYNC_PARTIAL_DIR CLI tests with ENV_LOCK

### DIFF
--- a/crates/cli/src/frontend/tests/parse_args_recognises_partial.rs
+++ b/crates/cli/src/frontend/tests/parse_args_recognises_partial.rs
@@ -5,6 +5,8 @@ use std::path::Path;
 
 #[test]
 fn parse_args_recognises_partial_dir_and_enables_partial() {
+    let _env_lock = ENV_LOCK.lock().expect("env lock");
+
     let parsed = parse_args([
         OsString::from(RSYNC),
         OsString::from("--partial-dir=.rsync-partial"),
@@ -22,6 +24,8 @@ fn parse_args_recognises_partial_dir_and_enables_partial() {
 
 #[test]
 fn parse_args_uses_rsync_partial_dir_env() {
+    let _env_lock = ENV_LOCK.lock().expect("env lock");
+
     let _guard = EnvGuard::set("RSYNC_PARTIAL_DIR", OsStr::new(".env-partial"));
 
     let parsed = parse_args([
@@ -40,6 +44,8 @@ fn parse_args_uses_rsync_partial_dir_env() {
 
 #[test]
 fn parse_args_no_partial_overrides_rsync_partial_dir_env() {
+    let _env_lock = ENV_LOCK.lock().expect("env lock");
+
     let _guard = EnvGuard::set("RSYNC_PARTIAL_DIR", OsStr::new(".env-partial"));
 
     let parsed = parse_args([
@@ -56,6 +62,8 @@ fn parse_args_no_partial_overrides_rsync_partial_dir_env() {
 
 #[test]
 fn parse_args_ignores_empty_rsync_partial_dir_env() {
+    let _env_lock = ENV_LOCK.lock().expect("env lock");
+
     let _guard = EnvGuard::set("RSYNC_PARTIAL_DIR", OsStr::new(""));
 
     let parsed = parse_args([


### PR DESCRIPTION
## Summary
- guard the RSYNC_PARTIAL_DIR parsing tests with the shared environment mutex to prevent cross-test races

## Testing
- cargo test --workspace --lib --tests -- --nocapture

------
[Codex Task](