### PR TITLE
fix: derive backup-dir path from destination instead of source-relative path

### DIFF
--- a/crates/cli/src/frontend/tests/backup.rs
+++ b/crates/cli/src/frontend/tests/backup.rs
@@ -58,6 +58,12 @@ fn backup_dir_flag_places_backups_in_relative_directory() {
     let source_file = source_dir.join("nested/file.txt");
     std::fs::write(&source_file, b"updated").expect("write source");
     std::fs::write(dest_dir.join("source/nested/file.txt"), b"previous").expect("seed dest");
+    // Backdate destination to prevent quick-check skip (same mtime+size = no transfer)
+    let one_hour_ago = filetime::FileTime::from_system_time(
+        std::time::SystemTime::now() - std::time::Duration::from_secs(3600),
+    );
+    filetime::set_file_mtime(dest_dir.join("source/nested/file.txt"), one_hour_ago)
+        .expect("backdate dest");
 
     let (code, stdout, stderr) = run_with_args([
         OsString::from(RSYNC),

--- a/crates/cli/src/frontend/tests/backup.rs
+++ b/crates/cli/src/frontend/tests/backup.rs
@@ -77,7 +77,8 @@ fn backup_dir_flag_places_backups_in_relative_directory() {
     assert!(stdout.is_empty());
     assert!(stderr.is_empty());
 
-    let backup_path = dest_dir.join("backups/source/nested/file.txt~");
+    // upstream: options.c:2278-2279 - --backup-dir without --suffix uses empty suffix
+    let backup_path = dest_dir.join("backups/source/nested/file.txt");
     assert_eq!(
         std::fs::read(&backup_path).expect("read backup"),
         b"previous"

--- a/crates/engine/src/local_copy/context_impl/state.rs
+++ b/crates/engine/src/local_copy/context_impl/state.rs
@@ -460,7 +460,7 @@ impl<'a> CopyContext<'a> {
     pub(super) fn backup_existing_entry(
         &mut self,
         destination: &Path,
-        relative: Option<&Path>,
+        _relative: Option<&Path>,
         file_type: fs::FileType,
     ) -> Result<(), LocalCopyError> {
         if !self.options.backup_enabled() || self.mode.is_dry_run() {

--- a/crates/engine/src/local_copy/context_impl/state.rs
+++ b/crates/engine/src/local_copy/context_impl/state.rs
@@ -471,10 +471,16 @@ impl<'a> CopyContext<'a> {
             return Ok(());
         }
 
+        // Always derive the relative path from destination/destination_root
+        // rather than using the source-relative path. The source-relative path
+        // may not include the source directory basename (e.g., "nested/file.txt"
+        // instead of "source/nested/file.txt"), causing backup files to be
+        // placed at the wrong location when --backup-dir is used.
+        // upstream: backup.c:get_backup_name() uses the destination-relative path
         let backup_path = compute_backup_path(
             self.destination_root(),
             destination,
-            relative,
+            None,
             self.options.backup_directory(),
             self.options.backup_suffix(),
         );


### PR DESCRIPTION
## Summary
- Fix backup-dir path computation to derive relative path from `destination.strip_prefix(destination_root)` instead of using the source-relative path
- The source-relative path may not include the source directory basename (e.g., `nested/file.txt` instead of `source/nested/file.txt`), causing backup files to be placed at the wrong location when `--backup-dir` is used without a trailing slash
- Matches upstream `backup.c:get_backup_name()` which uses the destination-relative fname parameter
- Also backdates dest files in backup tests to prevent quick-check skip flakiness

## Test plan
- [x] All 3 backup tests pass: `backup_flag_creates_default_suffix_backups`, `backup_dir_flag_places_backups_in_relative_directory`, `backup_suffix_flag_overrides_default_suffix`
- [ ] CI nextest stable passes
- [ ] CI fmt+clippy passes