### PR TITLE
docs: add rustdoc to embedded SSH public types

### DIFF
--- a/crates/rsync_io/src/ssh/embedded/config.rs
+++ b/crates/rsync_io/src/ssh/embedded/config.rs
@@ -28,6 +28,31 @@ const DEFAULT_KEEPALIVE_MAX_COUNT: u32 = 3;
 /// Holds all parameters needed to establish and maintain an SSH session.
 /// Use `Default::default()` for sensible defaults or the builder methods
 /// to customize individual fields. For `ssh://` URLs, use `from_url()`.
+///
+/// # Examples
+///
+/// Builder-style construction:
+///
+/// ```no_run
+/// use rsync_io::ssh::embedded::SshConfig;
+/// use std::time::Duration;
+///
+/// let mut cfg = SshConfig::default();
+/// cfg.host("example.com")
+///    .port(2222)
+///    .username("deploy")
+///    .connect_timeout(Duration::from_secs(10));
+/// ```
+///
+/// Parsing from an SSH URL:
+///
+/// ```no_run
+/// use rsync_io::ssh::embedded::SshConfig;
+///
+/// let (cfg, remote_path) = SshConfig::from_url("ssh://user@host/~/data").unwrap();
+/// assert_eq!(cfg.host, "host");
+/// assert_eq!(remote_path, "~/data");
+/// ```
 #[derive(Debug, Clone)]
 pub struct SshConfig {
     /// Remote hostname or IP address.
@@ -203,6 +228,13 @@ impl SshConfig {
     ///
     /// Returns `(config, remote_path)` where `remote_path` is the decoded path
     /// component. A leading `/~/` is converted to `~/` for home-relative paths.
+    /// Fields not present in the URL (ciphers, timeouts, etc.) use `Default`
+    /// values.
+    ///
+    /// # Errors
+    ///
+    /// Returns `SshError::UrlParse` for malformed URLs, or `SshError::InvalidUrl`
+    /// when the scheme is not `ssh://` or the host/path is empty.
     pub fn from_url(url_str: &str) -> Result<(Self, String), SshError> {
         let parsed = Url::parse(url_str)?;
 

--- a/crates/rsync_io/src/ssh/embedded/error.rs
+++ b/crates/rsync_io/src/ssh/embedded/error.rs
@@ -1,4 +1,8 @@
 //! Error types for the embedded SSH transport.
+//!
+//! Covers every failure mode in the SSH connection lifecycle: URL parsing,
+//! TCP connect, host key verification, authentication, key loading, and
+//! I/O during data transfer.
 
 /// Errors from the embedded SSH transport layer.
 ///

--- a/crates/rsync_io/src/ssh/embedded/types.rs
+++ b/crates/rsync_io/src/ssh/embedded/types.rs
@@ -1,4 +1,7 @@
 //! Configuration enums for the embedded SSH transport.
+//!
+//! These types mirror OpenSSH client options and control host key
+//! verification policy and IP version preference for DNS resolution.
 
 /// Host key verification policy.
 ///
@@ -7,10 +10,19 @@
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum StrictHostKeyChecking {
     /// Reject connections to hosts with unknown or mismatched keys.
+    ///
+    /// Safest option - requires the host key to already exist in the
+    /// known hosts file. New hosts must be added manually.
     Yes,
-    /// Accept any host key without verification (insecure).
+    /// Accept unknown host keys without prompting and persist them.
+    ///
+    /// Insecure - vulnerable to MITM on first connect. Changed keys
+    /// are still rejected. Useful for automated/batch transfers.
     No,
-    /// Prompt the user when encountering an unknown host key.
+    /// Prompt the user interactively when encountering an unknown host key.
+    ///
+    /// Default mode, matching OpenSSH behavior. Falls back to rejection
+    /// when no TTY is available (e.g., backgrounded or piped).
     Ask,
 }
 
@@ -26,13 +38,14 @@ impl Default for StrictHostKeyChecking {
 /// addresses. Mirrors the SSH `-4`/`-6` flag behavior.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum IpPreference {
-    /// Let the system choose (default: prefer IPv4 if both available).
+    /// Let the system choose based on available addresses.
     Auto,
-    /// Prefer IPv6 addresses when available.
+    /// Prefer IPv6 addresses when both are available. Mirrors `ssh -6` with
+    /// fallback to IPv4.
     PreferV6,
-    /// Only use IPv4 addresses.
+    /// Only resolve and connect to IPv4 addresses. Mirrors `ssh -4`.
     ForceV4,
-    /// Only use IPv6 addresses.
+    /// Only resolve and connect to IPv6 addresses. Mirrors `ssh -6`.
     ForceV6,
 }
 


### PR DESCRIPTION
## Summary

- Add `///` doc comments with `# Examples` sections to `SshConfig` (builder usage and `from_url()` parsing)
- Add `# Errors` section to `SshConfig::from_url()`
- Expand `//!` module-level docs for `error.rs` and `types.rs` with context on what they cover
- Add detailed variant docs to `StrictHostKeyChecking` (security implications, TTY fallback behavior)
- Add detailed variant docs to `IpPreference` (OpenSSH `-4`/`-6` flag equivalence)

No logic changes - documentation only.

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy -p rsync_io --all-features --no-deps -- -D warnings` passes
- [ ] CI passes (fmt+clippy, nextest, Windows, macOS, Linux musl)