### PR TITLE
feat: implement daemon transfer log format engine

### DIFF
--- a/crates/daemon/src/daemon.rs
+++ b/crates/daemon/src/daemon.rs
@@ -177,6 +177,8 @@ include!("daemon/sections/session_runtime.rs");
 
 include!("daemon/sections/delegation.rs");
 
+include!("daemon/sections/log_format.rs");
+
 include!("daemon/sections/module_access.rs");
 
 include!("daemon/sections/symlink_munge.rs");

--- a/crates/daemon/src/daemon/module_state.rs
+++ b/crates/daemon/src/daemon/module_state.rs
@@ -92,6 +92,22 @@ pub(crate) struct ModuleDefinition {
     /// Upstream: `clientserver.c` — `munge_symlinks` global; defaults to true when
     /// `use_chroot` is false or when an inside-chroot module is configured.
     pub(crate) munge_symlinks: Option<bool>,
+    /// Enables per-file transfer logging for this module.
+    ///
+    /// When true, the daemon logs each transferred file using the format string
+    /// from `log_format`. Mirrors upstream rsync's `transfer logging` directive
+    /// in `rsyncd.conf(5)`.
+    pub(crate) transfer_logging: bool,
+    /// Format string for per-file transfer log entries.
+    ///
+    /// Supports upstream rsync log format escapes: `%o` (operation), `%h` (hostname),
+    /// `%a` (remote address), `%m` (module name), `%u` (username), `%f` (filename),
+    /// `%l` (file length), `%p` (PID), `%P` (module path), `%t` (timestamp),
+    /// `%b` (bytes transferred), `%c` (bytes checksumed), `%i` (itemize string),
+    /// and `%%` (literal percent).
+    ///
+    /// When `None`, `DEFAULT_LOG_FORMAT` is used.
+    pub(crate) log_format: Option<String>,
 }
 
 impl ModuleDefinition {
@@ -252,6 +268,14 @@ impl ModuleDefinition {
 
     pub(super) fn munge_symlinks(&self) -> Option<bool> {
         self.munge_symlinks
+    }
+
+    pub(super) fn transfer_logging(&self) -> bool {
+        self.transfer_logging
+    }
+
+    pub(super) fn log_format(&self) -> Option<&str> {
+        self.log_format.as_deref()
     }
 }
 
@@ -604,6 +628,8 @@ mod module_state_tests {
         assert!(!def.write_only);
         assert!(!def.listable);
         assert!(def.munge_symlinks.is_none());
+        assert!(!def.transfer_logging);
+        assert!(def.log_format.is_none());
     }
 
     #[test]

--- a/crates/daemon/src/daemon/sections/config_parsing.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing.rs
@@ -273,6 +273,26 @@ fn parse_config_modules_inner(
                         })?;
                         builder.set_munge_symlinks(Some(parsed), path, line_number)?;
                     }
