### PR TITLE
chore: update Homebrew formula for v0.5.3

### DIFF
--- a/Formula/oc-rsync.rb
+++ b/Formula/oc-rsync.rb
@@ -2,17 +2,17 @@ class OcRsync < Formula
   desc "Pure-Rust rsync 3.4.1-compatible implementation"
   homepage "https://github.com/oferchen/rsync"
   license "GPL-3.0-or-later"
-  version "0.5.2"
+  version "0.5.3"
 
   on_macos do
     on_intel do
-      url "https://github.com/oferchen/rsync/releases/download/v0.5.2/oc-rsync-0.5.2-darwin-x86_64.tar.gz"
-      sha256 "b39b7fa1308c7c5c935485f202a053d3a14b6715c8b10d82e023c622a732e6c4"
+      url "https://github.com/oferchen/rsync/releases/download/v0.5.3/oc-rsync-0.5.2-darwin-x86_64.tar.gz"
+      sha256 "c4fc832fff7095663380b023d011faff1268310dd2571d47f19cd3d0dbe9c34d"
     end
 
     on_arm do
-      url "https://github.com/oferchen/rsync/releases/download/v0.5.2/oc-rsync-0.5.2-darwin-aarch64.tar.gz"
-      sha256 "3b5bb289ff251a93038d4dba61d89f4382859d0c94a13f337cc4de37f77447af"
+      url "https://github.com/oferchen/rsync/releases/download/v0.5.3/oc-rsync-0.5.2-darwin-aarch64.tar.gz"
+      sha256 "c36f720f129344a61ccb8cf6b7d5c3f7da028451de05288784e44ef42ee85428"
     end
   end
 


### PR DESCRIPTION
This PR updates the Homebrew formula.

## Changes
- Updates formula with new version and SHA256 checksums
- Auto-generated by CI on tag push

## Testing
```bash
brew install --build-from-source ./Formula/oc-rsync.rb
```