### PR TITLE
style: enforce unused_imports and dead_code deny at workspace level

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,6 +101,9 @@ async = ["daemon/async", "core/async"]
 # systemd sd-notify integration for daemon
 sd-notify = ["daemon/sd-notify"]
 
+[lints]
+workspace = true
+
 [dependencies]
 cli = { path = "crates/cli", default-features = false }
 daemon = { path = "crates/daemon", default-features = false }
@@ -213,6 +216,14 @@ all-features = true
 no-default-features = false
 rustdoc-args = ["--cfg", "docsrs", "-D", "rustdoc::broken_intra_doc_links"]
 targets = ["x86_64-unknown-linux-gnu"]
+
+# ============================================================================
+# Rust Compiler Lints - Workspace-Wide Enforcement
+# ============================================================================
+
+[workspace.lints.rust]
+unused_imports = "deny"
+dead_code = "deny"
 
 # ============================================================================
 # Clippy Lints - Strict Code Quality Configuration

--- a/crates/apple-fs/Cargo.toml
+++ b/crates/apple-fs/Cargo.toml
@@ -12,3 +12,6 @@ nix = { version = "0.29", default-features = false, features = ["fs"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 unicode-normalization = "0.1"
+
+[lints]
+workspace = true

--- a/crates/apple-fs/src/lib.rs
+++ b/crates/apple-fs/src/lib.rs
@@ -19,12 +19,12 @@ mod unix {
     use nix::sys::stat::{Mode, SFlag, mknod as nix_mknod};
     use nix::unistd::mkfifo as nix_mkfifo;
 
-    pub(super) fn mkfifo(path: &Path, mode: libc::mode_t) -> io::Result<()> {
+    pub fn mkfifo(path: &Path, mode: libc::mode_t) -> io::Result<()> {
         let mode = Mode::from_bits_truncate(mode);
         nix_mkfifo(path, mode).map_err(io::Error::from)
     }
 
-    pub(super) fn mknod(path: &Path, mode: libc::mode_t, device: libc::dev_t) -> io::Result<()> {
+    pub fn mknod(path: &Path, mode: libc::mode_t, device: libc::dev_t) -> io::Result<()> {
         let kind = SFlag::from_bits_truncate(mode);
         let perm = Mode::from_bits_truncate(mode);
         nix_mknod(path, kind, perm, device).map_err(io::Error::from)

--- a/crates/bandwidth/Cargo.toml
+++ b/crates/bandwidth/Cargo.toml
@@ -45,3 +45,6 @@ required-features = ["test-support"]
 [[test]]
 name = "bwlimit_scenarios"
 required-features = ["test-support"]
+
+[lints]
+workspace = true

--- a/crates/bandwidth/src/async_limiter.rs
+++ b/crates/bandwidth/src/async_limiter.rs
@@ -91,7 +91,7 @@ impl AsyncRateLimiter {
         self.tokens = 0;
 
         // Calculate sleep duration: deficit / rate seconds.
-        let sleep_nanos = (deficit as u128) * 1_000_000_000 / (self.rate.get() as u128);
+        let sleep_nanos = u128::from(deficit) * 1_000_000_000 / u128::from(self.rate.get());
         let sleep_duration = Duration::from_nanos(sleep_nanos as u64);
 
         tokio::time::sleep(sleep_duration).await;
@@ -158,8 +158,8 @@ impl AsyncRateLimiter {
         // Calculate tokens earned: elapsed_secs * rate.
         // Use nanos for precision: (elapsed_nanos * rate) / 1_000_000_000.
         let elapsed_nanos = elapsed.as_nanos();
-        let earned = (elapsed_nanos * (self.rate.get() as u128)) / 1_000_000_000;
-        let earned = earned.min(u64::MAX as u128) as u64;
+        let earned = (elapsed_nanos * u128::from(self.rate.get())) / 1_000_000_000;
+        let earned = earned.min(u128::from(u64::MAX)) as u64;
 
         self.tokens = self.tokens.saturating_add(earned).min(self.burst);
     }

--- a/crates/bandwidth/src/limiter/change.rs
+++ b/crates/bandwidth/src/limiter/change.rs
@@ -87,8 +87,8 @@ impl PartialOrd for LimiterChange {
     }
 }
 
-impl FromIterator<LimiterChange> for LimiterChange {
-    fn from_iter<I: IntoIterator<Item = LimiterChange>>(iter: I) -> Self {
+impl FromIterator<Self> for LimiterChange {
+    fn from_iter<I: IntoIterator<Item = Self>>(iter: I) -> Self {
         Self::combine_all(iter)
     }
 }

--- a/crates/bandwidth/src/limiter/mod.rs
+++ b/crates/bandwidth/src/limiter/mod.rs
@@ -21,31 +21,31 @@ pub use change::{LimiterChange, apply_effective_limit};
 pub use core::BandwidthLimiter;
 pub use sleep::LimiterSleep;
 
-pub(super) use sleep::{duration_from_microseconds, sleep_for};
+pub use sleep::{duration_from_microseconds, sleep_for};
 
 /// One million microseconds per second.
 // upstream: io.c:sleep_for_bwlimit() ONE_SEC macro
-pub(super) const MICROS_PER_SECOND: u128 = 1_000_000;
+pub const MICROS_PER_SECOND: u128 = 1_000_000;
 
 /// Minimum accumulated debt before the limiter actually sleeps.
 // upstream: io.c:sleep_for_bwlimit() - `ONE_SEC / 10` threshold
-pub(super) const MINIMUM_SLEEP_MICROS: u128 = MICROS_PER_SECOND / 10;
+pub const MINIMUM_SLEEP_MICROS: u128 = MICROS_PER_SECOND / 10;
 
 /// Largest microsecond value representable as a `Duration`.
-pub(super) const MAX_REPRESENTABLE_MICROSECONDS: u128 =
+pub const MAX_REPRESENTABLE_MICROSECONDS: u128 =
     (u64::MAX as u128) * MICROS_PER_SECOND + (MICROS_PER_SECOND - 1);
 
 /// Upper bound for a single `select()`-style sleep call.
-pub(super) const MAX_SLEEP_DURATION: Duration = Duration::new(i64::MAX as u64, 999_999_999);
+pub const MAX_SLEEP_DURATION: Duration = Duration::new(i64::MAX as u64, 999_999_999);
 
 /// Floor for the per-write chunk size.
 // upstream: options.c:2378 - `if (bwlimit_writemax < 512) bwlimit_writemax = 512`
-pub(super) const MIN_WRITE_MAX: usize = 512;
+pub const MIN_WRITE_MAX: usize = 512;
 
 #[cfg(any(test, feature = "test-support"))]
 mod test_support;
 #[cfg(any(test, feature = "test-support"))]
-pub(super) use self::test_support::append_recorded_sleeps;
+pub use self::test_support::append_recorded_sleeps;
 #[cfg(any(test, feature = "test-support"))]
 pub use self::test_support::{RecordedSleepIter, RecordedSleepSession, recorded_sleep_session};
 

--- a/crates/bandwidth/src/limiter/sleep.rs
+++ b/crates/bandwidth/src/limiter/sleep.rs
@@ -49,7 +49,7 @@ impl LimiterSleep {
 }
 
 /// Converts a microsecond count to a [`Duration`], saturating to `Duration::MAX` on overflow.
-pub(crate) const fn duration_from_microseconds(us: u128) -> Duration {
+pub const fn duration_from_microseconds(us: u128) -> Duration {
     if us == 0 {
         return Duration::ZERO;
     }
@@ -66,7 +66,7 @@ pub(crate) const fn duration_from_microseconds(us: u128) -> Duration {
 
 /// Sleeps for the given duration, chunking into `MAX_SLEEP_DURATION` segments.
 // upstream: io.c:sleep_for_bwlimit() - uses select() for the actual sleep
-pub(crate) fn sleep_for(duration: Duration) {
+pub fn sleep_for(duration: Duration) {
     let mut remaining = duration;
 
     #[cfg(any(test, feature = "test-support"))]

--- a/crates/bandwidth/src/limiter/test_support.rs
+++ b/crates/bandwidth/src/limiter/test_support.rs
@@ -13,7 +13,7 @@ use std::sync::{Mutex, MutexGuard, OnceLock};
 use std::time::Duration;
 
 /// Returns the global buffer where test sleep durations are accumulated.
-pub(crate) fn recorded_sleeps() -> &'static Mutex<Vec<Duration>> {
+pub fn recorded_sleeps() -> &'static Mutex<Vec<Duration>> {
     static RECORDED_SLEEPS: OnceLock<Mutex<Vec<Duration>>> = OnceLock::new();
     RECORDED_SLEEPS.get_or_init(|| Mutex::new(Vec::new()))
 }
@@ -24,20 +24,20 @@ fn recorded_sleep_session_lock() -> &'static Mutex<()> {
 }
 
 /// Appends the given sleep chunks to the global recorded buffer.
-pub(crate) fn append_recorded_sleeps(chunks: Vec<Duration>) {
+pub fn append_recorded_sleeps(chunks: Vec<Duration>) {
     lock_recorded_sleeps().extend(chunks);
 }
 
 fn lock_recorded_sleeps() -> MutexGuard<'static, Vec<Duration>> {
     recorded_sleeps()
         .lock()
-        .unwrap_or_else(|poison| poison.into_inner())
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
 }
 
 fn lock_recorded_sleep_session() -> MutexGuard<'static, ()> {
     recorded_sleep_session_lock()
         .lock()
-        .unwrap_or_else(|poison| poison.into_inner())
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
 }
 
 #[cfg_attr(docsrs, doc(cfg(feature = "test-support")))]
@@ -54,15 +54,15 @@ pub struct RecordedSleepSession<'a> {
     _guard: MutexGuard<'a, ()>,
 }
 
-impl<'a> RecordedSleepSession<'a> {
+impl RecordedSleepSession<'_> {
     #[inline]
-    fn with_recorded_sleeps<R>(&self, op: impl FnOnce(&[Duration]) -> R) -> R {
+    fn with_recorded_sleeps<R>(op: impl FnOnce(&[Duration]) -> R) -> R {
         let guard = lock_recorded_sleeps();
         op(guard.as_slice())
     }
 
     #[inline]
-    fn with_recorded_sleeps_mut<R>(&self, op: impl FnOnce(&mut Vec<Duration>) -> R) -> R {
+    fn with_recorded_sleeps_mut<R>(op: impl FnOnce(&mut Vec<Duration>) -> R) -> R {
         let mut guard = lock_recorded_sleeps();
         op(guard.as_mut())
     }
@@ -70,21 +70,21 @@ impl<'a> RecordedSleepSession<'a> {
     /// Removes any previously recorded durations.
     #[inline]
     pub fn clear(&mut self) {
-        self.with_recorded_sleeps_mut(|durations| durations.clear());
+        Self::with_recorded_sleeps_mut(Vec::clear);
     }
 
     /// Returns `true` when no sleep durations have been recorded.
     #[inline]
     #[must_use]
     pub fn is_empty(&self) -> bool {
-        self.with_recorded_sleeps(|durations| durations.is_empty())
+        Self::with_recorded_sleeps(<[Duration]>::is_empty)
     }
 
     /// Returns the number of recorded sleep intervals.
     #[inline]
     #[must_use]
     pub fn len(&self) -> usize {
-        self.with_recorded_sleeps(|durations| durations.len())
+        Self::with_recorded_sleeps(<[Duration]>::len)
     }
 
     /// Returns a snapshot of the recorded sleep durations without clearing them.
@@ -116,7 +116,7 @@ impl<'a> RecordedSleepSession<'a> {
     /// ```
     #[inline]
     pub fn snapshot(&self) -> Vec<Duration> {
-        self.with_recorded_sleeps(|durations| durations.to_vec())
+        Self::with_recorded_sleeps(<[Duration]>::to_vec)
     }
 
     /// Returns the most recently recorded sleep duration without draining the buffer.
@@ -147,7 +147,7 @@ impl<'a> RecordedSleepSession<'a> {
     /// ```
     #[inline]
     pub fn last_duration(&self) -> Option<Duration> {
-        self.with_recorded_sleeps(|durations| durations.last().copied())
+        Self::with_recorded_sleeps(|durations| durations.last().copied())
     }
 
     /// Returns the cumulative duration of all recorded sleeps without consuming them.
@@ -181,18 +181,18 @@ impl<'a> RecordedSleepSession<'a> {
     #[inline]
     #[must_use]
     pub fn total_duration(&self) -> Duration {
-        self.with_recorded_sleeps(|durations| {
+        Self::with_recorded_sleeps(|durations| {
             durations
                 .iter()
                 .copied()
-                .fold(Duration::ZERO, |acc, chunk| acc.saturating_add(chunk))
+                .fold(Duration::ZERO, Duration::saturating_add)
         })
     }
 
     /// Drains the recorded sleep durations, returning ownership of the vector.
     #[inline]
     pub fn take(&mut self) -> Vec<Duration> {
-        self.with_recorded_sleeps_mut(mem::take)
+        Self::with_recorded_sleeps_mut(mem::take)
     }
 
     /// Consumes the session and returns the recorded durations.
@@ -248,6 +248,17 @@ impl<'a> RecordedSleepSession<'a> {
             _session: PhantomData,
         }
     }
+
+    /// Returns a read-only iterator - identical to [`iter`](Self::iter).
+    ///
+    /// The recorded sleep buffer is behind a mutex, so mutation is performed
+    /// through [`clear`](Self::clear) or [`take`](Self::take) rather than via
+    /// the iterator. This method exists to satisfy the `IntoIterator for &mut`
+    /// contract.
+    #[inline]
+    pub fn iter_mut(&mut self) -> RecordedSleepIter<'_> {
+        self.iter()
+    }
 }
 
 /// Converts a [`RecordedSleepSession`] into an iterator over the captured durations.
@@ -275,7 +286,7 @@ impl<'a> RecordedSleepSession<'a> {
 /// assert_eq!(durations.len(), 1);
 /// # }
 /// ```
-impl<'a> IntoIterator for RecordedSleepSession<'a> {
+impl IntoIterator for RecordedSleepSession<'_> {
     type Item = Duration;
     type IntoIter = std::vec::IntoIter<Duration>;
 

--- a/crates/bandwidth/src/parse.rs
+++ b/crates/bandwidth/src/parse.rs
@@ -15,7 +15,7 @@ mod components;
 mod numeric;
 
 pub use components::BandwidthLimitComponents;
-pub(crate) use numeric::pow_u128;
+pub use numeric::pow_u128;
 
 use numeric::parse_decimal_with_exponent;
 
@@ -198,16 +198,20 @@ pub fn parse_bandwidth_argument(text: &str) -> Result<Option<NonZeroU64>, Bandwi
         .ok_or(BandwidthParseError::TooLarge)?;
     let mut denominator = denominator;
 
-    if decimal_exponent > 0 {
-        let factor = pow_u128(10, decimal_exponent.unsigned_abs())?;
-        numerator = numerator
-            .checked_mul(factor)
-            .ok_or(BandwidthParseError::TooLarge)?;
-    } else if decimal_exponent < 0 {
-        let factor = pow_u128(10, decimal_exponent.unsigned_abs())?;
-        denominator = denominator
-            .checked_mul(factor)
-            .ok_or(BandwidthParseError::TooLarge)?;
+    match decimal_exponent.cmp(&0) {
+        std::cmp::Ordering::Greater => {
+            let factor = pow_u128(10, decimal_exponent.unsigned_abs())?;
+            numerator = numerator
+                .checked_mul(factor)
+                .ok_or(BandwidthParseError::TooLarge)?;
+        }
+        std::cmp::Ordering::Less => {
+            let factor = pow_u128(10, decimal_exponent.unsigned_abs())?;
+            denominator = denominator
+                .checked_mul(factor)
+                .ok_or(BandwidthParseError::TooLarge)?;
+        }
+        std::cmp::Ordering::Equal => {}
     }
 
     let product = numerator

--- a/crates/bandwidth/src/parse/numeric.rs
+++ b/crates/bandwidth/src/parse/numeric.rs
@@ -8,7 +8,7 @@ use super::BandwidthParseError;
 use memchr::memchr2;
 
 // upstream: options.c:parse_size_arg() - atof() for decimal mantissa
-pub(crate) fn parse_decimal_with_exponent(
+pub fn parse_decimal_with_exponent(
     text: &str,
 ) -> Result<(u128, u128, u128, i32), BandwidthParseError> {
     let bytes = text.as_bytes();
@@ -40,7 +40,7 @@ pub(crate) fn parse_decimal_with_exponent(
 
 /// Checked exponentiation for suffix multiplier calculation.
 // upstream: options.c:parse_size_arg() - `while (reps--) size *= mult`
-pub(crate) fn pow_u128(base: u32, exponent: u32) -> Result<u128, BandwidthParseError> {
+pub fn pow_u128(base: u32, exponent: u32) -> Result<u128, BandwidthParseError> {
     let mut result = 1u128;
     let mut factor = u128::from(base);
     let mut exp = exponent;

--- a/crates/batch/Cargo.toml
+++ b/crates/batch/Cargo.toml
@@ -21,3 +21,6 @@ filetime = "0.2"
 [dev-dependencies]
 tempfile = "3.15"
 protocol = { path = "../protocol" }
+
+[lints]
+workspace = true

--- a/crates/branding/Cargo.toml
+++ b/crates/branding/Cargo.toml
@@ -22,3 +22,6 @@ toml = "1.1"
 
 [build-dependencies]
 toml = "1.1"
+
+[lints]
+workspace = true

--- a/crates/checksums/Cargo.toml
+++ b/crates/checksums/Cargo.toml
@@ -71,3 +71,6 @@ harness = false
 [[bench]]
 name = "pipelined_benchmark"
 harness = false
+
+[lints]
+workspace = true

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -79,3 +79,6 @@ criterion = { version = "0.5", features = ["html_reports"] }
 [[bench]]
 name = "startup_benchmark"
 harness = false
+
+[lints]
+workspace = true

--- a/crates/compress/Cargo.toml
+++ b/crates/compress/Cargo.toml
@@ -29,3 +29,6 @@ flate2 = "1.0"
 zstd = { version = "0.13", optional = true }
 lz4_flex = { version = "0.13", optional = true, default-features = false, features = ["frame", "safe-encode", "safe-decode"] }
 thiserror = "2.0"
+
+[lints]
+workspace = true

--- a/crates/compress/src/algorithm.rs
+++ b/crates/compress/src/algorithm.rs
@@ -43,11 +43,11 @@ impl CompressionAlgorithm {
     #[must_use]
     pub const fn name(self) -> &'static str {
         match self {
-            CompressionAlgorithm::Zlib => "zlib",
+            Self::Zlib => "zlib",
             #[cfg(feature = "lz4")]
-            CompressionAlgorithm::Lz4 => "lz4",
+            Self::Lz4 => "lz4",
             #[cfg(feature = "zstd")]
-            CompressionAlgorithm::Zstd => "zstd",
+            Self::Zstd => "zstd",
         }
     }
 
@@ -59,21 +59,21 @@ impl CompressionAlgorithm {
     pub const fn default_algorithm() -> Self {
         #[cfg(feature = "zstd")]
         {
-            CompressionAlgorithm::Zstd
+            Self::Zstd
         }
         #[cfg(all(not(feature = "zstd"), feature = "lz4"))]
         {
-            CompressionAlgorithm::Lz4
+            Self::Lz4
         }
         #[cfg(all(not(feature = "zstd"), not(feature = "lz4")))]
         {
-            CompressionAlgorithm::Zlib
+            Self::Zlib
         }
     }
 
     /// Returns the set of algorithms available in the current build.
     #[must_use]
-    pub const fn available() -> &'static [CompressionAlgorithm] {
+    pub const fn available() -> &'static [Self] {
         #[cfg(all(feature = "zstd", feature = "lz4"))]
         {
             const ALGORITHMS: &[CompressionAlgorithm] = &[
@@ -369,11 +369,11 @@ impl FromStr for CompressionAlgorithm {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.trim().to_ascii_lowercase().as_str() {
-            "zlib" | "zlibx" => Ok(CompressionAlgorithm::Zlib),
+            "zlib" | "zlibx" => Ok(Self::Zlib),
             #[cfg(feature = "lz4")]
-            "lz4" => Ok(CompressionAlgorithm::Lz4),
+            "lz4" => Ok(Self::Lz4),
             #[cfg(feature = "zstd")]
-            "zstd" => Ok(CompressionAlgorithm::Zstd),
+            "zstd" => Ok(Self::Zstd),
             other => Err(CompressionAlgorithmParseError::new(other.to_owned())),
         }
     }

--- a/crates/compress/src/common.rs
+++ b/crates/compress/src/common.rs
@@ -24,33 +24,33 @@ impl Write for CountingSink {
     }
 }
 
-pub(crate) struct CountingWriter<W> {
+pub struct CountingWriter<W> {
     inner: W,
     bytes: u64,
 }
 
 impl<W> CountingWriter<W> {
-    pub(crate) const fn new(inner: W) -> Self {
+    pub const fn new(inner: W) -> Self {
         Self { inner, bytes: 0 }
     }
 
     #[inline]
-    pub(crate) const fn bytes(&self) -> u64 {
+    pub const fn bytes(&self) -> u64 {
         self.bytes
     }
 
     #[inline]
-    pub(crate) const fn inner_ref(&self) -> &W {
+    pub const fn inner_ref(&self) -> &W {
         &self.inner
     }
 
     #[inline]
-    pub(crate) const fn inner_mut(&mut self) -> &mut W {
+    pub const fn inner_mut(&mut self) -> &mut W {
         &mut self.inner
     }
 
     #[inline]
-    pub(crate) fn into_parts(self) -> (W, u64) {
+    pub fn into_parts(self) -> (W, u64) {
         (self.inner, self.bytes)
     }
 
@@ -59,7 +59,7 @@ impl<W> CountingWriter<W> {
     /// Saturation prevents overflow if the counter exceeds `u64::MAX` (unlikely
     /// in practice but provides a safety guarantee for very long-running streams).
     #[inline]
-    pub(crate) const fn saturating_add_bytes(&mut self, written: usize) {
+    pub const fn saturating_add_bytes(&mut self, written: usize) {
         self.bytes = self.bytes.saturating_add(written as u64);
     }
 }

--- a/crates/compress/src/lz4/frame.rs
+++ b/crates/compress/src/lz4/frame.rs
@@ -196,8 +196,7 @@ pub fn decompress_into(input: &[u8], output: &mut Vec<u8>) -> io::Result<usize> 
 
 fn frame_info_for_level(level: CompressionLevel) -> FrameInfo {
     let block_size = match level {
-        CompressionLevel::None => BlockSize::Max64KB,
-        CompressionLevel::Fast => BlockSize::Max64KB,
+        CompressionLevel::None | CompressionLevel::Fast => BlockSize::Max64KB,
         CompressionLevel::Default => BlockSize::Max256KB,
         CompressionLevel::Best => BlockSize::Max4MB,
         CompressionLevel::Precise(value) => match value.get() {

--- a/crates/compress/src/lz4/raw.rs
+++ b/crates/compress/src/lz4/raw.rs
@@ -35,6 +35,7 @@ pub const DEFLATED_DATA: u8 = 0x40;
 pub const MAX_BLOCK_SIZE: usize = 16383;
 
 /// Maximum decompressed size to prevent memory exhaustion attacks.
+///
 /// Set to 64 MiB which is larger than any reasonable rsync block.
 /// Upstream rsync uses 128KB blocks max, but we allow for larger custom configs.
 pub const MAX_DECOMPRESSED_SIZE: usize = 64 * 1024 * 1024;
@@ -327,7 +328,7 @@ pub const fn compressed_size_from_header(header: [u8; 2]) -> Option<usize> {
 
 impl From<lz4_flex::block::CompressError> for RawLz4Error {
     fn from(e: lz4_flex::block::CompressError) -> Self {
-        RawLz4Error::Io(io::Error::new(io::ErrorKind::InvalidData, e.to_string()))
+        Self::Io(io::Error::new(io::ErrorKind::InvalidData, e.to_string()))
     }
 }
 
@@ -335,7 +336,7 @@ impl From<RawLz4Error> for io::Error {
     fn from(e: RawLz4Error) -> Self {
         match e {
             RawLz4Error::Io(io_err) => io_err,
-            other => io::Error::new(io::ErrorKind::InvalidData, other.to_string()),
+            other => Self::new(io::ErrorKind::InvalidData, other.to_string()),
         }
     }
 }

--- a/crates/compress/src/skip_compress/decider.rs
+++ b/crates/compress/src/skip_compress/decider.rs
@@ -180,7 +180,7 @@ impl CompressionDecider {
         // Check magic bytes if available and enabled
         if self.use_magic_detection {
             if let Some(data) = first_block {
-                if let Some(category) = self.detect_category_by_magic(data) {
+                if let Some(category) = Self::detect_category_by_magic(data) {
                     if !category.is_compressible() {
                         return CompressionDecision::Skip;
                     }
@@ -249,7 +249,7 @@ impl CompressionDecider {
     }
 
     /// Detects file category by examining magic bytes.
-    fn detect_category_by_magic(&self, data: &[u8]) -> Option<FileCategory> {
+    fn detect_category_by_magic(data: &[u8]) -> Option<FileCategory> {
         for sig in KNOWN_SIGNATURES {
             if sig.matches(data) {
                 // Special handling for RIFF container (can be AVI, WAV, or WEBP)
@@ -262,10 +262,9 @@ impl CompressionDecider {
                             b"WEBP" => FileCategory::Image,
                             _ => continue, // Unknown RIFF subtype, check other signatures
                         });
-                    } else {
-                        // Incomplete RIFF header - not enough data to determine type
-                        continue;
                     }
+                    // Incomplete RIFF header - not enough data to determine type
+                    continue;
                 }
 
                 return Some(sig.category);

--- a/crates/compress/src/skip_compress/types.rs
+++ b/crates/compress/src/skip_compress/types.rs
@@ -45,10 +45,9 @@ impl FileCategory {
     #[must_use]
     pub const fn is_compressible(self) -> bool {
         match self {
-            Self::Image | Self::Video | Self::Audio | Self::Archive => false,
-            Self::Document => false, // PDFs and Office docs are usually pre-compressed
-            Self::Text | Self::Data | Self::Executable => true,
-            Self::Unknown => true, // Optimistic default
+            // PDFs and Office docs are usually pre-compressed
+            Self::Image | Self::Video | Self::Audio | Self::Archive | Self::Document => false,
+            Self::Text | Self::Data | Self::Executable | Self::Unknown => true,
         }
     }
 }

--- a/crates/compress/src/strategy/kind.rs
+++ b/crates/compress/src/strategy/kind.rs
@@ -99,9 +99,8 @@ impl CompressionAlgorithmKind {
             return Self::Zstd;
             #[cfg(not(feature = "zstd"))]
             return Self::Zlib;
-        } else {
-            Self::Zlib
         }
+        Self::Zlib
     }
 }
 

--- a/crates/compress/src/strategy/selector.rs
+++ b/crates/compress/src/strategy/selector.rs
@@ -38,7 +38,6 @@ impl CompressionStrategySelector {
     pub fn for_protocol_version(protocol_version: u8) -> Box<dyn CompressionStrategy> {
         let kind = CompressionAlgorithmKind::for_protocol_version(protocol_version);
         Self::for_algorithm_kind(kind, kind.default_level())
-            .unwrap_or_else(|_| Box::new(ZlibStrategy::with_default_level()))
     }
 
     /// Creates a strategy for the specified algorithm kind with a given level.
@@ -63,21 +62,21 @@ impl CompressionStrategySelector {
         kind: CompressionAlgorithmKind,
         level: CompressionLevel,
     ) -> io::Result<Box<dyn CompressionStrategy>> {
-        Self::for_algorithm_kind(kind, level)
+        Ok(Self::for_algorithm_kind(kind, level))
     }
 
     /// Creates a strategy for the given algorithm kind and compression level.
     fn for_algorithm_kind(
         kind: CompressionAlgorithmKind,
         level: CompressionLevel,
-    ) -> io::Result<Box<dyn CompressionStrategy>> {
+    ) -> Box<dyn CompressionStrategy> {
         match kind {
-            CompressionAlgorithmKind::None => Ok(Box::new(NoCompressionStrategy::new())),
-            CompressionAlgorithmKind::Zlib => Ok(Box::new(ZlibStrategy::new(level))),
+            CompressionAlgorithmKind::None => Box::new(NoCompressionStrategy::new()),
+            CompressionAlgorithmKind::Zlib => Box::new(ZlibStrategy::new(level)),
             #[cfg(feature = "zstd")]
-            CompressionAlgorithmKind::Zstd => Ok(Box::new(ZstdStrategy::new(level))),
+            CompressionAlgorithmKind::Zstd => Box::new(ZstdStrategy::new(level)),
             #[cfg(feature = "lz4")]
-            CompressionAlgorithmKind::Lz4 => Ok(Box::new(Lz4Strategy::new(level))),
+            CompressionAlgorithmKind::Lz4 => Box::new(Lz4Strategy::new(level)),
         }
     }
 
@@ -117,9 +116,7 @@ impl CompressionStrategySelector {
     ) -> Box<dyn CompressionStrategy> {
         for &local_algo in local_algorithms {
             if remote_algorithms.contains(&local_algo) && local_algo.is_available() {
-                if let Ok(strategy) = Self::for_algorithm_kind(local_algo, level) {
-                    return strategy;
-                }
+                return Self::for_algorithm_kind(local_algo, level);
             }
         }
 

--- a/crates/compress/src/zlib/level.rs
+++ b/crates/compress/src/zlib/level.rs
@@ -56,11 +56,11 @@ impl CompressionLevel {
 impl From<CompressionLevel> for Compression {
     fn from(level: CompressionLevel) -> Self {
         match level {
-            CompressionLevel::None => Compression::none(),
-            CompressionLevel::Fast => Compression::fast(),
-            CompressionLevel::Default => Compression::default(),
-            CompressionLevel::Best => Compression::best(),
-            CompressionLevel::Precise(value) => Compression::new(u32::from(value.get())),
+            CompressionLevel::None => Self::none(),
+            CompressionLevel::Fast => Self::fast(),
+            CompressionLevel::Default => Self::default(),
+            CompressionLevel::Best => Self::best(),
+            CompressionLevel::Precise(value) => Self::new(u32::from(value.get())),
         }
     }
 }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -108,3 +108,6 @@ criterion = { version = "0.5", features = ["html_reports"] }
 [[bench]]
 name = "transfer_benchmark"
 harness = false
+
+[lints]
+workspace = true

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -71,3 +71,6 @@ exacl = { workspace = true }
 [[bench]]
 name = "daemon_benchmark"
 harness = false
+
+[lints]
+workspace = true

--- a/crates/embedding/Cargo.toml
+++ b/crates/embedding/Cargo.toml
@@ -18,3 +18,6 @@ targets = ["x86_64-unknown-linux-gnu"]
 cli = { path = "../cli" }
 daemon = { path = "../daemon" }
 core = { path = "../core" }
+
+[lints]
+workspace = true

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -143,3 +143,6 @@ harness = false
 [[bench]]
 name = "buffer_pool_contention"
 harness = false
+
+[lints]
+workspace = true

--- a/crates/fast_io/Cargo.toml
+++ b/crates/fast_io/Cargo.toml
@@ -84,3 +84,6 @@ harness = false
 [[bench]]
 name = "platform_copy"
 harness = false
+
+[lints]
+workspace = true

--- a/crates/filters/Cargo.toml
+++ b/crates/filters/Cargo.toml
@@ -26,3 +26,6 @@ tracing = ["dep:tracing"]
 proptest = "1.4"
 tempfile = "3.15"
 test-support = { path = "../test-support" }
+
+[lints]
+workspace = true

--- a/crates/flist/Cargo.toml
+++ b/crates/flist/Cargo.toml
@@ -34,3 +34,6 @@ default = []
 parallel = ["rayon", "dep:libc"]
 # Serialization support for file list types
 serde = ["dep:serde"]
+
+[lints]
+workspace = true

--- a/crates/logging-sink/Cargo.toml
+++ b/crates/logging-sink/Cargo.toml
@@ -19,3 +19,6 @@ core = { path = "../core", default-features = false }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
+
+[lints]
+workspace = true

--- a/crates/logging/Cargo.toml
+++ b/crates/logging/Cargo.toml
@@ -32,3 +32,6 @@ serde_json = { workspace = true }
 [[example]]
 name = "tracing_demo"
 required-features = ["tracing"]
+
+[lints]
+workspace = true

--- a/crates/logging/src/tracing_bridge.rs
+++ b/crates/logging/src/tracing_bridge.rs
@@ -158,11 +158,9 @@ impl RsyncLayer {
     }
 
     /// Map a tracing level to a verbosity level.
-    const fn level_to_verbosity_level(level: &Level) -> u8 {
-        match *level {
-            Level::ERROR => 1,
-            Level::WARN => 1,
-            Level::INFO => 1,
+    const fn level_to_verbosity_level(level: Level) -> u8 {
+        match level {
+            Level::ERROR | Level::WARN | Level::INFO => 1,
             Level::DEBUG => 2,
             Level::TRACE => 3,
         }
@@ -177,7 +175,7 @@ where
         let metadata = event.metadata();
         let target = metadata.target();
         let level = metadata.level();
-        let verbosity_level = Self::level_to_verbosity_level(level);
+        let verbosity_level = Self::level_to_verbosity_level(*level);
 
         // Try to map to debug flag first (more specific)
         if let Some(debug_flag) = Self::target_to_debug_flag(target) {
@@ -334,11 +332,11 @@ mod tests {
 
     #[test]
     fn test_level_to_verbosity_level() {
-        assert_eq!(RsyncLayer::level_to_verbosity_level(&Level::ERROR), 1);
-        assert_eq!(RsyncLayer::level_to_verbosity_level(&Level::WARN), 1);
-        assert_eq!(RsyncLayer::level_to_verbosity_level(&Level::INFO), 1);
-        assert_eq!(RsyncLayer::level_to_verbosity_level(&Level::DEBUG), 2);
-        assert_eq!(RsyncLayer::level_to_verbosity_level(&Level::TRACE), 3);
+        assert_eq!(RsyncLayer::level_to_verbosity_level(Level::ERROR), 1);
+        assert_eq!(RsyncLayer::level_to_verbosity_level(Level::WARN), 1);
+        assert_eq!(RsyncLayer::level_to_verbosity_level(Level::INFO), 1);
+        assert_eq!(RsyncLayer::level_to_verbosity_level(Level::DEBUG), 2);
+        assert_eq!(RsyncLayer::level_to_verbosity_level(Level::TRACE), 3);
     }
 }
 

--- a/crates/match/Cargo.toml
+++ b/crates/match/Cargo.toml
@@ -47,3 +47,6 @@ harness = false
 [[bench]]
 name = "profiling_analysis"
 harness = false
+
+[lints]
+workspace = true

--- a/crates/metadata/Cargo.toml
+++ b/crates/metadata/Cargo.toml
@@ -41,3 +41,6 @@ acl = ["dep:exacl"]
 [dev-dependencies]
 tempfile = "3.15"
 test-support = { path = "../test-support" }
+
+[lints]
+workspace = true

--- a/crates/platform/Cargo.toml
+++ b/crates/platform/Cargo.toml
@@ -30,3 +30,6 @@ windows = { version = "0.61", features = [
 
 [dev-dependencies]
 tempfile = "3.15"
+
+[lints]
+workspace = true

--- a/crates/protocol/Cargo.toml
+++ b/crates/protocol/Cargo.toml
@@ -72,3 +72,6 @@ harness = false
 [[bench]]
 name = "wire_protocol_bench"
 harness = false
+
+[lints]
+workspace = true

--- a/crates/rsync_io/Cargo.toml
+++ b/crates/rsync_io/Cargo.toml
@@ -37,3 +37,6 @@ embedded-ssh = ["dep:async-trait", "dep:russh", "dep:russh-keys", "dep:ssh-key",
 proptest = "1.4"
 tempfile = "3.15"
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "net"] }
+
+[lints]
+workspace = true

--- a/crates/signature/Cargo.toml
+++ b/crates/signature/Cargo.toml
@@ -36,3 +36,6 @@ parallel = []
 
 [dev-dependencies]
 tempfile = "3.15"
+
+[lints]
+workspace = true

--- a/crates/test-support/Cargo.toml
+++ b/crates/test-support/Cargo.toml
@@ -11,3 +11,6 @@ description = "Shared test utilities for the oc-rsync workspace"
 
 [dependencies]
 tempfile = "3.15"
+
+[lints]
+workspace = true

--- a/crates/transfer/Cargo.toml
+++ b/crates/transfer/Cargo.toml
@@ -113,3 +113,6 @@ harness = false
 [[bench]]
 name = "reorder_buffer_benchmark"
 harness = false
+
+[lints]
+workspace = true

--- a/crates/windows-gnu-eh/Cargo.toml
+++ b/crates/windows-gnu-eh/Cargo.toml
@@ -9,3 +9,6 @@ description = "Compatibility shims for x86_64-pc-windows-gnu DWARF unwinding - o
 
 [lib]
 path = "src/lib.rs"
+
+[lints]
+workspace = true

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -24,3 +24,6 @@ which = "6"
 toml_edit = "0.25"
 tempfile = "3.15"
 regex = "1"
+
+[lints]
+workspace = true


### PR DESCRIPTION
## Summary

- Add `unused_imports = "deny"` and `dead_code = "deny"` to `[workspace.lints.rust]` in the root Cargo.toml
- Add `[lints] workspace = true` to all 26 crate Cargo.toml files and xtask/Cargo.toml so they inherit workspace lint configuration
- Fix pre-existing clippy warnings in `bandwidth`, `compress`, `logging`, and `apple-fs` crates that surfaced from inheriting workspace clippy lints (pedantic/nursery): redundant `pub(crate)` in private modules, `use_self`, redundant closures, `cast_lossless`, comparison chains, identical match arms, unnecessary `Result` wrapping, needless lifetimes, unused `self`, and trivially-copy pass-by-ref

## Test plan

- [ ] CI fmt+clippy passes
- [ ] CI nextest passes on all platforms (Linux, macOS, Windows)
- [ ] Verify no `unused_imports` or `dead_code` violations across workspace