### PR TITLE
Add helper script for installing cargo-nextest

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,9 @@ AGENTS.md               # Internal agent roles & conventions
   cargo install cargo-nextest --locked
   ```
 
+  A helper script (`scripts/install-nextest.sh`) installs the locked
+  dependency set for environments that don't have a recent toolchain.
+
 * [`cargo-llvm-cov`](https://github.com/taiki-e/cargo-llvm-cov) if you want to
   generate coverage reports locally.
 

--- a/scripts/install-nextest.sh
+++ b/scripts/install-nextest.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if command -v cargo-nextest >/dev/null 2>&1; then
+    echo "cargo-nextest already installed: $(cargo-nextest --version)"
+    exit 0
+fi
+
+echo "Installing cargo-nextest with locked dependencies..."
+cargo install cargo-nextest --locked
+


### PR DESCRIPTION
## Summary
- add a helper script to install cargo-nextest with locked dependencies
- document the helper in the README testing prerequisites

## Testing
- not run (documentation and developer tooling only)

------
[Codex Task](