### PR TITLE
fix(rsync_io): gate SSH agent auth on cfg(unix) for russh 0.60

### DIFF
--- a/crates/rsync_io/src/ssh/embedded/auth.rs
+++ b/crates/rsync_io/src/ssh/embedded/auth.rs
@@ -40,6 +40,13 @@ fn effective_username(config: &SshConfig) -> Result<String, SshError> {
 /// signs each via `authenticate_publickey_with()` until one succeeds. Returns
 /// `Ok(true)` on success, `Ok(false)` when the agent is unavailable or no
 /// identity works.
+///
+/// `russh::keys::agent::client::AgentClient::connect_env` is gated to
+/// `cfg(unix)` upstream (Pageant / named-pipe support is a separate Windows
+/// path we have not validated). On non-Unix targets this method short-circuits
+/// to `Ok(false)` so the caller falls through to identity-file and password
+/// auth.
+#[cfg(unix)]
 async fn try_agent_auth(
     session: &mut russh::client::Handle<SshClientHandler>,
     username: &str,
@@ -80,6 +87,15 @@ async fn try_agent_auth(
         }
     }
 
+    Ok(false)
+}
+
+#[cfg(not(unix))]
+async fn try_agent_auth(
+    _session: &mut russh::client::Handle<SshClientHandler>,
+    _username: &str,
+) -> Result<bool, SshError> {
+    logging::debug_log!(Io, 1, "SSH agent auth is not supported on this platform");
     Ok(false)
 }
 


### PR DESCRIPTION
## Summary

- `russh::keys::agent::client::AgentClient::connect_env` is gated to `#[cfg(unix)]` upstream in russh 0.60. The unconditional call at `crates/rsync_io/src/ssh/embedded/auth.rs:47` fails to compile on Windows with E0599 (\"no function or associated item named \`connect_env\`\").
- Split \`try_agent_auth\` into a Unix implementation (existing logic) and a non-Unix fallback that logs and returns \`Ok(false)\`. The orchestrator already iterates through agent → identity-file → password; the Windows fallback simply skips the agent step and falls through.
- Pageant / named-pipe SSH agent integration on Windows is a separate work item and is intentionally not introduced here.

## Test plan

- [ ] CI: fmt+clippy
- [ ] CI: nextest (stable)
- [ ] CI: Windows (stable / beta) — was failing on master prior to this fix
- [ ] CI: macOS (stable)
- [ ] CI: Linux musl (stable)