### PR TITLE
Add Python version guard to Homebrew formula verifier

### DIFF
--- a/tools/verify-brew-formula.sh
+++ b/tools/verify-brew-formula.sh
@@ -15,6 +15,13 @@ import pathlib
 import re
 import sys
 
+if sys.version_info < (3, 11):
+    print(
+        f"[ERROR] Python 3.11+ is required for tomllib; found {sys.version.split()[0]}",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
 from pathlib import PurePosixPath
 
 import tomllib


### PR DESCRIPTION
## Summary
- add an explicit Python 3.11+ check to verify-brew-formula.sh so missing tomllib yields a clear error

## Testing
- cargo test --all-features --workspace

------
[Codex Task](