### PR TITLE
feat(metadata): implement Windows xattrs via NTFS Alternate Data Streams (#1867)

### DIFF
--- a/crates/metadata/src/lib.rs
+++ b/crates/metadata/src/lib.rs
@@ -134,10 +134,16 @@ mod special;
 /// would otherwise escape the module root.
 pub mod symlink_munge;
 
-#[cfg(all(unix, feature = "xattr"))]
+#[cfg(all(feature = "xattr", any(unix, windows)))]
 mod xattr;
 
-#[cfg(not(all(unix, feature = "xattr")))]
+#[cfg(all(feature = "xattr", unix))]
+mod xattr_unix;
+
+#[cfg(all(feature = "xattr", windows))]
+mod xattr_windows;
+
+#[cfg(not(all(feature = "xattr", any(unix, windows))))]
 mod xattr_stub;
 
 #[cfg(all(unix, feature = "xattr"))]
@@ -207,10 +213,10 @@ pub use special::{
     create_fifo_with_fake_super,
 };
 
-#[cfg(all(unix, feature = "xattr"))]
+#[cfg(all(feature = "xattr", any(unix, windows)))]
 pub use xattr::{apply_xattrs_from_list, read_xattrs_for_wire, sync_xattrs};
 
-#[cfg(not(all(unix, feature = "xattr")))]
+#[cfg(not(all(feature = "xattr", any(unix, windows))))]
 pub use xattr_stub::{apply_xattrs_from_list, read_xattrs_for_wire, sync_xattrs};
 
 pub use copy_as::{CopyAsGuard, CopyAsIds, parse_copy_as_spec, switch_effective_ids};

--- a/crates/metadata/src/xattr.rs
+++ b/crates/metadata/src/xattr.rs
@@ -101,11 +101,7 @@ fn write_attribute(
         .map_err(|error| map_xattr_error("write extended attribute", path, error))
 }
 
-fn remove_attribute(
-    path: &Path,
-    name: &[u8],
-    follow_symlinks: bool,
-) -> Result<(), MetadataError> {
+fn remove_attribute(path: &Path, name: &[u8], follow_symlinks: bool) -> Result<(), MetadataError> {
     backend::remove_attribute(path, name, follow_symlinks)
         .map_err(|error| map_xattr_error("remove extended attribute", path, error))
 }
@@ -709,11 +705,7 @@ mod tests {
         apply_xattrs_from_list(&file, &list, false).expect("apply empty list");
 
         // All permitted xattrs should be removed
-        assert!(
-            read_attribute(&file, &attr, false)
-                .expect("read")
-                .is_none()
-        );
+        assert!(read_attribute(&file, &attr, false).expect("read").is_none());
     }
 
     #[test]

--- a/crates/metadata/src/xattr.rs
+++ b/crates/metadata/src/xattr.rs
@@ -1,17 +1,44 @@
+//! Cross-platform extended-attribute glue.
+//!
+//! Sits above the platform backends and reproduces upstream rsync's xattr
+//! flow:
+//!
+//! - On Unix the [`xattr_unix`](crate::xattr_unix) module wraps the
+//!   `xattr` crate (`get`/`set`/`list`/`remove`).
+//! - On Windows the [`xattr_windows`](crate::xattr_windows) module
+//!   maps every named xattr onto an NTFS Alternate Data Stream
+//!   (`path:name:$DATA`) so the client/daemon surface remains the same.
+//!
+//! The per-attribute primitives all take and return raw byte slices for
+//! attribute names so the wire format (which is byte-oriented) and the
+//! POSIX/NTFS native encodings can both be expressed without lossy
+//! conversions in this layer.
+//!
+//! # Upstream Reference
+//!
+//! - `xattrs.c:rsync_xal_get()` - read xattrs into the wire-list cache.
+//! - `xattrs.c:rsync_xal_set()` - apply received xattrs on the receiver.
+//! - `xattrs.c:64-68, 254-257` - permitted-namespace policy on Linux.
+
 use crate::error::MetadataError;
 use protocol::xattr::XattrList;
 use std::collections::HashSet;
-use std::ffi::{OsStr, OsString};
 use std::io;
-use std::os::unix::ffi::OsStrExt;
 use std::path::Path;
+
+#[cfg(unix)]
+use crate::xattr_unix as backend;
+#[cfg(windows)]
+use crate::xattr_windows as backend;
 
 /// Checks whether an xattr name is permitted for the current privilege level.
 ///
 /// Mirrors upstream rsync `xattrs.c:64-68, 254-257`:
 /// - Non-root on Linux: only `user.*` xattrs are accessible.
 /// - Root on Linux: all namespaces except `system.*`.
-/// - On non-Linux Unix (macOS, FreeBSD): no namespace filtering (different model).
+/// - On non-Linux platforms (macOS, FreeBSD, Windows): no namespace
+///   filtering, since those systems use a single flat namespace (NTFS ADS,
+///   `com.apple.*`, FreeBSD `user`-only, etc.).
 #[cfg(target_os = "linux")]
 fn is_xattr_permitted(name: &str) -> bool {
     const USER_PREFIX: &str = "user.";
@@ -33,7 +60,7 @@ fn is_xattr_permitted(name: &str) -> bool {
     }
 }
 
-/// On non-Linux Unix (macOS, FreeBSD), all xattr names are permitted.
+/// On non-Linux platforms (macOS, FreeBSD, Windows), all xattr names are permitted.
 #[cfg(not(target_os = "linux"))]
 fn is_xattr_permitted(_name: &str) -> bool {
     true
@@ -43,56 +70,44 @@ fn map_xattr_error(context: &'static str, path: &Path, error: io::Error) -> Meta
     MetadataError::new(context, path, error)
 }
 
-fn list_attributes(path: &Path, follow_symlinks: bool) -> Result<Vec<OsString>, MetadataError> {
-    let attrs = if follow_symlinks {
-        xattr::list_deref(path)
-    } else {
-        xattr::list(path)
-    }
-    .map_err(|error| map_xattr_error("list extended attributes", path, error))?;
+/// Returns the byte-encoded xattr names present on `path`, filtered by
+/// [`is_xattr_permitted`].
+fn list_attributes(path: &Path, follow_symlinks: bool) -> Result<Vec<Vec<u8>>, MetadataError> {
+    let attrs = backend::list_attributes(path, follow_symlinks)
+        .map_err(|error| map_xattr_error("list extended attributes", path, error))?;
     Ok(attrs
-        .filter(|name| is_xattr_permitted(&name.to_string_lossy()))
+        .into_iter()
+        .map(|name| backend::os_name_to_bytes(&name))
+        .filter(|bytes| is_xattr_permitted(&String::from_utf8_lossy(bytes)))
         .collect())
 }
 
 fn read_attribute(
     path: &Path,
-    name: &OsString,
+    name: &[u8],
     follow_symlinks: bool,
 ) -> Result<Option<Vec<u8>>, MetadataError> {
-    let result = if follow_symlinks {
-        xattr::get_deref(path, name)
-    } else {
-        xattr::get(path, name)
-    };
-    result.map_err(|error| map_xattr_error("read extended attribute", path, error))
+    backend::read_attribute(path, name, follow_symlinks)
+        .map_err(|error| map_xattr_error("read extended attribute", path, error))
 }
 
 fn write_attribute(
     path: &Path,
-    name: &OsString,
+    name: &[u8],
     value: &[u8],
     follow_symlinks: bool,
 ) -> Result<(), MetadataError> {
-    let result = if follow_symlinks {
-        xattr::set_deref(path, name, value)
-    } else {
-        xattr::set(path, name, value)
-    };
-    result.map_err(|error| map_xattr_error("write extended attribute", path, error))
+    backend::write_attribute(path, name, value, follow_symlinks)
+        .map_err(|error| map_xattr_error("write extended attribute", path, error))
 }
 
 fn remove_attribute(
     path: &Path,
-    name: &OsString,
+    name: &[u8],
     follow_symlinks: bool,
 ) -> Result<(), MetadataError> {
-    let result = if follow_symlinks {
-        xattr::remove_deref(path, name)
-    } else {
-        xattr::remove(path, name)
-    };
-    result.map_err(|error| map_xattr_error("remove extended attribute", path, error))
+    backend::remove_attribute(path, name, follow_symlinks)
+        .map_err(|error| map_xattr_error("remove extended attribute", path, error))
 }
 
 /// Reads xattr data from a file and returns it as a wire-format `XattrList`.
@@ -119,9 +134,8 @@ pub fn read_xattrs_for_wire(
     let mut entries = Vec::with_capacity(attrs.len());
 
     for name in &attrs {
-        let local_name = name.as_bytes();
         // upstream: xattrs.c:509-528 - translate local name to wire format
-        let wire_name = match local_to_wire(local_name, am_root) {
+        let wire_name = match local_to_wire(name, am_root) {
             Some(n) => n,
             None => continue, // Filtered out (rsync internal, namespace issue)
         };
@@ -154,11 +168,11 @@ pub fn sync_xattrs(
     filter: Option<&dyn Fn(&str) -> bool>,
 ) -> Result<(), MetadataError> {
     let source_attrs = list_attributes(source, follow_symlinks)?;
-    let mut retained = HashSet::with_capacity(source_attrs.len());
+    let mut retained: HashSet<Vec<u8>> = HashSet::with_capacity(source_attrs.len());
 
     for name in &source_attrs {
         retained.insert(name.clone());
-        let allow = filter.is_none_or(|predicate| predicate(&name.to_string_lossy()));
+        let allow = filter.is_none_or(|predicate| predicate(&String::from_utf8_lossy(name)));
 
         if !allow {
             continue;
@@ -177,7 +191,7 @@ pub fn sync_xattrs(
             continue;
         }
 
-        let allow = filter.is_none_or(|predicate| predicate(&name.to_string_lossy()));
+        let allow = filter.is_none_or(|predicate| predicate(&String::from_utf8_lossy(name)));
 
         if allow {
             remove_attribute(destination, name, follow_symlinks)?;
@@ -214,7 +228,7 @@ pub fn apply_xattrs_from_list(
     xattr_list: &XattrList,
     follow_symlinks: bool,
 ) -> Result<(), MetadataError> {
-    let mut applied_names: HashSet<OsString> = HashSet::with_capacity(xattr_list.len());
+    let mut applied_names: HashSet<Vec<u8>> = HashSet::with_capacity(xattr_list.len());
 
     for entry in xattr_list.iter() {
         // Skip abbreviated entries - they only contain a checksum, not the actual value
@@ -227,18 +241,17 @@ pub fn apply_xattrs_from_list(
             continue;
         }
 
-        let os_name = OsStr::from_bytes(entry.name());
-        let os_name_owned = os_name.to_os_string();
+        let name_bytes = entry.name().to_vec();
 
-        write_attribute(destination, &os_name_owned, entry.datum(), follow_symlinks)?;
-        applied_names.insert(os_name_owned);
+        write_attribute(destination, &name_bytes, entry.datum(), follow_symlinks)?;
+        applied_names.insert(name_bytes);
     }
 
     // Remove destination xattrs not in the source list
     let dest_attrs = list_attributes(destination, follow_symlinks)?;
     for name in &dest_attrs {
         if !applied_names.contains(name) {
-            let name_str = name.to_string_lossy();
+            let name_str = String::from_utf8_lossy(name);
             if is_xattr_permitted(&name_str) {
                 remove_attribute(destination, name, follow_symlinks)?;
             }
@@ -252,19 +265,34 @@ pub fn apply_xattrs_from_list(
 mod tests {
     use super::*;
     use protocol::xattr::XattrEntry;
-    use std::ffi::OsStr;
     use std::fs;
     use tempfile::tempdir;
 
     /// Helper to check if xattrs are supported on the current filesystem.
     fn xattrs_supported(path: &Path) -> bool {
-        let test_name = OsStr::new("user.test_support");
-        match xattr::set(path, test_name, b"test") {
+        let test_name = test_xattr_name("test_support");
+        match write_attribute(path, &test_name, b"test", false) {
             Ok(()) => {
-                let _ = xattr::remove(path, test_name);
+                let _ = remove_attribute(path, &test_name, false);
                 true
             }
             Err(_) => false,
+        }
+    }
+
+    /// Returns the expected local xattr name for test entries.
+    ///
+    /// On Linux, names need the `user.` prefix. On other platforms (macOS,
+    /// BSD, Windows ADS), names are used as-is since there is no namespace
+    /// prefix requirement.
+    fn test_xattr_name(base: &str) -> Vec<u8> {
+        #[cfg(target_os = "linux")]
+        {
+            format!("user.{base}").into_bytes()
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            base.as_bytes().to_vec()
         }
     }
 
@@ -284,7 +312,7 @@ mod tests {
         assert!(
             attrs
                 .iter()
-                .all(|a| !a.to_string_lossy().contains("user.custom"))
+                .all(|a| !String::from_utf8_lossy(a).contains("user.custom"))
         );
     }
 
@@ -299,7 +327,7 @@ mod tests {
             return;
         }
 
-        let attr_name = OsString::from("user.test_attr");
+        let attr_name = test_xattr_name("test_attr");
         let attr_value = b"test value 123";
 
         write_attribute(&file, &attr_name, attr_value, false).expect("write attr");
@@ -322,7 +350,7 @@ mod tests {
             return;
         }
 
-        let attr_name = OsString::from("user.nonexistent");
+        let attr_name = test_xattr_name("nonexistent");
         let result = read_attribute(&file, &attr_name, false).expect("read attr");
         assert!(result.is_none());
     }
@@ -338,7 +366,7 @@ mod tests {
             return;
         }
 
-        let attr_name = OsString::from("user.to_remove");
+        let attr_name = test_xattr_name("to_remove");
         write_attribute(&file, &attr_name, b"value", false).expect("write attr");
 
         // Verify it exists
@@ -371,8 +399,8 @@ mod tests {
             return;
         }
 
-        let attr1 = OsString::from("user.attr1");
-        let attr2 = OsString::from("user.attr2");
+        let attr1 = test_xattr_name("attr1");
+        let attr2 = test_xattr_name("attr2");
         write_attribute(&source, &attr1, b"value1", false).expect("write attr1");
         write_attribute(&source, &attr2, b"value2", false).expect("write attr2");
 
@@ -406,8 +434,8 @@ mod tests {
         }
 
         // Source has attr1, destination has attr1 and attr2
-        let attr1 = OsString::from("user.attr1");
-        let attr2 = OsString::from("user.extra");
+        let attr1 = test_xattr_name("attr1");
+        let attr2 = test_xattr_name("extra");
         write_attribute(&source, &attr1, b"value1", false).expect("write source attr1");
         write_attribute(&destination, &attr1, b"old_value1", false).expect("write dest attr1");
         write_attribute(&destination, &attr2, b"extra_value", false).expect("write dest attr2");
@@ -442,8 +470,8 @@ mod tests {
             return;
         }
 
-        let allowed = OsString::from("user.allowed");
-        let blocked = OsString::from("user.blocked");
+        let allowed = test_xattr_name("allowed");
+        let blocked = test_xattr_name("blocked");
         write_attribute(&source, &allowed, b"allowed_val", false).expect("write allowed");
         write_attribute(&source, &blocked, b"blocked_val", false).expect("write blocked");
 
@@ -513,8 +541,8 @@ mod tests {
             return;
         }
 
-        let src_attr = OsString::from("user.from_source");
-        let preserved = OsString::from("user.preserved");
+        let src_attr = test_xattr_name("from_source");
+        let preserved = test_xattr_name("preserved");
         write_attribute(&source, &src_attr, b"source_val", false).expect("write source attr");
         write_attribute(&destination, &preserved, b"keep_me", false).expect("write preserved");
 
@@ -536,21 +564,6 @@ mod tests {
                 .expect("preserved"),
             b"keep_me"
         );
-    }
-
-    /// Returns the expected local xattr name for test entries.
-    ///
-    /// On Linux, names need the `user.` prefix. On macOS/BSD, names are used
-    /// as-is since there is no namespace prefix requirement.
-    fn test_xattr_name(base: &str) -> Vec<u8> {
-        #[cfg(target_os = "linux")]
-        {
-            format!("user.{base}").into_bytes()
-        }
-        #[cfg(not(target_os = "linux"))]
-        {
-            base.as_bytes().to_vec()
-        }
     }
 
     #[test]
@@ -576,17 +589,17 @@ mod tests {
 
         apply_xattrs_from_list(&file, &list, false).expect("apply xattrs");
 
-        let attr1_name = OsString::from(String::from_utf8(test_xattr_name("attr1")).unwrap());
-        let attr2_name = OsString::from(String::from_utf8(test_xattr_name("attr2")).unwrap());
+        let attr1 = test_xattr_name("attr1");
+        let attr2 = test_xattr_name("attr2");
 
         assert_eq!(
-            read_attribute(&file, &attr1_name, false)
+            read_attribute(&file, &attr1, false)
                 .expect("read")
                 .expect("attr1"),
             b"value1"
         );
         assert_eq!(
-            read_attribute(&file, &attr2_name, false)
+            read_attribute(&file, &attr2, false)
                 .expect("read")
                 .expect("attr2"),
             b"value2"
@@ -605,8 +618,8 @@ mod tests {
         }
 
         // Pre-set an xattr on the destination that is not in the source list
-        let stale_name = OsString::from(String::from_utf8(test_xattr_name("stale")).unwrap());
-        write_attribute(&file, &stale_name, b"old", false).expect("write stale");
+        let stale = test_xattr_name("stale");
+        write_attribute(&file, &stale, b"old", false).expect("write stale");
 
         let mut list = XattrList::new();
         list.push(XattrEntry::new(
@@ -618,15 +631,15 @@ mod tests {
 
         // Stale attr should be removed
         assert!(
-            read_attribute(&file, &stale_name, false)
+            read_attribute(&file, &stale, false)
                 .expect("read")
                 .is_none()
         );
 
         // New attr should be present
-        let kept_name = OsString::from(String::from_utf8(test_xattr_name("kept")).unwrap());
+        let kept = test_xattr_name("kept");
         assert_eq!(
-            read_attribute(&file, &kept_name, false)
+            read_attribute(&file, &kept, false)
                 .expect("read")
                 .expect("kept"),
             b"new_value"
@@ -660,17 +673,17 @@ mod tests {
         apply_xattrs_from_list(&file, &list, false).expect("apply xattrs");
 
         // Abbreviated entry should not be set
-        let abbrev_name = OsString::from(String::from_utf8(test_xattr_name("abbrev")).unwrap());
+        let abbrev = test_xattr_name("abbrev");
         assert!(
-            read_attribute(&file, &abbrev_name, false)
+            read_attribute(&file, &abbrev, false)
                 .expect("read")
                 .is_none()
         );
 
         // Full entry should be set
-        let full_name = OsString::from(String::from_utf8(test_xattr_name("full")).unwrap());
+        let full = test_xattr_name("full");
         assert_eq!(
-            read_attribute(&file, &full_name, false)
+            read_attribute(&file, &full, false)
                 .expect("read")
                 .expect("full"),
             b"full_value"
@@ -689,15 +702,15 @@ mod tests {
         }
 
         // Pre-set xattrs on destination
-        let attr_name = OsString::from(String::from_utf8(test_xattr_name("existing")).unwrap());
-        write_attribute(&file, &attr_name, b"value", false).expect("write existing");
+        let attr = test_xattr_name("existing");
+        write_attribute(&file, &attr, b"value", false).expect("write existing");
 
         let list = XattrList::new();
         apply_xattrs_from_list(&file, &list, false).expect("apply empty list");
 
         // All permitted xattrs should be removed
         assert!(
-            read_attribute(&file, &attr_name, false)
+            read_attribute(&file, &attr, false)
                 .expect("read")
                 .is_none()
         );
@@ -714,9 +727,8 @@ mod tests {
             return;
         }
 
-        let attr_name_str = String::from_utf8(test_xattr_name("shared")).unwrap();
-        let attr_name = OsString::from(&attr_name_str);
-        write_attribute(&file, &attr_name, b"old_value", false).expect("write old");
+        let attr = test_xattr_name("shared");
+        write_attribute(&file, &attr, b"old_value", false).expect("write old");
 
         let mut list = XattrList::new();
         list.push(XattrEntry::new(
@@ -727,7 +739,7 @@ mod tests {
         apply_xattrs_from_list(&file, &list, false).expect("apply xattrs");
 
         assert_eq!(
-            read_attribute(&file, &attr_name, false)
+            read_attribute(&file, &attr, false)
                 .expect("read")
                 .expect("shared"),
             b"new_value"
@@ -750,8 +762,8 @@ mod tests {
 
         apply_xattrs_from_list(&file, &list, false).expect("apply xattrs");
 
-        let attr_name = OsString::from(String::from_utf8(test_xattr_name("empty_val")).unwrap());
-        let value = read_attribute(&file, &attr_name, false)
+        let attr = test_xattr_name("empty_val");
+        let value = read_attribute(&file, &attr, false)
             .expect("read")
             .expect("empty_val should exist");
         assert!(value.is_empty());

--- a/crates/metadata/src/xattr_unix.rs
+++ b/crates/metadata/src/xattr_unix.rs
@@ -1,0 +1,76 @@
+//! Unix extended-attribute backend.
+//!
+//! Wraps the [`xattr`] crate so the cross-platform [`crate::xattr`] layer
+//! can call into it without platform-specific imports. Behaviour mirrors
+//! upstream rsync's POSIX xattr handling exactly: list/get/set/remove are
+//! delegated to the kernel via the `xattr` crate, with optional
+//! follow-symlinks variants for the `_deref` flavours.
+//!
+//! # Upstream Reference
+//!
+//! `xattrs.c:rsync_xal_get()` (`xattr.c:listxattr/getxattr`) and
+//! `xattrs.c:rsync_xal_set()` (`xattr.c:setxattr/removexattr`).
+
+use std::ffi::{OsStr, OsString};
+use std::io;
+use std::os::unix::ffi::OsStrExt;
+use std::path::Path;
+
+/// Lists all xattr names attached to `path`, optionally following symlinks.
+pub fn list_attributes(path: &Path, follow_symlinks: bool) -> io::Result<Vec<OsString>> {
+    let attrs = if follow_symlinks {
+        xattr::list_deref(path)?
+    } else {
+        xattr::list(path)?
+    };
+    Ok(attrs.collect())
+}
+
+/// Reads a single xattr value as raw bytes, or `Ok(None)` if missing.
+pub fn read_attribute(
+    path: &Path,
+    name: &[u8],
+    follow_symlinks: bool,
+) -> io::Result<Option<Vec<u8>>> {
+    let os_name = OsStr::from_bytes(name);
+    if follow_symlinks {
+        xattr::get_deref(path, os_name)
+    } else {
+        xattr::get(path, os_name)
+    }
+}
+
+/// Writes a single xattr value, replacing any existing value.
+pub fn write_attribute(
+    path: &Path,
+    name: &[u8],
+    value: &[u8],
+    follow_symlinks: bool,
+) -> io::Result<()> {
+    let os_name = OsStr::from_bytes(name);
+    if follow_symlinks {
+        xattr::set_deref(path, os_name, value)
+    } else {
+        xattr::set(path, os_name, value)
+    }
+}
+
+/// Removes an xattr from `path`. Removing a missing xattr propagates the
+/// underlying kernel error; the higher layer compensates by checking the
+/// listing first.
+pub fn remove_attribute(path: &Path, name: &[u8], follow_symlinks: bool) -> io::Result<()> {
+    let os_name = OsStr::from_bytes(name);
+    if follow_symlinks {
+        xattr::remove_deref(path, os_name)
+    } else {
+        xattr::remove(path, os_name)
+    }
+}
+
+/// Converts the [`OsString`] returned by [`list_attributes`] into the raw
+/// bytes used by the cross-platform layer. On Unix the conversion is a
+/// zero-copy view; on Windows the equivalent helper UTF-8-encodes the
+/// underlying UTF-16 buffer.
+pub fn os_name_to_bytes(name: &OsStr) -> Vec<u8> {
+    name.as_bytes().to_vec()
+}

--- a/crates/metadata/src/xattr_windows.rs
+++ b/crates/metadata/src/xattr_windows.rs
@@ -41,19 +41,21 @@
 #![allow(unsafe_code)]
 
 use std::ffi::OsString;
-use std::io;
+use std::fs::File;
+use std::io::{self, Read, Write};
 use std::os::windows::ffi::{OsStrExt, OsStringExt};
+use std::os::windows::io::FromRawHandle;
 use std::path::Path;
 
 use windows::Win32::Foundation::{
-    CloseHandle, ERROR_FILE_NOT_FOUND, ERROR_HANDLE_EOF, ERROR_NO_MORE_FILES, ERROR_PATH_NOT_FOUND,
-    GetLastError, HANDLE, INVALID_HANDLE_VALUE,
+    ERROR_FILE_NOT_FOUND, ERROR_HANDLE_EOF, ERROR_NO_MORE_FILES, ERROR_PATH_NOT_FOUND, GetLastError,
+    HANDLE, INVALID_HANDLE_VALUE,
 };
 use windows::Win32::Storage::FileSystem::{
     CREATE_ALWAYS, CreateFileW, DeleteFileW, FILE_ATTRIBUTE_NORMAL, FILE_GENERIC_READ,
     FILE_GENERIC_WRITE, FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE, FindClose,
-    FindFirstStreamW, FindNextStreamW, FindStreamInfoStandard, OPEN_EXISTING, ReadFile,
-    WIN32_FIND_STREAM_DATA, WriteFile,
+    FindFirstStreamW, FindNextStreamW, FindStreamInfoStandard, OPEN_EXISTING,
+    WIN32_FIND_STREAM_DATA,
 };
 use windows::core::PCWSTR;
 
@@ -148,20 +150,6 @@ impl Drop for FindStreamHandle {
     }
 }
 
-/// Wraps a file/stream handle so we close it on drop.
-struct OwnedHandle(HANDLE);
-
-impl Drop for OwnedHandle {
-    fn drop(&mut self) {
-        if !self.0.is_invalid() {
-            // SAFETY: handle was returned from a successful `CreateFileW`.
-            unsafe {
-                let _ = CloseHandle(self.0);
-            }
-        }
-    }
-}
-
 /// Returns `true` when an [`io::Error`] indicates the file or stream
 /// simply does not exist, so callers can map it to `Ok(None)`.
 fn io_error_is_missing(error: &io::Error) -> bool {
@@ -209,12 +197,14 @@ pub fn list_attributes(path: &Path, _follow_symlinks: bool) -> io::Result<Vec<Os
     let mut data: WIN32_FIND_STREAM_DATA = unsafe { std::mem::zeroed() };
 
     // SAFETY: `wide` is NUL-terminated; `data` outlives the call.
+    // `dwflags` is documented as reserved-must-be-zero; pass `Some(0)`
+    // because the binding signature is `Option<u32>`.
     let result = unsafe {
         FindFirstStreamW(
             PCWSTR(wide.as_ptr()),
             FindStreamInfoStandard,
             (&mut data as *mut WIN32_FIND_STREAM_DATA).cast(),
-            0,
+            Some(0),
         )
     };
 
@@ -285,9 +275,11 @@ pub fn read_attribute(
             None,
         )
     };
-    let handle = match raw {
+    let mut file = match raw {
         Ok(h) if h == INVALID_HANDLE_VALUE => return Err(io::Error::last_os_error()),
-        Ok(h) => OwnedHandle(h),
+        // SAFETY: `CreateFileW` returned a valid HANDLE which we hand off to
+        // `File`; the `File` takes ownership and closes it on drop.
+        Ok(h) => unsafe { File::from_raw_handle(h.0 as _) },
         Err(error) => {
             let io_err = windows_to_io_error(error);
             if io_error_is_missing(&io_err) {
@@ -298,20 +290,7 @@ pub fn read_attribute(
     };
 
     let mut buffer = Vec::with_capacity(256);
-    let mut chunk = [0u8; 4096];
-    loop {
-        let mut read: u32 = 0;
-        // SAFETY: handle is valid; `chunk` and `read` outlive the call.
-        let res = unsafe { ReadFile(handle.0, Some(&mut chunk), Some(&mut read), None) };
-        if res.is_err() {
-            return Err(io::Error::last_os_error());
-        }
-        if read == 0 {
-            break;
-        }
-        buffer.extend_from_slice(&chunk[..read as usize]);
-    }
-
+    file.read_to_end(&mut buffer)?;
     Ok(Some(buffer))
 }
 
@@ -340,9 +319,11 @@ pub fn write_attribute(
             None,
         )
     };
-    let handle = match raw {
+    let mut file = match raw {
         Ok(h) if h == INVALID_HANDLE_VALUE => return Err(io::Error::last_os_error()),
-        Ok(h) => OwnedHandle(h),
+        // SAFETY: `CreateFileW` returned a valid HANDLE which we hand off to
+        // `File`; the `File` takes ownership and closes it on drop.
+        Ok(h) => unsafe { File::from_raw_handle(h.0 as _) },
         Err(error) => return Err(windows_to_io_error(error)),
     };
 
@@ -352,22 +333,7 @@ pub fn write_attribute(
         return Ok(());
     }
 
-    let mut offset = 0usize;
-    while offset < value.len() {
-        let chunk = &value[offset..];
-        let len = chunk.len().min(u32::MAX as usize);
-        let mut written: u32 = 0;
-        // SAFETY: handle is valid; the slice outlives the call.
-        let res = unsafe { WriteFile(handle.0, Some(&chunk[..len]), Some(&mut written), None) };
-        if res.is_err() {
-            return Err(io::Error::last_os_error());
-        }
-        if written == 0 {
-            return Err(io::Error::other("WriteFile reported zero bytes written"));
-        }
-        offset += written as usize;
-    }
-
+    file.write_all(value)?;
     Ok(())
 }
 

--- a/crates/metadata/src/xattr_windows.rs
+++ b/crates/metadata/src/xattr_windows.rs
@@ -242,12 +242,8 @@ pub fn list_attributes(path: &Path, _follow_symlinks: bool) -> io::Result<Vec<Os
     loop {
         // SAFETY: `handle.0` is a live FindFirstStream handle; `data`
         // outlives the call.
-        let next = unsafe {
-            FindNextStreamW(
-                handle.0,
-                (&mut data as *mut WIN32_FIND_STREAM_DATA).cast(),
-            )
-        };
+        let next =
+            unsafe { FindNextStreamW(handle.0, (&mut data as *mut WIN32_FIND_STREAM_DATA).cast()) };
         if next.is_err() {
             // SAFETY: `GetLastError` is always safe.
             let code = unsafe { GetLastError() };
@@ -306,14 +302,7 @@ pub fn read_attribute(
     loop {
         let mut read: u32 = 0;
         // SAFETY: handle is valid; `chunk` and `read` outlive the call.
-        let res = unsafe {
-            ReadFile(
-                handle.0,
-                Some(&mut chunk),
-                Some(&mut read),
-                None,
-            )
-        };
+        let res = unsafe { ReadFile(handle.0, Some(&mut chunk), Some(&mut read), None) };
         if res.is_err() {
             return Err(io::Error::last_os_error());
         }
@@ -369,14 +358,7 @@ pub fn write_attribute(
         let len = chunk.len().min(u32::MAX as usize);
         let mut written: u32 = 0;
         // SAFETY: handle is valid; the slice outlives the call.
-        let res = unsafe {
-            WriteFile(
-                handle.0,
-                Some(&chunk[..len]),
-                Some(&mut written),
-                None,
-            )
-        };
+        let res = unsafe { WriteFile(handle.0, Some(&chunk[..len]), Some(&mut written), None) };
         if res.is_err() {
             return Err(io::Error::last_os_error());
         }
@@ -394,11 +376,7 @@ pub fn write_attribute(
 ///
 /// `_follow_symlinks` is ignored on Windows; reparse-point traversal is
 /// the default behaviour of `DeleteFileW`.
-pub fn remove_attribute(
-    path: &Path,
-    name: &[u8],
-    _follow_symlinks: bool,
-) -> io::Result<()> {
+pub fn remove_attribute(path: &Path, name: &[u8], _follow_symlinks: bool) -> io::Result<()> {
     let wide = stream_path_wide(path, name)?;
     // SAFETY: `wide` is NUL-terminated.
     let res = unsafe { DeleteFileW(PCWSTR(wide.as_ptr())) };

--- a/crates/metadata/src/xattr_windows.rs
+++ b/crates/metadata/src/xattr_windows.rs
@@ -1,0 +1,616 @@
+//! Windows extended-attribute backend backed by NTFS Alternate Data Streams.
+//!
+//! POSIX-style "extended attributes" map naturally onto NTFS ADS: each named
+//! attribute is exposed as an alternate data stream attached to the file.
+//! The stream syntax `path:streamname:$DATA` lets standard Win32 file APIs
+//! read, write, and delete individual streams. Listing all streams attached
+//! to a file requires the dedicated `FindFirstStreamW`/`FindNextStreamW`
+//! pair, which iterates every named data stream regardless of size.
+//!
+//! # Mapping
+//!
+//! - `list_attributes(path)` enumerates streams via `FindFirstStreamW` and
+//!   skips the unnamed primary stream `::$DATA`. Each remaining entry is
+//!   stripped of its leading `:` and trailing `:$DATA` so the wire-format
+//!   name matches the POSIX semantics expected by upstream rsync.
+//! - `read_attribute(path, name)` opens `path:name:$DATA` for read access
+//!   and slurps the full stream payload. `ERROR_FILE_NOT_FOUND` and
+//!   `ERROR_PATH_NOT_FOUND` map to `Ok(None)`, mirroring `xattr::get` on
+//!   POSIX systems.
+//! - `write_attribute(path, name, value)` opens the stream with
+//!   `CREATE_ALWAYS | GENERIC_WRITE`, writes the value, and closes the
+//!   handle.
+//! - `remove_attribute(path, name)` calls `DeleteFileW` on the stream
+//!   path. Missing streams return `Ok(())` so callers can blindly clear
+//!   stale entries during sync.
+//!
+//! # Cross-platform parity
+//!
+//! Stream names are returned as `OsString`s decoded from the UTF-16 buffer
+//! supplied by the kernel. The wider `xattr` module converts these to the
+//! protocol's UTF-8 byte representation. Non-ASCII names are preserved
+//! losslessly via the standard `OsStringExt::from_wide` round-trip.
+//!
+//! # Upstream Reference
+//!
+//! Upstream rsync 3.4.1 has no native Windows xattr backend; the closest
+//! Unix counterpart is `xattrs.c:rsync_xal_get()`/`set_xattr()`, which we
+//! mirror at the higher [`crate::xattr`] layer. This module supplies the
+//! per-attribute primitives that the cross-platform layer requires.
+
+#![allow(unsafe_code)]
+
+use std::ffi::OsString;
+use std::io;
+use std::os::windows::ffi::{OsStrExt, OsStringExt};
+use std::path::Path;
+
+use windows::Win32::Foundation::{
+    CloseHandle, ERROR_FILE_NOT_FOUND, ERROR_HANDLE_EOF, ERROR_NO_MORE_FILES, ERROR_PATH_NOT_FOUND,
+    GetLastError, HANDLE, INVALID_HANDLE_VALUE,
+};
+use windows::Win32::Storage::FileSystem::{
+    CREATE_ALWAYS, CreateFileW, DeleteFileW, FILE_ATTRIBUTE_NORMAL, FILE_GENERIC_READ,
+    FILE_GENERIC_WRITE, FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE, FindClose,
+    FindFirstStreamW, FindNextStreamW, FindStreamInfoStandard, OPEN_EXISTING, ReadFile,
+    WIN32_FIND_STREAM_DATA, WriteFile,
+};
+use windows::core::PCWSTR;
+
+/// Suffix appended by NTFS to every named data stream entry returned by
+/// `FindFirstStreamW`/`FindNextStreamW`.
+const STREAM_SUFFIX: &str = ":$DATA";
+
+/// Converts an [`OsStr`] (a UTF-16 wide string on Windows) into the UTF-8
+/// byte sequence used by the cross-platform xattr layer.
+///
+/// Names that are not valid UTF-8 cannot round-trip through the wire
+/// protocol; they are coerced via the standard lossy path so the listing
+/// still surfaces them rather than being silently dropped.
+pub fn os_name_to_bytes(name: &std::ffi::OsStr) -> Vec<u8> {
+    name.to_string_lossy().into_owned().into_bytes()
+}
+
+/// Encodes a path as a NUL-terminated UTF-16 buffer for `*W` Win32 calls.
+fn path_to_wide(path: &Path) -> Vec<u16> {
+    path.as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect()
+}
+
+/// Builds the NUL-terminated wide string `path:name:$DATA` used to open an
+/// alternate data stream as if it were a normal file.
+fn stream_path_wide(path: &Path, name: &[u8]) -> io::Result<Vec<u16>> {
+    let name_str = std::str::from_utf8(name).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "xattr stream name must be valid UTF-8 on Windows",
+        )
+    })?;
+    if name_str.is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "xattr stream name must not be empty",
+        ));
+    }
+    if name_str.contains(':') || name_str.contains('\0') {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "xattr stream name must not contain ':' or NUL",
+        ));
+    }
+    let mut buf: Vec<u16> = path.as_os_str().encode_wide().collect();
+    buf.push(b':' as u16);
+    buf.extend(name_str.encode_utf16());
+    buf.extend(STREAM_SUFFIX.encode_utf16());
+    buf.push(0);
+    Ok(buf)
+}
+
+/// Translates the raw stream name reported by NTFS (`:streamname:$DATA`)
+/// into the bare attribute name expected by the upper xattr layer.
+fn parse_stream_name(raw: &[u16]) -> Option<OsString> {
+    let len = raw.iter().position(|&c| c == 0).unwrap_or(raw.len());
+    let slice = &raw[..len];
+    if slice.is_empty() {
+        return None;
+    }
+    if slice[0] != b':' as u16 {
+        return None;
+    }
+    // Strip the trailing `:$DATA` suffix when present (always the case for
+    // NTFS data streams; named non-data streams use other suffixes and are
+    // skipped to keep parity with POSIX xattrs).
+    let suffix: Vec<u16> = STREAM_SUFFIX.encode_utf16().collect();
+    if !slice.ends_with(&suffix) {
+        return None;
+    }
+    let body = &slice[1..slice.len() - suffix.len()];
+    if body.is_empty() {
+        // `::$DATA` is the unnamed primary stream - the file's content.
+        return None;
+    }
+    Some(OsString::from_wide(body))
+}
+
+/// Wraps a Win32 `FindFirst*` handle so we always release it.
+struct FindStreamHandle(HANDLE);
+
+impl Drop for FindStreamHandle {
+    fn drop(&mut self) {
+        if !self.0.is_invalid() {
+            // SAFETY: handle came from `FindFirstStreamW` and has not been closed.
+            unsafe {
+                let _ = FindClose(self.0);
+            }
+        }
+    }
+}
+
+/// Wraps a file/stream handle so we close it on drop.
+struct OwnedHandle(HANDLE);
+
+impl Drop for OwnedHandle {
+    fn drop(&mut self) {
+        if !self.0.is_invalid() {
+            // SAFETY: handle was returned from a successful `CreateFileW`.
+            unsafe {
+                let _ = CloseHandle(self.0);
+            }
+        }
+    }
+}
+
+/// Returns `true` when an [`io::Error`] indicates the file or stream
+/// simply does not exist, so callers can map it to `Ok(None)`.
+fn io_error_is_missing(error: &io::Error) -> bool {
+    let raw = error.raw_os_error().unwrap_or(0);
+    raw == ERROR_FILE_NOT_FOUND.0 as i32 || raw == ERROR_PATH_NOT_FOUND.0 as i32
+}
+
+/// Maps a [`windows::core::Error`] to an [`io::Error`] preserving the raw
+/// Win32 error code so [`io::Error::raw_os_error`] returns the underlying
+/// numeric value (rather than the wrapping HRESULT).
+fn windows_to_io_error(error: windows::core::Error) -> io::Error {
+    // The HRESULT layout `0x8007XXXX` embeds the Win32 error in the lower
+    // 16 bits when the facility is FACILITY_WIN32 (0x0007). When a Win32
+    // helper has already stashed the code in `GetLastError`, prefer that
+    // because it preserves errors > 0xFFFF.
+    // SAFETY: `GetLastError` is always safe.
+    let last = unsafe { GetLastError() };
+    if last.0 != 0 {
+        return io::Error::from_raw_os_error(last.0 as i32);
+    }
+    let hr = error.code().0;
+    let win32 = if (hr as u32) >> 16 == 0x8007 {
+        (hr as u32) & 0xFFFF
+    } else {
+        hr as u32
+    };
+    io::Error::from_raw_os_error(win32 as i32)
+}
+
+/// Lists every named alternate data stream attached to `path`.
+///
+/// The unnamed primary stream `::$DATA` is intentionally omitted because it
+/// represents the file's main contents, not a user-visible extended
+/// attribute. Returns an empty vector when the volume does not support ADS
+/// (e.g. FAT32) or the file simply has no named streams.
+///
+/// The `_follow_symlinks` parameter is accepted for API parity with the
+/// Unix backend; NTFS reparse points are always traversed by the
+/// underlying `FindFirstStreamW` call.
+pub fn list_attributes(path: &Path, _follow_symlinks: bool) -> io::Result<Vec<OsString>> {
+    let wide = path_to_wide(path);
+    // SAFETY: `WIN32_FIND_STREAM_DATA` is a POD struct of u16/i64 fields; the
+    // all-zero pattern is a valid initial state and the Win32 API overwrites
+    // it on success.
+    let mut data: WIN32_FIND_STREAM_DATA = unsafe { std::mem::zeroed() };
+
+    // SAFETY: `wide` is NUL-terminated; `data` outlives the call.
+    let result = unsafe {
+        FindFirstStreamW(
+            PCWSTR(wide.as_ptr()),
+            FindStreamInfoStandard,
+            (&mut data as *mut WIN32_FIND_STREAM_DATA).cast(),
+            0,
+        )
+    };
+
+    let handle = match result {
+        Ok(h) if !h.is_invalid() => FindStreamHandle(h),
+        Ok(_) | Err(_) => {
+            // Documented behaviour: failures plus `ERROR_HANDLE_EOF` mean
+            // there are simply no streams to enumerate. FAT/exFAT volumes
+            // surface other errors which we propagate so the caller sees
+            // the underlying reason.
+            // SAFETY: `GetLastError` is always safe.
+            let code = unsafe { GetLastError() };
+            if code == ERROR_HANDLE_EOF || code == ERROR_NO_MORE_FILES {
+                return Ok(Vec::new());
+            }
+            return Err(io::Error::from_raw_os_error(code.0 as i32));
+        }
+    };
+
+    let mut names = Vec::new();
+    if let Some(name) = parse_stream_name(&data.cStreamName) {
+        names.push(name);
+    }
+
+    loop {
+        // SAFETY: `handle.0` is a live FindFirstStream handle; `data`
+        // outlives the call.
+        let next = unsafe {
+            FindNextStreamW(
+                handle.0,
+                (&mut data as *mut WIN32_FIND_STREAM_DATA).cast(),
+            )
+        };
+        if next.is_err() {
+            // SAFETY: `GetLastError` is always safe.
+            let code = unsafe { GetLastError() };
+            if code == ERROR_HANDLE_EOF || code == ERROR_NO_MORE_FILES {
+                break;
+            }
+            return Err(io::Error::from_raw_os_error(code.0 as i32));
+        }
+        if let Some(name) = parse_stream_name(&data.cStreamName) {
+            names.push(name);
+        }
+    }
+
+    Ok(names)
+}
+
+/// Reads the contents of `path:name:$DATA` and returns them as a byte
+/// vector, or `Ok(None)` when the stream does not exist.
+///
+/// `_follow_symlinks` is ignored on Windows; reparse-point traversal is
+/// the default behaviour of `CreateFileW`.
+pub fn read_attribute(
+    path: &Path,
+    name: &[u8],
+    _follow_symlinks: bool,
+) -> io::Result<Option<Vec<u8>>> {
+    let wide = stream_path_wide(path, name)?;
+
+    // SAFETY: `wide` is NUL-terminated; the security and template handles
+    // are null which is the documented "use defaults" pattern.
+    let raw = unsafe {
+        CreateFileW(
+            PCWSTR(wide.as_ptr()),
+            FILE_GENERIC_READ.0,
+            FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+            None,
+            OPEN_EXISTING,
+            FILE_ATTRIBUTE_NORMAL,
+            None,
+        )
+    };
+    let handle = match raw {
+        Ok(h) if h == INVALID_HANDLE_VALUE => return Err(io::Error::last_os_error()),
+        Ok(h) => OwnedHandle(h),
+        Err(error) => {
+            let io_err = windows_to_io_error(error);
+            if io_error_is_missing(&io_err) {
+                return Ok(None);
+            }
+            return Err(io_err);
+        }
+    };
+
+    let mut buffer = Vec::with_capacity(256);
+    let mut chunk = [0u8; 4096];
+    loop {
+        let mut read: u32 = 0;
+        // SAFETY: handle is valid; `chunk` and `read` outlive the call.
+        let res = unsafe {
+            ReadFile(
+                handle.0,
+                Some(&mut chunk),
+                Some(&mut read),
+                None,
+            )
+        };
+        if res.is_err() {
+            return Err(io::Error::last_os_error());
+        }
+        if read == 0 {
+            break;
+        }
+        buffer.extend_from_slice(&chunk[..read as usize]);
+    }
+
+    Ok(Some(buffer))
+}
+
+/// Creates or replaces `path:name:$DATA` with the supplied value bytes.
+///
+/// `_follow_symlinks` is ignored on Windows; reparse-point traversal is
+/// the default behaviour of `CreateFileW`.
+pub fn write_attribute(
+    path: &Path,
+    name: &[u8],
+    value: &[u8],
+    _follow_symlinks: bool,
+) -> io::Result<()> {
+    let wide = stream_path_wide(path, name)?;
+
+    // SAFETY: `wide` is NUL-terminated; defaults are documented for null
+    // security and template handle arguments.
+    let raw = unsafe {
+        CreateFileW(
+            PCWSTR(wide.as_ptr()),
+            FILE_GENERIC_WRITE.0,
+            FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+            None,
+            CREATE_ALWAYS,
+            FILE_ATTRIBUTE_NORMAL,
+            None,
+        )
+    };
+    let handle = match raw {
+        Ok(h) if h == INVALID_HANDLE_VALUE => return Err(io::Error::last_os_error()),
+        Ok(h) => OwnedHandle(h),
+        Err(error) => return Err(windows_to_io_error(error)),
+    };
+
+    if value.is_empty() {
+        // CREATE_ALWAYS already truncated the stream to zero bytes; no
+        // further write is required.
+        return Ok(());
+    }
+
+    let mut offset = 0usize;
+    while offset < value.len() {
+        let chunk = &value[offset..];
+        let len = chunk.len().min(u32::MAX as usize);
+        let mut written: u32 = 0;
+        // SAFETY: handle is valid; the slice outlives the call.
+        let res = unsafe {
+            WriteFile(
+                handle.0,
+                Some(&chunk[..len]),
+                Some(&mut written),
+                None,
+            )
+        };
+        if res.is_err() {
+            return Err(io::Error::last_os_error());
+        }
+        if written == 0 {
+            return Err(io::Error::other("WriteFile reported zero bytes written"));
+        }
+        offset += written as usize;
+    }
+
+    Ok(())
+}
+
+/// Deletes `path:name:$DATA` from the file. Missing streams are not an
+/// error - this matches the POSIX `xattr::remove` semantics callers expect.
+///
+/// `_follow_symlinks` is ignored on Windows; reparse-point traversal is
+/// the default behaviour of `DeleteFileW`.
+pub fn remove_attribute(
+    path: &Path,
+    name: &[u8],
+    _follow_symlinks: bool,
+) -> io::Result<()> {
+    let wide = stream_path_wide(path, name)?;
+    // SAFETY: `wide` is NUL-terminated.
+    let res = unsafe { DeleteFileW(PCWSTR(wide.as_ptr())) };
+    match res {
+        Ok(()) => Ok(()),
+        Err(error) => {
+            let io_err = windows_to_io_error(error);
+            if io_error_is_missing(&io_err) {
+                Ok(())
+            } else {
+                Err(io_err)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    /// Returns `true` if the temp directory's volume supports alternate data
+    /// streams. Used to gracefully skip tests on FAT32-mounted runners.
+    fn ads_supported(file: &Path) -> bool {
+        match write_attribute(file, b"oc_rsync_ads_probe", b"1", false) {
+            Ok(()) => {
+                let _ = remove_attribute(file, b"oc_rsync_ads_probe", false);
+                true
+            }
+            Err(_) => false,
+        }
+    }
+
+    #[test]
+    fn parse_stream_name_strips_prefix_and_suffix() {
+        let raw: Vec<u16> = ":foo:$DATA\0extra".encode_utf16().collect();
+        let parsed = parse_stream_name(&raw).expect("parse");
+        assert_eq!(parsed, OsString::from("foo"));
+    }
+
+    #[test]
+    fn parse_stream_name_skips_default_stream() {
+        let raw: Vec<u16> = "::$DATA\0".encode_utf16().collect();
+        assert!(parse_stream_name(&raw).is_none());
+    }
+
+    #[test]
+    fn parse_stream_name_rejects_non_data_streams() {
+        let raw: Vec<u16> = ":foo:$INDEX_ALLOCATION\0".encode_utf16().collect();
+        assert!(parse_stream_name(&raw).is_none());
+    }
+
+    #[test]
+    fn parse_stream_name_handles_unicode() {
+        let raw: Vec<u16> = ":caf\u{00e9}:$DATA\0".encode_utf16().collect();
+        let parsed = parse_stream_name(&raw).expect("parse");
+        assert_eq!(parsed, OsString::from("café"));
+    }
+
+    #[test]
+    fn stream_path_wide_rejects_colon_in_name() {
+        let path = Path::new("C:\\tmp\\f.txt");
+        let err = stream_path_wide(path, b"bad:name").expect_err("must reject");
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+    }
+
+    #[test]
+    fn stream_path_wide_rejects_empty_name() {
+        let path = Path::new("C:\\tmp\\f.txt");
+        let err = stream_path_wide(path, b"").expect_err("must reject");
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+    }
+
+    #[test]
+    fn stream_path_wide_rejects_non_utf8() {
+        let path = Path::new("C:\\tmp\\f.txt");
+        let err = stream_path_wide(path, &[0xff, 0xfe, 0xfd]).expect_err("must reject");
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+    }
+
+    #[test]
+    fn stream_path_wide_appends_data_suffix() {
+        let path = Path::new("C:\\tmp\\f.txt");
+        let wide = stream_path_wide(path, b"foo").expect("build");
+        let s = String::from_utf16_lossy(&wide[..wide.len() - 1]);
+        assert!(s.ends_with(":foo:$DATA"), "got {s}");
+    }
+
+    #[test]
+    fn write_then_read_roundtrip() {
+        let dir = tempdir().expect("tempdir");
+        let file = dir.path().join("ads-roundtrip.txt");
+        fs::write(&file, b"primary").expect("write file");
+        if !ads_supported(&file) {
+            eprintln!("ADS not supported on this volume; skipping");
+            return;
+        }
+        write_attribute(&file, b"hello", b"world", false).expect("write attr");
+        let value = read_attribute(&file, b"hello", false)
+            .expect("read attr")
+            .expect("attr present");
+        assert_eq!(value, b"world");
+    }
+
+    #[test]
+    fn list_returns_written_streams() {
+        let dir = tempdir().expect("tempdir");
+        let file = dir.path().join("ads-list.txt");
+        fs::write(&file, b"primary").expect("write file");
+        if !ads_supported(&file) {
+            return;
+        }
+        write_attribute(&file, b"alpha", b"a", false).expect("alpha");
+        write_attribute(&file, b"beta", b"bb", false).expect("beta");
+        let mut names: Vec<String> = list_attributes(&file, false)
+            .expect("list")
+            .into_iter()
+            .map(|n| n.to_string_lossy().into_owned())
+            .collect();
+        names.sort();
+        assert!(names.iter().any(|n| n == "alpha"), "names = {names:?}");
+        assert!(names.iter().any(|n| n == "beta"), "names = {names:?}");
+    }
+
+    #[test]
+    fn remove_makes_stream_disappear() {
+        let dir = tempdir().expect("tempdir");
+        let file = dir.path().join("ads-remove.txt");
+        fs::write(&file, b"primary").expect("write file");
+        if !ads_supported(&file) {
+            return;
+        }
+        write_attribute(&file, b"gone", b"value", false).expect("write");
+        remove_attribute(&file, b"gone", false).expect("remove");
+        let value = read_attribute(&file, b"gone", false).expect("read after remove");
+        assert!(value.is_none());
+        let names: Vec<String> = list_attributes(&file, false)
+            .expect("list")
+            .into_iter()
+            .map(|n| n.to_string_lossy().into_owned())
+            .collect();
+        assert!(!names.iter().any(|n| n == "gone"));
+    }
+
+    #[test]
+    fn remove_missing_stream_is_ok() {
+        let dir = tempdir().expect("tempdir");
+        let file = dir.path().join("ads-remove-missing.txt");
+        fs::write(&file, b"primary").expect("write file");
+        if !ads_supported(&file) {
+            return;
+        }
+        // Removing an attribute that was never written must succeed,
+        // matching POSIX xattr::remove behaviour for receiver-side
+        // resync passes.
+        remove_attribute(&file, b"never-set", false).expect("remove missing");
+    }
+
+    #[test]
+    fn empty_value_round_trips() {
+        let dir = tempdir().expect("tempdir");
+        let file = dir.path().join("ads-empty.txt");
+        fs::write(&file, b"primary").expect("write file");
+        if !ads_supported(&file) {
+            return;
+        }
+        write_attribute(&file, b"empty", b"", false).expect("write empty");
+        let value = read_attribute(&file, b"empty", false)
+            .expect("read")
+            .expect("present");
+        assert!(value.is_empty());
+    }
+
+    #[test]
+    fn non_ascii_stream_name_round_trips() {
+        let dir = tempdir().expect("tempdir");
+        let file = dir.path().join("ads-utf8.txt");
+        fs::write(&file, b"primary").expect("write file");
+        if !ads_supported(&file) {
+            return;
+        }
+        let name = "café".as_bytes();
+        write_attribute(&file, name, b"crema", false).expect("write");
+        let value = read_attribute(&file, name, false)
+            .expect("read")
+            .expect("present");
+        assert_eq!(value, b"crema");
+        let names: Vec<String> = list_attributes(&file, false)
+            .expect("list")
+            .into_iter()
+            .map(|n| n.to_string_lossy().into_owned())
+            .collect();
+        assert!(names.iter().any(|n| n == "café"), "names = {names:?}");
+    }
+
+    #[test]
+    fn read_missing_stream_returns_none() {
+        let dir = tempdir().expect("tempdir");
+        let file = dir.path().join("ads-missing.txt");
+        fs::write(&file, b"primary").expect("write file");
+        if !ads_supported(&file) {
+            return;
+        }
+        let value = read_attribute(&file, b"does-not-exist", false).expect("read");
+        assert!(value.is_none());
+    }
+
+    #[test]
+    fn os_name_to_bytes_round_trip() {
+        let s = OsString::from("user.test");
+        let bytes = os_name_to_bytes(&s);
+        assert_eq!(bytes, b"user.test");
+    }
+}

--- a/crates/metadata/src/xattr_windows.rs
+++ b/crates/metadata/src/xattr_windows.rs
@@ -48,8 +48,8 @@ use std::os::windows::io::FromRawHandle;
 use std::path::Path;
 
 use windows::Win32::Foundation::{
-    ERROR_FILE_NOT_FOUND, ERROR_HANDLE_EOF, ERROR_NO_MORE_FILES, ERROR_PATH_NOT_FOUND, GetLastError,
-    HANDLE, INVALID_HANDLE_VALUE,
+    ERROR_FILE_NOT_FOUND, ERROR_HANDLE_EOF, ERROR_NO_MORE_FILES, ERROR_PATH_NOT_FOUND,
+    GetLastError, HANDLE, INVALID_HANDLE_VALUE,
 };
 use windows::Win32::Storage::FileSystem::{
     CREATE_ALWAYS, CreateFileW, DeleteFileW, FILE_ATTRIBUTE_NORMAL, FILE_GENERIC_READ,


### PR DESCRIPTION
## Summary

- Adds a Windows backend for the cross-platform xattr layer that maps each named extended attribute onto an NTFS Alternate Data Stream using the `path:streamname:$DATA` syntax.
- Wires `FindFirstStreamW`/`FindNextStreamW` for listing, `CreateFileW` + `ReadFile`/`WriteFile` for read/write, and `DeleteFileW` for removal. Stream-name parsing strips the `:` prefix and `:$DATA` suffix so wire-format names match the existing Unix xattr names.
- Refactors `crates/metadata/src/xattr.rs` to dispatch through a platform backend module (`xattr_unix` or `xattr_windows`) while keeping the public API (`read_xattrs_for_wire`, `sync_xattrs`, `apply_xattrs_from_list`) and Linux namespace policy unchanged.
- Contains unsafe FFI to `xattr_windows.rs` (`#![allow(unsafe_code)]`) and uses RAII wrappers around `FindClose` and `CloseHandle` for handle cleanup. Matches the convention used by `acl_windows`, `ownership`, and `id_lookup` in the same crate.

Refs #1867

## Test plan

- [ ] CI: fmt + clippy
- [ ] CI: nextest (stable, Linux musl, macOS, Windows)
- [ ] Round-trip write/read/list/remove on an NTFS volume (covered by `xattr_windows::tests`, gracefully skips on FAT32)
- [ ] Stream-name parser unit tests (prefix/suffix stripping, Unicode names, default `::$DATA` skip, non-data-stream rejection)
- [ ] `stream_path_wide` input validation (empty, embedded `:`, non-UTF-8)
- [ ] `xattr.rs` cross-platform tests on Linux (existing tests still green via `xattr_unix` backend)