### PR TITLE
docs(transfer): comment cleanup for pipeline (#1959)

### DIFF
--- a/crates/transfer/src/pipeline/async_dispatch.rs
+++ b/crates/transfer/src/pipeline/async_dispatch.rs
@@ -46,7 +46,7 @@ pub async fn produce_file_jobs(
         let job = FileJob::new(ndx as u32, dest_path, entry_arc);
 
         if tx.send(job).await.is_err() {
-            // Consumer dropped — stop producing.
+            // Consumer dropped - stop producing.
             break;
         }
         dispatched += 1;
@@ -139,7 +139,7 @@ mod tests {
         let list = FileList::new(entries);
         let (tx, rx) = mpsc::channel(1);
 
-        // Drop the receiver immediately — producer should stop gracefully.
+        // Drop the receiver immediately - producer should stop gracefully.
         drop(rx);
         let count = produce_file_jobs(&list, Path::new("/dst"), tx).await;
 

--- a/crates/transfer/src/pipeline/job.rs
+++ b/crates/transfer/src/pipeline/job.rs
@@ -4,11 +4,11 @@
 //! and [`FileJob`] (a unit of work dispatched through a bounded channel with
 //! backpressure). Together they implement the two-phase pipeline:
 //!
-//! **Phase 1 — File List**: Build, sort, and freeze the file list into an `Arc`.
+//! **Phase 1 - File List**: Build, sort, and freeze the file list into an `Arc`.
 //! The NDX (0-based index into the sorted vector) remains stable and is used as
 //! the protocol index for all subsequent wire communication.
 //!
-//! **Phase 2 — Transfer Dispatch**: A producer iterates the file list creating
+//! **Phase 2 - Transfer Dispatch**: A producer iterates the file list creating
 //! `FileJob` values, a consumer pulls them in FIFO order and executes transfers.
 //! Bounded channel capacity provides natural backpressure.
 
@@ -25,7 +25,7 @@ pub const MAX_RETRY_COUNT: u8 = 2;
 /// Immutable, sorted file list shared between producer and consumer tasks.
 ///
 /// Wraps a `Vec<FileEntry>` in `Arc` for zero-copy sharing across tokio tasks.
-/// After construction (receiving from wire + sorting), the list is frozen — no
+/// After construction (receiving from wire + sorting), the list is frozen - no
 /// entries are added, removed, or reordered. NDX indices are the `Vec` positions,
 /// which remain stable after sort.
 ///

--- a/crates/transfer/src/pipeline/receiver.rs
+++ b/crates/transfer/src/pipeline/receiver.rs
@@ -1,4 +1,4 @@
-//! `PipelinedReceiver` — mediator between network and disk threads.
+//! `PipelinedReceiver` - mediator between network and disk threads.
 //!
 //! Owns the channels and the disk commit thread, coordinating lifecycle,
 //! error collection, and graceful shutdown. Supports upstream rsync's
@@ -8,9 +8,9 @@
 //!
 //! # Upstream Reference
 //!
-//! - `receiver.c:970-976` — `send_msg_int(MSG_REDO, ndx)` on checksum failure
-//! - `generator.c:2160-2199` — `check_for_finished_files()` processes redo queue
-//! - `receiver.c:580-587` — phase transition on `NDX_DONE`
+//! - `receiver.c:970-976` - `send_msg_int(MSG_REDO, ndx)` on checksum failure
+//! - `generator.c:2160-2199` - `check_for_finished_files()` processes redo queue
+//! - `receiver.c:580-587` - phase transition on `NDX_DONE`
 
 use std::collections::VecDeque;
 use std::io;
@@ -255,11 +255,11 @@ impl PipelinedReceiver {
     /// in submission order).
     ///
     /// When `redo_enabled` is true (phase 1), checksum mismatches queue the file
-    /// index into `redo_indices` and log a warning — mirroring upstream
+    /// index into `redo_indices` and log a warning - mirroring upstream
     /// `receiver.c:960-973` which sends `MSG_REDO` and continues.
     ///
     /// When `redo_enabled` is false (phase 2), checksum mismatches are logged
-    /// as errors but do not abort the transfer — mirroring upstream
+    /// as errors but do not abort the transfer - mirroring upstream
     /// `receiver.c:948-957` where `redoing=1` uses `FERROR_XFER`.
     fn verify_checksum(&mut self, result: &CommitResult) -> io::Result<()> {
         let pending = match self.expected_checksums.pop_front() {
@@ -571,7 +571,7 @@ mod tests {
             file_index: 5,
         });
 
-        // Same checksum — should succeed without redo.
+        // Same checksum - should succeed without redo.
         let result = CommitResult {
             bytes_written: 50,
             file_entry_index: 0,

--- a/crates/transfer/src/pipeline/spsc.rs
+++ b/crates/transfer/src/pipeline/spsc.rs
@@ -1,7 +1,7 @@
 //! Lock-free SPSC (single-producer, single-consumer) channel.
 //!
 //! Built on [`crossbeam_queue::ArrayQueue`] with [`AtomicBool`] disconnection
-//! flags and [`std::hint::spin_loop`] for waiting.  Zero syscalls — pure
+//! flags and [`std::hint::spin_loop`] for waiting.  Zero syscalls - pure
 //! userspace synchronization with no futex, no `thread::park`, no condvar.
 //!
 //! Designed for the network → disk thread pipeline where exactly one producer
@@ -113,7 +113,7 @@ impl<T> Receiver<T> {
                 return Ok(item);
             }
             if !self.0.producer_alive.load(Ordering::Acquire) {
-                // Producer is gone — drain one last time.
+                // Producer is gone - drain one last time.
                 return self.0.queue.pop().ok_or(RecvError);
             }
             std::hint::spin_loop();


### PR DESCRIPTION
## Summary

- Convert em-dash characters (—) to hyphens (-) in comments across `crates/transfer/src/pipeline/` per internal docs style rule.
- No code changes; only comment text touched.
- Preserves all `///` rustdoc, `//!` module docs, upstream rsync references, and informative comments.

## Files

- `async_dispatch.rs` (2 occurrences)
- `spsc.rs` (2 occurrences)
- `job.rs` (3 occurrences)
- `receiver.rs` (7 occurrences)

Closes #1959.

## Test plan

- [ ] CI fmt+clippy passes
- [ ] CI nextest passes (no source changes)