### PR TITLE
chore: remove hardlink entries from known failures config

### DIFF
--- a/tools/ci/known_failures.conf
+++ b/tools/ci/known_failures.conf
@@ -90,17 +90,6 @@ is_known_failure_from_conf() {
       # token level due to different deflate context initialization sequences.
       compress|compress-level-1|compress-level-9|compress-delta) return 0 ;;
 
-      # Hardlinks at proto < 30: the hardlink wire format uses a different
-      # encoding scheme for dev/ino fields at protocol versions below 30.
-      # Protocol 30+ uses a compact varint encoding; protocol < 30 uses a
-      # fixed-width 32-bit encoding with different field ordering.
-      # All hardlink test variants are affected because they all exercise
-      # the same underlying dev/ino wire format.
-      # Verified: upstream-to-upstream --hard-links at --protocol=29 works,
-      # but cross-implementation (oc-rsync <-> upstream) fails because
-      # oc-rsync's dev/ino encoding differs from upstream's legacy format.
-      hardlinks|hardlinks-relative|hardlinks-delete|hardlinks-numeric|\
-      hardlinks-checksum|hardlinks-existing|hardlinks-inc-recursive) return 0 ;;
     esac
   fi
 
@@ -145,15 +134,6 @@ DASHBOARD_ENTRIES=(
   "up:compress-level-1|compress-level-1 at proto <= 29 (deflate context init differs between versions)|daemon"
   "up:compress-level-9|compress-level-9 at proto <= 29 (deflate context init differs between versions)|daemon"
   "up:compress-delta|compress-delta at proto <= 29 (deflate context init differs between versions)|daemon"
-  # Hardlinks: dev/ino wire format encoding differs at proto < 30
-  "up:hardlinks|hardlinks at proto <= 29 (dev/ino wire encoding differs, 32-bit fixed vs varint)|daemon"
-  "up:hardlinks-relative|hardlinks-relative at proto <= 29 (dev/ino wire encoding differs)|daemon"
-  "up:hardlinks-delete|hardlinks-delete at proto <= 29 (dev/ino wire encoding differs)|daemon"
-  "up:hardlinks-numeric|hardlinks-numeric at proto <= 29 (dev/ino wire encoding differs)|daemon"
-  "up:hardlinks-checksum|hardlinks-checksum at proto <= 29 (dev/ino wire encoding differs)|daemon"
-  "up:hardlinks-existing|hardlinks-existing at proto <= 29 (dev/ino wire encoding differs)|daemon"
-  "up:hardlinks-inc-recursive|hardlinks-inc-recursive at proto <= 29 (dev/ino wire encoding differs)|daemon"
-
   # --- Proto <= 28: filter prefix limitations ---
 
   # Merge-filter: upstream exclude.c:1530 legal_len=1 prevents ':' dir-merge prefix


### PR DESCRIPTION
## Summary
- Remove all 7 hardlink known failure entries from `tools/ci/known_failures.conf`
- Hardlink interop at protocol <= 29 works correctly in both directions since the dev/ino wire encoding fix
- Container-verified: upstream rsync <-> oc-rsync daemon at proto 29 preserves hardlink inodes

## Test plan
- [ ] CI interop tests pass without hardlink entries in known failures
- [ ] `hardlinks` variants no longer masked as known failures at proto 29