### PR TITLE
docs(rsync_io): rustdoc cleanup for multiplex frontend

### DIFF
--- a/crates/rsync_io/src/lib.rs
+++ b/crates/rsync_io/src/lib.rs
@@ -4,7 +4,7 @@
 
 //! # Overview
 //!
-//! `transport` houses the transport adapters used by the Rust `rsync`
+//! `rsync_io` houses the transport adapters used by the Rust `rsync`
 //! implementation. The crate currently focuses on handshake detection and
 //! exposes wrappers that preserve bytes consumed while deciding between legacy
 //! ASCII and binary negotiations.


### PR DESCRIPTION
## Summary

- Fix stale `transport` crate-name reference in `crates/rsync_io/src/lib.rs` module-level rustdoc; the crate was renamed from `transport` to `rsync_io` in commit 077db1bb but the overview paragraph still referred to the old name.
- `debug_io.rs` already has rustdoc on every public item (cfg-gated tracing helpers and their no-op counterparts) and required no edits.
- Comment-only edit. No executable code changes. `cargo fmt --all -- --check` passes.

## Scope

- Audited only the top-level files of `crates/rsync_io/src/`: `lib.rs` and `debug_io.rs`.
- The `crates/rsync_io/src/ssh/` subtree is untouched (locked under TODO #2032).

## Test plan

- [ ] CI fmt+clippy passes.
- [ ] CI nextest stable passes.
- [ ] CI Windows / macOS / Linux musl pass.