### PR TITLE
docs(protocol): audit Windows path separator wire encoding (#1905)

### DIFF
--- a/docs/audits/windows-path-normalization.md
+++ b/docs/audits/windows-path-normalization.md
@@ -202,9 +202,12 @@ bytes contain only `/` separators - is queued for the follow-up fix.
 
 ## Follow-up Tasks
 
-1. **HIGH** Implement `to_wire_path_bytes()` and apply at every wire
+1. ~~**HIGH** Implement `to_wire_path_bytes()` and apply at every wire
    encode site. Add golden-byte test for nested-directory entries on
-   Windows. Tracks F1.
+   Windows. Tracks F1.~~ **CLOSED** by PR #3456 (helper landed as
+   `path_bytes_to_wire` in `crates/protocol/src/flist/wire_path.rs`)
+   and audit-confirmed in
+   `docs/audits/windows-path-separator-encoding.md`.
 2. **MEDIUM** Promote `engine::local_copy::operand_is_remote` to a
    shared helper and delete the duplicate in `transfer_role.rs`. Tracks
    F2.

--- a/docs/audits/windows-path-separator-encoding.md
+++ b/docs/audits/windows-path-separator-encoding.md
@@ -1,0 +1,154 @@
+# Windows Path Separator Encoding Audit
+
+Confirms that every sender-side wire-emit site for filenames and symlink
+targets normalizes Windows native `\` separators to POSIX `/` before the
+bytes leave the host. Complements the receiver-side hardening in
+PR #3496 (Windows drive-prefix rejection) and closes Finding F1 of the
+prior audit at `docs/audits/windows-path-normalization.md`.
+
+Tracks: issue #1905 (wire-encoded filename separator leak).
+
+Last updated: 2026-05-01.
+
+## Scope
+
+The rsync wire format treats filename bytes as opaque sequences with one
+implicit invariant: directory separators are `/`. Upstream rsync's only
+Windows port runs under Cygwin, whose POSIX layer presents `/`-separated
+paths to the application, so upstream never normalizes separators in the
+emit path - it relies on the OS surface. oc-rsync targets native Win32
+(`windows-msvc` and `windows-gnu`) where `std::path::PathBuf::push` and
+`Path::join` produce `\`-separated bytes. Without explicit normalization
+on the sender, those bytes would reach the wire and break interop with
+any non-Cygwin peer.
+
+This audit walks every code path that converts a `Path` (or `PathBuf`)
+into bytes destined for the wire and confirms the conversion goes
+through the central helper.
+
+## Central helper
+
+`crates/protocol/src/flist/wire_path.rs:33-60` defines
+`path_bytes_to_wire(p: &Path) -> Cow<'_, [u8]>`:
+
+- On Unix (`#[cfg(unix)]`), the function is a zero-copy borrow of the
+  `OsStr` bytes. `\` is a legitimate filename byte on POSIX and is
+  preserved verbatim.
+- On non-Unix (`#[cfg(not(unix))]`, i.e. Windows), the function inspects
+  the encoded bytes and only allocates when at least one `\` byte is
+  present, in which case every `\` is replaced with `/`. Inputs that
+  were already `/`-separated take the borrow path with no allocation.
+
+The helper mirrors the identity-on-Unix / convert-on-Windows shape of
+the sibling `wire_mode` module so the platform contract is documented
+in one place.
+
+## Sender-side wire-emit sites
+
+Every site that writes a filename or symlink-target byte stream to the
+wire goes through `path_bytes_to_wire`:
+
+1. **Filename emission** -
+   `crates/protocol/src/flist/entry/accessors.rs:131-135`
+   `FileEntry::name_bytes()` returns `path_bytes_to_wire(&self.name)`.
+   This is the single accessor used by the writer for the on-wire name.
+
+2. **Filename writer call site** -
+   `crates/protocol/src/flist/write/mod.rs:376`
+   `let raw_name = entry.name_bytes();` is the only path that produces
+   the bytes consumed by `write_name()`. There is no parallel "raw" path.
+
+3. **Symlink target emission** -
+   `crates/protocol/src/flist/write/encoding.rs:115-124`
+   `write_symlink_target` calls `path_bytes_to_wire(target.as_path())`
+   before `writer.write_all(&target_bytes)`. The `varint30(len)` prefix
+   is computed from the normalized byte count.
+
+4. **Batched flist writer** -
+   `crates/protocol/src/flist/batched_writer/writer.rs:216`
+   delegates to `FileListWriter::write_entry`, inheriting the same
+   normalization for `--write-batch` mode.
+
+5. **Generator file-list emission** -
+   `crates/transfer/src/generator/protocol_io.rs:240` and
+   `crates/transfer/src/generator/protocol_io.rs:310`
+   both call `flist_writer.write_entry(writer, entry)`, so the
+   sender's two emission loops (initial flist, INC_RECURSE segments)
+   share the normalized path.
+
+6. **Local-copy executor batch capture** -
+   `crates/engine/src/local_copy/executor/directory/recursive/batch.rs:152`
+   calls `flist_writer.write_entry(&mut buf, &entry)` to capture the
+   batch flist into a buffer that is later spooled to the batch file.
+   The same `path_bytes_to_wire` route is taken.
+
+## Sites that do *not* require normalization
+
+The following sites surface path bytes for purposes other than wire
+emission and are correctly left unnormalized:
+
+- `crates/protocol/src/flist/entry/accessors.rs:79-95` Unix branch of
+  `strip_leading_slashes`, which trims `/` (and only `/`) from a path
+  that lives in a `PathBuf`. The companion non-Unix branch trims both
+  `/` and `\` so receive-side normalization stays consistent (line
+  103). Trimming is independent from wire emission.
+- `crates/protocol/src/flist/trace.rs:180` formats the entry name for
+  human-readable trace logging, not the wire.
+- `crates/protocol/src/xattr/wire/encode.rs:56` writes xattr *attribute
+  names* (e.g. `user.foo`), not paths. Attribute names never contain
+  separators.
+- `crates/engine/src/local_copy/executor/directory/recursive/batch.rs:169`
+  records sort-key metadata for `flist_sort_and_clean()` parity. The
+  bytes never leave the process - they exist only to compute the
+  traversal-to-sorted index map for the local batch writer.
+
+## Test coverage
+
+Per-platform regression tests live next to the helper in
+`crates/protocol/src/flist/wire_path.rs:62-136`:
+
+- `forward_slash_path_is_identity` (all platforms).
+- `empty_path_yields_empty_bytes` (all platforms).
+- `dot_path_is_identity` (all platforms).
+- `unix_borrows_without_allocation` (`#[cfg(unix)]`) - verifies the
+  zero-copy invariant.
+- `unix_preserves_backslash_byte_in_filename` (`#[cfg(unix)]`) -
+  guards against accidentally rewriting `\` on POSIX where it is a
+  valid filename byte.
+- `windows_backslash_is_translated_to_forward_slash` (`#[cfg(windows)]`)
+  - the canonical fix-target: `PathBuf::push` produces `\` bytes that
+  must be rewritten.
+- `windows_deep_path_is_translated` (`#[cfg(windows)]`) - multiple
+  `\` separators in a single literal.
+- `windows_already_forward_slash_borrows` (`#[cfg(windows)]`) - the
+  borrow path is exercised when no `\` byte is present.
+- `windows_mixed_separators_are_normalized` (`#[cfg(windows)]`) -
+  inputs that interleave `/` and `\` (e.g. paths constructed by
+  `Path::join("a/b", "c\\d")`) emit pure `/`.
+
+## Result
+
+Audit confirmed clean: the fix that closes F1 from
+`docs/audits/windows-path-normalization.md` is live, every wire-emit
+site routes through `path_bytes_to_wire`, and the regression test
+matrix covers the documented edge cases. No code change is required by
+this audit.
+
+## References
+
+- Upstream `flist.c:534-570` `send_file_entry()` filename emission -
+  bytes are written verbatim with no separator normalization.
+- Upstream `flist.c:660-670` `send_file_entry()` symlink-target
+  emission - same verbatim contract as filename.
+- Upstream `util1.c:955-961` `__CYGWIN__` block - the only `\`
+  handling in upstream lives at the Cygwin POSIX boundary, which
+  oc-rsync does not run under.
+- PR #3456 - prior fix that introduced `path_bytes_to_wire` and the
+  per-platform test matrix.
+- PR #3496 - receiver-side counterpart that rejects Windows drive
+  prefixes (`Component::Prefix`) from untrusted senders during
+  `sanitize_file_list`.
+- `docs/audits/windows-path-normalization.md` - the originating audit
+  whose Finding F1 this audit retires.
+- `docs/audits/windows-path-edge-cases.md` - the broader Windows
+  hazard catalog referenced by PR #3496.


### PR DESCRIPTION
## Summary

- Adds `docs/audits/windows-path-separator-encoding.md` confirming that every sender-side wire-emit site for filenames and symlink targets routes through the `path_bytes_to_wire` helper, normalizing native `\` separators to `/` on Windows before bytes leave the host.
- Marks Finding F1 in `docs/audits/windows-path-normalization.md` as **CLOSED** with cross-references to the implementing PR (#3456) and this confirming audit.
- Documents the central helper, the six wire-emit call sites, the four non-wire path-byte sites that intentionally do not normalize, and the per-platform regression test matrix.

This is the sender-side counterpart to PR #3496 (receiver-side rejection of Windows drive prefixes from untrusted senders). Together they cover the bidirectional Windows path-separator hazard surface.

## Why docs-only

Investigation found the conversion is already correctly applied at every wire-emit call site:

- `crates/protocol/src/flist/entry/accessors.rs:131-135` (`name_bytes()`).
- `crates/protocol/src/flist/write/encoding.rs:115-124` (`write_symlink_target`).
- `crates/protocol/src/flist/write/mod.rs:376` (single bytes path into `write_name`).
- `crates/protocol/src/flist/batched_writer/writer.rs:216` (delegates to `FileListWriter::write_entry`).
- `crates/transfer/src/generator/protocol_io.rs:240,310` (initial flist + INC_RECURSE segments).
- `crates/engine/src/local_copy/executor/directory/recursive/batch.rs:152` (batch capture).

Test matrix verified in `crates/protocol/src/flist/wire_path.rs:62-136`, including `windows_backslash_is_translated_to_forward_slash`, `windows_deep_path_is_translated`, `windows_already_forward_slash_borrows`, and `windows_mixed_separators_are_normalized`.

Per upstream `flist.c:send_file_entry()` (lines 534-570 for filename, 660-670 for symlink target), filename bytes are written verbatim and the wire format requires POSIX `/` separators - upstream's only Windows port runs under Cygwin's POSIX layer, so upstream itself never normalizes.

## Test plan

- [x] No code changes - documentation only.
- [ ] CI fmt+clippy and Linux/macOS/Windows/Linux-musl matrices pass.
- [ ] Existing `path_bytes_to_wire` regression tests continue to pass (no behaviour change).