### PR TITLE
perf: add streaming drain_parallel_into for pipeline overlap

### DIFF
--- a/crates/engine/src/concurrent_delta/consumer.rs
+++ b/crates/engine/src/concurrent_delta/consumer.rs
@@ -11,22 +11,31 @@
 //! ```text
 //! WorkQueueReceiver
 //!     |
-//!     v  drain_parallel(dispatch)
+//!     v  drain_parallel_into(dispatch, stream_tx)
 //! rayon workers (parallel)
 //!     |
-//!     v  DeltaResult (arbitrary order)
-//! ReorderBuffer
+//!     v  SyncSender<DeltaResult> (streaming, bounded)
+//! delta-reorder thread
 //!     |
-//!     v  crossbeam channel (in sequence order)
+//!     v  ReorderBuffer (incremental insert + drain)
+//!     |
+//!     v  mpsc channel (in sequence order)
 //! DeltaConsumer::iter()
 //!     |
 //!     v  consumer (receiver pipeline)
 //! ```
 //!
-//! The consumer thread collects all results from `drain_parallel`, inserts
-//! them into the reorder buffer, and forwards the contiguous in-order run
-//! through a crossbeam channel. The main thread reads from this channel
-//! via the [`DeltaConsumerIter`] iterator.
+//! Two background threads provide pipeline overlap:
+//! - **delta-drain**: Runs `drain_parallel_into` inside `rayon::scope`,
+//!   streaming each completed result through a bounded channel.
+//! - **delta-reorder**: Receives streamed results incrementally, inserts
+//!   them into the reorder buffer, and forwards contiguous in-order runs
+//!   to the output channel.
+//!
+//! This architecture allows delta computation and disk writes to overlap -
+//! the reorder thread processes results while workers continue computing
+//! deltas for remaining files. The bounded stream channel provides
+//! backpressure when the reorder thread falls behind.
 //!
 //! # Upstream Reference
 //!
