### PR TITLE
docs: add upstream source refs to known failure comments

### DIFF
--- a/tools/ci/known_failures.conf
+++ b/tools/ci/known_failures.conf
@@ -24,13 +24,35 @@ is_known_failure_from_conf() {
     [[ "$kf" == "$key" ]] && return 0
   done
 
-  # Protocol-specific known failures: features that upstream rsync itself
-  # rejects when forced to a lower protocol version.
+  # Protocol-specific known failures: upstream rsync hard-rejects these
+  # features when the negotiated protocol version is below 30. These are
+  # NOT oc-rsync bugs - upstream rsync itself fails identically.
   if [[ -n "$forced_proto" && "$forced_proto" -le 29 ]]; then
-    # ACLs and xattrs require protocol >= 30 (upstream compat.c:655-668).
-    # compress-choice (zstd/lz4) requires negotiation which needs protocol >= 30.
     case "$name" in
-      acls|xattrs|compress-zstd|compress-lz4) return 0 ;;
+      # upstream compat.c:655-661 setup_protocol():
+      #   if (preserve_acls && !local_server) {
+      #     rprintf(FERROR, "--acls requires protocol 30 or higher (negotiated %d).\n", protocol_version);
+      #     exit_cleanup(RERR_PROTOCOL);
+      #   }
+      # ACL wire format fields were added in protocol 30; older protocols
+      # lack the flist encoding for ACL data entirely.
+      acls) return 0 ;;
+
+      # upstream compat.c:662-668 setup_protocol():
+      #   if (preserve_xattrs && !local_server) {
+      #     rprintf(FERROR, "--xattrs requires protocol 30 or higher (negotiated %d).\n", protocol_version);
+      #     exit_cleanup(RERR_PROTOCOL);
+      #   }
+      # Xattr wire format fields were added in protocol 30; same as ACLs.
+      xattrs) return 0 ;;
+
+      # upstream compat.c:556-564 negotiate_the_strings() + compat.c:729-742:
+      #   do_negotiated_strings is only set when the 'v' compat flag is present,
+      #   which requires protocol >= 30. At protocol < 30, compression algorithm
+      #   negotiation is skipped entirely and upstream falls back to hardcoded
+      #   "zlib" (strlcpy(tmpbuf, "zlib", MAX_NSTR_STRLEN)). zstd and lz4 cannot
+      #   be selected without the vstring negotiation mechanism.
+      compress-zstd|compress-lz4) return 0 ;;
     esac
   fi
 
@@ -42,12 +64,15 @@ is_known_failure_from_conf() {
 # test_method: "daemon" for scenario-based, "standalone" for standalone tests.
 # Keep in sync with actual known failure rules above.
 DASHBOARD_ENTRIES=(
-  "oc:acls|ACLs push to upstream daemon (proto <= 29)|daemon"
-  "oc:xattrs|xattrs push to upstream daemon (proto <= 29)|daemon"
-  "oc:compress-zstd|zstd compression (proto <= 29)|daemon"
-  "oc:compress-lz4|lz4 compression (proto <= 29)|daemon"
-  "up:acls|ACLs pull from upstream daemon (proto <= 29)|daemon"
-  "up:xattrs|xattrs pull from upstream daemon (proto <= 29)|daemon"
-  "up:compress-zstd|zstd compression pull (proto <= 29)|daemon"
-  "up:compress-lz4|lz4 compression pull (proto <= 29)|daemon"
+  # ACLs: upstream compat.c:655-661 - hard error RERR_PROTOCOL at proto < 30
+  "oc:acls|ACLs push to upstream daemon (proto <= 29, upstream compat.c:655-661)|daemon"
+  "up:acls|ACLs pull from upstream daemon (proto <= 29, upstream compat.c:655-661)|daemon"
+  # Xattrs: upstream compat.c:662-668 - hard error RERR_PROTOCOL at proto < 30
+  "oc:xattrs|xattrs push to upstream daemon (proto <= 29, upstream compat.c:662-668)|daemon"
+  "up:xattrs|xattrs pull from upstream daemon (proto <= 29, upstream compat.c:662-668)|daemon"
+  # Compress-choice: upstream compat.c:556-564 - no vstring negotiation at proto < 30
+  "oc:compress-zstd|zstd compression (proto <= 29, upstream compat.c:556-564)|daemon"
+  "oc:compress-lz4|lz4 compression (proto <= 29, upstream compat.c:556-564)|daemon"
+  "up:compress-zstd|zstd compression pull (proto <= 29, upstream compat.c:556-564)|daemon"
+  "up:compress-lz4|lz4 compression pull (proto <= 29, upstream compat.c:556-564)|daemon"
 )


### PR DESCRIPTION
## Summary

- Add precise upstream `compat.c` line references and C code snippets to each known failure entry in `known_failures.conf`
- Clarify that all 8 remaining known failures are upstream rsync protocol design limitations, not oc-rsync bugs
- Group dashboard entries by failure category with upstream references

### Upstream limitations documented:

| Feature | Upstream Code | Behavior at proto < 30 |
|---------|--------------|------------------------|
| ACLs | `compat.c:655-661` | Hard error: `exit_cleanup(RERR_PROTOCOL)` |
| Xattrs | `compat.c:662-668` | Hard error: `exit_cleanup(RERR_PROTOCOL)` |
| compress-zstd | `compat.c:556-564` | Silent downgrade to zlib (no negotiation) |
| compress-lz4 | `compat.c:556-564` | Silent downgrade to zlib (no negotiation) |

## Test plan

- [ ] CI passes (no functional changes, comments only)