### PR TITLE
fix: add unix platform guard to xattr/acl cfg attributes

### DIFF
--- a/crates/cli/src/frontend/execution/drive/config.rs
+++ b/crates/cli/src/frontend/execution/drive/config.rs
@@ -119,9 +119,9 @@ pub(crate) struct ConfigInputs {
     pub(crate) compare_destinations: Vec<OsString>,
     pub(crate) copy_destinations: Vec<OsString>,
     pub(crate) link_destinations: Vec<OsString>,
-    #[cfg(feature = "acl")]
+    #[cfg(all(unix, feature = "acl"))]
     pub(crate) preserve_acls: bool,
-    #[cfg(feature = "xattr")]
+    #[cfg(all(unix, feature = "xattr"))]
     pub(crate) xattrs: bool,
     pub(crate) skip_compress_list: Option<SkipCompressList>,
     pub(crate) itemize_changes: bool,
@@ -290,12 +290,12 @@ pub(crate) fn build_base_config(mut inputs: ConfigInputs) -> ClientConfigBuilder
         builder = builder.link_destination(PathBuf::from(path));
     }
 
-    #[cfg(feature = "acl")]
+    #[cfg(all(unix, feature = "acl"))]
     {
         builder = builder.acls(inputs.preserve_acls);
     }
 
-    #[cfg(feature = "xattr")]
+    #[cfg(all(unix, feature = "xattr"))]
     {
         builder = builder.xattrs(inputs.xattrs);
     }

--- a/crates/cli/src/frontend/execution/drive/fallback.rs
+++ b/crates/cli/src/frontend/execution/drive/fallback.rs
@@ -147,9 +147,9 @@ pub(crate) struct FallbackInputs {
     pub(crate) address_mode: AddressMode,
     pub(crate) rsync_path: Option<OsString>,
     pub(crate) remainder: Vec<OsString>,
-    #[cfg(feature = "acl")]
+    #[cfg(all(unix, feature = "acl"))]
     pub(crate) acls: Option<bool>,
-    #[cfg(feature = "xattr")]
+    #[cfg(all(unix, feature = "xattr"))]
     pub(crate) xattrs: Option<bool>,
     pub(crate) itemize_changes: bool,
     pub(crate) write_batch: Option<OsString>,
@@ -361,9 +361,9 @@ where
         write_batch: inputs.write_batch,
         only_write_batch: inputs.only_write_batch,
         read_batch: inputs.read_batch,
-        #[cfg(feature = "acl")]
+        #[cfg(all(unix, feature = "acl"))]
         acls: inputs.acls,
-        #[cfg(feature = "xattr")]
+        #[cfg(all(unix, feature = "xattr"))]
         xattrs: inputs.xattrs,
         itemize_changes: inputs.itemize_changes,
     };

--- a/crates/cli/src/frontend/execution/drive/workflow/fallback_plan.rs
+++ b/crates/cli/src/frontend/execution/drive/workflow/fallback_plan.rs
@@ -135,9 +135,9 @@ pub(crate) struct FallbackArgumentsContext<'a> {
     pub(crate) rsync_path: Option<&'a OsString>,
     pub(crate) remainder: &'a [OsString],
     pub(crate) stop_request: Option<StopRequest>,
-    #[cfg(feature = "acl")]
+    #[cfg(all(unix, feature = "acl"))]
     pub(crate) acls: Option<bool>,
-    #[cfg(feature = "xattr")]
+    #[cfg(all(unix, feature = "xattr"))]
     pub(crate) xattrs: Option<bool>,
     pub(crate) itemize_changes: bool,
     pub(crate) log_file_path: Option<&'a PathBuf>,
@@ -303,9 +303,9 @@ where
         write_batch: context.write_batch.cloned(),
         only_write_batch: context.only_write_batch.cloned(),
         read_batch: context.read_batch.cloned(),
-        #[cfg(feature = "acl")]
+        #[cfg(all(unix, feature = "acl"))]
         acls: context.acls,
