### PR TITLE
docs(signature): convert restating comments to rustdoc (#2034)

### DIFF
--- a/crates/signature/src/async_gen.rs
+++ b/crates/signature/src/async_gen.rs
@@ -92,9 +92,9 @@ pub struct SignatureResult {
 
 /// Message sent to worker threads.
 enum WorkerMessage {
-    /// Generate a signature.
+    /// Request that the worker compute a signature for the given basis file.
     GenerateSignature(SignatureRequest),
-    /// Shutdown signal.
+    /// Tell the worker to exit its receive loop.
     Shutdown,
 }
 
@@ -122,8 +122,7 @@ impl Default for AsyncSignatureConfig {
             .unwrap_or(2);
 
         Self {
-            // Cap at 4 threads - signature generation has diminishing returns
-            // beyond that due to disk I/O bottleneck
+            // Disk I/O bottleneck causes diminishing returns beyond 4 threads.
             num_threads: num_cpus.min(4),
             max_pending: 16,
         }
@@ -146,11 +145,8 @@ impl AsyncSignatureConfig {
     }
 }
 
-/// Async signature generator using a thread pool.
-///
-/// Spawns worker threads that generate signatures in the background,
-/// allowing the main transfer thread to overlap signature computation
-/// with network I/O.
+/// Spawns worker threads that generate signatures in the background, allowing
+/// the main transfer thread to overlap signature computation with network I/O.
 ///
 /// # Example
 ///
@@ -355,7 +351,6 @@ fn worker_thread_main_shared(
                 }
             }
             Ok(WorkerMessage::Shutdown) | Err(_) => {
-                // Shutdown requested or channel closed
                 break;
             }
         }

