### PR TITLE
docs(engine): comment cleanup for local_copy::deletion (#1947)

### DIFF
--- a/crates/engine/src/local_copy/executor/directory/recursive/deletion.rs
+++ b/crates/engine/src/local_copy/executor/directory/recursive/deletion.rs
@@ -3,7 +3,8 @@
 //! Implements the `--delete-after` and `--delete-during` phases that remove
 //! extraneous destination entries. Also handles `--prune-empty-dirs`.
 //!
-//! // upstream: generator.c:delete_in_dir() - post-transfer deletion
+//! upstream: generator.c:delete_in_dir() - post-transfer deletion
+
 use std::ffi::OsString;
 use std::fs;
 use std::path::Path;

--- a/crates/engine/src/local_copy/options/deletion.rs
+++ b/crates/engine/src/local_copy/options/deletion.rs
@@ -103,12 +103,10 @@ impl LocalCopyOptions {
     /// the rename sweep runs, corrupting the transfer.  We therefore promote
     /// `During` to `After` whenever `delay_updates` is set.
     ///
-    /// upstream: generator.c — delete_in_dir() is only invoked after the
+    /// upstream: generator.c - delete_in_dir() is only invoked after the
     /// receiver rename sweep completes when delay_updates is active.
     pub const fn delete_timing(&self) -> Option<DeleteTiming> {
         if self.delete {
-            // Promote During → After when --delay-updates is active so that
-            // staged .~tmp~ files are not treated as extraneous mid-transfer.
             if self.delay_updates && matches!(self.delete_timing, DeleteTiming::During) {
                 Some(DeleteTiming::After)
             } else {


### PR DESCRIPTION
Fixes #1947

## Summary
Comment cleanup for the deletion-related modules under `crates/engine/src/local_copy/`. There is no single `local_copy/deletion.rs` file; the deletion logic lives in `options/deletion.rs` and `executor/directory/recursive/deletion.rs`. Both files were audited per the project comment-cleanup rules in `internal docs`.

Changes:
- `options/deletion.rs`: removed an inline two-line comment in `delete_timing()` that restated the surrounding rustdoc paragraph. Replaced an em-dash with a hyphen in the upstream reference line, per project style.
- `executor/directory/recursive/deletion.rs`: the module-level `//!` block contained a malformed line `//! // upstream: ...` (an inner `//` inside a doc comment). Cleaned it up to `//! upstream: ...` and added the missing blank line before the `use` declarations.

The upstream reference is preserved in both files. No code logic changes.

## Test plan
- [ ] CI fmt+clippy passes
- [ ] CI nextest (stable) passes
- [ ] No behavioral change - comments only