### PR TITLE
fix: add pre-existing interop failures to known_failures.conf

### DIFF
--- a/tools/ci/known_failures.conf
+++ b/tools/ci/known_failures.conf
@@ -34,11 +34,24 @@ is_known_failure_from_conf() {
     esac
   fi
 
-  # All upstream-to-oc forced-protocol-28 tests fail with protocol
-  # incompatibility (code 2 at rsync.c:427). Pre-existing regression.
-  if [[ "$direction" == "up" && -n "$forced_proto" && "$forced_proto" -eq 28 ]]; then
+  # All upstream-to-oc forced-protocol-28/29 tests fail with protocol
+  # incompatibility (code 2 at rsync.c:427). Pre-existing regression -
+  # oc-rsync doesn't read the 4-byte io_error after flist for proto < 30.
+  if [[ "$direction" == "up" && -n "$forced_proto" && "$forced_proto" -le 29 ]]; then
     return 0
   fi
+
+  # Compressed batch replay: oc-rsync cannot read upstream-generated
+  # compressed batch files. Upstream writes zlib-compressed delta tokens
+  # that oc-rsync's batch replay doesn't decompress correctly.
+  # Error: "Unknown frame descriptor" in compressed delta token reader.
+  case "$key" in
+    standalone:upstream-compressed-batch-oc-reads|\
+    standalone:compressed-batch-delta-interop|\
+    standalone:write-batch-read-batch-compressed|\
+    standalone:oc-compressed-batch-upstream-reads)
+      return 0 ;;
+  esac
 
   return 1
 }
@@ -56,4 +69,9 @@ DASHBOARD_ENTRIES=(
   "up:xattrs|xattrs pull from upstream daemon (proto <= 29)|daemon"
   "up:compress-zstd|zstd compression pull (proto <= 29)|daemon"
   "up:compress-lz4|lz4 compression pull (proto <= 29)|daemon"
+  "up:*|All up direction forced-proto-28/29 (io_error after flist)|daemon"
+  "standalone:upstream-compressed-batch-oc-reads|Compressed batch read from upstream|standalone"
+  "standalone:compressed-batch-delta-interop|Compressed batch delta interop|standalone"
+  "standalone:write-batch-read-batch-compressed|Compressed batch roundtrip|standalone"
+  "standalone:oc-compressed-batch-upstream-reads|OC compressed batch read by upstream|standalone"
 )


### PR DESCRIPTION
## Summary

- Extended forced-protocol known failures from `fp=28` to `fp<=29` for `up` direction - same root cause (missing 4-byte io_error read after flist for proto < 30)
- Added 4 compressed batch standalone tests as known failures - oc-rsync cannot read upstream-generated compressed batch files ("Unknown frame descriptor" error in batch replay)
- Updated dashboard entries to track all known failures

These failures are pre-existing on master (48/50 standalone, all `up:*` fp=29 failing).

## Test plan
- [ ] CI interop job passes (all failures now tracked as known)
- [ ] No false positives - verify the 4 batch tests and fp=29 tests actually fail