### PR TITLE
fix: decompress upstream compressed batch tokens during replay

### DIFF
--- a/crates/batch/src/replay.rs
+++ b/crates/batch/src/replay.rs
@@ -844,34 +844,22 @@ fn default_xfer_sum_len(protocol_version: i32) -> usize {
     16
 }
 
-/// Creates the appropriate `CompressedTokenDecoder` for the batch protocol version.
+/// Creates a `CompressedTokenDecoder` for batch replay.
 ///
-/// Protocol 31 always uses zlib in CPRES_ZLIBX mode (upstream rsync 3.4.1 default).
-/// Protocol >= 32 defaults to zstd when the feature is compiled in, since oc-rsync
-/// (and future upstream versions) negotiate zstd as the preferred algorithm. The
-/// batch header does not record the negotiated compression algorithm, so the
-/// protocol version is the only disambiguation signal.
+/// Batch files do not record which compression algorithm was negotiated
+/// during the original transfer. When upstream's `check_batch_flags()`
+/// restores `do_compression` from the stream flags bitmap, the value is
+/// just 1 (truthy). `parse_compress_choice()` then maps that to
+/// `CPRES_ZLIB` (upstream compat.c:194-195), regardless of protocol
+/// version. So upstream batch files **always** contain CPRES_ZLIB
+/// compressed tokens, even at protocol 32+.
 ///
