### PR TITLE
docs(filters): rustdoc + comment cleanup for merge

### DIFF
--- a/crates/filters/src/merge/parse.rs
+++ b/crates/filters/src/merge/parse.rs
@@ -170,7 +170,7 @@ impl RuleModifiers {
 /// Returns the parsed modifiers and the remaining string (pattern).
 /// Modifiers are single characters that can appear in any order before the pattern.
 ///
-/// Reference: upstream rsync `exclude.c` lines 1220-1288 handles modifiers.
+/// upstream: exclude.c lines 1220-1288 - modifier character handling
 pub(crate) fn parse_modifiers(s: &str) -> (RuleModifiers, &str) {
     let mut mods = RuleModifiers::default();
 

--- a/crates/filters/src/merge/read.rs
+++ b/crates/filters/src/merge/read.rs
@@ -72,7 +72,6 @@ fn read_rules_recursive_impl(
     let mut expanded = Vec::with_capacity(rules.len());
     for rule in rules {
         if rule.action() == FilterAction::Merge {
-            // Resolve the merge file path relative to the current file's directory
             let merge_path = if rule.pattern().starts_with('/') {
                 Path::new(rule.pattern()).to_path_buf()
             } else if let Some(base) = base_dir {


### PR DESCRIPTION
## Summary

Closes task #2031 (filters::merge comment cleanup).

- `crates/filters/src/merge/parse.rs` - normalize the rustdoc on
  `parse_modifiers()` so the upstream reference uses the project's
  standard `upstream: <file>:<lines>` format instead of a free-form
  "Reference: ..." sentence (1 line touched, upstream ref preserved).
- `crates/filters/src/merge/read.rs` - delete a restating `//` comment
  that paraphrased the next three lines of code (1 line removed).

Counts:
- Rustdoc items added/normalized: 1 (`parse_modifiers` upstream ref)
- Restate-the-code comments removed: 1
- Upstream references preserved: all (including pre-existing
  `// upstream: exclude.c:parse_filter_file()` and
  `// upstream: exclude.c:parse_filter_str()` markers)

The remaining files in the module (`mod.rs`, `error.rs`, `tests.rs`)
were already in good shape from prior cleanup task #1424 and required
no changes.

## Test plan

- [ ] CI: fmt+clippy
- [ ] CI: nextest (stable)
- [ ] No behavior change - documentation/comment edits only