### PR TITLE
Use metadata program name for version footer

### DIFF
--- a/crates/core/src/version/report/renderer.rs
+++ b/crates/core/src/version/report/renderer.rs
@@ -189,10 +189,7 @@ impl VersionInfoReport {
 
     /// Internal helper for the GPL footer. Single fmt call, no allocations.
     fn write_gpl_footer<W: FmtWrite>(&self, writer: &mut W) -> fmt::Result {
-        // Derive the program name from the standard banner to avoid hardcoding.
-        // If you ever expose `VersionMetadata::program_name()`, use that instead.
-        let banner = self.metadata.standard_banner();
-        let program_name = banner.split_whitespace().next().unwrap_or("This program");
+        let program_name = self.metadata.program_name();
 
         writeln!(
             writer,

--- a/crates/core/src/version/tests/report.rs
+++ b/crates/core/src/version/tests/report.rs
@@ -6,6 +6,12 @@ use crate::version::report::{
 use libc::{ino_t, off_t, time_t};
 use std::mem;
 
+fn gpl_footer(program_name: &str) -> String {
+    format!(
+        "{program_name} comes with ABSOLUTELY NO WARRANTY. This is free software, and you are welcome to redistribute it under certain conditions. See the GNU General Public License for details.\n"
+    )
+}
+
 #[test]
 fn version_info_report_renders_default_report() {
     let config = VersionInfoConfig::default();
@@ -68,9 +74,7 @@ fn version_info_report_renders_default_report() {
     assert!(actual.contains(&format!(
         "Daemon auth list:\n    {daemon_auth_algorithms}\n"
     )));
-    assert!(actual.ends_with(
-        "oc-rsync comes with ABSOLUTELY NO WARRANTY. This is free software, and you are welcome to redistribute it under certain conditions. See the GNU General Public License for details.\n"
-    ));
+    assert!(actual.ends_with(&gpl_footer(PROGRAM_NAME)));
 }
 
 #[test]
@@ -183,6 +187,14 @@ fn version_info_report_omits_rust_specific_sections() {
 
     assert!(!rendered.contains("Compiled features:"));
     assert!(!rendered.contains("Build info:"));
+}
+
+#[test]
+fn version_info_report_daemon_footer_uses_daemon_program_name() {
+    let report = VersionInfoReport::for_daemon_brand(Brand::Oc);
+    let rendered = report.human_readable();
+
+    assert!(rendered.ends_with(&gpl_footer(DAEMON_PROGRAM_NAME)));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- use the recorded program name when rendering the GPL footer for version output
- share footer expectation helpers and add coverage for daemon-branded banners

## Testing
- cargo fmt
- cargo test -p core version_info_report_daemon_footer_uses_daemon_program_name -- --nocapture (aborted due to long compile)

------
[Codex Task](