### PR TITLE
fix: concatenate multiple --usermap/--groupmap values

### DIFF
--- a/crates/cli/src/frontend/arguments/tests.rs
+++ b/crates/cli/src/frontend/arguments/tests.rs
@@ -1487,19 +1487,17 @@ mod error_handling {
     }
 
     #[test]
-    fn usermap_twice_fails() {
-        let result = parse_test_args(["--usermap=0:1000", "--usermap=0:1001", "src/", "dst/"]);
-        assert!(result.is_err());
-        let err = result.unwrap_err();
-        assert!(err.to_string().contains("usermap"));
+    fn usermap_twice_concatenates() {
+        let result = parse_test_args(["--usermap=0:1000", "--usermap=100:2000", "src/", "dst/"]);
+        let parsed = result.expect("multiple --usermap should succeed");
+        assert_eq!(parsed.usermap, Some(OsString::from("0:1000,100:2000")));
     }
 
     #[test]
-    fn groupmap_twice_fails() {
-        let result = parse_test_args(["--groupmap=0:1000", "--groupmap=0:1001", "src/", "dst/"]);
-        assert!(result.is_err());
-        let err = result.unwrap_err();
-        assert!(err.to_string().contains("groupmap"));
+    fn groupmap_twice_concatenates() {
+        let result = parse_test_args(["--groupmap=0:1000", "--groupmap=100:2000", "src/", "dst/"]);
+        let parsed = result.expect("multiple --groupmap should succeed");
+        assert_eq!(parsed.groupmap, Some(OsString::from("0:1000,100:2000")));
     }
 
     #[test]

--- a/crates/cli/src/frontend/command_builder/sections/transfer_behavior_options.rs
+++ b/crates/cli/src/frontend/command_builder/sections/transfer_behavior_options.rs
@@ -487,6 +487,7 @@ pub(crate) fn add_transfer_behavior_options(command: ClapCommand) -> ClapCommand
                     .long("usermap")
                     .value_name("STRING")
                     .help("Apply custom user ID mapping rules.")
+                    .action(ArgAction::Append)
                     .value_parser(OsStringValueParser::new())
                     .num_args(1),
             )
@@ -495,6 +496,7 @@ pub(crate) fn add_transfer_behavior_options(command: ClapCommand) -> ClapCommand
                     .long("groupmap")
                     .value_name("STRING")
                     .help("Apply custom group ID mapping rules.")
+                    .action(ArgAction::Append)
                     .value_parser(OsStringValueParser::new())
                     .num_args(1),
             )

--- a/crates/cli/tests/argument_errors.rs
+++ b/crates/cli/tests/argument_errors.rs
@@ -98,15 +98,15 @@ fn test_delete_after_and_delay_conflict() {
 }
 
 #[test]
