### PR TITLE
feat: wire RunAsService callback to daemon accept loop

### DIFF
--- a/crates/daemon/src/cli.rs
+++ b/crates/daemon/src/cli.rs
@@ -80,7 +80,7 @@ where
 
     // Handle Windows Service management actions before entering the daemon loop.
     if let Some(action) = parsed.service_action {
-        return execute_service_action(action, stdout, stderr);
+        return execute_service_action(action, &parsed, stdout, stderr);
     }
 
     let config = DaemonConfig::builder()
@@ -106,6 +106,7 @@ where
 /// they delegate to `platform::windows_service` for SCM integration.
 fn execute_service_action<Out, Err>(
     action: ServiceAction,
+    parsed: &ParsedArgs,
     stdout: &mut Out,
     stderr: &mut MessageSink<Err>,
 ) -> i32
@@ -129,7 +130,18 @@ where
             );
         }),
         ServiceAction::RunAsService => {
-            platform::windows_service::run_service_dispatcher(Box::new(|_flags| Ok(())))
+            let remainder = parsed.remainder.clone();
+            let brand = parsed.program_name.brand();
+            platform::windows_service::run_service_dispatcher(Box::new(move |flags| {
+                let config = DaemonConfig::builder()
+                    .brand(brand)
+                    .arguments(remainder)
+                    .signal_flags(flags)
+                    .build();
+                run_daemon(config).map_err(|error| {
+                    std::io::Error::new(std::io::ErrorKind::Other, error.message().to_string())
+                })
+            }))
         }
     };
 

--- a/crates/daemon/src/config.rs
+++ b/crates/daemon/src/config.rs
@@ -11,14 +11,31 @@
 use std::ffi::OsString;
 
 use core::branding::Brand;
+use platform::signal::SignalFlags;
 
 /// Configuration describing the requested daemon operation.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug)]
 pub struct DaemonConfig {
     brand: Brand,
     arguments: Vec<OsString>,
     load_default_paths: bool,
+    /// External signal flags injected by the Windows Service dispatcher.
+    ///
+    /// When running as a Windows service, the SCM control handler sets these
+    /// flags in response to stop/shutdown/paramchange events. When `None`,
+    /// the daemon registers its own platform signal handlers on startup.
+    signal_flags: Option<SignalFlags>,
 }
+
+impl PartialEq for DaemonConfig {
+    fn eq(&self, other: &Self) -> bool {
+        self.brand == other.brand
+            && self.arguments == other.arguments
+            && self.load_default_paths == other.load_default_paths
+    }
+}
+
+impl Eq for DaemonConfig {}
 
 impl DaemonConfig {
     /// Creates a new [`DaemonConfigBuilder`].
@@ -46,6 +63,16 @@ impl DaemonConfig {
         self.load_default_paths
     }
 
+    /// Returns externally injected signal flags, if present.
+    ///
+    /// When running as a Windows service, the SCM control handler writes to
+    /// these flags. The daemon accept loop uses them instead of registering
+    /// its own platform signal handlers.
+    #[must_use]
+    pub fn take_signal_flags(&mut self) -> Option<SignalFlags> {
+        self.signal_flags.take()
+    }
+
     /// Reports whether any daemon-specific arguments were provided.
     #[must_use]
     pub const fn has_runtime_request(&self) -> bool {
@@ -54,12 +81,23 @@ impl DaemonConfig {
 }
 
 /// Builder used to assemble a [`DaemonConfig`].
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug)]
 pub struct DaemonConfigBuilder {
     brand: Brand,
     arguments: Vec<OsString>,
     load_default_paths: bool,
+    signal_flags: Option<SignalFlags>,
 }
+
+impl PartialEq for DaemonConfigBuilder {
+    fn eq(&self, other: &Self) -> bool {
+        self.brand == other.brand
+            && self.arguments == other.arguments
+            && self.load_default_paths == other.load_default_paths
+    }
+}
+
+impl Eq for DaemonConfigBuilder {}
 
 impl Default for DaemonConfigBuilder {
     fn default() -> Self {
@@ -67,6 +105,7 @@ impl Default for DaemonConfigBuilder {
             brand: Brand::Oc,
             arguments: Vec::new(),
             load_default_paths: true,
+            signal_flags: None,
         }
     }
 }
