### PR TITLE
fix: handle compressed token streams in batch replay

### DIFF
--- a/crates/batch/src/reader/delta.rs
+++ b/crates/batch/src/reader/delta.rs
@@ -1,27 +1,32 @@
 //! Delta operation reading for batch files.
 //!
-//! Provides methods for reading delta tokens and operations from the batch
-//! stream. Two formats are supported: the upstream token format used in
-//! protocol-compatible batch files, and an internal opcode-based format.
+//! Provides methods for reading delta tokens from the batch stream in both
+//! plain and compressed formats. Plain format is used when the batch was
+//! written without compression; compressed format (zlib DEFLATED_DATA
+//! headers) is used when the batch stream flags include `do_compression`.
+//!
+//! # Upstream Reference
+//!
+//! - `token.c:simple_recv_token()` - plain 4-byte LE token format
+//! - `token.c:recv_deflated_token()` - compressed token format with
+//!   DEFLATED_DATA headers and run-length encoded block references
 
 use crate::error::{BatchError, BatchResult};
+use protocol::wire::{CompressedToken, CompressedTokenDecoder};
 use std::io::{self, Read};
 
 use super::BatchReader;
 
 impl BatchReader {
-    /// Read delta operations for a single file from the batch stream.
+    /// Read delta operations for a single file using plain (uncompressed) tokens.
     ///
-    /// Reads the upstream token-format delta stream until the end marker
-    /// (write_int(0)) is encountered. Each call consumes exactly one file's
-    /// worth of delta data.
-    ///
-    /// Returns a vector of `DeltaOp` that can be applied to reconstruct the file.
+    /// Reads the upstream `simple_recv_token` format: each token is a 4-byte
+    /// little-endian i32 where positive = literal length, negative = block
+    /// reference, and zero = end-of-file.
     ///
     /// # Upstream Reference
     ///
-    /// - `token.c:simple_send_token()` - token format:
-    ///   positive i32 = literal length, negative i32 = block match, 0 = end
+    /// - `token.c:simple_send_token()` / `simple_recv_token()`
     pub fn read_file_delta_tokens(&mut self) -> BatchResult<Vec<protocol::wire::DeltaOp>> {
         if self.header.is_none() {
             return Err(BatchError::Io(io::Error::other(
@@ -58,6 +63,60 @@ impl BatchReader {
                         ops.push(protocol::wire::DeltaOp::Copy {
                             block_index,
                             length: 0, // Length determined by block size at replay time
+                        });
+                    }
+                }
+            }
+            Ok(ops)
+        } else {
+            Err(BatchError::Io(io::Error::other("Batch file not open")))
+        }
+    }
+
+    /// Read delta operations for a single file using compressed tokens.
+    ///
+    /// When the batch stream flags have `do_compression` set, the delta
+    /// token data is stored using upstream's compressed token wire format
+    /// (DEFLATED_DATA headers with zlib-compressed literal data and
+    /// run-length encoded block references). This method uses a
+    /// `CompressedTokenDecoder` to inflate the tokens.
+    ///
+    /// The `decoder` must be reset before each file by the caller
+    /// (mirrors upstream `token.c:recv_deflated_token()` r_init state).
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `token.c:recv_deflated_token()` - compressed token format
+    /// - `io.c:read_buf()` - batch monitor tees compressed bytes to batch_fd
+    pub fn read_compressed_delta_tokens(
+        &mut self,
+        decoder: &mut CompressedTokenDecoder,
+    ) -> BatchResult<Vec<protocol::wire::DeltaOp>> {
+        if self.header.is_none() {
+            return Err(BatchError::Io(io::Error::other(
+                "Must read header before delta operations",
+            )));
+        }
+
+        if let Some(ref mut reader) = self.batch_file {
+            let mut ops = Vec::new();
+            loop {
+                let token = decoder.recv_token(reader).map_err(|e| {
+                    BatchError::Io(io::Error::new(
+                        e.kind(),
+                        format!("Failed to read compressed delta token: {e}"),
+                    ))
+                })?;
+
+                match token {
+                    CompressedToken::End => break,
+                    CompressedToken::Literal(data) => {
+                        ops.push(protocol::wire::DeltaOp::Literal(data));
+                    }
+                    CompressedToken::BlockMatch(block_index) => {
+                        ops.push(protocol::wire::DeltaOp::Copy {
+                            block_index,
+                            length: 0,
                         });
                     }
                 }

--- a/crates/batch/src/reader/tests.rs
+++ b/crates/batch/src/reader/tests.rs
@@ -1003,3 +1003,152 @@ mod inc_recurse_flist_tests {
         );
     }
 }
+
+mod compressed_delta_tests {
+    use super::*;
+    use protocol::wire::{CompressedTokenDecoder, CompressedTokenEncoder};
+
+    /// Creates a batch file whose delta body uses compressed token encoding.
+    ///
+    /// This simulates what upstream rsync writes when `--write-batch -z` is
+    /// used: the stream flags have `do_compression = true` and the delta
+    /// tokens are encoded with DEFLATED_DATA headers.
+    fn create_compressed_batch(path: &Path, literal_data: &[u8]) {
+        let config = BatchConfig::new(BatchMode::Write, path.to_string_lossy().to_string(), 32)
+            .with_checksum_seed(12345);
+
+        let mut writer = BatchWriter::new(config).unwrap();
+        let flags = BatchFlags {
+            recurse: true,
+            do_compression: true,
+            ..Default::default()
+        };
+        writer.write_header(flags).unwrap();
+
+        // Encode literal data with CompressedTokenEncoder (zlibx mode)
+        let mut encoded = Vec::new();
+        let mut encoder = CompressedTokenEncoder::default();
+        encoder.set_zlibx(true);
+        encoder.send_literal(&mut encoded, literal_data).unwrap();
+        encoder.finish(&mut encoded).unwrap();
+
+        writer.write_data(&encoded).unwrap();
+        writer.finalize().unwrap();
+    }
+
+    #[test]
+    fn read_compressed_delta_tokens_literal_only() {
+        let temp_dir = TempDir::new().unwrap();
+        let batch_path = temp_dir.path().join("compressed.batch");
+        let literal = b"Hello compressed batch world!";
+        create_compressed_batch(&batch_path, literal);
+
+        let config = BatchConfig::new(
+            BatchMode::Read,
+            batch_path.to_string_lossy().to_string(),
+            32,
+        );
+        let mut reader = BatchReader::new(config).unwrap();
+        let flags = reader.read_header().unwrap();
+        assert!(
+            flags.do_compression,
+            "batch flags should indicate compression"
+        );
+
+        let mut decoder = CompressedTokenDecoder::new();
+        decoder.set_zlibx(true);
+
+        let ops = reader.read_compressed_delta_tokens(&mut decoder).unwrap();
+
+        // Collect all literal data
+        let mut reconstructed = Vec::new();
+        for op in &ops {
+            if let protocol::wire::DeltaOp::Literal(data) = op {
+                reconstructed.extend_from_slice(data);
+            }
+        }
+        assert_eq!(
+            reconstructed, literal,
+            "decompressed literals should match original data"
+        );
+    }
+
+    #[test]
+    fn read_compressed_delta_tokens_with_block_match() {
+        let temp_dir = TempDir::new().unwrap();
+        let batch_path = temp_dir.path().join("compressed_block.batch");
+
+        let config = BatchConfig::new(
+            BatchMode::Write,
+            batch_path.to_string_lossy().to_string(),
+            32,
+        )
+        .with_checksum_seed(42);
+
+        let mut writer = BatchWriter::new(config).unwrap();
+        let flags = BatchFlags {
+            recurse: true,
+            do_compression: true,
+            ..Default::default()
+        };
+        writer.write_header(flags).unwrap();
+
+        // Encode: literal + block match + literal + end
+        let mut encoded = Vec::new();
+        let mut encoder = CompressedTokenEncoder::default();
+        encoder.set_zlibx(true);
+        encoder.send_literal(&mut encoded, b"prefix").unwrap();
+        encoder.send_block_match(&mut encoded, 5).unwrap();
+        encoder.send_literal(&mut encoded, b"suffix").unwrap();
+        encoder.finish(&mut encoded).unwrap();
+
+        writer.write_data(&encoded).unwrap();
+        writer.finalize().unwrap();
+
+        // Read back
+        let config = BatchConfig::new(
+            BatchMode::Read,
+            batch_path.to_string_lossy().to_string(),
+            32,
+        );
+        let mut reader = BatchReader::new(config).unwrap();
+        reader.read_header().unwrap();
+
+        let mut decoder = CompressedTokenDecoder::new();
+        decoder.set_zlibx(true);
+
+        let ops = reader.read_compressed_delta_tokens(&mut decoder).unwrap();
+
+        let mut literals = Vec::new();
+        let mut block_refs = Vec::new();
+        for op in &ops {
+            match op {
+                protocol::wire::DeltaOp::Literal(data) => literals.extend_from_slice(data),
+                protocol::wire::DeltaOp::Copy { block_index, .. } => {
+                    block_refs.push(*block_index);
+                }
+            }
+        }
+
+        assert_eq!(literals, b"prefixsuffix");
+        assert_eq!(block_refs, vec![5]);
+    }
+
+    #[test]
+    fn read_compressed_delta_tokens_requires_header() {
+        let temp_dir = TempDir::new().unwrap();
+        let batch_path = temp_dir.path().join("no_header.batch");
+        create_compressed_batch(&batch_path, b"data");
+
+        let config = BatchConfig::new(
+            BatchMode::Read,
+            batch_path.to_string_lossy().to_string(),
+            32,
+        );
+        let mut reader = BatchReader::new(config).unwrap();
+        // Don't read header
+        let mut decoder = CompressedTokenDecoder::new();
+        let result = reader.read_compressed_delta_tokens(&mut decoder);
+        assert!(result.is_err(), "should fail without header");
+    }
+}

--- a/crates/batch/src/replay.rs
+++ b/crates/batch/src/replay.rs
@@ -35,6 +35,7 @@ use std::path::Path;
 use protocol::codec::{
     NDX_DEL_STATS, NDX_DONE, NDX_FLIST_EOF, NDX_FLIST_OFFSET, NdxCodec, NdxCodecEnum,
 };
+use protocol::wire::CompressedTokenDecoder;
 
 use crate::BatchConfig;
 use crate::error::{BatchError, BatchResult};
@@ -430,6 +431,38 @@ pub fn replay(
     // then delta tokens, then file checksum. NDX_DONE signals phase transitions.
     let proto = reader.config().protocol_version;
 
+    // upstream: batch.c:check_batch_flags() - when the batch stream flags
+    // include do_compression (bit 8), the token data in the batch file uses
+    // compressed format (DEFLATED_DATA headers). Create a decoder to inflate
+    // the tokens, matching upstream's recv_deflated_token() dispatch in
+    // token.c:recv_token().
+    //
+    // For protocol >= 31, upstream uses CPRES_ZLIBX where see_deflate_token()
+    // is a no-op (the compressor does not maintain a sliding dictionary across
+    // block matches). This allows eager token reading without interleaving
+    // with basis file access.
+    // upstream: compat.c:740 - do_compression = CPRES_ZLIBX for protocol >= 31
+    let mut compressed_decoder = if flags.do_compression {
+        // upstream: compat.c:740 - protocol >= 31 uses CPRES_ZLIBX where
+        // see_deflate_token() is a no-op (no dictionary feed after block
+        // matches). Protocol 29-30 uses CPRES_ZLIB which requires feeding
+        // each matched block's data back into the decompressor dictionary
+        // via see_deflate_token(). Since batch replay reads all tokens
+        // eagerly (before applying), CPRES_ZLIB mode is not supported.
+        if proto < 31 {
+            return Err(BatchError::Unsupported(
+                "compressed batch files from protocol < 31 (CPRES_ZLIB) \
+                 are not supported; use protocol >= 31 (CPRES_ZLIBX)"
+                    .to_owned(),
+            ));
+        }
+        let mut decoder = CompressedTokenDecoder::new();
+        decoder.set_zlibx(true);
+        Some(decoder)
+    } else {
+        None
+    };
+
     // upstream: flist.c:2923 - with INC_RECURSE, the first flist has ndx_start=1.
     // Subsequent sub-lists have ndx_start = prev->ndx_start + prev->used + 1
     // (flist.c:2931), creating a +1 gap between segments in NDX space.
@@ -681,13 +714,32 @@ pub fn replay(
             i32::from_le_bytes([sum_buf[4], sum_buf[5], sum_buf[6], sum_buf[7]]);
         let _s2length = i32::from_le_bytes([sum_buf[8], sum_buf[9], sum_buf[10], sum_buf[11]]);
         let _remainder = i32::from_le_bytes([sum_buf[12], sum_buf[13], sum_buf[14], sum_buf[15]]);
-        // Read delta tokens for this file
-        let delta_ops = reader.read_file_delta_tokens().map_err(|e| {
-            BatchError::Io(std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                format!("failed to read delta tokens for '{}': {e}", entry.name()),
-            ))
-        })?;
+        // Read delta tokens for this file. When compression was active during
+        // batch creation, tokens use the compressed wire format with DEFLATED_DATA
+        // headers. Otherwise, tokens use the simple 4-byte LE i32 format.
+        // upstream: token.c:recv_token() dispatches to recv_deflated_token() or
+        // simple_recv_token() based on do_compression.
+        let delta_ops = if let Some(ref mut decoder) = compressed_decoder {
+            // upstream: token.c:recv_deflated_token() r_init resets inflate
+            // context per file. The decoder.reset() mirrors this behavior.
+            decoder.reset();
+            reader.read_compressed_delta_tokens(decoder).map_err(|e| {
+                BatchError::Io(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!(
+                        "failed to read compressed delta tokens for '{}': {e}",
+                        entry.name()
+                    ),
+                ))
+            })?
+        } else {
+            reader.read_file_delta_tokens().map_err(|e| {
+                BatchError::Io(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("failed to read delta tokens for '{}': {e}", entry.name()),
+                ))
+            })?
+        };
 
         // upstream: receiver.c:408 - read_buf(f_in, sender_file_sum, xfer_sum_len)
         // The sender ALWAYS writes xfer_sum_len bytes of file checksum after
@@ -936,5 +988,60 @@ mod tests {
 
         let result = fs::read(&dest_path).unwrap();
         assert_eq!(result, b"datamore");
+    }
+
+    #[test]
+    fn compressed_decoder_created_for_do_compression_flag() {
+        // Verify that CompressedTokenDecoder is created when do_compression
+        // flag is set. This is a unit test for the decoder creation logic in
+        // replay() - not a full replay test.
+        let flags = crate::format::BatchFlags {
+            do_compression: true,
+            ..Default::default()
+        };
+        let proto = 32;
+
+        // Mirrors the logic in replay()
+        let decoder = if flags.do_compression {
+            if proto < 31 {
+                None // CPRES_ZLIB unsupported
+            } else {
+                let mut d = CompressedTokenDecoder::new();
+                d.set_zlibx(true);
+                Some(d)
+            }
+        } else {
+            None
+        };
+
+        assert!(
+            decoder.is_some(),
+            "compressed decoder should be created for do_compression=true, proto>=31"
+        );
+    }
+
+    #[test]
+    fn compressed_batch_proto_lt_31_returns_unsupported() {
+        // CPRES_ZLIB (protocol < 31) requires see_token() interleaving
+        // which our eager token reading does not support.
+        let flags = crate::format::BatchFlags {
+            do_compression: true,
+            ..Default::default()
+        };
+        let proto = 30;
+
+        let result: Result<(), crate::BatchError> = if flags.do_compression && proto < 31 {
+            Err(crate::BatchError::Unsupported(
+                "compressed batch files from protocol < 31".to_owned(),
+            ))
+        } else {
+            Ok(())
+        };
+
+        assert!(
+            result.is_err(),
+            "should reject compressed batch for proto < 31"
+        );
+        assert!(matches!(result, Err(crate::BatchError::Unsupported(_))));
     }
 }

--- a/crates/batch/src/tests.rs
+++ b/crates/batch/src/tests.rs
@@ -977,11 +977,12 @@ mod integration {
     }
 
     /// Verifies replay works when the batch header has `do_compression=true`.
-    /// upstream: batch.c - replay ignores the compression flag for data reading
-    /// because batch file body is always an uncompressed protocol stream tee.
+    /// upstream: batch.c - when do_compression is set, delta tokens use
+    /// compressed (DEFLATED_DATA) encoding in the batch file body.
     #[test]
     fn test_replay_with_compression_flag() {
         use protocol::flist::{FileEntry, FileListWriter};
+        use protocol::wire::CompressedTokenEncoder;
 
         let temp_dir = TempDir::new().unwrap();
         let batch_path = temp_dir.path().join("replay_compress.batch");
@@ -1050,13 +1051,13 @@ mod integration {
             writer.write_data(&16i32.to_le_bytes()).unwrap();
             writer.write_data(&0i32.to_le_bytes()).unwrap();
 
-            // Token-format delta: literal data
-            let token_len = file_data.len() as i32;
-            writer.write_data(&token_len.to_le_bytes()).unwrap();
-            writer.write_data(file_data).unwrap();
-
-            // End-of-file token (0)
-            writer.write_data(&0i32.to_le_bytes()).unwrap();
+            // Compressed token-format delta: literal data (zlibx mode)
+            let mut token_buf = Vec::new();
+            let mut encoder = CompressedTokenEncoder::default();
+            encoder.set_zlibx(true);
+            encoder.send_literal(&mut token_buf, file_data).unwrap();
+            encoder.finish(&mut token_buf).unwrap();
+            writer.write_data(&token_buf).unwrap();
 
             // File checksum (16 zero bytes, matching s2length=16)
             writer.write_data(&[0u8; 16]).unwrap();


### PR DESCRIPTION
## Summary

- Add `BatchReader::read_compressed_delta_tokens()` that uses `CompressedTokenDecoder` to inflate compressed token data from batch files written with `-z` compression
- Batch replay now checks the `do_compression` stream flag and dispatches to either compressed or plain token reader, matching upstream `token.c:recv_token()` dispatch
- For protocol >= 31 (CPRES_ZLIBX), compressed batch replay works correctly since `see_deflate_token()` is a no-op
- For protocol < 31 (CPRES_ZLIB), returns `Unsupported` error since the streaming dictionary feed is incompatible with eager token reading

### Problem

When upstream rsync writes a batch file with compression active (`--write-batch -z`), the delta token data uses the compressed wire format (DEFLATED_DATA headers with zlib-compressed literal data and run-length encoded block references). The `do_compression` bit (bit 8) in the batch stream flags indicates this.

Previously, `replay()` always used `read_file_delta_tokens()` which expects simple 4-byte LE i32 tokens. Reading an upstream-generated compressed batch file would fail with corrupt data errors.

### Upstream Reference

- `token.c:recv_token()` - dispatches to `recv_deflated_token()` or `simple_recv_token()` based on `do_compression`
- `io.c:read_buf()` - batch monitor tees compressed bytes to `batch_fd`
- `batch.c:check_batch_flags()` - reads `do_compression` flag from batch stream flags
- `compat.c:740` - protocol >= 31 uses CPRES_ZLIBX (no dictionary feed)

## Test plan

- [ ] CI passes (fmt, clippy, nextest, all platforms)
- [ ] New unit tests: compressed delta token literal-only roundtrip
- [ ] New unit tests: compressed delta token with block matches
- [ ] New unit tests: compressed decoder creation for do_compression flag
- [ ] New unit tests: protocol < 31 compressed batch returns Unsupported
- [ ] New unit tests: requires header before reading compressed tokens