### PR TITLE
docs(protocol): rustdoc cleanup for wire::file_entry

### DIFF
--- a/crates/protocol/src/wire/file_entry_decode/checksum.rs
+++ b/crates/protocol/src/wire/file_entry_decode/checksum.rs
@@ -1,8 +1,11 @@
 #![deny(unsafe_code)]
+//! Checksum field decoding for file entries (`--checksum` mode).
+//!
+//! upstream: flist.c:recv_file_entry() - checksum trailer
 
 use std::io::{self, Read};
 
-/// Decodes file checksum (for --checksum mode).
+/// Decodes file checksum (for `--checksum` mode).
 ///
 /// Reads raw bytes of length `checksum_len` from the wire.
 /// For regular files this is the actual checksum (or zeros if not computed).

--- a/crates/protocol/src/wire/file_entry_decode/device.rs
+++ b/crates/protocol/src/wire/file_entry_decode/device.rs
@@ -1,4 +1,7 @@
 #![deny(unsafe_code)]
+//! Device-number (`rdev`) decoding for block and character device entries.
+//!
+//! upstream: flist.c:recv_file_entry() - rdev_major / rdev_minor handling
 
 use std::io::{self, Read};
 
@@ -32,19 +35,17 @@ pub fn decode_rdev<R: Read>(
         prev_rdev_major
     } else if protocol_version >= 28 {
         read_varint30_int(reader, protocol_version)? as u32
+    } else if flags & (XMIT_SAME_RDEV_PRE28 as u32) != 0 {
+        // Protocols < 28 reuse bit 2 as XMIT_SAME_RDEV_PRE28.
+        prev_rdev_major
     } else {
-        // Protocol < 28: use XMIT_SAME_RDEV_PRE28 flag
-        if flags & (XMIT_SAME_RDEV_PRE28 as u32) != 0 {
-            prev_rdev_major
-        } else {
-            read_varint30_int(reader, protocol_version)? as u32
-        }
+        read_varint30_int(reader, protocol_version)? as u32
     };
 
     let minor = if protocol_version >= 30 {
         read_varint(reader)? as u32
     } else if protocol_version >= 28 {
-        // Protocol 28-29: check XMIT_RDEV_MINOR_8_PRE30 flag
+        // Protocols 28-29: XMIT_RDEV_MINOR_8_PRE30 selects 1-byte vs 4-byte minor.
         let minor_8_bit = (flags & ((XMIT_RDEV_MINOR_8_PRE30 as u32) << 8)) != 0;
         if minor_8_bit {
             let mut buf = [0u8; 1];

--- a/crates/protocol/src/wire/file_entry_decode/flags.rs
+++ b/crates/protocol/src/wire/file_entry_decode/flags.rs
@@ -1,4 +1,7 @@
 #![deny(unsafe_code)]
+//! Transmission-flag decoding for file entries (primary + extended bytes).
+//!
+//! upstream: flist.c:recv_file_entry() - flags / XMIT_EXTENDED_FLAGS handling
 
 use std::io::{self, Read};
 
@@ -9,7 +12,7 @@ use super::super::file_entry::{XMIT_EXTENDED_FLAGS, XMIT_IO_ERROR_ENDLIST};
 /// Decodes transmission flags from the wire format.
 ///
 /// The decoding varies by protocol version and compatibility flags:
-/// - **Varint mode** (VARINT_FLIST_FLAGS): Single varint containing all flag bits
+/// - **Varint mode** (`VARINT_FLIST_FLAGS`): Single varint containing all flag bits
 /// - **Protocol 28+**: 1 byte, or 2 bytes if extended flags present
 /// - **Protocol < 28**: 1 byte only
 ///
@@ -21,7 +24,7 @@ use super::super::file_entry::{XMIT_EXTENDED_FLAGS, XMIT_IO_ERROR_ENDLIST};
 /// | Mode | Format |
 /// |------|--------|
 /// | Varint | `varint(xflags)` where 0 means end-of-list |
-/// | Proto 28+ | `u8` or `u16 LE` if XMIT_EXTENDED_FLAGS set |
+/// | Proto 28+ | `u8` or `u16 LE` if `XMIT_EXTENDED_FLAGS` set |
 /// | Proto < 28 | `u8` only |
 ///
 /// # Examples
@@ -48,9 +51,8 @@ pub fn decode_flags<R: Read>(
     if use_varint_flags {
         let flags = read_varint(reader)? as u32;
 
-        // In varint mode:
-        // - actual 0 means end-of-list
-        // - XMIT_EXTENDED_FLAGS was written for flags=0 to avoid ambiguity
+        // Varint mode: 0 means end-of-list, so the encoder substitutes
+        // XMIT_EXTENDED_FLAGS when the real xflags value is 0.
         if flags == 0 {
             Ok((0, true))
         } else if flags == XMIT_EXTENDED_FLAGS as u32 {
@@ -76,13 +78,12 @@ pub fn decode_flags<R: Read>(
 
             // Detect the safe-file-list IO-error end-of-list sentinel.
             // Wire: [XMIT_EXTENDED_FLAGS, XMIT_IO_ERROR_ENDLIST] + varint(err).
-            // Without this, decode_end_marker is never called; the error
-            // varint leaks into the next entry parse, corrupting the flist.
-            // Upstream: flist.c recv_file_entry() XMIT_IO_ERROR_ENDLIST branch.
-            // The sentinel is exactly [XMIT_EXTENDED_FLAGS, XMIT_IO_ERROR_ENDLIST].
-            // XMIT_IO_ERROR_ENDLIST shares its bit with XMIT_HLINK_FIRST; a bitmask
-            // test would fire on any hardlink-leader or atime-inherit entry that also
-            // has bit 0x1000 set. Exact equality is the only safe check.
+            // Without this branch, decode_end_marker is never called and the
+            // error varint leaks into the next entry parse, corrupting the flist.
+            // XMIT_IO_ERROR_ENDLIST shares its bit with XMIT_HLINK_FIRST, so a
+            // bitmask test would also fire on any hardlink-leader or
+            // atime-inherit entry; exact equality is the only safe check.
+            // upstream: flist.c:recv_file_entry() XMIT_IO_ERROR_ENDLIST branch
             if flags == (XMIT_EXTENDED_FLAGS as u32) | ((XMIT_IO_ERROR_ENDLIST as u32) << 8) {
                 return Ok((flags, true));
             }
@@ -113,7 +114,7 @@ pub fn decode_flags<R: Read>(
 /// | Mode | Format |
 /// |------|--------|
 /// | Varint | `varint(0)` + `varint(io_error)` |
-/// | Safe file list with XMIT_IO_ERROR_ENDLIST | `varint(error)` |
+/// | Safe file list with `XMIT_IO_ERROR_ENDLIST` | `varint(error)` |
 /// | Normal | Nothing (flags == 0 is sufficient) |
 ///
 /// # Examples
@@ -145,17 +146,17 @@ pub fn decode_end_marker<R: Read>(
     }
 }
 
-/// Returns `true` when the flag word from `decode_flags` is a
+/// Returns `true` when the flag word from [`decode_flags`] is a
 /// safe-file-list IO-error end-of-list sentinel rather than a file entry.
 ///
-/// After `decode_flags` returns `(flags, true)`, callers must check this
+/// After [`decode_flags`] returns `(flags, true)`, callers must check this
 /// to distinguish `flags == 0` (normal end) from the IO-error sentinel
-/// (which needs `decode_end_marker` to consume the trailing error varint).
+/// (which needs [`decode_end_marker`] to consume the trailing error varint).
 ///
-/// Upstream: `flist.c:recv_file_entry()` XMIT_IO_ERROR_ENDLIST branch.
+/// upstream: flist.c:recv_file_entry() XMIT_IO_ERROR_ENDLIST branch
 #[must_use]
 pub fn is_io_error_end_marker(flags: u32) -> bool {
-    // Must match exact sentinel, not just the bit: XMIT_HLINK_FIRST shares
-    // the same bit position as XMIT_IO_ERROR_ENDLIST.
+    // XMIT_HLINK_FIRST shares the bit position of XMIT_IO_ERROR_ENDLIST,
+    // so an exact-equality test is required, not a bitmask test.
     flags == (XMIT_EXTENDED_FLAGS as u32) | ((XMIT_IO_ERROR_ENDLIST as u32) << 8)
 }

--- a/crates/protocol/src/wire/file_entry_decode/hardlink.rs
+++ b/crates/protocol/src/wire/file_entry_decode/hardlink.rs
@@ -1,4 +1,7 @@
 #![deny(unsafe_code)]
+//! Hardlink reference decoding (index for protocol 30+, dev/ino for 28-29).
+//!
+//! upstream: flist.c:recv_file_entry() - HLINKED / HLINK_FIRST / SAME_DEV branches
 
 use std::io::{self, Read};
 
@@ -20,8 +23,8 @@ pub fn decode_hardlink_idx<R: Read>(reader: &mut R, flags: u32) -> io::Result<Op
         if flags & ((XMIT_HLINK_FIRST as u32) << 8) != 0 {
             Ok(None)
         } else {
-            // Cast i32 bits to u32 to preserve the full index space;
-            // upstream C uses unsigned int for hlink_flist indices.
+            // Cast i32 bits to u32: upstream C uses unsigned int for
+            // hlink_flist indices, so we preserve the full index space.
             Ok(Some(read_varint(reader)? as u32))
         }
     } else {
@@ -50,7 +53,7 @@ pub fn decode_hardlink_dev_ino<R: Read>(
     let dev = if flags & ((XMIT_SAME_DEV_PRE30 as u32) << 8) != 0 {
         prev_dev
     } else {
-        // Read dev + 1 and subtract 1 (upstream convention)
+        // upstream writes dev + 1 so dev == 0 is distinguishable; reverse here.
         read_longint(reader)? - 1
     };
 

--- a/crates/protocol/src/wire/file_entry_decode/mode.rs
+++ b/crates/protocol/src/wire/file_entry_decode/mode.rs
@@ -1,4 +1,7 @@
 #![deny(unsafe_code)]
+//! Unix mode-bit decoding for file entries.
+//!
+//! upstream: flist.c:recv_file_entry() - mode field handling
 
 use std::io::{self, Read};
 

--- a/crates/protocol/src/wire/file_entry_decode/name.rs
+++ b/crates/protocol/src/wire/file_entry_decode/name.rs
@@ -1,4 +1,7 @@
 #![deny(unsafe_code)]
+//! File name decoding with shared-prefix decompression.
+//!
+//! upstream: flist.c:recv_file_entry() - SAME_NAME / LONG_NAME branches
 
 use std::io::{self, Read};
 

--- a/crates/protocol/src/wire/file_entry_decode/ownership.rs
+++ b/crates/protocol/src/wire/file_entry_decode/ownership.rs
@@ -1,4 +1,8 @@
 #![deny(unsafe_code)]
+//! UID/GID decoding plus optional owner-name field (protocol 30+).
+//!
+//! upstream: flist.c:recv_file_entry() - SAME_UID / SAME_GID and
+//! USER_NAME_FOLLOWS / GROUP_NAME_FOLLOWS handling
 
 use std::io::{self, Read};
 
@@ -62,9 +66,8 @@ pub fn decode_gid<R: Read>(
 
 /// Shared implementation for decoding a user or group ID from the wire format.
 ///
-/// The only difference between UID and GID decoding is which flag constants
-/// are checked: `same_flag` for reusing the previous value, and
-/// `name_follows_flag` for reading an associated owner name.
+/// `same_flag` selects the bit that reuses the previous value, and
+/// `name_follows_flag` selects the bit that signals an associated owner name.
 fn decode_owner_id<R: Read>(
     reader: &mut R,
     flags: u32,
@@ -94,7 +97,7 @@ fn decode_owner_id<R: Read>(
 
 /// Decodes a user or group name (protocol 30+).
 ///
-/// Wire format: `u8(len)` + `name_bytes[0..len]`
+/// Wire format: `u8(len)` + `name_bytes[0..len]`.
 fn decode_owner_name<R: Read>(reader: &mut R) -> io::Result<String> {
     let mut len_buf = [0u8; 1];
     reader.read_exact(&mut len_buf)?;

--- a/crates/protocol/src/wire/file_entry_decode/size.rs
+++ b/crates/protocol/src/wire/file_entry_decode/size.rs
@@ -1,4 +1,7 @@
 #![deny(unsafe_code)]
+//! File-size field decoding (varlong30 for protocol 30+, longint for older).
+//!
+//! upstream: flist.c:recv_file_entry() - file_length = read_varlong30(f, 3)
 
 use std::io::{self, Read};
 

--- a/crates/protocol/src/wire/file_entry_decode/symlink.rs
+++ b/crates/protocol/src/wire/file_entry_decode/symlink.rs
@@ -1,4 +1,7 @@
 #![deny(unsafe_code)]
+//! Symlink target decoding with a bounded length check.
+//!
+//! upstream: flist.c:recv_file_entry() - symlink target read_vstring branch
 
 use std::io::{self, Read};
 

--- a/crates/protocol/src/wire/file_entry_decode/timestamps.rs
+++ b/crates/protocol/src/wire/file_entry_decode/timestamps.rs
@@ -1,4 +1,8 @@
 #![deny(unsafe_code)]
+//! Timestamp field decoding (mtime, mtime_nsec, atime, crtime).
+//!
+//! upstream: flist.c:recv_file_entry() - SAME_TIME / MOD_NSEC / SAME_ATIME /
+//! CRTIME_EQ_MTIME branches
 
 use std::io::{self, Read};
 
@@ -62,19 +66,18 @@ pub fn decode_mtime_nsec<R: Read>(reader: &mut R, flags: u32) -> io::Result<Opti
     if flags & ((XMIT_MOD_NSEC as u32) << 8) != 0 {
         Ok(Some(read_varint(reader)? as u32))
     } else if flags & (XMIT_SAME_TIME as u32) != 0 {
-        // mtime is inherited from the previous entry; callers must also
-        // inherit the previous entry's nsec. Signal this with None.
+        // mtime is inherited; signal that the caller must also inherit the
+        // previous entry's nsec rather than reset to zero.
         Ok(None)
     } else {
-        // New mtime without XMIT_MOD_NSEC: upstream defines nsec = 0,
-        // NOT "carry forward the previous nsec". Returning Some(0)
-        // prevents callers from accidentally inheriting a stale nsec.
-        // Upstream: flist.c recv_file_entry() -- nsec absent => 0.
+        // upstream: flist.c:recv_file_entry() - nsec absent implies 0, not
+        // "carry forward". Returning Some(0) blocks callers from accidentally
+        // inheriting a stale nsec.
         Ok(Some(0))
     }
 }
 
-/// Decodes access time (for --atimes, non-directories only).
+/// Decodes access time (for `--atimes`, non-directories only).
 ///
 /// Returns the decoded atime, or previous value if `XMIT_SAME_ATIME` is set.
 ///
@@ -93,7 +96,7 @@ pub fn decode_atime<R: Read>(
     }
 }
 
-/// Decodes creation time (for --crtimes).
+/// Decodes creation time (for `--crtimes`).
 ///
 /// Returns the decoded crtime, or the current entry's mtime if `XMIT_CRTIME_EQ_MTIME` is set.
 ///


### PR DESCRIPTION
## Summary

- Add `//!` module summaries to all `file_entry_decode` leaf modules (`checksum`, `device`, `flags`, `hardlink`, `mode`, `name`, `ownership`, `size`, `symlink`, `timestamps`).
- Each leaf summary declares its scope and cites the upstream `flist.c:recv_file_entry()` branch it implements.
- Tighten internal `//` comments: drop pure restatements, normalize a few upstream cites to `// upstream: <file>:<symbol>` form, keep all upstream references and non-obvious explanations.

Documentation only - no behavior changes, no public API changes, no wire-format changes.

## Test plan

- [ ] CI: fmt+clippy
- [ ] CI: nextest (stable)
- [ ] CI: Windows/macOS/Linux musl matrices