### PR TITLE
docs(checksums): comment cleanup for pipelined module (#2017)

### DIFF
--- a/crates/checksums/src/pipelined/config.rs
+++ b/crates/checksums/src/pipelined/config.rs
@@ -30,8 +30,8 @@ pub struct PipelineConfig {
 impl Default for PipelineConfig {
     fn default() -> Self {
         Self {
-            block_size: 64 * 1024,     // 64 KiB
-            min_file_size: 256 * 1024, // 256 KiB
+            block_size: 64 * 1024,
+            min_file_size: 256 * 1024,
             enabled: true,
         }
     }


### PR DESCRIPTION
## Summary

Comment cleanup for `crates/checksums/src/pipelined/` per internal docs conventions.

- Removed restating-the-code unit annotations (`// 64 KiB`, `// 256 KiB`) on `PipelineConfig::default` literals; the rustdoc on the fields already documents the units, so the inline comments added no value beyond the code.
- All other files in the module (`mod.rs`, `reader.rs`, `checksums.rs`) already conform: rustdoc on public items, `//!` only at the top of true module files, and the only remaining `//` comments explain intent (e.g. why the first block is read synchronously, why the receiver is dropped before joining the I/O thread). No upstream rsync references existed to preserve.
- No code logic changes.

Fixes #2017

## Test plan

- [ ] CI: fmt + clippy
- [ ] CI: nextest (stable, all platforms)