### PR TITLE
fix: add dashboard tracking and test for compressed batch delta interop (3/3)

### DIFF
--- a/crates/batch/src/tests.rs
+++ b/crates/batch/src/tests.rs
@@ -974,6 +974,174 @@ mod integration {
         );
     }
 
+    /// Verifies that compressed batch delta replay with block matches works
+    /// correctly using CPRES_ZLIB dictionary synchronization.
+    ///
+    /// This exercises the exact scenario that upstream rsync 3.4.1 fails on:
+    /// a compressed delta batch with copy tokens (block matches) requires the
+    /// decoder to feed matched block data into the inflate dictionary via
+    /// see_token(). Without this, inflate fails with "invalid distance too
+    /// far back" (error -3 at token.c:608).
+    ///
+    /// oc-rsync implements proper dictionary sync in batch replay, making it
+    /// capable of reading compressed delta batches that upstream itself cannot.
+    ///
+    /// upstream: token.c:see_deflate_token() - dictionary sync during live transfer
+    /// upstream: token.c:608 - inflate fails without dictionary sync in batch read
+    #[test]
+    fn test_replay_compressed_delta_with_block_matches() {
+        use protocol::flist::{FileEntry, FileListWriter};
+        use protocol::wire::CompressedTokenEncoder;
+
+        let temp_dir = TempDir::new().unwrap();
+        let batch_path = temp_dir.path().join("replay_delta_z.batch");
+        let dest_dir = temp_dir.path().join("dest");
+        fs::create_dir_all(&dest_dir).unwrap();
+
+        let protocol_version = 31;
+
+        // Create basis file at destination (pre-existing file for delta transfer).
+        // 2000 bytes of 'B' - block_length will be chosen by choose_block_size.
+        let basis_data = vec![b'B'; 2000];
+        fs::write(dest_dir.join("data.bin"), &basis_data).unwrap();
+
+        // Delta layout: copy block0(700) + copy block1(700) + literal(17) + copy block2(600).
+        let patch = b"CHANGED_DATA_HERE";
+        let output_size = 700 + 700 + patch.len() + 600; // 2017
+
+        let write_config = BatchConfig::new(
+            BatchMode::Write,
+            batch_path.to_string_lossy().to_string(),
+            protocol_version,
+        )
+        .with_checksum_seed(42);
+
+        let mut writer = BatchWriter::new(write_config).unwrap();
+        let flags = BatchFlags {
+            recurse: true,
+            do_compression: true,
+            ..Default::default()
+        };
+        writer.write_header(flags).unwrap();
+
+        let protocol = protocol::ProtocolVersion::try_from(protocol_version as u8).unwrap();
+        let mut flist_writer = FileListWriter::new(protocol);
+
+        // Directory entry
+        let mut dir_entry = FileEntry::new_directory(".".into(), 0o755);
+        dir_entry.set_mtime(1_700_000_000, 0);
+        let mut buf = Vec::new();
+        flist_writer.write_entry(&mut buf, &dir_entry).unwrap();
+        writer.write_data(&buf).unwrap();
+
+        // File entry with output size
+        let mut file_entry = FileEntry::new_file("data.bin".into(), output_size as u64, 0o644);
+        file_entry.set_mtime(1_700_000_001, 0);
+        buf.clear();
+        flist_writer.write_entry(&mut buf, &file_entry).unwrap();
+        writer.write_data(&buf).unwrap();
+
+        // End of flist
+        let mut end_buf = Vec::new();
+        flist_writer.write_end(&mut end_buf, None).unwrap();
+        writer.write_data(&end_buf).unwrap();
+
+        // NDX-framed delta with block matches and literals.
+        // Use CPRES_ZLIB (zlibx=false) so dictionary sync is required.
+        {
+            use protocol::codec::{NdxCodec, NdxCodecEnum};
+
+            let mut ndx_codec = NdxCodecEnum::new(protocol_version as u8);
+            let mut ndx_buf = Vec::new();
+
+            // NDX for file entry (index 1)
+            ndx_codec.write_ndx(&mut ndx_buf, 1).unwrap();
+            writer.write_data(&ndx_buf).unwrap();
+
+            // iflags: ITEM_TRANSFER (0x8000)
+            writer.write_data(&0x8000u16.to_le_bytes()).unwrap();
+
+            // sum_head: block geometry for basis.
+            // Use block_length=700 (min block for 2000-byte file).
+            // 2000 / 700 = 2 full blocks + 600 remainder.
+            let block_length: i32 = 700;
+            let block_count: i32 = 3; // ceil(2000/700) = 3
+            let remainder: i32 = 2000 - 700 * 2; // 600
+            let s2length: i32 = 16;
+            writer.write_data(&block_count.to_le_bytes()).unwrap();
+            writer.write_data(&block_length.to_le_bytes()).unwrap();
+            writer.write_data(&s2length.to_le_bytes()).unwrap();
+            writer.write_data(&remainder.to_le_bytes()).unwrap();
+
+            // Encode compressed delta: copy block 0 (700 bytes), then literal
+            // patch, then copy remaining blocks. This requires CPRES_ZLIB
+            // dictionary sync because the encoder/decoder share state through
+            // the basis block data fed via see_token().
+            let mut token_buf = Vec::new();
+            let mut encoder = CompressedTokenEncoder::default();
+            encoder.set_zlibx(false); // CPRES_ZLIB mode
+
+            // Block 0: copy from basis (bytes 0..700)
+            encoder.send_block_match(&mut token_buf, 0).unwrap();
+            encoder.see_token(&basis_data[0..700]).unwrap();
+
+            // Delta layout: copy block 0, copy block 1, literal patch,
+            // copy block 2. Multiple block matches exercise dictionary sync.
+
+            // Block 1: copy from basis (bytes 700..1400)
+            encoder.send_block_match(&mut token_buf, 1).unwrap();
+            encoder.see_token(&basis_data[700..1400]).unwrap();
+
+            // Literal: the patched data (17 bytes)
+            encoder.send_literal(&mut token_buf, patch).unwrap();
+
+            // Block 2: copy from basis (bytes 1400..2000, remainder=600)
+            encoder.send_block_match(&mut token_buf, 2).unwrap();
+            encoder.see_token(&basis_data[1400..2000]).unwrap();
+
+            encoder.finish(&mut token_buf).unwrap();
+            writer.write_data(&token_buf).unwrap();
+
+            // File checksum (16 zero bytes)
+            writer.write_data(&[0u8; 16]).unwrap();
+
+            // NDX_DONE for phase 1 -> phase 2
+            ndx_buf.clear();
+            ndx_codec.write_ndx_done(&mut ndx_buf).unwrap();
+            writer.write_data(&ndx_buf).unwrap();
+
+            // NDX_DONE for phase 2 -> end
+            ndx_buf.clear();
+            ndx_codec.write_ndx_done(&mut ndx_buf).unwrap();
+            writer.write_data(&ndx_buf).unwrap();
+        }
+
+        writer.finalize().unwrap();
+
+        // Replay the compressed delta batch
+        let read_config = BatchConfig::new(
+            BatchMode::Read,
+            batch_path.to_string_lossy().to_string(),
+            protocol_version,
+        );
+
+        let result = crate::replay::replay(&read_config, &dest_dir, 0).unwrap();
+
+        assert_eq!(result.file_count, 2); // 1 dir + 1 file
+        assert!(dest_dir.join("data.bin").exists());
+
+        let content = fs::read(dest_dir.join("data.bin")).unwrap();
+        // The output should be: block0(700) + block1(700) + patch(17) + block2(600)
+        // = 2017 bytes total.
+        assert_eq!(content.len(), 700 + 700 + patch.len() + 600);
+        // Verify the literal patch is present in the output
+        assert_eq!(&content[1400..1400 + patch.len()], patch);
+        // Verify block copies are correct
+        assert_eq!(&content[0..700], &basis_data[0..700]);
+        assert_eq!(&content[700..1400], &basis_data[700..1400]);
+        assert_eq!(&content[1400 + patch.len()..], &basis_data[1400..2000]);
+    }
+
     /// Verifies replay works when the batch header has `do_compression=true`.
     /// upstream: batch.c - when do_compression is set, delta tokens use
     /// compressed (DEFLATED_DATA) encoding in the batch file body.

