### PR TITLE
docs(protocol): tidy flist entry rustdoc

### DIFF
--- a/crates/protocol/src/flist/entry/constructors.rs
+++ b/crates/protocol/src/flist/entry/constructors.rs
@@ -1,4 +1,6 @@
-// upstream: flist.c:make_file() - creates file_struct from stat data
+//! Constructors for [`FileEntry`].
+//!
+//! upstream: `flist.c:make_file()` - creates `file_struct` from stat data.
 
 use std::path::PathBuf;
 
@@ -141,7 +143,6 @@ impl FileEntry {
         mtime_nsec: u32,
         flags: super::super::flags::FileFlags,
     ) -> Self {
-        // Convert bytes to PathBuf without UTF-8 validation
         #[cfg(unix)]
         let path = {
             use std::ffi::OsStr;
@@ -150,7 +151,8 @@ impl FileEntry {
         };
         #[cfg(not(unix))]
         let path = {
-            // On non-Unix, we need UTF-8 validation
+            // Non-Unix targets cannot use `OsStr::from_bytes`; lossy UTF-8
+            // conversion preserves displayability for non-UTF-8 names.
             PathBuf::from(String::from_utf8_lossy(&name).into_owned())
         };
 

--- a/crates/protocol/src/flist/entry/file_type.rs
+++ b/crates/protocol/src/flist/entry/file_type.rs
@@ -28,12 +28,11 @@ pub enum FileType {
 impl FileType {
     /// Extracts the file type from Unix mode bits.
     ///
-    /// The file type is encoded in the upper 4 bits of the mode (S_IFMT mask).
-    /// Returns `None` for unrecognized mode patterns.
+    /// The file type is encoded in the upper 4 bits of the mode (S_IFMT mask
+    /// `0o170000`). Returns `None` for unrecognized mode patterns.
     ///
-    /// // upstream: rsync.h S_IFMT mask (0o170000)
+    /// upstream: rsync.h S_IFMT mask (`0o170000`).
     pub const fn from_mode(mode: u32) -> Option<Self> {
-        // S_IFMT = 0o170000
         match mode & 0o170000 {
             0o100000 => Some(Self::Regular),     // S_IFREG
             0o040000 => Some(Self::Directory),   // S_IFDIR


### PR DESCRIPTION
## Summary

- Promote the constructors-module upstream reference to a `//!` module doc.
- Fold the `S_IFMT = 0o170000` constant note into the `FileType::from_mode` rustdoc and drop the malformed `///` line that contained `// upstream:`.
- Strip restating step comments in `FileEntry::from_raw_bytes` while preserving the non-Unix UTF-8 conversion invariant.

No code changes - only comments and rustdoc.

## Test plan

- [ ] CI fmt + clippy
- [ ] CI nextest (stable)
- [ ] Windows / macOS / Linux musl