### PR TITLE
docs(protocol): tidy multiplex comments and rustdoc

### DIFF
--- a/crates/protocol/src/multiplex/codec.rs
+++ b/crates/protocol/src/multiplex/codec.rs
@@ -1,5 +1,3 @@
-//! crates/protocol/src/multiplex/codec.rs
-//!
 //! Async codec for multiplexed rsync protocol frames using tokio-util.
 //!
 //! This module provides [`MultiplexCodec`], a [`tokio_util::codec::Decoder`] and
@@ -103,12 +101,12 @@ impl Decoder for MultiplexCodec {
     type Error = io::Error;
 
     fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
-        // Need at least the header to proceed
         if src.len() < HEADER_LEN {
             return Ok(None);
         }
 
-        // Peek at header without consuming (in case payload isn't ready)
+        // Peek at the header without consuming so a partial-payload read can
+        // be retried once more bytes arrive.
         let header_bytes: [u8; HEADER_LEN] = src[..HEADER_LEN].try_into().map_err(|_| {
             io::Error::new(io::ErrorKind::InvalidData, "failed to read header bytes")
         })?;
@@ -116,7 +114,6 @@ impl Decoder for MultiplexCodec {
         let header = MessageHeader::decode(&header_bytes).map_err(map_envelope_error)?;
         let payload_len = header.payload_len();
 
-        // Validate payload length against our limit
         if payload_len > self.max_payload_len {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
@@ -129,20 +126,13 @@ impl Decoder for MultiplexCodec {
 
         let total_len = HEADER_LEN + payload_len as usize;
 
-        // Check if we have the complete frame
         if src.len() < total_len {
-            // Reserve space for the rest of the frame
             src.reserve(total_len - src.len());
             return Ok(None);
         }
 
-        // Consume the header
         src.advance(HEADER_LEN);
-
-        // Extract the payload
         let payload = src.split_to(payload_len as usize).to_vec();
-
-        // MessageFrame::new already returns io::Error
         let frame = MessageFrame::new(header.code(), payload)?;
 
         Ok(Some(frame))
@@ -156,20 +146,15 @@ impl Encoder<MessageFrame> for MultiplexCodec {
         let header = item.header()?;
         let payload = item.payload();
 
-        // Reserve space for header + payload
         dst.reserve(HEADER_LEN + payload.len());
-
-        // Write header
         dst.put_slice(&header.encode());
-
-        // Write payload
         dst.put_slice(payload);
 
         Ok(())
     }
 }
 
-/// Encoder implementation for borrowed frames to avoid cloning.
+/// Encodes borrowed frames without cloning the payload.
 impl Encoder<&MessageFrame> for MultiplexCodec {
     type Error = io::Error;
 
@@ -185,7 +170,8 @@ impl Encoder<&MessageFrame> for MultiplexCodec {
     }
 }
 
-/// Encoder implementation for (MessageCode, &[u8]) tuples for zero-copy sending.
+/// Encodes a `(MessageCode, &[u8])` tuple directly, avoiding an owned `MessageFrame` allocation
+/// when the caller already has a borrowed payload.
 impl Encoder<(MessageCode, &[u8])> for MultiplexCodec {
     type Error = io::Error;
 
@@ -222,7 +208,6 @@ mod tests {
         let mut codec = MultiplexCodec::new();
         let mut buf = BytesMut::new();
 
-        // Encode a frame with empty payload
         let header = MessageHeader::new(MessageCode::NoOp, 0).unwrap();
         buf.extend_from_slice(&header.encode());
 
@@ -253,11 +238,11 @@ mod tests {
         let mut codec = MultiplexCodec::new();
         let mut buf = BytesMut::new();
 
-        buf.extend_from_slice(&[0x07, 0x00]); // Only 2 bytes of header
+        buf.extend_from_slice(&[0x07, 0x00]);
 
         let result = codec.decode(&mut buf).unwrap();
         assert!(result.is_none());
-        assert_eq!(buf.len(), 2); // Buffer unchanged
+        assert_eq!(buf.len(), 2);
     }
 
     #[test]
@@ -265,14 +250,13 @@ mod tests {
         let mut codec = MultiplexCodec::new();
         let mut buf = BytesMut::new();
 
-        // Header says 10 bytes payload, but only 5 available
         let header = MessageHeader::new(MessageCode::Data, 10).unwrap();
         buf.extend_from_slice(&header.encode());
         buf.extend_from_slice(b"hello");
 
         let result = codec.decode(&mut buf).unwrap();
         assert!(result.is_none());
-        assert_eq!(buf.len(), HEADER_LEN + 5); // Buffer unchanged
+        assert_eq!(buf.len(), HEADER_LEN + 5);
     }
 
     #[test]
@@ -280,12 +264,10 @@ mod tests {
         let mut codec = MultiplexCodec::new();
         let mut buf = BytesMut::new();
 
-        // First frame
         let header1 = MessageHeader::new(MessageCode::Info, 3).unwrap();
         buf.extend_from_slice(&header1.encode());
         buf.extend_from_slice(b"abc");
 
-        // Second frame
         let header2 = MessageHeader::new(MessageCode::Data, 2).unwrap();
         buf.extend_from_slice(&header2.encode());
         buf.extend_from_slice(b"xy");
@@ -306,7 +288,6 @@ mod tests {
         let mut codec = MultiplexCodec::with_max_payload_len(100);
         let mut buf = BytesMut::new();
 
-        // Header claims 200 bytes payload
         let header = MessageHeader::new(MessageCode::Data, 200).unwrap();
         buf.extend_from_slice(&header.encode());
 
@@ -326,7 +307,6 @@ mod tests {
 
         assert_eq!(buf.len(), HEADER_LEN + 4);
 
-        // Verify we can decode what we encoded
         let decoded = codec.decode(&mut buf).unwrap().unwrap();
         assert_eq!(decoded.code(), MessageCode::Info);
         assert_eq!(decoded.payload(), b"test");

--- a/crates/protocol/src/multiplex/frame.rs
+++ b/crates/protocol/src/multiplex/frame.rs
@@ -321,7 +321,7 @@ mod tests {
         let frame = MessageFrame::new(MessageCode::Info, b"abc".to_vec()).unwrap();
         let mut bytes = Vec::new();
         frame.encode_into_vec(&mut bytes).unwrap();
-        // Header is 4 bytes + 3 bytes payload
+        // 4-byte header + 3-byte payload.
         assert_eq!(bytes.len(), 7);
     }
 
@@ -330,7 +330,7 @@ mod tests {
         let frame = MessageFrame::new(MessageCode::Info, b"a".to_vec()).unwrap();
         let mut bytes = vec![0xFF, 0xFF];
         frame.encode_into_vec(&mut bytes).unwrap();
-        // Original 2 bytes + header 4 + payload 1
+        // 2-byte prefix preserved + 4-byte header + 1-byte payload = 7.
         assert_eq!(bytes.len(), 7);
         assert_eq!(&bytes[0..2], &[0xFF, 0xFF]);
     }
@@ -340,7 +340,8 @@ mod tests {
         let frame = MessageFrame::new(MessageCode::Data, b"test".to_vec()).unwrap();
         let mut bytes = Vec::new();
         frame.encode_into_writer(&mut bytes).unwrap();
-        assert_eq!(bytes.len(), 8); // 4 header + 4 payload
+        // 4-byte header + 4-byte payload.
+        assert_eq!(bytes.len(), 8);
     }
 
     #[test]
@@ -427,7 +428,7 @@ mod tests {
         let original = MessageFrame::new(MessageCode::Info, b"a".to_vec()).unwrap();
         let mut encoded = Vec::new();
         original.encode_into_vec(&mut encoded).unwrap();
-        encoded.push(0xFF); // Extra trailing byte
+        encoded.push(0xFF);
 
         let result = MessageFrame::try_from(encoded.as_slice());
         assert!(result.is_err());

--- a/crates/protocol/src/multiplex/reader.rs
+++ b/crates/protocol/src/multiplex/reader.rs
@@ -197,19 +197,13 @@ impl<R: Read> MplexReader<R> {
         let code = header.code();
         let len = header.payload_len_usize();
 
-        // Clear buffer and read payload
         self.buffer.clear();
         self.pos = 0;
         read_payload_into(&mut self.inner, &mut self.buffer, len)?;
 
-        // Handle based on message type
         match code {
-            MessageCode::Data => {
-                // DATA messages are buffered for reading
-                Ok(true)
-            }
+            MessageCode::Data => Ok(true),
             other => {
-                // Out-of-band message: invoke handler if set
                 if let Some(ref mut handler) = self.message_handler {
                     handler(other, &self.buffer);
                 }
@@ -221,7 +215,6 @@ impl<R: Read> MplexReader<R> {
 
 impl<R: Read> Read for MplexReader<R> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        // If we have buffered data, copy it out first
         if self.pos < self.buffer.len() {
             let available = self.buffer.len() - self.pos;
             let to_copy = available.min(buf.len());
@@ -230,17 +223,15 @@ impl<R: Read> Read for MplexReader<R> {
             return Ok(to_copy);
         }
 
-        // Buffer is exhausted - read next message
-        // Loop until we get a DATA message
+        // Buffer exhausted: pump out-of-band frames through the handler until
+        // the next DATA frame arrives, then return its bytes to the caller.
         loop {
             if self.read_message()? {
-                // Got a DATA message, buffer is now filled
                 let to_copy = self.buffer.len().min(buf.len());
                 buf[..to_copy].copy_from_slice(&self.buffer[..to_copy]);
                 self.pos = to_copy;
                 return Ok(to_copy);
             }
-            // Non-DATA message handled, continue loop
         }
     }
 }
@@ -358,12 +349,12 @@ mod tests {
 
         let mut buf = [0u8; 10];
 
-        // First read: processes Info, then returns Data
         let n = reader.read(&mut buf).unwrap();
         assert_eq!(n, 4);
         assert_eq!(&buf[..4], b"data");
 
-        // After first read, only Info should be captured
+        // The Info frame ahead of the first DATA frame should have been
+        // dispatched to the handler before the read returns.
         {
             let captured = messages.lock().unwrap();
             assert_eq!(captured.len(), 1);
@@ -371,12 +362,10 @@ mod tests {
             assert_eq!(captured[0].1, b"info");
         }
 
-        // Second read: processes Warning, then returns more Data
         let n = reader.read(&mut buf).unwrap();
         assert_eq!(n, 4);
         assert_eq!(&buf[..4], b"more");
 
-        // Now both Info and Warning should be captured
         let captured = messages.lock().unwrap();
         assert_eq!(captured.len(), 2);
         assert_eq!(captured[0].0, MessageCode::Info);
@@ -458,10 +447,12 @@ mod tests {
 
         let mut buf = [0u8; 5];
         let _ = reader.read(&mut buf).unwrap();
-        assert_eq!(reader.buffered(), 6); // "hello world" - "hello" = " world"
+        // 11-byte payload, 5 consumed -> 6 remaining (" world").
+        assert_eq!(reader.buffered(), 6);
 
         let _ = reader.read(&mut buf).unwrap();
-        assert_eq!(reader.buffered(), 1); // " world" - " worl" = "d"
+        // Another 5 bytes consumed (" worl") -> 1 remaining ("d").
+        assert_eq!(reader.buffered(), 1);
     }
 
     #[test]
@@ -503,12 +494,11 @@ mod tests {
         let mut result = Vec::new();
         let mut buf = [0u8; 10];
 
-        // Read all data messages
         loop {
             match reader.read(&mut buf) {
-                Ok(0) => break, // Empty frame
+                Ok(0) => break,
                 Ok(n) => result.extend_from_slice(&buf[..n]),
-                Err(e) if e.kind() == io::ErrorKind::UnexpectedEof => break, // EOF
+                Err(e) if e.kind() == io::ErrorKind::UnexpectedEof => break,
                 Err(e) => panic!("unexpected error: {e}"),
             }
         }

--- a/crates/protocol/src/multiplex/tests/multiplexing_correctness.rs
+++ b/crates/protocol/src/multiplex/tests/multiplexing_correctness.rs
@@ -1,9 +1,6 @@
 use super::*;
 use std::io::{self, Cursor};
 
-/// Tests for multiplexing correctness covering message framing, type distinction,
-/// large messages, and error message parsing.
-
 #[test]
 fn message_framing_single_message_roundtrip() {
     let mut buffer = Vec::new();
@@ -40,7 +37,6 @@ fn message_framing_multiple_messages_in_sequence() {
 
 #[test]
 fn message_framing_preserves_exact_payload_boundaries() {
-    // Test that payload boundaries are preserved even with varying lengths
     let payloads = [
         b"" as &[u8],
         b"a",
@@ -92,7 +88,8 @@ fn message_framing_header_encodes_payload_length_correctly() {
         let mut buffer = Vec::new();
         send_msg(&mut buffer, MessageCode::Data, payload).expect("send succeeds");
 
-        // Extract length from header (lower 3 bytes of little-endian u32)
+        // Wire format: low 24 bits of the LE header word carry payload length;
+        // the high byte carries tag = MPLEX_BASE + code.
         let header_word = u32::from_le_bytes([
             buffer[0], buffer[1], buffer[2], buffer[3]
         ]);
@@ -200,7 +197,6 @@ fn message_types_error_variants_are_distinct() {
         MessageCode::ErrorExit,
     ];
 
-    // Verify each error code is distinct
     for (i, code1) in error_codes.iter().enumerate() {
         for (j, code2) in error_codes.iter().enumerate() {
             if i != j {
@@ -215,7 +211,6 @@ fn message_types_error_variants_are_distinct() {
         }
     }
 
-    // Verify they roundtrip correctly
     for code in error_codes {
         let mut buffer = Vec::new();
         send_msg(&mut buffer, code, b"error message").expect("send succeeds");
@@ -240,7 +235,6 @@ fn message_types_control_messages_have_unique_codes() {
         MessageCode::NoSend,
     ];
 
-    // Verify all control codes are unique
     for (i, code1) in control_codes.iter().enumerate() {
         for (j, code2) in control_codes.iter().enumerate() {
             if i != j {
@@ -304,7 +298,6 @@ fn message_types_flush_alias_equals_info() {
     assert_eq!(MessageCode::FLUSH, MessageCode::Info);
     assert_eq!(MessageCode::FLUSH.as_u8(), MessageCode::Info.as_u8());
 
-    // Verify they serialize identically
     let mut buffer1 = Vec::new();
     send_msg(&mut buffer1, MessageCode::FLUSH, b"test").expect("send flush");
 
@@ -387,7 +380,9 @@ fn large_messages_recv_into_reuses_buffer_capacity() {
     recv_msg_into(&mut cursor, &mut buffer).expect("receive succeeds");
 
     assert_eq!(buffer.len(), 64 * 1024);
-    assert_eq!(buffer.capacity(), capacity_before, "should reuse existing capacity");
+    // Existing capacity must be reused; recv_msg_into never reallocates when
+    // the buffer is already large enough for the incoming payload.
+    assert_eq!(buffer.capacity(), capacity_before);
 }
 
 #[test]
@@ -559,8 +554,9 @@ fn error_parsing_io_error_and_io_timeout_distinguished() {
 
 #[test]
 fn error_parsing_unknown_code_rejected() {
-    // Construct a header with an unknown message code
-    let unknown_code = 11u8; // Not in MessageCode::ALL
+    // 11 is above the highest currently-defined offset in MessageCode::ALL,
+    // so the resulting tag should be rejected as unknown.
+    let unknown_code = 11u8;
     let tag = u32::from(MPLEX_BASE) + u32::from(unknown_code);
     let raw_header = (tag << 24).to_le_bytes();
 
@@ -656,7 +652,6 @@ fn correctness_zero_length_messages_at_various_positions() {
 
 #[test]
 fn correctness_message_boundaries_with_identical_payloads() {
-    // Verify that identical payloads don't cause messages to merge
     let identical_payload = b"same payload";
     let codes = [
         MessageCode::Info,

--- a/crates/protocol/src/multiplex/writer.rs
+++ b/crates/protocol/src/multiplex/writer.rs
@@ -181,7 +181,6 @@ impl<W: Write> MplexWriter<W> {
             return Ok(());
         }
 
-        // Split buffer into frames if needed
         let mut pos = 0;
         while pos < self.buffer.len() {
             let remaining = self.buffer.len() - pos;
@@ -225,9 +224,9 @@ impl<W: Write> MplexWriter<W> {
     /// # example().unwrap();
     /// ```
     pub fn write_message(&mut self, code: MessageCode, payload: &[u8]) -> io::Result<()> {
-        // Flush buffered DATA first to maintain ordering
+        // Flush buffered DATA first so the control message does not appear
+        // before data the caller has already written.
         self.flush_buffer()?;
-        // Send the message
         send_msg(&mut self.inner, code, payload)?;
         self.inner.flush()
     }
@@ -254,10 +253,8 @@ impl<W: Write> MplexWriter<W> {
     /// # example().unwrap();
     /// ```
     pub fn write_data(&mut self, data: &[u8]) -> io::Result<()> {
-        // Flush buffered data first
         self.flush_buffer()?;
 
-        // Split into frames if needed
         let mut pos = 0;
         while pos < data.len() {
             let remaining = data.len() - pos;
@@ -296,9 +293,9 @@ impl<W: Write> MplexWriter<W> {
     /// # example().unwrap();
     /// ```
     pub fn write_raw(&mut self, data: &[u8]) -> io::Result<()> {
-        // Flush buffered data first
+        // Flush buffered DATA before raw bytes so the receiver sees the
+        // multiplexed prefix in the order the caller produced it.
         self.flush_buffer()?;
-        // Write directly without framing
         self.inner.write_all(data)?;
         self.inner.flush()
     }
@@ -362,18 +359,17 @@ impl<W: Write> Write for MplexWriter<W> {
             return Ok(0);
         }
 
-        // If buffer would overflow, flush first
         if self.buffer.len() + buf.len() > self.buffer_size {
             self.flush_buffer()?;
         }
 
-        // If buf is larger than buffer size, send directly
+        // Bypass the buffer when a single write exceeds the buffer size,
+        // splitting it into max_frame_size chunks via write_data.
         if buf.len() > self.buffer_size {
             self.write_data(buf)?;
             return Ok(buf.len());
         }
 
-        // Buffer the data
         self.buffer.extend_from_slice(buf);
         Ok(buf.len())
     }
@@ -437,7 +433,6 @@ mod tests {
         writer.flush().unwrap();
         assert_eq!(writer.buffered(), 0);
 
-        // Verify the frame
         let mut cursor = std::io::Cursor::new(&output);
         let frame = recv_msg(&mut cursor).unwrap();
         assert_eq!(frame.code(), MessageCode::Data);
@@ -455,7 +450,7 @@ mod tests {
 
         writer.flush().unwrap();
 
-        // Should be sent as a single frame
+        // Successive small writes coalesce into one frame.
         let mut cursor = std::io::Cursor::new(&output);
         let frame = recv_msg(&mut cursor).unwrap();
         assert_eq!(frame.payload(), b"hello world");
@@ -470,7 +465,7 @@ mod tests {
         writer.write_all(&data).unwrap();
         writer.flush().unwrap();
 
-        // Should be split into 3 frames: 100 + 100 + 50
+        // 250 bytes split into max_frame_size (100) chunks: 100 + 100 + 50.
         let mut cursor = std::io::Cursor::new(&output);
 
         let frame1 = recv_msg(&mut cursor).unwrap();
@@ -503,17 +498,15 @@ mod tests {
         let mut output = Vec::new();
         let mut writer = MplexWriter::new(&mut output);
 
-        // Buffer some data
         writer.write_all(b"buffered data").unwrap();
         assert_eq!(writer.buffered(), 13);
 
-        // Write a control message - should flush buffer first
+        // write_message must flush DATA before sending the control frame.
         writer
             .write_message(MessageCode::Warning, b"warning")
             .unwrap();
         assert_eq!(writer.buffered(), 0);
 
-        // Verify: DATA frame, then WARNING frame
         let mut cursor = std::io::Cursor::new(&output);
 
         let frame1 = recv_msg(&mut cursor).unwrap();
@@ -544,7 +537,7 @@ mod tests {
 
         writer.write_raw(b"raw bytes").unwrap();
 
-        // Raw bytes should be written directly, no multiplex frame
+        // write_raw bypasses framing, so the bytes appear verbatim.
         assert_eq!(output, b"raw bytes");
     }
 
@@ -561,12 +554,11 @@ mod tests {
         writer.write_raw(b"raw").unwrap();
         assert_eq!(writer.buffered(), 0);
 
-        // Should have a DATA frame followed by raw bytes
+        // Buffered data is flushed as a DATA frame before the raw bytes.
         let mut cursor = std::io::Cursor::new(&output[..]);
         let frame = recv_msg(&mut cursor).unwrap();
         assert_eq!(frame.payload(), b"buffered");
 
-        // Remaining bytes are raw
         let mut remaining = Vec::new();
         cursor.read_to_end(&mut remaining).unwrap();
         assert_eq!(remaining, b"raw");
@@ -630,10 +622,9 @@ mod tests {
         writer.write_all(b"small").unwrap();
         assert_eq!(writer.buffered(), 5);
 
-        // This should trigger auto-flush
+        // 16-byte write exceeds the 10-byte buffer, so it bypasses buffering
+        // and is sent directly via write_data, leaving the buffer empty.
         writer.write_all(b"trigger overflow").unwrap();
-        // Buffer now contains "trigger overflow" (16 bytes > 10)
-        // but since it's larger than buffer size, it was sent directly
         assert_eq!(writer.buffered(), 0);
     }
 
@@ -656,7 +647,6 @@ mod tests {
         writer.write_all(&large_data).unwrap();
         writer.flush().unwrap();
 
-        // Read back all frames
         let mut cursor = std::io::Cursor::new(&output);
         let mut reconstructed = Vec::new();
 


### PR DESCRIPTION
## Summary

- Strips restating-the-code comments and a stale filename header from the `protocol::multiplex` submodules (`codec.rs`, `frame.rs`, `reader.rs`, `writer.rs`, `tests/multiplexing_correctness.rs`).
- Replaces the few comments worth keeping with notes that explain non-obvious behavior: control-frame ordering vs buffered DATA, the buffer-bypass path in `MplexWriter::write`, and the LE wire-format byte layout.
- No code changes; public-item rustdoc, upstream references, `MSG_*` tag handling, the receiver out-of-band loop, and the SAFETY comment in `helpers.rs` are untouched.

## Test plan

- [ ] CI: fmt + clippy
- [ ] CI: nextest stable
- [ ] CI: Linux musl, macOS, Windows