### PR TITLE
fix: eliminate port TOCTOU race in daemon integration tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -19,5 +19,5 @@ slow-timeout = { period = "120s", terminate-after = 3 }
 # Retry policies for tests with inherent race conditions (port binding TOCTOU,
 # slow CI runner timing).
 [[profile.ci.overrides]]
-filter = "package(daemon) | test(execute_sparse)"
+filter = "package(daemon) | test(execute_sparse) | binary_id(~integration_daemon)"
 retries = 2


### PR DESCRIPTION
## Summary

- Replace manual port allocation (bind-check-drop-rebind with PID-based ranges) with OS ephemeral port assignment (port 0), eliminating the TOCTOU race where another nextest process could steal the port between drop and daemon bind
- Add `integration_daemon_server` binary to the nextest CI retry policy (was only covering `package(daemon)`)

## Root cause

nextest runs each test as a separate process. The old `allocate_test_port()` used PID-based port ranges with an atomic counter, but close PIDs from nextest forks could map to overlapping ranges. The bind-check-drop pattern left a window for port theft.

## Test plan

- [x] All 17 daemon integration tests pass locally
- [x] `cargo clippy` clean
- [x] `cargo fmt` clean