### PR TITLE
fix: avoid mmap basis when paired with io_uring writer

### DIFF
--- a/crates/transfer/src/delta_apply/applicator.rs
+++ b/crates/transfer/src/delta_apply/applicator.rs
@@ -26,11 +26,63 @@ type BasisMapStrategy = AdaptiveMapStrategy;
 #[cfg(not(unix))]
 type BasisMapStrategy = BufferedMap;
 
+/// Kind of writer paired with the [`DeltaApplicator`].
+///
+/// Drives the basis-file mapping policy: when the writer is io_uring-backed,
+/// the basis file must be opened via [`BufferedMap`] (a sliding-window
+/// `pread(2)` reader) rather than `mmap(2)`. Submitting an `mmap`-backed
+/// pointer to an `io_uring` SQE has two failure modes:
+///
+/// 1. Cold-page faults are serviced under the SQE submission thread (or the
+///    SQPOLL kernel thread when SQPOLL is enabled), turning a "free" zero-copy
+///    write into a synchronous fault and stalling other in-flight SQEs on the
+///    same poller.
+/// 2. A concurrent truncation of the basis file raises `SIGBUS` while the
+///    kernel is dereferencing the page on our behalf - recovery from
+///    in-kernel `SIGBUS` is not signal-safe.
+///
+/// Upstream rsync deliberately avoids `mmap(2)` for basis files for the same
+/// truncation reason - see `fileio.c:214-217` in upstream rsync 3.4.1.
+///
+/// See `docs/design/basis-file-io-policy.md` and audit
+/// `docs/audits/mmap-iouring-co-usage.md` finding F1.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum BasisWriterKind {
+    /// Standard buffered writer (or any writer not backed by io_uring).
+    ///
+    /// On Unix the basis file is opened with the adaptive strategy, which
+    /// selects `mmap(2)` for files >= 1 MiB. This matches existing behaviour.
+    #[default]
+    Standard,
+    /// io_uring-backed writer (e.g. `IoUringWriter` or `IoUringDiskBatch`).
+    ///
+    /// Forces the basis file onto [`BufferedMap`] regardless of size to keep
+    /// `mmap`-backed pointers out of any io_uring submission queue entry.
+    IoUring,
+}
+
+impl BasisWriterKind {
+    /// Returns true if this writer is io_uring-backed.
+    #[must_use]
+    pub const fn is_io_uring(self) -> bool {
+        matches!(self, Self::IoUring)
+    }
+}
+
 /// Configuration for delta application.
 #[derive(Debug, Clone, Default)]
 pub struct DeltaApplyConfig {
     /// Enable sparse file optimization.
     pub sparse: bool,
+    /// Writer kind paired with this applicator.
+    ///
+    /// Defaults to [`BasisWriterKind::Standard`]. Set to
+    /// [`BasisWriterKind::IoUring`] when the destination writer is an
+    /// io_uring-backed writer (e.g. `IoUringWriter` /
+    /// `IoUringDiskBatch`); the applicator then opens the basis file
+    /// via `BufferedMap` to avoid handing `mmap`-backed pointers to the
+    /// ring. See [`BasisWriterKind`] for the rationale.
+    pub writer_kind: BasisWriterKind,
 }
 
 /// Result of applying a delta to a file.
