### PR TITLE
fix(ci): escape charset backticks in known_failures.conf

### DIFF
--- a/tools/ci/known_failures.conf
+++ b/tools/ci/known_failures.conf
@@ -135,7 +135,7 @@ is_known_failure_from_conf() {
 DASHBOARD_ENTRIES=(
   # --- oc-rsync known gaps (unconditional) ---
   # daemon-mode iconv: `charset =` directive parsed but not wired to iconv runtime
-  "standalone:iconv-upstream|--iconv UTF-8/LATIN1 round-trip vs upstream 3.4.1 (#1916, daemon `charset` directive not yet wired to iconv runtime; see docs/audits/iconv-pipeline.md)|standalone"
+  "standalone:iconv-upstream|--iconv UTF-8/LATIN1 round-trip vs upstream 3.4.1 (#1916, daemon 'charset' directive not yet wired to iconv runtime; see docs/audits/iconv-pipeline.md)|standalone"
 
   # --- oc-rsync known bugs (unconditional) ---
   # delta engine does not engage in daemon mode - all data sent as literals


### PR DESCRIPTION
## Summary
- Replaces `` `charset` `` with `'charset'` inside the iconv-upstream `DASHBOARD_ENTRIES` description string in `tools/ci/known_failures.conf`.
- Backticks inside double-quoted bash strings are command substitution; sourcing the file ran `charset` as a command and exited 127, breaking the required `interop / interop with upstream rsync` CI check on master and on every open PR that inherited the failure.
- The neighbouring `# daemon-mode iconv: \`charset =\` directive parsed but not wired to iconv runtime` comment is unaffected because backticks inside `#` comments are inert.

The unwired `charset` directive itself is tracked in #1917 (daemon-side `iconv` / `charset` not yet threaded into the iconv runtime); this PR is purely a CI hygiene fix.

## Test plan
- [x] `bash -c 'source tools/ci/known_failures.conf && echo OK: \${#KNOWN_FAILURES[@]} known + \${#DASHBOARD_ENTRIES[@]} dashboard entries'` returns `OK: 3 known + 8 dashboard entries` (was `line 161: charset: command not found`).
- [ ] Required `interop / interop with upstream rsync` CI check passes on this PR.
- [ ] After merge, the same check turns green on master and on the downstream PRs whose only failure was the inherited interop break.