### PR TITLE
feat: add SSH connection establishment timeout with -o ConnectTimeout

### DIFF
--- a/crates/core/src/client/remote/remote_to_remote.rs
+++ b/crates/core/src/client/remote/remote_to_remote.rs
@@ -210,6 +210,12 @@ fn spawn_ssh_connection(
 
     ssh.set_prefer_aes_gcm(config.prefer_aes_gcm());
 
+    // Wire --contimeout to SSH's -o ConnectTimeout.
+    let connect_timeout = config
+        .connect_timeout()
+        .effective(std::time::Duration::from_secs(30));
+    ssh.set_connect_timeout(connect_timeout);
+
     ssh.set_remote_command(invocation_args);
 
     ssh.spawn().map_err(|e| {

--- a/crates/core/src/client/remote/ssh_transfer.rs
+++ b/crates/core/src/client/remote/ssh_transfer.rs
@@ -291,6 +291,12 @@ fn build_ssh_connection(
 
     ssh.set_prefer_aes_gcm(config.prefer_aes_gcm());
 
+    // Wire --contimeout to SSH's -o ConnectTimeout.
+    // upstream: options.c — contimeout is forwarded as ConnectTimeout when
+    // spawning the remote shell.
+    let connect_timeout = config.connect_timeout().effective(Duration::from_secs(30));
+    ssh.set_connect_timeout(connect_timeout);
+
     // Set the remote command (rsync --server ...)
     ssh.set_remote_command(invocation_args);
 

--- a/crates/rsync_io/src/ssh/builder.rs
+++ b/crates/rsync_io/src/ssh/builder.rs
@@ -2,6 +2,7 @@ use std::ffi::{OsStr, OsString};
 use std::io;
 use std::net::IpAddr;
 use std::process::{Command, Stdio};
+use std::time::Duration;
 
 use super::connection::SshConnection;
 use super::parse::{RemoteShellParseError, parse_remote_shell};
@@ -26,6 +27,14 @@ const DEFAULT_SERVER_ALIVE_INTERVAL: u32 = 20;
 /// many consecutive keepalive messages, SSH terminates the connection.
 const DEFAULT_SERVER_ALIVE_COUNT_MAX: u32 = 3;
 
+/// Default SSH connection establishment timeout in seconds.
+///
+/// When no explicit connect timeout is provided, SSH's TCP handshake is
+/// capped at this value. This prevents indefinite hangs when the remote
+/// host is unreachable or firewalled. Mirrors upstream rsync's default
+/// `--contimeout` behavior.
+const DEFAULT_CONNECT_TIMEOUT_SECS: u64 = 30;
+
 /// Builder used to configure and spawn an SSH subprocess.
 #[derive(Clone, Debug)]
 pub struct SshCommand {
@@ -37,6 +46,7 @@ pub struct SshCommand {
     bind_address: Option<IpAddr>,
     keepalive: bool,
     options: Vec<OsString>,
+    connect_timeout: Option<Duration>,
     remote_command: Vec<OsString>,
     envs: Vec<(OsString, OsString)>,
     target_override: Option<OsString>,
@@ -55,6 +65,7 @@ impl SshCommand {
             batch_mode: true,
             bind_address: None,
             keepalive: true,
+            connect_timeout: Some(Duration::from_secs(DEFAULT_CONNECT_TIMEOUT_SECS)),
             options: Vec::new(),
             remote_command: Vec::new(),
             envs: Vec::new(),
@@ -114,6 +125,23 @@ impl SshCommand {
     /// - Keepalive is explicitly disabled via `set_keepalive(false)`.
     pub const fn set_keepalive(&mut self, enabled: bool) -> &mut Self {
         self.keepalive = enabled;
+        self
+    }
+
+    /// Sets the SSH connection establishment timeout.
+    ///
+    /// When `Some(duration)`, `-o ConnectTimeout=N` is injected into the SSH
+    /// command line (where N is the duration in whole seconds, rounded up).
+    /// This prevents indefinite hangs when the remote host is unreachable or
+    /// firewalled. The option is only injected when the program is `ssh` and
+    /// the user has not already specified `ConnectTimeout` via `-o` options.
+    ///
+    /// When `None`, no connect timeout is injected and SSH uses its own
+    /// default (which typically falls through to the OS TCP timeout).
+    ///
+    /// The default is `Some(Duration::from_secs(30))`.
+    pub const fn set_connect_timeout(&mut self, timeout: Option<Duration>) -> &mut Self {
+        self.connect_timeout = timeout;
         self
     }
 
@@ -285,6 +313,15 @@ impl SshCommand {
             )));
         }
 
+        // Inject SSH connect timeout to prevent indefinite hangs when the
+        // remote host is unreachable. Skipped when the user already specifies
+        // ConnectTimeout or uses a non-SSH program.
+        if let Some(seconds) = self.connect_timeout_seconds() {
+            if self.should_inject_connect_timeout() {
+                args.push(OsString::from(format!("-oConnectTimeout={seconds}")));
+            }
+        }
+
         args.extend(self.options.iter().cloned());
 
         // Inject AES-GCM ciphers when requested and safe to do so.
@@ -379,6 +416,29 @@ impl SshCommand {
             let upper = s.to_ascii_uppercase();
             upper.contains("SERVERALIVEINTERVAL") || upper.contains("SERVERALIVECOUNTMAX")
         })
+    }
+
+    /// Determines whether the SSH connect timeout option should be injected.
+    ///
+    /// Returns `true` only when the program looks like an SSH client and no
+    /// existing option already specifies `ConnectTimeout`.
+    fn should_inject_connect_timeout(&self) -> bool {
+        self.is_ssh_program() && !self.options_contain_connect_timeout()
+    }
+
+    /// Checks whether any existing option already specifies `ConnectTimeout`.
+    fn options_contain_connect_timeout(&self) -> bool {
+        self.options.iter().any(|opt| {
+            let s = opt.to_string_lossy();
+            s.to_ascii_uppercase().contains("CONNECTTIMEOUT")
+        })
+    }
+
+    /// Returns the connect timeout as whole seconds (rounded up), or `None`
+    /// if no timeout is configured.
+    fn connect_timeout_seconds(&self) -> Option<u64> {
+        self.connect_timeout
+            .map(|d| d.as_secs() + if d.subsec_nanos() > 0 { 1 } else { 0 })
     }
 
     #[cfg(test)]

--- a/crates/rsync_io/src/ssh/tests.rs
+++ b/crates/rsync_io/src/ssh/tests.rs
@@ -24,6 +24,7 @@ fn assembles_minimal_command_with_batch_mode() {
             "-oBatchMode=yes".to_owned(),
             "-oServerAliveInterval=20".to_owned(),
             "-oServerAliveCountMax=3".to_owned(),
+            "-oConnectTimeout=30".to_owned(),
             "example.com".to_owned(),
         ]
     );
@@ -50,6 +51,7 @@ fn assembles_command_with_user_port_and_remote_args() {
             "2222".to_owned(),
             "-oServerAliveInterval=20".to_owned(),
             "-oServerAliveCountMax=3".to_owned(),
+            "-oConnectTimeout=30".to_owned(),
             "-vvv".to_owned(),
             "backup@rsync.example.com".to_owned(),
             "rsync".to_owned(),
@@ -70,6 +72,7 @@ fn disables_batch_mode_when_requested() {
         vec![
             "-oServerAliveInterval=20".to_owned(),
             "-oServerAliveCountMax=3".to_owned(),
+            "-oConnectTimeout=30".to_owned(),
             "example.com".to_owned(),
         ]
     );
@@ -86,6 +89,7 @@ fn wraps_ipv6_hosts_in_brackets() {
             "-oBatchMode=yes".to_owned(),
             "-oServerAliveInterval=20".to_owned(),
             "-oServerAliveCountMax=3".to_owned(),
+            "-oConnectTimeout=30".to_owned(),
             "[2001:db8::1]".to_owned(),
         ]
     );
@@ -104,6 +108,7 @@ fn wraps_ipv6_hosts_with_usernames() {
             "-oBatchMode=yes".to_owned(),
             "-oServerAliveInterval=20".to_owned(),
             "-oServerAliveCountMax=3".to_owned(),
+            "-oConnectTimeout=30".to_owned(),
             "backup@[2001:db8::1]".to_owned(),
         ]
     );
@@ -122,6 +127,7 @@ fn preserves_explicit_bracketed_ipv6_literals() {
             "-oBatchMode=yes".to_owned(),
             "-oServerAliveInterval=20".to_owned(),
             "-oServerAliveCountMax=3".to_owned(),
+            "-oConnectTimeout=30".to_owned(),
             "backup@[2001:db8::1]".to_owned(),
         ]
     );
