### PR TITLE
feat: wire embedded SSH transport into core/client remote transfer path

### DIFF
--- a/crates/compress/tests/zlib_ng_backend.rs
+++ b/crates/compress/tests/zlib_ng_backend.rs
@@ -92,7 +92,10 @@ fn zlib_ng_handles_incompressible_data() {
         compress_to_vec(&payload, CompressionLevel::Best).expect("compress incompressible");
 
     let decompressed = decompress_to_vec(&compressed).expect("decompress incompressible");
-    assert_eq!(decompressed, payload, "incompressible data roundtrip failed");
+    assert_eq!(
+        decompressed, payload,
+        "incompressible data roundtrip failed"
+    );
 }
 
 #[test]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -85,6 +85,9 @@ iconv = ["protocol/iconv"]
 # Runtime Features
 # ============================================================================
 
+# Embedded SSH transport using russh - pure Rust alternative to spawning system ssh
+embedded-ssh = ["dep:tokio", "rsync_io/embedded-ssh"]
+
 # Async runtime support - enables tokio-based async I/O for core operations
 async = ["dep:tokio", "engine/async", "transfer/async"]
 

--- a/crates/core/src/client/config/builder/mod.rs
+++ b/crates/core/src/client/config/builder/mod.rs
@@ -249,6 +249,8 @@ pub struct ClientConfigBuilder {
     no_motd: bool,
     daemon_params: Vec<String>,
     protocol_version: Option<protocol::ProtocolVersion>,
+    #[cfg(feature = "embedded-ssh")]
+    embedded_ssh_config: Option<super::client::EmbeddedSshOptions>,
     #[cfg(all(unix, feature = "acl"))]
     preserve_acls: bool,
     #[cfg(all(unix, feature = "xattr"))]
@@ -404,6 +406,8 @@ impl ClientConfigBuilder {
             no_motd: self.no_motd,
             daemon_params: self.daemon_params,
             protocol_version: self.protocol_version,
+            #[cfg(feature = "embedded-ssh")]
+            embedded_ssh_config: self.embedded_ssh_config,
             #[cfg(all(unix, feature = "acl"))]
             preserve_acls: self.preserve_acls,
             #[cfg(all(unix, feature = "xattr"))]

--- a/crates/core/src/client/config/builder/network.rs
+++ b/crates/core/src/client/config/builder/network.rs
@@ -56,6 +56,20 @@ impl ClientConfigBuilder {
         protect_args: Option<bool>,
     }
 
+    /// Configures the embedded SSH transport options.
+    ///
+    /// These options override `SshConfig` defaults when the `embedded-ssh`
+    /// feature is enabled and the transfer target uses an `ssh://` URL.
+    #[cfg(feature = "embedded-ssh")]
+    #[must_use]
+    pub fn embedded_ssh_config(
+        mut self,
+        config: Option<super::super::client::EmbeddedSshOptions>,
+    ) -> Self {
+        self.embedded_ssh_config = config;
+        self
+    }
+
     /// Configures the deadline at which the transfer should stop.
     #[must_use]
     #[doc(alias = "--stop-after")]

--- a/crates/core/src/client/config/client/mod.rs
+++ b/crates/core/src/client/config/client/mod.rs
@@ -178,10 +178,38 @@ pub struct ClientConfig {
     pub(super) no_motd: bool,
     pub(super) daemon_params: Vec<String>,
     pub(super) protocol_version: Option<protocol::ProtocolVersion>,
+    #[cfg(feature = "embedded-ssh")]
+    pub(super) embedded_ssh_config: Option<EmbeddedSshOptions>,
     #[cfg(all(unix, feature = "acl"))]
     pub(super) preserve_acls: bool,
     #[cfg(all(unix, feature = "xattr"))]
     pub(super) preserve_xattrs: bool,
+}
+
+/// Options for the embedded SSH transport (russh-based).
+///
+/// These fields override defaults from `SshConfig` when the transfer
+/// uses `ssh://` URLs with the `embedded-ssh` feature enabled. Fields
+/// left as `None` use `SshConfig::default()` values.
+#[cfg(feature = "embedded-ssh")]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct EmbeddedSshOptions {
+    /// Cipher preference list overriding hardware-detected defaults.
+    pub ciphers: Vec<String>,
+    /// Connection timeout in seconds (overrides `SshConfig` default of 30s).
+    pub connect_timeout_secs: Option<u64>,
+    /// Keepalive interval in seconds. `Some(0)` disables keepalives.
+    pub keepalive_interval_secs: Option<u64>,
+    /// Identity file paths for key-based authentication.
+    pub identity_files: Vec<std::path::PathBuf>,
+    /// Whether to disable SSH agent authentication.
+    pub no_agent: bool,
+    /// Host key verification policy (`yes`, `no`, `ask`).
+    pub strict_host_key_checking: Option<String>,
+    /// Prefer IPv6 for DNS resolution.
+    pub prefer_ipv6: bool,
+    /// Port override (takes precedence over port in the URL).
+    pub port: Option<u16>,
 }
 
 impl Default for ClientConfig {
@@ -303,6 +331,8 @@ impl Default for ClientConfig {
             no_motd: false,
             daemon_params: Vec::new(),
             protocol_version: None,
+            #[cfg(feature = "embedded-ssh")]
+            embedded_ssh_config: None,
             #[cfg(all(unix, feature = "acl"))]
             preserve_acls: false,
             #[cfg(all(unix, feature = "xattr"))]

--- a/crates/core/src/client/config/client/network.rs
+++ b/crates/core/src/client/config/client/network.rs
@@ -110,6 +110,17 @@ impl ClientConfig {
         self.protect_args
     }
 
+    /// Returns the embedded SSH options, if configured.
+    ///
+    /// These options override `SshConfig` defaults when the `embedded-ssh`
+    /// feature is enabled and an `ssh://` URL is used.
+    #[cfg(feature = "embedded-ssh")]
+    #[doc(alias = "--ssh-cipher")]
+    #[doc(alias = "--ssh-no-agent")]
+    pub fn embedded_ssh_config(&self) -> Option<&super::EmbeddedSshOptions> {
+        self.embedded_ssh_config.as_ref()
+    }
+
     /// Returns the forced protocol version, if any.
     ///
     /// When set, the client advertises this version during the daemon handshake

--- a/crates/core/src/client/config/mod.rs
+++ b/crates/core/src/client/config/mod.rs
@@ -31,6 +31,8 @@ mod skip_compress;
 pub use bandwidth::BandwidthLimit;
 pub use builder::{ClientConfigBuilder, ConfigConflict};
 pub use client::ClientConfig;
+#[cfg(feature = "embedded-ssh")]
+pub use client::EmbeddedSshOptions;
 pub use compress_env::force_no_compress_from_env;
 pub use enums::{
     AddressMode, CompressionSetting, DeleteMode, FilesFromSource, HumanReadableMode,

--- a/crates/core/src/client/mod.rs
+++ b/crates/core/src/client/mod.rs
@@ -98,6 +98,8 @@ pub mod remote;
 mod run;
 mod summary;
 
+#[cfg(feature = "embedded-ssh")]
+pub use self::config::EmbeddedSshOptions;
 pub use self::config::{
     AddressMode, BandwidthLimit, BindAddress, ClientConfig, ClientConfigBuilder,
     CompressionSetting, ConfigConflict, DeleteMode, FilesFromSource, FilterRuleKind,

--- a/crates/core/src/client/remote/embedded_ssh_transfer.rs
+++ b/crates/core/src/client/remote/embedded_ssh_transfer.rs
@@ -1,0 +1,739 @@
+//! Embedded SSH transfer orchestration using the russh library.
+//!
+//! Provides a pure-Rust alternative to spawning the system `ssh` binary for
+//! `ssh://` URL transfers. Feature-gated behind `embedded-ssh`. The module
+//! reuses the same server infrastructure as the system SSH path - only the
+//! connection establishment differs.
+//!
+//! # Architecture
+//!
+//! 1. Parse the `ssh://` URL via `SshConfig::from_url()`
+//! 2. Apply CLI overrides from `EmbeddedSshOptions`
+//! 3. Resolve the host, connect, and authenticate using russh
+//! 4. Open a channel and exec the remote `rsync --server` command
+//! 5. Wrap the channel's async I/O in synchronous `Read`/`Write` adapters
+//! 6. Hand off to `crate::server` for protocol negotiation and transfer
+//!
+//! # Upstream Reference
+//!
+//! - `main.c:do_cmd()` - SSH fork/exec and pipe setup (replaced by russh)
+//! - `main.c:client_run()` - Role dispatch after SSH connection
+
+use std::ffi::OsString;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+#[cfg(feature = "tracing")]
+use tracing::instrument;
+
+use engine::batch::BatchWriter;
+use rsync_io::ssh::embedded::SshConfig;
+
+use super::super::config::ClientConfig;
+#[allow(unused_imports)] // REASON: used in tests
+use super::super::config::EmbeddedSshOptions;
+use super::super::error::{ClientError, invalid_argument_error};
+use super::super::progress::ClientProgressObserver;
+use super::super::summary::ClientSummary;
+use super::batch_support::{build_batch_context, build_batch_recording};
+use super::flags;
+use super::invocation::{
+    RemoteInvocationBuilder, RemoteOperands, RemoteRole, TransferSpec, determine_transfer_role,
+};
+use super::ssh_transfer::convert_server_stats_to_summary;
+use crate::exit_code::ExitCode;
+use crate::server::{ServerConfig, ServerRole, TransferProgressCallback, TransferProgressEvent};
+
+/// Checks whether an operand is an `ssh://` URL suitable for embedded transport.
+///
+/// Returns `true` for operands starting with `ssh://`, which distinguishes
+/// embedded SSH transfers from standard `host:path` SSH operands that use
+/// the system SSH binary.
+pub(crate) fn is_ssh_url(operand: &str) -> bool {
+    operand.starts_with("ssh://")
+}
+
+/// Executes a transfer over the embedded SSH transport.
+///
+/// Entry point for `ssh://` URL transfers when the `embedded-ssh` feature is
+/// enabled. Mirrors `run_ssh_transfer` but replaces the system SSH binary
+/// with the russh-based pure-Rust transport.
+///
+/// # Arguments
+///
+/// * `config` - Client configuration with transfer options
+/// * `observer` - Optional progress observer
+/// * `batch_writer` - Optional batch recording writer
+///
+/// # Errors
+///
+/// Returns error if:
+/// - URL parsing fails
+/// - DNS resolution fails
+/// - SSH connection or authentication fails
+/// - Remote command execution fails
+/// - Protocol negotiation fails
+/// - Transfer execution fails
+#[cfg_attr(
+    feature = "tracing",
+    instrument(skip(config, observer), name = "embedded_ssh_transfer")
+)]
+pub fn run_embedded_ssh_transfer(
+    config: &ClientConfig,
+    observer: Option<&mut dyn ClientProgressObserver>,
+    batch_writer: Option<Arc<Mutex<BatchWriter>>>,
+) -> Result<ClientSummary, ClientError> {
+    let args = config.transfer_args();
+    if args.len() < 2 {
+        return Err(invalid_argument_error(
+            "need at least one source and one destination",
+            1,
+        ));
+    }
+
+    let (sources, destination) = args.split_at(args.len() - 1);
+    let destination = &destination[0];
+
+    let transfer_spec = determine_transfer_role(sources, destination)?;
+
+    match transfer_spec {
+        TransferSpec::Push {
+            local_sources,
+            remote_dest,
+        } => run_embedded_push(config, &remote_dest, &local_sources, observer, batch_writer),
+        TransferSpec::Pull {
+            remote_sources,
+            local_dest,
+        } => run_embedded_pull(config, &remote_sources, &local_dest, observer, batch_writer),
+        TransferSpec::Proxy { .. } => Err(invalid_argument_error(
+            "remote-to-remote proxy transfers are not supported with embedded SSH",
+            1,
+        )),
+    }
+}
+
+/// Executes a push transfer (local -> remote) via embedded SSH.
+fn run_embedded_push(
+    config: &ClientConfig,
+    remote_dest: &str,
+    local_sources: &[String],
+    observer: Option<&mut dyn ClientProgressObserver>,
+    batch_writer: Option<Arc<Mutex<BatchWriter>>>,
+) -> Result<ClientSummary, ClientError> {
+    let (ssh_config, remote_path) = parse_ssh_url(remote_dest, config)?;
+    let invocation_builder = RemoteInvocationBuilder::new(config, RemoteRole::Sender);
+    let secluded = invocation_builder.build_secluded(&[&remote_path]);
+
+    let mut server_config = build_server_config_for_generator(config, local_sources)?;
+    server_config.connection.client_mode = true;
+    server_config.connection.filter_rules = flags::build_wire_format_rules(config.filter_rules())
+        .map_err(|e| {
+        invalid_argument_error(&format!("failed to build filter rules: {e}"), 12)
+    })?;
+    server_config.stop_at = config.stop_at();
+
+    let batch_ctx = batch_writer.map(|bw| build_batch_context(config, bw));
+
+    run_transfer_over_embedded_ssh(
+        ssh_config,
+        &secluded.command_line_args,
+        &secluded.stdin_args,
+        server_config,
+        observer,
+        batch_ctx,
+    )
+}
+
+/// Executes a pull transfer (remote -> local) via embedded SSH.
+fn run_embedded_pull(
+    config: &ClientConfig,
+    remote_sources: &RemoteOperands,
+    local_dest: &str,
+    observer: Option<&mut dyn ClientProgressObserver>,
+    batch_writer: Option<Arc<Mutex<BatchWriter>>>,
+) -> Result<ClientSummary, ClientError> {
+    let (ssh_config, paths) = parse_remote_operands_urls(remote_sources, config)?;
+    let path_refs: Vec<&str> = paths.iter().map(String::as_str).collect();
+    let invocation_builder = RemoteInvocationBuilder::new(config, RemoteRole::Receiver);
+    let secluded = invocation_builder.build_secluded(&path_refs);
+
+    let mut server_config = build_server_config_for_receiver(config, &[local_dest.to_owned()])?;
+    server_config.connection.client_mode = true;
+    server_config.connection.filter_rules = flags::build_wire_format_rules(config.filter_rules())
+        .map_err(|e| {
+        invalid_argument_error(&format!("failed to build filter rules: {e}"), 12)
+    })?;
+    server_config.stop_at = config.stop_at();
+
+    let batch_ctx = batch_writer.map(|bw| build_batch_context(config, bw));
+
+    run_transfer_over_embedded_ssh(
+        ssh_config,
+        &secluded.command_line_args,
+        &secluded.stdin_args,
+        server_config,
+        observer,
+        batch_ctx,
+    )
+}
+
+/// Parses an `ssh://` URL and applies CLI overrides from `EmbeddedSshOptions`.
+fn parse_ssh_url(url: &str, config: &ClientConfig) -> Result<(SshConfig, String), ClientError> {
+    let (mut ssh_config, remote_path) = SshConfig::from_url(url)
+        .map_err(|e| invalid_argument_error(&format!("invalid ssh:// URL: {e}"), 1))?;
+
+    apply_cli_overrides(&mut ssh_config, config);
+
+    Ok((ssh_config, remote_path))
+}
+
+/// Parses remote operands (all `ssh://` URLs) and returns a single `SshConfig`.
+fn parse_remote_operands_urls(
+    operands: &RemoteOperands,
+    config: &ClientConfig,
+) -> Result<(SshConfig, Vec<String>), ClientError> {
+    match operands {
+        RemoteOperands::Single(url) => {
+            let (ssh_config, path) = parse_ssh_url(url, config)?;
+            Ok((ssh_config, vec![path]))
+        }
+        RemoteOperands::Multiple(urls) => {
+            let mut ssh_config = None;
+            let mut paths = Vec::with_capacity(urls.len());
+
+            for url in urls {
+                let (cfg, path) = parse_ssh_url(url, config)?;
+                if let Some(ref existing) = ssh_config {
+                    // Validate same host/port/user
+                    let existing: &SshConfig = existing;
+                    if cfg.host != existing.host
+                        || cfg.port != existing.port
+                        || cfg.username != existing.username
+                    {
+                        return Err(invalid_argument_error(
+                            "all ssh:// sources must use the same host, port, and user",
+                            1,
+                        ));
+                    }
+                } else {
+                    ssh_config = Some(cfg);
+                }
+                paths.push(path);
+            }
+
+            Ok((ssh_config.expect("at least one URL in Multiple"), paths))
+        }
+    }
+}
+
+/// Applies CLI `--ssh-*` overrides to an `SshConfig`.
+fn apply_cli_overrides(ssh_config: &mut SshConfig, config: &ClientConfig) {
+    let Some(opts) = config.embedded_ssh_config() else {
+        return;
+    };
+
+    if !opts.ciphers.is_empty() {
+        ssh_config.ciphers = Some(opts.ciphers.clone());
+    }
+
+    if let Some(timeout_secs) = opts.connect_timeout_secs {
+        ssh_config.connect_timeout = Duration::from_secs(timeout_secs);
+    }
+
+    if let Some(keepalive_secs) = opts.keepalive_interval_secs {
+        ssh_config.keepalive_interval = if keepalive_secs == 0 {
+            None
+        } else {
+            Some(Duration::from_secs(keepalive_secs))
+        };
+    }
+
+    if !opts.identity_files.is_empty() {
+        ssh_config.identity_files = opts.identity_files.clone();
+    }
+
+    if opts.no_agent {
+        ssh_config.use_agent = false;
+    }
+
+    if let Some(ref policy) = opts.strict_host_key_checking {
+        use rsync_io::ssh::embedded::StrictHostKeyChecking;
+        ssh_config.strict_host_key_checking = match policy.as_str() {
+            "yes" => StrictHostKeyChecking::Yes,
+            "no" => StrictHostKeyChecking::No,
+            _ => StrictHostKeyChecking::Ask,
+        };
+    }
+
+    if opts.prefer_ipv6 {
+        use rsync_io::ssh::embedded::IpPreference;
+        ssh_config.ip_preference = IpPreference::PreferV6;
+    }
+
+    if let Some(port) = opts.port {
+        ssh_config.port = port;
+    }
+}
+
+/// Connects, authenticates, and runs a transfer over the embedded SSH transport.
+///
+/// Delegates to `rsync_io::ssh::embedded::connect_and_exec` for the connection
+/// lifecycle, then hands the sync I/O handles to the server infrastructure for
+/// protocol negotiation and transfer execution.
+fn run_transfer_over_embedded_ssh(
+    ssh_config: SshConfig,
+    invocation_args: &[OsString],
+    stdin_args: &[String],
+    server_config: ServerConfig,
+    observer: Option<&mut dyn ClientProgressObserver>,
+    batch_ctx: Option<super::batch_support::BatchContext>,
+) -> Result<ClientSummary, ClientError> {
+    let remote_command = build_remote_command(invocation_args);
+
+    // Build stdin data for secluded-args delivery.
+    let stdin_data = if stdin_args.is_empty() {
+        None
+    } else {
+        let mut data = Vec::new();
+        for arg in stdin_args {
+            data.extend_from_slice(arg.as_bytes());
+            data.push(0);
+        }
+        data.push(0); // Terminal empty string
+        Some(data)
+    };
+
+    let (mut reader, mut writer) = rsync_io::ssh::embedded::connect_and_exec(
+        &ssh_config,
+        &remote_command,
+        stdin_data.as_deref(),
+    )
+    .map_err(|e| invalid_argument_error(&format!("embedded SSH connection failed: {e}"), 5))?;
+
+    // From here, the flow is identical to the system SSH path.
+    let start = Instant::now();
+    let batch_recording = batch_ctx.as_ref().map(|ctx| {
+        let is_sender = server_config.role == ServerRole::Generator;
+        build_batch_recording(ctx, is_sender)
+    });
+
+    let handshake = crate::server::perform_handshake(&mut reader, &mut writer)
+        .map_err(|e| invalid_argument_error(&format!("handshake failed: {e}"), 5))?;
+
+    let mut adapter = observer.map(|obs| ServerProgressAdapter::new(obs, start));
+    let progress: Option<&mut dyn TransferProgressCallback> = adapter
+        .as_mut()
+        .map(|a| a as &mut dyn TransferProgressCallback);
+
+    let transfer_result = crate::server::run_server_with_handshake(
+        server_config,
+        handshake,
+        &mut reader,
+        &mut writer,
+        progress,
+        batch_recording,
+        None,
+    );
+
+    drop(writer);
+    let elapsed = start.elapsed();
+
+    match transfer_result {
+        Ok(stats) => Ok(convert_server_stats_to_summary(stats, elapsed)),
+        Err(e) => {
+            let exit = ExitCode::from_io_error(&e);
+            Err(invalid_argument_error(
+                &format!("transfer failed: {e}"),
+                exit.as_i32(),
+            ))
+        }
+    }
+}
+
+/// Builds the remote command string from invocation arguments.
+fn build_remote_command(args: &[OsString]) -> String {
+    args.iter()
+        .map(|a| shell_escape(a.to_string_lossy().as_ref()))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// Shell-escapes a string for safe inclusion in a remote command.
+fn shell_escape(s: &str) -> String {
+    if s.chars()
+        .all(|c| c.is_ascii_alphanumeric() || "-_./=".contains(c))
+    {
+        s.to_owned()
+    } else {
+        format!("'{}'", s.replace('\'', "'\\''"))
+    }
+}
+
+/// Adapts a [`ClientProgressObserver`] to [`TransferProgressCallback`].
+///
+/// Identical to the adapter in `ssh_transfer.rs` - duplicated to keep
+/// module independence while both converge on the same server infrastructure.
+struct ServerProgressAdapter<'a> {
+    observer: &'a mut dyn ClientProgressObserver,
+    start: Instant,
+    overall_transferred: u64,
+}
+
+impl<'a> ServerProgressAdapter<'a> {
+    fn new(observer: &'a mut dyn ClientProgressObserver, start: Instant) -> Self {
+        Self {
+            observer,
+            start,
+            overall_transferred: 0,
+        }
+    }
+}
+
+impl TransferProgressCallback for ServerProgressAdapter<'_> {
+    fn on_file_transferred(&mut self, event: &TransferProgressEvent<'_>) {
+        use std::path::Path;
+        use std::sync::Arc;
+
+        self.overall_transferred += event.file_bytes;
+
+        let client_event = super::super::summary::ClientEvent::from_progress(
+            event.path,
+            event.file_bytes,
+            event.total_file_bytes,
+            self.start.elapsed(),
+            Arc::from(Path::new("")),
+        );
+
+        let update = super::super::progress::ClientProgressUpdate::from_transfer_event(
+            client_event,
+            event.files_done,
+            event.total_files,
+            event.total_file_bytes,
+            self.overall_transferred,
+            self.start.elapsed(),
+        );
+
+        self.observer.on_progress(&update);
+    }
+}
+
+/// Builds server configuration for receiver role (pull transfer).
+fn build_server_config_for_receiver(
+    config: &ClientConfig,
+    local_paths: &[String],
+) -> Result<ServerConfig, ClientError> {
+    let flag_string = flags::build_server_flag_string(config);
+    let args: Vec<OsString> = local_paths.iter().map(OsString::from).collect();
+
+    let mut server_config =
+        ServerConfig::from_flag_string_and_args(ServerRole::Receiver, flag_string, args)
+            .map_err(|e| invalid_argument_error(&format!("invalid server config: {e}"), 1))?;
+
+    server_config.flags.numeric_ids = config.numeric_ids();
+    server_config.flags.delete = config.delete_mode().is_enabled() || config.delete_excluded();
+    server_config.file_selection.size_only = config.size_only();
+
+    flags::apply_common_server_flags(config, &mut server_config);
+    Ok(server_config)
+}
+
+/// Builds server configuration for generator role (push transfer).
+fn build_server_config_for_generator(
+    config: &ClientConfig,
+    local_paths: &[String],
+) -> Result<ServerConfig, ClientError> {
+    let flag_string = flags::build_server_flag_string(config);
+    let args: Vec<OsString> = local_paths.iter().map(OsString::from).collect();
+
+    let mut server_config =
+        ServerConfig::from_flag_string_and_args(ServerRole::Generator, flag_string, args)
+            .map_err(|e| invalid_argument_error(&format!("invalid server config: {e}"), 1))?;
+
+    server_config.flags.numeric_ids = config.numeric_ids();
+    server_config.flags.delete = config.delete_mode().is_enabled() || config.delete_excluded();
+    server_config.file_selection.size_only = config.size_only();
+
+    flags::apply_common_server_flags(config, &mut server_config);
+    Ok(server_config)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_ssh_url_detects_ssh_scheme() {
+        assert!(is_ssh_url("ssh://host/path"));
+        assert!(is_ssh_url("ssh://user@host/path"));
+        assert!(is_ssh_url("ssh://user:pass@host:2222/path"));
+    }
+
+    #[test]
+    fn is_ssh_url_rejects_non_ssh() {
+        assert!(!is_ssh_url("rsync://host/module"));
+        assert!(!is_ssh_url("host:path"));
+        assert!(!is_ssh_url("host::module"));
+        assert!(!is_ssh_url("/local/path"));
+    }
+
+    #[test]
+    fn shell_escape_simple_string() {
+        assert_eq!(shell_escape("rsync"), "rsync");
+        assert_eq!(shell_escape("--server"), "--server");
+        assert_eq!(shell_escape("."), ".");
+    }
+
+    #[test]
+    fn shell_escape_string_with_spaces() {
+        assert_eq!(shell_escape("path with spaces"), "'path with spaces'");
+    }
+
+    #[test]
+    fn shell_escape_string_with_quotes() {
+        assert_eq!(shell_escape("it's"), "'it'\\''s'");
+    }
+
+    #[test]
+    fn build_remote_command_joins_args() {
+        let args = vec![
+            OsString::from("rsync"),
+            OsString::from("--server"),
+            OsString::from("--sender"),
+            OsString::from("."),
+            OsString::from("/path/to/data"),
+        ];
+        let cmd = build_remote_command(&args);
+        assert_eq!(cmd, "rsync --server --sender . /path/to/data");
+    }
+
+    #[test]
+    fn build_remote_command_escapes_special_chars() {
+        let args = vec![OsString::from("rsync"), OsString::from("path with space")];
+        let cmd = build_remote_command(&args);
+        assert!(cmd.contains("'path with space'"));
+    }
+
+    #[test]
+    fn apply_cli_overrides_ciphers() {
+        let mut ssh_config = SshConfig::default();
+        ssh_config.host("example.com");
+
+        let config = ClientConfig::builder()
+            .embedded_ssh_config(Some(EmbeddedSshOptions {
+                ciphers: vec!["aes256-ctr".to_owned()],
+                ..Default::default()
+            }))
+            .build();
+
+        apply_cli_overrides(&mut ssh_config, &config);
+        assert_eq!(ssh_config.ciphers, Some(vec!["aes256-ctr".to_owned()]));
+    }
+
+    #[test]
+    fn apply_cli_overrides_timeout() {
+        let mut ssh_config = SshConfig::default();
+
+        let config = ClientConfig::builder()
+            .embedded_ssh_config(Some(EmbeddedSshOptions {
+                connect_timeout_secs: Some(10),
+                ..Default::default()
+            }))
+            .build();
+
+        apply_cli_overrides(&mut ssh_config, &config);
+        assert_eq!(ssh_config.connect_timeout, Duration::from_secs(10));
+    }
+
+    #[test]
+    fn apply_cli_overrides_disable_keepalive() {
+        let mut ssh_config = SshConfig::default();
+        assert!(ssh_config.keepalive_interval.is_some());
+
+        let config = ClientConfig::builder()
+            .embedded_ssh_config(Some(EmbeddedSshOptions {
+                keepalive_interval_secs: Some(0),
+                ..Default::default()
+            }))
+            .build();
+
+        apply_cli_overrides(&mut ssh_config, &config);
+        assert!(ssh_config.keepalive_interval.is_none());
+    }
+
+    #[test]
+    fn apply_cli_overrides_no_agent() {
+        let mut ssh_config = SshConfig::default();
+        assert!(ssh_config.use_agent);
+
+        let config = ClientConfig::builder()
+            .embedded_ssh_config(Some(EmbeddedSshOptions {
+                no_agent: true,
+                ..Default::default()
+            }))
+            .build();
+
+        apply_cli_overrides(&mut ssh_config, &config);
+        assert!(!ssh_config.use_agent);
+    }
+
+    #[test]
+    fn apply_cli_overrides_strict_host_key_yes() {
+        let mut ssh_config = SshConfig::default();
+
+        let config = ClientConfig::builder()
+            .embedded_ssh_config(Some(EmbeddedSshOptions {
+                strict_host_key_checking: Some("yes".to_owned()),
+                ..Default::default()
+            }))
+            .build();
+
+        apply_cli_overrides(&mut ssh_config, &config);
+        assert_eq!(
+            ssh_config.strict_host_key_checking,
+            rsync_io::ssh::embedded::StrictHostKeyChecking::Yes,
+        );
+    }
+
+    #[test]
+    fn apply_cli_overrides_port() {
+        let mut ssh_config = SshConfig::default();
+
+        let config = ClientConfig::builder()
+            .embedded_ssh_config(Some(EmbeddedSshOptions {
+                port: Some(2222),
+                ..Default::default()
+            }))
+            .build();
+
+        apply_cli_overrides(&mut ssh_config, &config);
+        assert_eq!(ssh_config.port, 2222);
+    }
+
+    #[test]
+    fn apply_cli_overrides_identity_files() {
+        let mut ssh_config = SshConfig::default();
+        let original_count = ssh_config.identity_files.len();
+        assert!(original_count > 0);
+
+        let config = ClientConfig::builder()
+            .embedded_ssh_config(Some(EmbeddedSshOptions {
+                identity_files: vec![std::path::PathBuf::from("/custom/key")],
+                ..Default::default()
+            }))
+            .build();
+
+        apply_cli_overrides(&mut ssh_config, &config);
+        assert_eq!(ssh_config.identity_files.len(), 1);
+        assert_eq!(
+            ssh_config.identity_files[0],
+            std::path::PathBuf::from("/custom/key")
+        );
+    }
+
+    #[test]
+    fn apply_cli_overrides_ipv6() {
+        let mut ssh_config = SshConfig::default();
+
+        let config = ClientConfig::builder()
+            .embedded_ssh_config(Some(EmbeddedSshOptions {
+                prefer_ipv6: true,
+                ..Default::default()
+            }))
+            .build();
+
+        apply_cli_overrides(&mut ssh_config, &config);
+        assert_eq!(
+            ssh_config.ip_preference,
+            rsync_io::ssh::embedded::IpPreference::PreferV6,
+        );
+    }
+
+    #[test]
+    fn apply_cli_overrides_none_is_noop() {
+        let mut ssh_config = SshConfig::default();
+        let original_port = ssh_config.port;
+        let original_timeout = ssh_config.connect_timeout;
+
+        let config = ClientConfig::builder().build();
+        apply_cli_overrides(&mut ssh_config, &config);
+
+        assert_eq!(ssh_config.port, original_port);
+        assert_eq!(ssh_config.connect_timeout, original_timeout);
+    }
+
+    #[test]
+    fn parse_ssh_url_basic() {
+        let config = ClientConfig::builder().build();
+        let (ssh_config, path) = parse_ssh_url("ssh://user@host/~/data", &config).unwrap();
+        assert_eq!(ssh_config.host, "host");
+        assert_eq!(ssh_config.username.as_deref(), Some("user"));
+        assert_eq!(path, "~/data");
+    }
+
+    #[test]
+    fn parse_ssh_url_invalid_scheme() {
+        let config = ClientConfig::builder().build();
+        let result = parse_ssh_url("http://host/path", &config);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_ssh_url_with_port() {
+        let config = ClientConfig::builder().build();
+        let (ssh_config, _) = parse_ssh_url("ssh://host:2222/path", &config).unwrap();
+        assert_eq!(ssh_config.port, 2222);
+    }
+
+    #[test]
+    fn parse_ssh_url_cli_port_overrides_url() {
+        let config = ClientConfig::builder()
+            .embedded_ssh_config(Some(EmbeddedSshOptions {
+                port: Some(3333),
+                ..Default::default()
+            }))
+            .build();
+        let (ssh_config, _) = parse_ssh_url("ssh://host:2222/path", &config).unwrap();
+        assert_eq!(ssh_config.port, 3333);
+    }
+
+    #[test]
+    fn parse_remote_operands_single() {
+        let config = ClientConfig::builder().build();
+        let operands = RemoteOperands::Single("ssh://user@host/~/data".to_owned());
+        let (ssh_config, paths) = parse_remote_operands_urls(&operands, &config).unwrap();
+        assert_eq!(ssh_config.host, "host");
+        assert_eq!(paths, vec!["~/data"]);
+    }
+
+    #[test]
+    fn parse_remote_operands_multiple_same_host() {
+        let config = ClientConfig::builder().build();
+        let operands = RemoteOperands::Multiple(vec![
+            "ssh://user@host/~/file1".to_owned(),
+            "ssh://user@host/~/file2".to_owned(),
+        ]);
+        let (ssh_config, paths) = parse_remote_operands_urls(&operands, &config).unwrap();
+        assert_eq!(ssh_config.host, "host");
+        assert_eq!(paths, vec!["~/file1", "~/file2"]);
+    }
+
+    #[test]
+    fn parse_remote_operands_multiple_different_hosts_fails() {
+        let config = ClientConfig::builder().build();
+        let operands = RemoteOperands::Multiple(vec![
+            "ssh://user@host1/~/file1".to_owned(),
+            "ssh://user@host2/~/file2".to_owned(),
+        ]);
+        let result = parse_remote_operands_urls(&operands, &config);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn run_embedded_ssh_transfer_rejects_insufficient_args() {
+        let config = ClientConfig::builder()
+            .transfer_args(vec!["ssh://host/path"])
+            .build();
+        let result = run_embedded_ssh_transfer(&config, None, None);
+        assert!(result.is_err());
+    }
+}

--- a/crates/core/src/client/remote/mod.rs
+++ b/crates/core/src/client/remote/mod.rs
@@ -22,11 +22,17 @@
 
 pub(crate) mod batch_support;
 pub mod daemon_transfer;
+#[cfg(feature = "embedded-ssh")]
+pub mod embedded_ssh_transfer;
 pub(crate) mod flags;
 pub mod invocation;
 pub mod remote_to_remote;
 pub mod ssh_transfer;
 pub use daemon_transfer::run_daemon_transfer;
+#[cfg(feature = "embedded-ssh")]
+pub(crate) use embedded_ssh_transfer::is_ssh_url;
+#[cfg(feature = "embedded-ssh")]
+pub use embedded_ssh_transfer::run_embedded_ssh_transfer;
 pub use invocation::{
     RemoteInvocationBuilder, RemoteOperands, RemoteRole, SecludedInvocation, TransferSpec,
     determine_transfer_role, operand_is_remote,

--- a/crates/core/src/client/remote/ssh_transfer.rs
+++ b/crates/core/src/client/remote/ssh_transfer.rs
@@ -424,7 +424,7 @@ fn run_proxy_transfer(
 /// (files listed, files transferred, and bytes sent/received) to create a
 /// LocalCopySummary with the most relevant fields populated. The elapsed time
 /// is used to calculate the transfer rate (bytes/sec) shown in the summary output.
-fn convert_server_stats_to_summary(
+pub(super) fn convert_server_stats_to_summary(
     stats: crate::server::ServerStats,
     elapsed: Duration,
 ) -> ClientSummary {

--- a/crates/core/src/client/run/mod.rs
+++ b/crates/core/src/client/run/mod.rs
@@ -208,6 +208,30 @@ fn run_client_internal(
         .any(|arg| remote::operand_is_remote(arg));
 
     if has_remote {
+        // When the embedded-ssh feature is enabled and any operand uses an
+        // ssh:// URL, dispatch to the embedded SSH transport instead of
+        // spawning the system ssh binary.
+        #[cfg(feature = "embedded-ssh")]
+        {
+            let has_ssh_url = config
+                .transfer_args()
+                .iter()
+                .any(|arg| remote::is_ssh_url(&arg.to_string_lossy()));
+
+            if has_ssh_url {
+                let summary =
+                    remote::run_embedded_ssh_transfer(&config, observer, batch_writer.clone())?;
+
+                if let Some(ref writer_arc) = batch_writer
+                    && let Some(batch_cfg) = config.batch_config()
+                {
+                    batch::finalize_batch(writer_arc, batch_cfg, &summary)?;
+                }
+
+                return Ok(summary);
+            }
+        }
+
         let summary = remote::run_ssh_transfer(&config, observer, batch_writer.clone())?;
 
         // Finalize batch file if batch mode was active

--- a/crates/rsync_io/src/ssh/embedded/connect.rs
+++ b/crates/rsync_io/src/ssh/embedded/connect.rs
@@ -1,0 +1,296 @@
+//! High-level SSH connection establishment for the embedded transport.
+//!
+//! Provides `connect_and_exec` which handles the full lifecycle: DNS resolution,
+//! TCP connect, authentication, channel open, and command execution. Returns
+//! synchronous `Read`/`Write` handles suitable for the rsync protocol layer.
+
+use std::sync::Arc;
+
+use super::auth::authenticate;
+use super::config::SshConfig;
+use super::error::SshError;
+use super::handler::SshClientHandler;
+use super::resolve::resolve_host;
+
+/// Synchronous reader wrapping data received from the SSH channel.
+///
+/// Receives channel data chunks via a bounded sync channel and presents
+/// them through `std::io::Read`. Partial reads from oversized chunks are
+/// buffered internally.
+pub struct ChannelReader {
+    rx: std::sync::mpsc::Receiver<Vec<u8>>,
+    partial: Option<ReadBuffer>,
+}
+
+/// Partial buffer tracking for incomplete reads from channel messages.
+struct ReadBuffer {
+    data: Vec<u8>,
+    offset: usize,
+}
+
+impl std::io::Read for ChannelReader {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        // Drain any leftover data from a previous read.
+        if let Some(ref mut rb) = self.partial {
+            let remaining = &rb.data[rb.offset..];
+            let n = std::cmp::min(remaining.len(), buf.len());
+            buf[..n].copy_from_slice(&remaining[..n]);
+            rb.offset += n;
+            if rb.offset >= rb.data.len() {
+                self.partial = None;
+            }
+            return Ok(n);
+        }
+
+        // Wait for next chunk from the channel.
+        match self.rx.recv() {
+            Ok(data) => {
+                let n = std::cmp::min(data.len(), buf.len());
+                buf[..n].copy_from_slice(&data[..n]);
+                if n < data.len() {
+                    self.partial = Some(ReadBuffer { data, offset: n });
+                }
+                Ok(n)
+            }
+            Err(_) => Ok(0), // Channel closed = EOF
+        }
+    }
+}
+
+/// Synchronous writer forwarding data to the SSH channel.
+///
+/// Sends data to the async channel-forwarding task via a tokio mpsc channel.
+/// `blocking_send` bridges the sync/async boundary.
+pub struct ChannelWriter {
+    tx: tokio::sync::mpsc::Sender<Vec<u8>>,
+}
+
+impl std::io::Write for ChannelWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.tx
+            .blocking_send(buf.to_vec())
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::BrokenPipe, e))?;
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+/// Connects to a remote host via embedded SSH, authenticates, and executes
+/// a remote command. Returns synchronous `Read`/`Write` handles for the
+/// command's stdin/stdout.
+///
+/// This is the main entry point for the embedded SSH transport. The caller
+/// provides a fully configured `SshConfig` (with any CLI overrides applied)
+/// and the remote command string. The function:
+///
+/// 1. Creates a tokio current-thread runtime
+/// 2. Resolves the host via DNS
+/// 3. Establishes the SSH connection
+/// 4. Authenticates (agent, key files, password - in OpenSSH order)
+/// 5. Opens a session channel and executes the remote command
+/// 6. Spawns a background task to bridge async channel I/O to sync handles
+///
+/// # Arguments
+///
+/// * `ssh_config` - SSH connection parameters
+/// * `remote_command` - Shell command to execute on the remote host
+/// * `stdin_data` - Optional data to send over stdin immediately after exec
+///   (used for secluded-args delivery)
+///
+/// # Errors
+///
+/// Returns `SshError` for DNS resolution, connection, authentication,
+/// or channel errors.
+pub fn connect_and_exec(
+    ssh_config: &SshConfig,
+    remote_command: &str,
+    stdin_data: Option<&[u8]>,
+) -> Result<(ChannelReader, ChannelWriter), SshError> {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|e| SshError::Io(std::io::Error::other(format!("async runtime: {e}"))))?;
+
+    rt.block_on(connect_and_exec_async(
+        ssh_config,
+        remote_command,
+        stdin_data,
+    ))
+}
+
+/// Async implementation of `connect_and_exec`.
+async fn connect_and_exec_async(
+    ssh_config: &SshConfig,
+    remote_command: &str,
+    stdin_data: Option<&[u8]>,
+) -> Result<(ChannelReader, ChannelWriter), SshError> {
+    // Resolve host
+    let addrs = resolve_host(&ssh_config.host, ssh_config.port, ssh_config.ip_preference).await?;
+
+    let addr = addrs
+        .into_iter()
+        .next()
+        .ok_or_else(|| SshError::DnsResolution {
+            host: ssh_config.host.clone(),
+            preference: "any".to_owned(),
+        })?;
+
+    let client_config = Arc::new(russh::client::Config::default());
+
+    let handler = SshClientHandler::new(
+        ssh_config.host.clone(),
+        ssh_config.port,
+        ssh_config.strict_host_key_checking,
+        ssh_config.known_hosts_file.clone(),
+    );
+
+    // Connect with timeout
+    let mut handle = tokio::time::timeout(ssh_config.connect_timeout, async {
+        russh::client::connect(client_config, addr, handler).await
+    })
+    .await
+    .map_err(|_| SshError::Timeout {
+        secs: ssh_config.connect_timeout.as_secs(),
+    })??;
+
+    // Authenticate
+    authenticate(&mut handle, ssh_config).await?;
+
+    // Open session channel and exec
+    let channel = handle
+        .channel_open_session()
+        .await
+        .map_err(SshError::Connect)?;
+
+    channel
+        .exec(true, remote_command)
+        .await
+        .map_err(SshError::Connect)?;
+
+    // Set up sync/async bridge channels
+    let (data_tx, data_rx) = std::sync::mpsc::sync_channel::<Vec<u8>>(64);
+    let (write_tx, mut write_rx) = tokio::sync::mpsc::channel::<Vec<u8>>(64);
+
+    let channel_id = channel.id();
+    let mut channel_for_read = channel;
+
+    // We need a separate handle for writing data. Since Handle may not be
+    // Clone in russh 0.45, we share via Arc<Mutex<_>>.
+    let handle_shared = Arc::new(tokio::sync::Mutex::new(handle));
+    let handle_for_write = handle_shared.clone();
+
+    // Spawn a task to bridge async SSH channel I/O to sync channels.
+    tokio::spawn(async move {
+        loop {
+            tokio::select! {
+                msg = channel_for_read.wait() => {
+                    match msg {
+                        Some(russh::ChannelMsg::Data { data }) => {
+                            if data_tx.send(data.to_vec()).is_err() {
+                                break;
+                            }
+                        }
+                        Some(russh::ChannelMsg::Eof) | None => {
+                            break;
+                        }
+                        _ => continue,
+                    }
+                }
+                write_data = write_rx.recv() => {
+                    match write_data {
+                        Some(data) => {
+                            let h = handle_for_write.lock().await;
+                            if h.data(
+                                channel_id,
+                                russh::CryptoVec::from_slice(&data),
+                            )
+                            .await
+                            .is_err()
+                            {
+                                break;
+                            }
+                        }
+                        None => break,
+                    }
+                }
+            }
+        }
+    });
+
+    // Send initial stdin data (secluded args) if provided
+    if let Some(data) = stdin_data {
+        write_tx
+            .send(data.to_vec())
+            .await
+            .map_err(|e| SshError::Io(std::io::Error::new(std::io::ErrorKind::BrokenPipe, e)))?;
+    }
+
+    Ok((
+        ChannelReader {
+            rx: data_rx,
+            partial: None,
+        },
+        ChannelWriter { tx: write_tx },
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Read;
+
+    #[test]
+    fn channel_reader_eof_on_closed_channel() {
+        let (_, rx) = std::sync::mpsc::sync_channel::<Vec<u8>>(1);
+        let mut reader = ChannelReader { rx, partial: None };
+        let mut buf = [0u8; 64];
+        let n = reader.read(&mut buf).unwrap();
+        assert_eq!(n, 0);
+    }
+
+    #[test]
+    fn channel_reader_reads_full_chunk() {
+        let (tx, rx) = std::sync::mpsc::sync_channel::<Vec<u8>>(1);
+        tx.send(b"hello".to_vec()).unwrap();
+        drop(tx);
+
+        let mut reader = ChannelReader { rx, partial: None };
+        let mut buf = [0u8; 64];
+        let n = reader.read(&mut buf).unwrap();
+        assert_eq!(&buf[..n], b"hello");
+    }
+
+    #[test]
+    fn channel_reader_partial_read_buffers_remainder() {
+        let (tx, rx) = std::sync::mpsc::sync_channel::<Vec<u8>>(1);
+        tx.send(b"hello world".to_vec()).unwrap();
+        drop(tx);
+
+        let mut reader = ChannelReader { rx, partial: None };
+
+        let mut buf = [0u8; 5];
+        let n = reader.read(&mut buf).unwrap();
+        assert_eq!(n, 5);
+        assert_eq!(&buf[..n], b"hello");
+
+        let mut buf2 = [0u8; 64];
+        let n2 = reader.read(&mut buf2).unwrap();
+        assert_eq!(&buf2[..n2], b" world");
+    }
+
+    #[test]
+    fn channel_writer_broken_pipe_on_closed_receiver() {
+        // Create the channel outside any runtime - ChannelWriter::write uses
+        // blocking_send which cannot be called from within a tokio runtime.
+        let (tx, rx) = tokio::sync::mpsc::channel::<Vec<u8>>(1);
+        drop(rx);
+
+        let mut writer = ChannelWriter { tx };
+        let result = std::io::Write::write(&mut writer, b"data");
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().kind(), std::io::ErrorKind::BrokenPipe);
+    }
+}

--- a/crates/rsync_io/src/ssh/embedded/mod.rs
+++ b/crates/rsync_io/src/ssh/embedded/mod.rs
@@ -11,6 +11,8 @@ mod auth;
 #[cfg(feature = "embedded-ssh")]
 mod config;
 #[cfg(feature = "embedded-ssh")]
+mod connect;
+#[cfg(feature = "embedded-ssh")]
 mod error;
 #[cfg(feature = "embedded-ssh")]
 mod handler;
@@ -23,6 +25,8 @@ mod types;
 pub use auth::authenticate;
 #[cfg(feature = "embedded-ssh")]
 pub use config::SshConfig;
+#[cfg(feature = "embedded-ssh")]
+pub use connect::{ChannelReader, ChannelWriter, connect_and_exec};
 #[cfg(feature = "embedded-ssh")]
 pub use error::SshError;
 #[cfg(feature = "embedded-ssh")]


### PR DESCRIPTION
## Summary

- Add dispatch logic in `run_client_internal` to detect `ssh://` URLs and route transfers through the embedded russh-based SSH transport instead of spawning the system `ssh` binary
- Add `EmbeddedSshOptions` config struct with builder support for cipher selection, connection timeout, keepalive, identity files, agent toggle, host key checking, IPv6 preference, and port override
- Add `embedded_ssh_transfer` module in `core::client::remote` with URL parsing, push/pull dispatch, server config construction, and progress bridging
- Add `connect_and_exec` in `rsync_io::ssh::embedded` providing synchronous `Read`/`Write` handles over async SSH channels via tokio mpsc bridging
- Entire feature gated behind `embedded-ssh` feature flag - compiles cleanly with and without on all platforms

## Test plan

- [x] Clippy passes on both `core` and `rsync_io` with and without `embedded-ssh` feature
- [x] Formatting passes (`cargo fmt --all -- --check`)
- [x] 24 embedded SSH unit tests pass in `core` (URL parsing, CLI overrides, shell escaping, command construction, operand parsing)
- [x] 4 channel I/O tests pass in `rsync_io` (reader EOF, full read, partial buffering, writer broken pipe)
- [ ] CI: fmt+clippy, nextest (stable), Windows, macOS, Linux musl