### PR TITLE
style: remove decorative banner comments across all crates

### DIFF
--- a/crates/bandwidth/src/limiter/tests/apply_effective_limit_cases.rs
+++ b/crates/bandwidth/src/limiter/tests/apply_effective_limit_cases.rs
@@ -256,8 +256,6 @@ fn apply_effective_limit_ignores_unspecified_burst_when_creating_limiter() {
     assert_eq!(change, LimiterChange::Enabled);
 }
 
-// ==================== Additional coverage tests for apply_effective_limit ====================
-
 #[test]
 fn apply_effective_limit_caps_limit_and_updates_burst_together() {
     // Test the case where both limit_changed and burst_changed are true
@@ -535,8 +533,6 @@ fn apply_effective_limit_explicitly_disables_burst_with_limit_change() {
     assert_eq!(limiter.burst_bytes(), None); // Burst was explicitly cleared
 }
 
-// ==================== Comprehensive state transition tests ====================
-
 #[test]
 fn apply_effective_limit_state_transition_none_to_limited() {
     let mut limiter: Option<BandwidthLimiter> = None;
@@ -597,8 +593,6 @@ fn apply_effective_limit_state_transition_limited_to_limited_higher_unchanged() 
     assert_eq!(limiter.unwrap().limit_bytes(), low_limit);
 }
 
-// ==================== Burst-only edge cases ====================
-
 #[test]
 fn apply_effective_limit_burst_only_from_none_to_some() {
     let limit = NonZeroU64::new(4096).unwrap();
@@ -637,8 +631,6 @@ fn apply_effective_limit_burst_only_from_some_to_different() {
     assert_eq!(limiter.as_ref().unwrap().burst_bytes(), Some(burst2));
 }
 
-// ==================== Combined limit and burst changes ====================
-
 #[test]
 fn apply_effective_limit_both_limit_and_burst_change_simultaneously() {
     let limit1 = NonZeroU64::new(8192).unwrap();
@@ -671,8 +663,6 @@ fn apply_effective_limit_limit_changes_burst_cleared() {
     assert!(limiter.as_ref().unwrap().burst_bytes().is_none());
 }
 
-// ==================== No change scenarios ====================
-
 #[test]
 fn apply_effective_limit_all_params_none_with_no_limiter() {
     let mut limiter: Option<BandwidthLimiter> = None;
@@ -694,8 +684,6 @@ fn apply_effective_limit_all_params_none_with_existing_limiter() {
     assert_eq!(change, LimiterChange::Unchanged);
     assert!(limiter.is_some());
 }
-
-// ==================== Creating limiter with burst ====================
 
 #[test]
 fn apply_effective_limit_creates_limiter_with_burst_specified() {

--- a/crates/bandwidth/src/limiter/tests/configuration.rs
+++ b/crates/bandwidth/src/limiter/tests/configuration.rs
@@ -266,8 +266,6 @@ fn limiter_write_max_honours_minimum_when_burst_is_small() {
     assert_eq!(limiter.recommended_read_size(1024), 512);
 }
 
-// ==================== Configuration update comprehensive tests ====================
-
 #[test]
 fn update_limit_preserves_burst_setting() {
     let mut session = recorded_sleep_session();
@@ -331,8 +329,6 @@ fn multiple_sequential_updates() {
         assert_eq!(limiter.limit_bytes(), new_limit);
     }
 }
-
-// ==================== LimiterChange state transition tests ====================
 
 #[test]
 fn limiter_change_combine_all_empty_is_unchanged() {
@@ -421,8 +417,6 @@ fn limiter_change_partial_ord_consistent_with_ord() {
     }
 }
 
-// ==================== Reset behavior comprehensive tests ====================
-
 #[test]
 fn reset_clears_all_mutable_state() {
     let mut session = recorded_sleep_session();
@@ -470,8 +464,6 @@ fn reset_after_update_limit() {
     assert_eq!(limiter.accumulated_debt_for_testing(), 0);
 }
 
-// ==================== Clone and equality tests ====================
-
 #[test]
 fn cloned_limiter_has_same_configuration() {
     let original = BandwidthLimiter::with_burst(
@@ -498,8 +490,6 @@ fn cloned_limiter_has_same_debt() {
 
     assert_eq!(original_debt, cloned.accumulated_debt_for_testing());
 }
-
-// ==================== Write max calculation edge cases ====================
 
 #[test]
 fn write_max_scales_with_limit_at_boundaries() {
@@ -530,8 +520,6 @@ fn write_max_capped_at_burst() {
     // write_max should be capped to max(burst, MIN_WRITE_MAX)
     assert!(limiter.write_max_bytes() <= 1024);
 }
-
-// ==================== Accessor consistency tests ====================
 
 #[test]
 fn limit_bytes_consistent_after_operations() {

--- a/crates/bandwidth/src/limiter/tests/helpers.rs
+++ b/crates/bandwidth/src/limiter/tests/helpers.rs
@@ -84,8 +84,6 @@ fn sleep_for_splits_large_durations_into_chunks() {
     );
 }
 
-// ==================== Additional duration_from_microseconds tests ====================
-
 #[test]
 fn duration_from_microseconds_handles_exact_second_boundaries() {
     // Exactly 1 second
@@ -132,8 +130,6 @@ fn duration_from_microseconds_near_max_representable() {
     let duration = duration_from_microseconds(near_max);
     assert!(duration < Duration::MAX);
 }
-
-// ==================== sleep_for comprehensive tests ====================
 
 #[test]
 fn sleep_for_small_durations_record_correctly() {
@@ -255,8 +251,6 @@ fn sleep_for_nanoseconds() {
     let total: Duration = recorded.iter().copied().sum();
     assert_eq!(total, Duration::from_nanos(500));
 }
-
-// ==================== Boundary and overflow tests ====================
 
 #[test]
 fn duration_from_microseconds_various_overflow_boundaries() {

--- a/crates/bandwidth/src/limiter/tests/pacing.rs
+++ b/crates/bandwidth/src/limiter/tests/pacing.rs
@@ -142,8 +142,6 @@ fn limiter_clamps_debt_to_configured_burst() {
     assert!(sleep.requested() <= Duration::from_millis(1));
 }
 
-// ==================== Additional pacing tests ====================
-
 #[test]
 fn limiter_handles_very_slow_rate() {
     let mut session = recorded_sleep_session();

--- a/crates/bandwidth/src/parse/tests/argument.rs
+++ b/crates/bandwidth/src/parse/tests/argument.rs
@@ -270,8 +270,6 @@ fn parse_bandwidth_rejects_excessive_exponent() {
     assert_eq!(error, BandwidthParseError::TooLarge);
 }
 
-// ==================== Additional edge case tests ====================
-
 #[test]
 fn parse_bandwidth_rejects_empty_string() {
     let error = parse_bandwidth_argument("").unwrap_err();
@@ -384,8 +382,6 @@ proptest! {
         prop_assert_eq!(parsed, Some(expected));
     }
 }
-
-// ==================== Additional coverage tests ====================
 
 #[test]
 fn parse_bandwidth_handles_adjustment_when_product_less_than_denominator() {

--- a/crates/bandwidth/src/parse/tests/edge_cases.rs
+++ b/crates/bandwidth/src/parse/tests/edge_cases.rs
@@ -10,8 +10,6 @@
 
 use super::{BandwidthParseError, NonZeroU64, parse_bandwidth_argument, parse_bandwidth_limit};
 
-// ==================== Size Suffix Tests (1024-based like rsync) ====================
-
 mod size_suffixes {
     use super::*;
 
@@ -109,8 +107,6 @@ mod size_suffixes {
     }
 }
 
-// ==================== Rate Format Tests ====================
-
 mod rate_formats {
     use super::*;
 
@@ -178,8 +174,6 @@ mod rate_formats {
     }
 }
 
-// ==================== Zero Value Tests ====================
-
 mod zero_value {
     use super::*;
 
@@ -237,8 +231,6 @@ mod zero_value {
     }
 }
 
-// ==================== Negative Value Tests ====================
-
 mod negative_values {
     use super::*;
 
@@ -279,8 +271,6 @@ mod negative_values {
         assert!(result.is_some());
     }
 }
-
-// ==================== Overflow Tests ====================
 
 mod overflow {
     use super::*;
@@ -325,8 +315,6 @@ mod overflow {
         assert_eq!(error, BandwidthParseError::TooLarge);
     }
 }
-
-// ==================== Empty and Whitespace Tests ====================
 
 mod empty_and_whitespace {
     use super::*;
@@ -424,8 +412,6 @@ mod empty_and_whitespace {
         assert_eq!(error, BandwidthParseError::Invalid);
     }
 }
-
-// ==================== Invalid Format Tests ====================
 
 mod invalid_formats {
     use super::*;
@@ -590,8 +576,6 @@ mod invalid_formats {
     }
 }
 
-// ==================== Case Sensitivity Tests ====================
-
 mod case_sensitivity {
     use super::*;
 
@@ -675,8 +659,6 @@ mod case_sensitivity {
     }
 }
 
-// ==================== Error Message Tests ====================
-
 mod error_messages {
     use super::*;
 
@@ -724,8 +706,6 @@ mod error_messages {
     }
 }
 
-// ==================== Minimum Value Tests ====================
-
 mod minimum_values {
     use super::*;
 
@@ -764,8 +744,6 @@ mod minimum_values {
         assert_eq!(error, BandwidthParseError::TooSmall);
     }
 }
-
-// ==================== Scientific Notation Tests ====================
 
 mod scientific_notation {
     use super::*;
@@ -821,8 +799,6 @@ mod scientific_notation {
     }
 }
 
-// ==================== Decimal Separator Tests ====================
-
 mod decimal_separators {
     use super::*;
 
@@ -860,8 +836,6 @@ mod decimal_separators {
     }
 }
 
-// ==================== Leading Sign Tests ====================
-
 mod leading_signs {
     use super::*;
 
@@ -890,8 +864,6 @@ mod leading_signs {
     }
 }
 
-// ==================== Rounding Behavior Tests ====================
-
 mod rounding {
     use super::*;
 
@@ -919,8 +891,6 @@ mod rounding {
         assert_eq!(without_adj, with_adj);
     }
 }
-
-// ==================== Burst Component Tests ====================
 
 mod burst_component {
     use super::*;
@@ -958,8 +928,6 @@ mod burst_component {
         assert!(components.burst_specified());
     }
 }
-
-// ==================== Default Unit Behavior Tests ====================
 
 mod default_unit {
     use super::*;

--- a/crates/bandwidth/src/parse/tests/limit.rs
+++ b/crates/bandwidth/src/parse/tests/limit.rs
@@ -238,8 +238,6 @@ fn parse_bandwidth_limit_rejects_missing_burst_value() {
     assert_eq!(error, BandwidthParseError::Invalid);
 }
 
-// ==================== Additional coverage tests for bandwidth limit components ====================
-
 #[test]
 fn constrained_by_clears_burst_when_override_is_unlimited() {
     // Test lines 218-224 in components.rs

--- a/crates/cli/src/frontend/arguments/short_options.rs
+++ b/crates/cli/src/frontend/arguments/short_options.rs
@@ -117,8 +117,6 @@ fn expand_cluster(
 mod tests {
     use super::*;
 
-    // ==================== expand_cluster tests ====================
-
     fn make_flags(chars: &str) -> HashSet<char> {
         chars.chars().collect()
     }

--- a/crates/cli/src/frontend/dry_run/tests.rs
+++ b/crates/cli/src/frontend/dry_run/tests.rs
@@ -1,7 +1,5 @@
 use super::*;
 
-// ---- DryRunAction path extraction ----
-
 #[test]
 fn action_path_returns_send_file_path() {
     let action = DryRunAction::SendFile {
@@ -36,8 +34,6 @@ fn action_path_returns_create_dir_path() {
     assert_eq!(action.path(), "subdir/");
 }
 
-// ---- DryRunAction size extraction ----
-
 #[test]
 fn action_size_returns_send_file_size() {
     let action = DryRunAction::SendFile {
@@ -71,8 +67,6 @@ fn action_size_returns_none_for_create_dir() {
     };
     assert_eq!(action.size(), None);
 }
-
-// ---- DryRunAction type detection ----
 
 #[test]
 fn action_is_deletion_returns_true_for_delete_file() {
@@ -123,8 +117,6 @@ fn action_is_directory_returns_false_for_send_file() {
     };
     assert!(!action.is_directory());
 }
-
-// ---- DryRunSummary basic operations ----
 
 #[test]
 fn summary_new_creates_empty_summary() {
@@ -185,8 +177,6 @@ fn summary_actions_returns_all_actions() {
     summary.add_action(action2.clone());
     assert_eq!(summary.actions(), &[action1, action2]);
 }
-
-// ---- DryRunSummary output formatting ----
 
 #[test]
 fn summary_format_output_verbosity_zero_returns_empty() {
@@ -314,8 +304,6 @@ fn summary_format_output_handles_multiple_actions() {
     assert!(output.contains("deleting old.txt"));
 }
 
-// ---- DryRunSummary summary line ----
-
 #[test]
 fn summary_format_summary_includes_dry_run_marker() {
     let summary = DryRunSummary::new();
@@ -347,8 +335,6 @@ fn summary_format_summary_shows_speedup() {
     let output = summary.format_summary();
     assert!(output.contains("speedup is 0.00"));
 }
-
-// ---- DryRunFormatter ----
 
 #[test]
 fn formatter_new_creates_formatter() {
@@ -431,8 +417,6 @@ fn formatter_format_actions_formats_multiple_actions() {
     assert_eq!(output, "file1.txt\nfile2.txt\n");
 }
 
-// ---- Number formatting ----
-
 #[test]
 fn format_number_with_commas_handles_zero() {
     assert_eq!(format_number_with_commas(0), "0");
@@ -465,8 +449,6 @@ fn format_number_with_commas_handles_large_numbers() {
     );
 }
 
-// ---- Path with special characters ----
-
 #[test]
 fn summary_format_output_handles_paths_with_spaces() {
     let mut summary = DryRunSummary::new();
@@ -488,8 +470,6 @@ fn summary_format_output_handles_paths_with_unicode() {
     let output = summary.format_output(1);
     assert!(output.contains("\u{6587}\u{4ef6}.txt"));
 }
-
-// ---- Large file sizes ----
 
 #[test]
 fn summary_handles_large_file_sizes() {
@@ -516,8 +496,6 @@ fn summary_handles_size_overflow_gracefully() {
     });
     assert_eq!(summary.total_size(), u64::MAX);
 }
-
-// ---- Empty action list ----
 
 #[test]
 fn summary_format_output_empty_list_returns_empty_string() {

--- a/crates/cli/src/frontend/execution/drive/metadata/tests.rs
+++ b/crates/cli/src/frontend/execution/drive/metadata/tests.rs
@@ -32,8 +32,6 @@ fn default_inputs() -> MetadataInputs<'static> {
     }
 }
 
-// --- archive mode ---
-
 #[test]
 fn archive_false_defaults_to_no_preservation() {
     let result = compute_metadata_settings(default_inputs()).unwrap();
@@ -61,8 +59,6 @@ fn archive_true_enables_preservation() {
     assert!(result.preserve_specials);
     assert!(result.preserve_symlinks);
 }
-
-// --- explicit flag overrides ---
 
 #[test]
 fn explicit_owner_overrides_archive() {
@@ -124,8 +120,6 @@ fn explicit_links_overrides_archive() {
     assert!(!compute_metadata_settings(inputs).unwrap().preserve_symlinks);
 }
 
-// --- super_mode ---
-
 #[test]
 fn super_mode_enables_owner() {
     let mut inputs = default_inputs();
@@ -150,8 +144,6 @@ fn super_mode_enables_perms() {
             .preserve_permissions
     );
 }
-
-// --- executability ---
 
 #[test]
 fn executability_follows_perms_when_enabled() {
@@ -181,8 +173,6 @@ fn executability_defaults_to_false() {
             .preserve_executability
     );
 }
-
-// --- atime / crtime ---
 
 #[test]
 fn atimes_defaults_to_false() {
@@ -216,8 +206,6 @@ fn crtimes_explicit_true() {
     assert!(compute_metadata_settings(inputs).unwrap().preserve_crtimes);
 }
 
-// --- omit times ---
-
 #[test]
 fn omit_dir_times_defaults_to_false() {
     assert!(
@@ -249,8 +237,6 @@ fn omit_link_times_explicit_true() {
     inputs.omit_link_times = Some(true);
     assert!(compute_metadata_settings(inputs).unwrap().omit_link_times);
 }
-
-// --- link handling ---
 
 #[test]
 fn hard_links_defaults_to_false() {
@@ -320,8 +306,6 @@ fn keep_dirlinks_explicit_true() {
     assert!(compute_metadata_settings(inputs).unwrap().keep_dirlinks);
 }
 
-// --- sparse ---
-
 #[test]
 fn sparse_defaults_to_false() {
     assert!(!compute_metadata_settings(default_inputs()).unwrap().sparse);
@@ -333,8 +317,6 @@ fn sparse_explicit_true() {
     inputs.sparse = Some(true);
     assert!(compute_metadata_settings(inputs).unwrap().sparse);
 }
-
-// --- relative and one_file_system ---
 
 #[test]
 fn relative_defaults_to_false() {
@@ -382,8 +364,6 @@ fn one_file_system_explicit_double() {
     );
 }
 
-// --- chmod ---
-
 #[test]
 fn no_chmod_returns_none() {
     assert!(
@@ -414,8 +394,6 @@ fn invalid_chmod_returns_error() {
     inputs.chmod = &chmod_specs;
     assert!(compute_metadata_settings(inputs).is_err());
 }
-
-// --- struct accessibility ---
 
 #[test]
 fn metadata_settings_all_fields_accessible() {

--- a/crates/cli/src/frontend/execution/operands.rs
+++ b/crates/cli/src/frontend/execution/operands.rs
@@ -110,8 +110,6 @@ fn resolve_bind_address(text: &str) -> io::Result<SocketAddr> {
 mod tests {
     use super::*;
 
-    // ==================== is_option tests ====================
-
     #[test]
     fn is_option_single_dash_with_letter() {
         assert!(is_option(OsStr::new("-a")));
@@ -161,8 +159,6 @@ mod tests {
         assert!(is_option(OsStr::new("--port=8873")));
         assert!(is_option(OsStr::new("--config=/etc/rsyncd.conf")));
     }
-
-    // ==================== extract_operands tests ====================
 
     #[test]
     fn extract_operands_no_options() {
@@ -242,8 +238,6 @@ mod tests {
         assert!(result.is_err());
     }
 
-    // ==================== UnsupportedOption tests ====================
-
     #[test]
     fn unsupported_option_to_message_contains_option() {
         let unsupported = UnsupportedOption::new(OsString::from("--unknown-opt"));
@@ -251,8 +245,6 @@ mod tests {
         let text = format!("{message}");
         assert!(text.contains("--unknown-opt"));
     }
-
-    // ==================== parse_bind_address_argument tests ====================
 
     #[test]
     fn parse_bind_address_empty_value() {

--- a/crates/cli/src/frontend/execution/options/mod.rs
+++ b/crates/cli/src/frontend/execution/options/mod.rs
@@ -37,8 +37,6 @@ mod tests {
         OsString::from(s)
     }
 
-    // --- parse_timeout_argument tests ---
-
     #[test]
     fn parse_timeout_argument_zero() {
         let result = parse_timeout_argument(&os("0")).unwrap();
@@ -81,8 +79,6 @@ mod tests {
         assert!(matches!(result, TransferTimeout::Seconds(n) if n.get() == 30));
     }
 
-    // --- parse_max_delete_argument tests ---
-
     #[test]
     fn parse_max_delete_argument_zero() {
         assert_eq!(parse_max_delete_argument(&os("0")).unwrap(), 0);
@@ -112,8 +108,6 @@ mod tests {
     fn parse_max_delete_argument_invalid() {
         assert!(parse_max_delete_argument(&os("xyz")).is_err());
     }
-
-    // --- parse_checksum_seed_argument tests ---
 
     #[test]
     fn parse_checksum_seed_argument_zero() {
@@ -145,8 +139,6 @@ mod tests {
         assert!(parse_checksum_seed_argument(&os("abc")).is_err());
     }
 
-    // --- parse_modify_window_argument tests ---
-
     #[test]
     fn parse_modify_window_argument_zero() {
         assert_eq!(parse_modify_window_argument(&os("0")).unwrap(), 0);
@@ -176,8 +168,6 @@ mod tests {
     fn parse_modify_window_argument_invalid() {
         assert!(parse_modify_window_argument(&os("foo")).is_err());
     }
-
-    // --- parse_human_readable_level tests ---
 
     #[test]
     fn parse_human_readable_level_zero() {

--- a/crates/cli/src/frontend/execution/options/size.rs
+++ b/crates/cli/src/frontend/execution/options/size.rs
@@ -288,8 +288,6 @@ mod tests {
         OsString::from(s)
     }
 
-    // --- parse_size_spec tests ---
-
     #[test]
     fn parse_size_spec_empty() {
         assert_eq!(parse_size_spec(""), Err(SizeParseError::Empty));
@@ -413,8 +411,6 @@ mod tests {
         assert_eq!(parse_size_spec("1Ki"), Err(SizeParseError::Invalid));
     }
 
-    // --- pow_u128_for_size tests ---
-
     #[test]
     fn pow_u128_for_size_zero_exponent() {
         assert_eq!(pow_u128_for_size(1024, 0), Ok(1));
@@ -432,8 +428,6 @@ mod tests {
         assert_eq!(pow_u128_for_size(1024, 2), Ok(1_048_576));
         assert_eq!(pow_u128_for_size(1000, 3), Ok(1_000_000_000));
     }
-
-    // --- SizeParseError tests ---
 
     #[test]
     fn size_parse_error_eq() {
@@ -455,8 +449,6 @@ mod tests {
         let cloned = err;
         assert_eq!(err, cloned);
     }
-
-    // --- parse_size_limit_argument tests ---
 
     #[test]
     fn parse_size_limit_argument_valid() {
@@ -484,8 +476,6 @@ mod tests {
     fn parse_size_limit_argument_invalid() {
         assert!(parse_size_limit_argument(&os("abc"), "--max-size").is_err());
     }
-
-    // --- parse_size_limit_argument for --max-alloc specifically ---
 
     #[test]
     fn parse_max_alloc_bytes() {
@@ -573,8 +563,6 @@ mod tests {
         );
     }
 
-    // --- parse_block_size_argument tests ---
-
     #[test]
     fn parse_block_size_argument_valid() {
         let result = parse_block_size_argument(&os("1K")).unwrap();
@@ -601,8 +589,6 @@ mod tests {
     fn parse_block_size_argument_negative() {
         assert!(parse_block_size_argument(&os("-1")).is_err());
     }
-
-    // --- parse_decimal_components tests ---
 
     #[test]
     fn parse_decimal_components_integer_only() {

--- a/crates/cli/src/frontend/execution/stop.rs
+++ b/crates/cli/src/frontend/execution/stop.rs
@@ -346,8 +346,6 @@ mod tests {
     use super::*;
     use std::ffi::OsString;
 
-    // ==================== parse_stop_after_argument tests ====================
-
     #[test]
     fn stop_after_valid_minutes() {
         let result = parse_stop_after_argument(&OsString::from("10"));
@@ -434,8 +432,6 @@ mod tests {
         assert!(duration.as_secs() >= 86398 && duration.as_secs() <= 86402);
     }
 
-    // ==================== parse_stop_at_argument tests ====================
-
     #[test]
     fn stop_at_rejects_empty() {
         let result = parse_stop_at_argument(&OsString::from(""));
@@ -477,8 +473,6 @@ mod tests {
         let result = parse_stop_at_argument(&OsString::from("2025-01-32"));
         assert!(result.is_err());
     }
-
-    // ==================== parse_stop_at_internal tests ====================
 
     #[test]
     fn stop_at_internal_empty_input() {
@@ -553,8 +547,6 @@ mod tests {
         assert!(matches!(result, Err(StopAtError::InvalidFormat)));
     }
 
-    // ==================== StopAtError and BuildError tests ====================
-
     #[test]
     fn stop_at_error_debug() {
         let error = StopAtError::InvalidFormat;
@@ -604,8 +596,6 @@ mod tests {
         assert!(matches!(stop_error, StopAtError::LocalOffset));
     }
 
-    // ==================== offset_datetime_to_system_time tests ====================
-
     #[test]
     fn offset_datetime_converts_epoch() {
         let epoch = OffsetDateTime::UNIX_EPOCH;
@@ -625,8 +615,6 @@ mod tests {
         // Verify it's after now
         assert!(result.unwrap() > SystemTime::now());
     }
-
-    // ==================== Helper function tests ====================
 
     #[test]
     fn invalid_stop_after_message_contains_value() {
@@ -651,8 +639,6 @@ mod tests {
         assert!(text.contains("past_time"));
         assert!(text.contains("not in the future"));
     }
-
-    // ==================== Date separator tests ====================
 
     #[test]
     fn stop_at_internal_dash_separator() {
@@ -682,8 +668,6 @@ mod tests {
                 || matches!(result, Err(StopAtError::LocalOffset))
         );
     }
-
-    // ==================== Two-digit year tests ====================
 
     #[test]
     fn stop_at_internal_two_digit_year_future() {

--- a/crates/cli/src/frontend/filter_rules/merge.rs
+++ b/crates/cli/src/frontend/filter_rules/merge.rs
@@ -249,8 +249,6 @@ fn merge_directive_requires_argument(keyword: &str) -> bool {
 mod tests {
     use super::*;
 
-    // ==================== merge_directive_requires_argument tests ====================
-
     #[test]
     fn requires_argument_include() {
         assert!(merge_directive_requires_argument("include"));

--- a/crates/cli/src/frontend/filter_rules/parsing/mod.rs
+++ b/crates/cli/src/frontend/filter_rules/parsing/mod.rs
@@ -318,8 +318,6 @@ fn parse_keyword_rule(trimmed: &str) -> Result<FilterDirective, Message> {
 mod tests {
     use super::*;
 
-    // ==================== parse_filter_directive tests ====================
-
     #[test]
     fn parse_include_short() {
         let result = parse_filter_directive(OsStr::new("+ *.txt"));
@@ -401,8 +399,6 @@ mod tests {
         assert!(result.is_err());
     }
 
-    // ==================== parse_rule_directive tests ====================
-
     #[test]
     fn rule_directive_protect() {
         let result = parse_rule_directive("P *.keep");
@@ -465,8 +461,6 @@ mod tests {
         assert!(result.is_err());
     }
 
-    // ==================== parse_exclude_if_present tests ====================
-
     #[test]
     fn exclude_if_present_basic() {
         let result = parse_exclude_if_present("exclude-if-present .nobackup");
@@ -514,8 +508,6 @@ mod tests {
         assert!(result.is_none());
     }
 
-    // ==================== parse_short_include_rule tests ====================
-
     #[test]
     fn short_include_basic() {
         let result = parse_short_include_rule("+ *.rs", '+', FilterRuleSpec::include);
@@ -561,8 +553,6 @@ mod tests {
         let result = parse_short_include_rule("- foo", '+', FilterRuleSpec::include);
         assert!(result.is_none());
     }
-
-    // ==================== parse_dir_merge_alias tests ====================
 
     #[test]
     fn dir_merge_basic() {
@@ -628,8 +618,6 @@ mod tests {
         }
     }
 
-    // ==================== parse_keyword_rule tests ====================
-
     #[test]
     fn keyword_include() {
         let result = parse_keyword_rule("include *.txt");
@@ -684,8 +672,6 @@ mod tests {
         assert!(result.is_err());
     }
 
-    // ==================== parse_long_merge_directive tests ====================
-
     #[test]
     fn long_merge_basic() {
         let result = parse_long_merge_directive("merge filter.rules");
@@ -706,8 +692,6 @@ mod tests {
         let result = parse_long_merge_directive("include pattern");
         assert!(result.is_none());
     }
-
-    // ==================== parse_shorthand_rules tests ====================
 
     #[test]
     fn shorthand_protect() {
@@ -742,8 +726,6 @@ mod tests {
         let result = parse_shorthand_rules("+ pattern");
         assert!(result.is_none());
     }
-
-    // ==================== Leading whitespace handling tests ====================
 
     #[test]
     fn leading_whitespace_trimmed() {

--- a/crates/cli/src/frontend/itemize/tests/edge_cases.rs
+++ b/crates/cli/src/frontend/itemize/tests/edge_cases.rs
@@ -1,7 +1,5 @@
 use crate::frontend::itemize::*;
 
-// ---- Length is always 11 ----
-
 #[test]
 fn format_length_is_always_eleven() {
     let changes = vec![
@@ -32,8 +30,6 @@ fn format_length_is_always_eleven() {
     }
 }
 
-// ---- New file ignores individual change flags ----
-
 #[test]
 fn new_file_overrides_individual_flags() {
     let change = ItemizeChange::new()
@@ -46,8 +42,6 @@ fn new_file_overrides_individual_flags() {
     assert_eq!(change.format(), ">f+++++++++");
 }
 
-// ---- Typical content update pattern ----
-
 #[test]
 fn format_typical_content_update() {
     let change = ItemizeChange::new()
@@ -59,8 +53,6 @@ fn format_typical_content_update() {
     assert_eq!(change.format(), ">fcst......");
 }
 
-// ---- Directory with time update ----
-
 #[test]
 fn format_directory_time_update() {
     let change = ItemizeChange::new()
@@ -69,8 +61,6 @@ fn format_directory_time_update() {
         .with_time_changed(true);
     assert_eq!(change.format(), ">d..t......");
 }
-
-// ---- Missing data fills attribute positions with '?' ----
 
 #[test]
 fn format_missing_data_shows_question_marks() {

--- a/crates/cli/src/frontend/itemize/tests/format.rs
+++ b/crates/cli/src/frontend/itemize/tests/format.rs
@@ -1,7 +1,5 @@
 use crate::frontend::itemize::*;
 
-// ---- Basic formatting: unchanged file ----
-
 #[test]
 fn format_unchanged_file() {
     let change = ItemizeChange::new()
@@ -9,8 +7,6 @@ fn format_unchanged_file() {
         .with_file_type(FileType::RegularFile);
     assert_eq!(change.format(), ".f         ");
 }
-
-// ---- Basic formatting: new file ----
 
 #[test]
 fn format_new_file() {
@@ -20,8 +16,6 @@ fn format_new_file() {
         .with_new_file(true);
     assert_eq!(change.format(), ">f+++++++++");
 }
-
-// ---- Basic formatting: updated file with checksum+size ----
 
 #[test]
 fn format_updated_file_checksum_and_size() {
@@ -33,8 +27,6 @@ fn format_updated_file_checksum_and_size() {
     assert_eq!(change.format(), ">fcs.......");
 }
 
-// ---- Basic formatting: sent file ----
-
 #[test]
 fn format_sent_file() {
     let change = ItemizeChange::new()
@@ -42,8 +34,6 @@ fn format_sent_file() {
         .with_file_type(FileType::RegularFile);
     assert_eq!(change.format(), "<f.........");
 }
-
-// ---- Basic formatting: directory ----
 
 #[test]
 fn format_directory() {
@@ -53,8 +43,6 @@ fn format_directory() {
     assert_eq!(change.format(), ".d         ");
 }
 
-// ---- Basic formatting: symlink ----
-
 #[test]
 fn format_symlink() {
     let change = ItemizeChange::new()
@@ -62,8 +50,6 @@ fn format_symlink() {
         .with_file_type(FileType::Symlink);
     assert_eq!(change.format(), ".L         ");
 }
-
-// ---- All flags changed ----
 
 #[test]
 fn format_all_flags_changed() {
@@ -83,8 +69,6 @@ fn format_all_flags_changed() {
     assert_eq!(change.format(), ">fcstpogbax");
 }
 
-// ---- Time changed ----
-
 #[test]
 fn format_time_changed() {
     let change = ItemizeChange::new()
@@ -94,8 +78,6 @@ fn format_time_changed() {
     assert_eq!(change.format(), ">f..t......");
 }
 
-// ---- Permissions changed ----
-
 #[test]
 fn format_perms_changed() {
     let change = ItemizeChange::new()
@@ -104,8 +86,6 @@ fn format_perms_changed() {
         .with_perms_changed(true);
     assert_eq!(change.format(), ">f...p.....");
 }
-
-// ---- Owner and group changed ----
 
 #[test]
 fn format_owner_and_group_changed() {
@@ -117,8 +97,6 @@ fn format_owner_and_group_changed() {
     assert_eq!(change.format(), ">f....og...");
 }
 
-// ---- ACL and xattr changed ----
-
 #[test]
 fn format_acl_and_xattr_changed() {
     let change = ItemizeChange::new()
@@ -129,8 +107,6 @@ fn format_acl_and_xattr_changed() {
     assert_eq!(change.format(), ">f.......ax");
 }
 
-// ---- Created file with all new indicators ----
-
 #[test]
 fn format_created_file_all_new() {
     let change = ItemizeChange::new()
@@ -139,8 +115,6 @@ fn format_created_file_all_new() {
         .with_new_file(true);
     assert_eq!(change.format(), "cf+++++++++");
 }
-
-// ---- Builder pattern creates correct output ----
 
 #[test]
 fn builder_pattern_works() {
@@ -151,8 +125,6 @@ fn builder_pattern_works() {
     assert_eq!(change.format(), ">d..t......");
 }
 
-// ---- Edge case: device file ----
-
 #[test]
 fn format_device_file() {
     let change = ItemizeChange::new()
@@ -162,8 +134,6 @@ fn format_device_file() {
     assert_eq!(change.format(), "cD+++++++++");
 }
 
-// ---- Edge case: special file ----
-
 #[test]
 fn format_special_file() {
     let change = ItemizeChange::new()
@@ -172,8 +142,6 @@ fn format_special_file() {
         .with_new_file(true);
     assert_eq!(change.format(), "cS+++++++++");
 }
-
-// ---- Time set to transfer (uppercase T) ----
 
 #[test]
 fn format_time_set_to_transfer() {
@@ -194,8 +162,6 @@ fn time_set_to_transfer_overrides_time_changed() {
     assert_eq!(change.format(), ">f..T......");
 }
 
-// ---- Access time only (u) ----
-
 #[test]
 fn format_atime_changed_only() {
     let change = ItemizeChange::new()
@@ -205,8 +171,6 @@ fn format_atime_changed_only() {
     assert_eq!(change.format(), ">f......u..");
 }
 
-// ---- Create time only (n) ----
-
 #[test]
 fn format_ctime_changed_only() {
     let change = ItemizeChange::new()
@@ -215,8 +179,6 @@ fn format_ctime_changed_only() {
         .with_ctime_changed(true);
     assert_eq!(change.format(), ">f......n..");
 }
-
-// ---- Both access and create time (b) ----
 
 #[test]
 fn format_both_atime_and_ctime_changed() {
@@ -228,8 +190,6 @@ fn format_both_atime_and_ctime_changed() {
     assert_eq!(change.format(), ">f......b..");
 }
 
-// ---- Hard link ----
-
 #[test]
 fn format_hard_link() {
     let change = ItemizeChange::new()
@@ -239,8 +199,6 @@ fn format_hard_link() {
     assert_eq!(change.format(), "hf+++++++++");
 }
 
-// ---- Message type ----
-
 #[test]
 fn format_message_type() {
     let change = ItemizeChange::new()
@@ -248,8 +206,6 @@ fn format_message_type() {
         .with_file_type(FileType::RegularFile);
     assert_eq!(change.format(), "*f.........");
 }
-
-// ---- Standalone format_itemize function ----
 
 #[test]
 fn format_itemize_standalone_works() {

--- a/crates/cli/src/frontend/itemize/tests/golden_upstream.rs
+++ b/crates/cli/src/frontend/itemize/tests/golden_upstream.rs
@@ -5,16 +5,12 @@
 
 use crate::frontend::itemize::*;
 
-// ---- upstream: log.c:696-698 - ITEM_DELETED produces "*deleting  " (11 chars) ----
-
 #[test]
 fn golden_deleting_format_is_eleven_chars() {
     // upstream: `n = "*deleting  ";` - 9 content chars + 2 trailing spaces = 11
     let expected = "*deleting  ";
     assert_eq!(expected.len(), 11, "upstream *deleting must be 11 chars");
 }
-
-// ---- upstream: log.c:701-704 - direction indicators ----
 
 #[test]
 fn golden_direction_sent() {
@@ -64,8 +60,6 @@ fn golden_direction_not_updated() {
         .with_file_type(FileType::RegularFile);
     assert_eq!(change.format(), ".f         ");
 }
-
-// ---- upstream: log.c:705-714 - file type indicators ----
 
 #[test]
 fn golden_filetype_regular() {
@@ -117,8 +111,6 @@ fn golden_filetype_special() {
     assert_eq!(&change.format()[..2], ">S");
 }
 
-// ---- upstream: log.c:705-707 - symlinks never report size (position 3 = '.') ----
-
 #[test]
 fn golden_symlink_never_shows_size() {
     // upstream: log.c:707 - `c[3] = '.';` unconditionally for symlinks
@@ -141,8 +133,6 @@ fn golden_file_shows_size_when_changed() {
     assert_eq!(change.format(), ">f.s.......");
 }
 
-// ---- upstream: log.c:730-734 - ITEM_IS_NEW fills with '+', ITEM_MISSING_DATA with '?' ----
-
 #[test]
 fn golden_new_file_all_plus() {
     // upstream: log.c:731 - `ch = '+';` for ITEM_IS_NEW
@@ -162,8 +152,6 @@ fn golden_missing_data_all_question() {
         .with_missing_data(true);
     assert_eq!(change.format(), ">f?????????");
 }
-
-// ---- upstream: log.c:735-744 - trailing dots collapse to spaces for '.', 'h', 'c' ----
 
 #[test]
 fn golden_collapse_dots_for_not_updated() {
@@ -220,8 +208,6 @@ fn golden_partial_change_prevents_collapse() {
     assert_eq!(change.format(), ".f...p.....");
 }
 
-// ---- upstream: log.c:719-727 - attribute positions 2-10 ----
-
 #[test]
 fn golden_all_attributes_changed() {
     // upstream: log.c:719-727 - all flags set produces `cstpogbax`
@@ -240,8 +226,6 @@ fn golden_all_attributes_changed() {
         .with_xattr_changed(true);
     assert_eq!(change.format(), ">fcstpogbax");
 }
-
-// ---- upstream: log.c:723-725 - atime/crtime position (position 8) ----
 
 #[test]
 fn golden_atime_only_shows_u() {
@@ -274,8 +258,6 @@ fn golden_both_atime_crtime_shows_b() {
     assert_eq!(change.format(), ">f......b..");
 }
 
-// ---- upstream: log.c:708-710,716-717 - time position with T/t ----
-
 #[test]
 fn golden_time_lowercase_t() {
     // upstream: log.c:717 - preserve_mtimes => 't'
@@ -306,8 +288,6 @@ fn golden_time_uppercase_t_takes_precedence() {
         .with_time_set_to_transfer(true);
     assert_eq!(change.format(), ">f..T......");
 }
-
-// ---- string length invariant ----
 
 #[test]
 fn golden_all_outputs_are_eleven_chars() {
@@ -359,8 +339,6 @@ fn golden_all_outputs_are_eleven_chars() {
     }
 }
 
-// ---- symlink size suppression interacts with trailing-dot collapse ----
-
 #[test]
 fn golden_symlink_size_only_collapses_to_spaces() {
     // upstream: log.c:707 - symlink c[3] = '.', so if size_changed is the only flag,
@@ -372,8 +350,6 @@ fn golden_symlink_size_only_collapses_to_spaces() {
     // size is suppressed for symlinks, all rendered attrs are dots, collapse kicks in
     assert_eq!(change.format(), ".L         ");
 }
-
-// ---- symlink with checksum but no size ----
 
 #[test]
 fn golden_symlink_checksum_without_size() {

--- a/crates/cli/src/frontend/itemize/tests/types.rs
+++ b/crates/cli/src/frontend/itemize/tests/types.rs
@@ -1,7 +1,5 @@
 use crate::frontend::itemize::*;
 
-// ---- Update type character conversion ----
-
 #[test]
 fn update_type_sent_is_less_than() {
     assert_eq!(UpdateType::Sent.as_char(), '<');
@@ -32,8 +30,6 @@ fn update_type_message_is_star() {
     assert_eq!(UpdateType::Message.as_char(), '*');
 }
 
-// ---- File type character conversion ----
-
 #[test]
 fn file_type_regular_file_is_f() {
     assert_eq!(FileType::RegularFile.as_char(), 'f');
@@ -59,8 +55,6 @@ fn file_type_special_is_s_upper() {
     assert_eq!(FileType::Special.as_char(), 'S');
 }
 
-// ---- ItemizeChange construction and defaults ----
-
 #[test]
 fn new_creates_unchanged_regular_file() {
     let change = ItemizeChange::new();
@@ -74,8 +68,6 @@ fn new_creates_unchanged_regular_file() {
 fn default_is_same_as_new() {
     assert_eq!(ItemizeChange::default(), ItemizeChange::new());
 }
-
-// ---- is_unchanged detection ----
 
 #[test]
 fn is_unchanged_returns_true_for_no_changes() {

--- a/crates/cli/src/frontend/out_format/parser.rs
+++ b/crates/cli/src/frontend/out_format/parser.rs
@@ -439,7 +439,6 @@ mod tests {
         assert!(result.is_ok());
     }
 
-    // ---- Token content verification tests ----
     //
     // These tests verify that each placeholder letter maps to the correct
     // OutFormatPlaceholder variant, not just that parsing succeeds.
@@ -568,8 +567,6 @@ mod tests {
         assert_single_placeholder("%C", OutFormatPlaceholder::FullChecksum);
     }
 
-    // ---- Escaped percent produces a literal token ----
-
     #[test]
     fn parse_escaped_percent_produces_literal_percent_token() {
         let format = parse_out_format(&os("%%")).unwrap();
@@ -592,8 +589,6 @@ mod tests {
             other => panic!("expected literal '%%', got {other:?}"),
         }
     }
-
-    // ---- Token ordering with mixed literals and placeholders ----
 
     #[test]
     fn parse_mixed_format_preserves_token_order() {
@@ -631,8 +626,6 @@ mod tests {
         );
     }
 
-    // ---- Apostrophe before and after width combined ----
-
     #[test]
     fn parse_placeholder_format_apostrophe_before_and_after_width() {
         let mut chars = "'10'n".chars().peekable();
@@ -651,8 +644,6 @@ mod tests {
         assert_eq!(format.humanize(), HumanizeMode::BinaryUnits);
     }
 
-    // ---- Unsupported placeholder error messages ----
-
     #[test]
     fn parse_out_format_unsupported_placeholder_includes_letter_in_error() {
         let err = parse_out_format(&os("%z")).unwrap_err();
@@ -667,8 +658,6 @@ mod tests {
         assert!(msg.contains("%Q"), "error should mention '%Q', got: {msg}",);
     }
 
-    // ---- Literal-only input produces single literal token ----
-
     #[test]
     fn parse_literal_only_input_produces_single_literal_token() {
         let format = parse_out_format(&os("hello world")).unwrap();
@@ -679,8 +668,6 @@ mod tests {
             other => panic!("expected literal, got {other:?}"),
         }
     }
-
-    // ---- Placeholder with format metadata ----
 
     #[test]
     fn parse_width_format_attached_to_correct_placeholder() {

--- a/crates/cli/src/frontend/out_format/render/tests.rs
+++ b/crates/cli/src/frontend/out_format/render/tests.rs
@@ -33,7 +33,6 @@ fn make_event(
     )
 }
 
-// ==================== format_itemized_changes tests ====================
 //
 // Upstream rsync --itemize-changes format reference:
 //   YXcstpoguax  filename
@@ -46,8 +45,6 @@ fn make_event(
 //     '.' = attribute is unchanged
 //     '+' = file is new (all attributes are new)
 //     letter = attribute changed (c/s/t/T/p/o/g/u/n/b/a/x)
-
-// ---- Format length ----
 
 #[test]
 fn itemize_format_length_is_eleven_for_new_file() {
@@ -100,8 +97,6 @@ fn itemize_format_length_is_eleven_for_modified_file() {
         "format string should be 11 characters: {result:?}"
     );
 }
-
-// ---- Y (position 0): update type character ----
 
 #[test]
 fn itemize_y_position_data_copied_shows_greater_than() {
@@ -263,8 +258,6 @@ fn itemize_y_position_source_removed_shows_c() {
     );
 }
 
-// ---- X (position 1): file type character ----
-
 #[test]
 fn itemize_x_position_file_shows_f() {
     let event = make_event(
@@ -377,8 +370,6 @@ fn itemize_x_position_socket_shows_s_upper() {
     );
 }
 
-// ---- New file: all attributes show '+' (positions 2-10) ----
-
 #[test]
 fn itemize_new_file_shows_all_plus_in_attribute_positions() {
     let event = make_event(
@@ -469,8 +460,6 @@ fn itemize_hardlink_shows_all_plus_in_attribute_positions() {
     );
 }
 
-// ---- Delete format ----
-
 #[test]
 fn itemize_deleted_entry_shows_star_deleting() {
     let event = make_event(
@@ -485,8 +474,6 @@ fn itemize_deleted_entry_shows_star_deleting() {
         "deleted entry should be '*deleting  ' (11 chars): {result:?}"
     );
 }
-
-// ---- Individual attribute positions for changed files ----
 
 #[test]
 fn itemize_checksum_changed_shows_c_at_position_2() {
@@ -694,8 +681,6 @@ fn itemize_xattr_changed_shows_x_at_position_10() {
     );
 }
 
-// ---- No change shows dots for all attributes ----
-
 #[test]
 fn itemize_no_changes_shows_all_dots_in_attribute_positions() {
     let event = make_event(
@@ -710,8 +695,6 @@ fn itemize_no_changes_shows_all_dots_in_attribute_positions() {
         "no change with '.' update type should collapse dots to spaces: {result:?}"
     );
 }
-
-// ---- Combined changes ----
 
 #[test]
 fn itemize_checksum_and_size_change_shows_cs_at_positions_2_3() {
@@ -821,8 +804,6 @@ fn itemize_owner_and_group_change() {
     assert_eq!(result, ">f....og...", "owner+group change: {result:?}");
 }
 
-// ---- File type inference when metadata is None ----
-
 #[test]
 fn itemize_infers_file_type_from_data_copied_when_no_metadata() {
     let event = make_event(
@@ -902,8 +883,6 @@ fn itemize_infers_device_type_from_device_copied_when_no_metadata() {
         "should infer 'D' for DeviceCopied: {result:?}"
     );
 }
-
-// ---- Skipped variations show dot as Y ----
 
 #[test]
 fn itemize_skipped_missing_destination_shows_dot() {
@@ -1000,8 +979,6 @@ fn itemize_skipped_mount_point_shows_dot() {
         "SkippedMountPoint should be '.': {result:?}"
     );
 }
-
-// ---- Upstream format strings: complete patterns ----
 
 #[test]
 fn itemize_upstream_new_regular_file_pattern() {
@@ -1105,8 +1082,6 @@ fn itemize_upstream_transfer_time_pattern() {
     assert_eq!(format_itemized_changes(&event, false), ">f..T......");
 }
 
-// ---- Edge cases ----
-
 #[test]
 fn itemize_new_file_ignores_change_set_values() {
     // When created=true, all positions 2-10 should be '+' regardless of change_set
@@ -1195,8 +1170,6 @@ fn itemize_missing_data_length_is_eleven() {
     let result = format_itemized_changes(&event, false);
     assert_eq!(result.len(), 11);
 }
-
-// ---- Symlink-specific positions (upstream: log.c:705-710) ----
 
 #[test]
 fn itemize_symlink_size_always_dot_even_when_size_changed() {
@@ -1315,8 +1288,6 @@ fn itemize_file_size_still_reports_when_changed() {
     );
 }
 
-// ==================== Render integration tests ====================
-
 fn render_format(format_str: &str, event: &ClientEvent) -> String {
     let format = parse_out_format(std::ffi::OsStr::new(format_str)).unwrap();
     let mut output = Vec::new();
@@ -1337,8 +1308,6 @@ fn render_format_with_context(
     String::from_utf8(output).unwrap()
 }
 
-// ---- %n renders filename ----
-
 #[test]
 fn render_percent_n_shows_filename() {
     let event = make_event(
@@ -1349,8 +1318,6 @@ fn render_percent_n_shows_filename() {
     );
     assert_eq!(render_format("%n", &event), "test.txt\n");
 }
-
-// ---- %n adds trailing slash for directories ----
 
 #[test]
 fn render_percent_n_adds_trailing_slash_for_directory() {
@@ -1364,8 +1331,6 @@ fn render_percent_n_adds_trailing_slash_for_directory() {
     );
     assert_eq!(render_format("%n", &event), "mydir/\n");
 }
-
-// ---- %f does NOT add trailing slash for directories (full path) ----
 
 #[test]
 fn render_percent_f_no_trailing_slash_for_directory() {
@@ -1385,8 +1350,6 @@ fn render_percent_f_no_trailing_slash_for_directory() {
     );
 }
 
-// ---- %l shows file length ----
-
 #[test]
 fn render_percent_l_shows_file_length() {
     let event = make_event(
@@ -1399,8 +1362,6 @@ fn render_percent_l_shows_file_length() {
     assert_eq!(render_format("%l", &event), "0\n");
 }
 
-// ---- %b shows bytes transferred (0 for test events) ----
-
 #[test]
 fn render_percent_b_shows_bytes_transferred() {
     let event = make_event(
@@ -1412,8 +1373,6 @@ fn render_percent_b_shows_bytes_transferred() {
     // for_test always sets bytes_transferred to 0
     assert_eq!(render_format("%b", &event), "0\n");
 }
-
-// ---- %o shows operation description ----
 
 #[test]
 fn render_percent_o_shows_operation() {
@@ -1437,8 +1396,6 @@ fn render_percent_o_shows_deleted_for_entry_deleted() {
     assert_eq!(render_format("%o", &event), "deleted\n");
 }
 
-// ---- %p shows process ID ----
-
 #[test]
 fn render_percent_p_shows_current_pid() {
     let event = make_event(
@@ -1451,8 +1408,6 @@ fn render_percent_p_shows_current_pid() {
     let expected = format!("{}\n", std::process::id());
     assert_eq!(rendered, expected);
 }
-
-// ---- %t shows current timestamp in correct format ----
 
 #[test]
 fn render_percent_t_shows_timestamp_in_expected_format() {
@@ -1476,8 +1431,6 @@ fn render_percent_t_shows_timestamp_in_expected_format() {
     assert_eq!(&trimmed[16..17], ":", "position 16 should be ':'");
 }
 
-// ---- %M shows modification time (epoch default when no metadata) ----
-
 #[test]
 fn render_percent_m_shows_epoch_when_no_mtime() {
     let event = make_event(
@@ -1488,8 +1441,6 @@ fn render_percent_m_shows_epoch_when_no_mtime() {
     );
     assert_eq!(render_format("%M", &event), "1970/01/01-00:00:00\n");
 }
-
-// ---- %U and %G show uid/gid (0 when no metadata uid/gid) ----
 
 #[test]
 fn render_percent_u_upper_shows_uid_zero_for_test_metadata() {
@@ -1513,8 +1464,6 @@ fn render_percent_g_upper_shows_gid_zero_for_test_metadata() {
     assert_eq!(render_format("%G", &event), "0\n");
 }
 
-// ---- %B shows permissions (dashes when no mode) ----
-
 #[test]
 fn render_percent_b_upper_shows_dashes_for_test_metadata() {
     let event = make_event(
@@ -1526,8 +1475,6 @@ fn render_percent_b_upper_shows_dashes_for_test_metadata() {
     // test_metadata has mode = None => "---------"
     assert_eq!(render_format("%B", &event), "---------\n");
 }
-
-// ---- %L shows nothing for non-symlink files ----
 
 #[test]
 fn render_percent_l_upper_shows_nothing_for_regular_file() {
@@ -1542,8 +1489,6 @@ fn render_percent_l_upper_shows_nothing_for_regular_file() {
     // and the output is just the newline
     assert_eq!(render_format("%L", &event), "\n");
 }
-
-// ---- %i%n combined upstream pattern ----
 
 #[test]
 fn render_itemize_and_filename_combined_no_space() {
@@ -1569,8 +1514,6 @@ fn render_itemize_and_filename_with_space() {
     assert_eq!(render_format("%i %n", &event), ">f+++++++++ test.txt\n");
 }
 
-// ---- %% literal percent ----
-
 #[test]
 fn render_escaped_percent_produces_literal_percent() {
     let event = make_event(
@@ -1593,8 +1536,6 @@ fn render_literal_text_with_escaped_percent() {
     assert_eq!(render_format("100%%", &event), "100%\n");
 }
 
-// ---- Multiple codes in one format string ----
-
 #[test]
 fn render_multiple_codes_in_format_string() {
     let event = make_event(
@@ -1607,8 +1548,6 @@ fn render_multiple_codes_in_format_string() {
     assert_eq!(rendered, "[test.txt] 0 bytes copied\n");
 }
 
-// ---- Literal text mixed with codes ----
-
 #[test]
 fn render_literal_prefix_and_suffix_around_placeholder() {
     let event = make_event(
@@ -1620,8 +1559,6 @@ fn render_literal_prefix_and_suffix_around_placeholder() {
     let rendered = render_format("<<<%n>>>", &event);
     assert_eq!(rendered, "<<<test.txt>>>\n");
 }
-
-// ---- Remote context placeholders with populated context ----
 
 #[test]
 fn render_remote_host_with_context_populated() {
@@ -1723,8 +1660,6 @@ fn render_all_remote_placeholders_with_full_context() {
     assert_eq!(rendered, "host addr mod /path\n");
 }
 
-// ---- emit_out_format with multiple events ----
-
 #[test]
 fn emit_out_format_renders_multiple_events() {
     let event1 = ClientEvent::for_test(
@@ -1757,8 +1692,6 @@ fn emit_out_format_renders_empty_event_list() {
     emit_out_format(events, &format, &OutFormatContext::default(), &mut output).unwrap();
     assert!(output.is_empty());
 }
-
-// ---- Output always ends with newline ----
 
 #[test]
 fn render_output_always_ends_with_newline() {
@@ -1793,8 +1726,6 @@ fn render_output_does_not_double_newline_when_format_ends_with_newline() {
     assert!(!rendered.ends_with("\n\n"));
 }
 
-// ---- Width formatting with different placeholders ----
-
 #[test]
 fn render_width_right_aligned_filename() {
     let event = make_event(
@@ -1826,8 +1757,6 @@ fn render_width_left_aligned_filename() {
     assert!(trimmed.ends_with("            ")); // 12 trailing spaces
 }
 
-// ---- Humanized bytes formatting (unit-level, via format_numeric_value) ----
-
 #[test]
 fn render_separator_humanized_large_value() {
     let format = PlaceholderFormat::new(None, PlaceholderAlignment::Right, HumanizeMode::Separator);
@@ -1850,8 +1779,6 @@ fn render_binary_units_large_value() {
         PlaceholderFormat::new(None, PlaceholderAlignment::Right, HumanizeMode::BinaryUnits);
     assert_eq!(format_numeric_value(2048, &format), "2.00K");
 }
-
-// ---- Humanized bytes below threshold falls back ----
 
 #[test]
 fn render_decimal_units_below_threshold_falls_back_to_separator() {

--- a/crates/cli/src/frontend/server/tests.rs
+++ b/crates/cli/src/frontend/server/tests.rs
@@ -8,8 +8,6 @@ use super::parse::{
     parse_server_stop_after, parse_server_stop_at,
 };
 
-// ---- daemon_mode_arguments ----
-
 #[test]
 fn daemon_mode_arguments_empty_args() {
     let args: Vec<OsString> = vec![];
@@ -98,8 +96,6 @@ fn daemon_mode_arguments_oc_rsync_program() {
     assert!(!daemon_args.is_empty());
 }
 
-// ---- server_mode_requested ----
-
 #[test]
 fn server_mode_requested_no_server_flag() {
     let args: Vec<OsString> = vec![
@@ -178,8 +174,6 @@ fn server_mode_requested_server_not_in_first_position() {
     assert!(server_mode_requested(&args));
 }
 
-// ---- detect_secluded_args_flag ----
-
 #[test]
 fn detect_secluded_args_when_present() {
     let args: Vec<OsString> = vec![
@@ -208,8 +202,6 @@ fn detect_secluded_args_ignores_program_name() {
     let args: Vec<OsString> = vec![OsString::from("-s"), OsString::from("--server")];
     assert!(!detect_secluded_args_flag(&args));
 }
-
-// ---- parse_server_flag_string_and_args ----
 
 #[test]
 fn parse_server_args_basic() {
@@ -287,8 +279,6 @@ fn parse_server_args_skips_value_bearing_long_flags() {
     assert_eq!(flags, "-logDtpr");
     assert_eq!(pos_args, vec![OsString::from("dest/")]);
 }
-
-// ---- parse_server_long_flags ----
 
 #[test]
 fn long_flags_defaults() {
@@ -477,8 +467,6 @@ fn long_flags_all_combined() {
     assert_eq!(flags.stop_after.as_deref(), Some("30"));
 }
 
-// ---- is_known_server_long_flag ----
-
 #[test]
 fn known_flag_detects_boolean_flags() {
     assert!(is_known_server_long_flag("--server"));
@@ -515,8 +503,6 @@ fn known_flag_rejects_unknown() {
     assert!(!is_known_server_long_flag("dest/"));
 }
 
-// ---- parse_server_checksum_seed ----
-
 #[test]
 fn checksum_seed_parses_valid() {
     assert_eq!(parse_server_checksum_seed("0").unwrap(), 0);
@@ -543,8 +529,6 @@ fn checksum_seed_rejects_overflow() {
 fn checksum_seed_trims_whitespace() {
     assert_eq!(parse_server_checksum_seed("  42  ").unwrap(), 42);
 }
-
-// ---- parse_server_size_limit ----
 
 #[test]
 fn size_limit_parses_plain_number() {
@@ -582,8 +566,6 @@ fn size_limit_rejects_invalid() {
     assert!(parse_server_size_limit("abc", "--max-size").is_err());
 }
 
-// ---- parse_server_stop_after ----
-
 #[test]
 fn stop_after_parses_valid_minutes() {
     let deadline = parse_server_stop_after("10").unwrap();
@@ -606,8 +588,6 @@ fn stop_after_rejects_non_numeric() {
     assert!(parse_server_stop_after("abc").is_err());
 }
 
-// ---- parse_server_stop_at ----
-
 #[test]
 fn stop_at_rejects_empty() {
     assert!(parse_server_stop_at("").is_err());
@@ -624,8 +604,6 @@ fn stop_at_parses_far_future_date() {
     // May fail due to local offset issues in test env, but format should be ok
     assert!(result.is_ok() || result.is_err());
 }
-
-// ---- files-from and from0 flag ----
 
 #[test]
 fn long_flags_files_from_stdin() {

--- a/crates/cli/src/frontend/tests/files_from.rs
+++ b/crates/cli/src/frontend/tests/files_from.rs
@@ -1,8 +1,6 @@
 use super::common::*;
 use super::*;
 
-// ==================== File reading tests ====================
-
 #[test]
 fn files_from_reads_list_from_specified_file() {
     let tmp = test_support::create_tempdir();
@@ -54,8 +52,6 @@ fn files_from_preserves_non_utf8_entries() {
     assert_eq!(entries[0].as_os_str().as_bytes(), b"fo\x80");
 }
 
-// ==================== One filename per line tests ====================
-
 #[test]
 fn files_from_parses_one_filename_per_line() {
     let tmp = test_support::create_tempdir();
@@ -106,8 +102,6 @@ fn files_from_handles_mixed_line_endings() {
     assert_eq!(entries[1], "file2.txt");
     assert_eq!(entries[2], "file3.txt");
 }
-
-// ==================== Comment and blank line handling tests ====================
 
 #[test]
 fn files_from_skips_hash_comments() {
@@ -181,8 +175,6 @@ fn files_from_handles_comments_and_blank_lines_together() {
     assert_eq!(entries[1], "file2.txt");
 }
 
-// ==================== stdin tests ====================
-
 #[test]
 fn files_from_reads_from_stdin_with_dash() {
     use std::io::Cursor;
@@ -231,8 +223,6 @@ fn files_from_stdin_handles_blank_lines() {
     assert_eq!(entries[1], "file2.txt");
 }
 
-// ==================== zero-terminated tests ====================
-
 #[test]
 fn from0_reader_accepts_missing_trailing_separator() {
     let data = b"alpha\0beta\0gamma";
@@ -272,8 +262,6 @@ fn from0_disables_comment_handling() {
     assert_eq!(entries[1], ";alsonotacomment");
 }
 
-// ==================== edge cases ====================
-
 #[test]
 fn files_from_handles_empty_file() {
     let tmp = test_support::create_tempdir();
@@ -300,8 +288,6 @@ fn files_from_handles_whitespace_only_file() {
     assert_eq!(entries.len(), 0);
 }
 
-// ==================== Multiple files-from arguments ====================
-
 #[test]
 fn files_from_reads_from_multiple_files() {
     let tmp = test_support::create_tempdir();
@@ -327,8 +313,6 @@ fn files_from_empty_list_returns_empty_vec() {
     let result = load_file_list_operands(&entries, false).expect("load empty");
     assert!(result.is_empty());
 }
-
-// ==================== Unicode and special characters ====================
 
 #[test]
 fn files_from_handles_unicode_filenames() {
@@ -396,8 +380,6 @@ fn files_from_handles_special_characters_in_filenames() {
     assert_eq!(entries[4], "file\"5\".txt");
 }
 
-// ==================== Path handling tests ====================
-
 #[test]
 fn files_from_preserves_absolute_paths() {
     let tmp = test_support::create_tempdir();
@@ -455,8 +437,6 @@ fn files_from_handles_deeply_nested_paths() {
     assert_eq!(entries[0], "a/b/c/d/e/f/g/h/i/j/file.txt");
     assert_eq!(entries[1], "very/deeply/nested/path/to/some/file.txt");
 }
-
-// ==================== Zero-terminated edge cases ====================
 
 #[test]
 fn from0_handles_empty_entries() {
@@ -527,8 +507,6 @@ fn from0_preserves_non_utf8_in_zero_terminated() {
     assert_eq!(entries[1], "normal.txt");
 }
 
-// ==================== Comment edge cases ====================
-
 #[test]
 fn files_from_hash_only_on_first_char_is_comment() {
     let tmp = test_support::create_tempdir();
@@ -586,8 +564,6 @@ fn files_from_comments_only_file_returns_empty() {
     assert!(entries.is_empty());
 }
 
-// ==================== Reader function edge cases ====================
-
 #[test]
 fn reader_handles_very_long_lines() {
     use std::io::Cursor;
@@ -634,8 +610,6 @@ fn reader_handles_trailing_carriage_returns() {
     assert_eq!(entries.len(), 1);
     assert_eq!(entries[0], "file.txt");
 }
-
-// ==================== Integration tests with actual file operations ====================
 
 #[test]
 fn files_from_integration_copies_listed_files() {
@@ -756,8 +730,6 @@ fn files_from_integration_with_comments_only_list_succeeds() {
     assert!(!dest_dir.join("file.txt").exists());
 }
 
-// ==================== CLI argument parsing tests ====================
-
 #[test]
 fn parse_args_recognizes_files_from_with_equals() {
     use crate::frontend::arguments::parse_args;
@@ -846,8 +818,6 @@ fn parse_args_files_from_empty_value() {
     assert_eq!(parsed.files_from[0], "");
 }
 
-// ==================== Error handling tests ====================
-
 #[cfg(unix)]
 #[test]
 fn files_from_reports_permission_error() {
@@ -919,10 +889,6 @@ fn files_from_with_nonexistent_source_file_reports_error() {
             || rendered.contains("failed")
     );
 }
-
-// ==================== Additional comprehensive tests ====================
-
-// ==================== Real Unicode filename tests ====================
 
 #[test]
 fn files_from_handles_actual_unicode_characters() {
@@ -1004,8 +970,6 @@ fn files_from_handles_zero_width_characters() {
     assert_eq!(entries[0], "file\u{200D}name.txt");
     assert_eq!(entries[1], "test\u{200C}file.txt");
 }
-
-// ==================== Special character edge cases ====================
 
 #[test]
 fn files_from_handles_glob_metacharacters() {
@@ -1096,8 +1060,6 @@ fn files_from_handles_equals_and_colon_in_filenames() {
     assert_eq!(entries[3], "--not-a-flag.txt");
 }
 
-// ==================== Whitespace edge cases ====================
-
 #[test]
 fn files_from_handles_tab_characters() {
     let tmp = test_support::create_tempdir();
@@ -1152,8 +1114,6 @@ fn files_from_preserves_multiple_consecutive_spaces() {
     assert_eq!(entries[0], "file   three   spaces.txt");
     assert_eq!(entries[1], "file    four    spaces.txt");
 }
-
-// ==================== from0 comprehensive tests ====================
 
 #[test]
 fn from0_handles_embedded_newlines_and_carriage_returns() {
@@ -1254,8 +1214,6 @@ fn from0_handles_multiple_consecutive_nulls() {
     assert_eq!(entries[1], "file2.txt");
 }
 
-// ==================== Path edge cases ====================
-
 #[test]
 fn files_from_handles_dot_and_dotdot_paths() {
     let tmp = test_support::create_tempdir();
@@ -1337,8 +1295,6 @@ fn files_from_handles_double_slashes() {
     assert_eq!(entries[2], "trailing//");
 }
 
-// ==================== Comment edge cases ====================
-
 #[test]
 fn files_from_handles_whitespace_before_comment() {
     let tmp = test_support::create_tempdir();
@@ -1395,8 +1351,6 @@ fn files_from_handles_empty_comment_lines() {
     assert_eq!(entries[0], "file.txt");
 }
 
-// ==================== Large file tests ====================
-
 #[test]
 fn files_from_handles_large_number_of_entries() {
     let tmp = test_support::create_tempdir();
@@ -1430,8 +1384,6 @@ fn files_from_handles_large_file_with_comments() {
 
     assert_eq!(entries.len(), 5000);
 }
-
-// ==================== Mixed content tests ====================
 
 #[test]
 fn files_from_handles_comprehensive_mixed_content() {
@@ -1488,8 +1440,6 @@ more_files.txt
     assert_eq!(entries[14], "unicode_文件.txt");
     assert_eq!(entries[15], "more_files.txt");
 }
-
-// ==================== Multiple files-from sources ====================
 
 #[test]
 fn files_from_combines_multiple_list_files_preserving_order() {
@@ -1568,8 +1518,6 @@ fn files_from_handles_one_empty_file_among_many() {
     assert_eq!(entries[2], "c.txt");
     assert_eq!(entries[3], "d.txt");
 }
-
-// ==================== Integration tests with from0 and actual copy ====================
 
 #[test]
 fn files_from_integration_with_from0_copies_listed_files() {
@@ -1720,8 +1668,6 @@ fn files_from_integration_with_spaces_in_filenames() {
     assert!(dest_dir.join("  leading.txt").exists());
     assert!(dest_dir.join("trailing  .txt").exists());
 }
-
-// ==================== resolve_file_list_entries comprehensive tests ====================
 
 #[test]
 fn resolve_file_list_entries_handles_mixed_absolute_and_relative() {

--- a/crates/cli/src/frontend/tests/itemize_format_upstream.rs
+++ b/crates/cli/src/frontend/tests/itemize_format_upstream.rs
@@ -13,8 +13,6 @@
 use super::common::*;
 use super::*;
 
-// ==================== New file: >f+++++++++ ==================
-
 #[test]
 fn itemize_new_file_output_matches_upstream() {
     use tempfile::tempdir;
@@ -61,8 +59,6 @@ fn itemize_short_flag_i_produces_same_output() {
     assert_eq!(output, ">f+++++++++ short.txt\n");
 }
 
-// ==================== Format string length ==================
-
 #[test]
 fn itemize_output_format_is_eleven_chars_plus_space_plus_filename() {
     use tempfile::tempdir;
@@ -98,8 +94,6 @@ fn itemize_output_format_is_eleven_chars_plus_space_plus_filename() {
     );
     assert_eq!(parts[1], "measure.txt");
 }
-
-// ==================== Updated file: content change ==================
 
 #[test]
 fn itemize_updated_file_shows_change_indicators() {
@@ -156,8 +150,6 @@ fn itemize_updated_file_shows_change_indicators() {
     assert_eq!(&format_str[4..5], "t", "time should be 't': {format_str:?}");
 }
 
-// ==================== Unchanged file ==================
-
 #[test]
 fn itemize_unchanged_file_with_times_shows_no_output() {
     use filetime::{FileTime, set_file_mtime};
@@ -197,8 +189,6 @@ fn itemize_unchanged_file_with_times_shows_no_output() {
     );
 }
 
-// ==================== Multiple files ==================
-
 #[test]
 fn itemize_multiple_new_files_each_show_new_format() {
     use tempfile::tempdir;
@@ -237,8 +227,6 @@ fn itemize_multiple_new_files_each_show_new_format() {
     }
 }
 
-// ==================== Dry run combined with itemize ==================
-
 #[test]
 fn itemize_combined_with_dry_run_shows_what_would_transfer() {
     use tempfile::tempdir;
@@ -270,8 +258,6 @@ fn itemize_combined_with_dry_run_shows_what_would_transfer() {
     );
 }
 
-// ==================== Verbose combined with itemize ==================
-
 #[test]
 fn itemize_combined_with_verbose_shows_itemized_format() {
     use tempfile::tempdir;
@@ -297,8 +283,6 @@ fn itemize_combined_with_verbose_shows_itemized_format() {
         "verbose+itemize should show itemized format: {output:?}"
     );
 }
-
-// ==================== Delete with itemize ==================
 
 #[test]
 fn itemize_with_delete_shows_star_deleting_format() {
@@ -331,8 +315,6 @@ fn itemize_with_delete_shows_star_deleting_format() {
         "delete should show '*deleting' format: {output:?}"
     );
 }
-
-// ==================== Directory creation with itemize ==================
 
 #[test]
 fn itemize_recursive_new_directory_shows_cd_plus_pattern() {
@@ -373,8 +355,6 @@ fn itemize_recursive_new_directory_shows_cd_plus_pattern() {
     );
 }
 
-// ==================== Symlink with itemize ==================
-
 #[cfg(unix)]
 #[test]
 fn itemize_new_symlink_shows_cl_plus_pattern() {
@@ -411,8 +391,6 @@ fn itemize_new_symlink_shows_cl_plus_pattern() {
         "new symlink should show 'cL+++++++++': {output:?}"
     );
 }
-
-// ==================== Permission change with itemize ==================
 
 #[cfg(unix)]
 #[test]
@@ -463,8 +441,6 @@ fn itemize_chmod_shows_permission_indicator() {
     }
 }
 
-// ==================== No itemize suppresses output ==================
-
 #[test]
 fn no_itemize_changes_suppresses_output() {
     use tempfile::tempdir;
@@ -488,8 +464,6 @@ fn no_itemize_changes_suppresses_output() {
         "no-itemize-changes should suppress output"
     );
 }
-
-// ==================== Itemize toggle ordering ==================
 
 #[test]
 fn itemize_last_toggle_wins_enabled() {

--- a/crates/cli/src/frontend/tests/parse_checksum.rs
+++ b/crates/cli/src/frontend/tests/parse_checksum.rs
@@ -35,8 +35,6 @@ fn parse_checksum_seed_argument_rejects_non_numeric() {
     );
 }
 
-// ===== Additional edge case tests (task #99) =====
-
 #[test]
 fn parse_checksum_seed_argument_rejects_overflow_u32() {
     // u32::MAX + 1 = 4294967296 should fail

--- a/crates/core/src/client/config/builder/tests.rs
+++ b/crates/core/src/client/config/builder/tests.rs
@@ -8,8 +8,6 @@ fn builder() -> ClientConfigBuilder {
     ClientConfigBuilder::default()
 }
 
-// --- arguments ---
-
 #[test]
 fn transfer_args_sets_values() {
     let config = builder().transfer_args(["--verbose", "--progress"]).build();
@@ -105,8 +103,6 @@ fn default_batch_config_is_none() {
     assert!(config.batch_config().is_none());
 }
 
-// --- deletion ---
-
 #[test]
 fn delete_sets_during_and_resets_to_disabled() {
     let config = ClientConfigBuilder::default().delete(true).build();
@@ -182,8 +178,6 @@ fn max_delete_propagates_limit() {
     let config = ClientConfigBuilder::default().max_delete(None).build();
     assert_eq!(config.max_delete(), None);
 }
-
-// --- filters ---
 
 #[test]
 fn debug_flags_sets_values() {
@@ -299,8 +293,6 @@ fn default_filter_rules_is_empty() {
     let config = builder().build();
     assert!(config.filter_rules().is_empty());
 }
-
-// --- metadata ---
 
 #[test]
 fn owner_sets_preserve() {
@@ -556,8 +548,6 @@ fn default_preserve_permissions_is_false() {
     assert!(!config.preserve_permissions());
 }
 
-// --- network ---
-
 #[test]
 fn bind_address_sets_value() {
     let socket = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)), 0);
@@ -776,8 +766,6 @@ fn protect_args_default_is_none() {
     assert!(config.protect_args().is_none());
 }
 
-// --- output ---
-
 #[test]
 fn verbosity_sets_level() {
     let config = builder().verbosity(2).build();
@@ -889,8 +877,6 @@ fn itemize_changes_false_clears_flag() {
         .build();
     assert!(!config.itemize_changes());
 }
-
-// --- partials ---
 
 #[test]
 fn partial_sets_flag() {
@@ -1086,8 +1072,6 @@ fn validate_default_builder_ok() {
     assert!(b.validate().is_ok());
 }
 
-// --- paths ---
-
 #[test]
 fn compare_destination_adds_directory() {
     let config = builder().compare_destination("/tmp/compare").build();
@@ -1210,8 +1194,6 @@ fn default_backup_suffix_is_none() {
     let config = builder().build();
     assert!(config.backup_suffix().is_none());
 }
-
-// --- performance ---
 
 #[test]
 fn bandwidth_limit_sets_value() {
@@ -1483,8 +1465,6 @@ fn compress_false_after_level_clears_everything() {
     }
 }
 
-// --- preservation ---
-
 #[test]
 fn copy_links_sets_flag() {
     let config = builder().copy_links(true).build();
@@ -1637,8 +1617,6 @@ fn default_trust_sender_is_false() {
     let config = builder().build();
     assert!(!config.trust_sender());
 }
-
-// --- selection ---
 
 #[test]
 fn min_file_size_sets_limit() {
@@ -1862,8 +1840,6 @@ fn from0_default_is_false() {
     let config = builder().build();
     assert!(!config.from0());
 }
-
-// --- validation ---
 
 #[test]
 fn checksum_sets_flag() {

--- a/crates/core/src/client/module_list/connect/program.rs
+++ b/crates/core/src/client/module_list/connect/program.rs
@@ -241,8 +241,6 @@ fn connect_program_configuration_error(text: impl Into<String>) -> ClientError {
 mod tests {
     use super::*;
 
-    // ==================== ConnectProgramConfig::new tests ====================
-
     #[test]
     fn connect_program_config_new_valid() {
         let config = ConnectProgramConfig::new("nc %H %P".into(), None);
@@ -270,8 +268,6 @@ mod tests {
         assert!(config.unwrap_err().contains("RSYNC_SHELL"));
     }
 
-    // ==================== ConnectProgramConfig::shell tests ====================
-
     #[test]
     fn connect_program_config_shell_none() {
         let config = ConnectProgramConfig::new("nc %H %P".into(), None).unwrap();
@@ -283,8 +279,6 @@ mod tests {
         let config = ConnectProgramConfig::new("nc %H %P".into(), Some("/bin/zsh".into())).unwrap();
         assert_eq!(config.shell().unwrap(), "/bin/zsh");
     }
-
-    // ==================== ConnectProgramConfig::format_command tests ====================
 
     #[test]
     fn format_command_substitutes_host() {

--- a/crates/core/src/client/module_list/connect/proxy.rs
+++ b/crates/core/src/client/module_list/connect/proxy.rs
@@ -386,8 +386,6 @@ fn proxy_response_error(text: impl Into<String>) -> ClientError {
 mod tests {
     use super::*;
 
-    // ==================== parse_proxy_spec tests ====================
-
     #[test]
     fn parse_proxy_spec_simple_host_port() {
         let config = parse_proxy_spec("proxy.example.com:8080").unwrap();
@@ -512,8 +510,6 @@ mod tests {
         assert_eq!(config.port, 3128);
     }
 
-    // ==================== parse_proxy_host_port tests ====================
-
     #[test]
     fn parse_proxy_host_port_simple() {
         let (host, port) = parse_proxy_host_port("example.com:8080").unwrap();
@@ -570,8 +566,6 @@ mod tests {
         assert_eq!(host, "my host");
     }
 
-    // ==================== decode_proxy_component tests ====================
-
     #[test]
     fn decode_proxy_component_plain_text() {
         let result = decode_proxy_component("username", "test").unwrap();
@@ -623,8 +617,6 @@ mod tests {
         assert!(result.is_err());
     }
 
-    // ==================== ProxyCredentials tests ====================
-
     #[test]
     fn proxy_credentials_authorization_value_basic_auth() {
         let creds = ProxyCredentials::new("user".to_owned(), "pass".to_owned());
@@ -646,8 +638,6 @@ mod tests {
         assert_eq!(decoded, b"user@domain:p@ss:word");
     }
 
-    // ==================== ProxyConfig tests ====================
-
     #[test]
     fn proxy_config_display_returns_socket_addr() {
         let config = parse_proxy_spec("proxy.example.com:8080").unwrap();
@@ -668,8 +658,6 @@ mod tests {
         assert!(config.authorization_header().is_some());
         assert_eq!(config.authorization_header().unwrap(), "dXNlcjpwYXNz");
     }
-
-    // ==================== Edge cases and integration tests ====================
 
     #[test]
     fn parse_proxy_spec_localhost() {

--- a/crates/core/src/client/remote/daemon_transfer/orchestration/arguments.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/arguments.rs
@@ -155,7 +155,6 @@ pub(super) fn build_full_daemon_args(
         args.push(build_capability_string(is_sender));
     }
 
-    // --- Long-form arguments (upstream server_options() options.c:2737-2980) ---
     let we_are_sender = !is_sender;
 
     // upstream: options.c:2750-2762 - server needs to know about log-format

--- a/crates/core/src/client/remote/invocation/tests.rs
+++ b/crates/core/src/client/remote/invocation/tests.rs
@@ -435,8 +435,6 @@ fn remote_invocation_only_sends_upstream_compatible_args() {
     }
 }
 
-// ==================== new option forwarding tests ====================
-
 #[test]
 fn includes_delete_before_long_arg() {
     let config = ClientConfig::builder().delete_before(true).build();
@@ -758,8 +756,6 @@ fn includes_dry_run_flag() {
     assert!(flags.contains('n'), "expected 'n' in flags: {flags}");
 }
 
-// ==================== secluded-args tests ====================
-
 #[test]
 fn secluded_invocation_disabled_returns_normal_args() {
     let config = ClientConfig::builder().protect_args(None).build();
@@ -875,7 +871,6 @@ fn secluded_invocation_explicitly_disabled_returns_normal() {
     );
 }
 
-// ==================== comprehensive flag forwarding tests ====================
 //
 // These tests verify that every CLI flag supported by the builder is correctly
 // forwarded to the remote server invocation. Each test constructs a config with
@@ -926,8 +921,6 @@ fn receiver_flag_string(config: &ClientConfig) -> String {
     find_flag_string(&args).to_owned()
 }
 
-// ---------- default config produces minimal output ----------
-
 #[test]
 fn default_config_produces_expected_flags() {
     // ClientConfig::builder() sets recursive=true by default, and
@@ -957,8 +950,6 @@ fn default_config_has_no_long_form_args() {
     }
 }
 
-// ---------- archive mode composite test (-a = -rlptgoD) ----------
-
 #[test]
 fn archive_mode_flags_all_present() {
     // -a is equivalent to -rlptgoD
@@ -982,8 +973,6 @@ fn archive_mode_flags_all_present() {
     assert!(flags.contains('o'), "archive: missing 'o' in {flags}");
     assert!(flags.contains('D'), "archive: missing 'D' in {flags}");
 }
-
-// ---------- individual short-flag forwarding ----------
 
 #[test]
 fn includes_links_flag() {
@@ -1146,8 +1135,6 @@ fn delete_excluded_is_long_form_not_in_flag_string() {
     );
 }
 
-// ---------- ACL and xattr flags (feature-gated) ----------
-
 #[cfg(all(unix, feature = "acl"))]
 #[test]
 fn includes_acl_flag() {
@@ -1163,8 +1150,6 @@ fn includes_xattr_flag() {
     let flags = sender_flag_string(&config);
     assert!(flags.contains('X'), "expected 'X' in flags: {flags}");
 }
-
-// ---------- long-form argument forwarding ----------
 
 #[test]
 fn includes_delete_during_long_arg() {
@@ -1521,8 +1506,6 @@ fn includes_preallocate_long_arg() {
     );
 }
 
-// ---------- custom rsync path ----------
-
 #[test]
 fn custom_rsync_path_used_as_program_name() {
     let config = ClientConfig::builder()
@@ -1541,8 +1524,6 @@ fn default_rsync_path_is_rsync() {
     let args = build_sender_args(&config);
     assert_eq!(args[0], "rsync", "default program name should be 'rsync'");
 }
-
-// ---------- capability string ----------
 
 #[test]
 fn capability_string_present_in_sender_args() {
@@ -1565,8 +1546,6 @@ fn capability_string_present_in_receiver_args() {
         "expected capability string {expected} in args: {args:?}"
     );
 }
-
-// ---------- dot placeholder and path ----------
 
 #[test]
 fn dot_placeholder_precedes_remote_path_in_sender() {
@@ -1594,8 +1573,6 @@ fn dot_placeholder_precedes_remote_path_in_receiver() {
     );
 }
 
-// ---------- multiple remote paths ----------
-
 #[test]
 fn build_with_multiple_paths() {
     let config = ClientConfig::builder().build();
@@ -1611,8 +1588,6 @@ fn build_with_multiple_paths() {
     assert_eq!(args[dot_idx + 2], "/src2");
     assert_eq!(args[dot_idx + 3], "/src3");
 }
-
-// ---------- receiver-specific tests ----------
 
 #[test]
 fn receiver_flag_string_matches_sender_for_same_config() {
@@ -1630,8 +1605,6 @@ fn receiver_flag_string_matches_sender_for_same_config() {
         "flag strings should be identical for sender and receiver with same config"
     );
 }
-
-// ---------- delete mode exclusivity ----------
 
 #[test]
 fn only_one_delete_mode_emitted() {
@@ -1666,8 +1639,6 @@ fn delete_delay_emits_only_delay() {
     assert_eq!(delete_args.len(), 1);
     assert_eq!(delete_args[0], "--delete-delay");
 }
-
-// ---------- combined flag correctness ----------
 
 #[test]
 fn compress_with_level_emits_both_flag_and_level() {
@@ -1708,8 +1679,6 @@ fn backup_without_dir_or_suffix_emits_only_backup() {
     assert!(!args.iter().any(|a| a.starts_with("--backup-dir=")));
     assert!(!args.iter().any(|a| a.starts_with("--suffix=")));
 }
-
-// ---------- omission tests: disabled flags should NOT appear ----------
 
 #[test]
 fn omits_compress_flag_when_disabled() {
@@ -1872,8 +1841,6 @@ fn omits_reference_dirs_when_empty() {
         "should not emit reference dir args when empty: {args:?}"
     );
 }
-
-// ---------- exhaustive all-flags-at-once integration test ----------
 
 #[test]
 fn all_flags_enabled_produces_valid_invocation() {

--- a/crates/daemon/src/daemon/sections/config_parsing/tests.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing/tests.rs
@@ -11,7 +11,6 @@ mod config_parsing_tests {
         file
     }
 
-    // --- resolve_config_relative_path tests ---
 
     #[test]
     fn resolve_config_relative_path_absolute() {
@@ -37,7 +36,6 @@ mod config_parsing_tests {
         assert_eq!(result, PathBuf::from("relative.txt"));
     }
 
-    // --- parse_config_modules basic tests ---
 
     #[test]
     fn parse_empty_config() {
@@ -95,7 +93,6 @@ mod config_parsing_tests {
         assert_eq!(result.modules[1].name, "mod2");
     }
 
-    // --- Module header error tests ---
 
     #[test]
     fn parse_unterminated_module_header() {
@@ -137,7 +134,6 @@ mod config_parsing_tests {
         assert_eq!(result.modules.len(), 1);
     }
 
-    // --- Directive parsing tests ---
 
     #[test]
     fn parse_missing_equals() {
@@ -153,7 +149,6 @@ mod config_parsing_tests {
         assert!(result.modules.is_empty());
     }
 
-    // --- Global directive tests ---
 
     #[test]
     fn parse_global_pid_file() {
@@ -209,7 +204,6 @@ mod config_parsing_tests {
         assert_eq!(value, "a+r");
     }
 
-    // --- MOTD tests ---
 
     #[test]
     fn parse_inline_motd() {
@@ -228,7 +222,6 @@ mod config_parsing_tests {
         assert_eq!(result.motd_lines[0], "Line 1");
     }
 
-    // --- Module directive tests ---
 
     #[test]
     fn parse_module_read_only() {
@@ -351,7 +344,6 @@ mod config_parsing_tests {
         assert_eq!(result.modules[0].max_connections.unwrap().get(), 10);
     }
 
-    // --- Include directive tests ---
 
     #[test]
     fn parse_include_directive() {
@@ -383,7 +375,6 @@ mod config_parsing_tests {
         assert!(err.to_string().contains("recursive include"));
     }
 
-    // --- Empty value error tests ---
 
     #[test]
     fn parse_empty_path_errors() {
@@ -413,7 +404,6 @@ mod config_parsing_tests {
         assert!(err.to_string().contains("must not be empty"));
     }
 
-    // --- Duplicate directive tests ---
 
     #[test]
     fn parse_duplicate_pid_file_errors() {
@@ -429,7 +419,6 @@ mod config_parsing_tests {
         assert!(err.to_string().contains("duplicate"));
     }
 
-    // --- Invalid boolean tests ---
 
     #[test]
     fn parse_invalid_boolean_errors() {
@@ -438,7 +427,6 @@ mod config_parsing_tests {
         assert!(err.to_string().contains("invalid boolean"));
     }
 
-    // --- Case insensitivity tests ---
 
     #[test]
     fn parse_keys_case_insensitive() {
@@ -453,7 +441,6 @@ mod config_parsing_tests {
         assert!(!result.modules[0].read_only);
     }
 
-    // --- Munge symlinks directive tests ---
 
     #[test]
     fn parse_module_munge_symlinks_yes() {
@@ -507,7 +494,6 @@ mod config_parsing_tests {
         assert!(err.to_string().contains("duplicate"));
     }
 
-    // --- New directive parsing tests ---
 
     #[test]
     fn parse_module_max_verbosity() {
@@ -744,7 +730,6 @@ mod config_parsing_tests {
         assert!(result.modules[0].forward_lookup);
     }
 
-    // --- Strict modes directive tests ---
 
     #[test]
     fn parse_module_strict_modes_yes() {
@@ -819,7 +804,6 @@ mod config_parsing_tests {
         assert!(err.to_string().contains("duplicate"));
     }
 
-    // --- Open noatime directive tests ---
 
     #[test]
     fn parse_module_open_noatime_yes() {
@@ -937,7 +921,6 @@ mod config_parsing_tests {
         assert!(!module.forward_lookup);
     }
 
-    // --- Config file not found ---
 
     #[test]
     fn parse_nonexistent_config() {
@@ -946,7 +929,6 @@ mod config_parsing_tests {
         assert!(err.to_string().contains("failed to"));
     }
 
-    // --- Global vs module directive ordering tests ---
 
     #[test]
     fn global_directives_before_modules_apply_as_defaults() {
@@ -1314,7 +1296,6 @@ mod config_parsing_tests {
         assert!(result.modules[0].use_chroot);
     }
 
-    // --- exclude from / include from tests ---
 
     #[test]
     fn exclude_from_and_include_from_default_to_none() {
@@ -1520,7 +1501,6 @@ mod config_parsing_tests {
         assert!(result.modules[1].exclude_from.is_none());
     }
 
-    // --- Syslog facility directive tests ---
 
     #[test]
     fn parse_syslog_facility_global_directive() {
@@ -1579,7 +1559,6 @@ mod config_parsing_tests {
         assert!(result.syslog_facility.is_none());
     }
 
-    // --- Syslog tag directive tests ---
 
     #[test]
     fn parse_syslog_tag_global_directive() {
@@ -1645,7 +1624,6 @@ mod config_parsing_tests {
         assert_eq!(tag, "backup-daemon");
     }
 
-    // --- address directive tests ---
 
     #[test]
     fn parse_address_ipv4() {
@@ -1702,7 +1680,6 @@ mod config_parsing_tests {
         assert!(msg.contains("duplicate 'address' directive"), "{msg}");
     }
 
-    // --- socket options directive tests ---
 
     #[test]
     fn parse_socket_options_single_option() {
@@ -1852,7 +1829,6 @@ mod config_parsing_tests {
         assert!(result.is_err());
     }
 
-    // --- filter / exclude / include tests ---
 
     #[test]
     fn parse_module_filter_single_rule() {
@@ -1980,7 +1956,6 @@ mod config_parsing_tests {
         assert!(result.modules[1].exclude.is_empty());
     }
 
-    // --- rsync port tests ---
 
     #[test]
     fn parse_global_rsync_port() {
@@ -2045,7 +2020,6 @@ mod config_parsing_tests {
         assert!(result.is_err());
     }
 
-    // --- module log file tests ---
 
     #[test]
     fn parse_module_log_file_absolute() {

--- a/crates/daemon/src/daemon/sections/log_format.rs
+++ b/crates/daemon/src/daemon/sections/log_format.rs
@@ -208,7 +208,6 @@ mod log_format_tests {
         }
     }
 
-    // --- TransferOperation tests ---
 
     #[test]
     fn transfer_operation_send_str() {
@@ -252,14 +251,12 @@ mod log_format_tests {
         assert!(debug.contains("Send"));
     }
 
-    // --- DEFAULT_LOG_FORMAT tests ---
 
     #[test]
     fn default_log_format_matches_upstream() {
         assert_eq!(DEFAULT_LOG_FORMAT, "%o %h [%a] %m (%u) %f %l");
     }
 
-    // --- expand_log_format: individual escape tests ---
 
     #[test]
     fn expand_operation() {
@@ -345,7 +342,6 @@ mod log_format_tests {
         assert_eq!(expand_log_format("%%", &ctx), "%");
     }
 
-    // --- expand_log_format: default format test ---
 
     #[test]
     fn expand_default_format() {
@@ -357,7 +353,6 @@ mod log_format_tests {
         );
     }
 
-    // --- expand_log_format: recv operation ---
 
     #[test]
     fn expand_recv_operation() {
@@ -367,7 +362,6 @@ mod log_format_tests {
         assert_eq!(result, "recv");
     }
 
-    // --- expand_log_format: edge cases ---
 
     #[test]
     fn expand_empty_format() {
@@ -449,7 +443,6 @@ mod log_format_tests {
         assert_eq!(result, ">f+++++++++ send docs/report.pdf 1048576 524288");
     }
 
-    // --- effective_log_format tests ---
 
     #[test]
     fn effective_log_format_uses_module_setting() {
@@ -471,7 +464,6 @@ mod log_format_tests {
         assert_eq!(effective_log_format(&module), DEFAULT_LOG_FORMAT);
     }
 
-    // --- format_daemon_timestamp tests ---
 
     #[test]
     fn timestamp_unix_epoch() {
@@ -505,7 +497,6 @@ mod log_format_tests {
         assert_eq!(ts, "2024/02/29 12:00:00");
     }
 
-    // --- push_u64 / push_u32 tests ---
 
     #[test]
     fn push_u64_zero() {
@@ -528,7 +519,6 @@ mod log_format_tests {
         assert_eq!(buf, "12345");
     }
 
-    // --- civil_from_days tests ---
 
     #[test]
     fn civil_from_days_epoch() {

--- a/crates/daemon/src/daemon/sections/module_access/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_access/tests.rs
@@ -452,7 +452,6 @@ mod module_access_tests {
         assert!(!line.ends_with("\n\n"), "line must not have double newline");
     }
 
-    // --- check_secrets_file_permissions tests (Unix only) ---
 
     #[cfg(unix)]
     #[test]
@@ -506,7 +505,6 @@ mod module_access_tests {
         assert!(check_secrets_file_permissions(&secrets).is_ok());
     }
 
-    // --- verify_secret_response strict_modes enforcement tests ---
 
     #[cfg(unix)]
     #[test]
@@ -575,7 +573,6 @@ mod module_access_tests {
         assert!(!result, "auth should fail due to wrong response");
     }
 
-    // ==================== secluded-args daemon tests ====================
 
     #[test]
     fn read_client_arguments_normal_protocol30() {
@@ -635,7 +632,6 @@ mod module_access_tests {
         );
     }
 
-    // --- temp_dir wiring tests ---
 
     #[test]
     fn apply_long_form_args_parses_temp_dir_separate_args() {
@@ -676,7 +672,6 @@ mod module_access_tests {
         assert!(config.temp_dir.is_none());
     }
 
-    // --- reference directory wiring tests ---
 
     #[test]
     fn apply_long_form_args_parses_compare_dest_equals_format() {
@@ -912,7 +907,6 @@ mod module_access_tests {
         assert!(list.matches_path(Path::new("archive.bz2")));
     }
 
-    // ==================== build_daemon_filter_rules tests ====================
 
     fn test_module_with_defaults() -> ModuleRuntime {
         ModuleRuntime::from(ModuleDefinition::default())
@@ -1152,7 +1146,6 @@ mod module_access_tests {
         assert_eq!(rules[1].pattern, "*.bak");
     }
 
-    // ==================== build_pattern_rule tests ====================
 
     #[test]
     fn build_pattern_rule_exclude() {
@@ -1192,7 +1185,6 @@ mod module_access_tests {
         assert_eq!(rule.pattern, "build/");
     }
 
-    // ==================== parse_daemon_filter_token tests ====================
 
     #[test]
     fn parse_daemon_filter_token_exclude() {
@@ -1226,7 +1218,6 @@ mod module_access_tests {
         assert!(parse_daemon_filter_token("+").is_none());
     }
 
-    // ==================== keyword prefix tests (upstream exclude.c:1134-1178) ====================
 
     #[test]
     fn parse_daemon_filter_token_exclude_keyword() {
@@ -1311,7 +1302,6 @@ mod module_access_tests {
         assert!(parse_daemon_filter_token("include ").is_none());
     }
 
-    // ==================== strip_keyword_prefix tests ====================
 
     #[test]
     fn strip_keyword_prefix_space_separator() {
@@ -1339,7 +1329,6 @@ mod module_access_tests {
         assert_eq!(strip_keyword_prefix("include *.tmp", "exclude"), None);
     }
 
-    // ==================== read_patterns_from_file tests ====================
 
     #[test]
     fn read_patterns_from_file_basic() {
@@ -1462,7 +1451,6 @@ mod module_access_tests {
         assert!(has_secluded_args_flag(&args));
     }
 
-    // --- backup-dir wiring tests ---
 
     #[test]
     fn apply_long_form_args_parses_backup_dir_two_arg() {

--- a/crates/daemon/src/daemon/sections/symlink_munge.rs
+++ b/crates/daemon/src/daemon/sections/symlink_munge.rs
@@ -13,7 +13,6 @@ pub(crate) use ::metadata::symlink_munge::{munge_symlink, unmunge_symlink};
 mod symlink_munge_tests {
     use super::*;
 
-    // --- munge_symlink tests ---
 
     #[test]
     fn munge_prepends_prefix_to_absolute_path() {
@@ -45,7 +44,6 @@ mod symlink_munge_tests {
         assert_eq!(result, "/rsyncd-munged/.");
     }
 
-    // --- unmunge_symlink tests ---
 
     #[test]
     fn unmunge_strips_prefix() {
@@ -83,7 +81,6 @@ mod symlink_munge_tests {
         assert_eq!(result, Some(String::new()));
     }
 
-    // --- roundtrip tests ---
 
     #[test]
     fn roundtrip_absolute_path() {
@@ -117,7 +114,6 @@ mod symlink_munge_tests {
         assert_eq!(restored, Some(original.to_owned()));
     }
 
-    // --- effective_munge_symlinks tests ---
 
     #[test]
     fn effective_munge_auto_chroot_on() {

--- a/crates/daemon/src/daemon/sections/tests.rs
+++ b/crates/daemon/src/daemon/sections/tests.rs
@@ -19,7 +19,6 @@ fn canonical_option_trims_prefix_and_normalises_case() {
     assert_eq!(canonical_option("   CHECKSUM=md5"), "checksum");
 }
 
-// ==================== refused_option glob pattern tests ====================
 
 #[test]
 fn refused_option_exact_match() {
@@ -281,7 +280,6 @@ fn is_vital_option_rejects_non_vitals() {
     assert!(!is_vital_option("archive"));
 }
 
-// ==================== ProgramName tests ====================
 
 #[test]
 fn program_name_rsyncd_as_str() {
@@ -328,7 +326,6 @@ fn program_name_debug() {
     assert!(debug.contains("OcRsyncd"));
 }
 
-// ==================== parse_args tests ====================
 
 #[test]
 fn parse_args_empty_defaults_to_program_name() {
@@ -416,7 +413,6 @@ fn parse_args_hyphenated_values_in_remainder() {
     assert!(parsed.remainder.iter().any(|a| a == "--no-detach"));
 }
 
-// ==================== clap_command tests ====================
 
 #[test]
 fn clap_command_creates_command() {
@@ -438,7 +434,6 @@ fn clap_command_has_version_arg() {
     assert!(args.iter().any(|a| a.get_id() == "version"));
 }
 
-// ==================== render_help tests ====================
 
 #[test]
 fn render_help_rsyncd_contains_program_name() {
@@ -452,7 +447,6 @@ fn render_help_oc_rsyncd_contains_program_name() {
     assert!(!help.is_empty());
 }
 
-// ==================== apply_daemon_param_overrides tests ====================
 
 #[test]
 fn apply_daemon_param_overrides_sets_read_only() {

--- a/crates/daemon/src/daemon/sections/variable_expansion.rs
+++ b/crates/daemon/src/daemon/sections/variable_expansion.rs
@@ -251,7 +251,6 @@ mod variable_expansion_tests {
         }
     }
 
-    // --- expand_config_vars: individual variable tests ---
 
     #[test]
     fn expand_diffhost() {
@@ -313,7 +312,6 @@ mod variable_expansion_tests {
         );
     }
 
-    // --- Unknown and edge cases ---
 
     #[test]
     fn expand_unknown_variable_preserved() {
@@ -405,7 +403,6 @@ mod variable_expansion_tests {
         );
     }
 
-    // --- resolve_variable tests ---
 
     #[test]
     fn resolve_diffhost() {
@@ -443,7 +440,6 @@ mod variable_expansion_tests {
         assert_eq!(resolve_variable("NOPE", &ctx), None);
     }
 
-    // --- expand_module_vars tests ---
 
     #[test]
     fn expand_module_vars_expands_path() {
@@ -593,7 +589,6 @@ mod variable_expansion_tests {
         );
     }
 
-    // --- PathExpansionContext / expand_daemon_path tests ---
 
     fn sample_path_ctx<'a>() -> PathExpansionContext<'a> {
         PathExpansionContext {
@@ -721,7 +716,6 @@ mod variable_expansion_tests {
         );
     }
 
-    // --- expand_exec_command tests ---
 
     #[test]
     fn exec_command_expands_module_name() {
@@ -741,7 +735,6 @@ mod variable_expansion_tests {
         );
     }
 
-    // --- expand_log_file_path tests ---
 
     #[test]
     fn log_file_path_expands_module_name() {

--- a/crates/daemon/src/tests/chunks/daemon_acl_push.rs
+++ b/crates/daemon/src/tests/chunks/daemon_acl_push.rs
@@ -40,7 +40,6 @@ fn daemon_acl_push_preserves_acls() {
     #[cfg(target_os = "macos")]
     let acl_option = AclOption::empty();
 
-    // --- Probe ACL support on this filesystem ---
     // Some CI runners use tmpfs or other filesystems that lack ACL support.
     // Write a scratch file, set an extended ACL, read it back, and skip if
     // the round-trip fails.
@@ -94,7 +93,6 @@ fn daemon_acl_push_preserves_acls() {
         return;
     }
 
-    // --- Source tree ---
     let source_dir = temp.path().join("source");
     fs::create_dir(&source_dir).expect("create source");
 
@@ -134,11 +132,9 @@ fn daemon_acl_push_preserves_acls() {
     setfacl(&[&file_a], &source_acl_entries, acl_option).expect("setfacl on alpha.txt");
     setfacl(&[&file_b], &source_acl_entries, acl_option).expect("setfacl on beta.txt");
 
-    // --- Destination (served by daemon, writable, initially empty) ---
     let dest_dir = temp.path().join("dest");
     fs::create_dir(&dest_dir).expect("create dest");
 
-    // --- Daemon config ---
     let config_file = temp.path().join("rsyncd.conf");
     let config_content = format!(
         "[pushmod]\n\
@@ -166,7 +162,6 @@ fn daemon_acl_push_preserves_acls() {
     let (probe_stream, daemon_handle) = start_daemon(daemon_config, port, held_listener);
     drop(probe_stream);
 
-    // --- Run client push with ACL preservation ---
     let mut source_arg = source_dir.clone().into_os_string();
     source_arg.push("/");
     let rsync_url = format!("rsync://127.0.0.1:{port}/pushmod/");
@@ -192,7 +187,6 @@ fn daemon_acl_push_preserves_acls() {
         }
     }
 
-    // --- Verify destination file contents ---
     let dest_alpha = dest_dir.join("alpha.txt");
     let dest_beta = dest_dir.join("beta.txt");
 
@@ -210,7 +204,6 @@ fn daemon_acl_push_preserves_acls() {
         "beta.txt content mismatch"
     );
 
-    // --- Verify ACLs are preserved at the destination ---
     let dest_alpha_acl =
         getfacl(&dest_alpha, acl_option).expect("getfacl on destination alpha.txt");
     let dest_beta_acl =

--- a/crates/daemon/src/tests/chunks/daemon_checksum_push.rs
+++ b/crates/daemon/src/tests/chunks/daemon_checksum_push.rs
@@ -27,7 +27,6 @@ fn daemon_checksum_push_detects_content_change_despite_matching_mtime() {
 
     let temp = tempdir().expect("tempdir");
 
-    // --- Source tree (client side) ---
     let source_dir = temp.path().join("source");
     fs::create_dir(&source_dir).expect("create source");
 
@@ -45,11 +44,9 @@ fn daemon_checksum_push_detects_content_change_despite_matching_mtime() {
     fs::write(source_dir.join("alpha.txt"), original_content).expect("write alpha.txt");
     fs::write(source_dir.join("beta.txt"), original_content).expect("write beta.txt");
 
-    // --- Destination (served by daemon, writable, initially empty) ---
     let dest_dir = temp.path().join("dest");
     fs::create_dir(&dest_dir).expect("create dest");
 
-    // --- Daemon config with max-sessions=4 (probe + initial push + checksum push + margin) ---
     let config_file = temp.path().join("rsyncd.conf");
     let config_content = format!(
         "[pushmod]\n\

--- a/crates/daemon/src/tests/chunks/daemon_compare_dest_push.rs
+++ b/crates/daemon/src/tests/chunks/daemon_compare_dest_push.rs
@@ -31,14 +31,12 @@ fn daemon_compare_dest_push_skips_unchanged_files() {
 
     let temp = tempdir().expect("tempdir");
 
-    // --- Source tree (client side) ---
     let source_dir = temp.path().join("source");
     fs::create_dir(&source_dir).expect("create source");
 
     fs::write(source_dir.join("unchanged.txt"), b"shared content\n").expect("write unchanged");
     fs::write(source_dir.join("changed.txt"), b"new version\n").expect("write changed");
 
-    // --- Reference directory (sibling of dest, has old versions) ---
     let ref_dir = temp.path().join("reference");
     fs::create_dir(&ref_dir).expect("create reference");
 
@@ -56,11 +54,9 @@ fn daemon_compare_dest_push_skips_unchanged_files() {
     filetime::set_file_mtime(source_dir.join("unchanged.txt"), old_time)
         .expect("backdate source unchanged");
 
-    // --- Destination (served by daemon, writable, initially empty) ---
     let dest_dir = temp.path().join("dest");
     fs::create_dir(&dest_dir).expect("create dest");
 
-    // --- Daemon config ---
     let config_file = temp.path().join("rsyncd.conf");
     let config_content = format!(
         "[pushmod]\n\
@@ -88,7 +84,6 @@ fn daemon_compare_dest_push_skips_unchanged_files() {
     let (probe_stream, daemon_handle) = start_daemon(daemon_config, port, held_listener);
     drop(probe_stream);
 
-    // --- Run client push with --compare-dest ---
     let mut source_arg = source_dir.clone().into_os_string();
     source_arg.push("/");
     let rsync_url = format!("rsync://127.0.0.1:{port}/pushmod/");
@@ -165,14 +160,12 @@ fn daemon_link_dest_push_creates_hardlinks() {
 
     let temp = tempdir().expect("tempdir");
 
-    // --- Source tree (client side) ---
     let source_dir = temp.path().join("source");
     fs::create_dir(&source_dir).expect("create source");
 
     fs::write(source_dir.join("unchanged.txt"), b"shared content\n").expect("write unchanged");
     fs::write(source_dir.join("new_file.txt"), b"brand new\n").expect("write new_file");
 
-    // --- Reference directory (sibling of dest) ---
     let ref_dir = temp.path().join("reference");
     fs::create_dir(&ref_dir).expect("create reference");
 
@@ -187,11 +180,9 @@ fn daemon_link_dest_push_creates_hardlinks() {
     filetime::set_file_mtime(source_dir.join("unchanged.txt"), old_time)
         .expect("backdate source unchanged");
 
-    // --- Destination (served by daemon, writable, initially empty) ---
     let dest_dir = temp.path().join("dest");
     fs::create_dir(&dest_dir).expect("create dest");
 
-    // --- Daemon config ---
     let config_file = temp.path().join("rsyncd.conf");
     let config_content = format!(
         "[pushmod]\n\
@@ -219,7 +210,6 @@ fn daemon_link_dest_push_creates_hardlinks() {
     let (probe_stream, daemon_handle) = start_daemon(daemon_config, port, held_listener);
     drop(probe_stream);
 
-    // --- Run client push with --link-dest ---
     let mut source_arg = source_dir.clone().into_os_string();
     source_arg.push("/");
     let rsync_url = format!("rsync://127.0.0.1:{port}/pushmod/");
@@ -318,14 +308,12 @@ fn daemon_copy_dest_push_copies_from_reference() {
 
     let temp = tempdir().expect("tempdir");
 
-    // --- Source tree (client side) ---
     let source_dir = temp.path().join("source");
     fs::create_dir(&source_dir).expect("create source");
 
     fs::write(source_dir.join("unchanged.txt"), b"shared content\n").expect("write unchanged");
     fs::write(source_dir.join("changed.txt"), b"new version\n").expect("write changed");
 
-    // --- Reference directory (sibling of dest) ---
     let ref_dir = temp.path().join("reference");
     fs::create_dir(&ref_dir).expect("create reference");
 
@@ -343,11 +331,9 @@ fn daemon_copy_dest_push_copies_from_reference() {
     filetime::set_file_mtime(source_dir.join("unchanged.txt"), old_time)
         .expect("backdate source unchanged");
 
-    // --- Destination (served by daemon, writable, initially empty) ---
     let dest_dir = temp.path().join("dest");
     fs::create_dir(&dest_dir).expect("create dest");
 
-    // --- Daemon config ---
     let config_file = temp.path().join("rsyncd.conf");
     let config_content = format!(
         "[pushmod]\n\
@@ -375,7 +361,6 @@ fn daemon_copy_dest_push_copies_from_reference() {
     let (probe_stream, daemon_handle) = start_daemon(daemon_config, port, held_listener);
     drop(probe_stream);
 
-    // --- Run client push with --copy-dest ---
     let mut source_arg = source_dir.clone().into_os_string();
     source_arg.push("/");
     let rsync_url = format!("rsync://127.0.0.1:{port}/pushmod/");

--- a/crates/daemon/src/tests/chunks/daemon_compress_push.rs
+++ b/crates/daemon/src/tests/chunks/daemon_compress_push.rs
@@ -21,7 +21,6 @@ fn daemon_compress_push_transfers_files_with_compression() {
 
     let temp = tempdir().expect("tempdir");
 
-    // --- Source tree (client side) ---
     let source_dir = temp.path().join("source");
     fs::create_dir(&source_dir).expect("create source");
 
@@ -57,11 +56,9 @@ fn daemon_compress_push_transfers_files_with_compression() {
         .collect();
     fs::write(sub_dir.join("gamma.txt"), &compressible_c).expect("write gamma.txt");
 
-    // --- Destination (served by daemon, writable, initially empty) ---
     let dest_dir = temp.path().join("dest");
     fs::create_dir(&dest_dir).expect("create dest");
 
-    // --- Daemon config with max-sessions=2 (probe + push) ---
     let config_file = temp.path().join("rsyncd.conf");
     let config_content = format!(
         "[pushmod]\n\
@@ -89,7 +86,6 @@ fn daemon_compress_push_transfers_files_with_compression() {
     let (probe_stream, daemon_handle) = start_daemon(daemon_config, port, held_listener);
     drop(probe_stream);
 
-    // --- Push with compression enabled ---
     let mut source_arg = source_dir.clone().into_os_string();
     source_arg.push("/");
     let rsync_url = format!("rsync://127.0.0.1:{port}/pushmod/");
@@ -115,7 +111,6 @@ fn daemon_compress_push_transfers_files_with_compression() {
         }
     }
 
-    // --- Verify all files transferred correctly ---
     assert_eq!(
         fs::read(dest_dir.join("alpha.txt")).expect("read dest alpha.txt"),
         compressible_a,

--- a/crates/daemon/src/tests/chunks/daemon_copy_links_push_resolves_symlinks.rs
+++ b/crates/daemon/src/tests/chunks/daemon_copy_links_push_resolves_symlinks.rs
@@ -31,7 +31,6 @@ fn daemon_copy_links_push_resolves_symlinks() {
 
     let temp = tempdir().expect("tempdir");
 
-    // --- Source tree (client side) ---
     let source_dir = temp.path().join("source");
     let source_subdir = source_dir.join("subdir");
     fs::create_dir_all(&source_subdir).expect("create source/subdir");
@@ -48,11 +47,9 @@ fn daemon_copy_links_push_resolves_symlinks() {
     std::os::unix::fs::symlink("nested.txt", source_subdir.join("link_nested.txt"))
         .expect("create symlink link_nested.txt");
 
-    // --- Destination (served by daemon, writable, initially empty) ---
     let dest_dir = temp.path().join("dest");
     fs::create_dir(&dest_dir).expect("create dest");
 
-    // --- Daemon config ---
     let config_file = temp.path().join("rsyncd.conf");
     let config_content = format!(
         "[pushmod]\n\
@@ -82,7 +79,6 @@ fn daemon_copy_links_push_resolves_symlinks() {
     // Drop the probe connection so the daemon worker finishes quickly
     drop(probe_stream);
 
-    // --- Run client push with --copy-links ---
     let mut source_arg = source_dir.clone().into_os_string();
     source_arg.push("/");
     let rsync_url = format!("rsync://127.0.0.1:{port}/pushmod/");

--- a/crates/daemon/src/tests/chunks/daemon_delete_push.rs
+++ b/crates/daemon/src/tests/chunks/daemon_delete_push.rs
@@ -22,7 +22,6 @@ fn daemon_delete_push_removes_extraneous_destination_files() {
 
     let temp = tempdir().expect("tempdir");
 
-    // --- Source tree (client side) ---
     let source_dir = temp.path().join("source");
     fs::create_dir(&source_dir).expect("create source");
 
@@ -30,11 +29,9 @@ fn daemon_delete_push_removes_extraneous_destination_files() {
     fs::write(source_dir.join("file_b.txt"), "contents of file B\n").expect("write file_b");
     fs::write(source_dir.join("file_c.txt"), "contents of file C\n").expect("write file_c");
 
-    // --- Destination (served by daemon, writable, initially empty) ---
     let dest_dir = temp.path().join("dest");
     fs::create_dir(&dest_dir).expect("create dest");
 
-    // --- Daemon config with max-sessions=4 (probe + 2 pushes + margin) ---
     let config_file = temp.path().join("rsyncd.conf");
     let config_content = format!(
         "[pushmod]\n\

--- a/crates/daemon/src/tests/chunks/daemon_delta_transfer.rs
+++ b/crates/daemon/src/tests/chunks/daemon_delta_transfer.rs
@@ -25,7 +25,6 @@ fn daemon_delta_transfer_updates_modified_files() {
 
     let temp = tempdir().expect("tempdir");
 
-    // --- Source tree (client side) ---
     let source_dir = temp.path().join("source");
     fs::create_dir(&source_dir).expect("create source");
 
@@ -41,11 +40,9 @@ fn daemon_delta_transfer_updates_modified_files() {
     fs::write(source_dir.join("data.txt"), &base_content).expect("write data.txt");
     fs::write(source_dir.join("other.txt"), &base_content).expect("write other.txt");
 
-    // --- Destination (served by daemon, writable, initially empty) ---
     let dest_dir = temp.path().join("dest");
     fs::create_dir(&dest_dir).expect("create dest");
 
-    // --- Daemon config with max-sessions=4 (probe + initial push + second push + margin) ---
     let config_file = temp.path().join("rsyncd.conf");
     let config_content = format!(
         "[pushmod]\n\

--- a/crates/daemon/src/tests/chunks/daemon_dry_run_push.rs
+++ b/crates/daemon/src/tests/chunks/daemon_dry_run_push.rs
@@ -29,7 +29,6 @@ fn daemon_dry_run_push() {
 
     let temp = tempdir().expect("tempdir");
 
-    // --- Source tree (client side) ---
     let source_dir = temp.path().join("source");
     let source_subdir = source_dir.join("subdir");
     fs::create_dir_all(&source_subdir).expect("create source/subdir");
@@ -38,11 +37,9 @@ fn daemon_dry_run_push() {
     fs::write(source_dir.join("file_b.txt"), b"beta content\n").expect("write file_b");
     fs::write(source_subdir.join("file_c.txt"), b"gamma content\n").expect("write file_c");
 
-    // --- Destination (served by daemon, writable, initially empty) ---
     let dest_dir = temp.path().join("dest");
     fs::create_dir(&dest_dir).expect("create dest");
 
-    // --- Daemon config ---
     let config_file = temp.path().join("rsyncd.conf");
     let config_content = format!(
         "[pushmod]\n\
@@ -72,7 +69,6 @@ fn daemon_dry_run_push() {
     // Drop the probe connection so the daemon worker finishes quickly
     drop(probe_stream);
 
-    // --- Run client push with --dry-run ---
     let mut source_arg = source_dir.clone().into_os_string();
     source_arg.push("/");
     let rsync_url = format!("rsync://127.0.0.1:{port}/pushmod/");

--- a/crates/daemon/src/tests/chunks/daemon_dry_run_push_across_protocol_versions.rs
+++ b/crates/daemon/src/tests/chunks/daemon_dry_run_push_across_protocol_versions.rs
@@ -20,7 +20,6 @@
 fn run_dry_run_push_at_protocol(protocol: ProtocolVersion) {
     let temp = tempdir().expect("tempdir");
 
-    // --- Source tree (client side) ---
     let source_dir = temp.path().join("source");
     let source_subdir = source_dir.join("subdir");
     fs::create_dir_all(&source_subdir).expect("create source/subdir");
@@ -29,11 +28,9 @@ fn run_dry_run_push_at_protocol(protocol: ProtocolVersion) {
     fs::write(source_dir.join("file_b.txt"), b"beta content\n").expect("write file_b");
     fs::write(source_subdir.join("file_c.txt"), b"gamma content\n").expect("write file_c");
 
-    // --- Destination (served by daemon, writable, initially empty) ---
     let dest_dir = temp.path().join("dest");
     fs::create_dir(&dest_dir).expect("create dest");
 
-    // --- Daemon config ---
     let config_file = temp.path().join("rsyncd.conf");
     let config_content = format!(
         "[drymod]\n\
@@ -61,7 +58,6 @@ fn run_dry_run_push_at_protocol(protocol: ProtocolVersion) {
     let (probe_stream, daemon_handle) = start_daemon(daemon_config, port, held_listener);
     drop(probe_stream);
 
-    // --- Run client push with --dry-run at specified protocol ---
     let mut source_arg = source_dir.clone().into_os_string();
     source_arg.push("/");
     let rsync_url = format!("rsync://127.0.0.1:{port}/drymod/");

--- a/crates/daemon/src/tests/chunks/daemon_files_from_push.rs
+++ b/crates/daemon/src/tests/chunks/daemon_files_from_push.rs
@@ -33,7 +33,6 @@ fn daemon_files_from_push_limits_transferred_files() {
 
     let temp = tempdir().expect("tempdir");
 
-    // --- Source tree (client side) ---
     let source_dir = temp.path().join("source");
     fs::create_dir(&source_dir).expect("create source");
 
@@ -41,15 +40,12 @@ fn daemon_files_from_push_limits_transferred_files() {
     fs::write(source_dir.join("b.txt"), b"beta content\n").expect("write b.txt");
     fs::write(source_dir.join("c.txt"), b"gamma content\n").expect("write c.txt");
 
-    // --- Files-from list (only a.txt and c.txt) ---
     let files_from_path = temp.path().join("filelist.txt");
     fs::write(&files_from_path, "a.txt\nc.txt\n").expect("write files-from list");
 
-    // --- Destination (served by daemon, writable, initially empty) ---
     let dest_dir = temp.path().join("dest");
     fs::create_dir(&dest_dir).expect("create dest");
 
-    // --- Daemon config ---
     let config_file = temp.path().join("rsyncd.conf");
     let config_content = format!(
         "[pushmod]\n\
@@ -79,7 +75,6 @@ fn daemon_files_from_push_limits_transferred_files() {
     // Drop the probe connection so the daemon worker finishes quickly
     drop(probe_stream);
 
-    // --- Run client push with --files-from ---
     let mut source_arg = source_dir.clone().into_os_string();
     source_arg.push("/");
     let rsync_url = format!("rsync://127.0.0.1:{port}/pushmod/");

--- a/crates/daemon/src/tests/chunks/daemon_files_from_stdin_pull.rs
+++ b/crates/daemon/src/tests/chunks/daemon_files_from_stdin_pull.rs
@@ -40,7 +40,6 @@ fn daemon_files_from_stdin_pull_limits_transferred_files() {
 
     let temp = tempdir().expect("tempdir");
 
-    // --- Source tree (served by daemon, read-only) ---
     let source_dir = temp.path().join("source");
     let source_subdir = source_dir.join("dir");
     fs::create_dir_all(&source_subdir).expect("create source/dir");
@@ -49,7 +48,6 @@ fn daemon_files_from_stdin_pull_limits_transferred_files() {
     fs::write(source_subdir.join("two.txt"), b"second content\n").expect("write two.txt");
     fs::write(source_subdir.join("three.txt"), b"third content\n").expect("write three.txt");
 
-    // --- Files-from list (simulates stdin: only one.txt and three.txt) ---
     // In a real `--files-from=-` invocation, the user pipes file names to stdin.
     // The client reads them and forwards over the protocol as NUL-separated data.
     // Using LocalFile exercises the identical daemon-side code path because both
@@ -58,11 +56,9 @@ fn daemon_files_from_stdin_pull_limits_transferred_files() {
     let files_from_path = temp.path().join("filelist.txt");
     fs::write(&files_from_path, "dir/one.txt\ndir/three.txt\n").expect("write files-from list");
 
-    // --- Destination (client side, initially empty) ---
     let dest_dir = temp.path().join("dest");
     fs::create_dir(&dest_dir).expect("create dest");
 
-    // --- Daemon config ---
     let config_file = temp.path().join("rsyncd.conf");
     let config_content = format!(
         "[pullmod]\n\
@@ -92,7 +88,6 @@ fn daemon_files_from_stdin_pull_limits_transferred_files() {
     // Drop the probe connection so the daemon worker finishes quickly
     drop(probe_stream);
 
-    // --- Run client pull with --files-from (simulating stdin via LocalFile) ---
     // Pull: source is daemon URL, destination is local path.
     // The client sends --files-from=- to the daemon and forwards the file list
     // data over the protocol stream - identical to the stdin code path.

--- a/crates/daemon/src/tests/chunks/daemon_files_from_stdin_push.rs
+++ b/crates/daemon/src/tests/chunks/daemon_files_from_stdin_push.rs
@@ -40,7 +40,6 @@ fn daemon_files_from_stdin_pull_limits_transferred_files() {
 
     let temp = tempdir().expect("tempdir");
 
-    // --- Source tree (served by daemon, read-only) ---
     let source_dir = temp.path().join("source");
     let source_subdir = source_dir.join("dir");
     fs::create_dir_all(&source_subdir).expect("create source/dir");
@@ -49,7 +48,6 @@ fn daemon_files_from_stdin_pull_limits_transferred_files() {
     fs::write(source_subdir.join("two.txt"), b"second content\n").expect("write two.txt");
     fs::write(source_subdir.join("three.txt"), b"third content\n").expect("write three.txt");
 
-    // --- Files-from list (simulates stdin: only one.txt and three.txt) ---
     // In a real `--files-from=-` invocation, the user pipes file names to stdin.
     // The client reads them and forwards over the protocol as NUL-separated data.
     // Using LocalFile exercises the identical daemon-side code path because both
@@ -58,11 +56,9 @@ fn daemon_files_from_stdin_pull_limits_transferred_files() {
     let files_from_path = temp.path().join("filelist.txt");
     fs::write(&files_from_path, "dir/one.txt\ndir/three.txt\n").expect("write files-from list");
 
-    // --- Destination (client side, initially empty) ---
     let dest_dir = temp.path().join("dest");
     fs::create_dir(&dest_dir).expect("create dest");
 
-    // --- Daemon config ---
     let config_file = temp.path().join("rsyncd.conf");
     let config_content = format!(
         "[pullmod]\n\
@@ -92,7 +88,6 @@ fn daemon_files_from_stdin_pull_limits_transferred_files() {
     // Drop the probe connection so the daemon worker finishes quickly
     drop(probe_stream);
 
-    // --- Run client pull with --files-from (simulating stdin via LocalFile) ---
     // Pull: source is daemon URL, destination is local path.
     // The client sends --files-from=- to the daemon and forwards the file list
     // data over the protocol stream - identical to the stdin code path.

--- a/crates/daemon/src/tests/chunks/daemon_fuzzy_level2_pulls_basis_from_sibling_directories.rs
+++ b/crates/daemon/src/tests/chunks/daemon_fuzzy_level2_pulls_basis_from_sibling_directories.rs
@@ -31,7 +31,6 @@ fn daemon_fuzzy_level2_pulls_basis_from_sibling_directories() {
 
     let temp = tempdir().expect("tempdir");
 
-    // --- Source tree (served by daemon) ---
     let source_dir = temp.path().join("source");
     let src_dir_a = source_dir.join("dir_a");
     let src_dir_b = source_dir.join("dir_b");
@@ -44,7 +43,6 @@ fn daemon_fuzzy_level2_pulls_basis_from_sibling_directories() {
     fs::write(src_dir_a.join("alpha.dat"), &content_alpha).expect("write source alpha");
     fs::write(src_dir_b.join("beta.dat"), &content_beta).expect("write source beta");
 
-    // --- Destination tree (pre-populated with files in swapped dirs) ---
     let dest_dir = temp.path().join("dest");
     let dest_dir_a = dest_dir.join("dir_a");
     let dest_dir_b = dest_dir.join("dir_b");
@@ -60,7 +58,6 @@ fn daemon_fuzzy_level2_pulls_basis_from_sibling_directories() {
     fuzzy2_backdate_file(&dest_dir_b.join("alpha.dat"));
     fuzzy2_backdate_file(&dest_dir_a.join("beta.dat"));
 
-    // --- Daemon config ---
     let config_file = temp.path().join("rsyncd.conf");
     let config_content = format!(
         "[testmod]\n\
@@ -92,7 +89,6 @@ fn daemon_fuzzy_level2_pulls_basis_from_sibling_directories() {
     // Drop the probe connection so the daemon worker finishes quickly
     drop(probe_stream);
 
-    // --- Run client pull with --fuzzy --fuzzy ---
     let rsync_url = format!("rsync://127.0.0.1:{port}/testmod/");
     let client_config = core::client::ClientConfig::builder()
         .transfer_args([

--- a/crates/daemon/src/tests/chunks/daemon_hardlinks_relative_receive.rs
+++ b/crates/daemon/src/tests/chunks/daemon_hardlinks_relative_receive.rs
@@ -41,7 +41,6 @@ fn daemon_hardlinks_relative_receive_preserves_links() {
 
     let temp = tempdir().expect("tempdir");
 
-    // --- Source tree (client side) with nested directories ---
     let source_dir = temp.path().join("source");
 
     // Create x/ directory with a hard-link pair
@@ -73,11 +72,9 @@ fn daemon_hardlinks_relative_receive_preserves_links() {
         "source alpha.txt and alpha_link.txt must share an inode"
     );
 
-    // --- Destination (served by daemon, writable, initially empty) ---
     let dest_dir = temp.path().join("dest");
     fs::create_dir(&dest_dir).expect("create dest");
 
-    // --- Daemon config ---
     let config_file = temp.path().join("rsyncd.conf");
     let config_content = format!(
         "[pushmod]\n\
@@ -105,7 +102,6 @@ fn daemon_hardlinks_relative_receive_preserves_links() {
     let (probe_stream, daemon_handle) = start_daemon(daemon_config, port, held_listener);
     drop(probe_stream);
 
-    // --- Run client push with -H -R ---
     let mut source_arg = source_dir.clone().into_os_string();
     source_arg.push("/");
     let rsync_url = format!("rsync://127.0.0.1:{port}/pushmod/");

--- a/crates/daemon/src/tests/chunks/daemon_inc_recurse_push.rs
+++ b/crates/daemon/src/tests/chunks/daemon_inc_recurse_push.rs
@@ -41,7 +41,6 @@ fn daemon_inc_recurse_push_nested_directories() {
 
     let temp = tempdir().expect("tempdir");
 
-    // --- Source tree (client side) with nested structure ---
     let source_dir = temp.path().join("source");
     let dir_a = source_dir.join("a");
     let dir_ab = dir_a.join("b");
@@ -57,11 +56,9 @@ fn daemon_inc_recurse_push_nested_directories() {
     fs::write(dir_abc.join("deep.txt"), b"deep nested content\n").expect("write deep.txt");
     fs::write(dir_d.join("side.txt"), b"side branch content\n").expect("write side.txt");
 
-    // --- Destination (served by daemon, writable, initially empty) ---
     let dest_dir = temp.path().join("dest");
     fs::create_dir(&dest_dir).expect("create dest");
 
-    // --- Daemon config ---
     let config_file = temp.path().join("rsyncd.conf");
     let config_content = format!(
         "[incmod]\n\
@@ -89,7 +86,6 @@ fn daemon_inc_recurse_push_nested_directories() {
     let (probe_stream, daemon_handle) = start_daemon(daemon_config, port, held_listener);
     drop(probe_stream);
 
-    // --- Run client push with recursive + protocol 32 ---
     let mut source_arg = source_dir.clone().into_os_string();
     source_arg.push("/");
     let rsync_url = format!("rsync://127.0.0.1:{port}/incmod/");
@@ -116,7 +112,6 @@ fn daemon_inc_recurse_push_nested_directories() {
         }
     }
 
-    // --- Verify all directories were created ---
     assert!(
         dest_dir.join("a").is_dir(),
         "directory 'a' must exist after push"
@@ -134,7 +129,6 @@ fn daemon_inc_recurse_push_nested_directories() {
         "directory 'd' must exist after push"
     );
 
-    // --- Verify all files arrived with correct content ---
     assert_eq!(
         fs::read(dest_dir.join("top.txt")).expect("read dest top.txt"),
         b"top level content\n",

--- a/crates/daemon/src/tests/chunks/daemon_inplace_push.rs
+++ b/crates/daemon/src/tests/chunks/daemon_inplace_push.rs
@@ -24,7 +24,6 @@ fn daemon_inplace_push_preserves_destination_inodes() {
 
     let temp = tempdir().expect("tempdir");
 
-    // --- Source tree (client side) ---
     let source_dir = temp.path().join("source");
     fs::create_dir(&source_dir).expect("create source");
 
@@ -34,7 +33,6 @@ fn daemon_inplace_push_preserves_destination_inodes() {
     fs::write(source_dir.join("alpha.txt"), source_content_a).expect("write alpha.txt");
     fs::write(source_dir.join("beta.txt"), source_content_b).expect("write beta.txt");
 
-    // --- Destination (served by daemon, writable, pre-populated with old content) ---
     let dest_dir = temp.path().join("dest");
     fs::create_dir(&dest_dir).expect("create dest");
 
@@ -59,7 +57,6 @@ fn daemon_inplace_push_preserves_destination_inodes() {
         .expect("metadata beta before")
         .ino();
 
-    // --- Daemon config with max-sessions=2 (probe + 1 push) ---
     let config_file = temp.path().join("rsyncd.conf");
     let config_content = format!(
         "[pushmod]\n\
@@ -87,7 +84,6 @@ fn daemon_inplace_push_preserves_destination_inodes() {
     let (probe_stream, daemon_handle) = start_daemon(daemon_config, port, held_listener);
     drop(probe_stream);
 
-    // --- Push with inplace(true) ---
     let mut source_arg = source_dir.clone().into_os_string();
     source_arg.push("/");
     let rsync_url = format!("rsync://127.0.0.1:{port}/pushmod/");
@@ -113,7 +109,6 @@ fn daemon_inplace_push_preserves_destination_inodes() {
         }
     }
 
-    // --- Verify destination content matches source ---
     assert_eq!(
         fs::read(dest_dir.join("alpha.txt")).expect("read dest alpha.txt"),
         source_content_a,
@@ -125,7 +120,6 @@ fn daemon_inplace_push_preserves_destination_inodes() {
         "beta.txt content mismatch after inplace push"
     );
 
-    // --- Verify inode numbers are preserved (proves inplace, not temp+rename) ---
     let inode_alpha_after = fs::metadata(dest_dir.join("alpha.txt"))
         .expect("metadata alpha after")
         .ino();

--- a/crates/daemon/src/tests/chunks/daemon_itemize_pull.rs
+++ b/crates/daemon/src/tests/chunks/daemon_itemize_pull.rs
@@ -32,7 +32,6 @@ fn daemon_itemize_pull_reports_events() {
 
     let temp = tempdir().expect("tempdir");
 
-    // --- Source tree (served by daemon, read-only) ---
     let source_dir = temp.path().join("source");
     let source_subdir = source_dir.join("subdir");
     fs::create_dir_all(&source_subdir).expect("create source/subdir");
@@ -41,7 +40,6 @@ fn daemon_itemize_pull_reports_events() {
     fs::write(source_dir.join("existing.txt"), b"updated content\n").expect("write existing");
     fs::write(source_subdir.join("nested.txt"), b"nested content\n").expect("write nested");
 
-    // --- Destination (client side) ---
     let dest_dir = temp.path().join("dest");
     fs::create_dir(&dest_dir).expect("create dest");
 
@@ -52,7 +50,6 @@ fn daemon_itemize_pull_reports_events() {
     filetime::set_file_mtime(dest_dir.join("existing.txt"), old_time)
         .expect("backdate dest existing");
 
-    // --- Daemon config ---
     let config_file = temp.path().join("rsyncd.conf");
     let config_content = format!(
         "[pullmod]\n\
@@ -80,7 +77,6 @@ fn daemon_itemize_pull_reports_events() {
     let (probe_stream, daemon_handle) = start_daemon(daemon_config, port, held_listener);
     drop(probe_stream);
 
-    // --- Run client pull with verbosity to trigger itemize output ---
     let rsync_url = format!("rsync://127.0.0.1:{port}/pullmod/");
 
     let client_config = core::client::ClientConfig::builder()
@@ -99,7 +95,6 @@ fn daemon_itemize_pull_reports_events() {
         }
     };
 
-    // --- Verify files arrived at destination ---
     assert_eq!(
         fs::read(dest_dir.join("new_file.txt")).expect("read new_file"),
         b"brand new content\n",
@@ -116,7 +111,6 @@ fn daemon_itemize_pull_reports_events() {
         "nested.txt content mismatch"
     );
 
-    // --- Verify events contain expected itemize entries ---
     let events = summary.events();
 
     // Collect DataCopied events by relative path

--- a/crates/daemon/src/tests/chunks/daemon_itemize_push.rs
+++ b/crates/daemon/src/tests/chunks/daemon_itemize_push.rs
@@ -32,7 +32,6 @@ fn daemon_itemize_push_reports_events() {
 
     let temp = tempdir().expect("tempdir");
 
-    // --- Source tree (client side) ---
     let source_dir = temp.path().join("source");
     let source_subdir = source_dir.join("subdir");
     fs::create_dir_all(&source_subdir).expect("create source/subdir");
@@ -41,7 +40,6 @@ fn daemon_itemize_push_reports_events() {
     fs::write(source_dir.join("existing.txt"), b"updated content\n").expect("write existing");
     fs::write(source_subdir.join("nested.txt"), b"nested content\n").expect("write nested");
 
-    // --- Destination (served by daemon, writable) ---
     let dest_dir = temp.path().join("dest");
     fs::create_dir(&dest_dir).expect("create dest");
 
@@ -52,7 +50,6 @@ fn daemon_itemize_push_reports_events() {
     filetime::set_file_mtime(dest_dir.join("existing.txt"), old_time)
         .expect("backdate dest existing");
 
-    // --- Daemon config ---
     let config_file = temp.path().join("rsyncd.conf");
     let config_content = format!(
         "[pushmod]\n\
@@ -80,7 +77,6 @@ fn daemon_itemize_push_reports_events() {
     let (probe_stream, daemon_handle) = start_daemon(daemon_config, port, held_listener);
     drop(probe_stream);
 
-    // --- Run client push with verbosity to trigger itemize output ---
     let mut source_arg = source_dir.clone().into_os_string();
     source_arg.push("/");
     let rsync_url = format!("rsync://127.0.0.1:{port}/pushmod/");
@@ -101,7 +97,6 @@ fn daemon_itemize_push_reports_events() {
         }
     };
 
-    // --- Verify files arrived at destination ---
     assert_eq!(
         fs::read(dest_dir.join("new_file.txt")).expect("read new_file"),
         b"brand new content\n",
@@ -118,7 +113,6 @@ fn daemon_itemize_push_reports_events() {
         "nested.txt content mismatch"
     );
 
-    // --- Verify events contain expected itemize entries ---
     let events = summary.events();
 
     // Collect DataCopied events by relative path

--- a/crates/daemon/src/tests/chunks/daemon_push_pull_lifecycle.rs
+++ b/crates/daemon/src/tests/chunks/daemon_push_pull_lifecycle.rs
@@ -24,7 +24,6 @@ fn daemon_push_then_pull_roundtrip_preserves_content() {
 
     let temp = tempdir().expect("tempdir");
 
-    // --- Source tree (client side for push) ---
     let source_dir = temp.path().join("source");
     let source_subdir = source_dir.join("subdir");
     fs::create_dir_all(&source_subdir).expect("create source/subdir");
@@ -35,15 +34,12 @@ fn daemon_push_then_pull_roundtrip_preserves_content() {
     fs::write(source_subdir.join("nested.txt"), b"nested file content\n")
         .expect("write nested file");
 
-    // --- Module directory (served by daemon, writable) ---
     let module_dir = temp.path().join("module");
     fs::create_dir(&module_dir).expect("create module dir");
 
-    // --- Pull destination (client side for pull) ---
     let pull_dest = temp.path().join("pulled");
     fs::create_dir(&pull_dest).expect("create pull dest");
 
-    // --- Daemon config: 5 sessions = probe + push + pull + margin ---
     let config_file = temp.path().join("rsyncd.conf");
     let config_content = format!(
         "[lifecycle]\n\
@@ -183,18 +179,15 @@ fn daemon_push_incremental_update_lifecycle() {
 
     let temp = tempdir().expect("tempdir");
 
-    // --- Source tree ---
     let source_dir = temp.path().join("source");
     fs::create_dir(&source_dir).expect("create source");
 
     fs::write(source_dir.join("config.txt"), b"version=1\n").expect("write config v1");
     fs::write(source_dir.join("stable.txt"), b"unchanged content\n").expect("write stable");
 
-    // --- Module directory ---
     let module_dir = temp.path().join("module");
     fs::create_dir(&module_dir).expect("create module dir");
 
-    // --- Daemon config ---
     let config_file = temp.path().join("rsyncd.conf");
     let config_content = format!(
         "[incmod]\n\
@@ -313,7 +306,6 @@ fn daemon_pull_lifecycle_copies_full_tree() {
 
     let temp = tempdir().expect("tempdir");
 
-    // --- Module directory (pre-populated, read-only) ---
     let module_dir = temp.path().join("module");
     let module_subdir = module_dir.join("docs");
     let module_deep = module_dir.join("docs/api");
@@ -327,11 +319,9 @@ fn daemon_pull_lifecycle_copies_full_tree() {
     // Include an empty file to verify zero-length files transfer correctly
     fs::write(module_dir.join("empty.txt"), b"").expect("write empty file");
 
-    // --- Pull destination ---
     let dest_dir = temp.path().join("dest");
     fs::create_dir(&dest_dir).expect("create dest dir");
 
-    // --- Daemon config (read-only module) ---
     let config_file = temp.path().join("rsyncd.conf");
     let config_content = format!(
         "[docs]\n\
@@ -359,7 +349,6 @@ fn daemon_pull_lifecycle_copies_full_tree() {
     let (probe_stream, daemon_handle) = start_daemon(daemon_config, port, held_listener);
     drop(probe_stream);
 
-    // --- Pull from daemon ---
     let rsync_url = format!("rsync://127.0.0.1:{port}/docs/");
 
     let client_config = core::client::ClientConfig::builder()
@@ -430,7 +419,6 @@ fn daemon_push_lifecycle_preserves_permissions() {
 
     let temp = tempdir().expect("tempdir");
 
-    // --- Source with specific permissions ---
     let source_dir = temp.path().join("source");
     fs::create_dir(&source_dir).expect("create source");
 
@@ -444,11 +432,9 @@ fn daemon_push_lifecycle_preserves_permissions() {
     fs::set_permissions(&config_path, fs::Permissions::from_mode(0o644))
         .expect("chmod settings 644");
 
-    // --- Module directory ---
     let module_dir = temp.path().join("module");
     fs::create_dir(&module_dir).expect("create module dir");
 
-    // --- Daemon config ---
     let config_file = temp.path().join("rsyncd.conf");
     let config_content = format!(
         "[permmod]\n\
@@ -476,7 +462,6 @@ fn daemon_push_lifecycle_preserves_permissions() {
     let (probe_stream, daemon_handle) = start_daemon(daemon_config, port, held_listener);
     drop(probe_stream);
 
-    // --- Push with permission preservation ---
     let mut source_arg = source_dir.clone().into_os_string();
     source_arg.push("/");
     let rsync_url = format!("rsync://127.0.0.1:{port}/permmod/");
@@ -539,16 +524,13 @@ fn daemon_push_lifecycle_rejects_read_only_module() {
 
     let temp = tempdir().expect("tempdir");
 
-    // --- Source ---
     let source_dir = temp.path().join("source");
     fs::create_dir(&source_dir).expect("create source");
     fs::write(source_dir.join("file.txt"), b"should not arrive\n").expect("write file");
 
-    // --- Module directory (read-only) ---
     let module_dir = temp.path().join("module");
     fs::create_dir(&module_dir).expect("create module dir");
 
-    // --- Daemon config with read only = true ---
     let config_file = temp.path().join("rsyncd.conf");
     let config_content = format!(
         "[readonly]\n\
@@ -576,7 +558,6 @@ fn daemon_push_lifecycle_rejects_read_only_module() {
     let (probe_stream, daemon_handle) = start_daemon(daemon_config, port, held_listener);
     drop(probe_stream);
 
-    // --- Attempt push to read-only module ---
     let mut source_arg = source_dir.clone().into_os_string();
     source_arg.push("/");
     let rsync_url = format!("rsync://127.0.0.1:{port}/readonly/");

--- a/crates/daemon/src/tests/chunks/daemon_relative_receive.rs
+++ b/crates/daemon/src/tests/chunks/daemon_relative_receive.rs
@@ -32,7 +32,6 @@ fn daemon_relative_receive_preserves_nested_paths() {
 
     let temp = tempdir().expect("tempdir");
 
-    // --- Source tree (client side) with nested directories ---
     let source_dir = temp.path().join("source");
     let nested_abc = source_dir.join("a").join("b").join("c");
     fs::create_dir_all(&nested_abc).expect("create source/a/b/c");
@@ -45,11 +44,9 @@ fn daemon_relative_receive_preserves_nested_paths() {
     .expect("write shallow.txt");
     fs::write(source_dir.join("a").join("top.txt"), b"top content\n").expect("write top.txt");
 
-    // --- Destination (served by daemon, writable, initially empty) ---
     let dest_dir = temp.path().join("dest");
     fs::create_dir(&dest_dir).expect("create dest");
 
-    // --- Daemon config ---
     let config_file = temp.path().join("rsyncd.conf");
     let config_content = format!(
         "[pushmod]\n\
@@ -79,7 +76,6 @@ fn daemon_relative_receive_preserves_nested_paths() {
     // Drop the probe connection so the daemon worker finishes quickly
     drop(probe_stream);
 
-    // --- Run client push with --relative ---
     // Use trailing slash on source so contents are transferred with relative paths
     let mut source_arg = source_dir.clone().into_os_string();
     source_arg.push("/");

--- a/crates/daemon/src/tests/chunks/daemon_safe_links_copy_links_push.rs
+++ b/crates/daemon/src/tests/chunks/daemon_safe_links_copy_links_push.rs
@@ -28,7 +28,6 @@ fn daemon_safe_links_push_excludes_unsafe_preserves_safe() {
 
     let temp = tempdir().expect("tempdir");
 
-    // --- Source tree (client side) ---
     let source_dir = temp.path().join("source");
     let source_subdir = source_dir.join("subdir");
     fs::create_dir_all(&source_subdir).expect("create source/subdir");
@@ -48,11 +47,9 @@ fn daemon_safe_links_push_excludes_unsafe_preserves_safe() {
     unix_fs::symlink("../../outside.txt", source_dir.join("unsafe_rel"))
         .expect("create unsafe_rel");
 
-    // --- Destination (served by daemon, writable, initially empty) ---
     let dest_dir = temp.path().join("dest");
     fs::create_dir(&dest_dir).expect("create dest");
 
-    // --- Daemon config ---
     let config_file = temp.path().join("rsyncd.conf");
     let config_content = format!(
         "[pushmod]\n\
@@ -80,7 +77,6 @@ fn daemon_safe_links_push_excludes_unsafe_preserves_safe() {
     let (probe_stream, daemon_handle) = start_daemon(daemon_config, port, held_listener);
     drop(probe_stream);
 
-    // --- Run client push with --links --safe-links ---
     let mut source_arg = source_dir.clone().into_os_string();
     source_arg.push("/");
     let rsync_url = format!("rsync://127.0.0.1:{port}/pushmod/");
@@ -101,7 +97,6 @@ fn daemon_safe_links_push_excludes_unsafe_preserves_safe() {
         }
     }
 
-    // --- Verify safe symlinks are preserved ---
     let safe_link_path = dest_dir.join("safe_link");
     assert!(
         safe_link_path.symlink_metadata().is_ok(),
@@ -124,7 +119,6 @@ fn daemon_safe_links_push_excludes_unsafe_preserves_safe() {
         "inner_link target should be preserved"
     );
 
-    // --- Verify unsafe symlinks are filtered out ---
     assert!(
         dest_dir.join("unsafe_abs").symlink_metadata().is_err(),
         "unsafe_abs must not exist (absolute path outside transfer tree)"
@@ -134,7 +128,6 @@ fn daemon_safe_links_push_excludes_unsafe_preserves_safe() {
         "unsafe_rel must not exist (relative path escapes transfer tree)"
     );
 
-    // --- Verify the regular file was transferred ---
     assert_eq!(
         fs::read_to_string(dest_dir.join("file.txt")).expect("read file.txt"),
         "safe-links content\n",
@@ -173,7 +166,6 @@ fn daemon_copy_links_push_replaces_symlinks_with_file_contents() {
 
     let temp = tempdir().expect("tempdir");
 
-    // --- Source tree (client side) ---
     let source_dir = temp.path().join("source");
     let source_subdir = source_dir.join("subdir");
     fs::create_dir_all(&source_subdir).expect("create source/subdir");
@@ -189,11 +181,9 @@ fn daemon_copy_links_push_replaces_symlinks_with_file_contents() {
     std::os::unix::fs::symlink("../real.txt", source_subdir.join("link_up"))
         .expect("create link_up");
 
-    // --- Destination (served by daemon, writable, initially empty) ---
     let dest_dir = temp.path().join("dest");
     fs::create_dir(&dest_dir).expect("create dest");
 
-    // --- Daemon config ---
     let config_file = temp.path().join("rsyncd.conf");
     let config_content = format!(
         "[pushmod]\n\
@@ -221,7 +211,6 @@ fn daemon_copy_links_push_replaces_symlinks_with_file_contents() {
     let (probe_stream, daemon_handle) = start_daemon(daemon_config, port, held_listener);
     drop(probe_stream);
 
-    // --- Run client push with --copy-links ---
     let mut source_arg = source_dir.clone().into_os_string();
     source_arg.push("/");
     let rsync_url = format!("rsync://127.0.0.1:{port}/pushmod/");
@@ -248,7 +237,6 @@ fn daemon_copy_links_push_replaces_symlinks_with_file_contents() {
         }
     }
 
-    // --- Verify resolved symlinks are regular files with correct content ---
     let dest_link_same = dest_dir.join("link_same_dir");
     assert!(dest_link_same.exists(), "link_same_dir must exist at destination");
     assert!(
@@ -284,7 +272,6 @@ fn daemon_copy_links_push_replaces_symlinks_with_file_contents() {
         "subdir/link_up content must match the resolved symlink target"
     );
 
-    // --- Verify original regular files are also present ---
     assert_eq!(
         fs::read_to_string(dest_dir.join("real.txt")).expect("read real.txt"),
         "real data\n",

--- a/crates/daemon/src/tests/chunks/daemon_safe_links_filters_unsafe_symlinks_on_pull.rs
+++ b/crates/daemon/src/tests/chunks/daemon_safe_links_filters_unsafe_symlinks_on_pull.rs
@@ -35,7 +35,6 @@ fn daemon_safe_links_filters_unsafe_symlinks_on_pull() {
 
     let temp = tempdir().expect("tempdir");
 
-    // --- Source tree (served by daemon) ---
     let source_dir = temp.path().join("source");
     let source_subdir = source_dir.join("subdir");
     fs::create_dir_all(&source_subdir).expect("create source/subdir");
@@ -57,11 +56,9 @@ fn daemon_safe_links_filters_unsafe_symlinks_on_pull() {
     unix_fs::symlink("../../outside.txt", source_dir.join("escape_link"))
         .expect("create escape_link");
 
-    // --- Destination (initially empty) ---
     let dest_dir = temp.path().join("dest");
     fs::create_dir(&dest_dir).expect("create dest");
 
-    // --- Daemon config ---
     let config_file = temp.path().join("rsyncd.conf");
     let config_content = format!(
         "[safemod]\n\
@@ -91,7 +88,6 @@ fn daemon_safe_links_filters_unsafe_symlinks_on_pull() {
     // Drop the probe connection so the daemon worker finishes quickly
     drop(probe_stream);
 
-    // --- Run client pull with --links --safe-links ---
     let rsync_url = format!("rsync://127.0.0.1:{port}/safemod/");
     let client_config = core::client::ClientConfig::builder()
         .transfer_args([
@@ -112,7 +108,6 @@ fn daemon_safe_links_filters_unsafe_symlinks_on_pull() {
         }
     }
 
-    // --- Verify safe symlinks are preserved ---
     let safe_link_path = dest_dir.join("safe_link");
     assert!(
         safe_link_path.symlink_metadata().is_ok(),
@@ -137,7 +132,6 @@ fn daemon_safe_links_filters_unsafe_symlinks_on_pull() {
         "inner_link target should be preserved"
     );
 
-    // --- Verify unsafe symlinks are filtered out ---
     assert!(
         !dest_dir.join("unsafe_link").exists()
             && dest_dir.join("unsafe_link").symlink_metadata().is_err(),
@@ -150,7 +144,6 @@ fn daemon_safe_links_filters_unsafe_symlinks_on_pull() {
         "escape_link must not exist (relative path escapes transfer tree)"
     );
 
-    // --- Verify the regular file was transferred ---
     let file_content = fs::read_to_string(dest_dir.join("file.txt")).expect("read file.txt");
     assert_eq!(file_content, "hello\n", "file.txt content mismatch");
 

--- a/crates/daemon/src/tests/chunks/daemon_safe_links_filters_unsafe_symlinks_on_push.rs
+++ b/crates/daemon/src/tests/chunks/daemon_safe_links_filters_unsafe_symlinks_on_push.rs
@@ -35,7 +35,6 @@ fn daemon_safe_links_filters_unsafe_symlinks_on_push() {
 
     let temp = tempdir().expect("tempdir");
 
-    // --- Source tree (client side) ---
     let source_dir = temp.path().join("source");
     let source_subdir = source_dir.join("subdir");
     fs::create_dir_all(&source_subdir).expect("create source/subdir");
@@ -57,11 +56,9 @@ fn daemon_safe_links_filters_unsafe_symlinks_on_push() {
     unix_fs::symlink("../../outside.txt", source_dir.join("escape_link"))
         .expect("create escape_link");
 
-    // --- Destination (served by daemon, writable, initially empty) ---
     let dest_dir = temp.path().join("dest");
     fs::create_dir(&dest_dir).expect("create dest");
 
-    // --- Daemon config ---
     let config_file = temp.path().join("rsyncd.conf");
     let config_content = format!(
         "[pushmod]\n\
@@ -91,7 +88,6 @@ fn daemon_safe_links_filters_unsafe_symlinks_on_push() {
     // Drop the probe connection so the daemon worker finishes quickly
     drop(probe_stream);
 
-    // --- Run client push with --links --safe-links ---
     let mut source_arg = source_dir.clone().into_os_string();
     source_arg.push("/");
     let rsync_url = format!("rsync://127.0.0.1:{port}/pushmod/");
@@ -112,7 +108,6 @@ fn daemon_safe_links_filters_unsafe_symlinks_on_push() {
         }
     }
 
-    // --- Verify safe symlinks are preserved ---
     let safe_link_path = dest_dir.join("safe_link");
     assert!(
         safe_link_path.symlink_metadata().is_ok(),
@@ -137,7 +132,6 @@ fn daemon_safe_links_filters_unsafe_symlinks_on_push() {
         "inner_link target should be preserved"
     );
 
-    // --- Verify unsafe symlinks are filtered out ---
     assert!(
         !dest_dir.join("unsafe_link").exists()
             && dest_dir.join("unsafe_link").symlink_metadata().is_err(),
@@ -150,7 +144,6 @@ fn daemon_safe_links_filters_unsafe_symlinks_on_push() {
         "escape_link must not exist (relative path escapes transfer tree)"
     );
 
-    // --- Verify the regular file was transferred ---
     let file_content = fs::read_to_string(dest_dir.join("file.txt")).expect("read file.txt");
     assert_eq!(file_content, "hello\n", "file.txt content mismatch");
 

--- a/crates/daemon/src/tests/chunks/daemon_safe_links_receive.rs
+++ b/crates/daemon/src/tests/chunks/daemon_safe_links_receive.rs
@@ -44,7 +44,6 @@ fn daemon_safe_links_receive() {
 
     let temp = tempdir().expect("tempdir");
 
-    // --- Source tree (client side) ---
     let source_dir = temp.path().join("source");
     let source_subdir = source_dir.join("subdir");
     fs::create_dir_all(&source_subdir).expect("create source/subdir");
@@ -74,11 +73,9 @@ fn daemon_safe_links_receive() {
     unix_fs::symlink("../../outside.txt", source_subdir.join("deep_esc"))
         .expect("create deep_esc");
 
-    // --- Destination (served by daemon, writable, munge symlinks off) ---
     let dest_dir = temp.path().join("dest");
     fs::create_dir(&dest_dir).expect("create dest");
 
-    // --- Daemon config with munge symlinks explicitly disabled ---
     let config_file = temp.path().join("rsyncd.conf");
     let config_content = format!(
         "[recvmod]\n\
@@ -109,7 +106,6 @@ fn daemon_safe_links_receive() {
     // Drop the probe connection so the daemon worker finishes quickly
     drop(probe_stream);
 
-    // --- Run client push with --links --safe-links ---
     let mut source_arg = source_dir.clone().into_os_string();
     source_arg.push("/");
     let rsync_url = format!("rsync://127.0.0.1:{port}/recvmod/");
@@ -130,7 +126,6 @@ fn daemon_safe_links_receive() {
         }
     }
 
-    // --- Verify safe symlinks are preserved ---
     let safe_link_path = dest_dir.join("safe_link");
     assert!(
         safe_link_path.symlink_metadata().is_ok(),
@@ -167,7 +162,6 @@ fn daemon_safe_links_receive() {
         "peer_link target should be preserved"
     );
 
-    // --- Verify unsafe symlinks are filtered out ---
     assert!(
         !dest_dir.join("unsafe_link").exists()
             && dest_dir.join("unsafe_link").symlink_metadata().is_err(),
@@ -186,7 +180,6 @@ fn daemon_safe_links_receive() {
         "subdir/deep_esc must not exist (relative path escapes from subdirectory)"
     );
 
-    // --- Verify the regular files were transferred ---
     let file_content = fs::read_to_string(dest_dir.join("file.txt")).expect("read file.txt");
     assert_eq!(file_content, "hello\n", "file.txt content mismatch");
 

--- a/crates/daemon/src/tests/chunks/daemon_unicode_emoji_filenames.rs
+++ b/crates/daemon/src/tests/chunks/daemon_unicode_emoji_filenames.rs
@@ -37,7 +37,6 @@ fn daemon_unicode_emoji_filenames_roundtrip() {
     let emoji_dir_name = "\u{1F4C2}_folder"; // U+1F4C2 OPEN FILE FOLDER (4-byte UTF-8)
     let nested_name = "nested.txt";
 
-    // --- Source tree (client side) ---
     let source_dir = temp.path().join("source");
     let source_emoji_subdir = source_dir.join(emoji_dir_name);
     fs::create_dir_all(&source_emoji_subdir).expect("create source emoji subdir");
@@ -48,11 +47,9 @@ fn daemon_unicode_emoji_filenames_roundtrip() {
     fs::write(source_emoji_subdir.join(nested_name), b"nested payload\n")
         .expect("write nested in emoji dir");
 
-    // --- Destination (served by daemon, writable, initially empty) ---
     let dest_dir = temp.path().join("dest");
     fs::create_dir(&dest_dir).expect("create dest");
 
-    // --- Daemon config ---
     let config_file = temp.path().join("rsyncd.conf");
     let config_content = format!(
         "[pushmod]\n\
@@ -80,7 +77,6 @@ fn daemon_unicode_emoji_filenames_roundtrip() {
     let (probe_stream, daemon_handle) = start_daemon(daemon_config, port, held_listener);
     drop(probe_stream);
 
-    // --- Run client push ---
     let mut source_arg = source_dir.clone().into_os_string();
     source_arg.push("/");
     let rsync_url = format!("rsync://127.0.0.1:{port}/pushmod/");
@@ -99,7 +95,6 @@ fn daemon_unicode_emoji_filenames_roundtrip() {
         }
     }
 
-    // --- Verify destination files ---
     // Use a helper that checks content by scanning directory entries, tolerating
     // possible Unicode normalization differences on macOS.
 

--- a/crates/daemon/src/tests/chunks/daemon_xattr_push.rs
+++ b/crates/daemon/src/tests/chunks/daemon_xattr_push.rs
@@ -38,7 +38,6 @@ fn daemon_xattr_push_preserves_extended_attributes() {
 
     let temp = tempdir().expect("tempdir");
 
-    // --- Probe xattr support on the temp filesystem ---
     let probe_file = temp.path().join(".xattr_probe");
     fs::write(&probe_file, b"probe").expect("write probe file");
     if xattr::set(&probe_file, "user.probe", b"1").is_err() {
@@ -48,7 +47,6 @@ fn daemon_xattr_push_preserves_extended_attributes() {
     }
     fs::remove_file(&probe_file).expect("remove probe file");
 
-    // --- Source tree (client side) ---
     let source_dir = temp.path().join("source");
     fs::create_dir(&source_dir).expect("create source");
 
@@ -71,11 +69,9 @@ fn daemon_xattr_push_preserves_extended_attributes() {
     xattr::set(&nested_path, "user.nested_attr", b"deep_value")
         .expect("set xattr on nested.txt");
 
-    // --- Destination (served by daemon, writable, initially empty) ---
     let dest_dir = temp.path().join("dest");
     fs::create_dir(&dest_dir).expect("create dest");
 
-    // --- Daemon config ---
     let config_file = temp.path().join("rsyncd.conf");
     let config_content = format!(
         "[pushmod]\n\
@@ -103,7 +99,6 @@ fn daemon_xattr_push_preserves_extended_attributes() {
     let (probe_stream, daemon_handle) = start_daemon(daemon_config, port, held_listener);
     drop(probe_stream);
 
-    // --- Run client push with -X (xattrs) ---
     let mut source_arg = source_dir.clone().into_os_string();
     source_arg.push("/");
     let rsync_url = format!("rsync://127.0.0.1:{port}/pushmod/");
@@ -129,7 +124,6 @@ fn daemon_xattr_push_preserves_extended_attributes() {
         }
     }
 
-    // --- Verify file contents arrived correctly ---
     let dest_alpha = dest_dir.join("alpha.txt");
     let dest_beta = dest_dir.join("beta.txt");
     let dest_nested = dest_dir.join("subdir").join("nested.txt");
@@ -154,7 +148,6 @@ fn daemon_xattr_push_preserves_extended_attributes() {
         b"nested content\n"
     );
 
-    // --- Verify xattrs were preserved ---
 
     // alpha.txt: user.test_key = "test_value"
     let alpha_xattr = xattr::get(&dest_alpha, "user.test_key")

--- a/crates/daemon/src/tests/chunks/run_daemon_panic_isolation_keeps_daemon_alive.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_panic_isolation_keeps_daemon_alive.rs
@@ -29,7 +29,6 @@ fn run_daemon_panic_isolation_keeps_daemon_alive() {
     drop(held_listener);
     let daemon_handle = thread::spawn(move || run_daemon(config));
 
-    // --- Connection 1: send garbage instead of the @RSYNCD: version line ---
     // The daemon reads the greeting it sent, parses the garbage as a module
     // name, replies with @ERROR: and @RSYNCD: EXIT, then keeps the accept
     // loop running because catch_unwind isolates per-connection errors.
@@ -64,7 +63,6 @@ fn run_daemon_panic_isolation_keeps_daemon_alive() {
         }
     } // bad stream dropped here — worker thread has already finished
 
-    // --- Connection 2: well-formed handshake ---
     // If catch_unwind isolation had failed the daemon would have exited and
     // connect_with_retries would time out.
     {

--- a/crates/engine/src/concurrent_delta/consumer.rs
+++ b/crates/engine/src/concurrent_delta/consumer.rs
@@ -535,8 +535,6 @@ mod tests {
         assert_eq!(results[4].ndx(), 0);
     }
 
-    // ==================== try_recv tests ====================
-
     #[test]
     fn try_recv_returns_none_when_no_results_ready() {
         let (tx, rx) = work_queue::bounded_with_capacity(8);

--- a/crates/engine/src/concurrent_delta/strategy.rs
+++ b/crates/engine/src/concurrent_delta/strategy.rs
@@ -311,8 +311,6 @@ mod tests {
         assert_eq!(strategy.kind(), DeltaWorkKind::Delta);
     }
 
-    // ==================== Sequence propagation tests ====================
-
     #[test]
     fn dispatch_propagates_sequence_whole_file() {
         let work = DeltaWork::whole_file(0, PathBuf::from("/dest/a"), 256).with_sequence(17);

--- a/crates/engine/src/concurrent_delta/types.rs
+++ b/crates/engine/src/concurrent_delta/types.rs
@@ -344,8 +344,6 @@ impl DeltaResult {
 mod tests {
     use super::*;
 
-    // ==================== DeltaWork tests ====================
-
     #[test]
     fn whole_file_work_has_no_basis() {
         let work = DeltaWork::whole_file(0, PathBuf::from("/dest/file.txt"), 1024);
@@ -429,8 +427,6 @@ mod tests {
         assert_ne!(DeltaWorkKind::WholeFile, DeltaWorkKind::Delta);
     }
 
-    // ==================== DeltaResult tests ====================
-
     #[test]
     fn success_result() {
         let result = DeltaResult::success(42, 1000, 300, 700);
@@ -494,8 +490,6 @@ mod tests {
         assert_eq!(DeltaResultStatus::default(), DeltaResultStatus::Success);
     }
 
-    // ==================== DeltaWork sequence tests ====================
-
     #[test]
     fn work_default_sequence_is_zero() {
         let work = DeltaWork::whole_file(0, PathBuf::from("/dest"), 100);
@@ -542,8 +536,6 @@ mod tests {
         );
         assert_eq!(work.sequence(), 0);
     }
-
-    // ==================== DeltaResult sequence tests ====================
 
     #[test]
     fn result_default_sequence_is_zero() {

--- a/crates/engine/src/concurrent_delta/work_queue.rs
+++ b/crates/engine/src/concurrent_delta/work_queue.rs
@@ -703,8 +703,6 @@ mod tests {
         assert_eq!(ordered, expected);
     }
 
-    // ==================== drain_parallel_into tests ====================
-
     #[test]
     fn drain_parallel_into_streams_all_items() {
         let (tx, rx) = bounded_with_capacity(8);
@@ -817,8 +815,6 @@ mod tests {
         let results: Vec<_> = result_rx.iter().collect();
         assert_eq!(results, vec![(42, 128)]);
     }
-
-    // ==================== drain_parallel tests ====================
 
     #[test]
     fn drain_parallel_collects_all_items() {

--- a/crates/engine/src/local_copy/buffer_pool/tests.rs
+++ b/crates/engine/src/local_copy/buffer_pool/tests.rs
@@ -1003,8 +1003,6 @@ fn memory_cap_backpressure_multiple_waiters() {
     assert_eq!(pool.memory_usage(), 0);
 }
 
-// --- Throughput tracking integration tests ---
-
 #[test]
 fn no_throughput_tracker_by_default() {
     let pool = BufferPool::new(4);
@@ -1188,8 +1186,6 @@ fn sequential_returns_respect_soft_capacity() {
     assert_eq!(pool.available(), 2);
 }
 
-// --- Thread-local cache tests ---
-
 #[test]
 fn tls_absorbs_first_return() {
     // First buffer returned on a thread goes to TLS, not central pool.
@@ -1293,8 +1289,6 @@ fn tls_per_thread_isolation() {
         h.join().expect("thread panicked");
     }
 }
-
-// --- Adaptive resizing tests ---
 
 #[test]
 fn adaptive_resizing_disabled_by_default() {

--- a/crates/engine/src/local_copy/dir_merge/load.rs
+++ b/crates/engine/src/local_copy/dir_merge/load.rs
@@ -294,7 +294,6 @@ pub(crate) fn load_dir_merge_rules_recursive(
 mod tests {
     use super::*;
 
-    // ==================== resolve_dir_merge_path tests ====================
     // These tests use Unix-style absolute paths (starting with /)
 
     #[cfg(unix)]
@@ -342,8 +341,6 @@ mod tests {
         let result = resolve_dir_merge_path(base, pattern);
         assert_eq!(result, PathBuf::from("/base/."));
     }
-
-    // ==================== DirMergeEntries tests ====================
 
     #[test]
     fn dir_merge_entries_default_is_empty() {
@@ -415,8 +412,6 @@ mod tests {
 
         assert_eq!(entries.rules.len(), 1);
     }
-
-    // ==================== clear_inherited tests ====================
 
     #[test]
     fn dir_merge_entries_default_clear_inherited_is_false() {

--- a/crates/engine/src/local_copy/dir_merge/parse/merge.rs
+++ b/crates/engine/src/local_copy/dir_merge/parse/merge.rs
@@ -120,8 +120,6 @@ pub(super) fn parse_short_merge_directive_line(
 mod tests {
     use super::*;
 
-    // ==================== parse_merge_directive tests ====================
-
     #[test]
     fn parse_merge_directive_returns_none_for_non_merge() {
         let result = parse_merge_directive("include *.txt");
@@ -187,8 +185,6 @@ mod tests {
         let result = parse_merge_directive("merge ");
         assert!(result.is_err());
     }
-
-    // ==================== parse_short_merge_directive_line tests ====================
 
     #[test]
     fn parse_short_merge_returns_none_for_empty() {

--- a/crates/engine/src/local_copy/executor/directory/planner.rs
+++ b/crates/engine/src/local_copy/executor/directory/planner.rs
@@ -614,8 +614,6 @@ fn plan_directory_entries_with_prefetch<'a>(
 mod tests {
     use super::*;
 
-    // ==================== EntryAction tests ====================
-
     #[test]
     fn entry_action_clone() {
         let action = EntryAction::CopyFile;
@@ -673,8 +671,6 @@ mod tests {
         let action = EntryAction::CopyDeviceAsFile;
         assert!(matches!(action, EntryAction::CopyDeviceAsFile));
     }
-
-    // ==================== DirectoryPlan field tests ====================
 
     #[test]
     fn directory_plan_default_values() {

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/write_strategy.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/write_strategy.rs
@@ -253,8 +253,6 @@ mod tests {
         )
     }
 
-    // --- Append strategy ---
-
     #[test]
     fn append_offset_selects_append_strategy() {
         assert_eq!(
@@ -278,8 +276,6 @@ mod tests {
             WriteStrategy::Append
         );
     }
-
-    // --- Inplace strategy ---
 
     #[test]
     fn inplace_enabled_selects_inplace_strategy() {
@@ -305,8 +301,6 @@ mod tests {
         );
     }
 
-    // --- Direct strategy ---
-
     #[test]
     fn no_existing_dest_selects_direct_strategy() {
         assert_eq!(
@@ -314,8 +308,6 @@ mod tests {
             WriteStrategy::Direct
         );
     }
-
-    // --- TempFileRename strategy ---
 
     #[test]
     fn partial_forces_temp_file_rename() {
@@ -365,8 +357,6 @@ mod tests {
         );
     }
 
-    // --- Priority ordering ---
-
     #[test]
     fn append_has_highest_priority() {
         assert_eq!(
@@ -406,8 +396,6 @@ mod tests {
             WriteStrategy::Direct
         );
     }
-
-    // --- AnonymousTempFile strategy ---
 
     #[test]
     fn partial_prevents_anonymous_strategy() {

--- a/crates/engine/src/local_copy/executor/file/guard.rs
+++ b/crates/engine/src/local_copy/executor/file/guard.rs
@@ -662,8 +662,6 @@ mod tests {
         guard.discard();
     }
 
-    // --- Linux-specific anonymous guard tests ---
-
     #[cfg(target_os = "linux")]
     mod anonymous {
         use super::*;

--- a/crates/engine/src/local_copy/executor/file/sparse/tests.rs
+++ b/crates/engine/src/local_copy/executor/file/sparse/tests.rs
@@ -272,8 +272,6 @@ fn finish_reports_final_offset_after_trailing_zeros() {
     assert_eq!(metadata.len(), final_offset);
 }
 
-// ==================== punch_hole tests ====================
-
 #[test]
 fn punch_hole_zero_length_is_noop() {
     let mut file = NamedTempFile::new().expect("temp file");
@@ -336,8 +334,6 @@ fn punch_hole_advances_file_position() {
     assert_eq!(pos, 1500);
 }
 
-// ==================== write_zeros_fallback tests ====================
-
 #[test]
 fn write_zeros_fallback_writes_exact_length() {
     let mut file = NamedTempFile::new().expect("temp file");
@@ -367,8 +363,6 @@ fn write_zeros_fallback_handles_large_length() {
     let metadata = file.as_file_mut().metadata().expect("metadata");
     assert_eq!(metadata.len(), len);
 }
-
-// ==================== SparseWriteState hole punching tests ====================
 
 #[test]
 fn sparse_state_flush_with_punch_hole() {
@@ -432,8 +426,6 @@ fn sparse_state_pending_zeros_tracks_accumulation() {
     state.accumulate(200);
     assert_eq!(state.pending_zeros(), 300);
 }
-
-// ==================== Boundary Condition Tests ====================
 
 #[test]
 fn sparse_writer_exactly_sparse_write_size() {
@@ -537,8 +529,6 @@ fn sparse_writer_just_over_sparse_write_size() {
     assert_eq!(buffer[super::SPARSE_WRITE_SIZE], b'Y');
 }
 
-// ==================== Data Pattern Tests ====================
-
 #[test]
 fn sparse_writer_leading_zeros_only() {
     let mut file = NamedTempFile::new().expect("temp file");
@@ -639,8 +629,6 @@ fn sparse_writer_single_byte_surrounded_by_zeros() {
     assert!(buffer[2049..].iter().all(|&b| b == 0));
 }
 
-// ==================== State Machine Tests ====================
-
 #[test]
 fn sparse_state_replace_vs_accumulate() {
     let mut state = SparseWriteState::default();
@@ -721,8 +709,6 @@ fn sparse_state_multiple_flush_cycles() {
     assert!(buffer[6000..].iter().all(|&b| b == 0xCC));
 }
 
-// ==================== Zero-Run Detection Edge Cases ====================
-
 #[test]
 fn leading_zero_run_single_byte() {
     assert_eq!(leading_zero_run(&[0]), 1);
@@ -782,8 +768,6 @@ fn zero_run_at_16_byte_boundary() {
     assert_eq!(trailing_zero_run(&data_17_trail), 16);
 }
 
-// ==================== Empty Input Tests ====================
-
 #[test]
 fn write_sparse_chunk_empty_chunk_returns_zero() {
     let mut file = NamedTempFile::new().expect("temp file");
@@ -807,8 +791,6 @@ fn leading_zero_run_empty_slice() {
 fn trailing_zero_run_empty_slice() {
     assert_eq!(trailing_zero_run(&[]), 0);
 }
-
-// ==================== Flush Edge Cases ====================
 
 #[test]
 fn sparse_state_flush_with_zero_pending_is_noop() {
@@ -848,8 +830,6 @@ fn sparse_state_flush_with_punch_hole_zero_pending_is_noop() {
     assert_eq!(pos, 4);
 }
 
-// ==================== Large Value Tests ====================
-
 #[test]
 fn sparse_state_accumulate_saturation() {
     let mut state = SparseWriteState::default();
@@ -871,8 +851,6 @@ fn sparse_state_default_values() {
     let state = SparseWriteState::default();
     assert_eq!(state.pending_zeros(), 0);
 }
-
-// ==================== Multi-Segment Chunk Tests ====================
 
 #[test]
 fn write_sparse_chunk_multiple_segments_in_one_chunk() {
@@ -940,8 +918,6 @@ fn write_sparse_chunk_non_aligned_size() {
     assert_eq!(buffer[size - 1], b'L');
 }
 
-// ==================== Dense Data Tests ====================
-
 #[test]
 fn write_sparse_chunk_all_nonzero_data() {
     let mut file = NamedTempFile::new().expect("temp file");
@@ -1000,8 +976,6 @@ fn write_sparse_chunk_alternating_pattern() {
 
     assert_eq!(buffer, chunk);
 }
-
-// ==================== Boundary Alignment Tests ====================
 
 #[test]
 fn leading_zero_run_at_multiple_of_16() {
@@ -1062,8 +1036,6 @@ fn zero_run_with_interior_nonzero() {
     assert_eq!(trailing_zero_run(&data), 23);
 }
 
-// ==================== Write Zeros Fallback Tests ====================
-
 #[test]
 fn write_zeros_fallback_zero_length() {
     let mut file = NamedTempFile::new().expect("temp file");
@@ -1106,8 +1078,6 @@ fn write_zeros_fallback_exact_buffer_size() {
     let metadata = file.as_file_mut().metadata().expect("metadata");
     assert_eq!(metadata.len(), exact_size);
 }
-
-// ==================== Punch Hole Tests ====================
 
 #[test]
 fn punch_hole_at_file_end() {
@@ -1187,8 +1157,6 @@ fn punch_hole_small_length() {
     assert!(buffer[513..].iter().all(|&b| b == 0xCC));
 }
 
-// ==================== Finish Method Tests ====================
-
 #[test]
 fn sparse_state_finish_returns_correct_position() {
     let mut file = NamedTempFile::new().expect("temp file");
@@ -1242,8 +1210,6 @@ fn sparse_state_finish_with_punch_hole_returns_position() {
 
     assert_eq!(final_pos, 1500);
 }
-
-// ==================== Chunked Write Integration ====================
 
 #[test]
 fn write_sparse_chunk_sequential_calls() {
@@ -1313,8 +1279,6 @@ fn write_sparse_chunk_all_zeros_followed_by_data() {
     assert_eq!(&buffer[100..103], b"XYZ");
 }
 
-// ==================== SIMD Fast Path Verification ====================
-
 #[test]
 fn leading_zero_run_exercises_simd_path() {
     // 48 bytes = 3 full 16-byte chunks (exercises SIMD fast path)
@@ -1359,8 +1323,6 @@ fn trailing_zero_run_exercises_simd_path() {
     assert_eq!(trailing_zero_run(&data), 0);
 }
 
-// ==================== SPARSE_WRITE_SIZE Boundary Tests ====================
-
 #[test]
 fn write_sparse_chunk_multiple_of_sparse_write_size() {
     let mut file = NamedTempFile::new().expect("temp file");
@@ -1392,8 +1354,6 @@ fn write_sparse_chunk_multiple_of_sparse_write_size() {
     assert!(buffer[1..size - 1].iter().all(|&b| b == 0));
     assert_eq!(buffer[size - 1], b'Z');
 }
-
-// ==================== Data at Segment Boundaries ====================
 
 #[test]
 fn write_sparse_chunk_data_at_segment_boundary() {
@@ -1436,8 +1396,6 @@ fn write_sparse_chunk_data_at_segment_boundary() {
     );
 }
 
-// ==================== Scalar Remainder Tests ====================
-
 #[test]
 fn leading_zero_run_scalar_remainder() {
     // Test cases where remainder after SIMD chunks needs scalar processing
@@ -1466,8 +1424,6 @@ fn trailing_zero_run_scalar_remainder() {
     data[1] = 1;
     assert_eq!(trailing_zero_run(&data), 16);
 }
-
-// ==================== Mixed Pattern Tests ====================
 
 #[test]
 fn write_sparse_chunk_scattered_nonzero_bytes() {
@@ -1536,8 +1492,6 @@ fn write_sparse_chunk_contiguous_data_block() {
     assert!(buffer[400..600].iter().all(|&b| b == 0xBB));
     assert!(buffer[600..].iter().all(|&b| b == 0));
 }
-
-// ==================== Edge Case: data_end <= data_start ====================
 
 #[test]
 fn write_sparse_chunk_segment_all_leading_zeros() {
@@ -1638,8 +1592,6 @@ fn write_sparse_chunk_first_byte_only() {
     assert!(buffer[1..].iter().all(|&b| b == 0));
 }
 
-// ==================== Single Byte Edge Cases ====================
-
 #[test]
 fn write_sparse_chunk_single_zero_byte() {
     let mut file = NamedTempFile::new().expect("temp file");
@@ -1682,8 +1634,6 @@ fn write_sparse_chunk_single_nonzero_byte() {
     assert_eq!(pos, 1);
 }
 
-// ==================== Verify Replace vs Accumulate Behavior ====================
-
 #[test]
 fn write_sparse_chunk_trailing_zeros_become_next_leading() {
     let mut file = NamedTempFile::new().expect("temp file");
@@ -1721,8 +1671,6 @@ fn write_sparse_chunk_trailing_zeros_become_next_leading() {
     assert!(buffer[1..7].iter().all(|&b| b == 0));
     assert_eq!(buffer[7], b'B');
 }
-
-// ==================== Zero-Run Scalar vs SIMD Consistency ====================
 
 #[test]
 fn leading_zero_run_consistency_across_sizes() {
@@ -1812,8 +1760,6 @@ fn trailing_zero_run_consistency_across_sizes() {
     }
 }
 
-// ==================== Large Pending Zero Flush ====================
-
 #[test]
 fn sparse_state_flush_large_pending() {
     let mut file = NamedTempFile::new().expect("temp file");
@@ -1830,8 +1776,6 @@ fn sparse_state_flush_large_pending() {
 
     assert_eq!(final_pos, large_pending);
 }
-
-// ==================== File Truncation Tests ====================
 
 #[test]
 fn sparse_write_with_truncation_preserves_holes() {
@@ -1860,8 +1804,6 @@ fn sparse_write_with_truncation_preserves_holes() {
     assert!(buffer[1..8].iter().all(|&b| b == 0));
     assert_eq!(buffer[8], b'T');
 }
-
-// ==================== Multiple Write Cycles ====================
 
 #[test]
 fn sparse_writer_multiple_write_finish_cycles() {
@@ -1902,8 +1844,6 @@ fn sparse_writer_multiple_write_finish_cycles() {
     assert_eq!(buffer[6], b'4');
 }
 
-// ==================== Verify Const Methods ====================
-
 #[test]
 fn sparse_state_const_methods() {
     let mut state = SparseWriteState::default();
@@ -1919,8 +1859,6 @@ fn sparse_state_const_methods() {
     // pending_zeros is const
     let _pending: u64 = state.pending_zeros();
 }
-
-// ==================== SparseRegion Tests ====================
 
 #[test]
 fn sparse_region_accessors() {
@@ -1973,8 +1911,6 @@ fn sparse_region_equality() {
     assert_eq!(hole1, hole2);
     assert_ne!(data1, hole1);
 }
-
-// ==================== SparseDetector Tests ====================
 
 #[test]
 fn sparse_detector_all_zeros() {
@@ -2170,8 +2106,6 @@ fn sparse_detector_default_threshold() {
     assert!(regions[0].is_hole());
 }
 
-// ==================== SparseWriter Tests ====================
-
 #[test]
 fn sparse_writer_basic_write() {
     let file = NamedTempFile::new().expect("temp file");
@@ -2242,8 +2176,6 @@ fn sparse_writer_file_accessors() {
     let _file_ref: &fs::File = writer.file();
     let _file_mut: &mut fs::File = writer.file_mut();
 }
-
-// ==================== SparseReader Tests ====================
 
 #[test]
 fn sparse_reader_empty_file() {
@@ -2464,8 +2396,6 @@ fn sparse_reader_coalesce_multiple_adjacent() {
     );
 }
 
-// ==================== Very Small SPARSE_WRITE_SIZE Multiples ====================
-
 #[test]
 fn write_sparse_chunk_very_small_chunks() {
     let mut file = NamedTempFile::new().expect("temp file");
@@ -2485,8 +2415,6 @@ fn write_sparse_chunk_very_small_chunks() {
 
     assert_eq!(final_pos, 200);
 }
-
-// ==================== Punch Hole Edge Cases ====================
 
 #[test]
 fn punch_hole_consecutive_holes() {

--- a/crates/engine/src/local_copy/filter_program/options.rs
+++ b/crates/engine/src/local_copy/filter_program/options.rs
@@ -286,8 +286,6 @@ enum SideState {
 mod tests {
     use super::*;
 
-    // ==================== DirMergeEnforcedKind tests ====================
-
     #[test]
     fn dir_merge_enforced_kind_clone() {
         let kind = DirMergeEnforcedKind::Include;
@@ -309,8 +307,6 @@ mod tests {
         assert_eq!(DirMergeEnforcedKind::Exclude, DirMergeEnforcedKind::Exclude);
         assert_ne!(DirMergeEnforcedKind::Include, DirMergeEnforcedKind::Exclude);
     }
-
-    // ==================== DirMergeParser tests ====================
 
     #[test]
     fn dir_merge_parser_lines_enforce_kind_none() {
@@ -375,8 +371,6 @@ mod tests {
         assert!(whitespace.is_whitespace());
     }
 
-    // ==================== DirMergeOptions construction tests ====================
-
     #[test]
     fn dir_merge_options_new_default_values() {
         let opts = DirMergeOptions::new();
@@ -398,8 +392,6 @@ mod tests {
         let default_opts = DirMergeOptions::default();
         assert_eq!(new_opts, default_opts);
     }
-
-    // ==================== DirMergeOptions builder tests ====================
 
     #[test]
     fn dir_merge_options_inherit_false() {
@@ -499,8 +491,6 @@ mod tests {
         assert!(opts.list_clear_allowed());
     }
 
-    // ==================== sender/receiver modifier tests ====================
-
     #[test]
     fn dir_merge_options_sender_modifier() {
         let opts = DirMergeOptions::new().sender_modifier();
@@ -561,8 +551,6 @@ mod tests {
         assert!(!opts.applies_to_receiver());
     }
 
-    // ==================== anchor_root and perishable tests ====================
-
     #[test]
     fn dir_merge_options_anchor_root_true() {
         let opts = DirMergeOptions::new().anchor_root(true);
@@ -581,8 +569,6 @@ mod tests {
         assert!(opts.perishable());
     }
 
-    // ==================== clone and equality tests ====================
-
     #[test]
     fn dir_merge_options_clone() {
         let opts = DirMergeOptions::new()
@@ -600,8 +586,6 @@ mod tests {
         assert!(debug_str.contains("DirMergeOptions"));
     }
 
-    // ==================== parser accessor tests ====================
-
     #[test]
     fn dir_merge_options_parser_returns_reference() {
         let opts = DirMergeOptions::new();
@@ -616,8 +600,6 @@ mod tests {
         let parser = opts.parser();
         assert!(parser.is_whitespace());
     }
-
-    // ==================== integration tests ====================
 
     #[test]
     fn dir_merge_options_complex_configuration() {

--- a/crates/engine/src/local_copy/pipelined_state.rs
+++ b/crates/engine/src/local_copy/pipelined_state.rs
@@ -333,8 +333,6 @@ impl PipelineController {
 mod tests {
     use super::*;
 
-    // ==================== PipelineState tests ====================
-
     #[test]
     fn pipeline_state_idle_equality() {
         assert_eq!(PipelineState::Idle, PipelineState::Idle);
@@ -363,8 +361,6 @@ mod tests {
         assert!(debug.contains("ProcessingEntry"));
     }
 
-    // ==================== PipelinePriority tests ====================
-
     #[test]
     fn pipeline_priority_ordering() {
         assert!(PipelinePriority::ProcessReadyEntries < PipelinePriority::FillPipeline);
@@ -390,8 +386,6 @@ mod tests {
         let copied = priority;
         assert_eq!(priority, copied);
     }
-
-    // ==================== PipelineController tests ====================
 
     #[test]
     fn controller_new_creates_idle_state() {

--- a/crates/engine/src/local_copy/plan/metadata.rs
+++ b/crates/engine/src/local_copy/plan/metadata.rs
@@ -171,8 +171,6 @@ impl LocalCopyMetadata {
 mod tests {
     use super::*;
 
-    // ==================== LocalCopyFileKind tests ====================
-
     #[test]
     fn file_kind_is_directory_returns_true_for_directory() {
         assert!(LocalCopyFileKind::Directory.is_directory());

--- a/crates/engine/src/local_copy/plan/plan_impl.rs
+++ b/crates/engine/src/local_copy/plan/plan_impl.rs
@@ -169,8 +169,6 @@ mod tests {
     use super::*;
     use std::path::Path;
 
-    // ==================== from_operands tests ====================
-
     #[test]
     fn from_operands_single_source() {
         let operands = vec![OsString::from("src"), OsString::from("dst")];
@@ -242,8 +240,6 @@ mod tests {
         assert!(result.is_err());
     }
 
-    // ==================== accessor tests ====================
-
     #[test]
     fn destination_returns_correct_path() {
         let operands = vec![OsString::from("source"), OsString::from("dest_dir")];
@@ -262,8 +258,6 @@ mod tests {
         let plan = LocalCopyPlan::from_operands(&operands).unwrap();
         assert_eq!(plan.sources().len(), 3);
     }
-
-    // ==================== Clone and Eq tests ====================
 
     #[test]
     fn plan_is_clone() {

--- a/crates/engine/src/local_copy/tests/builder_integration.rs
+++ b/crates/engine/src/local_copy/tests/builder_integration.rs
@@ -12,7 +12,6 @@ use crate::local_copy::{
 use tempfile::tempdir;
 use std::fs;
 
-// ==================== Before: Using Fluent API Directly ====================
 // These tests show the previous pattern (still valid, but more verbose)
 
 #[test]
@@ -34,7 +33,6 @@ fn fluent_api_basic_copy() {
     assert_eq!(fs::read(&dest).expect("read"), b"hello");
 }
 
-// ==================== After: Using Builder Pattern ====================
 // These tests demonstrate cleaner setup with the builder
 
 #[test]

--- a/crates/engine/src/local_copy/tests/concurrent_modification.rs
+++ b/crates/engine/src/local_copy/tests/concurrent_modification.rs
@@ -1,6 +1,4 @@
-// =============================================================================
 // Concurrent File Modification Tests (Task #185)
-// =============================================================================
 //
 // This module contains comprehensive tests for handling files modified during transfer.
 // These scenarios simulate real-world race conditions where files change while rsync

--- a/crates/engine/src/local_copy/tests/delete_delay.rs
+++ b/crates/engine/src/local_copy/tests/delete_delay.rs
@@ -13,7 +13,6 @@
 // 5. Deferred deletions respect filter rules
 // 6. Works with max_deletions limit
 
-// ==================== Basic Delay Behavior Tests ====================
 
 #[test]
 fn delete_delay_removes_extraneous_files_after_transfer() {
@@ -91,7 +90,6 @@ fn delete_delay_defers_directory_deletions_until_end() {
     assert!(summary.items_deleted() >= 1); // At least the directory
 }
 
-// ==================== Comparison with --delete-during ====================
 
 #[test]
 fn delete_delay_differs_from_delete_during_timing() {
@@ -170,7 +168,6 @@ fn delete_during_option_enables_during_timing() {
     assert_eq!(options.delete_timing(), Some(DeleteTiming::During));
 }
 
-// ==================== Recursive Directory Handling ====================
 
 #[test]
 fn delete_delay_works_with_recursive_traversal() {
@@ -266,7 +263,6 @@ fn delete_delay_handles_nested_empty_directories() {
     assert!(summary.items_deleted() >= 1);
 }
 
-// ==================== Partial Failures and Error Handling ====================
 
 #[test]
 fn delete_delay_with_max_deletions_limit() {
@@ -413,7 +409,6 @@ fn delete_delay_batches_multiple_directory_deletions() {
     assert!(summary.items_deleted() >= 6);
 }
 
-// ==================== Filter Integration ====================
 
 #[test]
 fn delete_delay_respects_exclude_filters() {
@@ -502,7 +497,6 @@ fn delete_delay_with_delete_excluded_removes_filtered_files() {
     assert_eq!(summary.items_deleted(), 1);
 }
 
-// ==================== Edge Cases ====================
 
 #[test]
 fn delete_delay_with_no_files_to_delete() {

--- a/crates/engine/src/local_copy/tests/disk_full_errors.rs
+++ b/crates/engine/src/local_copy/tests/disk_full_errors.rs
@@ -11,7 +11,6 @@
 // 5. Error messages include path context
 // 6. Guard behavior on disk full errors (temp file cleanup)
 
-// ==================== LocalCopyError Construction Tests ====================
 
 #[test]
 fn local_copy_error_from_disk_full_io_error() {
@@ -62,7 +61,6 @@ fn local_copy_error_disk_full_code_name_is_rerr_partial() {
     assert_eq!(error.code_name(), "RERR_PARTIAL");
 }
 
-// ==================== Error Kind Detection Tests ====================
 
 #[test]
 fn detect_storage_full_error_kind() {
@@ -90,7 +88,6 @@ fn raw_os_error_enospc_detected_as_storage_full() {
     assert_eq!(enospc.raw_os_error(), Some(28));
 }
 
-// ==================== Error Message Quality Tests ====================
 
 #[test]
 fn disk_full_error_message_includes_action_context() {
@@ -153,7 +150,6 @@ fn disk_full_error_preserves_original_io_error_message() {
     }
 }
 
-// ==================== DestinationWriteGuard Cleanup Tests ====================
 
 #[test]
 fn guard_discard_cleans_up_temp_file_on_disk_full() {
@@ -213,7 +209,6 @@ fn guard_partial_mode_preserves_file_on_discard() {
     );
 }
 
-// ==================== Guard Remove Functions Tests ====================
 
 #[test]
 fn remove_existing_destination_handles_disk_full_context() {
@@ -247,7 +242,6 @@ fn remove_incomplete_destination_silent_on_not_found() {
     remove_incomplete_destination(&path);
 }
 
-// ==================== Exit Code Verification Tests ====================
 
 #[test]
 fn io_error_exit_code_is_23_for_general_io_errors() {
@@ -290,7 +284,6 @@ fn io_error_exit_code_matches_upstream_rerr_partial() {
     assert_eq!(error.exit_code(), 23);
 }
 
-// ==================== Error Source Chain Tests ====================
 
 #[test]
 fn disk_full_error_has_source() {
@@ -315,7 +308,6 @@ fn disk_full_error_debug_format_includes_details() {
     assert!(debug.contains("write file"));
 }
 
-// ==================== Real File Operation Tests ====================
 
 #[test]
 #[cfg(unix)]
@@ -369,7 +361,6 @@ fn directory_write_error_propagates_correctly() {
     }
 }
 
-// ==================== Error Kind Extraction Tests ====================
 
 #[test]
 fn local_copy_error_kind_as_io_returns_components() {
@@ -400,7 +391,6 @@ fn local_copy_error_into_kind_consumes_error() {
     assert!(matches!(kind, LocalCopyErrorKind::Io { .. }));
 }
 
-// ==================== Comparison with Other Error Types ====================
 
 #[test]
 fn disk_full_vs_general_io_errors_have_same_exit_code() {
@@ -435,7 +425,6 @@ fn io_errors_have_different_code_name_than_timeout() {
     assert_ne!(io_error.code_name(), timeout_error.code_name());
 }
 
-// ==================== Large File Handling Tests ====================
 
 #[test]
 fn error_context_preserved_for_large_file_paths() {
@@ -469,7 +458,6 @@ fn error_for_special_characters_in_path() {
     }
 }
 
-// ==================== Concurrent Error Handling Tests ====================
 
 #[test]
 fn multiple_disk_full_errors_are_independent() {
@@ -491,7 +479,6 @@ fn multiple_disk_full_errors_are_independent() {
     }
 }
 
-// ==================== Partial Transfer Behavior Tests ====================
 
 #[test]
 fn disk_full_during_copy_preserves_partial_file_in_partial_mode() {
@@ -535,7 +522,6 @@ fn disk_full_during_copy_removes_temp_file_in_normal_mode() {
     assert!(!staging.exists(), "Temp file should be removed in normal mode");
 }
 
-// ==================== Error Recovery Tests ====================
 
 #[test]
 fn can_retry_after_disk_full_error() {
@@ -584,7 +570,6 @@ fn multiple_failed_attempts_clean_up_properly() {
     assert_eq!(fs::read(&dest).expect("read"), b"final success");
 }
 
-// ==================== Read-Only Filesystem Error Tests ====================
 
 #[test]
 fn readonly_filesystem_error_maps_correctly() {

--- a/crates/engine/src/local_copy/tests/execute_append.rs
+++ b/crates/engine/src/local_copy/tests/execute_append.rs
@@ -15,7 +15,6 @@
 // 6. Mismatch detection with verification
 // 7. Works correctly with various file sizes
 
-// ==================== Basic Append Tests ====================
 
 #[test]
 fn append_adds_remaining_data_to_partial_file() {
@@ -175,7 +174,6 @@ fn append_handles_empty_destination() {
     );
 }
 
-// ==================== File Offset Correctness Tests ====================
 
 #[test]
 fn append_correct_offset_with_small_partial() {
@@ -297,7 +295,6 @@ fn append_almost_complete_file() {
     assert_eq!(fs::read(&destination).expect("read dest"), full);
 }
 
-// ==================== Append with Verification Tests ====================
 
 #[test]
 fn append_verify_succeeds_when_prefix_matches() {
@@ -458,7 +455,6 @@ fn append_without_verify_blindly_appends() {
     assert_eq!(result, b"WRONG DATAABCDEFGHIJ");
 }
 
-// ==================== Combined Options Tests ====================
 
 #[test]
 fn append_combined_with_times_preserves_mtime() {
@@ -564,7 +560,6 @@ fn append_with_checksum_mode() {
     );
 }
 
-// ==================== Directory Recursive Tests ====================
 
 #[test]
 fn append_recursive_directory_with_partial_files() {
@@ -668,7 +663,6 @@ fn append_nested_directory_structure() {
     );
 }
 
-// ==================== Binary Content Tests ====================
 
 #[test]
 fn append_binary_data() {
@@ -729,7 +723,6 @@ fn append_verify_binary_data_with_matching_prefix() {
     assert_eq!(fs::read(&destination).expect("read dest"), full_binary);
 }
 
-// ==================== Edge Cases ====================
 
 #[test]
 fn append_with_empty_source_skips_when_dest_has_content() {
@@ -819,7 +812,6 @@ fn append_verify_enabled_implies_append() {
     );
 }
 
-// ==================== Dry Run Tests ====================
 
 #[test]
 fn append_dry_run_reports_but_preserves_files() {
@@ -849,7 +841,6 @@ fn append_dry_run_reports_but_preserves_files() {
     assert_eq!(fs::read(&destination).expect("read dest"), b"complete");
 }
 
-// ==================== Behavior Consistency Tests ====================
 
 #[test]
 fn append_matches_upstream_append_semantics() {
@@ -921,7 +912,6 @@ fn append_matches_upstream_append_semantics() {
     );
 }
 
-// ==================== Skip Behavior Tests ====================
 
 #[test]
 fn append_skips_when_destination_exactly_equals_source_size() {

--- a/crates/engine/src/local_copy/tests/execute_basic.rs
+++ b/crates/engine/src/local_copy/tests/execute_basic.rs
@@ -317,7 +317,6 @@ fn execute_copies_directory_tree() {
     assert!(summary.directories_created() >= 1);
 }
 
-// ==================== Empty File Tests ====================
 
 #[test]
 fn execute_copies_empty_file() {
@@ -365,7 +364,6 @@ fn execute_copies_empty_file_over_existing() {
     assert_eq!(fs::metadata(&destination).expect("metadata").len(), 0);
 }
 
-// ==================== Large File Tests ====================
 
 #[test]
 fn execute_copies_large_file() {
@@ -392,7 +390,6 @@ fn execute_copies_large_file() {
     assert_eq!(fs::read(&destination).expect("read dest"), large_content);
 }
 
-// ==================== Multiple File Tests ====================
 
 #[test]
 fn execute_copies_multiple_files_to_directory() {
@@ -420,7 +417,6 @@ fn execute_copies_multiple_files_to_directory() {
     assert_eq!(fs::read(dest_root.join("file3.txt")).expect("read"), b"content3");
 }
 
-// ==================== Dry Run Tests ====================
 
 #[test]
 fn execute_dry_run_does_not_create_destination() {
@@ -465,7 +461,6 @@ fn execute_dry_run_does_not_modify_existing_destination() {
     assert_eq!(fs::read(&destination).expect("read dest"), b"original");
 }
 
-// ==================== Inplace Mode Tests ====================
 
 #[test]
 fn execute_with_inplace_updates_existing_file() {
@@ -492,7 +487,6 @@ fn execute_with_inplace_updates_existing_file() {
     assert_eq!(fs::read(&destination).expect("read dest"), b"updated content");
 }
 
-// ==================== Partial Mode Tests ====================
 
 #[test]
 fn execute_with_partial_enabled_creates_partial_file_on_success() {
@@ -518,7 +512,6 @@ fn execute_with_partial_enabled_creates_partial_file_on_success() {
     assert_eq!(fs::read(&destination).expect("read dest"), b"partial test");
 }
 
-// ==================== Permissions Tests ====================
 
 #[cfg(unix)]
 #[test]
@@ -552,7 +545,6 @@ fn execute_preserves_permissions_when_enabled() {
     assert_eq!(dest_perms.mode() & 0o777, 0o600);
 }
 
-// ==================== Times Preservation Tests ====================
 
 #[test]
 fn execute_preserves_modification_time_when_enabled() {
@@ -584,7 +576,6 @@ fn execute_preserves_modification_time_when_enabled() {
     assert_eq!(dest_mtime, past_time);
 }
 
-// ==================== Whole File Mode Tests ====================
 
 #[test]
 fn execute_with_whole_file_always_copies() {
@@ -617,7 +608,6 @@ fn execute_with_whole_file_always_copies() {
     assert_eq!(summary.files_copied(), 1);
 }
 
-// ==================== Recursive Directory Tests ====================
 
 #[test]
 fn execute_copies_deeply_nested_directory() {
@@ -643,7 +633,6 @@ fn execute_copies_deeply_nested_directory() {
     assert_eq!(fs::read(&dest_file).expect("read deep file"), b"deep content");
 }
 
-// ==================== Error Handling Tests ====================
 
 #[test]
 fn execute_file_copy_to_directory_places_file_inside() {
@@ -671,7 +660,6 @@ fn execute_file_copy_to_directory_places_file_inside() {
     assert_eq!(fs::read(&target_file).expect("read"), b"content");
 }
 
-// ==================== Summary Statistics Tests ====================
 
 #[test]
 fn execute_summary_tracks_total_source_bytes() {
@@ -720,7 +708,6 @@ fn execute_summary_tracks_directories_created() {
     assert!(dest_root.join("dir2").exists());
 }
 
-// ==================== Single File Copy Tests ====================
 
 #[test]
 fn execute_basic_single_file_copy() {
@@ -820,7 +807,6 @@ fn execute_creates_intermediate_directories_when_needed() {
     assert_eq!(fs::read(&destination).expect("read dest"), b"nested");
 }
 
-// ==================== Directory Copy Tests ====================
 
 #[test]
 fn execute_copies_empty_directory() {
@@ -894,7 +880,6 @@ fn execute_copies_nested_directories() {
     assert_eq!(fs::read(dest_root.join("subdir").join("nested.txt")).expect("read"), b"nested");
 }
 
-// ==================== Timestamp Preservation Tests ====================
 
 #[test]
 fn execute_does_not_preserve_timestamps_by_default() {
@@ -1007,7 +992,6 @@ fn execute_preserves_very_old_timestamps() {
     assert_eq!(dest_mtime, very_old);
 }
 
-// ==================== Permission Preservation Tests ====================
 
 #[cfg(unix)]
 #[test]
@@ -1158,7 +1142,6 @@ fn execute_preserves_permissions_across_directory_tree() {
     );
 }
 
-// ==================== Combined Options Tests ====================
 
 #[test]
 fn execute_preserves_both_times_and_permissions() {
@@ -1206,7 +1189,6 @@ fn execute_preserves_both_times_and_permissions() {
     }
 }
 
-// ==================== File Size Tests ====================
 
 #[test]
 fn execute_handles_various_file_sizes() {
@@ -1275,7 +1257,6 @@ fn execute_copies_file_exactly_one_block_size() {
     assert_eq!(fs::read(&destination).expect("read dest"), content);
 }
 
-// ==================== Binary Data Tests ====================
 
 #[test]
 fn execute_copies_binary_data_correctly() {
@@ -1328,7 +1309,6 @@ fn execute_copies_file_with_null_bytes() {
     assert_eq!(fs::read(&destination).expect("read dest"), content);
 }
 
-// ==================== Statistics and Reporting Tests ====================
 
 #[test]
 fn execute_summary_counts_bytes_correctly() {
@@ -1387,7 +1367,6 @@ fn execute_summary_reports_zero_for_no_changes() {
     assert_eq!(summary.bytes_copied(), 0);
 }
 
-// ==================== Edge Cases ====================
 
 #[test]
 fn execute_handles_filename_with_spaces() {
@@ -1494,7 +1473,6 @@ fn execute_copies_multiple_empty_directories() {
     assert!(dest_root.join("empty3").is_dir());
 }
 
-// ==================== Dry Run Validation Tests ====================
 
 #[test]
 fn execute_dry_run_reports_correct_statistics() {

--- a/crates/engine/src/local_copy/tests/execute_block_size.rs
+++ b/crates/engine/src/local_copy/tests/execute_block_size.rs
@@ -1,5 +1,4 @@
 
-// ==================== Option plumbing tests ====================
 
 #[test]
 fn block_size_override_default_is_none() {
@@ -53,7 +52,6 @@ fn block_size_builder_none_clears_override() {
     assert!(opts.block_size_override().is_none());
 }
 
-// ==================== Delta transfer integration tests ====================
 
 #[test]
 fn block_size_override_affects_delta_matching_small_block() {

--- a/crates/engine/src/local_copy/tests/execute_checksum_seed.rs
+++ b/crates/engine/src/local_copy/tests/execute_checksum_seed.rs
@@ -1,5 +1,4 @@
 
-// ==================== --checksum-seed tests ====================
 //
 // Upstream rsync behavior:
 // - Without --checksum-seed: the seed is negotiated automatically (typically
@@ -8,7 +7,6 @@
 //   producing deterministic results across runs. This is useful for debugging,
 //   testing, and batch mode reproducibility.
 
-// ==================== Option Unit Tests ====================
 
 #[test]
 fn checksum_seed_defaults_to_none() {
@@ -94,7 +92,6 @@ fn checksum_seed_new_defaults_to_none() {
     );
 }
 
-// ==================== Builder Unit Tests ====================
 
 #[test]
 fn checksum_seed_builder_defaults_to_none() {
@@ -187,7 +184,6 @@ fn checksum_seed_build_unchecked_works() {
     );
 }
 
-// ==================== Combination Tests ====================
 
 #[test]
 fn checksum_seed_compatible_with_checksum_mode() {
@@ -232,7 +228,6 @@ fn checksum_seed_without_checksum_mode() {
     assert_eq!(opts.checksum_seed(), Some(42));
 }
 
-// ==================== Functional Tests ====================
 //
 // These tests verify that the local copy engine works correctly when
 // checksum_seed is configured.
@@ -463,7 +458,6 @@ fn transfer_with_checksum_seed_and_delete() {
     assert!(summary.items_deleted() >= 1, "should report deletion");
 }
 
-// ==================== Round-Trip Tests ====================
 
 #[test]
 fn checksum_seed_round_trip_direct() {

--- a/crates/engine/src/local_copy/tests/execute_copy_dest.rs
+++ b/crates/engine/src/local_copy/tests/execute_copy_dest.rs
@@ -1,5 +1,4 @@
 
-// ==================== Basic Copy-Dest Tests ====================
 
 #[test]
 fn copy_dest_identical_file_is_copied_not_linked() {
@@ -135,7 +134,6 @@ fn copy_dest_missing_file_transfers_normally() {
     assert_eq!(summary.files_copied(), 1);
 }
 
-// ==================== Multiple Copy-Dest Directories Tests ====================
 
 #[test]
 fn copy_dest_multiple_directories_checks_in_order() {
@@ -244,7 +242,6 @@ fn copy_dest_multiple_directories_uses_first_match() {
     }
 }
 
-// ==================== Copy-Dest vs Compare-Dest Tests ====================
 
 #[test]
 fn copy_dest_creates_file_while_compare_dest_skips() {
@@ -314,7 +311,6 @@ fn copy_dest_creates_file_while_compare_dest_skips() {
     assert_eq!(summary_copy.files_copied(), 1);
 }
 
-// ==================== Copy-Dest with Directory Trees ====================
 
 #[test]
 fn copy_dest_works_with_directory_trees() {
@@ -417,7 +413,6 @@ fn copy_dest_mixed_existing_and_new_files() {
     assert_eq!(summary.files_copied(), 3);
 }
 
-// ==================== Copy-Dest with Checksum Tests ====================
 
 #[test]
 fn copy_dest_with_checksum_validates_content() {
@@ -469,7 +464,6 @@ fn copy_dest_with_checksum_validates_content() {
     assert_eq!(summary.files_copied(), 1);
 }
 
-// ==================== Edge Cases ====================
 
 #[test]
 fn copy_dest_ignores_non_regular_files() {
@@ -592,7 +586,6 @@ fn copy_dest_empty_reference_directory() {
     assert_eq!(summary.files_copied(), 1);
 }
 
-// ==================== Copy-Dest with Inplace Mode Tests ====================
 
 #[test]
 fn copy_dest_with_inplace_mode_still_copies() {
@@ -639,7 +632,6 @@ fn copy_dest_with_inplace_mode_still_copies() {
     assert_eq!(summary.files_copied(), 1);
 }
 
-// ==================== Copy-Dest with Nonexistent Directory Tests ====================
 
 #[test]
 fn copy_dest_nonexistent_directory_transfers_normally() {
@@ -676,7 +668,6 @@ fn copy_dest_nonexistent_directory_transfers_normally() {
     assert_eq!(summary.files_copied(), 1);
 }
 
-// ==================== Copy-Dest with Zero-Length File Tests ====================
 
 #[test]
 fn copy_dest_copies_zero_length_file() {

--- a/crates/engine/src/local_copy/tests/execute_delay_updates.rs
+++ b/crates/engine/src/local_copy/tests/execute_delay_updates.rs
@@ -14,7 +14,6 @@
 // 6. Hard links work correctly with delayed updates
 // 7. Metadata is applied after rename
 
-// ==================== Basic Delay Updates Tests ====================
 
 #[test]
 fn delay_updates_writes_to_temp_names_during_transfer() {
@@ -152,7 +151,6 @@ fn delay_updates_no_temp_files_remain_after_success() {
     );
 }
 
-// ==================== Combination with Temp Dir Tests ====================
 
 #[test]
 fn delay_updates_works_with_temp_dir() {
@@ -243,7 +241,6 @@ fn delay_updates_with_temp_dir_multiple_files() {
     assert!(staging_files.is_empty());
 }
 
-// ==================== Metadata Preservation Tests ====================
 
 #[cfg(unix)]
 #[test]
@@ -311,7 +308,6 @@ fn delay_updates_preserves_modification_time() {
     assert_eq!(dest_mtime, past_time);
 }
 
-// ==================== Nested Directory Tests ====================
 
 #[test]
 fn delay_updates_handles_nested_directories() {
@@ -361,7 +357,6 @@ fn delay_updates_handles_nested_directories() {
     );
 }
 
-// ==================== Replacing Existing Files Tests ====================
 
 #[test]
 fn delay_updates_replaces_existing_files_atomically() {
@@ -436,7 +431,6 @@ fn delay_updates_with_multiple_existing_files() {
     );
 }
 
-// ==================== Empty and Large File Tests ====================
 
 #[test]
 fn delay_updates_handles_empty_file() {
@@ -491,7 +485,6 @@ fn delay_updates_handles_large_file() {
     assert_eq!(fs::read(&destination).expect("read dest"), large_content);
 }
 
-// ==================== Dry Run Tests ====================
 
 #[test]
 fn delay_updates_dry_run_does_not_create_files() {
@@ -542,7 +535,6 @@ fn delay_updates_dry_run_does_not_modify_existing() {
     assert_eq!(fs::read(&destination).expect("read dest"), b"original");
 }
 
-// ==================== Interaction with Other Options Tests ====================
 
 /// Test that delay_updates works with --delete to remove extraneous files.
 /// TODO: Fix implementation - delay_updates with delete has partial file finalization issue.
@@ -617,7 +609,6 @@ fn delay_updates_with_update_flag_skips_older_files() {
     assert_eq!(fs::read(&destination).expect("read dest"), b"dest content");
 }
 
-// ==================== Special File Characteristics Tests ====================
 
 #[test]
 fn delay_updates_handles_files_with_spaces_in_name() {
@@ -670,7 +661,6 @@ fn delay_updates_handles_files_with_special_characters() {
     assert_eq!(fs::read(&destination).expect("read dest"), b"special chars");
 }
 
-// ==================== Atomicity Verification Tests ====================
 
 #[test]
 fn delay_updates_provides_atomic_directory_update() {
@@ -718,7 +708,6 @@ fn delay_updates_provides_atomic_directory_update() {
     assert_eq!(content3, b"new content 3");
 }
 
-// ==================== Comparison with Non-Delay Mode Tests ====================
 
 #[test]
 fn delay_updates_differs_from_immediate_mode() {
@@ -767,7 +756,6 @@ fn delay_updates_differs_from_immediate_mode() {
     );
 }
 
-// ==================== Option Interactions ====================
 
 #[test]
 fn delay_updates_setting_enables_partial() {
@@ -787,7 +775,6 @@ fn delay_updates_can_be_disabled() {
     assert!(!opts.delay_updates_enabled(), "delay_updates should be disabled");
 }
 
-// ==================== Mixed New and Existing Files Tests ====================
 
 #[test]
 fn delay_updates_handles_mix_of_new_and_existing_files() {
@@ -833,7 +820,6 @@ fn delay_updates_handles_mix_of_new_and_existing_files() {
     );
 }
 
-// ==================== Staging Path Verification Tests ====================
 
 /// Verify that delay_updates uses .~tmp~ prefix for staging files,
 /// matching upstream rsync behavior. We check this by running a transfer
@@ -891,7 +877,6 @@ fn delay_updates_temp_files_use_upstream_rsync_prefix() {
     }
 }
 
-// ==================== Per-Destination-Directory Staging Tests ====================
 
 #[test]
 fn delay_updates_handles_multiple_subdirectories() {
@@ -965,7 +950,6 @@ fn delay_updates_handles_multiple_subdirectories() {
     assert_no_staging(&dest_root);
 }
 
-// ==================== Backup + Delay Updates Tests ====================
 
 #[test]
 fn delay_updates_with_backup_creates_backup_files() {
@@ -1050,7 +1034,6 @@ fn delay_updates_with_backup_suffix() {
     assert_eq!(fs::read(&backup).expect("read backup"), b"old");
 }
 
-// ==================== Checksum + Delay Updates Tests ====================
 
 #[test]
 fn delay_updates_with_checksum_comparison() {
@@ -1131,7 +1114,6 @@ fn delay_updates_with_checksum_skips_identical_files() {
     );
 }
 
-// ==================== Symlink + Delay Updates Tests ====================
 
 #[cfg(unix)]
 #[test]
@@ -1180,7 +1162,6 @@ fn delay_updates_preserves_symlinks() {
     );
 }
 
-// ==================== Hard Links + Delay Updates Tests ====================
 
 #[cfg(unix)]
 #[test]
@@ -1247,7 +1228,6 @@ fn delay_updates_preserves_multiple_hard_link_groups() {
     assert!(summary.hard_links_created() >= 3);
 }
 
-// ==================== Ignore Existing + Delay Updates Tests ====================
 
 #[test]
 fn delay_updates_with_ignore_existing_skips_existing_files() {
@@ -1289,7 +1269,6 @@ fn delay_updates_with_ignore_existing_skips_existing_files() {
     );
 }
 
-// ==================== Existing-Only + Delay Updates Tests ====================
 
 #[test]
 fn delay_updates_with_existing_only_skips_new_files() {
@@ -1330,7 +1309,6 @@ fn delay_updates_with_existing_only_skips_new_files() {
     );
 }
 
-// ==================== Unicode Filename Tests ====================
 
 #[test]
 fn delay_updates_handles_unicode_filenames() {
@@ -1377,7 +1355,6 @@ fn delay_updates_handles_unicode_filenames() {
     );
 }
 
-// ==================== Size-Only + Delay Updates Tests ====================
 
 #[test]
 fn delay_updates_with_size_only_skips_same_size_files() {
@@ -1414,7 +1391,6 @@ fn delay_updates_with_size_only_skips_same_size_files() {
     );
 }
 
-// ==================== Ignore-Times + Delay Updates Tests ====================
 
 #[test]
 fn delay_updates_with_ignore_times_always_transfers() {
@@ -1452,7 +1428,6 @@ fn delay_updates_with_ignore_times_always_transfers() {
     assert_eq!(summary.files_copied(), 1);
 }
 
-// ==================== Many Files (Stress) Tests ====================
 
 #[test]
 fn delay_updates_handles_many_files() {
@@ -1506,7 +1481,6 @@ fn delay_updates_handles_many_files() {
     assert!(leftovers.is_empty(), "staging files remain: {leftovers:?}");
 }
 
-// ==================== Deeply Nested + Delay Updates Tests ====================
 
 #[test]
 fn delay_updates_handles_deeply_nested_structure() {
@@ -1548,7 +1522,6 @@ fn delay_updates_handles_deeply_nested_structure() {
     }
 }
 
-// ==================== Builder Validation Tests ====================
 
 #[test]
 fn builder_rejects_inplace_with_delay_updates() {
@@ -1572,7 +1545,6 @@ fn builder_accepts_delay_updates_without_inplace() {
     assert!(opts.partial_enabled());
 }
 
-// ==================== Idempotency Tests ====================
 
 #[test]
 fn delay_updates_is_idempotent_on_second_run() {
@@ -1623,7 +1595,6 @@ fn delay_updates_is_idempotent_on_second_run() {
     );
 }
 
-// ==================== Partial Re-transfer Tests ====================
 
 #[test]
 fn delay_updates_only_transfers_changed_files() {
@@ -1674,7 +1645,6 @@ fn delay_updates_only_transfers_changed_files() {
     );
 }
 
-// ==================== Remove Source Files + Delay Updates Tests ====================
 
 #[test]
 fn delay_updates_with_remove_source_files() {
@@ -1715,7 +1685,6 @@ fn delay_updates_with_remove_source_files() {
     );
 }
 
-// ==================== Times Preservation with Multiple Files ====================
 
 #[test]
 fn delay_updates_preserves_times_across_multiple_files() {
@@ -1764,7 +1733,6 @@ fn delay_updates_preserves_times_across_multiple_files() {
     }
 }
 
-// ==================== Permissions Preservation with Multiple Files ====================
 
 #[cfg(unix)]
 #[test]
@@ -1820,7 +1788,6 @@ fn delay_updates_preserves_permissions_across_multiple_files() {
     }
 }
 
-// ==================== Binary Content Tests ====================
 
 #[test]
 fn delay_updates_handles_binary_content() {
@@ -1881,7 +1848,6 @@ fn delay_updates_handles_file_with_null_bytes() {
     );
 }
 
-// ==================== Option Wiring Tests ====================
 
 #[test]
 fn delay_updates_option_is_false_by_default() {
@@ -1912,7 +1878,6 @@ fn delay_updates_disabled_does_not_set_partial() {
     assert!(!opts.delay_updates_enabled());
 }
 
-// ==================== Dry Run with Complex Trees ====================
 
 #[test]
 fn delay_updates_dry_run_with_nested_tree_no_changes() {
@@ -1945,7 +1910,6 @@ fn delay_updates_dry_run_with_nested_tree_no_changes() {
     assert!(!dest_root.exists(), "dest should not be created in dry run");
 }
 
-// ==================== Replacement with Larger/Smaller Files ====================
 
 #[test]
 fn delay_updates_replaces_smaller_file_with_larger() {
@@ -2005,7 +1969,6 @@ fn delay_updates_replaces_larger_file_with_smaller() {
     );
 }
 
-// ==================== Mixed Directory Operations ====================
 
 #[test]
 fn delay_updates_creates_destination_directories_as_needed() {
@@ -2048,7 +2011,6 @@ fn delay_updates_creates_destination_directories_as_needed() {
     );
 }
 
-// ==================== .~tmp~ Staging Directory Tests ====================
 
 /// Verifies that `--delay-updates` automatically sets the partial directory
 /// to `.~tmp~` (matching upstream rsync's `tmp_partialdir`).

--- a/crates/engine/src/local_copy/tests/execute_delay_updates_delete.rs
+++ b/crates/engine/src/local_copy/tests/execute_delay_updates_delete.rs
@@ -11,7 +11,6 @@
 // 2. No `.~tmp~` staging artifacts remain after the transfer.
 // 3. The summary correctly reports both transferred and deleted counts.
 
-// ==================== delay-updates + delete-during interaction ====================
 
 /// Verifies that when --delay-updates and --delete (During timing) are both
 /// active, the extraneous destination file C is not removed until AFTER files

--- a/crates/engine/src/local_copy/tests/execute_direct_write.rs
+++ b/crates/engine/src/local_copy/tests/execute_direct_write.rs
@@ -14,7 +14,6 @@
 // 6. Zero-length files use the direct write path
 // 7. Large files use the direct write path correctly
 
-// ==================== Basic Direct Write Tests ====================
 
 #[test]
 fn direct_write_creates_file_at_final_destination() {
@@ -133,7 +132,6 @@ fn direct_write_preserves_file_content_exactly() {
     );
 }
 
-// ==================== Multiple File Tests ====================
 
 #[test]
 fn direct_write_handles_multiple_files_in_directory() {
@@ -187,7 +185,6 @@ fn direct_write_handles_multiple_files_in_directory() {
     );
 }
 
-// ==================== Edge Case Tests ====================
 
 #[test]
 fn direct_write_zero_length_file() {
@@ -238,7 +235,6 @@ fn direct_write_large_file_content_intact() {
     );
 }
 
-// ==================== Fallback to Temp File Tests ====================
 
 #[test]
 fn existing_destination_does_not_use_direct_write() {

--- a/crates/engine/src/local_copy/tests/execute_dry_run.rs
+++ b/crates/engine/src/local_copy/tests/execute_dry_run.rs
@@ -8,7 +8,6 @@
 // providing a single, comprehensive test suite focused exclusively on dry-run
 // semantics as documented in the rsync(1) man page.
 
-// ==================== Basic Dry-Run Semantics ====================
 
 #[test]
 fn dry_run_single_file_lists_but_does_not_copy() {
@@ -123,7 +122,6 @@ fn dry_run_preserves_existing_destination_unmodified() {
     );
 }
 
-// ==================== Directory Structure in Dry-Run ====================
 
 #[test]
 fn dry_run_directory_tree_not_created() {
@@ -190,7 +188,6 @@ fn dry_run_empty_directory_tree_reported() {
     assert!(!ctx.dest.exists(), "no destination should be created");
 }
 
-// ==================== Dry-Run with --delete ====================
 
 #[test]
 fn dry_run_with_delete_reports_deletions_but_preserves_files() {
@@ -324,7 +321,6 @@ fn dry_run_with_delete_during_reports_interleaved_events() {
     assert_eq!(fs::read(dest.join("keep.txt")).expect("read"), b"old");
 }
 
-// ==================== Dry-Run with Filters ====================
 
 #[test]
 fn dry_run_with_exclude_filter_omits_excluded_files() {
@@ -403,7 +399,6 @@ fn dry_run_with_include_exclude_filter_chain() {
     assert_eq!(paths, vec!["important.cfg"]);
 }
 
-// ==================== Dry-Run Records and Metadata ====================
 
 #[test]
 fn dry_run_records_contain_file_metadata() {
@@ -500,7 +495,6 @@ fn dry_run_records_update_is_not_marked_as_created() {
     assert_eq!(fs::read(&destination).expect("read"), b"old");
 }
 
-// ==================== Dry-Run Statistics ====================
 
 #[test]
 fn dry_run_statistics_match_apply_mode_statistics() {
@@ -597,7 +591,6 @@ fn dry_run_empty_files_reported() {
     assert!(!ctx.dest.exists());
 }
 
-// ==================== Dry-Run Combined With Various Options ====================
 
 #[test]
 fn dry_run_with_times_does_not_set_timestamps() {
@@ -757,7 +750,6 @@ fn dry_run_with_checksum_mode_reports_correctly() {
     assert!(!destination.exists());
 }
 
-// ==================== Dry-Run with Symlinks ====================
 
 #[cfg(unix)]
 #[test]
@@ -782,7 +774,6 @@ fn dry_run_does_not_create_symlinks() {
     assert!(!ctx.dest.exists(), "no destination should be created in dry run");
 }
 
-// ==================== Dry-Run with delete + filters interaction ====================
 
 #[test]
 fn dry_run_delete_respects_exclude_filters() {
@@ -822,7 +813,6 @@ fn dry_run_delete_respects_exclude_filters() {
     assert!(dest.join("keep.txt").exists());
 }
 
-// ==================== Dry-Run Multiple Files ====================
 
 #[test]
 fn dry_run_multiple_files_all_reported() {
@@ -858,7 +848,6 @@ fn dry_run_multiple_files_all_reported() {
     assert!(!ctx.dest.exists());
 }
 
-// ==================== Dry-Run Idempotency ====================
 
 #[test]
 fn dry_run_is_idempotent() {
@@ -881,7 +870,6 @@ fn dry_run_is_idempotent() {
     }
 }
 
-// ==================== Dry-Run with large files ====================
 
 #[test]
 fn dry_run_large_file_reports_correct_byte_count() {
@@ -907,7 +895,6 @@ fn dry_run_large_file_reports_correct_byte_count() {
     assert!(!destination.exists());
 }
 
-// ==================== Dry-Run with matched (up-to-date) files ====================
 
 #[test]
 fn dry_run_reports_matched_file_as_would_copy() {
@@ -948,7 +935,6 @@ fn dry_run_reports_matched_file_as_would_copy() {
     );
 }
 
-// ==================== Dry-Run with backup option ====================
 
 #[test]
 fn dry_run_with_backup_does_not_create_backup_files() {
@@ -985,7 +971,6 @@ fn dry_run_with_backup_does_not_create_backup_files() {
     assert_eq!(fs::read(&destination).expect("read"), b"old");
 }
 
-// ==================== Dry-Run with recursive nested tree ====================
 
 #[test]
 fn dry_run_deeply_nested_tree_all_reported() {
@@ -1020,7 +1005,6 @@ fn dry_run_deeply_nested_tree_all_reported() {
     assert!(!ctx.dest.exists());
 }
 
-// ==================== Dry-Run with --whole-file ====================
 
 #[test]
 fn dry_run_whole_file_reports_transfer() {
@@ -1047,7 +1031,6 @@ fn dry_run_whole_file_reports_transfer() {
     assert!(!destination.exists());
 }
 
-// ==================== Dry-Run with --inplace ====================
 
 #[test]
 fn dry_run_with_inplace_does_not_modify_destination() {

--- a/crates/engine/src/local_copy/tests/execute_filter_program.rs
+++ b/crates/engine/src/local_copy/tests/execute_filter_program.rs
@@ -1,5 +1,4 @@
 
-// ============================================================================
 // Filter program engine tests
 //
 // Exercises the filter evaluation engine (FilterOutcome, FilterSegment,
@@ -18,7 +17,6 @@
 // - Directory-only patterns require the is_dir flag.
 // - Empty programs allow everything.
 // - Programs with multiple segments compose correctly.
-// ============================================================================
 
 #[test]
 fn filter_outcome_default_allows_transfer_and_deletion() {

--- a/crates/engine/src/local_copy/tests/execute_ignore_errors.rs
+++ b/crates/engine/src/local_copy/tests/execute_ignore_errors.rs
@@ -1,5 +1,4 @@
 
-// ==================== --ignore-errors tests ====================
 //
 // Upstream rsync behavior:
 // - Without --ignore-errors: if I/O errors occurred during transfer,
@@ -8,7 +7,6 @@
 // - With --ignore-errors: --delete proceeds with deletions even when
 //   I/O errors occurred during the transfer
 
-// ==================== Option Unit Tests ====================
 
 #[test]
 fn ignore_errors_option_defaults_to_false() {
@@ -127,7 +125,6 @@ fn ignore_errors_without_delete_is_harmless() {
     assert!(!opts.delete_extraneous());
 }
 
-// ==================== Functional Tests ====================
 //
 // These tests verify the actual interaction between --ignore-errors
 // and the deletion behavior when I/O errors occur.
@@ -447,7 +444,6 @@ fn no_ignore_errors_with_delete_after_suppresses_deletions() {
     assert!(result.is_err(), "copy should report I/O error");
 }
 
-// ==================== Edge Case Tests ====================
 
 #[test]
 fn ignore_errors_with_dry_run_reports_deletions() {

--- a/crates/engine/src/local_copy/tests/execute_inplace.rs
+++ b/crates/engine/src/local_copy/tests/execute_inplace.rs
@@ -14,7 +14,6 @@
 // 5. File permissions preserved during update
 // 6. Inode preservation (unlike temp file replacement)
 
-// ==================== Basic Inplace Tests ====================
 
 #[test]
 fn execute_inplace_updates_file_directly() {
@@ -68,7 +67,6 @@ fn execute_inplace_creates_new_file_when_destination_missing() {
     assert_eq!(fs::read(&destination).expect("read dest"), b"brand new file");
 }
 
-// ==================== Inode Preservation Tests ====================
 
 #[cfg(unix)]
 #[test]
@@ -155,7 +153,6 @@ fn execute_without_inplace_changes_inode() {
     );
 }
 
-// ==================== No Temp File Tests ====================
 
 #[test]
 fn execute_inplace_does_not_leave_temp_files() {
@@ -193,7 +190,6 @@ fn execute_inplace_does_not_leave_temp_files() {
     );
 }
 
-// ==================== Partial Update Tests ====================
 
 #[test]
 fn execute_inplace_partial_update_small_to_large() {
@@ -257,7 +253,6 @@ fn execute_inplace_partial_update_large_to_small() {
     assert_eq!(fs::metadata(&destination).expect("metadata").len(), 4);
 }
 
-// ==================== Whole-File Transfer Tests ====================
 
 #[test]
 fn execute_inplace_with_whole_file_transfer() {
@@ -319,7 +314,6 @@ fn execute_inplace_with_whole_file_large_file() {
     assert_eq!(fs::read(&destination).expect("read dest"), large_content);
 }
 
-// ==================== Permission Preservation Tests ====================
 
 #[cfg(unix)]
 #[test]
@@ -395,7 +389,6 @@ fn execute_inplace_preserves_restricted_permissions() {
     assert_eq!(dest_perms.mode() & 0o777, 0o600);
 }
 
-// ==================== Timestamp Preservation Tests ====================
 
 #[test]
 fn execute_inplace_preserves_timestamps() {
@@ -432,7 +425,6 @@ fn execute_inplace_preserves_timestamps() {
     assert_eq!(dest_mtime, past_time);
 }
 
-// ==================== Edge Cases ====================
 
 #[test]
 fn execute_inplace_with_empty_source() {
@@ -521,7 +513,6 @@ fn execute_inplace_identical_files_skips_copy() {
     assert_eq!(summary.files_copied(), 0);
 }
 
-// ==================== Directory Tree Tests ====================
 
 #[test]
 fn execute_inplace_recursive_directory() {
@@ -563,7 +554,6 @@ fn execute_inplace_recursive_directory() {
     );
 }
 
-// ==================== Read-Only Directory Tests ====================
 
 #[cfg(unix)]
 #[test]
@@ -657,7 +647,6 @@ fn execute_without_inplace_fails_in_read_only_directory() {
     chmod(&dest_dir, restore).expect("restore directory");
 }
 
-// ==================== Combined Flag Tests ====================
 
 #[test]
 fn execute_inplace_combined_with_checksum() {
@@ -752,7 +741,6 @@ fn execute_inplace_combined_with_ignore_times() {
     assert_eq!(summary.files_copied(), 1);
 }
 
-// ==================== Binary Content Tests ====================
 
 #[test]
 fn execute_inplace_with_binary_content() {
@@ -782,7 +770,6 @@ fn execute_inplace_with_binary_content() {
     assert_eq!(fs::read(&destination).expect("read dest"), binary_content);
 }
 
-// ==================== Report/Events Tests ====================
 
 #[test]
 fn execute_inplace_records_copy_event() {
@@ -813,7 +800,6 @@ fn execute_inplace_records_copy_event() {
     assert_eq!(records[0].bytes_transferred(), 10);
 }
 
-// ==================== Delta Transfer with Inplace Tests ====================
 
 #[test]
 fn execute_inplace_with_delta_transfer_skips_matched_blocks() {
@@ -973,7 +959,6 @@ fn execute_inplace_with_delta_truncates_when_smaller() {
     );
 }
 
-// ==================== Dry Run Tests ====================
 
 #[test]
 fn execute_inplace_dry_run_does_not_modify() {

--- a/crates/engine/src/local_copy/tests/execute_log_file.rs
+++ b/crates/engine/src/local_copy/tests/execute_log_file.rs
@@ -11,7 +11,6 @@
 // 8. Transfers work with log_file set (verify file is created)
 // 9. Combination with other options
 
-// ==================== Default Tests ====================
 
 #[test]
 fn log_file_default_is_none() {
@@ -25,7 +24,6 @@ fn log_file_format_default_is_none() {
     assert!(opts.log_file_format().is_none());
 }
 
-// ==================== Setter Tests ====================
 
 #[test]
 fn log_file_with_log_file_sets_path() {
@@ -75,7 +73,6 @@ fn log_file_format_with_log_file_format_accepts_string() {
     assert_eq!(opts.log_file_format(), Some("%o %n"));
 }
 
-// ==================== Effective Log File Format Tests ====================
 
 #[test]
 fn log_file_effective_format_returns_default_when_not_set() {
@@ -97,7 +94,6 @@ fn log_file_effective_format_after_clear_returns_default() {
     assert_eq!(opts.effective_log_file_format(), "%i %n%L");
 }
 
-// ==================== Builder Support Tests ====================
 
 #[test]
 fn log_file_builder_sets_log_file() {
@@ -162,7 +158,6 @@ fn log_file_builder_unchecked_sets_values() {
     assert_eq!(opts.log_file_format(), Some("%o %n"));
 }
 
-// ==================== Round-Trip Tests ====================
 
 #[test]
 fn log_file_round_trip_via_builder() {
@@ -188,7 +183,6 @@ fn log_file_round_trip_via_setters() {
     assert_eq!(opts.effective_log_file_format(), "%o %n %b");
 }
 
-// ==================== Transfer with Log File Tests ====================
 
 #[test]
 fn log_file_transfer_works_with_log_file_set() {
@@ -290,7 +284,6 @@ fn log_file_transfer_multiple_files_with_log_file() {
     );
 }
 
-// ==================== Combination with Other Options ====================
 
 #[test]
 fn log_file_combined_with_delete() {
@@ -455,7 +448,6 @@ fn log_file_combined_with_builder_archive() {
     );
 }
 
-// ==================== Dry Run with Log File ====================
 
 #[test]
 fn log_file_dry_run_does_not_fail() {
@@ -486,7 +478,6 @@ fn log_file_dry_run_does_not_fail() {
     );
 }
 
-// ==================== Builder Defaults Match Direct Defaults ====================
 
 #[test]
 fn log_file_builder_defaults_match_options_defaults() {
@@ -504,7 +495,6 @@ fn log_file_builder_defaults_match_options_defaults() {
     );
 }
 
-// ==================== Config Propagation Tests ====================
 
 #[test]
 fn log_file_config_propagation_setter_and_builder_agree() {
@@ -542,7 +532,6 @@ fn log_file_effective_format_uses_default_percent_i_n_l() {
     assert_eq!(opts.effective_log_file_format(), "%i %n%L");
 }
 
-// ==================== Edge Case Tests ====================
 
 #[test]
 fn log_file_empty_format_string_is_stored() {

--- a/crates/engine/src/local_copy/tests/execute_max_delete.rs
+++ b/crates/engine/src/local_copy/tests/execute_max_delete.rs
@@ -14,7 +14,6 @@
 
 use super::filter_program::MAX_DELETE_EXIT_CODE;
 
-// ==================== Basic Max-Delete Limit Tests ====================
 
 #[test]
 fn max_delete_stops_after_n_deletions() {
@@ -143,7 +142,6 @@ fn max_delete_error_message_format() {
     );
 }
 
-// ==================== Edge Cases ====================
 
 #[test]
 fn max_delete_zero_prevents_all_deletions() {
@@ -369,7 +367,6 @@ fn max_delete_none_allows_unlimited_deletions() {
     }
 }
 
-// ==================== Interaction with Delete Timing Modes ====================
 
 #[test]
 fn max_delete_with_delete_during() {
@@ -516,7 +513,6 @@ fn max_delete_with_delete_delay() {
     }
 }
 
-// ==================== Dry-Run Behavior ====================
 
 #[test]
 fn max_delete_with_dry_run_reports_limit_exceeded() {
@@ -589,7 +585,6 @@ fn max_delete_dry_run_success_when_under_limit() {
     assert!(target_root.join("extra.txt").exists());
 }
 
-// ==================== Directory Deletion Tests ====================
 
 #[test]
 fn max_delete_counts_directory_deletions() {
@@ -665,7 +660,6 @@ fn max_delete_mixed_files_and_directories() {
     }
 }
 
-// ==================== No Deletions Needed ====================
 
 #[test]
 fn max_delete_no_effect_when_no_deletions_needed() {
@@ -728,7 +722,6 @@ fn max_delete_without_delete_flag_has_no_effect() {
     );
 }
 
-// ==================== Exit Code Tests ====================
 
 #[test]
 fn max_delete_exit_code_is_25() {
@@ -742,7 +735,6 @@ fn max_delete_error_code_name() {
     assert_eq!(error.code_name(), "RERR_DEL_LIMIT");
 }
 
-// ==================== Option Builder Tests ====================
 
 #[test]
 fn max_deletions_option_sets_correctly() {

--- a/crates/engine/src/local_copy/tests/execute_omit_dir_times.rs
+++ b/crates/engine/src/local_copy/tests/execute_omit_dir_times.rs
@@ -1,6 +1,4 @@
-// ============================================================================
 // Tests for --omit-dir-times flag
-// ============================================================================
 //
 // The --omit-dir-times flag prevents directory modification times from being
 // preserved, while still preserving file timestamps. This is useful for:

--- a/crates/engine/src/local_copy/tests/execute_one_file_system.rs
+++ b/crates/engine/src/local_copy/tests/execute_one_file_system.rs
@@ -525,7 +525,6 @@ fn one_file_system_with_symlinks_follows_on_same_fs() {
     assert!(summary.files_copied() >= 1);
 }
 
-// --- Double -xx (level 2) tests ---
 
 #[test]
 fn double_one_file_system_skips_root_source_that_is_mount_point() {

--- a/crates/engine/src/local_copy/tests/execute_special.rs
+++ b/crates/engine/src/local_copy/tests/execute_special.rs
@@ -357,7 +357,6 @@ fn execute_without_one_file_system_crosses_mount_points() {
     );
 }
 
-// ==================== Symlink Tests ====================
 
 #[cfg(unix)]
 #[test]
@@ -504,7 +503,6 @@ fn execute_with_safe_links_skips_unsafe() {
     }));
 }
 
-// ==================== Hard Link Tests ====================
 
 #[cfg(unix)]
 #[test]
@@ -581,7 +579,6 @@ fn execute_without_hard_links_copies_separately() {
     assert_eq!(summary.files_copied(), 2);
 }
 
-// ==================== Dry Run Special Tests ====================
 
 #[cfg(unix)]
 #[test]
@@ -638,7 +635,6 @@ fn execute_dry_run_does_not_create_fifo() {
     assert!(!dest_fifo.exists());
 }
 
-// ==================== Symlink Edge Cases ====================
 
 #[cfg(unix)]
 #[test]
@@ -668,7 +664,6 @@ fn execute_copies_broken_symlink() {
     assert_eq!(dest_target, Path::new("nonexistent_target"));
 }
 
-// ==================== Multiple Special Files Tests ====================
 
 #[cfg(unix)]
 #[test]
@@ -723,7 +718,6 @@ fn execute_copies_mixed_special_files() {
         .is_fifo());
 }
 
-// ==================== Symlink to Special File Tests ====================
 
 #[cfg(unix)]
 #[test]
@@ -833,7 +827,6 @@ fn execute_symlink_pointing_to_socket_preserved_as_symlink() {
     assert_eq!(summary.fifos_created(), 1);
 }
 
-// ==================== FIFO Replacement Tests ====================
 
 #[cfg(unix)]
 #[test]
@@ -985,7 +978,6 @@ fn execute_symlink_replaces_existing_socket() {
     assert_eq!(fs::read_link(&dest).expect("read link"), target);
 }
 
-// ==================== FIFO Idempotent Re-copy ====================
 
 #[cfg(unix)]
 #[test]
@@ -1020,7 +1012,6 @@ fn execute_recopy_fifo_replaces_existing_fifo() {
     assert_eq!(summary.fifos_created(), 1);
 }
 
-// ==================== Multiple FIFOs with Different Permissions ====================
 
 #[cfg(unix)]
 #[test]
@@ -1087,7 +1078,6 @@ fn execute_copies_multiple_fifos_with_different_permissions() {
     );
 }
 
-// ==================== Specials with Delete ====================
 
 #[cfg(unix)]
 #[test]
@@ -1127,7 +1117,6 @@ fn execute_delete_removes_extraneous_fifo() {
     assert!(summary.items_deleted() >= 1);
 }
 
-// ==================== Device File Skipped Without Proper Option ====================
 
 #[cfg(unix)]
 #[test]
@@ -1159,7 +1148,6 @@ fn execute_device_file_skipped_without_devices_or_copy_devices() {
     }));
 }
 
-// ==================== copy_links with Symlink to FIFO (specials disabled) ====================
 
 #[cfg(unix)]
 #[test]
@@ -1214,7 +1202,6 @@ fn execute_copy_links_follows_symlink_to_fifo_specials_disabled_skips() {
     }));
 }
 
-// ==================== copy_unsafe_links with Broken Unsafe Symlink ====================
 
 #[cfg(unix)]
 #[test]
@@ -1252,7 +1239,6 @@ fn execute_copy_unsafe_links_broken_target_errors() {
     assert!(!dest_dir.join("broken_unsafe").exists());
 }
 
-// ==================== copy_dirlinks in Directory Tree ====================
 
 #[cfg(unix)]
 #[test]
@@ -1322,7 +1308,6 @@ fn execute_copy_dirlinks_follows_dir_symlink_but_preserves_file_symlink_in_tree(
     );
 }
 
-// ==================== safe_links Combined with copy_dirlinks ====================
 
 #[cfg(unix)]
 #[test]
@@ -1387,7 +1372,6 @@ fn execute_safe_links_with_copy_dirlinks_follows_unsafe_dir_symlink() {
     );
 }
 
-// ==================== FIFO Events with Collect Events ====================
 
 #[cfg(unix)]
 #[test]
@@ -1421,7 +1405,6 @@ fn execute_fifo_produces_fifo_copied_event() {
     );
 }
 
-// ==================== copy_links with Symlink Pointing to Symlink to File ====================
 
 #[cfg(unix)]
 #[test]
@@ -1480,7 +1463,6 @@ fn execute_copy_links_follows_nested_symlink_chain_to_regular_file() {
     assert_eq!(summary.files_copied(), 3);
 }
 
-// ==================== copy_links Overrides links Option ====================
 
 #[cfg(unix)]
 #[test]
@@ -1528,7 +1510,6 @@ fn execute_copy_links_overrides_links_option() {
     assert_eq!(summary.symlinks_copied(), 0);
 }
 
-// ==================== Symlink Without links Option Skipped ====================
 
 #[cfg(unix)]
 #[test]
@@ -1570,7 +1551,6 @@ fn execute_without_links_skips_symlink_records_event() {
     }));
 }
 
-// ==================== Specials Combined with All Metadata Options ====================
 
 #[cfg(all(
     unix,
@@ -1647,7 +1627,6 @@ fn execute_fifo_with_archive_options_preserves_all_metadata() {
     assert_eq!(summary.files_copied(), 1);
 }
 
-// ==================== copy_unsafe_links Preserves Safe Symlink in Dir Tree ====================
 
 #[cfg(unix)]
 #[test]
@@ -1714,7 +1693,6 @@ fn execute_copy_unsafe_links_in_tree_preserves_safe_and_dereferences_unsafe() {
     assert_eq!(summary.files_copied(), 2); // inside.txt + dereferenced unsafe
 }
 
-// ==================== keep_dirlinks with Multiple Nested Symlink Directories ====================
 
 #[cfg(unix)]
 #[test]
@@ -1770,7 +1748,6 @@ fn execute_keep_dirlinks_multiple_symlink_subdirs_all_preserved() {
     assert_eq!(fs::read(real_beta.join("b.txt")).expect("read"), b"beta");
 }
 
-// ==================== Dry Run with Specials and Symlinks Together ====================
 
 #[cfg(all(
     unix,

--- a/crates/engine/src/local_copy/tests/execute_specials.rs
+++ b/crates/engine/src/local_copy/tests/execute_specials.rs
@@ -29,7 +29,6 @@ fn mksocket_for_tests(path: &Path) -> io::Result<()> {
     Ok(())
 }
 
-// ==================== Socket Single-Source Tests ====================
 
 #[cfg(all(
     unix,
@@ -142,7 +141,6 @@ fn execute_without_specials_records_socket_skip_event() {
     );
 }
 
-// ==================== Socket Metadata Preservation ====================
 
 #[cfg(all(
     unix,
@@ -231,7 +229,6 @@ fn execute_copies_socket_preserving_timestamps() {
     assert_eq!(dest_mtime, mtime, "socket mtime should be preserved");
 }
 
-// ==================== Socket Within Directory ====================
 
 #[cfg(all(
     unix,
@@ -276,7 +273,6 @@ fn execute_copies_socket_within_directory() {
     assert_eq!(summary.fifos_created(), 1);
 }
 
-// ==================== Mixed FIFOs and Sockets ====================
 
 // Socket creation in temp dirs requires elevated privileges on macOS.
 #[cfg(all(
@@ -400,7 +396,6 @@ fn execute_without_specials_skips_both_fifos_and_sockets() {
     );
 }
 
-// ==================== Archive Mode (--specials implied) ====================
 
 #[cfg(all(
     unix,
@@ -497,7 +492,6 @@ fn execute_archive_mode_copies_fifo_and_socket_together() {
     assert_eq!(summary.files_copied(), 1);
 }
 
-// ==================== Dry Run ====================
 
 #[cfg(all(
     unix,
@@ -536,7 +530,6 @@ fn execute_dry_run_does_not_create_socket() {
     assert!(!dest_socket.exists(), "dry run should not create the socket");
 }
 
-// ==================== Force Replacement ====================
 
 #[cfg(all(
     unix,
@@ -618,7 +611,6 @@ fn execute_socket_replaces_regular_file() {
     );
 }
 
-// ==================== Socket Hard Link Preservation ====================
 
 #[cfg(all(
     unix,
@@ -675,7 +667,6 @@ fn execute_preserves_socket_hard_links() {
     );
 }
 
-// ==================== Specials with Delete ====================
 
 #[cfg(all(
     unix,
@@ -723,7 +714,6 @@ fn execute_delete_removes_extraneous_socket() {
     assert!(summary.items_deleted() >= 1);
 }
 
-// ==================== Specials Disabled Does Not Delete Specials ====================
 
 #[cfg(all(
     unix,
@@ -771,7 +761,6 @@ fn execute_without_specials_with_delete_does_not_delete_socket_from_keep_list() 
     assert_eq!(summary.fifos_created(), 0);
 }
 
-// ==================== Specials with Collect Events ====================
 
 #[cfg(all(
     unix,
@@ -813,7 +802,6 @@ fn execute_socket_produces_fifo_copied_event() {
     );
 }
 
-// ==================== Socket Idempotent Re-copy ====================
 
 #[cfg(all(
     unix,
@@ -854,7 +842,6 @@ fn execute_recopy_socket_replaces_existing_socket() {
     assert_eq!(summary.fifos_created(), 1);
 }
 
-// ==================== Specials with Symlinks ====================
 
 #[cfg(all(
     unix,
@@ -915,7 +902,6 @@ fn execute_copies_socket_and_symlink_together() {
     assert_eq!(summary.files_copied(), 1);
 }
 
-// ==================== Options Builder Tests ====================
 
 #[test]
 fn options_specials_enabled_returns_false_by_default() {

--- a/crates/engine/src/local_copy/tests/execute_symlink_edge_cases.rs
+++ b/crates/engine/src/local_copy/tests/execute_symlink_edge_cases.rs
@@ -8,7 +8,6 @@
 // - Self-referencing symlinks
 // - Permission handling for symlinks
 
-// ==================== Absolute vs Relative Symlink Targets ====================
 
 #[cfg(unix)]
 #[test]
@@ -128,7 +127,6 @@ fn symlink_complex_relative_path_with_dotdot() {
     assert!(dest_link.exists(), "symlink should resolve to target in dest");
 }
 
-// ==================== Broken Symlinks ====================
 
 #[cfg(unix)]
 #[test]
@@ -242,7 +240,6 @@ fn broken_symlink_becomes_valid_when_target_copied() {
     assert_eq!(fs::read(&dest_link).expect("read via link"), b"content");
 }
 
-// ==================== Symlink Chains ====================
 
 #[cfg(unix)]
 #[test]
@@ -385,7 +382,6 @@ fn symlink_chain_across_directories() {
     assert_eq!(fs::read(&dest_link2).expect("read content"), b"content");
 }
 
-// ==================== Symlinks Pointing Outside the Tree ====================
 
 #[cfg(unix)]
 #[test]
@@ -509,7 +505,6 @@ fn symlink_escapes_but_copy_unsafe_links_dereferences() {
     assert_eq!(summary.files_copied(), 1);
 }
 
-// ==================== Self-Referencing and Circular Symlinks ====================
 
 #[cfg(unix)]
 #[test]
@@ -630,7 +625,6 @@ fn three_way_symlink_cycle() {
     assert_eq!(summary.symlinks_copied(), 3);
 }
 
-// ==================== Permission Handling for Symlinks ====================
 
 #[cfg(unix)]
 #[test]
@@ -762,7 +756,6 @@ fn symlink_omit_link_times_option() {
     assert!(dest_link.exists());
 }
 
-// ==================== Edge Cases with Special Characters ====================
 
 #[cfg(unix)]
 #[test]
@@ -870,7 +863,6 @@ fn symlink_target_with_newline() {
     );
 }
 
-// ==================== Symlink to . and .. ====================
 
 #[cfg(unix)]
 #[test]
@@ -939,7 +931,6 @@ fn symlink_to_parent_within_safe_boundary() {
     assert_eq!(fs::read_link(&dest_link).expect("read"), Path::new(".."));
 }
 
-// ==================== Hard Links to Symlinks ====================
 
 #[cfg(unix)]
 #[test]
@@ -1000,7 +991,6 @@ fn hard_link_to_symlink_preserved() {
     assert_eq!(summary.symlinks_copied(), 2);
 }
 
-// ==================== Symlink Size Handling ====================
 
 #[cfg(unix)]
 #[test]

--- a/crates/engine/src/local_copy/tests/execute_symlinks.rs
+++ b/crates/engine/src/local_copy/tests/execute_symlinks.rs
@@ -291,7 +291,6 @@ fn execute_preserves_symlink_hard_links() {
     assert_eq!(summary.symlinks_copied(), 2);
 }
 
-// ==================== Safe Links Tests ====================
 
 #[cfg(unix)]
 #[test]
@@ -882,7 +881,6 @@ fn safe_links_disabled_allows_all_symlinks() {
     assert!(fs::symlink_metadata(dest_root.join("escape_link")).is_ok());
 }
 
-// ==================== --copy-unsafe-links Tests ====================
 
 #[cfg(unix)]
 #[test]

--- a/crates/engine/src/local_copy/tests/execute_temp_dir.rs
+++ b/crates/engine/src/local_copy/tests/execute_temp_dir.rs
@@ -7,7 +7,6 @@
 // 4. Atomic rename semantics
 // 5. Comparison with upstream rsync behavior
 
-// ==================== Basic Temp Dir Placement Tests ====================
 
 #[test]
 fn execute_with_temp_dir_places_temp_files_in_specified_directory() {
@@ -117,7 +116,6 @@ fn execute_with_temp_dir_same_filesystem_uses_atomic_rename() {
     assert_eq!(fs::read(&destination).expect("read dest"), large_content);
 }
 
-// ==================== Cross-filesystem Tests ====================
 
 #[cfg(unix)]
 #[test]
@@ -161,7 +159,6 @@ fn execute_with_temp_dir_different_filesystem_falls_back_to_copy() {
     assert_eq!(fs::read(&destination).expect("read dest"), content);
 }
 
-// ==================== Multiple Files Tests ====================
 
 #[test]
 fn execute_with_temp_dir_handles_multiple_files() {
@@ -211,7 +208,6 @@ fn execute_with_temp_dir_handles_multiple_files() {
     assert!(staging_files.is_empty(), "no temp files should remain");
 }
 
-// ==================== Nested Directory Tests ====================
 
 #[test]
 fn execute_with_temp_dir_handles_nested_directories() {
@@ -265,7 +261,6 @@ fn execute_with_temp_dir_handles_nested_directories() {
     assert!(staging_files.is_empty());
 }
 
-// ==================== Absolute Temp Dir Path Tests ====================
 
 #[test]
 fn execute_with_absolute_temp_dir_path() {
@@ -300,7 +295,6 @@ fn execute_with_absolute_temp_dir_path() {
     );
 }
 
-// ==================== Temp Dir with Existing Files Tests ====================
 
 #[test]
 fn execute_with_temp_dir_replaces_existing_destination() {
@@ -332,7 +326,6 @@ fn execute_with_temp_dir_replaces_existing_destination() {
     assert_eq!(fs::read(&destination).expect("read dest"), b"new content");
 }
 
-// ==================== Empty File Tests ====================
 
 #[test]
 fn execute_with_temp_dir_handles_empty_file() {
@@ -362,7 +355,6 @@ fn execute_with_temp_dir_handles_empty_file() {
     assert_eq!(fs::metadata(&destination).expect("metadata").len(), 0);
 }
 
-// ==================== Large File Tests ====================
 
 #[test]
 fn execute_with_temp_dir_handles_large_file() {
@@ -401,7 +393,6 @@ fn execute_with_temp_dir_handles_large_file() {
     assert!(staging_files.is_empty());
 }
 
-// ==================== Temp Dir with Metadata Preservation ====================
 
 #[cfg(unix)]
 #[test]
@@ -474,7 +465,6 @@ fn execute_with_temp_dir_preserves_modification_time() {
     assert_eq!(dest_mtime, past_time);
 }
 
-// ==================== Temp Dir Nonexistent Tests ====================
 
 #[test]
 fn execute_with_nonexistent_temp_dir_fails() {
@@ -506,7 +496,6 @@ fn execute_with_nonexistent_temp_dir_fails() {
     );
 }
 
-// ==================== Combination with Other Options ====================
 
 #[test]
 fn execute_with_temp_dir_and_partial_mode() {
@@ -574,7 +563,6 @@ fn execute_with_temp_dir_and_delay_updates() {
     );
 }
 
-// ==================== Dry Run with Temp Dir ====================
 
 #[test]
 fn execute_dry_run_with_temp_dir_does_not_create_files() {
@@ -610,7 +598,6 @@ fn execute_dry_run_with_temp_dir_does_not_create_files() {
     assert!(staging_files.is_empty(), "no temp files in dry run");
 }
 
-// ==================== Inplace Mode with Temp Dir ====================
 
 #[test]
 fn execute_inplace_mode_ignores_temp_dir() {
@@ -653,7 +640,6 @@ fn execute_inplace_mode_ignores_temp_dir() {
     assert!(staging_files.is_empty());
 }
 
-// ==================== Temp Dir Cleanup on Success ====================
 
 #[test]
 fn execute_with_temp_dir_cleans_up_on_successful_multi_file_transfer() {
@@ -704,7 +690,6 @@ fn execute_with_temp_dir_cleans_up_on_successful_multi_file_transfer() {
     );
 }
 
-// ==================== Temp Dir Path with Spaces ====================
 
 #[test]
 fn execute_with_temp_dir_containing_spaces() {
@@ -736,7 +721,6 @@ fn execute_with_temp_dir_containing_spaces() {
     );
 }
 
-// ==================== Temp Dir with Special Characters ====================
 
 #[test]
 fn execute_with_temp_dir_containing_special_chars() {
@@ -765,7 +749,6 @@ fn execute_with_temp_dir_containing_special_chars() {
     assert_eq!(fs::read(&destination).expect("read dest"), b"special chars");
 }
 
-// ==================== Atomic Semantics Verification ====================
 
 #[test]
 fn execute_with_temp_dir_provides_atomic_destination_update() {
@@ -803,7 +786,6 @@ fn execute_with_temp_dir_provides_atomic_destination_update() {
     assert_eq!(final_content, new_content);
 }
 
-// ==================== Temp Dir with Delete Option ====================
 
 #[test]
 fn execute_with_temp_dir_and_delete_removes_extraneous() {
@@ -842,7 +824,6 @@ fn execute_with_temp_dir_and_delete_removes_extraneous() {
     );
 }
 
-// ==================== Default Behavior (No Temp Dir) ====================
 
 #[test]
 fn execute_without_temp_dir_creates_temps_alongside_destination() {
@@ -880,7 +861,6 @@ fn execute_without_temp_dir_creates_temps_alongside_destination() {
     );
 }
 
-// ==================== Temp File Name Format Tests ====================
 
 #[test]
 fn execute_with_temp_dir_uses_upstream_temp_prefix() {
@@ -934,7 +914,6 @@ fn execute_with_temp_dir_format_in_custom_directory() {
     );
 }
 
-// ==================== Temp Dir with Whole File Transfer ====================
 
 #[test]
 fn execute_with_temp_dir_and_whole_file_mode() {
@@ -975,7 +954,6 @@ fn execute_with_temp_dir_and_whole_file_mode() {
     assert!(staging_files.is_empty());
 }
 
-// ==================== Options Round-Trip Tests ====================
 
 #[test]
 fn temp_dir_option_round_trip_via_builder() {
@@ -1016,7 +994,6 @@ fn temp_dir_option_does_not_affect_partial_mode() {
     );
 }
 
-// ==================== Binary Content Integrity ====================
 
 #[test]
 fn execute_with_temp_dir_preserves_binary_content_exactly() {
@@ -1051,7 +1028,6 @@ fn execute_with_temp_dir_preserves_binary_content_exactly() {
     );
 }
 
-// ==================== Idempotent Transfer with Temp Dir ====================
 
 #[test]
 fn execute_with_temp_dir_second_run_skips_identical_files() {
@@ -1099,7 +1075,6 @@ fn execute_with_temp_dir_second_run_skips_identical_files() {
     );
 }
 
-// ==================== Temp Dir Interaction with Checksum ====================
 
 #[test]
 fn execute_with_temp_dir_and_checksum_mode() {
@@ -1133,7 +1108,6 @@ fn execute_with_temp_dir_and_checksum_mode() {
     );
 }
 
-// ==================== Concurrent Unique Temp Files ====================
 
 #[test]
 fn execute_with_temp_dir_unique_temp_names_across_files() {
@@ -1167,7 +1141,6 @@ fn execute_with_temp_dir_unique_counter_per_file() {
     );
 }
 
-// ==================== Temp Dir with Backup Mode ====================
 
 #[test]
 fn execute_with_temp_dir_and_backup() {
@@ -1214,7 +1187,6 @@ fn execute_with_temp_dir_and_backup() {
     );
 }
 
-// ==================== Temp Dir with Nested Source and Flat Staging ====================
 
 #[test]
 fn execute_with_temp_dir_nested_source_uses_flat_staging() {

--- a/crates/engine/src/local_copy/tests/execute_timestamp_preservation.rs
+++ b/crates/engine/src/local_copy/tests/execute_timestamp_preservation.rs
@@ -1,6 +1,4 @@
-// ============================================================================
 // Tests for timestamp preservation behavior
-// ============================================================================
 //
 // This test module covers comprehensive timestamp preservation functionality:
 // - mtime preservation (modification time)

--- a/crates/engine/src/local_copy/tests/execute_xattrs.rs
+++ b/crates/engine/src/local_copy/tests/execute_xattrs.rs
@@ -24,7 +24,6 @@ mod xattr_tests {
         }
     }
 
-    // ==================== Basic xattr Preservation Tests ====================
 
     #[test]
     fn execute_copies_file_with_single_xattr() {
@@ -92,7 +91,6 @@ mod xattr_tests {
         assert!(dest_xattr.is_none(), "xattr should not be copied without --xattrs");
     }
 
-    // ==================== Multiple xattrs Tests ====================
 
     #[test]
     fn execute_copies_multiple_xattrs_on_same_file() {
@@ -196,7 +194,6 @@ mod xattr_tests {
         }
     }
 
-    // ==================== Large xattr Value Tests ====================
 
     #[test]
     fn execute_copies_large_xattr_value() {
@@ -311,7 +308,6 @@ mod xattr_tests {
         assert!(copied.is_empty());
     }
 
-    // ==================== xattr on Directories Tests ====================
 
     #[test]
     fn execute_copies_xattr_on_directory() {
@@ -454,7 +450,6 @@ mod xattr_tests {
         );
     }
 
-    // ==================== xattr Update/Sync Tests ====================
 
     #[test]
     fn execute_updates_existing_xattr_value() {
@@ -589,7 +584,6 @@ mod xattr_tests {
         );
     }
 
-    // ==================== xattr Filter Tests ====================
 
     #[test]
     fn execute_xattr_filter_excludes_specific_attrs() {
@@ -705,7 +699,6 @@ mod xattr_tests {
         );
     }
 
-    // ==================== Dry Run Tests ====================
 
     #[test]
     fn execute_dry_run_does_not_copy_xattrs() {
@@ -739,7 +732,6 @@ mod xattr_tests {
         assert!(!destination.exists(), "dry run should not create file");
     }
 
-    // ==================== Edge Cases ====================
 
     #[test]
     fn execute_handles_special_characters_in_xattr_name() {
@@ -925,7 +917,6 @@ mod xattr_tests {
         );
     }
 
-    // ==================== Symlink xattr Tests ====================
 
     #[cfg(unix)]
     #[test]

--- a/crates/engine/src/local_copy/tests/mod.rs
+++ b/crates/engine/src/local_copy/tests/mod.rs
@@ -206,8 +206,6 @@ mod test_helpers {
     use std::path::{Path, PathBuf};
     use tempfile::TempDir;
 
-    // ==================== Test Context ====================
-
     /// Test context for copy operations.
     ///
     /// This structure provides a self-contained test environment with:
@@ -311,8 +309,6 @@ mod test_helpers {
         }
     }
 
-    // ==================== Setup Functions ====================
-
     /// Creates a test context with temporary directory and source/dest paths.
     ///
     /// The source directory is created automatically. The dest directory is not
@@ -359,8 +355,6 @@ mod test_helpers {
         std::fs::create_dir_all(&reference).expect("create reference");
         (ctx, reference)
     }
-
-    // ==================== Tree Creation ====================
 
     /// Creates a directory tree for testing.
     ///
@@ -430,8 +424,6 @@ mod test_helpers {
         let mtime = FileTime::from_unix_time(mtime_unix, 0);
         filetime::set_file_times(path, atime, mtime).expect("set times");
     }
-
-    // ==================== Unix-specific Helpers ====================
 
     /// Creates a symbolic link (Unix only).
     #[cfg(unix)]
@@ -510,8 +502,6 @@ mod test_helpers {
         std::fs::metadata(path).expect("metadata").nlink()
     }
 
-    // ==================== Timestamp Helpers ====================
-
     /// A commonly used timestamp for tests (roughly 2023-11-14).
     pub const TEST_TIMESTAMP: i64 = 1_700_000_000;
 
@@ -549,8 +539,6 @@ mod test_helpers {
     pub fn get_mtime(path: &Path) -> FileTime {
         FileTime::from_last_modification_time(&std::fs::metadata(path).expect("metadata"))
     }
-
-    // ==================== Assertion Helpers ====================
 
     /// Asserts that a file exists at the given path.
     #[allow(dead_code)]
@@ -721,8 +709,6 @@ mod test_helpers {
         );
     }
 
-    // ==================== Summary Assertion Helpers ====================
-
     /// Builder for asserting copy summary statistics.
     ///
     /// # Example
@@ -879,8 +865,6 @@ mod test_helpers {
             }
         }
     }
-
-    // ==================== Options Builder Helpers ====================
 
     /// Common option presets for tests.
     pub mod presets {

--- a/crates/engine/src/local_copy/tests/partial_dir.rs
+++ b/crates/engine/src/local_copy/tests/partial_dir.rs
@@ -12,7 +12,6 @@
 // 5. Works correctly with nested directory structures
 // 6. Behavior matches upstream rsync
 
-// ==================== Basic Partial Dir Placement Tests ====================
 
 #[test]
 fn partial_dir_places_partial_file_in_specified_directory() {
@@ -154,7 +153,6 @@ fn partial_dir_preserves_partial_file_on_discard() {
     );
 }
 
-// ==================== Nested Directory Tests ====================
 
 #[test]
 fn partial_dir_works_with_nested_source_directories() {
@@ -248,7 +246,6 @@ fn partial_dir_handles_multiple_files_in_nested_directories() {
     );
 }
 
-// ==================== Absolute Path Partial Dir Tests ====================
 
 #[test]
 fn partial_dir_supports_absolute_path() {
@@ -314,7 +311,6 @@ fn partial_dir_absolute_path_preserves_partial_on_discard() {
     );
 }
 
-// ==================== Partial Dir with Relative Path Components Tests ====================
 
 #[test]
 fn partial_dir_relative_to_destination_directory() {
@@ -353,7 +349,6 @@ fn partial_dir_relative_to_destination_directory() {
     assert!(destination.exists());
 }
 
-// ==================== Edge Cases Tests ====================
 
 #[test]
 fn partial_dir_handles_empty_file() {
@@ -452,7 +447,6 @@ fn partial_dir_overwrites_existing_partial_file() {
     guard.discard();
 }
 
-// ==================== Comparison with Non-Partial Mode Tests ====================
 
 #[test]
 fn partial_dir_differs_from_non_partial_behavior() {
@@ -490,7 +484,6 @@ fn partial_dir_differs_from_non_partial_behavior() {
     assert!(!staging2.exists(), "non-partial mode should remove file");
 }
 
-// ==================== Special Characters in Path Tests ====================
 
 #[test]
 fn partial_dir_handles_special_characters_in_filename() {
@@ -525,7 +518,6 @@ fn partial_dir_handles_special_characters_in_filename() {
     );
 }
 
-// ==================== Integration with Other Options Tests ====================
 
 #[test]
 fn partial_dir_with_times_preservation() {
@@ -602,7 +594,6 @@ fn partial_dir_with_permissions_preservation() {
     assert_eq!(dest_perms.mode() & 0o777, 0o640);
 }
 
-// ==================== Dry Run Tests ====================
 
 #[test]
 fn partial_dir_dry_run_does_not_create_directory() {
@@ -638,7 +629,6 @@ fn partial_dir_dry_run_does_not_create_directory() {
     // The test documents expected behavior - partial dir should NOT be created
 }
 
-// ==================== Option Interaction Tests ====================
 
 #[test]
 fn partial_dir_setting_enables_partial_flag() {
@@ -668,7 +658,6 @@ fn partial_dir_can_be_cleared_after_setting() {
     assert!(opts.partial_directory_path().is_none());
 }
 
-// ==================== Delete + Partial Dir Interaction Tests ====================
 //
 // Upstream rsync protects the partial-dir from deletion when --delete is used
 // with --partial-dir. This prevents --delete from removing the directory that
@@ -978,7 +967,6 @@ fn partial_dir_delete_with_dry_run_does_not_modify_anything() {
     );
 }
 
-// ==================== Partial Dir Resume Workflow Tests ====================
 
 #[test]
 fn partial_dir_find_basis_locates_existing_partial_for_resume() {
@@ -1078,7 +1066,6 @@ fn partial_dir_full_resume_workflow() {
     );
 }
 
-// ==================== Partial Dir with Multiple Transfer Directories ====================
 
 #[test]
 fn partial_dir_relative_path_independent_per_directory() {
@@ -1155,7 +1142,6 @@ fn partial_dir_absolute_path_shared_across_directories() {
     assert_eq!(basis_b, Some(shared_partial.join("common.txt")));
 }
 
-// ==================== Partial Dir Guard Behavior Tests ====================
 
 #[test]
 fn partial_dir_guard_staging_path_is_inside_partial_dir() {
@@ -1273,7 +1259,6 @@ fn partial_dir_guard_discard_preserves_for_later_resume() {
     );
 }
 
-// ==================== Edge Cases: Partial Dir Names ====================
 
 #[test]
 fn partial_dir_with_deeply_nested_relative_path() {
@@ -1424,7 +1409,6 @@ fn partial_dir_empty_partial_dir_survives_delete() {
     );
 }
 
-// ==================== Integration: Partial Dir + Copy Workflow ====================
 
 #[test]
 fn partial_dir_successful_copy_creates_and_uses_partial_dir() {

--- a/crates/engine/src/local_copy/tests/permission_errors.rs
+++ b/crates/engine/src/local_copy/tests/permission_errors.rs
@@ -1,6 +1,4 @@
-// =============================================================================
 // Permission Denied Error Handling Tests
-// =============================================================================
 //
 // This module contains comprehensive tests for permission denied error handling
 // during local copy operations. Tests cover:

--- a/crates/logging-sink/src/syslog.rs
+++ b/crates/logging-sink/src/syslog.rs
@@ -505,8 +505,6 @@ mod tests {
         assert!(debug.contains(DEFAULT_SYSLOG_TAG));
     }
 
-    // --- SyslogConfig::open tests ---
-
     #[test]
     fn open_does_not_panic_with_default_config() {
         let config = SyslogConfig::default();

--- a/crates/protocol/src/acl/definition/tests.rs
+++ b/crates/protocol/src/acl/definition/tests.rs
@@ -7,8 +7,6 @@ use crate::acl::entry::{IdAccess, RsyncAcl};
 use crate::varint::write_varint;
 use std::io::Cursor;
 
-// --- AclPerms tests ---
-
 #[test]
 fn perms_from_bits_masks_to_three_bits() {
     assert_eq!(AclPerms::from_bits(0xFF).bits(), 0x07);
@@ -43,8 +41,6 @@ fn perms_display() {
     assert_eq!(format!("{}", AclPerms::from_bits(1)), "--x");
 }
 
-// --- AclTag tests ---
-
 #[test]
 fn tag_equality() {
     assert_eq!(AclTag::UserObj, AclTag::UserObj);
@@ -61,16 +57,12 @@ fn tag_debug_format() {
     assert!(format!("{:?}", AclTag::Group(100)).contains("Group"));
 }
 
-// --- AclEntry tests ---
-
 #[test]
 fn entry_construction() {
     let entry = AclEntry::new(AclTag::UserObj, AclPerms::from_bits(7));
     assert_eq!(entry.tag, AclTag::UserObj);
     assert_eq!(entry.perms.bits(), 7);
 }
-
-// --- AclDefinition tests ---
 
 #[test]
 fn empty_definition() {
@@ -162,8 +154,6 @@ fn definition_into_iterator_owned() {
     let entries: Vec<_> = def.into_iter().collect();
     assert_eq!(entries.len(), 3);
 }
-
-// --- Wire parsing tests ---
 
 /// Helper: builds wire bytes for a flags-only ACL (no entries).
 fn wire_empty_acl() -> Vec<u8> {
@@ -361,8 +351,6 @@ fn read_acl_all_permission_combinations() {
     }
 }
 
-// --- EOF error tests ---
-
 #[test]
 fn read_eof_on_flags() {
     let data: Vec<u8> = vec![];
@@ -404,8 +392,6 @@ fn read_eof_on_ida_count() {
     let mut cursor = Cursor::new(data);
     assert!(read_acl_definition(&mut cursor).is_err());
 }
-
-// --- Roundtrip tests ---
 
 #[test]
 fn roundtrip_empty_acl() {

--- a/crates/protocol/src/envelope/tests/message_code_comprehensive.rs
+++ b/crates/protocol/src/envelope/tests/message_code_comprehensive.rs
@@ -10,10 +10,8 @@
 use super::*;
 use std::collections::HashMap;
 
-// ============================================================================
 // Wire Format Compatibility Tests
 // These tests verify that our message codes match upstream rsync's exact values
-// ============================================================================
 
 /// Verifies that all message codes have the exact numeric values expected by
 /// upstream rsync 3.4.1. These values are defined in rsync.h and must match

--- a/crates/protocol/src/flist/incremental/tests.rs
+++ b/crates/protocol/src/flist/incremental/tests.rs
@@ -205,8 +205,6 @@ fn test_multiple_pending_directories() {
     assert_eq!(incremental.pending_count(), 1);
 }
 
-// --- Orphan finalization tests ---
-
 #[test]
 fn test_finalize_no_orphans() {
     let mut incremental = IncrementalFileList::new();

--- a/crates/protocol/src/multiplex/io/tests.rs
+++ b/crates/protocol/src/multiplex/io/tests.rs
@@ -6,8 +6,6 @@ use super::super::frame::MessageFrame;
 use super::send::write_all_vectored;
 use super::{recv_msg, send_frame, send_msg, send_msgs_vectored};
 
-// ==================== send_msg tests ====================
-
 #[test]
 fn send_msg_empty_payload() {
     let mut buffer = Vec::new();
@@ -47,8 +45,6 @@ fn send_msg_encodes_payload_length() {
     let header = MessageHeader::decode(&buffer[..HEADER_LEN]).unwrap();
     assert_eq!(header.payload_len_usize(), 1000);
 }
-
-// ==================== recv_msg tests ====================
 
 #[test]
 fn recv_msg_empty_payload() {
@@ -107,8 +103,6 @@ fn recv_msg_truncated_header_returns_error() {
     assert!(result.is_err());
 }
 
-// ==================== recv_msg_into tests ====================
-
 #[test]
 fn recv_msg_into_reuses_buffer() {
     let payload = b"buffer reuse test";
@@ -150,8 +144,6 @@ fn recv_msg_into_empty_payload() {
     assert!(recv_buffer.is_empty());
 }
 
-// ==================== send_frame tests ====================
-
 #[test]
 fn send_frame_matches_send_msg() {
     let payload = b"frame test";
@@ -173,8 +165,6 @@ fn send_frame_empty_payload() {
     send_frame(&mut buffer, &frame).unwrap();
     assert_eq!(buffer.len(), HEADER_LEN);
 }
-
-// ==================== roundtrip tests ====================
 
 #[test]
 fn roundtrip_preserves_message() {
@@ -224,8 +214,6 @@ fn roundtrip_large_payload() {
     assert_eq!(frame.payload(), large_payload.as_slice());
 }
 
-// ==================== write_all_vectored tests ====================
-
 #[test]
 fn write_all_vectored_empty_slices() {
     let mut buffer = Vec::new();
@@ -257,8 +245,6 @@ fn write_all_vectored_both_slices() {
     write_all_vectored(&mut buffer, header, payload).unwrap();
     assert_eq!(buffer, b"HEADERPAYLOAD".as_slice());
 }
-
-// ==================== send_msgs_vectored tests ====================
 
 #[test]
 fn send_msgs_vectored_empty() {
@@ -539,8 +525,6 @@ fn send_msgs_vectored_all_message_codes() {
         assert_eq!(frame.payload(), payload);
     }
 }
-
-// ==================== Additional edge case tests ====================
 
 #[test]
 fn send_msgs_vectored_single_empty_message() {

--- a/crates/protocol/src/negotiation/sniffer/legacy.rs
+++ b/crates/protocol/src/negotiation/sniffer/legacy.rs
@@ -138,8 +138,6 @@ mod tests {
         sniffer
     }
 
-    // ==================== read_legacy_daemon_line tests ====================
-
     #[test]
     fn read_legacy_daemon_line_complete_in_buffer() {
         // Complete greeting already buffered
@@ -244,8 +242,6 @@ mod tests {
         assert_eq!(result.unwrap_err().kind(), io::ErrorKind::UnexpectedEof);
     }
 
-    // ==================== read_and_parse_legacy_daemon_greeting tests ====================
-
     #[test]
     fn read_and_parse_greeting_version_31() {
         let data = b"@RSYNCD: 31.0\n";
@@ -300,8 +296,6 @@ mod tests {
         assert!(result.is_err());
     }
 
-    // ==================== read_and_parse_legacy_daemon_greeting_details tests ====================
-
     #[test]
     fn read_and_parse_greeting_details_basic() {
         let data = b"@RSYNCD: 31.0\n";
@@ -331,8 +325,6 @@ mod tests {
         // Should have checksum digests
         assert!(greeting.digest_list().is_some());
     }
-
-    // ==================== LegacyBufferReserveError tests ====================
 
     #[test]
     fn legacy_buffer_reserve_error_debug() {

--- a/crates/protocol/src/version/protocol_version/conversions.rs
+++ b/crates/protocol/src/version/protocol_version/conversions.rs
@@ -15,9 +15,7 @@ use super::super::constants::UPSTREAM_PROTOCOL_RANGE;
 use super::super::parse::{ParseProtocolVersionError, ParseProtocolVersionErrorKind};
 use super::ProtocolVersion;
 
-// ---------------------------------------------------------------------------
 // From<ProtocolVersion> for primitive types
-// ---------------------------------------------------------------------------
 
 impl From<ProtocolVersion> for u8 {
     #[inline]
@@ -122,9 +120,7 @@ impl_from_protocol_version_for_nonzero_signed!(
     NonZeroIsize => isize,
 );
 
-// ---------------------------------------------------------------------------
 // TryFrom implementations
-// ---------------------------------------------------------------------------
 
 impl TryFrom<u8> for ProtocolVersion {
     type Error = NegotiationError;
@@ -146,9 +142,7 @@ impl TryFrom<NonZeroU8> for ProtocolVersion {
     }
 }
 
-// ---------------------------------------------------------------------------
 // FromStr
-// ---------------------------------------------------------------------------
 
 impl FromStr for ProtocolVersion {
     type Err = ParseProtocolVersionError;
@@ -206,9 +200,7 @@ impl FromStr for ProtocolVersion {
     }
 }
 
-// ---------------------------------------------------------------------------
 // Display
-// ---------------------------------------------------------------------------
 
 impl fmt::Display for ProtocolVersion {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -216,9 +208,7 @@ impl fmt::Display for ProtocolVersion {
     }
 }
 
-// ---------------------------------------------------------------------------
 // PartialEq cross-type comparisons
-// ---------------------------------------------------------------------------
 
 impl PartialEq<u8> for ProtocolVersion {
     fn eq(&self, other: &u8) -> bool {

--- a/crates/protocol/src/version/protocol_version/mod.rs
+++ b/crates/protocol/src/version/protocol_version/mod.rs
@@ -65,9 +65,7 @@ use super::iter::{SupportedProtocolNumbersIter, SupportedVersionsIter};
 #[cfg_attr(feature = "serde", serde(transparent))]
 pub struct ProtocolVersion(NonZeroU8);
 
-// ---------------------------------------------------------------------------
 // Supported protocol declarations (macro-generated constants)
-// ---------------------------------------------------------------------------
 
 macro_rules! declare_supported_protocols {
     ($($ver:literal),+ $(,)?) => {
@@ -118,9 +116,7 @@ pub const SUPPORTED_PROTOCOL_BITMAP: u64 = {
     bitmap
 };
 
-// ---------------------------------------------------------------------------
 // Core impl block: constructors, accessors, supported-protocol queries
-// ---------------------------------------------------------------------------
 
 impl ProtocolVersion {
     pub(crate) const fn new_const(value: u8) -> Self {

--- a/crates/protocol/src/wire/compressed_token/tests.rs
+++ b/crates/protocol/src/wire/compressed_token/tests.rs
@@ -1076,7 +1076,6 @@ fn dictionary_sync_across_multiple_blocks() {
 fn dictionary_sync_across_file_boundaries() {
     let block_data = b"shared block data used in both files for dictionary sync";
 
-    // ---- File 1 ----
     let mut encoded_1 = Vec::new();
     let mut encoder = CompressedTokenEncoder::new(CompressionLevel::Default, 31);
 
@@ -1126,7 +1125,6 @@ fn dictionary_sync_across_file_boundaries() {
     .concat();
     assert_eq!(file1_combined, file1_expected);
 
-    // ---- File 2 (reset and reuse) ----
     encoder.reset();
     decoder.reset();
 

--- a/crates/protocol/src/xattr/entry.rs
+++ b/crates/protocol/src/xattr/entry.rs
@@ -210,8 +210,6 @@ mod tests {
         assert_eq!(entry.state(), XattrState::Done);
     }
 
-    // ==================== Additional Comprehensive Tests ====================
-
     #[test]
     fn xattr_state_needs_request_only_for_abbrev() {
         assert!(XattrState::Abbrev.needs_request());

--- a/crates/protocol/src/xattr/list.rs
+++ b/crates/protocol/src/xattr/list.rs
@@ -198,8 +198,6 @@ mod tests {
         assert!(list.find_by_name(b"user.missing").is_none());
     }
 
-    // ==================== Additional Comprehensive Tests ====================
-
     #[test]
     fn list_default_is_empty() {
         let list = XattrList::default();

--- a/crates/rsync_io/src/ssh/tests.rs
+++ b/crates/rsync_io/src/ssh/tests.rs
@@ -1339,8 +1339,6 @@ fn no_aes_gcm_injection_when_all_conditions_fail() {
     );
 }
 
-// --- ConnectTimeout injection tests ---
-
 #[test]
 fn connect_timeout_injected_by_default() {
     let command = SshCommand::new("example.com");

--- a/crates/transfer/src/delta_pipeline.rs
+++ b/crates/transfer/src/delta_pipeline.rs
@@ -594,8 +594,6 @@ mod tests {
         assert_eq!(*result.status(), DeltaResultStatus::Success);
     }
 
-    // ==================== ParallelDeltaPipeline tests ====================
-
     #[test]
     fn parallel_submit_and_flush() {
         let mut pipeline = ParallelDeltaPipeline::new(2);
@@ -762,8 +760,6 @@ mod tests {
         }
         assert_eq!(prev_seq, Some(19));
     }
-
-    // ==================== ThresholdDeltaPipeline tests ====================
 
     #[test]
     fn threshold_below_threshold_uses_sequential() {
@@ -987,8 +983,6 @@ mod tests {
         }
     }
 
-    // ==================== Integration tests ====================
-
     #[test]
     fn parallel_1000_small_files_all_ordered_and_successful() {
         let mut pipeline = ParallelDeltaPipeline::new(4);
@@ -1091,8 +1085,6 @@ mod tests {
             );
         }
     }
-
-    // ==================== Consumer thread integration tests ====================
 
     #[test]
     fn parallel_poll_yields_streaming_results_during_submission() {

--- a/crates/transfer/src/flags.rs
+++ b/crates/transfer/src/flags.rs
@@ -444,8 +444,6 @@ mod tests {
         assert!(!flags.backup);
     }
 
-    // ==================== clear_unsupported_features tests ====================
-
     /// When neither ACLs nor xattrs are requested, clearing unsupported features
     /// returns an empty list and leaves all flags unchanged.
     #[test]

--- a/crates/transfer/src/generator/itemize.rs
+++ b/crates/transfer/src/generator/itemize.rs
@@ -282,8 +282,6 @@ mod tests {
         }
     }
 
-    // ---- Existing tests updated to pass context ----
-
     #[test]
     fn format_new_file_transfer() {
         let iflags = ItemFlags::from_raw(ItemFlags::ITEM_TRANSFER | ItemFlags::ITEM_IS_NEW);
@@ -432,8 +430,6 @@ mod tests {
         let line = format_itemize_line(&iflags, &entry, true, &default_ctx());
         assert_eq!(line, "cL+++++++++ mylink -> target\n");
     }
-
-    // ---- New tests for T/t time position distinction ----
 
     /// upstream: log.c:716-717 - non-symlink with preserve_mtimes shows lowercase 't'
     #[test]

--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -1705,8 +1705,6 @@ fn write_delta_with_compression_plain_fallback() {
     assert!(!encoded.is_empty());
 }
 
-// ---- should_send_del_stats tests ----
-
 #[test]
 fn del_stats_not_sent_without_do_stats() {
     // upstream: INFO_GTE(STATS, 2) is false => never send del_stats
@@ -1996,8 +1994,6 @@ mod legacy_goodbye_tests {
     }
 }
 
-// ==================== files-from tests ====================
-
 mod files_from {
     use super::*;
 
@@ -2220,8 +2216,6 @@ mod files_from {
         assert_eq!(result, vec!["file.txt", "other.txt"]);
     }
 }
-
-// ==================== Per-directory merge filter tests ====================
 
 #[test]
 fn generator_skips_files_matching_per_directory_merge_rules() {

--- a/crates/transfer/src/pipeline/job.rs
+++ b/crates/transfer/src/pipeline/job.rs
@@ -186,8 +186,6 @@ mod tests {
         FileEntry::new_file(name.into(), size, 0o644)
     }
 
-    // ==================== FileList tests ====================
-
     #[test]
     fn file_list_new_empty() {
         let list = FileList::new(Vec::new());
@@ -252,8 +250,6 @@ mod tests {
         assert!(Arc::ptr_eq(&list1.shared(), &list2.shared()));
     }
 
-    // ==================== FileJob tests ====================
-
     #[test]
     fn file_job_new() {
         let entry = Arc::new(make_test_entry("test.txt", 1024));
@@ -304,8 +300,6 @@ mod tests {
         let job = FileJob::new(0, PathBuf::from("/dest/arc.txt"), Arc::clone(&entry));
         assert!(Arc::ptr_eq(job.entry_arc(), &entry));
     }
-
-    // ==================== TransferFlags tests ====================
 
     #[test]
     fn transfer_flags_default() {

--- a/crates/transfer/src/reader/tests.rs
+++ b/crates/transfer/src/reader/tests.rs
@@ -571,9 +571,7 @@ fn multiplex_reader_redo_and_no_send_interleaved() {
     assert_eq!(mux.no_send_indices, vec![7]);
 }
 
-// =========================================================================
 // Batch recorder tests
-// =========================================================================
 
 #[test]
 fn multiplex_reader_batch_recorder_captures_demuxed_data() {
@@ -721,9 +719,7 @@ fn batch_recorder_roundtrip_writer_reader_capture_same_data() {
     assert_eq!(&*write_recorded, b"roundtrip test data");
 }
 
-// =========================================================================
 // Batch recorder + compression tests
-// =========================================================================
 //
 // upstream: io.c:read_buf() tees data to batch_fd BEFORE decompression.
 // The batch recorder must stay on MultiplexReader (not CompressedReader)

--- a/crates/transfer/src/receiver/tests.rs
+++ b/crates/transfer/src/receiver/tests.rs
@@ -2212,8 +2212,6 @@ mod legacy_goodbye_tests {
     }
 }
 
-// --- Tests for --relative implied parent directory creation ---
-
 #[cfg(test)]
 mod relative_parents {
     use super::*;
@@ -2612,8 +2610,6 @@ mod receiver_itemize_tests {
     }
 }
 
-// ==================== path_contains_dot_dot security tests ====================
-
 #[test]
 fn path_contains_dot_dot_simple_traversal() {
     use std::path::Path;
@@ -2669,8 +2665,6 @@ fn path_contains_dot_dot_double_dotdot() {
         "a/../../b"
     )));
 }
-
-// --- sanitize_file_list / --trust-sender tests ---
 
 mod sanitize_file_list {
     use super::*;
@@ -2917,8 +2911,6 @@ mod input_multiplex_tests {
     }
 }
 
-// ==================== Per-directory merge filter deletion tests ====================
-
 /// Minimal writer that discards output and provides no-op `MsgInfoSender`.
 struct TestDeletionWriter;
 
@@ -3037,8 +3029,6 @@ fn receiver_set_and_get_filter_chain() {
 
     assert!(!ctx.filter_chain().is_empty());
 }
-
-// ==================== Hardlink creation tests ====================
 
 /// Creates a `ReceiverContext` configured for hardlink testing with protocol 32.
 fn receiver_with_hardlinks(entries: Vec<FileEntry>) -> ReceiverContext {
@@ -3504,8 +3494,6 @@ fn create_hardlinks_multiple_followers_same_group() {
     assert_eq!(nlink, 4, "link count should be 4");
 }
 
-// ==================== Daemon filter rule tests ====================
-
 #[test]
 fn daemon_filter_set_empty_when_no_rules() {
     let handshake = test_handshake();
@@ -3685,9 +3673,7 @@ fn daemon_filter_rules_prepended_to_receiver_deletion_chain() {
     );
 }
 
-// =====================================================================
 // Protocol 28/29 io_error after file list (flist.c:2738-2742)
-// =====================================================================
 
 /// Verifies that `receive_file_list` reads the 4-byte LE io_error flag
 /// after the file list end marker for protocol < 30.

--- a/crates/transfer/src/sanitize_path.rs
+++ b/crates/transfer/src/sanitize_path.rs
@@ -143,8 +143,6 @@ fn sanitize_path_with_depth(path: &str, mut depth: i32, keep_dot_dirs: bool) -> 
 mod tests {
     use super::*;
 
-    // --- Basic sanitization ---
-
     #[test]
     fn empty_path_becomes_dot() {
         assert_eq!(sanitize_path(""), ".");
@@ -165,8 +163,6 @@ mod tests {
         assert_eq!(sanitize_path("foo/bar/"), "foo/bar");
     }
 
-    // --- Absolute path stripping ---
-
     #[test]
     fn absolute_path_stripped() {
         assert_eq!(sanitize_path("/etc/passwd"), "etc/passwd");
@@ -176,8 +172,6 @@ mod tests {
     fn root_only_becomes_dot() {
         assert_eq!(sanitize_path("/"), ".");
     }
-
-    // --- Dot component removal ---
 
     #[test]
     fn interior_dot_removed() {
@@ -193,8 +187,6 @@ mod tests {
     fn multiple_leading_dot_slash_removed() {
         assert_eq!(sanitize_path("./././foo"), "foo");
     }
-
-    // --- Dotdot collapsing ---
 
     #[test]
     fn dotdot_at_start_dropped_depth_zero() {
@@ -226,8 +218,6 @@ mod tests {
         assert_eq!(sanitize_path("a/../../../etc/passwd"), "etc/passwd");
     }
 
-    // --- Duplicate slashes ---
-
     #[test]
     fn duplicate_slashes_collapsed() {
         assert_eq!(sanitize_path("foo//bar"), "foo/bar");
@@ -237,8 +227,6 @@ mod tests {
     fn triple_slashes_collapsed() {
         assert_eq!(sanitize_path("foo///bar///baz"), "foo/bar/baz");
     }
-
-    // --- CVE-like adversarial inputs ---
 
     #[test]
     fn absolute_dotdot_traversal_blocked() {
@@ -279,8 +267,6 @@ mod tests {
         assert_eq!(sanitize_path("a/b/../"), "a");
     }
 
-    // --- keep_dot_dirs variant ---
-
     #[test]
     fn keep_dot_dirs_preserves_leading_dot_slash() {
         assert_eq!(sanitize_path_keep_dot_dirs("./foo"), "./foo");
@@ -301,8 +287,6 @@ mod tests {
         assert_eq!(sanitize_path_keep_dot_dirs("a/./b"), "a/./b");
     }
 
-    // --- depth parameter ---
-
     #[test]
     fn depth_allows_leading_dotdots() {
         assert_eq!(sanitize_path_with_depth("../foo", 1, false), "../foo");
@@ -318,8 +302,6 @@ mod tests {
         assert_eq!(sanitize_path_with_depth("../../foo", 0, false), "foo");
     }
 
-    // --- Unicode paths ---
-
     #[test]
     fn unicode_path_preserved() {
         assert_eq!(sanitize_path("datos/archivo.txt"), "datos/archivo.txt");
@@ -330,8 +312,6 @@ mod tests {
         assert_eq!(sanitize_path("datos/../secreto"), "secreto");
     }
 
-    // --- Symlink target sanitization (daemon mode, flist.c:1154) ---
-
     #[test]
     fn symlink_target_absolute_stripped() {
         assert_eq!(sanitize_path("/etc/hosts"), "etc/hosts");
@@ -341,8 +321,6 @@ mod tests {
     fn symlink_target_traversal_collapsed() {
         assert_eq!(sanitize_path("../../../etc/passwd"), "etc/passwd");
     }
-
-    // --- files_from adversarial entries ---
 
     #[test]
     fn files_from_dotdot_traversal() {

--- a/crates/transfer/src/setup/tests.rs
+++ b/crates/transfer/src/setup/tests.rs
@@ -134,8 +134,6 @@ fn build_compat_flags_skips_avoid_xattr_optimization_when_client_missing_x() {
     );
 }
 
-// ===== setup_protocol() tests =====
-
 #[test]
 fn setup_protocol_below_30_returns_none_for_algorithms_and_compat() {
     // Protocol 29 should skip all negotiation and compat exchange
@@ -505,8 +503,6 @@ fn setup_protocol_protocol_30_minimum_for_compat_exchange() {
     );
 }
 
-// ===== ProtocolSetupConfig builder tests =====
-
 #[test]
 fn protocol_setup_config_builder_new_sets_defaults() {
     let protocol = ProtocolVersion::try_from(31).unwrap();
@@ -589,8 +585,6 @@ fn protocol_setup_config_builder_works_in_real_setup() {
         "Protocol 29 should not negotiate"
     );
 }
-
-// ===== Checksum seed edge case tests (task #99) =====
 
 #[test]
 fn setup_protocol_server_uses_fixed_checksum_seed() {
@@ -730,8 +724,6 @@ fn setup_protocol_client_reads_negative_seed_from_server() {
         "Client should correctly read negative seed value"
     );
 }
-
-// ===== Pre-release 'V' compat flag tests =====
 
 #[test]
 fn client_has_pre_release_v_flag_detects_uppercase_v() {
@@ -1031,8 +1023,6 @@ fn build_capability_string_matches_mapping_order() {
     assert_eq!(chars, expected);
 }
 
-// ===== ProtocolNegotiator trait tests =====
-
 /// Mock negotiator that returns fixed values without wire I/O.
 ///
 /// Used to verify that `setup_protocol_with` delegates correctly to the
@@ -1247,8 +1237,6 @@ fn setup_protocol_delegates_to_default_negotiator() {
     assert_eq!(result1.checksum_seed, result2.checksum_seed);
     assert_eq!(stdout1, stdout2);
 }
-
-// ==================== ACL/xattr capability negotiation tests ====================
 
 /// When the client capability string includes 'x' (CF_AVOID_XATTR_OPTIM),
 /// the server advertises xattr awareness. Clients use this flag to detect

--- a/crates/transfer/src/symlink_safety.rs
+++ b/crates/transfer/src/symlink_safety.rs
@@ -212,8 +212,6 @@ mod tests {
         is_unsafe_symlink(OsStr::new(target), Path::new(link))
     }
 
-    // --- Absolute and empty targets ---
-
     #[test]
     fn absolute_target_is_unsafe() {
         assert!(unsafe_link("/etc/passwd", "a/link"));
@@ -223,8 +221,6 @@ mod tests {
     fn empty_target_is_unsafe() {
         assert!(unsafe_link("", "a/link"));
     }
-
-    // --- Simple safe cases ---
 
     #[test]
     fn sibling_file_is_safe() {
@@ -242,8 +238,6 @@ mod tests {
         assert!(!unsafe_link("../file", "a/b/link"));
     }
 
-    // --- Depth escape ---
-
     #[test]
     fn dotdot_escaping_tree_is_unsafe() {
         // link at a/link, target ../../etc -> escapes
@@ -254,8 +248,6 @@ mod tests {
     fn deep_dotdot_escape_is_unsafe() {
         assert!(unsafe_link("../../../etc/passwd", "a/b/link"));
     }
-
-    // --- Mid-path /../ rejection (upstream 3.4.1 hardening) ---
 
     #[test]
     fn mid_path_dotdot_is_unsafe() {
@@ -275,8 +267,6 @@ mod tests {
         // Still checked by depth tracking
         assert!(!unsafe_link("../../file", "a/b/c/link"));
     }
-
-    // --- Upstream t_unsafe.c equivalents ---
 
     #[test]
     fn upstream_test_simple_relative() {
@@ -308,8 +298,6 @@ mod tests {
     fn dot_segment_is_safe() {
         assert!(!unsafe_link("./foo", "dir/link"));
     }
-
-    // --- Mid-path dotdot edge cases ---
 
     #[test]
     fn mid_path_dotdot_with_leading_dotdot() {

--- a/crates/transfer/src/writer/tests.rs
+++ b/crates/transfer/src/writer/tests.rs
@@ -520,9 +520,7 @@ fn mut_ref_delegates_msg_info() {
     assert!(!buf.is_empty());
 }
 
-// =========================================================================
 // Batch recorder tests
-// =========================================================================
 
 #[test]
 fn multiplex_writer_batch_recorder_captures_write_data() {
@@ -618,9 +616,7 @@ fn server_writer_batch_recorder_captures_through_server_write() {
     assert_eq!(&*recorded, b"server data");
 }
 
-// =========================================================================
 // Batch recorder + compression tests
-// =========================================================================
 //
 // upstream: io.c:write_buf() tees data to batch_fd AFTER compression.
 // The batch recorder must stay on MultiplexWriter (not CompressedWriter)


### PR DESCRIPTION
## Summary

- Remove decorative banner/divider comments (`// =====...=====` and `// ----...----`) across 132 files
- 1,379 lines of decorative noise removed, no functional changes
- Preserves all upstream rsync source references, batch reader test structural annotations, and daemon `include!()` navigation comments

## Test plan

- [ ] CI fmt+clippy passes (no functional code changes)
- [ ] All nextest tests pass (comment-only deletions)
- [ ] Windows/macOS/Linux matrix green