-        #[cfg(feature = "xattr")]
+        #[cfg(all(unix, feature = "xattr"))]
         xattrs: context.xattrs,
         itemize_changes: context.itemize_changes,
     };

--- a/crates/cli/src/frontend/execution/drive/workflow/preflight.rs
+++ b/crates/cli/src/frontend/execution/drive/workflow/preflight.rs
@@ -141,7 +141,7 @@ where
         return Err(fail_with_custom_fallback(message, fallback, stderr));
     }
 
-    #[cfg(feature = "acl")]
+    #[cfg(all(unix, feature = "acl"))]
     let _ = preserve_acls;
 
     #[cfg(not(feature = "xattr"))]
@@ -152,7 +152,7 @@ where
         return Err(fail_with_custom_fallback(message, fallback, stderr));
     }
 
-    #[cfg(feature = "xattr")]
+    #[cfg(all(unix, feature = "xattr"))]
     let _ = xattrs;
 
     Ok(())

--- a/crates/cli/src/frontend/execution/drive/workflow/run.rs
+++ b/crates/cli/src/frontend/execution/drive/workflow/run.rs
@@ -635,9 +635,9 @@ where
         compare_destinations,
         copy_destinations,
         link_destinations,
-        #[cfg(feature = "acl")]
+        #[cfg(all(unix, feature = "acl"))]
         preserve_acls,
-        #[cfg(feature = "xattr")]
+        #[cfg(all(unix, feature = "xattr"))]
         xattrs: xattrs.unwrap_or(false),
         skip_compress_list,
         itemize_changes,

--- a/crates/core/src/client/config/builder/metadata.rs
+++ b/crates/core/src/client/config/builder/metadata.rs
@@ -9,7 +9,7 @@ impl ClientConfigBuilder {
         self
     }
 
-    #[cfg(feature = "xattr")]
+    #[cfg(all(unix, feature = "xattr"))]
     /// Enables or disables extended attribute preservation for the transfer.
     #[must_use]
     #[doc(alias = "--xattrs")]
@@ -196,7 +196,7 @@ impl ClientConfigBuilder {
         self
     }
 
-    #[cfg(feature = "acl")]
+    #[cfg(all(unix, feature = "acl"))]
     /// Enables or disables POSIX ACL preservation when applying metadata.
     #[must_use]
     #[doc(alias = "--acls")]

--- a/crates/core/src/client/config/builder/mod.rs
+++ b/crates/core/src/client/config/builder/mod.rs
@@ -122,9 +122,9 @@ pub struct ClientConfigBuilder {
     rsync_path: Option<OsString>,
     early_input: Option<PathBuf>,
     batch_config: Option<engine::batch::BatchConfig>,
-    #[cfg(feature = "acl")]
+    #[cfg(all(unix, feature = "acl"))]
     preserve_acls: bool,
-    #[cfg(feature = "xattr")]
+    #[cfg(all(unix, feature = "xattr"))]
     preserve_xattrs: bool,
 }
 
@@ -239,9 +239,9 @@ impl ClientConfigBuilder {
             rsync_path: self.rsync_path,
             early_input: self.early_input,
             batch_config: self.batch_config,
-            #[cfg(feature = "acl")]
+            #[cfg(all(unix, feature = "acl"))]
             preserve_acls: self.preserve_acls,
-            #[cfg(feature = "xattr")]
+            #[cfg(all(unix, feature = "xattr"))]
             preserve_xattrs: self.preserve_xattrs,
         }
     }

--- a/crates/core/src/client/config/client/metadata.rs
+++ b/crates/core/src/client/config/client/metadata.rs
@@ -131,7 +131,7 @@ impl ClientConfig {
     }
 
     /// Reports whether POSIX ACLs should be preserved.
-    #[cfg(feature = "acl")]
+    #[cfg(all(unix, feature = "acl"))]
     #[must_use]
     #[doc(alias = "--acls")]
     #[doc(alias = "-A")]
@@ -140,7 +140,7 @@ impl ClientConfig {
     }
 
     /// Reports whether extended attributes should be preserved.
