### PR TITLE
Send compatibility flags during binary handshake

### DIFF
--- a/crates/transport/src/binary/mod.rs
+++ b/crates/transport/src/binary/mod.rs
@@ -5,6 +5,8 @@ mod negotiate;
 mod parts;
 
 pub use handshake::BinaryHandshake;
+#[cfg(test)]
+pub(crate) use negotiate::local_compatibility_flags;
 pub use negotiate::{
     negotiate_binary_session, negotiate_binary_session_from_stream,
     negotiate_binary_session_with_sniffer,

--- a/crates/transport/src/binary/tests/handshake.rs
+++ b/crates/transport/src/binary/tests/handshake.rs
@@ -82,7 +82,7 @@ fn into_stream_parts_exposes_negotiation_state() {
     let transport = stream.into_inner();
     assert_eq!(
         transport.written(),
-        &handshake_bytes(ProtocolVersion::NEWEST)
+        super::helpers::local_handshake_payload(ProtocolVersion::NEWEST).as_slice()
     );
 }
 
@@ -161,7 +161,7 @@ fn from_stream_parts_rehydrates_binary_handshake() {
     let transport = rehydrated.into_stream().into_inner();
     assert_eq!(transport.flushes(), 2);
 
-    let mut expected = handshake_bytes(ProtocolVersion::NEWEST).to_vec();
+    let mut expected = super::helpers::local_handshake_payload(ProtocolVersion::NEWEST);
     expected.extend_from_slice(b"payload");
     assert_eq!(transport.written(), expected.as_slice());
 }
@@ -201,7 +201,7 @@ fn into_parts_round_trips_binary_handshake() {
     let transport = rebuilt.into_stream().into_inner();
     assert_eq!(transport.flushes(), 2);
 
-    let mut expected = handshake_bytes(ProtocolVersion::NEWEST).to_vec();
+    let mut expected = super::helpers::local_handshake_payload(ProtocolVersion::NEWEST);
     expected.extend_from_slice(b"payload");
     assert_eq!(transport.written(), expected.as_slice());
 }

--- a/crates/transport/src/binary/tests/helpers.rs
+++ b/crates/transport/src/binary/tests/helpers.rs
@@ -140,3 +140,13 @@ pub(super) fn handshake_payload(version: ProtocolVersion, flags: CompatibilityFl
     }
     payload
 }
+
+pub(super) fn local_handshake_payload(version: ProtocolVersion) -> Vec<u8> {
+    let mut payload = handshake_bytes(version).to_vec();
+    if version.uses_binary_negotiation() {
+        crate::binary::local_compatibility_flags()
+            .encode_to_vec(&mut payload)
+            .expect("compatibility encoding succeeds");
+    }
+    payload
+}

--- a/crates/transport/src/binary/tests/mapping.rs
+++ b/crates/transport/src/binary/tests/mapping.rs
@@ -1,4 +1,4 @@
-use super::helpers::{InstrumentedTransport, MemoryTransport, handshake_bytes, handshake_payload};
+use super::helpers::{InstrumentedTransport, MemoryTransport, handshake_payload};
 use protocol::{CompatibilityFlags, ProtocolVersion};
 use std::io::{self, Write};
 
@@ -38,7 +38,7 @@ fn map_stream_inner_preserves_protocols_and_replays_transport() {
     assert_eq!(instrumented.flushes(), 1);
 
     let inner = instrumented.into_inner();
-    let mut expected = handshake_bytes(ProtocolVersion::NEWEST).to_vec();
+    let mut expected = super::helpers::local_handshake_payload(ProtocolVersion::NEWEST);
     expected.extend_from_slice(b"payload");
     assert_eq!(inner.written(), expected.as_slice());
 }
@@ -102,7 +102,7 @@ fn parts_map_stream_inner_transforms_transport() {
     assert_eq!(instrumented.flushes(), 1);
 
     let inner = instrumented.into_inner();
-    let mut expected = handshake_bytes(ProtocolVersion::NEWEST).to_vec();
+    let mut expected = super::helpers::local_handshake_payload(ProtocolVersion::NEWEST);
     expected.extend_from_slice(b"payload");
     assert_eq!(inner.written(), expected.as_slice());
 }
