### PR TITLE
feat: add process-level SSH connection establishment timeout

### DIFF
--- a/crates/core/src/client/remote/ssh_transfer.rs
+++ b/crates/core/src/client/remote/ssh_transfer.rs
@@ -548,7 +548,7 @@ fn run_server_over_ssh_connection(
     progress: Option<&mut dyn crate::server::TransferProgressCallback>,
     batch_ctx: Option<BatchContext>,
 ) -> Result<crate::server::ServerStats, ClientError> {
-    let (mut reader, mut writer, child_handle) = connection
+    let (mut reader, mut writer, mut child_handle) = connection
         .split()
         .map_err(|e| invalid_argument_error(&format!("failed to split SSH connection: {e}"), 23))?;
 
@@ -573,6 +573,16 @@ fn run_server_over_ssh_connection(
             ));
         }
     };
+
+    // Connection established - disarm the connect watchdog. If the watchdog
+    // already fired (timeout expired during handshake), map to exit code 35
+    // (RERR_CONTIMEOUT) matching upstream rsync's --contimeout behavior.
+    if let Err(e) = child_handle.cancel_connect_watchdog() {
+        return Err(invalid_argument_error(
+            &format!("{e}"),
+            crate::exit_code::ExitCode::ConnectionTimeout.as_i32(),
+        ));
+    }
     let transfer_result = crate::server::run_server_with_handshake(
         config,
         handshake,

--- a/crates/rsync_io/src/ssh/builder.rs
+++ b/crates/rsync_io/src/ssh/builder.rs
@@ -297,7 +297,13 @@ impl SshCommand {
         })?;
         let stderr = child.stderr.take();
 
-        Ok(SshConnection::new(child, Some(stdin), stdout, stderr))
+        Ok(SshConnection::new(
+            child,
+            Some(stdin),
+            stdout,
+            stderr,
+            self.connect_timeout,
+        ))
     }
 
     fn command_parts(&self) -> (OsString, Vec<OsString>) {

--- a/crates/rsync_io/src/ssh/connection.rs
+++ b/crates/rsync_io/src/ssh/connection.rs
@@ -8,8 +8,10 @@
 
 use std::io::{self, BufRead, BufReader, Read, Write};
 use std::process::{Child, ChildStderr, ChildStdin, ChildStdout, ExitStatus};
-use std::sync::{Arc, Mutex};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Condvar, Mutex};
 use std::thread::{self, JoinHandle};
+use std::time::Duration;
 
 use logging::debug_log;
 
@@ -35,25 +37,50 @@ pub struct SshConnection {
     stdin: Option<ChildStdin>,
     stdout: Option<ChildStdout>,
     stderr_drain: Option<StderrDrain>,
+    connect_watchdog: Option<ConnectWatchdog>,
 }
 
 impl SshConnection {
     /// Constructs a new connection from the spawned child process.
     ///
     /// If `stderr` is `Some`, a background thread is spawned immediately to
-    /// drain it, preventing pipe-buffer deadlocks.
+    /// drain it, preventing pipe-buffer deadlocks. If `connect_timeout` is
+    /// `Some`, a watchdog thread is armed that will kill the child process
+    /// if the connection is not established within the given duration. Call
+    /// [`cancel_connect_watchdog`](Self::cancel_connect_watchdog) after
+    /// the remote rsync version greeting is received to disarm it.
     pub(super) fn new(
         child: Child,
         stdin: Option<ChildStdin>,
         stdout: ChildStdout,
         stderr: Option<ChildStderr>,
+        connect_timeout: Option<Duration>,
     ) -> Self {
         let stderr_drain = stderr.map(StderrDrain::spawn);
+        let connect_watchdog = connect_timeout.map(|timeout| {
+            let pid = child.id();
+            ConnectWatchdog::arm(timeout, pid)
+        });
         Self {
             child: Some(child),
             stdin,
             stdout: Some(stdout),
             stderr_drain,
+            connect_watchdog,
+        }
+    }
+
+    /// Disarms the connection establishment watchdog.
+    ///
+    /// Call this after the SSH connection is confirmed as established (e.g.,
+    /// after receiving the remote rsync version greeting). If the watchdog has
+    /// already fired, this returns an error indicating the timeout expired.
+    /// If no watchdog was armed, this is a no-op.
+    pub fn cancel_connect_watchdog(&mut self) -> io::Result<()> {
+        if let Some(watchdog) = self.connect_watchdog.take() {
+            watchdog.cancel()
+        } else {
+            Ok(())
         }
     }
 
@@ -159,6 +186,7 @@ impl SshConnection {
         })?;
 
         let stderr_drain = self.stderr_drain.take();
