### PR TITLE
Send compatibility flags during binary handshake

### DIFF
--- a/crates/transport/src/binary/tests/handshake.rs
+++ b/crates/transport/src/binary/tests/handshake.rs
@@ -1,5 +1,7 @@
 use super::super::BinaryHandshake;
-use super::helpers::{CountingTransport, MemoryTransport, handshake_bytes, handshake_payload};
+use super::helpers::{
+    CountingTransport, MemoryTransport, handshake_bytes, handshake_payload, local_handshake_payload,
+};
 use crate::RemoteProtocolAdvertisement;
 use protocol::{
     CompatibilityFlags, NegotiationPrologue, NegotiationPrologueSniffer, ProtocolVersion,
@@ -82,7 +84,7 @@ fn into_stream_parts_exposes_negotiation_state() {
     let transport = stream.into_inner();
     assert_eq!(
         transport.written(),
-        &handshake_bytes(ProtocolVersion::NEWEST)
+        local_handshake_payload(ProtocolVersion::NEWEST)
     );
 }
 
@@ -159,9 +161,9 @@ fn from_stream_parts_rehydrates_binary_handshake() {
     rehydrated.stream_mut().flush().expect("flush propagates");
 
     let transport = rehydrated.into_stream().into_inner();
-    assert_eq!(transport.flushes(), 2);
+    assert_eq!(transport.flushes(), 3);
 
-    let mut expected = handshake_bytes(ProtocolVersion::NEWEST).to_vec();
+    let mut expected = local_handshake_payload(ProtocolVersion::NEWEST);
     expected.extend_from_slice(b"payload");
     assert_eq!(transport.written(), expected.as_slice());
 }
@@ -199,9 +201,9 @@ fn into_parts_round_trips_binary_handshake() {
     rebuilt.stream_mut().flush().expect("flush propagates");
 
     let transport = rebuilt.into_stream().into_inner();
-    assert_eq!(transport.flushes(), 2);
+    assert_eq!(transport.flushes(), 3);
 
-    let mut expected = handshake_bytes(ProtocolVersion::NEWEST).to_vec();
+    let mut expected = local_handshake_payload(ProtocolVersion::NEWEST);
     expected.extend_from_slice(b"payload");
     assert_eq!(transport.written(), expected.as_slice());
 }

--- a/crates/transport/src/binary/tests/helpers.rs
+++ b/crates/transport/src/binary/tests/helpers.rs
@@ -130,6 +130,14 @@ pub(super) fn handshake_bytes(version: ProtocolVersion) -> [u8; 4] {
     u32::from(version.as_u8()).to_be_bytes()
 }
 
+pub(super) fn default_local_flags(protocol: ProtocolVersion) -> CompatibilityFlags {
+    super::super::negotiate::local_compatibility_flags(protocol)
+}
+
+pub(super) fn local_handshake_payload(protocol: ProtocolVersion) -> Vec<u8> {
+    handshake_payload(protocol, default_local_flags(protocol))
+}
+
 #[must_use]
 pub(super) fn handshake_payload(version: ProtocolVersion, flags: CompatibilityFlags) -> Vec<u8> {
     let mut payload = handshake_bytes(version).to_vec();

--- a/crates/transport/src/binary/tests/mapping.rs
+++ b/crates/transport/src/binary/tests/mapping.rs
@@ -1,4 +1,6 @@
-use super::helpers::{InstrumentedTransport, MemoryTransport, handshake_bytes, handshake_payload};
+use super::helpers::{
+    InstrumentedTransport, MemoryTransport, handshake_payload, local_handshake_payload,
+};
 use protocol::{CompatibilityFlags, ProtocolVersion};
 use std::io::{self, Write};
 
@@ -38,7 +40,7 @@ fn map_stream_inner_preserves_protocols_and_replays_transport() {
     assert_eq!(instrumented.flushes(), 1);
 
     let inner = instrumented.into_inner();
-    let mut expected = handshake_bytes(ProtocolVersion::NEWEST).to_vec();
+    let mut expected = local_handshake_payload(ProtocolVersion::NEWEST);
     expected.extend_from_slice(b"payload");
     assert_eq!(inner.written(), expected.as_slice());
 }
@@ -102,7 +104,7 @@ fn parts_map_stream_inner_transforms_transport() {
     assert_eq!(instrumented.flushes(), 1);
 
     let inner = instrumented.into_inner();
-    let mut expected = handshake_bytes(ProtocolVersion::NEWEST).to_vec();
+    let mut expected = local_handshake_payload(ProtocolVersion::NEWEST);
     expected.extend_from_slice(b"payload");
     assert_eq!(inner.written(), expected.as_slice());
 }
@@ -187,6 +189,6 @@ fn try_map_stream_inner_preserves_original_on_error() {
     let transport = original.into_stream().into_inner();
     assert_eq!(
         transport.written(),
-        &handshake_bytes(ProtocolVersion::NEWEST)
+        local_handshake_payload(ProtocolVersion::NEWEST)
     );
 }

--- a/crates/transport/src/binary/tests/negotiation.rs
+++ b/crates/transport/src/binary/tests/negotiation.rs
@@ -1,4 +1,6 @@
-use super::helpers::{CountingTransport, MemoryTransport, handshake_bytes, handshake_payload};
+use super::helpers::{
+    CountingTransport, MemoryTransport, handshake_bytes, handshake_payload, local_handshake_payload,
+};
 use crate::RemoteProtocolAdvertisement;
 use protocol::{CompatibilityFlags, NegotiationPrologueSniffer, ProtocolVersion};
 use std::io;
@@ -37,7 +39,7 @@ fn negotiate_binary_session_exchanges_versions() {
     let transport = handshake.into_stream().into_inner();
     assert_eq!(
         transport.written(),
-        &handshake_bytes(ProtocolVersion::NEWEST)
+        local_handshake_payload(ProtocolVersion::NEWEST)
     );
 }
 
@@ -76,7 +78,7 @@ fn negotiate_binary_session_clamps_future_protocols() {
     assert_eq!(parts.remote_compatibility_flags(), sample_flags());
 
     let transport = parts.into_handshake().into_stream().into_inner();
-    assert_eq!(transport.written(), &handshake_bytes(desired));
+    assert_eq!(transport.written(), local_handshake_payload(desired));
 }
 
 #[test]
@@ -169,10 +171,10 @@ fn negotiate_binary_session_flushes_advertisement() {
     assert!(!handshake.local_protocol_was_capped());
     assert_eq!(handshake.remote_compatibility_flags(), sample_flags());
     let transport = handshake.into_stream().into_inner();
-    assert_eq!(transport.flushes(), 1);
+    assert_eq!(transport.flushes(), 2);
     assert_eq!(
         transport.written(),
-        &handshake_bytes(ProtocolVersion::NEWEST)
+        local_handshake_payload(ProtocolVersion::NEWEST)
     );
 }
 

--- a/crates/transport/src/binary/tests/parts.rs
+++ b/crates/transport/src/binary/tests/parts.rs
@@ -1,4 +1,4 @@
-use super::helpers::{MemoryTransport, handshake_bytes, handshake_payload};
+use super::helpers::{MemoryTransport, handshake_payload, local_handshake_payload};
 use crate::RemoteProtocolAdvertisement;
 use protocol::{CompatibilityFlags, ProtocolVersion};
 use std::io::Write;
@@ -37,7 +37,7 @@ fn parts_stream_parts_mut_exposes_inner_transport() {
     assert_eq!(parts.remote_compatibility_flags(), sample_flags());
 
     let inner = parts.into_handshake().into_stream().into_inner();
-    let mut expected = handshake_bytes(ProtocolVersion::NEWEST).to_vec();
+    let mut expected = local_handshake_payload(ProtocolVersion::NEWEST);
     expected.extend_from_slice(b"payload");
     assert_eq!(inner.written(), expected.as_slice());
 }


### PR DESCRIPTION
## Summary
- send the local compatibility flags during binary negotiation before reading the peer advertisement
- expose reusable helpers for expected local handshake payloads in tests
- update binary transport tests to expect the additional flags and flushes

## Testing
- cargo test

------
[Codex Task](