### PR TITLE
docs(protocol): drop redundant restatement comment in xattr wire decoder

### DIFF
--- a/crates/protocol/src/xattr/wire/decode.rs
+++ b/crates/protocol/src/xattr/wire/decode.rs
@@ -181,7 +181,6 @@ pub fn recv_xattr_request<R: Read>(reader: &mut R, list: &mut XattrList) -> io::
 
         // upstream: ndx = read_varint(f) + prior_req (1-based)
         let num = prior_req + rel;
-        // Convert 1-based wire num to 0-based index
         let idx = (num - 1) as usize;
         if idx < list.len() {
             list.mark_todo(idx);


### PR DESCRIPTION
## Summary

- Comment cleanup pass on `crates/protocol/src/xattr/wire/` per the project's comment cleanup rules.
- Removes one restatement comment in `decode.rs::recv_xattr_request` ("Convert 1-based wire num to 0-based index") that echoes both the arithmetic on the next line and the upstream reference comment two lines above it.
- Every `// upstream:` reference is preserved verbatim. No executable code, signatures, or formatting reflows beyond `cargo fmt --all`.

## File-by-file audit

- `mod.rs` - already pristine (module docs present, only `pub use` lines).
- `types.rs` - already pristine; all comments are rustdoc with WHY/upstream context.
- `decode.rs` - dropped one redundant restatement comment; all six upstream refs preserved.
- `encode.rs` - already pristine; all five upstream refs preserved.
- `tests.rs` - already pristine; helper has a rustdoc, tests are clean.

## Test plan

- [x] `cargo fmt --all -- --check` exits 0
- [x] Diff confined to `crates/protocol/src/xattr/wire/decode.rs`
- [ ] CI: fmt + clippy
- [ ] CI: nextest (stable)
- [ ] CI: Windows / macOS / Linux musl