### PR TITLE
feat: add FileNdx(u32) newtype wrapper for type-safe file indices

### DIFF
--- a/crates/engine/benches/drain_parallel_benchmark.rs
+++ b/crates/engine/benches/drain_parallel_benchmark.rs
@@ -66,7 +66,7 @@ fn bench_drain_parallel(c: &mut Criterion) {
                             });
 
                             let results: Vec<u64> = rx.drain_parallel(|w| {
-                                let hash = simulate_work(w.ndx(), w.target_size());
+                                let hash = simulate_work(w.ndx().get(), w.target_size());
                                 black_box(hash)
                             });
 

--- a/crates/engine/src/concurrent_delta/consumer.rs
+++ b/crates/engine/src/concurrent_delta/consumer.rs
@@ -356,7 +356,7 @@ mod tests {
         let results: Vec<DeltaResult> = consumer.iter().collect();
 
         assert_eq!(results.len(), 1);
-        assert_eq!(results[0].ndx(), 42);
+        assert_eq!(results[0].ndx().get(), 42);
         assert_eq!(results[0].sequence(), 0);
         assert_eq!(results[0].bytes_written(), 128);
     }
@@ -448,17 +448,17 @@ mod tests {
         assert_eq!(results.len(), 3);
 
         // First: whole-file, all literal.
-        assert_eq!(results[0].ndx(), 0);
+        assert_eq!(results[0].ndx().get(), 0);
         assert_eq!(results[0].literal_bytes(), 1024);
         assert_eq!(results[0].matched_bytes(), 0);
 
         // Second: delta, mixed literal/matched.
-        assert_eq!(results[1].ndx(), 1);
+        assert_eq!(results[1].ndx().get(), 1);
         assert_eq!(results[1].literal_bytes(), 800);
         assert_eq!(results[1].matched_bytes(), 1248);
 
         // Third: whole-file, all literal.
-        assert_eq!(results[2].ndx(), 2);
+        assert_eq!(results[2].ndx().get(), 2);
         assert_eq!(results[2].literal_bytes(), 512);
         assert_eq!(results[2].matched_bytes(), 0);
     }
@@ -528,11 +528,11 @@ mod tests {
 
         assert_eq!(results.len(), 5);
         // Results are in sequence order, so NDX values follow submission order.
-        assert_eq!(results[0].ndx(), 100);
-        assert_eq!(results[1].ndx(), 42);
-        assert_eq!(results[2].ndx(), 7);
-        assert_eq!(results[3].ndx(), 999);
-        assert_eq!(results[4].ndx(), 0);
+        assert_eq!(results[0].ndx().get(), 100);
+        assert_eq!(results[1].ndx().get(), 42);
+        assert_eq!(results[2].ndx().get(), 7);
+        assert_eq!(results[3].ndx().get(), 999);
+        assert_eq!(results[4].ndx().get(), 0);
     }
 
     #[test]

--- a/crates/engine/src/concurrent_delta/mod.rs
+++ b/crates/engine/src/concurrent_delta/mod.rs
@@ -179,4 +179,4 @@ pub mod work_queue;
 pub use consumer::DeltaConsumer;
 pub use reorder::ReorderBuffer;
 pub use strategy::{DeltaStrategy, DeltaTransferStrategy, WholeFileStrategy};
-pub use types::{DeltaResult, DeltaResultStatus, DeltaWork, DeltaWorkKind};
+pub use types::{DeltaResult, DeltaResultStatus, DeltaWork, DeltaWorkKind, FileNdx};

--- a/crates/engine/src/concurrent_delta/multi_producer_audit.rs
+++ b/crates/engine/src/concurrent_delta/multi_producer_audit.rs
@@ -155,7 +155,7 @@ mod tests {
             }
         });
 
-        let mut results = rx.drain_parallel(|w| (w.ndx(), w.sequence()));
+        let mut results = rx.drain_parallel(|w| (w.ndx().get(), w.sequence()));
         producer.join().unwrap();
 
         // Sort by sequence to verify all sequences are unique and contiguous.
@@ -196,7 +196,7 @@ mod tests {
             }
         });
 
-        let mut results = rx.drain_parallel(|w| (w.ndx(), w.sequence()));
+        let mut results = rx.drain_parallel(|w| (w.ndx().get(), w.sequence()));
         p1.join().unwrap();
         p2.join().unwrap();
 

--- a/crates/engine/src/concurrent_delta/reorder.rs
+++ b/crates/engine/src/concurrent_delta/reorder.rs
@@ -703,15 +703,15 @@ mod tests {
 
         // Verify ordering by sequence.
         assert_eq!(drained[0].sequence(), 0);
-        assert_eq!(drained[0].ndx(), 10);
+        assert_eq!(drained[0].ndx().get(), 10);
         assert!(drained[0].is_success());
 
         assert_eq!(drained[1].sequence(), 1);
-        assert_eq!(drained[1].ndx(), 15);
+        assert_eq!(drained[1].ndx().get(), 15);
         assert!(drained[1].needs_retry());
 
         assert_eq!(drained[2].sequence(), 2);
-        assert_eq!(drained[2].ndx(), 20);
+        assert_eq!(drained[2].ndx().get(), 20);
         assert!(drained[2].is_success());
         assert_eq!(drained[2].bytes_written(), 2000);
     }

--- a/crates/engine/src/concurrent_delta/strategy.rs
+++ b/crates/engine/src/concurrent_delta/strategy.rs
@@ -174,7 +174,7 @@ mod tests {
         let work = DeltaWork::whole_file(1, PathBuf::from("/dest/a.txt"), 2048);
         let result = strategy.process(&work);
         assert!(result.is_success());
-        assert_eq!(result.ndx(), 1);
+        assert_eq!(result.ndx().get(), 1);
         assert_eq!(result.bytes_written(), 2048);
         assert_eq!(result.literal_bytes(), 2048);
         assert_eq!(result.matched_bytes(), 0);
@@ -199,7 +199,7 @@ mod tests {
         );
         let result = strategy.process(&work);
         assert!(result.is_success());
-        assert_eq!(result.ndx(), 5);
+        assert_eq!(result.ndx().get(), 5);
         assert_eq!(result.bytes_written(), 4096);
         assert_eq!(result.matched_bytes(), 2896);
         assert_eq!(result.literal_bytes(), 1200);
@@ -237,7 +237,7 @@ mod tests {
         let work = DeltaWork::whole_file(3, PathBuf::from("/dest/c.txt"), 512);
         let result = dispatch(&work);
         assert!(result.is_success());
-        assert_eq!(result.ndx(), 3);
+        assert_eq!(result.ndx().get(), 3);
         assert_eq!(result.literal_bytes(), 512);
         assert_eq!(result.matched_bytes(), 0);
     }
@@ -254,7 +254,7 @@ mod tests {
         );
         let result = dispatch(&work);
         assert!(result.is_success());
-        assert_eq!(result.ndx(), 7);
+        assert_eq!(result.ndx().get(), 7);
         assert_eq!(result.bytes_written(), 1000);
         assert_eq!(result.matched_bytes(), 650);
         assert_eq!(result.literal_bytes(), 350);
@@ -356,7 +356,7 @@ mod tests {
         let results: Vec<DeltaResult> = items.iter().map(dispatch).collect();
         for (i, r) in results.iter().enumerate() {
             assert_eq!(r.sequence(), i as u64);
-            assert_eq!(r.ndx(), i as u32);
+            assert_eq!(r.ndx().get(), i as u32);
         }
     }
 }

