### PR TITLE
docs(flist): rustdoc cleanup for top-level entry points

### DIFF
--- a/crates/flist/src/lazy_entry.rs
+++ b/crates/flist/src/lazy_entry.rs
@@ -172,13 +172,10 @@ impl LazyFileListEntry {
     ///
     /// Returns an error if metadata cannot be fetched.
     pub fn into_resolved(mut self) -> Result<FileListEntry, io::Error> {
-        // Ensure metadata is resolved
         if let Err(e) = self.metadata.get() {
-            // Return owned error
             return Err(io::Error::new(e.kind(), e.to_string()));
         }
 
-        // Now we can extract the metadata
         let metadata = self.metadata.into_metadata()?;
 
         Ok(FileListEntry {
@@ -310,13 +307,10 @@ mod tests {
         let (_dir, path) = create_test_file();
         let mut entry = LazyFileListEntry::new(path, PathBuf::from("test.txt"), 1, false, false);
 
-        // Not resolved yet
         assert!(entry.metadata_if_resolved().is_none());
 
-        // Resolve it
         let _ = entry.metadata();
 
-        // Now should return Some
         assert!(entry.metadata_if_resolved().is_some());
     }
 
@@ -353,7 +347,6 @@ mod tests {
         let (_dir, path) = create_test_file();
         let entry = LazyFileListEntry::new(path, PathBuf::from("test.txt"), 1, false, false);
 
-        // Not resolved, should return None
         assert!(entry.try_into_resolved().is_none());
     }
 
@@ -364,7 +357,6 @@ mod tests {
         let entry =
             LazyFileListEntry::with_metadata(path, PathBuf::from("test.txt"), metadata, 1, false);
 
-        // Already resolved, should return Some
         let result = entry.try_into_resolved();
         assert!(result.is_some());
         assert!(result.unwrap().is_ok());
@@ -374,10 +366,8 @@ mod tests {
     fn test_filtering_without_stat() {
         let (_dir, path) = create_test_file();
 
-        // Create entry
         let entry = LazyFileListEntry::new(path, PathBuf::from("test.txt"), 1, false, false);
 
-        // Filter by extension without fetching metadata
         let should_process = entry
             .relative_path()
             .extension()
@@ -385,7 +375,6 @@ mod tests {
             .unwrap_or(true);
 
         assert!(should_process);
-        // Metadata was never fetched
         assert!(!entry.is_resolved());
     }
 }

--- a/crates/flist/src/lazy_metadata.rs
+++ b/crates/flist/src/lazy_metadata.rs
@@ -96,7 +96,6 @@ impl LazyMetadata {
     ///
     /// Returns the cached error if metadata fetch previously failed.
     pub fn get(&mut self) -> Result<&fs::Metadata, &io::Error> {
-        // Resolve if pending
         if let Self::Pending {
             path,
             follow_symlinks,
@@ -114,7 +113,6 @@ impl LazyMetadata {
             };
         }
 
-        // Return cached result
         match self {
             Self::Resolved(metadata) => Ok(metadata),
             Self::Error(error) => Err(error),
@@ -149,7 +147,6 @@ impl LazyMetadata {
     ///
     /// Returns the error if metadata fetch failed.
     pub fn into_metadata(mut self) -> Result<fs::Metadata, io::Error> {
-        // Ensure resolved
         let _ = self.get();
 
         match self {
@@ -222,7 +219,6 @@ mod tests {
         assert!(result.is_err());
         assert!(meta.is_error());
 
-        // Error is cached
         let result2 = meta.get();
         assert!(result2.is_err());
     }
@@ -264,13 +260,10 @@ mod tests {
         let (_dir, path) = create_test_file();
         let mut meta = LazyMetadata::new(path, false);
 
-        // Not resolved yet
         assert!(meta.get_if_resolved().is_none());
 
-        // Resolve it
         let _ = meta.get();
 
-        // Now should return Some
         assert!(meta.get_if_resolved().is_some());
     }
 

--- a/crates/flist/src/lib.rs
+++ b/crates/flist/src/lib.rs
@@ -1,6 +1,5 @@
 #![deny(missing_docs)]
 #![deny(rustdoc::broken_intra_doc_links)]
-// Note: unsafe code is used in batched_stat for syscall optimizations
 
 //! # Overview
 //!

--- a/crates/flist/src/parallel.rs
+++ b/crates/flist/src/parallel.rs
@@ -123,7 +123,6 @@ pub fn collect_paths_then_metadata_parallel(
     root: PathBuf,
     follow_symlinks: bool,
 ) -> Result<Vec<FileListEntry>, Vec<(PathBuf, std::io::Error)>> {
-    // Collect all paths first using std::fs::read_dir recursively
     let paths = collect_paths_recursive(&root, &root, follow_symlinks);
 
     // Ordering: wire protocol requires file list sorted by name for deterministic indices.
@@ -151,7 +150,6 @@ pub fn collect_paths_then_metadata_parallel(
         })
         .collect();
 
-    // Partition into successes and failures
     let mut entries = Vec::new();
     let mut errors = Vec::new();
 
@@ -198,10 +196,8 @@ pub fn collect_lazy_parallel(
     root: PathBuf,
     follow_symlinks: bool,
 ) -> Result<Vec<LazyFileListEntry>, std::io::Error> {
-    // Collect paths without metadata
     let paths = collect_paths_recursive(&root, &root, follow_symlinks);
 
-    // Convert to lazy entries
     let entries: Vec<LazyFileListEntry> = paths
         .into_iter()
         .map(|(full_path, relative_path, depth, is_root)| {
@@ -241,42 +237,34 @@ pub fn collect_with_batched_stats(
     root: PathBuf,
     follow_symlinks: bool,
 ) -> Result<Vec<FileListEntry>, Vec<(PathBuf, std::io::Error)>> {
-    // Collect all paths first
     let paths = collect_paths_recursive(&root, &root, follow_symlinks);
 
-    // Create batched stat cache
     let cache = BatchedStatCache::with_capacity(paths.len());
 
-    // Batch fetch metadata in parallel
     let path_refs: Vec<&PathBuf> = paths.iter().map(|(p, _, _, _)| p).collect();
     let path_slices: Vec<&std::path::Path> = path_refs.iter().map(|p| p.as_path()).collect();
     let metadata_results = cache.stat_batch(&path_slices, follow_symlinks);
 
-    // Combine paths and metadata
     let results: Vec<_> = paths
         .into_iter()
         .zip(metadata_results)
         .map(
-            |((full_path, relative_path, depth, is_root), metadata_result)| {
-                match metadata_result {
-                    Ok(metadata) => {
-                        // Extract metadata from Arc
-                        let metadata = (*metadata).clone();
-                        Ok(FileListEntry {
-                            full_path,
-                            relative_path,
-                            metadata,
-                            depth,
-                            is_root,
-                        })
-                    }
-                    Err(e) => Err((full_path, e)),
+            |((full_path, relative_path, depth, is_root), metadata_result)| match metadata_result {
+                Ok(metadata) => {
+                    let metadata = (*metadata).clone();
+                    Ok(FileListEntry {
+                        full_path,
+                        relative_path,
+                        metadata,
+                        depth,
+                        is_root,
+                    })
                 }
+                Err(e) => Err((full_path, e)),
             },
         )
         .collect();
 
-    // Partition into successes and failures
     let mut entries = Vec::new();
     let mut errors = Vec::new();
 
@@ -434,7 +422,6 @@ fn collect_paths_recursive(
     let mut paths = Vec::new();
     let is_root = current == root;
 
-    // Calculate relative path and depth
     let relative_path = if is_root {
         PathBuf::new()
     } else {
@@ -444,7 +431,6 @@ fn collect_paths_recursive(
 
     paths.push((current.clone(), relative_path, depth, is_root));
 
-    // Check if we should recurse
     let should_recurse = if let Ok(metadata) = fs::symlink_metadata(current) {
         metadata.is_dir() || (follow_symlinks && metadata.is_symlink())
     } else {


### PR DESCRIPTION
## Summary

Final rustdoc/comment-cleanup pass on the flist crate's top-level entry points (TODO #2041). Decomposed subdirectories (read/, entry/, batched_stat/) are tracked under separate cleanup tasks and were left untouched.

- `lib.rs`: drop a stray non-doc note about unsafe code in `batched_stat` that sat between the `#![deny]` attributes and the `//!` module doc.
- `lazy_entry.rs`: strip restating in-body comments from `into_resolved` and the deferred-metadata tests.
- `lazy_metadata.rs`: strip restating step-by-step comments from `get`/`into_metadata` and the cache-related tests.
- `parallel.rs`: strip restating "collect/convert/partition" markers from `collect_paths_then_metadata_parallel`, `collect_lazy_parallel`, `collect_with_batched_stats`, and `collect_paths_recursive`. The `// Ordering:` invariants and the example/upstream-reference rustdoc on every public function are preserved.

No public APIs change. `cargo fmt --all -- --check` passes.

## Test plan

- [ ] CI fmt + clippy
- [ ] CI nextest (stable)
- [ ] Windows / macOS / Linux musl