### PR TITLE
feat: add BufferPool telemetry counters and env var pool sizing

### DIFF
--- a/crates/engine/src/local_copy/buffer_pool/global.rs
+++ b/crates/engine/src/local_copy/buffer_pool/global.rs
@@ -41,12 +41,28 @@ pub struct GlobalBufferPoolConfig {
     pub buffer_size: usize,
 }
 
+/// Environment variable for overriding the buffer pool size (number of buffers).
+///
+/// When set to a valid positive integer, overrides the auto-detected
+/// hardware parallelism value. Useful for tuning memory usage in
+/// constrained environments or for benchmarking.
+const ENV_BUFFER_POOL_SIZE: &str = "OC_RSYNC_BUFFER_POOL_SIZE";
+
 impl Default for GlobalBufferPoolConfig {
     /// Defaults to one buffer per hardware thread at the standard copy buffer size.
+    ///
+    /// The `OC_RSYNC_BUFFER_POOL_SIZE` environment variable overrides the
+    /// auto-detected hardware parallelism value when set to a valid positive
+    /// integer. Invalid or non-positive values are silently ignored.
     fn default() -> Self {
-        let max_buffers = std::thread::available_parallelism()
+        let auto_detected = std::thread::available_parallelism()
             .map(std::num::NonZero::get)
             .unwrap_or(4);
+        let max_buffers = std::env::var(ENV_BUFFER_POOL_SIZE)
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok())
+            .filter(|&n| n > 0)
+            .unwrap_or(auto_detected);
         Self {
             max_buffers,
             buffer_size: super::super::COPY_BUFFER_SIZE,
@@ -180,6 +196,96 @@ mod tests {
 
         // Pool should have at least one buffer now (the returned one).
         assert!(pool.available() >= initial_available);
+    }
+
+    /// RAII guard that sets an env var and restores it on drop.
+    struct EnvGuard {
+        key: String,
+        original: Option<String>,
+    }
+
+    impl EnvGuard {
+        #[allow(unsafe_code)]
+        fn set(key: &str, value: &str) -> Self {
+            let original = std::env::var(key).ok();
+            // SAFETY: tests using EnvGuard are serialized via nextest
+            // test-group (max-threads = 1) to prevent concurrent env mutation.
+            unsafe { std::env::set_var(key, value) };
+            Self {
+                key: key.to_string(),
+                original,
+            }
+        }
+
+        #[allow(unsafe_code)]
+        fn remove(key: &str) -> Self {
+            let original = std::env::var(key).ok();
+            // SAFETY: see set() above.
+            unsafe { std::env::remove_var(key) };
+            Self {
+                key: key.to_string(),
+                original,
+            }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        #[allow(unsafe_code)]
+        fn drop(&mut self) {
+            // SAFETY: see EnvGuard::set() above.
+            match &self.original {
+                Some(val) => unsafe { std::env::set_var(&self.key, val) },
+                None => unsafe { std::env::remove_var(&self.key) },
+            }
+        }
+    }
+
+    #[test]
+    fn env_var_overrides_pool_size() {
+        let _guard = EnvGuard::set(super::ENV_BUFFER_POOL_SIZE, "42");
+        let config = GlobalBufferPoolConfig::default();
+        assert_eq!(config.max_buffers, 42);
+    }
+
+    #[test]
+    fn env_var_zero_ignored() {
+        let _guard = EnvGuard::set(super::ENV_BUFFER_POOL_SIZE, "0");
+        let config = GlobalBufferPoolConfig::default();
+        // Zero is invalid, should fall back to auto-detected.
+        let expected = std::thread::available_parallelism()
+            .map(std::num::NonZero::get)
+            .unwrap_or(4);
+        assert_eq!(config.max_buffers, expected);
+    }
+
+    #[test]
+    fn env_var_non_numeric_ignored() {
+        let _guard = EnvGuard::set(super::ENV_BUFFER_POOL_SIZE, "not_a_number");
+        let config = GlobalBufferPoolConfig::default();
+        let expected = std::thread::available_parallelism()
+            .map(std::num::NonZero::get)
+            .unwrap_or(4);
+        assert_eq!(config.max_buffers, expected);
+    }
+
+    #[test]
+    fn env_var_negative_ignored() {
+        let _guard = EnvGuard::set(super::ENV_BUFFER_POOL_SIZE, "-5");
+        let config = GlobalBufferPoolConfig::default();
+        let expected = std::thread::available_parallelism()
+            .map(std::num::NonZero::get)
+            .unwrap_or(4);
+        assert_eq!(config.max_buffers, expected);
+    }
+
+    #[test]
+    fn env_var_unset_uses_auto() {
+        let _guard = EnvGuard::remove(super::ENV_BUFFER_POOL_SIZE);
+        let config = GlobalBufferPoolConfig::default();
+        let expected = std::thread::available_parallelism()
+            .map(std::num::NonZero::get)
+            .unwrap_or(4);
+        assert_eq!(config.max_buffers, expected);
     }
 
     #[test]

--- a/crates/engine/src/local_copy/buffer_pool/pool.rs
+++ b/crates/engine/src/local_copy/buffer_pool/pool.rs
@@ -7,6 +7,7 @@
 
 use std::sync::Arc;
 use std::sync::Mutex;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use super::allocator::{BufferAllocator, DefaultAllocator};
 use super::guard::{BorrowedBufferGuard, BufferGuard};
@@ -80,6 +81,17 @@ pub struct BufferPool<A: BufferAllocator = DefaultAllocator> {
     /// The tracker is only allocated when explicitly enabled via
     /// [`with_throughput_tracking`](Self::with_throughput_tracking).
     throughput: Option<ThroughputTracker>,
+    /// Cumulative count of pool hits (buffer reused from central pool or TLS).
+    ///
+    /// Incremented on every successful acquire that reuses an existing buffer
+    /// rather than allocating a new one. Uses `Relaxed` ordering since exact
+    /// precision is not required - these are diagnostic counters.
+    total_hits: AtomicU64,
+    /// Cumulative count of pool misses (fresh allocation required).
+    ///
+    /// Incremented when neither the thread-local cache nor the central pool
+    /// has a buffer available, requiring a new allocation.
+    total_misses: AtomicU64,
 }
 
 impl BufferPool {
@@ -107,6 +119,8 @@ impl BufferPool {
             allocator: DefaultAllocator,
             memory_cap: None,
             throughput: None,
+            total_hits: AtomicU64::new(0),
+            total_misses: AtomicU64::new(0),
         }
     }
 
@@ -127,6 +141,8 @@ impl BufferPool {
             allocator: DefaultAllocator,
             memory_cap: None,
             throughput: None,
+            total_hits: AtomicU64::new(0),
+            total_misses: AtomicU64::new(0),
         }
     }
 }
@@ -152,6 +168,8 @@ impl<A: BufferAllocator> BufferPool<A> {
             allocator,
             memory_cap: None,
             throughput: None,
+            total_hits: AtomicU64::new(0),
+            total_misses: AtomicU64::new(0),
         }
     }
 
