### PR TITLE
docs(compress): convert restating comments to rustdoc in lz4 (#2026)

### DIFF
--- a/crates/compress/src/lz4/frame.rs
+++ b/crates/compress/src/lz4/frame.rs
@@ -418,7 +418,6 @@ mod tests {
             "flush must produce output in the sink"
         );
 
-        // Write second token
         let token2 = b"incremental decompression test - token two";
         encoder.write(token2).expect("write token 2");
 

--- a/crates/compress/src/lz4/raw.rs
+++ b/crates/compress/src/lz4/raw.rs
@@ -160,14 +160,12 @@ pub fn compress_block(input: &[u8], output: &mut [u8]) -> Result<usize, RawLz4Er
         });
     }
 
-    // Compress into buffer after header space
     let compressed_size = compress_into(input, &mut output[HEADER_SIZE..])?;
 
     if compressed_size > MAX_BLOCK_SIZE {
         return Err(RawLz4Error::CompressedTooLarge(compressed_size));
     }
 
-    // Write header
     let header = encode_header(compressed_size);
     output[0] = header[0];
     output[1] = header[1];
@@ -298,17 +296,14 @@ pub fn read_compressed_block<R: Read>(
         return Err(RawLz4Error::DecompressedSizeTooLarge(max_decompressed_size));
     }
 
-    // Read header
     let mut header = [0u8; HEADER_SIZE];
     reader.read_exact(&mut header)?;
 
     let compressed_size = decode_header(header).ok_or(RawLz4Error::InvalidHeader(header[0]))?;
 
-    // Read compressed data
     let mut compressed = vec![0u8; compressed_size];
     reader.read_exact(&mut compressed)?;
 
-    // Decompress
     let mut output = vec![0u8; max_decompressed_size];
     let size = decompress_into(&compressed, &mut output)?;
     output.truncate(size);
@@ -378,10 +373,8 @@ mod tests {
         let input = b"Hello, rsync wire protocol!";
         let compressed = compress_block_to_vec(input).expect("compress");
 
-        // Verify header
         assert!(is_deflated_data(compressed[0]));
 
-        // Decompress
         let decompressed = decompress_block_to_vec(&compressed, input.len()).expect("decompress");
         assert_eq!(decompressed, input);
     }


### PR DESCRIPTION
## Summary

- Remove inline comments inside lz4 codec function bodies that merely echo the next statement (`// Read header`, `// Read compressed data`, `// Decompress`, `// Compress into buffer after header space`, `// Write header`).
- Drop one duplicate echo comment (`// Write second token`) and a pair of single-word labels (`// Verify header`, `// Decompress`) inside lz4 tests.
- All public items already had `///` rustdoc; upstream rsync references (`// upstream: token.c:DEFLATED_DATA`, `// upstream: token.c:MAX_DATA_COUNT`, `// upstream: token.c - 2-byte header ...`, `# Upstream Reference -> token.c:send_deflated_token()` in frame docs) are preserved verbatim.
- Limited strictly to `crates/compress/src/lz4/{mod,frame,raw}.rs`. No changes to zlib, zstd, strategy, skip_compress, or other compress submodules.
- Comment-only cleanup; no runtime behaviour change.

## Test plan

- [ ] CI fmt+clippy
- [ ] CI nextest (stable)
- [ ] CI Windows / macOS / Linux musl