### PR TITLE
feat(daemon): wire module charset= directive to iconv runtime (#1917)

### DIFF
--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -26,6 +26,8 @@ xattr = ["core/xattr"]
 tracing = ["dep:tracing", "core/tracing"]
 # ACL (Access Control Lists) support on Unix systems
 acl = ["core/acl", "metadata/acl"]
+# Filename charset transcoding via the module `charset =` directive (iconv).
+iconv = ["core/iconv", "protocol/iconv"]
 
 [dependencies]
 clap = { version = "4.5.49", features = ["std"] }

--- a/crates/daemon/src/daemon.rs
+++ b/crates/daemon/src/daemon.rs
@@ -56,7 +56,8 @@ use core::{
 use logging_sink::MessageSink;
 use protocol::{
     LEGACY_DAEMON_PREFIX_LEN, LegacyDaemonMessage, MessageCode, MessageFrame, ProtocolVersion,
-    filters::FilterRuleWireFormat, format_legacy_daemon_message, parse_legacy_daemon_message,
+    filters::FilterRuleWireFormat, format_legacy_daemon_message, iconv::FilenameConverter,
+    parse_legacy_daemon_message,
 };
 
 use crate::{config::DaemonConfig, error::DaemonError, systemd};

--- a/crates/daemon/src/daemon/sections/module_access/client_args.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args.rs
@@ -280,7 +280,7 @@ fn build_server_config(
             // directive into the iconv handles used for filename transcoding.
             // Without this wiring the daemon would parse `charset = LATIN1` but
             // never apply it, leaving --iconv negotiation a silent no-op.
-            cfg.connection.iconv = resolve_module_charset_converter(module.charset());
+            cfg.connection.iconv = resolve_module_charset_converter(module.charset.as_deref());
 
             Ok(Some(cfg))
         }

--- a/crates/daemon/src/daemon/sections/module_access/client_args.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args.rs
@@ -275,6 +275,13 @@ fn build_server_config(
                 }
             }
 
+            // upstream: clientserver.c:712-716 - `iconv_opt = lp_charset(i);
+            // if (*iconv_opt) setup_iconv();` resolves the module's `charset =`
+            // directive into the iconv handles used for filename transcoding.
+            // Without this wiring the daemon would parse `charset = LATIN1` but
+            // never apply it, leaving --iconv negotiation a silent no-op.
+            cfg.connection.iconv = resolve_module_charset_converter(module.charset());
+
             Ok(Some(cfg))
         }
         Err(err) => {
@@ -508,5 +515,160 @@ fn apply_long_form_args(client_args: &[String], config: &mut ServerConfig) {
             }
         }
         i += 1;
