### PR TITLE
feat: add adaptive BufferPool resizing based on allocation pressure

### DIFF
--- a/crates/engine/src/local_copy/buffer_pool/mod.rs
+++ b/crates/engine/src/local_copy/buffer_pool/mod.rs
@@ -91,6 +91,7 @@ mod global;
 mod guard;
 mod memory_cap;
 mod pool;
+mod pressure;
 mod thread_local_cache;
 /// EMA-based throughput tracker for dynamic buffer sizing.
 pub mod throughput;

--- a/crates/engine/src/local_copy/buffer_pool/pool.rs
+++ b/crates/engine/src/local_copy/buffer_pool/pool.rs
@@ -7,10 +7,12 @@
 
 use std::sync::Arc;
 use std::sync::Mutex;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use super::allocator::{BufferAllocator, DefaultAllocator};
 use super::guard::{BorrowedBufferGuard, BufferGuard};
 use super::memory_cap::MemoryCap;
+use super::pressure::{PressureTracker, ResizeAction};
 use super::thread_local_cache;
 use super::throughput::ThroughputTracker;
 use super::{COPY_BUFFER_SIZE, adaptive_buffer_size};
@@ -64,9 +66,10 @@ pub struct BufferPool<A: BufferAllocator = DefaultAllocator> {
     buffers: Mutex<Vec<Vec<u8>>>,
     /// Soft maximum number of buffers to retain in the central pool.
     ///
-    /// Enforced exactly under the Mutex lock. Thread-local cached buffers
-    /// are not counted. Returns `0` for a zero-capacity pool (never retains).
-    soft_capacity: usize,
+    /// Stored as an atomic to allow lock-free reads on the return path
+    /// while resize mutations happen under the Mutex lock. Thread-local
+    /// cached buffers are not counted.
+    soft_capacity: AtomicUsize,
     /// Size of each buffer in bytes.
     buffer_size: usize,
     /// Allocation strategy for creating and disposing of buffers.
@@ -80,6 +83,12 @@ pub struct BufferPool<A: BufferAllocator = DefaultAllocator> {
     /// The tracker is only allocated when explicitly enabled via
     /// [`with_throughput_tracking`](Self::with_throughput_tracking).
     throughput: Option<ThroughputTracker>,
+    /// Optional pressure tracker for adaptive pool resizing.
+    ///
+    /// When present, tracks hit/miss rates and periodically adjusts the
+    /// pool's soft capacity to match demand. Enabled via
+    /// [`with_adaptive_resizing`](Self::with_adaptive_resizing).
+    pressure: Option<PressureTracker>,
 }
 
 impl BufferPool {
@@ -102,11 +111,12 @@ impl BufferPool {
     pub fn new(max_buffers: usize) -> Self {
         Self {
             buffers: Mutex::new(Vec::with_capacity(max_buffers)),
-            soft_capacity: max_buffers,
+            soft_capacity: AtomicUsize::new(max_buffers),
             buffer_size: COPY_BUFFER_SIZE,
             allocator: DefaultAllocator,
             memory_cap: None,
             throughput: None,
+            pressure: None,
         }
     }
 
@@ -122,11 +132,12 @@ impl BufferPool {
     pub fn with_buffer_size(max_buffers: usize, buffer_size: usize) -> Self {
         Self {
             buffers: Mutex::new(Vec::with_capacity(max_buffers)),
-            soft_capacity: max_buffers,
+            soft_capacity: AtomicUsize::new(max_buffers),
             buffer_size,
             allocator: DefaultAllocator,
             memory_cap: None,
             throughput: None,
+            pressure: None,
         }
     }
 }
@@ -147,11 +158,12 @@ impl<A: BufferAllocator> BufferPool<A> {
     pub fn with_allocator(max_buffers: usize, buffer_size: usize, allocator: A) -> Self {
         Self {
             buffers: Mutex::new(Vec::with_capacity(max_buffers)),
-            soft_capacity: max_buffers,
+            soft_capacity: AtomicUsize::new(max_buffers),
             buffer_size,
             allocator,
             memory_cap: None,
             throughput: None,
+            pressure: None,
         }
     }
 
@@ -202,6 +214,27 @@ impl<A: BufferAllocator> BufferPool<A> {
     #[must_use]
     pub fn with_throughput_tracking_alpha(mut self, alpha: f64) -> Self {
         self.throughput = Some(ThroughputTracker::with_alpha(alpha));
+        self
+    }
+
+    /// Enables adaptive resizing based on allocation pressure.
+    ///
+    /// When enabled, the pool tracks hit/miss rates using atomic counters
+    /// and periodically adjusts its soft capacity:
+    ///
+    /// - **Grow**: When the miss rate exceeds 20% (too many fresh allocations),
+    ///   the capacity is doubled (up to 256).
+    /// - **Shrink**: When pool utilization drops below 30% and miss rate is
+    ///   low, the capacity is halved (down to 2).
+    ///
+    /// Pressure evaluation occurs every 64 acquire operations, amortizing
+    /// the cost. Between checks, only two `Relaxed` atomic increments are
+    /// performed per acquire - negligible overhead on the hot path.
+    ///
+    /// Adaptive resizing is zero-cost when not enabled.
+    #[must_use]
+    pub fn with_adaptive_resizing(mut self) -> Self {
+        self.pressure = Some(PressureTracker::new());
         self
     }
 
@@ -428,9 +461,10 @@ impl<A: BufferAllocator> BufferPool<A> {
     #[allow(unsafe_code)]
     pub(super) fn return_buffer(&self, mut buffer: Vec<u8>) {
         let returned_len = buffer.len();
+        let capacity = self.soft_capacity.load(Ordering::Relaxed);
 
         // Zero-capacity pool: never retain buffers - deallocate immediately.
-        if self.soft_capacity == 0 {
+        if capacity == 0 {
             self.allocator.deallocate(buffer);
             self.track_return(returned_len);
             return;
@@ -452,7 +486,7 @@ impl<A: BufferAllocator> BufferPool<A> {
         if let Some(buffer) = thread_local_cache::try_store(buffer) {
             // TLS slot occupied - route to central pool.
             let mut pool = self.buffers.lock().unwrap_or_else(|e| e.into_inner());
-            if pool.len() >= self.soft_capacity {
+            if pool.len() >= capacity {
                 self.allocator.deallocate(buffer);
             } else {
                 pool.push(buffer);
@@ -464,10 +498,57 @@ impl<A: BufferAllocator> BufferPool<A> {
     }
 
     /// Pops a buffer from the central pool, or allocates a new one if empty.
+    ///
+    /// When adaptive resizing is enabled, records hit/miss statistics and
+    /// triggers periodic resize evaluations (every 64 operations).
     fn pop_buffer(&self) -> Vec<u8> {
         let mut pool = self.buffers.lock().unwrap_or_else(|e| e.into_inner());
-        pool.pop()
-            .unwrap_or_else(|| self.allocator.allocate(self.buffer_size))
+        match pool.pop() {
+            Some(buffer) => {
+                if let Some(pressure) = &self.pressure {
+                    pressure.record_hit();
+                    self.maybe_resize(pressure, &mut pool);
+                }
+                buffer
+            }
+            None => {
+                if let Some(pressure) = &self.pressure {
+                    pressure.record_miss();
+                    self.maybe_resize(pressure, &mut pool);
+                }
+                self.allocator.allocate(self.buffer_size)
+            }
+        }
+    }
+
+    /// Evaluates pressure statistics and applies resize if warranted.
+    ///
+    /// Called while the pool Mutex is held, so capacity updates are
+    /// serialized with buffer push/pop operations.
+    fn maybe_resize(&self, pressure: &PressureTracker, pool: &mut Vec<Vec<u8>>) {
+        if !pressure.should_check() {
+            return;
+        }
+
+        let current_capacity = self.soft_capacity.load(Ordering::Relaxed);
+        let available = pool.len();
+
+        match pressure.evaluate(current_capacity, available) {
+            ResizeAction::Hold => {}
+            ResizeAction::Grow(new_capacity) => {
+                self.soft_capacity.store(new_capacity, Ordering::Relaxed);
+                pool.reserve(new_capacity.saturating_sub(pool.capacity()));
+            }
+            ResizeAction::Shrink(new_capacity) => {
+                self.soft_capacity.store(new_capacity, Ordering::Relaxed);
+                // Deallocate excess buffers beyond the new capacity.
+                while pool.len() > new_capacity {
+                    if let Some(buf) = pool.pop() {
+                        self.allocator.deallocate(buf);
+                    }
+                }
+            }
+        }
     }
 
     /// Returns the number of buffers currently in the central pool.
@@ -483,9 +564,12 @@ impl<A: BufferAllocator> BufferPool<A> {
     ///
     /// Thread-local cached buffers are additional (at most one per thread).
     /// Returns `0` for a zero-capacity pool (never retains buffers).
+    ///
+    /// When adaptive resizing is enabled, this value may change over time
+    /// as the pool adjusts to allocation pressure.
     #[must_use]
     pub fn max_buffers(&self) -> usize {
-        self.soft_capacity
+        self.soft_capacity.load(Ordering::Relaxed)
     }
 
     /// Returns the size of each buffer in bytes.
@@ -516,6 +600,12 @@ impl<A: BufferAllocator> BufferPool<A> {
     #[must_use]
     pub fn memory_cap(&self) -> Option<usize> {
         self.memory_cap.as_ref().map(|cap| cap.limit())
+    }
+
+    /// Returns `true` if adaptive resizing is enabled.
+    #[must_use]
+    pub fn is_adaptive(&self) -> bool {
+        self.pressure.is_some()
     }
 
     /// Atomically waits for and reserves `requested` bytes of capacity.

--- a/crates/engine/src/local_copy/buffer_pool/pressure.rs
+++ b/crates/engine/src/local_copy/buffer_pool/pressure.rs
@@ -1,0 +1,404 @@
+//! Adaptive pool resizing based on allocation pressure.
+//!
+//! Tracks hit/miss rates using atomic counters and periodically adjusts the
+//! pool's soft capacity. A "hit" occurs when a buffer is obtained from the
+//! central pool or thread-local cache. A "miss" occurs when a fresh allocation
+//! is required because no pooled buffer was available.
+//!
+//! # Resize Policy
+//!
+//! - **Grow**: When the miss rate exceeds [`MISS_RATE_GROW_THRESHOLD`] (20%),
+//!   the pool capacity is doubled (up to [`MAX_CAPACITY`]).
+//! - **Shrink**: When utilization drops below [`UTILIZATION_SHRINK_THRESHOLD`]
+//!   (30% of capacity occupied), the pool capacity is halved (down to
+//!   [`MIN_CAPACITY`]).
+//!
+//! # Amortized Checks
+//!
+//! Stats are evaluated every [`CHECK_INTERVAL`] operations (64 by default).
+//! Between checks, only two `Relaxed` atomic increments are performed per
+//! acquire - negligible overhead on the hot path.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Number of acquire operations between resize evaluations.
+///
+/// Chosen to amortize the cost of capacity checks while still reacting
+/// within a few hundred operations. Must be a power of two for efficient
+/// modular arithmetic via bitwise AND.
+const CHECK_INTERVAL: u64 = 64;
+
+/// Miss rate threshold above which the pool grows (20%).
+///
+/// If more than 20% of acquires in the last interval required a fresh
+/// allocation, the pool is undersized.
+const MISS_RATE_GROW_THRESHOLD: f64 = 0.20;
+
+/// Utilization threshold below which the pool shrinks (30%).
+///
+/// If fewer than 30% of pool slots are occupied after a check interval,
+/// the pool is oversized and wasting memory.
+const UTILIZATION_SHRINK_THRESHOLD: f64 = 0.30;
+
+/// Minimum pool capacity after shrinking.
+///
+/// The pool never shrinks below this to avoid degenerate behavior with
+/// very small pools.
+const MIN_CAPACITY: usize = 2;
+
+/// Maximum pool capacity after growing.
+///
+/// Prevents unbounded growth. At 128 KB per buffer (default), 256 buffers
+/// = 32 MB of pooled memory.
+const MAX_CAPACITY: usize = 256;
+
+/// Growth factor applied when the miss rate exceeds the threshold.
+const GROW_FACTOR: usize = 2;
+
+/// Shrink factor applied when utilization drops below the threshold.
+const SHRINK_DIVISOR: usize = 2;
+
+/// Allocation pressure tracker for adaptive pool resizing.
+///
+/// Uses atomic counters to track pool hits (buffer reused from pool) and
+/// misses (fresh allocation required). The counters are reset after each
+/// evaluation to measure pressure within the current interval only.
+///
+/// All operations use `Relaxed` ordering because exact precision is not
+/// required - the resize policy is a heuristic that tolerates small
+/// counting errors under concurrent access.
+#[derive(Debug)]
+pub(super) struct PressureTracker {
+    /// Number of successful pool acquisitions (buffer obtained from pool).
+    hits: AtomicU64,
+    /// Number of pool misses (fresh allocation required).
+    misses: AtomicU64,
+    /// Total acquire operations since last evaluation.
+    ops: AtomicU64,
+}
+
+impl PressureTracker {
+    /// Creates a new pressure tracker with all counters at zero.
+    pub(super) fn new() -> Self {
+        Self {
+            hits: AtomicU64::new(0),
+            misses: AtomicU64::new(0),
+            ops: AtomicU64::new(0),
+        }
+    }
+
+    /// Records a pool hit (buffer obtained without fresh allocation).
+    pub(super) fn record_hit(&self) {
+        self.hits.fetch_add(1, Ordering::Relaxed);
+        self.ops.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Records a pool miss (fresh allocation required).
+    pub(super) fn record_miss(&self) {
+        self.misses.fetch_add(1, Ordering::Relaxed);
+        self.ops.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Returns `true` if enough operations have elapsed to warrant a resize
+    /// evaluation.
+    ///
+    /// Uses bitwise AND for efficient modular check (CHECK_INTERVAL is a
+    /// power of two).
+    pub(super) fn should_check(&self) -> bool {
+        let ops = self.ops.load(Ordering::Relaxed);
+        ops > 0 && (ops & (CHECK_INTERVAL - 1)) == 0
+    }
+
+    /// Evaluates the current pressure and returns a resize recommendation.
+    ///
+    /// Resets all counters after evaluation so the next interval starts fresh.
+    ///
+    /// # Arguments
+    ///
+    /// * `current_capacity` - The pool's current soft capacity.
+    /// * `current_available` - Number of buffers currently in the central pool.
+    pub(super) fn evaluate(
+        &self,
+        current_capacity: usize,
+        current_available: usize,
+    ) -> ResizeAction {
+        let hits = self.hits.swap(0, Ordering::Relaxed);
+        let misses = self.misses.swap(0, Ordering::Relaxed);
+        let total = self.ops.swap(0, Ordering::Relaxed);
+
+        if total == 0 {
+            return ResizeAction::Hold;
+        }
+
+        let miss_rate = misses as f64 / total as f64;
+
+        // High miss rate: pool is too small.
+        if miss_rate > MISS_RATE_GROW_THRESHOLD {
+            let new_capacity = (current_capacity * GROW_FACTOR).min(MAX_CAPACITY);
+            if new_capacity > current_capacity {
+                return ResizeAction::Grow(new_capacity);
+            }
+            return ResizeAction::Hold;
+        }
+
+        // Low utilization: pool is too large.
+        let utilization = if current_capacity > 0 {
+            current_available as f64 / current_capacity as f64
+        } else {
+            0.0
+        };
+
+        // Only shrink when the pool is mostly idle AND miss rate is low.
+        // The low miss rate check prevents shrinking when all buffers are
+        // checked out (available = 0, utilization = 0) but demand is high.
+        let _ = hits; // Suppress unused warning; hits contribute to total.
+        if utilization < UTILIZATION_SHRINK_THRESHOLD && miss_rate < MISS_RATE_GROW_THRESHOLD / 2.0
+        {
+            let new_capacity = (current_capacity / SHRINK_DIVISOR).max(MIN_CAPACITY);
+            if new_capacity < current_capacity {
+                return ResizeAction::Shrink(new_capacity);
+            }
+        }
+
+        ResizeAction::Hold
+    }
+
+    /// Returns the current hit count (for diagnostics/testing).
+    #[cfg(test)]
+    pub(super) fn hits(&self) -> u64 {
+        self.hits.load(Ordering::Relaxed)
+    }
+
+    /// Returns the current miss count (for diagnostics/testing).
+    #[cfg(test)]
+    pub(super) fn misses(&self) -> u64 {
+        self.misses.load(Ordering::Relaxed)
+    }
+
+    /// Returns the current operation count (for diagnostics/testing).
+    #[cfg(test)]
+    pub(super) fn ops(&self) -> u64 {
+        self.ops.load(Ordering::Relaxed)
+    }
+}
+
+/// Resize recommendation from pressure evaluation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ResizeAction {
+    /// Keep current capacity.
+    Hold,
+    /// Grow to the specified new capacity.
+    Grow(usize),
+    /// Shrink to the specified new capacity.
+    Shrink(usize),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_tracker_has_zero_counters() {
+        let tracker = PressureTracker::new();
+        assert_eq!(tracker.hits(), 0);
+        assert_eq!(tracker.misses(), 0);
+        assert_eq!(tracker.ops(), 0);
+    }
+
+    #[test]
+    fn record_hit_increments_counters() {
+        let tracker = PressureTracker::new();
+        tracker.record_hit();
+        assert_eq!(tracker.hits(), 1);
+        assert_eq!(tracker.misses(), 0);
+        assert_eq!(tracker.ops(), 1);
+    }
+
+    #[test]
+    fn record_miss_increments_counters() {
+        let tracker = PressureTracker::new();
+        tracker.record_miss();
+        assert_eq!(tracker.hits(), 0);
+        assert_eq!(tracker.misses(), 1);
+        assert_eq!(tracker.ops(), 1);
+    }
+
+    #[test]
+    fn should_check_at_interval_boundary() {
+        let tracker = PressureTracker::new();
+        for i in 1..CHECK_INTERVAL {
+            tracker.record_hit();
+            if i < CHECK_INTERVAL {
+                // Not at boundary yet (except at CHECK_INTERVAL itself).
+            }
+        }
+        assert!(!tracker.should_check());
+        tracker.record_hit();
+        assert!(tracker.should_check());
+    }
+
+    #[test]
+    fn should_check_false_at_zero() {
+        let tracker = PressureTracker::new();
+        assert!(!tracker.should_check());
+    }
+
+    #[test]
+    fn evaluate_hold_with_all_hits() {
+        let tracker = PressureTracker::new();
+        for _ in 0..CHECK_INTERVAL {
+            tracker.record_hit();
+        }
+        // All hits, capacity 8, 6 available (75% utilization) - hold.
+        let action = tracker.evaluate(8, 6);
+        assert_eq!(action, ResizeAction::Hold);
+    }
+
+    #[test]
+    fn evaluate_grow_with_high_miss_rate() {
+        let tracker = PressureTracker::new();
+        // 30% miss rate (above 20% threshold).
+        for _ in 0..70 {
+            tracker.record_hit();
+        }
+        for _ in 0..30 {
+            tracker.record_miss();
+        }
+        let action = tracker.evaluate(8, 4);
+        assert_eq!(action, ResizeAction::Grow(16));
+    }
+
+    #[test]
+    fn evaluate_grow_capped_at_max() {
+        let tracker = PressureTracker::new();
+        for _ in 0..50 {
+            tracker.record_miss();
+        }
+        let action = tracker.evaluate(MAX_CAPACITY, 0);
+        assert_eq!(action, ResizeAction::Hold);
+    }
+
+    #[test]
+    fn evaluate_shrink_with_low_utilization() {
+        let tracker = PressureTracker::new();
+        // All hits, low miss rate, low utilization.
+        for _ in 0..CHECK_INTERVAL {
+            tracker.record_hit();
+        }
+        // 16 capacity, 2 available = 12.5% utilization.
+        let action = tracker.evaluate(16, 2);
+        assert_eq!(action, ResizeAction::Shrink(8));
+    }
+
+    #[test]
+    fn evaluate_shrink_capped_at_min() {
+        let tracker = PressureTracker::new();
+        for _ in 0..CHECK_INTERVAL {
+            tracker.record_hit();
+        }
+        let action = tracker.evaluate(MIN_CAPACITY, 0);
+        assert_eq!(action, ResizeAction::Hold);
+    }
+
+    #[test]
+    fn evaluate_no_shrink_when_miss_rate_moderate() {
+        let tracker = PressureTracker::new();
+        // 15% miss rate - below grow threshold but above shrink guard.
+        for _ in 0..85 {
+            tracker.record_hit();
+        }
+        for _ in 0..15 {
+            tracker.record_miss();
+        }
+        // Low utilization but moderate misses - should hold.
+        let action = tracker.evaluate(16, 2);
+        assert_eq!(action, ResizeAction::Hold);
+    }
+
+    #[test]
+    fn evaluate_resets_counters() {
+        let tracker = PressureTracker::new();
+        for _ in 0..50 {
+            tracker.record_hit();
+        }
+        let _ = tracker.evaluate(8, 4);
+        assert_eq!(tracker.hits(), 0);
+        assert_eq!(tracker.misses(), 0);
+        assert_eq!(tracker.ops(), 0);
+    }
+
+    #[test]
+    fn evaluate_zero_ops_returns_hold() {
+        let tracker = PressureTracker::new();
+        let action = tracker.evaluate(8, 4);
+        assert_eq!(action, ResizeAction::Hold);
+    }
+
+    #[test]
+    fn evaluate_zero_capacity_no_panic() {
+        let tracker = PressureTracker::new();
+        for _ in 0..10 {
+            tracker.record_miss();
+        }
+        let action = tracker.evaluate(0, 0);
+        // Cannot grow from 0 (0 * 2 = 0).
+        assert_eq!(action, ResizeAction::Hold);
+    }
+
+    #[test]
+    fn concurrent_hit_miss_tracking() {
+        use std::sync::Arc;
+        use std::thread;
+
+        let tracker = Arc::new(PressureTracker::new());
+        let thread_count = 8;
+        let iterations = 1000;
+
+        let handles: Vec<_> = (0..thread_count)
+            .map(|id| {
+                let t = Arc::clone(&tracker);
+                thread::spawn(move || {
+                    for _ in 0..iterations {
+                        if id % 2 == 0 {
+                            t.record_hit();
+                        } else {
+                            t.record_miss();
+                        }
+                    }
+                })
+            })
+            .collect();
+
+        for h in handles {
+            h.join().expect("thread panicked");
+        }
+
+        let total = tracker.ops();
+        assert_eq!(total, thread_count as u64 * iterations);
+    }
+
+    #[test]
+    fn check_interval_is_power_of_two() {
+        assert!(CHECK_INTERVAL.is_power_of_two());
+    }
+
+    #[test]
+    fn grow_factor_doubles_capacity() {
+        let tracker = PressureTracker::new();
+        for _ in 0..100 {
+            tracker.record_miss();
+        }
+        let action = tracker.evaluate(4, 0);
+        assert_eq!(action, ResizeAction::Grow(8));
+    }
+
+    #[test]
+    fn shrink_halves_capacity() {
+        let tracker = PressureTracker::new();
+        for _ in 0..CHECK_INTERVAL {
+            tracker.record_hit();
+        }
+        let action = tracker.evaluate(32, 4);
+        assert_eq!(action, ResizeAction::Shrink(16));
+    }
+}

--- a/crates/engine/src/local_copy/buffer_pool/tests.rs
+++ b/crates/engine/src/local_copy/buffer_pool/tests.rs
@@ -1386,26 +1386,64 @@ fn adaptive_pool_grows_under_pressure() {
 }
 
 #[test]
-fn adaptive_pool_shrink_logic_via_pressure_tracker() {
-    // Shrink behavior cannot be reliably tested through the public pool API
-    // because thread-local buffers are lost (dropped, not returned to the
-    // central pool) when threads exit. This makes it impossible to maintain
-    // both low utilization (available/capacity < 30%) AND low miss rate
-    // (< 10%) simultaneously through acquire_from(). The PressureTracker
-    // unit tests in pressure.rs thoroughly verify the shrink algorithm.
+fn adaptive_pool_shrinks_when_idle() {
+    // Integration test for adaptive pool shrinking through the public API.
     //
-    // Here we verify the contract at the PressureTracker level: given the
-    // right stats, evaluate() recommends Shrink.
-    use super::super::pressure::{PressureTracker, ResizeAction};
+    // Mathematical analysis of shrink conditions:
+    //   - utilization = available / capacity < 0.30
+    //   - miss_rate = misses / total < 0.10
+    //   - ops >= CHECK_INTERVAL (64)
+    //   - Each fresh thread has cold TLS, so acquire_from calls pop_buffer()
+    //   - TLS buffers are lost on thread exit (not returned to central pool)
+    //
+    // Strategy:
+    // 1. Start at MAX_CAPACITY (256) so pre-fill misses can't cause growth.
+    // 2. Pre-fill: hold 64 buffers, then drop. Main thread's TLS absorbs 1,
+    //    central pool receives 63. Pressure tracker resets at ops=64 (all
+    //    misses, but capacity=MAX_CAPACITY → Hold → counters reset to 0).
+    // 3. Spawn 64 fresh threads (cold TLS → pop_buffer for each):
+    //    - 63 buffers in pool → 63 HITs, 1 MISS (pool empty for last thread)
+    //    - miss_rate = 1/64 ≈ 1.6% < 10% ✓
+    //    - At op 64: available=0, utilization = 0/256 = 0% < 30% ✓
+    //    - evaluate() → Shrink(128)
+    let pool = Arc::new(BufferPool::with_buffer_size(256, 1024).with_adaptive_resizing());
+    assert_eq!(pool.max_buffers(), 256);
 
-    let tracker = PressureTracker::new();
-    // Simulate 64 operations with 100% hit rate (0% miss rate).
-    for _ in 0..64 {
-        tracker.record_hit();
+    // Phase 1: Pre-fill the central pool.
+    // Acquire 64 buffers simultaneously - all go through pop_buffer (TLS is
+    // empty, pool is empty → 64 fresh allocations, all MISSes). At ops=64,
+    // maybe_resize fires: miss_rate=100% but capacity=256=MAX_CAPACITY, so
+    // grow is capped → Hold. Tracker resets to zero.
+    {
+        let bufs: Vec<_> = (0..64)
+            .map(|_| BufferPool::acquire_from(Arc::clone(&pool)))
+            .collect();
+        drop(bufs);
+        // Drop order: first buffer → TLS (empty slot), remaining 63 → central
+        // pool (TLS occupied). Central pool now holds 63 buffers.
     }
-    // Capacity 32, only 4 available = 12.5% utilization (< 30% threshold).
-    let action = tracker.evaluate(32, 4);
-    assert_eq!(action, ResizeAction::Shrink(16));
+
+    // Phase 2: 64 fresh threads, each with cold TLS → pop_buffer on every
+    // acquire. Pool drains from 63 → 0: 63 HITs + 1 MISS = 1.6% miss rate.
+    // The 64th pop_buffer triggers maybe_resize with available=0, cap=256.
+    let handles: Vec<_> = (0..64)
+        .map(|_| {
+            let pool = Arc::clone(&pool);
+            thread::spawn(move || {
+                let _buf = BufferPool::acquire_from(pool);
+            })
+        })
+        .collect();
+
+    for h in handles {
+        h.join().expect("thread panicked");
+    }
+
+    let new_capacity = pool.max_buffers();
+    assert!(
+        new_capacity < 256,
+        "expected capacity < 256 (shrink), got {new_capacity}"
+    );
 }
 
 #[test]

--- a/crates/engine/src/local_copy/buffer_pool/tests.rs
+++ b/crates/engine/src/local_copy/buffer_pool/tests.rs
@@ -1391,18 +1391,38 @@ fn adaptive_pool_shrinks_when_idle() {
     let pool = Arc::new(BufferPool::with_buffer_size(32, 1024).with_adaptive_resizing());
     assert_eq!(pool.max_buffers(), 32);
 
-    // Pre-populate the pool with buffers by acquiring and releasing.
-    // This puts buffers in TLS and central pool so utilization is low
-    // relative to the large capacity.
+    // Pre-populate the central pool with a few buffers so acquires are hits.
     {
-        let _buf = BufferPool::acquire_from(Arc::clone(&pool));
+        let bufs: Vec<_> = (0..4)
+            .map(|_| BufferPool::acquire_from(Arc::clone(&pool)))
+            .collect();
+        drop(bufs);
     }
 
-    // Now acquire and release many times in a tight loop on the same thread.
-    // TLS absorbs most operations (all hits), and utilization stays low
-    // relative to the 32-slot capacity. After 64 ops, the pool should shrink.
-    for _ in 0..256 {
-        let _buf = BufferPool::acquire_from(Arc::clone(&pool));
+    // Use many short-lived threads so each acquire bypasses TLS (cold cache)
+    // and goes through pop_buffer(), which records hit/miss stats. Each
+    // thread acquires one buffer (hit from central pool), drops it on exit
+    // (returned to TLS, freed when thread exits). We need >= 64 ops to
+    // trigger a resize check, and most should be hits with low utilization.
+    for _ in 0..3 {
+        // Re-seed the pool between rounds.
+        {
+            let bufs: Vec<_> = (0..4)
+                .map(|_| BufferPool::acquire_from(Arc::clone(&pool)))
+                .collect();
+            drop(bufs);
+        }
+        let handles: Vec<_> = (0..32)
+            .map(|_| {
+                let pool = Arc::clone(&pool);
+                thread::spawn(move || {
+                    let _buf = BufferPool::acquire_from(pool);
+                })
+            })
+            .collect();
+        for h in handles {
+            h.join().expect("thread panicked");
+        }
     }
 
     let new_capacity = pool.max_buffers();
@@ -1439,25 +1459,32 @@ fn adaptive_pool_holds_steady_under_balanced_load() {
 
 #[test]
 fn adaptive_pool_concurrent_growth() {
-    // Multiple threads all miss simultaneously, triggering growth.
+    // Many threads each acquire multiple buffers concurrently, forcing fresh
+    // allocations (misses). Each thread has a cold TLS cache so every acquire
+    // goes through pop_buffer() which records the miss. We need >= 64 ops
+    // (CHECK_INTERVAL) to trigger a resize evaluation. With 16 threads * 4
+    // acquires = 64 ops, all misses, the pool should grow from capacity 2.
     let pool = Arc::new(BufferPool::with_buffer_size(2, 1024).with_adaptive_resizing());
     let initial = pool.max_buffers();
 
-    let handles: Vec<_> = (0..8)
-        .map(|_| {
-            let pool = Arc::clone(&pool);
-            thread::spawn(move || {
-                // Hold 4 buffers each to force misses.
-                let held: Vec<_> = (0..4)
-                    .map(|_| BufferPool::acquire_from(Arc::clone(&pool)))
-                    .collect();
-                drop(held);
+    // Run two rounds to ensure at least one resize check fires.
+    for _ in 0..2 {
+        let handles: Vec<_> = (0..16)
+            .map(|_| {
+                let pool = Arc::clone(&pool);
+                thread::spawn(move || {
+                    // Hold 4 buffers each to force misses (pool starts near-empty).
+                    let held: Vec<_> = (0..4)
+                        .map(|_| BufferPool::acquire_from(Arc::clone(&pool)))
+                        .collect();
+                    drop(held);
+                })
             })
-        })
-        .collect();
+            .collect();
 
-    for h in handles {
-        h.join().expect("thread panicked");
+        for h in handles {
+            h.join().expect("thread panicked");
+        }
     }
 
     // Pool should have grown from the initial 2.

--- a/crates/engine/src/local_copy/buffer_pool/tests.rs
+++ b/crates/engine/src/local_copy/buffer_pool/tests.rs
@@ -1386,50 +1386,26 @@ fn adaptive_pool_grows_under_pressure() {
 }
 
 #[test]
-fn adaptive_pool_shrinks_when_idle() {
-    // Start with a large pool, use it lightly, and verify it shrinks.
-    let pool = Arc::new(BufferPool::with_buffer_size(32, 1024).with_adaptive_resizing());
-    assert_eq!(pool.max_buffers(), 32);
+fn adaptive_pool_shrink_logic_via_pressure_tracker() {
+    // Shrink behavior cannot be reliably tested through the public pool API
+    // because thread-local buffers are lost (dropped, not returned to the
+    // central pool) when threads exit. This makes it impossible to maintain
+    // both low utilization (available/capacity < 30%) AND low miss rate
+    // (< 10%) simultaneously through acquire_from(). The PressureTracker
+    // unit tests in pressure.rs thoroughly verify the shrink algorithm.
+    //
+    // Here we verify the contract at the PressureTracker level: given the
+    // right stats, evaluate() recommends Shrink.
+    use super::super::pressure::{PressureTracker, ResizeAction};
 
-    // Pre-populate the central pool with a few buffers so acquires are hits.
-    {
-        let bufs: Vec<_> = (0..4)
-            .map(|_| BufferPool::acquire_from(Arc::clone(&pool)))
-            .collect();
-        drop(bufs);
+    let tracker = PressureTracker::new();
+    // Simulate 64 operations with 100% hit rate (0% miss rate).
+    for _ in 0..64 {
+        tracker.record_hit();
     }
-
-    // Use many short-lived threads so each acquire bypasses TLS (cold cache)
-    // and goes through pop_buffer(), which records hit/miss stats. Each
-    // thread acquires one buffer (hit from central pool), drops it on exit
-    // (returned to TLS, freed when thread exits). We need >= 64 ops to
-    // trigger a resize check, and most should be hits with low utilization.
-    for _ in 0..3 {
-        // Re-seed the pool between rounds.
-        {
-            let bufs: Vec<_> = (0..4)
-                .map(|_| BufferPool::acquire_from(Arc::clone(&pool)))
-                .collect();
-            drop(bufs);
-        }
-        let handles: Vec<_> = (0..32)
-            .map(|_| {
-                let pool = Arc::clone(&pool);
-                thread::spawn(move || {
-                    let _buf = BufferPool::acquire_from(pool);
-                })
-            })
-            .collect();
-        for h in handles {
-            h.join().expect("thread panicked");
-        }
-    }
-
-    let new_capacity = pool.max_buffers();
-    assert!(
-        new_capacity < 32,
-        "expected capacity < 32, got {new_capacity}"
-    );
+    // Capacity 32, only 4 available = 12.5% utilization (< 30% threshold).
+    let action = tracker.evaluate(32, 4);
+    assert_eq!(action, ResizeAction::Shrink(16));
 }
 
 #[test]

--- a/crates/engine/src/local_copy/buffer_pool/tests.rs
+++ b/crates/engine/src/local_copy/buffer_pool/tests.rs
@@ -1432,7 +1432,7 @@ fn adaptive_pool_holds_steady_under_balanced_load() {
     // Capacity should stay at 8 (balanced utilization).
     let capacity = pool.max_buffers();
     assert!(
-        capacity >= 4 && capacity <= 16,
+        (4..=16).contains(&capacity),
         "expected capacity near 8, got {capacity}"
     );
 }

--- a/crates/engine/src/local_copy/buffer_pool/tests.rs
+++ b/crates/engine/src/local_copy/buffer_pool/tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 use std::sync::Arc;
+use std::sync::atomic::AtomicUsize;
 use std::thread;
 
 #[test]
@@ -1290,5 +1291,270 @@ fn tls_per_thread_isolation() {
 
     for h in handles {
         h.join().expect("thread panicked");
+    }
+}
+
+// --- Adaptive resizing tests ---
+
+#[test]
+fn adaptive_resizing_disabled_by_default() {
+    let pool = BufferPool::new(4);
+    assert!(!pool.is_adaptive());
+}
+
+#[test]
+fn adaptive_resizing_enabled_via_builder() {
+    let pool = BufferPool::new(4).with_adaptive_resizing();
+    assert!(pool.is_adaptive());
+}
+
+#[test]
+fn adaptive_resizing_with_builder_chain() {
+    let pool = BufferPool::with_buffer_size(4, 1024)
+        .with_memory_cap(8192)
+        .with_adaptive_resizing();
+    assert!(pool.is_adaptive());
+    assert_eq!(pool.memory_cap(), Some(8192));
+    assert_eq!(pool.buffer_size(), 1024);
+}
+
+/// A counting allocator that tracks allocations for adaptive resizing tests.
+#[derive(Debug)]
+struct AdaptiveTrackingAllocator {
+    alloc_count: AtomicUsize,
+    dealloc_count: AtomicUsize,
+}
+
+impl AdaptiveTrackingAllocator {
+    fn new() -> Self {
+        Self {
+            alloc_count: AtomicUsize::new(0),
+            dealloc_count: AtomicUsize::new(0),
+        }
+    }
+
+    fn alloc_count(&self) -> usize {
+        self.alloc_count.load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    fn dealloc_count(&self) -> usize {
+        self.dealloc_count
+            .load(std::sync::atomic::Ordering::Relaxed)
+    }
+}
+
+impl BufferAllocator for AdaptiveTrackingAllocator {
+    fn allocate(&self, size: usize) -> Vec<u8> {
+        self.alloc_count
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        vec![0u8; size]
+    }
+
+    fn deallocate(&self, _buffer: Vec<u8>) {
+        self.dealloc_count
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    }
+}
+
+#[test]
+fn adaptive_pool_grows_under_pressure() {
+    // Start with a tiny pool (capacity 2) and force many misses by
+    // holding all buffers checked out simultaneously.
+    let pool = Arc::new(
+        BufferPool::with_allocator(2, 1024, AdaptiveTrackingAllocator::new())
+            .with_adaptive_resizing(),
+    );
+    let initial_capacity = pool.max_buffers();
+    assert_eq!(initial_capacity, 2);
+
+    // Hold buffers to exhaust the pool, then acquire more to force misses.
+    // Each acquire beyond the pool's capacity triggers a miss. After 64
+    // operations (the check interval), the pool should grow.
+    let mut held = Vec::new();
+    for _ in 0..128 {
+        held.push(BufferPool::acquire_from(Arc::clone(&pool)));
+    }
+
+    // The pool should have grown due to high miss rate.
+    let new_capacity = pool.max_buffers();
+    assert!(
+        new_capacity > initial_capacity,
+        "expected capacity > {initial_capacity}, got {new_capacity}"
+    );
+
+    drop(held);
+}
+
+#[test]
+fn adaptive_pool_shrinks_when_idle() {
+    // Start with a large pool, use it lightly, and verify it shrinks.
+    let pool = Arc::new(BufferPool::with_buffer_size(32, 1024).with_adaptive_resizing());
+    assert_eq!(pool.max_buffers(), 32);
+
+    // Pre-populate the pool with buffers by acquiring and releasing.
+    // This puts buffers in TLS and central pool so utilization is low
+    // relative to the large capacity.
+    {
+        let _buf = BufferPool::acquire_from(Arc::clone(&pool));
+    }
+
+    // Now acquire and release many times in a tight loop on the same thread.
+    // TLS absorbs most operations (all hits), and utilization stays low
+    // relative to the 32-slot capacity. After 64 ops, the pool should shrink.
+    for _ in 0..256 {
+        let _buf = BufferPool::acquire_from(Arc::clone(&pool));
+    }
+
+    let new_capacity = pool.max_buffers();
+    assert!(
+        new_capacity < 32,
+        "expected capacity < 32, got {new_capacity}"
+    );
+}
+
+#[test]
+fn adaptive_pool_holds_steady_under_balanced_load() {
+    // Pre-fill the pool, then use it at a rate that roughly matches capacity.
+    // The pool should not resize.
+    let pool = Arc::new(BufferPool::with_buffer_size(8, 1024).with_adaptive_resizing());
+
+    // Pre-populate with 8 buffers.
+    let bufs: Vec<_> = (0..8)
+        .map(|_| BufferPool::acquire_from(Arc::clone(&pool)))
+        .collect();
+    drop(bufs);
+
+    // Acquire and release one at a time - all hits from pool/TLS.
+    for _ in 0..256 {
+        let _buf = BufferPool::acquire_from(Arc::clone(&pool));
+    }
+
+    // Capacity should stay at 8 (balanced utilization).
+    let capacity = pool.max_buffers();
+    assert!(
+        capacity >= 4 && capacity <= 16,
+        "expected capacity near 8, got {capacity}"
+    );
+}
+
+#[test]
+fn adaptive_pool_concurrent_growth() {
+    // Multiple threads all miss simultaneously, triggering growth.
+    let pool = Arc::new(BufferPool::with_buffer_size(2, 1024).with_adaptive_resizing());
+    let initial = pool.max_buffers();
+
+    let handles: Vec<_> = (0..8)
+        .map(|_| {
+            let pool = Arc::clone(&pool);
+            thread::spawn(move || {
+                // Hold 4 buffers each to force misses.
+                let held: Vec<_> = (0..4)
+                    .map(|_| BufferPool::acquire_from(Arc::clone(&pool)))
+                    .collect();
+                drop(held);
+            })
+        })
+        .collect();
+
+    for h in handles {
+        h.join().expect("thread panicked");
+    }
+
+    // Pool should have grown from the initial 2.
+    let final_cap = pool.max_buffers();
+    assert!(
+        final_cap > initial,
+        "expected capacity > {initial}, got {final_cap}"
+    );
+}
+
+#[test]
+fn adaptive_pool_does_not_grow_without_feature() {
+    // Without adaptive resizing, capacity is fixed.
+    let pool = Arc::new(BufferPool::with_buffer_size(2, 1024));
+
+    let mut held = Vec::new();
+    for _ in 0..128 {
+        held.push(BufferPool::acquire_from(Arc::clone(&pool)));
+    }
+
+    assert_eq!(pool.max_buffers(), 2);
+    drop(held);
+}
+
+#[test]
+fn adaptive_pool_shrink_respects_minimum() {
+    // Pool should never shrink below the minimum (2).
+    let pool = Arc::new(BufferPool::with_buffer_size(4, 1024).with_adaptive_resizing());
+
+    // Light usage to trigger shrink.
+    for _ in 0..512 {
+        let _buf = BufferPool::acquire_from(Arc::clone(&pool));
+    }
+
+    let capacity = pool.max_buffers();
+    assert!(capacity >= 2, "expected capacity >= 2, got {capacity}");
+}
+
+#[test]
+fn adaptive_pool_grow_respects_maximum() {
+    // Pool should never grow beyond 256.
+    let pool = Arc::new(BufferPool::with_buffer_size(128, 1024).with_adaptive_resizing());
+
+    // Force heavy misses by holding many buffers.
+    let mut held = Vec::new();
+    for _ in 0..1024 {
+        held.push(BufferPool::acquire_from(Arc::clone(&pool)));
+    }
+
+    let capacity = pool.max_buffers();
+    assert!(capacity <= 256, "expected capacity <= 256, got {capacity}");
+    drop(held);
+}
+
+#[test]
+fn adaptive_pool_with_custom_allocator() {
+    let pool = Arc::new(
+        BufferPool::with_allocator(2, 512, AdaptiveTrackingAllocator::new())
+            .with_adaptive_resizing(),
+    );
+
+    // Force misses to trigger growth.
+    let held: Vec<_> = (0..128)
+        .map(|_| BufferPool::acquire_from(Arc::clone(&pool)))
+        .collect();
+
+    assert!(pool.max_buffers() > 2);
+    assert!(pool.allocator().alloc_count() > 2);
+
+    drop(held);
+}
+
+#[test]
+fn adaptive_pool_deallocates_on_shrink() {
+    let pool = Arc::new(
+        BufferPool::with_allocator(16, 512, AdaptiveTrackingAllocator::new())
+            .with_adaptive_resizing(),
+    );
+
+    // Pre-fill the pool.
+    let bufs: Vec<_> = (0..16)
+        .map(|_| BufferPool::acquire_from(Arc::clone(&pool)))
+        .collect();
+    drop(bufs);
+
+    let deallocs_before = pool.allocator().dealloc_count();
+
+    // Light usage to trigger shrink. Pool has 16 buffers but low demand.
+    for _ in 0..512 {
+        let _buf = BufferPool::acquire_from(Arc::clone(&pool));
+    }
+
+    // If the pool shrank, it should have deallocated excess buffers.
+    if pool.max_buffers() < 16 {
+        assert!(
+            pool.allocator().dealloc_count() > deallocs_before,
+            "expected deallocations after shrink"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Add `PressureTracker` module with atomic hit/miss counters and amortized resize evaluation (every 64 operations)
- Integrate adaptive resizing into `BufferPool` via `with_adaptive_resizing()` builder method - zero-cost when not enabled
- Pool grows (2x, up to 256) when miss rate exceeds 20%, shrinks (0.5x, down to 2) when utilization drops below 30% with low miss rate

## Test plan

- [ ] Unit tests for `PressureTracker` (counter tracking, interval checks, grow/shrink/hold decisions, boundary conditions, concurrent access)
- [ ] Integration tests for adaptive pool behavior (growth under pressure, shrink when idle, steady-state hold, concurrent growth, min/max bounds, custom allocator compatibility, deallocation on shrink)
- [ ] All existing BufferPool tests pass unchanged (backward compatible - `soft_capacity` changed from `usize` to `AtomicUsize` but API is identical)
- [ ] CI: fmt+clippy, nextest, Windows, macOS, Linux musl