### PR TITLE
test: add inplace, append, delay-updates, compress-level, and files-from interop tests

### DIFF
--- a/crates/transfer/src/disk_commit/process.rs
+++ b/crates/transfer/src/disk_commit/process.rs
@@ -205,11 +205,16 @@ fn open_output_file(
         Ok((file, TempFileGuard::new(begin.file_path.clone()), false))
     } else if begin.is_inplace {
         // upstream: receiver.c:855 - do_open(fname, O_WRONLY|O_CREAT, 0600)
-        let file = fs::OpenOptions::new()
+        let mut file = fs::OpenOptions::new()
             .write(true)
             .create(true)
             .truncate(false)
             .open(&begin.file_path)?;
+        // upstream: receiver.c:307-308 - in append mode, seek past existing content
+        if begin.append_offset > 0 {
+            use std::io::Seek;
+            file.seek(io::SeekFrom::Start(begin.append_offset))?;
+        }
         Ok((file, TempFileGuard::new(begin.file_path.clone()), false))
     } else {
         let (file, guard) = open_tmpfile(&begin.file_path, config.temp_dir.as_deref())?;
@@ -251,8 +256,15 @@ fn commit_file(
         fs::rename(cleanup_guard.path(), &begin.file_path)?;
     } else if begin.is_inplace {
         // upstream: receiver.c:340 - set_file_length(fd, F_LENGTH(file))
+        // In append mode, bytes_written only counts newly received data -
+        // the full file size includes the existing content we seeked past.
+        let final_size = if begin.append_offset > 0 {
+            begin.target_size
+        } else {
+            bytes_written
+        };
         let file = fs::OpenOptions::new().write(true).open(&begin.file_path)?;
-        file.set_len(bytes_written)?;
+        file.set_len(final_size)?;
     }
     cleanup_guard.keep();
     Ok(())

--- a/crates/transfer/src/disk_commit/tests.rs
+++ b/crates/transfer/src/disk_commit/tests.rs
@@ -102,6 +102,7 @@ fn write_and_commit_file() {
             checksum_verifier: None,
             is_device_target: false,
             is_inplace: false,
+            append_offset: 0,
             xattr_list: None,
         })))
         .unwrap();
@@ -137,6 +138,7 @@ fn abort_cleans_up_temp_file() {
             checksum_verifier: None,
             is_device_target: false,
             is_inplace: false,
+            append_offset: 0,
             xattr_list: None,
         })))
         .unwrap();
@@ -222,6 +224,7 @@ fn multi_chunk_file() {
             checksum_verifier: None,
             is_device_target: false,
             is_inplace: false,
+            append_offset: 0,
             xattr_list: None,
         })))
         .unwrap();
@@ -254,6 +257,7 @@ fn buffer_recycling() {
             checksum_verifier: None,
             is_device_target: false,
             is_inplace: false,
+            append_offset: 0,
             xattr_list: None,
         })))
         .unwrap();

--- a/crates/transfer/src/disk_commit/tests.rs
+++ b/crates/transfer/src/disk_commit/tests.rs
@@ -178,6 +178,7 @@ fn multiple_files_sequential() {
                 checksum_verifier: None,
                 is_device_target: false,
                 is_inplace: false,
+                append_offset: 0,
                 xattr_list: None,
             })))
             .unwrap();
@@ -299,6 +300,7 @@ fn whole_file_coalesced() {
                 checksum_verifier: None,
                 is_device_target: false,
                 is_inplace: false,
+                append_offset: 0,
                 xattr_list: None,
             }),
             data: b"whole dat".to_vec(),

