### PR TITLE
docs(engine): tidy comments in local_copy::plan

### DIFF
--- a/crates/engine/src/local_copy/plan/action.rs
+++ b/crates/engine/src/local_copy/plan/action.rs
@@ -80,7 +80,6 @@ mod tests {
             LocalCopyAction::SourceRemoved,
         ];
 
-        // Each action should be equal only to itself
         for (i, a) in actions.iter().enumerate() {
             for (j, b) in actions.iter().enumerate() {
                 if i == j {

--- a/crates/engine/src/local_copy/plan/summary.rs
+++ b/crates/engine/src/local_copy/plan/summary.rs
@@ -373,7 +373,7 @@ impl LocalCopySummary {
         self.file_list_generation = self.file_list_generation.saturating_add(elapsed);
     }
 
-    #[allow(dead_code)] // symmetric with record_file_list_generation - will be used when file list transfer timing is wired in
+    #[allow(dead_code)] // symmetric with record_file_list_generation
     pub(in crate::local_copy) const fn record_file_list_transfer(&mut self, elapsed: Duration) {
         self.file_list_transfer = self.file_list_transfer.saturating_add(elapsed);
     }


### PR DESCRIPTION
## Summary
- Remove a single restatement comment from `plan::action` tests that echoed the assert structure inside the equality matrix.
- Trim a stale placeholder fragment from the `#[allow(dead_code)]` justification on `LocalCopySummary::record_file_list_transfer`; the remaining note still records the symmetry with `record_file_list_generation`.

## Test plan
- [x] `cargo fmt --all -- --check`
- [ ] CI: fmt+clippy, nextest (stable), Windows, macOS, Linux musl