@@ -187,6 +187,6 @@ fn try_map_stream_inner_preserves_original_on_error() {
     let transport = original.into_stream().into_inner();
     assert_eq!(
         transport.written(),
-        &handshake_bytes(ProtocolVersion::NEWEST)
+        super::helpers::local_handshake_payload(ProtocolVersion::NEWEST).as_slice()
     );
 }

--- a/crates/transport/src/binary/tests/negotiation.rs
+++ b/crates/transport/src/binary/tests/negotiation.rs
@@ -7,6 +7,10 @@ fn sample_flags() -> CompatibilityFlags {
     CompatibilityFlags::INC_RECURSE | CompatibilityFlags::VARINT_FLIST_FLAGS
 }
 
+fn expected_outbound_handshake(version: ProtocolVersion) -> Vec<u8> {
+    super::helpers::local_handshake_payload(version)
+}
+
 #[test]
 fn negotiate_binary_session_exchanges_versions() {
     let remote_version = ProtocolVersion::from_supported(31).expect("31 supported");
@@ -37,7 +41,7 @@ fn negotiate_binary_session_exchanges_versions() {
     let transport = handshake.into_stream().into_inner();
     assert_eq!(
         transport.written(),
-        &handshake_bytes(ProtocolVersion::NEWEST)
+        expected_outbound_handshake(ProtocolVersion::NEWEST).as_slice()
     );
 }
 
@@ -76,7 +80,10 @@ fn negotiate_binary_session_clamps_future_protocols() {
     assert_eq!(parts.remote_compatibility_flags(), sample_flags());
 
     let transport = parts.into_handshake().into_stream().into_inner();
-    assert_eq!(transport.written(), &handshake_bytes(desired));
+    assert_eq!(
+        transport.written(),
+        expected_outbound_handshake(desired).as_slice()
+    );
 }
 
 #[test]
@@ -172,7 +179,7 @@ fn negotiate_binary_session_flushes_advertisement() {
     assert_eq!(transport.flushes(), 1);
     assert_eq!(
         transport.written(),
-        &handshake_bytes(ProtocolVersion::NEWEST)
+        expected_outbound_handshake(ProtocolVersion::NEWEST).as_slice()
     );
 }
 

--- a/crates/transport/src/binary/tests/parts.rs
+++ b/crates/transport/src/binary/tests/parts.rs
@@ -1,4 +1,4 @@
-use super::helpers::{MemoryTransport, handshake_bytes, handshake_payload};
+use super::helpers::{MemoryTransport, handshake_payload};
 use crate::RemoteProtocolAdvertisement;
 use protocol::{CompatibilityFlags, ProtocolVersion};
 use std::io::Write;
@@ -37,7 +37,7 @@ fn parts_stream_parts_mut_exposes_inner_transport() {
     assert_eq!(parts.remote_compatibility_flags(), sample_flags());
 
     let inner = parts.into_handshake().into_stream().into_inner();
-    let mut expected = handshake_bytes(ProtocolVersion::NEWEST).to_vec();
+    let mut expected = super::helpers::local_handshake_payload(ProtocolVersion::NEWEST);
     expected.extend_from_slice(b"payload");
     assert_eq!(inner.written(), expected.as_slice());
 }

--- a/crates/transport/src/session/handshake/session.rs
+++ b/crates/transport/src/session/handshake/session.rs
@@ -297,7 +297,9 @@ impl<R> SessionHandshake<R> {
     ///
     /// // The returned transport is the original stream, including any bytes the
     /// // client wrote while negotiating.
-    /// assert_eq!(raw.writes(), &u32::from(protocol.as_u8()).to_be_bytes());
+    /// let mut expected = u32::from(protocol.as_u8()).to_be_bytes().to_vec();
+    /// expected.extend_from_slice(&[128, 169]);
+    /// assert_eq!(raw.writes(), expected.as_slice());
     /// ```
     #[must_use]
     pub fn into_inner(self) -> R {

--- a/crates/transport/src/session/tests/clones.rs
+++ b/crates/transport/src/session/tests/clones.rs
@@ -42,12 +42,12 @@ fn session_handshake_parts_clone_preserves_binary_stream_state() {
     let original_transport = binary.into_stream().into_inner();
     let cloned_transport = cloned.into_stream().into_inner();
 
-    let mut expected_original = binary_handshake_bytes(ProtocolVersion::NEWEST).to_vec();
+    let mut expected_original = binary_handshake_bytes(ProtocolVersion::NEWEST);
     expected_original.extend_from_slice(b"original");
     assert_eq!(original_transport.writes(), expected_original.as_slice());
     assert_eq!(original_transport.flushes(), 1);
 
-    let mut expected_clone = binary_handshake_bytes(ProtocolVersion::NEWEST).to_vec();
+    let mut expected_clone = binary_handshake_bytes(ProtocolVersion::NEWEST);
     expected_clone.extend_from_slice(b"clone");
     assert_eq!(cloned_transport.writes(), expected_clone.as_slice());
     assert_eq!(cloned_transport.flushes(), 1);

--- a/crates/transport/src/session/tests/mapping.rs
+++ b/crates/transport/src/session/tests/mapping.rs
@@ -48,7 +48,7 @@ fn as_variant_mut_helpers_allow_mutating_streams() {
         .expect("handshake remains binary")
         .into_stream()
         .into_inner();
-    let mut expected = binary_handshake_bytes(ProtocolVersion::NEWEST).to_vec();
+    let mut expected = binary_handshake_bytes(ProtocolVersion::NEWEST);
     expected.extend_from_slice(b"payload");
     assert_eq!(transport.writes(), expected.as_slice());
 
@@ -108,7 +108,7 @@ fn map_stream_inner_preserves_variant_and_metadata() {
         .into_stream()
         .into_inner();
 
-    let mut expected = binary_handshake_bytes(ProtocolVersion::NEWEST).to_vec();
+    let mut expected = binary_handshake_bytes(ProtocolVersion::NEWEST);
     expected.extend_from_slice(b"payload");
     assert_eq!(transport.writes(), expected.as_slice());
     assert_eq!(transport.flushes(), 1);
@@ -171,6 +171,6 @@ fn try_map_stream_inner_preserves_original_handshake_on_error() {
         .into_inner();
     assert_eq!(
         transport.writes(),
-        &binary_handshake_bytes(ProtocolVersion::NEWEST)
+        binary_handshake_bytes(ProtocolVersion::NEWEST).as_slice()
     );
 }

--- a/crates/transport/src/session/tests/roundtrip.rs
+++ b/crates/transport/src/session/tests/roundtrip.rs
@@ -78,7 +78,7 @@ fn session_handshake_parts_round_trip_binary_handshake() {
         .expect("write succeeds");
 
     let transport = binary.into_stream().into_inner();
-    let mut expected = binary_handshake_bytes(ProtocolVersion::NEWEST).to_vec();
+    let mut expected = binary_handshake_bytes(ProtocolVersion::NEWEST);
     expected.extend_from_slice(b"payload");
     assert_eq!(transport.writes(), expected.as_slice());
     assert_eq!(transport.flushes(), 1);
@@ -146,7 +146,7 @@ fn session_handshake_parts_try_map_preserves_original_on_error() {
     let transport = original.into_stream().into_inner();
     assert_eq!(
         transport.writes(),
-        &binary_handshake_bytes(ProtocolVersion::NEWEST)
+        binary_handshake_bytes(ProtocolVersion::NEWEST).as_slice()
     );
 }
 

--- a/crates/transport/src/session/tests/support.rs
+++ b/crates/transport/src/session/tests/support.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::binary::local_compatibility_flags;
 
 #[derive(Clone, Debug)]
 pub(crate) struct MemoryTransport {
@@ -78,6 +79,12 @@ impl Write for InstrumentedTransport {
     }
 }
 
-pub(crate) fn binary_handshake_bytes(version: ProtocolVersion) -> [u8; 4] {
-    u32::from(version.as_u8()).to_be_bytes()
+pub(crate) fn binary_handshake_bytes(version: ProtocolVersion) -> Vec<u8> {
+    let mut bytes = u32::from(version.as_u8()).to_be_bytes().to_vec();
+    if version.uses_binary_negotiation() {
+        local_compatibility_flags()
+            .encode_to_vec(&mut bytes)
+            .expect("compatibility encoding succeeds");
+    }
+    bytes
 }


### PR DESCRIPTION
## Summary
- send the local compatibility flags when performing binary session negotiation
- update handshake tests, helpers, and documentation to cover the additional compatibility bytes

## Testing
- cargo test -p transport

------
[Codex Task](