### PR TITLE
fix: add wait_with_stderr to SshConnection for stderr visibility

### DIFF
--- a/crates/rsync_io/src/ssh/connection.rs
+++ b/crates/rsync_io/src/ssh/connection.rs
@@ -92,6 +92,33 @@ impl SshConnection {
         }
     }
 
+    /// Waits for the subprocess to exit and returns the collected stderr output.
+    ///
+    /// This combines [`wait`](Self::wait) and [`stderr_output`](Self::stderr_output)
+    /// into a single call, ensuring the drain thread is joined and all stderr is
+    /// captured before the connection is consumed. This is the preferred method
+    /// when callers need to surface SSH error messages to the user on failure.
+    pub fn wait_with_stderr(mut self) -> io::Result<(ExitStatus, Vec<u8>)> {
+        let _ = self.close_stdin();
+        match self.child.take() {
+            Some(mut child) => {
+                let status = child.wait();
+                if let Some(ref mut drain) = self.stderr_drain {
+                    drain.join();
+                }
+                let stderr = self
+                    .stderr_drain
+                    .as_ref()
+                    .map_or_else(Vec::new, StderrDrain::collected);
+                status.map(|s| (s, stderr))
+            }
+            None => Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "child process already taken",
+            )),
+        }
+    }
+
     /// Attempts to retrieve the subprocess exit status without blocking.
     pub fn try_wait(&mut self) -> io::Result<Option<ExitStatus>> {
         match self.child.as_mut() {

--- a/crates/rsync_io/src/ssh/tests.rs
+++ b/crates/rsync_io/src/ssh/tests.rs
@@ -1039,3 +1039,75 @@ fn stderr_drain_with_no_stderr_output() {
     let status = child_handle.wait().expect("wait");
     assert!(status.success());
 }
+
+#[cfg(unix)]
+#[test]
+fn connection_wait_with_stderr_captures_error_on_failure() {
+    // Verifies that when an SSH-like subprocess fails (non-zero exit), the
+    // stderr message is captured and returned to the caller via
+    // `SshConnection::wait_with_stderr()`. This is the primary path for
+    // surfacing SSH connection errors (e.g., "Permission denied") to the user.
+    let mut command = SshCommand::new("ignored");
+    command.set_program("sh");
+    command.set_batch_mode(false);
+    command.push_option("-c");
+    command.push_option(
+        "printf 'ssh: connect to host unreachable port 22: Connection refused\\n' >&2; exit 255",
+    );
+    command.set_target_override(Some(OsString::new()));
+
+    let connection = command.spawn().expect("spawn shell");
+    let (status, stderr) = connection.wait_with_stderr().expect("wait");
+
+    assert!(!status.success(), "child should exit with non-zero status");
+    assert_eq!(
+        status.code(),
+        Some(255),
+        "exit code should be 255 (SSH connection failure)"
+    );
+
+    let text = String::from_utf8_lossy(&stderr);
+    assert!(
+        text.contains("Connection refused"),
+        "stderr should contain the SSH error message, got: {text}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn connection_wait_with_stderr_empty_on_success() {
+    // Verifies that wait_with_stderr returns empty stderr on successful exit.
+    let connection = spawn_echo_process();
+    let (status, stderr) = connection.wait_with_stderr().expect("wait");
+
+    assert!(status.success());
+    assert!(
+        stderr.is_empty(),
+        "expected empty stderr on success, got: {stderr:?}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn child_handle_wait_with_stderr_surfaces_error_after_split() {
+    // Verifies the split() path also captures stderr on connection failure.
+    // This covers the path used by ssh_transfer.rs and remote_to_remote.rs.
+    let mut command = SshCommand::new("ignored");
+    command.set_program("sh");
+    command.set_batch_mode(false);
+    command.push_option("-c");
+    command.push_option("printf 'Permission denied (publickey).\\n' >&2; exit 255");
+    command.set_target_override(Some(OsString::new()));
+
+    let connection = command.spawn().expect("spawn shell");
+    let (_reader, _writer, child_handle) = connection.split().expect("split");
+
+    let (status, stderr) = child_handle.wait_with_stderr().expect("wait");
+
+    assert!(!status.success());
+    let text = String::from_utf8_lossy(&stderr);
+    assert!(
+        text.contains("Permission denied"),
+        "stderr should contain the SSH error message, got: {text}"
+    );
+}


### PR DESCRIPTION
## Summary

- Audited SSH stderr handling in the `rsync_io` crate - the `StderrDrain` background thread is correctly spawned on `SshCommand::spawn()`, forwards lines to process stderr via `eprintln!`, and collects output in a bounded 64 KB buffer.
- Found API gap: `SshChildHandle` (used after `split()`) had `wait_with_stderr()`, but `SshConnection` itself only had `wait()` which discarded collected stderr after joining the drain thread.
- Added `SshConnection::wait_with_stderr()` for API parity, enabling callers using the connection directly (without `split()`) to retrieve SSH error messages on failure.
- Added three tests verifying stderr capture on connection failure (exit 255 with "Connection refused" / "Permission denied" messages), covering both the direct `SshConnection` and the `SshChildHandle` (post-split) paths.

## Test plan

- [ ] CI: fmt+clippy passes
- [ ] CI: nextest passes on all platforms (Linux, macOS, Windows)
- [ ] New tests `connection_wait_with_stderr_captures_error_on_failure`, `connection_wait_with_stderr_empty_on_success`, and `child_handle_wait_with_stderr_surfaces_error_after_split` pass on Unix platforms