### PR TITLE
feat: add io_uring availability logging at -vv verbosity

### DIFF
--- a/crates/fast_io/src/io_uring/config.rs
+++ b/crates/fast_io/src/io_uring/config.rs
@@ -55,6 +55,15 @@ pub mod config_detail {
     pub fn get_kernel_release_string() -> Option<String> {
         super::get_kernel_release()
     }
+
+    /// Returns a human-readable reason for io_uring availability or unavailability.
+    ///
+    /// Probes the kernel version and attempts to create a minimal io_uring
+    /// instance, returning a log-friendly string describing the result.
+    #[must_use]
+    pub fn io_uring_availability_reason() -> String {
+        super::check_io_uring_reason().reason()
+    }
 }
 
 /// Checks if the current kernel supports io_uring.
@@ -81,23 +90,87 @@ pub fn is_io_uring_available() -> bool {
 }
 
 fn check_io_uring_available() -> bool {
-    // Check kernel version
+    matches!(
+        check_io_uring_reason(),
+        IoUringProbeResult::Available { .. }
+    )
+}
+
+/// Result of probing io_uring availability with the specific reason.
+#[derive(Debug, Clone)]
+pub(crate) enum IoUringProbeResult {
+    /// io_uring is available on this kernel.
+    Available {
+        /// Detected kernel major.minor version.
+        major: u32,
+        minor: u32,
+    },
+    /// Could not read the kernel release string from uname(2).
+    NoKernelRelease,
+    /// Kernel release string could not be parsed into major.minor.
+    UnparsableVersion,
+    /// Kernel version is below the 5.6 minimum.
+    KernelTooOld {
+        /// Detected kernel major.minor version.
+        major: u32,
+        minor: u32,
+    },
+    /// Kernel version is sufficient but io_uring_setup(2) failed - likely
+    /// blocked by seccomp, container runtime, or permission restrictions.
+    SyscallBlocked {
+        /// Detected kernel major.minor version.
+        major: u32,
+        minor: u32,
+    },
+}
+
+impl IoUringProbeResult {
+    /// Returns a human-readable reason string suitable for log output.
+    pub(crate) fn reason(&self) -> String {
+        match self {
+            Self::Available { major, minor } => {
+                format!("io_uring available (kernel {major}.{minor})")
+            }
+            Self::NoKernelRelease => {
+                "io_uring unavailable: could not read kernel version".to_string()
+            }
+            Self::UnparsableVersion => {
+                "io_uring unavailable: could not parse kernel version".to_string()
+            }
+            Self::KernelTooOld { major, minor } => {
+                format!("io_uring unavailable: kernel {major}.{minor} is below minimum 5.6")
+            }
+            Self::SyscallBlocked { major, minor } => {
+                format!(
+                    "io_uring unavailable: io_uring_setup(2) blocked on kernel {major}.{minor} \
+                     (seccomp, container, or permission restriction)"
+                )
+            }
+        }
+    }
+}
+
+/// Probes io_uring availability and returns the detailed result.
+pub(crate) fn check_io_uring_reason() -> IoUringProbeResult {
     let release = match get_kernel_release() {
         Some(r) => r,
-        None => return false,
+        None => return IoUringProbeResult::NoKernelRelease,
     };
 
-    let version = match parse_kernel_version(&release) {
+    let (major, minor) = match parse_kernel_version(&release) {
         Some(v) => v,
-        None => return false,
+        None => return IoUringProbeResult::UnparsableVersion,
     };
 
-    if version < MIN_KERNEL_VERSION {
-        return false;
+    if (major, minor) < MIN_KERNEL_VERSION {
+        return IoUringProbeResult::KernelTooOld { major, minor };
     }
 
-    // Try to create a small io_uring instance to verify it's not blocked
-    RawIoUring::new(4).is_ok()
+    if RawIoUring::new(4).is_ok() {
+        IoUringProbeResult::Available { major, minor }
+    } else {
+        IoUringProbeResult::SyscallBlocked { major, minor }
+    }
 }
 
 /// Configuration for io_uring instances.

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -144,6 +144,37 @@ pub fn io_uring_status_detail() -> String {
     io_uring_status_detail_impl()
 }
 
+/// Returns a log-friendly reason string for io_uring availability.
+///
+/// On Linux with the `io_uring` feature enabled, probes the kernel version
+/// and attempts `io_uring_setup(2)`, returning a message like:
+/// - `"io_uring available (kernel 5.15)"`
+/// - `"io_uring unavailable: kernel 4.19 is below minimum 5.6"`
+/// - `"io_uring unavailable: io_uring_setup(2) blocked on kernel 6.1 (seccomp, container, or permission restriction)"`
+///
+/// On non-Linux platforms or without the feature, returns a compile-time reason.
+#[must_use]
+pub fn io_uring_availability_reason() -> String {
+    io_uring_availability_reason_impl()
+}
+
+#[cfg(all(target_os = "linux", feature = "io_uring"))]
+fn io_uring_availability_reason_impl() -> String {
+    io_uring::config_detail::io_uring_availability_reason()
+}
+
+#[cfg(not(all(target_os = "linux", feature = "io_uring")))]
+fn io_uring_availability_reason_impl() -> String {
+    #[cfg(not(target_os = "linux"))]
+    {
+        "io_uring unavailable: platform is not Linux".to_string()
+    }
+    #[cfg(all(target_os = "linux", not(feature = "io_uring")))]
+    {
+        "io_uring unavailable: io_uring feature not compiled in".to_string()
+    }
+}
+
 #[cfg(all(target_os = "linux", feature = "io_uring"))]
 fn io_uring_status_detail_impl() -> String {
     use io_uring::config_detail::{get_kernel_release_string, parse_kernel_version};
@@ -325,6 +356,25 @@ mod tests {
 
         #[cfg(all(target_os = "linux", feature = "io_uring"))]
         assert!(detail.contains("compiled in"));
+    }
+
+    #[test]
+    fn io_uring_availability_reason_returns_non_empty_string() {
+        let reason = io_uring_availability_reason();
+        assert!(!reason.is_empty());
+        assert!(reason.starts_with("io_uring "));
+
+        #[cfg(not(target_os = "linux"))]
+        assert!(reason.contains("not Linux"));
+
+        #[cfg(all(target_os = "linux", not(feature = "io_uring")))]
+        assert!(reason.contains("not compiled in"));
+
+        #[cfg(all(target_os = "linux", feature = "io_uring"))]
+        {
+            // Must contain either "available" or "unavailable"
+            assert!(reason.contains("available"));
+        }
     }
 
     #[test]

--- a/crates/transfer/src/disk_commit/thread.rs
+++ b/crates/transfer/src/disk_commit/thread.rs
@@ -11,6 +11,8 @@
 use std::io;
 use std::thread::{self, JoinHandle};
 
+use logging::debug_log;
+
 use crate::pipeline::messages::{CommitResult, FileMessage};
 use crate::pipeline::spsc;
 
@@ -75,6 +77,40 @@ fn try_create_disk_batch(policy: fast_io::IoUringPolicy) -> Option<fast_io::IoUr
     }
 }
 
+/// Logs io_uring availability at debug I/O level 1 (activated at `-vv`).
+///
+/// Reports whether io_uring is being used for disk writes and, if not, why.
+/// This gives users visibility into which I/O path is active without
+/// cluttering default output.
+fn log_io_uring_status(policy: fast_io::IoUringPolicy, batch_created: bool) {
+    match policy {
+        fast_io::IoUringPolicy::Disabled => {
+            debug_log!(
+                Io,
+                1,
+                "io_uring disabled by --no-io-uring, using standard I/O"
+            );
+        }
+        fast_io::IoUringPolicy::Auto | fast_io::IoUringPolicy::Enabled => {
+            if batch_created {
+                debug_log!(
+                    Io,
+                    1,
+                    "disk I/O: {}",
+                    fast_io::io_uring_availability_reason()
+                );
+            } else {
+                debug_log!(
+                    Io,
+                    1,
+                    "disk I/O: {}, using standard I/O fallback",
+                    fast_io::io_uring_availability_reason()
+                );
+            }
+        }
+    }
+}
+
 /// Main loop of the disk commit thread.
 ///
 /// Allocates a single 256KB write buffer reused across all files, matching
@@ -89,6 +125,8 @@ fn disk_thread_main(
 ) {
     let mut write_buf = Vec::with_capacity(WRITE_BUF_SIZE);
     let mut _disk_batch = try_create_disk_batch(config.io_uring_policy);
+
+    log_io_uring_status(config.io_uring_policy, _disk_batch.is_some());
 
     while let Ok(msg) = file_rx.recv() {
         match msg {


### PR DESCRIPTION
## Summary

- Adds a `debug_log!(Io, 1, ...)` message in the disk commit thread that reports whether io_uring is active for disk writes and, if unavailable, the specific reason (kernel too old, syscall blocked by seccomp/container, `--no-io-uring` flag, non-Linux platform, or feature not compiled in).
- Refactors `fast_io`'s io_uring probe to return a structured `IoUringProbeResult` enum with per-variant human-readable reason strings, exposed via `fast_io::io_uring_availability_reason()`.
- The message appears only at `-vv` (debug I/O level 1), keeping default output clean. The existing `--version` io_uring status output is unchanged.

Example messages at `-vv`:
- `disk I/O: io_uring available (kernel 6.8)`
- `disk I/O: io_uring unavailable: kernel 4.19 is below minimum 5.6, using standard I/O fallback`
- `io_uring disabled by --no-io-uring, using standard I/O`

## Test plan

- [ ] CI passes on all platforms (Linux, macOS, Windows)
- [ ] Verify non-Linux builds compile cleanly (cfg gates for stub path)
- [ ] Verify `io_uring_availability_reason_returns_non_empty_string` test passes on all platforms
- [ ] Manual test on Linux with `-vv` to confirm log message appears