### PR TITLE
docs(protocol): comment cleanup for flist::read (#1991)

### DIFF
--- a/crates/protocol/src/flist/read/extras.rs
+++ b/crates/protocol/src/flist/read/extras.rs
@@ -21,7 +21,7 @@ impl FileListReader {
     ///
     /// Wire format: varint30(len) + raw bytes
     ///
-    /// // upstream: flist.c:recv_file_entry() lines 920-935
+    /// upstream: flist.c:recv_file_entry() lines 920-935
     pub(super) fn read_symlink_target<R: Read + ?Sized>(
         &self,
         reader: &mut R,
@@ -91,7 +91,7 @@ impl FileListReader {
     /// - Major: varint30 (omitted if XMIT_SAME_RDEV_MAJOR set)
     /// - Minor: varint (protocol 30+) or byte/int (protocol 28-29)
     ///
-    /// // upstream: flist.c:recv_file_entry() lines 936-970
+    /// upstream: flist.c:recv_file_entry() lines 936-970
     pub(super) fn read_rdev<R: Read + ?Sized>(
         &mut self,
         reader: &mut R,
@@ -149,7 +149,7 @@ impl FileListReader {
     /// - If XMIT_HLINKED is set but not XMIT_HLINK_FIRST: read varint index
     /// - If XMIT_HLINK_FIRST is also set: return u32::MAX (this is the first/leader)
     ///
-    /// // upstream: flist.c:recv_file_entry() lines 800-815
+    /// upstream: flist.c:recv_file_entry() lines 800-815
     pub(super) fn read_hardlink_idx<R: Read + ?Sized>(
         &self,
         reader: &mut R,
@@ -183,8 +183,8 @@ impl FileListReader {
     /// - If not XMIT_SAME_DEV_PRE30: read longint as dev (stored as dev + 1)
     /// - Always read longint as ino
     ///
-    /// // upstream: flist.c:recv_file_entry() - dev/ino read is gated on
-    /// // `preserve_hard_links && xflags & XMIT_HLINKED`
+    /// upstream: flist.c:recv_file_entry() - dev/ino read is gated on
+    /// `preserve_hard_links && xflags & XMIT_HLINKED`
     pub(super) fn read_hardlink_dev_ino<R: Read + ?Sized>(
         &mut self,
         reader: &mut R,
@@ -225,7 +225,7 @@ impl FileListReader {
     ///
     /// Wire format: raw bytes of length flist_csum_len
     ///
-    /// // upstream: flist.c:recv_file_entry() lines 1010-1030
+    /// upstream: flist.c:recv_file_entry() lines 1010-1030
     pub(super) fn read_checksum<R: Read + ?Sized>(
         &self,
         reader: &mut R,
@@ -259,7 +259,7 @@ impl FileListReader {
     /// Tracks counts of files, directories, symlinks, devices, and special files,
     /// as well as total size for files and symlink targets.
     ///
-    /// // upstream: flist.c:recv_file_list() stat accumulation at end of loop
+    /// upstream: flist.c:recv_file_list() stat accumulation at end of loop
     pub(super) fn update_stats(&mut self, entry: &FileEntry) {
         if entry.is_dir() {
             self.stats.num_dirs += 1;

--- a/crates/protocol/src/flist/read/flags.rs
+++ b/crates/protocol/src/flist/read/flags.rs
@@ -19,7 +19,7 @@ use crate::flist::flags::{FileFlags, XMIT_EXTENDED_FLAGS, XMIT_IO_ERROR_ENDLIST}
 /// The first byte of each file entry encodes transmission flags that control
 /// which metadata fields follow. A zero byte signals end-of-list.
 ///
-/// // upstream: flist.c:recv_file_entry() lines 760-780
+/// upstream: flist.c:recv_file_entry() lines 760-780
 #[derive(Debug)]
 pub enum FlagsResult {
     /// End of file list reached (zero flags byte).
@@ -52,7 +52,7 @@ impl FileListReader {
     /// `FlagsResult::IoError` for I/O error markers, or
     /// `FlagsResult::Flags` for valid entry flags.
     ///
-    /// // upstream: flist.c:recv_file_entry() lines 2625-2670
+    /// upstream: flist.c:recv_file_entry() lines 2625-2670
     pub(super) fn read_flags<R: Read + ?Sized>(&self, reader: &mut R) -> io::Result<FlagsResult> {
         let use_varint = self.use_varint_flags();
 
@@ -144,7 +144,7 @@ impl FileListReader {
     /// Returns `Some(error_code)` if an error marker is detected,
     /// `None` if flags represent a valid entry.
     ///
-    /// // upstream: flist.c:recv_file_entry() safe_flist error check
+    /// upstream: flist.c:recv_file_entry() safe_flist error check
     fn check_error_marker<R: Read + ?Sized>(
         &self,
         primary: u8,

--- a/crates/protocol/src/flist/read/metadata.rs
+++ b/crates/protocol/src/flist/read/metadata.rs
@@ -219,7 +219,7 @@ impl FileListReader {
 /// value unchanged. Otherwise reads the ID using fixed or varint encoding,
 /// and optionally reads a name string if `name_follows` is set.
 ///
-/// // upstream: flist.c:recv_file_entry() lines 880-910 - uid/gid reading
+/// upstream: flist.c:recv_file_entry() lines 880-910 - uid/gid reading
 fn read_owner_id<R: Read + ?Sized>(
     reader: &mut R,
     same: bool,

--- a/crates/protocol/src/flist/read/mod.rs
+++ b/crates/protocol/src/flist/read/mod.rs
@@ -719,7 +719,6 @@ impl FileListReader {
             entry.set_xattr_ndx(xattr_ndx);
         }
 
-        // Update statistics
         self.update_stats(&entry);
 
         debug_log!(

--- a/crates/protocol/src/flist/read/name.rs
+++ b/crates/protocol/src/flist/read/name.rs
@@ -108,10 +108,9 @@ impl FileListReader {
     ///
     /// `flist.c:738-754` `recv_file_entry()` runs the freshly-read filename
     /// through `iconvbufs(ic_recv, ...)` before `clean_fname()`. The
-    /// prefix-compression buffer (`lastname` / `state.prev_name()`) intentionally
-    /// retains the wire bytes so subsequent entries can share the prefix
-    /// before any conversion is applied.
-    // upstream: flist.c recv_file_entry() iconv_buf(ic_recv, ...)
+    /// prefix-compression buffer (`lastname` / `state.prev_name()`)
+    /// intentionally retains the wire bytes so subsequent entries can share
+    /// the prefix before any conversion is applied.
     pub(super) fn apply_encoding_conversion(&self, name: Vec<u8>) -> io::Result<Vec<u8>> {
         if let Some(ref converter) = self.iconv {
             match converter.remote_to_local(&name) {


### PR DESCRIPTION
## Summary
- Fix `/// // upstream:` patterns in `crates/protocol/src/flist/read/` that rendered `//` as literal text in generated rustdoc; convert to plain `/// upstream:` lines.
- Drop a restating `// Update statistics` comment in `mod.rs` (the next line already calls `update_stats`).
- Consolidate a redundant duplicate upstream tag in `name.rs` that was already covered by the rustdoc `# Upstream Reference` section.
- All `// upstream:` references to upstream rsync C source preserved.

## Test plan
- [ ] CI: fmt+clippy
- [ ] CI: nextest (stable)
- [ ] CI: Windows / macOS / Linux musl

Refs: #1991