### PR TITLE
feat: add missing daemon config directives and fix unknown directive handling

### DIFF
--- a/crates/daemon/src/daemon/module_state.rs
+++ b/crates/daemon/src/daemon/module_state.rs
@@ -92,6 +92,50 @@ pub(crate) struct ModuleDefinition {
     /// Upstream: `clientserver.c` — `munge_symlinks` global; defaults to true when
     /// `use_chroot` is false or when an inside-chroot module is configured.
     pub(crate) munge_symlinks: Option<bool>,
+    /// Caps the client's requested verbosity level.
+    ///
+    /// Upstream: `loadparm.c` — `max verbosity` parameter, default 1.
+    pub(crate) max_verbosity: i32,
+    /// When true, I/O errors during delete operations are ignored.
+    ///
+    /// Upstream: `loadparm.c` — `ignore errors` parameter, default false.
+    pub(crate) ignore_errors: bool,
+    /// When true, files the daemon cannot read are silently skipped.
+    ///
+    /// Upstream: `loadparm.c` — `ignore nonreadable` parameter, default false.
+    pub(crate) ignore_nonreadable: bool,
+    /// When true, per-file transfer logging is enabled.
+    ///
+    /// Upstream: `loadparm.c` — `transfer logging` parameter, default false.
+    pub(crate) transfer_logging: bool,
+    /// Format string for per-file transfer log entries.
+    ///
+    /// Upstream: `loadparm.c` — `log format` parameter, default `"%o %h [%a] %m (%u) %f %l"`.
+    pub(crate) log_format: Option<String>,
+    /// Glob patterns of files that should not be compressed during transfer.
+    ///
+    /// Upstream: `loadparm.c` — `dont compress` parameter.
+    pub(crate) dont_compress: Option<String>,
+    /// Command to execute before a transfer begins.
+    ///
+    /// Upstream: `loadparm.c` — `pre-xfer exec` parameter.
+    pub(crate) pre_xfer_exec: Option<String>,
+    /// Command to execute after a transfer completes.
+    ///
+    /// Upstream: `loadparm.c` — `post-xfer exec` parameter.
+    pub(crate) post_xfer_exec: Option<String>,
+    /// Temporary directory for receiving files before final placement.
+    ///
+    /// Upstream: `loadparm.c` — `temp dir` parameter.
+    pub(crate) temp_dir: Option<String>,
+    /// Character set for filename conversion.
+    ///
+    /// Upstream: `loadparm.c` — `charset` parameter.
+    pub(crate) charset: Option<String>,
+    /// When true, DNS forward lookup verification is performed on connecting hosts.
+    ///
+    /// Upstream: `loadparm.c` — `forward lookup` parameter, default true.
+    pub(crate) forward_lookup: bool,
 }
 
 impl ModuleDefinition {
@@ -252,6 +296,50 @@ impl ModuleDefinition {
 
     pub(super) fn munge_symlinks(&self) -> Option<bool> {
         self.munge_symlinks
+    }
+
+    pub(super) fn max_verbosity(&self) -> i32 {
+        self.max_verbosity
+    }
+
+    pub(super) fn ignore_errors(&self) -> bool {
+        self.ignore_errors
+    }
+
+    pub(super) fn ignore_nonreadable(&self) -> bool {
+        self.ignore_nonreadable
+    }
+
+    pub(super) fn transfer_logging(&self) -> bool {
+        self.transfer_logging
+    }
+
+    pub(super) fn log_format(&self) -> Option<&str> {
+        self.log_format.as_deref()
+    }
+
+    pub(super) fn dont_compress(&self) -> Option<&str> {
+        self.dont_compress.as_deref()
+    }
+
+    pub(super) fn pre_xfer_exec(&self) -> Option<&str> {
+        self.pre_xfer_exec.as_deref()
+    }
+
+    pub(super) fn post_xfer_exec(&self) -> Option<&str> {
+        self.post_xfer_exec.as_deref()
+    }
+
+    pub(super) fn temp_dir(&self) -> Option<&str> {
+        self.temp_dir.as_deref()
+    }
+
+    pub(super) fn charset(&self) -> Option<&str> {
+        self.charset.as_deref()
+    }
+
+    pub(super) fn forward_lookup(&self) -> bool {
+        self.forward_lookup
     }
 }
 

--- a/crates/daemon/src/daemon/sections/config_parsing.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing.rs
@@ -333,8 +333,119 @@ fn parse_config_modules_inner(
                             line_number,
                         )?;
                     }