--- a/crates/transfer/src/pipeline/messages.rs
+++ b/crates/transfer/src/pipeline/messages.rs
@@ -76,6 +76,15 @@ pub struct BeginMessage {
     /// (created if absent) and truncated to target size after delta
     /// application. Preserves the destination inode.
     pub is_inplace: bool,
+    /// Byte offset at which to start writing in append mode.
+    ///
+    /// When non-zero, the output file is seeked to this offset before writing
+    /// delta data. The sender only sends bytes beyond this offset.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `receiver.c:307-308` - `offset = sum.flength; do_lseek(fd, offset, SEEK_SET)`
+    pub append_offset: u64,
     /// Xattr list resolved from the wire protocol cache for this file.
     ///
     /// When `Some`, the disk thread applies these xattrs after metadata

--- a/crates/transfer/src/pipeline/receiver.rs
+++ b/crates/transfer/src/pipeline/receiver.rs
@@ -391,6 +391,7 @@ mod tests {
                 checksum_verifier: None,
                 is_device_target: false,
                 is_inplace: false,
+                append_offset: 0,
                 xattr_list: None,
             })))
             .unwrap();
@@ -599,6 +600,7 @@ mod tests {
                     checksum_verifier: None,
                     is_device_target: false,
                     is_inplace: false,
+                    append_offset: 0,
                     xattr_list: None,
                 }),
                 data: b"test data".to_vec(),

--- a/crates/transfer/src/receiver/transfer.rs
+++ b/crates/transfer/src/receiver/transfer.rs
@@ -202,8 +202,11 @@ impl ReceiverContext {
             };
             sum_head.write(&mut *writer)?;
 
-            if let Some(ref signature) = signature_opt {
-                write_signature_blocks(&mut *writer, signature, sum_head.s2length)?;
+            // upstream: generator.c:775-776 - skip signature blocks in append mode
+            if !self.config.flags.append {
+                if let Some(ref signature) = signature_opt {
+                    write_signature_blocks(&mut *writer, signature, sum_head.s2length)?;
+                }
             }
             writer.flush()?;
 

--- a/crates/transfer/src/receiver/transfer/pipeline.rs
+++ b/crates/transfer/src/receiver/transfer/pipeline.rs
@@ -88,6 +88,7 @@ impl ReceiverContext {
             want_xattr_optim: self.compat_flags.is_some_and(|f| {
                 f.contains(protocol::CompatibilityFlags::AVOID_XATTR_OPTIMIZATION)
             }),
+            append: self.config.flags.append,
         };
 
         // Create the token reader once for the entire transfer session.

--- a/crates/transfer/src/receiver/wire.rs
+++ b/crates/transfer/src/receiver/wire.rs
@@ -66,6 +66,27 @@ impl SumHead {
         }
     }
 
+    /// Computes the total file length described by this sum_head.
+    ///
+    /// Used in append mode to determine the offset at which to start writing
+    /// new data (the sender only sends bytes beyond this length).
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `receiver.c:289-291` - `sum.flength = count * blength; if (remainder) flength -= blength - remainder`
+    #[must_use]
+    pub const fn flength(&self) -> u64 {
+        if self.count == 0 {
+            return 0;
+        }
+        let total = self.count as u64 * self.blength as u64;
+        if self.remainder > 0 {
+            total - self.blength as u64 + self.remainder as u64
+        } else {
+            total
+        }
+    }
+
     /// Creates a `SumHead` from a file signature.
     #[must_use]
     pub const fn from_signature(signature: &FileSignature) -> Self {

--- a/crates/transfer/src/transfer_ops/mod.rs
+++ b/crates/transfer/src/transfer_ops/mod.rs
@@ -204,16 +204,27 @@ fn read_response_header<R: Read>(
         ));
     }
 
-    // Read echoed sum_head (we don't use it, but must consume it)
-    let _echoed_sum_head = SumHead::read(reader)?;
+    // Read echoed sum_head - needed for append mode offset calculation.
+    let echoed_sum_head = SumHead::read(reader)?;
 
     // Decompose pending transfer
     let (file_path, basis_path, signature, target_size) = pending.into_parts();
 
     // upstream: receiver.c:797 - one_inplace = inplace_partial && fnamecmp_type == FNAMECMP_PARTIAL_DIR
+    // upstream: receiver.c:855 - append mode implies inplace (write directly to destination,
+    // preserving existing content; sender only sends data beyond the existing length)
     let use_inplace = ctx.config.inplace
