### PR TITLE
feat(fast_io): cache PBUF_RING probe and surface in --version

### DIFF
--- a/crates/fast_io/src/io_uring/buffer_ring.rs
+++ b/crates/fast_io/src/io_uring/buffer_ring.rs
@@ -24,13 +24,42 @@
 //! - **Linux 5.19+** for `IORING_REGISTER_PBUF_RING` support.
 //! - The kernel must not block io_uring via seccomp.
 //!
+//! # Runtime probe
+//!
+//! [`pbuf_ring_supported`] returns whether the running kernel can register a
+//! provided buffer ring. The first call performs the `uname(2)` parse; the
+//! result is cached in a process-wide [`OnceLock`] so subsequent calls are a
+//! single relaxed atomic load. The check is necessary but not sufficient -
+//! seccomp profiles, `IOSQE_REGISTER_PBUF_RING` rejection, or `-ENOMEM` can
+//! still cause [`BufferRing::new`] to fail; callers should prefer
+//! [`BufferRing::try_new`] for speculative use.
+//!
+//! # Fallback chain
+//!
+//! Each layer degrades independently so that PBUF_RING usage is best-effort:
+//!
+//! 1. **PBUF_RING** (Linux 5.19+, opcode 22) - completion-time buffer
+//!    selection, the path documented in this module.
+//! 2. **Classic provide-buffers** (Linux 5.6+, `IORING_OP_PROVIDE_BUFFERS`
+//!    opcode 31, or `IORING_REGISTER_BUFFERS` opcode 0) - pre-registered
+//!    buffer pool with per-SQE selection. See
+//!    [`super::registered_buffers::RegisteredBufferGroup`].
+//! 3. **Standard `read(2)` / `write(2)`** (any kernel) - the
+//!    `traits::StdFileReader` / `traits::StdFileWriter` fallback used when
+//!    io_uring is unavailable entirely.
+//! 4. **Non-Linux io_uring stub** (`io_uring_stub.rs`) - returns `false` from
+//!    [`pbuf_ring_supported`], `Err(Unsupported)` from [`BufferRing::new`],
+//!    and `None` from [`BufferRing::try_new`].
+//!
 //! # References
 //!
 //! - `io_uring_register(2)` - `IORING_REGISTER_PBUF_RING` / `IORING_UNREGISTER_PBUF_RING`
 //! - kernel source: `io_uring/kbuf.c` - `io_register_pbuf_ring()`
+//! - audit: `docs/audits/iouring-pbuf-ring.md` (task #2043)
 
 use std::io;
 use std::ptr;
+use std::sync::OnceLock;
 use std::sync::atomic::{AtomicU16, Ordering};
 
 use io_uring::IoUring as RawIoUring;
@@ -192,13 +221,40 @@ impl BufferRingConfig {
     }
 }
 
+/// Process-wide cache for the PBUF_RING support probe.
+///
+/// Populated by the first call to [`is_supported`] / [`pbuf_ring_supported`]
+/// and reused for the lifetime of the process. Caching avoids repeating
+/// the `uname(2)` syscall and version parse on every speculative call site.
+static PBUF_RING_SUPPORTED: OnceLock<bool> = OnceLock::new();
+
 /// Returns `true` if the kernel supports PBUF_RING (>= 5.19).
 ///
 /// Checks the kernel version via `uname(2)`. This is a necessary but not
 /// sufficient condition - the actual `IORING_REGISTER_PBUF_RING` call may
 /// still fail if seccomp blocks it.
