### PR TITLE
fix(filters): propagate P (protect) filter modifier in sender-side filter exchange

### DIFF
--- a/crates/protocol/src/filters/prefix.rs
+++ b/crates/protocol/src/filters/prefix.rs
@@ -87,12 +87,35 @@ fn build_old_prefix(rule: &FilterRuleWireFormat) -> Option<String> {
 }
 
 /// Builds a prefix for protocol >= 29 (modern, full modifiers).
+///
+/// Protect (`P`) and Risk (`R`) rules are normalized to upstream's wire
+/// representation before transmission. Upstream's `get_rule_prefix()`
+/// (`exclude.c:1536-1572`) only emits `+`, `-`, or `:` as the leading
+/// character; the receiver-side semantics that distinguish a protect rule
+/// from a plain exclude are conveyed exclusively via the `r` modifier flag.
+/// Sending a literal `P` over the wire causes upstream's parser to combine
+/// it with the receiver-side `r` modifier emitted from `applies_to_receiver`,
+/// producing an invalid `Pr` rule (upstream `exclude.c:1270-1271` rejects
+/// `r` after a side-specifying prefix).
+///
+/// upstream: exclude.c:1536-1542 - protect rules emit `-` (exclude semantics).
+/// upstream: exclude.c:1201-1206 - risk rules emit `+` (include semantics).
 fn build_modern_prefix(rule: &FilterRuleWireFormat, protocol: ProtocolVersion) -> String {
+    use super::wire::RuleType;
+
     // Maximum prefix length: type(1) + modifiers(10) + space(1) = 12 chars
     let mut prefix = String::with_capacity(12);
 
-    // First character: rule type
-    prefix.push(rule.rule_type.prefix_char());
+    // First character: rule type, with Protect/Risk normalized to upstream's
+    // wire format. The receiver-side flag (set on FilterRuleSpec::protect /
+    // FilterRuleSpec::risk via applies_to_receiver) is emitted as the `r`
+    // modifier below, matching upstream's send_filter_list().
+    let prefix_char = match rule.rule_type {
+        RuleType::Protect => '-',
+        RuleType::Risk => '+',
+        other => other.prefix_char(),
+    };
+    prefix.push(prefix_char);
 
     // Modifiers (order matters for compatibility)
     if rule.anchored {
@@ -123,12 +146,16 @@ fn build_modern_prefix(rule: &FilterRuleWireFormat, protocol: ProtocolVersion) -
         prefix.push('x');
     }
 
-    // Protocol version gated modifiers
+    // Protocol version gated modifiers. Protect/Risk rule types always emit
+    // the `r` modifier because upstream's wire encoding represents them
+    // exclusively via FILTRULE_RECEIVER_SIDE on a plain exclude/include rule.
+    // upstream: exclude.c:1569-1572 - `r` modifier on rules with RECEIVER_SIDE.
     if protocol.supports_sender_receiver_modifiers() {
         if rule.sender_side {
             prefix.push('s');
         }
-        if rule.receiver_side {
+        let force_receiver = matches!(rule.rule_type, RuleType::Protect | RuleType::Risk);
+        if rule.receiver_side || force_receiver {
             prefix.push('r');
         }
     }
@@ -296,7 +323,11 @@ mod tests {
     }
 
     #[test]
-    fn protect_rule_prefix() {
+    fn protect_rule_emits_dash_with_receiver_modifier() {
+        // upstream: exclude.c:1645 send_filter_list() encodes a P rule as
+        // an exclude (`-`) carrying the FILTRULE_RECEIVER_SIDE modifier (`r`).
+        // FilterRuleSpec::protect() sets applies_to_receiver=true, which
+        // build_wire_format_rules() forwards as receiver_side=true.
         let protocol = ProtocolVersion::from_supported(32).unwrap();
         let rule = FilterRuleWireFormat {
             rule_type: RuleType::Protect,
@@ -309,12 +340,37 @@ mod tests {
             exclude_from_merge: false,
             xattr_only: false,
             sender_side: false,
-            receiver_side: false,
+            receiver_side: true,
             perishable: false,
             negate: false,
         };
 
         let prefix = build_rule_prefix(&rule, protocol).unwrap();
-        assert_eq!(prefix, "P ");
+        assert_eq!(prefix, "-r ");
+    }
+
+    #[test]
+    fn risk_rule_emits_plus_with_receiver_modifier() {
+        // upstream: exclude.c:1201-1206 - 'R' parses as INCLUDE|RECEIVER_SIDE,
+        // so it serializes as `+r` (include with receiver modifier).
+        let protocol = ProtocolVersion::from_supported(32).unwrap();
+        let rule = FilterRuleWireFormat {
+            rule_type: RuleType::Risk,
+            pattern: "scratch".to_owned(),
+            anchored: false,
+            directory_only: false,
+            no_inherit: false,
+            cvs_exclude: false,
+            word_split: false,
+            exclude_from_merge: false,
+            xattr_only: false,
+            sender_side: false,
+            receiver_side: true,
+            perishable: false,
+            negate: false,
+        };
+
+        let prefix = build_rule_prefix(&rule, protocol).unwrap();
+        assert_eq!(prefix, "+r ");
     }
 }

--- a/tools/ci/known_failures.conf
+++ b/tools/ci/known_failures.conf
@@ -24,15 +24,6 @@ KNOWN_FAILURES=(
   # NOT FIXABLE HERE: requires fixing the delta engine daemon code path.
   "standalone:delta-stats"
 
-  # OC-RSYNC BUG: oc-rsync client fails when pushing to upstream daemon with
-  # --delete --filter='P *.log'. The P (protect) filter modifier is not
-  # correctly propagated in the sender-side filter rule exchange, causing
-  # the transfer to fail with a non-zero exit code.
-  # Direction 1 (up->oc) passes; direction 2 (oc->up) fails.
-  # Verified: fails identically on master branch.
-  # NOT FIXABLE HERE: requires fixing P filter rule handling in client sender.
-  "standalone:delete-filter-protect"
-
   # OC-RSYNC BUG: oc-rsync daemon does not apply R (risk) filter modifier
   # to override P (protect) rules. When upstream pushes with
   # --filter='P *.log' --filter='P *.sh' --filter='R *.log', the R modifier
@@ -138,8 +129,6 @@ DASHBOARD_ENTRIES=(
   "standalone:delta-stats|delta-stats in daemon mode (oc-rsync sends matched=0, delta engine not active in daemon code path)|standalone"
 
   # --- oc-rsync filter bugs (unconditional) ---
-  # P filter modifier not propagated correctly in client sender
-  "standalone:delete-filter-protect|delete-filter-protect (oc->up push fails with P filter, sender-side filter exchange bug)|standalone"
   # R filter modifier does not override P in daemon filter engine
   "standalone:delete-filter-risk|delete-filter-risk (oc-rsync daemon ignores R modifier override of P protect rules)|standalone"
 


### PR DESCRIPTION
## Summary

- Fix oc-rsync sending `Pr pattern` over the filter wire stream, which upstream rejects with `invalid modifier 'r' at position 1` (`exclude.c:1226`). Normalize Protect/Risk to upstream's wire encoding (`-r ` / `+r `) so the stream matches `get_rule_prefix()` byte-for-byte.
- The receiver-side `r` modifier is forced when serializing `RuleType::Protect`/`Risk` so hand-built `FilterRuleWireFormat` values without `receiver_side=true` still serialize correctly.
- Removes `standalone:delete-filter-protect` from `KNOWN_FAILURES` and `DASHBOARD_ENTRIES` in `tools/ci/known_failures.conf`.

## Root cause

Upstream's `get_rule_prefix()` (exclude.c:1536-1572) only ever emits `+`, `-`, or `:` as the leading character. `P` and `R` are CLI/file-syntax sugar that lower to plain exclude/include rules carrying the `FILTRULE_RECEIVER_SIDE` flag (exclude.c:1201-1206). The wire encoding for a P rule is `-r pattern`; the wire encoding for an R rule is `+r pattern`. oc-rsync was emitting the literal `P` prefix and ALSO appending the `r` modifier derived from `applies_to_receiver`, producing `Pr pattern` which upstream's parser rejects at exclude.c:1270-1271.

## Verification

Reproduced the original failure and confirmed the fix in the `rsync-profile` podman container against upstream rsync 3.4.1 daemon:

Before:
```
invalid modifier 'r' at position 1 in filter rule: Pr *.log
rsync error: syntax or usage error (code 1) at exclude.c(1226) [Receiver=3.4.1]
```

After (oc-rsync push with `--delete --filter='P *.log'`):
- `keeper.log` (dest-only, P-protected) survived `--delete`
- `subdir/nested.log` (dest-only, P-protected) survived `--delete`
- `unkept.txt` (dest-only, not protected) was deleted
- All source files transferred normally

## Test plan

- [x] Unit tests added for `protect_rule_emits_dash_with_receiver_modifier` and `risk_rule_emits_plus_with_receiver_modifier` in `crates/protocol/src/filters/prefix.rs`.
- [x] Manual interop verification against upstream rsync 3.4.1 daemon in podman container (`--delete --filter='P *.log'` push).
- [ ] CI: fmt + clippy
- [ ] CI: nextest (stable)
- [ ] CI: Windows / macOS / Linux musl
- [ ] CI: Interop Validation (delete-filter-protect should now pass without needing the known-failures bypass)

## Upstream references

- exclude.c:1536-1542 - protect rules emit `-` (exclude semantics).
- exclude.c:1569-1572 - `r` modifier on rules with `FILTRULE_RECEIVER_SIDE`.
- exclude.c:1201-1206 - risk rules emit `+` (include semantics).
- exclude.c:1226 - upstream rejects mismatched modifiers.
- exclude.c:1270-1271 - rejects `r` after a side-specifying prefix.

## Notes

The companion `standalone:delete-filter-risk` known failure is left in place. It tracks an independent bug (R modifier override semantics in oc-rsync's daemon-side filter engine) that this change does not address.