--- a/crates/engine/src/concurrent_delta/types.rs
+++ b/crates/engine/src/concurrent_delta/types.rs
@@ -10,6 +10,46 @@
 
 use std::path::PathBuf;
 
+/// File index in the transfer file list.
+///
+/// Wraps a `u32` NDX value to prevent accidental mixing with sequence
+/// numbers or other integer types in the concurrent delta pipeline.
+///
+/// # Upstream Reference
+///
+/// Corresponds to the NDX (file index) values that upstream rsync uses
+/// throughout `receiver.c` and `generator.c` to identify files in the
+/// sorted file list.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[repr(transparent)]
+pub struct FileNdx(u32);
+
+impl FileNdx {
+    /// Creates a new file index.
+    #[must_use]
+    pub const fn new(ndx: u32) -> Self {
+        Self(ndx)
+    }
+
+    /// Returns the raw `u32` value.
+    #[must_use]
+    pub const fn get(self) -> u32 {
+        self.0
+    }
+}
+
+impl std::fmt::Display for FileNdx {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl From<u32> for FileNdx {
+    fn from(ndx: u32) -> Self {
+        Self(ndx)
+    }
+}
+
 /// A unit of work for the concurrent delta pipeline.
 ///
 /// Represents a single file that requires delta computation. Created by the
@@ -24,7 +64,7 @@ use std::path::PathBuf;
 #[derive(Debug, Clone)]
 pub struct DeltaWork {
     /// File list index (NDX) - stable position in the sorted file list.
-    ndx: u32,
+    ndx: FileNdx,
     /// Pipeline sequence number for reordering after parallel dispatch.
     ///
     /// Assigned by the producer before sending into the work queue so that
@@ -60,9 +100,9 @@ pub enum DeltaWorkKind {
 impl DeltaWork {
     /// Creates a new whole-file transfer work item.
     #[must_use]
-    pub fn whole_file(ndx: u32, dest_path: PathBuf, target_size: u64) -> Self {
+    pub fn whole_file(ndx: impl Into<FileNdx>, dest_path: PathBuf, target_size: u64) -> Self {
         Self {
-            ndx,
+            ndx: ndx.into(),
             sequence: 0,
             dest_path,
             basis_path: None,
@@ -86,7 +126,7 @@ impl DeltaWork {
     /// * `matched_bytes` - Bytes copied from the basis file via block references
     #[must_use]
     pub fn delta(
-        ndx: u32,
+        ndx: impl Into<FileNdx>,
         dest_path: PathBuf,
         basis_path: PathBuf,
         target_size: u64,
@@ -94,7 +134,7 @@ impl DeltaWork {
         matched_bytes: u64,
     ) -> Self {
         Self {
-            ndx,
+            ndx: ndx.into(),
             sequence: 0,
             dest_path,
             basis_path: Some(basis_path),
@@ -107,7 +147,7 @@ impl DeltaWork {
 
     /// Returns the file list index (NDX).
     #[must_use]
-    pub const fn ndx(&self) -> u32 {
+    pub const fn ndx(&self) -> FileNdx {
         self.ndx
     }
 
@@ -182,7 +222,7 @@ impl DeltaWork {
     ///
     /// Returns `(ndx, dest_path, basis_path, target_size, literal_bytes, matched_bytes)`.
     #[must_use]
-    pub fn into_parts(self) -> (u32, PathBuf, Option<PathBuf>, u64, u64, u64) {
+    pub fn into_parts(self) -> (FileNdx, PathBuf, Option<PathBuf>, u64, u64, u64) {
         (
             self.ndx,
             self.dest_path,
@@ -207,7 +247,7 @@ impl DeltaWork {
 #[derive(Debug, Clone, Default)]
 pub struct DeltaResult {
     /// File list index (NDX) - correlates with the originating [`DeltaWork`].
-    ndx: u32,
+    ndx: FileNdx,
     /// Pipeline sequence number for reordering results from concurrent workers.
     ///
     /// Assigned by the producer before dispatching to the work queue so that
@@ -248,9 +288,14 @@ pub enum DeltaResultStatus {
 impl DeltaResult {
     /// Creates a successful result.
     #[must_use]
-    pub fn success(ndx: u32, bytes_written: u64, literal_bytes: u64, matched_bytes: u64) -> Self {
+    pub fn success(
+        ndx: impl Into<FileNdx>,
+        bytes_written: u64,
+        literal_bytes: u64,
+        matched_bytes: u64,
+    ) -> Self {
         Self {
-            ndx,
+            ndx: ndx.into(),
             sequence: 0,
             bytes_written,
             literal_bytes,
@@ -261,9 +306,9 @@ impl DeltaResult {
 
     /// Creates a redo result (checksum mismatch in phase 1).
     #[must_use]
-    pub fn needs_redo(ndx: u32, reason: String) -> Self {
+    pub fn needs_redo(ndx: impl Into<FileNdx>, reason: String) -> Self {
         Self {
-            ndx,
+            ndx: ndx.into(),
             status: DeltaResultStatus::NeedsRedo { reason },
             ..Default::default()
         }
@@ -271,9 +316,9 @@ impl DeltaResult {
 
     /// Creates a failed result (non-recoverable error).
     #[must_use]
-    pub fn failed(ndx: u32, reason: String) -> Self {
+    pub fn failed(ndx: impl Into<FileNdx>, reason: String) -> Self {
         Self {
-            ndx,
+            ndx: ndx.into(),
             status: DeltaResultStatus::Failed { reason },
             ..Default::default()
         }
@@ -293,7 +338,7 @@ impl DeltaResult {
 
     /// Returns the file list index (NDX).
     #[must_use]
-    pub const fn ndx(&self) -> u32 {
+    pub const fn ndx(&self) -> FileNdx {
         self.ndx
     }
 
@@ -346,8 +391,8 @@ mod tests {
 
     #[test]
     fn whole_file_work_has_no_basis() {
-        let work = DeltaWork::whole_file(0, PathBuf::from("/dest/file.txt"), 1024);
-        assert_eq!(work.ndx(), 0);
+        let work = DeltaWork::whole_file(0u32, PathBuf::from("/dest/file.txt"), 1024);
+        assert_eq!(work.ndx(), FileNdx::new(0));
         assert_eq!(work.dest_path(), std::path::Path::new("/dest/file.txt"));
         assert!(work.basis_path().is_none());
         assert_eq!(work.target_size(), 1024);
@@ -358,14 +403,14 @@ mod tests {
     #[test]
     fn delta_work_has_basis() {
         let work = DeltaWork::delta(
-            5,
+            5u32,
             PathBuf::from("/dest/file.txt"),
             PathBuf::from("/basis/file.txt"),
             2048,
             800,
             1248,
         );
-        assert_eq!(work.ndx(), 5);
+        assert_eq!(work.ndx(), FileNdx::new(5));
         assert_eq!(work.dest_path(), std::path::Path::new("/dest/file.txt"));
         assert_eq!(
             work.basis_path(),
@@ -381,7 +426,7 @@ mod tests {
     #[test]
     fn work_into_parts_returns_components() {
         let work = DeltaWork::delta(
-            3,
+            3u32,
             PathBuf::from("/dest"),
             PathBuf::from("/basis"),
             500,
@@ -389,7 +434,7 @@ mod tests {
             300,
         );
         let (ndx, dest, basis, size, literal, matched) = work.into_parts();
-        assert_eq!(ndx, 3);
+        assert_eq!(ndx, FileNdx::new(3));
         assert_eq!(dest, PathBuf::from("/dest"));
         assert_eq!(basis, Some(PathBuf::from("/basis")));
         assert_eq!(size, 500);
@@ -415,7 +460,7 @@ mod tests {
             2596,
         );
         let cloned = work.clone();
-        assert_eq!(cloned.ndx(), 7);
+        assert_eq!(cloned.ndx(), FileNdx::new(7));
         assert_eq!(cloned.dest_path(), std::path::Path::new("/dest/clone.txt"));
         assert!(cloned.is_delta());
     }
@@ -429,8 +474,8 @@ mod tests {
 
     #[test]
     fn success_result() {
-        let result = DeltaResult::success(42, 1000, 300, 700);
-        assert_eq!(result.ndx(), 42);
+        let result = DeltaResult::success(42u32, 1000, 300, 700);
+        assert_eq!(result.ndx(), FileNdx::new(42));
         assert_eq!(result.bytes_written(), 1000);
         assert_eq!(result.literal_bytes(), 300);
         assert_eq!(result.matched_bytes(), 700);
@@ -440,8 +485,8 @@ mod tests {
 
     #[test]
     fn needs_redo_result() {
-        let result = DeltaResult::needs_redo(10, "checksum mismatch".to_string());
-        assert_eq!(result.ndx(), 10);
+        let result = DeltaResult::needs_redo(10u32, "checksum mismatch".to_string());
+        assert_eq!(result.ndx(), FileNdx::new(10));
         assert_eq!(result.bytes_written(), 0);
         assert!(!result.is_success());
         assert!(result.needs_retry());
@@ -449,8 +494,8 @@ mod tests {
 
     #[test]
     fn failed_result() {
-        let result = DeltaResult::failed(99, "I/O error".to_string());
-        assert_eq!(result.ndx(), 99);
+        let result = DeltaResult::failed(99u32, "I/O error".to_string());
+        assert_eq!(result.ndx(), FileNdx::new(99));
         assert!(!result.is_success());
         assert!(!result.needs_retry());
     }
@@ -458,7 +503,7 @@ mod tests {
     #[test]
     fn default_result_is_success_with_zeroes() {
         let result = DeltaResult::default();
-        assert_eq!(result.ndx(), 0);
+        assert_eq!(result.ndx(), FileNdx::new(0));
         assert_eq!(result.bytes_written(), 0);
         assert_eq!(result.literal_bytes(), 0);
         assert_eq!(result.matched_bytes(), 0);
@@ -467,9 +512,9 @@ mod tests {
 
     #[test]
     fn result_clone() {
-        let result = DeltaResult::success(5, 500, 200, 300);
+        let result = DeltaResult::success(5u32, 500, 200, 300);
         let cloned = result.clone();
-        assert_eq!(cloned.ndx(), 5);
+        assert_eq!(cloned.ndx(), FileNdx::new(5));
         assert_eq!(cloned.bytes_written(), 500);
         assert!(cloned.is_success());
     }
@@ -547,7 +592,7 @@ mod tests {
     fn result_with_sequence() {
         let result = DeltaResult::success(1, 100, 50, 50).with_sequence(10);
         assert_eq!(result.sequence(), 10);
-        assert_eq!(result.ndx(), 1);
+        assert_eq!(result.ndx(), FileNdx::new(1));
     }
 
     #[test]
@@ -565,8 +610,79 @@ mod tests {
 
     #[test]
     fn result_failed_with_sequence() {
-        let result = DeltaResult::failed(7, "I/O error".to_string()).with_sequence(42);
+        let result = DeltaResult::failed(7u32, "I/O error".to_string()).with_sequence(42);
         assert_eq!(result.sequence(), 42);
         assert!(!result.is_success());
+    }
+
+    #[test]
+    fn file_ndx_new_and_get_roundtrip() {
+        for val in [0u32, 1, 42, u32::MAX] {
+            let ndx = FileNdx::new(val);
+            assert_eq!(ndx.get(), val);
+        }
+    }
+
+    #[test]
+    fn file_ndx_ordering_matches_u32() {
+        let a = FileNdx::new(1);
+        let b = FileNdx::new(2);
+        let c = FileNdx::new(2);
+        assert!(a < b);
+        assert!(b > a);
+        assert_eq!(b, c);
+        assert!(a <= b);
+        assert!(b >= a);
+    }
+
+    #[test]
+    fn file_ndx_display() {
+        assert_eq!(FileNdx::new(0).to_string(), "0");
+        assert_eq!(FileNdx::new(42).to_string(), "42");
+        assert_eq!(FileNdx::new(u32::MAX).to_string(), u32::MAX.to_string());
+    }
+
+    #[test]
+    fn file_ndx_from_u32() {
+        let ndx: FileNdx = 7u32.into();
+        assert_eq!(ndx, FileNdx::new(7));
+    }
+
+    #[test]
+    fn file_ndx_btreemap_key() {
+        use std::collections::BTreeMap;
+        let mut map = BTreeMap::new();
+        map.insert(FileNdx::new(3), "third");
+        map.insert(FileNdx::new(1), "first");
+        map.insert(FileNdx::new(2), "second");
+
+        let keys: Vec<FileNdx> = map.keys().copied().collect();
+        assert_eq!(
+            keys,
+            vec![FileNdx::new(1), FileNdx::new(2), FileNdx::new(3)]
+        );
+        assert_eq!(map[&FileNdx::new(2)], "second");
+    }
+
+    #[test]
+    fn file_ndx_hash() {
+        use std::collections::HashSet;
+        let mut set = HashSet::new();
+        set.insert(FileNdx::new(5));
+        set.insert(FileNdx::new(5));
+        set.insert(FileNdx::new(10));
+        assert_eq!(set.len(), 2);
+    }
+
+    #[test]
+    fn file_ndx_default_is_zero() {
+        assert_eq!(FileNdx::default(), FileNdx::new(0));
+    }
+
+    #[test]
+    fn file_ndx_copy_semantics() {
+        let a = FileNdx::new(42);
+        let b = a;
+        assert_eq!(a, b); // `a` still usable after copy
     }
 }

--- a/crates/engine/src/concurrent_delta/work_queue.rs
+++ b/crates/engine/src/concurrent_delta/work_queue.rs
@@ -85,7 +85,7 @@
 //! });
 //!
 //! // Parallel consumers via drain_parallel
-//! let ndx_list: Vec<u32> = rx.drain_parallel(|w| w.ndx());
+//! let ndx_list: Vec<u32> = rx.drain_parallel(|w| w.ndx().get());
 //! assert_eq!(ndx_list.len(), 100);
 //! ```
 //!
@@ -135,7 +135,7 @@ const CAPACITY_MULTIPLIER: usize = 2;
 /// });
 ///
 /// // Parallel consumers via drain_parallel
-/// let results: Vec<u32> = rx.drain_parallel(|w| w.ndx());
+/// let results: Vec<u32> = rx.drain_parallel(|w| w.ndx().get());
 /// ```
 pub struct WorkQueueSender {
     tx: Sender<DeltaWork>,
@@ -191,7 +191,7 @@ impl WorkQueueReceiver {
     ///     }
     /// });
     ///
-    /// let indices: Vec<u32> = rx.drain_parallel(|w| w.ndx());
+    /// let indices: Vec<u32> = rx.drain_parallel(|w| w.ndx().get());
     /// assert_eq!(indices.len(), 10);
     /// ```
     pub fn drain_parallel<F, R>(self, f: F) -> Vec<R>
@@ -265,7 +265,7 @@ impl WorkQueueReceiver {
     ///
     /// // Drain thread - sends results as workers complete
     /// std::thread::spawn(move || {
-    ///     work_rx.drain_parallel_into(|w| w.ndx(), result_tx);
+    ///     work_rx.drain_parallel_into(|w| w.ndx().get(), result_tx);
     /// });
     ///
     /// // Consumer thread - processes results incrementally
@@ -470,7 +470,7 @@ mod tests {
         tx.send(work).unwrap();
         let mut iter = rx.into_iter();
         let item = iter.next().unwrap();
-        assert_eq!(item.ndx(), 1);
+        assert_eq!(item.ndx().get(), 1);
     }
 
     #[test]
@@ -490,7 +490,7 @@ mod tests {
             .unwrap();
         drop(tx);
 
-        let items: Vec<u32> = rx.into_iter().map(|w| w.ndx()).collect();
+        let items: Vec<u32> = rx.into_iter().map(|w| w.ndx().get()).collect();
         assert_eq!(items, vec![1, 2]);
     }
 
@@ -511,7 +511,7 @@ mod tests {
             for w in rx.into_iter() {
                 let results = &results;
                 s.spawn(move |_| {
-                    results.lock().unwrap().push(w.ndx());
+                    results.lock().unwrap().push(w.ndx().get());
                 });
             }
         });
@@ -549,7 +549,7 @@ mod tests {
         );
 
         // Now drain everything.
-        let items: Vec<u32> = rx.into_iter().map(|w| w.ndx()).collect();
+        let items: Vec<u32> = rx.into_iter().map(|w| w.ndx().get()).collect();
         producer.join().unwrap();
         assert_eq!(items, vec![0, 1, 2, 3, 4]);
     }
@@ -588,7 +588,7 @@ mod tests {
                     // Simulate work to increase chance of overlapping.
                     thread::sleep(Duration::from_micros(100));
                     active_ref.fetch_sub(1, Ordering::SeqCst);
-                    collected.lock().unwrap().push(w.ndx());
+                    collected.lock().unwrap().push(w.ndx().get());
                 });
             }
         });
@@ -627,7 +627,7 @@ mod tests {
 
         // Queue is full (capacity 1). Verify the item arrives.
         let mut iter = rx.into_iter();
-        assert_eq!(iter.next().unwrap().ndx(), 0);
+        assert_eq!(iter.next().unwrap().ndx().get(), 0);
     }
 
     #[test]
@@ -638,7 +638,7 @@ mod tests {
             .send(DeltaWork::whole_file(0, PathBuf::from("/d"), 0))
             .unwrap_err();
         assert_eq!(err.to_string(), "work queue receiver has been dropped");
-        assert_eq!(err.0.ndx(), 0);
+        assert_eq!(err.0.ndx().get(), 0);
     }
 
     #[test]
@@ -688,7 +688,7 @@ mod tests {
         let items: Vec<_> = rx.into_iter().collect();
         assert_eq!(items.len(), 1);
         assert!(items[0].is_delta());
-        assert_eq!(items[0].ndx(), 42);
+        assert_eq!(items[0].ndx().get(), 42);
         assert_eq!(items[0].target_size(), 2048);
     }
 
@@ -702,7 +702,7 @@ mod tests {
         }
         drop(tx);
 
-        let items: Vec<u32> = rx.into_iter().map(|w| w.ndx()).collect();
+        let items: Vec<u32> = rx.into_iter().map(|w| w.ndx().get()).collect();
         assert_eq!(items, vec![0, 1, 2, 3, 4]);
     }
 
@@ -725,7 +725,7 @@ mod tests {
             .into_iter()
             .map(|w| {
                 assert!(Instant::now() < deadline, "deadlock detected - timed out");
-                w.ndx()
+                w.ndx().get()
             })
             .collect();
 
@@ -756,7 +756,7 @@ mod tests {
             for w in rx.into_iter() {
                 let collected = &collected;
                 s.spawn(move |_| {
-                    let seq = u64::from(w.ndx());
+                    let seq = u64::from(w.ndx().get());
                     let result = strategy::dispatch(&w).with_sequence(seq);
                     collected.lock().unwrap().push(result);
                 });
@@ -791,7 +791,7 @@ mod tests {
 
         let (result_tx, result_rx) = crossbeam_channel::bounded(16);
         thread::spawn(move || {
-            rx.drain_parallel_into(|w| w.ndx(), result_tx);
+            rx.drain_parallel_into(|w| w.ndx().get(), result_tx);
         });
 
         let mut results: Vec<u32> = result_rx.iter().collect();
@@ -808,7 +808,7 @@ mod tests {
 
         let (result_tx, result_rx) = crossbeam_channel::bounded(4);
         thread::spawn(move || {
-            rx.drain_parallel_into(|w| w.ndx(), result_tx);
+            rx.drain_parallel_into(|w| w.ndx().get(), result_tx);
         });
 
         let results: Vec<u32> = result_rx.iter().collect();
@@ -831,7 +831,7 @@ mod tests {
 
         let (result_tx, result_rx) = crossbeam_channel::bounded(2);
         thread::spawn(move || {
-            rx.drain_parallel_into(|w| w.ndx(), result_tx);
+            rx.drain_parallel_into(|w| w.ndx().get(), result_tx);
         });
 
         let mut results = Vec::new();
@@ -857,7 +857,7 @@ mod tests {
 
         let (result_tx, result_rx) = crossbeam_channel::bounded(4);
         let drain_handle = thread::spawn(move || {
-            rx.drain_parallel_into(|w| w.ndx(), result_tx);
+            rx.drain_parallel_into(|w| w.ndx().get(), result_tx);
         });
 
         // Take a few results then drop the receiver.
@@ -883,7 +883,7 @@ mod tests {
 
         let (result_tx, result_rx) = crossbeam_channel::bounded(4);
         thread::spawn(move || {
-            rx.drain_parallel_into(|w| (w.ndx(), w.target_size()), result_tx);
+            rx.drain_parallel_into(|w| (w.ndx().get(), w.target_size()), result_tx);
         });
 
         let results: Vec<_> = result_rx.iter().collect();
@@ -902,7 +902,7 @@ mod tests {
             }
         });
 
-        let mut results = rx.drain_parallel(|w| w.ndx());
+        let mut results = rx.drain_parallel(|w| w.ndx().get());
         producer.join().unwrap();
 
         results.sort_unstable();
@@ -913,7 +913,7 @@ mod tests {
     fn drain_parallel_empty_queue() {
         let (tx, rx) = bounded_with_capacity(4);
         drop(tx); // close immediately - no items sent
-        let results: Vec<u32> = rx.drain_parallel(|w| w.ndx());
+        let results: Vec<u32> = rx.drain_parallel(|w| w.ndx().get());
         assert!(results.is_empty());
     }
 
@@ -934,7 +934,7 @@ mod tests {
             }
         });
 
-        let results = rx.drain_parallel(|w| w.ndx());
+        let results = rx.drain_parallel(|w| w.ndx().get());
         producer.join().unwrap();
 
         assert_eq!(results.len(), total as usize);
@@ -957,7 +957,7 @@ mod tests {
         });
 
         let results: Vec<Result<u32, String>> = rx.drain_parallel(|w| {
-            let ndx = w.ndx();
+            let ndx = w.ndx().get();
             if ndx % 5 == 0 {
                 Err(format!("failed on ndx {ndx}"))
             } else {
@@ -981,7 +981,7 @@ mod tests {
             .unwrap();
         drop(tx);
 
-        let results = rx.drain_parallel(|w| (w.ndx(), w.target_size()));
+        let results = rx.drain_parallel(|w| (w.ndx().get(), w.target_size()));
         assert_eq!(results, vec![(42, 128)]);
     }
 
@@ -1001,7 +1001,7 @@ mod tests {
         });
 
         let results = rx.drain_parallel(|w| {
-            let seq = u64::from(w.ndx());
+            let seq = u64::from(w.ndx().get());
             strategy::dispatch(&w).with_sequence(seq)
         });
         producer.join().unwrap();
@@ -1036,7 +1036,7 @@ mod tests {
             }
         });
 
-        let mut results = rx.drain_parallel(|w| w.ndx());
+        let mut results = rx.drain_parallel(|w| w.ndx().get());
         p1.join().unwrap();
         p2.join().unwrap();
 
@@ -1071,7 +1071,7 @@ mod tests {
         // Drop the original sender so the channel closes when all clones drop.
         drop(tx);
 
-        let mut results = rx.drain_parallel(|w| w.ndx());
+        let mut results = rx.drain_parallel(|w| w.ndx().get());
         for h in handles {
             h.join().unwrap();
         }
@@ -1102,7 +1102,7 @@ mod tests {
         drop(tx);
         drop(tx3);
 
-        let mut items: Vec<u32> = rx.into_iter().map(|w| w.ndx()).collect();
+        let mut items: Vec<u32> = rx.into_iter().map(|w| w.ndx().get()).collect();
         items.sort_unstable();
         assert_eq!(items, vec![1, 2]);
     }
@@ -1121,7 +1121,7 @@ mod tests {
 
         let consumer = thread::spawn(move || {
             for w in rx.into_iter() {
-                received_clone.lock().unwrap().push(w.ndx());
+                received_clone.lock().unwrap().push(w.ndx().get());
             }
         });
 
@@ -1177,7 +1177,7 @@ mod tests {
             }
         });
 
-        let results = rx.drain_parallel(|w| (w.ndx(), w.target_size()));
+        let results = rx.drain_parallel(|w| (w.ndx().get(), w.target_size()));
         p1.join().unwrap();
         p2.join().unwrap();
 
@@ -1216,7 +1216,7 @@ mod tests {
 
         let (result_tx, result_rx) = crossbeam_channel::bounded(16);
         thread::spawn(move || {
-            rx.drain_parallel_into(|w| w.ndx(), result_tx);
+            rx.drain_parallel_into(|w| w.ndx().get(), result_tx);
         });
 
         let mut results: Vec<u32> = result_rx.iter().collect();
@@ -1245,8 +1245,8 @@ mod tests {
             .send(DeltaWork::whole_file(2, PathBuf::from("/d"), 0))
             .unwrap_err();
 
-        assert_eq!(err1.0.ndx(), 1);
-        assert_eq!(err2.0.ndx(), 2);
+        assert_eq!(err1.0.ndx().get(), 1);
+        assert_eq!(err2.0.ndx().get(), 2);
     }
 
     #[test]
@@ -1262,7 +1262,7 @@ mod tests {
             }
         });
 
-        let results = rx.drain_parallel(|w| w.ndx() * multiplier);
+        let results = rx.drain_parallel(|w| w.ndx().get() * multiplier);
         producer.join().unwrap();
 
         let mut sorted = results;
@@ -1429,7 +1429,7 @@ mod tests {
             // Each worker does a variable amount of spin work keyed on its index
             // to create scheduling contention and non-uniform completion times.
             let results: Vec<(u32, u32)> = rx.drain_parallel(|w| {
-                let idx = w.ndx();
+                let idx = w.ndx().get();
                 // Spin proportional to (idx % 17) to vary per-item cost.
                 let spin = (idx % 17) as usize * 50;
                 let mut acc = 0u64;

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -183,7 +183,7 @@ pub use delta::{
 /// Concurrent delta pipeline work-item, result, and strategy types.
 pub use concurrent_delta::{
     DeltaResult, DeltaResultStatus, DeltaStrategy, DeltaTransferStrategy, DeltaWork, DeltaWorkKind,
-    ReorderBuffer, WholeFileStrategy,
+    FileNdx, ReorderBuffer, WholeFileStrategy,
 };
 
 /// Common error types for engine operations.

--- a/crates/engine/tests/multi_producer_work_queue.rs
+++ b/crates/engine/tests/multi_producer_work_queue.rs
@@ -68,7 +68,7 @@ fn multi_producer_fan_in_all_items_received() {
     // Drop the original sender so the channel closes when all clones finish.
     drop(tx);
 
-    let results: Vec<(u32, u64)> = rx.drain_parallel(|w| (w.ndx(), w.target_size()));
+    let results: Vec<(u32, u64)> = rx.drain_parallel(|w| (w.ndx().get(), w.target_size()));
 
     for p in producers {
         p.join().unwrap();
@@ -139,7 +139,7 @@ fn multi_producer_fan_in_per_producer_ordering() {
     drop(tx);
 
     // Collect both NDX and sequence so we can verify per-producer order.
-    let results: Vec<(u32, u64)> = rx.drain_parallel(|w| (w.ndx(), w.sequence()));
+    let results: Vec<(u32, u64)> = rx.drain_parallel(|w| (w.ndx().get(), w.sequence()));
 
     for p in producers {
         p.join().unwrap();
@@ -207,7 +207,7 @@ fn multi_producer_fan_in_backpressure_no_deadlock() {
 
     drop(tx);
 
-    let results = rx.drain_parallel(|w| w.ndx());
+    let results = rx.drain_parallel(|w| w.ndx().get());
 
     for p in producers {
         p.join().unwrap();
@@ -267,7 +267,7 @@ fn multi_producer_fan_in_mixed_work_types() {
     drop(tx);
 
     let results: Vec<(u32, bool, u64)> =
-        rx.drain_parallel(|w| (w.ndx(), w.is_delta(), w.target_size()));
+        rx.drain_parallel(|w| (w.ndx().get(), w.is_delta(), w.target_size()));
 
     for p in producers {
         p.join().unwrap();
@@ -324,7 +324,7 @@ fn multi_producer_fan_in_high_contention_completeness() {
 
     drop(tx);
 
-    let results: Vec<(u32, u64)> = rx.drain_parallel(|w| (w.ndx(), w.target_size()));
+    let results: Vec<(u32, u64)> = rx.drain_parallel(|w| (w.ndx().get(), w.target_size()));
 
     for p in producers {
         p.join().unwrap();
@@ -432,7 +432,7 @@ fn multi_producer_fan_in_staggered_start() {
 
     drop(tx);
 
-    let results = rx.drain_parallel(|w| w.ndx());
+    let results = rx.drain_parallel(|w| w.ndx().get());
 
     for p in producers {
         p.join().unwrap();
@@ -478,7 +478,7 @@ fn multi_producer_fan_in_streaming_drain() {
 
     let (result_tx, result_rx) = crossbeam_channel::bounded(16);
     let drain_handle = thread::spawn(move || {
-        rx.drain_parallel_into(|w| w.ndx(), result_tx);
+        rx.drain_parallel_into(|w| w.ndx().get(), result_tx);
     });
 
     let mut results: Vec<u32> = result_rx.iter().collect();

--- a/crates/engine/tests/pipeline_reorder_integration.rs
+++ b/crates/engine/tests/pipeline_reorder_integration.rs
@@ -41,7 +41,7 @@ fn end_to_end_streaming_pipeline_delivers_in_order() {
         work_rx.drain_parallel_into(
             |work| {
                 // Simulate variable-cost work to induce out-of-order completion.
-                let spins = ((work.ndx() * 7 + 13) % 200) as usize;
+                let spins = ((work.ndx().get() * 7 + 13) % 200) as usize;
                 let mut acc = 0u64;
                 for j in 0..spins {
                     acc = acc.wrapping_add(j as u64);
@@ -102,7 +102,7 @@ fn end_to_end_streaming_pipeline_delivers_in_order() {
             "sequence mismatch at position {i}: expected {i}, got {}",
             r.sequence()
         );
-        assert_eq!(r.ndx(), i as u32);
+        assert_eq!(r.ndx().get(), i as u32);
         assert_eq!(r.bytes_written(), (i as u64) * 10);
         assert!(r.is_success());
     }
@@ -138,7 +138,7 @@ fn delta_consumer_end_to_end_ordering_guarantee() {
             "out of order at position {i}: expected seq {i}, got {}",
             r.sequence()
         );
-        assert_eq!(r.ndx(), i as u32);
+        assert_eq!(r.ndx().get(), i as u32);
         assert!(r.is_success());
     }
 }
@@ -181,7 +181,7 @@ fn mixed_work_kinds_preserve_stats_in_order() {
         let i_u64 = i as u64;
 
         assert_eq!(r.sequence(), i_u64, "sequence mismatch at {i}");
-        assert_eq!(r.ndx(), i_u32);
+        assert_eq!(r.ndx().get(), i_u32);
         assert!(r.is_success());
 
         if i_u32 % 3 == 0 {
@@ -246,7 +246,7 @@ fn batch_drain_parallel_with_reorder_buffer() {
     // drain_parallel collects all results (out of order).
     let results = work_rx.drain_parallel(|work| {
         // Variable spin to induce reordering.
-        let spins = ((work.ndx() * 11 + 3) % 150) as usize;
+        let spins = ((work.ndx().get() * 11 + 3) % 150) as usize;
         let mut acc = 0u64;
         for j in 0..spins {
             acc = acc.wrapping_add(j as u64);
@@ -271,6 +271,6 @@ fn batch_drain_parallel_with_reorder_buffer() {
 
     for (i, r) in ordered.iter().enumerate() {
         assert_eq!(r.sequence(), i as u64);
-        assert_eq!(r.ndx(), i as u32);
+        assert_eq!(r.ndx().get(), i as u32);
     }
 }

--- a/crates/transfer/src/delta_pipeline.rs
+++ b/crates/transfer/src/delta_pipeline.rs
@@ -388,7 +388,7 @@ mod tests {
 
         let result = pipeline.poll_result().unwrap();
         assert!(result.is_success());
-        assert_eq!(result.ndx(), 0);
+        assert_eq!(result.ndx().get(), 0);
         assert_eq!(result.bytes_written(), 1024);
         assert_eq!(result.literal_bytes(), 1024);
         assert_eq!(result.matched_bytes(), 0);
@@ -408,7 +408,7 @@ mod tests {
 
         for i in 0..5u32 {
             let result = pipeline.poll_result().unwrap();
-            assert_eq!(result.ndx(), i);
+            assert_eq!(result.ndx().get(), i);
             assert_eq!(result.sequence(), u64::from(i));
             assert_eq!(result.bytes_written(), u64::from(i) * 100);
         }
@@ -430,7 +430,7 @@ mod tests {
 
         let result = pipeline.poll_result().unwrap();
         assert!(result.is_success());
-        assert_eq!(result.ndx(), 5);
+        assert_eq!(result.ndx().get(), 5);
         assert_eq!(result.bytes_written(), 4096);
         assert_eq!(result.matched_bytes(), 2896);
         assert_eq!(result.literal_bytes(), 1200);
@@ -444,13 +444,13 @@ mod tests {
         let work0 = DeltaWork::whole_file(0, PathBuf::from("/dest/0"), 100);
         pipeline.submit_work(work0).unwrap();
         let r0 = pipeline.poll_result().unwrap();
-        assert_eq!(r0.ndx(), 0);
+        assert_eq!(r0.ndx().get(), 0);
         assert_eq!(r0.sequence(), 0);
 
         let work1 = DeltaWork::whole_file(1, PathBuf::from("/dest/1"), 200);
         pipeline.submit_work(work1).unwrap();
         let r1 = pipeline.poll_result().unwrap();
-        assert_eq!(r1.ndx(), 1);
+        assert_eq!(r1.ndx().get(), 1);
         assert_eq!(r1.sequence(), 1);
 
         assert!(pipeline.poll_result().is_none());
@@ -470,9 +470,9 @@ mod tests {
 
         let remaining = Box::new(pipeline).flush();
         assert_eq!(remaining.len(), 2);
-        assert_eq!(remaining[0].ndx(), 2);
+        assert_eq!(remaining[0].ndx().get(), 2);
         assert_eq!(remaining[0].sequence(), 2);
-        assert_eq!(remaining[1].ndx(), 3);
+        assert_eq!(remaining[1].ndx().get(), 3);
         assert_eq!(remaining[1].sequence(), 3);
     }
 
@@ -505,7 +505,7 @@ mod tests {
         let remaining = Box::new(pipeline).flush();
         assert_eq!(remaining.len(), 3);
         for (i, r) in remaining.iter().enumerate() {
-            assert_eq!(r.ndx(), i as u32);
+            assert_eq!(r.ndx().get(), i as u32);
             assert_eq!(r.sequence(), i as u64);
         }
     }
@@ -530,7 +530,7 @@ mod tests {
         pipeline.submit_work(work).unwrap();
 
         let result = pipeline.poll_result().unwrap();
-        assert_eq!(result.ndx(), 7);
+        assert_eq!(result.ndx().get(), 7);
         assert!(result.is_success());
 
         let remaining = pipeline.flush();
@@ -555,12 +555,12 @@ mod tests {
         pipeline.submit_work(delta).unwrap();
 
         let r0 = pipeline.poll_result().unwrap();
-        assert_eq!(r0.ndx(), 0);
+        assert_eq!(r0.ndx().get(), 0);
         assert_eq!(r0.literal_bytes(), 500);
         assert_eq!(r0.matched_bytes(), 0);
 
         let r1 = pipeline.poll_result().unwrap();
-        assert_eq!(r1.ndx(), 1);
+        assert_eq!(r1.ndx().get(), 1);
         assert_eq!(r1.literal_bytes(), 400);
         assert_eq!(r1.matched_bytes(), 600);
     }
@@ -607,7 +607,7 @@ mod tests {
         assert_eq!(results.len(), 10);
         for (i, r) in results.iter().enumerate() {
             assert_eq!(r.sequence(), i as u64);
-            assert_eq!(r.ndx(), i as u32);
+            assert_eq!(r.ndx().get(), i as u32);
             assert!(r.is_success());
             assert_eq!(r.bytes_written(), i as u64 * 100);
         }
@@ -625,7 +625,7 @@ mod tests {
         assert_eq!(results.len(), 50);
         for (i, r) in results.iter().enumerate() {
             assert_eq!(r.sequence(), i as u64, "result {i} has wrong sequence");
-            assert_eq!(r.ndx(), i as u32, "result {i} has wrong ndx");
+            assert_eq!(r.ndx().get(), i as u32, "result {i} has wrong ndx");
         }
     }
 
@@ -649,11 +649,11 @@ mod tests {
         let results = Box::new(pipeline).flush();
         assert_eq!(results.len(), 2);
 
-        assert_eq!(results[0].ndx(), 0);
+        assert_eq!(results[0].ndx().get(), 0);
         assert_eq!(results[0].literal_bytes(), 500);
         assert_eq!(results[0].matched_bytes(), 0);
 
-        assert_eq!(results[1].ndx(), 1);
+        assert_eq!(results[1].ndx().get(), 1);
         assert_eq!(results[1].literal_bytes(), 400);
         assert_eq!(results[1].matched_bytes(), 600);
     }
@@ -705,7 +705,7 @@ mod tests {
 
         let results = Box::new(pipeline).flush();
         assert_eq!(results.len(), 1);
-        assert_eq!(results[0].ndx(), 42);
+        assert_eq!(results[0].ndx().get(), 42);
         assert_eq!(results[0].sequence(), 0);
         assert_eq!(results[0].bytes_written(), 256);
     }
@@ -721,7 +721,7 @@ mod tests {
         let results = pipeline.flush();
         assert_eq!(results.len(), 3);
         for (i, r) in results.iter().enumerate() {
-            assert_eq!(r.ndx(), i as u32);
+            assert_eq!(r.ndx().get(), i as u32);
         }
     }
 
@@ -738,7 +738,7 @@ mod tests {
         assert_eq!(results.len(), count as usize);
         for (i, r) in results.iter().enumerate() {
             assert_eq!(r.sequence(), i as u64);
-            assert_eq!(r.ndx(), i as u32);
+            assert_eq!(r.ndx().get(), i as u32);
         }
     }
 
@@ -777,7 +777,7 @@ mod tests {
         let results = Box::new(pipeline).flush();
         assert_eq!(results.len(), 5);
         for (i, r) in results.iter().enumerate() {
-            assert_eq!(r.ndx(), i as u32);
+            assert_eq!(r.ndx().get(), i as u32);
             assert!(r.is_success());
         }
     }
@@ -797,7 +797,7 @@ mod tests {
         let results = Box::new(pipeline).flush();
         assert_eq!(results.len(), 5);
         for (i, r) in results.iter().enumerate() {
-            assert_eq!(r.ndx(), i as u32);
+            assert_eq!(r.ndx().get(), i as u32);
         }
     }
 
@@ -813,7 +813,7 @@ mod tests {
         let results = Box::new(pipeline).flush();
         assert_eq!(results.len(), 10);
         for (i, r) in results.iter().enumerate() {
-            assert_eq!(r.ndx(), i as u32);
+            assert_eq!(r.ndx().get(), i as u32);
             assert_eq!(r.sequence(), i as u64);
         }
     }
@@ -891,7 +891,7 @@ mod tests {
 
         let results = Box::new(pipeline).flush();
         assert_eq!(results.len(), 1);
-        assert_eq!(results[0].ndx(), 7);
+        assert_eq!(results[0].ndx().get(), 7);
         assert_eq!(results[0].bytes_written(), 128);
     }
 
@@ -943,7 +943,7 @@ mod tests {
         assert_eq!(results.len(), count as usize);
         for (i, r) in results.iter().enumerate() {
             assert_eq!(r.sequence(), i as u64);
-            assert_eq!(r.ndx(), i as u32);
+            assert_eq!(r.ndx().get(), i as u32);
         }
     }
 
@@ -999,7 +999,7 @@ mod tests {
             let i_u32 = i as u32;
             let expected_size = u64::from(i_u32 % 50) * 32 + 64;
             assert_eq!(r.sequence(), i as u64, "wrong sequence at index {i}");
-            assert_eq!(r.ndx(), i_u32, "wrong ndx at index {i}");
+            assert_eq!(r.ndx().get(), i_u32, "wrong ndx at index {i}");
             assert!(r.is_success(), "not successful at index {i}");
             assert_eq!(
                 r.bytes_written(),
@@ -1040,7 +1040,7 @@ mod tests {
         assert_eq!(results.len(), count as usize);
         for (i, r) in results.iter().enumerate() {
             assert_eq!(r.sequence(), i as u64, "wrong sequence at index {i}");
-            assert_eq!(r.ndx(), i as u32, "wrong ndx at index {i}");
+            assert_eq!(r.ndx().get(), i as u32, "wrong ndx at index {i}");
             assert!(r.is_success(), "not successful at index {i}");
             assert_eq!(r.bytes_written(), 256, "wrong bytes_written at index {i}");
         }
@@ -1076,7 +1076,7 @@ mod tests {
         for (i, r) in results.iter().enumerate() {
             let expected_size = if i < 30 { 128u64 } else { 256u64 };
             assert_eq!(r.sequence(), i as u64, "wrong sequence at index {i}");
-            assert_eq!(r.ndx(), i as u32, "wrong ndx at index {i}");
+            assert_eq!(r.ndx().get(), i as u32, "wrong ndx at index {i}");
             assert!(r.is_success(), "not successful at index {i}");
             assert_eq!(
                 r.bytes_written(),
@@ -1150,7 +1150,7 @@ mod tests {
                 "out of order at position {i}: got sequence {}",
                 r.sequence()
             );
-            assert_eq!(r.ndx(), i as u32);
+            assert_eq!(r.ndx().get(), i as u32);
             assert!(r.is_success());
         }
     }
@@ -1214,7 +1214,7 @@ mod tests {
         assert_eq!(results.len(), 10);
         for (i, r) in results.iter().enumerate() {
             assert_eq!(r.sequence(), i as u64);
-            assert_eq!(r.ndx(), i as u32);
+            assert_eq!(r.ndx().get(), i as u32);
             assert!(r.is_success());
         }
     }


### PR DESCRIPTION
## Summary

- Introduce `FileNdx`, a `#[repr(transparent)]` newtype wrapping `u32` NDX values in the concurrent delta pipeline to prevent accidental mixing with sequence numbers or other integer types
- Update `DeltaWork` and `DeltaResult` to use `FileNdx` for their file index fields, with constructors accepting `impl Into<FileNdx>` for ergonomic `u32` passthrough
- Update all call sites across engine, transfer, benchmarks, and integration tests

## Test plan

- [x] `FileNdx::new()` and `FileNdx::get()` roundtrip test
- [x] `FileNdx` ordering matches `u32` ordering
- [x] Display format verification
- [x] `BTreeMap` and `HashSet` usage with `FileNdx` keys
- [x] All 143 existing `concurrent_delta` tests pass
- [x] All 48 pipeline integration tests pass
- [x] All 44 delta_pipeline transfer tests pass
- [x] `cargo clippy -p engine --all-features --no-deps -- -D warnings` clean
- [x] `cargo clippy -p transfer --all-features --no-deps -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean

Closes #1767