### PR TITLE
chore: update Homebrew formula for v0.5.2

### DIFF
--- a/Formula/oc-rsync.rb
+++ b/Formula/oc-rsync.rb
@@ -2,17 +2,17 @@ class OcRsync < Formula
   desc "Pure-Rust rsync 3.4.1-compatible implementation"
   homepage "https://github.com/oferchen/rsync"
   license "GPL-3.0-or-later"
-  version "0.5.1"
+  version "0.5.2"
 
   on_macos do
     on_intel do
-      url "https://github.com/oferchen/rsync/releases/download/v0.5.1/oc-rsync-0.5.1-darwin-x86_64.tar.gz"
-      sha256 "dad19d95f34da859a798cc14ecb44abd45011095b785202dfbbc4a3c89af4a78"
+      url "https://github.com/oferchen/rsync/releases/download/v0.5.2/oc-rsync-0.5.1-darwin-x86_64.tar.gz"
+      sha256 "cddbbf1f3ec4b08f1b23f91053febd943d396d59e2e9a3f50effd537fa65f6e2"
     end
 
     on_arm do
-      url "https://github.com/oferchen/rsync/releases/download/v0.5.1/oc-rsync-0.5.1-darwin-aarch64.tar.gz"
-      sha256 "a3d3e12a29bfec77621ebc2850f2d79a8ad54ac6ff78227f1aaabf08e87193a6"
+      url "https://github.com/oferchen/rsync/releases/download/v0.5.2/oc-rsync-0.5.1-darwin-aarch64.tar.gz"
+      sha256 "4c98c1242c1bd8d9c5527387b8aeb0659eb32bf72fc726d3ddff4fd919ff2bf9"
     end
   end
 


### PR DESCRIPTION
This PR updates the Homebrew formula.

## Changes
- Updates formula with new version and SHA256 checksums
- Auto-generated by CI on tag push

## Testing
```bash
brew install --build-from-source ./Formula/oc-rsync.rb
```