### PR TITLE
docs: document --write-batch + --compress protocol 28 limitation

### DIFF
--- a/crates/cli/src/frontend/command_builder/sections/transfer_behavior_options.rs
+++ b/crates/cli/src/frontend/command_builder/sections/transfer_behavior_options.rs
@@ -37,7 +37,9 @@ pub(crate) fn add_transfer_behavior_options(command: ClapCommand) -> ClapCommand
                 Arg::new("write-batch")
                     .long("write-batch")
                     .value_name("PREFIX")
-                    .help("Store updated data in batch files named PREFIX for later replay.")
+                    .help("Store updated data in batch files named PREFIX for later replay. \
+                           Compression (--compress) is not supported with batch mode at protocol 28 \
+                           (rsync 2.x servers).")
                     .value_parser(OsStringValueParser::new())
                     .conflicts_with_all(["read-batch", "only-write-batch"]),
             )

--- a/docs/BATCH_MODE.md
+++ b/docs/BATCH_MODE.md
@@ -269,6 +269,7 @@ done
 2. **No compression of batch file**: The batch file itself is not compressed (matches upstream)
 3. **Protocol version must match**: Reading a batch requires the same protocol version it was written with
 4. **File list replay**: When reading a batch, the source directory is not accessed (file list comes from batch)
+5. **No compression at protocol 28**: `--compress` combined with `--write-batch` is not supported at protocol 28 (rsync 2.x servers) because the zlib streaming state cannot be serialized into the batch file. At protocol 30+, compression flags are stored in stream_flags and work correctly.
 
 ## Future Enhancements
 

--- a/docs/oc-rsync.1.md
+++ b/docs/oc-rsync.1.md
@@ -706,6 +706,9 @@ NEON) are used where available, with automatic scalar fallbacks.
 
 **--write-batch**=*PREFIX*
 :   Store updated data in batch files named *PREFIX* for later replay.
+    Compression (**--compress**) is not supported with batch mode at protocol 28
+    (rsync 2.x servers) because the zlib streaming state cannot be serialized
+    into the batch file at that protocol version.
 
 **--only-write-batch**=*PREFIX*
 :   Write batch files named *PREFIX* without applying the updates locally.


### PR DESCRIPTION
## Summary

- Add note to `--write-batch` CLI help text about compression being unsupported at protocol 28 (rsync 2.x servers)
- Add the same note to the man page (`docs/oc-rsync.1.md`)
- Add limitation entry to `docs/BATCH_MODE.md` explaining that zlib streaming state cannot be serialized into batch files at protocol 28, while protocol 30+ stores compression flags in stream_flags correctly

## Test plan

- [ ] CI passes (docs-only change, no code changes)
- [ ] Verify `--help` output shows the limitation note for `--write-batch`