### PR TITLE
Handle empty PATH for fallback cache

### DIFF
--- a/crates/core/src/fallback/binary/availability.rs
+++ b/crates/core/src/fallback/binary/availability.rs
@@ -165,6 +165,10 @@ fn cache_key_depends_on_cwd(binary: &OsStr, path_env: Option<&OsStr>) -> bool {
         return false;
     };
 
+    if path_env.is_empty() {
+        return true;
+    }
+
     env::split_paths(path_env).any(|entry| entry.as_os_str().is_empty() || entry.is_relative())
 }
 


### PR DESCRIPTION
## Summary
- treat empty PATH values as current-directory dependent when caching fallback binary lookups
- ensure cache entries change after working directory changes with empty PATH

## Testing
- cargo test -p core fallback_binary_available_respects_path_changes -- --nocapture
- cargo test -p core fallback_binary_cache_accounts_for_cwd_entries_in_path -- --nocapture

------
[Codex Task](