### PR TITLE
feat: add platform I/O capability detection to --version output

### DIFF
--- a/crates/core/src/version/report/renderer.rs
+++ b/crates/core/src/version/report/renderer.rs
@@ -186,12 +186,30 @@ impl VersionInfoReport {
     pub fn write_human_readable<W: FmtWrite>(&self, writer: &mut W) -> fmt::Result {
         self.metadata.write_standard_banner(writer)?;
         self.write_info_sections(writer)?;
+        self.write_platform_io(writer)?;
         self.write_named_list(writer, "Checksum list", &self.checksum_algorithms)?;
         self.write_named_list(writer, "Compress list", &self.compress_algorithms)?;
         self.write_named_list(writer, "Daemon auth list", &self.daemon_auth_algorithms)?;
         writer.write_char('\n')?;
 
         self.write_gpl_footer(writer)
+    }
+
+    /// Writes the "Platform I/O" section listing runtime-detected fast I/O paths.
+    fn write_platform_io<W: FmtWrite>(&self, writer: &mut W) -> fmt::Result {
+        let caps = fast_io::platform_io_capabilities();
+        if caps.is_empty() {
+            return Ok(());
+        }
+        write!(writer, "Platform I/O:")?;
+        for (i, cap) in caps.iter().enumerate() {
+            if i > 0 {
+                writer.write_char(',')?;
+            }
+            writer.write_char(' ')?;
+            writer.write_str(cap)?;
+        }
+        writer.write_char('\n')
     }
 
     /// Internal helper for the GPL footer. Single fmt call, no allocations.
@@ -509,6 +527,18 @@ mod tests {
         let report = VersionInfoReport::default();
         let output = report.human_readable();
         assert!(output.contains("Optimizations:"));
+    }
+
+    #[test]
+    fn human_readable_contains_platform_io_on_supported_platforms() {
+        let report = VersionInfoReport::default();
+        let output = report.human_readable();
+        let caps = fast_io::platform_io_capabilities();
+        if caps.is_empty() {
+            assert!(!output.contains("Platform I/O:"));
+        } else {
+            assert!(output.contains("Platform I/O:"));
+        }
     }
 
     #[test]

--- a/crates/core/src/version/tests/report.rs
+++ b/crates/core/src/version/tests/report.rs
@@ -79,7 +79,10 @@ fn version_info_report_renders_default_report() {
     if !platform_caps.is_empty() {
         assert!(actual.contains("Platform I/O:"));
         for cap in &platform_caps {
-            assert!(actual.contains(cap), "missing Platform I/O capability: {cap}");
+            assert!(
+                actual.contains(cap),
+                "missing Platform I/O capability: {cap}"
+            );
         }
     }
 
@@ -95,10 +98,7 @@ fn version_info_report_contains_platform_io_section() {
     if platform_caps.is_empty() {
         assert!(!rendered.contains("Platform I/O:"));
     } else {
-        let expected_line = format!(
-            "Platform I/O: {}",
-            platform_caps.join(", ")
-        );
+        let expected_line = format!("Platform I/O: {}", platform_caps.join(", "));
         assert!(
             rendered.contains(&expected_line),
             "expected Platform I/O line:\n  {expected_line}\nin:\n{rendered}"

--- a/crates/core/src/version/tests/report.rs
+++ b/crates/core/src/version/tests/report.rs
@@ -3,6 +3,7 @@ use crate::branding::Brand;
 use crate::version::report::{
     default_checksum_algorithms, default_compress_algorithms, default_daemon_auth_algorithms,
 };
+use fast_io::platform_io_capabilities;
 use libc::{ino_t, off_t};
 use std::mem;
 
@@ -74,7 +75,35 @@ fn version_info_report_renders_default_report() {
     assert!(actual.contains(&format!(
         "Daemon auth list:\n    {daemon_auth_algorithms}\n"
     )));
+    let platform_caps = platform_io_capabilities();
+    if !platform_caps.is_empty() {
+        assert!(actual.contains("Platform I/O:"));
+        for cap in &platform_caps {
+            assert!(actual.contains(cap), "missing Platform I/O capability: {cap}");
+        }
+    }
+
     assert!(actual.ends_with(&gpl_footer(PROGRAM_NAME)));
+}
+
+#[test]
+fn version_info_report_contains_platform_io_section() {
+    let report = VersionInfoReport::new(VersionInfoConfig::default());
+    let rendered = report.human_readable();
+    let platform_caps = platform_io_capabilities();
+
+    if platform_caps.is_empty() {
+        assert!(!rendered.contains("Platform I/O:"));
+    } else {
+        let expected_line = format!(
+            "Platform I/O: {}",
+            platform_caps.join(", ")
+        );
+        assert!(
+            rendered.contains(&expected_line),
+            "expected Platform I/O line:\n  {expected_line}\nin:\n{rendered}"
+        );
+    }
 }
 
 #[test]

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -139,6 +139,57 @@ pub use io_uring::{
     socket_reader_from_fd, socket_writer_from_fd,
 };
 
+/// Returns the platform I/O capabilities available on this system.
+///
+/// Each entry is a human-readable label describing an available fast I/O path.
+/// Compile-time capabilities (determined by target OS) are always included when
+/// applicable. Runtime-probed capabilities (io_uring, splice) are included only
+/// when the probe succeeds.
+///
+/// # Platform-specific entries
+///
+/// - **Linux**: `copy_file_range`, `sendfile`, `splice` (runtime-probed),
+///   `FICLONE`, `O_TMPFILE`, `io_uring` (runtime-probed)
+/// - **macOS**: `clonefile`, `fcopyfile`
+/// - **Windows**: `CopyFileEx`
+#[must_use]
+pub fn platform_io_capabilities() -> Vec<&'static str> {
+    let mut caps = Vec::new();
+
+    // Linux compile-time capabilities
+    #[cfg(target_os = "linux")]
+    {
+        caps.push("copy_file_range");
+        caps.push("sendfile");
+
+        if is_splice_available() {
+            caps.push("splice");
+        }
+
+        caps.push("FICLONE");
+        caps.push("O_TMPFILE");
+
+        if is_io_uring_available() {
+            caps.push("io_uring");
+        }
+    }
+
+    // macOS compile-time capabilities
+    #[cfg(target_os = "macos")]
+    {
+        caps.push("clonefile");
+        caps.push("fcopyfile");
+    }
+
+    // Windows compile-time capabilities
+    #[cfg(target_os = "windows")]
+    {
+        caps.push("CopyFileEx");
+    }
+
+    caps
+}
+
 /// Policy controlling io_uring usage for file and socket I/O.
 ///
 /// This enum allows callers to explicitly enable, disable, or auto-detect
@@ -189,4 +240,42 @@ pub enum IoUringPolicy {
     ///
     /// Useful for benchmarking or diagnosing io_uring-related issues.
     Disabled,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn platform_io_capabilities_returns_expected_entries() {
+        let caps = platform_io_capabilities();
+
+        #[cfg(target_os = "linux")]
+        {
+            assert!(caps.contains(&"copy_file_range"));
+            assert!(caps.contains(&"sendfile"));
+            assert!(caps.contains(&"FICLONE"));
+            assert!(caps.contains(&"O_TMPFILE"));
+        }
+
+        #[cfg(target_os = "macos")]
+        {
+            assert!(caps.contains(&"clonefile"));
+            assert!(caps.contains(&"fcopyfile"));
+        }
+
+        #[cfg(target_os = "windows")]
+        {
+            assert!(caps.contains(&"CopyFileEx"));
+        }
+    }
+
+    #[test]
+    fn platform_io_capabilities_has_no_duplicates() {
+        let caps = platform_io_capabilities();
+        let mut seen = std::collections::HashSet::new();
+        for cap in &caps {
+            assert!(seen.insert(cap), "duplicate capability: {cap}");
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- Add `platform_io_capabilities()` function to `fast_io` that returns available fast I/O paths per platform (compile-time and runtime-probed)
- Add a "Platform I/O" section to `--version` output between Optimizations and Checksum list, showing detected capabilities
- Linux shows: `copy_file_range`, `sendfile`, `splice` (probed), `FICLONE`, `O_TMPFILE`, `io_uring` (probed)
- macOS shows: `clonefile`, `fcopyfile`
- Windows shows: `CopyFileEx`

Example output on macOS:
```
Platform I/O: clonefile, fcopyfile
```

## Test plan

- [ ] `platform_io_capabilities_returns_expected_entries` - verifies correct entries per platform
- [ ] `platform_io_capabilities_has_no_duplicates` - no duplicate labels
- [ ] `human_readable_contains_platform_io_on_supported_platforms` - section present when capabilities exist
- [ ] `version_info_report_contains_platform_io_section` - correct formatted line in version output
- [ ] Existing CLI/daemon version tests pass unchanged (they compare against the same `human_readable()` function)
- [ ] CI: Linux, macOS, Windows matrix all pass