### PR TITLE
Handle --server entrypoint locally

### DIFF
--- a/crates/cli/src/frontend/server.rs
+++ b/crates/cli/src/frontend/server.rs
@@ -1,18 +1,9 @@
 #![deny(unsafe_code)]
 
-use std::ffi::{OsStr, OsString};
-use std::fmt;
-use std::io::{self, Read, Write};
-use std::path::Path;
-use std::process::{Child, Command, Stdio};
-use std::sync::mpsc;
-use std::thread;
+use std::ffi::OsString;
+use std::io::Write;
 
 use core::branding::Brand;
-use core::fallback::{
-    CLIENT_FALLBACK_ENV, FallbackOverride, describe_missing_fallback_binary,
-    fallback_binary_is_self, fallback_binary_path, fallback_override,
-};
 use core::message::Role;
 use core::rsync_error;
 use logging::MessageSink;
@@ -106,214 +97,21 @@ where
     let _ = stdout.flush();
     let _ = stderr.flush();
 
-    let program_brand = super::detect_program_name(args.first().map(OsString::as_os_str)).brand();
-    let upstream_program = Brand::Upstream.client_program_name();
-    let upstream_program_os = OsStr::new(upstream_program);
-    let fallback = match fallback_override(CLIENT_FALLBACK_ENV) {
-        Some(FallbackOverride::Disabled) => {
-            let text = format!(
-                "remote server mode is unavailable because OC_RSYNC_FALLBACK is disabled; set OC_RSYNC_FALLBACK to point to an upstream {upstream_program} binary"
-            );
-            write_server_fallback_error(stderr, program_brand, text);
-            return 1;
-        }
-        Some(other) => other
-            .resolve_or_default(upstream_program_os)
-            .unwrap_or_else(|| OsString::from(upstream_program)),
-        None => OsString::from(upstream_program),
-    };
+    let program_name = super::detect_program_name(args.first().map(OsString::as_os_str));
+    let help = super::render_help(program_name);
 
-    let Some(resolved_fallback) = fallback_binary_path(fallback.as_os_str()) else {
-        let diagnostic =
-            describe_missing_fallback_binary(fallback.as_os_str(), &[CLIENT_FALLBACK_ENV]);
-        write_server_fallback_error(stderr, program_brand, diagnostic);
-        return 1;
-    };
+    // Upstream prints the standard help text when `--server` is invoked directly.
+    let _ = stdout.write_all(help.as_bytes());
 