+                    "max verbosity" => {
+                        let parsed: i32 = value.parse().map_err(|_| {
+                            config_parse_error(
+                                path,
+                                line_number,
+                                format!("invalid integer value '{value}' for 'max verbosity'"),
+                            )
+                        })?;
+                        builder.set_max_verbosity(parsed, path, line_number)?;
+                    }
+                    "ignore errors" => {
+                        let parsed = parse_boolean_directive(value).ok_or_else(|| {
+                            config_parse_error(
+                                path,
+                                line_number,
+                                format!(
+                                    "invalid boolean value '{value}' for 'ignore errors'"
+                                ),
+                            )
+                        })?;
+                        builder.set_ignore_errors(parsed, path, line_number)?;
+                    }
+                    "ignore nonreadable" => {
+                        let parsed = parse_boolean_directive(value).ok_or_else(|| {
+                            config_parse_error(
+                                path,
+                                line_number,
+                                format!(
+                                    "invalid boolean value '{value}' for 'ignore nonreadable'"
+                                ),
+                            )
+                        })?;
+                        builder.set_ignore_nonreadable(parsed, path, line_number)?;
+                    }
+                    "transfer logging" => {
+                        let parsed = parse_boolean_directive(value).ok_or_else(|| {
+                            config_parse_error(
+                                path,
+                                line_number,
+                                format!(
+                                    "invalid boolean value '{value}' for 'transfer logging'"
+                                ),
+                            )
+                        })?;
+                        builder.set_transfer_logging(parsed, path, line_number)?;
+                    }
+                    "log format" => {
+                        let format = if value.is_empty() {
+                            None
+                        } else {
+                            Some(value.to_owned())
+                        };
+                        builder.set_log_format(format, path, line_number)?;
+                    }
+                    "dont compress" => {
+                        let patterns = if value.is_empty() {
+                            None
+                        } else {
+                            Some(value.to_owned())
+                        };
+                        builder.set_dont_compress(patterns, path, line_number)?;
+                    }
+                    "pre-xfer exec" => {
+                        let cmd = if value.is_empty() {
+                            None
+                        } else {
+                            Some(value.to_owned())
+                        };
+                        builder.set_pre_xfer_exec(cmd, path, line_number)?;
+                    }
+                    "post-xfer exec" => {
+                        let cmd = if value.is_empty() {
+                            None
+                        } else {
+                            Some(value.to_owned())
+                        };
+                        builder.set_post_xfer_exec(cmd, path, line_number)?;
+                    }
+                    "temp dir" => {
+                        let dir = if value.is_empty() {
+                            None
+                        } else {
+                            Some(value.to_owned())
+                        };
+                        builder.set_temp_dir(dir, path, line_number)?;
+                    }
+                    "charset" => {
+                        let cs = if value.is_empty() {
+                            None
+                        } else {
+                            Some(value.to_owned())
+                        };
+                        builder.set_charset(cs, path, line_number)?;
+                    }
+                    "forward lookup" => {
+                        let parsed = parse_boolean_directive(value).ok_or_else(|| {
+                            config_parse_error(
+                                path,
+                                line_number,
+                                format!(
+                                    "invalid boolean value '{value}' for 'forward lookup'"
+                                ),
+                            )
+                        })?;
+                        builder.set_forward_lookup(parsed, path, line_number)?;
+                    }
                     _ => {
-                        // Unsupported directives are ignored for now.
+                        eprintln!(
+                            "warning: unknown per-module directive '{}' in '{}' line {}",
+                            key,
+                            path.display(),
+                            line_number
+                        );
                     }
                 }
                 continue;
