### PR TITLE
chore: move dhat-profile to standalone excluded crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,6 @@ autobins = false
 name = "oc-rsync"
 path = "src/bin/oc-rsync.rs"
 
-[[bin]]
-name = "dhat-profile"
-path = "src/bin/dhat_profile.rs"
-required-features = ["dhat-heap"]
-
 [features]
 # ============================================================================
 # Default Features
@@ -106,9 +101,6 @@ async = ["daemon/async", "core/async"]
 # systemd sd-notify integration for daemon
 sd-notify = ["daemon/sd-notify"]
 
-# Heap allocation profiling with dhat - use with profile.dhat
-dhat-heap = ["dep:dhat"]
-
 [dependencies]
 cli = { path = "crates/cli", default-features = false }
 daemon = { path = "crates/daemon", default-features = false }
@@ -127,10 +119,6 @@ libc = "0.2"
 tempfile = "3.15"
 checksums = { path = "crates/checksums" }
 protocol = { path = "crates/protocol" }
-
-[dependencies.dhat]
-workspace = true
-optional = true
 
 # Extra deps only for Windows + GNU
 [target.'cfg(all(windows, target_env = "gnu"))'.dependencies]
@@ -167,6 +155,7 @@ members = [
 ]
 exclude = [
     "crates/protocol/fuzz",
+    "tools/dhat-profile",
 ]
 resolver = "2"
 
@@ -200,8 +189,6 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 rayon = "1.10"
 # Concurrent hash map - for shared state across daemon sessions
 dashmap = "6.1"
-# Heap profiling - for allocation analysis with dhat-viewer
-dhat = "0.3"
 
 [workspace.metadata.docs.rs]
 all-features = true

--- a/docs/PROFILING.md
+++ b/docs/PROFILING.md
@@ -15,8 +15,8 @@ cargo build --release
 cargo build --profile release-with-debug
 ./scripts/flamegraph_profile.sh --scenario small_files
 
-# Heap allocation analysis
-cargo run --profile dhat --features dhat-heap --bin dhat-profile
+# Heap allocation analysis (standalone tool, not part of workspace)
+cargo run --release --manifest-path tools/dhat-profile/Cargo.toml
 ```
 
 ## Profiling Workflow
@@ -61,11 +61,8 @@ Look for:
 Analyze memory allocations:
 
 ```bash
-# Build with dhat feature
-cargo build --profile dhat --features dhat-heap
-
-# Run profiler
-cargo run --profile dhat --features dhat-heap --bin dhat-profile
+# Build and run the standalone dhat-profile tool (excluded from workspace)
+cargo run --release --manifest-path tools/dhat-profile/Cargo.toml
 
 # Analyze results
 # Open https://nicholass.github.io/nicholasses-dhat-viewer/
@@ -106,7 +103,9 @@ Use for: Flamegraphs, perf profiling
 
 ### dhat
 
-Release optimizations for heap profiling:
+Release optimizations with debug symbols for heap profiling.
+The `dhat-profile` tool is a standalone crate at `tools/dhat-profile/` (excluded from workspace)
+to avoid pulling `dhat` into default or `--all-features` builds.
 
 ```toml
 [profile.dhat]
@@ -115,7 +114,7 @@ debug = true
 strip = false
 ```
 
-Use for: Dhat heap analysis
+Use for: Dhat heap analysis with `cargo run --profile dhat --manifest-path tools/dhat-profile/Cargo.toml`
 
 ## Benchmark Scenarios
 

--- a/tools/dhat-profile/Cargo.toml
+++ b/tools/dhat-profile/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "dhat-profile"
+version = "0.1.0"
+edition = "2024"
+rust-version = "1.88"
+publish = false
+
+[workspace]
+
+[[bin]]
+name = "dhat-profile"
+path = "src/main.rs"
+
+[dependencies]
+dhat = "0.3"

--- a/tools/dhat-profile/src/main.rs
+++ b/tools/dhat-profile/src/main.rs
@@ -1,22 +1,19 @@
 //! Dhat heap profiling harness for oc-rsync.
 //!
-//! This benchmark creates a controlled transfer scenario and profiles heap allocations
-//! using dhat. The output can be analyzed with dhat-viewer.
+//! This standalone tool profiles heap allocations using dhat.
+//! The output can be analyzed with dhat-viewer.
 //!
 //! # Usage
 //!
 //! ```bash
-//! # Build with dhat feature and profile
-//! cargo build --profile dhat --features dhat-heap
-//!
-//! # Run the profiler (generates dhat-heap.json)
-//! cargo run --profile dhat --features dhat-heap --bin dhat-profile
+//! # Build and run from the workspace root
+//! cargo build --release --manifest-path tools/dhat-profile/Cargo.toml
+//! cargo run --release --manifest-path tools/dhat-profile/Cargo.toml
 //!
 //! # Analyze with dhat-viewer
 //! # Open https://nicholass.github.io/nicholasses-dhat-viewer/ and load dhat-heap.json
 //! ```
 
-#[cfg(feature = "dhat-heap")]
 #[global_allocator]
 static ALLOC: dhat::Alloc = dhat::Alloc;
 
@@ -35,7 +32,6 @@ fn setup_test_data(dir: &Path, file_count: usize, file_size: usize) {
 }
 
 fn main() {
-    #[cfg(feature = "dhat-heap")]
     let _profiler = dhat::Profiler::new_heap();
 
     // Use temp directory based on env or /tmp
@@ -52,8 +48,7 @@ fn main() {
     println!("Source: {}", src_dir.display());
     println!("Dest: {}", dest_dir.display());
 
-    // Note: In a real harness, we would invoke the rsync transfer logic here.
-    // For now, this demonstrates the dhat setup pattern.
+    // Note: In a real harness, invoke the rsync transfer logic here.
     // The actual profiling should call into core::client::run_transfer() or similar.
 
     println!("\nTo profile actual transfers, modify this harness to call:");


### PR DESCRIPTION
## Summary
- Removed `dhat-profile` binary and `dhat-heap` feature from root Cargo.toml
- Created standalone crate at `tools/dhat-profile/` (excluded from workspace)
- CI `--all-features` no longer compiles dhat unnecessarily
- Tool remains buildable via `cargo run --release --manifest-path tools/dhat-profile/Cargo.toml`

## Test plan
- [x] `cargo clippy --workspace --all-targets --all-features` passes
- [x] `cargo fmt --all -- --check` passes
- [ ] CI nextest passes