### PR TITLE
docs: drop restatement comments and banners in aux crates

### DIFF
--- a/crates/apple-fs/src/resource_fork.rs
+++ b/crates/apple-fs/src/resource_fork.rs
@@ -154,8 +154,6 @@ fn is_no_attr(error: &io::Error) -> bool {
     error.raw_os_error() == Some(ENOATTR_DARWIN)
 }
 
-// -- non-macOS stubs ---------------------------------------------------------
-
 /// Stub: returns `Ok(None)`. The host has no resource-fork concept.
 #[cfg(not(target_os = "macos"))]
 pub fn read_resource_fork(_path: &Path) -> io::Result<Option<Vec<u8>>> {

--- a/crates/branding/src/branding/brand.rs
+++ b/crates/branding/src/branding/brand.rs
@@ -379,7 +379,6 @@ mod tests {
 
         #[test]
         fn from_str_parses_program_names() {
-            // Use actual program names from profiles
             let oc = super::oc_profile();
             let upstream = super::upstream_profile();
 

--- a/crates/branding/src/branding/detection.rs
+++ b/crates/branding/src/branding/detection.rs
@@ -101,7 +101,6 @@ mod tests {
         manifest().client_program_name_for(Brand::Upstream)
     }
 
-    // classify_program_name tests
     #[test]
     fn classify_oc_client() {
         assert_eq!(classify_program_name(oc_client()), Some(Brand::Oc));
@@ -130,7 +129,6 @@ mod tests {
         assert_eq!(classify_program_name(""), None);
     }
 
-    // brand_for_program_name tests
     #[test]
     fn brand_for_program_name_oc() {
         assert_eq!(brand_for_program_name(oc_client()), Brand::Oc);
@@ -146,7 +144,6 @@ mod tests {
         assert_eq!(brand_for_program_name("unknown"), default_brand());
     }
 
-    // brand_for_program_path tests
     #[test]
     fn brand_for_path_with_extension() {
         let path_str = format!("/usr/bin/{}.exe", oc_client());
@@ -173,7 +170,6 @@ mod tests {
         assert_eq!(brand_for_program_path(Path::new("/usr/bin/unknown")), None);
     }
 
-    // brand_for_program_os_str tests
     #[test]
     fn brand_for_os_str_oc() {
         let os_str = OsStr::new(oc_client());
@@ -187,12 +183,11 @@ mod tests {
         assert_eq!(brand_for_program_os_str(os_str), Some(Brand::Upstream));
     }
 
-    // detect_brand tests
     #[test]
     fn detect_brand_from_program_arg() {
         let program = OsString::from(oc_client());
         let brand = detect_brand(Some(program.as_os_str()));
-        // May return Oc or be overridden by env, but should not panic
+        // May return Oc or be overridden by env, but should not panic.
         assert!(brand == Brand::Oc || brand == Brand::Upstream);
     }
 
@@ -202,7 +197,6 @@ mod tests {
         assert!(brand == Brand::Oc || brand == Brand::Upstream);
     }
 
-    // resolve_brand_profile tests
     #[test]
     fn resolve_brand_profile_returns_profile() {
         let program = OsString::from(upstream_client());

--- a/crates/branding/src/branding/override_env.rs
+++ b/crates/branding/src/branding/override_env.rs
@@ -106,7 +106,6 @@ mod tests {
 
     #[test]
     fn all_brand_variants_covered() {
-        // Ensure encode covers all Brand variants
         for brand in [Brand::Oc, Brand::Upstream] {
             let encoded = encode_brand_override(Some(brand));
             let decoded = decode_brand_override(encoded);

--- a/crates/branding/src/validation.rs
+++ b/crates/branding/src/validation.rs
@@ -315,7 +315,6 @@ mod tests {
         ));
     }
 
-    // Protocol validation
     #[test]
     fn validate_protocol_version_accepts_valid() {
         assert!(validate_protocol_version(28).is_ok());
@@ -339,7 +338,6 @@ mod tests {
         ));
     }
 
-    // Brand validation
     #[test]
     fn validate_brand_name_accepts_oc() {
         assert!(validate_brand_name("oc").is_ok());
@@ -358,7 +356,6 @@ mod tests {
         ));
     }
 
-    // Revision sanitization
     #[test]
     fn sanitize_revision_trims_whitespace() {
         assert_eq!(sanitize_revision("  abc123  "), "abc123");

--- a/crates/embedding/src/lib.rs
+++ b/crates/embedding/src/lib.rs
@@ -519,7 +519,6 @@ mod tests {
 
     #[test]
     fn server_config_can_be_constructed() {
-        // Verify that ServerConfig can be constructed from flag string and args
         let config = ServerConfig::from_flag_string_and_args(
             ServerRole::Receiver,
             "-logDtpre.iLsfxC".to_string(),
@@ -539,7 +538,6 @@ mod tests {
 
     #[test]
     fn server_config_rejects_empty_inputs() {
-        // Empty flag string and no args should be rejected
         let config =
             ServerConfig::from_flag_string_and_args(ServerRole::Receiver, String::new(), vec![]);
 
@@ -751,7 +749,6 @@ mod tests {
         let mut stderr = Vec::new();
         run_daemon_with(args, &mut stdout, &mut stderr).expect("--help succeeds");
 
-        // Verify we got some output
         assert!(
             !stdout.is_empty() || !stderr.is_empty(),
             "daemon --help should produce output"


### PR DESCRIPTION
## Summary

- Comment-only cleanup across the small auxiliary crates (`branding`, `embedding`, `apple-fs`).
- Removes section-divider banners in test modules and a handful of echo-the-code comments that restated the next line.
- No executable code, public API, or formatting changes beyond the comment removals.

## Scope

| Crate | Files touched |
|-------|---------------|
| `apple-fs` | `src/resource_fork.rs` (decorative banner) |
| `branding` | `src/validation.rs`, `src/branding/brand.rs`, `src/branding/detection.rs`, `src/branding/override_env.rs` |
| `embedding` | `src/lib.rs` |
| `windows-gnu-eh` | audited, no changes needed |
| `test-support` | audited, no changes needed |

Every `// upstream:` cite and every `// SAFETY:` block was preserved verbatim. WHY comments explaining platform quirks, fast paths, and intent were kept.

## Test plan

- [x] `cargo fmt --all -- --check` passes locally.
- [ ] CI green: fmt+clippy, nextest (stable), Windows, macOS, Linux musl.