### PR TITLE
fix: zlib compression interop at protocol <= 29

### DIFF
--- a/crates/protocol/src/wire/compressed_token/zlib_codec.rs
+++ b/crates/protocol/src/wire/compressed_token/zlib_codec.rs
@@ -359,9 +359,12 @@ impl ZlibTokenDecoder {
                 let before_in = self.decompressor.total_in();
                 let before_out = self.decompressor.total_out();
 
-                self.decompressor
-                    .decompress(input, &mut self.output_buf, FlushDecompress::Sync)
-                    .map_err(|e| io::Error::other(e.to_string()))?;
+                let decompress_result = self.decompressor.decompress(
+                    input,
+                    &mut self.output_buf,
+                    FlushDecompress::Sync,
+                );
+                decompress_result.map_err(|e| io::Error::other(e.to_string()))?;
 
                 let consumed = (self.decompressor.total_in() - before_in) as usize;
                 let produced = (self.decompressor.total_out() - before_out) as usize;

--- a/crates/transfer/src/delta_apply/checksum.rs
+++ b/crates/transfer/src/delta_apply/checksum.rs
@@ -48,7 +48,7 @@ impl ChecksumVerifier {
         _compat_flags: Option<&CompatibilityFlags>,
     ) -> Self {
         negotiated
-            .map(|n| Self::for_algorithm(n.checksum))
+            .map(|n| Self::for_algorithm_seeded(n.checksum, seed))
             .unwrap_or_else(|| {
                 if protocol.uses_varint_encoding() {
                     Self::Md5(Md5::new())

--- a/crates/transfer/src/setup/mod.rs
+++ b/crates/transfer/src/setup/mod.rs
@@ -155,7 +155,22 @@ pub fn setup_protocol_with<'a>(
 
             (Some(compat_flags), Some(algorithms))
         } else {
-            (None, None)
+            // upstream: compat.c - at protocol < 30, no binary negotiation
+            // occurs. Compression is determined solely by the -z flag (CPRES_ZLIB).
+            // Checksum is always MD4. We must still populate negotiated_algorithms
+            // so the token reader/writer uses compressed format.
+            let legacy_algorithms = if config.do_compression {
+                let compression = config
+                    .compress_choice
+                    .unwrap_or(protocol::CompressionAlgorithm::Zlib);
+                Some(protocol::NegotiationResult {
+                    checksum: protocol::ChecksumAlgorithm::MD4,
+                    compression,
+                })
+            } else {
+                None
+            };
+            (None, legacy_algorithms)
         };
 
     // Checksum seed exchange (ALL protocols, upstream compat.c:750)

--- a/tools/ci/known_failures.conf
+++ b/tools/ci/known_failures.conf
@@ -81,14 +81,6 @@ is_known_failure_from_conf() {
       # silently falls back to zlib, causing codec mismatch.
       compress-zstd|compress-lz4) return 0 ;;
 
-      # Zlib compression interop at proto < 30: zlib token framing differs
-      # between protocol versions. At protocol < 30, the compression context
-      # management and token boundaries use a different wire encoding than
-      # protocol >= 30. This affects all compression-related test variants.
-      # Verified: upstream-to-upstream compression works at proto 29, but
-      # cross-implementation (oc-rsync <-> upstream) framing differs at the
-      # token level due to different deflate context initialization sequences.
-      compress|compress-level-1|compress-level-9|compress-delta) return 0 ;;
 
     esac
   fi
@@ -129,11 +121,6 @@ DASHBOARD_ENTRIES=(
   # Compression algorithm choice: no vstring negotiation at proto < 30
   "up:compress-zstd|zstd at proto <= 29 (upstream compat.c:556-564, no vstring negotiation for codec)|daemon"
   "up:compress-lz4|lz4 at proto <= 29 (upstream compat.c:556-564, no vstring negotiation for codec)|daemon"
-  # Zlib compression: token framing differences at proto < 30
-  "up:compress|zlib compression at proto <= 29 (deflate context init differs between versions)|daemon"
-  "up:compress-level-1|compress-level-1 at proto <= 29 (deflate context init differs between versions)|daemon"
-  "up:compress-level-9|compress-level-9 at proto <= 29 (deflate context init differs between versions)|daemon"
-  "up:compress-delta|compress-delta at proto <= 29 (deflate context init differs between versions)|daemon"
   # --- Proto <= 28: filter prefix limitations ---
 
   # Merge-filter: upstream exclude.c:1530 legal_len=1 prevents ':' dir-merge prefix


### PR DESCRIPTION
## Summary

- Populate `negotiated_algorithms` with legacy defaults (MD4 checksum, Zlib compression) at protocol < 30 when compression is enabled, so `TokenReader` creates a `Compressed` variant instead of `Plain`
- Use `for_algorithm_seeded()` instead of `for_algorithm()` in `ChecksumVerifier::new()` when negotiated algorithms are present, ensuring MD4 gets the 4-byte seed prepended to match upstream `CSUM_MD4_OLD` behavior
- Remove compress/compress-level-1/compress-level-9/compress-delta from known failures config

## Root Cause

Two issues caused zlib compression to fail at protocol <= 29:

1. **`setup_protocol_with()`** skipped binary negotiation at proto < 30 and returned `negotiated_algorithms = None`. This caused `TokenReader::new(None)` to create a `Plain` variant even when the sender was sending compressed tokens, resulting in "connection unexpectedly closed" errors.

2. **`ChecksumVerifier::new()`** took different code paths for `negotiated = Some` vs `None`. The fix for issue 1 provided `Some(NegotiationResult)`, which caused the verifier to call `for_algorithm()` - skipping the MD4 seed prepend. Upstream's `CSUM_MD4_OLD` always prepends the 4-byte seed at proto < 30, causing checksum verification failures.

## Test plan

- [x] Verified in container: proto 29 + `-z` transfers complete with exit 0 and content match
- [x] Verified compress-level-1 and compress-level-9 at proto 29
- [x] Verified compress-delta at proto 29 (upstream correctly skips transfer for similar files)
- [ ] CI interop tests pass with compress entries removed from known failures