### PR TITLE
Track caller location for fallback errors

### DIFF
--- a/crates/core/src/client/fallback/runner/helpers.rs
+++ b/crates/core/src/client/fallback/runner/helpers.rs
@@ -27,6 +27,7 @@ pub(crate) enum FallbackStreamMessage {
     Finished(FallbackStreamKind),
 }
 
+#[track_caller]
 pub(crate) fn fallback_error(text: impl Into<String>) -> ClientError {
     let message = rsync_error!(1, "{}", text.into()).with_role(Role::Client);
     ClientError::new(1, message)

--- a/crates/core/src/client/tests/fallback_error.rs
+++ b/crates/core/src/client/tests/fallback_error.rs
@@ -1,0 +1,13 @@
+mod fallback_error_tests {
+    use super::fallback::runner::helpers::fallback_error;
+
+    #[test]
+    fn fallback_error_tracks_call_site() {
+        let call_site_line = line!() + 1;
+        let error = fallback_error("call-site");
+        let source = error.message().source().expect("source location missing");
+
+        assert_eq!(source.path(), file!());
+        assert_eq!(source.line(), call_site_line);
+    }
+}

--- a/crates/core/src/client/tests/mod.rs
+++ b/crates/core/src/client/tests/mod.rs
@@ -13,3 +13,4 @@ include!("module_list_listing.rs");
 include!("module_list_socket_options.rs");
 include!("error_helpers.rs");
 include!("ignore_times.rs");
+include!("fallback_error.rs");


### PR DESCRIPTION
## Summary
- ensure fallback_error is annotated with track_caller so diagnostics point at the original call site
- add a regression test to assert fallback_error captures the caller file and line
- register the new test module in the client test harness

## Testing
- cargo fmt
- cargo test -p core fallback_error_tracks_call_site -- --nocapture *(fails/aborted due to vendored OpenSSL build taking too long in the environment)*

------
[Codex Task](