### PR TITLE
fix(ci): use nightly toolchain for branch coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -30,6 +30,9 @@ env:
   CARGO_INCREMENTAL: "0"
   RUST_BACKTRACE: "full"
   CACHE_VERSION: ${{ vars.CACHE_VERSION || 'v1' }}
+  # Override rust-toolchain.toml (which pins 1.88.0) so cargo-llvm-cov can use
+  # the unstable -Z coverage-options=branch flag, which requires nightly.
+  RUSTUP_TOOLCHAIN: nightly
 
 jobs:
   coverage:


### PR DESCRIPTION
## Summary
- Coverage workflow uses `cargo llvm-cov --branch` which compiles with unstable `-Z coverage-options=branch`, requiring nightly.
- The workflow installs nightly via `rust-toolchain` action, but `rust-toolchain.toml` pins 1.88.0 stable, which overrides the install when cargo-llvm-cov spawns rustc.
- Setting `RUSTUP_TOOLCHAIN=nightly` at the env level forces nightly for cargo-llvm-cov invocations, fixing the failing Coverage workflow.

## Why this is breaking
PRs #3377, #3378, #3381 (and others) all see `Coverage / llvm-cov` fail with:
```
error: the option `Z` is only accepted on the nightly compiler
help: consider switching to a nightly toolchain: `rustup default nightly`
```

## Test plan
- [ ] Coverage workflow on this PR completes successfully and reports line + branch coverage.
- [ ] Existing fmt+clippy/nextest checks remain green.