@@ -97,6 +136,17 @@ impl DaemonConfigBuilder {
         self
     }
 
+    /// Injects external signal flags from the Windows Service dispatcher.
+    ///
+    /// When set, the daemon accept loop uses these flags instead of
+    /// registering its own platform signal handlers. The SCM control handler
+    /// writes to these flags in response to stop/shutdown/paramchange events.
+    #[must_use]
+    pub fn signal_flags(mut self, flags: SignalFlags) -> Self {
+        self.signal_flags = Some(flags);
+        self
+    }
+
     /// Finalises the builder and constructs the [`DaemonConfig`].
     #[must_use]
     pub fn build(self) -> DaemonConfig {
@@ -104,6 +154,7 @@ impl DaemonConfigBuilder {
             brand: self.brand,
             arguments: self.arguments,
             load_default_paths: self.load_default_paths,
+            signal_flags: self.signal_flags,
         }
     }
 }
@@ -185,6 +236,39 @@ mod tests {
             assert!(debug.contains("DaemonConfig"));
             assert!(debug.contains("brand"));
         }
+
+        #[test]
+        fn builder_default_has_no_signal_flags() {
+            let mut config = DaemonConfig::builder().build();
+            assert!(config.take_signal_flags().is_none());
+        }
+
+        #[test]
+        fn builder_with_signal_flags() {
+            let flags = SignalFlags::new();
+            let mut config = DaemonConfig::builder().signal_flags(flags).build();
+            let taken = config.take_signal_flags();
+            assert!(taken.is_some());
+        }
+
+        #[test]
+        fn take_signal_flags_returns_none_on_second_call() {
+            let flags = SignalFlags::new();
+            let mut config = DaemonConfig::builder().signal_flags(flags).build();
+            assert!(config.take_signal_flags().is_some());
+            assert!(config.take_signal_flags().is_none());
+        }
+
+        #[test]
+        fn signal_flags_share_atomics_with_original() {
+            use std::sync::atomic::Ordering;
+            let flags = SignalFlags::new();
+            let shutdown = flags.shutdown.clone();
+            let mut config = DaemonConfig::builder().signal_flags(flags).build();
+            let taken = config.take_signal_flags().unwrap();
+            shutdown.store(true, Ordering::Relaxed);
+            assert!(taken.shutdown.load(Ordering::Relaxed));
+        }
     }
 
     mod daemon_config_builder_tests {
@@ -230,6 +314,20 @@ mod tests {
 
             assert_eq!(config.arguments().len(), 1);
             assert_eq!(config.arguments()[0], "--once");
+        }
+
+        #[test]
+        fn signal_flags_chained_with_other_options() {
+            let flags = SignalFlags::new();
+            let mut config = DaemonConfig::builder()
+                .brand(Brand::Upstream)
+                .arguments(["--port", "8873"])
+                .signal_flags(flags)
+                .build();
+
+            assert_eq!(config.brand(), Brand::Upstream);
+            assert_eq!(config.arguments().len(), 2);
+            assert!(config.take_signal_flags().is_some());
         }
     }
 }

--- a/crates/daemon/src/daemon.rs
+++ b/crates/daemon/src/daemon.rs
@@ -168,13 +168,14 @@ include!("daemon/sections/group_expansion.rs");
 /// Returns a `DaemonError` if option parsing, config loading, or socket
 /// binding fails.
 #[cfg_attr(feature = "tracing", instrument(skip(config), name = "daemon_run"))]
