### PR TITLE
docs: comment cleanup in protocol::flist::hardlink

### DIFF
--- a/crates/protocol/src/flist/hardlink/tests.rs
+++ b/crates/protocol/src/flist/hardlink/tests.rs
@@ -107,7 +107,6 @@ mod basic {
     #[test]
     fn hardlink_table_different_devices() {
         let mut table = HardlinkTable::new();
-        // Same inode on different devices - should be separate entries
         let r1 = table.find_or_insert(DevIno::new(1, 100), 0);
         let r2 = table.find_or_insert(DevIno::new(2, 100), 1);
         assert_eq!(r1, HardlinkLookup::First(0));
@@ -128,8 +127,6 @@ mod collision {
     use std::collections::hash_map::DefaultHasher;
     use std::hash::{Hash, Hasher};
 
-    /// Test that files from different systems with same dev/ino are correctly linked.
-    ///
     /// When syncing from the same source filesystem, files with identical
     /// (dev, ino) pairs are true hardlinks and should be linked together.
     #[test]
@@ -153,10 +150,8 @@ mod collision {
         assert_eq!(entry.first_ndx, 0);
     }
 
-    /// Test that same inode on different devices are NOT linked.
-    ///
-    /// Different devices with the same inode number are distinct files,
-    /// not hardlinks. This can happen when syncing from multiple filesystems.
+    /// Different devices with the same inode number are distinct files, not
+    /// hardlinks. This can happen when syncing from multiple filesystems.
     #[test]
     fn same_inode_different_device_not_linked() {
         let mut table = HardlinkTable::new();
@@ -181,7 +176,6 @@ mod collision {
         assert_eq!(table.len(), 4);
     }
 
-    /// Test that same device with different inodes are NOT linked.
     #[test]
     fn same_device_different_inode_not_linked() {
         let mut table = HardlinkTable::new();
@@ -245,8 +239,6 @@ mod collision {
         }
     }
 
-    /// Test that DevIno hash considers both dev and ino fields.
-    ///
     /// Verifies that the Hash implementation produces different hashes
     /// for DevIno pairs that differ only in one field.
     #[test]
@@ -309,10 +301,8 @@ mod collision {
 mod large_scale {
     use crate::flist::hardlink::{DevIno, HardlinkLookup, HardlinkTable};
 
-    /// Test handling of many hardlinks to a single file.
-    ///
-    /// In practice, a single file can have thousands of hardlinks.
-    /// This tests that link_count handles high values correctly.
+    /// In practice, a single file can have thousands of hardlinks; verifies
+    /// `link_count` handles high values correctly.
     #[test]
     fn many_hardlinks_to_single_file() {
         let mut table = HardlinkTable::new();
@@ -335,8 +325,6 @@ mod large_scale {
         assert_eq!(table.len(), 1);
     }
 
-    /// Test handling of many distinct hardlink groups.
-    ///
     /// Verifies the table can handle thousands of distinct (dev, ino) pairs
     /// without degraded performance or incorrect lookups.
     #[test]
@@ -400,9 +388,7 @@ mod large_scale {
         }
     }
 
-    /// Test with maximum u32 file indices.
-    ///
-    /// Verifies handling of file indices near u32::MAX.
+    /// Verifies handling of file indices near `u32::MAX`.
     #[test]
     fn max_file_index_values() {
         let mut table = HardlinkTable::new();
@@ -422,7 +408,6 @@ mod large_scale {
         }
     }
 
-    /// Test with extreme dev/ino values.
     #[test]
     fn extreme_dev_ino_values() {
         let mut table = HardlinkTable::new();
@@ -449,9 +434,7 @@ mod large_scale {
         }
     }
 
-    /// Test link count approaching u32::MAX.
-    ///
-    /// While unlikely in practice, verifies no overflow in link_count.
+    /// While unlikely in practice, verifies no overflow in `link_count`.
     #[test]
     fn link_count_high_values() {
         let mut table = HardlinkTable::new();
@@ -476,8 +459,6 @@ mod large_scale {
 mod interleaved_access {
     use crate::flist::hardlink::{DevIno, HardlinkLookup, HardlinkTable};
 
-    /// Test interleaved inserts and lookups.
-    ///
     /// Simulates realistic usage where files are discovered in arbitrary order.
     #[test]
     fn interleaved_inserts_and_lookups() {
@@ -549,9 +530,7 @@ mod interleaved_access {
         assert_eq!(table.get(&dev_ino).unwrap().link_count, 1);
     }
 
-    /// Test that file index is preserved correctly through lookups.
-    ///
-    /// The first_ndx should always point to the first file inserted,
+    /// The `first_ndx` should always point to the first file inserted,
     /// regardless of how many subsequent links are added.
     #[test]
     fn first_index_preserved_through_many_links() {


### PR DESCRIPTION
## Summary

Apply comment-cleanup rules to `crates/protocol/src/flist/hardlink/` (`mod.rs`, `types.rs`, `table.rs`, `tests.rs`).

The module had already received a substantial pass; this change removes the remaining restatement comments and rustdoc lines that merely paraphrase the test function name. Production code logic is untouched.

### Rules applied

- DELETE: restatement comments that echo what the code says.
- KEEP: comments referencing upstream rsync source.
- KEEP: rustdoc paragraphs that explain WHY (real-world rationale, invariants, hash-collision goals).
- KEEP: `///` rustdoc on items where the rustdoc adds explanatory value beyond the identifier.

### Specific changes (all in `tests.rs`)

- Dropped one inline restatement comment (`// Same inode on different devices - should be separate entries`) whose content is fully expressed by the test name `hardlink_table_different_devices` and the assertions below it.
- Removed three single-line `///` rustdocs that exactly paraphrase their test function names: `same_device_different_inode_not_linked`, `extreme_dev_ino_values`, and (the leading restatement line of) `interleaved_inserts_and_lookups`.
- For seven multi-line test rustdocs, dropped the leading restatement line and kept only the WHY paragraph (rationale, invariant, real-world context). Affected tests: `same_dev_ino_same_system_are_linked`, `same_inode_different_device_not_linked`, `dev_ino_hash_uses_both_fields`, `many_hardlinks_to_single_file`, `many_distinct_hardlink_groups`, `max_file_index_values`, `link_count_high_values`, `first_index_preserved_through_many_links`.
- Tightened a few wrapped paragraphs and added backticks around identifiers (`first_ndx`, `link_count`, `u32::MAX`) for accurate rustdoc rendering.

### Already-clean findings

- `mod.rs`, `types.rs`, `table.rs` required no changes. `types.rs` already uses proper `/// upstream: hlink.c ...` form, and all rustdoc on public items is informative rather than restating.
- All upstream references (`hlink.c:match_hlinkinfo()`, `hlink.c:init_hard_links()`, `hlink.c struct idev`, `hlink.c struct hlink`) are preserved.

### Net comment-line delta

`tests.rs`: 7 insertions, 28 deletions = **-21 lines**.

## Test plan

- [ ] CI fmt + clippy pass
- [ ] CI nextest (stable) pass on the `hardlink` module
- [ ] No production-code logic modified; only comment/rustdoc text changes