### PR TITLE
docs(engine): add module-level docs to local_copy::options submodules

### DIFF
--- a/crates/engine/src/local_copy/options/backup.rs
+++ b/crates/engine/src/local_copy/options/backup.rs
@@ -1,3 +1,6 @@
+//! Setters and accessors for `--backup`, `--backup-dir`, and `--suffix` on
+//! [`LocalCopyOptions`].
+
 use std::ffi::{OsStr, OsString};
 use std::path::{Path, PathBuf};
 

--- a/crates/engine/src/local_copy/options/builder/error.rs
+++ b/crates/engine/src/local_copy/options/builder/error.rs
@@ -1,3 +1,5 @@
+//! Error type returned by [`super::LocalCopyOptionsBuilder::build`].
+
 /// Errors that can occur when building [`super::LocalCopyOptionsBuilder`].
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum BuilderError {

--- a/crates/engine/src/local_copy/options/builder/tests.rs
+++ b/crates/engine/src/local_copy/options/builder/tests.rs
@@ -1,3 +1,6 @@
+//! Unit tests for [`super::LocalCopyOptionsBuilder`] covering presets,
+//! per-concern setters, validation rules, and error display.
+
 use std::num::NonZeroU64;
 use std::time::{Duration, SystemTime};
 

--- a/crates/engine/src/local_copy/options/builder/validation.rs
+++ b/crates/engine/src/local_copy/options/builder/validation.rs
@@ -23,7 +23,6 @@ impl LocalCopyOptionsBuilder {
             });
         }
 
