### PR TITLE
test: add cargo-fuzz targets for protocol wire format

### DIFF
--- a/crates/protocol/fuzz/Cargo.lock
+++ b/crates/protocol/fuzz/Cargo.lock
@@ -18,6 +18,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -36,8 +45,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "compress"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "flate2",
  "lz4_flex",
@@ -55,6 +73,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "derive_arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -63,6 +91,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -78,7 +116,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
 dependencies = [
  "crc32fast",
+ "libz-ng-sys",
  "miniz_oxide",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -120,8 +169,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "libz-ng-sys"
+version = "1.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be734b33b7bc6a42d92d23e25e69758f866cf564a88d0bf80866fcf5a52c2255"
+dependencies = [
+ "cmake",
+ "libc",
+]
+
+[[package]]
 name = "logging"
-version = "0.5.1"
+version = "0.6.0"
 
 [[package]]
 name = "lz4_flex"
@@ -130,6 +189,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08ab2867e3eeeca90e844d1940eab391c9dc5228783db2ed999acbc0a9ed375a"
 dependencies = [
  "twox-hash",
+]
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
 ]
 
 [[package]]
@@ -165,11 +234,14 @@ dependencies = [
 
 [[package]]
 name = "protocol"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "compress",
+ "flate2",
  "logging",
+ "md-5",
  "memchr",
+ "rustc-hash",
  "thiserror",
 ]
 
@@ -196,6 +268,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "shlex"
@@ -247,10 +325,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
+name = "typenum"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasip2"

--- a/crates/protocol/fuzz/Cargo.toml
+++ b/crates/protocol/fuzz/Cargo.toml
@@ -43,5 +43,26 @@ test = false
 doc = false
 bench = false
 
+[[bin]]
+name = "file_entry_roundtrip"
+path = "fuzz_targets/file_entry_roundtrip.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "multiplex_frame_roundtrip"
+path = "fuzz_targets/multiplex_frame.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "varint_roundtrip"
+path = "fuzz_targets/varint_roundtrip.rs"
+test = false
+doc = false
+bench = false
+
 # Standalone workspace - not part of root workspace
 [workspace]

