### PR TITLE
docs(protocol): trim restatement comments in batched_writer

### DIFF
--- a/crates/protocol/src/flist/batched_writer/config.rs
+++ b/crates/protocol/src/flist/batched_writer/config.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 pub const DEFAULT_MAX_ENTRIES: usize = 64;
 
 /// Default maximum batch size in bytes before auto-flush.
-pub const DEFAULT_MAX_BYTES: usize = 64 * 1024; // 64KB
+pub const DEFAULT_MAX_BYTES: usize = 64 * 1024;
 
 /// Default timeout for flush-on-timeout behavior.
 pub const DEFAULT_FLUSH_TIMEOUT: Duration = Duration::from_millis(100);

--- a/crates/protocol/src/flist/batched_writer/tests.rs
+++ b/crates/protocol/src/flist/batched_writer/tests.rs
@@ -263,11 +263,10 @@ fn check_timeout_flush() {
     let entry = FileEntry::new_file("test.txt".into(), 100, 0o644);
     writer.add_entry(&mut output, &entry).unwrap();
 
-    // Before expiry: timeout has not elapsed yet
     assert!(!writer.check_timeout_flush(&mut output).unwrap());
     assert!(!writer.is_empty());
 
-    // Simulate timeout expiry by backdating the batch start
+    // Backdate batch start so the timeout has elapsed deterministically.
     writer.expire_batch_timeout();
 
     assert!(writer.check_timeout_flush(&mut output).unwrap());


### PR DESCRIPTION
## Summary
- Drop the trailing `// 64KB` annotation on `DEFAULT_MAX_BYTES`; the constant name and `64 * 1024` literal already convey the unit.
- Remove a test comment that merely restated the assertion immediately below it, and reword the surviving comment to explain why the helper backdates the batch start.
- No code or behaviour changes; only comment cleanup in `crates/protocol/src/flist/batched_writer/`.

## Test plan
- [ ] CI fmt + clippy
- [ ] CI nextest (stable, Linux musl, Windows, macOS)