### PR TITLE
fix(checksums): rolling checksum sign-extends bytes to match upstream schar

### DIFF
--- a/crates/checksums/src/rolling/checksum/mod.rs
+++ b/crates/checksums/src/rolling/checksum/mod.rs
@@ -190,7 +190,8 @@ impl RollingChecksum {
     /// ```
     #[inline]
     pub fn update_byte(&mut self, byte: u8) {
-        let b = u32::from(byte);
+        // upstream: checksum.c:285 - schar *buf sign-extends bytes to int
+        let b = ((byte as i8) as i32) as u32;
         self.s1 = (self.s1.wrapping_add(b)) & 0xffff;
         self.s2 = (self.s2.wrapping_add(self.s1)) & 0xffff;
         self.len = self.len.saturating_add(1);
@@ -332,8 +333,9 @@ impl RollingChecksum {
     pub fn roll(&mut self, outgoing: u8, incoming: u8) -> Result<(), RollingError> {
         let window_len = self.window_len_u32()?;
 
-        let out = u32::from(outgoing);
-        let inn = u32::from(incoming);
+        // upstream: checksum.c - schar interpretation sign-extends bytes to int
+        let out = ((outgoing as i8) as i32) as u32;
+        let inn = ((incoming as i8) as i32) as u32;
 
         let new_s1 = self.s1.wrapping_sub(out).wrapping_add(inn) & 0xffff;
         let new_s2 = self
@@ -406,8 +408,9 @@ impl RollingChecksum {
 
         let mut weight = count_i128;
         for (&out_b, &in_b) in outgoing.iter().zip(incoming.iter()) {
-            let outgoing_val = i128::from(out_b);
-            let incoming_val = i128::from(in_b);
+            // upstream: checksum.c - schar interpretation sign-extends bytes
+            let outgoing_val = i128::from(out_b as i8);
+            let incoming_val = i128::from(in_b as i8);
             let delta = incoming_val - outgoing_val;
 
             sum_outgoing += outgoing_val;
@@ -556,6 +559,11 @@ const fn mask_result((s1, s2, len): (u32, u32, usize)) -> (u32, u32, usize) {
 }
 
 /// Scalar fallback matching upstream `checksum.c:get_checksum1()` byte loop.
+///
+/// Upstream casts the buffer to `schar *` (signed char), so each byte contributes
+/// in the range -128..127 rather than 0..255. We replicate that by sign-extending
+/// each byte through `i8` -> `i32` before folding into the accumulators with
+/// wrapping arithmetic.
 #[inline]
 fn accumulate_chunk_scalar_raw(
     mut s1: u32,
@@ -569,25 +577,32 @@ fn accumulate_chunk_scalar_raw(
 
     let mut iter = chunk.chunks_exact(4);
     for block in &mut iter {
-        s1 = s1.wrapping_add(u32::from(block[0]));
+        s1 = s1.wrapping_add(sign_extend_byte(block[0]));
         s2 = s2.wrapping_add(s1);
 
-        s1 = s1.wrapping_add(u32::from(block[1]));
+        s1 = s1.wrapping_add(sign_extend_byte(block[1]));
         s2 = s2.wrapping_add(s1);
 
-        s1 = s1.wrapping_add(u32::from(block[2]));
+        s1 = s1.wrapping_add(sign_extend_byte(block[2]));
         s2 = s2.wrapping_add(s1);
 
-        s1 = s1.wrapping_add(u32::from(block[3]));
+        s1 = s1.wrapping_add(sign_extend_byte(block[3]));
         s2 = s2.wrapping_add(s1);
     }
 
     for &byte in iter.remainder() {
-        s1 = s1.wrapping_add(u32::from(byte));
+        s1 = s1.wrapping_add(sign_extend_byte(byte));
         s2 = s2.wrapping_add(s1);
     }
 
     (s1, s2, len.saturating_add(chunk.len()))
+}
+
+/// Sign-extends a byte to `u32` so it folds into the rolling accumulators with
+/// the same -128..127 contribution that upstream `schar *buf` produces.
+#[inline]
+const fn sign_extend_byte(byte: u8) -> u32 {
+    ((byte as i8) as i32) as u32
 }
 
 /// Flushes accumulated bytes from the scratch buffer into the checksum state.

--- a/crates/checksums/src/rolling/checksum/neon.rs
+++ b/crates/checksums/src/rolling/checksum/neon.rs
@@ -38,20 +38,26 @@
 //! # Performance
 //!
 //! NEON processes 16 bytes per iteration using vector multiply-accumulate operations.
-//! The weighted sum computation uses `vmulq_u16` and `vaddvq_u16` for efficient reduction.
+//! Bytes are reinterpreted as `int8x16_t` and sign-extended via `vmovl_s8` so the
+//! accumulators carry the same -128..127 contribution as upstream's `schar *buf`.
+//! The weighted sum uses `vmulq_s16` (safe, max product magnitude 2048 fits in i16)
+//! and `vaddlvq_s16` for widening reduction into i32 to avoid horizontal overflow.
 
 #![allow(unsafe_code)]
 #![allow(unsafe_op_in_unsafe_fn)]
 
 use super::accumulate_chunk_scalar_raw;
 use core::arch::aarch64::{
-    uint16x8_t, vaddvq_u16, vget_high_u8, vget_low_u8, vld1q_u8, vld1q_u16, vmovl_u8, vmulq_u16,
+    int16x8_t, vaddlvq_s16, vget_high_s8, vget_low_s8, vld1q_s16, vld1q_u8, vmovl_s8, vmulq_s16,
+    vreinterpretq_s8_u8,
 };
 use std::sync::OnceLock;
 
 const BLOCK_LEN: usize = 16;
-const HIGH_WEIGHTS: [u16; 8] = [16, 15, 14, 13, 12, 11, 10, 9];
-const LOW_WEIGHTS: [u16; 8] = [8, 7, 6, 5, 4, 3, 2, 1];
+// upstream: checksum.c:285 - schar *buf treats bytes as signed [-128,127].
+// Weights map byte i to (BLOCK_LEN - i) for the prefix-sum contribution to s2.
+const HIGH_WEIGHTS: [i16; 8] = [16, 15, 14, 13, 12, 11, 10, 9];
+const LOW_WEIGHTS: [i16; 8] = [8, 7, 6, 5, 4, 3, 2, 1];
 
 static NEON_AVAILABLE: OnceLock<bool> = OnceLock::new();
 
@@ -84,21 +90,29 @@ unsafe fn accumulate_chunk_neon_impl(
     mut len: usize,
     mut chunk: &[u8],
 ) -> (u32, u32, usize) {
-    let high_weights: uint16x8_t = vld1q_u16(HIGH_WEIGHTS.as_ptr());
-    let low_weights: uint16x8_t = vld1q_u16(LOW_WEIGHTS.as_ptr());
+    let high_weights: int16x8_t = vld1q_s16(HIGH_WEIGHTS.as_ptr());
+    let low_weights: int16x8_t = vld1q_s16(LOW_WEIGHTS.as_ptr());
 
     while chunk.len() >= BLOCK_LEN {
-        let bytes = vld1q_u8(chunk.as_ptr());
-        let high = vmovl_u8(vget_low_u8(bytes));
-        let low = vmovl_u8(vget_high_u8(bytes));
+        // Load as u8x16 then reinterpret as i8x16 - upstream `schar *buf` cast.
+        let bytes_signed = vreinterpretq_s8_u8(vld1q_u8(chunk.as_ptr()));
+        // Sign-extend each half to int16x8_t so multiplications and weighted
+        // sums stay in the signed [-128,127] domain.
+        let high = vmovl_s8(vget_low_s8(bytes_signed));
+        let low = vmovl_s8(vget_high_s8(bytes_signed));
 
-        let sum_high = vaddvq_u16(high);
-        let sum_low = vaddvq_u16(low);
-        let block_sum = (sum_high + sum_low) as u32;
+        // vaddlvq_s16 widens the reduction to i32, avoiding the i16 overflow
+        // risk inherent in vaddvq_s16 when many lanes share a sign.
+        let sum_high = vaddlvq_s16(high);
+        let sum_low = vaddlvq_s16(low);
+        let block_sum = sum_high.wrapping_add(sum_low) as u32;
 
-        let weighted_high = vmulq_u16(high, high_weights);
-        let weighted_low = vmulq_u16(low, low_weights);
-        let block_prefix = (vaddvq_u16(weighted_high) + vaddvq_u16(weighted_low)) as u32;
+        // vmulq_s16 truncates to i16, but products are in [-2048, 2032]
+        // which fits with margin.
+        let weighted_high = vmulq_s16(high, high_weights);
+        let weighted_low = vmulq_s16(low, low_weights);
+        let block_prefix =
+            vaddlvq_s16(weighted_high).wrapping_add(vaddlvq_s16(weighted_low)) as u32;
 
         s2 = s2.wrapping_add(block_prefix);
         s2 = s2.wrapping_add(s1.wrapping_mul(BLOCK_LEN as u32));

--- a/crates/checksums/src/rolling/checksum/tests.rs
+++ b/crates/checksums/src/rolling/checksum/tests.rs
@@ -663,10 +663,11 @@ fn golden_test_all_ff() {
     let data = [0xFFu8; 16];
     let mut checksum = RollingChecksum::new();
     checksum.update(&data);
-    // s1 = 16 * 255 = 4080 = 0x0ff0
-    // s2 = 255*1 + 255*2 + ... + 255*16 = 255 * (16*17/2) = 255 * 136 = 34680 = 0x8778
-    // value = (s2 << 16) | s1 = 0x8778_0ff0
-    assert_eq!(checksum.value(), 0x8778_0ff0);
+    // upstream: checksum.c:285 reads bytes via `schar *buf`, so 0xFF == -1.
+    // s1 = 16 * (-1) = -16, masked to u16 = 0xfff0
+    // s2 = (-1)*16 + (-1)*15 + ... + (-1)*1 = -136, masked to u16 = 0xff78
+    // value = (s2 << 16) | s1 = 0xff78_fff0
+    assert_eq!(checksum.value(), 0xff78_fff0);
 }
 
 #[test]
@@ -694,9 +695,10 @@ fn golden_test_block_length_700() {
     }
     let mut checksum = RollingChecksum::new();
     checksum.update(&data);
-    // Pre-computed golden value (architecture-independent)
-    // This value was verified against the scalar implementation
-    assert_eq!(checksum.value(), 0xe2ea_5c96);
+    // Pre-computed golden value (architecture-independent), verified against
+    // a signed-Adler reference matching upstream `schar *buf` semantics
+    // (see upstream `checksum.c:285`).
+    assert_eq!(checksum.value(), 0x01ea_fe96);
     assert_eq!(checksum.len(), 700);
 }
 
@@ -709,7 +711,9 @@ fn golden_test_block_length_4096() {
     }
     let mut checksum = RollingChecksum::new();
     checksum.update(&data);
-    // Pre-computed golden value (architecture-independent)
+    // Pre-computed golden value (architecture-independent), reverified against
+    // a signed-Adler reference after the signed-byte fix
+    // (upstream `checksum.c:285` interprets bytes as `schar`).
     assert_eq!(checksum.value(), 0x2000_f800);
     assert_eq!(checksum.len(), 4096);
 }

--- a/crates/checksums/src/rolling/checksum/x86.rs
+++ b/crates/checksums/src/rolling/checksum/x86.rs
@@ -49,19 +49,19 @@
 use super::accumulate_chunk_scalar_raw;
 #[cfg(target_arch = "x86")]
 use core::arch::x86::{
-    __m128i, __m256i, _mm_add_epi64, _mm_loadu_si128, _mm_mullo_epi16, _mm_sad_epu8, _mm_set_epi16,
-    _mm_setzero_si128, _mm_srli_si128, _mm_storeu_si128, _mm_unpackhi_epi8, _mm_unpacklo_epi8,
-    _mm256_add_epi32, _mm256_castsi256_si128, _mm256_cvtepu8_epi16, _mm256_extracti128_si256,
-    _mm256_loadu_si256, _mm256_madd_epi16, _mm256_sad_epu8, _mm256_set_epi16, _mm256_setzero_si256,
-    _mm256_storeu_si256,
+    __m128i, __m256i, _mm_add_epi32, _mm_cmplt_epi8, _mm_loadu_si128, _mm_madd_epi16,
+    _mm_set1_epi16, _mm_set_epi16, _mm_setzero_si128, _mm_storeu_si128, _mm_unpackhi_epi8,
+    _mm_unpacklo_epi8, _mm256_add_epi32, _mm256_castsi256_si128, _mm256_cvtepi8_epi16,
+    _mm256_extracti128_si256, _mm256_loadu_si256, _mm256_madd_epi16, _mm256_set1_epi16,
+    _mm256_set_epi16, _mm256_storeu_si256,
 };
 #[cfg(target_arch = "x86_64")]
 use core::arch::x86_64::{
-    __m128i, __m256i, _mm_add_epi64, _mm_cvtsi128_si64, _mm_loadu_si128, _mm_mullo_epi16,
-    _mm_sad_epu8, _mm_set_epi16, _mm_setzero_si128, _mm_srli_si128, _mm_storeu_si128,
-    _mm_unpackhi_epi8, _mm_unpacklo_epi8, _mm256_add_epi32, _mm256_castsi256_si128,
-    _mm256_cvtepu8_epi16, _mm256_extracti128_si256, _mm256_loadu_si256, _mm256_madd_epi16,
-    _mm256_sad_epu8, _mm256_set_epi16, _mm256_setzero_si256, _mm256_storeu_si256,
+    __m128i, __m256i, _mm_add_epi32, _mm_cmplt_epi8, _mm_loadu_si128, _mm_madd_epi16,
+    _mm_set1_epi16, _mm_set_epi16, _mm_setzero_si128, _mm_storeu_si128, _mm_unpackhi_epi8,
+    _mm_unpacklo_epi8, _mm256_add_epi32, _mm256_castsi256_si128, _mm256_cvtepi8_epi16,
+    _mm256_extracti128_si256, _mm256_loadu_si256, _mm256_madd_epi16, _mm256_set1_epi16,
+    _mm256_set_epi16, _mm256_storeu_si256,
 };
 
 use std::sync::OnceLock;
@@ -126,6 +126,8 @@ pub(super) fn cpu_features_cached_for_tests() -> bool {
 /// Accumulates rolling checksum using SSE2 SIMD instructions.
 ///
 /// Processes 16 bytes at a time using vectorized prefix sum calculation.
+/// Bytes are sign-extended to match upstream's `schar *buf` interpretation
+/// in `checksum.c:get_checksum1()`.
 #[target_feature(enable = "sse2")]
 unsafe fn accumulate_chunk_sse2(
     mut s1: u32,
@@ -134,6 +136,7 @@ unsafe fn accumulate_chunk_sse2(
     mut chunk: &[u8],
 ) -> (u32, u32, usize) {
     let zero = _mm_setzero_si128();
+    let ones = _mm_set1_epi16(1);
     // Weights for prefix sum: byte i contributes (16-i) times to s2.
     // high_weights covers bytes 0-7 (weights 16,15,14,...,9)
     // low_weights covers bytes 8-15 (weights 8,7,6,...,1)
@@ -143,8 +146,15 @@ unsafe fn accumulate_chunk_sse2(
 
     while chunk.len() >= SSE2_BLOCK_LEN {
         let block = _mm_loadu_si128(chunk.as_ptr() as *const __m128i);
-        let block_sum = sum_block(block, zero);
-        let block_prefix = prefix_sum(block, zero, high_weights, low_weights);
+        // Sign-extend bytes to i16 in two halves: unpack against `cmplt(block,0)`
+        // which gives 0xFF where the byte is negative, replicating the sign bit
+        // into the high byte of each i16 lane.
+        let sign_mask = _mm_cmplt_epi8(block, zero);
+        let high_signed = _mm_unpacklo_epi8(block, sign_mask);
+        let low_signed = _mm_unpackhi_epi8(block, sign_mask);
+
+        let block_sum = sum_block_signed(high_signed, low_signed, ones);
+        let block_prefix = prefix_sum_signed(high_signed, low_signed, high_weights, low_weights);
 
         s2 = s2.wrapping_add(block_prefix);
         s2 = s2.wrapping_add(s1.wrapping_mul(SSE2_BLOCK_LEN as u32));
@@ -163,6 +173,10 @@ unsafe fn accumulate_chunk_sse2(
     (s1, s2, len)
 }
 
+/// Accumulates rolling checksum using AVX2 SIMD instructions.
+///
+/// Processes 32 bytes at a time. Bytes are sign-extended to match upstream's
+/// `schar *buf` interpretation in `checksum.c:get_checksum1()`.
 #[target_feature(enable = "avx2")]
 unsafe fn accumulate_chunk_avx2(
     mut s1: u32,
@@ -170,7 +184,7 @@ unsafe fn accumulate_chunk_avx2(
     mut len: usize,
     mut chunk: &[u8],
 ) -> (u32, u32, usize) {
-    let zero = _mm256_setzero_si256();
+    let ones = _mm256_set1_epi16(1);
     let first_half_weights = _mm256_set_epi16(
         17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,
     );
@@ -180,7 +194,7 @@ unsafe fn accumulate_chunk_avx2(
     while chunk.len() >= AVX2_BLOCK_LEN {
         let block = _mm256_loadu_si256(chunk.as_ptr() as *const __m256i);
 
-        let block_sum = sum_block_avx2(block, zero);
+        let block_sum = sum_block_avx2(block, ones);
         let block_prefix = prefix_sum_avx2(block, first_half_weights, second_half_weights);
 
         s2 = s2.wrapping_add(block_prefix);
@@ -205,13 +219,27 @@ unsafe fn accumulate_chunk_avx2(
     (s1, s2, len)
 }
 
+/// Computes the sum of 32 sign-extended bytes from a 256-bit block.
 #[target_feature(enable = "avx2")]
-unsafe fn sum_block_avx2(block: __m256i, zero: __m256i) -> u32 {
-    let sad = _mm256_sad_epu8(block, zero);
-    let lower = _mm256_castsi256_si128(sad);
-    let upper = _mm256_extracti128_si256(sad, 1);
-    let combined = _mm_add_epi64(lower, upper);
-    horizontal_sum_epi64(combined) as u32
+unsafe fn sum_block_avx2(block: __m256i, ones: __m256i) -> u32 {
+    let lower_bytes = _mm256_castsi256_si128(block);
+    let upper_bytes = _mm256_extracti128_si256(block, 1);
+
+    // Sign-extend the two 16-byte halves to i16 vectors.
+    let lower_signed = _mm256_cvtepi8_epi16(lower_bytes);
+    let upper_signed = _mm256_cvtepi8_epi16(upper_bytes);
+
+    // Multiply-add against ones to widen-and-sum into i32 lanes (no overflow:
+    // each pair of i16 values fits in i32 with margin).
+    let lower_pairs = _mm256_madd_epi16(lower_signed, ones);
+    let upper_pairs = _mm256_madd_epi16(upper_signed, ones);
+    let combined = _mm256_add_epi32(lower_pairs, upper_pairs);
+
+    let mut buffer = [0i32; 8];
+    _mm256_storeu_si256(buffer.as_mut_ptr() as *mut __m256i, combined);
+    buffer
+        .iter()
+        .fold(0u32, |acc, &value| acc.wrapping_add(value as u32))
 }
 
 #[target_feature(enable = "avx2")]
@@ -223,8 +251,10 @@ unsafe fn prefix_sum_avx2(
     let lower_bytes = _mm256_castsi256_si128(block);
     let upper_bytes = _mm256_extracti128_si256(block, 1);
 
-    let lower_extended = _mm256_cvtepu8_epi16(lower_bytes);
-    let upper_extended = _mm256_cvtepu8_epi16(upper_bytes);
+    // Sign-extend bytes to i16 so weighted products carry the upstream
+    // `schar *buf` interpretation through to s2.
+    let lower_extended = _mm256_cvtepi8_epi16(lower_bytes);
+    let upper_extended = _mm256_cvtepi8_epi16(upper_bytes);
 
     let lower_weighted = _mm256_madd_epi16(lower_extended, first_half_weights);
     let upper_weighted = _mm256_madd_epi16(upper_extended, second_half_weights);
@@ -238,50 +268,42 @@ unsafe fn prefix_sum_avx2(
         .fold(0u32, |acc, &value| acc.wrapping_add(value as u32))
 }
 
+/// Computes the sum of 16 sign-extended bytes already widened to two i16
+/// vectors via the SSE2 sign-extension trick.
 #[inline]
 #[target_feature(enable = "sse2")]
-unsafe fn sum_block(block: __m128i, zero: __m128i) -> u32 {
-    let sad = _mm_sad_epu8(block, zero);
-    horizontal_sum_epi64(sad) as u32
+unsafe fn sum_block_signed(high_signed: __m128i, low_signed: __m128i, ones: __m128i) -> u32 {
+    let high_pairs = _mm_madd_epi16(high_signed, ones);
+    let low_pairs = _mm_madd_epi16(low_signed, ones);
+    let combined = _mm_add_epi32(high_pairs, low_pairs);
+
+    let mut buffer = [0i32; 4];
+    _mm_storeu_si128(buffer.as_mut_ptr() as *mut __m128i, combined);
+    buffer
+        .iter()
+        .fold(0u32, |acc, &value| acc.wrapping_add(value as u32))
 }
 
+/// Computes the weighted prefix sum of 16 sign-extended bytes already widened
+/// to two i16 vectors. Uses `_mm_madd_epi16` to multiply-and-pairwise-add into
+/// i32 lanes, avoiding any i16 truncation.
 #[inline]
 #[target_feature(enable = "sse2")]
-unsafe fn prefix_sum(
-    block: __m128i,
-    zero: __m128i,
+unsafe fn prefix_sum_signed(
+    high_signed: __m128i,
+    low_signed: __m128i,
     high_weights: __m128i,
     low_weights: __m128i,
 ) -> u32 {
-    let high = _mm_unpacklo_epi8(block, zero);
-    let low = _mm_unpackhi_epi8(block, zero);
+    let weighted_high = _mm_madd_epi16(high_signed, high_weights);
+    let weighted_low = _mm_madd_epi16(low_signed, low_weights);
+    let combined = _mm_add_epi32(weighted_high, weighted_low);
 
-    let weighted_high = _mm_mullo_epi16(high, high_weights);
-    let weighted_low = _mm_mullo_epi16(low, low_weights);
-
-    let mut buf = [0u16; 8];
-    _mm_storeu_si128(buf.as_mut_ptr() as *mut __m128i, weighted_high);
-    let mut sum = buf.iter().fold(0u32, |acc, &v| acc + u32::from(v));
-    _mm_storeu_si128(buf.as_mut_ptr() as *mut __m128i, weighted_low);
-    sum += buf.iter().fold(0u32, |acc, &v| acc + u32::from(v));
-    sum
-}
-
-#[inline]
-#[target_feature(enable = "sse2")]
-unsafe fn horizontal_sum_epi64(values: __m128i) -> u64 {
-    #[cfg(target_arch = "x86_64")]
-    {
-        let low = _mm_cvtsi128_si64(values) as u64;
-        let high = _mm_cvtsi128_si64(_mm_srli_si128(values, 8)) as u64;
-        low.wrapping_add(high)
-    }
-    #[cfg(target_arch = "x86")]
-    {
-        let mut buf = [0i64; 2];
-        _mm_storeu_si128(buf.as_mut_ptr() as *mut __m128i, values);
-        buf[0] as u64 + buf[1] as u64
-    }
+    let mut buffer = [0i32; 4];
+    _mm_storeu_si128(buffer.as_mut_ptr() as *mut __m128i, combined);
+    buffer
+        .iter()
+        .fold(0u32, |acc, &value| acc.wrapping_add(value as u32))
 }
 
 #[cfg(test)]

--- a/crates/checksums/src/rolling/checksum/x86.rs
+++ b/crates/checksums/src/rolling/checksum/x86.rs
@@ -50,18 +50,18 @@ use super::accumulate_chunk_scalar_raw;
 #[cfg(target_arch = "x86")]
 use core::arch::x86::{
     __m128i, __m256i, _mm_add_epi32, _mm_cmplt_epi8, _mm_loadu_si128, _mm_madd_epi16,
-    _mm_set1_epi16, _mm_set_epi16, _mm_setzero_si128, _mm_storeu_si128, _mm_unpackhi_epi8,
+    _mm_set_epi16, _mm_set1_epi16, _mm_setzero_si128, _mm_storeu_si128, _mm_unpackhi_epi8,
     _mm_unpacklo_epi8, _mm256_add_epi32, _mm256_castsi256_si128, _mm256_cvtepi8_epi16,
-    _mm256_extracti128_si256, _mm256_loadu_si256, _mm256_madd_epi16, _mm256_set1_epi16,
-    _mm256_set_epi16, _mm256_storeu_si256,
+    _mm256_extracti128_si256, _mm256_loadu_si256, _mm256_madd_epi16, _mm256_set_epi16,
+    _mm256_set1_epi16, _mm256_storeu_si256,
 };
 #[cfg(target_arch = "x86_64")]
 use core::arch::x86_64::{
     __m128i, __m256i, _mm_add_epi32, _mm_cmplt_epi8, _mm_loadu_si128, _mm_madd_epi16,
-    _mm_set1_epi16, _mm_set_epi16, _mm_setzero_si128, _mm_storeu_si128, _mm_unpackhi_epi8,
+    _mm_set_epi16, _mm_set1_epi16, _mm_setzero_si128, _mm_storeu_si128, _mm_unpackhi_epi8,
     _mm_unpacklo_epi8, _mm256_add_epi32, _mm256_castsi256_si128, _mm256_cvtepi8_epi16,
-    _mm256_extracti128_si256, _mm256_loadu_si256, _mm256_madd_epi16, _mm256_set1_epi16,
-    _mm256_set_epi16, _mm256_storeu_si256,
+    _mm256_extracti128_si256, _mm256_loadu_si256, _mm256_madd_epi16, _mm256_set_epi16,
+    _mm256_set1_epi16, _mm256_storeu_si256,
 };
 
 use std::sync::OnceLock;

--- a/crates/checksums/tests/comprehensive_tests.rs
+++ b/crates/checksums/tests/comprehensive_tests.rs
@@ -36,8 +36,10 @@ mod rolling_edge_cases {
             let mut checksum = RollingChecksum::new();
             checksum.update(&[byte]);
             assert_eq!(checksum.len(), 1);
-            // For single byte b: s1 = b, s2 = b, value = (b << 16) | b
-            let expected = ((byte as u32) << 16) | (byte as u32);
+            // upstream: checksum.c:285 `schar *buf` cast - bytes are signed [-128,127].
+            // For single byte b: s1 = schar(b) & 0xFFFF, s2 = same, value = (s2 << 16) | s1.
+            let signed = ((byte as i8) as i32) as u32 & 0xFFFF;
+            let expected = (signed << 16) | signed;
             assert_eq!(checksum.value(), expected, "Failed for byte {byte}");
         }
     }

--- a/crates/checksums/tests/rolling_simd_parity.rs
+++ b/crates/checksums/tests/rolling_simd_parity.rs
@@ -16,19 +16,21 @@
 //! - `checksum.c:get_checksum1()` - rolling checksum core (CHAR_OFFSET = 0)
 //! - `match.c:hash_search()` - sliding-window consumer
 //!
+//! Bytes are reinterpreted as signed (`schar *buf = (schar *)buf1` in
+//! upstream `checksum.c:285`), so values >= 0x80 contribute `byte - 256`.
 //! The rsync formula over a block of length `n` is:
 //!
 //! ```text
-//! s1 = sum of bytes
-//! s2 = sum of (n - i) * bytes[i]   = sum of prefix sums
-//! value = (s2 << 16) | s1          (both terms masked to 16 bits)
+//! s1 = sum of schar(bytes[i])
+//! s2 = sum of (n - i) * schar(bytes[i])   = sum of prefix sums
+//! value = (s2 << 16) | s1                 (both terms masked to 16 bits)
 //! ```
 //!
 //! Rolling update (remove `out`, add `in`, window length stays `n`):
 //!
 //! ```text
-//! s1 = (s1 - out + in) & 0xFFFF
-//! s2 = (s2 - n * out + s1) & 0xFFFF
+//! s1 = (s1 - schar(out) + schar(in)) & 0xFFFF
+//! s2 = (s2 - n * schar(out) + s1) & 0xFFFF
 //! ```
 
 use checksums::{RollingChecksum, RollingDigest, simd_acceleration_available};
@@ -36,15 +38,20 @@ use proptest::prelude::*;
 
 /// Upstream-faithful scalar reference. Computes `s1`, `s2` exactly the way
 /// `checksum.c:get_checksum1()` does for a fresh window: byte-by-byte
-/// accumulation with 16-bit truncation only at the end.
+/// accumulation with 16-bit truncation only at the end. Bytes are
+/// sign-extended to match upstream's `schar *buf` cast.
 fn reference_digest(data: &[u8]) -> RollingDigest {
-    let mut s1: u64 = 0;
-    let mut s2: u64 = 0;
+    let mut s1: i64 = 0;
+    let mut s2: i64 = 0;
     for &byte in data {
-        s1 = s1.wrapping_add(u64::from(byte));
+        s1 = s1.wrapping_add(i64::from(byte as i8));
         s2 = s2.wrapping_add(s1);
     }
-    RollingDigest::new((s1 & 0xffff) as u16, (s2 & 0xffff) as u16, data.len())
+    RollingDigest::new(
+        (s1 as u64 & 0xffff) as u16,
+        (s2 as u64 & 0xffff) as u16,
+        data.len(),
+    )
 }
 
 /// Upstream-faithful scalar rolling update over a sliding window of length
@@ -60,7 +67,8 @@ fn reference_rolling_digests(data: &[u8], window: usize) -> Vec<RollingDigest> {
     let mut s1: u32 = 0;
     let mut s2: u32 = 0;
     for &byte in &data[..window] {
-        s1 = s1.wrapping_add(u32::from(byte));
+        let sb = ((byte as i8) as i32) as u32;
+        s1 = s1.wrapping_add(sb);
         s2 = s2.wrapping_add(s1);
     }
     s1 &= 0xffff;
@@ -71,8 +79,8 @@ fn reference_rolling_digests(data: &[u8], window: usize) -> Vec<RollingDigest> {
 
     let n = window as u32;
     for start in 1..=data.len() - window {
-        let outgoing = u32::from(data[start - 1]);
-        let incoming = u32::from(data[start + window - 1]);
+        let outgoing = ((data[start - 1] as i8) as i32) as u32;
+        let incoming = ((data[start + window - 1] as i8) as i32) as u32;
 
         s1 = s1.wrapping_sub(outgoing).wrapping_add(incoming) & 0xffff;
         s2 = s2.wrapping_sub(n.wrapping_mul(outgoing)).wrapping_add(s1) & 0xffff;

--- a/crates/checksums/tests/rsync_rolling_compat.rs
+++ b/crates/checksums/tests/rsync_rolling_compat.rs
@@ -9,19 +9,23 @@
 //! ```c
 //! #define CHAR_OFFSET 0  // rsync 3.x uses 0 (no offset)
 //!
-//! // Initial computation over block of length n:
-//! s1 = sum of all bytes
-//! s2 = sum of (n - i) * byte[i] for i in 0..n
-//!    = sum of prefix sums
+//! // upstream: checksum.c:285 - bytes are reinterpreted as signed via
+//! // `schar *buf = (schar *)buf1`, so each byte contributes int(schar(byte))
+//! // (i.e. values >= 0x80 contribute byte - 256).
+//!
+//! // Initial computation over block of length n (s1, s2 are u16, accumulated mod 2^16):
+//! s1 = sum of schar(byte[i]) for i in 0..n
+//! s2 = sum of (n - i) * schar(byte[i]) for i in 0..n
 //! checksum = (s2 << 16) | s1
 //!
 //! // Rolling update (remove old_byte, add new_byte):
-//! s1 = (s1 - old_byte + new_byte) & 0xFFFF
-//! s2 = (s2 - n * old_byte + s1) & 0xFFFF
+//! s1 = (s1 - schar(old_byte) + schar(new_byte)) & 0xFFFF
+//! s2 = (s2 - n * schar(old_byte) + s1) & 0xFFFF
 //! ```
 //!
 //! This is Mark Adler's rolling checksum algorithm, similar to Adler-32
-//! but without the base modulus and with CHAR_OFFSET = 0.
+//! but without the base modulus, with CHAR_OFFSET = 0, and with bytes
+//! interpreted as signed.
 
 use checksums::{RollingChecksum, RollingDigest};
 
@@ -36,19 +40,21 @@ fn char_offset_is_zero() {
 }
 
 /// Test single byte checksum.
-/// For a single byte b with CHAR_OFFSET = 0:
-/// s1 = b
-/// s2 = b (sum of prefix sums = just the first byte)
-/// value = (b << 16) | b
+/// For a single byte b with CHAR_OFFSET = 0 and signed-byte semantics
+/// (upstream `checksum.c:285` casts via `schar *buf`):
+/// s1 = schar(b) mod 2^16
+/// s2 = schar(b) mod 2^16
+/// value = (s2 << 16) | s1
 #[test]
 fn single_byte_matches_formula() {
-    for byte in [0x00, 0x01, 0x42, 0x7F, 0x80, 0xFF] {
+    for byte in [0x00u8, 0x01, 0x42, 0x7F, 0x80, 0xFF] {
         let mut checksum = RollingChecksum::new();
         checksum.update(&[byte]);
 
-        let expected_s1 = byte as u16;
-        let expected_s2 = byte as u16;
-        let expected_value = ((byte as u32) << 16) | (byte as u32);
+        let signed = ((byte as i8) as i32) as u32;
+        let expected_s1 = (signed & 0xFFFF) as u16;
+        let expected_s2 = (signed & 0xFFFF) as u16;
+        let expected_value = ((expected_s2 as u32) << 16) | (expected_s1 as u32);
 
         assert_eq!(
             checksum.digest().sum1(),
@@ -95,8 +101,8 @@ fn components_truncated_to_16_bits() {
     let mut checksum = RollingChecksum::new();
     checksum.update(&data);
 
-    // s1 = 256 * 0xFF = 65280 = 0xFF00 (fits in 16 bits)
-    // s2 will overflow and wrap
+    // upstream signed semantics: schar(0xFF) = -1, so s1 = 256 * (-1) =
+    // -256 mod 2^16 = 0xFF00 (still fits in 16 bits). s2 will overflow and wrap.
     let s1 = checksum.digest().sum1();
     let s2 = checksum.digest().sum2();
 
@@ -197,23 +203,22 @@ fn all_zeros_block() {
 }
 
 /// Test all-ones block (0xFF).
-/// This maximizes s1 and s2 for a given length.
+/// Upstream signed semantics: schar(0xFF) = -1, so this minimises s1/s2.
 #[test]
 fn all_ones_block() {
-    let size = 128;
+    let size: usize = 128;
     let data = vec![0xFF; size];
     let mut checksum = RollingChecksum::new();
     checksum.update(&data);
 
-    // s1 = 128 * 255 = 32640 = 0x7F80
-    let expected_s1 = ((size * 0xFF) & 0xFFFF) as u16;
+    // s1 = 128 * (-1) = -128, masked to u16 = 0xff80
+    let expected_s1 = (((size as i32).wrapping_neg()) as u32 & 0xFFFF) as u16;
     assert_eq!(checksum.digest().sum1(), expected_s1);
 
-    // s2 = sum of prefix sums = 255 * (1 + 2 + ... + 128)
-    //    = 255 * (128 * 129 / 2) = 255 * 8256 = 2105280
-    //    = 0x201FC0, truncated to 16 bits = 0x1FC0
-    let full_s2 = 255u32 * ((size * (size + 1) / 2) as u32);
-    let expected_s2 = (full_s2 & 0xFFFF) as u16;
+    // s2 = sum of prefix sums = (-1) * (1 + 2 + ... + 128)
+    //    = -(128 * 129 / 2) = -8256, masked to u16 = 0xdfc0
+    let triangular = (size * (size + 1) / 2) as i32;
+    let expected_s2 = ((triangular.wrapping_neg()) as u32 & 0xFFFF) as u16;
     assert_eq!(checksum.digest().sum2(), expected_s2);
 }
 


### PR DESCRIPTION
## Summary

Upstream rsync's `checksum.c:get_checksum1()` casts bytes via `schar *buf = (schar *)buf1`, treating each byte as **signed** (-128..127). oc-rsync was treating bytes as **unsigned** (0..255), causing per-byte divergence on any byte >= 0x80. This produced wrong rolling checksums on any binary basis file with high bytes, breaking the `standalone:delta-stats` interop test against upstream rsync.

Root-caused from pcap evidence captured against a basis file containing high bytes; oc-rsync's rolling sums diverged from upstream's exactly where bytes >= 0x80 first appeared.

## Changes

All rolling-checksum code paths now sign-extend bytes before accumulation:

- **Scalar** 4-byte unrolled loop (`sign_extend_byte` helper)
- **`update_byte`** fast path
- **`roll()`** outgoing/incoming bytes
- **`roll_many()`** outgoing/incoming bytes
- **AVX2**: `_mm256_cvtepi8_epi16` direct widening + `_mm256_madd_epi16`
- **SSE2**: `_mm_cmplt_epi8` sign-mask + `_mm_unpacklo/hi_epi8` + `_mm_madd_epi16`
- **NEON**: `vreinterpretq_s8_u8` + `vmovl_s8` + `vaddlvq_s16` widening reduction (avoids `vaddvq_s16` i16 overflow risk)

Property-test reference (`rolling_simd_parity.rs`) and goldens (`tests.rs`, `rsync_rolling_compat.rs`) updated to match upstream signed semantics:

| Test | Old | New | Notes |
|------|-----|-----|-------|
| all_ff (block_length=16) | `0x8778_0ff0` | `0xff78_fff0` | 0xFF == -1 signed; s1 = -16 = 0xfff0, s2 = -136 = 0xff78 |
| block_length=700 | `0xe2ea_5c96` | `0x01ea_fe96` | Mixed bytes, includes high bytes |
| block_length=4096 | `0x2000_f800` | `0x2000_f800` | Unchanged - data bytes all < 0x80 |

## Test plan

- [ ] CI fmt + clippy passes
- [ ] CI nextest (Linux stable) passes - exercises AVX2/SSE2 SIMD paths
- [ ] CI Windows (stable) passes - exercises AVX2/SSE2 SIMD paths
- [ ] CI macOS (stable) passes - exercises NEON SIMD path
- [ ] CI Linux musl (stable) passes
- [ ] CI Interop validation passes - `standalone:delta-stats` should now pass
- [ ] Property tests in `rolling_simd_parity.rs` confirm SIMD vs scalar parity over the full byte range