### PR TITLE
docs(platform): drop residual restating comments

### DIFF
--- a/crates/platform/src/daemonize.rs
+++ b/crates/platform/src/daemonize.rs
@@ -28,21 +28,18 @@ use std::io;
 #[cfg(unix)]
 #[allow(unsafe_code)]
 pub fn become_daemon() -> io::Result<()> {
-    // Fork - parent exits, child continues.
     // upstream: clientserver.c:1466
     // SAFETY: fork() is safe to call before threads are spawned.
     let pid = unsafe { libc::fork() };
     match pid {
         -1 => return Err(io::Error::last_os_error()),
-        0 => {} // child
+        0 => {}
         _ => std::process::exit(0),
     }
 
-    // Create a new session and detach from controlling terminal.
     // upstream: clientserver.c:1478
     nix::unistd::setsid().map_err(|e| io::Error::from_raw_os_error(e as i32))?;
 
-    // Redirect stdin/stdout/stderr to /dev/null.
     // upstream: clientserver.c:1490-1493
     redirect_stdio_to_devnull()
 }

--- a/crates/platform/src/env.rs
+++ b/crates/platform/src/env.rs
@@ -82,7 +82,6 @@ mod tests {
         let _lock = TEST_LOCK.lock().unwrap();
         let key = "PLATFORM_ENV_TEST_SET";
 
-        // Ensure clean state.
         #[allow(unsafe_code)]
         unsafe {
             env::remove_var(key);

--- a/crates/platform/src/privilege.rs
+++ b/crates/platform/src/privilege.rs
@@ -146,7 +146,6 @@ fn windows_impersonate(account_name: &str) -> io::Result<()> {
     };
     use windows::core::PCWSTR;
 
-    // Split DOMAIN\user if present.
     let (domain, user) = match account_name.split_once('\\') {
         Some((d, u)) => (Some(d), u),
         None => (None, account_name),


### PR DESCRIPTION
## Summary

Incremental cleanup pass over `crates/platform/src/`. Most of the work was already done by an earlier merged change; this PR removes the few remaining comments that purely restated the next line of code:

- `daemonize.rs::become_daemon()` - drops the `// Fork - parent exits, child continues.`, the inline `// child` on the `0 => {}` arm, the `// Create a new session and detach from controlling terminal.`, and the `// Redirect stdin/stdout/stderr to /dev/null.` lines. Each was followed immediately by a `// upstream: clientserver.c:NNN` reference and the corresponding call (`libc::fork`, `nix::unistd::setsid`, `redirect_stdio_to_devnull`) that already says the same thing. The upstream references are kept verbatim.
- `privilege.rs::windows_impersonate()` - drops `// Split DOMAIN\user if present.` directly above the `account_name.split_once('\\')` match.
- `env.rs` test - drops `// Ensure clean state.` above an `env::remove_var(key)` setup call.

All `// upstream: ...` and `// SAFETY: ...` comments in the crate are preserved verbatim. WHY/intent comments (`// OnceLock statics allow the extern "system" callback to access the flags.`, `// NERR_GroupNotFound (2220) or ERROR_NO_SUCH_ALIAS (1376)`, `// Administrators group always exists on Windows.`, etc.) are left untouched. No rustdoc on public items is changed; the crate already enforces `#![deny(missing_docs)]` and every public item already has a `///` block.

Files touched: `crates/platform/src/daemonize.rs`, `crates/platform/src/privilege.rs`, `crates/platform/src/env.rs`. Net change: 1 insertion, 6 deletions.

Tracks #2038.

## Test plan

- [ ] CI: fmt + clippy
- [ ] CI: nextest (stable) on Linux / macOS / Windows
- [ ] No behavior change