### PR TITLE
perf: add 10K-10M scaling benchmark for ring-buffer ReorderBuffer

### DIFF
--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -144,3 +144,7 @@ harness = false
 [[bench]]
 name = "buffer_pool_contention"
 harness = false
+
+[[bench]]
+name = "reorder_buffer_scaling"
+harness = false

--- a/crates/engine/benches/reorder_buffer_scaling.rs
+++ b/crates/engine/benches/reorder_buffer_scaling.rs
@@ -1,0 +1,138 @@
+//! Scaling benchmark for the `concurrent_delta::ReorderBuffer` ring buffer.
+//!
+//! Measures insert + drain throughput at 10K, 100K, 1M, and 10M items, comparing
+//! the production ring-buffer `ReorderBuffer` against a `BTreeMap`-backed
+//! baseline. The ring buffer is expected to scale linearly (O(1) per item),
+//! while the `BTreeMap` baseline scales as O(n log n) overall.
+//!
+//! Run with: `cargo bench -p engine --bench reorder_buffer_scaling`
+//!
+//! The 10M case is gated behind `--features bench-reorder-10m` style invocations
+//! through the `BENCH_REORDER_10M=1` environment variable to keep the default
+//! benchmark run within reasonable wall-clock time.
+
+#![deny(unsafe_code)]
+
+use std::collections::BTreeMap;
+
+use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
+use engine::concurrent_delta::ReorderBuffer;
+
+/// Generates a deterministic shuffled permutation of `0..count` using a simple
+/// linear congruential generator. Produces small local out-of-order gaps that
+/// resemble realistic worker-thread completion patterns.
+fn shuffled_with_local_swaps(count: usize) -> Vec<u64> {
+    let mut seq: Vec<u64> = (0..count as u64).collect();
+    let mut state: u64 = 0xDEAD_BEEF_CAFE_1234;
+    // Swap each element with one within a small local window so out-of-order
+    // gaps stay bounded by capacity and exercise the fast path.
+    let window = 16;
+    for i in 0..seq.len() {
+        state = state
+            .wrapping_mul(6_364_136_223_846_793_005)
+            .wrapping_add(1_442_695_040_888_963_407);
+        let span = ((state >> 33) as usize) % window;
+        let j = (i + span).min(seq.len() - 1);
+        seq.swap(i, j);
+    }
+    seq
+}
+
+/// Inserts items into the ring-buffer `ReorderBuffer`, draining opportunistically
+/// to keep the ring within capacity.
+fn run_ring(insertion_order: &[u64], capacity: usize) -> u64 {
+    let mut buf: ReorderBuffer<u64> = ReorderBuffer::new(capacity);
+    let mut sum: u64 = 0;
+    for &seq in insertion_order {
+        // On capacity exceeded, drain ready items then force-insert to make room.
+        if buf.insert(seq, seq).is_err() {
+            for v in buf.drain_ready() {
+                sum = sum.wrapping_add(v);
+            }
+            buf.force_insert(seq, seq);
+        }
+        for v in buf.drain_ready() {
+            sum = sum.wrapping_add(v);
+        }
+    }
+    for v in buf.drain_ready() {
+        sum = sum.wrapping_add(v);
+    }
+    sum
+}
+
+/// Inserts items into a `BTreeMap`-backed reorder buffer, draining contiguous
+/// runs from `next_expected`. Mirrors the pre-#1734 implementation that the
+/// ring buffer replaced.
+fn run_btreemap(insertion_order: &[u64]) -> u64 {
+    let mut pending: BTreeMap<u64, u64> = BTreeMap::new();
+    let mut next_expected: u64 = 0;
+    let mut sum: u64 = 0;
+    for &seq in insertion_order {
+        pending.insert(seq, seq);
+        while let Some(v) = pending.remove(&next_expected) {
+            sum = sum.wrapping_add(v);
+            next_expected += 1;
+        }
+    }
+    sum
+}
+
+fn bench_count(c: &mut Criterion, count: usize, group_name: &str) {
+    let mut group = c.benchmark_group(group_name);
+    group.throughput(Throughput::Elements(count as u64));
+    // Larger counts dominate criterion's default sample size; reduce for
+    // 1M and 10M to keep wall time reasonable.
+    if count >= 1_000_000 {
+        group.sample_size(10);
+    }
+
+    let order = shuffled_with_local_swaps(count);
+
+    // Capacity must comfortably exceed the local swap window (16) so the ring
+    // path stays on the O(1) fast track without falling back to grow.
+    let capacity = 1024usize;
+
+    group.bench_with_input(
+        BenchmarkId::new("ring", format!("cap{capacity}")),
+        &order,
+        |b, order| {
+            b.iter(|| black_box(run_ring(black_box(order), capacity)));
+        },
+    );
+
+    group.bench_with_input(
+        BenchmarkId::new("btreemap", "baseline"),
+        &order,
+        |b, order| {
+            b.iter(|| black_box(run_btreemap(black_box(order))));
+        },
+    );
+
+    group.finish();
+}
+
+fn bench_10k(c: &mut Criterion) {
+    bench_count(c, 10_000, "reorder_scaling_10k");
+}
+
+fn bench_100k(c: &mut Criterion) {
+    bench_count(c, 100_000, "reorder_scaling_100k");
+}
+
+fn bench_1m(c: &mut Criterion) {
+    bench_count(c, 1_000_000, "reorder_scaling_1m");
+}
+
+/// 10M scaling run, gated behind `BENCH_REORDER_10M=1` so default benchmark
+/// invocations stay fast. Provides the data point the perf review needs to
+/// confirm O(1) per item at million-plus file counts.
+fn bench_10m(c: &mut Criterion) {
+    if std::env::var("BENCH_REORDER_10M").is_err() {
+        return;
+    }
+    bench_count(c, 10_000_000, "reorder_scaling_10m");
+}
+
+criterion_group!(benches, bench_10k, bench_100k, bench_1m, bench_10m);
+criterion_main!(benches);

