### PR TITLE
fix: eliminate TOCTOU race in daemon test port allocation

### DIFF
--- a/crates/daemon/src/config.rs
+++ b/crates/daemon/src/config.rs
@@ -9,12 +9,13 @@
 //! and default-path behaviour across the workspace.
 
 use std::ffi::OsString;
+use std::net::TcpListener;
 
 use core::branding::Brand;
 use platform::signal::SignalFlags;
 
 /// Configuration describing the requested daemon operation.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct DaemonConfig {
     brand: Brand,
     arguments: Vec<OsString>,
@@ -25,6 +26,24 @@ pub struct DaemonConfig {
     /// flags in response to stop/shutdown/paramchange events. When `None`,
     /// the daemon registers its own platform signal handlers on startup.
     signal_flags: Option<SignalFlags>,
+    /// Pre-bound TCP listener injected by test infrastructure.
+    ///
+    /// When set, the daemon accept loop uses this listener directly instead of
+    /// binding a new socket, eliminating the TOCTOU race between port allocation
+    /// and daemon bind in tests.
+    pre_bound_listener: Option<TcpListener>,
+}
+
+impl Clone for DaemonConfig {
+    fn clone(&self) -> Self {
+        Self {
+            brand: self.brand,
+            arguments: self.arguments.clone(),
+            load_default_paths: self.load_default_paths,
+            signal_flags: self.signal_flags.clone(),
+            pre_bound_listener: None,
+        }
+    }
 }
 
 impl PartialEq for DaemonConfig {
@@ -73,6 +92,16 @@ impl DaemonConfig {
         self.signal_flags.take()
     }
 
+    /// Returns an already-bound TCP listener for the daemon to accept on.
+    ///
+    /// When set, the daemon skips its own socket bind and uses this listener
+    /// directly. This eliminates the TOCTOU race between test port allocation
+    /// and daemon bind.
+    #[must_use]
+    pub fn take_pre_bound_listener(&mut self) -> Option<TcpListener> {
+        self.pre_bound_listener.take()
+    }
+
     /// Reports whether any daemon-specific arguments were provided.
     #[must_use]
     pub const fn has_runtime_request(&self) -> bool {
@@ -81,12 +110,25 @@ impl DaemonConfig {
 }
 
 /// Builder used to assemble a [`DaemonConfig`].
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct DaemonConfigBuilder {
     brand: Brand,
     arguments: Vec<OsString>,
     load_default_paths: bool,
     signal_flags: Option<SignalFlags>,
+    pre_bound_listener: Option<TcpListener>,
+}
+
+impl Clone for DaemonConfigBuilder {
+    fn clone(&self) -> Self {
+        Self {
+            brand: self.brand,
+            arguments: self.arguments.clone(),
+            load_default_paths: self.load_default_paths,
+            signal_flags: self.signal_flags.clone(),
+            pre_bound_listener: None,
+        }
+    }
 }
 
 impl PartialEq for DaemonConfigBuilder {
@@ -106,6 +148,19 @@ impl Default for DaemonConfigBuilder {
             arguments: Vec::new(),
             load_default_paths: true,
             signal_flags: None,
+            pre_bound_listener: None,
+        }
+    }
+}
+
+impl From<DaemonConfig> for DaemonConfigBuilder {
+    fn from(config: DaemonConfig) -> Self {
+        Self {
+            brand: config.brand,
+            arguments: config.arguments,
+            load_default_paths: config.load_default_paths,
+            signal_flags: config.signal_flags,
+            pre_bound_listener: config.pre_bound_listener,
         }
     }
 }
@@ -147,6 +202,17 @@ impl DaemonConfigBuilder {
         self
     }
 
+    /// Injects a pre-bound TCP listener for the daemon to accept on.
+    ///
+    /// When set, the daemon skips its own socket bind and uses this listener
+    /// directly. Intended for test infrastructure to eliminate the TOCTOU race
+    /// between port allocation and daemon bind.
+    #[must_use]
+    pub fn pre_bound_listener(mut self, listener: TcpListener) -> Self {
+        self.pre_bound_listener = Some(listener);
+        self
+    }
+
     /// Finalises the builder and constructs the [`DaemonConfig`].
     #[must_use]
     pub fn build(self) -> DaemonConfig {
@@ -155,6 +221,7 @@ impl DaemonConfigBuilder {
             arguments: self.arguments,
             load_default_paths: self.load_default_paths,
             signal_flags: self.signal_flags,
+            pre_bound_listener: self.pre_bound_listener,
         }
     }
 }

