### PR TITLE
fix(interop): accept both stderr orderings in 3.0.9 protocol-mismatch golden

### DIFF
--- a/tests/interop/messages/golden-3.0.9.toml
+++ b/tests/interop/messages/golden-3.0.9.toml
@@ -35,6 +35,11 @@ text = "protocol version mismatch -- is your shell clean?(see the rsync man page
 scenario = "protocol_version_mismatch"
 optional = true
 
+[[messages]]
+text = "(see the rsync man page for an explanation)protocol version mismatch -- is your shell clean?"
+scenario = "protocol_version_mismatch"
+optional = true
+
 # At least one form of the shell-clean message must appear
 [[message_groups]]
 name = "protocol_mismatch_shell_clean"
@@ -42,6 +47,7 @@ scenario = "protocol_version_mismatch"
 require_at_least = 1
 messages = [
     { text = "protocol version mismatch -- is your shell clean?" },
+    { text = "(see the rsync man page for an explanation)protocol version mismatch -- is your shell clean?" },
     { text = "protocol version mismatch -- is your shell clean?(see the rsync man page for an explanation)" },
 ]
 


### PR DESCRIPTION
## Summary

Upstream rsync 3.0.9 emits two stderr lines on a protocol-version mismatch — `protocol version mismatch -- is your shell clean?` from the sender and `(see the rsync man page for an explanation)` from the receiver. The two writes flush in nondeterministic order, so the combined captured output appears as either:

- `protocol version mismatch -- is your shell clean?(see the rsync man page for an explanation)` (sender-first)
- `(see the rsync man page for an explanation)protocol version mismatch -- is your shell clean?` (receiver-first)

The 3.0.9 golden previously only accepted the sender-first ordering. This caused the Message Format Validation job in the Interop Validation workflow to flake whenever the receiver-first ordering occurred (observed on the post-merge run for #3576, run 25283076233).

The 3.1.3 golden already covers both orderings; this brings 3.0.9 to parity by adding the receiver-first variant in two places:

- as an additional optional `[[messages]]` entry
- as a member of the `protocol_mismatch_shell_clean` group's `messages = [ ... ]` array

No oc-rsync source change is required: the validator runs the upstream binary itself and compares its stderr against the recorded golden, so this is a golden-coverage gap rather than an oc-rsync behavioral bug.

## Test plan

- [ ] Message Format Validation job passes on this PR's CI run
- [ ] No regression in 3.1.3 / 3.4.1 message validation