### PR TITLE
chore: update Homebrew formula for v0.5.2

### DIFF
--- a/Formula/oc-rsync.rb
+++ b/Formula/oc-rsync.rb
@@ -7,12 +7,12 @@ class OcRsync < Formula
   on_macos do
     on_intel do
       url "https://github.com/oferchen/rsync/releases/download/v0.5.2/oc-rsync-0.5.2-darwin-x86_64.tar.gz"
-      sha256 "55c9f99015981772e79edd14d5fae5fd391d1118a22bbf7642835dde509cdc28"
+      sha256 "b39b7fa1308c7c5c935485f202a053d3a14b6715c8b10d82e023c622a732e6c4"
     end
 
     on_arm do
       url "https://github.com/oferchen/rsync/releases/download/v0.5.2/oc-rsync-0.5.2-darwin-aarch64.tar.gz"
-      sha256 "dd34a0e38380e97fb90a3c01492c149556e3b727312891255fc92b43337af6df"
+      sha256 "3b5bb289ff251a93038d4dba61d89f4382859d0c94a13f337cc4de37f77447af"
     end
   end
 


### PR DESCRIPTION
This PR updates the Homebrew formula.

## Changes
- Updates formula with new version and SHA256 checksums
- Auto-generated by CI on tag push

## Testing
```bash
brew install --build-from-source ./Formula/oc-rsync.rb
```