### PR TITLE
feat: implement pre-xfer and post-xfer exec daemon directives

### DIFF
--- a/crates/daemon/src/daemon.rs
+++ b/crates/daemon/src/daemon.rs
@@ -181,6 +181,8 @@ include!("daemon/sections/privilege.rs");
 
 include!("daemon/sections/module_access.rs");
 
+include!("daemon/sections/xfer_exec.rs");
+
 include!("daemon/sections/symlink_munge.rs");
 
 include!("daemon/sections/auth_helpers.rs");

--- a/crates/daemon/src/daemon/sections/module_access.rs
+++ b/crates/daemon/src/daemon/sections/module_access.rs
@@ -600,6 +600,8 @@ fn build_handshake_result(
 }
 
 /// Executes the server transfer and logs the result.
+///
+/// Returns the transfer exit status: `0` on success, non-zero on failure.
 fn execute_transfer(
     ctx: &ModuleRequestContext<'_>,
     config: ServerConfig,
@@ -608,7 +610,7 @@ fn execute_transfer(
     write_stream: &mut TcpStream,
     role: ServerRole,
     final_protocol: ProtocolVersion,
-) {
+) -> i32 {
     if let Some(log) = ctx.log_sink {
         let text = format!(
             "module '{}' from {} ({}): protocol {}, role: {:?}",
@@ -636,6 +638,7 @@ fn execute_transfer(
                 let message = rsync_info!(text).with_role(Role::Daemon);
                 log_message(log, &message);
             }
+            0
         }
         Err(err) => {
             if let Some(log) = ctx.log_sink {
@@ -649,6 +652,7 @@ fn execute_transfer(
                 let message = rsync_error!(1, text).with_role(Role::Daemon);
                 log_message(log, &message);
             }
+            1
         }
     }
 }
@@ -806,12 +810,71 @@ fn process_approved_module(
         None => return Ok(()),
     };
 
+    // Build XferExecContext for pre/post-xfer exec commands
+    let xfer_ctx = XferExecContext {
+        module_name: &module.name,
+        module_path: &module.path,
+        host_addr: ctx.peer_ip,
+        host_name: ctx.effective_host(),
+        user_name: None,
+        request: ctx.request,
+    };
+
+    // Run pre-xfer exec if configured
+    // upstream: clientserver.c — pre_exec() runs before the transfer starts
+    if let Some(command) = &module.pre_xfer_exec {
+        match run_pre_xfer_exec(command, &xfer_ctx) {
+            Ok(Ok(())) => {
+                if let Some(log) = ctx.log_sink {
+                    let text = format!(
+                        "pre-xfer exec succeeded for module '{}'",
+                        ctx.request
+                    );
+                    let message = rsync_info!(text).with_role(Role::Daemon);
+                    log_message(log, &message);
+                }
+            }
+            Ok(Err(error_msg)) => {
+                let payload = format!("@ERROR: {error_msg}");
+                send_error_and_exit(
+                    ctx.reader.get_mut(),
+                    ctx.limiter,
+                    ctx.messages,
+                    &payload,
+                )?;
+                if let Some(log) = ctx.log_sink {
+                    let message = rsync_error!(1, error_msg).with_role(Role::Daemon);
+                    log_message(log, &message);
+                }
+                return Ok(());
+            }
+            Err(io_err) => {
+                let error_msg = format!(
+                    "failed to run pre-xfer exec command for module '{}': {io_err}",
+                    ctx.request
+                );
+                let payload = format!("@ERROR: {error_msg}");
+                send_error_and_exit(
+                    ctx.reader.get_mut(),
+                    ctx.limiter,
+                    ctx.messages,
+                    &payload,
+                )?;
+                if let Some(log) = ctx.log_sink {
+                    let message = rsync_error!(1, error_msg).with_role(Role::Daemon);
+                    log_message(log, &message);
+                }
+                return Ok(());
+            }
+        }
+    }
+
     // Build handshake and execute transfer
     let role = determine_server_role(&client_args);
     let handshake = build_handshake_result(ctx.reader, negotiated_protocol, client_args, module);
     let final_protocol = handshake.protocol;
 
-    execute_transfer(
+    let exit_status = execute_transfer(
         ctx,
         config,
         handshake,
@@ -820,6 +883,12 @@ fn process_approved_module(
         role,
         final_protocol,
     );
+
+    // Run post-xfer exec if configured
+    // upstream: clientserver.c — post_exec() runs after the transfer, regardless of outcome
+    if let Some(command) = &module.post_xfer_exec {
+        run_post_xfer_exec(command, &xfer_ctx, exit_status, ctx.log_sink);
+    }
 
     Ok(())
 }

--- a/crates/daemon/src/daemon/sections/xfer_exec.rs
+++ b/crates/daemon/src/daemon/sections/xfer_exec.rs
@@ -1,0 +1,300 @@
+/// Information about the current transfer request, used to populate
+/// environment variables for pre/post-xfer exec commands.
+///
+/// Upstream: `clientserver.c` sets `RSYNC_MODULE_NAME`, `RSYNC_MODULE_PATH`,
+/// `RSYNC_HOST_ADDR`, `RSYNC_HOST_NAME`, `RSYNC_USER_NAME`, and
+/// `RSYNC_REQUEST` before invoking `pre-xfer exec` and `post-xfer exec`.
+struct XferExecContext<'a> {
+    module_name: &'a str,
+    module_path: &'a Path,
+    host_addr: IpAddr,
+    host_name: Option<&'a str>,
+    user_name: Option<&'a str>,
+    request: &'a str,
+}
+
+/// Builds a shell command with upstream-compatible environment variables.
+///
+/// On Unix, runs via `sh -c <command>`. On Windows, runs via `cmd /C <command>`.
+/// Sets the standard rsync daemon environment variables that upstream exposes
+/// to pre/post-xfer exec scripts.
+fn build_xfer_command(command: &str, ctx: &XferExecContext<'_>) -> ProcessCommand {
+    #[cfg(unix)]
+    let mut cmd = {
+        let mut c = ProcessCommand::new("sh");
+        c.args(["-c", command]);
+        c
+    };
+
+    #[cfg(windows)]
+    let mut cmd = {
+        let mut c = ProcessCommand::new("cmd");
+        c.args(["/C", command]);
+        c
+    };
+
+    cmd.env("RSYNC_MODULE_NAME", ctx.module_name);
+    cmd.env("RSYNC_MODULE_PATH", ctx.module_path);
+    cmd.env("RSYNC_HOST_ADDR", ctx.host_addr.to_string());
+    cmd.env(
+        "RSYNC_HOST_NAME",
+        ctx.host_name.unwrap_or_default(),
+    );
+    cmd.env("RSYNC_USER_NAME", ctx.user_name.unwrap_or_default());
+    cmd.env("RSYNC_REQUEST", ctx.request);
+
+    cmd
+}
+
+/// Runs the pre-xfer exec command for a daemon module.
+///
+/// The command is executed via `sh -c` (Unix) or `cmd /C` (Windows) with
+/// upstream-compatible environment variables. If the command exits non-zero,
+/// returns an error indicating the transfer should be denied.
+///
+/// Upstream: `clientserver.c` — `pre_exec()` runs the command and checks
+/// its exit status before starting the transfer.
+fn run_pre_xfer_exec(
+    command: &str,
+    ctx: &XferExecContext<'_>,
+) -> io::Result<Result<(), String>> {
+    let mut cmd = build_xfer_command(command, ctx);
+    cmd.stdin(Stdio::null());
+    cmd.stdout(Stdio::null());
+    cmd.stderr(Stdio::piped());
+
+    let output = cmd.output()?;
+
+    if output.status.success() {
+        Ok(Ok(()))
+    } else {
+        let code = output.status.code().unwrap_or(-1);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stderr_trimmed = stderr.trim();
+
+        let message = if stderr_trimmed.is_empty() {
+            format!(
+                "pre-xfer exec command failed with exit code {code} for module '{}'",
+                ctx.module_name
+            )
+        } else {
+            format!(
+                "pre-xfer exec command failed with exit code {code} for module '{}': {stderr_trimmed}",
+                ctx.module_name
+            )
+        };
+
+        Ok(Err(message))
+    }
+}
+
+/// Runs the post-xfer exec command for a daemon module.
+///
+/// Same environment variables as `run_pre_xfer_exec` plus `RSYNC_EXIT_STATUS`
+/// set to the transfer's exit code. Failures are logged but do not change the
+/// transfer exit status.
+///
+/// Upstream: `clientserver.c` — `post_exec()` runs the command after the
+/// transfer completes, regardless of success or failure.
+fn run_post_xfer_exec(
+    command: &str,
+    ctx: &XferExecContext<'_>,
+    exit_status: i32,
+    log_sink: Option<&SharedLogSink>,
+) {
+    let mut cmd = build_xfer_command(command, ctx);
+    cmd.env("RSYNC_EXIT_STATUS", exit_status.to_string());
+    cmd.stdin(Stdio::null());
+    cmd.stdout(Stdio::null());
+    cmd.stderr(Stdio::piped());
+
+    match cmd.output() {
+        Ok(output) => {
+            if !output.status.success() {
+                let code = output.status.code().unwrap_or(-1);
+                if let Some(log) = log_sink {
+                    let text = format!(
+                        "post-xfer exec command failed with exit code {code} for module '{}'",
+                        ctx.module_name
+                    );
+                    let message = rsync_warning!(text).with_role(Role::Daemon);
+                    log_message(log, &message);
+                }
+            }
+        }
+        Err(err) => {
+            if let Some(log) = log_sink {
+                let text = format!(
+                    "failed to run post-xfer exec command for module '{}': {err}",
+                    ctx.module_name
+                );
+                let message = rsync_warning!(text).with_role(Role::Daemon);
+                log_message(log, &message);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod xfer_exec_tests {
+    use super::*;
+    use std::net::Ipv4Addr;
+
+    fn test_context() -> XferExecContext<'static> {
+        XferExecContext {
+            module_name: "testmod",
+            module_path: Path::new("/srv/testmod"),
+            host_addr: IpAddr::V4(Ipv4Addr::new(192, 168, 1, 100)),
+            host_name: Some("client.example.com"),
+            user_name: Some("testuser"),
+            request: "testmod/subdir",
+        }
+    }
+
+    #[test]
+    fn build_xfer_command_sets_environment_variables() {
+        let ctx = test_context();
+        let cmd = build_xfer_command("echo test", &ctx);
+        let envs: Vec<_> = cmd.get_envs().collect();
+
+        let find_env = |key: &str| -> Option<String> {
+            envs.iter()
+                .find(|(k, _)| k == &key)
+                .and_then(|(_, v)| v.map(|s| s.to_string_lossy().into_owned()))
+        };
+
+        assert_eq!(find_env("RSYNC_MODULE_NAME").as_deref(), Some("testmod"));
+        assert_eq!(
+            find_env("RSYNC_MODULE_PATH").as_deref(),
+            Some("/srv/testmod")
+        );
+        assert_eq!(
+            find_env("RSYNC_HOST_ADDR").as_deref(),
+            Some("192.168.1.100")
+        );
+        assert_eq!(
+            find_env("RSYNC_HOST_NAME").as_deref(),
+            Some("client.example.com")
+        );
+        assert_eq!(find_env("RSYNC_USER_NAME").as_deref(), Some("testuser"));
+        assert_eq!(
+            find_env("RSYNC_REQUEST").as_deref(),
+            Some("testmod/subdir")
+        );
+    }
+
+    #[test]
+    fn build_xfer_command_handles_missing_optional_fields() {
+        let ctx = XferExecContext {
+            module_name: "mod",
+            module_path: Path::new("/data"),
+            host_addr: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+            host_name: None,
+            user_name: None,
+            request: "mod",
+        };
+        let cmd = build_xfer_command("echo test", &ctx);
+        let envs: Vec<_> = cmd.get_envs().collect();
+
+        let find_env = |key: &str| -> Option<String> {
+            envs.iter()
+                .find(|(k, _)| k == &key)
+                .and_then(|(_, v)| v.map(|s| s.to_string_lossy().into_owned()))
+        };
+
+        assert_eq!(find_env("RSYNC_HOST_NAME").as_deref(), Some(""));
+        assert_eq!(find_env("RSYNC_USER_NAME").as_deref(), Some(""));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn build_xfer_command_uses_sh_on_unix() {
+        let ctx = test_context();
+        let cmd = build_xfer_command("echo hello", &ctx);
+        assert_eq!(cmd.get_program(), "sh");
+        let args: Vec<_> = cmd.get_args().collect();
+        assert_eq!(args, vec!["-c", "echo hello"]);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn build_xfer_command_uses_cmd_on_windows() {
+        let ctx = test_context();
+        let cmd = build_xfer_command("echo hello", &ctx);
+        assert_eq!(cmd.get_program(), "cmd");
+        let args: Vec<_> = cmd.get_args().collect();
+        assert_eq!(args, vec!["/C", "echo hello"]);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn run_pre_xfer_exec_succeeds_on_zero_exit() {
+        let ctx = test_context();
+        let result = run_pre_xfer_exec("true", &ctx).expect("command should run");
+        assert!(result.is_ok());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn run_pre_xfer_exec_fails_on_nonzero_exit() {
+        let ctx = test_context();
+        let result = run_pre_xfer_exec("false", &ctx).expect("command should run");
+        assert!(result.is_err());
+        let msg = result.unwrap_err();
+        assert!(msg.contains("pre-xfer exec command failed"));
+        assert!(msg.contains("testmod"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn run_pre_xfer_exec_captures_stderr() {
+        let ctx = test_context();
+        let result =
+            run_pre_xfer_exec("echo 'custom error' >&2; exit 1", &ctx).expect("command should run");
+        assert!(result.is_err());
+        let msg = result.unwrap_err();
+        assert!(msg.contains("custom error"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn run_pre_xfer_exec_passes_env_variables() {
+        let ctx = test_context();
+        let result = run_pre_xfer_exec(
+            "test \"$RSYNC_MODULE_NAME\" = \"testmod\" && test \"$RSYNC_HOST_ADDR\" = \"192.168.1.100\"",
+            &ctx,
+        )
+        .expect("command should run");
+        assert!(result.is_ok(), "env vars should be set correctly");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn run_post_xfer_exec_passes_exit_status_env() {
+        let ctx = test_context();
+        run_post_xfer_exec(
+            "test \"$RSYNC_EXIT_STATUS\" = \"42\"",
+            &ctx,
+            42,
+            None,
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn run_post_xfer_exec_does_not_propagate_failure() {
+        let ctx = test_context();
+        run_post_xfer_exec("exit 1", &ctx, 0, None);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn run_pre_xfer_exec_returns_io_error_for_missing_command() {
+        let ctx = test_context();
+        // sh -c with a non-existent command will still run (sh exists), so
+        // the command itself returns non-zero rather than an I/O error.
+        let result = run_pre_xfer_exec("/nonexistent/binary/path", &ctx)
+            .expect("sh -c should run");
+        assert!(result.is_err());
+    }
+}


### PR DESCRIPTION
## Summary

- Add `xfer_exec.rs` module with `XferExecContext`, `build_xfer_command()`, `run_pre_xfer_exec()`, and `run_post_xfer_exec()` functions for executing shell commands before/after daemon transfers
- Wire pre-xfer and post-xfer exec into the daemon transfer flow in `module_access.rs`, running pre-xfer after authentication but before the transfer starts, and post-xfer after transfer completion
- Change `execute_transfer()` to return the transfer exit status (`i32`) so it can be passed to post-xfer exec via `RSYNC_EXIT_STATUS`

The config fields (`pre_xfer_exec`, `post_xfer_exec`), parsing, and builder methods were added in #2381. This PR adds the actual execution logic with upstream-compatible environment variables (`RSYNC_MODULE_NAME`, `RSYNC_MODULE_PATH`, `RSYNC_HOST_ADDR`, `RSYNC_HOST_NAME`, `RSYNC_USER_NAME`, `RSYNC_REQUEST`, `RSYNC_EXIT_STATUS`).

Commands run via `sh -c` (Unix) or `cmd /C` (Windows). Pre-xfer failures deny the transfer with an `@ERROR` message. Post-xfer failures are logged but do not affect the transfer exit status, matching upstream `clientserver.c` semantics.

## Test plan

- [x] All 805 daemon tests pass (`cargo nextest run -p daemon --all-features`)
- [x] Clippy clean (`cargo clippy -p daemon --all-targets --all-features --no-deps -- -D warnings`)
- [x] Format check passes (`cargo fmt -p daemon -- --check`)
- [ ] CI: fmt+clippy, nextest (stable), Windows (stable), macOS (stable), Linux musl (stable)