### PR TITLE
feat(ssh): warn when SSH and rsync compression both enabled

### DIFF
--- a/crates/core/src/client/remote/ssh_transfer.rs
+++ b/crates/core/src/client/remote/ssh_transfer.rs
@@ -292,6 +292,10 @@ fn build_ssh_connection(
 
     ssh.set_remote_command(invocation_args);
 
+    if config.compress() && ssh.has_ssh_compression() {
+        warn_double_compression_once();
+    }
+
     // upstream: pipe.c:85 - SSH spawn failures return IPC error code.
     let mut connection = ssh.spawn().map_err(|e| {
         invalid_argument_error(
@@ -677,6 +681,25 @@ fn build_server_config_for_generator(
 
     flags::apply_common_server_flags(config, &mut server_config);
     Ok(server_config)
+}
+
+/// Emits a one-time warning to stderr when SSH built-in compression and
+/// rsync `--compress` are both active.
+///
+/// Compressing twice wastes CPU and may expand already-compressed data.
+/// Upstream rsync does not detect this case; this is an oc-rsync usability
+/// enhancement. Detection is conservative: it only inspects the SSH
+/// command-line arguments built up from `-e`/`--rsh` and friends and does
+/// not parse `~/.ssh/config`, since that file is merged at spawn time and
+/// we cannot reliably read it.
+fn warn_double_compression_once() {
+    static EMITTED: std::sync::OnceLock<()> = std::sync::OnceLock::new();
+    EMITTED.get_or_init(|| {
+        eprintln!(
+            "rsync warning: SSH compression (-C / -o Compression=yes) and rsync --compress \
+             both enabled; double compression wastes CPU. Disable one."
+        );
+    });
 }
 
 #[cfg(test)]

--- a/crates/rsync_io/src/ssh/builder.rs
+++ b/crates/rsync_io/src/ssh/builder.rs
@@ -217,6 +217,28 @@ impl SshCommand {
         self
     }
 
+    /// Returns `true` when the configured SSH command requests built-in
+    /// OpenSSH compression via `-C` or `-o Compression=yes`.
+    ///
+    /// Used to detect double-compression hazards when rsync's own
+    /// `--compress` is enabled: compressing twice wastes CPU and can
+    /// expand already-compressed data.
+    ///
+    /// Detection is conservative and inspects the explicit command-line
+    /// arguments only - it does not parse `~/.ssh/config`, since the SSH
+    /// client merges that file at spawn time and we cannot reliably read it.
+    /// `-C` and `-o Compression=...` cover the cases users set on the
+    /// rsync invocation itself (via `-e ssh -C` / `--rsh`).
+    ///
+    /// Truthy values for `Compression`: `yes`, `true`, `1`, case-insensitive.
+    #[must_use]
+    pub fn has_ssh_compression(&self) -> bool {
+        self.options
+            .iter()
+            .enumerate()
+            .any(|(idx, opt)| arg_enables_ssh_compression(opt, self.options.get(idx + 1)))
+    }
+
     /// Configures the comma-separated list of OpenSSH ProxyJump hosts.
     ///
     /// When `Some(value)` and `value` is non-empty, `-J <value>` is appended
@@ -592,6 +614,44 @@ pub(super) fn has_hardware_aes() -> bool {
             false
         }
     })
+}
+
+/// Returns `true` if the SSH option `arg` (with optional split-pair `next`)
+/// requests built-in OpenSSH compression.
+///
+/// Recognises:
+/// - the standalone `-C` flag (case-sensitive, OpenSSH convention)
+/// - `-oCompression=<truthy>` and `-o Compression=<truthy>` (case-insensitive
+///   key, with `<truthy>` in `{yes, true, 1}` case-insensitive)
+///
+/// The split form (where `-o` and `Compression=...` are separate argv
+/// entries) consumes `next` so a future call on the same iterator does not
+/// double-count the value.
+fn arg_enables_ssh_compression(arg: &OsStr, next: Option<&OsString>) -> bool {
+    if arg == OsStr::new("-C") {
+        return true;
+    }
+    let Some(s) = arg.to_str() else {
+        return false;
+    };
+    if let Some(rest) = s.strip_prefix("-o") {
+        let body = if rest.is_empty() {
+            match next.and_then(|os| os.to_str()) {
+                Some(v) => v,
+                None => return false,
+            }
+        } else {
+            rest
+        };
+        if let Some((key, value)) = body.split_once('=') {
+            return key.eq_ignore_ascii_case("Compression")
+                && matches!(
+                    value.trim().to_ascii_lowercase().as_str(),
+                    "yes" | "true" | "1"
+                );
+        }
+    }
+    false
 }
 
 /// Classified SSH host operand.

--- a/crates/rsync_io/src/ssh/tests.rs
+++ b/crates/rsync_io/src/ssh/tests.rs
@@ -2120,3 +2120,68 @@ fn jump_host_clearable_via_none() {
         "clearing jump-hosts must remove -J: {rendered:?}"
     );
 }
