### PR TITLE
docs(protocol): add upstream compat.c references to compatibility module

### DIFF
--- a/crates/protocol/src/compatibility/flags.rs
+++ b/crates/protocol/src/compatibility/flags.rs
@@ -14,6 +14,8 @@ use super::known::KnownCompatibilityFlag;
 /// after version 30. The flags are transmitted using the variable-length
 /// integer codec implemented in the `varint` module, making the bitfield compact
 /// while retaining forward compatibility when new bits are defined.
+///
+/// Bit definitions mirror upstream `compat.c:117` (`CF_*` macros).
 #[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(transparent))]

--- a/crates/protocol/src/compatibility/known.rs
+++ b/crates/protocol/src/compatibility/known.rs
@@ -6,9 +6,10 @@ use super::flags::CompatibilityFlags;
 /// Enumerates the compatibility flags defined by upstream rsync 3.4.1.
 ///
 /// The variants mirror the canonical `CF_*` identifiers from the C
-/// implementation. They serve as a strongly-typed view that avoids leaking raw
-/// bit positions into higher layers while still supporting inexpensive
-/// conversions back into [`CompatibilityFlags`]. The iterator returned by
+/// implementation (see upstream `compat.c:117` for the bit definitions). They
+/// serve as a strongly-typed view that avoids leaking raw bit positions into
+/// higher layers while still supporting inexpensive conversions back into
+/// [`CompatibilityFlags`]. The iterator returned by
 /// [`CompatibilityFlags::iter_known`] yields values in ascending bit order.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum KnownCompatibilityFlag {

--- a/crates/protocol/src/compatibility/mod.rs
+++ b/crates/protocol/src/compatibility/mod.rs
@@ -7,6 +7,9 @@
 //! bitfield so higher layers can reason about individual compatibility bits
 //! without manipulating integers directly.
 //!
+//! Upstream reference: `compat.c:117` for the `CF_*` bit definitions and
+//! `compat.c:572` (`setup_protocol`) for the negotiation handshake.
+//!
 //! # Design
 //!
 //! - [`CompatibilityFlags`] wraps a `u32` and provides associated constants for


### PR DESCRIPTION
## Summary
- Cite upstream `compat.c:117` for the `CF_*` bit definitions in `CompatibilityFlags`, `KnownCompatibilityFlag`, and the module overview.
- Cite upstream `compat.c:572` (`setup_protocol`) for the negotiation handshake context.
- Comments-only change. No code modifications.

## Test plan
- [ ] CI fmt+clippy passes
- [ ] CI nextest (stable) passes