### PR TITLE
docs(rsync_io): audit SSH socketpair vs anonymous pipes for stdio transport (#1938)

### DIFF
--- a/docs/audits/ssh-socketpair-vs-pipes.md
+++ b/docs/audits/ssh-socketpair-vs-pipes.md
@@ -1,511 +1,799 @@
-# socketpair(2) vs anonymous pipes for the SSH subprocess
+# SSH stdio transport: socketpair(AF_UNIX, SOCK_STREAM) vs anonymous pipes
 
-Tracking issues: oc-rsync tasks #1686 (transport channel topology) and #1689
-(stderr multiplexing).
+Tracker: #1938 (formal audit). Branch: `docs/ssh-socketpair-1938`.
+No code changes - documentation only.
 
-## Summary
+Prerequisite trackers:
 
-Upstream rsync 3.4.1 uses `socketpair(AF_UNIX, SOCK_STREAM, 0)` for the wire
-between the parent rsync and its forked or `exec`-ed peer. The pair is
-created twice (one per direction) in `pipe.c::piped_child` and
-`pipe.c::local_child`, with a `pipe(2)` fallback selected at configure time
-when the host lacks `socketpair`. oc-rsync currently spawns SSH with
-`Command::stdin(Stdio::piped()) + Command::stdout(Stdio::piped())`, i.e. two
-half-duplex anonymous pipes. The stderr channel is already wired through a
-`socketpair` on Unix (added for #1689 groundwork), so half of the upstream
-topology is already in place.
+- #1686 (evaluate socketpair vs stdio pipes for SSH subprocess) - completed
+  via PR #3438; the merged audit was the working notebook this report
+  consolidates.
+- #1858 (document SSH stdio limitation: io_uring socket path is unreachable
+  for SSH transfers) - completed via PR #3418, recorded in
+  `crates/rsync_io/src/ssh/mod.rs:57-75`.
+- #1689 (add SSH subprocess stderr forwarding via socketpair auxiliary
+  channel) - completed via PR #3383; the socketpair stderr code lives in
+  `crates/rsync_io/src/ssh/aux_channel.rs:138-193`.
 
-This audit recommends a phased migration to a socketpair-backed wire on
-Unix while keeping anonymous pipes as the Windows fallback. The migration is
-additive, requires no protocol or wire-format changes, and consolidates the
-read and write FDs into a single bidirectional descriptor that can be polled
-once. The auxiliary stderr socketpair stays as is and continues to provide a
-real socket FD for future poll/epoll/kqueue integration.
+Pending follow-up trackers this audit informs:
 
-## 1. Current oc-rsync model
+- #1687 (prototype SSH subprocess using socketpair for bidirectional I/O).
+- #1902 (verify SSH socketpair vs anonymous-pipe wire claim against
+  `rsync_io` source).
 
-Single spawn site:
+Companion audits:
 
