### PR TITLE
fix: wire literal/matched byte stats through daemon transfer path

### DIFF
--- a/crates/core/src/client/remote/daemon_transfer/orchestration/stats.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/stats.rs
@@ -29,6 +29,8 @@ pub(super) fn convert_server_stats_to_summary(
                 transfer_stats.bytes_sent,
                 transfer_stats.total_source_bytes,
                 elapsed,
+                transfer_stats.literal_data,
+                transfer_stats.matched_data,
             );
             (s, transfer_stats.io_error, transfer_stats.error_count)
         }

--- a/crates/core/src/client/remote/ssh_transfer.rs
+++ b/crates/core/src/client/remote/ssh_transfer.rs
@@ -441,6 +441,8 @@ fn convert_server_stats_to_summary(
                 transfer_stats.bytes_sent,
                 transfer_stats.total_source_bytes,
                 elapsed,
+                transfer_stats.literal_data,
+                transfer_stats.matched_data,
             );
             (s, transfer_stats.io_error, transfer_stats.error_count)
         }

--- a/crates/engine/src/local_copy/plan/summary.rs
+++ b/crates/engine/src/local_copy/plan/summary.rs
@@ -240,12 +240,16 @@ impl LocalCopySummary {
         bytes_sent: u64,
         total_source_bytes: u64,
         elapsed: Duration,
+        literal_data: u64,
+        matched_data: u64,
     ) -> Self {
         Self {
             regular_files_total: files_listed as u64,
             files_copied: files_transferred as u64,
             bytes_received,
             bytes_sent,
+            bytes_copied: literal_data,
+            matched_bytes: matched_data,
             total_source_bytes,
             total_elapsed: elapsed,
             ..Default::default()
@@ -435,14 +439,40 @@ mod tests {
 
     #[test]
     fn from_receiver_stats_sets_fields() {
-        let summary =
-            LocalCopySummary::from_receiver_stats(100, 50, 1024, 256, 8192, Duration::from_secs(5));
+        let summary = LocalCopySummary::from_receiver_stats(
+            100,
+            50,
+            1024,
+            256,
+            8192,
+            Duration::from_secs(5),
+            0,
+            0,
+        );
         assert_eq!(summary.regular_files_total(), 100);
         assert_eq!(summary.files_copied(), 50);
         assert_eq!(summary.bytes_received(), 1024);
         assert_eq!(summary.bytes_sent(), 256);
         assert_eq!(summary.total_source_bytes(), 8192);
         assert_eq!(summary.total_elapsed(), Duration::from_secs(5));
+    }
+
+    #[test]
+    fn from_receiver_stats_with_delta_data() {
+        let summary = LocalCopySummary::from_receiver_stats(
+            10,
+            5,
+            2048,
+            512,
+            4096,
+            Duration::from_secs(2),
+            800,
+            1200,
+        );
+        assert_eq!(summary.bytes_copied(), 800);
+        assert_eq!(summary.matched_bytes(), 1200);
+        assert_eq!(summary.files_copied(), 5);
+        assert_eq!(summary.bytes_received(), 2048);
     }
 
     #[test]

--- a/crates/transfer/src/receiver/stats.rs
+++ b/crates/transfer/src/receiver/stats.rs
@@ -72,6 +72,26 @@ pub struct TransferStats {
     /// - `main.c:1367` - `deletion_count >= max_delete` triggers exit 25
     pub delete_limit_exceeded: bool,
 
+    /// Total literal (new) data bytes written during delta application.
+    ///
+    /// Accumulated from per-file delta token processing. Literal tokens carry
+    /// data that does not match any block in the basis file.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `match.c:330` - `stats.literal_data += s->sums[j].len`
+    pub literal_data: u64,
+
+    /// Total matched (reused) data bytes during delta application.
+    ///
+    /// Accumulated from per-file delta token processing. Matched tokens
+    /// reference blocks copied from the basis file.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `match.c:118` - `stats.matched_data += s2length`
+    pub matched_data: u64,
+
     /// Number of files that were retransmitted due to checksum verification failure.
     ///
     /// Mirrors upstream rsync's redo mechanism where files that fail whole-file

--- a/crates/transfer/src/receiver/tests.rs
+++ b/crates/transfer/src/receiver/tests.rs
@@ -1394,6 +1394,8 @@ fn transfer_stats_has_incremental_fields() {
         files_skipped: 5,
         delete_stats: DeleteStats::new(),
         delete_limit_exceeded: false,
+        literal_data: 0,
+        matched_data: 0,
         redo_count: 0,
     };
 

--- a/crates/transfer/src/receiver/transfer.rs
+++ b/crates/transfer/src/receiver/transfer.rs
@@ -488,6 +488,8 @@ impl ReceiverContext {
             files_skipped: 0,
             delete_stats: DeleteStats::new(),
             delete_limit_exceeded: false,
+            literal_data: 0,
+            matched_data: 0,
             redo_count: 0,
         })
     }
@@ -551,6 +553,8 @@ impl ReceiverContext {
 
         let mut files_transferred: usize = 0;
         let mut bytes_received: u64 = 0;
+        let mut literal_data: u64 = 0;
+        let mut matched_data: u64 = 0;
         let mut redo_count: usize = 0;
 
         // upstream: generator.c:1845 - dry_run sends NDX requests without data
@@ -561,7 +565,13 @@ impl ReceiverContext {
             let redo_config = pipeline_config.clone();
             let mut no_progress: Option<&mut dyn crate::TransferProgressCallback> = None;
             let redo_indices;
-            (files_transferred, bytes_received, redo_indices) = self.run_pipeline_loop_decoupled(
+            (
+                files_transferred,
+                bytes_received,
+                literal_data,
+                matched_data,
+                redo_indices,
+            ) = self.run_pipeline_loop_decoupled(
                 reader,
                 writer,
                 pipeline_config,
@@ -593,20 +603,23 @@ impl ReceiverContext {
                     })
                     .collect();
 
-                let (redo_transferred, redo_bytes, _) = self.run_pipeline_loop_decoupled(
-                    reader,
-                    writer,
-                    redo_config,
-                    &setup,
-                    redo_files,
-                    &mut metadata_errors,
-                    true,
-                    total_files,
-                    &mut no_progress,
-                )?;
+                let (redo_transferred, redo_bytes, redo_literal, redo_matched, _) = self
+                    .run_pipeline_loop_decoupled(
+                        reader,
+                        writer,
+                        redo_config,
+                        &setup,
+                        redo_files,
+                        &mut metadata_errors,
+                        true,
+                        total_files,
+                        &mut no_progress,
+                    )?;
 
                 files_transferred += redo_transferred;
                 bytes_received += redo_bytes;
+                literal_data += redo_literal;
+                matched_data += redo_matched;
             }
         }
 
@@ -631,6 +644,8 @@ impl ReceiverContext {
 
         stats.files_transferred = files_transferred;
         stats.bytes_received = bytes_received;
+        stats.literal_data = literal_data;
+        stats.matched_data = matched_data;
         stats.total_source_bytes = total_source_bytes;
         if !metadata_errors.is_empty() {
             stats.io_error |= crate::generator::io_error_flags::IOERR_GENERAL;
@@ -722,6 +737,8 @@ impl ReceiverContext {
 
         let mut files_transferred: usize = 0;
         let mut bytes_received: u64 = 0;
+        let mut literal_data: u64 = 0;
+        let mut matched_data: u64 = 0;
         let mut redo_count: usize = 0;
 
         // upstream: generator.c:1845 - dry_run sends NDX requests without data
@@ -731,7 +748,13 @@ impl ReceiverContext {
             let total_files = files_to_transfer.len();
             let redo_config = pipeline_config.clone();
             let redo_indices;
-            (files_transferred, bytes_received, redo_indices) = self.run_pipeline_loop_decoupled(
+            (
+                files_transferred,
+                bytes_received,
+                literal_data,
+                matched_data,
+                redo_indices,
+            ) = self.run_pipeline_loop_decoupled(
                 reader,
                 writer,
                 pipeline_config,
@@ -763,20 +786,23 @@ impl ReceiverContext {
                     })
                     .collect();
 
-                let (redo_transferred, redo_bytes, _) = self.run_pipeline_loop_decoupled(
-                    reader,
-                    writer,
-                    redo_config,
-                    &setup,
-                    redo_files,
-                    &mut metadata_errors,
-                    true,
-                    total_files,
-                    &mut progress,
-                )?;
+                let (redo_transferred, redo_bytes, redo_literal, redo_matched, _) = self
+                    .run_pipeline_loop_decoupled(
+                        reader,
+                        writer,
+                        redo_config,
+                        &setup,
+                        redo_files,
+                        &mut metadata_errors,
+                        true,
+                        total_files,
+                        &mut progress,
+                    )?;
 
                 files_transferred += redo_transferred;
                 bytes_received += redo_bytes;
+                literal_data += redo_literal;
+                matched_data += redo_matched;
             }
         }
 
@@ -784,6 +810,8 @@ impl ReceiverContext {
 
         stats.files_transferred = files_transferred;
         stats.bytes_received = bytes_received;
+        stats.literal_data = literal_data;
+        stats.matched_data = matched_data;
         stats.total_source_bytes = self.file_list.iter().map(|e| e.size()).sum();
         if !metadata_errors.is_empty() || stats.directories_failed > 0 || stats.files_skipped > 0 {
             stats.io_error |= crate::generator::io_error_flags::IOERR_GENERAL;

--- a/crates/transfer/src/receiver/transfer/pipeline.rs
+++ b/crates/transfer/src/receiver/transfer/pipeline.rs
@@ -49,7 +49,7 @@ impl ReceiverContext {
         is_redo_pass: bool,
         total_files: usize,
         progress: &mut Option<&mut dyn crate::TransferProgressCallback>,
-    ) -> io::Result<(usize, u64, Vec<usize>)> {
+    ) -> io::Result<(usize, u64, u64, u64, Vec<usize>)> {
         use crate::disk_commit::{BackupConfig, DiskCommitConfig};
         use crate::pipeline::receiver::PipelinedReceiver;
         use crate::shared::TransferDeadline;
@@ -61,7 +61,7 @@ impl ReceiverContext {
         // upstream: generator.c sends itemize immediately per-file via rwrite()
         if files_to_transfer.is_empty() {
             writer.flush()?;
-            return Ok((0, 0, Vec::new()));
+            return Ok((0, 0, 0, 0, Vec::new()));
         }
 
         let deadline = TransferDeadline::from_system_time(self.config.stop_at);
@@ -102,6 +102,8 @@ impl ReceiverContext {
             VecDeque::with_capacity(pipeline.window_size());
         let mut files_transferred = 0usize;
         let mut bytes_received = 0u64;
+        let mut total_literal_bytes = 0u64;
+        let mut total_matched_bytes = 0u64;
 
         let mut checksum_verifier = ChecksumVerifier::new(
             self.negotiated_algorithms.as_ref(),
@@ -135,7 +137,7 @@ impl ReceiverContext {
             let _ = pipelined_receiver.take_redo_indices();
         }
 
-        let result = (|| -> io::Result<(usize, u64, Vec<usize>)> {
+        let result = (|| -> io::Result<(usize, u64, u64, u64, Vec<usize>)> {
             // Track how many requests the sender has received (flushed) but
             // not yet responded to. We only flush the write buffer when this
             // drops to zero - otherwise the sender already has queued requests.
@@ -327,6 +329,8 @@ impl ReceiverContext {
                 }
 
                 bytes_received += result.total_bytes;
+                total_literal_bytes += result.literal_bytes;
+                total_matched_bytes += result.matched_bytes;
                 files_transferred += 1;
 
                 // upstream: receiver.c:950 - log_item() after successful file transfer
@@ -366,7 +370,13 @@ impl ReceiverContext {
 
             let redo_indices = pipelined_receiver.take_redo_indices();
 
-            Ok((files_transferred, bytes_received, redo_indices))
+            Ok((
+                files_transferred,
+                bytes_received,
+                total_literal_bytes,
+                total_matched_bytes,
+                redo_indices,
+            ))
         })();
 
         // Graceful shutdown regardless of success or failure.

--- a/crates/transfer/src/transfer_ops/streaming.rs
+++ b/crates/transfer/src/transfer_ops/streaming.rs
@@ -28,6 +28,16 @@ use super::{ResponseContext, read_response_header};
 pub struct StreamingResult {
     /// Total bytes of file data read from the wire.
     pub total_bytes: u64,
+    /// Literal (new) data bytes for this file.
+    ///
+    /// Data from `DeltaToken::Literal` tokens that did not match any block
+    /// in the basis file. Accumulated during token processing.
+    pub literal_bytes: u64,
+    /// Matched (reused) data bytes for this file.
+    ///
+    /// Data from `DeltaToken::BlockRef` tokens that reference basis file blocks.
+    /// Accumulated during token processing.
+    pub matched_bytes: u64,
     /// Expected whole-file checksum read from the sender (for deferred verification).
     pub expected_checksum: [u8; ChecksumVerifier::MAX_DIGEST_LEN],
     /// Number of valid bytes in `expected_checksum`.
@@ -157,6 +167,8 @@ pub fn process_file_response_streaming<R: Read>(
 
                 return Ok(StreamingResult {
                     total_bytes,
+                    literal_bytes: total_bytes,
+                    matched_bytes: 0,
                     expected_checksum,
                     checksum_len,
                 });
@@ -185,6 +197,7 @@ pub fn process_file_response_streaming<R: Read>(
                 total_bytes,
                 Some(next_delta),
                 token_reader,
+                total_bytes, // initial literal bytes from first chunk
             )
         }
         first_delta => {
@@ -203,6 +216,7 @@ pub fn process_file_response_streaming<R: Read>(
                 total_bytes,
                 Some(first_delta),
                 token_reader,
+                0,
             )
         }
     }

--- a/crates/transfer/src/transfer_ops/token_loop.rs
+++ b/crates/transfer/src/transfer_ops/token_loop.rs
@@ -84,11 +84,14 @@ pub(super) fn process_remaining_tokens<R: Read>(
     mut total_bytes: u64,
     pending_delta: Option<DeltaToken>,
     token_reader: &mut TokenReader,
+    initial_literal_bytes: u64,
 ) -> io::Result<StreamingResult> {
     let send_abort = |tx: &spsc::Sender<FileMessage>, reason: String| {
         let _ = tx.send(FileMessage::Abort { reason });
     };
 
+    let mut literal_bytes: u64 = initial_literal_bytes;
+    let mut matched_bytes: u64 = 0;
     let mut next_delta = pending_delta;
 
     loop {
@@ -121,6 +124,8 @@ pub(super) fn process_remaining_tokens<R: Read>(
 
                 return Ok(StreamingResult {
                     total_bytes,
+                    literal_bytes,
+                    matched_bytes,
                     expected_checksum,
                     checksum_len,
                 });
@@ -133,7 +138,7 @@ pub(super) fn process_remaining_tokens<R: Read>(
                         return Err(e);
                     }
                 };
-                let len = buf.len();
+                let len = buf.len() as u64;
 
                 file_tx.send(FileMessage::Chunk(buf)).map_err(|_| {
                     io::Error::new(
@@ -141,7 +146,8 @@ pub(super) fn process_remaining_tokens<R: Read>(
                         "disk commit thread disconnected during chunk send",
                     )
                 })?;
-                total_bytes += len as u64;
+                total_bytes += len;
+                literal_bytes += len;
             }
             DeltaToken::BlockRef(block_idx) => {
                 if let (Some(sig), Some(basis_map)) = (signature, basis_map.as_mut()) {
@@ -184,7 +190,9 @@ pub(super) fn process_remaining_tokens<R: Read>(
                             "disk commit thread disconnected during block send",
                         )
                     })?;
-                    total_bytes += bytes_to_copy as u64;
+                    let copy_len = bytes_to_copy as u64;
+                    total_bytes += copy_len;
+                    matched_bytes += copy_len;
                 } else {
                     let msg = format!("block reference {block_idx} without basis file");
                     send_abort(file_tx, msg.clone());

--- a/crates/transfer/tests/incremental_transfer.rs
+++ b/crates/transfer/tests/incremental_transfer.rs
@@ -31,6 +31,8 @@ fn transfer_stats_incremental_fields_exist() {
         files_skipped: 2,
         delete_stats: DeleteStats::new(),
         delete_limit_exceeded: false,
+        literal_data: 0,
+        matched_data: 0,
         redo_count: 0,
     };
 


### PR DESCRIPTION
## Summary
- Adds `literal_data` and `matched_data` fields to `TransferStats` in the transfer crate
- Accumulates per-file literal/matched bytes from `StreamingResult` through the receiver pipeline
- Passes stats through `convert_server_stats_to_summary()` (daemon) and SSH transfer paths
- Updates `LocalCopySummary::from_receiver_stats()` to accept and store delta breakdown
- Fixes daemon mode showing `matched=0` for all transfers (delta stats bug)

## Test plan
- [ ] CI passes all checks (10 files changed across transfer, core, engine crates)
- [ ] Unit test `from_receiver_stats_with_delta_data` validates stats flow
- [ ] Existing interop test `test_delta_stats` should now pass with correct matched/literal reporting