### PR TITLE
chore: update Homebrew formula for v0.5.1

### DIFF
--- a/Formula/oc-rsync.rb
+++ b/Formula/oc-rsync.rb
@@ -6,13 +6,13 @@ class OcRsync < Formula
 
   on_macos do
     on_intel do
-      url "https://github.com/oferchen/rsync/releases/download/v0.5.1/oc-rsync-0.5.0-darwin-x86_64.tar.gz"
-      sha256 "17cb879238e824aeb07cecb0e80f6972a83cb8671c09342146b96dc27c8fbbe0"
+      url "https://github.com/oferchen/rsync/releases/download/v0.5.1/oc-rsync-0.5.1-darwin-x86_64.tar.gz"
+      sha256 "ab5a25b31a2b154143d0e9b6696e3d9a882890a01bd8220ae10290397beb58af"
     end
 
     on_arm do
-      url "https://github.com/oferchen/rsync/releases/download/v0.5.1/oc-rsync-0.5.0-darwin-aarch64.tar.gz"
-      sha256 "28f2034dcc63273e0505bf48d991358f8ce46a166feb2f73666ff924231d1928"
+      url "https://github.com/oferchen/rsync/releases/download/v0.5.1/oc-rsync-0.5.1-darwin-aarch64.tar.gz"
+      sha256 "35141d43d84588cf2905e62d315c270ea07c4e4c0f3cb5c0c53a06c79bfe2ba0"
     end
   end
 


### PR DESCRIPTION
This PR updates the Homebrew formula.

## Changes
- Updates formula with new version and SHA256 checksums
- Auto-generated by CI on tag push

## Testing
```bash
brew install --build-from-source ./Formula/oc-rsync.rb
```