### PR TITLE
docs(protocol): convert restating comments to rustdoc in varint (#1999)

### DIFF
--- a/crates/protocol/src/varint/decode.rs
+++ b/crates/protocol/src/varint/decode.rs
@@ -99,8 +99,8 @@ pub fn read_varlong<R: Read + ?Sized>(reader: &mut R, min_bytes: u8) -> io::Resu
 
     let leading = initial[0];
 
-    // Place the initial data bytes (after the leading tag) into the result
-    // buffer at positions 0..min-1, mirroring `memcpy(u.b, b2+1, min_bytes-1)`.
+    // upstream: io.c:read_varlong() `memcpy(u.b, b2+1, min_bytes-1)` -
+    // initial data bytes (after the leading tag) land at result[0..min-1].
     let mut result = [0u8; 9];
     result[..min - 1].copy_from_slice(&initial[1..min]);
 
@@ -113,10 +113,9 @@ pub fn read_varlong<R: Read + ?Sized>(reader: &mut R, min_bytes: u8) -> io::Resu
             return Err(invalid_data("overflow in read_varlong"));
         }
         reader.read_exact(&mut result[min - 1..min - 1 + extra])?;
-        // The masked leading byte goes into position min+extra-1
         result[min + extra - 1] = leading & (bit - 1);
     } else {
-        // No extra bytes - all 8 bits of the leading byte are data
+        // No extra bytes: all 8 bits of the leading byte are data, no masking.
         result[min - 1] = leading;
     }
 

--- a/crates/protocol/src/varint/tests.rs
+++ b/crates/protocol/src/varint/tests.rs
@@ -993,8 +993,6 @@ fn read_longint_truncated_extended() {
     assert_eq!(err.kind(), io::ErrorKind::UnexpectedEof);
 }
 
-// -- 1-byte encoding tests --
-
 #[test]
 fn all_1byte_values_encode_to_single_byte() {
     for value in 0..=127_i32 {
@@ -1124,8 +1122,6 @@ fn multiple_1byte_values_in_stream() {
         assert_eq!(decoded, expected);
     }
 }
-
-// -- 2-byte encoding tests --
 
 #[test]
 fn boundary_128_encodes_to_2_bytes() {
@@ -1267,8 +1263,6 @@ fn encoding_matches_upstream_format() {
         );
     }
 }
-
-// -- Extended encoding tests (values > 16383) --
 
 #[test]
 fn boundary_16384_is_3_bytes() {
@@ -1487,8 +1481,6 @@ fn powers_of_two_extended() {
     }
 }
 
-// -- Proptest property tests --
-
 proptest! {
     #[test]
     fn varint_roundtrip_all_i32(value: i32) {
@@ -1572,8 +1564,6 @@ proptest! {
         prop_assert!(len <= 5, "varint encoding should use at most 5 bytes, got {}", len);
     }
 }
-
-// -- Byte boundary tests --
 
 /// The exact boundary values where encoding size changes.
 const BYTE_BOUNDARIES: [(i32, usize, &str); 8] = [


### PR DESCRIPTION
## Summary

Comment-cleanup pass over `crates/protocol/src/varint/` per task #1999.

- Remove decorative banner/divider comments from `tests.rs` (e.g. `// -- 1-byte encoding tests --`).
- Tighten one explanatory comment in `decode.rs::read_varlong` to delete pure restatement, while preserving the upstream rsync reference (`io.c:read_varlong()`, `memcpy(u.b, b2+1, min_bytes-1)`).
- Keep all upstream C source references verbatim.
- No behaviour, signature, or import changes; rustdoc on public items was already in place and is left intact.

## Scope

Only files under `crates/protocol/src/varint/` are touched (`decode.rs`, `tests.rs`).

## Test plan

- [ ] CI fmt + clippy
- [ ] CI nextest (stable) on Linux/macOS/Windows/musl