### PR TITLE
fix: reject --write-batch with compression at protocol 28-29

### DIFF
--- a/crates/core/src/client/run/batch.rs
+++ b/crates/core/src/client/run/batch.rs
@@ -17,6 +17,44 @@ use super::super::error::ClientError;
 use super::super::remote;
 use super::super::summary::ClientSummary;
 
+/// Validates that `--write-batch` with compression is not used at protocol <= 29.
+///
+/// Upstream rsync since protocol 30 stores batch tokens uncompressed in the
+/// batch file (it tees the uncompressed stream). For protocol 28-29, the batch
+/// file contains the raw compressed wire stream, and reading it back requires
+/// knowing the compression state - which can produce corrupt replays.
+///
+/// # Errors
+///
+/// Returns `Err(ClientError)` with exit code 1 (RERR_SYNTAX) if write-batch
+/// mode is active, compression is enabled, and the protocol version is <= 29.
+// upstream: options.c - batch + compress validation
+pub(crate) fn validate_batch_compress(
+    batch_cfg: &BatchConfig,
+    config: &ClientConfig,
+) -> Result<(), ClientError> {
+    if !batch_cfg.is_write_mode() {
+        return Ok(());
+    }
+    if !config.compress() {
+        return Ok(());
+    }
+    let proto = batch_cfg.protocol_version;
+    if proto < 30 {
+        return Err(ClientError::new(
+            super::super::FEATURE_UNAVAILABLE_EXIT_CODE,
+            rsync_error!(
+                super::super::FEATURE_UNAVAILABLE_EXIT_CODE,
+                "cannot combine --write-batch with compression at protocol {} \
+                 (requires protocol >= 30)",
+                proto
+            )
+            .with_role(Role::Client),
+        ));
+    }
+    Ok(())
+}
+
 /// Validates that `--read-batch` is not combined with remote destinations
 /// and dispatches to [`replay_batch`] when in read mode.
 ///
@@ -241,4 +279,82 @@ fn replay_batch(
 
     use engine::local_copy::LocalCopySummary;
     Ok(ClientSummary::from_summary(LocalCopySummary::default()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use engine::batch::BatchMode;
+
+    fn write_batch_config(proto: i32) -> BatchConfig {
+        BatchConfig::new(BatchMode::Write, "test_batch".to_owned(), proto)
+    }
+
+    fn read_batch_config(proto: i32) -> BatchConfig {
+        BatchConfig::new(BatchMode::Read, "test_batch".to_owned(), proto)
+    }
+
+    fn config_with_compress(compress: bool) -> ClientConfig {
+        ClientConfig::builder().compress(compress).build()
+    }
+
+    #[test]
+    fn batch_compress_rejected_at_protocol_28() {
+        let batch_cfg = write_batch_config(28);
+        let config = config_with_compress(true);
+        let err = validate_batch_compress(&batch_cfg, &config).unwrap_err();
+        assert_eq!(
+            err.exit_code(),
+            super::super::super::FEATURE_UNAVAILABLE_EXIT_CODE
+        );
+        assert!(
+            err.to_string()
+                .contains("cannot combine --write-batch with compression"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn batch_compress_rejected_at_protocol_29() {
+        let batch_cfg = write_batch_config(29);
+        let config = config_with_compress(true);
+        let err = validate_batch_compress(&batch_cfg, &config).unwrap_err();
+        assert_eq!(
+            err.exit_code(),
+            super::super::super::FEATURE_UNAVAILABLE_EXIT_CODE
+        );
+    }
+
+    #[test]
+    fn batch_compress_allowed_at_protocol_30() {
+        let batch_cfg = write_batch_config(30);
+        let config = config_with_compress(true);
+        assert!(validate_batch_compress(&batch_cfg, &config).is_ok());
+    }
+
+    #[test]
+    fn batch_compress_allowed_at_protocol_31() {
+        let batch_cfg = write_batch_config(31);
+        let config = config_with_compress(true);
+        assert!(validate_batch_compress(&batch_cfg, &config).is_ok());
+    }
+
+    #[test]
+    fn batch_no_compress_allowed_at_any_protocol() {
+        for proto in [28, 29, 30, 31, 32] {
+            let batch_cfg = write_batch_config(proto);
+            let config = config_with_compress(false);
+            assert!(
+                validate_batch_compress(&batch_cfg, &config).is_ok(),
+                "should allow write-batch without compress at protocol {proto}"
+            );
+        }
+    }
+
+    #[test]
+    fn read_batch_skips_validation() {
+        let batch_cfg = read_batch_config(28);
+        let config = config_with_compress(true);
+        assert!(validate_batch_compress(&batch_cfg, &config).is_ok());
+    }
 }

--- a/crates/core/src/client/run/mod.rs
+++ b/crates/core/src/client/run/mod.rs
@@ -187,6 +187,10 @@ fn run_client_internal(
         if let Some(result) = batch::handle_batch_read(batch_cfg, &config) {
             return result;
         }
+        // upstream: batch + compress is unreliable at protocol <= 29 because the
+        // batch file contains raw compressed wire tokens that cannot be replayed
+        // without matching compression state.
+        batch::validate_batch_compress(batch_cfg, &config)?;
         Some(batch::create_batch_writer(batch_cfg)?)
     } else {
         None


### PR DESCRIPTION
## Summary
- Adds `validate_batch_compress()` check before creating batch writer
- Returns RERR_SYNTAX error when --write-batch + compression at protocol <= 29
- Upstream rsync stores compressed wire stream verbatim in batch files at protocol 28-29, making replay unreliable with our uncompressed token capture

## Test plan
- [ ] 6 unit tests: protocol 28 rejected, 29 rejected, 30 allowed, 31 allowed, no-compress at any protocol, read-batch skips validation
- [ ] CI: fmt+clippy, nextest, Windows, macOS, Linux musl