### PR TITLE
fix: use rsync varint encoding in batch file format

### DIFF
--- a/crates/batch/src/lib.rs
+++ b/crates/batch/src/lib.rs
@@ -356,7 +356,7 @@ pub struct BatchConfig {
     ///
     /// These flags are automatically set based on protocol version in
     /// [`BatchConfig::new`]. For protocol versions < 30, this is `None`.
-    pub compat_flags: Option<u64>,
+    pub compat_flags: Option<i32>,
 
     /// Checksum seed for the transfer.
     ///
@@ -431,7 +431,7 @@ impl BatchConfig {
     ///
     /// assert_eq!(config.compat_flags, Some(0x01));
     /// ```
-    pub const fn with_compat_flags(mut self, flags: u64) -> Self {
+    pub const fn with_compat_flags(mut self, flags: i32) -> Self {
         if self.protocol_version >= 30 {
             self.compat_flags = Some(flags);
         }

--- a/crates/batch/tests/batch_integration.rs
+++ b/crates/batch/tests/batch_integration.rs
@@ -889,7 +889,7 @@ mod edge_cases {
     fn compat_flags_boundary_values() {
         let temp_dir = TempDir::new().unwrap();
 
-        let compat_flags = [0u64, 1, 0x7F, 0x80, 0xFF, 0xFFFF, u64::MAX];
+        let compat_flags: &[i32] = &[0, 1, 0x7F, 0x80, 0xFF, 0xFFFF, i32::MAX];
 
         for (i, &flags) in compat_flags.iter().enumerate() {
             let batch_path = temp_dir.path().join(format!("compat_{i}.batch"));


### PR DESCRIPTION
## Summary

- Replace LEB128 varint encoding in batch crate with upstream rsync varint format
- Delegate to `protocol::write_varint`/`protocol::read_varint` instead of custom LEB128
- Change `compat_flags` type from `u64` to `i32` to match protocol crate signature

The batch header's compat flags (protocol >= 30) were using LEB128 encoding, which produces different byte sequences from upstream rsync's varint format for values >= 128. This caused wire incompatibility.

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy` passes
- [x] All 22,065 tests pass