--- a/crates/signature/src/block_size.rs
+++ b/crates/signature/src/block_size.rs
@@ -131,14 +131,12 @@ pub fn calculate_block_length(
     protocol_version: u8,
     user_block_size: Option<u32>,
 ) -> u32 {
-    // If user specified a block size, use it (subject to protocol maximum)
     let block_length = if let Some(user_size) = user_block_size {
         user_size
     } else {
         derive_block_length_sqrt(file_size, protocol_version)
     };
 
-    // Clamp to protocol-specific maximum
     let max_block = if protocol_version < 30 {
         MAX_BLOCK_SIZE_OLD
     } else {
@@ -197,17 +195,16 @@ pub fn calculate_checksum_length(
     protocol_version: u8,
     requested_checksum_length: u8,
 ) -> u8 {
-    // Protocol versions < 27 don't support adaptive checksum lengths
+    // Protocol versions < 27 lack adaptive checksum length negotiation.
     if protocol_version < 27 {
         return requested_checksum_length;
     }
 
-    // If requesting the maximum length, use it directly
+    // Phase 2 redo short-circuit: full collision resistance for retransmits.
     if requested_checksum_length == MAX_SUM_LENGTH {
         return MAX_SUM_LENGTH;
     }
 
-    // Calculate bias based on file size
     let mut bias = BLOCKSUM_BIAS;
     let mut l = file_size;
     while l >> 1 != 0 {
@@ -215,17 +212,14 @@ pub fn calculate_checksum_length(
         bias += 2;
     }
 
-    // Adjust bias based on block length
     let mut current = block_length;
     while current >> 1 != 0 && bias > 0 {
         current >>= 1;
         bias -= 1;
     }
 
-    // Compute checksum length from bias
     let mut checksum_len = (bias + 1 - 32 + 7) / 8;
 
-    // Clamp to requested bounds
     let min_len = i32::from(requested_checksum_length);
     if checksum_len < min_len {
         checksum_len = min_len;
@@ -295,7 +289,6 @@ pub fn calculate_checksum_count(file_size: u64, block_length: u32) -> u64 {
 ///
 /// This mirrors `generator.c:sum_sizes_sqroot()` from upstream rsync.
 fn derive_block_length_sqrt(file_size: u64, protocol_version: u8) -> u32 {
-    // Small files use the default block size
     if file_size <= u64::from(DEFAULT_BLOCK_SIZE) * u64::from(DEFAULT_BLOCK_SIZE) {
         return DEFAULT_BLOCK_SIZE;
     }
@@ -306,8 +299,7 @@ fn derive_block_length_sqrt(file_size: u64, protocol_version: u8) -> u32 {
         MAX_BLOCK_SIZE_V30
     };
 
-    // Find the highest bit set in file_size, then compute c = 2^(floor(log2(file_size)/2))
-    // This gives us a power-of-2 upper bound for the square root
+    // c = 2^(floor(log2(file_size)/2)): power-of-2 upper bound for sqrt(file_size).
     let mut c: u64 = 1;
     let mut l = file_size;
     while l >> 2 != 0 {
@@ -315,12 +307,11 @@ fn derive_block_length_sqrt(file_size: u64, protocol_version: u8) -> u32 {
         l >>= 2;
     }
 
-    // If already at max, return it
     if c >= u64::from(max_block_length) {
         return max_block_length;
     }
 
-    // Binary search for the largest block_length where block_length² ≤ file_size
+    // Binary search for the largest block_length where block_length^2 <= file_size.
     let mut block_length = 0u64;
     let mut current = c;
     while current >= 8 {
@@ -332,7 +323,6 @@ fn derive_block_length_sqrt(file_size: u64, protocol_version: u8) -> u32 {
         current >>= 1;
     }
 
-    // Ensure we don't go below the default
     let block_length = block_length.max(u64::from(DEFAULT_BLOCK_SIZE));
 
     #[allow(clippy::cast_possible_truncation)]

--- a/crates/signature/src/pipelined_gen.rs
+++ b/crates/signature/src/pipelined_gen.rs
@@ -103,7 +103,6 @@ pub fn generate_signature_pipelined<R: Read + Send + 'static>(
 
     let file_size = layout.file_size();
 
-    // Configure pipeline with block size matching signature blocks
     let pipeline_config = PipelineConfig {
         block_size: block_len,
         min_file_size: config.pipeline.min_file_size,
@@ -113,14 +112,13 @@ pub fn generate_signature_pipelined<R: Read + Send + 'static>(
     let mut buffered_reader =
         DoubleBufferedReader::with_size_hint(reader, pipeline_config, Some(file_size));
 
-    // Batch size for SIMD strong checksum computation, matching generation.rs.
+    // Must match generation.rs::BATCH_SIZE so SIMD batch hashing widens identically.
     const BATCH_SIZE: usize = 16;
 
     let mut blocks = Vec::with_capacity(expected_blocks_usize);
     let mut total_bytes: u64 = 0;
     let mut block_index: usize = 0;
 
-    // Accumulators for batch strong checksum computation.
     let batch_cap = BATCH_SIZE.min(expected_blocks_usize).max(1);
     let mut batch_data: Vec<Vec<u8>> = Vec::with_capacity(batch_cap);
     let mut batch_rolling: Vec<RollingDigest> = Vec::with_capacity(batch_cap);


### PR DESCRIPTION
## Summary

Cleans up restating-the-code comments across the `signature` crate per task #2034 in `crates/signature/src/`.

Touched 3 production files (skipped already-clean `algorithm.rs`, `block.rs`, `file.rs`, `generation.rs`, `layout.rs`, `parallel.rs`, `lib.rs` and all test modules):

- `block_size.rs` - dropped 8 restating comments inside `calculate_block_length`, `calculate_checksum_length`, and `derive_block_length_sqrt`. Reworked the surviving notes to capture the WHY: phase 2 redo short-circuit (full collision resistance) and the sqrt-bound derivation `c = 2^(floor(log2(file_size)/2))`.
- `pipelined_gen.rs` - removed three restating comments; tightened the surviving `BATCH_SIZE` note to call out that it must match `generation.rs::BATCH_SIZE` for SIMD lane widths.
- `async_gen.rs` - tightened the `WorkerMessage` variant docs, condensed the duplicated thread-cap rationale, dropped the redundant `Async signature generator using a thread pool` lead-in, and removed the `// Shutdown requested or channel closed` echo.

Preserved all upstream rsync references (e.g. `rsync.h:714-715 SHORT_SUM_LENGTH`, `generator.c:725-738 sum_sizes_sqroot()`) and all WHY comments documenting non-obvious invariants (SHORT_SUM_LENGTH vs MAX_SUM_LENGTH phase toggle, ordering invariant in `parallel.rs`, channel close semantics in `async_gen.rs::new`).

Comment-only change. No code logic touched.

## Test plan

- [ ] CI: fmt + clippy
- [ ] CI: nextest stable (Linux musl, macOS, Windows)
- [ ] CI: rustdoc builds