### PR TITLE
feat: add embedded SSH foundation - deps, feature flag, error types, and enums

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -192,6 +192,19 @@ crossbeam = "0.8"
 crossbeam-channel = "0.5"
 # Concurrent hash map - for shared state across daemon sessions
 dashmap = "6.1"
+# Pure-Rust SSH client - embedded SSH transport alternative to system ssh binary
+russh = "0.45"
+russh-keys = "0.45"
+# SSH key parsing and manipulation
+ssh-key = { version = "0.6", features = ["std"] }
+# URL parsing for ssh:// URIs
+url = "2"
+# Secure password input from terminal
+rpassword = "7"
+# Terminal detection for interactive prompts
+is-terminal = "0.4"
+# CPU feature detection for cipher selection (x86/x86_64 only)
+raw-cpuid = "11"
 
 [workspace.metadata.docs.rs]
 all-features = true

--- a/crates/rsync_io/Cargo.toml
+++ b/crates/rsync_io/Cargo.toml
@@ -18,6 +18,19 @@ thiserror = "2.0"
 protocol = { path = "../protocol" }
 logging = { path = "../logging" }
 memchr = "2.7"
+russh = { workspace = true, optional = true }
+russh-keys = { workspace = true, optional = true }
+ssh-key = { workspace = true, optional = true }
+url = { workspace = true, optional = true }
+rpassword = { workspace = true, optional = true }
+is-terminal = { workspace = true, optional = true }
+tokio = { workspace = true, optional = true }
+
+[target.'cfg(any(target_arch = "x86", target_arch = "x86_64"))'.dependencies]
+raw-cpuid = { workspace = true, optional = true }
+
+[features]
+embedded-ssh = ["dep:russh", "dep:russh-keys", "dep:ssh-key", "dep:url", "dep:rpassword", "dep:is-terminal", "dep:tokio"]
 
 [dev-dependencies]
 proptest = "1.4"

--- a/crates/rsync_io/src/ssh/embedded/error.rs
+++ b/crates/rsync_io/src/ssh/embedded/error.rs
@@ -1,0 +1,52 @@
+//! Error types for the embedded SSH transport.
+
+/// Errors from the embedded SSH transport layer.
+///
+/// Each variant maps to a distinct failure mode in the SSH connection
+/// lifecycle - from URL parsing through authentication to data transfer.
+#[derive(Debug, thiserror::Error)]
+pub enum SshError {
+    /// SSH protocol or connection error from the russh library.
+    #[error("SSH connection error: {0}")]
+    Connect(#[from] russh::Error),
+
+    /// All authentication methods were exhausted without success.
+    #[error("authentication failed (tried: {tried})")]
+    AuthenticationFailed {
+        /// Comma-separated list of methods attempted.
+        tried: String,
+    },
+
+    /// Server's host key does not match the known key.
+    #[error("host key mismatch for {host}")]
+    HostKeyMismatch {
+        /// Hostname or IP that presented the mismatched key.
+        host: String,
+    },
+
+    /// Server's host key is not in the known hosts file and strict checking is enabled.
+    #[error("unknown host: {host}")]
+    UnknownHost {
+        /// Hostname or IP with no known key.
+        host: String,
+    },
+
+    /// Failed to parse an ssh:// URL.
+    #[error("URL parse error: {0}")]
+    UrlParse(#[from] url::ParseError),
+
+    /// Underlying I/O error.
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// Failed to load an SSH private key.
+    #[error("key load error: {0}")]
+    KeyLoad(String),
+
+    /// Connection or operation timed out.
+    #[error("timeout after {secs}s")]
+    Timeout {
+        /// Number of seconds before timeout.
+        secs: u64,
+    },
+}

--- a/crates/rsync_io/src/ssh/embedded/mod.rs
+++ b/crates/rsync_io/src/ssh/embedded/mod.rs
@@ -1,7 +1,17 @@
-//! Embedded SSH client support.
+//! Embedded SSH transport using the russh library.
 //!
-//! This module provides components for the built-in SSH client that does not
-//! depend on an external `ssh` binary. Cipher selection is hardware-aware,
-//! preferring AES-GCM on CPUs with AES acceleration.
+//! Provides a pure-Rust SSH client as an alternative to spawning the system
+//! `ssh` binary. Feature-gated behind `embedded-ssh`. Cipher selection is
+//! hardware-aware, preferring AES-GCM on CPUs with AES acceleration.
 
 pub mod cipher;
+
+#[cfg(feature = "embedded-ssh")]
+mod error;
+#[cfg(feature = "embedded-ssh")]
+mod types;
+
+#[cfg(feature = "embedded-ssh")]
+pub use error::SshError;
+#[cfg(feature = "embedded-ssh")]
+pub use types::{IpPreference, StrictHostKeyChecking};

--- a/crates/rsync_io/src/ssh/embedded/types.rs
+++ b/crates/rsync_io/src/ssh/embedded/types.rs
@@ -1,0 +1,43 @@
+//! Configuration enums for the embedded SSH transport.
+
+/// Host key verification policy.
+///
+/// Controls behavior when the remote server's host key is not recognized.
+/// Mirrors the SSH `StrictHostKeyChecking` option semantics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StrictHostKeyChecking {
+    /// Reject connections to hosts with unknown or mismatched keys.
+    Yes,
+    /// Accept any host key without verification (insecure).
+    No,
+    /// Prompt the user when encountering an unknown host key.
+    Ask,
+}
+
+impl Default for StrictHostKeyChecking {
+    fn default() -> Self {
+        Self::Ask
+    }
+}
+
+/// IP version preference for DNS resolution.
+///
+/// Controls whether the SSH transport resolves hostnames to IPv4 or IPv6
+/// addresses. Mirrors the SSH `-4`/`-6` flag behavior.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IpPreference {
+    /// Let the system choose (default: prefer IPv4 if both available).
+    Auto,
+    /// Prefer IPv6 addresses when available.
+    PreferV6,
+    /// Only use IPv4 addresses.
+    ForceV4,
+    /// Only use IPv6 addresses.
+    ForceV6,
+}
+
+impl Default for IpPreference {
+    fn default() -> Self {
+        Self::Auto
+    }
+}

