### PR TITLE
docs: comment cleanup in cli::frontend::filter_rules

### DIFF
--- a/crates/cli/src/frontend/filter_rules/directive.rs
+++ b/crates/cli/src/frontend/filter_rules/directive.rs
@@ -177,7 +177,6 @@ mod tests {
     fn merge_directive_options_returns_reference() {
         let directive = MergeDirective::new(OsString::from("rules.txt"), None);
         let options = directive.options();
-        // Verify options are accessible via the reference
         let _ = options.inherit_rules();
     }
 

--- a/crates/cli/src/frontend/filter_rules/parsing/merge.rs
+++ b/crates/cli/src/frontend/filter_rules/parsing/merge.rs
@@ -345,7 +345,6 @@ mod tests {
         let result = parse_short_merge_directive(":- filter");
         assert!(result.is_some());
         if let Some(Ok(FilterDirective::Rule(spec))) = result {
-            // The rule should have exclude enforced
             let _ = spec;
         }
     }


### PR DESCRIPTION
## Summary

Apply the project's comment-cleanup rules to the `cli::frontend::filter_rules` module tree (10 source files reviewed).

## Net Delta

- Files touched: 2
- Lines removed: 2
- Lines added: 0

## Rules Applied:

- **KEEP**: comments referencing upstream rsync source, WHY comments, rustdoc.
- **DELETE**: restatement comments that echo the code, outdated comments, debug/checkpoint comments, decorative banners, commented-out code.

## Changes

Both deletions are restatement comments inside test code that simply echoed the next line:

1. `crates/cli/src/frontend/filter_rules/directive.rs` - removed `// Verify options are accessible via the reference` directly above the `let _ = options.inherit_rules();` call that performs that verification.
2. `crates/cli/src/frontend/filter_rules/parsing/merge.rs` - removed `// The rule should have exclude enforced` above a `let _ = spec;` no-op binding (the comment described an assertion the test never actually performed).

## Preserved

All upstream references kept intact:

- `arguments.rs` - `// upstream: options.c:1589-1598 ...` and `// upstream: options.c:1589 ...`
- `parsing/mod.rs` - `// upstream: exclude.c - a leading '/' on the merge filename ...`

All WHY comments documenting filter precedence, dir-merge anchoring semantics, modifier validation logic, and test rationale (Hide-as-exclude/Show-as-include semantics, CVS-ignore implication, modifier extraction rules, positional ordering of `-F` vs `--filter`) are preserved.

## Test plan

- [x] `cargo fmt --all -- --check` (CI)
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` (CI)
- [x] `cargo nextest run --workspace --all-features` (CI)
- [x] No logic changes; only comment removals in test bodies.