### PR TITLE
docs(protocol): rustdoc cleanup for wire::file_entry

### DIFF
--- a/crates/protocol/src/wire/file_entry_decode/checksum.rs
+++ b/crates/protocol/src/wire/file_entry_decode/checksum.rs
@@ -1,4 +1,7 @@
 #![deny(unsafe_code)]
+//! Checksum field decoding for file list entries (`--checksum` mode).
+//!
+//! upstream: flist.c:recv_file_entry() checksum branch.
 
 use std::io::{self, Read};
 
@@ -7,6 +10,12 @@ use std::io::{self, Read};
 /// Reads raw bytes of length `checksum_len` from the wire.
 /// For regular files this is the actual checksum (or zeros if not computed).
 /// For non-regular files (proto < 28 only) this is `empty_sum` (all zeros).
+///
+/// # Wire Format
+///
+/// Raw bytes of length `checksum_len`. The length is fixed by the negotiated
+/// checksum algorithm (MD4=16, MD5=16, XXH3=8, XXH128=16) and does not vary
+/// by protocol version on the wire.
 pub fn decode_checksum<R: Read>(reader: &mut R, checksum_len: usize) -> io::Result<Vec<u8>> {
     let mut checksum = vec![0u8; checksum_len];
     reader.read_exact(&mut checksum)?;

--- a/crates/protocol/src/wire/file_entry_decode/device.rs
+++ b/crates/protocol/src/wire/file_entry_decode/device.rs
@@ -1,4 +1,7 @@
 #![deny(unsafe_code)]
+//! Device-number (rdev) field decoding for block/character device entries.
+//!
+//! upstream: flist.c:recv_file_entry() rdev branch (lines 910-945).
 
 use std::io::{self, Read};
 

--- a/crates/protocol/src/wire/file_entry_decode/flags.rs
+++ b/crates/protocol/src/wire/file_entry_decode/flags.rs
@@ -1,4 +1,8 @@
 #![deny(unsafe_code)]
+//! XMIT flag word decoding and end-of-list sentinel detection.
+//!
+//! upstream: flist.c:recv_file_entry() flags branch (lines 760-790),
+//! XMIT_IO_ERROR_ENDLIST sentinel handling.
 
 use std::io::{self, Read};
 
@@ -78,7 +82,7 @@ pub fn decode_flags<R: Read>(
             // Wire: [XMIT_EXTENDED_FLAGS, XMIT_IO_ERROR_ENDLIST] + varint(err).
             // Without this, decode_end_marker is never called; the error
             // varint leaks into the next entry parse, corrupting the flist.
-            // Upstream: flist.c recv_file_entry() XMIT_IO_ERROR_ENDLIST branch.
+            // upstream: flist.c:recv_file_entry() XMIT_IO_ERROR_ENDLIST branch.
             // The sentinel is exactly [XMIT_EXTENDED_FLAGS, XMIT_IO_ERROR_ENDLIST].
             // XMIT_IO_ERROR_ENDLIST shares its bit with XMIT_HLINK_FIRST; a bitmask
             // test would fire on any hardlink-leader or atime-inherit entry that also
@@ -152,7 +156,9 @@ pub fn decode_end_marker<R: Read>(
 /// to distinguish `flags == 0` (normal end) from the IO-error sentinel
 /// (which needs `decode_end_marker` to consume the trailing error varint).
 ///
-/// Upstream: `flist.c:recv_file_entry()` XMIT_IO_ERROR_ENDLIST branch.
+/// # Upstream Reference
+///
+/// `flist.c:recv_file_entry()` XMIT_IO_ERROR_ENDLIST branch.
 #[must_use]
 pub fn is_io_error_end_marker(flags: u32) -> bool {
     // Must match exact sentinel, not just the bit: XMIT_HLINK_FIRST shares

--- a/crates/protocol/src/wire/file_entry_decode/hardlink.rs
+++ b/crates/protocol/src/wire/file_entry_decode/hardlink.rs
@@ -1,4 +1,8 @@
 #![deny(unsafe_code)]
+//! Hardlink association decoding.
+//!
+//! Protocol 30+ uses a flist-relative index; protocols 28-29 use a (dev, ino)
+//! pair. upstream: flist.c:recv_file_entry() hardlink branches (lines 950-975).
 
 use std::io::{self, Read};
 

--- a/crates/protocol/src/wire/file_entry_decode/mode.rs
+++ b/crates/protocol/src/wire/file_entry_decode/mode.rs
@@ -1,4 +1,7 @@
 #![deny(unsafe_code)]
+//! Unix mode-bits field decoding (fixed 4-byte little-endian).
+//!
+//! upstream: flist.c:recv_file_entry() mode branch.
 
 use std::io::{self, Read};
 

--- a/crates/protocol/src/wire/file_entry_decode/name.rs
+++ b/crates/protocol/src/wire/file_entry_decode/name.rs
@@ -1,4 +1,7 @@
 #![deny(unsafe_code)]
+//! Filename decoding with shared-prefix decompression.
+//!
+//! upstream: flist.c:recv_file_entry() name branch (lines 800-850).
 
 use std::io::{self, Read};
 

--- a/crates/protocol/src/wire/file_entry_decode/ownership.rs
+++ b/crates/protocol/src/wire/file_entry_decode/ownership.rs
@@ -1,4 +1,7 @@
 #![deny(unsafe_code)]
+//! UID/GID decoding plus optional owner-name strings (protocol 30+).
+//!
+//! upstream: flist.c:recv_file_entry() user/group branches.
 
 use std::io::{self, Read};
 

--- a/crates/protocol/src/wire/file_entry_decode/size.rs
+++ b/crates/protocol/src/wire/file_entry_decode/size.rs
@@ -1,4 +1,7 @@
 #![deny(unsafe_code)]
+//! File-size field decoding (varlong30 on protocol 30+, longint on 28-29).
+//!
+//! upstream: flist.c:recv_file_entry() length branch (line 856).
 
 use std::io::{self, Read};
 

--- a/crates/protocol/src/wire/file_entry_decode/symlink.rs
+++ b/crates/protocol/src/wire/file_entry_decode/symlink.rs
@@ -1,4 +1,7 @@
 #![deny(unsafe_code)]
+//! Symlink-target decoding with `MAXPATHLEN`-bounded length cap.
+//!
+//! upstream: flist.c:recv_file_entry() symlink branch; rsync.h `MAXPATHLEN`.
 
 use std::io::{self, Read};
 

--- a/crates/protocol/src/wire/file_entry_decode/timestamps.rs
+++ b/crates/protocol/src/wire/file_entry_decode/timestamps.rs
@@ -1,4 +1,8 @@
 #![deny(unsafe_code)]
+//! Mtime/atime/crtime decoding plus protocol-31 nanosecond extension.
+//!
+//! upstream: flist.c:recv_file_entry() time branches (lines 858-862),
+//! XMIT_MOD_NSEC and XMIT_CRTIME_EQ_MTIME handling.
 
 use std::io::{self, Read};
 
@@ -69,7 +73,7 @@ pub fn decode_mtime_nsec<R: Read>(reader: &mut R, flags: u32) -> io::Result<Opti
         // New mtime without XMIT_MOD_NSEC: upstream defines nsec = 0,
         // NOT "carry forward the previous nsec". Returning Some(0)
         // prevents callers from accidentally inheriting a stale nsec.
-        // Upstream: flist.c recv_file_entry() -- nsec absent => 0.
+        // upstream: flist.c:recv_file_entry() - nsec absent => 0.
         Ok(Some(0))
     }
 }


### PR DESCRIPTION
## Summary

- Add `//!` module-level summaries to each `file_entry_decode` leaf submodule (checksum, device, flags, hardlink, mode, name, ownership, size, symlink, timestamps) so rustdoc renders a one-line description plus the canonical upstream cite (`flist.c:recv_file_entry()` and the relevant branch).
- Normalize two internal `// Upstream:` comment headings to the lowercase `// upstream:` convention used elsewhere in the codebase.
- Promote the inline `Upstream:` note on `is_io_error_end_marker` to a proper `# Upstream Reference` rustdoc section for symmetry with the other public decoder functions.

The encoder side (`wire::file_entry/{mod,constants,encode,flags}.rs`) already had complete rustdoc with wire-byte layouts and protocol-version differences, so no changes were needed there. No code logic was touched.

## Test plan

- [ ] CI: fmt+clippy
- [ ] CI: nextest stable
- [ ] CI: Linux musl, Windows, macOS