--- a/crates/protocol/fuzz/fuzz_targets/file_entry_roundtrip.rs
+++ b/crates/protocol/fuzz/fuzz_targets/file_entry_roundtrip.rs
@@ -1,0 +1,280 @@
+#![no_main]
+
+//! Fuzz target for file entry wire format encode/decode roundtrip.
+//!
+//! Tests that file entry field encoding followed by decoding produces
+//! the original values. Uses structured input via `arbitrary` to generate
+//! valid parameter combinations, catching encode/decode mismatches and
+//! panics on edge-case inputs.
+
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+use std::io::Cursor;
+
+/// Structured input for file entry field roundtrip testing.
+#[derive(Arbitrary, Debug)]
+struct FileEntryInput {
+    /// File size to encode/decode.
+    size: u64,
+    /// Modification time to encode/decode.
+    mtime: i64,
+    /// Unix mode bits.
+    mode: u32,
+    /// User ID.
+    uid: u32,
+    /// Group ID.
+    gid: u32,
+    /// Protocol version selector (mapped to 28-32 range).
+    proto_selector: u8,
+    /// Whether to use varint flags encoding.
+    use_varint_flags: bool,
+    /// Whether the entry is a directory.
+    is_dir: bool,
+    /// XMIT flags value for flag encode/decode.
+    xflags: u16,
+    /// File name bytes (short, for prefix compression testing).
+    name: Vec<u8>,
+    /// Previous name bytes (for prefix compression).
+    prev_name: Vec<u8>,
+    /// Symlink target bytes.
+    symlink_target: Vec<u8>,
+    /// Access time.
+    atime: i64,
+    /// Creation time.
+    crtime: i64,
+    /// Checksum bytes (up to 16).
+    checksum: [u8; 16],
+    /// Checksum length (mapped to valid range).
+    csum_len_selector: u8,
+}
+
+impl FileEntryInput {
+    /// Maps the proto_selector to a valid protocol version (28-32).
+    fn protocol_version(&self) -> u8 {
+        28 + (self.proto_selector % 5)
+    }
+
+    /// Maps csum_len_selector to a valid checksum length (1-16).
+    fn csum_len(&self) -> usize {
+        1 + (self.csum_len_selector % 16) as usize
+    }
+}
+
+fuzz_target!(|input: FileEntryInput| {
+    let proto = input.protocol_version();
+
+    // Roundtrip: flags encode/decode
+    {
+        let mut buf = Vec::new();
+        let xflags = input.xflags as u32;
+        if protocol::wire::file_entry::encode_flags(
+            &mut buf,
+            xflags,
+            proto,
+            input.use_varint_flags,
+            input.is_dir,
+        )
+        .is_ok()
+        {
+            let mut cursor = Cursor::new(&buf);
+            let _ = protocol::wire::file_entry_decode::decode_flags(
+                &mut cursor,
+                proto,
+                input.use_varint_flags,
+            );
+        }
+    }
+
+    // Roundtrip: size encode/decode
+    {
+        // Clamp size to non-negative i64 range for wire format compatibility
+        let size = input.size & 0x7FFF_FFFF_FFFF_FFFF;
+        let mut buf = Vec::new();
+        if protocol::wire::file_entry::encode_size(&mut buf, size, proto).is_ok() {
+            let mut cursor = Cursor::new(&buf);
+            if let Ok(decoded) = protocol::wire::file_entry_decode::decode_size(&mut cursor, proto)
+            {
+                assert_eq!(decoded as u64, size, "size roundtrip mismatch");
+            }
+        }
+    }
+
+    // Roundtrip: mtime encode/decode
+    // Encode writes unconditionally; decode only reads when XMIT_SAME_TIME is NOT set.
+    // Use flags=0 so decode reads from wire.
+    {
+        let mut buf = Vec::new();
+        if protocol::wire::file_entry::encode_mtime(&mut buf, input.mtime, proto).is_ok() {
+            let mut cursor = Cursor::new(&buf);
+            if let Ok(Some(decoded)) =
+                protocol::wire::file_entry_decode::decode_mtime(&mut cursor, 0, 0, proto)
+            {
+                if proto >= 30 {
+                    assert_eq!(decoded, input.mtime, "mtime roundtrip mismatch (proto 30+)");
+                } else {
+                    // Proto < 30 truncates to i32
+                    assert_eq!(
+                        decoded, input.mtime as i32 as i64,
+                        "mtime roundtrip mismatch (proto < 30)"
+                    );
+                }
+            }
+        }
+    }
+
+    // Roundtrip: mode encode/decode
+    // Encode writes unconditionally; decode reads when XMIT_SAME_MODE is NOT set (flags=0).
+    {
+        let mut buf = Vec::new();
+        if protocol::wire::file_entry::encode_mode(&mut buf, input.mode).is_ok() {
+            let mut cursor = Cursor::new(&buf);
+            if let Ok(Some(decoded)) =
+                protocol::wire::file_entry_decode::decode_mode(&mut cursor, 0, 0)
+            {
+                assert_eq!(decoded, input.mode, "mode roundtrip mismatch");
+            }
+        }
+    }
+
+    // Roundtrip: uid encode/decode
+    // Use flags=0 (no XMIT_SAME_UID) so decode reads from wire.
+    {
+        let mut buf = Vec::new();
+        if protocol::wire::file_entry::encode_uid(&mut buf, input.uid, proto).is_ok() {
+            let mut cursor = Cursor::new(&buf);
+            if let Ok(Some((decoded_uid, _name))) =
+                protocol::wire::file_entry_decode::decode_uid(&mut cursor, 0, 0, proto)
+            {
+                assert_eq!(decoded_uid, input.uid, "uid roundtrip mismatch");
+            }
+        }
+    }
+
+    // Roundtrip: gid encode/decode
+    // Use flags=0 (no XMIT_SAME_GID) so decode reads from wire.
+    {
+        let mut buf = Vec::new();
+        if protocol::wire::file_entry::encode_gid(&mut buf, input.gid, proto).is_ok() {
+            let mut cursor = Cursor::new(&buf);
+            if let Ok(Some((decoded_gid, _name))) =
+                protocol::wire::file_entry_decode::decode_gid(&mut cursor, 0, 0, proto)
+            {
+                assert_eq!(decoded_gid, input.gid, "gid roundtrip mismatch");
+            }
+        }
+    }
+
+    // Roundtrip: name encode/decode with prefix compression
+    if !input.name.is_empty() {
+        let name = &input.name[..input.name.len().min(255)];
+        let prev_name = &input.prev_name[..input.prev_name.len().min(255)];
+
+        // Calculate prefix length
+        let same_len = name
+            .iter()
+            .zip(prev_name.iter())
+            .take_while(|(a, b)| a == b)
+            .count()
+            .min(255);
+
+        let mut xflags = 0u32;
+        if same_len > 0 {
+            xflags |= protocol::wire::file_entry::XMIT_SAME_NAME as u32;
+        }
+
+        let mut buf = Vec::new();
+        if protocol::wire::file_entry::encode_name(&mut buf, name, same_len, xflags, proto).is_ok()
+        {
+            let mut cursor = Cursor::new(&buf);
+            if let Ok(decoded) = protocol::wire::file_entry_decode::decode_name(
+                &mut cursor,
+                xflags,
+                prev_name,
+                proto,
+            ) {
+                assert_eq!(decoded, name, "name roundtrip mismatch");
+            }
+        }
+    }
+
+    // Roundtrip: symlink target encode/decode
+    if !input.symlink_target.is_empty() {
+        let target = &input.symlink_target[..input.symlink_target.len().min(4096)];
+        let mut buf = Vec::new();
+        if protocol::wire::file_entry::encode_symlink_target(&mut buf, target, proto).is_ok() {
+            let mut cursor = Cursor::new(&buf);
+            if let Ok(decoded) =
+                protocol::wire::file_entry_decode::decode_symlink_target(&mut cursor, proto)
+            {
+                assert_eq!(decoded, target, "symlink target roundtrip mismatch");
+            }
+        }
+    }
+
+    // Roundtrip: atime encode/decode
+    // Use flags=0 (no XMIT_SAME_ATIME) so decode reads from wire.
+    {
+        let mut buf = Vec::new();
+        if protocol::wire::file_entry::encode_atime(&mut buf, input.atime).is_ok() {
+            let mut cursor = Cursor::new(&buf);
+            if let Ok(Some(decoded)) =
+                protocol::wire::file_entry_decode::decode_atime(&mut cursor, 0, 0)
+            {
+                assert_eq!(decoded, input.atime, "atime roundtrip mismatch");
+            }
+        }
+    }
+
+    // Roundtrip: crtime encode/decode
+    // Use flags=0 (no XMIT_CRTIME_EQ_MTIME) so decode reads from wire.
+    {
+        let mut buf = Vec::new();
+        if protocol::wire::file_entry::encode_crtime(&mut buf, input.crtime).is_ok() {
+            let mut cursor = Cursor::new(&buf);
+            if let Ok(Some(decoded)) =
+                protocol::wire::file_entry_decode::decode_crtime(&mut cursor, 0, 0)
+            {
+                assert_eq!(decoded, input.crtime, "crtime roundtrip mismatch");
+            }
+        }
+    }
+
+    // Roundtrip: checksum encode/decode
+    {
+        let csum_len = input.csum_len();
+        let sum = &input.checksum[..csum_len.min(16)];
+        let mut buf = Vec::new();
+        if protocol::wire::file_entry::encode_checksum(&mut buf, Some(sum), csum_len).is_ok() {
+            let mut cursor = Cursor::new(&buf);
+            if let Ok(decoded) =
+                protocol::wire::file_entry_decode::decode_checksum(&mut cursor, csum_len)
+            {
+                assert_eq!(
+                    &decoded[..],
+                    &sum[..csum_len.min(sum.len())],
+                    "checksum roundtrip mismatch"
+                );
+            }
+        }
+    }
+
+    // Roundtrip: end marker encode/decode
+    {
+        let mut buf = Vec::new();
+        if protocol::wire::file_entry::encode_end_marker(
+            &mut buf,
+            input.use_varint_flags,
+            false,
+            None,
+        )
+        .is_ok()
+        {
+            let mut cursor = Cursor::new(&buf);
+            let _ = protocol::wire::file_entry_decode::decode_flags(
+                &mut cursor,
+                proto,
+                input.use_varint_flags,
+            );
+        }
+    }
+});

