### PR TITLE
Centralize test environment guards for xtask tests

### DIFF
--- a/xtask/src/commands/package/tests.rs
+++ b/xtask/src/commands/package/tests.rs
@@ -6,6 +6,7 @@ use super::tarball::{TarballPlatform, TarballSpec};
 
 use super::{DIST_PROFILE, PackageOptions, execute};
 use crate::error::TaskError;
+use crate::util::test_env::EnvGuard;
 use std::env;
 use std::ffi::{OsStr, OsString};
 use std::path::{Path, PathBuf};
@@ -20,65 +21,22 @@ fn workspace_root() -> &'static Path {
     })
 }
 
-fn env_lock() -> &'static std::sync::Mutex<()> {
-    static LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
-    LOCK.get_or_init(|| std::sync::Mutex::new(()))
+type ScopedEnv = EnvGuard;
+
+fn scoped_env(keys: &[&'static str]) -> ScopedEnv {
+    let mut guard = EnvGuard::new();
+    for key in keys {
+        guard.track(*key);
+    }
+    guard
 }
 
-struct ScopedEnv {
-    previous: Vec<(&'static str, Option<OsString>)>,
-    _lock: std::sync::MutexGuard<'static, ()>,
+fn set_os(env: &mut ScopedEnv, key: &'static str, value: &OsStr) {
+    env.set(key, value);
 }
 
-impl ScopedEnv {
-    fn new(keys: &[&'static str]) -> Self {
-        let lock = env_lock().lock().unwrap();
-        let mut previous = Vec::with_capacity(keys.len());
-        for key in keys {
-            previous.push((*key, env::var_os(key)));
-        }
-        Self {
-            previous,
-            _lock: lock,
-        }
-    }
-
-    fn ensure_tracked(&mut self, key: &'static str) {
-        if self.previous.iter().any(|(existing, _)| existing == &key) {
-            return;
-        }
-
-        self.previous.push((key, env::var_os(key)));
-    }
-
-    #[allow(unsafe_code)]
-    fn set_os(&mut self, key: &'static str, value: &OsStr) {
-        self.ensure_tracked(key);
-        unsafe {
-            env::set_var(key, value);
-        }
-    }
-
-    fn set_str(&mut self, key: &'static str, value: &str) {
-        self.set_os(key, OsStr::new(value));
-    }
-}
-
-impl Drop for ScopedEnv {
-    #[allow(unsafe_code)]
-    fn drop(&mut self) {
-        for (key, previous) in self.previous.drain(..).rev() {
-            if let Some(value) = previous {
-                unsafe {
-                    env::set_var(key, value);
-                }
-            } else {
-                unsafe {
-                    env::remove_var(key);
-                }
-            }
-        }
-    }
+fn set_str(env: &mut ScopedEnv, key: &'static str, value: &str) {
+    set_os(env, key, OsStr::new(value));
 }
 
 #[test]
@@ -98,12 +56,12 @@ fn execute_with_no_targets_returns_success() {
 
 #[test]
 fn execute_reports_missing_cargo_deb_tool() {
-    let mut env = ScopedEnv::new(&[
+    let mut env = scoped_env(&[
         "OC_RSYNC_PACKAGE_SKIP_BUILD",
         "OC_RSYNC_FORCE_MISSING_CARGO_TOOLS",
     ]);
-    env.set_str("OC_RSYNC_PACKAGE_SKIP_BUILD", "1");
-    env.set_str("OC_RSYNC_FORCE_MISSING_CARGO_TOOLS", "cargo deb");
+    set_str(&mut env, "OC_RSYNC_PACKAGE_SKIP_BUILD", "1");
+    set_str(&mut env, "OC_RSYNC_FORCE_MISSING_CARGO_TOOLS", "cargo deb");
     let error = execute(
         workspace_root(),
         PackageOptions {
@@ -123,20 +81,24 @@ fn execute_reports_missing_cargo_deb_tool() {
 
 #[test]
 fn execute_reports_missing_cargo_rpm_tool() {
-    let mut env = ScopedEnv::new(&[
+    let mut env = scoped_env(&[
         "OC_RSYNC_PACKAGE_SKIP_BUILD",
         "OC_RSYNC_FORCE_MISSING_CARGO_TOOLS",
         "PATH",
     ]);
-    env.set_str("OC_RSYNC_PACKAGE_SKIP_BUILD", "1");
-    env.set_str("OC_RSYNC_FORCE_MISSING_CARGO_TOOLS", "cargo rpm build");
+    set_str(&mut env, "OC_RSYNC_PACKAGE_SKIP_BUILD", "1");
+    set_str(
+        &mut env,
+        "OC_RSYNC_FORCE_MISSING_CARGO_TOOLS",
+        "cargo rpm build",
+    );
     let (fake_rpmbuild_dir, _fake_rpmbuild) = fake_rpmbuild_path();
     let mut path_entries = vec![fake_rpmbuild_dir.path().to_path_buf()];
     if let Some(existing) = env::var_os("PATH") {
         path_entries.extend(env::split_paths(&existing));
     }
     let joined_path = env::join_paths(path_entries).expect("compose PATH with fake rpmbuild");
-    env.set_os("PATH", joined_path.as_os_str());
+    set_os(&mut env, "PATH", joined_path.as_os_str());
     let error = execute(
         workspace_root(),
         PackageOptions {
@@ -156,12 +118,12 @@ fn execute_reports_missing_cargo_rpm_tool() {
 
 #[test]
 fn execute_reports_missing_rpmbuild_tool() {
-    let mut env = ScopedEnv::new(&[
+    let mut env = scoped_env(&[
         "OC_RSYNC_PACKAGE_SKIP_BUILD",
         "OC_RSYNC_FORCE_MISSING_CARGO_TOOLS",
     ]);
-    env.set_str("OC_RSYNC_PACKAGE_SKIP_BUILD", "1");
-    env.set_str("OC_RSYNC_FORCE_MISSING_CARGO_TOOLS", "rpmbuild");
+    set_str(&mut env, "OC_RSYNC_PACKAGE_SKIP_BUILD", "1");
+    set_str(&mut env, "OC_RSYNC_FORCE_MISSING_CARGO_TOOLS", "rpmbuild");
     let error = execute(
         workspace_root(),
         PackageOptions {
@@ -182,8 +144,9 @@ fn execute_reports_missing_rpmbuild_tool() {
 #[cfg(all(test, target_os = "linux"))]
 #[test]
 fn execute_reports_missing_cross_compiler() {
-    let mut env = ScopedEnv::new(&["OC_RSYNC_FORCE_MISSING_CARGO_TOOLS"]);
-    env.set_str(
+    let mut env = scoped_env(&["OC_RSYNC_FORCE_MISSING_CARGO_TOOLS"]);
+    set_str(
+        &mut env,
         "OC_RSYNC_FORCE_MISSING_CARGO_TOOLS",
         "aarch64-linux-gnu-gcc,zig",
     );
@@ -203,9 +166,9 @@ fn execute_reports_missing_cross_compiler() {
 #[test]
 fn cross_compiler_resolution_prefers_cross_gcc() {
     let (dir, _path) = fake_tool("aarch64-linux-gnu-gcc");
-    let mut env = ScopedEnv::new(&["PATH", "OC_RSYNC_FORCE_MISSING_CARGO_TOOLS"]);
+    let mut env = scoped_env(&["PATH", "OC_RSYNC_FORCE_MISSING_CARGO_TOOLS"]);
     prepend_path(&mut env, dir.path());
-    env.set_str("OC_RSYNC_FORCE_MISSING_CARGO_TOOLS", "zig");
+    set_str(&mut env, "OC_RSYNC_FORCE_MISSING_CARGO_TOOLS", "zig");
 
     let override_value =
         resolve_cross_compiler_for_tests(workspace_root(), "aarch64-unknown-linux-gnu")
@@ -223,9 +186,10 @@ fn cross_compiler_resolution_prefers_cross_gcc() {
 #[test]
 fn cross_compiler_resolution_falls_back_to_zig() {
     let (dir, _path) = fake_tool("zig");
-    let mut env = ScopedEnv::new(&["PATH", "OC_RSYNC_FORCE_MISSING_CARGO_TOOLS"]);
+    let mut env = scoped_env(&["PATH", "OC_RSYNC_FORCE_MISSING_CARGO_TOOLS"]);
     prepend_path(&mut env, dir.path());
-    env.set_str(
+    set_str(
+        &mut env,
         "OC_RSYNC_FORCE_MISSING_CARGO_TOOLS",
         "aarch64-linux-gnu-gcc",
     );
@@ -248,8 +212,9 @@ fn cross_compiler_resolution_falls_back_to_zig() {
 #[cfg(all(test, target_os = "linux"))]
 #[test]
 fn tarball_resolution_skips_targets_without_cross_tooling() {
-    let mut env = ScopedEnv::new(&["OC_RSYNC_FORCE_MISSING_CARGO_TOOLS"]);
-    env.set_str(
+    let mut env = scoped_env(&["OC_RSYNC_FORCE_MISSING_CARGO_TOOLS"]);
+    set_str(
+        &mut env,
         "OC_RSYNC_FORCE_MISSING_CARGO_TOOLS",
         "aarch64-linux-gnu-gcc,zig",
     );
@@ -360,7 +325,7 @@ fn prepend_path(env: &mut ScopedEnv, directory: &Path) {
         path_entries.extend(env::split_paths(&existing));
     }
     let joined = env::join_paths(path_entries).expect("compose PATH");
-    env.set_os("PATH", joined.as_os_str());
+    set_os(env, "PATH", joined.as_os_str());
 }
 
 #[cfg(all(test, target_os = "linux"))]

--- a/xtask/src/commands/test.rs
+++ b/xtask/src/commands/test.rs
@@ -121,61 +121,10 @@ Options:\\n  --use-cargo-test    Force running cargo test even when cargo-nextes
 mod tests {
     use super::*;
     use crate::error::TaskError;
+    use crate::util::test_env::EnvGuard;
     use crate::workspace::workspace_root;
-    use std::env;
 
     const FORCE_MISSING_ENV: &str = "OC_RSYNC_FORCE_MISSING_CARGO_TOOLS";
-
-    struct EnvGuard {
-        key: &'static str,
-        previous: Option<OsString>,
-    }
-
-    impl EnvGuard {
-        fn set(key: &'static str, value: &str) -> Self {
-            let previous = env::var_os(key);
-            set_env_var(key, value);
-            Self { key, previous }
-        }
-    }
-
-    impl Drop for EnvGuard {
-        fn drop(&mut self) {
-            if let Some(previous) = self.previous.take() {
-                set_env_var(self.key, &previous);
-            } else {
-                remove_env_var(self.key);
-            }
-        }
-    }
-
-    #[allow(unsafe_code)]
-    fn set_env_var<K: AsRef<std::ffi::OsStr>, V: AsRef<std::ffi::OsStr>>(key: K, value: V) {
-        // SAFETY: These helpers are only used in tests to temporarily override process
-        // environment variables. The test harness serializes each invocation, so scoped
-        // mutations are safe for the duration of the test.
-        unsafe {
-            env::set_var(key, value);
-        }
-    }
-
-    #[allow(unsafe_code)]
-    fn remove_env_var<K: AsRef<std::ffi::OsStr>>(key: K) {
-        // SAFETY: These helpers are only used in tests to temporarily override process
-        // environment variables. The test harness serializes each invocation, so scoped
-        // mutations are safe for the duration of the test.
-        unsafe {
-            env::remove_var(key);
-        }
-    }
-
-    fn guard_cargo(value: &str) -> EnvGuard {
-        EnvGuard::set("CARGO", value)
-    }
-
-    fn guard_force_missing(value: &str) -> EnvGuard {
-        EnvGuard::set(FORCE_MISSING_ENV, value)
-    }
 
     #[test]
     fn parse_args_accepts_default_configuration() {
@@ -209,15 +158,17 @@ mod tests {
 
     #[test]
     fn execute_prefers_nextest_when_available() {
-        let _cargo = guard_cargo("true");
+        let mut env = EnvGuard::new();
+        env.set("CARGO", "true");
         let workspace = workspace_root().expect("workspace root");
         execute(workspace.as_path(), TestOptions::default()).expect("nextest invocation succeeds");
     }
 
     #[test]
     fn execute_falls_back_when_nextest_missing() {
-        let _cargo = guard_cargo("true");
-        let _missing = guard_force_missing(NEXTEST_DISPLAY);
+        let mut env = EnvGuard::new();
+        env.set("CARGO", "true");
+        env.set(FORCE_MISSING_ENV, NEXTEST_DISPLAY);
         let workspace = workspace_root().expect("workspace root");
         execute(workspace.as_path(), TestOptions::default()).expect("fallback succeeds");
     }
@@ -234,8 +185,9 @@ mod tests {
 
     #[test]
     fn execute_honours_force_cargo_test_flag() {
-        let _cargo = guard_cargo("true");
-        let _missing = guard_force_missing(NEXTEST_DISPLAY);
+        let mut env = EnvGuard::new();
+        env.set("CARGO", "true");
+        env.set(FORCE_MISSING_ENV, NEXTEST_DISPLAY);
         let workspace = workspace_root().expect("workspace root");
         execute(
             workspace.as_path(),
@@ -249,8 +201,9 @@ mod tests {
 
     #[test]
     fn execute_attempts_install_when_requested() {
-        let _cargo = guard_cargo("true");
-        let _missing = guard_force_missing(NEXTEST_DISPLAY);
+        let mut env = EnvGuard::new();
+        env.set("CARGO", "true");
+        env.set(FORCE_MISSING_ENV, NEXTEST_DISPLAY);
         let workspace = workspace_root().expect("workspace root");
 
         execute(

--- a/xtask/src/util/env.rs
+++ b/xtask/src/util/env.rs
@@ -30,24 +30,17 @@ pub(crate) fn tool_missing_error(display: &str, install_hint: &str) -> TaskError
 #[cfg(test)]
 mod tests {
     use super::{FORCE_MISSING_ENV, should_simulate_missing_tool};
+    use crate::util::test_env::EnvGuard;
     #[test]
     fn simulation_checks_match_exact_entries() {
-        #[allow(unsafe_code)]
-        unsafe {
-            std::env::remove_var(FORCE_MISSING_ENV);
-        }
+        let mut env = EnvGuard::new();
+        env.remove(FORCE_MISSING_ENV);
         assert!(!should_simulate_missing_tool("cargo fmt"));
 
-        #[allow(unsafe_code)]
-        unsafe {
-            std::env::set_var(FORCE_MISSING_ENV, "cargo fmt,git status");
-        }
+        env.set(FORCE_MISSING_ENV, "cargo fmt,git status");
         assert!(should_simulate_missing_tool("cargo fmt"));
         assert!(should_simulate_missing_tool("git status"));
         assert!(!should_simulate_missing_tool("cargo"));
-        #[allow(unsafe_code)]
-        unsafe {
-            std::env::remove_var(FORCE_MISSING_ENV);
-        }
+        env.remove(FORCE_MISSING_ENV);
     }
 }

--- a/xtask/src/util/mod.rs
+++ b/xtask/src/util/mod.rs
@@ -10,6 +10,8 @@ mod env;
 mod filesystem;
 mod git;
 mod limits;
+#[cfg(test)]
+pub mod test_env;
 
 pub use cargo::cargo_metadata_json;
 pub use commands::{

--- a/xtask/src/util/test_env.rs
+++ b/xtask/src/util/test_env.rs
@@ -1,0 +1,81 @@
+use std::env;
+use std::ffi::{OsStr, OsString};
+use std::sync::{Mutex, MutexGuard, OnceLock};
+
+fn env_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+/// Scoped environment guard for test-only mutations.
+#[cfg(test)]
+pub(crate) struct EnvGuard {
+    entries: Vec<(&'static str, Option<OsString>)>,
+    _lock: MutexGuard<'static, ()>,
+}
+
+#[cfg(test)]
+impl EnvGuard {
+    /// Acquires the global environment lock and prepares to track mutations.
+    pub(crate) fn new() -> Self {
+        Self {
+            entries: Vec::new(),
+            _lock: env_lock().lock().expect("env lock poisoned"),
+        }
+    }
+
+    /// Records the current value of an environment variable without mutating it.
+    pub(crate) fn track(&mut self, key: &'static str) {
+        if self.entries.iter().any(|(existing, _)| existing == &key) {
+            return;
+        }
+
+        self.entries.push((key, env::var_os(key)));
+    }
+
+    /// Sets an environment variable, recording its previous value for restoration.
+    #[allow(unsafe_code)]
+    pub(crate) fn set(&mut self, key: &'static str, value: impl AsRef<OsStr>) {
+        if self.entries.iter().all(|(existing, _)| existing != &key) {
+            self.entries.push((key, env::var_os(key)));
+        }
+
+        // SAFETY: Environment mutations are serialized by the global lock, and the
+        // previous value is restored when the guard drops.
+        unsafe {
+            env::set_var(key, value);
+        }
+    }
+
+    /// Removes an environment variable while preserving its prior value.
+    #[allow(unsafe_code)]
+    pub(crate) fn remove(&mut self, key: &'static str) {
+        if self.entries.iter().all(|(existing, _)| existing != &key) {
+            self.entries.push((key, env::var_os(key)));
+        }
+
+        // SAFETY: Environment mutations are serialized by the global lock, and the
+        // previous value is restored when the guard drops.
+        unsafe {
+            env::remove_var(key);
+        }
+    }
+}
+
+#[cfg(test)]
+impl Drop for EnvGuard {
+    #[allow(unsafe_code)]
+    fn drop(&mut self) {
+        for (key, previous) in self.entries.drain(..).rev() {
+            if let Some(value) = previous {
+                unsafe {
+                    env::set_var(key, value);
+                }
+            } else {
+                unsafe {
+                    env::remove_var(key);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a shared EnvGuard helper to serialize environment mutations during tests and restore previous values
- migrate xtask test suites to use EnvGuard instead of ad-hoc environment handling

## Testing
- cargo fmt --all
- cargo test --all-features --workspace

------
[Codex Task](