### PR TITLE
docs(match): convert restating comments to rustdoc

### DIFF
--- a/crates/match/src/fuzzy/mod.rs
+++ b/crates/match/src/fuzzy/mod.rs
@@ -254,14 +254,11 @@ mod tests {
 
         #[test]
         fn scoring_constants_reasonable() {
-            // Extension match should be worth several prefix chars
+            // Pin the relative weights: extension > prefix > suffix; size
+            // bonus is meaningful but never dominates name similarity.
             assert_eq!(EXTENSION_MATCH_BONUS, 50);
             assert_eq!(PREFIX_MATCH_POINTS, 10);
-
-            // Prefix should be worth more than suffix
             assert_eq!(SUFFIX_MATCH_POINTS, 8);
-
-            // Size bonus should be meaningful but not dominant
             assert_eq!(SIZE_SIMILARITY_BONUS, 30);
             assert_eq!(MIN_FUZZY_SCORE, 10);
         }

--- a/crates/match/src/fuzzy/scoring.rs
+++ b/crates/match/src/fuzzy/scoring.rs
@@ -77,24 +77,19 @@ pub fn compute_similarity_score(
 ) -> u32 {
     let mut score: u32 = 0;
 
-    // Extract extensions
     let (target_base, target_ext) = split_name_extension(target);
     let (candidate_base, candidate_ext) = split_name_extension(candidate);
 
-    // Extension match bonus
     if target_ext == candidate_ext && !target_ext.is_empty() {
         score += EXTENSION_MATCH_BONUS;
     }
 
-    // Common prefix length (on base name)
     let prefix_len = common_prefix_length(target_base, candidate_base);
     score += prefix_len as u32 * PREFIX_MATCH_POINTS;
 
-    // Common suffix length (on base name, excluding extension)
     let suffix_len = common_suffix_length(target_base, candidate_base);
     score += suffix_len as u32 * SUFFIX_MATCH_POINTS;
 
-    // Size similarity bonus
     if target_size > 0 && candidate_size > 0 {
         let size_ratio = if target_size >= candidate_size {
             candidate_size as f64 / target_size as f64
@@ -102,8 +97,8 @@ pub fn compute_similarity_score(
             target_size as f64 / candidate_size as f64
         };
 
-        // Bonus if sizes are within 50% of each other (ratio >= 0.5)
-        // This mirrors upstream rsync's size similarity heuristic
+        // upstream rsync's size-similarity heuristic: award a bonus when
+        // sizes are within 50% of each other (ratio >= 0.5).
         if size_ratio >= 0.5 {
             score += SIZE_SIMILARITY_BONUS;
         }
@@ -157,7 +152,7 @@ fn common_prefix_length(a: &str, b: &str) -> usize {
     let a_bytes = a.as_bytes();
     let b_bytes = b.as_bytes();
 
-    // Fast path: compare bytes directly for ASCII
+    // Fast path: byte-wise compare; ASCII filenames hit this branch.
     let min_len = a_bytes.len().min(b_bytes.len());
     let mut common_bytes = 0;
 
@@ -168,11 +163,12 @@ fn common_prefix_length(a: &str, b: &str) -> usize {
         common_bytes = i + 1;
     }
 
-    // If we're at a UTF-8 boundary on both sides, count chars in the prefix
+    // If the byte-prefix lands on a UTF-8 boundary in both strings the char
+    // count is exact; otherwise fall back to a Unicode-aware comparison so we
+    // never split a multibyte sequence.
     if a.is_char_boundary(common_bytes) && b.is_char_boundary(common_bytes) {
         a[..common_bytes].chars().count()
     } else {
-        // Fallback: count matching Unicode chars
         a.chars()
             .zip(b.chars())
             .take_while(|(ca, cb)| ca == cb)
@@ -201,7 +197,7 @@ fn common_suffix_length(a: &str, b: &str) -> usize {
     let a_bytes = a.as_bytes();
     let b_bytes = b.as_bytes();
 
-    // Fast path: compare bytes directly from the end for ASCII
+    // Fast path: byte-wise compare from the tail; ASCII filenames hit this branch.
     let min_len = a_bytes.len().min(b_bytes.len());
     let mut common_bytes = 0;
 
@@ -214,13 +210,13 @@ fn common_suffix_length(a: &str, b: &str) -> usize {
         common_bytes = i + 1;
     }
 
-    // If we're at a UTF-8 boundary on both sides, count chars in the suffix
     let a_start = a_bytes.len() - common_bytes;
     let b_start = b_bytes.len() - common_bytes;
     if a.is_char_boundary(a_start) && b.is_char_boundary(b_start) {
         a[a_start..].chars().count()
     } else {
-        // Fallback: count matching Unicode chars from the end
+        // Byte-suffix straddles a multibyte sequence; fall back to a
+        // Unicode-aware reverse comparison.
         a.chars()
             .rev()
             .zip(b.chars().rev())
@@ -292,7 +288,7 @@ mod tests {
 
         #[test]
         fn partial_match() {
-            assert_eq!(common_suffix_length("testing", "running"), 3); // "ing"
+            assert_eq!(common_suffix_length("testing", "running"), 3);
         }
 
         #[test]
@@ -307,7 +303,7 @@ mod tests {
 
         #[test]
         fn extension_like() {
-            assert_eq!(common_suffix_length("file.txt", "data.txt"), 4); // ".txt"
+            assert_eq!(common_suffix_length("file.txt", "data.txt"), 4);
         }
 
         #[test]
@@ -428,21 +424,18 @@ mod tests {
         #[test]
         fn zero_target_size() {
             let score = compute_similarity_score("file.txt", "data.txt", 0, 1000);
-            // Should not get size bonus when target size is 0
             assert!(score >= EXTENSION_MATCH_BONUS);
         }
 
         #[test]
         fn zero_candidate_size() {
             let score = compute_similarity_score("file.txt", "data.txt", 1000, 0);
-            // Should not get size bonus when candidate size is 0
             assert!(score >= EXTENSION_MATCH_BONUS);
         }
 
         #[test]
         fn both_sizes_zero() {
             let score = compute_similarity_score("file.txt", "data.txt", 0, 0);
-            // Should not get size bonus when both are 0
             assert!(score >= EXTENSION_MATCH_BONUS);
         }
 
@@ -457,14 +450,14 @@ mod tests {
 
         #[test]
         fn candidate_larger_than_target() {
+            // 500/1000 = 0.5 lands exactly on the bonus threshold.
             let score = compute_similarity_score("a.txt", "b.txt", 500, 1000);
-            // 500/1000 = 0.5, should still get size bonus
             assert!(score >= EXTENSION_MATCH_BONUS + SIZE_SIMILARITY_BONUS);
         }
 
         #[test]
         fn candidate_much_larger() {
-            // ratio < 0.5
+            // 100/1000 = 0.1 falls below the bonus threshold.
             let score = compute_similarity_score("a.txt", "b.txt", 100, 1000);
             assert!(
                 score < EXTENSION_MATCH_BONUS + SIZE_SIMILARITY_BONUS,
@@ -474,9 +467,9 @@ mod tests {
 
         #[test]
         fn no_extension_match() {
+            // Common prefix "file" (4 chars) but different extension.
             let score = compute_similarity_score("file.txt", "file.csv", 1000, 1000);
-            // Same prefix "file" but different extension
-            assert!(score >= PREFIX_MATCH_POINTS * 4); // "file" is 4 chars
+            assert!(score >= PREFIX_MATCH_POINTS * 4);
             assert!(
                 score < EXTENSION_MATCH_BONUS + PREFIX_MATCH_POINTS * 4 + SIZE_SIMILARITY_BONUS
             );

--- a/crates/match/src/fuzzy/search.rs
+++ b/crates/match/src/fuzzy/search.rs
@@ -72,12 +72,10 @@ impl FuzzyMatcher {
 
         let mut best_match: Option<FuzzyMatch> = None;
 
-        // Search destination directory (always done for level 1 and 2)
         if let Some(m) = search_directory(dest_dir, &target_name_str, target_size, self.min_score) {
             update_best_match(&mut best_match, m, self.min_score);
         }
 
-        // Search additional fuzzy basis directories (only for level 2)
         if self.fuzzy_level >= FUZZY_LEVEL_2 {
             for basis_dir in &self.fuzzy_basis_dirs {
                 if let Some(m) =
@@ -112,7 +110,6 @@ fn search_directory(
     for entry in entries.flatten() {
         let path = entry.path();
 
-        // Skip directories and non-regular files
         let metadata = match entry.metadata() {
             Ok(m) if m.is_file() => m,
             _ => continue,
@@ -123,7 +120,8 @@ fn search_directory(
             None => continue,
         };
 
-        // Don't match the exact same name (that's not fuzzy)
+        // Skip the exact-name match: fuzzy matching only fires when no
+        // identically-named file exists in the destination.
         if candidate_name == target_name {
             continue;
         }
@@ -180,7 +178,8 @@ mod tests {
 
         #[test]
         fn default_trait() {
-            // Default derive uses 0 for fuzzy_level
+            // Derived Default leaves both fields at 0; FuzzyMatcher::new() is
+            // the supported way to obtain a usable level-1 matcher.
             let matcher = FuzzyMatcher::default();
             assert_eq!(matcher.fuzzy_level(), 0);
             assert_eq!(matcher.min_score(), 0);
@@ -230,10 +229,10 @@ mod tests {
 
         #[test]
         fn level_2_skips_basis_dirs_without_config() {
-            // Even with level 2, if no basis dirs configured, only search dest
+            // Level 2 without configured basis dirs degenerates to level 1
+            // behaviour (search the destination directory only).
             let matcher = FuzzyMatcher::with_level(2);
             assert!(matcher.fuzzy_basis_dirs.is_empty());
-            // This is correct behavior - level 2 without basis dirs acts like level 1
         }
     }
 

--- a/crates/match/src/generator.rs
+++ b/crates/match/src/generator.rs
@@ -91,13 +91,12 @@ impl DeltaGenerator {
         let mut total_bytes = 0u64;
         let mut literal_bytes = 0u64;
 
-        // Statistics for DEBUG_DELTASUM level 2
         let mut hash_hits = 0u64;
         let mut false_alarms = 0u64;
         let mut matches = 0u64;
         let mut offset = 0u64;
 
-        // upstream: match.c — want_i tracks expected next block index for
+        // upstream: match.c - want_i tracks the expected next block index for
         // adjacent-match hinting. After a match at block i, the next match
         // is likely at block i+1. Checking this hint before the hash table
         // lookup skips the probe entirely when data is sequential.
@@ -107,7 +106,6 @@ impl DeltaGenerator {
         let mut buffer_pos = 0usize;
         let mut buffer_len = 0usize;
 
-        // DEBUG_DELTASUM level 2: Log hash search start (mirrors upstream match.c)
         debug_log!(
             Deltasum,
             2,
@@ -116,7 +114,6 @@ impl DeltaGenerator {
             index.block_length()
         );
 
-        // DEBUG_DELTASUM level 3: Log detailed search parameters
         debug_log!(
             Deltasum,
             3,
@@ -137,21 +134,17 @@ impl DeltaGenerator {
             let byte = buffer[buffer_pos];
             buffer_pos += 1;
 
-            // Ring buffer auto-evicts when at capacity, returning the evicted byte
             let evicted = window.push_back(byte);
 
-            // Rolling checksum update: use evicted byte directly (if any)
             if let Some(outgoing_byte) = evicted {
-                // Window was full: roll with evicted byte leaving, new byte entering
-                // Use roll() directly for single-byte operations (faster than roll_many)
+                // roll() is faster than roll_many() for single-byte updates.
                 rolling
                     .roll(outgoing_byte, byte)
                     .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
-                // Evicted byte becomes a literal
                 pending_literals.push(outgoing_byte);
                 offset += 1;
 
-                // upstream: match.c:339-340 — flush early to bound memory growth
+                // upstream: match.c:339-340 - flush early to bound memory growth
                 if pending_literals.len() >= block_len + CHUNK_SIZE {
                     literal_bytes += pending_literals.len() as u64;
                     total_bytes += pending_literals.len() as u64;
@@ -160,18 +153,15 @@ impl DeltaGenerator {
                     tokens.push(DeltaToken::Literal(filled));
                 }
             } else {
-                // Window not yet full: use optimized single-byte update
                 rolling.update_byte(byte);
             }
 
-            // Only check for matches when window is full
             if !window.is_full() {
                 continue;
             }
 
             let digest = rolling.digest();
 
-            // DEBUG_DELTASUM level 4: Per-iteration offset tracking (very verbose)
             debug_log!(
                 Deltasum,
                 4,
@@ -182,7 +172,7 @@ impl DeltaGenerator {
             );
 
             // Match using two-slice view to avoid O(block_len) rotation when wrapped.
-            // upstream: match.c:144-190 — try want_i hint before hash probe.
+            // upstream: match.c:144-190 - try want_i hint before hash probe.
             let (first, second) = window.as_slices();
             let matched = if let Some(hint) = want_i {
                 if index.check_block_match_slices(hint, digest, first, second) {
@@ -196,7 +186,7 @@ impl DeltaGenerator {
                 index.find_match_slices(digest, first, second)
             };
             if let Some(mut match_idx) = matched {
-                // upstream: match.c:265-310 — block match with bulk refill.
+                // upstream: match.c:265-310 - block match with bulk refill.
                 // After each match, refill the window in bulk and compute the
                 // rolling checksum via SIMD-accelerated update() instead of
                 // block_len individual push_back()+update_byte() calls. Chained
@@ -213,7 +203,6 @@ impl DeltaGenerator {
                         rolling.digest().value()
                     );
 
-                    // Flush pending literals before the copy token
                     if !pending_literals.is_empty() {
                         literal_bytes += pending_literals.len() as u64;
                         total_bytes += pending_literals.len() as u64;
@@ -239,8 +228,7 @@ impl DeltaGenerator {
                     rolling.reset();
                     offset += block_len as u64;
 
-                    // Bulk refill: gather block_len bytes from I/O buffer + reader.
-                    // upstream: match.c:303-308 — recomputes checksum from scratch
+                    // upstream: match.c:303-308 - recomputes checksum from scratch
                     // over the next window via get_checksum1() (SIMD-accelerated).
                     let mut filled = 0usize;
                     while filled < block_len {
@@ -258,18 +246,18 @@ impl DeltaGenerator {
                     }
 
                     if filled < block_len {
-                        break; // Near EOF — let byte-by-byte loop drain remaining
+                        // Near EOF: let the byte-by-byte loop drain the remaining bytes.
+                        break;
                     }
 
-                    // Full window: compute rolling checksum via SIMD bulk update
                     let (s1, s2) = window.as_slices();
                     rolling.update(s1);
                     if !s2.is_empty() {
                         rolling.update(s2);
                     }
 
-                    // Check for adjacent match at next block boundary.
-                    // upstream: match.c:144-190 — try want_i hint first.
+                    // upstream: match.c:144-190 - try want_i hint at the next
+                    // block boundary before falling back to a hash probe.
                     let adj_digest = rolling.digest();
                     let (f, s) = window.as_slices();
                     let adj_match = if let Some(hint) = want_i {
@@ -296,7 +284,8 @@ impl DeltaGenerator {
             }
         }
 
-        // Drain remaining bytes from window as literals
+        // Drain any bytes still in the window as literals (window held fewer
+        // than block_len bytes at EOF, so no further match is possible).
         while let Some(byte) = window.pop_front() {
             pending_literals.push(byte);
         }
@@ -307,7 +296,6 @@ impl DeltaGenerator {
             tokens.push(DeltaToken::Literal(pending_literals));
         }
 
-        // DEBUG_DELTASUM level 2: Log completion with statistics (mirrors upstream match.c)
         debug_log!(Deltasum, 2, "done hash search");
         debug_log!(
             Deltasum,
@@ -318,7 +306,7 @@ impl DeltaGenerator {
             matches
         );
 
-        // DEBUG_DELTASUM level 1: Basic summary (match_report equivalent)
+        // upstream: match.c match_report() equivalent.
         debug_log!(
             Deltasum,
             1,
@@ -406,7 +394,6 @@ mod tests {
         assert_eq!(output, input);
     }
 
-    // DeltaGenerator constructor tests
     #[test]
     fn delta_generator_new_uses_default_buffer_len() {
         let generator = DeltaGenerator::new();
@@ -455,7 +442,6 @@ mod tests {
         assert!(debug.contains("buffer_len"));
     }
 
-    // Empty input tests
     #[test]
     fn generate_delta_empty_input_produces_empty_script() {
         let basis = vec![0u8; 2048];
@@ -491,7 +477,6 @@ mod tests {
         assert_eq!(script.total_bytes(), input.len() as u64);
     }
 
-    // Buffer length effects
     #[test]
     fn generate_delta_with_small_buffer_produces_same_result() {
         let basis: Vec<u8> = (0..10_000).map(|b| (b % 251) as u8).collect();
@@ -524,17 +509,14 @@ mod tests {
         assert_eq!(script1.total_bytes(), script2.total_bytes());
     }
 
-    // Copy token tests
     #[test]
     fn generate_delta_copy_only_has_zero_literal_bytes() {
         let basis: Vec<u8> = (0..10_000).map(|b| (b % 251) as u8).collect();
         let index = build_index(&basis);
         let block_len = index.block_length();
-        // Use exact block boundaries
         let input = basis[..block_len].to_vec();
 
         let script = generate_delta(&input[..], &index).expect("script");
-        // Should be all copy, no literals
         assert_eq!(script.literal_bytes(), 0);
     }
 
@@ -544,16 +526,15 @@ mod tests {
         let index = build_index(&basis);
         let block_len = index.block_length();
 
-        let mut input = vec![1u8, 2u8, 3u8]; // 3 literal bytes
-        input.extend_from_slice(&basis[..block_len]); // matching block
-        input.extend_from_slice(b"end"); // 3 more literal bytes
+        let mut input = vec![1u8, 2u8, 3u8];
+        input.extend_from_slice(&basis[..block_len]);
+        input.extend_from_slice(b"end");
 
         let script = generate_delta(&input[..], &index).expect("script");
         assert!(script.tokens().len() >= 2);
         assert_eq!(script.literal_bytes(), 6);
     }
 
-    // Convenience function test
     #[test]
     fn generate_delta_convenience_function_works() {
         let basis = vec![0u8; 2048];
@@ -568,11 +549,9 @@ mod tests {
     fn delta_script_round_trip_identical_data() {
         let basis: Vec<u8> = (0..10_000).map(|b| (b % 251) as u8).collect();
         let index = build_index(&basis);
-        // Use the same data as basis
         let input = basis.clone();
 
         let script = generate_delta(&input[..], &index).expect("script");
-        // Should be mostly or all copy tokens
         assert!(script.literal_bytes() < script.total_bytes());
 
         let mut basis_cursor = Cursor::new(basis);

--- a/crates/match/src/index/builder.rs
+++ b/crates/match/src/index/builder.rs
@@ -27,7 +27,6 @@ fn populate_index(
         has_full_blocks = true;
         let digest = block.rolling();
         tag_table[digest.sum1() as usize] = true;
-        // Key is (sum1, sum2) only - all indexed blocks have block_length
         lookup
             .entry((digest.sum1(), digest.sum2()))
             .or_default()

--- a/crates/match/src/index/mod.rs
+++ b/crates/match/src/index/mod.rs
@@ -86,11 +86,11 @@ impl DeltaSignatureIndex {
             return None;
         }
 
-        // Key is (sum1, sum2) - all candidates have block_length
         let key = (digest.sum1(), digest.sum2());
         let candidates = self.lookup.get(&key)?;
 
-        // Use parallel matching for many candidates (strong checksum is CPU-intensive)
+        // Strong checksum is CPU-intensive; parallelise only when there are
+        // enough candidates to amortise rayon's per-call overhead.
         #[cfg(feature = "parallel")]
         if candidates.len() >= Self::PARALLEL_THRESHOLD {
             return self.find_match_parallel(candidates, window);
@@ -240,12 +240,10 @@ impl DeltaSignatureIndex {
         if block.len() != self.block_length {
             return false;
         }
-        // Cheap: compare rolling checksum first
         let block_digest = block.rolling();
         if digest.sum1() != block_digest.sum1() || digest.sum2() != block_digest.sum2() {
             return false;
         }
-        // Expensive: verify with strong checksum
         let strong = self
             .algorithm
             .compute_truncated_slices(first, second, self.strong_length);

--- a/crates/match/src/index/tests.rs
+++ b/crates/match/src/index/tests.rs
@@ -184,7 +184,6 @@ fn find_match_bytes_wrong_length_returns_none() {
         DeltaSignatureIndex::from_signature(&signature, SignatureAlgorithm::Md4).expect("index");
 
     let digest = index.block(0).rolling();
-    // Window with wrong length
     let window = vec![b'a'; index.block_length() - 1];
     assert!(index.find_match_bytes(digest, &window).is_none());
 }
@@ -205,7 +204,6 @@ fn find_match_bytes_no_match_returns_none() {
         DeltaSignatureIndex::from_signature(&signature, SignatureAlgorithm::Md4).expect("index");
 
     let digest = index.block(0).rolling();
-    // Window with right length but different content
     let window = vec![b'z'; index.block_length()];
     assert!(index.find_match_bytes(digest, &window).is_none());
 }
@@ -228,7 +226,6 @@ fn find_match_window_wrong_length_returns_none() {
     let digest = index.block(0).rolling();
     let mut window = VecDeque::new();
     let mut scratch = Vec::new();
-    // Add fewer bytes than block length
     for _ in 0..index.block_length() - 1 {
         window.push_back(b'a');
     }
@@ -245,20 +242,18 @@ fn find_match_window_wrong_length_returns_none() {
 /// collisions in the hash table, verifying the strong checksum disambiguates.
 #[test]
 fn find_match_bytes_uses_strong_checksum_for_collision() {
-    // Create data with two identical-content blocks - they'll have same rolling checksum
-    // but the lookup should still work correctly.
+    // Block 0 and block 2 share the same content (and therefore the same
+    // rolling checksum); block 1 carries a distinct pattern. The lookup must
+    // still resolve each block correctly via the strong checksum.
     let block_size = 700usize;
     let mut data = vec![0u8; block_size * 3];
 
-    // Block 0: pattern A
     for (i, byte) in data[..block_size].iter_mut().enumerate() {
         *byte = (i % 256) as u8;
     }
-    // Block 1: pattern B (different from A)
     for (i, byte) in data[block_size..2 * block_size].iter_mut().enumerate() {
         *byte = ((i + 128) % 256) as u8;
     }
-    // Block 2: pattern A again (same as block 0)
     for (i, byte) in data[2 * block_size..].iter_mut().enumerate() {
         *byte = (i % 256) as u8;
     }
@@ -275,21 +270,19 @@ fn find_match_bytes_uses_strong_checksum_for_collision() {
     let index =
         DeltaSignatureIndex::from_signature(&signature, SignatureAlgorithm::Md4).expect("index");
 
-    // Verify block 0 matches with its own content
     let block0_digest = index.block(0).rolling();
     let block0_window: Vec<u8> = data[..index.block_length()].to_vec();
     let found0 = index.find_match_bytes(block0_digest, &block0_window);
     assert!(found0.is_some(), "block 0 should match");
 
-    // Verify block 1 matches with its own content
     let block1_digest = index.block(1).rolling();
     let block1_start = index.block_length();
     let block1_window: Vec<u8> = data[block1_start..block1_start + index.block_length()].to_vec();
     let found1 = index.find_match_bytes(block1_digest, &block1_window);
     assert!(found1.is_some(), "block 1 should match");
 
-    // Use block 0's digest with block 1's content - should not match
-    // (same rolling checksum lookup, but strong checksum differs)
+    // Same rolling-checksum lookup key, but different content: the strong
+    // checksum disambiguates and rejects the false positive.
     let no_match = index.find_match_bytes(block0_digest, &block1_window);
     assert!(
         no_match.is_none(),
@@ -299,7 +292,6 @@ fn find_match_bytes_uses_strong_checksum_for_collision() {
 
 #[test]
 fn rebuild_reuses_allocation() {
-    // Build an index from a first signature.
     let data1 = vec![b'a'; 2048];
     let params1 = SignatureLayoutParams::new(
         data1.len() as u64,
@@ -315,7 +307,6 @@ fn rebuild_reuses_allocation() {
 
     let capacity_before = index.lookup.capacity();
 
-    // Build a second, different signature.
     let data2 = vec![b'b'; 3000];
     let params2 = SignatureLayoutParams::new(
         data2.len() as u64,
@@ -327,23 +318,20 @@ fn rebuild_reuses_allocation() {
     let sig2 =
         generate_file_signature(data2.as_slice(), layout2, SignatureAlgorithm::Md4).expect("sig2");
 
-    // Rebuild the index in-place.
     let has_full = index.rebuild(&sig2, SignatureAlgorithm::Md4);
     assert!(has_full, "second signature should have full blocks");
 
-    // The lookup table allocation must not have shrunk.
+    // The lookup-table allocation must be reused, not shrunk, after rebuild.
     assert!(
         index.lookup.capacity() >= capacity_before,
         "capacity should be preserved across rebuild"
     );
 
-    // Verify the lookup is correct: a match against the second data must work.
     let digest = index.block(0).rolling();
     let window = vec![b'b'; index.block_length()];
     let found = index.find_match_bytes(digest, &window);
     assert!(found.is_some(), "should find a match after rebuild");
 
-    // And the old data must no longer match.
     let old_window = vec![b'a'; index.block_length()];
     let old_found = index.find_match_bytes(digest, &old_window);
     assert!(

--- a/crates/match/src/optimized_search.rs
+++ b/crates/match/src/optimized_search.rs
@@ -100,7 +100,6 @@ impl BlockHashTable {
         let tag_table = TagTable::new(&blocks);
         let mut table = FxHashMap::default();
 
-        // Build hash table with chaining
         for (idx, block) in blocks.iter().enumerate() {
             table
                 .entry(block.checksum)
@@ -118,13 +117,11 @@ impl BlockHashTable {
 
     /// Build a hash table with pre-sorted blocks (enables sequential scan optimization).
     pub fn new_sorted(mut blocks: Vec<BlockEntry>) -> Self {
-        // Sort blocks by rolling checksum
         blocks.sort_by_key(|b| b.checksum);
 
         let tag_table = TagTable::new(&blocks);
         let mut table = FxHashMap::default();
 
-        // Build hash table with chaining
         for (idx, block) in blocks.iter().enumerate() {
             table
                 .entry(block.checksum)
@@ -144,12 +141,10 @@ impl BlockHashTable {
     /// Returns indices into the blocks array.
     /// Uses tag table for O(1) rejection of non-matches.
     pub fn find_weak_matches(&self, checksum: u32) -> &[usize] {
-        // First check tag table for quick rejection
         if !self.tag_table.might_match(checksum) {
             return &[];
         }
 
-        // Look up in hash table
         self.table
             .get(&checksum)
             .map(|v| v.as_slice())
@@ -172,10 +167,8 @@ impl BlockHashTable {
     /// 2. Rolling checksum match
     /// 3. Strong checksum verification
     pub fn find_match(&self, rolling_checksum: u32, strong_checksum: &[u8]) -> Option<&BlockEntry> {
-        // Get weak matches (includes tag table check)
         let weak_matches = self.find_weak_matches(rolling_checksum);
 
-        // Verify each weak match against strong checksum
         for &block_idx in weak_matches {
             if let Some(block) = self.verify_match(block_idx, strong_checksum) {
                 return Some(block);
@@ -316,7 +309,6 @@ mod tests {
         assert!(!table.is_empty());
         assert!(table.is_sorted());
 
-        // Verify blocks are actually sorted
         for i in 1..table.blocks.len() {
             assert!(table.blocks[i - 1].checksum <= table.blocks[i].checksum);
         }
@@ -467,24 +459,23 @@ mod tests {
             },
             BlockEntry {
                 index: 1,
-                checksum: 0x12345678, // Same rolling checksum
+                checksum: 0x12345678,
                 strong_checksum: vec![0xbb, 0xbb],
                 block_len: 4096,
             },
             BlockEntry {
                 index: 2,
-                checksum: 0x12345678, // Same rolling checksum
+                checksum: 0x12345678,
                 strong_checksum: vec![0xcc, 0xcc],
                 block_len: 4096,
             },
         ];
         let table = BlockHashTable::new(blocks);
 
-        // Should find all weak matches
         let weak_matches = table.find_weak_matches(0x12345678);
         assert_eq!(weak_matches.len(), 3);
 
-        // Should find the correct block by strong checksum
+        // Strong checksum disambiguates the colliding rolling checksums.
         let matched = table.find_match(0x12345678, &[0xbb, 0xbb]);
         assert!(matched.is_some());
         assert_eq!(matched.unwrap().index, 1);
@@ -516,21 +507,19 @@ mod tests {
 
         assert_eq!(table.len(), 10000);
 
-        // Verify we can find specific blocks
         let matched = table.find_match(5000 * 1000, &[(5000 >> 8) as u8, (5000 & 0xFF) as u8]);
         assert!(matched.is_some());
         assert_eq!(matched.unwrap().index, 5000);
 
-        // Verify non-existent block returns None
         let not_matched = table.find_match(0xFFFFFFFF, &[0xFF, 0xFF]);
         assert!(not_matched.is_none());
 
-        // Test sorted variant with large block set
         let mut blocks2 = Vec::new();
         for i in 0..10000 {
             blocks2.push(BlockEntry {
                 index: i,
-                checksum: (10000 - i) * 1000, // Reverse order
+                // Insert in reverse order to exercise the sorted constructor.
+                checksum: (10000 - i) * 1000,
                 strong_checksum: vec![(i >> 8) as u8, (i & 0xFF) as u8],
                 block_len: 4096,
             });
@@ -540,7 +529,6 @@ mod tests {
         assert_eq!(table_sorted.len(), 10000);
         assert!(table_sorted.is_sorted());
 
-        // Verify we can still find blocks after sorting
         let matched =
             table_sorted.find_match(5000 * 1000, &[(5000 >> 8) as u8, (5000 & 0xFF) as u8]);
         assert!(matched.is_some());

--- a/crates/match/src/ring_buffer.rs
+++ b/crates/match/src/ring_buffer.rs
@@ -92,13 +92,12 @@ impl RingBuffer {
     #[inline]
     pub fn push_back(&mut self, byte: u8) -> Option<u8> {
         if self.len < self.buffer.len() {
-            // Buffer not yet full: append at len position
             let pos = (self.head + self.len) % self.buffer.len();
             self.buffer[pos] = byte;
             self.len += 1;
             None
         } else {
-            // Buffer full: overwrite oldest byte at head
+            // Buffer full: overwrite the oldest byte (at head) and return it.
             let outgoing = self.buffer[self.head];
             self.buffer[self.head] = byte;
             self.head = (self.head + 1) % self.buffer.len();
@@ -144,19 +143,18 @@ impl RingBuffer {
             return &[];
         }
 
-        // Fast path: already contiguous
+        // Fast path: already contiguous from the start of the backing buffer.
         if self.head == 0 {
             return &self.buffer[..self.len];
         }
 
-        // Check if data is contiguous even with non-zero head
+        // Fast path: contiguous starting from a non-zero head, no wrap-around.
         let end = self.head + self.len;
         if end <= self.buffer.len() {
-            // Data is contiguous in the middle of the buffer
             return &self.buffer[self.head..end];
         }
 
-        // Slow path: need to rotate to make contiguous
+        // Slow path: data wraps; rotate the backing buffer to make it contiguous.
         self.buffer.rotate_left(self.head);
         self.head = 0;
         &self.buffer[..self.len]
@@ -176,10 +174,8 @@ impl RingBuffer {
 
         let end = self.head + self.len;
         if end <= self.buffer.len() {
-            // Data is contiguous
             Some(&self.buffer[self.head..end])
         } else {
-            // Wrapped, would need rotation
             None
         }
     }
@@ -195,10 +191,8 @@ impl RingBuffer {
 
         let end = self.head + self.len;
         if end <= self.buffer.len() {
-            // No wrap-around: single contiguous slice
             (&self.buffer[self.head..end], &[])
         } else {
-            // Wrapped: two slices
             let first_len = self.buffer.len() - self.head;
             let second_len = self.len - first_len;
             (&self.buffer[self.head..], &self.buffer[..second_len])
@@ -320,11 +314,10 @@ mod tests {
         buf.push_back(1);
         buf.push_back(2);
         buf.push_back(3);
-        buf.push_back(4); // overwrites 1, head moves
-        buf.push_back(5); // overwrites 2, head moves
+        buf.push_back(4);
+        buf.push_back(5);
 
-        // Buffer now contains [5, 3, 4] with head at position 2
-        // Logical order is [3, 4, 5]
+        // Backing buffer is [5, 3, 4] with head=2; logical order is [3, 4, 5].
         assert_eq!(buf.as_slice(), &[3, 4, 5]);
     }
 
@@ -348,7 +341,8 @@ mod tests {
         buf.push_back(1);
         buf.push_back(2);
         buf.push_back(3);
-        buf.push_back(4); // [4, 2, 3] head=1
+        // Backing layout becomes [4, 2, 3] with head=1.
+        buf.push_back(4);
 
         let (first, second) = buf.as_slices();
         assert_eq!(first, &[2, 3]);
@@ -374,7 +368,7 @@ mod tests {
         for i in 0..10u8 {
             buf.push_back(i);
         }
-        // After 10 pushes into capacity-3 buffer, contains [7, 8, 9]
+        // 10 pushes into a capacity-3 buffer leave the last three values.
         assert_eq!(buf.pop_front(), Some(7));
         assert_eq!(buf.pop_front(), Some(8));
         assert_eq!(buf.pop_front(), Some(9));
@@ -389,7 +383,6 @@ mod tests {
 
     #[test]
     fn sliding_window_simulation() {
-        // Simulate the delta generator's sliding window behavior
         let mut buf = RingBuffer::with_capacity(4);
         let data = b"hello world";
 
@@ -400,10 +393,7 @@ mod tests {
             }
         }
 
-        // After processing "hello world" with window size 4:
-        // Window contains "orld" (last 4 bytes)
         assert_eq!(buf.as_slice(), b"orld");
-        // Outgoing bytes are "hello w" (first 7 bytes)
         assert_eq!(outgoing_bytes, b"hello w");
     }
 
@@ -414,7 +404,6 @@ mod tests {
         buf.push_back(2);
         buf.push_back(3);
 
-        // Not wrapped, should return slice
         assert_eq!(buf.try_as_slice(), Some(&[1u8, 2, 3][..]));
     }
 
@@ -424,9 +413,9 @@ mod tests {
         buf.push_back(1);
         buf.push_back(2);
         buf.push_back(3);
-        buf.push_back(4); // Overwrites 1, buffer wraps
+        // The fourth push wraps the buffer; try_as_slice must not paper over it.
+        buf.push_back(4);
 
-        // Wrapped, should return None
         assert_eq!(buf.try_as_slice(), None);
     }
 
@@ -438,39 +427,35 @@ mod tests {
 
     #[test]
     fn as_slice_contiguous_middle() {
-        // Test the new optimization: contiguous data in the middle
+        // Exercise the contiguous-with-non-zero-head fast path: the data
+        // sits in the middle of the backing buffer with no wrap-around.
         let mut buf = RingBuffer::with_capacity(5);
         buf.push_back(1);
         buf.push_back(2);
         buf.push_back(3);
-        buf.pop_front(); // head moves to 1
-        buf.pop_front(); // head moves to 2
+        buf.pop_front();
+        buf.pop_front();
 
-        // Now only [3] at position 2, head=2, len=1
-        // This is contiguous in the middle
         assert_eq!(buf.as_slice(), &[3]);
     }
 
     #[test]
     fn capacity_one_buffer() {
-        // Edge case: buffer with capacity 1
         let mut buf = RingBuffer::with_capacity(1);
         assert!(buf.is_empty());
         assert_eq!(buf.capacity(), 1);
 
-        // Push first byte
         assert_eq!(buf.push_back(42), None);
         assert!(buf.is_full());
         assert_eq!(buf.len(), 1);
         assert_eq!(buf.as_slice(), &[42]);
 
-        // Push second byte - should evict first
+        // Pushing into a full capacity-1 buffer evicts and returns the prior byte.
         assert_eq!(buf.push_back(99), Some(42));
         assert!(buf.is_full());
         assert_eq!(buf.len(), 1);
         assert_eq!(buf.as_slice(), &[99]);
 
-        // Pop should return the byte
         assert_eq!(buf.pop_front(), Some(99));
         assert!(buf.is_empty());
     }
@@ -478,7 +463,6 @@ mod tests {
     #[test]
     #[should_panic(expected = "ring buffer capacity must be non-zero")]
     fn capacity_zero_panics() {
-        // Edge case: capacity 0 should panic
         let _ = RingBuffer::with_capacity(0);
     }
 
@@ -539,7 +523,6 @@ mod tests {
         buf.push_back(2);
         buf.push_back(3);
 
-        // Destination is too small (2 bytes for 3 bytes of data)
         let mut dest = [0u8; 2];
         buf.copy_to_slice(&mut dest);
     }

--- a/crates/match/src/script.rs
+++ b/crates/match/src/script.rs
@@ -275,7 +275,6 @@ mod tests {
         assert_eq!(error.kind(), ErrorKind::InvalidInput);
     }
 
-    // DeltaToken tests
     #[test]
     fn delta_token_literal_byte_len() {
         let token = DeltaToken::Literal(vec![1, 2, 3, 4, 5]);
@@ -329,7 +328,6 @@ mod tests {
         assert_ne!(a, c);
     }
 
-    // DeltaScript tests
     #[test]
     fn delta_script_new_and_accessors() {
         let tokens = vec![


### PR DESCRIPTION
## Summary

Comment audit of the block-matching crate (oc-rsync task #1845).

Scope: every `.rs` file under `crates/match/src/` (delta generator, hash-table signature index, optimized hash search, ring buffer, fuzzy basis matcher, delta script).

Applied the internal docs comment cleanup rules:

- Deleted restating comments that echo the next line (`// Extension match bonus`, `// Search destination directory`, `// Build hash table with chaining`, ...).
- Removed banner / section-label comments inside test modules (`// DeltaToken tests`, `// Buffer length effects`, etc.).
- Stripped `DEBUG_DELTASUM level N:` preface comments where the immediately following `debug_log!` macro already carries the level numerically.
- Tightened a handful of WHY comments to be sharper and shorter (false-positive hash-collision handling, `want_i` adjacent-match hint, near-EOF window drain, lookup-table allocation reuse on rebuild, fuzzy size-similarity threshold).
- Replaced em-dashes in upstream-ref comments with hyphens per the project style guide.

Preserved verbatim:
- Every `// upstream: match.c:...` / `generator.c:...` reference.
- All informative rustdoc on public APIs.

No behavior changes. No new code paths. Comments only.

Closes #1845.

## Test plan

- [ ] CI: fmt + clippy
- [ ] CI: nextest (stable)
- [ ] CI: Windows / macOS / Linux musl matrices