-- `crates/rsync_io/src/ssh/builder.rs:280-282` configures the child stdio:
-  ```rust
-  let mut command = Command::new(&program);
-  command.stdin(Stdio::piped());
-  command.stdout(Stdio::piped());
-  ```
-  These calls each create an anonymous `pipe(2)` pair under the hood
-  (Rust's `process_unix.rs::AnonPipe::pipe`). The parent retains the write
-  end of the stdin pipe and the read end of the stdout pipe; the child
-  receives the opposite ends as fds 0 and 1.
+- `docs/audits/iouring-pipe-stdio.md` (#1859 - io_uring on pipe FDs).
+- `docs/audits/splice-ssh-stdio.md` (#1860 - splice/vmsplice for SSH stdio).
 
-- `crates/rsync_io/src/ssh/builder.rs:293` installs the stderr channel:
-  ```rust
-  let parent_socketpair_end = configure_stderr_channel(&mut command);
-  ```
-  On Unix this attempts `UnixStream::pair()` and hands the child end to the
-  command via `Stdio::from(child_fd)`; on failure or on Windows the child
-  inherits a conventional `Stdio::piped()` stderr.
-  See `crates/rsync_io/src/ssh/aux_channel.rs:264-291`.
+## 1. Summary
 
-- `crates/rsync_io/src/ssh/connection.rs:30-39` stores the parent ends:
-  ```rust
-  pub struct SshConnection {
-      child: Arc<Mutex<Option<Child>>>,
-      stdin: Option<ChildStdin>,
-      stdout: Option<ChildStdout>,
-      stderr_drain: Option<BoxedStderrChannel>,
-      connect_watchdog: Option<ConnectWatchdog>,
-  }
-  ```
+Upstream rsync 3.4.1 sets up the SSH child via two `socketpair(AF_UNIX,
+SOCK_STREAM, 0)` invocations (one for each direction of the wire), with a
+configure-time fallback to `pipe(2)` on hosts that lack `socketpair`. Both
+ends are forced non-blocking. The same `fd_pair` helper is used for the
+read-batch back-channel and the receiver error pipe, so socketpair is the
+default IPC primitive throughout upstream. oc-rsync currently spawns SSH
+with two anonymous `pipe(2)` pairs - `Command::stdin(Stdio::piped())` and
+`Command::stdout(Stdio::piped())` - for the wire, and (since #1689) a
+`UnixStream::pair()` socketpair for the auxiliary stderr channel only.
 
-- `crates/rsync_io/src/ssh/connection.rs:178-208` splits into half-duplex
-  reader/writer:
-  ```rust
-  pub fn split(mut self) -> io::Result<(SshReader, SshWriter, SshChildHandle)>
-  ```
-  The reader wraps `ChildStdout`, the writer wraps `ChildStdin`. There is no
-  shared FD - the two halves cannot be polled together with a single
-  registration.
+The question this audit answers: should oc-rsync's SSH wire migrate to a
+socketpair-backed transport to match upstream, and what concrete behaviour
+changes does that unlock?
 
-- `crates/rsync_io/src/ssh/connection.rs:217-237` performs blocking
-  `read(2)`/`write(2)` directly on the inherited pipes. No `O_NONBLOCK` is
-  set on the parent ends. There is no `EAGAIN` retry path because the
-  pipes are blocking.
+**Recommendation:** keep anonymous pipes as the cross-platform default and
+do **not** pursue the socketpair migration on the wire at this time. The
+behavioural differences that motivated upstream's choice (non-blocking I/O,
+graceful half-close via `shutdown(SHUT_WR)`, unified poll registration) are
+either already covered by oc-rsync's threaded blocking model or fall under
+the larger async-transport refactor tracked by #1655 / #2068, which would
+subsume the socketpair work as a small step. Pipes also keep `splice(2)`
+eligibility on the file<->wire edge (#1860) and require no Windows-only
+fallback path. The audit closes #1687 as "do not implement" and #1902 as
+"verified: upstream uses `socketpair(AF_UNIX, SOCK_STREAM, 0)` via
+`util1.c::fd_pair`; oc-rsync intentionally diverges with `pipe(2)`." All
+six findings below are informational, not severity-medium-or-higher
+defects.
 
-- `crates/rsync_io/src/ssh/connection.rs:97-102` performs a half-close by
-  flushing and dropping the stdin handle. There is no `shutdown(2)` because
-  pipes do not support it; the only way to half-close is to drop the FD,
-  which closes the pipe entirely.
+## 2. Upstream behaviour reference
 
-- `crates/rsync_io/src/ssh/mod.rs:57-72` documents the consequence: io_uring
-  socket fast paths in `fast_io` cannot be applied to SSH stdio because the
-  parent FDs are pipes, not sockets. Splice (#1860) is feasible because
-  splice supports pipe FDs; sockets are not.
+Source of truth: `target/interop/upstream-src/rsync-3.4.1/`. All citations
+were verified by reading the C source.
 
-Blocking, EAGAIN, and half-close behaviour today:
+### 2.1 SSH child setup (`pipe.c::piped_child`)
 
-- The pipes are inherited blocking. The watchdog at
-  `connection.rs:271-322` kills the child to unblock pending I/O when a
-  connect timeout fires.
-- There is no select/poll on the wire. `Read::read` and `Write::write`
-  block in the kernel.
-- `close_stdin` is a one-way half-close by drop; the read half stays open
-  until the child closes its stdout or exits.
+`pipe.c:48-97` is the only call site that spawns the SSH client (or any
+remote-shell program selected via `RSYNC_RSH`). The structure is:
 
-## 2. Upstream model
+```c
+pid_t piped_child(char **command, int *f_in, int *f_out)
+{
+    int to_child_pipe[2];
+    int from_child_pipe[2];
 
-Source of truth: `target/interop/upstream-src/rsync-3.4.1/`.
+    if (fd_pair(to_child_pipe) < 0 || fd_pair(from_child_pipe) < 0) { ... }
+    pid = do_fork();
+    if (pid == 0) {
+        dup2(to_child_pipe[0], STDIN_FILENO);
+        dup2(from_child_pipe[1], STDOUT_FILENO);
+        ...
+        set_blocking(STDIN_FILENO);
+        if (blocking_io > 0) set_blocking(STDOUT_FILENO);
+        execvp(command[0], command);
+    }
+    *f_in = from_child_pipe[0];
+    *f_out = to_child_pipe[1];
+    return pid;
+}
+```
 
-- `pipe.c:48-97` `piped_child(char **command, int *f_in, int *f_out)`:
-  ```c
-  int to_child_pipe[2];
-  int from_child_pipe[2];
-  if (fd_pair(to_child_pipe) < 0 || fd_pair(from_child_pipe) < 0) {
-      rsyserr(FERROR, errno, "pipe");
-      exit_cleanup(RERR_IPC);
-  }
-  pid = do_fork();
-  ...
-  if (pid == 0) {
-      if (dup2(to_child_pipe[0], STDIN_FILENO) < 0
-          || close(to_child_pipe[1]) < 0
-          || close(from_child_pipe[0]) < 0
-          || dup2(from_child_pipe[1], STDOUT_FILENO) < 0) {
-          ...
-      }
-      set_blocking(STDIN_FILENO);
-      if (blocking_io > 0)
-          set_blocking(STDOUT_FILENO);
-      execvp(command[0], command);
-      ...
-  }
-  ...
-  *f_in = from_child_pipe[0];
-  *f_out = to_child_pipe[1];
-  ```
-  Both directions go through `fd_pair`, not `pipe`. The parent keeps two
-  ends, the child keeps the other two and `dup2`s them onto stdin/stdout.
+Key observations:
 
-- `util1.c:74-96` `fd_pair`:
-  ```c
-  int fd_pair(int fd[2])
-  {
-      int ret;
-  #ifdef HAVE_SOCKETPAIR
-      ret = socketpair(AF_UNIX, SOCK_STREAM, 0, fd);
-  #else
-      ret = pipe(fd);
-  #endif
-      if (ret == 0) {
-          set_nonblocking(fd[0]);
-          set_nonblocking(fd[1]);
-      }
-      return ret;
-  }
-  ```
-  Both ends are forced non-blocking on success, and the implementation
-  silently falls back to `pipe(2)` when `HAVE_SOCKETPAIR` is undefined.
-  `config.h:432` records `HAVE_SOCKETPAIR` as a configure-time probe.
+- Two `fd_pair` calls produce four FDs total: `to_child_pipe[0..1]` for
+  parent->child (stdin) and `from_child_pipe[0..1]` for child->parent
+  (stdout). The parent retains `to_child_pipe[1]` (write end) and
+  `from_child_pipe[0]` (read end); the child receives the opposite ends
+  and `dup2`s them onto fds 0 and 1.
+- The child explicitly forces blocking mode on stdin
+  (`set_blocking(STDIN_FILENO)`) and on stdout when `blocking_io > 0`
+  (`pipe.c:80-82`). The parent ends remain non-blocking (set by `fd_pair`
+  itself, see 2.3 below).
+- `local_child` (`pipe.c:99-178`) uses the same `fd_pair`-based topology
+  for forked-local rsync (no SSH involved). The block comment at
+  `pipe.c:99-108` explicitly names the endpoints "socket pairs" and
+  documents the four-end ownership pattern.
 
-- The same `fd_pair` is used at `main.c:629` (read-batch back-channel) and
-  `main.c:985` (receiver error pipe). These are auxiliary channels used in
-  parallel with the wire.
+### 2.2 `fd_pair` socketpair-or-pipe helper (`util1.c::fd_pair`)
 
-- Stderr handling on the upstream side never travels back through a
-  separate FD. The remote rsync multiplexes its own diagnostic output as
-  `MSG_INFO`/`MSG_ERROR` envelopes on the wire (`io.c::send_msg`, gated on
-  `iobuf.multiplex_writes`); only the local SSH client's own stderr remains
-  out-of-band and is forwarded by SSH directly to the user's terminal.
-  Upstream therefore does not need a third FD for remote-rsync diagnostics
-  - they are folded into the multiplex layer that already runs on the
-  wire. There is no SO_PASSCRED or auxiliary stderr socketpair in upstream
-  rsync.
+`util1.c:74-96`:
 
-- `cleanup.c:46-67` `close_all` walks every open FD and, when the FD is a
-  socket, calls `shutdown(fd, 2)` before `close(fd)` to avoid the abortive
-  RST sent by Winsock-based peers. This logic is gated on
-  `SHUTDOWN_ALL_SOCKETS` and exploits exactly the fact that `fd_pair`
-  returns sockets - shutdown is a no-op on pipes.
+```c
+/**
+ * Create a file descriptor pair - like pipe() but use socketpair if
+ * possible (because of blocking issues on pipes).
+ *
+ * Always set non-blocking.
+ */
+int fd_pair(int fd[2])
+{
+    int ret;
 
-- `local_child` (`pipe.c:99-178`) uses `fd_pair` twice for forked-local
-  rsync. The accompanying comment at `pipe.c:99-108` explicitly names the
-  endpoints "socket pairs" and explains the four-end ownership pattern.
+#ifdef HAVE_SOCKETPAIR
+    ret = socketpair(AF_UNIX, SOCK_STREAM, 0, fd);
+#else
+    ret = pipe(fd);
+#endif
 
-## 3. Trade-off analysis
+    if (ret == 0) {
+        set_nonblocking(fd[0]);
+        set_nonblocking(fd[1]);
+    }
+    return ret;
+}
+```
 
-### Anonymous pipes (status quo for stdin/stdout)
+Key observations:
 
-- 2 FDs per direction, 4 FDs total. Half-duplex in each direction.
-- Universally available, including on Windows where the anonymous-pipe
-  primitive is the only portable child-stdio mechanism. Rust's
-  `Stdio::piped` provides identical semantics on every supported platform.
-- No `shutdown(2)` support. Half-close is achieved only by dropping the
-  whole FD (which closes the pipe). Receiver cannot signal "no more
-  writes, but keep reading" without losing the read direction.
-- Read-readiness and write-readiness live on different FDs, so a poll-set
-  needs two registrations. Today oc-rsync sidesteps this by performing
-  blocking I/O on each side from separate threads.
-- `splice(2)` works on pipes (this is the path explored in
-  `splice-ssh-stdio.md`). `IORING_OP_READ`/`IORING_OP_WRITE` accept pipe
-  FDs from Linux 5.1, but the io_uring socket fast path
-  (`IORING_OP_RECV`/`SEND_ZC` and registered buffers) requires a socket
-  FD and is therefore inaccessible on pipes.
-- Pipe capacity is fixed at 64 KiB by default and can be lifted to
-  `/proc/sys/fs/pipe-max-size` via `fcntl(F_SETPIPE_SZ)`.
+- The implementation is a configure-time switch. `HAVE_SOCKETPAIR` is
+  defined on every modern Unix the autotools probe inspects. The pipe
+  branch exists as a fallback for hosts that lack `socketpair`.
+- The doc comment cites "blocking issues on pipes" as the reason
+  socketpair is preferred. This refers to two upstream-relevant
+  properties: `shutdown(SHUT_WR)` for orderly half-close, and the absence
+  of the 64 KiB pipe-buffer fence post that can cause stalls when both
+  parties write large bursts before either reads.
+- Both ends are forced non-blocking unconditionally on success. The
+  child re-enables blocking on its inherited stdin via `set_blocking`
+  later in `piped_child` (see 2.1) because rsh/SSH binaries expect
+  blocking stdin.
 
-### `socketpair(AF_UNIX, SOCK_STREAM, 0)` (upstream's choice)
+### 2.3 Auxiliary uses of `fd_pair`
 
-- 2 FDs total, each fully bidirectional. The same FD can be used for read
-  and write, so a poll-set needs one registration per direction-of-flow.
-  When both halves of oc-rsync's `split()` run on the same thread (e.g.,
-  in a future event loop) they could share an `epoll`/`kqueue`/`io_uring`
-  poll group.
-- `shutdown(SHUT_WR)` cleanly half-closes the write side while leaving the
-  read side open. This maps directly to "I am done sending; flush and
-  drain the response" semantics that the rsync end-of-transfer phase
-  needs. With pipes today, dropping `ChildStdin` (`connection.rs:97-102`)
-  also tears down the parent's view of the write FD entirely; the child
-  sees EOF on its stdin but the parent loses the ability to retry on
-  EAGAIN.
-- `SO_RCVBUF`/`SO_SNDBUF` are tunable per-direction. Linux's default is
-  `net.core.{r,w}mem_default` (typically 212 KiB), already larger than the
-  default 64 KiB pipe buffer.
-- Stream-oriented (`SOCK_STREAM`), so byte boundaries are preserved. No
-  message-boundary semantics.
-- Available on every Unix oc-rsync targets (Linux, macOS, *BSD,
-  illumos). NOT available on Windows: there is no `AF_UNIX, SOCK_STREAM`
-  socketpair; `WSASocket`/`WSADuplicateSocket` over a TCP loopback pair is
-  the only equivalent and is a much heavier dance.
-- io_uring socket fast paths apply: `IORING_OP_RECV/SEND` and registered
-  buffers work on AF_UNIX sockets. Splice still works through the pair via
-  an intermediate pipe (splice requires one of the two FDs to be a pipe),
-  so the splice plan in `splice-ssh-stdio.md` keeps working unchanged
-  because we splice between a regular file and the pipe-backed page cache;
-  the SSH wire is not part of the splice fast path on either layout.
-- `tcgetpgrp`-style controlling-terminal interactions do not apply to
-  `AF_UNIX` socketpairs; SSH already declines to allocate a PTY in the
-  invocation oc-rsync uses today.
+The same helper is reused for two non-wire channels:
 
-### Auxiliary stderr channel
+- `main.c:629` - read-batch back-channel from the generator to the
+  client when `--read-batch` is in effect.
+- `main.c:985` - receiver error pipe used by the receiver process to
+  signal IPC errors back to the generator.
 
-Upstream does not use one. Remote-rsync diagnostics flow back as `MSG_*`
-envelopes on the wire. Only the *local* SSH binary's own stderr (host-key
-warnings, connect errors) is out-of-band, and upstream simply lets the SSH
-client write to the inherited terminal stderr.
+Both rely on the same socketpair-or-pipe semantics (`fd_pair`) and both
+are non-blocking. There is no code path in upstream rsync that uses raw
+`pipe(2)` directly; every IPC pair goes through `fd_pair`.
 
-oc-rsync needs the auxiliary channel because:
+### 2.4 Daemon connection setup (`clientserver.c`)
 
-1. We capture the local SSH client's stderr to surface it on failure
-   (`connection.rs:124-151`, `aux_channel.rs:74-89`).
-2. We forward each line in real time to the controlling terminal so the
-   user sees host-key prompts and `Permission denied` immediately
-   (`aux_channel.rs:208-228`).
+For daemon-mode connections (`rsync://` URLs) the wire is a TCP socket,
+not a stdio pipe. `clientserver.c:116-148` `start_socket_client()`:
 
-Three implementations are conceivable:
+```c
+fd = open_socket_out_wrapped(host, rsync_port, bind_address, default_af_hint);
+if (fd == -1)
+    exit_cleanup(RERR_SOCKETIO);
+...
+ret = start_inband_exchange(fd, fd, user, remote_argc, remote_argv);
+return ret ? ret : client_run(fd, fd, -1, argc, argv);
+```
 
-1. **Anonymous pipe** (`Stdio::piped()`): default, what we fall back to.
-   Pure pipe(2) - pollable but no shutdown.
-2. **Socketpair** (current Unix path): `UnixStream::pair()` with one end
-   passed as the child stderr. Already implemented at
-   `aux_channel.rs:264-285`. Gives a real `AF_UNIX` socket FD on the
-   parent side, ready for future event-loop integration without touching
-   call sites.
-3. **`SO_PASSCRED` plus a third socketpair**: would let the SSH child
-   forward arbitrary FDs to the parent (e.g., a separate channel for
-   structured diagnostics). Not used by upstream, not needed by
-   oc-rsync, and would force SSH-server cooperation we do not have.
+Both directions share the same socket FD (`f_in == f_out`). This is a
+TCP `AF_INET` / `AF_INET6` socket via `connect(2)`, not a socketpair.
+`rsync_module()` at `clientserver.c:692` is the daemon-side counterpart
+and accepts the connection on the listener socket.
 
-Recommendation for #1689: keep the existing socketpair stderr channel as
-the Unix default; do not pursue `SO_PASSCRED` or a third pair. The
-socketpair already provides every property we need (pollable, real socket
-FD, bounded capture buffer, shutdown semantics) and the implementation
-landed under #1689's groundwork.
+### 2.5 `RSYNC_CONNECT_PROG` test escape (`socket.c::sock_exec`)
 
-## 4. Cross-platform impact
+`socket.c:805-846` provides a test-only escape that runs a local program
+across a TCP socketpair (`socket.c:736-802` `socketpair_tcp`) so the
+daemon-mode path can be exercised without a real TCP connection. This
+is gated by `RSYNC_CONNECT_PROG` and is the only place upstream uses a
+TCP-style socketpair built from `socket(PF_INET, SOCK_STREAM, 0)` plus
+`connect`/`accept`. Not relevant to SSH transport - it substitutes for
+the daemon's TCP socket, not for the SSH child stdio.
 
-| Platform | Wire (stdin/stdout) | Stderr | Notes |
+### 2.6 Multiplex envelope replaces a third FD
+
+Upstream does not allocate a separate fd 2 channel back from the remote
+rsync. Remote-rsync diagnostics flow through the multiplex envelope
+(`io.c::send_msg`, see `io.c:983-1031`) wrapped in `MSG_INFO` /
+`MSG_ERROR` / `MSG_WARNING` frame codes on the wire when
+`iobuf.multiplex_writes` is set. Only the *local* SSH client's own
+stderr (host-key warnings, `Permission denied`, banner messages) is
+out-of-band and is left attached to the inherited terminal stderr.
+
+`cleanup.c:46-67` `close_all` walks every open FD and calls
+`shutdown(fd, 2)` before `close(fd)` when the FD is a socket
+(gated on `SHUTDOWN_ALL_SOCKETS`). This logic exists specifically to
+take advantage of the fact that `fd_pair` returns sockets - the
+shutdown is a no-op on pipes.
+
+### 2.7 Summary of upstream defaults
+
+| Channel | Primitive | Citation |
+|---|---|---|
+| SSH wire (parent<->child stdio) | `socketpair(AF_UNIX, SOCK_STREAM, 0)` per direction (2 pairs) | `pipe.c:57`, `util1.c:84-85` |
+| Local-fork wire | same | `pipe.c:119`, `util1.c:84-85` |
+| Read-batch back-channel | same | `main.c:629`, `util1.c:84-85` |
+| Receiver error pipe | same | `main.c:985`, `util1.c:84-85` |
+| Daemon `rsync://` wire | TCP `AF_INET`/`AF_INET6` socket | `clientserver.c:137`, `socket.c::open_socket_out` |
+| `RSYNC_CONNECT_PROG` test escape | TCP socketpair (`socket.c::socketpair_tcp`) | `socket.c:740-802`, `socket.c:811-846` |
+| Remote-rsync diagnostics | multiplex envelope on the wire | `io.c:983-1031` |
+| Local SSH-client stderr | inherited terminal stderr | (no code; default child stderr) |
+
+## 3. Current oc-rsync implementation
+
+All citations are line numbers verified against the worktree at
+`crates/rsync_io/src/ssh/`.
+
+### 3.1 SSH wire setup (`builder.rs::SshCommand::spawn`)
+
+`crates/rsync_io/src/ssh/builder.rs:285-340` is the single spawn site:
+
+```rust
+pub fn spawn(&self) -> io::Result<SshConnection> {
+    let mut command = Command::new(&program);
+    command.stdin(Stdio::piped());
+    command.stdout(Stdio::piped());
+    command.args(args.iter());
+    ...
+    let parent_socketpair_end = configure_stderr_channel(&mut command);
+    let mut child = command.spawn()?;
+    ...
+```
+
+- `builder.rs:300-301` configures stdin and stdout as `Stdio::piped()`.
+  Each call creates an anonymous `pipe(2)` pair internally
+  (`std::sys::pal::unix::process::process_unix::AnonPipe::pipe`). The
+  parent retains the write end of the stdin pipe and the read end of the
+  stdout pipe; the child receives the opposite ends and the standard
+  library calls `dup2` to plant them on fds 0 and 1 before `execvp`.
+- `builder.rs:312` calls `configure_stderr_channel`, which on Unix
+  attempts a socketpair for stderr (see 3.3) and falls back to
+  `Stdio::piped()` on failure or non-Unix targets.
+- The wire channels (stdin/stdout) are never reconfigured to a
+  socketpair anywhere in the codebase. There is no `socketpair`,
+  `UnixStream::pair`, or manual `dup2` of a non-pipe FD onto the wire.
+
+### 3.2 Connection state (`connection.rs::SshConnection`)
+
+`crates/rsync_io/src/ssh/connection.rs:30-39`:
+
+```rust
+pub struct SshConnection {
+    child: Arc<Mutex<Option<Child>>>,
+    stdin: Option<ChildStdin>,
+    stdout: Option<ChildStdout>,
+    stderr_drain: Option<BoxedStderrChannel>,
+    connect_watchdog: Option<ConnectWatchdog>,
+}
+```
+
+- The wire is two unidirectional handles: `ChildStdin` (write side of the
+  stdin pipe) and `ChildStdout` (read side of the stdout pipe). They are
+  never combined into a single FD.
+- `connection.rs:217-221` `impl Read for SshReader` delegates to
+  `ChildStdout::read` -> `read(2)` on the pipe FD.
+- `connection.rs:229-237` `impl Write for SshWriter` delegates to
+  `ChildStdin::write` and `flush` -> `write(2)` on the pipe FD.
+- Both ends are blocking. There is no `set_nonblocking` call anywhere in
+  `crates/rsync_io/src/ssh/`. This contrasts with upstream's
+  `util1.c:90-93` which forces non-blocking on every `fd_pair` result.
+
+### 3.3 Stderr socketpair (`aux_channel.rs::configure_stderr_channel`)
+
+`crates/rsync_io/src/ssh/aux_channel.rs:263-291`:
+
+```rust
+#[cfg(unix)]
+pub(super) fn configure_stderr_channel(command: &mut Command) -> Option<UnixStream> {
+    match UnixStream::pair() {
+        Ok((parent, child)) => {
+            let child_fd: std::os::fd::OwnedFd = child.into();
+            command.stderr(Stdio::from(child_fd));
+            Some(parent)
+        }
+        Err(_) => { command.stderr(Stdio::piped()); None }
+    }
+}
+
+#[cfg(not(unix))]
+pub(super) fn configure_stderr_channel(command: &mut Command) -> Option<()> {
+    command.stderr(Stdio::piped());
+    None
+}
+```
+
+`std::os::unix::net::UnixStream::pair()` is the safe stdlib wrapper around
+`socketpair(AF_UNIX, SOCK_STREAM, 0)`. It returns two connected
+`UnixStream` handles. On success we keep one half on the parent side
+(wrapped by `SocketpairStderrChannel` at `aux_channel.rs:146-172`) and
+hand the other half to the child as its stderr fd via
+`Stdio::from(OwnedFd)`. On any failure we fall back to `Stdio::piped()`,
+matching upstream's `fd_pair` failover from socketpair to pipe.
+
+The `cfg(not(unix))` arm always uses `Stdio::piped()` because Windows
+does not support handing an `AF_UNIX` socket to `CreateProcess` as a
+standard handle (see Section 5.2).
+
+### 3.4 Half-close, half-open semantics
+
+`connection.rs:96-102` is the only "half-close" path:
+
+```rust
+pub fn close_stdin(&mut self) -> io::Result<()> {
+    if let Some(mut stdin) = self.stdin.take() {
+        stdin.flush()?;
+    }
+    Ok(())
+}
+```
+
+This drops `ChildStdin`, which closes the parent's view of the stdin
+pipe entirely. There is no `shutdown(SHUT_WR)` call - pipes do not
+support `shutdown(2)`.
+
+`SshWriter::close` at `connection.rs:241-243` is the same pattern after
+`split()`:
+
+```rust
+pub fn close(mut self) -> io::Result<()> {
+    self.stdin.flush()
+}
+```
+
+Drop closes the FD when the function returns.
+
+### 3.5 io_uring boundary
+
+`crates/rsync_io/src/ssh/mod.rs:57-75` documents the consequence of the
+pipe topology:
+
+```text
+The SSH data channel is the spawned `ssh` child's inherited stdio: a
+`(stdin, stdout)` pipe pair created by `Command::spawn`, not a socket.
+The `fast_io` io_uring `socket_reader` / `socket_writer` fast paths
+require an `AF_INET`/`AF_INET6` socket FD and are therefore unreachable
+for SSH transfers - regardless of kernel version or `io_uring_policy`.
+```
+
+The pipe-FD io_uring path (`IORING_OP_READ` / `IORING_OP_WRITE`) is
+tracked separately by #1859 and audited in
+`docs/audits/iouring-pipe-stdio.md`. The splice/vmsplice zero-copy plan
+is tracked by #1860 in `docs/audits/splice-ssh-stdio.md`.
+
+### 3.6 Watchdog as the "non-blocking" workaround
+
+`connection.rs:246-322` implements `ConnectWatchdog`, a background
+thread that calls `Child::kill()` after a configurable timeout. This
+exists because the inherited pipes are blocking; without a watchdog, a
+hung SSH client (waiting on host-key prompt, connecting to an
+unreachable address) would block the parent's first `read` indefinitely.
+Upstream avoids this by setting non-blocking on its `fd_pair` ends and
+using the rsync select loop in `io.c::perform_io`; oc-rsync substitutes
+a watchdog-plus-blocking-IO model.
+
+### 3.7 Summary of oc-rsync defaults
+
+| Channel | Primitive | Citation |
+|---|---|---|
+| SSH wire stdin (parent->child) | `pipe(2)` (anonymous pipe) | `builder.rs:300` |
+| SSH wire stdout (child->parent) | `pipe(2)` (anonymous pipe) | `builder.rs:301` |
+| SSH stderr (Unix) | `socketpair(AF_UNIX, SOCK_STREAM, 0)` | `aux_channel.rs:265` |
+| SSH stderr (Windows) | `pipe(2)` (anonymous pipe) | `aux_channel.rs:288-291` |
+| SSH stderr (Unix fallback) | `pipe(2)` (anonymous pipe) | `aux_channel.rs:276` |
+| Daemon `rsync://` wire | `TcpStream` (unaffected by this audit) | `crates/transport/` |
+| Local-fork wire | not implemented (`oc-rsync` does not fork-and-exec itself) | n/a |
+
+## 4. Trade-off analysis
+
+### 4.1 Bidirectional ergonomics
+
+- **Pipes (today):** Two unidirectional FDs. Each direction is half-duplex.
+  oc-rsync's `SshConnection::split()` (`connection.rs:178-208`) returns
+  `SshReader` (holds `ChildStdout`) and `SshWriter` (holds `ChildStdin`),
+  one FD each. They can be moved to separate threads without any sharing,
+  which matches the current threaded blocking model used by
+  `crates/core/src/client/remote/ssh_transfer.rs`.
+- **Socketpair:** One bidirectional FD, used for both reading and writing.
+  A single `Arc<UnixStream>` shared between the reader and writer halves
+  would replace the two-FD model. Future event-loop integration
+  (`tokio::io::AsyncFd`, `mio::Poll`, io_uring registered FDs) needs
+  exactly one registration instead of two and exposes a single readiness
+  mask covering both directions.
+
+The threaded blocking model oc-rsync uses today is straightforward and
+works for both. The socketpair advantage materializes only after the
+async-transport refactor (#2068, see also `docs/audits/async-ssh-transport.md`)
+which would unify the two halves anyway.
+
+### 4.2 Backpressure and buffer accounting
+
+- **Pipes:** Default kernel buffer is 64 KiB on Linux (`PIPE_BUF` is 4096
+  for atomic-write guarantees, but pipe capacity is separate; see
+  `man 7 pipe`, `/proc/sys/fs/pipe-max-size`). The capacity can be lifted
+  via `fcntl(F_SETPIPE_SZ)` up to `pipe-max-size` (typically 1 MiB). When
+  the parent's stdin buffer fills, `write(2)` blocks (or returns `EAGAIN`
+  if non-blocking).
+- **Socketpair (`SOCK_STREAM`):** Buffer is `SO_SNDBUF` / `SO_RCVBUF` per
+  direction. Linux defaults are `net.core.{r,w}mem_default` (typically
+  212 KiB) and `net.core.{r,w}mem_max` (4 MiB). Tunable per-FD via
+  `setsockopt(2)`. A `getsockopt(SO_SNDBUF)` returns the doubled value
+  the kernel actually allocated.
+
+The default socket buffers are larger than the default pipe buffer by ~3x,
+which means a socketpair-backed wire absorbs more burst-write before
+backpressure stalls a writer. In oc-rsync's threaded model this shows up
+only if the engine pushes >64 KiB without a corresponding read on the
+other side, which is rare because the rsync multiplex envelope chunks
+payloads to `MAX_PAYLOAD_LENGTH = 0x00FF_FFFF` (~16 MiB), and the file
+list / delta phases interleave reads and writes.
+
+oc-rsync has no measured stall attributable to pipe-buffer pressure on
+the SSH wire today. There is no concrete regression to fix.
+
+### 4.3 Auxiliary channels (`SCM_RIGHTS`, `SO_PASSCRED`)
+
+- **Pipes:** No ancillary data. `sendmsg(2)` / `recvmsg(2)` on a pipe
+  return `ENOTSOCK`. Pipes cannot pass file descriptors between
+  processes; cannot pass credentials; cannot do anything beyond byte
+  transfer.
+- **Socketpair:** Supports `SCM_RIGHTS` (FD passing) and `SCM_CREDENTIALS`
+  on Linux, `SCM_CREDS` on FreeBSD. The SSH child is an `ssh(1)` binary
+  oc-rsync does not control - it does not invoke `sendmsg` with
+  ancillary data on its stdio. So even if the parent had a socketpair,
+  the child would not use it for FD passing or credentials.
+
+oc-rsync has no upcoming feature that needs `SCM_RIGHTS` or
+`SCM_CREDENTIALS` on the SSH wire. Upstream rsync does not use ancillary
+data either. This is a hypothetical advantage with no current consumer.
+
+### 4.4 io_uring opcode compatibility
+
+This was audited in detail in `docs/audits/iouring-pipe-stdio.md` and
+`crates/rsync_io/src/ssh/mod.rs:57-75`. Summary:
+
+| FD type | `IORING_OP_READ` / `OP_WRITE` | `IORING_OP_RECV` / `OP_SEND` | Registered buffers (`IORING_REGISTER_BUFFERS`) |
 |---|---|---|---|
-| Linux | `pipe(2)` today, socketpair recommended (Unix path of phase 1) | `socketpair(AF_UNIX)` today | Both supported by `Command` via `Stdio::from(OwnedFd)`. |
-| macOS | same as Linux | `socketpair(AF_UNIX)` today | `socketpair` is POSIX; macOS `Stdio::from(OwnedFd)` is stable. |
-| *BSD / illumos | same as Linux | `socketpair(AF_UNIX)` today | Same `UnixStream::pair()` path. |
-| Windows | `pipe(2)` (anonymous pipe) - permanent | anonymous pipe - permanent | Windows `Command::stdin/stdout/stderr(Stdio::piped())` creates anonymous pipes with `CreatePipe`. There is no `AF_UNIX` socketpair on Windows that we can hand to a child as a stdio handle: `socketpair` is unavailable in WinSock, and although Windows 10 1809+ supports `AF_UNIX` for `socket(2)`, neither `WSASocket`/`DuplicateHandle` round trip nor `WSADuplicateSocket` produces a handle that `CreateProcess` can plant on stdin/stdout/stderr. The Rust `Stdio::from(OwnedFd)` path does not have a stable Windows analogue for sockets. The fallback strategy is therefore to keep the pipe path on Windows indefinitely. |
+| Pipe | works (Linux 5.1+) | rejects with `ENOTSOCK` | works on read/write paths |
+| `AF_UNIX SOCK_STREAM` socketpair | works | works | works |
+| `AF_INET` TCP socket | works | works (preferred fast path) | works |
 
-The asymmetry is acceptable: Windows does not run io_uring or
-`epoll(7)`, so the unified-poll motivation does not apply there. The
-existing `cfg(unix)` /  `cfg(not(unix))` factory pattern in
-`aux_channel.rs:263-291` is the model to follow for the wire too.
+The "socket fast path" advantage refers to `IORING_OP_RECV` /
+`IORING_OP_SEND` plus zero-copy variants (`SEND_ZC`). Those opcodes
+require a socket FD. A socketpair gets them; a pipe does not.
 
-## 5. Findings
+The actual io_uring wins on the SSH path (syscall amortization via
+`IORING_SETUP_SQPOLL`, batched submissions) work on pipe FDs too. The
+`iouring-pipe-stdio.md` analysis records no measurable throughput
+difference between `OP_READ`/`OP_WRITE` on pipes and `OP_RECV`/`OP_SEND`
+on sockets for multi-MiB sequential transfers; the socketpair advantage
+is theoretical for bulk I/O.
 
-### Finding 1 (medium severity): wire uses pipes where upstream uses socketpair
+### 4.5 `splice(2)` / `vmsplice(2)` eligibility
 
-- **Evidence:** `crates/rsync_io/src/ssh/builder.rs:280-282`. Upstream:
+Per `man 2 splice`, one of the two FDs must refer to a pipe. `man 2
+vmsplice` requires the destination to be a pipe. The two zero-copy paths
+oc-rsync wants are `splice(file_fd, NULL, wire, NULL, ...)` (sender) and
+`splice(wire, NULL, file_fd, NULL, ...)` (receiver); both require the
+wire to be a pipe.
+
+**A socketpair-backed wire breaks the splice path.**
+`splice-ssh-stdio.md:60-67` confirms the dependency. Migrating the wire
+to a socketpair would force the splice plan to insert an intermediate
+`pipe(2)` in user space and double-splice through it, negating the
+zero-copy benefit. This is the strongest argument against a socketpair
+migration and the primary reason this audit recommends keeping pipes.
+
+### 4.6 Stderr separation
+
+Both topologies need a separate FD for stderr because `ssh(1)` writes
+diagnostic output (host-key warnings, banners, `Permission denied`) to
+its inherited fd 2. oc-rsync must capture and forward it in real time
+so the user sees prompts and connection errors immediately. The current
+Unix path uses `socketpair(AF_UNIX, SOCK_STREAM)` for stderr (#1689 /
+`aux_channel.rs:263-285`); Windows uses an anonymous pipe
+(`aux_channel.rs:287-291`). Independent of the wire choice.
+
+### 4.7 Half-close semantics
+
+- **Pipes:** No `shutdown(2)`. Closing `ChildStdin` (by drop) closes the
+  entire FD; the child sees EOF on its stdin. The parent retains the
+  stdout FD and can drain remaining bytes - this is the rsync
+  end-of-transfer dance.
+- **Socketpair:** `shutdown(SHUT_WR)` cleanly half-closes the write
+  direction on the same FD while leaving the read side open. Matches
+  TCP-socket semantics.
+
+The behavioural difference is negligible for oc-rsync: with two FDs the
+half-close is implicit in the drop, and no caller wants to issue a
+write-side shutdown and continue reading on the same handle.
+
+### 4.8 Compatibility with the SSH child program
+
+Both topologies are transparent to the SSH child. `ssh(1)` reads from
+fd 0 and writes to fd 1 without calling `getsockopt`/`fstat` to
+discriminate sockets from pipes. `Command::spawn` calls `dup2` onto fds
+0 and 1 in either case. Read/write semantics are identical for a child
+that uses the FDs as plain bytestreams.
+
+### 4.9 Code complexity
+
+- **Pipes:** zero extra code. `Stdio::piped()` is the stdlib idiom.
+- **Socketpair:** at minimum, the same factory pattern as
+  `aux_channel.rs::configure_stderr_channel` repeated for two FDs (or
+  one FD `dup`ed to both). Add a `WireChannelKind::{Pipe, Socketpair}`
+  enum to keep the `SshReader`/`SshWriter` API surface portable. Add
+  Windows fallback. Add tests for `OwnedFd::try_clone` + `Stdio::from`
+  ordering.
+
+The socketpair migration is small (estimated 100-200 LOC across
+`builder.rs`, `connection.rs`, plus tests), but it is non-zero.
+
+### 4.10 Upstream parity
+
+- **Pipes:** diverges from upstream `pipe.c::piped_child`. Upstream uses
+  socketpair via `fd_pair`.
+- **Socketpair:** matches upstream exactly when `HAVE_SOCKETPAIR` is set
+  (which is the universal case for modern Unix builds).
+
+Upstream parity is a soft goal; oc-rsync deviates from upstream in
+several places (Rust stdlib, threaded blocking model, no select loop)
+and the deviation here is invisible on the wire.
+
+## 5. Decision matrix
+
+The two topologies compared on the dimensions Section 4 enumerates.
+"Better" entries are bolded.
+
+| Dimension | Pipes (status quo) | Socketpair (`AF_UNIX`, `SOCK_STREAM`) | Notes |
+|---|---|---|---|
+| Bidirectional ergonomics (single FD vs two) | two FDs | **one FD** | Matters only with an event loop; oc-rsync threads today. |
+| Backpressure / default buffer | 64 KiB | **~212 KiB (`SO_*BUF`)** | No measured oc-rsync stall on either. |
+| Tunable buffers | `F_SETPIPE_SZ` to `pipe-max-size` (1 MiB typical) | **`SO_*BUF` to `r/w mem_max` (4 MiB typical)** | Linux only; equivalents differ per OS. |
+| Ancillary channel (`SCM_RIGHTS`, creds) | not supported | supported | No oc-rsync consumer. |
+| io_uring opcode coverage | `OP_READ` / `OP_WRITE` | **also `OP_RECV` / `OP_SEND` / `SEND_ZC`** | Sequential bulk I/O parity in practice. |
+| `splice(2)` / `vmsplice(2)` eligibility | **pipe-end satisfied directly** | requires intermediate pipe | Splice plan (#1860) relies on pipes. |
+| Stderr separation | **independent fd 2 (already done)** | independent fd 2 (already done) | Orthogonal to wire choice. |
+| Half-close (`shutdown(SHUT_WR)`) | no, by drop only | **yes** | Implicit half-close already works for oc-rsync. |
+| Code complexity (LOC, branches) | **0** | ~100-200 | Plus Windows fallback. |
+| Upstream parity (`pipe.c::piped_child`) | divergent | **matches `fd_pair` default** | Soft goal. |
+| Cross-platform consistency (Unix vs Windows) | **identical primitive on both** | Unix-only; pipes on Windows | Asymmetry imposes cfg branches. |
+| Connect-timeout strategy | watchdog kills child | poll(2) timeout possible | Watchdog already shipped. |
+| Compatibility with SSH child | identical | identical | Both use `dup2` onto fd 0/1. |
+
+The matrix splits roughly evenly. The decisive entry for "do not
+implement" is the splice eligibility row, because the splice plan
+(#1860) is the highest-value zero-copy work in the SSH transport
+roadmap and a socketpair migration would force it to thread an
+intermediate pipe, defeating the point.
+
+## 6. Recommendation
+
+**Keep anonymous pipes for the SSH wire.** Close #1687 (prototype
+socketpair wire) as "do not implement" with this audit as the
+justification. Close #1902 (verify socketpair vs pipe wire claim against
+`rsync_io` source) as "verified" with the upstream/oc-rsync table in
+Sections 2 and 3.
+
+The reasoning is the union of three points:
+
+1. **Splice eligibility (Section 4.5).** `splice(2)` and `vmsplice(2)`
+   require one FD to be a pipe. oc-rsync's zero-copy roadmap (#1860)
+   wins back full memory-bandwidth on sender and receiver file<->wire
+   edges only when the wire is a pipe. A socketpair-backed wire would
+   force a double-splice through a user-space `pipe(2)`, eliminating the
+   benefit. The io_uring `OP_RECV` / `OP_SEND` socket fast path does
+   not recover this on an `AF_UNIX` socketpair because neither end is
+   a TCP socket, so `SEND_ZC` MSG-zerocopy paths do not apply.
+
+2. **No measured backpressure regression (Section 4.2).** The 64 KiB
+   pipe-buffer default is large enough that oc-rsync's multiplex-framed
+   writes do not stall. No issue points to pipe-buffer pressure on the
+   SSH wire.
+
+3. **Async-transport refactor subsumes the unified-FD argument
+   (Sections 4.1, 4.4).** The "one poll registration" and
+   `OP_RECV`/`OP_SEND` advantages only matter inside an event loop. The
+   async-transport audit in `docs/audits/async-ssh-transport.md` and
+   the wider `docs/audits/async-file-writer-trait.md` work (#1655)
+   plan an async I/O migration that consolidates readiness tracking
+   regardless of primitive. If that refactor lands and we measure a
+   socket-specific win, we reconsider with concrete numbers.
+
+The Unix stderr socketpair (`aux_channel.rs:263-285`, #1689) stays as
+is - it is the right primitive for stderr (`epoll`/`kqueue`-registrable,
+line-oriented, no splice need, gracefully shutdown-able).
+
+## 7. Findings (informational)
+
+All findings are informational. None require code changes; they document
+deliberate divergences from upstream and the reasoning behind them.
+
+### Finding 1: wire uses `pipe(2)` where upstream uses `socketpair`
+
+- **Evidence:** `crates/rsync_io/src/ssh/builder.rs:300-301`
+  (`Stdio::piped()` for stdin and stdout). Upstream:
   `target/interop/upstream-src/rsync-3.4.1/pipe.c:57` and
   `util1.c:84-85`.
-- **Impact:** No `shutdown(SHUT_WR)` available on the parent side, so
-  half-close on the write direction collapses the FD entirely; the
-  parent loses the ability to inspect or retry pending writes after
-  signalling EOF. `splice` and `vmsplice` continue to work, but the
-  io_uring socket fast path is unreachable on the wire FDs (already noted
-  in `mod.rs:57-72`). Cross-version interop is unaffected because
-  upstream's socketpair side reads/writes the same wire bytes either way.
-- **Recommended fix:** Implement phase 1 of section 6: spawn a
-  `socketpair(AF_UNIX, SOCK_STREAM, 0)` on Unix, hand one end to the
-  child as fd 0 and 1 (a single FD `dup2`-ed to both), retain the other
-  end as a single bidirectional `UnixStream` on the parent. Keep the
-  pipe path as the Windows fallback.
+- **Status:** intentional divergence per Section 6.
+- **Impact:** no `shutdown(SHUT_WR)`, no `OP_RECV`/`OP_SEND` opcodes,
+  but full `splice(2)` eligibility is preserved. Cross-version interop
+  is unaffected because both topologies write the same wire bytes.
 
-### Finding 2 (medium severity): no non-blocking mode on inherited stdio
+### Finding 2: parent stdio is blocking, upstream is non-blocking
 
 - **Evidence:** No `set_nonblocking` call in
   `crates/rsync_io/src/ssh/builder.rs` or `connection.rs`. Upstream:
   `util1.c:90-93` forces both ends non-blocking inside `fd_pair`.
-- **Impact:** The parent must run separate threads for read and write to
-  avoid deadlock when the wire fills. `fast_io`'s registered-buffer
-  rings cannot be driven against blocking pipes. The connect-watchdog at
-  `connection.rs:271-322` works around the blocking I/O by killing the
-  child, which is a sledgehammer compared to a `poll(2)` timeout.
-- **Recommended fix:** When the socketpair migration lands, set
-  `O_NONBLOCK` on the parent end via `UnixStream::set_nonblocking(true)`
-  and surface `WouldBlock` to callers with a thin retry helper. Keep
-  blocking semantics on the pipe-backed Windows path.
+- **Status:** intentional. oc-rsync's threaded blocking model uses
+  separate threads for the read and write halves, so non-blocking is
+  not required to avoid deadlock.
+- **Impact:** the connect-timeout watchdog
+  (`connection.rs:246-322`) substitutes for upstream's `select`-based
+  IO timeout. The watchdog is a correct, simple alternative.
 
-### Finding 3 (low severity): split halves cannot share a poll registration
+### Finding 3: stderr socketpair already in place; wire is not
 
-- **Evidence:** `crates/rsync_io/src/ssh/connection.rs:178-208`
-  (`SshReader { stdout }` and `SshWriter { stdin }` hold separate FDs).
-- **Impact:** Future event-loop integration (epoll, kqueue, io_uring)
-  requires two FD registrations and tracks read- and write-readiness
-  independently. With socketpair, a single FD covers both directions
-  and the readiness mask is unified.
-- **Recommended fix:** Phase 2 below: after the socketpair migration,
-  rewrite `SshReader`/`SshWriter` to share an `Arc<UnixStream>` and
-  attach the readiness machinery to the single FD. The `Read`/`Write`
-  trait surfaces stay identical so call sites do not change.
+- **Evidence:** `crates/rsync_io/src/ssh/aux_channel.rs:263-285` installs
+  a stderr socketpair on Unix; `builder.rs:300-301` keeps the wire on
+  pipes.
+- **Status:** intentional. The stderr socketpair was added (#1689) for
+  reasons that do not apply to the wire (line-oriented diagnostics,
+  potential future event-loop integration with no splice requirement).
+- **Impact:** the IPC primitives on a single SshConnection are mixed
+  (sockets for stderr, pipes for the wire). Documented here to prevent
+  surprise during future refactors.
 
-### Finding 4 (low severity): `close_stdin` cannot half-close cleanly
+### Finding 4: `close_stdin` cannot half-close cleanly
 
-- **Evidence:** `crates/rsync_io/src/ssh/connection.rs:97-102` and
-  `connection.rs:241-243` (`SshWriter::close`). The implementation
-  flushes and drops the `ChildStdin`, which closes the entire pipe FD.
-- **Impact:** On a pipe there is no other choice. If the protocol
-  requires the parent to keep reading after sending EOF (today the
-  receiver does this implicitly because read and write live on
-  different FDs, but a future unified-FD design would require explicit
-  half-close), pipes cannot express it.
-- **Recommended fix:** With the socketpair migration, replace the drop
-  with `socket.shutdown(Shutdown::Write)`. The parent retains the read
-  half until the child closes its end. Match upstream's
-  `cleanup.c:46-67` pattern by calling `shutdown(fd, SHUT_WR)` before
-  close on graceful exits.
+- **Evidence:** `crates/rsync_io/src/ssh/connection.rs:96-102` and
+  `connection.rs:241-243` (`SshWriter::close`). Both flush and drop
+  `ChildStdin`, which closes the entire pipe FD.
+- **Status:** acceptable. The two-FD topology already provides
+  half-open semantics implicitly: closing stdin signals EOF to the
+  child while leaving stdout open for the parent to drain.
+- **Impact:** none observable.
 
-### Finding 5 (low severity): stderr socketpair already in place but wire is not
+### Finding 5: io_uring socket fast paths unreachable on the SSH wire
 
-- **Evidence:** `crates/rsync_io/src/ssh/aux_channel.rs:264-285`
-  installs a stderr socketpair on Unix. The wire still uses pipes
-  (Finding 1), so the Unix data path is mixed: stderr uses one socket,
-  the wire uses two pipes.
-- **Impact:** The work to make stderr pollable has already been paid
-  for, but the wire does not benefit. The asymmetry also makes the
-  `SshConnection` struct slightly harder to reason about (two different
-  IPC primitives on the same connection).
-- **Recommended fix:** Land Finding 1's fix to unify the two paths and
-  factor `configure_stderr_channel` and `configure_wire_channel` behind
-  a shared `WireChannelKind::{Pipe, Socketpair}` enum. The factory
-  pattern from `aux_channel.rs:263-291` is the model.
+- **Evidence:** `crates/rsync_io/src/ssh/mod.rs:57-75` (already
+  documented for #1858).
+- **Status:** intentional. The socket-fast-path advantage is
+  theoretical for sequential bulk I/O on a `SOCK_STREAM` socketpair
+  versus pipe-FD `OP_READ`/`OP_WRITE`.
+- **Impact:** none. The pipe-FD io_uring plan (#1859) covers the
+  achievable wins.
 
-### Finding 6 (informational): no `MSG_INFO`/`MSG_ERROR` plumbing for local SSH-client stderr
+### Finding 6: stderr forwarding is not multiplexed onto the wire
 
-- **Evidence:** `aux_channel.rs:208-228` forwards SSH-client stderr
-  lines to `eprint!` rather than wrapping them in multiplex envelopes.
-- **Impact:** This is correct because the lines come from the *local*
-  SSH client (host-key warnings, connect errors) and never appear on
-  the rsync wire. Upstream rsync does the same: see comment block at
-  `pipe.c:99-108` and the fact that `io.c::send_msg` only multiplexes
-  output produced by the rsync process itself, not by SSH. No fix
-  needed; record this so we do not accidentally route SSH-client
-  stderr into the multiplex envelope when refactoring.
-- **Recommended fix:** none. Document the boundary in
-  `aux_channel.rs` so future refactors do not blur it.
+- **Evidence:** `crates/rsync_io/src/ssh/aux_channel.rs:208-228` writes
+  SSH-client stderr lines directly to `eprint!`. Upstream's multiplex
+  path (`io.c::send_msg`) only multiplexes diagnostic output produced
+  by the rsync process itself, not by SSH.
+- **Status:** matches upstream. The local SSH client's stderr is
+  out-of-band; it never appears on the rsync wire.
+- **Impact:** none. Documented to prevent future refactors from
+  inadvertently routing SSH-client stderr into the rsync multiplex
+  envelope.
 
-## 6. Recommendation
+## 8. Implementation notes (for the "keep" recommendation)
 
-**Implement** the socketpair migration on Unix; keep the pipe path as the
-permanent Windows fallback. The work is wire-compatible (no protocol
-changes), additive, and aligns oc-rsync with upstream's IPC topology. The
-auxiliary stderr socketpair stays as is.
+Because the recommendation is to keep pipes on the wire, the
+implementation note is the rationale for closing the pending trackers:
 
-### Phase 1: socketpair-backed wire on Unix
+### Closing #1687
 
-- **Spawn site:** in `crates/rsync_io/src/ssh/builder.rs::spawn`, before
-  the existing `Command::spawn`, attempt `UnixStream::pair()`. On
-  success, convert the child end to `OwnedFd` and pass it to the command
-  via `Stdio::from(child_fd)` for both stdin and stdout (the same FD,
-  duplicated by `Command` internally because the OS will `dup` for
-  position 0 and 1). Retain the parent end as a single bidirectional
-  `UnixStream`.
-- On failure (e.g., `EMFILE`), fall back to the existing
-  `Stdio::piped()` path. Mirror the structure of
-  `aux_channel.rs::configure_stderr_channel` for symmetry.
-- `SshConnection` keeps its current shape; the `stdin`/`stdout` fields
-  become `Option<Box<dyn Read + Write + Send>>` or are unified into a
-  single `wire: WireEnd` enum (`Pipe { stdin, stdout } | Socket(Arc<UnixStream>)`).
-- `split()` returns reader/writer halves that, on the socket variant,
-  hold an `Arc<UnixStream>` and a half-close marker. `SshWriter::close`
-  becomes `shutdown(Shutdown::Write)` on the socket variant and a drop
-  on the pipe variant.
-- Set `set_nonblocking(true)` on the parent end (Finding 2) and add a
-  small retry helper for `WouldBlock` to keep the blocking
-  `Read`/`Write` API contract the rest of the crate expects.
+> Prototype SSH subprocess using socketpair for bidirectional I/O.
 
-Acceptance criteria:
+Disposition: **do not prototype**. Justified by Section 6, primarily
+the splice eligibility argument (Section 4.5) and the no-measured-stall
+argument (Section 4.2). If the async-transport refactor (#2068) lands
+and benchmarks show a socket-specific win, this tracker can be
+reopened with concrete numbers. The audit closes #1687 in this PR's
+description so it is removed from the open queue.
 
-- All existing SSH integration tests pass on Linux, macOS, and Windows
-  unchanged (Windows continues on pipes).
-- A new socketpair-specific test asserts that
-  `shutdown(SHUT_WR)` from the parent surfaces EOF on the child's
-  stdin while the parent can still read responses.
-- Cross-version interop suite reports no regressions against rsync
-  3.0.9, 3.1.3, and 3.4.1 daemons.
+### Closing #1902
 
-### Phase 2: unified-FD event loop integration
+> Verify SSH socketpair vs anonymous-pipe wire claim against
+> `rsync_io` source.
 
-- Once phase 1 is in place, attach a single
-  `mio::Poll`/`tokio::io::AsyncFd`/`io_uring` registration to the
-  parent socketpair FD. Drive read- and write-readiness through one
-  poll set, eliminating the need for separate reader and writer
-  threads on the SSH path.
-- Map readiness to the existing `SshReader`/`SshWriter` API surface so
-  call sites in `crates/core/src/client/remote/ssh_transfer.rs` do not
-  change.
+Disposition: **verified**. The wire in `rsync_io` is two anonymous
+pipes (`crates/rsync_io/src/ssh/builder.rs:300-301`). Upstream uses
+two socketpairs (`pipe.c:57` plus `util1.c:84-85`). The audit closes
+#1902 in this PR's description.
 
-### Phase 3: half-close hygiene
+### What stays on the roadmap
 
-- Replace `SshConnection::close_stdin` (`connection.rs:97-102`) with a
-  `shutdown(Shutdown::Write)` on the socket variant. Match upstream
-  `cleanup.c:46-67` by issuing `shutdown(fd, 2)` before `close(fd)` on
-  the abnormal-exit path so the kernel sends an orderly FIN rather than
-  a RST. Keep the drop semantics on the pipe variant; pipes cannot
-  shut down.
+- **#1859** io_uring on pipe FDs - audited in
+  `iouring-pipe-stdio.md`. Pipes are eligible for `OP_READ`/`OP_WRITE`,
+  which is the path forward.
+- **#1860** splice/vmsplice for SSH stdio - audited in
+  `splice-ssh-stdio.md`. Pipes are required for splice.
+- **#2068** async SSH transport - audited in
+  `async-ssh-transport.md`. Will subsume the unified-FD discussion
+  whenever it lands.
 
-### Out of scope
+### Documentation hygiene
 
-- Any change to the wire protocol or multiplex envelope.
-- A third FD for SSH-client stderr (Finding 6: no need; upstream does
-  not do this and oc-rsync's existing stderr socketpair already covers
-  every observable property).
-- Windows. The pipe path stays. There is no productive way to wire an
-  `AF_UNIX` socketpair to `CreateProcess` standard handles on Windows
-  today.
+- `crates/rsync_io/src/ssh/mod.rs:57-75` already records the io_uring
+  consequence of using pipes. That paragraph remains accurate after this
+  audit and does not need a follow-up edit.
+- `crates/rsync_io/src/ssh/aux_channel.rs:1-22` already explains why
+  the stderr channel uses a socketpair while the wire does not need to.
+  No edit required.
 
-## Risks
+### If the recommendation is ever reversed
 
-- **Rust FD-as-stdio semantics.** `Stdio::from(OwnedFd)` consumes the
-  fd. To attach the *same* socketpair child end to both stdin and stdout,
-  we must `dup` the fd before constructing the second `Stdio`. This is
-  safe via `OwnedFd::try_clone` (which calls `fcntl(F_DUPFD_CLOEXEC)`)
-  but the test must verify the cloexec flag survives `dup2`-into-stdio
-  on every supported platform.
-- **Different read/write buffer accounting on socket vs pipe.** Code
-  that assumes 64 KiB pipe-buffer behaviour (today: none in oc-rsync's
-  SSH path) would need to switch to `SO_RCVBUF`/`SO_SNDBUF` queries.
-- **`splice(file -> wire)` no longer applies.** Splice requires one
-  side to be a pipe. With the socketpair migration the wire is no
-  longer a pipe, so the splice plan in `splice-ssh-stdio.md` does not
-  fire on the parent->child direction. Mitigation: that plan already
-  notes splice happens on the file<->page-cache edge, not across the
-  SSH child; the SSH wire was never a splice candidate. Confirmed by
-  re-reading `splice-ssh-stdio.md` lines 60-68.
-- **`Drop` ordering.** Today `SshConnection::Drop` (`connection.rs:543`)
-  drops the watchdog, then closes stdin, then waits on the child. With
-  socketpair the close-stdin step becomes a `shutdown(SHUT_WR)`. Drop
-  must still call `shutdown` before the inner `UnixStream` drops to
-  preserve the orderly-FIN behaviour.
-- **EAGAIN semantics under `set_nonblocking(true)`.** The blocking
-  `Read`/`Write` impls must wrap a retry loop or, in the event-loop
-  variant, hand readiness off to the runtime. Mistakes here cause busy
-  spins. Mitigation: add a unit test that pins the FD blocking and
-  asserts a single-shot read returns the expected number of bytes.
+For completeness, the touch-points a future socketpair migration would
+modify (recorded so a maintainer does not need to redo the search):
 
-## Follow-up tasks
+- `crates/rsync_io/src/ssh/builder.rs:300-301` - replace `Stdio::piped()`
+  with a factory that attempts `UnixStream::pair()` plus
+  `OwnedFd::try_clone` for the stdin child end and passes both child
+  ends as `Stdio::from(OwnedFd)`. Pipe fallback on failure.
+- `crates/rsync_io/src/ssh/connection.rs:30-39` - replace
+  `stdin`/`stdout` fields with a `wire: WireEnd` enum
+  (`Pipe { stdin, stdout }` or `Socket(Arc<UnixStream>)`).
+- `crates/rsync_io/src/ssh/connection.rs:178-208`,
+  `crates/rsync_io/src/ssh/connection.rs:241-243` - dispatch
+  `Read`/`Write`/`close` over the enum; socket variant uses
+  `shutdown(Shutdown::Write)`.
+- New tests: `shutdown(SHUT_WR)` surfaces EOF on the child's stdin while
+  the parent can still read; cloexec survives `dup2` into stdio.
+- Cross-version interop suite (`tools/ci/run_interop.sh`) must show no
+  regressions vs rsync 3.0.9, 3.1.3, 3.4.1.
+- Re-audit `splice-ssh-stdio.md` (#1860) - the splice plan would have
+  to thread an intermediate `pipe(2)`. Estimated ~100-200 LOC plus
+  tests, consistent with Section 4.9.
 
-- [ ] #1690 implement Unix socketpair-backed wire in
-      `crates/rsync_io/src/ssh/builder.rs::spawn`, with pipe fallback.
-- [ ] #1691 unify `SshReader`/`SshWriter` over an `Arc<UnixStream>` on
-      the socket variant and switch `close_stdin` to
-      `shutdown(SHUT_WR)`.
-- [ ] #1692 set `O_NONBLOCK` on the parent end and add a `WouldBlock`
-      retry helper (`crates/rsync_io/src/ssh/connection.rs`).
-- [ ] #1693 add cross-version interop test that exercises
-      `shutdown(SHUT_WR)`-based half-close against rsync 3.0.9, 3.1.3,
-      3.4.1.
-- [ ] #1694 (event loop) wire the unified FD into the poll/epoll/io_uring
-      readiness machinery; eliminate per-direction threads on the SSH
-      path. Depends on #1690-#1692.
-- [ ] #1695 document Windows pipe-only path in
-      `crates/rsync_io/src/ssh/mod.rs` once the Unix path lands so the
-      asymmetry is explicit.
+## 9. References
 
-## References
+Upstream rsync 3.4.1 (`target/interop/upstream-src/rsync-3.4.1/`):
 
-- Upstream: `target/interop/upstream-src/rsync-3.4.1/pipe.c:48-178`
-  (`piped_child`, `local_child`).
-- Upstream: `target/interop/upstream-src/rsync-3.4.1/util1.c:74-96`
-  (`fd_pair` socketpair-or-pipe wrapper).
-- Upstream: `target/interop/upstream-src/rsync-3.4.1/cleanup.c:46-67`
-  (`close_all`, orderly socket shutdown).
-- Upstream: `target/interop/upstream-src/rsync-3.4.1/io.c:983-1031`
-  (multiplex `send_msg`, the upstream substitute for an auxiliary
-  stderr channel).
-- oc-rsync: `crates/rsync_io/src/ssh/builder.rs:266-321`
-  (`SshCommand::spawn`).
-- oc-rsync: `crates/rsync_io/src/ssh/connection.rs:178-208`
-  (`SshConnection::split`).
-- oc-rsync: `crates/rsync_io/src/ssh/aux_channel.rs:138-193`
-  (`SocketpairStderrChannel` - the existing socketpair user).
-- oc-rsync: `crates/rsync_io/src/ssh/aux_channel.rs:263-291`
-  (`configure_stderr_channel` - the factory pattern to mirror for the
-  wire).
-- oc-rsync: `crates/rsync_io/src/ssh/mod.rs:57-72` (io_uring/splice
-  applicability notes that constrain phase 2/3 design).
-- Companion audit: `docs/audits/splice-ssh-stdio.md` (splice plan that
-  remains valid under both topologies).
+- `pipe.c:48-97` `piped_child` - SSH child setup, two `fd_pair` calls.
+- `pipe.c:99-178` `local_child` - forked-local rsync, same topology.
+- `util1.c:74-96` `fd_pair` - `socketpair`-or-`pipe` wrapper,
+  non-blocking on success.
+- `main.c:504-663` `do_cmd` - dispatch among `read_batch`,
+  `local_server`, `piped_child`.
+- `main.c:629`, `main.c:985` - auxiliary `fd_pair` uses (read-batch
+  back-channel, receiver error pipe).
+- `clientserver.c:116-148` `start_socket_client` - daemon TCP wire.
+- `clientserver.c:692` `rsync_module` - daemon per-connection handler.
+- `socket.c:736-846` `socketpair_tcp` + `sock_exec` -
+  `RSYNC_CONNECT_PROG` test escape (not used on real SSH paths).
+- `io.c:983-1031` `send_msg` - multiplex envelope (substitute for an
+  auxiliary stderr channel).
+- `cleanup.c:46-67` `close_all` - orderly socket shutdown.
+
+oc-rsync source:
+
+- `crates/rsync_io/src/ssh/builder.rs:285-340` `SshCommand::spawn`.
+- `crates/rsync_io/src/ssh/builder.rs:300-301` - `Stdio::piped()` for
+  wire stdin/stdout.
+- `crates/rsync_io/src/ssh/connection.rs:30-39` `SshConnection`.
+- `crates/rsync_io/src/ssh/connection.rs:96-102` `close_stdin`.
+- `crates/rsync_io/src/ssh/connection.rs:178-208`
+  `SshConnection::split`.
+- `crates/rsync_io/src/ssh/connection.rs:217-237` blocking `Read` /
+  `Write` impls.
+- `crates/rsync_io/src/ssh/connection.rs:241-243` `SshWriter::close`.
+- `crates/rsync_io/src/ssh/connection.rs:246-322` `ConnectWatchdog`.
+- `crates/rsync_io/src/ssh/aux_channel.rs:138-193`
+  `SocketpairStderrChannel` (#1689).
+- `crates/rsync_io/src/ssh/aux_channel.rs:263-291`
+  `configure_stderr_channel`.
+- `crates/rsync_io/src/ssh/mod.rs:57-75` io_uring boundary (#1858).
+
+Companion audits:
+
+- `docs/audits/iouring-pipe-stdio.md` (#1859), `splice-ssh-stdio.md`
+  (#1860), `async-ssh-transport.md` (#2068),
+  `async-file-writer-trait.md` (#1655),
+  `ssh-cipher-compression.md`.
+
+External references:
+
+- `man 2 socketpair`, `man 2 pipe`, `man 7 pipe`, `man 2 splice`,
+  `man 2 vmsplice`, `man 7 unix`.
+- Linux io_uring opcodes: `IORING_OP_READ`, `IORING_OP_WRITE`,
+  `IORING_OP_RECV`, `IORING_OP_SEND`, `SEND_ZC`.


### PR DESCRIPTION
Closes #1938.

## Summary

Formalizes the SSH stdio transport audit at `docs/audits/ssh-socketpair-vs-pipes.md` under tracker #1938. Consolidates prior #1686 working notes (PR #3438), the io_uring boundary documented for #1858 (PR #3418), and the stderr socketpair shipped under #1689 (PR #3383). Restructures the document into the formal seven-section layout (summary, upstream reference, current implementation, trade-offs, decision matrix, recommendation, implementation notes) plus findings and references.

Recommends **keeping anonymous pipes** for the SSH wire and not pursuing the socketpair migration. The decisive argument is that `splice(2)` / `vmsplice(2)` require one of the two FDs to be a pipe; oc-rsync's zero-copy roadmap in #1860 depends on the wire being a pipe so the file<->wire splice path remains direct. A socketpair-backed wire would force a double-splice through an intermediate user-space `pipe(2)`, eliminating the zero-copy benefit. The "unified poll FD" advantage of socketpair only matters inside an event loop, and the async-transport refactor (#2068, #1655) consolidates readiness tracking regardless of primitive.

The audit closes the two pending follow-ups in this tracker family:

- #1687 (prototype SSH subprocess using socketpair for bidirectional I/O) - **do not implement**, justified by the splice eligibility argument and absence of measured backpressure stalls on pipes.
- #1902 (verify SSH socketpair vs anonymous-pipe wire claim against `rsync_io` source) - **verified**: `crates/rsync_io/src/ssh/builder.rs:300-301` uses `Stdio::piped()` for stdin and stdout (anonymous pipes); upstream uses `socketpair(AF_UNIX, SOCK_STREAM, 0)` via `util1.c::fd_pair` called from `pipe.c::piped_child`. The divergence is intentional.

What stays on the roadmap (untouched by this audit):

- #1859 io_uring on pipe FDs (`docs/audits/iouring-pipe-stdio.md`).
- #1860 splice/vmsplice for SSH stdio (`docs/audits/splice-ssh-stdio.md`).
- #2068 async SSH transport (`docs/audits/async-ssh-transport.md`).

## Test plan

- [x] No code changes; documentation-only PR.
- [x] All upstream citations re-verified against `target/interop/upstream-src/rsync-3.4.1/` source files.
- [x] All `crates/rsync_io/src/ssh/` citations verified against worktree line numbers.
- [x] No em-dashes; conventional `docs:` prefix; branch name `docs/ssh-socketpair-1938`.
- [ ] CI: rustdoc renders without broken intra-doc links.
- [ ] CI: fmt+clippy (no code changes, expected to pass).
- [ ] CI: nextest (stable) (no code changes, expected to pass).
- [ ] CI: Windows / macOS / Linux musl (no code changes, expected to pass).