### PR TITLE
Update nextest config for current release

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,5 +1,3 @@
+# Nextest defaults: keep full workspace filter while relying on CLI flags for package selection.
 [profile.default]
-build-bins = true
-
-[profile.default.package]
-graph = "workspace"
+default-filter = "all()"


### PR DESCRIPTION
## Summary
- refresh `.config/nextest.toml` to drop deprecated keys and rely on the current default profile schema
- keep the default filter defined explicitly to retain the expected workspace-wide test behavior without nextest warnings

## Testing
- cargo nextest run --all-features --workspace
- cargo nextest run --all-features --workspace --no-run

------
[Codex Task](