### PR TITLE
ci: demote beta/nightly to non-required and gate coverage on label

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: lint
     timeout-minutes: 30
+    # Stable gates merge; beta/nightly are informational so a churning
+    # nightly compiler does not block PR throughput. Branch protection
+    # should pin the required check to `nextest (stable)`.
+    continue-on-error: ${{ matrix.toolchain != 'stable' }}
     strategy:
       fail-fast: false
       matrix:
@@ -167,6 +171,7 @@ jobs:
     runs-on: windows-latest
     needs: lint
     timeout-minutes: 45
+    continue-on-error: ${{ matrix.toolchain != 'stable' }}
     strategy:
       fail-fast: false
       matrix:
@@ -361,6 +366,7 @@ jobs:
     runs-on: macos-latest
     needs: lint
     timeout-minutes: 30
+    continue-on-error: ${{ matrix.toolchain != 'stable' }}
     strategy:
       fail-fast: false
       matrix:
@@ -412,6 +418,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: lint
     timeout-minutes: 30
+    continue-on-error: ${{ matrix.toolchain != 'stable' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,11 +1,12 @@
 name: Coverage
 
 # Measures test line + branch coverage with cargo-llvm-cov on Linux.
-# Runs on every push to master and on pull requests touching code paths.
-# This job is informational and non-blocking - it must not gate master.
-# Tracks the project's >= 95% line coverage target; gate is currently
-# pinned at 84% (see --fail-under-lines below) and tightened incrementally
-# as coverage improves.
+# Runs on every push to master, nightly via schedule, on demand via
+# workflow_dispatch, and on PRs that explicitly opt in via the
+# `coverage-required` label. This job is informational and non-blocking -
+# it must not gate master. Tracks the project's >= 95% line coverage
+# target; gate is currently pinned at 84% (see --fail-under-lines below)
+# and tightened incrementally as coverage improves.
 on:
   push:
     branches: [ master, main ]
@@ -17,6 +18,7 @@ on:
       - 'Cargo.toml'
       - '.github/workflows/coverage.yml'
   pull_request:
+    types: [labeled, synchronize]
     paths:
       - 'crates/**'
       - 'src/**'
@@ -24,6 +26,10 @@ on:
       - 'tools/ci/**'
       - 'Cargo.toml'
       - '.github/workflows/coverage.yml'
+  schedule:
+    # Nightly run at 03:17 UTC keeps the master baseline current without
+    # blocking PR queues. Off-peak time minimises hosted-runner contention.
+    - cron: '17 3 * * *'
   workflow_dispatch:
 
 concurrency:
@@ -49,6 +55,11 @@ env:
 jobs:
   coverage:
     name: llvm-cov
+    # PR runs only when the `coverage-required` label is present. Push,
+    # schedule, and manual dispatch always run.
+    if: >-
+      github.event_name != 'pull_request'
+      || contains(github.event.pull_request.labels.*.name, 'coverage-required')
     runs-on: ubuntu-latest
     timeout-minutes: 45
 


### PR DESCRIPTION
## Summary

Two changes to ease the GitHub-hosted runner queue when many PRs rebase concurrently. Today a 14-PR rebase wave dispatches ~520 jobs at once and stalls for an hour while runners drain.

* **Demote beta/nightly toolchains** across \`nextest\`, \`Windows\`, \`macOS\`, and \`Linux musl\` to \`continue-on-error: \${{ matrix.toolchain != 'stable' }}\`. Stable still gates merge; beta/nightly remain informational so a churning unstable compiler does not block PR throughput.
* **Move \`coverage.yml\` off the unconditional \`pull_request\` trigger.** It now runs on push to master, on a nightly cron, on \`workflow_dispatch\`, and on PRs only when the \`coverage-required\` label is applied. \`llvm-cov\` is the longest-running per-PR step and is redundant with the master baseline for routine PRs.

## Expected impact

- Required jobs per PR drop from ~12 (across 4 platforms × 3 toolchains) to **4** (one stable per platform) plus fmt+clippy.
- Coverage no longer competes with PR queue on every push.
- Beta/nightly still run and surface failures in the PR rollup; they just do not block.

## Branch protection follow-up

Required checks list should be pinned to:

- \`fmt + clippy\`
- \`nextest (stable)\`
- \`Windows (stable)\`
- \`macOS (stable)\`
- \`Linux musl (stable)\`

Branch protection currently includes the beta/nightly variants - those entries should be removed after this merges.

## Test plan

- [x] \`yaml.safe_load\` parses both files
- [ ] Verify on this PR's own CI run that beta/nightly jobs run but report success even on failure
- [ ] Verify coverage job is skipped on this PR (no \`coverage-required\` label)
- [ ] After merge, manually trigger \`workflow_dispatch\` on coverage.yml to confirm cron path still works