### PR TITLE
docs(protocol): tidy comments in filters module

### DIFF
--- a/crates/protocol/src/filters/mod.rs
+++ b/crates/protocol/src/filters/mod.rs
@@ -1,31 +1,36 @@
 //! Filter list wire protocol encoding and decoding.
 //!
-//! This module implements the rsync filter list exchange protocol, which allows
-//! clients to send include/exclude patterns to servers for server-side filtering
-//! during file list generation.
+//! Implements rsync's filter list exchange so clients can push
+//! include/exclude patterns to servers for server-side filtering during file
+//! list generation.
 //!
 //! ## Wire Format
 //!
 //! Each filter rule is encoded as:
-//! 1. **Length** (varint): Total bytes for prefix + pattern + optional `/`
-//! 2. **Prefix** (variable): Modifier flags as ASCII characters
-//! 3. **Pattern** (string): The glob pattern
-//! 4. **Trailing `/`** (optional): If DIRECTORY flag set
+//! 1. **Length** (4-byte little-endian `int32`): bytes for prefix + pattern +
+//!    optional trailing `/`.
+//! 2. **Prefix** (variable): rule-type character followed by modifier flags
+//!    as ASCII.
+//! 3. **Pattern** (UTF-8 bytes): the glob pattern.
+//! 4. **Trailing `/`** (optional): present when the directory-only flag is
+//!    set.
 //!
-//! The list is terminated with a 4-byte zero (varint encoding of 0).
+//! The list is terminated by a 4-byte little-endian zero. Upstream uses
+//! `write_int()` / `read_int()` here, not the protocol's varint encoding -
+//! see `exclude.c:1658 send_filter_list()` and `exclude.c:1675
+//! recv_filter_list()`.
 //!
 //! ## Prefix Format
 //!
-//! `[+/-/:][/][!][C][n][w][e][x][s][r][p][ ]`
+//! Layout: rule-type character, optional modifier characters, optional
+//! trailing space, then the pattern. The leading rule-type character is one
+//! of `+`, `-`, `!`, `.`, `:`, `P`, `R` (see `RuleType`). Modifier flags
+//! follow:
 //!
 //! | Char | Meaning | Protocol |
 //! |------|---------|----------|
-//! | `+` | Include rule | All |
-//! | `-` | Exclude rule | All |
-//! | `:` | Per-dir merge (dir-merge) | v29+ |
-//! | `!` | Clear rules | All |
 //! | `/` | Anchored pattern | All |
-//! | `!` | No-match-with-this negates | All |
+//! | `!` | Negate (no-match-with-this) | All |
 //! | `C` | CVS exclude | All |
 //! | `n` | No-inherit | All |
 //! | `w` | Word-split | All |
@@ -34,7 +39,7 @@
 //! | `s` | Apply sender-side | v29+ |
 //! | `r` | Apply receiver-side | v29+ |
 //! | `p` | Perishable | v30+ |
-//! | ` ` | Trailing space if needed | All |
+//! | ` ` | Trailing space separator | All |
 
 mod prefix;
 mod wire;

--- a/crates/protocol/src/filters/prefix.rs
+++ b/crates/protocol/src/filters/prefix.rs
@@ -44,7 +44,7 @@ fn build_old_prefix(rule: &FilterRuleWireFormat) -> Option<String> {
         return None;
     }
 
-    // Check if any modifiers are set - they would exceed legal_len = 1
+    // upstream: exclude.c:1530 - any modifier exceeds legal_len = 1 and is unsendable
     let has_modifiers = rule.anchored
         || rule.negate
         || rule.cvs_exclude
@@ -60,13 +60,12 @@ fn build_old_prefix(rule: &FilterRuleWireFormat) -> Option<String> {
         return None;
     }
 
-    // Include rules always get "+ " prefix
     if matches!(rule.rule_type, RuleType::Include) {
         return Some("+ ".to_owned());
     }
 
-    // Exclude rules: check if pattern needs disambiguation
-    // upstream: exclude.c:1538 - only write "-" if pattern starts with "- " or "+ "
+    // upstream: exclude.c:1538 - only emit "- " when the pattern would otherwise
+    // be ambiguous with another prefix; else send the bare pattern (legal_len = 0).
     if matches!(rule.rule_type, RuleType::Exclude) {
         let pat = &rule.pattern;
         let needs_prefix = (pat.starts_with("- ") || pat.starts_with("+ "))
@@ -77,12 +76,10 @@ fn build_old_prefix(rule: &FilterRuleWireFormat) -> Option<String> {
         if needs_prefix {
             return Some("- ".to_owned());
         }
-        // No prefix needed - raw pattern only (legal_len set to 0)
         return Some(String::new());
     }
 
-    // Other rule types (Protect, Risk, Merge, Clear) cannot be sent for proto < 29
-    // because their prefix chars would exceed legal_len = 1
+    // Protect/Risk/Merge/Clear use prefix chars that exceed legal_len = 1 for proto < 29.
     None
 }
 
