### PR TITLE
test: convert 17 ignore/no_run doctests to runnable across 4 crates

### DIFF
--- a/crates/bandwidth/src/async_limiter.rs
+++ b/crates/bandwidth/src/async_limiter.rs
@@ -23,7 +23,7 @@ use tokio::time::{Duration, Instant};
 /// # async fn example() {
 /// use bandwidth::AsyncRateLimiter;
 ///
-/// let limiter = AsyncRateLimiter::new(1_048_576); // 1 MiB/s
+/// let mut limiter = AsyncRateLimiter::new(1_048_576); // 1 MiB/s
 /// limiter.consume(4096).await;
 /// # }
 /// ```

--- a/crates/checksums/src/crc32c.rs
+++ b/crates/checksums/src/crc32c.rs
@@ -112,12 +112,15 @@ pub fn crc32c_bytes(data: &[u8]) -> u32 {
 ///
 /// # Examples
 ///
-/// ```no_run
-/// use checksums::crc32c::crc32c_file;
-/// use std::path::Path;
+/// ```
+/// use checksums::crc32c::{crc32c_file, crc32c_bytes};
 ///
-/// let checksum = crc32c_file(Path::new("/etc/hosts")).unwrap();
-/// println!("CRC32C: {checksum:#010x}");
+/// let dir = tempfile::tempdir().unwrap();
+/// let path = dir.path().join("test.txt");
+/// std::fs::write(&path, b"hello world").unwrap();
+///
+/// let file_checksum = crc32c_file(&path).unwrap();
+/// assert_eq!(file_checksum, crc32c_bytes(b"hello world"));
 /// ```
 pub fn crc32c_file(path: &Path) -> io::Result<u32> {
     let file = File::open(path)?;

--- a/crates/checksums/src/parallel/blocks.rs
+++ b/crates/checksums/src/parallel/blocks.rs
@@ -96,7 +96,7 @@ where
 ///
 /// # Example
 ///
-/// ```ignore
+/// ```
 /// use checksums::{parallel::compute_digests_parallel, strong::Md5};
 ///
 /// let blocks: Vec<&[u8]> = vec![b"block1", b"block2", b"block3"];
@@ -126,7 +126,7 @@ where
 ///
 /// # Example
 ///
-/// ```ignore
+/// ```
 /// use checksums::{parallel::compute_digests_with_seed_parallel, strong::Xxh64};
 ///
 /// let blocks: Vec<&[u8]> = vec![b"block1", b"block2", b"block3"];
@@ -154,7 +154,7 @@ where
 ///
 /// # Example
 ///
-/// ```ignore
+/// ```
 /// use checksums::parallel::compute_rolling_checksums_parallel;
 ///
 /// let blocks: Vec<&[u8]> = vec![b"block1", b"block2", b"block3"];
@@ -183,14 +183,15 @@ where
 ///
 /// # Example
 ///
-/// ```ignore
+/// ```
 /// use checksums::{parallel::compute_block_signatures_parallel, strong::Md5};
 ///
 /// let blocks: Vec<&[u8]> = vec![b"block1", b"block2", b"block3"];
 /// let signatures = compute_block_signatures_parallel::<Md5, _>(&blocks);
+/// assert_eq!(signatures.len(), 3);
 ///
 /// for sig in &signatures {
-///     println!("Rolling: {:08x}, Strong: {:?}", sig.rolling, sig.strong.as_ref());
+///     assert_ne!(sig.rolling, 0);
 /// }
 /// ```
 pub fn compute_block_signatures_parallel<D, T>(blocks: &[T]) -> Vec<BlockSignature<D::Digest>>
@@ -226,7 +227,7 @@ where
 ///
 /// # Example
 ///
-/// ```ignore
+/// ```
 /// use checksums::parallel::process_blocks_parallel;
 /// use checksums::RollingChecksum;
 ///
@@ -238,6 +239,8 @@ where
 ///     checksum.update(block);
 ///     (checksum.value(), block.len())
 /// });
+/// assert_eq!(results.len(), 3);
+/// assert_eq!(results[0].1, 6); // "block1" is 6 bytes
 /// ```
 pub fn process_blocks_parallel<T, R, F>(blocks: &[T], f: F) -> Vec<R>
 where
@@ -255,17 +258,20 @@ where
 ///
 /// # Example
 ///
-/// ```ignore
+/// ```
 /// use checksums::parallel::filter_blocks_by_checksum;
 ///
 /// let blocks: Vec<&[u8]> = vec![b"block1", b"block2", b"block3"];
-/// let target_mask = 0xFFFF0000u32;
-/// let target_value = 0x12340000u32;
 ///
-/// // Find blocks whose upper 16 bits match
-/// let matches = filter_blocks_by_checksum(&blocks, |checksum| {
-///     (checksum & target_mask) == target_value
+/// // Find blocks whose checksum is non-zero (all should match)
+/// let matches = filter_blocks_by_checksum(&blocks, |checksum| checksum != 0);
+/// assert_eq!(matches.len(), 3);
+///
+/// // Find blocks matching a specific mask - may return 0..3 results
+/// let narrow = filter_blocks_by_checksum(&blocks, |checksum| {
+///     (checksum & 0xFFFF0000) == 0
 /// });
+/// assert!(narrow.len() <= 3);
 /// ```
 pub fn filter_blocks_by_checksum<T, F>(blocks: &[T], predicate: F) -> Vec<usize>
 where

--- a/crates/checksums/src/parallel/files.rs
+++ b/crates/checksums/src/parallel/files.rs
@@ -96,24 +96,22 @@ where
 ///
 /// # Example
 ///
-/// ```ignore
+/// ```
 /// use checksums::parallel::hash_files_parallel;
 /// use checksums::strong::Sha256;
-/// use std::path::PathBuf;
 ///
-/// let files = vec![
-///     PathBuf::from("file1.txt"),
-///     PathBuf::from("file2.txt"),
-/// ];
+/// let dir = tempfile::tempdir().unwrap();
+/// let file1 = dir.path().join("file1.txt");
+/// let file2 = dir.path().join("file2.txt");
+/// std::fs::write(&file1, b"hello").unwrap();
+/// std::fs::write(&file2, b"world").unwrap();
 ///
+/// let files = vec![file1, file2];
 /// let results = hash_files_parallel::<Sha256>(&files, 64 * 1024);
 ///
-/// for result in results {
-///     match result.digest {
-///         Ok(digest) => println!("{}: {:x?}", result.path.display(), digest.as_ref()),
-///         Err(e) => eprintln!("{}: error - {}", result.path.display(), e),
-///     }
-/// }
+/// assert_eq!(results.len(), 2);
+/// assert!(results[0].digest.is_ok());
+/// assert!(results[1].digest.is_ok());
 /// ```
 pub fn hash_files_parallel<D>(
     paths: &[PathBuf],
@@ -135,17 +133,22 @@ where
 ///
 /// # Example
 ///
-/// ```ignore
+/// ```
 /// use checksums::parallel::{hash_files_parallel_with_config, FileHashConfig};
 /// use checksums::strong::Md5;
-/// use std::path::PathBuf;
+///
+/// let dir = tempfile::tempdir().unwrap();
+/// let path = dir.path().join("data.bin");
+/// std::fs::write(&path, b"test data").unwrap();
 ///
 /// let config = FileHashConfig::new()
 ///     .with_buffer_size(128 * 1024)
 ///     .with_max_memory_file_size(4 * 1024 * 1024);
 ///
-/// let files: Vec<PathBuf> = vec![/* ... */];
+/// let files = vec![path];
 /// let results = hash_files_parallel_with_config::<Md5>(&files, &config);
+/// assert_eq!(results.len(), 1);
+/// assert!(results[0].digest.is_ok());
 /// ```
 pub fn hash_files_parallel_with_config<D>(
     paths: &[PathBuf],
@@ -172,14 +175,19 @@ where
 ///
 /// # Example
 ///
-/// ```ignore
+/// ```
 /// use checksums::parallel::hash_files_with_seed_parallel;
 /// use checksums::strong::Xxh64;
-/// use std::path::PathBuf;
 ///
-/// let files: Vec<PathBuf> = vec![/* ... */];
+/// let dir = tempfile::tempdir().unwrap();
+/// let path = dir.path().join("data.bin");
+/// std::fs::write(&path, b"seeded hash input").unwrap();
+///
+/// let files = vec![path];
 /// let seed = 0x12345678u64;
 /// let results = hash_files_with_seed_parallel::<Xxh64>(&files, seed, 64 * 1024);
+/// assert_eq!(results.len(), 1);
+/// assert!(results[0].digest.is_ok());
 /// ```
 pub fn hash_files_with_seed_parallel<D>(
     paths: &[PathBuf],
@@ -275,19 +283,18 @@ where
 ///
 /// # Example
 ///
-/// ```ignore
+/// ```
 /// use checksums::parallel::compute_file_signatures_parallel;
 /// use checksums::strong::Md5;
-/// use std::path::PathBuf;
 ///
-/// let files: Vec<PathBuf> = vec![/* ... */];
+/// let dir = tempfile::tempdir().unwrap();
+/// let path = dir.path().join("test.bin");
+/// std::fs::write(&path, b"block signature test data").unwrap();
+///
+/// let files = vec![path];
 /// let results = compute_file_signatures_parallel::<Md5>(&files, 8192, 64 * 1024);
-///
-/// for result in results {
-///     if let Ok(sigs) = result.signatures {
-///         println!("{}: {} blocks", result.path.display(), sigs.len());
-///     }
-/// }
+/// assert_eq!(results.len(), 1);
+/// assert!(results[0].signatures.is_ok());
 /// ```
 pub fn compute_file_signatures_parallel<D>(
     paths: &[PathBuf],

--- a/crates/checksums/src/parallel/mod.rs
+++ b/crates/checksums/src/parallel/mod.rs
@@ -8,23 +8,22 @@
 //!
 //! The module provides functions for hashing multiple files concurrently:
 //!
-//! ```ignore
-//! use checksums::parallel::{hash_files_parallel, FileHashResult};
+//! ```
+//! use checksums::parallel::hash_files_parallel;
 //! use checksums::strong::Sha256;
-//! use std::path::PathBuf;
 //!
-//! let files = vec![
-//!     PathBuf::from("/path/to/file1"),
-//!     PathBuf::from("/path/to/file2"),
-//! ];
+//! let dir = tempfile::tempdir().unwrap();
+//! let file1 = dir.path().join("file1");
+//! let file2 = dir.path().join("file2");
+//! std::fs::write(&file1, b"data1").unwrap();
+//! std::fs::write(&file2, b"data2").unwrap();
 //!
+//! let files = vec![file1, file2];
 //! let results = hash_files_parallel::<Sha256>(&files, 64 * 1024);
 //!
-//! for result in results {
-//!     match result.digest {
-//!         Ok(digest) => println!("{}: {:?}", result.path.display(), digest.as_ref()),
-//!         Err(e) => eprintln!("{}: error - {}", result.path.display(), e),
-//!     }
+//! assert_eq!(results.len(), 2);
+//! for result in &results {
+//!     assert!(result.digest.is_ok());
 //! }
 //! ```
 

--- a/crates/checksums/src/pipelined/checksums.rs
+++ b/crates/checksums/src/pipelined/checksums.rs
@@ -42,7 +42,7 @@ pub struct BlockChecksums<D> {
 ///
 /// # Example
 ///
-/// ```ignore
+/// ```
 /// use checksums::pipelined::{compute_checksums_pipelined, PipelineConfig};
 /// use checksums::strong::Md5;
 /// use std::io::Cursor;

--- a/crates/filters/src/debug_filter.rs
+++ b/crates/filters/src/debug_filter.rs
@@ -7,8 +7,10 @@
 //!
 //! # Examples
 //!
-//! ```rust,ignore
-//! use filters::debug_filter::{FilterTracer, trace_filter_rule_added};
+//! ```
+//! use filters::debug_filter::{
+//!     FilterTracer, trace_filter_rule_added, trace_filter_evaluate,
+//! };
 //!
 //! let mut tracer = FilterTracer::new();
 //!
@@ -19,6 +21,8 @@
 //! tracer.record_evaluation(false);
 //!
 //! tracer.summary();
+//! assert_eq!(tracer.rules_added(), 1);
+//! assert_eq!(tracer.total_excluded(), 1);
 //! ```
 
 /// Target name for tracing events, matching rsync's debug category.
@@ -180,7 +184,7 @@ pub fn trace_filter_summary(
 ///
 /// # Examples
 ///
-/// ```no_run
+/// ```
 /// # use filters::debug_filter::FilterTracer;
 /// let mut tracer = FilterTracer::new();
 ///

--- a/crates/signature/src/parallel.rs
+++ b/crates/signature/src/parallel.rs
@@ -52,7 +52,7 @@ use crate::layout::SignatureLayout;
 ///
 /// # Example
 ///
-/// ```ignore
+/// ```
 /// use signature::{
 ///     SignatureLayoutParams, calculate_signature_layout,
 ///     SignatureAlgorithm,
@@ -76,6 +76,9 @@ use crate::layout::SignatureLayout;
 ///     layout,
 ///     SignatureAlgorithm::Md4,
 /// ).expect("signature");
+///
+/// assert!(signature.blocks().len() > 0);
+/// assert_eq!(signature.total_bytes(), 1_000_000);
 /// ```
 #[cfg_attr(feature = "tracing", instrument(skip(reader), fields(algorithm = ?algorithm, block_count = layout.block_count()), name = "generate_signature_parallel"))]
 pub fn generate_file_signature_parallel<R: Read>(
@@ -180,25 +183,30 @@ pub const PARALLEL_THRESHOLD_BYTES: u64 = 256 * 1024; // 256 KB
 ///
 /// # Example
 ///
-/// ```ignore
+/// ```
 /// use signature::{SignatureLayoutParams, calculate_signature_layout, SignatureAlgorithm};
 /// use signature::parallel::generate_file_signature_auto;
 /// use protocol::ProtocolVersion;
-/// use std::fs::File;
+/// use std::io::Cursor;
 /// use std::num::NonZeroU8;
 ///
-/// let file = File::open("large_file.bin")?;
-/// let metadata = file.metadata()?;
+/// let data = vec![0u8; 512 * 1024]; // 512 KB - above parallel threshold
 /// let params = SignatureLayoutParams::new(
-///     metadata.len(),
+///     data.len() as u64,
 ///     None,
 ///     ProtocolVersion::NEWEST,
 ///     NonZeroU8::new(16).unwrap(),
 /// );
-/// let layout = calculate_signature_layout(params)?;
+/// let layout = calculate_signature_layout(params).unwrap();
 ///
-/// // Automatically uses parallel mode for large files
-/// let signature = generate_file_signature_auto(file, layout, SignatureAlgorithm::Md4)?;
+/// // Automatically uses parallel mode for large inputs
+/// let signature = generate_file_signature_auto(
+///     Cursor::new(data),
+///     layout,
+///     SignatureAlgorithm::Md4,
+/// ).unwrap();
+///
+/// assert!(signature.blocks().len() > 0);
 /// ```
 pub fn generate_file_signature_auto<R: Read>(
     reader: R,


### PR DESCRIPTION
## Summary
- Convert 17 non-runnable doc examples (`ignore`/`no_run`) to fully runnable doctests
- Uses `tempfile` for filesystem operations and `Cursor` for I/O examples
- Fixes missing `mut` in bandwidth async_limiter doctest
- Crates: checksums (12), filters (2), signature (2), bandwidth (1)
- Results: 128 passing, 2 legitimately ignored (trait overview, async generator)

## Test plan
- [ ] All doctests pass: `cargo test --doc -p checksums -p filters -p bandwidth -p signature --all-features`
- [ ] No clippy warnings introduced
- [ ] Formatting clean