+        let connect_watchdog = self.connect_watchdog.take();
 
         Ok((
             SshReader { stdout },
@@ -166,6 +194,7 @@ impl SshConnection {
             SshChildHandle {
                 child,
                 stderr_drain,
+                connect_watchdog,
             },
         ))
     }
@@ -329,6 +358,127 @@ impl Drop for StderrDrain {
     }
 }
 
+/// Background watchdog that kills the SSH child process if the connection
+/// is not established within a configurable timeout.
+///
+/// The watchdog thread sleeps on a condvar until either the timeout expires
+/// or the watchdog is cancelled. If the timeout fires, the thread sets the
+/// `fired` flag. The caller (or Drop) is responsible for killing the child
+/// process when the watchdog fires - the watchdog itself only signals that
+/// the timeout expired.
+///
+/// The condvar-based design avoids busy polling and allows the cancel path
+/// to wake the thread immediately.
+struct ConnectWatchdog {
+    cancelled: Arc<AtomicBool>,
+    fired: Arc<AtomicBool>,
+    condvar_pair: Arc<(Mutex<bool>, Condvar)>,
+    handle: Option<JoinHandle<()>>,
+    timeout: Duration,
+}
+
+impl ConnectWatchdog {
+    /// Arms a watchdog that will fire after `timeout`.
+    fn arm(timeout: Duration, child_pid: u32) -> Self {
+        let cancelled = Arc::new(AtomicBool::new(false));
+        let fired = Arc::new(AtomicBool::new(false));
+        let condvar_pair = Arc::new((Mutex::new(false), Condvar::new()));
+
+        let thread_cancelled = Arc::clone(&cancelled);
+        let thread_fired = Arc::clone(&fired);
+        let thread_pair = Arc::clone(&condvar_pair);
+
+        let handle = thread::Builder::new()
+            .name("ssh-connect-watchdog".into())
+            .spawn(move || {
+                let (lock, cvar) = &*thread_pair;
+                let guard = lock.lock().unwrap_or_else(|e| e.into_inner());
+                // Wait until timeout or cancellation signal.
+                let (_guard, result) = cvar
+                    .wait_timeout_while(guard, timeout, |notified| !*notified)
+                    .unwrap_or_else(|e| e.into_inner());
+
+                // If we were cancelled, exit quietly.
+                if thread_cancelled.load(Ordering::Acquire) {
+                    return;
+                }
+
+                // Timeout expired - set the fired flag. The child will be killed
+                // by the connection's Drop impl or when the caller checks the flag.
+                if result.timed_out() {
+                    thread_fired.store(true, Ordering::Release);
+                    debug_log!(
+                        Connect,
+                        1,
+                        "ssh connect watchdog: timeout after {timeout:?} for pid {child_pid}"
+                    );
+                }
+            })
+            .expect("failed to spawn ssh connect watchdog thread");
+
+        Self {
+            cancelled,
+            fired,
+            condvar_pair,
+            handle: Some(handle),
+            timeout,
+        }
+    }
+
+    /// Returns `true` if the watchdog timeout has fired.
+    fn has_fired(&self) -> bool {
+        self.fired.load(Ordering::Acquire)
+    }
+
+    /// Cancels the watchdog, preventing it from firing.
+    ///
+    /// Returns `Ok(())` if the watchdog was successfully cancelled before it
+    /// fired. Returns an `io::Error` with `ErrorKind::TimedOut` if the
+    /// watchdog already fired (meaning the timeout expired).
+    fn cancel(mut self) -> io::Result<()> {
+        self.cancelled.store(true, Ordering::Release);
+
+        // Wake the watchdog thread so it exits immediately.
+        let (lock, cvar) = &*self.condvar_pair;
+        if let Ok(mut notified) = lock.lock() {
+            *notified = true;
+            cvar.notify_one();
+        }
+
+        // Join the watchdog thread.
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+
+        if self.fired.load(Ordering::Acquire) {
+            Err(io::Error::new(
+                io::ErrorKind::TimedOut,
+                format!(
+                    "ssh connection establishment timed out after {} seconds",
+                    self.timeout.as_secs()
+                ),
+            ))
+        } else {
+            Ok(())
+        }
+    }
+}
+
+impl Drop for ConnectWatchdog {
+    fn drop(&mut self) {
+        // Signal cancellation so the thread exits if still running.
+        self.cancelled.store(true, Ordering::Release);
+        let (lock, cvar) = &*self.condvar_pair;
+        if let Ok(mut notified) = lock.lock() {
+            *notified = true;
+            cvar.notify_one();
+        }
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
 /// Handle to wait for SSH subprocess completion.
 ///
 /// When the connection is split, the stderr drain thread (spawned at connection
@@ -339,6 +489,7 @@ impl Drop for StderrDrain {
 pub struct SshChildHandle {
     child: Child,
     stderr_drain: Option<StderrDrain>,
+    connect_watchdog: Option<ConnectWatchdog>,
 }
 
 impl std::fmt::Debug for SshChildHandle {
@@ -349,11 +500,32 @@ impl std::fmt::Debug for SshChildHandle {
                 "stderr_drain",
                 &self.stderr_drain.as_ref().map(|_| "StderrDrain(active)"),
             )
+            .field(
+                "connect_watchdog",
+                &self
+                    .connect_watchdog
+                    .as_ref()
+                    .map(|_| "ConnectWatchdog(armed)"),
+            )
             .finish()
     }
 }
 
 impl SshChildHandle {
+    /// Disarms the connection establishment watchdog.
+    ///
+    /// Call this after the SSH connection is confirmed as established (e.g.,
+    /// after receiving the remote rsync version greeting). If the watchdog has
+    /// already fired, this returns an error indicating the timeout expired.
+    /// If no watchdog was armed, this is a no-op.
+    pub fn cancel_connect_watchdog(&mut self) -> io::Result<()> {
+        if let Some(watchdog) = self.connect_watchdog.take() {
+            watchdog.cancel()
+        } else {
+            Ok(())
+        }
+    }
+
     /// Returns the stderr output collected so far by the background drain thread.
     ///
     /// The returned bytes are bounded to the most recent [`STDERR_BUFFER_CAP`]
@@ -400,6 +572,9 @@ impl SshChildHandle {
 
 impl Drop for SshChildHandle {
     fn drop(&mut self) {
+        // Drop the watchdog first to stop the background thread.
+        drop(self.connect_watchdog.take());
+
         // Reap the child process to prevent zombies.
         // Unlike SshConnection::Drop, stdin is not owned here (it lives in
         // SshWriter) so we skip the close_stdin step.
@@ -420,6 +595,21 @@ impl Drop for SshChildHandle {
 
 impl Read for SshConnection {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        // Check whether the connect watchdog has fired before attempting a read.
+        // When the watchdog fires, the child will be killed by Drop, and reads
+        // would return EOF or a broken pipe error. Returning TimedOut gives the
+        // caller a clear signal to map to the appropriate exit code.
+        if let Some(ref watchdog) = self.connect_watchdog {
+            if watchdog.has_fired() {
+                return Err(io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    format!(
+                        "ssh connection establishment timed out after {} seconds",
+                        watchdog.timeout.as_secs()
+                    ),
+                ));
+            }
+        }
         match self.stdout.as_mut() {
             Some(stdout) => stdout.read(buf),
             None => Err(io::Error::new(
@@ -451,6 +641,9 @@ impl Write for SshConnection {
 
 impl Drop for SshConnection {
     fn drop(&mut self) {
+        // Drop the watchdog first to stop the background thread.
+        drop(self.connect_watchdog.take());
+
         let _ = self.close_stdin();
 
         if let Some(ref mut child) = self.child {

--- a/crates/rsync_io/src/ssh/tests.rs
+++ b/crates/rsync_io/src/ssh/tests.rs
@@ -1502,3 +1502,210 @@ fn connect_timeout_zero_duration() {
         "zero duration should produce ConnectTimeout=0: {rendered:?}"
     );
 }
+
+#[cfg(unix)]
+#[test]
+fn connect_watchdog_fires_on_timeout() {
+    use std::time::{Duration, Instant};
+
+    // Spawn a process that sleeps for a long time - simulating an SSH process
+    // that hangs during connection establishment.
+    let mut command = SshCommand::new("ignored");
+    command.set_program("sh");
+    command.set_batch_mode(false);
+    command.push_option("-c");
+    command.push_option("sleep 60");
+    command.set_target_override(Some(OsString::new()));
+    // Set a very short connect timeout to trigger the watchdog quickly.
+    command.set_connect_timeout(Some(Duration::from_millis(200)));
+
+    let start = Instant::now();
+    let mut connection = command.spawn().expect("spawn shell");
+
+    // Reading should fail with TimedOut once the watchdog fires.
+    let mut buf = [0u8; 1];
+    let result = connection.read(&mut buf);
+
+    let elapsed = start.elapsed();
+
+    // The read might return an OS-level error (broken pipe / EOF) if the child
+    // was killed before we checked the flag, or TimedOut if we check first.
+    // Either outcome is acceptable - the key invariant is that the read does
+    // not hang for 60 seconds.
+    assert!(
+        elapsed < Duration::from_secs(5),
+        "read should not hang - took {elapsed:?}"
+    );
+
+    match result {
+        Err(e) if e.kind() == std::io::ErrorKind::TimedOut => {
+            assert!(
+                e.to_string().contains("timed out"),
+                "error should mention timeout: {e}"
+            );
+        }
+        Err(_) => {
+            // OS-level error from killed child (broken pipe, EOF) is also acceptable.
+        }
+        Ok(0) => {
+            // EOF from killed child is acceptable.
+        }
+        Ok(n) => {
+            panic!("unexpected successful read of {n} bytes from sleeping process");
+        }
+    }
+
+    // cancel_connect_watchdog should report that the timeout fired.
+    let cancel_result = connection.cancel_connect_watchdog();
+    assert!(
+        cancel_result.is_err(),
+        "cancel should report timeout after watchdog fired"
+    );
+    let err = cancel_result.unwrap_err();
+    assert_eq!(err.kind(), std::io::ErrorKind::TimedOut);
+}
+
+#[cfg(unix)]
+#[test]
+fn connect_watchdog_cancelled_before_timeout() {
+    use std::time::Duration;
+
+    // Spawn a process that exits quickly - simulating a successful SSH connection.
+    let mut command = SshCommand::new("ignored");
+    command.set_program("sh");
+    command.set_batch_mode(false);
+    command.push_option("-c");
+    command.push_option("echo hello");
+    command.set_target_override(Some(OsString::new()));
+    // Set a generous timeout that should not fire.
+    command.set_connect_timeout(Some(Duration::from_secs(30)));
+
+    let mut connection = command.spawn().expect("spawn shell");
+
+    // Read the output - this simulates reading the version greeting.
+    let mut buf = [0u8; 16];
+    let n = connection.read(&mut buf).expect("read should succeed");
+    assert!(n > 0, "should read some data");
+
+    // Cancel the watchdog - should succeed since the timeout hasn't fired.
+    let result = connection.cancel_connect_watchdog();
+    assert!(
+        result.is_ok(),
+        "cancel should succeed when watchdog hasn't fired: {result:?}"
+    );
+
+    // Second cancel is a no-op.
+    let result2 = connection.cancel_connect_watchdog();
+    assert!(result2.is_ok(), "double cancel should be a no-op");
+}
+
+#[cfg(unix)]
+#[test]
+fn connect_watchdog_not_armed_when_timeout_is_none() {
+    use std::time::Duration;
+
+    let mut command = SshCommand::new("ignored");
+    command.set_program("sh");
+    command.set_batch_mode(false);
+    command.push_option("-c");
+    command.push_option("echo no-watchdog");
+    command.set_target_override(Some(OsString::new()));
+    command.set_connect_timeout(None);
+
+    let mut connection = command.spawn().expect("spawn shell");
+
+    // cancel_connect_watchdog is a no-op when no timeout is configured.
+    let result = connection.cancel_connect_watchdog();
+    assert!(result.is_ok(), "cancel without watchdog should be no-op");
+
+    // Read should work normally.
+    let mut buf = [0u8; 32];
+    let n = connection.read(&mut buf).expect("read");
+    assert!(n > 0);
+
+    let status = connection.wait().expect("wait");
+    assert!(status.success());
+    let _ = Duration::from_millis(0); // suppress unused import lint
+}
+
+#[cfg(unix)]
+#[test]
+fn connect_watchdog_transferred_to_child_handle_on_split() {
+    use std::time::Duration;
+
+    let mut command = SshCommand::new("ignored");
+    command.set_program("sh");
+    command.set_batch_mode(false);
+    command.push_option("-c");
+    command.push_option("echo split-test");
+    command.set_target_override(Some(OsString::new()));
+    command.set_connect_timeout(Some(Duration::from_secs(30)));
+
+    let connection = command.spawn().expect("spawn shell");
+    let (_reader, _writer, mut child_handle) = connection.split().expect("split");
+
+    // Cancel via child handle should succeed.
+    let result = child_handle.cancel_connect_watchdog();
+    assert!(
+        result.is_ok(),
+        "cancel via child handle should succeed: {result:?}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn connect_watchdog_fires_and_child_handle_reports_timeout() {
+    use std::time::Duration;
+
+    // Spawn a process that hangs, with a short timeout.
+    let mut command = SshCommand::new("ignored");
+    command.set_program("sh");
+    command.set_batch_mode(false);
+    command.push_option("-c");
+    command.push_option("sleep 60");
+    command.set_target_override(Some(OsString::new()));
+    command.set_connect_timeout(Some(Duration::from_millis(200)));
+
+    let connection = command.spawn().expect("spawn shell");
+    let (_reader, _writer, mut child_handle) = connection.split().expect("split");
+
+    // Wait for the watchdog to fire.
+    std::thread::sleep(Duration::from_millis(500));
+
+    let cancel_result = child_handle.cancel_connect_watchdog();
+    assert!(cancel_result.is_err(), "watchdog should have fired");
+    let err = cancel_result.unwrap_err();
+    assert_eq!(err.kind(), std::io::ErrorKind::TimedOut);
+    assert!(
+        err.to_string().contains("timed out"),
+        "error message should mention timeout: {err}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn connect_watchdog_error_message_includes_duration() {
+    use std::time::Duration;
+
+    let mut command = SshCommand::new("ignored");
+    command.set_program("sh");
+    command.set_batch_mode(false);
+    command.push_option("-c");
+    command.push_option("sleep 60");
+    command.set_target_override(Some(OsString::new()));
+    // Use a 2-second timeout - short enough for fast tests, long enough
+    // to produce a recognizable duration in the error message.
+    command.set_connect_timeout(Some(Duration::from_secs(2)));
+
+    let connection = command.spawn().expect("spawn shell");
+    let (_reader, _writer, mut child_handle) = connection.split().expect("split");
+
+    // Wait for the watchdog to fire.
+    std::thread::sleep(Duration::from_millis(2500));
+
+    let err = child_handle.cancel_connect_watchdog().unwrap_err();
+    assert!(
+        err.to_string().contains("2 seconds"),
+        "error should include the timeout duration: {err}"
+    );
+}


### PR DESCRIPTION
## Summary

- Add `ConnectWatchdog` to `SshConnection` that arms a background thread at spawn time, enforcing a hard deadline on SSH connection establishment
- When the watchdog fires, reads return `io::ErrorKind::TimedOut` with a clear message including the timeout duration; the child is killed on Drop
- Wire watchdog cancellation into `run_server_over_ssh_connection` after the handshake succeeds, mapping timeout to `ExitCode::ConnectionTimeout` (35 / `RERR_CONTIMEOUT`)
- Complements the existing `-oConnectTimeout=N` SSH option (TCP-level) by catching post-TCP hangs (key exchange, banner exchange)

## Test plan

- [x] `connect_watchdog_fires_on_timeout` - verifies watchdog kills hanging process and read returns TimedOut
- [x] `connect_watchdog_cancelled_before_timeout` - verifies successful cancel after normal connection
- [x] `connect_watchdog_not_armed_when_timeout_is_none` - verifies no-op when timeout disabled
- [x] `connect_watchdog_transferred_to_child_handle_on_split` - verifies watchdog survives split()
- [x] `connect_watchdog_fires_and_child_handle_reports_timeout` - verifies timeout via child handle path
- [x] `connect_watchdog_error_message_includes_duration` - verifies error message format
- [x] Full workspace compiles clean (`cargo check --workspace --all-features`)
- [x] Clippy passes (`cargo clippy -p rsync_io -p core --all-targets --all-features --no-deps -- -D warnings`)