### PR TITLE
test: xattr capability negotiation when remote lacks xattr (#1393)

### DIFF
--- a/crates/protocol/src/flist/write/tests.rs
+++ b/crates/protocol/src/flist/write/tests.rs
@@ -2691,3 +2691,71 @@ fn xattr_write_roundtrip_with_reader() {
     let list = cached.unwrap();
     assert_eq!(list.len(), 1);
 }
+
+/// When the negotiated peer capabilities lack xattr support, the file list
+/// writer must NOT emit xattr wire bytes - even if the local file entry
+/// happens to carry an attached xattr list. The gating boolean
+/// `preserve.xattrs` mirrors the negotiated state derived from
+/// `CompatibilityFlags::AVOID_XATTR_OPTIMIZATION`. Suppression must be
+/// silent: no error, no partial emission.
+///
+/// upstream: flist.c:send_file_entry() line 656 - `send_xattr()` is only
+/// invoked when `preserve_xattrs` is set in the receiver's option block.
+#[test]
+fn xattr_emission_suppressed_when_peer_lacks_xattr_capability() {
+    use crate::xattr::{XattrEntry, XattrList};
+
+    // Simulate the post-negotiation state where the remote peer did not
+    // advertise CF_AVOID_XATTR_OPTIM, causing the local options layer to
+    // clear the xattrs preserve flag. The default for `PreserveFlags` is
+    // false, but we construct the writer explicitly to document intent.
+    let mut writer_no_xattr = FileListWriter::new(test_protocol()).with_preserve_xattrs(false);
+
+    let mut entry_with_xattr = FileEntry::new_file("attrs_attached.txt".into(), 100, 0o644);
+    entry_with_xattr.set_mtime(1700000000, 0);
+    let mut xattr_list = XattrList::new();
+    xattr_list.push(XattrEntry::new("user.tag", b"local-only".to_vec()));
+    xattr_list.push(XattrEntry::new(
+        "security.selinux",
+        b"system_u:object_r:default_t:s0".to_vec(),
+    ));
+    entry_with_xattr.set_xattr_list(xattr_list);
+
+    let mut buf_suppressed = Vec::new();
+    writer_no_xattr
+        .write_entry(&mut buf_suppressed, &entry_with_xattr)
+        .expect("write must succeed even when xattr emission is suppressed");
+
+    // Baseline: same writer config, identical entry but with no xattr list
+    // attached. Wire bytes must match exactly because xattrs are gated off.
+    let mut writer_baseline = FileListWriter::new(test_protocol()).with_preserve_xattrs(false);
+    let mut entry_no_xattr = FileEntry::new_file("attrs_attached.txt".into(), 100, 0o644);
+    entry_no_xattr.set_mtime(1700000000, 0);
+
+    let mut buf_baseline = Vec::new();
+    writer_baseline
+        .write_entry(&mut buf_baseline, &entry_no_xattr)
+        .expect("baseline write must succeed");
+
+    assert_eq!(
+        buf_suppressed, buf_baseline,
+        "writer with peer xattr capability OFF must emit identical bytes \
+         regardless of attached xattr_list - no xattr wire data leaks",
+    );
+
+    // Cross-check: enabling preservation produces strictly more bytes
+    // (literal xattr block appended), proving the suppression in the
+    // baseline is meaningful and not a no-op of the encoder.
+    let mut writer_enabled = FileListWriter::new(test_protocol()).with_preserve_xattrs(true);
+    let mut buf_enabled = Vec::new();
+    writer_enabled
+        .write_entry(&mut buf_enabled, &entry_with_xattr)
+        .expect("enabled write must succeed");
+    assert!(
+        buf_enabled.len() > buf_suppressed.len(),
+        "enabling xattr preservation must add wire bytes \
+         (enabled={}, suppressed={})",
+        buf_enabled.len(),
+        buf_suppressed.len(),
+    );
+}


### PR DESCRIPTION
## Summary
- Adds a focused unit test verifying that `FileListWriter` suppresses xattr wire emission when the negotiated peer capability flag is absent, mirroring upstream `flist.c:send_file_entry()` gating on `preserve_xattrs`.
- Confirms suppression is silent (no error, byte-identical baseline) and meaningful (enabling preservation produces strictly more bytes).

## Test plan
- [ ] `cargo nextest run -p protocol --all-features -E 'test(xattr_emission_suppressed_when_peer_lacks_xattr_capability)'`
- [ ] CI: fmt+clippy
- [ ] CI: nextest stable (Linux, macOS, Windows, Linux musl)

Closes #1393