### PR TITLE
Handle empty PATH when resolving fallback binaries

### DIFF
--- a/crates/core/src/fallback/binary/candidates.rs
+++ b/crates/core/src/fallback/binary/candidates.rs
@@ -106,14 +106,12 @@ fn effective_path_env() -> Option<OsString> {
 
 fn read_path_env() -> Option<OsString> {
     #[cfg(windows)]
-    {
-        env::var_os("PATH").or_else(|| env::var_os("Path"))
-    }
+    let path = env::var_os("PATH").or_else(|| env::var_os("Path"));
 
     #[cfg(not(windows))]
-    {
-        env::var_os("PATH")
-    }
+    let path = env::var_os("PATH");
+
+    path.and_then(|value| if value.is_empty() { None } else { Some(value) })
 }
 
 #[cfg(unix)]

--- a/crates/core/src/fallback/binary/tests.rs
+++ b/crates/core/src/fallback/binary/tests.rs
@@ -143,6 +143,22 @@ fn fallback_binary_candidates_use_default_path_when_path_missing() {
 }
 
 #[test]
+fn fallback_binary_candidates_use_default_path_when_path_empty() {
+    let _lock = env_lock().lock().expect("env lock");
+    let _guard = EnvGuard::set_os("PATH", OsStr::new(""));
+
+    #[cfg(windows)]
+    let _pathext_guard = EnvGuard::set("PATHEXT", ".exe");
+
+    let candidates = fallback_binary_candidates(OsStr::new("rsync"));
+
+    assert!(
+        candidates.iter().all(|candidate| candidate.is_absolute()),
+        "empty PATH should fall back to the default search path instead of the current directory: {candidates:?}",
+    );
+}
+
+#[test]
 fn fallback_binary_path_resolves_executable() {
     #[allow(unused_mut)]
     let mut temp = NamedTempFile::new().expect("tempfile");


### PR DESCRIPTION
## Summary
- treat an empty PATH as unset so fallback binary resolution falls back to the default search path
- add a regression test confirming empty PATH candidates stay within the default locations rather than the current directory

## Testing
- cargo test -p core fallback_binary_candidates_use_default_path_when_path_empty

------
[Codex Task](