### PR TITLE
feat: add zstd decoder support and delta interop test for compressed batch replay

### DIFF
--- a/crates/batch/Cargo.toml
+++ b/crates/batch/Cargo.toml
@@ -8,6 +8,10 @@ license.workspace = true
 description = "Batch mode support for offline rsync transfer workflows"
 repository.workspace = true
 
+[features]
+# Compression algorithm features forwarded from protocol crate.
+zstd = ["protocol/zstd"]
+
 [dependencies]
 thiserror = "2.0"
 protocol = { path = "../protocol" }

--- a/crates/batch/src/replay.rs
+++ b/crates/batch/src/replay.rs
@@ -456,9 +456,13 @@ pub fn replay(
                     .to_owned(),
             ));
         }
-        let mut decoder = CompressedTokenDecoder::new();
-        decoder.set_zlibx(true);
-        Some(decoder)
+        // upstream: compat.c - protocol 31 always uses zlib in CPRES_ZLIBX mode.
+        // Protocol >= 32 negotiates the compression algorithm via vstrings,
+        // defaulting to zstd when both sides support it. The batch header does
+        // not record which algorithm was negotiated, so we infer from the
+        // protocol version: 31 = zlib, >= 32 = zstd (falling through to zlib
+        // when the zstd feature is not compiled in).
+        Some(create_compressed_decoder(proto)?)
     } else {
         None
     };
@@ -844,6 +848,39 @@ fn default_xfer_sum_len(protocol_version: i32) -> usize {
     16
 }
 