@@ -713,11 +824,12 @@ fn parse_config_modules_inner(
                     }
                 }
                 _ => {
-                    return Err(config_parse_error(
-                        path,
-                        line_number,
-                        "directive outside module section",
-                    ));
+                    eprintln!(
+                        "warning: unknown global directive '{}' in '{}' line {}",
+                        key,
+                        path.display(),
+                        line_number
+                    );
                 }
             }
         }
@@ -916,10 +1028,10 @@ mod config_parsing_tests {
     }
 
     #[test]
-    fn parse_directive_outside_module() {
+    fn parse_unknown_global_directive_warns_and_continues() {
         let file = write_config("unknown = value\n");
-        let err = parse_config_modules(file.path()).expect_err("should fail");
-        assert!(err.to_string().contains("outside module"));
+        let result = parse_config_modules(file.path()).expect("parse succeeds with warning");
+        assert!(result.modules.is_empty());
     }
 
     // --- Global directive tests ---
@@ -1274,6 +1386,261 @@ mod config_parsing_tests {
         );
         let err = parse_config_modules(file.path()).expect_err("should fail");
         assert!(err.to_string().contains("duplicate"));
+    }
+
+    // --- New directive parsing tests ---
+
+    #[test]
+    fn parse_module_max_verbosity() {
+        let dir = TempDir::new().expect("create temp dir");
+        let path = dir.path().join("data");
+        fs::create_dir(&path).expect("create dir");
+
+        let config = format!("[mod]\npath = {}\nmax verbosity = 3\n", path.display());
+        let file = write_config(&config);
+        let result = parse_config_modules(file.path()).expect("parse succeeds");
+        assert_eq!(result.modules[0].max_verbosity, 3);
+    }
+
+    #[test]
+    fn parse_module_max_verbosity_default() {
+        let dir = TempDir::new().expect("create temp dir");
+        let path = dir.path().join("data");
+        fs::create_dir(&path).expect("create dir");
+
+        let config = format!("[mod]\npath = {}\n", path.display());
+        let file = write_config(&config);
+        let result = parse_config_modules(file.path()).expect("parse succeeds");
+        assert_eq!(result.modules[0].max_verbosity, 1);
+    }
+
+    #[test]
+    fn parse_module_max_verbosity_invalid() {
+        let file = write_config("[mod]\npath = /tmp\nmax verbosity = abc\n");
+        let err = parse_config_modules(file.path()).expect_err("should fail");
+        assert!(err.to_string().contains("invalid integer"));
+    }
+
+    #[test]
+    fn parse_module_ignore_errors() {
+        let dir = TempDir::new().expect("create temp dir");
+        let path = dir.path().join("data");
+        fs::create_dir(&path).expect("create dir");
+
+        let config = format!("[mod]\npath = {}\nignore errors = yes\n", path.display());
+        let file = write_config(&config);
+        let result = parse_config_modules(file.path()).expect("parse succeeds");
+        assert!(result.modules[0].ignore_errors);
+    }
+
+    #[test]
+    fn parse_module_ignore_nonreadable() {
+        let dir = TempDir::new().expect("create temp dir");
+        let path = dir.path().join("data");
+        fs::create_dir(&path).expect("create dir");
+
+        let config = format!(
+            "[mod]\npath = {}\nignore nonreadable = true\n",
+            path.display()
+        );
+        let file = write_config(&config);
+        let result = parse_config_modules(file.path()).expect("parse succeeds");
+        assert!(result.modules[0].ignore_nonreadable);
+    }
+
+    #[test]
+    fn parse_module_transfer_logging() {
+        let dir = TempDir::new().expect("create temp dir");
+        let path = dir.path().join("data");
+        fs::create_dir(&path).expect("create dir");
+
+        let config = format!(
+            "[mod]\npath = {}\ntransfer logging = yes\n",
+            path.display()
+        );
+        let file = write_config(&config);
+        let result = parse_config_modules(file.path()).expect("parse succeeds");
+        assert!(result.modules[0].transfer_logging);
+    }
+
+    #[test]
+    fn parse_module_log_format() {
+        let dir = TempDir::new().expect("create temp dir");
+        let path = dir.path().join("data");
+        fs::create_dir(&path).expect("create dir");
+
+        let config = format!(
+            "[mod]\npath = {}\nlog format = %o %h %f %l\n",
+            path.display()
+        );
+        let file = write_config(&config);
+        let result = parse_config_modules(file.path()).expect("parse succeeds");
+        assert_eq!(
+            result.modules[0].log_format.as_deref(),
+            Some("%o %h %f %l")
+        );
+    }
+
+    #[test]
+    fn parse_module_dont_compress() {
+        let dir = TempDir::new().expect("create temp dir");
+        let path = dir.path().join("data");
+        fs::create_dir(&path).expect("create dir");
+
+        let config = format!(
+            "[mod]\npath = {}\ndont compress = *.gz *.zip\n",
+            path.display()
+        );
+        let file = write_config(&config);
+        let result = parse_config_modules(file.path()).expect("parse succeeds");
+        assert_eq!(
+            result.modules[0].dont_compress.as_deref(),
+            Some("*.gz *.zip")
+        );
+    }
+
+    #[test]
+    fn parse_module_pre_xfer_exec() {
+        let dir = TempDir::new().expect("create temp dir");
+        let path = dir.path().join("data");
+        fs::create_dir(&path).expect("create dir");
+
+        let config = format!(
+            "[mod]\npath = {}\npre-xfer exec = /usr/bin/check\n",
+            path.display()
+        );
+        let file = write_config(&config);
+        let result = parse_config_modules(file.path()).expect("parse succeeds");
+        assert_eq!(
+            result.modules[0].pre_xfer_exec.as_deref(),
+            Some("/usr/bin/check")
+        );
+    }
+
+    #[test]
+    fn parse_module_post_xfer_exec() {
+        let dir = TempDir::new().expect("create temp dir");
+        let path = dir.path().join("data");
+        fs::create_dir(&path).expect("create dir");
+
+        let config = format!(
+            "[mod]\npath = {}\npost-xfer exec = /usr/bin/cleanup\n",
+            path.display()
+        );
+        let file = write_config(&config);
+        let result = parse_config_modules(file.path()).expect("parse succeeds");
+        assert_eq!(
+            result.modules[0].post_xfer_exec.as_deref(),
+            Some("/usr/bin/cleanup")
+        );
+    }
+
+    #[test]
+    fn parse_module_temp_dir() {
+        let dir = TempDir::new().expect("create temp dir");
+        let path = dir.path().join("data");
+        fs::create_dir(&path).expect("create dir");
+
+        let config = format!("[mod]\npath = {}\ntemp dir = /tmp/rsync\n", path.display());
+        let file = write_config(&config);
+        let result = parse_config_modules(file.path()).expect("parse succeeds");
+        assert_eq!(
+            result.modules[0].temp_dir.as_deref(),
+            Some("/tmp/rsync")
+        );
+    }
+
+    #[test]
+    fn parse_module_charset() {
+        let dir = TempDir::new().expect("create temp dir");
+        let path = dir.path().join("data");
+        fs::create_dir(&path).expect("create dir");
+
+        let config = format!("[mod]\npath = {}\ncharset = utf-8\n", path.display());
+        let file = write_config(&config);
+        let result = parse_config_modules(file.path()).expect("parse succeeds");
+        assert_eq!(result.modules[0].charset.as_deref(), Some("utf-8"));
+    }
+
+    #[test]
+    fn parse_module_forward_lookup() {
+        let dir = TempDir::new().expect("create temp dir");
+        let path = dir.path().join("data");
+        fs::create_dir(&path).expect("create dir");
+
+        let config = format!(
+            "[mod]\npath = {}\nforward lookup = no\n",
+            path.display()
+        );
+        let file = write_config(&config);
+        let result = parse_config_modules(file.path()).expect("parse succeeds");
+        assert!(!result.modules[0].forward_lookup);
+    }
+
+    #[test]
+    fn parse_module_forward_lookup_default_true() {
+        let dir = TempDir::new().expect("create temp dir");
+        let path = dir.path().join("data");
+        fs::create_dir(&path).expect("create dir");
+
+        let config = format!("[mod]\npath = {}\n", path.display());
+        let file = write_config(&config);
+        let result = parse_config_modules(file.path()).expect("parse succeeds");
+        assert!(result.modules[0].forward_lookup);
+    }
+
+    #[test]
+    fn parse_unknown_per_module_directive_continues() {
+        let dir = TempDir::new().expect("create temp dir");
+        let path = dir.path().join("data");
+        fs::create_dir(&path).expect("create dir");
+
+        let config = format!(
+            "[mod]\npath = {}\nunknown directive = value\n",
+            path.display()
+        );
+        let file = write_config(&config);
+        let result = parse_config_modules(file.path()).expect("parse succeeds with warning");
+        assert_eq!(result.modules.len(), 1);
+        assert_eq!(result.modules[0].name, "mod");
+    }
+
+    #[test]
+    fn parse_module_all_new_directives() {
+        let dir = TempDir::new().expect("create temp dir");
+        let path = dir.path().join("data");
+        fs::create_dir(&path).expect("create dir");
+
+        let config = format!(
+            "[mod]\n\
+             path = {}\n\
+             max verbosity = 5\n\
+             ignore errors = yes\n\
+             ignore nonreadable = true\n\
+             transfer logging = yes\n\
+             log format = %o %f\n\
+             dont compress = *.gz *.bz2\n\
+             pre-xfer exec = /bin/pre\n\
+             post-xfer exec = /bin/post\n\
+             temp dir = /tmp/staging\n\
+             charset = utf-8\n\
+             forward lookup = no\n",
+            path.display()
+        );
+        let file = write_config(&config);
+        let result = parse_config_modules(file.path()).expect("parse succeeds");
+        let module = &result.modules[0];
+        assert_eq!(module.max_verbosity, 5);
+        assert!(module.ignore_errors);
+        assert!(module.ignore_nonreadable);
+        assert!(module.transfer_logging);
+        assert_eq!(module.log_format.as_deref(), Some("%o %f"));
+        assert_eq!(module.dont_compress.as_deref(), Some("*.gz *.bz2"));
+        assert_eq!(module.pre_xfer_exec.as_deref(), Some("/bin/pre"));
+        assert_eq!(module.post_xfer_exec.as_deref(), Some("/bin/post"));
+        assert_eq!(module.temp_dir.as_deref(), Some("/tmp/staging"));
+        assert_eq!(module.charset.as_deref(), Some("utf-8"));
+        assert!(!module.forward_lookup);
     }
 
     // --- Config file not found ---

