### PR TITLE
test: add metadata platform stub coverage

### DIFF
--- a/crates/compress/tests/zlib_ng_backend.rs
+++ b/crates/compress/tests/zlib_ng_backend.rs
@@ -92,7 +92,10 @@ fn zlib_ng_handles_incompressible_data() {
         compress_to_vec(&payload, CompressionLevel::Best).expect("compress incompressible");
 
     let decompressed = decompress_to_vec(&compressed).expect("decompress incompressible");
-    assert_eq!(decompressed, payload, "incompressible data roundtrip failed");
+    assert_eq!(
+        decompressed, payload,
+        "incompressible data roundtrip failed"
+    );
 }
 
 #[test]

--- a/crates/metadata/src/acl_noop.rs
+++ b/crates/metadata/src/acl_noop.rs
@@ -64,3 +64,57 @@ pub fn apply_acls_from_cache(
     warn_acl_unsupported();
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn sync_acls_returns_ok() {
+        let src = Path::new("/nonexistent/src");
+        let dst = Path::new("/nonexistent/dst");
+        let result = sync_acls(src, dst, false);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn sync_acls_follow_symlinks_returns_ok() {
+        let src = Path::new("/nonexistent/src");
+        let dst = Path::new("/nonexistent/dst");
+        let result = sync_acls(src, dst, true);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn get_rsync_acl_non_default_returns_from_mode() {
+        let path = Path::new("/nonexistent/file");
+        let acl = get_rsync_acl(path, 0o755, false);
+        let from_mode = RsyncAcl::from_mode(0o755);
+        assert_eq!(acl, from_mode);
+    }
+
+    #[test]
+    fn get_rsync_acl_default_returns_empty() {
+        let path = Path::new("/nonexistent/file");
+        let acl = get_rsync_acl(path, 0o755, true);
+        let empty = RsyncAcl::new();
+        assert_eq!(acl, empty);
+    }
+
+    #[test]
+    fn apply_acls_from_cache_returns_ok() {
+        let dst = Path::new("/nonexistent/dst");
+        let cache = AclCache::new();
+        let result = apply_acls_from_cache(dst, &cache, 0, None, false, None);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn apply_acls_from_cache_with_default_ndx_returns_ok() {
+        let dst = Path::new("/nonexistent/dst");
+        let cache = AclCache::new();
+        let result = apply_acls_from_cache(dst, &cache, 0, Some(1), true, Some(0o644));
+        assert!(result.is_ok());
+    }
+}

--- a/crates/metadata/src/acl_stub.rs
+++ b/crates/metadata/src/acl_stub.rs
@@ -101,3 +101,41 @@ pub fn apply_acls_from_cache(
     warn_acl_unsupported();
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn sync_acls_returns_ok() {
+        let src = Path::new("/nonexistent/src");
+        let dst = Path::new("/nonexistent/dst");
+        let result = sync_acls(src, dst, false);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn get_rsync_acl_non_default_returns_from_mode() {
+        let path = Path::new("/nonexistent/file");
+        let acl = get_rsync_acl(path, 0o755, false);
+        let from_mode = RsyncAcl::from_mode(0o755);
+        assert_eq!(acl, from_mode);
+    }
+
+    #[test]
+    fn get_rsync_acl_default_returns_empty() {
+        let path = Path::new("/nonexistent/file");
+        let acl = get_rsync_acl(path, 0o755, true);
+        let empty = RsyncAcl::new();
+        assert_eq!(acl, empty);
+    }
+
+    #[test]
+    fn apply_acls_from_cache_returns_ok() {
+        let dst = Path::new("/nonexistent/dst");
+        let cache = AclCache::new();
+        let result = apply_acls_from_cache(dst, &cache, 0, None, false, None);
+        assert!(result.is_ok());
+    }
+}

--- a/crates/metadata/src/copy_as.rs
+++ b/crates/metadata/src/copy_as.rs
@@ -402,4 +402,54 @@ mod tests {
         let guard = switch_effective_ids(&ids);
         assert!(guard.is_ok());
     }
+
+    #[cfg(not(unix))]
+    #[test]
+    fn non_unix_switch_without_group_returns_noop_guard() {
+        let ids = CopyAsIds { uid: 0, gid: None };
+        let guard = switch_effective_ids(&ids);
+        assert!(guard.is_ok());
+    }
+
+    #[cfg(not(unix))]
+    #[test]
+    fn non_unix_resolve_user_by_name_returns_unsupported() {
+        let err = resolve_user_by_name("root").unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::Unsupported);
+    }
+
+    #[cfg(not(unix))]
+    #[test]
+    fn non_unix_resolve_group_by_name_returns_unsupported() {
+        let err = resolve_group_by_name("wheel").unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::Unsupported);
+    }
+
+    #[cfg(not(unix))]
+    #[test]
+    fn non_unix_parse_named_user_fails() {
+        let spec = OsString::from("root");
+        let err = parse_copy_as_spec(&spec).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::Unsupported);
+    }
+
+    #[cfg(not(unix))]
+    #[test]
+    fn non_unix_parse_named_group_fails() {
+        let spec = OsString::from("0:wheel");
+        let err = parse_copy_as_spec(&spec).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::Unsupported);
+    }
+
+    #[cfg(not(unix))]
+    #[test]
+    fn non_unix_guard_drop_is_noop() {
+        let ids = CopyAsIds {
+            uid: 1000,
+            gid: Some(1000),
+        };
+        let guard = switch_effective_ids(&ids).unwrap();
+        drop(guard);
+        // No panic or side effects from drop
+    }
 }

