### PR TITLE
feat(metadata): complete Windows ACL read/write via windows-rs (#1866)

### DIFF
--- a/crates/cli/src/frontend/execution/drive/config.rs
+++ b/crates/cli/src/frontend/execution/drive/config.rs
@@ -121,7 +121,7 @@ pub(crate) struct ConfigInputs {
     pub(crate) compare_destinations: Vec<OsString>,
     pub(crate) copy_destinations: Vec<OsString>,
     pub(crate) link_destinations: Vec<OsString>,
-    #[cfg(all(unix, feature = "acl"))]
+    #[cfg(all(any(unix, windows), feature = "acl"))]
     pub(crate) preserve_acls: bool,
     #[cfg(all(unix, feature = "xattr"))]
     pub(crate) xattrs: bool,
@@ -297,7 +297,7 @@ pub(crate) fn build_base_config(mut inputs: ConfigInputs) -> ClientConfigBuilder
         builder = builder.link_destination(PathBuf::from(path));
     }
 
-    #[cfg(all(unix, feature = "acl"))]
+    #[cfg(all(any(unix, windows), feature = "acl"))]
     {
         builder = builder.acls(inputs.preserve_acls);
     }

--- a/crates/cli/src/frontend/execution/drive/messages.rs
+++ b/crates/cli/src/frontend/execution/drive/messages.rs
@@ -29,7 +29,10 @@ where
     message.code().unwrap_or(1)
 }
 
-#[cfg(any(not(all(unix, feature = "acl")), not(all(unix, feature = "xattr"))))]
+#[cfg(any(
+    not(all(any(unix, windows), feature = "acl")),
+    not(all(unix, feature = "xattr"))
+))]
 /// Emits an error message with a caller-supplied fallback string and returns the exit code.
 pub(super) fn fail_with_custom_fallback<Err>(
     message: Message,

--- a/crates/cli/src/frontend/execution/drive/workflow/preflight.rs
+++ b/crates/cli/src/frontend/execution/drive/workflow/preflight.rs
@@ -16,7 +16,10 @@ use std::path::{Path, PathBuf};
 use super::super::super::{
     parse_bind_address_argument, parse_protocol_version_arg, parse_timeout_argument,
 };
-#[cfg(any(not(all(unix, feature = "acl")), not(all(unix, feature = "xattr"))))]
+#[cfg(any(
+    not(all(any(unix, windows), feature = "acl")),
+    not(all(unix, feature = "xattr"))
+))]
 use super::super::messages::fail_with_custom_fallback;
 use super::super::messages::fail_with_message;
 
