### PR TITLE
test: add comprehensive SHA-1/256/512 coverage

### DIFF
--- a/crates/checksums/src/strong/sha1.rs
+++ b/crates/checksums/src/strong/sha1.rs
@@ -127,4 +127,126 @@ mod tests {
             assert_eq!(to_hex(&one_shot), expected_hex);
         }
     }
+
+    #[test]
+    fn empty_input_known_hash() {
+        let digest = Sha1::digest(b"");
+        assert_eq!(to_hex(&digest), "da39a3ee5e6b4b0d3255bfef95601890afd80709");
+    }
+
+    #[test]
+    fn abc_known_hash() {
+        let digest = Sha1::digest(b"abc");
+        assert_eq!(to_hex(&digest), "a9993e364706816aba3e25717850c26c9cd0d89d");
+    }
+
+    #[test]
+    fn streaming_matches_one_shot() {
+        let data = b"The quick brown fox jumps over the lazy dog";
+
+        let one_shot = Sha1::digest(data);
+
+        let mut hasher = Sha1::new();
+        hasher.update(&data[..10]);
+        hasher.update(&data[10..20]);
+        hasher.update(&data[20..]);
+        let streaming = hasher.finalize();
+
+        assert_eq!(one_shot, streaming);
+    }
+
+    #[test]
+    fn byte_at_a_time_matches_one_shot() {
+        let data = b"incremental SHA-1 input";
+        let expected = Sha1::digest(data);
+
+        let mut hasher = Sha1::new();
+        for &byte in data.iter() {
+            hasher.update(&[byte]);
+        }
+        assert_eq!(hasher.finalize(), expected);
+    }
+
+    #[test]
+    fn different_data_different_hashes() {
+        assert_ne!(Sha1::digest(b"aaa"), Sha1::digest(b"bbb"));
+    }
+
+    #[test]
+    fn large_data_consistent() {
+        // Exercise the hash with > 1 MiB of cyclic data to walk multiple
+        // 64-byte SHA-1 compression blocks and verify deterministic output.
+        let data: Vec<u8> = (0u8..=255).cycle().take(1024 * 1024 + 17).collect();
+        let first = Sha1::digest(&data);
+        let second = Sha1::digest(&data);
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn incremental_chunks_consistent() {
+        let data: Vec<u8> = (0u8..=255).cycle().take(8192).collect();
+        let expected = Sha1::digest(&data);
+
+        for chunk_size in [1usize, 7, 13, 64, 1000] {
+            let mut hasher = Sha1::new();
+            for chunk in data.chunks(chunk_size) {
+                hasher.update(chunk);
+            }
+            assert_eq!(hasher.finalize(), expected, "chunk_size={chunk_size}");
+        }
+    }
+
+    #[test]
+    fn hash_function_is_deterministic() {
+        let data = b"deterministic input";
+        assert_eq!(Sha1::digest(data), Sha1::digest(data));
+    }
+
+    #[test]
+    fn default_trait_matches_new() {
+        let a = Sha1::new().finalize();
+        let b = Sha1::default().finalize();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn clone_preserves_state() {
+        let mut hasher = Sha1::new();
+        hasher.update(b"partial state");
+        let cloned = hasher.clone();
+
+        assert_eq!(hasher.finalize(), cloned.finalize());
+    }
+
+    #[test]
+    fn length_extension_protection() {
+        // hash(empty) must differ from hash([0u8]) - a single null byte is not
+        // the same as no input.
+        assert_ne!(Sha1::digest(b""), Sha1::digest(&[0u8]));
+    }
+
+    #[test]
+    fn hex_output_format_matches_lowercase() {
+        let digest = Sha1::digest(b"abc");
+        let hex = to_hex(&digest);
+        assert_eq!(hex.len(), 40);
+        assert!(hex.chars().all(|c| c.is_ascii_hexdigit()));
+        assert!(hex.chars().all(|c| !c.is_ascii_uppercase()));
+    }
+
+    #[test]
+    fn strong_digest_trait_matches_inherent_api() {
+        let data = b"trait dispatch parity";
+
+        let inherent = Sha1::digest(data);
+        let via_trait = <Sha1 as StrongDigest>::digest(data);
+        assert_eq!(inherent, via_trait);
+
+        let mut hasher = <Sha1 as StrongDigest>::with_seed(());
+        StrongDigest::update(&mut hasher, data);
+        let trait_streaming = StrongDigest::finalize(hasher);
+        assert_eq!(trait_streaming, inherent);
+
+        assert_eq!(<Sha1 as StrongDigest>::DIGEST_LEN, 20);
+    }
 }

--- a/crates/checksums/src/strong/sha256.rs
+++ b/crates/checksums/src/strong/sha256.rs
@@ -130,4 +130,129 @@ mod tests {
             assert_eq!(to_hex(&one_shot), expected_hex);
         }
     }