-fn test_multiple_usermap_conflict() {
+fn test_multiple_usermap_concatenated() {
     let result = parse_args(["oc-rsync", "--usermap=a:b", "--usermap=c:d", "src", "dest"]);
-    assert!(result.is_err(), "Multiple usermap should fail");
-    let err = result.unwrap_err();
-    assert_eq!(err.kind(), ErrorKind::ArgumentConflict);
+    assert!(result.is_ok(), "Multiple usermap should concatenate");
+    let args = result.unwrap();
+    assert_eq!(args.usermap, Some("a:b,c:d".into()));
 }
 
 #[test]
-fn test_multiple_groupmap_conflict() {
+fn test_multiple_groupmap_concatenated() {
     let result = parse_args([
         "oc-rsync",
         "--groupmap=a:b",
@@ -114,9 +114,9 @@ fn test_multiple_groupmap_conflict() {
         "src",
         "dest",
     ]);
-    assert!(result.is_err(), "Multiple groupmap should fail");
-    let err = result.unwrap_err();
-    assert_eq!(err.kind(), ErrorKind::ArgumentConflict);
+    assert!(result.is_ok(), "Multiple groupmap should concatenate");
+    let args = result.unwrap();
+    assert_eq!(args.groupmap, Some("a:b,c:d".into()));
 }
 
 #[test]
@@ -158,31 +158,33 @@ fn test_delete_conflict_error_message() {
 }
 
 #[test]
-fn test_usermap_conflict_error_message() {
-    let result = parse_args(["oc-rsync", "--usermap=a:b", "--usermap=c:d", "src", "dest"]);
-    assert!(result.is_err());
-    let err_msg = result.unwrap_err().to_string();
-    assert!(
-        err_msg.to_lowercase().contains("usermap") || err_msg.to_lowercase().contains("conflict"),
-        "Error message should mention usermap or conflict: {err_msg}"
-    );
+fn test_multiple_usermap_three_values() {
+    let result = parse_args([
+        "oc-rsync",
+        "--usermap=a:b",
+        "--usermap=c:d",
+        "--usermap=e:f",
+        "src",
+        "dest",
+    ]);
+    assert!(result.is_ok(), "Three --usermap values should concatenate");
+    let args = result.unwrap();
+    assert_eq!(args.usermap, Some("a:b,c:d,e:f".into()));
 }
 
 #[test]
-fn test_groupmap_conflict_error_message() {
+fn test_multiple_groupmap_three_values() {
     let result = parse_args([
         "oc-rsync",
         "--groupmap=a:b",
         "--groupmap=c:d",
+        "--groupmap=e:f",
         "src",
         "dest",
     ]);
-    assert!(result.is_err());
-    let err_msg = result.unwrap_err().to_string();
-    assert!(
-        err_msg.to_lowercase().contains("groupmap") || err_msg.to_lowercase().contains("conflict"),
-        "Error message should mention groupmap or conflict: {err_msg}"
-    );
+    assert!(result.is_ok(), "Three --groupmap values should concatenate");
+    let args = result.unwrap();
+    assert_eq!(args.groupmap, Some("a:b,c:d,e:f".into()));
 }
 
 #[test]

--- a/crates/cli/tests/mutually_exclusive_options.rs
+++ b/crates/cli/tests/mutually_exclusive_options.rs
@@ -147,7 +147,7 @@ fn test_single_usermap_accepted() {
 }
 
 #[test]
-fn test_multiple_usermap_rejected() {
+fn test_multiple_usermap_concatenated() {
     let result = parse_args([
         "oc-rsync",
         "--usermap=foo:bar",
@@ -156,12 +156,11 @@ fn test_multiple_usermap_rejected() {
         "dest",
     ]);
     assert!(
-        result.is_err(),
-        "Multiple --usermap options should be rejected"
+        result.is_ok(),
+        "Multiple --usermap options should be concatenated"
     );
-    let err = result.unwrap_err();
-    // Clap reports this as ArgumentConflict when the same option is used multiple times
-    assert_eq!(err.kind(), clap::error::ErrorKind::ArgumentConflict);
+    let args = result.unwrap();
+    assert_eq!(args.usermap, Some("foo:bar,baz:qux".into()));
 }
 
 #[test]
@@ -173,7 +172,7 @@ fn test_single_groupmap_accepted() {
 }
 
 #[test]
-fn test_multiple_groupmap_rejected() {
+fn test_multiple_groupmap_concatenated() {
     let result = parse_args([
         "oc-rsync",
         "--groupmap=admin:wheel",
@@ -182,12 +181,11 @@ fn test_multiple_groupmap_rejected() {
         "dest",
     ]);
     assert!(
-        result.is_err(),
-        "Multiple --groupmap options should be rejected"
+        result.is_ok(),
+        "Multiple --groupmap options should be concatenated"
     );
-    let err = result.unwrap_err();
-    // Clap reports this as ArgumentConflict when the same option is used multiple times
-    assert_eq!(err.kind(), clap::error::ErrorKind::ArgumentConflict);
+    let args = result.unwrap();
+    assert_eq!(args.groupmap, Some("admin:wheel,users:staff".into()));
 }
 
 #[test]
@@ -227,13 +225,8 @@ fn test_delete_conflict_error_message_contains_options() {
 }
 
 #[test]
-fn test_usermap_too_many_error_message() {
+fn test_multiple_usermap_concatenation_preserves_order() {
     let result = parse_args(["oc-rsync", "--usermap=a:b", "--usermap=c:d", "src", "dest"]);
-    assert!(result.is_err());
-    let err_msg = result.unwrap_err().to_string();
-    // Error message should mention usermap
-    assert!(
-        err_msg.contains("usermap") || err_msg.contains("once"),
-        "Error message should mention usermap can only be specified once"
-    );
+    let args = result.expect("multiple --usermap should succeed");
+    assert_eq!(args.usermap, Some("a:b,c:d".into()));
 }


### PR DESCRIPTION
## Summary
- Fix `--usermap` and `--groupmap` to concatenate multiple invocations instead of rejecting them
- Upstream rsync allows `--usermap=0:1000 --usermap=100:2000` (concatenated into single map)
- oc-rsync was incorrectly rejecting with "You can only specify --usermap once"

## Changes
- `transfer_behavior_options.rs`: Changed ArgAction to Append for both flags
- `parser.rs`: Added `join_os_values()` helper to concatenate with commas
- Updated tests to expect concatenation instead of errors

## Test plan
- [x] All 22065 tests pass
- [x] 40 usermap/groupmap-specific tests pass
- [x] cargo fmt + clippy clean