### PR TITLE
docs(rsync_io): comment cleanup for ssh module (#2032)

### DIFF
--- a/crates/rsync_io/src/ssh/builder.rs
+++ b/crates/rsync_io/src/ssh/builder.rs
@@ -102,7 +102,7 @@ impl SshCommand {
     /// before connecting to the remote host. This mirrors upstream rsync's
     /// `--address` handling for SSH transports.
     ///
-    /// upstream: clientserver.c — `--address` is forwarded to SSH as
+    /// upstream: clientserver.c - `--address` is forwarded to SSH as
     /// `-o BindAddress=<addr>`.
     pub const fn set_bind_address(&mut self, addr: Option<IpAddr>) -> &mut Self {
         self.bind_address = addr;

--- a/crates/rsync_io/src/ssh/connection.rs
+++ b/crates/rsync_io/src/ssh/connection.rs
@@ -473,12 +473,13 @@ impl SshChildHandle {
 
 impl Drop for SshChildHandle {
     fn drop(&mut self) {
-        // Drop the watchdog first to stop the background thread.
+        // Drop the watchdog first so its background thread exits before we
+        // touch the child handle.
         drop(self.connect_watchdog.take());
 
-        // Reap the child process to prevent zombies.
-        // Unlike SshConnection::Drop, stdin is not owned here (it lives in
-        // SshWriter) so we skip the close_stdin step.
+        // Reap the child to prevent zombies. Unlike SshConnection::Drop,
+        // stdin is not owned here (it lives in SshWriter) so we skip the
+        // close_stdin step.
         if let Ok(None) = self.child.try_wait() {
             let _ = self.child.kill();
         }
@@ -542,7 +543,8 @@ impl Write for SshConnection {
 
 impl Drop for SshConnection {
     fn drop(&mut self) {
-        // Drop the watchdog first to stop the background thread.
+        // Drop the watchdog first so its background thread exits before we
+        // touch the child handle.
         drop(self.connect_watchdog.take());
 
         let _ = self.close_stdin();

--- a/crates/rsync_io/src/ssh/embedded/auth.rs
+++ b/crates/rsync_io/src/ssh/embedded/auth.rs
@@ -220,7 +220,6 @@ pub async fn authenticate(
     let username = effective_username(config)?;
     let mut tried = Vec::new();
 
-    // 1. SSH agent.
     if config.use_agent {
         if try_agent_auth(session, &username).await? {
             return Ok(());
@@ -228,7 +227,6 @@ pub async fn authenticate(
         tried.push("agent");
     }
 
-    // 2. Identity files.
     if !config.identity_files.is_empty() {
         if try_identity_file_auth(session, &username, &config.identity_files).await? {
             return Ok(());
@@ -236,7 +234,6 @@ pub async fn authenticate(
         tried.push("publickey");
     }
 
-    // 3. Password.
     if try_password_auth(session, &username, config).await? {
         return Ok(());
     }

--- a/crates/rsync_io/src/ssh/embedded/connect.rs
+++ b/crates/rsync_io/src/ssh/embedded/connect.rs
@@ -127,7 +127,6 @@ async fn connect_and_exec_async(
     remote_command: &str,
     stdin_data: Option<&[u8]>,
 ) -> Result<(ChannelReader, ChannelWriter), SshError> {
-    // Resolve host
     let addrs = resolve_host(&ssh_config.host, ssh_config.port, ssh_config.ip_preference).await?;
 
     let addr = addrs
@@ -147,7 +146,6 @@ async fn connect_and_exec_async(
         ssh_config.known_hosts_file.clone(),
     );
 
-    // Connect with timeout
     let mut handle = tokio::time::timeout(ssh_config.connect_timeout, async {
         russh::client::connect(client_config, addr, handler).await
     })
@@ -156,10 +154,8 @@ async fn connect_and_exec_async(
         secs: ssh_config.connect_timeout.as_secs(),
     })??;
 
-    // Authenticate
     authenticate(&mut handle, ssh_config).await?;
 
-    // Open session channel and exec
     let channel = handle
         .channel_open_session()
         .await
@@ -170,19 +166,17 @@ async fn connect_and_exec_async(
         .await
         .map_err(SshError::Connect)?;
 
-    // Set up sync/async bridge channels
     let (data_tx, data_rx) = std::sync::mpsc::sync_channel::<Vec<u8>>(64);
     let (write_tx, mut write_rx) = tokio::sync::mpsc::channel::<Vec<u8>>(64);
 
     let channel_id = channel.id();
     let mut channel_for_read = channel;
 
-    // We need a separate handle for writing data. Since Handle may not be
-    // Clone in russh 0.45, we share via Arc<Mutex<_>>.
+    // Handle is not Clone in russh 0.45, so share via Arc<Mutex<_>> to allow
+    // the async bridge task to write while the caller still holds a reference.
     let handle_shared = Arc::new(tokio::sync::Mutex::new(handle));
     let handle_for_write = handle_shared.clone();
 
-    // Spawn a task to bridge async SSH channel I/O to sync channels.
     tokio::spawn(async move {
         loop {
             tokio::select! {
@@ -220,7 +214,6 @@ async fn connect_and_exec_async(
         }
     });
 
-    // Send initial stdin data (secluded args) if provided
     if let Some(data) = stdin_data {
         write_tx
             .send(data.to_vec())

--- a/crates/rsync_io/src/ssh/operand.rs
+++ b/crates/rsync_io/src/ssh/operand.rs
@@ -114,9 +114,6 @@ pub fn parse_ssh_operand(operand: &OsStr) -> Result<RemoteOperand, RemoteOperand
         return Err(RemoteOperandParseError::Empty);
     }
 
-    // Parse the operand: [user@][host]:path
-    // IPv6 hosts may be in brackets: [::1]:path or user@[::1]:path
-
     let (user, rest) = extract_user(&text);
     let (host, path) = extract_host_and_path(rest)?;
 


### PR DESCRIPTION
Fixes #2032

## Summary

Comment cleanup pass over `crates/rsync_io/src/ssh/` per the internal docs
rules: drop restating/obvious comments, preserve every upstream
reference and every comment that explains WHY, and convert one
em-dash to a hyphen.

No behavioural or API changes - comments only.

## Files touched (5)

- `crates/rsync_io/src/ssh/builder.rs` - em-dash to hyphen in the
  `clientserver.c` upstream reference on `set_bind_address`.
- `crates/rsync_io/src/ssh/connection.rs` - tighten the two Drop-impl
  comments on `SshConnection` and `SshChildHandle` so they explain
  ordering instead of restating "drop the watchdog" / "reap the child".
- `crates/rsync_io/src/ssh/embedded/auth.rs` - drop the numbered
  `// 1. SSH agent.` / `// 2. Identity files.` / `// 3. Password.`
  section comments in `authenticate()`; the rustdoc on the function
  already enumerates the OpenSSH order.
- `crates/rsync_io/src/ssh/embedded/connect.rs` - drop seven
  section-divider comments in `connect_and_exec_async` that simply
  restated the next statement (`Resolve host`, `Connect with timeout`,
  `Authenticate`, `Open session channel and exec`, `Set up sync/async
  bridge channels`, `Spawn a task to bridge async SSH channel I/O`,
  `Send initial stdin data`); tighten the Arc<Mutex<_>> rationale.
- `crates/rsync_io/src/ssh/operand.rs` - drop the
  `// Parse the operand: [user@][host]:path` and IPv6-bracket comments
  inside `parse_ssh_operand`; the rustdoc already lists the accepted
  formats.

## Stats

- Files touched: 5
- Comments removed: ~12
- Comments rewritten for clarity: 3 (2x Drop-impl, 1x Arc<Mutex<_>>)
- Em-dashes converted to hyphens: 1
- Net: +10 / -21 lines

All `// upstream:` references and every WHY-explaining comment in the
module (including rustdoc, drain-thread rationale, regression notes,
hardware-AES detection commentary, parser-strictness notes, etc.) are
preserved.

## Test plan

- [ ] CI: fmt + clippy
- [ ] CI: nextest (stable / Windows / macOS / Linux musl)

Comments-only change; no logic touched.