### PR TITLE
docs: clean up comments in protocol::error_recovery

### DIFF
--- a/crates/protocol/src/error_recovery/mod.rs
+++ b/crates/protocol/src/error_recovery/mod.rs
@@ -46,8 +46,6 @@ mod tests {
     use std::io;
     use std::path::PathBuf;
 
-    // PartialTransferState tests
-
     #[test]
     fn partial_transfer_state_new() {
         let state = PartialTransferState::new(PathBuf::from("/tmp/file.txt"), 1024, 2048, None);
@@ -59,19 +57,16 @@ mod tests {
 
     #[test]
     fn partial_transfer_state_is_resumable() {
-        // Partially received - should be resumable
         let state = PartialTransferState::new(PathBuf::from("/tmp/file.txt"), 1024, 2048, None);
         assert!(state.is_resumable());
 
-        // No data received - not resumable
         let state = PartialTransferState::new(PathBuf::from("/tmp/file.txt"), 0, 2048, None);
         assert!(!state.is_resumable());
 
-        // Fully received - not resumable
         let state = PartialTransferState::new(PathBuf::from("/tmp/file.txt"), 2048, 2048, None);
         assert!(!state.is_resumable());
 
-        // Received more than expected (should not happen, but handle gracefully)
+        // Over-received case shouldn't happen in practice but must not panic or report resumable.
         let state = PartialTransferState::new(PathBuf::from("/tmp/file.txt"), 3000, 2048, None);
         assert!(!state.is_resumable());
     }
@@ -100,8 +95,6 @@ mod tests {
         assert_eq!(state.checksum_so_far, Some(checksum));
     }
 
-    // PartialTransferLog tests
-
     #[test]
     fn partial_transfer_log_new() {
         let log = PartialTransferLog::new();
@@ -127,11 +120,9 @@ mod tests {
         let mut log = PartialTransferLog::new();
         let path = PathBuf::from("/tmp/file.txt");
 
-        // Record a non-resumable state (0 bytes received)
         let state = PartialTransferState::new(path.clone(), 0, 2048, None);
         log.record_partial(state);
 
-        // Should return None since it's not resumable
         assert!(log.get_resumable(&path).is_none());
     }
 
@@ -140,15 +131,13 @@ mod tests {
         let mut log = PartialTransferLog::new();
         let path = PathBuf::from("/tmp/file.txt");
 
-        // Record first state
         let state1 = PartialTransferState::new(path.clone(), 1024, 2048, None);
         log.record_partial(state1);
 
-        // Record second state for same path
         let state2 = PartialTransferState::new(path.clone(), 1536, 2048, None);
         log.record_partial(state2);
 
-        // Should have replaced, not added
+        // Re-recording the same path replaces the prior entry rather than appending a duplicate.
         assert_eq!(log.count(), 1);
         assert_eq!(log.get_resumable(&path).unwrap().bytes_received, 1536);
     }
@@ -187,8 +176,6 @@ mod tests {
         assert!(paths.contains(&PathBuf::from("/tmp/file1.txt")));
         assert!(paths.contains(&PathBuf::from("/tmp/file2.txt")));
     }
-
-    // Error classification tests
 
     #[test]
     fn classify_transient_errors() {
@@ -258,15 +245,13 @@ mod tests {
         );
     }
 
-    // Retry logic tests
-
     #[test]
     fn should_retry_timeout() {
         let err = TransferError::Timeout;
         assert!(should_retry(&err, 1, 3));
         assert!(should_retry(&err, 2, 3));
-        assert!(!should_retry(&err, 3, 3)); // At limit
-        assert!(!should_retry(&err, 4, 3)); // Exceeded
+        assert!(!should_retry(&err, 3, 3));
+        assert!(!should_retry(&err, 4, 3));
     }
 
     #[test]
@@ -324,8 +309,6 @@ mod tests {
         assert!(!should_retry(&err, 5, 5));
         assert!(!should_retry(&err, 10, 5));
     }
-
-    // Recovery action tests
 
     #[test]
     fn determine_recovery_disk_full_aborts() {
@@ -404,8 +387,6 @@ mod tests {
         let err = TransferError::Io(io::ErrorKind::Other);
         assert_eq!(determine_recovery(&err, None), RecoveryAction::Abort);
     }
-
-    // Edge cases
 
     #[test]
     fn partial_transfer_state_empty_path() {

--- a/crates/protocol/src/error_recovery/strategy.rs
+++ b/crates/protocol/src/error_recovery/strategy.rs
@@ -29,18 +29,16 @@ pub fn classify_error(error: io::Error) -> ErrorSeverity {
     use io::ErrorKind::*;
 
     match error.kind() {
-        // Transient errors - worth retrying
         Interrupted | WouldBlock => ErrorSeverity::Transient,
 
-        // Recoverable errors - skip file and continue
         NotFound | PermissionDenied | AlreadyExists | InvalidInput => ErrorSeverity::Recoverable,
 
-        // Fatal errors - abort transfer
         UnexpectedEof | InvalidData | ConnectionRefused | ConnectionReset | ConnectionAborted
         | BrokenPipe | AddrInUse | AddrNotAvailable | NotConnected | TimedOut
         | ReadOnlyFilesystem | StorageFull => ErrorSeverity::Fatal,
 
-        // Default to fatal for unknown errors
+        // Unknown kinds default to Fatal so unexpected conditions abort rather than silently
+        // skip - matches upstream rsync's conservative receiver.c handling.
         _ => ErrorSeverity::Fatal,
     }
 }
@@ -73,14 +71,11 @@ pub fn classify_error(error: io::Error) -> ErrorSeverity {
 /// ```
 #[must_use]
 pub fn should_retry(error: &TransferError, attempt: u32, max_retries: u32) -> bool {
-    // Don't retry if we've exceeded the limit
     if attempt >= max_retries {
         return false;
     }
 
-    // Determine if the error type is retryable
     match error {
-        // Transient errors worth retrying
         TransferError::Timeout
         | TransferError::ConnectionLost
         | TransferError::Interrupted
@@ -88,13 +83,11 @@ pub fn should_retry(error: &TransferError, attempt: u32, max_retries: u32) -> bo
         | TransferError::Io(io::ErrorKind::WouldBlock)
         | TransferError::Io(io::ErrorKind::TimedOut) => true,
 
-        // Fatal errors that should not be retried
         TransferError::DiskFull
         | TransferError::ProtocolMismatch
         | TransferError::ChecksumMismatch
         | TransferError::PermissionDenied => false,
 
-        // Other I/O errors - check if they're transient
         TransferError::Io(kind) => {
             matches!(kind, io::ErrorKind::Interrupted | io::ErrorKind::WouldBlock)
         }
@@ -131,16 +124,14 @@ pub fn determine_recovery(
     partial: Option<&PartialTransferState>,
 ) -> RecoveryAction {
     match error {
-        // Fatal errors require abort
         TransferError::DiskFull | TransferError::ProtocolMismatch => RecoveryAction::Abort,
 
-        // Checksum mismatch - retry from beginning
         TransferError::ChecksumMismatch => RecoveryAction::Retry,
 
-        // Permission denied - skip this file
         TransferError::PermissionDenied => RecoveryAction::Skip,
 
-        // Transient errors - resume if partial exists, otherwise retry
+        // Transient failures prefer resuming from the partial offset when one exists; without
+        // a resumable partial, fall back to a full retry.
         TransferError::Timeout | TransferError::ConnectionLost | TransferError::Interrupted => {
             if let Some(state) = partial {
                 if state.is_resumable() {
@@ -153,7 +144,6 @@ pub fn determine_recovery(
             }
         }
 
-        // I/O errors - classify and decide
         TransferError::Io(kind) => match kind {
             io::ErrorKind::NotFound | io::ErrorKind::PermissionDenied => RecoveryAction::Skip,
             io::ErrorKind::StorageFull => RecoveryAction::Abort,


### PR DESCRIPTION
## Summary

Comment cleanup pass for `crates/protocol/src/error_recovery/` (task #1985), enforcing the project standards:

- Removed decorative banner/divider comments inside the test module (`// PartialTransferState tests`, `// Error classification tests`, `// Retry logic tests`, `// Recovery action tests`, `// Edge cases`, `// PartialTransferLog tests`).
- Removed restatement comments inside `classify_error`, `should_retry`, and `determine_recovery` whose content was already obvious from the matched variant and returned action (e.g., `// Transient errors - worth retrying` next to a return of `ErrorSeverity::Transient`).
- Removed inline restatements inside individual tests (`// Record first state`, `// Should return None since it's not resumable`, `// At limit`, `// Exceeded`, etc.).
- Replaced a few of those with concise WHY comments where the behavior is non-obvious:
  - Default `Fatal` classification for unknown `io::ErrorKind`s mirrors upstream `receiver.c`'s conservative posture.
  - `record_partial` semantics: re-recording a path replaces the prior entry rather than appending.
  - Transient errors prefer `ResumeFrom` over full `Retry` when a resumable partial exists.
  - Over-received case must not panic or report resumable.

No functional changes. Public APIs, types, and test coverage are unchanged. All `///` rustdoc on public items is preserved. Scope is limited to `mod.rs` and `strategy.rs` (the two files that contained removable comments); `partial.rs` and `types.rs` already met the standards and were not modified.

Refs #1985.

## Test plan

- [ ] CI runs the workspace nextest suite (fmt + clippy + nextest stable on Linux/macOS/Windows + Linux musl).
- [ ] No new clippy warnings, since this is a comment-only change.