### PR TITLE
Align CLI and daemon diagnostics with exit code strings

### DIFF
--- a/crates/cli/src/frontend/execution/operands.rs
+++ b/crates/cli/src/frontend/execution/operands.rs
@@ -4,7 +4,7 @@ use std::net::{IpAddr, SocketAddr, ToSocketAddrs};
 
 use core::{
     client::BindAddress,
-    message::{Message, Role},
+    message::{Message, Role, strings},
     rsync_error,
 };
 
@@ -24,7 +24,9 @@ impl UnsupportedOption {
         let text = format!(
             "unknown option '{option}': this build currently supports only {SUPPORTED_OPTIONS_LIST}"
         );
-        rsync_error!(1, text).with_role(Role::Client)
+        strings::exit_code_message_with_detail(1, text.clone())
+            .unwrap_or_else(|| rsync_error!(1, text))
+            .with_role(Role::Client)
     }
 
     pub(crate) fn fallback_text(&self) -> String {

--- a/crates/cli/src/frontend/mod.rs
+++ b/crates/cli/src/frontend/mod.rs
@@ -95,7 +95,7 @@ pub(crate) use core::client::*;
 pub(crate) use core::version::VersionInfoReport;
 use core::{
     branding::Brand,
-    message::{Message, Role},
+    message::{Message, Role, strings},
     rsync_error,
 };
 use execution::execute;
@@ -303,7 +303,8 @@ where
             }
         }
         Err(error) => {
-            let mut message = rsync_error!(1, "{}", error);
+            let mut message = strings::exit_code_message_with_detail(1, error.to_string())
+                .unwrap_or_else(|| rsync_error!(1, "{}", error));
             message = message.with_role(Role::Client);
             if write_message(&message, &mut stderr_sink).is_err() {
                 let _ = writeln!(stderr_sink.writer_mut(), "{error}");

--- a/crates/cli/src/frontend/tests/run.rs
+++ b/crates/cli/src/frontend/tests/run.rs
@@ -24,6 +24,23 @@ fn run_reports_invalid_chmod_specification() {
 }
 
 #[test]
+fn clap_error_uses_canonical_exit_code_text() {
+    let (code, _stdout, stderr) = run_with_args([
+        OsString::from(OC_RSYNC),
+        OsString::from("--definitely-invalid-option"),
+    ]);
+
+    assert_eq!(code, 1);
+
+    let rendered = String::from_utf8(stderr).expect("diagnostic utf8");
+    assert!(rendered.contains("syntax or usage error"));
+    assert!(
+        rendered.contains("--definitely-invalid-option"),
+        "diagnostic should include the clap-provided detail"
+    );
+}
+
+#[test]
 fn run_without_operands_emits_usage_for_oc_rsync() {
     let (code, stdout, stderr) = run_with_args([OsString::from(OC_RSYNC)]);
 

--- a/crates/core/src/message/strings.rs
+++ b/crates/core/src/message/strings.rs
@@ -184,6 +184,37 @@ fn message_from_template(template: ExitCodeMessage) -> Message {
     Message::new(template.severity, template.text).with_code(template.code)
 }
 
+/// Returns the canonical template for the provided exit code while prefixing it with
+/// the supplied detail text.
+///
+/// This helper preserves the upstream wording associated with the exit code and
+/// appends a caller-provided description. It mirrors the style of rsync's
+/// diagnostics, which start with the stock `rerr_names` text and then include
+/// contextual details about the failure.
+///
+/// # Examples
+///
+/// ```
+/// use core::message::strings::exit_code_message_with_detail;
+///
+/// let message = exit_code_message_with_detail(1, "unrecognised flag --bad")
+///     .expect("exit code 1 is defined");
+///
+/// assert_eq!(message.code(), Some(1));
+/// assert!(message.text().starts_with("syntax or usage error: "));
+/// assert!(message.text().contains("unrecognised flag --bad"));
+/// ```
+#[must_use]
+pub fn exit_code_message_with_detail(code: i32, detail: impl Into<String>) -> Option<Message> {
+    exit_code_message(code).map(|template| {
+        Message::new(
+            template.severity(),
+            format!("{}: {}", template.text(), detail.into()),
+        )
+        .with_code(template.code())
+    })
+}
+
 /// Returns the canonical template for the provided exit code, if known.
 ///
 /// # Examples

--- a/crates/core/src/message/tests/part1.rs
+++ b/crates/core/src/message/tests/part1.rs
@@ -1,3 +1,5 @@
+use crate::message::strings;
+
 #[test]
 fn message_scratch_with_thread_local_borrows_shared_buffer() {
     let len = MessageScratch::with_thread_local(|scratch| {
@@ -79,6 +81,22 @@ fn message_from_exit_code_returns_none_for_unknown_values() {
             "unexpected mapping for {code}"
         );
     }
+}
+
+#[test]
+fn exit_code_message_with_detail_includes_canonical_text() {
+    let message = strings::exit_code_message_with_detail(1, "unrecognised flag --bad")
+        .expect("exit code 1 should be defined");
+
+    assert_eq!(message.code(), Some(1));
+    assert!(
+        message.text().starts_with("syntax or usage error: "),
+        "message should reuse the canonical exit-code wording"
+    );
+    assert!(
+        message.text().contains("unrecognised flag --bad"),
+        "detail text should be appended"
+    );
 }
 
 #[test]

--- a/crates/daemon/src/tests/chunks/clap_parse_error_is_reported_via_message.rs
+++ b/crates/daemon/src/tests/chunks/clap_parse_error_is_reported_via_message.rs
@@ -17,5 +17,6 @@ fn clap_parse_error_is_reported_via_message() {
     assert!(stdout.is_empty());
 
     let rendered = String::from_utf8(stderr).expect("diagnostic is valid UTF-8");
+    assert!(rendered.contains("syntax or usage error"));
     assert!(rendered.contains(error.to_string().trim()));
 }


### PR DESCRIPTION
## Summary
- add a helper for composing exit-code diagnostics that reuse the canonical `rerr_names` text
- route CLI and daemon parse/delegation errors through the centralized exit-code strings, preserving detailed context
- update tests to assert the canonical wording is present in client and daemon parse errors

## Testing
- cargo test

------
[Codex Task](