### PR TITLE
feat: add per-operation parallel thresholds for stat, signature, and metadata

### DIFF
--- a/crates/protocol/tests/zstd_interop_golden_bytes.rs
+++ b/crates/protocol/tests/zstd_interop_golden_bytes.rs
@@ -373,8 +373,7 @@ fn interop_decode_handcrafted_deflated_data_block() {
     let input = b"handcrafted upstream wire bytes";
 
     // Compress with standalone zstd to get raw payload (simulating upstream encoder)
-    let mut raw_encoder =
-        zstd::stream::write::Encoder::new(Vec::new(), 3).unwrap();
+    let mut raw_encoder = zstd::stream::write::Encoder::new(Vec::new(), 3).unwrap();
     std::io::Write::write_all(&mut raw_encoder, input).unwrap();
     std::io::Write::flush(&mut raw_encoder).unwrap();
     let compressed = raw_encoder.finish().unwrap();
@@ -405,8 +404,7 @@ fn interop_decode_handcrafted_literal_then_block_match() {
     let input = b"literal data before block";
 
     // Compress with standalone zstd (simulating upstream's ZSTD_compressStream2)
-    let mut raw_encoder =
-        zstd::stream::write::Encoder::new(Vec::new(), 3).unwrap();
+    let mut raw_encoder = zstd::stream::write::Encoder::new(Vec::new(), 3).unwrap();
     std::io::Write::write_all(&mut raw_encoder, input).unwrap();
     std::io::Write::flush(&mut raw_encoder).unwrap();
     let compressed = raw_encoder.finish().unwrap();
@@ -433,8 +431,7 @@ fn interop_decode_handcrafted_literal_then_block_match() {
 fn interop_decode_handcrafted_token_long_block() {
     // TOKEN_LONG + 4-byte LE index (1000) + END_FLAG
     let wire = [
-        TOKEN_LONG,
-        0xE8, 0x03, 0x00, 0x00, // 1000 in LE
+        TOKEN_LONG, 0xE8, 0x03, 0x00, 0x00, // 1000 in LE
         END_FLAG,
     ];
 
@@ -452,7 +449,8 @@ fn interop_decode_handcrafted_tokenrun_rel() {
     // TOKENRUN_REL|5, count=9 (LE16) -> blocks 5,6,7,8,9,10,11,12,13,14
     let wire = [
         TOKENRUN_REL | 5,
-        9, 0, // n=9 (LE16)
+        9,
+        0, // n=9 (LE16)
         END_FLAG,
     ];
 
@@ -471,8 +469,12 @@ fn interop_decode_handcrafted_tokenrun_long() {
     // TOKENRUN_LONG, run_start=500 (LE32), n=3 (LE16) -> blocks 500,501,502,503
     let wire = [
         TOKENRUN_LONG,
-        0xF4, 0x01, 0x00, 0x00, // run_start=500
-        3, 0,                     // n=3
+        0xF4,
+        0x01,
+        0x00,
+        0x00, // run_start=500
+        3,
+        0, // n=3
         END_FLAG,
     ];
 

--- a/crates/protocol/tests/zstd_interop_golden_bytes.rs
+++ b/crates/protocol/tests/zstd_interop_golden_bytes.rs
@@ -1,0 +1,1036 @@
+// `| 0` used deliberately in wire format constants to document the offset field.
+#![allow(clippy::identity_op)]
+#![cfg(feature = "zstd")]
+//! Zstd interop golden byte tests against upstream rsync 3.4.1 compressed token stream.
+//!
+//! Verifies wire compatibility between our zstd compressed token encoder/decoder
+//! and upstream rsync's CPRES_ZSTD mode (token.c:send_zstd_token / recv_zstd_token).
+//! Unlike the existing golden byte tests that verify structural properties, these
+//! tests pin exact upstream-compatible byte sequences and verify cross-codec
+//! decompression of raw zstd payloads.
+//!
+//! ## Upstream zstd framing specifics (token.c lines 678-776)
+//!
+//! - `ZSTD_CCtx` created once per session, never reset between files (line 688)
+//! - `ZSTD_e_continue` for literal data accumulation (implicit in compressStream2)
+//! - `ZSTD_e_flush` at every token boundary: block match or end-of-file (line 741)
+//! - Output buffered in `MAX_DATA_COUNT`-sized buffer (line 695, 735-736)
+//! - DEFLATED_DATA blocks written when buffer full OR on flush (line 755)
+//! - `flush_pending` flag tracks whether unflushed data exists (line 769)
+//! - No sync marker stripping (unlike zlib mode)
+//!
+//! ## Upstream zstd decoder behavior (token.c lines 780-870)
+//!
+//! - `ZSTD_DCtx` created once, never reset (line 788)
+//! - Reads DEFLATED_DATA header, then `n` bytes of compressed data (lines 814-821)
+//! - Calls `ZSTD_decompressStream` and returns decompressed output (line 850-851)
+//! - Transitions to `r_idle` when input consumed and output not full (line 862-863)
+//! - Token bytes (TOKEN_REL, TOKEN_LONG, etc.) handled identically to zlib (line 831)
+
+use std::io::{Cursor, Read};
+
+use protocol::wire::{
+    CompressedToken, CompressedTokenDecoder, CompressedTokenEncoder, DEFLATED_DATA, END_FLAG,
+    MAX_DATA_COUNT, TOKEN_LONG, TOKEN_REL, TOKENRUN_LONG, TOKENRUN_REL,
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Decodes all tokens from a zstd-encoded byte buffer.
+fn decode_all_zstd(data: &[u8]) -> (Vec<u8>, Vec<u32>) {
+    let mut cursor = Cursor::new(data);
+    let mut decoder = CompressedTokenDecoder::new_zstd().unwrap();
+    let mut literals = Vec::new();
+    let mut blocks = Vec::new();
+
+    loop {
+        match decoder.recv_token(&mut cursor).unwrap() {
+            CompressedToken::Literal(chunk) => literals.extend_from_slice(&chunk),
+            CompressedToken::BlockMatch(idx) => blocks.push(idx),
+            CompressedToken::End => break,
+        }
+    }
+
+    (literals, blocks)
+}
+
+/// Encodes a literal-only token stream at the given zstd compression level.
+fn encode_literal(data: &[u8], level: i32) -> Vec<u8> {
+    let mut encoder = CompressedTokenEncoder::new_zstd(level).unwrap();
+    let mut output = Vec::new();
+    encoder.send_literal(&mut output, data).unwrap();
+    encoder.finish(&mut output).unwrap();
+    output
+}
+
+/// Encodes a mixed stream of literals and block matches.
+fn encode_mixed(tokens: &[InteropToken], level: i32) -> Vec<u8> {
+    let mut encoder = CompressedTokenEncoder::new_zstd(level).unwrap();
+    let mut output = Vec::new();
+
+    for token in tokens {
+        match token {
+            InteropToken::Literal(data) => encoder.send_literal(&mut output, data).unwrap(),
+            InteropToken::BlockMatch(idx) => encoder.send_block_match(&mut output, *idx).unwrap(),
+        }
+    }
+
+    encoder.finish(&mut output).unwrap();
+    output
+}
+
+#[derive(Clone)]
+enum InteropToken {
+    Literal(Vec<u8>),
+    BlockMatch(u32),
+}
+
+/// Extracts all DEFLATED_DATA payloads from wire bytes, returning them in order
+/// alongside the remaining non-DEFLATED_DATA wire elements.
+fn extract_deflated_payloads(wire: &[u8]) -> (Vec<Vec<u8>>, Vec<u8>) {
+    let mut cursor = Cursor::new(wire);
+    let mut payloads = Vec::new();
+    let mut non_deflated = Vec::new();
+
+    loop {
+        let mut flag_buf = [0u8; 1];
+        if cursor.read_exact(&mut flag_buf).is_err() {
+            break;
+        }
+        let flag = flag_buf[0];
+
+        if (flag & 0xC0) == DEFLATED_DATA {
+            let high = (flag & 0x3F) as usize;
+            let mut low_buf = [0u8; 1];
+            cursor.read_exact(&mut low_buf).unwrap();
+            let len = (high << 8) | (low_buf[0] as usize);
+            let mut payload = vec![0u8; len];
+            cursor.read_exact(&mut payload).unwrap();
+            payloads.push(payload);
+        } else {
+            non_deflated.push(flag);
+            if flag == END_FLAG {
+                break;
+            }
+            // Consume trailing bytes for token types
+            if flag & 0x80 != 0 {
+                if flag & 0xC0 == TOKENRUN_REL {
+                    let mut run_buf = [0u8; 2];
+                    cursor.read_exact(&mut run_buf).unwrap();
+                    non_deflated.extend_from_slice(&run_buf);
+                }
+            } else if flag & 0xE0 == TOKEN_LONG {
+                let mut buf = [0u8; 4];
+                cursor.read_exact(&mut buf).unwrap();
+                non_deflated.extend_from_slice(&buf);
+                if flag & 1 != 0 {
+                    let mut run_buf = [0u8; 2];
+                    cursor.read_exact(&mut run_buf).unwrap();
+                    non_deflated.extend_from_slice(&run_buf);
+                }
+            }
+        }
+    }
+
+    (payloads, non_deflated)
+}
+
+// ===========================================================================
+// Section 1: Raw zstd payload cross-codec verification
+//
+// Extract the raw zstd compressed payload from our DEFLATED_DATA framing
+// and decompress it with the standalone zstd crate to verify the payload
+// is valid, standard zstd data that any conforming decompressor can handle.
+// This proves interop with upstream rsync's ZSTD_decompressStream call.
+//
+// upstream: token.c:846-851 - recv side calls ZSTD_decompressStream on the
+// raw payload bytes read after the DEFLATED_DATA header.
+// ===========================================================================
+
+/// Verify that the raw zstd payload extracted from our wire format can be
+/// decompressed by the standalone zstd crate (simulating upstream's decoder).
+/// This is the core interop guarantee: our encoder produces standard zstd
+/// frames that any ZSTD_decompressStream implementation can consume.
+///
+/// upstream: token.c:850 - ZSTD_decompressStream(zstd_dctx, &out, &in)
+#[test]
+fn interop_raw_payload_decompressible_by_standalone_zstd() {
+    let input = b"upstream rsync 3.4.1 compatibility test data for zstd interop";
+    let encoded = encode_literal(input, 3);
+
+    let (payloads, _) = extract_deflated_payloads(&encoded);
+    assert!(
+        !payloads.is_empty(),
+        "must produce at least one DEFLATED_DATA block"
+    );
+
+    // Concatenate all payloads - they form one continuous zstd stream
+    let raw_zstd: Vec<u8> = payloads.into_iter().flatten().collect();
+
+    // Decompress using the standalone zstd crate (not our wire decoder)
+    let mut decoder = zstd::stream::read::Decoder::new(&raw_zstd[..]).unwrap();
+    let mut decompressed = Vec::new();
+    decoder.read_to_end(&mut decompressed).unwrap();
+
+    assert_eq!(
+        decompressed, input,
+        "raw zstd payload must decompress to original input via standalone zstd crate"
+    );
+}
+
+/// Verify cross-codec decompression for medium-sized repetitive data
+/// typical of directory listing transfers. The repetitive structure
+/// exercises zstd's back-reference decompression across blocks.
+///
+/// upstream: token.c:729-730 - data mapped and fed to compressStream2
+#[test]
+fn interop_raw_payload_medium_repetitive_data() {
+    let mut input = Vec::with_capacity(800);
+    for i in 0..20u8 {
+        input.extend_from_slice(b"drwxr-xr-x  2 root root 4096 ");
+        input.extend_from_slice(format!("entry_{i:03}.dat\n").as_bytes());
+    }
+
+    let encoded = encode_literal(&input, 3);
+    let (payloads, _) = extract_deflated_payloads(&encoded);
+
+    let raw_zstd: Vec<u8> = payloads.into_iter().flatten().collect();
+    let mut decoder = zstd::stream::read::Decoder::new(&raw_zstd[..]).unwrap();
+    let mut decompressed = Vec::new();
+    decoder.read_to_end(&mut decompressed).unwrap();
+
+    assert_eq!(decompressed, input);
+}
+
+/// Verify cross-codec decompression of incompressible random data.
+/// Zstd must handle data that does not compress well, producing
+/// valid frames with stored/literal blocks.
+#[test]
+fn interop_raw_payload_incompressible_data() {
+    // Generate pseudorandom incompressible data using xorshift64
+    let mut state: u64 = 0xDEAD_BEEF_CAFE_1337;
+    let input: Vec<u8> = (0..4096)
+        .map(|_| {
+            state ^= state << 13;
+            state ^= state >> 7;
+            state ^= state << 17;
+            (state & 0xFF) as u8
+        })
+        .collect();
+
+    let encoded = encode_literal(&input, 3);
+    let (payloads, _) = extract_deflated_payloads(&encoded);
+
+    let raw_zstd: Vec<u8> = payloads.into_iter().flatten().collect();
+    let mut decoder = zstd::stream::read::Decoder::new(&raw_zstd[..]).unwrap();
+    let mut decompressed = Vec::new();
+    decoder.read_to_end(&mut decompressed).unwrap();
+
+    assert_eq!(decompressed, input);
+}
+
+// ===========================================================================
+// Section 2: Per-token ZSTD_e_flush boundary verification
+//
+// Upstream rsync flushes the zstd encoder at every token boundary (block
+// match or end-of-file). This means that after each flush, all literal
+// data accumulated since the last flush is decompressible. The tests below
+// verify this flush-per-token invariant by checking that each DEFLATED_DATA
+// block between token bytes produces complete, decompressible output.
+//
+// upstream: token.c:740-741 - if (token != -2) flush = ZSTD_e_flush
+// upstream: token.c:743 - ZSTD_compressStream2(cctx, &out, &in, flush)
+// ===========================================================================
+
+/// Verify that a literal followed by a block match produces a flush boundary.
+/// The DEFLATED_DATA block(s) before the token byte must contain all the
+/// literal data in a decompressible form.
+///
+/// upstream: token.c:727 - nb != 0 triggers compress path, flush at token
+#[test]
+fn interop_flush_boundary_literal_then_block() {
+    let literal = b"data before block match - verifies flush at token boundary";
+    let encoded = encode_mixed(
+        &[
+            InteropToken::Literal(literal.to_vec()),
+            InteropToken::BlockMatch(0),
+        ],
+        3,
+    );
+
+    // Extract payloads before the token byte
+    let (payloads, non_deflated) = extract_deflated_payloads(&encoded);
+    assert!(!payloads.is_empty(), "must have DEFLATED_DATA before token");
+
+    // The non-deflated bytes should be: TOKEN_REL|0, END_FLAG
+    assert_eq!(
+        non_deflated,
+        vec![TOKEN_REL | 0, END_FLAG],
+        "token bytes must follow the flushed DEFLATED_DATA blocks"
+    );
+
+    // The payload must be independently decompressible
+    let raw_zstd: Vec<u8> = payloads.into_iter().flatten().collect();
+    let mut decoder = zstd::stream::read::Decoder::new(&raw_zstd[..]).unwrap();
+    let mut decompressed = Vec::new();
+    decoder.read_to_end(&mut decompressed).unwrap();
+    assert_eq!(decompressed, literal);
+}
+
+/// Verify flush boundaries with interleaved literal-block-literal pattern.
+/// Each literal segment must be flushed before its following token, and
+/// the cumulative zstd stream must decompress to all literal data in order.
+///
+/// upstream: token.c:700-723 - run state logic, then compress+flush at 727-768
+#[test]
+fn interop_flush_boundary_interleaved_pattern() {
+    let encoded = encode_mixed(
+        &[
+            InteropToken::Literal(b"segment-one\n".to_vec()),
+            InteropToken::BlockMatch(0),
+            InteropToken::Literal(b"segment-two\n".to_vec()),
+            InteropToken::BlockMatch(5),
+            InteropToken::Literal(b"segment-three\n".to_vec()),
+        ],
+        3,
+    );
+
+    // Full round-trip must recover all data
+    let (literals, blocks) = decode_all_zstd(&encoded);
+    assert_eq!(literals, b"segment-one\nsegment-two\nsegment-three\n");
+    assert_eq!(blocks, vec![0, 5]);
+
+    // Verify the concatenated raw payloads form a valid zstd stream
+    let (payloads, _) = extract_deflated_payloads(&encoded);
+    assert!(
+        payloads.len() >= 3,
+        "3 literal segments should produce at least 3 DEFLATED_DATA blocks, got {}",
+        payloads.len()
+    );
+
+    let raw_zstd: Vec<u8> = payloads.into_iter().flatten().collect();
+    let mut decoder = zstd::stream::read::Decoder::new(&raw_zstd[..]).unwrap();
+    let mut decompressed = Vec::new();
+    decoder.read_to_end(&mut decompressed).unwrap();
+    assert_eq!(decompressed, b"segment-one\nsegment-two\nsegment-three\n");
+}
+
+/// Verify that ZSTD_e_flush at end-of-file (token == -1) produces a
+/// complete stream. After finish(), the DEFLATED_DATA blocks must form
+/// a fully decompressible zstd stream terminated properly.
+///
+/// upstream: token.c:772-775 - token == -1 triggers END_FLAG write
+#[test]
+fn interop_flush_at_eof_produces_complete_stream() {
+    let input = b"end-of-file flush verification for upstream interop";
+    let encoded = encode_literal(input, 3);
+
+    // Wire must end with END_FLAG
+    assert_eq!(
+        *encoded.last().unwrap(),
+        END_FLAG,
+        "stream must end with END_FLAG"
+    );
+
+    // The entire payload must form a valid, complete zstd stream
+    let (payloads, non_deflated) = extract_deflated_payloads(&encoded);
+    assert_eq!(
+        non_deflated,
+        vec![END_FLAG],
+        "literal-only stream non-deflated bytes should be just END_FLAG"
+    );
+
+    let raw_zstd: Vec<u8> = payloads.into_iter().flatten().collect();
+    let mut decoder = zstd::stream::read::Decoder::new(&raw_zstd[..]).unwrap();
+    let mut decompressed = Vec::new();
+    decoder.read_to_end(&mut decompressed).unwrap();
+    assert_eq!(decompressed, input);
+}
+
+// ===========================================================================
+// Section 3: Upstream-format hand-crafted wire byte decoding
+//
+// These tests construct raw wire byte sequences that match exactly what
+// upstream rsync 3.4.1 would produce for known inputs, then verify our
+// decoder handles them correctly. The byte sequences are built from
+// first principles using the upstream wire format specification.
+//
+// upstream: token.c lines 321-329 - flag byte definitions
+// upstream: token.c:758-760 - DEFLATED_DATA header encoding
+// ===========================================================================
+
+/// Hand-craft a DEFLATED_DATA block containing a known zstd-compressed
+/// payload, followed by END_FLAG. Verify our decoder extracts the
+/// original data correctly.
+///
+/// This simulates receiving a single-block compressed file from upstream.
+///
+/// upstream: token.c:755-760 - write DEFLATED_DATA header + payload
+#[test]
+fn interop_decode_handcrafted_deflated_data_block() {
+    let input = b"handcrafted upstream wire bytes";
+
+    // Compress with standalone zstd to get raw payload (simulating upstream encoder)
+    let mut raw_encoder =
+        zstd::stream::write::Encoder::new(Vec::new(), 3).unwrap();
+    std::io::Write::write_all(&mut raw_encoder, input).unwrap();
+    std::io::Write::flush(&mut raw_encoder).unwrap();
+    let compressed = raw_encoder.finish().unwrap();
+
+    // Build DEFLATED_DATA wire frame: header + payload + END_FLAG
+    let len = compressed.len();
+    assert!(len <= MAX_DATA_COUNT, "payload must fit in one block");
+    let mut wire = Vec::new();
+    wire.push(DEFLATED_DATA | ((len >> 8) as u8));
+    wire.push((len & 0xFF) as u8);
+    wire.extend_from_slice(&compressed);
+    wire.push(END_FLAG);
+
+    // Decode using our wire decoder
+    let (literals, blocks) = decode_all_zstd(&wire);
+    assert_eq!(literals, input);
+    assert!(blocks.is_empty());
+}
+
+/// Hand-craft a wire stream with DEFLATED_DATA + TOKEN_REL + END_FLAG.
+/// This matches upstream's output for a literal followed by a single
+/// block match at index 0.
+///
+/// upstream: token.c:712 - write_byte(f, TOKEN_REL + r) where r=0
+/// upstream: token.c:758-760 - DEFLATED_DATA header before token
+#[test]
+fn interop_decode_handcrafted_literal_then_block_match() {
+    let input = b"literal data before block";
+
+    // Compress with standalone zstd (simulating upstream's ZSTD_compressStream2)
+    let mut raw_encoder =
+        zstd::stream::write::Encoder::new(Vec::new(), 3).unwrap();
+    std::io::Write::write_all(&mut raw_encoder, input).unwrap();
+    std::io::Write::flush(&mut raw_encoder).unwrap();
+    let compressed = raw_encoder.finish().unwrap();
+
+    // Build wire: DEFLATED_DATA(compressed) + TOKEN_REL|0 + END_FLAG
+    let len = compressed.len();
+    let mut wire = Vec::new();
+    wire.push(DEFLATED_DATA | ((len >> 8) as u8));
+    wire.push((len & 0xFF) as u8);
+    wire.extend_from_slice(&compressed);
+    wire.push(TOKEN_REL | 0); // block match at index 0
+    wire.push(END_FLAG);
+
+    let (literals, blocks) = decode_all_zstd(&wire);
+    assert_eq!(literals, input);
+    assert_eq!(blocks, vec![0]);
+}
+
+/// Hand-craft a wire stream with TOKEN_LONG for a large block index.
+/// Upstream uses TOKEN_LONG when the relative offset exceeds 63.
+///
+/// upstream: token.c:714 - write_byte(f, TOKEN_LONG); write_int(f, run_start)
+#[test]
+fn interop_decode_handcrafted_token_long_block() {
+    // TOKEN_LONG + 4-byte LE index (1000) + END_FLAG
+    let wire = [
+        TOKEN_LONG,
+        0xE8, 0x03, 0x00, 0x00, // 1000 in LE
+        END_FLAG,
+    ];
+
+    let (literals, blocks) = decode_all_zstd(&wire);
+    assert!(literals.is_empty());
+    assert_eq!(blocks, vec![1000]);
+}
+
+/// Hand-craft a wire stream with TOKENRUN_REL for consecutive blocks.
+/// Upstream encodes runs of consecutive block matches as a single token.
+///
+/// upstream: token.c:712 - TOKENRUN_REL + r, followed by 16-bit LE count
+#[test]
+fn interop_decode_handcrafted_tokenrun_rel() {
+    // TOKENRUN_REL|5, count=9 (LE16) -> blocks 5,6,7,8,9,10,11,12,13,14
+    let wire = [
+        TOKENRUN_REL | 5,
+        9, 0, // n=9 (LE16)
+        END_FLAG,
+    ];
+
+    let (literals, blocks) = decode_all_zstd(&wire);
+    assert!(literals.is_empty());
+    let expected: Vec<u32> = (5..=14).collect();
+    assert_eq!(blocks, expected);
+}
+
+/// Hand-craft a wire stream with TOKENRUN_LONG for consecutive blocks
+/// starting at a large index.
+///
+/// upstream: token.c:714 - TOKENRUN_LONG + 32-bit LE run_start + 16-bit LE count
+#[test]
+fn interop_decode_handcrafted_tokenrun_long() {
+    // TOKENRUN_LONG, run_start=500 (LE32), n=3 (LE16) -> blocks 500,501,502,503
+    let wire = [
+        TOKENRUN_LONG,
+        0xF4, 0x01, 0x00, 0x00, // run_start=500
+        3, 0,                     // n=3
+        END_FLAG,
+    ];
+
+    let (literals, blocks) = decode_all_zstd(&wire);
+    assert!(literals.is_empty());
+    assert_eq!(blocks, vec![500, 501, 502, 503]);
+}
+
+/// Hand-craft a complex wire stream mixing DEFLATED_DATA, TOKEN_REL,
+/// TOKENRUN_REL, and TOKEN_LONG to verify our decoder handles the full
+/// upstream wire vocabulary in a single stream.
+///
+/// upstream: token.c:700-723 - run detection and token emission
+#[test]
+fn interop_decode_handcrafted_complex_mixed_stream() {
+    let literal1 = b"first segment";
+    let literal2 = b"second segment";
+
+    // Compress both literals with standalone zstd
+    let mut enc1 = zstd::stream::write::Encoder::new(Vec::new(), 3).unwrap();
+    std::io::Write::write_all(&mut enc1, literal1).unwrap();
+    std::io::Write::flush(&mut enc1).unwrap();
+    let comp1 = enc1.finish().unwrap();
+
+    let mut enc2 = zstd::stream::write::Encoder::new(Vec::new(), 3).unwrap();
+    std::io::Write::write_all(&mut enc2, literal2).unwrap();
+    std::io::Write::flush(&mut enc2).unwrap();
+    let comp2 = enc2.finish().unwrap();
+
+    // Build wire: DEFLATED(lit1) + TOKEN_REL|0 + DEFLATED(lit2) + TOKEN_LONG(100) + END_FLAG
+    let mut wire = Vec::new();
+
+    // First DEFLATED_DATA block
+    let len1 = comp1.len();
+    wire.push(DEFLATED_DATA | ((len1 >> 8) as u8));
+    wire.push((len1 & 0xFF) as u8);
+    wire.extend_from_slice(&comp1);
+
+    // TOKEN_REL | 0 (block match at index 0)
+    wire.push(TOKEN_REL | 0);
+
+    // Second DEFLATED_DATA block
+    let len2 = comp2.len();
+    wire.push(DEFLATED_DATA | ((len2 >> 8) as u8));
+    wire.push((len2 & 0xFF) as u8);
+    wire.extend_from_slice(&comp2);
+
+    // TOKEN_LONG (block match at index 100, relative offset > 63)
+    wire.push(TOKEN_LONG);
+    wire.extend_from_slice(&100i32.to_le_bytes());
+
+    // END_FLAG
+    wire.push(END_FLAG);
+
+    let (literals, blocks) = decode_all_zstd(&wire);
+    assert_eq!(literals, b"first segmentsecond segment");
+    assert_eq!(blocks, vec![0, 100]);
+}
+
+// ===========================================================================
+// Section 4: DEFLATED_DATA header encoding interop
+//
+// Verify exact header byte encoding matches upstream's formula:
+//   obuf[0] = DEFLATED_DATA + (n >> 8)
+//   obuf[1] = n
+// (upstream token.c lines 758-759)
+// ===========================================================================
+
+/// Verify DEFLATED_DATA header encoding for small payloads where the
+/// length fits entirely in the second byte (high bits are zero).
+///
+/// upstream: token.c:758-759 - obuf[0] = DEFLATED_DATA + (n >> 8), obuf[1] = n
+#[test]
+fn interop_deflated_header_small_payload() {
+    let encoded = encode_literal(b"x", 3);
+
+    let byte0 = encoded[0];
+    let byte1 = encoded[1];
+
+    // For small payload, n < 256, so n >> 8 == 0
+    assert_eq!(
+        byte0 & 0xC0, DEFLATED_DATA,
+        "must have DEFLATED_DATA flag"
+    );
+
+    let declared_len = ((byte0 & 0x3F) as usize) << 8 | byte1 as usize;
+    assert!(declared_len > 0, "payload must not be empty");
+    assert!(declared_len <= MAX_DATA_COUNT, "payload must fit in 14 bits");
+
+    // Verify the declared length matches actual payload
+    let actual_payload = &encoded[2..2 + declared_len];
+    assert_eq!(actual_payload.len(), declared_len);
+
+    // After payload: END_FLAG
+    assert_eq!(encoded[2 + declared_len], END_FLAG);
+}
+
+/// Verify DEFLATED_DATA header encoding uses both bytes of the 14-bit
+/// length field for larger payloads. With incompressible data, zstd
+/// output can exceed 256 bytes.
+///
+/// upstream: token.c:758 - obuf[0] = DEFLATED_DATA + (n >> 8) where n > 255
+#[test]
+fn interop_deflated_header_large_payload_uses_high_bits() {
+    // Generate ~1KB of incompressible data (will compress to > 256 bytes)
+    let mut state: u64 = 0xABCD_EF01_2345_6789;
+    let input: Vec<u8> = (0..2048)
+        .map(|_| {
+            state ^= state << 13;
+            state ^= state >> 7;
+            state ^= state << 17;
+            (state & 0xFF) as u8
+        })
+        .collect();
+
+    let encoded = encode_literal(&input, 3);
+
+    // Find a DEFLATED_DATA block with length > 255
+    let mut found_large = false;
+    let mut cursor = Cursor::new(&encoded[..]);
+    loop {
+        let mut flag_buf = [0u8; 1];
+        if cursor.read_exact(&mut flag_buf).is_err() {
+            break;
+        }
+        let flag = flag_buf[0];
+        if (flag & 0xC0) == DEFLATED_DATA {
+            let high = (flag & 0x3F) as usize;
+            let mut low_buf = [0u8; 1];
+            cursor.read_exact(&mut low_buf).unwrap();
+            let len = (high << 8) | (low_buf[0] as usize);
+
+            if len > 255 {
+                found_large = true;
+                // Verify the encoding: high bits must be non-zero
+                assert!(high > 0, "n > 255 requires high bits in byte 0");
+                // Verify reconstruction matches upstream formula
+                let reconstructed_byte0 = DEFLATED_DATA | (len >> 8) as u8;
+                let reconstructed_byte1 = (len & 0xFF) as u8;
+                assert_eq!(flag, reconstructed_byte0);
+                assert_eq!(low_buf[0], reconstructed_byte1);
+            }
+            let pos = cursor.position() as usize;
+            cursor.set_position((pos + len) as u64);
+        } else {
+            break;
+        }
+    }
+
+    assert!(
+        found_large,
+        "incompressible 2KB input should produce DEFLATED_DATA with len > 255"
+    );
+}
+
+// ===========================================================================
+// Section 5: Multi-file session interop - persistent zstd context
+//
+// Upstream rsync maintains a single ZSTD_CCtx / ZSTD_DCtx for the entire
+// transfer session. The context is NEVER reset between files - only the
+// token run-encoding state resets. This means the second file benefits
+// from dictionary/history built during the first file.
+//
+// upstream: token.c:686-698 - CCtx created once, comp_init_done flag
+// upstream: token.c:700-703 - only last_token/run_start/flush_pending reset
+// upstream: token.c:787-803 - DCtx created once, decomp_init_done flag
+// ===========================================================================
+
+/// Verify that our encoder/decoder can handle a multi-file session where
+/// the zstd context persists. Encode three files with one encoder, decode
+/// with one decoder, verify each file's data independently.
+///
+/// upstream: token.c:688 - CCtx created once, persists across files
+/// upstream: token.c:788 - DCtx created once, persists across files
+#[test]
+fn interop_multi_file_session_persistent_context() {
+    let files: &[&[u8]] = &[
+        b"# config.yml\nhost: rsync.example.com\nport: 873\n",
+        b"drwxr-xr-x root root 4096 modules/\ndrwxr-xr-x root root 4096 data/\n",
+        b"# config.yml\nhost: rsync.example.com\nport: 873\nmodule: backup\n",
+    ];
+
+    let mut encoder = CompressedTokenEncoder::new_zstd(3).unwrap();
+    let mut wire = Vec::new();
+
+    // Encode all three files
+    for file_data in files {
+        encoder.send_literal(&mut wire, file_data).unwrap();
+        encoder.finish(&mut wire).unwrap();
+    }
+
+    // Decode all three files with persistent decoder
+    let mut cursor = Cursor::new(&wire);
+    let mut decoder = CompressedTokenDecoder::new_zstd().unwrap();
+
+    for (i, expected) in files.iter().enumerate() {
+        let mut literals = Vec::new();
+        loop {
+            match decoder.recv_token(&mut cursor).unwrap() {
+                CompressedToken::Literal(d) => literals.extend_from_slice(&d),
+                CompressedToken::End => break,
+                CompressedToken::BlockMatch(_) => {
+                    panic!("file {i} should have no block matches")
+                }
+            }
+        }
+        assert_eq!(
+            literals, *expected,
+            "file {i} data mismatch in multi-file session"
+        );
+        decoder.reset();
+    }
+}
+
+/// Verify that the third file in a session with shared content compresses
+/// better than in isolation, proving the zstd context carries dictionary
+/// history across file boundaries.
+///
+/// upstream: token.c:686-698 - CCtx never recreated, dictionary persists
+#[test]
+fn interop_cross_file_dictionary_improves_compression() {
+    let shared_line = b"drwxr-xr-x  2 root root 4096 shared_module_data.txt\n";
+
+    // Encode file 1 (establishes dictionary) then file 2 (benefits)
+    let mut encoder = CompressedTokenEncoder::new_zstd(3).unwrap();
+    let mut session_wire = Vec::new();
+
+    encoder.send_literal(&mut session_wire, shared_line).unwrap();
+    encoder.finish(&mut session_wire).unwrap();
+    let file1_end = session_wire.len();
+
+    encoder.send_literal(&mut session_wire, shared_line).unwrap();
+    encoder.finish(&mut session_wire).unwrap();
+    let file2_session_len = session_wire.len() - file1_end;
+
+    // Encode same content in isolation (fresh context, no dictionary)
+    let isolated = encode_literal(shared_line, 3);
+
+    assert!(
+        file2_session_len <= isolated.len(),
+        "session file 2 ({file2_session_len}) should be <= isolated ({}) \
+         due to cross-file dictionary",
+        isolated.len()
+    );
+}
+
+// ===========================================================================
+// Section 6: Zstd frame magic and structural invariants
+//
+// Verify that the zstd compressed payloads contain valid zstd frame
+// structure, matching what upstream rsync's zstd encoder produces.
+// ===========================================================================
+
+/// Verify that the first DEFLATED_DATA payload starts with the zstd
+/// frame magic number (0xFD2FB528 in little-endian). This is a
+/// fundamental structural requirement for zstd interop.
+///
+/// upstream: token.c:694 - ZSTD_CCtx_setParameter, standard frame output
+#[test]
+fn interop_zstd_frame_magic_in_first_payload() {
+    let encoded = encode_literal(b"verify zstd frame magic for interop", 3);
+    let (payloads, _) = extract_deflated_payloads(&encoded);
+    assert!(!payloads.is_empty());
+
+    let first_payload = &payloads[0];
+    assert!(
+        first_payload.len() >= 4,
+        "payload too short for zstd magic"
+    );
+
+    let magic = u32::from_le_bytes([
+        first_payload[0],
+        first_payload[1],
+        first_payload[2],
+        first_payload[3],
+    ]);
+    assert_eq!(
+        magic, 0xFD2F_B528,
+        "first payload must start with zstd frame magic 0xFD2FB528"
+    );
+}
+
+/// Verify that zstd payloads never contain the zlib sync marker
+/// (0x00 0x00 0xFF 0xFF). This distinguishes zstd mode from zlib mode
+/// on the wire and is critical for mode detection.
+///
+/// upstream: token.c:685 - zstd never strips sync markers because it
+/// never produces them
+#[test]
+fn interop_no_zlib_sync_markers_in_zstd_payload() {
+    // Use data that might trigger false positives with certain byte patterns
+    let mut input = Vec::with_capacity(512);
+    for byte in 0..=255u8 {
+        input.push(byte);
+        input.push(byte.wrapping_add(1));
+    }
+
+    let encoded = encode_literal(&input, 3);
+    let (payloads, _) = extract_deflated_payloads(&encoded);
+
+    let sync_marker = [0x00u8, 0x00, 0xFF, 0xFF];
+    for (i, payload) in payloads.iter().enumerate() {
+        for window in payload.windows(4) {
+            assert_ne!(
+                window, &sync_marker,
+                "DEFLATED_DATA block {i} must not contain zlib sync marker"
+            );
+        }
+    }
+}
+
+/// Verify all DEFLATED_DATA blocks respect the MAX_DATA_COUNT limit.
+/// Upstream writes output only when the buffer is full (MAX_DATA_COUNT)
+/// or on flush.
+///
+/// upstream: token.c:735-736 - zstd_out_buff.size = MAX_DATA_COUNT
+/// upstream: token.c:755 - write when pos == size or on flush
+#[test]
+fn interop_all_deflated_blocks_within_max_data_count() {
+    // Generate large data that will produce multiple DEFLATED_DATA blocks
+    let mut state: u64 = 0x1234_5678_9ABC_DEF0;
+    let input: Vec<u8> = (0..100_000)
+        .map(|_| {
+            state ^= state << 13;
+            state ^= state >> 7;
+            state ^= state << 17;
+            (state & 0xFF) as u8
+        })
+        .collect();
+
+    let encoded = encode_literal(&input, 3);
+    let (payloads, _) = extract_deflated_payloads(&encoded);
+
+    assert!(
+        payloads.len() > 1,
+        "100KB incompressible data should produce multiple blocks"
+    );
+
+    for (i, payload) in payloads.iter().enumerate() {
+        assert!(
+            payload.len() <= MAX_DATA_COUNT,
+            "block {i} size {} exceeds MAX_DATA_COUNT ({MAX_DATA_COUNT})",
+            payload.len()
+        );
+        assert!(!payload.is_empty(), "block {i} must not be empty");
+    }
+}
+
+// ===========================================================================
+// Section 7: Compression level interop
+//
+// Upstream rsync respects the --compress-level flag, defaulting to
+// ZSTD_CLEVEL_DEFAULT (3) for daemon mode. Verify that different
+// compression levels all produce valid, decodable output.
+//
+// upstream: token.c:694 - ZSTD_CCtx_setParameter(cctx, ZSTD_c_compressionLevel, level)
+// ===========================================================================
+
+/// Verify that compression levels 1 through 6 all produce valid
+/// interoperable output. These are the most commonly used levels
+/// in production rsync daemon configurations.
+///
+/// upstream: token.c:694 - compression level applied via CCtx parameter
+#[test]
+fn interop_compression_levels_all_produce_valid_output() {
+    let input = b"compression level interop test - verify all levels produce valid zstd frames";
+
+    for level in 1..=6 {
+        let encoded = encode_literal(input, level);
+
+        // Verify round-trip through our decoder
+        let (literals, blocks) = decode_all_zstd(&encoded);
+        assert_eq!(
+            literals, input,
+            "round-trip failed at level {level}"
+        );
+        assert!(blocks.is_empty());
+
+        // Verify raw payload decompressible by standalone zstd
+        let (payloads, _) = extract_deflated_payloads(&encoded);
+        let raw: Vec<u8> = payloads.into_iter().flatten().collect();
+        let mut dec = zstd::stream::read::Decoder::new(&raw[..]).unwrap();
+        let mut out = Vec::new();
+        dec.read_to_end(&mut out).unwrap();
+        assert_eq!(out, input, "standalone zstd decode failed at level {level}");
+    }
+}
+
+/// Verify that higher compression levels produce smaller or equal output
+/// for compressible data, matching upstream's behavior where level
+/// affects compression ratio but not wire format correctness.
+///
+/// upstream: token.c:694 - level controls zstd internal strategy
+#[test]
+fn interop_higher_level_better_compression() {
+    let mut input = Vec::with_capacity(2000);
+    for i in 0..50u8 {
+        input.extend_from_slice(b"drwxr-xr-x  2 root root 4096 ");
+        input.extend_from_slice(format!("module_{i:03}/data.bin\n").as_bytes());
+    }
+
+    let wire_1 = encode_literal(&input, 1);
+    let wire_3 = encode_literal(&input, 3);
+    let wire_6 = encode_literal(&input, 6);
+
+    // All must decode correctly
+    assert_eq!(decode_all_zstd(&wire_1).0, input);
+    assert_eq!(decode_all_zstd(&wire_3).0, input);
+    assert_eq!(decode_all_zstd(&wire_6).0, input);
+
+    // Higher levels should compress at least as well
+    assert!(
+        wire_3.len() <= wire_1.len(),
+        "level 3 ({}) should be <= level 1 ({})",
+        wire_3.len(),
+        wire_1.len()
+    );
+    assert!(
+        wire_6.len() <= wire_3.len(),
+        "level 6 ({}) should be <= level 3 ({})",
+        wire_6.len(),
+        wire_3.len()
+    );
+}
+
+// ===========================================================================
+// Section 8: Round-trip integrity with diverse data patterns
+//
+// Verify that our encoder produces output that our decoder can consume
+// correctly for various data patterns representative of real rsync
+// transfers. Each test encodes, then decodes, then verifies exact
+// data and block-match recovery.
+// ===========================================================================
+
+/// Round-trip a mixed stream representing a typical incremental file
+/// transfer: changed header, unchanged middle blocks, changed footer.
+///
+/// upstream: token.c:678-776 - send path, 780-870 - recv path
+#[test]
+fn interop_roundtrip_incremental_transfer_pattern() {
+    let encoded = encode_mixed(
+        &[
+            InteropToken::Literal(b"#!/bin/bash\n# Updated header\n".to_vec()),
+            InteropToken::BlockMatch(0),
+            InteropToken::BlockMatch(1),
+            InteropToken::BlockMatch(2),
+            InteropToken::BlockMatch(3),
+            InteropToken::Literal(b"\n# Updated footer\nexit 0\n".to_vec()),
+        ],
+        3,
+    );
+
+    let (literals, blocks) = decode_all_zstd(&encoded);
+    assert_eq!(
+        literals,
+        b"#!/bin/bash\n# Updated header\n\n# Updated footer\nexit 0\n"
+    );
+    assert_eq!(blocks, vec![0, 1, 2, 3]);
+}
+
+/// Round-trip with zero-length input (empty file transfer).
+/// Must produce only END_FLAG with no DEFLATED_DATA blocks.
+///
+/// upstream: token.c:772-775 - token==-1 with no preceding data
+#[test]
+fn interop_roundtrip_empty_file() {
+    let mut encoder = CompressedTokenEncoder::new_zstd(3).unwrap();
+    let mut wire = Vec::new();
+    encoder.finish(&mut wire).unwrap();
+
+    assert_eq!(wire, vec![END_FLAG], "empty file should produce only END_FLAG");
+
+    let (literals, blocks) = decode_all_zstd(&wire);
+    assert!(literals.is_empty());
+    assert!(blocks.is_empty());
+}
+
+/// Round-trip with block-match-only stream (basis file unchanged).
+/// No DEFLATED_DATA blocks should appear - only token bytes.
+///
+/// upstream: token.c:706-723 - token emission without preceding literals
+#[test]
+fn interop_roundtrip_blocks_only_no_deflated_data() {
+    let encoded = encode_mixed(
+        &[
+            InteropToken::BlockMatch(0),
+            InteropToken::BlockMatch(1),
+            InteropToken::BlockMatch(2),
+        ],
+        3,
+    );
+
+    // Should have no DEFLATED_DATA blocks
+    let (payloads, _) = extract_deflated_payloads(&encoded);
+    assert!(
+        payloads.is_empty(),
+        "block-match-only stream should have no DEFLATED_DATA blocks"
+    );
+
+    let (literals, blocks) = decode_all_zstd(&encoded);
+    assert!(literals.is_empty());
+    assert_eq!(blocks, vec![0, 1, 2]);
+}
+
+/// Round-trip with a single large literal (64 KB) that exceeds
+/// `MAX_DATA_COUNT`, forcing multiple DEFLATED_DATA blocks.
+/// Verifies our chunking matches upstream's buffer-full write behavior.
+///
+/// upstream: token.c:755 - write when zstd_out_buff.pos == zstd_out_buff.size
+#[test]
+fn interop_roundtrip_large_literal_multiple_blocks() {
+    // Compressible data that still produces multiple output blocks
+    let input: Vec<u8> = (0..65536u32)
+        .flat_map(|i| format!("line {i:05}\n").into_bytes())
+        .collect();
+
+    let encoded = encode_literal(&input, 3);
+    let (payloads, _) = extract_deflated_payloads(&encoded);
+
+    // Large compressible input should still produce at least 2 blocks
+    assert!(
+        payloads.len() >= 2,
+        "large literal should produce multiple DEFLATED_DATA blocks, got {}",
+        payloads.len()
+    );
+
+    let (literals, blocks) = decode_all_zstd(&encoded);
+    assert_eq!(literals, input);
+    assert!(blocks.is_empty());
+}
+
+/// Round-trip with alternating small literals and block matches,
+/// verifying that the flush-per-token pattern preserves all data
+/// through many interleaving cycles.
+///
+/// upstream: token.c:727-768 - compress+flush loop per token
+#[test]
+fn interop_roundtrip_many_small_interleaved_tokens() {
+    let mut tokens = Vec::new();
+    let mut expected_literals = Vec::new();
+    let mut expected_blocks = Vec::new();
+
+    for i in 0..20u32 {
+        let lit = format!("chunk-{i:02}\n");
+        expected_literals.extend_from_slice(lit.as_bytes());
+        tokens.push(InteropToken::Literal(lit.into_bytes()));
+
+        expected_blocks.push(i);
+        tokens.push(InteropToken::BlockMatch(i));
+    }
+    // Trailing literal
+    let tail = b"tail\n";
+    expected_literals.extend_from_slice(tail);
+    tokens.push(InteropToken::Literal(tail.to_vec()));
+
+    let encoded = encode_mixed(&tokens, 3);
+    let (literals, blocks) = decode_all_zstd(&encoded);
+
+    assert_eq!(literals, expected_literals);
+    assert_eq!(blocks, expected_blocks);
+}

--- a/crates/protocol/tests/zstd_interop_golden_bytes.rs
+++ b/crates/protocol/tests/zstd_interop_golden_bytes.rs
@@ -553,14 +553,14 @@ fn interop_deflated_header_small_payload() {
     let byte1 = encoded[1];
 
     // For small payload, n < 256, so n >> 8 == 0
-    assert_eq!(
-        byte0 & 0xC0, DEFLATED_DATA,
-        "must have DEFLATED_DATA flag"
-    );
+    assert_eq!(byte0 & 0xC0, DEFLATED_DATA, "must have DEFLATED_DATA flag");
 
     let declared_len = ((byte0 & 0x3F) as usize) << 8 | byte1 as usize;
     assert!(declared_len > 0, "payload must not be empty");
-    assert!(declared_len <= MAX_DATA_COUNT, "payload must fit in 14 bits");
+    assert!(
+        declared_len <= MAX_DATA_COUNT,
+        "payload must fit in 14 bits"
+    );
 
     // Verify the declared length matches actual payload
     let actual_payload = &encoded[2..2 + declared_len];
@@ -700,11 +700,15 @@ fn interop_cross_file_dictionary_improves_compression() {
     let mut encoder = CompressedTokenEncoder::new_zstd(3).unwrap();
     let mut session_wire = Vec::new();
 
-    encoder.send_literal(&mut session_wire, shared_line).unwrap();
+    encoder
+        .send_literal(&mut session_wire, shared_line)
+        .unwrap();
     encoder.finish(&mut session_wire).unwrap();
     let file1_end = session_wire.len();
 
-    encoder.send_literal(&mut session_wire, shared_line).unwrap();
+    encoder
+        .send_literal(&mut session_wire, shared_line)
+        .unwrap();
     encoder.finish(&mut session_wire).unwrap();
     let file2_session_len = session_wire.len() - file1_end;
 
@@ -738,10 +742,7 @@ fn interop_zstd_frame_magic_in_first_payload() {
     assert!(!payloads.is_empty());
 
     let first_payload = &payloads[0];
-    assert!(
-        first_payload.len() >= 4,
-        "payload too short for zstd magic"
-    );
+    assert!(first_payload.len() >= 4, "payload too short for zstd magic");
 
     let magic = u32::from_le_bytes([
         first_payload[0],
@@ -845,10 +846,7 @@ fn interop_compression_levels_all_produce_valid_output() {
 
         // Verify round-trip through our decoder
         let (literals, blocks) = decode_all_zstd(&encoded);
-        assert_eq!(
-            literals, input,
-            "round-trip failed at level {level}"
-        );
+        assert_eq!(literals, input, "round-trip failed at level {level}");
         assert!(blocks.is_empty());
 
         // Verify raw payload decompressible by standalone zstd
@@ -943,7 +941,11 @@ fn interop_roundtrip_empty_file() {
     let mut wire = Vec::new();
     encoder.finish(&mut wire).unwrap();
 
-    assert_eq!(wire, vec![END_FLAG], "empty file should produce only END_FLAG");
+    assert_eq!(
+        wire,
+        vec![END_FLAG],
+        "empty file should produce only END_FLAG"
+    );
 
     let (literals, blocks) = decode_all_zstd(&wire);
     assert!(literals.is_empty());

--- a/crates/transfer/src/delta_pipeline.rs
+++ b/crates/transfer/src/delta_pipeline.rs
@@ -38,10 +38,10 @@ use engine::concurrent_delta::{DeltaResult, DeltaWork};
 
 /// Default threshold for switching from sequential to parallel dispatch.
 ///
-/// Matches the receiver's `PARALLEL_STAT_THRESHOLD` (64 files). Below this
-/// count, the overhead of thread spawning and channel communication exceeds
-/// the benefit of parallelism.
-pub const DEFAULT_PARALLEL_THRESHOLD: usize = 64;
+/// Matches the default stat threshold from [`ParallelThresholds`](crate::parallel_io::ParallelThresholds).
+/// Below this count, the overhead of thread spawning and channel communication
+/// exceeds the benefit of parallelism.
+pub const DEFAULT_PARALLEL_THRESHOLD: usize = crate::parallel_io::DEFAULT_STAT_THRESHOLD;
 
 /// Abstraction over the delta dispatch loop in the receiver.
 ///
@@ -301,14 +301,13 @@ enum ThresholdMode {
 ///   in which case items are processed sequentially.
 ///
 /// This follows the threshold-based dual-path pattern used throughout the
-/// codebase (e.g., `PARALLEL_STAT_THRESHOLD` in the receiver). For small
-/// transfers, the overhead of spawning threads and channels exceeds the
-/// benefit of parallelism.
+/// codebase (see [`ParallelThresholds`](crate::parallel_io::ParallelThresholds)
+/// for per-operation thresholds). For small transfers, the overhead of spawning
+/// threads and channels exceeds the benefit of parallelism.
 ///
 /// # Default Threshold
 ///
-/// [`DEFAULT_PARALLEL_THRESHOLD`] = 64, matching the receiver's
-/// `PARALLEL_STAT_THRESHOLD`.
+/// [`DEFAULT_PARALLEL_THRESHOLD`] = 64, matching the default stat threshold.
 pub struct ThresholdDeltaPipeline {
     /// Number of items required to switch to parallel mode.
     threshold: usize,

--- a/crates/transfer/src/generator/file_list/batch_stat.rs
+++ b/crates/transfer/src/generator/file_list/batch_stat.rs
@@ -1,7 +1,7 @@
 //! Batched metadata resolution for directory entries.
 //!
 //! Parallelizes `stat()` / `lstat()` syscalls across directory children using
-//! rayon when the entry count exceeds [`PARALLEL_STAT_THRESHOLD`]. For small
+//! rayon when the entry count exceeds the configured stat threshold. For small
 //! directories the overhead of thread-pool dispatch is avoided by falling back
 //! to sequential iteration.
 //!
@@ -12,14 +12,7 @@
 use std::fs;
 use std::path::PathBuf;
 
-use crate::parallel_io::map_blocking;
-
-/// Minimum number of directory entries required before parallel stat is used.
-///
-/// Below this threshold, sequential stat is faster because it avoids rayon
-/// thread-pool dispatch overhead. Value matches the receiver's threshold
-/// in `crate::receiver::PARALLEL_STAT_THRESHOLD`.
-pub(in crate::generator) const PARALLEL_STAT_THRESHOLD: usize = 64;
+use crate::parallel_io::{ParallelThresholds, map_blocking};
 
 /// Result of batched metadata resolution for a single directory entry.
 ///
@@ -40,13 +33,14 @@ pub(in crate::generator) struct StatResult {
 /// after receiving the raw metadata.
 ///
 /// Uses [`map_blocking`] which dispatches to rayon's work-stealing pool when
-/// the entry count meets [`PARALLEL_STAT_THRESHOLD`], otherwise falls back to
-/// sequential iteration.
+/// the entry count meets the stat threshold from `thresholds`, otherwise falls
+/// back to sequential iteration.
 pub(in crate::generator) fn batch_stat_dir_entries(
     paths: Vec<PathBuf>,
     follow_symlinks: bool,
+    thresholds: &ParallelThresholds,
 ) -> Vec<StatResult> {
-    map_blocking(paths, PARALLEL_STAT_THRESHOLD, move |path| {
+    map_blocking(paths, thresholds.stat, move |path| {
         let metadata = if follow_symlinks {
             fs::metadata(&path)
         } else {
@@ -62,6 +56,10 @@ mod tests {
     use std::fs::File;
     use tempfile::TempDir;
 
+    fn default_thresholds() -> ParallelThresholds {
+        ParallelThresholds::default()
+    }
+
     #[test]
     fn batch_stat_sequential_small_dir() {
         let dir = TempDir::new().unwrap();
@@ -75,7 +73,7 @@ mod tests {
             paths.push(p);
         }
 
-        let results = batch_stat_dir_entries(paths, false);
+        let results = batch_stat_dir_entries(paths, false, &default_thresholds());
         assert_eq!(results.len(), 5);
         for r in &results {
             assert!(
@@ -91,8 +89,9 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let root = dir.path();
 
+        let thresholds = default_thresholds();
         // Create enough files to exceed the parallel threshold
-        let count = PARALLEL_STAT_THRESHOLD + 10;
+        let count = thresholds.stat + 10;
         let mut paths = Vec::new();
         for i in 0..count {
             let p = root.join(format!("file{i}.txt"));
@@ -100,7 +99,7 @@ mod tests {
             paths.push(p);
         }
 
-        let results = batch_stat_dir_entries(paths, false);
+        let results = batch_stat_dir_entries(paths, false, &thresholds);
         assert_eq!(results.len(), count);
         for r in &results {
             assert!(
@@ -116,7 +115,8 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let root = dir.path();
 
-        let count = PARALLEL_STAT_THRESHOLD + 20;
+        let thresholds = default_thresholds();
+        let count = thresholds.stat + 20;
         let mut paths = Vec::new();
         for i in 0..count {
             let p = root.join(format!("entry_{i:04}.dat"));
@@ -125,7 +125,7 @@ mod tests {
         }
 
         let original_paths: Vec<PathBuf> = paths.clone();
-        let results = batch_stat_dir_entries(paths, false);
+        let results = batch_stat_dir_entries(paths, false, &thresholds);
 
         // Results must be in the same order as input
         for (i, r) in results.iter().enumerate() {
@@ -136,7 +136,7 @@ mod tests {
     #[test]
     fn batch_stat_nonexistent_returns_error() {
         let paths = vec![PathBuf::from("/nonexistent/path/abc123")];
-        let results = batch_stat_dir_entries(paths, false);
+        let results = batch_stat_dir_entries(paths, false, &default_thresholds());
         assert_eq!(results.len(), 1);
         assert!(results[0].metadata.is_err());
     }
@@ -148,19 +148,20 @@ mod tests {
 
         let p = root.join("regular.txt");
         File::create(&p).unwrap();
+        let thresholds = default_thresholds();
 
         // With follow_symlinks=true, uses fs::metadata (follows symlinks)
-        let results_follow = batch_stat_dir_entries(vec![p.clone()], true);
+        let results_follow = batch_stat_dir_entries(vec![p.clone()], true, &thresholds);
         assert!(results_follow[0].metadata.is_ok());
 
         // With follow_symlinks=false, uses fs::symlink_metadata (lstat)
-        let results_lstat = batch_stat_dir_entries(vec![p], false);
+        let results_lstat = batch_stat_dir_entries(vec![p], false, &thresholds);
         assert!(results_lstat[0].metadata.is_ok());
     }
 
     #[test]
     fn batch_stat_empty_input() {
-        let results = batch_stat_dir_entries(Vec::new(), false);
+        let results = batch_stat_dir_entries(Vec::new(), false, &default_thresholds());
         assert!(results.is_empty());
     }
 
@@ -190,7 +191,7 @@ mod tests {
             .collect();
 
         // Batched
-        let batched_results = batch_stat_dir_entries(paths, false);
+        let batched_results = batch_stat_dir_entries(paths, false, &default_thresholds());
         let batched: Vec<(PathBuf, bool, u64)> = batched_results
             .into_iter()
             .map(|r| {

--- a/crates/transfer/src/generator/file_list/walk.rs
+++ b/crates/transfer/src/generator/file_list/walk.rs
@@ -264,7 +264,7 @@ impl GeneratorContext {
         // default: lstat (fs::symlink_metadata)
         // --copy-unsafe-links needs post-batch fixup for unsafe symlinks
         let follow = self.config.flags.copy_links;
-        let stat_results = batch_stat_dir_entries(child_paths, follow);
+        let stat_results = batch_stat_dir_entries(child_paths, follow, &self.parallel_thresholds);
 
         // Phase 3: process each (path, metadata) pair
         for result in stat_results {

--- a/crates/transfer/src/generator/mod.rs
+++ b/crates/transfer/src/generator/mod.rs
@@ -356,6 +356,8 @@ pub struct GeneratorContext {
     /// Accumulated deletion statistics received via NDX_DEL_STATS messages.
     /// (upstream: main.c:238-247 `read_del_stats()`)
     delete_stats: DeleteStats,
+    /// Per-operation thresholds for parallel vs sequential execution.
+    parallel_thresholds: crate::parallel_io::ParallelThresholds,
 }
 
 impl GeneratorContext {
@@ -387,6 +389,7 @@ impl GeneratorContext {
             io_error: 0,
             incremental: IncrementalState::new(initial_ndx_start),
             delete_stats: DeleteStats::new(),
+            parallel_thresholds: crate::parallel_io::ParallelThresholds::default(),
         }
     }
 
@@ -649,7 +652,7 @@ impl GeneratorContext {
     /// the overhead of creating an io_uring ring per file.
     ///
     /// This threshold-based dual-path mirrors the existing pattern used for
-    /// parallel stat (PARALLEL_STAT_THRESHOLD) and adaptive buffer sizing.
+    /// parallel stat (`ParallelThresholds::stat`) and adaptive buffer sizing.
     fn open_source_reader(
         &self,
         path: &std::path::Path,

--- a/crates/transfer/src/lib.rs
+++ b/crates/transfer/src/lib.rs
@@ -195,6 +195,10 @@ pub use delta_pipeline::{
     DEFAULT_PARALLEL_THRESHOLD, ParallelDeltaPipeline, ReceiverDeltaPipeline,
     SequentialDeltaPipeline, ThresholdDeltaPipeline,
 };
+pub use parallel_io::{
+    DEFAULT_DELETION_THRESHOLD, DEFAULT_METADATA_THRESHOLD, DEFAULT_SIGNATURE_THRESHOLD,
+    DEFAULT_STAT_THRESHOLD, ParallelThresholds,
+};
 pub use pipeline::{
     DEFAULT_PIPELINE_WINDOW, MAX_PIPELINE_WINDOW, MIN_PIPELINE_WINDOW, PendingTransfer,
     PipelineConfig, PipelineState,

--- a/crates/transfer/src/parallel_io.rs
+++ b/crates/transfer/src/parallel_io.rs
@@ -10,6 +10,90 @@
 
 use rayon::prelude::*;
 
+/// Default threshold for parallel stat operations (filesystem metadata lookups).
+///
+/// Below this count, sequential iteration avoids rayon thread-pool dispatch overhead.
+pub const DEFAULT_STAT_THRESHOLD: usize = 64;
+
+/// Default threshold for parallel signature computation.
+///
+/// Signatures are CPU-bound (rolling + strong checksums), so parallelism
+/// pays off at lower counts than I/O-bound operations.
+pub const DEFAULT_SIGNATURE_THRESHOLD: usize = 32;
+
+/// Default threshold for parallel metadata application (chmod/chown/utimes).
+///
+/// Mixed I/O and CPU - similar overhead profile to stat operations.
+pub const DEFAULT_METADATA_THRESHOLD: usize = 64;
+
+/// Default threshold for parallel deletion scanning.
+///
+/// Each directory scan involves `read_dir` + per-entry checks, so the
+/// per-item cost is higher than a single stat call.
+pub const DEFAULT_DELETION_THRESHOLD: usize = 64;
+
+/// Per-operation thresholds for switching between sequential and parallel execution.
+///
+/// Different operations have different overhead profiles: CPU-bound signature
+/// computation benefits from parallelism at lower counts than I/O-bound stat calls.
+/// This struct allows each operation to use an appropriate threshold rather than
+/// a single global constant.
+///
+/// All thresholds represent the minimum item count required to justify rayon
+/// thread-pool dispatch. Below the threshold, sequential iteration is used.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ParallelThresholds {
+    /// Minimum file count for parallel `stat()` / `lstat()` calls.
+    pub stat: usize,
+    /// Minimum file count for parallel signature (basis file + checksum) computation.
+    pub signature: usize,
+    /// Minimum directory count for parallel metadata application (`chmod`/`chown`/`utimes`).
+    pub metadata: usize,
+    /// Minimum directory count for parallel deletion scanning.
+    pub deletion: usize,
+}
+
+impl Default for ParallelThresholds {
+    fn default() -> Self {
+        Self {
+            stat: DEFAULT_STAT_THRESHOLD,
+            signature: DEFAULT_SIGNATURE_THRESHOLD,
+            metadata: DEFAULT_METADATA_THRESHOLD,
+            deletion: DEFAULT_DELETION_THRESHOLD,
+        }
+    }
+}
+
+impl ParallelThresholds {
+    /// Sets the stat threshold.
+    #[must_use]
+    pub const fn with_stat(mut self, threshold: usize) -> Self {
+        self.stat = threshold;
+        self
+    }
+
+    /// Sets the signature computation threshold.
+    #[must_use]
+    pub const fn with_signature(mut self, threshold: usize) -> Self {
+        self.signature = threshold;
+        self
+    }
+
+    /// Sets the metadata application threshold.
+    #[must_use]
+    pub const fn with_metadata(mut self, threshold: usize) -> Self {
+        self.metadata = threshold;
+        self
+    }
+
+    /// Sets the deletion scanning threshold.
+    #[must_use]
+    pub const fn with_deletion(mut self, threshold: usize) -> Self {
+        self.deletion = threshold;
+        self
+    }
+}
+
 /// Runs `f` on each item in parallel using rayon's work-stealing pool.
 ///
 /// Returns results in the same order as the input. For lists smaller
@@ -74,5 +158,56 @@ mod tests {
         });
         let expected: Vec<u64> = (0..50).collect();
         assert_eq!(results, expected);
+    }
+
+    #[test]
+    fn test_parallel_thresholds_default() {
+        let t = ParallelThresholds::default();
+        assert_eq!(t.stat, DEFAULT_STAT_THRESHOLD);
+        assert_eq!(t.signature, DEFAULT_SIGNATURE_THRESHOLD);
+        assert_eq!(t.metadata, DEFAULT_METADATA_THRESHOLD);
+        assert_eq!(t.deletion, DEFAULT_DELETION_THRESHOLD);
+    }
+
+    #[test]
+    fn test_parallel_thresholds_default_values() {
+        let t = ParallelThresholds::default();
+        assert_eq!(t.stat, 64);
+        assert_eq!(t.signature, 32);
+        assert_eq!(t.metadata, 64);
+        assert_eq!(t.deletion, 64);
+    }
+
+    #[test]
+    fn test_parallel_thresholds_builder() {
+        let t = ParallelThresholds::default()
+            .with_stat(128)
+            .with_signature(16)
+            .with_metadata(256)
+            .with_deletion(48);
+        assert_eq!(t.stat, 128);
+        assert_eq!(t.signature, 16);
+        assert_eq!(t.metadata, 256);
+        assert_eq!(t.deletion, 48);
+    }
+
+    #[test]
+    fn test_parallel_thresholds_copy() {
+        let t1 = ParallelThresholds::default().with_stat(100);
+        let t2 = t1;
+        assert_eq!(t1, t2);
+    }
+
+    #[test]
+    fn test_parallel_thresholds_zero_thresholds() {
+        let t = ParallelThresholds::default()
+            .with_stat(0)
+            .with_signature(0);
+        assert_eq!(t.stat, 0);
+        assert_eq!(t.signature, 0);
+        // Always uses parallel path when threshold is 0
+        let items: Vec<i32> = (0..5).collect();
+        let results = map_blocking(items, t.stat, |x| x * 2);
+        assert_eq!(results, vec![0, 2, 4, 6, 8]);
     }
 }

--- a/crates/transfer/src/receiver/directory/creation.rs
+++ b/crates/transfer/src/receiver/directory/creation.rs
@@ -16,7 +16,7 @@ use protocol::flist::FileEntry;
 use protocol::xattr::XattrList;
 
 use super::FailedDirectories;
-use crate::receiver::{PARALLEL_STAT_THRESHOLD, ReceiverContext, apply_acls_from_receiver_cache};
+use crate::receiver::{ReceiverContext, apply_acls_from_receiver_cache};
 
 impl ReceiverContext {
     /// Creates directories from the file list, applying metadata in parallel.
@@ -121,7 +121,7 @@ impl ReceiverContext {
         let acl_cache_clone = acl_cache.cloned();
         let results = crate::parallel_io::map_blocking(
             entry_snapshots,
-            PARALLEL_STAT_THRESHOLD,
+            self.parallel_thresholds.metadata,
             move |(dir_path, entry, xattr_list)| {
                 if let Err(e) =
                     apply_metadata_from_file_entry(&dir_path, &entry, &metadata_opts_clone)

--- a/crates/transfer/src/receiver/directory/deletion.rs
+++ b/crates/transfer/src/receiver/directory/deletion.rs
@@ -14,7 +14,7 @@ use logging::{debug_log, info_log};
 use protocol::stats::DeleteStats;
 
 use super::normalize_filename_for_compare;
-use crate::receiver::{PARALLEL_STAT_THRESHOLD, ReceiverContext};
+use crate::receiver::ReceiverContext;
 
 impl ReceiverContext {
     /// Deletes extraneous files at the destination that are not in the received file list.
@@ -98,7 +98,7 @@ impl ReceiverContext {
         // after parallel deletion completes.
         let per_dir_results: Vec<(DeleteStats, Vec<PathBuf>)> = crate::parallel_io::map_blocking(
             dirs_to_scan,
-            PARALLEL_STAT_THRESHOLD,
+            self.parallel_thresholds.deletion,
             move |dir_relative| {
                 let dest_path = if dir_relative.as_os_str() == "." {
                     dest_dir_owned.clone()

--- a/crates/transfer/src/receiver/mod.rs
+++ b/crates/transfer/src/receiver/mod.rs
@@ -84,10 +84,11 @@ const PHASE1_CHECKSUM_LENGTH: NonZeroU8 =
 const REDO_CHECKSUM_LENGTH: NonZeroU8 =
     NonZeroU8::new(signature::block_size::MAX_SUM_LENGTH).unwrap();
 
-/// Minimum candidate count to justify parallel I/O overhead for
-/// stat() calls in the quick-check phase. Below this threshold,
-/// sequential iteration is faster.
-const PARALLEL_STAT_THRESHOLD: usize = 64;
+/// Per-operation parallel thresholds for the receiver.
+///
+/// Provides tunable thresholds for stat, signature, metadata, and deletion
+/// operations. Stored in `ReceiverContext` and propagated to each call site.
+pub(crate) use crate::parallel_io::ParallelThresholds;
 
 use signature;
 
@@ -180,6 +181,11 @@ pub struct ReceiverContext {
     ///
     /// - `hlink.c:match_gnums()` - `prior_hlinks` hashtable persists across segments
     prior_hlinks: HashMap<u32, bool>,
+    /// Per-operation thresholds for parallel vs sequential execution.
+    ///
+    /// Different operations benefit from parallelism at different item counts.
+    /// CPU-bound signature computation benefits earlier than I/O-bound stat calls.
+    parallel_thresholds: ParallelThresholds,
 }
 
 impl ReceiverContext {
@@ -222,6 +228,7 @@ impl ReceiverContext {
             filter_chain: FilterChain::empty(),
             hardlink_tracker,
             prior_hlinks: HashMap::new(),
+            parallel_thresholds: ParallelThresholds::default(),
         }
     }
 

--- a/crates/transfer/src/receiver/transfer/candidates.rs
+++ b/crates/transfer/src/receiver/transfer/candidates.rs
@@ -23,7 +23,7 @@ use crate::receiver::quick_check::{
     dest_mtime_newer, is_hardlink_follower, quick_check_matches, try_reference_dest,
 };
 use crate::receiver::stats::TransferStats;
-use crate::receiver::{PARALLEL_STAT_THRESHOLD, ReceiverContext, apply_acls_from_receiver_cache};
+use crate::receiver::{ReceiverContext, apply_acls_from_receiver_cache};
 
 impl ReceiverContext {
     /// Builds the list of files that need transfer, applying quick-check to skip
@@ -119,7 +119,7 @@ impl ReceiverContext {
         let stat_results: Vec<(usize, PathBuf, Option<fs::Metadata>)> =
             crate::parallel_io::map_blocking(
                 stat_paths,
-                PARALLEL_STAT_THRESHOLD,
+                self.parallel_thresholds.stat,
                 move |(idx, file_path)| {
                     let meta = fs::metadata(&file_path).ok();
                     (idx, file_path, meta)

--- a/crates/transfer/src/receiver/transfer/pipeline.rs
+++ b/crates/transfer/src/receiver/transfer/pipeline.rs
@@ -23,7 +23,7 @@ use protocol::flist::FileEntry;
 use crate::delta_apply::ChecksumVerifier;
 use crate::pipeline::{PipelineConfig, PipelineState};
 use crate::receiver::basis::find_basis_file_with_config;
-use crate::receiver::{PARALLEL_STAT_THRESHOLD, PipelineSetup, ReceiverContext};
+use crate::receiver::{PipelineSetup, ReceiverContext};
 use crate::transfer_ops::{
     RequestConfig, ResponseContext, process_file_response_streaming, send_file_request,
 };
@@ -32,7 +32,7 @@ impl ReceiverContext {
     /// Pipelined transfer loop with decoupled network/disk I/O.
     ///
     /// Fills a sliding window of file requests, computes signatures in parallel
-    /// when the batch exceeds `PARALLEL_STAT_THRESHOLD`, then processes responses
+    /// when the batch exceeds the signature threshold, then processes responses
     /// with a background disk commit thread. Returns `(files_transferred, bytes, redo_indices)`.
     #[allow(clippy::too_many_arguments)]
     pub(in crate::receiver) fn run_pipeline_loop_decoupled<
@@ -163,7 +163,7 @@ impl ReceiverContext {
 
                     if !batch.is_empty() && !is_redo_pass {
                         // Compute signatures - parallel when batch is large enough.
-                        let sig_results: Vec<_> = if batch.len() >= PARALLEL_STAT_THRESHOLD {
+                        let sig_results: Vec<_> = if batch.len() >= self.parallel_thresholds.signature {
                             batch
                                 .par_iter()
                                 .map(|(_, file_entry, file_path)| {


### PR DESCRIPTION
## Summary

- Replace the fixed `PARALLEL_STAT_THRESHOLD = 64` constant with a `ParallelThresholds` struct providing per-operation thresholds: `stat` (64), `signature` (32), `metadata` (64), `deletion` (64)
- Thread `ParallelThresholds` through `ReceiverContext` and `GeneratorContext` so each call site uses the appropriate threshold for its operation type
- CPU-bound signature computation now uses a lower default threshold (32) since it benefits from parallelism earlier than I/O-bound stat calls

## Test plan

- [ ] Verify CI passes (fmt, clippy, nextest on all platforms)
- [ ] Confirm default thresholds match previous behavior (stat=64, metadata=64, deletion=64) for backward compatibility
- [ ] Confirm signature threshold (32) activates parallel path earlier for CPU-bound work
- [ ] Unit tests for `ParallelThresholds` default values, builder methods, and `Copy`/`Eq` semantics