### PR TITLE
chore: update Homebrew formula for v0.5.1

### DIFF
--- a/Formula/oc-rsync.rb
+++ b/Formula/oc-rsync.rb
@@ -7,12 +7,12 @@ class OcRsync < Formula
   on_macos do
     on_intel do
       url "https://github.com/oferchen/rsync/releases/download/v0.5.1/oc-rsync-0.5.0-darwin-x86_64.tar.gz"
-      sha256 "4f6b5f199e9fa480259b7bd12d3a9f48548b30a54218495103e5ec1803c05075"
+      sha256 "17cb879238e824aeb07cecb0e80f6972a83cb8671c09342146b96dc27c8fbbe0"
     end
 
     on_arm do
       url "https://github.com/oferchen/rsync/releases/download/v0.5.1/oc-rsync-0.5.0-darwin-aarch64.tar.gz"
-      sha256 "a5549ff6cd67ecc1dc6cbd320cc3cb2fb1d7305bafa4de33edae3d4f7cf01472"
+      sha256 "28f2034dcc63273e0505bf48d991358f8ce46a166feb2f73666ff924231d1928"
     end
   end
 


### PR DESCRIPTION
This PR updates the Homebrew formula.

## Changes
- Updates formula with new version and SHA256 checksums
- Auto-generated by CI on tag push

## Testing
```bash
brew install --build-from-source ./Formula/oc-rsync.rb
```