### PR TITLE
Prevent fallback recursion when rsync resolves to oc-rsync

### DIFF
--- a/crates/core/src/client/tests/fallback_controls.rs
+++ b/crates/core/src/client/tests/fallback_controls.rs
@@ -220,6 +220,24 @@ fn remote_fallback_detects_missing_default_binary_on_path() {
     assert!(message.contains("is not available on PATH"));
 }
 
+#[test]
+fn remote_fallback_rejects_recursive_resolution() {
+    let _lock = env_lock().lock().expect("env mutex poisoned");
+
+    let mut stdout = Vec::new();
+    let mut stderr = Vec::new();
+
+    let mut args = baseline_fallback_args();
+    args.fallback_binary = Some(std::env::current_exe().expect("current exe").into_os_string());
+
+    let error = run_remote_transfer_fallback(&mut stdout, &mut stderr, args)
+        .expect_err("recursive fallback should be rejected");
+
+    assert_eq!(error.exit_code(), 1);
+    let message = format!("{error}");
+    assert!(message.contains("fallback resolution points to this oc-rsync executable"));
+}
+
 #[cfg(unix)]
 #[test]
 fn remote_fallback_reports_stdout_forward_errors() {

--- a/crates/core/src/fallback.rs
+++ b/crates/core/src/fallback.rs
@@ -82,6 +82,7 @@ use std::ffi::{OsStr, OsString};
 
 pub use binary::{
     describe_missing_fallback_binary, fallback_binary_available, fallback_binary_candidates,
+    fallback_binary_is_self, fallback_binary_path,
 };
 
 /// Name of the client fallback override environment variable.

--- a/crates/core/src/fallback/binary/mod.rs
+++ b/crates/core/src/fallback/binary/mod.rs
@@ -4,7 +4,9 @@ mod diagnostics;
 #[cfg(unix)]
 mod unix;
 
-pub use self::availability::fallback_binary_available;
+pub use self::availability::{
+    fallback_binary_available, fallback_binary_is_self, fallback_binary_path,
+};
 pub use self::candidates::fallback_binary_candidates;
 pub use self::diagnostics::describe_missing_fallback_binary;
 


### PR DESCRIPTION
## Summary
- resolve fallback binaries to their executable path and detect when they resolve to the current oc-rsync binary
- reject recursive fallback in server mode and remote transfer fallback with clear diagnostics
- add tests covering fallback path resolution and recursive fallback handling

## Testing
- cargo test --workspace

------
[Codex Task](