### PR TITLE
feat: add --aes/--no-aes CLI flags for SSH cipher control

### DIFF
--- a/crates/cli/src/frontend/arguments/parsed_args.rs
+++ b/crates/cli/src/frontend/arguments/parsed_args.rs
@@ -1472,4 +1472,17 @@ pub struct ParsedArgs {
     ///
     /// Default: `None`
     pub executability: Option<bool>,
+
+    /// Force or disable AES-GCM cipher selection for SSH connections.
+    ///
+    /// Controls whether SSH connections should prefer hardware-accelerated
+    /// AES-GCM ciphers over the default ChaCha20-Poly1305:
+    /// - `Some(true)`: Force AES-GCM (`--aes`).
+    /// - `Some(false)`: Disable automatic cipher selection (`--no-aes`).
+    /// - `None`: Use runtime hardware detection (default).
+    ///
+    /// Corresponds to: `--aes` / `--no-aes`
+    ///
+    /// Default: `None`
+    pub prefer_aes_gcm: Option<bool>,
 }

--- a/crates/cli/src/frontend/arguments/parser.rs
+++ b/crates/cli/src/frontend/arguments/parser.rs
@@ -221,6 +221,7 @@ where
     } else {
         open_noatime_flag
     };
+    let prefer_aes_gcm = tri_state_flag_positive_first(&matches, "aes", "no-aes");
     let compress_level_opt = matches.get_one::<OsString>("compress-level").cloned();
     if let Some(ref value) = compress_level_opt
         && let Ok(setting) = parse_compress_level_argument(value.as_os_str())
@@ -672,6 +673,7 @@ where
         dparam,
         no_iconv,
         executability,
+        prefer_aes_gcm,
     })
 }
 
@@ -1070,5 +1072,37 @@ mod tests {
         assert!(result.is_ok());
         let parsed = result.unwrap();
         assert_eq!(parsed.times, Some(false));
+    }
+
+    #[test]
+    fn aes_flag() {
+        let result = parse_test_args(["--aes", "src/", "dst/"]);
+        assert!(result.is_ok());
+        let parsed = result.unwrap();
+        assert_eq!(parsed.prefer_aes_gcm, Some(true));
+    }
+
+    #[test]
+    fn no_aes_flag() {
+        let result = parse_test_args(["--no-aes", "src/", "dst/"]);
+        assert!(result.is_ok());
+        let parsed = result.unwrap();
+        assert_eq!(parsed.prefer_aes_gcm, Some(false));
+    }
+
+    #[test]
+    fn aes_default_is_none() {
+        let result = parse_test_args(["src/", "dst/"]);
+        assert!(result.is_ok());
+        let parsed = result.unwrap();
+        assert_eq!(parsed.prefer_aes_gcm, None);
+    }
+
+    #[test]
+    fn no_aes_then_aes_uses_last() {
+        let result = parse_test_args(["--no-aes", "--aes", "src/", "dst/"]);
+        assert!(result.is_ok());
+        let parsed = result.unwrap();
+        assert_eq!(parsed.prefer_aes_gcm, Some(true));
     }
 }

--- a/crates/cli/src/frontend/command_builder/sections/connection_and_logging_options.rs
+++ b/crates/cli/src/frontend/command_builder/sections/connection_and_logging_options.rs
@@ -124,6 +124,20 @@ pub(crate) fn add_connection_and_logging_options(command: ClapCommand) -> ClapCo
                 .overrides_with("open-noatime"),
         )
         .arg(
+            Arg::new("aes")
+                .long("aes")
+                .help("Force AES-GCM ciphers for SSH (hardware-accelerated on AES-NI/ARMv8).")
+                .action(ArgAction::SetTrue)
+                .overrides_with("no-aes"),
+        )
+        .arg(
+            Arg::new("no-aes")
+                .long("no-aes")
+                .help("Disable automatic AES-GCM cipher selection for SSH.")
+                .action(ArgAction::SetTrue)
+                .overrides_with("aes"),
+        )
+        .arg(
             Arg::new("iconv")
                 .long("iconv")
                 .value_name("CONVERT_SPEC")

--- a/crates/cli/src/frontend/execution/drive/config.rs
+++ b/crates/cli/src/frontend/execution/drive/config.rs
@@ -133,6 +133,7 @@ pub(crate) struct ConfigInputs {
     pub(crate) remote_shell: Option<OsString>,
     pub(crate) rsync_path: Option<OsString>,
     pub(crate) early_input: Option<PathBuf>,
+    pub(crate) prefer_aes_gcm: Option<bool>,
     pub(crate) batch_config: Option<batch::BatchConfig>,
     pub(crate) no_motd: bool,
 }
@@ -267,6 +268,7 @@ pub(crate) fn build_base_config(mut inputs: ConfigInputs) -> ClientConfigBuilder
 
     // Configure early-input file if specified
     builder = builder.early_input(inputs.early_input.clone());
+    builder = builder.prefer_aes_gcm(inputs.prefer_aes_gcm);
 
     // Configure batch mode if specified
     if let Some(batch_cfg) = inputs.batch_config {

--- a/crates/cli/src/frontend/execution/drive/workflow/run.rs
+++ b/crates/cli/src/frontend/execution/drive/workflow/run.rs
@@ -198,6 +198,7 @@ where
         out_format,
         dparam: _,
         no_iconv,
+        prefer_aes_gcm,
     } = parsed;
 
     let password_file = password_file.map(PathBuf::from);
@@ -655,6 +656,7 @@ where
         remote_shell: parsed.remote_shell.clone(),
         rsync_path: parsed.rsync_path.clone(),
         early_input: early_input.map(PathBuf::from),
+        prefer_aes_gcm,
         batch_config,
         no_motd,
     };

