### PR TITLE
docs(core): comment cleanup for message (#2012)

### DIFF
--- a/crates/core/src/message/numbers.rs
+++ b/crates/core/src/message/numbers.rs
@@ -66,7 +66,6 @@ pub(super) fn encode_unsigned_decimal_into(mut value: u64, buf: &mut [u8]) -> us
 mod tests {
     use super::*;
 
-    // Tests for encode_unsigned_decimal
     #[test]
     fn encode_unsigned_decimal_zero() {
         let mut buf = [0u8; 20];
@@ -110,7 +109,6 @@ mod tests {
         assert_eq!(encode_unsigned_decimal(1000, &mut buf), "1000");
     }
 
-    // Tests for encode_signed_decimal
     #[test]
     fn encode_signed_decimal_zero() {
         let mut buf = [0u8; 21];
@@ -167,12 +165,11 @@ mod tests {
         assert_eq!(result, "-1");
     }
 
-    // Tests for encode_unsigned_decimal_into
     #[test]
     fn encode_unsigned_decimal_into_returns_correct_start_index() {
         let mut buf = [0u8; 10];
         let start = encode_unsigned_decimal_into(42, &mut buf);
-        assert_eq!(start, 8); // "42" is 2 digits, so starts at index 8 of 10
+        assert_eq!(start, 8);
     }
 
     #[test]
@@ -191,7 +188,6 @@ mod tests {
         assert_eq!(&buf, b"123");
     }
 
-    // Edge case tests
     #[test]
     fn encode_unsigned_decimal_exact_buffer_size() {
         let mut buf = [0u8; 1];
@@ -217,6 +213,6 @@ mod tests {
     #[should_panic(expected = "decimal representation does not fit")]
     fn encode_unsigned_decimal_into_buffer_too_small_panics() {
         let mut buf = [0u8; 2];
-        encode_unsigned_decimal_into(999, &mut buf); // 3 digits don't fit in 2 bytes
+        encode_unsigned_decimal_into(999, &mut buf);
     }
 }

--- a/crates/core/src/message/role.rs
+++ b/crates/core/src/message/role.rs
@@ -111,7 +111,6 @@ impl FromStr for Role {
 mod tests {
     use super::*;
 
-    // Tests for Role::ALL constant
     #[test]
     fn all_contains_six_roles() {
         assert_eq!(Role::ALL.len(), 6);
@@ -127,7 +126,6 @@ mod tests {
         assert_eq!(Role::ALL[5], Role::Daemon);
     }
 
-    // Tests for Role::as_str
     #[test]
     fn sender_as_str() {
         assert_eq!(Role::Sender.as_str(), "sender");
@@ -158,7 +156,6 @@ mod tests {
         assert_eq!(Role::Daemon.as_str(), "daemon");
     }
 
-    // Tests for Display trait
     #[test]
     fn display_matches_as_str() {
         for role in Role::ALL {
@@ -166,7 +163,6 @@ mod tests {
         }
     }
 
-    // Tests for FromStr trait
     #[test]
     fn parse_sender() {
         assert_eq!("sender".parse::<Role>().unwrap(), Role::Sender);
@@ -212,7 +208,6 @@ mod tests {
         assert!("SENDER".parse::<Role>().is_err());
     }
 
-    // Tests for trait implementations
     #[test]
     fn role_is_clone() {
         let role = Role::Sender;
@@ -242,7 +237,6 @@ mod tests {
         assert_eq!(set.len(), 2);
     }
 
-    // Tests for ParseRoleError
     #[test]
     fn parse_role_error_display() {
         let err = "invalid".parse::<Role>().unwrap_err();

--- a/crates/core/src/message/scratch.rs
+++ b/crates/core/src/message/scratch.rs
@@ -197,12 +197,9 @@ mod tests {
 
     #[test]
     fn with_thread_local_reuses_buffer() {
-        // First call modifies the thread-local buffer
         MessageScratch::with_thread_local(|scratch| {
             scratch.code_digits[0] = 99;
         });
-        // Second call may or may not see the modification depending on reuse
-        // Just verify it executes successfully
         let result = MessageScratch::with_thread_local(|_scratch| true);
         assert!(result);
     }

--- a/crates/core/src/message/segments/io.rs
+++ b/crates/core/src/message/segments/io.rs
@@ -203,7 +203,6 @@ mod tests {
     #[test]
     fn write_to_empty_segments_succeeds() {
         let mut scratch = MessageScratch::new();
-        // Create empty segments by not adding any content
         let msg = Message::info("");
         let segments = msg.as_segments(&mut scratch, false);
         let mut buffer = Vec::new();

--- a/crates/core/src/message/segments/mod.rs
+++ b/crates/core/src/message/segments/mod.rs
@@ -13,8 +13,3 @@ mod io;
 
 pub use base::MessageSegments;
 pub use error::CopyToSliceError;
-
-// The public API is re-exported from [`super`] so callers only interact with
-// `crate::message::segments` rather than the internal file layout. The helper
-// modules above provide `impl MessageSegments` blocks that extend the core
-// behaviour defined in [`base`].

--- a/crates/core/src/message/source.rs
+++ b/crates/core/src/message/source.rs
@@ -485,8 +485,6 @@ mod tests {
         assert_eq!(buffer, "dir/nested/file");
     }
 
-    // Tests for file_basename
-
     #[test]
     fn file_basename_extracts_filename_from_unix_path() {
         assert_eq!(
@@ -530,8 +528,6 @@ mod tests {
         assert_eq!(file_basename(""), "");
     }
 
-    // Tests for error_location! macro
-
     #[test]
     fn error_location_starts_with_at() {
         let location = crate::error_location!();
@@ -562,7 +558,6 @@ mod tests {
     #[test]
     fn error_location_uses_basename_not_full_path() {
         let location = crate::error_location!();
-        // Should not contain path separators before the filename
         let after_at = &location["at ".len()..];
         let paren_pos = after_at.find('(').expect("missing '('");
         let basename = &after_at[..paren_pos];


### PR DESCRIPTION
Remove section divider comments, restatement comments, and decorative banner comments in `crates/core/src/message/` per repository comment cleanup conventions. Addresses #2012; no code logic changes.