--- a/crates/rsync_io/src/ssh/mod.rs
+++ b/crates/rsync_io/src/ssh/mod.rs
@@ -65,5 +65,7 @@ pub use connection::{SshChildHandle, SshConnection, SshReader, SshWriter};
 pub use operand::{RemoteOperand, RemoteOperandParseError, parse_ssh_operand};
 pub use parse::{RemoteShellParseError, parse_remote_shell};
 
+pub mod embedded;
+
 #[cfg(test)]
 mod tests;


### PR DESCRIPTION
## Summary
- Add workspace dependencies for russh, russh-keys, ssh-key, url, rpassword, is-terminal, and raw-cpuid to root Cargo.toml
- Add `embedded-ssh` feature flag to `rsync_io` crate with all required optional dependencies
- Create `SshError` enum in `crates/rsync_io/src/ssh/embedded/error.rs` covering the full SSH connection lifecycle
- Create `StrictHostKeyChecking` and `IpPreference` configuration enums in `crates/rsync_io/src/ssh/embedded/types.rs`
- Wire up `embedded` submodule in `crates/rsync_io/src/ssh/mod.rs`
- `raw-cpuid` is target-gated to x86/x86_64 only and not included in the feature flag list, so embedded-ssh works on all architectures

## Design notes
- All new code is feature-gated behind `embedded-ssh` (not in default features)
- `raw-cpuid` lives under `[target.'cfg(any(target_arch = "x86", target_arch = "x86_64"))'.dependencies]` so it is only pulled on x86 targets
- Module structure: `ssh::embedded::{error, types}` with re-exports from `mod.rs`

## Test plan
- [x] `cargo check -p rsync_io --features embedded-ssh` compiles
- [x] `cargo clippy -p rsync_io --features embedded-ssh --no-deps -- -D warnings` passes
- [x] `cargo clippy -p rsync_io --no-deps -- -D warnings` passes (without feature)
- [ ] CI: fmt+clippy, nextest, Windows, macOS, Linux musl