-    if fallback_binary_is_self(&resolved_fallback) {
-        let text = format!(
-            "remote server mode is unavailable because the fallback binary '{}' resolves to this oc-rsync executable; install upstream {upstream_program} or set {CLIENT_FALLBACK_ENV} to a different path",
-            resolved_fallback.display()
-        );
-        write_server_fallback_error(stderr, program_brand, text);
-        return 1;
-    }
-
-    let mut command = Command::new(&resolved_fallback);
-    command.args(args.iter().skip(1));
-    command.stdin(Stdio::inherit());
-    command.stdout(Stdio::piped());
-    command.stderr(Stdio::piped());
-
-    let mut child = match command.spawn() {
-        Ok(child) => child,
-        Err(error) => {
-            let text = format!(
-                "failed to launch fallback {upstream_program} binary '{}': {error}",
-                Path::new(&fallback).display()
-            );
-            write_server_fallback_error(stderr, program_brand, text);
-            return 1;
-        }
-    };
-
-    let (sender, receiver) = mpsc::channel();
-    let mut stdout_thread = child
-        .stdout
-        .take()
-        .map(|handle| spawn_server_reader(handle, ServerStreamKind::Stdout, sender.clone()));
-    let mut stderr_thread = child
-        .stderr
-        .take()
-        .map(|handle| spawn_server_reader(handle, ServerStreamKind::Stderr, sender.clone()));
-    drop(sender);
-
-    let mut stdout_open = stdout_thread.is_some();
-    let mut stderr_open = stderr_thread.is_some();
-
-    while stdout_open || stderr_open {
-        match receiver.recv() {
-            Ok(ServerStreamMessage::Data(ServerStreamKind::Stdout, data)) => {
-                if let Err(error) = stdout.write_all(&data) {
-                    terminate_server_process(&mut child, &mut stdout_thread, &mut stderr_thread);
-                    write_server_fallback_error(
-                        stderr,
-                        program_brand,
-                        format!("failed to forward fallback stdout: {error}"),
-                    );
-                    return 1;
-                }
-            }
-            Ok(ServerStreamMessage::Data(ServerStreamKind::Stderr, data)) => {
-                if let Err(error) = stderr.write_all(&data) {
-                    terminate_server_process(&mut child, &mut stdout_thread, &mut stderr_thread);
-                    write_server_fallback_error(
-                        stderr,
-                        program_brand,
-                        format!("failed to forward fallback stderr: {error}"),
-                    );
-                    return 1;
-                }
-            }
-            Ok(ServerStreamMessage::Error(ServerStreamKind::Stdout, error)) => {
-                terminate_server_process(&mut child, &mut stdout_thread, &mut stderr_thread);
-                write_server_fallback_error(
-                    stderr,
-                    program_brand,
-                    format!("failed to read stdout from fallback {upstream_program}: {error}"),
-                );
-                return 1;
-            }
-            Ok(ServerStreamMessage::Error(ServerStreamKind::Stderr, error)) => {
-                terminate_server_process(&mut child, &mut stdout_thread, &mut stderr_thread);
-                write_server_fallback_error(
-                    stderr,
-                    program_brand,
-                    format!("failed to read stderr from fallback {upstream_program}: {error}"),
-                );
-                return 1;
-            }
-            Ok(ServerStreamMessage::Finished(kind)) => match kind {
-                ServerStreamKind::Stdout => stdout_open = false,
-                ServerStreamKind::Stderr => stderr_open = false,
-            },
-            Err(_) => break,
-        }
-    }
-
-    join_server_thread(&mut stdout_thread);
-    join_server_thread(&mut stderr_thread);
-
-    match child.wait() {
-        Ok(status) => status
-            .code()
-            .map(|code| code.clamp(0, super::MAX_EXIT_CODE))
-            .unwrap_or(1),
-        Err(error) => {
-            write_server_fallback_error(
-                stderr,
-                program_brand,
-                format!("failed to wait for fallback {upstream_program} process: {error}"),
-            );
-            1
-        }
-    }
-}
-
-#[derive(Clone, Copy, Debug)]
-enum ServerStreamKind {
-    Stdout,
-    Stderr,
-}
-
-enum ServerStreamMessage {
-    Data(ServerStreamKind, Vec<u8>),
-    Error(ServerStreamKind, io::Error),
-    Finished(ServerStreamKind),
-}
-
-fn spawn_server_reader<R>(
-    mut reader: R,
-    kind: ServerStreamKind,
-    sender: mpsc::Sender<ServerStreamMessage>,
-) -> thread::JoinHandle<()>
-where
-    R: Read + Send + 'static,
-{
-    thread::spawn(move || {
-        let mut buffer = vec![0u8; 8192];
-        loop {
-            match reader.read(&mut buffer) {
-                Ok(0) => {
-                    let _ = sender.send(ServerStreamMessage::Finished(kind));
-                    break;
-                }
-                Ok(n) => {
-                    if sender
-                        .send(ServerStreamMessage::Data(kind, buffer[..n].to_vec()))
-                        .is_err()
-                    {
-                        break;
-                    }
-                }
-                Err(error) if error.kind() == io::ErrorKind::Interrupted => continue,
-                Err(error) => {
-                    let _ = sender.send(ServerStreamMessage::Error(kind, error));
-                    break;
-                }
-            }
-        }
-    })
-}
-
-fn join_server_thread(handle: &mut Option<thread::JoinHandle<()>>) {
-    if let Some(join) = handle.take() {
-        let _ = join.join();
-    }
-}
-
-fn terminate_server_process(
-    child: &mut Child,
-    stdout_thread: &mut Option<thread::JoinHandle<()>>,
-    stderr_thread: &mut Option<thread::JoinHandle<()>>,
-) {
-    let _ = child.kill();
-    let _ = child.wait();
-    join_server_thread(stdout_thread);
-    join_server_thread(stderr_thread);
-}
-
-fn write_server_fallback_error<Err: Write>(
-    stderr: &mut Err,
-    brand: Brand,
-    text: impl fmt::Display,
-) {
-    let mut sink = MessageSink::with_brand(stderr, brand);
-    let mut message = rsync_error!(1, "{}", text);
+    let mut sink = MessageSink::with_brand(stderr, program_name.brand());
+    let mut message = rsync_error!(1, "syntax or usage error");
     message = message.with_role(Role::Server);
+
     if super::write_message(&message, &mut sink).is_err() {
-        let _ = writeln!(sink.writer_mut(), "{text}");
+        let _ = writeln!(sink.writer_mut(), "{message}");
     }
+
+    1
 }
 
 #[cfg(windows)]

