### PR TITLE
docs: comment cleanup in protocol::envelope

### DIFF
--- a/crates/protocol/src/envelope/tests/codes.rs
+++ b/crates/protocol/src/envelope/tests/codes.rs
@@ -79,7 +79,6 @@ fn message_code_try_from_u8_succeeds_for_all_18_codes() {
 fn message_code_all_array_contains_exactly_18_codes_with_correct_values() {
     assert_eq!(MessageCode::ALL.len(), 18);
 
-    // Map expected (variant, numeric_value) pairs
     let expected: [(MessageCode, u8); 18] = [
         (MessageCode::Data, 0),
         (MessageCode::ErrorXfer, 1),
@@ -183,7 +182,6 @@ fn message_code_from_u8_rejects_gap_values() {
 /// value for diagnostic purposes.
 #[test]
 fn message_code_try_from_u8_returns_unknown_message_code_error() {
-    // Test representative values from different gap ranges
     let invalid_values: &[u8] = &[
         11,  // First gap (11-21)
         21,  // Last value in first gap
@@ -287,7 +285,6 @@ fn message_code_from_u8_agrees_with_try_from_on_success() {
 /// Tests that `from_u8()` and `TryFrom<u8>` agree on failure cases.
 #[test]
 fn message_code_from_u8_agrees_with_try_from_on_failure() {
-    // Sample of invalid values
     for value in [11_u8, 50, 99, 150, 255] {
         let via_from = MessageCode::from_u8(value);
         let via_try = MessageCode::try_from(value).ok();
@@ -381,7 +378,6 @@ fn message_code_debug_differs_from_display() {
     for &code in MessageCode::all() {
         let debug_output = format!("{code:?}");
         let display_output = format!("{code}");
-        // Debug shows "Data", Display shows "MSG_DATA"
         assert_ne!(
             debug_output, display_output,
             "Debug and Display should differ for {code:?}"
@@ -406,12 +402,10 @@ fn message_code_values_are_unique() {
 /// Tests that the FLUSH alias constant has the expected properties.
 #[test]
 fn message_code_flush_alias_properties() {
-    // FLUSH is an alias for Info
     assert_eq!(MessageCode::FLUSH, MessageCode::Info);
     assert_eq!(MessageCode::FLUSH.as_u8(), 2);
     assert_eq!(MessageCode::FLUSH.name(), "MSG_INFO");
 
-    // MSG_FLUSH parses to Info
     let parsed: MessageCode = "MSG_FLUSH".parse().expect("MSG_FLUSH should parse");
     assert_eq!(parsed, MessageCode::FLUSH);
     assert_eq!(parsed, MessageCode::Info);

--- a/crates/protocol/src/envelope/tests/message_code_comprehensive.rs
+++ b/crates/protocol/src/envelope/tests/message_code_comprehensive.rs
@@ -1,17 +1,14 @@
-// Comprehensive tests for MessageCode and LogCode handling
-//
-// These tests verify:
-// - Wire format compatibility with upstream rsync 3.4.1
-// - Complete coverage of all message code variants
-// - Edge cases in parsing, formatting, and conversion
-// - Semantic correctness of message classification
-// - Cross-component integration between MessageCode and LogCode
+//! Comprehensive tests for MessageCode and LogCode handling.
+//!
+//! These tests verify:
+//! - Wire format compatibility with upstream rsync 3.4.1
+//! - Complete coverage of all message code variants
+//! - Edge cases in parsing, formatting, and conversion
+//! - Semantic correctness of message classification
+//! - Cross-component integration between MessageCode and LogCode
 
 use super::*;
 use std::collections::HashMap;
-
-// Wire Format Compatibility Tests
-// These tests verify that our message codes match upstream rsync's exact values
 
 /// Verifies that all message codes have the exact numeric values expected by
 /// upstream rsync 3.4.1. These values are defined in rsync.h and must match
@@ -141,7 +138,6 @@ fn message_code_is_logging_correctly_categorizes_all_variants() {
         );
     }
 
-    // Verify we covered all codes
     assert_eq!(
         logging_codes.len() + non_logging_codes.len(),
         MessageCode::ALL.len(),
@@ -177,11 +173,10 @@ fn message_code_flush_alias_is_info() {
     assert_eq!(MessageCode::FLUSH, MessageCode::Info);
     assert_eq!(MessageCode::FLUSH.as_u8(), 2);
 
-    // Parsing MSG_FLUSH should yield Info
     let parsed: MessageCode = "MSG_FLUSH".parse().expect("MSG_FLUSH should parse");
     assert_eq!(parsed, MessageCode::Info);
 
-    // But name() returns MSG_INFO, not MSG_FLUSH
+    // name() returns the canonical MSG_INFO, not the MSG_FLUSH alias.
     assert_eq!(MessageCode::FLUSH.name(), "MSG_INFO");
 }
 
@@ -189,7 +184,6 @@ fn message_code_flush_alias_is_info() {
 /// all logging variants.
 #[test]
 fn message_code_log_code_bidirectional_conversion() {
-    // All LogCodes except None should have a MessageCode equivalent
     for &log in LogCode::all() {
         if log == LogCode::None {
             assert!(
@@ -247,7 +241,6 @@ fn message_code_without_log_equivalent_fails_conversion() {
 /// LogCode variants.
 #[test]
 fn message_code_and_log_code_numeric_alignment() {
-    // These pairs should have the same numeric value
     let aligned_pairs = [
         (MessageCode::ErrorXfer, LogCode::ErrorXfer),
         (MessageCode::Info, LogCode::Info),
@@ -784,12 +777,10 @@ fn message_code_sparse_value_ranges() {
 /// Documents that log codes are contiguous (0-8) unlike message codes.
 #[test]
 fn log_code_contiguous_value_range() {
-    // Log codes are contiguous 0-8
     for i in 0u8..=8 {
         assert!(LogCode::from_u8(i).is_some(), "LogCode {i} should exist");
     }
 
-    // All other values are invalid
     for i in 9u8..=255 {
         assert!(
             LogCode::from_u8(i).is_none(),


### PR DESCRIPTION
## Summary

Comment cleanup pass over `crates/protocol/src/envelope/` per task #1984.
**No production code lines were modified** — every change is to
comments only.

## Files touched (net comment-line delta)

- `crates/protocol/src/envelope/tests/codes.rs` (-6 lines): removed
  five pure-restatement inline comments (`// Map expected ...`,
  `// Test representative values ...`, `// Sample of invalid values`,
  `// Debug shows "Data", Display shows "MSG_DATA"`,
  `// FLUSH is an alias for Info`, `// MSG_FLUSH parses to Info`).
- `crates/protocol/src/envelope/tests/message_code_comprehensive.rs`
  (+9 / -18, net -9): converted the top-of-file block comment from
  `//` to `//!` rustdoc (the file is a true module declared by
  `mod message_code_comprehensive;` in `tests/mod.rs`, never included
  via `include!()`); deleted a decorative banner
  (`// Wire Format Compatibility Tests` + restatement) and a handful
  of restatement comments inside test bodies.

## What was preserved

- All upstream-rsync references (`MSG_*` mnemonics, `enum msgcode`,
  `enum logcode`, `rsync.h`, protocol-version notes, etc.).
- All non-obvious WHY comments, including the `payload_len_usize`
  pointer-width rationale, the `tag without MPLEX_BASE offset`
  framing note, and the inline gap-range labels in
  `message_code_try_from_u8_returns_unknown_message_code_error`,
  which document which sparse gap each test value falls in.
- All `///` rustdoc on tests, types, and functions.

## Test plan
- [ ] CI fmt + clippy passes
- [ ] CI nextest passes (no production code changed; behaviour unchanged)