### PR TITLE
Align server-mode fallback diagnostics with server role trailers

### DIFF
--- a/crates/cli/src/frontend/server.rs
+++ b/crates/cli/src/frontend/server.rs
@@ -301,7 +301,7 @@ fn write_server_fallback_error<Err: Write>(
 ) {
     let mut sink = MessageSink::with_brand(stderr, brand);
     let mut message = rsync_error!(1, "{}", text);
-    message = message.with_role(Role::Client);
+    message = message.with_role(Role::Server);
     if super::write_message(&message, &mut sink).is_err() {
         let _ = writeln!(sink.writer_mut(), "{text}");
     }

--- a/crates/cli/src/frontend/tests/common.rs
+++ b/crates/cli/src/frontend/tests/common.rs
@@ -181,6 +181,14 @@ pub(super) fn assert_contains_client_trailer(rendered: &str) {
         "expected message to contain {expected:?}, got {rendered:?}"
     );
 }
+
+pub(super) fn assert_contains_server_trailer(rendered: &str) {
+    let expected = format!("[server={}]", rust_version());
+    assert!(
+        rendered.contains(&expected),
+        "expected message to contain {expected:?}, got {rendered:?}"
+    );
+}
 pub(super) static ENV_LOCK: Mutex<()> = Mutex::new(());
 
 pub(super) fn run_with_args<I, S>(args: I) -> (i32, Vec<u8>, Vec<u8>)

--- a/crates/cli/src/frontend/tests/server.rs
+++ b/crates/cli/src/frontend/tests/server.rs
@@ -151,5 +151,5 @@ fn server_mode_reports_missing_fallback_binary() {
     let stderr_text = String::from_utf8(stderr).expect("stderr utf8");
     assert!(stderr_text.contains("fallback rsync binary"));
     assert!(stderr_text.contains(&missing_display));
-    assert_contains_client_trailer(&stderr_text);
+    assert_contains_server_trailer(&stderr_text);
 }


### PR DESCRIPTION
## Summary
- render `--server` fallback errors with the server role trailer instead of the client role
- add a reusable server-trailer assertion helper for CLI tests
- update server fallback test expectations to reflect the server role

## Testing
- cargo fmt --all -- --check
- cargo test -p cli server_mode -- --nocapture

------
[Codex Task](