### PR TITLE
fix(metadata): add Win32_System_SystemServices feature for ACL build (#1866)

### DIFF
--- a/crates/metadata/Cargo.toml
+++ b/crates/metadata/Cargo.toml
@@ -41,6 +41,7 @@ windows = { version = "0.62", features = [
     "Win32_Security",
     "Win32_Security_Authorization",
     "Win32_Storage_FileSystem",
+    "Win32_System_SystemServices",
 ] }
 
 [features]


### PR DESCRIPTION
## Summary

- Adds the `Win32_System_SystemServices` feature flag to the `windows-rs` dependency in `crates/metadata/Cargo.toml` so the `ACCESS_ALLOWED_ACE_TYPE` import resolves on all Windows toolchains.
- Hotfix for master: PR #3544 fixed the import path to match windows-rs 0.62, but did not add the Cargo feature gate. Master CI has been red since that merge — Windows (stable) required check fails on every PR.

## Why

windows-rs 0.62 gates `ACCESS_ALLOWED_ACE_TYPE` behind the `Win32_System_SystemServices` Cargo feature:

```
note: the item is gated behind the `Win32_System_SystemServices` feature
135 | #[cfg(feature = "Win32_System_SystemServices")]
136 | pub mod SystemServices;
```

The import at `crates/metadata/src/acl_windows.rs:67` therefore fails to resolve:

```
error[E0432]: unresolved import `windows::Win32::System::SystemServices`
 --> crates/metadata/src/acl_windows.rs:67:30
  |
69 | use windows::Win32::System::SystemServices::ACCESS_ALLOWED_ACE_TYPE;
  |                              ^^^^^^^^^^^^^^ could not find `SystemServices` in `System`
```

This blocks Windows (stable), Windows (beta), Windows (nightly), and Windows GNU cross-check on master.

## Test plan

- [ ] CI: Windows (stable) green
- [ ] CI: Windows (beta) green
- [ ] CI: Windows (nightly) green
- [ ] CI: Windows GNU cross-check green
- [ ] Confirms `cargo clippy --workspace --all-targets --all-features` succeeds on Windows
- [ ] Unblocks the 11 open PRs that were red purely from this master regression

Refs #1866. Hotfix on top of #3544.