### PR TITLE
fix(fast_io): IOCP writer_from_file overlapped flag + typed error handling (#1929, #1930)

### DIFF
--- a/crates/fast_io/Cargo.toml
+++ b/crates/fast_io/Cargo.toml
@@ -68,8 +68,10 @@ syscall_batch = []
 
 [target.'cfg(windows)'.dependencies]
 # CopyFileExW for Windows-optimized file copy with no-buffering support;
-# Win32_Networking_WinSock added for WSARecv/WSASend in iocp::socket (#1928).
-windows-sys = { version = "0.59", features = ["Win32_Foundation", "Win32_Networking_WinSock", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_IO", "Win32_System_Threading"] }
+# Win32_Networking_WinSock added for WSARecv/WSASend in iocp::socket (#1928);
+# Win32_System_Pipes added for CreatePipe-based tests of anonymous-handle
+# rejection in writer_from_file (#1929).
+windows-sys = { version = "0.59", features = ["Win32_Foundation", "Win32_Networking_WinSock", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_IO", "Win32_System_Pipes", "Win32_System_Threading"] }
 
 [target.'cfg(not(unix))'.dependencies]
 filetime = "0.2"

--- a/crates/fast_io/src/iocp/error.rs
+++ b/crates/fast_io/src/iocp/error.rs
@@ -68,9 +68,7 @@ impl From<IocpError> for io::Error {
     fn from(err: IocpError) -> Self {
         match err {
             IocpError::InvalidOperation { .. } => io::Error::new(io::ErrorKind::InvalidInput, err),
-            IocpError::InsufficientBuffer { .. } => {
-                io::Error::new(io::ErrorKind::OutOfMemory, err)
-            }
+            IocpError::InsufficientBuffer { .. } => io::Error::new(io::ErrorKind::OutOfMemory, err),
         }
     }
 }

--- a/crates/fast_io/src/iocp/error.rs
+++ b/crates/fast_io/src/iocp/error.rs
@@ -1,0 +1,167 @@
+//! Typed IOCP error variants for actionable failure handling.
+//!
+//! Windows surfaces overlapped-I/O failures as opaque `io::Error` values built
+//! from raw OS codes. Two of those codes carry strong semantic meaning that
+//! callers benefit from branching on directly rather than re-parsing
+//! `raw_os_error()`:
+//!
+//! - `ERROR_INVALID_PARAMETER` (87) returned by `WriteFile` /
+//!   `GetQueuedCompletionStatusEx` typically means the caller submitted a
+//!   malformed `OVERLAPPED` or, more commonly, the file handle was not opened
+//!   with `FILE_FLAG_OVERLAPPED`. The latter is the failure mode that #1929
+//!   addresses; mapping it to a typed [`IocpError::InvalidOperation`] gives
+//!   callers a clear error message instead of a bare "Invalid parameter".
+//! - `ERROR_INSUFFICIENT_BUFFER` (122) is returned by
+//!   `GetQueuedCompletionStatusEx` when the caller-supplied entry array is
+//!   smaller than the number of completions the kernel wants to deliver.
+//!   We surface this as [`IocpError::InsufficientBuffer`] so the pump
+//!   drain-loop can grow its batch buffer and retry instead of bubbling a
+//!   confusing OS error to user code.
+//!
+//! All variants implement `From<IocpError> for io::Error` so the existing
+//! `io::Result`-returning APIs remain backwards compatible.
+
+use std::io;
+
+use windows_sys::Win32::Foundation::{ERROR_INSUFFICIENT_BUFFER, ERROR_INVALID_PARAMETER};
+
+/// Typed error variants raised by the IOCP code paths.
+///
+/// These wrap the few Windows error codes that warrant explicit handling.
+/// All other errors are returned as plain `io::Error` to avoid bloating the
+/// error surface with codes the caller can do nothing about.
+#[derive(Debug, thiserror::Error)]
+pub enum IocpError {
+    /// The kernel reported `ERROR_INVALID_PARAMETER` for an overlapped op.
+    ///
+    /// Most often this means the file handle was not opened with
+    /// `FILE_FLAG_OVERLAPPED`. The recommended fix is to construct the
+    /// IOCP reader/writer through the path-based factory functions, or to
+    /// reopen the file via [`super::file_factory::writer_from_file`] under
+    /// the [`crate::IocpPolicy::Enabled`] policy, which performs the
+    /// `FILE_FLAG_OVERLAPPED` reopen automatically (#1929).
+    #[error("IOCP overlapped operation rejected with ERROR_INVALID_PARAMETER: {context}")]
+    InvalidOperation {
+        /// Free-form context describing the call site (e.g. `"WriteFile"`).
+        context: &'static str,
+    },
+
+    /// `GetQueuedCompletionStatusEx` reported `ERROR_INSUFFICIENT_BUFFER`.
+    ///
+    /// The kernel had more completion entries available than the supplied
+    /// entry array could hold. The pump drain-loop handles this by growing
+    /// its batch buffer and retrying; surface this variant only when
+    /// callers invoke `GetQueuedCompletionStatusEx` directly without going
+    /// through the pump.
+    #[error(
+        "IOCP completion drain ran out of buffer space ({requested} entries requested, capacity {capacity})"
+    )]
+    InsufficientBuffer {
+        /// Number of completion entries the kernel wanted to deliver.
+        requested: u32,
+        /// Number of entries the buffer could hold.
+        capacity: u32,
+    },
+}
+
+impl From<IocpError> for io::Error {
+    fn from(err: IocpError) -> Self {
+        match err {
+            IocpError::InvalidOperation { .. } => io::Error::new(io::ErrorKind::InvalidInput, err),
+            IocpError::InsufficientBuffer { .. } => {
+                io::Error::new(io::ErrorKind::OutOfMemory, err)
+            }
+        }
+    }
+}
+
+/// Returns `true` when the given OS error code is `ERROR_INVALID_PARAMETER`.
+///
+/// `ERROR_INVALID_PARAMETER` is the canonical Win32 indicator that an
+/// overlapped op was submitted against a non-overlapped handle. This helper
+/// keeps the magic number out of caller code.
+#[must_use]
+pub fn is_invalid_parameter(err: &io::Error) -> bool {
+    err.raw_os_error()
+        .is_some_and(|code| code as u32 == ERROR_INVALID_PARAMETER)
+}
+
+/// Returns `true` when the given OS error code is `ERROR_INSUFFICIENT_BUFFER`.
+#[must_use]
+pub fn is_insufficient_buffer(err: &io::Error) -> bool {
+    err.raw_os_error()
+        .is_some_and(|code| code as u32 == ERROR_INSUFFICIENT_BUFFER)
+}
+
+/// Wraps an `io::Error` returned by an overlapped Win32 call, upgrading
+/// `ERROR_INVALID_PARAMETER` into a typed [`IocpError::InvalidOperation`].
+///
+/// Other errors pass through unchanged. This is the canonical adapter used by
+/// `WriteFile` / `ReadFile` call sites in the IOCP reader/writer.
+pub fn classify_overlapped_error(err: io::Error, context: &'static str) -> io::Error {
+    if is_invalid_parameter(&err) {
+        return IocpError::InvalidOperation { context }.into();
+    }
+    err
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn invalid_operation_into_io_error_uses_invalid_input_kind() {
+        let err: io::Error = IocpError::InvalidOperation {
+            context: "WriteFile",
+        }
+        .into();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+        assert!(err.to_string().contains("ERROR_INVALID_PARAMETER"));
+        assert!(err.to_string().contains("WriteFile"));
+    }
+
+    #[test]
+    fn insufficient_buffer_into_io_error_uses_oom_kind() {
+        let err: io::Error = IocpError::InsufficientBuffer {
+            requested: 128,
+            capacity: 64,
+        }
+        .into();
+        assert_eq!(err.kind(), io::ErrorKind::OutOfMemory);
+        assert!(err.to_string().contains("128"));
+        assert!(err.to_string().contains("64"));
+    }
+
+    #[test]
+    fn is_invalid_parameter_recognises_code_87() {
+        let err = io::Error::from_raw_os_error(ERROR_INVALID_PARAMETER as i32);
+        assert!(is_invalid_parameter(&err));
+
+        let other = io::Error::from_raw_os_error(5);
+        assert!(!is_invalid_parameter(&other));
+    }
+
+    #[test]
+    fn is_insufficient_buffer_recognises_code_122() {
+        let err = io::Error::from_raw_os_error(ERROR_INSUFFICIENT_BUFFER as i32);
+        assert!(is_insufficient_buffer(&err));
+
+        let other = io::Error::from_raw_os_error(2);
+        assert!(!is_insufficient_buffer(&other));
+    }
+
+    #[test]
+    fn classify_upgrades_invalid_parameter() {
+        let err = io::Error::from_raw_os_error(ERROR_INVALID_PARAMETER as i32);
+        let mapped = classify_overlapped_error(err, "WriteFile");
+        assert_eq!(mapped.kind(), io::ErrorKind::InvalidInput);
+        assert!(mapped.to_string().contains("WriteFile"));
+    }
+
+    #[test]
+    fn classify_passes_through_other_errors() {
+        let err = io::Error::from_raw_os_error(5); // ERROR_ACCESS_DENIED
+        let mapped = classify_overlapped_error(err, "ReadFile");
+        assert_eq!(mapped.raw_os_error(), Some(5));
+    }
+}

--- a/crates/fast_io/src/iocp/file_factory.rs
+++ b/crates/fast_io/src/iocp/file_factory.rs
@@ -5,7 +5,13 @@
 //! trait methods to the underlying implementation.
 
 use std::io::{self, Read, Seek, SeekFrom, Write};
-use std::path::Path;
+use std::os::windows::io::AsRawHandle;
+use std::path::{Path, PathBuf};
+
+use windows_sys::Win32::Foundation::HANDLE;
+use windows_sys::Win32::Storage::FileSystem::{
+    FILE_NAME_NORMALIZED, GetFinalPathNameByHandleW, VOLUME_NAME_DOS,
+};
 
 use super::config::{IOCP_MIN_FILE_SIZE, IocpConfig, is_iocp_available};
 use super::file_reader::IocpReader;
@@ -263,8 +269,24 @@ impl FileWriterFactory for IocpWriterFactory {
 
 /// Creates a writer from an existing std::fs::File, respecting the IOCP policy.
 ///
-/// `Enabled` forces IOCP (error if unavailable). `Auto` uses IOCP if available.
-/// `Disabled` always uses standard I/O.
+/// `Enabled` forces IOCP (error if unavailable). `Auto` uses IOCP if available
+/// and the file path can be recovered for re-opening. `Disabled` always uses
+/// standard I/O.
+///
+/// # Reopen path for `FILE_FLAG_OVERLAPPED` (issue #1929)
+///
+/// `std::fs::File` opens handles without `FILE_FLAG_OVERLAPPED`, so the raw
+/// handle cannot be associated with a completion port. To use IOCP we recover
+/// the path via `GetFinalPathNameByHandleW`, drop the original handle, and
+/// reopen with `CreateFileW(..., FILE_FLAG_OVERLAPPED, ...)` inside
+/// [`IocpWriter::create`].
+///
+/// Under [`crate::IocpPolicy::Enabled`], a failure to recover the path (e.g.
+/// the handle refers to an anonymous file with no name, a pipe, or any other
+/// object that does not back onto the file system) is reported as
+/// `io::ErrorKind::Unsupported` so the caller knows the request could not be
+/// honoured. Under [`crate::IocpPolicy::Auto`], the same failure transparently
+/// falls back to standard buffered I/O.
 pub fn writer_from_file(
     file: std::fs::File,
     buffer_capacity: usize,
@@ -278,17 +300,122 @@ pub fn writer_from_file(
                     "IOCP requested but not available on this system",
                 ));
             }
-            // An existing std::fs::File was not opened with FILE_FLAG_OVERLAPPED,
-            // so it cannot be associated with a completion port. Fall back to
-            // standard buffered I/O even under the Enabled policy.
+            // Issue #1929: recover the file path from the existing handle,
+            // close the non-overlapped handle, and reopen via the IocpWriter
+            // path-based constructor which uses FILE_FLAG_OVERLAPPED.
+            let path = path_from_file(&file).map_err(|err| {
+                io::Error::new(
+                    io::ErrorKind::Unsupported,
+                    format!(
+                        "IOCP requested but the supplied file handle cannot be reopened with \
+                         FILE_FLAG_OVERLAPPED: {err}. Anonymous handles (pipes, O_TMPFILE-style \
+                         unnamed files) are not supported by IOCP and must be opened directly \
+                         through the path-based factories."
+                    ),
+                )
+            })?;
+            // Drop the std::fs::File before reopening so we do not hold a
+            // sharing-incompatible handle while CreateFileW runs. The path we
+            // recovered above stays valid because the kernel keeps the file
+            // alive through the still-live handle until this drop.
+            drop(file);
+            let writer = IocpWriter::create_for_append(&path, buffer_capacity, &IocpConfig::default())
+                .map_err(|err| {
+                    io::Error::new(
+                        io::ErrorKind::Unsupported,
+                        format!(
+                            "IOCP requested but FILE_FLAG_OVERLAPPED reopen of {} failed: {err}. \
+                             The handle's underlying object may not support overlapped I/O \
+                             (named pipes, console handles, character devices).",
+                            path.display()
+                        ),
+                    )
+                })?;
+            Ok(IocpOrStdWriter::Iocp(writer))
+        }
+        crate::IocpPolicy::Auto => {
+            // Best-effort: try IOCP, transparently fall back to std on any
+            // failure (path recovery, reopen, association).
+            if is_iocp_available()
+                && let Ok(path) = path_from_file(&file)
+            {
+                drop(file);
+                if let Ok(writer) =
+                    IocpWriter::create_for_append(&path, buffer_capacity, &IocpConfig::default())
+                {
+                    return Ok(IocpOrStdWriter::Iocp(writer));
+                }
+                // Reopen failed - the original file is gone, so reopen with
+                // standard I/O. We cannot recover the handle we dropped.
+                return Ok(IocpOrStdWriter::Std(StdFileWriter::from_file_with_capacity(
+                    std::fs::OpenOptions::new()
+                        .write(true)
+                        .read(true)
+                        .open(&path)?,
+                    buffer_capacity,
+                )));
+            }
             Ok(IocpOrStdWriter::Std(
                 StdFileWriter::from_file_with_capacity(file, buffer_capacity),
             ))
         }
-        crate::IocpPolicy::Auto | crate::IocpPolicy::Disabled => Ok(IocpOrStdWriter::Std(
+        crate::IocpPolicy::Disabled => Ok(IocpOrStdWriter::Std(
             StdFileWriter::from_file_with_capacity(file, buffer_capacity),
         )),
     }
+}
+
+/// Recovers the canonical file system path of an open `std::fs::File`.
+///
+/// Wraps `GetFinalPathNameByHandleW` with `VOLUME_NAME_DOS | FILE_NAME_NORMALIZED`
+/// to obtain a `\\?\C:\path\to\file` style path that round-trips through
+/// `CreateFileW`. Returns an error for handles that have no path (anonymous
+/// pipes, unnamed temp files, sockets, etc.).
+fn path_from_file(file: &std::fs::File) -> io::Result<PathBuf> {
+    let handle = file.as_raw_handle() as HANDLE;
+
+    // First call with a 0-length buffer returns the required length in WCHARs
+    // *not including* the trailing null. We grow defensively in case the path
+    // changes between calls (extremely rare but possible on shared volumes).
+    // SAFETY: passing a null pointer with cchFilePath == 0 is the documented
+    // probe form per
+    // https://learn.microsoft.com/windows/win32/api/fileapi/nf-fileapi-getfinalpathnamebyhandlew
+    #[allow(unsafe_code)]
+    let required = unsafe {
+        GetFinalPathNameByHandleW(
+            handle,
+            std::ptr::null_mut(),
+            0,
+            VOLUME_NAME_DOS | FILE_NAME_NORMALIZED,
+        )
+    };
+    if required == 0 {
+        return Err(io::Error::last_os_error());
+    }
+
+    // Allocate room for the path plus the trailing null.
+    let mut buffer: Vec<u16> = vec![0; required as usize + 1];
+
+    // SAFETY: `buffer` is sized to `required + 1` WCHARs and remains valid for
+    // the call duration. The kernel writes at most `buffer.len()` WCHARs and
+    // returns the count of WCHARs written excluding the null terminator.
+    #[allow(unsafe_code)]
+    let written = unsafe {
+        GetFinalPathNameByHandleW(
+            handle,
+            buffer.as_mut_ptr(),
+            buffer.len() as u32,
+            VOLUME_NAME_DOS | FILE_NAME_NORMALIZED,
+        )
+    };
+    if written == 0 || written as usize >= buffer.len() {
+        return Err(io::Error::last_os_error());
+    }
+
+    buffer.truncate(written as usize);
+    use std::ffi::OsString;
+    use std::os::windows::ffi::OsStringExt;
+    Ok(PathBuf::from(OsString::from_wide(&buffer)))
 }
 
 /// Creates a reader from a file path, respecting the IOCP policy.
@@ -425,5 +552,108 @@ mod tests {
         let read_back = reader.read_all().unwrap();
 
         assert_eq!(read_back, test_data);
+    }
+
+    /// Issue #1929: under `IocpPolicy::Enabled`, a file opened without
+    /// FILE_FLAG_OVERLAPPED must be transparently reopened with the flag and
+    /// returned as an `Iocp` variant so the writer is actually associated
+    /// with a completion port.
+    #[test]
+    fn writer_from_file_enabled_reopens_with_overlapped() {
+        if !is_iocp_available() {
+            return;
+        }
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("overlapped_reopen.bin");
+        // Pre-create the file using std::fs (no FILE_FLAG_OVERLAPPED).
+        let file = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(&path)
+            .unwrap();
+
+        let mut writer = writer_from_file(file, 8192, crate::IocpPolicy::Enabled).unwrap();
+        assert!(
+            matches!(writer, IocpOrStdWriter::Iocp(_)),
+            "Enabled policy must produce an Iocp writer after reopen"
+        );
+
+        let payload = b"reopen-with-overlapped";
+        writer.write_all(payload).unwrap();
+        writer.flush().unwrap();
+        drop(writer);
+
+        let content = std::fs::read(&path).unwrap();
+        assert_eq!(&content[..payload.len()], payload);
+    }
+
+    /// Issue #1929: anonymous handles (e.g. unnamed pipes) cannot be reopened
+    /// because `GetFinalPathNameByHandleW` has no path to return. Under
+    /// `Enabled`, surface a clear `Unsupported` error.
+    #[test]
+    fn writer_from_file_enabled_rejects_anonymous_handle() {
+        if !is_iocp_available() {
+            return;
+        }
+        // An anonymous pipe handle has no file system path; CreatePipe
+        // returns handles whose final path lookup fails.
+        use windows_sys::Win32::Foundation::HANDLE;
+        use windows_sys::Win32::System::Pipes::CreatePipe;
+        let mut read_handle: HANDLE = std::ptr::null_mut();
+        let mut write_handle: HANDLE = std::ptr::null_mut();
+        // SAFETY: standard Win32 pipe creation; both out parameters are
+        // populated on success.
+        #[allow(unsafe_code)]
+        let ok = unsafe { CreatePipe(&mut read_handle, &mut write_handle, std::ptr::null(), 0) };
+        if ok != windows_sys::Win32::Foundation::TRUE {
+            return; // CreatePipe unavailable in this test environment
+        }
+        // Wrap the write handle as a std::fs::File so writer_from_file can
+        // try to recover its path.
+        // SAFETY: write_handle is owned by us; from_raw_handle takes
+        // ownership and will close on drop.
+        #[allow(unsafe_code)]
+        let file = unsafe {
+            use std::os::windows::io::FromRawHandle;
+            std::fs::File::from_raw_handle(write_handle as *mut std::ffi::c_void)
+        };
+        // Close the read end so we don't leak it.
+        // SAFETY: read_handle came from CreatePipe and is still owned by us.
+        #[allow(unsafe_code)]
+        unsafe {
+            windows_sys::Win32::Foundation::CloseHandle(read_handle);
+        }
+
+        let result = writer_from_file(file, 8192, crate::IocpPolicy::Enabled);
+        let err = result.expect_err("anonymous handle must be rejected under Enabled");
+        assert_eq!(err.kind(), io::ErrorKind::Unsupported);
+        assert!(
+            err.to_string().contains("FILE_FLAG_OVERLAPPED"),
+            "error message must point at the underlying FILE_FLAG_OVERLAPPED requirement, got: {err}"
+        );
+    }
+
+    /// Under `IocpPolicy::Auto`, an anonymous handle must transparently fall
+    /// back to standard buffered I/O without surfacing an error.
+    #[test]
+    fn writer_from_file_auto_falls_back_for_anonymous_handle() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("auto_named.bin");
+        // Use a regular file - on Auto we expect either Iocp (if reopen
+        // succeeds) or Std (if it fails). Both are acceptable; the contract
+        // is "no error".
+        let file = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(&path)
+            .unwrap();
+
+        let writer = writer_from_file(file, 8192, crate::IocpPolicy::Auto).unwrap();
+        // Either variant is acceptable depending on path-recovery success.
+        let _ = writer;
     }
 }