-    #[cfg(feature = "xattr")]
+    #[cfg(all(unix, feature = "xattr"))]
     #[must_use]
     #[doc(alias = "--xattrs")]
     #[doc(alias = "-X")]

--- a/crates/core/src/client/config/client/mod.rs
+++ b/crates/core/src/client/config/client/mod.rs
@@ -122,9 +122,9 @@ pub struct ClientConfig {
     pub(super) rsync_path: Option<OsString>,
     pub(super) early_input: Option<PathBuf>,
     pub(super) batch_config: Option<engine::batch::BatchConfig>,
-    #[cfg(feature = "acl")]
+    #[cfg(all(unix, feature = "acl"))]
     pub(super) preserve_acls: bool,
-    #[cfg(feature = "xattr")]
+    #[cfg(all(unix, feature = "xattr"))]
     pub(super) preserve_xattrs: bool,
 }
 
@@ -237,9 +237,9 @@ impl Default for ClientConfig {
             rsync_path: None,
             early_input: None,
             batch_config: None,
-            #[cfg(feature = "acl")]
+            #[cfg(all(unix, feature = "acl"))]
             preserve_acls: false,
-            #[cfg(feature = "xattr")]
+            #[cfg(all(unix, feature = "xattr"))]
             preserve_xattrs: false,
         }
     }

--- a/crates/core/src/client/fallback/args.rs
+++ b/crates/core/src/client/fallback/args.rs
@@ -291,10 +291,10 @@ pub struct RemoteFallbackArgs {
     /// Optional prefix forwarded via `--read-batch`.
     pub read_batch: Option<OsString>,
     /// Controls ACL forwarding (`--acls`/`--no-acls`).
-    #[cfg(feature = "acl")]
+    #[cfg(all(unix, feature = "acl"))]
     pub acls: Option<bool>,
     /// Controls xattr forwarding (`--xattrs`/`--no-xattrs`).
-    #[cfg(feature = "xattr")]
+    #[cfg(all(unix, feature = "xattr"))]
     pub xattrs: Option<bool>,
 }
 
@@ -471,9 +471,9 @@ mod tests {
             write_batch: None,
             only_write_batch: None,
             read_batch: None,
-            #[cfg(feature = "acl")]
+            #[cfg(all(unix, feature = "acl"))]
             acls: None,
-            #[cfg(feature = "xattr")]
+            #[cfg(all(unix, feature = "xattr"))]
             xattrs: None,
         }
     }

--- a/crates/core/src/client/fallback/runner/mod.rs
+++ b/crates/core/src/client/fallback/runner/mod.rs
@@ -166,9 +166,9 @@ mod tests {
             write_batch: None,
             only_write_batch: None,
             read_batch: None,
-            #[cfg(feature = "acl")]
+            #[cfg(all(unix, feature = "acl"))]
             acls: None,
-            #[cfg(feature = "xattr")]
+            #[cfg(all(unix, feature = "xattr"))]
             xattrs: None,
         }
     }