-pub fn run_daemon(config: DaemonConfig) -> Result<(), DaemonError> {
+pub fn run_daemon(mut config: DaemonConfig) -> Result<(), DaemonError> {
+    let external_signal_flags = config.take_signal_flags();
     let options = RuntimeOptions::parse_with_brand(
         config.arguments(),
         config.brand(),
         config.load_default_paths(),
     )?;
-    serve_connections(options)
+    serve_connections(options, external_signal_flags)
 }
 
 include!("daemon/sections/cli_args.rs");

--- a/crates/daemon/src/daemon/sections/server_runtime/accept_loop.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/accept_loop.rs
@@ -8,20 +8,27 @@
 ///
 /// See `docs/DAEMON_PROCESS_MODEL.md` for details on the thread-vs-fork
 /// trade-offs.
-fn serve_connections(options: RuntimeOptions) -> Result<(), DaemonError> {
-    // Register signal handlers before entering the accept loop so SIGPIPE is
+fn serve_connections(
+    options: RuntimeOptions,
+    external_signal_flags: Option<platform::signal::SignalFlags>,
+) -> Result<(), DaemonError> {
+    // Use externally injected signal flags (from the Windows Service dispatcher)
+    // when available, otherwise register platform signal handlers so SIGPIPE is
     // ignored and SIGHUP/SIGTERM/SIGINT flags are captured from the start.
     // upstream: main.c SIGACT(SIGPIPE, SIG_IGN) and rsync_panic_handler setup.
-    let signal_flags = register_signal_handlers().map_err(|error| {
-        DaemonError::new(
-            FEATURE_UNAVAILABLE_EXIT_CODE,
-            rsync_error!(
+    let signal_flags = match external_signal_flags {
+        Some(flags) => SignalFlags::from(flags),
+        None => register_signal_handlers().map_err(|error| {
+            DaemonError::new(
                 FEATURE_UNAVAILABLE_EXIT_CODE,
-                format!("failed to register signal handlers: {error}")
+                rsync_error!(
+                    FEATURE_UNAVAILABLE_EXIT_CODE,
+                    format!("failed to register signal handlers: {error}")
+                )
+                .with_role(Role::Daemon),
             )
-            .with_role(Role::Daemon),
-        )
-    })?;
+        })?,
+    };
 
     let manifest = manifest();
     let version = manifest.rust_version();

--- a/crates/platform/src/signal.rs
+++ b/crates/platform/src/signal.rs
@@ -27,6 +27,7 @@ use std::sync::atomic::AtomicBool;
 ///
 /// upstream: main.c - signal handler setup for SIGPIPE, SIGHUP, SIGTERM,
 /// SIGUSR1, SIGUSR2.
+#[derive(Clone, Debug)]
 pub struct SignalFlags {
     /// Reload configuration (SIGHUP on Unix).
     pub reload_config: Arc<AtomicBool>,

--- a/crates/platform/src/signal.rs
+++ b/crates/platform/src/signal.rs
@@ -27,7 +27,7 @@ use std::sync::atomic::AtomicBool;
 ///
 /// upstream: main.c - signal handler setup for SIGPIPE, SIGHUP, SIGTERM,
 /// SIGUSR1, SIGUSR2.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct SignalFlags {
     /// Reload configuration (SIGHUP on Unix).
     pub reload_config: Arc<AtomicBool>,


### PR DESCRIPTION
## Summary

- Wire the `RunAsService` callback in `execute_service_action` to build a `DaemonConfig` and call `run_daemon`, replacing the previous no-op closure
- Thread `SignalFlags` from the Windows SCM control handler through `DaemonConfig` → `run_daemon` → `serve_connections` so the daemon accept loop honors stop/shutdown/paramchange events
- Add `Clone` and `Debug` derives to `platform::signal::SignalFlags` and manual `PartialEq`/`Eq` impls for `DaemonConfig` (since `AtomicBool` does not implement equality)

## Test plan

- [x] All 353 daemon crate tests pass locally
- [ ] CI passes on all platforms (fmt+clippy, nextest stable, Windows, macOS, Linux musl)
- [ ] Verify Windows service lifecycle: install → start → accept connections → SCM stop triggers graceful shutdown