### PR TITLE
refactor: deduplicate SSH stderr surfacing logic in Drop impls

### DIFF
--- a/crates/rsync_io/src/ssh/connection.rs
+++ b/crates/rsync_io/src/ssh/connection.rs
@@ -297,6 +297,30 @@ impl StderrDrain {
             let _ = handle.join();
         }
     }
+
+    /// Joins the drain thread and prints collected stderr when `status`
+    /// indicates a non-zero exit.
+    ///
+    /// This is the single implementation of the "surface stderr on error in
+    /// Drop" logic used by both [`SshChildHandle::drop`] and
+    /// [`SshConnection::drop`]. The drain thread is joined first so all
+    /// output is available before the buffer is checked.
+    fn join_and_surface_on_error(&mut self, status: &io::Result<ExitStatus>) {
+        self.join();
+
+        if let Ok(exit) = status {
+            if !exit.success() {
+                let stderr = self.collected();
+                if !stderr.is_empty() {
+                    let text = String::from_utf8_lossy(&stderr);
+                    let trimmed = text.trim();
+                    if !trimmed.is_empty() {
+                        eprintln!("ssh process exited with status {exit}:\n{trimmed}");
+                    }
+                }
+            }
+        }
+    }
 }
 
 impl Drop for StderrDrain {
@@ -384,32 +408,12 @@ impl Drop for SshChildHandle {
         }
         let status = self.child.wait();
 
-        // Join the drain thread before checking the buffer so all stderr
-        // output is available. StderrDrain::Drop would also join, but we
-        // need the data now.
+        // Surface collected stderr when the child exited with an error,
+        // ensuring SSH diagnostics are visible even on abnormal control
+        // flow (panic, early return) where the caller never calls
+        // wait_with_stderr().
         if let Some(ref mut drain) = self.stderr_drain {
-            drain.join();
-        }
-
-        // When the child exited with a non-zero status and stderr was
-        // captured, surface it so SSH errors are never silently lost -
-        // even on abnormal control flow (panic, early return) where the
-        // caller never calls wait_with_stderr(). The drain thread already
-        // forwarded individual lines in real time via eprint!, but a
-        // consolidated message here makes the failure clearly visible.
-        if let Ok(exit) = &status {
-            if !exit.success() {
-                if let Some(drain) = &self.stderr_drain {
-                    let stderr = drain.collected();
-                    if !stderr.is_empty() {
-                        let text = String::from_utf8_lossy(&stderr);
-                        let trimmed = text.trim();
-                        if !trimmed.is_empty() {
-                            eprintln!("ssh process exited with status {exit}:\n{trimmed}");
-                        }
-                    }
-                }
-            }
+            drain.join_and_surface_on_error(&status);
         }
     }
 }
@@ -455,27 +459,11 @@ impl Drop for SshConnection {
             }
             let status = child.wait();
 
-            // Join the drain thread before checking the buffer.
-            if let Some(ref mut drain) = self.stderr_drain {
-                drain.join();
-            }
-
             // Surface collected stderr when the child exited with an error,
             // ensuring SSH diagnostics are visible even when the connection
             // is dropped without an explicit wait() call.
-            if let Ok(exit) = &status {
-                if !exit.success() {
-                    if let Some(drain) = &self.stderr_drain {
-                        let stderr = drain.collected();
-                        if !stderr.is_empty() {
-                            let text = String::from_utf8_lossy(&stderr);
-                            let trimmed = text.trim();
-                            if !trimmed.is_empty() {
-                                eprintln!("ssh process exited with status {exit}:\n{trimmed}");
-                            }
-                        }
-                    }
-                }
+            if let Some(ref mut drain) = self.stderr_drain {
+                drain.join_and_surface_on_error(&status);
             }
         }
     }

--- a/crates/rsync_io/src/ssh/tests.rs
+++ b/crates/rsync_io/src/ssh/tests.rs
@@ -1082,6 +1082,50 @@ fn stderr_drain_joins_on_drop() {
 
 #[cfg(unix)]
 #[test]
+fn child_handle_drop_surfaces_stderr_on_nonzero_exit() {
+    // When SshChildHandle is dropped without wait_with_stderr() and the child
+    // exited with a non-zero status, the Drop impl must join the drain thread
+    // and surface stderr. This exercises the abnormal-exit Drop path that
+    // prevents SSH errors from being silently lost.
+    let mut command = SshCommand::new("ignored");
+    command.set_program("sh");
+    command.set_batch_mode(false);
+    command.push_option("-c");
+    command.push_option("printf 'fatal: host key verification failed\\n' >&2; exit 255");
+    command.set_target_override(Some(OsString::new()));
+
+    let connection = command.spawn().expect("spawn shell");
+    let (_reader, writer, child_handle) = connection.split().expect("split");
+
+    writer.close().expect("close writer");
+
+    // Dropping the child handle without calling wait() should not panic,
+    // and the drain thread should be joined cleanly.
+    drop(child_handle);
+}
+
+#[cfg(unix)]
+#[test]
+fn connection_drop_surfaces_stderr_on_nonzero_exit() {
+    // When SshConnection is dropped (not split) and the child exited with
+    // an error, the Drop impl must surface stderr. This tests the direct
+    // connection Drop path used when callers do not split into reader/writer.
+    let mut command = SshCommand::new("ignored");
+    command.set_program("sh");
+    command.set_batch_mode(false);
+    command.push_option("-c");
+    command.push_option("printf 'Connection refused\\n' >&2; exit 1");
+    command.set_target_override(Some(OsString::new()));
+
+    let connection = command.spawn().expect("spawn shell");
+
+    // Dropping the connection directly without wait() should not panic,
+    // and the drain thread should be joined cleanly.
+    drop(connection);
+}
+
+#[cfg(unix)]
+#[test]
 fn stderr_deadlock_regression_large_stderr_does_not_block_stdout() {
     // Regression test: when a child writes large amounts to stderr while also
     // writing to stdout, the parent must be able to read stdout without


### PR DESCRIPTION
## Summary
- Extract duplicated stderr-on-error surfacing logic from `SshChildHandle::Drop` and `SshConnection::Drop` into a single `StderrDrain::join_and_surface_on_error()` helper method
- Add tests for the Drop-path stderr surfacing with non-zero exit for both `SshChildHandle` and `SshConnection`

Closes #1561, closes #1562.

The automatic SSH stderr drain thread on spawn (#1561) and forwarding of drained stderr to user-visible error output (#1562) were already implemented on master:
- `SshConnection::new()` spawns `StderrDrain` automatically when stderr is available
- `StderrDrain::drain_loop()` forwards each line in real time via `eprint!`
- PR #3249 added consolidated stderr surfacing in Drop impls

This PR deduplicates the Drop-path logic and adds test coverage for the non-zero-exit Drop paths.

## Test plan
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy -p rsync_io --all-features --no-deps -- -D warnings` passes
- [ ] CI nextest passes (includes new Drop-path stderr tests)