### PR TITLE
feat(daemon,transfer): consume fake super = yes module directive (#1904)

### DIFF
--- a/crates/daemon/src/daemon/sections/module_access/client_args.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args.rs
@@ -282,6 +282,13 @@ fn build_server_config(
             // never apply it, leaving --iconv negotiation a silent no-op.
             cfg.connection.iconv = resolve_module_charset_converter(module.charset.as_deref());
 
+            // upstream: clientserver.c:1106-1107 - `fake super = yes` on the
+            // daemon module demotes the receiver's am_root and forces fake-super
+            // semantics regardless of whether the client requested --fake-super.
+            // The directive is purely daemon-config-driven; client --fake-super
+            // is demoted to --super on the wire and never reaches us.
+            cfg.fake_super = module.fake_super;
+
             Ok(Some(cfg))
         }
         Err(err) => {

--- a/crates/daemon/src/tests.rs
+++ b/crates/daemon/src/tests.rs
@@ -339,6 +339,8 @@ include!("tests/chunks/daemon_safe_links_copy_links_push.rs");
 include!("tests/chunks/daemon_unicode_emoji_filenames.rs");
 // Daemon xattr preservation push test
 include!("tests/chunks/daemon_xattr_push.rs");
+// Daemon `fake super = yes` module directive end-to-end test
+include!("tests/chunks/daemon_fake_super_module_push.rs");
 // Daemon ACL push end-to-end test
 include!("tests/chunks/daemon_acl_push.rs");
 // Daemon INC_RECURSE push end-to-end test

--- a/crates/daemon/src/tests/chunks/daemon_fake_super_module_push.rs
+++ b/crates/daemon/src/tests/chunks/daemon_fake_super_module_push.rs
@@ -1,0 +1,157 @@
+/// End-to-end test for the `fake super = yes` daemon module directive.
+///
+/// Verifies that the daemon honours its module-config `fake super = yes`
+/// directive end-to-end: a non-root client pushes a file with `--owner`
+/// and `--group`, and the daemon receiver stores the ownership metadata
+/// in the `user.rsync.%stat` xattr instead of calling `chown` (which
+/// would fail without privileges).
+///
+/// # Wiring under test
+///
+/// `ModuleConfig.fake_super` -> `ServerConfig.fake_super` ->
+/// `MetadataOptions.fake_super` -> `apply_ownership_via_fake_super`.
+///
+/// Without the wire-up, the directive is parsed but never reaches the
+/// receiver, so a non-root daemon pushing with `-og` either fails the
+/// chown silently or leaves no metadata at all.
+///
+/// # Filesystem probe
+///
+/// User-namespace xattrs (`user.*`) are required. Some filesystems
+/// (e.g. tmpfs on older kernels) do not support them; the test probes
+/// for support and skips gracefully when absent.
+///
+/// # Upstream Reference
+///
+/// - `clientserver.c:1106-1107` - daemon `fake super = yes` demotes the
+///   receiver's `am_root` and forces fake-super semantics.
+/// - `loadparm.c` - `fake super` module parameter.
+/// - `rsync.c:set_file_attrs()` - fake-super stores ownership in xattrs.
+/// - `xattrs.c:set_stat_xattr()` - encodes mode/uid/gid into the
+///   `user.rsync.%stat` xattr.
+#[cfg(unix)]
+#[test]
+fn daemon_fake_super_module_directive_stores_ownership_in_xattr() {
+    let _lock = ENV_LOCK.lock().expect("env lock");
+    let _primary = EnvGuard::set(DAEMON_FALLBACK_ENV, OsStr::new("0"));
+    let _secondary = EnvGuard::set(CLIENT_FALLBACK_ENV, OsStr::new("0"));
+
+    let temp = tempdir().expect("tempdir");
+
+    // Probe the filesystem for user-namespace xattr support before going
+    // through the full daemon dance. tmpfs on older kernels and some CI
+    // overlays reject user.* writes outright.
+    let probe_file = temp.path().join(".fake_super_probe");
+    fs::write(&probe_file, b"probe").expect("write probe file");
+    if xattr::set(&probe_file, "user.probe", b"1").is_err() {
+        eprintln!(
+            "skipping daemon_fake_super_module_directive_stores_ownership_in_xattr: \
+             filesystem does not support user xattrs"
+        );
+        return;
+    }
+    fs::remove_file(&probe_file).expect("remove probe file");
+
+    let source_dir = temp.path().join("source");
+    fs::create_dir(&source_dir).expect("create source");
+
+    let payload_path = source_dir.join("ledger.txt");
+    fs::write(&payload_path, b"fake-super module payload\n").expect("write source payload");
+
+    let dest_dir = temp.path().join("dest");
+    fs::create_dir(&dest_dir).expect("create dest");
+
+    let config_file = temp.path().join("rsyncd.conf");
+    let config_content = format!(
+        "[fakesuper]\n\
+         path = {}\n\
+         read only = false\n\
+         use chroot = false\n\
+         fake super = yes\n",
+        dest_dir.display()
+    );
+    fs::write(&config_file, config_content).expect("write daemon config");
+
+    let (port, held_listener) = allocate_test_port();
+
+    let daemon_config = DaemonConfig::builder()
+        .disable_default_paths()
+        .arguments([
+            OsString::from("--config"),
+            config_file.as_os_str().to_owned(),
+            OsString::from("--port"),
+            OsString::from(port.to_string()),
+            OsString::from("--max-sessions"),
+            OsString::from("2"),
+        ])
+        .build();
+
+    let (probe_stream, daemon_handle) = start_daemon(daemon_config, port, held_listener);
+    drop(probe_stream);
+
+    let mut source_arg = source_dir.clone().into_os_string();
+    source_arg.push("/");
+    let rsync_url = format!("rsync://127.0.0.1:{port}/fakesuper/");
+
+    // -o + -g make the receiver's MetadataOptions request ownership
+    // preservation. Without `fake super = yes` wired through, the daemon
+    // would attempt chown(); with it, ownership is recorded in the
+    // user.rsync.%stat xattr instead.
+    let client_config = core::client::ClientConfig::builder()
+        .transfer_args([source_arg, OsString::from(&rsync_url)])
+        .owner(true)
+        .group(true)
+        .build();
+
+    let result = core::client::run_client(client_config);
+
+    match &result {
+        Ok(summary) => {
+            assert!(
+                summary.files_copied() >= 1,
+                "expected at least 1 file transferred, got {}",
+                summary.files_copied()
+            );
+        }
+        Err(e) => {
+            let _ = daemon_handle.join();
+            panic!("fake-super module push failed: {e}");
+        }
+    }
+
+    let dest_payload = dest_dir.join("ledger.txt");
+    assert!(
+        dest_payload.exists(),
+        "ledger.txt must exist at the destination after the push"
+    );
+    assert_eq!(
+        fs::read(&dest_payload).expect("read dest payload"),
+        b"fake-super module payload\n",
+        "destination payload content must match the source"
+    );
+
+    // The wire-up assertion: with `fake super = yes` on the module, the
+    // receiver must have stored ownership in the user.rsync.%stat xattr.
+    // upstream: xattrs.c:set_stat_xattr() encodes mode/uid/gid into this
+    // single xattr, used by xattrs.c:read_stat_xattr() on restore.
+    let stat_xattr = xattr::get(&dest_payload, "user.rsync.%stat")
+        .expect("read user.rsync.%stat from destination payload")
+        .expect(
+            "user.rsync.%stat must be present on the destination when \
+             `fake super = yes` is configured on the daemon module",
+        );
+
+    let stat_text = String::from_utf8(stat_xattr).expect("user.rsync.%stat must be UTF-8");
+    // upstream: xattrs.c:set_stat_xattr() format is "<mode_octal> <rdev_major>,<rdev_minor> <uid>:<gid>".
+    assert!(
+        stat_text.contains(":"),
+        "user.rsync.%stat must encode uid:gid (got {stat_text:?})"
+    );
+    assert!(
+        stat_text.contains(","),
+        "user.rsync.%stat must encode rdev_major,rdev_minor (got {stat_text:?})"
+    );
+
+    let daemon_result = daemon_handle.join().expect("daemon thread");
+    let _ = daemon_result;
+}

--- a/crates/transfer/src/config/builder.rs
+++ b/crates/transfer/src/config/builder.rs
@@ -84,6 +84,7 @@ pub struct ServerConfigBuilder {
     do_stats: bool,
     temp_dir: Option<PathBuf>,
     skip_compress: Option<SkipCompressList>,
+    fake_super: bool,
 }
 
 impl Default for ServerConfigBuilder {
@@ -119,6 +120,7 @@ impl ServerConfigBuilder {
             do_stats: false,
             temp_dir: None,
             skip_compress: None,
+            fake_super: false,
         }
     }
 
@@ -422,6 +424,26 @@ impl ServerConfigBuilder {
         self
     }
 
+    // -- Fake super --
+
+    /// Enables or disables daemon-side fake-super metadata storage.
+    ///
+    /// Sourced from the daemon module's `fake super = yes` directive in
+    /// `rsyncd.conf(5)`. When true, ownership and special-file metadata are
+    /// stored in the `user.rsync.%stat` xattr instead of being applied
+    /// directly to inodes, allowing a non-root daemon receiver to preserve
+    /// privileged metadata.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `clientserver.c:1106-1107` - daemon `fake super = yes` demotes
+    ///   `am_root` and forces `--fake-super` semantics on the receiver
+    /// - `loadparm.c` - `fake super` module parameter
+    pub fn fake_super(&mut self, enabled: bool) -> &mut Self {
+        self.fake_super = enabled;
+        self
+    }
+
     // -- Validation and build --
 
     /// Validates the builder configuration.
@@ -499,6 +521,7 @@ impl ServerConfigBuilder {
             do_stats: self.do_stats,
             temp_dir: self.temp_dir.clone(),
             skip_compress: self.skip_compress.clone(),
+            fake_super: self.fake_super,
         }
     }
 }

