### PR TITLE
docs(daemon): comment cleanup for module_state (#1968)

### DIFF
--- a/crates/daemon/src/daemon/module_state/mod.rs
+++ b/crates/daemon/src/daemon/module_state/mod.rs
@@ -20,9 +20,6 @@ mod test_support;
 #[cfg(test)]
 mod tests;
 
-// Re-export all public items to preserve the existing API surface.
-// All items were previously inlined into the daemon module via include!().
-
 pub(crate) use auth::{AuthUser, UserAccessLevel};
 pub(crate) use connection_limiter::{ConnectionLimiter, ConnectionLockGuard};
 pub(crate) use definition::ModuleDefinition;


### PR DESCRIPTION
## Summary
- Removes two restating comments above the re-export block in `crates/daemon/src/daemon/module_state/mod.rs` that echoed what `pub(crate) use` already conveys.
- All other files in the module already conform to the rustdoc convention: public items have `///` docs, upstream rsync references are preserved, `#[allow(dead_code)]` justifications remain, and the "why" comments documenting `include!()` import context are kept.

## Files touched
- `crates/daemon/src/daemon/module_state/mod.rs`

## Audit results
- Files audited: 8 (`mod.rs`, `auth.rs`, `connection_limiter.rs`, `definition.rs`, `hostname.rs`, `runtime.rs`, `test_support.rs`, `tests.rs`)
- Files modified: 1
- Comments deleted: 2 (restatement of `pub use` re-exports)
- Comments converted: 0
- Comments preserved: all upstream refs (`upstream: loadparm.c`, `clientserver.c`, `daemon-parm.h`, etc.), `#[allow(dead_code)]` justifications, and `include!()` import-context notes in `definition.rs` and `tests.rs`

Refs #1968.

## Test plan
- [ ] CI fmt+clippy
- [ ] CI nextest (stable)
- [ ] CI Windows / macOS / Linux musl