### PR TITLE
chore: update Homebrew formula for v0.5.2

### DIFF
--- a/Formula/oc-rsync.rb
+++ b/Formula/oc-rsync.rb
@@ -7,12 +7,12 @@ class OcRsync < Formula
   on_macos do
     on_intel do
       url "https://github.com/oferchen/rsync/releases/download/v0.5.2/oc-rsync-0.5.2-darwin-x86_64.tar.gz"
-      sha256 "0e5a02d678ba8b2e297900c0c93ea716f31518c63d664d2c810b0367c297344c"
+      sha256 "e2353dd520822b0d52a3985f64cb36f601dff5a7eeeb0c7f5f9b4429aa569b69"
     end
 
     on_arm do
       url "https://github.com/oferchen/rsync/releases/download/v0.5.2/oc-rsync-0.5.2-darwin-aarch64.tar.gz"
-      sha256 "8e8e4b119b24df00c80f9d7f5298e28da7ac4bceafd364ca6e9a7cf3c22cd6c4"
+      sha256 "448b0b1ad41e503febfa267ecef5da2b50ba87fa85857d3b22f21eb325790e17"
     end
   end
 


### PR DESCRIPTION
This PR updates the Homebrew formula.

## Changes
- Updates formula with new version and SHA256 checksums
- Auto-generated by CI on tag push

## Testing
```bash
brew install --build-from-source ./Formula/oc-rsync.rb
```