### PR TITLE
fix: narrow proto 28/29 known failures to compress and hardlinks only

### DIFF
--- a/tools/ci/known_failures.conf
+++ b/tools/ci/known_failures.conf
@@ -34,11 +34,22 @@ is_known_failure_from_conf() {
     esac
   fi
 
-  # All upstream-to-oc forced-protocol-28/29 tests fail with protocol
-  # incompatibility (code 2 at rsync.c:427). Pre-existing regression -
-  # oc-rsync doesn't fully handle proto < 30 wire format in daemon mode.
+  # Upstream-to-oc compression at proto <= 29: CPRES_ZLIB mode requires
+  # dictionary-based decompression with see_deflate_token history feeding.
+  # oc-rsync only implements CPRES_ZLIBX (per-token flush, proto >= 30).
   if [[ "$direction" == "up" && -n "$forced_proto" && "$forced_proto" -le 29 ]]; then
-    return 0
+    case "$name" in
+      compress-level-*|compress-delta) return 0 ;;
+    esac
+  fi
+
+  # Upstream-to-oc hardlinks at proto <= 29: wire format uses dev+ino pairs
+  # (longint) instead of varint indices (proto >= 30). oc-rsync daemon
+  # receiver does not correctly handle the pre-30 hardlink wire format.
+  if [[ "$direction" == "up" && -n "$forced_proto" && "$forced_proto" -le 29 ]]; then
+    case "$name" in
+      hardlinks-*) return 0 ;;
+    esac
   fi
 
   # Compressed batch delta interop: oc-rsync cannot correctly replay
@@ -63,6 +74,8 @@ DASHBOARD_ENTRIES=(
   "up:xattrs|xattrs pull from upstream daemon (proto <= 29)|daemon"
   "up:compress-zstd|zstd compression pull (proto <= 29)|daemon"
   "up:compress-lz4|lz4 compression pull (proto <= 29)|daemon"
-  "up:*|All up direction forced-proto-28/29 (proto < 30 wire format)|daemon"
+  "up:compress-level-*|Compression CPRES_ZLIB mode (proto <= 29)|daemon"
+  "up:compress-delta|Compression delta CPRES_ZLIB mode (proto <= 29)|daemon"
+  "up:hardlinks-*|Hardlinks dev+ino wire format (proto <= 29)|daemon"
   "standalone:compressed-batch-delta-interop|Compressed batch delta interop|standalone"
 )


### PR DESCRIPTION
## Summary

- Replace the blanket rule marking ALL upstream-to-oc proto <= 29 tests as known failures with two specific rules targeting only the scenarios that actually fail
- Compression (`compress-level-*`, `compress-delta`): CPRES_ZLIB dictionary mode not implemented - oc-rsync only supports CPRES_ZLIBX per-token flush (proto >= 30)
- Hardlinks (`hardlinks-*`): pre-30 dev+ino wire format not handled in daemon receiver (proto >= 30 uses varint indices)
- Update dashboard entries to match the narrowed rules

Comprehensive container testing confirmed 12/14 scenario categories pass at proto 28 in the upstream-to-oc direction: archive, relative, checksum, whole-file, delta, inplace, numeric-ids, symlinks, delete, exclude, permissions, itemize.

## Test plan

- [ ] CI interop tests pass with the narrowed known failure rules
- [ ] Verify compress and hardlinks scenarios are still correctly marked as known failures
- [ ] Verify previously-blanket-failed scenarios (archive, checksum, etc.) now run and pass