### PR TITLE
docs(filters): comment cleanup for merge (#2031)

### DIFF
--- a/crates/filters/src/merge/parse.rs
+++ b/crates/filters/src/merge/parse.rs
@@ -236,7 +236,7 @@ impl ShortFormAction {
 ///
 /// Returns `Some(rule)` if the line matches a short-form pattern, `None` otherwise.
 ///
-/// // upstream: exclude.c:parse_filter_str() - short-form prefix handling
+/// upstream: exclude.c:parse_filter_str() - short-form prefix handling
 fn try_parse_short_form(line: &str) -> Option<FilterRule> {
     let (rest, action) = if let Some(r) = line.strip_prefix('+') {
         (r, ShortFormAction::Include)
@@ -275,7 +275,7 @@ fn try_parse_short_form(line: &str) -> Option<FilterRule> {
 ///
 /// Returns `Some(rule)` if the line matches a long-form pattern, `None` otherwise.
 ///
-/// // upstream: exclude.c:parse_filter_str() - long-form keyword handling
+/// upstream: exclude.c:parse_filter_str() - long-form keyword handling
 fn try_parse_long_form(line: &str) -> Option<FilterRule> {
     let lower = line.to_ascii_lowercase();
 

--- a/crates/filters/src/merge/read.rs
+++ b/crates/filters/src/merge/read.rs
@@ -3,7 +3,7 @@
 //! Provides [`read_rules`] for single-file reads and [`read_rules_recursive`]
 //! for automatic expansion of nested `. FILE` (merge) directives.
 //!
-//! // upstream: exclude.c:parse_filter_file() - merge file reading
+//! upstream: exclude.c:parse_filter_file() - merge file reading
 
 use std::fs;
 use std::path::Path;


### PR DESCRIPTION
## Summary

Cleans up doc comments in `crates/filters/src/merge/` comment-cleanup rules: removes redundant `//` markers nested inside `///` and `//!` rustdoc blocks while preserving upstream rsync source references. Addresses #2031.

## Test plan

- [ ] CI fmt+clippy
- [ ] CI nextest