### PR TITLE
fix(metadata): force am_root=false under fake-super (#1926)

### DIFF
--- a/crates/engine/src/local_copy/options/metadata/accessors.rs
+++ b/crates/engine/src/local_copy/options/metadata/accessors.rs
@@ -127,19 +127,43 @@ impl LocalCopyOptions {
     ///
     /// When `--super` is explicitly set, that value is returned directly.
     /// Otherwise the decision falls back to checking whether the effective
-    /// user is root (UID 0 on Unix).
+    /// user is root (UID 0 on Unix). When `--fake-super` is active, the
+    /// result is forced to `false` so callers route privileged operations
+    /// (chown, mknod, mkfifo) through the fake-super xattr placeholder
+    /// path, mirroring upstream's `am_root < 0` sentinel.
+    // upstream: options.c:89 - am_root tri-state: 0 normal, 1 root, 2 --super,
+    //                          -1 --fake-super (negative is "fake")
+    // upstream: clientserver.c:1102-1105 - daemon `fake super = yes` forces am_root=-1
+    // upstream: syscall.c do_mknod() - am_root<0 sentinel substitutes 0600 placeholder
     #[must_use]
     pub fn am_root(&self) -> bool {
-        match self.super_mode {
-            Some(value) => value,
-            None => is_effective_root(),
-        }
+        effective_am_root(self.super_mode, self.fake_super)
     }
 
     /// Reports whether `--fake-super` mode is enabled.
     #[must_use]
     pub const fn fake_super_enabled(&self) -> bool {
         self.fake_super
+    }
+}
+
+/// Resolves the effective `am_root` boolean for privilege-gated operations.
+///
+/// Mirrors upstream rsync's `am_root` tri-state: when `fake_super` is set,
+/// the result is `false` regardless of `super_mode` (matching upstream's
+/// `am_root = -1` sentinel that demotes privileged paths to the
+/// fake-super xattr placeholder branch). Otherwise the explicit `--super`
+/// flag wins, falling back to the effective UID check.
+// upstream: options.c:89 - am_root tri-state, -1 is "fake-super"
+// upstream: syscall.c do_mknod() - am_root<0 sentinel substitutes 0600 placeholder
+#[must_use]
+pub(super) fn effective_am_root(super_mode: Option<bool>, fake_super: bool) -> bool {
+    if fake_super {
+        return false;
+    }
+    match super_mode {
+        Some(value) => value,
+        None => is_effective_root(),
     }
 }
 

--- a/crates/engine/src/local_copy/options/metadata/tests.rs
+++ b/crates/engine/src/local_copy/options/metadata/tests.rs
@@ -1,5 +1,5 @@
 use super::super::types::LocalCopyOptions;
-use super::accessors::is_effective_root;
+use super::accessors::{effective_am_root, is_effective_root};
 use ::metadata::CopyAsIds;
 
 #[test]
@@ -145,6 +145,53 @@ fn fake_super_round_trip() {
 
     let disabled = options.fake_super(false);
     assert!(!disabled.fake_super_enabled());
+}
+
+// upstream: options.c:89 - am_root tri-state, -1 is "fake-super"
+// upstream: syscall.c do_mknod() - am_root<0 sentinel substitutes placeholder
+#[test]
+fn effective_am_root_super_true_fake_super_true_is_false() {
+    // --super --fake-super: upstream demotes am_root to -1 regardless of --super.
+    assert!(!effective_am_root(Some(true), true));
+}
+
+#[test]
+fn effective_am_root_super_true_fake_super_false_is_true() {
+    // --super alone keeps the privileged path active.
+    assert!(effective_am_root(Some(true), false));
+}
+
+#[test]
+fn effective_am_root_super_false_fake_super_true_is_false() {
+    // --no-super --fake-super: privileged ops disabled, xattr placeholder used.
+    assert!(!effective_am_root(Some(false), true));
+}
+
+#[test]
+fn effective_am_root_super_false_fake_super_false_is_false() {
+    // --no-super alone disables privileged path even when running as root.
+    assert!(!effective_am_root(Some(false), false));
+}
+
+#[test]
+fn effective_am_root_super_none_fake_super_true_is_false() {
+    // --fake-super alone: forces am_root false even when EUID==0.
+    assert!(!effective_am_root(None, true));
+}
+
+#[test]
+fn effective_am_root_super_none_fake_super_false_defers_to_euid() {
+    // No flags: defers to the effective UID check.
+    assert_eq!(effective_am_root(None, false), is_effective_root());
+}
+
+#[test]
+fn fake_super_demotes_am_root_when_super_explicit() {
+    // Integration check via the public LocalCopyOptions::am_root() accessor.
+    let options = LocalCopyOptions::new()
+        .super_mode(Some(true))
+        .fake_super(true);
+    assert!(!options.am_root());
 }
 
 #[test]

--- a/crates/engine/src/local_copy/tests/execute_super.rs
+++ b/crates/engine/src/local_copy/tests/execute_super.rs
@@ -133,6 +133,10 @@ fn builder_fake_super_set_true() {
 
 #[test]
 fn builder_super_mode_and_fake_super_combined() {
+    // upstream: options.c:89 - --fake-super forces am_root=-1 even after --super.
+    // The tri-state demotion means am_root() must report false whenever
+    // fake_super is set, regardless of super_mode, so privileged ops route
+    // through the xattr placeholder branch.
     let options = LocalCopyOptions::builder()
         .super_mode(Some(true))
         .fake_super(true)
@@ -140,7 +144,7 @@ fn builder_super_mode_and_fake_super_combined() {
         .expect("valid options");
     assert_eq!(options.super_mode_setting(), Some(true));
     assert!(options.fake_super_enabled());
-    assert!(options.am_root());
+    assert!(!options.am_root());
 }
 
 #[test]
@@ -676,13 +680,16 @@ fn super_true_with_group_preserves_gid_when_root() {
 
 #[test]
 fn super_and_fake_super_both_enabled() {
-    // Both flags can be set simultaneously. In upstream rsync, --fake-super
-    // takes precedence for storage, while --super controls attempt behavior.
+    // Both flags can be set simultaneously. Upstream's am_root tri-state
+    // (options.c:89) treats --fake-super (-1) as a hard demotion even after
+    // --super (2), routing privileged ops through the xattr placeholder
+    // branch. am_root() therefore reports false.
+    // upstream: syscall.c do_mknod() - am_root<0 sentinel substitutes placeholder
     let options = LocalCopyOptions::default()
         .super_mode(Some(true))
         .fake_super(true);
 
-    assert!(options.am_root());
+    assert!(!options.am_root());
     assert!(options.fake_super_enabled());
     assert_eq!(options.super_mode_setting(), Some(true));
 }


### PR DESCRIPTION
## Summary

Closes #1926.

When the receiver has `fake_super` active (CLI `--fake-super` or daemon module `fake super = yes`), force `am_root = false` semantics in the privilege-decision branches that gate ownership and special-file creation, matching upstream rsync 3.4.1.

Upstream uses an `am_root` tri-state `int`:

- `0` - regular user
- `1` - real root
- `2` - `--super`
- `-1` - `--fake-super` / daemon `fake super = yes`

A negative `am_root` is the sentinel that routes privileged operations (`chown`, `mknod`, `mkfifo`) through the `user.rsync.%stat` xattr placeholder path instead of attempting real syscalls. See `options.c:89`, `clientserver.c:1102-1105`, and `syscall.c do_mknod()` (the `am_root < 0` branch substitutes a 0600 regular file).

## Changes

- Extract a single `effective_am_root(super_mode, fake_super) -> bool` helper in `crates/engine/src/local_copy/options/metadata/accessors.rs`. It returns `false` whenever `fake_super` is set, otherwise honours `super_mode` falling back to the effective UID check.
- Rewire `LocalCopyOptions::am_root()` through the helper so every privilege-decision call site sees the demotion uniformly.
- Update two tests in `tests/execute_super.rs` that previously asserted the un-demoted behavior; add upstream citations to the rewritten assertions.
- Add 6 unit tests covering the full truth table at the helper level (the four required cases plus the two `super_mode = None` cases).

The helper is `pub(super)` so internal call sites can be grown later (special-file executors, daemon hand-off path) without re-deriving the rule.

## Test plan

- [x] `cargo fmt --all` (clean).
- [x] `cargo clippy -p engine --all-features --all-targets -- -D warnings` (clean).
- [ ] CI nextest matrix (run by branch protection).

## Upstream references

- `target/interop/upstream-src/rsync-3.4.1/options.c:89` - `am_root` tri-state declaration.
- `target/interop/upstream-src/rsync-3.4.1/options.c:653` - `--fake-super` sets `am_root = -1`.
- `target/interop/upstream-src/rsync-3.4.1/clientserver.c:1102-1105` - daemon `fake super = yes` forces `am_root = -1`.
- `target/interop/upstream-src/rsync-3.4.1/syscall.c:90-174` - `do_mknod()` `am_root < 0` placeholder substitution.