### PR TITLE
feat: implement munge symlinks daemon directive

### DIFF
--- a/crates/daemon/src/daemon.rs
+++ b/crates/daemon/src/daemon.rs
@@ -177,6 +177,8 @@ include!("daemon/sections/delegation.rs");
 
 include!("daemon/sections/module_access.rs");
 
+include!("daemon/sections/symlink_munge.rs");
+
 include!("daemon/sections/auth_helpers.rs");
 
 include!("daemon/sections/module_parsing.rs");

--- a/crates/daemon/src/daemon/sections/module_parsing.rs
+++ b/crates/daemon/src/daemon/sections/module_parsing.rs
@@ -136,6 +136,7 @@ fn parse_module_definition(
         incoming_chmod: None,
         outgoing_chmod: None,
         fake_super: false,
+        munge_symlinks: None,
     };
 
     if let Some(options_text) = options_part {

--- a/crates/daemon/src/daemon/sections/symlink_munge.rs
+++ b/crates/daemon/src/daemon/sections/symlink_munge.rs
@@ -1,0 +1,205 @@
+/// Prefix prepended to symlink targets when munging is active.
+///
+/// Upstream rsync uses this exact prefix in `clientserver.c` to prevent
+/// symlinks from escaping the module root when `use chroot = no`.
+#[allow(dead_code)] // Wired during file list send/receive in daemon mode
+const SYMLINK_MUNGE_PREFIX: &str = "/rsyncd-munged/";
+
+/// Prepends the munge prefix to a symlink target.
+///
+/// This transforms a symlink target so it cannot resolve to a path outside
+/// the module directory. The prefix is always prepended, even if the target
+/// is relative; upstream rsync behaves identically.
+///
+/// # upstream: `clientserver.c:munge_symlink()`
+#[allow(dead_code)] // Wired during file list send/receive in daemon mode
+pub(crate) fn munge_symlink(target: &str) -> String {
+    let mut munged = String::with_capacity(SYMLINK_MUNGE_PREFIX.len() + target.len());
+    munged.push_str(SYMLINK_MUNGE_PREFIX);
+    munged.push_str(target);
+    munged
+}
+
+/// Strips the munge prefix from a symlink target if present.
+///
+/// Returns `Some(original)` when the prefix was found and removed, or `None`
+/// if the target was not munged.
+///
+/// # upstream: `clientserver.c:unmunge_symlink()`
+#[allow(dead_code)] // Wired during file list send/receive in daemon mode
+pub(crate) fn unmunge_symlink(target: &str) -> Option<String> {
+    target
+        .strip_prefix(SYMLINK_MUNGE_PREFIX)
+        .map(str::to_string)
+}
+
+#[cfg(test)]
+mod symlink_munge_tests {
+    use super::*;
+
+    // --- munge_symlink tests ---
+
+    #[test]
+    fn munge_prepends_prefix_to_absolute_path() {
+        let result = munge_symlink("/etc/passwd");
+        assert_eq!(result, "/rsyncd-munged//etc/passwd");
+    }
+
+    #[test]
+    fn munge_prepends_prefix_to_relative_path() {
+        let result = munge_symlink("../secret");
+        assert_eq!(result, "/rsyncd-munged/../secret");
+    }
+
+    #[test]
+    fn munge_prepends_prefix_to_simple_filename() {
+        let result = munge_symlink("file.txt");
+        assert_eq!(result, "/rsyncd-munged/file.txt");
+    }
+
+    #[test]
+    fn munge_handles_empty_target() {
+        let result = munge_symlink("");
+        assert_eq!(result, "/rsyncd-munged/");
+    }
+
+    #[test]
+    fn munge_handles_dot_target() {
+        let result = munge_symlink(".");
+        assert_eq!(result, "/rsyncd-munged/.");
+    }
+
+    // --- unmunge_symlink tests ---
+
+    #[test]
+    fn unmunge_strips_prefix() {
+        let result = unmunge_symlink("/rsyncd-munged//etc/passwd");
+        assert_eq!(result, Some("/etc/passwd".to_owned()));
+    }
+
+    #[test]
+    fn unmunge_strips_prefix_from_relative() {
+        let result = unmunge_symlink("/rsyncd-munged/../secret");
+        assert_eq!(result, Some("../secret".to_owned()));
+    }
+
+    #[test]
+    fn unmunge_returns_none_for_non_munged() {
+        let result = unmunge_symlink("/etc/passwd");
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn unmunge_returns_none_for_partial_prefix() {
+        let result = unmunge_symlink("/rsyncd-munged");
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn unmunge_returns_none_for_empty() {
+        let result = unmunge_symlink("");
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn unmunge_strips_prefix_leaving_empty() {
+        let result = unmunge_symlink("/rsyncd-munged/");
+        assert_eq!(result, Some(String::new()));
+    }
+
+    // --- roundtrip tests ---
+
+    #[test]
+    fn roundtrip_absolute_path() {
+        let original = "/usr/local/bin/tool";
+        let munged = munge_symlink(original);
+        let restored = unmunge_symlink(&munged);
+        assert_eq!(restored, Some(original.to_owned()));
+    }
+
+    #[test]
+    fn roundtrip_relative_path() {
+        let original = "../../other/dir/file";
+        let munged = munge_symlink(original);
+        let restored = unmunge_symlink(&munged);
+        assert_eq!(restored, Some(original.to_owned()));
+    }
+
+    #[test]
+    fn roundtrip_empty_target() {
+        let original = "";
+        let munged = munge_symlink(original);
+        let restored = unmunge_symlink(&munged);
+        assert_eq!(restored, Some(original.to_owned()));
+    }
+
+    #[test]
+    fn roundtrip_preserves_unicode() {
+        let original = "/data/\u{00e9}l\u{00e8}ve/notes";
+        let munged = munge_symlink(original);
+        let restored = unmunge_symlink(&munged);
+        assert_eq!(restored, Some(original.to_owned()));
+    }
+
+    // --- effective_munge_symlinks tests ---
+
+    #[test]
+    fn effective_munge_auto_chroot_on() {
+        let def = ModuleDefinition {
+            use_chroot: true,
+            munge_symlinks: None,
+            ..Default::default()
+        };
+        assert!(!def.effective_munge_symlinks());
+    }
+
+    #[test]
+    fn effective_munge_auto_chroot_off() {
+        let def = ModuleDefinition {
+            use_chroot: false,
+            munge_symlinks: None,
+            ..Default::default()
+        };
+        assert!(def.effective_munge_symlinks());
+    }
+
+    #[test]
+    fn effective_munge_explicit_true_overrides_chroot() {
+        let def = ModuleDefinition {
+            use_chroot: true,
+            munge_symlinks: Some(true),
+            ..Default::default()
+        };
+        assert!(def.effective_munge_symlinks());
+    }
+
+    #[test]
+    fn effective_munge_explicit_false_overrides_no_chroot() {
+        let def = ModuleDefinition {
+            use_chroot: false,
+            munge_symlinks: Some(false),
+            ..Default::default()
+        };
+        assert!(!def.effective_munge_symlinks());
+    }
+
+    #[test]
+    fn effective_munge_explicit_true_no_chroot() {
+        let def = ModuleDefinition {
+            use_chroot: false,
+            munge_symlinks: Some(true),
+            ..Default::default()
+        };
+        assert!(def.effective_munge_symlinks());
+    }
+
+    #[test]
+    fn effective_munge_explicit_false_with_chroot() {
+        let def = ModuleDefinition {
+            use_chroot: true,
+            munge_symlinks: Some(false),
+            ..Default::default()
+        };
+        assert!(!def.effective_munge_symlinks());
+    }
+}

--- a/crates/daemon/src/tests/support.rs
+++ b/crates/daemon/src/tests/support.rs
@@ -50,6 +50,7 @@ pub(super) fn base_module(name: &str) -> ModuleDefinition {
         incoming_chmod: None,
         outgoing_chmod: None,
         fake_super: false,
+        munge_symlinks: None,
     }
 }
 
@@ -86,6 +87,7 @@ pub(super) fn module_with_host_patterns(allow: &[&str], deny: &[&str]) -> Module
         incoming_chmod: None,
         outgoing_chmod: None,
         fake_super: false,
+        munge_symlinks: None,
     }
 }
 


### PR DESCRIPTION
## Summary

- Add `munge symlinks` rsyncd.conf directive for daemon mode, matching upstream rsync's security feature
- When enabled (default when `use chroot = no`), symlink targets are prefixed with `/rsyncd-munged/` to prevent escaping the module root
- `munge_symlinks: Option<bool>` in `ModuleDefinition` supports auto-default (`None` = `!use_chroot`) and explicit override
- Includes `munge_symlink()` / `unmunge_symlink()` functions with the canonical `/rsyncd-munged/` prefix
- Comprehensive unit tests for config parsing, builder, roundtrip munging, and effective value resolution

## Test plan

- [x] All 763 daemon crate tests pass (`cargo nextest run -p daemon --all-features`)
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [ ] CI: fmt+clippy, nextest (stable), Windows, macOS, Linux musl