### PR TITLE
fix(ci): guard zero-ratio in benchmark chart

### DIFF
--- a/.github/scripts/benchmark_chart.py
+++ b/.github/scripts/benchmark_chart.py
@@ -43,6 +43,11 @@ MODE_GAP = 16
 MIN_BAR_WIDTH = 2
 TEXT_INSIDE_THRESHOLD = 60
 
+# Speedup classification thresholds (oc_rsync / upstream timing ratio).
+# < FASTER: oc-rsync clearly faster.  <= SAME_UPPER: within noise.  > SAME_UPPER: slower.
+RATIO_FASTER_BELOW = 0.95
+RATIO_SAME_UPPER = 1.05
+
 # ---------------------------------------------------------------------------
 # Colors
 # ---------------------------------------------------------------------------
@@ -268,11 +273,19 @@ def fmt_time(seconds: float) -> str:
 
 
 def ratio_text(ratio: float) -> tuple[str, str]:
-    """Return (display_text, color) for a speedup annotation."""
-    if ratio < 0.95:
+    """Return (display_text, color) for a speedup annotation.
+
+    A non-positive ratio means timing data was missing or rounded to zero
+    on at least one side of the comparison (benchmark.py rounds ratios to
+    two decimals, collapsing sub-millisecond ratios such as 250x faster
+    to 0.0); render a neutral marker rather than dividing by zero.
+    """
+    if ratio <= 0:
+        return (">100x faster", COLOR_FASTER)
+    if ratio < RATIO_FASTER_BELOW:
         speedup = 1.0 / ratio
         return (f"{speedup:.1f}x faster", COLOR_FASTER)
-    if ratio <= 1.05:
+    if ratio <= RATIO_SAME_UPPER:
         return ("~same", COLOR_SAME)
     return (f"{ratio:.1f}x slower", COLOR_SLOWER)
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -10,6 +10,10 @@ on:
         description: 'Baseline tag/branch to compare against'
         required: false
         default: ''
+      target_tag:
+        description: 'Existing release tag to publish chart and notes to (e.g. v0.6.1). Use when re-running benchmarks against a release whose tag-triggered workflow failed.'
+        required: false
+        default: ''
 
 concurrency:
   group: benchmark-${{ github.ref }}
@@ -137,13 +141,31 @@ jobs:
             cat benchmark_report.md
           } >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Resolve release tag
+        id: release_tag
+        run: |
+          set -euo pipefail
+          if [ -n "${{ inputs.target_tag }}" ]; then
+            TAG="${{ inputs.target_tag }}"
+          elif [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            TAG="${GITHUB_REF##*/}"
+          else
+            TAG=""
+          fi
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          if [ -n "$TAG" ]; then
+            echo "Publishing benchmark artifacts to release: $TAG"
+          else
+            echo "No release tag resolved; skipping release publish steps."
+          fi
+
       - name: Add benchmark to release notes
-        if: startsWith(github.ref, 'refs/tags/')
+        if: steps.release_tag.outputs.tag != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          TAG="${GITHUB_REF##*/}"
+          TAG="${{ steps.release_tag.outputs.tag }}"
 
           # Wait for the release to exist (created by release-cross workflow)
           MAX_ATTEMPTS=60  # 30 minutes at 30-second intervals
@@ -184,9 +206,9 @@ jobs:
           gh release edit "$TAG" --notes "$NEW_BODY"
 
       - name: Upload benchmark assets to release
-        if: startsWith(github.ref, 'refs/tags/')
+        if: steps.release_tag.outputs.tag != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          TAG="${GITHUB_REF##*/}"
+          TAG="${{ steps.release_tag.outputs.tag }}"
           gh release upload "$TAG" benchmark.png benchmark_results.json benchmark_report.md --clobber


### PR DESCRIPTION
## Summary

- Guard `ratio <= 0` in `ratio_text()` to fix `ZeroDivisionError` that broke the v0.6.1 Benchmark workflow twice (runs 25271859729, 25276974191).
- Extract speedup classification thresholds into named constants (`RATIO_FASTER_BELOW`, `RATIO_SAME_UPPER`).
- Add `target_tag` `workflow_dispatch` input and a "Resolve release tag" step so we can dispatch the Benchmark workflow from master and still publish artifacts to an existing release tag without retagging.

## Root cause

`benchmark.py` rounds the `oc_rsync / upstream` timing ratio to 2 decimals. Sub-millisecond ratios (e.g. `0.004` = 250x faster) collapse to exactly `0.0`. `benchmark_chart.py:273` then computes `1.0 / ratio` and crashes the entire chart-generation step. Because the chart step is non-conditional, the workflow fails before the release-publish steps run, so no benchmark.png and no Performance Benchmark section land on the release.

## Why this matters now

v0.6.0 happened to have no zero-ratio entries; v0.6.1 does. Both v0.6.1 tag-triggered runs of the Benchmark workflow have failed at this exact line. The Criterion Benchmarks workflow (separate file) is unaffected.

## Test plan

- [x] Unit-validated `ratio_text` locally: `0.0 -> ">100x faster"`, `-0.5 -> ">100x faster"`, `0.04 -> "25.0x faster"`, `1.0 -> "~same"`, `2.5 -> "2.5x slower"`.
- [ ] CI green on this PR (fmt+clippy, nextest, Windows, macOS, Linux musl).
- [ ] After merge: `gh workflow run benchmark.yml --ref master -f target_tag=v0.6.1` to publish the missing chart + notes section to the v0.6.1 release. Master HEAD is byte-identical to v0.6.1 modulo this one tooling change, so the benchmarked binary represents v0.6.1 exactly.