### PR TITLE
docs(protocol): rustdoc cleanup for state module

### DIFF
--- a/crates/protocol/src/state/mod.rs
+++ b/crates/protocol/src/state/mod.rs
@@ -5,12 +5,32 @@
 //!
 //! # Protocol Phases
 //!
-//! The rsync protocol progresses through these phases:
+//! The rsync protocol progresses through these phases in strict forward order:
 //!
 //! 1. **Negotiation** - Protocol version and capability negotiation
 //! 2. **FileList** - File list exchange between sender and receiver
 //! 3. **Transfer** - Delta transfer phase
 //! 4. **Finalize** - Final statistics exchange and cleanup
+//!
+//! ```text
+//! Negotiation -> FileList -> Transfer -> Finalize
+//!     |             |           |          (terminal)
+//!     |             |           +-- record_transfer (loop)
+//!     |             +-- set_file_count
+//!     +-- set_protocol_version, set_checksum_seed
+//! ```
+//!
+//! # Invariants
+//!
+//! - Transitions are forward-only; there is no rollback path.
+//! - `Negotiation -> FileList` requires both `protocol_version` and `checksum_seed`.
+//! - `FileList -> Transfer` requires `file_count`.
+//! - `Transfer -> Finalize` is always valid and consumes the transfer state.
+//! - `Finalize` is terminal: [`DynamicProtocolState::advance`] is a no-op once
+//!   reached, so callers may invoke it unconditionally.
+//! - [`ProtocolState`] enforces the above at compile time via the typestate
+//!   pattern; [`DynamicProtocolState`] enforces it at runtime via
+//!   [`TransitionError`].
 //!
 //! # Submodules
 //!

--- a/crates/protocol/src/state/phases.rs
+++ b/crates/protocol/src/state/phases.rs
@@ -4,7 +4,7 @@
 
 use std::fmt;
 
-/// Protocol phase marker traits for type-safe transitions.
+/// Protocol phase marker trait for type-safe transitions.
 pub trait ProtocolPhase: fmt::Debug + Send + Sync {
     /// Human-readable name of this phase.
     fn name(&self) -> &'static str;

--- a/crates/protocol/src/state/typestate.rs
+++ b/crates/protocol/src/state/typestate.rs
@@ -59,17 +59,18 @@ impl ProtocolState<Negotiation> {
         self.phase.checksum_seed = Some(seed);
     }
 
-    /// Transition to file list phase.
+    /// Transition to the file list phase.
     ///
-    /// Requires protocol_version and checksum_seed to be set.
+    /// Both [`set_protocol_version`](Self::set_protocol_version) and
+    /// [`set_checksum_seed`](Self::set_checksum_seed) must have been called
+    /// first; the missing field is reported via the returned error.
     ///
     /// # Errors
     ///
-    /// Returns [`TransitionError::MissingProtocolVersion`] if the protocol version
-    /// has not been set.
-    ///
-    /// Returns [`TransitionError::MissingChecksumSeed`] if the checksum seed
-    /// has not been set.
+    /// - [`TransitionError::MissingProtocolVersion`] if the protocol version
+    ///   has not been set.
+    /// - [`TransitionError::MissingChecksumSeed`] if the checksum seed has not
+    ///   been set.
     ///
     /// # Examples
     ///
@@ -127,14 +128,14 @@ impl ProtocolState<FileList> {
         self.phase.file_count = Some(count);
     }
 
-    /// Transition to transfer phase.
+    /// Transition to the transfer phase.
     ///
-    /// Requires file_count to be set.
+    /// [`set_file_count`](Self::set_file_count) must have been called first.
     ///
     /// # Errors
     ///
-    /// Returns [`TransitionError::MissingFileCount`] if the file count
-    /// has not been set.
+    /// - [`TransitionError::MissingFileCount`] if the file count has not been
+    ///   set.
     ///
     /// # Examples
     ///
@@ -212,9 +213,11 @@ impl ProtocolState<Transfer> {
         self.phase.files_transferred
     }
 
-    /// Transition to finalize phase.
+    /// Transition to the finalize phase.
     ///
-    /// This transition is always valid and consumes the transfer state.
+    /// This transition is infallible and consumes the transfer state. The
+    /// running `files_transferred` counter and the original `file_count` are
+    /// carried into the [`Finalize`] phase as `total_files`.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
## Summary

- Add an ASCII state diagram and an `Invariants` section to the `protocol::state` module header so the forward-only transition contract is documented in one place.
- Tighten the `ProtocolPhase` trait doc (singular - it is one trait).
- Sharpen the entry-condition prose on each `begin_*` method in `typestate.rs` and clarify that `begin_finalize` is infallible and carries `file_count` forward as `total_files`.

No behavioural change; rustdoc only.

Refs #1997.

## Test plan

- [x] `cargo fmt --all` clean
- [ ] CI: fmt+clippy
- [ ] CI: nextest (stable)
- [ ] CI: Windows (stable)
- [ ] CI: macOS (stable)
- [ ] CI: Linux musl (stable)