### PR TITLE
docs(crates): rustdoc cleanup for branding embedding apple-fs windows-gnu-eh test-support

### DIFF
--- a/crates/branding/src/workspace/metadata.rs
+++ b/crates/branding/src/workspace/metadata.rs
@@ -1,3 +1,11 @@
+//! Immutable workspace metadata snapshot derived from `Cargo.toml`.
+//!
+//! [`metadata()`] returns a [`Metadata`] value that aggregates the brand,
+//! version, protocol, and packaging path constants emitted by the build
+//! script. Callers preferring a single accessor over individual constants use
+//! this module to render banners, locate configuration files, and report
+//! diagnostics without re-reading the manifest.
+
 use super::constants::{
     BRAND, CLIENT_PROGRAM_NAME, DAEMON_CONFIG_DIR, DAEMON_CONFIG_PATH, DAEMON_PROGRAM_NAME,
     DAEMON_SECRETS_PATH, LEGACY_CLIENT_PROGRAM_NAME, LEGACY_DAEMON_CONFIG_DIR,


### PR DESCRIPTION
## Summary

- Audited `branding`, `embedding`, `apple-fs`, `windows-gnu-eh`, and `test-support` for rustdoc gaps.
- Added the missing module-level `//!` summary on `crates/branding/src/workspace/metadata.rs`.
- All other files in scope already carry full `///` rustdoc on public items, `//!` summaries on every `mod.rs`/`lib.rs`/named submodule, and preserve upstream rsync citations (e.g. `xattrs.c` in `apple-fs/src/resource_fork.rs`) along with the wire-format reference for AppleDouble v2 (RFC 1740) in `apple-fs/src/apple_double.rs`.

## Test plan

- [ ] `cargo fmt --all -- --check`
- [ ] CI `fmt+clippy`, `nextest (stable)`, Windows, macOS, Linux musl jobs pass.