--- a/crates/transfer/src/config/builder_tests.rs
+++ b/crates/transfer/src/config/builder_tests.rs
@@ -196,6 +196,27 @@ mod defaults {
         assert!(!config.do_stats);
         assert!(config.temp_dir.is_none());
         assert!(config.skip_compress.is_none());
+        assert!(!config.fake_super);
+    }
+
+    /// Daemon-side `fake super = yes` flows through the builder into
+    /// `ServerConfig.fake_super`, which the receiver then forwards into
+    /// `MetadataOptions.fake_super` so ownership/special-file metadata is
+    /// stored in the `user.rsync.%stat` xattr instead of being applied to
+    /// inodes (upstream: `clientserver.c:1106-1107`).
+    #[test]
+    fn fake_super_round_trips_through_builder() {
+        let enabled = ServerConfigBuilder::new()
+            .fake_super(true)
+            .build()
+            .expect("valid");
+        assert!(enabled.fake_super);
+
+        let disabled = ServerConfigBuilder::new()
+            .fake_super(false)
+            .build()
+            .expect("valid");
+        assert!(!disabled.fake_super);
     }
 }
 

--- a/crates/transfer/src/config/mod.rs
+++ b/crates/transfer/src/config/mod.rs
@@ -313,6 +313,28 @@ pub struct ServerConfig {
     /// - `token.c:do_compression` - per-file compression decision
     /// - `loadparm.c` - `dont compress` daemon parameter
     pub skip_compress: Option<SkipCompressList>,
+    /// When true, store privileged metadata (uid/gid, devices, special files) in
+    /// the `user.rsync.%stat` xattr instead of applying it directly to inodes.
+    ///
+    /// Sourced from the daemon module's `fake super = yes` directive in
+    /// `rsyncd.conf(5)`. Lets a non-root daemon receive ownership and special-file
+    /// metadata from a privileged client by recording it in xattrs that a later
+    /// privileged restore can replay.
+    ///
+    /// Mirrors upstream's behaviour where a daemon module with `fake super = yes`
+    /// demotes the receiver's `am_root` to the fake-super marker (`-1`) and
+    /// rewrites a client's `--fake-super` so the daemon honours the directive
+    /// even when the client did not request it. The directive is purely
+    /// daemon-config-driven; this flag is set by the daemon when constructing
+    /// [`ServerConfig`] and is never populated from a client `--fake-super` arg.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `clientserver.c:1106-1107` - daemon `fake super = yes` demotes
+    ///   `am_root` and forces `--fake-super` semantics on the receiver
+    /// - `loadparm.c` - `fake super` module parameter
+    /// - `rsync.c:set_file_attrs()` - fake-super stores ownership in xattrs
+    pub fake_super: bool,
 }
 
 impl Default for ServerConfig {
@@ -340,6 +362,7 @@ impl Default for ServerConfig {
             do_stats: false,
             temp_dir: None,
             skip_compress: None,
+            fake_super: false,
         }
     }
 }

