### PR TITLE
docs(engine): comment cleanup for walk (#1944)

### DIFF
--- a/crates/engine/src/walk/filtered_walker.rs
+++ b/crates/engine/src/walk/filtered_walker.rs
@@ -165,7 +165,7 @@ mod tests {
         let walker = FilteredWalker::new(inner, filters);
 
         let entries: Vec<_> = walker.flatten().collect();
-        // Should have all entries: root + file.txt + file.bak + subdir + nested.txt + .git + config + src + main.rs
+        // root + file.txt + file.bak + subdir + nested.txt + .git + config + src + main.rs.
         assert_eq!(entries.len(), 9);
     }
 
@@ -197,7 +197,6 @@ mod tests {
 
         let entries: Vec<_> = walker.flatten().collect();
 
-        // Should not have .git directory or its contents
         let has_git = entries
             .iter()
             .any(|e| e.path().components().any(|c| c.as_os_str() == ".git"));
@@ -208,7 +207,7 @@ mod tests {
     fn include_overrides_exclude() {
         let dir = setup_test_tree();
         let inner = WalkdirWalker::new(dir.path(), WalkConfig::default());
-        // Exclude all .txt files except those in src/
+        // Exclude every *.txt except those reached via src/.
         let rules = vec![
             FilterRule::exclude("*.txt".to_owned()),
             FilterRule::include("src/**".to_owned()),
@@ -218,11 +217,9 @@ mod tests {
 
         let entries: Vec<_> = walker.flatten().collect();
 
-        // file.txt and subdir/nested.txt should be excluded
         let has_root_txt = entries.iter().any(|e| e.path().ends_with("file.txt"));
         assert!(!has_root_txt);
 
-        // src/ and src/main.rs should be included
         let has_src = entries
             .iter()
             .any(|e| e.path().file_name().map(|n| n == "src").unwrap_or(false));
@@ -303,7 +300,6 @@ mod tests {
 
     #[test]
     fn handles_errors_from_inner_walker() {
-        // Test that errors from the inner walker are propagated
         let walker =
             WalkdirWalker::new(Path::new("/nonexistent/path/12345"), WalkConfig::default());
         let filters = FilterSet::default();
@@ -328,7 +324,7 @@ mod tests {
 
         let entries: Vec<_> = walker.flatten().collect();
 
-        // Should only have: root, file.txt, src/, src/main.rs
+        // Survivors: root, file.txt, src/, src/main.rs.
         let names: Vec<_> = entries
             .iter()
             .filter_map(|e| e.file_name().map(|n| n.to_string_lossy().to_string()))

--- a/crates/engine/src/walk/walkdir_impl.rs
+++ b/crates/engine/src/walk/walkdir_impl.rs
@@ -131,9 +131,10 @@ impl WalkdirWalker {
         }
     }
 
+    /// Non-Unix platforms lack POSIX device IDs, so the one-file-system
+    /// constraint is a no-op.
     #[cfg(not(unix))]
     fn should_skip_for_filesystem(&self, _metadata: &fs::Metadata) -> bool {
-        // Windows doesn't have device IDs in the same way
         false
     }
 }
@@ -198,8 +199,8 @@ impl DirectoryWalker for WalkdirWalker {
     }
 
     fn skip_current_dir(&mut self) {
-        // jwalk lacks native skip_current_dir; approximate by skipping
-        // entries deeper than the last returned depth
+        // jwalk lacks native skip_current_dir; approximate by dropping
+        // entries deeper than the last returned depth.
         self.skip_dir_depth = Some(self.last_depth);
     }
 }
@@ -228,19 +229,16 @@ mod tests {
 
         let entries: Vec<_> = walker.flatten().collect();
 
-        // Root + 3 files + 1 subdir + 1 nested file = 6 entries
+        // Root + 3 files + 1 subdir + 1 nested file = 6 entries.
         assert_eq!(entries.len(), 6);
 
-        // Check sorting: root, then a.txt, b.txt, c.txt, subdir, subdir/nested.txt
         let names: Vec<_> = entries
             .iter()
             .filter_map(|e| e.file_name().map(|n| n.to_string_lossy().to_string()))
             .collect();
 
-        // First entry is root (no file_name)
         assert_eq!(entries[0].depth(), 0);
 
-        // Files should be sorted
         let file_names: Vec<_> = names
             .iter()
             .filter(|n| n.ends_with(".txt") && !n.contains("nested"))
@@ -256,7 +254,6 @@ mod tests {
 
         let entries: Vec<_> = walker.flatten().collect();
 
-        // Should only get root level entries, not nested.txt
         let has_nested = entries.iter().any(|e| {
             e.file_name()
                 .map(|n| n.to_string_lossy().contains("nested"))
@@ -273,7 +270,6 @@ mod tests {
 
         let entries: Vec<_> = walker.flatten().collect();
 
-        // All entries should have depth > 0
         assert!(entries.iter().all(|e| e.depth() > 0));
     }
 
@@ -293,8 +289,8 @@ mod tests {
         }
 
         assert!(found_subdir);
-        // Note: Due to parallel traversal, skip_current_dir may not prevent
-        // already-queued entries from being returned
+        // Parallel traversal may have already queued deeper entries before
+        // skip_current_dir runs, so we cannot assert their absence here.
     }
 
     #[test]
@@ -327,14 +323,14 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn one_file_system_skips_different_devices() {
-        // This test requires a mounted filesystem with different device ID
-        // We can at least verify the config is respected
+        // Exercising the cross-device skip would require an extra mount point;
+        // here we only verify the config flag survives and same-device walks
+        // still produce entries.
         let dir = TempDir::new().unwrap();
         let config = WalkConfig::default().one_file_system(true);
         let walker = WalkdirWalker::new(dir.path(), config);
 
         assert!(walker.config().is_one_file_system());
-        // Should still work for same-device traversal
         let entries: Vec<_> = walker.flatten().collect();
         assert!(!entries.is_empty());
     }


### PR DESCRIPTION
## Summary

Tidy comments under `crates/engine/src/walk/` following the project's comment hygiene rules:

- Remove restating comments that merely echo the assertion or branch they precede in tests.
- Convert an internal `//` rationale on `WalkdirWalker::should_skip_for_filesystem` (non-Unix stub) into proper `///` rustdoc.
- Reword two inline comments to focus on the WHY (`jwalk` lacks a native `skip_current_dir`; parallel traversal makes the post-`skip_current_dir` invariant unprovable).
- Tighten the cross-device test rationale to explain why coverage is intentionally limited.

No behaviour change, comments only.

## Test plan

- [ ] CI: fmt+clippy
- [ ] CI: nextest (stable)
- [ ] CI: Windows / macOS / Linux musl matrices