### PR TITLE
refactor: wire PlatformCopy trait through LocalCopyOptions

### DIFF
--- a/crates/engine/src/local_copy/clonefile.rs
+++ b/crates/engine/src/local_copy/clonefile.rs
@@ -35,6 +35,8 @@
 use std::io;
 use std::path::Path;
 
+use fast_io::{DefaultPlatformCopy, PlatformCopy};
+
 /// Result of a clone-or-copy operation.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CloneResult {
@@ -46,38 +48,44 @@ pub enum CloneResult {
 
 /// Try to clone a file using copy-on-write if available.
 ///
-/// Falls back to standard copy on non-macOS or when clonefile fails
-/// (e.g., cross-filesystem, unsupported filesystem).
+/// Dispatches through [`DefaultPlatformCopy`], which selects the best available
+/// mechanism (clonefile/FICLONE/ReFS reflink) and falls back to portable copy
+/// when CoW is unavailable. To inject a custom strategy (for example in tests),
+/// see [`clone_or_copy_with`].
 ///
-/// Returns `Ok(CloneResult::Cloned)` if CoW clone succeeded,
-/// `Ok(CloneResult::Copied(bytes))` if standard copy was used,
-/// or `Err` on failure of both paths.
-///
-/// # Platform Behavior
-///
-/// - **macOS**: Attempts `clonefile()` first. On failure (e.g., cross-device,
-///   unsupported fs), falls back to `std::fs::copy`.
-/// - **Other platforms**: Always uses `std::fs::copy` (clonefile unavailable).
+/// Returns `Ok(CloneResult::Cloned)` when a zero-copy CoW reflink succeeded,
+/// `Ok(CloneResult::Copied(bytes))` when the platform fell back to a data
+/// copy, or `Err` when every strategy failed.
 ///
 /// # Errors
 ///
 /// Returns an error if:
 /// - Source file doesn't exist or isn't readable
 /// - Destination cannot be created (permission denied, invalid path, etc.)
-/// - Both clonefile and standard copy fail
+/// - All copy mechanisms fail
 pub fn clone_or_copy(src: &Path, dst: &Path) -> io::Result<CloneResult> {
-    // Try clonefile first (macOS only, returns Unsupported on other platforms)
-    match try_clonefile(src, dst) {
-        Ok(()) => Ok(CloneResult::Cloned),
-        Err(_e) => {
-            // Clonefile failed or not available, clean up any partial destination
-            // and fall back to standard copy
-            let _ = std::fs::remove_file(dst); // Ignore errors (dst may not exist)
+    clone_or_copy_with(&DefaultPlatformCopy::new(), src, dst)
+}
 
-            // Fall back to standard copy
-            let bytes = copy_file_standard(src, dst)?;
-            Ok(CloneResult::Copied(bytes))
-        }
+/// Variant of [`clone_or_copy`] that uses a caller-supplied [`PlatformCopy`].
+///
+/// Allows injecting a fake strategy in tests or wiring the strategy stored in
+/// `LocalCopyOptions` so that engine paths share a single copy backend.
+///
+/// # Errors
+///
+/// Returns an error if every mechanism in the supplied strategy fails.
+pub fn clone_or_copy_with(
+    platform_copy: &dyn PlatformCopy,
+    src: &Path,
+    dst: &Path,
+) -> io::Result<CloneResult> {
+    let size_hint = std::fs::metadata(src).map(|m| m.len()).unwrap_or(0);
+    let result = platform_copy.copy_file(src, dst, size_hint)?;
+    if result.is_zero_copy() {
+        Ok(CloneResult::Cloned)
+    } else {
+        Ok(CloneResult::Copied(result.bytes_copied))
     }
 }
 

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/execute.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/execute.rs
@@ -160,7 +160,28 @@ pub(in crate::local_copy) fn execute_transfer(
     };
     #[cfg(target_os = "macos")]
     if clonefile_eligible {
-        if let Ok(()) = crate::local_copy::clonefile::try_clonefile(source, destination) {
+        // Dispatch through the configured PlatformCopy. Only commit to the
+        // fast path when the strategy reported a true zero-copy reflink
+        // (clonefile/FICLONE/ReFS reflink); any data-copy fallback would
+        // bypass rsync's delta machinery without honouring the eligibility
+        // assumptions, so on non-zero-copy results we discard and fall
+        // through to the normal copy path below.
+        let cloned = match context
+            .options()
+            .platform_copy()
+            .copy_file(source, destination, file_size)
+        {
+            Ok(result) if result.is_zero_copy() => true,
+            Ok(_) => {
+                let _ = std::fs::remove_file(destination);
+                false
+            }
+            Err(_) => {
+                let _ = std::fs::remove_file(destination);
+                false
+            }
+        };
+        if cloned {
             let start = Instant::now();
             debug_log!(
                 Send,

--- a/crates/engine/src/local_copy/options/builder/definition.rs
+++ b/crates/engine/src/local_copy/options/builder/definition.rs
@@ -9,6 +9,7 @@ use std::time::{Duration, SystemTime};
 use ::metadata::{ChmodModifiers, CopyAsIds, GroupMapping, UserMapping};
 use compress::algorithm::CompressionAlgorithm;
 use compress::zlib::CompressionLevel;
+use fast_io::{DefaultPlatformCopy, PlatformCopy};
 use filters::FilterSet;
 
 use crate::batch::BatchWriter;
@@ -153,6 +154,8 @@ pub struct LocalCopyOptionsBuilder {
 
     pub(super) log_file: Option<PathBuf>,
     pub(super) log_file_format: Option<String>,
+
+    pub(super) platform_copy: Arc<dyn PlatformCopy>,
 }
 
 impl Default for LocalCopyOptionsBuilder {
@@ -264,6 +267,7 @@ impl LocalCopyOptionsBuilder {
             ignore_errors: false,
             log_file: None,
             log_file_format: None,
+            platform_copy: Arc::new(DefaultPlatformCopy::new()),
         }
     }
 

--- a/crates/engine/src/local_copy/options/builder/setters_misc.rs
+++ b/crates/engine/src/local_copy/options/builder/setters_misc.rs
@@ -4,6 +4,8 @@ use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime};
 
+use fast_io::PlatformCopy;
+
 use super::LocalCopyOptionsBuilder;
 use crate::batch::BatchWriter;
 use crate::signature::SignatureAlgorithm;
@@ -136,6 +138,16 @@ impl LocalCopyOptionsBuilder {
     #[must_use]
     pub fn batch_writer(mut self, writer: Option<Arc<Mutex<BatchWriter>>>) -> Self {
         self.batch_writer = writer;
+        self
+    }
+
+    /// Replaces the platform copy strategy used by whole-file fast paths.
+    ///
+    /// Defaults to [`fast_io::DefaultPlatformCopy`]. Tests can substitute a
+    /// custom implementation to verify dispatch.
+    #[must_use]
+    pub fn platform_copy(mut self, platform_copy: Arc<dyn PlatformCopy>) -> Self {
+        self.platform_copy = platform_copy;
         self
     }
 }

--- a/crates/engine/src/local_copy/options/builder/validation.rs
+++ b/crates/engine/src/local_copy/options/builder/validation.rs
@@ -191,6 +191,7 @@ impl LocalCopyOptionsBuilder {
             ignore_errors: self.ignore_errors,
             log_file: self.log_file,
             log_file_format: self.log_file_format,
+            platform_copy: self.platform_copy,
         }
     }
 }

--- a/crates/engine/src/local_copy/options/mod.rs
+++ b/crates/engine/src/local_copy/options/mod.rs
@@ -17,6 +17,7 @@ mod link_dest;
 mod logging;
 mod metadata;
 mod path_behavior;
+mod platform_copy;
 pub(crate) mod staging;
 mod types;
 

--- a/crates/engine/src/local_copy/options/platform_copy.rs
+++ b/crates/engine/src/local_copy/options/platform_copy.rs
@@ -1,0 +1,82 @@
+//! Platform copy strategy injection for local copy options.
+//!
+//! Exposes a setter and accessor for the `platform_copy` field on
+//! [`LocalCopyOptions`]. The strategy is consulted by whole-file copy
+//! paths (clonefile/CopyFileExW/std::fs::copy fallbacks) so callers and
+//! tests can substitute a custom implementation.
+
+use std::sync::Arc;
+
+use fast_io::PlatformCopy;
+
+use super::types::LocalCopyOptions;
+
+impl LocalCopyOptions {
+    /// Replaces the platform copy strategy used by whole-file fast paths.
+    ///
+    /// Defaults to [`fast_io::DefaultPlatformCopy`]; tests can inject a fake
+    /// implementation to verify dispatch.
+    #[must_use]
+    pub fn with_platform_copy(mut self, platform_copy: Arc<dyn PlatformCopy>) -> Self {
+        self.platform_copy = platform_copy;
+        self
+    }
+
+    /// Returns the configured platform copy strategy.
+    #[must_use]
+    pub fn platform_copy(&self) -> &Arc<dyn PlatformCopy> {
+        &self.platform_copy
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use fast_io::{CopyMethod, CopyResult, DefaultPlatformCopy};
+    use std::io;
+    use std::path::Path;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[derive(Debug, Default)]
+    struct CountingPlatformCopy {
+        calls: AtomicUsize,
+    }
+
+    impl PlatformCopy for CountingPlatformCopy {
+        fn copy_file(&self, _src: &Path, _dst: &Path, _size_hint: u64) -> io::Result<CopyResult> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Ok(CopyResult::new(0, CopyMethod::StandardCopy))
+        }
+
+        fn supports_reflink(&self) -> bool {
+            false
+        }
+
+        fn preferred_method(&self, _size: u64) -> CopyMethod {
+            CopyMethod::StandardCopy
+        }
+    }
+
+    #[test]
+    fn default_platform_copy_is_set() {
+        let opts = LocalCopyOptions::new();
+        // The default strategy is callable.
+        assert_eq!(
+            opts.platform_copy().preferred_method(0),
+            DefaultPlatformCopy::new().preferred_method(0)
+        );
+    }
+
+    #[test]
+    fn with_platform_copy_overrides_default() {
+        let counting = Arc::new(CountingPlatformCopy::default());
+        let opts = LocalCopyOptions::new().with_platform_copy(counting.clone());
+        // Invoke through the option to confirm the injected impl is reachable.
+        let result = opts
+            .platform_copy()
+            .copy_file(Path::new("/dev/null"), Path::new("/dev/null"), 0)
+            .expect("counting strategy returns Ok");
+        assert_eq!(result.method, CopyMethod::StandardCopy);
+        assert_eq!(counting.calls.load(Ordering::SeqCst), 1);
+    }
+}

--- a/crates/engine/src/local_copy/options/types.rs
+++ b/crates/engine/src/local_copy/options/types.rs
@@ -7,6 +7,7 @@ use std::time::{Duration, SystemTime};
 use ::metadata::{ChmodModifiers, CopyAsIds, GroupMapping, UserMapping};
 use compress::algorithm::CompressionAlgorithm;
 use compress::zlib::CompressionLevel;
+use fast_io::{DefaultPlatformCopy, PlatformCopy};
 use filters::FilterSet;
 
 use crate::batch::BatchWriter;
@@ -191,6 +192,13 @@ pub struct LocalCopyOptions {
     pub(super) log_file: Option<PathBuf>,
     /// Optional format string for per-item log entries.
     pub(super) log_file_format: Option<String>,
+    /// Platform-abstracted file copy strategy used by whole-file copy paths.
+    ///
+    /// Defaults to [`DefaultPlatformCopy`], which selects the best available
+    /// mechanism (FICLONE/copy_file_range on Linux, clonefile/fcopyfile on
+    /// macOS, ReFS reflink/CopyFileExW on Windows) with portable fallback.
+    /// Tests can inject a fake implementation to verify dispatch.
+    pub(super) platform_copy: Arc<dyn PlatformCopy>,
 }
 
 impl LocalCopyOptions {
@@ -296,6 +304,7 @@ impl LocalCopyOptions {
             ignore_errors: false,
             log_file: None,
             log_file_format: None,
+            platform_copy: Arc::new(DefaultPlatformCopy::new()),
         }
     }
 }

--- a/crates/engine/src/local_copy/win_copy.rs
+++ b/crates/engine/src/local_copy/win_copy.rs
@@ -40,6 +40,8 @@
 use std::io;
 use std::path::Path;
 
+use fast_io::{CopyMethod, DefaultPlatformCopy, PlatformCopy};
+
 /// Threshold above which COPY_FILE_NO_BUFFERING is used on Windows.
 ///
 /// Re-exported from [`fast_io::copy_file_ex::NO_BUFFERING_THRESHOLD`] for
@@ -115,18 +117,29 @@ impl WinCopyResult {
 /// assert_eq!(result.bytes_copied(), 4);
 /// ```
 pub fn copy_file_optimized(src: &Path, dst: &Path) -> io::Result<WinCopyResult> {
-    // Try Windows-optimized copy first (returns Unsupported on other platforms)
-    match fast_io::copy_file_ex::try_copy_file_ex(src, dst) {
-        Ok(bytes) => Ok(WinCopyResult::WindowsCopy(bytes)),
-        Err(_e) => {
-            // Windows copy failed or not available, clean up any partial destination
-            // and fall back to standard copy
-            let _ = std::fs::remove_file(dst); // Ignore errors (dst may not exist)
+    copy_file_optimized_with(&DefaultPlatformCopy::new(), src, dst)
+}
 
-            // Fall back to standard copy
-            let bytes = copy_file_standard(src, dst)?;
-            Ok(WinCopyResult::StandardCopy(bytes))
+/// Variant of [`copy_file_optimized`] that uses a caller-supplied [`PlatformCopy`].
+///
+/// Allows injecting a fake strategy in tests or wiring the strategy stored in
+/// `LocalCopyOptions` so engine paths share a single copy backend.
+///
+/// # Errors
+///
+/// Returns an error if every mechanism in the supplied strategy fails.
+pub fn copy_file_optimized_with(
+    platform_copy: &dyn PlatformCopy,
+    src: &Path,
+    dst: &Path,
+) -> io::Result<WinCopyResult> {
+    let size_hint = std::fs::metadata(src).map(|m| m.len()).unwrap_or(0);
+    let result = platform_copy.copy_file(src, dst, size_hint)?;
+    match result.method {
+        CopyMethod::CopyFileEx | CopyMethod::ReFsReflink => {
+            Ok(WinCopyResult::WindowsCopy(result.bytes_copied))
         }
+        _ => Ok(WinCopyResult::StandardCopy(result.bytes_copied)),
     }
 }
 

--- a/crates/fast_io/src/platform_copy/types.rs
+++ b/crates/fast_io/src/platform_copy/types.rs
@@ -119,7 +119,7 @@ impl CopyResult {
 ///
 /// - [`DefaultPlatformCopy`](super::DefaultPlatformCopy) - auto-selects the best mechanism per platform
 /// - Custom implementations can be provided for testing or specialized behavior
-pub trait PlatformCopy: Send + Sync {
+pub trait PlatformCopy: fmt::Debug + Send + Sync {
     /// Copies a file from `src` to `dst`, selecting the best platform mechanism.
     ///
     /// The `size_hint` parameter is advisory - it helps select the optimal copy


### PR DESCRIPTION
## Summary

- Adds `platform_copy: Arc<dyn PlatformCopy>` to `LocalCopyOptions` (default `DefaultPlatformCopy`) and a matching builder setter, so whole-file copy fast paths share a single, swappable strategy.
- Migrates three call sites to dispatch through the configured strategy:
  - `engine::local_copy::clonefile::clone_or_copy` - now delegates to the new `clone_or_copy_with(&dyn PlatformCopy, ...)` variant.
  - `engine::local_copy::win_copy::copy_file_optimized` - now delegates to the new `copy_file_optimized_with(&dyn PlatformCopy, ...)` variant.
  - `engine::local_copy::executor::file::copy::transfer::execute` macOS clonefile fast path - now uses `context.options().platform_copy().copy_file()` and only commits to the fast path on a true zero-copy reflink (`is_zero_copy()`), discarding any data-copy fallback so transfer falls through to the normal rsync delta path.
- Adds `fmt::Debug` as a supertrait of `PlatformCopy` so `LocalCopyOptions` (which derives `Debug`) can hold the trait object.
- Adds a unit test that injects a fake `CountingPlatformCopy` and verifies the strategy is invoked through `LocalCopyOptions::platform_copy()`.

## Test plan

- [ ] CI: fmt + clippy
- [ ] CI: nextest (stable) - covers the new `platform_copy` injection unit test
- [ ] CI: Windows / macOS / Linux musl matrix