### PR TITLE
Tighten placeholder detection for TODO markers

### DIFF
--- a/tools/no_placeholders.sh
+++ b/tools/no_placeholders.sh
@@ -6,10 +6,11 @@ fail=0
 # handle escaped quotes inside the literal, so it uses a negated character
 # class that also permits escaped characters via `\.`.
 # GNU/BSD `grep -E` does not recognize `\b` as a word boundary, so approximate one
-# using start/end checks against non-identifier characters. This keeps `fixme` and
-# `xxx` detections case-insensitive without tripping on identifiers such as
-# `prefixme`. The panic! guard retains its escaped-quote handling.
-pattern='todo!|unimplemented!|(^|[^[:alnum:]_])(fixme|xxx)([^[:alnum:]_]|$)|panic!\("([^"\\]|\\.)*(todo|fixme|xxx|unimplemented)([^"\\]|\\.)*"\)'
+# using start/end checks against non-identifier characters. This keeps `todo`,
+# `unimplemented`, `fixme`, and `xxx` detections case-insensitive without
+# tripping on identifiers such as `prefixme`. The panic! guard retains its
+# escaped-quote handling.
+pattern='todo!|unimplemented!|(^|[^[:alnum:]_])(todo|unimplemented|fixme|xxx)([^[:alnum:]_]|$)|panic!\("([^"\\]|\\.)*(todo|fixme|xxx|unimplemented)([^"\\]|\\.)*"\)'
 
 while IFS= read -r -d '' file; do
     offenses=$(grep -nEi "$pattern" "$file" | grep -v '^1:' || true)


### PR DESCRIPTION
## Summary
- widen placeholder scanning to flag TODO and unimplemented words in comments alongside existing markers
- simplify the xtask no-placeholders checker while preserving macro and standalone word detection
- add coverage for TODO comments to prevent regressions

## Testing
- cargo test -p xtask no_placeholders

------
[Codex Task](