### PR TITLE
feat: add per-operation adaptive thresholds replacing fixed PARALLEL_STAT_THRESHOLD

### DIFF
--- a/crates/transfer/src/delta_pipeline.rs
+++ b/crates/transfer/src/delta_pipeline.rs
@@ -38,9 +38,9 @@ use engine::concurrent_delta::{DeltaResult, DeltaWork};
 
 /// Default threshold for switching from sequential to parallel dispatch.
 ///
-/// Matches the receiver's `PARALLEL_STAT_THRESHOLD` (64 files). Below this
-/// count, the overhead of thread spawning and channel communication exceeds
-/// the benefit of parallelism.
+/// Matches the receiver's default stat threshold from `ParallelThresholds`
+/// (64 files). Below this count, the overhead of thread spawning and channel
+/// communication exceeds the benefit of parallelism.
 pub const DEFAULT_PARALLEL_THRESHOLD: usize = 64;
 
 /// Abstraction over the delta dispatch loop in the receiver.
@@ -309,14 +309,14 @@ enum ThresholdMode {
 ///   in which case items are processed sequentially.
 ///
 /// This follows the threshold-based dual-path pattern used throughout the
-/// codebase (e.g., `PARALLEL_STAT_THRESHOLD` in the receiver). For small
+/// codebase (e.g., `ParallelThresholds` in the receiver). For small
 /// transfers, the overhead of spawning threads and channels exceeds the
 /// benefit of parallelism.
 ///
 /// # Default Threshold
 ///
 /// [`DEFAULT_PARALLEL_THRESHOLD`] = 64, matching the receiver's
-/// `PARALLEL_STAT_THRESHOLD`.
+/// default stat threshold from `ParallelThresholds`.
 pub struct ThresholdDeltaPipeline {
     /// Number of items required to switch to parallel mode.
     threshold: usize,

--- a/crates/transfer/src/generator/file_list/batch_stat.rs
+++ b/crates/transfer/src/generator/file_list/batch_stat.rs
@@ -155,7 +155,7 @@ mod tests {
 
     #[test]
     fn batch_stat_empty_input() {
-        let results = batch_stat_dir_entries(Vec::new(), false);
+        let results = batch_stat_dir_entries(Vec::new(), false, &ParallelThresholds::default());
         assert!(results.is_empty());
     }
 
@@ -185,7 +185,7 @@ mod tests {
             .collect();
 
         // Batched
-        let batched_results = batch_stat_dir_entries(paths, false);
+        let batched_results = batch_stat_dir_entries(paths, false, &ParallelThresholds::default());
         let batched: Vec<(PathBuf, bool, u64)> = batched_results
             .into_iter()
             .map(|r| {

--- a/crates/transfer/src/generator/file_list/batch_stat.rs
+++ b/crates/transfer/src/generator/file_list/batch_stat.rs
@@ -144,7 +144,8 @@ mod tests {
         File::create(&p).unwrap();
 
         // With follow_symlinks=true, uses fs::metadata (follows symlinks)
-        let results_follow = batch_stat_dir_entries(vec![p.clone()], true, &ParallelThresholds::default());
+        let results_follow =
+            batch_stat_dir_entries(vec![p.clone()], true, &ParallelThresholds::default());
         assert!(results_follow[0].metadata.is_ok());
 
         // With follow_symlinks=false, uses fs::symlink_metadata (lstat)

--- a/crates/transfer/src/generator/file_list/batch_stat.rs
+++ b/crates/transfer/src/generator/file_list/batch_stat.rs
@@ -1,7 +1,7 @@
 //! Batched metadata resolution for directory entries.
 //!
 //! Parallelizes `stat()` / `lstat()` syscalls across directory children using
-//! rayon when the entry count exceeds [`PARALLEL_STAT_THRESHOLD`]. For small
+//! rayon when the entry count exceeds the configured stat threshold. For small
 //! directories the overhead of thread-pool dispatch is avoided by falling back
 //! to sequential iteration.
 //!
@@ -12,14 +12,7 @@
 use std::fs;
 use std::path::PathBuf;
 
-use crate::parallel_io::map_blocking;
-
-/// Minimum number of directory entries required before parallel stat is used.
-///
-/// Below this threshold, sequential stat is faster because it avoids rayon
-/// thread-pool dispatch overhead. Value matches the receiver's threshold
-/// in `crate::receiver::PARALLEL_STAT_THRESHOLD`.
-pub(in crate::generator) const PARALLEL_STAT_THRESHOLD: usize = 64;
+use crate::parallel_io::{ParallelThresholds, map_blocking};
 
 /// Result of batched metadata resolution for a single directory entry.
 ///
@@ -40,13 +33,14 @@ pub(in crate::generator) struct StatResult {
 /// after receiving the raw metadata.
 ///
 /// Uses [`map_blocking`] which dispatches to rayon's work-stealing pool when
-/// the entry count meets [`PARALLEL_STAT_THRESHOLD`], otherwise falls back to
-/// sequential iteration.
+/// the entry count meets the configured stat threshold from [`ParallelThresholds`],
+/// otherwise falls back to sequential iteration.
 pub(in crate::generator) fn batch_stat_dir_entries(
     paths: Vec<PathBuf>,
     follow_symlinks: bool,
+    thresholds: &ParallelThresholds,
 ) -> Vec<StatResult> {
-    map_blocking(paths, PARALLEL_STAT_THRESHOLD, move |path| {
+    map_blocking(paths, thresholds.stat, move |path| {
         let metadata = if follow_symlinks {
             fs::metadata(&path)
         } else {
@@ -75,7 +69,7 @@ mod tests {
             paths.push(p);
         }
 
-        let results = batch_stat_dir_entries(paths, false);
+        let results = batch_stat_dir_entries(paths, false, &ParallelThresholds::default());
         assert_eq!(results.len(), 5);
         for r in &results {
             assert!(
@@ -92,7 +86,7 @@ mod tests {
         let root = dir.path();
 
         // Create enough files to exceed the parallel threshold
-        let count = PARALLEL_STAT_THRESHOLD + 10;
+        let count = ParallelThresholds::default().stat + 10;
         let mut paths = Vec::new();
         for i in 0..count {
             let p = root.join(format!("file{i}.txt"));
@@ -100,7 +94,7 @@ mod tests {
             paths.push(p);
         }
 
-        let results = batch_stat_dir_entries(paths, false);
+        let results = batch_stat_dir_entries(paths, false, &ParallelThresholds::default());
         assert_eq!(results.len(), count);
         for r in &results {
             assert!(
@@ -116,7 +110,7 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let root = dir.path();
 
-        let count = PARALLEL_STAT_THRESHOLD + 20;
+        let count = ParallelThresholds::default().stat + 20;
         let mut paths = Vec::new();
         for i in 0..count {
             let p = root.join(format!("entry_{i:04}.dat"));
@@ -125,7 +119,7 @@ mod tests {
         }
 
         let original_paths: Vec<PathBuf> = paths.clone();
-        let results = batch_stat_dir_entries(paths, false);
+        let results = batch_stat_dir_entries(paths, false, &ParallelThresholds::default());
 
         // Results must be in the same order as input
         for (i, r) in results.iter().enumerate() {
@@ -136,7 +130,7 @@ mod tests {
     #[test]
     fn batch_stat_nonexistent_returns_error() {
         let paths = vec![PathBuf::from("/nonexistent/path/abc123")];
-        let results = batch_stat_dir_entries(paths, false);
+        let results = batch_stat_dir_entries(paths, false, &ParallelThresholds::default());
         assert_eq!(results.len(), 1);
         assert!(results[0].metadata.is_err());
     }
@@ -150,11 +144,11 @@ mod tests {
         File::create(&p).unwrap();
 
         // With follow_symlinks=true, uses fs::metadata (follows symlinks)
-        let results_follow = batch_stat_dir_entries(vec![p.clone()], true);
+        let results_follow = batch_stat_dir_entries(vec![p.clone()], true, &ParallelThresholds::default());
         assert!(results_follow[0].metadata.is_ok());
 
         // With follow_symlinks=false, uses fs::symlink_metadata (lstat)
-        let results_lstat = batch_stat_dir_entries(vec![p], false);
+        let results_lstat = batch_stat_dir_entries(vec![p], false, &ParallelThresholds::default());
         assert!(results_lstat[0].metadata.is_ok());
     }
 

--- a/crates/transfer/src/generator/file_list/walk.rs
+++ b/crates/transfer/src/generator/file_list/walk.rs
@@ -264,7 +264,7 @@ impl GeneratorContext {
         // default: lstat (fs::symlink_metadata)
         // --copy-unsafe-links needs post-batch fixup for unsafe symlinks
         let follow = self.config.flags.copy_links;
-        let stat_results = batch_stat_dir_entries(child_paths, follow);
+        let stat_results = batch_stat_dir_entries(child_paths, follow, &self.parallel_thresholds);
 
         // Phase 3: process each (path, metadata) pair
         for result in stat_results {

--- a/crates/transfer/src/generator/mod.rs
+++ b/crates/transfer/src/generator/mod.rs
@@ -356,6 +356,11 @@ pub struct GeneratorContext {
     /// Accumulated deletion statistics received via NDX_DEL_STATS messages.
     /// (upstream: main.c:238-247 `read_del_stats()`)
     delete_stats: DeleteStats,
+    /// Per-operation thresholds for switching between sequential and parallel execution.
+    ///
+    /// Different operations have different overhead profiles: CPU-bound signature
+    /// computation benefits from parallelism at lower counts than I/O-bound stat calls.
+    parallel_thresholds: crate::parallel_io::ParallelThresholds,
 }
 
 impl GeneratorContext {
@@ -387,6 +392,7 @@ impl GeneratorContext {
             io_error: 0,
             incremental: IncrementalState::new(initial_ndx_start),
             delete_stats: DeleteStats::new(),
+            parallel_thresholds: crate::parallel_io::ParallelThresholds::default(),
         }
     }
 
@@ -649,7 +655,7 @@ impl GeneratorContext {
     /// the overhead of creating an io_uring ring per file.
     ///
     /// This threshold-based dual-path mirrors the existing pattern used for
-    /// parallel stat (PARALLEL_STAT_THRESHOLD) and adaptive buffer sizing.
+    /// parallel stat (`ParallelThresholds`) and adaptive buffer sizing.
     fn open_source_reader(
         &self,
         path: &std::path::Path,

--- a/crates/transfer/src/lib.rs
+++ b/crates/transfer/src/lib.rs
@@ -142,7 +142,7 @@ pub mod temp_guard;
 /// Writer abstraction supporting plain and multiplex modes.
 mod writer;
 
-/// Bounded-concurrency parallel I/O using tokio `spawn_blocking` + `Semaphore`.
+/// Bounded-concurrency parallel I/O using rayon for work-stealing parallelism.
 mod parallel_io;
 
 /// Pluggable delta dispatch pipeline for the receiver.
@@ -194,6 +194,10 @@ pub use ack_batcher::{
 pub use delta_pipeline::{
     DEFAULT_PARALLEL_THRESHOLD, ParallelDeltaPipeline, ReceiverDeltaPipeline,
     SequentialDeltaPipeline, ThresholdDeltaPipeline,
+};
+pub use parallel_io::{
+    DEFAULT_DELETION_THRESHOLD, DEFAULT_METADATA_THRESHOLD, DEFAULT_SIGNATURE_THRESHOLD,
+    DEFAULT_STAT_THRESHOLD, ParallelThresholds,
 };
 pub use pipeline::{
     DEFAULT_PIPELINE_WINDOW, MAX_PIPELINE_WINDOW, MIN_PIPELINE_WINDOW, PendingTransfer,

--- a/crates/transfer/src/parallel_io.rs
+++ b/crates/transfer/src/parallel_io.rs
@@ -10,6 +10,90 @@
 
 use rayon::prelude::*;
 
+/// Default threshold for parallel stat operations (filesystem metadata lookups).
+///
+/// Below this count, sequential iteration avoids rayon thread-pool dispatch overhead.
+pub const DEFAULT_STAT_THRESHOLD: usize = 64;
+
+/// Default threshold for parallel signature computation.
+///
+/// Signatures are CPU-bound (rolling + strong checksums), so parallelism
+/// pays off at lower counts than I/O-bound operations.
+pub const DEFAULT_SIGNATURE_THRESHOLD: usize = 32;
+
+/// Default threshold for parallel metadata application (chmod/chown/utimes).
+///
+/// Mixed I/O and CPU - similar overhead profile to stat operations.
+pub const DEFAULT_METADATA_THRESHOLD: usize = 64;
+
+/// Default threshold for parallel deletion scanning.
+///
+/// Each directory scan involves `read_dir` + per-entry checks, so the
+/// per-item cost is higher than a single stat call.
+pub const DEFAULT_DELETION_THRESHOLD: usize = 64;
+
+/// Per-operation thresholds for switching between sequential and parallel execution.
+///
+/// Different operations have different overhead profiles: CPU-bound signature
+/// computation benefits from parallelism at lower counts than I/O-bound stat calls.
+/// This struct allows each operation to use an appropriate threshold rather than
+/// a single global constant.
+///
+/// All thresholds represent the minimum item count required to justify rayon
+/// thread-pool dispatch. Below the threshold, sequential iteration is used.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ParallelThresholds {
+    /// Minimum file count for parallel `stat()` / `lstat()` calls.
+    pub stat: usize,
+    /// Minimum file count for parallel signature (basis file + checksum) computation.
+    pub signature: usize,
+    /// Minimum directory count for parallel metadata application (`chmod`/`chown`/`utimes`).
+    pub metadata: usize,
+    /// Minimum directory count for parallel deletion scanning.
+    pub deletion: usize,
+}
+
+impl Default for ParallelThresholds {
+    fn default() -> Self {
+        Self {
+            stat: DEFAULT_STAT_THRESHOLD,
+            signature: DEFAULT_SIGNATURE_THRESHOLD,
+            metadata: DEFAULT_METADATA_THRESHOLD,
+            deletion: DEFAULT_DELETION_THRESHOLD,
+        }
+    }
+}
+
+impl ParallelThresholds {
+    /// Sets the stat threshold.
+    #[must_use]
+    pub const fn with_stat(mut self, threshold: usize) -> Self {
+        self.stat = threshold;
+        self
+    }
+
+    /// Sets the signature computation threshold.
+    #[must_use]
+    pub const fn with_signature(mut self, threshold: usize) -> Self {
+        self.signature = threshold;
+        self
+    }
+
+    /// Sets the metadata application threshold.
+    #[must_use]
+    pub const fn with_metadata(mut self, threshold: usize) -> Self {
+        self.metadata = threshold;
+        self
+    }
+
+    /// Sets the deletion scanning threshold.
+    #[must_use]
+    pub const fn with_deletion(mut self, threshold: usize) -> Self {
+        self.deletion = threshold;
+        self
+    }
+}
+
 /// Runs `f` on each item in parallel using rayon's work-stealing pool.
 ///
 /// Returns results in the same order as the input. For lists smaller
@@ -74,5 +158,56 @@ mod tests {
         });
         let expected: Vec<u64> = (0..50).collect();
         assert_eq!(results, expected);
+    }
+
+    #[test]
+    fn test_parallel_thresholds_default() {
+        let t = ParallelThresholds::default();
+        assert_eq!(t.stat, DEFAULT_STAT_THRESHOLD);
+        assert_eq!(t.signature, DEFAULT_SIGNATURE_THRESHOLD);
+        assert_eq!(t.metadata, DEFAULT_METADATA_THRESHOLD);
+        assert_eq!(t.deletion, DEFAULT_DELETION_THRESHOLD);
+    }
+
+    #[test]
+    fn test_parallel_thresholds_default_values() {
+        let t = ParallelThresholds::default();
+        assert_eq!(t.stat, 64);
+        assert_eq!(t.signature, 32);
+        assert_eq!(t.metadata, 64);
+        assert_eq!(t.deletion, 64);
+    }
+
+    #[test]
+    fn test_parallel_thresholds_builder() {
+        let t = ParallelThresholds::default()
+            .with_stat(128)
+            .with_signature(16)
+            .with_metadata(256)
+            .with_deletion(48);
+        assert_eq!(t.stat, 128);
+        assert_eq!(t.signature, 16);
+        assert_eq!(t.metadata, 256);
+        assert_eq!(t.deletion, 48);
+    }
+
+    #[test]
+    fn test_parallel_thresholds_copy() {
+        let t1 = ParallelThresholds::default().with_stat(100);
+        let t2 = t1;
+        assert_eq!(t1, t2);
+    }
+
+    #[test]
+    fn test_parallel_thresholds_zero_thresholds() {
+        let t = ParallelThresholds::default()
+            .with_stat(0)
+            .with_signature(0);
+        assert_eq!(t.stat, 0);
+        assert_eq!(t.signature, 0);
+        // Always uses parallel path when threshold is 0
+        let items: Vec<i32> = (0..5).collect();
+        let results = map_blocking(items, t.stat, |x| x * 2);
+        assert_eq!(results, vec![0, 2, 4, 6, 8]);
     }
 }

--- a/crates/transfer/src/parallel_io.rs
+++ b/crates/transfer/src/parallel_io.rs
@@ -200,9 +200,7 @@ mod tests {
 
     #[test]
     fn test_parallel_thresholds_zero_thresholds() {
-        let t = ParallelThresholds::default()
-            .with_stat(0)
-            .with_signature(0);
+        let t = ParallelThresholds::default().with_stat(0).with_signature(0);
         assert_eq!(t.stat, 0);
         assert_eq!(t.signature, 0);
         // Always uses parallel path when threshold is 0

--- a/crates/transfer/src/receiver/directory/creation.rs
+++ b/crates/transfer/src/receiver/directory/creation.rs
@@ -16,7 +16,7 @@ use protocol::flist::FileEntry;
 use protocol::xattr::XattrList;
 
 use super::FailedDirectories;
-use crate::receiver::{PARALLEL_STAT_THRESHOLD, ReceiverContext, apply_acls_from_receiver_cache};
+use crate::receiver::{ReceiverContext, apply_acls_from_receiver_cache};
 
 impl ReceiverContext {
     /// Creates directories from the file list, applying metadata in parallel.
@@ -121,7 +121,7 @@ impl ReceiverContext {
         let acl_cache_clone = acl_cache.cloned();
         let results = crate::parallel_io::map_blocking(
             entry_snapshots,
-            PARALLEL_STAT_THRESHOLD,
+            self.parallel_thresholds.metadata,
             move |(dir_path, entry, xattr_list)| {
                 if let Err(e) =
                     apply_metadata_from_file_entry(&dir_path, &entry, &metadata_opts_clone)

--- a/crates/transfer/src/receiver/directory/deletion.rs
+++ b/crates/transfer/src/receiver/directory/deletion.rs
@@ -14,7 +14,7 @@ use logging::{debug_log, info_log};
 use protocol::stats::DeleteStats;
 
 use super::normalize_filename_for_compare;
-use crate::receiver::{PARALLEL_STAT_THRESHOLD, ReceiverContext};
+use crate::receiver::ReceiverContext;
 
 impl ReceiverContext {
     /// Deletes extraneous files at the destination that are not in the received file list.
@@ -98,7 +98,7 @@ impl ReceiverContext {
         // after parallel deletion completes.
         let per_dir_results: Vec<(DeleteStats, Vec<PathBuf>)> = crate::parallel_io::map_blocking(
             dirs_to_scan,
-            PARALLEL_STAT_THRESHOLD,
+            self.parallel_thresholds.deletion,
             move |dir_relative| {
                 let dest_path = if dir_relative.as_os_str() == "." {
                     dest_dir_owned.clone()

--- a/crates/transfer/src/receiver/mod.rs
+++ b/crates/transfer/src/receiver/mod.rs
@@ -85,10 +85,7 @@ const PHASE1_CHECKSUM_LENGTH: NonZeroU8 =
 const REDO_CHECKSUM_LENGTH: NonZeroU8 =
     NonZeroU8::new(signature::block_size::MAX_SUM_LENGTH).unwrap();
 
-/// Minimum candidate count to justify parallel I/O overhead for
-/// stat() calls in the quick-check phase. Below this threshold,
-/// sequential iteration is faster.
-const PARALLEL_STAT_THRESHOLD: usize = 64;
+pub(crate) use crate::parallel_io::ParallelThresholds;
 
 use signature;
 
@@ -187,6 +184,11 @@ pub struct ReceiverContext {
     /// sequential `recv_files()` loop. Can be swapped to a parallel or
     /// threshold-based pipeline via [`set_delta_pipeline`](Self::set_delta_pipeline).
     delta_pipeline: Option<Box<dyn ReceiverDeltaPipeline>>,
+    /// Per-operation thresholds for switching between sequential and parallel execution.
+    ///
+    /// Different operations have different overhead profiles: CPU-bound signature
+    /// computation benefits from parallelism at lower counts than I/O-bound stat calls.
+    parallel_thresholds: ParallelThresholds,
 }
 
 impl ReceiverContext {
@@ -230,6 +232,7 @@ impl ReceiverContext {
             hardlink_tracker,
             prior_hlinks: HashMap::new(),
             delta_pipeline: Some(Box::new(SequentialDeltaPipeline::new())),
+            parallel_thresholds: ParallelThresholds::default(),
         }
     }
 

--- a/crates/transfer/src/receiver/transfer/candidates.rs
+++ b/crates/transfer/src/receiver/transfer/candidates.rs
@@ -23,7 +23,7 @@ use crate::receiver::quick_check::{
     dest_mtime_newer, is_hardlink_follower, quick_check_matches, try_reference_dest,
 };
 use crate::receiver::stats::TransferStats;
-use crate::receiver::{PARALLEL_STAT_THRESHOLD, ReceiverContext, apply_acls_from_receiver_cache};
+use crate::receiver::{ReceiverContext, apply_acls_from_receiver_cache};
 
 impl ReceiverContext {
     /// Builds the list of files that need transfer, applying quick-check to skip
@@ -119,7 +119,7 @@ impl ReceiverContext {
         let stat_results: Vec<(usize, PathBuf, Option<fs::Metadata>)> =
             crate::parallel_io::map_blocking(
                 stat_paths,
-                PARALLEL_STAT_THRESHOLD,
+                self.parallel_thresholds.stat,
                 move |(idx, file_path)| {
                     let meta = fs::metadata(&file_path).ok();
                     (idx, file_path, meta)

--- a/crates/transfer/src/receiver/transfer/pipeline.rs
+++ b/crates/transfer/src/receiver/transfer/pipeline.rs
@@ -23,7 +23,7 @@ use protocol::flist::FileEntry;
 use crate::delta_apply::ChecksumVerifier;
 use crate::pipeline::{PipelineConfig, PipelineState};
 use crate::receiver::basis::{BasisFileConfig, find_basis_file_with_config};
-use crate::receiver::{PARALLEL_STAT_THRESHOLD, PipelineSetup, ReceiverContext};
+use crate::receiver::{PipelineSetup, ReceiverContext};
 use crate::transfer_ops::{
     RequestConfig, ResponseContext, process_file_response_streaming, send_file_request,
 };
@@ -32,7 +32,7 @@ impl ReceiverContext {
     /// Pipelined transfer loop with decoupled network/disk I/O.
     ///
     /// Fills a sliding window of file requests, computes signatures in parallel
-    /// when the batch exceeds `PARALLEL_STAT_THRESHOLD`, then processes responses
+    /// when the batch exceeds the configured signature threshold, then processes responses
     /// with a background disk commit thread. Returns `(files_transferred, bytes, redo_indices)`.
     #[allow(clippy::too_many_arguments)]
     pub(in crate::receiver) fn run_pipeline_loop_decoupled<
@@ -172,9 +172,10 @@ impl ReceiverContext {
                         let dest_dir = &setup.dest_dir;
                         let checksum_length = setup.checksum_length;
                         let checksum_algorithm = setup.checksum_algorithm;
+                        let sig_threshold = self.parallel_thresholds.signature;
 
                         // Compute signatures - parallel when batch is large enough.
-                        let sig_results: Vec<_> = if batch.len() >= PARALLEL_STAT_THRESHOLD {
+                        let sig_results: Vec<_> = if batch.len() >= sig_threshold {
                             batch
                                 .par_iter()
                                 .map(|(_, file_entry, file_path)| {


### PR DESCRIPTION
## Summary

- Replaces the single hardcoded `PARALLEL_STAT_THRESHOLD = 64` constant with a `ParallelThresholds` struct providing per-operation thresholds: stat (64), signature (32), metadata (64), deletion (64)
- Adds builder pattern (`with_stat()`, `with_signature()`, `with_metadata()`, `with_deletion()`) for per-operation tuning
- Threads `ParallelThresholds` through `ReceiverContext`, `GeneratorContext`, and `batch_stat_dir_entries()` so each parallel call site uses the appropriate threshold

Recreates #3174 on top of current master to resolve merge conflicts.

## Test plan

- [ ] CI passes fmt+clippy, nextest on all platforms (Linux, macOS, Windows, musl)
- [ ] 5 unit tests in `parallel_io.rs` verify defaults, builder, and `map_blocking` threshold gating
- [ ] Existing tests in `batch_stat.rs` updated to pass `ParallelThresholds::default()`
- [ ] No remaining references to `PARALLEL_STAT_THRESHOLD` in codebase