### PR TITLE
refactor: expose BufferPool types for cross-crate reuse

### DIFF
--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -195,6 +195,20 @@ pub use fuzzy::{FUZZY_LEVEL_1, FUZZY_LEVEL_2, FuzzyMatch, FuzzyMatcher, compute_
 /// Hardlink detection and resolution.
 pub use hardlink::{HardlinkAction, HardlinkGroup, HardlinkKey, HardlinkResolver, HardlinkTracker};
 
+/// Buffer pool for cross-crate I/O buffer reuse.
+///
+/// The pool uses a two-level cache (thread-local fast path + central Mutex) to
+/// eliminate per-file allocation overhead on the hot transfer path. Buffers are
+/// returned automatically via RAII guards on drop.
+///
+/// Use [`global_buffer_pool`] for the process-wide singleton, or create a
+/// dedicated [`BufferPool`] for isolated subsystems.
+pub use local_copy::{
+    BorrowedBufferGuard, BufferAllocator, BufferGuard, BufferPool, BufferPoolStats,
+    DefaultAllocator, GlobalBufferPoolConfig, ThroughputTracker, global_buffer_pool,
+    init_global_buffer_pool,
+};
+
 /// Local filesystem copy operations.
 pub use local_copy::{
     BuilderError, DeleteTiming, HardlinkApplyResult, HardlinkApplyTracker, LocalCopyArgumentError,

--- a/crates/engine/src/local_copy/mod.rs
+++ b/crates/engine/src/local_copy/mod.rs
@@ -92,8 +92,9 @@ mod skip_compress;
 pub mod win_copy;
 
 pub use buffer_pool::{
-    BufferAllocator, BufferGuard, BufferPool, DefaultAllocator, GlobalBufferPoolConfig,
-    ThroughputTracker, global_buffer_pool, init_global_buffer_pool,
+    BorrowedBufferGuard, BufferAllocator, BufferGuard, BufferPool, BufferPoolStats,
+    DefaultAllocator, GlobalBufferPoolConfig, ThroughputTracker, global_buffer_pool,
+    init_global_buffer_pool,
 };
 pub use deferred_sync::{DeferredSync, SyncStrategy};
 

--- a/crates/transfer/tests/buffer_pool_cross_crate.rs
+++ b/crates/transfer/tests/buffer_pool_cross_crate.rs
@@ -17,8 +17,11 @@ fn acquire_and_return_via_public_api() {
     guard[0] = 0xAB;
     assert_eq!(guard[0], 0xAB);
 
-    // Drop returns the buffer to the pool.
+    // Acquire a second buffer so the first drop fills the thread-local slot
+    // and the second overflows to the central pool where available() counts.
+    let guard2: BufferGuard = BufferPool::acquire_from(Arc::clone(&pool));
     drop(guard);
+    drop(guard2);
     assert_eq!(pool.available(), 1);
 }
 
@@ -26,9 +29,13 @@ fn acquire_and_return_via_public_api() {
 fn borrowed_guard_via_public_api() {
     let pool = BufferPool::with_buffer_size(4, 32);
 
+    // Acquire two buffers: first drop fills thread-local slot, second overflows
+    // to central pool where available() can observe it.
     let guard = pool.acquire();
     assert_eq!(guard.len(), 32);
+    let guard2 = pool.acquire();
     drop(guard);
+    drop(guard2);
 
     assert_eq!(pool.available(), 1);
 }

--- a/crates/transfer/tests/buffer_pool_cross_crate.rs
+++ b/crates/transfer/tests/buffer_pool_cross_crate.rs
@@ -1,0 +1,62 @@
+//! Integration test verifying that the `engine` buffer pool types are accessible
+//! from downstream crates (`transfer` depends on `engine`).
+
+use std::sync::Arc;
+
+use engine::{BufferGuard, BufferPool, BufferPoolStats, DefaultAllocator, global_buffer_pool};
+
+#[test]
+fn acquire_and_return_via_public_api() {
+    let pool = Arc::new(BufferPool::with_buffer_size(4, 64));
+
+    // Acquire a buffer through the Arc-based API.
+    let mut guard: BufferGuard = BufferPool::acquire_from(Arc::clone(&pool));
+    assert_eq!(guard.len(), 64);
+
+    // Write through the guard.
+    guard[0] = 0xAB;
+    assert_eq!(guard[0], 0xAB);
+
+    // Drop returns the buffer to the pool.
+    drop(guard);
+    assert_eq!(pool.available(), 1);
+}
+
+#[test]
+fn borrowed_guard_via_public_api() {
+    let pool = BufferPool::with_buffer_size(4, 32);
+
+    let guard = pool.acquire();
+    assert_eq!(guard.len(), 32);
+    drop(guard);
+
+    assert_eq!(pool.available(), 1);
+}
+
+#[test]
+fn global_pool_accessible_cross_crate() {
+    let pool = global_buffer_pool();
+    assert!(pool.buffer_size() > 0);
+    assert!(pool.max_buffers() > 0);
+}
+
+#[test]
+fn stats_accessible_cross_crate() {
+    let pool = Arc::new(BufferPool::with_buffer_size(2, 128));
+
+    // First acquire is a miss (pool starts empty).
+    let guard = BufferPool::acquire_from(Arc::clone(&pool));
+    drop(guard);
+
+    // Second acquire should hit the pool.
+    let guard = BufferPool::acquire_from(Arc::clone(&pool));
+    drop(guard);
+
+    let stats: BufferPoolStats = pool.stats();
+    assert!(stats.total_acquires() >= 2);
+}
+
+#[test]
+fn default_allocator_is_accessible() {
+    let _alloc: DefaultAllocator = DefaultAllocator;
+}


### PR DESCRIPTION
## Summary

- Re-export `BufferPool`, `BufferGuard`, `BorrowedBufferGuard`, `BufferPoolStats`, `BufferAllocator`, `DefaultAllocator`, `GlobalBufferPoolConfig`, `ThroughputTracker`, `global_buffer_pool`, and `init_global_buffer_pool` from the `engine` crate root
- Add `BorrowedBufferGuard` and `BufferPoolStats` to the `local_copy` module re-exports (previously missing)
- Add integration test in `transfer` crate verifying cross-crate buffer pool access

## Test plan

- [ ] CI passes fmt+clippy, nextest on all platforms
- [ ] New `buffer_pool_cross_crate` integration test exercises Arc-based acquire, borrowed acquire, global pool access, stats, and default allocator from the `transfer` crate