--- a/tests/batch_interop_test.sh
+++ b/tests/batch_interop_test.sh
@@ -3,19 +3,15 @@
 #
 # Tests batch mode compatibility between oc-rsync and upstream rsync versions.
 #
-# NOTE: All tests are currently informational. The batch system has known
-# design limitations:
+# NOTE: All tests are currently informational. Failures do not block CI.
 #
-# 1. Cross-tool interop: oc-rsync uses a different batch body format than
-#    upstream rsync's raw protocol stream tee, so batch files are not
-#    interchangeable between implementations.
+# oc-rsync can read upstream rsync batch files (including compressed delta
+# batches with CPRES_ZLIB dictionary sync). Cross-tool interop from oc-rsync
+# to upstream is limited because oc-rsync uses a different batch body format.
 #
-# 2. Roundtrip: The batch writer captures per-operation delta ops but the
-#    replay reader expects FileEntry-delimited records. These formats are
-#    not compatible, so oc-rsync cannot replay its own batch files.
-#
-# This test runs for visibility and tracking progress toward full batch
-# support. Failures do not block CI.
+# Known upstream bug: rsync 3.4.1 cannot read back its own compressed delta
+# batch files due to missing inflate dictionary synchronization in the batch
+# reader (token.c:608). oc-rsync does not have this limitation.
 #
 # Environment variable overrides:
 #   OC_RSYNC              - path to oc-rsync binary

