### PR TITLE
docs: add Windows feature parity matrix to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,28 @@ All transfer modes (local, SSH, daemon), delta algorithm, metadata preservation,
 | **Reference dirs** | `--compare-dest`, `--link-dest`, `--copy-dest` |
 | **Options** | `--delay-updates`, `--inplace`, `--partial`, `--iconv`, fuzzy matching |
 | **I/O** | io_uring (Linux 5.6+), `copy_file_range`, `clonefile` (macOS), adaptive buffers |
-| **Platforms** | Linux, macOS (full); Windows (partial - no ACLs/xattrs) |
+| **Platforms** | Linux, macOS (full); Windows (partial - no ACLs/xattrs/symlinks/devices) |
+
+### Platform Support
+
+The primary platform is Linux. macOS is well-supported with parity for all metadata, ACL, and xattr features. Windows builds and runs core transfer modes, but several POSIX-specific features are stubbed; ongoing work targets Windows ACL preservation (#1866), Windows xattr (alternate data stream) preservation (#1867), and wiring IOCP into the transfer pipeline (#1868).
+
+| Feature | Linux | macOS | Windows | Notes |
+|---------|:-----:|:-----:|:-------:|-------|
+| Permissions (`-p`) | ✓ | ✓ | ⚠ | Windows preserves only the read-only flag; POSIX mode bits are not applicable. |
+| Times (`-t`) | ✓ | ✓ | ✓ | Nanosecond precision via the `filetime` crate on all platforms. |
+| File ownership (`-o`/`-g`, uid/gid) | ✓ | ✓ | ✗ | `apply_ownership_from_entry` is a no-op on non-Unix; uid/gid mapping is Unix-only. |
+| ACLs (`-A`) | ✓ | ✓ | ✗ | Uses `exacl` on Linux/macOS/FreeBSD; Windows falls through to a no-op stub with a one-time warning (see #1866). |
+| Extended attributes (`-X`) | ✓ | ✓ | ✗ | Wired only behind `cfg(all(unix, feature = "xattr"))`; non-Unix uses a no-op stub with a one-time warning (see #1867). |
+| Hardlinks (`-H`) | ✓ | ✓ | ✓ | Uses portable `std::fs::hard_link`; works on NTFS. |
+| Symbolic links | ✓ | ✓ | ✗ | `create_symlinks` is `cfg(not(unix))` no-op; symlink entries are skipped on Windows. |
+| Devices/specials (`-D`) | ✓ | ✓ | ✗ | `create_fifo` and `create_device_node` are no-ops on non-Unix. |
+| Sparse files (`-S`) | ✓ | ✓ | ⚠ | Uses portable `seek` + `set_len`; depends on filesystem (NTFS supports sparse but is not explicitly marked via `FSCTL_SET_SPARSE`). |
+| Async I/O backend | ✓ io_uring | ⚠ standard I/O | ⚠ IOCP compiled, not wired | io_uring runtime-detected on Linux 5.6+; IOCP is implemented in `fast_io` but not yet consumed by the transfer pipeline (#1868). |
+| Reflink / clone copy | ✓ FICLONE | ✓ clonefile | ⚠ ReFS reflink | Linux Btrfs/XFS/bcachefs via `FICLONE`; macOS via `clonefile`; Windows via `FSCTL_DUPLICATE_EXTENTS_TO_FILE` (ReFS only). |
+| Optimized file copy | ✓ `copy_file_range` | ✓ `fcopyfile` | ✓ `CopyFileExW` | All three are wired into the local-copy executor with standard-I/O fallback. |
+
+Legend: ✓ supported, ⚠ partial or not yet wired, ✗ not implemented.
 
 ### What's New (v0.6.0)
 


### PR DESCRIPTION
## Summary

Adds a compact platform feature parity table to README.md so users have realistic expectations about Windows support. The previous wording (`Linux, macOS (full); Windows (partial - no ACLs/xattrs)`) understated the gap; the new section documents which features are stubbed and links to the open implementation tasks.

The matrix was built from a code-level audit of `#[cfg(unix)]` / `#[cfg(not(unix))]` gates in `crates/metadata/` and `crates/fast_io/`, not from memory:

| Feature | Linux | macOS | Windows |
|---------|:-----:|:-----:|:-------:|
| Permissions (`-p`) | OK | OK | partial (read-only flag only) |
| Times (`-t`) | OK | OK | OK |
| Ownership (uid/gid) | OK | OK | not implemented |
| ACLs (`-A`) | OK | OK | not implemented (#1866) |
| Xattrs (`-X`) | OK | OK | not implemented (#1867) |
| Hardlinks (`-H`) | OK | OK | OK |
| Symlinks | OK | OK | not implemented |
| Devices/specials (`-D`) | OK | OK | not implemented |
| Sparse (`-S`) | OK | OK | partial |
| Async I/O | io_uring | std I/O | IOCP compiled, not wired (#1868) |
| Reflink | FICLONE | clonefile | ReFS reflink |
| Optimized copy | `copy_file_range` | `fcopyfile` | `CopyFileExW` |

A short preamble explains that Linux is the primary platform, macOS is well-supported, and Windows has known gaps with ongoing work.

Closes task #1870. Related implementation tasks: #1866 (Windows ACLs), #1867 (Windows xattrs), #1868 (IOCP benchmark and wiring).

## Test plan

- [ ] CI fmt+clippy passes (no Rust changes; doc-only)
- [ ] Visual inspection of rendered README on GitHub