@@ -261,6 +279,7 @@ impl<A: BufferAllocator> BufferPool<A> {
         // Fast path: check thread-local cache.
         if let Some(buffer) = thread_local_cache::try_take() {
             if buffer.len() == pool.buffer_size {
+                pool.total_hits.fetch_add(1, Ordering::Relaxed);
                 // Re-reserve memory that was released by return_buffer's track_return.
                 pool.wait_and_reserve_memory(pool.buffer_size);
                 return BufferGuard {
@@ -299,6 +318,7 @@ impl<A: BufferAllocator> BufferPool<A> {
                     }
                     return None;
                 }
+                pool.total_hits.fetch_add(1, Ordering::Relaxed);
                 return Some(BufferGuard {
                     buffer: Some(buffer),
                     pool,
@@ -337,6 +357,7 @@ impl<A: BufferAllocator> BufferPool<A> {
         // Slow path: non-standard size - allocate fresh, skip TLS.
         // On drop the guard will pass it through `return_buffer` which
         // resizes it to the pool default before returning it.
+        pool.total_misses.fetch_add(1, Ordering::Relaxed);
         pool.wait_and_reserve_memory(desired);
         let buffer = pool.allocator.allocate(desired);
         BufferGuard {
@@ -357,6 +378,7 @@ impl<A: BufferAllocator> BufferPool<A> {
         // Fast path: check thread-local cache.
         if let Some(buffer) = thread_local_cache::try_take() {
             if buffer.len() == self.buffer_size {
+                self.total_hits.fetch_add(1, Ordering::Relaxed);
                 // Re-reserve memory that was released by return_buffer's track_return.
                 self.wait_and_reserve_memory(self.buffer_size);
                 return BorrowedBufferGuard {
@@ -393,6 +415,7 @@ impl<A: BufferAllocator> BufferPool<A> {
                     }
                     return None;
                 }
+                self.total_hits.fetch_add(1, Ordering::Relaxed);
                 return Some(BorrowedBufferGuard {
                     buffer: Some(buffer),
                     pool: self,
@@ -464,10 +487,21 @@ impl<A: BufferAllocator> BufferPool<A> {
     }
 
     /// Pops a buffer from the central pool, or allocates a new one if empty.
+    ///
+    /// Updates telemetry counters: increments `total_hits` on pool reuse,
+    /// `total_misses` on fresh allocation.
     fn pop_buffer(&self) -> Vec<u8> {
         let mut pool = self.buffers.lock().unwrap_or_else(|e| e.into_inner());
-        pool.pop()
-            .unwrap_or_else(|| self.allocator.allocate(self.buffer_size))
+        match pool.pop() {
+            Some(buf) => {
+                self.total_hits.fetch_add(1, Ordering::Relaxed);
+                buf
+            }
+            None => {
+                self.total_misses.fetch_add(1, Ordering::Relaxed);
+                self.allocator.allocate(self.buffer_size)
+            }
+        }
     }
 
     /// Returns the number of buffers currently in the central pool.
@@ -516,6 +550,44 @@ impl<A: BufferAllocator> BufferPool<A> {
     #[must_use]
     pub fn memory_cap(&self) -> Option<usize> {
         self.memory_cap.as_ref().map(|cap| cap.limit())
+    }
+
+    /// Returns the cumulative number of pool hits since creation.
+    ///
+    /// A hit occurs when a buffer is reused from the thread-local cache
+    /// or the central pool, avoiding a fresh allocation.
+    #[must_use]
+    pub fn total_hits(&self) -> u64 {
+        self.total_hits.load(Ordering::Relaxed)
+    }
+
+    /// Returns the cumulative number of pool misses since creation.
+    ///
+    /// A miss occurs when neither the thread-local cache nor the central
+    /// pool has a buffer available, requiring a fresh allocation.
+    #[must_use]
+    pub fn total_misses(&self) -> u64 {
+        self.total_misses.load(Ordering::Relaxed)
+    }
+
+    /// Returns the total number of acquire operations since creation.
+    ///
+    /// Equal to `total_hits() + total_misses()`.
+    #[must_use]
+    pub fn total_acquires(&self) -> u64 {
+        self.total_hits() + self.total_misses()
+    }
+
+    /// Returns the hit rate as a fraction in `[0.0, 1.0]`.
+    ///
+    /// Returns `1.0` if no acquires have occurred (no misses = perfect).
+    #[must_use]
+    pub fn hit_rate(&self) -> f64 {
+        let total = self.total_acquires();
+        if total == 0 {
+            return 1.0;
+        }
+        self.total_hits() as f64 / total as f64
     }
 
     /// Atomically waits for and reserves `requested` bytes of capacity.

--- a/crates/engine/src/local_copy/buffer_pool/tests.rs
+++ b/crates/engine/src/local_copy/buffer_pool/tests.rs
@@ -1292,3 +1292,119 @@ fn tls_per_thread_isolation() {
         h.join().expect("thread panicked");
     }
 }
+
+// --- Telemetry counter tests ---
+
+#[test]
+fn telemetry_starts_at_zero() {
+    let pool = BufferPool::new(4);
+    assert_eq!(pool.total_hits(), 0);
+    assert_eq!(pool.total_misses(), 0);
+    assert_eq!(pool.total_acquires(), 0);
+    assert!((pool.hit_rate() - 1.0).abs() < f64::EPSILON);
+}
+
+#[test]
+fn telemetry_tracks_miss_on_cold_pool() {
+    let pool = BufferPool::new(4);
+    let _buf = pool.acquire();
+    // First acquire on empty pool = miss (no TLS, no central pool buffer).
+    assert_eq!(pool.total_misses(), 1);
+    assert_eq!(pool.total_hits(), 0);
+    assert_eq!(pool.total_acquires(), 1);
+}
+
+#[test]
+fn telemetry_tracks_hit_on_warm_pool() {
+    let pool = BufferPool::new(4);
+
+    // First acquire: miss (cold pool).
+    {
+        let _buf = pool.acquire();
+    }
+    // Buffer returned to TLS.
+
+    // Second acquire: hit from TLS.
+    {
+        let _buf = pool.acquire();
+    }
+    assert!(pool.total_hits() >= 1);
+    assert_eq!(
+        pool.total_acquires(),
+        pool.total_hits() + pool.total_misses()
+    );
+}
+
+#[test]
+fn telemetry_total_acquires_equals_hits_plus_misses() {
+    let pool = Arc::new(BufferPool::new(4));
+
+    // Several acquire-release cycles.
+    for _ in 0..10 {
+        let _buf = BufferPool::acquire_from(Arc::clone(&pool));
+    }
+
+    assert_eq!(
+        pool.total_acquires(),
+        pool.total_hits() + pool.total_misses()
+    );
+    assert!(pool.total_acquires() == 10);
+}
+
+#[test]
+fn telemetry_hit_rate_calculation() {
+    let pool = Arc::new(BufferPool::new(4));
+
+    // First acquire: miss.
+    {
+        let _buf = BufferPool::acquire_from(Arc::clone(&pool));
+    }
+    // Returns to TLS.
+
+    // Next 9 acquires: all hits from TLS (sequential on same thread).
+    for _ in 0..9 {
+        let _buf = BufferPool::acquire_from(Arc::clone(&pool));
+    }
+
+    let rate = pool.hit_rate();
+    // 9 hits out of 10 total = 0.9.
+    assert!(rate > 0.5, "expected high hit rate, got {rate}");
+    assert!(rate <= 1.0);
+}
+
+#[test]
+fn telemetry_concurrent_tracking() {
+    let pool = Arc::new(BufferPool::new(8));
+    let thread_count = 8;
+    let iterations = 100;
+
+    let handles: Vec<_> = (0..thread_count)
+        .map(|_| {
+            let pool = Arc::clone(&pool);
+            thread::spawn(move || {
+                for _ in 0..iterations {
+                    let _buf = BufferPool::acquire_from(Arc::clone(&pool));
+                }
+            })
+        })
+        .collect();
+
+    for h in handles {
+        h.join().expect("thread panicked");
+    }
+
+    assert_eq!(pool.total_acquires(), thread_count * iterations);
+    assert_eq!(
+        pool.total_acquires(),
+        pool.total_hits() + pool.total_misses()
+    );
+    assert!(pool.hit_rate() >= 0.0 && pool.hit_rate() <= 1.0);
+}
+
+#[test]
+fn telemetry_adaptive_miss_tracked() {
+    let pool = Arc::new(BufferPool::new(4));
+    // Adaptive acquire for a tiny file (non-standard size) = miss.
+    let _buf = BufferPool::acquire_adaptive_from(Arc::clone(&pool), 1024);
+    assert!(pool.total_misses() >= 1);
+}


### PR DESCRIPTION
## Summary
- Add hit/miss telemetry counters (`total_hits`, `total_misses`, `total_acquires`, `hit_rate`) to `BufferPool` using `AtomicU64` with `Relaxed` ordering for zero-contention diagnostics
- Add `OC_RSYNC_BUFFER_POOL_SIZE` environment variable override in `GlobalBufferPoolConfig::default()` for tuning pool size in constrained environments or benchmarking
- Track hits at all acquire paths: TLS fast path, central pool pop, and adaptive size match; track misses on fresh allocation and adaptive size mismatch

## Test plan
- [x] `telemetry_starts_at_zero` - new pool has 0 hits, 0 misses, 1.0 hit_rate
- [x] `telemetry_tracks_miss_on_cold_pool` - first acquire = miss
- [x] `telemetry_tracks_hit_on_warm_pool` - acquire after return = hit from TLS
- [x] `telemetry_total_acquires_equals_hits_plus_misses` - invariant holds
- [x] `telemetry_hit_rate_calculation` - math correctness
- [x] `telemetry_concurrent_tracking` - 8 threads x 100 iterations, totals match
- [x] `telemetry_adaptive_miss_tracked` - non-standard size = miss
- [x] `env_var_overrides_pool_size` - OC_RSYNC_BUFFER_POOL_SIZE=42
- [x] `env_var_zero_ignored` - 0 falls back to auto-detect
- [x] `env_var_non_numeric_ignored` - "not_a_number" falls back
- [x] `env_var_negative_ignored` - "-5" falls back
- [x] `env_var_unset_uses_auto` - unset uses available_parallelism