### PR TITLE
test: verify ACL/xattr capability negotiation graceful degradation

### DIFF
--- a/crates/transfer/src/flags.rs
+++ b/crates/transfer/src/flags.rs
@@ -443,4 +443,129 @@ mod tests {
         let flags = ParsedServerFlags::parse("-r").unwrap();
         assert!(!flags.backup);
     }
+
+    // ==================== clear_unsupported_features tests ====================
+
+    /// When neither ACLs nor xattrs are requested, clearing unsupported features
+    /// returns an empty list and leaves all flags unchanged.
+    #[test]
+    fn clear_unsupported_features_noop_when_not_requested() {
+        let mut flags = ParsedServerFlags::parse("-r").unwrap();
+        assert!(!flags.acls);
+        assert!(!flags.xattrs);
+        let cleared = flags.clear_unsupported_features();
+        assert!(cleared.is_empty());
+        assert!(!flags.acls);
+        assert!(!flags.xattrs);
+    }
+
+    /// When ACLs are requested and the `acl` feature is compiled in (Unix),
+    /// no clearing occurs. When the feature is absent, the flag is cleared
+    /// and the feature name is returned.
+    ///
+    /// upstream: options.c:1842-1857 - SUPPORT_ACLS guard
+    #[test]
+    fn clear_unsupported_features_handles_acls() {
+        let mut flags = ParsedServerFlags::parse("-A").unwrap();
+        assert!(flags.acls);
+        let cleared = flags.clear_unsupported_features();
+
+        #[cfg(all(unix, feature = "acl"))]
+        {
+            assert!(cleared.is_empty());
+            assert!(flags.acls);
+        }
+
+        #[cfg(not(all(unix, feature = "acl")))]
+        {
+            assert_eq!(cleared, vec!["ACLs"]);
+            assert!(!flags.acls);
+        }
+    }
+
+    /// When xattrs are requested and the `xattr` feature is compiled in (Unix),
+    /// no clearing occurs. When the feature is absent, the flag is cleared
+    /// and the feature name is returned.
+    ///
+    /// upstream: options.c:1859-1868 - SUPPORT_XATTRS guard
+    #[test]
+    fn clear_unsupported_features_handles_xattrs() {
+        let mut flags = ParsedServerFlags::parse("-X").unwrap();
+        assert!(flags.xattrs);
+        let cleared = flags.clear_unsupported_features();
+
+        #[cfg(all(unix, feature = "xattr"))]
+        {
+            assert!(cleared.is_empty());
+            assert!(flags.xattrs);
+        }
+
+        #[cfg(not(all(unix, feature = "xattr")))]
+        {
+            assert_eq!(cleared, vec!["xattrs"]);
+            assert!(!flags.xattrs);
+        }
+    }
+
+    /// When both ACLs and xattrs are requested but the platform lacks support,
+    /// both are cleared and reported.
+    ///
+    /// upstream: options.c:1842-1868 - both guards apply independently
+    #[test]
+    fn clear_unsupported_features_handles_both_acl_and_xattr() {
+        let mut flags = ParsedServerFlags::parse("-AX").unwrap();
+        assert!(flags.acls);
+        assert!(flags.xattrs);
+        let cleared = flags.clear_unsupported_features();
+
+        // On a platform without both features, both are cleared.
+        // On a platform with both, neither is cleared.
+        // On a platform with only one, only the missing one is cleared.
+        // The exact result depends on the build, but the function must not panic.
+        for name in &cleared {
+            assert!(
+                *name == "ACLs" || *name == "xattrs",
+                "unexpected cleared feature: {name}"
+            );
+        }
+
+        // After clearing, the flag matches whether the feature is available.
+        #[cfg(all(unix, feature = "acl"))]
+        assert!(flags.acls, "ACLs should remain when feature is available");
+        #[cfg(not(all(unix, feature = "acl")))]
+        assert!(!flags.acls, "ACLs should be cleared when feature is absent");
+
+        #[cfg(all(unix, feature = "xattr"))]
+        assert!(
+            flags.xattrs,
+            "xattrs should remain when feature is available"
+        );
+        #[cfg(not(all(unix, feature = "xattr")))]
+        assert!(
+            !flags.xattrs,
+            "xattrs should be cleared when feature is absent"
+        );
+    }
+
+    /// Clearing unsupported features is idempotent - calling it twice
+    /// produces an empty result on the second call.
+    #[test]
+    fn clear_unsupported_features_idempotent() {
+        let mut flags = ParsedServerFlags::parse("-AX").unwrap();
+        let _ = flags.clear_unsupported_features();
+        let second = flags.clear_unsupported_features();
+        assert!(
+            second.is_empty(),
+            "second call should return empty: {second:?}"
+        );
+    }
+
+    /// Other transfer flags are not affected by clear_unsupported_features.
+    #[test]
+    fn clear_unsupported_features_preserves_other_flags() {
+        let mut flags = ParsedServerFlags::parse("-rAXz").unwrap();
+        let _ = flags.clear_unsupported_features();
+        assert!(flags.recursive, "recursive should be preserved");
+        assert!(flags.compress, "compress should be preserved");
+    }
 }

