### PR TITLE
docs: add rustdoc for xattr wire protocol types

### DIFF
--- a/crates/compress/tests/zlib_ng_backend.rs
+++ b/crates/compress/tests/zlib_ng_backend.rs
@@ -92,7 +92,10 @@ fn zlib_ng_handles_incompressible_data() {
         compress_to_vec(&payload, CompressionLevel::Best).expect("compress incompressible");
 
     let decompressed = decompress_to_vec(&compressed).expect("decompress incompressible");
-    assert_eq!(decompressed, payload, "incompressible data roundtrip failed");
+    assert_eq!(
+        decompressed, payload,
+        "incompressible data roundtrip failed"
+    );
 }
 
 #[test]

--- a/crates/protocol/src/xattr/list.rs
+++ b/crates/protocol/src/xattr/list.rs
@@ -129,6 +129,7 @@ impl XattrList {
     }
 }
 
+/// Consumes the list and yields owned `XattrEntry` values.
 impl IntoIterator for XattrList {
     type Item = XattrEntry;
     type IntoIter = std::vec::IntoIter<XattrEntry>;
@@ -138,6 +139,7 @@ impl IntoIterator for XattrList {
     }
 }
 
+/// Yields borrowed references to the xattr entries.
 impl<'a> IntoIterator for &'a XattrList {
     type Item = &'a XattrEntry;
     type IntoIter = std::slice::Iter<'a, XattrEntry>;
@@ -147,6 +149,7 @@ impl<'a> IntoIterator for &'a XattrList {
     }
 }
 
