### PR TITLE
chore: consolidate KNOWN_FAILURES into single shared config

### DIFF
--- a/crates/daemon/src/cli.rs
+++ b/crates/daemon/src/cli.rs
@@ -138,9 +138,8 @@ where
                     .arguments(remainder)
                     .signal_flags(flags)
                     .build();
-                run_daemon(config).map_err(|error| {
-                    std::io::Error::new(std::io::ErrorKind::Other, error.message().to_string())
-                })
+                run_daemon(config)
+                    .map_err(|error| std::io::Error::other(error.message().to_string()))
             }))
         }
     };

--- a/tools/ci/check_known_failures.sh
+++ b/tools/ci/check_known_failures.sh
@@ -40,21 +40,10 @@ find_upstream_binary() {
 echo "Ensuring upstream rsync versions are available..."
 bash "$interop_script" build-only 2>/dev/null || true
 
-# Known failures - mirrors KNOWN_FAILURES from run_interop.sh
-# Format: direction:name|description|test_method
-# test_method: "daemon" for scenario-based, "standalone" for standalone tests
-ENTRIES=(
-  "oc:acls|ACLs push to upstream daemon|daemon"
-  "oc:xattrs|xattrs push to upstream daemon|daemon"
-  "up:protocol-31|protocol-31 pull from upstream 3.0.9|daemon"
-  "up:acls|ACLs pull from upstream daemon|daemon"
-  "up:xattrs|xattrs pull from upstream daemon|daemon"
-  "standalone:write-batch-read-batch|batch file roundtrip|standalone"
-  "standalone:info-progress2|progress2 output|standalone"
-  "standalone:large-file-2gb|large file transfer|standalone"
-  "standalone:file-vanished|vanished file handling|standalone"
-  "standalone:iconv|iconv charset conversion|standalone"
-)
+# Source shared known failure definitions.
+# shellcheck source=tools/ci/known_failures.conf
+source "$(dirname "${BASH_SOURCE[0]}")/known_failures.conf"
+ENTRIES=("${DASHBOARD_ENTRIES[@]}")
 
 workdir=$(mktemp -d)
 trap 'rm -rf "$workdir"' EXIT
@@ -352,7 +341,7 @@ output_markdown() {
   echo "**Summary:** ${fixed} fixed, ${failing} still failing, ${skipped} skipped out of ${total} tracked failures"
   echo ""
   if [[ $fixed -gt 0 ]]; then
-    echo "> **Action needed:** ${fixed} known failure(s) are now passing. Consider removing them from \`KNOWN_FAILURES\` in \`tools/ci/run_interop.sh\`."
+    echo "> **Action needed:** ${fixed} known failure(s) are now passing. Consider removing them from \`tools/ci/known_failures.conf\`."
   fi
 }
 

--- a/tools/ci/known_failures.conf
+++ b/tools/ci/known_failures.conf
@@ -1,0 +1,59 @@
+# known_failures.conf - Single source of truth for interop known failures.
+# Sourced by run_interop.sh and check_known_failures.sh.
+#
+# KNOWN_FAILURES: array of "direction:name" entries for unconditional failures.
+# is_known_failure_from_conf(): protocol-specific and conditional failure rules.
+# DASHBOARD_ENTRIES: array of "direction:name|description|test_method" for the
+#   tracking dashboard in check_known_failures.sh.
+
+# Unconditional known failures (direction:name).
+# Currently empty - all remaining failures are protocol-conditional.
+KNOWN_FAILURES=(
+  # (none outside protocol-specific handling below)
+)
+
+# Protocol-specific and conditional known failure rules.
+# Returns 0 if the given test is a known failure, 1 otherwise.
+# Arguments: direction name forced_proto
+is_known_failure_from_conf() {
+  local direction=$1 name=$2 forced_proto=$3
+  local key="${direction}:${name}"
+
+  # Check unconditional failures
+  for kf in "${KNOWN_FAILURES[@]}"; do
+    [[ "$kf" == "$key" ]] && return 0
+  done
+
+  # Protocol-specific known failures: features that upstream rsync itself
+  # rejects when forced to a lower protocol version.
+  if [[ -n "$forced_proto" && "$forced_proto" -le 29 ]]; then
+    # ACLs and xattrs require protocol >= 30 (upstream compat.c:655-668).
+    # compress-choice (zstd/lz4) requires negotiation which needs protocol >= 30.
+    case "$name" in
+      acls|xattrs|compress-zstd|compress-lz4) return 0 ;;
+    esac
+  fi
+
+  # All upstream-to-oc forced-protocol-28 tests fail with protocol
+  # incompatibility (code 2 at rsync.c:427). Pre-existing regression.
+  if [[ "$direction" == "up" && -n "$forced_proto" && "$forced_proto" -eq 28 ]]; then
+    return 0
+  fi
+
+  return 1
+}
+
+# Dashboard entries for check_known_failures.sh.
+# Format: direction:name|description|test_method
+# test_method: "daemon" for scenario-based, "standalone" for standalone tests.
+# Keep in sync with actual known failure rules above.
+DASHBOARD_ENTRIES=(
+  "oc:acls|ACLs push to upstream daemon (proto <= 29)|daemon"
+  "oc:xattrs|xattrs push to upstream daemon (proto <= 29)|daemon"
+  "oc:compress-zstd|zstd compression (proto <= 29)|daemon"
+  "oc:compress-lz4|lz4 compression (proto <= 29)|daemon"
+  "up:acls|ACLs pull from upstream daemon (proto <= 29)|daemon"
+  "up:xattrs|xattrs pull from upstream daemon (proto <= 29)|daemon"
+  "up:compress-zstd|zstd compression pull (proto <= 29)|daemon"
+  "up:compress-lz4|lz4 compression pull (proto <= 29)|daemon"
+)

