### PR TITLE
fix: add symlink target length cap on receive

### DIFF
--- a/crates/protocol/src/flist/read.rs
+++ b/crates/protocol/src/flist/read.rs
@@ -587,6 +587,18 @@ impl FileListReader {
             return Ok(None);
         }
 
+        // upstream: rsync.h MAXPATHLEN — reject targets that exceed PATH_MAX to
+        // prevent unbounded allocation from a malicious sender.
+        if len > crate::wire::file_entry_decode::MAX_SYMLINK_TARGET_LEN {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "symlink target length {len} exceeds maximum {}",
+                    crate::wire::file_entry_decode::MAX_SYMLINK_TARGET_LEN
+                ),
+            ));
+        }
+
         let mut target_bytes = vec![0u8; len];
         reader.read_exact(&mut target_bytes)?;
 

--- a/crates/protocol/src/wire/mod.rs
+++ b/crates/protocol/src/wire/mod.rs
@@ -80,6 +80,8 @@ pub use self::file_entry::{
 
 // File entry wire format decoding
 pub use self::file_entry_decode::{
+    // Symlink safety limit
+    MAX_SYMLINK_TARGET_LEN,
     // Metadata decoding
     decode_atime,
     decode_checksum,


### PR DESCRIPTION
## Summary
- Add `MAX_SYMLINK_TARGET_LEN` constant (4096, matching upstream `MAXPATHLEN`)
- Enforce length cap in `decode_symlink_target()` and `FileListReader::read_symlink_target()`
- Prevents unbounded memory allocation from malicious sender claiming arbitrary symlink target length
- Update integration tests to verify rejection of oversized targets (8192 and 65535 bytes)

Closes #319

## Test plan
- [x] `decode_symlink_target_at_max_length` - target at exactly 4096 bytes passes
- [x] `decode_symlink_target_exceeding_max_length` - target at 4097 bytes rejected
- [x] `decode_symlink_target_far_exceeding_max_length` - 1 MiB target rejected
- [x] `flist_rejects_exceeding_path_max_target` - 8192-byte target rejected via flist reader
- [x] `flist_rejects_65535_byte_target` - 65535-byte target rejected
- [x] `cargo fmt` and `cargo clippy` pass clean