@@ -54,10 +106,19 @@ pub struct DeltaApplyResult {
 ///
 /// # Performance Optimizations
 ///
-/// - Uses `MapFile` with `BasisMapStrategy` for basis file access:
-///   - Unix: `AdaptiveMapStrategy` - files < 1MB use buffered I/O with 256KB sliding window,
-///     files >= 1MB use memory-mapped for zero-copy access
-///   - Non-Unix: `BufferedMap` - buffered I/O with 256KB sliding window for all files
+/// - Uses `MapFile` with `BasisMapStrategy` for basis file access. The
+///   exact strategy is policy-driven via [`DeltaApplyConfig::writer_kind`]:
+///   - Unix, [`BasisWriterKind::Standard`]: `AdaptiveMapStrategy` -
+///     files < 1MB use buffered I/O (256KB sliding window), files >= 1MB
+///     use mmap for zero-copy access.
+///   - Unix, [`BasisWriterKind::IoUring`]: forced to `BufferedMap` for all
+///     sizes. Submitting an mmap-backed pointer to an io_uring SQE can
+///     stall the SQPOLL kernel thread on cold-page faults and raises
+///     `SIGBUS` on concurrent truncation. Mirrors upstream rsync's
+///     deliberate avoidance of `mmap(2)` for basis files
+///     (`fileio.c:214-217`). See `docs/design/basis-file-io-policy.md`.
+///   - Non-Unix: `BufferedMap` - buffered I/O with 256KB sliding window
+///     for all files.
 /// - Uses `TokenBuffer` for literal data, reusing the same allocation across
 ///   all tokens to avoid per-token heap allocations.
 pub struct DeltaApplicator<'a> {
@@ -77,9 +138,18 @@ impl<'a> DeltaApplicator<'a> {
     /// Creates a new delta applicator.
     ///
     /// If `basis_path` is provided, opens the file once and caches it for
-    /// efficient block reference lookups. Uses `BasisMapStrategy` which:
-    /// - On Unix: automatically selects mmap for files >= 1MB, buffered I/O for smaller
-    /// - On non-Unix: uses buffered I/O for all files
+    /// efficient block reference lookups. Basis-file mapping policy:
+    ///
+    /// - **Unix, standard writer**: `AdaptiveMapStrategy` - mmap for files
+    ///   >= 1 MiB, buffered for smaller (existing behaviour).
+    /// - **Unix, io_uring writer**: forces `BufferedMap` regardless of size.
+    ///   Mmap'd basis pointers must never reach an io_uring SQE: cold-page
+    ///   faults stall the SQPOLL kernel thread, and truncation by another
+    ///   process raises `SIGBUS` inside the kernel SQE service path. Mirrors
+    ///   upstream rsync's `fileio.c:214-217` rationale for using `read(2)`
+    ///   instead of `mmap(2)` on basis files. See
+    ///   `docs/design/basis-file-io-policy.md`.
+    /// - **Non-Unix**: always `BufferedMap` (no mmap path is wired).
     pub fn new(
         output: File,
         config: &DeltaApplyConfig,
@@ -89,9 +159,20 @@ impl<'a> DeltaApplicator<'a> {
     ) -> io::Result<Self> {
         let basis_map = if let Some(path) = basis_path {
             #[cfg(unix)]
-            let map = MapFile::open_adaptive(path);
+            let map = if config.writer_kind.is_io_uring() {
+                // Avoid mmap when paired with io_uring (#1906, audit F1).
+                MapFile::open_adaptive_buffered(path)
+            } else {
+                MapFile::open_adaptive(path)
+            };
             #[cfg(not(unix))]
-            let map = MapFile::<BufferedMap>::open(path);
+            let map = {
+                // BufferedMap is the only basis strategy on non-Unix; the
+                // io_uring path itself is Linux-only, so the writer_kind
+                // signal is consumed indirectly via the cfg gate.
+                let _ = config.writer_kind;
+                MapFile::<BufferedMap>::open(path)
+            };
 
             Some(map.map_err(|e| {
                 io::Error::new(e.kind(), format!("failed to open basis file {path:?}: {e}"))
@@ -109,6 +190,30 @@ impl<'a> DeltaApplicator<'a> {
             token_buffer: TokenBuffer::with_default_capacity(),
             stats: DeltaApplyResult::default(),
         })
+    }
+
+    /// Returns true if a basis file is open and is using the mmap strategy.
+    ///
+    /// Used by tests to verify the policy decision in
+    /// [`Self::new`]: an io_uring-backed writer must never produce a
+    /// mmap-backed basis. See `docs/design/basis-file-io-policy.md`.
+    #[must_use]
+    pub fn basis_uses_mmap(&self) -> bool {
+        #[cfg(unix)]
+        {
+            self.basis_map.as_ref().is_some_and(MapFile::is_mmap)
+        }
+        #[cfg(not(unix))]
+        {
+            // BufferedMap is the only basis strategy on non-Unix.
+            false
+        }
+    }
+
+    /// Returns true if a basis file is open. Used by tests.
+    #[must_use]
+    pub fn has_basis(&self) -> bool {
+        self.basis_map.is_some()
     }
 
     /// Applies literal data.
@@ -138,9 +243,15 @@ impl<'a> DeltaApplicator<'a> {
 
     /// Applies a block reference by copying from basis file.
     ///
-    /// Uses cached `MapFile` with `AdaptiveMapStrategy` for efficient access:
-    /// - Small files (< 1MB): 256KB sliding window buffer
-    /// - Large files (>= 1MB): Zero-copy memory-mapped access
+    /// Uses the cached `MapFile` opened in [`Self::new`]. The mapping
+    /// strategy depends on the configured [`BasisWriterKind`]:
+    /// - Standard writer (Unix): adaptive - 256KB sliding window for files
+    ///   < 1MB, zero-copy mmap for files >= 1MB.
+    /// - io_uring writer: 256KB sliding window via `BufferedMap`,
+    ///   regardless of size, to keep mmap pointers out of any io_uring SQE
+    ///   (audit `docs/audits/mmap-iouring-co-usage.md` finding F1; upstream
+    ///   `fileio.c:214-217`).
+    /// - Non-Unix: 256KB sliding window for all files.
     ///
     /// # Errors
     ///
@@ -342,11 +453,14 @@ pub fn apply_delta_stream<R: Read>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::Write as _;
+    use tempfile::tempdir;
 
     #[test]
     fn delta_apply_config_default() {
         let config = DeltaApplyConfig::default();
         assert!(!config.sparse);
+        assert_eq!(config.writer_kind, BasisWriterKind::Standard);
     }
 
     #[test]
@@ -359,7 +473,98 @@ mod tests {
 
     #[test]
     fn delta_apply_config_sparse_enabled() {
-        let config = DeltaApplyConfig { sparse: true };
+        let config = DeltaApplyConfig {
+            sparse: true,
+            writer_kind: BasisWriterKind::Standard,
+        };
         assert!(config.sparse);
+    }
+
+    #[test]
+    fn basis_writer_kind_io_uring_predicate() {
+        assert!(BasisWriterKind::IoUring.is_io_uring());
+        assert!(!BasisWriterKind::Standard.is_io_uring());
+        assert_eq!(BasisWriterKind::default(), BasisWriterKind::Standard);
+    }
+
+    /// Creates a 2 MiB basis file and an output file, returning paths.
+    /// 2 MiB is above `MMAP_THRESHOLD` (1 MiB) so the adaptive strategy
+    /// would otherwise pick mmap on Unix.
+    fn make_large_basis(dir: &tempfile::TempDir) -> (std::path::PathBuf, File) {
+        let basis_path = dir.path().join("basis.bin");
+        let out_path = dir.path().join("out.bin");
+
+        let basis_bytes = vec![0xA5u8; 2 * 1024 * 1024];
+        let mut basis_file = File::create(&basis_path).expect("create basis");
+        basis_file.write_all(&basis_bytes).expect("write basis");
+        basis_file.sync_all().ok();
+        drop(basis_file);
+
+        let out = File::create(out_path).expect("create out");
+        (basis_path, out)
+    }
+
+    #[test]
+    fn standard_writer_kind_uses_mmap_on_unix_for_large_basis() {
+        let dir = tempdir().expect("tempdir");
+        let (basis_path, out) = make_large_basis(&dir);
+        let config = DeltaApplyConfig {
+            sparse: false,
+            writer_kind: BasisWriterKind::Standard,
+        };
+        let verifier = ChecksumVerifier::for_algorithm(protocol::ChecksumAlgorithm::MD5);
+        let applicator =
+            DeltaApplicator::new(out, &config, verifier, None, Some(basis_path.as_path()))
+                .expect("construct applicator");
+        assert!(applicator.has_basis());
+        // On Unix, AdaptiveMapStrategy picks mmap for files >= 1 MiB.
+        // On non-Unix only BufferedMap exists, so basis_uses_mmap() is
+        // always false.
+        #[cfg(unix)]
+        assert!(
+            applicator.basis_uses_mmap(),
+            "standard writer + 2 MiB basis should pick mmap on Unix"
+        );
+        #[cfg(not(unix))]
+        assert!(!applicator.basis_uses_mmap());
+    }
+
+    #[test]
+    fn io_uring_writer_kind_forces_buffered_basis() {
+        let dir = tempdir().expect("tempdir");
+        let (basis_path, out) = make_large_basis(&dir);
+        let config = DeltaApplyConfig {
+            sparse: false,
+            writer_kind: BasisWriterKind::IoUring,
+        };
+        let verifier = ChecksumVerifier::for_algorithm(protocol::ChecksumAlgorithm::MD5);
+        let applicator =
+            DeltaApplicator::new(out, &config, verifier, None, Some(basis_path.as_path()))
+                .expect("construct applicator");
+        assert!(applicator.has_basis());
+        // The load-bearing invariant: io_uring writer => never mmap basis.
+        // Submitting an mmap-backed pointer to an io_uring SQE either
+        // stalls the SQPOLL kernel thread on cold-page faults or raises
+        // SIGBUS on concurrent truncation (upstream fileio.c:214-217).
+        assert!(
+            !applicator.basis_uses_mmap(),
+            "io_uring writer must force BufferedMap to keep mmap pointers \
+             out of any io_uring SQE (audit F1, fileio.c:214-217)"
+        );
+    }
+
+    #[test]
+    fn applicator_without_basis_reports_no_mmap() {
+        let dir = tempdir().expect("tempdir");
+        let out = File::create(dir.path().join("out.bin")).expect("create out");
+        let config = DeltaApplyConfig {
+            sparse: false,
+            writer_kind: BasisWriterKind::IoUring,
+        };
+        let verifier = ChecksumVerifier::for_algorithm(protocol::ChecksumAlgorithm::MD5);
+        let applicator =
+            DeltaApplicator::new(out, &config, verifier, None, None).expect("construct applicator");
+        assert!(!applicator.has_basis());
+        assert!(!applicator.basis_uses_mmap());
     }
 }

--- a/crates/transfer/src/delta_apply/applicator.rs
+++ b/crates/transfer/src/delta_apply/applicator.rs
@@ -453,7 +453,6 @@ pub fn apply_delta_stream<R: Read>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::io::Write as _;
     use tempfile::tempdir;
 
     #[test]

--- a/crates/transfer/src/delta_apply/mod.rs
+++ b/crates/transfer/src/delta_apply/mod.rs
@@ -30,6 +30,8 @@ mod applicator;
 mod checksum;
 mod sparse;
 
-pub use applicator::{DeltaApplicator, DeltaApplyConfig, DeltaApplyResult, apply_delta_stream};
+pub use applicator::{
+    BasisWriterKind, DeltaApplicator, DeltaApplyConfig, DeltaApplyResult, apply_delta_stream,
+};
 pub use checksum::ChecksumVerifier;
 pub use sparse::SparseWriteState;

--- a/crates/transfer/src/map_file/adaptive.rs
+++ b/crates/transfer/src/map_file/adaptive.rs
@@ -53,6 +53,24 @@ impl AdaptiveMapStrategy {
         }
     }
 
+    /// Opens a file forcing the buffered (non-mmap) variant regardless of size.
+    ///
+    /// Used when the basis file pointer must never reach an io_uring submission
+    /// (cold-page faults can stall the SQPOLL kernel thread, and concurrent
+    /// truncation raises `SIGBUS` inside the kernel SQE service path).
+    /// See `docs/design/basis-file-io-policy.md` and audit
+    /// `docs/audits/mmap-iouring-co-usage.md` finding F1.
+    ///
+    /// Mirrors upstream rsync's deliberate avoidance of `mmap(2)` for basis
+    /// files (`fileio.c:214-217`).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the file cannot be opened.
+    pub fn open_buffered<P: AsRef<Path>>(path: P) -> io::Result<Self> {
+        Ok(Self::Buffered(BufferedMap::open(path)?))
+    }
+
     /// Returns true if using memory-mapped strategy.
     #[must_use]
     pub const fn is_mmap(&self) -> bool {

--- a/crates/transfer/src/map_file/tests.rs
+++ b/crates/transfer/src/map_file/tests.rs
@@ -1604,3 +1604,31 @@ fn mmap_as_slice_empty_file() {
     let slice = strategy.as_slice();
     assert!(slice.is_empty());
 }
+
+/// `open_buffered` forces the `Buffered` variant even for files that the
+/// adaptive selector would otherwise place on `mmap` (>= MMAP_THRESHOLD).
+/// This is the seam used by `DeltaApplicator` when paired with an io_uring
+/// writer (#1906, audit F1).
+#[test]
+fn adaptive_open_buffered_forces_buffered_for_large_file() {
+    // Above MMAP_THRESHOLD (1 MiB) - the adaptive default would pick mmap.
+    let temp = create_test_file((MMAP_THRESHOLD as usize) + 4096);
+
+    let buffered_only = AdaptiveMapStrategy::open_buffered(temp.path()).unwrap();
+    assert!(buffered_only.is_buffered());
+    assert!(!buffered_only.is_mmap());
+
+    // Sanity: the default adaptive open _would_ have picked mmap.
+    let adaptive_default = AdaptiveMapStrategy::open(temp.path()).unwrap();
+    assert!(adaptive_default.is_mmap());
+}
+
+/// `MapFile::open_adaptive_buffered` is the wrapper-level entry point that
+/// `DeltaApplicator::new` calls when `BasisWriterKind::IoUring` is selected.
+#[test]
+fn map_file_open_adaptive_buffered_is_buffered() {
+    let temp = create_test_file((MMAP_THRESHOLD as usize) + 4096);
+    let map = MapFile::open_adaptive_buffered(temp.path()).unwrap();
+    assert!(map.is_buffered());
+    assert!(!map.is_mmap());
+}

--- a/crates/transfer/src/map_file/wrapper.rs
+++ b/crates/transfer/src/map_file/wrapper.rs
@@ -87,6 +87,24 @@ impl MapFile<AdaptiveMapStrategy> {
         })
     }
 
+    /// Opens a file forcing the buffered (non-mmap) variant under the
+    /// `AdaptiveMapStrategy` enum.
+    ///
+    /// Used when the basis file must not be mmap-backed - notably when
+    /// the destination writer is io_uring-backed, where mmap'd pages reaching
+    /// an SQE can stall the SQPOLL kernel thread on cold-page faults or
+    /// raise `SIGBUS` inside the kernel on concurrent truncation. See
+    /// `docs/design/basis-file-io-policy.md`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the file cannot be opened.
+    pub fn open_adaptive_buffered<P: AsRef<Path>>(path: P) -> io::Result<Self> {
+        Ok(Self {
+            strategy: AdaptiveMapStrategy::open_buffered(path)?,
+        })
+    }
+
     /// Returns true if using memory-mapped strategy.
     #[must_use]
     pub fn is_mmap(&self) -> bool {

--- a/crates/transfer/tests/empty_file_handling.rs
+++ b/crates/transfer/tests/empty_file_handling.rs
@@ -213,7 +213,10 @@ fn delta_apply_config_default_works_for_empty() {
 
 #[test]
 fn delta_apply_config_sparse_mode_for_empty() {
-    let config = DeltaApplyConfig { sparse: true };
+    let config = DeltaApplyConfig {
+        sparse: true,
+        ..DeltaApplyConfig::default()
+    };
     assert!(config.sparse, "sparse mode should be enabled");
 }
 

--- a/docs/audits/mmap-iouring-co-usage.md
+++ b/docs/audits/mmap-iouring-co-usage.md
@@ -190,7 +190,14 @@ and is opt-in only via `open_mmap` / `open_adaptive`.
 
 ### F1 - Dormant seam: `DeltaApplicator` would expose mmap'd basis to io_uring if wired
 
-- **Severity:** MEDIUM (latent; HIGH if wired without changes)
+- **Status:** ADDRESSED in #1906 (branch
+  `fix/delta-applicator-buffered-basis-with-iouring`). `DeltaApplyConfig`
+  now carries a `BasisWriterKind` field; selecting `IoUring` forces the
+  basis through `MapFile::open_adaptive_buffered` (always `Buffered`
+  variant) regardless of file size, removing the page-fault stall and
+  `SIGBUS`-on-truncate failure modes for any future caller that wires an
+  io_uring writer to the applicator.
+- **Severity (historic):** MEDIUM (latent; HIGH if wired without changes)
 - **Evidence:**
   - `crates/transfer/src/delta_apply/applicator.rs:92` -
     `MapFile::open_adaptive(path)?` (Unix: mmap when size >= 1 MiB).

--- a/docs/design/basis-file-io-policy.md
+++ b/docs/design/basis-file-io-policy.md
@@ -1,7 +1,11 @@
 # Basis-file I/O policy: mmap vs buffered, with io_uring
 
 Tracking issue: oc-rsync task #1666.
-Companion audit: `docs/audits/mmap-iouring-co-usage.md` (#3440).
+Companion audit: `docs/audits/mmap-iouring-co-usage.md` (#3440, audit
+task #1660).
+Initial implementation (io_uring-pairing axis only):
+oc-rsync task #1906 - "DeltaApplicator: switch basis-file mmap to
+BufferedMap when paired with io_uring writer".
 
 ## Summary
 
@@ -173,6 +177,32 @@ open time proportional to file size, defeating the win.
 
 **Policy:** never use `MAP_POPULATE` to attempt to make mmap "safe."
 Use `B` instead.
+
+## Implementation status
+
+The full `BasisMapInputs` selector remains future work, but the
+io_uring-pairing axis is implemented today (#1906, audit #1660 finding
+F1). `DeltaApplyConfig` now carries a [`BasisWriterKind`] field; when
+the destination writer is io_uring-backed the applicator opens the
+basis via `MapFile::open_adaptive_buffered` (forcing the
+`AdaptiveMapStrategy::Buffered` variant) regardless of file size.
+Standard / std-write writers retain the existing
+`open_adaptive` selection (mmap >= 1 MiB on Unix). This narrows the F1
+hazard from latent-MEDIUM to "unrepresentable in code": no caller can
+construct a `DeltaApplicator` whose io_uring writer sees a
+`MmapStrategy`-backed basis pointer, removing the SQPOLL page-fault
+stall and `SIGBUS`-on-truncate failure modes for the dormant-but-now-
+wireable applicator. The remaining hazard columns from the matrix
+(`--inplace`, `--append`, `--copy-devices`, `sparse_likelihood`,
+`basis_on_network_fs`) still need wiring through `BasisMapInputs`;
+those follow the same pattern.
+
+The implementation entry points:
+
+- `crates/transfer/src/delta_apply/applicator.rs::BasisWriterKind`
+- `crates/transfer/src/delta_apply/applicator.rs::DeltaApplyConfig::writer_kind`
+- `crates/transfer/src/map_file/adaptive.rs::AdaptiveMapStrategy::open_buffered`
+- `crates/transfer/src/map_file/wrapper.rs::MapFile::open_adaptive_buffered`
 
 ## Implementation hooks
 


### PR DESCRIPTION
## Summary

- Closes the F1 hazard from `docs/audits/mmap-iouring-co-usage.md` (#1660): `DeltaApplicator` opened its basis file via `MapFile::open_adaptive`, which selects `mmap(2)` for files >= 1 MiB on Unix. The applicator has no production caller today but is the obvious next target for an io_uring-output rewrite, and submitting an mmap-backed pointer to an io_uring SQE either stalls the SQPOLL kernel thread on cold-page faults or raises `SIGBUS` inside the kernel SQE service path on concurrent truncation. Upstream rsync 3.4.1 sidesteps this entirely (`fileio.c:214-217`).
- Introduces `BasisWriterKind` (`Standard` / `IoUring`) on `DeltaApplyConfig`. When `IoUring` is selected, `DeltaApplicator::new` opens the basis through the new `MapFile::open_adaptive_buffered` constructor, which forces the `AdaptiveMapStrategy::Buffered` variant regardless of size. Standard writers retain the existing adaptive selection. Non-Unix is unaffected (`BufferedMap` is the only basis strategy there).
- Updates `docs/design/basis-file-io-policy.md` with an implementation-status section noting the io_uring-pairing axis is wired; remaining hazard columns (`--inplace`, `--append`, `--copy-devices`, sparse, network FS) are tracked in the same doc as future work. Marks F1 as ADDRESSED in the audit.

Refs: #1906 (this task), #1660 (audit).

## Test plan

- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo clippy -p engine -p transfer -p fast_io --all-features --no-deps -- -D warnings` clean.
- [x] New unit tests in `crates/transfer/src/delta_apply/applicator.rs`:
  - `standard_writer_kind_uses_mmap_on_unix_for_large_basis` - regression: 2 MiB basis + standard writer still picks mmap on Unix.
  - `io_uring_writer_kind_forces_buffered_basis` - load-bearing invariant: 2 MiB basis + io_uring writer never mmap.
  - `applicator_without_basis_reports_no_mmap` - degenerate case.
  - `basis_writer_kind_io_uring_predicate` - enum predicate sanity.
- [x] New tests in `crates/transfer/src/map_file/tests.rs`:
  - `adaptive_open_buffered_forces_buffered_for_large_file` - new `AdaptiveMapStrategy::open_buffered` constructor returns the buffered variant even above `MMAP_THRESHOLD`.
  - `map_file_open_adaptive_buffered_is_buffered` - wrapper-level entry point exposed correctly.
- [ ] Full nextest deferred to CI per project policy.

## Notes

The audit doc's recommended fix matched the existing code closely; `BufferedMap` already exists, and `AdaptiveMapStrategy` already had a `Buffered` variant. No new low-level abstraction was needed - just a constructor (`open_buffered`) that pins the variant choice and a config field plumbed through the applicator. The full `BasisMapInputs` selector sketched in the design doc remains future work; this PR ships only the io_uring-pairing axis (the hazard with the highest blast radius).