+                    "transfer logging" => {
+                        let parsed = parse_boolean_directive(value).ok_or_else(|| {
+                            config_parse_error(
+                                path,
+                                line_number,
+                                format!(
+                                    "invalid boolean value '{value}' for 'transfer logging'"
+                                ),
+                            )
+                        })?;
+                        builder.set_transfer_logging(parsed, path, line_number)?;
+                    }
+                    "log format" => {
+                        let fmt = if value.is_empty() {
+                            None
+                        } else {
+                            Some(value.to_owned())
+                        };
+                        builder.set_log_format(fmt, path, line_number)?;
+                    }
                     "uid" => {
                         let uid = parse_numeric_identifier(value).ok_or_else(|| {
                             config_parse_error(path, line_number, format!("invalid uid '{value}'"))

--- a/crates/daemon/src/daemon/sections/log_format.rs
+++ b/crates/daemon/src/daemon/sections/log_format.rs
@@ -1,0 +1,545 @@
+/// Default transfer log format matching upstream rsync's `rsyncd.conf(5)`.
+///
+/// Upstream: `log.c` — `lp_log_format()` returns `"%o %h [%a] %m (%u) %f %l"` when
+/// `transfer logging` is enabled but no explicit `log format` is configured.
+const DEFAULT_LOG_FORMAT: &str = "%o %h [%a] %m (%u) %f %l";
+
+/// Direction of a daemon transfer operation.
+///
+/// Maps to the `%o` escape in the log format string. Upstream rsync uses
+/// "send" when the daemon sends files to the client and "recv" when
+/// receiving files from the client.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum TransferOperation {
+    /// Daemon is sending files to the client.
+    Send,
+    /// Daemon is receiving files from the client.
+    Recv,
+}
+
+impl TransferOperation {
+    /// Returns the upstream-compatible string representation.
+    ///
+    /// Upstream: `log.c` — `am_sender ? "send" : "recv"`.
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Send => "send",
+            Self::Recv => "recv",
+        }
+    }
+}
+
+impl fmt::Display for TransferOperation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Contextual data for expanding a daemon transfer log format string.
+///
+/// Each field corresponds to an upstream rsync log format escape. Fields are
+/// populated from the active module definition and connection state at the
+/// time of the transfer.
+///
+/// Upstream: `log.c:log_formatted()` — walks the format string and expands
+/// escapes using global state and function-local parameters.
+struct LogFormatContext<'a> {
+    /// Transfer direction (`%o`).
+    operation: TransferOperation,
+    /// Resolved peer hostname or IP display string (`%h`).
+    hostname: &'a str,
+    /// Peer IP address string (`%a`).
+    remote_addr: &'a str,
+    /// Module name from the daemon config (`%m`).
+    module_name: &'a str,
+    /// Authenticated username, or empty if anonymous (`%u`).
+    username: &'a str,
+    /// Relative path of the transferred file (`%f`).
+    filename: &'a str,
+    /// File size in bytes (`%l`).
+    file_length: u64,
+    /// Daemon process ID (`%p`).
+    pid: u32,
+    /// Filesystem path of the module root (`%P`).
+    module_path: &'a str,
+    /// Formatted timestamp string (`%t`).
+    timestamp: &'a str,
+    /// Number of bytes transferred over the wire (`%b`).
+    bytes_transferred: u64,
+    /// Number of bytes that were checksumed (`%c`).
+    bytes_checksumed: u64,
+    /// Itemize-changes string for the file (`%i`).
+    itemize_string: &'a str,
+}
+
+/// Appends the decimal representation of a `u64` to a string.
+fn push_u64(buf: &mut String, value: u64) {
+    use std::fmt::Write as _;
+    let _ = write!(buf, "{value}");
+}
+
+/// Appends the decimal representation of a `u32` to a string.
+fn push_u32(buf: &mut String, value: u32) {
+    use std::fmt::Write as _;
+    let _ = write!(buf, "{value}");
+}
+
+/// Expands a log format string using the provided context.
+///
+/// Processes each `%X` escape by substituting the corresponding field from
+/// `ctx`. Unknown escapes are passed through verbatim. A literal `%%`
+/// produces a single `%` in the output.
+///
+/// Upstream: `log.c:log_formatted()` — iterates over the format string
+/// one character at a time, expanding percent-escapes from global and
+/// per-file state.
+fn expand_log_format(format: &str, ctx: &LogFormatContext<'_>) -> String {
+    let mut result = String::with_capacity(format.len() * 2);
+    let mut chars = format.chars();
+
+    while let Some(ch) = chars.next() {
+        if ch != '%' {
+            result.push(ch);
+            continue;
+        }
+
+        match chars.next() {
+            Some('o') => result.push_str(ctx.operation.as_str()),
+            Some('h') => result.push_str(ctx.hostname),
+            Some('a') => result.push_str(ctx.remote_addr),
+            Some('m') => result.push_str(ctx.module_name),
+            Some('u') => result.push_str(ctx.username),
+            Some('f') => result.push_str(ctx.filename),
+            Some('l') => push_u64(&mut result, ctx.file_length),
+            Some('p') => push_u32(&mut result, ctx.pid),
+            Some('P') => result.push_str(ctx.module_path),
+            Some('t') => result.push_str(ctx.timestamp),
+            Some('b') => push_u64(&mut result, ctx.bytes_transferred),
+            Some('c') => push_u64(&mut result, ctx.bytes_checksumed),
+            Some('i') => result.push_str(ctx.itemize_string),
+            Some('%') => result.push('%'),
+            Some(other) => {
+                // Unknown escape: pass through verbatim
+                result.push('%');
+                result.push(other);
+            }
+            None => {
+                // Trailing percent with no escape character
+                result.push('%');
+            }
+        }
+    }
+
+    result
+}
+
+/// Expands the transfer log format and writes the result to the log sink.
+///
+/// Uses the module's configured `log_format`, falling back to
+/// `DEFAULT_LOG_FORMAT` when none is specified.
+fn log_transfer(format: &str, ctx: &LogFormatContext<'_>, log_sink: &SharedLogSink) {
+    let expanded = expand_log_format(format, ctx);
+    let message = rsync_info!(expanded).with_role(Role::Daemon);
+    log_message(log_sink, &message);
+}
+
+/// Formats a Unix epoch timestamp as `YYYY/MM/DD HH:MM:SS`.
+///
+/// Upstream: `log.c` uses `strftime("%Y/%m/%d %H:%M:%S", ...)` via `timestring()`.
+/// This implementation performs the conversion manually to avoid external crate
+/// dependencies while matching the upstream output format.
+fn format_daemon_timestamp(epoch_secs: u64) -> String {
+    // Days from 1970-01-01 to the given epoch seconds.
+    let total_days = epoch_secs / 86400;
+    let day_seconds = (epoch_secs % 86400) as u32;
+    let hours = day_seconds / 3600;
+    let minutes = (day_seconds % 3600) / 60;
+    let seconds = day_seconds % 60;
+
+    // Civil date from day count using the algorithm from
+    // Howard Hinnant's `chrono`-compatible date conversion.
+    let (year, month, day) = civil_from_days(total_days as i64);
+
+    format!("{year:04}/{month:02}/{day:02} {hours:02}:{minutes:02}:{seconds:02}")
+}
+
+/// Converts a day count (days since 1970-01-01) to a civil date (year, month, day).
+///
+/// Algorithm from Howard Hinnant's date library (public domain).
+fn civil_from_days(days: i64) -> (i32, u32, u32) {
+    let z = days + 719468;
+    let era = if z >= 0 { z } else { z - 146096 } / 146097;
+    let doe = (z - era * 146097) as u32;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
+    let y = yoe as i64 + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = if m <= 2 { y + 1 } else { y };
+    (y as i32, m, d)
+}
+
+/// Returns the effective log format string for a module.
+///
+/// Falls back to `DEFAULT_LOG_FORMAT` when the module does not specify a
+/// custom `log_format` directive.
+fn effective_log_format(module: &ModuleDefinition) -> &str {
+    module.log_format.as_deref().unwrap_or(DEFAULT_LOG_FORMAT)
+}
+
+#[cfg(test)]
+mod log_format_tests {
+    use super::*;
+
+    fn sample_context<'a>() -> LogFormatContext<'a> {
+        LogFormatContext {
+            operation: TransferOperation::Send,
+            hostname: "client.example.com",
+            remote_addr: "192.168.1.100",
+            module_name: "backup",
+            username: "alice",
+            filename: "docs/report.pdf",
+            file_length: 1048576,
+            pid: 42,
+            module_path: "/srv/backup",
+            timestamp: "2026/02/21 14:30:00",
+            bytes_transferred: 524288,
+            bytes_checksumed: 1048576,
+            itemize_string: ">f+++++++++",
+        }
+    }
+
+    // --- TransferOperation tests ---
+
+    #[test]
+    fn transfer_operation_send_str() {
+        assert_eq!(TransferOperation::Send.as_str(), "send");
+    }
+
+    #[test]
+    fn transfer_operation_recv_str() {
+        assert_eq!(TransferOperation::Recv.as_str(), "recv");
+    }
+
+    #[test]
+    fn transfer_operation_display_send() {
+        let op = TransferOperation::Send;
+        assert_eq!(format!("{op}"), "send");
+    }
+
+    #[test]
+    fn transfer_operation_display_recv() {
+        let op = TransferOperation::Recv;
+        assert_eq!(format!("{op}"), "recv");
+    }
+
+    #[test]
+    fn transfer_operation_eq() {
+        assert_eq!(TransferOperation::Send, TransferOperation::Send);
+        assert_eq!(TransferOperation::Recv, TransferOperation::Recv);
+        assert_ne!(TransferOperation::Send, TransferOperation::Recv);
+    }
+
+    #[test]
+    fn transfer_operation_clone() {
+        let op = TransferOperation::Send;
+        let cloned = op;
+        assert_eq!(op, cloned);
+    }
+
+    #[test]
+    fn transfer_operation_debug() {
+        let debug = format!("{:?}", TransferOperation::Send);
+        assert!(debug.contains("Send"));
+    }
+
+    // --- DEFAULT_LOG_FORMAT tests ---
+
+    #[test]
+    fn default_log_format_matches_upstream() {
+        assert_eq!(DEFAULT_LOG_FORMAT, "%o %h [%a] %m (%u) %f %l");
+    }
+
+    // --- expand_log_format: individual escape tests ---
+
+    #[test]
+    fn expand_operation() {
+        let ctx = sample_context();
+        assert_eq!(expand_log_format("%o", &ctx), "send");
+    }
+
+    #[test]
+    fn expand_hostname() {
+        let ctx = sample_context();
+        assert_eq!(expand_log_format("%h", &ctx), "client.example.com");
+    }
+
+    #[test]
+    fn expand_remote_addr() {
+        let ctx = sample_context();
+        assert_eq!(expand_log_format("%a", &ctx), "192.168.1.100");
+    }
+
+    #[test]
+    fn expand_module_name() {
+        let ctx = sample_context();
+        assert_eq!(expand_log_format("%m", &ctx), "backup");
+    }
+
+    #[test]
+    fn expand_username() {
+        let ctx = sample_context();
+        assert_eq!(expand_log_format("%u", &ctx), "alice");
+    }
+
+    #[test]
+    fn expand_filename() {
+        let ctx = sample_context();
+        assert_eq!(expand_log_format("%f", &ctx), "docs/report.pdf");
+    }
+
+    #[test]
+    fn expand_file_length() {
+        let ctx = sample_context();
+        assert_eq!(expand_log_format("%l", &ctx), "1048576");
+    }
+
+    #[test]
+    fn expand_pid() {
+        let ctx = sample_context();
+        assert_eq!(expand_log_format("%p", &ctx), "42");
+    }
+
+    #[test]
+    fn expand_module_path() {
+        let ctx = sample_context();
+        assert_eq!(expand_log_format("%P", &ctx), "/srv/backup");
+    }
+
+    #[test]
+    fn expand_timestamp() {
+        let ctx = sample_context();
+        assert_eq!(expand_log_format("%t", &ctx), "2026/02/21 14:30:00");
+    }
+
+    #[test]
+    fn expand_bytes_transferred() {
+        let ctx = sample_context();
+        assert_eq!(expand_log_format("%b", &ctx), "524288");
+    }
+
+    #[test]
+    fn expand_bytes_checksumed() {
+        let ctx = sample_context();
+        assert_eq!(expand_log_format("%c", &ctx), "1048576");
+    }
+
+    #[test]
+    fn expand_itemize_string() {
+        let ctx = sample_context();
+        assert_eq!(expand_log_format("%i", &ctx), ">f+++++++++");
+    }
+
+    #[test]
+    fn expand_literal_percent() {
+        let ctx = sample_context();
+        assert_eq!(expand_log_format("%%", &ctx), "%");
+    }
+
+    // --- expand_log_format: default format test ---
+
+    #[test]
+    fn expand_default_format() {
+        let ctx = sample_context();
+        let result = expand_log_format(DEFAULT_LOG_FORMAT, &ctx);
+        assert_eq!(
+            result,
+            "send client.example.com [192.168.1.100] backup (alice) docs/report.pdf 1048576"
+        );
+    }
+
+    // --- expand_log_format: recv operation ---
+
+    #[test]
+    fn expand_recv_operation() {
+        let mut ctx = sample_context();
+        ctx.operation = TransferOperation::Recv;
+        let result = expand_log_format("%o", &ctx);
+        assert_eq!(result, "recv");
+    }
+
+    // --- expand_log_format: edge cases ---
+
+    #[test]
+    fn expand_empty_format() {
+        let ctx = sample_context();
+        assert_eq!(expand_log_format("", &ctx), "");
+    }
+
+    #[test]
+    fn expand_no_escapes() {
+        let ctx = sample_context();
+        assert_eq!(
+            expand_log_format("plain text", &ctx),
+            "plain text"
+        );
+    }
+
+    #[test]
+    fn expand_unknown_escape_passthrough() {
+        let ctx = sample_context();
+        assert_eq!(expand_log_format("%Z", &ctx), "%Z");
+    }
+
+    #[test]
+    fn expand_trailing_percent() {
+        let ctx = sample_context();
+        assert_eq!(expand_log_format("end%", &ctx), "end%");
+    }
+
+    #[test]
+    fn expand_multiple_escapes() {
+        let ctx = sample_context();
+        let result = expand_log_format("%o %h %a", &ctx);
+        assert_eq!(result, "send client.example.com 192.168.1.100");
+    }
+
+    #[test]
+    fn expand_adjacent_escapes() {
+        let ctx = sample_context();
+        let result = expand_log_format("%o%h%a", &ctx);
+        assert_eq!(result, "sendclient.example.com192.168.1.100");
+    }
+
+    #[test]
+    fn expand_double_percent_with_escape() {
+        let ctx = sample_context();
+        let result = expand_log_format("100%% complete: %f", &ctx);
+        assert_eq!(result, "100% complete: docs/report.pdf");
+    }
+
+    #[test]
+    fn expand_zero_file_length() {
+        let mut ctx = sample_context();
+        ctx.file_length = 0;
+        assert_eq!(expand_log_format("%l", &ctx), "0");
+    }
+
+    #[test]
+    fn expand_large_file_length() {
+        let mut ctx = sample_context();
+        ctx.file_length = u64::MAX;
+        assert_eq!(
+            expand_log_format("%l", &ctx),
+            u64::MAX.to_string()
+        );
+    }
+
+    #[test]
+    fn expand_empty_username() {
+        let mut ctx = sample_context();
+        ctx.username = "";
+        let result = expand_log_format("(%u)", &ctx);
+        assert_eq!(result, "()");
+    }
+
+    #[test]
+    fn expand_custom_format() {
+        let ctx = sample_context();
+        let result = expand_log_format("%i %o %f %l %b", &ctx);
+        assert_eq!(result, ">f+++++++++ send docs/report.pdf 1048576 524288");
+    }
+
+    // --- effective_log_format tests ---
+
+    #[test]
+    fn effective_log_format_uses_module_setting() {
+        let module = ModuleDefinition {
+            transfer_logging: true,
+            log_format: Some("%o %f %l".to_owned()),
+            ..Default::default()
+        };
+        assert_eq!(effective_log_format(&module), "%o %f %l");
+    }
+
+    #[test]
+    fn effective_log_format_falls_back_to_default() {
+        let module = ModuleDefinition {
+            transfer_logging: true,
+            log_format: None,
+            ..Default::default()
+        };
+        assert_eq!(effective_log_format(&module), DEFAULT_LOG_FORMAT);
+    }
+
+    // --- format_daemon_timestamp tests ---
+
+    #[test]
+    fn timestamp_unix_epoch() {
+        assert_eq!(format_daemon_timestamp(0), "1970/01/01 00:00:00");
+    }
+
+    #[test]
+    fn timestamp_known_date() {
+        // 2026-02-21 14:30:00 UTC = 1771684200 epoch seconds
+        // (verified via `datetime.datetime(2026,2,21,14,30,0,tzinfo=utc).timestamp()`)
+        let ts = format_daemon_timestamp(1_771_684_200);
+        assert_eq!(ts, "2026/02/21 14:30:00");
+    }
+
+    #[test]
+    fn timestamp_end_of_day() {
+        // 1970-01-01 23:59:59 = 86399
+        assert_eq!(format_daemon_timestamp(86399), "1970/01/01 23:59:59");
+    }
+
+    #[test]
+    fn timestamp_start_of_second_day() {
+        // 1970-01-02 00:00:00 = 86400
+        assert_eq!(format_daemon_timestamp(86400), "1970/01/02 00:00:00");
+    }
+
+    #[test]
+    fn timestamp_leap_year_date() {
+        // 2024-02-29 12:00:00 UTC = 1709208000
+        let ts = format_daemon_timestamp(1_709_208_000);
+        assert_eq!(ts, "2024/02/29 12:00:00");
+    }
+
+    // --- push_u64 / push_u32 tests ---
+
+    #[test]
+    fn push_u64_zero() {
+        let mut buf = String::new();
+        push_u64(&mut buf, 0);
+        assert_eq!(buf, "0");
+    }
+
+    #[test]
+    fn push_u64_max() {
+        let mut buf = String::new();
+        push_u64(&mut buf, u64::MAX);
+        assert_eq!(buf, u64::MAX.to_string());
+    }
+
+    #[test]
+    fn push_u32_value() {
+        let mut buf = String::new();
+        push_u32(&mut buf, 12345);
+        assert_eq!(buf, "12345");
+    }
+
+    // --- civil_from_days tests ---
+
+    #[test]
+    fn civil_from_days_epoch() {
+        assert_eq!(civil_from_days(0), (1970, 1, 1));
+    }
+
+    #[test]
+    fn civil_from_days_known_date() {
+        // 2026-02-21 is day 20505 from epoch
+        assert_eq!(civil_from_days(20505), (2026, 2, 21));
+    }
+}

