### PR TITLE
chore: rustdoc cleanup for checksums crate

### DIFF
--- a/crates/checksums/src/parallel/mod.rs
+++ b/crates/checksums/src/parallel/mod.rs
@@ -32,8 +32,6 @@ mod blocks;
 mod files;
 mod types;
 
-// Re-export all public items to preserve the existing API.
-
 pub use blocks::{
     compute_block_signatures_auto, compute_block_signatures_parallel, compute_digests_auto,
     compute_digests_parallel, compute_digests_with_seed_parallel,

--- a/crates/checksums/src/rolling/checksum/mod.rs
+++ b/crates/checksums/src/rolling/checksum/mod.rs
@@ -148,8 +148,9 @@ impl RollingChecksum {
 
     /// Updates the checksum with a single byte.
     ///
-    /// This is an optimized path for single-byte updates that avoids slice overhead.
-    /// Useful when building up the initial window in delta generation.
+    /// Optimized single-byte path matching the inner loop of upstream
+    /// `checksum.c:get_checksum1()`. Avoids slice overhead when building
+    /// up the initial window in delta generation.
     ///
     /// # Examples
     ///
@@ -278,8 +279,8 @@ impl RollingChecksum {
 
     /// Rolls the checksum by removing one byte and adding another.
     ///
-    /// This enables O(1) sliding window updates for delta detection.
-    /// The window size remains constant after rolling.
+    /// Implements the O(1) sliding window update from upstream
+    /// `match.c:hash_search()`. The window size remains constant after rolling.
     ///
     /// # Examples
     ///
@@ -422,7 +423,7 @@ impl RollingChecksum {
 
     /// Returns the rolling checksum value in rsync's packed 32-bit representation.
     ///
-    /// The format is `(s2 << 16) | s1`, matching upstream rsync's wire format.
+    /// The format is `(s2 << 16) | s1`, matching upstream `checksum.c:get_checksum1()`.
     /// Use this value for hash table lookups during delta detection.
     ///
     /// # Examples
@@ -486,9 +487,10 @@ impl From<RollingDigest> for RollingChecksum {
 
 impl_from_owned_and_ref!(RollingChecksum => RollingDigest, digest);
 
-/// Architecture-neutral dispatcher:
-/// 1. try arch-accelerated implementation,
-/// 2. fall back to scalar.
+/// Architecture-neutral dispatcher for rolling checksum accumulation.
+///
+/// Mirrors upstream `checksum.c:get_checksum1()` with SIMD fast paths:
+/// tries the arch-accelerated implementation first, falls back to scalar.
 #[inline]
 fn accumulate_chunk_dispatch(s1: u32, s2: u32, len: usize, chunk: &[u8]) -> (u32, u32, usize) {
     if chunk.is_empty() {
@@ -502,9 +504,7 @@ fn accumulate_chunk_dispatch(s1: u32, s2: u32, len: usize, chunk: &[u8]) -> (u32
     mask_result(accumulate_chunk_scalar_raw(s1, s2, len, chunk))
 }
 
-/// Arch-specific strategy: returns `Some(...)` if this arch has a fast path,
-/// otherwise `None`. This keeps the top-level dispatcher linear and avoids
-/// unreachable-code patterns.
+/// NEON fast path for aarch64 - delegates to vectorised accumulation.
 #[cfg(target_arch = "aarch64")]
 #[inline]
 fn accumulate_chunk_arch(s1: u32, s2: u32, len: usize, chunk: &[u8]) -> Option<(u32, u32, usize)> {
@@ -533,6 +533,7 @@ const fn mask_result((s1, s2, len): (u32, u32, usize)) -> (u32, u32, usize) {
     (s1 & 0xffff, s2 & 0xffff, len)
 }
 
+/// Scalar fallback matching upstream `checksum.c:get_checksum1()` byte loop.
 #[inline]
 fn accumulate_chunk_scalar_raw(
     mut s1: u32,
@@ -570,15 +571,7 @@ fn accumulate_chunk_scalar_raw(
 /// Flushes accumulated bytes from the scratch buffer into the checksum state.
 ///
 /// During vectored I/O processing, small chunks are collected into a stack-allocated
-/// scratch buffer to improve cache locality. This function processes the buffered
-/// bytes when the buffer is full or at the end of processing.
-///
-/// # Arguments
-///
-/// * `s1`, `s2` - Rolling checksum accumulators (modified in place)
-/// * `len` - Total bytes processed counter (modified in place)
-/// * `scratch` - Stack buffer holding pending bytes
-/// * `scratch_len` - Number of valid bytes in scratch (reset to 0 after flush)
+/// scratch buffer to improve cache locality before dispatching to SIMD.
 #[inline]
 fn flush_vectored_scratch(
     s1: &mut u32,

--- a/crates/checksums/src/rolling/mod.rs
+++ b/crates/checksums/src/rolling/mod.rs
@@ -36,18 +36,7 @@
 //! rolling.roll(b'h', b'!').unwrap();
 //! ```
 
-/// Macro to implement From trait for both owned and reference types.
-///
-/// This reduces boilerplate when implementing conversions that work
-/// identically for both `T` and `&T`. The macro generates both
-/// implementations, ensuring consistent behavior and eliminating
-/// duplicate code.
-///
-/// # Arguments
-///
-/// * `$source` - Source type (will also generate `&$source`)
-/// * `$target` - Target type
-/// * `$method` - Method to call on the source for conversion
+/// Generates `From<T>` and `From<&T>` implementations that delegate to `$method`.
 macro_rules! impl_from_owned_and_ref {
     ($source:ty => $target:ty, $method:ident) => {
         impl From<$source> for $target {

--- a/crates/checksums/src/strong/md5.rs
+++ b/crates/checksums/src/strong/md5.rs
@@ -211,7 +211,7 @@ impl Default for Md5Seed {
 #[derive(Clone)]
 pub struct Md5 {
     inner: Md5Backend,
-    /// Seed to hash AFTER data (when proper_order is false).
+    /// Deferred seed for legacy (pre-CHECKSUM_SEED_FIX) ordering.
     pending_seed: Option<i32>,
 }
 
@@ -331,7 +331,7 @@ impl Md5 {
     /// ```
     #[must_use]
     pub fn finalize(mut self) -> [u8; 16] {
-        // If we have a pending seed (legacy order), hash it AFTER the data
+        // upstream: checksum.c:get_checksum2() - legacy seed ordering
         if let Some(seed) = self.pending_seed {
             self.update(&seed.to_le_bytes());
         }
@@ -384,10 +384,10 @@ impl StrongDigest for Md5 {
 
         if let Some(value) = seed.value {
             if seed.proper_order {
-                // Hash seed BEFORE data (proper order, protocol 30+ with CHECKSUM_SEED_FIX)
+                // upstream: checksum.c:get_checksum2() - CHECKSUM_SEED_FIX (protocol 30+)
                 md5.update(&value.to_le_bytes());
             } else {
-                // Store seed to hash AFTER data (legacy order)
+                // upstream: checksum.c:get_checksum2() - pre-CHECKSUM_SEED_FIX ordering
                 md5.pending_seed = Some(value);
             }
         }
@@ -400,12 +400,11 @@ impl StrongDigest for Md5 {
     }
 
     fn finalize(mut self) -> Self::Digest {
-        // If we have a pending seed (legacy order), hash it AFTER the data
+        // upstream: checksum.c:get_checksum2() - legacy seed ordering
         if let Some(seed) = self.pending_seed {
             self.update(&seed.to_le_bytes());
         }
 
-        // Now finalize the hash
         match self.inner {
             #[cfg(feature = "openssl")]
             Md5Backend::OpenSsl(mut hasher) => {

--- a/crates/checksums/src/strong/strategy/kind.rs
+++ b/crates/checksums/src/strong/strategy/kind.rs
@@ -76,9 +76,10 @@ impl ChecksumAlgorithmKind {
         )
     }
 
-    /// Parses an algorithm from a string name.
+    /// Parses an algorithm from a string name used in upstream negotiation.
     ///
     /// Accepts canonical names and common aliases (case-insensitive).
+    /// See upstream `compat.c` for the negotiation protocol.
     pub fn from_name(name: &str) -> Option<Self> {
         match name.to_ascii_lowercase().as_str() {
             "md4" => Some(Self::Md4),

--- a/crates/checksums/src/strong/strategy/seed.rs
+++ b/crates/checksums/src/strong/strategy/seed.rs
@@ -4,7 +4,6 @@ use crate::strong::Md5Seed;
 
 /// Configuration for MD5 seed handling in the strategy pattern.
 ///
-/// Wraps the `Md5Seed` options for use with `SeedConfig`.
 /// See `Md5Seed` for details on seed ordering semantics.
 #[derive(Clone, Copy, Debug)]
 pub enum Md5SeedConfig {

--- a/crates/checksums/src/strong/strategy/selector.rs
+++ b/crates/checksums/src/strong/strategy/selector.rs
@@ -24,7 +24,7 @@ pub struct ChecksumStrategySelector;
 impl ChecksumStrategySelector {
     /// Selects the default algorithm for a given protocol version.
     ///
-    /// # Protocol Defaults
+    /// Mirrors upstream `checksum.c` algorithm selection:
     ///
     /// - Protocol < 30: MD4
     /// - Protocol >= 30: MD5

--- a/crates/checksums/src/strong/strategy/trait_def.rs
+++ b/crates/checksums/src/strong/strategy/trait_def.rs
@@ -1,9 +1,9 @@
-//! Strategy trait for checksum computation.
+//! Strategy trait for runtime checksum algorithm dispatch.
 
 use super::digest::ChecksumDigest;
 use super::kind::ChecksumAlgorithmKind;
 
-/// Strategy trait for checksum computation.
+/// Trait for runtime-dispatched checksum computation.
 ///
 /// Implementations provide algorithm-specific checksum computation while
 /// exposing a uniform interface for callers.


### PR DESCRIPTION
## Summary

- Replace restating-the-code comments with upstream rsync source references (`checksum.c`, `match.c`, `compat.c`) across rolling checksum dispatch, scalar fallback, roll method, and MD5 seed ordering logic
- Remove redundant/duplicate comments: MD5 finalize trait impl, vectored flush `# Arguments` section, macro verbose docs, parallel re-export comment, strategy trait duplication
- Condense verbose argument-list documentation into concise descriptions

## Test plan

- [ ] CI fmt+clippy passes (no functional changes)
- [ ] All nextest suites pass (comment-only changes)