### PR TITLE
docs: comment cleanup in core::version

### DIFF
--- a/crates/core/src/version/constants.rs
+++ b/crates/core/src/version/constants.rs
@@ -78,7 +78,6 @@ pub const fn build_revision() -> &'static str {
 mod tests {
     use super::*;
 
-    // Tests for program name constants
     #[test]
     fn program_name_is_not_empty() {
         assert!(!PROGRAM_NAME.is_empty());
@@ -109,7 +108,6 @@ mod tests {
         assert!(!LEGACY_DAEMON_PROGRAM_NAME.is_empty());
     }
 
-    // Tests for copyright constants
     #[test]
     fn copyright_start_year_is_valid() {
         let year: u32 = COPYRIGHT_START_YEAR.parse().expect("valid year");
@@ -139,7 +137,6 @@ mod tests {
         assert!(COPYRIGHT_NOTICE.contains(LATEST_COPYRIGHT_YEAR));
     }
 
-    // Tests for source URL
     #[test]
     fn source_url_is_not_empty() {
         assert!(!SOURCE_URL.is_empty());
@@ -150,13 +147,11 @@ mod tests {
         assert!(SOURCE_URL.starts_with("http://") || SOURCE_URL.starts_with("https://"));
     }
 
-    // Tests for build toolchain
     #[test]
     fn build_toolchain_is_not_empty() {
         assert!(!BUILD_TOOLCHAIN.is_empty());
     }
 
-    // Tests for version constants
     #[test]
     fn upstream_base_version_is_not_empty() {
         assert!(!UPSTREAM_BASE_VERSION.is_empty());
@@ -174,7 +169,6 @@ mod tests {
 
     #[test]
     fn rust_version_is_valid_semver() {
-        // RUST_VERSION should be a valid semantic version (x.y.z)
         let parts: Vec<&str> = RUST_VERSION.split('.').collect();
         assert_eq!(parts.len(), 3, "RUST_VERSION should have three components");
         for part in parts {
@@ -187,7 +181,6 @@ mod tests {
 
     #[test]
     fn upstream_version_is_valid_semver() {
-        // UPSTREAM_BASE_VERSION should be a valid semantic version (x.y.z)
         let parts: Vec<&str> = UPSTREAM_BASE_VERSION.split('.').collect();
         assert_eq!(
             parts.len(),
@@ -202,7 +195,6 @@ mod tests {
         }
     }
 
-    // Tests for protocol version
     #[test]
     fn highest_protocol_version_in_valid_range() {
         assert!(HIGHEST_PROTOCOL_VERSION >= 28);
@@ -214,7 +206,6 @@ mod tests {
         assert_eq!(HIGHEST_PROTOCOL_VERSION, ProtocolVersion::NEWEST.as_u8());
     }
 
-    // Tests for build_revision function
     #[test]
     fn build_revision_returns_non_empty_string() {
         let revision = build_revision();

--- a/crates/core/src/version/metadata.rs
+++ b/crates/core/src/version/metadata.rs
@@ -214,7 +214,6 @@ pub const fn version_metadata_for_program(program_name: &'static str) -> Version
 mod tests {
     use super::*;
 
-    // Tests for version_metadata factory function
     #[test]
     fn version_metadata_returns_valid_metadata() {
         let meta = version_metadata();
@@ -243,7 +242,6 @@ mod tests {
         assert!(!meta.source_url().is_empty());
     }
 
-    // Tests for daemon_version_metadata
     #[test]
     fn daemon_version_metadata_uses_daemon_program_name() {
         let meta = daemon_version_metadata();
@@ -258,21 +256,18 @@ mod tests {
         assert_eq!(client.protocol_version(), daemon.protocol_version());
     }
 
-    // Tests for oc_version_metadata
     #[test]
     fn oc_version_metadata_uses_oc_program_name() {
         let meta = oc_version_metadata();
         assert_eq!(meta.program_name(), OC_PROGRAM_NAME);
     }
 
-    // Tests for oc_daemon_version_metadata
     #[test]
     fn oc_daemon_version_metadata_uses_oc_daemon_program_name() {
         let meta = oc_daemon_version_metadata();
         assert_eq!(meta.program_name(), OC_DAEMON_PROGRAM_NAME);
     }
 
-    // Tests for version_metadata_for_program
     #[test]
     fn version_metadata_for_program_uses_custom_name() {
         let meta = version_metadata_for_program("custom-rsync");
@@ -286,21 +281,18 @@ mod tests {
         assert_eq!(meta.protocol_version(), ProtocolVersion::NEWEST);
     }
 
-    // Tests for version_metadata_for_client_brand
     #[test]
     fn version_metadata_for_client_brand_uses_brand_name() {
         let meta = version_metadata_for_client_brand(Brand::Upstream);
         assert_eq!(meta.program_name(), Brand::Upstream.client_program_name());
     }
 
-    // Tests for version_metadata_for_daemon_brand
     #[test]
     fn version_metadata_for_daemon_brand_uses_brand_name() {
         let meta = version_metadata_for_daemon_brand(Brand::Upstream);
         assert_eq!(meta.program_name(), Brand::Upstream.daemon_program_name());
     }
 
-    // Tests for accessor methods
     #[test]
     fn program_name_accessor_returns_correct_value() {
         let meta = version_metadata();
@@ -331,7 +323,7 @@ mod tests {
     #[test]
     fn subprotocol_version_is_accessible() {
         let meta = version_metadata();
-        let _ = meta.subprotocol_version(); // Just verify it's accessible
+        let _ = meta.subprotocol_version();
     }
 
     #[test]
@@ -341,7 +333,6 @@ mod tests {
         assert!(!meta.build_toolchain().is_empty());
     }
 
-    // Tests for write_standard_banner
     #[test]
     fn write_standard_banner_includes_program_name() {
         let meta = version_metadata();
@@ -409,7 +400,6 @@ mod tests {
         let meta = version_metadata();
         let mut output = String::new();
         meta.write_standard_banner(&mut output).unwrap();
-        // Should contain the arch and OS
         assert!(output.contains(std::env::consts::ARCH));
         assert!(output.contains(std::env::consts::OS));
     }
@@ -422,7 +412,6 @@ mod tests {
         assert!(output.ends_with('\n'));
     }
 
-    // Tests for standard_banner
     #[test]
     fn standard_banner_returns_non_empty_string() {
         let meta = version_metadata();
@@ -439,7 +428,6 @@ mod tests {
         assert_eq!(expected, actual);
     }
 
-    // Tests for Default implementation
     #[test]
     fn default_returns_same_as_version_metadata() {
         let default = VersionMetadata::default();
@@ -447,7 +435,6 @@ mod tests {
         assert_eq!(default, explicit);
     }
 
-    // Tests for trait implementations
     #[test]
     fn version_metadata_is_clone() {
         let meta = version_metadata();

--- a/crates/core/src/version/report/config.rs
+++ b/crates/core/src/version/report/config.rs
@@ -399,7 +399,6 @@ impl Default for VersionInfoConfigBuilder {
 mod tests {
     use super::*;
 
-    // Tests for VersionInfoConfig::new
     #[test]
     fn new_creates_default_config() {
         let config = VersionInfoConfig::new();
@@ -429,7 +428,6 @@ mod tests {
         assert_eq!(config.secluded_args_mode, SecludedArgsMode::Optional);
     }
 
-    // Tests for Default trait
     #[test]
     fn default_equals_new() {
         let default_config = VersionInfoConfig::default();
@@ -437,7 +435,6 @@ mod tests {
         assert_eq!(default_config, new_config);
     }
 
-    // Tests for builder
     #[test]
     fn builder_creates_same_as_new() {
         let builder_config = VersionInfoConfig::builder().build();
@@ -452,7 +449,6 @@ mod tests {
         assert_eq!(default_builder, new_builder);
     }
 
-    // Tests for builder setters
     #[test]
     fn builder_supports_socketpairs() {
         let config = VersionInfoConfig::builder()
@@ -619,7 +615,6 @@ mod tests {
         assert_eq!(config.secluded_args_mode, SecludedArgsMode::Default);
     }
 
-    // Tests for to_builder
     #[test]
     fn to_builder_preserves_values() {
         let original = VersionInfoConfig::builder()
@@ -638,7 +633,6 @@ mod tests {
         assert!(modified.supports_crtimes);
     }
 
-    // Tests for from_config
     #[test]
     fn from_config_preserves_values() {
         let config = VersionInfoConfig::builder()
@@ -648,7 +642,6 @@ mod tests {
         assert_eq!(builder.build(), config);
     }
 
-    // Tests for builder chaining
     #[test]
     fn builder_chaining_works() {
         let config = VersionInfoConfig::builder()
@@ -663,7 +656,6 @@ mod tests {
         assert!(config.supports_asm_md5);
     }
 
-    // Tests for trait implementations
     #[test]
     fn config_is_clone() {
         let config = VersionInfoConfig::new();
@@ -700,11 +692,9 @@ mod tests {
         assert_eq!(builder, copied);
     }
 
-    // Tests for with_runtime_capabilities
     #[test]
     fn with_runtime_capabilities_returns_config() {
         let config = VersionInfoConfig::with_runtime_capabilities();
-        // Basic sanity checks - runtime values vary
         assert!(config.supports_ipv6);
         assert!(config.supports_atimes);
     }

--- a/crates/core/src/version/report/renderer.rs
+++ b/crates/core/src/version/report/renderer.rs
@@ -632,7 +632,6 @@ mod tests {
     fn empty_algorithm_list_shows_none() {
         let report = VersionInfoReport::default().with_checksum_algorithms(Vec::<&str>::new());
         let output = report.human_readable();
-        // When empty, should show "none" under the list
         assert!(output.contains("Checksum list:"));
     }
 

--- a/crates/core/src/version/secluded_args.rs
+++ b/crates/core/src/version/secluded_args.rs
@@ -78,7 +78,6 @@ impl FromStr for SecludedArgsMode {
 mod tests {
     use super::*;
 
-    // Tests for SecludedArgsMode::label
     #[test]
     fn optional_label() {
         assert_eq!(SecludedArgsMode::Optional.label(), "optional secluded-args");
@@ -89,7 +88,6 @@ mod tests {
         assert_eq!(SecludedArgsMode::Default.label(), "default secluded-args");
     }
 
-    // Tests for SecludedArgsMode::from_label
     #[test]
     fn from_label_optional() {
         let result = SecludedArgsMode::from_label("optional secluded-args");
@@ -118,7 +116,6 @@ mod tests {
         assert_eq!(SecludedArgsMode::from_label("default"), None);
     }
 
-    // Tests for Display trait
     #[test]
     fn display_optional() {
         assert_eq!(
@@ -135,7 +132,6 @@ mod tests {
         );
     }
 
-    // Tests for FromStr trait
     #[test]
     fn parse_optional() {
         let result: Result<SecludedArgsMode, _> = "optional secluded-args".parse();
@@ -160,7 +156,6 @@ mod tests {
         assert!(result.is_err());
     }
 
-    // Tests for trait implementations
     #[test]
     fn mode_is_clone() {
         let mode = SecludedArgsMode::Optional;
@@ -186,7 +181,6 @@ mod tests {
         assert_ne!(SecludedArgsMode::Optional, SecludedArgsMode::Default);
     }
 
-    // Tests for ParseSecludedArgsModeError
     #[test]
     fn error_display() {
         let err = "invalid".parse::<SecludedArgsMode>().unwrap_err();
@@ -208,7 +202,6 @@ mod tests {
         assert_eq!(err, copied);
     }
 
-    // Tests for roundtrip
     #[test]
     fn label_roundtrip_optional() {
         let mode = SecludedArgsMode::Optional;


### PR DESCRIPTION
## Summary

Comment cleanup in `crates/core/src/version/` (and submodules `version/features/`, `version/report/`) following the comment-cleanup rules. Removed decorative banner-style group comments and pure restatement comments from test modules. Preserved all rustdoc, upstream-fidelity, and meaningful WHY comments.

**No production code lines modified.** Only `//`-style banner/restatement comments removed inside `#[cfg(test)] mod tests` blocks (and one trailing `// Just verify it's accessible` comment within a test).

## Files touched and net comment-line delta

| File | Net delta |
|---|---|
| `crates/core/src/version/constants.rs` | -9 |
| `crates/core/src/version/metadata.rs` | -13 (`-14`/`+1` rewrite of one inline comment line) |
| `crates/core/src/version/report/config.rs` | -10 |
| `crates/core/src/version/report/renderer.rs` | -1 |
| `crates/core/src/version/secluded_args.rs` | -7 |

Total: 5 files, -40 net comment lines (1 insertion is the rewrite of a line that previously held an inline restatement comment).

## What was preserved

- `// case-sensitive` (`features/mod.rs`) - meaningful WHY comment.
- `// libc::time_t is deprecated on musl targets...` and follow-up alias comment (`report/renderer.rs`) - non-obvious WHY about platform-specific aliasing.
- All `///` rustdoc and `//!` module-level docs.

Refs #2015

## Test plan

- [x] `git diff --stat` confirms only `crates/core/src/version/**` files touched.
- [x] No production code lines (non-comment, non-blank) altered.
- [ ] CI: fmt+clippy, nextest, Windows, macOS, Linux musl.