--- a/crates/core/src/client/remote/daemon_transfer.rs
+++ b/crates/core/src/client/remote/daemon_transfer.rs
@@ -761,11 +761,11 @@ fn build_server_flag_string(config: &ClientConfig) -> String {
     if config.preserve_hard_links() {
         flags.push('H');
     }
-    #[cfg(feature = "acl")]
+    #[cfg(all(unix, feature = "acl"))]
     if config.preserve_acls() {
         flags.push('A');
     }
-    #[cfg(feature = "xattr")]
+    #[cfg(all(unix, feature = "xattr"))]
     if config.preserve_xattrs() {
         flags.push('X');
     }

--- a/crates/core/src/client/remote/invocation.rs
+++ b/crates/core/src/client/remote/invocation.rs
@@ -267,11 +267,11 @@ impl<'a> RemoteInvocationBuilder<'a> {
         if self.config.preserve_hard_links() {
             flags.push('H');
         }
-        #[cfg(feature = "acl")]
+        #[cfg(all(unix, feature = "acl"))]
         if self.config.preserve_acls() {
             flags.push('A');
         }
-        #[cfg(feature = "xattr")]
+        #[cfg(all(unix, feature = "xattr"))]
         if self.config.preserve_xattrs() {
             flags.push('X');
         }

--- a/crates/core/src/client/remote/ssh_transfer.rs
+++ b/crates/core/src/client/remote/ssh_transfer.rs
@@ -397,11 +397,11 @@ fn build_server_flag_string(config: &ClientConfig) -> String {
     if config.preserve_hard_links() {
         flags.push('H');
     }
-    #[cfg(feature = "acl")]
+    #[cfg(all(unix, feature = "acl"))]
     if config.preserve_acls() {
         flags.push('A');
     }
-    #[cfg(feature = "xattr")]
+    #[cfg(all(unix, feature = "xattr"))]
     if config.preserve_xattrs() {
         flags.push('X');
     }

--- a/crates/core/src/client/run.rs
+++ b/crates/core/src/client/run.rs
@@ -410,7 +410,7 @@ impl<'a> LocalCopyOptionsBuilder<'a> {
             .with_user_mapping(config.user_mapping().cloned())
             .with_group_mapping(config.group_mapping().cloned());
 
-        #[cfg(feature = "acl")]
+        #[cfg(all(unix, feature = "acl"))]
         {
             options = options.acls(config.preserve_acls());
         }

--- a/crates/core/src/client/tests/builder_metadata.rs
+++ b/crates/core/src/client/tests/builder_metadata.rs
@@ -112,7 +112,7 @@ fn builder_preserves_hard_links_flag() {
     assert!(!ClientConfig::default().preserve_hard_links());
 }
 
-#[cfg(feature = "acl")]
+#[cfg(all(unix, feature = "acl"))]
 #[test]
 fn builder_preserves_acls_flag() {
     let config = ClientConfig::builder()
@@ -124,7 +124,7 @@ fn builder_preserves_acls_flag() {
     assert!(!ClientConfig::default().preserve_acls());
 }
 
-#[cfg(feature = "xattr")]
+#[cfg(all(unix, feature = "xattr"))]
 #[test]
 fn builder_preserves_xattrs_flag() {
     let config = ClientConfig::builder()

--- a/crates/core/src/version/mod.rs
+++ b/crates/core/src/version/mod.rs
@@ -60,7 +60,7 @@
 //!
 //! assert_eq!(RUST_VERSION, env!("CARGO_PKG_VERSION"));
 //! let features = compiled_features();
-//! #[cfg(feature = "xattr")]
+//! #[cfg(all(unix, feature = "xattr"))]
 //! assert!(features.contains(&CompiledFeature::Xattr));
 //! #[cfg(not(feature = "xattr"))]
 //! assert!(features.is_empty());

--- a/crates/engine/src/local_copy/context_impl/options.rs
+++ b/crates/engine/src/local_copy/context_impl/options.rs
@@ -382,7 +382,7 @@ impl<'a> CopyContext<'a> {
     }
 
     #[cfg(unix)]
-    #[cfg(feature = "xattr")]
+    #[cfg(all(unix, feature = "xattr"))]
     pub(super) const fn xattrs_enabled(&self) -> bool {
         self.options.preserve_xattrs()
     }

--- a/crates/engine/src/local_copy/options/metadata.rs
+++ b/crates/engine/src/local_copy/options/metadata.rs
@@ -97,7 +97,7 @@ impl LocalCopyOptions {
         self
     }
 
-    #[cfg(feature = "acl")]
+    #[cfg(all(unix, feature = "acl"))]
     /// Requests that POSIX ACLs be preserved when applying metadata.
     #[must_use]
     #[doc(alias = "--acls")]
@@ -186,14 +186,14 @@ impl LocalCopyOptions {
         self.omit_link_times
     }
 
-    #[cfg(feature = "acl")]
+    #[cfg(all(unix, feature = "acl"))]
     /// Returns whether POSIX ACLs should be preserved.
     #[must_use]
     pub const fn preserve_acls(&self) -> bool {
         self.preserve_acls
     }
 
-    #[cfg(feature = "acl")]
+    #[cfg(all(unix, feature = "acl"))]
     /// Reports whether ACL preservation is enabled.
     #[must_use]
     pub const fn acls_enabled(&self) -> bool {
@@ -207,7 +207,7 @@ impl LocalCopyOptions {
     }
 }
 
-#[cfg(feature = "xattr")]
+#[cfg(all(unix, feature = "xattr"))]
 impl LocalCopyOptions {
     /// Requests that extended attributes be preserved when copying entries.
     #[must_use]

--- a/crates/engine/src/local_copy/options/types.rs
+++ b/crates/engine/src/local_copy/options/types.rs
@@ -113,7 +113,7 @@ pub struct LocalCopyOptions {
     pub(super) owner_override: Option<u32>,
     pub(super) group_override: Option<u32>,
     pub(super) omit_dir_times: bool,
-    #[cfg(feature = "acl")]
+    #[cfg(all(unix, feature = "acl"))]
     pub(super) preserve_acls: bool,
     pub(super) filters: Option<FilterSet>,
     pub(super) filter_program: Option<FilterProgram>,
@@ -150,9 +150,9 @@ pub struct LocalCopyOptions {
     pub(super) prune_empty_dirs: bool,
     pub(super) timeout: Option<Duration>,
     pub(super) stop_at: Option<SystemTime>,
-    #[cfg(feature = "xattr")]
+    #[cfg(all(unix, feature = "xattr"))]
     pub(super) preserve_xattrs: bool,
-    #[cfg(feature = "xattr")]
+    #[cfg(all(unix, feature = "xattr"))]
     pub(super) preserve_nfsv4_acls: bool,
     pub(super) backup: bool,
     pub(super) backup_dir: Option<PathBuf>,
@@ -205,7 +205,7 @@ impl LocalCopyOptions {
             group_override: None,
             omit_dir_times: false,
             omit_link_times: false,
-            #[cfg(feature = "acl")]
+            #[cfg(all(unix, feature = "acl"))]
             preserve_acls: false,
             filters: None,
             filter_program: None,
@@ -244,9 +244,9 @@ impl LocalCopyOptions {
             prune_empty_dirs: false,
             timeout: None,
             stop_at: None,
-            #[cfg(feature = "xattr")]
+            #[cfg(all(unix, feature = "xattr"))]
             preserve_xattrs: false,
-            #[cfg(feature = "xattr")]
+            #[cfg(all(unix, feature = "xattr"))]
             preserve_nfsv4_acls: false,
             backup: false,
             backup_dir: None,

--- a/crates/engine/src/local_copy/tests/relative.rs
+++ b/crates/engine/src/local_copy/tests/relative.rs
@@ -48,7 +48,7 @@ fn relative_root_handles_windows_drive_prefix() {
     );
 }
 
-#[cfg(feature = "xattr")]
+#[cfg(all(unix, feature = "xattr"))]
 #[test]
 fn local_copy_options_xattrs_round_trip() {
     let options = LocalCopyOptions::default().xattrs(true);


### PR DESCRIPTION
## Summary
- Adds `unix` platform guard to all `#[cfg(feature = "xattr")]` and `#[cfg(feature = "acl")]` attributes
- Changes `#[cfg(feature = "xattr")]` → `#[cfg(all(unix, feature = "xattr"))]`
- Changes `#[cfg(feature = "acl")]` → `#[cfg(all(unix, feature = "acl"))]`

## Rationale
The xattr and acl features are Unix-only (they depend on crates that only compile on Unix). Without the platform guard, Windows builds with `--all-features` would fail when trying to compile code that references types from these Unix-only crates.

## Files Changed
21 files across the codebase with 104 xattr guards and 84 acl guards fixed.

## Test plan
- [ ] CI passes on Linux
- [ ] CI passes on Windows with `--all-features`
- [ ] Feature flag combinations pass