### PR TITLE
fix: make daemon greeting digest list protocol-version-aware

### DIFF
--- a/crates/daemon/src/auth.rs
+++ b/crates/daemon/src/auth.rs
@@ -119,7 +119,7 @@
 
 pub use core::auth::{
     DaemonAuthDigest, SUPPORTED_DAEMON_DIGESTS,
-    compute_daemon_auth_response as compute_auth_response,
+    compute_daemon_auth_response as compute_auth_response, digests_for_protocol,
     verify_daemon_auth_response as verify_client_response,
 };
 

--- a/crates/daemon/src/daemon.rs
+++ b/crates/daemon/src/daemon.rs
@@ -47,7 +47,7 @@ use std::os::unix::fs::PermissionsExt;
 use checksums::strong::Md5;
 use clap::{Arg, ArgAction, Command, builder::OsStringValueParser};
 use core::{
-    auth::{SUPPORTED_DAEMON_DIGESTS, verify_daemon_auth_response},
+    auth::{digests_for_protocol, verify_daemon_auth_response},
     bandwidth::{
         BandwidthLimitComponents, BandwidthLimiter, BandwidthParseError, LimiterChange,
         parse_bandwidth_limit,

--- a/crates/daemon/src/tests.rs
+++ b/crates/daemon/src/tests.rs
@@ -45,6 +45,7 @@ use crate::daemon::{
     format_connection_status,
     // From sections/delegation.rs
     legacy_daemon_greeting,
+    legacy_daemon_greeting_for_protocol,
     log_module_bandwidth_change,
     module_peer_hostname,
     open_log_sink,
@@ -121,6 +122,7 @@ include!("tests/chunks/first_existing_config_path_prefers_primary_candidate.rs")
 include!("tests/chunks/first_existing_config_path_returns_none_when_absent.rs");
 include!("tests/chunks/format_bandwidth_rate_prefers_largest_whole_unit.rs");
 include!("tests/chunks/help_flag_renders_static_help_snapshot.rs");
+include!("tests/chunks/legacy_daemon_greeting_digest_list_varies_by_protocol.rs");
 include!("tests/chunks/legacy_daemon_greeting_has_single_newline.rs");
 include!("tests/chunks/legacy_daemon_greeting_includes_version_and_digests.rs");
 include!("tests/chunks/log_module_bandwidth_change_ignores_unchanged.rs");

--- a/crates/daemon/src/tests/chunks/legacy_daemon_greeting_digest_list_varies_by_protocol.rs
+++ b/crates/daemon/src/tests/chunks/legacy_daemon_greeting_digest_list_varies_by_protocol.rs
@@ -1,0 +1,123 @@
+/// Protocol 32 greeting includes all five supported digest algorithms.
+///
+/// upstream: csprotocol.txt — protocol 32 requires the digest list and all
+/// algorithms introduced through protocol 31 (SHA-512, SHA-256, SHA-1) are
+/// present alongside MD5 and MD4.
+#[test]
+fn legacy_daemon_greeting_protocol_32_includes_all_digests() {
+    let greeting = legacy_daemon_greeting_for_protocol(ProtocolVersion::V32);
+
+    assert!(greeting.starts_with("@RSYNCD: 32.0"));
+    assert!(greeting.ends_with('\n'));
+
+    let trimmed = greeting.trim_end();
+    let after_version = trimmed
+        .strip_prefix("@RSYNCD: 32.0 ")
+        .expect("expected digest list after version");
+    let digests: Vec<&str> = after_version.split_whitespace().collect();
+
+    assert_eq!(
+        digests,
+        vec!["sha512", "sha256", "sha1", "md5", "md4"],
+        "protocol 32 must advertise all five digests in preference order"
+    );
+}
+
+/// Protocol 31 greeting includes all five supported digest algorithms.
+///
+/// SHA-family digests were introduced alongside protocol 31 (rsync 3.2.7).
+#[test]
+fn legacy_daemon_greeting_protocol_31_includes_all_digests() {
+    let greeting = legacy_daemon_greeting_for_protocol(ProtocolVersion::V31);
+
+    assert!(greeting.starts_with("@RSYNCD: 31.0"));
+    assert!(greeting.ends_with('\n'));
+
+    let trimmed = greeting.trim_end();
+    let after_version = trimmed
+        .strip_prefix("@RSYNCD: 31.0 ")
+        .expect("expected digest list after version");
+    let digests: Vec<&str> = after_version.split_whitespace().collect();
+
+    assert_eq!(
+        digests,
+        vec!["sha512", "sha256", "sha1", "md5", "md4"],
+        "protocol 31 must advertise all five digests"
+    );
+}
+
+/// Protocol 30 greeting includes only MD5 and MD4 — SHA-family digests were
+/// not available before protocol 31.
+///
+/// upstream: csprotocol.txt — protocol 30-31 default to "md5" when the digest
+/// list is absent.
+#[test]
+fn legacy_daemon_greeting_protocol_30_includes_md5_and_md4_only() {
+    let greeting = legacy_daemon_greeting_for_protocol(ProtocolVersion::V30);
+
+    assert!(greeting.starts_with("@RSYNCD: 30.0"));
+    assert!(greeting.ends_with('\n'));
+
+    let trimmed = greeting.trim_end();
+    let after_version = trimmed
+        .strip_prefix("@RSYNCD: 30.0 ")
+        .expect("expected digest list after version");
+    let digests: Vec<&str> = after_version.split_whitespace().collect();
+
+    assert_eq!(
+        digests,
+        vec!["md5", "md4"],
+        "protocol 30 must only advertise md5 and md4"
+    );
+
+    assert!(
+        !trimmed.contains("sha512"),
+        "protocol 30 must not include sha512"
+    );
+    assert!(
+        !trimmed.contains("sha256"),
+        "protocol 30 must not include sha256"
+    );
+    assert!(
+        !trimmed.contains("sha1"),
+        "protocol 30 must not include sha1"
+    );
+}
+
+/// Protocol 29 greeting omits the digest list entirely.
+///
+/// Pre-protocol-30 clients do not expect a digest list in the greeting. They
+/// assume MD4 by convention (upstream: csprotocol.txt).
+#[test]
+fn legacy_daemon_greeting_protocol_29_omits_digest_list() {
+    let greeting = legacy_daemon_greeting_for_protocol(ProtocolVersion::V29);
+
+    assert_eq!(
+        greeting, "@RSYNCD: 29.0\n",
+        "pre-protocol-30 greeting must not include a digest list"
+    );
+}
+
+/// Protocol 28 greeting omits the digest list entirely.
+#[test]
+fn legacy_daemon_greeting_protocol_28_omits_digest_list() {
+    let greeting = legacy_daemon_greeting_for_protocol(ProtocolVersion::V28);
+
+    assert_eq!(
+        greeting, "@RSYNCD: 28.0\n",
+        "protocol 28 greeting must not include a digest list"
+    );
+}
+
+/// The default greeting (no explicit version) uses the newest protocol and
+/// matches the output of the version-parameterised variant.
+#[test]
+fn legacy_daemon_greeting_default_matches_newest_protocol() {
+    let default = legacy_daemon_greeting();
+    let explicit = legacy_daemon_greeting_for_protocol(ProtocolVersion::NEWEST);
+
+    assert_eq!(
+        default, explicit,
+        "default greeting must match newest-protocol greeting"
+    );
+}


### PR DESCRIPTION
## Summary
- Add `digests_for_protocol()` returning supported auth digests based on negotiated protocol version
- Protocol >= 31: all 5 digests (sha512, sha256, sha1, md5, md4) per upstream csprotocol.txt
- Protocol 30: md5 and md4 only (MD5 introduced in protocol 30)
- Protocol < 30: md4 only, no digest list in greeting
- Previously greeting unconditionally included all five digests

Closes #330

## Test plan
- [x] 5 unit tests for `digests_for_protocol()` covering each protocol version boundary
- [x] 6 integration tests for version-aware greeting output
- [x] All 896 daemon tests pass
- [x] `cargo fmt` and `cargo clippy` pass clean