### PR TITLE
chore: remove oc-direction entries from known failures config

### DIFF
--- a/tools/ci/known_failures.conf
+++ b/tools/ci/known_failures.conf
@@ -38,7 +38,7 @@ is_known_failure_from_conf() {
   # Protocol-specific known failures: upstream rsync hard-rejects these
   # features when the negotiated protocol version is below 30. These are
   # NOT oc-rsync bugs - upstream rsync itself fails identically.
-  if [[ -n "$forced_proto" && "$forced_proto" -le 29 ]]; then
+  if [[ "$direction" == "up" && -n "$forced_proto" && "$forced_proto" -le 29 ]]; then
     case "$name" in
       # upstream compat.c:655-661 setup_protocol():
       #   if (preserve_acls && !local_server) {
@@ -81,7 +81,7 @@ is_known_failure_from_conf() {
   # Protocol < 29 known failures: features requiring modern filter prefixes.
   # upstream exclude.c:1530 - legal_len=1 at proto < 29; dir-merge ':'
   # prefix cannot be represented with old-style prefixes.
-  if [[ -n "$forced_proto" && "$forced_proto" -le 28 ]]; then
+  if [[ "$direction" == "up" && -n "$forced_proto" && "$forced_proto" -le 28 ]]; then
     case "$name" in
       merge-filter) return 0 ;;
     esac
@@ -96,14 +96,10 @@ is_known_failure_from_conf() {
 # Keep in sync with actual known failure rules above.
 DASHBOARD_ENTRIES=(
   # ACLs: upstream compat.c:655-661 - hard error RERR_PROTOCOL at proto < 30
-  "oc:acls|ACLs push to upstream daemon (proto <= 29, upstream compat.c:655-661)|daemon"
   "up:acls|ACLs pull from upstream daemon (proto <= 29, upstream compat.c:655-661)|daemon"
   # Xattrs: upstream compat.c:662-668 - hard error RERR_PROTOCOL at proto < 30
-  "oc:xattrs|xattrs push to upstream daemon (proto <= 29, upstream compat.c:662-668)|daemon"
   "up:xattrs|xattrs pull from upstream daemon (proto <= 29, upstream compat.c:662-668)|daemon"
   # Compress-choice: upstream compat.c:556-564 - no vstring negotiation at proto < 30
-  "oc:compress-zstd|zstd compression (proto <= 29, upstream compat.c:556-564)|daemon"
-  "oc:compress-lz4|lz4 compression (proto <= 29, upstream compat.c:556-564)|daemon"
   "up:compress-zstd|zstd compression pull (proto <= 29, upstream compat.c:556-564)|daemon"
   "up:compress-lz4|lz4 compression pull (proto <= 29, upstream compat.c:556-564)|daemon"
   # Compressed batch delta: upstream batch writer records raw compressed tokens
@@ -114,10 +110,6 @@ DASHBOARD_ENTRIES=(
   "up:compress-level-1|compress-level-1 interop (proto <= 29)|daemon"
   "up:compress-level-9|compress-level-9 interop (proto <= 29)|daemon"
   "up:compress-delta|compress-delta interop (proto <= 29)|daemon"
-  "oc:compress|zlib compression push interop (proto <= 29)|daemon"
-  "oc:compress-level-1|compress-level-1 push interop (proto <= 29)|daemon"
-  "oc:compress-level-9|compress-level-9 push interop (proto <= 29)|daemon"
-  "oc:compress-delta|compress-delta push interop (proto <= 29)|daemon"
   # Proto <= 29: hardlink wire format differences
   "up:hardlinks|hardlinks interop (proto <= 29)|daemon"
   "up:hardlinks-relative|hardlinks-relative interop (proto <= 29)|daemon"
@@ -126,14 +118,6 @@ DASHBOARD_ENTRIES=(
   "up:hardlinks-checksum|hardlinks-checksum interop (proto <= 29)|daemon"
   "up:hardlinks-existing|hardlinks-existing interop (proto <= 29)|daemon"
   "up:hardlinks-inc-recursive|hardlinks-inc-recursive interop (proto <= 29)|daemon"
-  "oc:hardlinks|hardlinks push interop (proto <= 29)|daemon"
-  "oc:hardlinks-relative|hardlinks-relative push interop (proto <= 29)|daemon"
-  "oc:hardlinks-delete|hardlinks-delete push interop (proto <= 29)|daemon"
-  "oc:hardlinks-numeric|hardlinks-numeric push interop (proto <= 29)|daemon"
-  "oc:hardlinks-checksum|hardlinks-checksum push interop (proto <= 29)|daemon"
-  "oc:hardlinks-existing|hardlinks-existing push interop (proto <= 29)|daemon"
-  "oc:hardlinks-inc-recursive|hardlinks-inc-recursive push interop (proto <= 29)|daemon"
   # Proto <= 28: merge-filter dir-merge prefix requires proto >= 29
   "up:merge-filter|merge-filter interop (proto <= 28, exclude.c:1530 legal_len=1)|daemon"
-  "oc:merge-filter|merge-filter push interop (proto <= 28, exclude.c:1530 legal_len=1)|daemon"
 )


### PR DESCRIPTION
## Summary

- Add `"$direction" == "up"` guard to both protocol-conditional blocks in `is_known_failure_from_conf()` (proto <= 29 and proto <= 28)
- Remove all 18 `oc:` direction entries from `DASHBOARD_ENTRIES`

These protocol-conditional failures (ACLs, xattrs, compression algorithm negotiation, hardlinks, merge-filter) only affect the `up:` direction (upstream client pushing to oc-rsync daemon). The upstream `compat.c` checks fire on the sender side, so when oc-rsync is the client pushing to an upstream daemon, upstream is the receiver and the checks don't apply.

## Test plan

- [ ] CI interop tests pass - no regressions in `up:` direction known failure detection
- [ ] `oc:` direction tests at proto <= 29 are no longer incorrectly marked as known failures