--- a/crates/transfer/src/lib.rs
+++ b/crates/transfer/src/lib.rs
@@ -459,6 +459,23 @@ pub fn run_server_with_handshake<W: Write>(
         // "refuse options" mechanism instead of compat-flag detection.
     }
 
+    // upstream: options.c:1842-1868 - when compiled without SUPPORT_ACLS or
+    // SUPPORT_XATTRS, the server rejects -A/-X from the client. We mirror this
+    // by clearing feature-gated flags and warning instead of hard-failing, so
+    // the transfer proceeds without the unsupported metadata type.
+    let cleared = config.flags.clear_unsupported_features();
+    for feature in &cleared {
+        let role_suffix = match config.role {
+            ServerRole::Receiver => role_trailer::receiver(),
+            ServerRole::Generator => role_trailer::generator(),
+        };
+        eprintln!(
+            "WARNING: {feature} are not supported on this host - disabling preservation {}{}",
+            role_trailer::error_location!(),
+            role_suffix
+        );
+    }
+
     // Flush raw-mode data before wrapping in multiplexed writer.
     stdout.flush()?;
 

--- a/crates/transfer/src/setup/tests.rs
+++ b/crates/transfer/src/setup/tests.rs
@@ -1247,3 +1247,215 @@ fn setup_protocol_delegates_to_default_negotiator() {
     assert_eq!(result1.checksum_seed, result2.checksum_seed);
     assert_eq!(stdout1, stdout2);
 }