--- a/crates/metadata/src/fake_super.rs
+++ b/crates/metadata/src/fake_super.rs
@@ -459,4 +459,52 @@ mod tests {
         assert!(is_device_file(0o60660)); // Block device
         assert!(is_device_file(0o20666)); // Char device
     }
+
+    #[cfg(not(all(unix, feature = "xattr")))]
+    mod stub_tests {
+        use super::*;
+        use std::path::Path;
+
+        #[test]
+        fn store_fake_super_stub_returns_unsupported() {
+            let path = Path::new("/nonexistent/file");
+            let stat = FakeSuperStat {
+                mode: 0o100644,
+                uid: 1000,
+                gid: 1000,
+                rdev: None,
+            };
+            let err = store_fake_super(path, &stat).unwrap_err();
+            assert_eq!(err.kind(), io::ErrorKind::Unsupported);
+            assert!(err.to_string().contains("xattr"));
+        }
+
+        #[test]
+        fn load_fake_super_stub_returns_none() {
+            let path = Path::new("/nonexistent/file");
+            let result = load_fake_super(path).unwrap();
+            assert!(result.is_none());
+        }
+
+        #[test]
+        fn remove_fake_super_stub_returns_ok() {
+            let path = Path::new("/nonexistent/file");
+            let result = remove_fake_super(path);
+            assert!(result.is_ok());
+        }
+    }
+
+    #[cfg(not(unix))]
+    #[test]
+    fn from_metadata_non_unix_returns_defaults() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = temp.path().join("test.txt");
+        std::fs::write(&path, b"content").expect("write");
+        let metadata = std::fs::metadata(&path).expect("metadata");
+        let stat = FakeSuperStat::from_metadata(&metadata);
+        assert_eq!(stat.mode, 0o100644);
+        assert_eq!(stat.uid, 0);
+        assert_eq!(stat.gid, 0);
+        assert_eq!(stat.rdev, None);
+    }
 }

