### PR TITLE
docs(cli): comment cleanup for frontend::arguments (#1972)

### DIFF
--- a/crates/cli/src/frontend/arguments/parsed_args/mod.rs
+++ b/crates/cli/src/frontend/arguments/parsed_args/mod.rs
@@ -26,7 +26,6 @@ use crate::frontend::progress::{NameOutputLevel, ProgressSetting};
 #[allow(private_interfaces)] // ProgramName, BandwidthArgument are pub(crate) but exposed for tests
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ParsedArgs {
-    // ── General ──────────────────────────────────────────────────────
     /// Program name detected from `argv[0]`.
     pub program_name: ProgramName,
 
@@ -48,7 +47,6 @@ pub struct ParsedArgs {
     /// Remaining non-option arguments (sources and destination).
     pub remainder: Vec<OsString>,
 
-    // ── Connection / Transport ───────────────────────────────────────
     /// `--rsh`, `-e` - remote shell command.
     pub remote_shell: Option<OsString>,
 
@@ -97,7 +95,6 @@ pub struct ParsedArgs {
     /// `--stop-at` - stop transfer at the specified wall-clock time.
     pub stop_at: Option<OsString>,
 
-    // ── Server / Daemon ──────────────────────────────────────────────
     /// `--server` - run in server mode (internal, set by remote invocation).
     pub server_mode: bool,
 
@@ -122,7 +119,6 @@ pub struct ParsedArgs {
     /// `--password-file` - file containing daemon authentication password.
     pub password_file: Option<OsString>,
 
-    // ── Recursion / Traversal ────────────────────────────────────────
     /// `--archive`, `-a` - shorthand for `-rlptgoD`.
     pub archive: bool,
 
@@ -155,7 +151,6 @@ pub struct ParsedArgs {
     /// `--prune-empty-dirs`, `-m` / `--no-prune-empty-dirs`.
     pub prune_empty_dirs: Option<bool>,
 
-    // ── Transfer Behavior ────────────────────────────────────────────
     /// `--checksum`, `-c` / `--no-checksum` - skip based on checksum, not mtime+size.
     pub checksum: Option<bool>,
 
@@ -209,7 +204,6 @@ pub struct ParsedArgs {
     /// `--trust-sender` - trust the sending side's file list.
     pub trust_sender: bool,
 
-    // ── Delete ───────────────────────────────────────────────────────
     /// `--delete`, `--delete-before`, `--delete-during`, `--delete-delay`,
     /// `--delete-after` - scheduling mode for extraneous file deletion.
     pub delete_mode: DeleteMode,
@@ -229,7 +223,6 @@ pub struct ParsedArgs {
     /// `--force` / `--no-force` - force deletion of non-empty directories.
     pub force: Option<bool>,
 
-    // ── Metadata / Permissions ───────────────────────────────────────
     /// `--owner`, `-o` / `--no-owner` - preserve file owner.
     pub owner: Option<bool>,
 
@@ -287,7 +280,6 @@ pub struct ParsedArgs {
     /// `--numeric-ids` / `--no-numeric-ids` - use numeric uid/gid instead of names.
     pub numeric_ids: Option<bool>,
 
-    // ── Symlinks / Links ─────────────────────────────────────────────
     /// `--hard-links`, `-H` / `--no-hard-links` - preserve hard links.
     pub hard_links: Option<bool>,
 
@@ -312,7 +304,6 @@ pub struct ParsedArgs {
     /// `--munge-links` / `--no-munge-links` - munge symlinks for safety.
     pub munge_links: Option<bool>,
 
-    // ── Devices / Specials ───────────────────────────────────────────
     /// `--devices` / `--no-devices` - preserve device files.
     pub devices: Option<bool>,
 
@@ -325,7 +316,6 @@ pub struct ParsedArgs {
     /// `--write-devices` / `--no-write-devices` - allow writing to device files.
     pub write_devices: Option<bool>,
 
-    // ── Compression ──────────────────────────────────────────────────
     /// `--compress`, `-z` - enable transfer compression.
     pub compress: bool,
 
@@ -347,7 +337,6 @@ pub struct ParsedArgs {
     /// `--skip-compress` - file suffixes to skip compression for.
     pub skip_compress: Option<OsString>,
 
-    // ── Backup ───────────────────────────────────────────────────────
     /// `--backup`, `-b` - make backups before overwriting.
     pub backup: bool,
 
@@ -357,7 +346,6 @@ pub struct ParsedArgs {
     /// `--suffix` - suffix for backup file names (default `~`).
     pub backup_suffix: Option<OsString>,
 
-    // ── Filters / Patterns ───────────────────────────────────────────
     /// `--exclude` - patterns for excluding files.
     pub excludes: Vec<OsString>,
 
@@ -388,7 +376,6 @@ pub struct ParsedArgs {
     /// `--from0`, `-0` - use NUL as line separator in files-from.
     pub from0: bool,
 
-    // ── Destination References ────────────────────────────────────────
     /// `--compare-dest` - directories to compare against when deciding transfers.
     pub compare_destinations: Vec<OsString>,
 
@@ -401,7 +388,6 @@ pub struct ParsedArgs {
     /// Resolved `--link-dest` paths for internal processing.
     pub link_dests: Vec<PathBuf>,
 
-    // ── I/O / Performance ────────────────────────────────────────────
     /// `--bwlimit` - bandwidth limit (supports K, M, G suffixes).
     pub bwlimit: Option<BandwidthArgument>,
 
@@ -459,7 +445,6 @@ pub struct ParsedArgs {
     /// `--qsort` - use qsort instead of merge-sort for file list sorting.
     pub qsort: bool,
 
-    // ── Output / Formatting ──────────────────────────────────────────
     /// `--verbose`, `-v` / `--quiet`, `-q` - output verbosity level.
     pub verbosity: u8,
 
@@ -505,7 +490,6 @@ pub struct ParsedArgs {
     /// `--log-file-format` - format string for log file entries.
     pub log_file_format: Option<OsString>,
 
-    // ── Batch ────────────────────────────────────────────────────────
     /// `--write-batch` - write a batch file for later replay.
     pub write_batch: Option<OsString>,
 
@@ -518,12 +502,10 @@ pub struct ParsedArgs {
     /// `--early-input` - input file for early protocol stages.
     pub early_input: Option<OsString>,
 
-    // ── SSH ──────────────────────────────────────────────────────────
     /// `--aes` - force AES-GCM cipher selection for SSH connections.
     /// `None` = use runtime hardware detection.
     pub prefer_aes_gcm: Option<bool>,
 
-    // ── Embedded SSH ────────────────────────────────────────────────
     /// `--ssh-cipher` - comma-separated cipher preference list for embedded SSH.
     pub ssh_cipher: Vec<String>,
 

--- a/crates/cli/src/frontend/arguments/parser/tests.rs
+++ b/crates/cli/src/frontend/arguments/parser/tests.rs
@@ -403,8 +403,6 @@ fn human_readable_two_separate_short_flags_is_combined() {
     assert_eq!(parsed.human_readable, Some(HumanReadableMode::Combined));
 }
 
-// ── Embedded SSH arguments ──────────────────────────────────────────
-
 #[test]
 fn ssh_cipher_parses_comma_separated_list() {
     let parsed = parse_test_args([

--- a/crates/cli/src/frontend/arguments/program_name.rs
+++ b/crates/cli/src/frontend/arguments/program_name.rs
@@ -45,7 +45,6 @@ mod tests {
     #[test]
     fn oc_rsync_as_str_returns_oc_rsync() {
         let result = ProgramName::OcRsync.as_str();
-        // Should be the oc branded name
         assert!(!result.is_empty());
     }
 
@@ -61,7 +60,6 @@ mod tests {
 
     #[test]
     fn detect_with_none_returns_program_name() {
-        // With None, it should return a valid program name
         let result = detect_program_name(None);
         assert!(result == ProgramName::Rsync || result == ProgramName::OcRsync);
     }

--- a/crates/cli/src/frontend/arguments/short_options.rs
+++ b/crates/cli/src/frontend/arguments/short_options.rs
@@ -136,7 +136,6 @@ mod tests {
     fn expand_cluster_single_char_not_expanded() {
         let flags = make_flags("a");
         let values = HashSet::new();
-        // Single char options are not expanded (cluster.len() <= 1)
         assert_eq!(expand_cluster("-a", &flags, &values), None);
     }
 
@@ -144,7 +143,6 @@ mod tests {
     fn expand_cluster_not_option() {
         let flags = make_flags("avz");
         let values = HashSet::new();
-        // Doesn't start with -
         assert_eq!(expand_cluster("avz", &flags, &values), None);
     }
 
@@ -152,7 +150,6 @@ mod tests {
     fn expand_cluster_long_option() {
         let flags = make_flags("avz");
         let values = HashSet::new();
-        // Long options (--) are not expanded
         assert_eq!(expand_cluster("--verbose", &flags, &values), None);
     }
 
@@ -160,7 +157,6 @@ mod tests {
     fn expand_cluster_value_option_at_end() {
         let flags = make_flags("av");
         let values = make_flags("M");
-        // Value option at end is valid
         let result = expand_cluster("-avM", &flags, &values);
         assert_eq!(
             result,
@@ -172,7 +168,6 @@ mod tests {
     fn expand_cluster_value_option_not_at_end() {
         let flags = make_flags("av");
         let values = make_flags("M");
-        // Value option not at end is invalid
         assert_eq!(expand_cluster("-aMv", &flags, &values), None);
     }
 
@@ -180,7 +175,6 @@ mod tests {
     fn expand_cluster_unknown_option() {
         let flags = make_flags("av");
         let values = HashSet::new();
-        // Unknown option 'x' in cluster
         assert_eq!(expand_cluster("-avx", &flags, &values), None);
     }
 
@@ -196,9 +190,7 @@ mod tests {
     fn expand_cluster_all_value_options() {
         let _flags: HashSet<char> = HashSet::new();
         let values = make_flags("e");
-        // Single value option at end is valid (even if it's the only one)
         let result = expand_cluster("-ee", &_flags, &values);
-        // First 'e' is a value option but not at end - returns None
         assert_eq!(result, None);
     }
 
@@ -206,7 +198,6 @@ mod tests {
     fn expand_cluster_empty_after_dash() {
         let flags = make_flags("avz");
         let values = HashSet::new();
-        // Just "-" with nothing after is not expanded (cluster.len() <= 1)
         assert_eq!(expand_cluster("-", &flags, &values), None);
     }
 
@@ -214,7 +205,6 @@ mod tests {
     fn expand_cluster_mixed_known_unknown() {
         let flags = make_flags("av");
         let values = HashSet::new();
-        // 'z' is not known
         assert_eq!(expand_cluster("-avz", &flags, &values), None);
     }
 
@@ -222,8 +212,6 @@ mod tests {
     fn expand_cluster_only_value_option() {
         let flags = HashSet::new();
         let values = make_flags("M");
-        // Single value option requires length > 1 to trigger expansion
-        // -M has length 1 in cluster, so None
         assert_eq!(expand_cluster("-M", &flags, &values), None);
     }
 
@@ -231,7 +219,6 @@ mod tests {
     fn expand_cluster_multiple_value_options() {
         let flags = HashSet::new();
         let values = make_flags("Me");
-        // Two value options - second must be at end
         assert_eq!(expand_cluster("-Me", &flags, &values), None);
     }
 

--- a/crates/cli/src/frontend/arguments/stop.rs
+++ b/crates/cli/src/frontend/arguments/stop.rs
@@ -31,13 +31,11 @@ impl StopRequest {
         }
     }
 
-    /// Returns the kind of stop request
     #[allow(dead_code)] // REASON: accessor used in unit tests
     pub(crate) const fn kind(&self) -> StopRequestKind {
         self.kind
     }
 
-    /// Returns the original CLI value
     #[allow(dead_code)] // REASON: accessor used in unit tests
     pub(crate) const fn cli_value(&self) -> &OsString {
         &self.value

--- a/crates/cli/src/frontend/arguments/tests.rs
+++ b/crates/cli/src/frontend/arguments/tests.rs
@@ -1605,7 +1605,6 @@ mod path_operands {
 
     #[test]
     fn paths_with_options_before_operands() {
-        // Options must come before operands
         let parsed = parse_test_args(["-a", "-v", "src/", "dst/"]).expect("parse");
         assert!(parsed.archive);
         assert_eq!(parsed.verbosity, 1);
@@ -2148,7 +2147,6 @@ mod checksum_choice_tests {
 
     #[test]
     fn checksum_seed_with_checksum_flag() {
-        // --checksum and --checksum-seed can be combined
         let parsed = parse_test_args(["-c", "--checksum-seed=42", "src/", "dst/"]).expect("parse");
         assert_eq!(parsed.checksum, Some(true));
         assert_eq!(parsed.checksum_seed, Some(42));
@@ -2705,7 +2703,6 @@ mod timeout_tests {
     fn no_timeout_option() {
         let parsed =
             parse_test_args(["--timeout=30", "--no-timeout", "src/", "dst/"]).expect("parse");
-        // --no-timeout should override --timeout
         assert_eq!(parsed.timeout, None);
     }
 
@@ -2713,7 +2710,6 @@ mod timeout_tests {
     fn no_contimeout_option() {
         let parsed =
             parse_test_args(["--contimeout=10", "--no-contimeout", "src/", "dst/"]).expect("parse");
-        // --no-contimeout should override --contimeout
         assert_eq!(parsed.contimeout, None);
     }
 }


### PR DESCRIPTION
Removes decorative banner dividers, restatement comments, and redundant rustdoc on accessor methods within `crates/cli/src/frontend/arguments/`. Comments-only change; no logic touched. Addresses #1972.