### PR TITLE
ci: add MSRV validation workflow for Rust 1.88

### DIFF
--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -1,0 +1,54 @@
+name: MSRV Check
+
+on:
+  push:
+    branches: [ master, main ]
+    paths:
+      - 'crates/**'
+      - 'src/**'
+      - 'Cargo.toml'
+      - 'rust-toolchain.toml'
+      - '.github/workflows/msrv.yml'
+  pull_request:
+    paths:
+      - 'crates/**'
+      - 'src/**'
+      - 'Cargo.toml'
+      - 'rust-toolchain.toml'
+      - '.github/workflows/msrv.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: msrv-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: "0"
+  CACHE_VERSION: ${{ vars.CACHE_VERSION || 'v1' }}
+
+jobs:
+  msrv:
+    name: MSRV 1.88
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Install Rust (MSRV 1.88)
+        uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
+        with:
+          toolchain: "1.88"
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
+        with:
+          shared-key: ci-${{ runner.os }}-msrv-cargo-${{ env.CACHE_VERSION }}-${{ hashFiles('**/Cargo.toml') }}
+
+      - name: Check workspace compiles on MSRV
+        run: cargo check --workspace --all-features


### PR DESCRIPTION
## Summary
- Adds CI workflow to validate compilation with MSRV (Rust 1.88)
- Uses `cargo check --workspace --all-features` for fast validation
- Runs on Rust source changes and rust-toolchain.toml updates
- Prevents accidental use of APIs or edition features requiring newer Rust

## Test plan
- [ ] Verify workflow runs and cargo check passes with toolchain 1.88
- [ ] Verify cache key is distinct from stable/beta/nightly CI jobs