### PR TITLE
docs(protocol): tighten rustdoc in stats module

### DIFF
--- a/crates/protocol/src/stats/delete.rs
+++ b/crates/protocol/src/stats/delete.rs
@@ -65,12 +65,8 @@ impl DeleteStats {
 
     /// Writes the delete stats to a stream in wire format.
     ///
-    /// Wire format (all varint):
-    /// - files (excluding dirs/symlinks/devices/specials)
-    /// - dirs
-    /// - symlinks
-    /// - devices
-    /// - specials
+    /// Encodes the five counters (files, dirs, symlinks, devices, specials)
+    /// in order, each as a varint.
     ///
     /// # Errors
     ///

--- a/crates/protocol/src/stats/mod.rs
+++ b/crates/protocol/src/stats/mod.rs
@@ -1,17 +1,10 @@
 //! Transfer and deletion statistics wire format encoding and decoding.
 //!
-//! This module implements the wire format for exchanging transfer statistics
-//! between rsync processes. The format varies by protocol version:
+//! Wire format varies by protocol version:
 //!
-//! - Protocol 30+: Uses varlong30 encoding with 3-byte minimum
-//! - Protocol 29: Adds flist build/transfer time fields
-//! - Protocol < 29: Basic stats only
-//!
-//! # Submodules
-//!
-//! - `transfer` - Transfer statistics struct, constructors, and wire format
-//! - `delete` - Deletion statistics struct and wire format
-//! - `display` - Display formatting for transfer statistics
+//! - Protocol 30+: varlong30 encoding with 3-byte minimum
+//! - Protocol 29: adds flist build/transfer time fields
+//! - Protocol < 29: basic byte counts only
 
 mod delete;
 mod display;

--- a/crates/protocol/src/stats/transfer.rs
+++ b/crates/protocol/src/stats/transfer.rs
@@ -1,14 +1,5 @@
 //! Transfer statistics struct and wire format encoding/decoding.
 //!
-//! Implements the wire format for exchanging transfer statistics between rsync
-//! processes. The format varies by protocol version:
-//!
-//! - Protocol 30+: Uses varlong30 encoding with 3-byte minimum
-//! - Protocol 29: Adds flist build/transfer time fields
-//! - Protocol < 29: Basic stats only
-//!
-//! # Wire Format
-//!
 //! Stats are exchanged at the end of a transfer in this order:
 //!
 //! ```text
@@ -19,7 +10,7 @@
 //! flist_xfertime  : varlong30 (protocol >= 29, microseconds)
 //! ```
 //!
-//! Note: The meaning of read/write swaps between sender and receiver perspectives.
+//! The meaning of read/write swaps between sender and receiver perspectives.
 
 use std::io::{self, Read, Write};
 
@@ -28,17 +19,13 @@ use crate::version::ProtocolVersion;
 
 /// Transfer statistics exchanged between rsync processes.
 ///
-/// These statistics are sent at the end of a transfer to allow both sides
-/// to report accurate totals. The field meanings depend on the role:
+/// Sent at the end of a transfer so both sides can report accurate totals.
+/// Field meanings depend on the role:
 ///
 /// - **Sender**: `total_read` is bytes received, `total_written` is bytes sent
 /// - **Receiver**: `total_read` is bytes sent, `total_written` is bytes received
 ///
-/// # Wire Format
-///
-/// The core byte counts (`total_read`, `total_written`, `total_size`) and
-/// optional timing fields are serialized using `varlong30` encoding. Use
-/// [`write_to`](Self::write_to) and [`read_from`](Self::read_from) for
+/// Use [`write_to`](Self::write_to) and [`read_from`](Self::read_from) for
 /// wire-format I/O.
 ///
 /// # Examples
@@ -204,9 +191,7 @@ impl TransferStats {
 
     /// Writes the stats to a stream in wire format.
     ///
-    /// The format depends on the protocol version:
-    /// - All versions: total_read, total_written, total_size (varlong30)
-    /// - Protocol >= 29: Also includes flist_buildtime, flist_xfertime
+    /// Protocol >= 29 additionally writes `flist_buildtime` and `flist_xfertime`.
     ///
     /// # Errors
     ///
@@ -226,9 +211,7 @@ impl TransferStats {
 
     /// Reads stats from a stream in wire format.
     ///
-    /// The format depends on the protocol version:
-    /// - All versions: total_read, total_written, total_size (varlong30)
-    /// - Protocol >= 29: Also includes flist_buildtime, flist_xfertime
+    /// Protocol >= 29 additionally reads `flist_buildtime` and `flist_xfertime`.
     ///
     /// # Errors
     ///


### PR DESCRIPTION
## Summary

- Drop decorative submodule listing in `stats/mod.rs` so the module doc focuses on the protocol-version wire-format quirks.
- Deduplicate the wire-format description in `stats/transfer.rs`: keep one canonical layout in the module doc and trim restatements in the struct rustdoc and `read_from`/`write_to` rustdoc.
- Fix the misleading "(excluding dirs/symlinks/devices/specials)" line in `DeleteStats::write_to` rustdoc and replace it with a concise description of the varint sequence.

## Test plan

- [ ] CI: fmt+clippy
- [ ] CI: nextest stable
- [ ] CI: Windows / macOS / Linux musl