### PR TITLE
Add no-mkpath compatibility options

### DIFF
--- a/crates/cli/src/frontend/arguments/parser.rs
+++ b/crates/cli/src/frontend/arguments/parser.rs
@@ -42,7 +42,7 @@ where
     }
     let mut dry_run = matches.get_flag("dry-run");
     let list_only = matches.get_flag("list-only");
-    let mkpath = matches.get_flag("mkpath");
+    let mkpath = tri_state_flag_positive_first(&matches, "mkpath", "no-mkpath").unwrap_or(false);
     let prune_empty_dirs =
         tri_state_flag_negative_first(&matches, "prune-empty-dirs", "no-prune-empty-dirs");
     let omit_link_times =

--- a/crates/cli/src/frontend/command_builder/sections/build_base_command.rs
+++ b/crates/cli/src/frontend/command_builder/sections/build_base_command.rs
@@ -209,7 +209,16 @@ pub(crate) fn build_base_command(program_name: &'static str) -> ClapCommand {
                 Arg::new("mkpath")
                     .long("mkpath")
                     .help("Create destination's missing path components.")
-                    .action(ArgAction::SetTrue),
+                    .action(ArgAction::SetTrue)
+                    .overrides_with("no-mkpath"),
+            )
+            .arg(
+                Arg::new("no-mkpath")
+                    .long("no-mkpath")
+                    .visible_alias("old-dirs")
+                    .help("Disable creation of destination path components (compatibility with older rsync releases).")
+                    .action(ArgAction::SetTrue)
+                    .overrides_with("mkpath"),
             )
             .arg(
                 Arg::new("prune-empty-dirs")

--- a/crates/cli/src/frontend/defaults.rs
+++ b/crates/cli/src/frontend/defaults.rs
@@ -17,7 +17,7 @@ pub(super) const SUPPORTED_OPTIONS_LIST: &str = concat!(
     "--blocking-io, --no-blocking-io, --protocol, --compress/-z, --no-compress, --compress-level, --compress-choice, ",
     "--skip-compress, --open-noatime, --no-open-noatime, --iconv, --no-iconv, --info, --debug, --verbose/-v, --no-verbose, ",
     "--relative/-R, --no-relative, --one-file-system/-x, --no-one-file-system, --implied-dirs, --no-implied-dirs, ",
-    "--mkpath, --prune-empty-dirs/-m, --no-prune-empty-dirs, --progress, --no-progress, --quiet, --no-quiet, ",
+    "--mkpath, --no-mkpath/--old-dirs, --prune-empty-dirs/-m, --no-prune-empty-dirs, --progress, --no-progress, --quiet, --no-quiet, ",
     "--force, --no-force, --msgs2stderr, --no-msgs2stderr, --outbuf, ",
     "--itemize-changes/-i, --no-itemize-changes, --out-format, --stats, --partial, --no-partial, --partial-dir, --temp-dir, --log-file, ",
     "--log-file-format, --delay-updates, --no-delay-updates, --whole-file/-W, --no-whole-file, --remove-source-files, ",

--- a/crates/cli/src/frontend/help.rs
+++ b/crates/cli/src/frontend/help.rs
@@ -111,6 +111,7 @@ pub(super) fn help_text(program_name: ProgramName) -> String {
             "      --implied-dirs  Create parent directories implied by source paths.\n",
             "      --no-implied-dirs  Disable creation of parent directories implied by source paths.\n",
             "      --mkpath     Create destination's missing path components.\n",
+            "      --no-mkpath, --old-dirs  Do not create destination's missing path components.\n",
             "  -m, --prune-empty-dirs  Skip creating directories that remain empty after filters.\n",
             "      --no-prune-empty-dirs  Disable pruning of empty directories.\n",
             "      --progress   Show progress information during transfers.\n",

--- a/crates/cli/src/frontend/tests/parse_args_recognises_mkpath.rs
+++ b/crates/cli/src/frontend/tests/parse_args_recognises_mkpath.rs
@@ -13,3 +13,44 @@ fn parse_args_recognises_mkpath_flag() {
 
     assert!(parsed.mkpath);
 }
+
+#[test]
+fn parse_args_recognises_no_mkpath_flag() {
+    let parsed = parse_args([
+        OsString::from(RSYNC),
+        OsString::from("--mkpath"),
+        OsString::from("--no-mkpath"),
+        OsString::from("source"),
+        OsString::from("dest"),
+    ])
+    .expect("parse");
+
+    assert!(!parsed.mkpath);
+}
+
+#[test]
+fn parse_args_recognises_old_dirs_alias() {
+    let parsed = parse_args([
+        OsString::from(RSYNC),
+        OsString::from("--old-dirs"),
+        OsString::from("source"),
+        OsString::from("dest"),
+    ])
+    .expect("parse");
+
+    assert!(!parsed.mkpath);
+}
+
+#[test]
+fn parse_args_no_mkpath_allows_later_mkpath_override() {
+    let parsed = parse_args([
+        OsString::from(RSYNC),
+        OsString::from("--no-mkpath"),
+        OsString::from("--mkpath"),
+        OsString::from("source"),
+        OsString::from("dest"),
+    ])
+    .expect("parse");
+
+    assert!(parsed.mkpath);
+}


### PR DESCRIPTION
## Summary
- add support for --no-mkpath and its --old-dirs alias in the CLI help and parser
- ensure mkpath toggling honours last-wins semantics between positive and negative flags
- extend tests and supported option listing to cover the new compatibility switches

## Testing
- cargo test -p cli parse_args_recognises_mkpath -- --nocapture
- cargo test -p cli help -- --nocapture

------
[Codex Task](