### PR TITLE
style: fix rustfmt formatting in io_uring and disk_commit modules

### DIFF
--- a/crates/fast_io/src/io_uring/disk_batch.rs
+++ b/crates/fast_io/src/io_uring/disk_batch.rs
@@ -105,7 +105,8 @@ impl IoUringDiskBatch {
         self.flush_current()?;
         self.finalize_current_file();
 
-        let fixed_fd_slot = try_register_fd(&self.ring, file.as_raw_fd(), self.config.register_files);
+        let fixed_fd_slot =
+            try_register_fd(&self.ring, file.as_raw_fd(), self.config.register_files);
         self.current_file = Some(ActiveFile {
             file,
             bytes_written: 0,
@@ -191,9 +192,7 @@ impl IoUringDiskBatch {
     /// Returns the number of bytes written to the current file (flushed only).
     #[must_use]
     pub fn bytes_written(&self) -> u64 {
-        self.current_file
-            .as_ref()
-            .map_or(0, |f| f.bytes_written)
+        self.current_file.as_ref().map_or(0, |f| f.bytes_written)
     }
 
     /// Returns the total bytes including unflushed buffer content.

--- a/crates/transfer/src/disk_commit/thread.rs
+++ b/crates/transfer/src/disk_commit/thread.rs
@@ -60,9 +60,7 @@ pub fn spawn_disk_thread(config: DiskCommitConfig) -> DiskThreadHandle {
 /// Returns `Some` on Linux 5.6+ when the `io_uring` feature is enabled and
 /// the policy is `Auto` or `Enabled`. Returns `None` when io_uring is
 /// unavailable or the policy is `Disabled`.
-fn try_create_disk_batch(
-    policy: fast_io::IoUringPolicy,
-) -> Option<fast_io::IoUringDiskBatch> {
+fn try_create_disk_batch(policy: fast_io::IoUringPolicy) -> Option<fast_io::IoUringDiskBatch> {
     match policy {
         fast_io::IoUringPolicy::Disabled => None,
         fast_io::IoUringPolicy::Auto => {


### PR DESCRIPTION
## Summary
- Fix line-length formatting in `disk_batch.rs` (wrap long `try_register_fd` call, collapse single-line chain)
- Fix function signature formatting in `thread.rs` (collapse to single line)

## Test plan
- CI fmt+clippy check passes