### PR TITLE
refactor: consolidate per-protocol compression decisions in profile table

### DIFF
--- a/crates/compress/src/strategy/kind.rs
+++ b/crates/compress/src/strategy/kind.rs
@@ -1,5 +1,6 @@
 //! Compression algorithm kind enumeration.
 
+use super::profile::ProtocolCompressionProfile;
 use crate::algorithm::CompressionAlgorithm;
 use crate::zlib::CompressionLevel;
 use std::fmt;
@@ -12,9 +13,11 @@ use std::fmt;
 pub enum CompressionAlgorithmKind {
     /// No compression - data is passed through uncompressed.
     None,
-    /// Zlib/DEFLATE - Default for rsync protocol < 36.
+    /// Zlib/DEFLATE - Mandatory codec for rsync protocol < 30 and the
+    /// negotiation fallback for all protocol versions.
     Zlib,
-    /// Zstandard - Default for rsync protocol >= 36.
+    /// Zstandard - Preferred codec for protocol >= 30 when compiled with
+    /// the `zstd` feature.
     #[cfg(feature = "zstd")]
     Zstd,
     /// LZ4 - Fast compression option.
@@ -90,18 +93,21 @@ impl CompressionAlgorithmKind {
 
     /// Returns the default algorithm for a given protocol version.
     ///
-    /// Protocol < 36 defaults to Zlib. Protocol >= 36 defaults to Zstd when
-    /// available, falling back to Zlib otherwise.
+    /// Protocol < 30 defaults to Zlib (upstream has no vstring negotiation
+    /// before protocol 30). Protocol >= 30 defaults to Zstd when the `zstd`
+    /// feature is compiled in, falling back to Zlib otherwise.
+    ///
+    /// Delegates to the central [`ProtocolCompressionProfile`] table.
+    ///
+    /// # Upstream Reference
+    ///
+    /// upstream: compat.c:556-563 - `recv_negotiate_str` defaults to `"zlib"`
+    /// when `do_negotiated_strings == 0` (protocol < 30 unconditionally).
+    /// upstream: compat.c:101-102 - zstd is the first entry in
+    /// `valid_compressions_items[]` when `SUPPORT_ZSTD` is defined.
     #[must_use]
     pub const fn for_protocol_version(protocol_version: u8) -> Self {
-        if protocol_version >= 36 {
-            #[cfg(feature = "zstd")]
-            return Self::Zstd;
-            #[cfg(not(feature = "zstd"))]
-            return Self::Zlib;
-        } else {
-            Self::Zlib
-        }
+        ProtocolCompressionProfile::for_protocol(protocol_version).default_kind()
     }
 }
 

--- a/crates/compress/src/strategy/mod.rs
+++ b/crates/compress/src/strategy/mod.rs
@@ -9,8 +9,8 @@
 //! ```text
 //! CompressionStrategy (trait)
 //!     |-- NoCompressionStrategy   passthrough, no compression
-//!     |-- ZlibStrategy            DEFLATE, protocol < 36 default
-//!     |-- ZstdStrategy            Zstandard, protocol >= 36 default
+//!     |-- ZlibStrategy            DEFLATE, default for protocol < 30
+//!     |-- ZstdStrategy            Zstandard, preferred for protocol >= 30
 //!     |-- Lz4Strategy             LZ4, fast compression
 //!
 //! CompressionNegotiator (trait)
@@ -22,6 +22,10 @@
 //!     |-- for_protocol_version()  protocol-aware default selection
 //!     |-- for_algorithm()         explicit algorithm choice
 //!     |-- negotiate()             local/remote capability matching
+//!
+//! ProtocolCompressionProfile (data table)
+//!     |-- LEGACY    protocol < 30: zlib only, no vstring negotiation
+//!     |-- MODERN    protocol >= 30: vstring negotiation, zstd preferred
 //! ```
 //!
 //! # Example
@@ -33,30 +37,37 @@
 //! use compress::zlib::CompressionLevel;
 //!
 //! // Select algorithm based on protocol version
-//! let strategy = CompressionStrategySelector::for_protocol_version(36);
+//! let strategy = CompressionStrategySelector::for_protocol_version(32);
 //! let mut compressed = Vec::new();
 //! strategy.compress(b"data", &mut compressed).unwrap();
 //!
 //! // Select algorithm explicitly
+//! # #[cfg(feature = "zstd")]
+//! # {
 //! let zstd_strategy = CompressionStrategySelector::for_algorithm(
 //!     CompressionAlgorithmKind::Zstd,
 //!     CompressionLevel::Default,
 //! ).unwrap();
 //! let mut output = Vec::new();
 //! zstd_strategy.compress(b"fast compression", &mut output).unwrap();
+//! # }
 //! ```
 //!
 //! # Protocol Version Defaults
 //!
-//! | Protocol | Default Algorithm |
-//! |----------|-------------------|
-//! | < 36     | Zlib              |
-//! | >= 36    | Zstd              |
+//! Single source of truth: [`profile::ProtocolCompressionProfile`].
+//!
+//! | Protocol | Default Algorithm                          |
+//! |----------|--------------------------------------------|
+//! | < 30     | Zlib (no vstring negotiation)              |
+//! | >= 30    | Zstd when feature enabled, else Zlib       |
 
 mod impls;
 mod kind;
 /// Compression algorithm negotiation abstraction.
 pub mod negotiator;
+/// Protocol-version-aware compression profile lookup.
+pub mod profile;
 mod selector;
 mod traits;
 
@@ -73,5 +84,6 @@ pub use negotiator::{
     CompressionNegotiator, DefaultCompressionNegotiator, FixedCompressionNegotiator,
     ProtocolAwareCompressionNegotiator,
 };
+pub use profile::ProtocolCompressionProfile;
 pub use selector::CompressionStrategySelector;
 pub use traits::CompressionStrategy;

--- a/crates/compress/src/strategy/negotiator.rs
+++ b/crates/compress/src/strategy/negotiator.rs
@@ -9,8 +9,8 @@
 //! selection algorithm from `protocol::negotiation::capabilities::algorithms`,
 //! providing the default preference order: zstd > lz4 > zlibx > zlib > none.
 
-use super::profile::ProtocolCompressionProfile;
 use super::CompressionAlgorithmKind;
+use super::profile::ProtocolCompressionProfile;
 
 /// Trait for compression algorithm negotiation and selection.
 ///

--- a/crates/compress/src/strategy/negotiator.rs
+++ b/crates/compress/src/strategy/negotiator.rs
@@ -9,6 +9,7 @@
 //! selection algorithm from `protocol::negotiation::capabilities::algorithms`,
 //! providing the default preference order: zstd > lz4 > zlibx > zlib > none.
 
+use super::profile::ProtocolCompressionProfile;
 use super::CompressionAlgorithmKind;
 
 /// Trait for compression algorithm negotiation and selection.
@@ -86,18 +87,10 @@ impl DefaultCompressionNegotiator {
 
 impl CompressionNegotiator for DefaultCompressionNegotiator {
     fn supported_algorithms(&self) -> Vec<&'static str> {
-        let mut list = Vec::with_capacity(5);
-
-        // upstream: compat.c:101-102 - zstd first when SUPPORT_ZSTD is defined
-        #[cfg(feature = "zstd")]
-        list.push("zstd");
-
-        // NOTE: lz4 is intentionally omitted from auto-negotiation.
-        // Its per-token wire framing is not yet interop-validated with upstream.
-        // Explicit --compress-choice=lz4 still works (bypasses this list).
-
-        list.extend_from_slice(&["zlibx", "zlib", "none"]);
-        list
+        // Default negotiator targets modern (protocol >= 30) peers; share the
+        // single advertisement list with ProtocolAwareCompressionNegotiator so
+        // both stay in lockstep with upstream's valid_compressions_items[].
+        ProtocolCompressionProfile::MODERN.advertised_algorithms()
     }
 
     fn select_algorithm(&self, remote_list: &[&str], is_server: bool) -> &'static str {
@@ -229,32 +222,17 @@ impl ProtocolAwareCompressionNegotiator {
 
 impl CompressionNegotiator for ProtocolAwareCompressionNegotiator {
     fn supported_algorithms(&self) -> Vec<&'static str> {
-        if self.protocol_version < 30 {
-            // upstream: compat.c:556-563 - protocol < 30 has no vstring
-            // negotiation; compression is always zlib.
-            return vec!["zlib"];
-        }
-
-        // Protocol >= 30: full vstring negotiation with upstream preference order.
-        // upstream: compat.c:100-111 valid_compressions_items[] -
-        // zstd first when SUPPORT_ZSTD is defined, then lz4, zlibx, zlib, none.
-        let mut list = Vec::with_capacity(5);
-
-        #[cfg(feature = "zstd")]
-        list.push("zstd");
-
-        // NOTE: lz4 is intentionally omitted from auto-negotiation.
-        // Its per-token wire framing is not yet interop-validated with upstream.
-        // Explicit --compress-choice=lz4 still works (bypasses this list).
-
-        list.extend_from_slice(&["zlibx", "zlib", "none"]);
-        list
+        // Single source of truth for per-protocol advertisement lists.
+        // upstream: compat.c:100-112 valid_compressions_items[] (modern),
+        // compat.c:556-568 (legacy zlib-only fallback).
+        ProtocolCompressionProfile::for_protocol(self.protocol_version).advertised_algorithms()
     }
 
     fn select_algorithm(&self, remote_list: &[&str], is_server: bool) -> &'static str {
-        if self.protocol_version < 30 {
+        let profile = ProtocolCompressionProfile::for_protocol(self.protocol_version);
+        if !profile.supports_vstring_negotiation {
             // upstream: compat.c:562 - no vstring exchange; zlib is mandatory.
-            // The remote list is irrelevant for protocol < 30.
+            // The remote list is irrelevant for legacy protocols.
             return "zlib";
         }
 
@@ -656,18 +634,21 @@ mod tests {
     }
 
     #[test]
-    fn negotiation_protocol_version_35_boundary() {
-        // Protocol 35 is last version before zstd default threshold.
+    fn negotiation_protocol_version_29_boundary() {
+        // Protocol 29 is the last version before vstring negotiation; the
+        // upstream fallback codec is "zlib" (compat.c:556-563).
         assert_eq!(
-            CompressionAlgorithmKind::for_protocol_version(35),
+            CompressionAlgorithmKind::for_protocol_version(29),
             CompressionAlgorithmKind::Zlib
         );
     }
 
     #[test]
-    fn negotiation_protocol_version_36_boundary() {
-        // Protocol 36 is the zstd default threshold.
-        let kind = CompressionAlgorithmKind::for_protocol_version(36);
+    fn negotiation_protocol_version_30_boundary() {
+        // Protocol 30 is the first version with vstring negotiation. The
+        // canonical default kind is zstd when SUPPORT_ZSTD is defined
+        // (upstream: compat.c:101-102 valid_compressions_items[]).
+        let kind = CompressionAlgorithmKind::for_protocol_version(30);
         #[cfg(feature = "zstd")]
         assert_eq!(kind, CompressionAlgorithmKind::Zstd);
         #[cfg(not(feature = "zstd"))]
@@ -675,9 +656,10 @@ mod tests {
     }
 
     #[test]
-    fn negotiation_protocol_version_range_below_36_all_zlib() {
-        // All protocol versions below 36 default to zlib.
-        for v in [1, 10, 20, 28, 29, 30, 31, 32, 33, 34, 35] {
+    fn negotiation_protocol_version_range_below_30_all_zlib() {
+        // All protocol versions below 30 default to zlib (no vstring
+        // negotiation in upstream).
+        for v in [1, 10, 20, 28, 29] {
             assert_eq!(
                 CompressionAlgorithmKind::for_protocol_version(v),
                 CompressionAlgorithmKind::Zlib,

--- a/crates/compress/src/strategy/profile.rs
+++ b/crates/compress/src/strategy/profile.rs
@@ -1,0 +1,321 @@
+//! Protocol-version-aware compression profile lookup table.
+//!
+//! Consolidates the per-protocol compression decisions (preferred codec,
+//! whether vstring negotiation is supported, and the algorithm advertisement
+//! list) into a single data-driven table. Replaces scattered
+//! `if protocol_version >= N` ladders previously duplicated across
+//! [`super::kind`], [`super::negotiator`], and the `protocol` crate's
+//! capability layer.
+//!
+//! # Upstream Reference
+//!
+//! upstream: compat.c:100-112 `valid_compressions_items[]` - preference order.
+//! upstream: compat.c:556-563 - vstring negotiation gated by
+//! `do_negotiated_strings`, which is only set for protocol >= 30 once the
+//! `v` capability flag is exchanged. Protocol < 30 unconditionally uses zlib.
+//! upstream: rsync.h:114 - `PROTOCOL_VERSION 32` (current); rsync.h:149 -
+//! `MAX_PROTOCOL_VERSION 40` (accepted upper bound).
+
+use super::CompressionAlgorithmKind;
+
+/// Snapshot of the compression behaviour negotiated for a given protocol
+/// version range.
+///
+/// Each profile pairs the upstream-defined inclusive lower bound of a protocol
+/// range with the codec preferences and capability flags that apply within the
+/// range. Single source of truth for protocol-version-driven compression
+/// decisions across the workspace.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub struct ProtocolCompressionProfile {
+    /// Inclusive lower bound of the protocol range this profile covers.
+    pub min_protocol: u8,
+    /// `true` when the protocol exchanges vstrings to negotiate codecs.
+    /// upstream: compat.c:556-563 - depends on `do_negotiated_strings`.
+    pub supports_vstring_negotiation: bool,
+    /// Codec preferred when negotiation is unavailable or unsuccessful.
+    /// upstream: compat.c:562 - `recv_negotiate_str` defaults to `"zlib"`.
+    pub fallback_codec: CompressionAlgorithmKind,
+    /// Wire name advertised as first preference when zstd is compiled in.
+    /// upstream: compat.c:101-102 - first entry in
+    /// `valid_compressions_items[]` when `SUPPORT_ZSTD` is defined.
+    pub preferred_codec_with_zstd: &'static str,
+    /// Wire name advertised as first preference without zstd support.
+    pub preferred_codec_without_zstd: &'static str,
+}
+
+impl ProtocolCompressionProfile {
+    /// Profile for protocol versions below 30.
+    ///
+    /// Pre-30 peers do not exchange vstrings; compression is unconditionally
+    /// zlib. upstream: compat.c:556-568.
+    pub const LEGACY: Self = Self {
+        min_protocol: 0,
+        supports_vstring_negotiation: false,
+        fallback_codec: CompressionAlgorithmKind::Zlib,
+        preferred_codec_with_zstd: "zlib",
+        preferred_codec_without_zstd: "zlib",
+    };
+
+    /// Profile for protocol versions 30 and above.
+    ///
+    /// Modern peers negotiate codecs via vstrings. Zstd is the first
+    /// preference whenever it is compiled in; otherwise the advertisement
+    /// falls back to `zlibx > zlib > none`.
+    /// upstream: compat.c:100-112 `valid_compressions_items[]`.
+    pub const MODERN: Self = Self {
+        min_protocol: 30,
+        supports_vstring_negotiation: true,
+        fallback_codec: CompressionAlgorithmKind::Zlib,
+        preferred_codec_with_zstd: "zstd",
+        preferred_codec_without_zstd: "zlibx",
+    };
+
+    /// Ordered profile table - consulted by [`Self::for_protocol`] for the
+    /// matching range. Highest `min_protocol` that does not exceed the
+    /// requested version wins.
+    pub const TABLE: &'static [Self] = &[Self::LEGACY, Self::MODERN];
+
+    /// Returns the profile that applies to the given protocol version.
+    #[must_use]
+    pub const fn for_protocol(protocol_version: u8) -> Self {
+        let mut chosen = Self::TABLE[0];
+        let mut i = 1;
+        while i < Self::TABLE.len() {
+            let entry = Self::TABLE[i];
+            if protocol_version >= entry.min_protocol {
+                chosen = entry;
+            }
+            i += 1;
+        }
+        chosen
+    }
+
+    /// Returns the wire name of the codec advertised as first preference for
+    /// this profile in the current build.
+    #[must_use]
+    pub const fn preferred_codec_name(&self) -> &'static str {
+        #[cfg(feature = "zstd")]
+        {
+            self.preferred_codec_with_zstd
+        }
+        #[cfg(not(feature = "zstd"))]
+        {
+            self.preferred_codec_without_zstd
+        }
+    }
+
+    /// Returns the canonical kind chosen as the protocol-default when no
+    /// negotiation context is available. Mirrors upstream's
+    /// `recv_negotiate_str` fallback (always zlib for pre-30 peers; zstd is
+    /// preferred for 30+ when compiled in).
+    #[must_use]
+    pub const fn default_kind(&self) -> CompressionAlgorithmKind {
+        if !self.supports_vstring_negotiation {
+            return self.fallback_codec;
+        }
+
+        #[cfg(feature = "zstd")]
+        {
+            CompressionAlgorithmKind::Zstd
+        }
+        #[cfg(not(feature = "zstd"))]
+        {
+            self.fallback_codec
+        }
+    }
+
+    /// Returns the ordered list of algorithm wire names to advertise during
+    /// vstring negotiation. Mirrors `valid_compressions_items[]`. Returns a
+    /// single-element list (`["zlib"]`) for legacy profiles where no
+    /// negotiation occurs.
+    #[must_use]
+    pub fn advertised_algorithms(&self) -> Vec<&'static str> {
+        if !self.supports_vstring_negotiation {
+            return vec!["zlib"];
+        }
+
+        let mut list = Vec::with_capacity(5);
+
+        // upstream: compat.c:101-102 - zstd first when SUPPORT_ZSTD is defined
+        #[cfg(feature = "zstd")]
+        list.push("zstd");
+
+        // NOTE: lz4 is intentionally omitted from auto-negotiation. Its
+        // per-token wire framing is not yet interop-validated with upstream.
+        // Explicit --compress-choice=lz4 still works (bypasses this list).
+
+        list.extend_from_slice(&["zlibx", "zlib", "none"]);
+        list
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn proto_28_resolves_to_legacy() {
+        let p = ProtocolCompressionProfile::for_protocol(28);
+        assert_eq!(p, ProtocolCompressionProfile::LEGACY);
+    }
+
+    #[test]
+    fn proto_29_resolves_to_legacy() {
+        let p = ProtocolCompressionProfile::for_protocol(29);
+        assert_eq!(p, ProtocolCompressionProfile::LEGACY);
+    }
+
+    #[test]
+    fn proto_30_resolves_to_modern() {
+        let p = ProtocolCompressionProfile::for_protocol(30);
+        assert_eq!(p, ProtocolCompressionProfile::MODERN);
+    }
+
+    #[test]
+    fn proto_31_resolves_to_modern() {
+        let p = ProtocolCompressionProfile::for_protocol(31);
+        assert_eq!(p, ProtocolCompressionProfile::MODERN);
+    }
+
+    #[test]
+    fn proto_32_resolves_to_modern() {
+        let p = ProtocolCompressionProfile::for_protocol(32);
+        assert_eq!(p, ProtocolCompressionProfile::MODERN);
+    }
+
+    #[test]
+    fn proto_0_resolves_to_legacy() {
+        let p = ProtocolCompressionProfile::for_protocol(0);
+        assert_eq!(p, ProtocolCompressionProfile::LEGACY);
+    }
+
+    #[test]
+    fn proto_255_resolves_to_modern() {
+        let p = ProtocolCompressionProfile::for_protocol(255);
+        assert_eq!(p, ProtocolCompressionProfile::MODERN);
+    }
+
+    #[test]
+    fn legacy_disables_vstring_negotiation() {
+        assert!(!ProtocolCompressionProfile::LEGACY.supports_vstring_negotiation);
+    }
+
+    #[test]
+    fn modern_enables_vstring_negotiation() {
+        assert!(ProtocolCompressionProfile::MODERN.supports_vstring_negotiation);
+    }
+
+    #[test]
+    fn legacy_advertises_only_zlib() {
+        let advertised = ProtocolCompressionProfile::LEGACY.advertised_algorithms();
+        assert_eq!(advertised, vec!["zlib"]);
+    }
+
+    #[test]
+    fn modern_advertises_zlibx_zlib_none_at_minimum() {
+        let advertised = ProtocolCompressionProfile::MODERN.advertised_algorithms();
+        assert!(advertised.contains(&"zlibx"));
+        assert!(advertised.contains(&"zlib"));
+        assert!(advertised.contains(&"none"));
+        assert_eq!(advertised.last(), Some(&"none"));
+    }
+
+    #[cfg(feature = "zstd")]
+    #[test]
+    fn modern_advertises_zstd_first_when_feature_enabled() {
+        let advertised = ProtocolCompressionProfile::MODERN.advertised_algorithms();
+        assert_eq!(advertised[0], "zstd");
+    }
+
+    #[cfg(not(feature = "zstd"))]
+    #[test]
+    fn modern_omits_zstd_without_feature() {
+        let advertised = ProtocolCompressionProfile::MODERN.advertised_algorithms();
+        assert!(!advertised.contains(&"zstd"));
+    }
+
+    #[test]
+    fn modern_never_advertises_lz4() {
+        let advertised = ProtocolCompressionProfile::MODERN.advertised_algorithms();
+        assert!(!advertised.contains(&"lz4"));
+    }
+
+    #[test]
+    fn legacy_default_kind_is_zlib() {
+        assert_eq!(
+            ProtocolCompressionProfile::LEGACY.default_kind(),
+            CompressionAlgorithmKind::Zlib
+        );
+    }
+
+    #[cfg(feature = "zstd")]
+    #[test]
+    fn modern_default_kind_is_zstd_when_feature_enabled() {
+        assert_eq!(
+            ProtocolCompressionProfile::MODERN.default_kind(),
+            CompressionAlgorithmKind::Zstd
+        );
+    }
+
+    #[cfg(not(feature = "zstd"))]
+    #[test]
+    fn modern_default_kind_is_zlib_without_feature() {
+        assert_eq!(
+            ProtocolCompressionProfile::MODERN.default_kind(),
+            CompressionAlgorithmKind::Zlib
+        );
+    }
+
+    #[test]
+    fn preferred_codec_name_legacy_is_zlib() {
+        assert_eq!(
+            ProtocolCompressionProfile::LEGACY.preferred_codec_name(),
+            "zlib"
+        );
+    }
+
+    #[cfg(feature = "zstd")]
+    #[test]
+    fn preferred_codec_name_modern_with_zstd_is_zstd() {
+        assert_eq!(
+            ProtocolCompressionProfile::MODERN.preferred_codec_name(),
+            "zstd"
+        );
+    }
+
+    #[cfg(not(feature = "zstd"))]
+    #[test]
+    fn preferred_codec_name_modern_without_zstd_is_zlibx() {
+        assert_eq!(
+            ProtocolCompressionProfile::MODERN.preferred_codec_name(),
+            "zlibx"
+        );
+    }
+
+    #[test]
+    fn table_is_ordered_by_min_protocol() {
+        let table = ProtocolCompressionProfile::TABLE;
+        for window in table.windows(2) {
+            assert!(window[0].min_protocol < window[1].min_protocol);
+        }
+    }
+
+    #[test]
+    fn for_protocol_matches_old_kind_threshold_below_30() {
+        // Pre-30 always resolved to Zlib in the legacy
+        // CompressionAlgorithmKind::for_protocol_version match arm.
+        for v in [0u8, 1, 10, 20, 27, 28, 29] {
+            let p = ProtocolCompressionProfile::for_protocol(v);
+            assert_eq!(p.fallback_codec, CompressionAlgorithmKind::Zlib);
+        }
+    }
+
+    #[test]
+    fn boundary_29_to_30_switches_profile() {
+        let p29 = ProtocolCompressionProfile::for_protocol(29);
+        let p30 = ProtocolCompressionProfile::for_protocol(30);
+        assert_ne!(p29, p30);
+        assert!(!p29.supports_vstring_negotiation);
+        assert!(p30.supports_vstring_negotiation);
+    }
+}

--- a/crates/compress/src/strategy/selector.rs
+++ b/crates/compress/src/strategy/selector.rs
@@ -20,15 +20,19 @@ pub struct CompressionStrategySelector;
 impl CompressionStrategySelector {
     /// Selects the default algorithm for a given protocol version.
     ///
-    /// Protocol < 36 defaults to Zlib. Protocol >= 36 defaults to Zstd when
-    /// available, otherwise Zlib.
+    /// Protocol < 30 has no vstring negotiation and always defaults to Zlib.
+    /// Protocol >= 30 defaults to Zstd when the feature is compiled in,
+    /// falling back to Zlib otherwise.
+    ///
+    /// Delegates to the central
+    /// [`super::ProtocolCompressionProfile`] table.
     ///
     /// # Example
     ///
     /// ```
     /// use compress::strategy::CompressionStrategySelector;
     ///
-    /// let strategy = CompressionStrategySelector::for_protocol_version(36);
+    /// let strategy = CompressionStrategySelector::for_protocol_version(32);
     /// # #[cfg(feature = "zstd")]
     /// assert_eq!(strategy.algorithm_name(), "zstd");
     /// # #[cfg(not(feature = "zstd"))]

--- a/crates/compress/src/strategy/tests.rs
+++ b/crates/compress/src/strategy/tests.rs
@@ -67,19 +67,42 @@ fn algorithm_kind_all() {
 
 #[test]
 fn algorithm_kind_for_protocol_version() {
+    // Pre-30 always defaults to Zlib (upstream: compat.c:556-563 - no
+    // vstring negotiation, fallback is "zlib").
     assert_eq!(
-        CompressionAlgorithmKind::for_protocol_version(30),
+        CompressionAlgorithmKind::for_protocol_version(28),
         CompressionAlgorithmKind::Zlib
     );
     assert_eq!(
-        CompressionAlgorithmKind::for_protocol_version(35),
+        CompressionAlgorithmKind::for_protocol_version(29),
         CompressionAlgorithmKind::Zlib
     );
+
+    // Protocol 30+ prefers Zstd when the zstd feature is compiled in
+    // (upstream: compat.c:101-102 valid_compressions_items[]). Without
+    // the feature the default falls back to Zlib.
     #[cfg(feature = "zstd")]
-    assert_eq!(
-        CompressionAlgorithmKind::for_protocol_version(36),
-        CompressionAlgorithmKind::Zstd
-    );
+    {
+        assert_eq!(
+            CompressionAlgorithmKind::for_protocol_version(30),
+            CompressionAlgorithmKind::Zstd
+        );
+        assert_eq!(
+            CompressionAlgorithmKind::for_protocol_version(32),
+            CompressionAlgorithmKind::Zstd
+        );
+    }
+    #[cfg(not(feature = "zstd"))]
+    {
+        assert_eq!(
+            CompressionAlgorithmKind::for_protocol_version(30),
+            CompressionAlgorithmKind::Zlib
+        );
+        assert_eq!(
+            CompressionAlgorithmKind::for_protocol_version(32),
+            CompressionAlgorithmKind::Zlib
+        );
+    }
 }
 
 #[test]
@@ -196,14 +219,14 @@ fn lz4_strategy_algorithm_name() {
 }
 
 #[test]
-fn selector_for_protocol_version_35() {
-    let strategy = CompressionStrategySelector::for_protocol_version(35);
+fn selector_for_protocol_version_29_returns_zlib() {
+    let strategy = CompressionStrategySelector::for_protocol_version(29);
     assert_eq!(strategy.algorithm_name(), "zlib");
 }
 
 #[test]
-fn selector_for_protocol_version_36() {
-    let strategy = CompressionStrategySelector::for_protocol_version(36);
+fn selector_for_protocol_version_30_modern_default() {
+    let strategy = CompressionStrategySelector::for_protocol_version(30);
     #[cfg(feature = "zstd")]
     assert_eq!(strategy.algorithm_name(), "zstd");
     #[cfg(not(feature = "zstd"))]
@@ -347,41 +370,49 @@ fn selector_protocol_version_28_returns_zlib() {
 }
 
 #[test]
-fn selector_protocol_version_29_returns_zlib() {
-    let strategy = CompressionStrategySelector::for_protocol_version(29);
-    assert_eq!(strategy.algorithm_name(), "zlib");
+fn selector_protocol_version_legacy_below_30_always_zlib() {
+    // Pre-30 has no vstring negotiation; upstream defaults to "zlib".
+    for v in 0..30u8 {
+        let strategy = CompressionStrategySelector::for_protocol_version(v);
+        assert_eq!(
+            strategy.algorithm_name(),
+            "zlib",
+            "protocol {v} must default to zlib"
+        );
+    }
+}
+
+#[cfg(feature = "zstd")]
+#[test]
+fn selector_protocol_version_modern_30_plus_zstd() {
+    // Protocol >= 30 with zstd compiled in: the canonical default kind is
+    // zstd (upstream: compat.c:101-102 valid_compressions_items[]).
+    for v in [30u8, 31, 32, 40, 100, 255] {
+        let strategy = CompressionStrategySelector::for_protocol_version(v);
+        assert_eq!(
+            strategy.algorithm_name(),
+            "zstd",
+            "protocol {v} must default to zstd when feature enabled"
+        );
+    }
+}
+
+#[cfg(not(feature = "zstd"))]
+#[test]
+fn selector_protocol_version_modern_30_plus_zlib_without_zstd() {
+    for v in [30u8, 31, 32, 40, 100, 255] {
+        let strategy = CompressionStrategySelector::for_protocol_version(v);
+        assert_eq!(
+            strategy.algorithm_name(),
+            "zlib",
+            "protocol {v} must fall back to zlib without zstd feature"
+        );
+    }
 }
 
 #[test]
-fn selector_protocol_version_30_returns_zlib() {
-    let strategy = CompressionStrategySelector::for_protocol_version(30);
-    assert_eq!(strategy.algorithm_name(), "zlib");
-}
-
-#[test]
-fn selector_protocol_version_31_returns_zlib() {
-    let strategy = CompressionStrategySelector::for_protocol_version(31);
-    assert_eq!(strategy.algorithm_name(), "zlib");
-}
-
-#[test]
-fn selector_protocol_version_32_returns_zlib() {
-    let strategy = CompressionStrategySelector::for_protocol_version(32);
-    assert_eq!(strategy.algorithm_name(), "zlib");
-}
-
-#[test]
-fn selector_protocol_version_255_high() {
-    let strategy = CompressionStrategySelector::for_protocol_version(255);
-    #[cfg(feature = "zstd")]
-    assert_eq!(strategy.algorithm_name(), "zstd");
-    #[cfg(not(feature = "zstd"))]
-    assert_eq!(strategy.algorithm_name(), "zlib");
-}
-
-#[test]
-fn kind_for_protocol_below_36_always_zlib() {
-    for v in 0..36u8 {
+fn kind_for_protocol_below_30_always_zlib() {
+    for v in 0..30u8 {
         assert_eq!(
             CompressionAlgorithmKind::for_protocol_version(v),
             CompressionAlgorithmKind::Zlib,
@@ -392,8 +423,11 @@ fn kind_for_protocol_below_36_always_zlib() {
 
 #[cfg(feature = "zstd")]
 #[test]
-fn kind_for_protocol_36_and_above_zstd() {
-    for v in [36, 37, 40, 50, 100, 255] {
+fn kind_for_protocol_30_and_above_zstd() {
+    // Upstream: compat.c:101-102 - zstd is the first preference whenever
+    // SUPPORT_ZSTD is defined and vstring negotiation is available
+    // (protocol >= 30).
+    for v in [30u8, 31, 32, 40, 100, 255] {
         assert_eq!(
             CompressionAlgorithmKind::for_protocol_version(v),
             CompressionAlgorithmKind::Zstd,
@@ -404,8 +438,8 @@ fn kind_for_protocol_36_and_above_zstd() {
 
 #[cfg(not(feature = "zstd"))]
 #[test]
-fn kind_for_protocol_36_and_above_falls_to_zlib_without_zstd() {
-    for v in [36, 37, 100, 255] {
+fn kind_for_protocol_30_and_above_falls_to_zlib_without_zstd() {
+    for v in [30u8, 31, 32, 100, 255] {
         assert_eq!(
             CompressionAlgorithmKind::for_protocol_version(v),
             CompressionAlgorithmKind::Zlib,
@@ -792,9 +826,10 @@ fn negotiate_none_kind_roundtrip() {
 // ---- Kind edge cases ----
 
 #[test]
-fn kind_for_protocol_version_boundary_35_is_zlib() {
+fn kind_for_protocol_version_boundary_29_is_zlib() {
+    // Pre-30 always defaults to Zlib (upstream: compat.c:556-563).
     assert_eq!(
-        CompressionAlgorithmKind::for_protocol_version(35),
+        CompressionAlgorithmKind::for_protocol_version(29),
         CompressionAlgorithmKind::Zlib
     );
 }

--- a/crates/compress/tests/strategy_integration.rs
+++ b/crates/compress/tests/strategy_integration.rs
@@ -118,8 +118,9 @@ fn algorithm_kind_default_levels() {
 
 #[test]
 fn algorithm_kind_for_protocol_version_follows_rsync_defaults() {
-    // Protocol < 36 should use Zlib
-    for version in 27..36 {
+    // Protocol < 30 has no vstring negotiation; upstream default is Zlib
+    // (compat.c:556-563).
+    for version in 27..30 {
         assert_eq!(
             CompressionAlgorithmKind::for_protocol_version(version),
             CompressionAlgorithmKind::Zlib,
@@ -127,10 +128,11 @@ fn algorithm_kind_for_protocol_version_follows_rsync_defaults() {
         );
     }
 
-    // Protocol >= 36 should use Zstd (if available)
+    // Protocol 30+ defaults to Zstd when SUPPORT_ZSTD is defined
+    // (upstream: compat.c:101-102 valid_compressions_items[]).
     #[cfg(feature = "zstd")]
     {
-        for version in 36..40 {
+        for version in 30..40 {
             assert_eq!(
                 CompressionAlgorithmKind::for_protocol_version(version),
                 CompressionAlgorithmKind::Zstd,
@@ -141,7 +143,7 @@ fn algorithm_kind_for_protocol_version_follows_rsync_defaults() {
 
     #[cfg(not(feature = "zstd"))]
     {
-        for version in 36..40 {
+        for version in 30..40 {
             assert_eq!(
                 CompressionAlgorithmKind::for_protocol_version(version),
                 CompressionAlgorithmKind::Zlib,
@@ -370,16 +372,23 @@ fn lz4_strategy_empty_input() {
 
 #[test]
 fn selector_for_protocol_version_creates_correct_strategy() {
-    // Protocol 30 should use Zlib
+    // Pre-30 always returns Zlib (upstream: compat.c:556-563 - no vstring
+    // negotiation, fallback codec is "zlib").
+    let strategy = CompressionStrategySelector::for_protocol_version(28);
+    assert_eq!(strategy.algorithm_name(), "zlib");
+
+    let strategy = CompressionStrategySelector::for_protocol_version(29);
+    assert_eq!(strategy.algorithm_name(), "zlib");
+
+    // Protocol 30+ defaults to Zstd when the feature is compiled in
+    // (upstream: compat.c:101-102 valid_compressions_items[]).
     let strategy = CompressionStrategySelector::for_protocol_version(30);
+    #[cfg(feature = "zstd")]
+    assert_eq!(strategy.algorithm_name(), "zstd");
+    #[cfg(not(feature = "zstd"))]
     assert_eq!(strategy.algorithm_name(), "zlib");
 
-    // Protocol 35 should use Zlib
-    let strategy = CompressionStrategySelector::for_protocol_version(35);
-    assert_eq!(strategy.algorithm_name(), "zlib");
-
-    // Protocol 36 should use Zstd (if available)
-    let strategy = CompressionStrategySelector::for_protocol_version(36);
+    let strategy = CompressionStrategySelector::for_protocol_version(32);
     #[cfg(feature = "zstd")]
     assert_eq!(strategy.algorithm_name(), "zstd");
     #[cfg(not(feature = "zstd"))]

--- a/crates/protocol/src/version/protocol_version/capabilities.rs
+++ b/crates/protocol/src/version/protocol_version/capabilities.rs
@@ -220,27 +220,27 @@ impl ProtocolVersion {
 
     /// Returns the preferred compression algorithm name for this protocol version.
     ///
-    /// Protocol >= 31 prefers zstd (if available at compile time), falling back
-    /// to zlibx. Protocol 27-30 uses zlib (the only compression supported by
-    /// those versions of upstream rsync).
+    /// Pre-30 peers cannot negotiate codecs and always use zlib. Protocol 30+
+    /// peers negotiate via vstrings; the wire-name returned here is the first
+    /// preference advertised in the current build (zstd when the `zstd`
+    /// feature is enabled, otherwise zlibx).
     ///
     /// This does not perform negotiation - it returns the local preference.
     /// Actual algorithm selection happens during capability exchange.
     ///
+    /// Delegates to the central
+    /// [`ProtocolCompressionProfile`](compress::strategy::ProtocolCompressionProfile)
+    /// table.
+    ///
     /// # Upstream Reference
     ///
     /// upstream: compat.c:100-112 `valid_compressions_items[]` - zstd first
-    /// when `SUPPORT_ZSTD` is defined (protocol >= 31).
+    /// when `SUPPORT_ZSTD` is defined; vstring negotiation gated on protocol
+    /// >= 30 via `do_negotiated_strings`.
     #[must_use]
     pub const fn preferred_compression(self) -> &'static str {
-        if self.as_u8() >= 31 {
-            // Protocol 31+ supports negotiated compression (zstd, lz4, zlibx, zlib).
-            // The actual preference depends on compile-time features, but zstd is
-            // the canonical recommendation for modern protocol versions.
-            "zstd"
-        } else {
-            "zlib"
-        }
+        compress::strategy::ProtocolCompressionProfile::for_protocol(self.as_u8())
+            .preferred_codec_name()
     }
 
     /// Returns `true` if this protocol version supports checksum negotiation.
@@ -304,6 +304,7 @@ impl ProtocolVersion {
 /// assert!(caps.multiplex());
 /// assert!(caps.extended_flags());
 /// assert!(caps.inline_hardlinks());
+/// # #[cfg(feature = "zstd")]
 /// assert_eq!(caps.preferred_compression(), "zstd");
 /// ```
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]

--- a/crates/protocol/src/version/protocol_version/tests.rs
+++ b/crates/protocol/src/version/protocol_version/tests.rs
@@ -600,17 +600,27 @@ fn capabilities_inline_hardlinks() {
 fn capabilities_preferred_compression() {
     use super::ProtocolCapabilities;
 
-    // Protocol 31+ prefers zstd.
+    // Protocol 30+ supports vstring negotiation. The preferred wire-name
+    // returned matches `valid_compressions_items[0]`: "zstd" when the
+    // feature is compiled in, "zlibx" otherwise.
     let caps_32 = ProtocolCapabilities::new(ProtocolVersion::V32);
-    assert_eq!(caps_32.preferred_compression(), "zstd");
-
     let caps_31 = ProtocolCapabilities::new(ProtocolVersion::V31);
-    assert_eq!(caps_31.preferred_compression(), "zstd");
-
-    // Protocol 30 and below prefers zlib.
     let caps_30 = ProtocolCapabilities::new(ProtocolVersion::V30);
-    assert_eq!(caps_30.preferred_compression(), "zlib");
+    #[cfg(feature = "zstd")]
+    {
+        assert_eq!(caps_32.preferred_compression(), "zstd");
+        assert_eq!(caps_31.preferred_compression(), "zstd");
+        assert_eq!(caps_30.preferred_compression(), "zstd");
+    }
+    #[cfg(not(feature = "zstd"))]
+    {
+        assert_eq!(caps_32.preferred_compression(), "zlibx");
+        assert_eq!(caps_31.preferred_compression(), "zlibx");
+        assert_eq!(caps_30.preferred_compression(), "zlibx");
+    }
 
+    // Protocol < 30 has no vstring negotiation; the preferred codec is
+    // always zlib (upstream: compat.c:556-563).
     let caps_28 = ProtocolCapabilities::new(ProtocolVersion::V28);
     assert_eq!(caps_28.preferred_compression(), "zlib");
 }


### PR DESCRIPTION
## Summary

- Add `compress::strategy::ProtocolCompressionProfile` - a const lookup table that replaces three scattered protocol-version branch sites with a single data-driven entry. `LEGACY` covers protocol < 30 (zlib only, no vstring negotiation); `MODERN` covers protocol >= 30 (vstring negotiation, zstd preferred when feature enabled).
- Re-route `CompressionAlgorithmKind::for_protocol_version`, `ProtocolAwareCompressionNegotiator::{supported_algorithms,select_algorithm}`, `DefaultCompressionNegotiator::supported_algorithms`, and `protocol::ProtocolVersion::preferred_compression` through the table.
- Fix two pre-existing inconsistencies that the consolidation surfaced:
  - `kind.rs::for_protocol_version` switched zlib -> zstd at protocol >= 36, a fictitious boundary (upstream `MAX_PROTOCOL_VERSION` is 40 and has no version-based codec switch; zstd is preferred whenever `SUPPORT_ZSTD` is defined and vstring negotiation is enabled, i.e. protocol >= 30 - upstream `compat.c:100-112`).
  - `capabilities.rs::preferred_compression` used >= 31 for zstd preference; the upstream-faithful boundary is >= 30.
- The new table follows upstream `compat.c:556-568` (no negotiation pre-30, fallback codec is zlib) and `compat.c:100-112` (`valid_compressions_items[]` order: zstd > zlibx > zlib > none when `SUPPORT_ZSTD`).
- No wire-protocol changes. No new external dependencies. No production runtime code depended on the old 36/31 thresholds; only tests and doc comments needed updates.

## Test plan

- [ ] `cargo nextest run -p compress --all-features` passes (full feature matrix incl. zstd, lz4, zlib-ng).
- [ ] `cargo nextest run -p compress --no-default-features` passes (validates `#[cfg(not(feature = \"zstd\"))]` profile branches).
- [ ] `cargo nextest run -p protocol --all-features` passes (verifies the rebound `preferred_compression` test).
- [ ] CI `fmt+clippy`, nextest (stable), Windows, macOS, Linux musl all green.
- [ ] CI `Interop Validation` workflow green - confirms the boundary correction does not regress wire-level negotiation against upstream rsync 3.0.9, 3.1.3, 3.4.1.