### PR TITLE
chore: disable coverage workflow on push/pull_request

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,21 +1,10 @@
 name: Coverage
 
+# Temporarily disabled: nightly llvm-cov 22.1 SIGSEGVs in
+# llvm::coverage::CoverageMapping::getInstantiationGroups - deterministic
+# regression affecting both PR and master runs. Re-enable once a
+# known-good nightly is pinned in RUSTUP_TOOLCHAIN below.
 on:
-  push:
-    branches: [ master, main ]
-    paths:
-      - 'crates/**'
-      - 'src/**'
-      - 'tests/**'
-      - 'Cargo.toml'
-      - '.github/workflows/coverage.yml'
-  pull_request:
-    paths:
-      - 'crates/**'
-      - 'src/**'
-      - 'tests/**'
-      - 'Cargo.toml'
-      - '.github/workflows/coverage.yml'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary
- Restrict `.github/workflows/coverage.yml` to `workflow_dispatch` only
- Nightly llvm-cov 22.1 SIGSEGVs deterministically inside `llvm::coverage::CoverageMapping::getInstantiationGroups`, breaking both master and PR coverage runs
- Re-enable once a known-good nightly is pinned via `RUSTUP_TOOLCHAIN`

## Test plan
- [ ] Verify only `workflow_dispatch` trigger remains
- [ ] Confirm coverage no longer auto-runs on PRs after merge