### PR TITLE
fix(client): forward --iconv to remote rsync server args

### DIFF
--- a/crates/core/src/client/remote/invocation/builder.rs
+++ b/crates/core/src/client/remote/invocation/builder.rs
@@ -12,8 +12,8 @@
 use std::ffi::OsString;
 
 use super::super::super::config::{
-    ClientConfig, DeleteMode, FilesFromSource, ReferenceDirectoryKind, StrongChecksumAlgorithm,
-    TransferTimeout,
+    ClientConfig, DeleteMode, FilesFromSource, IconvSetting, ReferenceDirectoryKind,
+    StrongChecksumAlgorithm, TransferTimeout,
 };
 use super::{RemoteRole, SecludedInvocation};
 use transfer::setup::build_capability_string;
@@ -430,6 +430,23 @@ impl<'a> RemoteInvocationBuilder<'a> {
                 if self.config.from0() {
                     args.push(OsString::from("--from0"));
                 }
+            }
+        }
+
+        // --iconv forwarding.
+        // upstream: options.c:2716-2723 - when iconv_opt contains a comma, only
+        // the post-comma half (the remote charset) is forwarded; otherwise the
+        // whole string is forwarded as-is. `--iconv=-` (Disabled) and the
+        // default (Unspecified) forward nothing because upstream nulls
+        // iconv_opt at options.c:2052-2054 before this branch runs.
+        match self.config.iconv() {
+            IconvSetting::Unspecified | IconvSetting::Disabled => {}
+            IconvSetting::LocaleDefault => {
+                args.push(OsString::from("--iconv=."));
+            }
+            IconvSetting::Explicit { local, remote } => {
+                let forwarded = remote.as_deref().unwrap_or(local);
+                args.push(OsString::from(format!("--iconv={forwarded}")));
             }
         }
     }

--- a/crates/core/src/client/remote/invocation/tests.rs
+++ b/crates/core/src/client/remote/invocation/tests.rs
@@ -8,7 +8,7 @@ use transfer::setup::build_capability_string;
 use super::builder::RemoteInvocationBuilder;
 use super::transfer_role::{determine_transfer_role, operand_is_remote};
 use super::{RemoteOperands, RemoteRole, TransferSpec};