+
+// ==================== ACL/xattr capability negotiation tests ====================
+
+/// When the client capability string includes 'x' (CF_AVOID_XATTR_OPTIM),
+/// the server advertises xattr awareness. Clients use this flag to detect
+/// that the remote peer supports xattrs.
+///
+/// upstream: compat.c:722 - server sets CF_AVOID_XATTR_OPTIM when compiled
+/// with SUPPORT_XATTRS
+#[test]
+fn server_advertises_xattr_support_via_avoid_xattr_optim_flag() {
+    let flags = build_compat_flags_from_client_info("LsfxCIvu", true);
+    assert!(
+        flags.contains(CompatibilityFlags::AVOID_XATTR_OPTIMIZATION),
+        "server should advertise CF_AVOID_XATTR_OPTIM when client sends 'x'"
+    );
+}
+
+/// When the client capability string does NOT include 'x', the server
+/// does not advertise xattr support. A client requesting --xattrs should
+/// detect this and gracefully disable xattr preservation.
+///
+/// upstream: compat.c:722 - CF_AVOID_XATTR_OPTIM only set when client
+/// advertises 'x' and server has SUPPORT_XATTRS
+#[test]
+fn server_omits_xattr_flag_when_client_lacks_x_capability() {
+    let flags = build_compat_flags_from_client_info("LsfCIvu", true);
+    assert!(
+        !flags.contains(CompatibilityFlags::AVOID_XATTR_OPTIMIZATION),
+        "server should NOT advertise CF_AVOID_XATTR_OPTIM when client omits 'x'"
+    );
+}
+
+/// The client reads compat flags from the server. When the server's flags
+/// lack CF_AVOID_XATTR_OPTIM, the client should detect that the remote
+/// does not support xattrs.
+///
+/// upstream: compat.c:780-785 - client detects missing xattr support
+#[test]
+fn client_detects_missing_xattr_support_from_server_flags() {
+    // Server flags without CF_AVOID_XATTR_OPTIM
+    let server_flags = CompatibilityFlags::CHECKSUM_SEED_FIX
+        | CompatibilityFlags::SAFE_FILE_LIST
+        | CompatibilityFlags::VARINT_FLIST_FLAGS;
+
+    assert!(
+        !server_flags.contains(CompatibilityFlags::AVOID_XATTR_OPTIMIZATION),
+        "server flags should lack CF_AVOID_XATTR_OPTIM"
+    );
+
+    // Server flags with CF_AVOID_XATTR_OPTIM
+    let server_flags_with_xattr = server_flags | CompatibilityFlags::AVOID_XATTR_OPTIMIZATION;
+    assert!(
+        server_flags_with_xattr.contains(CompatibilityFlags::AVOID_XATTR_OPTIMIZATION),
+        "server flags should have CF_AVOID_XATTR_OPTIM when added"
+    );
+}
+
+/// Verify that when the client does NOT request ACLs or xattrs (i.e., flags
+/// are false), no capability negotiation issues arise - the transfer proceeds
+/// without any degradation warnings.
+#[test]
+fn no_degradation_when_client_does_not_request_acls_or_xattrs() {
+    use crate::flags::ParsedServerFlags;
+
+    let mut flags = ParsedServerFlags::parse("-rlt").unwrap();
+    assert!(!flags.acls, "ACLs should not be set for -rlt");
+    assert!(!flags.xattrs, "xattrs should not be set for -rlt");
+
+    let cleared = flags.clear_unsupported_features();
+    assert!(
+        cleared.is_empty(),
+        "nothing should be cleared when neither ACL nor xattr is requested"
+    );
+}
+
+/// Protocol version < 30 must reject --acls for non-local transfers.
+/// This is enforced at the protocol restriction layer.
+///
+/// upstream: compat.c:655-661 - ACLs require protocol 30+
+#[test]
+fn protocol_restriction_rejects_acls_below_protocol_30() {
+    let flags = ProtocolRestrictionFlags {
+        preserve_acls: true,
+        local_server: false,
+        ..Default::default()
+    };
+    let err =
+        apply_protocol_restrictions(ProtocolVersion::try_from(29).unwrap(), &flags).unwrap_err();
+    assert!(
+        err.to_string().contains("--acls requires protocol 30"),
+        "should reject ACLs below protocol 30: {err}"
+    );
+}
+
+/// Protocol version < 30 must reject --xattrs for non-local transfers.
+/// This is enforced at the protocol restriction layer.
+///
+/// upstream: compat.c:662-668 - xattrs require protocol 30+
+#[test]
+fn protocol_restriction_rejects_xattrs_below_protocol_30() {
+    let flags = ProtocolRestrictionFlags {
+        preserve_xattrs: true,
+        local_server: false,
+        ..Default::default()
+    };
+    let err =
+        apply_protocol_restrictions(ProtocolVersion::try_from(29).unwrap(), &flags).unwrap_err();
+    assert!(
+        err.to_string().contains("--xattrs requires protocol 30"),
+        "should reject xattrs below protocol 30: {err}"
+    );
+}
+
+/// Protocol 30+ allows both ACLs and xattrs without error.
+///
+/// upstream: compat.c:652-668 - restrictions only apply below version 30
+#[test]
+fn protocol_30_allows_acls_and_xattrs() {
+    let flags = ProtocolRestrictionFlags {
+        preserve_acls: true,
+        preserve_xattrs: true,
+        local_server: false,
+        ..Default::default()
+    };
+    assert!(
+        apply_protocol_restrictions(ProtocolVersion::try_from(30).unwrap(), &flags,).is_ok(),
+        "protocol 30 should allow both ACLs and xattrs"
+    );
+}
+
+/// Local server (no remote connection) bypasses protocol version checks
+/// for ACLs and xattrs. This mirrors upstream which only checks these
+/// restrictions for remote connections.
+///
+/// upstream: compat.c:655,662 - `&& !local_server` guards
+#[test]
+fn local_server_allows_acls_and_xattrs_below_protocol_30() {
+    let flags = ProtocolRestrictionFlags {
+        preserve_acls: true,
+        preserve_xattrs: true,
+        local_server: true,
+        ..Default::default()
+    };
+    assert!(
+        apply_protocol_restrictions(ProtocolVersion::try_from(28).unwrap(), &flags,).is_ok(),
+        "local server should allow ACLs and xattrs regardless of protocol version"
+    );
+}
+
+/// When the server supports ACLs/xattrs (features enabled) but the client
+/// does NOT include -A/-X in its flag string, the parsed flags should be
+/// false. The transfer proceeds without metadata preservation.
+#[test]
+fn server_does_not_force_acl_xattr_when_client_omits_flags() {
+    use crate::flags::ParsedServerFlags;
+
+    let flags = ParsedServerFlags::parse("-logDtpre.iLsfxCIvu").unwrap();
+    assert!(
+        !flags.acls,
+        "ACLs should not be set when client omits 'A' from flag string"
+    );
+    assert!(
+        !flags.xattrs,
+        "xattrs should not be set when client omits 'X' from flag string"
+    );
+}
+
+/// When the client includes both -A and -X in its flag string, the server
+/// should parse both and set the corresponding flags to true.
+#[test]
+fn server_parses_client_acl_and_xattr_flags() {
+    use crate::flags::ParsedServerFlags;
+
+    let flags = ParsedServerFlags::parse("-logDtprAXe.iLsfxCIvu").unwrap();
+    assert!(flags.acls, "ACLs should be set when client sends 'A'");
+    assert!(flags.xattrs, "xattrs should be set when client sends 'X'");
+}
+
+/// The capability string from build_capability_string always includes 'x'
+/// (CF_AVOID_XATTR_OPTIM), since our build always compiles with xattr wire
+/// protocol support. This is how remote peers detect xattr awareness.
+///
+/// upstream: options.c:3003-3050 - maybe_add_e_option() builds -e.xxx
+#[test]
+fn capability_string_always_includes_xattr_marker() {
+    use super::build_capability_string;
+
+    let cap = build_capability_string(true);
+    assert!(
+        cap.contains('x'),
+        "capability string should include 'x' for xattr support: {cap}"
+    );
+}
+
+/// The capability string does not contain A or X directly - those are
+/// transfer flags in the compact flag string, not capability characters.
+/// Capabilities use lowercase letters for different purposes.
+#[test]
+fn capability_string_does_not_contain_acl_xattr_transfer_flags() {
+    use super::build_capability_string;
+
+    let cap = build_capability_string(true);
+    assert!(
+        !cap.contains('A'),
+        "capability string should not contain 'A' (ACL transfer flag): {cap}"
+    );
+    assert!(
+        !cap.contains('X'),
+        "capability string should not contain 'X' (xattr transfer flag): {cap}"
+    );
+}


### PR DESCRIPTION
## Summary

- Wire `ParsedServerFlags::clear_unsupported_features()` into `run_server_with_handshake()` so feature-gated ACL/xattr flags are cleared with a warning when the server build lacks support, preventing mid-transfer failures
- Add comprehensive tests for ACL/xattr capability negotiation graceful degradation across the transfer and setup layers
- Fix dead code: `clear_unsupported_features()` was defined but never called - client `-A`/`-X` flags went unchecked on servers compiled without `acl`/`xattr` features

## Test plan

- [ ] CI passes on all platforms (fmt, clippy, nextest, Windows, macOS, Linux musl)
- [ ] `clear_unsupported_features` tests validate feature-gated behavior under `#[cfg]` for both supported and unsupported builds
- [ ] Protocol restriction tests confirm `--acls`/`--xattrs` are rejected below protocol 30
- [ ] Capability string tests verify `CF_AVOID_XATTR_OPTIM` presence/absence for remote xattr detection
- [ ] Idempotency and flag preservation tests confirm no side effects on unrelated flags