### PR TITLE
chore: update Homebrew formula for v0.5.1

### DIFF
--- a/Formula/oc-rsync.rb
+++ b/Formula/oc-rsync.rb
@@ -2,17 +2,17 @@ class OcRsync < Formula
   desc "Pure-Rust rsync 3.4.1-compatible implementation"
   homepage "https://github.com/oferchen/rsync"
   license "GPL-3.0-or-later"
-  version "0.5.0"
+  version "0.5.1"
 
   on_macos do
     on_intel do
-      url "https://github.com/oferchen/rsync/releases/download/v0.5.0/oc-rsync-0.5.0-darwin-x86_64.tar.gz"
-      sha256 "dd1aeee9ccf1e9001dfe5629d7fd11b7fb4b98184797b041375f933db19d1820"
+      url "https://github.com/oferchen/rsync/releases/download/v0.5.1/oc-rsync-0.5.0-darwin-x86_64.tar.gz"
+      sha256 "04324066724b80940f79079d5e8bc711cd49dcd52154c35aed085b973ae65d06"
     end
 
     on_arm do
-      url "https://github.com/oferchen/rsync/releases/download/v0.5.0/oc-rsync-0.5.0-darwin-aarch64.tar.gz"
-      sha256 "ca795cfc3fe455c6e9a09b713e782660c7eb4b926a5cad6f5fa89cd91ea9261c"
+      url "https://github.com/oferchen/rsync/releases/download/v0.5.1/oc-rsync-0.5.0-darwin-aarch64.tar.gz"
+      sha256 "0c701daf2290b1634b4183bcd9edc07d25328ed0a19886ed5d6d62ad98d4977d"
     end
   end
 


### PR DESCRIPTION
This PR updates the Homebrew formula.

## Changes
- Updates formula with new version and SHA256 checksums
- Auto-generated by CI on tag push

## Testing
```bash
brew install --build-from-source ./Formula/oc-rsync.rb
```