### PR TITLE
fix: use %-15s alignment for daemon module listing

### DIFF
--- a/crates/daemon/src/daemon/sections/module_access.rs
+++ b/crates/daemon/src/daemon/sections/module_access.rs
@@ -39,14 +39,9 @@ fn respond_with_module_list(
             continue;
         }
 
-        let mut line = module.name.clone();
-        if let Some(comment) = &module.comment
-            && !comment.is_empty()
-        {
-            line.push('\t');
-            line.push_str(comment);
-        }
-        line.push('\n');
+        // upstream: clientserver.c:1254 — io_printf(fd, "%-15s\t%s\n", lp_name(i), lp_comment(i));
+        let comment = module.comment.as_deref().unwrap_or("");
+        let line = format!("{:<15}\t{}\n", module.name, comment);
         write_limited(stream, limiter, line.as_bytes())?;
     }
 

--- a/crates/daemon/src/tests/chunks/daemon_negotiation_module_listing.rs
+++ b/crates/daemon/src/tests/chunks/daemon_negotiation_module_listing.rs
@@ -49,10 +49,10 @@ fn daemon_negotiation_module_list_sends_capabilities_before_ok() {
     reader.read_line(&mut line).expect("ok line");
     assert_eq!(line, "@RSYNCD: OK\n");
 
-    // Read module listing
+    // Read module listing — upstream: clientserver.c:1254 uses %-15s\t%s\n format
     line.clear();
     reader.read_line(&mut line).expect("module listing");
-    assert!(line.starts_with("test"), "Expected module, got: {line}");
+    assert_eq!(line, "test           \t\n", "Expected %-15s aligned module, got: {line}");
 
     // Read exit
     line.clear();
@@ -184,10 +184,10 @@ fn daemon_negotiation_module_list_includes_comments() {
     line.clear();
     reader.read_line(&mut line).expect("module");
 
-    // Module line should contain name and comment separated by tab
-    assert!(
-        line.contains("mymod") && line.contains("This is a comment"),
-        "Module listing should include comment, got: {line}"
+    // upstream: clientserver.c:1254 — %-15s\t%s\n format
+    assert_eq!(
+        line, "mymod          \tThis is a comment\n",
+        "Module listing should use %-15s alignment, got: {line}"
     );
 
     drop(reader);

--- a/crates/daemon/src/tests/chunks/run_daemon_enforces_bwlimit_during_module_list.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_enforces_bwlimit_during_module_list.rs
@@ -50,12 +50,12 @@ fn run_daemon_enforces_bwlimit_during_module_list() {
 
     line.clear();
     reader.read_line(&mut line).expect("first module");
-    assert_eq!(line.trim_end(), format!("docs\t{comment}"));
+    assert_eq!(line, format!("docs           \t{comment}\n"));
     total_bytes += line.len();
 
     line.clear();
     reader.read_line(&mut line).expect("second module");
-    assert_eq!(line.trim_end(), "logs");
+    assert_eq!(line, "logs           \t\n");
     total_bytes += line.len();
 
     line.clear();

--- a/crates/daemon/src/tests/chunks/run_daemon_filters_modules_during_list_request.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_filters_modules_during_list_request.rs
@@ -45,7 +45,7 @@ fn run_daemon_filters_modules_during_list_request() {
 
     line.clear();
     reader.read_line(&mut line).expect("public module");
-    assert_eq!(line.trim_end(), "public");
+    assert_eq!(line, "public         \t\n");
 
     line.clear();
     reader

--- a/crates/daemon/src/tests/chunks/run_daemon_lists_modules_on_request.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_lists_modules_on_request.rs
@@ -40,11 +40,11 @@ fn run_daemon_lists_modules_on_request() {
 
     line.clear();
     reader.read_line(&mut line).expect("first module");
-    assert_eq!(line.trim_end(), "docs\tDocumentation");
+    assert_eq!(line, "docs           \tDocumentation\n");
 
     line.clear();
     reader.read_line(&mut line).expect("second module");
-    assert_eq!(line.trim_end(), "logs");
+    assert_eq!(line, "logs           \t\n");
 
     line.clear();
     reader.read_line(&mut line).expect("exit line");

--- a/crates/daemon/src/tests/chunks/run_daemon_lists_modules_with_motd_lines.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_lists_modules_with_motd_lines.rs
@@ -65,7 +65,7 @@ fn run_daemon_lists_modules_with_motd_lines() {
 
     line.clear();
     reader.read_line(&mut line).expect("module line");
-    assert_eq!(line.trim_end(), "docs");
+    assert_eq!(line, "docs           \t\n");
 
     line.clear();
     reader.read_line(&mut line).expect("exit line");

--- a/crates/daemon/src/tests/chunks/run_daemon_omits_unlisted_modules_from_listing.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_omits_unlisted_modules_from_listing.rs
@@ -47,7 +47,7 @@ fn run_daemon_omits_unlisted_modules_from_listing() {
 
     line.clear();
     reader.read_line(&mut line).expect("first module");
-    assert_eq!(line.trim_end(), "visible");
+    assert_eq!(line, "visible        \t\n");
 
     line.clear();
     reader.read_line(&mut line).expect("exit line");


### PR DESCRIPTION
## Summary
- Fix daemon module listing format to match upstream rsync's `%-15s\t%s\n` alignment from `clientserver.c:1254`
- Module names are now left-padded to 15 characters, always followed by tab and comment
- Updated 7 test files to assert exact wire format output

## Test plan
- [x] All 852 daemon tests pass
- [x] `cargo fmt` and `cargo clippy` pass
- [ ] CI passes on all platforms