### PR TITLE
Add --no-S alias for sparse toggle

### DIFF
--- a/crates/cli/src/frontend/command_builder/sections/build_base_command.rs
+++ b/crates/cli/src/frontend/command_builder/sections/build_base_command.rs
@@ -368,6 +368,7 @@ pub(crate) fn build_base_command(program_name: &'static str) -> ClapCommand {
             .arg(
                 Arg::new("no-sparse")
                     .long("no-sparse")
+                    .visible_alias("no-S")
                     .help("Disable sparse file handling.")
                     .action(ArgAction::SetTrue)
                     .conflicts_with("sparse"),

--- a/crates/cli/src/frontend/defaults.rs
+++ b/crates/cli/src/frontend/defaults.rs
@@ -22,7 +22,7 @@ pub(super) const SUPPORTED_OPTIONS_LIST: &str = concat!(
     "--itemize-changes/-i, --no-itemize-changes, --out-format, --stats, --partial, --no-partial, --partial-dir, --temp-dir, --log-file, ",
     "--log-file-format, --delay-updates, --no-delay-updates, --whole-file/-W, --no-whole-file, --remove-source-files, ",
     "--remove-sent-files, --append, --no-append, --append-verify, --preallocate, --fsync, --inplace, --no-inplace, ",
-    "--human-readable/-h, --no-human-readable, -P, --sparse/-S, --no-sparse, --links/-l, --no-links/--no-l, ",
+    "--human-readable/-h, --no-human-readable, -P, --sparse/-S, --no-sparse/--no-S, --links/-l, --no-links/--no-l, ",
     "--copy-links/-L, --no-copy-links, ",
     "--copy-unsafe-links, --no-copy-unsafe-links, --safe-links, --copy-dirlinks/-k, --keep-dirlinks/-K, --no-keep-dirlinks, ",
     "-D, --devices, --copy-devices, --no-devices, --specials, --no-specials, --super, --no-super, --owner, --no-owner, --group, --no-group, ",

--- a/crates/cli/src/frontend/help.rs
+++ b/crates/cli/src/frontend/help.rs
@@ -146,7 +146,7 @@ pub(super) fn help_text(program_name: ProgramName) -> String {
             "      --no-human-readable  Disable human-readable number formatting.\n",
             "  -P              Equivalent to --partial --progress.\n",
             "  -S, --sparse    Preserve sparse files by creating holes in the destination.\n",
-            "      --no-sparse Disable sparse file handling.\n",
+            "      --no-sparse/--no-S Disable sparse file handling.\n",
             "  -L, --copy-links     Transform symlinks into referent files/directories.\n",
             "      --no-copy-links  Preserve symlinks instead of following them.\n",
             "      --copy-unsafe-links  Transform unsafe symlinks into referent files/directories.\n",

--- a/crates/cli/src/frontend/tests/parse_args_recognises_sparse.rs
+++ b/crates/cli/src/frontend/tests/parse_args_recognises_sparse.rs
@@ -22,4 +22,14 @@ fn parse_args_recognises_sparse_flags() {
     .expect("parse");
 
     assert_eq!(parsed.sparse, Some(false));
+
+    let parsed = parse_args([
+        OsString::from(RSYNC),
+        OsString::from("--no-S"),
+        OsString::from("source"),
+        OsString::from("dest"),
+    ])
+    .expect("parse");
+
+    assert_eq!(parsed.sparse, Some(false));
 }

--- a/docs/parity-options.md
+++ b/docs/parity-options.md
@@ -22,8 +22,8 @@ workspace.
 
 | status | count |
 |---|---:|
-| implemented | 160 |
-| missing | 91 |
+| implemented | 161 |
+| missing | 90 |
 
 `missing` entries denote upstream flags that are absent from the current
 `oc-rsync` help surface. Many of these are `--no-*` aliases that suppress a
@@ -38,13 +38,13 @@ must be closed before we can claim full compatibility.
 | daemon | 3 | 2 |
 | deletion | 13 | 0 |
 | filters | 9 | 0 |
-| general | 50 | 72 |
+| general | 51 | 71 |
 | logging | 7 | 3 |
 | metadata | 23 | 4 |
 | transfer | 29 | 5 |
 | traversal | 14 | 2 |
 
-The `general` bucket (72 missing options) is dominated by compatibility
+The `general` bucket (71 missing options) is dominated by compatibility
 aliases such as `--no-r`, `--no-g`, and `--no-times`, together with
 functionality that is currently absent (`--links`, `--fake-super`, daemon-only
 options such as `--config`, etc.).
@@ -56,11 +56,11 @@ options such as `--config`, etc.).
 - **daemon** (2):
   --config, --motd
 - **filters** (0): (none)
-- **general** (72):
+- **general** (71):
   --8-bit-output, --cc, --copy-as, --detach, --dparam, --early-input, --executability,
   --fake-super, --force, --fuzzy, --i-d, --ignore-errors, --ignore-non-existing,
   --links, --max-alloc, --munge-links, --no-8, --no-8-bit-output, --no-A, --no-D,
-  --no-H, --no-J, --no-N, --no-O, --no-R, --no-S, --no-U, --no-W, --no-X, --no-backup,
+  --no-H, --no-J, --no-N, --no-O, --no-R, --no-U, --no-W, --no-X, --no-backup,
   --no-c, --no-d, --no-detach, --no-force, --no-fuzzy, --no-g, --no-h, --no-i,
   --no-i-d, --no-ignore-errors, --no-l, --no-links, --no-m, --no-munge-links,
   --no-o, --no-old-args, --no-p, --no-r, --no-s, --no-t, --no-v, --no-write-devices,

--- a/docs/parity-options.yml
+++ b/docs/parity-options.yml
@@ -672,11 +672,11 @@ options:
     status: implemented
     notes: Negates the corresponding positive option.
   - option: --no-S
-    short: 
+    short:
     category: general
     upstream_default: disabled by default
-    status: missing
-    notes: Negates the corresponding positive option.
+    status: implemented
+    notes: Alias of --no-sparse.
   - option: --preallocate
     short: 
     category: transfer


### PR DESCRIPTION
## Summary
- add the upstream-compatible `--no-S` alias to the sparse toggle so the CLI, help text, and supported option list all mention it
- ensure the parser treats `--no-S` the same as `--no-sparse` and cover it with a dedicated test
- update the parity matrix to reflect the new alias so the counts for implemented/missing options stay accurate

## Testing
- cargo test -p cli parse_args_recognises_sparse_flags
- cargo test -p cli help_flag_renders_static_help_snapshot

------
[Codex Task](