### PR TITLE
perf: wire IoUringDiskBatch into disk_commit hot path

### DIFF
--- a/crates/transfer/src/disk_commit/process.rs
+++ b/crates/transfer/src/disk_commit/process.rs
@@ -5,7 +5,7 @@
 //! application.
 
 use std::fs;
-use std::io::{self, Write};
+use std::io;
 use std::path::{Path, PathBuf};
 
 use engine::compute_backup_path;
@@ -17,22 +17,28 @@ use crate::pipeline::spsc;
 use crate::temp_guard::{TempFileGuard, open_tmpfile};
 
 use super::config::{BackupConfig, DiskCommitConfig};
-use super::writer::ReusableBufWriter;
+use super::writer::{ReusableBufWriter, Writer};
 
 /// Processes a single file: open, write chunks, commit or abort.
 ///
 /// After writing each chunk, the owned `Vec<u8>` is returned through
 /// `buf_return_tx` for reuse by the network thread.
+///
+/// When `disk_batch` is `Some` and sparse mode is disabled, writes are
+/// submitted via the shared [`fast_io::IoUringDiskBatch`] for batched
+/// io_uring submission. Sparse mode requires `Seek`, which the batch does
+/// not provide, so it always falls back to buffered writes.
 pub(super) fn process_file(
     file_rx: &spsc::Receiver<FileMessage>,
     buf_return_tx: &spsc::Sender<Vec<u8>>,
     config: &DiskCommitConfig,
     mut begin: BeginMessage,
     write_buf: &mut Vec<u8>,
+    disk_batch: Option<&mut fast_io::IoUringDiskBatch>,
 ) -> io::Result<CommitResult> {
     let (file, mut cleanup_guard, needs_rename) = open_output_file(&begin, config)?;
 
-    let mut output = ReusableBufWriter::new(file, write_buf);
+    let mut output = make_writer(file, write_buf, disk_batch, config.use_sparse)?;
 
     let mut sparse_state = if config.use_sparse {
         Some(SparseWriteState::default())
@@ -64,9 +70,9 @@ pub(super) fn process_file(
                 }
 
                 if let Some(ref mut sparse) = sparse_state {
-                    sparse.write(&mut output, &data)?;
+                    sparse.write(output.buffered_for_sparse(), &data)?;
                 } else {
-                    output.write_all(&data)?;
+                    output.write_chunk(&data)?;
                 }
                 bytes_written += data.len() as u64;
                 // Return the buffer for reuse. Ignore errors - the network
@@ -75,11 +81,11 @@ pub(super) fn process_file(
             }
             FileMessage::Commit => {
                 if let Some(ref mut sparse) = sparse_state {
-                    let _final_pos = sparse.finish(&mut output)?;
+                    let _final_pos = sparse.finish(output.buffered_for_sparse())?;
                 }
 
-                flush_and_sync(&mut output, config.do_fsync, &begin.file_path)?;
-                drop(output);
+                output.flush_and_sync(config.do_fsync, &begin.file_path)?;
+                output.finish(config.do_fsync, &begin.file_path)?;
 
                 commit_file(
                     &begin,
@@ -128,17 +134,20 @@ pub(super) fn process_file(
 /// Processes a single-chunk file in one shot (coalesced Begin+Chunk+Commit).
 ///
 /// Avoids the per-message channel recv loop of [`process_file`], reducing
-/// futex overhead from 3+ sends/recvs to 1 for small files.
+/// futex overhead from 3+ sends/recvs to 1 for small files. When
+/// `disk_batch` is `Some` and sparse mode is disabled, the chunk is
+/// submitted via the shared [`fast_io::IoUringDiskBatch`].
 pub(super) fn process_whole_file(
     buf_return_tx: &spsc::Sender<Vec<u8>>,
     config: &DiskCommitConfig,
     mut begin: BeginMessage,
     data: Vec<u8>,
     write_buf: &mut Vec<u8>,
+    disk_batch: Option<&mut fast_io::IoUringDiskBatch>,
 ) -> io::Result<CommitResult> {
     let (file, mut cleanup_guard, needs_rename) = open_output_file(&begin, config)?;
 
-    let mut output = ReusableBufWriter::new(file, write_buf);
+    let mut output = make_writer(file, write_buf, disk_batch, config.use_sparse)?;
     let bytes_written = data.len() as u64;
 
     let mut checksum_verifier = begin.checksum_verifier.take();
@@ -148,16 +157,16 @@ pub(super) fn process_whole_file(
 
     if config.use_sparse {
         let mut sparse = SparseWriteState::default();
-        sparse.write(&mut output, &data)?;
-        let _final_pos = sparse.finish(&mut output)?;
+        sparse.write(output.buffered_for_sparse(), &data)?;
+        let _final_pos = sparse.finish(output.buffered_for_sparse())?;
     } else {
-        output.write_all(&data)?;
+        output.write_chunk(&data)?;
     }
 
     let _ = buf_return_tx.send(data);
 
-    flush_and_sync(&mut output, config.do_fsync, &begin.file_path)?;
-    drop(output);
+    output.flush_and_sync(config.do_fsync, &begin.file_path)?;
+    output.finish(config.do_fsync, &begin.file_path)?;
 
     commit_file(
         &begin,
@@ -222,21 +231,33 @@ fn open_output_file(
     }
 }
 
-/// Flushes the writer and optionally calls `sync_all`.
-fn flush_and_sync(
-    output: &mut ReusableBufWriter<'_>,
-    do_fsync: bool,
-    file_path: &Path,
-) -> io::Result<()> {
-    if do_fsync {
-        output
-            .sync()
-            .map_err(|e| io::Error::new(e.kind(), format!("fsync failed for {file_path:?}: {e}")))
-    } else {
-        output
-            .flush()
-            .map_err(|e| io::Error::other(format!("flush failed for {file_path:?}: {e}")))
+/// Constructs the per-file [`Writer`] dispatching between io_uring batched
+/// submission and the buffered fallback.
+///
+/// Selects io_uring when (a) the disk thread holds an active
+/// [`fast_io::IoUringDiskBatch`] and (b) sparse mode is disabled. Sparse
+/// mode requires `Seek`, which the batch writer does not provide, so it
+/// always falls back to the buffered variant.
+///
+/// On the io_uring path, `batch.begin_file(file)` registers the fd with the
+/// ring; the matching `commit_file` happens via [`Writer::finish`].
+#[allow(unused_variables)] // disk_batch is unused on non-Linux / without feature
+fn make_writer<'a>(
+    file: fs::File,
+    write_buf: &'a mut Vec<u8>,
+    disk_batch: Option<&'a mut fast_io::IoUringDiskBatch>,
+    use_sparse: bool,
+) -> io::Result<Writer<'a>> {
+    #[cfg(all(target_os = "linux", feature = "io_uring"))]
+    {
+        if !use_sparse {
+            if let Some(batch) = disk_batch {
+                batch.begin_file(file)?;
+                return Ok(Writer::IoUring { batch });
+            }
+        }
     }
+    Ok(Writer::Buffered(ReusableBufWriter::new(file, write_buf)))
 }
 
 /// Performs backup, atomic rename, and inplace truncation after writing.

--- a/crates/transfer/src/disk_commit/process.rs
+++ b/crates/transfer/src/disk_commit/process.rs
@@ -38,7 +38,13 @@ pub(super) fn process_file(
 ) -> io::Result<CommitResult> {
     let (file, mut cleanup_guard, needs_rename) = open_output_file(&begin, config)?;
 
-    let mut output = make_writer(file, write_buf, disk_batch, config.use_sparse)?;
+    let mut output = make_writer(
+        file,
+        write_buf,
+        disk_batch,
+        config.use_sparse,
+        begin.append_offset,
+    )?;
 
     let mut sparse_state = if config.use_sparse {
         Some(SparseWriteState::default())
@@ -147,7 +153,13 @@ pub(super) fn process_whole_file(
 ) -> io::Result<CommitResult> {
     let (file, mut cleanup_guard, needs_rename) = open_output_file(&begin, config)?;
 
-    let mut output = make_writer(file, write_buf, disk_batch, config.use_sparse)?;
+    let mut output = make_writer(
+        file,
+        write_buf,
+        disk_batch,
+        config.use_sparse,
+        begin.append_offset,
+    )?;
     let bytes_written = data.len() as u64;
 
     let mut checksum_verifier = begin.checksum_verifier.take();
@@ -235,9 +247,16 @@ fn open_output_file(
 /// submission and the buffered fallback.
 ///
 /// Selects io_uring when (a) the disk thread holds an active
-/// [`fast_io::IoUringDiskBatch`] and (b) sparse mode is disabled. Sparse
-/// mode requires `Seek`, which the batch writer does not provide, so it
-/// always falls back to the buffered variant.
+/// [`fast_io::IoUringDiskBatch`], (b) sparse mode is disabled, and (c) the
+/// file does not start at a non-zero offset (append mode). Sparse mode
+/// requires `Seek`, which the batch writer does not provide.
+///
+/// Append mode opens the file and seeks past existing content via
+/// [`std::io::Seek::seek`]. The io_uring batch writer issues SQEs with
+/// absolute offsets starting at 0 and ignores the file position, so it would
+/// overwrite the existing prefix with zeros. Append mode therefore always
+/// falls back to the buffered writer, which honors the seek via
+/// `Write::write_all` on the underlying `File`.
 ///
 /// On the io_uring path, `batch.begin_file(file)` registers the fd with the
 /// ring; the matching `commit_file` happens via [`Writer::finish`].
@@ -247,10 +266,11 @@ fn make_writer<'a>(
     write_buf: &'a mut Vec<u8>,
     disk_batch: Option<&'a mut fast_io::IoUringDiskBatch>,
     use_sparse: bool,
+    append_offset: u64,
 ) -> io::Result<Writer<'a>> {
     #[cfg(all(target_os = "linux", feature = "io_uring"))]
     {
-        if !use_sparse {
+        if !use_sparse && append_offset == 0 {
             if let Some(batch) = disk_batch {
                 batch.begin_file(file)?;
                 return Ok(Writer::IoUring { batch });

--- a/crates/transfer/src/disk_commit/thread.rs
+++ b/crates/transfer/src/disk_commit/thread.rs
@@ -5,8 +5,12 @@
 //! blocks on disk latency.
 //!
 //! When io_uring is available (Linux 5.6+ with the `io_uring` feature), the
-//! thread creates a single [`fast_io::IoUringDiskBatch`] and reuses it across
-//! all file operations, batching writes into `io_uring_enter` syscalls.
+//! thread creates a single [`fast_io::IoUringDiskBatch`] and threads it into
+//! every per-file [`process_file`]/[`process_whole_file`] call so writes are
+//! submitted as batched io_uring SQEs. When the batch is unavailable or sparse
+//! mode is requested, the thread falls back to the buffered writer using a
+//! reusable 256 KB scratch buffer that mirrors upstream's static
+//! `wf_writeBuf` (fileio.c:161).
 
 use std::io;
 use std::thread::{self, JoinHandle};
@@ -124,23 +128,35 @@ fn disk_thread_main(
     config: DiskCommitConfig,
 ) {
     let mut write_buf = Vec::with_capacity(WRITE_BUF_SIZE);
-    let mut _disk_batch = try_create_disk_batch(config.io_uring_policy);
+    let mut disk_batch = try_create_disk_batch(config.io_uring_policy);
 
-    log_io_uring_status(config.io_uring_policy, _disk_batch.is_some());
+    log_io_uring_status(config.io_uring_policy, disk_batch.is_some());
 
     while let Ok(msg) = file_rx.recv() {
         match msg {
             FileMessage::Shutdown => break,
             FileMessage::Begin(begin) => {
-                let result =
-                    process_file(&file_rx, &buf_return_tx, &config, *begin, &mut write_buf);
+                let result = process_file(
+                    &file_rx,
+                    &buf_return_tx,
+                    &config,
+                    *begin,
+                    &mut write_buf,
+                    disk_batch.as_mut(),
+                );
                 if result_tx.send(result).is_err() {
                     break;
                 }
             }
             FileMessage::WholeFile { begin, data } => {
-                let result =
-                    process_whole_file(&buf_return_tx, &config, *begin, data, &mut write_buf);
+                let result = process_whole_file(
+                    &buf_return_tx,
+                    &config,
+                    *begin,
+                    data,
+                    &mut write_buf,
+                    disk_batch.as_mut(),
+                );
                 if result_tx.send(result).is_err() {
                     break;
                 }

--- a/crates/transfer/src/disk_commit/writer.rs
+++ b/crates/transfer/src/disk_commit/writer.rs
@@ -200,6 +200,10 @@ impl<'a> Writer<'a> {
     /// The buffered variant simply drops, closing the file. The io_uring
     /// variant calls `commit_file` to flush, optionally fsync, and detach the
     /// file from the batch.
+    #[cfg_attr(
+        not(all(target_os = "linux", feature = "io_uring")),
+        allow(unused_variables)
+    )]
     pub(super) fn finish(self, do_fsync: bool, file_path: &Path) -> io::Result<()> {
         match self {
             Writer::Buffered(_) => Ok(()),

--- a/crates/transfer/src/disk_commit/writer.rs
+++ b/crates/transfer/src/disk_commit/writer.rs
@@ -3,9 +3,16 @@
 //! Provides `ReusableBufWriter` which reuses an externally-owned buffer,
 //! matching upstream rsync's static `wf_writeBuf` (fileio.c:161). Large
 //! chunks bypass the buffer entirely via `write_all_vectored`.
+//!
+//! The [`Writer`] enum dispatches between `ReusableBufWriter` and
+//! [`fast_io::IoUringDiskBatch`] so the disk-commit hot path can use batched
+//! io_uring submissions when available (Linux 5.6+ with the `io_uring`
+//! feature) while preserving identical semantics for sparse mode and
+//! non-Linux platforms.
 
 use std::fs;
 use std::io::{self, IoSlice, Seek, Write};
+use std::path::Path;
 
 /// Fixed write buffer size matching upstream's `wf_writeBufSize = WRITE_SIZE * 8`
 /// (fileio.c:161). Upstream always uses 256 KB regardless of file size.
@@ -117,5 +124,92 @@ impl Seek for ReusableBufWriter<'_> {
     fn seek(&mut self, pos: io::SeekFrom) -> io::Result<u64> {
         self.flush()?;
         self.file.seek(pos)
+    }
+}
+
+/// Writer variant used by the disk-commit thread for a single file.
+///
+/// `Buffered` uses [`ReusableBufWriter`] backed by the thread's reusable
+/// 256 KB buffer. `IoUring` borrows the disk thread's persistent
+/// [`fast_io::IoUringDiskBatch`] which has already been registered with the
+/// active file via `begin_file`.
+///
+/// Sparse mode requires `Seek`, which `IoUringDiskBatch` does not provide,
+/// so callers must select `Buffered` whenever `use_sparse` is set.
+pub(super) enum Writer<'a> {
+    Buffered(ReusableBufWriter<'a>),
+    #[cfg(all(target_os = "linux", feature = "io_uring"))]
+    IoUring {
+        batch: &'a mut fast_io::IoUringDiskBatch,
+    },
+}
+
+impl<'a> Writer<'a> {
+    /// Returns a `Write + Seek` view of the buffered writer for sparse mode.
+    ///
+    /// Sparse writes require `Seek` to punch holes via `seek(Current(n))`,
+    /// which io_uring's batch writer does not support. Sparse mode therefore
+    /// always uses the buffered variant; this accessor enforces that at the
+    /// type level.
+    pub(super) fn buffered_for_sparse(&mut self) -> &mut ReusableBufWriter<'a> {
+        match self {
+            Writer::Buffered(w) => w,
+            #[cfg(all(target_os = "linux", feature = "io_uring"))]
+            Writer::IoUring { .. } => {
+                debug_assert!(false, "sparse mode must select buffered writer");
+                unreachable!("sparse mode must select buffered writer")
+            }
+        }
+    }
+
+    /// Writes the entire chunk, dispatching to the active variant.
+    pub(super) fn write_chunk(&mut self, data: &[u8]) -> io::Result<()> {
+        match self {
+            Writer::Buffered(w) => w.write_all(data),
+            #[cfg(all(target_os = "linux", feature = "io_uring"))]
+            Writer::IoUring { batch } => batch.write_data(data),
+        }
+    }
+
+    /// Flushes pending data and, when requested, fsyncs the underlying file.
+    ///
+    /// For the io_uring variant this is a no-op: both flush and fsync are
+    /// performed atomically by [`Self::finish`] via the batch's
+    /// `commit_file(do_fsync)`, avoiding a redundant ring submission.
+    pub(super) fn flush_and_sync(&mut self, do_fsync: bool, file_path: &Path) -> io::Result<()> {
+        match self {
+            Writer::Buffered(w) => {
+                if do_fsync {
+                    w.sync().map_err(|e| {
+                        io::Error::new(e.kind(), format!("fsync failed for {file_path:?}: {e}"))
+                    })
+                } else {
+                    w.flush().map_err(|e| {
+                        io::Error::other(format!("flush failed for {file_path:?}: {e}"))
+                    })
+                }
+            }
+            #[cfg(all(target_os = "linux", feature = "io_uring"))]
+            Writer::IoUring { .. } => Ok(()),
+        }
+    }
+
+    /// Releases the writer and, for io_uring, commits the active file (with
+    /// optional fsync) so its file handle can be used for rename/truncate.
+    ///
+    /// The buffered variant simply drops, closing the file. The io_uring
+    /// variant calls `commit_file` to flush, optionally fsync, and detach the
+    /// file from the batch.
+    pub(super) fn finish(self, do_fsync: bool, file_path: &Path) -> io::Result<()> {
+        match self {
+            Writer::Buffered(_) => Ok(()),
+            #[cfg(all(target_os = "linux", feature = "io_uring"))]
+            Writer::IoUring { batch } => batch.commit_file(do_fsync).map(|_| ()).map_err(|e| {
+                io::Error::new(
+                    e.kind(),
+                    format!("io_uring commit failed for {file_path:?}: {e}"),
+                )
+            }),
+        }
     }
 }


### PR DESCRIPTION
## Summary

Closes task #1901.

The disk-commit thread previously instantiated `IoUringDiskBatch` via `try_create_disk_batch()` but assigned it to an unused `_disk_batch` binding (`crates/transfer/src/disk_commit/thread.rs:127`), so every write fell through to the buffered path even when the io_uring policy was `Auto` or `Enabled` on Linux 5.6+. This PR threads the batch into the per-file write hot path so disk writes are submitted as batched io_uring SQEs.

### Changes

- **`crates/transfer/src/disk_commit/writer.rs`** - New `Writer<'a>` enum dispatching between the existing `ReusableBufWriter` (256 KB buffered, `write_vectored` + 8 KB direct-write threshold) and an `IoUring { batch }` variant that borrows the disk thread's persistent `IoUringDiskBatch`. The `IoUring` variant is gated by `#[cfg(all(target_os = "linux", feature = "io_uring"))]` so non-Linux builds never reference it. Methods: `write_chunk`, `flush_and_sync`, `finish`, plus `buffered_for_sparse` accessor for sparse mode (which requires `Seek`, unsupported by the batch).
- **`crates/transfer/src/disk_commit/thread.rs`** - Dropped the underscore from `_disk_batch`, threaded `disk_batch.as_mut()` into both `process_file` and `process_whole_file` on every iteration. Updated stale module doc to describe the io_uring batching path.
- **`crates/transfer/src/disk_commit/process.rs`** - Added `disk_batch: Option<&mut fast_io::IoUringDiskBatch>` parameter to both process functions. Replaced the unconditional `ReusableBufWriter::new` with a `make_writer()` helper that calls `batch.begin_file(file)` and returns the io_uring variant when the batch is present and sparse mode is disabled; otherwise falls back to the buffered writer. Sparse writes go through `output.buffered_for_sparse()`.

### Semantics preserved

- Temp-file commit ordering: `Writer::finish()` calls `commit_file(do_fsync)` which flushes + fsyncs + detaches the file *before* `commit_file()` performs the rename. Buffered path drops the writer (closing the file) before rename, identical to prior behaviour.
- fsync: `do_fsync` flows through `Writer::flush_and_sync` (buffered) and `Writer::finish` (io_uring). On the io_uring path `flush_and_sync` is a no-op so `commit_file` performs flush+fsync atomically in a single SQE submission.
- Error propagation: `io::Result` is preserved end-to-end with `file_path` context attached on fsync/commit errors.

## Test plan

- [ ] CI: fmt + clippy
- [ ] CI: nextest (stable) - existing `disk_commit::tests` cover `DiskCommitConfig::default()` (Auto policy) end-to-end via `spawn_disk_thread` for whole files, multi-chunk, abort, and buffer recycling, exercising both buffered and io_uring code paths
- [ ] CI: Linux musl (stable) - validates io_uring feature compiles and links
- [ ] CI: macOS + Windows (stable) - validates the cfg gate keeps the `IoUring` variant out on non-Linux