### PR TITLE
Handle server fallback exit codes

### DIFF
--- a/crates/cli/src/frontend/tests/server.rs
+++ b/crates/cli/src/frontend/tests/server.rs
@@ -94,6 +94,53 @@ exit 0
 
 #[cfg(unix)]
 #[test]
+fn server_mode_maps_signal_exit_status() {
+    use std::fs;
+    use std::io;
+    use std::os::unix::fs::PermissionsExt;
+    use tempfile::tempdir;
+
+    let _env_lock = ENV_LOCK.lock().expect("env lock");
+
+    let temp = tempdir().expect("tempdir");
+    let script_path = temp.path().join("server_signal.sh");
+
+    fs::write(
+        &script_path,
+        r#"#!/bin/sh
+set -eu
+kill -TERM $$
+"#,
+    )
+    .expect("write script");
+
+    let mut perms = fs::metadata(&script_path)
+        .expect("script metadata")
+        .permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(&script_path, perms).expect("set script perms");
+
+    let _fallback_guard = EnvGuard::set(CLIENT_FALLBACK_ENV, script_path.as_os_str());
+
+    let mut stdout = io::sink();
+    let mut stderr = io::sink();
+    let exit_code = run(
+        [
+            OsString::from(RSYNC),
+            OsString::from("--server"),
+            OsString::from("--sender"),
+            OsString::from("."),
+            OsString::from("dest"),
+        ],
+        &mut stdout,
+        &mut stderr,
+    );
+
+    assert_eq!(exit_code, 143);
+}
+
+#[cfg(unix)]
+#[test]
 fn server_mode_reports_disabled_fallback_override() {
     use std::io;
 


### PR DESCRIPTION
## Summary
- normalize `--server` fallback exit handling to report signal-based codes like upstream
- cover the signal termination path with an explicit server-mode regression test

## Testing
- cargo test -p cli server_mode
- cargo fmt --all

------
[Codex Task](