### PR TITLE
feat: add automatic SSH stderr drain with user-visible forwarding

### DIFF
--- a/crates/rsync_io/src/ssh/connection.rs
+++ b/crates/rsync_io/src/ssh/connection.rs
@@ -11,6 +11,8 @@ use std::process::{Child, ChildStderr, ChildStdin, ChildStdout, ExitStatus};
 use std::sync::{Arc, Mutex};
 use std::thread::{self, JoinHandle};
 
+use logging::debug_log;
+
 /// Maximum bytes retained in the stderr capture buffer.
 ///
 /// When the buffer exceeds this limit, the oldest bytes are discarded to keep
@@ -209,9 +211,11 @@ impl SshWriter {
 /// When an SSH child writes more than the OS pipe buffer capacity (typically
 /// 64 KB) to stderr, it blocks until the buffer is drained. If nothing reads
 /// stderr, the child stalls and the transfer deadlocks. This thread reads
-/// stderr line-by-line, forwards each line to the process stderr via
-/// `eprintln!` (matching upstream rsync's behavior of surfacing remote errors),
-/// and collects the output into a bounded buffer for programmatic retrieval.
+/// stderr line-by-line using raw byte reads (tolerant of non-UTF-8 output),
+/// forwards each line to the process stderr in real time (matching upstream
+/// rsync's behavior of surfacing remote errors immediately), and collects
+/// the output into a bounded buffer for programmatic retrieval via
+/// [`SshConnection::stderr_output`] or [`SshChildHandle::stderr_output`].
 struct StderrDrain {
     handle: Option<JoinHandle<()>>,
     buffer: Arc<Mutex<Vec<u8>>>,
@@ -238,18 +242,29 @@ impl StderrDrain {
 
     /// Reads stderr line-by-line, forwards to process stderr, and collects
     /// into the shared buffer (bounded to [`STDERR_BUFFER_CAP`]).
+    ///
+    /// Uses `read_until(b'\n')` instead of `lines()` to handle non-UTF-8
+    /// output without prematurely terminating the drain. SSH or the remote
+    /// process may emit binary data on stderr (e.g., locale-encoded error
+    /// messages); dropping such lines would leave the pipe un-drained and
+    /// risk the deadlock this thread exists to prevent.
     fn drain_loop(stderr: ChildStderr, buffer: &Mutex<Vec<u8>>) {
-        let reader = BufReader::new(stderr);
-        for line in reader.lines() {
-            match line {
-                Ok(text) => {
-                    eprintln!("{text}");
-                    // Collect the line with its newline into the bounded buffer.
-                    let mut bytes = text.into_bytes();
-                    bytes.push(b'\n');
-                    Self::append_bounded(buffer, &bytes);
+        let mut reader = BufReader::new(stderr);
+        let mut line_buf = Vec::new();
+        loop {
+            line_buf.clear();
+            match reader.read_until(b'\n', &mut line_buf) {
+                Ok(0) => break, // EOF
+                Ok(_) => {
+                    // Forward the line to the local process stderr so the user
+                    // sees SSH errors in real time - matching upstream rsync's
+                    // behavior of surfacing remote errors immediately.
+                    let text = String::from_utf8_lossy(&line_buf);
+                    eprint!("{text}");
+                    debug_log!(Connect, 3, "ssh stderr: {}", text.trim_end());
+                    Self::append_bounded(buffer, &line_buf);
                 }
-                // EOF or broken pipe - child exited, stop draining.
+                // I/O error (broken pipe, etc.) - child exited, stop draining.
                 Err(_) => break,
             }
         }

--- a/crates/rsync_io/src/ssh/tests.rs
+++ b/crates/rsync_io/src/ssh/tests.rs
@@ -826,6 +826,114 @@ fn keepalive_with_bind_address_and_batch_mode() {
     );
 }
 
+// --- SSH stderr drain thread tests ---
+
+#[cfg(unix)]
+#[test]
+fn stderr_drain_handles_non_utf8_output() {
+    // Non-UTF-8 bytes on stderr must not terminate the drain thread prematurely.
+    // This verifies the drain continues to collect all output even when
+    // individual lines contain invalid UTF-8 sequences.
+    let mut command = SshCommand::new("ignored");
+    command.set_program("sh");
+    command.set_batch_mode(false);
+    command.push_option("-c");
+    // Emit a valid line, then raw 0xFF bytes (invalid UTF-8), then another valid line.
+    command.push_option(
+        "printf 'before-binary\\n' >&2; printf '\\xff\\xfe\\n' >&2; printf 'after-binary\\n' >&2",
+    );
+    command.set_target_override(Some(OsString::new()));
+
+    let connection = command.spawn().expect("spawn shell");
+    let (_reader, _writer, child_handle) = connection.split().expect("split");
+
+    let (status, stderr) = child_handle.wait_with_stderr().expect("wait");
+    assert!(status.success());
+
+    // Both the pre-binary and post-binary lines must be present,
+    // proving the drain thread survived the non-UTF-8 bytes.
+    let text = String::from_utf8_lossy(&stderr);
+    assert!(
+        text.contains("before-binary"),
+        "expected 'before-binary' in stderr, got: {text}"
+    );
+    assert!(
+        text.contains("after-binary"),
+        "expected 'after-binary' after non-UTF-8 bytes, got: {text}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn stderr_drain_forwards_multiline_errors() {
+    // Verifies that multiple stderr lines are collected and forwarded,
+    // simulating an SSH error like "Permission denied" followed by additional
+    // context lines from the remote host.
+    let mut command = SshCommand::new("ignored");
+    command.set_program("sh");
+    command.set_batch_mode(false);
+    command.push_option("-c");
+    command.push_option(
+        "printf 'Permission denied (publickey).\\n' >&2; printf 'Connection closed by remote host\\n' >&2",
+    );
+    command.set_target_override(Some(OsString::new()));
+
+    let connection = command.spawn().expect("spawn shell");
+    let (_reader, _writer, child_handle) = connection.split().expect("split");
+
+    let (status, stderr) = child_handle.wait_with_stderr().expect("wait");
+    assert!(status.success());
+
+    let text = String::from_utf8_lossy(&stderr);
+    assert!(
+        text.contains("Permission denied"),
+        "expected 'Permission denied' in stderr, got: {text}"
+    );
+    assert!(
+        text.contains("Connection closed"),
+        "expected 'Connection closed' in stderr, got: {text}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn stderr_output_available_on_connection_before_split() {
+    // Verifies that stderr_output() works on the SshConnection itself
+    // (not just SshChildHandle), since the drain thread starts at spawn time.
+    use std::time::{Duration, Instant};
+
+    let mut command = SshCommand::new("ignored");
+    command.set_program("sh");
+    command.set_batch_mode(false);
+    command.push_option("-c");
+    command.push_option("printf 'conn-level-msg\\n' >&2; cat");
+    command.set_target_override(Some(OsString::new()));
+
+    let connection = command.spawn().expect("spawn shell");
+
+    // Poll stderr_output() on the connection (before split).
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        let output = connection.stderr_output();
+        if !output.is_empty() {
+            let text = String::from_utf8_lossy(&output);
+            assert!(
+                text.contains("conn-level-msg"),
+                "expected 'conn-level-msg', got: {text}"
+            );
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "timed out waiting for stderr output on connection"
+        );
+        std::thread::sleep(Duration::from_millis(10));
+    }
+
+    let status = connection.wait().expect("wait");
+    assert!(status.success());
+}
+
 #[test]
 fn skips_keepalive_when_interval_embedded_in_compound_option() {
     // User passes keepalive as part of a compound `-o` value.


### PR DESCRIPTION
## Summary

- Replace `BufReader::lines()` with `read_until(b'\n')` in the SSH stderr drain thread to handle non-UTF-8 output without prematurely terminating the drain loop - the previous `lines()` iterator breaks on any invalid UTF-8 byte, leaving the pipe un-drained and risking the deadlock the thread exists to prevent
- Forward each stderr line to the local process stderr via `eprint!` (matching upstream rsync's behavior) and log at debug level via `debug_log!(Connect, 3, ...)` for traceability
- Add tests for non-UTF-8 resilience, multiline SSH error forwarding, and pre-split stderr availability on `SshConnection`

Closes #1561, closes #1562.

## Test plan

- [ ] CI passes on all platforms (Linux, macOS, Windows)
- [ ] `stderr_drain_handles_non_utf8_output` - verifies drain thread survives invalid UTF-8 bytes
- [ ] `stderr_drain_forwards_multiline_errors` - verifies multi-line SSH errors are collected
- [ ] `stderr_output_available_on_connection_before_split` - verifies stderr is available before split
- [ ] Existing stderr tests continue to pass (bounded cap, pre-wait access, empty stderr)