### PR TITLE
feat: add SQPOLL fallback observability to fast_io crate

### DIFF
--- a/crates/fast_io/src/io_uring/config.rs
+++ b/crates/fast_io/src/io_uring/config.rs
@@ -22,6 +22,30 @@ const MIN_KERNEL_VERSION: (u32, u32) = (5, 6);
 static IO_URING_AVAILABLE: AtomicBool = AtomicBool::new(false);
 static IO_URING_CHECKED: AtomicBool = AtomicBool::new(false);
 
+/// Whether SQPOLL was requested but fell back to regular submission.
+///
+/// Set to `true` the first time `build_ring()` attempts SQPOLL and it fails
+/// (typically `EPERM` because the process lacks `CAP_SYS_NICE`). Callers
+/// can query this via [`sqpoll_fell_back`] for diagnostics or `--version` output.
+static SQPOLL_FALLBACK: AtomicBool = AtomicBool::new(false);
+
+/// Returns `true` if SQPOLL was requested but setup failed.
+///
+/// When `IoUringConfig::sqpoll` is `true` but the kernel rejects the request
+/// (usually `EPERM` due to missing `CAP_SYS_NICE`), `build_ring()` transparently
+/// falls back to a regular io_uring ring. This function reports whether that
+/// fallback occurred, enabling diagnostic output like:
+///
+/// ```text
+/// io_uring SQPOLL requires CAP_SYS_NICE, fell back to regular submission
+/// ```
+///
+/// Returns `false` if SQPOLL was never requested or if it succeeded.
+#[must_use]
+pub fn sqpoll_fell_back() -> bool {
+    SQPOLL_FALLBACK.load(Ordering::Relaxed)
+}
+
 /// Parses kernel version from uname release string (e.g., "5.15.0-generic").
 pub(super) fn parse_kernel_version(release: &str) -> Option<(u32, u32)> {
     let mut parts = release.split(|c: char| !c.is_ascii_digit());
@@ -277,7 +301,9 @@ impl IoUringConfig {
             match builder.build(self.sq_entries) {
                 Ok(ring) => return Ok(ring),
                 Err(_) => {
-                    // SQPOLL requires privileges — fall through to normal ring
+                    // SQPOLL requires CAP_SYS_NICE on most kernels. Record
+                    // the fallback so callers can surface it in diagnostics.
+                    SQPOLL_FALLBACK.store(true, Ordering::Relaxed);
                 }
             }
         }

--- a/crates/fast_io/src/io_uring/mod.rs
+++ b/crates/fast_io/src/io_uring/mod.rs
@@ -76,7 +76,7 @@ use std::fs::File;
 use std::io::{self, Write};
 use std::os::unix::io::AsRawFd;
 
-pub use config::{IoUringConfig, config_detail, is_io_uring_available};
+pub use config::{IoUringConfig, config_detail, is_io_uring_available, sqpoll_fell_back};
 pub use disk_batch::IoUringDiskBatch;
 pub use file_factory::{
     IoUringOrStdReader, IoUringOrStdWriter, IoUringReaderFactory, IoUringWriterFactory,

--- a/crates/fast_io/src/io_uring_stub.rs
+++ b/crates/fast_io/src/io_uring_stub.rs
@@ -26,6 +26,12 @@ pub fn is_io_uring_available() -> bool {
     false
 }
 
+/// Returns whether SQPOLL was requested but fell back (always `false` on this platform).
+#[must_use]
+pub fn sqpoll_fell_back() -> bool {
+    false
+}
+
 /// Configuration for io_uring instances (informational only on this platform).
 #[derive(Debug, Clone)]
 pub struct IoUringConfig {

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -130,7 +130,8 @@ pub use o_tmpfile::{
 pub use io_uring::{
     IoUringConfig, IoUringDiskBatch, IoUringOrStdReader, IoUringOrStdWriter, IoUringReader,
     IoUringReaderFactory, IoUringWriter, IoUringWriterFactory, RegisteredBufferGroup,
-    RegisteredBufferSlot, is_io_uring_available, reader_from_path, writer_from_file,
+    RegisteredBufferSlot, is_io_uring_available, reader_from_path, sqpoll_fell_back,
+    writer_from_file,
 };
 
 /// Detailed io_uring availability status for `--version` output.


### PR DESCRIPTION
## Summary

- Add `sqpoll_fell_back()` public API to `fast_io` crate reporting whether io_uring SQPOLL mode was requested but fell back to regular submission
- Uses process-wide `AtomicBool` matching the existing `is_io_uring_available()` caching pattern
- Records fallback in `build_ring()` when SQPOLL setup fails (typically `EPERM` due to missing `CAP_SYS_NICE`)
- Stub returns `false` on non-Linux platforms

## Test plan

- [ ] CI passes on all platforms (Linux, macOS, Windows)
- [ ] Verify stub compiles on non-Linux (macOS CI job)
- [ ] Verify io_uring feature gate compiles on Linux (Linux CI job)