### PR TITLE
Guard --server entrypoint against literal operands

### DIFF
--- a/crates/cli/src/frontend/server.rs
+++ b/crates/cli/src/frontend/server.rs
@@ -55,7 +55,7 @@ pub(crate) fn daemon_mode_arguments(args: &[OsString]) -> Option<Vec<OsString>> 
 
 /// Returns `true` when the invocation requests server mode.
 pub(crate) fn server_mode_requested(args: &[OsString]) -> bool {
-    args.iter().skip(1).any(|arg| arg == "--server")
+    matches!(args.get(1), Some(arg) if arg == "--server")
 }
 
 /// Delegates execution to the daemon front-end (Unix) or reports that daemon

--- a/crates/cli/src/frontend/tests/server.rs
+++ b/crates/cli/src/frontend/tests/server.rs
@@ -182,3 +182,46 @@ fn server_mode_rejects_recursive_fallback() {
     assert!(stderr_text.contains("resolves to this oc-rsync executable"));
     assert_contains_server_trailer(&stderr_text);
 }
+
+#[test]
+fn server_mode_ignores_flag_after_double_dash() {
+    use std::io;
+    use tempfile::tempdir;
+
+    let _env_lock = ENV_LOCK.lock().expect("env lock");
+
+    let temp = tempdir().expect("tempdir");
+    let script_path = temp.path().join("server_marker.sh");
+    let marker_path = temp.path().join("marker.txt");
+
+    let script = r#"#!/bin/sh
+set -eu
+printf 'invoked' > "$SERVER_MARKER"
+exit 5
+"#;
+
+    write_executable_script(&script_path, script);
+
+    let _fallback_guard = EnvGuard::set(CLIENT_FALLBACK_ENV, script_path.as_os_str());
+    let _marker_guard = EnvGuard::set("SERVER_MARKER", marker_path.as_os_str());
+
+    let mut stdout = io::sink();
+    let mut stderr = io::sink();
+    let exit_code = run(
+        [
+            OsString::from(RSYNC),
+            OsString::from("--"),
+            OsString::from("--server"),
+            OsString::from("source"),
+            OsString::from("dest"),
+        ],
+        &mut stdout,
+        &mut stderr,
+    );
+
+    assert!(
+        !marker_path.exists(),
+        "fallback script should not be invoked"
+    );
+    assert_ne!(exit_code, 5);
+}


### PR DESCRIPTION
## Summary
- limit `--server` mode activation to invocations where it appears as the first argument after the program name, matching upstream expectations
- add regression coverage to ensure literal `--server` operands after a `--` terminator do not trigger fallback execution

## Testing
- cargo test -p cli server_mode

------
[Codex Task](