### PR TITLE
docs(compress): comment cleanup for skip_compress (#2027)

### DIFF
--- a/crates/compress/src/skip_compress/adaptive.rs
+++ b/crates/compress/src/skip_compress/adaptive.rs
@@ -68,15 +68,12 @@ impl<W: Write> AdaptiveCompressor<W> {
         self.should_compress = self.decider.auto_detect_compressible(&self.buffer)?;
         self.decision_made = true;
 
-        // Flush buffered data according to decision
         if self.should_compress {
-            // Compress buffered data
             let mut encoder = CountingZlibEncoder::with_sink(Vec::new(), self.level);
             encoder.write_all(&self.buffer)?;
             let (compressed, _) = encoder.finish_into_inner()?;
             self.compress_buffer = compressed;
         } else {
-            // Write buffered data directly
             self.inner.write_all(&self.buffer)?;
         }
 
@@ -86,12 +83,11 @@ impl<W: Write> AdaptiveCompressor<W> {
 
     /// Finishes the compression stream and returns the inner writer.
     pub fn finish(mut self) -> io::Result<W> {
-        // Make decision if we haven't yet (for small files)
+        // Force a decision for small files that never reached the sample size.
         if !self.decision_made {
             self.make_decision()?;
         }
 
-        // Write any remaining compressed data
         if !self.compress_buffer.is_empty() {
             self.inner.write_all(&self.compress_buffer)?;
         }
@@ -104,23 +100,19 @@ impl<W: Write> AdaptiveCompressor<W> {
 impl<W: Write> Write for AdaptiveCompressor<W> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         if !self.decision_made {
-            // Buffer data until we have enough for auto-detection
             let remaining = self.decider.sample_size().saturating_sub(self.buffer.len());
 
             if remaining > 0 {
                 let to_buffer = buf.len().min(remaining);
                 self.buffer.extend_from_slice(&buf[..to_buffer]);
 
-                // If we still don't have enough, report buffered amount
                 if self.buffer.len() < self.decider.sample_size() {
                     return Ok(to_buffer);
                 }
             }
 
-            // We have enough data, make the decision
             self.make_decision()?;
 
-            // Write any remaining data from this call
             if remaining < buf.len() {
                 let written = self.write(&buf[remaining..])?;
                 return Ok(written + remaining);
@@ -129,9 +121,7 @@ impl<W: Write> Write for AdaptiveCompressor<W> {
             return Ok(buf.len());
         }
 
-        // Decision already made, write data accordingly
         if self.should_compress {
-            // Compress this chunk and add to buffer
             let mut encoder = CountingZlibEncoder::with_sink(Vec::new(), self.level);
             encoder.write_all(buf)?;
             let (compressed, _) = encoder.finish_into_inner()?;
@@ -143,7 +133,6 @@ impl<W: Write> Write for AdaptiveCompressor<W> {
     }
 
     fn flush(&mut self) -> io::Result<()> {
-        // Write any pending compressed data
         if !self.compress_buffer.is_empty() {
             self.inner.write_all(&self.compress_buffer)?;
             self.compress_buffer.clear();

--- a/crates/compress/src/skip_compress/decider.rs
+++ b/crates/compress/src/skip_compress/decider.rs
@@ -143,7 +143,8 @@ impl CompressionDecider {
 
     /// Sets the sample size for auto-detection.
     pub fn set_sample_size(&mut self, size: usize) {
-        self.sample_size = size.max(64); // Minimum 64 bytes for meaningful detection
+        // 64 bytes is the smallest sample that yields meaningful ratio measurements.
+        self.sample_size = size.max(64);
     }
 
     /// Byte count sampled from each file for auto-detection.
@@ -170,14 +171,13 @@ impl CompressionDecider {
     /// `AutoDetect` when no content is available for analysis.
     #[must_use]
     pub fn should_compress(&self, path: &Path, first_block: Option<&[u8]>) -> CompressionDecision {
-        // Check extension first (fastest path)
+        // Extension lookup is the fastest path; check it before any content inspection.
         if let Some(ext) = Self::extract_extension(path) {
             if self.skip_extensions.contains(ext.as_str()) {
                 return CompressionDecision::Skip;
             }
         }
 
-        // Check magic bytes if available and enabled
         if self.use_magic_detection {
             if let Some(data) = first_block {
                 if let Some(category) = self.detect_category_by_magic(data) {
@@ -188,12 +188,11 @@ impl CompressionDecider {
             }
         }
 
-        // If we have content but couldn't determine the type, suggest auto-detection
         if first_block.is_some() {
             return CompressionDecision::Compress;
         }
 
-        // Without content, we can't make a definitive decision
+        // No content available; defer to caller's auto-detection pass.
         CompressionDecision::AutoDetect
     }
 
@@ -215,15 +214,15 @@ impl CompressionDecider {
     /// ```
     pub fn auto_detect_compressible(&self, sample: &[u8]) -> io::Result<bool> {
         if sample.is_empty() {
-            return Ok(true); // Empty files are trivially compressible
+            // Empty input has nothing to skip and is trivially "compressible".
+            return Ok(true);
         }
 
-        // Use fast compression level for auto-detection
+        // Use the fastest level: detection only needs ratio, not optimal output.
         let mut encoder = CountingZlibEncoder::new(CompressionLevel::Fast);
         encoder.write_all(sample)?;
         let compressed_len = encoder.finish()? as usize;
 
-        // Calculate compression ratio
         let ratio = compressed_len as f64 / sample.len() as f64;
 
         Ok(ratio < self.compression_threshold)
@@ -231,18 +230,17 @@ impl CompressionDecider {
 
     /// Extracts and normalizes the file extension from a path.
     pub(crate) fn extract_extension(path: &Path) -> Option<Suffix> {
-        // Handle compound extensions like .tar.gz
         let file_name = path.file_name()?.to_str()?;
         let lower = file_name.to_ascii_lowercase();
 
-        // Check for known compound extensions
+        // Compound suffixes like `.tar.gz` must match the full filename to win
+        // over the trailing simple extension (`gz`).
         for compound in COMPOUND_EXTENSIONS {
             if lower.ends_with(compound) {
                 return Some(Suffix::new(compound.trim_start_matches('.')));
             }
         }
 
-        // Fall back to simple extension
         path.extension()
             .and_then(|ext| ext.to_str())
             .map(Suffix::new)


### PR DESCRIPTION
## Summary

Comment cleanup for the `skip_compress` module per repo `internal docs` guidelines:

- Removed restating-the-code comments that simply echoed the next line of Rust.
- Converted a couple of inline notes into informative comments that explain the rationale (why fast level, why 64-byte minimum, why compound suffix lookup precedes simple extension lookup, why `AutoDetect` is the no-content default).
- Preserved all upstream rsync source references (e.g., `token.c:set_compression()`, `loadparm.c:lp_dont_compress()`).
- No code logic changes - documentation/comments only.

Files touched:
- `crates/compress/src/skip_compress/adaptive.rs`
- `crates/compress/src/skip_compress/decider.rs`

The rest of the submodules (`mod.rs`, `defaults.rs`, `magic.rs`, `types.rs`, `tests.rs`) already conformed to the comment policy and were left untouched.

Fixes #2027

## Test plan

- [ ] CI: fmt + clippy
- [ ] CI: nextest (stable)
- [ ] CI: Windows / macOS / Linux musl