### PR TITLE
docs(engine): drop restatement comment in deletion tests

### DIFF
--- a/crates/engine/src/local_copy/deletion/tests.rs
+++ b/crates/engine/src/local_copy/deletion/tests.rs
@@ -287,7 +287,6 @@ mod build_keep_set_tests {
             OsString::from("other.txt"),
         ];
         let set = build_keep_set(&entries);
-        // Set deduplicates
         assert_eq!(set.len(), 2);
         assert!(set.contains(OsStr::new("file.txt")));
         assert!(set.contains(OsStr::new("other.txt")));


### PR DESCRIPTION
## Summary
- Remove a redundant `// Set deduplicates` inline comment in the `build_keep_set` duplicate-entry test.
- The test name (`handles_duplicate_entries`) and the input clearly convey the assertion intent.
- Pure comment cleanup in `crates/engine/src/local_copy/deletion/`; no code, public API, or behavior changes.

## Test plan
- [ ] CI fmt+clippy
- [ ] CI nextest (stable) on Linux/Windows/macOS