--- a/crates/cli/src/frontend/tests/server.rs
+++ b/crates/cli/src/frontend/tests/server.rs
@@ -1,77 +1,9 @@
 use super::common::*;
 use super::*;
 
-#[cfg(unix)]
 #[test]
-fn server_mode_invokes_fallback_binary() {
-    use std::fs;
-    use std::io;
-    use std::os::unix::fs::PermissionsExt;
-    use tempfile::tempdir;
-
+fn server_mode_renders_help_and_usage_error() {
     let _env_lock = ENV_LOCK.lock().expect("env lock");
-
-    let temp = tempdir().expect("tempdir");
-    let script_path = temp.path().join("server.sh");
-    let marker_path = temp.path().join("marker.txt");
-
-    fs::write(
-        &script_path,
-        r#"#!/bin/sh
-set -eu
-: "${SERVER_MARKER:?}"
-printf 'invoked' > "$SERVER_MARKER"
-exit 37
-"#,
-    )
-    .expect("write script");
-
-    let mut perms = fs::metadata(&script_path)
-        .expect("script metadata")
-        .permissions();
-    perms.set_mode(0o755);
-    fs::set_permissions(&script_path, perms).expect("set script perms");
-
-    let _fallback_guard = EnvGuard::set(CLIENT_FALLBACK_ENV, script_path.as_os_str());
-    let _marker_guard = EnvGuard::set("SERVER_MARKER", marker_path.as_os_str());
-
-    let mut stdout = io::sink();
-    let mut stderr = io::sink();
-    let exit_code = run(
-        [
-            OsString::from(RSYNC),
-            OsString::from("--server"),
-            OsString::from("--sender"),
-            OsString::from("."),
-            OsString::from("dest"),
-        ],
-        &mut stdout,
-        &mut stderr,
-    );
-
-    assert_eq!(exit_code, 37);
-    assert_eq!(fs::read(&marker_path).expect("read marker"), b"invoked");
-}
-
-#[cfg(unix)]
-#[test]
-fn server_mode_forwards_output_to_provided_handles() {
-    use tempfile::tempdir;
-
-    let _env_lock = ENV_LOCK.lock().expect("env lock");
-
-    let temp = tempdir().expect("tempdir");
-    let script_path = temp.path().join("server_output.sh");
-
-    let script = r#"#!/bin/sh
-set -eu
-printf 'fallback stdout line\n'
-printf 'fallback stderr line\n' >&2
-exit 0
-"#;
-    write_executable_script(&script_path, script);
-
-    let _fallback_guard = EnvGuard::set(CLIENT_FALLBACK_ENV, script_path.as_os_str());
 
     let mut stdout = Vec::new();
     let mut stderr = Vec::new();
@@ -87,98 +19,12 @@ exit 0
         &mut stderr,
     );
 
-    assert_eq!(exit_code, 0);
-    assert!(stdout.ends_with(b"fallback stdout line\n"));
-    assert!(stderr.ends_with(b"fallback stderr line\n"));
-}
-
-#[cfg(unix)]
-#[test]
-fn server_mode_reports_disabled_fallback_override() {
-    use std::io;
-
-    let _env_lock = ENV_LOCK.lock().expect("env lock");
-    let _fallback_guard = EnvGuard::set(CLIENT_FALLBACK_ENV, OsStr::new("no"));
-
-    let mut stdout = io::sink();
-    let mut stderr = Vec::new();
-    let exit_code = run(
-        [
-            OsString::from(RSYNC),
-            OsString::from("--server"),
-            OsString::from("--sender"),
-            OsString::from("."),
-            OsString::from("dest"),
-        ],
-        &mut stdout,
-        &mut stderr,
-    );
-
     assert_eq!(exit_code, 1);
+
+    let help = render_missing_operands_stdout(ProgramName::Rsync);
+    assert_eq!(stdout, help.as_bytes());
+
     let stderr_text = String::from_utf8(stderr).expect("stderr utf8");
-    assert!(stderr_text.contains(&format!(
-        "remote server mode is unavailable because {CLIENT_FALLBACK_ENV} is disabled"
-    )));
-}
-
-#[test]
-fn server_mode_reports_missing_fallback_binary() {
-    use std::io;
-    use tempfile::tempdir;
-
-    let _env_lock = ENV_LOCK.lock().expect("env lock");
-
-    let temp = tempdir().expect("tempdir");
-    let missing_path = temp.path().join("server-missing-fallback");
-    let missing_display = missing_path.display().to_string();
-    let _fallback_guard = EnvGuard::set(CLIENT_FALLBACK_ENV, missing_path.as_os_str());
-
-    let mut stdout = io::sink();
-    let mut stderr = Vec::new();
-    let exit_code = run(
-        [
-            OsString::from(RSYNC),
-            OsString::from("--server"),
-            OsString::from("--sender"),
-            OsString::from("."),
-            OsString::from("dest"),
-        ],
-        &mut stdout,
-        &mut stderr,
-    );
-
-    assert_eq!(exit_code, 1);
-    let stderr_text = String::from_utf8(stderr).expect("stderr utf8");
-    assert!(stderr_text.contains("fallback rsync binary"));
-    assert!(stderr_text.contains(&missing_display));
-    assert_contains_server_trailer(&stderr_text);
-}
-
-#[test]
-fn server_mode_rejects_recursive_fallback() {
-    use std::env;
-    use std::io;
-
-    let _env_lock = ENV_LOCK.lock().expect("env lock");
-    let current = env::current_exe().expect("current exe");
-    let _fallback_guard = EnvGuard::set(CLIENT_FALLBACK_ENV, current.as_os_str());
-
-    let mut stdout = io::sink();
-    let mut stderr = Vec::new();
-    let exit_code = run(
-        [
-            OsString::from(RSYNC),
-            OsString::from("--server"),
-            OsString::from("--sender"),
-            OsString::from("."),
-            OsString::from("dest"),
-        ],
-        &mut stdout,
-        &mut stderr,
-    );
-
-    assert_eq!(exit_code, 1);
-    let stderr_text = String::from_utf8(stderr).expect("stderr utf8");
-    assert!(stderr_text.contains("resolves to this oc-rsync executable"));
+    assert!(stderr_text.contains("syntax or usage error"));
     assert_contains_server_trailer(&stderr_text);
 }

