### PR TITLE
docs(engine): drop restatement comment in buffer pool allocator

### DIFF
--- a/crates/engine/src/local_copy/buffer_pool/allocator.rs
+++ b/crates/engine/src/local_copy/buffer_pool/allocator.rs
@@ -34,9 +34,7 @@ pub trait BufferAllocator: Send + Sync + std::fmt::Debug {
     ///
     /// Called when the pool is at capacity and cannot accept a returned buffer.
     /// The default implementation drops the buffer, freeing the heap allocation.
-    fn deallocate(&self, _buffer: Vec<u8>) {
-        // Default: drop the buffer (release memory back to the system allocator).
-    }
+    fn deallocate(&self, _buffer: Vec<u8>) {}
 }
 
 /// The default allocation strategy - zero-initialized heap `Vec<u8>`.


### PR DESCRIPTION
## Summary

- Audit comments under `crates/engine/src/local_copy/buffer_pool/` for restatement, dead code, decorative banners, and TODO/FIXME/XXX.
- Drop the inline `// Default: drop the buffer ...` comment in `BufferAllocator::deallocate`'s default body; the trait-level rustdoc already states the default behavior. `cargo fmt` collapses the now-empty body to `{}`.
- Every other file in the module (`mod.rs`, `global.rs`, `guard.rs`, `memory_cap.rs`, `pool.rs`, `pressure.rs`, `thread_local_cache.rs`, `throughput.rs`, `tests.rs`) audited and left untouched: existing comments either document why (concurrency invariants, CAS retry loops, hot/slow path notes), are SAFETY blocks, or convey test intent. No upstream references, SAFETY blocks, or non-trivial WHY comments were modified.

## Test plan

- [x] `cargo fmt --all -- --check` passes locally.
- [ ] CI: fmt+clippy
- [ ] CI: nextest (stable)
- [ ] CI: Windows (stable)
- [ ] CI: macOS (stable)
- [ ] CI: Linux musl (stable)