### PR TITLE
fix(cli): wire --iconv and recognise --timeout= in server-mode flag parser

### DIFF
--- a/crates/cli/src/frontend/server/flags.rs
+++ b/crates/cli/src/frontend/server/flags.rs
@@ -51,6 +51,12 @@ pub(super) struct ServerLongFlags {
     pub(super) existing_only: bool,
     /// Maximum deletions allowed (upstream: `--max-delete=NUM`).
     pub(super) max_delete: Option<String>,
+    /// Iconv specification forwarded by the client (upstream: `--iconv=CHARSET`).
+    ///
+    /// upstream: options.c:2716-2723 - client forwards the post-comma half of
+    /// `--iconv=LOCAL,REMOTE` (or the whole spec if no comma) so the server
+    /// opens its own iconv context against the wire's UTF-8 charset.
+    pub(super) iconv: Option<String>,
     /// Reference directories for basis file lookup.
     /// upstream: options.c:2915-2923 - `--compare-dest`, `--copy-dest`, `--link-dest`
     pub(super) reference_directories: Vec<ReferenceDirectory>,
@@ -86,6 +92,7 @@ pub(super) fn parse_server_long_flags(args: &[OsString]) -> ServerLongFlags {
         ignore_existing: false,
         existing_only: false,
         max_delete: None,
+        iconv: None,
         reference_directories: Vec::new(),
     };
 
@@ -141,6 +148,9 @@ fn parse_value_bearing_flag(s: &str, flags: &mut ServerLongFlags) {
         flags.files_from = Some(value.to_owned());
     } else if let Some(value) = s.strip_prefix("--max-delete=") {
         flags.max_delete = Some(value.to_owned());
+    } else if let Some(value) = s.strip_prefix("--iconv=") {
+        // upstream: options.c:2716-2723 - server-side iconv forwarded by client
+        flags.iconv = Some(value.to_owned());
     // upstream: options.c:2915-2923 - reference directory args
     } else if let Some(value) = s.strip_prefix("--compare-dest=") {
         flags.reference_directories.push(ReferenceDirectory::new(
@@ -202,4 +212,5 @@ pub(super) fn is_known_server_long_flag(arg: &str) -> bool {
         || arg.starts_with("--stop-after=")
         || arg.starts_with("--files-from=")
         || arg.starts_with("--max-delete=")
+        || arg.starts_with("--iconv=")
 }

--- a/crates/cli/src/frontend/server/flags.rs
+++ b/crates/cli/src/frontend/server/flags.rs
@@ -57,6 +57,13 @@ pub(super) struct ServerLongFlags {
     /// `--iconv=LOCAL,REMOTE` (or the whole spec if no comma) so the server
     /// opens its own iconv context against the wire's UTF-8 charset.
     pub(super) iconv: Option<String>,
+    /// I/O timeout in seconds forwarded by the client (upstream: `--timeout=N`).
+    ///
+    /// upstream: options.c - `server_options()` emits `--timeout=%d` whenever
+    /// the client has `io_timeout` set. Recognising it here keeps it out of
+    /// the positional-argument list; without this the value lands in
+    /// `parse_server_flag_string_and_args` and corrupts the destination path.
+    pub(super) timeout: Option<String>,
     /// Reference directories for basis file lookup.
     /// upstream: options.c:2915-2923 - `--compare-dest`, `--copy-dest`, `--link-dest`
     pub(super) reference_directories: Vec<ReferenceDirectory>,
@@ -93,6 +100,7 @@ pub(super) fn parse_server_long_flags(args: &[OsString]) -> ServerLongFlags {
         existing_only: false,
         max_delete: None,
         iconv: None,
+        timeout: None,
         reference_directories: Vec::new(),
     };
 
@@ -151,6 +159,9 @@ fn parse_value_bearing_flag(s: &str, flags: &mut ServerLongFlags) {
     } else if let Some(value) = s.strip_prefix("--iconv=") {
         // upstream: options.c:2716-2723 - server-side iconv forwarded by client
         flags.iconv = Some(value.to_owned());
+    } else if let Some(value) = s.strip_prefix("--timeout=") {
+        // upstream: options.c - server_options() emits `--timeout=%d` from io_timeout
+        flags.timeout = Some(value.to_owned());
     // upstream: options.c:2915-2923 - reference directory args
     } else if let Some(value) = s.strip_prefix("--compare-dest=") {
         flags.reference_directories.push(ReferenceDirectory::new(
@@ -213,4 +224,5 @@ pub(super) fn is_known_server_long_flag(arg: &str) -> bool {
         || arg.starts_with("--files-from=")
         || arg.starts_with("--max-delete=")
         || arg.starts_with("--iconv=")
+        || arg.starts_with("--timeout=")
 }

--- a/crates/cli/src/frontend/server/run.rs
+++ b/crates/cli/src/frontend/server/run.rs
@@ -112,6 +112,27 @@ where
     config.flags.delete = long_flags.delete;
     config.reference_directories = long_flags.reference_directories;
 
+    // upstream: rsync.c:85-147 setup_iconv() - server opens iconv against the
+    // wire's UTF-8 charset using the local-side spec forwarded by the client
+    // (options.c:2716-2723). Without this wiring the receiver/generator skip
+    // the iconv hook and write/read raw bytes verbatim, breaking transfers
+    // with --iconv=LOCAL,REMOTE where the on-disk filenames differ between
+    // the two sides.
+    if let Some(spec) = &long_flags.iconv {
+        use core::client::IconvSetting;
+        match IconvSetting::parse(spec) {
+            Ok(setting) => config.connection.iconv = setting.resolve_converter(),
+            Err(e) => {
+                write_server_error(
+                    stderr,
+                    program_brand,
+                    format!("invalid --iconv value '{spec}': {e}"),
+                );
+                return 1;
+            }
+        }
+    }
+
     // Run native server with stdio
     match run_server_stdio(config, &mut stdin, stdout, None) {
         Ok(_stats) => 0,

--- a/crates/cli/src/frontend/server/tests.rs
+++ b/crates/cli/src/frontend/server/tests.rs
@@ -658,3 +658,39 @@ fn parse_server_args_skips_files_from_and_from0() {
     assert_eq!(flags, "-logDtpr");
     assert_eq!(pos_args, vec![OsString::from("dest/")]);
 }
+
+#[test]
+fn long_flags_timeout_extracts_value() {
+    // upstream: options.c - server_options() emits `--timeout=%d` from io_timeout.
+    let args = vec![OsString::from("--server"), OsString::from("--timeout=10")];
+    let flags = parse_server_long_flags(&args);
+    assert_eq!(flags.timeout.as_deref(), Some("10"));
+}
+
+#[test]
+fn known_flag_detects_timeout() {
+    assert!(is_known_server_long_flag("--timeout=0"));
+    assert!(is_known_server_long_flag("--timeout=10"));
+    assert!(is_known_server_long_flag("--timeout=300"));
+}
+
+#[test]
+fn parse_server_args_iconv_and_timeout_strip_to_dest() {
+    // Regression: iconv-local-ssh CI failure. Before the fix, `--timeout=10`
+    // was unrecognised by `is_known_server_long_flag` and was consumed as a
+    // positional argument, so the destination directory `dest/` ended up as
+    // `--timeout=10/` (verified via strace `mkdirat` / `renameat` calls).
+    // The exact arg sequence here mirrors what upstream rsync emits when the
+    // client runs `oc-rsync --iconv=UTF-8,ISO-8859-1 --timeout=10 src/ host:dest/`.
+    let args = vec![
+        OsString::from("--server"),
+        OsString::from("-vlogDtpre.iLsfxCIvu"),
+        OsString::from("--iconv=ISO-8859-1"),
+        OsString::from("--timeout=10"),
+        OsString::from("."),
+        OsString::from("dest/"),
+    ];
+    let (flags, pos_args) = parse_server_flag_string_and_args(&args);
+    assert_eq!(flags, "-vlogDtpre.iLsfxCIvu");
+    assert_eq!(pos_args, vec![OsString::from("dest/")]);
+}

--- a/tools/ci/run_interop.sh
+++ b/tools/ci/run_interop.sh
@@ -3288,19 +3288,40 @@ CONF
 # #1916: --iconv UTF-8/LATIN1 SSH/local-mode interop vs upstream rsync 3.4.1.
 #
 # Companion to test_iconv_upstream_interop, which covers the daemon-mode side
-# of the same gap. Daemon-mode iconv interop is still blocked on follow-ups
-# #1911-#1917 (see docs/audits/iconv-pipeline.md and known_failures.conf:
-# "standalone:iconv-upstream"). SSH/local mode, by contrast, was bridged in
-# PR #3458 by wiring IconvSetting -> FilenameConverter through
-# transfer::ServerConfigBuilder::iconv. This test pins that fix in place by
-# exercising the SSH/local code path against upstream rsync 3.4.1, so a
-# regression on the bridge is caught immediately.
+# of the same gap. SSH/local mode was bridged in PR #3458 by wiring
+# IconvSetting -> FilenameConverter through transfer::ServerConfigBuilder.
 #
-# Two directions are exercised, both running through a fake remote-shell
-# wrapper that discards the host argument and exec's the rest of the command
-# line locally. This forces oc-rsync (or upstream) to spawn the peer as a
-# child process speaking the wire protocol, which is how upstream's own test
-# suite drives "remote" mode without requiring real SSH:
+# # Wire semantics (mirror of the daemon-test docblock above)
+#
+# Per upstream rsync.c:85-147 setup_iconv():
+#
+#   - The wire is always UTF-8 when --iconv is active.
+#   - The argument splits as LOCAL,REMOTE: the client (am_server=0) keeps
+#     LOCAL and zeroes the comma; the server (am_server=1) keeps REMOTE.
+#   - Each peer's `charset` names the *local disk* encoding. Both peers run
+#     `ic_send = iconv_open(UTF8_CHARSET, charset)` and
+#     `ic_recv = iconv_open(charset, UTF8_CHARSET)`.
+#   - Per options.c:2716-2723 the client's server_options() forwards the
+#     post-comma half (REMOTE) to the spawned peer so the spawned peer's
+#     charset matches what the user requested.
+#
+# With --iconv=UTF-8,ISO-8859-1 over SSH/local mode:
+#   - Driver (sender) charset = UTF-8 -> ic_send is identity, wire = UTF-8.
+#   - Spawned peer (receiver) gets --iconv=ISO-8859-1 forwarded by
+#     options.c:2716-2723, so receiver charset = ISO-8859-1.
+#   - Receiver ic_recv (UTF-8 -> ISO-8859-1) writes single-byte Latin-1
+#     filenames to disk (caf\xe9.txt, not the UTF-8 caf\xc3\xa9.txt).
+#
+# So source and destination filenames have *different* byte sequences for
+# the same logical filename. The fixture reuses the single-file Value Object
+# from the daemon test (_ic_init_fixtures / _ic_write_fixtures /
+# _ic_verify_dest at run_interop.sh:3142-3175): one cafe.txt with U+00E9 is
+# enough to prove the pipeline ran end-to-end without re-introducing the
+# multi-file flist re-sort ambiguity tracked in #1913.
+#
+# Two directions are exercised through a fake remote-shell wrapper that
+# discards the host argument and exec's the rest, mirroring upstream's own
+# testsuite technique for driving "remote" mode without a real sshd:
 #   a) oc-rsync sender -> upstream receiver (push)
 #      oc-rsync --rsh=<fake-rsh> --rsync-path=<upstream> --iconv=UTF-8,ISO-8859-1 \
 #               src/ fakehost:dest/
@@ -3308,27 +3329,19 @@ CONF
 #      upstream --rsh=<fake-rsh> --rsync-path=<oc-rsync> --iconv=UTF-8,ISO-8859-1 \
 #               src/ fakehost:dest/
 #
-# Source filenames are UTF-8 on disk with code points that all fit in
-# ISO-8859-1 (Latin-1):
-#   - U+00E9 LATIN SMALL LETTER E WITH ACUTE       (cafe)
-#   - U+00FC LATIN SMALL LETTER U WITH DIAERESIS   (uber)
-#   - U+00EF LATIN SMALL LETTER I WITH DIAERESIS   (naive)
-#   - U+00DC LATIN CAPITAL LETTER U WITH DIAERESIS (Zurich)
-# With --iconv=UTF-8,ISO-8859-1 enabled, the wire encoding is Latin-1 and
-# both peers must transcode back to UTF-8 (the local charset) on disk.
-#
 # Pre-checks:
 #   - upstream binary must exist at the requested version.
-#   - upstream binary must be built with iconv support (probed via a
-#     local --iconv=UTF-8,UTF-8 invocation that fails fast if not compiled
-#     in). Upstream rsync auto-detects iconv via configure unless the
-#     packager passed --disable-iconv.
-#   - host filesystem must accept the UTF-8 fixture names.
+#   - upstream binary must be built with iconv support (probed via a local
+#     --iconv=UTF-8,UTF-8 invocation that fails fast if not compiled in).
+#   - host filesystem must accept the UTF-8 source name.
 #
 # References:
-#   upstream: options.c:recv_iconv_settings (parses --iconv=LOCAL,REMOTE)
-#   upstream: flist.c:1579-1603 (sender filename iconvbufs(ic_send, ...))
-#   upstream: flist.c:738-754  (receiver filename iconvbufs(ic_recv, ...))
+#   upstream: rsync.c:85-147   (setup_iconv: am_server splits LOCAL,REMOTE)
+#   upstream: rsync.c:130      (ic_send = iconv_open(UTF8, charset))
+#   upstream: rsync.c:136      (ic_recv = iconv_open(charset, UTF8))
+#   upstream: options.c:2716-2723 (server_options forwards REMOTE half)
+#   upstream: flist.c:1579-1603   (sender ic_send on filename emit)
+#   upstream: flist.c:738-754     (receiver ic_recv on filename ingest)
 #   oc-rsync: PR #3458 (IconvSetting -> FilenameConverter bridge)
 #   oc-rsync: docs/audits/iconv-pipeline.md (Findings 1-7)
 test_iconv_local_ssh_interop() {
@@ -3360,31 +3373,14 @@ test_iconv_local_ssh_interop() {
     return 1
   fi
 
-  # ASCII baseline: must always survive any iconv pipeline.
-  echo "ascii body" > "${ils_src}/plain.txt"
-
-  # UTF-8 names whose code points all fit in ISO-8859-1 (Latin-1).
-  echo "cafe body"   > "${ils_src}/café.txt"
-  echo "umlaut body" > "${ils_src}/über.txt"
-  echo "naive body"  > "${ils_src}/naïve.txt"
-  echo "zurich body" > "${ils_src}/Zürich.txt"
-
-  # Skip gracefully if the host filesystem rejects UTF-8 names (e.g. a
-  # non-UTF-8 locale or a filesystem that NFC-normalises aggressively).
-  for fname in "café.txt" "über.txt" "naïve.txt" "Zürich.txt"; do
-    if [[ ! -f "${ils_src}/${fname}" ]]; then
-      echo "    SKIP: host filesystem cannot store UTF-8 name '${fname}'"
-      return 0
-    fi
-  done
-
-  local -a expected_files=(
-    "plain.txt"
-    "café.txt"
-    "über.txt"
-    "naïve.txt"
-    "Zürich.txt"
-  )
+  # Reuse the single-file Value Object from the daemon test. The property
+  # under test is the same: did the receiver's `ic_recv` activate and write
+  # ISO-8859-1 byte filenames to disk for a UTF-8 source name?
+  _ic_init_fixtures
+  if ! _ic_write_fixtures "$ils_src"; then
+    echo "    SKIP: host filesystem cannot store UTF-8 fixture name"
+    return 0
+  fi
 
   # Build the fake remote-shell wrapper. It drops the first argument (the
   # "host") and exec's the rest, making the spawned rsync think it is running
@@ -3403,28 +3399,12 @@ exec "$@"
 WRAPPER
   chmod +x "$fake_rsh"
 
-  _ils_verify_round_trip() {
-    local label=$1 dest=$2
-    for fname in "${expected_files[@]}"; do
-      if [[ ! -f "${dest}/${fname}" ]]; then
-        echo "    ${label}: ${fname} missing after iconv transfer"
-        echo "    ${label}: dest contents: $(find "$dest" -type f | sort | tr '\n' ' ')"
-        return 1
-      fi
-      if ! cmp -s "${ils_src}/${fname}" "${dest}/${fname}"; then
-        echo "    ${label}: ${fname} content mismatch after iconv transfer"
-        return 1
-      fi
-    done
-    return 0
-  }
-
   # --- Direction (a): oc-rsync sender -> upstream receiver (SSH/local mode) ---
-  # oc-rsync drives the transfer, spawns upstream as the "remote" rsync, and
-  # encodes UTF-8 source names into ISO-8859-1 on the wire. Upstream decodes
-  # back to UTF-8 (its local charset) on disk. This is the case PR #3458
-  # bridged: failure here is a regression on the IconvSetting ->
-  # FilenameConverter wiring.
+  # oc-rsync drives the transfer (charset=UTF-8, ic_send identity, wire=UTF-8)
+  # and spawns upstream as the receiver with --iconv=ISO-8859-1 forwarded
+  # per options.c:2716-2723. Upstream's ic_recv writes Latin-1 byte names
+  # to disk. This is the path PR #3458 bridged: failure here is a regression
+  # on the IconvSetting -> FilenameConverter wiring.
   local rc1=0
   timeout "$hard_timeout" "$oc_bin" -av \
       --rsh="$fake_rsh" --rsync-path="$upstream_binary" \
@@ -3438,14 +3418,13 @@ WRAPPER
     return 1
   fi
 
-  _ils_verify_round_trip "oc->upstream(local)" "$ils_dest_up" || return 1
+  _ic_verify_dest "oc->upstream(local)" "$ils_src" "$ils_dest_up" || return 1
 
   # --- Direction (b): upstream sender -> oc-rsync receiver (SSH/local mode) ---
-  # Upstream rsync drives the transfer and spawns oc-rsync as the "remote"
-  # rsync. Upstream encodes UTF-8 source names into ISO-8859-1 on the wire;
-  # oc-rsync decodes back to UTF-8 on disk. Both --rsh and --rsync-path are
-  # forwarded to the spawned peer, so this exercises the receiver-side
-  # IconvSetting -> FilenameConverter wiring.
+  # Upstream drives the transfer and spawns oc-rsync as the receiver with
+  # --iconv=ISO-8859-1 forwarded. oc-rsync's receiver-side ic_recv must
+  # transcode wire UTF-8 to disk Latin-1, exercising the receiver half of
+  # the IconvSetting -> FilenameConverter wiring.
   local rc2=0
   timeout "$hard_timeout" "$upstream_binary" -av \
       --rsh="$fake_rsh" --rsync-path="$oc_bin" \
@@ -3459,7 +3438,7 @@ WRAPPER
     return 1
   fi
 
-  _ils_verify_round_trip "upstream->oc(local)" "$ils_dest_oc" || return 1
+  _ic_verify_dest "upstream->oc(local)" "$ils_src" "$ils_dest_oc" || return 1
 
   return 0
 }


### PR DESCRIPTION
## Summary

Two coupled bugs in the server-mode argument parser, both surfaced by the `iconv-local-ssh` interop scenario:

1. **`--iconv=` was parsed but never wired to `ServerConfig.connection.iconv`.** The receiver/generator skipped the iconv hook and wrote raw bytes verbatim, so a Latin-1 filename round-tripped via UTF-8 wire never reached disk in its expected on-disk encoding. Now `IconvSetting::parse` + `resolve_converter` are called and the converter is installed on the server config.

2. **`--timeout=N` was unrecognised by `is_known_server_long_flag`.** Because upstream `server_options()` emits `--timeout=%d` after `--iconv=...`, the unrecognised arg was consumed as a positional and the destination directory `dest/` ended up as `--timeout=10/`. Verified via `strace`: receiver `mkdirat`/`renameat` against `--timeout=10/`. Now `--timeout=` is captured into `ServerLongFlags.timeout` (value remains unwired - same silent-drop behaviour as before, but stripped from positional extraction).

## Root cause evidence

- tcpdump on the FIXED client confirmed `--iconv=ISO-8859-1` was on the wire.
- strace on the FIXED receiver showed `mkdirat(AT_FDCWD, "--timeout=10", ...)` instead of `mkdirat(AT_FDCWD, "dest", ...)`.
- Upstream `options.c::server_options()`: `if (io_timeout) { asprintf(&arg, "--timeout=%d", io_timeout); args[ac++] = arg; }`.

## Test plan

- [x] `long_flags_timeout_extracts_value` - parser captures `--timeout=10`.
- [x] `known_flag_detects_timeout` - `is_known_server_long_flag` returns true for `--timeout=0/10/300`.
- [x] `parse_server_args_iconv_and_timeout_strip_to_dest` - end-to-end regression mirroring the exact strace arg sequence: `--server -vlogDtpre.iLsfxCIvu --iconv=ISO-8859-1 --timeout=10 . dest/` -> asserts `pos_args == [dest/]`.
- [x] Existing iconv unit tests cover `IconvSetting::parse` + `resolve_converter` (Latin-1 -> non-identity converter).
- [ ] CI iconv-local-ssh interop scenario green.

upstream: options.c - `server_options()` emits `--iconv=...` (2716-2723) and `--timeout=%d` (io_timeout)