### PR TITLE
test: verify ReorderBuffer ordering and WorkQueueReceiver RAII after crossbeam migration

### DIFF
--- a/crates/engine/src/concurrent_delta/reorder.rs
+++ b/crates/engine/src/concurrent_delta/reorder.rs
@@ -946,4 +946,93 @@ mod tests {
         let third: Vec<char> = buf.drain_ready().collect();
         assert_eq!(third, vec!['c', 'd']);
     }
+
+    /// Verifies that `ReorderBuffer` produces strictly sequential output
+    /// regardless of insertion order.
+    ///
+    /// This is the channel-agnostic ordering invariant: the reorder buffer
+    /// restores submission order using sequence numbers, independent of the
+    /// underlying channel implementation (std mpsc, crossbeam, etc.).
+    ///
+    /// Tests three scenarios:
+    /// 1. A small batch inserted in a specific scrambled order.
+    /// 2. A large batch (200 items) inserted in a deterministic pseudo-random
+    ///    order derived from a fixed seed.
+    /// 3. Burst insertion (groups of items arrive together) with interleaved drains.
+    #[test]
+    fn reorder_ordering_invariant() {
+        // Scenario 1: Small batch, specific scrambled order.
+        {
+            let mut buf = ReorderBuffer::new(16);
+            let insertion_order: Vec<u64> = vec![5, 2, 0, 3, 1, 4];
+            for seq in &insertion_order {
+                buf.insert(*seq, *seq).unwrap();
+            }
+            let drained: Vec<u64> = buf.drain_ready().collect();
+            let expected: Vec<u64> = (0..6).collect();
+            assert_eq!(
+                drained, expected,
+                "small batch: output must be sequential 0..6"
+            );
+            assert!(buf.is_empty());
+        }
+
+        // Scenario 2: Large batch with deterministic pseudo-random insertion order.
+        // Uses a simple LCG (linear congruential generator) seeded at 42 to
+        // produce a fixed permutation of 0..200, ensuring determinism across runs.
+        {
+            let n: u64 = 200;
+            let mut indices: Vec<u64> = (0..n).collect();
+
+            // Fisher-Yates shuffle with deterministic LCG.
+            let mut rng_state: u64 = 42;
+            for i in (1..indices.len()).rev() {
+                // LCG: state = state * 6364136223846793005 + 1 (mod 2^64)
+                rng_state = rng_state
+                    .wrapping_mul(6_364_136_223_846_793_005)
+                    .wrapping_add(1);
+                let j = (rng_state >> 33) as usize % (i + 1);
+                indices.swap(i, j);
+            }
+
+            let mut buf = ReorderBuffer::new(n as usize);
+            for &seq in &indices {
+                buf.insert(seq, seq * 10).unwrap();
+            }
+            let drained: Vec<u64> = buf.drain_ready().collect();
+            let expected: Vec<u64> = (0..n).map(|i| i * 10).collect();
+            assert_eq!(
+                drained, expected,
+                "large batch: output must be sequential with correct values"
+            );
+            assert!(buf.is_empty());
+        }
+
+        // Scenario 3: Burst insertion with interleaved drains.
+        // Items arrive in bursts (groups of 5), each burst scrambled,
+        // with drains after each burst.
+        {
+            let total: u64 = 30;
+            let burst_size: u64 = 5;
+            let mut buf = ReorderBuffer::new(total as usize);
+            let mut collected = Vec::new();
+
+            for burst_start in (0..total).step_by(burst_size as usize) {
+                // Each burst arrives in reverse order within the group.
+                let burst_end = (burst_start + burst_size).min(total);
+                for seq in (burst_start..burst_end).rev() {
+                    buf.insert(seq, seq).unwrap();
+                }
+                // Drain whatever is ready after this burst.
+                collected.extend(buf.drain_ready());
+            }
+
+            let expected: Vec<u64> = (0..total).collect();
+            assert_eq!(
+                collected, expected,
+                "burst insertion: output must be sequential 0..{total}"
+            );
+            assert!(buf.is_empty());
+        }
+    }
 }

--- a/crates/engine/src/concurrent_delta/work_queue.rs
+++ b/crates/engine/src/concurrent_delta/work_queue.rs
@@ -1306,6 +1306,102 @@ mod tests {
         }
     }
 
