### PR TITLE
docs(platform): rustdoc cleanup

### DIFF
--- a/crates/platform/src/lib.rs
+++ b/crates/platform/src/lib.rs
@@ -12,8 +12,8 @@
 //!
 //! # Windows
 //!
-//! Uses the `windows` crate (v0.61) for Win32 API bindings. Unsafe blocks
-//! are required for FFI calls but are scoped to individual functions.
+//! Uses the `windows` crate for Win32 API bindings. Unsafe blocks are required
+//! for FFI calls but are scoped to individual functions.
 //!
 //! # Safety Policy
 //!

--- a/crates/platform/src/windows_service.rs
+++ b/crates/platform/src/windows_service.rs
@@ -115,7 +115,6 @@ mod windows_impl {
     /// process was not launched by the SCM).
     #[allow(unsafe_code)]
     pub fn run_service_dispatcher(callback: ServiceMainCallback) -> Result<(), io::Error> {
-        // Store the callback for retrieval in service_main.
         SERVICE_CALLBACK
             .set(std::sync::Mutex::new(Some(callback)))
             .map_err(|_| {
@@ -161,7 +160,8 @@ mod windows_impl {
     unsafe extern "system" fn service_main_entry(_argc: u32, _argv: *mut windows::core::PWSTR) {
         let service_name = to_wide_null(SERVICE_NAME);
 
-        // Register the control handler before doing anything else.
+        // The control handler must be registered before any other SCM call so
+        // that stop/shutdown events arriving during start-up are handled.
         // SAFETY: service_name is a valid null-terminated UTF-16 string.
         // handler_function matches the LPHANDLER_FUNCTION signature.
         let status_handle = match unsafe {
@@ -176,18 +176,16 @@ mod windows_impl {
 
         let _ = SERVICE_STATUS_HANDLE.set(SendSyncHandle(status_handle));
 
-        // Create signal flags and store them globally for the control handler.
+        // SignalFlags must be reachable from the control handler, which is
+        // invoked from arbitrary SCM threads, so publish them via OnceLock.
         let flags = SignalFlags::new();
         let _ = SERVICE_FLAGS.set(flags.clone());
 
-        // Report SERVICE_START_PENDING.
         let _ = report_status_raw(status_handle, SERVICE_START_PENDING, 0, 3000);
-
-        // Report SERVICE_RUNNING.
         let _ = report_status_raw(status_handle, SERVICE_RUNNING, 0, 0);
 
-        // Run the user callback. Extract it from the OnceLock<Mutex<Option>>
-        // with a flat chain of and_then to avoid deep nesting.
+        // Extract the callback from OnceLock<Mutex<Option>> with a flat chain
+        // of and_then to avoid deep nesting.
         let callback = SERVICE_CALLBACK
             .get()
             .and_then(|mutex| mutex.lock().ok())
@@ -198,7 +196,6 @@ mod windows_impl {
             None => 1,
         };
 
-        // Report SERVICE_STOPPED.
         let _ = report_status_raw(status_handle, SERVICE_STOPPED, exit_code, 0);
     }
 


### PR DESCRIPTION
## Summary

Final rustdoc/comment-cleanup pass for the `platform` crate (#2038).

## Changes

- `crates/platform/src/lib.rs` - dropped the outdated `windows` crate version (`v0.61`) from the module-level docs; the workspace currently pins `v0.62` and the file no longer needs to track the bump.
- `crates/platform/src/windows_service.rs` - replaced five restating comments (`// Store the callback...`, `// Register the control handler before doing anything else.`, `// Create signal flags and store them globally...`, `// Report SERVICE_START_PENDING.`, `// Report SERVICE_RUNNING.`, `// Report SERVICE_STOPPED.`) with concise WHY notes that document the SCM control-handler ordering invariant and the OnceLock publication contract.

## Counts

- Public items now documented: 100% (no rustdoc additions needed; the crate already had `#![deny(missing_docs)]` and was passing).
- Restating comments removed: 4 single-line restatements collapsed into surrounding code.
- Restating comments rewritten as WHY: 3 (control-handler-first ordering, SignalFlags publication, callback extraction note).
- Outdated facts corrected: 1 (`windows` crate version).
- `// upstream:` references preserved verbatim: 11 (in daemonize, group, name_resolution, privilege, secrets, signal).
- `// SAFETY:` blocks preserved verbatim: 24.
- Platform-quirk WHY comments preserved: macOS `setgroups` fallback, SCM stopped-state controls, OnceLock thread-share rationale, descriptor-slot reuse in `redirect_stdio_to_devnull`.

## Wire-compatibility

Comment-only diff. Zero behaviour change. `cargo fmt --all -- --check` passes.

## Test plan
- [x] `cargo fmt --all -- --check` clean
- [ ] CI fmt+clippy
- [ ] CI nextest stable
- [ ] CI Windows / macOS / Linux musl