### PR TITLE
fix: move global directives before [module] section in rsyncd.conf

### DIFF
--- a/scripts/rsync-interop-server.sh
+++ b/scripts/rsync-interop-server.sh
@@ -311,8 +311,6 @@ ensure_upstream_build() {
 write_rust_daemon_conf() {
   local path=$1 pid_file=$2 port=$3 dest=$4 comment=$5
   cat >"${path}" <<CONF
-[daemon]
-path = ${dest}
 pid file = ${pid_file}
 port = ${port}
 use chroot = false

--- a/tools/ci/run_interop.sh
+++ b/tools/ci/run_interop.sh
@@ -410,8 +410,6 @@ write_rust_daemon_conf() {
   local comment=$5
 
   cat >"$path" <<CONF
-[daemon]
-path = ${dest}
 pid file = ${pid_file}
 port = ${port}
 use chroot = false

--- a/xtask/src/commands/benchmark.rs
+++ b/xtask/src/commands/benchmark.rs
@@ -1093,12 +1093,10 @@ fn start_loopback_daemon(
     let pid_path = bench_dir.join(format!("loopback-{name}.pid"));
     let log_path = bench_dir.join(format!("loopback-{name}.log"));
 
-    // Write daemon config (oc-rsync requires [daemon] section, upstream uses bare directives)
+    // Write daemon config: global directives before any [module] section
     let config = if is_oc_rsync {
         format!(
-            r#"[daemon]
-path = {data}
-pid file = {pid}
+            r#"pid file = {pid}
 log file = {log}
 port = {port}
 use chroot = false


### PR DESCRIPTION
## Summary
- Remove erroneous `[daemon]` section placed before global directives in rsyncd.conf templates
- Affects interop test scripts and benchmark loopback daemon config

## Test plan
- [ ] CI passes
- [ ] Interop tests run correctly