### PR TITLE
docs(engine): rustdoc cleanup for local_copy::dir_merge

### DIFF
--- a/crates/engine/src/local_copy/dir_merge/load.rs
+++ b/crates/engine/src/local_copy/dir_merge/load.rs
@@ -8,6 +8,9 @@ use std::fs;
 use std::io::{self, Read};
 use std::path::{Path, PathBuf};
 
+/// Wraps a `FilterProgramError` as a `LocalCopyError` with file path context,
+/// reporting the failure through the standard `compile filter file` operation
+/// label so callers see consistent error messages.
 pub(crate) fn filter_program_local_error(
     path: &Path,
     error: &FilterProgramError,
@@ -19,6 +22,11 @@ pub(crate) fn filter_program_local_error(
     )
 }
 
+/// Resolves a per-directory merge file pattern against `base`.
+///
+/// Absolute patterns whose root component is `/` are stripped of that root and
+/// joined onto `base`, mirroring upstream's treatment of root-anchored
+/// `dir-merge` paths. Relative patterns are joined to `base` directly.
 pub(crate) fn resolve_dir_merge_path(base: &Path, pattern: &Path) -> PathBuf {
     if pattern.is_absolute()
         && let Ok(stripped) = pattern.strip_prefix(Path::new("/"))
@@ -29,6 +37,11 @@ pub(crate) fn resolve_dir_merge_path(base: &Path, pattern: &Path) -> PathBuf {
     base.join(pattern)
 }
 
+/// Applies the per-directory merge `options` to `rule` as defaults.
+///
+/// Anchors the rule to the source root when configured, marks it perishable,
+/// and overrides the sender/receiver flags when the merge directive specified
+/// either side modifier. Returns the rule unchanged when no defaults apply.
 pub(crate) fn apply_dir_merge_rule_defaults(
     mut rule: FilterRule,
     options: &DirMergeOptions,
@@ -52,9 +65,13 @@ pub(crate) fn apply_dir_merge_rule_defaults(
     rule
 }
 
+/// Accumulated rules and `exclude-if-present` markers loaded from a single
+/// per-directory merge file (and any files it transitively merges).
 #[derive(Default)]
 pub(crate) struct DirMergeEntries {
+    /// Filter rules parsed from the merge file, in source order.
     pub(crate) rules: Vec<FilterRule>,
+    /// `exclude-if-present` marker rules parsed from the merge file.
     pub(crate) exclude_if_present: Vec<ExcludeIfPresentRule>,
     /// Indicates a clear directive was encountered, meaning inherited rules
     /// from parent directories should also be cleared.
@@ -88,6 +105,13 @@ impl DirMergeEntries {
     }
 }
 
+/// Loads filter rules from `path`, recursing into nested `merge` directives.
+///
+/// `options` controls the parser (whitespace-vs-line, comment handling,
+/// enforced include/exclude kind) used for this file. `visited` is a
+/// canonical-path stack used to detect cycles: if `path` would re-enter a file
+/// already on the stack the function returns an error rather than recursing
+/// infinitely. On success the visited entry is popped before returning.
 pub(crate) fn load_dir_merge_rules_recursive(
     path: &Path,
     options: &DirMergeOptions,

--- a/crates/engine/src/local_copy/dir_merge/parse/dir_merge.rs
+++ b/crates/engine/src/local_copy/dir_merge/parse/dir_merge.rs
@@ -2,6 +2,14 @@ use super::types::{FilterParseError, ParsedFilterDirective};
 use crate::local_copy::filter_program::{DirMergeEnforcedKind, DirMergeOptions};
 use std::path::PathBuf;
 
+/// Parses `dir-merge` and `per-dir` directives.
+///
+/// Returns `Ok(None)` for inputs that do not begin with either alias, or when
+/// the alias is followed by a non-separator character (so that
+/// `dir-mergeXXX` is not silently accepted). Modifiers are introduced by
+/// `,`; `+` and `-` are mutually exclusive, and `c` activates the CVS
+/// preset (whitespace parser, no comments, no inheritance, list-clearing
+/// permitted, default file `.cvsignore`).
 pub(super) fn parse_dir_merge_directive(
     text: &str,
 ) -> Result<Option<ParsedFilterDirective>, FilterParseError> {

--- a/crates/engine/src/local_copy/dir_merge/parse/line.rs
+++ b/crates/engine/src/local_copy/dir_merge/parse/line.rs
@@ -118,6 +118,13 @@ fn split_keyword_modifiers(keyword: &str) -> (&str, &str) {
     }
 }
 
+/// Parses a single line of a per-directory merge file.
+///
+/// Returns `Ok(None)` for blank or comment-only lines. Recognises list-clear
+/// (`!`/`clear`), short-form merges (`.`/`:`), `merge`/`dir-merge`/`per-dir`
+/// directives, `exclude-if-present`, the `+`/`-` short-form rule prefixes,
+/// and the `include`/`exclude`/`show`/`hide`/`protect`/`risk` keywords with
+/// their `,modifier` suffix. Trailing whitespace is trimmed from patterns.
 pub(crate) fn parse_filter_directive_line(
     text: &str,
 ) -> Result<Option<ParsedFilterDirective>, FilterParseError> {

--- a/crates/engine/src/local_copy/dir_merge/parse/merge.rs
+++ b/crates/engine/src/local_copy/dir_merge/parse/merge.rs
@@ -4,6 +4,13 @@ use super::{
 };
 use std::path::PathBuf;
 
+/// Parses a `merge` directive of the form `merge[,modifiers] PATH`.
+///
+/// Returns `Ok(None)` when the input does not start with the `merge` keyword.
+/// Rejects `merge -` (stdin merges are not allowed inside `.rsync-filter`
+/// files) and missing-path inputs unless the `,C` modifier supplies the
+/// implicit `.cvsignore` default. `options` is `None` only when no modifiers
+/// were specified, preserving inheritance of the caller's parser settings.
 pub(super) fn parse_merge_directive(
     text: &str,
 ) -> Result<Option<ParsedFilterDirective>, FilterParseError> {
@@ -62,6 +69,12 @@ pub(super) fn parse_merge_directive(
     }))
 }
 
+/// Parses the short-form merge prefixes `.` (plain merge) and `:` (dir-merge).
+///
+/// Returns `Ok(None)` when the input begins with any other character. The
+/// `:` form enables extended modifiers (`n`, `e`, `w`, `s`, `r`, `/`) and
+/// always returns explicit `options`. The `.` form mirrors the long-form
+/// `merge` semantics, returning `None` options when no modifiers were given.
 pub(super) fn parse_short_merge_directive_line(
     text: &str,
 ) -> Result<Option<ParsedFilterDirective>, FilterParseError> {

--- a/crates/engine/src/local_copy/dir_merge/parse/modifiers.rs
+++ b/crates/engine/src/local_copy/dir_merge/parse/modifiers.rs
@@ -9,6 +9,12 @@ fn trim_short_rule_remainder(remainder: &str) -> &str {
     remainder
 }
 
+/// Splits the modifier prefix of a short-form `+`/`-` rule from its pattern.
+///
+/// Returns `(modifiers, pattern)` where `modifiers` is the contiguous run of
+/// modifier characters following the rule sigil and `pattern` is the
+/// remaining text with separating commas, underscores, and whitespace
+/// stripped. A leading separator yields empty modifiers.
 pub(super) fn split_short_rule_modifiers(text: &str) -> (&str, &str) {
     if text.is_empty() {
         return ("", "");
@@ -37,6 +43,12 @@ pub(super) fn split_short_rule_modifiers(text: &str) -> (&str, &str) {
     ("", text)
 }
 
+/// Splits the modifier prefix of a short-form merge directive (`.`/`:`).
+///
+/// Only the characters valid as merge modifiers are consumed. The base set is
+/// `+`, `-`, `c`, `w`, `s`, `r`, `p`, `/`; passing `allow_extended` true
+/// additionally accepts `e` and `n` (the `dir-merge`-only modifiers). Stops
+/// at the first non-modifier character, separator, or end of input.
 pub(super) fn split_short_merge_modifiers(text: &str, allow_extended: bool) -> (&str, &str) {
     if text.is_empty() {
         return ("", "");
@@ -79,6 +91,14 @@ pub(super) fn split_short_merge_modifiers(text: &str, allow_extended: bool) -> (
     (&text[..end], "")
 }
 
+/// Parses the modifier characters of a `merge` or `dir-merge` directive into
+/// concrete `DirMergeOptions` plus an `assume_cvsignore` flag.
+///
+/// `allow_extended` selects between plain `merge` semantics (only `+`, `-`,
+/// `c` accepted) and `dir-merge` semantics (all modifiers accepted). Errors
+/// on unsupported characters and on conflicting `+`/`-` or `+`/`c`
+/// combinations. Plain `merge` directives implicitly enable list-clearing to
+/// match upstream behaviour.
 pub(super) fn parse_merge_modifiers(
     modifiers: &str,
     directive: &str,

--- a/crates/engine/src/local_copy/dir_merge/parse/types.rs
+++ b/crates/engine/src/local_copy/dir_merge/parse/types.rs
@@ -5,17 +5,30 @@ use thiserror::Error;
 use crate::local_copy::filter_program::{DirMergeOptions, ExcludeIfPresentRule};
 use filters::FilterRule;
 
+/// AST node produced by parsing a single line of a per-directory merge file.
 #[derive(Debug)]
 pub(crate) enum ParsedFilterDirective {
+    /// A concrete filter rule (`+`, `-`, `include`, `exclude`, `show`, `hide`,
+    /// `protect`, `risk`).
     Rule(FilterRule),
+    /// A `merge` or `dir-merge` directive that pulls in another filter file.
     Merge {
+        /// Path to the merged file, resolved relative to the enclosing file's
+        /// parent directory unless absolute.
         path: PathBuf,
+        /// Optional parser overrides (modifiers such as `,n`, `,e`, `,w`).
+        /// `None` indicates the merged file inherits the current parser
+        /// configuration unchanged.
         options: Option<DirMergeOptions>,
     },
+    /// An `exclude-if-present` directive naming a marker file whose presence
+    /// excludes the containing directory.
     ExcludeIfPresent(ExcludeIfPresentRule),
+    /// A list-clearing directive (`!` or `clear`) that wipes inherited rules.
     Clear,
 }
 
+/// Error returned when a filter directive cannot be parsed.
 #[derive(Debug, Error)]
 #[error("{message}")]
 pub(crate) struct FilterParseError {
@@ -23,6 +36,7 @@ pub(crate) struct FilterParseError {
 }
 
 impl FilterParseError {
+    /// Constructs a new parse error from any value convertible to `String`.
     pub(crate) fn new(message: impl Into<String>) -> Self {
         Self {
             message: message.into(),


### PR DESCRIPTION
## Summary

- Add rustdoc to `ParsedFilterDirective` (and its `Rule`/`Merge`/`ExcludeIfPresent`/`Clear` variants plus the `path`/`options` fields), `FilterParseError`, and `FilterParseError::new`.
- Document the crate-private helpers in `load.rs`: `filter_program_local_error`, `resolve_dir_merge_path`, `apply_dir_merge_rule_defaults`, `DirMergeEntries` (with field docs), and `load_dir_merge_rules_recursive`.
- Document the `pub(super)`/`pub(crate)` parser entry points in `parse/{line,merge,dir_merge,modifiers}.rs`, including modifier semantics, separator handling, and CVS preset behaviour.
- No upstream citations existed in this module; module-level `//!` summaries were already in place and were left unchanged. Test-only comments (`'f' is not a valid modifier`, `dir-merge followed by ...`) are preserved.

## Test plan
- [ ] CI fmt+clippy
- [ ] CI nextest (stable)
- [ ] CI Windows / macOS / Linux musl