+        || ctx.config.append
         || (ctx.config.inplace_partial
             && sender_attrs.fnamecmp_type == Some(protocol::FnameCmpType::PartialDir));
+
+    // upstream: receiver.c:287-307 - in append mode, seek output fd to existing file length
+    // (derived from echoed sum_head) before writing new data
+    let append_offset = if ctx.config.append {
+        echoed_sum_head.flength()
+    } else {
+        0
+    };
 
     Ok(ResponseHeader {
         file_path,
@@ -221,6 +232,7 @@ fn read_response_header<R: Read>(
         signature,
         target_size,
         use_inplace,
+        append_offset,
         xattr_values: sender_attrs.xattr_values,
     })
 }
@@ -237,6 +249,15 @@ struct ResponseHeader {
     target_size: u64,
     /// Whether to write directly to the destination (inplace mode).
     use_inplace: bool,
+    /// Byte offset at which to start writing in append mode.
+    ///
+    /// Derived from the echoed sum_head: existing file length that the sender
+    /// skipped. Zero when not in append mode.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `receiver.c:307-308` - `offset = sum.flength; do_lseek(fd, offset, SEEK_SET)`
+    append_offset: u64,
     /// Abbreviated xattr values from the sender (1-based num, value pairs).
     ///
     /// Non-empty only when the sender included `ITEM_REPORT_XATTR` in iflags.

--- a/crates/transfer/src/transfer_ops/mod.rs
+++ b/crates/transfer/src/transfer_ops/mod.rs
@@ -126,6 +126,17 @@ pub struct RequestConfig<'a> {
     ///
     /// - `compat.c` - `want_xattr_optim` set from capability negotiation
     pub want_xattr_optim: bool,
+    /// Whether append mode is active (`--append`).
+    ///
+    /// When true, signature blocks are NOT written after sum_head. The sender
+    /// uses sum_head fields to calculate existing file length and only sends
+    /// data appended beyond that point.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `generator.c:775-776` - generator skips writing signature blocks in append mode
+    /// - `sender.c:87-92` - `receive_sums()` returns early without reading blocks
+    pub append: bool,
 }
 
 impl RequestConfig<'_> {
@@ -257,6 +268,7 @@ mod tests {
             io_uring_policy: fast_io::IoUringPolicy::Auto,
             preserve_xattrs: false,
             want_xattr_optim: false,
+            append: false,
         };
         let debug_str = format!("{config:?}");
         assert!(debug_str.contains("RequestConfig"));

--- a/crates/transfer/src/transfer_ops/request.rs
+++ b/crates/transfer/src/transfer_ops/request.rs
@@ -129,9 +129,14 @@ pub fn send_file_request_xattr<W: Write + ?Sized>(
     };
     sum_head.write(writer)?;
 
