### PR TITLE
docs(core): comment cleanup for exit_code (#2011)

### DIFF
--- a/crates/core/src/exit_code/convert.rs
+++ b/crates/core/src/exit_code/convert.rs
@@ -16,7 +16,6 @@ impl From<ExitCode> for i32 {
 
 impl From<ExitCode> for std::process::ExitCode {
     fn from(code: ExitCode) -> Self {
-        // Clamp to u8 range for std::process::ExitCode
         let value = code.as_i32().clamp(0, 255) as u8;
         Self::from(value)
     }


### PR DESCRIPTION
## Summary
- Comment cleanup for `crates/core/src/exit_code/` per task #2011 style rules.
- Removed a single restating-the-code comment in `convert.rs` that merely echoed `clamp(0, 255) as u8`.
- All `///` rustdoc, `//!` module docs, and upstream `errcode.h` references preserved.

## Test plan
- [ ] CI fmt+clippy passes
- [ ] CI nextest (stable) passes
- [ ] CI Windows / macOS / Linux musl pass