### PR TITLE
fix: detect combined and compound SSH cipher flag forms in AES-GCM injection guard

### DIFF
--- a/crates/rsync_io/src/ssh/builder.rs
+++ b/crates/rsync_io/src/ssh/builder.rs
@@ -434,8 +434,19 @@ impl SshCommand {
     }
 
     /// Checks whether any existing option already specifies the `-c` cipher flag.
+    ///
+    /// Detects three forms:
+    /// - Split: `-c` as a standalone element followed by the cipher name in
+    ///   the next element.
+    /// - Combined: `-caes128-ctr` where the cipher name is concatenated
+    ///   directly after `-c` without whitespace. SSH accepts this form.
+    /// - Compound: `-c aes128-ctr` as a single unsplit string (e.g., from a
+    ///   `push_option` call that did not split on whitespace).
     fn options_contain_cipher_flag(&self) -> bool {
-        self.options.iter().any(|opt| opt == "-c")
+        self.options.iter().any(|opt| {
+            let s = opt.to_string_lossy();
+            s == "-c" || (s.starts_with("-c") && s.len() > 2)
+        })
     }
 
     /// Determines whether SSH keepalive options should be injected.

--- a/crates/rsync_io/src/ssh/tests.rs
+++ b/crates/rsync_io/src/ssh/tests.rs
@@ -1401,6 +1401,89 @@ fn no_aes_gcm_injection_when_explicitly_disabled() {
 }
 
 #[test]
+fn skips_cipher_injection_when_combined_cipher_option_present() {
+    // User specified `-caes128-ctr` (combined form without space) via push_option.
+    // The cipher flag detection must recognise this as a user-specified cipher.
+    let mut command = SshCommand::new("example.com");
+    command.push_option("-caes128-ctr");
+
+    let (_, args) = command.command_parts_for_testing();
+    let rendered = args_to_strings(&args);
+
+    assert!(
+        !rendered.contains(&"aes128-gcm@openssh.com,aes256-gcm@openssh.com".to_owned()),
+        "should not inject AES-GCM when user specified combined -c form: {rendered:?}"
+    );
+    assert!(
+        rendered.contains(&"-caes128-ctr".to_owned()),
+        "user combined cipher option should be preserved: {rendered:?}"
+    );
+}
+
+#[test]
+fn skips_cipher_injection_when_compound_cipher_option_present() {
+    // User specified `-c aes128-ctr` as a single unsplit option string.
+    // This can happen when push_option is called without splitting on whitespace.
+    let mut command = SshCommand::new("example.com");
+    command.push_option("-c aes128-ctr");
+
+    let (_, args) = command.command_parts_for_testing();
+    let rendered = args_to_strings(&args);
+
+    assert!(
+        !rendered.contains(&"aes128-gcm@openssh.com,aes256-gcm@openssh.com".to_owned()),
+        "should not inject AES-GCM when user specified compound -c form: {rendered:?}"
+    );
+}
+
+#[test]
+fn skips_cipher_injection_when_remote_shell_contains_cipher() {
+    // User specified `-e "ssh -c aes128-ctr"`. The parser splits this into
+    // separate tokens, so `-c` appears as a standalone option element.
+    let mut command = SshCommand::new("example.com");
+    command
+        .configure_remote_shell(OsStr::new("ssh -c aes128-ctr"))
+        .expect("valid remote shell");
+
+    let (_, args) = command.command_parts_for_testing();
+    let rendered = args_to_strings(&args);
+
+    assert!(
+        !rendered.contains(&"aes128-gcm@openssh.com,aes256-gcm@openssh.com".to_owned()),
+        "should not inject AES-GCM when remote shell specifies -c: {rendered:?}"
+    );
+    assert!(
+        rendered.contains(&"-c".to_owned()),
+        "user -c flag should be preserved: {rendered:?}"
+    );
+    assert!(
+        rendered.contains(&"aes128-ctr".to_owned()),
+        "user cipher name should be preserved: {rendered:?}"
+    );
+}
+
+#[test]
+fn skips_cipher_injection_when_remote_shell_has_combined_cipher() {
+    // User specified `-e "ssh -caes256-ctr"` (combined form in remote shell).
+    let mut command = SshCommand::new("example.com");
+    command
+        .configure_remote_shell(OsStr::new("ssh -caes256-ctr"))
+        .expect("valid remote shell");
+
+    let (_, args) = command.command_parts_for_testing();
+    let rendered = args_to_strings(&args);
+
+    assert!(
+        !rendered.contains(&"aes128-gcm@openssh.com,aes256-gcm@openssh.com".to_owned()),
+        "should not inject AES-GCM when remote shell has combined -c: {rendered:?}"
+    );
+    assert!(
+        rendered.contains(&"-caes256-ctr".to_owned()),
+        "user combined cipher should be preserved: {rendered:?}"
+    );
+}
+
+#[test]
 fn connect_timeout_injected_by_default() {
     let command = SshCommand::new("example.com");
     let (_, args) = command.command_parts_for_testing();


### PR DESCRIPTION
## Summary

- Fix `options_contain_cipher_flag()` in `SshCommand` to detect `-c` cipher flags in combined form (`-caes128-ctr`) and compound form (`-c aes128-ctr`), not just the standalone `-c` form.
- Previously, AES-GCM ciphers were auto-injected even when the user specified a cipher via `-e "ssh -caes128-ctr"` or a single compound option string, causing conflicting cipher selections.
- Add four tests covering: combined form via `push_option`, compound form via `push_option`, split form via `configure_remote_shell`, and combined form via `configure_remote_shell`.

## Test plan

- [ ] CI passes (fmt, clippy, nextest on all platforms)
- [ ] New tests verify combined `-caes128-ctr` blocks AES-GCM injection
- [ ] New tests verify compound `-c aes128-ctr` blocks AES-GCM injection
- [ ] New tests verify `-e "ssh -c aes128-ctr"` parsed via `configure_remote_shell` blocks injection
- [ ] Existing cipher detection tests continue to pass