+
+#[test]
+fn has_ssh_compression_detects_dash_c() {
+    let mut command = SshCommand::new("example.com");
+    command.push_option("-C");
+    assert!(command.has_ssh_compression());
+}
+
+#[test]
+fn has_ssh_compression_detects_combined_option_yes() {
+    let mut command = SshCommand::new("example.com");
+    command.push_option("-oCompression=yes");
+    assert!(command.has_ssh_compression());
+}
+
+#[test]
+fn has_ssh_compression_detects_split_option_yes() {
+    let mut command = SshCommand::new("example.com");
+    command.push_option("-o");
+    command.push_option("Compression=yes");
+    assert!(command.has_ssh_compression());
+}
+
+#[test]
+fn has_ssh_compression_truthy_aliases() {
+    for value in ["yes", "YES", "Yes", "true", "TRUE", "1"] {
+        let mut command = SshCommand::new("example.com");
+        command.push_option(format!("-oCompression={value}"));
+        assert!(
+            command.has_ssh_compression(),
+            "expected detection for value {value:?}"
+        );
+    }
+}
+
+#[test]
+fn has_ssh_compression_case_insensitive_key() {
+    let mut command = SshCommand::new("example.com");
+    command.push_option("-ocompression=yes");
+    assert!(command.has_ssh_compression());
+}
+
+#[test]
+fn has_ssh_compression_rejects_falsey_and_unrelated() {
+    for value in ["no", "NO", "false", "0", "off"] {
+        let mut command = SshCommand::new("example.com");
+        command.push_option(format!("-oCompression={value}"));
+        assert!(
+            !command.has_ssh_compression(),
+            "value {value:?} must not enable compression"
+        );
+    }
+
+    let mut command = SshCommand::new("example.com");
+    command.push_option("-oBatchMode=yes");
+    command.push_option("-c");
+    command.push_option("aes128-gcm@openssh.com");
+    assert!(!command.has_ssh_compression());
+}
+
+#[test]
+fn has_ssh_compression_default_is_false() {
+    let command = SshCommand::new("example.com");
+    assert!(!command.has_ssh_compression());
+}


### PR DESCRIPTION
## Summary

Detect when SSH built-in compression (-C / -o Compression=yes) and rsync `--compress` are both active and emit one stderr warning per process. Compressing twice wastes CPU and may expand already-compressed data.

## Changes

- `SshCommand::has_ssh_compression()` - new public inspector that scans the explicit SSH argv for compression flags. Detection is conservative; it does not parse `~/.ssh/config` since that file is merged at spawn time and we cannot reliably read it.
- `arg_enables_ssh_compression()` - private helper recognising:
  - bare `-C`
  - `-oCompression=<truthy>` (combined)
  - `-o Compression=<truthy>` (split across two argv entries)
  - case-insensitive key match (`Compression`/`compression`)
  - truthy values: `yes`, `true`, `1`, all case-insensitive
- `build_ssh_connection` (`crates/core/src/client/remote/ssh_transfer.rs`) checks `config.compress() && ssh.has_ssh_compression()` after building the SshCommand and before spawn, calling a new `warn_double_compression_once` helper.
- `warn_double_compression_once` uses `OnceLock<()>` to emit at most one `rsync warning:` line per process, then proceeds unchanged. No auto-disable, no CLI flag.

## Tests

Seven unit tests in `crates/rsync_io/src/ssh/tests.rs`:
- `has_ssh_compression_detects_dash_c`
- `has_ssh_compression_detects_combined_option_yes`
- `has_ssh_compression_detects_split_option_yes`
- `has_ssh_compression_truthy_aliases` (yes/YES/Yes/true/TRUE/1)
- `has_ssh_compression_case_insensitive_key`
- `has_ssh_compression_rejects_falsey_and_unrelated` (no/NO/false/0/off plus unrelated `-o BatchMode=yes`, `-c aes128-gcm@openssh.com`)
- `has_ssh_compression_default_is_false`

## Wire compatibility

No protocol or wire-format change. The warning is the only user-visible effect.