-        // Validate size limits
         if let (Some(min), Some(max)) = (self.min_file_size, self.max_file_size) {
             if min > max {
                 return Err(BuilderError::InvalidCombination {

--- a/crates/engine/src/local_copy/options/compression.rs
+++ b/crates/engine/src/local_copy/options/compression.rs
@@ -1,3 +1,7 @@
+//! Setters and accessors for compression-related options (`--compress`,
+//! `--compress-choice`, `--compress-level`, skip-compress suffix list) on
+//! [`LocalCopyOptions`].
+
 use std::path::Path;
 
 use compress::algorithm::CompressionAlgorithm;

--- a/crates/engine/src/local_copy/options/deletion.rs
+++ b/crates/engine/src/local_copy/options/deletion.rs
@@ -1,3 +1,7 @@
+//! Setters and accessors for deletion-related options (`--delete`,
+//! `--delete-before/during/after/delay`, `--delete-excluded`, `--max-delete`,
+//! `--ignore-errors`) on [`LocalCopyOptions`].
+
 use super::types::{DeleteTiming, LocalCopyOptions};
 
 impl LocalCopyOptions {

--- a/crates/engine/src/local_copy/options/filters.rs
+++ b/crates/engine/src/local_copy/options/filters.rs
@@ -1,3 +1,6 @@
+//! Setters and accessors for filter rules, filter programs, and the
+//! `--iconv` filename charset converter on [`LocalCopyOptions`].
+
 use filters::FilterSet;
 use protocol::iconv::FilenameConverter;
 

--- a/crates/engine/src/local_copy/options/integrity.rs
+++ b/crates/engine/src/local_copy/options/integrity.rs
@@ -1,3 +1,7 @@
+//! Setters and accessors for change-detection options on
+//! [`LocalCopyOptions`]: checksum mode, size-only, time-related toggles,
+//! existence filters, block-size override, and modify-window tolerance.
+
 use std::num::NonZeroU32;
 use std::time::Duration;
 

--- a/crates/engine/src/local_copy/options/limits.rs
+++ b/crates/engine/src/local_copy/options/limits.rs
@@ -1,3 +1,6 @@
+//! Setters and accessors for size filters, source removal, preallocation,
+//! bandwidth limits, and timeout/deadline options on [`LocalCopyOptions`].
+
 use std::num::NonZeroU64;
 use std::time::{Duration, SystemTime};
 

--- a/crates/engine/src/local_copy/options/link_dest.rs
+++ b/crates/engine/src/local_copy/options/link_dest.rs
@@ -1,3 +1,7 @@
+//! Setters and accessors for hard-link preservation, `--link-dest` entries,
+//! and reference directories (`--compare-dest`, `--copy-dest`, `--link-dest`)
+//! on [`LocalCopyOptions`].
+
 use std::path::{Path, PathBuf};
 
 use super::types::{LinkDestEntry, LocalCopyOptions, ReferenceDirectory};

--- a/crates/engine/src/local_copy/options/logging.rs
+++ b/crates/engine/src/local_copy/options/logging.rs
@@ -1,3 +1,6 @@
+//! Setters and accessors for `--log-file` and `--log-file-format` on
+//! [`LocalCopyOptions`].
+
 use std::path::{Path, PathBuf};
 
 use super::types::LocalCopyOptions;

--- a/crates/engine/src/local_copy/options/metadata/tests.rs
+++ b/crates/engine/src/local_copy/options/metadata/tests.rs
@@ -1,3 +1,6 @@
+//! Unit tests for the metadata setters and accessors and the
+//! `effective_am_root` privilege helper.
+
 use super::super::types::LocalCopyOptions;
 use super::accessors::{effective_am_root, is_effective_root};
 use ::metadata::CopyAsIds;

--- a/crates/engine/src/local_copy/options/path_behavior.rs
+++ b/crates/engine/src/local_copy/options/path_behavior.rs
@@ -1,3 +1,6 @@
+//! Setters and accessors for path traversal, symlink handling, and
+//! whole-file transfer behaviour on [`LocalCopyOptions`].
+
 use super::types::LocalCopyOptions;
 
 impl LocalCopyOptions {

--- a/crates/engine/src/local_copy/options/platform_copy.rs
+++ b/crates/engine/src/local_copy/options/platform_copy.rs
@@ -60,7 +60,6 @@ mod tests {
     #[test]
     fn default_platform_copy_is_set() {
         let opts = LocalCopyOptions::new();
-        // The default strategy is callable.
         assert_eq!(
             opts.platform_copy().preferred_method(0),
             DefaultPlatformCopy::new().preferred_method(0)

--- a/crates/engine/src/local_copy/options/staging.rs
+++ b/crates/engine/src/local_copy/options/staging.rs
@@ -1,3 +1,8 @@
+//! Setters and accessors for staging-related options on
+//! [`LocalCopyOptions`]: sparse handling, partial transfers,
+//! `--temp-dir`/`--partial-dir`, `--delay-updates`, `--inplace`, `--append`,
+//! `--append-verify`, fsync, and event collection.
+
 use std::path::{Path, PathBuf};
 
 use super::types::LocalCopyOptions;

--- a/crates/engine/src/local_copy/options/types.rs
+++ b/crates/engine/src/local_copy/options/types.rs
@@ -1,3 +1,10 @@
+//! Core type definitions for the [`LocalCopyOptions`] configuration surface.
+//!
+//! Defines the `LocalCopyOptions` struct, its defaults, and the supporting
+//! enums (`DeleteTiming`, `ReferenceDirectoryKind`) and helper structs
+//! (`ReferenceDirectory`, `LinkDestEntry`) used by the per-concern setter
+//! and accessor submodules.
+
 use std::ffi::OsString;
 use std::num::{NonZeroU32, NonZeroU64};
 use std::path::PathBuf;


### PR DESCRIPTION
## Summary

- Adds `//!` module-level documentation to the per-concern submodules under `crates/engine/src/local_copy/options/` that previously lacked it (`types`, `path_behavior`, `backup`, `compression`, `deletion`, `filters`, `integrity`, `limits`, `link_dest`, `logging`, `staging`, `builder/error`, `builder/tests`, `metadata/tests`).
- Deletes two trivial restating `//` comments (`builder/validation.rs` "Validate size limits" and `platform_copy.rs` test "The default strategy is callable.").
- Comment-only pass per task #1951; no executable code is changed.

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [ ] CI: fmt+clippy
- [ ] CI: nextest (stable)
- [ ] CI: Windows (stable)
- [ ] CI: macOS (stable)
- [ ] CI: Linux musl (stable)