-use crate::client::config::{ClientConfig, TransferTimeout};
+use crate::client::config::{ClientConfig, IconvSetting, TransferTimeout};
 
 #[test]
 fn builds_receiver_invocation_with_sender_flag() {
@@ -2427,4 +2427,91 @@ fn daemon_double_colon_to_local_is_pull() {
     let dest = OsString::from("/tmp/local");
     let spec = determine_transfer_role(&sources, &dest).unwrap();
     assert_eq!(spec.role(), RemoteRole::Receiver);
+}
+
+// --iconv server-arg forwarding tests.
+// upstream: options.c:2716-2723 - the post-comma half of iconv_opt is
+// forwarded; without a comma the whole spec is forwarded; --iconv=- and the
+// default forward nothing because options.c:2052-2054 nulls iconv_opt.
+
+#[test]
+fn iconv_unspecified_omits_iconv_arg() {
+    let config = ClientConfig::builder().build();
+    let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Receiver);
+    let args = builder.build("/remote/path");
+    assert!(
+        !args
+            .iter()
+            .any(|a| a.to_string_lossy().starts_with("--iconv")),
+        "default config must not forward --iconv: {args:?}"
+    );
+}
+
+#[test]
+fn iconv_disabled_omits_iconv_arg() {
+    let config = ClientConfig::builder()
+        .iconv(IconvSetting::Disabled)
+        .build();
+    let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Receiver);
+    let args = builder.build("/remote/path");
+    assert!(
+        !args
+            .iter()
+            .any(|a| a.to_string_lossy().starts_with("--iconv")),
+        "Disabled iconv must not forward --iconv: {args:?}"
+    );
+}
+
+#[test]
+fn iconv_locale_default_forwards_dot() {
+    let config = ClientConfig::builder()
+        .iconv(IconvSetting::LocaleDefault)
+        .build();
+    let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Receiver);
+    let args = builder.build("/remote/path");
+    assert!(
+        args.iter().any(|a| a == "--iconv=."),
+        "LocaleDefault must forward --iconv=.: {args:?}"
+    );
+}
+
+#[test]
+fn iconv_explicit_pair_forwards_only_remote_half() {
+    // upstream: options.c:2717-2721 - `set = strchr(iconv_opt, ','); if (set)
+    // set++;` so only the post-comma half (the remote charset) reaches the
+    // server. The local charset stays on the client side.
+    let config = ClientConfig::builder()
+        .iconv(IconvSetting::Explicit {
+            local: "UTF-8".to_owned(),
+            remote: Some("ISO-8859-1".to_owned()),
+        })
+        .build();
+    let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Receiver);
+    let args = builder.build("/remote/path");
+    assert!(
+        args.iter().any(|a| a == "--iconv=ISO-8859-1"),
+        "Explicit pair must forward only the remote half: {args:?}"
+    );
+    assert!(
+        !args.iter().any(|a| a == "--iconv=UTF-8,ISO-8859-1"),
+        "Explicit pair must not forward the swapped pair: {args:?}"
+    );
+}
+
+#[test]
+fn iconv_explicit_single_forwards_whole_spec() {
+    // upstream: options.c:2718-2721 - `else set = iconv_opt;` so when there
+    // is no comma the entire spec is forwarded as the remote charset.
+    let config = ClientConfig::builder()
+        .iconv(IconvSetting::Explicit {
+            local: "UTF-8".to_owned(),
+            remote: None,
+        })
+        .build();
+    let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Receiver);
+    let args = builder.build("/remote/path");
+    assert!(
+        args.iter().any(|a| a == "--iconv=UTF-8"),
+        "Explicit single must forward the whole spec: {args:?}"
+    );
 }


### PR DESCRIPTION
## Summary

Adds `--iconv` to the long-form server-args forwarded by `RemoteInvocationBuilder::append_long_form_args`. Without this, the spawned `rsync --server` ran with no iconv context and emitted raw bytes on the wire - gap 1 of the `standalone:iconv-local-ssh` known failure.

The mapping mirrors upstream `options.c:2716-2723` exactly:

| `IconvSetting` variant | Forwarded flag |
|---|---|
| `Unspecified` | (none) |
| `Disabled` | (none - upstream nulls `iconv_opt` at `options.c:2052-2054`) |
| `LocaleDefault` | `--iconv=.` |
| `Explicit { local, remote: Some(r) }` | `--iconv={r}` (post-comma half only) |
| `Explicit { local, remote: None }` | `--iconv={local}` (no comma => forward whole) |

Five new unit tests cover each row.

## Upstream Reference

```c
// options.c:2716-2723
if (iconv_opt) {
    char *set = strchr(iconv_opt, ',');
    if (set) set++;          // points to char *after* the comma -> "REMOTE"
    else set = iconv_opt;
    args[ac++] = safe_arg("--iconv", set);
}
```

## Scope: this does NOT close the KF

This is a focused fix for gap 1 only. The `standalone:iconv-local-ssh` known failure stays open because:

- Gap 2: UTF-8 wire mismatch on the file-list side is still unresolved
- Iconv audit findings 1, 2, 3, and 5 remain open

The KF entry in `tools/ci/known_failures.conf` is intentionally unchanged.

## Test plan

- [ ] CI: fmt + clippy
- [ ] CI: nextest (stable) - 5 new `iconv_*` tests in `crates/core/src/client/remote/invocation/tests.rs`
- [ ] CI: Windows / macOS / Linux musl matrices
- [ ] Confirm `standalone:iconv-local-ssh` remains in `KNOWN_FAILURES` (intentional)