### PR TITLE
chore: remove dead simd = [] feature flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,10 +272,10 @@ jobs:
           tool: cargo-nextest
 
       - name: Build
-        run: cargo build --workspace --target x86_64-unknown-linux-musl --no-default-features --features "zstd,lz4,xattr,iconv,simd,parallel,copy_file_range"
+        run: cargo build --workspace --target x86_64-unknown-linux-musl --no-default-features --features "zstd,lz4,xattr,iconv,parallel,copy_file_range"
 
       - name: Test
-        run: cargo nextest run --workspace --target x86_64-unknown-linux-musl --no-default-features --features "zstd,lz4,xattr,iconv,simd,parallel,copy_file_range"
+        run: cargo nextest run --workspace --target x86_64-unknown-linux-musl --no-default-features --features "zstd,lz4,xattr,iconv,parallel,copy_file_range"
 
       - name: Verify static linking
         run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,6 @@ default = [
     "acl",
     "xattr",
     "iconv",
-    "simd",
     "parallel",
     "copy_file_range",
 ]
@@ -57,10 +56,6 @@ iconv = ["core/iconv"]
 # ============================================================================
 # Performance Optimization Features
 # ============================================================================
-
-# SIMD-accelerated checksums - reserved for future use
-# XXH3 SIMD is now always compiled in (the xxh3 crate has its own runtime detection)
-simd = []
 
 # Parallel processing with rayon - enables multi-core file operations
 # Requirements: None (pure Rust)


### PR DESCRIPTION
## Summary
- Remove empty `simd = []` feature from workspace Cargo.toml default features
- Remove `simd` from CI musl build feature flags
- SIMD code uses `#[cfg(target_arch)]` and runtime CPU detection, not Cargo features

## Test plan
- [ ] CI passes (fmt, clippy, nextest on all platforms)