### PR TITLE
docs: comment cleanup in core::auth

### DIFF
--- a/crates/core/src/auth/mod.rs
+++ b/crates/core/src/auth/mod.rs
@@ -279,11 +279,9 @@ fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
         .zip(b.iter())
         .fold(0u8, |acc, (x, y)| acc | (x ^ y));
 
-    // Convert to bool without branching on intermediate values.
-    // wrapping_sub(1) on 0 gives 255 (0xFF), on any non-zero gives < 255.
-    // Right-shifting by 8 bits gives 0 for 0xFF and 0 for anything else that
-    // doesn't overflow. Instead, we use the fact that 0u8 == 0 is true.
-    // The fold above ensures constant-time iteration.
+    // The fold above visited every byte regardless of intermediate values, so
+    // the only timing-variable step that remains is this final equality check
+    // against zero, which is independent of where any difference occurred.
     diff == 0
 }
 
@@ -343,8 +341,6 @@ mod tests {
         assert_eq!(digests_for_response(&"A".repeat(len)), MD_LEGACY);
     }
 
-    // Tests for constant_time_eq
-
     #[test]
     fn constant_time_eq_returns_true_for_equal_slices() {
         assert!(constant_time_eq(b"hello", b"hello"));
@@ -368,7 +364,6 @@ mod tests {
 
     #[test]
     fn constant_time_eq_handles_single_byte_difference() {
-        // Test that even a single bit difference is detected
         assert!(!constant_time_eq(b"\x00", b"\x01"));
         assert!(!constant_time_eq(b"\xff", b"\xfe"));
     }
@@ -379,7 +374,6 @@ mod tests {
         let challenge = "mychallenge";
         let correct = compute_daemon_auth_response(secret, challenge, DaemonAuthDigest::Sha256);
 
-        // Tamper with the response
         let mut tampered = correct.clone();
         if let Some(c) = tampered.pop() {
             tampered.push(if c == 'A' { 'B' } else { 'A' });


### PR DESCRIPTION
## Summary

Comment cleanup in `crates/core/src/auth/` per the comment-cleanup rules. Task #2009.

## Files touched (net comment-line delta)

- `crates/core/src/auth/mod.rs`: -6 (9 deleted, 3 added)

## Changes

- Replaced stale/inaccurate commentary inside `constant_time_eq` that described a `wrapping_sub`/right-shift approach not present in the code; kept a concise note explaining the timing invariant of the final `diff == 0` check.
- Removed a decorative section header (`// Tests for constant_time_eq`) inside the `tests` module.
- Removed two restatement-only comments in tests (`// Test that even a single bit difference is detected`, `// Tamper with the response`) whose context is already conveyed by the test name and adjacent code.

Preserved (per rules):
- Module-level `//!` rustdoc.
- All upstream rsync references (`compat.c:858`, `csprotocol.txt`).
- Non-obvious WHY comments: protocol-version digest disambiguation, MD4/MD5 ambiguity rationale, the constant-time XOR-fold invariant, the `Security` rustdoc on `verify_daemon_auth_response`.
- `///` rustdoc on all public items.

**No production code lines were modified — comments only.**

Task: #2009.

## Test plan

- [ ] CI fmt+clippy passes (no logic changes).
- [ ] CI nextest passes (comments-only diff).