### PR TITLE
fix: record compressed wire bytes in batch files for upstream interop

### DIFF
--- a/crates/transfer/src/compressed_reader.rs
+++ b/crates/transfer/src/compressed_reader.rs
@@ -4,8 +4,7 @@
 //! mirroring upstream rsync's io.c:io_start_buffering_in() behavior where decompression
 //! is applied after multiplex framing.
 
-use std::io::{self, Read, Write};
-use std::sync::{Arc, Mutex};
+use std::io::{self, Read};
 
 use compress::algorithm::CompressionAlgorithm;
 use compress::zlib::CountingZlibDecoder;
@@ -20,17 +19,15 @@ use compress::zstd::CountingZstdDecoder;
 ///
 /// Mirrors upstream `io.c:io_start_buffering_in()` where decompression is
 /// applied on top of the multiplexed stream.
+///
+/// Batch recording is handled by the inner `MultiplexReader`, not here.
+/// upstream: `io.c:read_buf()` tees compressed wire bytes to `batch_fd`
+/// before decompression. The batch header stores `do_compression: true`
+/// so replay decompresses the tokens.
 pub struct CompressedReader<R: Read> {
     /// Active decompression decoder variant
     /// The decoder owns the underlying reader
     decoder: DecoderVariant<R>,
-    /// Optional recorder for batch mode - captures post-decompression (uncompressed) data.
-    ///
-    /// When `--write-batch` is used with compression, the batch file must contain
-    /// uncompressed tokens so `--read-batch` can replay without the compression codec.
-    /// upstream: io.c:read_buf() tees data to batch_fd; when compression is active,
-    /// upstream records the decompressed data, not the compressed wire bytes.
-    pub(crate) batch_recorder: Option<Arc<Mutex<dyn Write + Send>>>,
 }
 
 /// Compression decoder dispatch for supported algorithms.
@@ -71,10 +68,7 @@ impl<R: Read> CompressedReader<R> {
             }
         };
 
-        Ok(Self {
-            decoder,
-            batch_recorder: None,
-        })
+        Ok(Self { decoder })
     }
 
     /// Returns a mutable reference to the underlying reader.
@@ -104,27 +98,17 @@ impl<R: Read> CompressedReader<R> {
 
 impl<R: Read> Read for CompressedReader<R> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        // Decompress data from underlying reader
-        let n = match &mut self.decoder {
-            DecoderVariant::Zlib(decoder) => decoder.read(buf)?,
+        // Decompress data from underlying reader.
+        // Batch recording happens at the MultiplexReader level (compressed
+        // wire bytes), not here. upstream: io.c:read_buf() tees before
+        // decompression.
+        match &mut self.decoder {
+            DecoderVariant::Zlib(decoder) => decoder.read(buf),
             #[cfg(feature = "lz4")]
-            DecoderVariant::Lz4(decoder) => decoder.read(buf)?,
+            DecoderVariant::Lz4(decoder) => decoder.read(buf),
             #[cfg(feature = "zstd")]
-            DecoderVariant::Zstd(decoder) => decoder.read(buf)?,
-        };
-
-        // upstream: io.c:read_buf() tees data to batch_fd AFTER decompression.
-        // Record uncompressed data so --read-batch can replay without the codec.
-        if n > 0 {
-            if let Some(ref recorder) = self.batch_recorder {
-                recorder
-                    .lock()
-                    .map_err(|_| io::Error::other("batch recorder lock poisoned"))?
-                    .write_all(&buf[..n])?;
-            }
+            DecoderVariant::Zstd(decoder) => decoder.read(buf),
         }
-
-        Ok(n)
     }
 }
 

--- a/crates/transfer/src/compressed_writer.rs
+++ b/crates/transfer/src/compressed_writer.rs
@@ -5,7 +5,6 @@
 //! is applied after multiplex framing.
 
 use std::io::{self, IoSlice, Write};
-use std::sync::{Arc, Mutex};
 
 use compress::algorithm::CompressionAlgorithm;
 use compress::zlib::{CompressionLevel, CountingZlibEncoder};
@@ -20,6 +19,11 @@ use compress::zstd::CountingZstdEncoder;
 ///
 /// Mirrors upstream `io.c:io_start_buffering_out()` where compression is
 /// applied on top of the multiplexed stream.
+///
+/// Batch recording is handled by the inner `MultiplexWriter`, not here.
+/// upstream: `io.c:write_buf()` tees compressed wire bytes to `batch_fd`
+/// after compression. The batch header stores `do_compression: true`
+/// so replay decompresses the tokens.
 pub struct CompressedWriter<W: Write> {
     /// The underlying writer (typically MultiplexWriter)
     inner: W,
@@ -27,12 +31,6 @@ pub struct CompressedWriter<W: Write> {
     encoder: EncoderVariant,
     /// Flush threshold - flush when buffer exceeds this size
     flush_threshold: usize,
-    /// Optional recorder for batch mode - captures pre-compression (uncompressed) data.
-    ///
-    /// When `--write-batch` is used with compression, the batch file must contain
-    /// uncompressed tokens so `--read-batch` can replay without the compression codec.
-    /// upstream: token.c:send_token() writes to batch_fd before send_deflated_token().
-    pub(crate) batch_recorder: Option<Arc<Mutex<dyn Write + Send>>>,
 }
 
 /// Compression encoder dispatch for supported algorithms.
@@ -94,7 +92,6 @@ impl<W: Write> CompressedWriter<W> {
             inner,
             encoder,
             flush_threshold: BUFFER_SIZE,
-            batch_recorder: None,
         })
     }
 
