### PR TITLE
Reduce nextest verbosity

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,3 +1,6 @@
 # Nextest defaults: keep full workspace filter while relying on CLI flags for package selection.
 [profile.default]
 default-filter = "all()"
+status-level = "fail"
+final-status-level = "fail"
+failure-output = "immediate-final"


### PR DESCRIPTION
## Summary
- set the default nextest profile to only surface failing tests and immediate failure output to reduce log noise during full runs

## Testing
- cargo nextest list --all-features --workspace --profile default --config-file .config/nextest.toml --list-type binaries-only

------
[Codex Task](