### PR TITLE
chore: rustdoc cleanup for bandwidth crate

### DIFF
--- a/crates/bandwidth/src/limiter/change.rs
+++ b/crates/bandwidth/src/limiter/change.rs
@@ -2,7 +2,7 @@
 //!
 //! [`apply_effective_limit`] merges daemon-imposed caps with an existing
 //! limiter, mirroring upstream rsync's precedence rules in
-//! `clientserver.c:start_daemon()`. The returned [`LimiterChange`] describes
+//! `options.c:server_options()`. The returned [`LimiterChange`] describes
 //! the transition so callers can log or skip follow-up work.
 
 use super::core::BandwidthLimiter;
@@ -95,7 +95,7 @@ impl FromIterator<LimiterChange> for LimiterChange {
 
 /// Applies a module-specific bandwidth cap to an optional limiter, mirroring upstream precedence rules.
 ///
-// upstream: clientserver.c - daemon module bwlimit override logic
+// upstream: options.c:2374 - daemon_bwlimit override: strictest rate wins
 pub fn apply_effective_limit(
     limiter: &mut Option<BandwidthLimiter>,
     limit: Option<NonZeroU64>,

--- a/crates/bandwidth/src/limiter/core/write_max.rs
+++ b/crates/bandwidth/src/limiter/core/write_max.rs
@@ -1,9 +1,9 @@
 //! Write chunk-size calculation for bandwidth-limited transfers.
 //!
 //! The maximum chunk size scales linearly with the configured rate, keeping
-//! I/O granularity proportional to throughput. This mirrors the approach in
-//! upstream rsync's `io.c` where the write buffer is sized relative to the
-//! `--bwlimit` value so that pacing sleeps remain short and responsive.
+//! I/O granularity proportional to throughput. This mirrors upstream
+//! `options.c:2377` where `bwlimit_writemax = bwlimit * 128` with a floor
+//! of 512 bytes so that pacing sleeps remain short and responsive.
 
 use std::num::NonZeroU64;
 
@@ -14,6 +14,7 @@ use super::super::MIN_WRITE_MAX;
 /// The base write-max scales linearly with KiB of bandwidth, clamped to at
 /// least `MIN_WRITE_MAX`. When a burst override is present it replaces the
 /// calculated value (still respecting the minimum).
+// upstream: options.c:2377-2379 - bwlimit_writemax = bwlimit * 128, min 512
 pub(super) fn calculate_write_max(limit: NonZeroU64, burst: Option<NonZeroU64>) -> usize {
     let kib = if limit.get() < 1024 {
         1

--- a/crates/bandwidth/src/limiter/mod.rs
+++ b/crates/bandwidth/src/limiter/mod.rs
@@ -23,11 +23,23 @@ pub use sleep::LimiterSleep;
 
 pub(super) use sleep::{duration_from_microseconds, sleep_for};
 
+/// One million microseconds per second.
+// upstream: io.c:sleep_for_bwlimit() ONE_SEC macro
 pub(super) const MICROS_PER_SECOND: u128 = 1_000_000;
+
+/// Minimum accumulated debt before the limiter actually sleeps.
+// upstream: io.c:sleep_for_bwlimit() - `ONE_SEC / 10` threshold
 pub(super) const MINIMUM_SLEEP_MICROS: u128 = MICROS_PER_SECOND / 10;
+
+/// Largest microsecond value representable as a `Duration`.
 pub(super) const MAX_REPRESENTABLE_MICROSECONDS: u128 =
     (u64::MAX as u128) * MICROS_PER_SECOND + (MICROS_PER_SECOND - 1);
+
+/// Upper bound for a single `select()`-style sleep call.
 pub(super) const MAX_SLEEP_DURATION: Duration = Duration::new(i64::MAX as u64, 999_999_999);
+
+/// Floor for the per-write chunk size.
+// upstream: options.c:2378 - `if (bwlimit_writemax < 512) bwlimit_writemax = 512`
 pub(super) const MIN_WRITE_MAX: usize = 512;
 
 #[cfg(any(test, feature = "test-support"))]

--- a/crates/bandwidth/src/limiter/sleep.rs
+++ b/crates/bandwidth/src/limiter/sleep.rs
@@ -48,6 +48,7 @@ impl LimiterSleep {
     }
 }
 
+/// Converts a microsecond count to a [`Duration`], saturating to `Duration::MAX` on overflow.
 pub(crate) const fn duration_from_microseconds(us: u128) -> Duration {
     if us == 0 {
         return Duration::ZERO;
@@ -63,6 +64,8 @@ pub(crate) const fn duration_from_microseconds(us: u128) -> Duration {
     Duration::new(seconds, micros.saturating_mul(1_000))
 }
 
+/// Sleeps for the given duration, chunking into `MAX_SLEEP_DURATION` segments.
+// upstream: io.c:sleep_for_bwlimit() - uses select() for the actual sleep
 pub(crate) fn sleep_for(duration: Duration) {
     let mut remaining = duration;
 

--- a/crates/bandwidth/src/limiter/test_support.rs
+++ b/crates/bandwidth/src/limiter/test_support.rs
@@ -12,6 +12,7 @@ use std::mem;
 use std::sync::{Mutex, MutexGuard, OnceLock};
 use std::time::Duration;
 
+/// Returns the global buffer where test sleep durations are accumulated.
 pub(crate) fn recorded_sleeps() -> &'static Mutex<Vec<Duration>> {
     static RECORDED_SLEEPS: OnceLock<Mutex<Vec<Duration>>> = OnceLock::new();
     RECORDED_SLEEPS.get_or_init(|| Mutex::new(Vec::new()))
@@ -22,6 +23,7 @@ fn recorded_sleep_session_lock() -> &'static Mutex<()> {
     SESSION_LOCK.get_or_init(|| Mutex::new(()))
 }
 
+/// Appends the given sleep chunks to the global recorded buffer.
 pub(crate) fn append_recorded_sleeps(chunks: Vec<Duration>) {
     lock_recorded_sleeps().extend(chunks);
 }

--- a/crates/bandwidth/src/parse.rs
+++ b/crates/bandwidth/src/parse.rs
@@ -34,14 +34,14 @@ pub enum BandwidthParseError {
 }
 
 /// Parses a `--bwlimit` style argument into an optional byte-per-second limit.
-// upstream: util2.c:parse_size_arg()
-#[doc(alias = "--bwlimit")]
 ///
 /// The function mirrors upstream rsync's behaviour. Inputs must match the
 /// syntax accepted by `parse_size_arg()` which rejects embedded or surrounding
 /// whitespace. `Ok(None)` denotes an unlimited transfer rate (users may specify
 /// `0` for this effect). Successful parses return the rounded byte-per-second
 /// limit as [`NonZeroU64`].
+// upstream: options.c:parse_size_arg() - suffix/multiplier/adjust parsing
+#[doc(alias = "--bwlimit")]
 pub fn parse_bandwidth_argument(text: &str) -> Result<Option<NonZeroU64>, BandwidthParseError> {
     if text.as_bytes().iter().all(u8::is_ascii_whitespace) {
         return Err(BandwidthParseError::Invalid);

--- a/crates/bandwidth/src/parse/components.rs
+++ b/crates/bandwidth/src/parse/components.rs
@@ -3,7 +3,7 @@
 //! [`BandwidthLimitComponents`] stores the result of parsing a bandwidth
 //! argument and records whether each field was explicitly supplied. This
 //! distinction lets daemon modules apply upstream rsync's precedence rules
-//! in `clientserver.c` - the strictest byte-per-second rate wins while
+//! in `options.c:server_options()` - the strictest byte-per-second rate wins while
 //! explicit burst overrides take effect.
 
 use std::num::NonZeroU64;

--- a/crates/bandwidth/src/parse/numeric.rs
+++ b/crates/bandwidth/src/parse/numeric.rs
@@ -7,6 +7,7 @@
 use super::BandwidthParseError;
 use memchr::memchr2;
 
+// upstream: options.c:parse_size_arg() - atof() for decimal mantissa
 pub(crate) fn parse_decimal_with_exponent(
     text: &str,
 ) -> Result<(u128, u128, u128, i32), BandwidthParseError> {
@@ -37,6 +38,8 @@ pub(crate) fn parse_decimal_with_exponent(
     Ok((integer, fraction, denominator, exponent))
 }
 
+/// Checked exponentiation for suffix multiplier calculation.
+// upstream: options.c:parse_size_arg() - `while (reps--) size *= mult`
 pub(crate) fn pow_u128(base: u32, exponent: u32) -> Result<u128, BandwidthParseError> {
     let mut result = 1u128;
     let mut factor = u128::from(base);


### PR DESCRIPTION
## Summary
- Add upstream rsync source references (`options.c:parse_size_arg()`, `options.c:2377`, `io.c:sleep_for_bwlimit()`) to constants, functions, and module docs throughout the bandwidth crate
- Fix inaccurate upstream file references (`clientserver.c` -> `options.c:server_options()`) in module docs and function comments
- Add missing `///` rustdoc to `pub(crate)` helpers (`duration_from_microseconds`, `sleep_for`, `pow_u128`, `recorded_sleeps`, `append_recorded_sleeps`) and crate-level constants (`MICROS_PER_SECOND`, `MINIMUM_SLEEP_MICROS`, `MAX_REPRESENTABLE_MICROSECONDS`, `MAX_SLEEP_DURATION`, `MIN_WRITE_MAX`)

## Test plan
- [x] `cargo fmt --all -- --check` passes locally
- [ ] CI: fmt+clippy, nextest, Windows, macOS, Linux musl