### PR TITLE
ci(criterion): bump release benchmark timeout 90m -> 180m

### DIFF
--- a/.github/workflows/benchmark-release.yml
+++ b/.github/workflows/benchmark-release.yml
@@ -26,8 +26,12 @@ jobs:
     name: Criterion Benchmark Suite
     runs-on: ubuntu-24.04
     # Budget: ~30min waiting for release-cross to publish the release,
-    # ~10-15min cold-cache workspace compile, ~15-20min benchmark execution.
-    timeout-minutes: 90
+    # ~10-15min cold-cache workspace compile, ~60-90min benchmark execution
+    # across all 7 crates (checksums, core, engine, fast_io, match, protocol,
+    # transfer). Empirical: full suite at default criterion sample sizes hits
+    # ~110min on ubuntu-24.04 runners. Bumped from 90 -> 180 after run
+    # 25287815060 was wall-cancelled mid-run.
+    timeout-minutes: 180
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- Bump criterion-release workflow timeout from 90 to 180 minutes
- Update budget comment to reflect measured benchmark execution time

## Why
Run [25287815060](https://github.com/oferchen/rsync/actions/runs/25287815060) was wall-cancelled at 90 minutes while still executing the match crate benchmarks. The release-cross delay (~30min) plus cold-cache workspace compile (~15min) plus full criterion sweep (~100min on default sample sizes) exceeds the previous budget. This blocked v0.6.1 from receiving its `Criterion Microbenchmarks` section and `criterion_output.txt` release asset.

## Test plan
- [ ] CI fmt+clippy passes
- [ ] After merge, redispatch the criterion workflow against v0.6.1 via workflow_dispatch with `target_tag=v0.6.1` and confirm the section + asset land on the release page