### PR TITLE
feat(apple-fs): implement AppleDouble + resource-fork support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,7 +120,9 @@ version = "0.6.0"
 dependencies = [
  "libc",
  "nix",
+ "tempfile",
  "unicode-normalization",
+ "xattr",
 ]
 
 [[package]]

--- a/crates/apple-fs/Cargo.toml
+++ b/crates/apple-fs/Cargo.toml
@@ -12,3 +12,10 @@ nix = { version = "0.29", default-features = false, features = ["fs"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 unicode-normalization = "0.1"
+# Safe wrapper for getxattr(2)/setxattr(2). Used to access the macOS-native
+# `com.apple.ResourceFork` and `com.apple.FinderInfo` extended attributes
+# without introducing unsafe FFI inside this crate (per workspace policy).
+xattr = "1.6"
+
+[dev-dependencies]
+tempfile = "3.15"

--- a/crates/apple-fs/README.md
+++ b/crates/apple-fs/README.md
@@ -1,16 +1,49 @@
 # apple-fs
 
-Utilities that provide the small set of filesystem primitives required by
-`oc-rsync` when interacting with Apple platforms.
+Filesystem primitives that `oc-rsync` needs in order to interact with Apple
+platforms and with cross-platform formats originated by them.
 
-The upstream `rsync` implementation relies on the `mkfifo(3)` and `mknod(2)`
-syscalls when creating named pipes or other special files while synchronising
-directories.  The Rust standard library does not expose safe wrappers for these
-operations, so this crate offers minimal bindings that mirror the behaviour of
-the C routines while integrating with the rest of the Rust-based
-implementation.
+## Surface
 
-The public API intentionally remains tiny.  Consumers should prefer the higher
-level abstractions in `core` wherever possible and use these helpers only
-when direct access to the underlying syscalls is required.
+- `mkfifo` / `mknod` (Unix-only): safe wrappers around `mkfifo(3)` and
+  `mknod(2)` used by the receiver when materialising FIFOs and device nodes.
+  Mirror upstream rsync's `syscall.c:do_mknod`.
+- `normalize_filename` (macOS-only NFC pass; identity stub elsewhere): used
+  by the receiver and the local-copy delete pass to compare filenames between
+  HFS+/APFS (NFD) and the rest of the world (NFC).
+- `is_apple_double_name` / `apple_double_companion` (cross-platform): lexical
+  helpers that pair a regular file `foo` with its AppleDouble sidecar `._foo`
+  in either direction. Useful both as a filter primitive and as a building
+  block for AppleDouble-aware tooling.
+- `apple_double` module: a self-contained AppleDouble v2 (RFC 1740) parser
+  and encoder. Pure-data, no FFI. Lets callers inspect or synthesise
+  `._foo` containers in audit harnesses, tests, and any future merge
+  implementation.
+- `resource_fork` module: safe accessors for `com.apple.ResourceFork` and
+  `com.apple.FinderInfo`. On macOS they delegate to the third-party `xattr`
+  crate (the same safe wrapper used by `crates/metadata`); on every other
+  target every accessor is a no-op stub that returns `Ok(None)` / `Ok(())`.
 
+## Unsafe-code policy
+
+The crate keeps `#![deny(unsafe_code)]`. macOS xattr syscalls (`getxattr(2)`,
+`setxattr(2)`, `removexattr(2)`) are reached through the pre-vetted `xattr`
+crate, which contains the only `unsafe` blocks involved. Per the workspace
+unsafe-code policy, no FFI is added directly inside `apple-fs`.
+
+## Integration with the transfer pipeline
+
+End-to-end transfer of `com.apple.ResourceFork` / `com.apple.FinderInfo`
+already happens via `metadata::xattr` and `protocol::xattr::wire`; see
+`docs/audits/apple-fs-roundtrip.md` for the full audit. The accessors in
+this crate are intentionally orthogonal to that pipeline and are intended
+for tooling, audits, and any future opt-in AppleDouble merge feature
+(audit follow-up F-2).
+
+## References
+
+- RFC 1740: "MIME Encapsulation of Macintosh Files - MacMIME", section 5
+  (AppleDouble container layout).
+- Apple Technical Note TN1188: "AppleSingle/AppleDouble Formats".
+- Upstream rsync 3.4.1 `xattrs.c` - reads `com.apple.*` xattrs through the
+  generic `getxattr` / `setxattr` path with no Mac-specific code.

--- a/crates/apple-fs/src/apple_double.rs
+++ b/crates/apple-fs/src/apple_double.rs
@@ -1,0 +1,462 @@
+//! AppleDouble v2 (RFC 1740) container parser and encoder.
+//!
+//! AppleDouble is the on-disk format used by macOS to store the resource
+//! fork, Finder info, and other Mac-specific metadata when writing to a
+//! filesystem that does not natively support extended attributes (SMB, FAT,
+//! some NFS exports, older Linux NFS clients). Each metadata-bearing file
+//! `foo` is paired with a sidecar named `._foo` containing an AppleDouble v2
+//! header followed by one or more entry payloads.
+//!
+//! This module implements only the container format. It does not decide
+//! whether or how to merge sidecar payloads back into a destination file's
+//! native extended attributes - that is an interoperability policy decision
+//! that lives in the transfer pipeline (see `docs/audits/apple-fs-roundtrip.md`,
+//! finding F-2). The pure-data parser and encoder here are intended for
+//! inspection tools, audit harnesses, and any future merge implementation.
+//!
+//! # Wire layout (RFC 1740 section 5)
+//!
+//! ```text
+//! offset  size  field
+//! 0       4     magic number (big-endian, 0x00051607 for AppleDouble)
+//! 4       4     version number (big-endian, 0x00020000 for v2)
+//! 8       16    filler (zero)
+//! 24      2     number of entries (big-endian)
+//! 26      N*12  entry descriptors:
+//!                 +0  4  entry id (big-endian)
+//!                 +4  4  payload offset from start of file (big-endian)
+//!                 +8  4  payload length (big-endian)
+//! ```
+//!
+//! Entry payloads follow the descriptor table. Their order is unspecified by
+//! the RFC; this encoder writes them in entry-id order for determinism.
+//!
+//! # References
+//!
+//! - RFC 1740: "MIME Encapsulation of Macintosh Files - MacMIME", section 5.
+//! - Apple Technical Note TN1188: "AppleSingle/AppleDouble Formats".
+
+use std::io;
+
+/// Magic number identifying an AppleDouble v2 container.
+pub const APPLE_DOUBLE_MAGIC: u32 = 0x0005_1607;
+
+/// Magic number identifying an AppleSingle v2 container.
+///
+/// Provided for completeness: `oc-rsync` only emits AppleDouble, but parsers
+/// in the wild may receive either form.
+pub const APPLE_SINGLE_MAGIC: u32 = 0x0005_1600;
+
+/// Version number for AppleDouble / AppleSingle v2.
+pub const APPLE_DOUBLE_VERSION_2: u32 = 0x0002_0000;
+
+/// Size of the fixed-length header (magic + version + filler + entry count).
+pub const HEADER_SIZE: usize = 26;
+
+/// Size of one entry descriptor (id + offset + length).
+pub const ENTRY_DESCRIPTOR_SIZE: usize = 12;
+
+/// Standard AppleDouble entry identifiers (RFC 1740 section 5.1).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(u32)]
+#[allow(missing_docs)]
+pub enum EntryId {
+    DataFork = 1,
+    ResourceFork = 2,
+    RealName = 3,
+    Comment = 4,
+    IconBw = 5,
+    IconColor = 6,
+    FileDatesInfo = 8,
+    FinderInfo = 9,
+    MacFileInfo = 10,
+    ProDosFileInfo = 11,
+    MsDosFileInfo = 12,
+    ShortName = 13,
+    AfpFileInfo = 14,
+    DirectoryId = 15,
+}
+
+impl EntryId {
+    /// Returns the well-known [`EntryId`] for the given numeric identifier,
+    /// or `None` for vendor-specific or reserved values.
+    pub fn from_u32(value: u32) -> Option<Self> {
+        Some(match value {
+            1 => Self::DataFork,
+            2 => Self::ResourceFork,
+            3 => Self::RealName,
+            4 => Self::Comment,
+            5 => Self::IconBw,
+            6 => Self::IconColor,
+            8 => Self::FileDatesInfo,
+            9 => Self::FinderInfo,
+            10 => Self::MacFileInfo,
+            11 => Self::ProDosFileInfo,
+            12 => Self::MsDosFileInfo,
+            13 => Self::ShortName,
+            14 => Self::AfpFileInfo,
+            15 => Self::DirectoryId,
+            _ => return None,
+        })
+    }
+}
+
+/// One AppleDouble entry: a typed payload with a stable identifier.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Entry {
+    /// Numeric identifier. Use [`EntryId`] for the standard values.
+    pub id: u32,
+    /// Raw payload bytes for this entry.
+    pub data: Vec<u8>,
+}
+
+impl Entry {
+    /// Constructs an entry from a well-known [`EntryId`] and payload.
+    pub fn new(id: EntryId, data: Vec<u8>) -> Self {
+        Self {
+            id: id as u32,
+            data,
+        }
+    }
+
+    /// Constructs an entry from a raw numeric identifier and payload.
+    ///
+    /// Use this for vendor-specific or reserved IDs that are not part of
+    /// [`EntryId`].
+    pub fn from_raw(id: u32, data: Vec<u8>) -> Self {
+        Self { id, data }
+    }
+
+    /// Returns the well-known [`EntryId`] for this entry, when applicable.
+    pub fn standard_id(&self) -> Option<EntryId> {
+        EntryId::from_u32(self.id)
+    }
+}
+
+/// A decoded AppleDouble v2 container.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct AppleDouble {
+    /// Entries in encounter order. The container preserves insertion order
+    /// when round-tripping, but sorts by `id` when [`encode`](Self::encode) is
+    /// called for byte-stable output.
+    pub entries: Vec<Entry>,
+}
+
+impl AppleDouble {
+    /// Constructs an empty container.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Returns the first entry with the given identifier, if present.
+    pub fn entry(&self, id: EntryId) -> Option<&Entry> {
+        let raw = id as u32;
+        self.entries.iter().find(|entry| entry.id == raw)
+    }
+
+    /// Returns the resource-fork payload, if present.
+    pub fn resource_fork(&self) -> Option<&[u8]> {
+        self.entry(EntryId::ResourceFork).map(|e| e.data.as_slice())
+    }
+
+    /// Returns the Finder-info payload, if present.
+    ///
+    /// Finder info is canonically 32 bytes. The accessor returns the raw
+    /// payload regardless of length so callers can validate as appropriate.
+    pub fn finder_info(&self) -> Option<&[u8]> {
+        self.entry(EntryId::FinderInfo).map(|e| e.data.as_slice())
+    }
+
+    /// Adds or replaces the entry with the given identifier.
+    pub fn set_entry(&mut self, id: EntryId, data: Vec<u8>) {
+        let raw = id as u32;
+        if let Some(slot) = self.entries.iter_mut().find(|entry| entry.id == raw) {
+            slot.data = data;
+        } else {
+            self.entries.push(Entry::new(id, data));
+        }
+    }
+
+    /// Decodes an AppleDouble or AppleSingle v2 byte stream.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`io::Error`] of kind [`io::ErrorKind::InvalidData`] when:
+    /// - the input is shorter than the fixed header,
+    /// - the magic number does not match either container variant,
+    /// - the version is not 0x00020000,
+    /// - the entry-descriptor table is truncated, or
+    /// - an entry's declared offset/length exceeds the input length.
+    pub fn decode(input: &[u8]) -> io::Result<Self> {
+        if input.len() < HEADER_SIZE {
+            return Err(invalid("AppleDouble header truncated"));
+        }
+        let magic = read_u32(&input[0..4]);
+        if magic != APPLE_DOUBLE_MAGIC && magic != APPLE_SINGLE_MAGIC {
+            return Err(invalid("AppleDouble magic number mismatch"));
+        }
+        let version = read_u32(&input[4..8]);
+        if version != APPLE_DOUBLE_VERSION_2 {
+            return Err(invalid("AppleDouble version is not 2"));
+        }
+        // Bytes 8..24 are the filler; the spec says callers must ignore them.
+        let entry_count = u16::from_be_bytes([input[24], input[25]]) as usize;
+        let descriptors_end = HEADER_SIZE
+            .checked_add(
+                entry_count
+                    .checked_mul(ENTRY_DESCRIPTOR_SIZE)
+                    .ok_or_else(|| invalid("AppleDouble descriptor table size overflows"))?,
+            )
+            .ok_or_else(|| invalid("AppleDouble descriptor table size overflows"))?;
+        if input.len() < descriptors_end {
+            return Err(invalid("AppleDouble descriptor table truncated"));
+        }
+
+        let mut entries = Vec::with_capacity(entry_count);
+        for index in 0..entry_count {
+            let base = HEADER_SIZE + index * ENTRY_DESCRIPTOR_SIZE;
+            let id = read_u32(&input[base..base + 4]);
+            let offset = read_u32(&input[base + 4..base + 8]) as usize;
+            let length = read_u32(&input[base + 8..base + 12]) as usize;
+            let end = offset
+                .checked_add(length)
+                .ok_or_else(|| invalid("AppleDouble entry offset+length overflows"))?;
+            if end > input.len() {
+                return Err(invalid("AppleDouble entry payload extends past input"));
+            }
+            entries.push(Entry::from_raw(id, input[offset..end].to_vec()));
+        }
+        Ok(Self { entries })
+    }
+
+    /// Encodes the container into an AppleDouble v2 byte stream.
+    ///
+    /// Entries are written in ascending identifier order so that two
+    /// containers with the same logical content always produce identical
+    /// bytes. Payloads are laid out contiguously after the descriptor table.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`io::Error`] of kind [`io::ErrorKind::InvalidData`] when
+    /// the encoded layout would exceed `u32::MAX` bytes (the wire-format
+    /// width of `offset` and `length`) or contain more than `u16::MAX` entries.
+    pub fn encode(&self) -> io::Result<Vec<u8>> {
+        if self.entries.len() > u16::MAX as usize {
+            return Err(invalid("AppleDouble container has too many entries"));
+        }
+
+        // Sort a copy by id for byte-stable output without mutating the caller.
+        let mut ordered: Vec<&Entry> = self.entries.iter().collect();
+        ordered.sort_by_key(|entry| entry.id);
+
+        let entry_count = ordered.len();
+        let descriptors_end = HEADER_SIZE + entry_count * ENTRY_DESCRIPTOR_SIZE;
+        let total: usize = ordered.iter().map(|entry| entry.data.len()).sum();
+        let total_len = descriptors_end
+            .checked_add(total)
+            .ok_or_else(|| invalid("AppleDouble container size overflows"))?;
+        if total_len > u32::MAX as usize {
+            return Err(invalid("AppleDouble container size exceeds u32 range"));
+        }
+
+        let mut out = Vec::with_capacity(total_len);
+        out.extend_from_slice(&APPLE_DOUBLE_MAGIC.to_be_bytes());
+        out.extend_from_slice(&APPLE_DOUBLE_VERSION_2.to_be_bytes());
+        out.extend_from_slice(&[0u8; 16]); // filler
+        out.extend_from_slice(&(entry_count as u16).to_be_bytes());
+
+        let mut payload_offset = descriptors_end as u32;
+        for entry in &ordered {
+            let length = u32::try_from(entry.data.len())
+                .map_err(|_| invalid("AppleDouble entry payload exceeds u32 range"))?;
+            out.extend_from_slice(&entry.id.to_be_bytes());
+            out.extend_from_slice(&payload_offset.to_be_bytes());
+            out.extend_from_slice(&length.to_be_bytes());
+            payload_offset = payload_offset
+                .checked_add(length)
+                .ok_or_else(|| invalid("AppleDouble payload offset overflows"))?;
+        }
+        for entry in &ordered {
+            out.extend_from_slice(&entry.data);
+        }
+        Ok(out)
+    }
+}
+
+fn read_u32(bytes: &[u8]) -> u32 {
+    u32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]])
+}
+
+fn invalid(message: &'static str) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, message)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_finder_info() -> Vec<u8> {
+        // 32-byte canonical FinderInfo: file type "TEXT", creator "ttxt".
+        let mut info = vec![0u8; 32];
+        info[0..4].copy_from_slice(b"TEXT");
+        info[4..8].copy_from_slice(b"ttxt");
+        info
+    }
+
+    fn sample_resource_fork() -> Vec<u8> {
+        // A trivial empty resource map - 256 bytes is enough for shape tests.
+        (0..256u16).map(|i| (i & 0xff) as u8).collect()
+    }
+
+    #[test]
+    fn round_trip_finder_info_only() {
+        let mut container = AppleDouble::new();
+        container.set_entry(EntryId::FinderInfo, sample_finder_info());
+
+        let encoded = container.encode().expect("encode");
+        let decoded = AppleDouble::decode(&encoded).expect("decode");
+        assert_eq!(decoded, container);
+        assert_eq!(decoded.finder_info().unwrap().len(), 32);
+    }
+
+    #[test]
+    fn round_trip_resource_fork_and_finder_info() {
+        let mut container = AppleDouble::new();
+        container.set_entry(EntryId::ResourceFork, sample_resource_fork());
+        container.set_entry(EntryId::FinderInfo, sample_finder_info());
+
+        let encoded = container.encode().expect("encode");
+        let decoded = AppleDouble::decode(&encoded).expect("decode");
+        assert_eq!(
+            decoded.resource_fork().unwrap(),
+            &sample_resource_fork()[..]
+        );
+        assert_eq!(decoded.finder_info().unwrap(), &sample_finder_info()[..]);
+    }
+
+    #[test]
+    fn header_layout_is_stable() {
+        let mut container = AppleDouble::new();
+        container.set_entry(EntryId::FinderInfo, sample_finder_info());
+        let encoded = container.encode().expect("encode");
+        assert_eq!(read_u32(&encoded[0..4]), APPLE_DOUBLE_MAGIC);
+        assert_eq!(read_u32(&encoded[4..8]), APPLE_DOUBLE_VERSION_2);
+        assert_eq!(&encoded[8..24], &[0u8; 16]);
+        assert_eq!(u16::from_be_bytes([encoded[24], encoded[25]]), 1);
+    }
+
+    #[test]
+    fn encode_orders_entries_by_id() {
+        let mut container = AppleDouble::new();
+        container.set_entry(EntryId::FinderInfo, sample_finder_info()); // id 9
+        container.set_entry(EntryId::ResourceFork, sample_resource_fork()); // id 2
+
+        let encoded = container.encode().expect("encode");
+        // First descriptor's id field starts at HEADER_SIZE.
+        let first_id = read_u32(&encoded[HEADER_SIZE..HEADER_SIZE + 4]);
+        assert_eq!(first_id, EntryId::ResourceFork as u32);
+        let second_id = read_u32(
+            &encoded[HEADER_SIZE + ENTRY_DESCRIPTOR_SIZE..HEADER_SIZE + ENTRY_DESCRIPTOR_SIZE + 4],
+        );
+        assert_eq!(second_id, EntryId::FinderInfo as u32);
+    }
+
+    #[test]
+    fn set_entry_replaces_existing() {
+        let mut container = AppleDouble::new();
+        container.set_entry(EntryId::FinderInfo, vec![1; 32]);
+        container.set_entry(EntryId::FinderInfo, vec![2; 32]);
+        assert_eq!(container.entries.len(), 1);
+        assert_eq!(container.finder_info().unwrap(), &[2; 32][..]);
+    }
+
+    #[test]
+    fn decode_rejects_short_input() {
+        let err = AppleDouble::decode(&[0u8; 8]).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn decode_rejects_bad_magic() {
+        let mut bytes = vec![0u8; HEADER_SIZE];
+        bytes[0..4].copy_from_slice(&0xdead_beef_u32.to_be_bytes());
+        bytes[4..8].copy_from_slice(&APPLE_DOUBLE_VERSION_2.to_be_bytes());
+        let err = AppleDouble::decode(&bytes).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn decode_rejects_bad_version() {
+        let mut bytes = vec![0u8; HEADER_SIZE];
+        bytes[0..4].copy_from_slice(&APPLE_DOUBLE_MAGIC.to_be_bytes());
+        bytes[4..8].copy_from_slice(&0x0001_0000_u32.to_be_bytes());
+        let err = AppleDouble::decode(&bytes).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn decode_rejects_truncated_descriptor_table() {
+        let mut bytes = vec![0u8; HEADER_SIZE];
+        bytes[0..4].copy_from_slice(&APPLE_DOUBLE_MAGIC.to_be_bytes());
+        bytes[4..8].copy_from_slice(&APPLE_DOUBLE_VERSION_2.to_be_bytes());
+        // Claim 2 descriptors but provide none of their bytes.
+        bytes[24..26].copy_from_slice(&2u16.to_be_bytes());
+        let err = AppleDouble::decode(&bytes).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn decode_rejects_payload_past_end() {
+        let mut bytes = vec![0u8; HEADER_SIZE + ENTRY_DESCRIPTOR_SIZE];
+        bytes[0..4].copy_from_slice(&APPLE_DOUBLE_MAGIC.to_be_bytes());
+        bytes[4..8].copy_from_slice(&APPLE_DOUBLE_VERSION_2.to_be_bytes());
+        bytes[24..26].copy_from_slice(&1u16.to_be_bytes());
+        // Descriptor: id=9, offset=HEADER_SIZE+ENTRY_DESCRIPTOR_SIZE, length=999.
+        bytes[26..30].copy_from_slice(&9u32.to_be_bytes());
+        bytes[30..34]
+            .copy_from_slice(&((HEADER_SIZE + ENTRY_DESCRIPTOR_SIZE) as u32).to_be_bytes());
+        bytes[34..38].copy_from_slice(&999u32.to_be_bytes());
+        let err = AppleDouble::decode(&bytes).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn entry_id_round_trip_for_known_values() {
+        for id in [
+            EntryId::DataFork,
+            EntryId::ResourceFork,
+            EntryId::RealName,
+            EntryId::Comment,
+            EntryId::IconBw,
+            EntryId::IconColor,
+            EntryId::FileDatesInfo,
+            EntryId::FinderInfo,
+            EntryId::MacFileInfo,
+            EntryId::ProDosFileInfo,
+            EntryId::MsDosFileInfo,
+            EntryId::ShortName,
+            EntryId::AfpFileInfo,
+            EntryId::DirectoryId,
+        ] {
+            let raw = id as u32;
+            assert_eq!(EntryId::from_u32(raw), Some(id));
+        }
+    }
+
+    #[test]
+    fn entry_id_unknown_returns_none() {
+        assert_eq!(EntryId::from_u32(0), None);
+        assert_eq!(EntryId::from_u32(7), None);
+        assert_eq!(EntryId::from_u32(99), None);
+    }
+
+    #[test]
+    fn apple_single_magic_is_accepted_by_decoder() {
+        let mut bytes = vec![0u8; HEADER_SIZE];
+        bytes[0..4].copy_from_slice(&APPLE_SINGLE_MAGIC.to_be_bytes());
+        bytes[4..8].copy_from_slice(&APPLE_DOUBLE_VERSION_2.to_be_bytes());
+        // zero entries
+        let decoded = AppleDouble::decode(&bytes).expect("decode applesingle");
+        assert!(decoded.entries.is_empty());
+    }
+}

--- a/crates/apple-fs/src/lib.rs
+++ b/crates/apple-fs/src/lib.rs
@@ -5,8 +5,25 @@
 #![deny(clippy::undocumented_unsafe_blocks)]
 #![doc = include_str!("../README.md")]
 
+use std::ffi::OsStr;
 use std::io;
-use std::path::Path;
+use std::path::{Path, PathBuf};
+
+pub mod apple_double;
+pub mod resource_fork;
+
+pub use resource_fork::{
+    FINDER_INFO_LEN, FINDER_INFO_XATTR, RESOURCE_FORK_XATTR, read_finder_info, read_resource_fork,
+    remove_finder_info, remove_resource_fork, write_finder_info, write_resource_fork,
+};
+
+/// Filename prefix used for AppleDouble (`._foo`) sidecar files.
+///
+/// macOS prefixes the partner file's name with `._` when it has to write
+/// resource-fork or Finder metadata onto a filesystem that does not support
+/// extended attributes natively (FAT, SMB, some NFS exports). The prefix is
+/// the same on every platform that produces or consumes AppleDouble streams.
+pub const APPLE_DOUBLE_PREFIX: &str = "._";
 
 #[cfg(not(unix))]
 type ModeType = libc::c_uint;
@@ -180,6 +197,76 @@ pub fn normalize_filename(name: &std::ffi::OsStr) -> std::ffi::OsString {
     name.to_os_string()
 }
 
+/// Returns `true` when `name` looks like an AppleDouble (`._foo`) sidecar.
+///
+/// The check is purely lexical and applies to every platform: the same
+/// pattern is used for filtering on the sender side, for sibling-pairing on
+/// the receiver side, and for downstream tooling. The `._` itself - i.e. an
+/// empty payload after the prefix - is not considered an AppleDouble file
+/// because no real partner exists.
+///
+/// # Examples
+///
+/// ```
+/// use std::ffi::OsStr;
+/// use apple_fs::is_apple_double_name;
+///
+/// assert!(is_apple_double_name(OsStr::new("._Info.plist")));
+/// assert!(!is_apple_double_name(OsStr::new("Info.plist")));
+/// assert!(!is_apple_double_name(OsStr::new("._")));
+/// ```
+pub fn is_apple_double_name(name: &OsStr) -> bool {
+    name.to_str()
+        .map(|s| s.len() > APPLE_DOUBLE_PREFIX.len() && s.starts_with(APPLE_DOUBLE_PREFIX))
+        .unwrap_or(false)
+}
+
+/// Returns the AppleDouble companion path for `path`.
+///
+/// - For a regular file `dir/foo`, returns `Some(dir/._foo)`.
+/// - For an AppleDouble sidecar `dir/._foo`, returns `Some(dir/foo)` (the
+///   data fork it pairs with).
+/// - Returns `None` for paths whose final component is empty, is `.`, is
+///   `..`, or whose name cannot be encoded as UTF-8.
+///
+/// The returned path is purely lexical - the filesystem is not consulted -
+/// so the helper is safe to call on either platform regardless of whether
+/// the partner file actually exists.
+///
+/// # Examples
+///
+/// ```
+/// use std::path::{Path, PathBuf};
+/// use apple_fs::apple_double_companion;
+///
+/// assert_eq!(
+///     apple_double_companion(Path::new("dir/Info.plist")),
+///     Some(PathBuf::from("dir/._Info.plist")),
+/// );
+/// assert_eq!(
+///     apple_double_companion(Path::new("dir/._Info.plist")),
+///     Some(PathBuf::from("dir/Info.plist")),
+/// );
+/// ```
+pub fn apple_double_companion(path: &Path) -> Option<PathBuf> {
+    let file_name = path.file_name()?;
+    let name_str = file_name.to_str()?;
+    if name_str.is_empty() {
+        return None;
+    }
+    let companion_name = if let Some(stripped) = name_str.strip_prefix(APPLE_DOUBLE_PREFIX) {
+        if stripped.is_empty() {
+            return None;
+        }
+        stripped.to_string()
+    } else {
+        format!("{APPLE_DOUBLE_PREFIX}{name_str}")
+    };
+    let mut companion = path.to_path_buf();
+    companion.set_file_name(companion_name);
+    Some(companion)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -272,5 +359,64 @@ mod tests {
         let nfc = std::ffi::OsStr::new("\u{00fc}ber");
         let result = normalize_filename(nfd);
         assert_eq!(result, nfc);
+    }
+
+    #[test]
+    fn is_apple_double_name_detects_prefix() {
+        assert!(is_apple_double_name(OsStr::new("._Info.plist")));
+        assert!(is_apple_double_name(OsStr::new("._x")));
+    }
+
+    #[test]
+    fn is_apple_double_name_rejects_non_sidecars() {
+        assert!(!is_apple_double_name(OsStr::new("Info.plist")));
+        assert!(!is_apple_double_name(OsStr::new(".")));
+        assert!(!is_apple_double_name(OsStr::new(".hidden")));
+        assert!(!is_apple_double_name(OsStr::new("")));
+        // The bare prefix "._" with no payload is not an AppleDouble file.
+        assert!(!is_apple_double_name(OsStr::new("._")));
+    }
+
+    #[test]
+    fn apple_double_companion_pairs_data_to_sidecar() {
+        let data = std::path::PathBuf::from("dir/Info.plist");
+        let sidecar = apple_double_companion(&data).expect("companion");
+        assert_eq!(sidecar, std::path::PathBuf::from("dir/._Info.plist"));
+    }
+
+    #[test]
+    fn apple_double_companion_pairs_sidecar_to_data() {
+        let sidecar = std::path::PathBuf::from("dir/._Info.plist");
+        let data = apple_double_companion(&sidecar).expect("companion");
+        assert_eq!(data, std::path::PathBuf::from("dir/Info.plist"));
+    }
+
+    #[test]
+    fn apple_double_companion_round_trip() {
+        let original = std::path::PathBuf::from("a/b/c.txt");
+        let sidecar = apple_double_companion(&original).expect("forward");
+        let back = apple_double_companion(&sidecar).expect("reverse");
+        assert_eq!(back, original);
+    }
+
+    #[test]
+    fn apple_double_companion_returns_none_for_root() {
+        assert!(apple_double_companion(Path::new("/")).is_none());
+    }
+
+    #[test]
+    fn apple_double_companion_returns_none_for_bare_prefix() {
+        // "._" has no payload to pair against.
+        assert!(apple_double_companion(Path::new("dir/._")).is_none());
+    }
+
+    #[test]
+    fn apple_double_companion_preserves_parent_directory() {
+        let path = Path::new("/Users/me/Documents/draft.txt");
+        let sidecar = apple_double_companion(path).expect("companion");
+        assert_eq!(
+            sidecar,
+            std::path::PathBuf::from("/Users/me/Documents/._draft.txt"),
+        );
     }
 }

--- a/crates/apple-fs/src/resource_fork.rs
+++ b/crates/apple-fs/src/resource_fork.rs
@@ -1,0 +1,313 @@
+//! Safe accessors for the macOS native resource fork and Finder info.
+//!
+//! macOS exposes the resource fork and the 32-byte Finder info block as
+//! ordinary extended attributes named `com.apple.ResourceFork` and
+//! `com.apple.FinderInfo`. Upstream rsync 3.4.1 reads and writes them via
+//! the standard `getxattr(2)` / `setxattr(2)` syscalls (see `xattrs.c`,
+//! `rsync_xal_get` and `rsync_xal_set`); there is no dedicated resource-fork
+//! pathway. This module mirrors that approach by delegating to the
+//! third-party `xattr` crate, which is the same safe wrapper already used
+//! by `crates/metadata`.
+//!
+//! On non-macOS targets every accessor is a no-op stub:
+//! - readers return `Ok(None)` so callers can transparently skip Mac-specific
+//!   data when the host has no concept of a resource fork,
+//! - writers return `Ok(())` so a transfer that copies an AppleDouble sidecar
+//!   onto a non-Mac filesystem does not abort.
+//!
+//! No `unsafe` is used in this module. Per workspace policy, the `apple-fs`
+//! crate keeps `#![deny(unsafe_code)]`; macOS xattr syscalls run inside the
+//! pre-vetted `xattr` crate.
+
+use std::io;
+use std::path::Path;
+
+/// Extended-attribute name for the macOS resource fork.
+pub const RESOURCE_FORK_XATTR: &str = "com.apple.ResourceFork";
+
+/// Extended-attribute name for the 32-byte macOS Finder info block.
+pub const FINDER_INFO_XATTR: &str = "com.apple.FinderInfo";
+
+/// Canonical length, in bytes, of the Finder info payload.
+///
+/// macOS rejects writes whose length is not exactly 32 bytes.
+pub const FINDER_INFO_LEN: usize = 32;
+
+/// Reads the macOS resource fork from `path`.
+///
+/// Returns `Ok(None)` when the attribute is absent or when the host platform
+/// has no resource-fork concept (every non-macOS target).
+///
+/// # Errors
+///
+/// On macOS, propagates any [`io::Error`] surfaced by `getxattr(2)` other
+/// than `ENOATTR` (which is mapped to `Ok(None)`).
+#[cfg(target_os = "macos")]
+pub fn read_resource_fork(path: &Path) -> io::Result<Option<Vec<u8>>> {
+    read_xattr(path, RESOURCE_FORK_XATTR)
+}
+
+/// Writes `data` as the macOS resource fork on `path`.
+///
+/// # Errors
+///
+/// On macOS, propagates any [`io::Error`] surfaced by `setxattr(2)`.
+#[cfg(target_os = "macos")]
+pub fn write_resource_fork(path: &Path, data: &[u8]) -> io::Result<()> {
+    write_xattr(path, RESOURCE_FORK_XATTR, data)
+}
+
+/// Removes the macOS resource fork from `path`, if present.
+///
+/// # Errors
+///
+/// On macOS, propagates any [`io::Error`] surfaced by `removexattr(2)` other
+/// than `ENOATTR` (which is treated as success).
+#[cfg(target_os = "macos")]
+pub fn remove_resource_fork(path: &Path) -> io::Result<()> {
+    remove_xattr(path, RESOURCE_FORK_XATTR)
+}
+
+/// Reads the 32-byte Finder info block from `path`.
+///
+/// Returns `Ok(None)` when the attribute is absent. Returns
+/// [`io::ErrorKind::InvalidData`] when the attribute exists but is not exactly
+/// [`FINDER_INFO_LEN`] bytes long, since an arbitrarily sized Finder info is
+/// always malformed.
+///
+/// # Errors
+///
+/// Surfaces I/O errors from `getxattr(2)` and an
+/// [`io::ErrorKind::InvalidData`] error for malformed payloads.
+#[cfg(target_os = "macos")]
+pub fn read_finder_info(path: &Path) -> io::Result<Option<[u8; FINDER_INFO_LEN]>> {
+    let Some(bytes) = read_xattr(path, FINDER_INFO_XATTR)? else {
+        return Ok(None);
+    };
+    if bytes.len() != FINDER_INFO_LEN {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "{FINDER_INFO_XATTR} payload is {} bytes; expected {FINDER_INFO_LEN}",
+                bytes.len()
+            ),
+        ));
+    }
+    let mut info = [0u8; FINDER_INFO_LEN];
+    info.copy_from_slice(&bytes);
+    Ok(Some(info))
+}
+
+/// Writes the 32-byte Finder info block to `path`.
+///
+/// # Errors
+///
+/// On macOS, propagates any [`io::Error`] surfaced by `setxattr(2)`.
+#[cfg(target_os = "macos")]
+pub fn write_finder_info(path: &Path, info: &[u8; FINDER_INFO_LEN]) -> io::Result<()> {
+    write_xattr(path, FINDER_INFO_XATTR, info)
+}
+
+/// Removes the Finder info block from `path`, if present.
+///
+/// # Errors
+///
+/// On macOS, propagates any [`io::Error`] surfaced by `removexattr(2)` other
+/// than `ENOATTR` (which is treated as success).
+#[cfg(target_os = "macos")]
+pub fn remove_finder_info(path: &Path) -> io::Result<()> {
+    remove_xattr(path, FINDER_INFO_XATTR)
+}
+
+#[cfg(target_os = "macos")]
+fn read_xattr(path: &Path, name: &str) -> io::Result<Option<Vec<u8>>> {
+    // The xattr crate already maps ENOATTR (the "no such attribute" errno on
+    // macOS) to Ok(None), so the missing-attribute case requires no special
+    // handling here. See the xattr crate's `get` documentation.
+    xattr::get(path, name)
+}
+
+#[cfg(target_os = "macos")]
+fn write_xattr(path: &Path, name: &str, value: &[u8]) -> io::Result<()> {
+    xattr::set(path, name, value)
+}
+
+#[cfg(target_os = "macos")]
+fn remove_xattr(path: &Path, name: &str) -> io::Result<()> {
+    // ENOATTR surfaces as io::ErrorKind::Other from xattr::remove on macOS.
+    // Treat any "no such attribute" error as success so callers can use the
+    // remove accessors as idempotent cleanup hooks.
+    match xattr::remove(path, name) {
+        Ok(()) => Ok(()),
+        Err(error) if is_no_attr(&error) => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn is_no_attr(error: &io::Error) -> bool {
+    // macOS exposes ENOATTR (errno 93) when an xattr name is absent. The
+    // raw_os_error is the most reliable signal: the io::ErrorKind mapping
+    // varies across stdlib versions but the underlying errno does not.
+    // ENOATTR = 93 on Darwin (sys/xattr.h).
+    const ENOATTR_DARWIN: i32 = 93;
+    error.raw_os_error() == Some(ENOATTR_DARWIN)
+}
+
+// -- non-macOS stubs ---------------------------------------------------------
+
+/// Stub: returns `Ok(None)`. The host has no resource-fork concept.
+#[cfg(not(target_os = "macos"))]
+pub fn read_resource_fork(_path: &Path) -> io::Result<Option<Vec<u8>>> {
+    Ok(None)
+}
+
+/// Stub: returns `Ok(())`. The host has no resource-fork concept.
+#[cfg(not(target_os = "macos"))]
+pub fn write_resource_fork(_path: &Path, _data: &[u8]) -> io::Result<()> {
+    Ok(())
+}
+
+/// Stub: returns `Ok(())`. The host has no resource-fork concept.
+#[cfg(not(target_os = "macos"))]
+pub fn remove_resource_fork(_path: &Path) -> io::Result<()> {
+    Ok(())
+}
+
+/// Stub: returns `Ok(None)`. The host has no Finder-info concept.
+#[cfg(not(target_os = "macos"))]
+pub fn read_finder_info(_path: &Path) -> io::Result<Option<[u8; FINDER_INFO_LEN]>> {
+    Ok(None)
+}
+
+/// Stub: returns `Ok(())`. The host has no Finder-info concept.
+#[cfg(not(target_os = "macos"))]
+pub fn write_finder_info(_path: &Path, _info: &[u8; FINDER_INFO_LEN]) -> io::Result<()> {
+    Ok(())
+}
+
+/// Stub: returns `Ok(())`. The host has no Finder-info concept.
+#[cfg(not(target_os = "macos"))]
+pub fn remove_finder_info(_path: &Path) -> io::Result<()> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[cfg(not(target_os = "macos"))]
+    fn dummy_path() -> PathBuf {
+        PathBuf::from("/nonexistent/oc-rsync/apple-fs/stub")
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    #[test]
+    fn non_macos_resource_fork_reader_returns_none() {
+        let path = dummy_path();
+        assert!(read_resource_fork(&path).expect("stub ok").is_none());
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    #[test]
+    fn non_macos_resource_fork_writer_is_noop() {
+        let path = dummy_path();
+        write_resource_fork(&path, b"ignored").expect("stub ok");
+        remove_resource_fork(&path).expect("stub ok");
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    #[test]
+    fn non_macos_finder_info_accessors_are_noops() {
+        let path = dummy_path();
+        assert!(read_finder_info(&path).expect("stub ok").is_none());
+        write_finder_info(&path, &[0u8; FINDER_INFO_LEN]).expect("stub ok");
+        remove_finder_info(&path).expect("stub ok");
+    }
+
+    #[cfg(target_os = "macos")]
+    fn make_temp_file() -> (tempfile::TempDir, PathBuf) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("subject");
+        std::fs::write(&path, b"data fork contents").expect("write");
+        (dir, path)
+    }
+
+    #[cfg(target_os = "macos")]
+    fn xattr_supported(path: &Path) -> bool {
+        // Some macOS filesystems (FAT volumes mounted under /Volumes) silently
+        // refuse xattr writes. Probe with a no-op write+remove and skip the
+        // test when the filesystem rejects the operation.
+        match xattr::set(path, "com.apple.oc-rsync.probe", b"") {
+            Ok(()) => {
+                let _ = xattr::remove(path, "com.apple.oc-rsync.probe");
+                true
+            }
+            Err(error) => !matches!(
+                error.kind(),
+                io::ErrorKind::Unsupported | io::ErrorKind::PermissionDenied
+            ),
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_resource_fork_round_trip() {
+        let (_dir, path) = make_temp_file();
+        if !xattr_supported(&path) {
+            eprintln!("skipping: filesystem does not support xattrs");
+            return;
+        }
+        assert!(read_resource_fork(&path).expect("read absent").is_none());
+        let payload = b"resource-fork-payload".to_vec();
+        write_resource_fork(&path, &payload).expect("write");
+        let observed = read_resource_fork(&path).expect("read");
+        assert_eq!(observed.as_deref(), Some(payload.as_slice()));
+        remove_resource_fork(&path).expect("remove");
+        assert!(
+            read_resource_fork(&path)
+                .expect("read after remove")
+                .is_none()
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_finder_info_round_trip() {
+        let (_dir, path) = make_temp_file();
+        if !xattr_supported(&path) {
+            eprintln!("skipping: filesystem does not support xattrs");
+            return;
+        }
+        assert!(read_finder_info(&path).expect("read absent").is_none());
+        let mut info = [0u8; FINDER_INFO_LEN];
+        info[0..4].copy_from_slice(b"TEXT");
+        info[4..8].copy_from_slice(b"ttxt");
+        write_finder_info(&path, &info).expect("write");
+        let observed = read_finder_info(&path).expect("read").expect("present");
+        assert_eq!(observed, info);
+        remove_finder_info(&path).expect("remove");
+        assert!(
+            read_finder_info(&path)
+                .expect("read after remove")
+                .is_none()
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_finder_info_rejects_wrong_length_payload() {
+        let (_dir, path) = make_temp_file();
+        if !xattr_supported(&path) {
+            eprintln!("skipping: filesystem does not support xattrs");
+            return;
+        }
+        // Inject a malformed FinderInfo (16 bytes instead of 32) directly via
+        // the underlying xattr API to verify the read accessor flags it.
+        xattr::set(&path, FINDER_INFO_XATTR, &[1u8; 16]).expect("write malformed");
+        let err = read_finder_info(&path).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+        let _ = xattr::remove(&path, FINDER_INFO_XATTR);
+    }
+}

--- a/crates/apple-fs/tests/apple_double_round_trip.rs
+++ b/crates/apple-fs/tests/apple_double_round_trip.rs
@@ -1,0 +1,102 @@
+//! End-to-end AppleDouble container round-trip tests.
+//!
+//! Cross-platform: the parser/encoder is pure-data and runs identically
+//! everywhere. The macOS-only test additionally writes the synthesised
+//! container back as `com.apple.ResourceFork` / `com.apple.FinderInfo`
+//! xattrs and reads them through the safe accessors to confirm the two
+//! halves of the pipeline (sidecar bytes vs native xattrs) carry the same
+//! payload.
+
+use apple_fs::apple_double::{AppleDouble, EntryId};
+
+fn finder_info_payload() -> Vec<u8> {
+    let mut info = vec![0u8; 32];
+    info[0..4].copy_from_slice(b"TEXT");
+    info[4..8].copy_from_slice(b"ttxt");
+    info
+}
+
+fn resource_fork_payload() -> Vec<u8> {
+    // Deterministic 4 KiB payload mimicking a small resource map. The exact
+    // bytes are not interpreted by the container; what matters is fidelity.
+    (0..4096).map(|i| (i as u8).wrapping_mul(31)).collect()
+}
+
+#[test]
+fn round_trip_finder_info_and_resource_fork_through_apple_double() {
+    let mut container = AppleDouble::new();
+    container.set_entry(EntryId::FinderInfo, finder_info_payload());
+    container.set_entry(EntryId::ResourceFork, resource_fork_payload());
+
+    let bytes = container.encode().expect("encode");
+    let decoded = AppleDouble::decode(&bytes).expect("decode");
+
+    assert_eq!(
+        decoded.finder_info().expect("finder info present"),
+        &finder_info_payload()[..],
+    );
+    assert_eq!(
+        decoded.resource_fork().expect("resource fork present"),
+        &resource_fork_payload()[..],
+    );
+}
+
+#[test]
+fn empty_container_round_trips() {
+    let container = AppleDouble::new();
+    let bytes = container.encode().expect("encode");
+    let decoded = AppleDouble::decode(&bytes).expect("decode");
+    assert!(decoded.entries.is_empty());
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn macos_resource_fork_pipeline_matches_apple_double_payload() {
+    use apple_fs::{read_finder_info, read_resource_fork, write_finder_info, write_resource_fork};
+    use std::io;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("subject.txt");
+    std::fs::write(&path, b"data fork").expect("write data");
+
+    // Probe filesystem support: skip when xattrs are unavailable (e.g. when
+    // /tmp is mounted on a FAT volume).
+    if let Err(error) = xattr::set(&path, "com.apple.oc-rsync.probe", b"") {
+        if matches!(
+            error.kind(),
+            io::ErrorKind::Unsupported | io::ErrorKind::PermissionDenied
+        ) {
+            eprintln!("skipping: filesystem does not support xattrs");
+            return;
+        }
+    }
+    let _ = xattr::remove(&path, "com.apple.oc-rsync.probe");
+
+    let mut info = [0u8; 32];
+    info[0..4].copy_from_slice(b"TEXT");
+    info[4..8].copy_from_slice(b"ttxt");
+
+    let fork = resource_fork_payload();
+    write_finder_info(&path, &info).expect("write finder info");
+    write_resource_fork(&path, &fork).expect("write resource fork");
+
+    let observed_info = read_finder_info(&path)
+        .expect("read info")
+        .expect("present");
+    assert_eq!(observed_info, info);
+    let observed_fork = read_resource_fork(&path)
+        .expect("read fork")
+        .expect("present");
+    assert_eq!(observed_fork, fork);
+
+    // Build the equivalent AppleDouble container and confirm the same bytes
+    // round-trip through the on-disk container format.
+    let mut container = AppleDouble::new();
+    container.set_entry(EntryId::FinderInfo, info.to_vec());
+    container.set_entry(EntryId::ResourceFork, fork);
+
+    let encoded = container.encode().expect("encode container");
+    let decoded = AppleDouble::decode(&encoded).expect("decode container");
+    assert_eq!(decoded.finder_info().unwrap(), &observed_info[..]);
+    assert_eq!(decoded.resource_fork().unwrap(), observed_fork.as_slice());
+}


### PR DESCRIPTION
## Summary

Expand the `apple-fs` crate with three new pieces of standalone surface
that close the audit follow-ups in `docs/audits/apple-fs-roundtrip.md`:

- `apple_double` module: a self-contained AppleDouble v2 (RFC 1740)
  container parser and encoder. Pure-data, no FFI. Validates magic,
  version, descriptor table, and per-entry offset/length bounds. The
  encoder writes entries in ascending id order so identical logical
  content yields identical bytes.
- `resource_fork` module: safe accessors for `com.apple.ResourceFork`
  and `com.apple.FinderInfo`. On macOS they delegate to the third-party
  `xattr` crate (the same safe wrapper used by `crates/metadata`); on
  every other target the readers return `Ok(None)` and writers return
  `Ok(())`.
- AppleDouble companion-name helpers: `is_apple_double_name` and
  `apple_double_companion` translate between `foo` and `._foo`
  lexically, cross-platform.

## Public API surface added

```text
apple_fs::APPLE_DOUBLE_PREFIX                       // "._"
apple_fs::is_apple_double_name(&OsStr) -> bool
apple_fs::apple_double_companion(&Path) -> Option<PathBuf>

apple_fs::apple_double::AppleDouble                 // container
apple_fs::apple_double::Entry
apple_fs::apple_double::EntryId                     // RFC 1740 ids
apple_fs::apple_double::APPLE_DOUBLE_MAGIC          // 0x00051607
apple_fs::apple_double::APPLE_SINGLE_MAGIC          // 0x00051600
apple_fs::apple_double::APPLE_DOUBLE_VERSION_2      // 0x00020000
apple_fs::apple_double::HEADER_SIZE
apple_fs::apple_double::ENTRY_DESCRIPTOR_SIZE

apple_fs::RESOURCE_FORK_XATTR                       // "com.apple.ResourceFork"
apple_fs::FINDER_INFO_XATTR                         // "com.apple.FinderInfo"
apple_fs::FINDER_INFO_LEN                           // 32
apple_fs::read_resource_fork(&Path)  -> io::Result<Option<Vec<u8>>>
apple_fs::write_resource_fork(&Path, &[u8]) -> io::Result<()>
apple_fs::remove_resource_fork(&Path) -> io::Result<()>
apple_fs::read_finder_info(&Path)    -> io::Result<Option<[u8; 32]>>
apple_fs::write_finder_info(&Path, &[u8; 32]) -> io::Result<()>
apple_fs::remove_finder_info(&Path)  -> io::Result<()>
```

## Design choice: xattr-backed accessors, not sidecar synthesis

Upstream rsync 3.4.1 has no dedicated resource-fork pathway. macOS
exposes the resource fork and the 32-byte Finder info as ordinary
extended attributes named `com.apple.ResourceFork` and
`com.apple.FinderInfo`; upstream reads and writes them via standard
`getxattr(2)` / `setxattr(2)` (`xattrs.c` -> `rsync_xal_get` /
`rsync_xal_set`). This PR mirrors that approach for the in-process
accessors and keeps the AppleDouble container format as a standalone
helper for tools, audits, and any future opt-in merge feature.

Rationale: the existing transfer pipeline already round-trips
`com.apple.*` xattrs symmetrically via `metadata::xattr` and
`protocol::xattr::wire` (see `docs/audits/apple-fs-roundtrip.md`,
"Round-trip path" section). Adding a parallel sidecar path inside
`apple-fs` would either duplicate that work or change wire behaviour,
neither of which is upstream-compatible. The accessors here are
therefore orthogonal to the live pipeline and intended for tooling.

## Unsafe-code encapsulation

The crate keeps `#![deny(unsafe_code)]`. macOS xattr syscalls reach
the kernel through `xattr` 1.6, which contains the only `unsafe`
involved. No `#[allow(unsafe_code)]` was added to `apple-fs`, in line
with the workspace unsafe-code policy that routes platform FFI through
pre-vetted wrapper crates or the `fast_io` crate.

## Test plan

- [x] Cross-platform unit tests for the AppleDouble parser/encoder
      (round-trip, magic / version / descriptor / payload-bound
      validation, per-entry replacement, ordering).
- [x] Cross-platform unit tests for `is_apple_double_name` and
      `apple_double_companion` (round-trip pairing, root and
      bare-prefix edge cases).
- [x] Cross-platform unit tests for the non-macOS resource-fork stubs
      (readers return `Ok(None)`, writers / removers are no-ops).
- [x] macOS-gated integration test
      (`tests/apple_double_round_trip.rs::macos_resource_fork_pipeline_matches_apple_double_payload`)
      that writes payloads through `write_resource_fork` /
      `write_finder_info`, reads them back, and verifies the
      AppleDouble container encodes / decodes the same bytes.
- [x] macOS-gated unit tests for round-trip of resource fork and
      Finder info via the safe accessors, plus rejection of malformed
      Finder-info length.
- [x] `cargo fmt --all` clean.
- [ ] Full CI suite (fmt + clippy, nextest stable, Windows, macOS,
      Linux musl) - relies on CI; not run locally per workspace policy.

## Follow-ups (not in this PR)

- Audit follow-up F-2: decide whether to wire an opt-in
  `--apple-double-merge` analogue once or if upstream picks up the
  relevant patch. The standalone container helpers added here are the
  building block such a feature would need.
- Audit follow-up F-1: trim the workspace `README.md:223` line that
  still mentions "clonefile, FSEvents" for `apple-fs` (out of scope
  for this functional PR).