### PR TITLE
fix(checksums): apply checksum_seed to MD4 strong checksum (upstream parity)

### DIFF
--- a/crates/checksums/src/strong/md4.rs
+++ b/crates/checksums/src/strong/md4.rs
@@ -127,6 +127,55 @@ impl Md4 {
     pub fn digest(data: &[u8]) -> [u8; 16] {
         <Self as StrongDigest>::digest(data)
     }
+
+    /// Computes the MD4 digest for `data` with rsync's checksum seed applied.
+    ///
+    /// When `seed` is non-zero, the seed value is appended to the data as four
+    /// little-endian bytes before hashing. A `seed` of `0` is treated as
+    /// "no seed" and produces an identical digest to [`Md4::digest`].
+    ///
+    /// This mirrors upstream rsync's `get_checksum2()` MD4 path, which appends
+    /// `SIVAL(buf1, len, checksum_seed)` after the data and before digesting:
+    ///
+    /// ```text
+    /// memcpy(buf1, buf, len);
+    /// if (checksum_seed) {
+    ///     SIVAL(buf1, len, checksum_seed);
+    ///     len += 4;
+    /// }
+    /// ```
+    ///
+    /// upstream: checksum.c:358-396 `get_checksum2()` MD4 branch.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use checksums::strong::Md4;
+    ///
+    /// let data = b"block";
+    /// let seed: i32 = 0x12345678;
+    ///
+    /// let seeded = Md4::digest_with_seed(seed, data);
+    ///
+    /// // Equivalent: append seed bytes after data, then plain MD4.
+    /// let mut combined = data.to_vec();
+    /// combined.extend_from_slice(&seed.to_le_bytes());
+    /// assert_eq!(seeded, Md4::digest(&combined));
+    ///
+    /// // Zero seed produces the same digest as unseeded MD4.
+    /// assert_eq!(Md4::digest_with_seed(0, data), Md4::digest(data));
+    /// ```
+    #[must_use]
+    pub fn digest_with_seed(seed: i32, data: &[u8]) -> [u8; 16] {
+        let mut hasher = Md4::new();
+        hasher.update(data);
+        // upstream: checksum.c:377-380 - SIVAL(buf1, len, checksum_seed) appends
+        // the seed as a 32-bit little-endian value when seed != 0.
+        if seed != 0 {
+            hasher.update(&seed.to_le_bytes());
+        }
+        hasher.finalize()
+    }
 }
 
 impl StrongDigest for Md4 {
@@ -209,6 +258,57 @@ mod tests {
             let one_shot = Md4::digest(input);
             assert_eq!(to_hex(&one_shot), expected_hex);
         }
+    }
+
+    #[test]
+    fn md4_seeded_appends_seed_after_data() {
+        // upstream: checksum.c:376-380 - SIVAL(buf1, len, checksum_seed)
+        let seed: i32 = 0x12345678;
+        let data = b"rsync block payload";
+
+        let seeded = Md4::digest_with_seed(seed, data);
+
+        // Reference: build (data || seed_le_bytes) then plain MD4.
+        let mut reference_buf = data.to_vec();
+        reference_buf.extend_from_slice(&seed.to_le_bytes());
+        let reference = Md4::digest(&reference_buf);
+
+        assert_eq!(
+            to_hex(&seeded),
+            to_hex(&reference),
+            "seeded MD4 must match upstream's append-seed-after-data semantics"
+        );
+
+        // Seeded digest must differ from unseeded for non-zero seed.
+        assert_ne!(
+            to_hex(&seeded),
+            to_hex(&Md4::digest(data)),
+            "non-zero seed must change the digest"
+        );
+    }
+
+    #[test]
+    fn md4_seeded_zero_seed_matches_unseeded() {
+        // upstream: checksum.c:377 - `if (checksum_seed)` skips seed append on 0
+        let data = b"zero seed produces unseeded digest";
+        assert_eq!(
+            Md4::digest_with_seed(0, data),
+            Md4::digest(data),
+            "zero seed must produce identical digest to unseeded MD4"
+        );
+    }
+
+    #[test]
+    fn md4_seeded_negative_seed_is_le_two_complement() {
+        // i32::to_le_bytes preserves two's complement; verify wire equivalence.
+        let seed: i32 = -1;
+        let data = b"negative seed";
+
+        let seeded = Md4::digest_with_seed(seed, data);
+
+        let mut reference_buf = data.to_vec();
+        reference_buf.extend_from_slice(&[0xff, 0xff, 0xff, 0xff]);
+        assert_eq!(seeded, Md4::digest(&reference_buf));
     }
 
     #[test]

