### PR TITLE
chore: rustdoc cleanup for compress crate

### DIFF
--- a/crates/compress/src/algorithm.rs
+++ b/crates/compress/src/algorithm.rs
@@ -30,11 +30,10 @@ impl CompressionAlgorithm {
         }
     }
 
+    // upstream: compat.c:valid_compressions_items[] - zstd first, then lz4, zlibx, zlib
     /// Returns the default compression algorithm used when callers enable `--compress`.
     ///
     /// Matches upstream rsync 3.4.1 negotiation precedence: zstd > lz4 > zlib.
-    /// Upstream `compat.c:valid_compressions_items[]` lists zstd first, so when
-    /// both peers support zstd (protocol 32+), it wins negotiation.
     #[must_use]
     pub const fn default_algorithm() -> Self {
         #[cfg(feature = "zstd")]

--- a/crates/compress/src/lz4/raw.rs
+++ b/crates/compress/src/lz4/raw.rs
@@ -26,10 +26,12 @@ use std::io::{self, Read, Write};
 
 use lz4_flex::block::{compress_into, decompress_into, get_maximum_output_size};
 
-/// Flag byte indicating compressed data follows (upstream token.c DEFLATED_DATA).
+// upstream: token.c:DEFLATED_DATA
+/// Flag byte indicating compressed data follows.
 pub const DEFLATED_DATA: u8 = 0x40;
 
-/// Maximum compressed block size in bytes (14-bit field, upstream MAX_DATA_COUNT).
+// upstream: token.c:MAX_DATA_COUNT
+/// Maximum compressed block size in bytes (14-bit field).
 pub const MAX_BLOCK_SIZE: usize = 16383;
 
 /// Maximum decompressed size to prevent memory exhaustion attacks.
@@ -37,6 +39,7 @@ pub const MAX_BLOCK_SIZE: usize = 16383;
 /// Upstream rsync uses 128KB blocks max, but we allow for larger custom configs.
 pub const MAX_DECOMPRESSED_SIZE: usize = 64 * 1024 * 1024;
 
+// upstream: token.c - 2-byte header encodes DEFLATED_DATA flag + 14-bit size
 /// Minimum header size for a compressed block.
 pub const HEADER_SIZE: usize = 2;
 

--- a/crates/compress/src/skip_compress/decider.rs
+++ b/crates/compress/src/skip_compress/decider.rs
@@ -1,3 +1,16 @@
+//! Compression decision engine.
+//!
+//! Implements the three-pronged approach for deciding whether to compress a
+//! file: extension lookup, magic byte detection, and sample-based auto-detection.
+//! The extension-based skip list mirrors upstream rsync's `--skip-compress` option
+//! and `lp_dont_compress()` default list.
+//!
+//! # Upstream Reference
+//!
+//! See `token.c:set_compression()` and `token.c:init_set_compression()` for the
+//! upstream suffix tree and wildcard matching that drives per-file compression
+//! level selection.
+
 use std::collections::HashSet;
 use std::io::{self, Write};
 use std::path::Path;

--- a/crates/compress/src/skip_compress/defaults.rs
+++ b/crates/compress/src/skip_compress/defaults.rs
@@ -2,6 +2,9 @@
 //!
 //! These lists mirror upstream rsync's built-in set of file extensions that
 //! typically don't benefit from compression during transfer.
+//!
+//! upstream: `loadparm.c:lp_dont_compress()` provides the default suffix list
+//! that `token.c:init_set_compression()` loads into the suffix tree.
 
 use std::collections::HashSet;
 

--- a/crates/compress/src/skip_compress/magic.rs
+++ b/crates/compress/src/skip_compress/magic.rs
@@ -1,3 +1,5 @@
+//! Magic byte signatures for compressed file format detection.
+
 use super::FileCategory;
 
 /// Magic byte signature for detecting compressed file formats.

--- a/crates/compress/src/skip_compress/types.rs
+++ b/crates/compress/src/skip_compress/types.rs
@@ -1,3 +1,5 @@
+//! Core types for compression skip-list decisions and file categorisation.
+
 use std::fmt;
 use std::hash::{Hash, Hasher};
 

--- a/crates/compress/src/zlib/encoder.rs
+++ b/crates/compress/src/zlib/encoder.rs
@@ -8,6 +8,8 @@ use flate2::write::DeflateEncoder as FlateEncoder;
 use super::CompressionLevel;
 use crate::common::{CountingSink, CountingWriter};
 
+// upstream: token.c:send_deflated_token() - deflateInit2(..., -15, 8, Z_DEFAULT_STRATEGY)
+// uses raw deflate (negative windowBits) without zlib header/trailer.
 /// Streaming encoder that records the number of compressed bytes produced.
 ///
 /// The encoder implements [`std::io::Write`], enabling integration with APIs

--- a/crates/compress/src/zlib/level.rs
+++ b/crates/compress/src/zlib/level.rs
@@ -5,6 +5,8 @@ use std::num::NonZeroU8;
 use flate2::Compression;
 use thiserror::Error;
 
+// upstream: token.c:init_compression_level() - zlib range 0..=9,
+// default 6 (Z_DEFAULT_COMPRESSION is -1 but upstream remaps to 6).
 /// Compression levels recognised by the zlib encoder.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum CompressionLevel {

--- a/crates/compress/src/zstd.rs
+++ b/crates/compress/src/zstd.rs
@@ -220,6 +220,8 @@ pub const fn default_algorithm() -> CompressionAlgorithm {
     CompressionAlgorithm::Zstd
 }
 
+// upstream: token.c:init_compression_level() - ZSTD_CLEVEL_DEFAULT is 3,
+// ZSTD_minCLevel() is the minimum, ZSTD_maxCLevel() is the maximum.
 fn zstd_level(level: CompressionLevel) -> i32 {
     match level {
         CompressionLevel::None => 0,


### PR DESCRIPTION
## Summary

- Add missing `//!` module-level docs to `magic.rs`, `decider.rs`, `types.rs`
- Add upstream rsync source references (`token.c`, `compat.c`, `loadparm.c`) for non-obvious behavior: wire format constants, compression level defaults, skip-compress suffix tree, raw deflate `windowBits`
- Move inline upstream references from rustdoc into `// upstream:` code comments to follow project convention
- No logic changes, no commented-out code removed (none found), no decorative banners removed (none found)

The compress crate was already well-documented. Changes focus on adding upstream C source references where the code implements protocol-specific behavior.

## Test plan

- [ ] CI fmt+clippy passes (no doc lint violations)
- [ ] CI nextest passes (no functional changes)