### PR TITLE
ci: add Windows GNU cross-compilation check job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,6 +197,35 @@ jobs:
           retention-days: 7
 
   # ===========================================================================
+  # Windows GNU Cross-Check - Validate x86_64-pc-windows-gnu compilation
+  # ===========================================================================
+  windows-gnu-cross-check:
+    name: Windows GNU cross-check
+    runs-on: ubuntu-latest
+    needs: lint
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install Rust (stable)
+        uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
+        with:
+          targets: x86_64-pc-windows-gnu
+
+      - name: Install mingw-w64
+        run: sudo apt-get update && sudo apt-get install -y mingw-w64
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
+        with:
+          shared-key: ci-windows-gnu-cargo-${{ env.CACHE_VERSION }}-${{ hashFiles('**/Cargo.toml') }}
+
+      - name: Check compilation
+        run: cargo check --workspace --target x86_64-pc-windows-gnu
+
+  # ===========================================================================
   # macOS Test - Platform-specific testing with toolchain matrix
   # ===========================================================================
   macos-test:

--- a/crates/windows-gnu-eh/src/lib.rs
+++ b/crates/windows-gnu-eh/src/lib.rs
@@ -31,12 +31,11 @@
 //!
 //! # CI status
 //!
-//! As of 2026-04, CI does **not** test the `x86_64-pc-windows-gnu` target.
-//! All Windows CI jobs and release builds use `x86_64-pc-windows-msvc`:
-//! - `.github/workflows/ci.yml` - `windows-test` job runs on `windows-latest`
-//!   with MSVC toolchain only.
-//! - `.github/workflows/release-cross.yml` - Windows release artifacts target
-//!   `x86_64-pc-windows-msvc` exclusively.
+//! CI validates `x86_64-pc-windows-gnu` compilation via the
+//! `windows-gnu-cross-check` job in `.github/workflows/ci.yml`, which runs
+//! `cargo check --workspace --target x86_64-pc-windows-gnu` on Ubuntu with
+//! `mingw-w64`. Windows release builds still use `x86_64-pc-windows-msvc`
+//! exclusively (`.github/workflows/release-cross.yml`).
 //!
 //! # Maintenance burden
 //!


### PR DESCRIPTION
## Summary
- Add `windows-gnu-cross-check` CI job that validates `x86_64-pc-windows-gnu` compilation on Ubuntu with mingw-w64
- Lightweight `cargo check` only - validates the `windows-gnu-eh` crate and conditional dependencies compile
- Update `windows-gnu-eh` crate docs to reflect CI coverage

## Test plan
- [ ] CI `windows-gnu-cross-check` job passes on this PR
- [ ] Existing CI jobs unaffected (no modifications to existing jobs)