### PR TITLE
feat: add AttrsFlags for selective time attribute application

### DIFF
--- a/crates/metadata/src/lib.rs
+++ b/crates/metadata/src/lib.rs
@@ -184,8 +184,8 @@ pub use acl_noop::sync_acls;
 pub use apply::{
     apply_directory_metadata, apply_directory_metadata_with_options, apply_file_metadata,
     apply_file_metadata_if_changed, apply_file_metadata_with_options,
-    apply_metadata_from_file_entry, apply_metadata_with_cached_stat, apply_symlink_metadata,
-    apply_symlink_metadata_with_options,
+    apply_metadata_from_file_entry, apply_metadata_with_attrs_flags,
+    apply_metadata_with_cached_stat, apply_symlink_metadata, apply_symlink_metadata_with_options,
 };
 #[cfg(unix)]
 pub use apply::{apply_file_metadata_with_fd, apply_file_metadata_with_fd_if_changed};
@@ -200,7 +200,7 @@ pub use mapping::{GroupMapping, MappingKind, MappingParseError, NameMapping, Use
 #[cfg(not(unix))]
 pub use mapping_win::{GroupMapping, MappingKind, MappingParseError, NameMapping, UserMapping};
 
-pub use options::MetadataOptions;
+pub use options::{AttrsFlags, MetadataOptions};
 
 pub use special::{create_device_node, create_fifo};
 

--- a/crates/metadata/src/options.rs
+++ b/crates/metadata/src/options.rs
@@ -1,6 +1,160 @@
 use crate::chmod::ChmodModifiers;
 use crate::{GroupMapping, UserMapping};
 
+/// Bitflags controlling which time-related attributes to skip or force when
+/// applying metadata.
+///
+/// These flags mirror upstream rsync's `ATTRS_*` constants from `rsync.h:192-196`
+/// and are passed to `set_file_attrs()` to govern which timestamps are applied
+/// and under what tolerance. The default value (`empty()`) means "apply all
+/// requested time attributes normally using `modify_window` tolerance."
+///
+/// # Upstream Reference
+///
+/// - `rsync.h:192-196` - `ATTRS_REPORT`, `ATTRS_SKIP_MTIME`, `ATTRS_ACCURATE_TIME`,
+///   `ATTRS_SKIP_ATIME`, `ATTRS_SKIP_CRTIME`
+/// - `rsync.c:585-597` - Used in `set_file_attrs()` to conditionally apply mtime,
+///   atime, and crtime
+/// - `generator.c:1814` - `maybe_ATTRS_REPORT | maybe_ATTRS_ACCURATE_TIME` on quick-check
+///   match paths
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Hash)]
+pub struct AttrsFlags(u8);
+
+impl AttrsFlags {
+    /// Report attribute changes to the log. When set, `set_file_attrs` emits
+    /// verbose messages for unchanged files.
+    ///
+    /// Upstream: `rsync.h:192` — `ATTRS_REPORT (1<<0)`
+    pub const REPORT: Self = Self(1 << 0);
+
+    /// Skip modification time comparison and application entirely. When set,
+    /// `set_file_attrs` will not touch the destination's mtime regardless of
+    /// whether `preserve_times` is enabled.
+    ///
+    /// Upstream: `rsync.h:193` — `ATTRS_SKIP_MTIME (1<<1)`
+    pub const SKIP_MTIME: Self = Self(1 << 1);
+
+    /// Force exact time comparison instead of using `modify_window` tolerance.
+    /// Used after a transfer or checksum verification where the timestamp was
+    /// just set and should match precisely.
+    ///
+    /// Upstream: `rsync.h:194` — `ATTRS_ACCURATE_TIME (1<<2)`
+    pub const ACCURATE_TIME: Self = Self(1 << 2);
+
+    /// Skip access time comparison and application entirely. When set,
+    /// `set_file_attrs` will not touch the destination's atime regardless of
+    /// whether `preserve_atimes` is enabled.
+    ///
+    /// Upstream: `rsync.h:195` — `ATTRS_SKIP_ATIME (1<<3)`
+    pub const SKIP_ATIME: Self = Self(1 << 3);
+
+    /// Skip creation time comparison and application entirely. When set,
+    /// `set_file_attrs` will not touch the destination's crtime regardless of
+    /// whether `preserve_crtimes` is enabled.
+    ///
+    /// Upstream: `rsync.h:196` — `ATTRS_SKIP_CRTIME (1<<5)`
+    ///
+    /// Note: bit 4 is unused in upstream, matching the gap between
+    /// `ATTRS_SKIP_ATIME (1<<3)` and `ATTRS_SKIP_CRTIME (1<<5)`.
+    pub const SKIP_CRTIME: Self = Self(1 << 5);
+
+    /// Convenience constant combining all three time-skip flags.
+    ///
+    /// Used when directory times or link times should be omitted entirely.
+    ///
+    /// Upstream: `rsync.c:585` — `flags |= ATTRS_SKIP_MTIME | ATTRS_SKIP_ATIME | ATTRS_SKIP_CRTIME`
+    pub const SKIP_ALL_TIMES: Self =
+        Self(Self::SKIP_MTIME.0 | Self::SKIP_ATIME.0 | Self::SKIP_CRTIME.0);
+
+    /// Returns an empty flags value (no attributes skipped).
+    #[must_use]
+    pub const fn empty() -> Self {
+        Self(0)
+    }
+
+    /// Returns `true` when no flags are set.
+    #[must_use]
+    pub const fn is_empty(self) -> bool {
+        self.0 == 0
+    }
+
+    /// Returns the raw `u8` representation.
+    #[must_use]
+    pub const fn bits(self) -> u8 {
+        self.0
+    }
+
+    /// Creates flags from a raw `u8` value.
+    #[must_use]
+    pub const fn from_bits(bits: u8) -> Self {
+        Self(bits)
+    }
+
+    /// Returns `true` when the given flag is set.
+    #[must_use]
+    pub const fn contains(self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+
+    /// Returns the union of two flag sets.
+    #[must_use]
+    pub const fn union(self, other: Self) -> Self {
+        Self(self.0 | other.0)
+    }
+
+    /// Returns `true` when `ATTRS_SKIP_MTIME` is set.
+    #[must_use]
+    pub const fn skip_mtime(self) -> bool {
+        self.0 & Self::SKIP_MTIME.0 != 0
+    }
+
+    /// Returns `true` when `ATTRS_SKIP_ATIME` is set.
+    #[must_use]
+    pub const fn skip_atime(self) -> bool {
+        self.0 & Self::SKIP_ATIME.0 != 0
+    }
+
+    /// Returns `true` when `ATTRS_SKIP_CRTIME` is set.
+    #[must_use]
+    pub const fn skip_crtime(self) -> bool {
+        self.0 & Self::SKIP_CRTIME.0 != 0
+    }
+
+    /// Returns `true` when `ATTRS_ACCURATE_TIME` is set.
+    #[must_use]
+    pub const fn accurate_time(self) -> bool {
+        self.0 & Self::ACCURATE_TIME.0 != 0
+    }
+
+    /// Returns `true` when `ATTRS_REPORT` is set.
+    #[must_use]
+    pub const fn report(self) -> bool {
+        self.0 & Self::REPORT.0 != 0
+    }
+}
+
+impl std::ops::BitOr for AttrsFlags {
+    type Output = Self;
+
+    fn bitor(self, rhs: Self) -> Self {
+        Self(self.0 | rhs.0)
+    }
+}
+
+impl std::ops::BitOrAssign for AttrsFlags {
+    fn bitor_assign(&mut self, rhs: Self) {
+        self.0 |= rhs.0;
+    }
+}
+
+impl std::ops::BitAnd for AttrsFlags {
+    type Output = Self;
+
+    fn bitand(self, rhs: Self) -> Self {
+        Self(self.0 & rhs.0)
+    }
+}
+
 /// Options that control metadata preservation during copy operations.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct MetadataOptions {
@@ -275,6 +429,156 @@ impl Default for MetadataOptions {
 mod tests {
     use super::*;
     use crate::chmod::ChmodModifiers;
+
+    // ==================== AttrsFlags tests ====================
+
+    #[test]
+    fn attrs_flags_constants_match_upstream() {
+        // upstream rsync.h:192-196
+        assert_eq!(AttrsFlags::REPORT.bits(), 1 << 0);
+        assert_eq!(AttrsFlags::SKIP_MTIME.bits(), 1 << 1);
+        assert_eq!(AttrsFlags::ACCURATE_TIME.bits(), 1 << 2);
+        assert_eq!(AttrsFlags::SKIP_ATIME.bits(), 1 << 3);
+        assert_eq!(AttrsFlags::SKIP_CRTIME.bits(), 1 << 5);
+    }
+
+    #[test]
+    fn attrs_flags_skip_all_times_combines_three_skip_flags() {
+        let combined = AttrsFlags::SKIP_MTIME | AttrsFlags::SKIP_ATIME | AttrsFlags::SKIP_CRTIME;
+        assert_eq!(AttrsFlags::SKIP_ALL_TIMES, combined);
+        assert!(AttrsFlags::SKIP_ALL_TIMES.skip_mtime());
+        assert!(AttrsFlags::SKIP_ALL_TIMES.skip_atime());
+        assert!(AttrsFlags::SKIP_ALL_TIMES.skip_crtime());
+        assert!(!AttrsFlags::SKIP_ALL_TIMES.accurate_time());
+        assert!(!AttrsFlags::SKIP_ALL_TIMES.report());
+    }
+
+    #[test]
+    fn attrs_flags_empty_has_no_bits_set() {
+        let flags = AttrsFlags::empty();
+        assert!(flags.is_empty());
+        assert_eq!(flags.bits(), 0);
+        assert!(!flags.skip_mtime());
+        assert!(!flags.skip_atime());
+        assert!(!flags.skip_crtime());
+        assert!(!flags.accurate_time());
+        assert!(!flags.report());
+    }
+
+    #[test]
+    fn attrs_flags_default_is_empty() {
+        assert_eq!(AttrsFlags::default(), AttrsFlags::empty());
+    }
+
+    #[test]
+    fn attrs_flags_from_bits_round_trips() {
+        let flags = AttrsFlags::SKIP_MTIME | AttrsFlags::ACCURATE_TIME;
+        let raw = flags.bits();
+        assert_eq!(AttrsFlags::from_bits(raw), flags);
+    }
+
+    #[test]
+    fn attrs_flags_contains_checks_subset() {
+        let all = AttrsFlags::SKIP_ALL_TIMES;
+        assert!(all.contains(AttrsFlags::SKIP_MTIME));
+        assert!(all.contains(AttrsFlags::SKIP_ATIME));
+        assert!(all.contains(AttrsFlags::SKIP_CRTIME));
+        assert!(!all.contains(AttrsFlags::REPORT));
+        assert!(!all.contains(AttrsFlags::ACCURATE_TIME));
+    }
+
+    #[test]
+    fn attrs_flags_union_combines_flags() {
+        let a = AttrsFlags::REPORT;
+        let b = AttrsFlags::SKIP_MTIME;
+        let combined = a.union(b);
+        assert!(combined.report());
+        assert!(combined.skip_mtime());
+        assert!(!combined.skip_atime());
+    }
+
+    #[test]
+    fn attrs_flags_bitor_assign() {
+        let mut flags = AttrsFlags::empty();
+        flags |= AttrsFlags::SKIP_MTIME;
+        flags |= AttrsFlags::SKIP_ATIME;
+        assert!(flags.skip_mtime());
+        assert!(flags.skip_atime());
+        assert!(!flags.skip_crtime());
+    }
+
+    #[test]
+    fn attrs_flags_bitand_masks() {
+        let flags = AttrsFlags::SKIP_ALL_TIMES | AttrsFlags::REPORT;
+        let masked = flags & AttrsFlags::SKIP_MTIME;
+        assert!(masked.skip_mtime());
+        assert!(!masked.skip_atime());
+        assert!(!masked.report());
+    }
+
+    #[test]
+    fn attrs_flags_bit4_is_unused_gap() {
+        // upstream rsync.h has a gap between bit 3 (SKIP_ATIME) and bit 5
+        // (SKIP_CRTIME). Bit 4 is unused, matching upstream layout.
+        assert_eq!(AttrsFlags::SKIP_ATIME.bits(), 0x08);
+        assert_eq!(AttrsFlags::SKIP_CRTIME.bits(), 0x20);
+        // No constant occupies bit 4 (0x10)
+    }
+
+    #[test]
+    fn attrs_flags_individual_predicate_methods() {
+        assert!(AttrsFlags::REPORT.report());
+        assert!(!AttrsFlags::REPORT.skip_mtime());
+
+        assert!(AttrsFlags::SKIP_MTIME.skip_mtime());
+        assert!(!AttrsFlags::SKIP_MTIME.skip_atime());
+
+        assert!(AttrsFlags::ACCURATE_TIME.accurate_time());
+        assert!(!AttrsFlags::ACCURATE_TIME.skip_mtime());
+
+        assert!(AttrsFlags::SKIP_ATIME.skip_atime());
+        assert!(!AttrsFlags::SKIP_ATIME.skip_crtime());
+
+        assert!(AttrsFlags::SKIP_CRTIME.skip_crtime());
+        assert!(!AttrsFlags::SKIP_CRTIME.skip_mtime());
+    }
+
+    #[test]
+    fn attrs_flags_upstream_set_file_attrs_scenario() {
+        // Mirrors upstream rsync.c:583-593 logic for omit_dir_times / omit_link_times
+        // When dir/link times are omitted, all three time-skip flags are set.
+        let omit_times = AttrsFlags::SKIP_MTIME | AttrsFlags::SKIP_ATIME | AttrsFlags::SKIP_CRTIME;
+        assert_eq!(omit_times, AttrsFlags::SKIP_ALL_TIMES);
+
+        // When only mtime is not preserved, only SKIP_MTIME is set.
+        let no_preserve_mtime = AttrsFlags::SKIP_MTIME;
+        assert!(no_preserve_mtime.skip_mtime());
+        assert!(!no_preserve_mtime.skip_atime());
+        assert!(!no_preserve_mtime.skip_crtime());
+    }
+
+    #[test]
+    fn attrs_flags_upstream_accurate_time_with_report() {
+        // Mirrors upstream generator.c:1814 where quick-check match combines
+        // maybe_ATTRS_REPORT and maybe_ATTRS_ACCURATE_TIME.
+        let flags = AttrsFlags::REPORT | AttrsFlags::ACCURATE_TIME;
+        assert!(flags.report());
+        assert!(flags.accurate_time());
+        assert!(!flags.skip_mtime());
+    }
+
+    #[test]
+    fn attrs_flags_upstream_receiver_skip_all_when_not_ok_to_set_time() {
+        // Mirrors upstream rsync.c:749 and :774 where ok_to_set_time is false:
+        // ATTRS_SKIP_MTIME | ATTRS_SKIP_ATIME | ATTRS_SKIP_CRTIME
+        let flags = AttrsFlags::SKIP_MTIME | AttrsFlags::SKIP_ATIME | AttrsFlags::SKIP_CRTIME;
+        assert!(flags.skip_mtime());
+        assert!(flags.skip_atime());
+        assert!(flags.skip_crtime());
+        assert!(!flags.accurate_time());
+    }
+
+    // ==================== MetadataOptions tests ====================
 
     #[test]
     fn defaults_match_expected_configuration() {


### PR DESCRIPTION
## Summary
- Add `AttrsFlags` type with `SKIP_MTIME`, `SKIP_ATIME`, `SKIP_CRTIME`, `REPORT`, `ACCURATE_TIME` matching upstream `rsync.h:192-196`
- Add `SKIP_ALL_TIMES` convenience combination
- Add `apply_metadata_with_attrs_flags()` mirroring upstream `set_file_attrs()` (`rsync.c:574-625`)
- Refactor `apply_metadata_with_cached_stat()` to delegate with empty flags (backward compatible)
- Add `apply_atime_only_from_entry()` for `SKIP_MTIME` + preserve atime scenarios

Closes #291

## Test plan
- [x] 15 unit tests for `AttrsFlags` constant values, combinations, and upstream scenarios
- [x] 8 integration tests for `apply_metadata_with_attrs_flags()` covering skip behaviors
- [x] All 362 metadata tests pass, 3531 engine tests pass, 935 transfer tests pass
- [x] `cargo fmt` and `cargo clippy` pass clean