@@ -103,13 +100,12 @@ fn build_old_prefix(rule: &FilterRuleWireFormat) -> Option<String> {
 fn build_modern_prefix(rule: &FilterRuleWireFormat, protocol: ProtocolVersion) -> String {
     use super::wire::RuleType;
 
-    // Maximum prefix length: type(1) + modifiers(10) + space(1) = 12 chars
+    // Worst case: type(1) + modifiers(10) + trailing space(1) = 12 bytes.
     let mut prefix = String::with_capacity(12);
 
-    // First character: rule type, with Protect/Risk normalized to upstream's
-    // wire format. The receiver-side flag (set on FilterRuleSpec::protect /
-    // FilterRuleSpec::risk via applies_to_receiver) is emitted as the `r`
-    // modifier below, matching upstream's send_filter_list().
+    // upstream: exclude.c:1536-1572 send_filter_list() - Protect/Risk are encoded
+    // as `-`/`+` plus the `r` modifier (driven by FILTRULE_RECEIVER_SIDE), never
+    // as literal `P`/`R` on the wire.
     let prefix_char = match rule.rule_type {
         RuleType::Protect => '-',
         RuleType::Risk => '+',
@@ -117,7 +113,7 @@ fn build_modern_prefix(rule: &FilterRuleWireFormat, protocol: ProtocolVersion) -
     };
     prefix.push(prefix_char);
 
-    // Modifiers (order matters for compatibility)
+    // Modifier emission order is part of the wire contract; do not reorder.
     if rule.anchored {
         prefix.push('/');
     }
@@ -146,10 +142,8 @@ fn build_modern_prefix(rule: &FilterRuleWireFormat, protocol: ProtocolVersion) -
         prefix.push('x');
     }
 
-    // Protocol version gated modifiers. Protect/Risk rule types always emit
-    // the `r` modifier because upstream's wire encoding represents them
-    // exclusively via FILTRULE_RECEIVER_SIDE on a plain exclude/include rule.
-    // upstream: exclude.c:1569-1572 - `r` modifier on rules with RECEIVER_SIDE.
+    // upstream: exclude.c:1569-1572 - `r` is forced for Protect/Risk because
+    // their wire encoding relies on FILTRULE_RECEIVER_SIDE on a plain `-`/`+`.
     if protocol.supports_sender_receiver_modifiers() {
         if rule.sender_side {
             prefix.push('s');
@@ -164,7 +158,6 @@ fn build_modern_prefix(rule: &FilterRuleWireFormat, protocol: ProtocolVersion) -
         prefix.push('p');
     }
 
-    // Trailing space separator
     prefix.push(' ');
 
     prefix

--- a/crates/protocol/src/filters/wire.rs
+++ b/crates/protocol/src/filters/wire.rs
@@ -185,11 +185,11 @@ pub fn read_filter_list(
     let mut rules = Vec::new();
 
     loop {
-        // Read 4-byte little-endian integer (matches upstream read_int())
         let len = read_i32_le(reader)?;
 
         if len == 0 {
-            break; // Terminator
+            // Wire-format terminator (zero-length record).
+            break;
         }
 
         if len < 0 {
@@ -225,7 +225,8 @@ pub fn write_filter_list<W: Write>(
         writer.write_all(&bytes)?;
     }
 
-    write_i32_le(writer, 0)?; // Terminator
+    // Wire-format terminator (zero-length record).
+    write_i32_le(writer, 0)?;
     Ok(())
 }
 
@@ -363,7 +364,6 @@ fn parse_wire_rule_modern(
         negate: false,
     };
 
-    // Parse modifier flags
     let mut pattern_start = 1;
     for (i, c) in chars.enumerate() {
         match c {
@@ -408,17 +408,17 @@ fn parse_wire_rule_modern(
                 pattern_start += 1;
             }
             ' ' => {
+                // Trailing space terminates the modifier section per upstream
+                // exclude.c parser.
                 pattern_start += 1;
-                break; // Trailing space ends modifiers
+                break;
             }
-            _ => break, // Start of pattern
+            _ => break,
         }
     }
 
-    // Extract pattern (remaining text)
     let pattern_text = &text[pattern_start..];
 
-    // Check for trailing slash (directory-only)
     if let Some(stripped) = pattern_text.strip_suffix('/') {
         rule.directory_only = true;
         stripped.clone_into(&mut rule.pattern);


### PR DESCRIPTION
## Summary
- Correct the `crates/protocol/src/filters` module-level wire-format doc: the rule-length prefix is a 4-byte little-endian `int32` (upstream `read_int`/`write_int` per `exclude.c:1658`), not a varint.
- Convert restatement comments in `prefix.rs` and `wire.rs` into upstream-anchored notes citing `exclude.c` line ranges.
- Drop redundant section markers (`// Modifiers`, `// Extract pattern`, `// Check for trailing slash`, etc.) and the duplicated `!` / `/` rows in the prefix table.

## Test plan
- [ ] CI: fmt + clippy
- [ ] CI: nextest (stable)
- [ ] CI: Linux musl / macOS / Windows