### PR TITLE
docs(protocol): rustdoc cleanup for iconv module

### DIFF
--- a/crates/protocol/src/iconv/mod.rs
+++ b/crates/protocol/src/iconv/mod.rs
@@ -106,8 +106,6 @@ mod tests {
         assert_eq!(conv.remote_encoding_name(), "UTF-8");
     }
 
-    // New API tests (EncodingConverter/EncodingPair/EncodingError)
-
     #[test]
     fn test_encoding_pair_creation() {
         let pair = EncodingPair::new("utf-8", "iso-8859-1");


### PR DESCRIPTION
## Summary

- Audit pass on `crates/protocol/src/iconv/{mod,converter,error,pair}.rs` per TODO #1993.
- Module is largely pristine: every public item already carries `///` rustdoc, the `//!` module header documents `--iconv` semantics with a working example, and the WHY comments on UTF-8/Latin-1 boundaries and encoding-error policy remain in place.
- Removes a single decorative banner comment in the test module (`// New API tests (EncodingConverter/EncodingPair/EncodingError)`). No executable code changes.

## Test plan

- [x] `cargo fmt --all` clean.
- [ ] CI: fmt+clippy, nextest (stable), Windows, macOS, Linux musl.