--- a/crates/engine/benches/delta_transfer_benchmark.rs
+++ b/crates/engine/benches/delta_transfer_benchmark.rs
@@ -70,7 +70,9 @@ fn build_index(
     algorithm: SignatureAlgorithm,
 ) -> DeltaSignatureIndex {
     let strong_sum_len = match algorithm {
-        SignatureAlgorithm::Md4 | SignatureAlgorithm::Md5 { .. } => 16,
+        SignatureAlgorithm::Md4
+        | SignatureAlgorithm::Md4Seeded { .. }
+        | SignatureAlgorithm::Md5 { .. } => 16,
         SignatureAlgorithm::Xxh3 { .. } | SignatureAlgorithm::Xxh64 { .. } => 8,
         SignatureAlgorithm::Xxh3_128 { .. } | SignatureAlgorithm::Sha1 => 16,
     };

--- a/crates/engine/src/local_copy/executor/directory/parallel_checksum.rs
+++ b/crates/engine/src/local_copy/executor/directory/parallel_checksum.rs
@@ -164,6 +164,23 @@ fn hash_file_contents(
             }
             hasher.finalize().as_ref().to_vec()
         }
+        SignatureAlgorithm::Md4Seeded { seed } => {
+            // upstream: checksum.c:377-380 - append checksum_seed as 4 LE bytes
+            // after the file data when seed != 0. A zero seed degenerates to
+            // unseeded MD4 (preserved here for symmetry with `Md4`).
+            let mut hasher = Md4::new();
+            loop {
+                let n = file.read(&mut buffer)?;
+                if n == 0 {
+                    break;
+                }
+                hasher.update(&buffer[..n]);
+            }
+            if seed != 0 {
+                hasher.update(&seed.to_le_bytes());
+            }
+            hasher.finalize().as_ref().to_vec()
+        }
         SignatureAlgorithm::Md5 { seed_config } => {
             let mut hasher = Md5::with_seed(seed_config);
             loop {

--- a/crates/signature/src/algorithm.rs
+++ b/crates/signature/src/algorithm.rs
@@ -76,8 +76,19 @@ impl Eq for DigestBuf {}
 /// Strong checksum strategies supported by the signature generator.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum SignatureAlgorithm {
-    /// MD4, used by upstream rsync for historical protocol versions.
+    /// MD4 with no seed, used by upstream rsync for historical protocol
+    /// versions when `checksum_seed` is zero.
     Md4,
+    /// MD4 with rsync's checksum seed appended after the data, mirroring
+    /// upstream `get_checksum2()` (`checksum.c:358-396`).
+    ///
+    /// Used by protocol versions below 30 when `checksum_seed != 0`. The
+    /// seed value is encoded as four little-endian bytes appended to the
+    /// hash input, exactly as `SIVAL(buf1, len, checksum_seed)` does.
+    Md4Seeded {
+        /// Checksum seed (`checksum_seed`) negotiated during protocol setup.
+        seed: i32,
+    },
     /// MD5, negotiated when both peers enable the checksum.
     ///
     /// Supports optional seeded hashing with configurable ordering for protocol
@@ -113,7 +124,9 @@ impl SignatureAlgorithm {
     #[must_use]
     pub const fn digest_len(self) -> usize {
         match self {
-            SignatureAlgorithm::Md4 | SignatureAlgorithm::Md5 { .. } => 16,
+            SignatureAlgorithm::Md4
+            | SignatureAlgorithm::Md4Seeded { .. }
+            | SignatureAlgorithm::Md5 { .. } => 16,
             SignatureAlgorithm::Sha1 => Sha1::DIGEST_LEN,
             SignatureAlgorithm::Xxh64 { .. } | SignatureAlgorithm::Xxh3 { .. } => 8,
             SignatureAlgorithm::Xxh3_128 { .. } => 16,
@@ -128,6 +141,9 @@ impl SignatureAlgorithm {
         match self {
             SignatureAlgorithm::Md4 => {
                 DigestBuf::from_slice(Md4::digest(data).as_ref(), effective_len)
+            }
+            SignatureAlgorithm::Md4Seeded { seed } => {
+                DigestBuf::from_slice(Md4::digest_with_seed(seed, data).as_ref(), effective_len)
             }
             SignatureAlgorithm::Md5 { seed_config } => DigestBuf::from_slice(
                 Md5::digest_with_seed(seed_config, data).as_ref(),
@@ -181,7 +197,10 @@ impl SignatureAlgorithm {
                     .collect()
             }
             _ => {
-                // Seeded MD5, SHA1, XXH64, XXH3, XXH3_128: per-element fallback
+                // Seeded MD4, seeded MD5, SHA1, XXH64, XXH3, XXH3_128:
+                // per-element fallback. Seeded MD4 cannot use the SIMD batch
+                // path because the per-block input includes a 4-byte LE seed
+                // suffix appended after the data (upstream: checksum.c:377-380).
                 blocks
                     .iter()
                     .map(|data| self.compute_truncated(data, len))
@@ -206,6 +225,16 @@ impl SignatureAlgorithm {
                 let mut h = Md4::new();
                 h.update(a);
                 h.update(b);
+                DigestBuf::from_slice(h.finalize().as_ref(), effective_len)
+            }
+            SignatureAlgorithm::Md4Seeded { seed } => {
+                let mut h = Md4::new();
+                h.update(a);
+                h.update(b);
+                // upstream: checksum.c:377-380 - append seed as 4 LE bytes
+                if seed != 0 {
+                    h.update(&seed.to_le_bytes());
+                }
                 DigestBuf::from_slice(h.finalize().as_ref(), effective_len)
             }
             SignatureAlgorithm::Md5 { seed_config } => {
@@ -358,6 +387,51 @@ mod tests {
                 "mismatch for {algo:?}"
             );
         }
+    }
+
+    /// Verifies seeded MD4 matches upstream's "append 4 LE seed bytes after
+    /// data" semantics for both the contiguous and split-slice paths.
+    ///
+    /// upstream: `checksum.c:358-396` get_checksum2() MD4 branch.
+    #[test]
+    fn md4_seeded_signature_matches_upstream_format() {
+        let data: &[u8] = b"two-block payload that splits across slices";
+        let seed: i32 = 0x0BADF00Du32 as i32;
+
+        // Reference: append seed bytes manually, then plain MD4.
+        let mut reference_buf = data.to_vec();
+        reference_buf.extend_from_slice(&seed.to_le_bytes());
+        let reference = SignatureAlgorithm::Md4.compute_truncated(&reference_buf, 16);
+
+        // Contiguous path
+        let seeded = SignatureAlgorithm::Md4Seeded { seed }.compute_truncated(data, 16);
+        assert_eq!(seeded.as_slice(), reference.as_slice());
+
+        // Split-slice path must agree with the contiguous result.
+        let (head, tail) = data.split_at(11);
+        let seeded_split =
+            SignatureAlgorithm::Md4Seeded { seed }.compute_truncated_slices(head, tail, 16);
+        assert_eq!(seeded_split.as_slice(), reference.as_slice());
+
+        // Batch path must agree with per-element path.
+        let blocks: Vec<&[u8]> = vec![data, b"second block"];
+        let batch = SignatureAlgorithm::Md4Seeded { seed }.compute_truncated_batch(&blocks, 16);
+        let per_elem: Vec<DigestBuf> = blocks
+            .iter()
+            .map(|d| SignatureAlgorithm::Md4Seeded { seed }.compute_truncated(d, 16))
+            .collect();
+        for (b, s) in batch.iter().zip(per_elem.iter()) {
+            assert_eq!(b.as_slice(), s.as_slice());
+        }
+
+        // Zero seed must agree with unseeded MD4 (upstream: `if (checksum_seed)`).
+        let zero_seed_unseeded =
+            SignatureAlgorithm::Md4Seeded { seed: 0 }.compute_truncated(data, 16);
+        let unseeded = SignatureAlgorithm::Md4.compute_truncated(data, 16);
+        assert_eq!(zero_seed_unseeded.as_slice(), unseeded.as_slice());
+
+        // Non-zero seed must produce a different digest from unseeded MD4.
+        assert_ne!(seeded.as_slice(), unseeded.as_slice());
     }
 
     /// Verifies that `compute_truncated_slices` with an empty second slice

--- a/crates/transfer/src/shared/checksum.rs
+++ b/crates/transfer/src/shared/checksum.rs
@@ -140,8 +140,23 @@ impl ChecksumFactory {
         let seed_u64 = self.seed as u64;
 
         match self.algorithm {
-            ChecksumAlgorithm::None => SignatureAlgorithm::Md4,
-            ChecksumAlgorithm::MD4 => SignatureAlgorithm::Md4,
+            // upstream: checksum.c:358-396 - MD4 appends the 4-byte LE seed
+            // after the data when `checksum_seed != 0`. A zero seed is the
+            // "no seed" case and produces an unseeded digest.
+            ChecksumAlgorithm::None => {
+                if self.seed == 0 {
+                    SignatureAlgorithm::Md4
+                } else {
+                    SignatureAlgorithm::Md4Seeded { seed: self.seed }
+                }
+            }
+            ChecksumAlgorithm::MD4 => {
+                if self.seed == 0 {
+                    SignatureAlgorithm::Md4
+                } else {
+                    SignatureAlgorithm::Md4Seeded { seed: self.seed }
+                }
+            }
             ChecksumAlgorithm::MD5 => {
                 let seed_config = if self.use_proper_seed_order {
                     Md5Seed::proper(self.seed)
@@ -311,6 +326,38 @@ mod tests {
             factory.signature_algorithm(),
             SignatureAlgorithm::Md4
         ));
+    }
+
+    #[test]
+    fn signature_algorithm_md4_with_seed_returns_md4_seeded() {
+        // upstream: checksum.c:358-396 - MD4 appends checksum_seed when != 0
+        let factory = ChecksumFactory::new(ChecksumAlgorithm::MD4, 0x12345678, false);
+        let sig = factory.signature_algorithm();
+
+        if let SignatureAlgorithm::Md4Seeded { seed } = sig {
+            assert_eq!(seed, 0x12345678);
+        } else {
+            panic!("Expected Md4Seeded signature algorithm, got {sig:?}");
+        }
+    }
+
+    #[test]
+    fn signature_algorithm_md4_with_zero_seed_returns_unseeded_md4() {
+        // upstream: checksum.c:377 - `if (checksum_seed)` skips append when 0
+        let factory = ChecksumFactory::new(ChecksumAlgorithm::MD4, 0, false);
+        assert!(matches!(
+            factory.signature_algorithm(),
+            SignatureAlgorithm::Md4
+        ));
+    }
+
+    #[test]
+    fn signature_algorithm_none_with_seed_returns_md4_seeded() {
+        // ChecksumAlgorithm::None falls back to MD4 semantics; seed must
+        // still be honoured to mirror upstream behaviour.
+        let factory = ChecksumFactory::new(ChecksumAlgorithm::None, 42, false);
+        let sig = factory.signature_algorithm();
+        assert!(matches!(sig, SignatureAlgorithm::Md4Seeded { seed: 42 }));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes a long-standing divergence from upstream rsync where MD4 block strong
checksums ignored the negotiated `checksum_seed`. Upstream's `get_checksum2()`
(`checksum.c:358-396`) appends the seed as 4 little-endian bytes after the
data before digesting whenever the seed is non-zero:

```c
memcpy(buf1, buf, len);
if (checksum_seed) {
    SIVAL(buf1, len, checksum_seed);
    len += 4;
}
```

Our MD4 path was unconditionally calling `Md4::digest(data)` and dropping the
seed entirely. Block-level strong sums therefore diverged from upstream on any
session with `checksum_seed != 0`, silently hurting delta match quality and
inflating `hash_hits` / `false_alarms` in `delta-stats` output during
interop.

## Why this matters

- **Wire-level interop**: oc-rsync acting as sender to upstream receiver (or
  vice versa) computed mismatched strong sums for the same block whenever a
  non-zero seed was negotiated. The receiver's `hash_search` would treat
  every false-strong-match as a `false_alarm` (or, in our broken state,
  silently miss matches because the rolling sum would mismatch first).
- **Stats correctness**: the `delta-stats` interop scenario in
  `tools/ci/run_interop.sh` was failing with `matches=0 hash_hits=228
  false_alarms=0 data=102400` because no block actually matched.

## Changes

- `checksums::strong::md4::Md4::digest_with_seed(seed, data)` mirrors
  upstream's append-seed-after-data semantics. Zero seed short-circuits to
  unseeded MD4, matching upstream's `if (checksum_seed)` guard.
- New `SignatureAlgorithm::Md4Seeded { seed: i32 }` variant. Introducing a
  new variant (rather than mutating the unit `Md4`) keeps the 30+ existing
  call sites that match on `Md4` working unchanged.
- `ChecksumFactory::signature_algorithm()` selects `Md4Seeded { seed }` for
  MD4 (and the legacy `ChecksumAlgorithm::None`/protocol<27 default) when
  seed != 0; otherwise keeps the unit `Md4` so existing wire goldens stay
  byte-identical.
- Exhaustive matches updated in `signature::algorithm`, the parallel
  checksum executor (`engine/.../parallel_checksum.rs`), and the
  `delta_transfer_benchmark` to handle `Md4Seeded`.

## Tests

- `md4_seeded_appends_seed_after_data` - verifies layout against
  `MD4(data || seed_le_bytes)`.
- `md4_seeded_zero_seed_matches_unseeded` - guards the upstream zero-seed
  short-circuit.
- `md4_seeded_negative_seed_is_le_two_complement` - confirms i32 wire
  encoding for negative seeds.
- `md4_seeded_signature_matches_upstream_format` - parity at the
  `SignatureAlgorithm` layer.
- `ChecksumFactory` tests for MD4/None x seed=0/non-zero combinations.

## Test plan

- [x] `cargo fmt --all -- --check`
- [ ] CI: fmt+clippy
- [ ] CI: nextest (stable) - covers new MD4 seed and ChecksumFactory tests
- [ ] CI: Windows / macOS / Linux musl
- [ ] CI: Interop Validation - confirms `delta-stats` scenario improvement

upstream: `checksum.c:358-396` `get_checksum2()` MD4 branch