@@ -138,7 +141,7 @@ pub(crate) fn validate_feature_support<Err>(
 where
     Err: Write,
 {
-    #[cfg(not(all(unix, feature = "acl")))]
+    #[cfg(not(all(any(unix, windows), feature = "acl")))]
     if preserve_acls {
         let message =
             rsync_error!(1, "POSIX ACLs are not supported on this client").with_role(Role::Client);
@@ -146,7 +149,7 @@ where
         return Err(fail_with_custom_fallback(message, fallback, stderr));
     }
 
-    #[cfg(all(unix, feature = "acl"))]
+    #[cfg(all(any(unix, windows), feature = "acl"))]
     let _ = preserve_acls;
 
     #[cfg(not(all(unix, feature = "xattr")))]

--- a/crates/cli/src/frontend/execution/drive/workflow/run.rs
+++ b/crates/cli/src/frontend/execution/drive/workflow/run.rs
@@ -348,7 +348,7 @@ where
     };
     let open_noatime_enabled = open_noatime_setting.unwrap_or(false);
 
-    #[allow(unused_variables)] // REASON: used on unix with feature "acl"
+    #[allow(unused_variables)] // REASON: used on unix or windows with feature "acl"
     let preserve_acls = acls.unwrap_or(false);
 
     if let Err(code) = validate_feature_support(preserve_acls, xattrs, stderr) {
@@ -743,7 +743,7 @@ where
         compare_destinations,
         copy_destinations,
         link_destinations,
-        #[cfg(all(unix, feature = "acl"))]
+        #[cfg(all(any(unix, windows), feature = "acl"))]
         preserve_acls,
         #[cfg(all(unix, feature = "xattr"))]
         xattrs: xattrs.unwrap_or(false),

--- a/crates/core/src/client/config/builder/metadata.rs
+++ b/crates/core/src/client/config/builder/metadata.rs
@@ -185,7 +185,7 @@ impl ClientConfigBuilder {
         self
     }
 
-    #[cfg(all(unix, feature = "acl"))]
+    #[cfg(all(any(unix, windows), feature = "acl"))]
     /// Enables or disables POSIX ACL preservation when applying metadata.
     #[must_use]
     #[doc(alias = "--acls")]
@@ -195,7 +195,7 @@ impl ClientConfigBuilder {
         self
     }
 
-    #[cfg(not(all(unix, feature = "acl")))]
+    #[cfg(not(all(any(unix, windows), feature = "acl")))]
     /// No-op on platforms without ACL support.
     #[must_use]
     pub const fn acls(self, _preserve: bool) -> Self {

--- a/crates/core/src/client/config/builder/mod.rs
+++ b/crates/core/src/client/config/builder/mod.rs
@@ -253,7 +253,7 @@ pub struct ClientConfigBuilder {
     protocol_version: Option<protocol::ProtocolVersion>,
     #[cfg(feature = "embedded-ssh")]
     embedded_ssh_config: Option<super::client::EmbeddedSshOptions>,
-    #[cfg(all(unix, feature = "acl"))]
+    #[cfg(all(any(unix, windows), feature = "acl"))]
     preserve_acls: bool,
     #[cfg(all(unix, feature = "xattr"))]
     preserve_xattrs: bool,
@@ -412,7 +412,7 @@ impl ClientConfigBuilder {
             protocol_version: self.protocol_version,
             #[cfg(feature = "embedded-ssh")]
             embedded_ssh_config: self.embedded_ssh_config,
-            #[cfg(all(unix, feature = "acl"))]
+            #[cfg(all(any(unix, windows), feature = "acl"))]
             preserve_acls: self.preserve_acls,
             #[cfg(all(unix, feature = "xattr"))]
             preserve_xattrs: self.preserve_xattrs,

--- a/crates/core/src/client/config/client/metadata.rs
+++ b/crates/core/src/client/config/client/metadata.rs
@@ -125,7 +125,7 @@ impl ClientConfig {
     }
 
     /// Reports whether POSIX ACLs should be preserved.
-    #[cfg(all(unix, feature = "acl"))]
+    #[cfg(all(any(unix, windows), feature = "acl"))]
     #[must_use]
     #[doc(alias = "--acls")]
     #[doc(alias = "-A")]
@@ -134,7 +134,7 @@ impl ClientConfig {
     }
 
     /// Always returns `false` on platforms without ACL support.
-    #[cfg(not(all(unix, feature = "acl")))]
+    #[cfg(not(all(any(unix, windows), feature = "acl")))]
     #[must_use]
     pub const fn preserve_acls(&self) -> bool {
         false

--- a/crates/core/src/client/config/client/mod.rs
+++ b/crates/core/src/client/config/client/mod.rs
@@ -182,7 +182,7 @@ pub struct ClientConfig {
     pub(super) protocol_version: Option<protocol::ProtocolVersion>,
     #[cfg(feature = "embedded-ssh")]
     pub(super) embedded_ssh_config: Option<EmbeddedSshOptions>,
-    #[cfg(all(unix, feature = "acl"))]
+    #[cfg(all(any(unix, windows), feature = "acl"))]
     pub(super) preserve_acls: bool,
     #[cfg(all(unix, feature = "xattr"))]
     pub(super) preserve_xattrs: bool,
@@ -337,7 +337,7 @@ impl Default for ClientConfig {
             protocol_version: None,
             #[cfg(feature = "embedded-ssh")]
             embedded_ssh_config: None,
-            #[cfg(all(unix, feature = "acl"))]
+            #[cfg(all(any(unix, windows), feature = "acl"))]
             preserve_acls: false,
             #[cfg(all(unix, feature = "xattr"))]
             preserve_xattrs: false,

--- a/crates/core/src/client/remote/batch_support.rs
+++ b/crates/core/src/client/remote/batch_support.rs
@@ -30,9 +30,9 @@ pub(crate) fn build_batch_context(
     #[cfg(not(all(unix, feature = "xattr")))]
     let preserve_xattrs = false;
 
-    #[cfg(all(unix, feature = "acl"))]
+    #[cfg(all(any(unix, windows), feature = "acl"))]
     let preserve_acls = config.preserve_acls();
-    #[cfg(not(all(unix, feature = "acl")))]
+    #[cfg(not(all(any(unix, windows), feature = "acl")))]
     let preserve_acls = false;
 
     let flags = BatchFlags {

--- a/crates/core/src/client/remote/flags.rs
+++ b/crates/core/src/client/remote/flags.rs
@@ -74,7 +74,7 @@ pub(crate) fn build_server_flag_string(config: &ClientConfig) -> String {
     if config.ignore_times() {
         flags.push('I');
     }
-    #[cfg(all(unix, feature = "acl"))]
+    #[cfg(all(any(unix, windows), feature = "acl"))]
     if config.preserve_acls() {
         flags.push('A');
     }

--- a/crates/core/src/client/remote/invocation/builder.rs
+++ b/crates/core/src/client/remote/invocation/builder.rs
@@ -500,7 +500,7 @@ impl<'a> RemoteInvocationBuilder<'a> {
         if self.config.preserve_hard_links() {
             flags.push('H');
         }
-        #[cfg(all(unix, feature = "acl"))]
+        #[cfg(all(any(unix, windows), feature = "acl"))]
         if self.config.preserve_acls() {
             flags.push('A');
         }

--- a/crates/core/src/client/remote/invocation/tests.rs
+++ b/crates/core/src/client/remote/invocation/tests.rs
@@ -1201,7 +1201,7 @@ fn delete_excluded_is_long_form_not_in_flag_string() {
     );
 }
 
-#[cfg(all(unix, feature = "acl"))]
+#[cfg(all(any(unix, windows), feature = "acl"))]
 #[test]
 fn includes_acl_flag() {
     let config = ClientConfig::builder().acls(true).build();

--- a/crates/core/src/client/run/batch.rs
+++ b/crates/core/src/client/run/batch.rs
@@ -80,9 +80,9 @@ pub(crate) fn write_batch_header(
     #[cfg(not(all(unix, feature = "xattr")))]
     let preserve_xattrs = false;
 
-    #[cfg(all(unix, feature = "acl"))]
+    #[cfg(all(any(unix, windows), feature = "acl"))]
     let preserve_acls = config.preserve_acls();
-    #[cfg(not(all(unix, feature = "acl")))]
+    #[cfg(not(all(any(unix, windows), feature = "acl")))]
     let preserve_acls = false;
 
     let batch_flags = engine::batch::BatchFlags {

--- a/crates/core/src/client/run/mod.rs
+++ b/crates/core/src/client/run/mod.rs
@@ -498,7 +498,7 @@ impl<'a> LocalCopyOptionsBuilder<'a> {
             .with_user_mapping(config.user_mapping().cloned())
             .with_group_mapping(config.group_mapping().cloned());
 
-        #[cfg(all(unix, feature = "acl"))]
+        #[cfg(all(any(unix, windows), feature = "acl"))]
         {
             options = options.acls(config.preserve_acls());
         }

--- a/crates/core/src/client/tests/builder_metadata.rs
+++ b/crates/core/src/client/tests/builder_metadata.rs
@@ -112,7 +112,7 @@ fn builder_preserves_hard_links_flag() {
     assert!(!ClientConfig::default().preserve_hard_links());
 }
 
-#[cfg(all(unix, feature = "acl"))]
+#[cfg(all(any(unix, windows), feature = "acl"))]
 #[test]
 fn builder_preserves_acls_flag() {
     let config = ClientConfig::builder()

--- a/crates/engine/src/local_copy/context.rs
+++ b/crates/engine/src/local_copy/context.rs
@@ -19,7 +19,7 @@ use super::filter_program::{
     FilterSegmentLayers, FilterSegmentStack, directory_has_marker,
 };
 
-#[cfg(all(unix, feature = "acl"))]
+#[cfg(all(any(unix, windows), feature = "acl"))]
 use super::sync_acls_if_requested;
 #[cfg(all(unix, feature = "xattr"))]
 use super::sync_nfsv4_acls_if_requested;
@@ -182,7 +182,7 @@ pub(crate) struct FinalizeMetadataParams<'a> {
     #[cfg(all(unix, feature = "xattr"))]
     preserve_xattrs: bool,
 
-    #[cfg(all(unix, feature = "acl"))]
+    #[cfg(all(any(unix, windows), feature = "acl"))]
     preserve_acls: bool,
 }
 
@@ -193,7 +193,7 @@ impl<'a> FinalizeMetadataParams<'a> {
         mode: LocalCopyExecution,
         path_context: MetadataPathContext<'a>,
         #[cfg(all(unix, feature = "xattr"))] preserve_xattrs: bool,
-        #[cfg(all(unix, feature = "acl"))] preserve_acls: bool,
+        #[cfg(all(any(unix, windows), feature = "acl"))] preserve_acls: bool,
     ) -> Self {
         Self {
             metadata,
@@ -204,7 +204,7 @@ impl<'a> FinalizeMetadataParams<'a> {
             fd: None,
             #[cfg(all(unix, feature = "xattr"))]
             preserve_xattrs,
-            #[cfg(all(unix, feature = "acl"))]
+            #[cfg(all(any(unix, windows), feature = "acl"))]
             preserve_acls,
         }
     }
@@ -321,7 +321,7 @@ pub(crate) struct DeferredUpdate {
     destination: PathBuf,
     #[cfg(all(unix, feature = "xattr"))]
     preserve_xattrs: bool,
-    #[cfg(all(unix, feature = "acl"))]
+    #[cfg(all(any(unix, windows), feature = "acl"))]
     preserve_acls: bool,
 }
 
@@ -334,7 +334,7 @@ impl DeferredUpdate {
         path_context: OwnedPathContext,
         destination: PathBuf,
         #[cfg(all(unix, feature = "xattr"))] preserve_xattrs: bool,
-        #[cfg(all(unix, feature = "acl"))] preserve_acls: bool,
+        #[cfg(all(any(unix, windows), feature = "acl"))] preserve_acls: bool,
     ) -> Self {
         Self {
             guard,
@@ -345,7 +345,7 @@ impl DeferredUpdate {
             destination,
             #[cfg(all(unix, feature = "xattr"))]
             preserve_xattrs,
-            #[cfg(all(unix, feature = "acl"))]
+            #[cfg(all(any(unix, windows), feature = "acl"))]
             preserve_acls,
         }
     }

--- a/crates/engine/src/local_copy/context_impl/options.rs
+++ b/crates/engine/src/local_copy/context_impl/options.rs
@@ -121,7 +121,7 @@ impl<'a> CopyContext<'a> {
     }
 
     /// Reports whether ACL preservation is enabled.
-    #[cfg(all(unix, feature = "acl"))]
+    #[cfg(all(any(unix, windows), feature = "acl"))]
     pub(super) const fn acls_enabled(&self) -> bool {
         self.options.acls_enabled()
     }

--- a/crates/engine/src/local_copy/context_impl/state.rs
+++ b/crates/engine/src/local_copy/context_impl/state.rs
@@ -218,7 +218,7 @@ impl<'a> CopyContext<'a> {
             fd,
             #[cfg(all(unix, feature = "xattr"))]
             preserve_xattrs,
-            #[cfg(all(unix, feature = "acl"))]
+            #[cfg(all(any(unix, windows), feature = "acl"))]
             preserve_acls,
         } = params;
 
@@ -292,12 +292,12 @@ impl<'a> CopyContext<'a> {
             )?;
         }
 
-        #[cfg(all(unix, feature = "acl"))]
+        #[cfg(all(any(unix, windows), feature = "acl"))]
         {
             sync_acls_if_requested(preserve_acls, mode, source, destination, true)?;
         }
 
-        #[cfg(not(any(all(unix, feature = "xattr"), all(unix, feature = "acl"))))]
+        #[cfg(not(any(all(unix, feature = "xattr"), all(any(unix, windows), feature = "acl"))))]
         let _ = mode;
 
         self.record_hard_link(metadata, destination);
@@ -603,11 +603,11 @@ impl<'a> CopyContext<'a> {
             destination,
             #[cfg(all(unix, feature = "xattr"))]
             preserve_xattrs,
-            #[cfg(all(unix, feature = "acl"))]
+            #[cfg(all(any(unix, windows), feature = "acl"))]
             preserve_acls,
         } = update;
 
-        #[cfg(not(any(all(unix, feature = "xattr"), all(unix, feature = "acl"))))]
+        #[cfg(not(any(all(unix, feature = "xattr"), all(any(unix, windows), feature = "acl"))))]
         let _ = &path_context.source;
 
         guard.commit()?;
@@ -628,7 +628,7 @@ impl<'a> CopyContext<'a> {
                 fd: None, // No fd available for deferred updates
                 #[cfg(all(unix, feature = "xattr"))]
                 preserve_xattrs,
-                #[cfg(all(unix, feature = "acl"))]
+                #[cfg(all(any(unix, windows), feature = "acl"))]
                 preserve_acls,
             },
         )

--- a/crates/engine/src/local_copy/executor/directory/recursive/dir_metadata.rs
+++ b/crates/engine/src/local_copy/executor/directory/recursive/dir_metadata.rs
@@ -7,7 +7,10 @@
 use std::fs;
 use std::path::Path;
 
-#[cfg(all(unix, any(feature = "acl", feature = "xattr")))]
+#[cfg(any(
+    all(unix, any(feature = "acl", feature = "xattr")),
+    all(windows, feature = "acl")
+))]
 use crate::local_copy::LocalCopyExecution;
 #[cfg(all(any(unix, windows), feature = "acl"))]
 use crate::local_copy::sync_acls_if_requested;
@@ -25,7 +28,11 @@ pub(super) fn apply_final_directory_metadata(
     source: &Path,
     destination: &Path,
     metadata: &fs::Metadata,
-    #[cfg(all(unix, any(feature = "acl", feature = "xattr")))] mode: LocalCopyExecution,
+    #[cfg(any(
+        all(unix, any(feature = "acl", feature = "xattr")),
+        all(windows, feature = "acl")
+    ))]
+    mode: LocalCopyExecution,
     #[cfg(all(unix, feature = "xattr"))] preserve_xattrs: bool,
     #[cfg(all(any(unix, windows), feature = "acl"))] preserve_acls: bool,
 ) -> Result<(), LocalCopyError> {

--- a/crates/engine/src/local_copy/executor/directory/recursive/dir_metadata.rs
+++ b/crates/engine/src/local_copy/executor/directory/recursive/dir_metadata.rs
@@ -9,7 +9,7 @@ use std::path::Path;
 
 #[cfg(all(unix, any(feature = "acl", feature = "xattr")))]
 use crate::local_copy::LocalCopyExecution;
-#[cfg(all(unix, feature = "acl"))]
+#[cfg(all(any(unix, windows), feature = "acl"))]
 use crate::local_copy::sync_acls_if_requested;
 #[cfg(all(unix, feature = "xattr"))]
 use crate::local_copy::sync_xattrs_if_requested;
@@ -27,7 +27,7 @@ pub(super) fn apply_final_directory_metadata(
     metadata: &fs::Metadata,
     #[cfg(all(unix, any(feature = "acl", feature = "xattr")))] mode: LocalCopyExecution,
     #[cfg(all(unix, feature = "xattr"))] preserve_xattrs: bool,
-    #[cfg(all(unix, feature = "acl"))] preserve_acls: bool,
+    #[cfg(all(any(unix, windows), feature = "acl"))] preserve_acls: bool,
 ) -> Result<(), LocalCopyError> {
     let metadata_options = if context.omit_dir_times_enabled() {
         context.metadata_options().preserve_times(false)
@@ -47,7 +47,7 @@ pub(super) fn apply_final_directory_metadata(
         context.filter_program(),
     )?;
 
-    #[cfg(all(unix, feature = "acl"))]
+    #[cfg(all(any(unix, windows), feature = "acl"))]
     sync_acls_if_requested(preserve_acls, mode, source, destination, true)?;
 
     // Suppress unused variable warnings when features are disabled

--- a/crates/engine/src/local_copy/executor/directory/recursive/mod.rs
+++ b/crates/engine/src/local_copy/executor/directory/recursive/mod.rs
@@ -52,9 +52,15 @@ pub(crate) fn copy_directory_recursive(
     relative: Option<&Path>,
     root_device: Option<u64>,
 ) -> Result<bool, LocalCopyError> {
-    #[cfg(all(unix, any(feature = "acl", feature = "xattr")))]
+    #[cfg(any(
+        all(unix, any(feature = "acl", feature = "xattr")),
+        all(windows, feature = "acl")
+    ))]
     let mode = context.mode();
-    #[cfg(not(all(unix, any(feature = "acl", feature = "xattr"))))]
+    #[cfg(not(any(
+        all(unix, any(feature = "acl", feature = "xattr")),
+        all(windows, feature = "acl")
+    )))]
     let _mode = context.mode();
 
     #[cfg(all(unix, feature = "xattr"))]
@@ -166,7 +172,10 @@ pub(crate) fn copy_directory_recursive(
                 source,
                 destination,
                 metadata,
-                #[cfg(all(unix, any(feature = "acl", feature = "xattr")))]
+                #[cfg(any(
+                    all(unix, any(feature = "acl", feature = "xattr")),
+                    all(windows, feature = "acl")
+                ))]
                 mode,
                 #[cfg(all(unix, feature = "xattr"))]
                 preserve_xattrs,

--- a/crates/engine/src/local_copy/executor/directory/recursive/mod.rs
+++ b/crates/engine/src/local_copy/executor/directory/recursive/mod.rs
@@ -59,7 +59,7 @@ pub(crate) fn copy_directory_recursive(
 
     #[cfg(all(unix, feature = "xattr"))]
     let preserve_xattrs = context.xattrs_enabled();
-    #[cfg(all(unix, feature = "acl"))]
+    #[cfg(all(any(unix, windows), feature = "acl"))]
     let preserve_acls = context.acls_enabled();
 
     let prune_enabled = context.prune_empty_dirs_enabled();
@@ -170,7 +170,7 @@ pub(crate) fn copy_directory_recursive(
                 mode,
                 #[cfg(all(unix, feature = "xattr"))]
                 preserve_xattrs,
-                #[cfg(all(unix, feature = "acl"))]
+                #[cfg(all(any(unix, windows), feature = "acl"))]
                 preserve_acls,
             )?;
         }
@@ -267,7 +267,7 @@ pub(crate) fn copy_directory_recursive(
             mode,
             #[cfg(all(unix, feature = "xattr"))]
             preserve_xattrs,
-            #[cfg(all(unix, feature = "acl"))]
+            #[cfg(all(any(unix, windows), feature = "acl"))]
             preserve_acls,
         )?;
     }

--- a/crates/engine/src/local_copy/executor/directory/recursive/mod.rs
+++ b/crates/engine/src/local_copy/executor/directory/recursive/mod.rs
@@ -272,7 +272,10 @@ pub(crate) fn copy_directory_recursive(
             source,
             destination,
             metadata,
-            #[cfg(all(unix, any(feature = "acl", feature = "xattr")))]
+            #[cfg(any(
+                all(unix, any(feature = "acl", feature = "xattr")),
+                all(windows, feature = "acl")
+            ))]
             mode,
             #[cfg(all(unix, feature = "xattr"))]
             preserve_xattrs,

--- a/crates/engine/src/local_copy/executor/file/copy/links.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/links.rs
@@ -18,7 +18,7 @@ use crate::local_copy::{
     find_reference_action, map_metadata_error, remove_source_entry_if_requested,
 };
 
-#[cfg(all(unix, feature = "acl"))]
+#[cfg(all(any(unix, windows), feature = "acl"))]
 use crate::local_copy::sync_acls_if_requested;
 #[cfg(all(unix, feature = "xattr"))]
 use crate::local_copy::sync_xattrs_if_requested;
@@ -58,7 +58,7 @@ pub(super) fn process_links(
     checksum_enabled: bool,
     mode: LocalCopyExecution,
     #[cfg(all(unix, feature = "xattr"))] preserve_xattrs: bool,
-    #[cfg(all(unix, feature = "acl"))] preserve_acls: bool,
+    #[cfg(all(any(unix, windows), feature = "acl"))] preserve_acls: bool,
 ) -> Result<LinkOutcome, LocalCopyError> {
     #[cfg(not(all(unix, any(feature = "xattr", feature = "acl"))))]
     let _ = mode;
@@ -230,11 +230,11 @@ pub(super) fn process_links(
                         }
                     },
                     {
-                        #[cfg(all(unix, feature = "acl"))]
+                        #[cfg(all(any(unix, windows), feature = "acl"))]
                         {
                             preserve_acls
                         }
-                        #[cfg(not(all(unix, feature = "acl")))]
+                        #[cfg(not(all(any(unix, windows), feature = "acl")))]
                         {
                             false
                         }
@@ -311,7 +311,7 @@ pub(super) fn process_links(
                         true,
                         context.filter_program(),
                     )?;
-                    #[cfg(all(unix, feature = "acl"))]
+                    #[cfg(all(any(unix, windows), feature = "acl"))]
                     sync_acls_if_requested(preserve_acls, mode, source, destination, true)?;
                     context.record_hard_link(metadata, destination);
                     context.summary_mut().record_hard_link();

--- a/crates/engine/src/local_copy/executor/file/copy/mod.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/mod.rs
@@ -45,7 +45,7 @@ pub(crate) fn copy_file(
 
     #[cfg(all(unix, feature = "xattr"))]
     let preserve_xattrs = context.xattrs_enabled();
-    #[cfg(all(unix, feature = "acl"))]
+    #[cfg(all(any(unix, windows), feature = "acl"))]
     let preserve_acls = context.acls_enabled();
 
     let record_path = relative
@@ -191,7 +191,7 @@ pub(crate) fn copy_file(
         mode,
         #[cfg(all(unix, feature = "xattr"))]
         preserve_xattrs,
-        #[cfg(all(unix, feature = "acl"))]
+        #[cfg(all(any(unix, windows), feature = "acl"))]
         preserve_acls,
     )?;
 
@@ -212,7 +212,7 @@ pub(crate) fn copy_file(
         checksum_enabled,
         #[cfg(all(unix, feature = "xattr"))]
         preserve_xattrs,
-        #[cfg(all(unix, feature = "acl"))]
+        #[cfg(all(any(unix, windows), feature = "acl"))]
         preserve_acls,
     };
 

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/execute.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/execute.rs
@@ -15,7 +15,7 @@ use logging::debug_log;
 
 use ::metadata::MetadataOptions;
 
-#[cfg(all(unix, feature = "acl"))]
+#[cfg(all(any(unix, windows), feature = "acl"))]
 use crate::local_copy::sync_acls_if_requested;
 #[cfg(all(unix, feature = "xattr"))]
 use crate::local_copy::sync_xattrs_if_requested;
@@ -75,7 +75,7 @@ pub(in crate::local_copy) fn execute_transfer(
         checksum_enabled: _,
         #[cfg(all(unix, feature = "xattr"))]
         preserve_xattrs,
-        #[cfg(all(unix, feature = "acl"))]
+        #[cfg(all(any(unix, windows), feature = "acl"))]
         preserve_acls,
     } = flags;
 
@@ -256,7 +256,7 @@ pub(in crate::local_copy) fn execute_transfer(
                 &mut None,
                 #[cfg(all(unix, feature = "xattr"))]
                 preserve_xattrs,
-                #[cfg(all(unix, feature = "acl"))]
+                #[cfg(all(any(unix, windows), feature = "acl"))]
                 preserve_acls,
             )?;
 
@@ -565,7 +565,7 @@ pub(in crate::local_copy) fn execute_transfer(
         &mut writer_for_metadata,
         #[cfg(all(unix, feature = "xattr"))]
         preserve_xattrs,
-        #[cfg(all(unix, feature = "acl"))]
+        #[cfg(all(any(unix, windows), feature = "acl"))]
         preserve_acls,
     )?;
 
@@ -652,7 +652,7 @@ fn try_skip_up_to_date(
         true,
         context.filter_program(),
     )?;
-    #[cfg(all(unix, feature = "acl"))]
+    #[cfg(all(any(unix, windows), feature = "acl"))]
     sync_acls_if_requested(flags.preserve_acls, mode, source, destination, true)?;
 
     context.record_hard_link(metadata, destination);

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/finalize.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/finalize.rs
@@ -41,7 +41,7 @@ pub(in crate::local_copy) fn finalize_guard_and_metadata(
     delay_updates_enabled: bool,
     writer_for_metadata: &mut Option<fs::File>,
     #[cfg(all(unix, feature = "xattr"))] preserve_xattrs: bool,
-    #[cfg(all(unix, feature = "acl"))] preserve_acls: bool,
+    #[cfg(all(any(unix, windows), feature = "acl"))] preserve_acls: bool,
 ) -> Result<(), LocalCopyError> {
     let relative_for_removal = Some(record_path.to_path_buf());
     if let Some(guard) = guard {
@@ -62,7 +62,7 @@ pub(in crate::local_copy) fn finalize_guard_and_metadata(
                 destination_path,
                 #[cfg(all(unix, feature = "xattr"))]
                 preserve_xattrs,
-                #[cfg(all(unix, feature = "acl"))]
+                #[cfg(all(any(unix, windows), feature = "acl"))]
                 preserve_acls,
             );
             context.register_deferred_update(update);
@@ -88,7 +88,7 @@ pub(in crate::local_copy) fn finalize_guard_and_metadata(
                 },
                 #[cfg(all(unix, feature = "xattr"))]
                 preserve_xattrs,
-                #[cfg(all(unix, feature = "acl"))]
+                #[cfg(all(any(unix, windows), feature = "acl"))]
                 preserve_acls,
             );
             #[cfg(unix)]
@@ -113,7 +113,7 @@ pub(in crate::local_copy) fn finalize_guard_and_metadata(
             },
             #[cfg(all(unix, feature = "xattr"))]
             preserve_xattrs,
-            #[cfg(all(unix, feature = "acl"))]
+            #[cfg(all(any(unix, windows), feature = "acl"))]
             preserve_acls,
         );
         #[cfg(unix)]

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/mod.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/mod.rs
@@ -53,7 +53,7 @@ pub(super) struct TransferFlags {
     #[cfg(all(unix, feature = "xattr"))]
     pub preserve_xattrs: bool,
     /// Whether to preserve ACLs (Unix only).
-    #[cfg(all(unix, feature = "acl"))]
+    #[cfg(all(any(unix, windows), feature = "acl"))]
     pub preserve_acls: bool,
 }
 
@@ -76,11 +76,11 @@ impl TransferFlags {
     /// accounting for compile-time feature flags.
     #[inline]
     pub(super) const fn acls_enabled(self) -> bool {
-        #[cfg(all(unix, feature = "acl"))]
+        #[cfg(all(any(unix, windows), feature = "acl"))]
         {
             self.preserve_acls
         }
-        #[cfg(not(all(unix, feature = "acl")))]
+        #[cfg(not(all(any(unix, windows), feature = "acl")))]
         {
             false
         }

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/special.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/special.rs
@@ -138,7 +138,7 @@ pub(in crate::local_copy) fn copy_special_as_regular_file(
         &mut no_writer,
         #[cfg(all(unix, feature = "xattr"))]
         flags.preserve_xattrs,
-        #[cfg(all(unix, feature = "acl"))]
+        #[cfg(all(any(unix, windows), feature = "acl"))]
         flags.preserve_acls,
     )?;
 

--- a/crates/engine/src/local_copy/executor/special/device.rs
+++ b/crates/engine/src/local_copy/executor/special/device.rs
@@ -11,7 +11,7 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use crate::local_copy::remove_existing_destination;
-#[cfg(all(unix, feature = "acl"))]
+#[cfg(all(any(unix, windows), feature = "acl"))]
 use crate::local_copy::sync_acls_if_requested;
 #[cfg(all(unix, feature = "xattr"))]
 use crate::local_copy::sync_xattrs_if_requested;
@@ -43,11 +43,11 @@ pub(crate) fn copy_device(
     let file_type = metadata.file_type();
     #[cfg(all(unix, feature = "xattr"))]
     let preserve_xattrs = context.xattrs_enabled();
-    #[cfg(all(unix, feature = "acl"))]
+    #[cfg(all(any(unix, windows), feature = "acl"))]
     let preserve_acls = context.acls_enabled();
     #[cfg(not(all(unix, feature = "xattr")))]
     let _ = context;
-    #[cfg(not(all(unix, feature = "acl")))]
+    #[cfg(not(all(any(unix, windows), feature = "acl")))]
     let _ = mode;
 
     let record_path = relative
@@ -180,7 +180,7 @@ pub(crate) fn copy_device(
                 true,
                 context.filter_program(),
             )?;
-            #[cfg(all(unix, feature = "acl"))]
+            #[cfg(all(any(unix, windows), feature = "acl"))]
             sync_acls_if_requested(preserve_acls, mode, source, destination, true)?;
 
             context.record_hard_link(metadata, destination);
@@ -239,7 +239,7 @@ pub(crate) fn copy_device(
         true,
         context.filter_program(),
     )?;
-    #[cfg(all(unix, feature = "acl"))]
+    #[cfg(all(any(unix, windows), feature = "acl"))]
     sync_acls_if_requested(preserve_acls, mode, source, destination, true)?;
 
     // Under fake-super, capture the would-be device's mode/uid/gid/rdev in

--- a/crates/engine/src/local_copy/executor/special/fifo.rs
+++ b/crates/engine/src/local_copy/executor/special/fifo.rs
@@ -11,7 +11,7 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use crate::local_copy::remove_existing_destination;
-#[cfg(all(unix, feature = "acl"))]
+#[cfg(all(any(unix, windows), feature = "acl"))]
 use crate::local_copy::sync_acls_if_requested;
 #[cfg(all(unix, feature = "xattr"))]
 use crate::local_copy::sync_xattrs_if_requested;
@@ -44,12 +44,12 @@ pub(crate) fn copy_fifo(
 
     #[cfg(all(unix, feature = "xattr"))]
     let preserve_xattrs = context.xattrs_enabled();
-    #[cfg(all(unix, feature = "acl"))]
+    #[cfg(all(any(unix, windows), feature = "acl"))]
     let preserve_acls = context.acls_enabled();
 
     #[cfg(not(all(unix, feature = "xattr")))]
     let _ = context;
-    #[cfg(not(all(unix, feature = "acl")))]
+    #[cfg(not(all(any(unix, windows), feature = "acl")))]
     let _ = mode;
 
     let record_path = relative
@@ -182,7 +182,7 @@ pub(crate) fn copy_fifo(
                 true,
                 context.filter_program(),
             )?;
-            #[cfg(all(unix, feature = "acl"))]
+            #[cfg(all(any(unix, windows), feature = "acl"))]
             sync_acls_if_requested(preserve_acls, mode, source, destination, true)?;
 
             context.record_hard_link(metadata, destination);
@@ -247,7 +247,7 @@ pub(crate) fn copy_fifo(
         true,
         context.filter_program(),
     )?;
-    #[cfg(all(unix, feature = "acl"))]
+    #[cfg(all(any(unix, windows), feature = "acl"))]
     sync_acls_if_requested(preserve_acls, mode, source, destination, true)?;
 
     // Under fake-super, capture the would-be FIFO/socket's mode/uid/gid in

--- a/crates/engine/src/local_copy/executor/special/symlink.rs
+++ b/crates/engine/src/local_copy/executor/special/symlink.rs
@@ -12,7 +12,7 @@ use std::path::{Component, Path, PathBuf};
 use std::time::Duration;
 
 use crate::local_copy::remove_existing_destination;
-#[cfg(all(unix, feature = "acl"))]
+#[cfg(all(any(unix, windows), feature = "acl"))]
 use crate::local_copy::sync_acls_if_requested;
 #[cfg(all(unix, feature = "xattr"))]
 use crate::local_copy::sync_xattrs_if_requested;
@@ -120,12 +120,12 @@ pub(crate) fn copy_symlink(
 
     #[cfg(all(unix, feature = "xattr"))]
     let preserve_xattrs = context.xattrs_enabled();
-    #[cfg(all(unix, feature = "acl"))]
+    #[cfg(all(any(unix, windows), feature = "acl"))]
     let preserve_acls = context.acls_enabled();
 
     #[cfg(not(all(unix, feature = "xattr")))]
     let _ = context;
-    #[cfg(not(all(unix, feature = "acl")))]
+    #[cfg(not(all(any(unix, windows), feature = "acl")))]
     let _ = mode;
 
     let record_path = relative
@@ -429,7 +429,7 @@ pub(crate) fn copy_symlink(
         false,
         context.filter_program(),
     )?;
-    #[cfg(all(unix, feature = "acl"))]
+    #[cfg(all(any(unix, windows), feature = "acl"))]
     sync_acls_if_requested(preserve_acls, mode, source, destination, false)?;
 
     context.record_hard_link(metadata, destination);

--- a/crates/engine/src/local_copy/metadata_sync.rs
+++ b/crates/engine/src/local_copy/metadata_sync.rs
@@ -3,16 +3,22 @@
 use super::LocalCopyError;
 use ::metadata::MetadataError;
 
-#[cfg(all(unix, any(feature = "acl", feature = "xattr")))]
+#[cfg(any(
+    all(unix, any(feature = "acl", feature = "xattr")),
+    all(windows, feature = "acl")
+))]
 use std::path::Path;
 
-#[cfg(all(unix, any(feature = "acl", feature = "xattr")))]
+#[cfg(any(
+    all(unix, any(feature = "acl", feature = "xattr")),
+    all(windows, feature = "acl")
+))]
 use super::LocalCopyExecution;
 
 #[cfg(all(unix, feature = "xattr"))]
 use super::FilterProgram;
 
-#[cfg(all(unix, feature = "acl"))]
+#[cfg(all(any(unix, windows), feature = "acl"))]
 use ::metadata::sync_acls;
 
 #[cfg(all(unix, feature = "xattr"))]
@@ -101,7 +107,7 @@ pub(crate) fn sync_xattrs_if_requested(
 /// - **Linux**: POSIX ACLs (access and default)
 /// - **macOS**: Extended ACLs (NFSv4-style)
 /// - **FreeBSD**: POSIX and NFSv4 ACLs
-#[cfg(all(unix, feature = "acl"))]
+#[cfg(all(any(unix, windows), feature = "acl"))]
 pub(crate) fn sync_acls_if_requested(
     preserve_acls: bool,
     mode: LocalCopyExecution,

--- a/crates/engine/src/local_copy/mod.rs
+++ b/crates/engine/src/local_copy/mod.rs
@@ -141,7 +141,7 @@ pub use hard_links::{HardlinkApplyResult, HardlinkApplyTracker};
 
 pub(crate) use metadata_sync::map_metadata_error;
 
-#[cfg(all(unix, feature = "acl"))]
+#[cfg(all(any(unix, windows), feature = "acl"))]
 pub(crate) use metadata_sync::sync_acls_if_requested;
 
 #[cfg(all(unix, feature = "xattr"))]

--- a/crates/engine/src/local_copy/options/builder/definition.rs
+++ b/crates/engine/src/local_copy/options/builder/definition.rs
@@ -84,7 +84,7 @@ pub struct LocalCopyOptionsBuilder {
     pub(super) group_override: Option<u32>,
     pub(super) copy_as: Option<CopyAsIds>,
     pub(super) omit_dir_times: bool,
-    #[cfg(all(unix, feature = "acl"))]
+    #[cfg(all(any(unix, windows), feature = "acl"))]
     pub(super) preserve_acls: bool,
 
     pub(super) filters: Option<FilterSet>,
@@ -211,7 +211,7 @@ impl LocalCopyOptionsBuilder {
             copy_as: None,
             omit_dir_times: false,
             omit_link_times: false,
-            #[cfg(all(unix, feature = "acl"))]
+            #[cfg(all(any(unix, windows), feature = "acl"))]
             preserve_acls: false,
             filters: None,
             filter_program: None,

--- a/crates/engine/src/local_copy/options/builder/setters_metadata.rs
+++ b/crates/engine/src/local_copy/options/builder/setters_metadata.rs
@@ -141,7 +141,7 @@ impl LocalCopyOptionsBuilder {
     }
 
     /// Enables ACL preservation.
-    #[cfg(all(unix, feature = "acl"))]
+    #[cfg(all(any(unix, windows), feature = "acl"))]
     #[must_use]
     pub fn preserve_acls(mut self, enabled: bool) -> Self {
         self.preserve_acls = enabled;
@@ -149,7 +149,7 @@ impl LocalCopyOptionsBuilder {
     }
 
     /// Alias for `preserve_acls` for rsync compatibility.
-    #[cfg(all(unix, feature = "acl"))]
+    #[cfg(all(any(unix, windows), feature = "acl"))]
     #[must_use]
     pub fn acls(mut self, enabled: bool) -> Self {
         self.preserve_acls = enabled;

--- a/crates/engine/src/local_copy/options/builder/validation.rs
+++ b/crates/engine/src/local_copy/options/builder/validation.rs
@@ -134,7 +134,7 @@ impl LocalCopyOptionsBuilder {
             group_override: self.group_override,
             copy_as: self.copy_as,
             omit_dir_times: self.omit_dir_times,
-            #[cfg(all(unix, feature = "acl"))]
+            #[cfg(all(any(unix, windows), feature = "acl"))]
             preserve_acls: self.preserve_acls,
             filters: self.filters,
             filter_program: self.filter_program,

--- a/crates/engine/src/local_copy/options/metadata/accessors.rs
+++ b/crates/engine/src/local_copy/options/metadata/accessors.rs
@@ -98,14 +98,14 @@ impl LocalCopyOptions {
         self.omit_link_times
     }
 
-    #[cfg(all(unix, feature = "acl"))]
+    #[cfg(all(any(unix, windows), feature = "acl"))]
     /// Returns whether POSIX ACLs should be preserved.
     #[must_use]
     pub const fn preserve_acls(&self) -> bool {
         self.preserve_acls
     }
 
-    #[cfg(all(unix, feature = "acl"))]
+    #[cfg(all(any(unix, windows), feature = "acl"))]
     /// Reports whether ACL preservation is enabled.
     #[must_use]
     pub const fn acls_enabled(&self) -> bool {

--- a/crates/engine/src/local_copy/options/metadata/setters.rs
+++ b/crates/engine/src/local_copy/options/metadata/setters.rs
@@ -145,7 +145,7 @@ impl LocalCopyOptions {
         self
     }
 
-    #[cfg(all(unix, feature = "acl"))]
+    #[cfg(all(any(unix, windows), feature = "acl"))]
     /// Requests that POSIX ACLs be preserved when applying metadata.
     #[must_use]
     #[doc(alias = "--acls")]

--- a/crates/engine/src/local_copy/options/types.rs
+++ b/crates/engine/src/local_copy/options/types.rs
@@ -124,7 +124,7 @@ pub struct LocalCopyOptions {
     pub(super) group_override: Option<u32>,
     pub(super) copy_as: Option<CopyAsIds>,
     pub(super) omit_dir_times: bool,
-    #[cfg(all(unix, feature = "acl"))]
+    #[cfg(all(any(unix, windows), feature = "acl"))]
     pub(super) preserve_acls: bool,
     pub(super) filters: Option<FilterSet>,
     pub(super) filter_program: Option<FilterProgram>,
@@ -266,7 +266,7 @@ impl LocalCopyOptions {
             copy_as: None,
             omit_dir_times: false,
             omit_link_times: false,
-            #[cfg(all(unix, feature = "acl"))]
+            #[cfg(all(any(unix, windows), feature = "acl"))]
             preserve_acls: false,
             filters: None,
             filter_program: None,

--- a/crates/engine/src/local_copy/tests/execute_archive.rs
+++ b/crates/engine/src/local_copy/tests/execute_archive.rs
@@ -274,7 +274,7 @@ fn archive_does_not_enable_xattrs() {
     );
 }
 
-#[cfg(all(unix, feature = "acl"))]
+#[cfg(all(any(unix, windows), feature = "acl"))]
 #[test]
 fn archive_does_not_enable_acls() {
     let options = LocalCopyOptions::builder()

--- a/crates/engine/src/local_copy/tests/filters.rs
+++ b/crates/engine/src/local_copy/tests/filters.rs
@@ -316,7 +316,7 @@ fn deferred_updates_flush_commits_pending_files() {
         final_path,
         #[cfg(all(unix, feature = "xattr"))]
         context.xattrs_enabled(),
-        #[cfg(all(unix, feature = "acl"))]
+        #[cfg(all(any(unix, windows), feature = "acl"))]
         context.acls_enabled(),
     );
 

--- a/crates/transfer/src/flags.rs
+++ b/crates/transfer/src/flags.rs
@@ -154,8 +154,8 @@ impl ParsedServerFlags {
         #[allow(unused_mut)] // REASON: mutated when acl or xattr features are not enabled
         let mut cleared = Vec::new();
 
-        // ACL support requires the `acl` feature on Unix.
-        #[cfg(not(all(unix, feature = "acl")))]
+        // ACL support requires the `acl` feature (Unix POSIX/NFSv4 ACLs or Windows DACLs).
+        #[cfg(not(all(any(unix, windows), feature = "acl")))]
         if self.acls {
             self.acls = false;
             cleared.push("ACLs");
@@ -468,13 +468,13 @@ mod tests {
         assert!(flags.acls);
         let cleared = flags.clear_unsupported_features();
 
-        #[cfg(all(unix, feature = "acl"))]
+        #[cfg(all(any(unix, windows), feature = "acl"))]
         {
             assert!(cleared.is_empty());
             assert!(flags.acls);
         }
 
-        #[cfg(not(all(unix, feature = "acl")))]
+        #[cfg(not(all(any(unix, windows), feature = "acl")))]
         {
             assert_eq!(cleared, vec!["ACLs"]);
             assert!(!flags.acls);
@@ -528,9 +528,9 @@ mod tests {
         }
 
         // After clearing, the flag matches whether the feature is available.
-        #[cfg(all(unix, feature = "acl"))]
+        #[cfg(all(any(unix, windows), feature = "acl"))]
         assert!(flags.acls, "ACLs should remain when feature is available");
-        #[cfg(not(all(unix, feature = "acl")))]
+        #[cfg(not(all(any(unix, windows), feature = "acl")))]
         assert!(!flags.acls, "ACLs should be cleared when feature is absent");
 
         #[cfg(all(unix, feature = "xattr"))]


### PR DESCRIPTION
## Summary

- Wires the existing `metadata::acl_windows` (Win32 `GetNamedSecurityInfoW` / `SetNamedSecurityInfoW`) implementation into the engine pipeline so `--acls` / `-A` now reaches the Windows code path.
- Widens 99 cfg gates across 40 files in cli/core/engine/transfer from `cfg(all(unix, feature = "acl"))` to `cfg(all(any(unix, windows), feature = "acl"))`. Tests/fixtures that drive raw libacl/exacl FFI remain unix-only.
- Updates the preflight check and drive config so the Windows DACL dispatch is invoked instead of reporting "POSIX ACLs are not supported on this client".

## Context

The metadata-layer Windows ACL implementation already existed (commit 9b3a07f1) but was unreachable because every engine call site gated ACL handling on `cfg(all(unix, feature = "acl"))`. SID-to-uid mapping follows upstream `acls.c:902-928`. SACLs are intentionally skipped (require `SE_SECURITY_NAME` privilege).

## Test plan

- [ ] CI fmt + clippy
- [ ] CI nextest (stable) on Linux, macOS, Windows
- [ ] CI Linux musl
- [ ] Manual: `oc-rsync -aA src dst` on Windows preserves DACL ACEs across copy

Refs #1866