### PR TITLE
Advertise compatibility flags during binary session negotiation

### DIFF
--- a/crates/transport/src/binary/mod.rs
+++ b/crates/transport/src/binary/mod.rs
@@ -5,6 +5,8 @@ mod negotiate;
 mod parts;
 
 pub use handshake::BinaryHandshake;
+#[cfg(test)]
+pub(crate) use negotiate::ADVERTISED_COMPATIBILITY_FLAGS;
 pub use negotiate::{
     negotiate_binary_session, negotiate_binary_session_from_stream,
     negotiate_binary_session_with_sniffer,

--- a/crates/transport/src/binary/tests/handshake.rs
+++ b/crates/transport/src/binary/tests/handshake.rs
@@ -1,4 +1,5 @@
 use super::super::BinaryHandshake;
+use super::ADVERTISED_COMPATIBILITY_FLAGS;
 use super::helpers::{CountingTransport, MemoryTransport, handshake_bytes, handshake_payload};
 use crate::RemoteProtocolAdvertisement;
 use protocol::{
@@ -82,7 +83,7 @@ fn into_stream_parts_exposes_negotiation_state() {
     let transport = stream.into_inner();
     assert_eq!(
         transport.written(),
-        &handshake_bytes(ProtocolVersion::NEWEST)
+        &handshake_payload(ProtocolVersion::NEWEST, ADVERTISED_COMPATIBILITY_FLAGS)
     );
 }
 
@@ -161,7 +162,7 @@ fn from_stream_parts_rehydrates_binary_handshake() {
     let transport = rehydrated.into_stream().into_inner();
     assert_eq!(transport.flushes(), 2);
 
-    let mut expected = handshake_bytes(ProtocolVersion::NEWEST).to_vec();
+    let mut expected = handshake_payload(ProtocolVersion::NEWEST, ADVERTISED_COMPATIBILITY_FLAGS);
     expected.extend_from_slice(b"payload");
     assert_eq!(transport.written(), expected.as_slice());
 }
@@ -201,7 +202,7 @@ fn into_parts_round_trips_binary_handshake() {
     let transport = rebuilt.into_stream().into_inner();
     assert_eq!(transport.flushes(), 2);
 
-    let mut expected = handshake_bytes(ProtocolVersion::NEWEST).to_vec();
+    let mut expected = handshake_payload(ProtocolVersion::NEWEST, ADVERTISED_COMPATIBILITY_FLAGS);
     expected.extend_from_slice(b"payload");
     assert_eq!(transport.written(), expected.as_slice());
 }

--- a/crates/transport/src/binary/tests/mapping.rs
+++ b/crates/transport/src/binary/tests/mapping.rs
@@ -1,4 +1,5 @@
-use super::helpers::{InstrumentedTransport, MemoryTransport, handshake_bytes, handshake_payload};
+use super::ADVERTISED_COMPATIBILITY_FLAGS;
+use super::helpers::{InstrumentedTransport, MemoryTransport, handshake_payload};
 use protocol::{CompatibilityFlags, ProtocolVersion};
 use std::io::{self, Write};
 
@@ -38,7 +39,7 @@ fn map_stream_inner_preserves_protocols_and_replays_transport() {
     assert_eq!(instrumented.flushes(), 1);
 
     let inner = instrumented.into_inner();
-    let mut expected = handshake_bytes(ProtocolVersion::NEWEST).to_vec();
+    let mut expected = handshake_payload(ProtocolVersion::NEWEST, ADVERTISED_COMPATIBILITY_FLAGS);
     expected.extend_from_slice(b"payload");
     assert_eq!(inner.written(), expected.as_slice());
 }
@@ -102,7 +103,7 @@ fn parts_map_stream_inner_transforms_transport() {
     assert_eq!(instrumented.flushes(), 1);
 
     let inner = instrumented.into_inner();
-    let mut expected = handshake_bytes(ProtocolVersion::NEWEST).to_vec();
+    let mut expected = handshake_payload(ProtocolVersion::NEWEST, ADVERTISED_COMPATIBILITY_FLAGS);
     expected.extend_from_slice(b"payload");
     assert_eq!(inner.written(), expected.as_slice());
 }
@@ -187,6 +188,6 @@ fn try_map_stream_inner_preserves_original_on_error() {
     let transport = original.into_stream().into_inner();
     assert_eq!(
         transport.written(),
-        &handshake_bytes(ProtocolVersion::NEWEST)
+        &handshake_payload(ProtocolVersion::NEWEST, ADVERTISED_COMPATIBILITY_FLAGS)
     );
 }

--- a/crates/transport/src/binary/tests/negotiation.rs
+++ b/crates/transport/src/binary/tests/negotiation.rs
@@ -1,3 +1,4 @@
+use super::ADVERTISED_COMPATIBILITY_FLAGS;
 use super::helpers::{CountingTransport, MemoryTransport, handshake_bytes, handshake_payload};
 use crate::RemoteProtocolAdvertisement;
 use protocol::{CompatibilityFlags, NegotiationPrologueSniffer, ProtocolVersion};
@@ -37,7 +38,7 @@ fn negotiate_binary_session_exchanges_versions() {
     let transport = handshake.into_stream().into_inner();
     assert_eq!(
         transport.written(),
-        &handshake_bytes(ProtocolVersion::NEWEST)
+        &handshake_payload(ProtocolVersion::NEWEST, ADVERTISED_COMPATIBILITY_FLAGS)
     );
 }
 
@@ -76,7 +77,10 @@ fn negotiate_binary_session_clamps_future_protocols() {
     assert_eq!(parts.remote_compatibility_flags(), sample_flags());
 
     let transport = parts.into_handshake().into_stream().into_inner();
-    assert_eq!(transport.written(), &handshake_bytes(desired));
+    assert_eq!(
+        transport.written(),
+        &handshake_payload(desired, ADVERTISED_COMPATIBILITY_FLAGS)
+    );
 }
 
 #[test]
@@ -172,7 +176,7 @@ fn negotiate_binary_session_flushes_advertisement() {
     assert_eq!(transport.flushes(), 1);
     assert_eq!(
         transport.written(),
-        &handshake_bytes(ProtocolVersion::NEWEST)
+        &handshake_payload(ProtocolVersion::NEWEST, ADVERTISED_COMPATIBILITY_FLAGS)
     );
 }
 

--- a/crates/transport/src/binary/tests/parts.rs
+++ b/crates/transport/src/binary/tests/parts.rs
@@ -1,4 +1,5 @@
-use super::helpers::{MemoryTransport, handshake_bytes, handshake_payload};
+use super::ADVERTISED_COMPATIBILITY_FLAGS;
+use super::helpers::{MemoryTransport, handshake_payload};
 use crate::RemoteProtocolAdvertisement;
 use protocol::{CompatibilityFlags, ProtocolVersion};
 use std::io::Write;
@@ -37,7 +38,7 @@ fn parts_stream_parts_mut_exposes_inner_transport() {
     assert_eq!(parts.remote_compatibility_flags(), sample_flags());
 
     let inner = parts.into_handshake().into_stream().into_inner();
-    let mut expected = handshake_bytes(ProtocolVersion::NEWEST).to_vec();
+    let mut expected = handshake_payload(ProtocolVersion::NEWEST, ADVERTISED_COMPATIBILITY_FLAGS);
     expected.extend_from_slice(b"payload");
     assert_eq!(inner.written(), expected.as_slice());
 }


### PR DESCRIPTION
## Summary
- advertise the full compatibility flag set when performing binary protocol negotiation
- flush the negotiated stream after sending our flags to mirror upstream ordering
- update binary transport tests to expect the advertised flags in handshake payloads

## Testing
- cargo test -p transport negotiate_binary_session_exchanges_versions -- --nocapture

------
[Codex Task](