### PR TITLE
refactor(core): use zeroize crate for SensitiveBytes scrubbing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -593,6 +593,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "transfer",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -207,6 +207,8 @@ rpassword = "7"
 is-terminal = "0.4"
 # CPU feature detection for cipher selection (x86/x86_64 only)
 raw-cpuid = "11"
+# Secure memory zeroization - audited, widely deployed RAII wrapper
+zeroize = "1"
 
 [workspace.metadata.docs.rs]
 all-features = true

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -42,6 +42,7 @@ socket2 = "0.6"
 filetime = "0.2"
 branding = { path = "../branding" }
 tokio = { workspace = true, optional = true }
+zeroize = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 checksums = { path = "../checksums" }

--- a/crates/core/src/client/module_list/auth.rs
+++ b/crates/core/src/client/module_list/auth.rs
@@ -3,6 +3,8 @@ use std::cell::RefCell;
 use std::env;
 use std::io::{BufReader, Write};
 
+use zeroize::{Zeroize, Zeroizing};
+
 use crate::auth::{DaemonAuthDigest, compute_daemon_auth_response};
 
 use super::super::{ClientError, socket_error};
@@ -15,7 +17,7 @@ pub(crate) struct DaemonAuthContext {
 }
 
 impl DaemonAuthContext {
-    pub(crate) const fn new(username: String, secret: Vec<u8>, digest: DaemonAuthDigest) -> Self {
+    pub(crate) fn new(username: String, secret: Vec<u8>, digest: DaemonAuthDigest) -> Self {
         Self {
             username,
             secret: SensitiveBytes::new(secret),
@@ -40,51 +42,35 @@ impl DaemonAuthContext {
 
 /// Wrapper for sensitive byte data that is securely cleared on drop.
 ///
-/// Uses volatile writes and memory fences to ensure the compiler cannot
-/// optimize away the zeroing operation, preventing sensitive data from
-/// lingering in memory after the value is dropped.
-pub(crate) struct SensitiveBytes(Vec<u8>);
+/// Backed by [`zeroize::Zeroizing`], which uses volatile writes and memory
+/// fences to ensure the compiler cannot optimize away the zeroing operation,
+/// preventing sensitive data from lingering in memory after the value is
+/// dropped.
+pub(crate) struct SensitiveBytes(Zeroizing<Vec<u8>>);
 
 impl SensitiveBytes {
-    pub(crate) const fn new(bytes: Vec<u8>) -> Self {
-        Self(bytes)
+    pub(crate) fn new(bytes: Vec<u8>) -> Self {
+        Self(Zeroizing::new(bytes))
     }
 
     pub(crate) fn to_vec(&self) -> Vec<u8> {
-        self.0.clone()
+        self.0.as_slice().to_vec()
     }
 
     pub(crate) fn as_slice(&self) -> &[u8] {
-        &self.0
+        self.0.as_slice()
     }
 
     #[cfg(test)]
-    #[allow(dead_code, unsafe_code)]
+    #[allow(dead_code)]
     pub(crate) fn into_zeroized_vec(mut self) -> Vec<u8> {
-        for byte in &mut self.0 {
-            // SAFETY: Writing to valid memory owned by self.
-            unsafe {
-                std::ptr::write_volatile(byte, 0);
-            }
-        }
-        std::sync::atomic::compiler_fence(std::sync::atomic::Ordering::SeqCst);
-        std::mem::take(&mut self.0)
-    }
-}
-
-impl Drop for SensitiveBytes {
-    #[allow(unsafe_code)]
-    fn drop(&mut self) {
-        // Use volatile writes to prevent compiler from optimizing away the zeroing.
-        // This mirrors the approach used by the `zeroize` crate without the dependency.
-        for byte in &mut self.0 {
-            // SAFETY: Writing to valid memory owned by self.
-            unsafe {
-                std::ptr::write_volatile(byte, 0);
-            }
-        }
-        // Memory fence to ensure the writes complete before deallocation.
-        std::sync::atomic::compiler_fence(std::sync::atomic::Ordering::SeqCst);
+        // Consume `self` and return its bytes zeroed in place, preserving
+        // the original length. This mirrors the previous semantics where the
+        // returned Vec served as evidence that the storage was scrubbed
+        // before being released.
+        let mut inner = std::mem::take(&mut *self.0);
+        inner.zeroize();
+        inner
     }
 }
 

--- a/crates/core/src/client/module_list/auth.rs
+++ b/crates/core/src/client/module_list/auth.rs
@@ -3,7 +3,7 @@ use std::cell::RefCell;
 use std::env;
 use std::io::{BufReader, Write};
 
-use zeroize::{Zeroize, Zeroizing};
+use zeroize::Zeroizing;
 
 use crate::auth::{DaemonAuthDigest, compute_daemon_auth_response};
 

--- a/crates/core/src/client/module_list/auth.rs
+++ b/crates/core/src/client/module_list/auth.rs
@@ -3,6 +3,8 @@ use std::cell::RefCell;
 use std::env;
 use std::io::{BufReader, Write};
 
+#[cfg(test)]
+use zeroize::Zeroize;
 use zeroize::Zeroizing;
 
 use crate::auth::{DaemonAuthDigest, compute_daemon_auth_response};


### PR DESCRIPTION
## Summary

- Replace the hand-rolled `write_volatile` + `compiler_fence` `Drop` impl on `SensitiveBytes` with `zeroize::Zeroizing<Vec<u8>>`.
- Remove both `#[allow(unsafe_code)]` annotations from `crates/core/src/client/module_list/auth.rs`. The `core` crate is on the workspace forbidden-unsafe list (see `Unsafe Code Policy`); this is a beta-blocker.
- Add `zeroize = "1"` to `[workspace.dependencies]` and `zeroize = { workspace = true }` to `crates/core/Cargo.toml`.

The `zeroize` crate is the audited, widely-deployed standard for secure memory zeroization (used by `rustls`, `ring`, `bls12-381`, etc.) and provides the same volatile-write + memory-fence guarantees the previous code was emulating, with the comment in the old `Drop` impl literally calling out: "This mirrors the approach used by the `zeroize` crate without the dependency."

`zeroize` is already pulled in transitively via the existing dep graph (12 hits in `Cargo.lock`), so this adds zero net build cost.

### API surface

`SensitiveBytes::{new, as_slice, to_vec}` signatures are unchanged, so the three callers in `listing.rs` and the re-export in `mod.rs` need no edits. The only knock-on change is removing `const` from `SensitiveBytes::new` and `DaemonAuthContext::new` (both call sites are in regular function bodies, not `const` contexts).

### Acceptance checks

- `grep '#\[allow(unsafe_code)\]' crates/core/src/client/module_list/auth.rs` -> 0 matches
- `grep 'unsafe' crates/core/src/client/module_list/auth.rs` -> 0 matches
- `grep 'write_volatile\|compiler_fence' crates/core/src/client/module_list/auth.rs` -> 0 matches
- `crates/core/Cargo.toml` lists `zeroize = { workspace = true }`
- workspace `Cargo.toml` lists `zeroize = "1"` under `[workspace.dependencies]`

## Test plan

- [ ] CI: fmt + clippy (`#![deny(unsafe_code)]` on `core` will catch any regression)
- [ ] CI: nextest (stable) - existing module_list tests cover the `SensitiveBytes` lifecycle
- [ ] CI: Windows / macOS / Linux musl matrix