### PR TITLE
docs(transfer): comment cleanup for transfer_ops (#1964)

### DIFF
--- a/crates/transfer/src/transfer_ops/mod.rs
+++ b/crates/transfer/src/transfer_ops/mod.rs
@@ -186,7 +186,6 @@ fn read_response_header<R: Read>(
 ) -> io::Result<ResponseHeader> {
     let expected_ndx = pending.ndx();
 
-    // Read sender attributes (echoed NDX + iflags + optional xattr data)
     let (echoed_ndx, sender_attrs) = SenderAttrs::read_with_codec_xattr(
         reader,
         ndx_codec,
@@ -194,7 +193,7 @@ fn read_response_header<R: Read>(
         ctx.config.want_xattr_optim,
     )?;
 
-    // Verify NDX matches - protocol requires in-order responses
+    // Protocol requires in-order responses.
     if echoed_ndx != expected_ndx {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
@@ -204,10 +203,9 @@ fn read_response_header<R: Read>(
         ));
     }
 
-    // Read echoed sum_head - needed for append mode offset calculation.
+    // Echoed sum_head provides the existing file length for append mode offset.
     let echoed_sum_head = SumHead::read(reader)?;
 
-    // Decompose pending transfer
     let (file_path, basis_path, signature, target_size) = pending.into_parts();
 
     // upstream: receiver.c:797 - one_inplace = inplace_partial && fnamecmp_type == FNAMECMP_PARTIAL_DIR
@@ -270,7 +268,6 @@ mod tests {
 
     #[test]
     fn request_config_debug() {
-        // Verify RequestConfig is debuggable
         let protocol = ProtocolVersion::from_supported(31).expect("31 is supported");
         let config = RequestConfig {
             protocol,

--- a/crates/transfer/src/transfer_ops/request.rs
+++ b/crates/transfer/src/transfer_ops/request.rs
@@ -97,11 +97,10 @@ pub fn send_file_request_xattr<W: Write + ?Sized>(
     config: &RequestConfig<'_>,
     xattr_list: Option<&XattrList>,
 ) -> io::Result<PendingTransfer> {
-    // Send file index using NDX encoding
     ndx_codec.write_ndx(writer, ndx)?;
 
-    // For protocol >= 29, sender expects iflags after NDX
-    // ITEM_TRANSFER (0x8000) tells sender to read sum_head and send delta
+    // For protocol >= 29, sender expects iflags after NDX.
+    // ITEM_TRANSFER (0x8000) tells sender to read sum_head and send delta.
     // upstream: generator.c - ITEM_REPORT_XATTR set when xattr_diff() detects changes
     if config.write_iflags {
         let has_xattr_request = xattr_list.is_some_and(|list| {
@@ -122,14 +121,12 @@ pub fn send_file_request_xattr<W: Write + ?Sized>(
         }
     }
 
-    // Send sum_head (signature header)
     let sum_head = match signature {
         Some(ref sig) => SumHead::from_signature(sig),
         None => SumHead::empty(),
     };
     sum_head.write(writer)?;
 
-    // Write signature blocks if we have a signature.
     // upstream: generator.c:775-776 - in append mode, generator skips writing
     // signature blocks after sum_head. The sender's receive_sums() (sender.c:87-92)
     // returns early without reading blocks, using sum_head to calculate existing length.
@@ -142,7 +139,6 @@ pub fn send_file_request_xattr<W: Write + ?Sized>(
     // reads. Per-file flushes defeat buffer batching, causing 1 sendto per
     // ~20-byte request instead of upstream's batched iobuf_out pattern.
 
-    // Create pending transfer for response processing
     let pending = match (signature, basis_path) {
         (Some(sig), Some(basis)) => {
             PendingTransfer::new_delta_transfer(ndx, file_path, basis, sig, target_size)

--- a/crates/transfer/src/transfer_ops/response.rs
+++ b/crates/transfer/src/transfer_ops/response.rs
@@ -108,14 +108,12 @@ pub fn process_file_response<R: Read>(
     let mut output = fast_io::writer_from_file(file, writer_capacity, ctx.config.io_uring_policy)?;
     let mut total_bytes: u64 = 0;
 
-    // Sparse file support
     let mut sparse_state = if ctx.config.use_sparse {
         Some(SparseWriteState::default())
     } else {
         None
     };
 
-    // Open basis file if delta transfer
     let mut basis_map = if let Some(ref path) = basis_path {
         Some(MapFile::open(path).map_err(|e| {
             io::Error::new(e.kind(), format!("failed to open basis file {path:?}: {e}"))
@@ -132,8 +130,7 @@ pub fn process_file_response<R: Read>(
     loop {
         match token_reader.read_token(reader)? {
             DeltaToken::End => {
-                // End of file - verify checksum using stack buffers.
-                // Use mem::replace to consume the verifier for finalization while
+                // mem::replace consumes the verifier for finalization while
                 // resetting it for the next file (avoids per-file construction).
                 let checksum_len = checksum_verifier.digest_len();
                 let mut expected = [0u8; ChecksumVerifier::MAX_DIGEST_LEN];
@@ -168,7 +165,6 @@ pub fn process_file_response<R: Read>(
                 break;
             }
             DeltaToken::Literal(literal) => {
-                // Write literal data to output and update checksum.
                 // LiteralData::Ready = decompressed data from compressed stream.
                 // LiteralData::Pending = plain mode, caller reads data from stream.
                 match literal {
@@ -183,7 +179,6 @@ pub fn process_file_response<R: Read>(
                         total_bytes += len as u64;
                     }
                     LiteralData::Pending(len) => {
-                        // Plain token: read data from stream.
                         if let Some(data) = reader.try_borrow_exact(len)? {
                             if let Some(ref mut sparse) = sparse_state {
                                 sparse.write(&mut output, data)?;
@@ -258,12 +253,11 @@ pub fn process_file_response<R: Read>(
         }
     }
 
-    // Finalize sparse writing if active
     if let Some(ref mut sparse) = sparse_state {
         let _final_pos = sparse.finish(&mut output)?;
     }
 
-    // Flush and optionally sync (uses io_uring fsync op when available)
+    // Uses io_uring fsync op when available.
     if ctx.config.do_fsync {
         output.sync().map_err(|e| {
             io::Error::new(e.kind(), format!("fsync failed for {file_path:?}: {e}"))

--- a/crates/transfer/src/transfer_ops/streaming.rs
+++ b/crates/transfer/src/transfer_ops/streaming.rs
@@ -119,7 +119,6 @@ pub fn process_file_response_streaming<R: Read>(
         xattr_list,
     });
 
-    // Open basis file for block references
     let mut basis_map = if let Some(ref path) = header.basis_path {
         Some(MapFile::open(path).map_err(|e| {
             io::Error::new(e.kind(), format!("failed to open basis file {path:?}: {e}"))
@@ -146,11 +145,9 @@ pub fn process_file_response_streaming<R: Read>(
             let buf = literal_to_buf(literal_data, reader, buf_return_rx)?;
             let len = buf.len();
 
-            // Peek at the next token.
             let next_delta = token_reader.read_token(reader)?;
 
             if matches!(next_delta, DeltaToken::End) {
-                // Single-chunk file - coalesce into WholeFile.
                 total_bytes = len as u64;
                 let checksum_len = checksum_verifier.digest_len();
                 let mut expected_checksum = [0u8; ChecksumVerifier::MAX_DIGEST_LEN];


### PR DESCRIPTION
## Summary
- Remove restating-the-code comments from `transfer_ops/{mod,request,response,streaming}.rs`.
- Tighten phrasing on a few WHY comments without changing meaning.
- Preserve all rustdoc (`///`, `//!`), upstream references (`// upstream: ...`), and explanatory WHY/SAFETY comments.
- No code logic changes.

Refs #1964.

## Test plan
- [ ] CI fmt+clippy passes.
- [ ] CI nextest (stable) passes.
- [ ] Cross-platform builds (Windows, macOS, Linux musl) pass.