### PR TITLE
Handle empty PATH in fallback search

### DIFF
--- a/crates/core/src/fallback/binary/candidates.rs
+++ b/crates/core/src/fallback/binary/candidates.rs
@@ -24,6 +24,14 @@ pub fn fallback_binary_candidates(binary: &OsStr) -> Vec<PathBuf> {
         return Vec::new();
     };
 
+    // An explicitly empty PATH disables search resolution; `execvp` would fail
+    // in the same scenario because no lookup directories are available. Avoid
+    // probing the current working directory so callers surface a deterministic
+    // "not available" error instead of spawning an unexpected helper.
+    if path_env.is_empty() {
+        return Vec::new();
+    }
+
     let mut results = Vec::new();
     let mut seen = HashSet::new();
 


### PR DESCRIPTION
## Summary
- Avoid probing the current directory when PATH is explicitly empty during fallback binary resolution
- Surface deterministic missing-binary errors instead of spawning helpers when no search paths are available

## Testing
- OPENSSL_NO_VENDOR=1 cargo test -p core remote_fallback_detects_missing_default_binary_on_path -- --nocapture --test-threads=1

------
[Codex Task](