--- a/crates/daemon/src/daemon/sections/module_definition.rs
+++ b/crates/daemon/src/daemon/sections/module_definition.rs
@@ -26,6 +26,17 @@ struct ModuleDefinitionBuilder {
     outgoing_chmod: Option<Option<String>>,
     fake_super: Option<bool>,
     munge_symlinks: Option<Option<bool>>,
+    max_verbosity: Option<i32>,
+    ignore_errors: Option<bool>,
+    ignore_nonreadable: Option<bool>,
+    transfer_logging: Option<bool>,
+    log_format: Option<Option<String>>,
+    dont_compress: Option<Option<String>>,
+    pre_xfer_exec: Option<Option<String>>,
+    post_xfer_exec: Option<Option<String>>,
+    temp_dir: Option<Option<String>>,
+    charset: Option<Option<String>>,
+    forward_lookup: Option<bool>,
 }
 
 impl ModuleDefinitionBuilder {
@@ -58,6 +69,17 @@ impl ModuleDefinitionBuilder {
             outgoing_chmod: None,
             fake_super: None,
             munge_symlinks: None,
+            max_verbosity: None,
+            ignore_errors: None,
+            ignore_nonreadable: None,
+            transfer_logging: None,
+            log_format: None,
+            dont_compress: None,
+            pre_xfer_exec: None,
+            post_xfer_exec: None,
+            temp_dir: None,
+            charset: None,
+            forward_lookup: None,
         }
     }
 