--- a/crates/engine/src/concurrent_delta/mod.rs
+++ b/crates/engine/src/concurrent_delta/mod.rs
@@ -12,7 +12,7 @@
 //! | `types` | [`DeltaWork`], [`DeltaResult`] | Per-file work item (NDX, paths, size) and outcome (stats, redo/fail status) |
 //! | [`work_queue`] | `WorkQueueSender` / `WorkQueueReceiver` | Bounded `crossbeam_channel` (2x thread count) with backpressure |
 //! | [`strategy`] | [`DeltaStrategy`] trait | Dispatches to [`WholeFileStrategy`] or [`DeltaTransferStrategy`] based on [`DeltaWorkKind`] |
-//! | [`reorder`] | [`ReorderBuffer`] | `BTreeMap`-backed buffer that yields results in submission order |
+//! | [`reorder`] | [`ReorderBuffer`] | Ring-buffer (`Box<[Option<T>]>`) that yields results in submission order with O(1) insert and drain |
 //! | [`consumer`] | [`DeltaConsumer`] | Background thread that drains `WorkQueue` via `drain_parallel` into `ReorderBuffer` for in-order delivery |
 //!
 //! # Production Pipeline
@@ -66,8 +66,9 @@
 //! ### `engine::concurrent_delta` (this module)
 //! The core concurrent pipeline. The producer assigns monotonic sequence
 //! numbers, rayon workers process files out of order, and `ReorderBuffer`
-//! (BTreeMap-backed) yields results in submission order before wire output.
-//! **GUARDED** by `ReorderBuffer`.
+//! (ring-buffer-backed, `Box<[Option<T>]>`) yields results in submission order
+//! before wire output, with O(1) insert and drain. **GUARDED** by
+//! `ReorderBuffer`.
 //!
 //! ### `transfer::receiver::transfer::pipeline` (`pipeline.rs:180`)
 //! Parallel signature computation in the pipelined receiver. Results are


### PR DESCRIPTION
## Summary

Task #1853 asked for a VecDeque + index-mask ring-buffer prototype to replace the `BTreeMap` in the `ReorderBuffer` hot path. Investigation found the conversion was already done in #1734 (`Box<[Option<T>]>` indexed ring buffer with O(1) insert and drain) and further improved in #3392 (adaptive capacity scaling). The production `concurrent_delta::ReorderBuffer` is no longer a `BTreeMap` and has been the ring-buffer variant for a while.

This PR therefore takes the alternate branch from the task description: verify the existing implementation handles the gap-larger-than-capacity and wrap-around cases correctly (existing `force_insert_bypasses_capacity`, `force_insert_beyond_capacity_then_drain`, and `ring_buffer_wraps_correctly` tests cover these), and add the scaling benchmark called for in #1853 to confirm O(1) per-item behaviour at million-file scale.

- New benchmark `crates/engine/benches/reorder_buffer_scaling.rs` compares the production ring buffer against a self-contained `BTreeMap` baseline at 10K, 100K, 1M, and 10M items. The 10M case is gated behind `BENCH_REORDER_10M=1` so default invocations stay fast; CI can opt in when targeting the scaling regression dataset.
- Stale `BTreeMap-backed` doc comments in `concurrent_delta/mod.rs` corrected to describe the ring-buffer-backed implementation.
- No production code behaviour changes.

The criterion CI artifact will publish absolute timings; the expectation is roughly linear scaling for the ring path (constant ns/item across counts) versus super-linear scaling for the `BTreeMap` baseline.

## Test plan
- [ ] `cargo bench -p engine --bench reorder_buffer_scaling` runs without errors
- [ ] CI bench artifact shows ring buffer ns/item is roughly flat from 10K to 1M
- [ ] Optional: rerun with `BENCH_REORDER_10M=1` for the 10M data point
- [ ] Existing reorder buffer tests continue to pass (no production changes)