### PR TITLE
docs(engine): tidy filter_program comments

### DIFF
--- a/crates/engine/src/local_copy/filter_program/program.rs
+++ b/crates/engine/src/local_copy/filter_program/program.rs
@@ -49,7 +49,6 @@ pub struct FilterProgram {
     dir_merge_rules: Vec<DirMergeRule>,
     exclude_if_present_rules: Vec<ExcludeIfPresentRule>,
 
-    // XAttr filter strategy – present only where meaningful.
     #[cfg(all(unix, feature = "xattr"))]
     xattr_rules: Vec<XattrRule>,
 }
@@ -263,7 +262,6 @@ impl FilterProgram {
         Ok(false)
     }
 
-    // XAttr filtering strategy – only compiled where supported.
     #[cfg(all(unix, feature = "xattr"))]
     pub(crate) const fn has_xattr_rules(&self) -> bool {
         !self.xattr_rules.is_empty()
@@ -427,7 +425,6 @@ mod tests {
         let program = FilterProgram::new(std::iter::empty()).unwrap();
         let path = Path::new("test.txt");
         let outcome = program.evaluate(path, false, &[], None, FilterContext::Transfer);
-        // Default outcome allows transfer
         assert!(outcome.allows_transfer());
     }
 

--- a/crates/engine/src/local_copy/filter_program/segments.rs
+++ b/crates/engine/src/local_copy/filter_program/segments.rs
@@ -417,9 +417,9 @@ mod tests {
     #[test]
     fn include_directory_only_no_descendant_match() {
         let rule = CompiledRule::new(FilterRule::include("*/".to_owned())).unwrap();
-        // Directories match
         assert!(rule.matches(Path::new("subdir"), true));
-        // Files do NOT match - even inside directories
+        // Files inside an included directory must still match a separate rule;
+        // include never expands to descendants. See `CompiledRule::new`.
         assert!(!rule.matches(Path::new("file.txt"), false));
         assert!(!rule.matches(Path::new("subdir/debug.log"), false));
         assert!(!rule.matches(Path::new("subdir/report.csv"), false));
@@ -429,9 +429,9 @@ mod tests {
     #[test]
     fn exclude_directory_only_has_descendant_match() {
         let rule = CompiledRule::new(FilterRule::exclude("*/".to_owned())).unwrap();
-        // Directories match
         assert!(rule.matches(Path::new("subdir"), true));
-        // Files inside excluded directories also match via descendants
+        // Excluded directories also match descendants so their contents are
+        // skipped without a separate rule per file.
         assert!(rule.matches(Path::new("subdir/debug.log"), false));
     }
 


### PR DESCRIPTION
## Summary

- Drops restating `//` comments in `crates/engine/src/local_copy/filter_program/`:
  - `program.rs`: removes the `// XAttr filter strategy ...` banner comments above the `#[cfg(all(unix, feature = "xattr"))]` field and method (the cfg already conveys "only on supported platforms"), and the `// Default outcome allows transfer` test annotation that restated the adjacent assertion.
  - `segments.rs`: removes the `// Directories match` and `// Files do NOT match` / `// also match via descendants` comments that echoed the assertions, and replaces them with WHY-style notes explaining the include-vs-exclude descendant policy enforced in `CompiledRule::new`.
- Preserves every `// upstream:` reference and existing rustdoc; no executable code, signatures, or fmt reflows changed beyond what `cargo fmt --all` already produces.

## Test plan

- [x] `cargo fmt --all -- --check` (clean)
- [ ] CI: fmt + clippy
- [ ] CI: nextest (stable)
- [ ] CI: Windows / macOS / Linux musl