### PR TITLE
docs(transfer): comment cleanup for receiver (#1961)

### DIFF
--- a/crates/transfer/src/receiver/transfer/phases.rs
+++ b/crates/transfer/src/receiver/transfer/phases.rs
@@ -118,7 +118,7 @@ impl ReceiverContext {
         writer.flush()?;
 
         if self.protocol.supports_extended_goodbye() {
-            // upstream: main.c:875-906 read_final_goodbye() — the sender may
+            // upstream: main.c:875-906 read_final_goodbye() - the sender may
             // send NDX_DEL_STATS before the NDX_DONE echo. Loop to skip it.
             loop {
                 let ndx = ndx_read_codec.read_ndx(reader)?;


### PR DESCRIPTION
## Summary

Cleanup of comments in `crates/transfer/src/receiver/` module per audit task #1961.

The module is in excellent shape - one issue found:
- Em-dash converted to hyphen in `transfer/phases.rs` line 121, matching project style rules from internal docs.

All other comments (`///` rustdoc, `//!` module docs, `// upstream:` references, WHY comments) are appropriate and preserved as-is.

## Test plan

- [x] No code logic changes (comments only)
- [x] No remaining em-dashes or en-dashes in receiver module
- [x] No TODO/FIXME/XXX in receiver module (excluding upstream rsync constant `XSTATE_TODO`)
- [x] No commented-out code or decorative banners
- [ ] CI passes (fmt+clippy, nextest, Windows, macOS, Linux musl)