### PR TITLE
fix: gate proto 28-29 hardlink dev/ino read on XMIT_HLINKED flag

### DIFF
--- a/crates/protocol/src/flist/read/extras.rs
+++ b/crates/protocol/src/flist/read/extras.rs
@@ -159,13 +159,15 @@ impl FileListReader {
     /// Reads hardlink device and inode for protocol 28-29.
     ///
     /// In protocols before 30, hardlinks are identified by (dev, ino) pairs
-    /// rather than indices.
+    /// rather than indices. Only reads when XMIT_HLINKED is set - non-hardlinked
+    /// entries have no dev/ino data on the wire.
     ///
     /// Wire format:
     /// - If not XMIT_SAME_DEV_PRE30: read longint as dev (stored as dev + 1)
     /// - Always read longint as ino
     ///
-    /// // upstream: flist.c:recv_file_entry() lines 980-1000
+    /// // upstream: flist.c:recv_file_entry() - dev/ino read is gated on
+    /// // `preserve_hard_links && xflags & XMIT_HLINKED`
     pub(super) fn read_hardlink_dev_ino<R: Read + ?Sized>(
         &mut self,
         reader: &mut R,
@@ -173,6 +175,12 @@ impl FileListReader {
         mode: u32,
     ) -> io::Result<Option<(i64, i64)>> {
         if !self.preserve_hard_links || self.protocol.as_u8() >= 30 || self.protocol.as_u8() < 28 {
+            return Ok(None);
+        }
+
+        // upstream: flist.c:recv_file_entry() only reads dev/ino when
+        // XMIT_HLINKED is set. Non-hardlinked entries have no dev/ino on wire.
+        if !flags.hlinked() {
             return Ok(None);
         }
 

--- a/crates/protocol/tests/golden_protocol_v28_wire.rs
+++ b/crates/protocol/tests/golden_protocol_v28_wire.rs
@@ -1017,6 +1017,89 @@ fn golden_v28_hardlink_dev_ino_roundtrip() {
 }
 
 // ---------------------------------------------------------------------------
+// Mixed hardlink and non-hardlink entries (protocol 28-29 interop fix)
+// upstream: flist.c:recv_file_entry() - dev/ino read gated on XMIT_HLINKED
+// ---------------------------------------------------------------------------
+
+#[test]
+fn golden_v28_mixed_hardlink_and_plain_roundtrip() {
+    // Verifies that non-hardlinked entries interleaved with hardlinked entries
+    // decode correctly at protocol 28. The receiver must only read dev/ino
+    // when XMIT_HLINKED is set - reading unconditionally would consume bytes
+    // meant for the next entry, causing wire desync.
+    let protocol = proto28();
+    let mut buf = Vec::new();
+    let mut writer = FileListWriter::new(protocol).with_preserve_hard_links(true);
+
+    // Entry 1: plain file (no hardlink)
+    let mut e1 = FileEntry::new_file("plain.txt".into(), 100, 0o644);
+    e1.set_mtime(1_700_000_000, 0);
+
+    // Entry 2: hardlinked file
+    let mut e2 = FileEntry::new_file("linked_a.txt".into(), 200, 0o644);
+    e2.set_mtime(1_700_000_000, 0);
+    e2.set_hardlink_dev(42);
+    e2.set_hardlink_ino(12345);
+
+    // Entry 3: another plain file
+    let mut e3 = FileEntry::new_file("another.txt".into(), 300, 0o644);
+    e3.set_mtime(1_700_000_100, 0);
+
+    // Entry 4: same hardlink group
+    let mut e4 = FileEntry::new_file("linked_b.txt".into(), 200, 0o644);
+    e4.set_mtime(1_700_000_000, 0);
+    e4.set_hardlink_dev(42);
+    e4.set_hardlink_ino(12345);
+
+    writer.write_entry(&mut buf, &e1).unwrap();
+    writer.write_entry(&mut buf, &e2).unwrap();
+    writer.write_entry(&mut buf, &e3).unwrap();
+    writer.write_entry(&mut buf, &e4).unwrap();
+    writer.write_end(&mut buf, None).unwrap();
+
+    let mut cursor = Cursor::new(&buf[..]);
+    let mut reader = FileListReader::new(protocol).with_preserve_hard_links(true);
+
+    let r1 = reader.read_entry(&mut cursor).unwrap().unwrap();
+    assert_eq!(r1.name(), "plain.txt");
+    assert_eq!(r1.size(), 100);
+    assert_eq!(
+        r1.hardlink_dev(),
+        None,
+        "plain entry must have no hardlink dev"
+    );
+    assert_eq!(
+        r1.hardlink_ino(),
+        None,
+        "plain entry must have no hardlink ino"
+    );
+
+    let r2 = reader.read_entry(&mut cursor).unwrap().unwrap();
+    assert_eq!(r2.name(), "linked_a.txt");
+    assert_eq!(r2.size(), 200);
+    assert_eq!(r2.hardlink_dev(), Some(42));
+    assert_eq!(r2.hardlink_ino(), Some(12345));
+
+    let r3 = reader.read_entry(&mut cursor).unwrap().unwrap();
+    assert_eq!(r3.name(), "another.txt");
+    assert_eq!(r3.size(), 300);
+    assert_eq!(
+        r3.hardlink_dev(),
+        None,
+        "plain entry must have no hardlink dev"
+    );
+
+    let r4 = reader.read_entry(&mut cursor).unwrap().unwrap();
+    assert_eq!(r4.name(), "linked_b.txt");
+    assert_eq!(r4.size(), 200);
+    assert_eq!(r4.hardlink_dev(), Some(42));
+    assert_eq!(r4.hardlink_ino(), Some(12345));
+
+    // End marker
+    assert!(reader.read_entry(&mut cursor).unwrap().is_none());
+}
+
+// ---------------------------------------------------------------------------
 // Transfer stats exact wire bytes (protocol 28 - varlong30 only, no flist times)
 // upstream: main.c:handle_stats() - protocol < 29 omits flist times
 // ---------------------------------------------------------------------------

--- a/crates/protocol/tests/golden_protocol_v29_wire.rs
+++ b/crates/protocol/tests/golden_protocol_v29_wire.rs
@@ -509,6 +509,55 @@ fn golden_v29_hardlink_roundtrip() {
 }
 
 // ---------------------------------------------------------------------------
+// Mixed hardlink and non-hardlink entries (protocol 29 interop fix)
+// upstream: flist.c:recv_file_entry() - dev/ino read gated on XMIT_HLINKED
+// ---------------------------------------------------------------------------
+
+#[test]
+fn golden_v29_mixed_hardlink_and_plain_roundtrip() {
+    // Regression test: non-hardlinked entries must not attempt to read dev/ino
+    // at protocol 29. The XMIT_HLINKED flag gates dev/ino on the wire.
+    let protocol = v29();
+    let mut buf = Vec::new();
+    let mut writer = FileListWriter::new(protocol).with_preserve_hard_links(true);
+
+    let mut plain = FileEntry::new_file("plain.txt".into(), 50, 0o644);
+    plain.set_mtime(1_700_000_000, 0);
+
+    let mut linked = FileEntry::new_file("linked.txt".into(), 100, 0o644);
+    linked.set_mtime(1_700_000_000, 0);
+    linked.set_hardlink_dev(7);
+    linked.set_hardlink_ino(9999);
+
+    let mut plain2 = FileEntry::new_file("other.txt".into(), 75, 0o644);
+    plain2.set_mtime(1_700_000_100, 0);
+
+    writer.write_entry(&mut buf, &plain).unwrap();
+    writer.write_entry(&mut buf, &linked).unwrap();
+    writer.write_entry(&mut buf, &plain2).unwrap();
+    writer.write_end(&mut buf, None).unwrap();
+
+    let mut cursor = Cursor::new(&buf[..]);
+    let mut reader = FileListReader::new(protocol).with_preserve_hard_links(true);
+
+    let r1 = reader.read_entry(&mut cursor).unwrap().unwrap();
+    assert_eq!(r1.name(), "plain.txt");
+    assert_eq!(r1.hardlink_dev(), None);
+
+    let r2 = reader.read_entry(&mut cursor).unwrap().unwrap();
+    assert_eq!(r2.name(), "linked.txt");
+    assert_eq!(r2.hardlink_dev(), Some(7));
+    assert_eq!(r2.hardlink_ino(), Some(9999));
+
+    let r3 = reader.read_entry(&mut cursor).unwrap().unwrap();
+    assert_eq!(r3.name(), "other.txt");
+    assert_eq!(r3.size(), 75);
+    assert_eq!(r3.hardlink_dev(), None);
+
+    assert!(reader.read_entry(&mut cursor).unwrap().is_none());
+}
+
+// ---------------------------------------------------------------------------
 // Wire format identity: v29 file list encoding matches v28
 // upstream: flist.c - protocol 29 takes same code path as 28 for flist
 // ---------------------------------------------------------------------------

--- a/tools/ci/known_failures.conf
+++ b/tools/ci/known_failures.conf
@@ -70,12 +70,6 @@ is_known_failure_from_conf() {
       # transfer failures with -z and --compress-level options.
       compress|compress-level-1|compress-level-9|compress-delta) return 0 ;;
 
-      # Protocol < 30 hardlinks interop: hardlink wire format uses
-      # different encoding (dev/ino fields) at older protocol versions.
-      # All hardlink test variants affected.
-      hardlinks|hardlinks-relative|hardlinks-delete|hardlinks-numeric|\
-      hardlinks-checksum|hardlinks-existing|hardlinks-inc-recursive) return 0 ;;
-
       # Protocol < 30 merge-filter: filter rule exchange has subtle
       # differences at older protocol versions.
       merge-filter) return 0 ;;
@@ -113,21 +107,6 @@ DASHBOARD_ENTRIES=(
   "oc:compress-level-1|compress-level-1 push interop (proto <= 29)|daemon"
   "oc:compress-level-9|compress-level-9 push interop (proto <= 29)|daemon"
   "oc:compress-delta|compress-delta push interop (proto <= 29)|daemon"
-  # Proto <= 29: hardlink wire format differences
-  "up:hardlinks|hardlinks interop (proto <= 29)|daemon"
-  "up:hardlinks-relative|hardlinks-relative interop (proto <= 29)|daemon"
-  "up:hardlinks-delete|hardlinks-delete interop (proto <= 29)|daemon"
-  "up:hardlinks-numeric|hardlinks-numeric interop (proto <= 29)|daemon"
-  "up:hardlinks-checksum|hardlinks-checksum interop (proto <= 29)|daemon"
-  "up:hardlinks-existing|hardlinks-existing interop (proto <= 29)|daemon"
-  "up:hardlinks-inc-recursive|hardlinks-inc-recursive interop (proto <= 29)|daemon"
-  "oc:hardlinks|hardlinks push interop (proto <= 29)|daemon"
-  "oc:hardlinks-relative|hardlinks-relative push interop (proto <= 29)|daemon"
-  "oc:hardlinks-delete|hardlinks-delete push interop (proto <= 29)|daemon"
-  "oc:hardlinks-numeric|hardlinks-numeric push interop (proto <= 29)|daemon"
-  "oc:hardlinks-checksum|hardlinks-checksum push interop (proto <= 29)|daemon"
-  "oc:hardlinks-existing|hardlinks-existing push interop (proto <= 29)|daemon"
-  "oc:hardlinks-inc-recursive|hardlinks-inc-recursive push interop (proto <= 29)|daemon"
   # Proto <= 29: merge-filter exchange differences
   "up:merge-filter|merge-filter interop (proto <= 29)|daemon"
   "oc:merge-filter|merge-filter push interop (proto <= 29)|daemon"


### PR DESCRIPTION
## Summary

- Fix wire desynchronization at protocol 28-29 when hardlinks are enabled: `read_hardlink_dev_ino()` was unconditionally reading dev/ino longint pairs for all non-directory entries, but upstream only reads them when `XMIT_HLINKED` is set. Non-hardlinked entries have no dev/ino on the wire, so the reader consumed bytes from subsequent fields.
- Add the missing `flags.hlinked()` guard to match upstream `flist.c:recv_file_entry()` behavior.
- Remove 14 hardlink interop tests from `known_failures.conf` (7 up-direction, 7 oc-direction).

## Test plan

- [ ] Golden byte tests `golden_v28_mixed_hardlink_and_plain_roundtrip` and `golden_v29_mixed_hardlink_and_plain_roundtrip` verify mixed hardlink/plain entries decode correctly
- [ ] Existing `golden_v28_hardlink_dev_ino_roundtrip` and `golden_v29_hardlink_roundtrip` still pass (hardlinked entries unaffected)
- [ ] CI interop tests for `hardlinks`, `hardlinks-relative`, `hardlinks-delete`, `hardlinks-numeric`, `hardlinks-checksum`, `hardlinks-existing`, `hardlinks-inc-recursive` pass at protocol 28-29