### PR TITLE
style: clean up comments in batch and transfer crates

### DIFF
--- a/crates/batch/src/replay.rs
+++ b/crates/batch/src/replay.rs
@@ -109,27 +109,11 @@ fn write_literals_to_file(
     Ok(())
 }
 
-/// Apply delta operations to reconstruct a target file from a basis file.
+/// Applies delta operations to reconstruct a file from a basis file.
 ///
 /// Reads copy and literal tokens from `delta_ops` and writes the
 /// reconstructed output to `dest_path`. Copy tokens reference blocks in
 /// `basis_path` at offsets computed as `block_index * block_length`.
-///
-/// # Arguments
-///
-/// * `basis_path` - Path to the existing basis file used for copy operations.
-/// * `dest_path` - Path where the reconstructed output is written.
-/// * `delta_ops` - Sequence of delta operations (literal data and basis-file
-///   copies) to apply.
-/// * `block_length` - Block size used to calculate basis-file offsets for copy
-///   operations. Upstream rsync derives this from `choose_block_size()` in
-///   `match.c:365`.
-///
-/// # Errors
-///
-/// Returns [`BatchError::Io`] if the basis file cannot be opened, the output
-/// file cannot be created, or any read/write/seek operation fails.
-/// Applies delta operations to reconstruct a file from a basis file.
 ///
 /// `block_count` is the number of blocks in the basis file's signature.
 /// `remainder` is the size of the last block (which may be shorter than
