### PR TITLE
docs(metadata): comment cleanup for id_lookup (#2023)

### DIFF
--- a/crates/metadata/src/id_lookup/tests.rs
+++ b/crates/metadata/src/id_lookup/tests.rs
@@ -238,9 +238,8 @@ fn clear_id_caches_empties_both_caches() {
     assert_eq!(gid_cache_size(), 0, "GID cache should be empty after clear");
 }
 
-// UID/GID 0 bypass tests - upstream invariant:
-// "The special uid 0 and the special group 0 are never mapped via user/group
-// names even if the --numeric-ids option is not specified."
+// upstream invariant: "The special uid 0 and the special group 0 are never
+// mapped via user/group names even if the --numeric-ids option is not specified."
 
 #[cfg(unix)]
 #[test]
@@ -324,8 +323,6 @@ fn non_zero_ids_still_use_name_lookup_when_numeric_ids_false() {
         "Non-zero GID should populate cache via name lookup path"
     );
 }
-
-// Non-Unix stub tests - map_uid/map_gid return the raw value unchanged.
 
 #[cfg(not(unix))]
 #[test]


### PR DESCRIPTION
## Summary
- Remove a banner comment ("Non-Unix stub tests - ...") in `id_lookup/tests.rs` that restated what the tests already document via their names.
- Tighten the section divider above the UID/GID-0 bypass tests to keep only the upstream invariant quote, dropping the "UID/GID 0 bypass tests" prefix that duplicated the test names.
- Per internal docs style rules: KEEP `///` rustdoc, `//!` module docs, `// upstream:` references, WHY comments, and SAFETY comments. SAFETY blocks in `nss.rs` (libc FFI) are preserved verbatim. No code logic touched.

## Test plan
- [ ] CI: fmt + clippy
- [ ] CI: nextest (stable) on Linux/macOS/Windows/musl