### PR TITLE
docs: add rustdoc and #[must_use] to engine public API

### DIFF
--- a/crates/compress/tests/zlib_ng_backend.rs
+++ b/crates/compress/tests/zlib_ng_backend.rs
@@ -92,7 +92,10 @@ fn zlib_ng_handles_incompressible_data() {
         compress_to_vec(&payload, CompressionLevel::Best).expect("compress incompressible");
 
     let decompressed = decompress_to_vec(&compressed).expect("decompress incompressible");
-    assert_eq!(decompressed, payload, "incompressible data roundtrip failed");
+    assert_eq!(
+        decompressed, payload,
+        "incompressible data roundtrip failed"
+    );
 }
 
 #[test]

--- a/crates/engine/src/async_io/error.rs
+++ b/crates/engine/src/async_io/error.rs
@@ -29,6 +29,7 @@ pub enum AsyncIoError {
 
 impl AsyncIoError {
     /// Creates an I/O error with path context.
+    #[must_use]
     pub fn io(path: impl Into<PathBuf>, source: io::Error) -> Self {
         Self::Io {
             path: path.into(),

--- a/crates/engine/src/concurrent_delta/consumer.rs
+++ b/crates/engine/src/concurrent_delta/consumer.rs
@@ -201,6 +201,7 @@ impl DeltaConsumer {
     ///
     /// Useful for polling from a pipeline loop where blocking would stall
     /// the producer.
+    #[must_use]
     pub fn try_recv(&self) -> Option<DeltaResult> {
         self.result_rx.try_recv().ok()
     }
@@ -210,6 +211,7 @@ impl DeltaConsumer {
     /// The iterator blocks waiting for the next result and terminates when
     /// all results have been delivered (the background thread finishes and
     /// the internal channel closes).
+    #[must_use]
     pub fn iter(&self) -> DeltaConsumerIter<'_> {
         DeltaConsumerIter {
             rx: &self.result_rx,

--- a/crates/engine/src/hardlink.rs
+++ b/crates/engine/src/hardlink.rs
@@ -256,6 +256,7 @@ impl HardlinkTracker {
     ///
     /// - `Some(source_index)` if this file should be linked to `source_index`
     /// - `None` if this file should be transferred normally or was never registered
+    #[must_use]
     pub fn get_hardlink_target(&self, file_index: i32) -> Option<i32> {
         match self.resolve(file_index) {
             HardlinkAction::LinkTo(target) => Some(target),

--- a/crates/engine/src/local_copy/error.rs
+++ b/crates/engine/src/local_copy/error.rs
@@ -210,6 +210,7 @@ pub enum LocalCopyErrorKind {
 
 impl LocalCopyErrorKind {
     /// Returns the action, path, and source error for [`LocalCopyErrorKind::Io`] values.
+    #[must_use]
     pub fn as_io(&self) -> Option<(&'static str, &Path, &io::Error)> {
         match self {
             Self::Io {

--- a/crates/engine/src/local_copy/executor/file/backup.rs
+++ b/crates/engine/src/local_copy/executor/file/backup.rs
@@ -21,6 +21,7 @@ use crate::local_copy::create_symlink;
 /// # Upstream Reference
 ///
 /// - `backup.c:get_backup_name()` - path computation for backup files
+#[must_use]
 pub fn compute_backup_path(
     destination_root: &Path,
     destination: &Path,

--- a/crates/engine/src/local_copy/executor/file/guard.rs
+++ b/crates/engine/src/local_copy/executor/file/guard.rs
@@ -246,6 +246,7 @@ impl DestinationWriteGuard {
     ///
     /// For named temp files this is the on-disk temp path. For anonymous files
     /// this returns the final destination path since no intermediate path exists.
+    #[must_use]
     pub fn staging_path(&self) -> &Path {
         match &self.strategy {
             GuardStrategy::NamedTempFile { temp_path, .. } => temp_path,
@@ -362,18 +363,21 @@ impl DestinationWriteGuard {
     /// Returns the final destination path.
     ///
     /// This is the path where the file will be located after calling [`commit`](Self::commit).
+    #[must_use]
     pub fn final_path(&self) -> &Path {
         &self.final_path
     }
 
     /// Returns `true` if this guard uses the anonymous `O_TMPFILE` strategy.
     #[cfg(target_os = "linux")]
+    #[must_use]
     pub fn is_anonymous(&self) -> bool {
         matches!(self.strategy, GuardStrategy::Anonymous { .. })
     }
 
     /// Returns `true` if this guard uses the anonymous `O_TMPFILE` strategy.
     #[cfg(not(target_os = "linux"))]
+    #[must_use]
     pub fn is_anonymous(&self) -> bool {
         false
     }

--- a/crates/engine/src/local_copy/executor/file/partial.rs
+++ b/crates/engine/src/local_copy/executor/file/partial.rs
@@ -87,6 +87,7 @@ impl PartialMode {
     }
 
     /// Returns the partial directory path if this mode uses one.
+    #[must_use]
     pub fn partial_dir_path(&self) -> Option<&Path> {
         match self {
             Self::PartialDir(path) => Some(path),
@@ -208,6 +209,7 @@ impl PartialFileManager {
     }
 
     /// Returns the partial directory path if using `PartialMode::PartialDir`.
+    #[must_use]
     pub fn partial_dir(&self) -> Option<&Path> {
         self.mode.partial_dir_path()
     }

--- a/crates/engine/src/local_copy/executor/file/sparse/detect.rs
+++ b/crates/engine/src/local_copy/executor/file/sparse/detect.rs
@@ -38,11 +38,13 @@ impl SparseDetector {
     /// # Arguments
     ///
     /// * `min_hole_size` - Minimum number of consecutive zero bytes to treat as a hole
+    #[must_use]
     pub const fn new(min_hole_size: usize) -> Self {
         Self { min_hole_size }
     }
 
     /// Creates a detector with the default threshold matching rsync's behavior.
+    #[must_use]
     pub const fn default_threshold() -> Self {
         Self::new(SPARSE_WRITE_SIZE)
     }
@@ -62,6 +64,7 @@ impl SparseDetector {
     ///
     /// A vector of `SparseRegion` entries describing the data and hole regions.
     /// An empty input buffer returns an empty vector.
+    #[must_use]
     pub fn scan(&self, data: &[u8], base_offset: u64) -> Vec<SparseRegion> {
         if data.is_empty() {
             return Vec::new();
@@ -137,6 +140,7 @@ impl SparseDetector {
     ///
     /// `true` if all bytes in the buffer are zero, `false` otherwise.
     /// An empty buffer returns `true`.
+    #[must_use]
     pub fn is_all_zeros(data: &[u8]) -> bool {
         fast_io::zero_detect::is_all_zeros(data)
     }

--- a/crates/engine/src/local_copy/executor/file/sparse/mod.rs
+++ b/crates/engine/src/local_copy/executor/file/sparse/mod.rs
@@ -48,6 +48,7 @@ pub enum SparseRegion {
 
 impl SparseRegion {
     /// Returns the starting offset of this region.
+    #[must_use]
     pub const fn offset(&self) -> u64 {
         match self {
             Self::Data { offset, .. } | Self::Hole { offset, .. } => *offset,
@@ -55,6 +56,7 @@ impl SparseRegion {
     }
 
     /// Returns the length of this region in bytes.
+    #[must_use]
     pub const fn length(&self) -> u64 {
         match self {
             Self::Data { length, .. } | Self::Hole { length, .. } => *length,
@@ -62,11 +64,13 @@ impl SparseRegion {
     }
 
     /// Returns true if this is a hole (sparse) region.
+    #[must_use]
     pub const fn is_hole(&self) -> bool {
         matches!(self, Self::Hole { .. })
     }
 
     /// Returns true if this is a data region.
+    #[must_use]
     pub const fn is_data(&self) -> bool {
         matches!(self, Self::Data { .. })
     }

--- a/crates/engine/src/local_copy/executor/file/sparse/writer.rs
+++ b/crates/engine/src/local_copy/executor/file/sparse/writer.rs
@@ -44,6 +44,7 @@ impl SparseWriter {
     ///
     /// * `file` - The file to write to
     /// * `sparse_enabled` - Whether to create sparse holes for zero regions
+    #[must_use]
     pub fn new(file: fs::File, sparse_enabled: bool) -> Self {
         Self {
             file,

--- a/crates/engine/src/local_copy/plan/metadata.rs
+++ b/crates/engine/src/local_copy/plan/metadata.rs
@@ -137,31 +137,37 @@ impl LocalCopyMetadata {
     }
 
     /// Returns the recorded modification time, when available.
+    #[must_use]
     pub const fn modified(&self) -> Option<SystemTime> {
         self.modified
     }
 
     /// Returns the Unix permission bits when available.
+    #[must_use]
     pub const fn mode(&self) -> Option<u32> {
         self.mode
     }
 
     /// Returns the numeric owner identifier when available.
+    #[must_use]
     pub const fn uid(&self) -> Option<u32> {
         self.uid
     }
 
     /// Returns the numeric group identifier when available.
+    #[must_use]
     pub const fn gid(&self) -> Option<u32> {
         self.gid
     }
 
     /// Returns the hard link count when available.
+    #[must_use]
     pub const fn nlink(&self) -> Option<u64> {
         self.nlink
     }
 
     /// Returns the recorded symbolic link target when the metadata describes a symlink.
+    #[must_use]
     pub fn symlink_target(&self) -> Option<&Path> {
         self.symlink_target.as_deref()
     }

--- a/crates/engine/src/local_copy/plan/record.rs
+++ b/crates/engine/src/local_copy/plan/record.rs
@@ -64,6 +64,7 @@ impl LocalCopyRecord {
     }
 
     /// Returns the total number of bytes expected for this record, when known.
+    #[must_use]
     pub const fn total_bytes(&self) -> Option<u64> {
         self.total_bytes
     }
@@ -75,6 +76,7 @@ impl LocalCopyRecord {
     }
 
     /// Returns the metadata snapshot associated with this record, when available.
+    #[must_use]
     pub const fn metadata(&self) -> Option<&LocalCopyMetadata> {
         self.metadata.as_ref()
     }

--- a/crates/engine/src/local_copy/skip_compress.rs
+++ b/crates/engine/src/local_copy/skip_compress.rs
@@ -60,6 +60,7 @@ impl SkipCompressList {
     }
 
     /// Returns `true` when the provided path's extension matches a skipped suffix.
+    #[must_use]
     pub fn matches_path(&self, path: &Path) -> bool {
         if self.patterns.is_empty() {
             return false;
@@ -76,6 +77,7 @@ impl SkipCompressList {
     }
 
     /// Returns `true` if no suffixes are configured.
+    #[must_use]
     pub const fn is_empty(&self) -> bool {
         self.patterns.is_empty()
     }

--- a/crates/engine/src/walk/config.rs
+++ b/crates/engine/src/walk/config.rs
@@ -151,6 +151,7 @@ impl WalkConfig {
     }
 
     /// Returns the maximum depth, if set.
+    #[must_use]
     pub const fn get_max_depth(&self) -> Option<NonZeroUsize> {
         self.max_depth
     }

--- a/crates/engine/src/walk/entry.rs
+++ b/crates/engine/src/walk/entry.rs
@@ -54,6 +54,7 @@ impl WalkEntry {
     /// Returns the file name of this entry.
     ///
     /// Returns `None` if the path terminates in `..` or is the root.
+    #[must_use]
     pub fn file_name(&self) -> Option<&std::ffi::OsStr> {
         self.path.file_name()
     }

--- a/crates/engine/src/walk/error.rs
+++ b/crates/engine/src/walk/error.rs
@@ -68,6 +68,7 @@ impl WalkError {
     }
 
     /// Returns the path where the error occurred, if available.
+    #[must_use]
     pub fn path(&self) -> Option<&PathBuf> {
         match self {
             Self::Io { path, .. } | Self::Loop { path, .. } => Some(path),


### PR DESCRIPTION
## Summary

- Add missing `#[must_use]` annotations to 30+ public functions and methods across the engine crate that return values without side effects
- Covers modules: `walk` (entry, config, error), `hardlink`, `concurrent_delta/consumer`, `local_copy` (error, skip_compress, metadata, record, sparse, guard, partial, backup), and `async_io/error`
- All public items already had rustdoc (`#![deny(missing_docs)]` is enforced crate-wide)
- No logic or behavior changes

## Test plan

- [x] `cargo fmt --all` passes
- [x] `cargo clippy -p engine --all-features --no-deps -- -D warnings` passes with zero warnings
- [ ] CI: fmt+clippy, nextest, Windows, macOS, Linux musl