### PR TITLE
fix: normalise Windows backslash to forward slash in wire-encoded paths

### DIFF
--- a/crates/protocol/src/flist/entry/accessors.rs
+++ b/crates/protocol/src/flist/entry/accessors.rs
@@ -1,6 +1,8 @@
+use std::borrow::Cow;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+use super::super::wire_path::path_bytes_to_wire;
 use super::FileEntry;
 use super::core::extract_dirname;
 use super::extras::FileEntryExtras;
@@ -94,7 +96,11 @@ impl FileEntry {
         #[cfg(not(unix))]
         {
             let s = self.name.to_string_lossy();
-            let trimmed = s.trim_start_matches('/');
+            // Trim both POSIX `/` and native `\` so behaviour matches the
+            // Unix branch when paths arrive in either form (e.g.
+            // `\\share\foo` from a Windows operand). Wire-form paths
+            // always use `/`, but Windows operands may carry `\`.
+            let trimmed = s.trim_start_matches(|c| c == '/' || c == '\\');
             if trimmed.len() != s.len() {
                 self.name = if trimmed.is_empty() {
                     PathBuf::from(".")
@@ -106,25 +112,26 @@ impl FileEntry {
         }
     }
 
-    /// Returns the path as raw bytes without UTF-8 validation.
+    /// Returns the path as wire-format bytes (rsync filename encoding).
     ///
-    /// This is an optimized accessor for protocol operations that work
-    /// with byte sequences. Use this for sorting, comparison, and wire
-    /// encoding to avoid repeated UTF-8 validation via `name().as_bytes()`.
+    /// Used for sorting, comparison, and wire encoding. On Unix, paths are
+    /// already `/`-separated and the underlying `OsStr` bytes are returned
+    /// without copying (`Cow::Borrowed`). On Windows, native `\` separators
+    /// are translated to `/` to match the rsync wire-format invariant
+    /// (upstream `flist.c:send_file_entry()` writes filename bytes
+    /// verbatim, and upstream's only Windows port runs under Cygwin which
+    /// presents `/`-separated paths). When the input already contains no
+    /// `\` byte, the borrow path is taken without allocation.
     ///
-    /// On Unix, paths are inherently byte sequences (OsStr), so this
-    /// provides zero-copy access. On other platforms, it performs UTF-8
-    /// encoding once rather than validating twice (name() then as_bytes()).
+    /// # Upstream Reference
+    ///
+    /// - `flist.c:534-570` `send_file_entry()` filename emission.
+    /// - `util1.c:955-961` Cygwin POSIX boundary - the only `\` handling
+    ///   in upstream lives there, which oc-rsync does not run under.
     #[inline]
     #[must_use]
-    pub fn name_bytes(&self) -> &[u8] {
-        #[cfg(unix)]
-        {
-            use std::os::unix::ffi::OsStrExt;
-            self.name.as_os_str().as_bytes()
-        }
-        #[cfg(not(unix))]
-        self.name().as_bytes()
+    pub fn name_bytes(&self) -> Cow<'_, [u8]> {
+        path_bytes_to_wire(&self.name)
     }
 
     /// Returns the file size in bytes.

--- a/crates/protocol/src/flist/entry/tests.rs
+++ b/crates/protocol/src/flist/entry/tests.rs
@@ -1184,7 +1184,7 @@ fn strip_leading_slashes_preserves_extras() {
 #[test]
 fn name_bytes_accessor() {
     let entry = FileEntry::new_file("hello.txt".into(), 100, 0o644);
-    assert_eq!(entry.name_bytes(), b"hello.txt");
+    assert_eq!(&*entry.name_bytes(), b"hello.txt");
 }
 
 /// Extras with unicode user/group names.

--- a/crates/protocol/src/flist/mod.rs
+++ b/crates/protocol/src/flist/mod.rs
@@ -43,6 +43,7 @@ mod sort;
 mod state;
 mod trace;
 mod wire_mode;
+mod wire_path;
 mod write;
 
 pub use batched_writer::{BatchConfig, BatchStats, BatchedFileListWriter};

--- a/crates/protocol/src/flist/sort.rs
+++ b/crates/protocol/src/flist/sort.rs
@@ -42,7 +42,7 @@ struct SortKey {
 impl SortKey {
     fn new(index: usize, entry: &FileEntry) -> Self {
         let bytes = entry.name_bytes();
-        let last_slash = memrchr(b'/', bytes).map_or(u32::MAX, |p| p as u32);
+        let last_slash = memrchr(b'/', &bytes).map_or(u32::MAX, |p| p as u32);
         Self {
             index: index as u32,
             is_dir: entry.is_dir(),
@@ -85,7 +85,9 @@ impl SortKey {
 pub fn compare_file_entries(a: &FileEntry, b: &FileEntry) -> Ordering {
     let key_a = SortKey::new(0, a);
     let key_b = SortKey::new(0, b);
-    compare_with_keys(a.name_bytes(), &key_a, b.name_bytes(), &key_b)
+    let bytes_a = a.name_bytes();
+    let bytes_b = b.name_bytes();
+    compare_with_keys(&bytes_a, &key_a, &bytes_b, &key_b)
 }
 
 /// Protocol < 29 comparison: plain byte-for-byte comparison without
@@ -227,10 +229,9 @@ pub fn sort_file_list(file_list: &mut [FileEntry], use_qsort: bool, protocol_pre
         // Protocol < 29: plain lexicographic sort, no file-before-dir.
         // upstream: flist.c:3223 - t_path = t_ITEM at protocol < 29.
         let cmp = |a: &SortKey, b: &SortKey| {
-            compare_with_keys_pre29(
-                file_list[a.index as usize].name_bytes(),
-                file_list[b.index as usize].name_bytes(),
-            )
+            let bytes_a = file_list[a.index as usize].name_bytes();
+            let bytes_b = file_list[b.index as usize].name_bytes();
+            compare_with_keys_pre29(&bytes_a, &bytes_b)
         };
         if use_qsort {
             keys.sort_unstable_by(cmp);
@@ -239,12 +240,9 @@ pub fn sort_file_list(file_list: &mut [FileEntry], use_qsort: bool, protocol_pre
         }
     } else {
         let cmp = |a: &SortKey, b: &SortKey| {
-            compare_with_keys(
-                file_list[a.index as usize].name_bytes(),
-                a,
-                file_list[b.index as usize].name_bytes(),
-                b,
-            )
+            let bytes_a = file_list[a.index as usize].name_bytes();
+            let bytes_b = file_list[b.index as usize].name_bytes();
+            compare_with_keys(&bytes_a, a, &bytes_b, b)
         };
         if use_qsort {
             keys.sort_unstable_by(cmp);
@@ -760,12 +758,14 @@ mod tests {
     fn pre29_dot_first() {
         let dot = make_dir(".");
         let file = make_file("abc.txt");
+        let dot_bytes = dot.name_bytes();
+        let file_bytes = file.name_bytes();
         assert_eq!(
-            compare_with_keys_pre29(dot.name_bytes(), file.name_bytes()),
+            compare_with_keys_pre29(&dot_bytes, &file_bytes),
             Ordering::Less
         );
         assert_eq!(
-            compare_with_keys_pre29(file.name_bytes(), dot.name_bytes()),
+            compare_with_keys_pre29(&file_bytes, &dot_bytes),
             Ordering::Greater
         );
     }

--- a/crates/protocol/src/flist/wire_path.rs
+++ b/crates/protocol/src/flist/wire_path.rs
@@ -1,0 +1,137 @@
+//! Platform-normalized path encoding for the rsync wire protocol.
+//!
+//! On Unix, filesystem paths use `/` as the only separator, so converting a
+//! `Path` to its wire-format byte representation is a zero-copy borrow of the
+//! underlying `OsStr` bytes. On Windows, paths constructed via
+//! [`std::path::PathBuf::push`] or [`std::path::Path::join`] use the native
+//! `\` separator. The rsync wire format requires `/` (upstream
+//! `flist.c:send_file_entry()` writes filename bytes verbatim - upstream's
+//! Windows port runs under Cygwin's POSIX layer, which presents `/`-separated
+//! paths to the application). oc-rsync targets native Win32 directly, so the
+//! sender must perform the separator normalization explicitly.
+//!
+//! This module mirrors the identity-on-Unix / convert-on-Windows pattern of
+//! the sibling `wire_mode` module.
+//!
+//! # Upstream Reference
+//!
+//! - `flist.c:534-570` `send_file_entry()` filename emission - the wire bytes
+//!   are written verbatim with no separator normalisation.
+//! - `util1.c:955-961` `__CYGWIN__` block - the only `\` handling in upstream
+//!   lives on the Cygwin POSIX boundary, which oc-rsync does not run under.
+
+use std::borrow::Cow;
+use std::path::Path;
+
+/// Returns the wire-format byte representation of a filesystem path.
+///
+/// On Unix, this is a zero-copy borrow of the path's `OsStr` bytes.
+///
+/// On non-Unix platforms (Windows), `\` separators are translated to `/` so
+/// the bytes match the format a POSIX peer expects to read on the wire.
+/// Allocation is avoided when the path contains no `\` byte.
+#[cfg(unix)]
+#[inline]
+#[must_use]
+pub(crate) fn path_bytes_to_wire(p: &Path) -> Cow<'_, [u8]> {
+    use std::os::unix::ffi::OsStrExt;
+    Cow::Borrowed(p.as_os_str().as_bytes())
+}
+
+/// Returns the wire-format byte representation of a filesystem path.
+///
+/// On non-Unix platforms (Windows), `\` separators are translated to `/` so
+/// the bytes match the format a POSIX peer expects to read on the wire.
+/// Allocation is avoided when the path contains no `\` byte.
+#[cfg(not(unix))]
+#[inline]
+#[must_use]
+pub(crate) fn path_bytes_to_wire(p: &Path) -> Cow<'_, [u8]> {
+    let raw = p.as_os_str().as_encoded_bytes();
+    if raw.contains(&b'\\') {
+        let mut out = Vec::with_capacity(raw.len());
+        for &b in raw {
+            out.push(if b == b'\\' { b'/' } else { b });
+        }
+        Cow::Owned(out)
+    } else {
+        Cow::Borrowed(raw)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn forward_slash_path_is_identity() {
+        let p = PathBuf::from("subdir/file.txt");
+        let bytes = path_bytes_to_wire(&p);
+        assert_eq!(&*bytes, b"subdir/file.txt");
+    }
+
+    #[test]
+    fn empty_path_yields_empty_bytes() {
+        let p = PathBuf::new();
+        let bytes = path_bytes_to_wire(&p);
+        assert_eq!(&*bytes, b"");
+    }
+
+    #[test]
+    fn dot_path_is_identity() {
+        let p = PathBuf::from(".");
+        let bytes = path_bytes_to_wire(&p);
+        assert_eq!(&*bytes, b".");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unix_borrows_without_allocation() {
+        let p = PathBuf::from("a/b/c");
+        let bytes = path_bytes_to_wire(&p);
+        assert!(matches!(bytes, Cow::Borrowed(_)));
+        assert_eq!(&*bytes, b"a/b/c");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unix_preserves_backslash_byte_in_filename() {
+        // On Unix, `\` is a legitimate filename byte and must NOT be rewritten.
+        let p = PathBuf::from("weird\\name");
+        let bytes = path_bytes_to_wire(&p);
+        assert_eq!(&*bytes, b"weird\\name");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_backslash_is_translated_to_forward_slash() {
+        let mut p = PathBuf::from("subdir");
+        p.push("file.txt");
+        let bytes = path_bytes_to_wire(&p);
+        assert_eq!(&*bytes, b"subdir/file.txt");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_deep_path_is_translated() {
+        let bytes = path_bytes_to_wire(Path::new("a\\b\\c"));
+        assert_eq!(&*bytes, b"a/b/c");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_already_forward_slash_borrows() {
+        let p = PathBuf::from("a/b/c");
+        let bytes = path_bytes_to_wire(&p);
+        assert!(matches!(bytes, Cow::Borrowed(_)));
+        assert_eq!(&*bytes, b"a/b/c");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_mixed_separators_are_normalized() {
+        let bytes = path_bytes_to_wire(Path::new("a/b\\c/d\\e"));
+        assert_eq!(&*bytes, b"a/b/c/d/e");
+    }
+}

--- a/crates/protocol/src/flist/write/encoding.rs
+++ b/crates/protocol/src/flist/write/encoding.rs
@@ -14,6 +14,7 @@ use super::super::flags::{
     XMIT_RDEV_MINOR_8_PRE30, XMIT_SAME_DEV_PRE30, XMIT_SAME_NAME, XMIT_SAME_RDEV_MAJOR,
     XMIT_TOP_DIR,
 };
+use super::super::wire_path::path_bytes_to_wire;
 use super::FileListWriter;
 
 impl FileListWriter {
@@ -112,10 +113,14 @@ impl FileListWriter {
         }
 
         if let Some(target) = entry.link_target() {
-            let target_bytes = target.as_os_str().as_encoded_bytes();
+            // Symlink targets use the same wire-form normalisation as filenames:
+            // any platform-native backslash separators are translated to forward
+            // slashes before transmission.
+            // upstream: flist.c:send_file_entry() lines 660-670 and util1.c:955-961
+            let target_bytes = path_bytes_to_wire(target.as_path());
             let len = target_bytes.len();
             write_varint30_int(writer, len as i32, self.protocol.as_u8())?;
-            writer.write_all(target_bytes)?;
+            writer.write_all(&target_bytes)?;
         }
 
         Ok(())

--- a/crates/protocol/src/flist/write/mod.rs
+++ b/crates/protocol/src/flist/write/mod.rs
@@ -374,7 +374,7 @@ impl FileListWriter {
     /// See `flist.c:send_file_entry()` lines 470-750 for the complete wire encoding.
     pub fn write_entry<W: Write>(&mut self, writer: &mut W, entry: &FileEntry) -> io::Result<()> {
         let raw_name = entry.name_bytes();
-        let name = self.apply_encoding_conversion(raw_name)?;
+        let name = self.apply_encoding_conversion(&raw_name)?;
 
         let same_len = self.state.calculate_name_prefix_len(&name);
         let suffix_len = name.len() - same_len;

--- a/crates/protocol/src/flist/write/tests.rs
+++ b/crates/protocol/src/flist/write/tests.rs
@@ -2759,3 +2759,92 @@ fn xattr_emission_suppressed_when_peer_lacks_xattr_capability() {
         buf_suppressed.len(),
     );
 }
+
+/// Regression for #1905 / #1939.
+///
+/// On every platform, the wire-encoded filename must NEVER contain a backslash
+/// byte. POSIX peers expect `/` as the only separator (upstream `flist.c`
+/// writes filename bytes verbatim, and upstream's only Windows port runs
+/// under Cygwin which presents `/`-separated paths to the writer).
+#[test]
+fn wire_encoded_filename_never_contains_backslash_byte() {
+    use std::path::PathBuf;
+
+    // Construct a path the same way an enumeration loop would on the host:
+    // `PathBuf::push` uses the native separator on Windows.
+    let mut path = PathBuf::from("subdir");
+    path.push("file.txt");
+
+    let mut buf = Vec::new();
+    let mut writer = FileListWriter::new(test_protocol());
+    let entry = FileEntry::new_file(path, 100, 0o644);
+
+    writer.write_entry(&mut buf, &entry).unwrap();
+
+    assert!(
+        !buf.contains(&b'\\'),
+        "wire-encoded entry must not contain a `\\` byte, got: {buf:?}",
+    );
+    let needle = b"subdir/file.txt";
+    assert!(
+        buf.windows(needle.len()).any(|w| w == needle),
+        "wire-encoded entry must contain the forward-slash form `subdir/file.txt`, got: {buf:?}",
+    );
+}
+
+/// Regression for #1905 / #1939: roundtrip via the reader must yield a
+/// `/`-separated name regardless of the host platform that produced the bytes.
+#[test]
+fn wire_filename_roundtrip_yields_forward_slashes() {
+    use super::super::read::FileListReader;
+    use std::io::Cursor;
+    use std::path::PathBuf;
+
+    let mut path = PathBuf::from("a");
+    path.push("b");
+    path.push("c.txt");
+
+    let protocol = test_protocol();
+    let mut buf = Vec::new();
+    let mut writer = FileListWriter::new(protocol);
+    let entry = FileEntry::new_file(path, 42, 0o644);
+
+    writer.write_entry(&mut buf, &entry).unwrap();
+    writer.write_end(&mut buf, None).unwrap();
+
+    let mut cursor = Cursor::new(&buf[..]);
+    let mut reader = FileListReader::new(protocol);
+    let read_entry = reader.read_entry(&mut cursor).unwrap().unwrap();
+
+    assert_eq!(read_entry.name(), "a/b/c.txt");
+    assert_eq!(read_entry.size(), 42);
+}
+
+/// Regression for #1905 / #1939: symlink targets must also be normalised.
+/// A Windows-side relative symlink target like `sub\target.txt` would emit
+/// raw bytes containing `\` without normalisation; this asserts the helper is
+/// applied on the symlink-target write path too.
+#[test]
+fn wire_encoded_symlink_target_never_contains_backslash_byte() {
+    use std::path::PathBuf;
+
+    let mut target = PathBuf::from("sub");
+    target.push("target.txt");
+
+    let mut entry = FileEntry::new_symlink("link".into(), target);
+    entry.set_mtime(0, 0);
+
+    let mut buf = Vec::new();
+    let mut writer = FileListWriter::new(test_protocol()).with_preserve_links(true);
+    writer.write_entry(&mut buf, &entry).unwrap();
+
+    assert!(
+        !buf.contains(&b'\\'),
+        "wire-encoded symlink entry must not contain a `\\` byte, got: {buf:?}",
+    );
+    let needle = b"sub/target.txt";
+    assert!(
+        buf.windows(needle.len()).any(|w| w == needle),
+        "symlink target must be forward-slash form `sub/target.txt`, got: {buf:?}",
+    );
+}

--- a/docs/audits/windows-path.md
+++ b/docs/audits/windows-path.md
@@ -1,0 +1,171 @@
+# Windows Backslash Wire-Encoding Audit
+
+Investigation of the user claim filed in tasks #1905 and #1939 that Windows
+filesystem path separators (`\`) leak into wire-encoded filenames sent by
+oc-rsync, breaking transfers from a Windows sender to a non-Windows
+receiver.
+
+Last updated: 2026-04-29
+Tracks: #1905 (fix) and #1939 (this audit)
+Companion audit: `docs/audits/windows-path-normalization.md` (#1842)
+
+## Verdict
+
+**BUG CONFIRMED.** Severity: **HIGH**.
+
+A Windows oc-rsync sender that builds a `FileEntry` whose path was
+constructed via `Path::join` / `PathBuf::push` (the normal case for
+recursive transfers) emits the native string with `\` separators
+verbatim on the wire. A POSIX rsync receiver decoding these bytes
+treats every `\` as part of a single filename, producing one literal
+filename per source file instead of the expected directory hierarchy.
+
+This finding mirrors and expands F1 in the existing
+`windows-path-normalization.md` audit (#1842), which classified F1 as
+HIGH but deferred the fix because it changes wire-encoded bytes.
+
+## Reproducer
+
+```rust
+#[cfg(windows)]
+#[test]
+fn windows_path_uses_forward_slash_on_wire() {
+    use protocol::flist::{FileEntry, FileType};
+    use std::path::PathBuf;
+
+    let mut path = PathBuf::from("subdir");
+    path.push("file.txt");                // Windows: now stored as `subdir\file.txt`
+
+    let entry = FileEntry::new_file(path, 1024, 0o644);
+    assert_eq!(entry.name_bytes(), b"subdir/file.txt"); // FAILS today: returns b"subdir\\file.txt"
+}
+```
+
+The same byte stream reaches the receiver via
+`crates/protocol/src/flist/write/mod.rs:376`:
+
+```rust
+let raw_name = entry.name_bytes();
+let name = self.apply_encoding_conversion(raw_name)?;
+// ...
+writer.write_all(&name[same_len..])?;        // mod.rs eventually -> encoding.rs:97
+```
+
+A Linux receiver of the bytes `subdir\file.txt` then writes a single
+15-byte file named literally `subdir\file.txt`, with the backslash
+embedded in the filename. The destination directory hierarchy
+(`subdir/file.txt`) is not created.
+
+## Wire-format Invariant
+
+Upstream rsync 3.4.1, `flist.c:534-570` (`send_file_entry`):
+
+```c
+if (xflags & XMIT_SAME_NAME)
+    write_byte(f, l1);
+if (xflags & XMIT_LONG_NAME)
+    write_varint30(f, l2);
+else
+    write_byte(f, l2);
+write_buf(f, fname + l1, l2);
+```
+
+`write_buf` writes `fname + l1` for `l2` bytes verbatim - the
+filename bytes go on the wire untouched. Upstream does not normalise
+separators at this layer because every upstream build either runs on a
+POSIX kernel (paths are already `/`-separated) or runs under Cygwin,
+whose POSIX layer presents `/`-separated paths to the application
+before this code is reached.
+
+oc-rsync targets native Win32 (`windows-msvc`, `windows-gnu`) where no
+such layer exists. The wire format remains `/` because both POSIX and
+Cygwin senders produce it, but the sender is responsible for producing
+those bytes. The bug is therefore on the oc-rsync sender side and not
+a wire-protocol divergence.
+
+## Affected Code
+
+All sites are in `crates/protocol/src/flist/`. None of them perform
+separator normalisation on Windows.
+
+| File | Line(s) | Purpose | Carries `\` on Windows? |
+|---|---|---|---|
+| `entry/accessors.rs` | 120-128 | `name_bytes()` accessor used by every wire write site | YES (root cause) |
+| `entry/accessors.rs` | 77-107 | `strip_leading_slashes()` Windows branch trims `/` only | YES (does not strip leading `\`) |
+| `write/encoding.rs` | 105-122 | `write_symlink_target()` writes `target.as_os_str().as_encoded_bytes()` verbatim | YES (Windows symlink targets carry `\`) |
+| `write/mod.rs` | 376 | `write_entry()` calls `entry.name_bytes()` and forwards the bytes through `apply_encoding_conversion` to `write_name` | Inherits the bug from `name_bytes()` |
+| `sort.rs` | 44, 88, 231-245, 764-768 | Sort comparison uses `name_bytes()` | Stable across platforms only after the fix |
+
+## Remediation
+
+Add a single-purpose helper that mirrors the existing `wire_mode.rs`
+identity-on-Unix / convert-on-Windows pattern:
+
+```rust
+// crates/protocol/src/flist/wire_path.rs
+
+#[cfg(unix)]
+pub(crate) fn path_bytes_to_wire(p: &std::path::Path) -> std::borrow::Cow<'_, [u8]> {
+    use std::os::unix::ffi::OsStrExt;
+    std::borrow::Cow::Borrowed(p.as_os_str().as_bytes())
+}
+
+#[cfg(not(unix))]
+pub(crate) fn path_bytes_to_wire(p: &std::path::Path) -> std::borrow::Cow<'_, [u8]> {
+    let s = p.to_string_lossy();
+    if s.as_bytes().contains(&b'\\') {
+        std::borrow::Cow::Owned(s.as_bytes().iter().map(|&b| if b == b'\\' { b'/' } else { b }).collect())
+    } else {
+        std::borrow::Cow::Owned(s.into_owned().into_bytes())
+    }
+}
+```
+
+Apply this helper at every wire-encode call site:
+
+1. `entry::FileEntry::name_bytes()` - return wire-format bytes. Because
+   the helper may need to allocate on Windows the accessor changes
+   signature from `&[u8]` to `Cow<'_, [u8]>`. Sort comparators in
+   `sort.rs` borrow the inner slice; they continue to work unchanged
+   because sort keys are still `&[u8]` borrowed from the `Cow`.
+2. `entry::FileEntry::strip_leading_slashes()` - the Windows branch
+   must trim both `/` and `\` so that `--relative` pre-strip behaves
+   the same on Windows as on POSIX.
+3. `write::encoding::write_symlink_target()` - call the helper for the
+   target's bytes. Targets are paths and follow the same convention.
+
+Testing:
+
+- `#[cfg(windows)]` unit test asserting `path_bytes_to_wire` returns
+  `b"a/b/c"` for `Path::new("a\\b\\c")`.
+- `#[cfg(windows)]` integration test that builds a `FileEntry` via
+  `PathBuf::push`, writes it through `FileListWriter`, reads the bytes
+  back, and asserts no `\` byte appears anywhere in the encoded
+  filename.
+- Roundtrip: a writer-then-reader test that asserts the decoded entry
+  yields a `name()` of `subdir/file.txt` regardless of host platform.
+- Identity test on Unix: the helper performs zero allocation when the
+  input is already `/`-separated (asserted via
+  `matches!(_, Cow::Borrowed(_))` on Unix only).
+
+## Why this is "fix only" and the audit goes in this PR
+
+The companion audit `windows-path-normalization.md` (HIGH severity F1)
+was filed without code changes because the fix touches wire-encoded
+bytes and required dedicated regression coverage. This PR closes that
+loop by shipping the helper, the call-site changes, and the regression
+tests in one atomic change. The file `docs/audits/windows-path.md`
+serves as the per-fix audit-of-record citing #1905 and #1939.
+
+## References
+
+- Upstream `flist.c:534-570` (`send_file_entry` filename emission).
+- Upstream `flist.c:570` (`write_buf(f, fname + l1, l2)` - the wire
+  bytes are written without any separator normalisation).
+- Upstream `util1.c:955-961` `__CYGWIN__` block (Cygwin's two-leading-
+  slash preservation - the only `\` handling in upstream is on the
+  Cygwin POSIX boundary, which oc-rsync does not run under).
+- oc-rsync `crates/protocol/src/flist/wire_mode.rs` (the
+  identity-on-Unix / convert-on-Windows precedent this fix copies).
+- oc-rsync `docs/audits/windows-path-normalization.md` F1 (the prior
+  classification of the same bug).


### PR DESCRIPTION
## Summary

A Windows oc-rsync sender that builds a `FileEntry` whose path was constructed via `Path::join` / `PathBuf::push` (the normal case for recursive transfers) emitted the native string with `\` separators verbatim on the wire. A POSIX rsync receiver decoding those bytes treated every `\` as part of a single filename, producing one literal filename per source file instead of the expected directory hierarchy.

Upstream rsync 3.4.1 writes filename bytes verbatim in `flist.c:send_file_entry()` (lines 534-570). The wire format remains `/`-separated because every upstream build either runs on a POSIX kernel or under Cygwin's POSIX layer, which presents `/`-separated paths to the application before this code is reached. oc-rsync targets native Win32 directly, so the sender must perform the separator normalisation explicitly.

Closes #1905
Refs #1939

## Before / After bytes

On Windows, with `let mut path = PathBuf::from("subdir"); path.push("file.txt");`:

```
Before: entry.name_bytes() == b"subdir\\file.txt"   (wrong — leaks `\` to the wire)
After:  entry.name_bytes() == b"subdir/file.txt"    (matches upstream wire format)
```

End-to-end byte stream emitted by `FileListWriter::write_entry`:

```
Before: ... 0f 73 75 62 64 69 72 5c 66 69 6c 65 2e 74 78 74 ...   (note 0x5c = '\\')
After:  ... 0f 73 75 62 64 69 72 2f 66 69 6c 65 2e 74 78 74 ...   (note 0x2f = '/')
```

## Changes

- New `crates/protocol/src/flist/wire_path.rs` with `path_bytes_to_wire` helper. Borrows on Unix (zero allocation), translates `\` to `/` on Windows (allocates only when needed).
- `FileEntry::name_bytes()` now returns `Cow<'_, [u8]>` and routes through the helper.
- `write_symlink_target()` routes the symlink target through the same helper.
- `strip_leading_slashes()` Windows branch now also trims `\` so `--relative` pre-strip behaves uniformly.
- Sort comparators borrow the inner slice via `Deref`.

## Tests added

- `wire_path` module: 8 unit tests (forward-slash identity, empty, dot, Unix borrow, Unix `\`-as-filename preservation, Windows translation, mixed separators, already-forward borrow).
- `flist::write` regression tests: assert the wire-encoded filename and symlink target contain no `\` byte and a writer-then-reader roundtrip yields `a/b/c.txt`.

## Audit

Companion audit `docs/audits/windows-path.md` (severity HIGH) cites upstream `flist.c:534-570` and `util1.c:955-961` for the wire-format invariant.

## Test plan

- [ ] CI fmt + clippy on Linux/macOS/Windows
- [ ] CI nextest on Linux/macOS/Windows (the new regression tests run on every host)
- [ ] CI interop validation