### PR TITLE
fix: use sentinel-based detection for human-readable flag counting

### DIFF
--- a/crates/cli/src/frontend/command_builder/sections/build_base_command.rs
+++ b/crates/cli/src/frontend/command_builder/sections/build_base_command.rs
@@ -20,7 +20,7 @@ pub(crate) fn build_base_command(program_name: &'static str) -> ClapCommand {
                         "Output numbers in a human-readable format; optional LEVEL selects 0, 1, or 2. Can be repeated to increase level.",
                     )
                     .num_args(0..=1)
-                    .default_missing_value("1")
+                    .default_missing_value("__h_count__")
                     .require_equals(true)
                     .value_parser(OsStringValueParser::new())
                     .action(ArgAction::Append)


### PR DESCRIPTION
## Summary
- Replace fragile value-counting logic for -h/--human-readable with sentinel approach
- Bare flags emit __h_count__ sentinel and are counted separately
- Explicit values (--human-readable=2) set the level directly
- Prevents false level escalation when --human-readable=1 repeated
- Add comprehensive tests for all combinations

## Test plan
- [ ] CI passes (fmt, clippy, nextest)
- [ ] Single -h = Enabled, double -hh = Combined
- [ ] --human-readable=1 twice stays Enabled (not Combined)