### PR TITLE
refactor: improve protocol message codes and negotiation

### DIFF
--- a/crates/protocol/src/envelope/message_code.rs
+++ b/crates/protocol/src/envelope/message_code.rs
@@ -195,6 +195,26 @@ impl MessageCode {
         matches!(self, MessageCode::NoOp)
     }
 
+    /// Reports whether this message represents an error condition.
+    ///
+    /// Returns `true` for all error-class message codes: `Error`, `ErrorXfer`,
+    /// `ErrorSocket`, `ErrorUtf8`, and `ErrorExit`. Useful for counting remote
+    /// errors received through the multiplex channel.
+    ///
+    /// upstream: io.c — `FERROR*` codes map to these message types.
+    #[inline]
+    #[must_use]
+    pub const fn is_error(self) -> bool {
+        matches!(
+            self,
+            MessageCode::Error
+                | MessageCode::ErrorXfer
+                | MessageCode::ErrorSocket
+                | MessageCode::ErrorUtf8
+                | MessageCode::ErrorExit
+        )
+    }
+
     /// Reports whether this message carries human-readable logging output.
     #[inline]
     #[must_use]

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -77,7 +77,8 @@ pub use negotiation::{
     BufferedPrefixTooSmall, ChecksumAlgorithm, CompressionAlgorithm, NegotiationPrologue,
     NegotiationPrologueDetector, NegotiationPrologueSniffer, NegotiationResult,
     ParseNegotiationPrologueError, ParseNegotiationPrologueErrorKind, detect_negotiation_prologue,
-    negotiate_capabilities, read_and_parse_legacy_daemon_greeting,
+    negotiate_capabilities, negotiate_capabilities_with_override,
+    read_and_parse_legacy_daemon_greeting,
     read_and_parse_legacy_daemon_greeting_details, read_legacy_daemon_line,
 };
 pub use stats::{DeleteStats, TransferStats};

--- a/crates/protocol/src/negotiation/mod.rs
+++ b/crates/protocol/src/negotiation/mod.rs
@@ -22,6 +22,7 @@ mod types;
 
 pub use capabilities::{
     ChecksumAlgorithm, CompressionAlgorithm, NegotiationResult, negotiate_capabilities,
+    negotiate_capabilities_with_override,
 };
 pub use detector::NegotiationPrologueDetector;
 pub use sniffer::{


### PR DESCRIPTION
## Summary
- Improve message code handling in envelope layer
- Enhance negotiation capabilities
- Clean up wire compressed token handling

## Test plan
- [x] cargo check -p protocol passes
- [x] cargo clippy passes
- [x] cargo nextest run -p protocol passes