### PR TITLE
Add server config builder and server invocation parsing

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -16,6 +16,8 @@ pub mod client;
 pub mod fallback;
 /// Message formatting utilities shared across workspace binaries.
 pub mod message;
+/// Server orchestration helpers consumed by CLI and embedding entry points.
+pub mod server;
 /// Version constants and capability helpers used by CLI and daemon entry points.
 pub mod version;
 /// Workspace metadata derived from the repository `Cargo.toml`.

--- a/crates/core/src/server/config.rs
+++ b/crates/core/src/server/config.rs
@@ -1,0 +1,43 @@
+//! Server configuration derived from the compact flag string and trailing arguments.
+
+use std::ffi::OsString;
+
+use protocol::ProtocolVersion;
+
+use super::role::ServerRole;
+
+/// Configuration supplied to the server entry point.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct ServerConfig {
+    /// Server-side role negotiated via `--server` / `--sender`.
+    pub role: ServerRole,
+    /// Requested protocol version; capped during handshake.
+    pub protocol: ProtocolVersion,
+    /// Raw compact flag string provided by the client.
+    pub flag_string: String,
+    /// Remaining positional arguments passed to the server.
+    pub args: Vec<OsString>,
+}
+
+impl ServerConfig {
+    /// Builds a [`ServerConfig`] from the compact flag string and positional arguments.
+    ///
+    /// The parser mirrors upstream rsync expectations by rejecting empty flag strings
+    /// so obvious misuse surfaces before any protocol negotiation occurs.
+    pub fn from_flag_string_and_args(
+        role: ServerRole,
+        flag_string: String,
+        args: Vec<OsString>,
+    ) -> Result<Self, String> {
+        if flag_string.trim().is_empty() {
+            return Err("missing rsync server flag string".to_string());
+        }
+
+        Ok(Self {
+            role,
+            protocol: ProtocolVersion::NEWEST,
+            flag_string,
+            args,
+        })
+    }
+}

--- a/crates/core/src/server/mod.rs
+++ b/crates/core/src/server/mod.rs
@@ -1,0 +1,10 @@
+//! Server orchestration entry points mirroring the client facade.
+
+mod config;
+mod role;
+
+pub use self::config::ServerConfig;
+pub use self::role::ServerRole;
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/server/role.rs
+++ b/crates/core/src/server/role.rs
@@ -1,0 +1,10 @@
+//! Server roles negotiated through the `--server` entry point.
+
+/// Enumerates the server-side pipeline roles.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum ServerRole {
+    /// Receives data from the client and applies it to the local filesystem.
+    Receiver,
+    /// Generates file lists and delta streams to send back to the client.
+    Generator,
+}

--- a/crates/core/src/server/tests.rs
+++ b/crates/core/src/server/tests.rs
@@ -1,0 +1,26 @@
+use std::ffi::OsString;
+
+use super::{ServerConfig, ServerRole};
+
+#[test]
+fn config_rejects_empty_flag_string() {
+    let result =
+        ServerConfig::from_flag_string_and_args(ServerRole::Receiver, String::new(), Vec::new());
+
+    assert!(result.is_err());
+}
+
+#[test]
+fn config_captures_fields() {
+    let args = vec![OsString::from("."), OsString::from("dest")];
+    let config = ServerConfig::from_flag_string_and_args(
+        ServerRole::Generator,
+        "-logDtpre.iLsfxC".to_string(),
+        args.clone(),
+    )
+    .expect("config parses");
+
+    assert_eq!(config.role, ServerRole::Generator);
+    assert_eq!(config.flag_string, "-logDtpre.iLsfxC");
+    assert_eq!(config.args, args);
+}


### PR DESCRIPTION
## Summary
- add a new `core::server` module with server roles/configuration validation and basic tests
- parse `--server` invocations in the CLI and translate them into server configurations before deferring to the fallback binary
- add CLI unit tests that exercise receiver and sender parsing paths along with error handling for missing flag strings

## Testing
- cargo test -p core config_captures_fields
- cargo test -p cli parses_receiver_invocation_and_normalises_dot_placeholder
- cargo test -p cli parses_sender_invocation_without_placeholder
- cargo test -p cli parse_rejects_missing_flag_string

------
[Codex Task](