@@ -482,6 +504,237 @@ impl ModuleDefinitionBuilder {
         Ok(())
     }
 
+    fn set_max_verbosity(
+        &mut self,
+        max_verbosity: i32,
+        config_path: &Path,
+        line: usize,
+    ) -> Result<(), DaemonError> {
+        if self.max_verbosity.is_some() {
+            return Err(config_parse_error(
+                config_path,
+                line,
+                format!(
+                    "duplicate 'max verbosity' directive in module '{}'",
+                    self.name
+                ),
+            ));
+        }
+
+        self.max_verbosity = Some(max_verbosity);
+        Ok(())
+    }
+
+    fn set_ignore_errors(
+        &mut self,
+        ignore_errors: bool,
+        config_path: &Path,
+        line: usize,
+    ) -> Result<(), DaemonError> {
+        if self.ignore_errors.is_some() {
+            return Err(config_parse_error(
+                config_path,
+                line,
+                format!(
+                    "duplicate 'ignore errors' directive in module '{}'",
+                    self.name
+                ),
+            ));
+        }
+
+        self.ignore_errors = Some(ignore_errors);
+        Ok(())
+    }
+
+    fn set_ignore_nonreadable(
+        &mut self,
+        ignore_nonreadable: bool,
+        config_path: &Path,
+        line: usize,
+    ) -> Result<(), DaemonError> {
+        if self.ignore_nonreadable.is_some() {
+            return Err(config_parse_error(
+                config_path,
+                line,
+                format!(
+                    "duplicate 'ignore nonreadable' directive in module '{}'",
+                    self.name
+                ),
+            ));
+        }
+
+        self.ignore_nonreadable = Some(ignore_nonreadable);
+        Ok(())
+    }
+
+    fn set_transfer_logging(
+        &mut self,
+        transfer_logging: bool,
+        config_path: &Path,
+        line: usize,
+    ) -> Result<(), DaemonError> {
+        if self.transfer_logging.is_some() {
+            return Err(config_parse_error(
+                config_path,
+                line,
+                format!(
+                    "duplicate 'transfer logging' directive in module '{}'",
+                    self.name
+                ),
+            ));
+        }
+
+        self.transfer_logging = Some(transfer_logging);
+        Ok(())
+    }
+
+    fn set_log_format(
+        &mut self,
+        log_format: Option<String>,
+        config_path: &Path,
+        line: usize,
+    ) -> Result<(), DaemonError> {
+        if self.log_format.is_some() {
+            return Err(config_parse_error(
+                config_path,
+                line,
+                format!(
+                    "duplicate 'log format' directive in module '{}'",
+                    self.name
+                ),
+            ));
+        }
+
+        self.log_format = Some(log_format);
+        Ok(())
+    }
+
+    fn set_dont_compress(
+        &mut self,
+        dont_compress: Option<String>,
+        config_path: &Path,
+        line: usize,
+    ) -> Result<(), DaemonError> {
+        if self.dont_compress.is_some() {
+            return Err(config_parse_error(
+                config_path,
+                line,
+                format!(
+                    "duplicate 'dont compress' directive in module '{}'",
+                    self.name
+                ),
+            ));
+        }
+
+        self.dont_compress = Some(dont_compress);
+        Ok(())
+    }
+
+    fn set_pre_xfer_exec(
+        &mut self,
+        pre_xfer_exec: Option<String>,
+        config_path: &Path,
+        line: usize,
+    ) -> Result<(), DaemonError> {
+        if self.pre_xfer_exec.is_some() {
+            return Err(config_parse_error(
+                config_path,
+                line,
+                format!(
+                    "duplicate 'pre-xfer exec' directive in module '{}'",
+                    self.name
+                ),
+            ));
+        }
+
+        self.pre_xfer_exec = Some(pre_xfer_exec);
+        Ok(())
+    }
+
+    fn set_post_xfer_exec(
+        &mut self,
+        post_xfer_exec: Option<String>,
+        config_path: &Path,
+        line: usize,
+    ) -> Result<(), DaemonError> {
+        if self.post_xfer_exec.is_some() {
+            return Err(config_parse_error(
+                config_path,
+                line,
+                format!(
+                    "duplicate 'post-xfer exec' directive in module '{}'",
+                    self.name
+                ),
+            ));
+        }
+
+        self.post_xfer_exec = Some(post_xfer_exec);
+        Ok(())
+    }
+
+    fn set_temp_dir(
+        &mut self,
+        temp_dir: Option<String>,
+        config_path: &Path,
+        line: usize,
+    ) -> Result<(), DaemonError> {
+        if self.temp_dir.is_some() {
+            return Err(config_parse_error(
+                config_path,
+                line,
+                format!(
+                    "duplicate 'temp dir' directive in module '{}'",
+                    self.name
+                ),
+            ));
+        }
+
+        self.temp_dir = Some(temp_dir);
+        Ok(())
+    }
+
+    fn set_charset(
+        &mut self,
+        charset: Option<String>,
+        config_path: &Path,
+        line: usize,
+    ) -> Result<(), DaemonError> {
+        if self.charset.is_some() {
+            return Err(config_parse_error(
+                config_path,
+                line,
+                format!(
+                    "duplicate 'charset' directive in module '{}'",
+                    self.name
+                ),
+            ));
+        }
+
+        self.charset = Some(charset);
+        Ok(())
+    }
+
+    fn set_forward_lookup(
+        &mut self,
+        forward_lookup: bool,
+        config_path: &Path,
+        line: usize,
+    ) -> Result<(), DaemonError> {
+        if self.forward_lookup.is_some() {
+            return Err(config_parse_error(
+                config_path,
+                line,
+                format!(
+                    "duplicate 'forward lookup' directive in module '{}'",
+                    self.name
+                ),
+            ));
+        }
+
+        self.forward_lookup = Some(forward_lookup);
+        Ok(())
+    }
+
     fn finish(
         self,
         config_path: &Path,
@@ -573,6 +826,19 @@ impl ModuleDefinitionBuilder {
                 .unwrap_or_else(|| default_outgoing_chmod.map(str::to_string)),
             fake_super: self.fake_super.unwrap_or(false),
             munge_symlinks: self.munge_symlinks.unwrap_or(None),
+            max_verbosity: self.max_verbosity.unwrap_or(1),
+            ignore_errors: self.ignore_errors.unwrap_or(false),
+            ignore_nonreadable: self.ignore_nonreadable.unwrap_or(false),
+            transfer_logging: self.transfer_logging.unwrap_or(false),
+            log_format: self
+                .log_format
+                .unwrap_or_else(|| Some("%o %h [%a] %m (%u) %f %l".to_owned())),
+            dont_compress: self.dont_compress.unwrap_or(None),
+            pre_xfer_exec: self.pre_xfer_exec.unwrap_or(None),
+            post_xfer_exec: self.post_xfer_exec.unwrap_or(None),
+            temp_dir: self.temp_dir.unwrap_or(None),
+            charset: self.charset.unwrap_or(None),
+            forward_lookup: self.forward_lookup.unwrap_or(true),
         })
     }
 }