--- a/crates/core/src/client/config/builder/mod.rs
+++ b/crates/core/src/client/config/builder/mod.rs
@@ -211,6 +211,7 @@ pub struct ClientConfigBuilder {
     remote_shell: Option<Vec<OsString>>,
     rsync_path: Option<OsString>,
     early_input: Option<PathBuf>,
+    prefer_aes_gcm: Option<bool>,
     batch_config: Option<engine::batch::BatchConfig>,
     no_motd: bool,
     #[cfg(all(unix, feature = "acl"))]
@@ -330,6 +331,7 @@ impl ClientConfigBuilder {
             remote_shell: self.remote_shell,
             rsync_path: self.rsync_path,
             early_input: self.early_input,
+            prefer_aes_gcm: self.prefer_aes_gcm,
             batch_config: self.batch_config,
             no_motd: self.no_motd,
             #[cfg(all(unix, feature = "acl"))]

--- a/crates/core/src/client/config/builder/network.rs
+++ b/crates/core/src/client/config/builder/network.rs
@@ -35,6 +35,15 @@ impl ClientConfigBuilder {
         #[doc(alias = "--ipv4")]
         #[doc(alias = "--ipv6")]
         address_mode: AddressMode,
+
+        /// Overrides automatic AES-GCM cipher selection for SSH connections.
+        ///
+        /// `Some(true)` forces AES-GCM regardless of hardware detection,
+        /// `Some(false)` disables automatic cipher selection entirely,
+        /// `None` (default) uses runtime hardware detection.
+        #[doc(alias = "--aes")]
+        #[doc(alias = "--no-aes")]
+        prefer_aes_gcm: Option<bool>,
     }
 
     /// Configures the deadline at which the transfer should stop.
@@ -308,5 +317,23 @@ mod tests {
     fn default_timeout_is_default() {
         let config = builder().build();
         assert_eq!(config.timeout(), TransferTimeout::Default);
+    }
+
+    #[test]
+    fn prefer_aes_gcm_sets_some_true() {
+        let config = builder().prefer_aes_gcm(Some(true)).build();
+        assert_eq!(config.prefer_aes_gcm(), Some(true));
+    }
+
+    #[test]
+    fn prefer_aes_gcm_sets_some_false() {
+        let config = builder().prefer_aes_gcm(Some(false)).build();
+        assert_eq!(config.prefer_aes_gcm(), Some(false));
+    }
+
+    #[test]
+    fn prefer_aes_gcm_default_is_none() {
+        let config = builder().prefer_aes_gcm(None).build();
+        assert!(config.prefer_aes_gcm().is_none());
     }
 }

--- a/crates/core/src/client/config/client/mod.rs
+++ b/crates/core/src/client/config/client/mod.rs
@@ -159,6 +159,7 @@ pub struct ClientConfig {
     pub(super) remote_shell: Option<Vec<OsString>>,
     pub(super) rsync_path: Option<OsString>,
     pub(super) early_input: Option<PathBuf>,
+    pub(super) prefer_aes_gcm: Option<bool>,
     pub(super) batch_config: Option<engine::batch::BatchConfig>,
     pub(super) no_motd: bool,
     #[cfg(all(unix, feature = "acl"))]
@@ -276,6 +277,7 @@ impl Default for ClientConfig {
             remote_shell: None,
             rsync_path: None,
             early_input: None,
+            prefer_aes_gcm: None,
             batch_config: None,
             no_motd: false,
             #[cfg(all(unix, feature = "acl"))]

--- a/crates/core/src/client/config/client/network.rs
+++ b/crates/core/src/client/config/client/network.rs
@@ -91,6 +91,18 @@ impl ClientConfig {
     pub fn early_input(&self) -> Option<&Path> {
         self.early_input.as_deref()
     }
+
+    /// Returns the AES-GCM cipher preference for SSH connections.
+    ///
+    /// `Some(true)` forces AES-GCM ciphers regardless of hardware detection,
+    /// `Some(false)` disables automatic cipher selection entirely,
+    /// `None` (default) uses runtime hardware detection.
+    #[must_use]
+    #[doc(alias = "--aes")]
+    #[doc(alias = "--no-aes")]
+    pub const fn prefer_aes_gcm(&self) -> Option<bool> {
+        self.prefer_aes_gcm
+    }
 }
 
 #[cfg(test)]
@@ -183,5 +195,12 @@ mod tests {
     fn early_input_default_is_none() {
         let config = default_config();
         assert!(config.early_input().is_none());
+    }
+
+    // Tests for prefer_aes_gcm
+    #[test]
+    fn prefer_aes_gcm_default_is_none() {
+        let config = default_config();
+        assert!(config.prefer_aes_gcm().is_none());
     }
 }


### PR DESCRIPTION
## Summary
- Add `--aes` and `--no-aes` CLI arguments for controlling SSH AES-GCM cipher preference
- Wire `prefer_aes_gcm` through `ParsedArgs`, `ConfigInputs`, `ClientConfigBuilder`, and `ClientConfig`
- Hardware-accelerated AES-GCM can outperform ChaCha20-Poly1305 on AES-NI/ARMv8 crypto CPUs

## Test plan
- [x] `cargo clippy -p cli -p core --no-deps -- -D warnings` passes
- [x] `cargo check -p cli` compiles cleanly
- [ ] CI: fmt+clippy, nextest, cross-platform