@@ -218,15 +215,9 @@ impl<W: Write> CompressedWriter<W> {
 
 impl<W: Write> Write for CompressedWriter<W> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        // upstream: token.c:send_token() writes to batch_fd BEFORE compression.
-        // Tee uncompressed data to batch recorder so --read-batch can replay
-        // without the compression codec.
-        if let Some(ref recorder) = self.batch_recorder {
-            recorder
-                .lock()
-                .map_err(|_| io::Error::other("batch recorder lock poisoned"))?
-                .write_all(buf)?;
-        }
+        // Batch recording happens at the MultiplexWriter level (compressed
+        // wire bytes), not here. upstream: io.c:write_buf() tees after
+        // compression.
 
         // Compress input data - this writes to the encoder's internal Vec<u8> sink
         match &mut self.encoder {

--- a/crates/transfer/src/reader/server.rs
+++ b/crates/transfer/src/reader/server.rs
@@ -41,27 +41,28 @@ impl<R: Read> ServerReader<R> {
         }
     }
 
-    /// Registers a batch recorder for capturing uncompressed protocol data.
+    /// Registers a batch recorder for capturing compressed protocol data.
     ///
-    /// When compression is active, the recorder is attached to the
-    /// `CompressedReader` so it captures **post-decompression** (uncompressed) data.
-    /// This ensures `--read-batch` can replay without the compression codec.
-    /// When only multiplex is active, the recorder is attached to the
-    /// `MultiplexReader` to capture post-demux data.
-    /// If neither is active yet, the recorder is stored until `activate_multiplex`.
+    /// The recorder is always attached to the `MultiplexReader` so it captures
+    /// data at the same level as upstream rsync's `read_buf()` tee to `batch_fd`.
+    /// When compression is active, this means capturing **pre-decompression**
+    /// (compressed) wire bytes. The batch header records `do_compression: true`
+    /// so replay knows to decompress the tokens.
     ///
-    /// upstream: token.c:send_token() writes to batch_fd before compression.
-    /// upstream: io.c:read_buf() tees data after decompression when compression
-    /// is active.
+    /// If neither multiplex nor compression is active yet, the recorder is
+    /// stored until `activate_multiplex`.
+    ///
+    /// upstream: io.c:read_buf() tees data to batch_fd before decompression.
     pub fn set_batch_recorder(&mut self, recorder: Arc<Mutex<dyn Write + Send>>) {
         match &mut self.inner {
             ServerReaderInner::Multiplex(mux) => {
                 mux.batch_recorder = Some(recorder);
             }
             ServerReaderInner::Compressed(compressed) => {
-                // Attach to CompressedReader so we capture decompressed data,
-                // not to the inner MultiplexReader which would see compressed data.
-                compressed.batch_recorder = Some(recorder);
+                // upstream: io.c:read_buf() tees at the read_buf level, which
+                // is the MultiplexReader's output (compressed data). Attach to
+                // the inner MultiplexReader to capture compressed wire bytes.
+                compressed.get_mut().batch_recorder = Some(recorder);
             }
             ServerReaderInner::Plain(_) => {
                 self.pending_batch_recorder = Some(recorder);
@@ -109,13 +110,14 @@ impl<R: Read> ServerReader<R> {
     /// - The compression algorithm is not supported in this build
     pub fn activate_compression(self, algorithm: CompressionAlgorithm) -> io::Result<Self> {
         match self.inner {
-            ServerReaderInner::Multiplex(mut mux) => {
-                // If a batch recorder was attached to the MultiplexReader, move it
-                // to the CompressedReader so it captures decompressed (uncompressed)
-                // data instead of compressed wire bytes.
-                let recorder = mux.batch_recorder.take();
-                let mut compressed = CompressedReader::new(mux, algorithm)?;
-                compressed.batch_recorder = recorder;
+            ServerReaderInner::Multiplex(mux) => {
+                // upstream: io.c:read_buf() tees data to batch_fd at the
+                // read_buf level, which is BEFORE decompression. Keep the
+                // batch recorder on MultiplexReader so it captures the
+                // compressed wire bytes, matching upstream behavior. The
+                // batch header records do_compression=true so replay knows
+                // to decompress.
+                let compressed = CompressedReader::new(mux, algorithm)?;
                 Ok(Self {
                     inner: ServerReaderInner::Compressed(compressed),
                     pending_batch_recorder: None,

--- a/crates/transfer/src/reader/tests.rs
+++ b/crates/transfer/src/reader/tests.rs
@@ -724,45 +724,22 @@ fn batch_recorder_roundtrip_writer_reader_capture_same_data() {
 // =========================================================================
 // Batch recorder + compression tests
 // =========================================================================
+//
+// upstream: io.c:read_buf() tees data to batch_fd BEFORE decompression.
+// The batch recorder must stay on MultiplexReader (not CompressedReader)
+// so it captures compressed wire bytes. The batch header stores
+// do_compression=true so replay decompresses the tokens.
 
 #[test]
-fn compressed_reader_batch_recorder_captures_decompressed_data() {
-    // When compression is active, the batch recorder must capture
-    // post-decompression (uncompressed) data so --read-batch can replay
-    // without the compression codec.
-    // upstream: io.c:read_buf() tees decompressed data to batch_fd.
-    use crate::compressed_reader::CompressedReader;
-    use compress::zlib::{CompressionLevel, compress_to_vec};
-
-    let original = b"uncompressed payload for batch";
-    let compressed = compress_to_vec(original, CompressionLevel::Default).unwrap();
-
-    let recorder_buf: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
-    let mut reader =
-        CompressedReader::new(Cursor::new(compressed), CompressionAlgorithm::Zlib).unwrap();
-    reader.batch_recorder = Some(recorder_buf.clone());
-
-    let mut output = Vec::new();
-    reader.read_to_end(&mut output).unwrap();
-    assert_eq!(&output, original);
-
-    let recorded = recorder_buf.lock().unwrap();
-    assert_eq!(
-        &*recorded, original,
-        "batch recorder must capture decompressed (uncompressed) data"
-    );
-}
-
-#[test]
-fn server_reader_compressed_batch_recorder_captures_decompressed() {
-    // End-to-end: write compressed data through a multiplex writer,
-    // read it back through a compressed server reader with a batch recorder,
-    // verify the recorder captures the original uncompressed data.
+fn server_reader_compressed_batch_recorder_captures_compressed_wire_bytes() {
+    // When compression is active, the batch recorder on the inner
+    // MultiplexReader captures the compressed wire bytes (not decompressed).
+    // This matches upstream io.c:read_buf() behavior.
     use crate::compressed_writer::CompressedWriter;
     use crate::writer::multiplex::MultiplexWriter;
     use compress::zlib::CompressionLevel;
 
-    let original = b"server reader compressed batch test";
+    let original = b"server reader compressed batch test data payload";
 
     // Build a compressed+multiplexed wire stream
     let mut wire = Vec::new();
@@ -791,24 +768,29 @@ fn server_reader_compressed_batch_recorder_captures_decompressed() {
     assert_eq!(&output, original);
 
     let recorded = recorder_buf.lock().unwrap();
-    assert_eq!(
+    // The recorded data should be compressed (different from original).
+    // It should NOT equal the original uncompressed data.
+    assert_ne!(
         &*recorded, original,
-        "batch recorder on compressed reader must capture uncompressed data"
+        "batch recorder must capture compressed wire bytes, not decompressed data"
+    );
+    assert!(
+        !recorded.is_empty(),
+        "batch recorder must capture some data"
     );
 }
 
 #[test]
-fn server_reader_batch_recorder_migrates_on_compression_activation() {
-    // Verify that if a batch recorder is set on the MultiplexReader and
-    // then compression is activated, the recorder is moved to the
-    // CompressedReader to capture decompressed data.
+fn server_reader_batch_recorder_stays_on_mux_after_compression_activation() {
+    // When a batch recorder is set on MultiplexReader before compression is
+    // activated, it stays on MultiplexReader (not moved to CompressedReader).
+    // This captures compressed wire bytes matching upstream behavior.
     use crate::compressed_writer::CompressedWriter;
     use crate::writer::multiplex::MultiplexWriter;
     use compress::zlib::CompressionLevel;
 
-    let original = b"migrated recorder test data";
+    let original = b"recorder stays on mux test data";
 
-    // Build a compressed+multiplexed wire stream
     let mut wire = Vec::new();
     {
         let mux = MultiplexWriter::new(&mut wire);
@@ -819,7 +801,6 @@ fn server_reader_batch_recorder_migrates_on_compression_activation() {
         compressed.finish().unwrap();
     }
 
-    // Set batch recorder on multiplex reader, then activate compression
     let reader = ServerReader::new_plain(Cursor::new(wire));
     let mut mux_reader = reader.activate_multiplex().unwrap();
 
@@ -827,7 +808,7 @@ fn server_reader_batch_recorder_migrates_on_compression_activation() {
     let recorder: Arc<Mutex<dyn Write + Send>> = recorder_buf.clone();
     mux_reader.set_batch_recorder(recorder);
 
-    // Activate compression - recorder should migrate from mux to compressed layer
+    // Activate compression - recorder stays on MultiplexReader
     let mut compressed_reader = mux_reader
         .activate_compression(CompressionAlgorithm::Zlib)
         .unwrap();
@@ -837,43 +818,47 @@ fn server_reader_batch_recorder_migrates_on_compression_activation() {
     assert_eq!(&output, original);
 
     let recorded = recorder_buf.lock().unwrap();
-    assert_eq!(
+    // Recorded data is compressed wire bytes, not equal to original
+    assert_ne!(
         &*recorded, original,
-        "recorder migrated to compression layer should capture decompressed data"
+        "recorder on mux layer should capture compressed wire bytes"
     );
+    assert!(!recorded.is_empty());
 }
 
 #[test]
-fn batch_recorder_roundtrip_compressed_captures_uncompressed() {
+fn batch_recorder_roundtrip_compressed_captures_identical_wire_bytes() {
     // End-to-end: write data through compressed+multiplexed writer with
-    // batch recorder, read back through compressed+multiplexed reader with
-    // batch recorder. Both recorders should capture identical UNCOMPRESSED data.
+    // batch recorder on mux layer, read back through compressed+multiplexed
+    // reader with batch recorder on mux layer. Both recorders capture
+    // identical COMPRESSED wire bytes.
     use crate::compressed_writer::CompressedWriter;
     use crate::writer::multiplex::MultiplexWriter;
     use compress::zlib::CompressionLevel;
 
-    let original = b"compressed roundtrip batch verification";
+    let original = b"compressed roundtrip batch verification payload data";
     let mut wire = Vec::new();
 
-    // Writer side: record pre-compression data
+    // Writer side: record post-compression (compressed) data at mux layer
     let write_recorder: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
     {
-        let mux = MultiplexWriter::new(&mut wire);
+        let mut mux = MultiplexWriter::new(&mut wire);
+        mux.batch_recorder = Some(write_recorder.clone());
         let mut compressed =
             CompressedWriter::new(mux, CompressionAlgorithm::Zlib, CompressionLevel::Default)
                 .unwrap();
-        compressed.batch_recorder = Some(write_recorder.clone());
         compressed.write_all(original).unwrap();
         compressed.finish().unwrap();
     }
 
-    // Reader side: record post-decompression data
+    // Reader side: record pre-decompression (compressed) data at mux layer
     let read_recorder: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
     {
-        use crate::compressed_reader::CompressedReader;
-        let mux = MultiplexReader::new(Cursor::new(wire));
-        let mut compressed = CompressedReader::new(mux, CompressionAlgorithm::Zlib).unwrap();
-        compressed.batch_recorder = Some(read_recorder.clone());
+        let mut mux = MultiplexReader::new(Cursor::new(wire));
+        mux.batch_recorder = Some(read_recorder.clone());
+        let mut compressed =
+            crate::compressed_reader::CompressedReader::new(mux, CompressionAlgorithm::Zlib)
+                .unwrap();
 
         let mut output = vec![0u8; original.len()];
         compressed.read_exact(&mut output).unwrap();
@@ -884,102 +869,23 @@ fn batch_recorder_roundtrip_compressed_captures_uncompressed() {
     let read_recorded = read_recorder.lock().unwrap();
     assert_eq!(
         &*write_recorded, &*read_recorded,
-        "writer and reader batch recorders should capture identical uncompressed data"
+        "writer and reader batch recorders should capture identical compressed wire bytes"
     );
-    assert_eq!(&*write_recorded, original);
+    // Both should contain compressed data, not the original
+    assert_ne!(&*write_recorded, original);
+    assert!(!write_recorded.is_empty());
 }
 
 #[test]
-fn compressed_reader_batch_recorder_level_none_captures_passthrough_data() {
-    // CompressionLevel::None (--compress-level=0) produces stored (not deflated)
-    // output. The reader's batch recorder must still capture the decompressed bytes.
-    use crate::compressed_reader::CompressedReader;
-    use compress::zlib::{CompressionLevel, compress_to_vec};
-
-    let original = b"level zero reader payload";
-    let compressed = compress_to_vec(original, CompressionLevel::None).unwrap();
-
-    let recorder_buf: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
-    let mut reader =
-        CompressedReader::new(Cursor::new(compressed), CompressionAlgorithm::Zlib).unwrap();
-    reader.batch_recorder = Some(recorder_buf.clone());
-
-    let mut output = Vec::new();
-    reader.read_to_end(&mut output).unwrap();
-    assert_eq!(&output, original);
-
-    let recorded = recorder_buf.lock().unwrap();
-    assert_eq!(
-        &*recorded, original,
-        "batch recorder must capture data even at compression level 0"
-    );
-}
-
-#[cfg(feature = "lz4")]
-#[test]
-fn compressed_reader_batch_recorder_lz4_captures_decompressed() {
-    // Verify the batch recorder captures post-decompression data with LZ4.
-    use crate::compressed_reader::CompressedReader;
-    use compress::lz4::compress_to_vec as lz4_compress;
-    use compress::zlib::CompressionLevel;
-
-    let original = b"lz4 batch reader payload";
-    let compressed = lz4_compress(original, CompressionLevel::Default).unwrap();
-
-    let recorder_buf: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
-    let mut reader =
-        CompressedReader::new(Cursor::new(compressed), CompressionAlgorithm::Lz4).unwrap();
-    reader.batch_recorder = Some(recorder_buf.clone());
-
-    let mut output = Vec::new();
-    reader.read_to_end(&mut output).unwrap();
-    assert_eq!(&output, original);
-
-    let recorded = recorder_buf.lock().unwrap();
-    assert_eq!(
-        &*recorded, original,
-        "batch recorder with LZ4 must capture decompressed data"
-    );
-}
-
-#[cfg(feature = "zstd")]
-#[test]
-fn compressed_reader_batch_recorder_zstd_captures_decompressed() {
-    // Verify the batch recorder captures post-decompression data with Zstd.
-    use crate::compressed_reader::CompressedReader;
-    use compress::zlib::CompressionLevel;
-    use compress::zstd::compress_to_vec as zstd_compress;
-
-    let original = b"zstd batch reader payload";
-    let compressed = zstd_compress(original, CompressionLevel::Default).unwrap();
-
-    let recorder_buf: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
-    let mut reader =
-        CompressedReader::new(Cursor::new(compressed), CompressionAlgorithm::Zstd).unwrap();
-    reader.batch_recorder = Some(recorder_buf.clone());
-
-    let mut output = Vec::new();
-    reader.read_to_end(&mut output).unwrap();
-    assert_eq!(&output, original);
-
-    let recorded = recorder_buf.lock().unwrap();
-    assert_eq!(
-        &*recorded, original,
-        "batch recorder with Zstd must capture decompressed data"
-    );
-}
-
-#[test]
-fn server_reader_batch_recorder_migrates_on_compression_activation_lz4() {
-    // Verify recorder migration from MultiplexReader to CompressedReader
-    // works for LZ4, not just Zlib.
+fn server_reader_batch_recorder_stays_on_mux_lz4() {
+    // Verify batch recorder stays on MultiplexReader with LZ4 compression.
     #[cfg(feature = "lz4")]
     {
         use crate::compressed_writer::CompressedWriter;
         use crate::writer::multiplex::MultiplexWriter;
         use compress::zlib::CompressionLevel;
 
-        let original = b"lz4 migration test";
+        let original = b"lz4 mux recorder test";
 
         let mut wire = Vec::new();
         {
@@ -1007,24 +913,20 @@ fn server_reader_batch_recorder_migrates_on_compression_activation_lz4() {
         assert_eq!(&output, original);
 
         let recorded = recorder_buf.lock().unwrap();
-        assert_eq!(
-            &*recorded, original,
-            "recorder migrated to LZ4 layer should capture decompressed data"
-        );
+        assert!(!recorded.is_empty(), "recorder must capture data");
     }
 }
 
 #[test]
-fn server_reader_batch_recorder_migrates_on_compression_activation_zstd() {
-    // Verify recorder migration from MultiplexReader to CompressedReader
-    // works for Zstd, not just Zlib.
+fn server_reader_batch_recorder_stays_on_mux_zstd() {
+    // Verify batch recorder stays on MultiplexReader with Zstd compression.
     #[cfg(feature = "zstd")]
     {
         use crate::compressed_writer::CompressedWriter;
         use crate::writer::multiplex::MultiplexWriter;
         use compress::zlib::CompressionLevel;
 
-        let original = b"zstd migration test";
+        let original = b"zstd mux recorder test";
 
         let mut wire = Vec::new();
         {
@@ -1052,101 +954,6 @@ fn server_reader_batch_recorder_migrates_on_compression_activation_zstd() {
         assert_eq!(&output, original);
 
         let recorded = recorder_buf.lock().unwrap();
-        assert_eq!(
-            &*recorded, original,
-            "recorder migrated to Zstd layer should capture decompressed data"
-        );
-    }
-}
-
-#[test]
-fn batch_recorder_roundtrip_compressed_lz4_captures_uncompressed() {
-    // End-to-end roundtrip with LZ4: both write and read recorders capture
-    // identical uncompressed data.
-    #[cfg(feature = "lz4")]
-    {
-        use crate::compressed_reader::CompressedReader;
-        use crate::compressed_writer::CompressedWriter;
-        use crate::writer::multiplex::MultiplexWriter;
-        use compress::zlib::CompressionLevel;
-
-        let original = b"lz4 roundtrip batch verification";
-        let mut wire = Vec::new();
-
-        let write_recorder: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
-        {
-            let mux = MultiplexWriter::new(&mut wire);
-            let mut compressed =
-                CompressedWriter::new(mux, CompressionAlgorithm::Lz4, CompressionLevel::Default)
-                    .unwrap();
-            compressed.batch_recorder = Some(write_recorder.clone());
-            compressed.write_all(original).unwrap();
-            compressed.finish().unwrap();
-        }
-
-        let read_recorder: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
-        {
-            let mux = MultiplexReader::new(Cursor::new(wire));
-            let mut compressed = CompressedReader::new(mux, CompressionAlgorithm::Lz4).unwrap();
-            compressed.batch_recorder = Some(read_recorder.clone());
-
-            let mut output = vec![0u8; original.len()];
-            compressed.read_exact(&mut output).unwrap();
-            assert_eq!(&output, original);
-        }
-
-        let write_recorded = write_recorder.lock().unwrap();
-        let read_recorded = read_recorder.lock().unwrap();
-        assert_eq!(
-            &*write_recorded, &*read_recorded,
-            "LZ4 writer and reader batch recorders should capture identical uncompressed data"
-        );
-        assert_eq!(&*write_recorded, original);
-    }
-}
-
-#[test]
-fn batch_recorder_roundtrip_compressed_zstd_captures_uncompressed() {
-    // End-to-end roundtrip with Zstd: both write and read recorders capture
-    // identical uncompressed data.
-    #[cfg(feature = "zstd")]
-    {
-        use crate::compressed_reader::CompressedReader;
-        use crate::compressed_writer::CompressedWriter;
-        use crate::writer::multiplex::MultiplexWriter;
-        use compress::zlib::CompressionLevel;
-
-        let original = b"zstd roundtrip batch verification";
-        let mut wire = Vec::new();
-
-        let write_recorder: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
-        {
-            let mux = MultiplexWriter::new(&mut wire);
-            let mut compressed =
-                CompressedWriter::new(mux, CompressionAlgorithm::Zstd, CompressionLevel::Default)
-                    .unwrap();
-            compressed.batch_recorder = Some(write_recorder.clone());
-            compressed.write_all(original).unwrap();
-            compressed.finish().unwrap();
-        }
-
-        let read_recorder: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
-        {
-            let mux = MultiplexReader::new(Cursor::new(wire));
-            let mut compressed = CompressedReader::new(mux, CompressionAlgorithm::Zstd).unwrap();
-            compressed.batch_recorder = Some(read_recorder.clone());
-
-            let mut output = vec![0u8; original.len()];
-            compressed.read_exact(&mut output).unwrap();
-            assert_eq!(&output, original);
-        }
-
-        let write_recorded = write_recorder.lock().unwrap();
-        let read_recorded = read_recorder.lock().unwrap();
-        assert_eq!(
-            &*write_recorded, &*read_recorded,
-            "Zstd writer and reader batch recorders should capture identical uncompressed data"
-        );
-        assert_eq!(&*write_recorded, original);
+        assert!(!recorded.is_empty(), "recorder must capture data");
     }
 }

--- a/crates/transfer/src/writer/server.rs
+++ b/crates/transfer/src/writer/server.rs
@@ -76,13 +76,14 @@ impl<W: Write> ServerWriter<W> {
         level: CompressionLevel,
     ) -> io::Result<Self> {
         match self {
-            Self::Multiplex(mut mux) => {
-                // If a batch recorder was attached to the MultiplexWriter, move it
-                // to the CompressedWriter so it captures uncompressed data instead
-                // of compressed wire bytes.
-                let recorder = mux.batch_recorder.take();
-                let mut compressed = CompressedWriter::new(mux, algorithm, level)?;
-                compressed.batch_recorder = recorder;
+            Self::Multiplex(mux) => {
+                // upstream: io.c:write_buf() tees data to batch_fd at the
+                // write_buf level, which is AFTER compression. Keep the
+                // batch recorder on MultiplexWriter so it captures the
+                // compressed wire bytes, matching upstream behavior. The
+                // batch header records do_compression=true so replay knows
+                // to decompress.
+                let compressed = CompressedWriter::new(mux, algorithm, level)?;
                 Ok(Self::Compressed(compressed))
             }
             Self::Plain(_) => Err(io::Error::new(
@@ -202,17 +203,16 @@ impl<W: Write> ServerWriter<W> {
         self.send_message(MessageCode::Redo, &ndx.to_le_bytes())
     }
 
-    /// Attaches a batch recorder for capturing uncompressed protocol data.
+    /// Attaches a batch recorder for capturing compressed protocol data.
     ///
-    /// When compression is active, the recorder is attached to the
-    /// `CompressedWriter` so it captures **pre-compression** (uncompressed) data.
-    /// This ensures `--read-batch` can replay without the compression codec.
-    /// When only multiplex is active, the recorder is attached to the
-    /// `MultiplexWriter` to capture pre-mux data.
+    /// The recorder is always attached to the `MultiplexWriter` so it captures
+    /// data at the same level as upstream rsync's `write_buf()` tee to `batch_fd`.
+    /// When compression is active, this means capturing **post-compression**
+    /// (compressed) wire bytes. The batch header records `do_compression: true`
+    /// so replay knows to decompress the tokens.
     ///
-    /// upstream: token.c:send_token() writes to batch_fd before compression.
-    /// upstream: io.c:write_batch_monitor_out tees pre-mux data when no
-    /// compression is active.
+    /// upstream: io.c:write_buf() tees to batch_fd after compression but before
+    /// multiplex framing.
     pub fn set_batch_recorder(&mut self, recorder: Arc<Mutex<dyn Write + Send>>) -> io::Result<()> {
         match self {
             Self::Multiplex(mux) => {
@@ -220,9 +220,10 @@ impl<W: Write> ServerWriter<W> {
                 Ok(())
             }
             Self::Compressed(compressed) => {
-                // Attach to CompressedWriter so we capture uncompressed data,
-                // not to the inner MultiplexWriter which would see compressed data.
-                compressed.batch_recorder = Some(recorder);
+                // upstream: io.c:write_buf() tees at the write_buf level, which
+                // is the MultiplexWriter's input (compressed data). Attach to the
+                // inner MultiplexWriter to capture compressed wire bytes.
+                compressed.inner_mut().batch_recorder = Some(recorder);
                 Ok(())
             }
             _ => Err(io::Error::new(

--- a/crates/transfer/src/writer/tests.rs
+++ b/crates/transfer/src/writer/tests.rs
@@ -621,49 +621,17 @@ fn server_writer_batch_recorder_captures_through_server_write() {
 // =========================================================================
 // Batch recorder + compression tests
 // =========================================================================
+//
+// upstream: io.c:write_buf() tees data to batch_fd AFTER compression.
+// The batch recorder must stay on MultiplexWriter (not CompressedWriter)
+// so it captures compressed wire bytes. The batch header stores
+// do_compression=true so replay decompresses the tokens.
 
 #[test]
-fn compressed_writer_batch_recorder_captures_uncompressed_data() {
-    // When compression is active, the batch recorder must capture
-    // pre-compression (uncompressed) data so --read-batch can replay
-    // without the compression codec.
-    // upstream: token.c:send_token() writes to batch_fd before compression.
-    use crate::compressed_writer::CompressedWriter;
-
-    let mut wire = Vec::new();
-    let recorder_buf: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
-
-    {
-        let mut compressed = CompressedWriter::new(
-            &mut wire,
-            CompressionAlgorithm::Zlib,
-            CompressionLevel::Default,
-        )
-        .unwrap();
-        compressed.batch_recorder = Some(recorder_buf.clone());
-
-        compressed.write_all(b"uncompressed payload").unwrap();
-        compressed.finish().unwrap();
-    }
-
-    let recorded = recorder_buf.lock().unwrap();
-    assert_eq!(
-        &*recorded, b"uncompressed payload",
-        "batch recorder must capture uncompressed data, not compressed"
-    );
-
-    // Wire should contain compressed data (different from raw input)
-    assert_ne!(
-        &wire[..],
-        b"uncompressed payload",
-        "wire should contain compressed data"
-    );
-}
-
-#[test]
-fn server_writer_compressed_batch_recorder_captures_uncompressed() {
-    // Verify that set_batch_recorder on a Compressed ServerWriter captures
-    // uncompressed data, not the compressed bytes flowing to the mux layer.
+fn server_writer_compressed_batch_recorder_captures_compressed() {
+    // When compression is active, set_batch_recorder attaches to the inner
+    // MultiplexWriter, capturing compressed wire bytes (not uncompressed).
+    // upstream: io.c:write_buf() tees after compression.
     let mut wire = Vec::new();
     let mut writer = ServerWriter::new_plain(&mut wire)
         .activate_multiplex()
@@ -675,21 +643,27 @@ fn server_writer_compressed_batch_recorder_captures_uncompressed() {
     let recorder: Arc<Mutex<dyn Write + Send>> = recorder_buf.clone();
     writer.set_batch_recorder(recorder).unwrap();
 
-    writer.write_all(b"batch test data").unwrap();
+    writer.write_all(b"batch test data payload here").unwrap();
     writer.flush().unwrap();
 
     let recorded = recorder_buf.lock().unwrap();
-    assert_eq!(
-        &*recorded, b"batch test data",
-        "batch recorder on compressed writer must capture uncompressed data"
+    // The recorded data is compressed, so it differs from the original.
+    assert_ne!(
+        &*recorded,
+        b"batch test data payload here",
+        "batch recorder on compressed writer must capture compressed wire bytes"
+    );
+    assert!(
+        !recorded.is_empty(),
+        "batch recorder must capture some data"
     );
 }
 
 #[test]
-fn server_writer_batch_recorder_migrates_on_compression_activation() {
-    // Verify that if a batch recorder is set on the MultiplexWriter
-    // and then compression is activated, the recorder is moved to the
-    // CompressedWriter to capture uncompressed data.
+fn server_writer_batch_recorder_stays_on_mux_after_compression_activation() {
+    // When a batch recorder is set on MultiplexWriter before compression
+    // is activated, it stays on MultiplexWriter (not moved to CompressedWriter).
+    // This captures compressed wire bytes matching upstream behavior.
     let mut wire = Vec::new();
     let mut writer = ServerWriter::new_plain(&mut wire)
         .activate_multiplex()
@@ -699,123 +673,27 @@ fn server_writer_batch_recorder_migrates_on_compression_activation() {
     let recorder: Arc<Mutex<dyn Write + Send>> = recorder_buf.clone();
     writer.set_batch_recorder(recorder).unwrap();
 
-    // Now activate compression - recorder should migrate from mux to compressed layer
+    // Activate compression - recorder stays on MultiplexWriter
     let mut writer = writer
         .activate_compression(CompressionAlgorithm::Zlib, CompressionLevel::Default)
         .unwrap();
 
-    writer.write_all(b"migrated recorder").unwrap();
+    writer.write_all(b"stays on mux test data").unwrap();
     writer.flush().unwrap();
 
     let recorded = recorder_buf.lock().unwrap();
-    assert_eq!(
-        &*recorded, b"migrated recorder",
-        "recorder migrated to compression layer should capture uncompressed data"
-    );
-}
-
-#[test]
-fn compressed_writer_batch_recorder_level_none_captures_passthrough_data() {
-    // CompressionLevel::None (--compress-level=0) still wraps in a CompressedWriter
-    // but data passes through without deflation. The batch recorder must still
-    // capture the original uncompressed bytes.
-    use crate::compressed_writer::CompressedWriter;
-
-    let mut wire = Vec::new();
-    let recorder_buf: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
-
-    {
-        let mut compressed = CompressedWriter::new(
-            &mut wire,
-            CompressionAlgorithm::Zlib,
-            CompressionLevel::None,
-        )
-        .unwrap();
-        compressed.batch_recorder = Some(recorder_buf.clone());
-
-        compressed.write_all(b"level zero payload").unwrap();
-        compressed.finish().unwrap();
-    }
-
-    let recorded = recorder_buf.lock().unwrap();
-    assert_eq!(
-        &*recorded, b"level zero payload",
-        "batch recorder must capture data even at compression level 0"
-    );
-}
-
-#[cfg(feature = "lz4")]
-#[test]
-fn compressed_writer_batch_recorder_lz4_captures_uncompressed() {
-    // Verify the batch recorder captures pre-compression data with LZ4.
-    use crate::compressed_writer::CompressedWriter;
-
-    let mut wire = Vec::new();
-    let recorder_buf: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
-
-    {
-        let mut compressed = CompressedWriter::new(
-            &mut wire,
-            CompressionAlgorithm::Lz4,
-            CompressionLevel::Default,
-        )
-        .unwrap();
-        compressed.batch_recorder = Some(recorder_buf.clone());
-
-        compressed.write_all(b"lz4 batch payload").unwrap();
-        compressed.finish().unwrap();
-    }
-
-    let recorded = recorder_buf.lock().unwrap();
-    assert_eq!(
-        &*recorded, b"lz4 batch payload",
-        "batch recorder with LZ4 must capture uncompressed data"
-    );
+    // Recorded data is compressed wire bytes
     assert_ne!(
-        &wire[..],
-        b"lz4 batch payload",
-        "wire should contain LZ4 compressed data"
+        &*recorded,
+        b"stays on mux test data",
+        "recorder on mux layer should capture compressed wire bytes"
     );
-}
-
-#[cfg(feature = "zstd")]
-#[test]
-fn compressed_writer_batch_recorder_zstd_captures_uncompressed() {
-    // Verify the batch recorder captures pre-compression data with Zstd.
-    use crate::compressed_writer::CompressedWriter;
-
-    let mut wire = Vec::new();
-    let recorder_buf: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
-
-    {
-        let mut compressed = CompressedWriter::new(
-            &mut wire,
-            CompressionAlgorithm::Zstd,
-            CompressionLevel::Default,
-        )
-        .unwrap();
-        compressed.batch_recorder = Some(recorder_buf.clone());
-
-        compressed.write_all(b"zstd batch payload").unwrap();
-        compressed.finish().unwrap();
-    }
-
-    let recorded = recorder_buf.lock().unwrap();
-    assert_eq!(
-        &*recorded, b"zstd batch payload",
-        "batch recorder with Zstd must capture uncompressed data"
-    );
-    assert_ne!(
-        &wire[..],
-        b"zstd batch payload",
-        "wire should contain Zstd compressed data"
-    );
+    assert!(!recorded.is_empty());
 }
 
 #[test]
-fn server_writer_batch_recorder_migrates_on_compression_activation_lz4() {
-    // Verify recorder migration from MultiplexWriter to CompressedWriter
-    // works for LZ4, not just Zlib.
+fn server_writer_batch_recorder_stays_on_mux_lz4() {
+    // Verify batch recorder stays on MultiplexWriter with LZ4 compression.
     #[cfg(feature = "lz4")]
     {
         let mut wire = Vec::new();
@@ -831,21 +709,17 @@ fn server_writer_batch_recorder_migrates_on_compression_activation_lz4() {
             .activate_compression(CompressionAlgorithm::Lz4, CompressionLevel::Default)
             .unwrap();
 
-        writer.write_all(b"lz4 migrated").unwrap();
+        writer.write_all(b"lz4 mux recorder test").unwrap();
         writer.flush().unwrap();
 
         let recorded = recorder_buf.lock().unwrap();
-        assert_eq!(
-            &*recorded, b"lz4 migrated",
-            "recorder migrated to LZ4 compression layer should capture uncompressed data"
-        );
+        assert!(!recorded.is_empty(), "recorder must capture data");
     }
 }
 
 #[test]
-fn server_writer_batch_recorder_migrates_on_compression_activation_zstd() {
-    // Verify recorder migration from MultiplexWriter to CompressedWriter
-    // works for Zstd, not just Zlib.
+fn server_writer_batch_recorder_stays_on_mux_zstd() {
+    // Verify batch recorder stays on MultiplexWriter with Zstd compression.
     #[cfg(feature = "zstd")]
     {
         let mut wire = Vec::new();
@@ -861,48 +735,10 @@ fn server_writer_batch_recorder_migrates_on_compression_activation_zstd() {
             .activate_compression(CompressionAlgorithm::Zstd, CompressionLevel::Default)
             .unwrap();
 
-        writer.write_all(b"zstd migrated").unwrap();
+        writer.write_all(b"zstd mux recorder test").unwrap();
         writer.flush().unwrap();
 
         let recorded = recorder_buf.lock().unwrap();
-        assert_eq!(
-            &*recorded, b"zstd migrated",
-            "recorder migrated to Zstd compression layer should capture uncompressed data"
-        );
+        assert!(!recorded.is_empty(), "recorder must capture data");
     }
-}
-
-#[test]
-fn compressed_writer_batch_recorder_vectored_write_captures_all_chunks() {
-    // Verify that write_vectored also tees through the batch recorder correctly.
-    // write_vectored delegates to write() which does the tee, but this test
-    // exercises the multi-buffer path explicitly.
-    use crate::compressed_writer::CompressedWriter;
-
-    let mut wire = Vec::new();
-    let recorder_buf: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
-
-    {
-        let mut compressed = CompressedWriter::new(
-            &mut wire,
-            CompressionAlgorithm::Zlib,
-            CompressionLevel::Default,
-        )
-        .unwrap();
-        compressed.batch_recorder = Some(recorder_buf.clone());
-
-        let bufs = [
-            IoSlice::new(b"chunk1 "),
-            IoSlice::new(b"chunk2 "),
-            IoSlice::new(b"chunk3"),
-        ];
-        let _n = compressed.write_vectored(&bufs).unwrap();
-        compressed.finish().unwrap();
-    }
-
-    let recorded = recorder_buf.lock().unwrap();
-    assert_eq!(
-        &*recorded, b"chunk1 chunk2 chunk3",
-        "batch recorder must capture all vectored write chunks uncompressed"
-    );
 }

--- a/crates/transfer/src/writer/tests.rs
+++ b/crates/transfer/src/writer/tests.rs
@@ -649,8 +649,7 @@ fn server_writer_compressed_batch_recorder_captures_compressed() {
     let recorded = recorder_buf.lock().unwrap();
     // The recorded data is compressed, so it differs from the original.
     assert_ne!(
-        &*recorded,
-        b"batch test data payload here",
+        &*recorded, b"batch test data payload here",
         "batch recorder on compressed writer must capture compressed wire bytes"
     );
     assert!(
@@ -684,8 +683,7 @@ fn server_writer_batch_recorder_stays_on_mux_after_compression_activation() {
     let recorded = recorder_buf.lock().unwrap();
     // Recorded data is compressed wire bytes
     assert_ne!(
-        &*recorded,
-        b"stays on mux test data",
+        &*recorded, b"stays on mux test data",
         "recorder on mux layer should capture compressed wire bytes"
     );
     assert!(!recorded.is_empty());


### PR DESCRIPTION
## Summary

- Keep batch recorder on `MultiplexReader`/`MultiplexWriter` when compression is activated, instead of migrating it to `CompressedReader`/`CompressedWriter`
- This matches upstream rsync's `io.c:read_buf()`/`write_buf()` behavior where batch_fd captures compressed wire bytes
- Remove `batch_recorder` field from `CompressedReader` and `CompressedWriter` entirely
- Remove 4 compressed batch interop known failures from `known_failures.conf`

## Problem

oc-rsync was writing uncompressed delta tokens to batch files while setting `do_compression: true` in the batch header. When upstream rsync read such a batch, it tried to decompress already-decompressed data. When oc-rsync read upstream batch files (which correctly contain compressed tokens), it read compressed bytes without decompressing.

## Root cause

When compression was activated, the batch recorder was migrated from `MultiplexReader`/`MultiplexWriter` to `CompressedReader`/`CompressedWriter`. This caused:
- **Writer side**: recorded pre-compression (uncompressed) input to `CompressedWriter`
- **Reader side**: recorded post-decompression (uncompressed) output from `CompressedReader`

Upstream rsync tees at the `read_buf()`/`write_buf()` level in `io.c`, which is between the multiplex framing and compression layers - capturing compressed wire bytes.

## Fix

Keep the batch recorder on the multiplex layer. The `CompressedWriter` writes compressed output to `MultiplexWriter`, so the recorder on `MultiplexWriter` naturally captures compressed bytes. Similarly, `CompressedReader` reads from `MultiplexReader`, so the recorder on `MultiplexReader` captures compressed bytes before decompression.

The replay path (`crates/batch/src/replay.rs`) already has `CompressedTokenDecoder` support that decompresses tokens when `do_compression: true`.

## Test plan

- [ ] CI fmt+clippy passes
- [ ] CI nextest passes on all platforms
- [ ] Interop tests pass - specifically the 4 previously-failing compressed batch tests
- [ ] Existing batch replay tests continue to pass