### PR TITLE
docs(rsync_io): convert restating comments to rustdoc

### DIFF
--- a/crates/rsync_io/src/binary/handshake.rs
+++ b/crates/rsync_io/src/binary/handshake.rs
@@ -422,9 +422,10 @@ mod tests {
     use crate::sniff_negotiation_stream;
     use std::io::{self, Cursor};
 
+    /// Builds a binary handshake fixture at protocol 31. The first byte differs
+    /// from `'@'` so the sniffer chooses the binary prologue, and the remaining
+    /// bytes encode protocol 31 as a little-endian u32.
     fn create_test_handshake() -> BinaryHandshake<Cursor<Vec<u8>>> {
-        // Binary negotiation is triggered by first byte != '@'
-        // Protocol 31 as LE u32: 0x1f 0x00 0x00 0x00
         let stream = sniff_negotiation_stream(Cursor::new(vec![0x1f, 0x00, 0x00, 0x00]))
             .expect("sniff succeeds");
         let proto31 = ProtocolVersion::from_supported(31).unwrap();

--- a/crates/rsync_io/src/binary/parts.rs
+++ b/crates/rsync_io/src/binary/parts.rs
@@ -447,9 +447,10 @@ mod tests {
     use protocol::NegotiationPrologue;
     use std::io::{self, Cursor};
 
+    /// Builds binary handshake parts at protocol 31. The first byte differs
+    /// from `'@'` so the sniffer chooses the binary prologue, and the remaining
+    /// bytes encode protocol 31 as a little-endian u32.
     fn create_test_parts() -> BinaryHandshakeParts<Cursor<Vec<u8>>> {
-        // Binary negotiation is triggered by first byte != '@'
-        // Protocol 31 as LE u32: 0x1f 0x00 0x00 0x00
         let stream = sniff_negotiation_stream(Cursor::new(vec![0x1f, 0x00, 0x00, 0x00]))
             .expect("sniff succeeds");
         let proto31 = ProtocolVersion::from_supported(31).unwrap();

--- a/crates/rsync_io/src/daemon/negotiate.rs
+++ b/crates/rsync_io/src/daemon/negotiate.rs
@@ -189,7 +189,6 @@ mod tests {
         let protocol = ProtocolVersion::from_supported(31).unwrap();
         let greeting = build_client_greeting(&server, protocol);
         let greeting_str = String::from_utf8_lossy(&greeting);
-        // When negotiated == server protocol, we preserve subprotocol
         assert!(greeting_str.contains("31.9"), "got: {greeting_str}");
     }
 
@@ -199,7 +198,6 @@ mod tests {
         let protocol = ProtocolVersion::from_supported(30).unwrap();
         let greeting = build_client_greeting(&server, protocol);
         let greeting_str = String::from_utf8_lossy(&greeting);
-        // When negotiated < server protocol, subprotocol is 0
         assert!(greeting_str.contains("30.0"), "got: {greeting_str}");
     }
 
@@ -227,7 +225,6 @@ mod tests {
         let protocol = ProtocolVersion::from_supported(30).unwrap();
         let greeting = build_client_greeting(&server, protocol);
         let greeting_str = String::from_utf8_lossy(&greeting);
-        // Should only have "@RSYNCD: 30.0\n"
         assert_eq!(greeting_str.trim(), "@RSYNCD: 30.0");
     }
 
@@ -272,7 +269,6 @@ mod tests {
         let protocol = ProtocolVersion::from_supported(30).unwrap();
         let greeting = build_client_greeting(&server, protocol);
         let greeting_str = String::from_utf8_lossy(&greeting);
-        // Should have "@RSYNCD: 30.0" with space after colon
         assert!(greeting_str.starts_with("@RSYNCD: "));
     }
 
@@ -282,7 +278,6 @@ mod tests {
         let protocol = ProtocolVersion::from_supported(31).unwrap();
         let greeting = build_client_greeting(&server, protocol);
         let greeting_str = String::from_utf8_lossy(&greeting);
-        // Should contain "31.5" (dot separating major.minor)
         assert!(greeting_str.contains('.'));
     }
 

--- a/crates/rsync_io/src/debug_io.rs
+++ b/crates/rsync_io/src/debug_io.rs
@@ -532,11 +532,10 @@ mod tests {
 
     #[test]
     fn test_format_hex_dump_rsyncd_banner() {
-        // Test with typical rsync banner prefix
         let data = b"@RSYNCD: 31.0\n";
         let result = format_hex_dump(data);
-        assert!(result.contains("40 52 53 59")); // @RSY in hex
-        assert!(result.contains("|@RSYNCD: 31.0.|")); // newline becomes dot
+        assert!(result.contains("40 52 53 59"));
+        assert!(result.contains("|@RSYNCD: 31.0.|"));
     }
 }
 
@@ -544,31 +543,26 @@ mod tests {
 mod no_tracing_tests {
     use super::*;
 
-    // These tests verify that the no-op functions compile and can be called
-    // without the tracing feature enabled
-
+    /// Verifies the no-op trace functions compile and remain callable when the
+    /// `tracing` feature is disabled.
     #[test]
     fn test_trace_functions_compile() {
-        // Level 1
         trace_stream_open("tcp://localhost:873");
         trace_stream_close("tcp://localhost:873");
         trace_ssh_spawn("ssh", "localhost");
         trace_negotiation_style("binary");
 
-        // Level 2
         trace_stream_read(512);
         trace_stream_write(256);
         trace_buffered_read(100, true);
         trace_buffered_read(100, false);
         trace_banner("recv", "@RSYNCD: 31.0");
 
-        // Level 3
         trace_negotiation_buffer_state("initial", 0, 100, 14);
         trace_buffer_consume(50, 50);
         trace_buffer_extend(100, 200);
         trace_stream_map("map_inner", true);
 
-        // Level 4
         trace_protocol_bytes("banner", b"@RSYNCD: 31.0\n");
         trace_sniff_bytes(b"@RSY", "NeedMoreData");
         trace_raw_read(&[1, 2, 3], "socket");

--- a/crates/rsync_io/src/session/handshake/session/tests/helpers.rs
+++ b/crates/rsync_io/src/session/handshake/session/tests/helpers.rs
@@ -6,10 +6,10 @@ use crate::sniff_negotiation_stream;
 use protocol::{CompatibilityFlags, ProtocolVersion, parse_legacy_daemon_greeting_owned};
 use std::io::Cursor;
 
-/// Creates a binary handshake fixture at protocol 31.
+/// Creates a binary handshake fixture at protocol 31. The first byte differs
+/// from `'@'` so the sniffer chooses the binary prologue, and the remaining
+/// bytes encode protocol 31 as a little-endian u32.
 pub(super) fn create_binary_handshake() -> BinaryHandshake<Cursor<Vec<u8>>> {
-    // Binary negotiation is triggered by first byte != '@'
-    // Protocol 31 as LE u32: 0x1f 0x00 0x00 0x00
     let stream = sniff_negotiation_stream(Cursor::new(vec![0x1f, 0x00, 0x00, 0x00]))
         .expect("sniff succeeds");
     let proto31 = ProtocolVersion::from_supported(31).unwrap();

--- a/crates/rsync_io/src/session/handshake/session/tests/protocol_tests.rs
+++ b/crates/rsync_io/src/session/handshake/session/tests/protocol_tests.rs
@@ -126,7 +126,6 @@ fn remote_advertisement_legacy() {
 fn remote_protocol_was_clamped_binary() {
     let binary = create_binary_handshake();
     let session = SessionHandshake::Binary(binary);
-    // Our test handshake uses protocol 31 which is in supported range
     assert!(!session.remote_protocol_was_clamped());
 }
 
@@ -134,7 +133,6 @@ fn remote_protocol_was_clamped_binary() {
 fn remote_protocol_was_clamped_legacy() {
     let legacy = create_legacy_handshake();
     let session = SessionHandshake::Legacy(legacy);
-    // Our test handshake uses protocol 31 which is in supported range
     assert!(!session.remote_protocol_was_clamped());
 }
 
@@ -142,7 +140,6 @@ fn remote_protocol_was_clamped_legacy() {
 fn local_protocol_was_capped_binary() {
     let binary = create_binary_handshake();
     let session = SessionHandshake::Binary(binary);
-    // Our test handshake uses the same protocol for desired and negotiated
     assert!(!session.local_protocol_was_capped());
 }
 
@@ -150,7 +147,6 @@ fn local_protocol_was_capped_binary() {
 fn local_protocol_was_capped_legacy() {
     let legacy = create_legacy_handshake();
     let session = SessionHandshake::Legacy(legacy);
-    // Our test handshake uses the same protocol for desired and negotiated
     assert!(!session.local_protocol_was_capped());
 }
 

--- a/crates/rsync_io/src/session/handshake/session/tests/stream_tests.rs
+++ b/crates/rsync_io/src/session/handshake/session/tests/stream_tests.rs
@@ -189,9 +189,7 @@ fn try_from_session_to_legacy_err() {
 fn map_stream_inner_binary() {
     let binary = create_binary_handshake();
     let session = SessionHandshake::Binary(binary);
-    let mapped = session.map_stream_inner(|_cursor| {
-        // Return a simple unit type to verify transformation
-    });
+    let mapped = session.map_stream_inner(|_cursor| {});
     assert!(mapped.is_binary());
 }
 
@@ -199,9 +197,7 @@ fn map_stream_inner_binary() {
 fn map_stream_inner_legacy() {
     let legacy = create_legacy_handshake();
     let session = SessionHandshake::Legacy(legacy);
-    let mapped = session.map_stream_inner(|_cursor| {
-        // Return a simple unit type to verify transformation
-    });
+    let mapped = session.map_stream_inner(|_cursor| {});
     assert!(mapped.is_legacy());
 }
 

--- a/crates/rsync_io/src/session/parts/accessors.rs
+++ b/crates/rsync_io/src/session/parts/accessors.rs
@@ -113,7 +113,9 @@ mod tests {
     use protocol::CompatibilityFlags;
     use std::io::Cursor;
 
-    // Helper to create binary handshake parts
+    /// Builds binary handshake parts at protocol 31. The first byte differs
+    /// from `'@'` so the sniffer chooses the binary prologue, and the remaining
+    /// bytes encode protocol 31 as a little-endian u32.
     fn create_binary_parts() -> SessionHandshakeParts<Cursor<Vec<u8>>> {
         let stream = sniff_negotiation_stream(Cursor::new(vec![0x1f, 0x00, 0x00, 0x00]))
             .expect("sniff succeeds");
@@ -128,7 +130,7 @@ mod tests {
         )
     }
 
-    // Helper to create legacy handshake parts
+    /// Builds legacy daemon handshake parts at protocol 31.
     fn create_legacy_parts() -> SessionHandshakeParts<Cursor<Vec<u8>>> {
         let stream = sniff_negotiation_stream(Cursor::new(b"@RSYNCD: 31.0\n".to_vec()))
             .expect("sniff succeeds");
@@ -265,7 +267,6 @@ mod tests {
     fn remote_advertisement_returns_classification_for_binary() {
         let parts = create_binary_parts();
         let adv = parts.remote_advertisement();
-        // Protocol 31 is supported, so clamped() returns None
         assert!(adv.supported().is_some());
         assert_eq!(adv.supported().unwrap().as_u8(), 31);
     }
@@ -274,7 +275,6 @@ mod tests {
     fn remote_advertisement_returns_classification_for_legacy() {
         let parts = create_legacy_parts();
         let adv = parts.remote_advertisement();
-        // Protocol 31 is supported, so clamped() returns None
         assert!(adv.supported().is_some());
         assert_eq!(adv.supported().unwrap().as_u8(), 31);
     }
@@ -296,7 +296,6 @@ mod tests {
     fn server_greeting_includes_subprotocol() {
         let parts = create_legacy_parts();
         let greeting = parts.server_greeting().expect("legacy has greeting");
-        // Subprotocol is a u32 (0 in our test case)
         assert_eq!(greeting.subprotocol(), 0);
     }
 

--- a/crates/rsync_io/src/session/parts/conversions.rs
+++ b/crates/rsync_io/src/session/parts/conversions.rs
@@ -60,7 +60,7 @@ mod tests {
     use protocol::{CompatibilityFlags, LegacyDaemonGreetingOwned, ProtocolVersion};
     use std::io::Cursor;
 
-    // Helper to create a BinaryHandshake
+    /// Builds a binary handshake fixture at protocol 31.
     fn create_binary_handshake() -> BinaryHandshake<Cursor<Vec<u8>>> {
         let stream = sniff_negotiation_stream(Cursor::new(vec![0x1f, 0x00, 0x00, 0x00]))
             .expect("sniff succeeds");
@@ -75,7 +75,7 @@ mod tests {
         )
     }
 
-    // Helper to create a LegacyDaemonHandshake
+    /// Builds a legacy daemon handshake fixture at protocol 31.
     fn create_legacy_handshake() -> LegacyDaemonHandshake<Cursor<Vec<u8>>> {
         let stream = sniff_negotiation_stream(Cursor::new(b"@RSYNCD: 31.0\n".to_vec()))
             .expect("sniff succeeds");
@@ -85,7 +85,7 @@ mod tests {
         LegacyDaemonHandshake::from_components(greeting, proto31, stream)
     }
 
-    // Helper to create SessionHandshakeParts (binary)
+    /// Builds binary `SessionHandshakeParts` at protocol 31.
     fn create_binary_parts() -> SessionHandshakeParts<Cursor<Vec<u8>>> {
         let stream = sniff_negotiation_stream(Cursor::new(vec![0x1f, 0x00, 0x00, 0x00]))
             .expect("sniff succeeds");
@@ -100,7 +100,7 @@ mod tests {
         )
     }
 
-    // Helper to create SessionHandshakeParts (legacy)
+    /// Builds legacy `SessionHandshakeParts` at protocol 31.
     fn create_legacy_parts() -> SessionHandshakeParts<Cursor<Vec<u8>>> {
         let stream = sniff_negotiation_stream(Cursor::new(b"@RSYNCD: 31.0\n".to_vec()))
             .expect("sniff succeeds");

--- a/crates/rsync_io/src/session/parts/ownership.rs
+++ b/crates/rsync_io/src/session/parts/ownership.rs
@@ -249,7 +249,9 @@ mod tests {
     use protocol::{CompatibilityFlags, LegacyDaemonGreetingOwned, ProtocolVersion};
     use std::io::Cursor;
 
-    // Helper to create binary handshake parts
+    /// Builds binary handshake parts at protocol 31. The first byte differs
+    /// from `'@'` so the sniffer chooses the binary prologue, and the remaining
+    /// bytes encode protocol 31 as a little-endian u32.
     fn create_binary_parts() -> SessionHandshakeParts<Cursor<Vec<u8>>> {
         let stream = sniff_negotiation_stream(Cursor::new(vec![0x1f, 0x00, 0x00, 0x00]))
             .expect("sniff succeeds");
@@ -264,7 +266,7 @@ mod tests {
         )
     }
 
-    // Helper to create legacy handshake parts
+    /// Builds legacy daemon handshake parts at protocol 31.
     fn create_legacy_parts() -> SessionHandshakeParts<Cursor<Vec<u8>>> {
         let stream = sniff_negotiation_stream(Cursor::new(b"@RSYNCD: 31.0\n".to_vec()))
             .expect("sniff succeeds");
@@ -292,7 +294,6 @@ mod tests {
     fn into_stream_reconstructs_negotiated_stream_for_binary() {
         let parts = create_binary_parts();
         let stream = parts.into_stream();
-        // After sniffing, only the first byte was read to determine binary mode
         assert!(stream.buffered_len() > 0);
     }
 
@@ -482,7 +483,6 @@ mod tests {
             CompatibilityFlags::EMPTY,
             stream.into_parts(),
         );
-        // Capped if negotiated < remote
         assert!(parts.local_protocol_was_capped());
     }
 
@@ -512,7 +512,6 @@ mod tests {
     fn into_inner_extracts_transport_for_binary() {
         let parts = create_binary_parts();
         let inner: Cursor<Vec<u8>> = parts.into_inner();
-        // The position may have advanced during sniffing
         assert!(!inner.get_ref().is_empty());
     }
 
@@ -520,7 +519,6 @@ mod tests {
     fn into_inner_extracts_transport_for_legacy() {
         let parts = create_legacy_parts();
         let inner: Cursor<Vec<u8>> = parts.into_inner();
-        // The position may have advanced during sniffing
         assert!(!inner.get_ref().is_empty());
     }
 }

--- a/crates/rsync_io/src/session/parts/state.rs
+++ b/crates/rsync_io/src/session/parts/state.rs
@@ -213,9 +213,10 @@ mod tests {
     use crate::sniff_negotiation_stream;
     use std::io::Cursor;
 
-    // Helper to create binary handshake parts
+    /// Builds binary handshake parts at protocol 31. The first byte differs
+    /// from `'@'` so the sniffer chooses the binary prologue, and the remaining
+    /// bytes encode protocol 31 as a little-endian u32.
     fn create_binary_parts() -> SessionHandshakeParts<Cursor<Vec<u8>>> {
-        // Binary negotiation: protocol 31 as BE u32
         let stream = sniff_negotiation_stream(Cursor::new(vec![0x1f, 0x00, 0x00, 0x00]))
             .expect("sniff succeeds");
         let proto31 = ProtocolVersion::from_supported(31).unwrap();
@@ -229,7 +230,7 @@ mod tests {
         )
     }
 
-    // Helper to create legacy handshake parts
+    /// Builds legacy daemon handshake parts at protocol 31.
     fn create_legacy_parts() -> SessionHandshakeParts<Cursor<Vec<u8>>> {
         let stream = sniff_negotiation_stream(Cursor::new(b"@RSYNCD: 31.0\n".to_vec()))
             .expect("sniff succeeds");
@@ -451,7 +452,6 @@ mod tests {
             assert_eq!(local.as_u8(), 31);
             assert_eq!(negotiated.as_u8(), 31);
             assert_eq!(flags, CompatibilityFlags::EMPTY);
-            // Stream contains the buffered bytes captured during sniffing
             assert!(!stream.buffered().is_empty());
         } else {
             panic!("expected Binary variant");

--- a/crates/rsync_io/src/session/tests/clones.rs
+++ b/crates/rsync_io/src/session/tests/clones.rs
@@ -460,5 +460,3 @@ fn session_handshake_parts_from_legacy_components_round_trips() {
     assert_eq!(transport.writes(), b"@RSYNCD: 31.0\n");
     assert_eq!(transport.flushes(), 1);
 }
-
-// InstrumentedTransport is provided by the support module.

--- a/crates/rsync_io/src/ssh/embedded/auth.rs
+++ b/crates/rsync_io/src/ssh/embedded/auth.rs
@@ -408,8 +408,6 @@ mod tests {
         assert_eq!(user, "explicit");
     }
 
-    // --- Mock SSH server for auth flow integration tests ---
-
     use std::sync::Arc;
 
     use russh::server::Server as _;

--- a/crates/rsync_io/src/ssh/embedded/config.rs
+++ b/crates/rsync_io/src/ssh/embedded/config.rs
@@ -499,8 +499,6 @@ mod tests {
         assert_eq!(cfg.username.as_deref(), Some("bob"));
     }
 
-    // --- URL parsing tests ---
-
     #[test]
     fn from_url_simple_host_path() {
         let (cfg, path) = SshConfig::from_url("ssh://host/path/to/file").unwrap();
@@ -629,8 +627,6 @@ mod tests {
         assert_eq!(cfg.password.as_deref(), Some("s3cret"));
         assert_eq!(path, "~/backups");
     }
-
-    // --- Keepalive and timeout edge-case tests ---
 
     #[test]
     fn connect_timeout_zero_disables_timeout() {

--- a/crates/rsync_io/src/ssh/embedded/handler.rs
+++ b/crates/rsync_io/src/ssh/embedded/handler.rs
@@ -251,7 +251,6 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         let kh_path = dir.path().join("known_hosts");
 
-        // Write the key as a known host.
         russh_keys::learn_known_hosts_path("testhost.example", 22, &pubkey, &kh_path)
             .expect("learn");
 
@@ -274,7 +273,6 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         let kh_path = dir.path().join("known_hosts");
 
-        // Create an empty known_hosts file.
         std::fs::File::create(&kh_path).expect("create");
 
         let handler = SshClientHandler::new(
@@ -300,7 +298,6 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         let kh_path = dir.path().join("known_hosts");
 
-        // Create an empty known_hosts file.
         std::fs::File::create(&kh_path).expect("create");
 
         let handler = SshClientHandler::new(
@@ -405,7 +402,6 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         let kh_path = dir.path().join("known_hosts");
 
-        // Write garbage.
         let mut f = std::fs::File::create(&kh_path).expect("create");
         writeln!(f, "not a valid known_hosts line !!! garbage").expect("write");
         drop(f);

--- a/crates/rsync_io/src/ssh/tests.rs
+++ b/crates/rsync_io/src/ssh/tests.rs
@@ -284,14 +284,12 @@ fn stderr_output_bounded_to_cap() {
     let (status, stderr) = child_handle.wait_with_stderr().expect("wait");
     assert!(status.success());
 
-    // Buffer should be bounded to 64 KB.
     let cap = 64 * 1024;
     assert!(
         stderr.len() <= cap,
         "stderr buffer should be bounded to {cap}, got {}",
         stderr.len()
     );
-    // Should have collected some output (not empty).
     assert!(!stderr.is_empty(), "expected non-empty stderr output");
 }
 
@@ -410,16 +408,13 @@ fn split_connection_provides_separate_read_write_halves() {
 
     let (mut reader, mut writer, child_handle) = connection.split().expect("split succeeds");
 
-    // Write to stdin via writer
     writer.write_all(b"test").expect("write");
     writer.close().expect("close writer");
 
-    // Read from stdout via reader
     let mut buffer = Vec::new();
     reader.read_to_end(&mut buffer).expect("read");
     assert_eq!(&buffer, b"test");
 
-    // Wait for child via handle
     let status = child_handle.wait().expect("wait");
     assert!(status.success());
 }


### PR DESCRIPTION
## Summary

Comment audit of the `rsync_io` crate per internal docs cleanup rules (refs #1847).

- Delete echo/restatement comments that simply mirror the code beneath.
- Delete debug-checkpoint, decorative banner, and divider comments.
- Preserve all `// upstream:` references and comments that explain WHY:
  multiplex framing, error semantics, MSG_INFO/ERROR/STATS classification,
  protocol math/computation, security/cipher injection rationale, SSH
  process lifecycle, drain thread/zombie handling, and design tradeoffs.

## Stats

- 16 files touched in `crates/rsync_io/src/`
- ~30 echo/banner/checkpoint comments removed
- A handful of restating comments converted to `///` rustdoc form
- No public API or behavioural changes

## Test plan

- [x] `cargo fmt --all`
- [ ] CI: fmt+clippy
- [ ] CI: nextest (stable / Windows / macOS / Linux musl)