### PR TITLE
docs(protocol): drop redundant comments in wire file_entry module

### DIFF
--- a/crates/protocol/src/wire/file_entry/mod.rs
+++ b/crates/protocol/src/wire/file_entry/mod.rs
@@ -36,7 +36,6 @@ mod flags;
 #[cfg(test)]
 mod tests;
 
-// Re-export all constants
 pub use self::constants::{
     XMIT_CRTIME_EQ_MTIME, XMIT_EXTENDED_FLAGS, XMIT_GROUP_NAME_FOLLOWS, XMIT_HLINK_FIRST,
     XMIT_HLINKED, XMIT_IO_ERROR_ENDLIST, XMIT_LONG_NAME, XMIT_MOD_NSEC, XMIT_NO_CONTENT_DIR,
@@ -45,14 +44,12 @@ pub use self::constants::{
     XMIT_TOP_DIR, XMIT_USER_NAME_FOLLOWS,
 };
 
-// Re-export encoding functions
 pub use self::encode::{
     encode_atime, encode_checksum, encode_crtime, encode_end_marker, encode_flags, encode_gid,
     encode_hardlink_dev_ino, encode_hardlink_idx, encode_mode, encode_mtime, encode_mtime_nsec,
     encode_name, encode_owner_name, encode_rdev, encode_size, encode_symlink_target, encode_uid,
 };
 
-// Re-export flag calculation helpers
 pub use self::flags::{
     calculate_basic_flags, calculate_device_flags, calculate_hardlink_flags,
     calculate_name_prefix_len, calculate_time_flags,

--- a/crates/protocol/src/wire/file_entry/tests.rs
+++ b/crates/protocol/src/wire/file_entry/tests.rs
@@ -595,7 +595,6 @@ fn roundtrip_flags_and_name() {
     encode_flags(&mut buf, xflags, 32, false, false).unwrap();
     encode_name(&mut buf, b"dir/file2.txt", 8, xflags, 32).unwrap();
 
-    // Verify structure
     assert_eq!(buf[0], xflags as u8); // flags byte
     assert_eq!(buf[1], 8); // same_len
     assert_eq!(buf[2], 5); // suffix_len ("2.txt")
@@ -606,7 +605,6 @@ fn roundtrip_flags_and_name() {
 fn roundtrip_full_entry_modern() {
     let mut buf = Vec::new();
 
-    // Encode a complete file entry
     let xflags = 0u32; // All fields different from previous
     encode_flags(&mut buf, xflags, 32, false, false).unwrap();
     encode_name(&mut buf, b"test.txt", 0, xflags, 32).unwrap();
@@ -614,6 +612,5 @@ fn roundtrip_full_entry_modern() {
     encode_mtime(&mut buf, 1700000000, 32).unwrap();
     encode_mode(&mut buf, 0o100644).unwrap();
 
-    // Should have produced a valid byte sequence
     assert!(!buf.is_empty());
 }


### PR DESCRIPTION
## Summary

- Drop three decorative re-export divider comments from `crates/protocol/src/wire/file_entry/mod.rs`; the surrounding `pub use` statements speak for themselves.
- Drop three restatement-only comments inside `crates/protocol/src/wire/file_entry/tests.rs` (`// Verify structure`, `// Encode a complete file entry`, `// Should have produced a valid byte sequence`).
- Preserve every `// upstream:` reference, every wire-format/varint/protocol-version/INC_RECURSE WHY comment, and every section comment that documents bit ranges or varint-mode-only encoding constraints.

## Test plan

- [x] `cargo fmt --all -- --check`
- [ ] CI: fmt+clippy, nextest (stable), Windows, macOS, Linux musl