### PR TITLE
feat: add io_uring backend info to transfer statistics summary

### DIFF
--- a/crates/cli/src/frontend/progress/render.rs
+++ b/crates/cli/src/frontend/progress/render.rs
@@ -1,6 +1,7 @@
 use std::io::{self, Write};
 
 use core::client::{ClientEvent, ClientEventKind, ClientSummary, HumanReadableMode};
+use fast_io::{is_io_uring_available, sqpoll_fell_back};
 
 use super::format::{
     compute_rate, describe_event_kind, event_matches_name_level, format_list_permissions,
@@ -280,6 +281,7 @@ pub(crate) fn emit_stats<W: Write + ?Sized>(
     )?;
     writeln!(stdout, "Total bytes sent: {bytes_sent_display}")?;
     writeln!(stdout, "Total bytes received: {bytes_received_display}")?;
+    writeln!(stdout, "I/O backend: {}", io_backend_label())?;
     writeln!(stdout)?;
 
     emit_totals(summary, stdout, human_readable, dry_run)
@@ -473,4 +475,41 @@ pub(crate) fn emit_verbose<W: Write + ?Sized>(
         }
     }
     Ok(())
+}
+
+/// Returns a human-readable label describing the I/O backend in use.
+///
+/// On Linux with io_uring available, reports whether SQPOLL mode is active
+/// or whether it fell back to standard submission. On non-Linux or when
+/// io_uring is unavailable, reports "standard I/O".
+fn io_backend_label() -> &'static str {
+    if is_io_uring_available() {
+        if sqpoll_fell_back() {
+            "io_uring"
+        } else {
+            "io_uring (SQPOLL)"
+        }
+    } else {
+        "standard I/O"
+    }
+}
+
+#[cfg(test)]
+mod io_backend_tests {
+    use super::*;
+
+    #[test]
+    fn io_backend_label_returns_known_value() {
+        let label = io_backend_label();
+        assert!(
+            label == "standard I/O" || label == "io_uring" || label == "io_uring (SQPOLL)",
+            "unexpected io_backend_label: {label}"
+        );
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    #[test]
+    fn io_backend_label_is_standard_on_non_linux() {
+        assert_eq!(io_backend_label(), "standard I/O");
+    }
 }


### PR DESCRIPTION
## Summary
- Adds an "I/O backend" line to the `--stats` output showing whether io_uring, io_uring (SQPOLL), or standard I/O was used during the transfer
- Leverages existing `fast_io::is_io_uring_available()` and `fast_io::sqpoll_fell_back()` APIs
- No-op on non-Linux (always shows "standard I/O")

## Test plan
- [x] Unit tests verify `io_backend_label()` returns a known value
- [x] Platform-specific test asserts "standard I/O" on non-Linux
- [x] `cargo clippy` passes
- [x] `cargo nextest run -p cli -E 'test(io_backend)'` passes