### PR TITLE
fix: skip AES-GCM cipher injection on CPUs without hardware AES

### DIFF
--- a/crates/rsync_io/src/ssh/builder.rs
+++ b/crates/rsync_io/src/ssh/builder.rs
@@ -336,14 +336,16 @@ impl SshCommand {
 
     /// Determines whether AES-GCM cipher arguments should be injected.
     ///
-    /// Returns `true` only when `prefer_aes_gcm` is `Some(true)`, the program
-    /// looks like an SSH client, and no existing option already specifies `-c`.
+    /// Returns `true` only when `prefer_aes_gcm` is `Some(true)`, the CPU has
+    /// hardware AES acceleration, the program looks like an SSH client, and no
+    /// existing option already specifies `-c`.
     ///
-    /// Returns `false` when `prefer_aes_gcm` is `None` (default — no change),
-    /// `Some(false)` (explicitly disabled), when custom options contain `-c`,
-    /// or when the program is not `ssh`.
+    /// Returns `false` when `prefer_aes_gcm` is `None` (default - no change),
+    /// `Some(false)` (explicitly disabled), when the CPU lacks hardware AES,
+    /// when custom options contain `-c`, or when the program is not `ssh`.
     fn should_inject_aes_gcm_ciphers(&self) -> bool {
         matches!(self.prefer_aes_gcm, Some(true))
+            && has_hardware_aes()
             && self.is_ssh_program()
             && !self.options_contain_cipher_flag()
     }
@@ -383,6 +385,29 @@ impl SshCommand {
     pub(crate) fn command_parts_for_testing(&self) -> (OsString, Vec<OsString>) {
         self.command_parts()
     }
+}
+
+/// Returns `true` when the CPU has hardware AES acceleration.
+///
+/// Caches the result in a `OnceLock` to avoid repeated feature detection
+/// syscalls on platforms that probe `/proc/cpuinfo` or issue `mrs` instructions.
+/// Returns `false` on architectures where detection is unavailable.
+pub(super) fn has_hardware_aes() -> bool {
+    static HAS_AES: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *HAS_AES.get_or_init(|| {
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        {
+            std::arch::is_x86_feature_detected!("aes")
+        }
+        #[cfg(target_arch = "aarch64")]
+        {
+            std::arch::is_aarch64_feature_detected!("aes")
+        }
+        #[cfg(not(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64")))]
+        {
+            false
+        }
+    })
 }
 
 fn host_needs_ipv6_brackets(host: &OsStr) -> bool {

--- a/crates/rsync_io/src/ssh/tests.rs
+++ b/crates/rsync_io/src/ssh/tests.rs
@@ -474,14 +474,21 @@ fn drop_child_handle_kills_running_process() {
 
 #[test]
 fn forces_aes_gcm_ciphers_when_explicitly_enabled() {
+    use super::builder::has_hardware_aes;
+
     let mut command = SshCommand::new("example.com");
     command.set_prefer_aes_gcm(Some(true));
 
     let (_, args) = command.command_parts_for_testing();
     let rendered = args_to_strings(&args);
 
-    assert!(rendered.contains(&"-c".to_owned()));
-    assert!(rendered.contains(&"aes128-gcm@openssh.com,aes256-gcm@openssh.com".to_owned()));
+    if has_hardware_aes() {
+        assert!(rendered.contains(&"-c".to_owned()));
+        assert!(rendered.contains(&"aes128-gcm@openssh.com,aes256-gcm@openssh.com".to_owned()));
+    } else {
+        // Without hardware AES, cipher injection is skipped even when preferred.
+        assert!(!rendered.contains(&"-c".to_owned()));
+    }
 }
 
 #[test]
@@ -1213,5 +1220,35 @@ fn child_handle_wait_with_stderr_surfaces_error_after_split() {
     assert!(
         text.contains("Permission denied"),
         "stderr should contain the SSH error message, got: {text}"
+    );
+}
+
+#[test]
+fn has_hardware_aes_is_consistent() {
+    use super::builder::has_hardware_aes;
+
+    let first = has_hardware_aes();
+    let second = has_hardware_aes();
+    assert_eq!(first, second, "cached result must be stable across calls");
+}
+
+#[test]
+fn aes_gcm_injection_requires_hardware_aes() {
+    use super::builder::has_hardware_aes;
+
+    // When hardware AES is absent, cipher injection must be skipped even
+    // with `prefer_aes_gcm = Some(true)`. On CI hosts with hardware AES,
+    // this test verifies that injection proceeds as expected.
+    let mut command = SshCommand::new("example.com");
+    command.set_prefer_aes_gcm(Some(true));
+
+    let (_, args) = command.command_parts_for_testing();
+    let rendered = args_to_strings(&args);
+    let has_cipher_flag = rendered.contains(&"-c".to_owned());
+
+    assert_eq!(
+        has_cipher_flag,
+        has_hardware_aes(),
+        "cipher injection should match hardware AES availability"
     );
 }


### PR DESCRIPTION
## Summary

- Add `has_hardware_aes()` function with `OnceLock`-cached CPU feature detection for x86/x86_64 (AES-NI) and aarch64 (AES extensions), returning `false` on other architectures
- Gate `should_inject_aes_gcm_ciphers()` on hardware AES availability so that CPUs without AES acceleration (e.g. Raspberry Pi, older ARM boards) are not penalized by software AES-GCM which is slower than ChaCha20
- Update existing test to be hardware-aware and add two new tests: consistency check for the cached result and a test verifying cipher injection tracks hardware AES availability

## Test plan

- [x] `has_hardware_aes_is_consistent` - verifies cached result is stable across calls
- [x] `aes_gcm_injection_requires_hardware_aes` - verifies cipher injection matches hardware AES availability
- [x] `forces_aes_gcm_ciphers_when_explicitly_enabled` - updated to handle both hardware-present and hardware-absent cases
- [x] All existing AES-GCM tests continue to pass
- [ ] CI passes on all platforms (x86_64 Linux, macOS aarch64, Windows)