### PR TITLE
perf: optimize match crate delta generator and ring buffer

### DIFF
--- a/crates/match/src/index.rs
+++ b/crates/match/src/index.rs
@@ -15,11 +15,20 @@ use checksums::RollingDigest;
 
 use signature::{FileSignature, SignatureAlgorithm, SignatureBlock};
 
+/// Size of the tag table for quick rolling checksum rejection (2^16 entries).
+///
+/// Upstream rsync uses a boolean array indexed by the low 16 bits (sum1) of the
+/// rolling checksum to reject non-matching positions before probing the hash
+/// table. This constant matches upstream's `TABLESIZE` in `match.c`.
+const TAG_TABLE_SIZE: usize = 1 << 16;
+
 /// Index over a file signature that accelerates delta matching.
 ///
 /// Uses [`FxHashMap`] keyed by `(sum1, sum2)` rolling checksum components for O(1)
-/// block lookup. The block length is stored separately since all indexed blocks
-/// have the same canonical length.
+/// block lookup. A tag table indexed by `sum1` provides fast-path rejection
+/// before the hash probe, mirroring upstream rsync's `tag_table` in `match.c`.
+/// The block length is stored separately since all indexed blocks have the same
+/// canonical length.
 #[derive(Clone, Debug)]
 pub struct DeltaSignatureIndex {
     block_length: usize,
@@ -28,6 +37,9 @@ pub struct DeltaSignatureIndex {
     blocks: Vec<SignatureBlock>,
     /// Lookup table keyed by (sum1, sum2) - block length is constant for all entries.
     lookup: FxHashMap<(u16, u16), Vec<usize>>,
+    /// Tag table for O(1) rejection using sum1 (low 16 bits of rolling checksum).
+    /// upstream: match.c — `tag_table[s1]` check before hash probe.
+    tag_table: Vec<bool>,
 }
 
 impl DeltaSignatureIndex {
@@ -48,6 +60,7 @@ impl DeltaSignatureIndex {
 
         let mut lookup: FxHashMap<(u16, u16), Vec<usize>> =
             FxHashMap::with_capacity_and_hasher(blocks.len(), Default::default());
+        let mut tag_table = vec![false; TAG_TABLE_SIZE];
         let mut has_full_blocks = false;
 
         for (index, block) in blocks.iter().enumerate() {
@@ -57,6 +70,7 @@ impl DeltaSignatureIndex {
 
             has_full_blocks = true;
             let digest = block.rolling();
+            tag_table[digest.sum1() as usize] = true;
             // Key is (sum1, sum2) only - all indexed blocks have block_length
             lookup
                 .entry((digest.sum1(), digest.sum2()))
@@ -74,6 +88,7 @@ impl DeltaSignatureIndex {
             algorithm,
             blocks,
             lookup,
+            tag_table,
         })
     }
 
@@ -96,6 +111,7 @@ impl DeltaSignatureIndex {
         self.blocks.clear();
         self.blocks.extend_from_slice(signature.blocks());
         self.lookup.clear();
+        self.tag_table.iter_mut().for_each(|v| *v = false);
 
         let mut has_full_blocks = false;
         for (index, block) in self.blocks.iter().enumerate() {
@@ -104,6 +120,7 @@ impl DeltaSignatureIndex {
             }
             has_full_blocks = true;
             let digest = block.rolling();
+            self.tag_table[digest.sum1() as usize] = true;
             self.lookup
                 .entry((digest.sum1(), digest.sum2()))
                 .or_default()
@@ -117,6 +134,12 @@ impl DeltaSignatureIndex {
     #[must_use]
     pub const fn block_length(&self) -> usize {
         self.block_length
+    }
+
+    /// Returns the total number of signature blocks.
+    #[must_use]
+    pub fn block_count(&self) -> usize {
+        self.blocks.len()
     }
 
     /// Returns the strong checksum length used by the signature.
@@ -136,6 +159,12 @@ impl DeltaSignatureIndex {
     #[inline]
     pub fn find_match_bytes(&self, digest: RollingDigest, window: &[u8]) -> Option<usize> {
         if window.len() != self.block_length {
+            return None;
+        }
+
+        // upstream: match.c — tag_table[s1] fast-path rejects most non-matching
+        // positions before the more expensive hash probe.
+        if !self.tag_table[digest.sum1() as usize] {
             return None;
         }
 
@@ -160,12 +189,15 @@ impl DeltaSignatureIndex {
     const PARALLEL_THRESHOLD: usize = 4;
 
     /// Sequential candidate verification (used for few candidates).
+    ///
+    /// Computes the strong checksum once and compares against all candidates,
+    /// mirroring upstream rsync's `done_csum2` flag in `match.c:hash_search()`.
     #[inline]
     fn find_match_sequential(&self, candidates: &[usize], window: &[u8]) -> Option<usize> {
+        let strong = self.algorithm.compute_truncated(window, self.strong_length);
         for &index in candidates {
             let block = &self.blocks[index];
             debug_assert_eq!(block.len(), self.block_length);
-            let strong = self.algorithm.compute_truncated(window, self.strong_length);
             if strong.as_slice() == block.strong() {
                 return Some(index);
             }
@@ -191,6 +223,117 @@ impl DeltaSignatureIndex {
             .copied()
     }
 
+    /// Attempts to locate a matching block for a possibly non-contiguous window
+    /// represented as two slices.
+    ///
+    /// This avoids O(block_len) ring buffer rotation by feeding both slices
+    /// directly into the streaming strong checksum. The combined length of
+    /// `first` and `second` must equal `block_length`.
+    #[inline]
+    pub fn find_match_slices(
+        &self,
+        digest: RollingDigest,
+        first: &[u8],
+        second: &[u8],
+    ) -> Option<usize> {
+        if first.len() + second.len() != self.block_length {
+            return None;
+        }
+
+        if !self.tag_table[digest.sum1() as usize] {
+            return None;
+        }
+
+        let key = (digest.sum1(), digest.sum2());
+        let candidates = self.lookup.get(&key)?;
+
+        #[cfg(feature = "parallel")]
+        if candidates.len() >= Self::PARALLEL_THRESHOLD {
+            return self.find_match_slices_parallel(candidates, first, second);
+        }
+
+        self.find_match_slices_sequential(candidates, first, second)
+    }
+
+    /// Sequential candidate verification for non-contiguous window data.
+    #[inline]
+    fn find_match_slices_sequential(
+        &self,
+        candidates: &[usize],
+        first: &[u8],
+        second: &[u8],
+    ) -> Option<usize> {
+        let strong = self
+            .algorithm
+            .compute_truncated_slices(first, second, self.strong_length);
+        for &index in candidates {
+            let block = &self.blocks[index];
+            debug_assert_eq!(block.len(), self.block_length);
+            if strong.as_slice() == block.strong() {
+                return Some(index);
+            }
+        }
+        None
+    }
+
+    /// Parallel candidate verification for non-contiguous window data.
+    #[cfg(feature = "parallel")]
+    fn find_match_slices_parallel(
+        &self,
+        candidates: &[usize],
+        first: &[u8],
+        second: &[u8],
+    ) -> Option<usize> {
+        use rayon::prelude::*;
+
+        candidates
+            .par_iter()
+            .find_any(|&&index| {
+                let block = &self.blocks[index];
+                let strong =
+                    self.algorithm
+                        .compute_truncated_slices(first, second, self.strong_length);
+                strong.as_slice() == block.strong()
+            })
+            .copied()
+    }
+
+    /// Checks whether a specific block matches the given rolling digest and window data.
+    ///
+    /// Used by the `want_i` adjacent-match hinting optimization: after a match at
+    /// block `i`, the next match is likely at block `i+1`. This method verifies that
+    /// hypothesis with a rolling checksum comparison (cheap) followed by a strong
+    /// checksum comparison (expensive) only on rolling match, bypassing the hash
+    /// table entirely.
+    ///
+    /// upstream: match.c:144-190 — `want_i` hint check before full hash search.
+    #[inline]
+    pub fn check_block_match_slices(
+        &self,
+        block_index: usize,
+        digest: RollingDigest,
+        first: &[u8],
+        second: &[u8],
+    ) -> bool {
+        if block_index >= self.blocks.len() {
+            return false;
+        }
+        let block = &self.blocks[block_index];
+        if block.len() != self.block_length {
+            return false;
+        }
+        // Cheap: compare rolling checksum first
+        let block_digest = block.rolling();
+        if digest.sum1() != block_digest.sum1() || digest.sum2() != block_digest.sum2() {
+            return false;
+        }
+        // Expensive: verify with strong checksum
+        let strong = self
+            .algorithm
+            .compute_truncated_slices(first, second, self.strong_length);
+        strong.as_slice() == block.strong()
+    }
+
     /// Attempts to locate a matching block for a non-contiguous window backed by a [`VecDeque`].
     pub fn find_match_window(
         &self,
@@ -214,7 +357,7 @@ impl DeltaSignatureIndex {
 mod tests {
     use super::*;
     use protocol::ProtocolVersion;
-    use signature::{SignatureLayoutParams, calculate_signature_layout, generate_file_signature};
+    use signature::{calculate_signature_layout, generate_file_signature, SignatureLayoutParams};
     use std::num::NonZeroU8;
 
     #[test]
@@ -445,11 +588,9 @@ mod tests {
         for _ in 0..index.block_length() - 1 {
             window.push_back(b'a');
         }
-        assert!(
-            index
-                .find_match_window(digest, &window, &mut scratch)
-                .is_none()
-        );
+        assert!(index
+            .find_match_window(digest, &window, &mut scratch)
+            .is_none());
     }
 
     /// Tests that rolling checksum collisions are resolved by strong checksum.
@@ -564,5 +705,77 @@ mod tests {
             old_found.is_none(),
             "old data should not match after rebuild"
         );
+    }
+
+    /// `find_match_slices` with a single contiguous slice (empty second) matches
+    /// `find_match_bytes`.
+    #[test]
+    fn find_match_slices_contiguous_matches_find_match_bytes() {
+        let data = vec![b'a'; 1500];
+        let params = SignatureLayoutParams::new(
+            data.len() as u64,
+            None,
+            ProtocolVersion::NEWEST,
+            NonZeroU8::new(16).unwrap(),
+        );
+        let layout = calculate_signature_layout(params).expect("layout");
+        let signature = generate_file_signature(data.as_slice(), layout, SignatureAlgorithm::Md4)
+            .expect("signature");
+        let index = DeltaSignatureIndex::from_signature(&signature, SignatureAlgorithm::Md4)
+            .expect("index");
+
+        let digest = index.block(0).rolling();
+        let window = vec![b'a'; index.block_length()];
+        let found_bytes = index.find_match_bytes(digest, &window);
+        let found_slices = index.find_match_slices(digest, &window, &[]);
+        assert_eq!(found_bytes, found_slices);
+    }
+
+    /// `find_match_slices` with a split window finds the same block as `find_match_bytes`.
+    #[test]
+    fn find_match_slices_split_window_finds_block() {
+        let data = vec![b'a'; 1500];
+        let params = SignatureLayoutParams::new(
+            data.len() as u64,
+            None,
+            ProtocolVersion::NEWEST,
+            NonZeroU8::new(16).unwrap(),
+        );
+        let layout = calculate_signature_layout(params).expect("layout");
+        let signature = generate_file_signature(data.as_slice(), layout, SignatureAlgorithm::Md4)
+            .expect("signature");
+        let index = DeltaSignatureIndex::from_signature(&signature, SignatureAlgorithm::Md4)
+            .expect("index");
+
+        let digest = index.block(0).rolling();
+        let window = vec![b'a'; index.block_length()];
+        let split_at = index.block_length() / 3;
+        let (first, second) = window.split_at(split_at);
+        let found = index.find_match_slices(digest, first, second);
+        assert!(found.is_some(), "split window should find a match");
+        assert_eq!(found, index.find_match_bytes(digest, &window));
+    }
+
+    /// `find_match_slices` rejects windows with wrong combined length.
+    #[test]
+    fn find_match_slices_wrong_length_returns_none() {
+        let data = vec![b'a'; 2048];
+        let params = SignatureLayoutParams::new(
+            data.len() as u64,
+            None,
+            ProtocolVersion::NEWEST,
+            NonZeroU8::new(16).unwrap(),
+        );
+        let layout = calculate_signature_layout(params).expect("layout");
+        let signature = generate_file_signature(data.as_slice(), layout, SignatureAlgorithm::Md4)
+            .expect("signature");
+        let index = DeltaSignatureIndex::from_signature(&signature, SignatureAlgorithm::Md4)
+            .expect("index");
+
+        let digest = index.block(0).rolling();
+        let short_window = vec![b'a'; index.block_length() - 1];
+        assert!(index
+            .find_match_slices(digest, &short_window, &[])
+            .is_none());
     }
 }


### PR DESCRIPTION
## Summary
- Add tag table for O(1) rolling checksum rejection before hash probe, mirroring upstream rsync's `tag_table` in `match.c`
- Implement `want_i` adjacent-match hinting to skip hash table lookups for sequential block matches (upstream: `match.c:144-190`)
- Add bulk refill loop after block matches to avoid per-byte ring buffer operations
- Add `find_match_slices` and `check_block_match_slices` methods to avoid O(block_len) ring buffer rotation on wrapped windows
- Add `extend_from_slice` to `RingBuffer` for bulk append without eviction
- Add `compute_truncated_slices` to `SignatureAlgorithm` for streaming two-slice strong checksum without intermediate allocation
- Flush pending literals early at `block_length + CHUNK_SIZE` to bound memory growth (upstream: `rsync.h:158, match.c:339`)

## Test plan
- [x] `cargo check -p matching` passes
- [x] `cargo clippy -p signature -p matching --all-targets --all-features --no-deps -D warnings` passes
- [x] `cargo nextest run -p signature -p matching --all-features` passes (468 tests)
- [x] New tests for `find_match_slices`, `check_block_match_slices`, `extend_from_slice`, and `compute_truncated_slices`