### PR TITLE
docs(batch): convert restating comments to rustdoc

### DIFF
--- a/crates/batch/src/reader/flist.rs
+++ b/crates/batch/src/reader/flist.rs
@@ -29,12 +29,11 @@ impl BatchReader {
         }
 
         if let Some(ref mut reader) = self.batch_file {
-            // Try to read the next file entry
-            // If we hit EOF or an empty path, we've reached the end of the file list
+            // EOF or an empty path marks the end of the file list.
             match FileEntry::read_from(reader) {
                 Ok(entry) => {
                     if entry.path.is_empty() {
-                        Ok(None) // End of file list marker
+                        Ok(None)
                     } else {
                         Ok(Some(entry))
                     }

--- a/crates/batch/src/reader/mod.rs
+++ b/crates/batch/src/reader/mod.rs
@@ -63,7 +63,6 @@ pub struct BatchReader {
 impl BatchReader {
     /// Create a new batch reader.
     pub fn new(config: BatchConfig) -> BatchResult<Self> {
-        // Open the batch file
         let batch_path = config.batch_file_path();
         let file = File::open(batch_path).map_err(|e| {
             BatchError::Io(io::Error::new(

--- a/crates/batch/src/replay.rs
+++ b/crates/batch/src/replay.rs
@@ -405,7 +405,6 @@ pub fn replay(
             }
             protocol::flist::FileType::Symlink => {
                 if let Some(target) = entry.link_target() {
-                    // Ensure parent directory exists
                     if let Some(parent) = dest_path.parent() {
                         if !parent.exists() {
                             fs::create_dir_all(parent).map_err(|e| {
@@ -424,7 +423,6 @@ pub fn replay(
                 }
             }
             protocol::flist::FileType::Regular => {
-                // Ensure parent directory exists
                 if let Some(parent) = dest_path.parent() {
                     if !parent.exists() {
                         fs::create_dir_all(parent).map_err(|e| {

--- a/crates/batch/src/script.rs
+++ b/crates/batch/src/script.rs
@@ -158,15 +158,17 @@ pub fn generate_script_with_args(
 }
 
 /// Quote a string for safe shell usage.
+///
+/// Returns the string unchanged when it only contains shell-safe characters
+/// (alphanumerics plus `-_/.:=`); otherwise wraps it in single quotes and
+/// escapes embedded single quotes using the `'\''` idiom.
 fn shell_quote(s: &str) -> String {
-    // Check if quoting is needed
     if s.chars().all(|c| {
         c.is_alphanumeric() || c == '-' || c == '_' || c == '/' || c == '.' || c == ':' || c == '='
     }) {
         return s.to_owned();
     }
 
-    // Need quoting - use single quotes and escape any single quotes
     let mut result = String::from("'");
     for ch in s.chars() {
         if ch == '\'' {

--- a/crates/batch/src/writer.rs
+++ b/crates/batch/src/writer.rs
@@ -23,7 +23,6 @@ pub struct BatchWriter {
 impl BatchWriter {
     /// Create a new batch writer.
     pub fn new(config: BatchConfig) -> BatchResult<Self> {
-        // Create the batch file
         let batch_path = config.batch_file_path();
         let file = File::create(batch_path).map_err(|e| {
             BatchError::Io(io::Error::new(
@@ -270,13 +269,12 @@ mod tests {
 
         let mut writer = BatchWriter::new(config).unwrap();
 
-        // Must write header first
+        // write_data before write_header must fail
         assert!(writer.write_data(b"test").is_err());
 
         let flags = BatchFlags::default();
         writer.write_header(flags).unwrap();
 
-        // Now data write should succeed
         assert!(writer.write_data(b"test data").is_ok());
         assert!(writer.flush().is_ok());
     }


### PR DESCRIPTION
## Summary

Comment audit of the `batch` crate (`--write-batch` / `--read-batch` wire format) per internal docs cleanup rules. Resolves task #1846.

This PR is **comment-only - no behavior change**. All upstream-reference comments (`// upstream: batch.c:...`, `// upstream: io.c:...`, `// upstream: token.c:...`, etc.) and WHY-style invariants are preserved verbatim.

### Changes

- **Delete** pure echo restatement comments:
  - `crates/batch/src/reader/mod.rs`: `// Open the batch file` before `File::open`.
  - `crates/batch/src/writer.rs`: `// Create the batch file` before `File::create`.
  - `crates/batch/src/replay.rs`: two `// Ensure parent directory exists` comments before `fs::create_dir_all(parent)`.
  - `crates/batch/src/reader/flist.rs`: `// Try to read the next file entry` and the inline `// End of file list marker` echo on `Ok(None)`.
  - `crates/batch/src/script.rs`: `// Check if quoting is needed` and `// Need quoting - use single quotes ...`.
  - `crates/batch/src/writer.rs` test: `// Now data write should succeed` echo on the assertion.

- **Convert** shell_quote internal comments into a rustdoc summary on the function (private helper, but documents the quoting rules in one place).

- **Tighten** the file-list end-of-list comment to a single concise line.

- **Rephrase** the writer test precondition comment from `// Must write header first` to `// write_data before write_header must fail` so it documents the assertion's intent rather than restating the next line.

## Files touched

- `crates/batch/src/reader/flist.rs`
- `crates/batch/src/reader/mod.rs`
- `crates/batch/src/replay.rs`
- `crates/batch/src/script.rs`
- `crates/batch/src/writer.rs`

Net change: +7 / -11 lines.

## Test plan

- [ ] CI fmt+clippy passes
- [ ] CI nextest (stable) passes
- [ ] CI Windows / macOS / Linux musl pass