### PR TITLE
fix(metadata): import ACCESS_ALLOWED_ACE_TYPE from SystemServices (#1866)

### DIFF
--- a/crates/metadata/src/acl_windows.rs
+++ b/crates/metadata/src/acl_windows.rs
@@ -56,15 +56,17 @@ use windows::Win32::Security::Authorization::{
     GetNamedSecurityInfoW, SE_FILE_OBJECT, SetNamedSecurityInfoW,
 };
 use windows::Win32::Security::{
-    ACCESS_ALLOWED_ACE, ACCESS_ALLOWED_ACE_TYPE, ACE_HEADER, ACL, ACL_REVISION,
-    ACL_SIZE_INFORMATION, AclSizeInformation, AddAccessAllowedAce, DACL_SECURITY_INFORMATION,
-    GetAce, GetAclInformation, GetSidSubAuthority, GetSidSubAuthorityCount, InitializeAcl,
-    IsValidSid, LookupAccountNameW, LookupAccountSidW, PSECURITY_DESCRIPTOR, PSID, SID_NAME_USE,
-    SidTypeAlias, SidTypeGroup, SidTypeWellKnownGroup,
+    ACCESS_ALLOWED_ACE, ACE_HEADER, ACL, ACL_REVISION, ACL_SIZE_INFORMATION, AclSizeInformation,
+    AddAccessAllowedAce, DACL_SECURITY_INFORMATION, GetAce, GetAclInformation, GetSidSubAuthority,
+    GetSidSubAuthorityCount, InitializeAcl, IsValidSid, LookupAccountNameW, LookupAccountSidW,
+    PSECURITY_DESCRIPTOR, PSID, SID_NAME_USE, SidTypeAlias, SidTypeGroup, SidTypeWellKnownGroup,
 };
 use windows::Win32::Storage::FileSystem::{
     FILE_GENERIC_EXECUTE, FILE_GENERIC_READ, FILE_GENERIC_WRITE,
 };
+// upstream: WinNT.h - ACCESS_ALLOWED_ACE_TYPE is the ACE-type discriminant byte (0x0)
+// for an allow ACE; in windows-rs 0.62 it lives under SystemServices, not Security.
+use windows::Win32::System::SystemServices::ACCESS_ALLOWED_ACE_TYPE;
 use windows::core::{PCWSTR, PWSTR};
 
 use crate::MetadataError;


### PR DESCRIPTION
## Summary
- Fixes the master Windows build break introduced by #1866.
- windows-rs 0.62.2 exports \`ACCESS_ALLOWED_ACE_TYPE\` (the ACE-type discriminant byte, value 0x0) under \`windows::Win32::System::SystemServices\`, not \`windows::Win32::Security\` where the same-named struct \`ACCESS_ALLOWED_ACE\` lives. The original import in #1866 placed both names in the Security group, which fails to resolve and breaks every Windows CI job on master.
- Unblocks Windows CI on every open PR currently rebased onto master.

## Why this is correct
- \`windows-rs 0.62.2\` source: \`src/Windows/Win32/Security/mod.rs\` defines the \`ACCESS_ALLOWED_ACE\` struct; \`src/Windows/Win32/System/SystemServices/mod.rs\` defines \`pub const ACCESS_ALLOWED_ACE_TYPE: u32 = 0u32;\`.
- All in-file usages cast through \`as u8\` already (e.g. \`acl_windows.rs:321\`), so the constant width does not change.
- upstream: \`WinNT.h\` declares \`ACCESS_ALLOWED_ACE_TYPE (0x0)\`.

## Test plan
- [x] Local edit verified against windows-rs 0.62.2 vendored source.
- [ ] CI Windows (stable) green
- [ ] CI Windows (beta) green
- [ ] CI Windows (nightly) green
- [ ] CI Windows GNU cross-check green
- [ ] fmt+clippy green