### PR TITLE
ci: auto-label PRs from conventional commit prefixes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -8,16 +8,18 @@ changelog:
       - github-actions[bot]
       - oc-rsync-bot
   categories:
-    - title: Performance
+    - title: Features
       labels:
         - enhancement
-      exclude:
-        labels:
-          - bug
-          - documentation
+    - title: Performance
+      labels:
+        - performance
     - title: Bug Fixes
       labels:
         - bug
+    - title: CI/CD
+      labels:
+        - ci
     - title: Documentation
       labels:
         - documentation

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,46 @@
+name: Label PRs
+
+on:
+  pull_request:
+    types: [opened, edited]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const title = context.payload.pull_request.title;
+            const labels = [];
+
+            if (/^feat[:(]/.test(title))
+              labels.push('enhancement');
+            else if (/^perf[:(]/.test(title))
+              labels.push('performance');
+            else if (/^fix[:(]/.test(title))
+              labels.push('bug');
+            else if (/^docs[:(]/.test(title))
+              labels.push('documentation');
+            else if (/^ci[:(]/.test(title))
+              labels.push('ci');
+            else if (/^test[:(]/.test(title))
+              labels.push('test');
+            else if (/^refactor[:(]/.test(title))
+              labels.push('refactor');
+            else if (/^chore[:(]/.test(title))
+              labels.push('chore');
+            else if (/^style[:(]/.test(title))
+              labels.push('style');
+
+            if (labels.length > 0) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                labels: labels,
+              });
+            }


### PR DESCRIPTION
## Summary

- Adds `labeler.yml` workflow that auto-applies GitHub labels (`performance`, `bug`, `enhancement`, `ci`, `documentation`, `chore`, `style`, `test`, `refactor`) based on PR title prefixes
- Updates `release.yml` categories to include Performance and CI/CD sections
- Fixes release notes categorization — previously all PRs fell under "Other Changes" because no labels were applied

## Test plan
- [ ] CI skip checks pass on this PR
- [ ] Verify labeler applies `ci` label to this PR automatically