### PR TITLE
docs(protocol): clean up legacy module comments

### DIFF
--- a/crates/protocol/src/legacy/greeting/format.rs
+++ b/crates/protocol/src/legacy/greeting/format.rs
@@ -108,7 +108,6 @@ mod tests {
     #[test]
     fn greeting_contains_version_and_minor() {
         let greeting = format_legacy_daemon_greeting(ProtocolVersion::V32);
-        // Format is "@RSYNCD: 32.0\n"
         assert!(greeting.contains(".0"));
     }
 }

--- a/crates/protocol/src/legacy/greeting/mod.rs
+++ b/crates/protocol/src/legacy/greeting/mod.rs
@@ -1,3 +1,10 @@
+//! Legacy daemon greeting parsing, formatting, and structured representations.
+//!
+//! Splits the `@RSYNCD: <version>` greeting helpers across focused submodules:
+//! `format` renders the canonical banner, `parse` validates incoming bytes,
+//! `tokens` iterates digest lists, and `types` exposes borrowed and owned views
+//! of the parsed metadata.
+
 mod format;
 mod parse;
 mod tokens;

--- a/crates/protocol/src/legacy/mod.rs
+++ b/crates/protocol/src/legacy/mod.rs
@@ -1,3 +1,10 @@
+//! Legacy ASCII `@RSYNCD:` negotiation helpers shared by daemon clients and servers.
+//!
+//! The legacy path is used when either peer is limited to protocols older than 30. This
+//! module groups the prefix constants together with the byte-, string-, and structured
+//! parsers that mirror upstream rsync's wire formatting for greetings, error banners,
+//! and warning lines.
+
 use crate::error::NegotiationError;
 
 /// Canonical ASCII prefix that identifies the legacy `@RSYNCD:` negotiation style.


### PR DESCRIPTION
## Summary

- Add `//!` module-level rustdoc to `crates/protocol/src/legacy/mod.rs` describing the legacy `@RSYNCD:` negotiation helpers.
- Add `//!` module-level rustdoc to `crates/protocol/src/legacy/greeting/mod.rs` summarising the format/parse/tokens/types split.
- Drop a restatement comment from the `format_legacy_daemon_greeting` test that merely echoed the rendered string.

Comment-only changes; no executable code, signatures, or behaviour are touched. All `// upstream:` and `// SAFETY:` comments are preserved (none exist in the affected scope).

## Test plan

- [x] `cargo fmt --all -- --check`
- [ ] CI: fmt+clippy, nextest (stable), Windows, macOS, Linux musl