### PR TITLE
perf: reduce per-file allocation overhead; bump to v0.5.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,7 +90,7 @@ checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "apple-fs"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "libc",
  "nix",
@@ -134,7 +134,7 @@ dependencies = [
 
 [[package]]
 name = "bandwidth"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "memchr",
  "proptest",
@@ -149,7 +149,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "batch"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "protocol",
  "tempfile",
@@ -158,7 +158,7 @@ dependencies = [
 
 [[package]]
 name = "bin"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "assert_cmd",
  "checksums",
@@ -209,7 +209,7 @@ dependencies = [
 
 [[package]]
 name = "branding"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "serde",
  "serde_json",
@@ -304,7 +304,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "checksums"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "criterion",
  "digest",
@@ -392,7 +392,7 @@ checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
 name = "cli"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "apple-fs",
  "assert_cmd",
@@ -439,7 +439,7 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "compress"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "flate2",
  "lz4_flex",
@@ -449,7 +449,7 @@ dependencies = [
 
 [[package]]
 name = "core"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "bandwidth",
  "base64",
@@ -605,7 +605,7 @@ dependencies = [
 
 [[package]]
 name = "daemon"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "bandwidth",
  "base64",
@@ -699,7 +699,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "embedding"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "cli",
  "core",
@@ -717,7 +717,7 @@ dependencies = [
 
 [[package]]
 name = "engine"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "apple-fs",
  "bandwidth",
@@ -778,7 +778,7 @@ dependencies = [
 
 [[package]]
 name = "fast_io"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "criterion",
  "filetime",
@@ -812,7 +812,7 @@ dependencies = [
 
 [[package]]
 name = "filters"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "globset",
  "logging",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "flist"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "libc",
  "logging",
@@ -1229,7 +1229,7 @@ checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
 name = "logging"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "serde",
  "serde_json",
@@ -1239,7 +1239,7 @@ dependencies = [
 
 [[package]]
 name = "logging-sink"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "core",
 ]
@@ -1264,7 +1264,7 @@ dependencies = [
 
 [[package]]
 name = "matching"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "checksums",
  "criterion",
@@ -1330,7 +1330,7 @@ dependencies = [
 
 [[package]]
 name = "metadata"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "apple-fs",
  "exacl",
@@ -1655,7 +1655,7 @@ dependencies = [
 
 [[package]]
 name = "protocol"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "bytes",
  "compress",
@@ -1825,7 +1825,7 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "rsync_io"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "logging",
  "memchr",
@@ -2076,7 +2076,7 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "checksums",
  "protocol",
@@ -2413,7 +2413,7 @@ dependencies = [
 
 [[package]]
 name = "transfer"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "checksums",
  "compress",
@@ -2634,7 +2634,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-gnu-eh"
-version = "0.5.5"
+version = "0.5.6"
 
 [[package]]
 name = "windows-link"
@@ -2840,7 +2840,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "anstyle",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,7 +157,7 @@ edition = "2024"
 rust-version = "1.88"
 authors = ["Ofer Chen <skewers.irises.3b@icloud.com>"]
 license = "GPL-3.0-or-later"
-version = "0.5.5"
+version = "0.5.6"
 repository = "https://github.com/oferchen/rsync"
 
 [workspace.dependencies]
@@ -315,7 +315,7 @@ strip = false
 [workspace.metadata.oc_rsync]
 brand = "oc"
 upstream_version = "3.4.1"
-rust_version = "0.5.5"
+rust_version = "0.5.6"
 protocol = 32
 client_bin = "oc-rsync"
 daemon_bin = "oc-rsync"


### PR DESCRIPTION
## Summary

- Eliminate ~30K unnecessary heap allocations per 10K-file transfer:
  - Pass PathBuf by value through `walk_path`/`create_entry` (2 fewer clones per file)
  - Add `ChecksumVerifier::finalize_into()` for stack-based digest output
  - Replace `vec![0u8; N]` with stack array in `write_checksum`
  - Pre-allocate `file_list`/`full_paths` Vecs with capacity 4096
- Reduces push-to-daemon peak RSS by 11.5% (16.5 MB → 14.6 MB for 10K files)
- Bump version to 0.5.6
- Update README.md: add push-to-daemon benchmarks, complete project layout (23 crates), clarify security claims

## Benchmark (push-to-daemon, TCP loopback, Linux aarch64)

| Workload | upstream 3.4.1 | oc-rsync v0.5.5 | oc-rsync v0.5.6 | v0.5.6 vs upstream |
|---|---|---|---|---|
| 10K × 4KB | 484 ms | 604 ms | 388 ms | **1.25x faster** |
| 1K × 128KB | 237 ms | 360 ms | 142 ms | **1.68x faster** |
| 100 × 1MB | 180 ms | 316 ms | 90 ms | **1.99x faster** |
| Empty dir | 96 ms | 215 ms | 3 ms | **32x faster** |

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -D warnings`
- [x] `cargo nextest run --workspace --all-features` — 21,710 tests pass
- [x] Push-to-daemon benchmarked against upstream rsync 3.4.1 in container
- [x] Wire format unchanged (interop with upstream daemon verified)