### PR TITLE
test(interop): add --iconv UTF-8/LATIN1 round-trip vs upstream 3.4.1 (#1916)

### DIFF
--- a/tools/ci/check_known_failures.sh
+++ b/tools/ci/check_known_failures.sh
@@ -252,6 +252,45 @@ run_standalone_test_by_name() {
       timeout "$hard_timeout" "$oc_bin" -av --iconv=utf8,latin1 --timeout=10 \
           "${comp_src}/" "${idest}/" >/dev/null 2>&1 || return 1
       ;;
+    iconv-upstream)
+      # Reproducer for #1916: --iconv UTF-8/LATIN1 round-trip vs upstream
+      # rsync 3.4.1. Mirrors the standalone harness scenario but with a
+      # minimal fixture so the dashboard can rerun quickly.
+      local iu_src="${dest}/iconv-up-src"
+      local iu_dest_oc="${dest}/iconv-up-dest-oc"
+      local iu_conf="${dest}/iconv-up-oc.conf"
+      local iu_pid="${dest}/iconv-up-oc.pid"
+      local iu_log="${dest}/iconv-up-oc.log"
+      local iu_port iu_rc=0
+      iu_port=$(alloc_port)
+      mkdir -p "$iu_src" "$iu_dest_oc"
+      echo "ascii body" > "${iu_src}/plain.txt"
+      echo "cafe body" > "${iu_src}/café.txt" 2>/dev/null || return 2
+      [[ -f "${iu_src}/café.txt" ]] || return 2
+      cat > "$iu_conf" <<CONF
+pid file = ${iu_pid}
+port = ${iu_port}
+use chroot = false
+
+[interop]
+path = ${iu_dest_oc}
+read only = false
+numeric ids = yes
+charset = ISO-8859-1
+CONF
+      if ! start_daemon "$oc_bin" "$iu_conf" "$iu_log" "$iu_pid" "$iu_port"; then
+        stop_daemon "$iu_pid"
+        return 1
+      fi
+      timeout "$hard_timeout" "$upstream_binary" -av \
+          --iconv=UTF-8,ISO-8859-1 --timeout=10 \
+          "${iu_src}/" "rsync://127.0.0.1:${iu_port}/interop" \
+          >/dev/null 2>&1 || iu_rc=$?
+      stop_daemon "$iu_pid"
+      [[ $iu_rc -eq 0 ]] || return 1
+      [[ -f "${iu_dest_oc}/café.txt" ]] || return 1
+      cmp -s "${iu_src}/café.txt" "${iu_dest_oc}/café.txt" || return 1
+      ;;
     upstream-compressed-batch-self-roundtrip)
       # upstream rsync 3.4.1 cannot read back its own compressed delta batch
       # files. The batch writer records raw compressed tokens (zlib DEFLATED_DATA)

