### PR TITLE
refactor: derive Clone for SignalFlags and document OnceLock constraint

### DIFF
--- a/crates/platform/src/signal.rs
+++ b/crates/platform/src/signal.rs
@@ -89,6 +89,13 @@ pub fn register_signal_handlers() -> io::Result<SignalFlags> {
 /// Maps CTRL_C/CTRL_CLOSE to `shutdown` and CTRL_BREAK to `graceful_exit`.
 /// Broken pipes surface as I/O errors natively on Windows (no SIGPIPE).
 /// Config reload requires a named event (not yet implemented).
+///
+/// # One-shot constraint
+///
+/// Internally stores flag references in `OnceLock` statics so the
+/// `extern "system"` callback can reach them. This means the function
+/// can only succeed once per process - subsequent calls return
+/// `io::ErrorKind::Other` with "signal handlers already registered".
 #[cfg(windows)]
 #[allow(unsafe_code)]
 pub fn register_signal_handlers() -> io::Result<SignalFlags> {

--- a/crates/platform/src/windows_service.rs
+++ b/crates/platform/src/windows_service.rs
@@ -48,7 +48,6 @@ mod windows_impl {
     use std::ffi::OsString;
     use std::io;
     use std::os::windows::ffi::OsStrExt;
-    use std::sync::Arc;
     use std::sync::OnceLock;
     use std::sync::atomic::Ordering;
 
@@ -179,12 +178,7 @@ mod windows_impl {
 
         // Create signal flags and store them globally for the control handler.
         let flags = SignalFlags::new();
-        let _ = SERVICE_FLAGS.set(SignalFlags {
-            reload_config: Arc::clone(&flags.reload_config),
-            shutdown: Arc::clone(&flags.shutdown),
-            graceful_exit: Arc::clone(&flags.graceful_exit),
-            progress_dump: Arc::clone(&flags.progress_dump),
-        });
+        let _ = SERVICE_FLAGS.set(flags.clone());
 
         // Report SERVICE_START_PENDING.
         let _ = report_status_raw(status_handle, SERVICE_START_PENDING, 0, 3000);


### PR DESCRIPTION
## Summary
- Derive `Clone` on `SignalFlags` since all fields are `Arc<AtomicBool>` - eliminates manual field-by-field `Arc::clone` chains
- Replace 4-field manual clone in `windows_service.rs` with `.clone()`
- Document one-shot `OnceLock` constraint on Windows `register_signal_handlers`

## Test plan
- [ ] CI passes on all platforms (no behavior change)
- [ ] Existing signal handler tests still pass