### PR TITLE
feat: enable SHA-NI auto-detection for SHA-256 hashing

### DIFF
--- a/crates/checksums/Cargo.toml
+++ b/crates/checksums/Cargo.toml
@@ -35,8 +35,6 @@ openssl-vendored = ["openssl", "openssl/vendored"]
 [dependencies]
 md4 = { version = "0.10", default-features = false, features = ["std"] }
 digest = { version = "0.10", default-features = false, features = ["std"] }
-sha1 = { version = "0.10", default-features = false, features = ["std"] }
-sha2 = { version = "0.10", default-features = false, features = ["std"] }
 xxhash-rust = { version = "0.8", default-features = false, features = ["xxh64", "xxh3"] }
 # xxh3 crate provides runtime SIMD detection (AVX2 on x86_64, NEON on aarch64)
 xxh3 = { version = "0.1" }
@@ -47,12 +45,19 @@ rayon = { version = "1.10" }
 fast_io = { path = "../fast_io", default-features = false }
 logging = { path = "../logging" }
 
-# md5-asm requires NASM on Windows and fails under MSVC; enable asm only on unix
+# *-asm crates require NASM on Windows and fail under MSVC; enable asm only on unix.
+# On unix, the `asm` feature on sha1/sha2 enables sha2-asm which provides assembly
+# fallbacks; the pure-Rust backend already auto-detects SHA-NI (x86_64) and
+# crypto extensions (aarch64) via `cpufeatures` regardless of this feature.
 [target.'cfg(unix)'.dependencies]
 md-5 = { version = "0.10", default-features = false, features = ["std", "asm"] }
+sha1 = { version = "0.10", default-features = false, features = ["std", "asm"] }
+sha2 = { version = "0.10", default-features = false, features = ["std", "asm"] }
 
 [target.'cfg(not(unix))'.dependencies]
 md-5 = { version = "0.10", default-features = false, features = ["std"] }
+sha1 = { version = "0.10", default-features = false, features = ["std"] }
+sha2 = { version = "0.10", default-features = false, features = ["std"] }
 
 [dev-dependencies]
 proptest = "1.4"

--- a/crates/checksums/src/strong/mod.rs
+++ b/crates/checksums/src/strong/mod.rs
@@ -94,8 +94,15 @@ pub const fn openssl_acceleration_available() -> bool {
 
 /// Streaming SHA-1 hasher (160-bit output).
 pub use sha1::Sha1;
-/// Streaming SHA-256 hasher (256-bit output).
-pub use sha256::Sha256;
+/// Streaming SHA-256 hasher (256-bit output) and runtime hardware acceleration
+/// query.
+///
+/// - [`Sha256`] -- streaming hasher with automatic SHA-NI (x86_64) and ARMv8
+///   crypto extension (aarch64) detection via the `sha2` crate's `cpufeatures`
+///   integration.
+/// - [`sha256_hardware_acceleration_available`] -- reports whether the running
+///   CPU exposes SHA-256 hardware acceleration on the current architecture.
+pub use sha256::{Sha256, sha256_hardware_acceleration_available};
 /// Streaming SHA-512 hasher (512-bit output).
 pub use sha512::Sha512;
 /// XXHash streaming hashers and runtime SIMD detection query.

--- a/crates/checksums/src/strong/sha256.rs
+++ b/crates/checksums/src/strong/sha256.rs
@@ -6,8 +6,27 @@ use super::StrongDigest;
 ///
 /// SHA-256 produces a 256-bit (32-byte) digest and is cryptographically
 /// secure. It is used for daemon authentication and high-security transfers.
-/// Hardware acceleration via SHA-NI (x86_64) or crypto extensions (aarch64)
-/// is used automatically when compiled with appropriate target features.
+///
+/// # Hardware Acceleration
+///
+/// The `sha2` crate auto-detects hardware SHA acceleration at runtime via
+/// the `cpufeatures` crate:
+///
+/// - **x86_64**: SHA-NI (Intel SHA Extensions, AMD Zen) when the `sha`,
+///   `sse2`, `ssse3`, and `sse4.1` CPU features are present.
+/// - **aarch64**: ARMv8 Cryptography Extensions (`sha2`) when present.
+/// - **Other architectures**: software fallback only.
+///
+/// Detection happens automatically on the first hash operation and is cached
+/// internally by `cpufeatures`. No `RUSTFLAGS` or compile-time target features
+/// are required: a single binary picks the fastest backend at runtime on every
+/// host. On Unix targets the `asm` feature is enabled to provide an additional
+/// hand-tuned assembly fallback for hosts without SHA-NI; Windows builds use
+/// the pure-Rust backend because the `sha2-asm` build script depends on NASM
+/// and fails under MSVC.
+///
+/// Runtime availability can be queried via
+/// [`sha256_hardware_acceleration_available`].
 ///
 /// # Examples
 ///
@@ -87,6 +106,49 @@ impl StrongDigest for Sha256 {
     }
 }
 
