### PR TITLE
Align xtask test command targets

### DIFF
--- a/xtask/src/commands/test.rs
+++ b/xtask/src/commands/test.rs
@@ -3,14 +3,20 @@ use crate::util::{is_help_flag, run_cargo_tool};
 use std::ffi::OsString;
 use std::path::Path;
 
-const NEXTEST_ARGS: &[&str] = &["nextest", "run", "--workspace", "--all-features"];
-const NEXTEST_DISPLAY: &str = "cargo nextest run --workspace --all-features";
+const NEXTEST_ARGS: &[&str] = &[
+    "nextest",
+    "run",
+    "--workspace",
+    "--all-targets",
+    "--all-features",
+];
+const NEXTEST_DISPLAY: &str = "cargo nextest run --workspace --all-targets --all-features";
 const NEXTEST_INSTALL_COMMAND: &str = "cargo install cargo-nextest --locked";
 const NEXTEST_INSTALL_HINT: &str =
     "install cargo-nextest with `cargo install cargo-nextest --locked`";
 
-const CARGO_TEST_ARGS: &[&str] = &["test", "--workspace", "--all-features"];
-const CARGO_TEST_DISPLAY: &str = "cargo test --workspace --all-features";
+const CARGO_TEST_ARGS: &[&str] = &["test", "--workspace", "--all-targets", "--all-features"];
+const CARGO_TEST_DISPLAY: &str = "cargo test --workspace --all-targets --all-features";
 const CARGO_TEST_INSTALL_HINT: &str = "install Rust and cargo from https://rustup.rs";
 
 /// Options accepted by the `test` command.


### PR DESCRIPTION
## Summary
- ensure `cargo xtask test` invokes cargo-nextest and cargo test with `--all-targets` to match documented guidance
- keep test/fallback messaging aligned with the updated commands

## Testing
- cargo test -p xtask --all-features

------
[Codex Task](