### PR TITLE
Add sparse copy coverage for zeroed sources

### DIFF
--- a/crates/cli/src/frontend/tests/transfer_request_with_sparse.rs
+++ b/crates/cli/src/frontend/tests/transfer_request_with_sparse.rs
@@ -58,6 +58,54 @@ fn transfer_request_with_sparse_preserves_holes() {
 
 #[cfg(unix)]
 #[test]
+fn transfer_request_with_sparse_copies_all_zero_source_without_extra_blocks() {
+    use std::os::unix::fs::MetadataExt;
+    use tempfile::tempdir;
+
+    let tmp = tempdir().expect("tempdir");
+    let source = tmp.path().join("zeros.bin");
+    let mut source_file = std::fs::File::create(&source).expect("create source");
+    let payload = vec![0u8; 2 * 1024 * 1024];
+    source_file.write_all(&payload).expect("write zero payload");
+
+    let dense_dest = tmp.path().join("dense.bin");
+    let sparse_dest = tmp.path().join("sparse.bin");
+
+    let (code, stdout, stderr) = run_with_args([
+        OsString::from(RSYNC),
+        source.clone().into_os_string(),
+        dense_dest.clone().into_os_string(),
+    ]);
+    assert_eq!(code, 0);
+    assert!(stdout.is_empty());
+    assert!(stderr.is_empty());
+
+    let (code, stdout, stderr) = run_with_args([
+        OsString::from(RSYNC),
+        OsString::from("--sparse"),
+        source.into_os_string(),
+        sparse_dest.clone().into_os_string(),
+    ]);
+    assert_eq!(code, 0);
+    assert!(stdout.is_empty());
+    assert!(stderr.is_empty());
+
+    let dense_meta = std::fs::metadata(&dense_dest).expect("dense metadata");
+    let sparse_meta = std::fs::metadata(&sparse_dest).expect("sparse metadata");
+
+    assert_eq!(dense_meta.len(), sparse_meta.len());
+
+    let dense_blocks = dense_meta.blocks();
+    let sparse_blocks = sparse_meta.blocks();
+
+    assert!(
+        sparse_blocks <= dense_blocks,
+        "sparse copy must not use more blocks than dense copy (sparse={sparse_blocks}, dense={dense_blocks})",
+    );
+}
+
+#[cfg(unix)]
+#[test]
 fn transfer_request_with_sparse_and_preallocate_allocates_dense() {
     use std::os::unix::fs::MetadataExt;
     use tempfile::tempdir;


### PR DESCRIPTION
## Summary
- add a CLI sparse-transfer test covering all-zero sources to ensure block usage doesn’t exceed dense copies

## Testing
- cargo test --all-features --workspace transfer_request_with_sparse_copies_all_zero_source_without_extra_blocks

------
[Codex Task](