### PR TITLE
fix: correct mtime encoding for protocol versions below 30

### DIFF
--- a/crates/protocol/src/flist/read.rs
+++ b/crates/protocol/src/flist/read.rs
@@ -437,10 +437,12 @@ impl FileListReader {
         flags: FileFlags,
     ) -> io::Result<MetadataResult> {
         // 1. Read mtime
+        // upstream: flist.c:828-839 — proto >= 30 uses read_varlong(f, 4),
+        // proto < 30 uses read_uint(f) (fixed 4-byte unsigned)
         let mtime = if flags.same_time() {
             self.state.prev_mtime()
         } else {
-            let mtime = crate::read_varlong(reader, 4)?;
+            let mtime = self.codec.read_mtime(reader)?;
             self.state.update_mtime(mtime);
             mtime
         };


### PR DESCRIPTION
## Summary

- **Fix read path**: `read_metadata()` in `flist/read.rs` bypassed the protocol codec and always called `read_varlong(reader, 4)` for mtime, regardless of protocol version. Upstream rsync uses `read_uint(f)` (fixed 4-byte unsigned) for protocol < 30 and `read_varlong(f, 4)` only for protocol >= 30. Now delegates to `self.codec.read_mtime()` which dispatches correctly.
- **Fix codec signedness**: `LegacyProtocolCodec::write_mtime()` cast mtime to `i32` (signed) and `read_mtime()` read as `i32` with sign extension. Upstream uses `read_uint`/`write_uint` which are unsigned `u32`. This caused timestamps above `2^31 - 1` (year 2038+) to be encoded incorrectly. Now uses `u32` for both read and write.
- **Update tests**: Extended `mtime_boundary_values` and `mtime_round_trip_all_versions` tests to cover post-2038 timestamps and the full `u32` range for legacy protocol versions.

## Upstream Reference

`flist.c:828-839`:
```c
if (!(xflags & XMIT_SAME_TIME)) {
    if (protocol_version >= 30)
        modtime = read_varlong(f, 4);
    else
        modtime = read_uint(f);
}
```

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -D warnings` passes
- [x] `cargo nextest run --workspace --all-features` — all 22054 tests pass
- [x] Protocol 30+ (modern) behavior unchanged — uses varlong encoding
- [x] Protocol 28-29 (legacy) now correctly uses unsigned u32 encoding
- [x] Timestamps above `i32::MAX` (2038+) round-trip correctly for all protocol versions