### PR TITLE
Ensure daemon logs use runtime branding

### DIFF
--- a/crates/daemon/src/daemon/runtime_options.rs
+++ b/crates/daemon/src/daemon/runtime_options.rs
@@ -1,5 +1,6 @@
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct RuntimeOptions {
+    brand: Brand,
     bind_address: IpAddr,
     port: u16,
     max_sessions: Option<NonZeroUsize>,
@@ -30,6 +31,7 @@ struct RuntimeOptions {
 impl Default for RuntimeOptions {
     fn default() -> Self {
         Self {
+            brand: Brand::Oc,
             bind_address: DEFAULT_BIND_ADDRESS,
             port: DEFAULT_PORT,
             max_sessions: None,
@@ -72,6 +74,7 @@ impl RuntimeOptions {
         load_defaults: bool,
     ) -> Result<Self, DaemonError> {
         let mut options = Self::default();
+        options.brand = brand;
         let mut seen_modules = HashSet::new();
         if load_defaults && !config_argument_present(arguments) {
             if let Some(path) = environment_config_override() {
@@ -614,6 +617,10 @@ impl RuntimeOptions {
 
     pub(super) fn bandwidth_burst(&self) -> Option<NonZeroU64> {
         self.bandwidth_burst
+    }
+
+    pub(super) fn brand(&self) -> Brand {
+        self.brand
     }
 
     pub(super) fn bandwidth_limit_configured(&self) -> bool {

--- a/crates/daemon/src/daemon/sections/module_access.rs
+++ b/crates/daemon/src/daemon/sections/module_access.rs
@@ -411,13 +411,13 @@ fn respond_with_module_request(
     stream.flush()
 }
 
-fn open_log_sink(path: &Path) -> Result<SharedLogSink, DaemonError> {
+fn open_log_sink(path: &Path, brand: Brand) -> Result<SharedLogSink, DaemonError> {
     let file = OpenOptions::new()
         .create(true)
         .append(true)
         .open(path)
         .map_err(|error| log_file_error(path, error))?;
-    Ok(Arc::new(Mutex::new(MessageSink::new(file))))
+    Ok(Arc::new(Mutex::new(MessageSink::with_brand(file, brand))))
 }
 
 fn log_file_error(path: &Path, error: io::Error) -> DaemonError {

--- a/crates/daemon/src/daemon/sections/server_runtime.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime.rs
@@ -196,6 +196,7 @@ fn serve_connections(options: RuntimeOptions) -> Result<(), DaemonError> {
     let manifest = manifest();
     let version = manifest.rust_version();
     let RuntimeOptions {
+        brand,
         bind_address,
         port,
         max_sessions,
@@ -257,11 +258,11 @@ fn serve_connections(options: RuntimeOptions) -> Result<(), DaemonError> {
     };
 
     if let Some(message) = fallback_warning_message.as_ref() {
-        eprintln!("{message}");
+        eprintln!("{}", message.clone().with_brand(brand));
     }
 
     let log_sink = if let Some(path) = log_file {
-        Some(open_log_sink(&path)?)
+        Some(open_log_sink(&path, brand)?)
     } else {
         None
     };

--- a/crates/daemon/src/tests/chunks/run_daemon_records_log_file_entries.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_records_log_file_entries.rs
@@ -65,6 +65,12 @@ fn run_daemon_records_log_file_entries() {
     assert!(result.is_ok());
 
     let log_contents = fs::read_to_string(&log_path).expect("read log file");
+    assert!(
+        log_contents
+            .lines()
+            .any(|line| line.contains("oc-rsyncd info: rsyncd version")),
+        "log should use oc-rsyncd branding: {log_contents:?}"
+    );
     assert!(log_contents.contains("connect from"));
     assert!(log_contents.contains("127.0.0.1"));
     assert!(log_contents.contains("module 'docs'"));


### PR DESCRIPTION
## Summary
- store the daemon's branding choice in runtime options and apply it when opening log sinks
- brand fallback warnings and log file output with the correct oc-rsyncd name
- extend daemon log file test to assert branded prefixes

## Testing
- cargo test --all-features

------
[Codex Task](