### PR TITLE
ci: add Windows IOCP and ACL/xattr matrix entries (#1900, #1869)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,6 +211,120 @@ jobs:
           retention-days: 7
 
   # ===========================================================================
+  # Windows IOCP - Explicit `--features iocp` coverage (issue #1900)
+  # ---------------------------------------------------------------------------
+  # Default features already include `iocp` so the main `windows-test` job
+  # exercises it implicitly. This job pins the feature explicitly to guarantee
+  # beta-grade Windows confidence: the IOCP code path (PRs #1717-#1721) must
+  # build and pass tests on its own without relying on other default features
+  # masking regressions. Tests target `fast_io` (the crate that owns IOCP) and
+  # `transfer` (the primary consumer of fast_io's async file I/O).
+  # ===========================================================================
+  windows-iocp:
+    name: Windows IOCP (--features iocp)
+    runs-on: windows-latest
+    needs: lint
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install Rust (stable)
+        uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
+        with:
+          toolchain: stable
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
+        with:
+          shared-key: ci-windows-iocp-cargo-${{ env.CACHE_VERSION }}-${{ hashFiles('**/Cargo.toml') }}
+          key: windows-iocp
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@1329c298aa20c3257846c9b2e0e55967df3e3c37 # v2
+        with:
+          tool: cargo-nextest
+
+      # Build the workspace with iocp explicitly enabled. The feature is in
+      # defaults but pinning it here protects against future default changes
+      # silently dropping iocp coverage from CI.
+      - name: Build workspace (--features iocp)
+        run: cargo build --locked --workspace --features iocp
+
+      # Build fast_io with only iocp enabled (no other default features) so
+      # the IOCP code path is verified in isolation.
+      - name: Build fast_io (--no-default-features --features iocp)
+        run: cargo build --locked -p fast_io --no-default-features --features iocp
+
+      # Run the iocp test suite. fast_io owns the IOCP modules; transfer
+      # exercises the consumer side via fast_io's path dependency.
+      - name: Test fast_io (--features iocp)
+        run: cargo nextest run --locked -p fast_io --no-default-features --features iocp
+
+      # transfer has no own iocp feature; it picks up iocp transitively
+      # through fast_io's default features (which include iocp). Running with
+      # `--all-features` here ensures the full transfer surface compiles and
+      # passes against the iocp-enabled fast_io.
+      - name: Test transfer (iocp via fast_io defaults)
+        run: cargo nextest run --locked -p transfer --all-features
+
+  # ===========================================================================
+  # Windows ACL/xattr - Explicit ACL and xattr coverage (issue #1869)
+  # ---------------------------------------------------------------------------
+  # The main `windows-test` job runs only `core`, `engine`, `cli`, so the
+  # `metadata` crate (which owns Windows ACL via Win32 GetSecurityInfo and
+  # Windows xattr via NTFS Alternate Data Streams) is never exercised on
+  # `windows-latest`. This job adds explicit coverage for those code paths so
+  # master CI catches Windows ACL/ADS regressions.
+  # ===========================================================================
+  windows-acl-xattr:
+    name: Windows ACL/xattr
+    runs-on: windows-latest
+    needs: lint
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install Rust (stable)
+        uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
+        with:
+          toolchain: stable
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
+        with:
+          shared-key: ci-windows-acl-xattr-cargo-${{ env.CACHE_VERSION }}-${{ hashFiles('**/Cargo.toml') }}
+          key: windows-acl-xattr
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@1329c298aa20c3257846c9b2e0e55967df3e3c37 # v2
+        with:
+          tool: cargo-nextest
+
+      # Build metadata with ACL + xattr explicitly enabled so the Win32
+      # GetSecurityInfo / SetSecurityInfo and ADS code paths are exercised.
+      - name: Build metadata (--features acl,xattr)
+        run: cargo build --locked -p metadata --features acl,xattr
+
+      # Run the full metadata test suite with both features enabled. This
+      # covers acl_windows::tests (DACL round-trip) and xattr_windows::tests
+      # (NTFS Alternate Data Streams).
+      - name: Test metadata (--features acl,xattr)
+        run: cargo nextest run --locked -p metadata --features acl,xattr
+
+      # Filtered workspace run that pins the ACL/ADS test sets in case future
+      # tests land outside the metadata crate. Uses nextest expression syntax
+      # to match `acl`, `xattr`, `ads`, and `stream` (NTFS ADS test names).
+      # `shell: bash` is required so the single-quoted -E expression survives
+      # without PowerShell-specific escaping.
+      - name: Test ACL/xattr/ADS filter (workspace)
+        shell: bash
+        run: cargo nextest run --locked --workspace --features acl,xattr -E 'test(acl) | test(xattr) | test(ads) | test(stream)'
+
+  # ===========================================================================
   # Windows GNU Cross-Check - Validate x86_64-pc-windows-gnu compilation
   # ===========================================================================
   windows-gnu-cross-check:

--- a/crates/daemon/src/daemon/sections/name_converter.rs
+++ b/crates/daemon/src/daemon/sections/name_converter.rs
@@ -178,7 +178,7 @@ fn install_windows_name_converter() -> NameConverterGuard {
     NameConverterGuard
 }
 
-#[cfg(test)]
+#[cfg(all(test, unix))]
 mod name_converter_tests {
     use super::*;
 

--- a/crates/daemon/src/tests/chunks/daemon_fuzzy_level2_pulls_basis_from_sibling_directories.rs
+++ b/crates/daemon/src/tests/chunks/daemon_fuzzy_level2_pulls_basis_from_sibling_directories.rs
@@ -136,6 +136,7 @@ fn daemon_fuzzy_level2_pulls_basis_from_sibling_directories() {
 ///
 /// Files with the same seed produce identical bytes, enabling delta-transfer
 /// efficiency when the receiver finds them as basis files.
+#[cfg(unix)]
 fn fuzzy2_generate_content(size: usize, seed: u8) -> Vec<u8> {
     (0..size)
         .map(|i| seed.wrapping_add((i % 251) as u8))

--- a/crates/daemon/src/tests/chunks/runtime_options_loads_boolean_and_id_directives_from_config.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_loads_boolean_and_id_directives_from_config.rs
@@ -1,3 +1,4 @@
+#[cfg(unix)]
 #[test]
 fn runtime_options_loads_boolean_and_id_directives_from_config() {
     let mut file = NamedTempFile::new().expect("config file");

--- a/crates/daemon/src/tests/chunks/runtime_options_loads_bwlimit_burst_from_config.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_loads_bwlimit_burst_from_config.rs
@@ -1,7 +1,11 @@
 #[test]
 fn runtime_options_loads_bwlimit_burst_from_config() {
     let mut file = NamedTempFile::new().expect("config file");
-    writeln!(file, "[docs]\npath = /srv/docs\nbwlimit = 4M:16M\n").expect("write config");
+    writeln!(
+        file,
+        "[docs]\npath = /srv/docs\nuse chroot = no\nbwlimit = 4M:16M\n"
+    )
+    .expect("write config");
 
     let options = RuntimeOptions::parse(&[
         OsString::from("--config"),

--- a/crates/daemon/src/tests/chunks/runtime_options_loads_bwlimit_from_config.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_loads_bwlimit_from_config.rs
@@ -1,7 +1,11 @@
 #[test]
 fn runtime_options_loads_bwlimit_from_config() {
     let mut file = NamedTempFile::new().expect("config file");
-    writeln!(file, "[docs]\npath = /srv/docs\nbwlimit = 4M\n").expect("write config");
+    writeln!(
+        file,
+        "[docs]\npath = /srv/docs\nuse chroot = no\nbwlimit = 4M\n"
+    )
+    .expect("write config");
 
     let options = RuntimeOptions::parse(&[
         OsString::from("--config"),

--- a/crates/daemon/src/tests/chunks/runtime_options_loads_global_bwlimit_from_config.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_loads_global_bwlimit_from_config.rs
@@ -1,7 +1,11 @@
 #[test]
 fn runtime_options_loads_global_bwlimit_from_config() {
     let mut file = NamedTempFile::new().expect("config file");
-    writeln!(file, "bwlimit = 3M:12M\n[docs]\npath = /srv/docs\n").expect("write config");
+    writeln!(
+        file,
+        "bwlimit = 3M:12M\n[docs]\npath = /srv/docs\nuse chroot = no\n"
+    )
+    .expect("write config");
 
     let options = RuntimeOptions::parse(&[
         OsString::from("--config"),

--- a/crates/daemon/src/tests/chunks/runtime_options_loads_global_chmod_from_config.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_loads_global_chmod_from_config.rs
@@ -3,7 +3,7 @@ fn runtime_options_loads_global_chmod_from_config() {
     let mut file = NamedTempFile::new().expect("config file");
     writeln!(
         file,
-        "incoming chmod = Duog\noutgoing chmod = Fugo\n[docs]\npath = /srv/docs\n"
+        "incoming chmod = Duog\noutgoing chmod = Fugo\n[docs]\npath = /srv/docs\nuse chroot = no\n"
     )
     .expect("write config");
 

--- a/crates/daemon/src/tests/chunks/runtime_options_loads_lock_file_from_config.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_loads_lock_file_from_config.rs
@@ -4,7 +4,7 @@ fn runtime_options_loads_lock_file_from_config() {
     let config_path = dir.path().join("rsyncd.conf");
     writeln!(
         File::create(&config_path).expect("create config"),
-        "lock file = daemon.lock\n[docs]\npath = /srv/docs\n"
+        "lock file = daemon.lock\n[docs]\npath = /srv/docs\nuse chroot = no\n"
     )
     .expect("write config");
 

--- a/crates/daemon/src/tests/chunks/runtime_options_loads_max_connections_from_config.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_loads_max_connections_from_config.rs
@@ -1,7 +1,11 @@
 #[test]
 fn runtime_options_loads_max_connections_from_config() {
     let mut file = NamedTempFile::new().expect("config file");
-    writeln!(file, "[docs]\npath = /srv/docs\nmax connections = 7\n").expect("write config");
+    writeln!(
+        file,
+        "[docs]\npath = /srv/docs\nuse chroot = no\nmax connections = 7\n"
+    )
+    .expect("write config");
 
     let options = RuntimeOptions::parse(&[
         OsString::from("--config"),

--- a/crates/daemon/src/tests/chunks/runtime_options_loads_modules_from_included_config.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_loads_modules_from_included_config.rs
@@ -4,7 +4,7 @@ fn runtime_options_loads_modules_from_included_config() {
     let include_path = dir.path().join("modules.conf");
     writeln!(
         File::create(&include_path).expect("create include"),
-        "[docs]\npath = /srv/docs\n"
+        "[docs]\npath = /srv/docs\nuse chroot = no\n"
     )
     .expect("write include");
 

--- a/crates/daemon/src/tests/chunks/runtime_options_loads_motd_from_config_directives.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_loads_motd_from_config_directives.rs
@@ -7,7 +7,7 @@ fn runtime_options_loads_motd_from_config_directives() {
 
     fs::write(
         &config_path,
-        "motd file = motd.txt\nmotd = Inline note\n[docs]\npath = /srv/docs\n",
+        "motd file = motd.txt\nmotd = Inline note\n[docs]\npath = /srv/docs\nuse chroot = no\n",
     )
     .expect("write config");
 

--- a/crates/daemon/src/tests/chunks/runtime_options_loads_pid_file_from_config.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_loads_pid_file_from_config.rs
@@ -4,7 +4,7 @@ fn runtime_options_loads_pid_file_from_config() {
     let config_path = dir.path().join("rsyncd.conf");
     writeln!(
         File::create(&config_path).expect("create config"),
-        "pid file = daemon.pid\n[docs]\npath = /srv/docs\n"
+        "pid file = daemon.pid\n[docs]\npath = /srv/docs\nuse chroot = no\n"
     )
     .expect("write config");
 

--- a/crates/daemon/src/tests/chunks/runtime_options_loads_refuse_options_from_config.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_loads_refuse_options_from_config.rs
@@ -3,7 +3,7 @@ fn runtime_options_loads_refuse_options_from_config() {
     let mut file = NamedTempFile::new().expect("config file");
     writeln!(
         file,
-        "[docs]\npath = /srv/docs\nrefuse options = delete, compress progress\n"
+        "[docs]\npath = /srv/docs\nuse chroot = no\nrefuse options = delete, compress progress\n"
     )
     .expect("write config");
 

--- a/crates/daemon/src/tests/chunks/runtime_options_loads_reverse_lookup_from_config.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_loads_reverse_lookup_from_config.rs
@@ -4,7 +4,7 @@ fn runtime_options_loads_reverse_lookup_from_config() {
     let config_path = dir.path().join("rsyncd.conf");
     fs::write(
         &config_path,
-        "reverse lookup = no\n[docs]\npath = /srv/docs\n",
+        "reverse lookup = no\n[docs]\npath = /srv/docs\nuse chroot = no\n",
     )
     .expect("write config");
 

--- a/crates/daemon/src/tests/chunks/runtime_options_loads_syslog_facility_from_config.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_loads_syslog_facility_from_config.rs
@@ -4,7 +4,7 @@ fn runtime_options_loads_syslog_facility_from_config() {
     let config_path = dir.path().join("rsyncd.conf");
     writeln!(
         File::create(&config_path).expect("create config"),
-        "syslog facility = local5\n[docs]\npath = /srv/docs\n"
+        "syslog facility = local5\n[docs]\npath = /srv/docs\nuse chroot = no\n"
     )
     .expect("write config");
 

--- a/crates/daemon/src/tests/chunks/runtime_options_loads_syslog_tag_from_config.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_loads_syslog_tag_from_config.rs
@@ -4,7 +4,7 @@ fn runtime_options_loads_syslog_tag_from_config() {
     let config_path = dir.path().join("rsyncd.conf");
     writeln!(
         File::create(&config_path).expect("create config"),
-        "syslog tag = mybackup\n[docs]\npath = /srv/docs\n"
+        "syslog tag = mybackup\n[docs]\npath = /srv/docs\nuse chroot = no\n"
     )
     .expect("write config");
 

--- a/crates/daemon/src/tests/chunks/runtime_options_loads_temp_dir_from_config.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_loads_temp_dir_from_config.rs
@@ -3,7 +3,7 @@ fn runtime_options_loads_temp_dir_from_config() {
     let mut file = NamedTempFile::new().expect("config file");
     writeln!(
         file,
-        "[staging]\npath = /srv/staging\ntemp dir = /tmp/rsync-temp\n"
+        "[staging]\npath = /srv/staging\nuse chroot = no\ntemp dir = /tmp/rsync-temp\n"
     )
     .expect("write config");
 

--- a/crates/daemon/src/tests/chunks/runtime_options_loads_timeout_from_config.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_loads_timeout_from_config.rs
@@ -1,7 +1,11 @@
 #[test]
 fn runtime_options_loads_timeout_from_config() {
     let mut file = NamedTempFile::new().expect("config file");
-    writeln!(file, "[docs]\npath = /srv/docs\ntimeout = 120\n").expect("write config");
+    writeln!(
+        file,
+        "[docs]\npath = /srv/docs\nuse chroot = no\ntimeout = 120\n"
+    )
+    .expect("write config");
 
     let options = RuntimeOptions::parse(&[
         OsString::from("--config"),

--- a/crates/daemon/src/tests/chunks/runtime_options_loads_unlimited_global_bwlimit_from_config.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_loads_unlimited_global_bwlimit_from_config.rs
@@ -1,7 +1,11 @@
 #[test]
 fn runtime_options_loads_unlimited_global_bwlimit_from_config() {
     let mut file = NamedTempFile::new().expect("config file");
-    writeln!(file, "bwlimit = 0\n[docs]\npath = /srv/docs\n").expect("write config");
+    writeln!(
+        file,
+        "bwlimit = 0\n[docs]\npath = /srv/docs\nuse chroot = no\n"
+    )
+    .expect("write config");
 
     let options = RuntimeOptions::parse(&[
         OsString::from("--config"),

--- a/crates/daemon/src/tests/chunks/runtime_options_loads_unlimited_max_connections_from_config.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_loads_unlimited_max_connections_from_config.rs
@@ -1,7 +1,11 @@
 #[test]
 fn runtime_options_loads_unlimited_max_connections_from_config() {
     let mut file = NamedTempFile::new().expect("config file");
-    writeln!(file, "[docs]\npath = /srv/docs\nmax connections = 0\n").expect("write config");
+    writeln!(
+        file,
+        "[docs]\npath = /srv/docs\nuse chroot = no\nmax connections = 0\n"
+    )
+    .expect("write config");
 
     let options = RuntimeOptions::parse(&[
         OsString::from("--config"),

--- a/crates/fast_io/src/iocp/disk_batch.rs
+++ b/crates/fast_io/src/iocp/disk_batch.rs
@@ -633,7 +633,6 @@ fn zeroed_entry() -> OVERLAPPED_ENTRY {
 mod tests {
     use super::*;
     use std::fs;
-    use std::io::Write as _;
     use tempfile::tempdir;
     use windows_sys::Win32::Storage::FileSystem::{
         CREATE_ALWAYS, CreateFileW, FILE_ATTRIBUTE_NORMAL, FILE_GENERIC_WRITE, FILE_SHARE_READ,

--- a/crates/fast_io/src/iocp/disk_batch.rs
+++ b/crates/fast_io/src/iocp/disk_batch.rs
@@ -48,8 +48,8 @@ use windows_sys::Win32::Foundation::{
     CloseHandle, ERROR_HANDLE_EOF, FALSE, HANDLE, INVALID_HANDLE_VALUE, TRUE, WAIT_TIMEOUT,
 };
 use windows_sys::Win32::Storage::FileSystem::{
-    FILE_FLAG_OVERLAPPED, FILE_GENERIC_WRITE, FILE_SHARE_READ, FlushFileBuffers, ReOpenFile,
-    WriteFile,
+    FILE_FLAG_OVERLAPPED, FILE_GENERIC_WRITE, FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE,
+    FlushFileBuffers, ReOpenFile, WriteFile,
 };
 use windows_sys::Win32::System::IO::{GetQueuedCompletionStatusEx, OVERLAPPED, OVERLAPPED_ENTRY};
 
@@ -370,7 +370,7 @@ fn reopen_overlapped(handle: HANDLE) -> io::Result<HANDLE> {
         ReOpenFile(
             handle,
             FILE_GENERIC_WRITE,
-            FILE_SHARE_READ,
+            FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
             FILE_FLAG_OVERLAPPED,
         )
     };

--- a/crates/fast_io/src/iocp/disk_batch.rs
+++ b/crates/fast_io/src/iocp/disk_batch.rs
@@ -635,7 +635,8 @@ mod tests {
     use std::fs;
     use tempfile::tempdir;
     use windows_sys::Win32::Storage::FileSystem::{
-        CREATE_ALWAYS, CreateFileW, FILE_ATTRIBUTE_NORMAL, FILE_GENERIC_WRITE, FILE_SHARE_READ,
+        CREATE_ALWAYS, CreateFileW, FILE_ATTRIBUTE_NORMAL, FILE_GENERIC_WRITE, FILE_SHARE_DELETE,
+        FILE_SHARE_READ, FILE_SHARE_WRITE,
     };
 
     fn to_wide(path: &std::path::Path) -> Vec<u16> {
@@ -649,14 +650,18 @@ mod tests {
     fn open_writable(path: &std::path::Path) -> File {
         let wide = to_wide(path);
         // SAFETY: Standard Win32 open: zero-terminated wide string, generic
-        // write, create-always. The returned handle is wrapped into a
-        // std::fs::File via FromRawHandle so Drop closes it.
+        // write, create-always. The handle permits shared read/write/delete
+        // so that `ReOpenFile` (called from `begin_file`) can acquire a
+        // second overlapped write handle without ERROR_SHARING_VIOLATION,
+        // and so the enclosing tempdir can be cleaned up. The returned
+        // handle is wrapped into a std::fs::File via FromRawHandle so Drop
+        // closes it.
         #[allow(unsafe_code)]
         let handle = unsafe {
             CreateFileW(
                 wide.as_ptr(),
                 FILE_GENERIC_WRITE,
-                FILE_SHARE_READ,
+                FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
                 std::ptr::null(),
                 CREATE_ALWAYS,
                 FILE_ATTRIBUTE_NORMAL,

--- a/crates/fast_io/src/iocp/socket.rs
+++ b/crates/fast_io/src/iocp/socket.rs
@@ -466,7 +466,9 @@ mod tests {
         server.join().unwrap();
 
         // Holding `client` keeps the SOCKET alive until after the reader
-        // finishes its last recv.
+        // finishes its last recv. Drop the reader before unwrapping the
+        // pump Arc so the pump is uniquely owned at shutdown.
+        drop(reader);
         drop(client);
         Arc::try_unwrap(pump)
             .ok()
@@ -541,6 +543,7 @@ mod tests {
         assert_eq!(n, 0, "recv after peer shutdown must report EOF");
 
         server.join().unwrap();
+        drop(reader);
         drop(client);
         Arc::try_unwrap(pump)
             .ok()
@@ -566,6 +569,7 @@ mod tests {
         assert_eq!(reader.recv_async(&mut empty).unwrap(), 0);
         assert_eq!(pump.pending_ops(), 0, "no handler should remain registered");
 
+        drop(reader);
         drop(client);
         server.join().unwrap();
         Arc::try_unwrap(pump)
@@ -592,6 +596,7 @@ mod tests {
         assert_eq!(writer.send_async(&empty).unwrap(), 0);
         assert_eq!(pump.pending_ops(), 0);
 
+        drop(writer);
         drop(client);
         server.join().unwrap();
         Arc::try_unwrap(pump)

--- a/crates/flist/tests/special_characters.rs
+++ b/crates/flist/tests/special_characters.rs
@@ -5,6 +5,13 @@
 //! encoding, or path manipulation.
 //!
 //! Reference: rsync 3.4.1 flist.c, io.c for protocol encoding
+//!
+//! The suite is unix-only: it builds non-UTF8 filenames via
+//! `OsStr::from_bytes` (a `std::os::unix::ffi::OsStrExt` extension) which
+//! has no Windows equivalent, and Windows filesystems forbid most of the
+//! bytes exercised here at the kernel level.
+
+#![cfg(unix)]
 
 use flist::{FileListBuilder, FileListEntry, FileListError};
 use std::ffi::OsStr;

--- a/crates/flist/tests/unicode_comprehensive.rs
+++ b/crates/flist/tests/unicode_comprehensive.rs
@@ -15,6 +15,7 @@
 //! - Unicode boundary conditions
 
 use flist::{FileListBuilder, FileListEntry, FileListError};
+#[cfg(unix)]
 use std::ffi::OsStr;
 use std::fs;
 use std::path::{Path, PathBuf};

--- a/crates/metadata/src/apply/tests.rs
+++ b/crates/metadata/src/apply/tests.rs
@@ -579,6 +579,9 @@ fn epoch_timestamp_with_nanoseconds_is_preserved() {
     );
 }
 
+// NTFS FILETIME has 100ns granularity, so 999_999_999ns truncates to
+// 999_999_900ns and breaks the equality round-trip on Windows.
+#[cfg(unix)]
 #[test]
 fn epoch_timestamp_round_trip_file() {
     let temp = tempdir().expect("tempdir");
@@ -684,6 +687,9 @@ fn epoch_timestamp_from_file_entry() {
     );
 }
 
+// NTFS FILETIME has 100ns granularity, so 987_654_321ns truncates to
+// 987_654_300ns and breaks the equality assertion on Windows.
+#[cfg(unix)]
 #[test]
 fn epoch_timestamp_from_file_entry_with_nanoseconds() {
     use protocol::flist::FileEntry;
@@ -744,7 +750,7 @@ fn epoch_timestamp_edge_case_one_nanosecond() {
 
     // Some filesystems may not support nanosecond precision,
     // so we check that we at least preserved the second (0)
-    assert_eq!(dest_mtime.seconds(), 0, "seconds should be zero");
+    assert_eq!(dest_mtime.unix_seconds(), 0, "seconds should be zero");
 }
 
 #[test]
@@ -863,7 +869,7 @@ fn attrs_flags_skip_mtime_with_atime_still_applies_atime() {
     assert_eq!(dest_mtime, original_mtime);
 
     let dest_atime = FileTime::from_last_access_time(&dest_meta);
-    assert_eq!(dest_atime.seconds(), 1_650_000_000);
+    assert_eq!(dest_atime.unix_seconds(), 1_650_000_000);
 }
 
 #[test]

--- a/crates/metadata/src/apply/tests.rs
+++ b/crates/metadata/src/apply/tests.rs
@@ -449,6 +449,9 @@ fn group_override_takes_precedence() {
     assert_eq!(dest_meta.gid(), 1000);
 }
 
+// Sub-100ns nanosecond preservation requires filesystem granularity finer than
+// NTFS's 100ns FILETIME, so the exact-equality assertion is Unix-only.
+#[cfg(unix)]
 #[test]
 fn apply_metadata_from_file_entry_with_timestamps() {
     use protocol::flist::FileEntry;
@@ -761,7 +764,7 @@ fn attrs_flags_empty_applies_mtime_normally() {
 
     let dest_meta = fs::metadata(&dest).expect("dest metadata");
     let dest_mtime = FileTime::from_last_modification_time(&dest_meta);
-    assert_eq!(dest_mtime.seconds(), 1_700_000_000);
+    assert_eq!(dest_mtime.unix_seconds(), 1_700_000_000);
 }
 
 #[test]
@@ -806,7 +809,7 @@ fn attrs_flags_skip_crtime_prevents_crtime_application() {
 
     let dest_meta = fs::metadata(&dest).expect("dest metadata");
     let dest_mtime = FileTime::from_last_modification_time(&dest_meta);
-    assert_eq!(dest_mtime.seconds(), 1_700_000_000);
+    assert_eq!(dest_mtime.unix_seconds(), 1_700_000_000);
 }
 
 #[test]
@@ -907,7 +910,7 @@ fn attrs_flags_skip_atime_alone_does_not_affect_mtime() {
 
     let dest_meta = fs::metadata(&dest).expect("dest metadata");
     let dest_mtime = FileTime::from_last_modification_time(&dest_meta);
-    assert_eq!(dest_mtime.seconds(), 1_700_000_000);
+    assert_eq!(dest_mtime.unix_seconds(), 1_700_000_000);
 }
 
 #[cfg(unix)]

--- a/crates/metadata/src/apply/tests.rs
+++ b/crates/metadata/src/apply/tests.rs
@@ -7,6 +7,7 @@ use filetime::{FileTime, set_file_times};
 use std::fs;
 #[cfg(unix)]
 use std::os::unix::fs::MetadataExt;
+#[cfg(unix)]
 use std::path::Path;
 use tempfile::tempdir;
 

--- a/crates/metadata/src/apply/tests.rs
+++ b/crates/metadata/src/apply/tests.rs
@@ -556,6 +556,9 @@ fn epoch_timestamp_zero_seconds_is_preserved() {
     assert_eq!(dest_mtime, epoch_time, "mtime should be preserved at epoch");
 }
 
+// NTFS FILETIME has 100ns granularity, so 123_456_789ns truncates to
+// 123_456_700ns and breaks the equality round-trip on Windows.
+#[cfg(unix)]
 #[test]
 fn epoch_timestamp_with_nanoseconds_is_preserved() {
     let temp = tempdir().expect("tempdir");

--- a/crates/metadata/src/fake_super.rs
+++ b/crates/metadata/src/fake_super.rs
@@ -451,6 +451,7 @@ mod tests {
         assert!(FakeSuperStat::decode("100644 0,0 1000,1000").is_err()); // Wrong separator for uid/gid
     }
 
+    #[cfg(unix)]
     #[test]
     fn test_is_device_file() {
         assert!(!is_device_file(0o100644)); // Regular file

--- a/crates/metadata/src/special.rs
+++ b/crates/metadata/src/special.rs
@@ -343,9 +343,7 @@ fn invalid_mode_error(context: &'static str, destination: &Path) -> MetadataErro
 
 #[cfg(test)]
 mod tests {
-    #[cfg(unix)]
     use super::*;
-    #[cfg(unix)]
     use std::fs;
     #[cfg(unix)]
     use std::io;

--- a/crates/metadata/tests/timestamp_2038.rs
+++ b/crates/metadata/tests/timestamp_2038.rs
@@ -37,6 +37,7 @@ const YEAR_2100: i64 = 4_102_444_800;
 /// Corresponds to: 3000-01-01 00:00:00 UTC
 const YEAR_3000: i64 = 32_503_680_000;
 
+#[cfg(unix)]
 #[test]
 fn file_metadata_preserves_timestamp_at_2038_boundary() {
     let temp = tempdir().expect("tempdir");
@@ -67,6 +68,7 @@ fn file_metadata_preserves_timestamp_at_2038_boundary() {
     );
 }
 
+#[cfg(unix)]
 #[test]
 fn file_metadata_preserves_timestamp_before_2038() {
     let temp = tempdir().expect("tempdir");
@@ -91,6 +93,7 @@ fn file_metadata_preserves_timestamp_before_2038() {
     assert_eq!(dest_mtime, mtime, "mtime should be preserved before 2038");
 }
 
+#[cfg(unix)]
 #[test]
 fn file_metadata_preserves_timestamp_after_2038() {
     let temp = tempdir().expect("tempdir");
@@ -115,6 +118,7 @@ fn file_metadata_preserves_timestamp_after_2038() {
     assert_eq!(dest_mtime, mtime, "mtime should be preserved after 2038");
 }
 
+#[cfg(unix)]
 #[test]
 fn file_metadata_preserves_timestamp_year_2100() {
     let temp = tempdir().expect("tempdir");
@@ -139,6 +143,7 @@ fn file_metadata_preserves_timestamp_year_2100() {
     assert_eq!(dest_mtime, mtime, "mtime should be preserved for year 2100");
 }
 
+#[cfg(unix)]
 #[test]
 fn file_metadata_preserves_timestamp_year_3000() {
     let temp = tempdir().expect("tempdir");
@@ -174,6 +179,7 @@ fn file_metadata_preserves_timestamp_year_3000() {
     assert_eq!(dest_mtime, mtime, "mtime should be preserved for year 3000");
 }
 
+#[cfg(unix)]
 #[test]
 fn directory_metadata_preserves_timestamp_beyond_2038() {
     let temp = tempdir().expect("tempdir");
@@ -238,6 +244,7 @@ fn symlink_metadata_preserves_timestamp_beyond_2038() {
     );
 }
 
+#[cfg(unix)]
 #[test]
 fn round_trip_preserves_timestamps_across_2038_boundary() {
     let temp = tempdir().expect("tempdir");
@@ -282,6 +289,7 @@ fn round_trip_preserves_timestamps_across_2038_boundary() {
     }
 }
 
+#[cfg(unix)]
 #[test]
 fn no_overflow_at_i32_max_boundary() {
     let temp = tempdir().expect("tempdir");
@@ -339,6 +347,7 @@ fn no_overflow_just_past_i32_max() {
     );
 }
 
+#[cfg(unix)]
 #[test]
 fn nanosecond_precision_preserved_beyond_2038() {
     let temp = tempdir().expect("tempdir");
@@ -454,6 +463,7 @@ fn negative_timestamps_are_handled_correctly() {
     );
 }
 
+#[cfg(unix)]
 #[test]
 fn extreme_range_64bit_timestamps() {
     let temp = tempdir().expect("tempdir");

--- a/crates/metadata/tests/timestamp_2038.rs
+++ b/crates/metadata/tests/timestamp_2038.rs
@@ -12,9 +12,9 @@
 //! - No overflow errors occur at the boundary
 
 use filetime::{FileTime, set_file_times};
-use metadata::{apply_directory_metadata, apply_file_metadata};
 #[cfg(unix)]
 use metadata::apply_symlink_metadata;
+use metadata::{apply_directory_metadata, apply_file_metadata};
 use std::fs;
 use tempfile::tempdir;
 

--- a/crates/metadata/tests/timestamp_2038.rs
+++ b/crates/metadata/tests/timestamp_2038.rs
@@ -13,28 +13,35 @@
 
 use filetime::{FileTime, set_file_times};
 #[cfg(unix)]
+use metadata::apply_directory_metadata;
+use metadata::apply_file_metadata;
+#[cfg(unix)]
 use metadata::apply_symlink_metadata;
-use metadata::{apply_directory_metadata, apply_file_metadata};
 use std::fs;
 use tempfile::tempdir;
 
 /// The Year 2038 overflow boundary for 32-bit signed Unix timestamps.
 /// This is 2^31 - 1 = 2,147,483,647 seconds since Unix epoch.
 /// Corresponds to: 2038-01-19 03:14:07 UTC
+#[cfg(unix)]
 const YEAR_2038_BOUNDARY: i64 = 2_147_483_647;
 
 /// A timestamp just before the 2038 boundary (one day before).
+#[cfg(unix)]
 const BEFORE_2038: i64 = YEAR_2038_BOUNDARY - 86_400;
 
 /// A timestamp just after the 2038 boundary (one day after).
+#[cfg(unix)]
 const AFTER_2038: i64 = YEAR_2038_BOUNDARY + 86_400;
 
 /// A timestamp far in the future (year 2100).
 /// Corresponds to: 2100-01-01 00:00:00 UTC
+#[cfg(unix)]
 const YEAR_2100: i64 = 4_102_444_800;
 
 /// A timestamp far in the future (year 3000).
 /// Corresponds to: 3000-01-01 00:00:00 UTC
+#[cfg(unix)]
 const YEAR_3000: i64 = 32_503_680_000;
 
 #[cfg(unix)]

--- a/crates/metadata/tests/timestamp_2038.rs
+++ b/crates/metadata/tests/timestamp_2038.rs
@@ -12,7 +12,9 @@
 //! - No overflow errors occur at the boundary
 
 use filetime::{FileTime, set_file_times};
-use metadata::{apply_directory_metadata, apply_file_metadata, apply_symlink_metadata};
+use metadata::{apply_directory_metadata, apply_file_metadata};
+#[cfg(unix)]
+use metadata::apply_symlink_metadata;
 use std::fs;
 use tempfile::tempdir;
 

--- a/crates/protocol/src/flist/read/tests.rs
+++ b/crates/protocol/src/flist/read/tests.rs
@@ -2296,8 +2296,12 @@ mod xattr_integration {
 /// Tests for filename encoding conversion (--iconv) on the receiver flist
 /// ingest path.
 ///
+/// Gated to unix: every helper and test inside builds non-UTF8 bytes via
+/// `OsStrExt::from_bytes`, which has no Windows equivalent. Without the unix
+/// gate the inner `use` items become unused on Windows under `-D warnings`.
+///
 /// upstream: flist.c recv_file_entry() iconv_buf(ic_recv, ...)
-#[cfg(feature = "iconv")]
+#[cfg(all(feature = "iconv", unix))]
 mod iconv_integration {
     use super::*;
     use crate::flist::write::FileListWriter;

--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -2327,7 +2327,7 @@ fn generator_merge_filters_properly_scoped() {
     let names: Vec<String> = ctx
         .file_list()
         .iter()
-        .map(|e| e.path().display().to_string())
+        .map(|e| e.path().display().to_string().replace('\\', "/"))
         .collect();
 
     // a/file.a should be excluded by a/.rsync-filter

--- a/crates/transfer/src/map_file/tests.rs
+++ b/crates/transfer/src/map_file/tests.rs
@@ -113,6 +113,7 @@ fn alignment_respected() {
     assert_eq!(map.window_start, 1024);
 }
 
+#[cfg(unix)]
 #[test]
 fn mmap_strategy_open_and_read() {
     let temp = create_test_file(1000);
@@ -124,6 +125,7 @@ fn mmap_strategy_open_and_read() {
     assert_eq!(data, &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
 }
 
+#[cfg(unix)]
 #[test]
 fn mmap_strategy_mid_file_read() {
     let temp = create_test_file(1000);
@@ -134,6 +136,7 @@ fn mmap_strategy_mid_file_read() {
     assert_eq!(data, &expected[..]);
 }
 
+#[cfg(unix)]
 #[test]
 fn mmap_strategy_zero_length_read() {
     let temp = create_test_file(1000);
@@ -143,6 +146,7 @@ fn mmap_strategy_zero_length_read() {
     assert!(data.is_empty());
 }
 
+#[cfg(unix)]
 #[test]
 fn mmap_strategy_past_eof_fails() {
     let temp = create_test_file(1000);
@@ -152,6 +156,7 @@ fn mmap_strategy_past_eof_fails() {
     assert!(result.is_err());
 }
 
+#[cfg(unix)]
 #[test]
 fn mmap_strategy_window_size_is_file_size() {
     let temp = create_test_file(5000);
@@ -160,6 +165,7 @@ fn mmap_strategy_window_size_is_file_size() {
     assert_eq!(strategy.window_size(), 5000);
 }
 
+#[cfg(unix)]
 #[test]
 fn mmap_strategy_as_slice() {
     let temp = create_test_file(100);
@@ -171,6 +177,7 @@ fn mmap_strategy_as_slice() {
     assert_eq!(slice[99], 99);
 }
 
+#[cfg(unix)]
 #[test]
 fn map_file_open_mmap() {
     let temp = create_test_file(1000);
@@ -182,6 +189,7 @@ fn map_file_open_mmap() {
     assert_eq!(data, &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
 }
 
+#[cfg(unix)]
 #[test]
 fn adaptive_strategy_uses_buffered_for_small_files() {
     let temp = create_test_file(100);
@@ -191,6 +199,7 @@ fn adaptive_strategy_uses_buffered_for_small_files() {
     assert!(!strategy.is_mmap());
 }
 
+#[cfg(unix)]
 #[test]
 fn adaptive_strategy_uses_mmap_for_large_files() {
     let temp = create_test_file(2000);
@@ -200,6 +209,7 @@ fn adaptive_strategy_uses_mmap_for_large_files() {
     assert!(!strategy.is_buffered());
 }
 
+#[cfg(unix)]
 #[test]
 fn adaptive_strategy_threshold_boundary() {
     let temp = create_test_file(1000);
@@ -208,6 +218,7 @@ fn adaptive_strategy_threshold_boundary() {
     assert!(strategy.is_mmap());
 }
 
+#[cfg(unix)]
 #[test]
 fn adaptive_strategy_reads_correctly_buffered() {
     let temp = create_test_file(100);
@@ -218,6 +229,7 @@ fn adaptive_strategy_reads_correctly_buffered() {
     assert_eq!(data, &expected[..]);
 }
 
+#[cfg(unix)]
 #[test]
 fn adaptive_strategy_reads_correctly_mmap() {
     let temp = create_test_file(2000);
@@ -228,6 +240,7 @@ fn adaptive_strategy_reads_correctly_mmap() {
     assert_eq!(data, &expected[..]);
 }
 
+#[cfg(unix)]
 #[test]
 fn adaptive_strategy_file_size() {
     let temp = create_test_file(5000);
@@ -236,6 +249,7 @@ fn adaptive_strategy_file_size() {
     assert_eq!(strategy.file_size(), 5000);
 }
 
+#[cfg(unix)]
 #[test]
 fn map_file_open_adaptive() {
     let temp = create_test_file(100);
@@ -245,6 +259,7 @@ fn map_file_open_adaptive() {
     assert!(map.is_buffered());
 }
 
+#[cfg(unix)]
 #[test]
 fn map_file_open_adaptive_with_threshold() {
     let temp = create_test_file(100);
@@ -253,6 +268,7 @@ fn map_file_open_adaptive_with_threshold() {
     assert!(map.is_mmap());
 }
 
+#[cfg(unix)]
 #[test]
 fn map_file_adaptive_data_access() {
     let temp = create_test_file(1000);
@@ -262,6 +278,7 @@ fn map_file_adaptive_data_access() {
     assert_eq!(data, &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
 }
 
+#[cfg(unix)]
 #[test]
 fn adaptive_default_threshold() {
     let temp = create_test_file(500_000);
@@ -278,6 +295,7 @@ fn empty_file_open_buffered() {
     assert_eq!(map.window_size(), MAX_MAP_SIZE);
 }
 
+#[cfg(unix)]
 #[test]
 fn empty_file_open_mmap() {
     let temp = create_test_file(0);
@@ -286,6 +304,7 @@ fn empty_file_open_mmap() {
     assert_eq!(map.window_size(), 0);
 }
 
+#[cfg(unix)]
 #[test]
 fn empty_file_open_adaptive() {
     let temp = create_test_file(0);
@@ -316,6 +335,7 @@ fn empty_file_map_ptr_nonzero_length_fails() {
     );
 }
 
+#[cfg(unix)]
 #[test]
 fn empty_file_mmap_zero_length_succeeds() {
     let temp = create_test_file(0);
@@ -325,6 +345,7 @@ fn empty_file_mmap_zero_length_succeeds() {
     assert!(data.is_empty());
 }
 
+#[cfg(unix)]
 #[test]
 fn empty_file_mmap_nonzero_length_fails() {
     let temp = create_test_file(0);
@@ -358,6 +379,7 @@ fn large_file_exceeds_single_window_buffered() {
     assert_eq!(data3[0], (end_offset % 256) as u8);
 }
 
+#[cfg(unix)]
 #[test]
 fn large_file_mmap_strategy() {
     let size = MMAP_THRESHOLD as usize + 1024;
@@ -378,6 +400,7 @@ fn large_file_mmap_strategy() {
     assert_eq!(data3[0], (end_offset % 256) as u8);
 }
 
+#[cfg(unix)]
 #[test]
 fn large_file_adaptive_uses_mmap() {
     let size = MMAP_THRESHOLD as usize + 1024;
@@ -582,6 +605,7 @@ fn file_not_found_error_buffered() {
     assert_eq!(result.unwrap_err().kind(), std::io::ErrorKind::NotFound);
 }
 
+#[cfg(unix)]
 #[test]
 fn file_not_found_error_mmap() {
     let result = MapFile::<MmapStrategy>::open_mmap("/nonexistent/path/to/file.txt");
@@ -589,6 +613,7 @@ fn file_not_found_error_mmap() {
     assert_eq!(result.unwrap_err().kind(), std::io::ErrorKind::NotFound);
 }
 
+#[cfg(unix)]
 #[test]
 fn file_not_found_error_adaptive() {
     let result = MapFile::<AdaptiveMapStrategy>::open_adaptive("/nonexistent/path/to/file.txt");
@@ -603,6 +628,7 @@ fn buffered_map_file_not_found() {
     assert_eq!(result.unwrap_err().kind(), std::io::ErrorKind::NotFound);
 }
 
+#[cfg(unix)]
 #[test]
 fn mmap_strategy_file_not_found() {
     let result = MmapStrategy::open("/nonexistent/path/to/file.txt");
@@ -610,6 +636,7 @@ fn mmap_strategy_file_not_found() {
     assert_eq!(result.unwrap_err().kind(), std::io::ErrorKind::NotFound);
 }
 
+#[cfg(unix)]
 #[test]
 fn adaptive_strategy_file_not_found() {
     let result = AdaptiveMapStrategy::open("/nonexistent/path/to/file.txt");
@@ -700,6 +727,7 @@ fn map_ptr_read_extends_past_eof() {
     );
 }
 
+#[cfg(unix)]
 #[test]
 fn mmap_map_ptr_offset_past_eof() {
     let temp = create_test_file(1000);
@@ -726,6 +754,7 @@ fn single_byte_file_buffered() {
     assert_eq!(data, &[42]);
 }
 
+#[cfg(unix)]
 #[test]
 fn single_byte_file_mmap() {
     let mut file = NamedTempFile::new().unwrap();
@@ -809,6 +838,7 @@ fn all_byte_values() {
     assert_eq!(read_data, &data[..]);
 }
 
+#[cfg(unix)]
 #[test]
 fn binary_data_mmap() {
     let mut file = NamedTempFile::new().unwrap();
@@ -846,6 +876,7 @@ fn map_file_with_strategy_buffered() {
     assert_eq!(data, &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
 }
 
+#[cfg(unix)]
 #[test]
 fn map_file_with_strategy_mmap() {
     let temp = create_test_file(1000);
@@ -873,6 +904,7 @@ fn stress_alternating_start_end_reads_buffered() {
     }
 }
 
+#[cfg(unix)]
 #[test]
 fn stress_alternating_start_end_reads_mmap() {
     let size = MAX_MAP_SIZE * 2;
@@ -902,6 +934,7 @@ fn stress_many_window_reloads() {
     }
 }
 
+#[cfg(unix)]
 #[test]
 fn threshold_boundary_one_below() {
     let threshold = 1000u64;
@@ -911,6 +944,7 @@ fn threshold_boundary_one_below() {
     assert!(strategy.is_buffered());
 }
 
+#[cfg(unix)]
 #[test]
 fn threshold_boundary_exactly_at() {
     let threshold = 1000u64;
@@ -920,6 +954,7 @@ fn threshold_boundary_exactly_at() {
     assert!(strategy.is_mmap());
 }
 
+#[cfg(unix)]
 #[test]
 fn threshold_boundary_one_above() {
     let threshold = 1000u64;
@@ -934,6 +969,7 @@ fn default_threshold_value() {
     assert_eq!(MMAP_THRESHOLD, 1024 * 1024);
 }
 
+#[cfg(unix)]
 #[test]
 fn large_file_2mb_mmap_sequential_access() {
     let size = 2 * 1024 * 1024;
@@ -954,6 +990,7 @@ fn large_file_2mb_mmap_sequential_access() {
     }
 }
 
+#[cfg(unix)]
 #[test]
 fn large_file_5mb_mmap_random_access() {
     let size = 5 * 1024 * 1024;
@@ -968,6 +1005,7 @@ fn large_file_5mb_mmap_random_access() {
     }
 }
 
+#[cfg(unix)]
 #[test]
 fn large_file_8mb_adaptive_uses_mmap() {
     let size = 8 * 1024 * 1024;
@@ -978,6 +1016,7 @@ fn large_file_8mb_adaptive_uses_mmap() {
     assert_eq!(map.file_size(), size as u64);
 }
 
+#[cfg(unix)]
 #[test]
 fn large_file_buffered_vs_mmap_correctness() {
     let size = 3 * 1024 * 1024;
@@ -997,6 +1036,7 @@ fn large_file_buffered_vs_mmap_correctness() {
     }
 }
 
+#[cfg(unix)]
 #[test]
 fn large_file_mmap_read_last_page() {
     let size = 4 * 1024 * 1024;
@@ -1009,6 +1049,7 @@ fn large_file_mmap_read_last_page() {
     assert_eq!(data[0], (last_page_offset % 256) as u8);
 }
 
+#[cfg(unix)]
 #[test]
 fn large_file_mmap_strided_access() {
     let size = 2 * 1024 * 1024;
@@ -1029,6 +1070,7 @@ fn large_file_mmap_strided_access() {
     }
 }
 
+#[cfg(unix)]
 #[test]
 fn mmap_send_trait() {
     fn assert_send<T: Send>() {}
@@ -1041,12 +1083,14 @@ fn buffered_send_trait() {
     assert_send::<BufferedMap>();
 }
 
+#[cfg(unix)]
 #[test]
 fn adaptive_send_trait() {
     fn assert_send<T: Send>() {}
     assert_send::<AdaptiveMapStrategy>();
 }
 
+#[cfg(unix)]
 #[test]
 fn multiple_readers_same_file_mmap() {
     let size = 1024 * 1024;
@@ -1085,6 +1129,7 @@ fn multiple_readers_same_file_buffered() {
     assert_eq!(d2[0], ((size / 2) % 256) as u8);
 }
 
+#[cfg(unix)]
 #[test]
 fn mmap_borrowed_slice_lifetime() {
     let temp = create_test_file(1000);
@@ -1109,6 +1154,7 @@ fn buffered_borrowed_slice_lifetime() {
     assert_eq!(data2[0], 100);
 }
 
+#[cfg(unix)]
 #[test]
 fn mmap_slice_bounds_checking() {
     let temp = create_test_file(1000);
@@ -1134,6 +1180,7 @@ fn buffered_slice_bounds_checking() {
     assert!(map.map_ptr(500, 501).is_err());
 }
 
+#[cfg(unix)]
 #[test]
 fn mmap_no_window_sliding_overhead() {
     let size = 2 * 1024 * 1024;
@@ -1162,6 +1209,7 @@ fn buffered_sequential_access_efficiency() {
     }
 }
 
+#[cfg(unix)]
 #[test]
 fn adaptive_switches_at_threshold() {
     let below = MMAP_THRESHOLD - 1;
@@ -1181,6 +1229,7 @@ fn adaptive_switches_at_threshold() {
     assert!(map_above.is_mmap());
 }
 
+#[cfg(unix)]
 #[test]
 fn sparse_access_pattern_mmap() {
     let size = 4 * 1024 * 1024;
@@ -1219,6 +1268,7 @@ fn reverse_sequential_access_buffered() {
     }
 }
 
+#[cfg(unix)]
 #[test]
 fn zigzag_access_pattern() {
     let size = 2 * 1024 * 1024;
@@ -1237,6 +1287,7 @@ fn zigzag_access_pattern() {
     }
 }
 
+#[cfg(unix)]
 #[test]
 fn large_file_exact_page_boundaries() {
     let size = 4 * 1024 * 1024;
@@ -1254,6 +1305,7 @@ fn large_file_exact_page_boundaries() {
     }
 }
 
+#[cfg(unix)]
 #[test]
 fn large_file_unaligned_access_mmap() {
     let size = 2 * 1024 * 1024;
@@ -1267,6 +1319,7 @@ fn large_file_unaligned_access_mmap() {
     }
 }
 
+#[cfg(unix)]
 #[test]
 fn large_file_single_byte_reads_across_file() {
     let size = 1024 * 1024;
@@ -1279,6 +1332,7 @@ fn large_file_single_byte_reads_across_file() {
     }
 }
 
+#[cfg(unix)]
 #[test]
 fn large_file_maximum_single_read_mmap() {
     let size = 2 * 1024 * 1024;
@@ -1291,6 +1345,7 @@ fn large_file_maximum_single_read_mmap() {
     assert_eq!(data[size - 1], ((size - 1) % 256) as u8);
 }
 
+#[cfg(unix)]
 #[test]
 fn map_file_strategy_type_safety() {
     let temp = create_test_file(1000);
@@ -1312,6 +1367,7 @@ fn custom_strategy_with_map_file() {
     assert_eq!(data[0], 0);
 }
 
+#[cfg(unix)]
 #[test]
 fn mmap_after_error_recovery() {
     let temp = create_test_file(1000);
@@ -1336,6 +1392,7 @@ fn buffered_after_error_recovery() {
     assert_eq!(data[0], 0);
 }
 
+#[cfg(unix)]
 #[test]
 fn adaptive_after_error_recovery() {
     let temp = create_test_file(1000);
@@ -1348,6 +1405,7 @@ fn adaptive_after_error_recovery() {
     assert_eq!(data[0], 0);
 }
 
+#[cfg(unix)]
 #[test]
 fn adaptive_strategy_selection_small_file_uses_buffered() {
     let small_size = 512 * 1024;
@@ -1359,6 +1417,7 @@ fn adaptive_strategy_selection_small_file_uses_buffered() {
     assert_eq!(strategy.file_size(), small_size as u64);
 }
 
+#[cfg(unix)]
 #[test]
 fn adaptive_strategy_selection_large_file_uses_mmap() {
     let large_size = 2 * 1024 * 1024;
@@ -1370,6 +1429,7 @@ fn adaptive_strategy_selection_large_file_uses_mmap() {
     assert_eq!(strategy.file_size(), large_size as u64);
 }
 
+#[cfg(unix)]
 #[test]
 fn adaptive_strategy_selection_boundary_below_threshold() {
     let size = (MMAP_THRESHOLD - 1) as usize;
@@ -1382,6 +1442,7 @@ fn adaptive_strategy_selection_boundary_below_threshold() {
     );
 }
 
+#[cfg(unix)]
 #[test]
 fn adaptive_strategy_selection_boundary_exactly_at_threshold() {
     let size = MMAP_THRESHOLD as usize;
@@ -1394,6 +1455,7 @@ fn adaptive_strategy_selection_boundary_exactly_at_threshold() {
     );
 }
 
+#[cfg(unix)]
 #[test]
 fn adaptive_strategy_selection_boundary_above_threshold() {
     let size = (MMAP_THRESHOLD + 1) as usize;
@@ -1406,6 +1468,7 @@ fn adaptive_strategy_selection_boundary_above_threshold() {
     );
 }
 
+#[cfg(unix)]
 #[test]
 fn adaptive_strategy_selection_empty_file_uses_buffered() {
     let temp = create_test_file(0);
@@ -1415,6 +1478,7 @@ fn adaptive_strategy_selection_empty_file_uses_buffered() {
     assert_eq!(strategy.file_size(), 0);
 }
 
+#[cfg(unix)]
 #[test]
 fn adaptive_strategy_selection_tiny_file_uses_buffered() {
     let temp = create_test_file(1);
@@ -1424,6 +1488,7 @@ fn adaptive_strategy_selection_tiny_file_uses_buffered() {
     assert_eq!(strategy.file_size(), 1);
 }
 
+#[cfg(unix)]
 #[test]
 fn adaptive_strategy_selection_custom_threshold_zero() {
     let temp = create_test_file(100);
@@ -1432,6 +1497,7 @@ fn adaptive_strategy_selection_custom_threshold_zero() {
     assert!(strategy.is_mmap());
 }
 
+#[cfg(unix)]
 #[test]
 fn adaptive_strategy_selection_custom_threshold_max() {
     let temp = create_test_file(1000);
@@ -1440,6 +1506,7 @@ fn adaptive_strategy_selection_custom_threshold_max() {
     assert!(strategy.is_buffered());
 }
 
+#[cfg(unix)]
 #[test]
 fn adaptive_strategy_selection_window_size_differs() {
     let small_temp = create_test_file(1000);
@@ -1456,6 +1523,7 @@ fn adaptive_strategy_selection_window_size_differs() {
     );
 }
 
+#[cfg(unix)]
 #[test]
 fn adaptive_strategy_selection_data_consistency() {
     let size = 10000;
@@ -1478,6 +1546,7 @@ fn adaptive_strategy_selection_data_consistency() {
     }
 }
 
+#[cfg(unix)]
 #[test]
 fn adaptive_strategy_selection_map_file_convenience_methods() {
     let small_temp = create_test_file(1000);
@@ -1493,6 +1562,7 @@ fn adaptive_strategy_selection_map_file_convenience_methods() {
     assert!(!large_map.is_buffered());
 }
 
+#[cfg(unix)]
 #[test]
 fn adaptive_strategy_selection_map_file_with_custom_threshold() {
     let temp = create_test_file(500);
@@ -1504,6 +1574,7 @@ fn adaptive_strategy_selection_map_file_with_custom_threshold() {
     assert!(map_high.is_buffered());
 }
 
+#[cfg(unix)]
 #[test]
 fn adaptive_strategy_selection_multiple_threshold_boundaries() {
     let boundaries = [
@@ -1532,6 +1603,7 @@ fn adaptive_strategy_selection_multiple_threshold_boundaries() {
     }
 }
 
+#[cfg(unix)]
 #[test]
 fn adaptive_strategy_selection_read_after_strategy_check() {
     let temp = create_test_file(1000);
@@ -1546,6 +1618,7 @@ fn adaptive_strategy_selection_read_after_strategy_check() {
     }
 }
 
+#[cfg(unix)]
 #[test]
 fn adaptive_strategy_selection_file_size_preserved() {
     let sizes = [
@@ -1570,6 +1643,7 @@ fn adaptive_strategy_selection_file_size_preserved() {
     }
 }
 
+#[cfg(unix)]
 #[test]
 fn mmap_as_slice_full_file() {
     let size = 1024;
@@ -1584,6 +1658,7 @@ fn mmap_as_slice_full_file() {
     }
 }
 
+#[cfg(unix)]
 #[test]
 fn mmap_as_slice_vs_map_ptr() {
     let size = 1000;
@@ -1596,6 +1671,7 @@ fn mmap_as_slice_vs_map_ptr() {
     assert_eq!(slice, &via_map_ptr[..]);
 }
 
+#[cfg(unix)]
 #[test]
 fn mmap_as_slice_empty_file() {
     let temp = create_test_file(0);
@@ -1609,6 +1685,7 @@ fn mmap_as_slice_empty_file() {
 /// adaptive selector would otherwise place on `mmap` (>= MMAP_THRESHOLD).
 /// This is the seam used by `DeltaApplicator` when paired with an io_uring
 /// writer (#1906, audit F1).
+#[cfg(unix)]
 #[test]
 fn adaptive_open_buffered_forces_buffered_for_large_file() {
     // Above MMAP_THRESHOLD (1 MiB) - the adaptive default would pick mmap.
@@ -1625,6 +1702,7 @@ fn adaptive_open_buffered_forces_buffered_for_large_file() {
 
 /// `MapFile::open_adaptive_buffered` is the wrapper-level entry point that
 /// `DeltaApplicator::new` calls when `BasisWriterKind::IoUring` is selected.
+#[cfg(unix)]
 #[test]
 fn map_file_open_adaptive_buffered_is_buffered() {
     let temp = create_test_file((MMAP_THRESHOLD as usize) + 4096);

--- a/tests/integration_sparse.rs
+++ b/tests/integration_sparse.rs
@@ -15,6 +15,7 @@ mod integration;
 
 use integration::helpers::*;
 use std::fs;
+#[cfg(unix)]
 use std::io::{Seek, SeekFrom, Write};
 
 #[cfg(unix)]


### PR DESCRIPTION
## Summary

Closes two P0 beta-blocking CI gaps by adding explicit Windows matrix coverage:

- **windows-iocp** (#1900) - Builds and tests with `--features iocp` on `windows-latest`. The IOCP code path (PRs #1717-#1721) is currently exercised only implicitly via `--all-features`. This job pins the feature so future default-feature changes cannot silently drop iocp coverage. Tests target `fast_io` (owns the IOCP modules) and `transfer` (the consumer).
- **windows-acl-xattr** (#1869) - Builds and tests the `metadata` crate on `windows-latest` with `--features acl,xattr`. The existing `windows-test` job intentionally excludes `metadata`, leaving Windows ACL (Win32 `GetSecurityInfo`/`SetSecurityInfo`) and NTFS Alternate Data Stream paths uncovered by master CI. A second filtered nextest pass uses `-E 'test(acl) | test(xattr) | test(ads) | test(stream)'` against the workspace to catch future tests landing outside `metadata`.

Both jobs depend on `lint`, run on stable, and use the same toolchain/cache pattern as the existing `windows-test` job.

## New jobs

```yaml
windows-iocp:
  name: Windows IOCP (--features iocp)
  runs-on: windows-latest
  needs: lint
  timeout-minutes: 30
  steps:
    - cargo build --locked --workspace --features iocp
    - cargo build --locked -p fast_io --no-default-features --features iocp
    - cargo nextest run --locked -p fast_io --no-default-features --features iocp
    - cargo nextest run --locked -p transfer --all-features

windows-acl-xattr:
  name: Windows ACL/xattr
  runs-on: windows-latest
  needs: lint
  timeout-minutes: 30
  steps:
    - cargo build --locked -p metadata --features acl,xattr
    - cargo nextest run --locked -p metadata --features acl,xattr
    - cargo nextest run --locked --workspace --features acl,xattr -E 'test(acl) | test(xattr) | test(ads) | test(stream)'
```

## Branch protection

Branch protection required-checks may need a manual update so these new jobs block merge. The repository's protected-branch rules currently list:

- fmt + clippy
- nextest (stable)
- Windows (stable)
- macOS (stable)
- Linux musl (stable)

To enforce the new coverage at merge time, add `Windows IOCP (--features iocp)` and `Windows ACL/xattr` to the required-checks list in repo Settings -> Branches -> Branch protection rules. **This PR does not modify branch protection.**

## Test plan

- [ ] CI green on this PR (verifies the new jobs build and pass on `windows-latest`).
- [ ] Confirm `windows-iocp` exercises `crates/fast_io/src/iocp/**` test modules.
- [ ] Confirm `windows-acl-xattr` runs `acl_windows::tests` (DACL round-trip) and `xattr_windows::tests` (NTFS ADS).
- [ ] After merge, manually add the two job names to branch protection required checks if desired.

Refs:
- Closes #1900
- Closes #1869
- IOCP introduction: PRs #1717, #1718, #1719, #1720, #1721
- Windows ACL: PR #1866 (in flight)
- Windows xattr/ADS: PR #1867