### PR TITLE
perf: replace std::sync::mpsc with flume for channel communication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -862,6 +862,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "nanorand",
+ "spin",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -986,8 +998,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1377,6 +1391,15 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nanorand"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
+dependencies = [
+ "getrandom 0.2.16",
 ]
 
 [[package]]
@@ -2125,6 +2148,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2421,6 +2453,7 @@ dependencies = [
  "engine",
  "fast_io",
  "filters",
+ "flume",
  "getrandom 0.3.4",
  "logging",
  "metadata",

--- a/crates/transfer/Cargo.toml
+++ b/crates/transfer/Cargo.toml
@@ -23,6 +23,7 @@ filters = { path = "../filters" }
 compress = { path = "../compress" }
 logging = { path = "../logging" }
 fast_io = { path = "../fast_io", default-features = false }
+flume = "0.11"
 getrandom = "0.3"
 thiserror = "2.0"
 tracing = { workspace = true, optional = true }

--- a/crates/transfer/src/pipeline/receiver.rs
+++ b/crates/transfer/src/pipeline/receiver.rs
@@ -6,8 +6,9 @@
 use std::collections::VecDeque;
 use std::io;
 use std::path::PathBuf;
-use std::sync::mpsc::{Receiver, SyncSender, TryRecvError};
 use std::thread::JoinHandle;
+
+use flume::{Receiver, Sender, TryRecvError};
 
 use crate::delta_apply::ChecksumVerifier;
 use crate::disk_commit::{DiskCommitConfig, spawn_disk_thread};
@@ -28,7 +29,7 @@ struct PendingChecksum {
 /// commit thread via bounded channels, including deferred checksum
 /// verification.
 pub struct PipelinedReceiver {
-    file_tx: SyncSender<FileMessage>,
+    file_tx: Sender<FileMessage>,
     result_rx: Receiver<io::Result<CommitResult>>,
     /// Return channel for buffer recycling from the disk thread.
     buf_return_rx: Receiver<Vec<u8>>,
@@ -59,7 +60,7 @@ impl PipelinedReceiver {
     ///
     /// Pass this to [`crate::transfer_ops::process_file_response_streaming`].
     #[inline]
-    pub fn file_sender(&self) -> &SyncSender<FileMessage> {
+    pub fn file_sender(&self) -> &Sender<FileMessage> {
         &self.file_tx
     }
 

--- a/crates/transfer/src/transfer_ops.rs
+++ b/crates/transfer/src/transfer_ops.rs
@@ -39,7 +39,7 @@ use engine::signature::FileSignature;
 use protocol::ProtocolVersion;
 use protocol::codec::NdxCodec;
 
-use std::sync::mpsc::{Receiver, SyncSender};
+use flume::{Receiver, Sender};
 
 use crate::adaptive_buffer::adaptive_writer_capacity;
 use crate::delta_apply::{ChecksumVerifier, SparseWriteState};
@@ -473,7 +473,7 @@ pub fn process_file_response_streaming<R: Read>(
     pending: PendingTransfer,
     ctx: &ResponseContext<'_>,
     checksum_verifier: &mut ChecksumVerifier,
-    file_tx: &SyncSender<FileMessage>,
+    file_tx: &Sender<FileMessage>,
     buf_return_rx: &Receiver<Vec<u8>>,
     file_entry_index: usize,
     file_entry: Option<FileEntry>,
@@ -530,7 +530,7 @@ pub fn process_file_response_streaming<R: Read>(
     let mut total_bytes: u64 = 0;
 
     // Helper: send abort on error and propagate.
-    let send_abort = |tx: &SyncSender<FileMessage>, reason: String| {
+    let send_abort = |tx: &Sender<FileMessage>, reason: String| {
         let _ = tx.send(FileMessage::Abort { reason });
     };
 


### PR DESCRIPTION
## Summary

- Replace `std::sync::mpsc` channels in the disk commit pipeline with `flume`, which uses `thread::park()/unpark()` for OS-level blocking instead of spin-wait (`sched_yield` with crossbeam) or unconditional `futex(WAKE)` on every `send()` (std)
- Eliminates sched_yield overhead under backpressure while maintaining proper OS-level blocking when the bounded channel is full
- flume: 126M downloads on crates.io, no unsafe code, API-compatible drop-in replacement

## Benchmark (10K files, 422MB, loopback daemon)

| Metric | upstream rsync | oc-rsync (std::sync::mpsc) | oc-rsync (flume) |
|--------|---------------|---------------------------|-----------------|
| Initial copy | 139ms | 127ms | **116ms** |
| Incremental | 143ms | - | **120ms** |
| vs upstream | 1.00x | 1.10x | **1.20x** |
| System time | 12.2ms | 23.9ms | **19.1ms** |
| sched_yield | 0 | 0 | **0** |

## Why flume over crossbeam-channel

crossbeam-channel was tested first but showed a **regression** — its bounded channel uses `sched_yield()` spin-wait under backpressure (known issue [crossbeam#821](https://github.com/crossbeam-rs/crossbeam/issues/821)), generating 28K sched_yield calls and doubling system time. flume uses `thread::park()/unpark()` which properly sleeps the sender thread when the channel is full.

## Test plan

- [x] `cargo check` — compilation
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo nextest run --workspace --all-features` — all 21,724 tests pass
- [x] Container build + mtime verification
- [x] Benchmark: 1.20x faster than upstream on both initial and incremental
- [x] strace: zero sched_yield, proper futex blocking