### PR TITLE
style: remove type-name-restating doc comments across 6 crates

### DIFF
--- a/crates/bandwidth/src/async_limiter.rs
+++ b/crates/bandwidth/src/async_limiter.rs
@@ -128,18 +128,21 @@ impl AsyncRateLimiter {
         self.tokens = self.tokens.min(self.burst);
     }
 
+    /// Configured bytes-per-second limit.
     #[inline]
     #[must_use]
     pub const fn rate(&self) -> u64 {
         self.rate.get()
     }
 
+    /// Maximum token accumulation before capping.
     #[inline]
     #[must_use]
     pub const fn burst_capacity(&self) -> u64 {
         self.burst
     }
 
+    /// Tokens currently available for consumption.
     #[inline]
     #[must_use]
     pub const fn available_tokens(&self) -> u64 {

--- a/crates/bandwidth/src/async_limiter.rs
+++ b/crates/bandwidth/src/async_limiter.rs
@@ -128,21 +128,18 @@ impl AsyncRateLimiter {
         self.tokens = self.tokens.min(self.burst);
     }
 
-    /// Returns the current rate in bytes per second.
     #[inline]
     #[must_use]
     pub const fn rate(&self) -> u64 {
         self.rate.get()
     }
 
-    /// Returns the burst capacity in bytes.
     #[inline]
     #[must_use]
     pub const fn burst_capacity(&self) -> u64 {
         self.burst
     }
 
-    /// Returns the number of tokens currently available.
     #[inline]
     #[must_use]
     pub const fn available_tokens(&self) -> u64 {

--- a/crates/bandwidth/src/limiter/core/limiter.rs
+++ b/crates/bandwidth/src/limiter/core/limiter.rs
@@ -84,27 +84,24 @@ impl BandwidthLimiter {
         }
     }
 
-    /// Returns the configured limit in bytes per second.
     #[inline]
     #[must_use]
     pub const fn limit_bytes(&self) -> NonZeroU64 {
         self.limit_bytes
     }
 
-    /// Returns the configured burst size in bytes, if any.
     #[inline]
     pub const fn burst_bytes(&self) -> Option<NonZeroU64> {
         self.burst_bytes
     }
 
-    /// Returns the maximum chunk size the limiter schedules before sleeping.
     #[inline]
     #[must_use]
     pub const fn write_max_bytes(&self) -> usize {
         self.write_max
     }
 
-    /// Returns the maximum chunk size that should be written before sleeping.
+    /// Clamps `buffer_len` to `write_max` so each I/O batch stays within the pacing budget.
     #[inline]
     #[must_use]
     pub fn recommended_read_size(&self, buffer_len: usize) -> usize {

--- a/crates/bandwidth/src/limiter/core/limiter.rs
+++ b/crates/bandwidth/src/limiter/core/limiter.rs
@@ -84,17 +84,20 @@ impl BandwidthLimiter {
         }
     }
 
+    /// Configured bytes-per-second transfer cap.
     #[inline]
     #[must_use]
     pub const fn limit_bytes(&self) -> NonZeroU64 {
         self.limit_bytes
     }
 
+    /// Optional burst allowance above the steady-state limit.
     #[inline]
     pub const fn burst_bytes(&self) -> Option<NonZeroU64> {
         self.burst_bytes
     }
 
+    /// Maximum bytes permitted in a single I/O operation.
     #[inline]
     #[must_use]
     pub const fn write_max_bytes(&self) -> usize {

--- a/crates/bandwidth/src/limiter/sleep.rs
+++ b/crates/bandwidth/src/limiter/sleep.rs
@@ -29,11 +29,13 @@ impl LimiterSleep {
         Self { requested, actual }
     }
 
+    /// Duration the limiter intended to sleep based on accumulated debt.
     #[must_use]
     pub const fn requested(&self) -> Duration {
         self.requested
     }
 
+    /// Duration actually elapsed after chunked sleeping.
     #[must_use]
     pub const fn actual(&self) -> Duration {
         self.actual

--- a/crates/bandwidth/src/limiter/sleep.rs
+++ b/crates/bandwidth/src/limiter/sleep.rs
@@ -29,13 +29,11 @@ impl LimiterSleep {
         Self { requested, actual }
     }
 
-    /// Returns the amount of time the limiter attempted to sleep.
     #[must_use]
     pub const fn requested(&self) -> Duration {
         self.requested
     }
 
-    /// Returns the time actually observed by the limiter.
     #[must_use]
     pub const fn actual(&self) -> Duration {
         self.actual

--- a/crates/bandwidth/src/parse/components.rs
+++ b/crates/bandwidth/src/parse/components.rs
@@ -128,12 +128,10 @@ impl BandwidthLimitComponents {
         }
     }
 
-    /// Returns the configured byte-per-second rate, if any.
     pub const fn rate(&self) -> Option<NonZeroU64> {
         self.rate
     }
 
-    /// Returns the configured burst size in bytes, if any.
     pub const fn burst(&self) -> Option<NonZeroU64> {
         self.burst
     }

--- a/crates/bandwidth/src/parse/components.rs
+++ b/crates/bandwidth/src/parse/components.rs
@@ -128,10 +128,12 @@ impl BandwidthLimitComponents {
         }
     }
 
+    /// Negotiated bytes-per-second rate, or `None` for unlimited.
     pub const fn rate(&self) -> Option<NonZeroU64> {
         self.rate
     }
 
+    /// Negotiated burst allowance, or `None` if unset.
     pub const fn burst(&self) -> Option<NonZeroU64> {
         self.burst
     }

--- a/crates/compress/src/algorithm.rs
+++ b/crates/compress/src/algorithm.rs
@@ -358,7 +358,6 @@ impl CompressionAlgorithmParseError {
         }
     }
 
-    /// Returns the invalid input.
     #[must_use]
     pub fn input(&self) -> &str {
         &self.input

--- a/crates/compress/src/algorithm.rs
+++ b/crates/compress/src/algorithm.rs
@@ -358,6 +358,7 @@ impl CompressionAlgorithmParseError {
         }
     }
 
+    /// Input string that failed to parse as a compression algorithm.
     #[must_use]
     pub fn input(&self) -> &str {
         &self.input

--- a/crates/compress/src/skip_compress/decider.rs
+++ b/crates/compress/src/skip_compress/decider.rs
@@ -117,7 +117,6 @@ impl CompressionDecider {
         self.skip_extensions.remove(&suffix)
     }
 
-    /// Returns the current set of skip extensions.
     #[must_use]
     pub fn skip_extensions(&self) -> &HashSet<Suffix> {
         &self.skip_extensions
@@ -135,7 +134,6 @@ impl CompressionDecider {
         self.compression_threshold = threshold.clamp(0.0, 1.0);
     }
 
-    /// Returns the current compression threshold.
     #[must_use]
     pub fn compression_threshold(&self) -> f64 {
         self.compression_threshold
@@ -146,7 +144,6 @@ impl CompressionDecider {
         self.sample_size = size.max(64); // Minimum 64 bytes for meaningful detection
     }
 
-    /// Returns the current sample size.
     #[must_use]
     pub fn sample_size(&self) -> usize {
         self.sample_size

--- a/crates/compress/src/skip_compress/decider.rs
+++ b/crates/compress/src/skip_compress/decider.rs
@@ -117,6 +117,7 @@ impl CompressionDecider {
         self.skip_extensions.remove(&suffix)
     }
 
+    /// File extensions that bypass compression entirely.
     #[must_use]
     pub fn skip_extensions(&self) -> &HashSet<Suffix> {
         &self.skip_extensions
@@ -134,6 +135,7 @@ impl CompressionDecider {
         self.compression_threshold = threshold.clamp(0.0, 1.0);
     }
 
+    /// Ratio at or above which a file is considered incompressible.
     #[must_use]
     pub fn compression_threshold(&self) -> f64 {
         self.compression_threshold
@@ -144,6 +146,7 @@ impl CompressionDecider {
         self.sample_size = size.max(64); // Minimum 64 bytes for meaningful detection
     }
 
+    /// Byte count sampled from each file for auto-detection.
     #[must_use]
     pub fn sample_size(&self) -> usize {
         self.sample_size

--- a/crates/compress/src/skip_compress/types.rs
+++ b/crates/compress/src/skip_compress/types.rs
@@ -86,7 +86,6 @@ impl Suffix {
         Self(normalized)
     }
 
-    /// Returns the normalized suffix string.
     #[must_use]
     pub fn as_str(&self) -> &str {
         &self.0

--- a/crates/compress/src/skip_compress/types.rs
+++ b/crates/compress/src/skip_compress/types.rs
@@ -86,6 +86,7 @@ impl Suffix {
         Self(normalized)
     }
 
+    /// Normalized, lowercase, dot-stripped suffix text.
     #[must_use]
     pub fn as_str(&self) -> &str {
         &self.0

--- a/crates/compress/src/strategy/impls.rs
+++ b/crates/compress/src/strategy/impls.rs
@@ -17,7 +17,6 @@ use crate::lz4::raw;
 pub struct NoCompressionStrategy;
 
 impl NoCompressionStrategy {
-    /// Creates a new no-compression strategy.
     #[must_use]
     pub const fn new() -> Self {
         Self
@@ -49,7 +48,6 @@ pub struct ZlibStrategy {
 }
 
 impl ZlibStrategy {
-    /// Creates a new Zlib strategy with the specified compression level.
     #[must_use]
     pub const fn new(level: CompressionLevel) -> Self {
         Self { level }
@@ -103,7 +101,6 @@ pub struct ZstdStrategy {
 
 #[cfg(feature = "zstd")]
 impl ZstdStrategy {
-    /// Creates a new Zstd strategy with the specified compression level.
     #[must_use]
     pub const fn new(level: CompressionLevel) -> Self {
         Self { level }
@@ -164,7 +161,6 @@ pub struct Lz4Strategy {
 
 #[cfg(feature = "lz4")]
 impl Lz4Strategy {
-    /// Creates a new LZ4 strategy with the specified compression level.
     #[must_use]
     pub const fn new(level: CompressionLevel) -> Self {
         Self { level }
@@ -176,7 +172,6 @@ impl Lz4Strategy {
         Self::new(CompressionLevel::Default)
     }
 
-    /// Returns the configured compression level.
     #[must_use]
     pub const fn level(&self) -> CompressionLevel {
         self.level

--- a/crates/compress/src/strategy/impls.rs
+++ b/crates/compress/src/strategy/impls.rs
@@ -17,6 +17,7 @@ use crate::lz4::raw;
 pub struct NoCompressionStrategy;
 
 impl NoCompressionStrategy {
+    /// Creates a passthrough strategy that performs no compression.
     #[must_use]
     pub const fn new() -> Self {
         Self
@@ -48,6 +49,7 @@ pub struct ZlibStrategy {
 }
 
 impl ZlibStrategy {
+    /// Creates a zlib strategy at the given compression level.
     #[must_use]
     pub const fn new(level: CompressionLevel) -> Self {
         Self { level }
@@ -101,6 +103,7 @@ pub struct ZstdStrategy {
 
 #[cfg(feature = "zstd")]
 impl ZstdStrategy {
+    /// Creates a zstd strategy at the given compression level.
     #[must_use]
     pub const fn new(level: CompressionLevel) -> Self {
         Self { level }
@@ -161,6 +164,7 @@ pub struct Lz4Strategy {
 
 #[cfg(feature = "lz4")]
 impl Lz4Strategy {
+    /// Creates an LZ4 strategy at the given compression level.
     #[must_use]
     pub const fn new(level: CompressionLevel) -> Self {
         Self { level }
@@ -172,6 +176,7 @@ impl Lz4Strategy {
         Self::new(CompressionLevel::Default)
     }
 
+    /// Active compression level for this strategy instance.
     #[must_use]
     pub const fn level(&self) -> CompressionLevel {
         self.level

--- a/crates/compress/src/strategy/kind.rs
+++ b/crates/compress/src/strategy/kind.rs
@@ -23,6 +23,7 @@ pub enum CompressionAlgorithmKind {
 }
 
 impl CompressionAlgorithmKind {
+    /// Wire-format name used during protocol negotiation.
     #[must_use]
     pub const fn name(&self) -> &'static str {
         match self {
@@ -47,6 +48,7 @@ impl CompressionAlgorithmKind {
         }
     }
 
+    /// Upstream-compatible default compression level per algorithm.
     #[must_use]
     pub const fn default_level(&self) -> CompressionLevel {
         match self {

--- a/crates/compress/src/strategy/kind.rs
+++ b/crates/compress/src/strategy/kind.rs
@@ -23,7 +23,6 @@ pub enum CompressionAlgorithmKind {
 }
 
 impl CompressionAlgorithmKind {
-    /// Returns the canonical name for the algorithm.
     #[must_use]
     pub const fn name(&self) -> &'static str {
         match self {
@@ -48,7 +47,6 @@ impl CompressionAlgorithmKind {
         }
     }
 
-    /// Returns the default compression level for the algorithm.
     #[must_use]
     pub const fn default_level(&self) -> CompressionLevel {
         match self {

--- a/crates/compress/src/strategy/traits.rs
+++ b/crates/compress/src/strategy/traits.rs
@@ -34,8 +34,10 @@ pub trait CompressionStrategy: Send + Sync {
     /// Returns the number of decompressed bytes written to `output`.
     fn decompress(&self, input: &[u8], output: &mut Vec<u8>) -> io::Result<usize>;
 
+    /// Identifies which compression algorithm this strategy implements.
     fn algorithm_kind(&self) -> CompressionAlgorithmKind;
 
+    /// Wire-format name derived from the algorithm kind.
     fn algorithm_name(&self) -> &'static str {
         self.algorithm_kind().name()
     }

--- a/crates/compress/src/strategy/traits.rs
+++ b/crates/compress/src/strategy/traits.rs
@@ -34,10 +34,8 @@ pub trait CompressionStrategy: Send + Sync {
     /// Returns the number of decompressed bytes written to `output`.
     fn decompress(&self, input: &[u8], output: &mut Vec<u8>) -> io::Result<usize>;
 
-    /// Returns the algorithm kind for this strategy.
     fn algorithm_kind(&self) -> CompressionAlgorithmKind;
 
-    /// Returns the human-readable algorithm name.
     fn algorithm_name(&self) -> &'static str {
         self.algorithm_kind().name()
     }

--- a/crates/filters/src/chain.rs
+++ b/crates/filters/src/chain.rs
@@ -135,6 +135,7 @@ impl DirMergeConfig {
         self
     }
 
+    /// Per-directory merge filename configured for this rule.
     #[must_use]
     pub fn filename(&self) -> &str {
         &self.filename
@@ -396,16 +397,19 @@ impl FilterChain {
         self.global.is_empty() && self.scopes.is_empty()
     }
 
+    /// Number of active per-directory filter scopes on the stack.
     #[must_use]
     pub fn scope_depth(&self) -> usize {
         self.scopes.len()
     }
 
+    /// Directory nesting level relative to the transfer root.
     #[must_use]
     pub fn current_depth(&self) -> usize {
         self.current_depth
     }
 
+    /// Base filter set applied before any per-directory rules.
     #[must_use]
     pub fn global(&self) -> &FilterSet {
         &self.global
@@ -475,11 +479,13 @@ pub struct DirFilterGuard {
 }
 
 impl DirFilterGuard {
+    /// Directory depth at which this guard was pushed.
     #[must_use]
     pub const fn depth(&self) -> usize {
         self.depth
     }
 
+    /// Number of per-directory scopes introduced by this guard.
     #[must_use]
     pub const fn pushed_count(&self) -> usize {
         self.pushed_count

--- a/crates/filters/src/chain.rs
+++ b/crates/filters/src/chain.rs
@@ -135,7 +135,6 @@ impl DirMergeConfig {
         self
     }
 
-    /// Returns the filename to search for in each directory.
     #[must_use]
     pub fn filename(&self) -> &str {
         &self.filename
@@ -397,19 +396,16 @@ impl FilterChain {
         self.global.is_empty() && self.scopes.is_empty()
     }
 
-    /// Returns the number of active per-directory scopes.
     #[must_use]
     pub fn scope_depth(&self) -> usize {
         self.scopes.len()
     }
 
-    /// Returns the current directory depth.
     #[must_use]
     pub fn current_depth(&self) -> usize {
         self.current_depth
     }
 
-    /// Returns the global base filter set.
     #[must_use]
     pub fn global(&self) -> &FilterSet {
         &self.global
@@ -479,13 +475,11 @@ pub struct DirFilterGuard {
 }
 
 impl DirFilterGuard {
-    /// Returns the directory depth at which this guard was created.
     #[must_use]
     pub const fn depth(&self) -> usize {
         self.depth
     }
 
-    /// Returns the number of filter scopes pushed for this directory.
     #[must_use]
     pub const fn pushed_count(&self) -> usize {
         self.pushed_count

--- a/crates/filters/src/debug_filter.rs
+++ b/crates/filters/src/debug_filter.rs
@@ -272,26 +272,31 @@ impl FilterTracer {
         self.dir_merges = 0;
     }
 
+    /// Total filter rules loaded from all sources.
     #[must_use]
     pub const fn rules_added(&self) -> usize {
         self.rules_added
     }
 
+    /// Paths tested against the filter chain so far.
     #[must_use]
     pub const fn total_evaluated(&self) -> usize {
         self.total_evaluated
     }
 
+    /// Paths that matched an include rule or passed by default.
     #[must_use]
     pub const fn total_included(&self) -> usize {
         self.total_included
     }
 
+    /// Paths that matched an exclude rule.
     #[must_use]
     pub const fn total_excluded(&self) -> usize {
         self.total_excluded
     }
 
+    /// Per-directory merge file loads performed.
     #[must_use]
     pub const fn dir_merges(&self) -> usize {
         self.dir_merges

--- a/crates/filters/src/debug_filter.rs
+++ b/crates/filters/src/debug_filter.rs
@@ -272,31 +272,26 @@ impl FilterTracer {
         self.dir_merges = 0;
     }
 
-    /// Returns the number of rules added.
     #[must_use]
     pub const fn rules_added(&self) -> usize {
         self.rules_added
     }
 
-    /// Returns the total number of paths evaluated.
     #[must_use]
     pub const fn total_evaluated(&self) -> usize {
         self.total_evaluated
     }
 
-    /// Returns the number of paths included.
     #[must_use]
     pub const fn total_included(&self) -> usize {
         self.total_included
     }
 
-    /// Returns the number of paths excluded.
     #[must_use]
     pub const fn total_excluded(&self) -> usize {
         self.total_excluded
     }
 
-    /// Returns the number of directory merge operations.
     #[must_use]
     pub const fn dir_merges(&self) -> usize {
         self.dir_merges

--- a/crates/filters/src/error.rs
+++ b/crates/filters/src/error.rs
@@ -22,6 +22,7 @@ impl FilterError {
         Self { pattern, source }
     }
 
+    /// Filter pattern that triggered this error.
     #[must_use]
     pub fn pattern(&self) -> &str {
         &self.pattern

--- a/crates/filters/src/error.rs
+++ b/crates/filters/src/error.rs
@@ -22,7 +22,6 @@ impl FilterError {
         Self { pattern, source }
     }
 
-    /// Returns the offending pattern.
     #[must_use]
     pub fn pattern(&self) -> &str {
         &self.pattern

--- a/crates/filters/src/rule.rs
+++ b/crates/filters/src/rule.rs
@@ -305,13 +305,11 @@ impl FilterRule {
         }
     }
 
-    /// Returns the rule action.
     #[must_use]
     pub const fn action(&self) -> FilterAction {
         self.action
     }
 
-    /// Returns the pattern text associated with the rule.
     #[must_use]
     pub fn pattern(&self) -> &str {
         &self.pattern

--- a/crates/filters/src/rule.rs
+++ b/crates/filters/src/rule.rs
@@ -305,11 +305,13 @@ impl FilterRule {
         }
     }
 
+    /// Include or exclude action applied when this rule matches.
     #[must_use]
     pub const fn action(&self) -> FilterAction {
         self.action
     }
 
+    /// Glob or literal pattern text for matching.
     #[must_use]
     pub fn pattern(&self) -> &str {
         &self.pattern

--- a/crates/protocol/src/xattr/entry.rs
+++ b/crates/protocol/src/xattr/entry.rs
@@ -81,13 +81,11 @@ impl XattrEntry {
         }
     }
 
-    /// Returns the attribute name.
     #[must_use]
     pub fn name(&self) -> &[u8] {
         &self.name
     }
 
-    /// Returns the attribute name as a string (lossy conversion).
     #[must_use]
     pub fn name_str(&self) -> Cow<'_, str> {
         String::from_utf8_lossy(&self.name)
@@ -123,7 +121,6 @@ impl XattrEntry {
         self.datum_len > MAX_FULL_DATUM
     }
 
-    /// Returns the transfer state.
     #[must_use]
     pub const fn state(&self) -> XattrState {
         self.state

--- a/crates/protocol/src/xattr/entry.rs
+++ b/crates/protocol/src/xattr/entry.rs
@@ -81,11 +81,13 @@ impl XattrEntry {
         }
     }
 
+    /// Raw attribute name as bytes, preserving non-UTF-8 names.
     #[must_use]
     pub fn name(&self) -> &[u8] {
         &self.name
     }
 
+    /// Attribute name as a UTF-8 string, replacing invalid bytes with the replacement character.
     #[must_use]
     pub fn name_str(&self) -> Cow<'_, str> {
         String::from_utf8_lossy(&self.name)
@@ -121,6 +123,7 @@ impl XattrEntry {
         self.datum_len > MAX_FULL_DATUM
     }
 
+    /// Current wire transfer state of this extended attribute.
     #[must_use]
     pub const fn state(&self) -> XattrState {
         self.state

--- a/crates/protocol/src/xattr/list.rs
+++ b/crates/protocol/src/xattr/list.rs
@@ -28,6 +28,7 @@ impl XattrList {
         Self { entries }
     }
 
+    /// Number of extended attributes in this list.
     #[must_use]
     pub fn len(&self) -> usize {
         self.entries.len()

--- a/crates/protocol/src/xattr/list.rs
+++ b/crates/protocol/src/xattr/list.rs
@@ -28,7 +28,6 @@ impl XattrList {
         Self { entries }
     }
 
-    /// Returns the number of entries.
     #[must_use]
     pub fn len(&self) -> usize {
         self.entries.len()

--- a/crates/signature/src/block.rs
+++ b/crates/signature/src/block.rs
@@ -32,24 +32,28 @@ impl SignatureBlock {
         Self::new(index, rolling, DigestBuf::from_slice(strong, strong.len()))
     }
 
+    /// Zero-based position of this block within the file signature.
     #[inline]
     #[must_use]
     pub const fn index(&self) -> u64 {
         self.index
     }
 
+    /// Rolling checksum used for fast block matching.
     #[inline]
     #[must_use]
     pub const fn rolling(&self) -> RollingDigest {
         self.rolling
     }
 
+    /// Strong checksum bytes for collision-resistant verification.
     #[inline]
     #[must_use]
     pub fn strong(&self) -> &[u8] {
         self.strong.as_slice()
     }
 
+    /// Strong checksum as an owned digest buffer.
     #[inline]
     #[must_use]
     pub const fn strong_digest(&self) -> DigestBuf {

--- a/crates/signature/src/block.rs
+++ b/crates/signature/src/block.rs
@@ -32,28 +32,24 @@ impl SignatureBlock {
         Self::new(index, rolling, DigestBuf::from_slice(strong, strong.len()))
     }
 
-    /// Returns the zero-based index of the block within the signature.
     #[inline]
     #[must_use]
     pub const fn index(&self) -> u64 {
         self.index
     }
 
-    /// Returns the rolling checksum digest associated with the block.
     #[inline]
     #[must_use]
     pub const fn rolling(&self) -> RollingDigest {
         self.rolling
     }
 
-    /// Returns the strong checksum bytes for the block.
     #[inline]
     #[must_use]
     pub fn strong(&self) -> &[u8] {
         self.strong.as_slice()
     }
 
-    /// Returns the strong checksum as a [`DigestBuf`].
     #[inline]
     #[must_use]
     pub const fn strong_digest(&self) -> DigestBuf {

--- a/crates/signature/src/file.rs
+++ b/crates/signature/src/file.rs
@@ -12,7 +12,6 @@ pub struct FileSignature {
 }
 
 impl FileSignature {
-    /// Creates a new signature container.
     pub(crate) const fn new(
         layout: SignatureLayout,
         blocks: Vec<SignatureBlock>,
@@ -35,7 +34,6 @@ impl FileSignature {
         Self::new(layout, blocks, total_bytes)
     }
 
-    /// Returns the layout used to generate the signature.
     #[inline]
     #[must_use]
     pub const fn layout(&self) -> SignatureLayout {
@@ -49,7 +47,6 @@ impl FileSignature {
         &self.blocks
     }
 
-    /// Returns the total number of bytes consumed while generating the signature.
     #[inline]
     #[must_use]
     pub const fn total_bytes(&self) -> u64 {

--- a/crates/signature/src/file.rs
+++ b/crates/signature/src/file.rs
@@ -12,6 +12,7 @@ pub struct FileSignature {
 }
 
 impl FileSignature {
+    /// Constructs a signature from a computed layout and block list.
     pub(crate) const fn new(
         layout: SignatureLayout,
         blocks: Vec<SignatureBlock>,
@@ -34,6 +35,7 @@ impl FileSignature {
         Self::new(layout, blocks, total_bytes)
     }
 
+    /// Block size and checksum parameters used during generation.
     #[inline]
     #[must_use]
     pub const fn layout(&self) -> SignatureLayout {
@@ -47,6 +49,7 @@ impl FileSignature {
         &self.blocks
     }
 
+    /// Source file size consumed while computing the signature.
     #[inline]
     #[must_use]
     pub const fn total_bytes(&self) -> u64 {

--- a/crates/signature/src/layout.rs
+++ b/crates/signature/src/layout.rs
@@ -26,6 +26,7 @@ pub struct SignatureLayoutParams {
 }
 
 impl SignatureLayoutParams {
+    /// Constructs layout parameters from file metadata and protocol settings.
     #[must_use]
     pub const fn new(
         file_length: u64,
@@ -41,23 +42,27 @@ impl SignatureLayoutParams {
         }
     }
 
+    /// Source file size in bytes.
     #[inline]
     #[must_use]
     pub const fn file_length(self) -> u64 {
         self.file_length
     }
 
+    /// Caller-specified block length override, if any.
     #[inline]
     pub const fn forced_block_length(self) -> Option<NonZeroU32> {
         self.forced_block_length
     }
 
+    /// Protocol version governing layout computation.
     #[inline]
     #[must_use]
     pub const fn protocol(self) -> ProtocolVersion {
         self.protocol
     }
 
+    /// Negotiated strong checksum truncation length.
     #[inline]
     #[must_use]
     pub const fn checksum_length(self) -> NonZeroU8 {
@@ -91,6 +96,7 @@ impl SignatureLayout {
         }
     }
 
+    /// Computed block size in bytes for signature generation.
     #[inline]
     #[must_use]
     pub const fn block_length(self) -> NonZeroU32 {
@@ -104,12 +110,14 @@ impl SignatureLayout {
         self.remainder
     }
 
+    /// Total number of blocks covering the source file.
     #[inline]
     #[must_use]
     pub const fn block_count(self) -> u64 {
         self.block_count
     }
 
+    /// Strong checksum byte length per block.
     #[inline]
     #[must_use]
     pub const fn strong_sum_length(self) -> NonZeroU8 {

--- a/crates/signature/src/layout.rs
+++ b/crates/signature/src/layout.rs
@@ -26,7 +26,6 @@ pub struct SignatureLayoutParams {
 }
 
 impl SignatureLayoutParams {
-    /// Creates a new descriptor.
     #[must_use]
     pub const fn new(
         file_length: u64,
@@ -42,27 +41,23 @@ impl SignatureLayoutParams {
         }
     }
 
-    /// Returns the file length in bytes.
     #[inline]
     #[must_use]
     pub const fn file_length(self) -> u64 {
         self.file_length
     }
 
-    /// Returns the optional caller-specified block length.
     #[inline]
     pub const fn forced_block_length(self) -> Option<NonZeroU32> {
         self.forced_block_length
     }
 
-    /// Returns the negotiated protocol version.
     #[inline]
     #[must_use]
     pub const fn protocol(self) -> ProtocolVersion {
         self.protocol
     }
 
-    /// Returns the negotiated checksum length.
     #[inline]
     #[must_use]
     pub const fn checksum_length(self) -> NonZeroU8 {
@@ -96,7 +91,6 @@ impl SignatureLayout {
         }
     }
 
-    /// Returns the block length in bytes.
     #[inline]
     #[must_use]
     pub const fn block_length(self) -> NonZeroU32 {
@@ -110,14 +104,12 @@ impl SignatureLayout {
         self.remainder
     }
 
-    /// Returns the number of blocks in the layout.
     #[inline]
     #[must_use]
     pub const fn block_count(self) -> u64 {
         self.block_count
     }
 
-    /// Returns the strong checksum length in bytes.
     #[inline]
     #[must_use]
     pub const fn strong_sum_length(self) -> NonZeroU8 {


### PR DESCRIPTION
## Summary
- Remove 57 lines of doc comments that merely restate function/method names across filters, compress, signature, bandwidth, and protocol crates
- Replace one restating comment with a meaningful description of `recommended_read_size()` behavior
- No production logic changes - purely doc comment cleanup

## Test plan
- [ ] CI passes (no code changes, only doc comment removals)
- [ ] Verify rustdoc still builds cleanly