@@ -138,6 +122,11 @@ fn write_literals_to_file(
 ///
 /// upstream: receiver.c:recv_files() / match.c - block_length for all blocks
 /// except the last, which uses remainder.
+///
+/// # Errors
+///
+/// Returns [`BatchError::Io`] if the basis file cannot be opened, the output
+/// file cannot be created, or any read/write/seek operation fails.
 pub fn apply_delta_ops(
     basis_path: &Path,
     dest_path: &Path,
@@ -900,13 +889,6 @@ pub fn replay(
     Ok(result)
 }
 
-/// Choose block length using the same heuristic as upstream rsync.
-///
-/// Upstream `match.c:choose_block_size()` computes the block length as the
-/// integer square root of the file size, clamped to `[BLOCK_SIZE (700),
-/// MAX_BLOCK_SIZE (128 * 1024)]`. For batch replay the exact same
-/// derivation ensures copy-token offsets align with the blocks that the
-/// sender used during the original transfer.
 /// Returns the default xfer checksum length for batch replay.
 ///
 /// upstream: `checksum.c:188` - `xfer_sum_len = csum_len_for_type(xfer_sum_nni->num, 0)`.
@@ -952,6 +934,13 @@ fn create_compressed_decoder(_proto: i32) -> BatchResult<CompressedTokenDecoder>
     Ok(decoder)
 }
 
+/// Chooses block length using the same heuristic as upstream rsync.
+///
+/// Upstream `match.c:choose_block_size()` computes the block length as the
+/// integer square root of the file size, clamped to `[BLOCK_SIZE (700),
+/// MAX_BLOCK_SIZE (128 * 1024)]`. For batch replay the exact same
+/// derivation ensures copy-token offsets align with the blocks that the
+/// sender used during the original transfer.
 fn choose_block_length(file_size: u64) -> usize {
     const MIN_BLOCK: usize = 700;
     const MAX_BLOCK: usize = 128 * 1024;

--- a/crates/batch/src/writer.rs
+++ b/crates/batch/src/writer.rs
@@ -202,7 +202,6 @@ impl BatchWriter {
 
 impl Drop for BatchWriter {
     fn drop(&mut self) {
-        // Ensure file is flushed on drop
         let _ = self.flush();
     }
 }

--- a/crates/transfer/src/delta_apply/applicator.rs
+++ b/crates/transfer/src/delta_apply/applicator.rs
@@ -65,10 +65,10 @@ pub struct DeltaApplicator<'a> {
     sparse_state: Option<SparseWriteState>,
     checksum_verifier: ChecksumVerifier,
     basis_signature: Option<&'a FileSignature>,
-    /// Cached basis file mapper - opened once and reused for all block refs
-    /// Uses BasisMapStrategy: adaptive on Unix, buffered on Windows
+    /// Cached basis file mapper, opened once and reused for all block references.
+    /// Uses `AdaptiveMapStrategy` on Unix, `BufferedMap` on Windows.
     basis_map: Option<MapFile<BasisMapStrategy>>,
-    /// Reusable buffer for literal token data
+    /// Reusable buffer for literal token data to avoid per-token allocations.
     token_buffer: TokenBuffer,
     stats: DeltaApplyResult,
 }
@@ -87,8 +87,6 @@ impl<'a> DeltaApplicator<'a> {
         basis_signature: Option<&'a FileSignature>,
         basis_path: Option<&'a Path>,
     ) -> io::Result<Self> {
-        // Open basis file once if provided - cached for all block references
-        // Uses BasisMapStrategy: adaptive on Unix, buffered on Windows
         let basis_map = if let Some(path) = basis_path {
             #[cfg(unix)]
             let map = MapFile::open_adaptive(path);
@@ -194,7 +192,6 @@ impl<'a> DeltaApplicator<'a> {
             self.stats.bytes_written
         );
 
-        // Use cached MapFile - data stays in 256KB sliding window
         let block_data = basis_map.map_ptr(offset, bytes_to_copy)?;
 
         self.checksum_verifier.update(block_data);
@@ -244,7 +241,6 @@ impl<'a> DeltaApplicator<'a> {
             }
             std::cmp::Ordering::Greater => {
                 let len = token as usize;
-                // Reuse TokenBuffer - grows but never shrinks
                 self.token_buffer.resize_for(len);
                 reader.read_exact(self.token_buffer.as_mut_slice())?;
 
@@ -257,7 +253,6 @@ impl<'a> DeltaApplicator<'a> {
                     self.stats.bytes_written
                 );
 
-                // Apply literal data inline to avoid borrow conflict
                 let data = self.token_buffer.as_slice();
                 self.checksum_verifier.update(data);
 
@@ -286,11 +281,8 @@ impl<'a> DeltaApplicator<'a> {
             sparse.finish(&mut self.output)?;
         }
 
-        // Note: We don't call sync_all() by default, matching upstream rsync behavior.
-        // Upstream rsync only fsyncs when --fsync flag is explicitly set.
-
-        // Read expected checksum into stack buffer - mirrors upstream sum_end(char *sum)
-        // which writes into a caller-provided buffer, never allocating.
+        // upstream: sum_end(char *sum) writes into caller-provided buffer.
+        // sync_all() is not called - upstream rsync only fsyncs with --fsync.
         let expected_len = self.checksum_verifier.digest_len();
         let mut expected = [0u8; ChecksumVerifier::MAX_DIGEST_LEN];
         reader.read_exact(&mut expected[..expected_len])?;


### PR DESCRIPTION
## Summary

- **batch/replay.rs**: Fixed duplicate doc comment block on `apply_delta_ops` (two stacked `///` blocks merged into one), separated `choose_block_length` doc comment that was incorrectly merged with `default_xfer_sum_len`
- **batch/writer.rs**: Removed restating `// Ensure file is flushed on drop` comment in `Drop` impl
- **transfer/delta_apply/applicator.rs**: Converted informal `//` field comments to proper `///` rustdoc on `basis_map` and `token_buffer` fields; removed restating comments (`// Reuse TokenBuffer`, `// Apply literal data inline`, `// Use cached MapFile`, `// Open basis file once`); consolidated verbose multi-line comment about sync_all/sum_end into concise upstream reference

## Test plan

- [x] `cargo fmt --all` passes
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` passes
- [ ] CI checks (fmt+clippy, nextest, Windows, macOS, Linux musl)