### PR TITLE
docs(protocol): scrub decorative banners in negotiation tests

### DIFF
--- a/crates/protocol/src/negotiation/sniffer/async_read.rs
+++ b/crates/protocol/src/negotiation/sniffer/async_read.rs
@@ -1,8 +1,6 @@
-//! crates/protocol/src/negotiation/sniffer/async_read.rs
-//!
 //! Async I/O extensions for [`NegotiationPrologueSniffer`].
 //!
-//! This module provides async read functionality using tokio's [`AsyncRead`] trait,
+//! Provides async read functionality using tokio's [`AsyncRead`] trait,
 //! enabling non-blocking negotiation detection in async contexts.
 
 use std::io;
@@ -54,7 +52,6 @@ impl NegotiationPrologueSniffer {
     where
         R: AsyncRead + Unpin,
     {
-        // Check if we already have a decision
         match self.detector.decision() {
             Some(decision) if !self.needs_more_legacy_prefix_bytes(decision) => {
                 return Ok(decision);
@@ -118,7 +115,6 @@ mod tests {
     use std::io::Cursor;
     use tokio::io::AsyncRead;
 
-    /// Wrapper to make Cursor implement tokio's AsyncRead via read_buf
     struct AsyncCursor(Cursor<Vec<u8>>);
 
     impl AsyncRead for AsyncCursor {
@@ -150,7 +146,6 @@ mod tests {
 
     #[tokio::test]
     async fn async_read_detects_binary() {
-        // Binary protocol starts with non-@ byte
         let data = vec![0x00, 0x1f, 0x00, 0x00];
         let mut reader = AsyncCursor(Cursor::new(data));
         let mut sniffer = NegotiationPrologueSniffer::new();
@@ -178,7 +173,6 @@ mod tests {
 
         let result = sniffer.read_from_async(&mut reader).await.unwrap();
         assert_eq!(result, NegotiationPrologue::LegacyAscii);
-        // Sniffer should have buffered the prefix
         assert!(!sniffer.buffered().is_empty());
     }
 }

--- a/crates/protocol/src/negotiation/sniffer/core.rs
+++ b/crates/protocol/src/negotiation/sniffer/core.rs
@@ -225,8 +225,6 @@ impl Default for NegotiationPrologueSniffer {
 mod tests {
     use super::*;
 
-    // ==== new() tests ====
-
     #[test]
     fn new_creates_empty_sniffer() {
         let sniffer = NegotiationPrologueSniffer::new();
@@ -250,8 +248,6 @@ mod tests {
         let sniffer = NegotiationPrologueSniffer::new();
         assert!(sniffer.buffered_storage().capacity() >= LEGACY_DAEMON_PREFIX_LEN);
     }
-
-    // ==== with_buffer() tests ====
 
     #[test]
     fn with_buffer_reuses_allocation() {
@@ -284,8 +280,6 @@ mod tests {
         assert!(sniffer.buffered_storage().capacity() <= LEGACY_DAEMON_PREFIX_LEN * 2);
     }
 
-    // ==== buffered() tests ====
-
     #[test]
     fn buffered_empty_initially() {
         let sniffer = NegotiationPrologueSniffer::new();
@@ -298,8 +292,6 @@ mod tests {
         sniffer.observe(b"@RSY").unwrap();
         assert_eq!(sniffer.buffered(), b"@RSY");
     }
-
-    // ==== buffered_remainder() tests ====
 
     #[test]
     fn buffered_remainder_empty_when_no_remainder() {
@@ -324,8 +316,6 @@ mod tests {
         // Binary prefix is 1 byte, remainder is the rest of buffered data
         assert_eq!(sniffer.sniffed_prefix_len(), 1);
     }
-
-    // ==== buffered_split() tests ====
 
     #[test]
     fn buffered_split_with_remainder() {
@@ -354,8 +344,6 @@ mod tests {
         assert!(remainder.is_empty());
     }
 
-    // ==== is_decided() tests ====
-
     #[test]
     fn is_decided_false_initially() {
         let sniffer = NegotiationPrologueSniffer::new();
@@ -375,8 +363,6 @@ mod tests {
         sniffer.observe(b"@RSYNCD:").unwrap();
         assert!(sniffer.is_decided());
     }
-
-    // ==== requires_more_data() tests ====
 
     #[test]
     fn requires_more_data_true_initially() {
@@ -405,8 +391,6 @@ mod tests {
         assert!(sniffer.requires_more_data());
     }
 
-    // ==== buffered_len() tests ====
-
     #[test]
     fn buffered_len_zero_initially() {
         let sniffer = NegotiationPrologueSniffer::new();
@@ -428,8 +412,6 @@ mod tests {
         assert_eq!(sniffer.buffered_len(), 13);
     }
 
-    // ==== try_reserve_buffered() tests ====
-
     #[test]
     fn try_reserve_buffered_ensures_capacity() {
         let mut sniffer = NegotiationPrologueSniffer::new();
@@ -445,8 +427,6 @@ mod tests {
         // Even after capacity normalization, should be able to reserve more
         sniffer.try_reserve_buffered(50).unwrap();
     }
-
-    // ==== sniffed_prefix_len() tests ====
 
     #[test]
     fn sniffed_prefix_len_zero_initially() {
@@ -475,8 +455,6 @@ mod tests {
         assert_eq!(sniffer.sniffed_prefix_len(), 4);
     }
 
-    // ==== sniffed_prefix() tests ====
-
     #[test]
     fn sniffed_prefix_empty_initially() {
         let sniffer = NegotiationPrologueSniffer::new();
@@ -498,8 +476,6 @@ mod tests {
         // sniffed_prefix() should not include the remainder
         assert_eq!(sniffer.sniffed_prefix(), b"@RSYNCD:");
     }
-
-    // ==== rehydrate_from_parts() tests ====
 
     #[test]
     fn rehydrate_from_parts_restores_binary() {
@@ -559,8 +535,6 @@ mod tests {
         assert!(sniffer.is_legacy());
     }
 
-    // ==== into_buffered() tests ====
-
     #[test]
     fn into_buffered_returns_buffer() {
         let mut sniffer = NegotiationPrologueSniffer::new();
@@ -579,8 +553,6 @@ mod tests {
         // Should shrink to reasonable capacity
         assert!(buffer.capacity() <= LEGACY_DAEMON_PREFIX_LEN * 2);
     }
-
-    // ==== into_parts() tests ====
 
     #[test]
     fn into_parts_returns_binary_decision() {
@@ -611,8 +583,6 @@ mod tests {
         assert!(buffer.is_empty());
     }
 
-    // ==== decision() tests ====
-
     #[test]
     fn decision_none_initially() {
         let sniffer = NegotiationPrologueSniffer::new();
@@ -632,8 +602,6 @@ mod tests {
         sniffer.observe(b"@").unwrap();
         assert_eq!(sniffer.decision(), Some(NegotiationPrologue::LegacyAscii));
     }
-
-    // ==== is_legacy() tests ====
 
     #[test]
     fn is_legacy_false_initially() {
@@ -655,8 +623,6 @@ mod tests {
         assert!(!sniffer.is_legacy());
     }
 
-    // ==== is_binary() tests ====
-
     #[test]
     fn is_binary_false_initially() {
         let sniffer = NegotiationPrologueSniffer::new();
@@ -677,8 +643,6 @@ mod tests {
         assert!(!sniffer.is_binary());
     }
 
-    // ==== Default impl tests ====
-
     #[test]
     fn default_matches_new() {
         let default_sniffer = NegotiationPrologueSniffer::default();
@@ -690,8 +654,6 @@ mod tests {
         assert!(default_sniffer.decision().is_none());
         assert!(new_sniffer.decision().is_none());
     }
-
-    // ==== Clone/Debug tests ====
 
     #[test]
     fn clone_preserves_state() {

--- a/crates/protocol/src/negotiation/sniffer/drain/take_buffered.rs
+++ b/crates/protocol/src/negotiation/sniffer/drain/take_buffered.rs
@@ -147,8 +147,6 @@ mod tests {
         NegotiationPrologueSniffer::new()
     }
 
-    // ==== take_buffered tests ====
-
     #[test]
     fn take_buffered_returns_vec_for_binary() {
         let mut sniffer = create_binary_sniffer();
@@ -186,8 +184,6 @@ mod tests {
         assert!(buffered.len() > 8);
     }
 
-    // ==== take_buffered_into tests ====
-
     #[test]
     fn take_buffered_into_fills_target() {
         let mut sniffer = create_binary_sniffer();
@@ -223,8 +219,6 @@ mod tests {
         assert!(target.starts_with(b"@RSYNCD:"));
     }
 
-    // ==== take_buffered_into_slice tests ====
-
     #[test]
     fn take_buffered_into_slice_copies_all() {
         let mut sniffer = create_binary_sniffer();
@@ -248,8 +242,6 @@ mod tests {
         let len = sniffer.take_buffered_into_slice(&mut buf).unwrap();
         assert_eq!(len, 0);
     }
-
-    // ==== take_buffered_into_vectored tests ====
 
     #[test]
     fn take_buffered_into_vectored_copies_across_slices() {
@@ -281,8 +273,6 @@ mod tests {
         assert_eq!(len, 0);
     }
 
-    // ==== take_buffered_into_array tests ====
-
     #[test]
     fn take_buffered_into_array_copies_all() {
         let mut sniffer = create_binary_sniffer();
@@ -290,8 +280,6 @@ mod tests {
         let len = sniffer.take_buffered_into_array(&mut buf).unwrap();
         assert!(len > 0);
     }
-
-    // ==== take_buffered_into_writer tests ====
 
     #[test]
     fn take_buffered_into_writer_writes_all() {
@@ -309,8 +297,6 @@ mod tests {
         let len = sniffer.take_buffered_into_writer(&mut writer).unwrap();
         assert_eq!(len, 0);
     }
-
-    // ==== Edge cases ====
 
     #[test]
     fn take_operations_on_partial_legacy_prefix() {

--- a/crates/protocol/src/negotiation/sniffer/drain/take_prefix.rs
+++ b/crates/protocol/src/negotiation/sniffer/drain/take_prefix.rs
@@ -156,8 +156,6 @@ mod tests {
         NegotiationPrologueSniffer::new()
     }
 
-    // ==== take_sniffed_prefix tests ====
-
     #[test]
     fn take_sniffed_prefix_returns_prefix_only() {
         let mut sniffer = create_sniffer_with_remainder();
@@ -188,8 +186,6 @@ mod tests {
         assert_eq!(prefix[0], 0x00);
     }
 
-    // ==== take_sniffed_prefix_into tests ====
-
     #[test]
     fn take_sniffed_prefix_into_fills_target() {
         let mut sniffer = create_legacy_sniffer();
@@ -214,8 +210,6 @@ mod tests {
         let _ = sniffer.take_sniffed_prefix_into(&mut target).unwrap();
         assert_eq!(&target, b"@RSYNCD:");
     }
-
-    // ==== take_sniffed_prefix_into_slice tests ====
 
     #[test]
     fn take_sniffed_prefix_into_slice_copies_to_slice() {
@@ -245,8 +239,6 @@ mod tests {
         assert_eq!(len, 0);
     }
 
-    // ==== take_sniffed_prefix_into_array tests ====
-
     #[test]
     fn take_sniffed_prefix_into_array_copies_to_array() {
         let mut sniffer = create_legacy_sniffer();
@@ -263,8 +255,6 @@ mod tests {
         let result = sniffer.take_sniffed_prefix_into_array(&mut buf);
         assert!(result.is_err());
     }
-
-    // ==== take_sniffed_prefix_into_writer tests ====
 
     #[test]
     fn take_sniffed_prefix_into_writer_writes_prefix() {
@@ -287,8 +277,6 @@ mod tests {
         assert_eq!(len, 0);
         assert!(writer.get_ref().is_empty());
     }
-
-    // ==== discard_sniffed_prefix tests ====
 
     #[test]
     fn discard_sniffed_prefix_returns_prefix_length() {
@@ -318,8 +306,6 @@ mod tests {
         let _ = sniffer.discard_sniffed_prefix();
         assert_eq!(sniffer.sniffed_prefix_len(), 0);
     }
-
-    // ==== Edge cases ====
 
     #[test]
     fn take_sniffed_prefix_updates_prefix_bytes_retained() {

--- a/crates/protocol/src/negotiation/sniffer/drain/take_remainder.rs
+++ b/crates/protocol/src/negotiation/sniffer/drain/take_remainder.rs
@@ -162,8 +162,6 @@ mod tests {
         NegotiationPrologueSniffer::new()
     }
 
-    // ==== take_buffered_remainder tests ====
-
     #[test]
     fn take_buffered_remainder_returns_remainder_only() {
         let mut sniffer = create_sniffer_with_remainder();
@@ -185,8 +183,6 @@ mod tests {
         assert_eq!(sniffer.buffered(), b"@RSYNCD:");
     }
 
-    // ==== take_buffered_remainder_into tests ====
-
     #[test]
     fn take_buffered_remainder_into_fills_target() {
         let mut sniffer = create_sniffer_with_remainder();
@@ -203,8 +199,6 @@ mod tests {
         let len = sniffer.take_buffered_remainder_into(&mut target).unwrap();
         assert_eq!(len, 0);
     }
-
-    // ==== take_buffered_remainder_into_slice tests ====
 
     #[test]
     fn take_buffered_remainder_into_slice_copies_remainder() {
@@ -235,8 +229,6 @@ mod tests {
         assert_eq!(len, 0);
     }
 
-    // ==== take_buffered_remainder_into_vectored tests ====
-
     #[test]
     fn take_buffered_remainder_into_vectored_copies_remainder() {
         let mut sniffer = create_sniffer_with_remainder();
@@ -259,8 +251,6 @@ mod tests {
         assert_eq!(len, 0);
     }
 
-    // ==== take_buffered_remainder_into_array tests ====
-
     #[test]
     fn take_buffered_remainder_into_array_copies_remainder() {
         let mut sniffer = create_sniffer_with_remainder();
@@ -270,8 +260,6 @@ mod tests {
             .unwrap();
         assert!(len > 0);
     }
-
-    // ==== take_buffered_remainder_into_writer tests ====
 
     #[test]
     fn take_buffered_remainder_into_writer_writes_remainder() {
@@ -293,8 +281,6 @@ mod tests {
             .unwrap();
         assert_eq!(len, 0);
     }
-
-    // ==== take_buffered_split_into tests ====
 
     #[test]
     fn take_buffered_split_into_separates_prefix_and_remainder() {
@@ -334,8 +320,6 @@ mod tests {
         assert_eq!(remainder_len, 0);
         assert!(remainder.is_empty());
     }
-
-    // ==== Cross-submodule edge case ====
 
     #[test]
     fn multiple_drain_calls_work_correctly() {

--- a/crates/protocol/src/negotiation/sniffer/observe.rs
+++ b/crates/protocol/src/negotiation/sniffer/observe.rs
@@ -207,8 +207,6 @@ mod tests {
     use super::*;
     use std::io::Cursor;
 
-    // ==== observe tests ====
-
     #[test]
     fn observe_binary_first_byte() {
         let mut sniffer = NegotiationPrologueSniffer::new();
@@ -292,8 +290,6 @@ mod tests {
         assert_eq!(consumed, 0);
     }
 
-    // ==== observe_byte tests ====
-
     #[test]
     fn observe_byte_binary() {
         let mut sniffer = NegotiationPrologueSniffer::new();
@@ -320,8 +316,6 @@ mod tests {
         assert_eq!(decision, NegotiationPrologue::LegacyAscii);
     }
 
-    // ==== reset tests ====
-
     #[test]
     fn reset_clears_state() {
         let mut sniffer = NegotiationPrologueSniffer::new();
@@ -341,8 +335,6 @@ mod tests {
         sniffer.observe(b"@RSYNCD:").unwrap();
         assert!(sniffer.is_legacy());
     }
-
-    // ==== read_from tests ====
 
     #[test]
     fn read_from_binary() {
@@ -387,8 +379,6 @@ mod tests {
         assert_eq!(decision, NegotiationPrologue::Binary);
     }
 
-    // ==== legacy_prefix_complete tests ====
-
     #[test]
     fn legacy_prefix_complete_false_initially() {
         let sniffer = NegotiationPrologueSniffer::new();
@@ -408,8 +398,6 @@ mod tests {
         sniffer.observe(b"@RSYNCD:").unwrap();
         assert!(sniffer.legacy_prefix_complete());
     }
-
-    // ==== legacy_prefix_remaining tests ====
 
     #[test]
     fn legacy_prefix_remaining_none_before_start() {
@@ -434,8 +422,6 @@ mod tests {
         // (it only returns Some(n) while prefix is incomplete)
         assert!(sniffer.legacy_prefix_remaining().is_none());
     }
-
-    // ==== State transition tests ====
 
     #[test]
     fn is_decided_false_initially() {

--- a/crates/protocol/src/negotiation/types.rs
+++ b/crates/protocol/src/negotiation/types.rs
@@ -423,7 +423,6 @@ pub const fn detect_negotiation_prologue(buffer: &[u8]) -> NegotiationPrologue {
 mod tests {
     use super::*;
 
-    // Tests for BufferedPrefixTooSmall
     #[test]
     fn buffered_prefix_too_small_new() {
         let err = BufferedPrefixTooSmall::new(100, 50);
@@ -439,7 +438,6 @@ mod tests {
 
     #[test]
     fn buffered_prefix_too_small_missing_saturates() {
-        // When available exceeds required, missing should be 0
         let err = BufferedPrefixTooSmall::new(50, 100);
         assert_eq!(err.missing(), 0);
     }
@@ -478,7 +476,6 @@ mod tests {
         assert_eq!(err, copy);
     }
 
-    // Tests for ParseNegotiationPrologueError
     #[test]
     fn parse_error_empty_kind() {
         let err = ParseNegotiationPrologueError::new(ParseNegotiationPrologueErrorKind::Empty);
@@ -511,7 +508,6 @@ mod tests {
         assert_eq!(err.clone(), err);
     }
 
-    // Tests for NegotiationPrologue
     #[test]
     fn negotiation_prologue_as_str() {
         assert_eq!(NegotiationPrologue::NeedMoreData.as_str(), "need-more-data");
@@ -675,7 +671,6 @@ mod tests {
         assert!(set.contains(&NegotiationPrologue::LegacyAscii));
     }
 
-    // Tests for detect_negotiation_prologue
     #[test]
     fn detect_negotiation_prologue_empty() {
         assert_eq!(


### PR DESCRIPTION
## Summary
- Remove redundant `// ==== ... ====` test-section banners from negotiation sniffer test modules.
- Drop the file-path heading at the top of `negotiation/sniffer/async_read.rs` and a handful of restatement comments.
- Trim `// Tests for Foo` headings inside the `negotiation/types.rs` test module.

No code or behaviour changes. Public rustdoc, upstream references (e.g. `compat.c:534-585`), capability-string format notes, and version negotiation invariants are preserved verbatim.

## Test plan
- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings`
- [ ] `cargo nextest run -p protocol --all-features` (CI)