### PR TITLE
docs(checksums): convert restating comments to rustdoc in rolling (#2018)

### DIFF
--- a/crates/checksums/src/rolling/checksum/tests.rs
+++ b/crates/checksums/src/rolling/checksum/tests.rs
@@ -439,7 +439,6 @@ fn value_format_is_s2_high_s1_low() {
     let s1 = value & 0xFFFF;
     let s2 = (value >> 16) & 0xFFFF;
 
-    // Verify components match digest
     let digest = checksum.digest();
     assert_eq!(s1 as u16, digest.sum1());
     assert_eq!(s2 as u16, digest.sum2());
@@ -481,7 +480,6 @@ fn from_rolling_checksum_ref_for_rolling_digest() {
 
 #[test]
 fn simd_acceleration_available_returns_bool() {
-    // Just verify it doesn't panic and returns a boolean
     let _available = simd_acceleration_available();
 }
 
@@ -591,7 +589,6 @@ fn force_state_sets_internal_values() {
 
 #[test]
 fn default_reader_buffer_len_constant() {
-    // Verify constant is reasonable for efficient I/O
     let len = RollingChecksum::DEFAULT_READER_BUFFER_LEN;
     assert_ne!(len, 0);
     assert!(len >= 1024, "buffer should be at least 1KB, got {len}");
@@ -604,12 +601,10 @@ fn x86_cpu_feature_detection_is_cached() {
     assert!(x86::cpu_features_cached_for_tests());
 }
 
-// ==== Inter-architecture compatibility golden tests ====
-//
-// These tests verify the checksum algorithm produces identical results across all
-// supported architectures (x86 SSE2/AVX2, ARM NEON, scalar fallback). The expected
-// values are computed once and hardcoded, ensuring any SIMD optimization changes
-// don't break compatibility.
+// Golden tests below verify that the checksum algorithm produces identical
+// results across all supported architectures (x86 SSE2/AVX2, ARM NEON, scalar
+// fallback). The expected values are hardcoded, so any SIMD optimisation that
+// drifts from upstream `checksum.c:get_checksum1()` will be caught here.
 
 #[test]
 fn golden_test_empty_input() {
@@ -692,8 +687,7 @@ fn golden_test_ascending_bytes() {
 
 #[test]
 fn golden_test_block_length_700() {
-    // rsync commonly uses 700-byte blocks for small files
-    // Create deterministic data pattern
+    // 700-byte block matches the default block size rsync picks for small files.
     let mut data = vec![0u8; 700];
     for (i, byte) in data.iter_mut().enumerate() {
         *byte = ((i * 31) % 256) as u8;
@@ -722,7 +716,6 @@ fn golden_test_block_length_4096() {
 
 #[test]
 fn golden_test_incremental_matches_full() {
-    // Verify incremental updates produce same result as full update
     let data = b"The quick brown fox jumps over the lazy dog";
 
     let mut full = RollingChecksum::new();
@@ -739,18 +732,14 @@ fn golden_test_incremental_matches_full() {
 
 #[test]
 fn golden_test_roll_produces_expected_value() {
-    // Verify rolling produces correct checksum after shift
     let data = b"ABCDEFGH";
     let mut checksum = RollingChecksum::new();
     checksum.update(&data[0..4]); // "ABCD"
 
-    // Verify initial value
     assert_eq!(checksum.value(), 0x0294_010a);
 
-    // Roll: remove 'A', add 'E'
     checksum.roll(b'A', b'E').unwrap();
 
-    // Should match fresh computation of "BCDE"
     let mut fresh = RollingChecksum::new();
     fresh.update(&data[1..5]);
     assert_eq!(checksum.value(), fresh.value());

--- a/crates/checksums/src/rolling/digest.rs
+++ b/crates/checksums/src/rolling/digest.rs
@@ -294,7 +294,6 @@ mod tests {
         let digest = RollingDigest::from_bytes(data);
         assert_eq!(digest.len(), data.len());
         assert!(!digest.is_empty());
-        // Verify it matches manual computation
         let mut checksum = RollingChecksum::new();
         checksum.update(data);
         assert_eq!(digest, checksum.digest());
@@ -344,7 +343,7 @@ mod tests {
 
     #[test]
     fn rolling_digest_from_value_unpacks_correctly() {
-        // Pack s2 in high 16 bits, s1 in low 16 bits
+        // Mirrors the upstream wire layout: s2 in the high 16 bits, s1 in the low 16 bits.
         let s1: u16 = 0x1234;
         let s2: u16 = 0x5678;
         let packed: u32 = ((s2 as u32) << 16) | (s1 as u32);
@@ -358,7 +357,7 @@ mod tests {
     fn rolling_digest_value_packs_correctly() {
         let digest = RollingDigest::new(0x1234, 0x5678, 100);
         let value = digest.value();
-        // s2 should be in high 16 bits, s1 in low 16 bits
+        // Wire layout: s2 in the high 16 bits, s1 in the low 16 bits.
         assert_eq!(value & 0xFFFF, 0x1234);
         assert_eq!((value >> 16) & 0xFFFF, 0x5678);
     }


### PR DESCRIPTION
## Summary

Task #2018 - comment cleanup pass over `crates/checksums/src/rolling/`.

- Drops decorative banner divider above the inter-architecture golden-test block in `rolling/checksum/tests.rs`; replaces it with a short prose explanation that ties the tests to upstream `checksum.c:get_checksum1()`.
- Removes restating-the-code comments whose information is already conveyed by the surrounding code or test name (e.g. "Verify rolling produces correct checksum after shift", "Just verify it doesn't panic and returns a boolean", "Verify components match digest").
- Sharpens two wire-format comments in `rolling/digest.rs` to spell out their connection to upstream rsync's packed `(s2 << 16) | s1` layout instead of merely echoing the surrounding shift expression.

## Notes

- Production source files in `rolling/` (`mod.rs`, `error.rs`, `digest.rs`, `checksum/mod.rs`, `checksum/x86.rs`, `checksum/neon.rs`) already document every public item with `///` rustdoc, so no `//` -> `///` conversions are required there.
- All SAFETY comments and SIMD weight-table explanations are preserved verbatim.
- No upstream-rsync references were touched.
- Pure rustdoc/comment cleanup; no runtime behaviour changes.
- Scope deliberately excluded `simd_batch`, `parallel`, `pipelined`, and `strong` per task instructions.

## Test plan

- [ ] CI fmt+clippy passes
- [ ] CI nextest (stable) passes
- [ ] CI Windows / macOS / Linux musl builds pass