### PR TITLE
refactor: add ServerConfigBuilder with validation

### DIFF
--- a/crates/transfer/src/config/builder.rs
+++ b/crates/transfer/src/config/builder.rs
@@ -1,0 +1,525 @@
+//! Builder pattern for constructing [`ServerConfig`](super::ServerConfig) with validation.
+//!
+//! All setter methods take `&mut self` and return `&mut Self` for chaining.
+//! The [`build`](ServerConfigBuilder::build) method validates invariants before
+//! returning the final configuration.
+//!
+//! # Example
+//!
+//! ```rust
+//! use transfer::config::ServerConfigBuilder;
+//! use transfer::ServerRole;
+//!
+//! let config = ServerConfigBuilder::new()
+//!     .role(ServerRole::Receiver)
+//!     .flag_string("-logDtpre.")
+//!     .build()
+//!     .expect("valid config");
+//! ```
+
+use std::ffi::OsString;
+use std::path::PathBuf;
+use std::time::SystemTime;
+
+use compress::zlib::CompressionLevel;
+use engine::SkipCompressList;
+use protocol::FilenameConverter;
+use protocol::ProtocolVersion;
+use protocol::filters::FilterRuleWireFormat;
+
+use super::error::BuilderError;
+use super::{
+    ConnectionConfig, DeletionConfig, FileSelectionConfig, ReferenceDirectory, ServerConfig,
+    WriteConfig,
+};
+use crate::flags::ParsedServerFlags;
+use crate::role::ServerRole;
+
+/// Builder for constructing [`ServerConfig`] with validation at build time.
+///
+/// Uses `&mut self` setters that return `&mut Self` for ergonomic chaining.
+/// Call [`build`](Self::build) to validate invariants and produce the config.
+///
+/// # Validation
+///
+/// The [`build`](Self::build) method checks:
+/// - `--inplace` and `--delay-updates` are mutually exclusive
+/// - `--append` and `--partial-dir` are mutually exclusive
+/// - `min_file_size` must not exceed `max_file_size`
+///
+/// # Example
+///
+/// ```rust
+/// use transfer::config::ServerConfigBuilder;
+/// use transfer::ServerRole;
+///
+/// let config = ServerConfigBuilder::new()
+///     .role(ServerRole::Generator)
+///     .flag_string("-rv")
+///     .args(vec![std::ffi::OsString::from("/path")])
+///     .build()
+///     .expect("valid config");
+/// ```
+#[derive(Clone, Debug)]
+pub struct ServerConfigBuilder {
+    role: ServerRole,
+    protocol: ProtocolVersion,
+    flag_string: String,
+    flags: ParsedServerFlags,
+    args: Vec<OsString>,
+    connection: ConnectionConfig,
+    reference_directories: Vec<ReferenceDirectory>,
+    deletion: DeletionConfig,
+    write: WriteConfig,
+    checksum_seed: Option<u32>,
+    checksum_choice: Option<protocol::ChecksumAlgorithm>,
+    trust_sender: bool,
+    stop_at: Option<SystemTime>,
+    qsort: bool,
+    has_partial_dir: bool,
+    backup_dir: Option<String>,
+    backup_suffix: Option<String>,
+    daemon_filter_rules: Vec<FilterRuleWireFormat>,
+    file_selection: FileSelectionConfig,
+    do_stats: bool,
+    temp_dir: Option<PathBuf>,
+    skip_compress: Option<SkipCompressList>,
+}
+
+impl Default for ServerConfigBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ServerConfigBuilder {
+    /// Creates a new builder with default values.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            role: ServerRole::Receiver,
+            protocol: ProtocolVersion::NEWEST,
+            flag_string: String::new(),
+            flags: ParsedServerFlags::default(),
+            args: Vec::new(),
+            connection: ConnectionConfig::default(),
+            reference_directories: Vec::new(),
+            deletion: DeletionConfig::default(),
+            write: WriteConfig::default(),
+            checksum_seed: None,
+            checksum_choice: None,
+            trust_sender: false,
+            stop_at: None,
+            qsort: false,
+            has_partial_dir: false,
+            backup_dir: None,
+            backup_suffix: None,
+            daemon_filter_rules: Vec::new(),
+            file_selection: FileSelectionConfig::default(),
+            do_stats: false,
+            temp_dir: None,
+            skip_compress: None,
+        }
+    }
+
+    // -- Role and protocol --
+
+    /// Sets the server-side role (receiver or generator).
+    pub fn role(&mut self, role: ServerRole) -> &mut Self {
+        self.role = role;
+        self
+    }
+
+    /// Sets the requested protocol version.
+    pub fn protocol(&mut self, protocol: ProtocolVersion) -> &mut Self {
+        self.protocol = protocol;
+        self
+    }
+
+    /// Sets the raw compact flag string.
+    pub fn flag_string(&mut self, flag_string: &str) -> &mut Self {
+        self.flag_string = flag_string.to_owned();
+        self
+    }
+
+    /// Sets the parsed server flags.
+    pub fn flags(&mut self, flags: ParsedServerFlags) -> &mut Self {
+        self.flags = flags;
+        self
+    }
+
+    /// Sets the positional arguments passed to the server.
+    pub fn args(&mut self, args: Vec<OsString>) -> &mut Self {
+        self.args = args;
+        self
+    }
+
+    // -- Connection --
+
+    /// Sets the full connection configuration.
+    pub fn connection(&mut self, connection: ConnectionConfig) -> &mut Self {
+        self.connection = connection;
+        self
+    }
+
+    /// Enables or disables client mode.
+    pub fn client_mode(&mut self, enabled: bool) -> &mut Self {
+        self.connection.client_mode = enabled;
+        self
+    }
+
+    /// Marks the transfer as occurring over a daemon connection.
+    pub fn is_daemon_connection(&mut self, enabled: bool) -> &mut Self {
+        self.connection.is_daemon_connection = enabled;
+        self
+    }
+
+    /// Sets filter rules to send to a remote daemon.
+    pub fn filter_rules(&mut self, rules: Vec<FilterRuleWireFormat>) -> &mut Self {
+        self.connection.filter_rules = rules;
+        self
+    }
+
+    /// Sets the filename encoding converter for `--iconv` support.
+    pub fn iconv(&mut self, converter: Option<FilenameConverter>) -> &mut Self {
+        self.connection.iconv = converter;
+        self
+    }
+
+    /// Sets the optional compression level for zlib compression.
+    pub fn compression_level(&mut self, level: Option<CompressionLevel>) -> &mut Self {
+        self.connection.compression_level = level;
+        self
+    }
+
+    /// Sets the explicit compression algorithm from `--compress-choice`.
+    pub fn compress_choice(&mut self, algo: Option<protocol::CompressionAlgorithm>) -> &mut Self {
+        self.connection.compress_choice = algo;
+        self
+    }
+
+    /// Sets pre-read `--files-from` data for forwarding to a remote daemon.
+    pub fn files_from_data(&mut self, data: Option<Vec<u8>>) -> &mut Self {
+        self.connection.files_from_data = data;
+        self
+    }
+
+    // -- Deletion --
+
+    /// Sets the full deletion configuration.
+    pub fn deletion(&mut self, deletion: DeletionConfig) -> &mut Self {
+        self.deletion = deletion;
+        self
+    }
+
+    /// Sets the maximum number of deletions allowed.
+    pub fn max_delete(&mut self, max: Option<u64>) -> &mut Self {
+        self.deletion.max_delete = max;
+        self
+    }
+
+    /// Enables or disables deletion despite I/O errors.
+    pub fn ignore_errors(&mut self, enabled: bool) -> &mut Self {
+        self.deletion.ignore_errors = enabled;
+        self
+    }
+
+    /// Enables or disables late (deferred) deletion.
+    pub fn late_delete(&mut self, enabled: bool) -> &mut Self {
+        self.deletion.late_delete = enabled;
+        self
+    }
+
+    // -- Write behavior --
+
+    /// Sets the full write configuration.
+    pub fn write(&mut self, write: WriteConfig) -> &mut Self {
+        self.write = write;
+        self
+    }
+
+    /// Enables or disables fsync after writing each file.
+    pub fn fsync(&mut self, enabled: bool) -> &mut Self {
+        self.write.fsync = enabled;
+        self
+    }
+
+    /// Enables or disables in-place writes (`--inplace`).
+    pub fn inplace(&mut self, enabled: bool) -> &mut Self {
+        self.write.inplace = enabled;
+        self
+    }
+
+    /// Enables or disables per-file inplace for partial-dir basis files.
+    pub fn inplace_partial(&mut self, enabled: bool) -> &mut Self {
+        self.write.inplace_partial = enabled;
+        self
+    }
+
+    /// Enables or disables writing data to device files.
+    pub fn write_devices(&mut self, enabled: bool) -> &mut Self {
+        self.write.write_devices = enabled;
+        self
+    }
+
+    /// Enables or disables delayed file updates (`--delay-updates`).
+    pub fn delay_updates(&mut self, enabled: bool) -> &mut Self {
+        self.write.delay_updates = enabled;
+        self
+    }
+
+    /// Sets the io_uring usage policy.
+    pub fn io_uring_policy(&mut self, policy: fast_io::IoUringPolicy) -> &mut Self {
+        self.write.io_uring_policy = policy;
+        self
+    }
+
+    // -- Reference directories --
+
+    /// Sets the reference directories for basis file lookup.
+    pub fn reference_directories(&mut self, dirs: Vec<ReferenceDirectory>) -> &mut Self {
+        self.reference_directories = dirs;
+        self
+    }
+
+    // -- Checksum --
+
+    /// Sets an optional user-specified checksum seed.
+    pub fn checksum_seed(&mut self, seed: Option<u32>) -> &mut Self {
+        self.checksum_seed = seed;
+        self
+    }
+
+    /// Sets an optional checksum algorithm override.
+    pub fn checksum_choice(&mut self, choice: Option<protocol::ChecksumAlgorithm>) -> &mut Self {
+        self.checksum_choice = choice;
+        self
+    }
+
+    // -- Security --
+
+    /// Enables or disables `--trust-sender`.
+    pub fn trust_sender(&mut self, enabled: bool) -> &mut Self {
+        self.trust_sender = enabled;
+        self
+    }
+
+    // -- Scheduling --
+
+    /// Sets an optional wall-clock deadline for the transfer.
+    pub fn stop_at(&mut self, deadline: Option<SystemTime>) -> &mut Self {
+        self.stop_at = deadline;
+        self
+    }
+
+    /// Enables or disables unstable sort for file lists (`--qsort`).
+    pub fn qsort(&mut self, enabled: bool) -> &mut Self {
+        self.qsort = enabled;
+        self
+    }
+
+    // -- Partial --
+
+    /// Sets whether `--partial-dir` is configured.
+    pub fn has_partial_dir(&mut self, enabled: bool) -> &mut Self {
+        self.has_partial_dir = enabled;
+        self
+    }
+
+    // -- Backup --
+
+    /// Sets the backup directory path (`--backup-dir`).
+    pub fn backup_dir(&mut self, dir: Option<String>) -> &mut Self {
+        self.backup_dir = dir;
+        self
+    }
+
+    /// Sets the backup file suffix (`--backup-suffix`).
+    pub fn backup_suffix(&mut self, suffix: Option<String>) -> &mut Self {
+        self.backup_suffix = suffix;
+        self
+    }
+
+    // -- Daemon filters --
+
+    /// Sets daemon-side filter rules from module configuration.
+    pub fn daemon_filter_rules(&mut self, rules: Vec<FilterRuleWireFormat>) -> &mut Self {
+        self.daemon_filter_rules = rules;
+        self
+    }
+
+    // -- File selection --
+
+    /// Sets the full file selection configuration.
+    pub fn file_selection(&mut self, config: FileSelectionConfig) -> &mut Self {
+        self.file_selection = config;
+        self
+    }
+
+    /// Sets the minimum file size filter.
+    pub fn min_file_size(&mut self, size: Option<u64>) -> &mut Self {
+        self.file_selection.min_file_size = size;
+        self
+    }
+
+    /// Sets the maximum file size filter.
+    pub fn max_file_size(&mut self, size: Option<u64>) -> &mut Self {
+        self.file_selection.max_file_size = size;
+        self
+    }
+
+    /// Enables or disables skipping files that already exist at the destination.
+    pub fn ignore_existing(&mut self, enabled: bool) -> &mut Self {
+        self.file_selection.ignore_existing = enabled;
+        self
+    }
+
+    /// Enables or disables only updating existing files.
+    pub fn existing_only(&mut self, enabled: bool) -> &mut Self {
+        self.file_selection.existing_only = enabled;
+        self
+    }
+
+    /// Enables or disables size-only comparison.
+    pub fn size_only(&mut self, enabled: bool) -> &mut Self {
+        self.file_selection.size_only = enabled;
+        self
+    }
+
+    /// Sets the `--files-from` path for direct server-side reading.
+    pub fn files_from_path(&mut self, path: Option<String>) -> &mut Self {
+        self.file_selection.files_from_path = path;
+        self
+    }
+
+    /// Enables or disables NUL-delimited `--files-from` input.
+    pub fn from0(&mut self, enabled: bool) -> &mut Self {
+        self.file_selection.from0 = enabled;
+        self
+    }
+
+    // -- Stats --
+
+    /// Enables or disables detailed transfer statistics.
+    pub fn do_stats(&mut self, enabled: bool) -> &mut Self {
+        self.do_stats = enabled;
+        self
+    }
+
+    // -- Temp dir --
+
+    /// Sets the temporary directory for receiving files.
+    pub fn temp_dir(&mut self, dir: Option<PathBuf>) -> &mut Self {
+        self.temp_dir = dir;
+        self
+    }
+
+    // -- Skip compress --
+
+    /// Sets the file suffixes that should skip per-file compression.
+    pub fn skip_compress(&mut self, list: Option<SkipCompressList>) -> &mut Self {
+        self.skip_compress = list;
+        self
+    }
+
+    // -- Validation and build --
+
+    /// Validates the builder configuration.
+    fn validate(&self) -> Result<(), BuilderError> {
+        // upstream: options.c:2934 - --inplace and --delay-updates are mutually exclusive
+        if self.write.inplace && self.write.delay_updates {
+            return Err(BuilderError::ConflictingOptions {
+                option1: "--inplace",
+                option2: "--delay-updates",
+            });
+        }
+
+        // upstream: options.c - --append implies --inplace, which conflicts with --partial-dir
+        if self.flags.append && self.has_partial_dir {
+            return Err(BuilderError::ConflictingOptions {
+                option1: "--append",
+                option2: "--partial-dir",
+            });
+        }
+
+        // Validate file size range
+        if let (Some(min), Some(max)) = (
+            self.file_selection.min_file_size,
+            self.file_selection.max_file_size,
+        ) {
+            if min > max {
+                return Err(BuilderError::InvalidCombination {
+                    message: format!("min_file_size ({min}) cannot exceed max_file_size ({max})"),
+                });
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Validates the configuration and builds the [`ServerConfig`].
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`BuilderError`] if:
+    /// - `--inplace` and `--delay-updates` are both enabled
+    /// - `--append` and `--partial-dir` are both enabled
+    /// - `min_file_size` exceeds `max_file_size`
+    pub fn build(&self) -> Result<ServerConfig, BuilderError> {
+        self.validate()?;
+        Ok(self.build_unchecked())
+    }
+
+    /// Builds the [`ServerConfig`] without validation.
+    ///
+    /// Useful when the configuration is known to be valid or when
+    /// validation should be skipped for performance.
+    #[must_use]
+    pub fn build_unchecked(&self) -> ServerConfig {
+        ServerConfig {
+            role: self.role,
+            protocol: self.protocol,
+            flag_string: self.flag_string.clone(),
+            flags: self.flags.clone(),
+            args: self.args.clone(),
+            connection: self.connection.clone(),
+            reference_directories: self.reference_directories.clone(),
+            deletion: self.deletion.clone(),
+            write: self.write.clone(),
+            checksum_seed: self.checksum_seed,
+            checksum_choice: self.checksum_choice,
+            trust_sender: self.trust_sender,
+            stop_at: self.stop_at,
+            qsort: self.qsort,
+            has_partial_dir: self.has_partial_dir,
+            backup_dir: self.backup_dir.clone(),
+            backup_suffix: self.backup_suffix.clone(),
+            daemon_filter_rules: self.daemon_filter_rules.clone(),
+            file_selection: self.file_selection.clone(),
+            do_stats: self.do_stats,
+            temp_dir: self.temp_dir.clone(),
+            skip_compress: self.skip_compress.clone(),
+        }
+    }
+}
+
+impl ServerConfig {
+    /// Creates a new [`ServerConfigBuilder`] for constructing a server configuration.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use transfer::ServerConfig;
+    /// use transfer::ServerRole;
+    ///
+    /// let config = ServerConfig::builder()
+    ///     .role(ServerRole::Generator)
+    ///     .flag_string("-rv")
+    ///     .build()
+    ///     .expect("valid config");
+    /// ```
+    #[must_use]
+    pub fn builder() -> ServerConfigBuilder {
+        ServerConfigBuilder::new()
+    }
+}

--- a/crates/transfer/src/config/builder_tests.rs
+++ b/crates/transfer/src/config/builder_tests.rs
@@ -1,0 +1,417 @@
+//! Tests for [`ServerConfigBuilder`].
+
+use std::ffi::OsString;
+
+use protocol::ProtocolVersion;
+
+use super::builder::ServerConfigBuilder;
+use super::error::BuilderError;
+use super::{ConnectionConfig, DeletionConfig, FileSelectionConfig, ServerConfig, WriteConfig};
+use crate::flags::ParsedServerFlags;
+use crate::role::ServerRole;
+
+mod builder_creation {
+    use super::*;
+
+    #[test]
+    fn new_creates_builder_with_defaults() {
+        let config = ServerConfigBuilder::new().build().expect("valid config");
+        assert_eq!(config.role, ServerRole::Receiver);
+        assert_eq!(config.protocol, ProtocolVersion::NEWEST);
+        assert!(config.flag_string.is_empty());
+        assert!(config.args.is_empty());
+    }
+
+    #[test]
+    fn default_trait_matches_new() {
+        let c1 = ServerConfigBuilder::new().build().expect("valid");
+        let c2 = ServerConfigBuilder::default().build().expect("valid");
+        assert_eq!(c1.role, c2.role);
+        assert_eq!(c1.protocol, c2.protocol);
+        assert_eq!(c1.flag_string, c2.flag_string);
+    }
+
+    #[test]
+    fn builder_method_on_server_config() {
+        let config = ServerConfig::builder().build().expect("valid config");
+        assert_eq!(config.role, ServerRole::Receiver);
+    }
+}
+
+mod chaining {
+    use super::*;
+
+    #[test]
+    fn setters_chain_correctly() {
+        let mut builder = ServerConfigBuilder::new();
+        let config = builder
+            .role(ServerRole::Generator)
+            .flag_string("-rv")
+            .args(vec![OsString::from("/src"), OsString::from("/dst")])
+            .trust_sender(true)
+            .do_stats(true)
+            .qsort(true)
+            .build()
+            .expect("valid config");
+
+        assert_eq!(config.role, ServerRole::Generator);
+        assert_eq!(config.flag_string, "-rv");
+        assert_eq!(config.args.len(), 2);
+        assert!(config.trust_sender);
+        assert!(config.do_stats);
+        assert!(config.qsort);
+    }
+
+    #[test]
+    fn write_setters_chain() {
+        let mut builder = ServerConfigBuilder::new();
+        let config = builder
+            .fsync(true)
+            .inplace(true)
+            .write_devices(true)
+            .build()
+            .expect("valid config");
+
+        assert!(config.write.fsync);
+        assert!(config.write.inplace);
+        assert!(config.write.write_devices);
+    }
+
+    #[test]
+    fn deletion_setters_chain() {
+        let mut builder = ServerConfigBuilder::new();
+        let config = builder
+            .max_delete(Some(100))
+            .ignore_errors(true)
+            .late_delete(true)
+            .build()
+            .expect("valid config");
+
+        assert_eq!(config.deletion.max_delete, Some(100));
+        assert!(config.deletion.ignore_errors);
+        assert!(config.deletion.late_delete);
+    }
+
+    #[test]
+    fn file_selection_setters_chain() {
+        let mut builder = ServerConfigBuilder::new();
+        let config = builder
+            .min_file_size(Some(1024))
+            .max_file_size(Some(1_000_000))
+            .ignore_existing(true)
+            .existing_only(false)
+            .size_only(true)
+            .from0(true)
+            .build()
+            .expect("valid config");
+
+        assert_eq!(config.file_selection.min_file_size, Some(1024));
+        assert_eq!(config.file_selection.max_file_size, Some(1_000_000));
+        assert!(config.file_selection.ignore_existing);
+        assert!(!config.file_selection.existing_only);
+        assert!(config.file_selection.size_only);
+        assert!(config.file_selection.from0);
+    }
+
+    #[test]
+    fn connection_setters_chain() {
+        let mut builder = ServerConfigBuilder::new();
+        let config = builder
+            .client_mode(true)
+            .is_daemon_connection(true)
+            .build()
+            .expect("valid config");
+
+        assert!(config.connection.client_mode);
+        assert!(config.connection.is_daemon_connection);
+    }
+
+    #[test]
+    fn builder_reusable_after_build() {
+        let mut builder = ServerConfigBuilder::new();
+        builder.role(ServerRole::Generator).flag_string("-r");
+
+        let c1 = builder.build().expect("first build");
+        let c2 = builder.build().expect("second build");
+
+        assert_eq!(c1.role, c2.role);
+        assert_eq!(c1.flag_string, c2.flag_string);
+    }
+}
+
+mod defaults {
+    use super::*;
+
+    #[test]
+    fn default_write_config() {
+        let config = ServerConfigBuilder::new().build().expect("valid");
+        assert!(!config.write.fsync);
+        assert!(!config.write.inplace);
+        assert!(!config.write.inplace_partial);
+        assert!(!config.write.write_devices);
+        assert!(!config.write.delay_updates);
+    }
+
+    #[test]
+    fn default_deletion_config() {
+        let config = ServerConfigBuilder::new().build().expect("valid");
+        assert!(config.deletion.max_delete.is_none());
+        assert!(!config.deletion.ignore_errors);
+        assert!(!config.deletion.late_delete);
+    }
+
+    #[test]
+    fn default_connection_config() {
+        let config = ServerConfigBuilder::new().build().expect("valid");
+        assert!(!config.connection.client_mode);
+        assert!(!config.connection.is_daemon_connection);
+        assert!(config.connection.filter_rules.is_empty());
+        assert!(config.connection.compression_level.is_none());
+        assert!(config.connection.compress_choice.is_none());
+        assert!(config.connection.files_from_data.is_none());
+    }
+
+    #[test]
+    fn default_file_selection_config() {
+        let config = ServerConfigBuilder::new().build().expect("valid");
+        assert!(config.file_selection.min_file_size.is_none());
+        assert!(config.file_selection.max_file_size.is_none());
+        assert!(!config.file_selection.ignore_existing);
+        assert!(!config.file_selection.existing_only);
+        assert!(!config.file_selection.size_only);
+    }
+
+    #[test]
+    fn default_optional_fields() {
+        let config = ServerConfigBuilder::new().build().expect("valid");
+        assert!(config.checksum_seed.is_none());
+        assert!(config.checksum_choice.is_none());
+        assert!(!config.trust_sender);
+        assert!(config.stop_at.is_none());
+        assert!(!config.qsort);
+        assert!(!config.has_partial_dir);
+        assert!(config.backup_dir.is_none());
+        assert!(config.backup_suffix.is_none());
+        assert!(config.daemon_filter_rules.is_empty());
+        assert!(!config.do_stats);
+        assert!(config.temp_dir.is_none());
+        assert!(config.skip_compress.is_none());
+    }
+}
+
+mod validation {
+    use super::*;
+
+    #[test]
+    fn valid_configuration_passes() {
+        let result = ServerConfigBuilder::new()
+            .role(ServerRole::Generator)
+            .flag_string("-rv")
+            .args(vec![OsString::from("/path")])
+            .build();
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn inplace_and_delay_updates_conflict() {
+        let result = ServerConfigBuilder::new()
+            .inplace(true)
+            .delay_updates(true)
+            .build();
+
+        assert!(matches!(
+            result,
+            Err(BuilderError::ConflictingOptions {
+                option1: "--inplace",
+                option2: "--delay-updates",
+            })
+        ));
+    }
+
+    #[test]
+    fn append_and_partial_dir_conflict() {
+        let mut builder = ServerConfigBuilder::new();
+        builder.flags(ParsedServerFlags {
+            append: true,
+            ..ParsedServerFlags::default()
+        });
+        builder.has_partial_dir(true);
+
+        let result = builder.build();
+
+        assert!(matches!(
+            result,
+            Err(BuilderError::ConflictingOptions {
+                option1: "--append",
+                option2: "--partial-dir",
+            })
+        ));
+    }
+
+    #[test]
+    fn min_greater_than_max_file_size_fails() {
+        let result = ServerConfigBuilder::new()
+            .min_file_size(Some(1000))
+            .max_file_size(Some(500))
+            .build();
+
+        assert!(matches!(
+            result,
+            Err(BuilderError::InvalidCombination { .. })
+        ));
+    }
+
+    #[test]
+    fn equal_min_max_file_size_passes() {
+        let result = ServerConfigBuilder::new()
+            .min_file_size(Some(1000))
+            .max_file_size(Some(1000))
+            .build();
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn only_inplace_without_delay_updates_passes() {
+        let result = ServerConfigBuilder::new().inplace(true).build();
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn only_delay_updates_without_inplace_passes() {
+        let result = ServerConfigBuilder::new().delay_updates(true).build();
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn build_unchecked_skips_validation() {
+        let mut builder = ServerConfigBuilder::new();
+        builder.inplace(true).delay_updates(true);
+
+        let config = builder.build_unchecked();
+        assert!(config.write.inplace);
+        assert!(config.write.delay_updates);
+    }
+}
+
+mod composite_setters {
+    use super::*;
+
+    #[test]
+    fn write_config_setter_replaces_entire_config() {
+        let write = WriteConfig {
+            fsync: true,
+            inplace: true,
+            ..Default::default()
+        };
+        let config = ServerConfigBuilder::new()
+            .write(write.clone())
+            .build()
+            .expect("valid");
+
+        assert_eq!(config.write, write);
+    }
+
+    #[test]
+    fn deletion_config_setter_replaces_entire_config() {
+        let deletion = DeletionConfig {
+            max_delete: Some(50),
+            ignore_errors: true,
+            late_delete: true,
+        };
+        let config = ServerConfigBuilder::new()
+            .deletion(deletion.clone())
+            .build()
+            .expect("valid");
+
+        assert_eq!(config.deletion, deletion);
+    }
+
+    #[test]
+    fn connection_config_setter_replaces_entire_config() {
+        let connection = ConnectionConfig {
+            client_mode: true,
+            is_daemon_connection: true,
+            ..Default::default()
+        };
+        let config = ServerConfigBuilder::new()
+            .connection(connection.clone())
+            .build()
+            .expect("valid");
+
+        assert_eq!(config.connection, connection);
+    }
+
+    #[test]
+    fn file_selection_config_setter_replaces_entire_config() {
+        let selection = FileSelectionConfig {
+            min_file_size: Some(100),
+            max_file_size: Some(10_000),
+            size_only: true,
+            ..Default::default()
+        };
+        let config = ServerConfigBuilder::new()
+            .file_selection(selection.clone())
+            .build()
+            .expect("valid");
+
+        assert_eq!(config.file_selection, selection);
+    }
+}
+
+mod builder_error {
+    use super::*;
+
+    #[test]
+    fn conflicting_options_display() {
+        let err = BuilderError::ConflictingOptions {
+            option1: "--foo",
+            option2: "--bar",
+        };
+        assert_eq!(err.to_string(), "conflicting options: --foo and --bar");
+    }
+
+    #[test]
+    fn invalid_combination_display() {
+        let err = BuilderError::InvalidCombination {
+            message: "test message".to_string(),
+        };
+        assert_eq!(err.to_string(), "invalid option combination: test message");
+    }
+
+    #[test]
+    fn builder_error_implements_error_trait() {
+        let err: Box<dyn std::error::Error> = Box::new(BuilderError::ConflictingOptions {
+            option1: "a",
+            option2: "b",
+        });
+        assert!(!err.to_string().is_empty());
+    }
+
+    #[test]
+    fn builder_error_eq() {
+        let err1 = BuilderError::ConflictingOptions {
+            option1: "a",
+            option2: "b",
+        };
+        let err2 = BuilderError::ConflictingOptions {
+            option1: "a",
+            option2: "b",
+        };
+        assert_eq!(err1, err2);
+    }
+
+    #[test]
+    fn builder_error_ne() {
+        let err1 = BuilderError::ConflictingOptions {
+            option1: "a",
+            option2: "b",
+        };
+        let err2 = BuilderError::ConflictingOptions {
+            option1: "c",
+            option2: "d",
+        };
+        assert_ne!(err1, err2);
+    }
+}

--- a/crates/transfer/src/config/error.rs
+++ b/crates/transfer/src/config/error.rs
@@ -1,0 +1,33 @@
+//! Error types for [`ServerConfigBuilder`](super::ServerConfigBuilder) validation.
+
+/// Errors that can occur when building a [`ServerConfig`](super::ServerConfig).
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum BuilderError {
+    /// Mutually exclusive options were specified.
+    ConflictingOptions {
+        /// The first conflicting option.
+        option1: &'static str,
+        /// The second conflicting option.
+        option2: &'static str,
+    },
+    /// An invalid combination of options was specified.
+    InvalidCombination {
+        /// Description of the invalid combination.
+        message: String,
+    },
+}
+
+impl std::fmt::Display for BuilderError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ConflictingOptions { option1, option2 } => {
+                write!(f, "conflicting options: {option1} and {option2}")
+            }
+            Self::InvalidCombination { message } => {
+                write!(f, "invalid option combination: {message}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for BuilderError {}

--- a/crates/transfer/src/config/mod.rs
+++ b/crates/transfer/src/config/mod.rs
@@ -1,5 +1,10 @@
-#![deny(unsafe_code)]
 //! Server configuration derived from the compact flag string and trailing arguments.
+
+mod builder;
+mod error;
+
+pub use builder::ServerConfigBuilder;
+pub use error::BuilderError;
 
 use std::ffi::OsString;
 use std::time::SystemTime;
@@ -391,6 +396,9 @@ impl ServerConfig {
         })
     }
 }
+
+#[cfg(test)]
+mod builder_tests;
 
 #[cfg(test)]
 mod tests {

--- a/crates/transfer/src/lib.rs
+++ b/crates/transfer/src/lib.rs
@@ -179,7 +179,8 @@ pub use self::adaptive_buffer::{
     adaptive_buffer_size, adaptive_token_capacity, adaptive_writer_capacity,
 };
 pub use self::config::{
-    FileSelectionConfig, ReferenceDirectory, ReferenceDirectoryKind, ServerConfig,
+    BuilderError, FileSelectionConfig, ReferenceDirectory, ReferenceDirectoryKind, ServerConfig,
+    ServerConfigBuilder,
 };
 pub use self::delta_config::DeltaGeneratorConfig;
 pub use self::flags::{InfoFlags, ParseFlagError, ParsedServerFlags};


### PR DESCRIPTION
## Summary

- Add `ServerConfigBuilder` for the transfer crate's `ServerConfig`, following the `LocalCopyOptionsBuilder` reference pattern
- All public setters use `&mut self -> &mut Self` for ergonomic chaining and builder reuse
- `build()` validates mutual exclusion constraints: `--inplace` vs `--delay-updates`, `--append` vs `--partial-dir`, and `min_file_size` vs `max_file_size` range
- Export `ServerConfigBuilder` and `BuilderError` from `transfer::config` and top-level `transfer`
- 31 tests covering builder creation, chaining, defaults, validation, composite setters, and error types

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy -p transfer --all-features --no-deps -- -D warnings` passes
- [x] `cargo nextest run -p transfer --all-features -E 'test(config::builder_tests)'` - 31 new tests pass
- [x] `cargo nextest run -p transfer --all-features -E 'test(config::tests)'` - 20 existing tests pass
- [ ] CI: fmt+clippy, nextest, Windows, macOS, Linux musl