--- a/crates/protocol/fuzz/fuzz_targets/multiplex_frame.rs
+++ b/crates/protocol/fuzz/fuzz_targets/multiplex_frame.rs
@@ -1,0 +1,123 @@
+#![no_main]
+
+//! Fuzz target for multiplex frame encode/decode roundtrip.
+//!
+//! Tests `MessageFrame` and `BorrowedMessageFrame` encode/decode roundtrip
+//! with structured input. Also exercises `MessageHeader` parsing and
+//! `recv_msg`/`send_msg` with arbitrary byte streams to catch panics
+//! and logic errors in the multiplexing layer.
+
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+use std::io::Cursor;
+
+/// Structured input for multiplex frame roundtrip testing.
+#[derive(Arbitrary, Debug)]
+struct MplexInput {
+    /// Message code selector (mapped to valid codes).
+    code_selector: u8,
+    /// Payload bytes (capped at 64 KB for practical fuzzing).
+    payload: Vec<u8>,
+    /// Raw bytes for unstructured parsing tests.
+    raw_bytes: Vec<u8>,
+}
+
+impl MplexInput {
+    /// Maps code_selector to a valid `MessageCode`.
+    fn message_code(&self) -> protocol::MessageCode {
+        // Map to the most common message codes to get good coverage
+        match self.code_selector % 10 {
+            0 => protocol::MessageCode::Data,
+            1 => protocol::MessageCode::ErrorXfer,
+            2 => protocol::MessageCode::Info,
+            3 => protocol::MessageCode::Error,
+            4 => protocol::MessageCode::Warning,
+            5 => protocol::MessageCode::ErrorSocket,
+            6 => protocol::MessageCode::Log,
+            7 => protocol::MessageCode::Redo,
+            8 => protocol::MessageCode::Success,
+            _ => protocol::MessageCode::Deleted,
+        }
+    }
+}
+
+fuzz_target!(|input: MplexInput| {
+    let code = input.message_code();
+
+    // Cap payload to the 24-bit limit (16 MB) for valid frames,
+    // but also test oversized payloads for error handling
+    let payload = if input.payload.len() > 0xFF_FFFF {
+        &input.payload[..0xFF_FFFF]
+    } else {
+        &input.payload
+    };
+
+    // Roundtrip: MessageFrame encode/decode via Vec
+    if let Ok(frame) = protocol::MessageFrame::new(code, payload.to_vec()) {
+        let mut encoded = Vec::new();
+        if frame.encode_into_vec(&mut encoded).is_ok() {
+            if let Ok((decoded, remainder)) = protocol::MessageFrame::decode_from_slice(&encoded) {
+                assert!(
+                    remainder.is_empty(),
+                    "unexpected trailing bytes after roundtrip"
+                );
+                assert_eq!(decoded.code(), code, "message code mismatch");
+                assert_eq!(decoded.payload(), payload, "payload mismatch");
+            }
+        }
+    }
+
+    // Roundtrip: MessageFrame encode/decode via writer
+    if let Ok(frame) = protocol::MessageFrame::new(code, payload.to_vec()) {
+        let mut encoded = Vec::new();
+        if frame.encode_into_writer(&mut encoded).is_ok() {
+            let mut cursor = Cursor::new(&encoded);
+            if let Ok(decoded) = protocol::recv_msg(&mut cursor) {
+                assert_eq!(decoded.code(), code, "writer roundtrip code mismatch");
+                assert_eq!(
+                    decoded.payload(),
+                    payload,
+                    "writer roundtrip payload mismatch"
+                );
+            }
+        }
+    }
+
+    // Roundtrip: BorrowedMessageFrame decode from encoded frame
+    if let Ok(frame) = protocol::MessageFrame::new(code, payload.to_vec()) {
+        let mut encoded = Vec::new();
+        if frame.encode_into_vec(&mut encoded).is_ok() {
+            if let Ok((borrowed, remainder)) =
+                protocol::BorrowedMessageFrame::decode_from_slice(&encoded)
+            {
+                assert!(remainder.is_empty(), "borrowed: trailing bytes");
+                assert_eq!(borrowed.code(), code, "borrowed: code mismatch");
+                assert_eq!(borrowed.payload(), payload, "borrowed: payload mismatch");
+            }
+        }
+    }
+
+    // Test oversized payload rejection
+    if input.payload.len() > 0xFF_FFFF {
+        let result = protocol::MessageFrame::new(code, input.payload.clone());
+        assert!(result.is_err(), "oversized payload should be rejected");
+    }
+
+    // Unstructured: parse arbitrary bytes as MessageHeader
+    let _ = protocol::MessageHeader::decode(&input.raw_bytes);
+
+    // Unstructured: parse arbitrary bytes as BorrowedMessageFrame
+    let _ = protocol::BorrowedMessageFrame::decode_from_slice(&input.raw_bytes);
+
+    // Unstructured: parse arbitrary bytes via recv_msg
+    let mut cursor = Cursor::new(&input.raw_bytes);
+    let _ = protocol::recv_msg(&mut cursor);
+
+    // Unstructured: parse arbitrary bytes via recv_msg_into
+    let mut cursor = Cursor::new(&input.raw_bytes);
+    let mut buffer = Vec::new();
+    let _ = protocol::recv_msg_into(&mut cursor, &mut buffer);
+
+    // Unstructured: TryFrom<&[u8]> for MessageFrame
+    let _ = <protocol::MessageFrame as std::convert::TryFrom<&[u8]>>::try_from(&input.raw_bytes);
+});

