### PR TITLE
docs: replace internal-tool references with project-policy citations

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -3,7 +3,7 @@ name: Coverage
 # Measures test line + branch coverage with cargo-llvm-cov on Linux.
 # Runs on every push to master and on pull requests touching code paths.
 # This job is informational and non-blocking - it must not gate master.
-# Tracks the CLAUDE.md target of >= 95% line coverage; gate is currently
+# Tracks the project's >= 95% line coverage target; gate is currently
 # pinned at 84% (see --fail-under-lines below) and tightened incrementally
 # as coverage improves.
 on:
@@ -75,7 +75,7 @@ jobs:
       # --branch enables LLVM branch coverage instrumentation (-C instrument-coverage=branch).
       # The profraw data then supports both line and branch coverage reports.
       # --fail-under-lines enforces the line coverage threshold only.
-      # Currently pinned at 84; CLAUDE.md target is >= 95. Raise incrementally.
+      # Currently pinned at 84; project target is >= 95. Raise incrementally.
       # continue-on-error makes the gate informational - the surrounding job
       # still uploads artifacts and the step summary even if the threshold trips.
       - name: Generate LCOV coverage report and enforce threshold
@@ -102,7 +102,7 @@ jobs:
           TOTAL_LINE=$(echo "$SUMMARY" | grep '^TOTAL' || true)
           TOTAL_BRANCH=$(echo "$BRANCH_SUMMARY" | grep '^TOTAL' || true)
           printf '## Coverage Report\n\n' >> "$GITHUB_STEP_SUMMARY"
-          printf 'Target: >= 95%% line coverage (CLAUDE.md). Gate: 84%% (informational).\n\n' >> "$GITHUB_STEP_SUMMARY"
+          printf 'Target: >= 95%% line coverage (project policy). Gate: 84%% (informational).\n\n' >> "$GITHUB_STEP_SUMMARY"
           printf '| Metric | Value |\n' >> "$GITHUB_STEP_SUMMARY"
           printf '|--------|-------|\n' >> "$GITHUB_STEP_SUMMARY"
           if [ -n "$TOTAL_LINE" ]; then

--- a/docs/audits/async-daemon-listener.md
+++ b/docs/audits/async-daemon-listener.md
@@ -163,9 +163,8 @@ in #1935, not here.
 
 ### tokio dependency-scope policy
 
-Per the project's tokio dependency-scope policy (CLAUDE.md "Audit
-tokio dependency scope" pair, tasks #1818 and #1779), tokio MUST NOT
-leak into other crates. The boundary held by this RFC:
+Per the project's tokio dependency-scope policy (tasks #1818 and #1779),
+tokio MUST NOT leak into other crates. The boundary held by this RFC:
 
 - `crates/daemon/Cargo.toml` adds `tokio` only behind the
   `async-daemon` feature (already optional at `Cargo.toml:43`).
@@ -334,9 +333,9 @@ implementation:
   any observable on-the-wire behaviour. This is a daemon-internal
   scheduling change.
 - Touching other crates' dependency graphs. `tokio` stays daemon-
-  only and feature-gated. Per CLAUDE.md, no new tokio leakage into
-  `cli`, `core`, `transfer`, `protocol`, `engine`, or anywhere
-  else.
+  only and feature-gated. Per the project's tokio-scope policy, no
+  new tokio leakage into `cli`, `core`, `transfer`, `protocol`,
+  `engine`, or anywhere else.
 - Replacing `catch_unwind`-based panic isolation. Tokio's
   `JoinHandle` returns `Err(JoinError)` on panic
   (`crates/daemon/src/daemon/async_session/listener.rs:211-215`);
@@ -383,9 +382,8 @@ implementation:
   `docs/DAEMON_PROCESS_MODEL.md`.
 - #1367: related daemon-scaling input from the prior audit;
   informs the motivation.
