### PR TITLE
Ensure sparse finish preserves final offset

### DIFF
--- a/crates/engine/src/local_copy/context_impl/delta_transfer.rs
+++ b/crates/engine/src/local_copy/context_impl/delta_transfer.rs
@@ -162,9 +162,8 @@ impl<'a> CopyContext<'a> {
         }
 
         if sparse {
-            sparse_state.finish(writer, destination)?;
-            let final_len = initial_bytes.saturating_add(total_bytes);
-            writer.set_len(final_len).map_err(|error| {
+            let final_position = sparse_state.finish(writer, destination)?;
+            writer.set_len(final_position).map_err(|error| {
                 LocalCopyError::io(
                     "truncate destination file",
                     destination.to_path_buf(),

--- a/crates/engine/src/local_copy/context_impl/transfer.rs
+++ b/crates/engine/src/local_copy/context_impl/transfer.rs
@@ -330,9 +330,8 @@ impl<'a> CopyContext<'a> {
         }
 
         if sparse {
-            sparse_state.finish(writer, destination)?;
-            let final_len = initial_bytes.saturating_add(total_bytes);
-            writer.set_len(final_len).map_err(|error| {
+            let final_position = sparse_state.finish(writer, destination)?;
+            writer.set_len(final_position).map_err(|error| {
                 LocalCopyError::io(
                     "truncate destination file",
                     destination.to_path_buf(),


### PR DESCRIPTION
## Summary
- return the current file offset from sparse writes so callers can truncate to the actual end of the sparse run
- use the returned position when finalising sparse transfers and delta transfers
- add a regression test covering trailing zero runs to ensure the final sparse length is honoured

## Testing
- cargo test -p engine --all-features finish_reports_final_offset_after_trailing_zeros *(fails to complete in this environment due to long OpenSSL build; aborted)*

------
[Codex Task](