### PR TITLE
docs: comment cleanup in platform crate

### DIFF
--- a/crates/platform/src/daemonize.rs
+++ b/crates/platform/src/daemonize.rs
@@ -58,7 +58,6 @@ pub fn redirect_stdio_to_devnull() -> io::Result<()> {
     let nix_to_io = |e: nix::Error| io::Error::from_raw_os_error(e as i32);
 
     for fd in 0..=2_i32 {
-        // nix::unistd::close is safe
         let _ = nix::unistd::close(fd);
         let new_fd =
             nix::fcntl::open(c"/dev/null", OFlag::O_RDWR, Mode::empty()).map_err(nix_to_io)?;

--- a/crates/platform/src/name_resolution.rs
+++ b/crates/platform/src/name_resolution.rs
@@ -33,9 +33,9 @@ pub fn name_to_rid(name: &str) -> Option<u32> {
     let mut domain_size: u32 = 0;
     let mut sid_type = SID_NAME_USE::default();
 
-    // First call to determine buffer sizes.
-    // SAFETY: Passing null buffers with zero sizes to get required sizes is
-    // the documented usage pattern for LookupAccountNameW.
+    // SAFETY: First call uses null buffers and zero sizes to retrieve the
+    // required buffer sizes - this is the documented two-call pattern for
+    // LookupAccountNameW.
     unsafe {
         let _ = LookupAccountNameW(
             PCWSTR::null(),
@@ -55,8 +55,8 @@ pub fn name_to_rid(name: &str) -> Option<u32> {
     let mut sid_buf = vec![0_u8; sid_size as usize];
     let mut domain_buf = vec![0_u16; domain_size as usize];
 
-    // SAFETY: `sid_buf` and `domain_buf` are correctly sized from the first call.
-    // `sid_type` receives the account type classification.
+    // SAFETY: Buffers are correctly sized from the first call; `sid_type`
+    // receives the account type classification.
     let ok = unsafe {
         LookupAccountNameW(
             PCWSTR::null(),

--- a/crates/platform/src/windows_service.rs
+++ b/crates/platform/src/windows_service.rs
@@ -115,7 +115,6 @@ mod windows_impl {
     /// process was not launched by the SCM).
     #[allow(unsafe_code)]
     pub fn run_service_dispatcher(callback: ServiceMainCallback) -> Result<(), io::Error> {
-        // Store the callback for retrieval in service_main.
         SERVICE_CALLBACK
             .set(std::sync::Mutex::new(Some(callback)))
             .map_err(|_| {
@@ -176,18 +175,13 @@ mod windows_impl {
 
         let _ = SERVICE_STATUS_HANDLE.set(SendSyncHandle(status_handle));
 
-        // Create signal flags and store them globally for the control handler.
+        // Publish flags globally so the control handler can reach them.
         let flags = SignalFlags::new();
         let _ = SERVICE_FLAGS.set(flags.clone());
 
-        // Report SERVICE_START_PENDING.
         let _ = report_status_raw(status_handle, SERVICE_START_PENDING, 0, 3000);
-
-        // Report SERVICE_RUNNING.
         let _ = report_status_raw(status_handle, SERVICE_RUNNING, 0, 0);
 
-        // Run the user callback. Extract it from the OnceLock<Mutex<Option>>
-        // with a flat chain of and_then to avoid deep nesting.
         let callback = SERVICE_CALLBACK
             .get()
             .and_then(|mutex| mutex.lock().ok())
@@ -198,7 +192,6 @@ mod windows_impl {
             None => 1,
         };
 
-        // Report SERVICE_STOPPED.
         let _ = report_status_raw(status_handle, SERVICE_STOPPED, exit_code, 0);
     }
 


### PR DESCRIPTION
## Summary

- Drop restatement-of-code comments in `daemonize.rs` (`// nix::unistd::close is safe`) and `windows_service.rs` (the `// Report SERVICE_*` lines and a couple of intent-restating preambles).
- Consolidate two consecutive comment blocks in `name_resolution.rs::name_to_rid` into a single SAFETY block that explains the documented two-call sizing pattern for `LookupAccountNameW` without duplicating the surrounding prose.

All `// upstream:` references and substantive `// SAFETY:` invariants in the crate are preserved verbatim. No code or rustdoc on public items was changed.

## Test plan

- [ ] CI: fmt + clippy
- [ ] CI: nextest (stable) on Linux/macOS/Windows