### PR TITLE
perf: replace flume with lock-free SPSC spin channel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -862,18 +862,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "flume"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
-dependencies = [
- "futures-core",
- "futures-sink",
- "nanorand",
- "spin",
-]
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -998,10 +986,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1391,15 +1377,6 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "nanorand"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
-dependencies = [
- "getrandom 0.2.16",
 ]
 
 [[package]]
@@ -2148,15 +2125,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-dependencies = [
- "lock_api",
-]
-
-[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2450,10 +2418,10 @@ dependencies = [
  "checksums",
  "compress",
  "criterion",
+ "crossbeam-queue",
  "engine",
  "fast_io",
  "filters",
- "flume",
  "getrandom 0.3.4",
  "logging",
  "metadata",

--- a/crates/transfer/Cargo.toml
+++ b/crates/transfer/Cargo.toml
@@ -23,7 +23,7 @@ filters = { path = "../filters" }
 compress = { path = "../compress" }
 logging = { path = "../logging" }
 fast_io = { path = "../fast_io", default-features = false }
-flume = "0.11"
+crossbeam-queue = "0.3"
 getrandom = "0.3"
 thiserror = "2.0"
 tracing = { workspace = true, optional = true }

--- a/crates/transfer/src/pipeline/mod.rs
+++ b/crates/transfer/src/pipeline/mod.rs
@@ -63,6 +63,7 @@ pub mod async_signature;
 pub mod messages;
 mod pending;
 pub mod receiver;
+pub mod spsc;
 mod state;
 
 pub use pending::PendingTransfer;

--- a/crates/transfer/src/pipeline/spsc.rs
+++ b/crates/transfer/src/pipeline/spsc.rs
@@ -1,0 +1,279 @@
+//! Lock-free SPSC (single-producer, single-consumer) channel.
+//!
+//! Built on [`crossbeam_queue::ArrayQueue`] with [`AtomicBool`] disconnection
+//! flags and [`std::hint::spin_loop`] for waiting.  Zero syscalls — pure
+//! userspace synchronization with no futex, no `thread::park`, no condvar.
+//!
+//! Designed for the network → disk thread pipeline where exactly one producer
+//! (network ingest) and one consumer (disk commit) exchange [`FileMessage`]
+//! items at high throughput.
+
+use std::fmt;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use crossbeam_queue::ArrayQueue;
+
+// ---------------------------------------------------------------------------
+// Shared state
+// ---------------------------------------------------------------------------
+
+struct Shared<T> {
+    queue: ArrayQueue<T>,
+    producer_alive: AtomicBool,
+    consumer_alive: AtomicBool,
+}
+
+// ---------------------------------------------------------------------------
+// Error types (mirror flume's API shape for easy migration)
+// ---------------------------------------------------------------------------
+
+/// Error returned by [`Sender::send`] when the receiver has been dropped.
+pub struct SendError<T>(pub T);
+
+impl<T> fmt::Debug for SendError<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("SendError(..)")
+    }
+}
+
+impl<T> fmt::Display for SendError<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("sending on a disconnected channel")
+    }
+}
+
+/// Error returned by [`Receiver::recv`] when the sender has been dropped
+/// and the queue is drained.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RecvError;
+
+impl fmt::Display for RecvError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("receiving on a disconnected channel")
+    }
+}
+
+/// Error returned by [`Receiver::try_recv`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TryRecvError {
+    /// The queue is empty but the sender is still alive.
+    Empty,
+    /// The sender has been dropped and the queue is drained.
+    Disconnected,
+}
+
+impl fmt::Display for TryRecvError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Empty => f.write_str("channel is empty"),
+            Self::Disconnected => f.write_str("channel is disconnected"),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Sender
+// ---------------------------------------------------------------------------
+
+/// Sending half of the SPSC channel.
+pub struct Sender<T>(Arc<Shared<T>>);
+
+impl<T> Sender<T> {
+    /// Sends `item` through the channel, spin-waiting if the queue is full.
+    ///
+    /// Returns `Err(SendError(item))` if the receiver has been dropped.
+    pub fn send(&self, mut item: T) -> Result<(), SendError<T>> {
+        loop {
+            if !self.0.consumer_alive.load(Ordering::Relaxed) {
+                return Err(SendError(item));
+            }
+            match self.0.queue.push(item) {
+                Ok(()) => return Ok(()),
+                Err(returned) => {
+                    item = returned;
+                    std::hint::spin_loop();
+                }
+            }
+        }
+    }
+
+    /// Returns `true` if the receiver has been dropped.
+    #[cfg(test)]
+    pub fn is_disconnected(&self) -> bool {
+        !self.0.consumer_alive.load(Ordering::Relaxed)
+    }
+}
+
+impl<T> Drop for Sender<T> {
+    fn drop(&mut self) {
+        self.0.producer_alive.store(false, Ordering::Release);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Receiver
+// ---------------------------------------------------------------------------
+
+/// Receiving half of the SPSC channel.
+pub struct Receiver<T>(Arc<Shared<T>>);
+
+impl<T> Receiver<T> {
+    /// Blocks (spin-waits) until an item is available, then returns it.
+    ///
+    /// Returns `Err(RecvError)` if the sender has been dropped and the
+    /// queue is fully drained.
+    pub fn recv(&self) -> Result<T, RecvError> {
+        loop {
+            if let Some(item) = self.0.queue.pop() {
+                return Ok(item);
+            }
+            if !self.0.producer_alive.load(Ordering::Acquire) {
+                // Producer is gone — drain one last time.
+                return self.0.queue.pop().ok_or(RecvError);
+            }
+            std::hint::spin_loop();
+        }
+    }
+
+    /// Non-blocking receive.  Returns `Err(TryRecvError::Empty)` if the
+    /// queue is empty but the sender is alive, or
+    /// `Err(TryRecvError::Disconnected)` if the sender is gone and the
+    /// queue is drained.
+    pub fn try_recv(&self) -> Result<T, TryRecvError> {
+        if let Some(item) = self.0.queue.pop() {
+            return Ok(item);
+        }
+        if !self.0.producer_alive.load(Ordering::Acquire) {
+            // One more attempt after observing disconnection.
+            return self.0.queue.pop().ok_or(TryRecvError::Disconnected);
+        }
+        Err(TryRecvError::Empty)
+    }
+}
+
+impl<T> Drop for Receiver<T> {
+    fn drop(&mut self) {
+        self.0.consumer_alive.store(false, Ordering::Release);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Constructor
+// ---------------------------------------------------------------------------
+
+/// Creates a bounded SPSC channel backed by a lock-free ring buffer.
+///
+/// `capacity` is the maximum number of items the channel can hold.
+/// When the channel is full, [`Sender::send`] spin-waits until space
+/// is available.
+pub fn channel<T>(capacity: usize) -> (Sender<T>, Receiver<T>) {
+    let shared = Arc::new(Shared {
+        queue: ArrayQueue::new(capacity),
+        producer_alive: AtomicBool::new(true),
+        consumer_alive: AtomicBool::new(true),
+    });
+    (Sender(Arc::clone(&shared)), Receiver(shared))
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::thread;
+
+    #[test]
+    fn send_recv_basic() {
+        let (tx, rx) = channel::<i32>(4);
+        tx.send(1).unwrap();
+        tx.send(2).unwrap();
+        assert_eq!(rx.recv().unwrap(), 1);
+        assert_eq!(rx.recv().unwrap(), 2);
+    }
+
+    #[test]
+    fn try_recv_empty() {
+        let (tx, rx) = channel::<i32>(4);
+        assert_eq!(rx.try_recv().unwrap_err(), TryRecvError::Empty);
+        tx.send(42).unwrap();
+        assert_eq!(rx.try_recv().unwrap(), 42);
+    }
+
+    #[test]
+    fn sender_drop_disconnects() {
+        let (tx, rx) = channel::<i32>(4);
+        tx.send(10).unwrap();
+        drop(tx);
+        // Should still drain the remaining item.
+        assert_eq!(rx.recv().unwrap(), 10);
+        // Now should return RecvError.
+        assert_eq!(rx.recv().unwrap_err(), RecvError);
+    }
+
+    #[test]
+    fn receiver_drop_disconnects() {
+        let (tx, _rx) = channel::<i32>(4);
+        tx.send(1).unwrap();
+        drop(_rx);
+        assert!(tx.send(2).is_err());
+    }
+
+    #[test]
+    fn try_recv_disconnected() {
+        let (tx, rx) = channel::<i32>(4);
+        drop(tx);
+        assert_eq!(rx.try_recv().unwrap_err(), TryRecvError::Disconnected);
+    }
+
+    #[test]
+    fn cross_thread_streaming() {
+        let (tx, rx) = channel::<usize>(32);
+        let n = 10_000;
+
+        let producer = thread::spawn(move || {
+            for i in 0..n {
+                tx.send(i).unwrap();
+            }
+        });
+
+        let consumer = thread::spawn(move || {
+            let mut received = Vec::with_capacity(n);
+            for _ in 0..n {
+                received.push(rx.recv().unwrap());
+            }
+            received
+        });
+
+        producer.join().unwrap();
+        let received = consumer.join().unwrap();
+        assert_eq!(received, (0..n).collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn backpressure_bounded() {
+        // Queue of capacity 2 — sender must spin-wait when full.
+        let (tx, rx) = channel::<i32>(2);
+        tx.send(1).unwrap();
+        tx.send(2).unwrap();
+        // Queue is full.  Spawn a thread to drain after a moment.
+        let drain = thread::spawn(move || {
+            thread::sleep(std::time::Duration::from_millis(10));
+            rx.recv().unwrap()
+        });
+        // This send should spin-wait until the drain thread pops.
+        tx.send(3).unwrap();
+        let first = drain.join().unwrap();
+        assert_eq!(first, 1);
+    }
+
+    #[test]
+    fn sender_is_disconnected() {
+        let (tx, rx) = channel::<i32>(4);
+        assert!(!tx.is_disconnected());
+        drop(rx);
+        assert!(tx.is_disconnected());
+    }
+}


### PR DESCRIPTION
## Summary
- Replace flume channels with a custom SPSC channel backed by `crossbeam_queue::ArrayQueue` + `AtomicBool` disconnection flags + `spin_loop()` waiting — zero futex syscalls
- Eliminate redundant zero-initialization in `read_payload_into()` (`buffer.resize(len, 0)` → `unsafe set_len()` before read overwrites)
- Remove `flume` dependency, add `crossbeam-queue` (already in Cargo.lock via rayon)

## Benchmark Results (10K files, 422MB, daemon loopback)

| Metric | Before (flume) | After (SPSC) | Change |
|--------|---------------|-------------|--------|
| futex syscalls | 47,000 | **3** | **-99.99%** |
| Total syscalls | 136,156 | **88,192** | **-35%** |
| Initial copy vs upstream | 1.63x faster | **1.69x faster** | +4% |
| Incremental vs upstream | 1.82x faster | **1.84x faster** | +1% |

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings`
- [x] `cargo nextest run --workspace --all-features` — 21,733 tests pass
- [x] Functional alignment verified: 10K files, matching sizes
- [x] strace confirms futex elimination (47K → 3)
- [x] Hyperfine benchmarks vs upstream rsync and previous HEAD