### PR TITLE
fix: resolve ReorderBuffer deadlock when capacity < total items

### DIFF
--- a/crates/engine/src/concurrent_delta/consumer.rs
+++ b/crates/engine/src/concurrent_delta/consumer.rs
@@ -124,10 +124,21 @@ impl DeltaConsumer {
                     // Insert may fail if buffer is at capacity. Since we have all
                     // results collected, drain ready items first to free space.
                     while reorder.insert(result.sequence(), result.clone()).is_err() {
+                        let mut drained_any = false;
                         for ready in reorder.drain_ready() {
+                            drained_any = true;
                             if result_tx.send(ready).is_err() {
                                 return; // Receiver dropped - stop processing.
                             }
+                        }
+                        if !drained_any {
+                            // Buffer is full but next_expected is not buffered,
+                            // so drain_ready cannot free space. Force the insert
+                            // to break the deadlock. This temporarily exceeds
+                            // capacity, which is safe since drain_parallel already
+                            // collected all results in memory.
+                            reorder.force_insert(result.sequence(), result.clone());
+                            break;
                         }
                     }
 

--- a/crates/engine/src/concurrent_delta/reorder.rs
+++ b/crates/engine/src/concurrent_delta/reorder.rs
@@ -149,6 +149,17 @@ impl<T> ReorderBuffer<T> {
     pub const fn capacity(&self) -> usize {
         self.capacity
     }
+
+    /// Inserts an item regardless of the capacity bound.
+    ///
+    /// Used by the consumer loop to break deadlocks when the buffer is full
+    /// and [`drain_ready`](Self::drain_ready) cannot make progress because
+    /// `next_expected` is not yet buffered. Temporarily exceeding capacity is
+    /// safe when all items are already in memory (e.g., collected by
+    /// `drain_parallel`).
+    pub fn force_insert(&mut self, sequence: u64, item: T) {
+        self.pending.insert(sequence, item);
+    }
 }
 
 /// Iterator that drains contiguous in-order items from a [`ReorderBuffer`].
@@ -417,6 +428,21 @@ mod tests {
         }
         let drained: Vec<u64> = buf.drain_ready().collect();
         assert_eq!(drained, vec![0, 1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn force_insert_bypasses_capacity() {
+        let mut buf = ReorderBuffer::new(2);
+        buf.insert(1, "a").unwrap();
+        buf.insert(2, "b").unwrap();
+        // Normal insert fails at capacity.
+        assert_eq!(buf.insert(0, "c"), Err(CapacityExceeded));
+        // force_insert succeeds despite being over capacity.
+        buf.force_insert(0, "c");
+        assert_eq!(buf.buffered_count(), 3);
+        // drain_ready yields all three in order.
+        let drained: Vec<&str> = buf.drain_ready().collect();
+        assert_eq!(drained, vec!["c", "a", "b"]);
     }
 
     /// Validates `ReorderBuffer` with the actual `DeltaResult` type to ensure


### PR DESCRIPTION
## Summary

- Fix infinite loop in `DeltaConsumer::spawn()` when reorder buffer capacity is smaller than total items and `drain_parallel` returns results in an order where the buffer fills with out-of-order items before `next_expected` arrives
- Add `ReorderBuffer::force_insert()` to bypass capacity checks when `drain_ready()` cannot free space
- Add unit test for `force_insert` in reorder buffer

## Root Cause

The consumer loop called `drain_ready()` when `insert()` failed (buffer full), but `drain_ready()` only yields items starting from `next_expected`. If the buffer was full with items ahead of `next_expected`, the `while` loop spun forever.

Example: capacity=4, results arrive as `[4, 3, 2, 1, 0, ...]`. After inserting `{1,2,3,4}`, inserting `0` fails. `drain_ready()` yields nothing (sequence 0 not in buffer). Infinite loop.

## Test plan

- [x] `small_reorder_capacity_still_delivers_all` - previously hung for 1800+ seconds, now passes instantly
- [x] `force_insert_bypasses_capacity` - new unit test for the force_insert API
- [x] All 97 `concurrent_delta` tests pass