### PR TITLE
docs: SSH stdio io_uring constraint and sender INC_RECURSE state machine

### DIFF
--- a/crates/rsync_io/src/ssh/mod.rs
+++ b/crates/rsync_io/src/ssh/mod.rs
@@ -53,6 +53,26 @@
 //!
 //! - [`crate::negotiate_session`] for the negotiation façade that consumes
 //!   [`SshConnection`] streams.
+//!
+//! # io_uring and SSH stdio
+//!
+//! The SSH data channel is the spawned `ssh` child's inherited stdio: a
+//! `(stdin, stdout)` pipe pair created by `Command::spawn`, not a socket.
+//! The `fast_io` io_uring `socket_reader` / `socket_writer` fast paths
+//! require an `AF_INET`/`AF_INET6` socket FD and are therefore unreachable
+//! for SSH transfers - regardless of kernel version or `io_uring_policy`.
+//! This mirrors upstream rsync, which also performs blocking reads/writes
+//! on the inherited stdio FDs when invoked over SSH (`main.c:504 do_cmd()`).
+//!
+//! The Linux kernel does support submitting `IORING_OP_READ` /
+//! `IORING_OP_WRITE` against pipe FDs (5.1+), and `splice()` / `vmsplice()`
+//! enable zero-copy pipe transfers. Wiring these into the SSH transport
+//! is tracked separately as tasks #1859 (pipe-FD io_uring) and #1860
+//! (splice-based zero-copy).
+//!
+//! Daemon-mode TCP sockets and local-disk transfers DO benefit from
+//! `fast_io`: TCP uses the socket fast path, and on-disk file I/O uses
+//! the io_uring read/write submission paths.
 
 mod aux_channel;
 mod builder;

--- a/crates/transfer/src/generator/mod.rs
+++ b/crates/transfer/src/generator/mod.rs
@@ -28,6 +28,56 @@
 //! - [`engine::delta::DeltaSignatureIndex`] - Fast block lookup for delta generation
 //! - [`engine::signature`] - Signature reconstruction from wire format
 //! - [`protocol::wire`] - Wire format for signatures and deltas
+//!
+//! # Sender-side INC_RECURSE state machine
+//!
+//! When the sender advertises and negotiates `INC_RECURSE` (`'i'` capability),
+//! the file list is streamed as per-directory sub-segments rather than as one
+//! monolithic list. The send loop drives the following state machine:
+//!
+//! ```text
+//!   Idle -> ScanDir -> SendChunk -> WaitAck -> NextDir -> Done
+//!     ^                                          |
+//!     +------------------------------------------+
+//! ```
+//!
+//! - **Idle**: handshake complete, top-level entries enqueued.
+//! - **ScanDir**: walk one directory; produce a `PendingSegment`.
+//! - **SendChunk**: emit the segment via `send_file_list` /
+//!   `encode_and_send_segment`, throttled by `MIN_FILECNT_LOOKAHEAD`
+//!   (see `SegmentScheduler`).
+//! - **WaitAck**: process incoming NDX requests / signatures from the
+//!   receiver while the next segment is staged.
+//! - **NextDir**: advance the cursor; loop back to ScanDir.
+//! - **Done**: emit `NDX_FLIST_EOF` (`flist_eof_sent = true`) and proceed
+//!   to the goodbye phase.
+//!
+//! ## Upstream Reference
+//!
+//! - `flist.c:2192 send_file_list()` - top-level + initial segment dispatch.
+//! - `flist.c:send_extra_file_list()` - per-directory sub-segments,
+//!   `MIN_FILECNT_LOOKAHEAD` throttling, `NDX_FLIST_EOF` finalization.
+//! - `sender.c:199 send_files()` - main send loop, calls into segment
+//!   scheduling at the top and bottom of each iteration (lines ~227, ~261).
+//! - `generator.c:2226 generate_files()` - peer side that consumes the
+//!   segmented stream and drives signature/data exchange.
+//! - `receiver.c:522 recv_files()` - receiver-side counterpart to the
+//!   sender's segmented dispatch.
+//! - `compat.c:161 set_allow_inc_recurse()` - capability negotiation gate
+//!   (`allow_inc_recurse` is cleared when `!recurse || use_qsort` or when
+//!   the sender side cannot satisfy the segmentation contract).
+//!
+//! ## Current status
+//!
+//! The sender-side state machine and segment scheduler are implemented
+//! (see `IncrementalState`, `SegmentScheduler`, `PendingSegment`),
+//! but oc-rsync does NOT advertise the `'i'` capability when acting as
+//! sender. [`crate::setup::build_capability_string`] is
+//! invoked with `allow_inc_recurse = !is_sender`, so push transfers
+//! omit `'i'` from the capability string sent to the daemon. This is a
+//! deliberate, documented gate while sender-side interop is validated
+//! against upstream rsync 3.0.9 / 3.1.3 / 3.4.1; see task #1862.
+//! Pull transfers (oc-rsync as receiver) negotiate INC_RECURSE normally.
 
 mod delta;
 mod file_list;


### PR DESCRIPTION
## Summary

Two doc-only additions covering questions that recur during reviews and onboarding. No code logic changes.

### Task #1858 - SSH stdio io_uring limitation note

Extends the `crates/rsync_io/src/ssh/mod.rs` module rustdoc to explain:

- The SSH data channel is the inherited stdio (`stdin`/`stdout`) of the spawned `ssh` child - a pipe pair, not an `AF_INET`/`AF_INET6` socket.
- The `fast_io` io_uring `socket_reader` / `socket_writer` paths require a socket FD, so they are unreachable for SSH regardless of kernel version or `io_uring_policy`.
- Linux alternatives that exist for pipe FDs (`IORING_OP_READ`/`IORING_OP_WRITE` since 5.1, `splice()` / `vmsplice()` for zero-copy) are tracked separately as #1859 and #1860.
- Daemon-mode TCP and local-disk transfers DO benefit from `fast_io`.
- Mirrors upstream rsync, which also performs blocking reads/writes on inherited stdio FDs (`main.c:504 do_cmd()`).

### Task #1865 - Sender-side INC_RECURSE state machine doc

Extends the `crates/transfer/src/generator/mod.rs` module rustdoc with:

- The state machine: `Idle -> ScanDir -> SendChunk -> WaitAck -> NextDir -> Done`.
- Upstream citations (verified against `target/interop/upstream-src/rsync-3.4.1/`):
  - `flist.c:2192 send_file_list()`
  - `flist.c send_extra_file_list()`
  - `sender.c:199 send_files()` (segment dispatch at top/bottom of loop)
  - `generator.c:2226 generate_files()`
  - `receiver.c:522 recv_files()`
  - `compat.c:161 set_allow_inc_recurse()`
- Status note: sender-side state machine and segment scheduler are implemented (`IncrementalState` / `SegmentScheduler` / `PendingSegment`), but `'i'` is NOT advertised when oc-rsync is sender. `build_capability_string` is called with `allow_inc_recurse = !is_sender` until interop is validated (task #1862). Pull transfers negotiate INC_RECURSE normally.

Closes #1858. Closes #1865.

## Test plan

- [x] `cargo fmt --all` clean
- [ ] CI: fmt+clippy
- [ ] CI: nextest (stable)
- [ ] CI: Windows / macOS / Linux musl
- [ ] CI: rustdoc renders the new module docs without broken intra-doc links