### PR TITLE
chore: update Homebrew formula for v0.5.2

### DIFF
--- a/Formula/oc-rsync.rb
+++ b/Formula/oc-rsync.rb
@@ -7,12 +7,12 @@ class OcRsync < Formula
   on_macos do
     on_intel do
       url "https://github.com/oferchen/rsync/releases/download/v0.5.2/oc-rsync-0.5.2-darwin-x86_64.tar.gz"
-      sha256 "09527d6e6415c863ba1445a04ed0a7693382d2dfe0ac8530eda22d4c59a60b6e"
+      sha256 "c210ddf9ba80aeb04d77399636b279bc023d806d781d0a1c1ef5d1350cc5f43e"
     end
 
     on_arm do
       url "https://github.com/oferchen/rsync/releases/download/v0.5.2/oc-rsync-0.5.2-darwin-aarch64.tar.gz"
-      sha256 "a58ba118c07e9a38a5252cb35ec879c12886d0c02ba228c89b569393a0f85896"
+      sha256 "70de3f739c9bea07970bd2fe898da18171d512123d46dbaab342f524791df54b"
     end
   end
 


### PR DESCRIPTION
This PR updates the Homebrew formula.

## Changes
- Updates formula with new version and SHA256 checksums
- Auto-generated by CI on tag push

## Testing
```bash
brew install --build-from-source ./Formula/oc-rsync.rb
```