### PR TITLE
fix: socket2 0.6 renamed set_nodelay/set_tos methods

### DIFF
--- a/crates/daemon/src/daemon/sections/server_runtime/socket_options.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/socket_options.rs
@@ -151,12 +151,29 @@ fn apply_socket_options_impl(
 ) -> io::Result<()> {
     for opt in options {
         match opt {
-            SocketOption::TcpNoDelay(enabled) => sock.set_nodelay(*enabled)?,
+            SocketOption::TcpNoDelay(enabled) => sock.set_tcp_nodelay(*enabled)?,
             SocketOption::SoKeepAlive(enabled) => sock.set_keepalive(*enabled)?,
             SocketOption::SoSndBuf(size) => sock.set_send_buffer_size(*size)?,
             SocketOption::SoRcvBuf(size) => sock.set_recv_buffer_size(*size)?,
-            SocketOption::IpTos(tos) => sock.set_tos(*tos)?,
+            SocketOption::IpTos(tos) => apply_ip_tos(&sock, *tos)?,
         }
     }
     Ok(())
+}
+
+/// Sets IP_TOS / IPV6_TCLASS depending on the socket's address family.
+///
+/// socket2 0.6 split the unified `set_tos` into `set_tos_v4` (u8) for IPv4 and
+/// `set_tclass_v6` (u32) for IPv6. Upstream rsync's `socket.c` calls
+/// `setsockopt(..., IPPROTO_IP, IP_TOS, ...)` which only succeeds on AF_INET
+/// sockets; we mirror that semantics for v4 and apply the equivalent
+/// `IPV6_TCLASS` for v6.
+fn apply_ip_tos(sock: &socket2::SockRef<'_>, tos: u32) -> io::Result<()> {
+    match sock.local_addr()?.as_socket() {
+        Some(std::net::SocketAddr::V4(_)) => sock.set_tos_v4(tos as u8),
+        Some(std::net::SocketAddr::V6(_)) => sock.set_tclass_v6(tos),
+        None => Err(io::Error::other(
+            "cannot determine socket address family for IP_TOS",
+        )),
+    }
 }


### PR DESCRIPTION
## Summary
- socket2 0.6 (merged via dependabot PR #3407) renamed `set_nodelay` to `set_tcp_nodelay` and split the unified `set_tos` into address-family specific `set_tos_v4(u8)` (IPv4) and `set_tclass_v6(u32)` (IPv6).
- Master CI is currently broken with `E0599: no method named set_nodelay`/`set_tos` on `socket2::SockRef`, blocking all open PRs.
- This change updates `apply_socket_options_impl` to use the new method names and adds an `apply_ip_tos` helper that dispatches by local address family.

## Rationale
Upstream rsync's `socket.c` calls `setsockopt(IPPROTO_IP, IP_TOS, ...)` which only succeeds on AF_INET sockets. We mirror that semantics for v4 and apply the equivalent `IPV6_TCLASS` for v6 (common values like `0x10`/LOWDELAY and `0x08`/THROUGHPUT all fit in `u8`).

## Test plan
- [ ] CI: fmt + clippy
- [ ] CI: nextest workspace (Linux/macOS/Windows/musl)
- [ ] CI: MSRV 1.88