### PR TITLE
fix: revert batch+compress validation that contradicts upstream

### DIFF
--- a/crates/core/src/client/run/batch.rs
+++ b/crates/core/src/client/run/batch.rs
@@ -17,44 +17,6 @@ use super::super::error::ClientError;
 use super::super::remote;
 use super::super::summary::ClientSummary;
 
-/// Validates that `--write-batch` with compression is not used at protocol <= 29.
-///
-/// Upstream rsync since protocol 30 stores batch tokens uncompressed in the
-/// batch file (it tees the uncompressed stream). For protocol 28-29, the batch
-/// file contains the raw compressed wire stream, and reading it back requires
-/// knowing the compression state - which can produce corrupt replays.
-///
-/// # Errors
-///
-/// Returns `Err(ClientError)` with exit code 1 (RERR_SYNTAX) if write-batch
-/// mode is active, compression is enabled, and the protocol version is <= 29.
-// upstream: options.c - batch + compress validation
-pub(crate) fn validate_batch_compress(
-    batch_cfg: &BatchConfig,
-    config: &ClientConfig,
-) -> Result<(), ClientError> {
-    if !batch_cfg.is_write_mode() {
-        return Ok(());
-    }
-    if !config.compress() {
-        return Ok(());
-    }
-    let proto = batch_cfg.protocol_version;
-    if proto < 30 {
-        return Err(ClientError::new(
-            super::super::FEATURE_UNAVAILABLE_EXIT_CODE,
-            rsync_error!(
-                super::super::FEATURE_UNAVAILABLE_EXIT_CODE,
-                "cannot combine --write-batch with compression at protocol {} \
-                 (requires protocol >= 30)",
-                proto
-            )
-            .with_role(Role::Client),
-        ));
-    }
-    Ok(())
-}
-
 /// Validates that `--read-batch` is not combined with remote destinations
 /// and dispatches to [`replay_batch`] when in read mode.
 ///
