### PR TITLE
feat: add io_uring availability detail to --version output

### DIFF
--- a/crates/core/src/version/report/config.rs
+++ b/crates/core/src/version/report/config.rs
@@ -137,6 +137,7 @@ impl VersionInfoConfig {
         config.supports_socketpairs = socketpair_available();
         config.supports_simd_roll = checksums::simd_acceleration_available();
         config.supports_openssl_crypto = checksums::openssl_acceleration_available();
+        config.supports_io_uring = fast_io::is_io_uring_available();
         config
     }
 }
@@ -706,5 +707,11 @@ mod tests {
         // Basic sanity checks - runtime values vary
         assert!(config.supports_ipv6);
         assert!(config.supports_atimes);
+    }
+
+    #[test]
+    fn with_runtime_capabilities_detects_io_uring() {
+        let config = VersionInfoConfig::with_runtime_capabilities();
+        assert_eq!(config.supports_io_uring, fast_io::is_io_uring_available());
     }
 }

--- a/crates/core/src/version/report/renderer.rs
+++ b/crates/core/src/version/report/renderer.rs
@@ -187,6 +187,7 @@ impl VersionInfoReport {
         self.metadata.write_standard_banner(writer)?;
         self.write_info_sections(writer)?;
         self.write_platform_io(writer)?;
+        self.write_io_uring_detail(writer)?;
         self.write_named_list(writer, "Checksum list", &self.checksum_algorithms)?;
         self.write_named_list(writer, "Compress list", &self.compress_algorithms)?;
         self.write_named_list(writer, "Daemon auth list", &self.daemon_auth_algorithms)?;
@@ -210,6 +211,12 @@ impl VersionInfoReport {
             writer.write_str(cap)?;
         }
         writer.write_char('\n')
+    }
+
+    /// Writes the io_uring availability detail line.
+    fn write_io_uring_detail<W: FmtWrite>(&self, writer: &mut W) -> fmt::Result {
+        let detail = fast_io::io_uring_status_detail();
+        writeln!(writer, "io_uring: {detail}")
     }
 
     /// Internal helper for the GPL footer. Single fmt call, no allocations.
@@ -539,6 +546,13 @@ mod tests {
         } else {
             assert!(output.contains("Platform I/O:"));
         }
+    }
+
+    #[test]
+    fn human_readable_contains_io_uring_detail() {
+        let report = VersionInfoReport::default();
+        let output = report.human_readable();
+        assert!(output.contains("io_uring:"));
     }
 
     #[test]

--- a/crates/fast_io/src/io_uring/config.rs
+++ b/crates/fast_io/src/io_uring/config.rs
@@ -42,6 +42,21 @@ fn get_kernel_release() -> Option<String> {
     }
 }
 
+/// Public accessors for kernel version detection used by `--version` output.
+pub mod config_detail {
+    /// Parses kernel version from uname release string (e.g., "5.15.0-generic").
+    #[must_use]
+    pub fn parse_kernel_version(release: &str) -> Option<(u32, u32)> {
+        super::parse_kernel_version(release)
+    }
+
+    /// Returns the kernel release string from `uname(2)`.
+    #[must_use]
+    pub fn get_kernel_release_string() -> Option<String> {
+        super::get_kernel_release()
+    }
+}
+
 /// Checks if the current kernel supports io_uring.
 ///
 /// Returns `true` if all of the following hold:

--- a/crates/fast_io/src/io_uring/mod.rs
+++ b/crates/fast_io/src/io_uring/mod.rs
@@ -76,7 +76,7 @@ use std::fs::File;
 use std::io::{self, Write};
 use std::os::unix::io::AsRawFd;
 
