### PR TITLE
docs(checksums): tidy comments in simd_batch module

### DIFF
--- a/crates/checksums/src/simd_batch/md4/simd/avx2.rs
+++ b/crates/checksums/src/simd_batch/md4/simd/avx2.rs
@@ -34,7 +34,11 @@ const M3: [usize; 16] = [0, 8, 4, 12, 2, 10, 6, 14, 1, 9, 5, 13, 3, 11, 7, 15];
 /// Maximum input size supported.
 const MAX_INPUT_SIZE: usize = 1_024 * 1_024; // 1MB per input
 
-/// Rotate left helper - AVX2 doesn't have a rotate instruction
+/// 32-bit rotate-left for AVX2 using variable-shift intrinsics.
+///
+/// AVX2 has no native rotate, so this pairs `_mm256_sllv_epi32` with
+/// `_mm256_srlv_epi32` and OR. Variable shifts let the shift amount be
+/// a runtime value.
 #[target_feature(enable = "avx2")]
 unsafe fn rotl(x: __m256i, n: i32) -> __m256i {
     _mm256_or_si256(
@@ -43,10 +47,16 @@ unsafe fn rotl(x: __m256i, n: i32) -> __m256i {
     )
 }
 
-/// Compute MD4 digests for up to 8 inputs in parallel using AVX2.
+/// Compute MD4 digests for 8 inputs in parallel using AVX2.
+///
+/// Returns digests in the same order as `inputs`. Lanes with shorter inputs
+/// are masked off via `_mm256_blendv_epi8` after their final block. Inputs
+/// larger than 1 MiB fall back to the scalar path to cap padding allocations.
 ///
 /// # Safety
-/// Caller must ensure AVX2 is available.
+///
+/// Caller must ensure AVX2 is available; verify at runtime with
+/// `is_x86_feature_detected!("avx2")` before calling.
 #[target_feature(enable = "avx2")]
 pub unsafe fn digest_x8(inputs: &[&[u8]; 8]) -> [Digest; 8] {
     // Find the maximum length to determine block count

--- a/crates/checksums/src/simd_batch/md4/simd/avx512.rs
+++ b/crates/checksums/src/simd_batch/md4/simd/avx512.rs
@@ -11,10 +11,6 @@ use std::arch::asm;
 use super::super::super::Digest;
 
 /// MD4 initial state constants (RFC 1320).
-///
-/// These magic constants initialize the MD4 hash state. They represent
-/// the first 32 bits of the fractional parts of the cube roots of the
-/// first four prime numbers (2, 3, 5, 7).
 const INIT_A: u32 = 0x6745_2301;
 const INIT_B: u32 = 0xefcd_ab89;
 const INIT_C: u32 = 0x98ba_dcfe;
@@ -22,98 +18,38 @@ const INIT_D: u32 = 0x1032_5476;
 
 /// Round constants for MD4 (RFC 1320).
 ///
-/// MD4 uses three round constants:
-/// - Round 1 (steps 0-15): 0 (no constant added)
-/// - Round 2 (steps 16-31): 0x5A827999 (sqrt(2) fractional part scaled)
-/// - Round 3 (steps 32-47): 0x6ED9EBA1 (sqrt(3) fractional part scaled)
+/// Round 1 (steps 0-15) adds 0; round 2 (16-31) adds `0x5A827999` (scaled
+/// sqrt(2)); round 3 (32-47) adds `0x6ED9EBA1` (scaled sqrt(3)).
 const K: [u32; 3] = [
     0x0000_0000, // Round 1
     0x5A82_7999, // Round 2
     0x6ED9_EBA1, // Round 3
 ];
 
-// Message word indices for round 2 (used in round macros below):
-// [0, 4, 8, 12, 1, 5, 9, 13, 2, 6, 10, 14, 3, 7, 11, 15]
-// Maps to zmm registers: [8, 12, 16, 20, 9, 13, 17, 21, 10, 14, 18, 22, 11, 15, 19, 23]
+// Message schedules consumed inside the round! macros below:
+// M2 = [0, 4, 8, 12, 1, 5, 9, 13, 2, 6, 10, 14, 3, 7, 11, 15]
+// M3 = [0, 8, 4, 12, 2, 10, 6, 14, 1, 9, 5, 13, 3, 11, 7, 15]
 
-// Message word indices for round 3 (used in round macros below):
-// [0, 8, 4, 12, 2, 10, 6, 14, 1, 9, 5, 13, 3, 11, 7, 15]
-// Maps to zmm registers: [8, 16, 12, 20, 10, 18, 14, 22, 9, 17, 13, 21, 11, 19, 15, 23]
-
-/// 64-byte aligned storage for 16 u32 values.
+/// 64-byte aligned 16x u32 storage for ZMM register loads/stores.
 ///
-/// This type ensures proper 64-byte alignment required for efficient AVX-512 operations.
-/// Each instance holds 16 32-bit values that are accessed by a single ZMM register load/store.
-///
-/// The 64-byte alignment matches cache line boundaries on most modern CPUs, reducing
-/// the risk of cache line splits and improving memory access performance.
+/// AVX-512 ZMM moves perform best on 64-byte-aligned addresses, which also
+/// matches the cache line on most modern CPUs.
 #[repr(C, align(64))]
 struct Aligned512([u32; 16]);
 
 /// Compute MD4 digests for 16 inputs in parallel using AVX-512.
 ///
-/// This function processes 16 independent MD4 hash computations simultaneously using
-/// AVX-512 SIMD instructions, providing significant performance improvements over
-/// sequential hashing when multiple inputs need to be processed.
-///
-/// # Algorithm
-///
-/// Uses 512-bit ZMM registers to compute 16 MD4 hashes in parallel through data-level
-/// parallelism. The implementation uses inline assembly to access AVX-512F and AVX-512BW
-/// instructions on stable Rust. Data is organized in a "transposed" layout where each
-/// ZMM register holds the same field (e.g., message word 0) from all 16 inputs.
-///
-/// # Performance
-///
-/// - **Throughput**: Processes 16 hashes with only ~16x the latency of a single hash
-/// - **Best for**: Batches of similarly-sized inputs (e.g., legacy protocol checksums)
-/// - **Fallback**: Inputs larger than 1MB automatically fall back to scalar implementation
-///   to avoid excessive memory allocation
-/// - **Requirements**: Requires AVX-512F and AVX-512BW CPU features (Intel Skylake-X or later,
-///   AMD Zen 4 or later)
-///
-/// # Parameters
-///
-/// * `inputs` - Array of exactly 16 byte slices to hash. Each slice can be any length,
-///   though performance is optimal when all inputs are similar in size.
-///
-/// # Returns
-///
-/// Array of 16 MD4 digests (16-byte arrays) corresponding to each input in the same order.
+/// Inputs are padded to 64-byte block boundaries and processed in lockstep
+/// across 16 lanes; per-lane opmask handling keeps short lanes inactive while
+/// longer lanes continue. Inputs larger than 1 MiB fall back to scalar to
+/// cap padding allocations. Implements the full RFC 1320 48-round MD4
+/// compression function.
 ///
 /// # Safety
 ///
-/// Caller must ensure AVX-512F and AVX-512BW CPU features are available at runtime.
-/// The dispatcher module verifies this before calling this function. Calling this
-/// function on a CPU without these features will result in an illegal instruction fault.
-///
-/// # Security Warning
-///
-/// MD4 is cryptographically broken and should not be used for security purposes.
-/// This implementation is provided for compatibility with legacy systems only.
-/// For secure hashing, use SHA-2 or SHA-3 family algorithms.
-///
-/// # Examples
-///
-/// ```ignore
-/// // Prepare 16 inputs to hash in parallel
-/// let inputs: [&[u8]; 16] = [
-///     b"input 0", b"input 1", b"input 2", b"input 3",
-///     b"input 4", b"input 5", b"input 6", b"input 7",
-///     b"input 8", b"input 9", b"input 10", b"input 11",
-///     b"input 12", b"input 13", b"input 14", b"input 15",
-/// ];
-///
-/// // Safety: Caller must ensure AVX-512F and AVX-512BW are available.
-/// let digests = unsafe { digest_x16(&inputs) };
-/// ```
-///
-/// # Implementation Notes
-///
-/// - Handles variable-length inputs by padding each to the nearest 64-byte block boundary
-/// - Processes blocks in lockstep, using masking to handle inputs of different lengths
-/// - Uses transposed data layout for efficient SIMD processing
-/// - Implements full MD4 specification (RFC 1320) including all 48 rounds (3 rounds of 16 steps)
+/// Caller must verify AVX-512F and AVX-512BW are available at runtime.
+/// Invoking this on a CPU without these features triggers an illegal-
+/// instruction fault.
 #[cfg(target_arch = "x86_64")]
 pub unsafe fn digest_x16(inputs: &[&[u8]; 16]) -> [Digest; 16] {
     // Find the maximum length to determine block count
@@ -202,40 +138,20 @@ pub unsafe fn digest_x16(inputs: &[&[u8]; 16]) -> [Digest; 16] {
     results
 }
 
-/// Process a single MD4 block for 16 lanes using AVX-512 inline assembly.
+/// Apply one MD4 block in parallel across 16 lanes via AVX-512 inline assembly.
 ///
-/// This is the core computation kernel that implements the MD4 compression function
-/// for 16 independent hash states in parallel. It processes one 64-byte block for
-/// each of the 16 lanes simultaneously.
+/// Implements the RFC 1320 48-round compression function: round 1 (F, K=0),
+/// round 2 (G, K=0x5A827999), round 3 (H, K=0x6ED9EBA1). `mask_bits` is a
+/// 16-bit lane mask (bit i selects lane i) used through `vpblendmd` so
+/// short-input lanes are not advanced past their final block.
 ///
-/// # Algorithm
-///
-/// Implements the 48-round MD4 compression function (RFC 1320):
-/// - Round 1 (0-15): F function with message schedule [0..15], no added constant
-/// - Round 2 (16-31): G function with permuted message schedule, K = 0x5A827999
-/// - Round 3 (32-47): H function with permuted message schedule, K = 0x6ED9EBA1
-///
-/// # Parameters
-///
-/// * `state_a`, `state_b`, `state_c`, `state_d` - MD4 state registers for all 16 lanes
-/// * `m` - Transposed message words (16 arrays of 16 u32 values each)
-/// * `mask_bits` - Bitmask indicating which lanes are active (bit i = lane i)
-///
-/// # Implementation
-///
-/// Uses inline assembly to efficiently utilize AVX-512 instructions including:
-/// - `vpternlogd` for computing MD4 auxiliary functions
-/// - `vprold` for rotation operations
-/// - `vpblendmd` for conditional updates based on lane mask
-/// - `vmovdqa32/vmovdqu32` for aligned/unaligned loads and stores
-///
-/// The function is marked `#[inline(never)]` to reduce code size, as it contains
-/// substantial inline assembly that doesn't benefit from inlining.
+/// Marked `#[inline(never)]` because the asm body is large enough that
+/// inlining bloats call sites without speedup.
 ///
 /// # Safety
 ///
-/// Requires AVX-512F and AVX-512BW to be available. Violating this precondition
-/// results in undefined behavior (illegal instruction fault).
+/// Caller must guarantee AVX-512F and AVX-512BW are available; violating
+/// this triggers an illegal-instruction fault.
 #[cfg(target_arch = "x86_64")]
 #[inline(never)]
 unsafe fn process_block_avx512(

--- a/crates/checksums/src/simd_batch/md4/simd/neon.rs
+++ b/crates/checksums/src/simd_batch/md4/simd/neon.rs
@@ -33,7 +33,10 @@ const M3: [usize; 16] = [0, 8, 4, 12, 2, 10, 6, 14, 1, 9, 5, 13, 3, 11, 7, 15];
 /// Maximum input size supported.
 const MAX_INPUT_SIZE: usize = 1_024 * 1_024; // 1MB per input
 
-/// Macro for compile-time rotate left.
+/// 32-bit rotate-left for NEON; shift amount must be a const generic.
+///
+/// NEON has no native rotate, so this pairs `vshlq_n_u32::<N>` with
+/// `vshrq_n_u32::<{ 32 - N }>` and OR.
 macro_rules! rotl_const {
     ($x:expr, $n:expr) => {{
         let left = vshlq_n_u32::<$n>($x);
@@ -42,10 +45,16 @@ macro_rules! rotl_const {
     }};
 }
 
-/// Compute MD4 digests for up to 4 inputs in parallel using NEON.
+/// Compute MD4 digests for 4 inputs in parallel using ARM NEON.
+///
+/// Returns digests in the same order as `inputs`. Lanes with shorter inputs
+/// are masked off via `vbslq_u32` after their final block. Inputs larger
+/// than 1 MiB fall back to the scalar path to cap padding allocations.
 ///
 /// # Safety
-/// Caller must ensure NEON is available (mandatory on aarch64).
+///
+/// Caller must ensure NEON is available. NEON is mandatory on aarch64
+/// (ARMv8-A baseline), so this is always satisfied on 64-bit ARM.
 #[cfg(target_arch = "aarch64")]
 #[allow(unsafe_op_in_unsafe_fn)]
 pub unsafe fn digest_x4(inputs: &[&[u8]; 4]) -> [Digest; 4] {

--- a/crates/checksums/src/simd_batch/md4/simd/sse2.rs
+++ b/crates/checksums/src/simd_batch/md4/simd/sse2.rs
@@ -31,7 +31,11 @@ const M3: [usize; 16] = [0, 8, 4, 12, 2, 10, 6, 14, 1, 9, 5, 13, 3, 11, 7, 15];
 /// Maximum input size supported.
 const MAX_INPUT_SIZE: usize = 1_024 * 1_024;
 
-/// Rotate left macro for SSE2 (requires compile-time constant).
+/// Rotate-left helper for SSE2 (requires a compile-time shift constant).
+///
+/// SSE2 has no native rotate; each arm pairs `_mm_slli_epi32` with
+/// `_mm_srli_epi32` and OR. Arms cover only the MD4 shift amounts
+/// `{3, 5, 7, 9, 11, 13, 15, 19}`.
 macro_rules! rotl {
     ($x:expr, 3) => {
         _mm_or_si128(_mm_slli_epi32($x, 3), _mm_srli_epi32($x, 29))
@@ -59,10 +63,16 @@ macro_rules! rotl {
     };
 }
 
-/// Compute MD4 digests for up to 4 inputs in parallel using SSE2.
+/// Compute MD4 digests for 4 inputs in parallel using SSE2.
+///
+/// Returns digests in the same order as `inputs`. Lanes with shorter inputs
+/// are masked off via AND/ANDNOT/OR after their final block. Inputs larger
+/// than 1 MiB fall back to scalar to cap padding allocations.
 ///
 /// # Safety
-/// Caller must ensure SSE2 is available (always true on x86_64).
+///
+/// Caller must ensure SSE2 is available; SSE2 is part of the x86_64
+/// baseline so this is always satisfied on 64-bit Intel/AMD.
 #[target_feature(enable = "sse2")]
 pub unsafe fn digest_x4(inputs: &[&[u8]; 4]) -> [Digest; 4] {
     let max_len = inputs.iter().map(|i| i.len()).max().unwrap_or(0);

--- a/crates/checksums/src/simd_batch/md4/simd/wasm.rs
+++ b/crates/checksums/src/simd_batch/md4/simd/wasm.rs
@@ -27,14 +27,21 @@ const M3: [usize; 16] = [0, 8, 4, 12, 2, 10, 6, 14, 1, 9, 5, 13, 3, 11, 7, 15];
 
 const MAX_INPUT_SIZE: usize = 1_024 * 1_024;
 
-/// Rotate left for WASM SIMD.
+/// 32-bit rotate-left for WASM SIMD; shift may be a runtime value.
+///
+/// WASM SIMD has no native rotate, so this pairs `i32x4_shl` with
+/// `u32x4_shr` and OR.
 #[cfg(target_arch = "wasm32")]
 #[inline(always)]
 fn rotl(x: v128, n: u32) -> v128 {
     v128_or(i32x4_shl(x, n), u32x4_shr(x, 32 - n))
 }
 
-/// Compute MD4 digests for up to 4 inputs in parallel using WASM SIMD.
+/// Compute MD4 digests for 4 inputs in parallel using WASM SIMD.
+///
+/// Returns digests in the same order as `inputs`. Available only when
+/// compiling for `wasm32` with the `simd128` target feature; the
+/// non-SIMD WASM build falls through to the scalar `digest_x4` below.
 #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
 pub fn digest_x4(inputs: &[&[u8]; 4]) -> [Digest; 4] {
     let max_len = inputs.iter().map(|i| i.len()).max().unwrap_or(0);

--- a/crates/checksums/src/simd_batch/md5_simd/avx2.rs
+++ b/crates/checksums/src/simd_batch/md5_simd/avx2.rs
@@ -1,36 +1,13 @@
 //! AVX2 8-lane parallel MD5 implementation.
 //!
-//! Processes 8 independent MD5 computations simultaneously using 256-bit YMM registers.
-//!
-//! # CPU Feature Requirements
-//!
-//! - **AVX2**: Intel Haswell (2013+), AMD Excavator (2015+) or newer
-//! - Must be verified at runtime using `is_x86_feature_detected!("avx2")`
-//!
-//! # SIMD Strategy
-//!
-//! Similar to SSE2 but with twice the parallelism using 256-bit YMM registers.
-//! Each YMM register holds 8 lanes of 32-bit values, allowing 8 parallel MD5
-//! computations to proceed in lockstep.
+//! Processes 8 independent MD5 computations simultaneously using 256-bit YMM
+//! registers. AVX2 provides variable-shift instructions (`vpsllvd`/`vpsrlvd`)
+//! for efficient rotation and `vpblendvb` for cleaner lane masking compared to
+//! SSE2. CPU feature must be verified at runtime via
+//! `is_x86_feature_detected!("avx2")` (Intel Haswell 2013+, AMD Excavator 2015+).
+//! Inputs exceeding 1 MB fall back to scalar to avoid excessive padding allocation.
 
 #![allow(unsafe_op_in_unsafe_fn)]
-//!
-//! AVX2 provides significant advantages over SSE2:
-//! - Variable-shift instructions (`vpsllvd`/`vpsrlvd`) for efficient rotation
-//! - Native blend instruction (`vpblendvb`) for cleaner lane masking
-//! - 256-bit loads/stores for better memory bandwidth
-//!
-//! # Performance Characteristics
-//!
-//! - **Throughput**: ~8x scalar performance when all 8 lanes are active
-//! - **Latency**: Similar to scalar for single input
-//! - **Best use case**: Processing 8 or more inputs of similar lengths
-//! - **Efficiency**: ~2x throughput vs SSE2 with comparable energy
-//!
-//! # Input Size Limits
-//!
-//! Falls back to scalar implementation for inputs exceeding 1 MB to avoid
-//! excessive memory allocation for padding buffers.
 
 #[cfg(target_arch = "x86_64")]
 use std::arch::x86_64::*;
@@ -121,58 +98,33 @@ const K: [u32; 64] = [
 /// Maximum input size supported (can be increased if needed).
 const MAX_INPUT_SIZE: usize = 1_024 * 1_024; // 1MB per input
 
-/// Rotate left helper - AVX2 doesn't have a rotate instruction.
+/// 32-bit rotate-left for AVX2 using variable-shift intrinsics.
 ///
-/// Implements 32-bit rotate-left using AVX2's variable shift instructions.
-/// Unlike SSE2, AVX2 supports variable shift amounts via `vpsllvd`/`vpsrlvd`,
-/// allowing the shift amount to be a runtime value.
+/// AVX2 has no native rotate, so this pairs `_mm256_sllv_epi32` with
+/// `_mm256_srlv_epi32` and OR. Variable shifts let the shift amount be a
+/// runtime value, unlike the compile-time-constant requirement on SSE2.
 ///
 /// # Safety
 ///
-/// Requires AVX2 support. This is enforced by the `#[target_feature]` attribute.
+/// Requires AVX2; enforced by the `#[target_feature]` attribute.
 #[target_feature(enable = "avx2")]
 unsafe fn rotl(x: __m256i, n: i32) -> __m256i {
-    // Use variable shift for runtime values
     _mm256_or_si256(
         _mm256_sllv_epi32(x, _mm256_set1_epi32(n)),
         _mm256_srlv_epi32(x, _mm256_set1_epi32(32 - n)),
     )
 }
 
-/// Compute MD5 digests for up to 8 inputs in parallel using AVX2.
+/// Compute MD5 digests for 8 inputs in parallel using AVX2.
 ///
-/// Processes 8 independent byte slices in parallel, computing their MD5 digests
-/// simultaneously using 256-bit YMM registers.
-///
-/// # Arguments
-///
-/// * `inputs` - Array of 8 byte slices to hash
-///
-/// # Returns
-///
-/// Array of 8 MD5 digests (16 bytes each) in the same order as the inputs
-///
-/// # Performance
-///
-/// Best performance is achieved when:
-/// - All 8 input slots are used
-/// - Inputs have similar lengths (minimizes masked blocks)
-/// - Input sizes are reasonable (< 1 MB)
-/// - CPU supports AVX2 (Haswell/2013 or newer)
+/// Returns digests in the same order as `inputs`. Lanes with shorter inputs
+/// are masked off after their final block via `_mm256_blendv_epi8`. Inputs
+/// larger than 1 MiB fall back to the scalar path to cap padding allocations.
 ///
 /// # Safety
 ///
-/// Caller must ensure AVX2 is available. Use runtime detection before calling:
-///
-/// ```ignore
-/// if is_x86_feature_detected!("avx2") {
-///     let digests = unsafe { digest_x8(&inputs) };
-/// }
-/// ```
-///
-/// This function uses `unsafe` internally for:
-/// - AVX2 intrinsics (`_mm256_*` functions)
-/// - Aligned memory access via `_mm256_store_si256`
+/// Caller must ensure AVX2 is available; verify at runtime with
+/// `is_x86_feature_detected!("avx2")` before calling.
 #[target_feature(enable = "avx2")]
 pub unsafe fn digest_x8(inputs: &[&[u8]; 8]) -> [Digest; 8] {
     // Find the maximum length to determine block count

--- a/crates/checksums/src/simd_batch/md5_simd/avx512.rs
+++ b/crates/checksums/src/simd_batch/md5_simd/avx512.rs
@@ -1,46 +1,17 @@
 //! AVX-512 16-lane parallel MD5 implementation.
 //!
-//! Processes 16 independent MD5 computations simultaneously using 512-bit ZMM registers.
+//! Processes 16 independent MD5 computations simultaneously using 512-bit ZMM
+//! registers. Requires both AVX-512F (foundation) and AVX-512BW (byte/word)
+//! - Intel Skylake-X 2017+, AMD Zen 4 2022+ - and the caller must verify both
+//! via `is_x86_feature_detected!` before invoking [`digest_x16`].
 //!
-//! # CPU Feature Requirements
-//!
-//! - **AVX-512F**: Foundation instructions (Intel Skylake-X/2017+, AMD Zen 4/2022+)
-//! - **AVX-512BW**: Byte/word instructions (same CPU generations)
-//! - Must be verified at runtime using `is_x86_feature_detected!`
-//!
-//! # Implementation Strategy
-//!
-//! This implementation uses **inline assembly** rather than intrinsics because AVX-512
-//! intrinsics require nightly Rust. Inline assembly is stable as of Rust 1.59 and provides
-//! full access to AVX-512 instructions.
+//! Uses inline assembly rather than intrinsics because AVX-512 intrinsics still
+//! require nightly Rust. The kernel exploits `vprold` for native rotates,
+//! `vpternlogd` for the MD5 auxiliary functions, and opmask register `k1` for
+//! per-lane masking. AVX-512 can throttle CPU frequency on older Skylake-X;
+//! prefer the AVX2 backend if 16-wide parallelism is not warranted.
 
 #![allow(unsafe_op_in_unsafe_fn)]
-//!
-//! The assembly implementation:
-//! - Uses ZMM registers (zmm0-zmm30) for 512-bit operations
-//! - Leverages `vprold` for efficient rotation (AVX-512F native rotate)
-//! - Uses `vpternlogd` for computing MD5 round functions efficiently
-//! - Employs opmask registers (k1) for lane masking
-//!
-//! # Performance Characteristics
-//!
-//! - **Throughput**: ~16x scalar performance when all 16 lanes are active
-//! - **Latency**: Similar to scalar for single input
-//! - **Best use case**: High-throughput scenarios with 16+ inputs
-//! - **Efficiency**: Best on Ice Lake and newer (improved AVX-512 execution)
-//!
-//! # Power Considerations
-//!
-//! AVX-512 can cause CPU frequency throttling on some processors (Skylake-X).
-//! Modern CPUs (Ice Lake, Zen 4) have improved this significantly. Consider
-//! using AVX2 for workloads that don't benefit from 16-wide parallelism.
-//!
-//! # Safety
-//!
-//! All AVX-512 operations are performed via inline assembly, which is stable in Rust.
-//! The `digest_x16` function requires AVX-512F and AVX-512BW to be available, which
-//! must be verified at runtime by the caller before invoking this function.
-
 #![allow(unsafe_code)]
 
 #[cfg(target_arch = "x86_64")]
@@ -49,20 +20,12 @@ use std::arch::asm;
 use super::super::Digest;
 
 /// MD5 initial state constants (RFC 1321).
-///
-/// These magic constants initialize the MD5 hash state. They represent
-/// the first 32 bits of the fractional parts of the cube roots of the
-/// first four prime numbers (2, 3, 5, 7).
 const INIT_A: u32 = 0x6745_2301;
 const INIT_B: u32 = 0xefcd_ab89;
 const INIT_C: u32 = 0x98ba_dcfe;
 const INIT_D: u32 = 0x1032_5476;
 
-/// Pre-computed K constants for MD5 rounds (RFC 1321).
-///
-/// These 64 constants are derived from the sine function and are used as
-/// additive constants in the MD5 compression function. Specifically,
-/// K[i] = floor(2^32 × abs(sin(i + 1))).
+/// Pre-computed K constants (RFC 1321): `K[i] = floor(2^32 * abs(sin(i + 1)))`.
 const K: [u32; 64] = [
     0xd76a_a478,
     0xe8c7_b756,
@@ -130,81 +93,29 @@ const K: [u32; 64] = [
     0xeb86_d391,
 ];
 
-/// Maximum input size supported for parallel processing.
-///
-/// Inputs larger than this threshold automatically fall back to scalar processing
-/// to avoid excessive memory allocation for padded buffers. This limit balances
-/// memory usage with the benefits of parallel processing.
+/// Inputs larger than this fall back to scalar to cap padding allocations.
 const MAX_INPUT_SIZE: usize = 1_024 * 1_024; // 1MB per input
 
-/// Aligned storage for 512-bit (16 × 32-bit) values.
+/// 64-byte aligned 16x u32 storage for ZMM register loads/stores.
 ///
-/// This type ensures proper 64-byte alignment required for efficient AVX-512 operations.
-/// Each instance holds 16 32-bit values that are accessed by a single ZMM register load/store.
-///
-/// The 64-byte alignment matches cache line boundaries on most modern CPUs, reducing
-/// the risk of cache line splits and improving memory access performance.
+/// AVX-512 ZMM moves perform best on 64-byte-aligned addresses, which also
+/// matches the cache line on most modern CPUs.
 #[repr(C, align(64))]
 struct Aligned512([u32; 16]);
 
 /// Compute MD5 digests for 16 inputs in parallel using AVX-512.
 ///
-/// This function processes 16 independent MD5 hash computations simultaneously using
-/// AVX-512 SIMD instructions, providing significant performance improvements over
-/// sequential hashing when multiple inputs need to be processed.
-///
-/// # Algorithm
-///
-/// Uses 512-bit ZMM registers to compute 16 MD5 hashes in parallel through data-level
-/// parallelism. The implementation uses inline assembly to access AVX-512F and AVX-512BW
-/// instructions on stable Rust. Data is organized in a "transposed" layout where each
-/// ZMM register holds the same field (e.g., message word 0) from all 16 inputs.
-///
-/// # Performance
-///
-/// - **Throughput**: Processes 16 hashes with only ~16x the latency of a single hash
-/// - **Best for**: Batches of similarly-sized inputs (e.g., file checksums, password hashing)
-/// - **Fallback**: Inputs larger than 1MB automatically fall back to scalar implementation
-///   to avoid excessive memory allocation
-/// - **Requirements**: Requires AVX-512F and AVX-512BW CPU features (Intel Skylake-X or later,
-///   AMD Zen 4 or later)
-///
-/// # Parameters
-///
-/// * `inputs` - Array of exactly 16 byte slices to hash. Each slice can be any length,
-///   though performance is optimal when all inputs are similar in size.
-///
-/// # Returns
-///
-/// Array of 16 MD5 digests (16-byte arrays) corresponding to each input in the same order.
+/// Inputs are padded to 64-byte block boundaries and processed in lockstep
+/// across 16 lanes; per-lane opmask handling keeps short lanes inactive while
+/// longer lanes continue. Inputs larger than 1 MiB fall back to scalar to
+/// cap padding allocations. Implements the full RFC 1321 64-round MD5
+/// compression function.
 ///
 /// # Safety
 ///
-/// Caller must ensure AVX-512F and AVX-512BW CPU features are available at runtime.
-/// The dispatcher module verifies this before calling this function. Calling this
-/// function on a CPU without these features will result in an illegal instruction fault.
-///
-/// # Examples
-///
-/// ```ignore
-/// // Prepare 16 inputs to hash in parallel
-/// let inputs: [&[u8]; 16] = [
-///     b"input 0", b"input 1", b"input 2", b"input 3",
-///     b"input 4", b"input 5", b"input 6", b"input 7",
-///     b"input 8", b"input 9", b"input 10", b"input 11",
-///     b"input 12", b"input 13", b"input 14", b"input 15",
-/// ];
-///
-/// // Safety: Caller must ensure AVX-512F and AVX-512BW are available.
-/// let digests = unsafe { digest_x16(&inputs) };
-/// ```
-///
-/// # Implementation Notes
-///
-/// - Handles variable-length inputs by padding each to the nearest 64-byte block boundary
-/// - Processes blocks in lockstep, using masking to handle inputs of different lengths
-/// - Uses transposed data layout for efficient SIMD processing
-/// - Implements full MD5 specification (RFC 1321) including all 64 rounds
+/// Caller must verify AVX-512F and AVX-512BW are available at runtime.
+/// Invoking this on a CPU without these features triggers an illegal-
+/// instruction fault.
 #[cfg(target_arch = "x86_64")]
 pub unsafe fn digest_x16(inputs: &[&[u8]; 16]) -> [Digest; 16] {
     // Find the maximum length to determine block count
@@ -294,41 +205,20 @@ pub unsafe fn digest_x16(inputs: &[&[u8]; 16]) -> [Digest; 16] {
     })
 }
 
-/// Process a single MD5 block for 16 lanes using AVX-512 inline assembly.
+/// Apply one MD5 block in parallel across 16 lanes via AVX-512 inline assembly.
 ///
-/// This is the core computation kernel that implements the MD5 compression function
-/// for 16 independent hash states in parallel. It processes one 64-byte block for
-/// each of the 16 lanes simultaneously.
+/// Implements the RFC 1321 64-round compression function: rounds 0-15 use F
+/// with message schedule [0..15], 16-31 use G, 32-47 use H, 48-63 use I.
+/// `mask_bits` is a 16-bit lane mask (bit i selects lane i) used through
+/// `vpblendmd` so short-input lanes are not advanced past their final block.
 ///
-/// # Algorithm
-///
-/// Implements the 64-round MD5 compression function (RFC 1321):
-/// - Rounds 0-15: F function with message schedule [0..15]
-/// - Rounds 16-31: G function with permuted message schedule
-/// - Rounds 32-47: H function with permuted message schedule
-/// - Rounds 48-63: I function with permuted message schedule
-///
-/// # Parameters
-///
-/// * `state_a`, `state_b`, `state_c`, `state_d` - MD5 state registers for all 16 lanes
-/// * `m` - Transposed message words (16 arrays of 16 u32 values each)
-/// * `mask_bits` - Bitmask indicating which lanes are active (bit i = lane i)
-///
-/// # Implementation
-///
-/// Uses inline assembly to efficiently utilize AVX-512 instructions including:
-/// - `vpternlogd` for computing MD5 auxiliary functions
-/// - `vprold` for rotation operations
-/// - `vpblendmd` for conditional updates based on lane mask
-/// - `vmovdqa32/vmovdqu32` for aligned/unaligned loads and stores
-///
-/// The function is marked `#[inline(never)]` to reduce code size, as it contains
-/// substantial inline assembly that doesn't benefit from inlining.
+/// Marked `#[inline(never)]` because the asm body is large enough that
+/// inlining bloats call sites without speedup.
 ///
 /// # Safety
 ///
-/// Requires AVX-512F and AVX-512BW to be available. Violating this precondition
-/// results in undefined behavior (illegal instruction fault).
+/// Caller must guarantee AVX-512F and AVX-512BW are available; violating
+/// this triggers an illegal-instruction fault.
 #[cfg(target_arch = "x86_64")]
 #[inline(never)]
 unsafe fn process_block_avx512(

--- a/crates/checksums/src/simd_batch/md5_simd/avx512.rs
+++ b/crates/checksums/src/simd_batch/md5_simd/avx512.rs
@@ -1,9 +1,9 @@
 //! AVX-512 16-lane parallel MD5 implementation.
 //!
 //! Processes 16 independent MD5 computations simultaneously using 512-bit ZMM
-//! registers. Requires both AVX-512F (foundation) and AVX-512BW (byte/word)
-//! - Intel Skylake-X 2017+, AMD Zen 4 2022+ - and the caller must verify both
-//! via `is_x86_feature_detected!` before invoking [`digest_x16`].
+//! registers. Requires both AVX-512F (foundation) and AVX-512BW (byte/word),
+//! available on Intel Skylake-X 2017+ and AMD Zen 4 2022+; the caller must
+//! verify both via `is_x86_feature_detected!` before invoking [`digest_x16`].
 //!
 //! Uses inline assembly rather than intrinsics because AVX-512 intrinsics still
 //! require nightly Rust. The kernel exploits `vprold` for native rotates,

--- a/crates/checksums/src/simd_batch/md5_simd/neon.rs
+++ b/crates/checksums/src/simd_batch/md5_simd/neon.rs
@@ -1,38 +1,11 @@
 //! ARM NEON 4-lane parallel MD5 implementation.
 //!
-//! Processes 4 independent MD5 computations simultaneously using 128-bit NEON registers.
-//!
-//! # CPU Feature Requirements
-//!
-//! - **NEON**: Mandatory on aarch64 (ARMv8-A baseline)
-//! - No runtime feature detection needed on 64-bit ARM
-//!
-//! # SIMD Strategy
-//!
-//! NEON provides 128-bit registers similar to SSE2, but with different instruction
-//! semantics. The implementation uses NEON's efficient bitwise operations:
-//!
-//! - `vbic` (bit clear) for AND-NOT operations
-//! - `vorn` (OR-NOT) for the I-function in round 4
-//! - `vbsl` (bit select) for efficient lane masking
-//!
-//! Rotation is implemented using compile-time constant shifts (`vshlq_n_u32`/`vshrq_n_u32`)
-//! combined with OR, similar to SSE2 but with unsigned types for cleaner semantics.
-//!
-//! # Performance Characteristics
-//!
-//! - **Throughput**: ~4x scalar performance when all 4 lanes are active
-//! - **Latency**: Similar to scalar for single input
-//! - **Best use case**: Processing 4 or more inputs on ARM servers or mobile devices
-//! - **Power efficiency**: Excellent for ARM-based cloud instances
-//!
-//! # Platform Availability
-//!
-//! This backend is used on:
-//! - AWS Graviton (ARMv8.2+)
-//! - Apple Silicon M1/M2 (ARMv8.5+)
-//! - Ampere Altra (ARMv8.2+)
-//! - Mobile devices (Android, iOS)
+//! Processes 4 independent MD5 computations simultaneously using 128-bit NEON
+//! registers. NEON is mandatory on aarch64 (ARMv8-A baseline), so no runtime
+//! feature detection is required. The kernel uses `vbic` (bit clear) for
+//! AND-NOT, `vorn` for the I round 4 function, and `vbsl` for lane masking.
+//! Rotation uses paired `vshlq_n_u32` / `vshrq_n_u32` with OR (compile-time
+//! shift constants), since NEON has no native rotate.
 
 #[cfg(target_arch = "aarch64")]
 use std::arch::aarch64::*;
@@ -129,35 +102,16 @@ macro_rules! rotl_const {
     }};
 }
 
-/// Compute MD5 digests for up to 4 inputs in parallel using NEON.
+/// Compute MD5 digests for 4 inputs in parallel using ARM NEON.
 ///
-/// Processes 4 independent byte slices in parallel, computing their MD5 digests
-/// simultaneously using ARM NEON 128-bit registers.
-///
-/// # Arguments
-///
-/// * `inputs` - Array of 4 byte slices to hash
-///
-/// # Returns
-///
-/// Array of 4 MD5 digests (16 bytes each) in the same order as the inputs
-///
-/// # Performance
-///
-/// Best performance is achieved when:
-/// - All 4 input slots are used
-/// - Inputs have similar lengths (minimizes masked blocks)
-/// - Running on modern ARM processors (ARMv8+)
+/// Returns digests in the same order as `inputs`. Lanes with shorter inputs
+/// are masked off via `vbslq_u32` after their final block. Inputs larger
+/// than 1 MiB fall back to the scalar path to cap padding allocations.
 ///
 /// # Safety
 ///
-/// Caller must ensure NEON is available. On aarch64, NEON is mandatory
-/// (part of the ARMv8-A baseline), so this function is always safe to
-/// call on 64-bit ARM platforms.
-///
-/// This function uses `unsafe` internally for:
-/// - NEON intrinsics (`v*` functions from `std::arch::aarch64`)
-/// - Aligned memory access via `vst1q_u32`
+/// Caller must ensure NEON is available. NEON is mandatory on aarch64
+/// (ARMv8-A baseline), so this is always satisfied on 64-bit ARM.
 #[cfg(target_arch = "aarch64")]
 #[target_feature(enable = "neon")]
 #[allow(unsafe_op_in_unsafe_fn)]

--- a/crates/checksums/src/simd_batch/md5_simd/sse2.rs
+++ b/crates/checksums/src/simd_batch/md5_simd/sse2.rs
@@ -1,40 +1,14 @@
 //! SSE2 4-lane parallel MD5 implementation.
 //!
-//! Processes 4 independent MD5 computations simultaneously using 128-bit XMM registers.
-//!
-//! # CPU Feature Requirements
-//!
-//! - **SSE2**: Always available on x86_64 (baseline requirement)
-//! - No runtime feature detection needed on 64-bit platforms
-//!
-//! # SIMD Strategy
-//!
-//! This implementation uses a transposed data layout where each XMM register holds
-//! the same state variable (A, B, C, or D) for all 4 parallel computations. The MD5
-//! algorithm's 64 rounds are executed in parallel across all lanes.
+//! Processes 4 independent MD5 computations simultaneously using 128-bit XMM
+//! registers. SSE2 is the x86_64 baseline, so no runtime feature detection is
+//! required. Each XMM register holds the same MD5 state variable (A, B, C, or D)
+//! for all 4 lanes; message words are loaded transposed (word N from all 4
+//! inputs) so the 64 MD5 rounds run in lockstep across lanes. SSE2 lacks a
+//! blend instruction, so lane masking uses AND/ANDNOT/OR. Inputs exceeding 1 MB
+//! fall back to scalar to avoid excessive padding allocation.
 
 #![allow(unsafe_op_in_unsafe_fn)]
-//!
-//! Message words are loaded in transposed order: for each of the 16 message words,
-//! we load word N from all 4 inputs into a single XMM register. This allows efficient
-//! parallel processing of the MD5 rounds.
-//!
-//! # Performance Characteristics
-//!
-//! - **Throughput**: ~4x scalar performance when all 4 lanes are active
-//! - **Latency**: Similar to scalar for single input
-//! - **Best use case**: Processing 4 or more inputs of similar lengths
-//!
-//! # Lane Masking
-//!
-//! When inputs have different lengths (requiring different numbers of blocks), inactive
-//! lanes are masked out using bitwise operations. The implementation uses SSE2's AND/ANDNOT/OR
-//! instructions for masking since SSE2 lacks dedicated blend instructions.
-//!
-//! # Input Size Limits
-//!
-//! Falls back to scalar implementation for inputs exceeding 1 MB to avoid excessive
-//! memory allocation for padding buffers.
 
 #[cfg(target_arch = "x86_64")]
 use std::arch::x86_64::*;
@@ -118,11 +92,11 @@ const K: [u32; 64] = [
 /// Maximum input size supported.
 const MAX_INPUT_SIZE: usize = 1_024 * 1_024;
 
-/// Rotate left macro for SSE2 (requires compile-time constant).
+/// Rotate-left helper for SSE2 (requires a compile-time shift constant).
 ///
-/// SSE2 lacks a rotate instruction, so rotation is implemented using
-/// logical left shift combined with logical right shift and OR.
-/// The shift amounts must be compile-time constants.
+/// SSE2 has no native rotate, so each arm pairs `_mm_slli_epi32` with
+/// `_mm_srli_epi32` and OR. Each MD5 shift amount used by the four rounds
+/// gets its own arm.
 macro_rules! rotl {
     ($x:expr, 4) => {
         _mm_or_si128(_mm_slli_epi32($x, 4), _mm_srli_epi32($x, 28))
@@ -174,43 +148,16 @@ macro_rules! rotl {
     };
 }
 
-/// Compute MD5 digests for up to 4 inputs in parallel using SSE2.
+/// Compute MD5 digests for 4 inputs in parallel using SSE2.
 ///
-/// Processes 4 independent byte slices in parallel, computing their MD5 digests
-/// simultaneously. The implementation handles inputs of varying lengths by using
-/// lane masking for blocks that don't exist in shorter inputs.
-///
-/// # Arguments
-///
-/// * `inputs` - Array of 4 byte slices to hash
-///
-/// # Returns
-///
-/// Array of 4 MD5 digests (16 bytes each) in the same order as the inputs
-///
-/// # Performance
-///
-/// Best performance is achieved when:
-/// - All 4 input slots are used
-/// - Inputs have similar lengths (minimizes masked blocks)
-/// - Input sizes are reasonable (< 1 MB)
+/// Returns digests in the same order as `inputs`. Lanes with shorter inputs
+/// are masked off after their final block via AND/ANDNOT/OR. Inputs larger
+/// than 1 MiB fall back to the scalar path to cap padding allocations.
 ///
 /// # Safety
 ///
-/// Caller must ensure SSE2 is available. On x86_64, SSE2 is always available
-/// as it's part of the baseline ISA, so this function is always safe to call
-/// on 64-bit platforms.
-///
-/// This function uses `unsafe` internally for:
-/// - SSE2 intrinsics (`_mm_*` functions)
-/// - Aligned memory access via `_mm_store_si128`
-///
-/// # Examples
-///
-/// ```ignore
-/// let inputs = [b"hello", b"world", b"foo", b"bar"];
-/// let digests = unsafe { digest_x4(&inputs) };
-/// ```
+/// Caller must ensure SSE2 is available. SSE2 is part of the x86_64 baseline,
+/// so this is always satisfied on 64-bit Intel/AMD platforms.
 #[target_feature(enable = "sse2")]
 pub unsafe fn digest_x4(inputs: &[&[u8]; 4]) -> [Digest; 4] {
     let max_len = inputs.iter().map(|i| i.len()).max().unwrap_or(0);

--- a/crates/checksums/src/simd_batch/md5_simd/sse41.rs
+++ b/crates/checksums/src/simd_batch/md5_simd/sse41.rs
@@ -1,36 +1,12 @@
 //! SSE4.1 4-lane parallel MD5 implementation.
 //!
-//! Processes 4 independent MD5 computations simultaneously using 128-bit XMM registers.
-//!
-//! # CPU Feature Requirements
-//!
-//! - **SSE4.1**: Intel Penryn (2007+), AMD Bulldozer (2011+) or newer
-//! - Must be verified at runtime using `is_x86_feature_detected!("sse4.1")`
-//!
-//! # SIMD Strategy
-//!
-//! SSE4.1 provides a significant improvement over SSE2/SSSE3 with the `blendv`
-//! instruction family. This implementation uses `_mm_blendv_epi8` for efficient
-//! lane masking when inputs have different lengths.
+//! Processes 4 independent MD5 computations simultaneously using 128-bit XMM
+//! registers. SSE4.1 (Intel Penryn 2007+, AMD Bulldozer 2011+) must be verified
+//! at runtime via `is_x86_feature_detected!("sse4.1")`. Uses `_mm_blendv_epi8`
+//! for lane masking, replacing the three-instruction AND/ANDNOT/OR sequence
+//! required by SSE2 - a measurable win for inputs with varying block counts.
 
 #![allow(unsafe_op_in_unsafe_fn)]
-//!
-//! **Key advantage over SSE2**: The SSE2 implementation requires three instructions
-//! (AND, ANDNOT, OR) to implement conditional blending, while SSE4.1 does it in
-//! a single `blendv` instruction. This reduces instruction count and improves
-//! performance for inputs with varying lengths.
-//!
-//! # Performance Characteristics
-//!
-//! - **Throughput**: ~4x scalar performance
-//! - **Latency**: Similar to SSE2/SSSE3
-//! - **Best use case**: Processing inputs with varying block counts
-//! - **Efficiency**: Better than SSE2 for mixed-length inputs
-//!
-//! # Availability
-//!
-//! SSE4.1 is available on most processors from 2008 onwards but not guaranteed
-//! on all x86_64. Always use runtime detection before calling this implementation.
 
 #[cfg(target_arch = "x86_64")]
 use std::arch::x86_64::*;
@@ -165,39 +141,16 @@ macro_rules! rotl {
     };
 }
 
-/// Compute MD5 digests for up to 4 inputs in parallel using SSE4.1.
+/// Compute MD5 digests for 4 inputs in parallel using SSE4.1.
 ///
-/// Processes 4 independent byte slices in parallel, computing their MD5 digests
-/// simultaneously. Uses SSE4.1's `blendv` instruction for more efficient lane
-/// masking compared to SSE2.
-///
-/// # Arguments
-///
-/// * `inputs` - Array of 4 byte slices to hash
-///
-/// # Returns
-///
-/// Array of 4 MD5 digests (16 bytes each) in the same order as the inputs
-///
-/// # Performance
-///
-/// This implementation is particularly efficient when processing inputs of
-/// varying lengths, as the `blendv` instruction provides better masking
-/// performance than SSE2's manual AND/ANDNOT/OR sequence.
+/// Returns digests in the same order as `inputs`. Uses `_mm_blendv_epi8` for
+/// lane masking, which is faster than the AND/ANDNOT/OR sequence required by
+/// the SSE2 path - especially helpful for inputs with varying block counts.
 ///
 /// # Safety
 ///
-/// Caller must ensure SSE4.1 is available. Use runtime detection before calling:
-///
-/// ```ignore
-/// if is_x86_feature_detected!("sse4.1") {
-///     let digests = unsafe { digest_x4(&inputs) };
-/// }
-/// ```
-///
-/// This function uses `unsafe` internally for:
-/// - SSE4.1 intrinsics (`_mm_*` functions including `_mm_blendv_epi8`)
-/// - Aligned memory access via `_mm_store_si128`
+/// Caller must ensure SSE4.1 is available; verify at runtime with
+/// `is_x86_feature_detected!("sse4.1")` before calling.
 #[cfg(target_arch = "x86_64")]
 #[target_feature(enable = "sse4.1")]
 pub unsafe fn digest_x4(inputs: &[&[u8]; 4]) -> [Digest; 4] {

--- a/crates/checksums/src/simd_batch/md5_simd/ssse3.rs
+++ b/crates/checksums/src/simd_batch/md5_simd/ssse3.rs
@@ -1,37 +1,12 @@
 //! SSSE3 4-lane parallel MD5 implementation.
 //!
-//! Processes 4 independent MD5 computations simultaneously using 128-bit XMM registers.
-//!
-//! # CPU Feature Requirements
-//!
-//! - **SSSE3**: Supplemental SSE3 (Intel Core 2/2006+, AMD Bulldozer/2011+)
-//! - Must be verified at runtime using `is_x86_feature_detected!("ssse3")`
-//!
-//! # SIMD Strategy
-//!
-//! SSSE3 adds the `pshufb` (packed shuffle bytes) instruction which enables
-//! efficient byte reordering within XMM registers. While this implementation
-//! currently uses the same structure as SSE2, SSSE3 could be leveraged for:
+//! Processes 4 independent MD5 computations simultaneously using 128-bit XMM
+//! registers. SSSE3 (Intel Core 2 2006+, AMD Bulldozer 2011+) must be verified
+//! at runtime via `is_x86_feature_detected!("ssse3")`. The current code reuses
+//! the SSE2 structure; the dedicated SSSE3 backend exists so future revisions
+//! can leverage `pshufb` for byte reordering without disturbing the SSE2 path.
 
 #![allow(unsafe_op_in_unsafe_fn)]
-//!
-//! - More efficient byte swapping for endianness conversion
-//! - Optimized message word extraction from packed buffers
-//! - Potential improvements to the transposition step
-//!
-//! The current implementation serves as a baseline that can be enhanced with
-//! SSSE3-specific optimizations in the future.
-//!
-//! # Performance Characteristics
-//!
-//! - **Throughput**: ~4x scalar performance (similar to SSE2)
-//! - **Latency**: Similar to SSE2
-//! - **Best use case**: CPUs with SSSE3 but not SSE4.1 (older processors)
-//!
-//! # Availability
-//!
-//! SSSE3 is available on most modern processors but not guaranteed on all x86_64.
-//! Always use runtime detection before calling this implementation.
 
 #[cfg(target_arch = "x86_64")]
 use std::arch::x86_64::*;
@@ -166,33 +141,16 @@ macro_rules! rotl {
     };
 }
 
-/// Compute MD5 digests for up to 4 inputs in parallel using SSSE3.
+/// Compute MD5 digests for 4 inputs in parallel using SSSE3.
 ///
-/// Processes 4 independent byte slices in parallel, computing their MD5 digests
-/// simultaneously. The implementation is currently similar to SSE2 but targets
-/// CPUs with SSSE3 support.
-///
-/// # Arguments
-///
-/// * `inputs` - Array of 4 byte slices to hash
-///
-/// # Returns
-///
-/// Array of 4 MD5 digests (16 bytes each) in the same order as the inputs
+/// Returns digests in the same order as `inputs`. Currently mirrors the SSE2
+/// kernel; the dedicated SSSE3 entry point exists so future revisions can
+/// adopt `pshufb`-based byte handling without disturbing the SSE2 path.
 ///
 /// # Safety
 ///
-/// Caller must ensure SSSE3 is available. Use runtime detection before calling:
-///
-/// ```ignore
-/// if is_x86_feature_detected!("ssse3") {
-///     let digests = unsafe { digest_x4(&inputs) };
-/// }
-/// ```
-///
-/// This function uses `unsafe` internally for:
-/// - SSSE3/SSE2 intrinsics (`_mm_*` functions)
-/// - Aligned memory access via `_mm_store_si128`
+/// Caller must ensure SSSE3 is available; verify at runtime with
+/// `is_x86_feature_detected!("ssse3")` before calling.
 #[cfg(target_arch = "x86_64")]
 #[target_feature(enable = "ssse3")]
 pub unsafe fn digest_x4(inputs: &[&[u8]; 4]) -> [Digest; 4] {

--- a/crates/checksums/src/simd_batch/md5_simd/wasm.rs
+++ b/crates/checksums/src/simd_batch/md5_simd/wasm.rs
@@ -1,46 +1,11 @@
 //! WebAssembly SIMD 4-lane parallel MD5 implementation.
 //!
-//! Processes 4 independent MD5 computations simultaneously using 128-bit WASM SIMD.
-//!
-//! # CPU Feature Requirements
-//!
-//! - **WASM SIMD (simd128)**: WebAssembly SIMD proposal
-//! - Widely supported in modern browsers and runtimes
-//! - Feature must be enabled at compile time with `target_feature = "simd128"`
-//!
-//! # Platform Support
-//!
-//! WASM SIMD is supported in:
-//! - Chrome/Edge 91+ (May 2021)
-//! - Firefox 89+ (June 2021)
-//! - Safari 16.4+ (March 2023)
-//! - Node.js 16.4+ with V8 9.1+
-//! - Wasmtime, Wasmer (modern versions)
-//!
-//! # SIMD Strategy
-//!
-//! WASM SIMD provides 128-bit vectors similar to SSE2, but with a portable
-//! instruction set that works across all architectures (x86, ARM, RISC-V).
-//!
-//! The implementation uses:
-//! - `v128` type for 128-bit SIMD values
-//! - `i32x4` operations for 32-bit integer lanes
-//! - `v128_bitselect` for efficient lane masking (similar to SSE4.1's blendv)
-//! - Manual rotation using shifts and OR (no native rotate instruction)
-//!
-//! # Performance Characteristics
-//!
-//! - **Throughput**: ~4x scalar performance (similar to SSE2/NEON)
-//! - **Portability**: Same code runs on x86, ARM, and other architectures
-//! - **Best use case**: Web applications, serverless functions, portable libraries
-//!
-//! # Differences from Native SIMD
-//!
-//! Unlike native x86/ARM SIMD, WASM SIMD:
-//! - Has no alignment requirements (but alignment can improve performance)
-//! - Always uses little-endian regardless of host
-//! - Provides `v128_bitselect` which is cleaner than SSE2 masking
-//! - Lacks specialized instructions like `pshufb` or hardware rotate
+//! Processes 4 independent MD5 computations simultaneously using 128-bit
+//! `v128` vectors. The `simd128` target feature must be enabled at compile
+//! time. Uses `i32x4` arithmetic, `v128_bitselect` for lane masking, and
+//! manual rotation via paired shifts plus OR (WASM SIMD has no native
+//! rotate). WASM SIMD is always little-endian and has no alignment
+//! requirements.
 
 #[cfg(target_arch = "wasm32")]
 use std::arch::wasm32::*;
@@ -124,54 +89,24 @@ const K: [u32; 64] = [
 /// Maximum input size supported.
 const MAX_INPUT_SIZE: usize = 1_024 * 1_024;
 
-/// Rotate left for WASM SIMD (requires runtime shift amount).
+/// 32-bit rotate-left for WASM SIMD; shift may be a runtime value.
 ///
-/// WASM SIMD lacks a native rotate instruction, so rotation is implemented
-/// using shifts and OR. Unlike SSE2, WASM SIMD supports runtime shift amounts
-/// without requiring compile-time constants.
-///
-/// This is a safe function (not `unsafe`) because WASM SIMD operations are
-/// inherently safe - they cannot cause undefined behavior.
+/// WASM SIMD has no native rotate, so this pairs `i32x4_shl` with
+/// `u32x4_shr` and OR. WASM SIMD operations cannot cause undefined
+/// behavior, so this function is safe rather than `unsafe`.
 #[cfg(target_arch = "wasm32")]
 #[inline(always)]
 fn rotl(x: v128, n: u32) -> v128 {
     v128_or(i32x4_shl(x, n), u32x4_shr(x, 32 - n))
 }
 
-/// Compute MD5 digests for up to 4 inputs in parallel using WASM SIMD.
+/// Compute MD5 digests for 4 inputs in parallel using WASM SIMD.
 ///
-/// Processes 4 independent byte slices in parallel, computing their MD5 digests
-/// simultaneously using WebAssembly SIMD instructions.
-///
-/// # Arguments
-///
-/// * `inputs` - Array of 4 byte slices to hash
-///
-/// # Returns
-///
-/// Array of 4 MD5 digests (16 bytes each) in the same order as the inputs
-///
-/// # Performance
-///
-/// WASM SIMD performance varies by runtime:
-/// - Browser engines: Near-native performance on modern V8/SpiderMonkey/JavaScriptCore
-/// - Standalone runtimes: Performance depends on JIT quality and host architecture
-/// - Generally achieves 3-4x speedup over scalar WASM code
-///
-/// # Platform Requirements
-///
-/// This function is only available when:
-/// - Compiling for `wasm32` target
-/// - The `simd128` target feature is enabled
-///
-/// Unlike native SIMD implementations, this is a **safe** function (not `unsafe`)
-/// because WASM SIMD operations cannot cause undefined behavior - they're
-/// sandboxed and validated by the WASM runtime.
-///
-/// # Availability
-///
-/// The function has a fallback for WASM without SIMD support that processes
-/// inputs sequentially using the scalar implementation.
+/// Returns digests in the same order as `inputs`. Lanes with shorter inputs
+/// are masked off via `v128_bitselect` after their final block. Inputs
+/// larger than 1 MiB fall back to the scalar path. Available only when
+/// compiling for `wasm32` with the `simd128` target feature; the
+/// non-SIMD WASM build falls through to a scalar `digest_x4` below.
 #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
 pub fn digest_x4(inputs: &[&[u8]; 4]) -> [Digest; 4] {
     let max_len = inputs.iter().map(|i| i.len()).max().unwrap_or(0);


### PR DESCRIPTION
## Summary
- Consolidate the MD5 SIMD module-doc blocks (`avx2`, `sse2`, `ssse3`, `sse41`, `avx512`) that were previously split by the `#![allow(unsafe_op_in_unsafe_fn)]` inner attribute, leaving everything after the attribute as orphaned documentation.
- Drop restating rustdoc on RFC-1320 / RFC-1321 constants and shrink verbose function docblocks down to the contract: lane width, masking strategy, 1 MiB scalar fallback, and CPU-feature gating.
- Preserve every `// SAFETY:` annotation (20 in total across `md4/mod.rs` and `md5_dispatcher.rs`), every `#[cfg(...)]` / `#[target_feature(...)]` gate, and the assembly-internal register-allocation comments in the AVX-512 inline-asm kernels.

## Test plan
- [ ] CI: fmt + clippy
- [ ] CI: nextest stable (Linux/macOS/Windows/musl)