@@ -619,6 +885,17 @@ mod module_definition_builder_tests {
         assert!(builder.incoming_chmod.is_none());
         assert!(builder.outgoing_chmod.is_none());
         assert!(builder.munge_symlinks.is_none());
+        assert!(builder.max_verbosity.is_none());
+        assert!(builder.ignore_errors.is_none());
+        assert!(builder.ignore_nonreadable.is_none());
+        assert!(builder.transfer_logging.is_none());
+        assert!(builder.log_format.is_none());
+        assert!(builder.dont_compress.is_none());
+        assert!(builder.pre_xfer_exec.is_none());
+        assert!(builder.post_xfer_exec.is_none());
+        assert!(builder.temp_dir.is_none());
+        assert!(builder.charset.is_none());
+        assert!(builder.forward_lookup.is_none());
     }
 
     // ==================== set_path tests ====================
@@ -1206,6 +1483,20 @@ mod module_definition_builder_tests {
         assert!(!def.bandwidth_limit_configured);
         assert!(!def.fake_super); // default false
         assert!(def.munge_symlinks.is_none()); // default None (auto)
+        assert_eq!(def.max_verbosity, 1); // default 1
+        assert!(!def.ignore_errors); // default false
+        assert!(!def.ignore_nonreadable); // default false
+        assert!(!def.transfer_logging); // default false
+        assert_eq!(
+            def.log_format.as_deref(),
+            Some("%o %h [%a] %m (%u) %f %l")
+        ); // default format
+        assert!(def.dont_compress.is_none());
+        assert!(def.pre_xfer_exec.is_none());
+        assert!(def.post_xfer_exec.is_none());
+        assert!(def.temp_dir.is_none());
+        assert!(def.charset.is_none());
+        assert!(def.forward_lookup); // default true
     }
 
     #[test]

