### PR TITLE
docs(core): comment cleanup for signal (#2013)

### DIFF
--- a/crates/core/src/signal/cleanup.rs
+++ b/crates/core/src/signal/cleanup.rs
@@ -211,12 +211,11 @@ impl CleanupManagerState {
     }
 
     fn cleanup(&mut self) {
-        // Run cleanup callbacks in reverse order (LIFO)
+        // Run cleanup callbacks in reverse order (LIFO).
         while let Some(callback) = self.cleanup_callbacks.pop() {
             callback();
         }
 
-        // Clean up temp files
         self.cleanup_temp_files();
     }
 
@@ -265,7 +264,6 @@ mod tests {
         let path1 = dir.path().join("test1_cleanup.tmp");
         let path2 = dir.path().join("test2_cleanup.tmp");
 
-        // Create temp files
         fs::write(&path1, b"data1").expect("write file 1");
         fs::write(&path2, b"data2").expect("write file 2");
 
@@ -278,7 +276,6 @@ mod tests {
 
         manager.cleanup_temp_files();
 
-        // Files should be removed
         assert!(!path1.exists());
         assert!(!path2.exists());
         assert_eq!(manager.temp_file_count(), 0);

--- a/crates/core/src/signal/stub.rs
+++ b/crates/core/src/signal/stub.rs
@@ -103,8 +103,6 @@ impl SignalHandler {
 ///
 /// This stub implementation never returns an error.
 pub fn install_signal_handlers() -> io::Result<SignalHandler> {
-    // On Windows, we could use SetConsoleCtrlHandler here
-    // For now, just return a stub handler
     Ok(SignalHandler { _installed: true })
 }
 

--- a/crates/core/src/signal/unix.rs
+++ b/crates/core/src/signal/unix.rs
@@ -127,14 +127,11 @@ static SIGNAL_COUNT: AtomicBool = AtomicBool::new(false);
 /// First signal: Sets graceful shutdown flag.
 /// Second signal: Sets abort flag for immediate termination.
 extern "C" fn handle_sigint(_signum: libc::c_int) {
-    // Check if this is the first or second signal
     let already_signaled = SIGNAL_COUNT.swap(true, Ordering::SeqCst);
 
     if already_signaled {
-        // Second signal - abort immediately
         super::request_abort();
     } else {
-        // First signal - graceful shutdown
         super::request_shutdown(ShutdownReason::Interrupted);
     }
 }
@@ -267,8 +264,6 @@ pub fn wait_for_signal() -> ShutdownReason {
             return reason;
         }
 
-        // Sleep briefly to avoid busy-waiting
-        // In a real implementation, this would use sigwait() or similar
         std::thread::sleep(std::time::Duration::from_millis(100));
     }
 }
@@ -356,7 +351,6 @@ mod tests {
 
     #[test]
     fn install_signal_handlers_succeeds() {
-        // This test actually installs signal handlers
         let result = install_signal_handlers();
         assert!(result.is_ok());
 
@@ -366,16 +360,13 @@ mod tests {
 
     #[test]
     fn signal_count_tracks_multiple_signals() {
-        // Reset state
         SIGNAL_COUNT.store(false, Ordering::SeqCst);
         super::super::reset_for_testing();
 
-        // Simulate first SIGINT
         handle_sigint(libc::SIGINT);
         assert!(super::super::is_shutdown_requested());
         assert!(!super::super::is_abort_requested());
 
-        // Simulate second SIGINT
         handle_sigint(libc::SIGINT);
         assert!(super::super::is_abort_requested());
     }


### PR DESCRIPTION
## Summary
- Remove restating-the-code comments from `crates/core/src/signal/{unix,stub,cleanup}.rs`.
- Drop aspirational placeholders ("In a real implementation, this would use sigwait()...", "On Windows, we could use SetConsoleCtrlHandler...").
- Keep all `///` rustdoc, `//!` module docs, WHY comments (LIFO ordering, SA_RESTART rationale, intentional non-restore in `Drop`, best-effort cleanup), and the `#[allow(dead_code)] // REASON: ...` annotation.
- No code logic changed.

Closes #2013.

## Test plan
- [ ] CI: fmt + clippy
- [ ] CI: nextest (stable, Linux musl, macOS, Windows)