### PR TITLE
docs: v0.6 known limitations and security hardening notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,20 @@ Tested against upstream rsync **3.0.9**, **3.1.3**, and **3.4.1** in CI across p
 
 Threaded architecture replaces upstream's fork-based pipeline while keeping full protocol compatibility, reducing syscall overhead and context switches. Adaptive I/O buffers scale from 8KB to 1MB based on file size. Optional io_uring on Linux 5.6+ with three policies: *auto* (default; probe kernel and fall back to standard I/O), `--io-uring` (require io_uring; error if unavailable), `--no-io-uring` (always use standard buffered I/O). The active backend is reported by `--version` and `-vv` output. See `oc-rsync(1)` for details.
 
+### Known Limitations / Architectural Trade-offs
+
+oc-rsync is wire-compatible with upstream rsync 3.4.1, but a few architectural choices and unfinished surfaces are worth calling out for operators planning a deployment:
+
+- **io_uring kernel requirement.** Provided buffer rings (PBUF_RING) require Linux **5.19+**; older 5.6-5.18 kernels fall back to standard buffered I/O via runtime probing.
+- **Fixed io_uring buffer pool.** The registered buffer pool is sized at compile time (1024 × 4 KiB = 4 MiB) and does not adapt under sustained I/O pressure. Workloads with very high concurrent file fan-out may see throughput plateau before saturating the device.
+- **bgid namespace.** io_uring buffer-group IDs are a 16-bit namespace; the buffer ring helpers cap at this bound. Long-running daemons that recycle thousands of distinct ring groups should monitor for exhaustion.
+- **Single-thread delta computation.** The delta sender is sequential per file. Rolling-hash fan-out across files is not yet parallelised; large-file workloads fully utilise one CPU per transfer rather than scaling delta CPU horizontally.
+- **SSH compression interaction.** When the SSH cipher already performs compression (e.g., `Compression yes` in `ssh_config`), running `oc-rsync -z` will compress payloads twice. There is currently no auto-detection / auto-disable path; operators should pick one layer.
+- **Daemon TLS.** Native TLS is not built into the daemon. Deploy `oc-rsync --daemon` behind `stunnel`, `ssh -L`, or a reverse proxy that terminates TLS. See [SECURITY.md](./SECURITY.md) for hardening recipes.
+- **Windows IOCP not wired.** IOCP is implemented in `fast_io` but not yet consumed by the transfer pipeline (#1868); Windows uses standard buffered I/O for transfers.
+- **`.rsync-filter` per-directory inheritance.** Inheritance semantics match upstream for the common cases tested in the interop suite, but exhaustive parity against upstream's filter-tree corner cases (deeply nested merges, anchored vs unanchored interactions) is still being validated.
+- **`--checksum-seed` / `--fuzzy` / `--iconv`.** These flags are accepted and exercised in the common path; deeper conformance audits against upstream rsync 3.4.1 are tracked separately.
+
 ---
 
 ## Installation

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,8 @@
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.5.x   | :white_check_mark: |
+| 0.6.x   | :white_check_mark: |
+| 0.5.x   | :warning: critical fixes only |
 | < 0.5   | :x:                |
 
 ## Reporting a Vulnerability
@@ -96,6 +97,41 @@ cargo +nightly fuzz run fuzz_legacy_greeting
 ```
 
 See `crates/protocol/fuzz/README.md` for detailed fuzzing instructions.
+
+## Hardening Notes
+
+These cover operationally relevant trade-offs in the current code base and how to mitigate them.
+
+### Buffer pool bounds checks
+
+`recycle_buffer(buf_id)` in the io_uring path validates that `buf_id` falls within the registered buffer pool using `debug_assert!`. In release builds the assertion compiles out, so a corrupted or attacker-influenced `buf_id` reaching this code path would index out of range and either produce undefined behaviour inside the io_uring crate or — more likely — be caught by the kernel as an invalid SQE. A defense-in-depth fix to upgrade the check to a release-mode bound is tracked; until it lands, do not expose the io_uring path to untrusted protocol input.
+
+### io_uring buffer-group ID namespace
+
+io_uring buffer-group IDs (`bgid`) live in a 16-bit namespace. The provided-buffer ring helpers in `fast_io` cap allocation at this bound, and exhaustion returns an error rather than wrapping. Long-running daemons that churn ring groups should monitor for the bounded error and recycle.
+
+### SSH double compression
+
+If the SSH transport itself compresses the stream (`Compression yes` in `ssh_config` or a cipher with built-in compression), running `oc-rsync -z` will compress payloads twice. The amplification surface is small in practice but adds CPU and can mask compressor-specific bugs. Disable one layer; the canonical choice is to leave compression to rsync (`-z` / `--compress`) and disable it in SSH.
+
+### Daemon TLS
+
+`oc-rsync --daemon` does not terminate TLS natively. To expose the daemon over an untrusted network, deploy it behind one of:
+
+- **stunnel** in front of `rsync://`-style daemon traffic
+- **SSH tunnel** (`ssh -L` to a localhost-bound daemon)
+- **A reverse proxy** that performs TLS termination (e.g., HAProxy in TCP mode)
+
+Bind the daemon itself to `127.0.0.1` (or a private VPC interface) and route external clients exclusively through the TLS terminator.
+
+### Daemon module hardening
+
+In addition to `use chroot = yes`, prefer:
+
+- `numeric ids = yes` so uid/gid mapping does not depend on the daemon's `passwd`/`group`
+- `refuse options = delete *` for read-only mirrors
+- `hosts allow` / `hosts deny` ACLs at the daemon layer (these run before authentication)
+- `secrets file` permissions of `0600`, owned by the daemon user only
 
 ## Security Best Practices for Users
 


### PR DESCRIPTION
## Summary

- README.md: new "Known Limitations / Architectural Trade-offs" section documenting PBUF_RING 5.19+, io_uring buffer pool ceiling, SSH double-compression interaction, single-thread delta computation, daemon TLS gap, Windows IOCP wiring status, `.rsync-filter` inheritance audit gap.
- SECURITY.md: bumped supported-versions table to 0.6.x; new "Hardening Notes" section covering recycle_buffer release-mode bounds-check gap, bgid u16 namespace exhaustion, SSH double-compression amplification surface, daemon TLS-in-front guidance, daemon module hardening defaults.

These trade-offs are tracked individually as decomposed tasks (#2042-#2052) for follow-up implementation work.

## Test plan

- [ ] CI green (docs-only change, no behaviour impact)
- [ ] Render preview on GitHub looks correct
- [ ] Cross-links between README ↔ SECURITY resolve