### PR TITLE
docs(engine): rustdoc cleanup for local_copy::filter_program

### DIFF
--- a/crates/engine/src/local_copy/filter_program/options.rs
+++ b/crates/engine/src/local_copy/filter_program/options.rs
@@ -1,3 +1,6 @@
+//! Per-directory merge parser configuration and enforced-kind modifiers
+//! controlling how `.rsync-filter`-style files are interpreted.
+
 /// Rule kind enforced for entries inside a dir-merge file when modifiers
 /// request include-only or exclude-only semantics.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/crates/engine/src/local_copy/filter_program/program.rs
+++ b/crates/engine/src/local_copy/filter_program/program.rs
@@ -1,3 +1,7 @@
+//! `FilterProgram` aggregate: ordered filter instructions plus per-directory
+//! merge and exclude-if-present rules, along with the upstream-mapped exit
+//! code constants surfaced when filter evaluation aborts a transfer.
+
 use std::path::Path;
 
 #[cfg(all(unix, feature = "xattr"))]
@@ -29,7 +33,7 @@ pub(crate) const TIMEOUT_EXIT_CODE: i32 = 30;
 /// Exit code returned when the connection setup exceeds the configured timeout.
 ///
 /// Maps to upstream rsync's `RERR_CONTIMEOUT` (35) and `core::exit_code::ExitCode::ConnectionTimeout`.
-#[allow(dead_code)] // upstream exit code constant - will be used when filter program handles connection timeouts
+#[allow(dead_code)] // upstream exit code constant; reserved for connection-timeout reporting
 pub(crate) const CONNECTION_TIMEOUT_EXIT_CODE: i32 = 35;
 
 /// Exit code returned when source files vanished during transfer.

--- a/crates/engine/src/local_copy/filter_program/rules.rs
+++ b/crates/engine/src/local_copy/filter_program/rules.rs
@@ -1,3 +1,6 @@
+//! Per-directory merge and exclude-if-present rule descriptors used by
+//! `FilterProgram` to evaluate `.rsync-filter`-style markers during traversal.
+
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};

--- a/crates/engine/src/local_copy/filter_program/segments.rs
+++ b/crates/engine/src/local_copy/filter_program/segments.rs
@@ -1,3 +1,7 @@
+//! Compiled filter segments and stacks that evaluate include/exclude,
+//! protect/risk, and exclude-if-present rules sequentially with first-match
+//! semantics, mirroring upstream `exclude.c` rule traversal.
+
 use std::collections::HashSet;
 use std::path::Path;
 


### PR DESCRIPTION
## Summary

- Add concise module-level (`//!`) rustdoc to the `options`, `program`, `rules`, and `segments` submodules so each file documents its own concern (the `mod.rs` crate-level summary already existed).
- Trim a stale forward-looking phrasing on `CONNECTION_TIMEOUT_EXIT_CODE` from "will be used when filter program handles connection timeouts" to "reserved for connection-timeout reporting".

## Notes

- All public items already carry `///` rustdoc.
- Existing upstream cites (`segments.rs:233` `exclude.c`, `segments.rs:298` `parse_filter_str()`, `segments.rs:418` include-directory semantics) are preserved verbatim.
- Non-obvious internal `//` notes in `segments.rs` (clear-directive debug assertion, Merge/DirMerge handler, include-directory test rationale) are preserved.
- No TODO/FIXME/XXX, decorative banners, commented-out code, or behavioural changes.

## Test plan

- [ ] `cargo fmt --all -- --check`
- [ ] CI fmt+clippy
- [ ] CI nextest (stable)
- [ ] CI Windows / macOS / Linux musl