### PR TITLE
feat: add BufferPool telemetry counters and env var pool sizing

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -36,8 +36,9 @@ max-threads = 1
 # Buffer pool global singleton tests share a process-wide OnceLock.
 # Parallel execution causes init_global_buffer_pool to see already-initialized
 # state from another test, leading to non-deterministic failures.
+# Env var tests mutate OC_RSYNC_BUFFER_POOL_SIZE and must not run concurrently.
 [[profile.default.overrides]]
-filter = "test(global_pool)"
+filter = "test(global_pool) | test(env_var)"
 test-group = "global-pool-serial"
 
 [test-groups.global-pool-serial]

--- a/crates/engine/src/local_copy/buffer_pool/global.rs
+++ b/crates/engine/src/local_copy/buffer_pool/global.rs
@@ -41,12 +41,28 @@ pub struct GlobalBufferPoolConfig {
     pub buffer_size: usize,
 }
 
+/// Environment variable for overriding the buffer pool size (number of buffers).
+///
+/// When set to a valid positive integer, overrides the auto-detected
+/// hardware parallelism value. Useful for tuning memory usage in
+/// constrained environments or for benchmarking.
+const ENV_BUFFER_POOL_SIZE: &str = "OC_RSYNC_BUFFER_POOL_SIZE";
+
 impl Default for GlobalBufferPoolConfig {
     /// Defaults to one buffer per hardware thread at the standard copy buffer size.
+    ///
+    /// The `OC_RSYNC_BUFFER_POOL_SIZE` environment variable overrides the
+    /// auto-detected hardware parallelism value when set to a valid positive
+    /// integer. Invalid or non-positive values are silently ignored.
     fn default() -> Self {
-        let max_buffers = std::thread::available_parallelism()
+        let auto_detected = std::thread::available_parallelism()
             .map(std::num::NonZero::get)
             .unwrap_or(4);
+        let max_buffers = std::env::var(ENV_BUFFER_POOL_SIZE)
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok())
+            .filter(|&n| n > 0)
+            .unwrap_or(auto_detected);
         Self {
             max_buffers,
             buffer_size: super::super::COPY_BUFFER_SIZE,
@@ -180,6 +196,96 @@ mod tests {
 
         // Pool should have at least one buffer now (the returned one).
         assert!(pool.available() >= initial_available);
+    }
+
+    /// RAII guard that sets an env var and restores it on drop.
+    struct EnvGuard {
+        key: String,
+        original: Option<String>,
+    }
+
+    impl EnvGuard {
+        #[allow(unsafe_code)]
+        fn set(key: &str, value: &str) -> Self {
+            let original = std::env::var(key).ok();
+            // SAFETY: tests using EnvGuard are serialized via nextest
+            // test-group (max-threads = 1) to prevent concurrent env mutation.
+            unsafe { std::env::set_var(key, value) };
+            Self {
+                key: key.to_string(),
+                original,
+            }
+        }
+
+        #[allow(unsafe_code)]
+        fn remove(key: &str) -> Self {
+            let original = std::env::var(key).ok();
+            // SAFETY: see set() above.
+            unsafe { std::env::remove_var(key) };
+            Self {
+                key: key.to_string(),
+                original,
+            }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        #[allow(unsafe_code)]
+        fn drop(&mut self) {
+            // SAFETY: see EnvGuard::set() above.
+            match &self.original {
+                Some(val) => unsafe { std::env::set_var(&self.key, val) },
+                None => unsafe { std::env::remove_var(&self.key) },
+            }
+        }
+    }
+
+    #[test]
+    fn env_var_overrides_pool_size() {
+        let _guard = EnvGuard::set(super::ENV_BUFFER_POOL_SIZE, "42");
+        let config = GlobalBufferPoolConfig::default();
+        assert_eq!(config.max_buffers, 42);
+    }
+
+    #[test]
+    fn env_var_zero_ignored() {
+        let _guard = EnvGuard::set(super::ENV_BUFFER_POOL_SIZE, "0");
+        let config = GlobalBufferPoolConfig::default();
+        // Zero is invalid, should fall back to auto-detected.
+        let expected = std::thread::available_parallelism()
+            .map(std::num::NonZero::get)
+            .unwrap_or(4);
+        assert_eq!(config.max_buffers, expected);
+    }
+
+    #[test]
+    fn env_var_non_numeric_ignored() {
+        let _guard = EnvGuard::set(super::ENV_BUFFER_POOL_SIZE, "not_a_number");
+        let config = GlobalBufferPoolConfig::default();
+        let expected = std::thread::available_parallelism()
+            .map(std::num::NonZero::get)
+            .unwrap_or(4);
+        assert_eq!(config.max_buffers, expected);
+    }
+
+    #[test]
+    fn env_var_negative_ignored() {
+        let _guard = EnvGuard::set(super::ENV_BUFFER_POOL_SIZE, "-5");
+        let config = GlobalBufferPoolConfig::default();
+        let expected = std::thread::available_parallelism()
+            .map(std::num::NonZero::get)
+            .unwrap_or(4);
+        assert_eq!(config.max_buffers, expected);
+    }
+
+    #[test]
+    fn env_var_unset_uses_auto() {
+        let _guard = EnvGuard::remove(super::ENV_BUFFER_POOL_SIZE);
+        let config = GlobalBufferPoolConfig::default();
+        let expected = std::thread::available_parallelism()
+            .map(std::num::NonZero::get)
+            .unwrap_or(4);
+        assert_eq!(config.max_buffers, expected);
     }
 
     #[test]

--- a/crates/engine/src/local_copy/buffer_pool/pool.rs
+++ b/crates/engine/src/local_copy/buffer_pool/pool.rs
@@ -7,7 +7,7 @@
 
 use std::sync::Arc;
 use std::sync::Mutex;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 
 use super::allocator::{BufferAllocator, DefaultAllocator};
 use super::guard::{BorrowedBufferGuard, BufferGuard};
@@ -89,6 +89,19 @@ pub struct BufferPool<A: BufferAllocator = DefaultAllocator> {
     /// pool's soft capacity to match demand. Enabled via
     /// [`with_adaptive_resizing`](Self::with_adaptive_resizing).
     pressure: Option<PressureTracker>,
+    /// Cumulative count of acquire operations that found a buffer in the
+    /// thread-local cache or central pool (no fresh allocation needed).
+    ///
+    /// Always active regardless of whether adaptive resizing is enabled.
+    /// Uses `Relaxed` ordering since exact precision is not required for
+    /// telemetry - small counting errors under concurrent access are
+    /// acceptable.
+    total_hits: AtomicU64,
+    /// Cumulative count of acquire operations that required a fresh
+    /// allocation because no pooled buffer was available.
+    ///
+    /// Always active regardless of whether adaptive resizing is enabled.
+    total_misses: AtomicU64,
 }
 
 impl BufferPool {
@@ -117,6 +130,8 @@ impl BufferPool {
             memory_cap: None,
             throughput: None,
             pressure: None,
+            total_hits: AtomicU64::new(0),
+            total_misses: AtomicU64::new(0),
         }
     }
 
@@ -138,6 +153,8 @@ impl BufferPool {
             memory_cap: None,
             throughput: None,
             pressure: None,
+            total_hits: AtomicU64::new(0),
+            total_misses: AtomicU64::new(0),
         }
     }
 }
@@ -164,6 +181,8 @@ impl<A: BufferAllocator> BufferPool<A> {
             memory_cap: None,
             throughput: None,
             pressure: None,
+            total_hits: AtomicU64::new(0),
+            total_misses: AtomicU64::new(0),
         }
     }
 
