### PR TITLE
docs(engine): comment cleanup for concurrent_delta (#1942)

### DIFF
--- a/crates/engine/src/concurrent_delta/consumer.rs
+++ b/crates/engine/src/concurrent_delta/consumer.rs
@@ -373,8 +373,6 @@ mod tests {
         producer.join().unwrap();
 
         assert_eq!(results.len(), 10);
-        // join() requires ownership, so we reconstruct via into_iter on a new consumer.
-        // For this test, just verify iter() completion works correctly.
     }
 
     #[test]
@@ -383,7 +381,6 @@ mod tests {
         let producer = std::thread::spawn(move || send_items(&tx, 5));
 
         let consumer = DeltaConsumer::spawn(rx, 16);
-        // Consume via join after explicit iter.
         for r in consumer.iter() {
             assert!(r.is_success());
         }
@@ -504,10 +501,8 @@ mod tests {
         });
 
         let consumer = DeltaConsumer::spawn(rx, 16);
-        // Drop immediately without consuming any results.
         drop(consumer);
         producer.join().unwrap();
-        // Test passes if it completes without hanging.
     }
 
     #[test]
@@ -542,14 +537,12 @@ mod tests {
         let (tx, rx) = work_queue::bounded_with_capacity(8);
         let consumer = DeltaConsumer::spawn(rx, 16);
 
-        // No items sent yet - try_recv should return None.
         assert!(consumer.try_recv().is_none());
 
         // Send items so the consumer thread can finish.
         send_items(&tx, 3);
         drop(tx);
 
-        // Eventually all results arrive via blocking iter.
         let results: Vec<DeltaResult> = consumer.iter().collect();
         assert_eq!(results.len(), 3);
     }