--- a/crates/protocol/fuzz/fuzz_targets/varint_roundtrip.rs
+++ b/crates/protocol/fuzz/fuzz_targets/varint_roundtrip.rs
@@ -1,0 +1,260 @@
+#![no_main]
+
+//! Fuzz target for varint encode/decode roundtrip verification.
+//!
+//! Tests that encoding a value and decoding the result produces the
+//! original value, for all varint/varlong/longint formats. Uses
+//! structured input via `arbitrary` to generate values across the
+//! full range of each encoding.
+
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+use std::io::Cursor;
+
+/// Structured input for varint roundtrip testing.
+#[derive(Arbitrary, Debug)]
+struct VarintInput {
+    /// Value for varint (i32) roundtrip.
+    varint_value: i32,
+    /// Value for varlong (i64) roundtrip.
+    varlong_value: i64,
+    /// Value for longint (i64) roundtrip.
+    longint_value: i64,
+    /// Min bytes selector for varlong (mapped to 1-8).
+    min_bytes_selector: u8,
+    /// Protocol version selector for varint30 (mapped to 28-32).
+    proto_selector: u8,
+    /// Raw bytes for unstructured decode testing.
+    raw_bytes: Vec<u8>,
+    /// Stats roundtrip fields.
+    total_read: u64,
+    total_written: u64,
+    total_size: u64,
+    flist_buildtime: u64,
+    flist_xfertime: u64,
+    /// Delete stats fields.
+    del_files: u32,
+    del_dirs: u32,
+    del_symlinks: u32,
+    del_devices: u32,
+    del_specials: u32,
+}
+
+impl VarintInput {
+    /// Maps min_bytes_selector to a valid min_bytes value (1-8).
+    fn min_bytes(&self) -> u8 {
+        1 + (self.min_bytes_selector % 8)
+    }
+
+    /// Maps proto_selector to a valid protocol version (28-32).
+    fn protocol_version(&self) -> u8 {
+        28 + (self.proto_selector % 5)
+    }
+}
+
+fuzz_target!(|input: VarintInput| {
+    // Roundtrip: write_varint / read_varint
+    {
+        let mut buf = Vec::new();
+        if protocol::write_varint(&mut buf, input.varint_value).is_ok() {
+            let mut cursor = Cursor::new(&buf);
+            if let Ok(decoded) = protocol::read_varint(&mut cursor) {
+                assert_eq!(
+                    decoded, input.varint_value,
+                    "varint roundtrip mismatch for {}",
+                    input.varint_value
+                );
+            }
+        }
+    }
+
+    // Roundtrip: encode_varint_to_vec / decode_varint
+    {
+        let mut buf = Vec::new();
+        protocol::encode_varint_to_vec(input.varint_value, &mut buf);
+        if let Ok((decoded, remainder)) = protocol::decode_varint(&buf) {
+            assert!(remainder.is_empty(), "trailing bytes after decode_varint");
+            assert_eq!(
+                decoded, input.varint_value,
+                "encode/decode_varint roundtrip mismatch"
+            );
+        }
+    }
+
+    // Roundtrip: write_varlong / read_varlong
+    {
+        let min_bytes = input.min_bytes();
+        let mut buf = Vec::new();
+        if protocol::write_varlong(&mut buf, input.varlong_value, min_bytes).is_ok() {
+            let mut cursor = Cursor::new(&buf);
+            if let Ok(decoded) = protocol::read_varlong(&mut cursor, min_bytes) {
+                assert_eq!(
+                    decoded, input.varlong_value,
+                    "varlong roundtrip mismatch for {} (min_bytes={})",
+                    input.varlong_value, min_bytes
+                );
+            }
+        }
+    }
+
+    // Roundtrip: write_varlong30 / read_varlong30
+    {
+        let min_bytes = input.min_bytes();
+        let mut buf = Vec::new();
+        if protocol::write_varlong30(&mut buf, input.varlong_value, min_bytes).is_ok() {
+            let mut cursor = Cursor::new(&buf);
+            if let Ok(decoded) = protocol::read_varlong30(&mut cursor, min_bytes) {
+                assert_eq!(
+                    decoded, input.varlong_value,
+                    "varlong30 roundtrip mismatch for {} (min_bytes={})",
+                    input.varlong_value, min_bytes
+                );
+            }
+        }
+    }
+
+    // Roundtrip: write_longint / read_longint
+    {
+        let mut buf = Vec::new();
+        if protocol::write_longint(&mut buf, input.longint_value).is_ok() {
+            let mut cursor = Cursor::new(&buf);
+            if let Ok(decoded) = protocol::read_longint(&mut cursor) {
+                assert_eq!(
+                    decoded, input.longint_value,
+                    "longint roundtrip mismatch for {}",
+                    input.longint_value
+                );
+            }
+        }
+    }
+
+    // Roundtrip: write_int / read_int
+    {
+        let mut buf = Vec::new();
+        if protocol::write_int(&mut buf, input.varint_value).is_ok() {
+            let mut cursor = Cursor::new(&buf);
+            if let Ok(decoded) = protocol::read_int(&mut cursor) {
+                assert_eq!(
+                    decoded, input.varint_value,
+                    "int roundtrip mismatch for {}",
+                    input.varint_value
+                );
+            }
+        }
+    }
+
+    // Roundtrip: write_varint30_int / read_varint30_int
+    {
+        let proto = input.protocol_version();
+        let mut buf = Vec::new();
+        if protocol::write_varint30_int(&mut buf, input.varint_value, proto).is_ok() {
+            let mut cursor = Cursor::new(&buf);
+            if let Ok(decoded) = protocol::read_varint30_int(&mut cursor, proto) {
+                assert_eq!(
+                    decoded, input.varint_value,
+                    "varint30_int roundtrip mismatch for {} (proto={})",
+                    input.varint_value, proto
+                );
+            }
+        }
+    }
+
+    // Roundtrip: TransferStats write_to / read_from
+    {
+        // Clamp values to non-negative i64 range for wire format compatibility
+        let stats = protocol::TransferStats::with_bytes(
+            input.total_read & 0x7FFF_FFFF_FFFF_FFFF,
+            input.total_written & 0x7FFF_FFFF_FFFF_FFFF,
+            input.total_size & 0x7FFF_FFFF_FFFF_FFFF,
+        )
+        .with_flist_times(
+            input.flist_buildtime & 0x7FFF_FFFF_FFFF_FFFF,
+            input.flist_xfertime & 0x7FFF_FFFF_FFFF_FFFF,
+        );
+
+        // Test with protocol versions that support flist times (>= 29) and those that do not
+        for proto_num in [28u8, 29, 30, 31, 32] {
+            if let Ok(proto) = protocol::ProtocolVersion::try_from(proto_num) {
+                let mut buf = Vec::new();
+                if stats.write_to(&mut buf, proto).is_ok() {
+                    let mut cursor = Cursor::new(&buf);
+                    if let Ok(decoded) = protocol::TransferStats::read_from(&mut cursor, proto) {
+                        assert_eq!(
+                            decoded.total_read, stats.total_read,
+                            "stats total_read mismatch (proto={})",
+                            proto_num
+                        );
+                        assert_eq!(
+                            decoded.total_written, stats.total_written,
+                            "stats total_written mismatch (proto={})",
+                            proto_num
+                        );
+                        assert_eq!(
+                            decoded.total_size, stats.total_size,
+                            "stats total_size mismatch (proto={})",
+                            proto_num
+                        );
+                        if proto.supports_flist_times() {
+                            assert_eq!(
+                                decoded.flist_buildtime, stats.flist_buildtime,
+                                "stats flist_buildtime mismatch (proto={})",
+                                proto_num
+                            );
+                            assert_eq!(
+                                decoded.flist_xfertime, stats.flist_xfertime,
+                                "stats flist_xfertime mismatch (proto={})",
+                                proto_num
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Roundtrip: DeleteStats write_to / read_from
+    {
+        let del_stats = protocol::DeleteStats {
+            files: input.del_files,
+            dirs: input.del_dirs,
+            symlinks: input.del_symlinks,
+            devices: input.del_devices,
+            specials: input.del_specials,
+        };
+
+        let mut buf = Vec::new();
+        if del_stats.write_to(&mut buf).is_ok() {
+            let mut cursor = Cursor::new(&buf);
+            if let Ok(decoded) = protocol::DeleteStats::read_from(&mut cursor) {
+                assert_eq!(decoded, del_stats, "delete stats roundtrip mismatch");
+            }
+        }
+    }
+
+    // Unstructured: parse arbitrary bytes through all decode functions
+    {
+        let mut cursor = Cursor::new(&input.raw_bytes);
+        let _ = protocol::read_varint(&mut cursor);
+    }
+    for min_bytes in [1u8, 2, 3, 4, 5, 6, 7, 8] {
+        let mut cursor = Cursor::new(&input.raw_bytes);
+        let _ = protocol::read_varlong(&mut cursor, min_bytes);
+    }
+    {
+        let mut cursor = Cursor::new(&input.raw_bytes);
+        let _ = protocol::read_longint(&mut cursor);
+    }
+    {
+        let _ = protocol::decode_varint(&input.raw_bytes);
+    }
+    {
+        let mut cursor = Cursor::new(&input.raw_bytes);
+        let _ = protocol::DeleteStats::read_from(&mut cursor);
+    }
+    for proto_num in [28u8, 29, 30, 31, 32] {
+        if let Ok(proto) = protocol::ProtocolVersion::try_from(proto_num) {
+            let mut cursor = Cursor::new(&input.raw_bytes);
+            let _ = protocol::TransferStats::read_from(&mut cursor, proto);
+        }
+    }
+});


### PR DESCRIPTION
## Summary

- Add three new fuzz targets to `crates/protocol/fuzz/` using `libfuzzer-sys` and `arbitrary` for structured input generation
- **file_entry_roundtrip**: encode/decode roundtrip for all file entry wire fields (flags, size, mtime, mode, uid/gid, name prefix compression, symlink target, atime, crtime, checksum, end marker)
- **multiplex_frame**: `MessageFrame` and `BorrowedMessageFrame` encode/decode roundtrip via both Vec and writer paths, plus unstructured parsing of arbitrary bytes through `recv_msg`, `recv_msg_into`, and `MessageHeader::decode`
- **varint_roundtrip**: roundtrip for all varint/varlong/longint/varint30 formats, plus `TransferStats` and `DeleteStats` wire format roundtrip across all supported protocol versions (28-32)

## Test plan

- [x] All fuzz targets compile with `cargo check --all-targets` in the fuzz workspace
- [ ] CI passes (fmt, clippy, nextest on all platforms)
- [ ] Targets can be run with `cargo fuzz run <target>` (not required for merge)