### PR TITLE
ci: raise coverage threshold to current baseline

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -63,9 +63,10 @@ jobs:
       # --branch enables LLVM branch coverage instrumentation (-C instrument-coverage=branch).
       # The profraw data then supports both line and branch coverage reports.
       # --fail-under-lines enforces the line coverage threshold only.
+      # Tightened from 80; raise toward 95 incrementally. See AGENTS.md.
       - name: Generate LCOV coverage report and enforce threshold
         id: coverage
-        run: cargo llvm-cov nextest --branch --workspace --all-features --lcov --output-path lcov.info --fail-under-lines 80
+        run: cargo llvm-cov nextest --branch --workspace --all-features --lcov --output-path lcov.info --fail-under-lines 84
 
       - name: Generate HTML coverage report
         if: always() && steps.coverage.outcome != 'skipped'


### PR DESCRIPTION
## Summary
- Raise `--fail-under-lines` from 80 to 84 in `.github/workflows/coverage.yml`.
- The new threshold is `floor(actual - 0.5)` where the actual baseline measured from the most recent successful master coverage run (run 24928631365, sha 902ce59e) is 85.0126% line coverage (LH=131699, LF=154917).
- This ratchets the floor to lock in the current level without immediately breaking CI. The long-term target per internal docs remains > 95%, to be raised incrementally.
- A previous attempt (PR #3382) jumped too high and broke CI; this change is intentionally conservative.

## Test plan
- [ ] Coverage workflow on this PR completes successfully with `--fail-under-lines 84`.
- [ ] No other CI checks affected (only `.github/workflows/coverage.yml` was touched).