### PR TITLE
Ensure --rsync-path is gated on remote operands

### DIFF
--- a/crates/cli/src/frontend/execution/drive/validation.rs
+++ b/crates/cli/src/frontend/execution/drive/validation.rs
@@ -20,7 +20,7 @@ pub(crate) const CONNECT_PROGRAM_DAEMON_ONLY_MESSAGE: &str =
     "the --connect-program option may only be used when accessing an rsync daemon";
 
 pub(super) fn validate_local_only_options<Err>(
-    fallback_required: bool,
+    has_remote_operands: bool,
     desired_protocol: Option<ProtocolVersion>,
     password_file: Option<&PathBuf>,
     connect_program: Option<&OsString>,
@@ -31,7 +31,7 @@ pub(super) fn validate_local_only_options<Err>(
 where
     Err: Write,
 {
-    if fallback_required {
+    if has_remote_operands {
         return None;
     }
 

--- a/crates/cli/src/frontend/execution/drive/workflow/run.rs
+++ b/crates/cli/src/frontend/execution/drive/workflow/run.rs
@@ -369,8 +369,8 @@ where
     let recursive_effective = !matches!(recursive_override, Some(false));
     let batch_mode_requested =
         write_batch.is_some() || only_write_batch.is_some() || read_batch.is_some();
-    let requires_remote_fallback = transfer_requires_remote(&remainder, &file_list_operands);
-    let fallback_required = requires_remote_fallback || batch_mode_requested;
+    let has_remote_operands = transfer_requires_remote(&remainder, &file_list_operands);
+    let fallback_required = has_remote_operands || batch_mode_requested;
 
     let fallback_context = FallbackArgumentsContext {
         required: fallback_required,
@@ -532,7 +532,7 @@ where
     }
 
     if let Some(exit_code) = validation::validate_local_only_options(
-        fallback_required,
+        has_remote_operands,
         desired_protocol,
         password_file.as_ref(),
         connect_program.as_ref(),

--- a/crates/cli/src/frontend/tests/rsync.rs
+++ b/crates/cli/src/frontend/tests/rsync.rs
@@ -23,3 +23,27 @@ fn rsync_path_requires_remote_operands() {
     assert!(message.contains("the --rsync-path option may only be used with remote connections"));
     assert!(!dest.exists());
 }
+
+#[test]
+fn rsync_path_rejected_for_batch_without_remote_operands() {
+    use tempfile::tempdir;
+
+    let temp = tempdir().expect("tempdir");
+    let source = temp.path().join("source.txt");
+    let dest = temp.path().join("dest.txt");
+    std::fs::write(&source, b"content").expect("write source");
+
+    let (code, stdout, stderr) = run_with_args([
+        OsString::from(RSYNC),
+        OsString::from("--write-batch=batch"),
+        OsString::from("--rsync-path=/opt/custom/rsync"),
+        source.clone().into_os_string(),
+        dest.clone().into_os_string(),
+    ]);
+
+    assert_eq!(code, 1);
+    assert!(stdout.is_empty());
+    let message = String::from_utf8(stderr).expect("stderr utf8");
+    assert!(message.contains("the --rsync-path option may only be used with remote connections"));
+    assert!(!dest.exists());
+}


### PR DESCRIPTION
## Summary
- treat --rsync-path as a remote-only flag based on the presence of remote operands rather than fallback usage
- align batch-only workflows with upstream by rejecting rsync-path when no remote targets are present
- add a regression test covering batch mode without remote operands

## Testing
- cargo test -p cli rsync_path -- --nocapture

------
[Codex Task](