### PR TITLE
docs(protocol): comment cleanup for acl (#1981)

### DIFF
--- a/crates/protocol/src/acl/definition/wire.rs
+++ b/crates/protocol/src/acl/definition/wire.rs
@@ -118,7 +118,6 @@ pub fn write_acl_definition<W: io::Write>(
     use super::super::wire::send_ida_entries;
     use crate::varint::write_varint;
 
-    // Build the wire-level RsyncAcl from the definition
     let mut user_obj: Option<u8> = None;
     let mut group_obj: Option<u8> = None;
     let mut mask_obj: Option<u8> = None;
@@ -140,7 +139,6 @@ pub fn write_acl_definition<W: io::Write>(
         }
     }
 
-    // Compute flags byte
     let mut flags = 0u8;
     if user_obj.is_some() {
         flags |= XMIT_USER_OBJ;

--- a/crates/protocol/src/acl/entry.rs
+++ b/crates/protocol/src/acl/entry.rs
@@ -442,7 +442,6 @@ impl RsyncAcl {
             return false;
         }
 
-        // Compare named entries element-by-element
         for (a, b) in self.names.iter().zip(other.names.iter()) {
             if a.id != b.id || a.access != b.access {
                 return false;
@@ -452,9 +451,9 @@ impl RsyncAcl {
         // upstream: acls.c:309-331 - mask and group_obj comparison depends
         // on whether named entries exist
         if self.names.is_empty() {
-            // No named entries - mask is irrelevant, compare group_obj directly.
-            // upstream: acls.c:310-315 - when no named entries, only group_obj
-            // matters regardless of mask presence
+            // upstream: acls.c:310-315 - without named entries, mask is
+            // irrelevant; the effective group is mask_obj if present, else
+            // group_obj
             let self_group = if self.has_mask_obj() {
                 self.mask_obj
             } else {
@@ -467,8 +466,8 @@ impl RsyncAcl {
             };
             self_group == other_group
         } else {
-            // Named entries present - both mask and group must match exactly
-            // upstream: acls.c:325-331
+            // upstream: acls.c:325-331 - with named entries, both mask and
+            // group must match exactly
             self.group_obj == other.group_obj && self.mask_obj == other.mask_obj
         }
     }

--- a/crates/protocol/src/acl/tests.rs
+++ b/crates/protocol/src/acl/tests.rs
@@ -28,7 +28,6 @@ mod id_access_tests {
     fn permissions_mask_removes_name_is_user() {
         let entry = IdAccess::user(1000, 0x07);
         assert_eq!(entry.permissions(), 0x07);
-        // Access field has the flag
         assert_eq!(entry.access & NAME_IS_USER, NAME_IS_USER);
     }
 
@@ -74,7 +73,6 @@ mod ida_entries_tests {
     fn computed_mask_bits_excludes_no_entry() {
         let mut entries = IdaEntries::new();
         entries.push(IdAccess::user(1000, 0x07 | NO_ENTRY as u32));
-        // NO_ENTRY bits should be excluded from the mask
         let mask = entries.computed_mask_bits();
         assert_eq!(mask & NO_ENTRY, 0);
     }
@@ -581,16 +579,13 @@ mod edge_cases {
         let acl2 = {
             let mut a = RsyncAcl::new();
             a.user_obj = 0x07;
-            a.group_obj = 0x04; // Different!
+            a.group_obj = 0x04;
             a
         };
 
         let _ = cache.store_access(acl1.clone());
 
-        // acl2 should not match acl1
         assert!(cache.find_access(&acl2).is_none());
-
-        // But acl1 should still match
         assert_eq!(cache.find_access(&acl1), Some(0));
     }
 }

--- a/crates/protocol/src/acl/wire/send.rs
+++ b/crates/protocol/src/acl/wire/send.rs
@@ -91,7 +91,6 @@ pub fn send_rsync_acl<W: Write>(
     cache: &mut AclCache,
     include_names: bool,
 ) -> io::Result<()> {
-    // Check cache for matching ACL
     let cached_index = match acl_type {
         AclType::Access => cache.find_access(acl),
         AclType::Default => cache.find_default(acl),


### PR DESCRIPTION
## Summary

Comment-only cleanup for `crates/protocol/src/acl/`. Removes restating-the-code comments while preserving rustdoc and upstream rsync source references per internal docs comment cleanup rules. No behavior or signature changes.

## Files touched

- `crates/protocol/src/acl/entry.rs` - dropped "Compare named entries element-by-element" header above the for loop it merely names; consolidated the no-named-entries vs named-entries explanatory comments into single upstream-anchored (`acls.c:310-315`, `acls.c:325-331`) notes.
- `crates/protocol/src/acl/definition/wire.rs` - dropped "Build the wire-level RsyncAcl from the definition" and "Compute flags byte" section headers that restate the immediately following code.
- `crates/protocol/src/acl/wire/send.rs` - dropped "Check cache for matching ACL" header above the cache lookup.
- `crates/protocol/src/acl/tests.rs` - dropped redundant in-test commentary ("Access field has the flag", "NO_ENTRY bits should be excluded from the mask", "Different!", "acl2 should not match acl1", "But acl1 should still match") where the asserts are self-explanatory.

## Preserved

- All `///` rustdoc on public types, traits, functions, methods.
- All `//!` module-level docs.
- All `// upstream: acls.c:...` source references.
- Comments explaining WHY (e.g., POSIX.1e mask-vs-group semantics in `get_perms`, computed-mask fallback in `recv_rsync_acl`).

## Test plan

- [ ] CI fmt+clippy passes
- [ ] CI nextest (stable) passes on all platforms
- [ ] No code semantics changed - comment edits only