### PR TITLE
ci: add permissions to _ci-skip-interop.yml

### DIFF
--- a/.github/workflows/_ci-skip-interop.yml
+++ b/.github/workflows/_ci-skip-interop.yml
@@ -3,6 +3,9 @@ name: CI skip interop
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   interop-with-upstream:
     name: interop with upstream rsync


### PR DESCRIPTION
## Summary

- Adds `permissions: contents: read` to the reusable `_ci-skip-interop.yml` workflow

## Test plan
- [ ] CI skip checks pass on this PR