### PR TITLE
docs: add missing #[must_use] to checksums public API

### DIFF
--- a/crates/checksums/src/strong/mod.rs
+++ b/crates/checksums/src/strong/mod.rs
@@ -145,20 +145,24 @@ pub trait StrongDigest: Sized {
     }
 
     /// Creates a new hasher using the provided seed value.
+    #[must_use]
     fn with_seed(seed: Self::Seed) -> Self;
 
     /// Feeds additional bytes into the digest state.
     fn update(&mut self, data: &[u8]);
 
     /// Finalises the digest and returns the resulting hash.
+    #[must_use]
     fn finalize(self) -> Self::Digest;
 
     /// Convenience helper that hashes `data` in a single call.
+    #[must_use]
     fn digest(data: &[u8]) -> Self::Digest {
         Self::digest_with_seed(Default::default(), data)
     }
 
     /// Convenience helper that hashes `data` using an explicit seed value.
+    #[must_use]
     fn digest_with_seed(seed: Self::Seed, data: &[u8]) -> Self::Digest {
         let mut hasher = Self::with_seed(seed);
         hasher.update(data);

--- a/crates/checksums/src/strong/strategy/kind.rs
+++ b/crates/checksums/src/strong/strategy/kind.rs
@@ -80,6 +80,7 @@ impl ChecksumAlgorithmKind {
     ///
     /// Accepts canonical names and common aliases (case-insensitive).
     /// See upstream `compat.c` for the negotiation protocol.
+    #[must_use]
     pub fn from_name(name: &str) -> Option<Self> {
         match name.to_ascii_lowercase().as_str() {
             "md4" => Some(Self::Md4),

--- a/crates/compress/tests/zlib_ng_backend.rs
+++ b/crates/compress/tests/zlib_ng_backend.rs
@@ -92,7 +92,10 @@ fn zlib_ng_handles_incompressible_data() {
         compress_to_vec(&payload, CompressionLevel::Best).expect("compress incompressible");
 
     let decompressed = decompress_to_vec(&compressed).expect("decompress incompressible");
-    assert_eq!(decompressed, payload, "incompressible data roundtrip failed");
+    assert_eq!(
+        decompressed, payload,
+        "incompressible data roundtrip failed"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Add `#[must_use]` to `StrongDigest` trait methods (`with_seed`, `finalize`, `digest`, `digest_with_seed`) that return values but were missing the annotation
- Add `#[must_use]` to `ChecksumAlgorithmKind::from_name()` which returns `Option<Self>`

The checksums crate already has `#![deny(missing_docs)]` and comprehensive rustdoc on all public items. This change addresses the remaining gap: public functions returning values without `#[must_use]` warnings.

## Test plan

- [x] `cargo check -p checksums --all-features` passes
- [x] `cargo clippy -p checksums --all-features --no-deps -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [ ] CI validates cross-platform (Windows, macOS, Linux musl)