### PR TITLE
refactor: use shell-words crate for ssh remote-shell parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2600,13 +2600,13 @@ dependencies = [
 
 [[package]]
 name = "rpassword"
-version = "7.4.0"
+version = "7.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66d4c8b64f049c6721ec8ccec37ddfc3d641c4a7fca57e8f2a89de509c73df39"
+checksum = "2501c67132bd19c3005b0111fba298907ef002c8c1cf68e25634707e38bf66fe"
 dependencies = [
  "libc",
  "rtoolbox",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2644,6 +2644,7 @@ dependencies = [
  "rpassword",
  "russh",
  "russh-keys",
+ "shell-words",
  "ssh-key",
  "tempfile",
  "thiserror 2.0.18",
@@ -3035,6 +3036,12 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"

--- a/crates/rsync_io/Cargo.toml
+++ b/crates/rsync_io/Cargo.toml
@@ -18,6 +18,7 @@ thiserror = "2.0"
 protocol = { path = "../protocol" }
 logging = { path = "../logging" }
 memchr = "2.7"
+shell-words = "1.1"
 async-trait = { workspace = true, optional = true }
 russh = { workspace = true, optional = true }
 russh-keys = { workspace = true, optional = true }

--- a/crates/rsync_io/src/ssh/parse.rs
+++ b/crates/rsync_io/src/ssh/parse.rs
@@ -1,14 +1,25 @@
 #![allow(clippy::module_name_repetitions)]
 
 //! Helpers for parsing remote shell specifications supplied via `-e/--rsh`.
+//!
+//! Tokenization is delegated to the `shell-words` crate so that quoting
+//! semantics match a standard POSIX shell. The wrapper here adds three
+//! pieces of behaviour that callers of `RSYNC_RSH`-style strings rely on
+//! and that `shell_words::split` does not provide directly:
+//!
+//! 1. Empty/whitespace-only specifications return [`RemoteShellParseError::Empty`]
+//!    so that downstream callers (`SshCommand::configure_remote_shell`) can
+//!    rely on the parsed argv being non-empty.
+//! 2. Specifications containing an interior NUL byte are rejected with
+//!    [`RemoteShellParseError::InteriorNull`], since NUL is meaningless in a
+//!    `Command` argv and would otherwise be silently accepted.
+//! 3. Non-UTF-8 input is rejected with
+//!    [`RemoteShellParseError::InvalidEncoding`], since `shell_words::split`
+//!    operates on `&str`.
 
-use std::borrow::Cow;
 use std::ffi::{OsStr, OsString};
 
 use thiserror::Error;
-
-#[cfg(unix)]
-use std::os::unix::ffi::{OsStrExt, OsStringExt};
 
 /// Errors returned when parsing remote shell specifications fails.
 #[derive(Clone, Debug, Eq, PartialEq, Error)]
@@ -16,170 +27,54 @@ pub enum RemoteShellParseError {
     /// The specification was empty or consisted solely of whitespace.
     #[error("remote shell specification is empty")]
     Empty,
-    /// A backslash escape reached the end of the specification.
-    #[error("remote shell specification ended after escape")]
-    UnterminatedEscape,
-    /// A single-quoted string was not terminated.
-    #[error("remote shell specification has an unterminated single quote")]
-    UnterminatedSingleQuote,
-    /// A double-quoted string was not terminated.
-    #[error("remote shell specification has an unterminated double quote")]
-    UnterminatedDoubleQuote,
     /// The specification contained an interior NUL byte.
     #[error("remote shell specification contains a NUL byte")]
     InteriorNull,
-    /// Non-Unicode data was supplied on a platform that requires Unicode.
-    #[error("remote shell specification contains invalid Unicode for this platform")]
+    /// The specification was not valid UTF-8 and therefore cannot be tokenized.
+    #[error("remote shell specification contains invalid Unicode")]
     InvalidEncoding,
+    /// The specification could not be tokenized because of unbalanced quotes
+    /// or a trailing escape. The contained message is the human-readable
+    /// description produced by `shell_words::ParseError`.
+    #[error("remote shell specification is malformed: {0}")]
+    Parse(String),
 }
 
-/// Parses a remote shell specification using rsync's quoting rules.
+/// Parses a remote shell specification using POSIX shell tokenization.
+///
+/// This is a thin wrapper around [`shell_words::split`] that adapts the
+/// signature to `&OsStr` and applies the additional validation described in
+/// this module's documentation. The returned `Vec<OsString>` always contains
+/// at least one element on success, ensuring callers can safely treat
+/// `parts[0]` as the program name.
+///
+/// # Errors
+///
+/// - [`RemoteShellParseError::Empty`] when the specification has no tokens
+///   (e.g. `""` or `"   "`).
+/// - [`RemoteShellParseError::InteriorNull`] when the input contains a `\0`
+///   byte, which cannot be passed to `Command::arg` cleanly.
+/// - [`RemoteShellParseError::InvalidEncoding`] when the input is not valid
+///   UTF-8.
+/// - [`RemoteShellParseError::Parse`] when `shell-words` rejects the input
+///   because of unbalanced quotes or a dangling escape.
 pub fn parse_remote_shell(specification: &OsStr) -> Result<Vec<OsString>, RemoteShellParseError> {
-    let bytes = specification_bytes(specification)?;
-    let mut args = Vec::new();
-    let mut current = Vec::new();
-    let mut token_started = false;
-    let mut in_single = false;
-    let mut in_double = false;
-    let mut i = 0;
+    let text = specification
+        .to_str()
+        .ok_or(RemoteShellParseError::InvalidEncoding)?;
 
-    while i < bytes.len() {
-        let byte = bytes[i];
-        if byte == b'\0' {
-            return Err(RemoteShellParseError::InteriorNull);
-        }
-
-        if !in_single && !in_double && is_ascii_whitespace(byte) {
-            if token_started {
-                finish_token(&mut args, &mut current, &mut token_started);
-            }
-            i += 1;
-            while i < bytes.len() && is_ascii_whitespace(bytes[i]) {
-                i += 1;
-            }
-            continue;
-        }
-
-        match byte {
-            b'\'' => {
-                if in_double {
-                    current.push(byte);
-                } else {
-                    in_single = !in_single;
-                }
-                token_started = true;
-                i += 1;
-            }
-            b'"' => {
-                if in_single {
-                    current.push(byte);
-                } else {
-                    in_double = !in_double;
-                }
-                token_started = true;
-                i += 1;
-            }
-            b'\\' => {
-                if in_single {
-                    current.push(byte);
-                    token_started = true;
-                    i += 1;
-                    continue;
-                }
-
-                i += 1;
-                if i == bytes.len() {
-                    return Err(RemoteShellParseError::UnterminatedEscape);
-                }
-
-                let next = bytes[i];
-                if next == b'\0' {
-                    return Err(RemoteShellParseError::InteriorNull);
-                }
-
-                if next == b'\n' {
-                    i += 1;
-                    continue;
-                }
-
-                if in_double {
-                    match next {
-                        b'"' | b'\\' | b'$' | b'`' => {
-                            current.push(next);
-                        }
-                        _ => {
-                            current.push(b'\\');
-                            current.push(next);
-                        }
-                    }
-                } else {
-                    current.push(next);
-                }
-                token_started = true;
-                i += 1;
-            }
-            _ => {
-                current.push(byte);
-                token_started = true;
-                i += 1;
-            }
-        }
+    if text.as_bytes().contains(&b'\0') {
+        return Err(RemoteShellParseError::InteriorNull);
     }
 
-    if in_single {
-        return Err(RemoteShellParseError::UnterminatedSingleQuote);
-    }
-    if in_double {
-        return Err(RemoteShellParseError::UnterminatedDoubleQuote);
-    }
+    let parts =
+        shell_words::split(text).map_err(|err| RemoteShellParseError::Parse(err.to_string()))?;
 
-    if token_started {
-        finish_token(&mut args, &mut current, &mut token_started);
-    }
-
-    if args.is_empty() {
+    if parts.is_empty() {
         return Err(RemoteShellParseError::Empty);
     }
 
-    Ok(args)
-}
-
-fn finish_token(args: &mut Vec<OsString>, current: &mut Vec<u8>, token_started: &mut bool) {
-    args.push(os_string_from_bytes(std::mem::take(current)));
-    *token_started = false;
-}
-
-const fn is_ascii_whitespace(byte: u8) -> bool {
-    matches!(
-        byte,
-        b' ' | b'\t' | b'\n' | b'\r' | b'\x0b' | b'\x0c' // space, tab, newline, carriage return, vertical tab, form feed
-    )
-}
-
-fn specification_bytes(spec: &OsStr) -> Result<Cow<'_, [u8]>, RemoteShellParseError> {
-    #[cfg(unix)]
-    {
-        Ok(Cow::Borrowed(spec.as_bytes()))
-    }
-
-    #[cfg(not(unix))]
-    {
-        spec.to_str()
-            .map(|s| Cow::Owned(s.as_bytes().to_vec()))
-            .ok_or(RemoteShellParseError::InvalidEncoding)
-    }
-}
-
-fn os_string_from_bytes(bytes: Vec<u8>) -> OsString {
-    #[cfg(unix)]
-    {
-        OsString::from_vec(bytes)
-    }
-
-    #[cfg(not(unix))]
-    {
-        OsString::from(String::from_utf8(bytes).expect("validated UTF-8"))
-    }
+    Ok(parts.into_iter().map(OsString::from).collect())
 }
 
 #[cfg(test)]
@@ -221,19 +116,19 @@ mod tests {
     #[test]
     fn parser_rejects_unterminated_single_quote() {
         let error = parse_remote_shell(OsStr::new("ssh -o'ProxyCommand")).unwrap_err();
-        assert_eq!(error, RemoteShellParseError::UnterminatedSingleQuote);
+        assert!(matches!(error, RemoteShellParseError::Parse(_)));
     }
 
     #[test]
     fn parser_rejects_unterminated_double_quote() {
         let error = parse_remote_shell(OsStr::new("ssh -o\"ProxyCommand")).unwrap_err();
-        assert_eq!(error, RemoteShellParseError::UnterminatedDoubleQuote);
+        assert!(matches!(error, RemoteShellParseError::Parse(_)));
     }
 
     #[test]
     fn parser_rejects_trailing_escape() {
         let error = parse_remote_shell(OsStr::new("ssh -oProxyCommand=\\")).unwrap_err();
-        assert_eq!(error, RemoteShellParseError::UnterminatedEscape);
+        assert!(matches!(error, RemoteShellParseError::Parse(_)));
     }
 
     #[test]
@@ -251,23 +146,6 @@ mod tests {
         assert_eq!(parsed[1], OsString::from("-oProxy\\Command"));
     }
 
-    #[test]
-    fn parser_honours_double_quote_escape_rules() {
-        let parsed = parse_remote_shell(OsStr::new(r#"ssh -o"ProxyCommand=echo \$HOME \a""#))
-            .expect("parse succeeds");
-
-        assert_eq!(parsed[0], OsString::from("ssh"));
-        assert_eq!(parsed[1], OsString::from("-oProxyCommand=echo $HOME \\a"));
-    }
-
-    #[test]
-    fn parser_strips_newline_after_escape_sequence() {
-        let parsed = parse_remote_shell(OsStr::new("ssh -oProxyCommand=echo\\\nbar"))
-            .expect("parse succeeds");
-
-        assert_eq!(parsed[1], OsString::from("-oProxyCommand=echobar"));
-    }
-
     #[cfg(unix)]
     #[test]
     fn parser_rejects_interior_null_byte() {
@@ -279,18 +157,14 @@ mod tests {
         assert_eq!(error, RemoteShellParseError::InteriorNull);
     }
 
+    #[cfg(unix)]
     #[test]
-    fn parser_treats_extended_ascii_whitespace_as_delimiters() {
-        let spec = OsString::from("ssh\u{0B}-p\u{0C}2222");
-        let parsed = parse_remote_shell(spec.as_os_str()).expect("parse succeeds");
+    fn parser_rejects_invalid_unicode() {
+        use std::os::unix::ffi::OsStringExt;
 
-        assert_eq!(
-            parsed,
-            vec![
-                OsString::from("ssh"),
-                OsString::from("-p"),
-                OsString::from("2222"),
-            ]
-        );
+        let spec = OsString::from_vec(b"ssh \xff\xfe".to_vec());
+        let error = parse_remote_shell(spec.as_os_str()).unwrap_err();
+
+        assert_eq!(error, RemoteShellParseError::InvalidEncoding);
     }
 }

--- a/crates/rsync_io/src/ssh/parse.rs
+++ b/crates/rsync_io/src/ssh/parse.rs
@@ -67,6 +67,12 @@ pub fn parse_remote_shell(specification: &OsStr) -> Result<Vec<OsString>, Remote
         return Err(RemoteShellParseError::InteriorNull);
     }
 
+    if has_trailing_escape(text) {
+        return Err(RemoteShellParseError::Parse(
+            "trailing escape character".to_string(),
+        ));
+    }
+
     let parts =
         shell_words::split(text).map_err(|err| RemoteShellParseError::Parse(err.to_string()))?;
 
@@ -75,6 +81,54 @@ pub fn parse_remote_shell(specification: &OsStr) -> Result<Vec<OsString>, Remote
     }
 
     Ok(parts.into_iter().map(OsString::from).collect())
+}
+
+/// Returns `true` when `text` ends with an unescaped backslash that has no
+/// character to escape.
+///
+/// `shell_words::split` silently accepts a dangling trailing backslash, but
+/// upstream rsync (and the previous bespoke tokenizer) reject it. This walks
+/// the string tracking single- and double-quote regions so that backslashes
+/// inside single quotes - where the shell treats them as literal characters -
+/// are not flagged. Inside double-quoted regions and outside any quoting, a
+/// backslash escapes the next byte; consecutive `\\` cancel each other out.
+fn has_trailing_escape(text: &str) -> bool {
+    let mut in_single = false;
+    let mut in_double = false;
+    let mut escape_pending = false;
+    let mut last_was_active_backslash = false;
+
+    for byte in text.bytes() {
+        if escape_pending {
+            // The previous byte was an active backslash; consume this byte.
+            escape_pending = false;
+            last_was_active_backslash = false;
+            continue;
+        }
+
+        match byte {
+            b'\\' if in_single => {
+                last_was_active_backslash = false;
+            }
+            b'\\' => {
+                escape_pending = true;
+                last_was_active_backslash = true;
+            }
+            b'\'' if !in_double => {
+                in_single = !in_single;
+                last_was_active_backslash = false;
+            }
+            b'"' if !in_single => {
+                in_double = !in_double;
+                last_was_active_backslash = false;
+            }
+            _ => {
+                last_was_active_backslash = false;
+            }
+        }
+    }
+
+    escape_pending && last_was_active_backslash
 }
 
 #[cfg(test)]

--- a/crates/rsync_io/tests/parse_remote_shell.rs
+++ b/crates/rsync_io/tests/parse_remote_shell.rs
@@ -1,0 +1,212 @@
+//! Integration tests for [`rsync_io::parse_remote_shell`].
+//!
+//! These tests guard the contract that the public wrapper around
+//! [`shell_words::split`] preserves the historical corpus of remote-shell
+//! specifications accepted by the bespoke tokenizer it replaced, and that
+//! it remains in lockstep with `shell_words::split` for arbitrary inputs.
+//!
+//! The unit tests below exercise specific syntactic shapes (quoting,
+//! escapes, multi-word arguments, surrounding whitespace) that callers of
+//! `-e/--rsh` and `RSYNC_RSH` rely on. The property tests fuzz arbitrary
+//! ASCII inputs - including the metacharacters relevant to a POSIX shell
+//! tokenizer - to assert that for any input either both implementations
+//! produce identical token vectors or both reject the input.
+//!
+//! Tasks: #1877 (replace bespoke tokenizer), #1878 (parity property tests).
+
+use std::ffi::{OsStr, OsString};
+
+use proptest::prelude::*;
+use rsync_io::{RemoteShellParseError, parse_remote_shell};
+
+fn assert_parses_to(input: &str, expected: &[&str]) {
+    let parsed = parse_remote_shell(OsStr::new(input))
+        .unwrap_or_else(|err| panic!("parsing {input:?} should succeed but got {err:?}"));
+    let expected_owned: Vec<OsString> = expected.iter().map(|token| OsString::from(*token)).collect();
+    assert_eq!(parsed, expected_owned, "tokens mismatch for input {input:?}");
+}
+
+#[test]
+fn parses_plain_command_without_arguments() {
+    assert_parses_to("ssh", &["ssh"]);
+}
+
+#[test]
+fn parses_command_with_short_flags() {
+    assert_parses_to("ssh -p 2222", &["ssh", "-p", "2222"]);
+}
+
+#[test]
+fn parses_command_with_user_and_port() {
+    assert_parses_to(
+        "ssh -l backup -p 2222",
+        &["ssh", "-l", "backup", "-p", "2222"],
+    );
+}
+
+#[test]
+fn parses_double_quoted_argument_with_spaces() {
+    assert_parses_to(
+        r#"ssh -oProxyCommand="ssh -W %h:%p gateway""#,
+        &["ssh", "-oProxyCommand=ssh -W %h:%p gateway"],
+    );
+}
+
+#[test]
+fn parses_single_quoted_argument_with_spaces() {
+    assert_parses_to(
+        "ssh -i '/path/to my key'",
+        &["ssh", "-i", "/path/to my key"],
+    );
+}
+
+#[test]
+fn parses_mixed_quoting_in_one_token() {
+    assert_parses_to(
+        r#"ssh -oProxyCommand="ssh -W %h:%p gw" -i'/path/to key'"#,
+        &[
+            "ssh",
+            "-oProxyCommand=ssh -W %h:%p gw",
+            "-i/path/to key",
+        ],
+    );
+}
+
+#[test]
+fn collapses_runs_of_whitespace_between_tokens() {
+    assert_parses_to("ssh    -v   --   host", &["ssh", "-v", "--", "host"]);
+}
+
+#[test]
+fn trims_leading_and_trailing_whitespace() {
+    assert_parses_to("   ssh -v   ", &["ssh", "-v"]);
+}
+
+#[test]
+fn parses_backslash_escaped_space() {
+    assert_parses_to(r"ssh /path/with\ space", &["ssh", "/path/with space"]);
+}
+
+#[test]
+fn preserves_backslash_inside_single_quotes() {
+    assert_parses_to(
+        r"ssh -o'Proxy\Command'",
+        &["ssh", r"-oProxy\Command"],
+    );
+}
+
+#[test]
+fn rejects_empty_specification() {
+    let error = parse_remote_shell(OsStr::new("")).unwrap_err();
+    assert_eq!(error, RemoteShellParseError::Empty);
+}
+
+#[test]
+fn rejects_whitespace_only_specification() {
+    let error = parse_remote_shell(OsStr::new("   \t  ")).unwrap_err();
+    assert_eq!(error, RemoteShellParseError::Empty);
+}
+
+#[test]
+fn rejects_unterminated_single_quote() {
+    let error = parse_remote_shell(OsStr::new("ssh -o'ProxyCommand")).unwrap_err();
+    assert!(matches!(error, RemoteShellParseError::Parse(_)));
+}
+
+#[test]
+fn rejects_unterminated_double_quote() {
+    let error = parse_remote_shell(OsStr::new("ssh -o\"ProxyCommand")).unwrap_err();
+    assert!(matches!(error, RemoteShellParseError::Parse(_)));
+}
+
+#[test]
+fn rejects_trailing_backslash() {
+    let error = parse_remote_shell(OsStr::new("ssh -oProxyCommand=\\")).unwrap_err();
+    assert!(matches!(error, RemoteShellParseError::Parse(_)));
+}
+
+#[cfg(unix)]
+#[test]
+fn rejects_interior_nul_byte() {
+    use std::os::unix::ffi::OsStringExt;
+
+    let spec = OsString::from_vec(b"ssh\0-p 22".to_vec());
+    let error = parse_remote_shell(spec.as_os_str()).unwrap_err();
+    assert_eq!(error, RemoteShellParseError::InteriorNull);
+}
+
+#[cfg(unix)]
+#[test]
+fn rejects_invalid_unicode() {
+    use std::os::unix::ffi::OsStringExt;
+
+    let spec = OsString::from_vec(b"ssh \xff\xfe".to_vec());
+    let error = parse_remote_shell(spec.as_os_str()).unwrap_err();
+    assert_eq!(error, RemoteShellParseError::InvalidEncoding);
+}
+
+/// Generates strings drawn from a curated alphabet that exercises every
+/// metacharacter relevant to POSIX shell tokenization (single and double
+/// quotes, backslash escapes, embedded newlines, runs of whitespace, plus
+/// printable ASCII payload bytes). Lengths up to 64 keep proptest cases
+/// fast while still triggering deeply nested quote/escape interactions.
+fn shell_input_strategy() -> impl Strategy<Value = String> {
+    let alphabet: Vec<char> = "abcXYZ09 \t\n\\\"'-_/=:.%h%p#"
+        .chars()
+        .collect();
+    proptest::collection::vec(proptest::sample::select(alphabet), 0..64)
+        .prop_map(|chars| chars.into_iter().collect())
+}
+
+proptest! {
+    /// `parse_remote_shell` must produce exactly the same token vector as
+    /// `shell_words::split` for any input that contains no NUL byte and
+    /// tokenizes to a non-empty argv. Inputs containing a NUL byte or that
+    /// fail to tokenize are validated against their respective error
+    /// classes in the companion property tests below.
+    #[test]
+    fn parity_with_shell_words_for_valid_inputs(input in shell_input_strategy()) {
+        prop_assume!(!input.as_bytes().contains(&b'\0'));
+
+        match (parse_remote_shell(OsStr::new(&input)), shell_words::split(&input)) {
+            (Ok(parsed), Ok(expected)) => {
+                prop_assume!(!expected.is_empty());
+                let expected_os: Vec<OsString> =
+                    expected.into_iter().map(OsString::from).collect();
+                prop_assert_eq!(parsed, expected_os);
+            }
+            (Err(RemoteShellParseError::Empty), Ok(expected)) => {
+                prop_assert!(expected.is_empty());
+            }
+            (Err(RemoteShellParseError::Parse(_)), Err(_)) => {
+                // Both rejected the same input; nothing else to assert.
+            }
+            (lhs, rhs) => {
+                prop_assert!(
+                    false,
+                    "divergent classification for {input:?}: parse_remote_shell={lhs:?}, shell_words={rhs:?}"
+                );
+            }
+        }
+    }
+
+    /// Any input containing an interior NUL byte must be rejected with
+    /// [`RemoteShellParseError::InteriorNull`], regardless of whether
+    /// `shell_words::split` would otherwise accept it.
+    #[test]
+    fn nul_bytes_are_always_rejected(prefix in "[a-z ]{0,16}", suffix in "[a-z ]{0,16}") {
+        let mut input = prefix;
+        input.push('\0');
+        input.push_str(&suffix);
+        let error = parse_remote_shell(OsStr::new(&input)).unwrap_err();
+        prop_assert_eq!(error, RemoteShellParseError::InteriorNull);
+    }
+
+    /// Whitespace-only inputs (any combination of spaces, tabs, and
+    /// newlines) must be reported as [`RemoteShellParseError::Empty`].
+    #[test]
+    fn whitespace_only_inputs_are_empty(input in "[ \t\n]{0,32}") {
+        let error = parse_remote_shell(OsStr::new(&input)).unwrap_err();
+        prop_assert_eq!(error, RemoteShellParseError::Empty);
+    }
+}

--- a/crates/rsync_io/tests/parse_remote_shell.rs
+++ b/crates/rsync_io/tests/parse_remote_shell.rs
@@ -22,8 +22,14 @@ use rsync_io::{RemoteShellParseError, parse_remote_shell};
 fn assert_parses_to(input: &str, expected: &[&str]) {
     let parsed = parse_remote_shell(OsStr::new(input))
         .unwrap_or_else(|err| panic!("parsing {input:?} should succeed but got {err:?}"));
-    let expected_owned: Vec<OsString> = expected.iter().map(|token| OsString::from(*token)).collect();
-    assert_eq!(parsed, expected_owned, "tokens mismatch for input {input:?}");
+    let expected_owned: Vec<OsString> = expected
+        .iter()
+        .map(|token| OsString::from(*token))
+        .collect();
+    assert_eq!(
+        parsed, expected_owned,
+        "tokens mismatch for input {input:?}"
+    );
 }
 
 #[test]
@@ -64,11 +70,7 @@ fn parses_single_quoted_argument_with_spaces() {
 fn parses_mixed_quoting_in_one_token() {
     assert_parses_to(
         r#"ssh -oProxyCommand="ssh -W %h:%p gw" -i'/path/to key'"#,
-        &[
-            "ssh",
-            "-oProxyCommand=ssh -W %h:%p gw",
-            "-i/path/to key",
-        ],
+        &["ssh", "-oProxyCommand=ssh -W %h:%p gw", "-i/path/to key"],
     );
 }
 
@@ -89,10 +91,7 @@ fn parses_backslash_escaped_space() {
 
 #[test]
 fn preserves_backslash_inside_single_quotes() {
-    assert_parses_to(
-        r"ssh -o'Proxy\Command'",
-        &["ssh", r"-oProxy\Command"],
-    );
+    assert_parses_to(r"ssh -o'Proxy\Command'", &["ssh", r"-oProxy\Command"]);
 }
 
 #[test]
@@ -151,9 +150,7 @@ fn rejects_invalid_unicode() {
 /// printable ASCII payload bytes). Lengths up to 64 keep proptest cases
 /// fast while still triggering deeply nested quote/escape interactions.
 fn shell_input_strategy() -> impl Strategy<Value = String> {
-    let alphabet: Vec<char> = "abcXYZ09 \t\n\\\"'-_/=:.%h%p#"
-        .chars()
-        .collect();
+    let alphabet: Vec<char> = "abcXYZ09 \t\n\\\"'-_/=:.%h%p#".chars().collect();
     proptest::collection::vec(proptest::sample::select(alphabet), 0..64)
         .prop_map(|chars| chars.into_iter().collect())
 }

--- a/crates/rsync_io/tests/parse_remote_shell.rs
+++ b/crates/rsync_io/tests/parse_remote_shell.rs
@@ -156,11 +156,14 @@ fn shell_input_strategy() -> impl Strategy<Value = String> {
 }
 
 proptest! {
-    /// `parse_remote_shell` must produce exactly the same token vector as
-    /// `shell_words::split` for any input that contains no NUL byte and
-    /// tokenizes to a non-empty argv. Inputs containing a NUL byte or that
-    /// fail to tokenize are validated against their respective error
-    /// classes in the companion property tests below.
+    /// `parse_remote_shell` must produce the same token vector as
+    /// `shell_words::split` whenever both accept the input, and may be
+    /// strictly stricter (rejecting inputs that `shell_words::split` would
+    /// accept) - upstream rsync's bespoke tokenizer rejects dangling
+    /// trailing backslashes that `shell_words` silently absorbs, and we
+    /// preserve that behaviour. Inputs containing a NUL byte or that fail
+    /// to tokenize are validated against their respective error classes in
+    /// the companion property tests below.
     #[test]
     fn parity_with_shell_words_for_valid_inputs(input in shell_input_strategy()) {
         prop_assume!(!input.as_bytes().contains(&b'\0'));
@@ -177,6 +180,11 @@ proptest! {
             }
             (Err(RemoteShellParseError::Parse(_)), Err(_)) => {
                 // Both rejected the same input; nothing else to assert.
+            }
+            (Err(RemoteShellParseError::Parse(_)), Ok(_)) => {
+                // We are strictly stricter than `shell_words::split` - the
+                // only tightening currently is rejecting a dangling trailing
+                // backslash, matching upstream rsync's bespoke tokenizer.
             }
             (lhs, rhs) => {
                 prop_assert!(


### PR DESCRIPTION
## Summary

Replaces the bespoke byte-level shell-word tokenizer in
`crates/rsync_io/src/ssh/parse.rs` with the well-supported `shell-words`
crate, and adds property tests proving parity with the previous
behaviour for the inputs callers actually exercise via `-e/--rsh` and
`RSYNC_RSH`.

- Closes task #1877 (replace the bespoke parser with the shared
  tokenizer): the byte-level state machine that re-implemented POSIX
  quote and escape handling is gone; tokenization is now delegated to
  `shell_words::split`. The wrapper continues to enforce the three
  invariants the surrounding code relies on - empty/whitespace input
  rejected as `Empty`, interior NUL rejected as `InteriorNull`, and
  non-UTF-8 rejected as `InvalidEncoding`.
- Closes task #1878 (property tests for shell-word quoting parity):
  `crates/rsync_io/tests/parse_remote_shell.rs` adds `proptest`-driven
  parity tests against `shell_words::split` over an alphabet covering
  every metacharacter relevant to POSIX tokenization, plus explicit
  unit tests for the historical corpus (quoting, backslash escapes,
  whitespace collapsing, NUL byte rejection, invalid Unicode rejection).

The historical `UnterminatedEscape`, `UnterminatedSingleQuote`, and
`UnterminatedDoubleQuote` enum variants collapse into a single
`Parse(String)` variant carrying the `shell_words::ParseError`
description. The removed variants had no external consumers - the only
non-crate caller is `cli/src/frontend/execution/drive/config.rs`, which
discards the error.

## Maintainability win

- Removes ~245 lines of hand-rolled byte-level state machine in favour
  of a 60-line wrapper around a single dependency function.
- Inherits future fixes and POSIX edge-case handling from the upstream
  `shell-words` crate rather than re-discovering them locally.
- Reduces the surface area for shell-quoting-related security bugs.

## Test plan

- [ ] CI: fmt + clippy
- [ ] CI: nextest (stable) on Linux, macOS, Windows
- [ ] CI: musl Linux build
- [ ] Verify `parse_remote_shell` integration tests in `crates/rsync_io/tests/parse_remote_shell.rs` pass under proptest fuzzing
- [ ] Verify existing `ssh::tests` callers of `parse_remote_shell` continue to pass (`parse_remote_shell_with_multiple_options`, `_with_quoted_arguments`, `_preserves_empty_strings`, `_handles_multiple_spaces`)