--- a/crates/transfer/src/receiver/transfer.rs
+++ b/crates/transfer/src/receiver/transfer.rs
@@ -928,7 +928,12 @@ impl ReceiverContext {
             .preserve_crtimes(self.config.flags.crtimes)
             .preserve_owner(self.config.flags.owner)
             .preserve_group(self.config.flags.group)
-            .numeric_ids(self.config.flags.numeric_ids);
+            .numeric_ids(self.config.flags.numeric_ids)
+            // upstream: clientserver.c:1106-1107 - `fake super = yes` on the
+            // daemon module forces fake-super metadata storage on the receiver
+            // (ownership and special-file metadata go to user.rsync.%stat
+            // xattrs instead of being applied to inodes).
+            .fake_super(self.config.fake_super);
 
         let dest_dir = self
             .config


### PR DESCRIPTION
## Summary
- Threads the daemon module directive `fake super = yes` from `ModuleConfig.fake_super` through `ServerConfig.fake_super` and into `MetadataOptions.fake_super`, so daemon-side receivers honour the directive end-to-end.
- Previously, `fake super = yes` was parsed but never consumed: receivers issued real `chown()` calls regardless of the directive, which silently dropped ownership for non-root daemons and contradicted upstream's `clientserver.c:1106-1107` semantics.
- Adds an end-to-end daemon push test that pushes with `-og` to a module configured with `fake super = yes` and asserts the destination carries the `user.rsync.%stat` xattr.

## Wire-up path
```
ModuleConfig.fake_super (already parsed)
  -> ServerConfig.fake_super              [transfer/config]
    -> MetadataOptions.fake_super         [transfer/receiver/transfer.rs]
      -> apply_ownership_via_fake_super   [metadata/apply/ownership.rs] (already in place)
        -> store user.rsync.%stat xattr   [metadata/fake_super.rs] (already in place)
```

## Files changed
- `crates/transfer/src/config/mod.rs` (+23): add `pub fake_super: bool` field with upstream-cited rustdoc.
- `crates/transfer/src/config/builder.rs` (+23): add `.fake_super(bool)` builder method.
- `crates/transfer/src/config/builder_tests.rs` (+21): default-false assertion and round-trip test.
- `crates/daemon/src/daemon/sections/module_access/client_args.rs` (+7): set `cfg.fake_super = module.fake_super` in `build_server_config`.
- `crates/transfer/src/receiver/transfer.rs` (+6/-1): chain `.fake_super(self.config.fake_super)` on the receiver's `MetadataOptions::new()` builder.
- `crates/daemon/src/tests/chunks/daemon_fake_super_module_push.rs` (+158, new): end-to-end daemon test.
- `crates/daemon/src/tests.rs` (+2): wire the new chunk into the test harness.

## Upstream references
- `clientserver.c:1106-1107` — daemon `fake super = yes` demotes the receiver's `am_root` and forces fake-super semantics regardless of client args.
- `loadparm.c` — `fake super` module parameter parsing.
- `rsync.c:set_file_attrs()` — fake-super stores ownership in xattrs.
- `xattrs.c:set_stat_xattr()` — `user.rsync.%stat` encoding format.

Per upstream, client `--fake-super` is demoted to `--super` on the wire before reaching the daemon, so the directive is purely daemon-config-driven; we do not parse `--fake-super` server-side.

## Test plan
- [x] `crates/daemon/src/tests/chunks/daemon_fake_super_module_push.rs` covers the end-to-end daemon push case (skips gracefully on filesystems without user.* xattr support).
- [x] `crates/transfer/src/config/builder_tests.rs::fake_super_round_trips_through_builder` covers the builder.
- [x] `crates/transfer/src/config/builder_tests.rs::default_optional_fields` adds the default-false assertion.
- [x] Existing `crates/daemon/src/rsyncd_config/tests.rs::module_fake_super_yes_parses_to_true_for_am_root_demotion` covers the parser side (unchanged).
- [ ] CI: fmt+clippy, nextest stable, Windows stable, macOS stable, Linux musl stable.

Closes #1904.