### PR TITLE
docs(core): comment cleanup for client (#2010)

### DIFF
--- a/crates/core/src/client/config/client/arguments.rs
+++ b/crates/core/src/client/config/client/arguments.rs
@@ -47,35 +47,30 @@ mod tests {
         ClientConfig::default()
     }
 
-    // Tests for transfer_args
     #[test]
     fn transfer_args_default_is_empty() {
         let config = default_config();
         assert!(config.transfer_args().is_empty());
     }
 
-    // Tests for reference_directories
     #[test]
     fn reference_directories_default_is_empty() {
         let config = default_config();
         assert!(config.reference_directories().is_empty());
     }
 
-    // Tests for list_only
     #[test]
     fn list_only_default_is_false() {
         let config = default_config();
         assert!(!config.list_only());
     }
 
-    // Tests for has_transfer_request
     #[test]
     fn has_transfer_request_default_is_false() {
         let config = default_config();
         assert!(!config.has_transfer_request());
     }
 
-    // Tests for batch_config
     #[test]
     fn batch_config_default_is_none() {
         let config = default_config();

--- a/crates/core/src/client/config/client/deletion.rs
+++ b/crates/core/src/client/config/client/deletion.rs
@@ -77,63 +77,54 @@ mod tests {
         ClientConfig::default()
     }
 
-    // Tests for dry_run
     #[test]
     fn dry_run_default_is_false() {
         let config = default_config();
         assert!(!config.dry_run());
     }
 
-    // Tests for delete_mode
     #[test]
     fn delete_mode_default_is_disabled() {
         let config = default_config();
         assert_eq!(config.delete_mode(), DeleteMode::Disabled);
     }
 
-    // Tests for delete
     #[test]
     fn delete_default_is_false() {
         let config = default_config();
         assert!(!config.delete());
     }
 
-    // Tests for delete_before
     #[test]
     fn delete_before_default_is_false() {
         let config = default_config();
         assert!(!config.delete_before());
     }
 
-    // Tests for delete_after
     #[test]
     fn delete_after_default_is_false() {
         let config = default_config();
         assert!(!config.delete_after());
     }
 
-    // Tests for delete_delay
     #[test]
     fn delete_delay_default_is_false() {
         let config = default_config();
         assert!(!config.delete_delay());
     }
 
-    // Tests for delete_excluded
     #[test]
     fn delete_excluded_default_is_false() {
         let config = default_config();
         assert!(!config.delete_excluded());
     }
 
-    // Tests for max_delete
     #[test]
     fn max_delete_default_is_none() {
         let config = default_config();
         assert!(config.max_delete().is_none());
     }
 
-    // Tests for ignore_errors
     #[test]
     fn ignore_errors_default_is_false() {
         let config = default_config();

--- a/crates/core/src/client/config/client/metadata.rs
+++ b/crates/core/src/client/config/client/metadata.rs
@@ -199,147 +199,126 @@ mod tests {
         ClientConfig::default()
     }
 
-    // Tests for preserve_owner
     #[test]
     fn preserve_owner_default_is_false() {
         let config = default_config();
         assert!(!config.preserve_owner());
     }
 
-    // Tests for owner_override
     #[test]
     fn owner_override_default_is_none() {
         let config = default_config();
         assert!(config.owner_override().is_none());
     }
 
-    // Tests for preserve_group
     #[test]
     fn preserve_group_default_is_false() {
         let config = default_config();
         assert!(!config.preserve_group());
     }
 
-    // Tests for group_override
     #[test]
     fn group_override_default_is_none() {
         let config = default_config();
         assert!(config.group_override().is_none());
     }
 
-    // Tests for copy_as
     #[test]
     fn copy_as_default_is_none() {
         let config = default_config();
         assert!(config.copy_as().is_none());
     }
 
-    // Tests for preserve_executability
     #[test]
     fn preserve_executability_default_is_false() {
         let config = default_config();
         assert!(!config.preserve_executability());
     }
 
-    // Tests for chmod
     #[test]
     fn chmod_default_is_none() {
         let config = default_config();
         assert!(config.chmod().is_none());
     }
 
-    // Tests for user_mapping
     #[test]
     fn user_mapping_default_is_none() {
         let config = default_config();
         assert!(config.user_mapping().is_none());
     }
 
-    // Tests for group_mapping
     #[test]
     fn group_mapping_default_is_none() {
         let config = default_config();
         assert!(config.group_mapping().is_none());
     }
 
-    // Tests for preserve_permissions
     #[test]
     fn preserve_permissions_default_is_false() {
         let config = default_config();
         assert!(!config.preserve_permissions());
     }
 
-    // Tests for fake_super
     #[test]
     fn fake_super_default_is_false() {
         let config = default_config();
         assert!(!config.fake_super());
     }
 
-    // Tests for preserve_times
     #[test]
     fn preserve_times_default_is_false() {
         let config = default_config();
         assert!(!config.preserve_times());
     }
 
-    // Tests for preserve_atimes
     #[test]
     fn preserve_atimes_default_is_false() {
         let config = default_config();
         assert!(!config.preserve_atimes());
     }
 
-    // Tests for preserve_crtimes
     #[test]
     fn preserve_crtimes_default_is_false() {
         let config = default_config();
         assert!(!config.preserve_crtimes());
     }
 
-    // Tests for omit_dir_times
     #[test]
     fn omit_dir_times_default_is_false() {
         let config = default_config();
         assert!(!config.omit_dir_times());
     }
 
-    // Tests for omit_link_times
     #[test]
     fn omit_link_times_default_is_false() {
         let config = default_config();
         assert!(!config.omit_link_times());
     }
 
-    // Tests for preserve_hard_links
     #[test]
     fn preserve_hard_links_default_is_false() {
         let config = default_config();
         assert!(!config.preserve_hard_links());
     }
 
-    // Tests for numeric_ids
     #[test]
     fn numeric_ids_default_is_false() {
         let config = default_config();
         assert!(!config.numeric_ids());
     }
 
-    // Tests for preallocate
     #[test]
     fn preallocate_default_is_false() {
         let config = default_config();
         assert!(!config.preallocate());
     }
 
-    // Tests for preserve_devices
     #[test]
     fn preserve_devices_default_is_false() {
         let config = default_config();
         assert!(!config.preserve_devices());
     }
 
-    // Tests for preserve_specials
     #[test]
     fn preserve_specials_default_is_false() {
         let config = default_config();

--- a/crates/core/src/client/config/client/network.rs
+++ b/crates/core/src/client/config/client/network.rs
@@ -151,105 +151,90 @@ mod tests {
         ClientConfig::default()
     }
 
-    // Tests for address_mode
     #[test]
     fn address_mode_default_is_default() {
         let config = default_config();
         assert_eq!(config.address_mode(), AddressMode::Default);
     }
 
-    // Tests for connect_program
     #[test]
     fn connect_program_default_is_none() {
         let config = default_config();
         assert!(config.connect_program().is_none());
     }
 
-    // Tests for bind_address
     #[test]
     fn bind_address_default_is_none() {
         let config = default_config();
         assert!(config.bind_address().is_none());
     }
 
-    // Tests for sockopts
     #[test]
     fn sockopts_default_is_none() {
         let config = default_config();
         assert!(config.sockopts().is_none());
     }
 
-    // Tests for blocking_io
     #[test]
     fn blocking_io_default_is_none() {
         let config = default_config();
         assert!(config.blocking_io().is_none());
     }
 
-    // Tests for bandwidth_limit
     #[test]
     fn bandwidth_limit_default_is_none() {
         let config = default_config();
         assert!(config.bandwidth_limit().is_none());
     }
 
-    // Tests for timeout
     #[test]
     fn timeout_default_is_default() {
         let config = default_config();
         assert_eq!(config.timeout(), TransferTimeout::Default);
     }
 
-    // Tests for connect_timeout
     #[test]
     fn connect_timeout_default_is_default() {
         let config = default_config();
         assert_eq!(config.connect_timeout(), TransferTimeout::Default);
     }
 
-    // Tests for stop_at
     #[test]
     fn stop_at_default_is_none() {
         let config = default_config();
         assert!(config.stop_at().is_none());
     }
 
-    // Tests for remote_shell
     #[test]
     fn remote_shell_default_is_none() {
         let config = default_config();
         assert!(config.remote_shell().is_none());
     }
 
-    // Tests for rsync_path
     #[test]
     fn rsync_path_default_is_none() {
         let config = default_config();
         assert!(config.rsync_path().is_none());
     }
 
-    // Tests for early_input
     #[test]
     fn early_input_default_is_none() {
         let config = default_config();
         assert!(config.early_input().is_none());
     }
 
-    // Tests for prefer_aes_gcm
     #[test]
     fn prefer_aes_gcm_default_is_none() {
         let config = default_config();
         assert!(config.prefer_aes_gcm().is_none());
     }
 
-    // Tests for protect_args
     #[test]
     fn protect_args_default_is_none() {
         let config = default_config();
         assert!(config.protect_args().is_none());
     }
 
-    // Tests for jump_hosts
     #[test]
     fn jump_hosts_default_is_none() {
         let config = default_config();

--- a/crates/core/src/client/config/client/output.rs
+++ b/crates/core/src/client/config/client/output.rs
@@ -83,57 +83,48 @@ mod tests {
         ClientConfig::default()
     }
 
-    // Tests for verbosity
     #[test]
     fn verbosity_default_is_zero() {
         let config = default_config();
         assert_eq!(config.verbosity(), 0);
     }
 
-    // Tests for progress
     #[test]
     fn progress_default_is_false() {
         let config = default_config();
         assert!(!config.progress());
     }
 
-    // Tests for stats
     #[test]
     fn stats_default_is_false() {
         let config = default_config();
         assert!(!config.stats());
     }
 
-    // Tests for human readable
     #[test]
     fn human_readable_default_is_false() {
         let config = default_config();
         assert!(!config.human_readable());
     }
 
-    // Tests for itemize_changes
     #[test]
     fn itemize_changes_default_is_false() {
         let config = default_config();
         assert!(!config.itemize_changes());
     }
 
-    // Tests for force event collection
     #[test]
     fn force_event_collection_default_is_false() {
         let config = default_config();
         assert!(!config.force_event_collection());
     }
 
-    // Tests for collect_events
     #[test]
     fn collect_events_default_is_false() {
         let config = default_config();
-        // By default: force_event_collection=false, verbosity=0, progress=false, list_only=false
         assert!(!config.collect_events());
     }
 
-    // Tests for daemon_params
     #[test]
     fn daemon_params_default_is_empty() {
         let config = default_config();

--- a/crates/core/src/client/config/client/partials.rs
+++ b/crates/core/src/client/config/client/partials.rs
@@ -74,56 +74,48 @@ mod tests {
         ClientConfig::default()
     }
 
-    // Tests for partial
     #[test]
     fn partial_default_is_false() {
         let config = default_config();
         assert!(!config.partial());
     }
 
-    // Tests for delay_updates
     #[test]
     fn delay_updates_default_is_false() {
         let config = default_config();
         assert!(!config.delay_updates());
     }
 
-    // Tests for partial_directory
     #[test]
     fn partial_directory_default_is_none() {
         let config = default_config();
         assert!(config.partial_directory().is_none());
     }
 
-    // Tests for temp_directory
     #[test]
     fn temp_directory_default_is_none() {
         let config = default_config();
         assert!(config.temp_directory().is_none());
     }
 
-    // Tests for inplace
     #[test]
     fn inplace_default_is_false() {
         let config = default_config();
         assert!(!config.inplace());
     }
 
-    // Tests for append
     #[test]
     fn append_default_is_false() {
         let config = default_config();
         assert!(!config.append());
     }
 
-    // Tests for append_verify
     #[test]
     fn append_verify_default_is_false() {
         let config = default_config();
         assert!(!config.append_verify());
     }
 
-    // Tests for fsync
     #[test]
     fn fsync_default_is_false() {
         let config = default_config();

--- a/crates/core/src/client/config/client/paths.rs
+++ b/crates/core/src/client/config/client/paths.rs
@@ -36,28 +36,24 @@ mod tests {
         ClientConfig::default()
     }
 
-    // Tests for link_dest_paths
     #[test]
     fn link_dest_paths_default_is_empty() {
         let config = default_config();
         assert!(config.link_dest_paths().is_empty());
     }
 
-    // Tests for backup
     #[test]
     fn backup_default_is_false() {
         let config = default_config();
         assert!(!config.backup());
     }
 
-    // Tests for backup_directory
     #[test]
     fn backup_directory_default_is_none() {
         let config = default_config();
         assert!(config.backup_directory().is_none());
     }
 
-    // Tests for backup_suffix
     #[test]
     fn backup_suffix_default_is_none() {
         let config = default_config();

--- a/crates/core/src/client/config/client/performance.rs
+++ b/crates/core/src/client/config/client/performance.rs
@@ -164,51 +164,42 @@ mod tests {
         ClientConfig::default()
     }
 
-    // Tests for compress
     #[test]
     fn compress_default_is_false() {
         let config = default_config();
         assert!(!config.compress());
     }
 
-    // Tests for compression_level
     #[test]
     fn compression_level_default_is_none() {
         let config = default_config();
         assert!(config.compression_level().is_none());
     }
 
-    // Tests for compression_algorithm
     #[test]
     fn compression_algorithm_default_is_valid() {
         let config = default_config();
         let _algo = config.compression_algorithm();
-        // Just verify it returns successfully
     }
 
-    // Tests for skip_compress
     #[test]
     fn skip_compress_default_exists() {
         let config = default_config();
         let _skip = config.skip_compress();
-        // Just verify it returns successfully
     }
 
-    // Tests for whole_file
     #[test]
     fn whole_file_default_is_true() {
         let config = default_config();
         assert!(config.whole_file());
     }
 
-    // Tests for open_noatime
     #[test]
     fn open_noatime_default_is_false() {
         let config = default_config();
         assert!(!config.open_noatime());
     }
 
-    // Tests for sparse
     #[test]
     fn sparse_default_is_false() {
         let config = default_config();
@@ -222,28 +213,25 @@ mod tests {
         assert!(!config.fuzzy());
     }
 
-    // Tests for block_size_override
     #[test]
     fn block_size_override_default_is_none() {
         let config = default_config();
         assert!(config.block_size_override().is_none());
     }
 
-    // Tests for max_alloc
     #[test]
     fn max_alloc_default_is_none() {
         let config = default_config();
         assert!(config.max_alloc().is_none());
     }
 
-    // Tests for qsort
     #[test]
     fn qsort_default_is_false() {
         let config = default_config();
         assert!(!config.qsort());
     }
 
-    // Tests for inc_recursive_send (mirrors upstream allow_inc_recurse = 1)
+    // upstream: allow_inc_recurse = 1 (default).
     #[test]
     fn inc_recursive_send_default_is_true() {
         let config = default_config();

--- a/crates/core/src/client/config/client/preservation.rs
+++ b/crates/core/src/client/config/client/preservation.rs
@@ -82,63 +82,54 @@ mod tests {
         ClientConfig::default()
     }
 
-    // Tests for copy_links
     #[test]
     fn copy_links_default_is_false() {
         let config = default_config();
         assert!(!config.copy_links());
     }
 
-    // Tests for copy_dirlinks
     #[test]
     fn copy_dirlinks_default_is_false() {
         let config = default_config();
         assert!(!config.copy_dirlinks());
     }
 
-    // Tests for copy_devices
     #[test]
     fn copy_devices_default_is_false() {
         let config = default_config();
         assert!(!config.copy_devices());
     }
 
-    // Tests for write_devices
     #[test]
     fn write_devices_default_is_false() {
         let config = default_config();
         assert!(!config.write_devices());
     }
 
-    // Tests for copy_unsafe_links
     #[test]
     fn copy_unsafe_links_default_is_false() {
         let config = default_config();
         assert!(!config.copy_unsafe_links());
     }
 
-    // Tests for keep_dirlinks
     #[test]
     fn keep_dirlinks_default_is_false() {
         let config = default_config();
         assert!(!config.keep_dirlinks());
     }
 
-    // Tests for safe_links
     #[test]
     fn safe_links_default_is_false() {
         let config = default_config();
         assert!(!config.safe_links());
     }
 
-    // Tests for munge_links
     #[test]
     fn munge_links_default_is_false() {
         let config = default_config();
         assert!(!config.munge_links());
     }
 
-    // Tests for trust_sender
     #[test]
     fn trust_sender_default_is_false() {
         let config = default_config();

--- a/crates/core/src/client/config/client/selection.rs
+++ b/crates/core/src/client/config/client/selection.rs
@@ -174,7 +174,6 @@ mod tests {
         ClientConfig::default()
     }
 
-    // Tests for file size filters
     #[test]
     fn min_file_size_default_is_none() {
         let config = default_config();
@@ -187,7 +186,6 @@ mod tests {
         assert!(config.max_file_size().is_none());
     }
 
-    // Tests for modify window
     #[test]
     fn modify_window_default_is_none() {
         let config = default_config();
@@ -200,70 +198,60 @@ mod tests {
         assert_eq!(config.modify_window_duration(), Duration::ZERO);
     }
 
-    // Tests for remove source files
     #[test]
     fn remove_source_files_default_is_false() {
         let config = default_config();
         assert!(!config.remove_source_files());
     }
 
-    // Tests for size-only mode
     #[test]
     fn size_only_default_is_false() {
         let config = default_config();
         assert!(!config.size_only());
     }
 
-    // Tests for ignore times
     #[test]
     fn ignore_times_default_is_false() {
         let config = default_config();
         assert!(!config.ignore_times());
     }
 
-    // Tests for ignore existing
     #[test]
     fn ignore_existing_default_is_false() {
         let config = default_config();
         assert!(!config.ignore_existing());
     }
 
-    // Tests for existing only
     #[test]
     fn existing_only_default_is_false() {
         let config = default_config();
         assert!(!config.existing_only());
     }
 
-    // Tests for ignore missing args
     #[test]
     fn ignore_missing_args_default_is_false() {
         let config = default_config();
         assert!(!config.ignore_missing_args());
     }
 
-    // Tests for delete missing args
     #[test]
     fn delete_missing_args_default_is_false() {
         let config = default_config();
         assert!(!config.delete_missing_args());
     }
 
-    // Tests for update mode
     #[test]
     fn update_default_is_false() {
         let config = default_config();
         assert!(!config.update());
     }
 
-    // Tests for relative paths
     #[test]
     fn relative_paths_default_is_false() {
         let config = default_config();
         assert!(!config.relative_paths());
     }
 
-    // Tests for one file system
     #[test]
     fn one_file_system_default_is_false() {
         let config = default_config();
@@ -271,42 +259,36 @@ mod tests {
         assert_eq!(config.one_file_system_level(), 0);
     }
 
-    // Tests for implied dirs
     #[test]
     fn implied_dirs_default_is_true() {
         let config = default_config();
         assert!(config.implied_dirs());
     }
 
-    // Tests for mkpath
     #[test]
     fn mkpath_default_is_false() {
         let config = default_config();
         assert!(!config.mkpath());
     }
 
-    // Tests for force replacements
     #[test]
     fn force_replacements_default_is_false() {
         let config = default_config();
         assert!(!config.force_replacements());
     }
 
-    // Tests for prune empty dirs
     #[test]
     fn prune_empty_dirs_default_is_false() {
         let config = default_config();
         assert!(!config.prune_empty_dirs());
     }
 
-    // Tests for files_from
     #[test]
     fn files_from_default_is_none() {
         let config = default_config();
         assert!(!config.files_from().is_active());
     }
 
-    // Tests for from0
     #[test]
     fn from0_default_is_false() {
         let config = default_config();

--- a/crates/core/src/client/config/client/validation.rs
+++ b/crates/core/src/client/config/client/validation.rs
@@ -60,33 +60,27 @@ mod tests {
         ClientConfig::default()
     }
 
-    // Tests for checksum
     #[test]
     fn checksum_default_is_false() {
         let config = default_config();
         assert!(!config.checksum());
     }
 
-    // Tests for checksum_choice
     #[test]
     fn checksum_choice_default() {
         let config = default_config();
-        // Default should be Auto or similar
         let _choice = config.checksum_choice();
     }
 
-    // Tests for checksum_seed
     #[test]
     fn checksum_seed_default_is_none() {
         let config = default_config();
         assert!(config.checksum_seed().is_none());
     }
 
-    // Tests for checksum_signature_algorithm
     #[test]
     fn checksum_signature_algorithm_returns_algorithm() {
         let config = default_config();
         let _algorithm = config.checksum_signature_algorithm();
-        // Just verify it returns something without panicking
     }
 }

--- a/crates/core/src/client/config/compress_env.rs
+++ b/crates/core/src/client/config/compress_env.rs
@@ -69,9 +69,7 @@ mod tests {
     use std::ffi::{OsStr, OsString};
     use std::sync::Mutex;
 
-    // Environment variables are process-global, so serialize access to avoid
-    // cross-test interference when multiple threads run this module's tests in
-    // parallel.
+    // Process-global env state - serialize access across parallel test threads.
     static ENV_MUTEX: Mutex<()> = Mutex::new(());
 
     struct EnvGuard {
@@ -182,7 +180,7 @@ mod tests {
         let value = {
             use std::os::windows::ffi::OsStringExt;
 
-            // Use an unpaired surrogate to produce a non-UTF-16 value.
+            // Unpaired surrogate produces a non-UTF-16 value.
             OsString::from_wide(&[0xD800])
         };
 

--- a/crates/core/src/client/config/network.rs
+++ b/crates/core/src/client/config/network.rs
@@ -33,7 +33,6 @@ mod tests {
     use super::*;
     use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
-    // Tests for BindAddress::new
     #[test]
     fn new_creates_bind_address() {
         let raw = OsString::from("192.168.1.1");
@@ -43,7 +42,6 @@ mod tests {
         assert_eq!(bind.socket(), socket);
     }
 
-    // Tests for BindAddress::raw
     #[test]
     fn raw_returns_original_string() {
         let raw = OsString::from("10.0.0.1");
@@ -52,7 +50,6 @@ mod tests {
         assert_eq!(bind.raw(), "10.0.0.1");
     }
 
-    // Tests for BindAddress::socket
     #[test]
     fn socket_returns_address() {
         let raw = OsString::from("127.0.0.1");
@@ -70,7 +67,6 @@ mod tests {
         assert_eq!(bind.socket().ip(), IpAddr::V6(Ipv6Addr::LOCALHOST));
     }
 
-    // Tests for trait implementations
     #[test]
     fn bind_address_is_clone() {
         let raw = OsString::from("192.168.1.1");

--- a/crates/core/src/client/config/skip_compress.rs
+++ b/crates/core/src/client/config/skip_compress.rs
@@ -79,7 +79,6 @@ mod tests {
     use super::*;
     use std::ffi::OsString;
 
-    // Tests for parse_skip_compress_list
     #[test]
     fn parse_skip_compress_list_valid_pattern() {
         let value = OsString::from("*.jpg/*.png/*.gif");
@@ -101,10 +100,8 @@ mod tests {
         assert!(result.is_ok());
     }
 
-    // Tests for skip_compress_from_env
     #[test]
     fn skip_compress_from_env_unset_returns_none() {
-        // Use a unique variable name that won't be set
         let result = skip_compress_from_env("RSYNC_SKIP_COMPRESS_TEST_UNSET_VAR_12345");
         assert!(result.is_ok());
         assert!(result.unwrap().is_none());

--- a/crates/core/src/client/error.rs
+++ b/crates/core/src/client/error.rs
@@ -9,9 +9,6 @@ use crate::message::{Message, Role};
 use crate::rsync_error;
 use engine::local_copy::{LocalCopyError, LocalCopyErrorKind};
 
-// Re-export exit code constants for backward compatibility.
-// These map directly to ExitCode variants and should be preferred
-// when type safety is important.
 // upstream: errcode.h - Exit code definitions
 
 /// Exit code returned when client functionality is unavailable.
@@ -89,8 +86,6 @@ impl HasExitCode for ClientError {
 
 impl ErrorCodification for ClientError {
     fn error_code(&self) -> u32 {
-        // Map exit codes to unique error codes
-        // Use exit code as base (multiplied by 100) for namespace separation
         match self.exit_code {
             ExitCode::Ok => 0,
             ExitCode::Syntax => 100,
@@ -161,13 +156,13 @@ impl ErrorCodification for ClientError {
 
 #[cold]
 pub(crate) fn missing_operands_error() -> ClientError {
+    // upstream: exit code 23 (RERR_PARTIAL) for missing source operands.
     let code = ExitCode::PartialTransfer;
     let message = rsync_error!(
         code.as_i32(),
         "missing source operands: supply at least one source and a destination"
     )
     .with_role(Role::Client);
-    // Mirror upstream: return exit code 23 for missing source operands
     ClientError::with_code(code, message)
 }
 
@@ -258,11 +253,11 @@ pub(crate) fn io_error(action: &str, path: &Path, error: io::Error) -> ClientErr
 
 #[cold]
 pub(crate) fn destination_access_error(path: &Path, error: io::Error) -> ClientError {
+    // upstream: main.c:751 change_dir validation returns FileSelect (3) for
+    // destination directory access errors.
     let code = ExitCode::FileSelect;
     let path_display = path.display();
     let text = format!("failed to access destination directory '{path_display}': {error}");
-    // Mirror upstream: destination directory access errors return FileSelect (3)
-    // This matches upstream main.c:751 change_dir validation
     let message = rsync_error!(code.as_i32(), text).with_role(Role::Client);
     ClientError::with_code(code, message)
 }
@@ -395,7 +390,6 @@ mod tests {
 
             assert_eq!(error.exit_code(), code.as_i32());
             assert_eq!(error.code(), code);
-            // Verify message is accessible
             let _ = error.message();
         }
 
@@ -437,7 +431,6 @@ mod tests {
             let message = rsync_error!(999, "unknown code").with_role(Role::Client);
             let error = ClientError::new(999, message);
 
-            // Unknown exit codes fall back to PartialTransfer
             assert_eq!(error.code(), ExitCode::PartialTransfer);
         }
 
@@ -447,7 +440,6 @@ mod tests {
             let message = rsync_error!(code.as_i32(), "test").with_role(Role::Client);
             let error = ClientError::with_code(code, message);
 
-            // Test the HasExitCode trait
             let trait_code: ExitCode = HasExitCode::exit_code(&error);
             assert_eq!(trait_code, code);
         }
@@ -457,8 +449,8 @@ mod tests {
             let local_error = LocalCopyError::missing_operands();
             let client_error: ClientError = local_error.into();
 
-            // Note: missing_operands maps to PartialTransfer (23) in ClientError
-            // to match upstream rsync behavior, even though LocalCopyError uses Syntax (1)
+            // upstream: missing_operands maps to PartialTransfer (23) in
+            // ClientError, even though LocalCopyError uses Syntax (1).
             assert_eq!(client_error.code(), ExitCode::PartialTransfer);
         }
 
@@ -608,7 +600,6 @@ mod tests {
             assert_eq!(error.exit_code(), FEATURE_UNAVAILABLE_EXIT_CODE);
             let msg = error.to_string();
             assert!(msg.contains("daemon requires authentication for module listing"));
-            // When reason is empty, the message should not have a reason suffix
             assert!(!msg.contains("module listing: "));
         }
 
@@ -628,7 +619,6 @@ mod tests {
             assert_eq!(error.exit_code(), FEATURE_UNAVAILABLE_EXIT_CODE);
             let msg = error.to_string();
             assert!(msg.contains("daemon rejected provided credentials"));
-            // When reason is None, message should not have a reason suffix
             assert!(!msg.contains("credentials: "));
         }
 
@@ -639,7 +629,6 @@ mod tests {
             assert_eq!(error.exit_code(), FEATURE_UNAVAILABLE_EXIT_CODE);
             let msg = error.to_string();
             assert!(msg.contains("daemon rejected provided credentials"));
-            // When reason is empty, message should not have a reason suffix
             assert!(!msg.contains("credentials: "));
         }
 
@@ -659,7 +648,6 @@ mod tests {
             assert_eq!(error.exit_code(), PARTIAL_TRANSFER_EXIT_CODE);
             let msg = error.to_string();
             assert!(msg.contains("daemon denied access to module listing"));
-            // When reason is empty, message should not have a reason suffix
             assert!(!msg.contains("listing: "));
         }
 
@@ -679,7 +667,6 @@ mod tests {
             assert_eq!(error.exit_code(), FEATURE_UNAVAILABLE_EXIT_CODE);
             let msg = error.to_string();
             assert!(msg.contains("daemon refused module listing"));
-            // When reason is empty, message should not have a reason suffix
             assert!(!msg.contains("listing: "));
         }
 
@@ -690,7 +677,6 @@ mod tests {
             assert_eq!(error.exit_code(), FEATURE_UNAVAILABLE_EXIT_CODE);
             let msg = error.to_string();
             assert!(msg.contains("daemon refused module listing"));
-            // When reason is whitespace only, message should not have a reason suffix
             assert!(!msg.contains("listing: "));
         }
 

--- a/crates/core/src/client/module_list/auth.rs
+++ b/crates/core/src/client/module_list/auth.rs
@@ -63,13 +63,12 @@ impl SensitiveBytes {
         self.0.as_slice()
     }
 
+    /// Consumes `self` and returns its bytes zeroed in place, preserving
+    /// the original length. The returned `Vec` is evidence that the storage
+    /// was scrubbed before release.
     #[cfg(test)]
     #[allow(dead_code)]
     pub(crate) fn into_zeroized_vec(mut self) -> Vec<u8> {
-        // Consume `self` and return its bytes zeroed in place, preserving
-        // the original length. This mirrors the previous semantics where the
-        // returned Vec served as evidence that the storage was scrubbed
-        // before being released.
         let mut inner = std::mem::take(&mut *self.0);
         inner.zeroize();
         inner

--- a/crates/core/src/client/module_list/connect/proxy.rs
+++ b/crates/core/src/client/module_list/connect/proxy.rs
@@ -612,7 +612,6 @@ mod tests {
 
     #[test]
     fn decode_proxy_component_invalid_utf8_returns_error() {
-        // %FF %FE are not valid UTF-8 sequence starters
         let result = decode_proxy_component("%FF%FE", "field");
         assert!(result.is_err());
     }
@@ -620,14 +619,12 @@ mod tests {
     #[test]
     fn proxy_credentials_authorization_value_basic_auth() {
         let creds = ProxyCredentials::new("user".to_owned(), "pass".to_owned());
-        // user:pass base64 encoded should be "dXNlcjpwYXNz"
         assert_eq!(creds.authorization_value(), "dXNlcjpwYXNz");
     }
 
     #[test]
     fn proxy_credentials_authorization_value_empty_password() {
         let creds = ProxyCredentials::new("user".to_owned(), "".to_owned());
-        // user: base64 encoded should be "dXNlcjo="
         assert_eq!(creds.authorization_value(), "dXNlcjo=");
     }
 
@@ -687,10 +684,9 @@ mod tests {
 
     #[test]
     fn parse_proxy_spec_colon_in_password() {
-        // Password containing colons should work (only first colon splits user:pass)
+        // Only first colon splits user:pass; remaining colons are part of the password.
         let config = parse_proxy_spec("user:pass:with:colons@proxy.example.com:8080").unwrap();
         assert!(config.credentials.is_some());
-        // The password should be "pass:with:colons"
         let decoded = STANDARD
             .decode(config.credentials.unwrap().authorization_value())
             .unwrap();

--- a/crates/core/src/client/progress.rs
+++ b/crates/core/src/client/progress.rs
@@ -374,7 +374,6 @@ mod tests {
     fn event_returns_reference() {
         let update = create_test_update(10, 5, 5, false);
         let _event = update.event();
-        // Just verify we can access the event
     }
 
     #[test]

--- a/crates/core/src/client/remote/daemon_transfer/connection/mod.rs
+++ b/crates/core/src/client/remote/daemon_transfer/connection/mod.rs
@@ -274,14 +274,13 @@ pub(crate) fn perform_daemon_handshake(
             ));
         }
 
-        // MOTD output - mirrors upstream rprintf(FINFO, "%s\n", line)
+        // upstream: rprintf(FINFO, "%s\n", line) - MOTD output.
         if output_motd {
             println!("{trimmed}");
         }
     }
 
-    // Negotiate to minimum of our version and daemon's version.
-    // upstream: exchange_protocols lines 211-227
+    // upstream: exchange_protocols:211-227 - negotiate to minimum of our and daemon version.
     let negotiated = if our_version.as_u8() < remote_protocol.as_u8() {
         our_version
     } else {

--- a/crates/core/src/client/remote/daemon_transfer/orchestration/arguments.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/arguments.rs
@@ -36,10 +36,9 @@ pub(crate) fn send_daemon_arguments(
 
     let full_args = build_full_daemon_args(config, request, protocol, is_sender);
 
-    // Phase 1: send args over the daemon text protocol.
-    // With protect-args, only send the minimal set so the daemon detects `-s`
-    // and expects a phase-2 secluded-args payload.
-    // upstream: clientserver.c:393-405 - stops at the NULL marker in sargs
+    // upstream: clientserver.c:393-405 - phase 1 sends args over the daemon text
+    // protocol; with protect-args, only the minimal set is sent so the daemon
+    // detects `-s` and stops at the NULL marker, expecting phase-2 secluded args.
     let phase1_args = if protect {
         build_minimal_daemon_args(is_sender)
     } else {
@@ -61,7 +60,7 @@ pub(crate) fn send_daemon_arguments(
         })?;
     }
 
-    // Empty string signals end of phase-1 argument list.
+    // upstream: empty string signals end of phase-1 argument list.
     stream.write_all(&[terminator]).map_err(|e| {
         socket_error(
             "send final terminator to",
@@ -70,11 +69,10 @@ pub(crate) fn send_daemon_arguments(
         )
     })?;
 
-    // Phase 2: when protect-args is active, send the real arguments via
-    // the secluded-args wire format (null-separated with empty terminator).
-    // upstream: clientserver.c:407-408 - send_protected_args(f_out, sargs)
-    // upstream: rsync.c:283-320 - send_protected_args() applies
-    // iconvbufs(ic_send, ...) per arg when --iconv is configured.
+    // upstream: clientserver.c:407-408 send_protected_args(f_out, sargs) +
+    // rsync.c:283-320 send_protected_args() - phase 2 sends the real arguments
+    // via the secluded-args wire format (null-separated with empty terminator),
+    // applying iconvbufs(ic_send, ...) per arg when --iconv is configured.
     if protect {
         let mut secluded = vec!["rsync"];
         secluded.extend(full_args.iter().map(String::as_str));
@@ -143,36 +141,32 @@ pub(super) fn build_full_daemon_args(
         args.push(format!("--checksum-choice={}", override_algo.as_str()));
     }
 
-    // Single-character flag string (e.g., "-logDtprzc").
-    // upstream: options.c:2594-2713
+    // upstream: options.c:2594-2713 - single-character flag string (e.g., "-logDtprzc").
     let flag_string = flags::build_server_flag_string(config);
     if !flag_string.is_empty() {
         args.push(flag_string);
     }
 
-    // Capability flags for protocol 30+.
-    // upstream: options.c:2707-2713 (via maybe_add_e_option appended to argstr)
-    // upstream: compat.c:177-178 - daemon checks client_info for 'i' to set allow_inc_recurse
-    // INC_RECURSE ('i') is advertised in both directions by default, mirroring
-    // upstream's `allow_inc_recurse = 1` initialization. `--no-inc-recursive`
-    // clears the gate and suppresses the bit.
-    // upstream: compat.c:720 set_allow_inc_recurse() - capability gate.
+    // upstream: options.c:2707-2713 maybe_add_e_option, compat.c:177-178 daemon
+    // 'i' check, compat.c:720 set_allow_inc_recurse() - capability flags for
+    // protocol 30+; INC_RECURSE ('i') is advertised in both directions by
+    // default and `--no-inc-recursive` clears the gate.
     if protocol.as_u8() >= 30 {
         args.push(build_capability_string(config.inc_recursive_send()));
     }
 
     let we_are_sender = !is_sender;
 
-    // upstream: options.c:2750-2762 - server needs to know about log-format
-    // so it can generate itemize output via MSG_INFO frames.
-    // Only sent when client is sender (push) - matches upstream am_sender guard.
+    // upstream: options.c:2750-2762 - server needs the log-format to generate
+    // itemize output via MSG_INFO frames. Only sent when client is sender
+    // (push), matching upstream am_sender guard.
     if we_are_sender && config.itemize_changes() {
         args.push("--log-format=%i".to_owned());
     }
 
-    // upstream: options.c:2800-2805 - compress choice forwarding.
-    // Only sent when the user explicitly specified --compress-choice,
-    // --new-compress, or --old-compress.
+    // upstream: options.c:2800-2805 - compress choice is only forwarded when
+    // the user explicitly specified --compress-choice, --new-compress, or
+    // --old-compress.
     if config.explicit_compress_choice() {
         let algo = config.compression_algorithm();
         let name = algo.name();
@@ -183,8 +177,7 @@ pub(super) fn build_full_daemon_args(
         }
     }
 
-    // --compress-level=N
-    // upstream: options.c:2737-2740
+    // upstream: options.c:2737-2740 - --compress-level=N
     if let Some(level) = config.compression_level() {
         args.push(format!(
             "--compress-level={}",
@@ -192,8 +185,7 @@ pub(super) fn build_full_daemon_args(
         ));
     }
 
-    // Sender-specific args
-    // upstream: options.c:2807-2839
+    // upstream: options.c:2807-2839 - sender-specific args.
     if we_are_sender {
         if let Some(max_delete) = config.max_delete() {
             if max_delete > 0 {
@@ -249,8 +241,7 @@ pub(super) fn build_full_daemon_args(
         args.push("--use-qsort".to_owned());
     }
 
-    // Sender-only long-form args
-    // upstream: options.c:2893-2925
+    // upstream: options.c:2893-2925 - sender-only long-form args.
     if we_are_sender {
         if config.ignore_existing() {
             args.push("--ignore-existing".to_owned());
@@ -262,8 +253,8 @@ pub(super) fn build_full_daemon_args(
             args.push("--fsync".to_owned());
         }
 
-        // --compare-dest=DIR, --copy-dest=DIR, --link-dest=DIR
-        // upstream: options.c:2915-2923 - sent only when client is sender (push).
+        // upstream: options.c:2915-2923 - --compare-dest/copy-dest/link-dest
+        // sent only when client is sender (push).
         for ref_dir in config.reference_directories() {
             let flag = match ref_dir.kind() {
                 ReferenceDirectoryKind::Compare => "--compare-dest=",
@@ -301,8 +292,7 @@ pub(super) fn build_full_daemon_args(
         args.push("--remove-source-files".to_owned());
     }
 
-    // --files-from
-    // upstream: options.c:2944-2956
+    // upstream: options.c:2944-2956 - --files-from
     {
         use crate::client::config::FilesFromSource;
         let client_is_sender = !is_sender;
@@ -310,7 +300,6 @@ pub(super) fn build_full_daemon_args(
             FilesFromSource::None => {}
             FilesFromSource::Stdin | FilesFromSource::LocalFile(_) => {
                 if !client_is_sender {
-                    // Pull: daemon is sender and needs the file list from us.
                     args.push("--files-from=-".to_owned());
                     args.push("--from0".to_owned());
                 }
@@ -324,14 +313,13 @@ pub(super) fn build_full_daemon_args(
         }
     }
 
-    // --iconv forwarding to the remote daemon.
-    // upstream: options.c:2716-2723 - when iconv_opt contains a comma, only the
-    // post-comma half (the daemon's local charset) is forwarded; otherwise the
+    // upstream: options.c:2716-2723, options.c:2052-2054 - --iconv forwarding
+    // to the remote daemon. When iconv_opt contains a comma, only the
+    // post-comma half (daemon's local charset) is forwarded; otherwise the
     // whole string is forwarded as-is. `--iconv=-` (Disabled) and the default
     // (Unspecified) forward nothing because upstream nulls iconv_opt at
     // options.c:2052-2054 before this branch runs. Without this the daemon
-    // never enables `ic_recv` and writes wire UTF-8 bytes verbatim instead of
-    // transcoding to its local charset.
+    // never enables `ic_recv` and writes wire UTF-8 bytes verbatim.
     match config.iconv() {
         IconvSetting::Unspecified | IconvSetting::Disabled => {}
         IconvSetting::LocaleDefault => args.push("--iconv=.".to_owned()),
@@ -341,10 +329,9 @@ pub(super) fn build_full_daemon_args(
         }
     }
 
-    // Dummy argument (upstream requirement - represents CWD)
+    // upstream: dummy argument representing CWD.
     args.push(".".to_owned());
 
-    // Module path
     let module_path = format!("{}/{}", request.module, request.path);
     args.push(module_path);
 

--- a/crates/core/src/client/remote/daemon_transfer/orchestration/transfer.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/transfer.rs
@@ -39,22 +39,21 @@ pub(crate) fn run_pull_transfer(
 
     let filter_rules = flags::build_wire_format_rules(config.filter_rules())?;
 
-    // Protocol was negotiated via @RSYNCD text exchange, not binary 4-byte exchange.
-    // setup_protocol() will skip the binary exchange because remote_protocol != 0
-    // upstream: compat.c:599 - if (remote_protocol == 0) { ... }
+    // upstream: compat.c:599 - protocol was negotiated via @RSYNCD text exchange,
+    // setup_protocol() skips the binary exchange because remote_protocol != 0.
     let handshake = build_daemon_handshake(config, protocol);
 
     let mut server_config = build_server_config_for_receiver(config, local_paths, filter_rules)?;
 
-    // upstream: main.c:1354-1356 - when pulling with --files-from pointing to
-    // a local file or stdin, the client reads the file list locally and forwards
+    // upstream: main.c:1354-1356 - when pulling with --files-from pointing to a
+    // local file or stdin, the client reads the file list locally and forwards
     // it to the daemon's generator over the protocol stream.
     if config.files_from().is_local_forwarded() {
         let data = read_files_from_for_forwarding(config)?;
         server_config.connection.files_from_data = Some(data);
     }
 
-    // Pull: local side is Receiver, batch records incoming data (is_sender=false)
+    // Pull: local side is Receiver; batch records incoming data (is_sender=false).
     let batch_recording = batch_ctx
         .as_ref()
         .map(|ctx| build_batch_recording(ctx, false));
@@ -100,21 +99,21 @@ pub(crate) fn run_push_transfer(
     let server_config = build_server_config_for_generator(config, local_paths, filter_rules)?;
     let dry_run = config.dry_run();
 
-    // Push: local side is Generator (sender), batch records outgoing data (is_sender=true)
+    // Push: local side is Generator (sender); batch records outgoing data (is_sender=true).
     let batch_recording = batch_ctx
         .as_ref()
         .map(|ctx| build_batch_recording(ctx, true));
 
     let start = Instant::now();
 
-    // Call the server directly (not the error-wrapping helper) so we can
-    // inspect the raw io::Error kind for dry-run graceful close handling.
+    // Call the server directly (not the error-wrapping helper) to inspect the
+    // raw io::Error kind for dry-run graceful close handling.
     let mut reader = stream
         .try_clone()
         .map_err(|e| invalid_argument_error(&format!("failed to clone stream: {e}"), 23))?;
 
     // upstream: log.c:330-340 - when !am_server, rwrite() sends itemize to
-    // FCLIENT (stdout). Build a callback that writes directly to process stdout.
+    // FCLIENT (stdout); the callback writes directly to process stdout.
     let wants_itemize = config.itemize_changes();
     let stdout_handle = std::io::stdout();
     let mut itemize_cb = move |line: &str| {
@@ -144,8 +143,7 @@ pub(crate) fn run_push_transfer(
         }
         Err(ref e) if dry_run && is_dry_run_remote_close(e) => {
             // upstream: clientserver.c - during --dry-run push, the daemon closes
-            // its socket early after receiving the file list since no actual data
-            // transfer is needed.
+            // its socket early after receiving the file list.
             Ok(ClientSummary::default())
         }
         Err(e) => Err(invalid_argument_error(&format!("transfer failed: {e}"), 23)),
@@ -261,10 +259,10 @@ pub(super) fn read_files_from_for_forwarding(
     use crate::client::config::FilesFromSource;
 
     let eol_nulls = config.from0();
-    // upstream: compat.c:799-806 — filesfrom_convert is set when
+    // upstream: compat.c:799-806 - filesfrom_convert is set when
     // protect_args && files_from && (am_sender ? ic_send : ic_recv) != -1.
     // For pull, this peer is the receiver writing to the wire; the converter
-    // must transcode from local charset to the UTF-8 wire encoding.
+    // transcodes from local charset to the UTF-8 wire encoding.
     let iconv_converter = if config.protect_args().unwrap_or(false) {
         config.iconv().resolve_converter()
     } else {

--- a/crates/core/src/client/remote/embedded_ssh_transfer.rs
+++ b/crates/core/src/client/remote/embedded_ssh_transfer.rs
@@ -204,7 +204,6 @@ fn parse_remote_operands_urls(
             for url in urls {
                 let (cfg, path) = parse_ssh_url(url, config)?;
                 if let Some(ref existing) = ssh_config {
-                    // Validate same host/port/user
                     let existing: &SshConfig = existing;
                     if cfg.host != existing.host
                         || cfg.port != existing.port
@@ -290,7 +289,6 @@ fn run_transfer_over_embedded_ssh(
 ) -> Result<ClientSummary, ClientError> {
     let remote_command = build_remote_command(invocation_args);
 
-    // Build stdin data for secluded-args delivery.
     let stdin_data = if stdin_args.is_empty() {
         None
     } else {
@@ -299,7 +297,7 @@ fn run_transfer_over_embedded_ssh(
             data.extend_from_slice(arg.as_bytes());
             data.push(0);
         }
-        data.push(0); // Terminal empty string
+        data.push(0);
         Some(data)
     };
 
@@ -310,7 +308,6 @@ fn run_transfer_over_embedded_ssh(
     )
     .map_err(|e| invalid_argument_error(&format!("embedded SSH connection failed: {e}"), 5))?;
 
-    // From here, the flow is identical to the system SSH path.
     let start = Instant::now();
     let batch_recording = batch_ctx.as_ref().map(|ctx| {
         let is_sender = server_config.role == ServerRole::Generator;

--- a/crates/core/src/client/remote/flags.rs
+++ b/crates/core/src/client/remote/flags.rs
@@ -30,7 +30,6 @@ pub(crate) fn build_server_flag_string(config: &ClientConfig) -> String {
     let effective_recursive = config.recursive() && !files_from_active;
     let effective_relative = config.relative_paths() || files_from_active;
 
-    // Order matches upstream server_options().
     if config.links() {
         flags.push('l');
     }
@@ -122,8 +121,8 @@ pub(crate) fn build_server_flag_string(config: &ClientConfig) -> String {
         flags.push('L');
     }
 
-    // Note: itemize-changes is forwarded via --log-format=%i in the
-    // long-form args, not as a compact flag - upstream: options.c:2750-2762
+    // upstream: options.c:2750-2762 - itemize-changes is forwarded via
+    // --log-format=%i in the long-form args, not as a compact flag.
 
     flags
 }
@@ -146,8 +145,8 @@ pub(crate) fn build_wire_format_rules(
             FilterRuleKind::Risk => RuleType::Risk,
             FilterRuleKind::DirMerge => RuleType::DirMerge,
             FilterRuleKind::ExcludeIfPresent => {
-                // ExcludeIfPresent is transmitted as Exclude with 'e' flag
-                // (FILTRULE_EXCLUDE_SELF in upstream rsync)
+                // upstream: ExcludeIfPresent is transmitted as Exclude with 'e' flag
+                // (FILTRULE_EXCLUDE_SELF).
                 wire_rules.push(FilterRuleWireFormat {
                     rule_type: RuleType::Exclude,
                     pattern: spec.pattern().to_owned(),
@@ -156,7 +155,8 @@ pub(crate) fn build_wire_format_rules(
                     no_inherit: false,
                     cvs_exclude: false,
                     word_split: false,
-                    exclude_from_merge: true, // 'e' flag = EXCLUDE_SELF
+                    // upstream: 'e' flag = FILTRULE_EXCLUDE_SELF.
+                    exclude_from_merge: true,
                     xattr_only: spec.is_xattr_only(),
                     sender_side: spec.applies_to_sender(),
                     receiver_side: spec.applies_to_receiver(),
@@ -426,13 +426,11 @@ mod tests {
 
         let rules = build_wire_format_rules(&specs).expect("should transmit ExcludeIfPresent");
 
-        // ExcludeIfPresent is now transmitted as Exclude with 'e' flag
         assert_eq!(rules.len(), 3);
         assert_eq!(rules[0].rule_type, RuleType::Exclude);
         assert_eq!(rules[0].pattern, "*.log");
         assert!(!rules[0].exclude_from_merge);
 
-        // ExcludeIfPresent becomes Exclude with exclude_from_merge (EXCLUDE_SELF)
         assert_eq!(rules[1].rule_type, RuleType::Exclude);
         assert_eq!(rules[1].pattern, ".git");
         assert!(rules[1].exclude_from_merge);
@@ -455,9 +453,9 @@ mod tests {
 
         assert_eq!(rules.len(), 1);
         assert_eq!(rules[0].rule_type, RuleType::DirMerge);
-        assert!(rules[0].no_inherit); // inherit(false) -> no_inherit(true)
-        assert!(rules[0].exclude_from_merge); // exclude_filter_file(true)
-        assert!(rules[0].word_split); // use_whitespace()
+        assert!(rules[0].no_inherit);
+        assert!(rules[0].exclude_from_merge);
+        assert!(rules[0].word_split);
     }
 
     #[test]

--- a/crates/core/src/client/remote/invocation/builder.rs
+++ b/crates/core/src/client/remote/invocation/builder.rs
@@ -71,7 +71,6 @@ impl<'a> RemoteInvocationBuilder<'a> {
     pub fn build_with_paths(&self, remote_paths: &[&str]) -> Vec<OsString> {
         let mut args = Vec::new();
 
-        // Use custom rsync path if specified, otherwise default to "rsync"
         if let Some(rsync_path) = self.config.rsync_path() {
             args.push(OsString::from(rsync_path));
         } else {
@@ -103,11 +102,10 @@ impl<'a> RemoteInvocationBuilder<'a> {
             };
         }
 
-        // Build the full argument list as if secluded args were off -
-        // these are what we will send over stdin.
+        // Build the full argument list as if secluded args were off; these
+        // are what we will send over stdin.
         let full_args = self.build_full_args_for_stdin(remote_paths);
 
-        // Build the minimal command line: rsync --server [-s] [--sender]
         let mut cmd_args = Vec::new();
         if let Some(rsync_path) = self.config.rsync_path() {
             cmd_args.push(OsString::from(rsync_path));
@@ -118,10 +116,10 @@ impl<'a> RemoteInvocationBuilder<'a> {
         if self.role == RemoteRole::Receiver {
             cmd_args.push(OsString::from("--sender"));
         }
-        // The `-s` flag tells the remote server to read args from stdin.
-        // upstream: options.c - protect_args flag sent as `-s` in server mode
+        // upstream: options.c - protect_args flag sent as `-s` in server
+        // mode tells the remote server to read args from stdin.
         cmd_args.push(OsString::from("-s"));
-        // Dummy argument required by upstream
+        // upstream: dummy argument required after the flag string.
         cmd_args.push(OsString::from("."));
 
         SecludedInvocation {
@@ -197,8 +195,8 @@ impl<'a> RemoteInvocationBuilder<'a> {
     /// `--key=value` tokens rather than single-character flags. The order mirrors
     /// upstream for predictable interop testing.
     fn append_long_form_args(&self, args: &mut Vec<OsString>) {
-        // --delete-* timing variants
-        // upstream: options.c - delete_mode forwarded as --delete-before/during/after/delay
+        // upstream: options.c - delete_mode forwarded as
+        // --delete-before/during/after/delay timing variants.
         match self.config.delete_mode() {
             DeleteMode::Disabled => {}
             DeleteMode::Before => args.push(OsString::from("--delete-before")),
@@ -215,12 +213,10 @@ impl<'a> RemoteInvocationBuilder<'a> {
             args.push(OsString::from("--force"));
         }
 
-        // --max-delete=N
         if let Some(max) = self.config.max_delete() {
             args.push(OsString::from(format!("--max-delete={max}")));
         }
 
-        // --max-size / --min-size
         if let Some(max) = self.config.max_file_size() {
             args.push(OsString::from(format!("--max-size={max}")));
         }
@@ -228,13 +224,12 @@ impl<'a> RemoteInvocationBuilder<'a> {
             args.push(OsString::from(format!("--min-size={min}")));
         }
 
-        // --modify-window=N
         if let Some(window) = self.config.modify_window() {
             args.push(OsString::from(format!("--modify-window={window}")));
         }
 
-        // --compress-level=N
-        // upstream: options.c - compress_level sent to server when explicitly set
+        // upstream: options.c - compress_level sent to server when
+        // explicitly set.
         if let Some(level) = self.config.compression_level() {
             let numeric = compression_level_to_numeric(level);
             args.push(OsString::from(format!("--compress-level={numeric}")));
@@ -258,8 +253,8 @@ impl<'a> RemoteInvocationBuilder<'a> {
             }
         }
 
-        // --checksum-choice=ALGO
-        // upstream: options.c - checksum_choice forwarded when not auto
+        // upstream: options.c - checksum_choice forwarded as
+        // --checksum-choice=ALGO when not auto.
         let checksum_choice = self.config.checksum_choice();
         if checksum_choice.transfer() != StrongChecksumAlgorithm::Auto
             || checksum_choice.file() != StrongChecksumAlgorithm::Auto
@@ -270,32 +265,27 @@ impl<'a> RemoteInvocationBuilder<'a> {
             )));
         }
 
-        // --block-size=N
         if let Some(bs) = self.config.block_size_override() {
             args.push(OsString::from(format!("--block-size={}", bs.get())));
         }
 
-        // --timeout=N
         if let TransferTimeout::Seconds(secs) = self.config.timeout() {
             args.push(OsString::from(format!("--timeout={}", secs.get())));
         }
 
-        // --bwlimit=N
-        // upstream: options.c - bwlimit forwarded as bytes-per-second
+        // upstream: options.c - bwlimit forwarded as bytes-per-second.
         if let Some(bwlimit) = self.config.bandwidth_limit() {
             let mut arg = OsString::from("--bwlimit=");
             arg.push(bwlimit.fallback_argument());
             args.push(arg);
         }
 
-        // --partial-dir=DIR
         if let Some(dir) = self.config.partial_directory() {
             let mut arg = OsString::from("--partial-dir=");
             arg.push(dir.as_os_str());
             args.push(arg);
         }
 
-        // --temp-dir=DIR
         if let Some(dir) = self.config.temp_directory() {
             let mut arg = OsString::from("--temp-dir=");
             arg.push(dir.as_os_str());
@@ -312,7 +302,6 @@ impl<'a> RemoteInvocationBuilder<'a> {
             args.push(OsString::from("--append-verify"));
         }
 
-        // --copy-unsafe-links, --safe-links, --munge-links
         if self.config.copy_unsafe_links() {
             args.push(OsString::from("--copy-unsafe-links"));
         }
@@ -323,7 +312,7 @@ impl<'a> RemoteInvocationBuilder<'a> {
             args.push(OsString::from("--munge-links"));
         }
 
-        // --numeric-ids - upstream: options.c:2887-2888 (long-form only)
+        // upstream: options.c:2887-2888 - --numeric-ids is long-form only.
         if self.config.numeric_ids() {
             args.push(OsString::from("--numeric-ids"));
         }
@@ -364,7 +353,6 @@ impl<'a> RemoteInvocationBuilder<'a> {
             args.push(OsString::from("--delay-updates"));
         }
 
-        // --backup, --backup-dir=DIR, --suffix=SUFFIX
         if self.config.backup() {
             args.push(OsString::from("--backup"));
             if let Some(dir) = self.config.backup_directory() {
@@ -379,7 +367,6 @@ impl<'a> RemoteInvocationBuilder<'a> {
             }
         }
 
-        // --compare-dest, --copy-dest, --link-dest
         for ref_dir in self.config.reference_directories() {
             let flag = match ref_dir.kind() {
                 ReferenceDirectoryKind::Compare => "--compare-dest=",
@@ -414,11 +401,11 @@ impl<'a> RemoteInvocationBuilder<'a> {
             args.push(OsString::from("--log-format=%i"));
         }
 
-        // --files-from forwarding.
-        // upstream: options.c:2944-2956 - when the file is local (or stdin),
-        // the client reads it and forwards content over the socket, so we tell
-        // the server `--files-from=- --from0`. When the file is remote, we
-        // send `--files-from=<path>` and optionally `--from0`.
+        // upstream: options.c:2944-2956 - --files-from forwarding. When the
+        // file is local (or stdin), the client reads it and forwards content
+        // over the socket, so we tell the server `--files-from=- --from0`.
+        // When the file is remote, we send `--files-from=<path>` and
+        // optionally `--from0`.
         match self.config.files_from() {
             FilesFromSource::None => {}
             FilesFromSource::LocalFile(_) | FilesFromSource::Stdin => {
@@ -433,12 +420,12 @@ impl<'a> RemoteInvocationBuilder<'a> {
             }
         }
 
-        // --iconv forwarding.
-        // upstream: options.c:2716-2723 - when iconv_opt contains a comma, only
-        // the post-comma half (the remote charset) is forwarded; otherwise the
-        // whole string is forwarded as-is. `--iconv=-` (Disabled) and the
-        // default (Unspecified) forward nothing because upstream nulls
-        // iconv_opt at options.c:2052-2054 before this branch runs.
+        // upstream: options.c:2716-2723 - --iconv forwarding. When iconv_opt
+        // contains a comma, only the post-comma half (the remote charset) is
+        // forwarded; otherwise the whole string is forwarded as-is.
+        // `--iconv=-` (Disabled) and the default (Unspecified) forward
+        // nothing because upstream nulls iconv_opt at options.c:2052-2054
+        // before this branch runs.
         match self.config.iconv() {
             IconvSetting::Unspecified | IconvSetting::Disabled => {}
             IconvSetting::LocaleDefault => {
@@ -466,7 +453,7 @@ impl<'a> RemoteInvocationBuilder<'a> {
         let effective_recursive = self.config.recursive() && !files_from_active;
         let effective_relative = self.config.relative_paths() || files_from_active;
 
-        // Transfer flags (order matches upstream server_options())
+        // upstream: options.c:server_options() - transfer flag order.
         if self.config.links() {
             flags.push('l');
         }
@@ -570,8 +557,8 @@ impl<'a> RemoteInvocationBuilder<'a> {
             flags.push('v');
         }
 
-        // Note: itemize-changes is forwarded via --log-format=%i in
-        // append_long_form_args(), not as a compact flag - upstream: options.c:2750-2762
+        // upstream: options.c:2750-2762 - itemize-changes is forwarded via
+        // --log-format=%i in append_long_form_args(), not as a compact flag.
 
         flags
     }

--- a/crates/core/src/client/remote/invocation/tests.rs
+++ b/crates/core/src/client/remote/invocation/tests.rs
@@ -2165,10 +2165,6 @@ fn all_flags_enabled_produces_valid_invocation() {
     assert!(args.contains(&"/path".to_owned()));
 }
 
-// ---------------------------------------------------------------------------
-// operand_is_remote: local path classification
-// ---------------------------------------------------------------------------
-
 #[test]
 fn local_absolute_path_is_not_remote() {
     assert!(!operand_is_remote(OsStr::new("/tmp/foo")));
@@ -2211,10 +2207,6 @@ fn local_parent_path_is_not_remote() {
     assert!(!operand_is_remote(OsStr::new("..")));
 }
 
-// ---------------------------------------------------------------------------
-// operand_is_remote: Windows drive letter handling
-// ---------------------------------------------------------------------------
-
 #[cfg(windows)]
 #[test]
 fn windows_drive_letter_is_not_remote() {
@@ -2235,10 +2227,6 @@ fn single_letter_colon_on_unix_is_remote() {
     assert!(operand_is_remote(OsStr::new("C:")));
 }
 
-// ---------------------------------------------------------------------------
-// operand_is_remote: rsync:// URL detection
-// ---------------------------------------------------------------------------
-
 #[test]
 fn rsync_url_is_remote() {
     assert!(operand_is_remote(OsStr::new("rsync://host/module/path")));
@@ -2253,10 +2241,6 @@ fn rsync_url_with_user_is_remote() {
 fn rsync_url_bare_host_is_remote() {
     assert!(operand_is_remote(OsStr::new("rsync://host")));
 }
-
-// ---------------------------------------------------------------------------
-// operand_is_remote: ssh:// URL detection
-// ---------------------------------------------------------------------------
 
 #[test]
 fn ssh_url_is_remote() {
@@ -2278,10 +2262,6 @@ fn ssh_url_bare_host_is_remote() {
     assert!(operand_is_remote(OsStr::new("ssh://host")));
 }
 
-// ---------------------------------------------------------------------------
-// operand_is_remote: traditional remote-shell syntax (host:path)
-// ---------------------------------------------------------------------------
-
 #[test]
 fn host_colon_path_is_remote() {
     assert!(operand_is_remote(OsStr::new("host:path")));
@@ -2302,10 +2282,6 @@ fn ip_colon_path_is_remote() {
     assert!(operand_is_remote(OsStr::new("192.168.1.1:/data")));
 }
 
-// ---------------------------------------------------------------------------
-// operand_is_remote: double-colon daemon syntax (host::module)
-// ---------------------------------------------------------------------------
-
 #[test]
 fn host_double_colon_module_is_remote() {
     assert!(operand_is_remote(OsStr::new("host::module")));
@@ -2320,10 +2296,6 @@ fn user_at_host_double_colon_module_is_remote() {
 fn host_double_colon_module_path_is_remote() {
     assert!(operand_is_remote(OsStr::new("host::module/subdir")));
 }
-
-// ---------------------------------------------------------------------------
-// operand_is_remote: edge cases
-// ---------------------------------------------------------------------------
 
 #[test]
 fn empty_string_is_not_remote() {
@@ -2370,10 +2342,6 @@ fn path_with_single_colon_only_is_remote() {
     // '/' or '\', so it falls through to remote classification.
     assert!(operand_is_remote(OsStr::new(":")));
 }
-
-// ---------------------------------------------------------------------------
-// operand_is_remote integration with determine_transfer_role
-// ---------------------------------------------------------------------------
 
 #[test]
 fn local_to_ssh_url_is_push() {

--- a/crates/core/src/client/remote/invocation/transfer_role.rs
+++ b/crates/core/src/client/remote/invocation/transfer_role.rs
@@ -41,7 +41,7 @@ pub fn operand_is_remote(path: &OsStr) -> bool {
                 .next()
                 .map_or(false, |c| c.is_ascii_alphabetic())
         {
-            return false; // Windows drive letter
+            return false;
         }
 
         let before = &text[..colon_index];
@@ -68,7 +68,6 @@ pub fn operand_is_remote(path: &OsStr) -> bool {
 fn parse_remote_operand(operand: &str) -> Result<RemoteOperandParsed, ClientError> {
     let operand_str = operand.to_owned();
 
-    // Split on first colon to separate host part from path
     let colon_pos = operand.rfind(':').ok_or_else(|| {
         invalid_argument_error(
             &format!("invalid remote operand: missing ':' in {operand}"),
@@ -78,7 +77,6 @@ fn parse_remote_operand(operand: &str) -> Result<RemoteOperandParsed, ClientErro
 
     let host_part = &operand[..colon_pos];
 
-    // Check for user@host format
     let (user, host_with_port) = if let Some(at_pos) = host_part.find('@') {
         let user = host_part[..at_pos].to_string();
         let host = &host_part[at_pos + 1..];
@@ -87,8 +85,6 @@ fn parse_remote_operand(operand: &str) -> Result<RemoteOperandParsed, ClientErro
         (None, host_part)
     };
 
-    // For now, we don't parse port from host (would need more complex parsing for IPv6)
-    // Port parsing can be added later if needed
     let host = host_with_port.to_owned();
     let port = None;
 
@@ -116,7 +112,6 @@ fn validate_same_host(operands: &[RemoteOperandParsed]) -> Result<(), ClientErro
     let first = &operands[0];
 
     for operand in &operands[1..] {
-        // Validate host consistency
         if operand.host != first.host {
             return Err(invalid_argument_error(
                 &format!(
@@ -127,7 +122,6 @@ fn validate_same_host(operands: &[RemoteOperandParsed]) -> Result<(), ClientErro
             ));
         }
 
-        // Validate user consistency
         match (&operand.user, &first.user) {
             (Some(u1), Some(u2)) if u1 != u2 => {
                 return Err(invalid_argument_error(
@@ -144,7 +138,6 @@ fn validate_same_host(operands: &[RemoteOperandParsed]) -> Result<(), ClientErro
             _ => {}
         }
 
-        // Validate port consistency
         if operand.port != first.port {
             return Err(invalid_argument_error(
                 "remote sources must use the same port",
@@ -182,7 +175,6 @@ pub fn determine_transfer_role(
 ) -> Result<TransferSpec, ClientError> {
     let dest_is_remote = operand_is_remote(destination);
 
-    // Check if any sources are remote
     let remote_sources: Vec<_> = sources.iter().filter(|s| operand_is_remote(s)).collect();
 
     let has_remote_source = !remote_sources.is_empty();
@@ -190,7 +182,6 @@ pub fn determine_transfer_role(
 
     match (has_remote_source, dest_is_remote) {
         (true, true) => {
-            // Remote-to-remote: proxy between two remote hosts
             if !all_sources_remote {
                 return Err(invalid_argument_error(
                     "mixing remote and local sources is not supported",
@@ -198,17 +189,14 @@ pub fn determine_transfer_role(
                 ));
             }
 
-            // Parse all remote sources
             let parsed_sources: Result<Vec<_>, _> = sources
                 .iter()
                 .map(|s| parse_remote_operand(&s.to_string_lossy()))
                 .collect();
             let parsed_sources = parsed_sources?;
 
-            // Validate all sources are from the same host
             validate_same_host(&parsed_sources)?;
 
-            // Build remote source operands
             let remote_sources = if sources.len() > 1 {
                 RemoteOperands::Multiple(
                     sources
@@ -225,12 +213,8 @@ pub fn determine_transfer_role(
                 remote_dest: destination.to_string_lossy().to_string(),
             })
         }
-        (false, false) => {
-            // Neither is remote - should use local copy
-            Err(invalid_argument_error("no remote operand found", 1))
-        }
+        (false, false) => Err(invalid_argument_error("no remote operand found", 1)),
         (true, false) => {
-            // Pull: remote source(s) -> local destination
             if !all_sources_remote {
                 return Err(invalid_argument_error(
                     "mixing remote and local sources is not supported",
@@ -238,19 +222,16 @@ pub fn determine_transfer_role(
                 ));
             }
 
-            // Parse all remote sources
             let parsed_sources: Result<Vec<_>, _> = sources
                 .iter()
                 .map(|s| parse_remote_operand(&s.to_string_lossy()))
                 .collect();
             let parsed_sources = parsed_sources?;
 
-            // Validate all sources are from the same host
             validate_same_host(&parsed_sources)?;
 
             let local_dest = destination.to_string_lossy().to_string();
 
-            // Return Multiple if > 1 source, Single otherwise
             let remote_sources = if sources.len() > 1 {
                 RemoteOperands::Multiple(
                     sources
@@ -268,7 +249,6 @@ pub fn determine_transfer_role(
             })
         }
         (false, true) => {
-            // Push: local source(s) -> remote destination
             let local_sources: Vec<String> = sources
                 .iter()
                 .map(|s| s.to_string_lossy().to_string())

--- a/crates/core/src/client/remote/remote_to_remote.rs
+++ b/crates/core/src/client/remote/remote_to_remote.rs
@@ -82,16 +82,13 @@ pub fn run_remote_to_remote_transfer(
     remote_sources: RemoteOperands,
     remote_dest: String,
 ) -> Result<ClientSummary, ClientError> {
-    // Parse remote operands
     let (source_host, source_user, source_port, source_paths) =
         parse_source_operands(&remote_sources)?;
     let (dest_host, dest_user, dest_port, dest_path) = parse_dest_operand(&remote_dest)?;
 
-    // Build invocation arguments for both sides
     let source_invocation = build_source_invocation(config, &source_paths);
     let dest_invocation = build_dest_invocation(config, &dest_path);
 
-    // Spawn SSH connections
     let source_conn = spawn_ssh_connection(
         &source_user,
         &source_host,
@@ -102,10 +99,8 @@ pub fn run_remote_to_remote_transfer(
     let dest_conn =
         spawn_ssh_connection(&dest_user, &dest_host, dest_port, &dest_invocation, config)?;
 
-    // Run bidirectional relay
     let stats = run_bidirectional_relay(source_conn, dest_conn)?;
 
-    // Convert stats to client summary
     Ok(build_proxy_summary(stats))
 }
 
@@ -193,7 +188,6 @@ fn spawn_ssh_connection(
         ssh.set_port(port);
     }
 
-    // Configure custom remote shell if specified
     if let Some(shell_args) = config.remote_shell()
         && !shell_args.is_empty()
     {
@@ -203,14 +197,12 @@ fn spawn_ssh_connection(
         }
     }
 
-    // Forward --address to SSH as -o BindAddress=<addr>.
     if let Some(bind_addr) = config.bind_address() {
         ssh.set_bind_address(Some(bind_addr.socket().ip()));
     }
 
     ssh.set_prefer_aes_gcm(config.prefer_aes_gcm());
 
-    // Wire --contimeout to SSH's -o ConnectTimeout.
     let connect_timeout = config
         .connect_timeout()
         .effective(std::time::Duration::from_secs(30));
@@ -250,7 +242,6 @@ fn run_bidirectional_relay(
     source: SshConnection,
     dest: SshConnection,
 ) -> Result<ProxyStats, ClientError> {
-    // Split connections into read/write halves for thread-safe operation
     let (source_reader, source_writer, source_handle) = source.split().map_err(|e| {
         invalid_argument_error(&format!("failed to split source connection: {e}"), 23)
     })?;
@@ -258,14 +249,11 @@ fn run_bidirectional_relay(
         invalid_argument_error(&format!("failed to split destination connection: {e}"), 23)
     })?;
 
-    // Shared flag to signal shutdown
     let shutdown = Arc::new(AtomicBool::new(false));
 
-    // Channels for receiving thread completion (enables timeout)
     let (s2d_tx, s2d_rx) = mpsc::channel();
     let (d2s_tx, d2s_rx) = mpsc::channel();
 
-    // Thread 1: source → destination (file data, file list)
     let shutdown_s2d = Arc::clone(&shutdown);
     thread::spawn(move || {
         let result =
@@ -273,7 +261,6 @@ fn run_bidirectional_relay(
         let _ = s2d_tx.send(result);
     });
 
-    // Thread 2: destination → source (checksums, acks)
     let shutdown_d2s = Arc::clone(&shutdown);
     thread::spawn(move || {
         let result =
@@ -281,7 +268,6 @@ fn run_bidirectional_relay(
         let _ = d2s_tx.send(result);
     });
 
-    // Wait for both threads with timeout
     let s2d_result = s2d_rx
         .recv_timeout(RELAY_THREAD_TIMEOUT)
         .map_err(|e| match e {
@@ -306,8 +292,7 @@ fn run_bidirectional_relay(
             }
         })??;
 
-    // Wait for child processes and check exit status.
-    // Mirror upstream: propagate the worst exit code from either child.
+    // upstream: propagate the worst exit code from either child.
     let (source_exit, source_stderr) = match source_handle.wait_with_stderr() {
         Ok((status, stderr_bytes)) => (
             super::ssh_transfer::map_child_exit_status(status),
@@ -323,7 +308,6 @@ fn run_bidirectional_relay(
         Err(_) => (ExitCode::WaitChild, Vec::new()),
     };
 
-    // Take the worst (highest) exit code from either child.
     let worst_exit = if source_exit.as_i32() >= dest_exit.as_i32() {
         source_exit
     } else {
@@ -331,7 +315,6 @@ fn run_bidirectional_relay(
     };
 
     if !worst_exit.is_success() {
-        // Combine stderr from both sides for the error message.
         let mut combined_stderr = source_stderr;
         if !combined_stderr.is_empty() && !dest_stderr.is_empty() {
             combined_stderr.push(b'\n');
@@ -372,7 +355,6 @@ fn run_relay_with_panic_guard(
     match result {
         Ok(inner_result) => inner_result,
         Err(panic_info) => {
-            // Ensure shutdown is signaled on panic
             shutdown_clone.store(true, Ordering::SeqCst);
             let message = if let Some(s) = panic_info.downcast_ref::<&str>() {
                 format!("{direction} relay thread panicked: {s}")
@@ -407,14 +389,12 @@ fn relay_data(
     let mut total_bytes = 0u64;
 
     loop {
-        // Check for shutdown signal
         if shutdown.load(Ordering::Relaxed) {
             break;
         }
 
         match reader.read(&mut buf) {
             Ok(0) => {
-                // EOF reached - signal shutdown and close writer
                 shutdown.store(true, Ordering::Relaxed);
                 let _ = writer.close();
                 break;
@@ -432,7 +412,6 @@ fn relay_data(
             }
             Err(e) if e.kind() == io::ErrorKind::Interrupted => continue,
             Err(e) if e.kind() == io::ErrorKind::WouldBlock => {
-                // Non-blocking I/O - yield and retry
                 thread::yield_now();
                 continue;
             }
@@ -453,7 +432,6 @@ fn relay_data(
 fn build_proxy_summary(stats: ProxyStats) -> ClientSummary {
     use engine::local_copy::LocalCopySummary;
 
-    // Create a summary with the bytes relayed
     let summary =
         LocalCopySummary::from_proxy_stats(stats.bytes_source_to_dest, stats.bytes_dest_to_source);
 

--- a/crates/core/src/client/remote/ssh_transfer.rs
+++ b/crates/core/src/client/remote/ssh_transfer.rs
@@ -185,10 +185,7 @@ pub fn run_ssh_transfer(
         TransferSpec::Proxy {
             remote_sources,
             remote_dest,
-        } => {
-            // Proxy: remote → remote (via local)
-            run_proxy_transfer(config, remote_sources, remote_dest, observer)
-        }
+        } => run_proxy_transfer(config, remote_sources, remote_dest, observer),
     }
 }
 
@@ -222,7 +219,6 @@ fn parse_remote_operands(
     match remote_operands {
         RemoteOperands::Single(operand_str) => parse_single_remote(operand_str, config, role),
         RemoteOperands::Multiple(operand_strs) => {
-            // Multiple sources (pull operation)
             let first_operand = parse_ssh_operand(OsStr::new(&operand_strs[0]))
                 .map_err(|e| invalid_argument_error(&format!("invalid remote operand: {e}"), 1))?;
 
@@ -272,19 +268,17 @@ fn build_ssh_connection(
         ssh.set_port(port);
     }
 
-    // Configure custom remote shell if specified
     if let Some(shell_args) = config.remote_shell()
         && !shell_args.is_empty()
     {
         ssh.set_program(&shell_args[0]);
-        // Remaining arguments are SSH options
         for arg in &shell_args[1..] {
             ssh.push_option(arg.clone());
         }
     }
 
-    // Forward --address to SSH as -o BindAddress=<addr>.
-    // upstream: clientserver.c — start_socket_client() binds the local address.
+    // upstream: clientserver.c start_socket_client() binds the local address;
+    // forward --address to SSH as -o BindAddress=<addr>.
     if let Some(bind_addr) = config.bind_address() {
         ssh.set_bind_address(Some(bind_addr.socket().ip()));
     }
@@ -292,17 +286,13 @@ fn build_ssh_connection(
     ssh.set_prefer_aes_gcm(config.prefer_aes_gcm());
     ssh.set_jump_hosts(config.jump_hosts().map(OsString::from));
 
-    // Wire --contimeout to SSH's -o ConnectTimeout.
-    // upstream: options.c — contimeout is forwarded as ConnectTimeout when
-    // spawning the remote shell.
+    // upstream: options.c - contimeout is forwarded as SSH's -o ConnectTimeout.
     let connect_timeout = config.connect_timeout().effective(Duration::from_secs(30));
     ssh.set_connect_timeout(connect_timeout);
 
-    // Set the remote command (rsync --server ...)
     ssh.set_remote_command(invocation_args);
 
-    // Spawn the SSH process
-    // Mirror upstream: SSH spawn failures return IPC error code (pipe.c:85)
+    // upstream: pipe.c:85 - SSH spawn failures return IPC error code.
     let mut connection = ssh.spawn().map_err(|e| {
         invalid_argument_error(
             &format!("failed to spawn SSH connection: {e}"),
@@ -310,8 +300,7 @@ fn build_ssh_connection(
         )
     })?;
 
-    // Send secluded args over stdin if enabled.
-    // upstream: rsync.c:283-320 — send_protected_args() sends args as
+    // upstream: rsync.c:283-320 send_protected_args() sends args as
     // null-separated strings over the pipe before protocol negotiation begins,
     // applying iconvbufs(ic_send, ...) to each arg when iconv is configured
     // (compat.c:799-806 filesfrom_convert / protect-args iconv gating).
@@ -349,10 +338,9 @@ fn run_pull_transfer(
     observer: Option<&mut dyn ClientProgressObserver>,
     batch_writer: Option<Arc<Mutex<BatchWriter>>>,
 ) -> Result<ClientSummary, ClientError> {
-    // Build server config for receiver role with client_mode enabled.
-    // client_mode = true tells the server flow to send the filter list at the
-    // correct point in the protocol (after handshake + compat exchange), matching
-    // upstream main.c:1258 where recv_filter_list() is called inside the server.
+    // upstream: main.c:1258 - client_mode=true tells the server flow to send the
+    // filter list after handshake + compat exchange (where recv_filter_list() is
+    // called inside the server).
     let mut server_config = build_server_config_for_receiver(config, local_paths)?;
     server_config.connection.client_mode = true;
     server_config.connection.filter_rules = flags::build_wire_format_rules(config.filter_rules())
@@ -386,9 +374,8 @@ fn run_push_transfer(
     observer: Option<&mut dyn ClientProgressObserver>,
     batch_writer: Option<Arc<Mutex<BatchWriter>>>,
 ) -> Result<ClientSummary, ClientError> {
-    // Build server config for generator (sender) role with client_mode enabled.
-    // client_mode = true ensures the filter list is sent at the correct point
-    // in the protocol flow (after handshake + compat exchange).
+    // upstream: client_mode=true ensures the filter list is sent after
+    // handshake + compat exchange.
     let mut server_config = build_server_config_for_generator(config, local_paths)?;
     server_config.connection.client_mode = true;
     server_config.connection.filter_rules = flags::build_wire_format_rules(config.filter_rules())
@@ -472,14 +459,13 @@ pub(super) fn convert_server_stats_to_summary(
 
     let mut summary = ClientSummary::from_summary(local_summary);
 
-    // Map accumulated I/O error flags to an exit code.
-    // upstream: log.c - log_exit() converts io_error bitfield to RERR_* codes.
+    // upstream: log.c log_exit() - convert io_error bitfield to RERR_* codes.
     let exit_code = io_error_flags::to_exit_code(io_error);
     if exit_code != 0 {
         summary.set_io_error_exit_code(exit_code);
     } else if error_count > 0 {
-        // Remote sender reported errors via MSG_ERROR - treat as partial transfer.
-        summary.set_io_error_exit_code(23); // RERR_PARTIAL
+        // Remote sender reported errors via MSG_ERROR - treat as RERR_PARTIAL.
+        summary.set_io_error_exit_code(23);
     }
 
     summary
@@ -499,7 +485,6 @@ pub(super) fn map_child_exit_status(status: std::process::ExitStatus) -> ExitCod
         return ExitCode::Ok;
     }
 
-    // On Unix, check if killed by signal
     #[cfg(unix)]
     {
         use std::os::unix::process::ExitStatusExt;
@@ -511,10 +496,7 @@ pub(super) fn map_child_exit_status(status: std::process::ExitStatus) -> ExitCod
     match status.code() {
         Some(127) => ExitCode::CommandNotFound,
         Some(255) => ExitCode::CommandFailed,
-        Some(code) => {
-            // Try to interpret as a known rsync exit code from the remote side.
-            ExitCode::from_i32(code).unwrap_or(ExitCode::PartialTransfer)
-        }
+        Some(code) => ExitCode::from_i32(code).unwrap_or(ExitCode::PartialTransfer),
         None => ExitCode::WaitChild,
     }
 }
@@ -538,7 +520,6 @@ pub(super) fn format_stderr_context(stderr_bytes: &[u8]) -> String {
 }
 
 /// Batch recording context passed through the SSH transfer chain.
-// Batch support types are shared with the daemon transfer path.
 use super::batch_support::{BatchContext, build_batch_context, build_batch_recording};
 
 /// Runs server over an SSH connection using split read/write halves.
@@ -575,8 +556,8 @@ fn run_server_over_ssh_connection(
     let handshake = match crate::server::perform_handshake(&mut reader, &mut writer) {
         Ok(h) => h,
         Err(e) => {
-            // Capture SSH stderr before returning - the remote process likely wrote
-            // diagnostic output (e.g., "Connection refused") that explains the failure.
+            // Capture SSH stderr - the remote process likely wrote diagnostic
+            // output (e.g., "Connection refused") that explains the failure.
             drop(writer);
             let stderr_text = match child_handle.wait_with_stderr() {
                 Ok((_, stderr_bytes)) => format_stderr_context(&stderr_bytes),
@@ -589,9 +570,8 @@ fn run_server_over_ssh_connection(
         }
     };
 
-    // Connection established - disarm the connect watchdog. If the watchdog
-    // already fired (timeout expired during handshake), map to exit code 35
-    // (RERR_CONTIMEOUT) matching upstream rsync's --contimeout behavior.
+    // upstream: --contimeout - if watchdog already fired (timeout expired during
+    // handshake), map to exit code 35 (RERR_CONTIMEOUT).
     if let Err(e) = child_handle.cancel_connect_watchdog() {
         return Err(invalid_argument_error(
             &format!("{e}"),
@@ -608,11 +588,10 @@ fn run_server_over_ssh_connection(
         None,
     );
 
-    // Close the writer to signal EOF to the remote process, allowing it to exit.
+    // Close the writer to signal EOF so the remote process can exit.
     drop(writer);
 
-    // Wait for SSH child and map its exit status.
-    // Mirror upstream: wait_process_with_flush() in main.c
+    // upstream: main.c wait_process_with_flush() - wait for child and map status.
     let (child_exit_code, stderr_text) = match child_handle.wait_with_stderr() {
         Ok((status, stderr_bytes)) => {
             let stderr_text = format_stderr_context(&stderr_bytes);
@@ -767,7 +746,6 @@ mod tests {
         assert!(output.contains("error:"));
     }
 
-    // Tests for map_child_exit_status
     #[cfg(unix)]
     mod child_exit_status_tests {
         use super::*;

--- a/crates/core/src/client/run/batch.rs
+++ b/crates/core/src/client/run/batch.rs
@@ -198,7 +198,6 @@ pub(crate) fn finalize_batch(
         }
     }
 
-    // Generate the .sh replay script
     if let Err(e) = engine::batch::script::generate_script(batch_cfg) {
         let msg = format!("failed to generate batch script: {e}");
         return Err(ClientError::new(
@@ -294,12 +293,10 @@ mod tests {
 
         let writer_arc = create_batch_writer(&batch_cfg).unwrap();
 
-        // Even when compress=true, the header must say do_compression=false
         let config = config_with_compress(true);
         write_batch_header(&writer_arc, &config).unwrap();
         drop(writer_arc);
 
-        // Read back and verify
         let read_cfg = BatchConfig::new(BatchMode::Read, path.to_string_lossy().to_string(), 31);
         let mut reader = engine::batch::BatchReader::new(read_cfg).unwrap();
         let flags = reader.read_header().unwrap();

--- a/crates/core/src/client/run/mod.rs
+++ b/crates/core/src/client/run/mod.rs
@@ -182,7 +182,6 @@ fn run_client_internal(
         return Err(missing_operands_error());
     }
 
-    // Handle batch mode configuration
     let batch_writer = if let Some(batch_cfg) = config.batch_config() {
         if let Some(result) = batch::handle_batch_read(batch_cfg, &config) {
             return result;
@@ -192,13 +191,11 @@ fn run_client_internal(
         None
     };
 
-    // Check for remote operands and dispatch appropriately
     let has_daemon_url = config.transfer_args().iter().any(|arg| {
         arg.to_string_lossy().starts_with("rsync://") || arg.to_string_lossy().contains("::")
     });
 
     if has_daemon_url {
-        // Daemon data transfer via rsync:// URLs
         return remote::run_daemon_transfer(&config, observer, batch_writer);
     }
 
@@ -208,9 +205,8 @@ fn run_client_internal(
         .any(|arg| remote::operand_is_remote(arg));
 
     if has_remote {
-        // When the embedded-ssh feature is enabled and any operand uses an
-        // ssh:// URL, dispatch to the embedded SSH transport instead of
-        // spawning the system ssh binary.
+        // ssh:// operands dispatch to the embedded SSH transport instead of
+        // spawning the system ssh binary when embedded-ssh is enabled.
         #[cfg(feature = "embedded-ssh")]
         {
             let has_ssh_url = config
@@ -234,7 +230,6 @@ fn run_client_internal(
 
         let summary = remote::run_ssh_transfer(&config, observer, batch_writer.clone())?;
 
-        // Finalize batch file if batch mode was active
         if let Some(ref writer_arc) = batch_writer
             && let Some(batch_cfg) = config.batch_config()
         {
@@ -244,15 +239,14 @@ fn run_client_internal(
         return Ok(summary);
     }
 
-    // Local copy path
     let plan = match LocalCopyPlan::from_operands(config.transfer_args()) {
         Ok(plan) => plan,
         Err(error) => return Err(map_local_copy_error(error)),
     };
 
-    // Mirror upstream: validate destination directory access early (main.c:751)
-    // This returns FILE_SELECTION error (3) instead of PARTIAL_TRANSFER (23)
-    // Check the destination itself if it's a directory, otherwise check its parent
+    // upstream: main.c:751 validates destination directory access early,
+    // returning FILE_SELECTION (3) for PermissionDenied instead of
+    // PARTIAL_TRANSFER (23). Other errors (e.g. NotFound) proceed normally.
     use std::fs;
     let dest_to_check = if plan.destination().is_dir() {
         plan.destination()
@@ -262,10 +256,7 @@ fn run_client_internal(
         plan.destination()
     };
 
-    // Try to read the directory - this will fail with Permission Denied if not accessible
     if let Err(error) = fs::read_dir(dest_to_check) {
-        // Only return FILE_SELECTION error for permission denied
-        // Other errors (like NotFound) should proceed normally
         if error.kind() == std::io::ErrorKind::PermissionDenied {
             return Err(super::error::destination_access_error(dest_to_check, error));
         }
@@ -274,7 +265,6 @@ fn run_client_internal(
     let filter_program = filters::compile_filter_program(config.filter_rules())?;
     let mut options = build_local_copy_options(&config, filter_program);
 
-    // Attach batch writer to options if in batch write mode
     let batch_writer_for_options = if let Some(ref writer) = batch_writer {
         batch::write_batch_header(writer, &config)?;
         Some(writer.clone())
@@ -324,7 +314,6 @@ fn run_client_internal(
 
     let summary = summary.map_err(map_local_copy_error)?;
 
-    // Finalize batch file if batch mode was active
     if let Some(ref writer_arc) = batch_writer
         && let Some(batch_cfg) = config.batch_config()
     {
@@ -450,11 +439,10 @@ impl<'a> LocalCopyOptionsBuilder<'a> {
         options: LocalCopyOptions,
         config: &ClientConfig,
     ) -> LocalCopyOptions {
-        // When writing batch files, force zlib compression for cross-tool
-        // interop. The batch header records do_compression but not which
-        // algorithm was used, so upstream rsync (which defaults to zlib)
-        // cannot decode zstd/lz4 batch data. Force zlib to match upstream.
         // upstream: batch.c tees compressed wire bytes using zlib by default.
+        // The batch header records do_compression but not which algorithm,
+        // so upstream rsync cannot decode zstd/lz4 batch data; force zlib for
+        // cross-tool interop.
         let algorithm = if config.batch_config().is_some_and(|bc| bc.is_write_mode()) {
             compress::algorithm::CompressionAlgorithm::Zlib
         } else {
@@ -473,7 +461,6 @@ impl<'a> LocalCopyOptionsBuilder<'a> {
         mut options: LocalCopyOptions,
         config: &ClientConfig,
     ) -> LocalCopyOptions {
-        // Resolve --copy-as USER[:GROUP] specification into numeric IDs
         let copy_as_ids = config
             .copy_as()
             .and_then(|spec| ::metadata::parse_copy_as_spec(spec).ok());
@@ -503,9 +490,8 @@ impl<'a> LocalCopyOptionsBuilder<'a> {
             options = options.acls(config.preserve_acls());
         }
 
-        // IMPORTANT: LocalCopyOptions::xattrs is only implemented on Unix.
-        // Match the engine crate's cfg so Windows builds with the `xattr`
-        // feature do not try to call a non-existent method.
+        // LocalCopyOptions::xattrs is Unix-only; match the engine crate's cfg
+        // so Windows builds with the `xattr` feature do not call a missing method.
         #[cfg(all(feature = "xattr", unix))]
         {
             options = options.xattrs(config.preserve_xattrs());
@@ -653,8 +639,6 @@ mod iconv_wiring_tests {
         let converter = options
             .iconv()
             .expect("locale-default iconv should produce a converter");
-        // converter_from_locale() currently returns identity; the contract
-        // is that *some* converter is attached, regardless of identity.
         assert!(converter.is_identity());
     }
 

--- a/crates/core/src/client/summary/mod.rs
+++ b/crates/core/src/client/summary/mod.rs
@@ -75,8 +75,7 @@ impl ClientSummary {
         }
     }
 
-    // Allow large_types_passed_by_value: constructor intentionally takes ownership
-    #[allow(clippy::large_types_passed_by_value)]
+    #[allow(clippy::large_types_passed_by_value)] // REASON: constructor takes ownership
     pub(crate) const fn from_summary(summary: LocalCopySummary) -> Self {
         Self {
             stats: summary,

--- a/crates/core/src/client/tests/builder_compress.rs
+++ b/crates/core/src/client/tests/builder_compress.rs
@@ -505,7 +505,6 @@ fn connect_direct_applies_io_timeout() {
     assert_eq!(stream.read_timeout().expect("read timeout"), timeout);
     assert_eq!(stream.write_timeout().expect("write timeout"), timeout);
 
-    // Wake the accept loop and close cleanly.
     let _ = stream.write_all(&[0]);
     handle.join().expect("listener thread");
 }


### PR DESCRIPTION
Comment cleanup for `crates/core/src/client/`. Addresses #2010.

Removes restating comments and section-header banners; preserves all `// upstream:` references and rustdoc on public APIs. No code or behavior changes.