### PR TITLE
chore: rustdoc cleanup for transfer crate

### DIFF
--- a/crates/transfer/src/compressed_reader.rs
+++ b/crates/transfer/src/compressed_reader.rs
@@ -18,12 +18,8 @@ use compress::zstd::CountingZstdDecoder;
 
 /// Wraps a reader with decompression, reading compressed input.
 ///
-/// Mirrors upstream rsync's io.c:io_start_buffering_in() behavior where
-/// decompression is applied on top of the multiplexed stream.
-///
-/// The reader decompresses input data from the underlying reader, matching
-/// upstream's buffering strategy where compressed data is received through
-/// the multiplex layer and decompressed before being consumed.
+/// Mirrors upstream `io.c:io_start_buffering_in()` where decompression is
+/// applied on top of the multiplexed stream.
 pub struct CompressedReader<R: Read> {
     /// Active decompression decoder variant
     /// The decoder owns the underlying reader
@@ -37,9 +33,7 @@ pub struct CompressedReader<R: Read> {
     pub(crate) batch_recorder: Option<Arc<Mutex<dyn Write + Send>>>,
 }
 
-/// Enum wrapper around different compression decoder types.
-///
-/// Each variant holds a decoder configured to read from the underlying stream.
+/// Compression decoder dispatch for supported algorithms.
 #[allow(clippy::large_enum_variant)]
 enum DecoderVariant<R: Read> {
     /// zlib decoder
@@ -55,18 +49,9 @@ enum DecoderVariant<R: Read> {
 impl<R: Read> CompressedReader<R> {
     /// Creates a new compressed reader wrapping the given reader.
     ///
-    /// The decompressor is initialized based on the negotiated algorithm and reads
-    /// compressed data from the underlying reader.
-    ///
-    /// # Arguments
-    ///
-    /// * `inner` - The underlying reader (typically `MultiplexReader`)
-    /// * `algorithm` - Negotiated compression algorithm
-    ///
     /// # Errors
     ///
-    /// Returns an error if the compression algorithm is not supported in this build
-    /// (e.g., LZ4 or Zstd without the corresponding feature flag).
+    /// Returns an error if the compression algorithm is not supported in this build.
     pub fn new(inner: R, algorithm: CompressionAlgorithm) -> io::Result<Self> {
         let decoder = match algorithm {
             CompressionAlgorithm::Zlib => DecoderVariant::Zlib(CountingZlibDecoder::new(inner)),
@@ -93,9 +78,6 @@ impl<R: Read> CompressedReader<R> {
     }
 
     /// Returns a mutable reference to the underlying reader.
-    ///
-    /// This is used to access the `MultiplexReader`'s `take_io_error()` method
-    /// when the compressed reader wraps a multiplex stream.
     pub fn get_mut(&mut self) -> &mut R {
         match &mut self.decoder {
             DecoderVariant::Zlib(decoder) => decoder.get_mut(),

--- a/crates/transfer/src/compressed_writer.rs
+++ b/crates/transfer/src/compressed_writer.rs
@@ -18,12 +18,8 @@ use compress::zstd::CountingZstdEncoder;
 
 /// Wraps a writer with compression, buffering compressed output.
 ///
-/// Mirrors upstream rsync's io.c:io_start_buffering_out() behavior where
-/// compression is applied on top of the multiplexed stream.
-///
-/// The writer compresses input data and buffers the compressed output before
-/// writing to the underlying writer. This matches upstream's buffering strategy
-/// where compressed data is accumulated before being sent through the multiplex layer.
+/// Mirrors upstream `io.c:io_start_buffering_out()` where compression is
+/// applied on top of the multiplexed stream.
 pub struct CompressedWriter<W: Write> {
     /// The underlying writer (typically MultiplexWriter)
     inner: W,
@@ -39,9 +35,7 @@ pub struct CompressedWriter<W: Write> {
     pub(crate) batch_recorder: Option<Arc<Mutex<dyn Write + Send>>>,
 }
 
-/// Enum wrapper around different compression encoder types.
-///
-/// Each variant holds an encoder configured to write to a Vec<u8> sink.
+/// Compression encoder dispatch for supported algorithms.
 #[allow(clippy::large_enum_variant)]
 enum EncoderVariant {
     /// zlib encoder writing to Vec<u8>
@@ -57,19 +51,9 @@ enum EncoderVariant {
 impl<W: Write> CompressedWriter<W> {
     /// Creates a new compressed writer wrapping the given writer.
     ///
-    /// The compressor is initialized based on the negotiated algorithm and writes
-    /// compressed data to an internal buffer before flushing to the underlying writer.
-    ///
-    /// # Arguments
-    ///
-    /// * `inner` - The underlying writer (typically `MultiplexWriter`)
-    /// * `algorithm` - Negotiated compression algorithm
-    /// * `level` - Compression level to use
-    ///
     /// # Errors
     ///
-    /// Returns an error if the compression algorithm is not supported in this build
-    /// (e.g., LZ4 or Zstd without the corresponding feature flag).
+    /// Returns an error if the compression algorithm is not supported in this build.
     pub fn new(
         inner: W,
         algorithm: CompressionAlgorithm,
@@ -114,11 +98,8 @@ impl<W: Write> CompressedWriter<W> {
         })
     }
 
-    /// Drains the encoder's internal sink to the underlying writer.
-    ///
-    /// This writes accumulated compressed bytes from the encoder's Vec sink
-    /// to the underlying writer without triggering a compressor-level flush.
-    /// Used by `write()` for threshold-based buffer draining.
+    /// Drains the encoder's internal sink to the underlying writer without
+    /// triggering a compressor-level flush.
     fn drain_sink(&mut self) -> io::Result<()> {
         match &mut self.encoder {
             EncoderVariant::Zlib(encoder) => {
@@ -150,15 +131,11 @@ impl<W: Write> CompressedWriter<W> {
 
     /// Performs a sync flush on the encoder and drains all output.
     ///
-    /// Calls `Z_SYNC_FLUSH` (or equivalent) on the compressor to materialize
-    /// all pending compressed data, then drains the encoder's sink to the
-    /// underlying writer. This ensures the receiver can decompress all data
-    /// written so far without waiting for more input.
+    /// Calls `Z_SYNC_FLUSH` (or equivalent) on the compressor so the receiver
+    /// can decompress all data written so far without waiting for more input.
     ///
-    /// Upstream rsync uses `Z_SYNC_FLUSH` at token boundaries
-    /// (token.c:send_deflated_token lines 433-434) so each token is
-    /// independently decompressible. This method provides the same guarantee
-    /// at the stream-compression layer.
+    /// upstream: `token.c:send_deflated_token()` lines 433-434 uses
+    /// `Z_SYNC_FLUSH` at token boundaries for independent decompressibility.
     fn flush_compressed(&mut self) -> io::Result<()> {
         // First, sync-flush the encoder so all pending data in the deflate
         // state is materialized into the encoder's Vec sink.
@@ -232,15 +209,8 @@ impl<W: Write> CompressedWriter<W> {
 
     /// Provides mutable access to the underlying writer.
     ///
-    /// This is used for sending control messages through the multiplex layer
-    /// without compressing them (matching upstream rsync behavior where control
-    /// messages bypass the compression buffer).
-    ///
-    /// # Safety
-    ///
-    /// Caller must ensure that any writes to the underlying writer don't corrupt
-    /// the compression stream. This should only be used for multiplex control
-    /// messages that are handled at a different protocol layer.
+    /// Used for sending multiplex control messages that bypass the compression
+    /// buffer, matching upstream behavior where control messages are uncompressed.
     pub const fn inner_mut(&mut self) -> &mut W {
         &mut self.inner
     }
@@ -284,10 +254,8 @@ impl<W: Write> Write for CompressedWriter<W> {
         Ok(buf.len())
     }
 
-    /// Writes multiple buffers using vectored I/O.
-    ///
-    /// For compression, vectored writes are processed sequentially through the
-    /// encoder since compression state must be maintained across buffers.
+    /// Writes multiple buffers sequentially through the encoder since
+    /// compression state must be maintained across buffers.
     fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
         let mut total_written = 0;
         for buf in bufs {

--- a/crates/transfer/src/config.rs
+++ b/crates/transfer/src/config.rs
@@ -16,9 +16,7 @@ use super::role::ServerRole;
 /// Reference directory types for remote transfers.
 pub use engine::{ReferenceDirectory, ReferenceDirectoryKind};
 
-/// File write behavior configuration.
-///
-/// Controls how the receiver writes transferred data to disk.
+/// File write behavior configuration for the receiver.
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct WriteConfig {
     /// Call fsync() after writing each file (`--fsync`).
@@ -127,10 +125,7 @@ pub struct ConnectionConfig {
     pub files_from_data: Option<Vec<u8>>,
 }
 
-/// File selection and filtering options.
-///
-/// Controls which files are candidates for transfer based on size,
-/// existence at destination, and external file lists.
+/// File selection and filtering options for transfer candidates.
 #[derive(Debug, Clone, Eq, PartialEq, Default)]
 pub struct FileSelectionConfig {
     /// Minimum file size in bytes. Files smaller than this are skipped.

--- a/crates/transfer/src/delta_transfer.rs
+++ b/crates/transfer/src/delta_transfer.rs
@@ -437,21 +437,3 @@
 //! - **Engine documentation**: [`engine::delta`]
 //! - **Wire format**: [`protocol::wire`]
 //! - **Metadata**: `metadata::apply`
-//!
-//! # Implementation Status
-//!
-//! **Complete** (as of 2025-12-09):
-//! - ✅ Signature generation from basis files
-//! - ✅ Delta generation with block matching
-//! - ✅ Delta application with atomic file operations
-//! - ✅ Metadata preservation (permissions, timestamps, ownership)
-//! - ✅ Wire protocol integration (protocol 32)
-//! - ✅ SIMD acceleration (AVX2/NEON)
-//! - ✅ Comprehensive test coverage (3,228 tests)
-//!
-//! **Deferred**:
-//! - ⏳ Advanced error handling (ENOSPC, permission errors, cleanup)
-//! - ⏳ Protocol version compatibility testing (28-31)
-//! - ⏳ Performance profiling and optimization
-//! - ⏳ Sparse file detection and handling
-//! - ⏳ Progress reporting callbacks

--- a/crates/transfer/src/error.rs
+++ b/crates/transfer/src/error.rs
@@ -38,11 +38,7 @@ pub enum DeltaTransferError {
 /// Fatal errors that require aborting the entire transfer.
 #[derive(Debug, Error)]
 pub enum DeltaFatalError {
-    /// Disk full - abort to prevent data loss.
-    ///
-    /// When the filesystem runs out of space, continuing the transfer
-    /// risks partial file writes and data corruption. The transfer must
-    /// abort immediately.
+    /// Disk full - abort to prevent partial writes and data corruption.
     #[error("Disk full at {}{}", path.display(), bytes_needed.map(|b| format!(" ({b} bytes needed)")).unwrap_or_default())]
     DiskFull {
         /// Path where disk full was detected.
@@ -51,29 +47,21 @@ pub enum DeltaFatalError {
         bytes_needed: Option<u64>,
     },
 
-    /// Read-only filesystem.
-    ///
-    /// Cannot write to a read-only filesystem. This is fatal because
-    /// it affects all subsequent file operations.
+    /// Read-only filesystem - fatal because it affects all subsequent writes.
     #[error("Read-only filesystem at {}", path.display())]
     ReadOnlyFilesystem {
         /// Path where read-only filesystem was detected.
         path: PathBuf,
     },
 
-    /// Wire protocol error.
-    ///
-    /// Protocol violations indicate a fundamental communication problem
-    /// that cannot be recovered from.
+    /// Wire protocol error indicating a fundamental communication failure.
     #[error("Protocol error: {message}")]
     ProtocolError {
         /// Description of the protocol error.
         message: String,
     },
 
-    /// Other fatal I/O error.
-    ///
-    /// Catch-all for I/O errors that should abort the transfer.
+    /// Other fatal I/O error that should abort the transfer.
     #[error("I/O error: {0}")]
     Io(#[source] io::Error),
 }
@@ -81,20 +69,14 @@ pub enum DeltaFatalError {
 /// Recoverable errors that allow skipping the current file.
 #[derive(Debug, Error)]
 pub enum DeltaRecoverableError {
-    /// File not found (disappeared during transfer).
-    ///
-    /// If a file is deleted between the file list being generated and
-    /// the actual transfer, we can safely skip it.
+    /// File disappeared between file-list generation and transfer.
     #[error("File not found: {}", path.display())]
     FileNotFound {
         /// Path to the missing file.
         path: PathBuf,
     },
 
-    /// Permission denied (insufficient privileges).
-    ///
-    /// Permission errors on individual files can be skipped. The user
-    /// will see a warning but the transfer continues.
+    /// Permission denied on an individual file - skip and continue.
     #[error("Permission denied for {operation} on {}", path.display())]
     PermissionDenied {
         /// Path where permission was denied.
@@ -103,9 +85,7 @@ pub enum DeltaRecoverableError {
         operation: String,
     },
 
-    /// Other I/O error that allows continuing.
-    ///
-    /// Catch-all for I/O errors that affect only the current file.
+    /// Other I/O error affecting only the current file.
     #[error("I/O error on {}: {error}", path.display())]
     Io {
         /// Path where the error occurred.

--- a/crates/transfer/src/handshake.rs
+++ b/crates/transfer/src/handshake.rs
@@ -68,7 +68,6 @@ pub fn perform_handshake(
 
     let remote_version = read_client_version(stdin)?;
 
-    // Negotiate: pick the highest mutually supported version
     let negotiated = select_highest_mutual([remote_version]).map_err(|e| {
         io::Error::new(
             io::ErrorKind::InvalidData,
@@ -96,7 +95,6 @@ fn read_client_version(stdin: &mut dyn Read) -> io::Result<ProtocolVersion> {
     let mut buf = [0u8; 4];
     stdin.read_exact(&mut buf)?;
 
-    // The first byte is the protocol version
     let version_byte = buf[0];
     if version_byte == 0 {
         return Err(io::Error::new(
@@ -134,8 +132,6 @@ pub fn perform_legacy_handshake(
     let mut line = String::new();
     reader.read_line(&mut line)?;
 
-    // Parse the legacy greeting line
-    // Format: @RSYNCD: <version>\n
     let trimmed = line.trim();
     if !trimmed.starts_with("@RSYNCD:") {
         return Err(io::Error::new(
@@ -161,7 +157,6 @@ pub fn perform_legacy_handshake(
             )
         })?;
 
-    // Parse version (may include sub-version like "32.0")
     let version_number: u8 = version_str
         .split('.')
         .next()
@@ -188,7 +183,6 @@ pub fn perform_legacy_handshake(
         )
     })?;
 
-    // Respond with our version in legacy format
     let response = format!("@RSYNCD: {}.0\n", negotiated.as_u8());
     stdout.write_all(response.as_bytes())?;
     stdout.flush()?;

--- a/crates/transfer/src/lib.rs
+++ b/crates/transfer/src/lib.rs
@@ -107,23 +107,15 @@ mod compressed_reader;
 mod compressed_writer;
 /// Server configuration derived from the compact `--server` flag string.
 pub mod config;
-/// Delta application for file transfer.
-///
-/// Encapsulates the logic for applying delta data received from a sender.
-/// Mirrors upstream rsync's `receive_data()` function from `receiver.c:240`.
+/// Delta application mirroring upstream `receiver.c:receive_data()`.
 pub mod delta_apply;
-/// Delta generator configuration parameter object.
-///
-/// Provides `DeltaGeneratorConfig` struct for encapsulating delta generation parameters.
+/// Delta generator configuration parameters.
 pub mod delta_config;
-/// Delta transfer implementation guide and documentation.
-///
-/// **Start here** for comprehensive documentation on how the delta transfer algorithm works,
-/// including signature generation, delta creation, delta application, and metadata preservation.
+/// Delta transfer algorithm documentation and implementation guide.
 pub mod delta_transfer;
-/// Error categorization for delta transfer operations.
+/// Error categorization and retry utilities for delta transfer operations.
 pub mod error;
-/// Parser for the compact server flag string.
+/// Compact server flag string parser (`-logDtpre.iLsfxC`).
 pub mod flags;
 /// Server-side Generator role implementation.
 pub mod generator;
@@ -135,9 +127,7 @@ mod reader;
 pub mod receiver;
 /// Enumerations describing the role executed by the server process.
 pub mod role;
-/// Role trailer formatting for error and warning messages.
-///
-/// Upstream rsync appends `[role=VERSION]` suffixes to diagnostic output.
+/// Role trailer formatting (`[sender=VERSION]`) for diagnostic output.
 pub(crate) mod role_trailer;
 /// Path sanitization mirroring upstream `util1.c:sanitize_path()`.
 pub mod sanitize_path;

--- a/crates/transfer/src/sanitize_path.rs
+++ b/crates/transfer/src/sanitize_path.rs
@@ -59,17 +59,15 @@ fn sanitize_path_with_depth(path: &str, mut depth: i32, keep_dot_dirs: bool) -> 
     let bytes = path.as_bytes();
     let mut p = 0usize;
 
-    // upstream: strip leading slash (absolute -> relative)
+    // upstream: util1.c:1051 - strip leading slash (absolute -> relative)
     if p < bytes.len() && bytes[p] == b'/' {
         p += 1;
-        // depth is forced to 0 for absolute paths in upstream
     }
 
-    // upstream: drop leading "./" unless SP_KEEP_DOT_DIRS
+    // upstream: util1.c:1061 - drop leading "./" unless SP_KEEP_DOT_DIRS
     if !keep_dot_dirs {
         while p + 1 < bytes.len() && bytes[p] == b'.' && bytes[p + 1] == b'/' {
             p += 2;
-            // skip extra slashes
             while p < bytes.len() && bytes[p] == b'/' {
                 p += 1;
             }
@@ -77,25 +75,20 @@ fn sanitize_path_with_depth(path: &str, mut depth: i32, keep_dot_dirs: bool) -> 
     }
 
     let mut result = Vec::with_capacity(bytes.len());
-    // `start` tracks the virtual beginning - segments before it are committed
-    // leading `..` components that were within the depth budget.
+    // Segments before `start` are committed leading `..` within the depth budget.
     let mut start = 0usize;
 
-    // Iterate over path components
     while p < bytes.len() {
-        // Skip leading/extra slashes
         if bytes[p] == b'/' {
             p += 1;
             continue;
         }
 
-        // Check for "." component
         if !keep_dot_dirs && bytes[p] == b'.' && (p + 1 >= bytes.len() || bytes[p + 1] == b'/') {
             p += 1;
             continue;
         }
 
-        // Check for ".." component
         if bytes[p] == b'.'
             && p + 1 < bytes.len()
             && bytes[p + 1] == b'.'
@@ -104,7 +97,6 @@ fn sanitize_path_with_depth(path: &str, mut depth: i32, keep_dot_dirs: bool) -> 
             if depth <= 0 || result.len() > start {
                 p += 2;
                 if result.len() > start {
-                    // Back up one level: remove trailing slash then last component
                     if result.last() == Some(&b'/') {
                         result.pop();
                     }
@@ -114,9 +106,7 @@ fn sanitize_path_with_depth(path: &str, mut depth: i32, keep_dot_dirs: bool) -> 
                 }
                 continue;
             }
-            // Allow this ".." - within depth budget at the start
             depth -= 1;
-            // Copy ".." and advance start past it
             result.extend_from_slice(b"..");
             if p + 2 < bytes.len() {
                 result.push(b'/');
@@ -126,7 +116,6 @@ fn sanitize_path_with_depth(path: &str, mut depth: i32, keep_dot_dirs: bool) -> 
             continue;
         }
 
-        // Copy one component through next slash
         while p < bytes.len() && bytes[p] != b'/' {
             result.push(bytes[p]);
             p += 1;
@@ -137,7 +126,6 @@ fn sanitize_path_with_depth(path: &str, mut depth: i32, keep_dot_dirs: bool) -> 
         }
     }
 
-    // Remove trailing slash
     if result.len() > 1 && result.last() == Some(&b'/') {
         result.pop();
     }

--- a/crates/transfer/src/symlink_safety.rs
+++ b/crates/transfer/src/symlink_safety.rs
@@ -48,13 +48,8 @@ pub fn is_unsafe_symlink(target: &OsStr, link_path: &std::path::Path) -> bool {
         return true;
     }
 
-    // Compute depth budget from the link's position in the transfer tree.
-    // upstream: walks src path counting directory components, resetting on ".."
+    // upstream: util1.c:1356-1383
     let depth = compute_link_depth(link_path);
-
-    // Walk the target, checking if ".." ever escapes the tree.
-    // upstream: walks dest path, decrementing depth on "..", incrementing on
-    // normal components, returns depth < 0
     !is_target_within_depth(&target_bytes, depth)
 }
 

--- a/crates/transfer/src/temp_guard.rs
+++ b/crates/transfer/src/temp_guard.rs
@@ -57,25 +57,19 @@ fn get_tmpname(dest: &Path, temp_dir: Option<&Path>) -> io::Result<PathBuf> {
         .map(|n| n.to_string_lossy().into_owned())
         .unwrap_or_else(|| "rsync".to_owned());
 
-    // Build temp filename: ".filename.XXXXXX"
-    // For dotfiles, skip the leading dot to avoid double-dot (upstream macOS compat).
-    // When using --temp-dir, no leading dot is added (file is already hidden in temp dir).
+    // upstream: receiver.c:get_tmpname() - ".filename.XXXXXX" convention.
+    // No leading dot when using --temp-dir. Dotfiles consume original dot.
     let temp_name = if temp_dir.is_some() {
-        // No leading dot when using temp_dir (mirrors upstream)
         format!("{file_name}.XXXXXX")
     } else {
         let name = if let Some(stripped) = file_name.strip_prefix('.') {
-            // Dotfile: consume original dot, add our own → ".bashrc.XXXXXX"
             stripped
         } else {
-            // Regular file: add leading dot → ".file.txt.XXXXXX"
             &file_name
         };
         format!(".{name}.XXXXXX")
     };
 
-    // Truncate if the temp name exceeds NAME_MAX.
-    // Reserve space for the suffix (.XXXXXX = 7 bytes) + leading dot (1 byte).
     let max_name_len = NAME_MAX;
     let truncated = if temp_name.len() > max_name_len {
         truncate_utf8_safe(&temp_name, max_name_len)
@@ -83,7 +77,6 @@ fn get_tmpname(dest: &Path, temp_dir: Option<&Path>) -> io::Result<PathBuf> {
         temp_name
     };
 
-    // Place in temp_dir or same directory as destination
     let dir = temp_dir.unwrap_or_else(|| dest.parent().unwrap_or(Path::new(".")));
     Ok(dir.join(truncated))
 }
@@ -97,19 +90,14 @@ fn truncate_utf8_safe(s: &str, max_len: usize) -> String {
         return s.to_owned();
     }
 
-    // We need to keep the last TMPNAME_SUFFIX_LEN bytes (".XXXXXX")
-    // and truncate the middle (the original filename part).
     let suffix = &s[s.len() - TMPNAME_SUFFIX_LEN..];
     let prefix_budget = max_len - TMPNAME_SUFFIX_LEN;
-
-    // Find the largest UTF-8-safe prefix
     let prefix = &s[..s.len() - TMPNAME_SUFFIX_LEN];
     let mut safe_end = prefix_budget.min(prefix.len());
     while safe_end > 0 && !prefix.is_char_boundary(safe_end) {
         safe_end -= 1;
     }
 
-    // Trim trailing dot to avoid double-dot before suffix (mirrors upstream)
     let trimmed = prefix[..safe_end].trim_end_matches('.');
 
     format!("{trimmed}{suffix}")
@@ -135,7 +123,6 @@ pub fn open_tmpfile(dest: &Path, temp_dir: Option<&Path>) -> io::Result<(fs::Fil
     let template = get_tmpname(dest, temp_dir)?;
     let template_str = template.to_string_lossy().into_owned();
 
-    // Replace XXXXXX with random chars, retry on collision (mirrors mkstemp behavior)
     for _ in 0..MAX_OPEN_ATTEMPTS {
         let concrete = fill_random_suffix(&template_str);
         let concrete_path = PathBuf::from(&concrete);
@@ -180,11 +167,9 @@ pub fn open_tmpfile(dest: &Path, temp_dir: Option<&Path>) -> io::Result<(fs::Fil
 /// Replaces the trailing `XXXXXX` in a template string with random alphanumeric
 /// characters using `getrandom` for entropy.
 fn fill_random_suffix(template: &str) -> String {
-    // Generate 6 random bytes
     let mut random_bytes = [0u8; 6];
     getrandom::fill(&mut random_bytes).expect("getrandom failed");
 
-    // Build suffix from random bytes
     let suffix: String = random_bytes
         .iter()
         .map(|&b| RAND_CHARS[(b as usize) % RAND_CHARS.len()] as char)


### PR DESCRIPTION
## Summary

- Condense verbose rustdoc on public items to single-line descriptions where multi-line added no value
- Convert restating-the-code inline comments to upstream rsync source references
- Remove echo comments that merely restate what the next line of code does
- Remove outdated "Implementation Status" section from delta_transfer.rs that listed completed features as pending

## Test plan

- [ ] CI fmt+clippy passes (no functional changes, doc/comment only)
- [ ] CI nextest passes on all platforms