-pub use config::{IoUringConfig, is_io_uring_available};
+pub use config::{IoUringConfig, config_detail, is_io_uring_available};
 pub use disk_batch::IoUringDiskBatch;
 pub use file_factory::{
     IoUringOrStdReader, IoUringOrStdWriter, IoUringReaderFactory, IoUringWriterFactory,

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -148,17 +148,15 @@ pub fn io_uring_status_detail() -> String {
 fn io_uring_status_detail_impl() -> String {
     use io_uring::config_detail::{get_kernel_release_string, parse_kernel_version};
 
-    let kernel_version = get_kernel_release_string()
-        .and_then(|release| parse_kernel_version(&release));
+    let kernel_version =
+        get_kernel_release_string().and_then(|release| parse_kernel_version(&release));
 
     match kernel_version {
         Some((major, minor)) => {
             if is_io_uring_available() {
                 format!("compiled in, available (kernel {major}.{minor})")
             } else {
-                format!(
-                    "compiled in, unavailable (kernel {major}.{minor}, requires >= 5.6)"
-                )
+                format!("compiled in, unavailable (kernel {major}.{minor}, requires >= 5.6)")
             }
         }
         None => "compiled in, unavailable (could not detect kernel version)".to_string(),

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -133,6 +133,50 @@ pub use io_uring::{
     RegisteredBufferSlot, is_io_uring_available, reader_from_path, writer_from_file,
 };
 
+/// Detailed io_uring availability status for `--version` output.
+///
+/// Returns a human-readable string describing io_uring support:
+/// - Whether the feature was compiled in
+/// - Whether the kernel supports it (Linux only)
+/// - The detected kernel version when relevant
+#[must_use]
+pub fn io_uring_status_detail() -> String {
+    io_uring_status_detail_impl()
+}
+
+#[cfg(all(target_os = "linux", feature = "io_uring"))]
+fn io_uring_status_detail_impl() -> String {
+    use io_uring::config_detail::{get_kernel_release_string, parse_kernel_version};
+
+    let kernel_version = get_kernel_release_string()
+        .and_then(|release| parse_kernel_version(&release));
+
+    match kernel_version {
+        Some((major, minor)) => {
+            if is_io_uring_available() {
+                format!("compiled in, available (kernel {major}.{minor})")
+            } else {
+                format!(
+                    "compiled in, unavailable (kernel {major}.{minor}, requires >= 5.6)"
+                )
+            }
+        }
+        None => "compiled in, unavailable (could not detect kernel version)".to_string(),
+    }
+}
+
+#[cfg(not(all(target_os = "linux", feature = "io_uring")))]
+fn io_uring_status_detail_impl() -> String {
+    #[cfg(not(target_os = "linux"))]
+    {
+        "not available (platform is not Linux)".to_string()
+    }
+    #[cfg(all(target_os = "linux", not(feature = "io_uring")))]
+    {
+        "not compiled in (io_uring feature disabled)".to_string()
+    }
+}
+
 #[cfg(unix)]
 pub use io_uring::{
     IoUringOrStdSocketReader, IoUringOrStdSocketWriter, IoUringSocketReader, IoUringSocketWriter,
@@ -268,6 +312,21 @@ mod tests {
         {
             assert!(caps.contains(&"CopyFileEx"));
         }
+    }
+
+    #[test]
+    fn io_uring_status_detail_returns_non_empty_string() {
+        let detail = io_uring_status_detail();
+        assert!(!detail.is_empty());
+
+        #[cfg(not(target_os = "linux"))]
+        assert!(detail.contains("not available"));
+
+        #[cfg(all(target_os = "linux", not(feature = "io_uring")))]
+        assert!(detail.contains("not compiled in"));
+
+        #[cfg(all(target_os = "linux", feature = "io_uring"))]
+        assert!(detail.contains("compiled in"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add `io_uring_status_detail()` to `fast_io` crate returning a human-readable string describing io_uring compile-time and runtime status with kernel version info
- Wire `fast_io::is_io_uring_available()` into `VersionInfoConfig::with_runtime_capabilities()` so the Optimizations section reflects actual io_uring availability
- Add `io_uring:` detail line to `--version` output between Platform I/O and Checksum list sections
- Platform-appropriate messages: "compiled in, available (kernel X.Y)" on Linux 5.6+, "not available (platform is not Linux)" on macOS/Windows, "not compiled in (io_uring feature disabled)" when feature is off

## Test plan

- [ ] CI passes on all platforms (Linux, macOS, Windows)
- [ ] `oc-rsync --version` output includes `io_uring:` line
- [ ] On macOS: shows "not available (platform is not Linux)"
- [ ] On Linux 5.6+: shows "compiled in, available (kernel X.Y)"
- [ ] On older Linux: shows "compiled in, unavailable (kernel X.Y, requires >= 5.6)"
- [ ] Optimizations section shows `io-uring` or `no io-uring` based on runtime detection