--- a/crates/daemon/src/daemon/sections/module_parsing.rs
+++ b/crates/daemon/src/daemon/sections/module_parsing.rs
@@ -137,6 +137,17 @@ fn parse_module_definition(
         outgoing_chmod: None,
         fake_super: false,
         munge_symlinks: None,
+        max_verbosity: 1,
+        ignore_errors: false,
+        ignore_nonreadable: false,
+        transfer_logging: false,
+        log_format: Some("%o %h [%a] %m (%u) %f %l".to_owned()),
+        dont_compress: None,
+        pre_xfer_exec: None,
+        post_xfer_exec: None,
+        temp_dir: None,
+        charset: None,
+        forward_lookup: true,
     };
 
     if let Some(options_text) = options_part {

--- a/crates/daemon/src/tests/support.rs
+++ b/crates/daemon/src/tests/support.rs
@@ -51,6 +51,17 @@ pub(super) fn base_module(name: &str) -> ModuleDefinition {
         outgoing_chmod: None,
         fake_super: false,
         munge_symlinks: None,
+        max_verbosity: 1,
+        ignore_errors: false,
+        ignore_nonreadable: false,
+        transfer_logging: false,
+        log_format: Some("%o %h [%a] %m (%u) %f %l".to_owned()),
+        dont_compress: None,
+        pre_xfer_exec: None,
+        post_xfer_exec: None,
+        temp_dir: None,
+        charset: None,
+        forward_lookup: true,
     }
 }
 
