### PR TITLE
fix: validate IPv6 host with Ipv6Addr and support scoped zone ids

### DIFF
--- a/crates/rsync_io/src/ssh/builder.rs
+++ b/crates/rsync_io/src/ssh/builder.rs
@@ -643,8 +643,8 @@ pub(super) fn parse_host_for_ssh(host: &str) -> Result<HostKind, BuildError> {
     // Zone identifiers (`%eth0`) only attach to IPv6 literals. A hostname
     // containing `%` is invalid here -- DNS labels do not permit `%`.
     if let Some((addr_str, zone_str)) = stripped.split_once('%') {
-        let addr = Ipv6Addr::from_str(addr_str)
-            .map_err(|_| BuildError::InvalidIpv6(host.to_string()))?;
+        let addr =
+            Ipv6Addr::from_str(addr_str).map_err(|_| BuildError::InvalidIpv6(host.to_string()))?;
         validate_zone_id(zone_str).map_err(|_| BuildError::InvalidZoneId(host.to_string()))?;
         return Ok(HostKind::Ipv6 {
             addr,
@@ -695,9 +695,7 @@ fn validate_zone_id(zone: &str) -> Result<(), ()> {
 fn host_str_for_validation(host: &OsStr) -> Option<String> {
     #[cfg(unix)]
     {
-        std::str::from_utf8(host.as_bytes())
-            .ok()
-            .map(str::to_owned)
+        std::str::from_utf8(host.as_bytes()).ok().map(str::to_owned)
     }
 
     #[cfg(not(unix))]

--- a/crates/rsync_io/src/ssh/builder.rs
+++ b/crates/rsync_io/src/ssh/builder.rs
@@ -1,7 +1,8 @@
 use std::ffi::{OsStr, OsString};
 use std::io;
-use std::net::IpAddr;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::process::{Command, Stdio};
+use std::str::FromStr;
 use std::time::Duration;
 
 use super::aux_channel::{build_stderr_channel, configure_stderr_channel};
@@ -399,12 +400,25 @@ impl SshCommand {
             target.push("@");
         }
 
-        if host_needs_ipv6_brackets(&self.host) {
-            target.push("[");
-            target.push(&self.host);
-            target.push("]");
-        } else {
-            target.push(&self.host);
+        // Strict validation: IPv6 hosts must parse via `Ipv6Addr::from_str`
+        // (with optional `%zone` suffix per RFC 4007). Anything else is
+        // treated as an opaque hostname/operand and emitted unchanged.
+        // The bracket form `[addr%zone]` follows upstream rsync's IPv6
+        // host-operand convention used by `parse_ssh_operand`.
+        let host_str = host_str_for_validation(&self.host);
+        match host_str.as_deref().map(parse_host_for_ssh) {
+            Some(Ok(HostKind::Ipv6 { addr, zone })) => {
+                target.push("[");
+                target.push(addr.to_string());
+                if let Some(zone) = zone {
+                    target.push("%");
+                    target.push(zone);
+                }
+                target.push("]");
+            }
+            _ => {
+                target.push(&self.host);
+            }
         }
 
         Some(target)
@@ -543,40 +557,151 @@ pub(super) fn has_hardware_aes() -> bool {
     })
 }
 
-fn host_needs_ipv6_brackets(host: &OsStr) -> bool {
+/// Classified SSH host operand.
+///
+/// Returned by [`parse_host_for_ssh`]. Only the [`HostKind::Ipv6`] variant
+/// requires bracket-wrapping when emitting the `user@host` operand to SSH.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(super) enum HostKind {
+    /// DNS hostname (or any string the validator does not classify as an IP
+    /// literal). Emitted to SSH unchanged, with no surrounding brackets.
+    Hostname(String),
+    /// Successfully parsed IPv4 dotted-quad literal. Emitted unbracketed.
+    Ipv4(Ipv4Addr),
+    /// Successfully parsed IPv6 literal, optionally carrying an RFC 4007
+    /// scoped zone identifier (e.g. `fe80::1%eth0`). Always emitted inside
+    /// brackets, with `%zone` re-attached inside the brackets per upstream
+    /// rsync convention: `[fe80::1%eth0]`.
+    Ipv6 {
+        /// The parsed IPv6 address.
+        addr: Ipv6Addr,
+        /// The optional zone identifier as authored by the caller (no `%`
+        /// prefix). Validated to be non-empty and free of whitespace and
+        /// `]`, but otherwise opaque (interface names vary by OS).
+        zone: Option<String>,
+    },
+}
+
+/// Errors returned by [`parse_host_for_ssh`].
+///
+/// Kept private to the SSH builder module for now; the public surface
+/// continues to accept any host string and falls back to passing it through
+/// unchanged when validation fails. These variants exist so unit tests can
+/// assert which malformed inputs the strict parser rejects.
+#[derive(Clone, Debug, Eq, PartialEq, thiserror::Error)]
+pub(super) enum BuildError {
+    /// Input was empty.
+    #[error("ssh host is empty")]
+    EmptyHost,
+    /// A `:` was present but the input did not parse as a valid IPv6 literal.
+    /// Catches multiple `::` sequences, trailing junk, invalid hex groups,
+    /// etc.
+    #[error("ssh host contains ':' but is not a valid IPv6 address: {0}")]
+    InvalidIpv6(String),
+    /// The zone identifier following `%` was empty or contained whitespace
+    /// or `]`. Bare hostnames containing `%` also reach this branch when
+    /// the prefix is not a valid IPv6 literal.
+    #[error("ssh host has malformed zone identifier: {0}")]
+    InvalidZoneId(String),
+}
+
+/// Classifies an SSH `host` operand for `ssh user@host` rendering.
+///
+/// Behaviour:
+///
+/// - Inputs surrounded by `[...]` have the brackets stripped before parsing
+///   (URL-style `[2001:db8::1]`).
+/// - Inputs containing `%` are split into address and zone halves; the
+///   address must parse as `Ipv6Addr::from_str`, and the zone is rejected
+///   if empty or if it contains whitespace or `]`.
+/// - Inputs containing `:` (without `%`) must parse as `Ipv6Addr::from_str`.
+///   Loose substring checks like the prior `host_contains_colon` heuristic
+///   accepted malformed input such as `2001:db8:::1` or `garbage:input`;
+///   strict validation rejects both.
+/// - Inputs that successfully parse as `Ipv4Addr::from_str` are returned as
+///   [`HostKind::Ipv4`] (no brackets).
+/// - All other inputs are returned as [`HostKind::Hostname`].
+///
+/// # Errors
+///
+/// Returns [`BuildError`] for empty input, malformed IPv6 (multi-`::`,
+/// trailing junk, invalid hex groups), or malformed zone identifiers.
+pub(super) fn parse_host_for_ssh(host: &str) -> Result<HostKind, BuildError> {
     if host.is_empty() {
-        return false;
+        return Err(BuildError::EmptyHost);
     }
 
-    if host_is_bracketed(host) {
-        return false;
+    // Strip a single matching set of surrounding brackets, e.g. URL-style
+    // `[2001:db8::1]`. We deliberately do not strip nested brackets; an
+    // input like `[[::1]]` stays intact and falls through to the IPv6
+    // parser, which will reject it.
+    let stripped = host
+        .strip_prefix('[')
+        .and_then(|s| s.strip_suffix(']'))
+        .unwrap_or(host);
+
+    // Zone identifiers (`%eth0`) only attach to IPv6 literals. A hostname
+    // containing `%` is invalid here -- DNS labels do not permit `%`.
+    if let Some((addr_str, zone_str)) = stripped.split_once('%') {
+        let addr = Ipv6Addr::from_str(addr_str)
+            .map_err(|_| BuildError::InvalidIpv6(host.to_string()))?;
+        validate_zone_id(zone_str).map_err(|_| BuildError::InvalidZoneId(host.to_string()))?;
+        return Ok(HostKind::Ipv6 {
+            addr,
+            zone: Some(zone_str.to_string()),
+        });
     }
 
-    host_contains_colon(host)
+    // Any colon-bearing input must parse as a valid IPv6 literal. This is
+    // the load-bearing strictness change vs. the old `host_contains_colon`
+    // heuristic, which accepted any string containing `:`.
+    if stripped.contains(':') {
+        return match Ipv6Addr::from_str(stripped) {
+            Ok(addr) => Ok(HostKind::Ipv6 { addr, zone: None }),
+            Err(_) => Err(BuildError::InvalidIpv6(host.to_string())),
+        };
+    }
+
+    // Dotted-quad IPv4 vs. ordinary hostname. We do not error on invalid
+    // hostnames -- DNS label validation is intentionally out of scope and
+    // SSH itself surfaces resolution failures.
+    if let Ok(addr) = Ipv4Addr::from_str(stripped) {
+        return Ok(HostKind::Ipv4(addr));
+    }
+    Ok(HostKind::Hostname(stripped.to_string()))
 }
 
-fn host_is_bracketed(host: &OsStr) -> bool {
+/// Validates the body of an RFC 4007 zone identifier.
+///
+/// Zone IDs are opaque strings naming a network interface (e.g. `eth0`,
+/// `en0`, numeric scope ids on Windows). We reject only the cases that
+/// would unambiguously break the `[addr%zone]` rendering: empty bodies,
+/// whitespace, and `]` (which would prematurely close the bracket form).
+fn validate_zone_id(zone: &str) -> Result<(), ()> {
+    if zone.is_empty() {
+        return Err(());
+    }
+    if zone.chars().any(|c| c.is_whitespace() || c == ']') {
+        return Err(());
+    }
+    Ok(())
+}
+
+/// Returns the host as a UTF-8 `String` for validation purposes when
+/// possible. Non-UTF-8 hosts cannot be valid IPv4/IPv6 literals or DNS
+/// names, so we skip strict validation for them and fall through to
+/// emitting the bytes unchanged (preserving the prior cross-platform
+/// behaviour for exotic input).
+fn host_str_for_validation(host: &OsStr) -> Option<String> {
     #[cfg(unix)]
     {
-        let bytes = host.as_bytes();
-        bytes.len() >= 2 && bytes.first() == Some(&b'[') && bytes.last() == Some(&b']')
+        std::str::from_utf8(host.as_bytes())
+            .ok()
+            .map(str::to_owned)
     }
 
     #[cfg(not(unix))]
     {
-        let text = host.to_string_lossy();
-        text.starts_with('[') && text.ends_with(']')
-    }
-}
-
-fn host_contains_colon(host: &OsStr) -> bool {
-    #[cfg(unix)]
-    {
-        host.as_bytes().contains(&b':')
-    }
-
-    #[cfg(not(unix))]
-    {
-        host.to_string_lossy().contains(':')
+        host.to_str().map(str::to_owned)
     }
 }

--- a/crates/rsync_io/src/ssh/tests.rs
+++ b/crates/rsync_io/src/ssh/tests.rs
@@ -297,10 +297,7 @@ fn parse_host_for_ssh_classifies_inputs() {
         })
     );
 
-    assert!(matches!(
-        parse_host_for_ssh(""),
-        Err(BuildError::EmptyHost)
-    ));
+    assert!(matches!(parse_host_for_ssh(""), Err(BuildError::EmptyHost)));
     assert!(matches!(
         parse_host_for_ssh("2001:db8:::1"),
         Err(BuildError::InvalidIpv6(_))

--- a/crates/rsync_io/src/ssh/tests.rs
+++ b/crates/rsync_io/src/ssh/tests.rs
@@ -140,6 +140,190 @@ fn preserves_explicit_bracketed_ipv6_literals() {
 }
 
 #[test]
+fn wraps_ipv6_hosts_with_scoped_zone_id() {
+    // RFC 4007 link-local with interface zone id: must round-trip the
+    // literal `%zone` inside the brackets.
+    let mut command = SshCommand::new("fe80::1%eth0");
+    command.set_prefer_aes_gcm(Some(false));
+    command.set_user("backup");
+
+    let (_, args) = command.command_parts_for_testing();
+
+    assert_eq!(
+        args_to_strings(&args),
+        vec![
+            "-oBatchMode=yes".to_owned(),
+            "-oServerAliveInterval=20".to_owned(),
+            "-oServerAliveCountMax=3".to_owned(),
+            "-oConnectTimeout=30".to_owned(),
+            "backup@[fe80::1%eth0]".to_owned(),
+        ]
+    );
+}
+
+#[test]
+fn wraps_bracketed_ipv6_hosts_with_scoped_zone_id() {
+    // URL-style outer brackets around an IPv6+zone literal still
+    // re-emit the canonical `[addr%zone]` form.
+    let mut command = SshCommand::new("[fe80::1%en0]");
+    command.set_prefer_aes_gcm(Some(false));
+
+    let (_, args) = command.command_parts_for_testing();
+
+    assert_eq!(
+        args_to_strings(&args),
+        vec![
+            "-oBatchMode=yes".to_owned(),
+            "-oServerAliveInterval=20".to_owned(),
+            "-oServerAliveCountMax=3".to_owned(),
+            "-oConnectTimeout=30".to_owned(),
+            "[fe80::1%en0]".to_owned(),
+        ]
+    );
+}
+
+#[test]
+fn does_not_bracket_malformed_ipv6_with_multiple_double_colons() {
+    // The legacy `host_contains_colon` heuristic accepted any `:`-bearing
+    // input as IPv6 and would have wrapped this in brackets. Strict
+    // `Ipv6Addr::from_str` validation rejects multi-`::` literals, so the
+    // host is now passed through unchanged for SSH to surface the
+    // resolution failure.
+    let mut command = SshCommand::new("2001:db8:::1");
+    command.set_prefer_aes_gcm(Some(false));
+
+    let (_, args) = command.command_parts_for_testing();
+
+    assert_eq!(
+        args_to_strings(&args),
+        vec![
+            "-oBatchMode=yes".to_owned(),
+            "-oServerAliveInterval=20".to_owned(),
+            "-oServerAliveCountMax=3".to_owned(),
+            "-oConnectTimeout=30".to_owned(),
+            "2001:db8:::1".to_owned(),
+        ]
+    );
+}
+
+#[test]
+fn does_not_bracket_garbage_colon_input() {
+    // Loose substring checks (`host.contains(':')`) would have also
+    // bracketed this; strict parsing leaves it untouched.
+    let mut command = SshCommand::new("garbage:input");
+    command.set_prefer_aes_gcm(Some(false));
+
+    let (_, args) = command.command_parts_for_testing();
+
+    assert_eq!(
+        args_to_strings(&args),
+        vec![
+            "-oBatchMode=yes".to_owned(),
+            "-oServerAliveInterval=20".to_owned(),
+            "-oServerAliveCountMax=3".to_owned(),
+            "-oConnectTimeout=30".to_owned(),
+            "garbage:input".to_owned(),
+        ]
+    );
+}
+
+#[test]
+fn does_not_bracket_zone_with_whitespace() {
+    // Zone identifiers must not contain whitespace; the malformed input
+    // is passed through unchanged rather than silently wrapped.
+    let mut command = SshCommand::new("fe80::1%eth 0");
+    command.set_prefer_aes_gcm(Some(false));
+
+    let (_, args) = command.command_parts_for_testing();
+
+    assert_eq!(
+        args_to_strings(&args),
+        vec![
+            "-oBatchMode=yes".to_owned(),
+            "-oServerAliveInterval=20".to_owned(),
+            "-oServerAliveCountMax=3".to_owned(),
+            "-oConnectTimeout=30".to_owned(),
+            "fe80::1%eth 0".to_owned(),
+        ]
+    );
+}
+
+#[test]
+fn does_not_bracket_ipv4_or_hostname() {
+    // Sanity check: dotted-quad IPv4 and ordinary hostnames are emitted
+    // verbatim with no brackets.
+    let mut ipv4 = SshCommand::new("192.0.2.1");
+    ipv4.set_prefer_aes_gcm(Some(false));
+    let (_, ipv4_args) = ipv4.command_parts_for_testing();
+    assert!(args_to_strings(&ipv4_args).contains(&"192.0.2.1".to_owned()));
+
+    let mut hostname = SshCommand::new("rsync.example.com");
+    hostname.set_prefer_aes_gcm(Some(false));
+    let (_, host_args) = hostname.command_parts_for_testing();
+    assert!(args_to_strings(&host_args).contains(&"rsync.example.com".to_owned()));
+}
+
+#[test]
+fn parse_host_for_ssh_classifies_inputs() {
+    use super::builder::{BuildError, HostKind, parse_host_for_ssh};
+
+    assert_eq!(
+        parse_host_for_ssh("rsync.example.com"),
+        Ok(HostKind::Hostname("rsync.example.com".to_owned()))
+    );
+    assert_eq!(
+        parse_host_for_ssh("192.0.2.1"),
+        Ok(HostKind::Ipv4(Ipv4Addr::new(192, 0, 2, 1)))
+    );
+    assert_eq!(
+        parse_host_for_ssh("2001:db8::1"),
+        Ok(HostKind::Ipv6 {
+            addr: "2001:db8::1".parse().unwrap(),
+            zone: None,
+        })
+    );
+    assert_eq!(
+        parse_host_for_ssh("[2001:db8::1]"),
+        Ok(HostKind::Ipv6 {
+            addr: "2001:db8::1".parse().unwrap(),
+            zone: None,
+        })
+    );
+    assert_eq!(
+        parse_host_for_ssh("fe80::1%eth0"),
+        Ok(HostKind::Ipv6 {
+            addr: "fe80::1".parse().unwrap(),
+            zone: Some("eth0".to_owned()),
+        })
+    );
+
+    assert!(matches!(
+        parse_host_for_ssh(""),
+        Err(BuildError::EmptyHost)
+    ));
+    assert!(matches!(
+        parse_host_for_ssh("2001:db8:::1"),
+        Err(BuildError::InvalidIpv6(_))
+    ));
+    assert!(matches!(
+        parse_host_for_ssh("garbage:input"),
+        Err(BuildError::InvalidIpv6(_))
+    ));
+    assert!(matches!(
+        parse_host_for_ssh("fe80::1%"),
+        Err(BuildError::InvalidZoneId(_))
+    ));
+    assert!(matches!(
+        parse_host_for_ssh("fe80::1%eth 0"),
+        Err(BuildError::InvalidZoneId(_))
+    ));
+    assert!(matches!(
+        parse_host_for_ssh("fe80::1%eth]0"),
+        Err(BuildError::InvalidZoneId(_))
+    ));
+}
+
+#[test]
 fn command_parts_skip_target_when_host_and_user_missing() {
     let mut command = SshCommand::new("");
     command.set_prefer_aes_gcm(Some(false));


### PR DESCRIPTION
## Summary

Closes #1879 and #1880.

Replace the loose `host_contains_colon` substring check in
`crates/rsync_io/src/ssh/builder.rs::target_argument` with strict
`std::net::Ipv6Addr::from_str` validation, and add RFC 4007 scoped zone
identifier support so link-local addresses can be addressed by interface
(e.g. `fe80::1%eth0`).

The new `parse_host_for_ssh(host: &str) -> Result<HostKind, BuildError>`
helper classifies a host operand as one of:

- `HostKind::Hostname(String)` - DNS-style names; emitted unbracketed.
- `HostKind::Ipv4(Ipv4Addr)` - dotted-quad literals; emitted unbracketed.
- `HostKind::Ipv6 { addr, zone }` - parsed IPv6 (with optional zone);
  emitted as `[addr]` or `[addr%zone]` per upstream rsync convention.

URL-style outer brackets (`[2001:db8::1]`, `[fe80::1%en0]`) are stripped
before parsing and the canonical bracketed form is re-emitted. Zone ids
are rejected when empty or when they contain whitespace or `]`.

## Before / after on malformed input

Take `2001:db8:::1` (three colons - illegal IPv6):

- **Before:** `host_contains_colon("2001:db8:::1")` returns `true`; the
  builder wraps the operand in brackets and ships
  `[2001:db8:::1]` to `ssh`, which then has to surface a confusing
  error about an invalid hostname literal.
- **After:** `parse_host_for_ssh("2001:db8:::1")` returns
  `Err(BuildError::InvalidIpv6(_))`; the builder passes the host
  through unchanged so `ssh` reports a normal resolution failure on
  the original literal. No silent bracket wrapping of malformed
  input.

The same correction applies to other previously-misclassified inputs
such as `garbage:input` or `fe80::1%eth 0` (zone with whitespace).

## Test plan

- [x] Existing IPv6 bracket tests (`wraps_ipv6_hosts_in_brackets`,
      `wraps_ipv6_hosts_with_usernames`,
      `preserves_explicit_bracketed_ipv6_literals`) continue to pass -
      their inputs are valid IPv6 literals.
- [x] New `wraps_ipv6_hosts_with_scoped_zone_id` -> `backup@[fe80::1%eth0]`.
- [x] New `wraps_bracketed_ipv6_hosts_with_scoped_zone_id` -> `[fe80::1%en0]`.
- [x] New `does_not_bracket_malformed_ipv6_with_multiple_double_colons`
      verifies `2001:db8:::1` is no longer wrapped.
- [x] New `does_not_bracket_garbage_colon_input` verifies `garbage:input`
      is no longer wrapped.
- [x] New `does_not_bracket_zone_with_whitespace` verifies `fe80::1%eth 0`
      is rejected and passed through unchanged.
- [x] New `does_not_bracket_ipv4_or_hostname` verifies dotted-quad and
      DNS names remain unbracketed.
- [x] New `parse_host_for_ssh_classifies_inputs` exercises the validator
      directly across all `HostKind` variants and `BuildError` cases
      (empty host, multi-`::`, garbage colons, empty zone, whitespace
      zone, `]` in zone).
- [ ] CI: fmt + clippy, nextest (stable), Windows, macOS, Linux musl.