### PR TITLE
Use exec for --server fallback and add integration test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,6 +125,7 @@ dependencies = [
  "daemon",
  "libc",
  "openssl",
+ "tempfile",
  "windows-gnu-eh",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ core = { path = "crates/core" }
 assert_cmd = "2.0"
 core = { path = "crates/core" }
 libc = "0.2"
+tempfile = "3.10"
 
 # Windows-wide deps (applies to MSVC and GNU toolchains)
 [target.'cfg(windows)'.dependencies]


### PR DESCRIPTION
## Summary
- replace the local proxy for `--server` invocations with an exec on Unix to align behaviour with upstream rsync
- factor fallback resolution and gate server proxy helpers to target platforms
- add an integration test covering the exec path for the server fallback and include tempfile for test setup

## Testing
- cargo test --test cli_binaries -- server_entry_execs_fallback_binary

------
[Codex Task](