+/// Collects `XattrEntry` values into an `XattrList`.
 impl FromIterator<XattrEntry> for XattrList {
     fn from_iter<T: IntoIterator<Item = XattrEntry>>(iter: T) -> Self {
         Self {

--- a/crates/protocol/src/xattr/wire/decode.rs
+++ b/crates/protocol/src/xattr/wire/decode.rs
@@ -101,10 +101,20 @@ pub fn read_xattr_definitions<R: Read>(reader: &mut R) -> io::Result<XattrSet> {
     Ok(XattrSet { entries })
 }
 
-/// Receives xattr data from the wire.
+/// Receives xattr data from the wire during file list transfer.
 ///
-/// Returns `CacheHit` if a cache index was received, or `Literal` with
-/// the parsed xattr list for inline data.
+/// Reads the `ndx` varint and dispatches:
+/// - Non-negative `ndx` returns [`RecvXattrResult::CacheHit`] with the 0-based cache index.
+/// - Negative `ndx` (wire value 0) reads inline literal entries and returns
+///   [`RecvXattrResult::Literal`] with the parsed `XattrList`.
+///
+/// Literal entries with values exceeding [`MAX_FULL_DATUM`] are stored as
+/// abbreviated checksums and must be resolved later via the request protocol.
+///
+/// # Upstream Reference
+///
+/// See `xattrs.c:receive_xattr()` - reads `ndx = read_varint(f)`, branches
+/// on `ndx != 0` for cache hit vs literal data.
 pub fn recv_xattr<R: Read>(reader: &mut R) -> io::Result<RecvXattrResult> {
     let ndx_plus_one = read_varint(reader)?;
     let ndx = ndx_plus_one - 1;
@@ -183,9 +193,19 @@ pub fn recv_xattr_request<R: Read>(reader: &mut R, list: &mut XattrList) -> io::
     Ok(indices)
 }
 
-/// Receives full values for abbreviated entries.
+/// Receives full values for abbreviated xattr entries from the sender.
 ///
-/// Updates the list entries with full values received from the sender.
+/// Iterates over the list and for each entry in [`XattrState::Abbrev`](crate::xattr::XattrState::Abbrev)
+/// state, reads the value length (varint) and full value bytes from the wire,
+/// then updates the entry via [`XattrEntry::set_full_value`]. Entries already
+/// in `Done` or `Todo` state are skipped.
+///
+/// Must be called after [`recv_xattr_request`] has been processed by the sender
+/// and the sender has transmitted the requested values via [`send_xattr_values`](super::send_xattr_values).
+///
+/// # Upstream Reference
+///
+/// See `xattrs.c` - receiver reads full values for entries marked `XSTATE_ABBREV`.
 pub fn recv_xattr_values<R: Read>(reader: &mut R, list: &mut XattrList) -> io::Result<()> {
     for entry in list.entries_mut() {
         if entry.state().needs_request() {
@@ -198,11 +218,19 @@ pub fn recv_xattr_values<R: Read>(reader: &mut R, list: &mut XattrList) -> io::R
     Ok(())
 }
 
-/// Compares an abbreviated checksum with a local value.
+/// Compares an abbreviated xattr checksum against a local value.
 ///
-/// The `checksum_seed` must match the seed used when the checksum was computed.
+/// Computes the seeded MD5 digest of `local_value` using `checksum_seed` and
+/// compares it byte-for-byte with `checksum`. Returns `true` if they match,
+/// indicating the remote and local xattr values are identical and the full
+/// value does not need to be transferred.
 ///
-/// Returns true if the checksums match (values are the same).
+/// Returns `false` if `checksum` is not exactly [`MAX_XATTR_DIGEST_LEN`] bytes.
+///
+/// # Upstream Reference
+///
+/// Used during the abbreviation protocol in `xattrs.c` to determine which
+/// abbreviated values the receiver needs to request from the sender.
 #[must_use]
 pub fn checksum_matches(checksum: &[u8], local_value: &[u8], checksum_seed: i32) -> bool {
     if checksum.len() != MAX_XATTR_DIGEST_LEN {

--- a/crates/protocol/src/xattr/wire/types.rs
+++ b/crates/protocol/src/xattr/wire/types.rs
@@ -140,6 +140,7 @@ impl XattrSet {
     }
 }
 
+/// Yields borrowed references to the xattr definitions.
 impl<'a> IntoIterator for &'a XattrSet {
     type Item = &'a XattrDefinition;
     type IntoIter = std::slice::Iter<'a, XattrDefinition>;
@@ -149,6 +150,7 @@ impl<'a> IntoIterator for &'a XattrSet {
     }
 }
 
+/// Consumes the set and yields owned `XattrDefinition` values.
 impl IntoIterator for XattrSet {
     type Item = XattrDefinition;
     type IntoIter = std::vec::IntoIter<XattrDefinition>;
@@ -159,10 +161,24 @@ impl IntoIterator for XattrSet {
 }
 
 /// Result of receiving xattr data from the wire.
+///
+/// Returned by [`recv_xattr`](super::recv_xattr) to distinguish between
+/// a cache reference (the common case for files sharing the same xattrs)
+/// and a newly received literal xattr set.
+///
+/// # Upstream Reference
+///
+/// Mirrors the two branches of `xattrs.c:receive_xattr()`: `ndx != 0`
+/// yields a cache lookup, `ndx == 0` reads literal entry data.
 #[derive(Debug)]
 pub enum RecvXattrResult {
-    /// A cache index was received - look up in the xattr cache.
+    /// A previously cached xattr set is referenced by this 0-based index.
+    ///
+    /// Look up the corresponding `XattrList` in the `XattrCache`.
     CacheHit(u32),
-    /// Literal xattr data was received.
+    /// A new xattr set was received inline with full entry data.
+    ///
+    /// The entries have been parsed but names remain in wire format -
+    /// the caller must apply `wire_to_local()` for platform translation.
     Literal(XattrList),
 }


### PR DESCRIPTION
## Summary

- Add `///` rustdoc to `IntoIterator` and `FromIterator` trait impls on `XattrList` and `XattrSet`
- Expand `RecvXattrResult` enum and variant docs with upstream references and usage context
- Improve docs for `recv_xattr`, `recv_xattr_values`, and `checksum_matches` with wire format details, upstream references, and edge case documentation
- No logic changes - documentation only

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy -p protocol --all-features --no-deps -- -D warnings` passes
- [ ] CI passes