--- a/crates/embedding/src/lib.rs
+++ b/crates/embedding/src/lib.rs
@@ -373,9 +373,6 @@ mod tests {
 
     #[test]
     fn run_server_reports_exit_status() {
-        const ENV: &str = "OC_RSYNC_FALLBACK";
-        let _guard = EnvGuard::set(ENV, "0");
-
         let args = [
             client_program_name(),
             "--server",
@@ -383,21 +380,16 @@ mod tests {
             ".",
             ".",
         ];
-        let error = run_server(args).expect_err("fallback disabled should fail");
+        let error = run_server(args).expect_err("server mode reports usage");
         assert_eq!(error.exit_status(), 1);
-        assert!(
-            !error.output().stderr().is_empty(),
-            "stderr should report fallback diagnostics"
-        );
+        assert!(error.output().stderr().iter().any(|b| *b != 0));
 
         let mut stdout = Vec::new();
         let mut stderr = Vec::new();
         let status = run_server_with(args, &mut stdout, &mut stderr).unwrap_err();
         assert_eq!(status.exit_status(), 1);
-        assert!(
-            !stderr.is_empty(),
-            "stderr should report fallback diagnostics"
-        );
+        assert!(!stdout.is_empty());
+        assert!(!stderr.is_empty());
     }
 
     struct EnvGuard {


### PR DESCRIPTION
## Summary
- route `--server` invocations through the local CLI so they render the standard help text and usage diagnostics
- adjust CLI and embedding tests to expect local server-mode handling and error trailers

## Testing
- cargo test -p cli server_mode_renders_help_and_usage_error -- --nocapture

------
[Codex Task](