### PR TITLE
docs(protocol): comment cleanup for flist::incremental (#1990)

### DIFF
--- a/crates/protocol/src/flist/incremental/ready_entry.rs
+++ b/crates/protocol/src/flist/incremental/ready_entry.rs
@@ -150,7 +150,6 @@ where
         return ReadyEntryAction::SkipFiltered(entry);
     }
 
-    // Dispatch by entry type.
     if entry.is_dir() {
         ReadyEntryAction::CreateDirectory(entry)
     } else if entry.is_file() {


### PR DESCRIPTION
## Summary

Tidy comments in `crates/protocol/src/flist/incremental/` per the standard comment-cleanup rules:

- Remove restating comments that merely echo the code beneath them
- Preserve all `// upstream:` references
- Preserve comments documenting non-obvious WHY context (ordering, invariants, fallbacks)
- Keep `///` rustdoc on all public items and `//!` only at the top of true module files

## Changes

Single deletion in `ready_entry.rs`: dropped the line `// Dispatch by entry type.` immediately above the if/else dispatch chain in `process_ready_entry()` - the chain itself self-documents the dispatch, so the comment was a pure restatement.

The rest of the module was already in good shape:
- `mod.rs` retains WHY comments around root-directory pre-population, ancestor sort order, and root-down ancestor synthesis.
- `ready_entry.rs` retains the cheapest-first ordering rationale and the unknown-type upstream fallback note.
- `streaming.rs` retains the `// upstream: io.c:read_a_msg()` reference in module rustdoc.
- `tests.rs` inline comments document expected placeholder counts and test-setup intent and were preserved.

## Test plan

- [ ] CI fmt + clippy
- [ ] CI nextest (stable) on Linux/macOS/Windows
- [ ] CI Linux musl