### PR TITLE
chore: update Homebrew formula for v0.5.1

### DIFF
--- a/Formula/oc-rsync.rb
+++ b/Formula/oc-rsync.rb
@@ -7,12 +7,12 @@ class OcRsync < Formula
   on_macos do
     on_intel do
       url "https://github.com/oferchen/rsync/releases/download/v0.5.1/oc-rsync-0.5.0-darwin-x86_64.tar.gz"
-      sha256 "04324066724b80940f79079d5e8bc711cd49dcd52154c35aed085b973ae65d06"
+      sha256 "4f6b5f199e9fa480259b7bd12d3a9f48548b30a54218495103e5ec1803c05075"
     end
 
     on_arm do
       url "https://github.com/oferchen/rsync/releases/download/v0.5.1/oc-rsync-0.5.0-darwin-aarch64.tar.gz"
-      sha256 "0c701daf2290b1634b4183bcd9edc07d25328ed0a19886ed5d6d62ad98d4977d"
+      sha256 "a5549ff6cd67ecc1dc6cbd320cc3cb2fb1d7305bafa4de33edae3d4f7cf01472"
     end
   end
 


### PR DESCRIPTION
This PR updates the Homebrew formula.

## Changes
- Updates formula with new version and SHA256 checksums
- Auto-generated by CI on tag push

## Testing
```bash
brew install --build-from-source ./Formula/oc-rsync.rb
```