### PR TITLE
fix: remove duplicate fields and fix type mismatches

### DIFF
--- a/crates/core/src/client/config/builder/mod.rs
+++ b/crates/core/src/client/config/builder/mod.rs
@@ -214,7 +214,6 @@ pub struct ClientConfigBuilder {
     prefer_aes_gcm: Option<bool>,
     batch_config: Option<engine::batch::BatchConfig>,
     no_motd: bool,
-    prefer_aes_gcm: Option<bool>,
     #[cfg(all(unix, feature = "acl"))]
     preserve_acls: bool,
     #[cfg(all(unix, feature = "xattr"))]
@@ -335,7 +334,6 @@ impl ClientConfigBuilder {
             prefer_aes_gcm: self.prefer_aes_gcm,
             batch_config: self.batch_config,
             no_motd: self.no_motd,
-            prefer_aes_gcm: self.prefer_aes_gcm,
             #[cfg(all(unix, feature = "acl"))]
             preserve_acls: self.preserve_acls,
             #[cfg(all(unix, feature = "xattr"))]

--- a/crates/core/src/client/config/client/mod.rs
+++ b/crates/core/src/client/config/client/mod.rs
@@ -162,7 +162,6 @@ pub struct ClientConfig {
     pub(super) prefer_aes_gcm: Option<bool>,
     pub(super) batch_config: Option<engine::batch::BatchConfig>,
     pub(super) no_motd: bool,
-    pub(super) prefer_aes_gcm: Option<bool>,
     #[cfg(all(unix, feature = "acl"))]
     pub(super) preserve_acls: bool,
     #[cfg(all(unix, feature = "xattr"))]
@@ -281,7 +280,6 @@ impl Default for ClientConfig {
             prefer_aes_gcm: None,
             batch_config: None,
             no_motd: false,
-            prefer_aes_gcm: None,
             #[cfg(all(unix, feature = "acl"))]
             preserve_acls: false,
             #[cfg(all(unix, feature = "xattr"))]

--- a/crates/transfer/src/generator.rs
+++ b/crates/transfer/src/generator.rs
@@ -1489,7 +1489,7 @@ pub fn generate_delta_from_signature<R: Read>(
             SignatureBlock::from_raw_parts(
                 wire_block.index as u64,
                 RollingDigest::from_value(wire_block.rolling_sum, config.block_length as usize),
-                wire_block.strong_sum,
+                &wire_block.strong_sum,
             )
         })
         .collect();

--- a/crates/transfer/src/token_reader.rs
+++ b/crates/transfer/src/token_reader.rs
@@ -172,6 +172,21 @@ impl TokenReader {
     }
 }
 
+impl std::fmt::Debug for DeltaToken {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Literal(LiteralData::Pending(len)) => {
+                write!(f, "Literal(Pending({len}))")
+            }
+            Self::Literal(LiteralData::Ready(data)) => {
+                write!(f, "Literal(Ready({} bytes))", data.len())
+            }
+            Self::BlockRef(idx) => write!(f, "BlockRef({idx})"),
+            Self::End => write!(f, "End"),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -360,21 +375,5 @@ mod tests {
         let mut cursor = Cursor::new(Vec::<u8>::new());
         let result = reader.read_token(&mut cursor);
         assert!(result.is_err());
-    }
-}
-
-// Provide Debug for DeltaToken for test assertion messages
-impl std::fmt::Debug for DeltaToken {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Literal(LiteralData::Pending(len)) => {
-                write!(f, "Literal(Pending({len}))")
-            }
-            Self::Literal(LiteralData::Ready(data)) => {
-                write!(f, "Literal(Ready({} bytes))", data.len())
-            }
-            Self::BlockRef(idx) => write!(f, "BlockRef({idx})"),
-            Self::End => write!(f, "End"),
-        }
     }
 }


### PR DESCRIPTION
## Summary
- Fix `Vec<u8>` vs `&[u8]` type mismatch in generator signature block conversion
- Remove duplicate `prefer_aes_gcm` fields in `ClientConfigBuilder` and `ClientConfig`
- Move `Debug` impl for `DeltaToken` before test module to satisfy clippy

## Test plan
- [x] cargo check --workspace --all-features passes
- [x] cargo clippy --workspace --all-targets --all-features --no-deps -D warnings passes