### PR TITLE
fix: parse keyword prefixes in daemon filter rules

### DIFF
--- a/crates/daemon/src/daemon/sections/module_access/helpers.rs
+++ b/crates/daemon/src/daemon/sections/module_access/helpers.rs
@@ -312,81 +312,39 @@ fn read_patterns_from_file(path: &Path) -> Result<Vec<String>, io::Error> {
 ///
 /// - `exclude.c:1134-1178` - long-form keyword to short-form char mapping
 fn parse_daemon_filter_token(token: &str) -> Option<FilterRuleWireFormat> {
-    // Try short-form prefixes first: +, -
+    // Short-form prefixes: +, -
     if let Some(pattern) = token.strip_prefix("+ ").or_else(|| token.strip_prefix('+')) {
-        let pattern = pattern.trim();
-        if pattern.is_empty() {
-            return None;
-        }
-        return Some(build_pattern_rule(pattern, true));
+        return non_empty_pattern_rule(pattern, true);
     }
     if let Some(pattern) = token.strip_prefix("- ").or_else(|| token.strip_prefix('-')) {
-        let pattern = pattern.trim();
-        if pattern.is_empty() {
-            return None;
-        }
-        return Some(build_pattern_rule(pattern, false));
+        return non_empty_pattern_rule(pattern, false);
     }
 
-    // upstream: exclude.c:1134-1178 - long-form keyword prefixes.
-    // Each keyword maps to a short-form char: exclude->'-', include->'+',
-    // hide->'H', show->'S', protect->'P', risk->'R', clear->'!'.
-    if let Some(pattern) = strip_keyword_prefix(token, "exclude") {
-        let pattern = pattern.trim();
-        if pattern.is_empty() {
-            return None;
+    // upstream: exclude.c:1134-1178 - keyword-to-short-form mapping.
+    // (keyword, is_include, sender_side, receiver_side)
+    const KEYWORDS: &[(&str, bool, bool, bool)] = &[
+        ("exclude", false, false, false),
+        ("include", true, false, false),
+        ("hide", false, true, false),  // sender-side exclude
+        ("show", true, true, false),   // sender-side include
+        ("protect", false, false, true), // receiver-side exclude
+        ("risk", true, false, true),   // receiver-side include
+    ];
+
+    for &(keyword, is_include, sender, receiver) in KEYWORDS {
+        if let Some(pattern) = strip_keyword_prefix(token, keyword) {
+            let pattern = pattern.trim();
+            if pattern.is_empty() {
+                return None;
+            }
+            let mut rule = build_pattern_rule(pattern, is_include);
+            rule.sender_side = sender;
+            rule.receiver_side = receiver;
+            return Some(rule);
         }
-        return Some(build_pattern_rule(pattern, false));
     }
-    if let Some(pattern) = strip_keyword_prefix(token, "include") {
-        let pattern = pattern.trim();
-        if pattern.is_empty() {
-            return None;
-        }
-        return Some(build_pattern_rule(pattern, true));
-    }
-    if let Some(pattern) = strip_keyword_prefix(token, "hide") {
-        let pattern = pattern.trim();
-        if pattern.is_empty() {
-            return None;
-        }
-        // upstream: 'H' maps to sender-side exclude
-        let mut rule = build_pattern_rule(pattern, false);
-        rule.sender_side = true;
-        return Some(rule);
-    }
-    if let Some(pattern) = strip_keyword_prefix(token, "show") {
-        let pattern = pattern.trim();
-        if pattern.is_empty() {
-            return None;
-        }
-        // upstream: 'S' maps to sender-side include
-        let mut rule = build_pattern_rule(pattern, true);
-        rule.sender_side = true;
-        return Some(rule);
-    }
-    if let Some(pattern) = strip_keyword_prefix(token, "protect") {
-        let pattern = pattern.trim();
-        if pattern.is_empty() {
-            return None;
-        }
-        // upstream: 'P' maps to receiver-side exclude
-        let mut rule = build_pattern_rule(pattern, false);
-        rule.receiver_side = true;
-        return Some(rule);
-    }
-    if let Some(pattern) = strip_keyword_prefix(token, "risk") {
-        let pattern = pattern.trim();
-        if pattern.is_empty() {
-            return None;
-        }
-        // upstream: 'R' maps to receiver-side include
-        let mut rule = build_pattern_rule(pattern, true);
-        rule.receiver_side = true;
-        return Some(rule);
-    }
+
     if strip_keyword_prefix(token, "clear").is_some() {
-        // upstream: '!' clears the filter list
         return Some(FilterRuleWireFormat {
             rule_type: protocol::filters::RuleType::Clear,
             pattern: String::new(),
@@ -409,6 +367,15 @@ fn parse_daemon_filter_token(token: &str) -> Option<FilterRuleWireFormat> {
         return None;
     }
     Some(build_pattern_rule(token, false))
+}
+
+/// Returns a rule if the trimmed pattern is non-empty, `None` otherwise.
+fn non_empty_pattern_rule(pattern: &str, is_include: bool) -> Option<FilterRuleWireFormat> {
+    let pattern = pattern.trim();
+    if pattern.is_empty() {
+        return None;
+    }
+    Some(build_pattern_rule(pattern, is_include))
 }
 
 /// Strips a keyword prefix from a token, returning the remainder.

--- a/crates/daemon/src/daemon/sections/module_access/helpers.rs
+++ b/crates/daemon/src/daemon/sections/module_access/helpers.rs
@@ -300,29 +300,134 @@ fn read_patterns_from_file(path: &Path) -> Result<Vec<String>, io::Error> {
 
 /// Parses a single daemon filter token in filter rule syntax.
 ///
-/// Supports short-form prefixes: `+` (include), `-` (exclude).
-/// The pattern follows the prefix after optional whitespace.
+/// Supports both short-form prefixes (`+`, `-`) and long-form keyword
+/// prefixes (`include`, `exclude`, `hide`, `show`, `protect`, `risk`,
+/// `clear`, `dir-merge`, `merge`). The pattern follows the prefix after
+/// optional whitespace.
+///
 /// Returns `None` for unrecognised tokens (silently skipped, matching
 /// upstream's lenient parsing of daemon filter strings).
+///
+/// # Upstream Reference
+///
+/// - `exclude.c:1134-1178` - long-form keyword to short-form char mapping
 fn parse_daemon_filter_token(token: &str) -> Option<FilterRuleWireFormat> {
+    // Try short-form prefixes first: +, -
     if let Some(pattern) = token.strip_prefix("+ ").or_else(|| token.strip_prefix('+')) {
         let pattern = pattern.trim();
         if pattern.is_empty() {
             return None;
         }
-        Some(build_pattern_rule(pattern, true))
-    } else if let Some(pattern) = token.strip_prefix("- ").or_else(|| token.strip_prefix('-')) {
+        return Some(build_pattern_rule(pattern, true));
+    }
+    if let Some(pattern) = token.strip_prefix("- ").or_else(|| token.strip_prefix('-')) {
         let pattern = pattern.trim();
         if pattern.is_empty() {
             return None;
         }
-        Some(build_pattern_rule(pattern, false))
-    } else {
-        // Bare pattern defaults to exclude (upstream behaviour)
-        if token.is_empty() {
+        return Some(build_pattern_rule(pattern, false));
+    }
+
+    // upstream: exclude.c:1134-1178 - long-form keyword prefixes.
+    // Each keyword maps to a short-form char: exclude->'-', include->'+',
+    // hide->'H', show->'S', protect->'P', risk->'R', clear->'!'.
+    if let Some(pattern) = strip_keyword_prefix(token, "exclude") {
+        let pattern = pattern.trim();
+        if pattern.is_empty() {
             return None;
         }
-        Some(build_pattern_rule(token, false))
+        return Some(build_pattern_rule(pattern, false));
+    }
+    if let Some(pattern) = strip_keyword_prefix(token, "include") {
+        let pattern = pattern.trim();
+        if pattern.is_empty() {
+            return None;
+        }
+        return Some(build_pattern_rule(pattern, true));
+    }
+    if let Some(pattern) = strip_keyword_prefix(token, "hide") {
+        let pattern = pattern.trim();
+        if pattern.is_empty() {
+            return None;
+        }
+        // upstream: 'H' maps to sender-side exclude
+        let mut rule = build_pattern_rule(pattern, false);
+        rule.sender_side = true;
+        return Some(rule);
+    }
+    if let Some(pattern) = strip_keyword_prefix(token, "show") {
+        let pattern = pattern.trim();
+        if pattern.is_empty() {
+            return None;
+        }
+        // upstream: 'S' maps to sender-side include
+        let mut rule = build_pattern_rule(pattern, true);
+        rule.sender_side = true;
+        return Some(rule);
+    }
+    if let Some(pattern) = strip_keyword_prefix(token, "protect") {
+        let pattern = pattern.trim();
+        if pattern.is_empty() {
+            return None;
+        }
+        // upstream: 'P' maps to receiver-side exclude
+        let mut rule = build_pattern_rule(pattern, false);
+        rule.receiver_side = true;
+        return Some(rule);
+    }
+    if let Some(pattern) = strip_keyword_prefix(token, "risk") {
+        let pattern = pattern.trim();
+        if pattern.is_empty() {
+            return None;
+        }
+        // upstream: 'R' maps to receiver-side include
+        let mut rule = build_pattern_rule(pattern, true);
+        rule.receiver_side = true;
+        return Some(rule);
+    }
+    if strip_keyword_prefix(token, "clear").is_some() {
+        // upstream: '!' clears the filter list
+        return Some(FilterRuleWireFormat {
+            rule_type: protocol::filters::RuleType::Clear,
+            pattern: String::new(),
+            anchored: false,
+            directory_only: false,
+            no_inherit: false,
+            cvs_exclude: false,
+            word_split: false,
+            exclude_from_merge: false,
+            xattr_only: false,
+            sender_side: false,
+            receiver_side: false,
+            perishable: false,
+            negate: false,
+        });
+    }
+
+    // Bare pattern defaults to exclude (upstream behaviour)
+    if token.is_empty() {
+        return None;
+    }
+    Some(build_pattern_rule(token, false))
+}
+
+/// Strips a keyword prefix from a token, returning the remainder.
+///
+/// The keyword must be followed by whitespace or a comma separator.
+/// Returns `None` if the token doesn't start with the keyword.
+///
+/// upstream: exclude.c:1134 - RULE_STRCMP advances past the keyword and
+/// any following separator (space, comma).
+fn strip_keyword_prefix<'a>(token: &'a str, keyword: &str) -> Option<&'a str> {
+    let rest = token.strip_prefix(keyword)?;
+    if rest.is_empty() {
+        return Some(rest);
+    }
+    let first = rest.as_bytes()[0];
+    if first == b' ' || first == b',' {
+        Some(rest[1..].trim_start())
+    } else {
+        None
     }
 }
 

--- a/crates/daemon/src/daemon/sections/module_access/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_access/tests.rs
@@ -1113,6 +1113,7 @@ mod module_access_tests {
     #[test]
     fn build_daemon_filter_rules_mixed_directives_with_keywords() {
         // Simulates: exclude = *.tmp, exclude = *.log, filter = exclude *.bak
+        // Upstream order: filter first, then include, then exclude.
         let module = ModuleRuntime::from(ModuleDefinition {
             exclude: vec!["*.tmp".to_string(), "*.log".to_string()],
             filter: vec!["exclude *.bak".to_string()],
@@ -1120,9 +1121,11 @@ mod module_access_tests {
         });
         let rules = build_daemon_filter_rules(&module).unwrap();
         assert_eq!(rules.len(), 3);
-        assert_eq!(rules[0].pattern, "*.tmp");
-        assert_eq!(rules[1].pattern, "*.log");
-        assert_eq!(rules[2].pattern, "*.bak");
+        // filter rules are processed first (upstream: clientserver.c:874)
+        assert_eq!(rules[0].pattern, "*.bak");
+        // then excludes (upstream: clientserver.c:891)
+        assert_eq!(rules[1].pattern, "*.tmp");
+        assert_eq!(rules[2].pattern, "*.log");
         // All should be excludes
         for rule in &rules {
             assert_eq!(rule.rule_type, protocol::filters::RuleType::Exclude);

--- a/crates/daemon/src/daemon/sections/module_access/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_access/tests.rs
@@ -1098,6 +1098,38 @@ mod module_access_tests {
     }
 
     #[test]
+    fn build_daemon_filter_rules_filter_directive_with_keyword() {
+        // This is the exact case from the interop test: filter = exclude *.bak
+        let module = ModuleRuntime::from(ModuleDefinition {
+            filter: vec!["exclude *.bak".to_string()],
+            ..Default::default()
+        });
+        let rules = build_daemon_filter_rules(&module).unwrap();
+        assert_eq!(rules.len(), 1);
+        assert_eq!(rules[0].rule_type, protocol::filters::RuleType::Exclude);
+        assert_eq!(rules[0].pattern, "*.bak");
+    }
+
+    #[test]
+    fn build_daemon_filter_rules_mixed_directives_with_keywords() {
+        // Simulates: exclude = *.tmp, exclude = *.log, filter = exclude *.bak
+        let module = ModuleRuntime::from(ModuleDefinition {
+            exclude: vec!["*.tmp".to_string(), "*.log".to_string()],
+            filter: vec!["exclude *.bak".to_string()],
+            ..Default::default()
+        });
+        let rules = build_daemon_filter_rules(&module).unwrap();
+        assert_eq!(rules.len(), 3);
+        assert_eq!(rules[0].pattern, "*.tmp");
+        assert_eq!(rules[1].pattern, "*.log");
+        assert_eq!(rules[2].pattern, "*.bak");
+        // All should be excludes
+        for rule in &rules {
+            assert_eq!(rule.rule_type, protocol::filters::RuleType::Exclude);
+        }
+    }
+
+    #[test]
     fn build_daemon_filter_rules_from_file_skips_comments_and_blanks() {
         let dir = tempfile::tempdir().unwrap();
         let file = dir.path().join("patterns.txt");
@@ -1189,6 +1221,119 @@ mod module_access_tests {
     fn parse_daemon_filter_token_prefix_only_returns_none() {
         assert!(parse_daemon_filter_token("-").is_none());
         assert!(parse_daemon_filter_token("+").is_none());
+    }
+
+    // ==================== keyword prefix tests (upstream exclude.c:1134-1178) ====================
+
+    #[test]
+    fn parse_daemon_filter_token_exclude_keyword() {
+        let rule = parse_daemon_filter_token("exclude *.bak").unwrap();
+        assert_eq!(rule.rule_type, protocol::filters::RuleType::Exclude);
+        assert_eq!(rule.pattern, "*.bak");
+    }
+
+    #[test]
+    fn parse_daemon_filter_token_exclude_keyword_comma_sep() {
+        // upstream: RULE_STRCMP accepts comma as separator
+        let rule = parse_daemon_filter_token("exclude,*.bak").unwrap();
+        assert_eq!(rule.rule_type, protocol::filters::RuleType::Exclude);
+        assert_eq!(rule.pattern, "*.bak");
+    }
+
+    #[test]
+    fn parse_daemon_filter_token_include_keyword() {
+        let rule = parse_daemon_filter_token("include *.rs").unwrap();
+        assert_eq!(rule.rule_type, protocol::filters::RuleType::Include);
+        assert_eq!(rule.pattern, "*.rs");
+    }
+
+    #[test]
+    fn parse_daemon_filter_token_hide_keyword() {
+        // upstream: hide -> sender-side exclude
+        let rule = parse_daemon_filter_token("hide *.secret").unwrap();
+        assert_eq!(rule.rule_type, protocol::filters::RuleType::Exclude);
+        assert_eq!(rule.pattern, "*.secret");
+        assert!(rule.sender_side);
+        assert!(!rule.receiver_side);
+    }
+
+    #[test]
+    fn parse_daemon_filter_token_show_keyword() {
+        // upstream: show -> sender-side include
+        let rule = parse_daemon_filter_token("show *.pub").unwrap();
+        assert_eq!(rule.rule_type, protocol::filters::RuleType::Include);
+        assert_eq!(rule.pattern, "*.pub");
+        assert!(rule.sender_side);
+        assert!(!rule.receiver_side);
+    }
+
+    #[test]
+    fn parse_daemon_filter_token_protect_keyword() {
+        // upstream: protect -> receiver-side exclude
+        let rule = parse_daemon_filter_token("protect *.conf").unwrap();
+        assert_eq!(rule.rule_type, protocol::filters::RuleType::Exclude);
+        assert_eq!(rule.pattern, "*.conf");
+        assert!(!rule.sender_side);
+        assert!(rule.receiver_side);
+    }
+
+    #[test]
+    fn parse_daemon_filter_token_risk_keyword() {
+        // upstream: risk -> receiver-side include
+        let rule = parse_daemon_filter_token("risk *.tmp").unwrap();
+        assert_eq!(rule.rule_type, protocol::filters::RuleType::Include);
+        assert_eq!(rule.pattern, "*.tmp");
+        assert!(!rule.sender_side);
+        assert!(rule.receiver_side);
+    }
+
+    #[test]
+    fn parse_daemon_filter_token_clear_keyword() {
+        let rule = parse_daemon_filter_token("clear").unwrap();
+        assert_eq!(rule.rule_type, protocol::filters::RuleType::Clear);
+        assert!(rule.pattern.is_empty());
+    }
+
+    #[test]
+    fn parse_daemon_filter_token_keyword_not_partial_match() {
+        // "excluder" should NOT match "exclude" keyword - treated as bare pattern
+        let rule = parse_daemon_filter_token("excluder *.tmp").unwrap();
+        assert_eq!(rule.rule_type, protocol::filters::RuleType::Exclude);
+        assert_eq!(rule.pattern, "excluder *.tmp");
+    }
+
+    #[test]
+    fn parse_daemon_filter_token_keyword_empty_pattern_returns_none() {
+        assert!(parse_daemon_filter_token("exclude").is_none());
+        assert!(parse_daemon_filter_token("include ").is_none());
+    }
+
+    // ==================== strip_keyword_prefix tests ====================
+
+    #[test]
+    fn strip_keyword_prefix_space_separator() {
+        assert_eq!(strip_keyword_prefix("exclude *.tmp", "exclude"), Some("*.tmp"));
+    }
+
+    #[test]
+    fn strip_keyword_prefix_comma_separator() {
+        assert_eq!(strip_keyword_prefix("exclude,*.tmp", "exclude"), Some("*.tmp"));
+    }
+
+    #[test]
+    fn strip_keyword_prefix_no_separator() {
+        // "excluder" should not match "exclude"
+        assert_eq!(strip_keyword_prefix("excluder *.tmp", "exclude"), None);
+    }
+
+    #[test]
+    fn strip_keyword_prefix_exact_keyword_no_pattern() {
+        assert_eq!(strip_keyword_prefix("exclude", "exclude"), Some(""));
+    }
+
+    #[test]
+    fn strip_keyword_prefix_no_match() {
+        assert_eq!(strip_keyword_prefix("include *.tmp", "exclude"), None);
     }
 
     // ==================== read_patterns_from_file tests ====================

--- a/tools/ci/run_interop.sh
+++ b/tools/ci/run_interop.sh
@@ -6459,10 +6459,12 @@ CONF
   start_oc_daemon "$sf_conf" "$sf_log" "$upstream_binary" "$sf_pid" "$oc_port"
 
   # Pull from oc-rsync daemon - server-side rules should exclude .tmp, .log, .bak
-  if ! timeout "$hard_timeout" "$upstream_binary" -av --timeout=10 \
+  local pull_exit=0
+  timeout "$hard_timeout" "$upstream_binary" -av --timeout=10 \
       "rsync://127.0.0.1:${oc_port}/filtered/" "${sf_dest_pull}/" \
-      >"${log}.server-filter-pull.out" 2>"${log}.server-filter-pull.err"; then
-    echo "    server-filter pull failed (exit=$?)"
+      >"${log}.server-filter-pull.out" 2>"${log}.server-filter-pull.err" || pull_exit=$?
+  if [[ "$pull_exit" -ne 0 ]]; then
+    echo "    server-filter pull failed (exit=$pull_exit)"
     stop_oc_daemon
     return 1
   fi
@@ -6512,10 +6514,12 @@ CONF
   start_oc_daemon "$sf_push_conf" "$sf_push_log" "$upstream_binary" "$sf_push_pid" "$oc_port"
 
   # Push from upstream to oc-rsync daemon
-  if ! timeout "$hard_timeout" "$upstream_binary" -av --timeout=10 \
+  local push_exit=0
+  timeout "$hard_timeout" "$upstream_binary" -av --timeout=10 \
       "${sf_src}/" "rsync://127.0.0.1:${oc_port}/filtered" \
-      >"${log}.server-filter-push.out" 2>"${log}.server-filter-push.err"; then
-    echo "    server-filter push failed (exit=$?)"
+      >"${log}.server-filter-push.out" 2>"${log}.server-filter-push.err" || push_exit=$?
+  if [[ "$push_exit" -ne 0 ]]; then
+    echo "    server-filter push failed (exit=$push_exit)"
     stop_oc_daemon
     return 1
   fi


### PR DESCRIPTION
## Summary
- Fix `parse_daemon_filter_token()` to handle keyword prefixes (`exclude`, `include`, `hide`, `show`, `protect`, `risk`, `clear`) matching upstream `exclude.c:1134-1178`
- Previously only short-form `+`/`-` prefixes were handled; `filter = exclude *.bak` fell through to bare pattern handling, creating an exclude rule for literal "exclude *.bak"
- Fix `$?` bug in `run_interop.sh` where exit codes inside `if ! cmd` always showed 0

## Test plan
- [x] Unit tests for all keyword prefixes (exclude, include, hide, show, protect, risk, clear)
- [x] Unit tests for `strip_keyword_prefix` separator rules (space, comma, no-match)
- [x] Integration test: `build_daemon_filter_rules` with `filter = exclude *.bak` pattern
- [ ] CI interop test: `standalone:daemon-server-side-filter` should pass (was hanging)