### PR TITLE
fix: accumulate MSG_IO_ERROR in multiplex reader

### DIFF
--- a/crates/transfer/src/compressed_reader.rs
+++ b/crates/transfer/src/compressed_reader.rs
@@ -81,6 +81,20 @@ impl<R: Read> CompressedReader<R> {
         Ok(Self { decoder })
     }
 
+    /// Returns a mutable reference to the underlying reader.
+    ///
+    /// This is used to access the `MultiplexReader`'s `take_io_error()` method
+    /// when the compressed reader wraps a multiplex stream.
+    pub fn get_mut(&mut self) -> &mut R {
+        match &mut self.decoder {
+            DecoderVariant::Zlib(decoder) => decoder.get_mut(),
+            #[cfg(feature = "lz4")]
+            DecoderVariant::Lz4(decoder) => decoder.get_mut(),
+            #[cfg(feature = "zstd")]
+            DecoderVariant::Zstd(decoder) => decoder.get_mut(),
+        }
+    }
+
     /// Returns the number of compressed bytes read so far.
     #[must_use]
     pub const fn bytes_read(&self) -> u64 {


### PR DESCRIPTION
## Summary
- Add `io_error: i32` accumulator to `MultiplexReader` that OR's incoming `MSG_IO_ERROR` payloads (upstream `io.c:1521-1528`)
- Previously `MSG_IO_ERROR` messages were silently discarded in the catch-all `_ =>` arm
- Add `take_io_error()` to both `MultiplexReader` and `ServerReader` for retrieving accumulated I/O error flags
- Add `get_mut()` to `CompressedReader` for the compressed variant to delegate
- Payloads not exactly 4 bytes are silently ignored (matching upstream guard)

Closes #296

## Test plan
- [x] `multiplex_reader_accumulates_msg_io_error` - verifies OR accumulation of multiple messages
- [x] `multiplex_reader_io_error_wrong_payload_length_ignored` - non-4-byte payloads ignored
- [x] `server_reader_take_io_error_plain_returns_zero` - plain mode returns 0
- [x] `server_reader_take_io_error_multiplex_accumulates` - ServerReader wrapper delegates
- [x] `msg_io_error_round_trip_through_multiplex_layer` - full end-to-end round trip
- [x] `cargo fmt` and `cargo clippy` pass clean