-/// upstream: compat.c - protocol 31 hardcodes CPRES_ZLIBX; protocol 32+ uses
-/// vstring negotiation where zstd wins if both sides support it.
-fn create_compressed_decoder(proto: i32) -> BatchResult<CompressedTokenDecoder> {
-    // Protocol 32+ defaults to zstd when the feature is compiled in.
-    if proto >= 32 {
-        #[cfg(feature = "zstd")]
-        {
-            return CompressedTokenDecoder::new_zstd().map_err(|e| {
-                BatchError::Io(std::io::Error::new(
-                    e.kind(),
-                    format!("failed to create zstd decoder for batch replay: {e}"),
-                ))
-            });
-        }
-    }
-
-    // Suppress unused variable warning when zstd feature is disabled.
-    let _ = proto;
-
-    // Protocol 31 or zstd not available: use zlib in CPRES_ZLIBX mode.
+/// We mirror that behavior: always create a zlib decoder in CPRES_ZLIBX
+/// mode (ZLIBX is the no-dictionary variant used for protocol >= 31).
+///
+/// upstream: compat.c:194 - `else if (do_compression) do_compression = CPRES_ZLIB;`
+/// upstream: token.c:recv_deflated_token() - decodes CPRES_ZLIB/CPRES_ZLIBX
+fn create_compressed_decoder(_proto: i32) -> BatchResult<CompressedTokenDecoder> {
     let mut decoder = CompressedTokenDecoder::new();
     decoder.set_zlibx(true);
     Ok(decoder)
@@ -1035,7 +1023,9 @@ mod tests {
 
     #[test]
     fn compressed_decoder_created_for_proto_32() {
-        // Protocol 32 creates a zstd decoder (when feature enabled) or zlib fallback.
+        // Protocol 32 also uses zlib for batch replay - batch files don't
+        // record the negotiated algorithm, and upstream always falls back
+        // to CPRES_ZLIB via parse_compress_choice().
         let decoder = create_compressed_decoder(32).unwrap();
         assert!(
             !decoder.initialized(),

--- a/crates/core/src/client/remote/batch_support.rs
+++ b/crates/core/src/client/remote/batch_support.rs
@@ -44,7 +44,10 @@ pub(crate) fn build_batch_context(
         preserve_hard_links: config.preserve_hard_links(),
         always_checksum: config.checksum(),
         xfer_dirs: config.dirs(),
-        do_compression: config.compress(),
+        // upstream tees raw (compressed) wire bytes to the batch file,
+        // but oc-rsync captures post-decompression data. Always false
+        // so replay reads uncompressed tokens correctly.
+        do_compression: false,
         preserve_acls,
         preserve_xattrs,
         inplace: config.inplace(),
@@ -123,5 +126,32 @@ impl std::io::Write for BatchWriteAdapter {
             .map_err(|_| std::io::Error::other("batch writer lock poisoned"))?;
         bw.flush()
             .map_err(|e| std::io::Error::other(format!("batch flush failed: {e}")))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Verifies that `build_batch_context` always sets `do_compression=false`,
+    /// even when the client configuration has compression enabled. oc-rsync
+    /// captures post-decompression data, so the batch file body is always
+    /// uncompressed.
+    #[test]
+    fn batch_context_never_sets_do_compression() {
+        let config = ClientConfig::builder().compress(true).build();
+        let temp = tempfile::TempDir::new().unwrap();
+        let path = temp.path().join("test.batch");
+        let batch_cfg = engine::batch::BatchConfig::new(
+            engine::batch::BatchMode::Write,
+            path.to_string_lossy().to_string(),
+            31,
+        );
+        let writer = Arc::new(Mutex::new(BatchWriter::new(batch_cfg).unwrap()));
+        let ctx = build_batch_context(&config, writer);
+        assert!(
+            !ctx.flags.do_compression,
+            "do_compression must be false - oc-rsync captures uncompressed data"
+        );
     }
 }

--- a/crates/core/src/client/run/batch.rs
+++ b/crates/core/src/client/run/batch.rs
@@ -95,9 +95,16 @@ pub(crate) fn write_batch_header(
         always_checksum: config.checksum(),
         xfer_dirs: config.dirs(),
         // upstream: batch.c:68 - do_compression is bit 8 in stream flags.
-        // write_stream_flags() stores the compression state so that
-        // check_batch_flags() can restore it on replay.
-        do_compression: config.compress(),
+        // Upstream tees the raw (pre-decompression) wire bytes to
+        // batch_fd via write_batch_monitor_in in io.c:read_buf(),
+        // so its batch files contain compressed tokens and the header
+        // says do_compression=true.
+        // oc-rsync captures post-decompression (uncompressed) data at
+        // the CompressedReader layer, so the batch body is always
+        // uncompressed. Setting do_compression=false ensures that both
+        // oc-rsync and upstream rsync replay the file without trying to
+        // decompress already-uncompressed tokens.
+        do_compression: false,
         preserve_acls,
         preserve_xattrs,
         inplace: config.inplace(),
@@ -272,5 +279,40 @@ mod tests {
         let batch_cfg = BatchConfig::new(BatchMode::Write, "test_batch".to_owned(), 30);
         let config = config_with_compress(false);
         assert!(handle_batch_read(&batch_cfg, &config).is_none());
+    }
+
+    /// Batch header must always have do_compression=false because oc-rsync
+    /// captures post-decompression (uncompressed) data in the batch file.
+    /// upstream tees pre-decompression data and sets do_compression=true,
+    /// but our approach avoids that complexity.
+    #[test]
+    fn write_batch_header_never_sets_do_compression() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let path = temp.path().join("test.batch");
+        let batch_cfg = BatchConfig::new(
+            BatchMode::Write,
+            path.to_string_lossy().to_string(),
+            31,
+        )
+        .with_checksum_seed(1);
+
+        let writer_arc = create_batch_writer(&batch_cfg).unwrap();
+
+        // Even when compress=true, the header must say do_compression=false
+        let config = config_with_compress(true);
+        write_batch_header(&writer_arc, &config).unwrap();
+
+        // Read back and verify
+        let read_cfg = BatchConfig::new(
+            BatchMode::Read,
+            path.to_string_lossy().to_string(),
+            31,
+        );
+        let mut reader = engine::batch::BatchReader::new(read_cfg).unwrap();
+        let flags = reader.read_header().unwrap();
+        assert!(
+            !flags.do_compression,
+            "do_compression must be false - oc-rsync captures uncompressed data"
+        );
     }
 }

--- a/crates/core/src/client/run/batch.rs
+++ b/crates/core/src/client/run/batch.rs
@@ -297,6 +297,7 @@ mod tests {
         // Even when compress=true, the header must say do_compression=false
         let config = config_with_compress(true);
         write_batch_header(&writer_arc, &config).unwrap();
+        drop(writer_arc);
 
         // Read back and verify
         let read_cfg = BatchConfig::new(BatchMode::Read, path.to_string_lossy().to_string(), 31);

--- a/crates/core/src/client/run/batch.rs
+++ b/crates/core/src/client/run/batch.rs
@@ -289,12 +289,8 @@ mod tests {
     fn write_batch_header_never_sets_do_compression() {
         let temp = tempfile::TempDir::new().unwrap();
         let path = temp.path().join("test.batch");
-        let batch_cfg = BatchConfig::new(
-            BatchMode::Write,
-            path.to_string_lossy().to_string(),
-            31,
-        )
-        .with_checksum_seed(1);
+        let batch_cfg = BatchConfig::new(BatchMode::Write, path.to_string_lossy().to_string(), 31)
+            .with_checksum_seed(1);
 
         let writer_arc = create_batch_writer(&batch_cfg).unwrap();
 
@@ -303,11 +299,7 @@ mod tests {
         write_batch_header(&writer_arc, &config).unwrap();
 
         // Read back and verify
-        let read_cfg = BatchConfig::new(
-            BatchMode::Read,
-            path.to_string_lossy().to_string(),
-            31,
-        );
+        let read_cfg = BatchConfig::new(BatchMode::Read, path.to_string_lossy().to_string(), 31);
         let mut reader = engine::batch::BatchReader::new(read_cfg).unwrap();
         let flags = reader.read_header().unwrap();
         assert!(


### PR DESCRIPTION
## Summary

- **Write side**: Always set `do_compression=false` in batch header because oc-rsync captures post-decompression (uncompressed) data at the `CompressedReader` layer, unlike upstream which tees raw compressed wire bytes via `write_batch_monitor_in` in `io.c:read_buf()`. This ensures both oc-rsync and upstream can replay the batch without trying to decompress already-uncompressed tokens.
- **Read side**: Always use zlib decoder for compressed batch replay. Batch files don't record which compression algorithm was negotiated - upstream's `parse_compress_choice()` maps the `do_compression` flag to `CPRES_ZLIB` regardless of protocol version (compat.c:194). The previous code incorrectly selected zstd for protocol >= 32, causing "Unknown frame descriptor" errors.
- Removes 4 tests from `known_failures.conf` that are now expected to pass.

## Test plan

- [ ] CI: `write-batch-read-batch-compressed` interop test passes (oc-rsync writes compressed batch, oc-rsync reads)
- [ ] CI: `upstream-compressed-batch-oc-reads` interop test passes (upstream writes compressed batch, oc-rsync reads)
- [ ] CI: `oc-compressed-batch-upstream-reads` interop test passes (oc-rsync writes batch with -z, upstream reads)
- [ ] CI: `compressed-batch-delta-interop` interop test passes (upstream writes compressed delta batch, oc-rsync reads)
- [ ] New unit tests: `write_batch_header_never_sets_do_compression`, `batch_context_never_sets_do_compression`
- [ ] Existing test `test_replay_with_compression_flag` still passes (compressed token decode path)