-- CLAUDE.md "Audit tokio dependency scope" pair (#1818, #1779):
-  policy enforced by the "tokio dependency-scope policy"
-  section.
+- Tokio dependency-scope policy pair (#1818, #1779): policy enforced
+  by the "tokio dependency-scope policy" section.
 
 ## References
 

--- a/docs/audits/async-file-writer-trait.md
+++ b/docs/audits/async-file-writer-trait.md
@@ -750,8 +750,8 @@ Recommended landing sequence for #1655:
 
 ### Unsafe boundary
 
-Per `feedback_unsafe_code_policy.md` and the `[Unsafe Code Policy]` in
-`/Users/ofer/devel/CLAUDE.md`, the trait must stay in `fast_io` - the only
+Per `feedback_unsafe_code_policy.md` and the project's unsafe-code
+policy, the trait must stay in `fast_io` - the only
 crate that may currently contain `unsafe`. Every backend that touches
 io_uring, OVERLAPPED, libdispatch, or `writev` keeps its `#[allow(unsafe_code)]`
 inside `crates/fast_io/src/`. Engine and transfer hold only the
@@ -762,9 +762,10 @@ new trait is what makes the boundary practically enforceable.
 
 ### Long-term consolidation
 
-CLAUDE.md states: "Consolidate all unsafe code into `fast_io` as the
-single crate permitted to contain unsafe code. New unsafe code should go
-into `fast_io` and expose safe public APIs." `AsyncFileWriter` is exactly
+The project's unsafe-code policy states: "Consolidate all unsafe code
+into `fast_io` as the single crate permitted to contain unsafe code. New
+unsafe code should go into `fast_io` and expose safe public APIs."
+`AsyncFileWriter` is exactly
 this pattern: every io_uring SQE, every OVERLAPPED, every
 `dispatch_io_write` is wrapped behind a single safe trait method. After
 phase 4, `crates/transfer` and `crates/engine` no longer reference any

--- a/docs/audits/capture-replay-harness.md
+++ b/docs/audits/capture-replay-harness.md
@@ -92,8 +92,8 @@ bits 0-23) is documented inline at `crates/protocol/src/multiplex/mod.rs:9-14`.
 
 ### Client orchestration entry points
 
-CLAUDE.md references `core::session()`, but the actual public entry points on
-master are:
+The project conventions document references `core::session()`, but the actual
+public entry points on master are:
 
 - `crates/core/src/client/run/mod.rs:113` - `pub fn run_client(config: ClientConfig)`
 - `crates/core/src/client/run/mod.rs:166` - `pub fn run_client_with_observer(...)`
@@ -287,7 +287,7 @@ and the daemon path. The orchestration entry point
 not need a new injection point - the test seam is one layer down, where the
 `Read+Write` is constructed.
 
-This honours the project's design pattern guidance from CLAUDE.md:
+This honours the project's design-pattern guidance:
 
 - **Strategy Pattern.** `ReplayMode::Strict` vs `ReplayMode::Structural`
   are interchangeable strategies behind one type.
@@ -410,7 +410,7 @@ understands with a clear error pointing at the recorder's version. The
 - Existing env-var patterns: `crates/cli/src/frontend/execution/drive/options.rs:374`
   (`OC_RSYNC_FORCE_NO_COMPRESS`), `crates/branding/build.rs:14`
   (`OC_RSYNC_BUILD_OVERRIDE`).
-- Design pattern guidance: CLAUDE.md "Strategy Pattern" and "Dependency
+- Design-pattern guidance: project's "Strategy Pattern" and "Dependency
   Inversion" notes - both directly applicable here.
 
 ## Summary

--- a/docs/audits/daemon-async-listener-rfc.md
+++ b/docs/audits/daemon-async-listener-rfc.md
@@ -37,9 +37,9 @@ What this RFC does NOT change:
   `transfer`, `compress`, `checksums`, `signature`, `bandwidth`,
   `filters`, `metadata`, and `rsync_io` crates do not gain any tokio
   dependency or become async. Per the project's tokio-scope policy
-  (CLAUDE.md "Audit tokio dependency scope" pair, tasks #1779 and
-  #1818), tokio MUST stay confined to `daemon` (and behind `core`'s
-  optional `async` feature, which we reuse without changes).
+  (tasks #1779 and #1818), tokio MUST stay confined to `daemon` (and
+  behind `core`'s optional `async` feature, which we reuse without
+  changes).
 - No wire protocol change. No new capability flag. No new option on
   `oc-rsyncd.conf` beyond an opt-in toggle wired in #1935. No
   observable on-the-wire behaviour difference vs the synchronous

--- a/docs/audits/delta-sender-parallel-rolling-hash.md
+++ b/docs/audits/delta-sender-parallel-rolling-hash.md
@@ -431,7 +431,8 @@ receiver-side concurrent_delta footprint.
 ## 5. Benchmarking plan (not executed in this PR)
 
 Two workloads, both runnable inside the `rsync-profile` podman
-container per `CLAUDE.md`. The container has upstream rsync 3.4.1 and
+container described in the project's container conventions. The
+container has upstream rsync 3.4.1 and
 oc-rsync-dev pre-built; the workspace bind-mount exposes the source
 tree at `/workspace`.
 

--- a/docs/audits/iconv-feature-design.md
+++ b/docs/audits/iconv-feature-design.md
@@ -11,8 +11,8 @@ is in PR #1840 (`docs/audits/iconv-pipeline.md`) and PR #1996.
 `target/interop/upstream-src/rsync-3.4.1/`; that tree is absent from
 this checkout, so file/line references below come from
 `docs/audits/iconv-pipeline.md` (PR #1840, written with the tarball
-unpacked). The fetch command in `/Users/ofer/devel/CLAUDE.md` rehydrates
-it. Behavioural prose is cross-checked against
+unpacked). The repo-root project conventions document a fetch command
+that rehydrates it. Behavioural prose is cross-checked against
 `docs/oc-rsync.1.md:688-693` and the upstream `rsync.1` section
 "USING --iconv FOR CHARACTER SET CONVERSIONS".
 

