### PR TITLE
docs(compress): convert restating comments to rustdoc in strategy (#2028)

### DIFF
--- a/crates/compress/src/strategy/negotiator.rs
+++ b/crates/compress/src/strategy/negotiator.rs
@@ -473,12 +473,6 @@ mod tests {
         );
     }
 
-    // ---- Protocol version x feature matrix tests ----
-    //
-    // These test the full negotiation matrix: protocol version ranges
-    // (which determine what a remote peer might advertise) combined with
-    // feature-gated local algorithm availability.
-
     #[test]
     fn negotiation_pre_v30_remote_only_zlib() {
         // Protocol < 30: remote peer only supports zlib (no negotiation vstring).
@@ -804,8 +798,6 @@ mod tests {
             "none"
         );
     }
-
-    // ---- ProtocolAwareCompressionNegotiator tests ----
 
     #[test]
     fn protocol_aware_proto_28_supported_only_zlib() {

--- a/crates/compress/src/strategy/tests.rs
+++ b/crates/compress/src/strategy/tests.rs
@@ -355,8 +355,6 @@ fn consistent_results_across_calls() {
     assert_eq!(out1, out2);
 }
 
-// ---- Protocol version x feature flag matrix for selector and kind ----
-
 #[test]
 fn selector_protocol_version_0_returns_zlib() {
     let strategy = CompressionStrategySelector::for_protocol_version(0);
@@ -652,8 +650,6 @@ fn negotiate_local_preference_order_wins() {
     assert_eq!(strategy.algorithm_name(), "zlib");
 }
 
-// ---- Selector roundtrip tests: verify returned strategies compress/decompress ----
-
 #[test]
 fn selector_for_protocol_version_roundtrip() {
     for version in [0, 28, 29, 30, 31, 32, 35, 36, 255] {
@@ -749,8 +745,6 @@ fn selector_for_algorithm_roundtrip_lz4() {
     assert_eq!(&decompressed, TEST_DATA);
 }
 
-// ---- Concrete factory methods with explicit levels ----
-
 #[test]
 fn selector_zlib_with_level() {
     let strategy = CompressionStrategySelector::zlib(CompressionLevel::Fast);
@@ -789,8 +783,6 @@ fn selector_lz4_with_level() {
     assert_eq!(&decompressed, TEST_DATA);
 }
 
-// ---- Negotiate with custom compression level ----
-
 #[test]
 fn negotiate_passes_level_to_strategy() {
     let local = vec![CompressionAlgorithmKind::Zlib];
@@ -822,8 +814,6 @@ fn negotiate_none_kind_roundtrip() {
     strategy.decompress(&compressed, &mut decompressed).unwrap();
     assert_eq!(&decompressed, TEST_DATA);
 }
-
-// ---- Kind edge cases ----
 
 #[test]
 fn kind_for_protocol_version_boundary_29_is_zlib() {

--- a/crates/compress/src/strategy/type_state.rs
+++ b/crates/compress/src/strategy/type_state.rs
@@ -303,8 +303,6 @@ mod tests {
         )
     }
 
-    // ---- Full lifecycle tests ----
-
     #[test]
     fn full_lifecycle_selects_zlib() {
         let strategy = default_pipeline()
@@ -349,8 +347,6 @@ mod tests {
             .into_strategy();
         assert_eq!(strategy.algorithm_name(), "none");
     }
-
-    // ---- State-specific method tests ----
 
     #[test]
     fn uninit_local_algorithms_returns_negotiator_list() {
@@ -406,8 +402,6 @@ mod tests {
         assert_eq!(selected.compression_level(), CompressionLevel::Best);
     }
 
-    // ---- Server vs client asymmetry ----
-
     #[test]
     fn server_respects_remote_order() {
         let selected = default_pipeline()
@@ -425,8 +419,6 @@ mod tests {
         // Client iterates local list: zlibx appears before "none" locally
         assert_eq!(selected.selected_algorithm_name(), "zlibx");
     }
-
-    // ---- Feature-gated tests ----
 
     #[cfg(feature = "zstd")]
     #[test]
@@ -450,8 +442,6 @@ mod tests {
         );
     }
 
-    // ---- Strategy roundtrip through pipeline ----
-
     #[test]
     fn strategy_from_pipeline_compresses_and_decompresses() {
         let strategy = default_pipeline()
@@ -468,8 +458,6 @@ mod tests {
         assert_eq!(&decompressed, input);
     }
 
-    // ---- Send + Sync ----
-
     #[test]
     fn pipeline_states_are_send() {
         fn assert_send<T: Send>() {}
@@ -478,8 +466,6 @@ mod tests {
         assert_send::<NegotiationPipeline<AlgorithmSelected>>();
     }
 
-    // ---- Compile-time safety ----
-    //
     // The following invalid transitions are prevented at compile time:
     //
     // ```compile_fail


### PR DESCRIPTION
## Summary

Comment cleanup for the `compress::strategy` module per task #2028.

The module's rustdoc was already comprehensive across all public APIs (traits, types, methods). This PR removes the remaining decorative banner/divider comments (`// ---- Section ----`) inside test modules, which violate the no-decorative-divider rule.

## Scope

Files audited under `crates/compress/src/strategy/`:

- `adaptive_level.rs` - already clean (rustdoc + rationale comments)
- `impls.rs` - already clean (rustdoc + safety-bounds comment)
- `kind.rs` - already clean (rustdoc + REASON gate)
- `mod.rs` - already clean (`//!` module doc with architecture diagram)
- `negotiator.rs` - removed 2 banner comments inside `#[cfg(test)]`
- `profile.rs` - already clean (rustdoc + compile-time-invariant rationale)
- `selector.rs` - already clean (rustdoc only)
- `tests.rs` - removed 5 decorative section banners
- `traits.rs` - already clean (rustdoc only)
- `type_state.rs` - removed 7 banner comments inside `#[cfg(test)]`

Total: 32 lines removed, no behavior changes.

## Constraints honored

- No upstream rsync C source references were touched - all `// upstream: compat.c:...` etc. preserved verbatim.
- No function bodies, signatures, types, or imports modified.
- No `cargo` invocations run locally - CI handles validation.

## Test plan

- [ ] CI checks pass (fmt, clippy, nextest stable, Windows, macOS, Linux musl).
- [ ] No behavior change: only comment lines removed.