### PR TITLE
perf: replace std sync_channel with crossbeam bounded channel in work queue

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -198,6 +198,9 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 # Parallel computation - feature-gated for parallel file operations
 rayon = "1.10"
+# Crossbeam concurrency primitives - bounded channels with lower overhead than std
+crossbeam = "0.8"
+crossbeam-channel = "0.5"
 # Concurrent hash map - for shared state across daemon sessions
 dashmap = "6.1"
 # Heap profiling - for allocation analysis with dhat-viewer

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -27,6 +27,7 @@ batch = { path = "../batch" }
 fast_io = { path = "../fast_io", default-features = false }
 thiserror = "2.0"
 rayon = { workspace = true }
+crossbeam-channel = { workspace = true }
 tracing = { workspace = true, optional = true }
 globset = "0.4"
 jwalk = { workspace = true }

--- a/crates/engine/src/concurrent_delta/consumer.rs
+++ b/crates/engine/src/concurrent_delta/consumer.rs
@@ -14,7 +14,7 @@
 //!     v  drain_parallel_into(dispatch, stream_tx)
 //! rayon workers (parallel)
 //!     |
-//!     v  SyncSender<DeltaResult> (streaming, bounded)
+//!     v  crossbeam_channel::Sender<DeltaResult> (streaming, bounded)
 //! delta-reorder thread
 //!     |
 //!     v  ReorderBuffer (incremental insert + drain)
