### PR TITLE
docs(engine): comment cleanup for async_io (#1941)

### DIFF
--- a/crates/engine/src/async_io/batch.rs
+++ b/crates/engine/src/async_io/batch.rs
@@ -18,7 +18,7 @@ use super::progress::CopyResult;
 /// Each copy holds 2 fds; 64 workers = 128 fds, well within typical `ulimit -n`.
 const MAX_CONCURRENT_UPPER_BOUND: usize = 64;
 
-/// Minimum concurrency — always at least one worker.
+/// Minimum concurrency - always at least one worker.
 const MAX_CONCURRENT_LOWER_BOUND: usize = 1;
 
 /// Resolves the effective `max_concurrent` value.


### PR DESCRIPTION
## Summary
- Audited every file in `crates/engine/src/async_io/` (`mod.rs`, `batch.rs`, `copier.rs`, `error.rs`, `progress.rs`) per the comment cleanup convention.
- Replaced the only stylistic violation found: an em-dash in `batch.rs` rustdoc, swapped for a hyphen.
- All other comments in the module are already valid `///` rustdoc or `//!` module headers; none are restate-the-code, decorative banners, debug checkpoints, TODO/FIXME, or commented-out code, so no further edits were necessary.

## Files touched
- `crates/engine/src/async_io/batch.rs`

## Test plan
- [x] No behavior changes - comment-only edit, CI handles validation.