### PR TITLE
feat: bridge IconvSetting to FilenameConverter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ acl = ["cli/acl", "core/acl"]
 # Extended attributes (xattr) support on Unix systems
 xattr = ["cli/xattr", "core/xattr"]
 # Character encoding conversion for filenames
-iconv = ["core/iconv"]
+iconv = ["cli/iconv", "core/iconv"]
 
 # ============================================================================
 # Performance Optimization Features

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -28,6 +28,13 @@ xattr = ["core/xattr"]
 acl = ["core/acl"]
 
 # ============================================================================
+# Character Encoding Conversion
+# ============================================================================
+# Filename encoding conversion (--iconv). When disabled, --iconv=LOCAL,REMOTE
+# is rejected at config build with a hard error rather than silently no-opping.
+iconv = ["core/iconv"]
+
+# ============================================================================
 # Performance Optimization Features
 # ============================================================================
 

--- a/crates/cli/src/frontend/execution/options/iconv.rs
+++ b/crates/cli/src/frontend/execution/options/iconv.rs
@@ -13,6 +13,19 @@ use core::{
 /// - If `spec` is `Some`, parses the charset specification.
 /// - If `disable` is `true` and no spec is given, returns `Disabled`.
 /// - Otherwise returns `Unspecified`.
+///
+/// When the `iconv` cargo feature is disabled and the user supplies an
+/// explicit `--iconv=LOCAL,REMOTE` (anything other than `--no-iconv` or
+/// absence), this function returns a hard error rather than silently
+/// no-opping. Without this guard, the parsed setting would flow through
+/// `IconvSetting::resolve_converter` and produce `None`, causing
+/// filenames containing non-ASCII bytes to be passed through verbatim
+/// despite the user's explicit conversion request.
+///
+/// # Upstream Reference
+///
+/// - `options.c::recv_iconv_settings` - parses `--iconv=LOCAL,REMOTE`
+/// - `flist.c::iconv_for_local` - applies the converter on the local side
 pub(crate) fn resolve_iconv_setting(
     spec: Option<&OsStr>,
     disable: bool,
@@ -20,7 +33,7 @@ pub(crate) fn resolve_iconv_setting(
     if let Some(value) = spec {
         let text = value.to_string_lossy();
         match IconvSetting::parse(text.as_ref()) {
-            Ok(setting) => Ok(setting),
+            Ok(setting) => accept_parsed_setting(setting),
             Err(error) => {
                 let detail = match error {
                     IconvParseError::EmptySpecification => {
@@ -41,6 +54,23 @@ pub(crate) fn resolve_iconv_setting(
     } else {
         Ok(IconvSetting::Unspecified)
     }
+}
+
+/// Accepts a parsed setting when the `iconv` feature is enabled.
+#[cfg(feature = "iconv")]
+fn accept_parsed_setting(setting: IconvSetting) -> Result<IconvSetting, Message> {
+    Ok(setting)
+}
+
+/// Rejects an explicit iconv setting with a hard error when the `iconv`
+/// feature was disabled at build time. Closes #1915.
+#[cfg(not(feature = "iconv"))]
+fn accept_parsed_setting(_setting: IconvSetting) -> Result<IconvSetting, Message> {
+    Err(rsync_error!(
+        1,
+        "--iconv requires the iconv feature, which was disabled at build time".to_owned()
+    )
+    .with_role(Role::Client))
 }
 
 #[cfg(test)]
@@ -64,6 +94,7 @@ mod tests {
         assert_eq!(result, IconvSetting::Disabled);
     }
 
+    #[cfg(feature = "iconv")]
     #[test]
     fn resolve_iconv_setting_valid_spec() {
         let result = resolve_iconv_setting(Some(&os("UTF-8")), false).unwrap();
@@ -76,6 +107,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "iconv")]
     #[test]
     fn resolve_iconv_setting_both_charsets() {
         let result = resolve_iconv_setting(Some(&os("UTF-8,ISO-8859-1")), false).unwrap();
@@ -94,9 +126,42 @@ mod tests {
         assert!(result.is_err());
     }
 
+    #[cfg(feature = "iconv")]
     #[test]
     fn resolve_iconv_setting_locale_default() {
         let result = resolve_iconv_setting(Some(&os(".")), false).unwrap();
         assert_eq!(result, IconvSetting::LocaleDefault);
+    }
+
+    #[cfg(not(feature = "iconv"))]
+    #[test]
+    fn resolve_iconv_setting_rejects_explicit_when_feature_off() {
+        // Closes #1915 - when the iconv feature is compiled out, an
+        // explicit --iconv=LOCAL,REMOTE must produce a hard error rather
+        // than silently no-opping.
+        let result = resolve_iconv_setting(Some(&os("UTF-8,ISO-8859-1")), false);
+        assert!(result.is_err());
+    }
+
+    #[cfg(not(feature = "iconv"))]
+    #[test]
+    fn resolve_iconv_setting_rejects_locale_default_when_feature_off() {
+        let result = resolve_iconv_setting(Some(&os(".")), false);
+        assert!(result.is_err());
+    }
+
+    #[cfg(not(feature = "iconv"))]
+    #[test]
+    fn resolve_iconv_setting_accepts_no_iconv_when_feature_off() {
+        // --no-iconv must always succeed regardless of feature gating.
+        let result = resolve_iconv_setting(None, true).unwrap();
+        assert_eq!(result, IconvSetting::Disabled);
+    }
+
+    #[cfg(not(feature = "iconv"))]
+    #[test]
+    fn resolve_iconv_setting_accepts_absence_when_feature_off() {
+        let result = resolve_iconv_setting(None, false).unwrap();
+        assert_eq!(result, IconvSetting::Unspecified);
     }
 }

--- a/crates/cli/src/frontend/tests/iconv.rs
+++ b/crates/cli/src/frontend/tests/iconv.rs
@@ -2,6 +2,7 @@ use super::*;
 use crate::frontend::execution::resolve_iconv_setting;
 use std::ffi::OsStr;
 
+#[cfg(feature = "iconv")]
 #[test]
 fn resolve_iconv_setting_parses_explicit_spec() {
     let setting =
@@ -26,4 +27,14 @@ fn resolve_iconv_setting_rejects_empty_spec() {
     let error =
         resolve_iconv_setting(Some(OsStr::new("   ")), false).expect_err("reject empty iconv spec");
     assert!(error.to_string().contains("iconv value must not be empty"));
+}
+
+#[cfg(not(feature = "iconv"))]
+#[test]
+fn resolve_iconv_setting_rejects_explicit_when_feature_disabled() {
+    // Closes #1915 - --iconv must hard-fail rather than silently no-op
+    // when the iconv feature is compiled out.
+    let error = resolve_iconv_setting(Some(OsStr::new("utf8,iso88591")), false)
+        .expect_err("reject iconv spec when feature is disabled");
+    assert!(error.to_string().contains("iconv feature"));
 }

--- a/crates/core/src/client/config/iconv.rs
+++ b/crates/core/src/client/config/iconv.rs
@@ -1,3 +1,4 @@
+use protocol::iconv::{FilenameConverter, converter_from_locale};
 use thiserror::Error;
 
 /// Describes the requested iconv charset conversion behaviour.
@@ -83,6 +84,67 @@ impl IconvSetting {
                     Some(format!("{local},{remote}"))
                 } else {
                     Some(local.clone())
+                }
+            }
+        }
+    }
+
+    /// Resolves the CLI-side iconv setting into a transfer-side
+    /// [`FilenameConverter`].
+    ///
+    /// This is the bridge from the parsed user request
+    /// ([`IconvSetting`] in `core::client::config`) to the in-process
+    /// converter consumed by the transfer crate's file-list reader and
+    /// writer hooks. Without this bridge, `--iconv` parses, validates,
+    /// and is forwarded to the remote peer over SSH, but the local
+    /// process silently passes raw bytes through file-list ingest,
+    /// file-list emit, and filter matching.
+    ///
+    /// Mapping:
+    ///
+    /// - [`IconvSetting::Unspecified`] / [`IconvSetting::Disabled`]
+    ///   resolve to `None`. The receiver and generator skip the iconv
+    ///   hook and operate on raw bytes, matching upstream rsync's
+    ///   behaviour when `--iconv` is absent or `--no-iconv` is supplied.
+    /// - [`IconvSetting::LocaleDefault`] (`--iconv=.`) resolves to
+    ///   [`converter_from_locale`], mirroring upstream
+    ///   `options.c::recv_iconv_settings` which uses the locale's
+    ///   `nl_langinfo(CODESET)` for the local side and UTF-8 for the
+    ///   remote side.
+    /// - [`IconvSetting::Explicit`] resolves via
+    ///   [`FilenameConverter::new`]. When the explicit charsets are
+    ///   not recognised by `encoding_rs`, this returns `None` and emits
+    ///   a `tracing::warn!` (gated on the `tracing` feature) so the
+    ///   transfer falls back to verbatim bytes rather than aborting in
+    ///   the middle of a file list. The CLI parser already validates
+    ///   that the spec is non-empty, so reaching this fallback
+    ///   indicates an unsupported encoding label.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `flist.c::iconv_for_local` (file-list path entry transcode)
+    /// - `options.c::recv_iconv_settings` (parse `--iconv=LOCAL,REMOTE`)
+    /// - `compat.c:716-718` (gates `CF_SYMLINK_ICONV` advertisement on
+    ///   whether iconv is configured)
+    #[must_use]
+    pub fn resolve_converter(&self) -> Option<FilenameConverter> {
+        match self {
+            Self::Unspecified | Self::Disabled => None,
+            Self::LocaleDefault => Some(converter_from_locale()),
+            Self::Explicit { local, remote } => {
+                let remote_charset = remote.as_deref().unwrap_or(".");
+                match FilenameConverter::new(local, remote_charset) {
+                    Ok(converter) => Some(converter),
+                    Err(_error) => {
+                        #[cfg(feature = "tracing")]
+                        tracing::warn!(
+                            local = %local,
+                            remote = %remote_charset,
+                            error = %_error,
+                            "--iconv: unsupported charset; filenames will not be transcoded locally",
+                        );
+                        None
+                    }
                 }
             }
         }
@@ -175,5 +237,65 @@ mod tests {
     fn parse_errors_for_empty_value() {
         let error = IconvSetting::parse("").expect_err("reject");
         assert_eq!(error, IconvParseError::EmptySpecification);
+    }
+
+    #[test]
+    fn resolve_converter_unspecified_is_none() {
+        assert!(IconvSetting::Unspecified.resolve_converter().is_none());
+    }
+
+    #[test]
+    fn resolve_converter_disabled_is_none() {
+        assert!(IconvSetting::Disabled.resolve_converter().is_none());
+    }
+
+    #[test]
+    fn resolve_converter_locale_default_is_some() {
+        let converter = IconvSetting::LocaleDefault
+            .resolve_converter()
+            .expect("locale-default should produce a converter");
+        // Locale-default maps to UTF-8/UTF-8 on most modern systems and
+        // is therefore an identity converter; the only contract here is
+        // that we produce *some* converter (rather than None).
+        assert!(converter.is_identity());
+    }
+
+    #[cfg(feature = "iconv")]
+    #[test]
+    fn resolve_converter_explicit_pair_is_some() {
+        let setting = IconvSetting::Explicit {
+            local: "UTF-8".to_owned(),
+            remote: Some("ISO-8859-1".to_owned()),
+        };
+        let converter = setting
+            .resolve_converter()
+            .expect("explicit pair should resolve to a converter");
+        assert!(!converter.is_identity());
+        assert_eq!(converter.local_encoding_name(), "UTF-8");
+    }
+
+    #[cfg(feature = "iconv")]
+    #[test]
+    fn resolve_converter_explicit_single_uses_locale_remote() {
+        // A single charset means "local only"; the remote side defaults
+        // to the locale (UTF-8), matching upstream rsync's behaviour when
+        // only one side of the pair is specified.
+        let setting = IconvSetting::Explicit {
+            local: "ISO-8859-1".to_owned(),
+            remote: None,
+        };
+        let converter = setting
+            .resolve_converter()
+            .expect("single charset should resolve to a converter");
+        assert!(!converter.is_identity());
+    }
+
+    #[test]
+    fn resolve_converter_malformed_explicit_falls_back_to_none() {
+        let setting = IconvSetting::Explicit {
+            local: "definitely-not-a-real-charset".to_owned(),
+            remote: Some("also-fake".to_owned()),
+        };
+        assert!(setting.resolve_converter().is_none());
     }
 }

--- a/crates/core/src/client/remote/daemon_transfer/orchestration/tests.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/tests.rs
@@ -689,3 +689,86 @@ mod files_from_forwarding_tests {
         assert!(conn.files_from_data.is_none());
     }
 }
+
+mod iconv_bridge {
+    //! Integration tests for the `--iconv` bridge from `IconvSetting`
+    //! to `ConnectionConfig.iconv` (closes #1911).
+
+    use super::*;
+    use crate::client::config::IconvSetting;
+
+    #[test]
+    fn unspecified_setting_leaves_connection_iconv_none() {
+        let config = ClientConfig::builder()
+            .iconv(IconvSetting::Unspecified)
+            .build();
+        let server_config =
+            build_server_config_for_receiver(&config, &["dest".to_owned()], Vec::new()).unwrap();
+        assert!(server_config.connection.iconv.is_none());
+    }
+
+    #[test]
+    fn disabled_setting_leaves_connection_iconv_none() {
+        let config = ClientConfig::builder()
+            .iconv(IconvSetting::Disabled)
+            .build();
+        let server_config =
+            build_server_config_for_receiver(&config, &["dest".to_owned()], Vec::new()).unwrap();
+        assert!(server_config.connection.iconv.is_none());
+    }
+
+    #[cfg(feature = "iconv")]
+    #[test]
+    fn explicit_setting_populates_connection_iconv_for_receiver() {
+        let config = ClientConfig::builder()
+            .iconv(IconvSetting::Explicit {
+                local: "UTF-8".to_owned(),
+                remote: Some("ISO-8859-1".to_owned()),
+            })
+            .build();
+        let server_config =
+            build_server_config_for_receiver(&config, &["dest".to_owned()], Vec::new()).unwrap();
+        let converter = server_config
+            .connection
+            .iconv
+            .expect("--iconv=utf-8,latin1 must produce a converter on the receiver path");
+        assert!(!converter.is_identity());
+        assert_eq!(converter.local_encoding_name(), "UTF-8");
+        assert_eq!(converter.remote_encoding_name(), "windows-1252");
+        // encoding_rs maps "ISO-8859-1" to "windows-1252" per WHATWG spec.
+        // The contract for this bridge is that a non-identity converter
+        // is wired through; the exact label normalisation is owned by
+        // the protocol crate's iconv module.
+    }
+
+    #[cfg(feature = "iconv")]
+    #[test]
+    fn explicit_setting_populates_connection_iconv_for_generator() {
+        let config = ClientConfig::builder()
+            .iconv(IconvSetting::Explicit {
+                local: "UTF-8".to_owned(),
+                remote: Some("ISO-8859-1".to_owned()),
+            })
+            .build();
+        let server_config =
+            build_server_config_for_generator(&config, &["src".to_owned()], Vec::new()).unwrap();
+        assert!(server_config.connection.iconv.is_some());
+    }
+
+    #[cfg(feature = "iconv")]
+    #[test]
+    fn locale_default_setting_populates_connection_iconv() {
+        let config = ClientConfig::builder()
+            .iconv(IconvSetting::LocaleDefault)
+            .build();
+        let server_config =
+            build_server_config_for_receiver(&config, &["dest".to_owned()], Vec::new()).unwrap();
+        let converter = server_config
+            .connection
+            .iconv
+            .expect("--iconv=. must produce a locale-derived converter");
+        // converter_from_locale uses UTF-8 on both sides for portability,
+        // making it an identity converter on most modern systems.
+        assert!(converter.is_identity());
+    }
+}

--- a/crates/core/src/client/remote/flags.rs
+++ b/crates/core/src/client/remote/flags.rs
@@ -219,6 +219,13 @@ pub(crate) fn apply_common_server_flags(config: &ClientConfig, server_config: &m
     // as --log-format=%i, but the local ServerConfig also needs the flag set so
     // the generator's maybe_emit_itemize() produces client-side output via callback.
     server_config.flags.info_flags.itemize = config.itemize_changes();
+    // upstream: flist.c::iconv_for_local and options.c::recv_iconv_settings -
+    // when --iconv is configured, the local process must transcode file-list
+    // entries between the local and remote charsets. Without this bridge the
+    // CLI parses --iconv, validates it, and forwards it to the remote peer
+    // over SSH/daemon, but the in-process file-list reader and writer never
+    // see a converter and silently pass raw bytes through.
+    server_config.connection.iconv = config.iconv().resolve_converter();
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Closes the inert `--iconv` data hazard documented in `docs/audits/iconv-inert.md`. Today the CLI parses `--iconv=utf-8,latin1`, validates it, and forwards it to the remote peer over SSH/daemon, but the local file-list reader and writer hooks always observe `None` and silently pass raw bytes through, producing mojibake on disk and silent filter-rule mismatches.

This PR closes the two remediation tasks called out as in-scope:

- **#1911 (the bridge)**: adds `IconvSetting::resolve_converter() -> Option<FilenameConverter>` next to `IconvSetting::cli_value()` in `crates/core/src/client/config/iconv.rs`, and invokes it from `apply_common_server_flags` in `crates/core/src/client/remote/flags.rs` so every SSH and daemon `ServerConfig` builder populates `ConnectionConfig.iconv`. After this change, the existing dead branches at `crates/transfer/src/receiver/mod.rs:369` and `crates/transfer/src/generator/mod.rs:564` see `Some(converter)` whenever the user supplies `--iconv`.
- **#1915 (hard error when feature off)**: when the `iconv` cargo feature is disabled and the user supplies `--iconv=LOCAL,REMOTE` (or `--iconv=.`), `resolve_iconv_setting` now returns a hard error rather than silently no-opping. Adds a matching `iconv` feature to `crates/cli/Cargo.toml` (propagated from the top-level binary's `iconv` feature) so the CLI can be compiled without iconv.

Tasks #1912 / #1913 / #1914 / #1917 / #1919 are explicitly out of scope and remain open.

## Implementation notes

- `resolve_converter` mapping mirrors the audit's spec exactly:
  - `Unspecified`, `Disabled` -> `None`
  - `LocaleDefault` -> `Some(converter_from_locale())`
  - `Explicit { local, remote }` -> `FilenameConverter::new(&local, remote.unwrap_or("."))`. On unsupported encoding labels, falls back to `None` and emits a `tracing::warn!` (feature-gated) so the transfer continues with verbatim bytes rather than aborting mid-file-list.
- The bridge call site is `apply_common_server_flags` because it is the single point already invoked by all five `build_server_config_for_*` paths (ssh, embedded ssh, daemon receiver, daemon generator).
- Upstream references cited in the new code: `flist.c::iconv_for_local`, `options.c::recv_iconv_settings`, `compat.c:716-718`.

## Test plan

- [x] Unit tests for `IconvSetting::resolve_converter` covering each variant, the locale-default case, the malformed-explicit fallback path, and the iconv-feature-on/off split.
- [x] Integration tests in `crates/core/src/client/remote/daemon_transfer/orchestration/tests.rs` that build a full `ServerConfig` via `build_server_config_for_receiver`/`_generator` with `--iconv=UTF-8,ISO-8859-1` and assert `ConnectionConfig.iconv` is `Some(non_identity)`.
- [x] Hard-error path tested under `#[cfg(not(feature = "iconv"))]` in both `crates/cli/src/frontend/execution/options/iconv.rs` (unit) and `crates/cli/src/frontend/tests/iconv.rs` (integration), plus a positive control verifying `--no-iconv` and absence still succeed.
- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo clippy -p core -p cli -p transfer --all-features --no-deps -- -D warnings` clean.
- [x] `cargo clippy -p cli --no-default-features --no-deps -- -D warnings` clean (one pre-existing `useless_vec` warning in `compression.rs:121` is unrelated to this PR).
- [x] `cargo nextest run -p core -p cli --all-features -E 'test(iconv)'` -> 35 passed.
- [x] `cargo nextest run -p cli --no-default-features -E 'test(iconv)'` -> 17 passed.