### PR TITLE
docs(fast_io): convert restating comments to rustdoc

### DIFF
--- a/crates/fast_io/src/copy_file_ex.rs
+++ b/crates/fast_io/src/copy_file_ex.rs
@@ -144,7 +144,8 @@ fn try_copy_file_ex_impl(src: &Path, dst: &Path) -> io::Result<u64> {
         .chain(std::iter::once(0))
         .collect();
 
-    // Use no-buffering for files above the threshold to bypass system cache
+    // Bypass the system cache for files above the threshold: large sequential
+    // copies otherwise pollute the cache and take a hit from the buffer copy.
     let file_size = std::fs::metadata(src)?.len();
     let flags = if file_size > NO_BUFFERING_THRESHOLD {
         ffi::COPY_FILE_NO_BUFFERING

--- a/crates/fast_io/src/copy_file_range.rs
+++ b/crates/fast_io/src/copy_file_range.rs
@@ -169,7 +169,6 @@ fn try_io_uring_copy(source: &File, destination: &File, length: u64) -> io::Resu
     while total_copied < length {
         let want = ((length - total_copied) as usize).min(buf_size);
 
-        // Submit read from source
         let read_entry =
             io_uring::opcode::Read::new(io_uring::types::Fd(src_fd), buf.as_mut_ptr(), want as u32)
                 .offset(src_offset)
@@ -202,7 +201,6 @@ fn try_io_uring_copy(source: &File, destination: &File, length: u64) -> io::Resu
         let bytes_read = read_result as usize;
         src_offset += bytes_read as u64;
 
-        // Submit write to destination
         let write_entry = io_uring::opcode::Write::new(
             io_uring::types::Fd(dst_fd),
             buf.as_ptr(),
@@ -318,17 +316,12 @@ fn try_copy_file_range(source: &File, destination: &File, length: u64) -> io::Re
         };
 
         if result < 0 {
-            let err = io::Error::last_os_error();
-            if total_copied == 0 {
-                // Failed on first chunk - return error to trigger fallback
-                return Err(err);
-            }
-            // Partial copy succeeded, but now we hit an error - still return error
-            return Err(err);
+            // Always surface the error so the caller can fall back; partial copies
+            // are still treated as failures because a partial dst is invalid.
+            return Err(io::Error::last_os_error());
         }
 
         if result == 0 {
-            // EOF reached
             break;
         }
 
@@ -381,7 +374,6 @@ fn copy_file_contents_readwrite(source: &File, destination: &File, length: u64) 
         let to_read = (remaining as usize).min(buf.len());
         let n = reader.read(&mut buf[..to_read])?;
         if n == 0 {
-            // EOF reached
             break;
         }
         writer.write_all(&buf[..n])?;
@@ -450,7 +442,6 @@ mod tests {
 
     #[test]
     fn test_copy_small_file_below_threshold() {
-        // Small file (< 64KB) should use read/write path directly
         let content = b"Hello, world! This is a small file.";
         let source = create_temp_file(content).unwrap();
         let mut dest = NamedTempFile::new().unwrap();
@@ -466,8 +457,7 @@ mod tests {
 
     #[test]
     fn test_copy_large_file_above_threshold() {
-        // Large file (>= 64KB) should attempt copy_file_range
-        let size = 128 * 1024; // 128KB
+        let size = 128 * 1024; // 128KB - exceeds COPY_FILE_RANGE_THRESHOLD
         let content: Vec<u8> = (0..size).map(|i| (i % 256) as u8).collect();
         let source = create_temp_file(&content).unwrap();
         let mut dest = NamedTempFile::new().unwrap();
@@ -497,7 +487,6 @@ mod tests {
 
     #[test]
     fn test_copy_partial_eof() {
-        // Request more bytes than available - should stop at EOF
         let content = b"Short content";
         let source = create_temp_file(content).unwrap();
         let mut dest = NamedTempFile::new().unwrap();
@@ -512,7 +501,6 @@ mod tests {
 
     #[test]
     fn test_copy_exact_threshold() {
-        // Exactly at threshold should attempt copy_file_range
         let size = COPY_FILE_RANGE_THRESHOLD as usize;
         let content: Vec<u8> = (0..size).map(|i| (i % 256) as u8).collect();
         let source = create_temp_file(&content).unwrap();
@@ -529,7 +517,6 @@ mod tests {
 
     #[test]
     fn test_readwrite_fallback_direct() {
-        // Test the read/write fallback path directly
         let content = b"Testing fallback path directly";
         let source = create_temp_file(content).unwrap();
         let mut dest = NamedTempFile::new().unwrap();
@@ -546,20 +533,17 @@ mod tests {
 
     #[test]
     fn test_parity_both_paths() {
-        // Both paths should produce identical output for same input
+        // Tiered dispatch and the read/write fallback must produce byte-identical
+        // output for the same input - regression guard against silent data drift.
         let size = 256 * 1024; // 256KB - forces copy_file_range attempt
-        let content: Vec<u8> = (0..size)
-            .map(|i| ((i * 7 + 13) % 256) as u8) // Pseudo-random pattern
-            .collect();
+        let content: Vec<u8> = (0..size).map(|i| ((i * 7 + 13) % 256) as u8).collect();
 
-        // Path 1: copy_file_contents (attempts copy_file_range)
         let source1 = create_temp_file(&content).unwrap();
         let mut dest1 = NamedTempFile::new().unwrap();
         let copied1 = copy_file_contents(source1.as_file(), dest1.as_file(), size as u64).unwrap();
         dest1.seek(SeekFrom::Start(0)).unwrap();
         let result1 = read_file_contents(dest1.as_file()).unwrap();
 
-        // Path 2: copy_file_contents_readwrite (direct fallback)
         let source2 = create_temp_file(&content).unwrap();
         let mut dest2 = NamedTempFile::new().unwrap();
         let copied2 =
@@ -567,19 +551,17 @@ mod tests {
         dest2.seek(SeekFrom::Start(0)).unwrap();
         let result2 = read_file_contents(dest2.as_file()).unwrap();
 
-        // Both should copy all bytes
         assert_eq!(copied1, size as u64);
         assert_eq!(copied2, size as u64);
-
-        // Both should produce identical output
         assert_eq!(result1, result2);
         assert_eq!(result1, content);
     }
 
     #[test]
     fn test_large_file_multi_chunk() {
-        // Test file larger than typical kernel copy_file_range limit
-        let size = 2 * 1024 * 1024; // 2MB - may require multiple syscalls
+        // 2MB exercises the multi-iteration loop in try_copy_file_range, where the
+        // kernel typically returns short copies and the caller must continue.
+        let size = 2 * 1024 * 1024;
         let content: Vec<u8> = (0..size).map(|i| (i % 256) as u8).collect();
         let source = create_temp_file(&content).unwrap();
         let mut dest = NamedTempFile::new().unwrap();
@@ -595,15 +577,15 @@ mod tests {
 
     #[test]
     fn test_copy_with_file_position() {
-        // Test that file position is respected
+        // Verifies that copy_file_contents honours the source's current file
+        // position rather than implicitly seeking to zero - critical because
+        // copy_file_range advances the source offset in place.
         let content = b"0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
         let mut source = create_temp_file(content).unwrap();
         let mut dest = NamedTempFile::new().unwrap();
 
-        // Seek source to position 10
         source.seek(SeekFrom::Start(10)).unwrap();
 
-        // Copy 10 bytes from position 10
         let copied = copy_file_contents(source.as_file(), dest.as_file(), 10).unwrap();
 
         assert_eq!(copied, 10);
@@ -615,12 +597,13 @@ mod tests {
     #[cfg(target_os = "linux")]
     #[test]
     fn test_try_copy_file_range_linux() {
-        // On Linux, try_copy_file_range should succeed for same-filesystem copy
+        // Same-filesystem temp files succeed on kernel 4.5+. Older kernels and
+        // cross-filesystem cases (kernel < 5.3) return an error, which is the
+        // signal the production code uses to fall back to read/write.
         let content = b"Testing copy_file_range syscall directly";
         let source = create_temp_file(content).unwrap();
         let mut dest = NamedTempFile::new().unwrap();
 
-        // This may fail on old kernels or cross-filesystem, but that's expected
         match try_copy_file_range(source.as_file(), dest.as_file(), content.len() as u64) {
             Ok(copied) => {
                 assert_eq!(copied, content.len() as u64);
@@ -629,7 +612,6 @@ mod tests {
                 assert_eq!(dest_content, content);
             }
             Err(_) => {
-                // Fallback is expected on old kernels or cross-filesystem
                 eprintln!("copy_file_range not available, fallback will be used");
             }
         }
@@ -638,7 +620,6 @@ mod tests {
     #[cfg(not(target_os = "linux"))]
     #[test]
     fn test_try_copy_file_range_non_linux() {
-        // On non-Linux platforms, should always return Unsupported
         let content = b"Test";
         let source = create_temp_file(content).unwrap();
         let dest = NamedTempFile::new().unwrap();
@@ -651,8 +632,8 @@ mod tests {
     #[cfg(all(target_os = "linux", feature = "io_uring"))]
     #[test]
     fn test_try_io_uring_copy_linux() {
-        // On Linux with io_uring, try_io_uring_copy should succeed when the
-        // kernel supports it. Falls back gracefully on older kernels.
+        // Succeeds on kernels with io_uring (5.6+); older kernels return Err so
+        // production callers can fall back. Either outcome is acceptable here.
         let size = 512 * 1024; // 512KB - above IO_URING_COPY_THRESHOLD
         let content: Vec<u8> = (0..size).map(|i| (i % 256) as u8).collect();
         let source = create_temp_file(&content).unwrap();
@@ -666,7 +647,6 @@ mod tests {
                 assert_eq!(dest_content, content);
             }
             Err(_) => {
-                // io_uring unavailable on this kernel - expected fallback
                 eprintln!("io_uring not available, fallback will be used");
             }
         }
@@ -675,7 +655,6 @@ mod tests {
     #[cfg(not(all(target_os = "linux", feature = "io_uring")))]
     #[test]
     fn test_try_io_uring_copy_stub() {
-        // On non-Linux or without io_uring feature, should return Unsupported
         let content = b"Test io_uring stub";
         let source = create_temp_file(content).unwrap();
         let dest = NamedTempFile::new().unwrap();
@@ -687,9 +666,9 @@ mod tests {
 
     #[test]
     fn test_buffered_copy_above_io_uring_threshold() {
-        // Files above IO_URING_COPY_THRESHOLD should try io_uring first,
-        // then fall through to copy_file_range or read/write
-        let size = 512 * 1024; // 512KB
+        // 512KB exceeds IO_URING_COPY_THRESHOLD so the buffered path exercises
+        // tier 1 (io_uring), then 2 (copy_file_range), then 3 (read/write).
+        let size = 512 * 1024;
         let content: Vec<u8> = (0..size).map(|i| (i % 256) as u8).collect();
         let source = create_temp_file(&content).unwrap();
         let mut dest = NamedTempFile::new().unwrap();

--- a/crates/fast_io/src/io_uring/config.rs
+++ b/crates/fast_io/src/io_uring/config.rs
@@ -562,8 +562,6 @@ mod tests {
         assert!(reason.starts_with("io_uring: "));
     }
 
-    // --- Kernel version parsing edge cases ---
-
     #[test]
     fn parse_kernel_version_extra_dots_azure() {
         // Azure kernel strings have extra dot-separated segments.
@@ -617,8 +615,6 @@ mod tests {
             Some((5, 10))
         );
     }
-
-    // --- Config presets ---
 
     fn is_power_of_two(n: u32) -> bool {
         n > 0 && (n & (n - 1)) == 0
@@ -713,8 +709,6 @@ mod tests {
         let config = IoUringConfig::default();
         assert!(!config.sqpoll, "SQPOLL should be disabled by default");
     }
-
-    // --- SQPOLL fallback ---
 
     #[test]
     fn build_ring_with_sqpoll_falls_back_gracefully() {

--- a/crates/fast_io/src/io_uring/file_writer.rs
+++ b/crates/fast_io/src/io_uring/file_writer.rs
@@ -332,24 +332,22 @@ impl Write for IoUringWriter {
             return Ok(0);
         }
 
-        // If data fits in buffer, just copy it
         if self.buffer_pos + buf.len() <= self.buffer_size {
             self.buffer[self.buffer_pos..self.buffer_pos + buf.len()].copy_from_slice(buf);
             self.buffer_pos += buf.len();
             return Ok(buf.len());
         }
 
-        // Flush current buffer
         self.flush_buffer()?;
 
-        // If data is larger than buffer, write directly using batched path
+        // Bypass internal buffer when data is at least one full chunk: a single
+        // batched submission is cheaper than copy-then-flush.
         if buf.len() >= self.buffer_size {
             self.write_all_batched(buf, self.bytes_written)?;
             self.bytes_written += buf.len() as u64;
             return Ok(buf.len());
         }
 
-        // Otherwise, buffer the data
         self.buffer[..buf.len()].copy_from_slice(buf);
         self.buffer_pos = buf.len();
         Ok(buf.len())
@@ -412,7 +410,6 @@ impl Seek for IoUringWriter {
 
 impl Drop for IoUringWriter {
     fn drop(&mut self) {
-        // Best-effort flush on drop
         let _ = self.flush_buffer();
     }
 }

--- a/crates/fast_io/src/io_uring_stub.rs
+++ b/crates/fast_io/src/io_uring_stub.rs
@@ -1073,7 +1073,8 @@ mod tests {
 
     #[test]
     fn disk_batch_bytes_written_is_zero() {
-        // Cannot construct one on stub platform, but verify the trait.
+        // The stub cannot construct an IoUringDiskBatch; this test only
+        // confirms try_new always returns None on this platform.
         let config = IoUringConfig::default();
         assert!(IoUringDiskBatch::try_new(&config).is_none());
     }
@@ -1119,8 +1120,9 @@ mod tests {
         tmp.write_all(b"").unwrap();
         let file = tmp.reopen().unwrap();
 
+        // Auto must silently fall back to Std on this platform; the probe
+        // returns false unconditionally so io_uring is never selected.
         let writer = writer_from_file(file, 8192, IoUringPolicy::Auto).unwrap();
-        // On non-Linux, Auto always falls back to Std
         assert!(matches!(writer, IoUringOrStdWriter::Std(_)));
     }
 
@@ -1163,7 +1165,6 @@ mod tests {
     fn writer_parity_disabled_vs_auto() {
         let test_data: Vec<u8> = (0..4096).map(|i| ((i * 7 + 13) % 256) as u8).collect();
 
-        // Write via Disabled policy
         let dir = tempdir().unwrap();
         let path_disabled = dir.path().join("parity_disabled.bin");
         {
@@ -1173,7 +1174,8 @@ mod tests {
             writer.flush().unwrap();
         }
 
-        // Write via Auto policy (also falls back to Std on non-Linux)
+        // Auto also falls back to Std on non-Linux, so the two outputs must
+        // be byte-identical.
         let path_auto = dir.path().join("parity_auto.bin");
         {
             let file = std::fs::File::create(&path_auto).unwrap();
@@ -1197,11 +1199,9 @@ mod tests {
         let test_data: Vec<u8> = (0..8192).map(|i| ((i * 11 + 3) % 256) as u8).collect();
         std::fs::write(&path, &test_data).unwrap();
 
-        // Read via Disabled policy
         let mut reader_disabled = reader_from_path(&path, IoUringPolicy::Disabled).unwrap();
         let data_disabled = reader_disabled.read_all().unwrap();
 
-        // Read via Auto policy
         let mut reader_auto = reader_from_path(&path, IoUringPolicy::Auto).unwrap();
         let data_auto = reader_auto.read_all().unwrap();
 
@@ -1265,7 +1265,6 @@ mod tests {
         reader.read_exact(&mut buf).unwrap();
         assert_eq!(&buf, b"4567");
 
-        // Read remaining
         let mut rest = Vec::new();
         reader.read_to_end(&mut rest).unwrap();
         assert_eq!(&rest, b"89ABCDEF");
@@ -1310,7 +1309,6 @@ mod tests {
         let path = dir.path().join("roundtrip.bin");
         let test_data: Vec<u8> = (0..65536).map(|i| ((i * 17 + 5) % 256) as u8).collect();
 
-        // Write
         {
             let file = std::fs::File::create(&path).unwrap();
             let mut writer = writer_from_file(file, 16384, IoUringPolicy::Disabled).unwrap();
@@ -1318,7 +1316,6 @@ mod tests {
             writer.flush().unwrap();
         }
 
-        // Read back
         let mut reader = reader_from_path(&path, IoUringPolicy::Disabled).unwrap();
         let read_back = reader.read_all().unwrap();
 

--- a/crates/fast_io/src/iocp/completion_port.rs
+++ b/crates/fast_io/src/iocp/completion_port.rs
@@ -105,6 +105,5 @@ mod tests {
     fn completion_port_drops_cleanly() {
         let port = CompletionPort::new(1).unwrap();
         drop(port);
-        // No panic = success
     }
 }

--- a/crates/fast_io/src/iocp/config.rs
+++ b/crates/fast_io/src/iocp/config.rs
@@ -103,7 +103,7 @@ pub fn is_iocp_available() -> bool {
 /// completion port instead).
 #[must_use]
 pub fn skip_event_optimization_available() -> bool {
-    // Ensure we've probed
+    // Force the probe to run so SKIP_EVENT_AVAILABLE reflects detected support.
     let _ = is_iocp_available();
     SKIP_EVENT_AVAILABLE.load(Ordering::Relaxed)
 }
@@ -140,14 +140,14 @@ fn probe_iocp() -> bool {
         return false;
     }
 
-    // Clean up the test port
     #[allow(unsafe_code)]
     unsafe {
         windows_sys::Win32::Foundation::CloseHandle(handle);
     }
 
-    // Probe FILE_SKIP_SET_EVENT_ON_HANDLE - available on Windows Vista+
-    // We set this globally; it's safe because we always use completion ports.
+    // FILE_SKIP_SET_EVENT_ON_HANDLE is unconditionally safe under our model
+    // because we always use completion ports rather than waiting on the
+    // file handle's event. Available on Windows Vista+.
     SKIP_EVENT_AVAILABLE.store(true, Ordering::Relaxed);
 
     IOCP_STATUS.store(AVAILABLE, Ordering::Relaxed);
@@ -183,13 +183,13 @@ mod tests {
 
     #[test]
     fn iocp_available_on_windows() {
-        // On Windows, IOCP should always be available (Vista+)
+        // IOCP is part of the kernel on Windows Vista+, so the probe must
+        // succeed on every supported Windows host.
         assert!(is_iocp_available());
     }
 
     #[test]
     fn iocp_availability_cached() {
-        // First call probes, subsequent calls use cache
         let first = is_iocp_available();
         let second = is_iocp_available();
         assert_eq!(first, second);

--- a/crates/fast_io/src/iocp/file_factory.rs
+++ b/crates/fast_io/src/iocp/file_factory.rs
@@ -184,12 +184,12 @@ impl FileReaderFactory for IocpReaderFactory {
 
     fn open(&self, path: &Path) -> io::Result<Self::Reader> {
         if self.will_use_iocp() {
-            // Check file size - small files don't benefit from IOCP
+            // Files below IOCP_MIN_FILE_SIZE are read synchronously because the
+            // overlapped-I/O setup overhead exceeds the async benefit at that size.
             let metadata = std::fs::metadata(path)?;
             if metadata.len() >= IOCP_MIN_FILE_SIZE {
-                match IocpReader::open(path, &self.config) {
-                    Ok(reader) => return Ok(IocpOrStdReader::Iocp(reader)),
-                    Err(_) => {} // Fall through to std
+                if let Ok(reader) = IocpReader::open(path, &self.config) {
+                    return Ok(IocpOrStdReader::Iocp(reader));
                 }
             }
         }
@@ -242,9 +242,8 @@ impl FileWriterFactory for IocpWriterFactory {
 
     fn create(&self, path: &Path) -> io::Result<Self::Writer> {
         if self.will_use_iocp() {
-            match IocpWriter::create(path, &self.config) {
-                Ok(writer) => return Ok(IocpOrStdWriter::Iocp(writer)),
-                Err(_) => {} // Fall through to std
+            if let Ok(writer) = IocpWriter::create(path, &self.config) {
+                return Ok(IocpOrStdWriter::Iocp(writer));
             }
         }
         Ok(IocpOrStdWriter::Std(StdFileWriter::create(path)?))
@@ -252,9 +251,8 @@ impl FileWriterFactory for IocpWriterFactory {
 
     fn create_with_size(&self, path: &Path, size: u64) -> io::Result<Self::Writer> {
         if self.will_use_iocp() {
-            match IocpWriter::create_with_size(path, size, &self.config) {
-                Ok(writer) => return Ok(IocpOrStdWriter::Iocp(writer)),
-                Err(_) => {} // Fall through to std
+            if let Ok(writer) = IocpWriter::create_with_size(path, size, &self.config) {
+                return Ok(IocpOrStdWriter::Iocp(writer));
             }
         }
         Ok(IocpOrStdWriter::Std(StdFileWriter::create_with_size(
@@ -280,8 +278,9 @@ pub fn writer_from_file(
                     "IOCP requested but not available on this system",
                 ));
             }
-            // Can't use IOCP with an existing File handle easily since
-            // it wasn't opened with FILE_FLAG_OVERLAPPED. Fall back.
+            // An existing std::fs::File was not opened with FILE_FLAG_OVERLAPPED,
+            // so it cannot be associated with a completion port. Fall back to
+            // standard buffered I/O even under the Enabled policy.
             Ok(IocpOrStdWriter::Std(
                 StdFileWriter::from_file_with_capacity(file, buffer_capacity),
             ))
@@ -346,7 +345,6 @@ mod tests {
 
         let factory = IocpReaderFactory::default();
         let reader = factory.open(&path).unwrap();
-        // Small file should use Std variant
         assert!(matches!(reader, IocpOrStdReader::Std(_)));
     }
 
@@ -415,7 +413,6 @@ mod tests {
         let path = dir.path().join("roundtrip.bin");
         let test_data: Vec<u8> = (0..65536).map(|i| ((i * 17 + 5) % 256) as u8).collect();
 
-        // Write
         {
             let factory = IocpWriterFactory::default();
             let mut writer = factory.create(&path).unwrap();
@@ -423,7 +420,6 @@ mod tests {
             writer.flush().unwrap();
         }
 
-        // Read back
         let factory = IocpReaderFactory::default();
         let mut reader = factory.open(&path).unwrap();
         let read_back = reader.read_all().unwrap();

--- a/crates/fast_io/src/iocp/file_reader.rs
+++ b/crates/fast_io/src/iocp/file_reader.rs
@@ -112,19 +112,20 @@ impl IocpReader {
         };
 
         if success == TRUE {
-            // Completed synchronously
+            // ReadFile may complete synchronously even with FILE_FLAG_OVERLAPPED;
+            // when it does, no completion will be queued so handle it inline.
             let n = bytes_read as usize;
             buf[..n].copy_from_slice(&op.buffer[..n]);
             return Ok(n);
         }
 
         let err = io::Error::last_os_error();
+        // ERROR_IO_PENDING (997) is the documented "operation queued" status;
+        // any other error is fatal.
         if err.raw_os_error() != Some(997) {
-            // ERROR_IO_PENDING = 997
             return Err(err);
         }
 
-        // Wait for completion
         let mut transferred: u32 = 0;
         let mut key: usize = 0;
         let mut overlapped_out: *mut windows_sys::Win32::System::IO::OVERLAPPED =
@@ -168,7 +169,6 @@ impl IocpReader {
         let mut offset: usize = 0;
 
         while offset < file_size {
-            // Submit a batch of reads
             let batch_count = std::cmp::min(
                 max_concurrent,
                 (file_size - offset + buf_size - 1) / buf_size,
@@ -182,7 +182,6 @@ impl IocpReader {
                 })
                 .collect();
 
-            // Submit all reads
             for (i, op) in ops.iter_mut().enumerate() {
                 let op_offset = offset + i * buf_size;
                 let op_size = std::cmp::min(buf_size, file_size - op_offset);
@@ -211,7 +210,6 @@ impl IocpReader {
                 }
             }
 
-            // Collect completions
             for i in 0..batch_count {
                 let mut transferred: u32 = 0;
                 let mut key: usize = 0;
@@ -234,7 +232,9 @@ impl IocpReader {
                     return Err(io::Error::last_os_error());
                 }
 
-                // Determine which op completed by matching the overlapped pointer
+                // Completions are processed in submission order rather than by
+                // matching the returned OVERLAPPED pointer. This is safe because
+                // each batch waits for all submitted ops before moving on.
                 let op_offset = offset + i * buf_size;
                 let n = transferred as usize;
                 let dest_end = std::cmp::min(op_offset + n, file_size);

--- a/crates/fast_io/src/iocp/file_writer.rs
+++ b/crates/fast_io/src/iocp/file_writer.rs
@@ -78,9 +78,9 @@ impl IocpWriter {
     ) -> io::Result<Self> {
         let writer = Self::create(path, config)?;
 
-        // Preallocate by setting end of file
-        // SAFETY: handle is valid, SetFilePointerEx and SetEndOfFile are
-        // standard Win32 operations.
+        // SAFETY: handle is valid; the SetFilePointerEx/SetEndOfFile pair is
+        // the documented Win32 sequence to preallocate disk blocks for the
+        // file before any overlapped write is submitted.
         #[allow(unsafe_code)]
         unsafe {
             let mut new_pos: i64 = 0;
@@ -127,12 +127,11 @@ impl IocpWriter {
         }
 
         let err = io::Error::last_os_error();
+        // ERROR_IO_PENDING (997) means the write is queued; any other error is fatal.
         if err.raw_os_error() != Some(997) {
-            // ERROR_IO_PENDING = 997
             return Err(err);
         }
 
-        // Wait for completion
         let mut transferred: u32 = 0;
         let mut key: usize = 0;
         let mut overlapped_out: *mut windows_sys::Win32::System::IO::OVERLAPPED =
@@ -193,18 +192,18 @@ impl Write for IocpWriter {
         let available = self.config.buffer_size - self.buffer.len();
 
         if buf.len() <= available {
-            // Fits in buffer
             self.buffer.extend_from_slice(buf);
             self.bytes_written += buf.len() as u64;
             Ok(buf.len())
         } else if self.buffer.is_empty() && buf.len() >= self.config.buffer_size {
-            // Large write, bypass buffer entirely
+            // Bypass the internal buffer when the caller already provided at
+            // least one full chunk: an overlapped write directly from `buf`
+            // saves a copy.
             let n = self.write_at(self.file_offset, buf)?;
             self.file_offset += n as u64;
             self.bytes_written += n as u64;
             Ok(n)
         } else {
-            // Fill buffer, flush, then continue
             self.buffer.extend_from_slice(&buf[..available]);
             self.flush_buffer()?;
             let remaining = &buf[available..];
@@ -223,7 +222,6 @@ impl Write for IocpWriter {
 
 impl Seek for IocpWriter {
     fn seek(&mut self, pos: SeekFrom) -> io::Result<u64> {
-        // Flush any buffered data first
         self.flush_buffer()?;
         match pos {
             SeekFrom::Start(p) => {
@@ -278,7 +276,8 @@ impl FileWriter for IocpWriter {
             if SetEndOfFile(self.handle) != TRUE {
                 return Err(io::Error::last_os_error());
             }
-            // Reset file pointer to current write position
+            // SetEndOfFile leaves the pointer at `size`; restore it so that the
+            // next overlapped write resumes at the caller's logical offset.
             if SetFilePointerEx(self.handle, self.file_offset as i64, &mut new_pos, 0) != TRUE {
                 return Err(io::Error::last_os_error());
             }
@@ -289,7 +288,6 @@ impl FileWriter for IocpWriter {
 
 impl Drop for IocpWriter {
     fn drop(&mut self) {
-        // Best-effort flush
         let _ = self.flush_buffer();
         // SAFETY: self.handle is valid and owned by this struct.
         #[allow(unsafe_code)]
@@ -408,7 +406,6 @@ mod tests {
         }
 
         let metadata = std::fs::metadata(&path).unwrap();
-        // File should be at least 1024 bytes due to preallocation
         assert!(metadata.len() >= 1024);
     }
 }

--- a/crates/fast_io/src/kernel_version.rs
+++ b/crates/fast_io/src/kernel_version.rs
@@ -95,8 +95,6 @@ pub fn log_io_uring_probe_result() {}
 mod tests {
     use super::*;
 
-    // --- parse_kernel_version: valid inputs ---
-
     #[test]
     fn parse_standard_release() {
         assert_eq!(
@@ -206,8 +204,6 @@ mod tests {
         );
     }
 
-    // --- parse_kernel_version: invalid inputs ---
-
     #[test]
     fn parse_empty_string() {
         assert_eq!(parse_kernel_version(""), None);
@@ -232,8 +228,6 @@ mod tests {
     fn parse_letters_only() {
         assert_eq!(parse_kernel_version("abc.def.ghi"), None);
     }
-
-    // --- KernelVersion::meets_minimum ---
 
     #[test]
     fn meets_minimum_exact_match() {
@@ -271,8 +265,6 @@ mod tests {
         assert!(!v.meets_minimum(5, 6));
     }
 
-    // --- KernelVersion::Display ---
-
     #[test]
     fn display_format() {
         let v = KernelVersion {
@@ -281,8 +273,6 @@ mod tests {
         };
         assert_eq!(format!("{v}"), "5.15");
     }
-
-    // --- IO_URING_MIN_KERNEL constant ---
 
     #[test]
     fn min_kernel_is_5_6() {
@@ -294,8 +284,6 @@ mod tests {
     fn min_kernel_meets_itself() {
         assert!(IO_URING_MIN_KERNEL.meets_minimum(5, 6));
     }
-
-    // --- log_io_uring_probe_result ---
 
     #[test]
     fn log_probe_result_does_not_panic() {

--- a/crates/fast_io/src/sendfile.rs
+++ b/crates/fast_io/src/sendfile.rs
@@ -149,9 +149,7 @@ pub fn send_file_to_fd(source: &File, dest_fd: i32, length: u64) -> io::Result<u
         if let Ok(n) = try_sendfile(source, dest_fd, length) {
             return Ok(n);
         }
-        // Fall through to read/write fallback
     }
-    // Fallback: read from source, write to fd
     copy_via_fd_write(source, dest_fd, length)
 }
 
@@ -213,16 +211,15 @@ fn try_sendfile(source: &File, dest_fd: i32, length: u64) -> io::Result<u64> {
         let result = unsafe { libc::sendfile(dest_fd, src_fd, std::ptr::null_mut(), chunk) };
 
         if result < 0 {
-            let err = io::Error::last_os_error();
+            // First-chunk failure surfaces the error so the caller can fall back.
+            // Once any bytes have moved we return what was already sent so the
+            // socket peer sees a consistent prefix rather than a duplicated retry.
             if total == 0 {
-                // Failed on first chunk - return error to trigger fallback
-                return Err(err);
+                return Err(io::Error::last_os_error());
             }
-            // Partial transfer succeeded, but now we hit an error - return what we have
             return Ok(total);
         }
         if result == 0 {
-            // EOF reached
             break;
         }
 
@@ -263,11 +260,10 @@ fn copy_via_fd_write(source: &File, dest_fd: i32, length: u64) -> io::Result<u64
         let to_read = (remaining as usize).min(buf.len());
         let n = reader.read(&mut buf[..to_read])?;
         if n == 0 {
-            // EOF reached
             break;
         }
 
-        // Write all bytes to the file descriptor, handling partial writes
+        // libc::write may return short, so loop until the chunk is drained.
         let mut written = 0;
         while written < n {
             // SAFETY: buf[written..n] is a valid slice, and dest_fd is assumed valid
@@ -303,11 +299,10 @@ fn copy_via_fd_write(source: &File, dest_fd: i32, length: u64) -> io::Result<u64
         let to_read = (remaining as usize).min(buf.len());
         let n = reader.read(&mut buf[..to_read])?;
         if n == 0 {
-            // EOF reached
             break;
         }
 
-        // Write all bytes to the file descriptor, handling partial writes
+        // libc::write may return short, so loop until the chunk is drained.
         let mut written = 0;
         while written < n {
             // SAFETY: buf[written..n] is a valid slice, and dest_fd is assumed valid
@@ -363,7 +358,6 @@ fn copy_via_readwrite<W: Write>(
         let to_read = (remaining as usize).min(buf.len());
         let n = reader.read(&mut buf[..to_read])?;
         if n == 0 {
-            // EOF reached
             break;
         }
         destination.write_all(&buf[..n])?;
@@ -392,7 +386,6 @@ mod tests {
 
     #[test]
     fn test_send_to_writer_small_file() {
-        // Small file (< 64KB) should use read/write path directly
         let content = b"Hello, world! This is a small file for testing.";
         let source = create_temp_file(content).unwrap();
         let mut output = Vec::new();
@@ -406,8 +399,8 @@ mod tests {
 
     #[test]
     fn test_send_to_writer_large_file() {
-        // Large file (>= 64KB) should trigger sendfile attempt (but falls back for Vec)
-        let size = 128 * 1024; // 128KB
+        // Above SENDFILE_THRESHOLD; the Vec writer forces the read/write fallback.
+        let size = 128 * 1024;
         let content: Vec<u8> = (0..size).map(|i| (i % 256) as u8).collect();
         let source = create_temp_file(&content).unwrap();
         let mut output = Vec::new();
@@ -421,7 +414,6 @@ mod tests {
 
     #[test]
     fn test_send_to_writer_empty_file() {
-        // Empty file should work without errors
         let content = b"";
         let source = create_temp_file(content).unwrap();
         let mut output = Vec::new();
@@ -434,7 +426,6 @@ mod tests {
 
     #[test]
     fn test_send_to_writer_exact_content() {
-        // Verify data integrity with specific pattern
         let content: Vec<u8> = (0..1000).map(|i| ((i * 7 + 13) % 256) as u8).collect();
         let source = create_temp_file(&content).unwrap();
         let mut output = Vec::new();
@@ -448,7 +439,6 @@ mod tests {
 
     #[test]
     fn test_send_to_writer_partial() {
-        // Request fewer bytes than available
         let content = b"0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
         let source = create_temp_file(content).unwrap();
         let mut output = Vec::new();
@@ -461,7 +451,6 @@ mod tests {
 
     #[test]
     fn test_send_to_writer_beyond_eof() {
-        // Request more bytes than available - should stop at EOF
         let content = b"Short content";
         let source = create_temp_file(content).unwrap();
         let mut output = Vec::new();
@@ -474,15 +463,14 @@ mod tests {
 
     #[test]
     fn test_send_with_file_position() {
-        // Test that file position is respected
+        // sendfile uses the source's current offset; verify the wrapper preserves
+        // that contract instead of implicitly seeking to zero.
         let content = b"0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
         let mut source = create_temp_file(content).unwrap();
         let mut output = Vec::new();
 
-        // Seek source to position 10
         source.seek(SeekFrom::Start(10)).unwrap();
 
-        // Send 10 bytes from position 10
         let sent = send_file_to_writer(source.as_file(), &mut output, 10).unwrap();
 
         assert_eq!(sent, 10);
@@ -492,11 +480,9 @@ mod tests {
     #[cfg(target_os = "linux")]
     #[test]
     fn test_send_file_to_fd_pipe() {
-        // Test sendfile to a pipe (should work on Linux)
         let content = b"Testing sendfile with pipe on Linux";
         let source = create_temp_file(content).unwrap();
 
-        // Create a pipe for testing
         let mut pipe_fds = [0i32; 2];
         let result = unsafe { libc::pipe(pipe_fds.as_mut_ptr()) };
         assert_eq!(result, 0, "Failed to create pipe");
@@ -504,16 +490,13 @@ mod tests {
         let read_fd = pipe_fds[0];
         let write_fd = pipe_fds[1];
 
-        // Send data through sendfile to pipe
         let sent = send_file_to_fd(source.as_file(), write_fd, content.len() as u64);
 
-        // Close write end
         unsafe { libc::close(write_fd) };
 
         if let Ok(sent_bytes) = sent {
             assert_eq!(sent_bytes, content.len() as u64);
 
-            // Read from pipe to verify content
             let mut received = vec![0u8; content.len()];
             let n = unsafe {
                 libc::read(
@@ -526,18 +509,17 @@ mod tests {
             assert_eq!(received, content);
         }
 
-        // Close read end
         unsafe { libc::close(read_fd) };
     }
 
     #[cfg(target_os = "linux")]
     #[test]
     fn test_send_file_to_fd_socketpair() {
-        // Test sendfile to a socket (ideal use case)
+        // socketpair is the canonical sendfile destination - exercises the
+        // kernel's zero-copy fast path rather than the read/write fallback.
         let content = b"Testing sendfile with socketpair";
         let source = create_temp_file(content).unwrap();
 
-        // Create a socket pair for testing
         let mut socket_fds = [0i32; 2];
         let result = unsafe {
             libc::socketpair(libc::AF_UNIX, libc::SOCK_STREAM, 0, socket_fds.as_mut_ptr())
@@ -547,15 +529,11 @@ mod tests {
         let recv_fd = socket_fds[0];
         let send_fd = socket_fds[1];
 
-        // Send data through sendfile to socket
         let sent = send_file_to_fd(source.as_file(), send_fd, content.len() as u64).unwrap();
-
         assert_eq!(sent, content.len() as u64);
 
-        // Close send end to signal EOF
         unsafe { libc::close(send_fd) };
 
-        // Read from socket to verify content
         let mut received = vec![0u8; content.len()];
         let n = unsafe {
             libc::read(
@@ -567,7 +545,6 @@ mod tests {
         assert_eq!(n, content.len() as isize);
         assert_eq!(received, content);
 
-        // Close receive end
         unsafe { libc::close(recv_fd) };
     }
 
@@ -576,12 +553,10 @@ mod tests {
     fn test_send_file_to_fd_large() {
         use std::thread;
 
-        // Test large file transfer via sendfile
-        let size = 512 * 1024; // 512KB - well above threshold
+        let size = 512 * 1024; // 512KB - exceeds SENDFILE_THRESHOLD
         let content: Vec<u8> = (0..size).map(|i| (i % 256) as u8).collect();
         let source = create_temp_file(&content).unwrap();
 
-        // Create a pipe for testing
         let mut pipe_fds = [0i32; 2];
         let result = unsafe { libc::pipe(pipe_fds.as_mut_ptr()) };
         assert_eq!(result, 0, "Failed to create pipe");
@@ -589,7 +564,8 @@ mod tests {
         let read_fd = pipe_fds[0];
         let write_fd = pipe_fds[1];
 
-        // Spawn reader thread to avoid pipe buffer deadlock
+        // 512KB exceeds the default 64KB pipe buffer, so we must drain it from
+        // another thread to avoid blocking the sender.
         let expected_content = content.clone();
         let reader_thread = thread::spawn(move || {
             let mut received = Vec::new();
@@ -607,18 +583,14 @@ mod tests {
             received
         });
 
-        // Send data through sendfile (main thread)
         let sent = send_file_to_fd(source.as_file(), write_fd, size as u64);
 
-        // Close write end to signal EOF to reader
         unsafe { libc::close(write_fd) };
 
-        // Verify send succeeded
         assert!(sent.is_ok(), "sendfile should succeed");
         let sent_bytes = sent.unwrap();
         assert_eq!(sent_bytes, size as u64);
 
-        // Wait for reader and verify content
         let received = reader_thread.join().expect("reader thread should succeed");
         assert_eq!(received.len(), expected_content.len());
         assert_eq!(received, expected_content);

--- a/crates/fast_io/src/zero_detect.rs
+++ b/crates/fast_io/src/zero_detect.rs
@@ -78,10 +78,6 @@ pub fn is_all_zeros(buf: &[u8]) -> bool {
     find_first_nonzero(buf) == buf.len()
 }
 
-// ---------------------------------------------------------------------------
-// Dispatch
-// ---------------------------------------------------------------------------
-
 type FindFn = fn(&[u8]) -> usize;
 
 static DISPATCH: OnceLock<FindFn> = OnceLock::new();
@@ -112,10 +108,7 @@ fn select_impl() -> FindFn {
     find_first_nonzero_scalar
 }
 
-// ---------------------------------------------------------------------------
-// Scalar fallback - processes 16 bytes at a time via u128
-// ---------------------------------------------------------------------------
-
+/// Scalar fallback - processes 16 bytes per iteration via `u128`.
 fn find_first_nonzero_scalar(buf: &[u8]) -> usize {
     let mut offset = 0;
     let mut iter = buf.chunks_exact(16);
@@ -138,10 +131,7 @@ fn find_first_nonzero_scalar(buf: &[u8]) -> usize {
     offset
 }
 
-// ---------------------------------------------------------------------------
-// x86/x86_64: AVX2 (32 bytes per iteration)
-// ---------------------------------------------------------------------------
-
+/// AVX2 implementation processing 32 bytes per iteration on x86/x86_64.
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 fn find_first_nonzero_avx2(buf: &[u8]) -> usize {
     // SAFETY: Caller is only reached when AVX2 is detected at runtime.
@@ -188,10 +178,7 @@ unsafe fn find_first_nonzero_avx2_inner(buf: &[u8]) -> usize {
     }
 }
 
-// ---------------------------------------------------------------------------
-// x86/x86_64: SSE2 (16 bytes per iteration)
-// ---------------------------------------------------------------------------
-
+/// SSE2 implementation processing 16 bytes per iteration on x86/x86_64.
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 fn find_first_nonzero_sse2(buf: &[u8]) -> usize {
     // SAFETY: Caller is only reached when SSE2 is detected at runtime.
@@ -233,10 +220,7 @@ unsafe fn find_first_nonzero_sse2_inner(buf: &[u8]) -> usize {
     }
 }
 
-// ---------------------------------------------------------------------------
-// aarch64: NEON (16 bytes per iteration)
-// ---------------------------------------------------------------------------
-
+/// NEON implementation processing 16 bytes per iteration on aarch64.
 #[cfg(target_arch = "aarch64")]
 fn find_first_nonzero_neon(buf: &[u8]) -> usize {
     // SAFETY: Caller is only reached when NEON is detected at runtime.
@@ -291,15 +275,9 @@ unsafe fn find_first_nonzero_neon_inner(buf: &[u8]) -> usize {
     offset + find_first_nonzero_scalar(&buf[offset..])
 }
 
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    // -- Basic API tests --
 
     #[test]
     fn zero_empty_buffer() {
@@ -364,8 +342,6 @@ mod tests {
         let buf = vec![0xAA; 128];
         assert_eq!(find_first_nonzero(&buf), 0);
     }
-
-    // -- Parity tests: all implementations must agree --
 
     #[test]
     fn zero_parity_scalar_vs_dispatch() {
@@ -486,8 +462,6 @@ mod tests {
             );
         }
     }
-
-    // -- Edge cases --
 
     #[test]
     fn zero_buffer_smaller_than_simd_width() {

--- a/crates/fast_io/tests/io_uring_probe_fallback.rs
+++ b/crates/fast_io/tests/io_uring_probe_fallback.rs
@@ -20,11 +20,6 @@ use fast_io::{
 };
 use tempfile::tempdir;
 
-// ---------------------------------------------------------------------------
-// Cross-platform: the probe must always answer without panicking and the
-// answer must be consistent across calls (result is cached).
-// ---------------------------------------------------------------------------
-
 #[test]
 fn is_io_uring_available_is_idempotent() {
     let first = is_io_uring_available();
@@ -143,13 +138,6 @@ fn concurrent_probe_calls_are_safe() {
     assert!(!panicked.load(Ordering::SeqCst), "probe panicked");
 }
 
-// ---------------------------------------------------------------------------
-// Fallback chain: with `IoUringPolicy::Auto` and `Disabled`, factories must
-// always yield a working reader/writer regardless of probe outcome. With
-// `Enabled` on a platform that lacks io_uring, callers must receive an
-// `Unsupported` error rather than a panic.
-// ---------------------------------------------------------------------------
-
 #[test]
 fn auto_policy_yields_working_writer_and_reader() {
     let dir = tempdir().unwrap();
@@ -203,11 +191,6 @@ fn factory_reports_runtime_decision_consistently() {
     assert_eq!(writer_factory.will_use_io_uring(), probe);
 }
 
-// ---------------------------------------------------------------------------
-// Non-Linux platforms (or builds without the `io_uring` feature) must always
-// report the probe as unavailable and surface a clear platform reason.
-// ---------------------------------------------------------------------------
-
 #[cfg(not(all(target_os = "linux", feature = "io_uring")))]
 #[test]
 fn probe_is_unavailable_without_linux_io_uring() {
@@ -245,14 +228,10 @@ fn enabled_policy_returns_unsupported_without_linux_io_uring() {
     assert!(reader_err.to_string().to_lowercase().contains("io_uring"));
 }
 
-// ---------------------------------------------------------------------------
-// Linux-with-feature: the probe runs against the live kernel. It must agree
-// with whether the kernel meets the documented 5.6 minimum, but a kernel
-// that meets the minimum can still be reported unavailable if the syscall
-// is blocked (for example by seccomp inside a container). Both outcomes are
-// acceptable - what matters is that the boolean and the reason agree.
-// ---------------------------------------------------------------------------
-
+/// Linux with the io_uring feature: the probe runs against the live kernel.
+/// A kernel meeting the documented 5.6 minimum can still be reported unavailable
+/// if the syscall is blocked (for example by seccomp inside a container). Both
+/// outcomes are acceptable - what matters is that the boolean and the reason agree.
 #[cfg(all(target_os = "linux", feature = "io_uring"))]
 #[test]
 fn linux_probe_matches_kernel_version() {

--- a/crates/fast_io/tests/splice_integration.rs
+++ b/crates/fast_io/tests/splice_integration.rs
@@ -7,10 +7,6 @@
 
 use fast_io::splice::{is_splice_available, recv_fd_to_file, try_splice_to_file};
 
-// ---------------------------------------------------------------------------
-// Cross-platform tests
-// ---------------------------------------------------------------------------
-
 #[test]
 fn splice_availability_is_deterministic() {
     // Repeated calls must return the same cached result.
@@ -33,10 +29,6 @@ fn recv_fd_returns_unsupported_on_non_unix() {
     let err = recv_fd_to_file(0, 0, 1024).unwrap_err();
     assert_eq!(err.kind(), std::io::ErrorKind::Unsupported);
 }
-
-// ---------------------------------------------------------------------------
-// Unix helpers (shared by macOS fallback tests and Linux tests)
-// ---------------------------------------------------------------------------
 
 /// Creates a Unix socketpair. The writer thread sends `content` then closes
 /// its end so the reader sees EOF. Returns `(recv_fd, join_handle)`.
@@ -80,10 +72,7 @@ fn assert_file_contents(dest: &mut tempfile::NamedTempFile, expected: &[u8]) {
     assert_eq!(buf, expected, "file content mismatch");
 }
 
-// ---------------------------------------------------------------------------
-// Unix fallback tests (run on all unix platforms including Linux)
-// ---------------------------------------------------------------------------
-
+/// Unix fallback tests (run on all unix platforms including Linux).
 #[cfg(unix)]
 mod fallback {
     use super::*;
@@ -189,10 +178,7 @@ mod fallback {
     }
 }
 
-// ---------------------------------------------------------------------------
-// Linux-specific splice tests
-// ---------------------------------------------------------------------------
-
+/// Linux-specific splice tests.
 #[cfg(target_os = "linux")]
 mod linux_splice {
     use super::*;


### PR DESCRIPTION
## Summary

- Converts restating / sequence-label comments to rustdoc across fast_io's platform submodules (io_uring, IOCP, sendfile, copy_file_range, zero_detect, kernel_version)
- Replaces a handful of restated comments with WHY rationale where the motivation isn't obvious from the code
- Preserves every `// upstream:` reference verbatim

Closes #1848.

## Test plan
- [x] All `// upstream:` references in `crates/fast_io/src/` left intact (verified via grep)
- [ ] CI: fmt + clippy
- [ ] CI: nextest (stable)
- [ ] CI: Windows / macOS / Linux musl