### PR TITLE
feat: add AppleDouble filter and optional xattr merge for macOS

### DIFF
--- a/crates/cli/src/frontend/arguments/parsed_args/mod.rs
+++ b/crates/cli/src/frontend/arguments/parsed_args/mod.rs
@@ -376,6 +376,9 @@ pub struct ParsedArgs {
     /// `--cvs-exclude`, `-C` - use CVS-style ignore patterns.
     pub cvs_exclude: bool,
 
+    /// `--apple-double-skip` - exclude macOS AppleDouble (`._*`) sidecar files.
+    pub apple_double_skip: bool,
+
     /// `-F` (repeatable) - rsync filter shortcut count.
     pub rsync_filter_shortcuts: usize,
 

--- a/crates/cli/src/frontend/arguments/parser/mod.rs
+++ b/crates/cli/src/frontend/arguments/parser/mod.rs
@@ -575,6 +575,7 @@ where
     let rsync_filter_shortcuts = rsync_filter_indices.len();
     let filter_args = collect_filter_arguments(&filters, &filter_indices, &rsync_filter_indices);
     let cvs_exclude = matches.get_flag("cvs-exclude");
+    let apple_double_skip = matches.get_flag("apple-double-skip");
     let files_from = matches
         .remove_many::<OsString>("files-from")
         .map(Iterator::collect)
@@ -751,6 +752,7 @@ where
         include_from,
         filters: filter_args,
         cvs_exclude,
+        apple_double_skip,
         rsync_filter_shortcuts,
         files_from,
         from0,

--- a/crates/cli/src/frontend/command_builder/sections/transfer_behavior_options.rs
+++ b/crates/cli/src/frontend/command_builder/sections/transfer_behavior_options.rs
@@ -377,6 +377,12 @@ pub(crate) fn add_transfer_behavior_options(command: ClapCommand) -> ClapCommand
                     .action(ArgAction::SetTrue),
             )
             .arg(
+                Arg::new("apple-double-skip")
+                    .long("apple-double-skip")
+                    .help("Skip macOS AppleDouble (._foo) sidecar files.")
+                    .action(ArgAction::SetTrue),
+            )
+            .arg(
                 Arg::new("filter")
                     .long("filter")
                     .short('f')

--- a/crates/cli/src/frontend/defaults.rs
+++ b/crates/cli/src/frontend/defaults.rs
@@ -12,7 +12,7 @@ pub(super) const SUPPORTED_OPTIONS_LIST: &str = concat!(
     "--suffix, --checksum/-c, --checksum-choice, --checksum-seed, --size-only, --ignore-times, --ignore-existing, --existing, ",
     "--ignore-missing-args, --delete-missing-args, --update/-u, --modify-window, --exclude, --exclude-from, ",
     "--include, --include-from, --compare-dest, --copy-dest, --link-dest, --hard-links/-H, --no-hard-links, ",
-    "--cvs-exclude/-C, --filter/-F (including exclude-if-present=FILE), --files-from, --password-file, --no-motd, ",
+    "--cvs-exclude/-C, --apple-double-skip, --filter/-F (including exclude-if-present=FILE), --files-from, --password-file, --no-motd, ",
     "--from0, --no-from0, --bwlimit, --no-bwlimit, --timeout, --contimeout, --stop-after/--time-limit, --stop-at, --sockopts, ",
     "--blocking-io, --no-blocking-io, --protocol, --compress/-z, --no-compress, --compress-level, --compress-choice, ",
     "--skip-compress, --open-noatime, --no-open-noatime, --iconv, --no-iconv, --info, --debug, --verbose/-v, --no-verbose, ",
@@ -75,6 +75,14 @@ pub(super) const CVS_EXCLUDE_PATTERNS: &[&str] = &[
     ".bzr/",
 ];
 
+/// Default patterns excluded by `--apple-double-skip` (macOS AppleDouble sidecars).
+///
+/// These files (`._foo`) carry FinderInfo, resource forks, and extended
+/// attributes for files on filesystems that cannot represent them natively.
+/// They are rarely useful when transferred to other systems and clutter
+/// destinations.
+pub(super) const APPLE_DOUBLE_EXCLUDE_PATTERNS: &[&str] = &["._*"];
+
 /// Timestamp format used for `--list-only` and `--out-format` placeholders.
 pub(crate) const LIST_TIMESTAMP_FORMAT: &[FormatItem<'static>] = format_description!(
     "[year]/[month padding:zero]/[day padding:zero] [hour padding:zero]:[minute padding:zero]:[second padding:zero]"
@@ -130,5 +138,20 @@ mod tests {
     #[test]
     fn list_timestamp_format_not_empty() {
         assert!(!LIST_TIMESTAMP_FORMAT.is_empty());
+    }
+
+    #[test]
+    fn apple_double_exclude_patterns_not_empty() {
+        assert!(!APPLE_DOUBLE_EXCLUDE_PATTERNS.is_empty());
+    }
+
+    #[test]
+    fn apple_double_exclude_patterns_contains_dot_underscore() {
+        assert!(APPLE_DOUBLE_EXCLUDE_PATTERNS.contains(&"._*"));
+    }
+
+    #[test]
+    fn supported_options_list_contains_apple_double_skip() {
+        assert!(SUPPORTED_OPTIONS_LIST.contains("--apple-double-skip"));
     }
 }

--- a/crates/cli/src/frontend/execution/drive/filters.rs
+++ b/crates/cli/src/frontend/execution/drive/filters.rs
@@ -10,8 +10,9 @@ use logging_sink::MessageSink;
 
 use super::messages::fail_with_message;
 use crate::frontend::filter_rules::{
-    FilterDirective, append_cvs_exclude_rules, append_filter_rules_from_files,
-    apply_merge_directive, merge_directive_options, os_string_to_pattern, parse_filter_directive,
+    FilterDirective, append_apple_double_exclude_rules, append_cvs_exclude_rules,
+    append_filter_rules_from_files, apply_merge_directive, merge_directive_options,
+    os_string_to_pattern, parse_filter_directive,
 };
 
 /// Filter configuration supplied by the command line.
@@ -22,6 +23,7 @@ pub(crate) struct FilterInputs {
     pub(crate) includes: Vec<OsString>,
     pub(crate) filters: Vec<OsString>,
     pub(crate) cvs_exclude: bool,
+    pub(crate) apple_double_skip: bool,
 }
 
 /// Applies CLI-provided filter rules to the [`ClientConfigBuilder`].
@@ -66,6 +68,12 @@ where
 
     if inputs.cvs_exclude
         && let Err(message) = append_cvs_exclude_rules(&mut filter_rules)
+    {
+        return Err(fail_with_message(message, stderr));
+    }
+
+    if inputs.apple_double_skip
+        && let Err(message) = append_apple_double_exclude_rules(&mut filter_rules)
     {
         return Err(fail_with_message(message, stderr));
     }

--- a/crates/cli/src/frontend/execution/drive/workflow/run.rs
+++ b/crates/cli/src/frontend/execution/drive/workflow/run.rs
@@ -126,6 +126,7 @@ where
         include_from,
         filters,
         cvs_exclude,
+        apple_double_skip,
         rsync_filter_shortcuts: _,
         files_from,
         from0,
@@ -773,6 +774,7 @@ where
         includes,
         filters,
         cvs_exclude,
+        apple_double_skip,
     };
 
     let builder = match filters::apply_filters(builder, filter_inputs, stderr) {

--- a/crates/cli/src/frontend/filter_rules/apple_double.rs
+++ b/crates/cli/src/frontend/filter_rules/apple_double.rs
@@ -49,7 +49,11 @@ mod tests {
         let mut rules = Vec::new();
         append_apple_double_exclude_rules(&mut rules).unwrap();
         for rule in &rules {
-            assert!(rule.is_perishable(), "rule {} not perishable", rule.pattern());
+            assert!(
+                rule.is_perishable(),
+                "rule {} not perishable",
+                rule.pattern()
+            );
         }
     }
 

--- a/crates/cli/src/frontend/filter_rules/apple_double.rs
+++ b/crates/cli/src/frontend/filter_rules/apple_double.rs
@@ -1,0 +1,64 @@
+//! AppleDouble (`._foo`) sidecar exclusion rules for `--apple-double-skip`.
+//!
+//! Mirrors the structure of [`super::cvs`] but with a single canonical
+//! pattern (`._*`). The rule is marked perishable so that explicit include
+//! rules supplied earlier in the filter chain win under first-match-wins
+//! evaluation, matching the precedence semantics of `--cvs-exclude`.
+//!
+//! See [`crate::frontend::defaults::APPLE_DOUBLE_EXCLUDE_PATTERNS`] for the
+//! authoritative pattern list.
+
+use core::client::FilterRuleSpec;
+use core::message::Message;
+
+use crate::frontend::defaults::APPLE_DOUBLE_EXCLUDE_PATTERNS;
+
+/// Appends AppleDouble sidecar exclusion rules to the destination chain.
+///
+/// The function is infallible today but returns [`Result`] to keep its
+/// signature aligned with [`super::cvs::append_cvs_exclude_rules`] in case
+/// future patterns require I/O.
+pub(crate) fn append_apple_double_exclude_rules(
+    destination: &mut Vec<FilterRuleSpec>,
+) -> Result<(), Message> {
+    for pattern in APPLE_DOUBLE_EXCLUDE_PATTERNS {
+        destination.push(FilterRuleSpec::exclude((*pattern).to_owned()).with_perishable(true));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::client::FilterRuleKind;
+
+    #[test]
+    fn append_apple_double_adds_dot_underscore_pattern() {
+        let mut rules = Vec::new();
+        append_apple_double_exclude_rules(&mut rules).unwrap();
+        assert!(!rules.is_empty());
+        assert!(
+            rules
+                .iter()
+                .any(|rule| rule.kind() == FilterRuleKind::Exclude && rule.pattern() == "._*")
+        );
+    }
+
+    #[test]
+    fn append_apple_double_marks_rules_perishable() {
+        let mut rules = Vec::new();
+        append_apple_double_exclude_rules(&mut rules).unwrap();
+        for rule in &rules {
+            assert!(rule.is_perishable(), "rule {} not perishable", rule.pattern());
+        }
+    }
+
+    #[test]
+    fn append_apple_double_appends_without_clearing_existing() {
+        let mut rules = vec![FilterRuleSpec::include("keep.txt".to_owned())];
+        append_apple_double_exclude_rules(&mut rules).unwrap();
+        assert!(rules.len() >= 2);
+        assert_eq!(rules[0].kind(), FilterRuleKind::Include);
+        assert_eq!(rules[0].pattern(), "keep.txt");
+    }
+}

--- a/crates/cli/src/frontend/filter_rules/mod.rs
+++ b/crates/cli/src/frontend/filter_rules/mod.rs
@@ -1,5 +1,6 @@
 //! Utilities for parsing and loading filter rules supplied via the CLI.
 
+mod apple_double;
 mod arguments;
 mod cvs;
 mod directive;
@@ -7,6 +8,7 @@ mod merge;
 mod parsing;
 mod sources;
 
+pub(crate) use apple_double::append_apple_double_exclude_rules;
 pub(crate) use arguments::{collect_filter_arguments, locate_filter_arguments};
 pub(crate) use cvs::append_cvs_exclude_rules;
 pub(crate) use directive::{FilterDirective, merge_directive_options, os_string_to_pattern};

--- a/crates/cli/src/frontend/help.rs
+++ b/crates/cli/src/frontend/help.rs
@@ -71,6 +71,7 @@ pub(super) fn help_text(program_name: ProgramName) -> String {
             "  -H, --hard-links  Preserve hard links between files.\n",
             "      --no-hard-links  Disable hard link preservation.\n",
             "  -C, --cvs-exclude  Auto-ignore files using CVS-style ignore rules.\n",
+            "      --apple-double-skip  Skip macOS AppleDouble (._foo) sidecar files.\n",
             "      --filter=RULE  Apply filter RULE (supports '+' include, '-' exclude, '!' clear, 'include PATTERN', 'exclude PATTERN', 'show PATTERN'/'S PATTERN', 'hide PATTERN'/'H PATTERN', 'protect PATTERN'/'P PATTERN', 'risk PATTERN'/'R PATTERN', 'exclude-if-present=FILE', 'merge[,MODS] FILE' or '.[,MODS] FILE' with MODS drawn from '+', '-', 'C', 'e', 'n', 'w', 's', 'r', 'p', '/', and 'dir-merge[,MODS] FILE' or ':[,MODS] FILE' with MODS drawn from '+', '-', 'n', 'e', 'w', 's', 'r', 'p', '/', and 'C').\n",
             "  -F            Alias for per-directory .rsync-filter handling (repeat to also load receiver-side files).\n",
             "      --files-from=FILE  Read additional source operands from FILE.\n",

--- a/crates/cli/src/frontend/tests/mod.rs
+++ b/crates/cli/src/frontend/tests/mod.rs
@@ -119,6 +119,8 @@ mod parse_args_no_tests;
 mod parse_args_reads_tests;
 #[path = "parse_args_recognises_append.rs"]
 mod parse_args_recognises_append_tests;
+#[path = "parse_args_recognises_apple_double.rs"]
+mod parse_args_recognises_apple_double_tests;
 #[path = "parse_args_recognises_archive.rs"]
 mod parse_args_recognises_archive_tests;
 #[path = "parse_args_recognises_batch.rs"]
@@ -294,6 +296,8 @@ mod tracing_integration_tests;
 mod transfer_request_copies_tests;
 #[path = "transfer_request_reports.rs"]
 mod transfer_request_reports_tests;
+#[path = "transfer_request_with_apple_double.rs"]
+mod transfer_request_with_apple_double_tests;
 #[path = "transfer_request_with_archive.rs"]
 mod transfer_request_with_archive_tests;
 #[path = "transfer_request_with_bwlimit.rs"]

--- a/crates/cli/src/frontend/tests/parse_args_recognises_apple_double.rs
+++ b/crates/cli/src/frontend/tests/parse_args_recognises_apple_double.rs
@@ -1,0 +1,27 @@
+use super::common::*;
+use super::*;
+
+#[test]
+fn parse_args_recognises_apple_double_skip_flag() {
+    let parsed = parse_args([
+        OsString::from(RSYNC),
+        OsString::from("--apple-double-skip"),
+        OsString::from("source"),
+        OsString::from("dest"),
+    ])
+    .expect("parse");
+
+    assert!(parsed.apple_double_skip);
+}
+
+#[test]
+fn parse_args_apple_double_skip_defaults_off() {
+    let parsed = parse_args([
+        OsString::from(RSYNC),
+        OsString::from("source"),
+        OsString::from("dest"),
+    ])
+    .expect("parse");
+
+    assert!(!parsed.apple_double_skip);
+}

--- a/crates/cli/src/frontend/tests/transfer_request_with_apple_double.rs
+++ b/crates/cli/src/frontend/tests/transfer_request_with_apple_double.rs
@@ -1,0 +1,71 @@
+use super::common::*;
+use super::*;
+
+#[test]
+fn transfer_request_with_apple_double_skip_excludes_dot_underscore_files() {
+    use tempfile::tempdir;
+
+    let _env_lock = ENV_LOCK.lock().expect("env lock");
+    let _home_guard = EnvGuard::set("HOME", OsStr::new(""));
+
+    let tmp = tempdir().expect("tempdir");
+    let source_root = tmp.path().join("source");
+    let dest_root = tmp.path().join("dest");
+    std::fs::create_dir_all(&source_root).expect("create source root");
+    std::fs::create_dir_all(&dest_root).expect("create dest root");
+    std::fs::write(source_root.join("keep.txt"), b"keep").expect("write keep");
+    std::fs::write(source_root.join("._keep.txt"), b"sidecar").expect("write sidecar");
+    let nested = source_root.join("nested");
+    std::fs::create_dir_all(&nested).expect("create nested");
+    std::fs::write(nested.join("data.bin"), b"data").expect("write data");
+    std::fs::write(nested.join("._data.bin"), b"sidecar").expect("write nested sidecar");
+
+    let (code, stdout, stderr) = run_with_args([
+        OsString::from(RSYNC),
+        OsString::from("-r"),
+        OsString::from("--apple-double-skip"),
+        source_root.into_os_string(),
+        dest_root.clone().into_os_string(),
+    ]);
+
+    assert_eq!(code, 0);
+    assert!(stdout.is_empty());
+    assert!(stderr.is_empty());
+
+    let copied_root = dest_root.join("source");
+    assert!(copied_root.join("keep.txt").exists());
+    assert!(!copied_root.join("._keep.txt").exists());
+    assert!(copied_root.join("nested/data.bin").exists());
+    assert!(!copied_root.join("nested/._data.bin").exists());
+}
+
+#[test]
+fn transfer_request_without_apple_double_skip_includes_dot_underscore_files() {
+    use tempfile::tempdir;
+
+    let _env_lock = ENV_LOCK.lock().expect("env lock");
+    let _home_guard = EnvGuard::set("HOME", OsStr::new(""));
+
+    let tmp = tempdir().expect("tempdir");
+    let source_root = tmp.path().join("source");
+    let dest_root = tmp.path().join("dest");
+    std::fs::create_dir_all(&source_root).expect("create source root");
+    std::fs::create_dir_all(&dest_root).expect("create dest root");
+    std::fs::write(source_root.join("keep.txt"), b"keep").expect("write keep");
+    std::fs::write(source_root.join("._keep.txt"), b"sidecar").expect("write sidecar");
+
+    let (code, stdout, stderr) = run_with_args([
+        OsString::from(RSYNC),
+        OsString::from("-r"),
+        source_root.into_os_string(),
+        dest_root.clone().into_os_string(),
+    ]);
+
+    assert_eq!(code, 0);
+    assert!(stdout.is_empty());
+    assert!(stderr.is_empty());
+
+    let copied_root = dest_root.join("source");
+    assert!(copied_root.join("keep.txt").exists());
+    assert!(copied_root.join("._keep.txt").exists());
+}

--- a/crates/cli/tests/argument_defaults_special.rs
+++ b/crates/cli/tests/argument_defaults_special.rs
@@ -248,6 +248,24 @@ fn test_cvs_exclude_defaults_to_false() {
 }
 
 #[test]
+fn test_apple_double_skip_defaults_to_false() {
+    let args = parse_args(["oc-rsync", "src", "dest"]).unwrap();
+    assert!(
+        !args.apple_double_skip,
+        "apple_double_skip should default to false"
+    );
+}
+
+#[test]
+fn test_apple_double_skip_can_be_enabled() {
+    let args = parse_args(["oc-rsync", "--apple-double-skip", "src", "dest"]).unwrap();
+    assert!(
+        args.apple_double_skip,
+        "apple_double_skip should be true when --apple-double-skip flag is passed"
+    );
+}
+
+#[test]
 fn test_from0_defaults_to_false() {
     let args = parse_args(["oc-rsync", "src", "dest"]).unwrap();
     assert!(!args.from0, "from0 should default to false");

--- a/crates/filters/src/apple_double.rs
+++ b/crates/filters/src/apple_double.rs
@@ -1,0 +1,89 @@
+//! AppleDouble (`._foo`) sidecar exclusion patterns for macOS interoperability.
+//!
+//! When macOS writes files to a non-HFS+/APFS filesystem (such as a network
+//! share, FAT32, or many cross-platform mounts) it stores Finder metadata,
+//! resource forks, and extended attributes in a companion file whose name is
+//! the original filename prefixed with `._`. These AppleDouble sidecars are
+//! useful only on the Mac that produced them; replicating them onto a Linux
+//! receiver or back into a fresh macOS xattr space simply litters the
+//! destination with stale metadata. This module supplies the patterns used by
+//! the `--apple-double-skip` option to filter them out.
+//!
+//! # Default Patterns
+//!
+//! The single canonical pattern is `._*`. It is unanchored so that AppleDouble
+//! sidecars are excluded at any directory depth.
+//!
+//! # Perishable Rules
+//!
+//! Like the CVS exclusions, AppleDouble exclusions are marked as perishable
+//! when running on rsync protocol version 30 or higher. Perishable rules can
+//! be overridden by an explicit include rule placed earlier in the filter
+//! chain, mirroring the precedence semantics used for `--cvs-exclude`.
+//!
+//! # References
+//!
+//! - Apple Technical Note TN2078: AppleDouble sidecar layout on non-HFS volumes
+//! - upstream: exclude.c (filter list scaffolding reused for built-in patterns)
+
+/// Default AppleDouble exclusion pattern: any file whose name begins with `._`.
+///
+/// The pattern is unanchored so the rule fires at every directory depth, which
+/// matches the behaviour users expect when they enable `--apple-double-skip`.
+pub const DEFAULT_APPLE_DOUBLE_PATTERN: &str = "._*";
+
+/// Returns an iterator over the default AppleDouble exclusion patterns.
+///
+/// The list is intentionally tiny - only `._*` - but the iterator shape mirrors
+/// [`crate::cvs::default_patterns`] so callers can treat both built-in pattern
+/// sets uniformly.
+///
+/// # Examples
+///
+/// ```
+/// use filters::apple_double::default_patterns;
+///
+/// let patterns: Vec<&str> = default_patterns().collect();
+/// assert_eq!(patterns, vec!["._*"]);
+/// ```
+pub fn default_patterns() -> impl Iterator<Item = &'static str> {
+    std::iter::once(DEFAULT_APPLE_DOUBLE_PATTERN)
+}
+
+/// Returns the number of default AppleDouble exclusion patterns.
+pub fn pattern_count() -> usize {
+    default_patterns().count()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_patterns_contains_apple_double() {
+        let patterns: Vec<&str> = default_patterns().collect();
+        assert!(patterns.contains(&"._*"));
+    }
+
+    #[test]
+    fn default_patterns_count_is_one() {
+        assert_eq!(pattern_count(), 1);
+    }
+
+    #[test]
+    fn default_patterns_no_empty_entries() {
+        for pattern in default_patterns() {
+            assert!(!pattern.is_empty(), "found empty pattern");
+            assert!(
+                !pattern.contains(' '),
+                "pattern contains whitespace: {pattern:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn default_apple_double_pattern_constant_matches_iterator() {
+        let patterns: Vec<&str> = default_patterns().collect();
+        assert_eq!(patterns[0], DEFAULT_APPLE_DOUBLE_PATTERN);
+    }
+}

--- a/crates/filters/src/lib.rs
+++ b/crates/filters/src/lib.rs
@@ -99,6 +99,8 @@
 //! - [`globset`] for the glob matching primitives used internally.
 
 mod action;
+/// AppleDouble (`._foo`) sidecar exclusion patterns for `--apple-double-skip`.
+pub mod apple_double;
 /// Per-directory scoped filter chain with push/pop semantics.
 pub mod chain;
 mod compiled;
@@ -114,12 +116,15 @@ mod rule;
 mod set;
 
 pub use action::FilterAction;
+pub use apple_double::{
+    DEFAULT_APPLE_DOUBLE_PATTERN, default_patterns as apple_double_default_patterns,
+};
 pub use chain::{DirFilterGuard, DirMergeConfig, FilterChain, FilterChainError};
 pub use cvs::{DEFAULT_CVSIGNORE, default_patterns as cvs_default_patterns};
 pub use error::FilterError;
 pub use merge::{MergeFileError, parse_rules, read_rules, read_rules_recursive};
 pub use rule::FilterRule;
-pub use set::{FilterSet, FilterSetError, cvs_exclusion_rules};
+pub use set::{FilterSet, FilterSetError, apple_double_exclusion_rules, cvs_exclusion_rules};
 
 #[cfg(test)]
 mod tests;

--- a/crates/filters/src/set.rs
+++ b/crates/filters/src/set.rs
@@ -261,10 +261,7 @@ impl FilterSet {
     /// assert!(!set.allows(Path::new("._notes.txt"), false));
     /// assert!(set.allows(Path::new("notes.txt"), false));
     /// ```
-    pub fn from_rules_with_apple_double<I>(
-        rules: I,
-        perishable: bool,
-    ) -> Result<Self, FilterError>
+    pub fn from_rules_with_apple_double<I>(rules: I, perishable: bool) -> Result<Self, FilterError>
     where
         I: IntoIterator<Item = FilterRule>,
     {

--- a/crates/filters/src/set.rs
+++ b/crates/filters/src/set.rs
@@ -18,6 +18,7 @@ use std::sync::Arc;
 
 use crate::{
     FilterAction, FilterError, FilterRule, MergeFileError,
+    apple_double::default_patterns as apple_double_default_patterns,
     compiled::{CompiledRule, apply_clear_rule},
     cvs::default_patterns as cvs_default_patterns,
     decision::{DecisionContext, FilterSetInner},
@@ -226,6 +227,52 @@ impl FilterSet {
         Self::from_rules(all_rules)
     }
 
+    /// Builds a [`FilterSet`] from the supplied rules with AppleDouble
+    /// exclusions appended.
+    ///
+    /// AppleDouble (`._foo`) sidecars are macOS metadata companion files
+    /// emitted on filesystems that cannot store extended attributes natively.
+    /// Replicating them across machines is rarely useful and frequently
+    /// undesirable; the `--apple-double-skip` option appends `._*` to the
+    /// filter chain so they are dropped from transfers.
+    ///
+    /// AppleDouble rules are placed at the end of the rule list so explicit
+    /// include rules supplied earlier still win under first-match-wins
+    /// evaluation, matching the precedence used by `--cvs-exclude`.
+    ///
+    /// # Perishable Rules
+    ///
+    /// When `perishable` is `true`, the AppleDouble pattern is marked as
+    /// perishable. This should be `true` for protocol version 30 or higher,
+    /// allowing explicit include rules to override the built-in exclusion.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use filters::{FilterRule, FilterSet};
+    /// use std::path::Path;
+    ///
+    /// let set = FilterSet::from_rules_with_apple_double(
+    ///     [FilterRule::include("notes.txt")],
+    ///     true,
+    /// )
+    /// .unwrap();
+    ///
+    /// assert!(!set.allows(Path::new("._notes.txt"), false));
+    /// assert!(set.allows(Path::new("notes.txt"), false));
+    /// ```
+    pub fn from_rules_with_apple_double<I>(
+        rules: I,
+        perishable: bool,
+    ) -> Result<Self, FilterError>
+    where
+        I: IntoIterator<Item = FilterRule>,
+    {
+        let mut all_rules: Vec<FilterRule> = rules.into_iter().collect();
+        all_rules.extend(apple_double_exclusion_rules(perishable));
+        Self::from_rules(all_rules)
+    }
+
     /// Builds a [`FilterSet`] from rules, expanding merge file references.
     ///
     /// When a merge rule (`. FILE`) is encountered, the referenced file is
@@ -381,6 +428,38 @@ pub fn cvs_exclusion_rules(perishable: bool) -> impl Iterator<Item = FilterRule>
     })
 }
 
+/// Creates filter rules for the default AppleDouble exclusion pattern.
+///
+/// The single canonical pattern is `._*`, which matches any file whose name
+/// begins with `._`. This is the pattern macOS uses to store FinderInfo,
+/// resource forks, and extended attributes alongside files on filesystems
+/// that cannot represent them natively. The patterns mirror the format
+/// surfaced by [`crate::apple_double::default_patterns`].
+///
+/// # Arguments
+///
+/// * `perishable` - If `true`, marks the rules as perishable (overridable by
+///   explicit include rules). This should be `true` for rsync protocol
+///   version 30 or higher to mirror the behaviour of `--cvs-exclude`.
+///
+/// # Examples
+///
+/// ```
+/// use filters::apple_double_exclusion_rules;
+///
+/// let rules: Vec<_> = apple_double_exclusion_rules(false).collect();
+/// assert_eq!(rules.len(), 1);
+/// ```
+pub fn apple_double_exclusion_rules(perishable: bool) -> impl Iterator<Item = FilterRule> {
+    apple_double_default_patterns().map(move |pattern| {
+        let mut rule = FilterRule::exclude(pattern.to_owned());
+        if perishable {
+            rule = rule.with_perishable(true);
+        }
+        rule
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -526,5 +605,60 @@ mod tests {
         // Both explicit and CVS exclusions should work
         assert!(!set.allows(Path::new("notes.txt"), false));
         assert!(!set.allows(Path::new("main.o"), false));
+    }
+
+    // AppleDouble exclusion tests
+
+    #[test]
+    fn apple_double_exclusion_rules_not_empty() {
+        let rules: Vec<_> = apple_double_exclusion_rules(false).collect();
+        assert!(!rules.is_empty());
+    }
+
+    #[test]
+    fn apple_double_exclusion_rules_perishable_flag() {
+        let perishable_rules: Vec<_> = apple_double_exclusion_rules(true).collect();
+        let non_perishable_rules: Vec<_> = apple_double_exclusion_rules(false).collect();
+
+        for rule in &perishable_rules {
+            assert!(rule.is_perishable());
+        }
+        for rule in &non_perishable_rules {
+            assert!(!rule.is_perishable());
+        }
+    }
+
+    #[test]
+    fn from_rules_with_apple_double_excludes_top_level_sidecar() {
+        let set = FilterSet::from_rules_with_apple_double(vec![], false).unwrap();
+        assert!(!set.allows(Path::new("._notes.txt"), false));
+        assert!(!set.allows(Path::new("._DS_Store"), false));
+    }
+
+    #[test]
+    fn from_rules_with_apple_double_excludes_nested_sidecar() {
+        let set = FilterSet::from_rules_with_apple_double(vec![], false).unwrap();
+        assert!(!set.allows(Path::new("subdir/._inner.txt"), false));
+        assert!(!set.allows(Path::new("a/b/c/._deep"), false));
+    }
+
+    #[test]
+    fn from_rules_with_apple_double_allows_normal_files() {
+        let set = FilterSet::from_rules_with_apple_double(vec![], false).unwrap();
+        assert!(set.allows(Path::new("notes.txt"), false));
+        assert!(set.allows(Path::new("subdir/inner.txt"), false));
+        // Files starting with a single dot but not ._ should pass
+        assert!(set.allows(Path::new(".hidden"), false));
+    }
+
+    #[test]
+    fn from_rules_with_apple_double_explicit_include_higher_priority() {
+        // Explicit include rule should take precedence over AppleDouble exclusions
+        // because first-match-wins favours rules supplied earlier.
+        let rules = vec![FilterRule::include("._keep")];
+        let set = FilterSet::from_rules_with_apple_double(rules, false).unwrap();
+        assert!(set.allows(Path::new("._keep"), false));
+        // Non-included sidecars are still excluded.
+        assert!(!set.allows(Path::new("._other"), false));
     }
 }

--- a/crates/filters/tests/apple_double.rs
+++ b/crates/filters/tests/apple_double.rs
@@ -1,0 +1,134 @@
+//! Integration tests for the AppleDouble (`._foo`) sidecar exclusion patterns
+//! exposed by the `--apple-double-skip` option.
+//!
+//! macOS writes AppleDouble sidecar files on filesystems that cannot
+//! represent extended attributes natively (FAT, exFAT, NFS, SMB) to carry
+//! FinderInfo, resource forks, and xattrs alongside their parent file.
+//! Replicating them across machines is rarely useful and frequently clutters
+//! destinations with stale metadata. The `--apple-double-skip` option appends
+//! a single `._*` exclusion to the filter chain. This test module pins down
+//! the user-visible behaviour against [`filters::FilterSet`].
+//!
+//! Reference: Apple Technical Note TN2078 (AppleDouble layout on non-HFS
+//! volumes); upstream rsync `exclude.c` for the filter list scaffolding the
+//! built-in patterns reuse.
+
+use filters::{
+    DEFAULT_APPLE_DOUBLE_PATTERN, FilterRule, FilterSet, apple_double_default_patterns,
+    apple_double_exclusion_rules,
+};
+use std::path::Path;
+
+/// The default pattern set surfaces the canonical `._*` glob.
+#[test]
+fn default_pattern_is_dot_underscore() {
+    let patterns: Vec<&str> = apple_double_default_patterns().collect();
+    assert_eq!(patterns, vec![DEFAULT_APPLE_DOUBLE_PATTERN]);
+    assert_eq!(DEFAULT_APPLE_DOUBLE_PATTERN, "._*");
+}
+
+/// A single canonical pattern keeps the rule list small and predictable.
+#[test]
+fn default_patterns_count_is_one() {
+    assert_eq!(apple_double_default_patterns().count(), 1);
+}
+
+/// `apple_double_exclusion_rules` produces exclude rules with no surprises.
+#[test]
+fn exclusion_rules_are_excludes() {
+    let rules: Vec<FilterRule> = apple_double_exclusion_rules(false).collect();
+    assert!(!rules.is_empty());
+    for rule in &rules {
+        assert_eq!(rule.action(), filters::FilterAction::Exclude);
+    }
+}
+
+/// The perishable flag toggles correctly between true and false.
+#[test]
+fn exclusion_rules_perishable_flag_round_trips() {
+    let perishable: Vec<FilterRule> = apple_double_exclusion_rules(true).collect();
+    let plain: Vec<FilterRule> = apple_double_exclusion_rules(false).collect();
+    assert!(perishable.iter().all(|rule| rule.is_perishable()));
+    assert!(plain.iter().all(|rule| !rule.is_perishable()));
+}
+
+/// AppleDouble sidecars are excluded at the top level.
+#[test]
+fn filter_set_excludes_top_level_sidecars() {
+    let set = FilterSet::from_rules_with_apple_double(Vec::<FilterRule>::new(), false).unwrap();
+    assert!(!set.allows(Path::new("._notes.txt"), false));
+    assert!(!set.allows(Path::new("._photo.jpg"), false));
+    assert!(!set.allows(Path::new("._DS_Store"), false));
+}
+
+/// AppleDouble sidecars are excluded at any depth.
+#[test]
+fn filter_set_excludes_nested_sidecars() {
+    let set = FilterSet::from_rules_with_apple_double(Vec::<FilterRule>::new(), false).unwrap();
+    assert!(!set.allows(Path::new("photos/._holiday.jpg"), false));
+    assert!(!set.allows(Path::new("a/b/c/._deeply_buried"), false));
+}
+
+/// Files that merely start with a single dot are not affected.
+#[test]
+fn filter_set_allows_single_dot_files() {
+    let set = FilterSet::from_rules_with_apple_double(Vec::<FilterRule>::new(), false).unwrap();
+    assert!(set.allows(Path::new(".bashrc"), false));
+    assert!(set.allows(Path::new(".gitignore"), false));
+    assert!(set.allows(Path::new(".hidden"), false));
+}
+
+/// Files whose names happen to contain `._` mid-string still pass.
+#[test]
+fn filter_set_allows_embedded_dot_underscore() {
+    let set = FilterSet::from_rules_with_apple_double(Vec::<FilterRule>::new(), false).unwrap();
+    assert!(set.allows(Path::new("foo._bar"), false));
+    assert!(set.allows(Path::new("dir/foo._bar"), false));
+}
+
+/// Normal data files always pass.
+#[test]
+fn filter_set_allows_normal_files() {
+    let set = FilterSet::from_rules_with_apple_double(Vec::<FilterRule>::new(), false).unwrap();
+    assert!(set.allows(Path::new("notes.txt"), false));
+    assert!(set.allows(Path::new("subdir/inner.txt"), false));
+    assert!(set.allows(Path::new("Photo.jpg"), false));
+}
+
+/// An explicit include placed before the AppleDouble rules wins under the
+/// first-match-wins evaluation strategy.
+#[test]
+fn explicit_include_overrides_apple_double() {
+    let rules = vec![FilterRule::include("._keep")];
+    let set = FilterSet::from_rules_with_apple_double(rules, false).unwrap();
+    assert!(set.allows(Path::new("._keep"), false));
+    // Other sidecars remain excluded.
+    assert!(!set.allows(Path::new("._other"), false));
+}
+
+/// Perishable rules continue to apply during transfers but are skipped during
+/// deletion passes, matching `--cvs-exclude` semantics.
+#[test]
+fn perishable_rules_skip_deletion_pass() {
+    let set = FilterSet::from_rules_with_apple_double(Vec::<FilterRule>::new(), true).unwrap();
+    assert!(!set.allows(Path::new("._notes.txt"), false));
+    assert!(set.allows_deletion(Path::new("._notes.txt"), false));
+}
+
+/// Non-perishable rules apply to both transfer and deletion passes.
+#[test]
+fn non_perishable_rules_apply_to_deletion() {
+    let set = FilterSet::from_rules_with_apple_double(Vec::<FilterRule>::new(), false).unwrap();
+    assert!(!set.allows(Path::new("._notes.txt"), false));
+    assert!(!set.allows_deletion(Path::new("._notes.txt"), false));
+}
+
+/// Combining AppleDouble with a clear rule keeps the built-in exclusion
+/// active because the clear only affects user-supplied rules.
+#[test]
+fn clear_rule_does_not_remove_apple_double() {
+    let rules = vec![FilterRule::exclude("*.custom"), FilterRule::clear()];
+    let set = FilterSet::from_rules_with_apple_double(rules, false).unwrap();
+    assert!(set.allows(Path::new("file.custom"), false));
+    assert!(!set.allows(Path::new("._sidecar"), false));
+}

--- a/docs/oc-rsync.1.md
+++ b/docs/oc-rsync.1.md
@@ -543,6 +543,14 @@ NEON) are used where available, with automatic scalar fallbacks.
 **-C**, **--cvs-exclude**
 :   Auto-ignore files using CVS-style ignore rules.
 
+**--apple-double-skip**
+:   Skip macOS AppleDouble (`._foo`) sidecar files. macOS writes these files on
+    filesystems that cannot represent extended attributes natively (FAT, exFAT,
+    most network shares) to carry FinderInfo, resource forks, and xattrs.
+    Replicating them onto other systems usually clutters destinations with
+    stale metadata; enabling this flag appends `._*` to the filter chain as a
+    perishable exclusion so explicit include rules supplied earlier still win.
+
 **-F**
 :   Shortcut for per-directory .rsync-filter handling. Repeat (**-FF**) to
     also load receiver-side filter files.


### PR DESCRIPTION
## Summary

- Adds `--apple-double-skip` to exclude macOS AppleDouble (`._foo`) sidecar files from transfers via a perishable `._*` rule appended to the filter chain. Upstream rsync 3.4.1 has no equivalent flag (verified against `target/interop/upstream-src/rsync-3.4.1/options.c`), so the descriptive option name is used.
- Wires the option end-to-end: `command_builder` registers the flag, `parser` lifts it onto `ParsedArgs`, the workflow runner threads it into `FilterInputs`, and `apply_filters` appends `filter_rules::append_apple_double_exclude_rules` after the existing CVS branch with matching first-match-wins precedence.
- Adds `filters::apple_double` plus `FilterSet::from_rules_with_apple_double` so library consumers can compose AppleDouble exclusions without going through the CLI.
- Documents the option in the man page (`docs/oc-rsync.1.md`) and the inline `--help` text.

The optional xattr merge half is deferred: the existing `apple-fs` crate exposes only `mkfifo`, `mknod`, and NFC filename normalisation, so the AppleDouble parser/merger needs to land in `apple-fs` first. Follow-up task to be filed alongside this PR.

Refs #1907

## Test plan

- [ ] `crates/filters/tests/apple_double.rs` covers default patterns, perishable behaviour, top-level and nested matching, allow-listing, embedded `._` filenames, perishable-vs-deletion semantics, clear-rule interaction, and explicit-include precedence.
- [ ] Frontend tests `crates/cli/src/frontend/tests/parse_args_recognises_apple_double.rs` and `transfer_request_with_apple_double.rs` exercise CLI parsing and an end-to-end recursive transfer that drops `._foo` while keeping siblings.
- [ ] `crates/cli/tests/argument_defaults_special.rs` pins the default-off and explicit-on parser behaviour.
- [ ] Inline unit tests in `filters::set`, `filters::apple_double`, and `cli::frontend::filter_rules::apple_double` cover the helper APIs.