### PR TITLE
ci: include ci-skip workflow in its own path triggers

### DIFF
--- a/.github/workflows/ci-skip.yml
+++ b/.github/workflows/ci-skip.yml
@@ -7,6 +7,8 @@ on:
       - 'docs/**'
       - '*.md'
       - 'LICENSE'
+      - '.github/workflows/ci-skip.yml'
+      - '.github/workflows/_ci-skip-interop.yml'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

- Adds `ci-skip.yml` and `_ci-skip-interop.yml` to the ci-skip workflow's own path triggers
- Without this, PRs that only modify the skip workflow files would trigger neither CI nor ci-skip, leaving required checks permanently pending

## Test plan
- [ ] This PR itself is the test — it only modifies `ci-skip.yml`, so the skip workflow should trigger and provide all 6 required checks