@@ -132,7 +132,7 @@ impl DeltaConsumer {
         // Bounded channel between drain and reorder threads. Capacity matches
         // reorder buffer so workers can stay ahead without unbounded buffering.
         let stream_capacity = reorder_capacity.max(rayon::current_num_threads() * 2);
-        let (stream_tx, stream_rx) = mpsc::sync_channel::<DeltaResult>(stream_capacity);
+        let (stream_tx, stream_rx) = crossbeam_channel::bounded::<DeltaResult>(stream_capacity);
 
         // Thread 1: runs rayon::scope, streaming results as workers complete.
         let drain_handle = thread::Builder::new()

--- a/crates/engine/src/concurrent_delta/mod.rs
+++ b/crates/engine/src/concurrent_delta/mod.rs
@@ -10,7 +10,7 @@
 //! | Submodule | Type | Role |
 //! |-----------|------|------|
 //! | `types` | [`DeltaWork`], [`DeltaResult`] | Per-file work item (NDX, paths, size) and outcome (stats, redo/fail status) |
-//! | [`work_queue`] | `WorkQueueSender` / `WorkQueueReceiver` | Bounded `sync_channel` (2x thread count) with backpressure |
+//! | [`work_queue`] | `WorkQueueSender` / `WorkQueueReceiver` | Bounded `crossbeam_channel` (2x thread count) with backpressure |
 //! | [`strategy`] | [`DeltaStrategy`] trait | Dispatches to [`WholeFileStrategy`] or [`DeltaTransferStrategy`] based on [`DeltaWorkKind`] |
 //! | [`reorder`] | [`ReorderBuffer`] | `BTreeMap`-backed buffer that yields results in submission order |
 //! | [`consumer`] | [`DeltaConsumer`] | Background thread that drains `WorkQueue` via `drain_parallel` into `ReorderBuffer` for in-order delivery |

--- a/crates/engine/src/concurrent_delta/work_queue.rs
+++ b/crates/engine/src/concurrent_delta/work_queue.rs
@@ -30,8 +30,7 @@
 //!
 //! ## Multi-Producer Considerations
 //!
-//! Supporting multiple producers would require replacing the `SyncSender` with
-//! a cloneable MPMC channel and revising the ordering contract (multiple
+//! Supporting multiple producers would require revising the ordering contract (multiple
 //! producers would need coordinated sequence numbering). See issues #1382 and
 //! #1569 for future multi-producer design discussion.
 //!
@@ -59,7 +58,7 @@
 //! waiting for all items to finish:
 //!
 //! ```text
-//! Generator ─► WorkQueue ─► drain_parallel_into(f, tx) ─► SyncSender<R>
+//! Generator ─► WorkQueue ─► drain_parallel_into(f, tx) ─► Sender<R>
 //!  (single        rayon::scope                                 |
 //!  producer)      work-stealing                                v
 //!                 (N consumers)                       ReorderBuffer (live)
@@ -96,7 +95,7 @@
 //! enables parallel processing while bounding memory - upstream does not need
 //! this because it never queues ahead.
 
-use std::sync::mpsc::{self, Receiver, SyncSender};
+use crossbeam_channel::{self as channel, Receiver, Sender};
 
 use super::DeltaWork;
 
@@ -139,7 +138,7 @@ const CAPACITY_MULTIPLIER: usize = 2;
 /// let results: Vec<u32> = rx.drain_parallel(|w| w.ndx());
 /// ```
 pub struct WorkQueueSender {
-    tx: SyncSender<DeltaWork>,
+    tx: Sender<DeltaWork>,
 }
 
 /// Receiving half of the bounded work queue.
@@ -239,7 +238,7 @@ impl WorkQueueReceiver {
     /// consumer can process results (e.g., reorder and write to disk) while
     /// delta computation continues for remaining items.
     ///
-    /// The `SyncSender` provides backpressure: if the consumer falls behind,
+    /// The bounded `Sender` provides backpressure: if the consumer falls behind,
     /// workers block on `tx.send()` rather than accumulating unbounded results
     /// in memory.
     ///
@@ -253,10 +252,9 @@ impl WorkQueueReceiver {
     /// use engine::concurrent_delta::work_queue;
     /// use engine::concurrent_delta::DeltaWork;
     /// use std::path::PathBuf;
-    /// use std::sync::mpsc;
     ///
     /// let (work_tx, work_rx) = work_queue::bounded();
-    /// let (result_tx, result_rx) = mpsc::sync_channel(16);
+    /// let (result_tx, result_rx) = crossbeam_channel::bounded(16);
     ///
     /// // Producer thread
     /// std::thread::spawn(move || {
@@ -275,7 +273,7 @@ impl WorkQueueReceiver {
     ///     // Process each result as it arrives
     /// }
     /// ```
-    pub fn drain_parallel_into<F, R>(self, f: F, tx: SyncSender<R>)
+    pub fn drain_parallel_into<F, R>(self, f: F, tx: Sender<R>)
     where
         F: Fn(DeltaWork) -> R + Send + Sync,
         R: Send,
@@ -380,7 +378,7 @@ pub fn bounded() -> (WorkQueueSender, WorkQueueReceiver) {
 #[must_use]
 pub fn bounded_with_capacity(capacity: usize) -> (WorkQueueSender, WorkQueueReceiver) {
     assert!(capacity > 0, "work queue capacity must be non-zero");
-    let (tx, rx) = mpsc::sync_channel(capacity);
+    let (tx, rx) = channel::bounded(capacity);
     (WorkQueueSender { tx }, WorkQueueReceiver { rx })
 }
 
@@ -543,7 +541,7 @@ mod tests {
         thread::sleep(Duration::from_millis(50));
         let sent_before_drain = sent_count.load(Ordering::Acquire);
         // The producer should have sent at most capacity + 1 items
-        // (capacity in the buffer + 1 that the sync_channel allows to be
+        // (capacity in the buffer + 1 that the bounded channel allows to be
         // "in flight" during the blocking send call).
         assert!(
             sent_before_drain <= 3,
@@ -791,7 +789,7 @@ mod tests {
             }
         });
 
-        let (result_tx, result_rx) = mpsc::sync_channel(16);
+        let (result_tx, result_rx) = crossbeam_channel::bounded(16);
         thread::spawn(move || {
             rx.drain_parallel_into(|w| w.ndx(), result_tx);
         });
@@ -808,7 +806,7 @@ mod tests {
         let (tx, rx) = bounded_with_capacity(4);
         drop(tx);
 
-        let (result_tx, result_rx) = mpsc::sync_channel(4);
+        let (result_tx, result_rx) = crossbeam_channel::bounded(4);
         thread::spawn(move || {
             rx.drain_parallel_into(|w| w.ndx(), result_tx);
         });
@@ -831,7 +829,7 @@ mod tests {
             }
         });
 
-        let (result_tx, result_rx) = mpsc::sync_channel(2);
+        let (result_tx, result_rx) = crossbeam_channel::bounded(2);
         thread::spawn(move || {
             rx.drain_parallel_into(|w| w.ndx(), result_tx);
         });
@@ -857,7 +855,7 @@ mod tests {
             }
         });
 
-        let (result_tx, result_rx) = mpsc::sync_channel(4);
+        let (result_tx, result_rx) = crossbeam_channel::bounded(4);
         let drain_handle = thread::spawn(move || {
             rx.drain_parallel_into(|w| w.ndx(), result_tx);
         });
@@ -883,7 +881,7 @@ mod tests {
             .unwrap();
         drop(tx);
 
-        let (result_tx, result_rx) = mpsc::sync_channel(4);
+        let (result_tx, result_rx) = crossbeam_channel::bounded(4);
         thread::spawn(move || {
             rx.drain_parallel_into(|w| (w.ndx(), w.target_size()), result_tx);
         });
@@ -1216,7 +1214,7 @@ mod tests {
             })
             .collect();
 
-        let (result_tx, result_rx) = mpsc::sync_channel(16);
+        let (result_tx, result_rx) = crossbeam_channel::bounded(16);
         thread::spawn(move || {
             rx.drain_parallel_into(|w| w.ndx(), result_tx);
         });

--- a/crates/engine/tests/multi_producer_work_queue.rs
+++ b/crates/engine/tests/multi_producer_work_queue.rs
@@ -459,8 +459,6 @@ fn multi_producer_fan_in_staggered_start() {
 /// with multiple producers, enabling incremental consumption.
 #[test]
 fn multi_producer_fan_in_streaming_drain() {
-    use std::sync::mpsc;
-
     let (tx, rx) = work_queue::bounded_with_capacity(8);
 
     let producers: Vec<_> = (0..NUM_PRODUCERS)
@@ -478,7 +476,7 @@ fn multi_producer_fan_in_streaming_drain() {
 
     drop(tx);
 
-    let (result_tx, result_rx) = mpsc::sync_channel(16);
+    let (result_tx, result_rx) = crossbeam_channel::bounded(16);
     let drain_handle = thread::spawn(move || {
         rx.drain_parallel_into(|w| w.ndx(), result_tx);
     });

--- a/crates/engine/tests/pipeline_reorder_integration.rs
+++ b/crates/engine/tests/pipeline_reorder_integration.rs
@@ -34,7 +34,7 @@ fn end_to_end_streaming_pipeline_delivers_in_order() {
     });
 
     // Stream channel: results arrive out of order from rayon workers.
-    let (stream_tx, stream_rx) = mpsc::sync_channel::<DeltaResult>(32);
+    let (stream_tx, stream_rx) = crossbeam_channel::bounded::<DeltaResult>(32);
 
     // Drain thread: processes items in parallel, streams results as they complete.
     let drain_thread = thread::spawn(move || {


### PR DESCRIPTION
## Summary
- Added `crossbeam = "0.8"` and `crossbeam-channel = "0.5"` to workspace dependencies
- Replaced `std::sync::mpsc::sync_channel` with `crossbeam_channel::bounded` in work queue
- Updated `WorkQueueSender`/`WorkQueueReceiver` internals, `drain_parallel_into`, and consumer pipeline
- Pipeline remains Rayon-driven with capacity at `2 * rayon::current_num_threads()`
- crossbeam's bounded channel avoids internal Mutex on sends, reducing contention

## Changed files
- `Cargo.toml` (workspace deps)
- `crates/engine/Cargo.toml`
- `crates/engine/src/concurrent_delta/work_queue.rs`
- `crates/engine/src/concurrent_delta/consumer.rs`
- `crates/engine/src/concurrent_delta/mod.rs`
- `crates/engine/tests/pipeline_reorder_integration.rs`
- `crates/engine/tests/multi_producer_work_queue.rs`

## Test plan
- [x] `cargo clippy --workspace --all-targets --all-features` passes
- [x] `cargo fmt --all -- --check` passes
- [ ] CI nextest passes