### PR TITLE
docs(metadata): convert restating comments to rustdoc in chmod

### DIFF
--- a/crates/metadata/src/chmod/comprehensive_tests.rs
+++ b/crates/metadata/src/chmod/comprehensive_tests.rs
@@ -252,7 +252,6 @@ mod numeric_mode {
         assert!(!modifiers.is_empty());
     }
 
-    // Four-digit modes with special bits
     #[test]
     fn mode_4755_setuid() {
         let modifiers = ChmodModifiers::parse("4755").expect("parse 4755");
@@ -283,7 +282,6 @@ mod numeric_mode {
         assert!(!modifiers.is_empty());
     }
 
-    // Invalid numeric modes
     #[test]
     fn invalid_two_digit_mode() {
         let result = ChmodModifiers::parse("75");
@@ -567,9 +565,7 @@ mod apply_mode {
         let file_result = modifiers.apply(0o644, file_type);
         let dir_result = modifiers.apply(0o644, dir_type);
 
-        // File should be unchanged
         assert_eq!(file_result & 0o777, 0o644);
-        // Directory should be changed
         assert_eq!(dir_result & 0o777, 0o755);
     }
 
@@ -588,9 +584,7 @@ mod apply_mode {
         let file_result = modifiers.apply(0o755, file_type);
         let dir_result = modifiers.apply(0o755, dir_type);
 
-        // File should be changed
         assert_eq!(file_result & 0o777, 0o644);
-        // Directory should be unchanged
         assert_eq!(dir_result & 0o777, 0o755);
     }
 
@@ -622,7 +616,6 @@ mod apply_mode {
         let dir_type = get_file_type(&dir_path);
         let modifiers = ChmodModifiers::parse("a+X").expect("parse");
 
-        // Directory should get execute bit
         let result = modifiers.apply(0o600, dir_type);
         assert_eq!(result & 0o111, 0o111);
     }
@@ -824,10 +817,9 @@ mod error_cases {
 }
 
 mod upstream_compatibility {
-    use super::*;
+    //! Tests that document behavior matching upstream rsync's `--chmod` semantics.
 
-    /// Tests that document behavior that should match upstream rsync.
-    /// These tests verify our implementation matches rsync's documented behavior.
+    use super::*;
 
     #[test]
     fn rsync_style_directory_only_execute() {
@@ -878,7 +870,6 @@ mod upstream_compatibility {
     #[cfg(unix)]
     #[test]
     fn upstream_behavior_fgo_minus_w() {
-        // Verify Fgo-w removes group/other write from files, leaves directories alone
         let temp = tempfile::tempdir().expect("tempdir");
         let file_path = temp.path().join("test.txt");
         let dir_path = temp.path().join("testdir");
@@ -894,11 +885,10 @@ mod upstream_compatibility {
 
         let modifiers = ChmodModifiers::parse("Fgo-w").expect("parse");
 
-        // File: 0o666 -> 0o644 (remove g-w and o-w)
+        // File: 0o666 -> 0o644 (remove g-w and o-w); directory unchanged.
         let file_result = modifiers.apply(0o666, file_type);
         assert_eq!(file_result & 0o777, 0o644);
 
-        // Directory: unchanged
         let dir_result = modifiers.apply(0o777, dir_type);
         assert_eq!(dir_result & 0o777, 0o777);
     }
@@ -906,7 +896,6 @@ mod upstream_compatibility {
     #[cfg(unix)]
     #[test]
     fn upstream_behavior_d755_f644() {
-        // Verify D755,F644 sets correct modes for each type
         let temp = tempfile::tempdir().expect("tempdir");
         let file_path = temp.path().join("test.txt");
         let dir_path = temp.path().join("testdir");
@@ -932,7 +921,6 @@ mod upstream_compatibility {
     #[cfg(unix)]
     #[test]
     fn upstream_behavior_ugo_equals_rwx() {
-        // Verify ugo=rwX behavior matches rsync
         let temp = tempfile::tempdir().expect("tempdir");
         let file_path = temp.path().join("test.txt");
         let dir_path = temp.path().join("testdir");

--- a/crates/metadata/src/chmod/parse.rs
+++ b/crates/metadata/src/chmod/parse.rs
@@ -156,7 +156,6 @@ fn parse_perm_spec(perms: &str, op: Operation) -> Result<PermSpec, ChmodError> {
 mod tests {
     use super::*;
 
-    // Tests for parse_spec
     #[test]
     fn parse_spec_single_numeric() {
         let clauses = parse_spec("755").unwrap();
@@ -194,7 +193,6 @@ mod tests {
         assert!(clauses.is_empty());
     }
 
-    // Tests for parse_clause - numeric
     #[test]
     fn parse_clause_numeric_three_digits() {
         let clause = parse_clause("644").unwrap();
@@ -237,7 +235,6 @@ mod tests {
         }
     }
 
-    // Tests for parse_clause - symbolic
     #[test]
     fn parse_clause_symbolic_user_add_read() {
         let clause = parse_clause("u+r").unwrap();
@@ -374,7 +371,6 @@ mod tests {
         assert!(result.is_err());
     }
 
-    // Tests for parse_numeric_clause
     #[test]
     fn parse_numeric_clause_valid_three_digits() {
         assert_eq!(parse_numeric_clause("755").unwrap(), 0o755);
@@ -407,7 +403,6 @@ mod tests {
         assert!(parse_numeric_clause("789").is_err());
     }
 
-    // Tests for parse_perm_spec
     #[test]
     fn parse_perm_spec_read() {
         let spec = parse_perm_spec("r", Operation::Add).unwrap();


### PR DESCRIPTION
## Summary

Closes task #2022. Comment-only cleanup in `crates/metadata/src/chmod/`:

- Remove decorative section-banner comments inside the `parse.rs` and `comprehensive_tests.rs` test modules (e.g. `// Tests for parse_spec`, `// Four-digit modes with special bits`, `// Invalid numeric modes`).
- Remove pure-restatement comments that echoed adjacent `assert_eq!` lines in `apply_mode` and `upstream_compatibility` tests (e.g. `// File should be unchanged`, `// Directory should be changed`).
- Convert a stranded `///` doc-comment block in `mod upstream_compatibility` (which would have attached to the next test function) to a proper `//!` module doc.
- Preserve every comment that references upstream rsync semantics (`// rsync uses D+x ...`, `// Common rsync pattern: a+rX ...`, etc.).
- Preserve "why" comments that explain non-obvious invariants: conditional-X behaviour, assign-empty-perms validity, octal digit validation.

No functional code changes.

## Test plan

- [ ] CI: fmt + clippy
- [ ] CI: nextest (stable)
- [ ] CI: Windows / macOS / Linux musl