@@ -93,13 +102,21 @@ pub struct DeltaConsumer {
 }
 
 impl DeltaConsumer {
-    /// Spawns a background thread that drains the work queue in parallel
-    /// and delivers results in sequence order.
+    /// Spawns background threads that drain the work queue in parallel
+    /// and deliver results in sequence order with pipeline overlap.
     ///
-    /// The background thread uses [`WorkQueueReceiver::drain_parallel`] to
-    /// process all work items via the rayon thread pool, then inserts each
-    /// result into a [`ReorderBuffer`] and forwards the contiguous in-order
-    /// run through an internal channel.
+    /// Two threads are spawned:
+    /// - **delta-drain**: Runs [`WorkQueueReceiver::drain_parallel_into`] to
+    ///   process work items via the rayon thread pool, streaming each result
+    ///   through an internal channel as soon as its worker completes.
+    /// - **delta-reorder**: Receives streamed results, inserts them into a
+    ///   [`ReorderBuffer`], and forwards the contiguous in-order run to the
+    ///   consumer's output channel.
+    ///
+    /// This architecture enables pipeline overlap: delta computation continues
+    /// while previously completed results are reordered and written to disk.
+    /// The bounded stream channel provides backpressure - if reordering falls
+    /// behind, delta workers block rather than accumulating unbounded results.
     ///
     /// `reorder_capacity` sets the maximum number of out-of-order results
     /// the reorder buffer will hold. A good default is the total number of
@@ -112,37 +129,45 @@ impl DeltaConsumer {
     pub fn spawn(rx: WorkQueueReceiver, reorder_capacity: usize) -> Self {
         let (result_tx, result_rx) = mpsc::channel();
 
-        let handle = thread::Builder::new()
-            .name("delta-consumer".to_string())
-            .spawn(move || {
-                // Drain the work queue in parallel via rayon, collecting all results.
-                let results = rx.drain_parallel(|work| strategy::dispatch(&work));
+        // Bounded channel between drain and reorder threads. Capacity matches
+        // reorder buffer so workers can stay ahead without unbounded buffering.
+        let stream_capacity = reorder_capacity.max(rayon::current_num_threads() * 2);
+        let (stream_tx, stream_rx) = mpsc::sync_channel::<DeltaResult>(stream_capacity);
 
-                // Feed results into the reorder buffer and forward in sequence order.
+        // Thread 1: runs rayon::scope, streaming results as workers complete.
+        let drain_handle = thread::Builder::new()
+            .name("delta-drain".to_string())
+            .spawn(move || {
+                rx.drain_parallel_into(|work| strategy::dispatch(&work), stream_tx);
+            })
+            .expect("failed to spawn delta-drain thread");
+
+        // Thread 2: receives streamed results, reorders, forwards in sequence order.
+        let handle = thread::Builder::new()
+            .name("delta-reorder".to_string())
+            .spawn(move || {
                 let mut reorder = ReorderBuffer::new(reorder_capacity);
-                for result in results {
-                    // Insert may fail if buffer is at capacity. Since we have all
-                    // results collected, drain ready items first to free space.
+
+                for result in stream_rx {
+                    // Insert may fail if buffer is at capacity. Drain ready
+                    // items first to free space before retrying.
                     while reorder.insert(result.sequence(), result.clone()).is_err() {
                         let mut drained_any = false;
                         for ready in reorder.drain_ready() {
                             drained_any = true;
                             if result_tx.send(ready).is_err() {
-                                return; // Receiver dropped - stop processing.
+                                return;
                             }
                         }
                         if !drained_any {
-                            // Buffer is full but next_expected is not buffered,
-                            // so drain_ready cannot free space. Force the insert
-                            // to break the deadlock. This temporarily exceeds
-                            // capacity, which is safe since drain_parallel already
-                            // collected all results in memory.
+                            // Buffer full but next_expected is not buffered.
+                            // Force insert to break the deadlock.
                             reorder.force_insert(result.sequence(), result.clone());
                             break;
                         }
                     }
 
-                    // After each insert, forward any newly available contiguous run.
+                    // Forward any newly available contiguous run.
                     for ready in reorder.drain_ready() {
                         if result_tx.send(ready).is_err() {
                             return;
@@ -150,14 +175,17 @@ impl DeltaConsumer {
                     }
                 }
 
-                // Drain any remaining items (handles the tail of the sequence).
+                // Drain remaining items after the stream closes.
                 for ready in reorder.drain_ready() {
                     if result_tx.send(ready).is_err() {
                         return;
                     }
                 }
+
+                // Wait for drain thread to finish (propagates panics).
+                let _ = drain_handle.join();
             })
-            .expect("failed to spawn delta-consumer thread");
+            .expect("failed to spawn delta-reorder thread");
 
         Self {
             result_rx,

--- a/crates/engine/src/concurrent_delta/work_queue.rs
+++ b/crates/engine/src/concurrent_delta/work_queue.rs
@@ -27,6 +27,20 @@
 //!                                                   consumer (in-order)
 //! ```
 //!
+//! For streaming pipelines, [`drain_parallel_into`] sends results through a
+//! channel as workers complete, enabling incremental consumption without
+//! waiting for all items to finish:
+//!
+//! ```text
+//! Generator ─► WorkQueue ─► drain_parallel_into(f, tx) ─► SyncSender<R>
+//!                              rayon::scope                    |
+//!                              work-stealing                   v
+//!                                                     ReorderBuffer (live)
+//!                                                             |
+//!                                                             v
+//!                                                   consumer (incremental)
+//! ```
+//!
 //! # Usage
 //!
 //! ```rust,no_run
@@ -120,11 +134,13 @@ impl WorkQueueReceiver {
     /// timing). Use [`ReorderBuffer`] on the returned `Vec` if sequential
     /// ordering is required.
     ///
-    /// Internally, each rayon worker thread accumulates results in its own
-    /// thread-local `Vec`, indexed by [`rayon::current_thread_index`]. This
-    /// eliminates the lock contention that a single shared `Mutex<Vec<R>>`
-    /// would cause at scale (10K+ items). After all tasks complete, the
-    /// per-thread buffers are flattened into a single `Vec`.
+    /// Internally, results are sharded across `N` mutex-guarded `Vec`s (one per
+    /// rayon thread). Each worker indexes its shard via [`rayon::current_thread_index`],
+    /// distributing contention across shards instead of concentrating it in a
+    /// single `Mutex<Vec<R>>`. Threads outside the rayon pool fall back to a
+    /// thread-ID hash to avoid the degenerate case of all mapping to shard 0.
+    /// After all tasks complete, the per-shard buffers are flattened into a
+    /// single `Vec`.
     ///
     /// This method consumes the receiver. It returns once the sender is dropped
     /// and all queued items have been processed.
@@ -154,8 +170,8 @@ impl WorkQueueReceiver {
         F: Fn(DeltaWork) -> R + Send + Sync,
         R: Send,
     {
-        let num_threads = rayon::current_num_threads();
-        let shards: Vec<std::sync::Mutex<Vec<R>>> = (0..num_threads)
+        let num_shards = rayon::current_num_threads();
+        let shards: Vec<std::sync::Mutex<Vec<R>>> = (0..num_shards)
             .map(|_| std::sync::Mutex::new(Vec::new()))
             .collect();
 
@@ -165,8 +181,15 @@ impl WorkQueueReceiver {
                 let shards = &shards;
                 s.spawn(move |_| {
                     let result = f(work);
-                    let idx = rayon::current_thread_index().unwrap_or(0);
-                    shards[idx % shards.len()].lock().unwrap().push(result);
+                    let idx = rayon::current_thread_index().unwrap_or_else(|| {
+                        // Outside rayon pool: hash thread ID to distribute
+                        // across shards instead of collapsing to shard 0.
+                        let id = std::thread::current().id();
+                        let mut hasher = std::hash::DefaultHasher::new();
+                        std::hash::Hash::hash(&id, &mut hasher);
+                        std::hash::Hasher::finish(&hasher) as usize
+                    });
+                    shards[idx % num_shards].lock().unwrap().push(result);
                 });
             }
         });
@@ -175,6 +198,72 @@ impl WorkQueueReceiver {
             .into_iter()
             .flat_map(|shard| shard.into_inner().unwrap())
             .collect()
+    }
+
+    /// Streams results through a channel as workers complete, enabling
+    /// incremental consumption without waiting for all items to finish.
+    ///
+    /// Unlike [`drain_parallel`](Self::drain_parallel) which collects all
+    /// results into a `Vec`, this method sends each result through `tx` as
+    /// soon as its worker finishes. This enables pipeline overlap - the
+    /// consumer can process results (e.g., reorder and write to disk) while
+    /// delta computation continues for remaining items.
+    ///
+    /// The `SyncSender` provides backpressure: if the consumer falls behind,
+    /// workers block on `tx.send()` rather than accumulating unbounded results
+    /// in memory.
+    ///
+    /// This method blocks until the sender is dropped and all queued items
+    /// have been processed. The `tx` channel is dropped when this method
+    /// returns, signaling completion to the receiver.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// use engine::concurrent_delta::work_queue;
+    /// use engine::concurrent_delta::DeltaWork;
+    /// use std::path::PathBuf;
+    /// use std::sync::mpsc;
+    ///
+    /// let (work_tx, work_rx) = work_queue::bounded();
+    /// let (result_tx, result_rx) = mpsc::sync_channel(16);
+    ///
+    /// // Producer thread
+    /// std::thread::spawn(move || {
+    ///     for i in 0..100 {
+    ///         work_tx.send(DeltaWork::whole_file(i, PathBuf::from("/dst"), 64)).unwrap();
+    ///     }
+    /// });
+    ///
+    /// // Drain thread - sends results as workers complete
+    /// std::thread::spawn(move || {
+    ///     work_rx.drain_parallel_into(|w| w.ndx(), result_tx);
+    /// });
+    ///
+    /// // Consumer thread - processes results incrementally
+    /// for ndx in result_rx {
+    ///     // Process each result as it arrives
+    /// }
+    /// ```
+    pub fn drain_parallel_into<F, R>(self, f: F, tx: SyncSender<R>)
+    where
+        F: Fn(DeltaWork) -> R + Send + Sync,
+        R: Send,
+    {
+        rayon::scope(|s| {
+            for work in self.into_iter() {
+                let f = &f;
+                let tx = tx.clone();
+                s.spawn(move |_| {
+                    let result = f(work);
+                    // If the receiver is dropped, silently stop - the consumer
+                    // has decided it doesn't need more results.
+                    let _ = tx.send(result);
+                });
+            }
+        });
+        // `tx` (the original, not clones) is dropped here, closing the channel
+        // after all rayon tasks complete.
     }
 }
 
@@ -580,6 +669,118 @@ mod tests {
         let ordered: Vec<u64> = reorder.drain_ready().map(|r| r.sequence()).collect();
         let expected: Vec<u64> = (0..u64::from(total)).collect();
         assert_eq!(ordered, expected);
+    }
+
+    // ==================== drain_parallel_into tests ====================
+
+    #[test]
+    fn drain_parallel_into_streams_all_items() {
+        let (tx, rx) = bounded_with_capacity(8);
+        let count = 200u32;
+
+        let producer = thread::spawn(move || {
+            for i in 0..count {
+                tx.send(DeltaWork::whole_file(i, PathBuf::from("/dst"), 64))
+                    .unwrap();
+            }
+        });
+
+        let (result_tx, result_rx) = mpsc::sync_channel(16);
+        thread::spawn(move || {
+            rx.drain_parallel_into(|w| w.ndx(), result_tx);
+        });
+
+        let mut results: Vec<u32> = result_rx.iter().collect();
+        producer.join().unwrap();
+
+        results.sort_unstable();
+        assert_eq!(results, (0..count).collect::<Vec<u32>>());
+    }
+
+    #[test]
+    fn drain_parallel_into_empty_queue() {
+        let (tx, rx) = bounded_with_capacity(4);
+        drop(tx);
+
+        let (result_tx, result_rx) = mpsc::sync_channel(4);
+        thread::spawn(move || {
+            rx.drain_parallel_into(|w| w.ndx(), result_tx);
+        });
+
+        let results: Vec<u32> = result_rx.iter().collect();
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn drain_parallel_into_backpressure() {
+        // Bounded result channel with capacity 2: workers block when consumer
+        // is slow, preventing unbounded memory growth.
+        let (tx, rx) = bounded_with_capacity(4);
+        let total = 50u32;
+
+        let producer = thread::spawn(move || {
+            for i in 0..total {
+                tx.send(DeltaWork::whole_file(i, PathBuf::from("/dst"), 0))
+                    .unwrap();
+            }
+        });
+
+        let (result_tx, result_rx) = mpsc::sync_channel(2);
+        thread::spawn(move || {
+            rx.drain_parallel_into(|w| w.ndx(), result_tx);
+        });
+
+        let mut results = Vec::new();
+        for r in result_rx {
+            results.push(r);
+        }
+        producer.join().unwrap();
+
+        results.sort_unstable();
+        assert_eq!(results, (0..total).collect::<Vec<u32>>());
+    }
+
+    #[test]
+    fn drain_parallel_into_receiver_drop_stops_workers() {
+        let (tx, rx) = bounded_with_capacity(8);
+        let total = 100u32;
+
+        let producer = thread::spawn(move || {
+            for i in 0..total {
+                let _ = tx.send(DeltaWork::whole_file(i, PathBuf::from("/dst"), 0));
+            }
+        });
+
+        let (result_tx, result_rx) = mpsc::sync_channel(4);
+        let drain_handle = thread::spawn(move || {
+            rx.drain_parallel_into(|w| w.ndx(), result_tx);
+        });
+
+        // Take a few results then drop the receiver.
+        let _ = result_rx.recv();
+        drop(result_rx);
+
+        // Drain thread should complete without hanging.
+        let deadline = Instant::now() + Duration::from_secs(5);
+        producer.join().unwrap();
+        drain_handle.join().unwrap();
+        assert!(Instant::now() < deadline, "drain_parallel_into hung after receiver drop");
+    }
+
+    #[test]
+    fn drain_parallel_into_single_item() {
+        let (tx, rx) = bounded_with_capacity(4);
+        tx.send(DeltaWork::whole_file(42, PathBuf::from("/dst"), 128))
+            .unwrap();
+        drop(tx);
+
+        let (result_tx, result_rx) = mpsc::sync_channel(4);
+        thread::spawn(move || {
+            rx.drain_parallel_into(|w| (w.ndx(), w.target_size()), result_tx);
+        });
+
+        let results: Vec<_> = result_rx.iter().collect();
+        assert_eq!(results, vec![(42, 128)]);
     }
 
     // ==================== drain_parallel tests ====================

--- a/crates/engine/src/concurrent_delta/work_queue.rs
+++ b/crates/engine/src/concurrent_delta/work_queue.rs
@@ -764,7 +764,10 @@ mod tests {
         let deadline = Instant::now() + Duration::from_secs(5);
         producer.join().unwrap();
         drain_handle.join().unwrap();
-        assert!(Instant::now() < deadline, "drain_parallel_into hung after receiver drop");
+        assert!(
+            Instant::now() < deadline,
+            "drain_parallel_into hung after receiver drop"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add `drain_parallel_into` method to `WorkQueueReceiver` that streams results via `SyncSender` as rayon workers complete, enabling incremental consumption without waiting for all items to finish
- Update `DeltaConsumer::spawn` to use two background threads (delta-drain + delta-reorder) for pipeline overlap between delta computation and disk writes
- Fix shard-0 degenerate case in `drain_parallel` where threads outside the rayon pool all collapsed to shard 0 via `unwrap_or(0)` - now uses thread-ID hash for even distribution

## Test plan

- [x] New unit tests for `drain_parallel_into`: streaming, empty queue, backpressure, receiver drop, single item
- [x] Existing `DeltaConsumer` tests verify correct in-order delivery with new streaming architecture
- [ ] CI: fmt+clippy, nextest (stable), Windows, macOS, Linux musl