### PR TITLE
docs(engine): clean up executor module comment style

### DIFF
--- a/crates/engine/src/local_copy/executor/directory/planner.rs
+++ b/crates/engine/src/local_copy/executor/directory/planner.rs
@@ -159,8 +159,7 @@ fn decide_entry_action(
 /// Iterates over pre-sorted directory entries, applies filter rules,
 /// resolves symlinks when `--copy-links` or `--copy-dirlinks` is active,
 /// and determines the appropriate action for each entry.
-///
-/// // upstream: flist.c:send_directory() - builds file list from directory
+// upstream: flist.c:send_directory() - builds file list from directory
 pub(crate) fn plan_directory_entries<'a>(
     context: &mut CopyContext,
     entries: &'a [DirectoryEntry],
@@ -345,8 +344,7 @@ pub(crate) fn plan_directory_entries<'a>(
 }
 
 /// Applies pre-transfer deletions when `--delete-before` is active.
-///
-/// // upstream: generator.c:do_delete_pass() - pre-transfer deletion
+// upstream: generator.c:do_delete_pass() - pre-transfer deletion
 pub(crate) fn apply_pre_transfer_deletions(
     context: &mut CopyContext,
     destination: &Path,

--- a/crates/engine/src/local_copy/executor/directory/recursive/batch.rs
+++ b/crates/engine/src/local_copy/executor/directory/recursive/batch.rs
@@ -2,8 +2,9 @@
 //!
 //! When `--write-batch` is active, each transferred entry is serialized into
 //! the protocol's file-list wire format for later replay.
-//!
-//! // upstream: batch.c:write_batch_flist_info()
+
+// upstream: batch.c:write_batch_flist_info()
+
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::UNIX_EPOCH;

--- a/crates/engine/src/local_copy/executor/directory/recursive/deletion.rs
+++ b/crates/engine/src/local_copy/executor/directory/recursive/deletion.rs
@@ -2,8 +2,8 @@
 //!
 //! Implements the `--delete-after` and `--delete-during` phases that remove
 //! extraneous destination entries. Also handles `--prune-empty-dirs`.
-//!
-//! upstream: generator.c:delete_in_dir() - post-transfer deletion
+
+// upstream: generator.c:delete_in_dir() - post-transfer deletion
 
 use std::ffi::OsString;
 use std::fs;

--- a/crates/engine/src/local_copy/executor/directory/recursive/dir_metadata.rs
+++ b/crates/engine/src/local_copy/executor/directory/recursive/dir_metadata.rs
@@ -2,8 +2,9 @@
 //!
 //! Applies ownership, permissions, timestamps, ACLs, and extended attributes
 //! to directories after all their contents have been transferred.
-//!
-//! // upstream: receiver.c - directory metadata finalization after recv_files()
+
+// upstream: receiver.c - directory metadata finalization after recv_files()
+
 use std::fs;
 use std::path::Path;
 

--- a/crates/engine/src/local_copy/executor/file/append.rs
+++ b/crates/engine/src/local_copy/executor/file/append.rs
@@ -23,8 +23,7 @@ pub(crate) enum AppendMode {
 /// Returns `Disabled` when append is off, `Skip` when the destination is
 /// already at least as large, or `Append(offset)` when the destination is
 /// shorter and the transfer should resume from that offset.
-///
-/// // upstream: receiver.c:recv_files() - append mode size comparison
+// upstream: receiver.c:recv_files() - append mode size comparison
 pub(crate) fn determine_append_mode(
     append_allowed: bool,
     append_verify: bool,

--- a/crates/engine/src/local_copy/executor/file/backup.rs
+++ b/crates/engine/src/local_copy/executor/file/backup.rs
@@ -2,8 +2,8 @@
 //!
 //! Computes backup paths (with optional suffix and directory prefix) and
 //! creates the backup copy or symlink before the destination is overwritten.
-//!
-//! // upstream: backup.c:make_backup() - backup path computation and creation
+
+// upstream: backup.c:make_backup() - backup path computation and creation
 
 use std::ffi::{OsStr, OsString};
 use std::fs;
@@ -75,8 +75,7 @@ pub fn compute_backup_path(
 }
 
 /// Copies a file or recreates a symlink at the backup path.
-///
-/// // upstream: backup.c:make_backup() - backup creation
+// upstream: backup.c:make_backup() - backup creation
 pub(crate) fn copy_entry_to_backup(
     source: &Path,
     backup_path: &Path,

--- a/crates/engine/src/local_copy/executor/file/comparison.rs
+++ b/crates/engine/src/local_copy/executor/file/comparison.rs
@@ -168,7 +168,7 @@ pub(crate) fn should_skip_copy(params: CopyComparison<'_>) -> bool {
 /// Returns `true` when two timestamps differ by no more than `window`.
 ///
 /// With a zero window, only exact equality matches.
-/// // upstream: generator.c:unchanged_file() - modify window comparison
+// upstream: generator.c:unchanged_file() - modify window comparison
 pub(crate) fn system_time_within_window(a: SystemTime, b: SystemTime, window: Duration) -> bool {
     if window.is_zero() {
         return a.eq(&b);

--- a/crates/engine/src/local_copy/executor/file/copy/existing.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/existing.rs
@@ -2,8 +2,8 @@
 //!
 //! Evaluates whether a file should be skipped based on modification time
 //! comparison or the presence of an existing destination file.
-//!
-//! // upstream: generator.c:recv_generator() - update and ignore-existing checks
+
+// upstream: generator.c:recv_generator() - update and ignore-existing checks
 
 use std::fs;
 use std::path::Path;

--- a/crates/engine/src/local_copy/executor/file/copy/links.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/links.rs
@@ -3,9 +3,9 @@
 //!
 //! Attempts to satisfy a file transfer via hard link or reference copy before
 //! falling back to a full data transfer.
-//!
-//! // upstream: generator.c - hard_link_one(), do_hard_links logic
-//! // upstream: generator.c - find_fuzzy(), compare_dest handling
+
+// upstream: generator.c - hard_link_one(), do_hard_links logic
+// upstream: generator.c - find_fuzzy(), compare_dest handling
 
 use std::fs;
 use std::path::{Path, PathBuf};

--- a/crates/engine/src/local_copy/executor/file/guard.rs
+++ b/crates/engine/src/local_copy/executor/file/guard.rs
@@ -3,8 +3,8 @@
 //! Provides [`DestinationWriteGuard`] which manages the lifecycle of a
 //! temporary file during transfer: creation, writing, and atomic rename
 //! to the final destination on commit.
-//!
-//! // upstream: receiver.c:recv_files() - temp file creation and rename
+
+// upstream: receiver.c:recv_files() - temp file creation and rename
 
 use std::fs;
 use std::io;

--- a/crates/engine/src/local_copy/executor/file/paths.rs
+++ b/crates/engine/src/local_copy/executor/file/paths.rs
@@ -2,8 +2,8 @@
 //!
 //! Generates temp file paths (`.~tmp~` prefix with PID), partial transfer
 //! paths (`--partial-dir`), and resolves the final destination for each file.
-//!
-//! // upstream: receiver.c - temp file naming, util1.c:partial_dir_fname()
+
+// upstream: receiver.c - temp file naming, util1.c:partial_dir_fname()
 
 use std::ffi::OsStr;
 use std::fs;
@@ -54,7 +54,7 @@ pub(crate) fn partial_directory_destination_path(
 /// Computes the temporary file path used during atomic writes.
 ///
 /// The name includes the PID and a unique counter to prevent collisions.
-/// // upstream: receiver.c:get_tmpname()
+// upstream: receiver.c:get_tmpname()
 pub(crate) fn temporary_destination_path(
     destination: &Path,
     unique: usize,

--- a/crates/engine/src/local_copy/executor/file/preallocate.rs
+++ b/crates/engine/src/local_copy/executor/file/preallocate.rs
@@ -2,8 +2,8 @@
 //!
 //! Uses `fallocate(2)` on Linux to reserve contiguous disk space before
 //! writing file data, falling back to a no-op on other platforms.
-//!
-//! // upstream: receiver.c - preallocate support via --preallocate
+
+// upstream: receiver.c - preallocate support via --preallocate
 
 use std::fs;
 #[cfg(unix)]
@@ -23,8 +23,7 @@ use crate::local_copy::LocalCopyError;
 ///
 /// Skips preallocation when disabled, when `total_len` is zero, or when the
 /// file already has at least `total_len` bytes allocated.
-///
-/// // upstream: receiver.c:recv_files() - preallocate_file()
+// upstream: receiver.c:recv_files() - preallocate_file()
 pub(crate) fn maybe_preallocate_destination(
     file: &mut fs::File,
     path: &Path,

--- a/crates/engine/src/local_copy/executor/file/sparse/mod.rs
+++ b/crates/engine/src/local_copy/executor/file/sparse/mod.rs
@@ -4,8 +4,8 @@
 //! file data and writes them as filesystem holes rather than allocating blocks.
 //! Uses `SEEK_HOLE`/`SEEK_DATA` for reading and `fallocate(PUNCH_HOLE)` on
 //! Linux for post-write hole creation.
-//!
-//! // upstream: fileio.c:write_sparse() - sparse write with seek-past-zeros
+
+// upstream: fileio.c:write_sparse() - sparse write with seek-past-zeros
 
 mod detect;
 mod hole_punch;

--- a/crates/engine/src/local_copy/executor/file/sparse/state.rs
+++ b/crates/engine/src/local_copy/executor/file/sparse/state.rs
@@ -3,8 +3,8 @@
 //! Maintains the offset of the current pending zero-byte region during a
 //! sequential write pass, converting zero runs into seeks (holes) and
 //! flushing them with hole-punch or trailing-zero finalization.
-//!
-//! // upstream: fileio.c - sparse write buffering logic
+
+// upstream: fileio.c - sparse write buffering logic
 
 use std::fs;
 use std::io::{Seek, SeekFrom, Write};

--- a/crates/engine/src/local_copy/executor/special/device.rs
+++ b/crates/engine/src/local_copy/executor/special/device.rs
@@ -2,8 +2,8 @@
 //!
 //! Recreates block and character device nodes at the destination using
 //! `mknod(2)`, with optional hard-link deduplication to earlier devices.
-//!
-//! // upstream: receiver.c - device node handling, syscall.c:do_mknod()
+
+// upstream: receiver.c - device node handling, syscall.c:do_mknod()
 
 use std::fs;
 use std::io;
@@ -28,8 +28,7 @@ use ::metadata::{MetadataOptions, apply_file_metadata_with_options};
 ///
 /// Handles hard-link deduplication, `--existing`, directory replacement via
 /// `--force`, backup, and dry-run mode.
-///
-/// // upstream: receiver.c - device node handling
+// upstream: receiver.c - device node handling
 pub(crate) fn copy_device(
     context: &mut CopyContext,
     source: &Path,

--- a/crates/engine/src/local_copy/executor/special/fifo.rs
+++ b/crates/engine/src/local_copy/executor/special/fifo.rs
@@ -2,8 +2,8 @@
 //!
 //! Recreates FIFOs at the destination using `mkfifo(3)`, with optional
 //! hard-link deduplication to earlier FIFOs.
-//!
-//! // upstream: receiver.c - FIFO handling, syscall.c:do_mknod()
+
+// upstream: receiver.c - FIFO handling, syscall.c:do_mknod()
 
 use std::fs;
 use std::io;
@@ -28,8 +28,7 @@ use ::metadata::{MetadataOptions, apply_file_metadata_with_options};
 ///
 /// Handles hard-link deduplication, `--existing`, directory replacement via
 /// `--force`, backup, and dry-run mode.
-///
-/// // upstream: receiver.c - FIFO handling
+// upstream: receiver.c - FIFO handling
 pub(crate) fn copy_fifo(
     context: &mut CopyContext,
     source: &Path,

--- a/crates/engine/src/local_copy/executor/special/symlink.rs
+++ b/crates/engine/src/local_copy/executor/special/symlink.rs
@@ -3,8 +3,8 @@
 //! Recreates symlinks at the destination, optionally munging unsafe targets
 //! (absolute paths or `..` escapes) when `--safe-links` or `--munge-links`
 //! is active.
-//!
-//! // upstream: receiver.c - symlink handling, syscall.c:do_symlink()
+
+// upstream: receiver.c - symlink handling, syscall.c:do_symlink()
 
 use std::fs;
 use std::io;
@@ -31,7 +31,7 @@ use super::{device::copy_device, fifo::copy_fifo};
 ///
 /// Rejects absolute paths, empty targets, and targets whose `..` components
 /// would escape above the directory depth implied by `link_relative`.
-/// // upstream: clientserver.c - safe symlink checking
+// upstream: clientserver.c - safe symlink checking
 pub(crate) fn symlink_target_is_safe(target: &Path, link_relative: &Path) -> bool {
     if target.as_os_str().is_empty() || target.has_root() {
         return false;
@@ -103,8 +103,7 @@ pub(crate) fn symlink_target_is_safe(target: &Path, link_relative: &Path) -> boo
 /// Handles `--safe-links`, `--copy-unsafe-links`, `--munge-links`, hard-link
 /// deduplication, and dry-run mode. When `--copy-unsafe-links` is active and
 /// the target is unsafe, the link target is copied as a regular entry instead.
-///
-/// // upstream: receiver.c:recv_files() - symlink handling
+// upstream: receiver.c:recv_files() - symlink handling
 pub(crate) fn copy_symlink(
     context: &mut CopyContext,
     source: &Path,


### PR DESCRIPTION
## Summary

- Move `// upstream:` references out of `///` rustdoc and `//!` module-doc blocks where they were rendering as literal "// upstream:" text in the generated docs.
- Each upstream citation now sits as a plain non-doc comment adjacent to the item or below the module header, preserving the upstream provenance while keeping rendered API docs clean.
- Comment-only changes; no executable code, signatures, or behaviour modified.

## Scope

`crates/engine/src/local_copy/executor/` only (17 files).

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] Diff confined to executor module
- [x] Every `// upstream:` reference preserved verbatim
- [x] No `// SAFETY:` blocks touched
- [ ] CI green