### PR TITLE
docs(transfer): comment cleanup for reader (#1960)

### DIFF
--- a/crates/transfer/src/reader/multiplex.rs
+++ b/crates/transfer/src/reader/multiplex.rs
@@ -264,7 +264,6 @@ impl<R: Read> MultiplexReader<R> {
 
 impl<R: Read> Read for MultiplexReader<R> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        // If we have buffered data, copy it out first
         if self.pos < self.buffer.len() {
             let available = self.buffer.len() - self.pos;
             let to_copy = available.min(buf.len());

--- a/crates/transfer/src/reader/tests.rs
+++ b/crates/transfer/src/reader/tests.rs
@@ -571,8 +571,6 @@ fn multiplex_reader_redo_and_no_send_interleaved() {
     assert_eq!(mux.no_send_indices, vec![7]);
 }
 
-// Batch recorder tests
-
 #[test]
 fn multiplex_reader_batch_recorder_captures_demuxed_data() {
     // Verify that the batch recorder captures post-demux MSG_DATA payloads.
@@ -601,7 +599,6 @@ fn multiplex_reader_batch_recorder_skips_control_messages() {
     // Verify that control messages (MSG_IO_ERROR) are NOT recorded -
     // only MSG_DATA payloads go to the batch recorder.
     let mut stream = Vec::new();
-    // Send an IO_ERROR control message followed by a DATA payload
     protocol::send_msg(
         &mut stream,
         protocol::MessageCode::IoError,
@@ -719,8 +716,6 @@ fn batch_recorder_roundtrip_writer_reader_capture_same_data() {
     assert_eq!(&*write_recorded, b"roundtrip test data");
 }
 
-// Batch recorder + compression tests
-//
 // upstream: io.c:read_buf() tees data to batch_fd BEFORE decompression.
 // The batch recorder must stay on MultiplexReader (not CompressedReader)
 // so it captures compressed wire bytes. The batch header stores


### PR DESCRIPTION
## Summary
- Remove a restating-the-code comment in `MultiplexReader::read` that paraphrased the buffered-data condition.
- Drop a decorative `// Batch recorder tests` banner divider in `reader/tests.rs`.
- Drop a `// Batch recorder + compression tests` banner header (kept the upstream/WHY block immediately below it).
- Delete a comment that restated the next two `protocol::send_msg` calls in the control-message recorder test.

All `///` rustdoc, `//!` module docs, `// upstream:` references, and WHY comments are preserved. No code logic was touched.

Refs #1960.

## Test plan
- [ ] CI: fmt + clippy
- [ ] CI: nextest (stable) on Linux/macOS/Windows