### PR TITLE
feat: add -4/-6/-0/-I short option aliases

### DIFF
--- a/crates/cli/src/frontend/arguments/tests.rs
+++ b/crates/cli/src/frontend/arguments/tests.rs
@@ -175,8 +175,17 @@ mod short_options {
         assert!(parsed.itemize_changes);
     }
 
-    // Note: -4 and -6 short options are not supported in this implementation
-    // Use --ipv4 and --ipv6 long options instead (tested in long_options module)
+    #[test]
+    fn ipv4_short_flag() {
+        let parsed = parse_test_args(["-4", "src/", "dst/"]).expect("parse");
+        assert_eq!(parsed.address_mode, AddressMode::Ipv4);
+    }
+
+    #[test]
+    fn ipv6_short_flag() {
+        let parsed = parse_test_args(["-6", "src/", "dst/"]).expect("parse");
+        assert_eq!(parsed.address_mode, AddressMode::Ipv6);
+    }
 
     #[test]
     fn eight_bit_output_short_flag() {
@@ -184,11 +193,17 @@ mod short_options {
         assert!(parsed.eight_bit_output);
     }
 
-    // Note: -0 (from0) short option is not supported in this implementation
-    // Use --from0 long option instead (tested in long_options module)
+    #[test]
+    fn from0_short_flag() {
+        let parsed = parse_test_args(["-0", "src/", "dst/"]).expect("parse");
+        assert!(parsed.from0);
+    }
 
-    // Note: -I (ignore-times) short option is not supported in this implementation
-    // Use --ignore-times long option instead (tested in long_options module)
+    #[test]
+    fn ignore_times_short_flag() {
+        let parsed = parse_test_args(["-I", "src/", "dst/"]).expect("parse");
+        assert!(parsed.ignore_times);
+    }
 
     #[test]
     fn cvs_exclude_short_flag() {

--- a/crates/cli/src/frontend/command_builder/sections/build_base_command.rs
+++ b/crates/cli/src/frontend/command_builder/sections/build_base_command.rs
@@ -198,6 +198,7 @@ pub(crate) fn build_base_command(program_name: &'static str) -> ClapCommand {
             .arg(
                 Arg::new("ipv4")
                     .long("ipv4")
+                    .short('4')
                     .help("Prefer IPv4 when contacting remote hosts.")
                     .action(ArgAction::SetTrue)
                     .conflicts_with("ipv6"),
@@ -205,6 +206,7 @@ pub(crate) fn build_base_command(program_name: &'static str) -> ClapCommand {
             .arg(
                 Arg::new("ipv6")
                     .long("ipv6")
+                    .short('6')
                     .help("Prefer IPv6 when contacting remote hosts.")
                     .action(ArgAction::SetTrue)
                     .conflicts_with("ipv4"),

--- a/crates/cli/src/frontend/command_builder/sections/transfer_behavior_options.rs
+++ b/crates/cli/src/frontend/command_builder/sections/transfer_behavior_options.rs
@@ -422,6 +422,7 @@ pub(crate) fn add_transfer_behavior_options(command: ClapCommand) -> ClapCommand
             .arg(
                 Arg::new("from0")
                     .long("from0")
+                    .short('0')
                     .help("Treat file list entries as NUL-terminated records.")
                     .action(ArgAction::SetTrue)
                     .overrides_with("no-from0"),


### PR DESCRIPTION
## Summary
- Add `-4` short flag for `--ipv4`
- Add `-6` short flag for `--ipv6`
- Add `-0` short flag for `--from0`
- `-I` for `--ignore-times` (already defined, tests added)
- Replaces "not supported" comments with actual test coverage

## Test plan
- [x] All 4 short option tests pass
- [ ] `cargo clippy -p cli` passes
- [ ] CI passes