+    /// Verifies the RAII correctness invariant: dropping `WorkQueueReceiver`
+    /// signals the producer via `SendError`, preventing indefinite blocking.
+    ///
+    /// This invariant holds for both `std::sync::mpsc::sync_channel` and
+    /// `crossbeam_channel::bounded` - both disconnect the channel when the
+    /// receiver is dropped, causing the sender to observe an error.
+    ///
+    /// The test spawns a producer thread that sends items into the queue,
+    /// drops the receiver on the main thread, and verifies:
+    /// 1. The producer observes a `SendError` (not an indefinite block).
+    /// 2. The producer thread exits cleanly without hanging.
+    #[test]
+    fn receiver_drop_signals_producer_raii() {
+        let (tx, rx) = bounded_with_capacity(2);
+
+        // Fill the queue to capacity so the next send will block.
+        tx.send(DeltaWork::whole_file(0, PathBuf::from("/dst"), 0))
+            .unwrap();
+        tx.send(DeltaWork::whole_file(1, PathBuf::from("/dst"), 0))
+            .unwrap();
+
+        // Spawn a producer that will block on send (queue is full).
+        let producer = thread::spawn(move || {
+            let mut send_errors = 0u32;
+            for i in 2..100u32 {
+                match tx.send(DeltaWork::whole_file(i, PathBuf::from("/dst"), 0)) {
+                    Ok(()) => {}
+                    Err(_) => {
+                        send_errors += 1;
+                        break;
+                    }
+                }
+            }
+            send_errors
+        });
+
+        // Drop the receiver - this must unblock the producer's send.
+        drop(rx);
+
+        // Producer must exit within a reasonable time and report a SendError.
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let send_errors = producer.join().expect("producer thread panicked");
+        assert!(
+            Instant::now() < deadline,
+            "producer thread hung after receiver drop - RAII disconnect failed"
+        );
+        assert!(
+            send_errors > 0,
+            "producer never observed SendError after receiver drop"
+        );
+    }
+
+    /// Verifies that dropping `WorkQueueReceiver` while the producer is blocked
+    /// on a full queue causes the blocked send to return `SendError`.
+    ///
+    /// This is a stricter variant of the RAII test that specifically targets the
+    /// "blocked producer" scenario - the producer is guaranteed to be mid-send
+    /// when the receiver drops.
+    #[test]
+    fn receiver_drop_unblocks_full_queue_producer() {
+        let (tx, rx) = bounded_with_capacity(1);
+
+        // Fill the single-slot queue.
+        tx.send(DeltaWork::whole_file(0, PathBuf::from("/dst"), 0))
+            .unwrap();
+
+        let error_observed = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let error_clone = Arc::clone(&error_observed);
+
+        // Producer will block on this send because the queue is full.
+        let producer = thread::spawn(move || {
+            let result = tx.send(DeltaWork::whole_file(1, PathBuf::from("/dst"), 0));
+            if result.is_err() {
+                error_clone.store(true, Ordering::Release);
+            }
+        });
+
+        // Give the producer time to enter the blocking send.
+        thread::sleep(Duration::from_millis(50));
+
+        // Drop the receiver - must unblock the producer.
+        drop(rx);
+
+        // Producer must complete without hanging.
+        let deadline = Instant::now() + Duration::from_secs(5);
+        producer.join().expect("producer thread panicked");
+        assert!(
+            Instant::now() < deadline,
+            "producer thread hung after receiver drop"
+        );
+        assert!(
+            error_observed.load(Ordering::Acquire),
+            "blocked producer did not observe SendError when receiver was dropped"
+        );
+    }
+
     proptest! {
         /// Property test: `drain_parallel` preserves input ordering under contention.
         ///


### PR DESCRIPTION
## Summary

- Add `reorder_ordering_invariant` test verifying ReorderBuffer produces strictly sequential output regardless of insertion order (small batch, large 200-item LCG-shuffled batch, burst insertion with interleaved drains)
- Add `receiver_drop_signals_producer_raii` and `receiver_drop_unblocks_full_queue_producer` tests verifying that dropping WorkQueueReceiver causes the producer to observe SendError and exit cleanly - the RAII disconnect invariant

These tests are channel-implementation-agnostic: they pass on the current `std::sync::mpsc::sync_channel` and will verify correctness when the crossbeam_channel migration lands.

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy -p engine --all-targets --all-features --no-deps -- -D warnings` passes
- [x] `cargo nextest run -p engine --all-features -E 'test(reorder_ordering) or test(receiver_drop)'` - all 6 tests pass (3 new + 3 existing)
- [ ] CI passes on all platforms (Linux, macOS, Windows)