### PR TITLE
fix: surface SSH stderr on error in Drop impls

### DIFF
--- a/crates/rsync_io/src/ssh/connection.rs
+++ b/crates/rsync_io/src/ssh/connection.rs
@@ -382,8 +382,35 @@ impl Drop for SshChildHandle {
         if let Ok(None) = self.child.try_wait() {
             let _ = self.child.kill();
         }
-        let _ = self.child.wait();
-        // The StderrDrain's own Drop will join the thread.
+        let status = self.child.wait();
+
+        // Join the drain thread before checking the buffer so all stderr
+        // output is available. StderrDrain::Drop would also join, but we
+        // need the data now.
+        if let Some(ref mut drain) = self.stderr_drain {
+            drain.join();
+        }
+
+        // When the child exited with a non-zero status and stderr was
+        // captured, surface it so SSH errors are never silently lost -
+        // even on abnormal control flow (panic, early return) where the
+        // caller never calls wait_with_stderr(). The drain thread already
+        // forwarded individual lines in real time via eprint!, but a
+        // consolidated message here makes the failure clearly visible.
+        if let Ok(exit) = &status {
+            if !exit.success() {
+                if let Some(drain) = &self.stderr_drain {
+                    let stderr = drain.collected();
+                    if !stderr.is_empty() {
+                        let text = String::from_utf8_lossy(&stderr);
+                        let trimmed = text.trim();
+                        if !trimmed.is_empty() {
+                            eprintln!("ssh process exited with status {exit}:\n{trimmed}");
+                        }
+                    }
+                }
+            }
+        }
     }
 }
 
@@ -426,7 +453,30 @@ impl Drop for SshConnection {
             if let Ok(None) = child.try_wait() {
                 let _ = child.kill();
             }
-            let _ = child.wait();
+            let status = child.wait();
+
+            // Join the drain thread before checking the buffer.
+            if let Some(ref mut drain) = self.stderr_drain {
+                drain.join();
+            }
+
+            // Surface collected stderr when the child exited with an error,
+            // ensuring SSH diagnostics are visible even when the connection
+            // is dropped without an explicit wait() call.
+            if let Ok(exit) = &status {
+                if !exit.success() {
+                    if let Some(drain) = &self.stderr_drain {
+                        let stderr = drain.collected();
+                        if !stderr.is_empty() {
+                            let text = String::from_utf8_lossy(&stderr);
+                            let trimmed = text.trim();
+                            if !trimmed.is_empty() {
+                                eprintln!("ssh process exited with status {exit}:\n{trimmed}");
+                            }
+                        }
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

- When `SshChildHandle` or `SshConnection` is dropped without an explicit `wait_with_stderr()` call (e.g., due to a panic or early return), the collected SSH stderr was silently discarded after the drain thread finished
- Both `Drop` impls now join the drain thread, check the child exit status, and print collected stderr via `eprintln!` when the child exited with a non-zero status
- The drain thread's real-time `eprint!` forwarding remains unchanged - this adds a consolidated error message on drop as a safety net

## Test plan

- [ ] CI passes (fmt, clippy, nextest, all platforms)
- [ ] Existing SSH tests continue to pass (they call `wait()` explicitly, so `Drop` does not fire)
- [ ] Manual test: kill an SSH connection mid-transfer and verify stderr is printed