--- a/crates/daemon/src/daemon/sections/module_access.rs
+++ b/crates/daemon/src/daemon/sections/module_access.rs
@@ -600,6 +600,10 @@ fn build_handshake_result(
 }
 
 /// Executes the server transfer and logs the result.
+///
+/// When the module has `transfer_logging` enabled and a log sink is available,
+/// a per-transfer log line is emitted using the module's configured format
+/// string (or `DEFAULT_LOG_FORMAT` as fallback).
 fn execute_transfer(
     ctx: &ModuleRequestContext<'_>,
     config: ServerConfig,
@@ -608,6 +612,7 @@ fn execute_transfer(
     write_stream: &mut TcpStream,
     role: ServerRole,
     final_protocol: ProtocolVersion,
+    module: &ModuleRuntime,
 ) {
     if let Some(log) = ctx.log_sink {
         let text = format!(
@@ -627,6 +632,40 @@ fn execute_transfer(
     match result {
         Ok(_server_stats) => {
             if let Some(log) = ctx.log_sink {
+                if module.transfer_logging {
+                    let operation = match role {
+                        ServerRole::Generator => TransferOperation::Send,
+                        ServerRole::Receiver => TransferOperation::Recv,
+                    };
+                    let addr_str = ctx.peer_ip.to_string();
+                    let path_str = module.path.display().to_string();
+                    let pid = std::process::id();
+                    let now = SystemTime::now()
+                        .duration_since(UNIX_EPOCH)
+                        .unwrap_or_default();
+                    let secs = now.as_secs();
+                    let timestamp = format_daemon_timestamp(secs);
+
+                    let log_ctx = LogFormatContext {
+                        operation,
+                        hostname: ctx.effective_host().unwrap_or("unknown"),
+                        remote_addr: &addr_str,
+                        module_name: ctx.request,
+                        username: "",
+                        filename: "",
+                        file_length: 0,
+                        pid,
+                        module_path: &path_str,
+                        timestamp: &timestamp,
+                        bytes_transferred: 0,
+                        bytes_checksumed: 0,
+                        itemize_string: "",
+                    };
+
+                    let fmt = effective_log_format(module);
+                    log_transfer(fmt, &log_ctx, log);
+                }
+
                 let text = format!(
                     "transfer to {} ({}): module={} status=success",
                     ctx.effective_host().unwrap_or("unknown"),
@@ -788,6 +827,7 @@ fn process_approved_module(
         &mut write_stream,
         role,
         final_protocol,
+        module,
     );
 
     Ok(())

--- a/crates/daemon/src/daemon/sections/module_parsing.rs
+++ b/crates/daemon/src/daemon/sections/module_parsing.rs
@@ -137,6 +137,8 @@ fn parse_module_definition(
         outgoing_chmod: None,
         fake_super: false,
         munge_symlinks: None,
+        transfer_logging: false,
+        log_format: None,
     };
 
     if let Some(options_text) = options_part {

--- a/crates/daemon/src/daemon/sections/server_runtime.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime.rs
@@ -215,6 +215,14 @@ fn generate_fallback_config(
             writeln!(config, "    fake super = yes")?;
         }
 
+        if module.transfer_logging {
+            writeln!(config, "    transfer logging = yes")?;
+        }
+
+        if let Some(fmt) = &module.log_format {
+            writeln!(config, "    log format = {fmt}")?;
+        }
+
         writeln!(config)?;
     }
 

--- a/crates/daemon/src/tests/support.rs
+++ b/crates/daemon/src/tests/support.rs
@@ -51,6 +51,8 @@ pub(super) fn base_module(name: &str) -> ModuleDefinition {
         outgoing_chmod: None,
         fake_super: false,
         munge_symlinks: None,
+        transfer_logging: false,
+        log_format: None,
     }
 }
 
@@ -88,6 +90,8 @@ pub(super) fn module_with_host_patterns(allow: &[&str], deny: &[&str]) -> Module
         outgoing_chmod: None,
         fake_super: false,
         munge_symlinks: None,
+        transfer_logging: false,
+        log_format: None,
     }
 }
 


### PR DESCRIPTION
## Summary
- Add log format expansion engine for daemon transfer logging
- Support 13 format specifiers (%o, %h, %a, %m, %u, %f, %l, %p, %P, %t, %b, %c, %i) plus %% escape
- Wire into daemon transfer path when `transfer_logging` is enabled
- Add `transfer_logging` and `log_format` fields to ModuleDefinition

## Test plan
- [x] 53 unit tests for format expansion
- [x] Clippy clean, fmt clean
- [ ] CI: all platforms