### PR TITLE
Handle server fallback via exec with optional proxy

### DIFF
--- a/crates/cli/src/frontend/tests/server.rs
+++ b/crates/cli/src/frontend/tests/server.rs
@@ -1,11 +1,11 @@
 use super::common::*;
 use super::*;
+use crate::frontend::server::SERVER_PROXY_ENV;
 
 #[cfg(unix)]
 #[test]
 fn server_mode_invokes_fallback_binary() {
     use std::fs;
-    use std::io;
     use std::os::unix::fs::PermissionsExt;
     use tempfile::tempdir;
 
@@ -32,11 +32,12 @@ exit 37
     perms.set_mode(0o755);
     fs::set_permissions(&script_path, perms).expect("set script perms");
 
+    let _proxy_guard = EnvGuard::set(SERVER_PROXY_ENV, OsStr::new("1"));
     let _fallback_guard = EnvGuard::set(CLIENT_FALLBACK_ENV, script_path.as_os_str());
     let _marker_guard = EnvGuard::set("SERVER_MARKER", marker_path.as_os_str());
 
-    let mut stdout = io::sink();
-    let mut stderr = io::sink();
+    let mut stdout = Vec::new();
+    let mut stderr = Vec::new();
     let exit_code = run(
         [
             OsString::from(RSYNC),
@@ -71,6 +72,7 @@ exit 0
 "#;
     write_executable_script(&script_path, script);
 
+    let _proxy_guard = EnvGuard::set(SERVER_PROXY_ENV, OsStr::new("1"));
     let _fallback_guard = EnvGuard::set(CLIENT_FALLBACK_ENV, script_path.as_os_str());
 
     let mut stdout = Vec::new();


### PR DESCRIPTION
## Summary
- exec the upstream fallback binary for `--server` on Unix while keeping a proxy fallback path gated by `OC_RSYNC_SERVER_PROXY`
- adjust server fallback handling to accept path buffers and share the proxy implementation across platforms
- update server-mode tests to exercise the proxy path without requiring the binary to exec

## Testing
- cargo test --package cli server_mode -- --nocapture

------
[Codex Task](