### PR TITLE
Add --old-d alias for mkpath and refresh parity docs

### DIFF
--- a/crates/cli/src/frontend/command_builder/sections/build_base_command.rs
+++ b/crates/cli/src/frontend/command_builder/sections/build_base_command.rs
@@ -216,6 +216,7 @@ pub(crate) fn build_base_command(program_name: &'static str) -> ClapCommand {
                 Arg::new("no-mkpath")
                     .long("no-mkpath")
                     .visible_alias("old-dirs")
+                    .visible_alias("old-d")
                     .help("Disable creation of destination path components (compatibility with older rsync releases).")
                     .action(ArgAction::SetTrue)
                     .overrides_with("mkpath"),

--- a/crates/cli/src/frontend/defaults.rs
+++ b/crates/cli/src/frontend/defaults.rs
@@ -17,7 +17,7 @@ pub(super) const SUPPORTED_OPTIONS_LIST: &str = concat!(
     "--blocking-io, --no-blocking-io, --protocol, --compress/-z, --no-compress, --compress-level, --compress-choice, ",
     "--skip-compress, --open-noatime, --no-open-noatime, --iconv, --no-iconv, --info, --debug, --verbose/-v, --no-verbose, ",
     "--relative/-R, --no-relative, --one-file-system/-x, --no-one-file-system, --implied-dirs, --no-implied-dirs, ",
-    "--mkpath, --no-mkpath/--old-dirs, --prune-empty-dirs/-m, --no-prune-empty-dirs, --progress, --no-progress, --quiet, --no-quiet, ",
+    "--mkpath, --no-mkpath/--old-dirs/--old-d, --prune-empty-dirs/-m, --no-prune-empty-dirs, --progress, --no-progress, --quiet, --no-quiet, ",
     "--force, --no-force, --msgs2stderr, --no-msgs2stderr, --outbuf, ",
     "--itemize-changes/-i, --no-itemize-changes, --out-format, --stats, --partial, --no-partial, --partial-dir, --temp-dir, --log-file, ",
     "--log-file-format, --delay-updates, --no-delay-updates, --whole-file/-W, --no-whole-file, --remove-source-files, ",

--- a/crates/cli/src/frontend/tests/parse_args_recognises_mkpath.rs
+++ b/crates/cli/src/frontend/tests/parse_args_recognises_mkpath.rs
@@ -42,6 +42,19 @@ fn parse_args_recognises_old_dirs_alias() {
 }
 
 #[test]
+fn parse_args_recognises_old_d_alias() {
+    let parsed = parse_args([
+        OsString::from(RSYNC),
+        OsString::from("--old-d"),
+        OsString::from("source"),
+        OsString::from("dest"),
+    ])
+    .expect("parse");
+
+    assert!(!parsed.mkpath);
+}
+
+#[test]
 fn parse_args_no_mkpath_allows_later_mkpath_override() {
     let parsed = parse_args([
         OsString::from(RSYNC),

--- a/docs/parity-options.md
+++ b/docs/parity-options.md
@@ -22,8 +22,8 @@ workspace.
 
 | status | count |
 |---|---:|
-| implemented | 161 |
-| missing | 90 |
+| implemented | 164 |
+| missing | 87 |
 
 `missing` entries denote upstream flags that are absent from the current
 `oc-rsync` help surface. Many of these are `--no-*` aliases that suppress a
@@ -38,13 +38,13 @@ must be closed before we can claim full compatibility.
 | daemon | 3 | 2 |
 | deletion | 13 | 0 |
 | filters | 9 | 0 |
-| general | 51 | 71 |
+| general | 52 | 70 |
 | logging | 7 | 3 |
 | metadata | 23 | 4 |
 | transfer | 29 | 5 |
-| traversal | 14 | 2 |
+| traversal | 16 | 0 |
 
-The `general` bucket (71 missing options) is dominated by compatibility
+The `general` bucket (70 missing options) is dominated by compatibility
 aliases such as `--no-r`, `--no-g`, and `--no-times`, together with
 functionality that is currently absent (`--links`, `--fake-super`, daemon-only
 options such as `--config`, etc.).
@@ -56,7 +56,7 @@ options such as `--config`, etc.).
 - **daemon** (2):
   --config, --motd
 - **filters** (0): (none)
-- **general** (71):
+- **general** (70):
   --8-bit-output, --cc, --copy-as, --detach, --dparam, --early-input, --executability,
   --fake-super, --force, --fuzzy, --i-d, --ignore-errors, --ignore-non-existing,
   --links, --max-alloc, --munge-links, --no-8, --no-8-bit-output, --no-A, --no-D,
@@ -64,7 +64,7 @@ options such as `--config`, etc.).
   --no-c, --no-d, --no-detach, --no-force, --no-fuzzy, --no-g, --no-h, --no-i,
   --no-i-d, --no-ignore-errors, --no-l, --no-links, --no-m, --no-munge-links,
   --no-o, --no-old-args, --no-p, --no-r, --no-s, --no-t, --no-v, --no-write-devices,
-  --no-x, --no-y, --no-z, --old-args, --old-d, --only-write-batch, --qsort, --quiet,
+  --no-x, --no-y, --no-z, --old-args, --only-write-batch, --qsort, --quiet,
   --read-batch, --sender, --server, --stderr, --stop-after, --stop-at, --time-limit,
   --trust-sender, --write-batch, --write-devices, --zc, --zl
 - **logging** (2):
@@ -73,8 +73,7 @@ options such as `--config`, etc.).
   --atimes, --crtimes, --no-atimes, --no-crtimes
 - **transfer** (5):
   --compress-choice, --log-format, --new-compress, --no-checksum, --old-compress
-- **traversal** (2):
-  --no-mkpath, --old-dirs
+- **traversal** (0): (none)
 
 ### oc-rsync–only switches
 

--- a/docs/parity-options.yml
+++ b/docs/parity-options.yml
@@ -174,17 +174,17 @@ options:
     status: implemented
     notes: Negates the corresponding positive option.; Alias maintained for compatibility.
   - option: --old-dirs
-    short: 
+    short:
     category: traversal
     upstream_default: default -1
-    status: missing
-    notes: ""
+    status: implemented
+    notes: Alias for --no-mkpath (compatibility with older rsync releases).
   - option: --old-d
-    short: 
+    short:
     category: general
     upstream_default: default -1
-    status: missing
-    notes: ""
+    status: implemented
+    notes: Alias for --no-mkpath.
   - option: --perms
     short: p
     category: metadata
@@ -1380,10 +1380,10 @@ options:
     status: implemented
     notes: ""
   - option: --no-mkpath
-    short: 
+    short:
     category: traversal
     upstream_default: disabled by default
-    status: missing
+    status: implemented
     notes: Negates the corresponding positive option.
   - option: --qsort
     short: 


### PR DESCRIPTION
## Summary
- add the legacy `--old-d` alias for `--no-mkpath` alongside the existing `--old-dirs` alias
- extend CLI parsing tests and defaults listing to cover the new alias
- mark mkpath aliases as implemented in the parity option matrices and refresh counts

## Testing
- cargo test --workspace --all-features

------
[Codex Task](