### PR TITLE
chore: rustdoc cleanup for filters crate

### DIFF
--- a/crates/filters/src/chain.rs
+++ b/crates/filters/src/chain.rs
@@ -52,21 +52,14 @@ use crate::{FilterError, FilterRule, FilterSet};
 /// ```
 #[derive(Clone, Debug)]
 pub struct DirMergeConfig {
-    /// Filename to look for in each directory.
     filename: String,
-    /// Whether rules from parent directories are inherited by children.
-    /// upstream: exclude.c - FILTRULE_NO_INHERIT flag
+    // upstream: exclude.c - FILTRULE_NO_INHERIT flag
     inherit: bool,
-    /// Whether the merge file itself should be excluded from transfer.
-    /// upstream: exclude.c - `e` modifier on dir-merge rules
+    // upstream: exclude.c - `e` modifier on dir-merge rules
     exclude_self: bool,
-    /// Restrict rules to sender side only.
     sender_only: bool,
-    /// Restrict rules to receiver side only.
     receiver_only: bool,
-    /// Anchor patterns to the directory root.
     anchor_root: bool,
-    /// Mark rules as perishable.
     perishable: bool,
 }
 
@@ -183,9 +176,7 @@ impl DirMergeConfig {
 /// are stacked during traversal and popped when leaving directories.
 #[derive(Clone, Debug)]
 struct DirScope {
-    /// The directory depth at which this scope was pushed.
     depth: usize,
-    /// Compiled filter set for this directory's rules.
     filter_set: FilterSet,
 }
 
@@ -219,13 +210,10 @@ struct DirScope {
 /// ```
 #[derive(Clone, Debug)]
 pub struct FilterChain {
-    /// Global (base) filter rules from command-line options.
     global: FilterSet,
-    /// Per-directory merge file configurations.
     merge_configs: Vec<DirMergeConfig>,
-    /// Stack of per-directory filter scopes, ordered from outermost to innermost.
+    /// Ordered from outermost to innermost; evaluation iterates in reverse.
     scopes: Vec<DirScope>,
-    /// Current directory depth for tracking scope lifetimes.
     current_depth: usize,
 }
 

--- a/crates/filters/src/compiled/rule.rs
+++ b/crates/filters/src/compiled/rule.rs
@@ -38,8 +38,7 @@ impl CompiledRule {
     pub(crate) fn matches(&self, path: &Path, is_dir: bool) -> bool {
         let pattern_matched = self.pattern_matches_impl(path, is_dir);
 
-        // Upstream rsync: ret_match = ex->rflags & FILTRULE_NEGATE ? 0 : 1;
-        // When negated, invert the match result
+        // upstream: exclude.c:906 - ret_match = ex->rflags & FILTRULE_NEGATE ? 0 : 1
         if self.negate {
             debug_log!(
                 Filter,

--- a/crates/filters/src/decision.rs
+++ b/crates/filters/src/decision.rs
@@ -93,9 +93,6 @@ impl FilterSetInner {
             match rule.action {
                 FilterAction::Protect => decision.protect(),
                 FilterAction::Risk => decision.unprotect(),
-                // Include/Exclude/Clear/Merge/DirMerge are not protection actions.
-                // Merge and DirMerge are expanded before compilation, so they
-                // should never appear in compiled rules.
                 FilterAction::Include
                 | FilterAction::Exclude
                 | FilterAction::Clear

--- a/crates/filters/src/rule.rs
+++ b/crates/filters/src/rule.rs
@@ -63,9 +63,9 @@ pub struct FilterRule {
     pub(crate) perishable: bool,
     pub(crate) xattr_only: bool,
     pub(crate) negate: bool,
-    /// Exclude-only flag (`e` modifier) - forces rule to act as exclude.
+    // `e` modifier - forces rule to act as exclude
     pub(crate) exclude_only: bool,
-    /// No-inherit flag (`n` modifier) - for merge rules, don't inherit parent rules.
+    // `n` modifier - for merge rules, don't inherit parent rules
     pub(crate) no_inherit: bool,
 }
 

--- a/crates/filters/src/set.rs
+++ b/crates/filters/src/set.rs
@@ -110,10 +110,7 @@ impl FilterSet {
                         rule.applies_to_receiver,
                     );
                 }
-                FilterAction::Merge | FilterAction::DirMerge => {
-                    // Handled by from_rules_with_merge_expansion (Merge) or
-                    // per-directory traversal (DirMerge).
-                }
+                FilterAction::Merge | FilterAction::DirMerge => {}
             }
         }
 


### PR DESCRIPTION
## Summary

- Remove redundant comments that restate code behavior on private struct fields and match arms
- Convert `///` rustdoc on `pub(crate)` fields to `//` internal comments where appropriate
- Normalize upstream rsync reference format to consistent `// upstream:` style
- Keep all comments that explain WHY, reference upstream source, or are required by `#![deny(missing_docs)]`

## Test plan

- [ ] `cargo fmt --all -- --check` passes
- [ ] CI fmt+clippy, nextest, and platform matrix checks pass