### PR TITLE
fix: remove blanket proto <=29 known failure after io_error fix

### DIFF
--- a/tools/ci/known_failures.conf
+++ b/tools/ci/known_failures.conf
@@ -34,13 +34,6 @@ is_known_failure_from_conf() {
     esac
   fi
 
-  # All upstream-to-oc forced-protocol-28/29 tests fail with protocol
-  # incompatibility (code 2 at rsync.c:427). Pre-existing regression -
-  # oc-rsync doesn't read the 4-byte io_error after flist for proto < 30.
-  if [[ "$direction" == "up" && -n "$forced_proto" && "$forced_proto" -le 29 ]]; then
-    return 0
-  fi
-
   # Compressed batch replay: oc-rsync cannot read upstream-generated
   # compressed batch files. Upstream writes zlib-compressed delta tokens
   # that oc-rsync's batch replay doesn't decompress correctly.
@@ -69,7 +62,6 @@ DASHBOARD_ENTRIES=(
   "up:xattrs|xattrs pull from upstream daemon (proto <= 29)|daemon"
   "up:compress-zstd|zstd compression pull (proto <= 29)|daemon"
   "up:compress-lz4|lz4 compression pull (proto <= 29)|daemon"
-  "up:*|All up direction forced-proto-28/29 (io_error after flist)|daemon"
   "standalone:upstream-compressed-batch-oc-reads|Compressed batch read from upstream|standalone"
   "standalone:compressed-batch-delta-interop|Compressed batch delta interop|standalone"
   "standalone:write-batch-read-batch-compressed|Compressed batch roundtrip|standalone"


### PR DESCRIPTION
## Summary

- Remove the blanket known-failure rule that marked ALL `up` direction forced-protocol-28/29 interop tests as expected failures
- PR #3210 fixed the root cause: oc-rsync was not reading the 4-byte `io_error` value after the file list for protocol < 30
- Protocol-specific known failures for ACLs, xattrs, compress-zstd, and compress-lz4 at proto <=29 are retained (those features genuinely require proto >= 30)
- Compressed batch standalone test failures are also retained (separate issue)

## Test plan

- CI interop tests will run all `up` direction forced-protocol-28/29 scenarios without the blanket skip
- Verify that previously-blanket-skipped tests now pass (except ACLs/xattrs/compress which remain known failures)