-    // Write signature blocks if we have a signature
-    if let Some(ref sig) = signature {
-        write_signature_blocks(writer, sig, sum_head.s2length)?;
+    // Write signature blocks if we have a signature.
+    // upstream: generator.c:775-776 - in append mode, generator skips writing
+    // signature blocks after sum_head. The sender's receive_sums() (sender.c:87-92)
+    // returns early without reading blocks, using sum_head to calculate existing length.
+    if !config.append {
+        if let Some(ref sig) = signature {
+            write_signature_blocks(writer, sig, sum_head.s2length)?;
+        }
     }
     // No flush here - the pipeline loop flushes before blocking on response
     // reads. Per-file flushes defeat buffer batching, causing 1 sendto per

--- a/crates/transfer/src/transfer_ops/response.rs
+++ b/crates/transfer/src/transfer_ops/response.rs
@@ -10,7 +10,7 @@
 //! - `receiver.c:receive_data()` applies delta tokens
 
 use std::fs;
-use std::io::{self, Read, Write};
+use std::io::{self, Read, Seek, Write};
 
 use fast_io::FileWriter;
 
@@ -75,7 +75,7 @@ pub fn process_file_response<R: Read>(
     let use_inplace = header.use_inplace;
 
     // Inplace: write directly to destination. Otherwise temp+rename for atomicity.
-    let (file, mut cleanup_guard, needs_rename) = if use_inplace {
+    let (mut file, mut cleanup_guard, needs_rename) = if use_inplace {
         // upstream: receiver.c:855 - do_open(fname, O_WRONLY|O_CREAT, 0600)
         let f = fs::OpenOptions::new()
             .write(true)
@@ -91,6 +91,13 @@ pub fn process_file_response<R: Read>(
         let (f, guard) = open_tmpfile(&file_path, ctx.config.temp_dir)?;
         (f, guard, true)
     };
+
+    // upstream: receiver.c:307-308 - in append mode, seek past existing content
+    // so new data is written at the end of the file
+    let append_offset = header.append_offset;
+    if append_offset > 0 {
+        file.seek(io::SeekFrom::Start(append_offset))?;
+    }
 
     // Use io_uring when available (Linux 5.6+), falling back to BufWriter.
     // Buffer capacity is adaptive based on file size:
@@ -273,8 +280,15 @@ pub fn process_file_response<R: Read>(
     } else if ctx.config.inplace {
         // Inplace: truncate to final size.
         // upstream: receiver.c:340 - set_file_length(fd, F_LENGTH(file))
+        // In append mode, total_bytes only counts newly received data -
+        // the full file size includes the existing content we seeked past.
+        let final_size = if append_offset > 0 {
+            target_size
+        } else {
+            total_bytes
+        };
         let file = fs::OpenOptions::new().write(true).open(&file_path)?;
-        file.set_len(total_bytes)?;
+        file.set_len(final_size)?;
     }
     cleanup_guard.keep();
 

--- a/crates/transfer/src/transfer_ops/streaming.rs
+++ b/crates/transfer/src/transfer_ops/streaming.rs
@@ -100,6 +100,7 @@ pub fn process_file_response_streaming<R: Read>(
         is_device_target,
         // upstream: receiver.c:797 - one_inplace = inplace_partial && fnamecmp_type == FNAMECMP_PARTIAL_DIR
         is_inplace: header.use_inplace,
+        append_offset: header.append_offset,
         xattr_list,
     });
 

--- a/tools/ci/run_interop.sh
+++ b/tools/ci/run_interop.sh
@@ -1537,8 +1537,9 @@ run_ssh_interop_test() {
 }
 
 # Remaining known failures:
-# (none - all interop tests passing)
+# standalone:append - daemon receiver sends invalid NDX during --append second sync
 KNOWN_FAILURES=(
+  "standalone:append"
 )
 
 is_known_failure() {

--- a/tools/ci/run_interop.sh
+++ b/tools/ci/run_interop.sh
@@ -1537,9 +1537,8 @@ run_ssh_interop_test() {
 }
 
 # Remaining known failures:
-# standalone:append - daemon receiver sends invalid NDX during --append second sync
+# (none - all interop tests passing)
 KNOWN_FAILURES=(
-  "standalone:append"
 )
 
 is_known_failure() {

--- a/tools/ci/run_interop.sh
+++ b/tools/ci/run_interop.sh
@@ -3996,6 +3996,378 @@ CONF
   return 0
 }
 
+# Inplace daemon push interop test.
+# Upstream rsync pushes files with --inplace to an oc-rsync daemon. The
+# destination is pre-populated with smaller versions of the same files so
+# delta transfer exercises the in-place write path.
+test_inplace() {
+  local upstream_binary=$1 oc_bin=$2 src_dir=$3 work=$4 log=$5 \
+        oc_port=$6 upstream_port=$7
+
+  local ip_src="${work}/inplace-src"
+  local ip_dest="${work}/inplace-dest"
+  rm -rf "$ip_src" "$ip_dest"
+  mkdir -p "$ip_src" "$ip_dest"
+
+  # Create source files with known content
+  dd if=/dev/urandom of="$ip_src/data.bin" bs=1K count=64 2>/dev/null
+  echo "inplace test alpha content full version" > "$ip_src/alpha.txt"
+  mkdir -p "$ip_src/sub"
+  echo "inplace nested content full" > "$ip_src/sub/nested.txt"
+
+  # Pre-populate dest with smaller versions to exercise delta inplace write
+  echo "small" > "$ip_dest/data.bin"
+  echo "short" > "$ip_dest/alpha.txt"
+  mkdir -p "$ip_dest/sub"
+  echo "tiny" > "$ip_dest/sub/nested.txt"
+
+  # Start oc-rsync daemon
+  local ip_conf="${work}/inplace-oc.conf"
+  local ip_pid="${work}/inplace-oc.pid"
+  local ip_log="${work}/inplace-oc.log"
+  cat > "$ip_conf" <<CONF
+pid file = ${ip_pid}
+port = ${oc_port}
+use chroot = false
+
+[interop]
+path = ${ip_dest}
+comment = inplace test
+read only = false
+numeric ids = yes
+CONF
+
+  start_oc_daemon "$ip_conf" "$ip_log" "$upstream_binary" "$ip_pid" "$oc_port"
+
+  # Push with --inplace
+  if ! timeout "$hard_timeout" "$upstream_binary" -av --inplace --timeout=10 \
+      "${ip_src}/" "rsync://127.0.0.1:${oc_port}/interop" \
+      >"${log}.inplace.out" 2>"${log}.inplace.err"; then
+    echo "    inplace push failed (exit=$?)"
+    stop_oc_daemon
+    return 1
+  fi
+
+  stop_oc_daemon
+
+  # Verify content integrity
+  if ! cmp -s "$ip_src/data.bin" "$ip_dest/data.bin"; then
+    echo "    data.bin content mismatch"
+    return 1
+  fi
+  if ! cmp -s "$ip_src/alpha.txt" "$ip_dest/alpha.txt"; then
+    echo "    alpha.txt content mismatch"
+    return 1
+  fi
+  if ! cmp -s "$ip_src/sub/nested.txt" "$ip_dest/sub/nested.txt"; then
+    echo "    sub/nested.txt content mismatch"
+    return 1
+  fi
+
+  return 0
+}
+
+# Append daemon push interop test.
+# Upstream rsync pushes a file, then extends it and pushes again with --append.
+# Verifies the destination file contains the original content plus appended data.
+test_append() {
+  local upstream_binary=$1 oc_bin=$2 src_dir=$3 work=$4 log=$5 \
+        oc_port=$6 upstream_port=$7
+
+  local ap_src="${work}/append-src"
+  local ap_dest="${work}/append-dest"
+  rm -rf "$ap_src" "$ap_dest"
+  mkdir -p "$ap_src" "$ap_dest"
+
+  # Create initial file
+  echo "original-line-1" > "$ap_src/logfile.txt"
+  echo "original-line-2" >> "$ap_src/logfile.txt"
+
+  # Start oc-rsync daemon
+  local ap_conf="${work}/append-oc.conf"
+  local ap_pid="${work}/append-oc.pid"
+  local ap_log="${work}/append-oc.log"
+  cat > "$ap_conf" <<CONF
+pid file = ${ap_pid}
+port = ${oc_port}
+use chroot = false
+
+[interop]
+path = ${ap_dest}
+comment = append test
+read only = false
+numeric ids = yes
+CONF
+
+  start_oc_daemon "$ap_conf" "$ap_log" "$upstream_binary" "$ap_pid" "$oc_port"
+
+  # First push - populate destination with initial content
+  if ! timeout "$hard_timeout" "$upstream_binary" -av --timeout=10 \
+      "${ap_src}/" "rsync://127.0.0.1:${oc_port}/interop" \
+      >"${log}.append-init.out" 2>"${log}.append-init.err"; then
+    echo "    initial append push failed (exit=$?)"
+    stop_oc_daemon
+    return 1
+  fi
+
+  # Extend the source file with more data
+  echo "appended-line-3" >> "$ap_src/logfile.txt"
+  echo "appended-line-4" >> "$ap_src/logfile.txt"
+
+  # Second push with --append
+  if ! timeout "$hard_timeout" "$upstream_binary" -av --append --timeout=10 \
+      "${ap_src}/" "rsync://127.0.0.1:${oc_port}/interop" \
+      >"${log}.append-update.out" 2>"${log}.append-update.err"; then
+    echo "    append push failed (exit=$?)"
+    stop_oc_daemon
+    return 1
+  fi
+
+  stop_oc_daemon
+
+  # Verify dest file has all content (original + appended)
+  if ! cmp -s "$ap_src/logfile.txt" "$ap_dest/logfile.txt"; then
+    echo "    logfile.txt content mismatch after append"
+    echo "    expected:"
+    cat "$ap_src/logfile.txt" 2>/dev/null | head -5
+    echo "    got:"
+    cat "$ap_dest/logfile.txt" 2>/dev/null | head -5
+    return 1
+  fi
+
+  return 0
+}
+
+# Delay-updates daemon push interop test.
+# Upstream rsync pushes files with --delay-updates to an oc-rsync daemon,
+# verifying atomic file placement works correctly.
+test_delay_updates() {
+  local upstream_binary=$1 oc_bin=$2 src_dir=$3 work=$4 log=$5 \
+        oc_port=$6 upstream_port=$7
+
+  local du_src="${work}/delay-updates-src"
+  local du_dest="${work}/delay-updates-dest"
+  rm -rf "$du_src" "$du_dest"
+  mkdir -p "$du_src" "$du_dest"
+
+  # Create source files
+  echo "delay-alpha-content" > "$du_src/alpha.txt"
+  echo "delay-beta-content" > "$du_src/beta.txt"
+  mkdir -p "$du_src/sub"
+  echo "delay-nested-content" > "$du_src/sub/nested.txt"
+  dd if=/dev/urandom of="$du_src/binary.dat" bs=1K count=32 2>/dev/null
+
+  # Start oc-rsync daemon
+  local du_conf="${work}/delay-updates-oc.conf"
+  local du_pid="${work}/delay-updates-oc.pid"
+  local du_log="${work}/delay-updates-oc.log"
+  cat > "$du_conf" <<CONF
+pid file = ${du_pid}
+port = ${oc_port}
+use chroot = false
+
+[interop]
+path = ${du_dest}
+comment = delay-updates test
+read only = false
+numeric ids = yes
+CONF
+
+  start_oc_daemon "$du_conf" "$du_log" "$upstream_binary" "$du_pid" "$oc_port"
+
+  # Push with --delay-updates
+  if ! timeout "$hard_timeout" "$upstream_binary" -av --delay-updates --timeout=10 \
+      "${du_src}/" "rsync://127.0.0.1:${oc_port}/interop" \
+      >"${log}.delay-updates.out" 2>"${log}.delay-updates.err"; then
+    echo "    delay-updates push failed (exit=$?)"
+    stop_oc_daemon
+    return 1
+  fi
+
+  stop_oc_daemon
+
+  # Verify all files transferred correctly
+  for f in alpha.txt beta.txt sub/nested.txt binary.dat; do
+    if [[ ! -f "$du_dest/$f" ]]; then
+      echo "    missing file: $f"
+      return 1
+    fi
+    if ! cmp -s "$du_src/$f" "$du_dest/$f"; then
+      echo "    content mismatch: $f"
+      return 1
+    fi
+  done
+
+  return 0
+}
+
+# Compress-level daemon push interop test.
+# Upstream rsync pushes compressible data with -z --compress-level=1 and
+# then --compress-level=9 to verify compression with explicit levels.
+test_compress_level() {
+  local upstream_binary=$1 oc_bin=$2 src_dir=$3 work=$4 log=$5 \
+        oc_port=$6 upstream_port=$7
+
+  local cl_src="${work}/compress-level-src"
+  local cl_dest="${work}/compress-level-dest"
+  rm -rf "$cl_src" "$cl_dest"
+  mkdir -p "$cl_src" "$cl_dest"
+
+  # Create compressible data (repeated patterns)
+  local i
+  for i in $(seq 1 200); do
+    echo "This is a highly compressible repeated line number ${i} with padding data" >> "$cl_src/compressible.txt"
+  done
+  echo "compress-level small file" > "$cl_src/small.txt"
+
+  # Start oc-rsync daemon
+  local cl_conf="${work}/compress-level-oc.conf"
+  local cl_pid="${work}/compress-level-oc.pid"
+  local cl_log="${work}/compress-level-oc.log"
+  cat > "$cl_conf" <<CONF
+pid file = ${cl_pid}
+port = ${oc_port}
+use chroot = false
+
+[interop]
+path = ${cl_dest}
+comment = compress-level test
+read only = false
+numeric ids = yes
+CONF
+
+  start_oc_daemon "$cl_conf" "$cl_log" "$upstream_binary" "$cl_pid" "$oc_port"
+
+  # Push with --compress-level=1
+  if ! timeout "$hard_timeout" "$upstream_binary" -avz --compress-level=1 --timeout=10 \
+      "${cl_src}/" "rsync://127.0.0.1:${oc_port}/interop" \
+      >"${log}.compress-level-1.out" 2>"${log}.compress-level-1.err"; then
+    echo "    compress-level=1 push failed (exit=$?)"
+    stop_oc_daemon
+    return 1
+  fi
+
+  # Verify files match after level 1
+  if ! cmp -s "$cl_src/compressible.txt" "$cl_dest/compressible.txt"; then
+    echo "    compressible.txt mismatch after level 1"
+    stop_oc_daemon
+    return 1
+  fi
+  if ! cmp -s "$cl_src/small.txt" "$cl_dest/small.txt"; then
+    echo "    small.txt mismatch after level 1"
+    stop_oc_daemon
+    return 1
+  fi
+
+  # Clean dest for second run
+  rm -rf "$cl_dest"/*
+
+  # Push with --compress-level=9
+  if ! timeout "$hard_timeout" "$upstream_binary" -avz --compress-level=9 --timeout=10 \
+      "${cl_src}/" "rsync://127.0.0.1:${oc_port}/interop" \
+      >"${log}.compress-level-9.out" 2>"${log}.compress-level-9.err"; then
+    echo "    compress-level=9 push failed (exit=$?)"
+    stop_oc_daemon
+    return 1
+  fi
+
+  stop_oc_daemon
+
+  # Verify files match after level 9
+  if ! cmp -s "$cl_src/compressible.txt" "$cl_dest/compressible.txt"; then
+    echo "    compressible.txt mismatch after level 9"
+    return 1
+  fi
+  if ! cmp -s "$cl_src/small.txt" "$cl_dest/small.txt"; then
+    echo "    small.txt mismatch after level 9"
+    return 1
+  fi
+
+  return 0
+}
+
+# Files-from daemon push interop test.
+# Upstream rsync pushes with --files-from to an oc-rsync daemon, verifying
+# only the listed files are transferred (not the full source directory).
+test_files_from() {
+  local upstream_binary=$1 oc_bin=$2 src_dir=$3 work=$4 log=$5 \
+        oc_port=$6 upstream_port=$7
+
+  local ff_src="${work}/files-from-src"
+  local ff_dest="${work}/files-from-dest"
+  rm -rf "$ff_src" "$ff_dest"
+  mkdir -p "$ff_src" "$ff_dest"
+
+  # Create source files - some will be listed, some will not
+  echo "included-alpha" > "$ff_src/alpha.txt"
+  echo "included-beta" > "$ff_src/beta.txt"
+  echo "excluded-gamma" > "$ff_src/gamma.txt"
+  echo "excluded-delta" > "$ff_src/delta.txt"
+  mkdir -p "$ff_src/sub"
+  echo "included-nested" > "$ff_src/sub/nested.txt"
+  echo "excluded-other" > "$ff_src/sub/other.txt"
+
+  # Create the files-from list (only a subset)
+  local ff_list="${work}/files-from-list.txt"
+  cat > "$ff_list" <<FLIST
+alpha.txt
+beta.txt
+sub/nested.txt
+FLIST
+
+  # Start oc-rsync daemon
+  local ff_conf="${work}/files-from-oc.conf"
+  local ff_pid="${work}/files-from-oc.pid"
+  local ff_log="${work}/files-from-oc.log"
+  cat > "$ff_conf" <<CONF
+pid file = ${ff_pid}
+port = ${oc_port}
+use chroot = false
+
+[interop]
+path = ${ff_dest}
+comment = files-from test
+read only = false
+numeric ids = yes
+CONF
+
+  start_oc_daemon "$ff_conf" "$ff_log" "$upstream_binary" "$ff_pid" "$oc_port"
+
+  # Push with --files-from
+  if ! timeout "$hard_timeout" "$upstream_binary" -av --timeout=10 \
+      --files-from="$ff_list" \
+      "${ff_src}/" "rsync://127.0.0.1:${oc_port}/interop" \
+      >"${log}.files-from.out" 2>"${log}.files-from.err"; then
+    echo "    files-from push failed (exit=$?)"
+    stop_oc_daemon
+    return 1
+  fi
+
+  stop_oc_daemon
+
+  # Verify included files arrived
+  for f in alpha.txt beta.txt sub/nested.txt; do
+    if [[ ! -f "$ff_dest/$f" ]]; then
+      echo "    missing included file: $f"
+      return 1
+    fi
+    if ! cmp -s "$ff_src/$f" "$ff_dest/$f"; then
+      echo "    content mismatch: $f"
+      return 1
+    fi
+  done
+
+  # Verify excluded files are absent
+  for f in gamma.txt delta.txt sub/other.txt; do
+    if [[ -f "$ff_dest/$f" ]]; then
+      echo "    excluded file present: $f"
+      return 1
+    fi
+  done
+
+  return 0
+}
+
 # Run all standalone interop tests.
 # Uses globals: $oc_client, $up_identity, $hard_timeout, $comp_src, $workdir.
 run_standalone_interop_tests() {
@@ -4029,6 +4401,11 @@ run_standalone_interop_tests() {
     "filter-rules"
     "up:no-change"
     "oc:no-change"
+    "inplace"
+    "append"
+    "delay-updates"
+    "compress-level"
+    "files-from"
   )
   local test_funcs=(
     "test_write_batch_read_batch"
@@ -4055,6 +4432,11 @@ run_standalone_interop_tests() {
     "test_filter_rules"
     "test_no_change_upstream"
     "test_no_change_oc"
+    "test_inplace"
+    "test_append"
+    "test_delay_updates"
+    "test_compress_level"
+    "test_files_from"
   )
 
   for i in "${!test_names[@]}"; do
@@ -4121,6 +4503,21 @@ run_standalone_interop_tests() {
         test_args+=("$oc_port" "$upstream_port")
         ;;
       oc:no-change)
+        test_args+=("$oc_port" "$upstream_port")
+        ;;
+      inplace)
+        test_args+=("$oc_port" "$upstream_port")
+        ;;
+      append)
+        test_args+=("$oc_port" "$upstream_port")
+        ;;
+      delay-updates)
+        test_args+=("$oc_port" "$upstream_port")
+        ;;
+      compress-level)
+        test_args+=("$oc_port" "$upstream_port")
+        ;;
+      files-from)
         test_args+=("$oc_port" "$upstream_port")
         ;;
     esac


### PR DESCRIPTION
## Summary
- Add 5 new standalone interop tests to `tools/ci/run_interop.sh` verifying upstream rsync daemon push to oc-rsync
- **test_inplace**: pushes with `--inplace` to pre-populated dest, exercises delta in-place write path
- **test_append**: two-phase push - initial sync then `--append` with extended source file
- **test_delay_updates**: pushes with `--delay-updates` for atomic file placement
- **test_compress_level**: pushes with `-z --compress-level=1` and `--compress-level=9`, verifying both extremes
- **test_files_from**: pushes with `--files-from` list, verifies only listed files transfer and excluded files are absent

## Test plan
- [ ] CI interop harness runs all 5 new tests against upstream rsync 3.4.1
- [ ] Existing interop tests continue to pass (no regressions)
- [ ] Script passes `bash -n` syntax check