+///
+/// The result is cached in a process-wide [`OnceLock`], so repeated calls
+/// after the first are a single relaxed atomic load. Use
+/// [`BufferRing::try_new`] when you also need to verify that registration
+/// will actually succeed.
 #[must_use]
 pub fn is_supported() -> bool {
+    *PBUF_RING_SUPPORTED.get_or_init(probe_pbuf_ring_support)
+}
+
+/// Alias for [`is_supported`] matching the cross-crate naming used by
+/// [`crate::pbuf_ring_supported`].
+///
+/// Provided so callers that import this module directly can use the
+/// crate-wide name without going through the top-level re-export.
+#[must_use]
+pub fn pbuf_ring_supported() -> bool {
+    is_supported()
+}
+
+/// Performs the actual kernel-version check used by [`is_supported`].
+fn probe_pbuf_ring_support() -> bool {
     let release = match config::config_detail::get_kernel_release_string() {
         Some(r) => r,
         None => return false,

--- a/crates/fast_io/src/io_uring/config.rs
+++ b/crates/fast_io/src/io_uring/config.rs
@@ -80,6 +80,14 @@ pub struct IoUringKernelInfo {
     pub kernel_minor: Option<u32>,
     /// Number of supported io_uring opcodes (0 if unavailable or probe failed).
     pub supported_ops: u32,
+    /// Whether the kernel supports `IORING_REGISTER_PBUF_RING` (Linux 5.19+).
+    ///
+    /// Determined by the kernel-version probe in
+    /// [`super::buffer_ring::pbuf_ring_supported`]. `false` does not preclude
+    /// classic provided buffers (`IORING_OP_PROVIDE_BUFFERS` /
+    /// `IORING_REGISTER_BUFFERS`); see the fallback chain documented on
+    /// `crate::io_uring::buffer_ring`.
+    pub pbuf_ring_supported: bool,
     /// Human-readable reason string (same as `io_uring_availability_reason()`).
     pub reason: String,
 }
@@ -116,9 +124,12 @@ pub mod config_detail {
     ///
     /// Probes the kernel version and io_uring syscall availability, returning
     /// a struct with machine-readable fields for programmatic consumption.
+    /// The PBUF_RING capability flag reflects the cached
+    /// [`crate::io_uring::buffer_ring::pbuf_ring_supported`] probe.
     #[must_use]
     pub fn io_uring_kernel_info() -> super::IoUringKernelInfo {
         let result = super::check_io_uring_reason();
+        let pbuf_ring_supported = crate::io_uring::buffer_ring::pbuf_ring_supported();
         match &result {
             super::IoUringProbeResult::Available {
                 major,
@@ -129,6 +140,7 @@ pub mod config_detail {
                 kernel_major: Some(*major),
                 kernel_minor: Some(*minor),
                 supported_ops: *supported_ops,
+                pbuf_ring_supported,
                 reason: result.reason(),
             },
             super::IoUringProbeResult::KernelTooOld { major, minor }
@@ -138,6 +150,7 @@ pub mod config_detail {
                     kernel_major: Some(*major),
                     kernel_minor: Some(*minor),
                     supported_ops: 0,
+                    pbuf_ring_supported,
                     reason: result.reason(),
                 }
             }
@@ -147,6 +160,7 @@ pub mod config_detail {
                 kernel_major: None,
                 kernel_minor: None,
                 supported_ops: 0,
+                pbuf_ring_supported,
                 reason: result.reason(),
             },
         }
@@ -211,6 +225,11 @@ pub(crate) enum IoUringProbeResult {
 
 impl IoUringProbeResult {
     /// Returns a human-readable reason string suitable for log output.
+    ///
+    /// For the [`Available`](Self::Available) variant the suffix
+    /// `, pbuf_ring=yes` or `, pbuf_ring=no` reflects the cached
+    /// [`super::buffer_ring::pbuf_ring_supported`] probe so that
+    /// `--version` output can communicate which fallback tier is in use.
     pub(crate) fn reason(&self) -> String {
         match self {
             Self::Available {
@@ -218,7 +237,15 @@ impl IoUringProbeResult {
                 minor,
                 supported_ops,
             } => {
-                format!("io_uring: enabled (kernel {major}.{minor}, {supported_ops} ops supported)")
+                let pbuf = if super::buffer_ring::pbuf_ring_supported() {
+                    "yes"
+                } else {
+                    "no"
+                };
+                format!(
+                    "io_uring: enabled (kernel {major}.{minor}, {supported_ops} ops supported, \
+                     pbuf_ring={pbuf})"
+                )
             }
             Self::NoKernelRelease => {
                 "io_uring: disabled (could not read kernel version)".to_string()
@@ -441,6 +468,10 @@ mod tests {
         assert!(reason.contains("enabled"));
         assert!(reason.contains("6.1"));
         assert!(reason.contains("48 ops supported"));
+        assert!(
+            reason.contains("pbuf_ring=yes") || reason.contains("pbuf_ring=no"),
+            "available reason must surface PBUF_RING probe result, got: {reason}"
+        );
     }
 
     #[test]
@@ -521,12 +552,14 @@ mod tests {
             kernel_major: Some(6),
             kernel_minor: Some(1),
             supported_ops: 48,
-            reason: "io_uring: enabled (kernel 6.1, 48 ops supported)".to_string(),
+            pbuf_ring_supported: true,
+            reason: "io_uring: enabled (kernel 6.1, 48 ops supported, pbuf_ring=yes)".to_string(),
         };
         assert!(info.available);
         assert_eq!(info.kernel_major, Some(6));
         assert_eq!(info.kernel_minor, Some(1));
         assert!(info.supported_ops > 0);
+        assert!(info.pbuf_ring_supported);
     }
 
     #[test]
@@ -536,10 +569,12 @@ mod tests {
             kernel_major: Some(4),
             kernel_minor: Some(19),
             supported_ops: 0,
+            pbuf_ring_supported: false,
             reason: "io_uring: disabled (kernel 4.19 < 5.6 required)".to_string(),
         };
         assert!(!info.available);
         assert_eq!(info.supported_ops, 0);
+        assert!(!info.pbuf_ring_supported);
     }
 
     #[test]
@@ -549,6 +584,7 @@ mod tests {
             kernel_major: None,
             kernel_minor: None,
             supported_ops: 0,
+            pbuf_ring_supported: false,
             reason: "io_uring: disabled (could not read kernel version)".to_string(),
         };
         assert!(!info.available);

--- a/crates/fast_io/src/io_uring/mod.rs
+++ b/crates/fast_io/src/io_uring/mod.rs
@@ -77,6 +77,12 @@
 //!   Factory types handle the final fallback to `BufReader`/`BufWriter`.
 //! - **Buffer registration**: registered (`READ_FIXED`/`WRITE_FIXED`) -> regular
 //!   (`Read`/`Write`) opcodes. Silent fallback on registration failure.
+//! - **Provided-buffer rings (PBUF_RING)**: Linux 5.19+ ring-mapped supplied
+//!   buffers (`IORING_REGISTER_PBUF_RING`, opcode 22) -> classic provide-buffers
+//!   path on 5.6+ -> standard `read`/`write` -> non-Linux io_uring stub. The
+//!   probe is cached process-wide via [`buffer_ring::pbuf_ring_supported`] and
+//!   surfaced on [`IoUringKernelInfo::pbuf_ring_supported`]. See
+//!   `docs/audits/iouring-pbuf-ring.md` for the full call-site survey.
 
 mod batching;
 pub mod buffer_ring;
@@ -100,7 +106,9 @@ use std::fs::File;
 use std::io::{self, Write};
 use std::os::unix::io::AsRawFd;
 
-pub use buffer_ring::{BufferRing, BufferRingConfig, BufferRingError, buffer_id_from_cqe_flags};
+pub use buffer_ring::{
+    BufferRing, BufferRingConfig, BufferRingError, buffer_id_from_cqe_flags, pbuf_ring_supported,
+};
 pub use config::{
     IoUringConfig, IoUringKernelInfo, config_detail, is_io_uring_available, sqpoll_fell_back,
 };

--- a/crates/fast_io/src/io_uring_stub.rs
+++ b/crates/fast_io/src/io_uring_stub.rs
@@ -39,6 +39,8 @@ pub struct IoUringKernelInfo {
     pub kernel_minor: Option<u32>,
     /// Number of supported io_uring opcodes (always 0).
     pub supported_ops: u32,
+    /// Whether the kernel supports `IORING_REGISTER_PBUF_RING` (always `false`).
+    pub pbuf_ring_supported: bool,
     /// Human-readable reason string.
     pub reason: String,
 }
@@ -232,6 +234,15 @@ pub mod buffer_ring {
         false
     }
 
+    /// Returns `false` on non-Linux platforms.
+    ///
+    /// Cross-platform alias for [`is_supported`] matching the
+    /// [`crate::pbuf_ring_supported`] re-export.
+    #[must_use]
+    pub fn pbuf_ring_supported() -> bool {
+        false
+    }
+
     /// Always returns `None` on this platform (no CQE buffer flag support).
     #[inline]
     #[must_use]
@@ -361,7 +372,9 @@ pub mod registered_buffers {
     }
 }
 
-pub use buffer_ring::{BufferRing, BufferRingConfig, BufferRingError, buffer_id_from_cqe_flags};
+pub use buffer_ring::{
+    BufferRing, BufferRingConfig, BufferRingError, buffer_id_from_cqe_flags, pbuf_ring_supported,
+};
 pub use linkat::{
     IORING_OP_LINKAT, LINKAT_MIN_KERNEL, LinkAtArgs, build_linkat_sqe, build_linkat_sqe_unchecked,
     linkat_supported, submit_linkat_blocking,

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -162,8 +162,9 @@ pub use io_uring::{
     RegisteredBufferSlot, RegisteredBufferStats, RenameAt2Args, SharedCompletion, SharedRing,
     SharedRingConfig, buffer_id_from_cqe_flags, build_linkat_sqe, build_linkat_sqe_unchecked,
     build_renameat2_sqe, build_renameat2_sqe_unchecked, is_io_uring_available, linkat_supported,
-    reader_from_path, reader_from_path_with_depth, renameat2_blocking, renameat2_supported,
-    sqpoll_fell_back, submit_linkat_blocking, writer_from_file, writer_from_file_with_depth,
+    pbuf_ring_supported, reader_from_path, reader_from_path_with_depth, renameat2_blocking,
+    renameat2_supported, sqpoll_fell_back, submit_linkat_blocking, writer_from_file,
+    writer_from_file_with_depth,
 };
 
 #[cfg(all(target_os = "windows", feature = "iocp"))]
@@ -279,6 +280,7 @@ fn io_uring_kernel_info_impl() -> io_uring::IoUringKernelInfo {
         kernel_major: None,
         kernel_minor: None,
         supported_ops: 0,
+        pbuf_ring_supported: false,
         reason: io_uring_availability_reason_impl(),
     }
 }

--- a/crates/fast_io/tests/pbuf_ring_probe.rs
+++ b/crates/fast_io/tests/pbuf_ring_probe.rs
@@ -1,0 +1,106 @@
+//! Integration tests for the `IORING_REGISTER_PBUF_RING` runtime probe.
+//!
+//! These tests cover the cross-platform `pbuf_ring_supported()` re-export at
+//! the crate root (and the matching `IoUringKernelInfo::pbuf_ring_supported`
+//! field), exercising both the Linux + io_uring path and the non-Linux stub.
+//!
+//! On non-Linux platforms (or with the `io_uring` feature disabled) the probe
+//! must always return `false`. On Linux with the feature enabled the probe is
+//! cached process-wide via `OnceLock`, so multiple calls (including from many
+//! threads) must agree without re-entering the kernel-version parser.
+//!
+//! See `docs/audits/iouring-pbuf-ring.md` for the full fallback chain
+//! documentation: PBUF_RING (5.19+) -> classic provide-buffers (5.6+) ->
+//! standard read/write -> non-Linux io_uring stub.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::thread;
+
+use fast_io::{io_uring_kernel_info, is_io_uring_available, pbuf_ring_supported};
+
+#[test]
+fn pbuf_ring_supported_is_idempotent() {
+    let first = pbuf_ring_supported();
+    let second = pbuf_ring_supported();
+    let third = pbuf_ring_supported();
+    assert_eq!(first, second);
+    assert_eq!(second, third);
+}
+
+#[test]
+fn pbuf_ring_supported_false_on_non_linux() {
+    // On any non-Linux target, or when io_uring is compiled out, the probe
+    // must report unsupported. PBUF_RING (kernel 5.19+) is a Linux-only
+    // io_uring feature; the cross-platform stub returns `false`.
+    #[cfg(not(all(target_os = "linux", feature = "io_uring")))]
+    {
+        assert!(
+            !pbuf_ring_supported(),
+            "stub probe must return false on non-Linux or feature-disabled builds"
+        );
+    }
+    // On Linux with io_uring enabled, simply assert that the call succeeds
+    // and is type-correct. The actual support depends on the kernel.
+    #[cfg(all(target_os = "linux", feature = "io_uring"))]
+    {
+        let _: bool = pbuf_ring_supported();
+    }
+}
+
+#[test]
+fn pbuf_ring_supported_implies_io_uring_available() {
+    // Logical invariant: PBUF_RING requires kernel 5.19+, which is strictly
+    // stronger than the io_uring 5.6+ floor. If PBUF_RING is reported as
+    // supported but io_uring itself is not, the layered probe is
+    // inconsistent.
+    if pbuf_ring_supported() {
+        assert!(
+            is_io_uring_available(),
+            "PBUF_RING claimed without io_uring base support; layered probe is broken"
+        );
+    }
+}
+
+#[test]
+fn kernel_info_pbuf_ring_field_agrees_with_probe() {
+    let info = io_uring_kernel_info();
+    assert_eq!(
+        info.pbuf_ring_supported,
+        pbuf_ring_supported(),
+        "IoUringKernelInfo.pbuf_ring_supported must mirror the crate-root probe"
+    );
+}
+
+#[test]
+fn pbuf_ring_probe_is_cached_across_threads() {
+    // The probe is cached behind `OnceLock`, so concurrent callers must all
+    // see the same boolean. Spawn a fan-out that races the probe against
+    // itself; the OnceLock contract guarantees at most one initialiser
+    // runs.
+    let expected = pbuf_ring_supported();
+    let mismatched = Arc::new(AtomicBool::new(false));
+
+    let handles: Vec<_> = (0..16)
+        .map(|_| {
+            let mismatched = Arc::clone(&mismatched);
+            thread::spawn(move || {
+                for _ in 0..64 {
+                    if pbuf_ring_supported() != expected {
+                        mismatched.store(true, Ordering::Relaxed);
+                        return;
+                    }
+                }
+            })
+        })
+        .collect();
+
+    for handle in handles {
+        handle.join().expect("probe thread panicked");
+    }
+
+    assert!(
+        !mismatched.load(Ordering::Relaxed),
+        "OnceLock-cached probe returned divergent values across threads"
+    );
+}

--- a/docs/audits/iouring-pbuf-ring.md
+++ b/docs/audits/iouring-pbuf-ring.md
@@ -6,7 +6,7 @@ Tracking issue: oc-rsync task #2043. Sibling audits:
 (task #1086), [`docs/audits/mmap-iouring-co-usage.md`](mmap-iouring-co-usage.md)
 (task #1660).
 
-Last verified: 2026-05-01 against master @ `83c8aa41`. Files spot-checked:
+Last verified: 2026-05-05 against master @ `5ca6c71eb`. Files spot-checked:
 `crates/fast_io/src/io_uring/mod.rs`,
 `crates/fast_io/src/io_uring/buffer_ring.rs`,
 `crates/fast_io/src/io_uring/registered_buffers.rs`,
@@ -15,6 +15,13 @@ Last verified: 2026-05-01 against master @ `83c8aa41`. Files spot-checked:
 `crates/fast_io/src/io_uring/socket_writer.rs`,
 `crates/fast_io/src/io_uring/config.rs`,
 `crates/fast_io/src/lib.rs`.
+
+Phase 2 status: probe is now process-cached at `OnceLock` boundary in
+[`buffer_ring::pbuf_ring_supported`](../../crates/fast_io/src/io_uring/buffer_ring.rs)
+and re-exported at the crate root as `fast_io::pbuf_ring_supported` and
+on `IoUringKernelInfo::pbuf_ring_supported`. The `--version` reason
+string now includes `pbuf_ring=yes/no`. The cross-platform stub
+mirrors the same surface and always returns `false`.
 
 ## Scope
 


### PR DESCRIPTION
## Summary

Implements task #2043: probe `IORING_REGISTER_PBUF_RING` (Linux 5.19+) at runtime, cache the result behind `OnceLock`, surface it on `IoUringKernelInfo`, and document the layered fallback chain in code and audit docs.

- Adds a process-wide `OnceLock`-cached `pbuf_ring_supported() -> bool` probe in `crates/fast_io/src/io_uring/buffer_ring.rs`, re-exported at the crate root as `fast_io::pbuf_ring_supported`. The first call performs a `uname(2)` parse via `config_detail::get_kernel_release_string`; subsequent calls are a single relaxed atomic load.
- Surfaces the probe on `IoUringKernelInfo::pbuf_ring_supported` (both Linux and the cross-platform stub) and appends `, pbuf_ring=yes/no` to the `IoUringProbeResult::Available` reason string so `--version` output communicates which fallback tier is active.
- Cross-platform stub (`io_uring_stub.rs`) mirrors the same surface and always returns `false`; matching re-export added.
- Module-level rustdoc updated on `io_uring/buffer_ring.rs` and `io_uring/mod.rs`, and `docs/audits/iouring-pbuf-ring.md` updated with the Phase 2 status note.

## Fallback chain

1. **PBUF_RING** (Linux 5.19+, `IORING_REGISTER_PBUF_RING`, opcode 22) - completion-time buffer selection via ring-mapped supplied buffers.
2. **Classic provide-buffers** (Linux 5.6+, `IORING_OP_PROVIDE_BUFFERS` opcode 31, or `IORING_REGISTER_BUFFERS` opcode 0) - pre-registered pool with per-SQE selection.
3. **Standard `read(2)` / `write(2)`** - `traits::StdFileReader` / `traits::StdFileWriter` fallback used when io_uring is unavailable entirely.
4. **Non-Linux io_uring stub** (`io_uring_stub.rs`) - `pbuf_ring_supported()` returns `false`; `BufferRing::new` returns `Err(Unsupported)`; `BufferRing::try_new` returns `None`.

## Test plan

New `crates/fast_io/tests/pbuf_ring_probe.rs` adds five integration tests covering:

- [x] Idempotency across repeated calls (`OnceLock` caching contract).
- [x] Stub returns `false` on non-Linux / feature-disabled builds; type-correct on Linux.
- [x] `pbuf_ring_supported() => is_io_uring_available()` invariant (5.19+ implies the 5.6+ floor).
- [x] `IoUringKernelInfo::pbuf_ring_supported` mirrors the crate-root probe.
- [x] Cached probe returns identical values from 16 threads x 64 calls each (no torn reads, no re-entry into the kernel-version parser).

CI: fmt+clippy, nextest (Linux probe path; non-Linux stub path); audit doc renders.

Refs task #2043.