--- a/docs/audits/iconv-filename-converter-design.md
+++ b/docs/audits/iconv-filename-converter-design.md
@@ -491,8 +491,8 @@ Recommendation: stay on `encoding_rs`. Detailed rationale lives in
 | Thread-safe converter | `&'static Encoding`: free `Sync` | `iconv_t`: not safe across threads in glibc | inherits system iconv constraints |
 | Already a dependency | yes | no | no |
 
-The unsafe-code policy in `/Users/ofer/devel/CLAUDE.md` forbids unsafe
-in `protocol`. A direct `iconv` FFI binding is therefore not an
+The project's unsafe-code policy forbids unsafe in `protocol`. A direct
+`iconv` FFI binding is therefore not an
 option. The `iconv` Rust crate wraps `libiconv` with a safer API but
 still requires linking system iconv on Windows (via `win-iconv`)
 and on musl-static builds. `encoding_rs` is pure Rust, ships with

--- a/docs/audits/iconv-inert.md
+++ b/docs/audits/iconv-inert.md
@@ -950,7 +950,7 @@ sections 1-3 above. Quick index of the load-bearing entries:
 ### 8.3 Upstream rsync 3.4.1
 
 Source tree: `target/interop/upstream-src/rsync-3.4.1/`. Fetch
-instructions live in `/Users/ofer/devel/CLAUDE.md`.
+instructions live in the project conventions document.
 
 - `options.c:219` - `iconv_opt` global.
 - `options.c:814` - popt entry.

--- a/docs/audits/iconv-parse-deadend.md
+++ b/docs/audits/iconv-parse-deadend.md
@@ -297,7 +297,7 @@ and document task.
 
 Source tree (when present):
 `target/interop/upstream-src/rsync-3.4.1/`. Fetch instructions live in
-`/Users/ofer/devel/CLAUDE.md`.
+the project conventions document.
 
 - `flist.c::iconv_filename` and the `iconvbufs(ic_send/ic_recv, ...)`
   call-outs at `flist.c:738-754, 1127-1150, 1579-1603, 1605-1621` -

--- a/docs/audits/io-uring-adaptive-buffer-sizing.md
+++ b/docs/audits/io-uring-adaptive-buffer-sizing.md
@@ -274,8 +274,8 @@ encoding pattern in `throughput.rs:53-60`.
     io::Result<()>` which actually performs the unregister-and-reregister
     cycle. `RegisteredBufferOwner` is a small trait implemented by
     `IoUringReader` and `IoUringWriter` so the sizer can call into them
-    without depending on either concretely (Dependency Inversion - see
-    CLAUDE.md "Design Patterns").
+    without depending on either concretely (Dependency Inversion, per
+    the project's design-patterns guidance).
 - Extend `IoUringReader` and `IoUringWriter` with an
   `Option<AdaptiveBufferSizer>` and call `observe` after each batch.
 - Resize executes off-hot-path: between `submit_and_wait` calls, never

--- a/docs/audits/known-failures-eliminate.md
+++ b/docs/audits/known-failures-eliminate.md
@@ -52,8 +52,8 @@ For each surface this audit produces one section that records:
     version gate; the feature is by definition unavailable at that
     negotiated protocol. Removing the conf entry would require shipping
     a wire feature upstream itself does not implement, which the project
-    has explicitly declined (see CLAUDE.md "no wire protocol features"
-    feedback).
+    has explicitly declined (per the "no wire protocol features"
+    policy).
 - Estimated complexity for fixable items (S, M, L).
 
 A change is not credited toward criterion #3 until both the conf entry
@@ -189,8 +189,8 @@ needing to install older upstream binaries on every runner.
   --protocol=29` exits with code 2.
 - **Eliminate path:** Permanent: protocol-version-locked. There is no
   oc-rsync change that can encode ACLs over a protocol version that
