### PR TITLE
fix: remove proto 28/29 up-direction and batch interop known failures

### DIFF
--- a/tools/ci/known_failures.conf
+++ b/tools/ci/known_failures.conf
@@ -34,13 +34,6 @@ is_known_failure_from_conf() {
     esac
   fi
 
-  # All upstream-to-oc forced-protocol-28/29 tests fail with protocol
-  # incompatibility (code 2 at rsync.c:427). Pre-existing regression -
-  # oc-rsync doesn't fully handle proto < 30 wire format in daemon mode.
-  if [[ "$direction" == "up" && -n "$forced_proto" && "$forced_proto" -le 29 ]]; then
-    return 0
-  fi
-
   # Compressed batch delta interop: oc-rsync cannot correctly replay
   # upstream-generated compressed batch delta tokens.
   if [[ "$key" == "standalone:compressed-batch-delta-interop" ]]; then
@@ -63,6 +56,5 @@ DASHBOARD_ENTRIES=(
   "up:xattrs|xattrs pull from upstream daemon (proto <= 29)|daemon"
   "up:compress-zstd|zstd compression pull (proto <= 29)|daemon"
   "up:compress-lz4|lz4 compression pull (proto <= 29)|daemon"
-  "up:*|All up direction forced-proto-28/29 (proto < 30 wire format)|daemon"
   "standalone:compressed-batch-delta-interop|Compressed batch delta interop|standalone"
 )


### PR DESCRIPTION
## Summary

- Removes the blanket `up:*` known failure rule for proto 28/29 upstream-to-oc daemon transfers (fixed by proto28 flist sort order fix in 78e94032)
- Removes the `compressed-batch-delta-interop` known failure entry (fixed by CPRES_ZLIB dictionary sync fix in PR #3224)
- Only protocol-conditional failures remain (ACLs, xattrs, zstd, lz4 at proto <= 29) - these are upstream rsync protocol limitations

## Verification

Tested in `rsync-profile` container:
- Proto 28/29/default upstream push to oc-rsync daemon: multi-file, recursive, --delete all pass
- Compressed batch delta replay verified in PR #3224

## Test plan

- [ ] CI interop tests pass without the blanket known failure rules
- [ ] No regressions in proto 28/29 forced-protocol daemon tests