### PR TITLE
fix: report logical bytes for zero-copy clonefile/FICLONE/ReFS paths

### DIFF
--- a/crates/engine/src/local_copy/win_copy.rs
+++ b/crates/engine/src/local_copy/win_copy.rs
@@ -135,11 +135,19 @@ pub fn copy_file_optimized_with(
 ) -> io::Result<WinCopyResult> {
     let size_hint = std::fs::metadata(src).map(|m| m.len()).unwrap_or(0);
     let result = platform_copy.copy_file(src, dst, size_hint)?;
+    // Zero-copy reflink methods (clonefile/FICLONE/ReFS) return
+    // bytes_copied=0 because no data physically traversed userspace.
+    // The caller-facing byte count is the logical file size so that
+    // progress and statistics reflect the data made available at the
+    // destination, matching upstream rsync's accounting.
+    let bytes = if result.is_zero_copy() {
+        size_hint
+    } else {
+        result.bytes_copied
+    };
     match result.method {
-        CopyMethod::CopyFileEx | CopyMethod::ReFsReflink => {
-            Ok(WinCopyResult::WindowsCopy(result.bytes_copied))
-        }
-        _ => Ok(WinCopyResult::StandardCopy(result.bytes_copied)),
+        CopyMethod::CopyFileEx | CopyMethod::ReFsReflink => Ok(WinCopyResult::WindowsCopy(bytes)),
+        _ => Ok(WinCopyResult::StandardCopy(bytes)),
     }
 }
 


### PR DESCRIPTION
## Summary

- Fix `copy_file_optimized_with` in `crates/engine/src/local_copy/win_copy.rs` to report the logical file size (via `size_hint`) when the underlying platform copy used a zero-copy reflink method (clonefile/FICLONE/ReFS `DUPLICATE_EXTENTS`).
- Resolves macOS test failures `test_copy_large_file` and `test_copy_file_optimized_result_type` that have been blocking master and several open PRs (#3391, #3392, #3393).
- Preserves the lower-layer dispatch contract: `platform_copy` still returns `bytes_copied=0` for zero-copy methods (verified by `crates/fast_io/src/platform_copy/tests.rs`).

## Root cause

`dispatch::platform_copy_impl` correctly returns `CopyResult { bytes_copied: 0, method: Clonefile }` because no bytes physically traversed userspace. The `win_copy` user-facing wrapper passed this through, so `WinCopyResult::StandardCopy(0)` was reported even when a multi-MB file was cloned.

## Fix

Use `CopyResult::is_zero_copy()` (already exists for exactly this distinction) to substitute the source `size_hint` for the user-facing byte count when the operation went through a zero-copy path. Statistics and progress now reflect the data made available at the destination, matching upstream rsync's accounting.

## Test plan

- [x] Local build/lint clean (per workflow policy, full nextest deferred to CI)
- [ ] CI: macOS stable
- [ ] CI: Linux musl + Windows stable (regression check)
- [ ] CI: fmt + clippy