### PR TITLE
docs(cli): comment cleanup for frontend::progress (#1979)

### DIFF
--- a/crates/cli/src/frontend/progress/diagnostic.rs
+++ b/crates/cli/src/frontend/progress/diagnostic.rs
@@ -46,7 +46,6 @@ pub fn render_diagnostic_events<O: Write, E: Write>(
                 level: _,
                 message,
             } => {
-                // Debug always goes to stderr with flag prefix
                 writeln!(err, "[{flag:?}] {message}")?;
             }
         }
@@ -186,14 +185,12 @@ mod tests {
 
     #[test]
     fn test_flush_diagnostics_drains_events() {
-        // Emit some events to the thread-local queue
         logging::emit_info(InfoFlag::Progress, 1, "test info".to_owned());
         logging::emit_debug(DebugFlag::Filter, 1, "test debug".to_owned());
 
         let mut stdout = Vec::new();
         let mut stderr = Vec::new();
 
-        // Flush should drain and render them
         flush_diagnostics(&mut stdout, &mut stderr, false).unwrap();
 
         let stdout_output = String::from_utf8(stdout).unwrap();
@@ -202,7 +199,6 @@ mod tests {
         let stderr_output = String::from_utf8(stderr).unwrap();
         assert!(stderr_output.contains("[Filter] test debug"));
 
-        // Second flush should be empty
         let mut stdout2 = Vec::new();
         let mut stderr2 = Vec::new();
         flush_diagnostics(&mut stdout2, &mut stderr2, false).unwrap();

--- a/crates/cli/src/frontend/progress/format/list.rs
+++ b/crates/cli/src/frontend/progress/format/list.rs
@@ -137,32 +137,26 @@ mod tests {
         let time = SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_000);
         let result = format_list_timestamp(Some(time));
 
-        // Year: chars 0-3
         assert!(
             result[0..4].chars().all(|c| c.is_ascii_digit()),
             "year should be digits"
         );
-        // Month: chars 5-6
         assert!(
             result[5..7].chars().all(|c| c.is_ascii_digit()),
             "month should be digits"
         );
-        // Day: chars 8-9
         assert!(
             result[8..10].chars().all(|c| c.is_ascii_digit()),
             "day should be digits"
         );
-        // Hours: chars 11-12
         assert!(
             result[11..13].chars().all(|c| c.is_ascii_digit()),
             "hours should be digits"
         );
-        // Minutes: chars 14-15
         assert!(
             result[14..16].chars().all(|c| c.is_ascii_digit()),
             "minutes should be digits"
         );
-        // Seconds: chars 17-18
         assert!(
             result[17..19].chars().all(|c| c.is_ascii_digit()),
             "seconds should be digits"

--- a/crates/cli/src/frontend/progress/format/size.rs
+++ b/crates/cli/src/frontend/progress/format/size.rs
@@ -185,11 +185,9 @@ mod tests {
         let small = format_list_size(1, HumanReadableMode::Disabled);
         let large = format_list_size(1_000_000, HumanReadableMode::Disabled);
 
-        // Both should be 15 chars
         assert_eq!(small.len(), 15);
         assert_eq!(large.len(), 15);
 
-        // Small value should have more leading spaces
         let small_spaces = small.len() - small.trim_start().len();
         let large_spaces = large.len() - large.trim_start().len();
         assert!(


### PR DESCRIPTION
## Summary
- Remove restate-the-code comments in `progress/diagnostic.rs`, `progress/format/list.rs`, and `progress/format/size.rs`.
- No logic changes; only noise comments that the adjacent code or assertion messages already conveyed.
- Closes #1979.

## Test plan
- [ ] CI: fmt + clippy
- [ ] CI: nextest (stable)
- [ ] CI: Windows / macOS / Linux musl