### PR TITLE
docs(protocol): tidy version module comments

### DIFF
--- a/crates/protocol/src/version/constants.rs
+++ b/crates/protocol/src/version/constants.rs
@@ -40,7 +40,6 @@ pub const SUPPORTED_PROTOCOL_BOUNDS: (u8, u8) =
 mod tests {
     use super::*;
 
-    // Tests for protocol version constants
     #[test]
     fn oldest_supported_protocol_is_28() {
         assert_eq!(OLDEST_SUPPORTED_PROTOCOL, 28);
@@ -61,7 +60,6 @@ mod tests {
         assert_eq!(MAXIMUM_PROTOCOL_ADVERTISEMENT, 40);
     }
 
-    // Tests for range consistency
     #[test]
     fn oldest_is_less_than_newest() {
         assert!(OLDEST_SUPPORTED_PROTOCOL < NEWEST_SUPPORTED_PROTOCOL);
@@ -78,7 +76,6 @@ mod tests {
         assert!(MAXIMUM_PROTOCOL_ADVERTISEMENT > NEWEST_SUPPORTED_PROTOCOL);
     }
 
-    // Tests for upstream_protocol_range
     #[test]
     fn upstream_protocol_range_start_is_oldest() {
         assert_eq!(*UPSTREAM_PROTOCOL_RANGE.start(), OLDEST_SUPPORTED_PROTOCOL);
@@ -94,7 +91,6 @@ mod tests {
         assert!(UPSTREAM_PROTOCOL_RANGE.contains(&FIRST_BINARY_NEGOTIATION_PROTOCOL));
     }
 
-    // Tests for supported_protocol_range
     #[test]
     fn supported_protocol_range_start_is_oldest() {
         assert_eq!(*SUPPORTED_PROTOCOL_RANGE.start(), OLDEST_SUPPORTED_PROTOCOL);
@@ -110,7 +106,6 @@ mod tests {
         assert_eq!(SUPPORTED_PROTOCOL_RANGE, UPSTREAM_PROTOCOL_RANGE);
     }
 
-    // Tests for supported_protocol_bounds
     #[test]
     fn supported_protocol_bounds_oldest() {
         assert_eq!(SUPPORTED_PROTOCOL_BOUNDS.0, OLDEST_SUPPORTED_PROTOCOL);

--- a/crates/protocol/src/version/protocol_version/conversions.rs
+++ b/crates/protocol/src/version/protocol_version/conversions.rs
@@ -15,8 +15,6 @@ use super::super::constants::UPSTREAM_PROTOCOL_RANGE;
 use super::super::parse::{ParseProtocolVersionError, ParseProtocolVersionErrorKind};
 use super::ProtocolVersion;
 
-// From<ProtocolVersion> for primitive types
-
 impl From<ProtocolVersion> for u8 {
     #[inline]
     fn from(version: ProtocolVersion) -> Self {
@@ -120,8 +118,6 @@ impl_from_protocol_version_for_nonzero_signed!(
     NonZeroIsize => isize,
 );
 
-// TryFrom implementations
-
 impl TryFrom<u8> for ProtocolVersion {
     type Error = NegotiationError;
 
@@ -141,8 +137,6 @@ impl TryFrom<NonZeroU8> for ProtocolVersion {
         <ProtocolVersion as TryFrom<u8>>::try_from(value.get())
     }
 }
-
-// FromStr
 
 impl FromStr for ProtocolVersion {
     type Err = ParseProtocolVersionError;
@@ -200,15 +194,11 @@ impl FromStr for ProtocolVersion {
     }
 }
 
-// Display
-
 impl fmt::Display for ProtocolVersion {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.as_u8())
     }
 }
-
-// PartialEq cross-type comparisons
 
 impl PartialEq<u8> for ProtocolVersion {
     fn eq(&self, other: &u8) -> bool {

--- a/crates/protocol/src/version/protocol_version/mod.rs
+++ b/crates/protocol/src/version/protocol_version/mod.rs
@@ -67,8 +67,6 @@ use super::iter::{SupportedProtocolNumbersIter, SupportedVersionsIter};
 #[cfg_attr(feature = "serde", serde(transparent))]
 pub struct ProtocolVersion(NonZeroU8);
 
-// Supported protocol declarations (macro-generated constants)
-
 macro_rules! declare_supported_protocols {
     ($($ver:literal),+ $(,)?) => {
         /// Number of protocol versions supported by the Rust implementation.
@@ -117,8 +115,6 @@ pub const SUPPORTED_PROTOCOL_BITMAP: u64 = {
 
     bitmap
 };
-
-// Core impl block: constructors, accessors, supported-protocol queries
 
 impl ProtocolVersion {
     pub(crate) const fn new_const(value: u8) -> Self {

--- a/crates/protocol/src/version/protocol_version/tests.rs
+++ b/crates/protocol/src/version/protocol_version/tests.rs
@@ -545,8 +545,6 @@ fn supported_protocols_display_is_not_empty() {
     assert!(display.contains("28"));
 }
 
-// ProtocolCapabilities tests
-
 #[test]
 fn capabilities_from_protocol_version() {
     use super::ProtocolCapabilities;

--- a/crates/protocol/src/version/select.rs
+++ b/crates/protocol/src/version/select.rs
@@ -225,7 +225,6 @@ const _: () = {
 mod tests {
     use super::*;
 
-    // Tests for select_highest_mutual with empty input
     #[test]
     fn select_highest_mutual_empty_iterator_returns_no_mutual_protocol() {
         let empty: Vec<u8> = vec![];
@@ -239,7 +238,6 @@ mod tests {
         }
     }
 
-    // Tests for select_highest_mutual with single version
     #[test]
     fn select_highest_mutual_single_supported_version() {
         let versions = vec![30_u8];
@@ -254,7 +252,6 @@ mod tests {
         assert_eq!(result, ProtocolVersion::NEWEST);
     }
 
-    // Tests for select_highest_mutual with multiple versions
     #[test]
     fn select_highest_mutual_multiple_versions_returns_highest() {
         let versions = vec![28_u8, 29, 30];
@@ -276,25 +273,20 @@ mod tests {
         assert_eq!(result, ProtocolVersion::NEWEST);
     }
 
-    // Tests for select_highest_mutual with NEWEST version early return
     #[test]
     fn select_highest_mutual_newest_first_returns_immediately() {
-        // When NEWEST is first, we return early without processing the rest
         let versions = vec![ProtocolVersion::NEWEST.as_u8(), 28, 29];
         let result = select_highest_mutual(versions).unwrap();
         assert_eq!(result, ProtocolVersion::NEWEST);
     }
 
-    // Tests for select_highest_mutual with unsupported versions
     #[test]
     fn select_highest_mutual_only_too_old_versions() {
-        // Versions below OLDEST (28) should trigger UnsupportedVersion
         let versions = vec![27_u8, 26, 25];
         let result = select_highest_mutual(versions);
         assert!(result.is_err());
         match result.unwrap_err() {
             NegotiationError::UnsupportedVersion(v) => {
-                // Should report the oldest rejection
                 assert_eq!(v, 25);
             }
             _ => panic!("expected UnsupportedVersion error"),
@@ -308,7 +300,7 @@ mod tests {
         assert!(result.is_err());
         match result.unwrap_err() {
             NegotiationError::UnsupportedVersion(v) => {
-                assert_eq!(v, 20); // Oldest rejected version
+                assert_eq!(v, 20);
             }
             _ => panic!("expected UnsupportedVersion error"),
         }
@@ -316,7 +308,6 @@ mod tests {
 
     #[test]
     fn select_highest_mutual_versions_above_newest_are_clamped() {
-        // Versions between NEWEST and MAXIMUM_PROTOCOL_ADVERTISEMENT are clamped to NEWEST
         let versions = vec![35_u8, 36, 37];
         let result = select_highest_mutual(versions).unwrap();
         assert_eq!(result, ProtocolVersion::NEWEST);
@@ -324,14 +315,14 @@ mod tests {
 
     #[test]
     fn select_highest_mutual_mixed_supported_and_clamped() {
-        let versions = vec![35_u8, 30, 29]; // 35 is clamped to NEWEST (32)
+        // 35 is clamped to NEWEST (32).
+        let versions = vec![35_u8, 30, 29];
         let result = select_highest_mutual(versions).unwrap();
         assert_eq!(result, ProtocolVersion::NEWEST);
     }
 
     #[test]
     fn select_highest_mutual_version_above_maximum_fails() {
-        // Versions above MAXIMUM_PROTOCOL_ADVERTISEMENT (40) should fail
         let versions = vec![50_u32];
         let result = select_highest_mutual(versions);
         assert!(result.is_err());
@@ -343,7 +334,6 @@ mod tests {
         }
     }
 
-    // Tests with different input types
     #[test]
     fn select_highest_mutual_accepts_u8_slice() {
         let versions: &[u8] = &[30, 31];
@@ -365,10 +355,9 @@ mod tests {
         assert_eq!(result, ProtocolVersion::V30);
     }
 
-    // Tests for edge cases
     #[test]
     fn select_highest_mutual_zero_version_is_ignored_but_valid_versions_win() {
-        // Zero is rejected by from_peer_advertisement, but if there are valid versions, they win
+        // Zero is rejected by from_peer_advertisement; valid versions still win.
         let versions: Vec<u32> = vec![0, 30];
         let result = select_highest_mutual(versions).unwrap();
         assert_eq!(result, ProtocolVersion::V30);
@@ -389,8 +378,8 @@ mod tests {
 
     #[test]
     fn select_highest_mutual_version_at_bitmap_boundary() {
-        // Version 63 is at the boundary of u64 bitmap (bit 63)
-        // But it's above MAXIMUM_PROTOCOL_ADVERTISEMENT
+        // Version 63 sits at the u64 bitmap boundary but exceeds
+        // MAXIMUM_PROTOCOL_ADVERTISEMENT, so it must be rejected.
         let versions: Vec<u32> = vec![63];
         let result = select_highest_mutual(versions);
         assert!(result.is_err());
@@ -398,8 +387,8 @@ mod tests {
 
     #[test]
     fn select_highest_mutual_version_above_bitmap_boundary() {
-        // Version 64 would overflow the u64 bitmap
-        // But it's above MAXIMUM_PROTOCOL_ADVERTISEMENT so it's rejected first
+        // Version 64 would overflow the u64 bitmap but is rejected first
+        // because it exceeds MAXIMUM_PROTOCOL_ADVERTISEMENT.
         let versions: Vec<u32> = vec![64];
         let result = select_highest_mutual(versions);
         assert!(result.is_err());
@@ -414,28 +403,18 @@ mod tests {
 
     #[test]
     fn select_highest_mutual_mixed_valid_and_invalid() {
-        // Mix of too-old, valid, and clamped versions
+        // 27 is too old (tracked as rejection), 30 is valid, 35 clamps to NEWEST.
         let versions: Vec<u32> = vec![27, 30, 35];
         let result = select_highest_mutual(versions).unwrap();
-        // 27 is too old (ignored for bitmap, tracked as rejection)
-        // 30 is valid
-        // 35 is clamped to NEWEST (32)
         assert_eq!(result, ProtocolVersion::NEWEST);
     }
 
     #[test]
     fn select_highest_mutual_no_mutual_with_unrecognized_versions() {
-        // Versions that parse successfully but are above our bitmap range
-        // Actually, versions 33-40 are clamped to NEWEST, so they work
-        // We need versions that are recognized but not in bitmap
-        // All versions 28-32 are in our bitmap, so we can't test this easily
-        // Let's test NoMutualProtocol with versions that get filtered out differently
-
-        // This scenario is hard to trigger since all recognized versions 28-32 are supported
-        // But we can verify the behavior when only versions above MAXIMUM are given
+        // Versions above MAXIMUM_PROTOCOL_ADVERTISEMENT all yield
+        // UnsupportedVersion; the first encountered value is returned.
         let versions: Vec<u32> = vec![50, 60, 70];
         let result = select_highest_mutual(versions);
-        // All are UnsupportedVersion errors, first one (50) should be returned
         match result.unwrap_err() {
             NegotiationError::UnsupportedVersion(v) => {
                 assert_eq!(v, 50);
@@ -444,7 +423,6 @@ mod tests {
         }
     }
 
-    // Test with references
     #[test]
     fn select_highest_mutual_accepts_references() {
         let versions = vec![30_u8, 31];
@@ -461,7 +439,6 @@ mod tests {
 
     #[test]
     fn select_negotiates_v28_as_oldest_supported() {
-        // Version 28 is the oldest supported version
         let result = select_highest_mutual([28_u8]).unwrap();
         assert_eq!(result, ProtocolVersion::V28);
         assert_eq!(result.as_u8(), 28);
@@ -496,42 +473,36 @@ mod tests {
 
     #[test]
     fn select_rejects_v27_alone() {
-        // Version 27 is not supported
         let err = select_highest_mutual([27_u8]).unwrap_err();
         assert!(matches!(err, NegotiationError::UnsupportedVersion(27)));
     }
 
     #[test]
     fn select_v27_with_supported_uses_supported() {
-        // When v27 is offered alongside supported versions, pick the supported one
         let result = select_highest_mutual([27_u8, 28]).unwrap();
         assert_eq!(result.as_u8(), 28);
     }
 
     #[test]
     fn select_all_supported_versions_returns_newest() {
-        // When all supported versions are offered, return newest
         let result = select_highest_mutual([28_u8, 29, 30, 31, 32]).unwrap();
         assert_eq!(result, ProtocolVersion::NEWEST);
     }
 
     #[test]
     fn select_highest_from_sparse_set() {
-        // Test with gaps in version set
         let result = select_highest_mutual([28_u8, 31]).unwrap();
         assert_eq!(result.as_u8(), 31);
     }
 
     #[test]
     fn select_highest_when_multiple_duplicates() {
-        // Handle duplicates gracefully
         let result = select_highest_mutual([30_u8, 30, 30, 31, 31, 31, 31]).unwrap();
         assert_eq!(result.as_u8(), 31);
     }
 
     #[test]
     fn select_with_reversed_order() {
-        // Input order shouldn't matter
         let result = select_highest_mutual([32_u8, 31, 30, 29, 28]).unwrap();
         assert_eq!(result, ProtocolVersion::NEWEST);
     }
@@ -544,8 +515,7 @@ mod tests {
 
     #[test]
     fn select_early_return_optimization() {
-        // Once NEWEST is seen, should return immediately
-        // (tested via short-circuit test above, but verify behavior)
+        // Encountering NEWEST short-circuits the iterator.
         let result = select_highest_mutual([32_u8, 28]).unwrap();
         assert_eq!(result, ProtocolVersion::NEWEST);
     }
@@ -558,14 +528,13 @@ mod tests {
 
     #[test]
     fn select_with_zero_and_valid() {
-        // Zero should be ignored when valid versions present
         let result = select_highest_mutual([0_u8, 30]).unwrap();
         assert_eq!(result.as_u8(), 30);
     }
 
     #[test]
     fn select_future_clamps_to_newest() {
-        // Future versions (33-40) clamp to NEWEST
+        // Versions 33-40 fall within the upstream tolerance window and clamp.
         let result = select_highest_mutual([33_u8]).unwrap();
         assert_eq!(result, ProtocolVersion::NEWEST);
 
@@ -575,14 +544,12 @@ mod tests {
 
     #[test]
     fn select_beyond_maximum_fails() {
-        // Versions beyond MAXIMUM_PROTOCOL_ADVERTISEMENT fail
         let err = select_highest_mutual([41_u8]).unwrap_err();
         assert!(matches!(err, NegotiationError::UnsupportedVersion(41)));
     }
 
     #[test]
     fn select_reports_oldest_unsupported_version() {
-        // When all versions are too old, report the oldest one
         let err = select_highest_mutual([25_u8, 26, 27]).unwrap_err();
         assert!(matches!(err, NegotiationError::UnsupportedVersion(25)));
     }
@@ -600,21 +567,19 @@ mod tests {
 
     #[test]
     fn interop_upstream_rsync_34_offers_32() {
-        // rsync 3.4.x offers protocol 32 as newest
         let result = select_highest_mutual([32_u8]).unwrap();
         assert_eq!(result, ProtocolVersion::V32);
     }
 
     #[test]
     fn interop_upstream_rsync_31_offers_31() {
-        // rsync 3.1.x offers protocol 31
         let result = select_highest_mutual([31_u8]).unwrap();
         assert_eq!(result, ProtocolVersion::V31);
     }
 
     #[test]
     fn interop_upstream_rsync_30_offers_30() {
-        // rsync 3.0.x introduced protocol 30 (binary negotiation)
+        // rsync 3.0.x introduced binary negotiation at protocol 30.
         let result = select_highest_mutual([30_u8]).unwrap();
         assert_eq!(result, ProtocolVersion::V30);
         assert!(result.uses_binary_negotiation());
@@ -622,7 +587,7 @@ mod tests {
 
     #[test]
     fn interop_old_rsync_offers_29() {
-        // Older rsync versions use protocol 29 (legacy ASCII)
+        // Pre-3.0 releases use the legacy ASCII negotiation at protocol 29.
         let result = select_highest_mutual([29_u8]).unwrap();
         assert_eq!(result, ProtocolVersion::V29);
         assert!(result.uses_legacy_ascii_negotiation());
@@ -630,14 +595,13 @@ mod tests {
 
     #[test]
     fn interop_multiple_upstream_versions() {
-        // Upstream might advertise range of versions
         let result = select_highest_mutual([30_u8, 31, 32]).unwrap();
         assert_eq!(result, ProtocolVersion::NEWEST);
     }
 
     #[test]
     fn interop_negotiation_style_boundary() {
-        // Verify the legacy/binary boundary at version 30
+        // Legacy/binary boundary sits at protocol 30.
         let v29 = select_highest_mutual([29_u8]).unwrap();
         let v30 = select_highest_mutual([30_u8]).unwrap();
 

--- a/crates/protocol/src/version/tests/protocol/negotiation.rs
+++ b/crates/protocol/src/version/tests/protocol/negotiation.rs
@@ -65,7 +65,6 @@ fn negotiation_succeeds_for_all_supported_versions() {
 /// Verifies negotiation selects the highest mutual version.
 #[test]
 fn negotiation_selects_highest_mutual_version() {
-    // When peer offers multiple supported versions, select highest
     let result = select_highest_mutual([28, 29, 30]).unwrap();
     assert_eq!(result.as_u8(), 30);
 
@@ -79,12 +78,10 @@ fn negotiation_selects_highest_mutual_version() {
 /// Verifies the version range boundaries are correctly handled.
 #[test]
 fn negotiation_boundary_versions() {
-    // Minimum boundary
     let min_result = select_highest_mutual([28]);
     assert!(min_result.is_ok());
     assert_eq!(min_result.unwrap(), ProtocolVersion::OLDEST);
 
-    // Maximum boundary
     let max_result = select_highest_mutual([32]);
     assert!(max_result.is_ok());
     assert_eq!(max_result.unwrap(), ProtocolVersion::NEWEST);
@@ -93,7 +90,7 @@ fn negotiation_boundary_versions() {
 /// Verifies versions between NEWEST and MAXIMUM_PROTOCOL_ADVERTISEMENT are clamped.
 #[test]
 fn future_versions_clamp_to_newest() {
-    // Versions 33-40 should clamp to NEWEST (32)
+    // Versions 33-40 fall within the upstream tolerance window and clamp to NEWEST.
     for version in 33..=40 {
         let result = select_highest_mutual([version]);
         assert!(result.is_ok(), "version {version} should clamp to NEWEST");
@@ -108,7 +105,6 @@ fn future_versions_clamp_to_newest() {
 /// Verifies mixed clamped and supported versions select NEWEST.
 #[test]
 fn mixed_clamped_and_supported_versions() {
-    // Mix of supported and clamped versions
     let result = select_highest_mutual([28, 35]).unwrap();
     assert_eq!(result, ProtocolVersion::NEWEST);
 
@@ -173,7 +169,6 @@ fn empty_version_list_returns_no_mutual_protocol() {
 /// Verifies only-too-old versions report the oldest rejected version.
 #[test]
 fn reports_oldest_rejected_version() {
-    // When all versions are too old, report the oldest
     let result = select_highest_mutual([25_u8, 26, 27]);
     match result.unwrap_err() {
         NegotiationError::UnsupportedVersion(v) => {
@@ -186,15 +181,12 @@ fn reports_oldest_rejected_version() {
 /// Verifies mixed valid and invalid versions succeed with valid version.
 #[test]
 fn mixed_valid_and_invalid_versions_succeeds() {
-    // Too old + valid
     let result = select_highest_mutual([27_u8, 30]).unwrap();
     assert_eq!(result.as_u8(), 30);
 
-    // Zero + valid
     let result = select_highest_mutual([0_u32, 31]).unwrap();
     assert_eq!(result.as_u8(), 31);
 
-    // Too old + clamped
     let result = select_highest_mutual([27_u8, 35]).unwrap();
     assert_eq!(result, ProtocolVersion::NEWEST);
 }

--- a/crates/protocol/src/version/tests/protocol/v31_compatibility.rs
+++ b/crates/protocol/src/version/tests/protocol/v31_compatibility.rs
@@ -69,11 +69,10 @@ fn v31_is_within_supported_range() {
 /// Verifies protocol 31 handshake with mixed valid and invalid versions.
 #[test]
 fn v31_handshake_ignores_invalid_versions() {
-    // Mix of too old, valid, and too new (within clamping range)
-    // Version 50 is above MAXIMUM_PROTOCOL_ADVERTISEMENT (40), so it causes an error
-    // Use version 35 instead, which gets clamped to NEWEST (32)
+    // 35 falls within the upstream tolerance window and clamps to NEWEST.
+    // Values above MAXIMUM_PROTOCOL_ADVERTISEMENT (40) would error instead.
     let result = select_highest_mutual([0, 27, 31, 35]).unwrap();
-    assert_eq!(result, ProtocolVersion::NEWEST); // 35 clamps to 32 (NEWEST)
+    assert_eq!(result, ProtocolVersion::NEWEST);
 }
 
 /// Verifies protocol 31 can be parsed from string.

--- a/crates/protocol/src/version/tests/protocol/v32_compatibility.rs
+++ b/crates/protocol/src/version/tests/protocol/v32_compatibility.rs
@@ -68,8 +68,7 @@ fn v32_is_within_supported_range() {
 /// Verifies protocol 32 handshake with mixed valid and invalid versions.
 #[test]
 fn v32_handshake_ignores_invalid_versions() {
-    // Mix of too old, valid, and within clamping range
-    // Version 35 is clamped to NEWEST (32)
+    // 35 falls within the upstream tolerance window and clamps to NEWEST.
     let result = select_highest_mutual([0, 27, 32, 35]).unwrap();
     assert_eq!(result, ProtocolVersion::NEWEST);
 }


### PR DESCRIPTION
## Summary

- Removes decorative section banners (`// Tests for ...`, `// From<ProtocolVersion> for primitive types`, etc.) from `crates/protocol/src/version/`.
- Drops restating-the-code comments inside test bodies while keeping informative threshold notes (legacy/binary boundary at protocol 30, upstream tolerance window 33-40, MAXIMUM_PROTOCOL_ADVERTISEMENT).
- Preserves all upstream-rsync references, per-protocol feature gating commentary, and the compile-time validation guard.

## Test plan

- [ ] CI fmt+clippy
- [ ] CI nextest (stable)
- [ ] Windows / macOS / Linux musl matrix