@@ -558,13 +551,11 @@ mod tests {
     fn try_recv_returns_results_when_available() {
         let (tx, rx) = work_queue::bounded_with_capacity(8);
 
-        // Send all items and close the channel before spawning the consumer.
         send_items(&tx, 5);
         drop(tx);
 
         let consumer = DeltaConsumer::spawn(rx, 16);
 
-        // Collect all results using try_recv with a polling loop.
         let mut results = Vec::new();
         let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
         loop {
@@ -592,14 +583,13 @@ mod tests {
     #[test]
     fn try_recv_on_empty_queue_returns_none() {
         let (tx, rx) = work_queue::bounded_with_capacity(4);
-        drop(tx); // Close immediately.
+        drop(tx);
 
         let consumer = DeltaConsumer::spawn(rx, 8);
 
         // Give the consumer thread a moment to finish.
         std::thread::sleep(std::time::Duration::from_millis(50));
 
-        // No items were sent, so try_recv should always return None.
         assert!(consumer.try_recv().is_none());
         consumer.join().unwrap();
     }

--- a/crates/engine/src/concurrent_delta/reorder.rs
+++ b/crates/engine/src/concurrent_delta/reorder.rs
@@ -462,7 +462,6 @@ mod tests {
     #[test]
     fn out_of_order_reordering() {
         let mut buf = ReorderBuffer::new(8);
-        // Arrive: 2, 0, 1
         buf.insert(2, "c").unwrap();
         assert_eq!(buf.next_in_order(), None); // waiting for 0
 
@@ -523,7 +522,6 @@ mod tests {
         // Seq 2 has offset 2 from next_expected=0, which equals capacity
         assert_eq!(buf.insert(2, 30), Err(CapacityExceeded));
 
-        // Drain the ready items
         assert_eq!(buf.next_in_order(), Some(10));
         // Now there is room (next_expected=1, seq 2 has offset 1)
         buf.insert(2, 30).unwrap();
@@ -684,7 +682,6 @@ mod tests {
     #[test]
     fn reverse_order_insertion() {
         let mut buf = ReorderBuffer::new(8);
-        // Insert in reverse: 4, 3, 2, 1, 0
         for i in (0..5).rev() {
             buf.insert(i, i).unwrap();
         }
@@ -772,12 +769,10 @@ mod tests {
             collected.extend(buf.drain_ready());
         }
 
-        // Wait for all producers.
         for p in producers {
             p.join().expect("producer panicked");
         }
 
-        // Final drain of any remaining buffered items.
         collected.extend(buf.drain_ready());
 
         assert_eq!(
@@ -1012,13 +1007,11 @@ mod tests {
             perm.swap(i, j);
         }
 
-        // Insert in shuffled order, draining opportunistically.
         let mut collected: Vec<u64> = Vec::with_capacity(N);
         for &seq in &perm {
             buf.insert(seq, seq).unwrap();
             collected.extend(buf.drain_ready());
         }
-        // Final drain for any remaining items.
         collected.extend(buf.drain_ready());
 
         assert_eq!(collected.len(), N);

--- a/crates/engine/src/concurrent_delta/work_queue/tests.rs
+++ b/crates/engine/src/concurrent_delta/work_queue/tests.rs
@@ -96,7 +96,6 @@ fn backpressure_blocks_producer() {
         "producer sent {sent_before_drain} items with capacity 2 - backpressure not working"
     );
 
-    // Now drain everything.
     let items: Vec<u32> = rx.into_iter().map(|w| w.ndx().get()).collect();
     producer.join().unwrap();
     assert_eq!(items, vec![0, 1, 2, 3, 4]);
@@ -131,7 +130,6 @@ fn bounded_respects_in_flight_limit() {
             let collected = &collected;
             s.spawn(move |_| {
                 let current = active_ref.fetch_add(1, Ordering::SeqCst) + 1;
-                // Update max observed concurrency.
                 max_active_ref.fetch_max(current, Ordering::SeqCst);
                 // Simulate work to increase chance of overlapping.
                 thread::sleep(Duration::from_micros(100));
@@ -313,13 +311,11 @@ fn pipeline_with_reorder_buffer() {
     let results: Vec<_> = collected.into_inner().unwrap();
     producer.join().unwrap();
 
-    // Feed out-of-order results into the reorder buffer.
     let mut reorder = ReorderBuffer::new(total as usize);
     for r in results {
         reorder.insert(r.sequence(), r).unwrap();
     }
 
-    // Drain in order and verify sequence.
     let ordered: Vec<u64> = reorder.drain_ready().map(|r| r.sequence()).collect();
     let expected: Vec<u64> = (0..u64::from(total)).collect();
     assert_eq!(ordered, expected);
@@ -408,11 +404,9 @@ fn drain_parallel_into_receiver_drop_stops_workers() {
         rx.drain_parallel_into(|w| w.ndx().get(), result_tx);
     });
 
-    // Take a few results then drop the receiver.
     let _ = result_rx.recv();
     drop(result_rx);
 
-    // Drain thread should complete without hanging.
     let deadline = Instant::now() + Duration::from_secs(5);
     producer.join().unwrap();
     drain_handle.join().unwrap();
@@ -554,7 +548,6 @@ fn drain_parallel_with_reorder_buffer() {
     });
     producer.join().unwrap();
 
-    // Feed into reorder buffer and verify sequential output.
     let mut reorder = ReorderBuffer::new(total as usize);
     for r in results {
         reorder.insert(r.sequence(), r).unwrap();


### PR DESCRIPTION
## Summary

Apply the project's comment-cleanup rules to the
`crates/engine/src/concurrent_delta/` module per issue #1942.

### Rules applied

- **Delete:** restatement comments that echo the code (mostly in test
  bodies where the assertion already says the same thing).
- **Keep:** every `///` rustdoc, `//!` module doc, `// upstream:`
  reference, WHY/intent comments (e.g. backpressure rationale, deadlock
  break-glass note, `(propagates panics)` side-effect note), and test
  scenario explanations that walk through multi-step setups.

No em-dashes were present. No TODO/FIXME/XXX, banners, or commented-out
code were present. Logic untouched.

### Net delta

| File | Added | Removed | Net |
|------|------:|--------:|----:|
| `crates/engine/src/concurrent_delta/consumer.rs` | 1 | 11 | -10 |
| `crates/engine/src/concurrent_delta/reorder.rs` | 0 | 7 | -7 |
| `crates/engine/src/concurrent_delta/work_queue/tests.rs` | 0 | 7 | -7 |
| **Total** | **1** | **25** | **-24** |

## Test plan

- [ ] CI: fmt + clippy
- [ ] CI: nextest (stable) for `engine`
- [ ] CI: Windows / macOS / Linux musl matrix