--- a/crates/daemon/src/daemon.rs
+++ b/crates/daemon/src/daemon.rs
@@ -170,12 +170,13 @@ include!("daemon/sections/group_expansion.rs");
 #[cfg_attr(feature = "tracing", instrument(skip(config), name = "daemon_run"))]
 pub fn run_daemon(mut config: DaemonConfig) -> Result<(), DaemonError> {
     let external_signal_flags = config.take_signal_flags();
+    let pre_bound_listener = config.take_pre_bound_listener();
     let options = RuntimeOptions::parse_with_brand(
         config.arguments(),
         config.brand(),
         config.load_default_paths(),
     )?;
-    serve_connections(options, external_signal_flags)
+    serve_connections(options, external_signal_flags, pre_bound_listener)
 }
 
 include!("daemon/sections/cli_args.rs");

--- a/crates/daemon/src/daemon/sections/server_runtime/accept_loop.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/accept_loop.rs
@@ -11,6 +11,7 @@
 fn serve_connections(
     options: RuntimeOptions,
     external_signal_flags: Option<platform::signal::SignalFlags>,
+    pre_bound_listener: Option<TcpListener>,
 ) -> Result<(), DaemonError> {
     // Use externally injected signal flags (from the Windows Service dispatcher)
     // when available, otherwise register platform signal handlers so SIGPIPE is
@@ -118,40 +119,57 @@ fn serve_connections(
         }
     };
 
-    // upstream: daemon-parm.txt - listen_backlog INTEGER, default 5.
-    // Using socket2 to create the listener allows explicit control over the
-    // backlog argument passed to listen(2).
-    const DEFAULT_LISTEN_BACKLOG: i32 = 5;
-    let backlog = listen_backlog.map_or(DEFAULT_LISTEN_BACKLOG, |v| v as i32);
+    // When a pre-bound listener is injected (test infrastructure), use it
+    // directly - skipping the bind step eliminates the TOCTOU race between
+    // port allocation and daemon bind.
+    let mut listeners: Vec<TcpListener>;
+    let mut bound_addresses: Vec<SocketAddr>;
 