@@ -88,6 +99,17 @@ pub(super) fn module_with_host_patterns(allow: &[&str], deny: &[&str]) -> Module
         outgoing_chmod: None,
         fake_super: false,
         munge_symlinks: None,
+        max_verbosity: 1,
+        ignore_errors: false,
+        ignore_nonreadable: false,
+        transfer_logging: false,
+        log_format: Some("%o %h [%a] %m (%u) %f %l".to_owned()),
+        dont_compress: None,
+        pre_xfer_exec: None,
+        post_xfer_exec: None,
+        temp_dir: None,
+        charset: None,
+        forward_lookup: true,
     }
 }
 


### PR DESCRIPTION
## Summary

- Add 11 new per-module configuration directives to the daemon config parser, mirroring upstream rsync's `rsyncd.conf` parameters from `loadparm.c`:
  - `max_verbosity` (default: 1) — caps client verbosity
  - `ignore_errors` (default: false) — ignore I/O errors during delete
  - `ignore_nonreadable` (default: false) — skip unreadable files
  - `transfer_logging` (default: false) — enable per-file transfer logging
  - `log_format` (default: `"%o %h [%a] %m (%u) %f %l"`) — transfer log format
  - `dont_compress` — glob patterns of files not to compress
  - `pre_xfer_exec` / `post_xfer_exec` — pre/post transfer commands
  - `temp_dir` — temporary directory for received files
  - `charset` — character set for filename conversion
  - `forward_lookup` (default: true) — DNS forward lookup verification
- Change unknown directive handling to log a warning and continue instead of returning an error, for both global and per-module sections

## Test plan

- [x] All 789 daemon crate tests pass
- [x] New tests for each directive: parsing, defaults, invalid values
- [x] Test for unknown global and per-module directive warning behavior
- [x] Comprehensive test parsing all 11 new directives together
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes