### PR TITLE
docs(transfer): comment cleanup for generator (#1957)

### DIFF
--- a/crates/transfer/src/generator/delta.rs
+++ b/crates/transfer/src/generator/delta.rs
@@ -217,7 +217,7 @@ pub(super) fn stream_whole_file_transfer<R: Read, W: Write>(
     let mut verifier = ChecksumVerifier::for_algorithm(checksum_algorithm);
 
     // Read buffer sized for fewer syscalls (up to 256KB per read).
-    // Buffer is reused across files — no allocation after the first large file.
+    // Buffer is reused across files - no allocation after the first large file.
     const MAX_READ_SIZE: usize = 256 * 1024;
     let read_size = (file_size as usize).clamp(1, MAX_READ_SIZE);
 

--- a/crates/transfer/src/generator/filters.rs
+++ b/crates/transfer/src/generator/filters.rs
@@ -122,7 +122,7 @@ impl GeneratorContext {
             // Read from protocol stream (stdin). The client forwards the file
             // list as NUL-separated entries with a double-NUL terminator.
             // upstream: main.c:681 - filesfrom_fd = STDIN_FILENO
-            // upstream: io.c:read_line(RL_CONVERT) — wire bytes are UTF-8 and
+            // upstream: io.c:read_line(RL_CONVERT) - wire bytes are UTF-8 and
             // must be transcoded to the local charset via ic_recv when
             // protect_args && --iconv are both in effect (compat.c:799-806).
             protocol::read_files_from_stream(reader, self.config.connection.iconv.as_ref())?
@@ -130,7 +130,7 @@ impl GeneratorContext {
             // Read from a local file on the server.
             // upstream: main.c:675-679 - open(files_from, O_RDONLY)
             // The file lives in the server's local charset, so no wire iconv
-            // applies — read it as-is, mirroring upstream's omission of
+            // applies - read it as-is, mirroring upstream's omission of
             // RL_CONVERT for the local-file fd.
             let from0 = self.config.file_selection.from0;
             read_files_from_local_path(&files_from_path, from0)?

--- a/crates/transfer/src/generator/item_flags.rs
+++ b/crates/transfer/src/generator/item_flags.rs
@@ -32,7 +32,7 @@ pub struct ItemFlags {
 }
 
 impl ItemFlags {
-    // Wire flags (bits 0-15) — upstream rsync.h:214-229
+    // Wire flags (bits 0-15) - upstream rsync.h:214-229
     /// Item reports access time change.
     pub const ITEM_REPORT_ATIME: u32 = 1 << 0; // 0x0001
     /// Item reports generic change (itemized output).
@@ -72,7 +72,7 @@ impl ItemFlags {
     /// Item needs data transfer (file content differs).
     pub const ITEM_TRANSFER: u32 = 1 << 15; // 0x8000
 
-    // Log-only flags (bits 16-18) — never sent on wire
+    // Log-only flags (bits 16-18) - never sent on wire
     /// Item is missing data (log formatting only).
     pub const ITEM_MISSING_DATA: u32 = 1 << 16; // 0x1_0000
     /// Item was deleted (log formatting only).

--- a/crates/transfer/src/generator/mod.rs
+++ b/crates/transfer/src/generator/mod.rs
@@ -126,7 +126,7 @@ pub mod io_error_flags {
     /// Converts an accumulated `io_error` bitfield into the corresponding rsync
     /// exit code.
     ///
-    /// Mirrors upstream `log.c` — `log_exit()` which maps the io_error flags to
+    /// Mirrors upstream `log.c` - `log_exit()` which maps the io_error flags to
     /// `RERR_*` exit codes. Returns 0 when no error bits are set.
     ///
     /// # Exit code mapping
@@ -424,7 +424,7 @@ impl GeneratorContext {
     /// [`run`](Self::run) to execute the transfer.
     #[must_use]
     pub fn new(handshake: &HandshakeResult, config: ServerConfig) -> Self {
-        // upstream: flist.c:2923 — ndx_start = inc_recurse ? 1 : 0
+        // upstream: flist.c:2923 - ndx_start = inc_recurse ? 1 : 0
         let inc_recurse = handshake
             .compat_flags
             .is_some_and(|f| f.contains(CompatibilityFlags::INC_RECURSE));
@@ -470,7 +470,7 @@ impl GeneratorContext {
     ///
     /// # Upstream Reference
     ///
-    /// - `generator.c:2321` — `ndx = i + cur_flist->ndx_start`
+    /// - `generator.c:2321` - `ndx = i + cur_flist->ndx_start`
     fn flat_to_wire_ndx(&self, flat_idx: usize) -> i32 {
         let seg_idx = self
             .incremental
@@ -548,7 +548,7 @@ impl GeneratorContext {
         .with_preserve_xattrs(self.config.flags.xattrs)
         .with_checksum_seed(self.checksum_seed);
 
-        // upstream: flist.c — always_checksum includes per-file checksums in the file list
+        // upstream: flist.c - always_checksum includes per-file checksums in the file list
         if self.config.flags.checksum {
             let factory = ChecksumFactory::from_negotiation(
                 self.negotiated_algorithms.as_ref(),

--- a/crates/transfer/src/generator/protocol_io.rs
+++ b/crates/transfer/src/generator/protocol_io.rs
@@ -129,7 +129,7 @@ impl GeneratorContext {
     ) -> io::Result<()> {
         if error.kind() == io::ErrorKind::NotFound {
             self.io_error |= super::io_error_flags::IOERR_VANISHED;
-            // upstream: sender.c:358 — rprintf(c, "file has vanished: %s\n", ...)
+            // upstream: sender.c:358 - rprintf(c, "file has vanished: %s\n", ...)
             eprintln!(
                 "file has vanished: {path_display} {}{}",
                 error_location!(),
@@ -137,7 +137,7 @@ impl GeneratorContext {
             );
         } else {
             self.io_error |= super::io_error_flags::IOERR_GENERAL;
-            // upstream: sender.c:362 — rsyserr(FERROR_XFER, errno, "send_files failed to open %s", ...)
+            // upstream: sender.c:362 - rsyserr(FERROR_XFER, errno, "send_files failed to open %s", ...)
             eprintln!(
                 "rsync: send_files failed to open \"{path_display}\": {} ({}) {}{}",
                 error,

--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -753,7 +753,7 @@ fn item_flags_constants() {
 
 #[test]
 fn significant_item_flags_masks_framing_and_internal_bits() {
-    // upstream rsync.h:235-236 — strips BASIS_TYPE_FOLLOWS, XNAME_FOLLOWS, LOCAL_CHANGE
+    // upstream rsync.h:235-236 - strips BASIS_TYPE_FOLLOWS, XNAME_FOLLOWS, LOCAL_CHANGE
     let mask = ItemFlags::SIGNIFICANT_ITEM_FLAGS;
     assert_eq!(mask & ItemFlags::ITEM_BASIS_TYPE_FOLLOWS, 0);
     assert_eq!(mask & ItemFlags::ITEM_XNAME_FOLLOWS, 0);

--- a/crates/transfer/src/generator/transfer.rs
+++ b/crates/transfer/src/generator/transfer.rs
@@ -238,7 +238,7 @@ impl GeneratorContext {
             }
 
             if !iflags.needs_transfer() {
-                // upstream: sender.c:287 — maybe_log_item() for non-transfer items
+                // upstream: sender.c:287 - maybe_log_item() for non-transfer items
                 self.maybe_emit_itemize(writer, &iflags, ndx, itemize)?;
                 continue;
             }
@@ -387,7 +387,7 @@ impl GeneratorContext {
             }
             files_transferred += 1;
 
-            // upstream: sender.c:430 — log_item(log_code, file, iflags, NULL)
+            // upstream: sender.c:430 - log_item(log_code, file, iflags, NULL)
             self.maybe_emit_itemize(writer, &iflags, ndx, itemize)?;
 
             if let Some(cb) = progress.as_mut() {


### PR DESCRIPTION
## Summary

Comment cleanup for `crates/transfer/src/generator/` per task #1957. Replaces em-dashes with hyphens across the submodule per the internal docs writing-style rule. No behavior changes; all upstream rsync references and rustdoc structure preserved.

## Changes

- 14 em-dash to hyphen replacements across 7 files.
- No restate-the-code comments, decorative banners, commented-out code, or TODO/FIXME found that required deletion - the module was otherwise stylistically clean.
- All `// upstream: ...` references and `///` rustdoc preserved.

## Files touched

- `crates/transfer/src/generator/mod.rs`
- `crates/transfer/src/generator/delta.rs`
- `crates/transfer/src/generator/filters.rs`
- `crates/transfer/src/generator/item_flags.rs`
- `crates/transfer/src/generator/protocol_io.rs`
- `crates/transfer/src/generator/transfer.rs`
- `crates/transfer/src/generator/tests.rs`

## Test plan

- [ ] CI: fmt + clippy
- [ ] CI: nextest (stable)
- [ ] CI: Windows / macOS / Linux musl matrices