### PR TITLE
docs: convert restating comments to rustdoc in small crates

### DIFF
--- a/crates/branding/src/workspace/version.rs
+++ b/crates/branding/src/workspace/version.rs
@@ -193,7 +193,6 @@ impl std::str::FromStr for Version {
             return Err(VersionParseError::new(s, "empty version string"));
         }
 
-        // Split on optional -rust suffix
         let (base, rust_branded) = match trimmed.rsplit_once("-rust") {
             Some((base, "")) => (base, true),
             Some(_) => {
@@ -205,7 +204,6 @@ impl std::str::FromStr for Version {
             None => (trimmed, false),
         };
 
-        // Parse x.y.z components
         let parts: Vec<&str> = base.split('.').collect();
         if parts.len() != 3 {
             return Err(VersionParseError::new(
@@ -236,7 +234,6 @@ fn parse_component(
         return Err(VersionParseError::new(original, component_name));
     }
 
-    // Allow leading zeros but reject non-numeric characters
     s.parse::<u32>().map_err(|_| {
         VersionParseError::new(original, "version components must be non-negative integers")
     })


### PR DESCRIPTION
## Summary

- Removes three restating-the-code `//` comments from production paths in `crates/branding/src/workspace/version.rs` (the `FromStr` impl and `parse_component` helper).
- The remaining small crates (`logging-sink`, `embedding`, `windows-gnu-eh`, `test-support`) were already clean: their only `//` comments are inside `#[cfg(test)] mod tests` blocks, SAFETY blocks documenting unsafe invariants, or non-obvious WHY notes (kernel/ABI/runtime context) that the audit rules require preserving.
- Zero `// upstream:` references were touched. All SAFETY comments and module-level `//!` docs are unchanged.

## Test plan

- [x] No production logic changed (comment-only edits in `version.rs`).
- [ ] CI: fmt + clippy.
- [ ] CI: nextest stable.

Closes #1849.