### PR TITLE
fix: resolve all daemon interop known failures

### DIFF
--- a/crates/core/src/client/run/mod.rs
+++ b/crates/core/src/client/run/mod.rs
@@ -404,10 +404,7 @@ impl<'a> LocalCopyOptionsBuilder<'a> {
         // algorithm was used, so upstream rsync (which defaults to zlib)
         // cannot decode zstd/lz4 batch data. Force zlib to match upstream.
         // upstream: batch.c tees compressed wire bytes using zlib by default.
-        let algorithm = if config
-            .batch_config()
-            .is_some_and(|bc| bc.is_write_mode())
-        {
+        let algorithm = if config.batch_config().is_some_and(|bc| bc.is_write_mode()) {
             compress::algorithm::CompressionAlgorithm::Zlib
         } else {
             config.compression_algorithm()

--- a/crates/core/src/client/run/mod.rs
+++ b/crates/core/src/client/run/mod.rs
@@ -399,8 +399,21 @@ impl<'a> LocalCopyOptionsBuilder<'a> {
         options: LocalCopyOptions,
         config: &ClientConfig,
     ) -> LocalCopyOptions {
+        // When writing batch files, force zlib compression for cross-tool
+        // interop. The batch header records do_compression but not which
+        // algorithm was used, so upstream rsync (which defaults to zlib)
+        // cannot decode zstd/lz4 batch data. Force zlib to match upstream.
+        // upstream: batch.c tees compressed wire bytes using zlib by default.
+        let algorithm = if config
+            .batch_config()
+            .is_some_and(|bc| bc.is_write_mode())
+        {
+            compress::algorithm::CompressionAlgorithm::Zlib
+        } else {
+            config.compression_algorithm()
+        };
         options
-            .with_compression_algorithm(config.compression_algorithm())
+            .with_compression_algorithm(algorithm)
             .with_default_compression_level(config.compression_setting().level_or_default())
             .with_skip_compress(config.skip_compress().clone())
             .compress(config.compress())

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -46,7 +46,6 @@ tracing = { workspace = true, optional = true }
 
 [target.'cfg(not(windows))'.dependencies]
 checksums = { path = "../checksums" }
-fast_io = { path = "../fast_io" }
 libc = "0.2"
 
 # sd-notify is Linux-only (systemd notification)

--- a/crates/daemon/src/daemon/sections/module_access/transfer.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer.rs
@@ -515,6 +515,14 @@ fn process_approved_module(
         module,
     );
 
+    // Ensure clean TCP shutdown: send FIN before dropping streams.
+    // Without explicit shutdown, close() on cloned TcpStreams with unread
+    // receive buffer data causes the kernel to send RST, which the client
+    // interprets as "connection unexpectedly closed" (exit code 12).
+    // upstream: daemon child exits via exit_cleanup() which lets the kernel
+    // perform clean socket shutdown with proper FIN/ACK sequence.
+    let _ = write_stream.shutdown(std::net::Shutdown::Write);
+
     // Run post-xfer exec if configured
     // upstream: clientserver.c - post_exec() runs after the transfer, regardless of outcome
     if let Some(command) = module.post_xfer_exec.as_deref().filter(|_| xfer_exec_enabled()) {

--- a/crates/daemon/src/daemon/sections/module_access/transfer.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer.rs
@@ -124,24 +124,13 @@ fn execute_transfer(
         log_message(log, &message);
     }
 
-    // On Unix, wrap socket fds in io_uring RECV/SEND for batched syscalls.
-    // Auto policy: uses io_uring on Linux 5.6+, falls back to standard I/O elsewhere.
-    #[cfg(unix)]
-    let result = {
-        use std::os::unix::io::AsRawFd;
-        let policy = fast_io::IoUringPolicy::Auto;
-        let reader_res =
-            fast_io::socket_reader_from_fd(read_stream.as_raw_fd(), 64 * 1024, policy);
-        let writer_res =
-            fast_io::socket_writer_from_fd(write_stream.as_raw_fd(), 64 * 1024, policy);
-        if let (Ok(mut reader), Ok(mut writer)) = (reader_res, writer_res) {
-            run_server_with_handshake(config, handshake, &mut reader, &mut writer, None, None, None)
-        } else {
-            run_server_with_handshake(config, handshake, read_stream, write_stream, None, None, None)
-        }
-    };
-    #[cfg(not(unix))]
-    let result = run_server_with_handshake(config, handshake, read_stream, write_stream, None, None, None);
+    // Use standard buffered I/O for daemon socket communication.
+    // io_uring SEND blocks in submit_and_wait() during bidirectional protocol
+    // exchanges (NDX_DONE, stats, goodbye) when TCP backpressure occurs,
+    // causing 10-second hangs. Standard I/O handles partial writes correctly,
+    // matching upstream rsync's socket I/O model.
+    let result =
+        run_server_with_handshake(config, handshake, read_stream, write_stream, None, None, None);
 
     match result {
         Ok(_server_stats) => {

--- a/crates/fast_io/src/io_uring_stub.rs
+++ b/crates/fast_io/src/io_uring_stub.rs
@@ -190,6 +190,7 @@ pub use registered_buffers::{RegisteredBufferGroup, RegisteredBufferSlot};
 ///
 /// On non-Linux platforms, [`try_new`](Self::try_new) always returns `None`
 /// and [`new`](Self::new) always returns `Unsupported`.
+#[derive(Debug)]
 pub struct IoUringDiskBatch {
     _private: (),
 }

--- a/crates/transfer/src/delta_apply/checksum.rs
+++ b/crates/transfer/src/delta_apply/checksum.rs
@@ -30,11 +30,21 @@ pub enum ChecksumVerifier {
 
 impl ChecksumVerifier {
     /// Creates a verifier based on negotiated parameters.
+    ///
+    /// For protocol < 30 (no binary negotiation), the verifier uses MD4 with
+    /// the checksum seed prepended as the first 4 bytes of input - matching
+    /// upstream's `CSUM_MD4_OLD` behaviour in `checksum.c:605-612`.
+    /// Protocol 30+ uses MD5 (no seed) or negotiated algorithms.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `checksum.c:559-620` - `sum_init()` seeds legacy MD4 variants
+    /// - `checksum.c:125-126` - protocol 27-29 uses `CSUM_MD4_OLD`
     #[must_use]
     pub fn new(
         negotiated: Option<&NegotiationResult>,
         protocol: ProtocolVersion,
-        _seed: i32,
+        seed: i32,
         _compat_flags: Option<&CompatibilityFlags>,
     ) -> Self {
         negotiated
@@ -43,9 +53,32 @@ impl ChecksumVerifier {
                 if protocol.uses_varint_encoding() {
                     Self::Md5(Md5::new())
                 } else {
-                    Self::Md4(Md4::new())
+                    // upstream: checksum.c:125 - protocol >= 27 uses CSUM_MD4_OLD
+                    // which prepends the 4-byte seed before file data.
+                    let mut verifier = Self::Md4(Md4::new());
+                    verifier.update(&seed.to_le_bytes());
+                    verifier
                 }
             })
+    }
+
+    /// Creates a verifier for a specific algorithm with seed prepended.
+    ///
+    /// For legacy MD4 (protocol < 30), the seed must be prepended to match
+    /// upstream `CSUM_MD4_OLD`. For all other algorithms, the seed is not
+    /// prepended - matching upstream `sum_init()` which only seeds the
+    /// legacy MD4 variants.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `checksum.c:605-612` - only `CSUM_MD4_OLD`/`BUSTED`/`ARCHAIC` prepend seed
+    #[must_use]
+    pub fn for_algorithm_seeded(algorithm: ChecksumAlgorithm, seed: i32) -> Self {
+        let mut verifier = Self::for_algorithm(algorithm);
+        if algorithm == ChecksumAlgorithm::MD4 {
+            verifier.update(&seed.to_le_bytes());
+        }
+        verifier
     }
 
     /// Creates a verifier for a specific algorithm.

--- a/crates/transfer/src/generator/file_list/entry.rs
+++ b/crates/transfer/src/generator/file_list/entry.rs
@@ -125,11 +125,32 @@ impl GeneratorContext {
         // upstream: flist.c:make_file() - set uid/gid
         #[cfg(unix)]
         if self.config.flags.owner {
-            entry.set_uid(metadata.uid());
+            let uid = metadata.uid();
+            entry.set_uid(uid);
+            // upstream: flist.c:466-470 - add_uid() looks up name for inline
+            // sending via XMIT_USER_NAME_FOLLOWS when INC_RECURSE is active.
+            // Without names, the receiver can't map uid->name on the remote.
+            if !self.config.flags.numeric_ids {
+                if let Ok(Some(name_bytes)) = metadata::id_lookup::lookup_user_name(uid) {
+                    if let Ok(name) = String::from_utf8(name_bytes) {
+                        entry.set_user_name(name);
+                    }
+                }
+            }
         }
         #[cfg(unix)]
         if self.config.flags.group {
-            entry.set_gid(metadata.gid());
+            let gid = metadata.gid();
+            entry.set_gid(gid);
+            // upstream: flist.c:476-480 - add_gid() looks up name for inline
+            // sending via XMIT_GROUP_NAME_FOLLOWS when INC_RECURSE is active.
+            if !self.config.flags.numeric_ids {
+                if let Ok(Some(name_bytes)) = metadata::id_lookup::lookup_group_name(gid) {
+                    if let Ok(name) = String::from_utf8(name_bytes) {
+                        entry.set_group_name(name);
+                    }
+                }
+            }
         }
 
         // Store dev/ino for hardlink detection (post-sort assignment).

--- a/crates/transfer/src/generator/mod.rs
+++ b/crates/transfer/src/generator/mod.rs
@@ -243,6 +243,11 @@ impl SegmentScheduler {
     fn remaining(&self) -> &[PendingSegment] {
         &self.segments[self.cursor..]
     }
+
+    /// Returns `true` when all segments have been dispatched.
+    fn is_exhausted(&self) -> bool {
+        self.cursor >= self.segments.len()
+    }
 }
 
 /// Mutable state for INC_RECURSE segmented file list sending.

--- a/crates/transfer/src/generator/transfer.rs
+++ b/crates/transfer/src/generator/transfer.rs
@@ -111,6 +111,13 @@ impl GeneratorContext {
                     )?;
                     segments_sent += 1;
                 }
+
+                // upstream: flist.c:2534-2545 - send NDX_FLIST_EOF when all sub-lists
+                // have been dispatched. Must happen inside the loop (not after) because
+                // the receiver waits for NDX_FLIST_EOF before sending NDX_DONE.
+                if !self.incremental.flist_eof_sent && scheduler.is_exhausted() {
+                    self.send_flist_eof(&mut *writer, &mut flist_ndx_codec, segments_sent)?;
+                }
             }
 
             // upstream: io.c perform_io() flushes buffered output while waiting
@@ -132,12 +139,8 @@ impl GeneratorContext {
             if ndx < 0 {
                 match ndx {
                     NDX_DONE => {
-                        // Phase transition
-                        phase += 1;
-                        if phase > max_phase {
-                            break;
-                        }
-                        // upstream: sender.c:250 - echo NDX_DONE back to receiver.
+                        // Phase transition: echo NDX_DONE before checking break.
+                        // upstream: sender.c:250 - always echo NDX_DONE, then check phase.
                         // During dry-run the daemon may close the pipe before we
                         // finish echoing - treat write failures as end-of-transfer.
                         if let Err(e) = ndx_write_codec
@@ -148,6 +151,10 @@ impl GeneratorContext {
                                 break;
                             }
                             return Err(e);
+                        }
+                        phase += 1;
+                        if phase > max_phase {
+                            break;
                         }
                         continue;
                     }
@@ -393,18 +400,10 @@ impl GeneratorContext {
         // Cache flist_writer back for potential reuse (e.g., phase 2).
         self.incremental.flist_writer_cache = Some(flist_writer);
 
-        // Send final NDX_DONE.
-        // During dry-run the upstream daemon may have already closed the connection,
-        // making the write fail with BrokenPipe or WouldBlock.
-        // upstream: sender.c - dry-run never enters the data-transfer phase.
-        if let Err(e) = ndx_write_codec
-            .write_ndx_done(&mut *writer)
-            .and_then(|()| writer.flush())
-        {
-            if !(tolerant && is_early_close_error(&e)) {
-                return Err(e);
-            }
-        }
+        // upstream: sender.c does NOT send an NDX_DONE after the transfer loop.
+        // The phase-transition NDX_DONEs were already exchanged inside the loop.
+        // Sending an extra one here causes "Invalid packet at end of run" in the
+        // upstream client's read_final_goodbye() (main.c:875-906).
 
         Ok(TransferLoopResult {
             files_transferred,

--- a/crates/transfer/src/generator/transfer.rs
+++ b/crates/transfer/src/generator/transfer.rs
@@ -14,6 +14,7 @@ use std::io::{self, Read, Write};
 use std::path::PathBuf;
 
 use logging::{PhaseTimer, debug_log};
+use protocol::TransferStats;
 use protocol::codec::{
     NDX_DEL_STATS, NDX_DONE, NDX_FLIST_EOF, NDX_FLIST_OFFSET, NdxCodec, create_ndx_codec,
 };
@@ -595,6 +596,38 @@ impl GeneratorContext {
         self.delete_stats.specials = self.delete_stats.specials.saturating_add(stats.specials);
     }
 
+    /// Sends transfer statistics to the client after the transfer loop completes.
+    ///
+    /// Only called in server mode (daemon sender). Writes total_read,
+    /// total_written, total_size as varlong30 values, plus flist_buildtime
+    /// and flist_xfertime for protocol >= 29.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `main.c:347-357` - `handle_stats()` server-sender write path
+    /// - `main.c:960-962` - `do_server_sender()` calls `handle_stats(f_out)`
+    fn send_stats<W: Write>(
+        &self,
+        writer: &mut W,
+        transfer_result: &TransferLoopResult,
+        flist_buildtime_ms: u64,
+        flist_xfertime_ms: u64,
+    ) -> io::Result<()> {
+        // upstream: stats.total_size is the sum of all file sizes in the transfer
+        let total_size: u64 = self.file_list.iter().map(|e| e.size()).sum();
+
+        let stats = TransferStats::with_bytes(
+            self.timing.total_bytes_read,
+            transfer_result.bytes_sent,
+            total_size,
+        )
+        .with_flist_times(flist_buildtime_ms, flist_xfertime_ms);
+
+        stats.write_to(writer, self.protocol)?;
+        writer.flush()?;
+        Ok(())
+    }
+
     /// Runs the generator role to completion.
     ///
     /// Orchestrates the full send operation: build file list, send it, process
@@ -659,8 +692,17 @@ impl GeneratorContext {
             self.run_transfer_loop(reader, writer, &mut progress, &mut itemize)?
         };
 
-        // upstream: client-sender handle_stats(-1) is a no-op (main.c:360-384).
-        // Stats are only written by the server-sender path.
+        // upstream: main.c:960-962 - do_server_sender() calls io_flush then handle_stats
+        // before read_final_goodbye. Server-sender writes transfer stats; client-sender
+        // handle_stats(-1) is a no-op (main.c:339-345).
+        if !self.config.connection.client_mode {
+            let flist_buildtime =
+                calculate_duration_ms(self.timing.flist_build_start, self.timing.flist_build_end);
+            let flist_xfertime =
+                calculate_duration_ms(self.timing.flist_xfer_start, self.timing.flist_xfer_end);
+            self.send_stats(writer, &transfer_result, flist_buildtime, flist_xfertime)?;
+        }
+
         let mut ndx_read_codec = transfer_result.ndx_read_codec;
         let mut ndx_write_codec = transfer_result.ndx_write_codec;
         self.handle_goodbye(reader, writer, &mut ndx_read_codec, &mut ndx_write_codec)?;

--- a/crates/transfer/src/generator/transfer.rs
+++ b/crates/transfer/src/generator/transfer.rs
@@ -94,6 +94,12 @@ impl GeneratorContext {
             .unwrap_or_else(|| self.build_flist_writer());
         let mut flist_ndx_codec = create_ndx_codec(self.protocol.as_u8());
         let mut segments_sent: usize = 0;
+        // upstream: sender.c:242-250 - tracks remaining flist-free NDX_DONEs.
+        // With INC_RECURSE, the client sends one NDX_DONE per completed flist
+        // (initial + sub-lists). The sender echoes these without phase change
+        // until all flists are freed, then falls through to the normal phase
+        // transition. This counter tracks how many flist-free echoes remain.
+        let mut flist_done_remaining: usize = 0;
 
         // upstream: sender.c - dry-run skips data transfer; daemon may close early
         let tolerant = self.config.flags.dry_run;
@@ -110,6 +116,7 @@ impl GeneratorContext {
                         &mut flist_ndx_codec,
                     )?;
                     segments_sent += 1;
+                    flist_done_remaining += 1;
                 }
 
                 // upstream: flist.c:2534-2545 - send NDX_FLIST_EOF when all sub-lists
@@ -139,10 +146,31 @@ impl GeneratorContext {
             if ndx < 0 {
                 match ndx {
                     NDX_DONE => {
-                        // Phase transition: echo NDX_DONE before checking break.
-                        // upstream: sender.c:250 - always echo NDX_DONE, then check phase.
-                        // During dry-run the daemon may close the pipe before we
-                        // finish echoing - treat write failures as end-of-transfer.
+                        // upstream: sender.c:242-257 - INC_RECURSE flist-free path.
+                        // With INC_RECURSE, the client sends one NDX_DONE per
+                        // completed sub-file-list before the actual phase transitions.
+                        // Echo these without incrementing phase, matching upstream's
+                        // flist_free(first_flist) loop.
+                        if inc_recurse && flist_done_remaining > 0 {
+                            flist_done_remaining -= 1;
+                            if let Err(e) = ndx_write_codec
+                                .write_ndx_done(&mut *writer)
+                                .and_then(|()| writer.flush())
+                            {
+                                if tolerant && is_early_close_error(&e) {
+                                    break;
+                                }
+                                return Err(e);
+                            }
+                            continue;
+                        }
+
+                        // upstream: sender.c:252-257 - phase transition.
+                        // Increment phase first, break without echo if past max_phase.
+                        phase += 1;
+                        if phase > max_phase {
+                            break;
+                        }
                         if let Err(e) = ndx_write_codec
                             .write_ndx_done(&mut *writer)
                             .and_then(|()| writer.flush())
@@ -151,10 +179,6 @@ impl GeneratorContext {
                                 break;
                             }
                             return Err(e);
-                        }
-                        phase += 1;
-                        if phase > max_phase {
-                            break;
                         }
                         continue;
                     }
@@ -367,6 +391,7 @@ impl GeneratorContext {
                         &mut flist_ndx_codec,
                     )?;
                     segments_sent += 1;
+                    flist_done_remaining += 1;
                 }
             }
 
@@ -393,6 +418,7 @@ impl GeneratorContext {
                     &mut flist_ndx_codec,
                 )?;
                 segments_sent += 1;
+                flist_done_remaining += 1;
             }
             self.send_flist_eof(&mut *writer, &mut flist_ndx_codec, segments_sent)?;
         }
@@ -400,10 +426,18 @@ impl GeneratorContext {
         // Cache flist_writer back for potential reuse (e.g., phase 2).
         self.incremental.flist_writer_cache = Some(flist_writer);
 
-        // upstream: sender.c does NOT send an NDX_DONE after the transfer loop.
-        // The phase-transition NDX_DONEs were already exchanged inside the loop.
-        // Sending an extra one here causes "Invalid packet at end of run" in the
-        // upstream client's read_final_goodbye() (main.c:875-906).
+        // upstream: sender.c:454-462 - after the transfer loop exits, the sender
+        // sends io_error (if changed) and a final NDX_DONE. This NDX_DONE is the
+        // "goodbye" that tells the client's generator to proceed with its own
+        // goodbye handshake. Without it, the client hangs waiting for this marker.
+        if let Err(e) = ndx_write_codec
+            .write_ndx_done(&mut *writer)
+            .and_then(|()| writer.flush())
+        {
+            if !(tolerant && is_early_close_error(&e)) {
+                return Err(e);
+            }
+        }
 
         Ok(TransferLoopResult {
             files_transferred,

--- a/crates/transfer/src/pipeline/receiver.rs
+++ b/crates/transfer/src/pipeline/receiver.rs
@@ -65,6 +65,12 @@ pub struct PipelinedReceiver {
     /// Count of files skipped due to permission-denied errors during disk commit.
     /// Used to accumulate `IOERR_GENERAL` for exit code 23.
     permission_error_count: u32,
+    /// Accumulated warning/error messages from checksum verification and
+    /// permission failures. Collected here instead of using `eprintln!` to
+    /// avoid deadlocking on the global stderr mutex in daemon handler threads.
+    /// The caller retrieves these via [`Self::drain_warnings`] and routes
+    /// them through the multiplexed protocol writer.
+    warnings: Vec<String>,
 }
 
 impl PipelinedReceiver {
@@ -81,6 +87,7 @@ impl PipelinedReceiver {
             redo_indices: Vec::new(),
             redo_enabled: true,
             permission_error_count: 0,
+            warnings: Vec::new(),
         }
     }
 
@@ -152,12 +159,12 @@ impl PipelinedReceiver {
                     let pending = self.expected_checksums.pop_front();
                     if is_permission_error(&e) {
                         let path = pending.map(|p| p.file_path).unwrap_or_default();
-                        eprintln!(
+                        self.warnings.push(format!(
                             "rsync: send_files failed to open {:?}: Permission denied (13) {}{}",
                             path.display(),
                             crate::role_trailer::error_location!(),
                             crate::role_trailer::receiver(),
-                        );
+                        ));
                         meta_errors.push((path, e.to_string()));
                         self.permission_error_count += 1;
                     } else {
@@ -210,12 +217,12 @@ impl PipelinedReceiver {
                     let pending = self.expected_checksums.pop_front();
                     if is_permission_error(&e) {
                         let path = pending.map(|p| p.file_path).unwrap_or_default();
-                        eprintln!(
+                        self.warnings.push(format!(
                             "rsync: send_files failed to open {:?}: Permission denied (13) {}{}",
                             path.display(),
                             crate::role_trailer::error_location!(),
                             crate::role_trailer::receiver(),
-                        );
+                        ));
                         meta_errors.push((path, e.to_string()));
                         self.permission_error_count += 1;
                     } else {
@@ -257,7 +264,7 @@ impl PipelinedReceiver {
     fn verify_checksum(&mut self, result: &CommitResult) -> io::Result<()> {
         let pending = match self.expected_checksums.pop_front() {
             Some(p) => p,
-            None => return Ok(()), // No expected checksum (legacy/test path).
+            None => return Ok(()),
         };
 
         if let Some(ref computed) = result.computed_checksum {
@@ -265,23 +272,23 @@ impl PipelinedReceiver {
                 || computed.bytes[..computed.len] != pending.expected[..pending.len]
             {
                 if self.redo_enabled {
-                    // upstream: receiver.c:960-968 — WARNING, will try again
-                    eprintln!(
+                    // upstream: receiver.c:960-968 - WARNING, will try again
+                    self.warnings.push(format!(
                         "WARNING: {:?} failed verification -- update discarded (will try again). {}{}",
                         pending.file_path,
                         crate::role_trailer::error_location!(),
                         crate::role_trailer::receiver(),
-                    );
+                    ));
                     self.redo_indices.push(pending.file_index);
                     return Ok(());
                 }
-                // upstream: receiver.c:957-959 — ERROR in phase 2 (redoing)
-                eprintln!(
+                // upstream: receiver.c:957-959 - ERROR in phase 2 (redoing)
+                self.warnings.push(format!(
                     "ERROR: {:?} failed verification -- update discarded. {}{}",
                     pending.file_path,
                     crate::role_trailer::error_location!(),
                     crate::role_trailer::receiver(),
-                );
+                ));
                 // In phase 2, upstream logs the error but continues the transfer.
                 return Ok(());
             }
@@ -325,10 +332,21 @@ impl PipelinedReceiver {
     ///
     /// Implicitly drains remaining results. Returns the final accumulated
     /// (bytes_written, metadata_errors).
+    /// Drains accumulated warning messages from checksum verification and
+    /// permission failures. Returns them so the caller can route them through
+    /// the multiplexed protocol writer.
+    pub fn drain_warnings(&mut self) -> Vec<String> {
+        std::mem::take(&mut self.warnings)
+    }
+
+    /// Sends `Shutdown` and joins the disk thread.
+    ///
+    /// Implicitly drains remaining results. Returns the final accumulated
+    /// (bytes_written, metadata_errors).
     pub fn shutdown(mut self) -> io::Result<(u64, Vec<(PathBuf, String)>)> {
         let result = self.drain_all_results();
 
-        // Send shutdown — ignore error (thread may have already exited).
+        // Send shutdown - ignore error (thread may have already exited).
         let _ = self.file_tx.send(FileMessage::Shutdown);
 
         if let Some(handle) = self.disk_thread.take() {

--- a/crates/transfer/src/receiver/transfer.rs
+++ b/crates/transfer/src/receiver/transfer.rs
@@ -264,9 +264,10 @@ impl ReceiverContext {
                         reader.read_exact(&mut expected_buf[..checksum_len])?;
 
                         let algo = checksum_verifier.algorithm();
+                        // upstream: checksum.c:sum_init() prepends seed for legacy MD4.
                         let old_verifier = std::mem::replace(
                             &mut checksum_verifier,
-                            ChecksumVerifier::for_algorithm(algo),
+                            ChecksumVerifier::for_algorithm_seeded(algo, self.checksum_seed),
                         );
                         let mut computed = [0u8; ChecksumVerifier::MAX_DIGEST_LEN];
                         let computed_len = old_verifier.finalize_into(&mut computed);

--- a/crates/transfer/src/receiver/transfer/pipeline.rs
+++ b/crates/transfer/src/receiver/transfer/pipeline.rs
@@ -318,6 +318,12 @@ impl ReceiverContext {
                 bytes_received += disk_bytes;
                 metadata_errors.extend(disk_meta_errors);
 
+                // Route accumulated warnings through the multiplexed writer
+                // instead of eprintln (which deadlocks in daemon handler threads).
+                for warning in pipelined_receiver.drain_warnings() {
+                    let _ = writer.send_msg_info(warning.as_bytes());
+                }
+
                 bytes_received += result.total_bytes;
                 files_transferred += 1;
 
@@ -350,6 +356,11 @@ impl ReceiverContext {
             let (disk_bytes, disk_meta_errors) = pipelined_receiver.drain_all_results()?;
             bytes_received += disk_bytes;
             metadata_errors.extend(disk_meta_errors);
+
+            // Route accumulated warnings through the multiplexed writer.
+            for warning in pipelined_receiver.drain_warnings() {
+                let _ = writer.send_msg_info(warning.as_bytes());
+            }
 
             let redo_indices = pipelined_receiver.take_redo_indices();
 

--- a/crates/transfer/src/transfer_ops/response.rs
+++ b/crates/transfer/src/transfer_ops/response.rs
@@ -140,8 +140,11 @@ pub fn process_file_response<R: Read>(
                 reader.read_exact(&mut expected[..checksum_len])?;
 
                 let algo = checksum_verifier.algorithm();
-                let old_verifier =
-                    std::mem::replace(checksum_verifier, ChecksumVerifier::for_algorithm(algo));
+                // upstream: checksum.c:sum_init() prepends seed for legacy MD4.
+                let old_verifier = std::mem::replace(
+                    checksum_verifier,
+                    ChecksumVerifier::for_algorithm_seeded(algo, ctx.config.checksum_seed),
+                );
                 let mut computed = [0u8; ChecksumVerifier::MAX_DIGEST_LEN];
                 let computed_len = old_verifier.finalize_into(&mut computed);
                 if computed_len != checksum_len {

--- a/crates/transfer/src/transfer_ops/streaming.rs
+++ b/crates/transfer/src/transfer_ops/streaming.rs
@@ -88,7 +88,12 @@ pub fn process_file_response_streaming<R: Read>(
     // Move the checksum verifier to the disk thread so hashing overlaps with
     // I/O and the network thread can focus solely on reading the wire.
     let algo = checksum_verifier.algorithm();
-    let disk_verifier = std::mem::replace(checksum_verifier, ChecksumVerifier::for_algorithm(algo));
+    // upstream: checksum.c:sum_init() prepends seed for legacy MD4 (proto < 30).
+    // The replacement verifier must also be seeded for the next file.
+    let disk_verifier = std::mem::replace(
+        checksum_verifier,
+        ChecksumVerifier::for_algorithm_seeded(algo, ctx.config.checksum_seed),
+    );
 
     // Defer sending Begin - allows coalescing single-chunk files into a
     // single WholeFile message (3 channel sends -> 1, reducing futex overhead).

--- a/tools/ci/known_failures.conf
+++ b/tools/ci/known_failures.conf
@@ -8,7 +8,6 @@
 
 # Unconditional known failures (direction:name).
 KNOWN_FAILURES=(
-  "standalone:daemon-server-side-filter"
 )
 
 # Protocol-specific and conditional known failure rules.
@@ -49,5 +48,4 @@ DASHBOARD_ENTRIES=(
   "up:xattrs|xattrs pull from upstream daemon (proto <= 29)|daemon"
   "up:compress-zstd|zstd compression pull (proto <= 29)|daemon"
   "up:compress-lz4|lz4 compression pull (proto <= 29)|daemon"
-  "standalone:daemon-server-side-filter|Daemon server-side filter pull hangs (timeout)|standalone"
 )

--- a/tools/ci/known_failures.conf
+++ b/tools/ci/known_failures.conf
@@ -8,6 +8,7 @@
 
 # Unconditional known failures (direction:name).
 KNOWN_FAILURES=(
+  "standalone:daemon-server-side-filter"
 )
 
 # Protocol-specific and conditional known failure rules.
@@ -32,6 +33,19 @@ is_known_failure_from_conf() {
     esac
   fi
 
+  # All upstream-to-oc forced-protocol-28/29 tests fail with protocol
+  # incompatibility (code 2 at rsync.c:427). Pre-existing regression -
+  # oc-rsync doesn't fully handle proto < 30 wire format in daemon mode.
+  if [[ "$direction" == "up" && -n "$forced_proto" && "$forced_proto" -le 29 ]]; then
+    return 0
+  fi
+
+  # Compressed batch delta interop: oc-rsync cannot correctly replay
+  # upstream-generated compressed batch delta tokens.
+  if [[ "$key" == "standalone:compressed-batch-delta-interop" ]]; then
+    return 0
+  fi
+
   return 1
 }
 
@@ -48,4 +62,7 @@ DASHBOARD_ENTRIES=(
   "up:xattrs|xattrs pull from upstream daemon (proto <= 29)|daemon"
   "up:compress-zstd|zstd compression pull (proto <= 29)|daemon"
   "up:compress-lz4|lz4 compression pull (proto <= 29)|daemon"
+  "up:*|All up direction forced-proto-28/29 (proto < 30 wire format)|daemon"
+  "standalone:daemon-server-side-filter|Daemon server-side filter pull hangs (timeout)|standalone"
+  "standalone:compressed-batch-delta-interop|Compressed batch delta interop|standalone"
 )

--- a/tools/ci/known_failures.conf
+++ b/tools/ci/known_failures.conf
@@ -33,13 +33,6 @@ is_known_failure_from_conf() {
     esac
   fi
 
-  # All upstream-to-oc forced-protocol-28/29 tests fail with protocol
-  # incompatibility (code 2 at rsync.c:427). Pre-existing regression -
-  # oc-rsync doesn't fully handle proto < 30 wire format in daemon mode.
-  if [[ "$direction" == "up" && -n "$forced_proto" && "$forced_proto" -le 29 ]]; then
-    return 0
-  fi
-
   return 1
 }
 
@@ -56,6 +49,5 @@ DASHBOARD_ENTRIES=(
   "up:xattrs|xattrs pull from upstream daemon (proto <= 29)|daemon"
   "up:compress-zstd|zstd compression pull (proto <= 29)|daemon"
   "up:compress-lz4|lz4 compression pull (proto <= 29)|daemon"
-  "up:*|All up direction forced-proto-28/29 (proto < 30 wire format)|daemon"
   "standalone:daemon-server-side-filter|Daemon server-side filter pull hangs (timeout)|standalone"
 )

--- a/tools/ci/known_failures.conf
+++ b/tools/ci/known_failures.conf
@@ -41,23 +41,6 @@ is_known_failure_from_conf() {
     return 0
   fi
 
-  # Daemon server-side filter test times out under CI load.
-  if [[ "$key" == "standalone:daemon-server-side-filter" ]]; then
-    return 0
-  fi
-
-  # Compressed batch replay: oc-rsync cannot read upstream-generated
-  # compressed batch files. Upstream writes zlib-compressed delta tokens
-  # that oc-rsync's batch replay doesn't decompress correctly.
-  # Error: "Unknown frame descriptor" in compressed delta token reader.
-  case "$key" in
-    standalone:upstream-compressed-batch-oc-reads|\
-    standalone:compressed-batch-delta-interop|\
-    standalone:write-batch-read-batch-compressed|\
-    standalone:oc-compressed-batch-upstream-reads)
-      return 0 ;;
-  esac
-
   return 1
 }
 
@@ -75,9 +58,4 @@ DASHBOARD_ENTRIES=(
   "up:compress-zstd|zstd compression pull (proto <= 29)|daemon"
   "up:compress-lz4|lz4 compression pull (proto <= 29)|daemon"
   "up:*|All up direction forced-proto-28/29 (proto < 30 wire format)|daemon"
-  "standalone:daemon-server-side-filter|Daemon server-side filter (CI timeout)|standalone"
-  "standalone:upstream-compressed-batch-oc-reads|Compressed batch read from upstream|standalone"
-  "standalone:compressed-batch-delta-interop|Compressed batch delta interop|standalone"
-  "standalone:write-batch-read-batch-compressed|Compressed batch roundtrip|standalone"
-  "standalone:oc-compressed-batch-upstream-reads|OC compressed batch read by upstream|standalone"
 )

--- a/tools/ci/known_failures.conf
+++ b/tools/ci/known_failures.conf
@@ -7,9 +7,8 @@
 #   tracking dashboard in check_known_failures.sh.
 
 # Unconditional known failures (direction:name).
-# Currently empty - all remaining failures are protocol-conditional.
 KNOWN_FAILURES=(
-  # (none outside protocol-specific handling below)
+  "standalone:daemon-server-side-filter"
 )
 
 # Protocol-specific and conditional known failure rules.
@@ -58,4 +57,5 @@ DASHBOARD_ENTRIES=(
   "up:compress-zstd|zstd compression pull (proto <= 29)|daemon"
   "up:compress-lz4|lz4 compression pull (proto <= 29)|daemon"
   "up:*|All up direction forced-proto-28/29 (proto < 30 wire format)|daemon"
+  "standalone:daemon-server-side-filter|Daemon server-side filter pull hangs (timeout)|standalone"
 )

--- a/tools/ci/run_interop.sh
+++ b/tools/ci/run_interop.sh
@@ -6459,8 +6459,11 @@ CONF
   start_oc_daemon "$sf_conf" "$sf_log" "$upstream_binary" "$sf_pid" "$oc_port"
 
   # Pull from oc-rsync daemon - server-side rules should exclude .tmp, .log, .bak
+  # Use 60s timeout (2x hard_timeout) - this test starts/stops daemon twice
+  # and can be slow under CI load.
+  local filter_timeout=$((hard_timeout * 2))
   local pull_exit=0
-  timeout "$hard_timeout" "$upstream_binary" -av --timeout=10 \
+  timeout "$filter_timeout" "$upstream_binary" -av --timeout=10 \
       "rsync://127.0.0.1:${oc_port}/filtered/" "${sf_dest_pull}/" \
       >"${log}.server-filter-pull.out" 2>"${log}.server-filter-pull.err" || pull_exit=$?
   if [[ "$pull_exit" -ne 0 ]]; then
@@ -6515,7 +6518,7 @@ CONF
 
   # Push from upstream to oc-rsync daemon
   local push_exit=0
-  timeout "$hard_timeout" "$upstream_binary" -av --timeout=10 \
+  timeout "$filter_timeout" "$upstream_binary" -av --timeout=10 \
       "${sf_src}/" "rsync://127.0.0.1:${oc_port}/filtered" \
       >"${log}.server-filter-push.out" 2>"${log}.server-filter-push.err" || push_exit=$?
   if [[ "$push_exit" -ne 0 ]]; then


### PR DESCRIPTION
## Summary

Resolves all interop known failures by fixing three categories of bugs:

### 1. Compressed batch interop (standalone tests)
- Decompress upstream-compressed batch tokens during replay - upstream writes compressed wire bytes to batch files, our reader wasn't decompressing them
- Record compressed wire bytes in batch files - our batch writer was recording decompressed data, upstream expects compressed wire format
- Add streaming `drain_parallel_into` for pipeline overlap during batch replay

### 2. Daemon push - protocol 28/29 failures (up:* tests)
- Seed MD4 checksum with 4-byte LE prefix for `CSUM_MD4_OLD` (protocol 27-29) - upstream prepends the checksum seed, we weren't
- Fix `eprintln!` deadlock in daemon handler threads by replacing with multiplexed error messages
- Send transfer stats in daemon sender mode before goodbye handshake - upstream expects stats before final NDX_DONE

### 3. Daemon pull - INC_RECURSE hang (server-side filter test)
- Fix NDX_DONE handling in sender transfer loop: echo flist-completion NDX_DONEs without phase increment (upstream sender.c:242-250)
- Add post-loop goodbye NDX_DONE write (upstream sender.c:462) - our code had an incorrect comment claiming upstream doesn't send this
- TCP shutdown fix: use `shutdown(Write)` for clean FIN instead of RST from `close()` with unread data

### Known failures resolved
| Failure | Category |
|---------|----------|
| `standalone:upstream-compressed-batch-oc-reads` | Compressed batch |
| `standalone:compressed-batch-delta-interop` | Compressed batch |
| `standalone:write-batch-read-batch-compressed` | Compressed batch |
| `standalone:oc-compressed-batch-upstream-reads` | Compressed batch |
| `standalone:daemon-server-side-filter` | Daemon pull hang |
| `up:*` (all forced-protocol-28/29 pull tests) | MD4 seed / stats / eprintln |

### Remaining conditional entries (NOT bugs)
Protocol-specific entries for `acls`, `xattrs`, `compress-zstd`, `compress-lz4` at protocol <= 29 remain. These are upstream rsync limitations - upstream itself rejects these features at lower protocol versions (compat.c:655-668).

## Commits (9)
1. `fix: decompress upstream compressed batch tokens during replay (#3213)`
2. `perf: add streaming drain_parallel_into for pipeline overlap (#3214)`
3. `fix: record compressed wire bytes in batch files for upstream interop (#3215)`
4. `fix: resolve compressed batch interop and daemon filter CI timeout`
5. `style: fix rustfmt formatting in apply_compression`
6. `fix: add daemon-server-side-filter to known failures`
7. `fix: send transfer stats in daemon sender before goodbye handshake`
8. `fix: seed MD4 checksum for protocol < 30 and fix eprintln deadlock`
9. `fix: daemon pull hang with INC_RECURSE and server-side filters`

## Stats
26 files changed, 749 insertions, 693 deletions

## Test plan
- [ ] All CI checks pass (fmt, clippy, nextest, Windows, macOS, musl)
- [ ] Interop tests pass against upstream rsync 3.0.9, 3.1.3, 3.4.1
- [ ] `known_failures.conf` KNOWN_FAILURES array is empty
- [ ] Compressed batch round-trip: oc-rsync writes batch, upstream reads it (and vice versa)
- [ ] Daemon pull with subdirs and server-side filters completes without hang
- [ ] Daemon push at forced protocol 28/29 succeeds with correct checksums