### PR TITLE
docs(protocol): comment cleanup for wire::delta (#2002)

### DIFF
--- a/crates/protocol/src/wire/delta/int_encoding.rs
+++ b/crates/protocol/src/wire/delta/int_encoding.rs
@@ -25,7 +25,7 @@ use std::io::{self, Read, Write};
 ///
 /// let mut buf = Vec::new();
 /// write_int(&mut buf, 0x12345678).unwrap();
-/// assert_eq!(buf, [0x78, 0x56, 0x34, 0x12]); // Little-endian
+/// assert_eq!(buf, [0x78, 0x56, 0x34, 0x12]);
 /// ```
 ///
 /// Reference: `io.c:write_int()` line ~2082

--- a/crates/protocol/src/wire/delta/types.rs
+++ b/crates/protocol/src/wire/delta/types.rs
@@ -17,10 +17,8 @@ pub const CHUNK_SIZE: usize = 32 * 1024;
 /// ```
 /// use protocol::wire::DeltaOp;
 ///
-/// // Create a literal operation
 /// let lit = DeltaOp::Literal(vec![1, 2, 3, 4, 5]);
 ///
-/// // Create a copy operation
 /// let copy = DeltaOp::Copy {
 ///     block_index: 0,
 ///     length: 4096,


### PR DESCRIPTION
## Summary

Comment cleanup for `crates/protocol/src/wire/delta/` per task #2002. Removes restating-the-code comments while preserving every upstream rsync reference and all intent-bearing comments.

## Files touched

- `crates/protocol/src/wire/delta/int_encoding.rs` - drop trailing `// Little-endian` comment in doc example (info already conveyed by function name and `# Wire Format` section).
- `crates/protocol/src/wire/delta/types.rs` - drop `// Create a literal operation` and `// Create a copy operation` comments that echo the immediately following code.

## Files audited (no changes)

- `crates/protocol/src/wire/delta/mod.rs` - module rustdoc with upstream refs is appropriate.
- `crates/protocol/src/wire/delta/internal.rs` - rustdoc + OOM-cap intent comment preserved.
- `crates/protocol/src/wire/delta/token.rs` - rustdoc with upstream refs preserved.
- `crates/protocol/src/wire/delta/tests.rs` - test code; the lone inline comment `// Block match: token is -(block_index + 1)` is upstream encoding context and is preserved.

## Test plan

- [ ] CI: fmt + clippy
- [ ] CI: nextest (stable)
- [ ] Comment-only changes; no behavior modifications