### PR TITLE
fix: eliminate flaky tests from port TOCTOU race and CI timing

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -15,3 +15,9 @@ success-output = "never"
 slow-timeout = { period = "120s", terminate-after = 3 }
 # Generate JUnit XML for CI dashboards (optional, not currently used)
 # junit.path = "junit.xml"
+
+# Retry policies for tests with inherent race conditions (port binding TOCTOU,
+# slow CI runner timing).
+[[profile.ci.overrides]]
+filter = "package(daemon) | test(execute_sparse)"
+retries = 2

--- a/crates/daemon/src/tests/chunks/daemon_generator_accepts_file_pull.rs
+++ b/crates/daemon/src/tests/chunks/daemon_generator_accepts_file_pull.rs
@@ -20,7 +20,7 @@ fn daemon_generator_accepts_file_pull() {
     );
     fs::write(&config_file, config_content).expect("write config");
 
-    let port = allocate_test_port();
+    let (port, held_listener) = allocate_test_port();
 
     let config = DaemonConfig::builder()
         .disable_default_paths()
@@ -33,7 +33,7 @@ fn daemon_generator_accepts_file_pull() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon(config, port);
+    let (mut stream, handle) = start_daemon(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
 
     // Read daemon greeting

--- a/crates/daemon/src/tests/chunks/daemon_negotiation_authentication.rs
+++ b/crates/daemon/src/tests/chunks/daemon_negotiation_authentication.rs
@@ -38,7 +38,7 @@ fn daemon_negotiation_auth_challenge_is_unique_per_session() {
     let mut challenges = Vec::new();
 
     for _ in 0..2 {
-        let port = allocate_test_port();
+        let (port, held_listener) = allocate_test_port();
 
         let config = DaemonConfig::builder()
             .disable_default_paths()
@@ -51,7 +51,7 @@ fn daemon_negotiation_auth_challenge_is_unique_per_session() {
             ])
             .build();
 
-        let (mut stream, handle) = start_daemon(config, port);
+        let (mut stream, handle) = start_daemon(config, port, held_listener);
         let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
 
         // Read greeting
@@ -126,7 +126,7 @@ fn daemon_negotiation_auth_denies_wrong_password() {
     )
     .expect("write config");
 
-    let port = allocate_test_port();
+    let (port, held_listener) = allocate_test_port();
 
     let config = DaemonConfig::builder()
         .disable_default_paths()
@@ -139,7 +139,7 @@ fn daemon_negotiation_auth_denies_wrong_password() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon(config, port);
+    let (mut stream, handle) = start_daemon(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
 
     // Read greeting
@@ -220,7 +220,7 @@ fn daemon_negotiation_auth_denies_unknown_user() {
     )
     .expect("write config");
 
-    let port = allocate_test_port();
+    let (port, held_listener) = allocate_test_port();
 
     let config = DaemonConfig::builder()
         .disable_default_paths()
@@ -233,7 +233,7 @@ fn daemon_negotiation_auth_denies_unknown_user() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon(config, port);
+    let (mut stream, handle) = start_daemon(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
 
     // Read greeting
@@ -301,7 +301,7 @@ fn daemon_negotiation_auth_skipped_for_unprotected_module() {
     )
     .expect("write config");
 
-    let port = allocate_test_port();
+    let (port, held_listener) = allocate_test_port();
 
     let config = DaemonConfig::builder()
         .disable_default_paths()
@@ -314,7 +314,7 @@ fn daemon_negotiation_auth_skipped_for_unprotected_module() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon(config, port);
+    let (mut stream, handle) = start_daemon(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
 
     // Read greeting
@@ -375,7 +375,7 @@ fn daemon_negotiation_auth_denies_empty_credentials() {
     )
     .expect("write config");
 
-    let port = allocate_test_port();
+    let (port, held_listener) = allocate_test_port();
 
     let config = DaemonConfig::builder()
         .disable_default_paths()
@@ -388,7 +388,7 @@ fn daemon_negotiation_auth_denies_empty_credentials() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon(config, port);
+    let (mut stream, handle) = start_daemon(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
 
     // Read greeting
@@ -460,7 +460,7 @@ fn daemon_negotiation_auth_successful_sends_ok() {
     )
     .expect("write config");
 
-    let port = allocate_test_port();
+    let (port, held_listener) = allocate_test_port();
 
     let config = DaemonConfig::builder()
         .disable_default_paths()
@@ -473,7 +473,7 @@ fn daemon_negotiation_auth_successful_sends_ok() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon(config, port);
+    let (mut stream, handle) = start_daemon(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
 
     // Read greeting

--- a/crates/daemon/src/tests/chunks/daemon_negotiation_error_handling.rs
+++ b/crates/daemon/src/tests/chunks/daemon_negotiation_error_handling.rs
@@ -10,7 +10,7 @@ fn daemon_negotiation_error_unknown_module() {
     let _primary = EnvGuard::set(DAEMON_FALLBACK_ENV, OsStr::new("0"));
     let _secondary = EnvGuard::set(CLIENT_FALLBACK_ENV, OsStr::new("0"));
 
-    let port = allocate_test_port();
+    let (port, held_listener) = allocate_test_port();
 
     let config = DaemonConfig::builder()
         .disable_default_paths()
@@ -21,7 +21,7 @@ fn daemon_negotiation_error_unknown_module() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon(config, port);
+    let (mut stream, handle) = start_daemon(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone"));
 
     // Read greeting
@@ -65,7 +65,7 @@ fn daemon_negotiation_error_empty_module_request() {
     let _primary = EnvGuard::set(DAEMON_FALLBACK_ENV, OsStr::new("0"));
     let _secondary = EnvGuard::set(CLIENT_FALLBACK_ENV, OsStr::new("0"));
 
-    let port = allocate_test_port();
+    let (port, held_listener) = allocate_test_port();
 
     let config = DaemonConfig::builder()
         .disable_default_paths()
@@ -76,7 +76,7 @@ fn daemon_negotiation_error_empty_module_request() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon(config, port);
+    let (mut stream, handle) = start_daemon(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone"));
 
     // Read greeting
@@ -127,7 +127,7 @@ fn daemon_negotiation_error_host_denied() {
     )
     .expect("write config");
 
-    let port = allocate_test_port();
+    let (port, held_listener) = allocate_test_port();
 
     let config = DaemonConfig::builder()
         .disable_default_paths()
@@ -140,7 +140,7 @@ fn daemon_negotiation_error_host_denied() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon(config, port);
+    let (mut stream, handle) = start_daemon(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone"));
 
     // Read greeting
@@ -194,7 +194,7 @@ fn daemon_negotiation_error_refused_options() {
     )
     .expect("write config");
 
-    let port = allocate_test_port();
+    let (port, held_listener) = allocate_test_port();
 
     let config = DaemonConfig::builder()
         .disable_default_paths()
@@ -207,7 +207,7 @@ fn daemon_negotiation_error_refused_options() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon(config, port);
+    let (mut stream, handle) = start_daemon(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone"));
 
     // Read greeting
@@ -278,7 +278,7 @@ fn daemon_negotiation_error_max_connections_exceeded() {
     )
     .expect("write config");
 
-    let port = allocate_test_port();
+    let (port, held_listener) = allocate_test_port();
 
     // Run daemon with multiple allowed sessions
     let config = DaemonConfig::builder()
@@ -293,7 +293,7 @@ fn daemon_negotiation_error_max_connections_exceeded() {
         ])
         .build();
 
-    let (mut stream1, handle) = start_daemon(config, port);
+    let (mut stream1, handle) = start_daemon(config, port, held_listener);
 
     // First connection should succeed (up to the OK)
     let mut reader1 = BufReader::new(stream1.try_clone().expect("clone"));
@@ -357,7 +357,7 @@ fn daemon_negotiation_error_sanitizes_module_name_in_response() {
     let _primary = EnvGuard::set(DAEMON_FALLBACK_ENV, OsStr::new("0"));
     let _secondary = EnvGuard::set(CLIENT_FALLBACK_ENV, OsStr::new("0"));
 
-    let port = allocate_test_port();
+    let (port, held_listener) = allocate_test_port();
 
     let config = DaemonConfig::builder()
         .disable_default_paths()
@@ -368,7 +368,7 @@ fn daemon_negotiation_error_sanitizes_module_name_in_response() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon(config, port);
+    let (mut stream, handle) = start_daemon(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone"));
 
     // Read greeting
@@ -409,7 +409,7 @@ fn daemon_negotiation_error_sends_exit_after_error() {
     let _primary = EnvGuard::set(DAEMON_FALLBACK_ENV, OsStr::new("0"));
     let _secondary = EnvGuard::set(CLIENT_FALLBACK_ENV, OsStr::new("0"));
 
-    let port = allocate_test_port();
+    let (port, held_listener) = allocate_test_port();
 
     let config = DaemonConfig::builder()
         .disable_default_paths()
@@ -420,7 +420,7 @@ fn daemon_negotiation_error_sends_exit_after_error() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon(config, port);
+    let (mut stream, handle) = start_daemon(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone"));
 
     // Read greeting
@@ -462,7 +462,7 @@ fn daemon_negotiation_error_connection_closed_early() {
     let _primary = EnvGuard::set(DAEMON_FALLBACK_ENV, OsStr::new("0"));
     let _secondary = EnvGuard::set(CLIENT_FALLBACK_ENV, OsStr::new("0"));
 
-    let port = allocate_test_port();
+    let (port, held_listener) = allocate_test_port();
 
     let config = DaemonConfig::builder()
         .disable_default_paths()
@@ -473,7 +473,7 @@ fn daemon_negotiation_error_connection_closed_early() {
         ])
         .build();
 
-    let (stream, handle) = start_daemon(config, port);
+    let (stream, handle) = start_daemon(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone"));
 
     // Read greeting
@@ -497,7 +497,7 @@ fn daemon_negotiation_error_invalid_greeting_response() {
     let _primary = EnvGuard::set(DAEMON_FALLBACK_ENV, OsStr::new("0"));
     let _secondary = EnvGuard::set(CLIENT_FALLBACK_ENV, OsStr::new("0"));
 
-    let port = allocate_test_port();
+    let (port, held_listener) = allocate_test_port();
 
     let config = DaemonConfig::builder()
         .disable_default_paths()
@@ -508,7 +508,7 @@ fn daemon_negotiation_error_invalid_greeting_response() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon(config, port);
+    let (mut stream, handle) = start_daemon(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone"));
 
     // Read greeting

--- a/crates/daemon/src/tests/chunks/daemon_negotiation_module_listing.rs
+++ b/crates/daemon/src/tests/chunks/daemon_negotiation_module_listing.rs
@@ -11,7 +11,7 @@ fn daemon_negotiation_module_list_sends_capabilities_before_ok() {
     let _primary = EnvGuard::set(DAEMON_FALLBACK_ENV, OsStr::new("0"));
     let _secondary = EnvGuard::set(CLIENT_FALLBACK_ENV, OsStr::new("0"));
 
-    let port = allocate_test_port();
+    let (port, held_listener) = allocate_test_port();
 
     let config = DaemonConfig::builder()
         .disable_default_paths()
@@ -24,7 +24,7 @@ fn daemon_negotiation_module_list_sends_capabilities_before_ok() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon(config, port);
+    let (mut stream, handle) = start_daemon(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
 
     // Read greeting
@@ -88,7 +88,7 @@ fn daemon_negotiation_module_list_respects_listable_flag() {
     )
     .expect("write config");
 
-    let port = allocate_test_port();
+    let (port, held_listener) = allocate_test_port();
 
     let config = DaemonConfig::builder()
         .disable_default_paths()
@@ -101,7 +101,7 @@ fn daemon_negotiation_module_list_respects_listable_flag() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon(config, port);
+    let (mut stream, handle) = start_daemon(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
 
     // Read greeting
@@ -150,7 +150,7 @@ fn daemon_negotiation_module_list_includes_comments() {
     let _primary = EnvGuard::set(DAEMON_FALLBACK_ENV, OsStr::new("0"));
     let _secondary = EnvGuard::set(CLIENT_FALLBACK_ENV, OsStr::new("0"));
 
-    let port = allocate_test_port();
+    let (port, held_listener) = allocate_test_port();
 
     let config = DaemonConfig::builder()
         .disable_default_paths()
@@ -163,7 +163,7 @@ fn daemon_negotiation_module_list_includes_comments() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon(config, port);
+    let (mut stream, handle) = start_daemon(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
 
     // Read greeting
@@ -201,7 +201,7 @@ fn daemon_negotiation_module_list_empty_when_no_modules() {
     let _primary = EnvGuard::set(DAEMON_FALLBACK_ENV, OsStr::new("0"));
     let _secondary = EnvGuard::set(CLIENT_FALLBACK_ENV, OsStr::new("0"));
 
-    let port = allocate_test_port();
+    let (port, held_listener) = allocate_test_port();
 
     let config = DaemonConfig::builder()
         .disable_default_paths()
@@ -212,7 +212,7 @@ fn daemon_negotiation_module_list_empty_when_no_modules() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon(config, port);
+    let (mut stream, handle) = start_daemon(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
 
     // Read greeting

--- a/crates/daemon/src/tests/chunks/daemon_negotiation_version.rs
+++ b/crates/daemon/src/tests/chunks/daemon_negotiation_version.rs
@@ -10,7 +10,7 @@ fn daemon_negotiation_version_sends_greeting_first() {
     let _primary = EnvGuard::set(DAEMON_FALLBACK_ENV, OsStr::new("0"));
     let _secondary = EnvGuard::set(CLIENT_FALLBACK_ENV, OsStr::new("0"));
 
-    let port = allocate_test_port();
+    let (port, held_listener) = allocate_test_port();
 
     let config = DaemonConfig::builder()
         .disable_default_paths()
@@ -21,7 +21,7 @@ fn daemon_negotiation_version_sends_greeting_first() {
         ])
         .build();
 
-    let (stream, handle) = start_daemon(config, port);
+    let (stream, handle) = start_daemon(config, port, held_listener);
     stream
         .set_read_timeout(Some(Duration::from_secs(5)))
         .expect("set timeout");
@@ -48,7 +48,7 @@ fn daemon_negotiation_version_greeting_format() {
     let _primary = EnvGuard::set(DAEMON_FALLBACK_ENV, OsStr::new("0"));
     let _secondary = EnvGuard::set(CLIENT_FALLBACK_ENV, OsStr::new("0"));
 
-    let port = allocate_test_port();
+    let (port, held_listener) = allocate_test_port();
 
     let config = DaemonConfig::builder()
         .disable_default_paths()
@@ -59,7 +59,7 @@ fn daemon_negotiation_version_greeting_format() {
         ])
         .build();
 
-    let (stream, handle) = start_daemon(config, port);
+    let (stream, handle) = start_daemon(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone"));
 
     let mut line = String::new();
@@ -100,7 +100,7 @@ fn daemon_negotiation_version_accepts_older_client_version() {
     let _primary = EnvGuard::set(DAEMON_FALLBACK_ENV, OsStr::new("0"));
     let _secondary = EnvGuard::set(CLIENT_FALLBACK_ENV, OsStr::new("0"));
 
-    let port = allocate_test_port();
+    let (port, held_listener) = allocate_test_port();
 
     let config = DaemonConfig::builder()
         .disable_default_paths()
@@ -111,7 +111,7 @@ fn daemon_negotiation_version_accepts_older_client_version() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon(config, port);
+    let (mut stream, handle) = start_daemon(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone"));
 
     // Read greeting
@@ -149,7 +149,7 @@ fn daemon_negotiation_version_includes_digest_list_for_protocol_31_plus() {
     let _primary = EnvGuard::set(DAEMON_FALLBACK_ENV, OsStr::new("0"));
     let _secondary = EnvGuard::set(CLIENT_FALLBACK_ENV, OsStr::new("0"));
 
-    let port = allocate_test_port();
+    let (port, held_listener) = allocate_test_port();
 
     let config = DaemonConfig::builder()
         .disable_default_paths()
@@ -160,7 +160,7 @@ fn daemon_negotiation_version_includes_digest_list_for_protocol_31_plus() {
         ])
         .build();
 
-    let (stream, handle) = start_daemon(config, port);
+    let (stream, handle) = start_daemon(config, port, held_listener);
     let mut reader = BufReader::new(stream);
 
     let mut line = String::new();
@@ -211,7 +211,7 @@ fn daemon_negotiation_version_echoes_client_digests() {
     let _primary = EnvGuard::set(DAEMON_FALLBACK_ENV, OsStr::new("0"));
     let _secondary = EnvGuard::set(CLIENT_FALLBACK_ENV, OsStr::new("0"));
 
-    let port = allocate_test_port();
+    let (port, held_listener) = allocate_test_port();
 
     let config = DaemonConfig::builder()
         .disable_default_paths()
@@ -222,7 +222,7 @@ fn daemon_negotiation_version_echoes_client_digests() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon(config, port);
+    let (mut stream, handle) = start_daemon(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone"));
 
     // Read greeting
@@ -258,7 +258,7 @@ fn daemon_negotiation_version_handles_whitespace_variations() {
     let _primary = EnvGuard::set(DAEMON_FALLBACK_ENV, OsStr::new("0"));
     let _secondary = EnvGuard::set(CLIENT_FALLBACK_ENV, OsStr::new("0"));
 
-    let port = allocate_test_port();
+    let (port, held_listener) = allocate_test_port();
 
     let config = DaemonConfig::builder()
         .disable_default_paths()
@@ -269,7 +269,7 @@ fn daemon_negotiation_version_handles_whitespace_variations() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon(config, port);
+    let (mut stream, handle) = start_daemon(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone"));
 
     // Read greeting
@@ -305,7 +305,7 @@ fn daemon_negotiation_version_greeting_ends_with_newline() {
     let _primary = EnvGuard::set(DAEMON_FALLBACK_ENV, OsStr::new("0"));
     let _secondary = EnvGuard::set(CLIENT_FALLBACK_ENV, OsStr::new("0"));
 
-    let port = allocate_test_port();
+    let (port, held_listener) = allocate_test_port();
 
     let config = DaemonConfig::builder()
         .disable_default_paths()
@@ -316,7 +316,7 @@ fn daemon_negotiation_version_greeting_ends_with_newline() {
         ])
         .build();
 
-    let (stream, handle) = start_daemon(config, port);
+    let (stream, handle) = start_daemon(config, port, held_listener);
     let mut reader = BufReader::new(stream);
 
     let mut line = String::new();

--- a/crates/daemon/src/tests/chunks/daemon_receiver_accepts_file_push.rs
+++ b/crates/daemon/src/tests/chunks/daemon_receiver_accepts_file_push.rs
@@ -35,7 +35,7 @@ fn daemon_receiver_accepts_file_push() {
     );
     fs::write(&config_file, config_content).expect("write config");
 
-    let port = allocate_test_port();
+    let (port, held_listener) = allocate_test_port();
 
     let config = DaemonConfig::builder()
         .disable_default_paths()
@@ -48,7 +48,7 @@ fn daemon_receiver_accepts_file_push() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon(config, port);
+    let (mut stream, handle) = start_daemon(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
 
     // Read daemon greeting

--- a/crates/daemon/src/tests/chunks/run_daemon_accepts_valid_credentials.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_accepts_valid_credentials.rs
@@ -28,7 +28,7 @@ fn run_daemon_accepts_valid_credentials() {
     )
     .expect("write config");
 
-    let port = allocate_test_port();
+    let (port, held_listener) = allocate_test_port();
 
     let config = DaemonConfig::builder()
         .disable_default_paths()
@@ -41,7 +41,7 @@ fn run_daemon_accepts_valid_credentials() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon(config, port);
+    let (mut stream, handle) = start_daemon(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
 
     let expected_greeting = legacy_daemon_greeting();

--- a/crates/daemon/src/tests/chunks/run_daemon_denies_module_when_host_not_allowed.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_denies_module_when_host_not_allowed.rs
@@ -4,7 +4,7 @@ fn run_daemon_denies_module_when_host_not_allowed() {
     let _primary = EnvGuard::set(DAEMON_FALLBACK_ENV, OsStr::new("0"));
     let _secondary = EnvGuard::set(CLIENT_FALLBACK_ENV, OsStr::new("0"));
 
-    let port = allocate_test_port();
+    let (port, held_listener) = allocate_test_port();
 
     let mut file = NamedTempFile::new().expect("config file");
     writeln!(file, "[docs]\npath = /srv/docs\nhosts allow = 10.0.0.0/8\n",).expect("write config");
@@ -20,7 +20,7 @@ fn run_daemon_denies_module_when_host_not_allowed() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon(config, port);
+    let (mut stream, handle) = start_daemon(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
 
     let expected_greeting = legacy_daemon_greeting();

--- a/crates/daemon/src/tests/chunks/run_daemon_enforces_bwlimit_during_module_list.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_enforces_bwlimit_during_module_list.rs
@@ -7,7 +7,7 @@ fn run_daemon_enforces_bwlimit_during_module_list() {
     let mut recorder = bandwidth::recorded_sleep_session();
     recorder.clear();
 
-    let port = allocate_test_port();
+    let (port, held_listener) = allocate_test_port();
 
     let comment = "x".repeat(4096);
     let config = DaemonConfig::builder()
@@ -25,7 +25,7 @@ fn run_daemon_enforces_bwlimit_during_module_list() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon(config, port);
+    let (mut stream, handle) = start_daemon(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
 
     let expected_greeting = legacy_daemon_greeting();

--- a/crates/daemon/src/tests/chunks/run_daemon_enforces_module_connection_limit.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_enforces_module_connection_limit.rs
@@ -26,7 +26,7 @@ fn run_daemon_enforces_module_connection_limit() {
     )
     .expect("write config");
 
-    let port = allocate_test_port();
+    let (port, held_listener) = allocate_test_port();
 
     let config = DaemonConfig::builder()
         .disable_default_paths()
@@ -40,7 +40,7 @@ fn run_daemon_enforces_module_connection_limit() {
         ])
         .build();
 
-    let (mut first_stream, handle) = start_daemon(config, port);
+    let (mut first_stream, handle) = start_daemon(config, port, held_listener);
     let mut first_reader = BufReader::new(first_stream.try_clone().expect("clone stream"));
 
     let expected_greeting = legacy_daemon_greeting();

--- a/crates/daemon/src/tests/chunks/run_daemon_filters_modules_during_list_request.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_filters_modules_during_list_request.rs
@@ -4,7 +4,7 @@ fn run_daemon_filters_modules_during_list_request() {
     let _primary = EnvGuard::set(DAEMON_FALLBACK_ENV, OsStr::new("0"));
     let _secondary = EnvGuard::set(CLIENT_FALLBACK_ENV, OsStr::new("0"));
 
-    let port = allocate_test_port();
+    let (port, held_listener) = allocate_test_port();
 
     let mut file = NamedTempFile::new().expect("config file");
     writeln!(
@@ -24,7 +24,7 @@ fn run_daemon_filters_modules_during_list_request() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon(config, port);
+    let (mut stream, handle) = start_daemon(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
 
     let expected_greeting = legacy_daemon_greeting();

--- a/crates/daemon/src/tests/chunks/run_daemon_handles_binary_negotiation.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_handles_binary_negotiation.rs
@@ -8,7 +8,7 @@ fn run_daemon_handles_binary_negotiation() {
     let _primary = EnvGuard::set(DAEMON_FALLBACK_ENV, OsStr::new("0"));
     let _secondary = EnvGuard::set(CLIENT_FALLBACK_ENV, OsStr::new("0"));
 
-    let port = allocate_test_port();
+    let (port, held_listener) = allocate_test_port();
 
     let config = DaemonConfig::builder()
         .disable_default_paths()
@@ -19,7 +19,7 @@ fn run_daemon_handles_binary_negotiation() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon(config, port);
+    let (mut stream, handle) = start_daemon(config, port, held_listener);
     stream
         .set_read_timeout(Some(Duration::from_secs(5)))
         .expect("set read timeout");

--- a/crates/daemon/src/tests/chunks/run_daemon_handles_parallel_sessions.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_handles_parallel_sessions.rs
@@ -4,7 +4,7 @@ fn run_daemon_handles_parallel_sessions() {
     let _primary = EnvGuard::set(DAEMON_FALLBACK_ENV, OsStr::new("0"));
     let _secondary = EnvGuard::set(CLIENT_FALLBACK_ENV, OsStr::new("0"));
 
-    let port = allocate_test_port();
+    let (port, held_listener) = allocate_test_port();
 
     let config = DaemonConfig::builder()
         .disable_default_paths()
@@ -16,6 +16,7 @@ fn run_daemon_handles_parallel_sessions() {
         ])
         .build();
 
+    drop(held_listener);
     let handle = thread::spawn(move || run_daemon(config));
 
     let barrier = Arc::new(Barrier::new(2));

--- a/crates/daemon/src/tests/chunks/run_daemon_honours_max_sessions.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_honours_max_sessions.rs
@@ -4,7 +4,7 @@ fn run_daemon_honours_max_sessions() {
     let _primary = EnvGuard::set(DAEMON_FALLBACK_ENV, OsStr::new("0"));
     let _secondary = EnvGuard::set(CLIENT_FALLBACK_ENV, OsStr::new("0"));
 
-    let port = allocate_test_port();
+    let (port, held_listener) = allocate_test_port();
 
     let config = DaemonConfig::builder()
         .disable_default_paths()
@@ -16,6 +16,7 @@ fn run_daemon_honours_max_sessions() {
         ])
         .build();
 
+    drop(held_listener);
     let handle = thread::spawn(move || run_daemon(config));
 
     let expected_greeting = legacy_daemon_greeting();

--- a/crates/daemon/src/tests/chunks/run_daemon_lists_modules_on_request.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_lists_modules_on_request.rs
@@ -4,7 +4,7 @@ fn run_daemon_lists_modules_on_request() {
     let _primary = EnvGuard::set(DAEMON_FALLBACK_ENV, OsStr::new("0"));
     let _secondary = EnvGuard::set(CLIENT_FALLBACK_ENV, OsStr::new("0"));
 
-    let port = allocate_test_port();
+    let (port, held_listener) = allocate_test_port();
 
     let config = DaemonConfig::builder()
         .disable_default_paths()
@@ -19,7 +19,7 @@ fn run_daemon_lists_modules_on_request() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon(config, port);
+    let (mut stream, handle) = start_daemon(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
 
     let expected_greeting = legacy_daemon_greeting();

--- a/crates/daemon/src/tests/chunks/run_daemon_lists_modules_with_motd_lines.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_lists_modules_with_motd_lines.rs
@@ -4,7 +4,7 @@ fn run_daemon_lists_modules_with_motd_lines() {
     let _primary = EnvGuard::set(DAEMON_FALLBACK_ENV, OsStr::new("0"));
     let _secondary = EnvGuard::set(CLIENT_FALLBACK_ENV, OsStr::new("0"));
 
-    let port = allocate_test_port();
+    let (port, held_listener) = allocate_test_port();
 
     let dir = tempdir().expect("motd dir");
     let motd_path = dir.path().join("motd.txt");
@@ -29,7 +29,7 @@ fn run_daemon_lists_modules_with_motd_lines() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon(config, port);
+    let (mut stream, handle) = start_daemon(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
 
     let expected_greeting = legacy_daemon_greeting();

--- a/crates/daemon/src/tests/chunks/run_daemon_omits_unlisted_modules_from_listing.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_omits_unlisted_modules_from_listing.rs
@@ -4,7 +4,7 @@ fn run_daemon_omits_unlisted_modules_from_listing() {
     let _primary = EnvGuard::set(DAEMON_FALLBACK_ENV, OsStr::new("0"));
     let _secondary = EnvGuard::set(CLIENT_FALLBACK_ENV, OsStr::new("0"));
 
-    let port = allocate_test_port();
+    let (port, held_listener) = allocate_test_port();
 
     let mut file = NamedTempFile::new().expect("config file");
     writeln!(
@@ -26,7 +26,7 @@ fn run_daemon_omits_unlisted_modules_from_listing() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon(config, port);
+    let (mut stream, handle) = start_daemon(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
 
     let expected_greeting = legacy_daemon_greeting();

--- a/crates/daemon/src/tests/chunks/run_daemon_records_log_file_entries.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_records_log_file_entries.rs
@@ -4,7 +4,7 @@ fn run_daemon_records_log_file_entries() {
     let _primary = EnvGuard::set(DAEMON_FALLBACK_ENV, OsStr::new("0"));
     let _secondary = EnvGuard::set(CLIENT_FALLBACK_ENV, OsStr::new("0"));
 
-    let port = allocate_test_port();
+    let (port, held_listener) = allocate_test_port();
 
     let temp = tempdir().expect("log dir");
     let log_path = temp.path().join("rsyncd.log");
@@ -22,7 +22,7 @@ fn run_daemon_records_log_file_entries() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon(config, port);
+    let (mut stream, handle) = start_daemon(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
 
     let expected_greeting = legacy_daemon_greeting();

--- a/crates/daemon/src/tests/chunks/run_daemon_refuses_disallowed_module_options.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_refuses_disallowed_module_options.rs
@@ -4,7 +4,7 @@ fn run_daemon_refuses_disallowed_module_options() {
     let _primary = EnvGuard::set(DAEMON_FALLBACK_ENV, OsStr::new("0"));
     let _secondary = EnvGuard::set(CLIENT_FALLBACK_ENV, OsStr::new("0"));
 
-    let port = allocate_test_port();
+    let (port, held_listener) = allocate_test_port();
 
     let mut file = NamedTempFile::new().expect("config file");
     writeln!(
@@ -24,7 +24,7 @@ fn run_daemon_refuses_disallowed_module_options() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon(config, port);
+    let (mut stream, handle) = start_daemon(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
 
     let expected_greeting = legacy_daemon_greeting();

--- a/crates/daemon/src/tests/chunks/run_daemon_requests_authentication_for_protected_module.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_requests_authentication_for_protected_module.rs
@@ -28,7 +28,7 @@ fn run_daemon_requests_authentication_for_protected_module() {
     )
     .expect("write config");
 
-    let port = allocate_test_port();
+    let (port, held_listener) = allocate_test_port();
 
     let config = DaemonConfig::builder()
         .disable_default_paths()
@@ -41,7 +41,7 @@ fn run_daemon_requests_authentication_for_protected_module() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon(config, port);
+    let (mut stream, handle) = start_daemon(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
 
     let expected_greeting = legacy_daemon_greeting();

--- a/crates/daemon/src/tests/chunks/run_daemon_serves_single_legacy_connection.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_serves_single_legacy_connection.rs
@@ -4,7 +4,7 @@ fn run_daemon_serves_single_legacy_connection() {
     let _primary = EnvGuard::set(DAEMON_FALLBACK_ENV, OsStr::new("0"));
     let _secondary = EnvGuard::set(CLIENT_FALLBACK_ENV, OsStr::new("0"));
 
-    let port = allocate_test_port();
+    let (port, held_listener) = allocate_test_port();
 
     let config = DaemonConfig::builder()
         .disable_default_paths()
@@ -15,7 +15,7 @@ fn run_daemon_serves_single_legacy_connection() {
         ])
         .build();
 
-    let (mut stream, handle) = start_daemon(config, port);
+    let (mut stream, handle) = start_daemon(config, port, held_listener);
     let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
 
     let expected_greeting = legacy_daemon_greeting();

--- a/crates/daemon/src/tests/chunks/run_daemon_writes_and_removes_pid_file.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_writes_and_removes_pid_file.rs
@@ -4,7 +4,7 @@ fn run_daemon_writes_and_removes_pid_file() {
     let _primary = EnvGuard::set(DAEMON_FALLBACK_ENV, OsStr::new("0"));
     let _secondary = EnvGuard::set(CLIENT_FALLBACK_ENV, OsStr::new("0"));
 
-    let port = allocate_test_port();
+    let (port, held_listener) = allocate_test_port();
 
     let temp = tempdir().expect("pid dir");
     let pid_path = temp.path().join("rsyncd.pid");
@@ -21,6 +21,7 @@ fn run_daemon_writes_and_removes_pid_file() {
         .build();
 
     let pid_clone = pid_path.clone();
+    drop(held_listener);
     let handle = thread::spawn(move || run_daemon(config));
 
     let start = Instant::now();

--- a/crates/engine/src/local_copy/tests/execute_sparse.rs
+++ b/crates/engine/src/local_copy/tests/execute_sparse.rs
@@ -1097,9 +1097,10 @@ fn execute_sparse_with_large_file() {
     .expect("large sparse copy succeeds");
     let elapsed = start.elapsed();
 
-    // Should complete quickly despite 1GB size (mostly holes)
+    // Should complete quickly despite 1GB size (mostly holes).
+    // CI runners (especially macOS) can be slow; allow up to 30 seconds.
     assert!(
-        elapsed.as_secs() < 10,
+        elapsed.as_secs() < 30,
         "large sparse copy took too long: {elapsed:?}"
     );
 


### PR DESCRIPTION
## Summary

- Replace daemon test port allocator with OS-assigned ephemeral ports (port 0), eliminating the file-based counter and cross-process collision window
- Hold `TcpListener` until right before daemon spawn to minimize TOCTOU between port release and daemon bind
- Widen `execute_sparse_with_large_file` timeout from 10s to 30s for slow CI runners (macOS beta observed 13.8s)
- Add nextest CI retry policy (retries=2) for daemon and sparse tests

## Test plan

- [x] All 730 daemon tests pass locally
- [x] `execute_sparse_with_large_file` passes locally
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [ ] CI passes on all platforms