### PR TITLE
fix: io_uring bench MEMLOCK + Criterion workflow target_tag

### DIFF
--- a/.github/workflows/benchmark-release.yml
+++ b/.github/workflows/benchmark-release.yml
@@ -5,6 +5,11 @@ on:
     tags:
       - "v[0-9]*.[0-9]*.[0-9]*"
   workflow_dispatch:
+    inputs:
+      target_tag:
+        description: 'Existing release tag to publish criterion results to (e.g. v0.6.1). Use when re-running benchmarks against a release whose tag-triggered workflow failed.'
+        required: false
+        default: ''
 
 concurrency:
   group: criterion-${{ github.ref }}
@@ -82,13 +87,31 @@ jobs:
             criterion_output.txt
             target/criterion/
 
+      - name: Resolve release tag
+        id: release_tag
+        run: |
+          set -euo pipefail
+          if [ -n "${{ inputs.target_tag }}" ]; then
+            TAG="${{ inputs.target_tag }}"
+          elif [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            TAG="${GITHUB_REF##*/}"
+          else
+            TAG=""
+          fi
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          if [ -n "$TAG" ]; then
+            echo "Publishing criterion artifacts to release: $TAG"
+          else
+            echo "No release tag resolved; skipping release publish steps."
+          fi
+
       - name: Append criterion summary to release notes
-        if: startsWith(github.ref, 'refs/tags/')
+        if: steps.release_tag.outputs.tag != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          TAG="${GITHUB_REF##*/}"
+          TAG="${{ steps.release_tag.outputs.tag }}"
 
           # Wait for the release to exist (created by release-cross workflow).
           # The release-cross workflow may take 20+ minutes to build all
@@ -140,9 +163,9 @@ jobs:
           gh release edit "$TAG" --notes "$NEW_BODY"
 
       - name: Upload criterion results to release
-        if: startsWith(github.ref, 'refs/tags/')
+        if: steps.release_tag.outputs.tag != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          TAG="${GITHUB_REF##*/}"
+          TAG="${{ steps.release_tag.outputs.tag }}"
           gh release upload "$TAG" criterion_output.txt --clobber

--- a/crates/fast_io/benches/io_optimizations.rs
+++ b/crates/fast_io/benches/io_optimizations.rs
@@ -11,6 +11,8 @@
 
 use std::fs::File;
 use std::io::{BufWriter, IoSlice, Read, Write};
+#[cfg(all(target_os = "linux", feature = "io_uring"))]
+use std::time::Duration;
 
 use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
 use tempfile::{NamedTempFile, tempdir};
@@ -191,17 +193,19 @@ fn bench_io_uring(c: &mut Criterion) {
             });
         });
 
-        // io_uring optimized I/O. Sentinel-allocate one ring up front: the
-        // kernel-level probe (`is_io_uring_available`) does not catch ring
-        // allocation failures from RLIMIT_MEMLOCK, which CI runners often
-        // impose. Skipping here keeps the standard_io baseline measurable.
+        // io_uring optimized I/O. Allocate the ring once per sub-benchmark
+        // and reuse it across iterations: `read_all_batched` reads from
+        // offset 0 and returns registered-buffer slots via Drop, so reuse
+        // is safe. Per-iteration ring allocation in tight read loops
+        // (~6us/iter * thousands of iters during warm-up + measurement)
+        // exhausts RLIMIT_MEMLOCK on CI runners, panicking with ENOMEM.
+        // Hoisting also doubles as the sentinel: a failed open here skips
+        // the sub-bench and keeps the standard_io baseline measurable.
         let config = IoUringConfig::default();
         match IoUringReader::open(path, &config) {
-            Ok(_) => {
-                group.bench_with_input(BenchmarkId::new("io_uring", name), &path, |b, path| {
+            Ok(mut reader) => {
+                group.bench_with_input(BenchmarkId::new("io_uring", name), &path, |b, _path| {
                     b.iter(|| {
-                        let config = IoUringConfig::default();
-                        let mut reader = IoUringReader::open(path, &config).unwrap();
                         let data = reader.read_all_batched().unwrap();
                         black_box(&data);
                         data.len()
@@ -227,6 +231,14 @@ fn bench_io_uring_writes(c: &mut Criterion) {
     }
 
     let mut group = c.benchmark_group("io_uring_writes");
+    // Bound per-iteration ring allocations: each io_uring write iter
+    // allocates a fresh ring via `IoUringWriter::create`, and tight loops
+    // exhaust RLIMIT_MEMLOCK on CI runners. The writer owns its file with
+    // an internal write cursor, so cross-iter reuse would grow the file
+    // unboundedly -- bound iteration count instead.
+    group.sample_size(10);
+    group.warm_up_time(Duration::from_millis(500));
+    group.measurement_time(Duration::from_secs(2));
 
     let test_sizes = [("64kb", 64 * 1024), ("1mb", 1024 * 1024)];
 


### PR DESCRIPTION
Two release-blocker fixes for the v0.6.1 Criterion publishing pipeline.

## fix(bench): hoist io_uring reader to prevent MEMLOCK exhaustion

The v0.6.1 Criterion workflow (run 25276974185) panicked with `Cannot allocate memory (os error 12)` during `io_uring/io_uring/64kb` warm-up. Per-iteration `IoUringReader::open` allocates a fresh ring; at ~6us/iter across 3s warm-up + 5s measurement, hundreds of thousands of ring allocations exhaust `RLIMIT_MEMLOCK` on CI runners.

Fix:
- **Reads:** hoist `IoUringReader` allocation outside `b.iter`. `read_all_batched` reads from offset 0 each call and returns registered-buffer slots via Drop, so reuse is safe. The hoisted open also doubles as the sentinel: a failed open skips the sub-bench and keeps the `standard_io` baseline measurable.
- **Writes:** `IoUringWriter` owns its file with an internal byte cursor (no reset path), so cross-iter reuse is impractical. Bound the write iteration count instead via `sample_size(10)`, `warm_up_time(500ms)`, `measurement_time(2s)`.

## fix(ci): allow Criterion workflow to publish to existing release tag

Mirrors the `target_tag` dispatch pattern from benchmark.yml (PR #3574). Adds a `workflow_dispatch` input plus a `Resolve release tag` step so the Criterion workflow can be re-run against an existing release tag without retagging - required to publish criterion results to v0.6.1 once the bench fix above lands.

## Verification

- v0.6.1 source tarball reproduces the original ENOMEM panic
- Bench fix runs to completion locally with both reads and writes
- Workflow YAML follows the same target_tag pattern already merged in PR #3574