### PR TITLE
docs(checksums): convert restating comments to rustdoc in strong (#2020)

### DIFF
--- a/crates/checksums/src/strong/openssl_support.rs
+++ b/crates/checksums/src/strong/openssl_support.rs
@@ -18,6 +18,8 @@ fn detect() -> Result<(), ()> {
     let md5 = MessageDigest::md5();
 
     Hasher::new(md5).map_err(|_| ())?;
+    // MD4 may be absent on OpenSSL builds that exclude the legacy provider;
+    // the probe is best-effort and detection succeeds as long as MD5 works.
     if let Some(md4) = MessageDigest::from_name("md4") {
         let _ = Hasher::new(md4);
     }


### PR DESCRIPTION
## Summary

Comment cleanup audit for `crates/checksums/src/strong/` (task #2020).

The strong checksum module's production source files are already well-curated from prior cleanup passes:

- Every public type, trait, function, and method carries `///` rustdoc covering purpose, invariants, and edge cases (digest output sizes, seed semantics, MD4/MD5 quirks).
- Upstream rsync references (`upstream: checksum.c:get_checksum2()`, `upstream: checksum.c:377-380`, `CHECKSUM_SEED_FIX`) are preserved verbatim on the seed-handling paths in `md4.rs` and `md5.rs`.
- No decorative banners, debug checkpoints, dead code, or restating-the-code internal comments remain in scope.
- `mod.rs` already exposes module-level `//!` docs with cross-algorithm usage examples and an upstream reference block.

The single substantive change this PR introduces clarifies a non-obvious quirk in `openssl_support.rs::detect()`:

```rust
// MD4 may be absent on OpenSSL builds that exclude the legacy provider;
// the probe is best-effort and detection succeeds as long as MD5 works.
```

This explains the `if let Some(md4) = ...` whose `Hasher::new` result is deliberately discarded - readers were otherwise left to infer why the MD4 branch is non-fatal.

## Out of scope (per task brief)

- `crates/checksums/src/strong/strategy/` - tracked under a separate audit task; left untouched.
- `md4_tests.rs` and `xxh64_tests.rs` - explicitly skipped per task instructions.

## Constraints honoured

- No behaviour, signature, or import changes.
- All upstream rsync C source references retained.
- No SAFETY/invariant comments touched (none required edits in this scope; the `strong/` module relies on safe wrappers and `#[deny(unsafe_code)]`).

## Test plan

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings`
- [ ] `cargo nextest run -p checksums --all-features`