-  defines no wire encoding for them. Project policy in CLAUDE.md
-  forbids inventing wire features absent from upstream.
+  defines no wire encoding for them. Project policy forbids inventing
+  wire features absent from upstream.
 
 ### 2.2 Protocol <= 29: `up:xattrs`
 

--- a/docs/audits/macos-dispatch-io.md
+++ b/docs/audits/macos-dispatch-io.md
@@ -253,7 +253,7 @@ Phase plan, sized to land one PR each:
    `tempfile`-backed regular files. New dependency: `block2 = "0.5"` under
    `[target.'cfg(target_os = "macos")'.dependencies]`. `fast_io` already has
    `#[allow(unsafe_code)]` on specific functions (`fast_io` is one of the
-   five crates listed in CLAUDE.md's "Unsafe Code Policy" as permitted to
+   five crates the project's unsafe-code policy lists as permitted to
    contain unsafe), so no policy change is required.
 2. **`FileWriter` impl.** Add `DispatchIoWriter` and the `DispatchIoOrStdWriter`
    factory enum, mirroring `IocpOrStdWriter`. Wire into the `FileWriterFactory`
@@ -289,13 +289,13 @@ builds because of the cfg gate.
   first transitive ObjC dependency on macOS. Open question: is the
   maintenance cost of pulling `block2` into `fast_io` acceptable, or does
   the team prefer a hand-rolled `BlockLiteral` (smaller surface, more risk)?
-  CLAUDE.md's "Standard library first" rule weighs against `block2`; the
+  The project's "Standard library first" rule weighs against `block2`; the
   "no deprecated APIs" and unsafe-confined-to-`fast_io` rules weigh for it.
 - **`dispatch_data_t` lifetime vs `BufferPool`.** The most attractive design
   hands `dispatch_io_write` a `dispatch_data_t` whose destructor returns the
   buffer to oc-rsync's `BufferPool`. The `BufferPool` is a
-  `Mutex<Vec<Vec<u8>>>` (per CLAUDE.md "Buffer pool contention" note), and
-  the destructor block runs on a libdispatch-managed queue, not on the
+  `Mutex<Vec<Vec<u8>>>` (per the project's "Buffer pool contention" note),
+  and the destructor block runs on a libdispatch-managed queue, not on the
   receiver thread. Open question: does the destructor's queue reentrancy
   interact poorly with the existing pool's `Mutex`? Worth a microbenchmark
   before phase 2 lands.
@@ -320,8 +320,9 @@ builds because of the cfg gate.
   trait shape from #1655. Phases 1-4 and 6 can land before #1655.
 - **Benchmark gap.** The benchmark scripts (`scripts/benchmark.sh`,
   `scripts/benchmark_hyperfine.sh`) only run inside the
-  `localhost/oc-rsync-bench:latest` Linux container per CLAUDE.md
-  "Containers (Podman)". A macOS-host benchmark harness will need to be
+  `localhost/oc-rsync-bench:latest` Linux container described in the
+  project's "Containers (Podman)" conventions. A macOS-host benchmark
+  harness will need to be
   added in `xtask` to validate that `dispatch_io` actually wins against
   `BufWriter` on APFS - an unbenched optimization is not one we should land.
 

--- a/docs/audits/mutex-implementation-policy.md
+++ b/docs/audits/mutex-implementation-policy.md
@@ -6,7 +6,8 @@ Tracking issue: oc-rsync task #1781.
 
 This audit verifies that the oc-rsync workspace honours the project policy
 "prefer `std` unless a well-supported external crate provides a substantial,
-documented advantage" (CLAUDE.md, Code Quality section) for synchronisation
+documented advantage" (Code Quality section of the project conventions) for
+synchronisation
 primitives. The conclusion is that no first-party code in the workspace uses
 `parking_lot::Mutex`, `parking_lot::RwLock`, `parking_lot_core`, or `spin`
 directly. There are no `use parking_lot` imports, no `parking_lot::` paths in
@@ -143,7 +144,7 @@ uses (classifications (a) and (b)). The two classification (b) entries are:
   not on the byte path). The session registry is touched at session
   start/end. None of this is on the bytes-per-second hot path for a
   transfer.
-- Note: the policy in CLAUDE.md is about `std::sync::Mutex` /
+- Note: the project policy is about `std::sync::Mutex` /
   `std::sync::RwLock` versus `parking_lot::Mutex` /
   `parking_lot::RwLock`. `dashmap` is a sharded concurrent map, not a
   parking_lot wrapper; the `parking_lot_core` use is internal to the crate
@@ -272,8 +273,8 @@ Concrete TODOs, in priority order:
 
 ## References
 
