### PR TITLE
chore: add comprehensive benchmarking and profiling scripts

### DIFF
--- a/scripts/profile_hotpaths.sh
+++ b/scripts/profile_hotpaths.sh
@@ -1,0 +1,547 @@
+#!/bin/bash
+# Profile oc-rsync vs upstream rsync hot paths.
+#
+# Generates flamegraphs, strace syscall summaries, and perf stat comparisons.
+# Runs inside the Arch Linux benchmark container (requires --privileged).
+#
+# Usage: profile_hotpaths.sh [--scenarios SCENARIOS] [--skip-flamegraph]
+#
+# Output is written to /results/ (mount a volume to extract).
+
+set -euo pipefail
+
+# Binaries
+UPSTREAM="/usr/local/bin/upstream-rsync"
+OC_RSYNC="/usr/local/bin/oc-rsync-dev"
+OC_V058="/usr/local/bin/oc-rsync-v058"
+
+# Configuration
+RESULTS_DIR="/results"
+BENCH_DIR="/tmp/rsync-profile"
+SRC_DIR="$BENCH_DIR/src"
+FLAMEGRAPH_FREQ=999
+SKIP_FLAMEGRAPH=false
+SKIP_SSH=false
+
+SCENARIOS="initial,no_change,incremental"
+COPY_MODES="delta:'-av',whole_file:'-avW',checksum:'-avc',compressed:'-avz'"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --scenarios)        SCENARIOS="$2"; shift 2 ;;
+        --skip-flamegraph)  SKIP_FLAMEGRAPH=true; shift ;;
+        --skip-ssh)         SKIP_SSH=true; shift ;;
+        -h|--help)
+            echo "Usage: $0 [--scenarios initial,no_change,incremental] [--skip-flamegraph] [--skip-ssh]"
+            exit 0
+            ;;
+        *)  echo "Unknown option: $1" >&2; exit 1 ;;
+    esac
+done
+
+log() {
+    echo "[$(date '+%H:%M:%S')] $*"
+}
+
+mkdir -p "$RESULTS_DIR"/{flamegraphs,strace,perf_stat}
+mkdir -p "$BENCH_DIR"
+
+# ---------------------------------------------------------------------------
+# Test data generation (10,000 files, ~290 MB)
+# ---------------------------------------------------------------------------
+
+generate_test_data() {
+    log "Generating test data (10,000 files, ~290 MB)..."
+    rm -rf "$SRC_DIR"
+    mkdir -p "$SRC_DIR"/{small,medium,large}
+
+    # 9,000 x 1KB
+    for i in $(seq 0 8999); do
+        dd if=/dev/urandom of="$SRC_DIR/small/file_$(printf '%05d' "$i").txt" \
+            bs=1024 count=1 2>/dev/null
+    done
+
+    # 800 x 100KB
+    for i in $(seq 0 799); do
+        dd if=/dev/urandom of="$SRC_DIR/medium/file_$(printf '%04d' "$i").bin" \
+            bs=102400 count=1 2>/dev/null
+    done
+
+    # 200 x 1MB
+    for i in $(seq 0 199); do
+        dd if=/dev/urandom of="$SRC_DIR/large/file_$(printf '%04d' "$i").dat" \
+            bs=1048576 count=1 2>/dev/null
+    done
+
+    local total_size total_files
+    total_size=$(du -sb "$SRC_DIR" | cut -f1)
+    total_files=$(find "$SRC_DIR" -type f | wc -l)
+    log "Test data: $(( total_size / 1024 / 1024 )) MB, $total_files files"
+}
+
+# ---------------------------------------------------------------------------
+# Daemon setup
+# ---------------------------------------------------------------------------
+
+DAEMON_PID=""
+DAEMON_PORT=""
+
+start_daemon() {
+    DAEMON_PORT=$(python3 -c "import socket; s=socket.socket(); s.bind(('',0)); print(s.getsockname()[1]); s.close()")
+    local daemon_dst="$BENCH_DIR/daemon_dest"
+    mkdir -p "$daemon_dst"
+
+    cat > "$BENCH_DIR/rsyncd.conf" <<CONF
+port = $DAEMON_PORT
+use chroot = false
+
+[bench]
+    path = $SRC_DIR
+    read only = true
+
+[dest]
+    path = $daemon_dst
+    read only = false
+CONF
+
+    "$UPSTREAM" --daemon --config="$BENCH_DIR/rsyncd.conf" --no-detach &
+    DAEMON_PID=$!
+    sleep 1
+
+    if ! kill -0 "$DAEMON_PID" 2>/dev/null; then
+        log "ERROR: daemon failed to start"
+        return 1
+    fi
+    log "rsync daemon started on port $DAEMON_PORT (pid $DAEMON_PID)"
+}
+
+stop_daemon() {
+    if [[ -n "${DAEMON_PID:-}" ]]; then
+        kill "$DAEMON_PID" 2>/dev/null || true
+        wait "$DAEMON_PID" 2>/dev/null || true
+    fi
+}
+
+trap stop_daemon EXIT
+
+# ---------------------------------------------------------------------------
+# Profiling functions
+# ---------------------------------------------------------------------------
+
+clean_dst() {
+    rm -rf "$BENCH_DIR/dst"
+    mkdir -p "$BENCH_DIR/dst"
+}
+
+modify_src() {
+    log "Modifying 10% of source files..."
+    local count=0
+    find "$SRC_DIR" -type f | head -1000 | while IFS= read -r f; do
+        dd if=/dev/urandom of="$f" bs=64 count=1 seek=$(( $(stat -c%s "$f" 2>/dev/null || stat -f%z "$f") / 2 / 64 )) conv=notrunc 2>/dev/null || true
+        count=$((count + 1))
+    done
+}
+
+run_strace_profile() {
+    local binary="$1"
+    local name="$2"
+    local scenario="$3"
+    local dst="$BENCH_DIR/dst"
+    local output="$RESULTS_DIR/strace/${name}_${scenario}.txt"
+
+    log "  strace -f -c: $name ($scenario)"
+    strace -f -c -o "$output" -- \
+        "$binary" -a "$SRC_DIR/" "$dst/" 2>/dev/null || true
+}
+
+run_strace_daemon() {
+    local binary="$1"
+    local name="$2"
+    local scenario="$3"
+    local dst="$BENCH_DIR/dst"
+    local output="$RESULTS_DIR/strace/${name}_daemon_${scenario}.txt"
+
+    log "  strace -f -c (daemon): $name ($scenario)"
+    strace -f -c -o "$output" -- \
+        "$binary" -a "rsync://localhost:$DAEMON_PORT/bench/" "$dst/" 2>/dev/null || true
+}
+
+run_perf_stat() {
+    local binary="$1"
+    local name="$2"
+    local scenario="$3"
+    local dst="$BENCH_DIR/dst"
+    local output="$RESULTS_DIR/perf_stat/${name}_${scenario}.txt"
+
+    log "  perf stat: $name ($scenario)"
+    perf stat -d -o "$output" -- \
+        "$binary" -a "$SRC_DIR/" "$dst/" 2>/dev/null || true
+}
+
+run_perf_stat_daemon() {
+    local binary="$1"
+    local name="$2"
+    local scenario="$3"
+    local dst="$BENCH_DIR/dst"
+    local output="$RESULTS_DIR/perf_stat/${name}_daemon_${scenario}.txt"
+
+    log "  perf stat (daemon): $name ($scenario)"
+    perf stat -d -o "$output" -- \
+        "$binary" -a "rsync://localhost:$DAEMON_PORT/bench/" "$dst/" 2>/dev/null || true
+}
+
+run_flamegraph() {
+    local binary="$1"
+    local name="$2"
+    local scenario="$3"
+    local dst="$BENCH_DIR/dst"
+    local output="$RESULTS_DIR/flamegraphs/${name}_${scenario}.svg"
+
+    log "  flamegraph: $name ($scenario)"
+    flamegraph -o "$output" --freq "$FLAMEGRAPH_FREQ" -- \
+        "$binary" -a "$SRC_DIR/" "$dst/" 2>/dev/null || true
+    if [[ -f "$output" ]]; then
+        log "    saved: $output"
+    fi
+}
+
+run_flamegraph_daemon() {
+    local binary="$1"
+    local name="$2"
+    local scenario="$3"
+    local dst="$BENCH_DIR/dst"
+    local output="$RESULTS_DIR/flamegraphs/${name}_daemon_${scenario}.svg"
+
+    log "  flamegraph (daemon): $name ($scenario)"
+    flamegraph -o "$output" --freq "$FLAMEGRAPH_FREQ" -- \
+        "$binary" -a "rsync://localhost:$DAEMON_PORT/bench/" "$dst/" 2>/dev/null || true
+    if [[ -f "$output" ]]; then
+        log "    saved: $output"
+    fi
+}
+
+run_strace_ssh_pull() {
+    local binary="$1"
+    local name="$2"
+    local scenario="$3"
+    local dst="$BENCH_DIR/dst"
+    local output="$RESULTS_DIR/strace/${name}_ssh_pull_${scenario}.txt"
+
+    log "  strace -f -c (ssh pull): $name ($scenario)"
+    strace -f -c -o "$output" -- \
+        "$binary" -a -e 'ssh -o StrictHostKeyChecking=no' "localhost:$SRC_DIR/" "$dst/" 2>/dev/null || true
+}
+
+run_strace_ssh_push() {
+    local binary="$1"
+    local name="$2"
+    local scenario="$3"
+    local dst="$BENCH_DIR/dst"
+    local output="$RESULTS_DIR/strace/${name}_ssh_push_${scenario}.txt"
+
+    log "  strace -f -c (ssh push): $name ($scenario)"
+    strace -f -c -o "$output" -- \
+        "$binary" -a -e 'ssh -o StrictHostKeyChecking=no' "$SRC_DIR/" "localhost:$dst/" 2>/dev/null || true
+}
+
+run_perf_stat_ssh_pull() {
+    local binary="$1"
+    local name="$2"
+    local scenario="$3"
+    local dst="$BENCH_DIR/dst"
+    local output="$RESULTS_DIR/perf_stat/${name}_ssh_pull_${scenario}.txt"
+
+    log "  perf stat (ssh pull): $name ($scenario)"
+    perf stat -d -o "$output" -- \
+        "$binary" -a -e 'ssh -o StrictHostKeyChecking=no' "localhost:$SRC_DIR/" "$dst/" 2>/dev/null || true
+}
+
+run_perf_stat_ssh_push() {
+    local binary="$1"
+    local name="$2"
+    local scenario="$3"
+    local dst="$BENCH_DIR/dst"
+    local output="$RESULTS_DIR/perf_stat/${name}_ssh_push_${scenario}.txt"
+
+    log "  perf stat (ssh push): $name ($scenario)"
+    perf stat -d -o "$output" -- \
+        "$binary" -a -e 'ssh -o StrictHostKeyChecking=no' "$SRC_DIR/" "localhost:$dst/" 2>/dev/null || true
+}
+
+run_flamegraph_ssh_pull() {
+    local binary="$1"
+    local name="$2"
+    local scenario="$3"
+    local dst="$BENCH_DIR/dst"
+    local output="$RESULTS_DIR/flamegraphs/${name}_ssh_pull_${scenario}.svg"
+
+    log "  flamegraph (ssh pull): $name ($scenario)"
+    flamegraph -o "$output" --freq "$FLAMEGRAPH_FREQ" -- \
+        "$binary" -a -e 'ssh -o StrictHostKeyChecking=no' "localhost:$SRC_DIR/" "$dst/" 2>/dev/null || true
+    if [[ -f "$output" ]]; then
+        log "    saved: $output"
+    fi
+}
+
+run_flamegraph_ssh_push() {
+    local binary="$1"
+    local name="$2"
+    local scenario="$3"
+    local dst="$BENCH_DIR/dst"
+    local output="$RESULTS_DIR/flamegraphs/${name}_ssh_push_${scenario}.svg"
+
+    log "  flamegraph (ssh push): $name ($scenario)"
+    flamegraph -o "$output" --freq "$FLAMEGRAPH_FREQ" -- \
+        "$binary" -a -e 'ssh -o StrictHostKeyChecking=no' "$SRC_DIR/" "localhost:$dst/" 2>/dev/null || true
+    if [[ -f "$output" ]]; then
+        log "    saved: $output"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Run profiling for a scenario
+# ---------------------------------------------------------------------------
+
+profile_scenario() {
+    local scenario="$1"
+
+    log "=== Profiling scenario: $scenario ==="
+
+    case "$scenario" in
+        initial)
+            ;;
+        no_change)
+            ;;
+        incremental)
+            modify_src
+            ;;
+    esac
+
+    local binaries=("$UPSTREAM" "$OC_V058" "$OC_RSYNC")
+    local names=("upstream" "v058" "dev")
+
+    for i in "${!binaries[@]}"; do
+        local binary="${binaries[$i]}"
+        local name="${names[$i]}"
+
+        if [[ ! -x "$binary" ]]; then
+            log "  SKIP $name: binary not found"
+            continue
+        fi
+
+        # Local copy profiling
+        clean_dst
+        if [[ "$scenario" == "no_change" ]]; then
+            "$binary" -a "$SRC_DIR/" "$BENCH_DIR/dst/" 2>/dev/null || true
+        fi
+        run_strace_profile "$binary" "$name" "$scenario"
+
+        clean_dst
+        if [[ "$scenario" == "no_change" ]]; then
+            "$binary" -a "$SRC_DIR/" "$BENCH_DIR/dst/" 2>/dev/null || true
+        fi
+        run_perf_stat "$binary" "$name" "$scenario"
+
+        if ! $SKIP_FLAMEGRAPH; then
+            clean_dst
+            if [[ "$scenario" == "no_change" ]]; then
+                "$binary" -a "$SRC_DIR/" "$BENCH_DIR/dst/" 2>/dev/null || true
+            fi
+            run_flamegraph "$binary" "$name" "$scenario"
+        fi
+
+        # Daemon profiling
+        if [[ -n "${DAEMON_PORT:-}" ]]; then
+            clean_dst
+            if [[ "$scenario" == "no_change" ]]; then
+                "$binary" -a "rsync://localhost:$DAEMON_PORT/bench/" "$BENCH_DIR/dst/" 2>/dev/null || true
+            fi
+            run_strace_daemon "$binary" "$name" "$scenario"
+
+            clean_dst
+            if [[ "$scenario" == "no_change" ]]; then
+                "$binary" -a "rsync://localhost:$DAEMON_PORT/bench/" "$BENCH_DIR/dst/" 2>/dev/null || true
+            fi
+            run_perf_stat_daemon "$binary" "$name" "$scenario"
+
+            if ! $SKIP_FLAMEGRAPH; then
+                clean_dst
+                if [[ "$scenario" == "no_change" ]]; then
+                    "$binary" -a "rsync://localhost:$DAEMON_PORT/bench/" "$BENCH_DIR/dst/" 2>/dev/null || true
+                fi
+                run_flamegraph_daemon "$binary" "$name" "$scenario"
+            fi
+        fi
+
+        # SSH profiling
+        if ! $SKIP_SSH; then
+            # SSH Pull
+            clean_dst
+            if [[ "$scenario" == "no_change" ]]; then
+                "$binary" -a -e 'ssh -o StrictHostKeyChecking=no' "localhost:$SRC_DIR/" "$BENCH_DIR/dst/" 2>/dev/null || true
+            fi
+            run_strace_ssh_pull "$binary" "$name" "$scenario"
+
+            clean_dst
+            if [[ "$scenario" == "no_change" ]]; then
+                "$binary" -a -e 'ssh -o StrictHostKeyChecking=no' "localhost:$SRC_DIR/" "$BENCH_DIR/dst/" 2>/dev/null || true
+            fi
+            run_perf_stat_ssh_pull "$binary" "$name" "$scenario"
+
+            if ! $SKIP_FLAMEGRAPH; then
+                clean_dst
+                if [[ "$scenario" == "no_change" ]]; then
+                    "$binary" -a -e 'ssh -o StrictHostKeyChecking=no' "localhost:$SRC_DIR/" "$BENCH_DIR/dst/" 2>/dev/null || true
+                fi
+                run_flamegraph_ssh_pull "$binary" "$name" "$scenario"
+            fi
+
+            # SSH Push
+            clean_dst
+            if [[ "$scenario" == "no_change" ]]; then
+                "$binary" -a -e 'ssh -o StrictHostKeyChecking=no' "$SRC_DIR/" "localhost:$BENCH_DIR/dst/" 2>/dev/null || true
+            fi
+            run_strace_ssh_push "$binary" "$name" "$scenario"
+
+            clean_dst
+            if [[ "$scenario" == "no_change" ]]; then
+                "$binary" -a -e 'ssh -o StrictHostKeyChecking=no' "$SRC_DIR/" "localhost:$BENCH_DIR/dst/" 2>/dev/null || true
+            fi
+            run_perf_stat_ssh_push "$binary" "$name" "$scenario"
+
+            if ! $SKIP_FLAMEGRAPH; then
+                clean_dst
+                if [[ "$scenario" == "no_change" ]]; then
+                    "$binary" -a -e 'ssh -o StrictHostKeyChecking=no' "$SRC_DIR/" "localhost:$BENCH_DIR/dst/" 2>/dev/null || true
+                fi
+                run_flamegraph_ssh_push "$binary" "$name" "$scenario"
+            fi
+        fi
+    done
+}
+
+# ---------------------------------------------------------------------------
+# Syscall comparison report
+# ---------------------------------------------------------------------------
+
+generate_comparison() {
+    local report="$RESULTS_DIR/syscall_comparison.txt"
+    log "Generating syscall comparison report..."
+
+    {
+        echo "================================================================"
+        echo "  Syscall Comparison: upstream rsync vs oc-rsync"
+        echo "================================================================"
+        echo ""
+        echo "Date: $(date)"
+        echo "Upstream: $($UPSTREAM --version | head -1)"
+        echo "oc-rsync dev: $($OC_RSYNC --version | head -1)"
+        if [[ -x "$OC_V058" ]]; then
+            echo "oc-rsync v0.5.8: $($OC_V058 --version | head -1)"
+        fi
+        echo ""
+
+        IFS=',' read -ra scenario_list <<< "$SCENARIOS"
+        for scenario in "${scenario_list[@]}"; do
+            echo "--- Scenario: $scenario ---"
+            echo ""
+
+            for mode in "" "daemon_" "ssh_pull_" "ssh_push_"; do
+                local label
+                case "$mode" in
+                    "")           label="Local Copy" ;;
+                    "daemon_")    label="Daemon Pull" ;;
+                    "ssh_pull_")  label="SSH Pull" ;;
+                    "ssh_push_")  label="SSH Push" ;;
+                esac
+                echo "  [$label]"
+
+                for name in upstream v058 dev; do
+                    local file="$RESULTS_DIR/strace/${name}_${mode}${scenario}.txt"
+                    if [[ -f "$file" ]]; then
+                        echo "    $name:"
+                        grep -E '^\s+[0-9]' "$file" | head -15 | sed 's/^/      /'
+                        echo ""
+                    fi
+                done
+            done
+        done
+
+        echo ""
+        echo "--- perf stat summaries ---"
+        echo ""
+        for f in "$RESULTS_DIR"/perf_stat/*.txt; do
+            if [[ -f "$f" ]]; then
+                echo "  $(basename "$f" .txt):"
+                grep -E '(instructions|cycles|cache-misses|branch-misses|task-clock)' "$f" | sed 's/^/    /' || true
+                echo ""
+            fi
+        done
+
+    } > "$report"
+
+    log "Comparison report saved to $report"
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+main() {
+    log "=== oc-rsync Hot Path Profiling ==="
+    log "Scenarios: $SCENARIOS"
+    log ""
+
+    # Check binaries
+    for bin in "$UPSTREAM" "$OC_RSYNC"; do
+        if [[ ! -x "$bin" ]]; then
+            log "ERROR: $bin not found"
+            exit 1
+        fi
+    done
+
+    # Check profiling tools
+    for tool in strace perf; do
+        if ! command -v "$tool" &>/dev/null; then
+            log "WARNING: $tool not found, some profiles will be skipped"
+        fi
+    done
+
+    if ! $SKIP_FLAMEGRAPH && ! command -v flamegraph &>/dev/null; then
+        log "WARNING: flamegraph not found, skipping flamegraph generation"
+        SKIP_FLAMEGRAPH=true
+    fi
+
+    generate_test_data
+
+    # Setup SSH loopback for SSH profiling
+    if ! $SKIP_SSH; then
+        log "Setting up SSH loopback..."
+        if ! ssh -o StrictHostKeyChecking=no -o BatchMode=yes localhost echo ok 2>/dev/null; then
+            log "WARNING: SSH loopback failed, skipping SSH profiles"
+            SKIP_SSH=true
+        else
+            log "SSH loopback OK"
+        fi
+    fi
+
+    start_daemon
+
+    IFS=',' read -ra scenario_list <<< "$SCENARIOS"
+    for scenario in "${scenario_list[@]}"; do
+        profile_scenario "$scenario"
+    done
+
+    generate_comparison
+
+    log ""
+    log "=== Profiling complete ==="
+    log "Results directory: $RESULTS_DIR/"
+    log ""
+    log "Flamegraphs: $RESULTS_DIR/flamegraphs/"
+    log "Strace:      $RESULTS_DIR/strace/"
+    log "Perf stat:   $RESULTS_DIR/perf_stat/"
+    log "Comparison:  $RESULTS_DIR/syscall_comparison.txt"
+}
+
+main "$@"

--- a/scripts/run_arch_benchmark.py
+++ b/scripts/run_arch_benchmark.py
@@ -1,0 +1,627 @@
+#!/usr/bin/env python3
+"""Benchmark: upstream rsync 3.4.1 vs oc-rsync v0.5.8 vs oc-rsync HEAD.
+
+Tests 3 binaries x 5 transfer modes x 4 copy modes x 3 scenarios = 180 data points.
+Runs inside the Arch Linux benchmark container with SSH loopback and rsync
+daemon configured.
+
+Usage: python3 run_arch_benchmark.py [--runs N] [--json]
+"""
+
+import argparse
+import json
+import os
+import shutil
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+
+BINARIES = {
+    "upstream": "/usr/local/bin/upstream-rsync",
+    "v0.5.8": "/usr/local/bin/oc-rsync-v058",
+    "dev": "/usr/local/bin/oc-rsync-dev",
+}
+
+TRANSFER_MODES = {
+    "local": {
+        "template": "{bin} {flags} {src}/ {dst}/",
+        "label": "Local Copy",
+    },
+    "ssh_pull": {
+        "template": (
+            "{bin} {flags} --timeout=60"
+            " -e 'ssh -o StrictHostKeyChecking=no'"
+            " localhost:{src}/ {dst}/"
+        ),
+        "label": "SSH Pull",
+    },
+    "ssh_push": {
+        "template": (
+            "{bin} {flags} --timeout=60"
+            " -e 'ssh -o StrictHostKeyChecking=no'"
+            " {src}/ localhost:{dst}/"
+        ),
+        "label": "SSH Push",
+    },
+    "daemon_pull": {
+        "template": (
+            "{bin} {flags} --timeout=60"
+            " rsync://localhost:{port}/bench/ {dst}/"
+        ),
+        "label": "Daemon Pull",
+    },
+    "daemon_push": {
+        "template": (
+            "{bin} {flags} --timeout=60"
+            " {src}/ rsync://localhost:{port}/dest/"
+        ),
+        "label": "Daemon Push",
+    },
+}
+
+COPY_MODES = {
+    "delta": {"flags": "-av", "label": "Delta (default)"},
+    "whole_file": {"flags": "-avW", "label": "Whole-file (-W)"},
+    "checksum": {"flags": "-avc", "label": "Checksum (-c)"},
+    "compressed": {"flags": "-avz", "label": "Compressed (-z)"},
+}
+
+SCENARIOS = ["initial", "no_change", "incremental"]
+
+CMD_TIMEOUT = 90
+
+
+def find_free_port():
+    """Find an available TCP port."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("", 0))
+        return s.getsockname()[1]
+
+
+def wait_for_port(port, timeout=10):
+    """Wait for a TCP port to accept connections."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            with socket.create_connection(("localhost", port), timeout=1):
+                return True
+        except OSError:
+            time.sleep(0.25)
+    return False
+
+
+def version_string(binary):
+    """Get version string from a binary."""
+    try:
+        out = subprocess.run(
+            [binary, "--version"], capture_output=True, text=True, timeout=5
+        )
+        return out.stdout.splitlines()[0] if out.stdout else "unknown"
+    except Exception:
+        return "unavailable"
+
+
+def run_timed(cmd, runs=5, warmup=1):
+    """Run a command multiple times and return timing stats.
+
+    Warmup runs are excluded from timing. Returns None on first failure
+    (timeout or non-zero exit) to avoid wasting time on known-broken combos.
+    """
+    for _ in range(warmup):
+        try:
+            result = subprocess.run(
+                cmd, shell=True, capture_output=True, timeout=CMD_TIMEOUT
+            )
+            if result.returncode not in (0, 23, 24):
+                return None
+        except subprocess.TimeoutExpired:
+            return None
+
+    times = []
+    failures = 0
+    for _ in range(runs):
+        start = time.perf_counter()
+        try:
+            result = subprocess.run(
+                cmd, shell=True, capture_output=True, timeout=CMD_TIMEOUT
+            )
+        except subprocess.TimeoutExpired:
+            failures += 1
+            print(
+                f"  WARNING: timeout ({CMD_TIMEOUT}s): {cmd[:120]}",
+                file=sys.stderr,
+            )
+            if failures >= 1:
+                return None
+            continue
+        elapsed = time.perf_counter() - start
+        if result.returncode not in (0, 23, 24):
+            failures += 1
+            stderr = result.stderr.decode(errors="replace").strip()
+            print(
+                f"  WARNING: exit {result.returncode}: {cmd[:120]}",
+                file=sys.stderr,
+            )
+            if stderr:
+                print(f"    {stderr[:300]}", file=sys.stderr)
+            if failures >= 1:
+                return None
+        else:
+            times.append(elapsed)
+    if not times:
+        return None
+    times.sort()
+    median = times[len(times) // 2]
+    return {
+        "mean": round(sum(times) / len(times), 4),
+        "median": round(median, 4),
+        "min": round(min(times), 4),
+        "max": round(max(times), 4),
+        "stddev": round(
+            (sum((t - sum(times) / len(times)) ** 2 for t in times) / len(times))
+            ** 0.5,
+            4,
+        ),
+        "runs": len(times),
+    }
+
+
+def run_with_stats(binary, flags, src, dst):
+    """Run a transfer with --stats and parse throughput."""
+    cmd = f"{binary} {flags} --stats {src}/ {dst}/"
+    try:
+        result = subprocess.run(
+            cmd, shell=True, capture_output=True, text=True, timeout=CMD_TIMEOUT
+        )
+    except subprocess.TimeoutExpired:
+        return None
+    if result.returncode not in (0, 23, 24):
+        return None
+    stats = {}
+    for line in result.stdout.splitlines() + result.stderr.splitlines():
+        line = line.strip()
+        if "Total bytes sent:" in line or "total bytes sent:" in line:
+            parts = line.split(":")
+            if len(parts) >= 2:
+                try:
+                    stats["bytes_sent"] = int(
+                        parts[1].strip().replace(",", "").split()[0]
+                    )
+                except (ValueError, IndexError):
+                    pass
+        elif "Total bytes received:" in line or "total bytes received:" in line:
+            parts = line.split(":")
+            if len(parts) >= 2:
+                try:
+                    stats["bytes_received"] = int(
+                        parts[1].strip().replace(",", "").split()[0]
+                    )
+                except (ValueError, IndexError):
+                    pass
+        elif "Total file size:" in line or "total size is" in line:
+            parts = line.split(":")
+            if len(parts) >= 2:
+                try:
+                    stats["total_size"] = int(
+                        parts[1].strip().replace(",", "").split()[0]
+                    )
+                except (ValueError, IndexError):
+                    pass
+    return stats
+
+
+def create_test_data(base):
+    """Generate 10,000 files (~290 MB) with three tiers."""
+    os.makedirs(f"{base}/small", exist_ok=True)
+    os.makedirs(f"{base}/medium", exist_ok=True)
+    os.makedirs(f"{base}/large", exist_ok=True)
+
+    print("  Generating 9,000 small files (1KB each)...", file=sys.stderr)
+    for i in range(9000):
+        with open(f"{base}/small/file_{i:05d}.txt", "wb") as f:
+            f.write(os.urandom(1024))
+
+    print("  Generating 800 medium files (100KB each)...", file=sys.stderr)
+    for i in range(800):
+        with open(f"{base}/medium/file_{i:04d}.bin", "wb") as f:
+            f.write(os.urandom(100 * 1024))
+
+    print("  Generating 200 large files (1MB each)...", file=sys.stderr)
+    for i in range(200):
+        with open(f"{base}/large/file_{i:04d}.dat", "wb") as f:
+            f.write(os.urandom(1024 * 1024))
+
+
+def total_stats(path):
+    """Count total bytes and files under a path."""
+    total_bytes = 0
+    total_files = 0
+    for dp, _, fnames in os.walk(path):
+        for fn in fnames:
+            total_bytes += os.path.getsize(os.path.join(dp, fn))
+            total_files += 1
+    return total_bytes, total_files
+
+
+def modify_files(src, fraction=0.1):
+    """Modify a fraction of files for incremental tests."""
+    all_files = []
+    for dp, _, fnames in os.walk(src):
+        for fn in fnames:
+            all_files.append(os.path.join(dp, fn))
+    count = max(1, int(len(all_files) * fraction))
+    for path in all_files[:count]:
+        with open(path, "r+b") as f:
+            data = f.read()
+            mid = len(data) // 2
+            patch = os.urandom(min(64, len(data)))
+            f.seek(mid)
+            f.write(patch)
+
+
+def setup_ssh():
+    """Start SSH server and configure loopback."""
+    subprocess.run(["ssh-keygen", "-A"], capture_output=True)
+    os.makedirs("/run/sshd", exist_ok=True)
+    subprocess.Popen(
+        ["/usr/sbin/sshd"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    time.sleep(1)
+
+    home = os.path.expanduser("~")
+    ssh_dir = f"{home}/.ssh"
+    os.makedirs(ssh_dir, mode=0o700, exist_ok=True)
+
+    key_path = f"{ssh_dir}/id_ed25519"
+    if not os.path.exists(key_path):
+        subprocess.run(
+            ["ssh-keygen", "-t", "ed25519", "-N", "", "-f", key_path],
+            capture_output=True,
+        )
+
+    pub_key = open(f"{key_path}.pub").read().strip()
+    auth_keys = f"{ssh_dir}/authorized_keys"
+    existing = open(auth_keys).read() if os.path.exists(auth_keys) else ""
+    if pub_key not in existing:
+        with open(auth_keys, "a") as f:
+            f.write(pub_key + "\n")
+    os.chmod(auth_keys, 0o600)
+
+    result = subprocess.run(
+        ["ssh", "-o", "StrictHostKeyChecking=no", "localhost", "echo", "ok"],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    if result.returncode != 0:
+        print(f"WARNING: SSH loopback failed: {result.stderr}", file=sys.stderr)
+        return False
+    return True
+
+
+def start_daemon(binary, conf_path, port):
+    """Start an rsync daemon and wait for it to listen."""
+    proc = subprocess.Popen(
+        [binary, "--daemon", "--config", conf_path, "--no-detach"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    if not wait_for_port(port):
+        print(
+            f"WARNING: daemon failed to start on port {port} ({binary})",
+            file=sys.stderr,
+        )
+        return None
+    return proc
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="oc-rsync benchmark: upstream vs v0.5.8 vs HEAD"
+    )
+    parser.add_argument("--runs", type=int, default=5, help="Runs per test")
+    parser.add_argument("--json", action="store_true", help="Output JSON only")
+    args = parser.parse_args()
+
+    runs = args.runs
+    tmpdir = tempfile.mkdtemp(prefix="rsync_bench_")
+    daemon_procs = []
+    results = {"tests": [], "summary": {}}
+
+    try:
+        # Check binary availability
+        versions = {}
+        available = {}
+        for name, binary in BINARIES.items():
+            ver = version_string(binary)
+            versions[name] = ver
+            available[name] = os.path.isfile(binary)
+        results["versions"] = versions
+
+        if not args.json:
+            print("=" * 90)
+            print("  oc-rsync Benchmark — upstream rsync 3.4.1 vs v0.5.8 vs HEAD")
+            print("=" * 90)
+            for name, ver in versions.items():
+                status = "OK" if available[name] else "MISSING"
+                print(f"  {name:>10} : {ver} [{status}]")
+            print(f"  {'runs':>10} : {runs}")
+            print()
+
+        active_binaries = {k: v for k, v in BINARIES.items() if available[k]}
+        if "upstream" not in active_binaries:
+            print("ERROR: upstream rsync not found", file=sys.stderr)
+            sys.exit(1)
+        if len(active_binaries) < 2:
+            print("ERROR: need at least 2 binaries", file=sys.stderr)
+            sys.exit(1)
+
+        # Generate test data
+        src = f"{tmpdir}/src"
+        if not args.json:
+            print("Creating test data (10,000 files, ~290 MB)...", file=sys.stderr)
+        create_test_data(src)
+        total_bytes, total_files = total_stats(src)
+        total_mb = total_bytes / 1024 / 1024
+        results["test_data"] = {
+            "size_mb": round(total_mb, 1),
+            "files": total_files,
+        }
+        if not args.json:
+            print(f"Test data: {total_mb:.1f} MB, {total_files} files\n")
+
+        # Setup SSH
+        if not args.json:
+            print("Setting up SSH loopback...", file=sys.stderr)
+        ssh_ok = setup_ssh()
+
+        # Setup rsync daemon (use upstream rsync as daemon for all clients)
+        port = find_free_port()
+        daemon_dst = f"{tmpdir}/daemon_dest"
+        os.makedirs(daemon_dst, exist_ok=True)
+        conf_path = f"{tmpdir}/rsyncd.conf"
+        with open(conf_path, "w") as f:
+            f.write(
+                f"port = {port}\n"
+                f"use chroot = false\n"
+                f"\n"
+                f"[bench]\n"
+                f"    path = {src}\n"
+                f"    read only = true\n"
+                f"\n"
+                f"[dest]\n"
+                f"    path = {daemon_dst}\n"
+                f"    read only = false\n"
+            )
+
+        if not args.json:
+            print(f"Starting rsync daemon on port {port}...", file=sys.stderr)
+        daemon_proc = start_daemon(BINARIES["upstream"], conf_path, port)
+        daemon_ok = daemon_proc is not None
+        if daemon_proc:
+            daemon_procs.append(daemon_proc)
+
+        # Destination directories per binary
+        dsts = {}
+        for name in active_binaries:
+            dsts[name] = f"{tmpdir}/dst_{name}"
+
+        def reset_dsts():
+            for dst in dsts.values():
+                shutil.rmtree(dst, ignore_errors=True)
+                os.makedirs(dst, exist_ok=True)
+
+        def reset_daemon_dst():
+            shutil.rmtree(daemon_dst, ignore_errors=True)
+            os.makedirs(daemon_dst, exist_ok=True)
+
+        # Print header
+        if not args.json:
+            hdr = f"{'Mode':<14} {'Copy':<12} {'Scenario':<12}"
+            for name in active_binaries:
+                hdr += f" {name:>10}"
+            for name in active_binaries:
+                if name != "upstream":
+                    hdr += f" {name}/up"
+            print(hdr)
+            print("-" * len(hdr))
+
+        modified_for_incremental = False
+
+        for mode_id, mode_cfg in TRANSFER_MODES.items():
+            if mode_id.startswith("ssh_") and not ssh_ok:
+                if not args.json:
+                    print(
+                        f"SKIP {mode_id}: SSH not available", file=sys.stderr
+                    )
+                continue
+            if mode_id.startswith("daemon_") and not daemon_ok:
+                if not args.json:
+                    print(
+                        f"SKIP {mode_id}: daemon not available",
+                        file=sys.stderr,
+                    )
+                continue
+
+            for copy_id, copy_cfg in COPY_MODES.items():
+                for scenario in SCENARIOS:
+                    if not args.json:
+                        print(
+                            f"Running: [{mode_id}] [{copy_id}] [{scenario}]...",
+                            file=sys.stderr,
+                        )
+
+                    if scenario == "initial":
+                        reset_dsts()
+                        if mode_id == "daemon_push":
+                            reset_daemon_dst()
+                    elif scenario == "no_change":
+                        pass
+                    elif scenario == "incremental":
+                        if not modified_for_incremental:
+                            modify_files(src, 0.1)
+                            modified_for_incremental = True
+
+                    timings = {}
+                    skip = False
+                    for name, binary in active_binaries.items():
+                        tpl = mode_cfg["template"]
+                        cmd = tpl.format(
+                            bin=binary,
+                            flags=copy_cfg["flags"],
+                            src=src,
+                            dst=dsts[name],
+                            port=port,
+                        )
+
+                        if mode_id == "daemon_push" and scenario == "initial":
+                            reset_daemon_dst()
+
+                        result = run_timed(cmd, runs=runs, warmup=1)
+                        if result is None:
+                            if not args.json:
+                                print(
+                                    f"  SKIP {mode_id}/{copy_id}/{scenario}:"
+                                    f" {name} failed",
+                                    file=sys.stderr,
+                                )
+                            skip = True
+                            break
+                        timings[name] = result
+
+                    if skip:
+                        continue
+
+                    # Compute ratios vs upstream
+                    up_mean = timings["upstream"]["mean"]
+                    ratios = {}
+                    for name in active_binaries:
+                        if name != "upstream" and up_mean > 0:
+                            ratios[f"{name}_vs_upstream"] = round(
+                                timings[name]["mean"] / up_mean, 3
+                            )
+
+                    entry = {
+                        "mode": mode_id,
+                        "copy_mode": copy_id,
+                        "scenario": scenario,
+                        "timings": timings,
+                        "ratios": ratios,
+                    }
+                    results["tests"].append(entry)
+
+                    if not args.json:
+                        row = f"{mode_id:<14} {copy_id:<12} {scenario:<12}"
+                        for name in active_binaries:
+                            row += f" {timings[name]['mean']:>9.3f}s"
+                        for name in active_binaries:
+                            if name != "upstream":
+                                r = ratios.get(f"{name}_vs_upstream", 0)
+                                row += f" {r:>6.2f}x"
+                        print(row)
+
+        # Summary statistics
+        all_ratios_by_binary = {}
+        by_mode = {}
+        by_copy = {}
+        by_scenario = {}
+        for t in results["tests"]:
+            for rname, rval in t["ratios"].items():
+                all_ratios_by_binary.setdefault(rname, []).append(rval)
+                by_mode.setdefault((rname, t["mode"]), []).append(rval)
+                by_copy.setdefault((rname, t["copy_mode"]), []).append(rval)
+                by_scenario.setdefault((rname, t["scenario"]), []).append(rval)
+
+        def avg(lst):
+            return round(sum(lst) / len(lst), 3) if lst else 0
+
+        summary = {}
+        for rname, ratios in all_ratios_by_binary.items():
+            summary[rname] = {
+                "avg": avg(ratios),
+                "best": round(min(ratios), 3) if ratios else 0,
+                "worst": round(max(ratios), 3) if ratios else 0,
+            }
+            summary[f"{rname}_by_mode"] = {}
+            for (rn, mode), vals in by_mode.items():
+                if rn == rname:
+                    summary[f"{rname}_by_mode"][mode] = avg(vals)
+            summary[f"{rname}_by_copy_mode"] = {}
+            for (rn, copy_mode), vals in by_copy.items():
+                if rn == rname:
+                    summary[f"{rname}_by_copy_mode"][copy_mode] = avg(vals)
+            summary[f"{rname}_by_scenario"] = {}
+            for (rn, scenario), vals in by_scenario.items():
+                if rn == rname:
+                    summary[f"{rname}_by_scenario"][scenario] = avg(vals)
+
+        results["summary"] = summary
+
+        if not args.json:
+            print()
+            print("=" * 90)
+            print(
+                "  Summary (ratio < 1.0 = faster than upstream,"
+                " > 1.0 = slower)"
+            )
+            print("=" * 90)
+            for rname, s in summary.items():
+                if isinstance(s, dict) and "avg" in s:
+                    print(
+                        f"\n  {rname}: avg {s['avg']:.2f}x"
+                        f"  (best {s['best']:.2f}x,"
+                        f" worst {s['worst']:.2f}x)"
+                    )
+            for rname in all_ratios_by_binary:
+                mode_key = f"{rname}_by_mode"
+                if mode_key in summary:
+                    items = ", ".join(
+                        f"{m}={v:.2f}x"
+                        for m, v in summary[mode_key].items()
+                    )
+                    print(f"  {rname} by mode: {items}")
+                copy_key = f"{rname}_by_copy_mode"
+                if copy_key in summary:
+                    items = ", ".join(
+                        f"{m}={v:.2f}x"
+                        for m, v in summary[copy_key].items()
+                    )
+                    print(f"  {rname} by copy: {items}")
+                scenario_key = f"{rname}_by_scenario"
+                if scenario_key in summary:
+                    items = ", ".join(
+                        f"{m}={v:.2f}x"
+                        for m, v in summary[scenario_key].items()
+                    )
+                    print(f"  {rname} by scenario: {items}")
+
+        if args.json:
+            print(json.dumps(results, indent=2))
+
+        # Save results to /results if mounted
+        if os.path.isdir("/results"):
+            ts = time.strftime("%Y%m%d_%H%M%S")
+            json_path = f"/results/benchmark_{ts}.json"
+            with open(json_path, "w") as f:
+                json.dump(results, f, indent=2)
+            with open("/results/benchmark.json", "w") as f:
+                json.dump(results, f, indent=2)
+            if not args.json:
+                print(f"\nResults saved to {json_path}")
+
+    finally:
+        for proc in daemon_procs:
+            proc.terminate()
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_arch_benchmark_container.sh
+++ b/scripts/run_arch_benchmark_container.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+# Run benchmark + profiling inside an Arch Linux container.
+#
+# Usage:
+#   ./scripts/run_arch_benchmark_container.sh [--runs N] [--json] [--profile]
+#
+# Builds upstream rsync 3.4.1 + oc-rsync v0.5.8 + oc-rsync HEAD inside
+# an Arch Linux container, then runs the full benchmark matrix.
+#
+# Modes:
+#   (default)   Run benchmark: 3 binaries × 5 modes × 3 scenarios
+#   --profile   Run profiling: flamegraphs, strace, perf stat
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+RUNS=5
+JSON_FLAG=""
+PROFILE_MODE=false
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --runs)     RUNS="$2"; shift 2 ;;
+        --json)     JSON_FLAG="--json"; shift ;;
+        --profile)  PROFILE_MODE=true; shift ;;
+        -h|--help)
+            echo "Usage: $0 [--runs N] [--json] [--profile]"
+            echo ""
+            echo "Options:"
+            echo "  --runs N     Number of benchmark runs per test (default: 5)"
+            echo "  --json       Output JSON only"
+            echo "  --profile    Run profiling (flamegraphs, strace, perf stat)"
+            exit 0
+            ;;
+        *)  echo "Unknown option: $1" >&2; exit 1 ;;
+    esac
+done
+
+CONTAINER_ENGINE="${CONTAINER_ENGINE:-podman}"
+IMAGE_NAME="oc-rsync-bench-arch"
+RESULTS_DIR="$REPO_ROOT/benchmark-results"
+
+echo "=== oc-rsync Benchmark: Arch Linux Container ==="
+echo "Container engine: $CONTAINER_ENGINE"
+echo "Runs per test: $RUNS"
+echo "Profile mode: $PROFILE_MODE"
+echo ""
+
+echo "Building container image (this may take a while)..."
+"$CONTAINER_ENGINE" build \
+    -t "$IMAGE_NAME" \
+    -f "$REPO_ROOT/scripts/Containerfile.benchmark-arch" \
+    "$REPO_ROOT"
+
+echo ""
+
+mkdir -p "$RESULTS_DIR"
+
+if $PROFILE_MODE; then
+    echo "Running profiling inside container..."
+    echo ""
+    "$CONTAINER_ENGINE" run --rm --privileged \
+        -v "$RESULTS_DIR:/results:Z" \
+        "$IMAGE_NAME" \
+        "/usr/sbin/sshd && bash /usr/local/bin/profile_hotpaths.sh"
+    echo ""
+    echo "Profiling results saved to: $RESULTS_DIR/"
+else
+    echo "Running benchmarks inside container..."
+    echo ""
+    "$CONTAINER_ENGINE" run --rm --privileged \
+        -v "$RESULTS_DIR:/results:Z" \
+        -e BENCH_RUNS="$RUNS" \
+        "$IMAGE_NAME" \
+        "/usr/sbin/sshd && python3 /usr/local/bin/run_arch_benchmark.py --runs ${RUNS} ${JSON_FLAG}"
+fi

--- a/scripts/run_full_benchmark.py
+++ b/scripts/run_full_benchmark.py
@@ -1,0 +1,454 @@
+#!/usr/bin/env python3
+"""Benchmark: upstream rsync vs oc-rsync (current build).
+
+Tests 2 binaries x 5 transfer modes x 4 copy modes x 3 scenarios = 120 data points.
+Runs inside the benchmark container with SSH loopback and rsync daemon configured.
+
+Usage: python3 run_full_benchmark.py [--runs N] [--json]
+"""
+
+import argparse
+import json
+import os
+import shutil
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+
+BINARIES = {
+    "upstream": "/usr/local/bin/upstream-rsync",
+    "oc-rsync": "/usr/local/bin/oc-rsync-release",
+}
+
+TRANSFER_MODES = {
+    "local": {
+        "template": "{bin} {flags} {src}/ {dst}/",
+        "label": "Local Copy",
+    },
+    "ssh_pull": {
+        "template": "{bin} {flags} --timeout=30 -e 'ssh -o StrictHostKeyChecking=no' localhost:{src}/ {dst}/",
+        "label": "SSH Pull",
+    },
+    "ssh_push": {
+        "template": "{bin} {flags} --timeout=30 -e 'ssh -o StrictHostKeyChecking=no' {src}/ localhost:{dst}/",
+        "label": "SSH Push",
+    },
+    "daemon_pull": {
+        "template": "{bin} {flags} --timeout=30 rsync://localhost:{port}/bench/ {dst}/",
+        "label": "Daemon Pull",
+    },
+    "daemon_push": {
+        "template": "{bin} {flags} --timeout=30 {src}/ rsync://localhost:{port}/dest/",
+        "label": "Daemon Push",
+    },
+}
+
+COPY_MODES = {
+    "whole_file": {"flags": "-avW", "label": "Whole-file (-W)"},
+    "delta": {"flags": "-av", "label": "Delta (default)"},
+    "checksum": {"flags": "-avc", "label": "Checksum (-c)"},
+    "compressed": {"flags": "-avz", "label": "Compressed (-z)"},
+}
+
+SCENARIOS = ["initial", "no_change", "incremental"]
+
+
+def find_free_port():
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("", 0))
+        return s.getsockname()[1]
+
+
+def wait_for_port(port, timeout=10):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            with socket.create_connection(("localhost", port), timeout=1):
+                return True
+        except OSError:
+            time.sleep(0.25)
+    return False
+
+
+def version_string(binary):
+    try:
+        out = subprocess.run(
+            [binary, "--version"], capture_output=True, text=True, timeout=5
+        )
+        return out.stdout.splitlines()[0] if out.stdout else "unknown"
+    except Exception:
+        return "unavailable"
+
+
+CMD_TIMEOUT = 120
+
+
+def benchmark(cmd, runs=5):
+    """Run command multiple times and return timing stats."""
+    times = []
+    failures = 0
+    for _ in range(runs):
+        start = time.perf_counter()
+        try:
+            result = subprocess.run(
+                cmd, shell=True, capture_output=True, timeout=CMD_TIMEOUT
+            )
+        except subprocess.TimeoutExpired:
+            failures += 1
+            print(
+                f"  WARNING: timeout ({CMD_TIMEOUT}s): {cmd[:120]}",
+                file=sys.stderr,
+            )
+            if failures >= 2:
+                return None
+            continue
+        elapsed = time.perf_counter() - start
+        if result.returncode not in (0, 23, 24):
+            failures += 1
+            stderr = result.stderr.decode(errors="replace").strip()
+            print(
+                f"  WARNING: exit {result.returncode}: {cmd[:120]}",
+                file=sys.stderr,
+            )
+            if stderr:
+                print(f"    {stderr[:200]}", file=sys.stderr)
+            if failures >= 2:
+                return None
+        else:
+            times.append(elapsed)
+    if not times:
+        return None
+    return {
+        "mean": round(sum(times) / len(times), 4),
+        "min": round(min(times), 4),
+        "max": round(max(times), 4),
+    }
+
+
+def create_test_data(base):
+    """Generate 10,000 files (~150 MB)."""
+    os.makedirs(f"{base}/small", exist_ok=True)
+    os.makedirs(f"{base}/medium", exist_ok=True)
+    os.makedirs(f"{base}/large", exist_ok=True)
+
+    for i in range(9000):
+        with open(f"{base}/small/file_{i:05d}.txt", "wb") as f:
+            f.write(os.urandom(1024))
+
+    for i in range(800):
+        with open(f"{base}/medium/file_{i:04d}.bin", "wb") as f:
+            f.write(os.urandom(100 * 1024))
+
+    for i in range(200):
+        with open(f"{base}/large/file_{i:04d}.dat", "wb") as f:
+            f.write(os.urandom(1024 * 1024))
+
+
+def total_stats(path):
+    total_bytes = 0
+    total_files = 0
+    for dp, _, fnames in os.walk(path):
+        for fn in fnames:
+            total_bytes += os.path.getsize(os.path.join(dp, fn))
+            total_files += 1
+    return total_bytes, total_files
+
+
+def modify_files(src, fraction=0.1):
+    """Modify a fraction of files for incremental tests."""
+    all_files = []
+    for dp, _, fnames in os.walk(src):
+        for fn in fnames:
+            all_files.append(os.path.join(dp, fn))
+    count = max(1, int(len(all_files) * fraction))
+    for path in all_files[:count]:
+        with open(path, "r+b") as f:
+            data = f.read()
+            mid = len(data) // 2
+            patch = os.urandom(min(64, len(data)))
+            f.seek(mid)
+            f.write(patch)
+
+
+def setup_ssh():
+    """Start SSH server and configure loopback."""
+    subprocess.run(["ssh-keygen", "-A"], capture_output=True)
+    os.makedirs("/run/sshd", exist_ok=True)
+    subprocess.Popen(
+        ["/usr/sbin/sshd"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    time.sleep(1)
+
+    home = os.path.expanduser("~")
+    ssh_dir = f"{home}/.ssh"
+    os.makedirs(ssh_dir, mode=0o700, exist_ok=True)
+
+    key_path = f"{ssh_dir}/id_ed25519"
+    if not os.path.exists(key_path):
+        subprocess.run(
+            ["ssh-keygen", "-t", "ed25519", "-N", "", "-f", key_path],
+            capture_output=True,
+        )
+
+    pub_key = open(f"{key_path}.pub").read().strip()
+    auth_keys = f"{ssh_dir}/authorized_keys"
+    existing = open(auth_keys).read() if os.path.exists(auth_keys) else ""
+    if pub_key not in existing:
+        with open(auth_keys, "a") as f:
+            f.write(pub_key + "\n")
+    os.chmod(auth_keys, 0o600)
+
+    result = subprocess.run(
+        ["ssh", "-o", "StrictHostKeyChecking=no", "localhost", "echo", "ok"],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    if result.returncode != 0:
+        print(f"WARNING: SSH loopback failed: {result.stderr}", file=sys.stderr)
+        return False
+    return True
+
+
+def main():
+    parser = argparse.ArgumentParser(description="oc-rsync benchmark vs upstream")
+    parser.add_argument("--runs", type=int, default=5, help="Runs per test")
+    parser.add_argument("--json", action="store_true", help="Output JSON only")
+    args = parser.parse_args()
+
+    runs = args.runs
+    tmpdir = tempfile.mkdtemp(prefix="rsync_bench_")
+    daemon_proc = None
+    results = {"tests": [], "summary": {}}
+
+    try:
+        versions = {}
+        available = {}
+        for name, binary in BINARIES.items():
+            ver = version_string(binary)
+            versions[name] = ver
+            available[name] = os.path.isfile(binary)
+
+        results["versions"] = versions
+
+        if not args.json:
+            print("=" * 80)
+            print("  oc-rsync Benchmark — upstream rsync vs oc-rsync")
+            print("=" * 80)
+            for name, ver in versions.items():
+                status = "OK" if available[name] else "MISSING"
+                print(f"  {name:>10} : {ver} [{status}]")
+            print(f"  {'runs':>10} : {runs}")
+            print()
+
+        active_binaries = {k: v for k, v in BINARIES.items() if available[k]}
+        if "upstream" not in active_binaries:
+            print("ERROR: upstream rsync not found", file=sys.stderr)
+            sys.exit(1)
+        if "oc-rsync" not in active_binaries:
+            print("ERROR: oc-rsync not found", file=sys.stderr)
+            sys.exit(1)
+
+        src = f"{tmpdir}/src"
+        if not args.json:
+            print("Creating test data (10,000 files, ~150 MB)...", file=sys.stderr)
+        create_test_data(src)
+        total_bytes, total_files = total_stats(src)
+        total_mb = total_bytes / 1024 / 1024
+        results["test_data"] = {
+            "size_mb": round(total_mb, 1),
+            "files": total_files,
+        }
+        if not args.json:
+            print(f"Test data: {total_mb:.1f} MB, {total_files} files\n")
+
+        if not args.json:
+            print("Setting up SSH loopback...", file=sys.stderr)
+        ssh_ok = setup_ssh()
+
+        port = find_free_port()
+        daemon_dst = f"{tmpdir}/daemon_dest"
+        os.makedirs(daemon_dst, exist_ok=True)
+        conf_path = f"{tmpdir}/rsyncd.conf"
+        with open(conf_path, "w") as f:
+            f.write(
+                f"port = {port}\n"
+                f"use chroot = false\n"
+                f"\n"
+                f"[bench]\n"
+                f"    path = {src}\n"
+                f"    read only = true\n"
+                f"\n"
+                f"[dest]\n"
+                f"    path = {daemon_dst}\n"
+                f"    read only = false\n"
+            )
+
+        if not args.json:
+            print(f"Starting rsync daemon on port {port}...", file=sys.stderr)
+        daemon_proc = subprocess.Popen(
+            [BINARIES["upstream"], "--daemon", "--config", conf_path, "--no-detach"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        daemon_ok = wait_for_port(port)
+        if not daemon_ok:
+            print("WARNING: rsync daemon failed to start", file=sys.stderr)
+
+        dsts = {}
+        for name in active_binaries:
+            dsts[name] = f"{tmpdir}/dst_{name}"
+
+        def reset_dsts():
+            for dst in dsts.values():
+                shutil.rmtree(dst, ignore_errors=True)
+                os.makedirs(dst, exist_ok=True)
+
+        def reset_daemon_dst():
+            shutil.rmtree(daemon_dst, ignore_errors=True)
+            os.makedirs(daemon_dst, exist_ok=True)
+
+        if not args.json:
+            hdr = f"{'Mode':<14} {'Copy':<12} {'Scenario':<12}"
+            for name in active_binaries:
+                hdr += f" {name:>10}"
+            hdr += "  ratio"
+            print(hdr)
+            print("-" * len(hdr))
+
+        modified_for_incremental = False
+
+        for mode_id, mode_cfg in TRANSFER_MODES.items():
+            if mode_id.startswith("ssh_") and not ssh_ok:
+                if not args.json:
+                    print(f"SKIP {mode_id}: SSH not available", file=sys.stderr)
+                continue
+            if mode_id.startswith("daemon_") and not daemon_ok:
+                if not args.json:
+                    print(f"SKIP {mode_id}: daemon not available", file=sys.stderr)
+                continue
+
+            for copy_id, copy_cfg in COPY_MODES.items():
+                for scenario in SCENARIOS:
+                    if not args.json:
+                        print(
+                            f"Running: [{mode_id}] [{copy_id}] [{scenario}]...",
+                            file=sys.stderr,
+                        )
+
+                    if scenario == "initial":
+                        reset_dsts()
+                        if mode_id == "daemon_push":
+                            reset_daemon_dst()
+
+                    if scenario == "incremental" and not modified_for_incremental:
+                        modify_files(src, 0.1)
+                        modified_for_incremental = True
+
+                    timings = {}
+                    skip = False
+                    for name, binary in active_binaries.items():
+                        tpl = mode_cfg["template"]
+                        cmd = tpl.format(
+                            bin=binary,
+                            flags=copy_cfg["flags"],
+                            src=src,
+                            dst=dsts[name],
+                            port=port,
+                        )
+
+                        if mode_id == "daemon_push" and scenario == "initial":
+                            reset_daemon_dst()
+
+                        result = benchmark(cmd, runs=runs)
+                        if result is None:
+                            if not args.json:
+                                print(
+                                    f"  SKIP {mode_id}/{copy_id}/{scenario}: {name} failed",
+                                    file=sys.stderr,
+                                )
+                            skip = True
+                            break
+                        timings[name] = result
+
+                    if skip:
+                        continue
+
+                    up_mean = timings["upstream"]["mean"]
+                    oc_mean = timings["oc-rsync"]["mean"]
+                    ratio = round(oc_mean / up_mean, 3) if up_mean > 0 else 0
+
+                    entry = {
+                        "mode": mode_id,
+                        "copy_mode": copy_id,
+                        "scenario": scenario,
+                        "timings": timings,
+                        "ratio": ratio,
+                    }
+                    results["tests"].append(entry)
+
+                    if not args.json:
+                        row = f"{mode_id:<14} {copy_id:<12} {scenario:<12}"
+                        for name in active_binaries:
+                            row += f" {timings[name]['mean']:>9.3f}s"
+                        tag = "faster" if ratio < 0.85 else ("~same" if ratio <= 1.15 else "slower")
+                        row += f"  {ratio:.2f}x ({tag})"
+                        print(row)
+
+        # Summary
+        all_ratios = [t["ratio"] for t in results["tests"]]
+        by_mode = {}
+        by_copy = {}
+        by_scenario = {}
+        for t in results["tests"]:
+            by_mode.setdefault(t["mode"], []).append(t["ratio"])
+            by_copy.setdefault(t["copy_mode"], []).append(t["ratio"])
+            by_scenario.setdefault(t["scenario"], []).append(t["ratio"])
+
+        def avg(lst):
+            return round(sum(lst) / len(lst), 3) if lst else 0
+
+        if not all_ratios:
+            summary = {"overall": {"avg": 0, "best": 0, "worst": 0}}
+            results["summary"] = summary
+            if not args.json:
+                print("\nNo successful benchmarks to summarize.")
+            if args.json:
+                print(json.dumps(results, indent=2))
+            return
+
+        summary = {
+            "overall": {"avg": avg(all_ratios), "best": round(min(all_ratios), 3), "worst": round(max(all_ratios), 3)},
+            "by_mode": {m: avg(v) for m, v in by_mode.items()},
+            "by_copy_mode": {m: avg(v) for m, v in by_copy.items()},
+            "by_scenario": {m: avg(v) for m, v in by_scenario.items()},
+        }
+        results["summary"] = summary
+
+        if not args.json:
+            print()
+            print("=" * 80)
+            print("  Summary (ratio < 1.0 = oc-rsync faster than upstream)")
+            print("=" * 80)
+            o = summary["overall"]
+            print(f"\n  Overall: avg {o['avg']:.2f}x  (best {o['best']:.2f}x, worst {o['worst']:.2f}x)")
+            print(f"  By mode:     {', '.join(f'{m}={v:.2f}x' for m, v in summary['by_mode'].items())}")
+            print(f"  By copy:     {', '.join(f'{m}={v:.2f}x' for m, v in summary['by_copy_mode'].items())}")
+            print(f"  By scenario: {', '.join(f'{m}={v:.2f}x' for m, v in summary['by_scenario'].items())}")
+
+        if args.json:
+            print(json.dumps(results, indent=2))
+
+    finally:
+        if daemon_proc is not None:
+            daemon_proc.terminate()
+            daemon_proc.wait(timeout=5)
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_full_benchmark_container.sh
+++ b/scripts/run_full_benchmark_container.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Run benchmark inside a podman/docker container.
+#
+# Usage: ./scripts/run_full_benchmark_container.sh [--runs N] [--json]
+#
+# Builds upstream rsync 3.4.1 + oc-rsync (current HEAD) inside
+# an Arch Linux container, then runs the full benchmark matrix.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+RUNS=5
+JSON_FLAG=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --runs)  RUNS="$2"; shift 2 ;;
+        --json)  JSON_FLAG="--json"; shift ;;
+        *)       echo "Usage: $0 [--runs N] [--json]" >&2; exit 1 ;;
+    esac
+done
+
+CONTAINER_ENGINE="${CONTAINER_ENGINE:-podman}"
+IMAGE_NAME="oc-rsync-bench-full"
+
+echo "=== oc-rsync Benchmark: upstream rsync vs oc-rsync ==="
+echo "Container engine: $CONTAINER_ENGINE"
+echo "Runs per test: $RUNS"
+echo ""
+
+echo "Building container image (this may take a while)..."
+"$CONTAINER_ENGINE" build \
+    -t "$IMAGE_NAME" \
+    -f "$REPO_ROOT/scripts/Containerfile.benchmark-full" \
+    "$REPO_ROOT"
+
+echo ""
+echo "Running benchmarks inside container..."
+echo ""
+
+"$CONTAINER_ENGINE" run --rm \
+    -e BENCH_RUNS="$RUNS" \
+    "$IMAGE_NAME" \
+    "/usr/sbin/sshd && python3 /usr/local/bin/run_full_benchmark.py --runs ${RUNS} ${JSON_FLAG}"


### PR DESCRIPTION
## Summary
- Add hot path profiling script (flamegraphs, strace, perf stat)
- Add full benchmark matrix: 3 binaries x 5 transfer modes x 4 copy modes x 3 scenarios
- Add container wrappers for Arch Linux podman image
- Add simplified release-vs-upstream benchmark variant

## Test plan
- [x] Scripts are executable and syntax-valid
- [x] Container wrappers reference correct image and paths