### PR TITLE
feat: enable AES-GCM cipher auto-detection by default for SSH

### DIFF
--- a/crates/cli/src/frontend/arguments/parser/mod.rs
+++ b/crates/cli/src/frontend/arguments/parser/mod.rs
@@ -270,7 +270,9 @@ where
     } else {
         open_noatime_flag
     };
-    let prefer_aes_gcm = if matches.get_flag("aes") {
+    let prefer_aes_gcm = if matches.get_flag("no-aes") {
+        Some(false)
+    } else if matches.get_flag("aes") {
         Some(true)
     } else {
         None

--- a/crates/cli/src/frontend/command_builder/sections/connection_and_logging_options.rs
+++ b/crates/cli/src/frontend/command_builder/sections/connection_and_logging_options.rs
@@ -127,8 +127,16 @@ pub(crate) fn add_connection_and_logging_options(command: ClapCommand) -> ClapCo
         .arg(
             Arg::new("aes")
                 .long("aes")
-                .help("Force AES-GCM ciphers for SSH (hardware-accelerated on AES-NI/ARMv8).")
-                .action(ArgAction::SetTrue),
+                .help("Force AES-GCM ciphers for SSH even without hardware AES detection.")
+                .action(ArgAction::SetTrue)
+                .overrides_with("no-aes"),
+        )
+        .arg(
+            Arg::new("no-aes")
+                .long("no-aes")
+                .help("Disable automatic AES-GCM cipher selection for SSH.")
+                .action(ArgAction::SetTrue)
+                .overrides_with("aes"),
         )
         .arg(
             Arg::new("iconv")

--- a/crates/rsync_io/src/ssh/builder.rs
+++ b/crates/rsync_io/src/ssh/builder.rs
@@ -412,11 +412,19 @@ impl SshCommand {
     }
 
     /// Checks whether the configured program appears to be an SSH client.
+    ///
+    /// Uses case-insensitive comparison on Windows where `SSH.EXE` or
+    /// `Ssh.exe` are common depending on how the path is resolved.
     fn is_ssh_program(&self) -> bool {
         let program = self.program.to_string_lossy();
         // Handle both forward slash (Unix) and backslash (Windows) path separators.
         let basename = program.rsplit(['/', '\\']).next().unwrap_or(&program);
-        basename == "ssh" || basename == "ssh.exe"
+        if cfg!(windows) {
+            let lower = basename.to_ascii_lowercase();
+            lower == "ssh" || lower == "ssh.exe"
+        } else {
+            basename == "ssh" || basename == "ssh.exe"
+        }
     }
 
     /// Checks whether any existing option already specifies the `-c` cipher flag.

--- a/crates/rsync_io/src/ssh/builder.rs
+++ b/crates/rsync_io/src/ssh/builder.rs
@@ -392,23 +392,23 @@ impl SshCommand {
 
     /// Determines whether AES-GCM cipher arguments should be injected.
     ///
-    /// Returns `true` only when all four conditions are met:
+    /// Returns `true` when all of these conditions are met:
     ///
-    /// 1. `prefer_aes_gcm` is `Some(true)` (caller opted in).
+    /// 1. `prefer_aes_gcm` is not `Some(false)` (caller has not opted out).
     /// 2. The CPU has hardware AES - AES-NI on x86/x86_64, or the `aes`
     ///    feature on aarch64 (see [`has_hardware_aes`]).
     /// 3. The program basename is `ssh` or `ssh.exe`.
     /// 4. No existing option already contains `-c` (the user has not specified
     ///    a cipher via `-e "ssh -c ..."` or `push_option`).
     ///
-    /// Returns `false` otherwise - including when `prefer_aes_gcm` is `None`
-    /// (the default, meaning no preference) or `Some(false)` (explicitly
-    /// disabled).
+    /// Returns `false` when `prefer_aes_gcm` is `Some(false)` (explicitly
+    /// disabled via `--no-aes`) or when any hardware/program/cipher guard
+    /// fails.
     fn should_inject_aes_gcm_ciphers(&self) -> bool {
-        matches!(self.prefer_aes_gcm, Some(true))
-            && has_hardware_aes()
-            && self.is_ssh_program()
-            && !self.options_contain_cipher_flag()
+        if matches!(self.prefer_aes_gcm, Some(false)) {
+            return false;
+        }
+        has_hardware_aes() && self.is_ssh_program() && !self.options_contain_cipher_flag()
     }
 
     /// Checks whether the configured program appears to be an SSH client.

--- a/crates/rsync_io/src/ssh/tests.rs
+++ b/crates/rsync_io/src/ssh/tests.rs
@@ -513,24 +513,35 @@ fn omits_cipher_args_when_aes_explicitly_disabled() {
 
 #[test]
 fn auto_detects_aes_when_preference_is_none() {
-    // Default (None) does not inject cipher args, preserving backward compatibility
+    use super::builder::has_hardware_aes;
+
+    // Default (None) auto-detects hardware AES and injects ciphers when available.
     let command = SshCommand::new("example.com");
     let (_, args) = command.command_parts_for_testing();
     let rendered = args_to_strings(&args);
 
-    assert!(!rendered.iter().any(|a| a == "-c"));
+    assert_eq!(
+        rendered.iter().any(|a| a == "-c"),
+        has_hardware_aes(),
+        "cipher injection should match hardware AES availability when preference is None"
+    );
 }
 
 #[test]
-fn skips_cipher_injection_when_custom_options_present() {
-    // Auto-detect with custom options present -> no cipher injection
+fn skips_cipher_injection_when_cipher_option_present() {
+    // User-specified `-c` prevents automatic AES-GCM injection regardless
+    // of hardware support.
     let mut command = SshCommand::new("example.com");
-    command.push_option("-v");
+    command.push_option("-c");
+    command.push_option("chacha20-poly1305@openssh.com");
 
     let (_, args) = command.command_parts_for_testing();
     let rendered = args_to_strings(&args);
 
-    assert!(!rendered.iter().any(|a| a == "-c"));
+    assert!(
+        !rendered.contains(&"aes128-gcm@openssh.com,aes256-gcm@openssh.com".to_owned()),
+        "should not inject AES-GCM when user specified -c: {rendered:?}"
+    );
 }
 
 #[test]
@@ -1364,22 +1375,19 @@ fn no_aes_gcm_injection_without_hardware_and_user_cipher() {
 }
 
 #[test]
-fn no_aes_gcm_injection_when_all_conditions_fail() {
-    // Exercises the case where every guard in should_inject_aes_gcm_ciphers()
-    // causes rejection: preference is None, program is not SSH, and custom
-    // options contain -c. On platforms without hardware AES (some VMs,
-    // older x86 without AES-NI), the hardware check also returns false.
+fn no_aes_gcm_injection_when_explicitly_disabled() {
+    // Exercises the case where the user opts out via `--no-aes`: even with
+    // an SSH program and no existing cipher option, `Some(false)` prevents
+    // injection regardless of hardware support.
     let mut command = SshCommand::new("example.com");
-    command.set_program("plink");
-    command.set_prefer_aes_gcm(None);
-    command.push_option("-c");
+    command.set_prefer_aes_gcm(Some(false));
 
     let (_, args) = command.command_parts_for_testing();
     let rendered = args_to_strings(&args);
 
     assert!(
         !rendered.contains(&"aes128-gcm@openssh.com,aes256-gcm@openssh.com".to_owned()),
-        "no AES-GCM injection when all conditions fail: {rendered:?}"
+        "no AES-GCM injection when explicitly disabled via --no-aes: {rendered:?}"
     );
 }
 

--- a/crates/rsync_io/src/ssh/tests.rs
+++ b/crates/rsync_io/src/ssh/tests.rs
@@ -14,7 +14,8 @@ fn args_to_strings(args: &[OsString]) -> Vec<String> {
 
 #[test]
 fn assembles_minimal_command_with_batch_mode() {
-    let command = SshCommand::new("example.com");
+    let mut command = SshCommand::new("example.com");
+    command.set_prefer_aes_gcm(Some(false));
     let (program, args) = command.command_parts_for_testing();
 
     assert_eq!(program, OsString::from("ssh"));
@@ -33,6 +34,7 @@ fn assembles_minimal_command_with_batch_mode() {
 #[test]
 fn assembles_command_with_user_port_and_remote_args() {
     let mut command = SshCommand::new("rsync.example.com");
+    command.set_prefer_aes_gcm(Some(false));
     command.set_user("backup");
     command.set_port(2222);
     command.push_option("-vvv");
@@ -64,6 +66,7 @@ fn assembles_command_with_user_port_and_remote_args() {
 #[test]
 fn disables_batch_mode_when_requested() {
     let mut command = SshCommand::new("example.com");
+    command.set_prefer_aes_gcm(Some(false));
     command.set_batch_mode(false);
 
     let (_, args) = command.command_parts_for_testing();
@@ -80,7 +83,8 @@ fn disables_batch_mode_when_requested() {
 
 #[test]
 fn wraps_ipv6_hosts_in_brackets() {
-    let command = SshCommand::new("2001:db8::1");
+    let mut command = SshCommand::new("2001:db8::1");
+    command.set_prefer_aes_gcm(Some(false));
     let (_, args) = command.command_parts_for_testing();
 
     assert_eq!(
@@ -98,6 +102,7 @@ fn wraps_ipv6_hosts_in_brackets() {
 #[test]
 fn wraps_ipv6_hosts_with_usernames() {
     let mut command = SshCommand::new("2001:db8::1");
+    command.set_prefer_aes_gcm(Some(false));
     command.set_user("backup");
 
     let (_, args) = command.command_parts_for_testing();
@@ -117,6 +122,7 @@ fn wraps_ipv6_hosts_with_usernames() {
 #[test]
 fn preserves_explicit_bracketed_ipv6_literals() {
     let mut command = SshCommand::new("[2001:db8::1]");
+    command.set_prefer_aes_gcm(Some(false));
     command.set_user("backup");
 
     let (_, args) = command.command_parts_for_testing();
@@ -136,6 +142,7 @@ fn preserves_explicit_bracketed_ipv6_literals() {
 #[test]
 fn command_parts_skip_target_when_host_and_user_missing() {
     let mut command = SshCommand::new("");
+    command.set_prefer_aes_gcm(Some(false));
     command.set_remote_command([OsString::from("rsync")]);
 
     let (_, args) = command.command_parts_for_testing();
@@ -155,6 +162,7 @@ fn command_parts_skip_target_when_host_and_user_missing() {
 #[test]
 fn target_override_supersedes_computed_target() {
     let mut command = SshCommand::new("example.com");
+    command.set_prefer_aes_gcm(Some(false));
     command.set_user("backup");
     command.set_target_override(Some("custom-target"));
 
@@ -175,6 +183,7 @@ fn target_override_supersedes_computed_target() {
 #[test]
 fn empty_target_override_suppresses_target_argument() {
     let mut command = SshCommand::new("example.com");
+    command.set_prefer_aes_gcm(Some(false));
     command.set_target_override(Some(OsString::new()));
     command.push_remote_arg("rsync");
 


### PR DESCRIPTION
## Summary
- AES-GCM ciphers are now automatically injected for SSH connections when hardware AES is available, the program is `ssh`, and the user hasn't specified a cipher via `-c`
- Previously required explicit `--aes` flag; now the default behavior leverages hardware acceleration when conditions are met
- Added `--no-aes` flag to explicitly disable automatic cipher selection

## Test plan
- [ ] Verify `auto_detects_aes_when_preference_is_none` test passes on hardware with AES support
- [ ] Verify `no_aes_gcm_injection_when_explicitly_disabled` test passes (--no-aes opt-out)
- [ ] Verify `skips_cipher_injection_when_cipher_option_present` prevents double-injection
- [ ] Verify SSH interop tests still pass (cipher change is transparent to rsync protocol)