### PR TITLE
feat: add sequence numbering to DeltaWork and DeltaResult

### DIFF
--- a/crates/engine/src/concurrent_delta/strategy.rs
+++ b/crates/engine/src/concurrent_delta/strategy.rs
@@ -336,7 +336,7 @@ mod tests {
             })
             .collect();
 
-        let results: Vec<DeltaResult> = items.iter().map(|w| dispatch(w)).collect();
+        let results: Vec<DeltaResult> = items.iter().map(dispatch).collect();
         for (i, r) in results.iter().enumerate() {
             assert_eq!(r.sequence(), i as u64);
             assert_eq!(r.ndx(), i as u32);

--- a/crates/engine/src/concurrent_delta/strategy.rs
+++ b/crates/engine/src/concurrent_delta/strategy.rs
@@ -311,13 +311,9 @@ mod tests {
 
     #[test]
     fn dispatch_propagates_sequence_delta() {
-        let work = DeltaWork::delta(
-            2,
-            PathBuf::from("/dest/b"),
-            PathBuf::from("/basis/b"),
-            512,
-        )
-        .with_sequence(99);
+        let work =
+            DeltaWork::delta(2, PathBuf::from("/dest/b"), PathBuf::from("/basis/b"), 512)
+                .with_sequence(99);
         let result = dispatch(&work);
         assert_eq!(result.sequence(), 99);
         assert!(result.is_success());

--- a/crates/engine/src/concurrent_delta/strategy.rs
+++ b/crates/engine/src/concurrent_delta/strategy.rs
@@ -151,11 +151,15 @@ pub fn select_strategy(work: &DeltaWork) -> &'static dyn DeltaStrategy {
 /// Dispatches a work item through the appropriate strategy.
 ///
 /// Convenience function that selects the strategy for the work item's kind
-/// and immediately processes it. Equivalent to calling
-/// `select_strategy(work).process(work)`.
+/// and immediately processes it. Propagates the work item's sequence number
+/// onto the result so the consumer can reorder via [`ReorderBuffer`].
+///
+/// [`ReorderBuffer`]: super::reorder::ReorderBuffer
 #[must_use]
 pub fn dispatch(work: &DeltaWork) -> DeltaResult {
-    select_strategy(work).process(work)
+    select_strategy(work)
+        .process(work)
+        .with_sequence(work.sequence())
 }
 
 #[cfg(test)]
@@ -293,5 +297,54 @@ mod tests {
     fn delta_transfer_strategy_default() {
         let strategy = DeltaTransferStrategy;
         assert_eq!(strategy.kind(), DeltaWorkKind::Delta);
+    }
+
+    // ==================== Sequence propagation tests ====================
+
+    #[test]
+    fn dispatch_propagates_sequence_whole_file() {
+        let work = DeltaWork::whole_file(0, PathBuf::from("/dest/a"), 256).with_sequence(17);
+        let result = dispatch(&work);
+        assert_eq!(result.sequence(), 17);
+        assert!(result.is_success());
+    }
+
+    #[test]
+    fn dispatch_propagates_sequence_delta() {
+        let work = DeltaWork::delta(
+            2,
+            PathBuf::from("/dest/b"),
+            PathBuf::from("/basis/b"),
+            512,
+        )
+        .with_sequence(99);
+        let result = dispatch(&work);
+        assert_eq!(result.sequence(), 99);
+        assert!(result.is_success());
+    }
+
+    #[test]
+    fn dispatch_default_sequence_is_zero() {
+        let work = DeltaWork::whole_file(0, PathBuf::from("/dest"), 100);
+        let result = dispatch(&work);
+        assert_eq!(result.sequence(), 0);
+    }
+
+    #[test]
+    fn dispatch_sequence_survives_pipeline() {
+        // Simulate a producer stamping sequential IDs and verify they survive
+        // through dispatch back to the consumer.
+        let items: Vec<DeltaWork> = (0..5)
+            .map(|i| {
+                DeltaWork::whole_file(i, PathBuf::from(format!("/dest/{i}")), 64)
+                    .with_sequence(u64::from(i))
+            })
+            .collect();
+
+        let results: Vec<DeltaResult> = items.iter().map(|w| dispatch(w)).collect();
+        for (i, r) in results.iter().enumerate() {
+            assert_eq!(r.sequence(), i as u64);
+            assert_eq!(r.ndx(), i as u32);
+        }
     }
 }

--- a/crates/engine/src/concurrent_delta/strategy.rs
+++ b/crates/engine/src/concurrent_delta/strategy.rs
@@ -311,9 +311,8 @@ mod tests {
 
     #[test]
     fn dispatch_propagates_sequence_delta() {
-        let work =
-            DeltaWork::delta(2, PathBuf::from("/dest/b"), PathBuf::from("/basis/b"), 512)
-                .with_sequence(99);
+        let work = DeltaWork::delta(2, PathBuf::from("/dest/b"), PathBuf::from("/basis/b"), 512)
+            .with_sequence(99);
         let result = dispatch(&work);
         assert_eq!(result.sequence(), 99);
         assert!(result.is_success());

--- a/crates/engine/src/concurrent_delta/types.rs
+++ b/crates/engine/src/concurrent_delta/types.rs
@@ -456,25 +456,17 @@ mod tests {
 
     #[test]
     fn work_sequence_preserved_on_clone() {
-        let work = DeltaWork::delta(
-            1,
-            PathBuf::from("/dest"),
-            PathBuf::from("/basis"),
-            200,
-        )
-        .with_sequence(99);
+        let work =
+            DeltaWork::delta(1, PathBuf::from("/dest"), PathBuf::from("/basis"), 200)
+                .with_sequence(99);
         let cloned = work.clone();
         assert_eq!(cloned.sequence(), 99);
     }
 
     #[test]
     fn delta_work_default_sequence_is_zero() {
-        let work = DeltaWork::delta(
-            5,
-            PathBuf::from("/dest"),
-            PathBuf::from("/basis"),
-            1024,
-        );
+        let work =
+            DeltaWork::delta(5, PathBuf::from("/dest"), PathBuf::from("/basis"), 1024);
         assert_eq!(work.sequence(), 0);
     }
 

--- a/crates/engine/src/concurrent_delta/types.rs
+++ b/crates/engine/src/concurrent_delta/types.rs
@@ -25,6 +25,13 @@ use std::path::PathBuf;
 pub struct DeltaWork {
     /// File list index (NDX) - stable position in the sorted file list.
     ndx: u32,
+    /// Pipeline sequence number for reordering after parallel dispatch.
+    ///
+    /// Assigned by the producer before sending into the work queue so that
+    /// the consumer can reconstruct the original submission order via
+    /// [`ReorderBuffer`](super::reorder::ReorderBuffer). Defaults to 0;
+    /// the producer stamps monotonically increasing values.
+    sequence: u64,
     /// Destination path where the reconstructed file will be placed.
     dest_path: PathBuf,
     /// Path to the basis file for delta transfer, `None` for whole-file transfer.
@@ -50,6 +57,7 @@ impl DeltaWork {
     pub fn whole_file(ndx: u32, dest_path: PathBuf, target_size: u64) -> Self {
         Self {
             ndx,
+            sequence: 0,
             dest_path,
             basis_path: None,
             target_size,
@@ -62,6 +70,7 @@ impl DeltaWork {
     pub fn delta(ndx: u32, dest_path: PathBuf, basis_path: PathBuf, target_size: u64) -> Self {
         Self {
             ndx,
+            sequence: 0,
             dest_path,
             basis_path: Some(basis_path),
             target_size,
@@ -103,6 +112,31 @@ impl DeltaWork {
     #[must_use]
     pub const fn is_delta(&self) -> bool {
         matches!(self.kind, DeltaWorkKind::Delta)
+    }
+
+    /// Returns the pipeline sequence number.
+    #[must_use]
+    pub const fn sequence(&self) -> u64 {
+        self.sequence
+    }
+
+    /// Sets the pipeline sequence number.
+    ///
+    /// Called by the producer before dispatching to the work queue so that
+    /// the consumer can reconstruct the original submission order via
+    /// [`ReorderBuffer`](super::reorder::ReorderBuffer).
+    pub fn set_sequence(&mut self, seq: u64) {
+        self.sequence = seq;
+    }
+
+    /// Sets the pipeline sequence number (builder-style).
+    ///
+    /// Returns `self` for chaining. Equivalent to calling
+    /// [`set_sequence`](Self::set_sequence) but consumes and returns the item.
+    #[must_use]
+    pub const fn with_sequence(mut self, seq: u64) -> Self {
+        self.sequence = seq;
+        self
     }
 
     /// Consumes the work item and returns its components.
@@ -397,5 +431,85 @@ mod tests {
     #[test]
     fn result_status_default_is_success() {
         assert_eq!(DeltaResultStatus::default(), DeltaResultStatus::Success);
+    }
+
+    // ==================== DeltaWork sequence tests ====================
+
+    #[test]
+    fn work_default_sequence_is_zero() {
+        let work = DeltaWork::whole_file(0, PathBuf::from("/dest"), 100);
+        assert_eq!(work.sequence(), 0);
+    }
+
+    #[test]
+    fn work_set_sequence() {
+        let mut work = DeltaWork::whole_file(0, PathBuf::from("/dest"), 100);
+        work.set_sequence(42);
+        assert_eq!(work.sequence(), 42);
+    }
+
+    #[test]
+    fn work_with_sequence_builder() {
+        let work = DeltaWork::whole_file(0, PathBuf::from("/dest"), 100).with_sequence(7);
+        assert_eq!(work.sequence(), 7);
+    }
+
+    #[test]
+    fn work_sequence_preserved_on_clone() {
+        let work = DeltaWork::delta(
+            1,
+            PathBuf::from("/dest"),
+            PathBuf::from("/basis"),
+            200,
+        )
+        .with_sequence(99);
+        let cloned = work.clone();
+        assert_eq!(cloned.sequence(), 99);
+    }
+
+    #[test]
+    fn delta_work_default_sequence_is_zero() {
+        let work = DeltaWork::delta(
+            5,
+            PathBuf::from("/dest"),
+            PathBuf::from("/basis"),
+            1024,
+        );
+        assert_eq!(work.sequence(), 0);
+    }
+
+    // ==================== DeltaResult sequence tests ====================
+
+    #[test]
+    fn result_default_sequence_is_zero() {
+        let result = DeltaResult::default();
+        assert_eq!(result.sequence(), 0);
+    }
+
+    #[test]
+    fn result_with_sequence() {
+        let result = DeltaResult::success(1, 100, 50, 50).with_sequence(10);
+        assert_eq!(result.sequence(), 10);
+        assert_eq!(result.ndx(), 1);
+    }
+
+    #[test]
+    fn result_sequence_preserved_on_clone() {
+        let result = DeltaResult::success(0, 0, 0, 0).with_sequence(55);
+        let cloned = result.clone();
+        assert_eq!(cloned.sequence(), 55);
+    }
+
+    #[test]
+    fn result_needs_redo_default_sequence() {
+        let result = DeltaResult::needs_redo(3, "mismatch".to_string());
+        assert_eq!(result.sequence(), 0);
+    }
+
+    #[test]
+    fn result_failed_with_sequence() {
+        let result = DeltaResult::failed(7, "I/O error".to_string()).with_sequence(42);
+        assert_eq!(result.sequence(), 42);
+        assert!(!result.is_success());
     }
 }

--- a/crates/engine/src/concurrent_delta/types.rs
+++ b/crates/engine/src/concurrent_delta/types.rs
@@ -456,17 +456,15 @@ mod tests {
 
     #[test]
     fn work_sequence_preserved_on_clone() {
-        let work =
-            DeltaWork::delta(1, PathBuf::from("/dest"), PathBuf::from("/basis"), 200)
-                .with_sequence(99);
+        let work = DeltaWork::delta(1, PathBuf::from("/dest"), PathBuf::from("/basis"), 200)
+            .with_sequence(99);
         let cloned = work.clone();
         assert_eq!(cloned.sequence(), 99);
     }
 
     #[test]
     fn delta_work_default_sequence_is_zero() {
-        let work =
-            DeltaWork::delta(5, PathBuf::from("/dest"), PathBuf::from("/basis"), 1024);
+        let work = DeltaWork::delta(5, PathBuf::from("/dest"), PathBuf::from("/basis"), 1024);
         assert_eq!(work.sequence(), 0);
     }
 


### PR DESCRIPTION
## Summary
- Adds `sequence: u64` field to `DeltaWork` with `set_sequence()`, `sequence()`, and `with_sequence()` builder methods
- Propagates sequence numbers through `dispatch()` so `DeltaResult` inherits the work item's sequence after parallel processing
- Enables `ReorderBuffer` to reconstruct original wire order after parallel delta computation

## Test plan
- [ ] CI passes (fmt, clippy, nextest on all platforms)
- [ ] New sequence tests pass for DeltaWork, DeltaResult, and dispatch propagation
- [ ] Existing concurrent_delta tests unchanged and passing