--- a/crates/metadata/src/id_lookup/nss_stub.rs
+++ b/crates/metadata/src/id_lookup/nss_stub.rs
@@ -64,3 +64,114 @@ pub fn lookup_group_by_name(name: &[u8]) -> Result<Option<u32>, io::Error> {
     });
     Ok(converted)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::id_lookup::converter::{
+        NameConverterCallbacks, clear_name_converter, set_name_converter,
+    };
+
+    struct TestConverter;
+
+    impl NameConverterCallbacks for TestConverter {
+        fn uid_to_name(&mut self, uid: u32) -> Option<String> {
+            if uid == 0 {
+                Some("root".to_string())
+            } else {
+                None
+            }
+        }
+        fn gid_to_name(&mut self, gid: u32) -> Option<String> {
+            if gid == 0 {
+                Some("wheel".to_string())
+            } else {
+                None
+            }
+        }
+        fn name_to_uid(&mut self, name: &str) -> Option<u32> {
+            if name == "root" { Some(0) } else { None }
+        }
+        fn name_to_gid(&mut self, name: &str) -> Option<u32> {
+            if name == "wheel" { Some(0) } else { None }
+        }
+    }
+
+    #[test]
+    fn lookup_user_name_without_converter_returns_none() {
+        clear_name_converter();
+        let result = lookup_user_name(0).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn lookup_group_name_without_converter_returns_none() {
+        clear_name_converter();
+        let result = lookup_group_name(0).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn lookup_user_by_name_without_converter_returns_none() {
+        clear_name_converter();
+        let result = lookup_user_by_name(b"root").unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn lookup_group_by_name_without_converter_returns_none() {
+        clear_name_converter();
+        let result = lookup_group_by_name(b"wheel").unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn lookup_user_by_name_invalid_utf8_returns_none() {
+        let result = lookup_user_by_name(b"\xff\xfe").unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn lookup_group_by_name_invalid_utf8_returns_none() {
+        let result = lookup_group_by_name(b"\xff\xfe").unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn lookup_with_converter_delegates() {
+        set_name_converter(Box::new(TestConverter));
+
+        let user = lookup_user_name(0).unwrap();
+        assert_eq!(user, Some(b"root".to_vec()));
+
+        let uid = lookup_user_by_name(b"root").unwrap();
+        assert_eq!(uid, Some(0));
+
+        let group = lookup_group_name(0).unwrap();
+        assert_eq!(group, Some(b"wheel".to_vec()));
+
+        let gid = lookup_group_by_name(b"wheel").unwrap();
+        assert_eq!(gid, Some(0));
+
+        clear_name_converter();
+    }
+
+    #[test]
+    fn lookup_with_converter_unknown_returns_none() {
+        set_name_converter(Box::new(TestConverter));
+
+        let user = lookup_user_name(9999).unwrap();
+        assert!(user.is_none());
+
+        let uid = lookup_user_by_name(b"nobody").unwrap();
+        assert!(uid.is_none());
+
+        let group = lookup_group_name(9999).unwrap();
+        assert!(group.is_none());
+
+        let gid = lookup_group_by_name(b"nobody").unwrap();
+        assert!(gid.is_none());
+
+        clear_name_converter();
+    }
+}

--- a/crates/metadata/src/id_lookup/tests.rs
+++ b/crates/metadata/src/id_lookup/tests.rs
@@ -1,9 +1,11 @@
 //! Tests for UID/GID lookup and mapping.
 
 use super::*;
+#[cfg(unix)]
 use std::sync::{Mutex, OnceLock};
 
 /// Global lock to serialize tests that modify shared caches.
+#[cfg(unix)]
 fn cache_lock() -> &'static Mutex<()> {
     static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
     LOCK.get_or_init(|| Mutex::new(()))
@@ -156,6 +158,7 @@ fn map_uid_and_map_gid_consistency() {
     assert!(gid_result.is_some());
 }
 
+#[cfg(unix)]
 #[test]
 fn uid_cache_stores_mapping_on_lookup() {
     let _lock = cache_lock().lock().unwrap();
@@ -170,6 +173,7 @@ fn uid_cache_stores_mapping_on_lookup() {
     );
 }
 
+#[cfg(unix)]
 #[test]
 fn gid_cache_stores_mapping_on_lookup() {
     let _lock = cache_lock().lock().unwrap();
@@ -184,6 +188,7 @@ fn gid_cache_stores_mapping_on_lookup() {
     );
 }
 
+#[cfg(unix)]
 #[test]
 fn numeric_ids_bypasses_cache() {
     let _lock = cache_lock().lock().unwrap();
@@ -206,6 +211,7 @@ fn numeric_ids_bypasses_cache() {
     );
 }
 
+#[cfg(unix)]
 #[test]
 fn repeated_lookups_return_same_result() {
     let _lock = cache_lock().lock().unwrap();
@@ -219,6 +225,7 @@ fn repeated_lookups_return_same_result() {
     assert_eq!(second, third);
 }
 
+#[cfg(unix)]
 #[test]
 fn clear_id_caches_empties_both_caches() {
     let _lock = cache_lock().lock().unwrap();
@@ -235,6 +242,7 @@ fn clear_id_caches_empties_both_caches() {
 // "The special uid 0 and the special group 0 are never mapped via user/group
 // names even if the --numeric-ids option is not specified."
 
+#[cfg(unix)]
 #[test]
 fn map_uid_zero_bypasses_name_lookup_even_without_numeric_ids() {
     let result = map_uid(0, false);
@@ -242,6 +250,7 @@ fn map_uid_zero_bypasses_name_lookup_even_without_numeric_ids() {
     assert_eq!(result.unwrap().as_raw(), 0);
 }
 
+#[cfg(unix)]
 #[test]
 fn map_gid_zero_bypasses_name_lookup_even_without_numeric_ids() {
     let result = map_gid(0, false);
@@ -249,6 +258,7 @@ fn map_gid_zero_bypasses_name_lookup_even_without_numeric_ids() {
     assert_eq!(result.unwrap().as_raw(), 0);
 }
 
+#[cfg(unix)]
 #[test]
 fn map_uid_zero_does_not_populate_cache() {
     let _lock = cache_lock().lock().unwrap();
@@ -263,6 +273,7 @@ fn map_uid_zero_does_not_populate_cache() {
     );
 }
 
+#[cfg(unix)]
 #[test]
 fn map_gid_zero_does_not_populate_cache() {
     let _lock = cache_lock().lock().unwrap();
@@ -277,6 +288,7 @@ fn map_gid_zero_does_not_populate_cache() {
     );
 }
 
+#[cfg(unix)]
 #[test]
 fn map_uid_zero_with_numeric_ids_true() {
     let result = map_uid(0, true);
@@ -284,6 +296,7 @@ fn map_uid_zero_with_numeric_ids_true() {
     assert_eq!(result.unwrap().as_raw(), 0);
 }
 
+#[cfg(unix)]
 #[test]
 fn map_gid_zero_with_numeric_ids_true() {
     let result = map_gid(0, true);
@@ -291,6 +304,7 @@ fn map_gid_zero_with_numeric_ids_true() {
     assert_eq!(result.unwrap().as_raw(), 0);
 }
 
+#[cfg(unix)]
 #[test]
 fn non_zero_ids_still_use_name_lookup_when_numeric_ids_false() {
     let _lock = cache_lock().lock().unwrap();
@@ -309,4 +323,35 @@ fn non_zero_ids_still_use_name_lookup_when_numeric_ids_false() {
         gid_cache_size() > 0,
         "Non-zero GID should populate cache via name lookup path"
     );
+}
+
+// Non-Unix stub tests - map_uid/map_gid return the raw value unchanged.
+
+#[cfg(not(unix))]
+#[test]
+fn non_unix_map_uid_returns_raw_value() {
+    assert_eq!(map_uid(0, false), Some(0));
+    assert_eq!(map_uid(1000, false), Some(1000));
+    assert_eq!(map_uid(65534, true), Some(65534));
+}
+
+#[cfg(not(unix))]
+#[test]
+fn non_unix_map_gid_returns_raw_value() {
+    assert_eq!(map_gid(0, false), Some(0));
+    assert_eq!(map_gid(1000, false), Some(1000));
+    assert_eq!(map_gid(65534, true), Some(65534));
+}
+
+#[cfg(not(unix))]
+#[test]
+fn non_unix_map_uid_numeric_ids_flag_ignored() {
+    // On non-unix, numeric_ids flag has no effect - always passthrough.
+    assert_eq!(map_uid(42, true), map_uid(42, false));
+}
+
+#[cfg(not(unix))]
+#[test]
+fn non_unix_map_gid_numeric_ids_flag_ignored() {
+    assert_eq!(map_gid(42, true), map_gid(42, false));
 }

--- a/crates/metadata/src/mapping_win.rs
+++ b/crates/metadata/src/mapping_win.rs
@@ -86,3 +86,77 @@ impl NameMapping {
         Err(MappingParseError)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mapping_kind_none_display() {
+        let kind = MappingKind::None;
+        let display = format!("{kind}");
+        assert!(display.contains("unsupported"));
+        assert!(display.contains("Windows"));
+    }
+
+    #[test]
+    fn mapping_parse_error_display() {
+        let err = MappingParseError;
+        let display = format!("{err}");
+        assert!(display.contains("not supported on Windows"));
+    }
+
+    #[test]
+    fn mapping_parse_error_is_std_error() {
+        let err = MappingParseError;
+        let _: &dyn std::error::Error = &err;
+    }
+
+    #[test]
+    fn user_mapping_parse_always_fails() {
+        assert!(UserMapping::parse("root:0").is_err());
+        assert!(UserMapping::parse("*:65534").is_err());
+        assert!(UserMapping::parse("").is_err());
+    }
+
+    #[test]
+    fn group_mapping_parse_always_fails() {
+        assert!(GroupMapping::parse("wheel:0").is_err());
+        assert!(GroupMapping::parse("*:65534").is_err());
+        assert!(GroupMapping::parse("").is_err());
+    }
+
+    #[test]
+    fn name_mapping_parse_always_fails() {
+        assert!(NameMapping::parse("user:group").is_err());
+        assert!(NameMapping::parse("root:root").is_err());
+        assert!(NameMapping::parse("").is_err());
+    }
+
+    #[test]
+    fn mapping_kind_debug() {
+        let kind = MappingKind::None;
+        let debug = format!("{kind:?}");
+        assert!(debug.contains("None"));
+    }
+
+    #[test]
+    fn mapping_parse_error_equality() {
+        assert_eq!(MappingParseError, MappingParseError);
+    }
+
+    #[test]
+    fn user_mapping_equality() {
+        assert_eq!(UserMapping, UserMapping);
+    }
+
+    #[test]
+    fn group_mapping_equality() {
+        assert_eq!(GroupMapping, GroupMapping);
+    }
+
+    #[test]
+    fn name_mapping_equality() {
+        assert_eq!(NameMapping, NameMapping);
+    }
+}

--- a/crates/metadata/src/nfsv4_acl_stub.rs
+++ b/crates/metadata/src/nfsv4_acl_stub.rs
@@ -86,3 +86,123 @@ pub fn sync_nfsv4_acls(
 pub fn has_nfsv4_acl(_path: &Path, _follow_symlinks: bool) -> bool {
     false
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn nfs4_acl_xattr_constant_value() {
+        assert_eq!(NFS4_ACL_XATTR, "system.nfs4_acl");
+    }
+
+    #[test]
+    fn get_nfsv4_acl_returns_none() {
+        let path = Path::new("/nonexistent/file");
+        let result = get_nfsv4_acl(path, false).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn get_nfsv4_acl_follow_symlinks_returns_none() {
+        let path = Path::new("/nonexistent/file");
+        let result = get_nfsv4_acl(path, true).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn set_nfsv4_acl_with_none_returns_ok() {
+        let path = Path::new("/nonexistent/file");
+        let result = set_nfsv4_acl(path, None, false);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn set_nfsv4_acl_with_acl_returns_ok() {
+        let path = Path::new("/nonexistent/file");
+        let acl = Nfs4Acl::default();
+        let result = set_nfsv4_acl(path, Some(&acl), true);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn set_nfsv4_acl_with_nonempty_acl_returns_ok() {
+        let path = Path::new("/nonexistent/file");
+        let acl = Nfs4Acl {
+            aces: vec![Nfs4Ace {
+                ace_type: AceType::Allow,
+                flags: AceFlags(0),
+                mask: AccessMask(0x1f),
+                who: "OWNER@".to_string(),
+            }],
+        };
+        let result = set_nfsv4_acl(path, Some(&acl), false);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn sync_nfsv4_acls_returns_ok() {
+        let src = Path::new("/nonexistent/src");
+        let dst = Path::new("/nonexistent/dst");
+        let result = sync_nfsv4_acls(src, dst, false);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn has_nfsv4_acl_returns_false() {
+        let path = Path::new("/nonexistent/file");
+        assert!(!has_nfsv4_acl(path, false));
+        assert!(!has_nfsv4_acl(path, true));
+    }
+
+    #[test]
+    fn nfs4_acl_default_is_empty() {
+        let acl = Nfs4Acl::default();
+        assert!(acl.aces.is_empty());
+    }
+
+    #[test]
+    fn ace_type_values() {
+        assert_eq!(AceType::Allow as u32, 0);
+        assert_eq!(AceType::Deny as u32, 1);
+    }
+
+    #[test]
+    fn ace_flags_default_is_zero() {
+        let flags = AceFlags::default();
+        assert_eq!(flags.0, 0);
+    }
+
+    #[test]
+    fn access_mask_default_is_zero() {
+        let mask = AccessMask::default();
+        assert_eq!(mask.0, 0);
+    }
+
+    #[test]
+    fn nfs4_ace_equality() {
+        let ace1 = Nfs4Ace {
+            ace_type: AceType::Allow,
+            flags: AceFlags(0),
+            mask: AccessMask(0x1f),
+            who: "OWNER@".to_string(),
+        };
+        let ace2 = ace1.clone();
+        assert_eq!(ace1, ace2);
+    }
+
+    #[test]
+    fn nfs4_acl_clone() {
+        let acl = Nfs4Acl {
+            aces: vec![Nfs4Ace {
+                ace_type: AceType::Deny,
+                flags: AceFlags(1),
+                mask: AccessMask(0xff),
+                who: "GROUP@".to_string(),
+            }],
+        };
+        let cloned = acl.clone();
+        assert_eq!(acl, cloned);
+    }
+}

--- a/crates/metadata/src/ownership_stub.rs
+++ b/crates/metadata/src/ownership_stub.rs
@@ -19,3 +19,22 @@ pub const fn uid_from_raw(raw: u32) -> u32 {
 pub const fn gid_from_raw(raw: u32) -> u32 {
     raw
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn uid_from_raw_identity() {
+        assert_eq!(uid_from_raw(0), 0);
+        assert_eq!(uid_from_raw(1000), 1000);
+        assert_eq!(uid_from_raw(u32::MAX), u32::MAX);
+    }
+
+    #[test]
+    fn gid_from_raw_identity() {
+        assert_eq!(gid_from_raw(0), 0);
+        assert_eq!(gid_from_raw(1000), 1000);
+        assert_eq!(gid_from_raw(u32::MAX), u32::MAX);
+    }
+}

--- a/crates/metadata/src/special.rs
+++ b/crates/metadata/src/special.rs
@@ -348,4 +348,28 @@ mod tests {
                 .contains("mode value exceeds platform limits")
         );
     }
+
+    #[cfg(not(unix))]
+    #[test]
+    fn create_fifo_noop_on_non_unix() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let source = temp.path().join("source");
+        fs::File::create(&source).expect("create source");
+        let metadata = fs::metadata(&source).expect("metadata");
+        let fifo_path = temp.path().join("fifo");
+        let result = create_fifo(&fifo_path, &metadata);
+        assert!(result.is_ok());
+    }
+
+    #[cfg(not(unix))]
+    #[test]
+    fn create_device_node_noop_on_non_unix() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let source = temp.path().join("source");
+        fs::File::create(&source).expect("create source");
+        let metadata = fs::metadata(&source).expect("metadata");
+        let device_path = temp.path().join("device");
+        let result = create_device_node(&device_path, &metadata);
+        assert!(result.is_ok());
+    }
 }

--- a/crates/metadata/src/xattr_stub.rs
+++ b/crates/metadata/src/xattr_stub.rs
@@ -58,3 +58,56 @@ pub fn apply_xattrs_from_list(
     warn_xattr_unsupported();
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn sync_xattrs_returns_ok() {
+        let src = Path::new("/nonexistent/src");
+        let dst = Path::new("/nonexistent/dst");
+        let result = sync_xattrs(src, dst, false, None);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn sync_xattrs_with_filter_returns_ok() {
+        let src = Path::new("/nonexistent/src");
+        let dst = Path::new("/nonexistent/dst");
+        let filter = |_name: &str| true;
+        let result = sync_xattrs(src, dst, true, Some(&filter));
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn read_xattrs_for_wire_returns_empty_list() {
+        let path = Path::new("/nonexistent/file");
+        let result = read_xattrs_for_wire(path, false, false, 0).unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn read_xattrs_for_wire_as_root_returns_empty_list() {
+        let path = Path::new("/nonexistent/file");
+        let result = read_xattrs_for_wire(path, true, true, 42).unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn apply_xattrs_from_list_returns_ok() {
+        let dst = Path::new("/nonexistent/dst");
+        let xattr_list = XattrList::new();
+        let result = apply_xattrs_from_list(dst, &xattr_list, false);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn apply_xattrs_from_list_follow_symlinks_returns_ok() {
+        let dst = Path::new("/nonexistent/dst");
+        let xattr_list = XattrList::new();
+        let result = apply_xattrs_from_list(dst, &xattr_list, true);
+        assert!(result.is_ok());
+    }
+}


### PR DESCRIPTION
## Summary

- Add test coverage for all platform-specific stub implementations in `crates/metadata/`
- Tests verify graceful degradation behavior: `Ok(())`, `Ok(None)`, empty collections, and error returns
- All tests are gated with appropriate `#[cfg()]` attributes so they compile on every platform

## Stubs covered

| File | Platform gate | Stub behavior tested |
|------|--------------|---------------------|
| `xattr_stub.rs` | `not(unix && xattr)` | `sync_xattrs`, `read_xattrs_for_wire`, `apply_xattrs_from_list` return Ok/empty |
| `acl_noop.rs` | no acl feature or unsupported OS | `sync_acls`, `get_rsync_acl`, `apply_acls_from_cache` return Ok/from_mode |
| `acl_stub.rs` | iOS/tvOS/watchOS with acl | Same as acl_noop |
| `nfsv4_acl_stub.rs` | `not(unix && xattr)` | `get`/`set`/`sync`/`has` NFSv4 ACL stubs, type constructors |
| `ownership_stub.rs` | `not(unix)` | `uid_from_raw`/`gid_from_raw` identity functions |
| `mapping_win.rs` | `not(unix)` | `UserMapping`/`GroupMapping`/`NameMapping` parse always fails |
| `special.rs` | `not(unix)` | `create_fifo`/`create_device_node` are no-ops |
| `fake_super.rs` | `not(unix && xattr)` / `not(unix)` | `store` returns Unsupported, `load` returns None, `remove` returns Ok |
| `copy_as.rs` | `not(unix)` | `switch_effective_ids` noop guard, name resolution returns Unsupported |
| `id_lookup/nss_stub.rs` | `not(unix)` | Lookups without converter return None, with converter delegates correctly |
| `id_lookup/tests.rs` | added `#[cfg(unix)]` gates | Existing cache tests gated; new `not(unix)` passthrough tests added |

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy -p metadata --all-features --no-deps -- -D warnings` passes
- [x] `cargo nextest run -p metadata --all-features` - 447 tests pass
- [ ] CI: Windows matrix validates `not(unix)` stub tests compile and pass
- [ ] CI: Linux musl validates all-features tests pass