### PR TITLE
chore: update Homebrew formula for v0.5.1

### DIFF
--- a/Formula/oc-rsync.rb
+++ b/Formula/oc-rsync.rb
@@ -7,12 +7,12 @@ class OcRsync < Formula
   on_macos do
     on_intel do
       url "https://github.com/oferchen/rsync/releases/download/v0.5.1/oc-rsync-0.5.1-darwin-x86_64.tar.gz"
-      sha256 "7907f4a84257c55df95bed26fdeb8ead882d4d6581ebe5d0a82e60b5d0cc8381"
+      sha256 "dad19d95f34da859a798cc14ecb44abd45011095b785202dfbbc4a3c89af4a78"
     end
 
     on_arm do
       url "https://github.com/oferchen/rsync/releases/download/v0.5.1/oc-rsync-0.5.1-darwin-aarch64.tar.gz"
-      sha256 "bf2422256760516958b1cd43bc68a4bc29b5d3cc2a2f08b6b03d83e3d9c2156e"
+      sha256 "a3d3e12a29bfec77621ebc2850f2d79a8ad54ac6ff78227f1aaabf08e87193a6"
     end
   end
 


### PR DESCRIPTION
This PR updates the Homebrew formula.

## Changes
- Updates formula with new version and SHA256 checksums
- Auto-generated by CI on tag push

## Testing
```bash
brew install --build-from-source ./Formula/oc-rsync.rb
```