+
+    #[test]
+    fn empty_input_known_hash() {
+        let digest = Sha256::digest(b"");
+        assert_eq!(
+            to_hex(&digest),
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+    }
+
+    #[test]
+    fn abc_known_hash() {
+        let digest = Sha256::digest(b"abc");
+        assert_eq!(
+            to_hex(&digest),
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
+    }
+
+    #[test]
+    fn streaming_matches_one_shot() {
+        let data = b"The quick brown fox jumps over the lazy dog";
+
+        let one_shot = Sha256::digest(data);
+
+        let mut hasher = Sha256::new();
+        hasher.update(&data[..10]);
+        hasher.update(&data[10..20]);
+        hasher.update(&data[20..]);
+        let streaming = hasher.finalize();
+
+        assert_eq!(one_shot, streaming);
+    }
+
+    #[test]
+    fn byte_at_a_time_matches_one_shot() {
+        let data = b"incremental SHA-256 input";
+        let expected = Sha256::digest(data);
+
+        let mut hasher = Sha256::new();
+        for &byte in data.iter() {
+            hasher.update(&[byte]);
+        }
+        assert_eq!(hasher.finalize(), expected);
+    }
+
+    #[test]
+    fn different_data_different_hashes() {
+        assert_ne!(Sha256::digest(b"aaa"), Sha256::digest(b"bbb"));
+    }
+
+    #[test]
+    fn large_data_consistent() {
+        // Walk the 64-byte SHA-256 compression function across many blocks.
+        let data: Vec<u8> = (0u8..=255).cycle().take(1024 * 1024 + 17).collect();
+        let first = Sha256::digest(&data);
+        let second = Sha256::digest(&data);
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn incremental_chunks_consistent() {
+        let data: Vec<u8> = (0u8..=255).cycle().take(8192).collect();
+        let expected = Sha256::digest(&data);
+
+        for chunk_size in [1usize, 7, 13, 64, 1000] {
+            let mut hasher = Sha256::new();
+            for chunk in data.chunks(chunk_size) {
+                hasher.update(chunk);
+            }
+            assert_eq!(hasher.finalize(), expected, "chunk_size={chunk_size}");
+        }
+    }
+
+    #[test]
+    fn hash_function_is_deterministic() {
+        let data = b"deterministic input";
+        assert_eq!(Sha256::digest(data), Sha256::digest(data));
+    }
+
+    #[test]
+    fn default_trait_matches_new() {
+        let a = Sha256::new().finalize();
+        let b = Sha256::default().finalize();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn clone_preserves_state() {
+        let mut hasher = Sha256::new();
+        hasher.update(b"partial state");
+        let cloned = hasher.clone();
+
+        assert_eq!(hasher.finalize(), cloned.finalize());
+    }
+
+    #[test]
+    fn length_extension_protection() {
+        assert_ne!(Sha256::digest(b""), Sha256::digest(&[0u8]));
+    }
+
+    #[test]
+    fn hex_output_format_matches_lowercase() {
+        let digest = Sha256::digest(b"abc");
+        let hex = to_hex(&digest);
+        assert_eq!(hex.len(), 64);
+        assert!(hex.chars().all(|c| c.is_ascii_hexdigit()));
+        assert!(hex.chars().all(|c| !c.is_ascii_uppercase()));
+    }
+
+    #[test]
+    fn strong_digest_trait_matches_inherent_api() {
+        let data = b"trait dispatch parity";
+
+        let inherent = Sha256::digest(data);
+        let via_trait = <Sha256 as StrongDigest>::digest(data);
+        assert_eq!(inherent, via_trait);
+
+        let mut hasher = <Sha256 as StrongDigest>::with_seed(());
+        StrongDigest::update(&mut hasher, data);
+        let trait_streaming = StrongDigest::finalize(hasher);
+        assert_eq!(trait_streaming, inherent);
+
+        assert_eq!(<Sha256 as StrongDigest>::DIGEST_LEN, 32);
+    }
 }

--- a/crates/checksums/src/strong/sha512.rs
+++ b/crates/checksums/src/strong/sha512.rs
@@ -129,4 +129,129 @@ mod tests {
             assert_eq!(to_hex(&one_shot), expected_hex);
         }
     }
+
+    #[test]
+    fn empty_input_known_hash() {
+        let digest = Sha512::digest(b"");
+        assert_eq!(
+            to_hex(&digest),
+            "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e"
+        );
+    }
+
+    #[test]
+    fn abc_known_hash() {
+        let digest = Sha512::digest(b"abc");
+        assert_eq!(
+            to_hex(&digest),
+            "ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f"
+        );
+    }
+
+    #[test]
+    fn streaming_matches_one_shot() {
+        let data = b"The quick brown fox jumps over the lazy dog";
+
+        let one_shot = Sha512::digest(data);
+
+        let mut hasher = Sha512::new();
+        hasher.update(&data[..10]);
+        hasher.update(&data[10..20]);
+        hasher.update(&data[20..]);
+        let streaming = hasher.finalize();
+
+        assert_eq!(one_shot, streaming);
+    }
+
+    #[test]
+    fn byte_at_a_time_matches_one_shot() {
+        let data = b"incremental SHA-512 input";
+        let expected = Sha512::digest(data);
+
+        let mut hasher = Sha512::new();
+        for &byte in data.iter() {
+            hasher.update(&[byte]);
+        }
+        assert_eq!(hasher.finalize(), expected);
+    }
+
+    #[test]
+    fn different_data_different_hashes() {
+        assert_ne!(Sha512::digest(b"aaa"), Sha512::digest(b"bbb"));
+    }
+
+    #[test]
+    fn large_data_consistent() {
+        // Walk the 128-byte SHA-512 compression function across many blocks.
+        let data: Vec<u8> = (0u8..=255).cycle().take(1024 * 1024 + 17).collect();
+        let first = Sha512::digest(&data);
+        let second = Sha512::digest(&data);
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn incremental_chunks_consistent() {
+        let data: Vec<u8> = (0u8..=255).cycle().take(8192).collect();
+        let expected = Sha512::digest(&data);
+
+        for chunk_size in [1usize, 7, 13, 128, 1000] {
+            let mut hasher = Sha512::new();
+            for chunk in data.chunks(chunk_size) {
+                hasher.update(chunk);
+            }
+            assert_eq!(hasher.finalize(), expected, "chunk_size={chunk_size}");
+        }
+    }
+
+    #[test]
+    fn hash_function_is_deterministic() {
+        let data = b"deterministic input";
+        assert_eq!(Sha512::digest(data), Sha512::digest(data));
+    }
+
+    #[test]
+    fn default_trait_matches_new() {
+        let a = Sha512::new().finalize();
+        let b = Sha512::default().finalize();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn clone_preserves_state() {
+        let mut hasher = Sha512::new();
+        hasher.update(b"partial state");
+        let cloned = hasher.clone();
+
+        assert_eq!(hasher.finalize(), cloned.finalize());
+    }
+
+    #[test]
+    fn length_extension_protection() {
+        assert_ne!(Sha512::digest(b""), Sha512::digest(&[0u8]));
+    }
+
+    #[test]
+    fn hex_output_format_matches_lowercase() {
+        let digest = Sha512::digest(b"abc");
+        let hex = to_hex(&digest);
+        assert_eq!(hex.len(), 128);
+        assert!(hex.chars().all(|c| c.is_ascii_hexdigit()));
+        assert!(hex.chars().all(|c| !c.is_ascii_uppercase()));
+    }
+
+    #[test]
+    fn strong_digest_trait_matches_inherent_api() {
+        let data = b"trait dispatch parity";
+
+        let inherent = Sha512::digest(data);
+        let via_trait = <Sha512 as StrongDigest>::digest(data);
+        assert_eq!(inherent, via_trait);
+
+        let mut hasher = <Sha512 as StrongDigest>::with_seed(());
+        StrongDigest::update(&mut hasher, data);
+        let trait_streaming = StrongDigest::finalize(hasher);
+        assert_eq!(trait_streaming, inherent);
+
+        assert_eq!(<Sha512 as StrongDigest>::DIGEST_LEN, 64);
+    }
 }


### PR DESCRIPTION
## Summary
- Adds 12 inline tests to each of `Sha1`, `Sha256`, `Sha512` wrappers in `crates/checksums/src/strong/` (1 -> 13 each).
- Mirrors the CRC32C test pattern landed in #3378.
- Tests use only the existing public API; no production code touched.

## Coverage added per module
- FIPS-180-4 known vectors for empty input and `"abc"`
- Streaming vs one-shot parity
- Byte-at-a-time `update()` parity
- 1 MiB+ cyclic-data determinism
- Varied chunk-size incremental hashing
- `Default` trait equivalence
- `Clone` state preservation mid-stream
- Length-extension sanity (`hash("") != hash(&[0u8])`)
- Lowercase hex output format
- `StrongDigest` trait dispatch parity (including `DIGEST_LEN` 20/32/64)

## Test plan
- [ ] `cargo nextest run -p checksums --all-features` (CI)
- [ ] llvm-cov reports increased coverage for `crates/checksums/src/strong/sha*.rs`