--- a/tools/ci/known_failures.conf
+++ b/tools/ci/known_failures.conf
@@ -17,6 +17,24 @@
 
 # Unconditional known failures (direction:name).
 KNOWN_FAILURES=(
+  # OC-RSYNC GAP: --iconv daemon-mode interop with upstream rsync 3.4.1.
+  # Reference: #1916, docs/audits/iconv-pipeline.md.
+  #
+  # PR #3458 bridged IconvSetting -> FilenameConverter for SSH/local transfers,
+  # but daemon-mode iconv negotiation is still incomplete: the `charset =`
+  # module directive is parsed (crates/daemon/src/daemon/sections/config_parsing
+  # /module_directives.rs:330) but never threaded into the daemon's iconv setup
+  # path. Findings 1-3 of the audit (symlink target transcoding, --files-from
+  # forwarding, --secluded-args/--protect-args transcoding) also remain open.
+  #
+  # Until daemon-side `charset` is wired to the iconv runtime, --iconv from a
+  # client to an oc-rsync daemon either fails outright (option refused per
+  # upstream contract) or stores raw wire bytes on disk (mojibake). The
+  # interop test sets `charset = ISO-8859-1` on the daemon and pushes UTF-8
+  # source names with --iconv=UTF-8,ISO-8859-1.
+  # NOT FIXABLE HERE: requires daemon iconv plumbing follow-up.
+  "standalone:iconv-upstream"
+
   # OC-RSYNC BUG: oc-rsync sends all literal data (matched=0) in daemon mode
   # instead of performing delta transfer. The delta engine does not engage when
   # operating as an rsync daemon server, so block-match statistics show 0 matched
@@ -115,6 +133,10 @@ is_known_failure_from_conf() {
 # test_method: "daemon" for scenario-based, "standalone" for standalone tests.
 # Keep in sync with actual known failure rules above.
 DASHBOARD_ENTRIES=(
+  # --- oc-rsync known gaps (unconditional) ---
+  # daemon-mode iconv: `charset =` directive parsed but not wired to iconv runtime
+  "standalone:iconv-upstream|--iconv UTF-8/LATIN1 round-trip vs upstream 3.4.1 (#1916, daemon `charset` directive not yet wired to iconv runtime; see docs/audits/iconv-pipeline.md)|standalone"
+
   # --- oc-rsync known bugs (unconditional) ---
   # delta engine does not engage in daemon mode - all data sent as literals
   "standalone:delta-stats|delta-stats in daemon mode (oc-rsync sends matched=0, delta engine not active in daemon code path)|standalone"

--- a/tools/ci/run_interop.sh
+++ b/tools/ci/run_interop.sh
@@ -3091,6 +3091,157 @@ test_iconv() {
   return 0
 }
 
+# #1916: --iconv UTF-8/LATIN1 round-trip vs upstream rsync 3.4.1
+# Verifies that upstream rsync 3.4.1 and oc-rsync interoperate when the user
+# requests --iconv=UTF-8,ISO-8859-1. Both directions are exercised:
+#   1. upstream client -> oc-rsync daemon (push)
+#   2. oc-rsync client -> upstream daemon (push)
+# In each direction the source contains UTF-8 filenames whose code points all
+# fit in ISO-8859-1 (Latin-1). With --iconv enabled, the wire encoding is
+# Latin-1 and both peers must transcode back to UTF-8 on disk.
+#
+# References:
+#   upstream: options.c:recv_iconv_settings (parses --iconv=LOCAL,REMOTE)
+#   upstream: flist.c:1579-1603 (sender filename iconvbufs(ic_send, ...))
+#   upstream: flist.c:738-754 (receiver filename iconvbufs(ic_recv, ...))
+#   oc-rsync: docs/audits/iconv-pipeline.md (Findings 1-5)
+#
+# The test is deterministic: same fixture bytes every run, ASCII fallback
+# files act as the always-passing baseline, and Latin-1 representable names
+# are the iconv probe.
+test_iconv_upstream_interop() {
+  local upstream_binary=$1 oc_bin=$2 src_dir=$3 work=$4 log=$5 \
+        oc_port=$6 upstream_port=$7
+
+  local ic_src="${work}/iconv-up-src"
+  local ic_dest_oc="${work}/iconv-up-dest-oc"
+  local ic_dest_up="${work}/iconv-up-dest-up"
+  rm -rf "$ic_src" "$ic_dest_oc" "$ic_dest_up"
+  mkdir -p "$ic_src" "$ic_dest_oc" "$ic_dest_up"
+
+  # ASCII baseline: must always survive any iconv pipeline.
+  echo "ascii body" > "${ic_src}/plain.txt"
+
+  # UTF-8 names whose code points all fit in ISO-8859-1 (Latin-1):
+  # - U+00E9 LATIN SMALL LETTER E WITH ACUTE (cafe)
+  # - U+00FC LATIN SMALL LETTER U WITH DIAERESIS, U+00DF SHARP S
+  # - U+00E5 LATIN SMALL LETTER A WITH RING ABOVE
+  echo "cafe body" > "${ic_src}/café.txt"
+  echo "umlaut body" > "${ic_src}/über.txt"
+  echo "nordic body" > "${ic_src}/ångström.txt"
+
+  # Skip the test gracefully if the host filesystem rejects any UTF-8 names
+  # (e.g. a non-UTF-8 locale or a filesystem that NFC-normalises).
+  for fname in "café.txt" "über.txt" "ångström.txt"; do
+    if [[ ! -f "${ic_src}/${fname}" ]]; then
+      echo "    SKIP: host filesystem cannot store UTF-8 name '${fname}'"
+      return 0
+    fi
+  done
+
+  local -a expected_files=(
+    "plain.txt"
+    "café.txt"
+    "über.txt"
+    "ångström.txt"
+  )
+
+  _ic_verify_round_trip() {
+    local label=$1 dest=$2
+    for fname in "${expected_files[@]}"; do
+      if [[ ! -f "${dest}/${fname}" ]]; then
+        echo "    ${label}: ${fname} missing after iconv transfer"
+        echo "    ${label}: dest contents: $(find "$dest" -type f | sort | tr '\n' ' ')"
+        return 1
+      fi
+      if ! cmp -s "${ic_src}/${fname}" "${dest}/${fname}"; then
+        echo "    ${label}: ${fname} content mismatch after iconv transfer"
+        return 1
+      fi
+    done
+    return 0
+  }
+
+  # --- Direction 1: upstream client -> oc-rsync daemon ---
+  # Upstream encodes UTF-8 source names into ISO-8859-1 on the wire; oc-rsync
+  # daemon must decode back to UTF-8 (its local charset) on disk.
+  local ic_oc_conf="${work}/iconv-up-oc.conf"
+  local ic_oc_pid="${work}/iconv-up-oc.pid"
+  local ic_oc_log="${work}/iconv-up-oc.log"
+  cat > "$ic_oc_conf" <<CONF
+pid file = ${ic_oc_pid}
+port = ${oc_port}
+use chroot = false
+
+[interop]
+path = ${ic_dest_oc}
+comment = iconv interop test
+read only = false
+numeric ids = yes
+charset = ISO-8859-1
+CONF
+
+  start_oc_daemon_with_retry "$ic_oc_conf" "$ic_oc_log" "$upstream_binary" \
+      "$ic_oc_pid" "$oc_port"
+
+  local rc1=0
+  timeout "$hard_timeout" "$upstream_binary" -av \
+      --iconv=UTF-8,ISO-8859-1 --timeout=10 \
+      "${ic_src}/" "rsync://127.0.0.1:${oc_port}/interop" \
+      >"${log}.iconv-up-oc.out" 2>"${log}.iconv-up-oc.err" || rc1=$?
+  stop_oc_daemon
+
+  if [[ $rc1 -ne 0 ]]; then
+    echo "    upstream -> oc daemon iconv push failed (exit=$rc1)"
+    echo "    stderr: $(head -5 "${log}.iconv-up-oc.err")"
+    echo "    daemon log: $(tail -5 "$ic_oc_log" 2>/dev/null)"
+    return 1
+  fi
+
+  _ic_verify_round_trip "upstream->oc" "$ic_dest_oc" || return 1
+
+  # --- Direction 2: oc-rsync client -> upstream daemon ---
+  # oc-rsync encodes UTF-8 source names into ISO-8859-1 on the wire; upstream
+  # daemon decodes back to UTF-8 (its local charset, per `charset =`) on disk.
+  local ic_up_conf="${work}/iconv-up-up.conf"
+  local ic_up_pid="${work}/iconv-up-up.pid"
+  local ic_up_log="${work}/iconv-up-up.log"
+  cat > "$ic_up_conf" <<CONF
+pid file = ${ic_up_pid}
+port = ${upstream_port}
+use chroot = false
+munge symlinks = false
+
+[interop]
+path = ${ic_dest_up}
+comment = iconv interop test
+read only = false
+numeric ids = yes
+charset = ISO-8859-1
+CONF
+
+  start_upstream_daemon_with_retry "$upstream_binary" "$ic_up_conf" \
+      "$ic_up_log" "$ic_up_pid"
+
+  local rc2=0
+  timeout "$hard_timeout" "$oc_bin" -av \
+      --iconv=UTF-8,ISO-8859-1 --timeout=10 \
+      "${ic_src}/" "rsync://127.0.0.1:${upstream_port}/interop" \
+      >"${log}.iconv-up-up.out" 2>"${log}.iconv-up-up.err" || rc2=$?
+  stop_upstream_daemon
+
+  if [[ $rc2 -ne 0 ]]; then
+    echo "    oc -> upstream daemon iconv push failed (exit=$rc2)"
+    echo "    stderr: $(head -5 "${log}.iconv-up-up.err")"
+    echo "    daemon log: $(tail -5 "$ic_up_log" 2>/dev/null)"
+    return 1
+  fi
+
+  _ic_verify_round_trip "oc->upstream" "$ic_dest_up" || return 1
+
+  return 0
+}
+
 # #885: Comprehensive hardlink interop
 # Tests hardlink scenarios that go beyond the basic -H flag: multiple hardlink
 # groups, chains of 3+ links to the same inode, hardlinks across subdirectories,
@@ -8716,6 +8867,7 @@ run_standalone_interop_tests() {
     "read-only-module"
     "wrong-password-auth"
     "iconv"
+    "iconv-upstream"
     "hardlinks-comprehensive"
     "inc-recurse-comprehensive"
     "inc-recurse-sender-push"
@@ -8787,6 +8939,7 @@ run_standalone_interop_tests() {
     "test_read_only_module"
     "test_wrong_password_auth"
     "test_iconv"
+    "test_iconv_upstream_interop"
     "test_hardlinks_comprehensive"
     "test_inc_recurse_comprehensive"
     "test_inc_recurse_sender_push"
@@ -8865,6 +9018,9 @@ run_standalone_interop_tests() {
         test_args+=("$oc_port" "$upstream_port")
         ;;
       wrong-password-auth)
+        test_args+=("$oc_port" "$upstream_port")
+        ;;
+      iconv-upstream)
         test_args+=("$oc_port" "$upstream_port")
         ;;
       hardlinks-comprehensive)


### PR DESCRIPTION
## Summary

- Adds `test_iconv_upstream_interop` to the standalone interop matrix in `tools/ci/run_interop.sh`. It exercises `--iconv=UTF-8,ISO-8859-1` in both directions between oc-rsync and upstream rsync 3.4.1 via daemon transport, with a deterministic UTF-8 fixture (`café.txt`, `über.txt`, `ångström.txt`, plus an ASCII baseline) whose code points all fit in Latin-1.
- Tracks the gap as a known failure: the audit in `docs/audits/iconv-pipeline.md` (Findings 1-5) plus PR #3458's bridge fix the SSH/local path, but daemon-mode iconv (the `charset =` directive) is not yet wired to the iconv runtime, so this test surfaces the remaining work without blocking CI.
- Adds a matching reproducer in `tools/ci/check_known_failures.sh` so the tracking dashboard can rerun the scenario as the gap is closed.

## What changed

- `tools/ci/run_interop.sh`: new `test_iconv_upstream_interop` function (after the existing `test_iconv` at line 3092). Wired into the standalone matrix at the `test_names`, `test_funcs`, and port-injection `case` branches.
- `tools/ci/known_failures.conf`: new `"standalone:iconv-upstream"` entry in `KNOWN_FAILURES` and a corresponding `DASHBOARD_ENTRIES` row referencing `#1916` and the audit doc.
- `tools/ci/check_known_failures.sh`: new `iconv-upstream)` dispatch case that drives a minimal upstream-client -> oc-rsync-daemon push.

## Test plan

- [ ] CI: Interop Validation workflow runs `tools/ci/run_interop.sh`. The new scenario should appear under `[standalone] iconv-upstream` and be reported as `SKIP (known limitation)` until the daemon iconv plumbing lands.
- [ ] CI: fmt+clippy, nextest (stable), Windows, macOS, Linux musl pass unchanged (no Rust changes).
- [ ] When daemon iconv plumbing is wired, drop the `KNOWN_FAILURES` entry; the test should then report `PASS` for both directions.

## References

- Audit: `docs/audits/iconv-pipeline.md`
- Bridge: PR #3458 (`feat: bridge IconvSetting to FilenameConverter`)
- Tracking: #1916
- Upstream: `options.c::recv_iconv_settings`, `flist.c:1579-1603` (sender), `flist.c:738-754` (receiver)