### PR TITLE
feat(protocol): apply FilenameConverter on sender flist emit (#1912)

### DIFF
--- a/crates/protocol/src/flist/batched_writer/writer.rs
+++ b/crates/protocol/src/flist/batched_writer/writer.rs
@@ -9,6 +9,7 @@ use super::config::{BatchConfig, DEFAULT_MAX_BYTES};
 use super::stats::{BatchStats, FlushReason};
 use crate::flist::entry::FileEntry;
 use crate::flist::write::FileListWriter;
+use crate::iconv::FilenameConverter;
 use crate::{CompatibilityFlags, ProtocolVersion};
 
 /// A batched file list writer that accumulates entries before writing.
@@ -168,6 +169,18 @@ impl BatchedFileListWriter {
     #[must_use]
     pub fn with_always_checksum(mut self, csum_len: usize) -> Self {
         self.writer = self.writer.with_always_checksum(csum_len);
+        self
+    }
+
+    /// Sets the filename encoding converter for `--iconv` support.
+    ///
+    /// Mirrors [`FileListWriter::with_iconv`] so that the batched sender
+    /// path transcodes filenames from local to remote charset before
+    /// emission, matching upstream `flist.c send_file_entry()`'s
+    /// `iconv_buf(ic_send, ...)` call.
+    #[must_use]
+    pub fn with_iconv(mut self, converter: FilenameConverter) -> Self {
+        self.writer = self.writer.with_iconv(converter);
         self
     }
 

--- a/crates/protocol/src/flist/write/mod.rs
+++ b/crates/protocol/src/flist/write/mod.rs
@@ -374,6 +374,11 @@ impl FileListWriter {
     /// See `flist.c:send_file_entry()` lines 470-750 for the complete wire encoding.
     pub fn write_entry<W: Write>(&mut self, writer: &mut W, entry: &FileEntry) -> io::Result<()> {
         let raw_name = entry.name_bytes();
+        // upstream: flist.c send_file_entry() iconv_buf(ic_send, ...) - when
+        // --iconv is in effect, the filename is transcoded from local to
+        // remote charset before any prefix-compression bookkeeping or wire
+        // emission, so all downstream xflags and length fields refer to the
+        // converted bytes.
         let name = self.apply_encoding_conversion(&raw_name)?;
 
         let same_len = self.state.calculate_name_prefix_len(&name);

--- a/crates/protocol/src/flist/write/tests.rs
+++ b/crates/protocol/src/flist/write/tests.rs
@@ -2848,3 +2848,61 @@ fn wire_encoded_symlink_target_never_contains_backslash_byte() {
         "symlink target must be forward-slash form `sub/target.txt`, got: {buf:?}",
     );
 }
+
+/// Tracker #1912: when `--iconv=remote,local` is in effect, the sender's
+/// filename must be transcoded from local to remote charset before being
+/// written to the wire. A UTF-8 source name must appear on the wire as
+/// ISO-8859-1 bytes when the converter is configured `(local=UTF-8,
+/// remote=ISO-8859-1)`.
+///
+/// upstream: flist.c send_file_entry() iconv_buf(ic_send, ...)
+#[cfg(feature = "iconv")]
+#[test]
+fn write_entry_transcodes_filename_with_iconv_to_remote_charset() {
+    use crate::iconv::FilenameConverter;
+
+    // Local UTF-8 "café.txt": 0x63 0x61 0x66 0xc3 0xa9 0x2e 0x74 0x78 0x74
+    // Remote ISO-8859-1 "café.txt": 0x63 0x61 0x66 0xe9 0x2e 0x74 0x78 0x74
+    let utf8_name = "café.txt";
+    let latin1_bytes: &[u8] = &[0x63, 0x61, 0x66, 0xe9, 0x2e, 0x74, 0x78, 0x74];
+
+    let converter = FilenameConverter::new("UTF-8", "ISO-8859-1").unwrap();
+    let mut writer = FileListWriter::new(test_protocol()).with_iconv(converter);
+
+    let entry = FileEntry::new_file(utf8_name.into(), 100, 0o644);
+    let mut buf = Vec::new();
+    writer.write_entry(&mut buf, &entry).unwrap();
+
+    // The transcoded ISO-8859-1 bytes must appear on the wire.
+    assert!(
+        buf.windows(latin1_bytes.len()).any(|w| w == latin1_bytes),
+        "wire bytes must contain ISO-8859-1 form of the filename, got: {buf:?}",
+    );
+
+    // The original UTF-8 multi-byte sequence (0xc3 0xa9 for é) must NOT be
+    // present, otherwise the converter was bypassed.
+    let utf8_e_acute: &[u8] = &[0xc3, 0xa9];
+    assert!(
+        !buf.windows(utf8_e_acute.len()).any(|w| w == utf8_e_acute),
+        "wire bytes must not contain UTF-8 form of é (0xc3 0xa9), got: {buf:?}",
+    );
+}
+
+/// Tracker #1912: with no converter configured the sender must emit the
+/// raw filename bytes unchanged, preserving current behaviour for all
+/// transfers that do not pass `--iconv`.
+#[test]
+fn write_entry_without_iconv_emits_raw_filename_bytes() {
+    let utf8_name = "café.txt";
+    let utf8_bytes = utf8_name.as_bytes();
+
+    let mut writer = FileListWriter::new(test_protocol());
+    let entry = FileEntry::new_file(utf8_name.into(), 100, 0o644);
+    let mut buf = Vec::new();
+    writer.write_entry(&mut buf, &entry).unwrap();
+
+    assert!(
+        buf.windows(utf8_bytes.len()).any(|w| w == utf8_bytes),
+        "without --iconv, wire bytes must match the original filename, got: {buf:?}",
+    );
+}


### PR DESCRIPTION
## Summary

- Wires the existing `apply_encoding_conversion` hook on the sender's file-list emit path so filenames are transcoded from local to remote charset before prefix-compression bookkeeping and wire emission when `--iconv=remote,local` is in effect.
- Annotates the iconv call site in `FileListWriter::write_entry` with the upstream reference `flist.c send_file_entry() iconv_buf(ic_send, ...)` so the protocol-fidelity contract is visible at the wire boundary.
- Mirrors `FileListWriter::with_iconv` on `BatchedFileListWriter` so the batched sender path can attach a converter through the same builder surface.

## Why

The audit at `docs/audits/iconv-pipeline.md` (Finding 4) flagged that the conversion helper existed but no production caller emitted converted bytes. PR #1911 (`feat(core): wire IconvSetting to FilenameConverter at config build`) plumbed the resolved converter into `transfer::ConnectionConfig::iconv` and `engine::LocalCopyOptions::iconv`, and `transfer::generator::build_flist_writer` already calls `writer.with_iconv(...)` from `connection.iconv`. With this change, the hook now takes effect end-to-end whenever the runtime config carries a resolved converter, so `--iconv` stops being a silent no-op for sender flist emit.

The follow-ups for receiver ingest (#1913) and filter-rule path matching (#1914) remain tracked separately.

## Tests

- `crates/protocol/src/flist/write/tests.rs::write_entry_transcodes_filename_with_iconv_to_remote_charset` (feature-gated `iconv`): asserts that a UTF-8 source name `"café.txt"` emerges on the wire as the ISO-8859-1 byte sequence `[0x63, 0x61, 0x66, 0xe9, 0x2e, 0x74, 0x78, 0x74]` and that the UTF-8 form of `é` (`0xc3 0xa9`) does not appear.
- `crates/protocol/src/flist/write/tests.rs::write_entry_without_iconv_emits_raw_filename_bytes`: asserts the no-converter path still emits raw filename bytes unchanged, preserving current behaviour.

## Test plan

- [ ] CI: fmt + clippy
- [ ] CI: nextest (stable)
- [ ] CI: Windows (stable)
- [ ] CI: macOS (stable)
- [ ] CI: Linux musl (stable)

## Upstream

- `target/interop/upstream-src/rsync-3.4.1/flist.c` lines 1579-1603, `send_file_entry()` filename `iconvbufs(ic_send, ...)` (dirname + '/' + basename).

Tracker: #1912.