-    let mut listeners: Vec<TcpListener> = Vec::with_capacity(bind_addresses.len());
-    let mut bound_addresses: Vec<SocketAddr> = Vec::with_capacity(bind_addresses.len());
+    if let Some(listener) = pre_bound_listener {
+        let local_addr = listener
+            .local_addr()
+            .unwrap_or_else(|_| SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port));
+        bound_addresses = vec![local_addr];
+        listeners = vec![listener];
+    } else {
+        // upstream: daemon-parm.txt - listen_backlog INTEGER, default 5.
+        // Using socket2 to create the listener allows explicit control over the
+        // backlog argument passed to listen(2).
+        const DEFAULT_LISTEN_BACKLOG: i32 = 5;
+        let backlog = listen_backlog.map_or(DEFAULT_LISTEN_BACKLOG, |v| v as i32);
 
-    for addr in &bind_addresses {
-        let requested_addr = SocketAddr::new(*addr, port);
-        match bind_with_backlog(requested_addr, backlog) {
-            Ok(listener) => {
-                let local_addr = listener.local_addr().unwrap_or(requested_addr);
-                bound_addresses.push(local_addr);
-                listeners.push(listener);
-            }
-            Err(error) => {
-                // If binding to one family fails (e.g., IPv6 not available), continue
-                // with the other family if we're in dual-stack mode. Otherwise, fail.
-                if bind_addresses.len() > 1 && !listeners.is_empty() {
-                    continue;
+        listeners = Vec::with_capacity(bind_addresses.len());
+        bound_addresses = Vec::with_capacity(bind_addresses.len());
+
+        for addr in &bind_addresses {
+            let requested_addr = SocketAddr::new(*addr, port);
+            match bind_with_backlog(requested_addr, backlog) {
+                Ok(listener) => {
+                    let local_addr = listener.local_addr().unwrap_or(requested_addr);
+                    bound_addresses.push(local_addr);
+                    listeners.push(listener);
                 }
-                return Err(bind_error(requested_addr, error));
+                Err(error) => {
+                    // If binding to one family fails (e.g., IPv6 not available), continue
+                    // with the other family if we're in dual-stack mode. Otherwise, fail.
+                    if bind_addresses.len() > 1 && !listeners.is_empty() {
+                        continue;
+                    }
+                    return Err(bind_error(requested_addr, error));
+                }
             }
         }
-    }
 
-    if listeners.is_empty() {
-        let requested_addr = SocketAddr::new(bind_addresses[0], port);
-        return Err(bind_error(
-            requested_addr,
-            io::Error::new(io::ErrorKind::AddrNotAvailable, "no addresses available to bind"),
-        ));
+        if listeners.is_empty() {
+            let requested_addr = SocketAddr::new(bind_addresses[0], port);
+            return Err(bind_error(
+                requested_addr,
+                io::Error::new(
+                    io::ErrorKind::AddrNotAvailable,
+                    "no addresses available to bind",
+                ),
+            ));
+        }
     }
 
     // upstream: socket.c:set_socket_options() - apply socket options to each

--- a/crates/daemon/src/tests/support.rs
+++ b/crates/daemon/src/tests/support.rs
@@ -199,6 +199,10 @@ pub(super) fn write_executable_script(path: &Path, contents: &str) {
 /// thread finishes before a connection succeeds the actual daemon error is
 /// included in the panic message instead of waiting for the full 30-second
 /// timeout.
+///
+/// The pre-bound `TcpListener` is passed directly to the daemon via
+/// `DaemonConfig`, eliminating the TOCTOU race between port allocation and
+/// daemon bind that previously caused flaky failures under CI load.
 pub(super) fn start_daemon(
     config: crate::DaemonConfig,
     port: u16,
@@ -207,9 +211,11 @@ pub(super) fn start_daemon(
     TcpStream,
     thread::JoinHandle<Result<(), crate::DaemonError>>,
 ) {
-    // Release the port reservation right before spawning the daemon thread
-    // to minimize the TOCTOU window between release and the daemon's bind.
-    drop(held_listener);
+    // Inject the already-bound listener into the config so the daemon uses it
+    // directly instead of binding a new socket to the same port.
+    let config = crate::DaemonConfigBuilder::from(config)
+        .pre_bound_listener(held_listener)
+        .build();
     let handle = thread::spawn(move || run_daemon(config));
     let stream = connect_to_daemon(port, Some(&handle));
     (stream, handle)

--- a/crates/protocol/tests/golden_protocol_v28_handshake.rs
+++ b/crates/protocol/tests/golden_protocol_v28_handshake.rs
@@ -192,13 +192,7 @@ fn golden_v28_daemon_server_greeting_bytes() {
     // This is exactly 14 bytes of ASCII text.
     let greeting = format_legacy_daemon_greeting(ProtocolVersion::V28);
 
-    #[rustfmt::skip]
-    let expected: &[u8] = &[
-        b'@', b'R', b'S', b'Y', b'N', b'C', b'D', b':', b' ',  // prefix (9 bytes)
-        b'2', b'8',                                               // version (2 bytes)
-        b'.', b'0',                                               // sub-version (2 bytes)
-        b'\n',                                                    // terminator (1 byte)
-    ];
+    let expected: &[u8] = b"@RSYNCD: 28.0\n";
 
     assert_eq!(greeting.as_bytes(), expected);
     assert_eq!(greeting.len(), 14, "greeting must be exactly 14 bytes");


### PR DESCRIPTION
## Summary
- Adds `pre_bound_listener` option to `DaemonConfig` allowing tests to inject an already-bound `TcpListener`
- When set, the daemon's `serve_connections` uses the injected listener directly, skipping the bind loop
- Test `start_daemon()` now passes the held listener through the config instead of dropping and rebinding
- Completely eliminates the TOCTOU race that caused flaky `daemon_negotiation_version_handles_whitespace_variations` failures in CI

## Test plan
- [ ] CI daemon tests pass without flaky failures
- [ ] No regression in daemon startup for production (pre_bound_listener defaults to None)