### PR TITLE
fix: scope tokio dependency behind async feature in transfer crate

### DIFF
--- a/crates/transfer/Cargo.toml
+++ b/crates/transfer/Cargo.toml
@@ -28,7 +28,7 @@ getrandom = "0.3"
 thiserror = "2.0"
 tracing = { workspace = true, optional = true }
 rayon = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, optional = true }
 tokio-util = { workspace = true, optional = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
@@ -86,7 +86,7 @@ incremental-flist = []
 # ============================================================================
 
 # Async runtime support - enables tokio-based async pipeline for transfers
-async = ["dep:tokio-util"]
+async = ["dep:tokio", "dep:tokio-util"]
 
 # ============================================================================
 # Debugging Features


### PR DESCRIPTION
## Summary
- Move tokio from unconditional to optional dependency in the transfer crate
- Add `dep:tokio` to the `async` feature flag alongside `dep:tokio-util`
- Enforces project policy: only daemon and core (behind async feature) should depend on tokio

## Test plan
- [ ] CI passes (fmt+clippy, nextest, all platforms)
- [ ] Verify transfer crate builds without tokio when async feature is disabled