--- a/tools/ci/run_interop.sh
+++ b/tools/ci/run_interop.sh
@@ -1673,35 +1673,12 @@ run_ssh_interop_test() {
   return 0
 }
 
-# Remaining known failures:
-# All up:* forced-protocol-28 tests fail with protocol incompatibility (code 2).
-# This is a pre-existing regression masked by master CI failing on a different
-# check (duplicate test function). Needs investigation in a separate PR.
-KNOWN_FAILURES=(
-  # (none outside protocol-specific handling below)
-)
+# Source shared known failure definitions.
+# shellcheck source=tools/ci/known_failures.conf
+source "$(dirname "${BASH_SOURCE[0]}")/known_failures.conf"
 
 is_known_failure() {
-  local direction=$1 name=$2 forced_proto=$3
-  local key="${direction}:${name}"
-  for kf in "${KNOWN_FAILURES[@]}"; do
-    [[ "$kf" == "$key" ]] && return 0
-  done
-  # Protocol-specific known failures: features that upstream rsync itself
-  # rejects when forced to a lower protocol version.
-  if [[ -n "$forced_proto" && "$forced_proto" -le 29 ]]; then
-    # ACLs and xattrs require protocol >= 30 (upstream compat.c:655-668).
-    # compress-choice (zstd/lz4) requires negotiation which needs protocol >= 30.
-    case "$name" in
-      acls|xattrs|compress-zstd|compress-lz4) return 0 ;;
-    esac
-  fi
-  # All upstream-to-oc forced-protocol-28 tests fail with protocol
-  # incompatibility (code 2 at rsync.c:427). Pre-existing regression.
-  if [[ "$direction" == "up" && -n "$forced_proto" && "$forced_proto" -eq 28 ]]; then
-    return 0
-  fi
-  return 1
+  is_known_failure_from_conf "$@"
 }
 
 # ============================================================================


### PR DESCRIPTION
## Summary

- Extract known failure definitions from `run_interop.sh` and `check_known_failures.sh` into a single shared file `tools/ci/known_failures.conf`
- Replace inline `KNOWN_FAILURES` array and `is_known_failure()` logic in `run_interop.sh` with sourced definitions from the conf file
- Replace stale hardcoded `ENTRIES` array in `check_known_failures.sh` (which contained 10 entries, many already fixed) with sourced `DASHBOARD_ENTRIES` from the conf file

## Test plan

- [ ] CI interop workflow passes - `is_known_failure()` behavior is identical (delegates to `is_known_failure_from_conf()` with same logic)
- [ ] `check_known_failures.sh` dashboard still runs and sources entries correctly
- [ ] Verify `bash -n tools/ci/known_failures.conf` passes syntax check