-- Policy source: `CLAUDE.md` "Code Quality" section ("prefer std unless a
-  well-supported external crate provides a substantial, documented
+- Policy source: project conventions, "Code Quality" section ("prefer std
+  unless a well-supported external crate provides a substantial, documented
   advantage").
 - Workspace dependencies block: `Cargo.toml:180-209` (no `parking_lot`
   entry).

--- a/docs/audits/shared-iouring-session-instance.md
+++ b/docs/audits/shared-iouring-session-instance.md
@@ -683,7 +683,8 @@ observable effect on the bytes that go on the wire. The protocol crate
 confirms this: a workspace search for `io_uring` or `IoUring` in
 `crates/protocol/src/` returns no matches. The protocol layer does not
 import `fast_io` at all - it depends only on `checksums`, `filters`,
-`compress`, and `bandwidth` (see the dependency graph in `CLAUDE.md`).
+`compress`, and `bandwidth` (see the workspace dependency graph in the
+project conventions document).
 
 This is consistent with `feedback_no_wire_protocol_features.md`:
 sharing rings is a `fast_io`-internal optimisation, not a wire feature.
@@ -802,8 +803,8 @@ Constraints that must hold across all four steps:
   `feedback_no_wire_protocol_features.md` and confirmed by the empty
   search for `io_uring` in `crates/protocol/src/`.
 - **All unsafe code stays in `fast_io`.** Per
-  `feedback_unsafe_code_policy.md` and the unsafe-code policy in
-  `CLAUDE.md`. The pool is a `fast_io` concern; `transfer` and
+  `feedback_unsafe_code_policy.md` and the project's unsafe-code policy.
+  The pool is a `fast_io` concern; `transfer` and
   `core` only see `Send`-safe handles.
 - **Fallback chain unchanged from the user's perspective.**
   `IoUringPolicy::Auto` continues to mean "best-effort"; the only

--- a/docs/audits/windows-iocp-benchmark.md
+++ b/docs/audits/windows-iocp-benchmark.md
@@ -348,8 +348,9 @@ For each invocation of `scripts/benchmark_windows.ps1`:
 - Each measurement run runs in its own destination directory and deletes
   the directory afterward. **Never use `Remove-Item -Recurse -Force` on a
   variable-expanded path that could be empty - it has bitten this project
-  before (per `CLAUDE.md` "Containers & Bind Mounts" pitfall).** The xtask
-  runner uses a typed `PathBuf` and refuses to delete the workspace root.
+  before (per the project's "Containers & Bind Mounts" pitfall).** The
+  xtask runner uses a typed `PathBuf` and refuses to delete the workspace
+  root.
 
 ## 4. Parity with existing scripts
 

--- a/docs/interop_testing.md
+++ b/docs/interop_testing.md
@@ -360,7 +360,6 @@ grep -c "^fn test_" crates/core/tests/upstream_client_to_oc_daemon_interop.rs
 
 ## Related Documentation
 
-- [CLAUDE.md](../CLAUDE.md) - Overall architecture and conventions
 - [Protocol Documentation](../crates/protocol/README.md) - Wire protocol details
 - [Daemon Implementation](../crates/daemon/README.md) - Daemon internals
 

--- a/docs/plans/2026-03-07-serverconfig-decomposition.md
+++ b/docs/plans/2026-03-07-serverconfig-decomposition.md
@@ -1,6 +1,6 @@
 # ServerConfig Decomposition Implementation Plan
 
-> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+> **For implementers:** Work through this plan task-by-task; complete each before moving to the next.
 
 **Goal:** Break ServerConfig (27 fields) into focused sub-configs using the Parameter Object pattern, reducing construction boilerplate from 27 fields to ~5 grouped structs, each with `Default`.
 

--- a/docs/plans/2026-03-29-interop-known-failures.md
+++ b/docs/plans/2026-03-29-interop-known-failures.md
@@ -1,6 +1,6 @@
 # Interop Known Failures Fix Plan
 
-> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+> **For implementers:** Work through this plan task-by-task; complete each before moving to the next.
 
 **Goal:** Eliminate all fixable interop KNOWN_FAILURES, reducing the list from 15 to 5 (environment-dependent only).
 


### PR DESCRIPTION
## Summary

- Rewrite audit and plan docs (and the coverage workflow) to cite project policies and conventions directly, instead of pointing at an external internal-tool document.
- Wording-only changes; no behaviour, policy, or wire-protocol changes.
- 19 files touched (workflow + 16 audits + 2 plans + 1 interop doc), +58/-55 lines.

## Test plan

- [ ] CI: fmt+clippy
- [ ] CI: nextest (stable, Linux/macOS/Windows)
- [ ] CI: Linux musl (stable)