### PR TITLE
Add opt-out flag for system rsync fallback

### DIFF
--- a/crates/core/src/client/fallback/runner/command_builder.rs
+++ b/crates/core/src/client/fallback/runner/command_builder.rs
@@ -8,7 +8,7 @@ use super::helpers::{fallback_error, prepare_file_list, push_human_readable, pus
 use crate::client::{AddressMode, ClientError, DeleteMode, IconvSetting, TransferTimeout};
 use crate::fallback::{
     CLIENT_FALLBACK_ENV, FallbackOverride, describe_missing_fallback_binary,
-    fallback_binary_is_self, fallback_binary_path, fallback_override,
+    fallback_binary_is_self, fallback_binary_path, fallback_disabled_reason, fallback_override,
 };
 
 /// Prepared command invocation for the legacy fallback binary.
@@ -24,6 +24,12 @@ pub(crate) struct PreparedInvocation {
 pub(crate) fn prepare_invocation(
     args: RemoteFallbackArgs,
 ) -> Result<PreparedInvocation, ClientError> {
+    if let Some(reason) = fallback_disabled_reason() {
+        return Err(fallback_error(format!(
+            "remote transfers are unavailable because {reason}"
+        )));
+    }
+
     let RemoteFallbackArgs {
         dry_run,
         list_only,

--- a/crates/daemon/src/daemon.rs
+++ b/crates/daemon/src/daemon.rs
@@ -50,7 +50,7 @@ use core::{
     branding::{self, Brand, manifest},
     fallback::{
         CLIENT_FALLBACK_ENV, DAEMON_FALLBACK_ENV, describe_missing_fallback_binary,
-        fallback_binary_available, fallback_override,
+        fallback_binary_available, fallback_disabled_reason, fallback_override,
     },
     message::{Message, Role},
     rsync_error, rsync_info, rsync_warning,

--- a/crates/daemon/src/daemon/sections/server_runtime.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime.rs
@@ -216,6 +216,10 @@ fn serve_connections(options: RuntimeOptions) -> Result<(), DaemonError> {
     let mut delegate_arguments = delegate_arguments;
     let mut generated_config: Option<GeneratedFallbackConfig> = None;
 
+    if let Some(reason) = fallback_disabled_reason() {
+        fallback_warning_message = Some(rsync_warning!(reason).with_role(Role::Daemon));
+    }
+
     if inline_modules {
         generated_config = generate_fallback_config(&modules, &motd_lines).map_err(|error| {
             DaemonError::new(
@@ -233,15 +237,19 @@ fn serve_connections(options: RuntimeOptions) -> Result<(), DaemonError> {
         }
     }
 
-    let delegation = if let Some(binary) = configured_fallback_binary() {
-        if fallback_binary_available(binary.as_os_str()) {
-            Some(SessionDelegation::new(binary, delegate_arguments))
+    let delegation = if fallback_warning_message.is_none() {
+        if let Some(binary) = configured_fallback_binary() {
+            if fallback_binary_available(binary.as_os_str()) {
+                Some(SessionDelegation::new(binary, delegate_arguments))
+            } else {
+                let warning_text = describe_missing_fallback_binary(
+                    binary.as_os_str(),
+                    &[DAEMON_FALLBACK_ENV, CLIENT_FALLBACK_ENV],
+                );
+                fallback_warning_message = Some(rsync_warning!(warning_text).with_role(Role::Daemon));
+                None
+            }
         } else {
-            let warning_text = describe_missing_fallback_binary(
-                binary.as_os_str(),
-                &[DAEMON_FALLBACK_ENV, CLIENT_FALLBACK_ENV],
-            );
-            fallback_warning_message = Some(rsync_warning!(warning_text).with_role(Role::Daemon));
             None
         }
     } else {

--- a/crates/daemon/src/tests.rs
+++ b/crates/daemon/src/tests.rs
@@ -38,6 +38,7 @@ include!("tests/chunks/default_secrets_path_falls_back_to_secondary_candidate.rs
 include!("tests/chunks/default_secrets_path_prefers_primary_candidate.rs");
 include!("tests/chunks/default_secrets_path_returns_none_when_absent.rs");
 include!("tests/chunks/delegate_system_daemon_fallback_env_triggers_delegation.rs");
+include!("tests/chunks/delegate_system_rsync_disable_env_blocks_delegation.rs");
 include!("tests/chunks/delegate_system_rsync_env_false_skips_fallback.rs");
 include!("tests/chunks/delegate_system_rsync_env_triggers_fallback.rs");
 include!("tests/chunks/delegate_system_rsync_fallback_env_triggers_delegation.rs");

--- a/crates/daemon/src/tests/chunks/delegate_system_rsync_disable_env_blocks_delegation.rs
+++ b/crates/daemon/src/tests/chunks/delegate_system_rsync_disable_env_blocks_delegation.rs
@@ -1,0 +1,23 @@
+use core::fallback::DISABLE_FALLBACK_ENV;
+
+#[cfg(unix)]
+#[test]
+fn delegate_system_rsync_disable_env_blocks_delegation() {
+    let _lock = ENV_LOCK.lock().unwrap();
+    let temp = tempdir().expect("tempdir");
+    let script_path = temp.path().join("rsync-wrapper.sh");
+    let log_path = temp.path().join("invocation.log");
+    let script = format!("#!/bin/sh\necho invoked > {}\nexit 0\n", log_path.display());
+    write_executable_script(&script_path, &script);
+    let _fallback = EnvGuard::set(DAEMON_FALLBACK_ENV, script_path.as_os_str());
+    let _disable = EnvGuard::set(DISABLE_FALLBACK_ENV, OsStr::new("1"));
+
+    let (code, _stdout, stderr) =
+        run_with_args([OsStr::new(RSYNCD), OsStr::new("--delegate-system-rsync")]);
+
+    assert_eq!(code, 1);
+    assert!(!log_path.exists());
+    let stderr_text = String::from_utf8_lossy(&stderr);
+    assert!(stderr_text.contains(DISABLE_FALLBACK_ENV));
+}
+


### PR DESCRIPTION
## Summary
- add a workspace-wide OC_RSYNC_DISABLE_FALLBACK flag that blocks delegation to system rsync
- surface the disable flag across client, server, and daemon fallback paths with focused diagnostics
- extend tests to cover the new opt-out behaviour and guard daemon delegation

## Testing
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings
- cargo nextest run --workspace --all-targets --all-features *(fails: cargo-nextest is not installed in the environment)*
- cargo xtask docs

------
[Codex Task](