### PR TITLE
Align --rsync-path forwarding with upstream

### DIFF
--- a/crates/cli/src/frontend/tests/remote_fallback_forwards_rsync.rs
+++ b/crates/cli/src/frontend/tests/remote_fallback_forwards_rsync.rs
@@ -33,6 +33,9 @@ exit 0
     assert!(stderr.is_empty());
 
     let recorded = std::fs::read_to_string(&args_path).expect("read args file");
-    assert!(recorded.lines().any(|line| line == "--rsync-path"));
-    assert!(recorded.lines().any(|line| line == "/opt/custom/rsync"));
+    assert!(
+        recorded
+            .lines()
+            .any(|line| line == "--rsync-path=/opt/custom/rsync")
+    );
 }

--- a/crates/core/src/client/fallback/runner/command_builder.rs
+++ b/crates/core/src/client/fallback/runner/command_builder.rs
@@ -702,8 +702,9 @@ pub(crate) fn prepare_invocation(
     }
 
     if let Some(path) = rsync_path {
-        command_args.push(OsString::from("--rsync-path"));
-        command_args.push(path);
+        let mut arg = OsString::from("--rsync-path=");
+        arg.push(path);
+        command_args.push(arg);
     }
 
     command_args.append(&mut remainder);


### PR DESCRIPTION
## Summary
- encode --rsync-path as a single --rsync-path= argument to mirror upstream server invocation
- update remote fallback tests to expect the combined argument form

## Testing
- cargo test -p cli remote_fallback_forwards_rsync_path_option

------
[Codex Task](