### PR TITLE
docs: document rayon ordering contracts at parallelism boundaries

### DIFF
--- a/crates/checksums/src/parallel/blocks.rs
+++ b/crates/checksums/src/parallel/blocks.rs
@@ -110,6 +110,9 @@ where
     D::Digest: Send,
     T: AsRef<[u8]> + Sync,
 {
+    // Ordering: digests must correspond 1:1 with blocks by position for signature assembly.
+    // Preserved by par_iter().map().collect() (rayon preserves index order).
+    // Violation produces wrong strong checksums per block, breaking delta matching.
     blocks
         .par_iter()
         .map(|block| D::digest(block.as_ref()))
@@ -197,6 +200,9 @@ where
     D::Digest: Send,
     T: AsRef<[u8]> + Sync,
 {
+    // Ordering: signatures must match block positions for delta reconstruction.
+    // Preserved by par_iter().map().collect() (rayon preserves index order).
+    // Violation pairs wrong rolling+strong checksums with block offsets.
     blocks
         .par_iter()
         .map(|block| {

--- a/crates/checksums/src/parallel/files.rs
+++ b/crates/checksums/src/parallel/files.rs
@@ -156,6 +156,9 @@ where
     D::Seed: Default + Clone + Send + Sync,
     D::Digest: Send,
 {
+    // Ordering: results must correspond 1:1 with input paths for whole-file checksum comparison.
+    // Preserved by par_iter().map().collect() (rayon preserves index order).
+    // Violation mismatches file hashes with paths, causing incorrect transfer decisions.
     paths
         .par_iter()
         .map(|path| hash_file_internal::<D>(path, config))
@@ -296,6 +299,9 @@ where
     D::Seed: Default + Clone + Send + Sync,
     D::Digest: Send,
 {
+    // Ordering: results must correspond 1:1 with input paths by position.
+    // Preserved by par_iter().map().collect() (rayon preserves index order).
+    // Violation mismatches file signatures with paths.
     paths
         .par_iter()
         .map(|path| compute_file_signatures_internal::<D>(path, block_size, buffer_size))

--- a/crates/engine/src/local_copy/executor/directory/parallel_planner.rs
+++ b/crates/engine/src/local_copy/executor/directory/parallel_planner.rs
@@ -94,7 +94,9 @@ pub(crate) fn prefetch_entry_metadata(
             .collect();
     }
 
-    // Parallel prefetch using rayon
+    // Ordering: prefetched data is matched to entries by index for sequential processing.
+    // Preserved by par_iter().enumerate().map().collect() (rayon preserves index order).
+    // Violation assigns wrong symlink/device metadata to entries, corrupting copies.
     entries
         .par_iter()
         .enumerate()

--- a/crates/engine/src/local_copy/executor/directory/support.rs
+++ b/crates/engine/src/local_copy/executor/directory/support.rs
@@ -100,7 +100,9 @@ fn read_directory_entries_sorted_parallel(
         return Ok(entries);
     }
 
-    // Phase 2: Fetch metadata in parallel using rayon
+    // Ordering: local copy requires deterministic directory listing order.
+    // Parallel metadata fetch loses traversal order, so sort_unstable_by() is
+    // applied after collection. Omitting the sort produces non-deterministic copies.
     let results: Vec<Result<DirectoryEntry, (PathBuf, std::io::Error)>> = pending
         .into_par_iter()
         .map(

--- a/crates/fast_io/src/cached_sort.rs
+++ b/crates/fast_io/src/cached_sort.rs
@@ -114,7 +114,9 @@ where
         return;
     }
 
-    // Parallel key extraction
+    // Ordering: keys must correspond 1:1 with items by position for correct permutation.
+    // Preserved by par_iter().map().collect() (rayon preserves index order).
+    // Violation permutes items by wrong keys, producing incorrectly sorted file lists.
     let keys: Vec<K> = items.par_iter().map(&key_fn).collect();
 
     // Sort indices by keys

--- a/crates/fast_io/src/parallel.rs
+++ b/crates/fast_io/src/parallel.rs
@@ -128,6 +128,9 @@ impl ParallelExecutor {
         U: Send,
         F: Fn(&T) -> io::Result<U> + Sync,
     {
+        // Ordering: fold+reduce does NOT preserve input order - successes arrive in
+        // arbitrary thread order. Errors carry their original index for identification.
+        // Callers must not assume positional correspondence with input items.
         let run = || -> (Vec<U>, Vec<(usize, io::Error)>) {
             items
                 .par_iter()
@@ -181,6 +184,8 @@ impl ParallelExecutor {
     {
         let bytes = AtomicU64::new(0);
 
+        // Ordering: fold+reduce does NOT preserve input order - same as process().
+        // Errors carry their original index. Callers must not assume positional order.
         let run = || -> (Vec<U>, Vec<(usize, io::Error)>) {
             paths
                 .par_iter()

--- a/crates/flist/src/batched_stat/cache.rs
+++ b/crates/flist/src/batched_stat/cache.rs
@@ -124,6 +124,9 @@ impl BatchedStatCache {
         paths: &[&Path],
         follow_symlinks: bool,
     ) -> Vec<io::Result<Arc<fs::Metadata>>> {
+        // Ordering: results must correspond 1:1 with input paths by position.
+        // Preserved by par_iter().map().collect() (rayon preserves index order).
+        // Violation mismatches metadata with paths, corrupting file list construction.
         paths
             .par_iter()
             .map(|path| self.get_or_fetch(path, follow_symlinks))

--- a/crates/flist/src/batched_stat/dir_stat.rs
+++ b/crates/flist/src/batched_stat/dir_stat.rs
@@ -146,6 +146,9 @@ impl DirectoryStatBatch {
         names: &[OsString],
         follow_symlinks: bool,
     ) -> Vec<io::Result<FstatResult>> {
+        // Ordering: results must correspond 1:1 with input names by position.
+        // Preserved by par_iter().map().collect() (rayon preserves index order).
+        // Violation mismatches metadata with file names.
         names
             .par_iter()
             .map(|name| self.stat_relative(name, follow_symlinks))

--- a/crates/flist/src/parallel.rs
+++ b/crates/flist/src/parallel.rs
@@ -77,6 +77,9 @@ where
     T: Send,
     F: Fn(&FileListEntry) -> T + Sync + Send,
 {
+    // Ordering: results correspond 1:1 with file list entries by position.
+    // Preserved by par_iter().map().collect() (rayon preserves index order).
+    // Violation mismatches computed values with file entries.
     entries.par_iter().map(f).collect()
 }
 
@@ -123,7 +126,9 @@ pub fn collect_paths_then_metadata_parallel(
     // Collect all paths first using std::fs::read_dir recursively
     let paths = collect_paths_recursive(&root, &root, follow_symlinks);
 
-    // Fetch metadata in parallel
+    // Ordering: wire protocol requires file list sorted by name for deterministic indices.
+    // Parallel metadata fetch does not preserve traversal order, so sort_file_entries()
+    // is applied after collection. Omitting the sort breaks file-list index agreement.
     let results: Vec<_> = paths
         .into_par_iter()
         .map(|(full_path, relative_path, depth, is_root)| {
@@ -318,6 +323,9 @@ pub fn collect_paths_chunked_parallel(
     let mut entries = Vec::with_capacity(paths.len());
     let mut errors = Vec::new();
 
+    // Ordering: same as collect_paths_then_metadata_parallel - post-sort required.
+    // Each chunk's par_iter preserves intra-chunk order, but final sort_file_entries()
+    // establishes the canonical wire order. Omitting the sort breaks index agreement.
     for chunk in paths.chunks(chunk_size) {
         let results: Vec<_> = chunk
             .par_iter()
@@ -385,6 +393,9 @@ pub fn collect_paths_chunked_parallel(
 pub fn resolve_metadata_parallel(
     entries: Vec<LazyFileListEntry>,
 ) -> Result<Vec<FileListEntry>, Vec<(PathBuf, std::io::Error)>> {
+    // Ordering: wire protocol requires sorted file list for deterministic indices.
+    // Parallel metadata resolution does not preserve input order, so
+    // sort_file_entries() is applied after. Omitting the sort breaks index agreement.
     let results: Vec<_> = entries
         .into_par_iter()
         .map(|entry| {

--- a/crates/signature/src/parallel.rs
+++ b/crates/signature/src/parallel.rs
@@ -133,6 +133,9 @@ pub fn generate_file_signature_parallel<R: Read>(
     // data-level parallelism for maximum throughput.
     const BATCH_SIZE: usize = 16;
 
+    // Ordering: block indices must match sequential file offsets for delta reconstruction.
+    // Preserved by par_chunks() + enumerate() assigning base_index from chunk position.
+    // Violation produces wrong block indices, causing corrupted file reconstruction.
     let blocks: Vec<SignatureBlock> = block_data
         .par_chunks(BATCH_SIZE)
         .enumerate()

--- a/crates/transfer/src/parallel_io.rs
+++ b/crates/transfer/src/parallel_io.rs
@@ -118,6 +118,9 @@ where
         return items.into_iter().map(&f).collect();
     }
 
+    // Ordering: callers zip results with input by position.
+    // Preserved by `into_par_iter().map().collect()` (rayon preserves index order).
+    // Violation breaks result-to-file correspondence, applying wrong metadata.
     items.into_par_iter().map(f).collect()
 }
 

--- a/crates/transfer/src/receiver/transfer/pipeline.rs
+++ b/crates/transfer/src/receiver/transfer/pipeline.rs
@@ -174,7 +174,9 @@ impl ReceiverContext {
                         let checksum_algorithm = setup.checksum_algorithm;
                         let sig_threshold = self.parallel_thresholds.signature;
 
-                        // Compute signatures - parallel when batch is large enough.
+                        // Ordering: wire protocol requires file requests in file-list index order.
+                        // Preserved by par_iter().map().collect() + sequential zip/send loop below.
+                        // Violation sends signatures for wrong files, corrupting delta transfer.
                         let sig_results: Vec<_> = if batch.len() >= sig_threshold {
                             batch
                                 .par_iter()


### PR DESCRIPTION
## Summary

- Added concise ordering contract comments at all 15 rayon parallelism boundaries across 12 files
- Each comment documents: what ordering is required, how it is preserved, and what breaks if violated
- Categorized sites by their ordering mechanism:
  - **`par_iter().map().collect()` (order-preserving):** `transfer/parallel_io.rs`, `transfer/receiver/pipeline.rs`, `flist/batched_stat/dir_stat.rs`, `flist/batched_stat/cache.rs`, `flist/parallel.rs` (process_entries), `checksums/parallel/blocks.rs` (2 sites), `checksums/parallel/files.rs` (2 sites), `engine/parallel_planner.rs`, `fast_io/cached_sort.rs`
  - **Post-sort after unordered parallel fetch:** `flist/parallel.rs` (3 sites: metadata, chunked, resolve), `engine/support.rs` (directory listing)
  - **Unordered fold+reduce (callers warned):** `fast_io/parallel.rs` (2 sites: process, process_files)
  - **Ordered par_chunks with explicit index tracking:** `signature/parallel.rs` (block signatures)

## Test plan

- [ ] Verify `cargo fmt --all -- --check` passes (comment-only changes)
- [ ] Verify `cargo clippy --workspace` passes
- [ ] Verify no test regressions in CI