@@ -294,6 +313,7 @@ impl<A: BufferAllocator> BufferPool<A> {
         // Fast path: check thread-local cache.
         if let Some(buffer) = thread_local_cache::try_take() {
             if buffer.len() == pool.buffer_size {
+                pool.total_hits.fetch_add(1, Ordering::Relaxed);
                 // Re-reserve memory that was released by return_buffer's track_return.
                 pool.wait_and_reserve_memory(pool.buffer_size);
                 return BufferGuard {
@@ -332,6 +352,7 @@ impl<A: BufferAllocator> BufferPool<A> {
                     }
                     return None;
                 }
+                pool.total_hits.fetch_add(1, Ordering::Relaxed);
                 return Some(BufferGuard {
                     buffer: Some(buffer),
                     pool,
@@ -390,6 +411,7 @@ impl<A: BufferAllocator> BufferPool<A> {
         // Fast path: check thread-local cache.
         if let Some(buffer) = thread_local_cache::try_take() {
             if buffer.len() == self.buffer_size {
+                self.total_hits.fetch_add(1, Ordering::Relaxed);
                 // Re-reserve memory that was released by return_buffer's track_return.
                 self.wait_and_reserve_memory(self.buffer_size);
                 return BorrowedBufferGuard {
@@ -426,6 +448,7 @@ impl<A: BufferAllocator> BufferPool<A> {
                     }
                     return None;
                 }
+                self.total_hits.fetch_add(1, Ordering::Relaxed);
                 return Some(BorrowedBufferGuard {
                     buffer: Some(buffer),
                     pool: self,
@@ -505,6 +528,7 @@ impl<A: BufferAllocator> BufferPool<A> {
         let mut pool = self.buffers.lock().unwrap_or_else(|e| e.into_inner());
         match pool.pop() {
             Some(buffer) => {
+                self.total_hits.fetch_add(1, Ordering::Relaxed);
                 if let Some(pressure) = &self.pressure {
                     pressure.record_hit();
                     self.maybe_resize(pressure, &mut pool);
@@ -512,6 +536,7 @@ impl<A: BufferAllocator> BufferPool<A> {
                 buffer
             }
             None => {
+                self.total_misses.fetch_add(1, Ordering::Relaxed);
                 if let Some(pressure) = &self.pressure {
                     pressure.record_miss();
                     self.maybe_resize(pressure, &mut pool);
@@ -606,6 +631,41 @@ impl<A: BufferAllocator> BufferPool<A> {
     #[must_use]
     pub fn is_adaptive(&self) -> bool {
         self.pressure.is_some()
+    }
+
+    /// Returns the cumulative number of acquire operations that found a
+    /// buffer in the thread-local cache or central pool (no fresh
+    /// allocation needed).
+    #[must_use]
+    pub fn total_hits(&self) -> u64 {
+        self.total_hits.load(Ordering::Relaxed)
+    }
+
+    /// Returns the cumulative number of acquire operations that required
+    /// a fresh allocation because no pooled buffer was available.
+    #[must_use]
+    pub fn total_misses(&self) -> u64 {
+        self.total_misses.load(Ordering::Relaxed)
+    }
+
+    /// Returns the total number of acquire operations (hits + misses).
+    #[must_use]
+    pub fn total_acquires(&self) -> u64 {
+        self.total_hits() + self.total_misses()
+    }
+
+    /// Returns the hit rate as a fraction in `[0.0, 1.0]`.
+    ///
+    /// Returns `0.0` if no acquires have been recorded yet. The hit rate
+    /// measures how effectively the pool reuses buffers - higher values
+    /// indicate less allocation overhead.
+    #[must_use]
+    pub fn hit_rate(&self) -> f64 {
+        let total = self.total_acquires();
+        if total == 0 {
+            return 0.0;
+        }
+        self.total_hits() as f64 / total as f64
     }
 
     /// Atomically waits for and reserves `requested` bytes of capacity.

--- a/crates/engine/src/local_copy/buffer_pool/tests.rs
+++ b/crates/engine/src/local_copy/buffer_pool/tests.rs
@@ -1593,3 +1593,135 @@ fn adaptive_pool_deallocates_on_shrink() {
         );
     }
 }
+
+#[test]
+fn telemetry_starts_at_zero() {
+    let pool = BufferPool::new(4);
+    assert_eq!(pool.total_hits(), 0);
+    assert_eq!(pool.total_misses(), 0);
+    assert_eq!(pool.total_acquires(), 0);
+    assert_eq!(pool.hit_rate(), 0.0);
+}
+
+#[test]
+fn telemetry_first_acquire_is_miss() {
+    let pool = BufferPool::new(4);
+    let _buf = pool.acquire();
+    // First acquire on a fresh pool: TLS empty, central pool empty -> miss.
+    assert_eq!(pool.total_misses(), 1);
+    assert_eq!(pool.total_acquires(), 1);
+}
+
+#[test]
+fn telemetry_tls_reuse_is_hit() {
+    let pool = BufferPool::new(4);
+    // First acquire: miss (fresh allocation).
+    {
+        let _buf = pool.acquire();
+    }
+    // Buffer returned to TLS.
+    // Second acquire: hit (from TLS).
+    let _buf = pool.acquire();
+    assert!(pool.total_hits() >= 1);
+    assert_eq!(pool.total_acquires(), 2);
+}
+
+#[test]
+fn telemetry_hit_rate_calculation() {
+    let pool = Arc::new(BufferPool::new(4));
+    // First acquire: miss.
+    {
+        let _buf = BufferPool::acquire_from(Arc::clone(&pool));
+    }
+    // Second acquire: hit from TLS.
+    {
+        let _buf = BufferPool::acquire_from(Arc::clone(&pool));
+    }
+    let rate = pool.hit_rate();
+    assert!(rate > 0.0, "expected hit rate > 0, got {rate}");
+    assert!(rate <= 1.0, "expected hit rate <= 1, got {rate}");
+}
+
+#[test]
+fn telemetry_cumulative_across_many_acquires() {
+    let pool = Arc::new(BufferPool::new(4));
+    let iterations = 100;
+    for _ in 0..iterations {
+        let _buf = BufferPool::acquire_from(Arc::clone(&pool));
+    }
+    assert_eq!(pool.total_acquires(), iterations);
+    // First acquire is a miss, rest are TLS hits.
+    assert_eq!(pool.total_hits(), iterations - 1);
+    assert_eq!(pool.total_misses(), 1);
+}
+
+#[test]
+fn telemetry_concurrent_counting() {
+    let pool = Arc::new(BufferPool::new(8));
+    let thread_count = 8u64;
+    let iterations = 200u64;
+
+    let handles: Vec<_> = (0..thread_count)
+        .map(|_| {
+            let pool = Arc::clone(&pool);
+            thread::spawn(move || {
+                for _ in 0..iterations {
+                    let _buf = BufferPool::acquire_from(Arc::clone(&pool));
+                }
+            })
+        })
+        .collect();
+
+    for h in handles {
+        h.join().expect("thread panicked");
+    }
+
+    let total = pool.total_acquires();
+    assert_eq!(
+        total,
+        thread_count * iterations,
+        "expected {}, got {total}",
+        thread_count * iterations
+    );
+    assert_eq!(total, pool.total_hits() + pool.total_misses());
+}
+
+#[test]
+fn telemetry_with_adaptive_resizing() {
+    // Telemetry counters work independently of adaptive resizing.
+    let pool = Arc::new(BufferPool::new(4).with_adaptive_resizing());
+    for _ in 0..100 {
+        let _buf = BufferPool::acquire_from(Arc::clone(&pool));
+    }
+    assert_eq!(pool.total_acquires(), 100);
+}
+
+#[test]
+fn telemetry_try_acquire_counts_hits() {
+    let pool = BufferPool::with_buffer_size(4, 1024).with_memory_cap(4096);
+    // First acquire: miss.
+    {
+        let _buf = pool.acquire();
+    }
+    // Second acquire via try_acquire: TLS hit.
+    {
+        let _buf = pool.try_acquire();
+    }
+    assert!(pool.total_hits() >= 1);
+    assert_eq!(pool.total_acquires(), 2);
+}
+
+#[test]
+fn telemetry_try_acquire_from_counts_hits() {
+    let pool = Arc::new(BufferPool::with_buffer_size(4, 1024).with_memory_cap(4096));
+    // First acquire: miss.
+    {
+        let _buf = BufferPool::acquire_from(Arc::clone(&pool));
+    }
+    // Second acquire via try_acquire_from: TLS hit.
+    {
+        let _buf = BufferPool::try_acquire_from(Arc::clone(&pool));
+    }
+    assert!(pool.total_hits() >= 1);
+    assert_eq!(pool.total_acquires(), 2);
+}


### PR DESCRIPTION
## Summary

- Add cumulative `AtomicU64` hit/miss telemetry counters to `BufferPool`, tracking TLS fast-path hits, central pool hits, and fresh allocation misses across all acquire paths
- Add `OC_RSYNC_BUFFER_POOL_SIZE` environment variable to override auto-detected hardware parallelism for global buffer pool sizing
- Add public accessors: `total_hits()`, `total_misses()`, `total_acquires()`, `hit_rate()`
- Serialize env var tests and global pool tests via nextest test-group to prevent OnceLock/env mutation races

Re-implementation of closed PR #3251 on a clean branch from current master.

## Test plan

- [x] 9 telemetry tests covering zero-init, first-acquire miss, TLS reuse hit, hit rate calculation, cumulative counting, concurrent counting, adaptive resizing interaction, try_acquire variants
- [x] 5 env var tests: override, zero ignored, non-numeric ignored, negative ignored, unset uses auto
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` passes
- [ ] CI nextest suite