### PR TITLE
docs(engine): rustdoc cleanup for local_copy::buffer_pool

### DIFF
--- a/crates/engine/src/local_copy/buffer_pool/throughput.rs
+++ b/crates/engine/src/local_copy/buffer_pool/throughput.rs
@@ -246,6 +246,7 @@ impl ThroughputTracker {
 }
 
 impl Default for ThroughputTracker {
+    /// Creates a tracker with the default smoothing factor ([`DEFAULT_ALPHA`]).
     fn default() -> Self {
         Self::new()
     }


### PR DESCRIPTION
## Summary

- Audit of `crates/engine/src/local_copy/buffer_pool/` (10 files, ~4,600 LoC) for rustdoc completeness and comment hygiene.
- All public items already carry concise rustdoc covering purpose, invariants, and edge cases. Internal `//` comments justify CAS/lock ordering, soft-cap admission, SAFETY claims, and the avoided `resize(size, 0)` memset hotspot.
- Module-level `//!` summaries are present on every file.
- Single material change: add a one-line rustdoc on `Default::default` for `ThroughputTracker` so `cargo doc` renders a description for the trait method.

## Test plan

- [ ] CI fmt+clippy passes.
- [ ] CI nextest (stable) passes.
- [ ] CI Windows / macOS / Linux musl pass.