### PR TITLE
fix: correct CPRES_ZLIB dictionary sync in compressed batch replay

### DIFF
--- a/crates/batch/src/replay.rs
+++ b/crates/batch/src/replay.rs
@@ -776,8 +776,10 @@ pub fn replay(
                     match token {
                         CompressedToken::End => break,
                         CompressedToken::Literal(data) => {
-                            // upstream: receiver.c - see_token(buf, len) after literal
-                            decoder.see_token(&data).map_err(BatchError::Io)?;
+                            // Literals already pass through inflate in recv_token(),
+                            // which updates the decompressor dictionary. Do NOT call
+                            // see_token() here - upstream receiver.c only calls
+                            // see_token() for block matches, not literals.
                             ops.push(protocol::wire::DeltaOp::Literal(data));
                         }
                         CompressedToken::BlockMatch(block_index) => {


### PR DESCRIPTION
## Summary

- Remove erroneous `see_token()` call on literal data during CPRES_ZLIB compressed batch replay
- Remove `compressed-batch-delta-interop` from known_failures.conf

## Root Cause

Upstream `receiver.c:receive_data()` only calls `see_token()` for block matches - never for literals. Literals already pass through `inflate()` during `recv_token()`, which updates the decompressor dictionary. Our code incorrectly called `see_token()` on literal data too, double-feeding it into the dictionary and corrupting the inflate state.

This caused "invalid distance too far back" zlib errors when replaying upstream-generated compressed batch files that contained delta transfers with block matches.

## Test plan

- [x] Verified in rsync-profile container: upstream writes compressed batch with `--compress-choice=zlib`, oc-rsync reads it back, files match
- [x] Tested with delta transfers (block matches + literal tails) - the critical path
- [x] Stress tested with 21 files of varying sizes and compression level 6
- [ ] CI interop validation passes with compressed-batch-delta-interop removed from known failures