### PR TITLE
feat: add debug_assert for strictly monotonic NDX emission

### DIFF
--- a/crates/protocol/src/codec/mod.rs
+++ b/crates/protocol/src/codec/mod.rs
@@ -52,9 +52,10 @@ pub use protocol::{
 
 /// NDX (file index) codec types for file list operations.
 pub use ndx::{
-    LegacyNdxCodec, ModernNdxCodec, NDX_DEL_STATS, NDX_DONE, NDX_DONE_LEGACY_BYTES,
-    NDX_DONE_MODERN_BYTE, NDX_FLIST_EOF, NDX_FLIST_OFFSET, NdxCodec, NdxCodecEnum, NdxState,
-    create_ndx_codec, read_goodbye, write_goodbye, write_ndx_done, write_ndx_flist_eof,
+    LegacyNdxCodec, ModernNdxCodec, MonotonicNdxWriter, NDX_DEL_STATS, NDX_DONE,
+    NDX_DONE_LEGACY_BYTES, NDX_DONE_MODERN_BYTE, NDX_FLIST_EOF, NDX_FLIST_OFFSET, NdxCodec,
+    NdxCodecEnum, NdxState, create_ndx_codec, read_goodbye, write_goodbye, write_ndx_done,
+    write_ndx_flist_eof,
 };
 
 /// Unified container for all protocol version-aware codecs.

--- a/crates/protocol/src/codec/ndx/codec.rs
+++ b/crates/protocol/src/codec/ndx/codec.rs
@@ -353,3 +353,69 @@ impl NdxCodec for NdxCodecEnum {
 pub fn create_ndx_codec(protocol_version: u8) -> NdxCodecEnum {
     NdxCodecEnum::new(protocol_version)
 }
+
+/// NDX codec wrapper that asserts strictly monotonic positive file indices.
+///
+/// Wraps an [`NdxCodecEnum`] and adds a `debug_assert!` in `write_ndx` to
+/// verify that each positive NDX (file index) is strictly greater than the
+/// previous one. Negative sentinel values (NDX_DONE, NDX_FLIST_EOF, etc.)
+/// are excluded from this check since they are control signals, not file
+/// indices.
+///
+/// Use this at wire-emission points (generator/receiver transfer loops) to
+/// catch ordering violations from parallel processing before they become
+/// protocol errors.
+///
+/// In release builds, the assertion is compiled out and this wrapper has
+/// zero overhead.
+#[derive(Debug, Clone)]
+pub struct MonotonicNdxWriter {
+    /// Inner codec that performs the actual wire encoding.
+    inner: NdxCodecEnum,
+    /// Tracks the last positive NDX written for monotonicity verification.
+    #[cfg(debug_assertions)]
+    last_positive: Option<i32>,
+}
+
+impl MonotonicNdxWriter {
+    /// Creates a new monotonic NDX writer for the given protocol version.
+    #[must_use]
+    pub fn new(protocol_version: u8) -> Self {
+        Self {
+            inner: NdxCodecEnum::new(protocol_version),
+            #[cfg(debug_assertions)]
+            last_positive: None,
+        }
+    }
+}
+
+impl NdxCodec for MonotonicNdxWriter {
+    fn write_ndx<W: Write + ?Sized>(&mut self, writer: &mut W, ndx: i32) -> io::Result<()> {
+        // Only check positive file indices - negative values are sentinels
+        // (NDX_DONE, NDX_FLIST_EOF, NDX_DEL_STATS, NDX_FLIST_OFFSET).
+        #[cfg(debug_assertions)]
+        if ndx >= 0 {
+            if let Some(prev) = self.last_positive {
+                debug_assert!(
+                    ndx > prev,
+                    "NDX monotonicity violation: emitted {ndx} after {prev} - \
+                     file indices must be strictly increasing on the wire"
+                );
+            }
+            self.last_positive = Some(ndx);
+        }
+        self.inner.write_ndx(writer, ndx)
+    }
+
+    fn write_ndx_done<W: Write + ?Sized>(&mut self, writer: &mut W) -> io::Result<()> {
+        self.inner.write_ndx_done(writer)
+    }
+
+    fn read_ndx<R: Read + ?Sized>(&mut self, reader: &mut R) -> io::Result<i32> {
+        self.inner.read_ndx(reader)
+    }
+
+    fn protocol_version(&self) -> u8 {
+        self.inner.protocol_version()
+    }
+}

--- a/crates/protocol/src/codec/ndx/mod.rs
+++ b/crates/protocol/src/codec/ndx/mod.rs
@@ -46,7 +46,9 @@ mod state;
 #[cfg(test)]
 mod tests;
 
-pub use codec::{LegacyNdxCodec, ModernNdxCodec, NdxCodec, NdxCodecEnum, create_ndx_codec};
+pub use codec::{
+    LegacyNdxCodec, ModernNdxCodec, MonotonicNdxWriter, NdxCodec, NdxCodecEnum, create_ndx_codec,
+};
 pub use constants::{
     NDX_DEL_STATS, NDX_DONE, NDX_DONE_LEGACY_BYTES, NDX_DONE_MODERN_BYTE, NDX_FLIST_EOF,
     NDX_FLIST_OFFSET,

--- a/crates/transfer/src/generator/mod.rs
+++ b/crates/transfer/src/generator/mod.rs
@@ -43,7 +43,7 @@ use std::path::PathBuf;
 use std::time::Instant;
 
 use ::filters::FilterChain;
-use protocol::codec::NdxCodecEnum;
+use protocol::codec::{MonotonicNdxWriter, NdxCodecEnum};
 use protocol::flist::FileEntry;
 use protocol::idlist::IdList;
 use protocol::stats::DeleteStats;
@@ -726,7 +726,8 @@ struct TransferLoopResult {
     /// NDX read codec state carried over for the goodbye handshake.
     ndx_read_codec: NdxCodecEnum,
     /// NDX write codec state carried over for the goodbye handshake.
-    ndx_write_codec: NdxCodecEnum,
+    /// Uses `MonotonicNdxWriter` to assert strictly increasing file indices.
+    ndx_write_codec: MonotonicNdxWriter,
 }
 
 /// Statistics from a generator (sender) transfer operation.

--- a/crates/transfer/src/generator/protocol_io.rs
+++ b/crates/transfer/src/generator/protocol_io.rs
@@ -94,7 +94,7 @@ impl GeneratorContext {
     pub(super) fn write_ndx_and_attrs<W: Write>(
         &self,
         writer: &mut W,
-        ndx_codec: &mut NdxCodecEnum,
+        ndx_codec: &mut impl NdxCodec,
         ndx: i32,
         iflags: &ItemFlags,
         sum_head: &SumHead,

--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -1879,7 +1879,7 @@ fn to_exit_code_no_errors_returns_zero() {
 /// upstream: main.c:875-906 `read_final_goodbye()`
 mod legacy_goodbye_tests {
     use super::*;
-    use protocol::codec::create_ndx_codec;
+    use protocol::codec::{MonotonicNdxWriter, create_ndx_codec};
 
     /// NDX_DONE as 4-byte little-endian (-1 = 0xFFFFFFFF).
     const NDX_DONE_LE: [u8; 4] = [0xFF, 0xFF, 0xFF, 0xFF];
@@ -1914,7 +1914,7 @@ mod legacy_goodbye_tests {
         let mut reader = Cursor::new(receiver_input);
         let mut output = Vec::new();
         let mut ndx_read = create_ndx_codec(28);
-        let mut ndx_write = create_ndx_codec(28);
+        let mut ndx_write = MonotonicNdxWriter::new(28);
 
         ctx.handle_goodbye(&mut reader, &mut output, &mut ndx_read, &mut ndx_write)
             .unwrap();
@@ -1931,7 +1931,7 @@ mod legacy_goodbye_tests {
         let mut reader = Cursor::new(receiver_input);
         let mut output = Vec::new();
         let mut ndx_read = create_ndx_codec(29);
-        let mut ndx_write = create_ndx_codec(29);
+        let mut ndx_write = MonotonicNdxWriter::new(29);
 
         ctx.handle_goodbye(&mut reader, &mut output, &mut ndx_read, &mut ndx_write)
             .unwrap();
@@ -1948,7 +1948,7 @@ mod legacy_goodbye_tests {
         let mut reader = Cursor::new(bad_input);
         let mut output = Vec::new();
         let mut ndx_read = create_ndx_codec(28);
-        let mut ndx_write = create_ndx_codec(28);
+        let mut ndx_write = MonotonicNdxWriter::new(28);
 
         let result = ctx.handle_goodbye(&mut reader, &mut output, &mut ndx_read, &mut ndx_write);
         assert!(result.is_err());
@@ -1969,7 +1969,7 @@ mod legacy_goodbye_tests {
         let mut reader = Cursor::new(receiver_input);
         let mut output = Vec::new();
         let mut ndx_read = create_ndx_codec(28);
-        let mut ndx_write = create_ndx_codec(28);
+        let mut ndx_write = MonotonicNdxWriter::new(28);
 
         ctx.handle_goodbye(&mut reader, &mut output, &mut ndx_read, &mut ndx_write)
             .unwrap();

--- a/crates/transfer/src/generator/transfer.rs
+++ b/crates/transfer/src/generator/transfer.rs
@@ -16,7 +16,8 @@ use std::path::PathBuf;
 use logging::{PhaseTimer, debug_log};
 use protocol::TransferStats;
 use protocol::codec::{
-    NDX_DEL_STATS, NDX_DONE, NDX_FLIST_EOF, NDX_FLIST_OFFSET, NdxCodec, create_ndx_codec,
+    MonotonicNdxWriter, NDX_DEL_STATS, NDX_DONE, NDX_FLIST_EOF, NDX_FLIST_OFFSET, NdxCodec,
+    create_ndx_codec,
 };
 use protocol::stats::DeleteStats;
 
@@ -80,7 +81,7 @@ impl GeneratorContext {
 
         // upstream: io.c:2244-2245 - separate read/write NDX state
         let mut ndx_read_codec = create_ndx_codec(self.protocol.as_u8());
-        let mut ndx_write_codec = create_ndx_codec(self.protocol.as_u8());
+        let mut ndx_write_codec = MonotonicNdxWriter::new(self.protocol.as_u8());
 
         // INC_RECURSE: create scheduler and wire encoding state for lazy sub-list sending.
         // upstream: sender.c:227,261 - interleaves sub-list sending with file transfers.
@@ -478,7 +479,7 @@ impl GeneratorContext {
         reader: &mut R,
         writer: &mut W,
         ndx_read_codec: &mut protocol::codec::NdxCodecEnum,
-        ndx_write_codec: &mut protocol::codec::NdxCodecEnum,
+        ndx_write_codec: &mut MonotonicNdxWriter,
     ) -> io::Result<()> {
         if !self.protocol.supports_goodbye_exchange() {
             return Ok(());

--- a/crates/transfer/src/receiver/transfer.rs
+++ b/crates/transfer/src/receiver/transfer.rs
@@ -15,7 +15,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use logging::{PhaseTimer, info_log};
-use protocol::codec::{NdxCodec, create_ndx_codec};
+use protocol::codec::{MonotonicNdxWriter, NdxCodec, create_ndx_codec};
 use protocol::flist::FileEntry;
 use protocol::stats::DeleteStats;
 
@@ -105,7 +105,7 @@ impl ReceiverContext {
             self.create_directories(&dest_dir, &metadata_opts, acl_cache.as_deref())?;
         self.create_symlinks(&dest_dir, writer);
 
-        let mut ndx_write_codec = create_ndx_codec(self.protocol.as_u8());
+        let mut ndx_write_codec = MonotonicNdxWriter::new(self.protocol.as_u8());
         let mut ndx_read_codec = create_ndx_codec(self.protocol.as_u8());
 
         let mut checksum_verifier = ChecksumVerifier::new(

--- a/crates/transfer/src/receiver/transfer/pipeline.rs
+++ b/crates/transfer/src/receiver/transfer/pipeline.rs
@@ -17,7 +17,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use logging::info_log;
-use protocol::codec::create_ndx_codec;
+use protocol::codec::{MonotonicNdxWriter, create_ndx_codec};
 use protocol::flist::FileEntry;
 
 use crate::delta_apply::ChecksumVerifier;
@@ -66,7 +66,7 @@ impl ReceiverContext {
 
         let deadline = TransferDeadline::from_system_time(self.config.stop_at);
 
-        let mut ndx_write_codec = create_ndx_codec(self.protocol.as_u8());
+        let mut ndx_write_codec = MonotonicNdxWriter::new(self.protocol.as_u8());
         let mut ndx_read_codec = create_ndx_codec(self.protocol.as_u8());
 
         let request_config = RequestConfig {


### PR DESCRIPTION
## Summary
- Add `MonotonicNdxWriter` wrapper around `NdxCodecEnum` that `debug_assert`s each positive file index is strictly greater than the previous one
- Wire the wrapper into all transfer-loop NDX write paths (generator and receiver)
- Catches ordering violations from parallel processing before they become wire protocol errors
- Assertion compiled out in release builds

## Test plan
- [ ] CI passes (fmt, clippy, nextest, all platforms)
- [ ] Existing NDX codec tests continue to pass
- [ ] Debug builds would panic on non-monotonic NDX emission