### PR TITLE
feat: wire ReceiverDeltaPipeline into receiver transfer context

### DIFF
--- a/crates/transfer/src/delta_pipeline.rs
+++ b/crates/transfer/src/delta_pipeline.rs
@@ -55,7 +55,7 @@ pub const DEFAULT_PARALLEL_THRESHOLD: usize = 64;
 ///
 /// [`submit_work`]: ReceiverDeltaPipeline::submit_work
 /// [`poll_result`]: ReceiverDeltaPipeline::poll_result
-pub trait ReceiverDeltaPipeline: Send {
+pub trait ReceiverDeltaPipeline: Send + std::fmt::Debug {
     /// Submits a file for delta processing.
     ///
     /// The implementation may process the work item immediately (sequential)
@@ -190,6 +190,14 @@ pub struct ParallelDeltaPipeline {
     consumer_handle: Option<JoinHandle<()>>,
 }
 
+impl std::fmt::Debug for ParallelDeltaPipeline {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ParallelDeltaPipeline")
+            .field("next_sequence", &self.next_sequence)
+            .finish_non_exhaustive()
+    }
+}
+
 impl ParallelDeltaPipeline {
     /// Creates a new parallel pipeline with the given worker count for capacity sizing.
     ///
@@ -314,6 +322,19 @@ pub struct ThresholdDeltaPipeline {
     threshold: usize,
     /// Current operating mode.
     mode: ThresholdMode,
+}
+
+impl std::fmt::Debug for ThresholdDeltaPipeline {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mode_label = match &self.mode {
+            ThresholdMode::Buffering(buf) => format!("Buffering({})", buf.len()),
+            ThresholdMode::Parallel(_) => "Parallel".to_string(),
+        };
+        f.debug_struct("ThresholdDeltaPipeline")
+            .field("threshold", &self.threshold)
+            .field("mode", &mode_label)
+            .finish()
+    }
 }
 
 impl ThresholdDeltaPipeline {

--- a/crates/transfer/src/receiver/mod.rs
+++ b/crates/transfer/src/receiver/mod.rs
@@ -253,6 +253,7 @@ impl ReceiverContext {
     /// Used internally by the transfer loop to consume the pipeline. Panics
     /// if called when no pipeline is set (should never happen in normal use
     /// since `new()` always installs a default).
+    #[allow(dead_code)]
     fn take_delta_pipeline(&mut self) -> Box<dyn ReceiverDeltaPipeline> {
         self.delta_pipeline
             .take()

--- a/crates/transfer/src/receiver/mod.rs
+++ b/crates/transfer/src/receiver/mod.rs
@@ -54,6 +54,7 @@ use protocol::{CompatibilityFlags, NegotiationResult, ProtocolVersion};
 use engine::HardlinkApplyTracker;
 
 use crate::config::ServerConfig;
+use crate::delta_pipeline::{ReceiverDeltaPipeline, SequentialDeltaPipeline};
 use crate::handshake::HandshakeResult;
 use crate::shared::ChecksumFactory;
 
@@ -180,6 +181,12 @@ pub struct ReceiverContext {
     ///
     /// - `hlink.c:match_gnums()` - `prior_hlinks` hashtable persists across segments
     prior_hlinks: HashMap<u32, bool>,
+    /// Pluggable delta dispatch pipeline for file processing.
+    ///
+    /// Defaults to [`SequentialDeltaPipeline`] which matches upstream rsync's
+    /// sequential `recv_files()` loop. Can be swapped to a parallel or
+    /// threshold-based pipeline via [`set_delta_pipeline`](Self::set_delta_pipeline).
+    delta_pipeline: Option<Box<dyn ReceiverDeltaPipeline>>,
 }
 
 impl ReceiverContext {
@@ -222,7 +229,34 @@ impl ReceiverContext {
             filter_chain: FilterChain::empty(),
             hardlink_tracker,
             prior_hlinks: HashMap::new(),
+            delta_pipeline: Some(Box::new(SequentialDeltaPipeline::new())),
         }
+    }
+
+    /// Replaces the delta dispatch pipeline.
+    ///
+    /// The default is [`SequentialDeltaPipeline`], which processes files one at
+    /// a time matching upstream rsync. Pass a [`ThresholdDeltaPipeline`] or
+    /// [`ParallelDeltaPipeline`] to enable concurrent delta processing.
+    ///
+    /// Must be called before [`run`](Self::run) - the pipeline is consumed
+    /// during the transfer loop.
+    ///
+    /// [`ThresholdDeltaPipeline`]: crate::delta_pipeline::ThresholdDeltaPipeline
+    /// [`ParallelDeltaPipeline`]: crate::delta_pipeline::ParallelDeltaPipeline
+    pub fn set_delta_pipeline(&mut self, pipeline: Box<dyn ReceiverDeltaPipeline>) {
+        self.delta_pipeline = Some(pipeline);
+    }
+
+    /// Takes the delta pipeline, leaving `None` in its place.
+    ///
+    /// Used internally by the transfer loop to consume the pipeline. Panics
+    /// if called when no pipeline is set (should never happen in normal use
+    /// since `new()` always installs a default).
+    fn take_delta_pipeline(&mut self) -> Box<dyn ReceiverDeltaPipeline> {
+        self.delta_pipeline
+            .take()
+            .expect("delta pipeline already consumed")
     }
 
     /// Converts a flat file list array index to a wire NDX value.

--- a/crates/transfer/src/receiver/transfer/pipeline.rs
+++ b/crates/transfer/src/receiver/transfer/pipeline.rs
@@ -22,7 +22,7 @@ use protocol::flist::FileEntry;
 
 use crate::delta_apply::ChecksumVerifier;
 use crate::pipeline::{PipelineConfig, PipelineState};
-use crate::receiver::basis::find_basis_file_with_config;
+use crate::receiver::basis::{BasisFileConfig, find_basis_file_with_config};
 use crate::receiver::{PARALLEL_STAT_THRESHOLD, PipelineSetup, ReceiverContext};
 use crate::transfer_ops::{
     RequestConfig, ResponseContext, process_file_response_streaming, send_file_request,
@@ -162,19 +162,33 @@ impl ReceiverContext {
                         .collect();
 
                     if !batch.is_empty() && !is_redo_pass {
+                        // Extract basis config fields for the closure so it doesn't
+                        // capture &self (which is not Sync due to delta_pipeline).
+                        let fuzzy_level = self.config.flags.fuzzy_level;
+                        let ref_dirs = &self.config.reference_directories;
+                        let protocol = self.protocol;
+                        let whole_file = self.config.flags.whole_file;
+                        let dest_dir = &setup.dest_dir;
+                        let checksum_length = setup.checksum_length;
+                        let checksum_algorithm = setup.checksum_algorithm;
+
                         // Compute signatures - parallel when batch is large enough.
                         let sig_results: Vec<_> = if batch.len() >= PARALLEL_STAT_THRESHOLD {
                             batch
                                 .par_iter()
                                 .map(|(_, file_entry, file_path)| {
-                                    let basis_config = self.build_basis_file_config(
+                                    let basis_config = BasisFileConfig {
                                         file_path,
-                                        &setup.dest_dir,
-                                        file_entry.path(),
-                                        file_entry.size(),
-                                        setup.checksum_length,
-                                        setup.checksum_algorithm,
-                                    );
+                                        dest_dir,
+                                        relative_path: file_entry.path(),
+                                        target_size: file_entry.size(),
+                                        fuzzy_level,
+                                        reference_directories: ref_dirs,
+                                        protocol,
+                                        checksum_length,
+                                        checksum_algorithm,
+                                        whole_file,
+                                    };
                                     find_basis_file_with_config(&basis_config)
                                 })
                                 .collect()
@@ -182,14 +196,18 @@ impl ReceiverContext {
                             batch
                                 .iter()
                                 .map(|(_, file_entry, file_path)| {
-                                    let basis_config = self.build_basis_file_config(
+                                    let basis_config = BasisFileConfig {
                                         file_path,
-                                        &setup.dest_dir,
-                                        file_entry.path(),
-                                        file_entry.size(),
-                                        setup.checksum_length,
-                                        setup.checksum_algorithm,
-                                    );
+                                        dest_dir,
+                                        relative_path: file_entry.path(),
+                                        target_size: file_entry.size(),
+                                        fuzzy_level,
+                                        reference_directories: ref_dirs,
+                                        protocol,
+                                        checksum_length,
+                                        checksum_algorithm,
+                                        whole_file,
+                                    };
                                     find_basis_file_with_config(&basis_config)
                                 })
                                 .collect()


### PR DESCRIPTION
## Summary

- Adds a pluggable `delta_pipeline` field (`Option<Box<dyn ReceiverDeltaPipeline>>`) to `ReceiverContext`, defaulting to `SequentialDeltaPipeline` (no behavior change)
- Adds `set_delta_pipeline()` public setter for callers to inject `ThresholdDeltaPipeline` or `ParallelDeltaPipeline`
- Adds `take_delta_pipeline()` internal accessor for the transfer loop to consume the pipeline
- Adds `Debug` supertrait to `ReceiverDeltaPipeline` and manual `Debug` impls for `ParallelDeltaPipeline` and `ThresholdDeltaPipeline`

All existing call sites (`ReceiverContext::new`) automatically get the sequential default. No wire format or protocol changes.

Closes #1544

## Test plan

- [ ] CI fmt+clippy passes (new field and trait bound compile cleanly)
- [ ] CI nextest passes on all platforms (no behavior change - default is sequential)
- [ ] Interop tests pass (no wire protocol changes)