@@ -140,6 +146,7 @@ fn command_parts_skip_target_when_host_and_user_missing() {
             "-oBatchMode=yes".to_owned(),
             "-oServerAliveInterval=20".to_owned(),
             "-oServerAliveCountMax=3".to_owned(),
+            "-oConnectTimeout=30".to_owned(),
             "rsync".to_owned(),
         ]
     );
@@ -159,6 +166,7 @@ fn target_override_supersedes_computed_target() {
             "-oBatchMode=yes".to_owned(),
             "-oServerAliveInterval=20".to_owned(),
             "-oServerAliveCountMax=3".to_owned(),
+            "-oConnectTimeout=30".to_owned(),
             "custom-target".to_owned(),
         ]
     );
@@ -178,6 +186,7 @@ fn empty_target_override_suppresses_target_argument() {
             "-oBatchMode=yes".to_owned(),
             "-oServerAliveInterval=20".to_owned(),
             "-oServerAliveCountMax=3".to_owned(),
+            "-oConnectTimeout=30".to_owned(),
             "rsync".to_owned(),
         ]
     );
@@ -1250,5 +1259,127 @@ fn aes_gcm_injection_requires_hardware_aes() {
         has_cipher_flag,
         has_hardware_aes(),
         "cipher injection should match hardware AES availability"
+    );
+}
+
+// --- ConnectTimeout injection tests ---
+
+#[test]
+fn connect_timeout_injected_by_default() {
+    let command = SshCommand::new("example.com");
+    let (_, args) = command.command_parts_for_testing();
+    let rendered = args_to_strings(&args);
+    assert!(
+        rendered.contains(&"-oConnectTimeout=30".to_owned()),
+        "default 30s connect timeout should be injected: {rendered:?}"
+    );
+}
+
+#[test]
+fn connect_timeout_custom_value() {
+    let mut command = SshCommand::new("example.com");
+    command.set_connect_timeout(Some(std::time::Duration::from_secs(60)));
+    let (_, args) = command.command_parts_for_testing();
+    let rendered = args_to_strings(&args);
+    assert!(
+        rendered.contains(&"-oConnectTimeout=60".to_owned()),
+        "custom 60s connect timeout should be injected: {rendered:?}"
+    );
+}
+
+#[test]
+fn connect_timeout_disabled_when_none() {
+    let mut command = SshCommand::new("example.com");
+    command.set_connect_timeout(None);
+    let (_, args) = command.command_parts_for_testing();
+    let rendered = args_to_strings(&args);
+    assert!(
+        !rendered.iter().any(|a| a.contains("ConnectTimeout")),
+        "no ConnectTimeout when disabled: {rendered:?}"
+    );
+}
+
+#[test]
+fn connect_timeout_not_injected_for_non_ssh_program() {
+    let mut command = SshCommand::new("example.com");
+    command.set_program("rsh");
+    let (_, args) = command.command_parts_for_testing();
+    let rendered = args_to_strings(&args);
+    assert!(
+        !rendered.iter().any(|a| a.contains("ConnectTimeout")),
+        "ConnectTimeout should not be injected for non-SSH program: {rendered:?}"
+    );
+}
+
+#[test]
+fn connect_timeout_not_injected_when_user_specified() {
+    let mut command = SshCommand::new("example.com");
+    command.push_option("-oConnectTimeout=10");
+    let (_, args) = command.command_parts_for_testing();
+    let rendered = args_to_strings(&args);
+    let count = rendered
+        .iter()
+        .filter(|a| a.contains("ConnectTimeout"))
+        .count();
+    assert_eq!(
+        count, 1,
+        "user-specified ConnectTimeout should not be duplicated: {rendered:?}"
+    );
+    assert!(
+        rendered.contains(&"-oConnectTimeout=10".to_owned()),
+        "user value should be preserved: {rendered:?}"
+    );
+}
+
+#[test]
+fn connect_timeout_not_injected_when_user_specified_case_insensitive() {
+    let mut command = SshCommand::new("example.com");
+    command.push_option("-o connecttimeout=15");
+    let (_, args) = command.command_parts_for_testing();
+    let rendered = args_to_strings(&args);
+    let count = rendered
+        .iter()
+        .filter(|a| a.to_ascii_lowercase().contains("connecttimeout"))
+        .count();
+    assert_eq!(
+        count, 1,
+        "case-insensitive match should prevent duplicate: {rendered:?}"
+    );
+}
+
+#[test]
+fn connect_timeout_rounds_up_subsecond_durations() {
+    let mut command = SshCommand::new("example.com");
+    // 10.1 seconds should round up to 11
+    command.set_connect_timeout(Some(std::time::Duration::from_millis(10_100)));
+    let (_, args) = command.command_parts_for_testing();
+    let rendered = args_to_strings(&args);
+    assert!(
+        rendered.contains(&"-oConnectTimeout=11".to_owned()),
+        "10.1s should round up to 11: {rendered:?}"
+    );
+}
+
+#[test]
+fn connect_timeout_exact_seconds_not_rounded() {
+    let mut command = SshCommand::new("example.com");
+    command.set_connect_timeout(Some(std::time::Duration::from_secs(45)));
+    let (_, args) = command.command_parts_for_testing();
+    let rendered = args_to_strings(&args);
+    assert!(
+        rendered.contains(&"-oConnectTimeout=45".to_owned()),
+        "exact 45s should not round up: {rendered:?}"
+    );
+}
+
+#[test]
+fn connect_timeout_zero_duration() {
+    let mut command = SshCommand::new("example.com");
+    command.set_connect_timeout(Some(std::time::Duration::from_secs(0)));
+    let (_, args) = command.command_parts_for_testing();
+    let rendered = args_to_strings(&args);
+    assert!(
+        rendered.contains(&"-oConnectTimeout=0".to_owned()),
+        "zero duration should produce ConnectTimeout=0: {rendered:?}"
     );
 }


### PR DESCRIPTION
## Summary
- Adds `connect_timeout` field to `SshCommand` with 30-second default
- Injects `-o ConnectTimeout=N` into SSH args when using SSH program
- Respects user-specified ConnectTimeout options (case-insensitive detection)
- Wired through from CoreConfig in both ssh_transfer and remote_to_remote paths

## Test plan
- [ ] 9 new unit tests covering default injection, custom value, disabled, non-SSH program, user override, case-insensitive, subsecond rounding, exact seconds, zero duration
- [ ] 9 existing tests updated to expect new ConnectTimeout arg
- [ ] CI: fmt+clippy, nextest, Windows, macOS, Linux musl