### PR TITLE
test: add io_uring fallback and availability diagnostic tests

### DIFF
--- a/crates/fast_io/src/io_uring/config.rs
+++ b/crates/fast_io/src/io_uring/config.rs
@@ -311,3 +311,111 @@ impl IoUringConfig {
             .map_err(|e| io::Error::other(format!("io_uring init failed: {e}")))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn probe_result_available_reason_contains_kernel_version() {
+        let result = IoUringProbeResult::Available { major: 6, minor: 1 };
+        let reason = result.reason();
+        assert!(reason.contains("io_uring available"));
+        assert!(reason.contains("6.1"));
+    }
+
+    #[test]
+    fn probe_result_no_kernel_release_reason() {
+        let result = IoUringProbeResult::NoKernelRelease;
+        let reason = result.reason();
+        assert!(reason.contains("unavailable"));
+        assert!(reason.contains("could not read kernel version"));
+    }
+
+    #[test]
+    fn probe_result_unparsable_version_reason() {
+        let result = IoUringProbeResult::UnparsableVersion;
+        let reason = result.reason();
+        assert!(reason.contains("unavailable"));
+        assert!(reason.contains("could not parse kernel version"));
+    }
+
+    #[test]
+    fn probe_result_kernel_too_old_reason() {
+        let result = IoUringProbeResult::KernelTooOld {
+            major: 4,
+            minor: 19,
+        };
+        let reason = result.reason();
+        assert!(reason.contains("unavailable"));
+        assert!(reason.contains("4.19"));
+        assert!(reason.contains("below minimum 5.6"));
+    }
+
+    #[test]
+    fn probe_result_syscall_blocked_reason() {
+        let result = IoUringProbeResult::SyscallBlocked {
+            major: 5,
+            minor: 15,
+        };
+        let reason = result.reason();
+        assert!(reason.contains("unavailable"));
+        assert!(reason.contains("5.15"));
+        assert!(reason.contains("blocked"));
+        assert!(reason.contains("seccomp"));
+    }
+
+    #[test]
+    fn probe_result_all_variants_start_with_io_uring_prefix() {
+        let variants: Vec<IoUringProbeResult> = vec![
+            IoUringProbeResult::Available { major: 6, minor: 8 },
+            IoUringProbeResult::NoKernelRelease,
+            IoUringProbeResult::UnparsableVersion,
+            IoUringProbeResult::KernelTooOld { major: 4, minor: 0 },
+            IoUringProbeResult::SyscallBlocked {
+                major: 5,
+                minor: 10,
+            },
+        ];
+
+        for variant in &variants {
+            let reason = variant.reason();
+            assert!(
+                reason.starts_with("io_uring "),
+                "all variants must start with 'io_uring ' prefix, got: {reason}"
+            );
+            assert!(
+                !reason.contains('\n'),
+                "reason must be single line, got: {reason}"
+            );
+        }
+    }
+
+    #[test]
+    fn sqpoll_fell_back_initial_state() {
+        // The SQPOLL_FALLBACK atomic starts as false. It is only set to true
+        // when build_ring() attempts SQPOLL and it fails.
+        assert!(!sqpoll_fell_back());
+    }
+
+    #[test]
+    fn parse_kernel_version_valid_strings() {
+        assert_eq!(parse_kernel_version("5.6.0"), Some((5, 6)));
+        assert_eq!(parse_kernel_version("5.15.0-generic"), Some((5, 15)));
+        assert_eq!(parse_kernel_version("6.1.0"), Some((6, 1)));
+        assert_eq!(parse_kernel_version("4.19.123-aws"), Some((4, 19)));
+    }
+
+    #[test]
+    fn parse_kernel_version_invalid_strings() {
+        assert_eq!(parse_kernel_version("invalid"), None);
+        assert_eq!(parse_kernel_version(""), None);
+    }
+
+    #[test]
+    fn config_detail_io_uring_availability_reason_is_non_empty() {
+        let reason = config_detail::io_uring_availability_reason();
+        assert!(!reason.is_empty());
+        assert!(reason.starts_with("io_uring "));
+    }
+}

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -575,4 +575,76 @@ mod io_uring_fallback_tests {
             "availability reason must not have leading/trailing whitespace"
         );
     }
+
+    #[test]
+    fn sqpoll_fell_back_starts_as_false() {
+        // SQPOLL fallback flag must default to false - it is only set when
+        // SQPOLL setup is attempted and fails on a Linux kernel.
+        assert!(
+            !sqpoll_fell_back(),
+            "sqpoll_fell_back() must be false at startup"
+        );
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    #[test]
+    fn factory_reader_falls_back_to_std_on_non_linux() {
+        use crate::traits::FileReaderFactory;
+        use io_uring::{IoUringOrStdReader, IoUringReaderFactory};
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("factory_fallback_reader.txt");
+        std::fs::write(&path, b"fallback test content").unwrap();
+
+        let factory = IoUringReaderFactory::default();
+        assert!(
+            !factory.will_use_io_uring(),
+            "factory must not use io_uring on non-Linux"
+        );
+
+        let reader = factory.open(&path).unwrap();
+        assert!(
+            matches!(reader, IoUringOrStdReader::Std(_)),
+            "reader must be Std variant on non-Linux"
+        );
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    #[test]
+    fn factory_writer_falls_back_to_std_on_non_linux() {
+        use crate::traits::FileWriterFactory;
+        use io_uring::{IoUringOrStdWriter, IoUringWriterFactory};
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("factory_fallback_writer.txt");
+
+        let factory = IoUringWriterFactory::default();
+        assert!(
+            !factory.will_use_io_uring(),
+            "factory must not use io_uring on non-Linux"
+        );
+
+        let writer = factory.create(&path).unwrap();
+        assert!(
+            matches!(writer, IoUringOrStdWriter::Std(_)),
+            "writer must be Std variant on non-Linux"
+        );
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    #[test]
+    fn factory_writer_create_with_size_falls_back_to_std_on_non_linux() {
+        use crate::traits::FileWriterFactory;
+        use io_uring::{IoUringOrStdWriter, IoUringWriterFactory};
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("factory_fallback_sized.txt");
+
+        let factory = IoUringWriterFactory::default();
+        let writer = factory.create_with_size(&path, 4096).unwrap();
+        assert!(
+            matches!(writer, IoUringOrStdWriter::Std(_)),
+            "sized writer must be Std variant on non-Linux"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- Add unit tests for `IoUringProbeResult` enum variants verifying each produces correct human-readable reason strings (Available, NoKernelRelease, UnparsableVersion, KernelTooOld, SyscallBlocked)
- Add test that `sqpoll_fell_back()` starts as false at process startup
- Add tests that `IoUringReaderFactory` and `IoUringWriterFactory` gracefully produce `Std` variants on non-Linux platforms
- Add kernel version parsing edge case tests in config.rs

## Test plan

- [ ] macOS CI passes (exercises non-Linux stub path and factory fallback tests)
- [ ] Linux CI passes (exercises IoUringProbeResult reason string tests in config.rs)
- [ ] Windows CI passes (no io_uring code compiled, tests are cfg-gated)