### PR TITLE
docs: add rustdoc for bandwidth limiter types

### DIFF
--- a/crates/bandwidth/src/limiter/change.rs
+++ b/crates/bandwidth/src/limiter/change.rs
@@ -10,6 +10,11 @@ use std::cmp::Ordering;
 use std::num::NonZeroU64;
 
 /// Result returned by limiter updates describing how throttling changed.
+///
+/// Variants are ordered by precedence so that [`combine`](Self::combine) and
+/// [`combine_all`](Self::combine_all) return the most significant transition
+/// when multiple updates are applied in sequence. The ordering is:
+/// `Unchanged` < `Updated` < `Enabled` < `Disabled`.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[must_use]
 pub enum LimiterChange {
@@ -93,8 +98,16 @@ impl FromIterator<LimiterChange> for LimiterChange {
     }
 }
 
-/// Applies a module-specific bandwidth cap to an optional limiter, mirroring upstream precedence rules.
+/// Applies a module-specific bandwidth cap to an optional limiter, mirroring
+/// upstream rsync's precedence rules.
 ///
+/// When a daemon module defines its own `bwlimit`, the strictest (lowest)
+/// byte-per-second rate wins. If `limit` is `None` and `limit_specified` is
+/// `true`, throttling is disabled entirely. The `burst` and `burst_specified`
+/// flags are handled independently so daemon modules can override burst
+/// without touching the rate.
+///
+/// Returns a [`LimiterChange`] describing the transition that occurred.
 // upstream: options.c:2374 - daemon_bwlimit override: strictest rate wins
 pub fn apply_effective_limit(
     limiter: &mut Option<BandwidthLimiter>,

--- a/crates/bandwidth/src/limiter/core/limiter.rs
+++ b/crates/bandwidth/src/limiter/core/limiter.rs
@@ -15,7 +15,18 @@ use super::super::{
 };
 use super::write_max::calculate_write_max;
 
-/// Token-bucket style limiter that mirrors upstream rsync's pacing rules.
+/// Token-bucket style bandwidth limiter that mirrors upstream rsync's pacing rules.
+///
+/// Each call to [`register`](Self::register) accumulates byte debt. The limiter
+/// subtracts a time-based allowance (proportional to the configured rate) for
+/// the wall-clock time elapsed since the previous call. When outstanding debt
+/// exceeds a minimum threshold, the limiter sleeps to keep the transfer at or
+/// below the target byte-per-second rate. An optional burst cap prevents
+/// excessive debt accumulation after idle periods.
+///
+/// The chunk size returned by [`write_max_bytes`](Self::write_max_bytes) scales
+/// linearly with the rate so that pacing sleeps remain short and responsive,
+/// matching the `bwlimit_writemax = bwlimit * 128` formula in upstream rsync.
 ///
 // upstream: io.c:sleep_for_bwlimit()
 #[doc(alias = "--bwlimit")]
@@ -31,12 +42,22 @@ pub struct BandwidthLimiter {
 
 impl BandwidthLimiter {
     /// Constructs a new limiter from the supplied byte-per-second rate.
+    ///
+    /// The burst cap is left unconstrained so debt can grow freely between
+    /// calls. Use [`with_burst`](Self::with_burst) to cap debt accumulation.
+    // upstream: io.c:sleep_for_bwlimit() - initial setup
     #[must_use]
     pub fn new(limit: NonZeroU64) -> Self {
         Self::with_burst(limit, None)
     }
 
     /// Constructs a new limiter from the supplied rate and optional burst size.
+    ///
+    /// When `burst` is `Some`, outstanding debt is clamped to that many bytes
+    /// after every [`register`](Self::register) call, preventing long stalls
+    /// that would otherwise occur after idle periods. When `burst` is `None`,
+    /// debt grows without bound.
+    // upstream: io.c:sleep_for_bwlimit() - burst cap logic
     #[must_use]
     pub fn with_burst(limit: NonZeroU64, burst: Option<NonZeroU64>) -> Self {
         let write_max = calculate_write_max(limit, burst);
@@ -52,11 +73,20 @@ impl BandwidthLimiter {
     }
 
     /// Updates the limiter so a new byte-per-second limit takes effect.
+    ///
+    /// The burst cap is preserved from the current configuration. Accumulated
+    /// debt and timing state are reset so the new rate applies immediately
+    /// without carryover from the previous period.
     pub fn update_limit(&mut self, limit: NonZeroU64) {
         self.update_configuration(limit, self.burst_bytes);
     }
 
     /// Updates the limiter so both the rate and burst configuration take effect.
+    ///
+    /// Recalculates the write-max chunk size for the new rate and resets all
+    /// internal accounting (debt, timing, simulated elapsed time). This is
+    /// used when a daemon module overrides the client-supplied `--bwlimit`.
+    // upstream: options.c:2374 - daemon_bwlimit override reconfiguration
     #[doc(alias = "--bwlimit")]
     pub fn update_configuration(&mut self, limit: NonZeroU64, burst: Option<NonZeroU64>) {
         let write_max = calculate_write_max(limit, burst);
@@ -70,6 +100,10 @@ impl BandwidthLimiter {
     }
 
     /// Resets the limiter while keeping the current configuration.
+    ///
+    /// Clears accumulated debt and timing state so the next
+    /// [`register`](Self::register) call starts a fresh accounting period.
+    /// The rate and burst settings are preserved.
     pub const fn reset(&mut self) {
         self.total_written = 0;
         self.last_instant = None;
@@ -92,19 +126,33 @@ impl BandwidthLimiter {
     }
 
     /// Optional burst allowance above the steady-state limit.
+    ///
+    /// When set, the limiter clamps outstanding debt to this value after
+    /// each [`register`](Self::register) call. Returns `None` when debt is
+    /// unconstrained.
     #[inline]
+    #[must_use]
     pub const fn burst_bytes(&self) -> Option<NonZeroU64> {
         self.burst_bytes
     }
 
     /// Maximum bytes permitted in a single I/O operation.
+    ///
+    /// The value scales linearly with the configured rate so that pacing
+    /// sleeps remain short and responsive. Callers should split writes
+    /// larger than this threshold into chunks.
+    // upstream: options.c:2377 - bwlimit_writemax = bwlimit * 128
     #[inline]
     #[must_use]
     pub const fn write_max_bytes(&self) -> usize {
         self.write_max
     }
 
-    /// Clamps `buffer_len` to `write_max` so each I/O batch stays within the pacing budget.
+    /// Clamps `buffer_len` to [`write_max_bytes`](Self::write_max_bytes) so each
+    /// I/O batch stays within the pacing budget.
+    ///
+    /// Returns the smaller of `buffer_len` and the configured write-max,
+    /// guaranteeing at least one byte to prevent zero-length reads.
     #[inline]
     #[must_use]
     pub fn recommended_read_size(&self, buffer_len: usize) -> usize {
@@ -112,7 +160,17 @@ impl BandwidthLimiter {
         buffer_len.min(limit)
     }
 
-    /// Records a completed write and sleeps if the limiter accumulated debt.
+    /// Records a completed write and sleeps if the accumulated debt exceeds
+    /// the minimum threshold.
+    ///
+    /// The method adds `bytes` to the outstanding debt, subtracts the
+    /// time-based allowance for the wall-clock time since the previous call,
+    /// clamps debt to the burst cap when configured, and sleeps if the
+    /// resulting debt represents at least 100 ms of transfer time. Returns a
+    /// [`LimiterSleep`](super::super::LimiterSleep) describing the requested
+    /// and actual sleep durations.
+    ///
+    /// A zero-byte call is a no-op and returns immediately.
     // upstream: io.c:sleep_for_bwlimit() - debt accumulation and sleep logic
     pub fn register(&mut self, bytes: usize) -> super::super::LimiterSleep {
         if bytes == 0 {

--- a/crates/bandwidth/src/parse.rs
+++ b/crates/bandwidth/src/parse.rs
@@ -253,6 +253,13 @@ pub fn parse_bandwidth_argument(text: &str) -> Result<Option<NonZeroU64>, Bandwi
 }
 
 /// Parses a bandwidth limit containing an optional burst component.
+///
+/// Accepts the `RATE[:BURST]` syntax used in daemon module configuration.
+/// Both the rate and burst segments follow the same suffix and multiplier
+/// rules as [`parse_bandwidth_argument`]. A rate of `0` produces an
+/// unlimited configuration. Surrounding whitespace is rejected to match
+/// upstream rsync's strict parsing.
+// upstream: options.c:server_options() - bwlimit with optional burst
 #[doc(alias = "--bwlimit")]
 pub fn parse_bandwidth_limit(text: &str) -> Result<BandwidthLimitComponents, BandwidthParseError> {
     let trimmed = text.trim_matches(|ch: char| ch.is_ascii_whitespace());

--- a/crates/bandwidth/src/parse/components.rs
+++ b/crates/bandwidth/src/parse/components.rs
@@ -129,11 +129,13 @@ impl BandwidthLimitComponents {
     }
 
     /// Negotiated bytes-per-second rate, or `None` for unlimited.
+    #[must_use]
     pub const fn rate(&self) -> Option<NonZeroU64> {
         self.rate
     }
 
     /// Negotiated burst allowance, or `None` if unset.
+    #[must_use]
     pub const fn burst(&self) -> Option<NonZeroU64> {
         self.burst
     }
@@ -244,6 +246,10 @@ impl BandwidthLimitComponents {
 impl FromStr for BandwidthLimitComponents {
     type Err = BandwidthParseError;
 
+    /// Parses a `--bwlimit` style string into bandwidth limit components.
+    ///
+    /// Delegates to [`parse_bandwidth_limit`] to handle rate, burst, and
+    /// suffix parsing.
     fn from_str(text: &str) -> Result<Self, Self::Err> {
         parse_bandwidth_limit(text)
     }

--- a/crates/compress/tests/zlib_ng_backend.rs
+++ b/crates/compress/tests/zlib_ng_backend.rs
@@ -92,7 +92,10 @@ fn zlib_ng_handles_incompressible_data() {
         compress_to_vec(&payload, CompressionLevel::Best).expect("compress incompressible");
 
     let decompressed = decompress_to_vec(&compressed).expect("decompress incompressible");
-    assert_eq!(decompressed, payload, "incompressible data roundtrip failed");
+    assert_eq!(
+        decompressed, payload,
+        "incompressible data roundtrip failed"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Expand `///` rustdoc on all public types, methods, and functions in `crates/bandwidth/` that had minimal single-line docs
- Add upstream rsync source references where applicable (e.g., `io.c:sleep_for_bwlimit()`, `options.c:2374`)
- Add missing `#[must_use]` on `burst_bytes()`, `rate()`, and `burst()` accessors
- Add `FromStr` impl doc for `BandwidthLimitComponents`
- No logic changes - documentation only

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy -p bandwidth --all-features --no-deps -- -D warnings` passes
- [x] Existing `#![deny(missing_docs)]` continues to enforce coverage