### PR TITLE
docs(fast_io): rustdoc cleanup for io_uring module

### DIFF
--- a/crates/fast_io/src/io_uring/mod.rs
+++ b/crates/fast_io/src/io_uring/mod.rs
@@ -149,7 +149,7 @@ pub fn writer_from_file(
     match policy {
         crate::IoUringPolicy::Auto => {
             if is_io_uring_available() {
-                // Build ring first — if this fails, `file` is still ours.
+                // Build ring first - if this fails, `file` is still ours.
                 if let Ok(ring) = config.build_ring() {
                     let fixed_fd_slot =
                         try_register_fd(&ring, file.as_raw_fd(), config.register_files);

--- a/crates/fast_io/src/io_uring/socket_factory.rs
+++ b/crates/fast_io/src/io_uring/socket_factory.rs
@@ -57,7 +57,7 @@ impl Write for IoUringOrStdSocketWriter {
 /// falls back to `BufReader` wrapping a standard `Read`.
 ///
 /// The `fd` must be a valid socket file descriptor. The caller retains
-/// ownership — this function does not close the fd.
+/// ownership - this function does not close the fd.
 pub fn socket_reader_from_fd(
     fd: RawFd,
     buffer_capacity: usize,
@@ -108,7 +108,7 @@ pub fn socket_reader_from_fd(
 /// falls back to a standard `Write` wrapper.
 ///
 /// The `fd` must be a valid socket file descriptor. The caller retains
-/// ownership — this function does not close the fd.
+/// ownership - this function does not close the fd.
 pub fn socket_writer_from_fd(
     fd: RawFd,
     buffer_capacity: usize,

--- a/crates/fast_io/src/io_uring/socket_reader.rs
+++ b/crates/fast_io/src/io_uring/socket_reader.rs
@@ -27,7 +27,7 @@ impl IoUringSocketReader {
     /// Creates a socket reader from a raw file descriptor.
     ///
     /// The caller must ensure `fd` remains valid for the lifetime of this reader.
-    /// The reader does NOT take ownership of the fd — it will not close it on drop.
+    /// The reader does NOT take ownership of the fd - it will not close it on drop.
     pub fn from_raw_fd(fd: RawFd, config: &IoUringConfig) -> io::Result<Self> {
         let ring = config.build_ring()?;
         let fixed_fd_slot = try_register_fd(&ring, fd, config.register_files);

--- a/crates/fast_io/src/io_uring/socket_writer.rs
+++ b/crates/fast_io/src/io_uring/socket_writer.rs
@@ -27,7 +27,7 @@ impl IoUringSocketWriter {
     /// Creates a socket writer from a raw file descriptor.
     ///
     /// The caller must ensure `fd` remains valid for the lifetime of this writer.
-    /// The writer does NOT take ownership of the fd — it will not close it on drop.
+    /// The writer does NOT take ownership of the fd - it will not close it on drop.
     pub fn from_raw_fd(fd: RawFd, config: &IoUringConfig) -> io::Result<Self> {
         let ring = config.build_ring()?;
         let fixed_fd_slot = try_register_fd(&ring, fd, config.register_files);

--- a/crates/fast_io/src/io_uring/tests.rs
+++ b/crates/fast_io/src/io_uring/tests.rs
@@ -221,10 +221,6 @@ fn test_reader_seek() {
     assert_eq!(&buf, b"world");
 }
 
-// ─────────────────────────────────────────────────────────────────────────
-// Comprehensive io_uring tests with graceful fallback
-// ─────────────────────────────────────────────────────────────────────────
-
 #[test]
 fn test_basic_read_with_io_uring_or_fallback() {
     let dir = tempdir().unwrap();
@@ -850,10 +846,6 @@ fn test_drop_flushes_writer() {
     assert_eq!(written, b"data to flush on drop");
 }
 
-// ─────────────────────────────────────────────────────────────────────────
-// Socket I/O tests (exercises io_uring path on Linux, fallback elsewhere)
-// ─────────────────────────────────────────────────────────────────────────
-
 /// Creates a Unix socket pair suitable for testing socket read/write.
 fn make_socket_pair() -> (RawFd, RawFd) {
     let mut fds = [0i32; 2];
@@ -898,7 +890,7 @@ fn test_socket_large_payload_roundtrip() {
     let mut writer = socket_writer_from_fd(fd_a, 8 * 1024, policy).unwrap();
     let mut reader = socket_reader_from_fd(fd_b, 8 * 1024, policy).unwrap();
 
-    // 128KB payload — larger than internal buffer, forces multiple batches.
+    // 128KB payload - larger than internal buffer, forces multiple batches.
     let payload: Vec<u8> = (0..128 * 1024).map(|i| (i % 251) as u8).collect();
 
     // Write in a separate thread to avoid deadlock on blocking socket pair.
@@ -1154,10 +1146,6 @@ fn test_fd_reader_writer_basic() {
     close_fd(fd_b);
 }
 
-// ─────────────────────────────────────────────────────────────────────────
-// IoUringPolicy tests for writer_from_file / reader_from_path
-// ─────────────────────────────────────────────────────────────────────────
-
 #[test]
 fn test_policy_disabled_writer_uses_std() {
     let dir = tempdir().unwrap();
@@ -1367,10 +1355,6 @@ fn test_empty_file_roundtrip_via_policy() {
     assert!(data.is_empty());
 }
 
-// ────────────────────────────────────────────────────────────────────────────
-// Registered buffer configuration tests
-// ────────────────────────────────────────────────────────────────────────────
-
 #[test]
 fn test_config_register_buffers_defaults() {
     let config = IoUringConfig::default();
@@ -1397,10 +1381,6 @@ fn test_config_register_buffers_disabled() {
     };
     assert!(!config.register_buffers);
 }
-
-// ────────────────────────────────────────────────────────────────────────────
-// Registered buffer group tests (require io_uring availability)
-// ────────────────────────────────────────────────────────────────────────────
 
 #[test]
 fn test_registered_buffer_group_via_writer() {


### PR DESCRIPTION
## Summary

- Comment-only cleanup for `crates/fast_io/src/io_uring/`. No executable code changes.
- Removed five decorative banner blocks from `tests.rs` (the `─` divider lines around section labels).
- Replaced six stray em-dash characters with hyphens in `mod.rs`, `socket_factory.rs`, `socket_reader.rs`, `socket_writer.rs`, and `tests.rs` to match the project writing-style rule.
- Preserved every `// upstream:` reference, every `// SAFETY:` annotation, and every WHY comment carrying kernel-level invariants (PBUF_RING kernel >= 5.19, drop ordering vs ring fd, SQPOLL fallback rationale, EAGAIN/POLLOUT gating, etc.).

## Files

- `mod.rs` - one em-dash replaced.
- `socket_factory.rs` - two em-dashes replaced.
- `socket_reader.rs` - one em-dash replaced.
- `socket_writer.rs` - one em-dash replaced.
- `tests.rs` - one em-dash replaced; five decorative banner blocks deleted.

The remaining files (`batching.rs`, `buffer_ring.rs`, `config.rs`, `disk_batch.rs`, `file_factory.rs`, `file_reader.rs`, `file_writer.rs`, `registered_buffers.rs`, `shared_ring.rs`) were already pristine and were not modified.

## Test plan

- [x] `cargo fmt --all -- --check` passes.
- [x] `git diff` confirms comment-only edits (no code lines moved or altered).
- [x] No `// upstream:` references removed.
- [x] No `// SAFETY:` annotations removed.
- [ ] CI: fmt+clippy, nextest (stable), Windows, macOS, Linux musl.