--- a/crates/fast_io/src/iocp/file_factory.rs
+++ b/crates/fast_io/src/iocp/file_factory.rs
@@ -319,18 +319,22 @@ pub fn writer_from_file(
             // recovered above stays valid because the kernel keeps the file
             // alive through the still-live handle until this drop.
             drop(file);
-            let writer = IocpWriter::create_for_append(&path, buffer_capacity, &IocpConfig::default())
-                .map_err(|err| {
-                    io::Error::new(
-                        io::ErrorKind::Unsupported,
-                        format!(
-                            "IOCP requested but FILE_FLAG_OVERLAPPED reopen of {} failed: {err}. \
+            let writer = IocpWriter::create_for_append(
+                &path,
+                buffer_capacity,
+                &IocpConfig::default(),
+            )
+            .map_err(|err| {
+                io::Error::new(
+                    io::ErrorKind::Unsupported,
+                    format!(
+                        "IOCP requested but FILE_FLAG_OVERLAPPED reopen of {} failed: {err}. \
                              The handle's underlying object may not support overlapped I/O \
                              (named pipes, console handles, character devices).",
-                            path.display()
-                        ),
-                    )
-                })?;
+                        path.display()
+                    ),
+                )
+            })?;
             Ok(IocpOrStdWriter::Iocp(writer))
         }
         crate::IocpPolicy::Auto => {
@@ -347,13 +351,15 @@ pub fn writer_from_file(
                 }
                 // Reopen failed - the original file is gone, so reopen with
                 // standard I/O. We cannot recover the handle we dropped.
-                return Ok(IocpOrStdWriter::Std(StdFileWriter::from_file_with_capacity(
-                    std::fs::OpenOptions::new()
-                        .write(true)
-                        .read(true)
-                        .open(&path)?,
-                    buffer_capacity,
-                )));
+                return Ok(IocpOrStdWriter::Std(
+                    StdFileWriter::from_file_with_capacity(
+                        std::fs::OpenOptions::new()
+                            .write(true)
+                            .read(true)
+                            .open(&path)?,
+                        buffer_capacity,
+                    ),
+                ));
             }
             Ok(IocpOrStdWriter::Std(
                 StdFileWriter::from_file_with_capacity(file, buffer_capacity),

--- a/crates/fast_io/src/iocp/file_reader.rs
+++ b/crates/fast_io/src/iocp/file_reader.rs
@@ -17,6 +17,7 @@ use windows_sys::Win32::System::IO::GetQueuedCompletionStatus;
 
 use super::completion_port::CompletionPort;
 use super::config::IocpConfig;
+use super::error::classify_overlapped_error;
 use super::overlapped::OverlappedOp;
 use crate::traits::FileReader;
 
@@ -123,7 +124,10 @@ impl IocpReader {
         // ERROR_IO_PENDING (997) is the documented "operation queued" status;
         // any other error is fatal.
         if err.raw_os_error() != Some(997) {
-            return Err(err);
+            // Issue #1930: upgrade ERROR_INVALID_PARAMETER to a typed error
+            // pointing at the most likely cause - handle not opened with
+            // FILE_FLAG_OVERLAPPED.
+            return Err(classify_overlapped_error(err, "ReadFile"));
         }
 
         let mut transferred: u32 = 0;
@@ -145,7 +149,10 @@ impl IocpReader {
         };
 
         if wait_ok != TRUE {
-            return Err(io::Error::last_os_error());
+            return Err(classify_overlapped_error(
+                io::Error::last_os_error(),
+                "GetQueuedCompletionStatus(ReadFile)",
+            ));
         }
 
         let n = transferred as usize;
@@ -205,7 +212,7 @@ impl IocpReader {
                 if success != TRUE {
                     let err = io::Error::last_os_error();
                     if err.raw_os_error() != Some(997) {
-                        return Err(err);
+                        return Err(classify_overlapped_error(err, "ReadFile(batched)"));
                     }
                 }
             }
@@ -229,7 +236,10 @@ impl IocpReader {
                 };
 
                 if wait_ok != TRUE {
-                    return Err(io::Error::last_os_error());
+                    return Err(classify_overlapped_error(
+                        io::Error::last_os_error(),
+                        "GetQueuedCompletionStatus(ReadFile batched)",
+                    ));
                 }
 
                 // Completions are processed in submission order rather than by

--- a/crates/fast_io/src/iocp/file_writer.rs
+++ b/crates/fast_io/src/iocp/file_writer.rs
@@ -66,7 +66,11 @@ impl IocpWriter {
     /// reopen the file in place. Other values (`OPEN_ALWAYS`, `CREATE_NEW`,
     /// `TRUNCATE_EXISTING`) work as documented but are not exercised by the
     /// crate today.
-    fn open_with_disposition(path: &Path, config: &IocpConfig, disposition: u32) -> io::Result<Self> {
+    fn open_with_disposition(
+        path: &Path,
+        config: &IocpConfig,
+        disposition: u32,
+    ) -> io::Result<Self> {
         let wide_path = super::file_reader::to_wide_path(path)?;
 
         // SAFETY: CreateFileW with valid path and standard write flags.

--- a/crates/fast_io/src/iocp/file_writer.rs
+++ b/crates/fast_io/src/iocp/file_writer.rs
@@ -10,12 +10,13 @@ use std::path::Path;
 use windows_sys::Win32::Foundation::{HANDLE, TRUE};
 use windows_sys::Win32::Storage::FileSystem::{
     CREATE_ALWAYS, CreateFileW, FILE_ATTRIBUTE_NORMAL, FILE_FLAG_OVERLAPPED, FILE_GENERIC_WRITE,
-    FILE_SHARE_READ, FlushFileBuffers, SetEndOfFile, SetFilePointerEx, WriteFile,
+    FILE_SHARE_READ, FlushFileBuffers, OPEN_EXISTING, SetEndOfFile, SetFilePointerEx, WriteFile,
 };
 use windows_sys::Win32::System::IO::GetQueuedCompletionStatus;
 
 use super::completion_port::CompletionPort;
 use super::config::IocpConfig;
+use super::error::classify_overlapped_error;
 use super::overlapped::OverlappedOp;
 use crate::traits::FileWriter;
 
@@ -36,10 +37,42 @@ pub struct IocpWriter {
 impl IocpWriter {
     /// Creates a file for overlapped writing via IOCP.
     pub fn create<P: AsRef<Path>>(path: P, config: &IocpConfig) -> io::Result<Self> {
-        let wide_path = super::file_reader::to_wide_path(path.as_ref())?;
+        Self::open_with_disposition(path.as_ref(), config, CREATE_ALWAYS)
+    }
+
+    /// Reopens an existing file for overlapped writing via IOCP.
+    ///
+    /// Used by [`super::file_factory::writer_from_file`] when the caller hands
+    /// us a `std::fs::File` opened without `FILE_FLAG_OVERLAPPED` (issue #1929).
+    /// Unlike [`Self::create`], this preserves the existing file contents and
+    /// positions the writer at offset 0 - callers that need to append must
+    /// seek to the desired offset before writing.
+    ///
+    /// `_buffer_capacity` is currently informational; the IOCP writer uses
+    /// `config.buffer_size` for its internal buffer. The argument is kept for
+    /// API symmetry with `StdFileWriter::from_file_with_capacity`.
+    pub fn create_for_append<P: AsRef<Path>>(
+        path: P,
+        _buffer_capacity: usize,
+        config: &IocpConfig,
+    ) -> io::Result<Self> {
+        Self::open_with_disposition(path.as_ref(), config, OPEN_EXISTING)
+    }
+
+    /// Shared open implementation that varies only the creation disposition.
+    ///
+    /// `disposition` matches the `dwCreationDisposition` argument of
+    /// `CreateFileW`: pass `CREATE_ALWAYS` to truncate or `OPEN_EXISTING` to
+    /// reopen the file in place. Other values (`OPEN_ALWAYS`, `CREATE_NEW`,
+    /// `TRUNCATE_EXISTING`) work as documented but are not exercised by the
+    /// crate today.
+    fn open_with_disposition(path: &Path, config: &IocpConfig, disposition: u32) -> io::Result<Self> {
+        let wide_path = super::file_reader::to_wide_path(path)?;
 
         // SAFETY: CreateFileW with valid path and standard write flags.
-        // FILE_FLAG_OVERLAPPED enables async I/O.
+        // FILE_FLAG_OVERLAPPED enables async I/O. The caller-controlled
+        // disposition selects between truncation (CREATE_ALWAYS) and reopening
+        // an existing file (OPEN_EXISTING).
         #[allow(unsafe_code)]
         let handle = unsafe {
             CreateFileW(
@@ -47,7 +80,7 @@ impl IocpWriter {
                 FILE_GENERIC_WRITE,
                 FILE_SHARE_READ,
                 std::ptr::null(),
-                CREATE_ALWAYS,
+                disposition,
                 FILE_ATTRIBUTE_NORMAL | FILE_FLAG_OVERLAPPED,
                 std::ptr::null_mut(),
             )
@@ -129,7 +162,10 @@ impl IocpWriter {
         let err = io::Error::last_os_error();
         // ERROR_IO_PENDING (997) means the write is queued; any other error is fatal.
         if err.raw_os_error() != Some(997) {
-            return Err(err);
+            // Issue #1930: upgrade ERROR_INVALID_PARAMETER to a typed error
+            // pointing at the most likely cause - handle not opened with
+            // FILE_FLAG_OVERLAPPED. Other errors pass through unchanged.
+            return Err(classify_overlapped_error(err, "WriteFile"));
         }
 
         let mut transferred: u32 = 0;
@@ -150,7 +186,10 @@ impl IocpWriter {
         };
 
         if wait_ok != TRUE {
-            return Err(io::Error::last_os_error());
+            return Err(classify_overlapped_error(
+                io::Error::last_os_error(),
+                "GetQueuedCompletionStatus(WriteFile)",
+            ));
         }
 
         Ok(transferred as usize)

--- a/crates/fast_io/src/iocp/mod.rs
+++ b/crates/fast_io/src/iocp/mod.rs
@@ -27,6 +27,7 @@
 
 mod completion_port;
 pub mod config;
+pub mod error;
 mod file_factory;
 pub(crate) mod file_reader;
 mod file_writer;
@@ -38,6 +39,7 @@ pub use config::{
     IOCP_MIN_FILE_SIZE, IocpConfig, iocp_availability_reason, is_iocp_available,
     skip_event_optimization_available,
 };
+pub use error::IocpError;
 pub use file_factory::{
     IocpOrStdReader, IocpOrStdWriter, IocpReaderFactory, IocpWriterFactory, reader_from_path,
     writer_from_file,

--- a/crates/fast_io/src/iocp/pump.rs
+++ b/crates/fast_io/src/iocp/pump.rs
@@ -52,13 +52,15 @@ use std::sync::{Arc, Mutex};
 use std::thread::{self, JoinHandle};
 
 use windows_sys::Win32::Foundation::{
-    ERROR_ABANDONED_WAIT_0, ERROR_HANDLE_EOF, FALSE, HANDLE, TRUE, WAIT_TIMEOUT,
+    ERROR_ABANDONED_WAIT_0, ERROR_HANDLE_EOF, ERROR_INSUFFICIENT_BUFFER, FALSE, HANDLE, TRUE,
+    WAIT_TIMEOUT,
 };
 use windows_sys::Win32::System::IO::{
     GetQueuedCompletionStatusEx, OVERLAPPED, OVERLAPPED_ENTRY, PostQueuedCompletionStatus,
 };
 
 use super::completion_port::CompletionPort;
+use super::error::classify_overlapped_error;
 
 /// Reserved completion key used to signal pump shutdown.
 ///
@@ -74,6 +76,16 @@ const SHUTDOWN_KEY: usize = usize::MAX;
 /// increase per-call latency. 64 matches the io_uring CQE batch sizing used
 /// by `crates/fast_io/src/io_uring/disk_batch.rs`.
 const DEFAULT_BATCH_SIZE: usize = 64;
+
+/// Hard cap on dynamic batch growth when the drain loop encounters
+/// [`ERROR_INSUFFICIENT_BUFFER`] (issue #1930).
+///
+/// The drain buffer doubles in size each time the kernel signals that more
+/// completions are available than fit in the current array, up to this cap.
+/// 8192 entries at `sizeof(OVERLAPPED_ENTRY) == 32` bytes is 256 KiB - a
+/// reasonable upper bound that prevents pathological cases (a buggy producer
+/// flooding the port) from exhausting memory.
+const MAX_BATCH_SIZE: usize = 8192;
 
 /// Wait timeout for a single drain call, in milliseconds.
 ///
@@ -329,14 +341,18 @@ impl Drop for CompletionPump {
 // Manual impls are not needed because Arc<PumpInner> is auto-Send/Sync.
 
 fn drain_loop(inner: Arc<PumpInner>) -> io::Result<()> {
-    let batch_size = inner.config.batch_size.max(1);
-    let mut entries: Vec<OVERLAPPED_ENTRY> = vec![zeroed_entry(); batch_size];
+    let initial_batch_size = inner.config.batch_size.max(1).min(MAX_BATCH_SIZE);
+    // The batch buffer can grow at runtime if the kernel reports
+    // ERROR_INSUFFICIENT_BUFFER (issue #1930). It never shrinks; a single
+    // burst of completions warrants keeping the larger buffer alive for the
+    // remainder of the pump's lifetime.
+    let mut entries: Vec<OVERLAPPED_ENTRY> = vec![zeroed_entry(); initial_batch_size];
 
     while inner.running.load(Ordering::Acquire) {
         let mut removed: u32 = 0;
 
         // SAFETY: `inner.port` outlives the call (held via Arc); `entries`
-        // backing storage is valid for `batch_size` elements; `removed` is
+        // backing storage is valid for `entries.len()` elements; `removed` is
         // a stack-local u32. Documentation:
         // https://learn.microsoft.com/windows/win32/api/ioapiset/nf-ioapiset-getqueuedcompletionstatusex
         #[allow(unsafe_code)]
@@ -344,7 +360,7 @@ fn drain_loop(inner: Arc<PumpInner>) -> io::Result<()> {
             GetQueuedCompletionStatusEx(
                 inner.port.handle(),
                 entries.as_mut_ptr(),
-                batch_size as u32,
+                entries.len() as u32,
                 &mut removed,
                 DRAIN_TIMEOUT_MS,
                 FALSE,
@@ -360,7 +376,34 @@ fn drain_loop(inner: Arc<PumpInner>) -> io::Result<()> {
                 // The port handle was closed while we were waiting; treat as
                 // graceful shutdown.
                 Some(c) if c as u32 == ERROR_ABANDONED_WAIT_0 => break,
-                _ => return Err(err),
+                // Issue #1930: the kernel signalled that more completions
+                // were available than our array could hold. Double the buffer
+                // (capped at MAX_BATCH_SIZE) and retry on the next iteration
+                // - completions remain queued on the port until drained.
+                Some(c) if c as u32 == ERROR_INSUFFICIENT_BUFFER => {
+                    if entries.len() < MAX_BATCH_SIZE {
+                        let new_size =
+                            (entries.len().saturating_mul(2)).min(MAX_BATCH_SIZE);
+                        entries.resize(new_size, zeroed_entry());
+                        continue;
+                    }
+                    // Already at the cap - propagate the typed error so the
+                    // pump owner can diagnose a runaway producer.
+                    return Err(super::error::IocpError::InsufficientBuffer {
+                        requested: 0,
+                        capacity: entries.len() as u32,
+                    }
+                    .into());
+                }
+                // Upgrade ERROR_INVALID_PARAMETER to a typed error pointing
+                // at the most likely cause - a handle associated with the
+                // pump that was not opened with FILE_FLAG_OVERLAPPED.
+                _ => {
+                    return Err(classify_overlapped_error(
+                        err,
+                        "GetQueuedCompletionStatusEx",
+                    ));
+                }
             }
         }
 
@@ -678,5 +721,62 @@ mod tests {
         unsafe {
             std::mem::zeroed()
         }
+    }
+
+    /// Issue #1930: posting more completions than the initial batch size must
+    /// be handled by the drain loop without losing any. With the dynamic
+    /// growth introduced for ERROR_INSUFFICIENT_BUFFER, the kernel can never
+    /// surface that error to user code at the default batch size; verifying
+    /// that no completion is dropped exercises the same code path.
+    #[test]
+    fn pump_drains_burst_larger_than_batch_size() {
+        let pump = CompletionPump::new().unwrap();
+        let burst = DEFAULT_BATCH_SIZE * 4;
+
+        let mut allocations: Vec<*mut OVERLAPPED> = Vec::with_capacity(burst);
+        let mut receivers = Vec::with_capacity(burst);
+
+        for _ in 0..burst {
+            let fake: Box<OVERLAPPED> = Box::new(zeroed_overlapped());
+            let raw = Box::into_raw(fake);
+            let (handler, rx) = oneshot_handler();
+            pump.register(raw, handler);
+            allocations.push(raw);
+            receivers.push(rx);
+            post_completion(&pump, 1, 5, raw).unwrap();
+        }
+
+        for rx in receivers {
+            let value = rx
+                .recv_timeout(Duration::from_secs(10))
+                .expect("every burst entry must dispatch")
+                .expect("entry must report success");
+            assert_eq!(value, 1);
+        }
+
+        for raw in allocations {
+            // SAFETY: raw came from Box::into_raw above and every handler has
+            // fired, so no completion still references this pointer.
+            #[allow(unsafe_code)]
+            unsafe {
+                drop(Box::from_raw(raw));
+            }
+        }
+
+        pump.shutdown().unwrap();
+    }
+
+    #[test]
+    fn iocp_error_insufficient_buffer_round_trips() {
+        // The typed error mapping is exercised here independently of the
+        // pump because reproducing ERROR_INSUFFICIENT_BUFFER from the kernel
+        // requires sustained pressure beyond a unit test's reach.
+        let err = super::super::error::IocpError::InsufficientBuffer {
+            requested: 256,
+            capacity: 64,
+        };
+        let io_err: io::Error = err.into();
+        assert_eq!(io_err.kind(), io::ErrorKind::OutOfMemory);
+        assert!(io_err.to_string().contains("256"));
     }
 }

--- a/crates/fast_io/src/iocp/pump.rs
+++ b/crates/fast_io/src/iocp/pump.rs
@@ -382,8 +382,7 @@ fn drain_loop(inner: Arc<PumpInner>) -> io::Result<()> {
                 // - completions remain queued on the port until drained.
                 Some(c) if c as u32 == ERROR_INSUFFICIENT_BUFFER => {
                     if entries.len() < MAX_BATCH_SIZE {
-                        let new_size =
-                            (entries.len().saturating_mul(2)).min(MAX_BATCH_SIZE);
+                        let new_size = (entries.len().saturating_mul(2)).min(MAX_BATCH_SIZE);
                         entries.resize(new_size, zeroed_entry());
                         continue;
                     }

--- a/crates/fast_io/src/iocp_stub.rs
+++ b/crates/fast_io/src/iocp_stub.rs
@@ -23,6 +23,42 @@ use crate::traits::{
 /// Minimum file size threshold (informational only on this platform).
 pub const IOCP_MIN_FILE_SIZE: u64 = 64 * 1024;
 
+/// Typed IOCP error variants.
+///
+/// On non-Windows platforms the IOCP backend is never constructed, so this
+/// type exists purely to keep cross-platform callers compiling. Both variants
+/// implement `From<IocpError> for io::Error` to match the Windows surface.
+#[derive(Debug, thiserror::Error)]
+pub enum IocpError {
+    /// Mirrors the Windows `ERROR_INVALID_PARAMETER` mapping.
+    #[error("IOCP overlapped operation rejected with ERROR_INVALID_PARAMETER: {context}")]
+    InvalidOperation {
+        /// Free-form context describing the call site.
+        context: &'static str,
+    },
+    /// Mirrors the Windows `ERROR_INSUFFICIENT_BUFFER` mapping.
+    #[error(
+        "IOCP completion drain ran out of buffer space ({requested} entries requested, capacity {capacity})"
+    )]
+    InsufficientBuffer {
+        /// Number of completion entries the kernel wanted to deliver.
+        requested: u32,
+        /// Number of entries the buffer could hold.
+        capacity: u32,
+    },
+}
+
+impl From<IocpError> for io::Error {
+    fn from(err: IocpError) -> Self {
+        match err {
+            IocpError::InvalidOperation { .. } => io::Error::new(io::ErrorKind::InvalidInput, err),
+            IocpError::InsufficientBuffer { .. } => {
+                io::Error::new(io::ErrorKind::OutOfMemory, err)
+            }
+        }
+    }
+}
+
 /// Check whether IOCP is available (always `false` on this platform).
 #[must_use]
 pub fn is_iocp_available() -> bool {

--- a/crates/fast_io/src/iocp_stub.rs
+++ b/crates/fast_io/src/iocp_stub.rs
@@ -52,9 +52,7 @@ impl From<IocpError> for io::Error {
     fn from(err: IocpError) -> Self {
         match err {
             IocpError::InvalidOperation { .. } => io::Error::new(io::ErrorKind::InvalidInput, err),
-            IocpError::InsufficientBuffer { .. } => {
-                io::Error::new(io::ErrorKind::OutOfMemory, err)
-            }
+            IocpError::InsufficientBuffer { .. } => io::Error::new(io::ErrorKind::OutOfMemory, err),
         }
     }
 }

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -165,7 +165,7 @@ pub use io_uring::{
 #[cfg(all(target_os = "windows", feature = "iocp"))]
 pub use iocp::post_completion as iocp_post_completion;
 pub use iocp::{
-    CompletionHandler, CompletionPump, IocpConfig, IocpOrStdReader, IocpOrStdWriter,
+    CompletionHandler, CompletionPump, IocpConfig, IocpError, IocpOrStdReader, IocpOrStdWriter,
     IocpPumpConfig, IocpReader, IocpReaderFactory, IocpWriter, IocpWriterFactory,
     iocp_availability_reason, is_iocp_available, oneshot_handler,
     skip_event_optimization_available,


### PR DESCRIPTION
## Summary

Closes two P0 beta-blocking IOCP bugs in `fast_io`:

- **#1929** - `iocp::writer_from_file` now reopens std::fs::File handles with `FILE_FLAG_OVERLAPPED` instead of silently corrupting overlapped I/O. Path is recovered via `GetFinalPathNameByHandleW`, the original handle is dropped, and the file is reopened through a new `IocpWriter::create_for_append` that uses `OPEN_EXISTING` + `FILE_FLAG_OVERLAPPED`. Anonymous handles (pipes, unnamed temp files) are rejected under `IocpPolicy::Enabled` with a clear `ErrorKind::Unsupported` message naming `FILE_FLAG_OVERLAPPED` and the typical culprits (named pipes, console handles, character devices). `IocpPolicy::Auto` transparently falls back to standard buffered I/O when path recovery or reopen fails.
- **#1930** - Two Win32 error codes are now mapped to typed `IocpError` variants:
  - `ERROR_INVALID_PARAMETER` (87) -> `IocpError::InvalidOperation { context }`. Surfaced from `WriteFile`, `ReadFile`, `GetQueuedCompletionStatus`, and `GetQueuedCompletionStatusEx` call sites in `file_writer`, `file_reader`, and `pump`. Maps to `io::ErrorKind::InvalidInput`.
  - `ERROR_INSUFFICIENT_BUFFER` (122) -> `IocpError::InsufficientBuffer { requested, capacity }`. The pump drain loop transparently doubles its `OVERLAPPED_ENTRY` buffer (capped at 8192 entries / 256 KiB) and retries; the typed error is only surfaced if the cap is reached. Maps to `io::ErrorKind::OutOfMemory`.

  Both variants implement `From<IocpError> for io::Error`, so existing `io::Result`-returning APIs stay backwards-compatible.

### Files modified

- `crates/fast_io/src/iocp/error.rs` (new) - `IocpError` enum, `is_invalid_parameter`, `is_insufficient_buffer`, `classify_overlapped_error`.
- `crates/fast_io/src/iocp/mod.rs` - export `error` module and re-export `IocpError`.
- `crates/fast_io/src/iocp/file_factory.rs` - rewrite `writer_from_file` per #1929; add private `path_from_file` helper; add 3 Windows tests.
- `crates/fast_io/src/iocp/file_writer.rs` - factor `open_with_disposition`; add `IocpWriter::create_for_append`; classify errors via `classify_overlapped_error`.
- `crates/fast_io/src/iocp/file_reader.rs` - classify `ReadFile` and `GetQueuedCompletionStatus` errors.
- `crates/fast_io/src/iocp/pump.rs` - dynamic batch growth on `ERROR_INSUFFICIENT_BUFFER`; classify default error path; add 2 tests.
- `crates/fast_io/src/iocp_stub.rs` - mirror `IocpError` enum on non-Windows for type compatibility.
- `crates/fast_io/src/lib.rs` - re-export `IocpError`.
- `crates/fast_io/Cargo.toml` - add `Win32_System_Pipes` feature for the `CreatePipe`-based test.

### Coordination with #1897

Did not block this work. The completion pump from #1897 is already on master; this PR only modifies the drain loop's *error-handling* path (adds `ERROR_INSUFFICIENT_BUFFER` retry and `classify_overlapped_error` upgrade) and leaves the pump's public API untouched.

### New error variants (signatures)

```rust
pub enum IocpError {
    InvalidOperation { context: &'static str },
    InsufficientBuffer { requested: u32, capacity: u32 },
}

impl From<IocpError> for io::Error { ... }

pub fn is_invalid_parameter(err: &io::Error) -> bool;
pub fn is_insufficient_buffer(err: &io::Error) -> bool;
pub fn classify_overlapped_error(err: io::Error, context: &'static str) -> io::Error;
```

## Test plan

- [ ] CI: fmt + clippy clean on Linux/macOS/Windows.
- [ ] CI: nextest runs the 6 new `error.rs` unit tests on every platform (typed-error variants, kind mapping, code recognition, classify pass-through).
- [ ] CI Windows runner: `writer_from_file_enabled_reopens_with_overlapped` confirms reopen produces an `Iocp` variant and writes succeed.
- [ ] CI Windows runner: `writer_from_file_enabled_rejects_anonymous_handle` confirms anonymous (CreatePipe) handles are rejected with `ErrorKind::Unsupported` and the message names `FILE_FLAG_OVERLAPPED`.
- [ ] CI Windows runner: `writer_from_file_auto_falls_back_for_anonymous_handle` confirms `Auto` never errors on a real file.
- [ ] CI Windows runner: `pump_drains_burst_larger_than_batch_size` confirms a 4x batch burst dispatches every completion (exercises the dynamic growth path).
- [ ] CI Windows runner: `iocp_error_insufficient_buffer_round_trips` confirms the typed error maps to `OutOfMemory` and preserves request/capacity in the message.
- [ ] No regressions in the existing `iocp_stub` test suite (cross-platform compile parity preserved).