+/// Returns `true` when the running CPU exposes SHA-256 hardware acceleration.
+///
+/// This mirrors the runtime detection performed by the `sha2` crate's
+/// `cpufeatures` integration:
+///
+/// - **x86_64**: returns `true` if the CPU advertises Intel SHA Extensions
+///   (`sha`) together with the `sse2`, `ssse3`, and `sse4.1` baseline that
+///   `sha2` requires for its accelerated backend.
+/// - **aarch64**: returns `true` if the CPU advertises the ARMv8 `sha2`
+///   crypto extension.
+/// - **Other architectures**: always returns `false`.
+///
+/// The result reflects the actual capability of the host CPU, regardless of
+/// any compile-time target features. Use this to verify that a deployment
+/// is benefiting from hardware acceleration or to select instrumentation in
+/// benchmarks.
+///
+/// # Examples
+///
+/// ```
+/// use checksums::strong::sha256_hardware_acceleration_available;
+///
+/// let _accelerated = sha256_hardware_acceleration_available();
+/// ```
+#[must_use]
+pub fn sha256_hardware_acceleration_available() -> bool {
+    #[cfg(target_arch = "x86_64")]
+    {
+        std::arch::is_x86_feature_detected!("sha")
+            && std::arch::is_x86_feature_detected!("sse2")
+            && std::arch::is_x86_feature_detected!("ssse3")
+            && std::arch::is_x86_feature_detected!("sse4.1")
+    }
+    #[cfg(target_arch = "aarch64")]
+    {
+        std::arch::is_aarch64_feature_detected!("sha2")
+    }
+    #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
+    {
+        false
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -129,5 +191,68 @@ mod tests {
             let one_shot = Sha256::digest(input);
             assert_eq!(to_hex(&one_shot), expected_hex);
         }
+    }
+
+    #[test]
+    fn hardware_detection_query_is_consistent() {
+        let first = sha256_hardware_acceleration_available();
+        let second = sha256_hardware_acceleration_available();
+        assert_eq!(
+            first, second,
+            "hardware detection must be deterministic across calls"
+        );
+    }
+
+    #[test]
+    #[cfg(target_arch = "x86_64")]
+    fn x86_64_detection_implies_sha_extension() {
+        if sha256_hardware_acceleration_available() {
+            assert!(
+                std::arch::is_x86_feature_detected!("sha"),
+                "SHA-NI must be present whenever hardware acceleration is reported on x86_64"
+            );
+        }
+    }
+
+    #[test]
+    #[cfg(target_arch = "aarch64")]
+    fn aarch64_detection_implies_sha2_extension() {
+        if sha256_hardware_acceleration_available() {
+            assert!(
+                std::arch::is_aarch64_feature_detected!("sha2"),
+                "ARMv8 sha2 extension must be present whenever hardware acceleration is reported on aarch64"
+            );
+        }
+    }
+
+    #[test]
+    #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
+    fn hardware_detection_is_unavailable_on_other_architectures() {
+        assert!(
+            !sha256_hardware_acceleration_available(),
+            "no SHA-256 hardware acceleration is exposed on this architecture"
+        );
+    }
+
+    #[test]
+    fn accelerated_backend_produces_identical_digests() {
+        // Regression guard: ensure the cpufeatures-selected backend (whether
+        // SHA-NI, ARMv8 crypto, or scalar) produces standards-compliant
+        // digests. If hardware acceleration silently miscomputed, the RFC
+        // vectors above would already fail; this test additionally exercises
+        // a longer input that crosses multiple SHA-256 compression blocks.
+        let input = vec![0x5au8; 1024 * 16];
+        let one_shot = Sha256::digest(&input);
+
+        let mut hasher = Sha256::new();
+        for chunk in input.chunks(57) {
+            hasher.update(chunk);
+        }
+        let streamed = hasher.finalize();
+
+        assert_eq!(
+            one_shot, streamed,
+            "streaming and one-shot SHA-256 must agree regardless of backend"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Enable the `asm` feature on `sha1` and `sha2` for Unix targets, matching the existing `md-5` configuration; Windows builds keep the pure-Rust backend because `sha2-asm` requires NASM and fails under MSVC.
- The pure-Rust `sha2` backend already auto-detects SHA-NI (x86_64) and ARMv8 crypto extensions (aarch64) at runtime via the `cpufeatures` crate. No `RUSTFLAGS` are required - a single binary picks the fastest backend on every host.
- Add `checksums::strong::sha256_hardware_acceleration_available()` so deployments and benchmarks can verify at runtime that SHA-256 hardware acceleration is being used.
- Document the auto-detection contract on `Sha256` and on the re-export.

## Test plan

- [x] New unit tests cover the runtime detection query: deterministic across calls, agrees with `std::arch::is_x86_feature_detected!("sha")` on x86_64 and `std::arch::is_aarch64_feature_detected!("sha2")` on aarch64, and reports `false` on other architectures.
- [x] Existing RFC vector tests continue to validate that the auto-selected backend (SHA-NI / ARMv8 crypto / scalar) produces standards-compliant digests.
- [x] New regression test (`accelerated_backend_produces_identical_digests`) cross-checks streaming vs one-shot for a 16 KiB input that crosses multiple SHA-256 compression blocks.
- [x] CI matrix exercises Linux x86_64 (with/without SHA-NI), Linux musl, macOS aarch64 (ARMv8 crypto), and Windows MSVC (pure-Rust backend, no NASM dependency).