### PR TITLE
docs(fast_io): trim restate comments in o_tmpfile

### DIFF
--- a/crates/fast_io/src/o_tmpfile/low_level.rs
+++ b/crates/fast_io/src/o_tmpfile/low_level.rs
@@ -81,8 +81,6 @@ mod linux {
         O_TMPFILE_STATUS.store(STATUS_UNKNOWN, Ordering::Relaxed);
     }
 
-    /// Performs the actual `O_TMPFILE` probe by opening and immediately closing
-    /// an anonymous file.
     fn probe_o_tmpfile(dir: &Path) -> bool {
         // O_TMPFILE requires O_WRONLY or O_RDWR
         let dir_cstr = match CString::new(dir.as_os_str().as_bytes()) {
@@ -233,7 +231,6 @@ mod linux {
             reset_probe_cache();
             let dir = tempfile::tempdir().unwrap();
             let first = o_tmpfile_available(dir.path());
-            // Second call should use cache and return the same result
             let second = o_tmpfile_available(dir.path());
             assert_eq!(first, second);
         }
@@ -251,7 +248,6 @@ mod linux {
             let result = open_anonymous_tmpfile(dir.path(), 0o644);
             // O_TMPFILE may not be supported on all filesystems (e.g., tmpfs in CI)
             if let Ok(file) = result {
-                // File is open and writable
                 drop(file);
             }
         }
@@ -264,16 +260,13 @@ mod linux {
                 Err(_) => return, // O_TMPFILE not supported on this filesystem
             };
 
-            // Write some data
             let mut file = file;
             file.write_all(b"hello anonymous tmpfile").unwrap();
             file.flush().unwrap();
 
-            // Materialize at a destination path
             let dest = dir.path().join("materialized.txt");
             match link_anonymous_tmpfile(&file, &dest) {
                 Ok(()) => {
-                    // Verify the file appeared with correct contents
                     let contents = std::fs::read_to_string(&dest).unwrap();
                     assert_eq!(contents, "hello anonymous tmpfile");
                 }
@@ -298,7 +291,6 @@ mod linux {
             let result = link_anonymous_tmpfile(&file, &dest);
             assert!(result.is_err());
             if let Err(e) = result {
-                // EEXIST
                 assert_eq!(e.raw_os_error(), Some(libc::EEXIST));
             }
         }

--- a/crates/fast_io/src/o_tmpfile/types.rs
+++ b/crates/fast_io/src/o_tmpfile/types.rs
@@ -160,7 +160,7 @@ mod tests {
             let dir = tempdir().expect("tempdir");
             let mut atf = match AnonymousTempFile::open(dir.path()) {
                 Ok(a) => a,
-                Err(_) => return, // O_TMPFILE not supported
+                Err(_) => return, // O_TMPFILE not supported on this filesystem
             };
 
             atf.file_mut().write_all(b"test data").expect("write");


### PR DESCRIPTION
Comment cleanup for `crates/fast_io/src/o_tmpfile/` per task #2007.

## Files touched

- `crates/fast_io/src/o_tmpfile/low_level.rs`
- `crates/fast_io/src/o_tmpfile/types.rs`

## Summary

- Restate-the-code comments removed: 7
  - 1 doc comment on the private `probe_o_tmpfile` helper that merely echoed the function body.
  - 6 inline `//` comments inside test bodies that restated the next line ("Write some data", "Materialize at a destination path", "Verify the file appeared", "Second call should use cache", "File is open and writable", "EEXIST").
- Rustdoc added: 0. Every public item (`o_tmpfile_available`, `open_anonymous_tmpfile`, `link_anonymous_tmpfile`, `o_tmpfile_probe`, `OTmpfileSupport`, `AnonymousTempFile` and its methods, `TempFileResult`, `open_temp_file`, plus the non-Linux stubs) already carries `///` rustdoc covering purpose, kernel-version requirements (Linux 3.11+ for `O_TMPFILE`, `linkat AT_SYMLINK_FOLLOW` via `/proc/self/fd/N`), and non-Linux fallback semantics. Module-level `//!` docs are unchanged.
- `// SAFETY:` blocks preserved verbatim: 5 (probe open + close, `open_anonymous_tmpfile` open + `File::from_raw_fd`, `linkat`).
- `// upstream:` references preserved: 0 - this module wraps Linux syscalls directly, so there is no upstream rsync C reference to cite.
- Kept the kernel-constraint note `// O_TMPFILE requires O_WRONLY or O_RDWR` and the test comments that explain why `O_TMPFILE` / `linkat` may legitimately fail in CI environments (tmpfs, missing `/proc`, umask). One end-of-line test comment was clarified from "O_TMPFILE not supported" to "O_TMPFILE not supported on this filesystem" for symmetry with the matching comment in `low_level.rs`.

## Test plan

- CI: fmt + clippy, nextest (Linux primary, must still compile on macOS / Windows / musl via the non-Linux stubs).
- No behavior change - pure comment cleanup; no code, signatures, or unsafe blocks were modified.