### PR TITLE
docs(transfer): comment cleanup for ack_batcher (#1953)

### DIFF
--- a/crates/transfer/src/ack_batcher/batcher.rs
+++ b/crates/transfer/src/ack_batcher/batcher.rs
@@ -16,11 +16,9 @@ use super::types::{AckBatcherConfig, AckBatcherStats, AckEntry};
 ///
 /// let mut batcher = AckBatcher::new(AckBatcherConfig::default());
 ///
-/// // Queue successful ACKs
 /// batcher.queue(AckEntry::success(0));
 /// batcher.queue(AckEntry::success(1));
 ///
-/// // Check if flush is needed
 /// if batcher.should_flush() {
 ///     let batch = batcher.take_batch();
 ///     send_batch_to_network(batch);


### PR DESCRIPTION
## Summary

- Tidy comments in `crates/transfer/src/ack_batcher/` per the project comment-cleanup conventions.
- Remove two restating comments from the `AckBatcher` doctest example (the comments echoed the next line of code rather than adding context).
- Preserve all rustdoc on public items, module-level wire-format documentation, and inline byte-array annotations in tests (those describe non-obvious wire bytes).

The remainder of the directory already followed the conventions: every public type/trait/function/method has `///` rustdoc, no decorative banners or commented-out code, and no debug traces.

Closes #1953.

## Test plan

- [ ] CI: fmt + clippy
- [ ] CI: nextest (stable) on Linux, macOS, Windows
- [ ] CI: Linux musl build