+/// Creates the appropriate `CompressedTokenDecoder` for the batch protocol version.
+///
+/// Protocol 31 always uses zlib in CPRES_ZLIBX mode (upstream rsync 3.4.1 default).
+/// Protocol >= 32 defaults to zstd when the feature is compiled in, since oc-rsync
+/// (and future upstream versions) negotiate zstd as the preferred algorithm. The
+/// batch header does not record the negotiated compression algorithm, so the
+/// protocol version is the only disambiguation signal.
+///
+/// upstream: compat.c - protocol 31 hardcodes CPRES_ZLIBX; protocol 32+ uses
+/// vstring negotiation where zstd wins if both sides support it.
+fn create_compressed_decoder(proto: i32) -> BatchResult<CompressedTokenDecoder> {
+    // Protocol 32+ defaults to zstd when the feature is compiled in.
+    if proto >= 32 {
+        #[cfg(feature = "zstd")]
+        {
+            return CompressedTokenDecoder::new_zstd().map_err(|e| {
+                BatchError::Io(std::io::Error::new(
+                    e.kind(),
+                    format!("failed to create zstd decoder for batch replay: {e}"),
+                ))
+            });
+        }
+    }
+
+    // Suppress unused variable warning when zstd feature is disabled.
+    let _ = proto;
+
+    // Protocol 31 or zstd not available: use zlib in CPRES_ZLIBX mode.
+    let mut decoder = CompressedTokenDecoder::new();
+    decoder.set_zlibx(true);
+    Ok(decoder)
+}
+
 fn choose_block_length(file_size: u64) -> usize {
     const MIN_BLOCK: usize = 700;
     const MAX_BLOCK: usize = 128 * 1024;
@@ -991,32 +1028,22 @@ mod tests {
     }
 
     #[test]
-    fn compressed_decoder_created_for_do_compression_flag() {
-        // Verify that CompressedTokenDecoder is created when do_compression
-        // flag is set. This is a unit test for the decoder creation logic in
-        // replay() - not a full replay test.
-        let flags = crate::format::BatchFlags {
-            do_compression: true,
-            ..Default::default()
-        };
-        let proto = 32;
-
-        // Mirrors the logic in replay()
-        let decoder = if flags.do_compression {
-            if proto < 31 {
-                None // CPRES_ZLIB unsupported
-            } else {
-                let mut d = CompressedTokenDecoder::new();
-                d.set_zlibx(true);
-                Some(d)
-            }
-        } else {
-            None
-        };
-
+    fn compressed_decoder_created_for_proto_31() {
+        // Protocol 31 creates a zlib/zlibx decoder.
+        let decoder = create_compressed_decoder(31).unwrap();
         assert!(
-            decoder.is_some(),
-            "compressed decoder should be created for do_compression=true, proto>=31"
+            !decoder.initialized(),
+            "fresh decoder should not be initialized"
+        );
+    }
+
+    #[test]
+    fn compressed_decoder_created_for_proto_32() {
+        // Protocol 32 creates a zstd decoder (when feature enabled) or zlib fallback.
+        let decoder = create_compressed_decoder(32).unwrap();
+        assert!(
+            !decoder.initialized(),
+            "fresh decoder should not be initialized"
         );
     }
 

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -55,7 +55,7 @@ default = ["zstd", "lz4", "xattr", "lazy-metadata"]
 # ============================================================================
 # Compression Features
 # ============================================================================
-zstd = ["compress/zstd", "protocol/zstd"]
+zstd = ["compress/zstd", "protocol/zstd", "batch/zstd"]
 lz4 = ["compress/lz4", "protocol/lz4"]
 zlib-ng = ["compress/zlib-ng", "protocol/zlib-ng"]
 

--- a/tests/batch_interop_test.sh
+++ b/tests/batch_interop_test.sh
@@ -291,6 +291,58 @@ test_upstream_to_oc() {
     fi
 }
 
+# =========================================================================
+# Compressed batch test: upstream writes compressed, oc-rsync reads
+# =========================================================================
+
+test_upstream_compressed_to_oc() {
+    local upstream_rsync="$1"
+    local version="$2"
+    local test_name="upstream $version -z -> oc-rsync (compressed batch)"
+
+    log_test "$test_name"
+    TESTS_RUN=$((TESTS_RUN + 1))
+
+    local work_dir="$TEST_DIR/${version//./_}_z_to_oc"
+    mkdir -p "$work_dir"/{src,dest,basis,final}
+
+    setup_test_data_with_basis "$work_dir/src" "$work_dir/dest" "$work_dir/basis"
+
+    log_info "Creating compressed batch with upstream rsync $version..."
+    if ! "$upstream_rsync" -av -z --no-whole-file --ignore-times \
+        --write-batch="$work_dir/mybatch" \
+        "$work_dir/src/" "$work_dir/dest/" > "$work_dir/write.log" 2>&1; then
+        log_warn "$test_name: upstream rsync --write-batch -z failed"
+        cat "$work_dir/write.log" >&2
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        return 0
+    fi
+
+    if [ ! -f "$work_dir/mybatch" ]; then
+        log_warn "$test_name: Batch file not created"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        return 0
+    fi
+
+    cp "$work_dir/basis/testfile.bin" "$work_dir/final/testfile.bin"
+
+    log_info "Replaying compressed batch with oc-rsync..."
+    if ! "$OC_RSYNC" --read-batch="$work_dir/mybatch" "$work_dir/final/" > "$work_dir/read.log" 2>&1; then
+        log_warn "$test_name: oc-rsync --read-batch failed"
+        cat "$work_dir/read.log" >&2
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        return 0
+    fi
+
+    if verify_files_match "$work_dir/src/testfile.bin" "$work_dir/final/testfile.bin" "$test_name"; then
+        log_info "$test_name: PASS"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    else
+        log_warn "$test_name: FAIL"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+    fi
+}
+
 main() {
     log_info "Starting Batch Mode Interoperability Tests"
     log_info "oc-rsync: $OC_RSYNC"
@@ -315,7 +367,7 @@ main() {
     test_oc_roundtrip
 
     # =====================================================================
-    # Cross-tool tests
+    # Cross-tool tests (uncompressed and compressed)
     # =====================================================================
     log_info ""
     log_info "=== Cross-tool Compatibility Tests ==="
@@ -327,7 +379,7 @@ main() {
             available_versions+=("$version")
         else
             log_warn "Upstream rsync $version not found at $binary, skipping"
-            TESTS_SKIPPED=$((TESTS_SKIPPED + 2))
+            TESTS_SKIPPED=$((TESTS_SKIPPED + 3))
         fi
     done
 
@@ -337,6 +389,9 @@ main() {
         done
         for version in "${available_versions[@]}"; do
             test_upstream_to_oc "$UPSTREAM_INSTALL_ROOT/$version/bin/rsync" "$version"
+        done
+        for version in "${available_versions[@]}"; do
+            test_upstream_compressed_to_oc "$UPSTREAM_INSTALL_ROOT/$version/bin/rsync" "$version"
         done
     else
         log_warn "No upstream rsync versions available, skipping cross-tool tests"

--- a/tools/ci/run_interop.sh
+++ b/tools/ci/run_interop.sh
@@ -2090,6 +2090,85 @@ test_oc_compressed_batch_upstream_reads() {
   return 0
 }
 
+# #3085: compressed batch delta interop - upstream writes compressed batch with
+# delta transfers (basis files present), oc-rsync reads it.
+# This exercises the compressed token decoder with actual copy+literal delta
+# operations, not just whole-file literals. The destination is pre-seeded with
+# slightly different versions of the source files so rsync produces delta tokens.
+test_compressed_batch_delta_interop() {
+  local upstream_binary=$1 oc_bin=$2 src_dir=$3 work=$4 log=$5
+
+  local batch_dir="${work}/batch-compress-delta"
+  rm -rf "$batch_dir"
+
+  # Build a custom source tree with files large enough to produce block matches.
+  local delta_src="${batch_dir}/src"
+  local delta_basis="${batch_dir}/basis"
+  local delta_write_dest="${batch_dir}/write-dest"
+  local delta_read_dest="${batch_dir}/read-dest"
+  local batch_file="${batch_dir}/batch-z-delta.rsync"
+  mkdir -p "$delta_src" "$delta_basis" "$delta_write_dest" "$delta_read_dest"
+
+  # Create source files with enough data for rsync to use delta encoding.
+  # 100 KB file with known pattern - large enough that rsync picks block matches.
+  dd if=/dev/zero bs=1K count=100 2>/dev/null | tr '\0' 'A' > "$delta_src/large.dat"
+  # Modify a small section so the delta has both copy and literal tokens.
+  printf 'MODIFIED_SECTION_HERE' | dd of="$delta_src/large.dat" bs=1 seek=50000 conv=notrunc 2>/dev/null
+
+  # A second file with repeated pattern.
+  for i in $(seq 1 200); do
+    printf 'line %04d: some repeated content for delta testing\n' "$i"
+  done > "$delta_src/repeated.txt"
+
+  # Pre-seed the write destination with slightly different versions (basis files).
+  # This causes rsync to generate delta tokens with block matches.
+  dd if=/dev/zero bs=1K count=100 2>/dev/null | tr '\0' 'A' > "$delta_write_dest/large.dat"
+  for i in $(seq 1 200); do
+    printf 'line %04d: original content before modification here\n' "$i"
+  done > "$delta_write_dest/repeated.txt"
+
+  # Copy basis to the read destination so replay can apply deltas against it.
+  cp "$delta_write_dest/large.dat" "$delta_read_dest/large.dat"
+  cp "$delta_write_dest/repeated.txt" "$delta_read_dest/repeated.txt"
+
+  # Step 1: upstream rsync writes a compressed batch with delta transfers.
+  # --no-whole-file forces delta mode even for local transfers.
+  if ! timeout "$hard_timeout" "$upstream_binary" -av -z --no-whole-file \
+      --write-batch="$batch_file" --timeout=10 \
+      "${delta_src}/" "${delta_write_dest}/" \
+      >"${log}.compress-delta-write.out" 2>"${log}.compress-delta-write.err"; then
+    echo "    write-batch with -z --no-whole-file failed (upstream, exit=$?)"
+    return 1
+  fi
+
+  if [[ ! -f "$batch_file" ]]; then
+    echo "    compressed delta batch file not created"
+    return 1
+  fi
+
+  # Step 2: oc-rsync reads the compressed delta batch.
+  local rc1=0
+  timeout "$hard_timeout" "$oc_bin" -av \
+      --read-batch="$batch_file" --timeout=10 \
+      "${delta_read_dest}/" \
+      >"${log}.compress-delta-read.out" 2>"${log}.compress-delta-read.err" || rc1=$?
+  if [[ $rc1 -ne 0 ]]; then
+    echo "    read-batch failed (oc-rsync reading upstream compressed delta batch, exit=$rc1)"
+    head -5 "${log}.compress-delta-read.err" 2>/dev/null | sed 's/^/    stderr: /'
+    return 1
+  fi
+
+  # Step 3: verify destination files match source byte-for-byte.
+  for f in large.dat repeated.txt; do
+    if ! cmp -s "${delta_src}/${f}" "${delta_read_dest}/${f}"; then
+      echo "    content mismatch for ${f} after compressed delta batch replay"
+      return 1
+    fi
+  done
+
+  return 0
+}
+
 # #3084: batch framing interop with multi-file varying-size transfers
 # Validates that the NDX-driven batch framing produces correct upstream-compatible
 # batch files when transferring many files with varying sizes. PR #3084 fixed the
@@ -6358,6 +6437,7 @@ run_standalone_interop_tests() {
     "write-batch-read-batch-compressed"
     "upstream-compressed-batch-oc-reads"
     "oc-compressed-batch-upstream-reads"
+    "compressed-batch-delta-interop"
     "batch-framing-multifile"
     "info-progress2"
     "large-file-2gb"
@@ -6409,6 +6489,7 @@ run_standalone_interop_tests() {
     "test_write_batch_read_batch_compressed"
     "test_upstream_compressed_batch_oc_reads"
     "test_oc_compressed_batch_upstream_reads"
+    "test_compressed_batch_delta_interop"
     "test_batch_framing_multifile"
     "test_info_progress2"
     "test_large_file_2gb"


### PR DESCRIPTION
## Summary

- **Protocol-aware compression decoder selection in batch replay**: The `create_compressed_decoder()` function now selects zstd for protocol >= 32 (when the `zstd` feature is enabled) and zlib/zlibx for protocol 31. Previously, all compressed batch files used zlib regardless of protocol version, which would fail for protocol 32 batch files containing zstd-compressed tokens.

- **Feature wiring for zstd in batch crate**: Added `zstd` feature to `crates/batch/Cargo.toml` forwarding to `protocol/zstd`, and wired it through `crates/engine/Cargo.toml` so the workspace `zstd` feature propagates correctly.

- **Compressed delta batch interop test**: New `test_compressed_batch_delta_interop` in `tools/ci/run_interop.sh` exercises compressed token decoding with actual copy+literal delta operations (not just whole-file literals). Uses `--no-whole-file` with pre-seeded basis files to ensure rsync produces block-match tokens.

- **Standalone compressed batch test**: Added `test_upstream_compressed_to_oc` to `tests/batch_interop_test.sh` for upstream-writes-compressed, oc-rsync-reads verification with delta transfers.

## Test plan

- [ ] CI fmt+clippy passes (no unused variable warnings from `#[cfg]` gating)
- [ ] CI nextest passes (unit tests for `create_compressed_decoder` at protocol 31 and 32)
- [ ] Interop `compressed-batch-delta-interop` test passes against upstream rsync 3.4.1
- [ ] Existing `upstream-compressed-batch-oc-reads` and `oc-compressed-batch-upstream-reads` continue passing