### PR TITLE
docs(transport): investigate splice/vmsplice for SSH stdio

### DIFF
--- a/crates/fast_io/Cargo.toml
+++ b/crates/fast_io/Cargo.toml
@@ -84,3 +84,7 @@ harness = false
 [[bench]]
 name = "platform_copy"
 harness = false
+
+[[bench]]
+name = "splice_pipe"
+harness = false

--- a/crates/fast_io/benches/splice_pipe.rs
+++ b/crates/fast_io/benches/splice_pipe.rs
@@ -1,0 +1,166 @@
+//! Benchmark skeleton for the splice/vmsplice SSH-stdio investigation.
+//!
+//! Tracks oc-rsync task #1860. The audit doc lives at
+//! `docs/audits/splice-ssh-stdio.md`. This bench provides a baseline so that
+//! once the splice driver lands (`fast_io::splice_pipe`, see follow-up
+//! #1861), a measurable delta can be reported against the read/write loop
+//! that oc-rsync uses today on the SSH-stdio sender path.
+//!
+//! Two benches are defined inside the `splice_pipe` group:
+//!
+//! - `read_write_baseline` - a real file -> pipe transfer using
+//!   `read(2)` + `write_all(2)` with a 64 KiB buffer. This mirrors the
+//!   current sender code path (modulo the multiplex envelope) and produces
+//!   the comparison baseline for future splice work.
+//! - `splice_baseline` - a placeholder slot that today just records a
+//!   constant. It exists so that the criterion group has a stable identity
+//!   on Linux and so that follow-up patches can drop the splice driver into
+//!   place without changing the report layout. The body is intentionally
+//!   trivial; replace it once #1861 lands.
+//!
+//! Cross-platform: the meaningful code is gated to Linux. On other targets
+//! the bench compiles to an empty criterion main so that
+//! `cargo bench -p fast_io --bench splice_pipe` does not fail to build on
+//! macOS or Windows. CI runs the meaningful benches on Linux only.
+//!
+//! Run with: `cargo bench -p fast_io --bench splice_pipe`
+
+use criterion::{Criterion, criterion_group, criterion_main};
+
+#[cfg(target_os = "linux")]
+fn bench_splice_pipe(c: &mut Criterion) {
+    use std::fs::File;
+    use std::io::{Read, Write};
+    use std::os::fd::{FromRawFd, IntoRawFd, OwnedFd};
+    use std::thread;
+
+    use criterion::{BenchmarkId, Throughput, black_box};
+    use tempfile::NamedTempFile;
+
+    /// Payload sizes exercised by the bench. 64 KiB matches the default
+    /// Linux pipe buffer; 1 MiB and 16 MiB stress the loop and the multiplex
+    /// max-payload boundary respectively.
+    const SIZES: &[(&str, usize)] = &[
+        ("64KB", 64 * 1024),
+        ("1MB", 1024 * 1024),
+        ("16MB", 16 * 1024 * 1024),
+    ];
+
+    /// Buffer size used by the read/write baseline. Mirrors the chunk size
+    /// that oc-rsync's existing sender path uses for whole-file transfers.
+    const BUFFER_SIZE: usize = 64 * 1024;
+
+    fn create_payload(size: usize) -> NamedTempFile {
+        let mut file = NamedTempFile::new().expect("create temp file");
+        let chunk: Vec<u8> = (0..BUFFER_SIZE).map(|i| (i % 251) as u8).collect();
+        let mut remaining = size;
+        while remaining > 0 {
+            let n = remaining.min(BUFFER_SIZE);
+            file.write_all(&chunk[..n]).expect("write payload");
+            remaining -= n;
+        }
+        file.flush().expect("flush payload");
+        file
+    }
+
+    /// Creates a pipe pair via `pipe(2)`. The reader fd is wrapped in a
+    /// drain thread to keep the pipe from filling up; the writer fd is
+    /// returned to the caller as an `OwnedFd`.
+    fn make_drained_pipe() -> (OwnedFd, thread::JoinHandle<()>) {
+        let mut fds = [0i32; 2];
+        // SAFETY: pipe(2) writes two fresh fds into the array. We immediately
+        // wrap each fd in OwnedFd / File so ownership is well-defined.
+        let rc = unsafe { libc::pipe(fds.as_mut_ptr()) };
+        assert_eq!(rc, 0, "pipe(2) failed: {}", std::io::Error::last_os_error());
+        // SAFETY: fds[0] is a fresh pipe read fd we own.
+        let read_end = unsafe { File::from_raw_fd(fds[0]) };
+        // SAFETY: fds[1] is a fresh pipe write fd we own.
+        let write_end = unsafe { OwnedFd::from_raw_fd(fds[1]) };
+
+        let drain = thread::spawn(move || {
+            let mut reader = read_end;
+            let mut sink = [0u8; BUFFER_SIZE];
+            loop {
+                match reader.read(&mut sink) {
+                    Ok(0) => break,
+                    Ok(_) => continue,
+                    Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+                    Err(_) => break,
+                }
+            }
+        });
+
+        (write_end, drain)
+    }
+
+    /// Drives the read/write baseline once. Reads `payload` from start to end
+    /// into a 64 KiB buffer and writes it through `writer` (a pipe).
+    fn run_read_write(payload: &NamedTempFile, writer: OwnedFd) {
+        // SAFETY: `writer` is a fresh OwnedFd handed to us by the bench
+        // setup; converting it to a File transfers ownership cleanly.
+        let mut writer = unsafe { File::from_raw_fd(writer.into_raw_fd()) };
+        let mut src = File::open(payload.path()).expect("open payload");
+        let mut buffer = vec![0u8; BUFFER_SIZE];
+        loop {
+            match src.read(&mut buffer) {
+                Ok(0) => break,
+                Ok(n) => {
+                    writer.write_all(&buffer[..n]).expect("write_all");
+                    black_box(n);
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+                Err(e) => panic!("read failed: {e}"),
+            }
+        }
+    }
+
+    let mut group = c.benchmark_group("splice_pipe");
+    group.sample_size(10);
+
+    for &(label, size) in SIZES {
+        let payload = create_payload(size);
+        group.throughput(Throughput::Bytes(size as u64));
+        group.bench_with_input(
+            BenchmarkId::new("read_write_baseline", label),
+            &(),
+            |b, _| {
+                b.iter_with_setup(make_drained_pipe, |(writer_fd, drain)| {
+                    run_read_write(&payload, writer_fd);
+                    drain.join().expect("drain thread");
+                });
+            },
+        );
+    }
+
+    eprintln!(
+        "splice_pipe::splice_baseline is a placeholder; tracking #1861 \
+         for the real fast_io::splice_pipe driver"
+    );
+    for &(label, size) in SIZES {
+        group.throughput(Throughput::Bytes(size as u64));
+        group.bench_with_input(
+            BenchmarkId::new("splice_baseline", label),
+            &size,
+            |b, &size| {
+                b.iter(|| black_box(size as u64));
+            },
+        );
+    }
+
+    group.finish();
+}
+
+#[cfg(not(target_os = "linux"))]
+fn bench_splice_pipe(c: &mut Criterion) {
+    // splice(2) is Linux-only. Define an empty group on other targets so the
+    // criterion harness still emits a report and the bench binary compiles.
+    let mut group = c.benchmark_group("splice_pipe");
+    group.sample_size(10);
+    group.bench_function("noop_non_linux", |b| {
+        b.iter(|| criterion::black_box(0u64));
+    });
+    group.finish();
+}
+
+criterion_group!(splice_pipe, bench_splice_pipe);
+criterion_main!(splice_pipe);

--- a/docs/audits/splice-ssh-stdio.md
+++ b/docs/audits/splice-ssh-stdio.md
@@ -1,0 +1,223 @@
+# splice/vmsplice for SSH stdio
+
+Tracking issue: oc-rsync task #1860.
+
+## Summary
+
+This audit evaluates whether `splice(2)` and `vmsplice(2)` (Linux 2.6.17+) can
+replace user-space buffer copies on the SSH stdio data path inside oc-rsync.
+The conclusion is that splice is applicable on the file-to-pipe (sender) and
+pipe-to-file (receiver) edges of the data path, but not across the SSH child
+itself. The multiplex framing layer adds a constraint that requires `vmsplice`
+or pre-staged pipe writes for the 4-byte MSG header before each payload chunk.
+The work is feasible, additive, and stays inside oc-rsync (no wire-protocol
+change). Upstream rsync 3.4.1 does not use splice; this is a pure oc-rsync
+optimisation.
+
+## Upstream evidence
+
+A recursive search for `splice`, `vmsplice`, `tee(`, `SPLICE`, and `sys_splice`
+under `target/interop/upstream-src/rsync-3.4.1/` returns one match: the shell
+helper `checktee()` inside `testsuite/rsync.fns` (an unrelated test scaffold).
+Upstream therefore performs all SSH stdio I/O via plain `read(2)`/`write(2)`
+on the pipe file descriptors. No protocol-level expectation of splice exists.
+
+## Where splice can apply
+
+oc-rsync drives an SSH client subprocess and exchanges rsync wire bytes through
+its stdio pipes. The local end owns the parent side of the pipes
+(`std::process::ChildStdin`, `ChildStdout`). The SSH child reads its stdin pipe,
+encrypts, and writes the cipher text to its own TCP socket; the reverse path
+mirrors that. We do not own the SSH socket, so any zero-copy work has to stay
+on the parent side of the pipe.
+
+```
+                       parent (oc-rsync)                       SSH child
+sender:
+  src file (page cache) -- splice --> ChildStdin pipe ----> [encrypt] -> TCP
+                          ^                  ^
+                          |                  |
+                          +--- file -> pipe  +--- pipe (we own)
+
+receiver:
+  TCP -> [decrypt] -> ChildStdout pipe -- splice --> dst file (page cache)
+                            ^                  ^
+                            |                  |
+                            +--- pipe (we own) +--- pipe -> file
+```
+
+Useful invariants:
+
+- `splice(2)` requires that one of the two file descriptors be a pipe.
+- The parent's view of the SSH child stdio is a pipe at both ends, so file <->
+  pipe transfers in either direction are eligible.
+- `vmsplice(2)` moves user pages into a pipe without copying. With
+  `SPLICE_F_GIFT`, ownership of the pages passes to the kernel; the caller may
+  not reuse those pages until the consumer drains them.
+- `tee(2)` duplicates between two pipes without consuming bytes; useful when
+  oc-rsync wants to peek at MSG headers while still forwarding the payload.
+
+What we cannot splice:
+
+- The encrypted bytes leaving the SSH child socket. We do not own that fd, and
+  it is a TCP socket, so even if we did, it could not pair with another socket
+  via splice.
+- Any data that has to be inspected, transformed, compressed, or checksummed
+  in user space before transmission. Delta-token, compression, and checksum
+  paths are out of scope for this audit.
+
+## Multiplex constraint
+
+oc-rsync uses the rsync multiplex envelope (see `crates/protocol/src/envelope`)
+on every byte that crosses SSH stdio:
+
+- 4-byte header (`HEADER_LEN`) carrying a tag byte (`MPLEX_BASE + code`) and a
+  24-bit length (`MAX_PAYLOAD_LENGTH = 0x00FF_FFFF` ~= 16 MiB - 1).
+- Up to `MAX_PAYLOAD_LENGTH` bytes of payload.
+- For raw file data, code is `MessageCode::Data` (`MSG_DATA = 0`).
+
+A naive `splice(file, pipe, payload_len)` would push raw file bytes into the
+pipe with no envelope, and the remote end would mis-frame the stream. The
+options for keeping framing correct without a user-space copy of the payload
+are:
+
+1. Write the 4-byte header with `write(2)` to the pipe, then `splice(file ->
+   pipe, payload_len)` for the payload. The header write is small enough that
+   the lack of zero-copy is not material; the saving is on the payload, which
+   dominates throughput.
+2. Stage the header on a small user-space buffer and `vmsplice(buf -> pipe, 4)`
+   with `SPLICE_F_GIFT`, then splice the payload. The buffer must not be
+   reused or freed until the SSH child has drained it; in practice we rotate
+   through a small pool of header pages.
+3. Pre-build a reusable header pipe that holds many pre-encoded headers via
+   `tee` plus `splice`, dripping headers into the data pipe between payload
+   chunks. This is the most complex variant and is only worth it if the
+   header-write syscall cost is measurable.
+
+Phase 1 of the plan picks option (1) because it is simple, correct, and lets
+us measure the payload-side savings independently.
+
+## Phased plan
+
+### Phase 1: file -> ChildStdin (sender), MSG_DATA payload only
+
+Deliverables:
+
+- A `fast_io::splice_pipe` module that, given an open source `File` and a
+  `ChildStdin`, writes a 4-byte MSG_DATA header via `write_all` and then
+  drives `splice(file_fd, pipe_fd, len, SPLICE_F_MOVE | SPLICE_F_MORE)` in a
+  loop until the requested chunk is delivered or `EAGAIN` is returned.
+- Integration point: the sender's whole-file send path, gated behind a
+  `--splice` capability flag and runtime kernel-version check (Linux 2.6.17+).
+- Fallback: on `EINVAL`, `ENOSYS`, or any non-`EAGAIN` error from `splice`,
+  fall back to the existing buffered `read` + `write_all` loop.
+
+Acceptance criteria:
+
+- `crates/fast_io/benches/splice_pipe.rs` reports a measurable reduction in
+  syscalls per MiB versus the read/write baseline on Linux for a 1 GiB
+  payload. Baseline: `read` + `write_all` loop with 64 KiB buffer.
+- No correctness regressions in the SSH integration test suite.
+- macOS and Windows compile cleanly with stub paths returning `Unsupported`.
+
+### Phase 2: ChildStdout -> dst file (receiver)
+
+Deliverables:
+
+- Mirror of phase 1: read the multiplex header into a small buffer, then
+  `splice(pipe_fd, file_fd, payload_len)` to land the payload directly in the
+  destination file's page cache.
+- Integrate with the receiver's whole-file write path. Skip when `--inplace`
+  combined with delta tokens is in effect, since those payloads are not raw
+  file bytes.
+
+Acceptance criteria:
+
+- Same syscall-savings target as phase 1 on the receive side.
+- `truncate(2)` / `fsync(2)` semantics preserved.
+- Sparse-file detection still works when phase 2 is disabled (it must remain
+  the responsibility of the existing zero-run detector).
+
+### Phase 3: vmsplice the multiplex header
+
+Deliverables:
+
+- A small ring of pre-encoded 4-byte header pages, fed into the pipe via
+  `vmsplice(SPLICE_F_GIFT)` so the header write joins the splice path.
+- Per-direction header allocator with lifetime tracking: a header page is
+  reusable only after the SSH child has drained it.
+
+Acceptance criteria:
+
+- Payload + header path is fully zero-copy on the parent side.
+- Bench shows a further reduction in `sendto`/`writev` syscalls per second
+  versus phase 1 + 2.
+
+### Out of scope
+
+- Socket-to-pipe paths (handled by the SSH child, not by oc-rsync).
+- Compression and checksum/delta-token paths (the bytes are computed in user
+  space and cannot be splice-fed without a copy).
+- Cross-platform support: macOS and Windows continue to use `read`/`write`.
+
+## Risks
+
+- **vmsplice page lifetime.** With `SPLICE_F_GIFT`, the kernel takes ownership
+  of the page. Reusing or freeing the page before the consumer (the SSH
+  child) reads it produces silent corruption. Mitigation: rotate header pages
+  and only recycle once the pipe has confirmed drain via successful subsequent
+  `splice` returns. The header ring should have at least
+  `pipe_capacity / HEADER_LEN` slots.
+- **`SPLICE_F_NONBLOCK` semantics.** When the pipe is full, splice returns
+  `EAGAIN`. Mixing blocking and non-blocking flags with the existing pipe
+  state can mis-drive the loop. Mitigation: keep the pipe in blocking mode
+  and handle `EAGAIN` with a poll/retry loop only when the pipe was
+  explicitly set non-blocking.
+- **Short splice returns.** `splice` may transfer fewer bytes than requested.
+  The driver must loop until either `len == 0` or a real error is returned.
+- **EPIPE on closed peer.** If the SSH child has exited, `splice` to its
+  stdin returns `EPIPE`. Mitigation: map to the existing broken-pipe path so
+  that the parent surfaces SSH stderr and the appropriate exit code.
+- **Pipe capacity.** Default Linux pipe buffer is 64 KiB. Larger transfers
+  require `fcntl(F_SETPIPE_SZ, ...)` to lift the buffer up to
+  `/proc/sys/fs/pipe-max-size`. The wrapper should attempt `F_SETPIPE_SZ` to
+  1 MiB and gracefully accept failure.
+- **`splice` between two regular files is not supported.** All call sites
+  must verify the destination/source kind before invoking the syscall.
+- **Interaction with `--bwlimit`.** Bandwidth limiting is enforced in user
+  space today via the bandwidth crate. Splice bypasses that path; phase 1
+  must keep `--bwlimit` on the read/write fallback or move pacing into the
+  splice loop via bounded chunk sizes.
+- **Interaction with `--checksum-seed` / debug logging.** Anything that
+  inspects the bytes after they leave the file must remain on the read/write
+  fallback.
+
+## Follow-up tasks
+
+- [ ] #1861 implement `fast_io::splice_pipe` driver (phase 1).
+- [ ] #1862 wire splice driver into the sender whole-file send path with a
+  capability gate and `--bwlimit` interaction guard.
+- [ ] #1863 mirror driver for the receiver path (phase 2).
+- [ ] #1864 vmsplice header ring (phase 3) with lifetime tracking.
+- [ ] #1865 add `bench(fast_io)` Linux-only criterion suite under
+  `splice_pipe` to track per-phase syscall and CPU savings; today the suite
+  contains a baseline plus an ignored placeholder for the splice path.
+- [ ] #1866 audit interaction with io_uring `IOSQE_IO_LINK` chains; splice
+  may compete with the existing buffer-ring registered-buffer path on
+  Linux 5.6+ and we should document a chooser.
+- [ ] #1867 cross-version interop test: confirm that an oc-rsync sender with
+  splice enabled is byte-identical on the wire to a sender without it.
+
+## References
+
+- Upstream rsync 3.4.1 source: `target/interop/upstream-src/rsync-3.4.1/`
+  (no splice usage).
+- Existing socket-to-disk splice driver:
+  `crates/fast_io/src/splice.rs`.
+- Multiplex envelope constants:
+  `crates/protocol/src/envelope/constants.rs` (`HEADER_LEN`,
+  `MAX_PAYLOAD_LENGTH`, `MPLEX_BASE`).
+- SSH connection ownership of stdio pipes:
+  `crates/rsync_io/src/ssh/connection.rs` (`SshReader`, `SshWriter`).
+- Linux man pages: `splice(2)`, `vmsplice(2)`, `tee(2)`,
+  `fcntl(2) F_SETPIPE_SZ`.

--- a/docs/perf-roadmap.md
+++ b/docs/perf-roadmap.md
@@ -1,0 +1,17 @@
+# Performance roadmap
+
+Rolling list of throughput and latency optimisations under investigation. Each
+entry links to the audit doc and the tracking issue. Status is one of
+`audit`, `phase-N`, or `landed`.
+
+| Topic | Status | Audit | Tracking |
+|-------|--------|-------|----------|
+| splice/vmsplice for SSH stdio | audit | [docs/audits/splice-ssh-stdio.md](audits/splice-ssh-stdio.md) | #1860 |
+
+Notes:
+
+- Add new entries above the table footer. Keep them sorted by topic.
+- An entry leaves this list once every phase has landed and the corresponding
+  benchmark dashboard shows the expected savings.
+- The audit doc is the source of truth for phased plan, risks, and follow-up
+  tasks. This file is the index.


### PR DESCRIPTION
## Summary

Investigation for oc-rsync task #1860. Adds a written audit and a criterion bench skeleton so a follow-up implementer can land the real driver against a measured baseline.

- Confirms upstream rsync 3.4.1 does NOT use splice (a recursive search of `target/interop/upstream-src/rsync-3.4.1/` for `splice`, `vmsplice`, `tee(`, and `SPLICE` returns one match: an unrelated `checktee()` shell helper in `testsuite/rsync.fns`). This is a pure oc-rsync optimisation, no wire-protocol change.
- Identifies the only realistic targets for zero-copy on the SSH stdio path: file -> ChildStdin pipe (sender) and ChildStdout pipe -> destination file (receiver). The parent does not own the SSH child's TCP socket, so we cannot splice past the SSH child.
- Documents the multiplex envelope constraint: a 4-byte header (`HEADER_LEN`, `MPLEX_BASE + MessageCode::Data`, 24-bit payload length) sits in front of every chunk. Phase 1 keeps the header on a `write_all` and splices only the payload; phase 3 moves the header onto a `vmsplice(SPLICE_F_GIFT)` ring.

## Phased plan

- **Phase 1** - file -> ChildStdin payload-only splice on the sender path, gated behind a runtime kernel-version check with a fallback to the existing `read` + `write_all` loop. Acceptance: bench delta vs the baseline reported in `crates/fast_io/benches/splice_pipe.rs`.
- **Phase 2** - mirror driver on the receiver: ChildStdout -> destination file. Skip when delta-token paths are in flight (those bytes are not raw file content).
- **Phase 3** - `vmsplice(SPLICE_F_GIFT)` for the multiplex header. Requires a header-page ring with explicit lifetime tracking against the SSH child's drain.

Out of scope: socket-to-pipe (handled by the SSH child), checksum/delta-token paths, compression paths.

## Risks

vmsplice page lifetime, `SPLICE_F_NONBLOCK` semantics, short splice returns, `EPIPE` on closed peer, default 64 KiB pipe capacity (`F_SETPIPE_SZ` lift), interaction with `--bwlimit` user-space pacing. Each is enumerated with a mitigation in the audit doc.

## Files

- `docs/audits/splice-ssh-stdio.md` - full audit with ASCII flow diagram, phased plan, risks, and follow-up task list.
- `docs/perf-roadmap.md` - new index file linking to this audit.
- `crates/fast_io/benches/splice_pipe.rs` - criterion bench skeleton with a real `read_write_baseline` (Linux) and a `splice_baseline` placeholder slot. Non-Linux targets compile to a no-op group.
- `crates/fast_io/Cargo.toml` - register the new bench.

## Test plan

- [ ] CI fmt + clippy on Linux, macOS, Windows.
- [ ] CI nextest passes (no test changes; bench compiles as a separate target).
- [ ] Manual: `cargo bench -p fast_io --bench splice_pipe` succeeds on Linux and prints the placeholder notice on the splice slot.
- [ ] Manual: `cargo build --benches -p fast_io` succeeds on macOS / Windows.

Tracking: oc-rsync #1860. Follow-ups: #1861 (driver), #1862 (sender wiring), #1863 (receiver mirror), #1864 (vmsplice header ring), #1865 (Linux bench suite), #1866 (io_uring chooser), #1867 (interop byte-identity).