### PR TITLE
fix: resolve daemon-server-side-filter CI timeout

### DIFF
--- a/tools/ci/known_failures.conf
+++ b/tools/ci/known_failures.conf
@@ -7,8 +7,9 @@
 #   tracking dashboard in check_known_failures.sh.
 
 # Unconditional known failures (direction:name).
+# Currently empty - all remaining failures are protocol-conditional or batch-specific.
 KNOWN_FAILURES=(
-  "standalone:daemon-server-side-filter"
+  # (none outside protocol-specific handling below)
 )
 
 # Protocol-specific and conditional known failure rules.
@@ -63,6 +64,5 @@ DASHBOARD_ENTRIES=(
   "up:compress-zstd|zstd compression pull (proto <= 29)|daemon"
   "up:compress-lz4|lz4 compression pull (proto <= 29)|daemon"
   "up:*|All up direction forced-proto-28/29 (proto < 30 wire format)|daemon"
-  "standalone:daemon-server-side-filter|Daemon server-side filter pull hangs (timeout)|standalone"
   "standalone:compressed-batch-delta-interop|Compressed batch delta interop|standalone"
 )

--- a/tools/ci/run_interop.sh
+++ b/tools/ci/run_interop.sh
@@ -6456,11 +6456,8 @@ exclude = *.log
 filter = exclude *.bak
 CONF
 
-  start_oc_daemon "$sf_conf" "$sf_log" "$upstream_binary" "$sf_pid" "$oc_port"
+  start_oc_daemon_with_retry "$sf_conf" "$sf_log" "$upstream_binary" "$sf_pid" "$oc_port"
 
-  # Pull from oc-rsync daemon - server-side rules should exclude .tmp, .log, .bak
-  # Use 60s timeout (2x hard_timeout) - this test starts/stops daemon twice
-  # and can be slow under CI load.
   local filter_timeout=$((hard_timeout * 2))
   local pull_exit=0
   timeout "$filter_timeout" "$upstream_binary" -av --timeout=10 \
@@ -6514,7 +6511,7 @@ exclude = *.log
 filter = exclude *.bak
 CONF
 
-  start_oc_daemon "$sf_push_conf" "$sf_push_log" "$upstream_binary" "$sf_push_pid" "$oc_port"
+  start_oc_daemon_with_retry "$sf_push_conf" "$sf_push_log" "$upstream_binary" "$sf_push_pid" "$oc_port"
 
   # Push from upstream to oc-rsync daemon
   local push_exit=0


### PR DESCRIPTION
## Summary
- Use `start_oc_daemon_with_retry` (exponential backoff) instead of `start_oc_daemon` for the server-side filter interop test
- The test works correctly but times out under CI load when the daemon is slow to bind its port
- Remove `standalone:daemon-server-side-filter` from known failures and dashboard

## Test plan
- [ ] Interop CI passes with daemon-server-side-filter no longer in known failures
- [ ] Verified locally in container: pull and push both work with exclude/filter directives