### PR TITLE
chore: update Homebrew formula for v0.5.3

### DIFF
--- a/Formula/oc-rsync.rb
+++ b/Formula/oc-rsync.rb
@@ -2,17 +2,17 @@ class OcRsync < Formula
   desc "Pure-Rust rsync 3.4.1-compatible implementation"
   homepage "https://github.com/oferchen/rsync"
   license "GPL-3.0-or-later"
-  version "0.5.2"
+  version "0.5.3"
 
   on_macos do
     on_intel do
-      url "https://github.com/oferchen/rsync/releases/download/v0.5.2/oc-rsync-0.5.2-darwin-x86_64.tar.gz"
-      sha256 "fa0d26190b3c4e5d28b77b210e452840295e0b278feb6d9a62917348bfc88e1e"
+      url "https://github.com/oferchen/rsync/releases/download/v0.5.3/oc-rsync-0.5.3-darwin-x86_64.tar.gz"
+      sha256 "5b0ac2f96aa371b8c54364b82ad4084d6706c8419774fed9c04cc648cafac855"
     end
 
     on_arm do
-      url "https://github.com/oferchen/rsync/releases/download/v0.5.2/oc-rsync-0.5.2-darwin-aarch64.tar.gz"
-      sha256 "d9ed3a8afc63f4b3cc64e5362411d361d10e5800889d901cda273552768a448f"
+      url "https://github.com/oferchen/rsync/releases/download/v0.5.3/oc-rsync-0.5.3-darwin-aarch64.tar.gz"
+      sha256 "db8c5da96f88aa484de928402f241c91ab62cf7817f7011bfdd53c4bde05d467"
     end
   end
 


### PR DESCRIPTION
This PR updates the Homebrew formula.

## Changes
- Updates formula with new version and SHA256 checksums
- Auto-generated by CI on tag push

## Testing
```bash
brew install --build-from-source ./Formula/oc-rsync.rb
```