@@ -132,11 +94,10 @@ pub(crate) fn write_batch_header(
         preserve_hard_links: config.preserve_hard_links(),
         always_checksum: config.checksum(),
         xfer_dirs: config.dirs(),
-        // upstream: batch token data is a verbatim tee of the compressed
-        // wire stream, so do_compression controls recv_token() dispatch
-        // during replay. Our batch delta buffer captures uncompressed
-        // tokens, so we must report false to avoid decompression mismatch.
-        do_compression: false,
+        // upstream: batch.c:68 - do_compression is bit 8 in stream flags.
+        // write_stream_flags() stores the compression state so that
+        // check_batch_flags() can restore it on replay.
+        do_compression: config.compress(),
         preserve_acls,
         preserve_xattrs,
         inplace: config.inplace(),
@@ -286,10 +247,6 @@ mod tests {
     use super::*;
     use engine::batch::BatchMode;
 
-    fn write_batch_config(proto: i32) -> BatchConfig {
-        BatchConfig::new(BatchMode::Write, "test_batch".to_owned(), proto)
-    }
-
     fn read_batch_config(proto: i32) -> BatchConfig {
         BatchConfig::new(BatchMode::Read, "test_batch".to_owned(), proto)
     }
@@ -299,62 +256,21 @@ mod tests {
     }
 
     #[test]
-    fn batch_compress_rejected_at_protocol_28() {
-        let batch_cfg = write_batch_config(28);
-        let config = config_with_compress(true);
-        let err = validate_batch_compress(&batch_cfg, &config).unwrap_err();
-        assert_eq!(
-            err.exit_code(),
-            super::super::super::FEATURE_UNAVAILABLE_EXIT_CODE
-        );
-        assert!(
-            err.to_string()
-                .contains("cannot combine --write-batch with compression"),
-            "unexpected error: {err}"
-        );
+    fn read_batch_rejects_remote_destination() {
+        let batch_cfg = read_batch_config(30);
+        let config = ClientConfig::builder()
+            .compress(false)
+            .transfer_args(["rsync://host/mod/dest"])
+            .build();
+        let result = handle_batch_read(&batch_cfg, &config);
+        assert!(result.is_some());
+        assert!(result.unwrap().is_err());
     }
 
     #[test]
-    fn batch_compress_rejected_at_protocol_29() {
-        let batch_cfg = write_batch_config(29);
-        let config = config_with_compress(true);
-        let err = validate_batch_compress(&batch_cfg, &config).unwrap_err();
-        assert_eq!(
-            err.exit_code(),
-            super::super::super::FEATURE_UNAVAILABLE_EXIT_CODE
-        );
-    }
-
-    #[test]
-    fn batch_compress_allowed_at_protocol_30() {
-        let batch_cfg = write_batch_config(30);
-        let config = config_with_compress(true);
-        assert!(validate_batch_compress(&batch_cfg, &config).is_ok());
-    }
-
-    #[test]
-    fn batch_compress_allowed_at_protocol_31() {
-        let batch_cfg = write_batch_config(31);
-        let config = config_with_compress(true);
-        assert!(validate_batch_compress(&batch_cfg, &config).is_ok());
-    }
-
-    #[test]
-    fn batch_no_compress_allowed_at_any_protocol() {
-        for proto in [28, 29, 30, 31, 32] {
-            let batch_cfg = write_batch_config(proto);
-            let config = config_with_compress(false);
-            assert!(
-                validate_batch_compress(&batch_cfg, &config).is_ok(),
-                "should allow write-batch without compress at protocol {proto}"
-            );
-        }
-    }
-
-    #[test]
-    fn read_batch_skips_validation() {
-        let batch_cfg = read_batch_config(28);
-        let config = config_with_compress(true);
-        assert!(validate_batch_compress(&batch_cfg, &config).is_ok());
+    fn write_batch_skips_read_handling() {
+        let batch_cfg = BatchConfig::new(BatchMode::Write, "test_batch".to_owned(), 30);
+        let config = config_with_compress(false);
+        assert!(handle_batch_read(&batch_cfg, &config).is_none());
     }
 }

--- a/crates/core/src/client/run/mod.rs
+++ b/crates/core/src/client/run/mod.rs
@@ -187,10 +187,6 @@ fn run_client_internal(
         if let Some(result) = batch::handle_batch_read(batch_cfg, &config) {
             return result;
         }
-        // upstream: batch + compress is unreliable at protocol <= 29 because the
-        // batch file contains raw compressed wire tokens that cannot be replayed
-        // without matching compression state.
-        batch::validate_batch_compress(batch_cfg, &config)?;
         Some(batch::create_batch_writer(batch_cfg)?)
     } else {
         None


### PR DESCRIPTION
## Summary

- Removes `validate_batch_compress()` from PR #3202 which incorrectly rejected `--write-batch` with `--compress` at protocol 28-29
- Fixes `do_compression` being hardcoded to `false` in the local batch header writer - now correctly passes `config.compress()` to match upstream behavior and the existing remote `batch_support.rs` code
- Replaces removed tests with tests for `handle_batch_read` validation

## Upstream evidence

Upstream rsync's `batch.c:59-76` defines `flag_ptr[]` with `do_compression` at index 8. `write_stream_flags()` stores the actual compression state as bit 8. `check_batch_flags()` restores it on replay - for protocol >= 29, the loop processes indices 0-8 (including compression). Upstream never rejects batch + compression at any protocol version.

Key upstream code (`batch.c:121-162`):
- `protocol_version < 29`: `flag_ptr[7] = NULL` (truncates before xfer_dirs/compression, so compression is not stored but also not rejected)
- `protocol_version >= 29 && < 30`: `flag_ptr[9] = NULL` (compression at index 8 IS included)
- `protocol_version >= 30`: all flags including compression

## Test plan

- [x] `cargo nextest run -p core --all-features -E 'test(batch)'` - 7 tests pass
- [x] `cargo clippy -p core --all-targets --all-features --no-deps -- -D warnings` - clean
- [x] `cargo fmt --all -- --check` - clean