+    }
+}
+
+/// Resolves the daemon module's `charset =` directive into a
+/// [`FilenameConverter`] that mirrors upstream rsync's iconv setup.
+///
+/// Upstream `clientserver.c:712-716` sets `iconv_opt = lp_charset(i)` and
+/// calls `setup_iconv()` whenever the value is non-empty. `setup_iconv()`
+/// (`rsync.c:87-140`) then opens two iconv handles:
+///
+/// - `ic_send = iconv_open(UTF8, charset)` - convert local-charset bytes to
+///   UTF-8 wire bytes when sending file lists.
+/// - `ic_recv = iconv_open(charset, UTF8)` - convert UTF-8 wire bytes back
+///   to the local charset when receiving file lists.
+///
+/// When the directive includes a comma (`charset = LOCAL,REMOTE`), upstream
+/// honours the server side by using the segment after the comma
+/// (`rsync.c:118-120`, `am_server` branch). When no comma is present, the
+/// whole value is the charset. The literal value `.` and the empty string
+/// both resolve to the locale default per `rsync.c:125-126`.
+///
+/// Our [`FilenameConverter`] models the same direction pair: `local_to_remote`
+/// matches `ic_send` (local -> wire UTF-8), and `remote_to_local` matches
+/// `ic_recv` (wire UTF-8 -> local). Therefore a daemon-side converter is
+/// built with the daemon's local charset on the local side and the literal
+/// `"UTF-8"` on the remote (wire) side.
+///
+/// Returns `None` when the directive is absent, empty, or unrecognised by
+/// `encoding_rs`. An unrecognised charset is treated as a soft failure: we
+/// log via `tracing` (when enabled) and fall through to identity conversion,
+/// matching the lenient behaviour `IconvSetting::resolve_converter` already
+/// uses on the client side.
+///
+/// # Upstream Reference
+///
+/// - `clientserver.c:712-716` - `iconv_opt = lp_charset(i); setup_iconv();`
+/// - `rsync.c:87-140` - `setup_iconv()` opens `ic_send` and `ic_recv`.
+/// - `loadparm.c` - `charset` module parameter.
+fn resolve_module_charset_converter(charset: Option<&str>) -> Option<FilenameConverter> {
+    let raw = charset?.trim();
+    if raw.is_empty() {
+        return None;
+    }
+
+    // upstream: rsync.c:118-120 - on the server side, the segment after the
+    // comma is the effective local charset; the segment before the comma
+    // describes the peer's local charset and is irrelevant to the daemon.
+    let local_part = match raw.split_once(',') {
+        Some((_, remote)) => remote.trim(),
+        None => raw,
+    };
+
+    // upstream: rsync.c:125-126 - empty or "." means "use locale default".
+    // Our converter treats UTF-8 as the locale default, matching
+    // `converter_from_locale`.
+    if local_part.is_empty() || local_part == "." {
+        return Some(FilenameConverter::identity());
+    }
+
+    match FilenameConverter::new(local_part, "UTF-8") {
+        Ok(converter) => Some(converter),
+        Err(_error) => {
+            #[cfg(feature = "tracing")]
+            tracing::warn!(
+                charset = %local_part,
+                error = %_error,
+                "module 'charset' directive: unsupported encoding; daemon will not transcode filenames",
+            );
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod iconv_charset_converter_tests {
+    use super::resolve_module_charset_converter;
+
+    #[test]
+    fn iconv_charset_returns_none_for_missing_directive() {
+        assert!(resolve_module_charset_converter(None).is_none());
+    }
+
+    #[test]
+    fn iconv_charset_returns_none_for_empty_directive() {
+        assert!(resolve_module_charset_converter(Some("")).is_none());
+        assert!(resolve_module_charset_converter(Some("   ")).is_none());
+    }
+
+    #[test]
+    fn iconv_charset_dot_means_locale_default() {
+        let converter =
+            resolve_module_charset_converter(Some(".")).expect("dot should resolve");
+        assert!(converter.is_identity());
+    }
+
+    #[test]
+    fn iconv_charset_comma_with_dot_resolves_to_identity() {
+        // upstream: rsync.c:118-120 - server side honours the post-comma value.
+        // upstream: rsync.c:125-126 - "." means "use locale default".
+        let converter = resolve_module_charset_converter(Some("UTF-8,."))
+            .expect("dot remote should resolve");
+        assert!(converter.is_identity());
+    }
+
+    #[cfg(feature = "iconv")]
+    #[test]
+    fn iconv_charset_resolves_simple_charset() {
+        let converter =
+            resolve_module_charset_converter(Some("ISO-8859-1")).expect("charset should resolve");
+        // encoding_rs aliases ISO-8859-1 to windows-1252 internally.
+        assert_eq!(converter.local_encoding_name(), "windows-1252");
+        assert_eq!(converter.remote_encoding_name(), "UTF-8");
+    }
+
+    #[cfg(feature = "iconv")]
+    #[test]
+    fn iconv_charset_uses_segment_after_comma() {
+        // upstream: rsync.c:118-120 - server side honours the post-comma value.
+        let converter = resolve_module_charset_converter(Some("UTF-8,ISO-8859-1"))
+            .expect("charset should resolve");
+        assert_eq!(converter.local_encoding_name(), "windows-1252");
+        assert_eq!(converter.remote_encoding_name(), "UTF-8");
+    }
+
+    #[cfg(feature = "iconv")]
+    #[test]
+    fn iconv_charset_returns_none_for_unknown_charset() {
+        assert!(resolve_module_charset_converter(Some("not-a-real-charset")).is_none());
+    }
+
+    #[cfg(feature = "iconv")]
+    #[test]
+    fn iconv_charset_trims_whitespace() {
+        let converter = resolve_module_charset_converter(Some("  ISO-8859-1  "))
+            .expect("trimmed charset should resolve");
+        assert_eq!(converter.local_encoding_name(), "windows-1252");
+    }
+
+    #[cfg(feature = "iconv")]
+    #[test]
+    fn iconv_charset_round_trip_latin1_utf8() {
+        // Verify the converter actually transcodes correctly: a Latin-1 byte
+        // sequence containing U+00E9 ('é' as 0xE9) should round-trip through
+        // UTF-8 wire encoding and back.
+        let converter =
+            resolve_module_charset_converter(Some("ISO-8859-1")).expect("charset should resolve");
+
+        let local_bytes = b"caf\xe9.txt"; // 'café.txt' in Latin-1
+        let wire = converter
+            .local_to_remote(local_bytes)
+            .expect("local_to_remote");
+        assert_eq!(wire.as_ref(), "café.txt".as_bytes());
+
+        let round_trip = converter.remote_to_local(&wire).expect("remote_to_local");
+        assert_eq!(round_trip.as_ref(), local_bytes);
     }
 }

--- a/tools/ci/known_failures.conf
+++ b/tools/ci/known_failures.conf
@@ -17,23 +17,6 @@
 
 # Unconditional known failures (direction:name).
 KNOWN_FAILURES=(
-  # OC-RSYNC GAP: --iconv daemon-mode interop with upstream rsync 3.4.1.
-  # Reference: #1916, docs/audits/iconv-pipeline.md.
-  #
-  # The `charset =` module directive is parsed
-  # (crates/daemon/src/daemon/sections/config_parsing/module_directives.rs:330)
-  # but never threaded into the daemon's iconv setup path. Findings 1-3 of the
-  # audit (symlink target transcoding, --files-from forwarding,
-  # --secluded-args/--protect-args transcoding) also remain open.
-  #
-  # Until daemon-side `charset` is wired to the iconv runtime, --iconv from a
-  # client to an oc-rsync daemon either fails outright (option refused per
-  # upstream contract) or stores raw wire bytes on disk (mojibake). The
-  # interop test sets `charset = ISO-8859-1` on the daemon and pushes UTF-8
-  # source names with --iconv=UTF-8,ISO-8859-1.
-  # NOT FIXABLE HERE: requires daemon iconv plumbing follow-up (#1911-#1917).
-  "standalone:iconv-upstream"
-
   # OC-RSYNC GAP: --iconv SSH/local interop with upstream rsync 3.4.1.
   # Reference: #1916, docs/audits/iconv-pipeline.md (Finding 4).
   #
@@ -151,9 +134,6 @@ is_known_failure_from_conf() {
 # Keep in sync with actual known failure rules above.
 DASHBOARD_ENTRIES=(
   # --- oc-rsync known gaps (unconditional) ---
-  # daemon-mode iconv: `charset =` directive parsed but not wired to iconv runtime
-  "standalone:iconv-upstream|--iconv UTF-8/LATIN1 round-trip vs upstream 3.4.1 (#1916, daemon 'charset' directive not yet wired to iconv runtime; see docs/audits/iconv-pipeline.md)|standalone"
-
   # SSH/local iconv: IconvSetting -> FilenameConverter bridge missing in production code
   "standalone:iconv-local-ssh|--iconv UTF-8/LATIN1 over SSH/local vs upstream 3.4.1 (#1916, audit Finding 4: IconvSetting -> FilenameConverter bridge missing; pending #1911/#1912/#1913)|standalone"
 

--- a/tools/ci/run_interop.sh
+++ b/tools/ci/run_interop.sh
@@ -3091,24 +3091,127 @@ test_iconv() {
   return 0
 }
 
-# #1916: --iconv UTF-8/LATIN1 round-trip vs upstream rsync 3.4.1
-# Verifies that upstream rsync 3.4.1 and oc-rsync interoperate when the user
-# requests --iconv=UTF-8,ISO-8859-1. Both directions are exercised:
-#   1. upstream client -> oc-rsync daemon (push)
-#   2. oc-rsync client -> upstream daemon (push)
-# In each direction the source contains UTF-8 filenames whose code points all
-# fit in ISO-8859-1 (Latin-1). With --iconv enabled, the wire encoding is
-# Latin-1 and both peers must transcode back to UTF-8 on disk.
+# #1916: --iconv daemon round-trip vs upstream rsync 3.4.1
 #
-# References:
-#   upstream: options.c:recv_iconv_settings (parses --iconv=LOCAL,REMOTE)
-#   upstream: flist.c:1579-1603 (sender filename iconvbufs(ic_send, ...))
-#   upstream: flist.c:738-754 (receiver filename iconvbufs(ic_recv, ...))
+# # Wire semantics
+#
+# Per upstream rsync.c:130-140 the wire is always UTF-8 when --iconv is
+# active. The `charset` parameter (whether on the client `--iconv=LOCAL,REMOTE`
+# or on the daemon `charset =` directive) names the *local disk* encoding,
+# not the wire encoding:
+#
+#     ic_send = iconv_open(UTF8_CHARSET, charset)  # disk -> wire
+#     ic_recv = iconv_open(charset, UTF8_CHARSET)  # wire -> disk
+#
+# Per options.c:recv_iconv_settings the comma-separated argument splits as
+# LOCAL,REMOTE. The client uses LOCAL for its own `charset`; the server
+# (daemon) uses REMOTE, but the daemon `charset =` directive overrides REMOTE
+# with the daemon's own configured local-disk encoding.
+#
+# # Test fixture model
+#
+# With client `--iconv=UTF-8,ISO-8859-1` and daemon `charset = ISO-8859-1`:
+#
+#   - Source disk holds UTF-8 byte filenames (e.g. caf\xc3\xa9.txt).
+#   - Sender ic_send (UTF-8 -> UTF-8) is identity; wire bytes are UTF-8.
+#   - Daemon ic_recv (UTF-8 -> ISO-8859-1) maps to single-byte names on
+#     disk (e.g. caf\xe9.txt).
+#
+# So source and destination filenames have *different* byte sequences for the
+# same logical filename. The fixture model uses parallel arrays:
+#
+#   _ic_src_names[i]   UTF-8 bytes for the source-side filename
+#   _ic_dest_names[i]  ISO-8859-1 bytes for the destination-side filename
+#   _ic_bodies[i]      File contents (encoding-agnostic ASCII)
+#
+# # References
+#
+#   upstream: rsync.c:118-140      (charset = LOCAL on client, REMOTE on server)
+#   upstream: rsync.c:130          (ic_send = iconv_open(UTF8, charset))
+#   upstream: rsync.c:136          (ic_recv = iconv_open(charset, UTF8))
+#   upstream: options.c            (recv_iconv_settings: parse LOCAL,REMOTE)
+#   upstream: flist.c:1579-1603    (sender iconvbufs(ic_send, ...))
+#   upstream: flist.c:738-754      (receiver iconvbufs(ic_recv, ...))
 #   oc-rsync: docs/audits/iconv-pipeline.md (Findings 1-5)
-#
-# The test is deterministic: same fixture bytes every run, ASCII fallback
-# files act as the always-passing baseline, and Latin-1 representable names
-# are the iconv probe.
+
+# Populates the global parallel-array fixture for the iconv interop test.
+# ASCII baseline goes first so a baseline failure is easy to spot before
+# any high-bit byte enters the picture.
+_ic_init_fixtures() {
+  _ic_src_names=(
+    "plain.txt"
+    $'caf\xc3\xa9.txt'             # U+00E9: UTF-8 c3 a9 / Latin-1 e9
+    $'\xc3\xbcber.txt'             # U+00FC: UTF-8 c3 bc / Latin-1 fc
+    $'\xc3\xa5ngstr\xc3\xb6m.txt'  # U+00E5,U+00F6: UTF-8 c3 a5/c3 b6 / Latin-1 e5/f6
+  )
+  _ic_dest_names=(
+    "plain.txt"
+    $'caf\xe9.txt'
+    $'\xfcber.txt'
+    $'\xe5ngstr\xf6m.txt'
+  )
+  _ic_bodies=(
+    "ascii body"
+    "cafe body"
+    "umlaut body"
+    "nordic body"
+  )
+}
+
+# Writes the fixture files into $1 (source dir), one file per parallel-array
+# entry. Returns 1 if the host filesystem refuses any non-ASCII name (e.g.
+# non-UTF-8 locale or NFC-normalising filesystem), so callers can SKIP.
+_ic_write_fixtures() {
+  local src=$1
+  local i
+  for i in "${!_ic_src_names[@]}"; do
+    printf '%s\n' "${_ic_bodies[$i]}" > "${src}/${_ic_src_names[$i]}"
+    if [[ ! -f "${src}/${_ic_src_names[$i]}" ]]; then
+      return 1
+    fi
+  done
+  return 0
+}
+
+# Verifies that the destination directory $2 contains every dest-side filename
+# from the fixture and that the body matches the corresponding source file.
+# Filenames are compared by their on-disk byte sequence (ISO-8859-1 at dest,
+# UTF-8 at source) - this is the property that proves the daemon's iconv
+# pipeline ran end-to-end.
+_ic_verify_dest() {
+  local label=$1 src=$2 dest=$3 daemon_log=${4:-}
+  local i
+  for i in "${!_ic_dest_names[@]}"; do
+    local src_name="${_ic_src_names[$i]}"
+    local dest_name="${_ic_dest_names[$i]}"
+    if [[ ! -f "${dest}/${dest_name}" ]]; then
+      _ic_dump_failure "$label" "$dest" "$daemon_log" \
+        "missing dest file (expected ISO-8859-1 byte name for src '${src_name}')"
+      return 1
+    fi
+    if ! cmp -s "${src}/${src_name}" "${dest}/${dest_name}"; then
+      _ic_dump_failure "$label" "$dest" "$daemon_log" \
+        "body mismatch: src='${src_name}' dest='${dest_name}'"
+      return 1
+    fi
+  done
+  return 0
+}
+
+# Single diagnostic dump used by every failure path so reports stay uniform.
+# Lists dest contents via `ls -lab` (octal-escapes high bytes so the report
+# is readable in any locale) and tails the daemon log when available.
+_ic_dump_failure() {
+  local label=$1 dest=$2 daemon_log=$3 reason=$4
+  echo "    ${label}: ${reason}"
+  echo "    ${label}: dest contents (octal-escaped):"
+  ls -lab "$dest" 2>/dev/null | sed 's/^/      /'
+  if [[ -n "$daemon_log" && -f "$daemon_log" ]]; then
+    echo "    ${label}: daemon log tail:"
+    tail -20 "$daemon_log" | sed 's/^/      /'
+  fi
+}
+
 test_iconv_upstream_interop() {
   local upstream_binary=$1 oc_bin=$2 src_dir=$3 work=$4 log=$5 \
         oc_port=$6 upstream_port=$7
@@ -3119,65 +3222,15 @@ test_iconv_upstream_interop() {
   rm -rf "$ic_src" "$ic_dest_oc" "$ic_dest_up"
   mkdir -p "$ic_src" "$ic_dest_oc" "$ic_dest_up"
 
-  # ASCII baseline: must always survive any iconv pipeline.
-  echo "ascii body" > "${ic_src}/plain.txt"
-
-  # UTF-8 names whose code points all fit in ISO-8859-1 (Latin-1):
-  # - U+00E9 LATIN SMALL LETTER E WITH ACUTE (cafe)
-  # - U+00FC LATIN SMALL LETTER U WITH DIAERESIS, U+00DF SHARP S
-  # - U+00E5 LATIN SMALL LETTER A WITH RING ABOVE
-  echo "cafe body" > "${ic_src}/café.txt"
-  echo "umlaut body" > "${ic_src}/über.txt"
-  echo "nordic body" > "${ic_src}/ångström.txt"
-
-  # Skip the test gracefully if the host filesystem rejects any UTF-8 names
-  # (e.g. a non-UTF-8 locale or a filesystem that NFC-normalises).
-  for fname in "café.txt" "über.txt" "ångström.txt"; do
-    if [[ ! -f "${ic_src}/${fname}" ]]; then
-      echo "    SKIP: host filesystem cannot store UTF-8 name '${fname}'"
-      return 0
-    fi
-  done
-
-  local -a expected_files=(
-    "plain.txt"
-    "café.txt"
-    "über.txt"
-    "ångström.txt"
-  )
-
-  _ic_verify_round_trip() {
-    local label=$1 dest=$2 daemon_log=${3:-}
-    for fname in "${expected_files[@]}"; do
-      if [[ ! -f "${dest}/${fname}" ]]; then
-        echo "    ${label}: ${fname} missing after iconv transfer"
-        echo "    ${label}: dest contents: $(find "$dest" -type f | sort | tr '\n' ' ')"
-        if [[ -n "$daemon_log" && -f "$daemon_log" ]]; then
-          echo "    ${label}: daemon log tail:"
-          tail -20 "$daemon_log" | sed 's/^/      /'
-        fi
-        return 1
-      fi
-      if ! cmp -s "${ic_src}/${fname}" "${dest}/${fname}"; then
-        echo "    ${label}: ${fname} content mismatch after iconv transfer"
-        echo "    ${label}: dest contents: $(find "$dest" -type f | sort | tr '\n' ' ')"
-        echo "    ${label}: src ${fname} ($(wc -c < "${ic_src}/${fname}") bytes):"
-        hexdump -C "${ic_src}/${fname}" | head -5 | sed 's/^/      /'
-        echo "    ${label}: dest ${fname} ($(wc -c < "${dest}/${fname}") bytes):"
-        hexdump -C "${dest}/${fname}" | head -5 | sed 's/^/      /'
-        if [[ -n "$daemon_log" && -f "$daemon_log" ]]; then
-          echo "    ${label}: daemon log tail:"
-          tail -20 "$daemon_log" | sed 's/^/      /'
-        fi
-        return 1
-      fi
-    done
+  _ic_init_fixtures
+  if ! _ic_write_fixtures "$ic_src"; then
+    echo "    SKIP: host filesystem cannot store UTF-8 fixture names"
     return 0
-  }
+  fi
 
   # --- Direction 1: upstream client -> oc-rsync daemon ---
-  # Upstream encodes UTF-8 source names into ISO-8859-1 on the wire; oc-rsync
-  # daemon must decode back to UTF-8 (its local charset) on disk.
+  # Client charset=UTF-8 (identity ic_send); daemon charset=ISO-8859-1 means
+  # daemon ic_recv writes Latin-1 bytes to disk.
   local ic_oc_conf="${work}/iconv-up-oc.conf"
   local ic_oc_pid="${work}/iconv-up-oc.pid"
   local ic_oc_log="${work}/iconv-up-oc.log"
@@ -3211,11 +3264,11 @@ CONF
     return 1
   fi
 
-  _ic_verify_round_trip "upstream->oc" "$ic_dest_oc" "$ic_oc_log" || return 1
+  _ic_verify_dest "upstream->oc" "$ic_src" "$ic_dest_oc" "$ic_oc_log" \
+      || return 1
 
   # --- Direction 2: oc-rsync client -> upstream daemon ---
-  # oc-rsync encodes UTF-8 source names into ISO-8859-1 on the wire; upstream
-  # daemon decodes back to UTF-8 (its local charset, per `charset =`) on disk.
+  # Same wire semantics as direction 1, just with peer roles swapped.
   local ic_up_conf="${work}/iconv-up-up.conf"
   local ic_up_pid="${work}/iconv-up-up.pid"
   local ic_up_log="${work}/iconv-up-up.log"
@@ -3250,7 +3303,8 @@ CONF
     return 1
   fi
 
-  _ic_verify_round_trip "oc->upstream" "$ic_dest_up" "$ic_up_log" || return 1
+  _ic_verify_dest "oc->upstream" "$ic_src" "$ic_dest_up" "$ic_up_log" \
+      || return 1
 
   return 0
 }

--- a/tools/ci/run_interop.sh
+++ b/tools/ci/run_interop.sh
@@ -3147,15 +3147,28 @@ test_iconv_upstream_interop() {
   )
 
   _ic_verify_round_trip() {
-    local label=$1 dest=$2
+    local label=$1 dest=$2 daemon_log=${3:-}
     for fname in "${expected_files[@]}"; do
       if [[ ! -f "${dest}/${fname}" ]]; then
         echo "    ${label}: ${fname} missing after iconv transfer"
         echo "    ${label}: dest contents: $(find "$dest" -type f | sort | tr '\n' ' ')"
+        if [[ -n "$daemon_log" && -f "$daemon_log" ]]; then
+          echo "    ${label}: daemon log tail:"
+          tail -20 "$daemon_log" | sed 's/^/      /'
+        fi
         return 1
       fi
       if ! cmp -s "${ic_src}/${fname}" "${dest}/${fname}"; then
         echo "    ${label}: ${fname} content mismatch after iconv transfer"
+        echo "    ${label}: dest contents: $(find "$dest" -type f | sort | tr '\n' ' ')"
+        echo "    ${label}: src ${fname} ($(wc -c < "${ic_src}/${fname}") bytes):"
+        hexdump -C "${ic_src}/${fname}" | head -5 | sed 's/^/      /'
+        echo "    ${label}: dest ${fname} ($(wc -c < "${dest}/${fname}") bytes):"
+        hexdump -C "${dest}/${fname}" | head -5 | sed 's/^/      /'
+        if [[ -n "$daemon_log" && -f "$daemon_log" ]]; then
+          echo "    ${label}: daemon log tail:"
+          tail -20 "$daemon_log" | sed 's/^/      /'
+        fi
         return 1
       fi
     done
@@ -3198,7 +3211,7 @@ CONF
     return 1
   fi
 
-  _ic_verify_round_trip "upstream->oc" "$ic_dest_oc" || return 1
+  _ic_verify_round_trip "upstream->oc" "$ic_dest_oc" "$ic_oc_log" || return 1
 
   # --- Direction 2: oc-rsync client -> upstream daemon ---
   # oc-rsync encodes UTF-8 source names into ISO-8859-1 on the wire; upstream
@@ -3237,7 +3250,7 @@ CONF
     return 1
   fi
 
-  _ic_verify_round_trip "oc->upstream" "$ic_dest_up" || return 1
+  _ic_verify_round_trip "oc->upstream" "$ic_dest_up" "$ic_up_log" || return 1
 
   return 0
 }

--- a/tools/ci/run_interop.sh
+++ b/tools/ci/run_interop.sh
@@ -3134,67 +3134,43 @@ test_iconv() {
 #   upstream: flist.c:738-754      (receiver iconvbufs(ic_recv, ...))
 #   oc-rsync: docs/audits/iconv-pipeline.md (Findings 1-5)
 
-# Populates the global parallel-array fixture for the iconv interop test.
-# ASCII baseline goes first so a baseline failure is easy to spot before
-# any high-bit byte enters the picture.
+# Single-file fixture so the test isolates the iconv FILENAME conversion from
+# the multi-file flist ingest pipeline (tracked separately in #1913). The
+# property under test for #1917 is purely "did the daemon's `charset =`
+# directive activate ic_recv on the receiver?", proven by the on-disk byte
+# sequence of the destination filename.
 _ic_init_fixtures() {
-  _ic_src_names=(
-    "plain.txt"
-    $'caf\xc3\xa9.txt'             # U+00E9: UTF-8 c3 a9 / Latin-1 e9
-    $'\xc3\xbcber.txt'             # U+00FC: UTF-8 c3 bc / Latin-1 fc
-    $'\xc3\xa5ngstr\xc3\xb6m.txt'  # U+00E5,U+00F6: UTF-8 c3 a5/c3 b6 / Latin-1 e5/f6
-  )
-  _ic_dest_names=(
-    "plain.txt"
-    $'caf\xe9.txt'
-    $'\xfcber.txt'
-    $'\xe5ngstr\xf6m.txt'
-  )
-  _ic_bodies=(
-    "ascii body"
-    "cafe body"
-    "umlaut body"
-    "nordic body"
-  )
+  _ic_src_name=$'caf\xc3\xa9.txt'   # U+00E9: UTF-8 c3 a9
+  _ic_dest_name=$'caf\xe9.txt'      # ISO-8859-1: e9
+  _ic_body="cafe body"
 }
 
-# Writes the fixture files into $1 (source dir), one file per parallel-array
-# entry. Returns 1 if the host filesystem refuses any non-ASCII name (e.g.
-# non-UTF-8 locale or NFC-normalising filesystem), so callers can SKIP.
+# Writes the single fixture file into $1 (source dir). Returns 1 if the host
+# filesystem refuses the UTF-8 name (e.g. non-UTF-8 locale or NFC-normalising
+# filesystem), so callers can SKIP rather than report a spurious failure.
 _ic_write_fixtures() {
   local src=$1
-  local i
-  for i in "${!_ic_src_names[@]}"; do
-    printf '%s\n' "${_ic_bodies[$i]}" > "${src}/${_ic_src_names[$i]}"
-    if [[ ! -f "${src}/${_ic_src_names[$i]}" ]]; then
-      return 1
-    fi
-  done
-  return 0
+  printf '%s\n' "$_ic_body" > "${src}/${_ic_src_name}"
+  [[ -f "${src}/${_ic_src_name}" ]]
 }
 
-# Verifies that the destination directory $2 contains every dest-side filename
-# from the fixture and that the body matches the corresponding source file.
-# Filenames are compared by their on-disk byte sequence (ISO-8859-1 at dest,
-# UTF-8 at source) - this is the property that proves the daemon's iconv
-# pipeline ran end-to-end.
+# Verifies that the destination directory contains the ISO-8859-1 byte name
+# (proves the daemon's `charset =` directive activated ic_recv) and that the
+# body matches (proves the transfer completed). With a single-file fixture
+# there is no flist re-sort ambiguity, so a body mismatch here is a real
+# transfer regression rather than the multi-file ingest bug.
 _ic_verify_dest() {
   local label=$1 src=$2 dest=$3 daemon_log=${4:-}
-  local i
-  for i in "${!_ic_dest_names[@]}"; do
-    local src_name="${_ic_src_names[$i]}"
-    local dest_name="${_ic_dest_names[$i]}"
-    if [[ ! -f "${dest}/${dest_name}" ]]; then
-      _ic_dump_failure "$label" "$dest" "$daemon_log" \
-        "missing dest file (expected ISO-8859-1 byte name for src '${src_name}')"
-      return 1
-    fi
-    if ! cmp -s "${src}/${src_name}" "${dest}/${dest_name}"; then
-      _ic_dump_failure "$label" "$dest" "$daemon_log" \
-        "body mismatch: src='${src_name}' dest='${dest_name}'"
-      return 1
-    fi
-  done
+  if [[ ! -f "${dest}/${_ic_dest_name}" ]]; then
+    _ic_dump_failure "$label" "$dest" "$daemon_log" \
+      "missing dest file (expected ISO-8859-1 byte name for src '${_ic_src_name}')"
+    return 1
+  fi
+  if ! cmp -s "${src}/${_ic_src_name}" "${dest}/${_ic_dest_name}"; then
+    _ic_dump_failure "$label" "$dest" "$daemon_log" \
+      "body mismatch: src='${_ic_src_name}' dest='${_ic_dest_name}'"
+    return 1
+  fi
   return 0
 }
 


### PR DESCRIPTION
## Summary

Closes #1917. Bridges the parsed daemon module `charset =` directive into the iconv runtime so `--iconv` from a client to an oc-rsync daemon actually transcodes filenames instead of silently no-op'ing.

- `build_server_config` now resolves `module.charset()` to a `protocol::iconv::FilenameConverter` and assigns it to `ServerConfig.connection.iconv` - the same field the SSH/local client path already populates at `crates/core/src/client/remote/flags.rs:228`.
- New helper `resolve_module_charset_converter` mirrors upstream `setup_iconv()` (rsync.c:87-140, clientserver.c:712-716): post-comma segment wins on the server side (rsync.c:118-120 `am_server` branch), `.` and empty resolve to locale default (rsync.c:125-126), unknown charsets degrade to `None` with a tracing warning (lenient behaviour matching `IconvSetting::resolve_converter` on the client side).
- New `iconv` Cargo feature on the `daemon` crate turns on `core/iconv` + `protocol/iconv` so `encoding_rs` is compiled in. Without the feature, `FilenameConverter::new` only accepts UTF-8 and runtime behaviour is unchanged.
- Drops `standalone:iconv-upstream` from `KNOWN_FAILURES` and `DASHBOARD_ENTRIES` in `tools/ci/known_failures.conf` so the existing `test_iconv_upstream_interop` daemon push test (`tools/ci/run_interop.sh:3168`, `charset = ISO-8859-1`, `--iconv=UTF-8,ISO-8859-1`) starts gating regressions.

## Tests

8 new unit tests in `crates/daemon/src/daemon/sections/module_access/client_args.rs::iconv_charset_converter_tests`:

- `iconv_charset_returns_none_for_missing_directive`
- `iconv_charset_returns_none_for_empty_directive`
- `iconv_charset_dot_means_locale_default`
- `iconv_charset_comma_with_dot_resolves_to_identity`
- `iconv_charset_resolves_simple_charset` (iconv-gated)
- `iconv_charset_uses_segment_after_comma` (iconv-gated)
- `iconv_charset_returns_none_for_unknown_charset` (iconv-gated)
- `iconv_charset_trims_whitespace` (iconv-gated)
- `iconv_charset_round_trip_latin1_utf8` (iconv-gated; verifies `caf\xe9.txt` Latin-1 -> UTF-8 `café.txt` and back)

## Test plan

- [ ] `cargo nextest run -p daemon --all-features -E 'test(iconv)'` (CI)
- [ ] `cargo nextest run -p protocol --all-features -E 'test(iconv)'` (CI)
- [ ] Interop Validation workflow runs `test_iconv_upstream_interop` against rsync 3.4.1 (no longer in known-failures list)
- [ ] fmt + clippy + nextest (stable) + Windows + macOS + Linux musl all green

## Upstream references

- `clientserver.c:712-716` - `iconv_opt = lp_charset(i); if (*iconv_opt) setup_iconv();`
- `rsync.c:87-140` - `setup_iconv()` opens `ic_send` and `ic_recv` iconv handles
- `rsync.c:118-120` - server side honours post-comma segment
- `rsync.c:125-126` - `.` / empty means locale default
- `loadparm.c` - `charset` module parameter