--- a/tools/ci/check_known_failures.sh
+++ b/tools/ci/check_known_failures.sh
@@ -252,6 +252,73 @@ run_standalone_test_by_name() {
       timeout "$hard_timeout" "$oc_bin" -av --iconv=utf8,latin1 --timeout=10 \
           "${comp_src}/" "${idest}/" >/dev/null 2>&1 || return 1
       ;;
+    upstream-compressed-batch-self-roundtrip)
+      # upstream rsync 3.4.1 cannot read back its own compressed delta batch
+      # files. The batch writer records raw compressed tokens (zlib DEFLATED_DATA)
+      # but the batch reader's inflate context lacks the dictionary sync that
+      # see_deflate_token() provides during live transfers, causing "inflate
+      # returned -3" at token.c:608.
+      #
+      # This test verifies the upstream bug still exists by:
+      # 1. Having upstream write a compressed delta batch
+      # 2. Having upstream try to read its own batch (expected to fail)
+      # 3. Having oc-rsync read the same batch (expected to succeed)
+      #
+      # upstream: token.c:608 - inflate fails without dictionary sync
+      # upstream: compat.c:194-195 - batch read defaults to CPRES_ZLIB
+      local bdir="${dest}/batch-delta"
+      local bsrc="${bdir}/src"
+      local bwrite="${bdir}/write-dest"
+      local bread="${bdir}/read-dest"
+      local oc_read="${bdir}/oc-read-dest"
+      local bfile="${bdir}/batch.rsync"
+      mkdir -p "$bsrc" "$bwrite" "$bread" "$oc_read"
+
+      # Create basis + modified source for delta transfer
+      dd if=/dev/zero bs=1K count=100 2>/dev/null | tr '\0' 'B' > "$bsrc/data.bin"
+      printf 'CHANGED_DATA_HERE' | dd of="$bsrc/data.bin" bs=1 seek=40000 conv=notrunc 2>/dev/null
+      dd if=/dev/zero bs=1K count=100 2>/dev/null | tr '\0' 'B' > "$bwrite/data.bin"
+      cp "$bwrite/data.bin" "$bread/data.bin"
+      cp "$bwrite/data.bin" "$oc_read/data.bin"
+
+      # Step 1: upstream writes compressed delta batch
+      if ! timeout "$hard_timeout" "$upstream_binary" -avI -z --no-whole-file \
+          --compress-choice=zlib --write-batch="$bfile" --timeout=10 \
+          "${bsrc}/" "${bwrite}/" >/dev/null 2>&1; then
+        return 1
+      fi
+
+      # Step 2: upstream reads its own batch - expected to fail (upstream bug)
+      local up_rc=0
+      timeout "$hard_timeout" "$upstream_binary" -av \
+          --read-batch="$bfile" --timeout=10 \
+          "${bread}/" >/dev/null 2>&1 || up_rc=$?
+
+      # Step 3: oc-rsync reads the same batch - expected to succeed
+      local oc_rc=0
+      timeout "$hard_timeout" "$oc_bin" -av \
+          --read-batch="$bfile" --timeout=10 \
+          "${oc_read}/" >/dev/null 2>&1 || oc_rc=$?
+
+      if [[ $oc_rc -ne 0 ]]; then
+        echo "    oc-rsync cannot read upstream compressed delta batch (regression)"
+        return 1
+      fi
+
+      if ! cmp -s "${bsrc}/data.bin" "${oc_read}/data.bin"; then
+        echo "    oc-rsync content mismatch after reading upstream compressed delta batch"
+        return 1
+      fi
+
+      # The test "fails" if upstream still cannot read its own batch -
+      # which is the expected upstream bug we are tracking.
+      if [[ $up_rc -ne 0 ]]; then
+        return 1
+      fi
+
+      # Verify upstream content match if it somehow succeeds
+      cmp -s "${bsrc}/data.bin" "${bread}/data.bin" || return 1
+      ;;
     *)
       return 2  # Unknown test, skip
       ;;

