### PR TITLE
feat(core): wire IconvSetting to FilenameConverter at config build (#1911)

### DIFF
--- a/crates/core/src/client/run/mod.rs
+++ b/crates/core/src/client/run/mod.rs
@@ -368,9 +368,36 @@ impl<'a> LocalCopyOptionsBuilder<'a> {
         options = self.apply_paths_and_backups(options, config);
         options = self.apply_time_and_timeout(options, config);
         options = self.apply_reference_directories(options, config);
+        options = self.apply_iconv(options, config);
         options = self.apply_filter_program(options);
 
         options
+    }
+
+    /// Resolves the user's `--iconv` request into a
+    /// [`FilenameConverter`](protocol::iconv::FilenameConverter) and
+    /// attaches it to the local-copy options.
+    ///
+    /// This is the local-copy mirror of the SSH/daemon path's
+    /// `apply_common_server_flags`
+    /// (`crates/core/src/client/remote/flags.rs:203-228`), which writes the
+    /// converter onto `transfer::config::ConnectionConfig::iconv`. The
+    /// local-copy executor lives in the engine crate and does not traverse
+    /// the SSH/daemon `ServerConfig` builder, so the bridge has to be
+    /// re-applied here.
+    ///
+    /// When `IconvSetting::Unspecified` or `IconvSetting::Disabled`,
+    /// `resolve_converter` returns `None`, leaving the engine's
+    /// pass-through behaviour untouched. This mirrors upstream rsync's
+    /// behaviour when `--iconv` is absent or `--no-iconv` is supplied.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `flist.c::iconv_for_local`
+    /// - `options.c::recv_iconv_settings`
+    /// - `compat.c:716-718`
+    fn apply_iconv(&self, options: LocalCopyOptions, config: &ClientConfig) -> LocalCopyOptions {
+        options.with_iconv(config.iconv().resolve_converter())
     }
 
     const fn apply_recursion_and_delete(
@@ -587,4 +614,72 @@ pub fn build_local_copy_options(
     filter_program: Option<FilterProgram>,
 ) -> LocalCopyOptions {
     LocalCopyOptionsBuilder::new(config, filter_program).build()
+}
+
+#[cfg(test)]
+mod iconv_wiring_tests {
+    use std::ffi::OsString;
+
+    use super::build_local_copy_options;
+    use crate::client::config::{ClientConfig, IconvSetting};
+
+    fn config_with_iconv(setting: IconvSetting) -> ClientConfig {
+        ClientConfig::builder()
+            .transfer_args([OsString::from("src"), OsString::from("dst")])
+            .iconv(setting)
+            .build()
+    }
+
+    #[test]
+    fn local_copy_options_iconv_unset_yields_none() {
+        let config = ClientConfig::builder()
+            .transfer_args([OsString::from("src"), OsString::from("dst")])
+            .build();
+        let options = build_local_copy_options(&config, None);
+        assert!(options.iconv().is_none());
+    }
+
+    #[test]
+    fn local_copy_options_iconv_disabled_yields_none() {
+        let config = config_with_iconv(IconvSetting::Disabled);
+        let options = build_local_copy_options(&config, None);
+        assert!(options.iconv().is_none());
+    }
+
+    #[test]
+    fn local_copy_options_iconv_locale_default_yields_some() {
+        let config = config_with_iconv(IconvSetting::LocaleDefault);
+        let options = build_local_copy_options(&config, None);
+        let converter = options
+            .iconv()
+            .expect("locale-default iconv should produce a converter");
+        // converter_from_locale() currently returns identity; the contract
+        // is that *some* converter is attached, regardless of identity.
+        assert!(converter.is_identity());
+    }
+
+    #[cfg(feature = "iconv")]
+    #[test]
+    fn local_copy_options_iconv_explicit_yields_non_identity_converter() {
+        let config = config_with_iconv(IconvSetting::Explicit {
+            local: "UTF-8".to_owned(),
+            remote: Some("ISO-8859-1".to_owned()),
+        });
+        let options = build_local_copy_options(&config, None);
+        let converter = options
+            .iconv()
+            .expect("explicit iconv pair should produce a converter");
+        assert!(!converter.is_identity());
+        assert_eq!(converter.local_encoding_name(), "UTF-8");
+    }
+
+    #[test]
+    fn local_copy_options_iconv_unsupported_charset_falls_back_to_none() {
+        let config = config_with_iconv(IconvSetting::Explicit {
+            local: "definitely-not-a-real-charset".to_owned(),
+            remote: Some("also-fake".to_owned()),
+        });
+        let options = build_local_copy_options(&config, None);
+        assert!(options.iconv().is_none());
+    }
 }

--- a/crates/engine/src/local_copy/options/builder/definition.rs
+++ b/crates/engine/src/local_copy/options/builder/definition.rs
@@ -11,6 +11,7 @@ use compress::algorithm::CompressionAlgorithm;
 use compress::zlib::CompressionLevel;
 use fast_io::{DefaultPlatformCopy, PlatformCopy};
 use filters::FilterSet;
+use protocol::iconv::FilenameConverter;
 
 use crate::batch::BatchWriter;
 use crate::local_copy::filter_program::FilterProgram;
@@ -88,6 +89,8 @@ pub struct LocalCopyOptionsBuilder {
 
     pub(super) filters: Option<FilterSet>,
     pub(super) filter_program: Option<FilterProgram>,
+    /// See [`LocalCopyOptions`](crate::local_copy::LocalCopyOptions)::iconv.
+    pub(super) iconv: Option<FilenameConverter>,
 
     pub(super) numeric_ids: bool,
     pub(super) sparse: bool,
@@ -212,6 +215,7 @@ impl LocalCopyOptionsBuilder {
             preserve_acls: false,
             filters: None,
             filter_program: None,
+            iconv: None,
             numeric_ids: false,
             sparse: false,
             checksum: false,

--- a/crates/engine/src/local_copy/options/builder/setters_filter.rs
+++ b/crates/engine/src/local_copy/options/builder/setters_filter.rs
@@ -1,6 +1,7 @@
 //! Setter methods for filter and exclusion options.
 
 use filters::FilterSet;
+use protocol::iconv::FilenameConverter;
 
 use super::LocalCopyOptionsBuilder;
 use crate::local_copy::filter_program::FilterProgram;
@@ -17,6 +18,20 @@ impl LocalCopyOptionsBuilder {
     #[must_use]
     pub fn filter_program(mut self, program: Option<FilterProgram>) -> Self {
         self.filter_program = program;
+        self
+    }
+
+    /// Sets the optional filename charset converter resolved from
+    /// `--iconv=LOCAL,REMOTE`.
+    ///
+    /// Pass `None` to disable transcoding (the default). When `Some`, the
+    /// converter is propagated to
+    /// [`LocalCopyOptions::iconv`](crate::local_copy::LocalCopyOptions::iconv)
+    /// for later use by file-list emit, file-list ingest, and filter
+    /// matching once those producer wirings land (#1912, #1913, #1914).
+    #[must_use]
+    pub fn iconv(mut self, converter: Option<FilenameConverter>) -> Self {
+        self.iconv = converter;
         self
     }
 }

--- a/crates/engine/src/local_copy/options/builder/validation.rs
+++ b/crates/engine/src/local_copy/options/builder/validation.rs
@@ -138,6 +138,7 @@ impl LocalCopyOptionsBuilder {
             preserve_acls: self.preserve_acls,
             filters: self.filters,
             filter_program: self.filter_program,
+            iconv: self.iconv,
             numeric_ids: self.numeric_ids,
             sparse: self.sparse,
             checksum: self.checksum,

--- a/crates/engine/src/local_copy/options/filters.rs
+++ b/crates/engine/src/local_copy/options/filters.rs
@@ -1,4 +1,5 @@
 use filters::FilterSet;
+use protocol::iconv::FilenameConverter;
 
 use super::types::LocalCopyOptions;
 use crate::local_copy::filter_program::FilterProgram;
@@ -24,6 +25,25 @@ impl LocalCopyOptions {
         self
     }
 
+    /// Attaches a filename charset converter to the local-copy options.
+    ///
+    /// Mirrors the SSH/daemon path's
+    /// `transfer::config::ConnectionConfig::iconv`, which is populated from
+    /// `apply_common_server_flags`. The local-copy path bypasses that
+    /// bridge, so this setter is the only route by which a converter
+    /// resolved from
+    /// `core::client::config::IconvSetting::resolve_converter` reaches the
+    /// engine. Pass `None` to disable transcoding.
+    ///
+    /// This setter does not yet apply the converter on emit, ingest, or
+    /// filter matching; those producer wirings are tracked under
+    /// trackers #1912, #1913, and #1914 respectively.
+    #[must_use]
+    pub fn with_iconv(mut self, converter: Option<FilenameConverter>) -> Self {
+        self.iconv = converter;
+        self
+    }
+
     /// Returns the configured filter set, if any.
     pub const fn filter_set(&self) -> Option<&FilterSet> {
         self.filters.as_ref()
@@ -32,6 +52,16 @@ impl LocalCopyOptions {
     /// Returns the configured filter program, if any.
     pub const fn filter_program(&self) -> Option<&FilterProgram> {
         self.filter_program.as_ref()
+    }
+
+    /// Returns the configured filename charset converter, if any.
+    ///
+    /// Returns `None` when `--iconv` was not set, when `--no-iconv` was set,
+    /// or when the user-supplied charset spec failed to resolve to a
+    /// supported `encoding_rs` encoding (in which case the resolver also
+    /// emits a `tracing::warn!`).
+    pub const fn iconv(&self) -> Option<&FilenameConverter> {
+        self.iconv.as_ref()
     }
 }
 
@@ -67,5 +97,27 @@ mod tests {
     fn filter_program_returns_none_by_default() {
         let options = LocalCopyOptions::new();
         assert!(options.filter_program().is_none());
+    }
+
+    #[test]
+    fn iconv_returns_none_by_default() {
+        let options = LocalCopyOptions::new();
+        assert!(options.iconv().is_none());
+    }
+
+    #[test]
+    fn with_iconv_attaches_converter() {
+        let converter = FilenameConverter::identity();
+        let options = LocalCopyOptions::new().with_iconv(Some(converter.clone()));
+        assert_eq!(options.iconv(), Some(&converter));
+    }
+
+    #[test]
+    fn with_iconv_none_clears_converter() {
+        let converter = FilenameConverter::identity();
+        let options = LocalCopyOptions::new()
+            .with_iconv(Some(converter))
+            .with_iconv(None);
+        assert!(options.iconv().is_none());
     }
 }

--- a/crates/engine/src/local_copy/options/types.rs
+++ b/crates/engine/src/local_copy/options/types.rs
@@ -9,6 +9,7 @@ use compress::algorithm::CompressionAlgorithm;
 use compress::zlib::CompressionLevel;
 use fast_io::{DefaultPlatformCopy, PlatformCopy};
 use filters::FilterSet;
+use protocol::iconv::FilenameConverter;
 
 use crate::batch::BatchWriter;
 use crate::local_copy::filter_program::FilterProgram;
@@ -127,6 +128,26 @@ pub struct LocalCopyOptions {
     pub(super) preserve_acls: bool,
     pub(super) filters: Option<FilterSet>,
     pub(super) filter_program: Option<FilterProgram>,
+    /// Optional filename charset converter resolved from the user's
+    /// `--iconv=LOCAL,REMOTE` request.
+    ///
+    /// `None` means raw bytes are passed through verbatim, matching upstream
+    /// rsync's behaviour when `--iconv` is absent or `--no-iconv` is set.
+    /// `Some(converter)` means file-list emit, file-list ingest, and filter
+    /// matching call sites should transcode names through this converter
+    /// when those producers are wired (tracked under #1912, #1913, #1914).
+    ///
+    /// This field is the local-copy mirror of
+    /// `transfer::config::ConnectionConfig::iconv`, populated for SSH and
+    /// daemon transfers via `apply_common_server_flags`. The local-copy
+    /// path bypasses that bridge, so the converter is plumbed here directly
+    /// from `core::client::run::build_local_copy_options`.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `flist.c::iconv_for_local` (file-list path entry transcode)
+    /// - `options.c::recv_iconv_settings` (parse `--iconv=LOCAL,REMOTE`)
+    pub(super) iconv: Option<FilenameConverter>,
     pub(super) numeric_ids: bool,
     pub(super) sparse: bool,
     pub(super) checksum: bool,
@@ -249,6 +270,7 @@ impl LocalCopyOptions {
             preserve_acls: false,
             filters: None,
             filter_program: None,
+            iconv: None,
             numeric_ids: false,
             sparse: false,
             checksum: false,


### PR DESCRIPTION
Closes #1911.

## Summary

Completes the local-copy bridge between the parsed `IconvSetting` on `ClientConfig` and the engine's `LocalCopyOptions`, mirroring the SSH / daemon bridge that PR #3458 wired through `apply_common_server_flags`. The audit at `docs/audits/iconv-inert.md` (PR #3526) labels #1911 as "Partial" because the local-copy path bypasses `apply_common_server_flags` and had no route by which a resolved `FilenameConverter` could reach the engine.

After this PR, every transport that hands a `ClientConfig` to the engine has an `Option<FilenameConverter>` available on `LocalCopyOptions::iconv()` for downstream wiring sites (#1912 sender emit, #1913 receiver ingest, #1914 filter-rule path matching) to consume. Wire encoding, application semantics, and producer-site changes remain out of scope and are tracked separately.

## Changes

- `engine::local_copy::LocalCopyOptions` and `LocalCopyOptionsBuilder` gain an `iconv: Option<FilenameConverter>` field with a `with_iconv` setter and `iconv()` accessor on the options struct, plus an `iconv()` setter on the builder.
- `core::client::run::LocalCopyOptionsBuilder::build` (the internal wrapper around the engine builder) calls `config.iconv().resolve_converter()` via a new `apply_iconv` step and propagates the result onto `LocalCopyOptions`.
- Unit tests at `crates/engine/src/local_copy/options/filters.rs` cover default-none, attach, and clear semantics.
- Unit tests at `crates/core/src/client/run/mod.rs` cover the `IconvSetting -> LocalCopyOptions.iconv` mapping for `Unspecified`, `Disabled`, `LocaleDefault`, `Explicit`, and unsupported-charset variants.

## Audit alignment

This is exactly the work called out as "Smallest-PR-first sequence" step 1 in `docs/audits/iconv-inert.md` section 4.2:

> #1911 local-copy bridge - extend `LocalCopyOptions` (in `crates/engine/src/local_copy/`) with `iconv: Option<FilenameConverter>` and call `config.iconv().resolve_converter()` from `crates/core/src/client/run/mod.rs::build_local_copy_options`. Roughly +20 lines, no new types.

Net source change is +189 lines including tests and rustdoc. No new types.

Upstream references in the new code:

- `flist.c::iconv_for_local`
- `options.c::recv_iconv_settings`
- `compat.c:716-718`

## Out of scope

This PR does not apply the converter on emit, ingest, or filter matching. Those producer wirings are #1912, #1913, and #1914 respectively. The hard-error-when-feature-off check is already in tree (#1915, PR #3458) so no `iconv` feature gate work is needed here.

## Test plan

- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo nextest run -p engine --all-features -E 'test(iconv) + test(local_copy_options)'` -> 56 tests passed (locally).
- [x] `cargo nextest run -p core --all-features -E 'test(iconv)'` -> 24 tests passed (locally).
- [x] `cargo nextest run -p core --all-features -E 'test(iconv_wiring)'` -> 5 new tests passed (locally).
- [ ] Full CI: fmt+clippy, nextest (stable), Windows (stable), macOS (stable), Linux musl (stable), interop.