### PR TITLE
chore: update Homebrew formula for v0.5.3

### DIFF
--- a/Formula/oc-rsync.rb
+++ b/Formula/oc-rsync.rb
@@ -7,12 +7,12 @@ class OcRsync < Formula
   on_macos do
     on_intel do
       url "https://github.com/oferchen/rsync/releases/download/v0.5.3/oc-rsync-0.5.3-darwin-x86_64.tar.gz"
-      sha256 "80b923e8a140df6d688a2aec7916f2833e9c16d756de65d94d856b84ff546c53"
+      sha256 "7e7ae59e2ef32fbe3bb347fba4aab8d3eeadad5c75cf9a72d9b78b6300515cda"
     end
 
     on_arm do
       url "https://github.com/oferchen/rsync/releases/download/v0.5.3/oc-rsync-0.5.3-darwin-aarch64.tar.gz"
-      sha256 "26f4d0212587d2c6b89d0f444c8ff1c9c3e6248999155adda2b2141c43bc1be6"
+      sha256 "ae2622ba639f5ff79c24984c775cc158e2acd567ea799527e76180b565699e9b"
     end
   end
 


### PR DESCRIPTION
This PR updates the Homebrew formula.

## Changes
- Updates formula with new version and SHA256 checksums
- Auto-generated by CI on tag push

## Testing
```bash
brew install --build-from-source ./Formula/oc-rsync.rb
```