--- a/tools/ci/known_failures.conf
+++ b/tools/ci/known_failures.conf
@@ -10,9 +10,15 @@
 # Currently empty - all remaining failures are protocol-conditional or batch-specific.
 KNOWN_FAILURES=(
   # upstream-compressed-batch-self-roundtrip: upstream rsync 3.4.1 cannot
-  # read back its own compressed delta batch files. The batch writer records
-  # raw compressed tokens but the reader expects uncompressed data, causing
-  # data corruption on replay. This is an upstream limitation, not oc-rsync.
+  # read back its own compressed delta batch files. The batch writer tees
+  # raw DEFLATED_DATA tokens (zlib-compressed) to the batch fd, but the
+  # batch reader's inflate context lacks the dictionary synchronization
+  # that see_deflate_token() provides during live transfers. This causes
+  # "inflate returned -3" at token.c:608 on any delta batch with block
+  # matches (copy tokens). oc-rsync reads these batch files correctly by
+  # implementing proper CPRES_ZLIB dictionary sync in its batch reader.
+  # upstream: token.c:608 - inflate fails without dictionary sync
+  # upstream: compat.c:194-195 - batch read always assumes CPRES_ZLIB
   "standalone:upstream-compressed-batch-self-roundtrip"
 
   # --backup-dir: oc-rsync does not yet implement --backup-dir rename logic.
@@ -104,7 +110,7 @@ DASHBOARD_ENTRIES=(
   "up:compress-lz4|lz4 compression pull (proto <= 29, upstream compat.c:556-564)|daemon"
   # Compressed batch delta: upstream batch writer records raw compressed tokens
   # but batch reader expects uncompressed data - upstream limitation
-  "standalone:upstream-compressed-batch-self-roundtrip|upstream compressed batch delta self-roundtrip fails|standalone"
+  "standalone:upstream-compressed-batch-self-roundtrip|upstream compressed batch delta self-roundtrip fails (token.c:608 inflate -3, upstream bug)|standalone"
   # Unconditional: backup-dir not yet implemented
   "up:backup-dir|backup-dir rename logic not implemented|daemon"
   # Unconditional: dry-run comparison incomplete


### PR DESCRIPTION
## Summary

Final PR in the compressed batch delta interop series (3/3).

Previous PRs:
- PR #3224: `fix: correct CPRES_ZLIB dictionary sync in compressed batch replay`
- PR #3226: `fix: always use CPRES_ZLIB streaming path for compressed batch replay`

This PR completes the series by:

- **Dashboard tracking**: Added standalone test handler for `upstream-compressed-batch-self-roundtrip` in `check_known_failures.sh`. The handler verifies that upstream rsync 3.4.1 still fails reading its own compressed delta batches (`inflate returned -3` at `token.c:608`) while oc-rsync reads them correctly. Previously this test was skipped in the dashboard.

- **Rust test**: Added `test_replay_compressed_delta_with_block_matches` exercising CPRES_ZLIB dictionary synchronization with copy tokens during compressed batch delta replay - the exact scenario that upstream rsync fails on. The test constructs a batch file with block match + literal + block match patterns requiring dictionary sync via `see_token()`.

- **Documentation**: Updated `known_failures.conf` with precise upstream source references (`token.c:608`, `compat.c:194-195`) explaining the root cause. Updated `batch_interop_test.sh` header to reflect current status.

### Upstream bug summary

upstream rsync 3.4.1 tees raw DEFLATED_DATA tokens to the batch fd during `--write-batch -z`, but the batch reader's inflate context lacks the dictionary synchronization that `see_deflate_token()` provides during live transfers. Any delta batch with block matches (copy tokens) fails with `inflate returned -3`. This is not an oc-rsync bug.

## Test plan

- [ ] CI passes (fmt, clippy, nextest, all platforms)
- [ ] New Rust test `test_replay_compressed_delta_with_block_matches` passes
- [ ] Dashboard handler correctly tracks the upstream bug status