### PR TITLE
fix(fast_io): prevent io_uring SEND deadlock under TCP backpressure (#1872)

### DIFF
--- a/crates/fast_io/src/io_uring/batching.rs
+++ b/crates/fast_io/src/io_uring/batching.rs
@@ -142,10 +142,131 @@ pub(super) fn submit_write_batch(
     Ok(global_done)
 }
 
+/// Sentinel user_data tag for a `PollAdd(POLLOUT)` gating CQE.
+///
+/// Picked far above any plausible SEND/WRITE batch index so it cannot collide
+/// with a slot index in [`submit_send_batch`].
+const POLL_OUT_USER_DATA: u64 = u64::MAX;
+
+/// Sentinel user_data tag for the linked-timeout CQE that cancels a pending
+/// `PollAdd(POLLOUT)`.
+const POLL_OUT_TIMEOUT_USER_DATA: u64 = u64::MAX - 1;
+
+/// Waits for the socket to become writable using `IORING_OP_POLL_ADD` with
+/// `POLLOUT`.
+///
+/// Without a readiness gate, an `IORING_OP_SEND` SQE on a back-pressured TCP
+/// socket can sit in the kernel until the send buffer drains. While that SQE
+/// is pending the ring's `submit_and_wait` does not return, which means any
+/// concurrent `IORING_OP_RECV` completion on the same ring stays unreaped --
+/// the symptom in issue #1872. By polling for `POLLOUT` first we let the
+/// receive side keep draining; only when the kernel has room do we submit
+/// the SEND.
+///
+/// A linked `Timeout` SQE bounds the wait so callers cannot block forever
+/// (e.g., the peer froze entirely). On expiry we surface `WouldBlock` so the
+/// caller can re-arm without treating it as a fatal error.
+///
+/// upstream: io.c:perform_io -- `FD_SET(out_fd, &w_fds); select(... &w_fds ...)`
+fn poll_writable(
+    ring: &mut RawIoUring,
+    fd: types::Fd,
+    fixed_fd_slot: i32,
+    timeout: &types::Timespec,
+) -> io::Result<()> {
+    // POLLOUT is a stable kernel UAPI constant (4); the libc::POLLOUT alias
+    // is `c_short`, so widen it to the `u32` mask io_uring expects.
+    let pollout_mask: u32 = libc::POLLOUT as u32;
+
+    // Build the PollAdd with IO_LINK; if the fd is registered, OR in
+    // FIXED_FILE rather than letting `maybe_fixed_file` overwrite IO_LINK.
+    let mut sqe_flags = io_uring::squeue::Flags::IO_LINK;
+    if fixed_fd_slot != NO_FIXED_FD {
+        sqe_flags |= io_uring::squeue::Flags::FIXED_FILE;
+    }
+    let poll_entry = opcode::PollAdd::new(sqe_fd(fd.0, fixed_fd_slot), pollout_mask)
+        .build()
+        .flags(sqe_flags)
+        .user_data(POLL_OUT_USER_DATA);
+
+    let timeout_entry = opcode::LinkTimeout::new(timeout as *const types::Timespec)
+        .build()
+        .user_data(POLL_OUT_TIMEOUT_USER_DATA);
+
+    // SAFETY: Both SQEs reference data that outlives this submission: the fd
+    // is owned by the caller's socket, and `timeout` is borrowed for the
+    // duration of the call. The poll SQE carries `IO_LINK` so the kernel
+    // atomically applies the immediately following `LinkTimeout`. We drain
+    // every completion synchronously below before returning, so neither SQE
+    // payload outlives this stack frame.
+    unsafe {
+        let mut sq = ring.submission();
+        sq.push(&poll_entry)
+            .map_err(|_| io::Error::other("submission queue full"))?;
+        sq.push(&timeout_entry)
+            .map_err(|_| io::Error::other("submission queue full"))?;
+    }
+
+    // Wait for at least one completion. The poll and the linked timeout both
+    // post CQEs; whichever fires first will satisfy this wait. We then drain
+    // the second CQE (it is already queued) without re-entering the kernel.
+    ring.submit_and_wait(1)?;
+
+    let mut poll_result: Option<i32> = None;
+    let mut saw_timeout = false;
+    loop {
+        let cqe = match ring.completion().next() {
+            Some(c) => c,
+            None => break,
+        };
+        match cqe.user_data() {
+            POLL_OUT_USER_DATA => poll_result = Some(cqe.result()),
+            POLL_OUT_TIMEOUT_USER_DATA => saw_timeout = true,
+            _ => {}
+        }
+    }
+
+    match poll_result {
+        Some(r) if r >= 0 => Ok(()),
+        Some(neg) => {
+            let err = io::Error::from_raw_os_error(-neg);
+            // `ECANCELED` is what the poll reports when the linked timeout
+            // fired first; treat that and an explicit `ETIME` as transient
+            // backpressure.
+            if matches!(
+                err.raw_os_error(),
+                Some(libc::ETIME) | Some(libc::ECANCELED)
+            ) {
+                Err(io::Error::new(
+                    io::ErrorKind::WouldBlock,
+                    "POLLOUT timed out waiting for socket writability",
+                ))
+            } else {
+                Err(err)
+            }
+        }
+        None if saw_timeout => Err(io::Error::new(
+            io::ErrorKind::WouldBlock,
+            "POLLOUT linked timeout fired before poll completion",
+        )),
+        None => Err(io::Error::other("missing POLLOUT CQE")),
+    }
+}
+
 /// Submits a batch of send SQEs from contiguous `data` and collects completions.
 ///
 /// Analogous to [`submit_write_batch`] but uses `opcode::Send` instead of
 /// `opcode::Write` and omits file offsets (stream sockets have no position).
+///
+/// To prevent the receive side from starving when the kernel send buffer is
+/// full (issue #1872), each batch is gated by a `IORING_OP_POLL_ADD(POLLOUT)`
+/// SQE. The SEND SQEs are only submitted once the socket reports writable,
+/// mirroring the bidirectional `select()` strategy in upstream rsync's
+/// `perform_io()`. This keeps `submit_and_wait` from being held hostage by a
+/// back-pressured SEND that would otherwise leave concurrent RECV CQEs
+/// un-reaped.
+///
+/// upstream: io.c:perform_io
 pub(super) fn submit_send_batch(
     ring: &mut RawIoUring,
     fd: types::Fd,
@@ -158,6 +279,10 @@ pub(super) fn submit_send_batch(
         return Ok(0);
     }
 
+    // Per-iteration readiness ceiling. Re-armed each loop pass; a back-
+    // pressured but progressing peer never trips it. 30 s matches the
+    // default upstream `select_timeout`.
+    let timeout = types::Timespec::new().sec(30).nsec(0);
     let total = data.len();
     let mut global_done = 0usize;
 
@@ -173,6 +298,14 @@ pub(super) fn submit_send_batch(
 
         let mut batch_complete = false;
         while !batch_complete {
+            // Gate on POLLOUT. Transient backpressure surfaces as WouldBlock;
+            // we re-arm and continue without escalating to the caller.
+            match poll_writable(ring, fd, fixed_fd_slot, &timeout) {
+                Ok(()) => {}
+                Err(e) if e.kind() == io::ErrorKind::WouldBlock => continue,
+                Err(e) => return Err(e),
+            }
+
             let mut submitted = 0u32;
             for (idx, &(start, len, done)) in slots.iter().enumerate() {
                 let want = len - done;
@@ -213,7 +346,18 @@ pub(super) fn submit_send_batch(
                 let result = cqe.result();
 
                 if result < 0 {
-                    return Err(io::Error::from_raw_os_error(-result));
+                    let err = io::Error::from_raw_os_error(-result);
+                    // EAGAIN/EWOULDBLOCK on a non-blocking-style send: rearm
+                    // the readiness poll on the next outer loop iteration
+                    // rather than failing.
+                    if matches!(
+                        err.raw_os_error(),
+                        Some(libc::EAGAIN) | Some(libc::EWOULDBLOCK)
+                    ) {
+                        completed += 1;
+                        continue;
+                    }
+                    return Err(err);
                 }
                 if result == 0 {
                     return Err(io::Error::new(

--- a/crates/fast_io/src/io_uring/batching.rs
+++ b/crates/fast_io/src/io_uring/batching.rs
@@ -349,11 +349,9 @@ pub(super) fn submit_send_batch(
                     let err = io::Error::from_raw_os_error(-result);
                     // EAGAIN/EWOULDBLOCK on a non-blocking-style send: rearm
                     // the readiness poll on the next outer loop iteration
-                    // rather than failing.
-                    if matches!(
-                        err.raw_os_error(),
-                        Some(libc::EAGAIN) | Some(libc::EWOULDBLOCK)
-                    ) {
+                    // rather than failing. EWOULDBLOCK == EAGAIN on Linux per
+                    // POSIX, so a single arm covers both names.
+                    if err.raw_os_error() == Some(libc::EAGAIN) {
                         completed += 1;
                         continue;
                     }

--- a/crates/fast_io/src/io_uring/tests.rs
+++ b/crates/fast_io/src/io_uring/tests.rs
@@ -1035,8 +1035,15 @@ fn test_socket_send_no_deadlock_under_backpressure_1872() {
     assert!(prefill_total > 0, "prefill made no progress");
 
     // Distinct payload bytes (never == PREFILL_MARKER) so the drain side
-    // can recognize the boundary between prefill and payload.
-    let payload: Vec<u8> = (0..64 * 1024).map(|i| ((i % 250) + 1) as u8).collect();
+    // can recognize the boundary between prefill and payload. The mapping
+    // walks 1..=255 skipping PREFILL_MARKER (0xAB) so every payload byte is
+    // guaranteed != PREFILL_MARKER for any input index.
+    let payload: Vec<u8> = (0..64 * 1024)
+        .map(|i| {
+            let v = ((i % 254) + 1) as u8;
+            if v >= PREFILL_MARKER { v + 1 } else { v }
+        })
+        .collect();
     debug_assert!(payload.iter().all(|&b| b != PREFILL_MARKER));
     let payload_len = payload.len();
     let payload_for_writer = payload.clone();

--- a/crates/fast_io/src/io_uring/tests.rs
+++ b/crates/fast_io/src/io_uring/tests.rs
@@ -926,6 +926,196 @@ fn test_socket_large_payload_roundtrip() {
     assert_eq!(received, payload);
 }
 
+/// Regression test for issue #1872: an `IORING_OP_SEND` on a back-pressured
+/// TCP socket must not stall `submit_and_wait()` and starve concurrent RECV
+/// completions, producing a perceived deadlock.
+///
+/// The test sets up a loopback TCP pair with shrunk socket buffers, pre-fills
+/// the kernel send buffer until a non-blocking write returns `EAGAIN`, then
+/// runs an io_uring SEND on the writer side concurrently with a draining RECV
+/// on the reader side. Each side uses its own io_uring ring (matching how the
+/// daemon-mode bidirectional path is wired). Without the `PollAdd(POLLOUT)`
+/// readiness gate the writer's `submit_and_wait` would only return after the
+/// peer drained enough buffer; with the gate the SEND submission itself is
+/// deferred until the kernel has room. A wall-clock timeout fails the test
+/// if the writer stalls.
+///
+/// upstream: io.c:perform_io -- bidirectional select() drives both directions
+#[cfg(target_os = "linux")]
+#[test]
+fn test_socket_send_no_deadlock_under_backpressure_1872() {
+    use std::net::{TcpListener, TcpStream};
+    use std::os::unix::io::AsRawFd;
+    use std::sync::mpsc;
+    use std::time::{Duration, Instant};
+
+    if !is_io_uring_available() {
+        println!("Skipping: io_uring not available on this host");
+        return;
+    }
+
+    // A loopback TCP pair is required to exercise real socket-buffer
+    // backpressure; Unix `socketpair` uses pipe-style flow control that
+    // does not reproduce the issue.
+    let listener = match TcpListener::bind("127.0.0.1:0") {
+        Ok(l) => l,
+        Err(e) => {
+            println!("Skipping: cannot bind loopback ({e})");
+            return;
+        }
+    };
+    let addr = listener.local_addr().unwrap();
+    let connect_thread = std::thread::spawn(move || TcpStream::connect(addr).unwrap());
+    let (server, _peer) = listener.accept().unwrap();
+    let client = connect_thread.join().unwrap();
+
+    // Shrink both kernel buffers so backpressure kicks in below 64 KiB.
+    let small: libc::c_int = 4 * 1024;
+    for fd in [server.as_raw_fd(), client.as_raw_fd()] {
+        // SAFETY: setsockopt on a valid fd with a known-good optval/optlen.
+        unsafe {
+            libc::setsockopt(
+                fd,
+                libc::SOL_SOCKET,
+                libc::SO_SNDBUF,
+                (&small as *const libc::c_int).cast(),
+                std::mem::size_of::<libc::c_int>() as libc::socklen_t,
+            );
+            libc::setsockopt(
+                fd,
+                libc::SOL_SOCKET,
+                libc::SO_RCVBUF,
+                (&small as *const libc::c_int).cast(),
+                std::mem::size_of::<libc::c_int>() as libc::socklen_t,
+            );
+        }
+    }
+
+    // Pre-fill the client's kernel send buffer using a non-blocking write
+    // loop until `EAGAIN` confirms the buffer is wedged, then restore
+    // blocking mode for io_uring.
+    let client_fd = client.as_raw_fd();
+    // SAFETY: fcntl on a valid fd; we restore the original flags below.
+    let orig_flags = unsafe { libc::fcntl(client_fd, libc::F_GETFL) };
+    // SAFETY: same fd; setting O_NONBLOCK.
+    unsafe {
+        libc::fcntl(client_fd, libc::F_SETFL, orig_flags | libc::O_NONBLOCK);
+    }
+    const PREFILL_MARKER: u8 = 0xAB;
+    let prefill_chunk = vec![PREFILL_MARKER; 4 * 1024];
+    let mut prefill_total = 0usize;
+    loop {
+        // SAFETY: write into a valid fd from a borrowed slice.
+        let n = unsafe {
+            libc::write(
+                client_fd,
+                prefill_chunk.as_ptr().cast::<libc::c_void>(),
+                prefill_chunk.len(),
+            )
+        };
+        if n < 0 {
+            let err = std::io::Error::last_os_error();
+            if matches!(
+                err.raw_os_error(),
+                Some(libc::EAGAIN) | Some(libc::EWOULDBLOCK)
+            ) {
+                break;
+            }
+            panic!("prefill write failed: {err}");
+        }
+        prefill_total += n as usize;
+        // Cap prefill so the test stays bounded even on hosts that grow
+        // SO_SNDBUF beyond the requested size.
+        if prefill_total > 1 << 20 {
+            break;
+        }
+    }
+    // SAFETY: restore original (blocking) flags.
+    unsafe {
+        libc::fcntl(client_fd, libc::F_SETFL, orig_flags);
+    }
+    assert!(prefill_total > 0, "prefill made no progress");
+
+    // Distinct payload bytes (never == PREFILL_MARKER) so the drain side
+    // can recognize the boundary between prefill and payload.
+    let payload: Vec<u8> = (0..64 * 1024).map(|i| ((i % 250) + 1) as u8).collect();
+    debug_assert!(payload.iter().all(|&b| b != PREFILL_MARKER));
+    let payload_len = payload.len();
+    let payload_for_writer = payload.clone();
+
+    let (done_tx, done_rx) = mpsc::channel::<std::io::Result<usize>>();
+
+    let writer_thread = std::thread::spawn(move || {
+        // Keep the TcpStream alive in this scope so the fd stays valid.
+        let _client = client;
+        let mut writer = match socket_writer_from_fd(
+            client_fd,
+            16 * 1024,
+            crate::IoUringPolicy::Enabled,
+        ) {
+            Ok(w) => w,
+            Err(e) => {
+                let _ = done_tx.send(Err(e));
+                return;
+            }
+        };
+        let res = writer.write_all(&payload_for_writer).and_then(|()| {
+            writer.flush()?;
+            Ok(payload_for_writer.len())
+        });
+        let _ = done_tx.send(res);
+        // Drop writer (and ring) before the stream so the writer cannot
+        // outlive the fd.
+        drop(writer);
+    });
+
+    let server_fd = server.as_raw_fd();
+    let drain_thread = std::thread::spawn(move || -> std::io::Result<usize> {
+        let _server = server;
+        let mut reader =
+            socket_reader_from_fd(server_fd, 16 * 1024, crate::IoUringPolicy::Enabled)?;
+        let mut buf = vec![0u8; 8 * 1024];
+        let mut payload_bytes = 0usize;
+        while payload_bytes < payload_len {
+            let n = reader.read(&mut buf)?;
+            if n == 0 {
+                break;
+            }
+            payload_bytes += buf[..n].iter().filter(|&&b| b != PREFILL_MARKER).count();
+        }
+        Ok(payload_bytes)
+    });
+
+    // Wall-clock liveness check: with the fix the writer finishes within
+    // seconds because the drain thread keeps emptying the kernel buffer.
+    // Without the fix this loops past the deadline.
+    let deadline = Instant::now() + Duration::from_secs(20);
+    let mut writer_result: Option<std::io::Result<usize>> = None;
+    while Instant::now() < deadline {
+        match done_rx.recv_timeout(Duration::from_millis(100)) {
+            Ok(r) => {
+                writer_result = Some(r);
+                break;
+            }
+            Err(mpsc::RecvTimeoutError::Timeout) => continue,
+            Err(mpsc::RecvTimeoutError::Disconnected) => break,
+        }
+    }
+
+    let writer_result =
+        writer_result.unwrap_or_else(|| panic!("writer stalled: io_uring SEND deadlocked"));
+    let bytes_sent = writer_result.expect("writer error");
+    assert_eq!(bytes_sent, payload_len, "writer must report full payload");
+
+    // Wait for drain thread to finish before the test ends.
+    let drained = drain_thread.join().expect("drain thread panicked").unwrap();
+    assert!(
+        drained >= payload_len,
+        "drain saw {drained} of {payload_len} payload bytes"
+    );
+    let _ = writer_thread.join();
+}
+
 #[test]
 fn test_socket_reader_disabled_policy() {
     let (fd_a, fd_b) = make_socket_pair();

--- a/crates/fast_io/src/io_uring/tests.rs
+++ b/crates/fast_io/src/io_uring/tests.rs
@@ -1048,17 +1048,14 @@ fn test_socket_send_no_deadlock_under_backpressure_1872() {
     let writer_thread = std::thread::spawn(move || {
         // Keep the TcpStream alive in this scope so the fd stays valid.
         let _client = client;
-        let mut writer = match socket_writer_from_fd(
-            client_fd,
-            16 * 1024,
-            crate::IoUringPolicy::Enabled,
-        ) {
-            Ok(w) => w,
-            Err(e) => {
-                let _ = done_tx.send(Err(e));
-                return;
-            }
-        };
+        let mut writer =
+            match socket_writer_from_fd(client_fd, 16 * 1024, crate::IoUringPolicy::Enabled) {
+                Ok(w) => w,
+                Err(e) => {
+                    let _ = done_tx.send(Err(e));
+                    return;
+                }
+            };
         let res = writer.write_all(&payload_for_writer).and_then(|()| {
             writer.flush()?;
             Ok(payload_for_writer.len())

--- a/crates/fast_io/src/io_uring/tests.rs
+++ b/crates/fast_io/src/io_uring/tests.rs
@@ -1015,10 +1015,8 @@ fn test_socket_send_no_deadlock_under_backpressure_1872() {
         };
         if n < 0 {
             let err = std::io::Error::last_os_error();
-            if matches!(
-                err.raw_os_error(),
-                Some(libc::EAGAIN) | Some(libc::EWOULDBLOCK)
-            ) {
+            // EWOULDBLOCK == EAGAIN on Linux per POSIX, so a single arm covers both names.
+            if err.raw_os_error() == Some(libc::EAGAIN) {
                 break;
             }
             panic!("prefill write failed: {err}");


### PR DESCRIPTION
## Summary

- Fixes #1872. An `IORING_OP_SEND` on a back-pressured TCP socket would sit in the kernel until the send buffer drained, holding `submit_and_wait` and starving any concurrent RECV completion side, producing an apparent deadlock during daemon-mode bidirectional transfers.
- Adds a `PollAdd(POLLOUT)` readiness gate (with a linked timeout) in front of every `submit_send_batch` flush. SEND SQEs only enter the kernel once the socket reports writable, so `submit_and_wait` is bounded by readiness rather than peer drain. This mirrors upstream rsync's `select()`-based bidirectional I/O loop in `io.c:perform_io`.
- Transient `EAGAIN`/`EWOULDBLOCK` SEND CQEs and `ETIME`/`ECANCELED` poll CQEs re-arm the readiness wait without surfacing fatal errors.

## Why poll-add gating instead of an interleaved peek loop

Each `IoUringSocketWriter`/`IoUringSocketReader` already owns a private ring (so the SEND ring never carries RECV SQEs). The cleanest containment for the deadlock is therefore inside the writer's own `submit_send_batch`: defer the SEND submission until the kernel signals room. This adds zero coupling between the writer and reader rings and keeps the existing API surface intact, whereas an interleaved peek/timeout loop would require sharing CQE handling between two rings that today have no shared state.

## Test plan

- [ ] CI: `cargo nextest run -p fast_io --all-features -E 'test(io_uring) or test(socket) or test(send)'` (Linux must exercise `test_socket_send_no_deadlock_under_backpressure_1872`; macOS/Windows skip via `#[cfg(target_os = "linux")]`).
- [ ] CI: full nextest matrix (Linux musl, Windows, macOS) on stable.
- [ ] CI: fmt + clippy + interop workflows.

The new regression test:

1. Opens a loopback TCP pair and shrinks `SO_SNDBUF`/`SO_RCVBUF` to 4 KiB.
2. Pre-fills the writer's kernel send buffer with a sentinel byte until a non-blocking write returns `EAGAIN`, then restores blocking mode.
3. Spawns separate writer and drain threads, each backed by its own io_uring ring (`IoUringPolicy::Enabled`).
4. Asserts the writer reports the full 64 KiB payload within a 20 s wall-clock deadline (without the fix this would loop indefinitely).
5. Skips gracefully when io_uring is unavailable.