### PR TITLE
Document test prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,18 @@ AGENTS.md               # Internal agent roles & conventions
 
 ## Development
 
+### Prerequisites
+
+* Rust toolchain 1.88.0 (managed via `rust-toolchain.toml`).
+* [`cargo-nextest`](https://nexte.st/) for running the test suite:
+
+  ```bash
+  cargo install cargo-nextest --locked
+  ```
+
+* [`cargo-llvm-cov`](https://github.com/taiki-e/cargo-llvm-cov) if you want to
+  generate coverage reports locally.
+
 ### Linting and formatting
 
 ```bash


### PR DESCRIPTION
## Summary
- add a development prerequisites section noting the required cargo-nextest install
- mention optional cargo-llvm-cov setup for local coverage generation

## Testing
- cargo test --all-features --workspace
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo nextest run --all-features --workspace *(fails: cargo-nextest not installed in environment)*

------
[Codex Task](