### PR TITLE
chore(ci): remove standalone:delta-stats from KNOWN_FAILURES

### DIFF
--- a/tools/ci/known_failures.conf
+++ b/tools/ci/known_failures.conf
@@ -17,13 +17,6 @@
 
 # Unconditional known failures (direction:name).
 KNOWN_FAILURES=(
-  # OC-RSYNC BUG: oc-rsync sends all literal data (matched=0) in daemon mode
-  # instead of performing delta transfer. The delta engine does not engage when
-  # operating as an rsync daemon server, so block-match statistics show 0 matched
-  # bytes even for identical pre-seeded destination files.
-  # NOT FIXABLE HERE: requires fixing the delta engine daemon code path.
-  "standalone:delta-stats"
-
   # OC-RSYNC GAP: --iconv pipeline is not yet upstream-compatible end-to-end
   # for SSH transfers. PR #3458 (cd76ec2f) wired IconvSetting -> FilenameConverter
   # for the local generator/receiver, but two architectural gaps remain plus
@@ -145,10 +138,7 @@ is_known_failure_from_conf() {
 # test_method: "daemon" for scenario-based, "standalone" for standalone tests.
 # Keep in sync with actual known failure rules above.
 DASHBOARD_ENTRIES=(
-  # --- oc-rsync known bugs (unconditional) ---
-  # delta engine does not engage in daemon mode - all data sent as literals
-  "standalone:delta-stats|delta-stats in daemon mode (oc-rsync sends matched=0, delta engine not active in daemon code path)|standalone"
-
+  # --- oc-rsync known gaps (unconditional) ---
   # iconv SSH pipeline: --iconv not forwarded to remote (options.c:2715-2723) and
   # FilenameConverter wire encoding diverges from upstream UTF-8 wire (rsync.c:87-147)
   "standalone:iconv-local-ssh|--iconv over SSH (server-arg forwarding gap + UTF-8 wire mismatch + audit findings 1-3,5 open)|standalone"


### PR DESCRIPTION
## Summary

- PR #3560 fixed the rolling-checksum signed-byte semantics in `crates/checksums/src/rolling/` so that oc-rsync now matches upstream's `schar *buf` cast in `checksum.c:285`.
- In daemon mode, oc-rsync acts as the receiver/generator and produces signatures from the basis file. Pre-fix, those signatures used unsigned-byte rolling checksums while upstream's sender computed signed-byte rolling checksums on its source data — so block-match lookups always missed and `matched=0`.
- Post-fix, both sides agree on the rolling checksum value, so block matching engages and `standalone:delta-stats` should now report `matched > 0`.

The previous KNOWN_FAILURES comment ("delta engine not active in daemon code path") described the symptom, not the root cause.

## Test plan
- [ ] Interop Validation workflow (`tools/ci/run_interop.sh`) exercises `test_delta_stats` without the KNOWN_FAILURE skip and passes.
- [ ] If it fails, the entry can be reinstated; otherwise this closes one of the two remaining oc-rsync entries in `tools/ci/known_failures.conf`, advancing beta criterion #3.

Related: PR #3560 (rolling checksum sign-extends bytes to match upstream).