### PR TITLE
feat(match): add zsync-inspired bithash prefilter to MatchIndex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2185,6 +2185,7 @@ dependencies = [
  "checksums",
  "criterion",
  "logging",
+ "proptest",
  "protocol",
  "rayon",
  "rustc-hash",

--- a/crates/match/Cargo.toml
+++ b/crates/match/Cargo.toml
@@ -37,6 +37,7 @@ parallel = ["dep:rayon"]
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }
+proptest = "1.4"
 protocol = { path = "../protocol" }
 tempfile = "3.15"
 

--- a/crates/match/src/index/bithash.rs
+++ b/crates/match/src/index/bithash.rs
@@ -1,0 +1,222 @@
+//! Bithash prefilter for the [`DeltaSignatureIndex`].
+//!
+//! Translates zsync's `librcksum` bithash mechanism (see
+//! `librcksum/hash.c:101-102` and `librcksum/rsum.c:362-366` in zsync 0.6.2)
+//! into oc-rsync's existing index. The bithash is an oversized one-sided bit
+//! filter that rejects ~7/8 of non-matching rolling-hash probes in O(1)
+//! before the strong-checksum hash-table walk.
+//!
+//! The structure is built once per signature, populated alongside the
+//! [`super::DeltaSignatureIndex::tag_table`], and probed alongside it on every
+//! rolling-hash advance. It never leaves the receiver's memory; no wire,
+//! capability, or golden-byte surface is affected.
+//!
+//! Sizing follows the design note `docs/design/zsync-bithash.md`:
+//!
+//! - Bucket count `2^i` is chosen so that `2^i >= 4 * N` for `N` blocks,
+//!   clamped at a `2^7` minimum to keep the mask stable for tiny basis files.
+//! - Bit count is `2^(i + 1 + BITHASH_BITS)`, i.e. 8 times the bucket count
+//!   (zsync's `BITHASHBITS = 3`), giving the canonical 1/8 set-bit density
+//!   and the matching 7/8 reject rate on uniform misses.
+//! - The bit count is capped at `2^28` (32 MiB of bits, 4 MiB of bytes) to
+//!   bound memory at adversarial input sizes per the parent design.
+
+/// Logarithm of the per-bucket bit budget.
+///
+/// Mirrors zsync's `BITHASHBITS` macro from `librcksum/internal.h:83`.
+/// Each `2^i` bucket of the rsum hash table is paired with `2^(BITHASH_BITS+1)
+/// = 16` bithash bits, giving a 1/8 set-bit density at saturation.
+pub(super) const BITHASH_BITS: u32 = 3;
+
+/// Minimum bithash size in bits, expressed as a power-of-two exponent.
+///
+/// `2^7 = 128` bits keeps the mask stable for very small basis files and
+/// matches the 1 KB lower bound discussed in `docs/design/zsync-bithash.md`.
+const MIN_LOG2_BITS: u32 = 7;
+
+/// Maximum bithash size in bits, expressed as a power-of-two exponent.
+///
+/// `2^28 = 256 Mibits = 32 MiB`, capping memory at the parent design's
+/// adversarial-input ceiling. Beyond this, the bithash starts costing more
+/// in cache misses than it saves in hash-table probes.
+const MAX_LOG2_BITS: u32 = 28;
+
+/// One-sided rolling-checksum prefilter mirroring zsync's bithash.
+///
+/// Sized to roughly `8 * 4 * N` bits for `N` indexed blocks (the `8x` factor
+/// is `2^BITHASH_BITS`, the `4x` factor is the standard rsum-bucket
+/// over-allocation). At saturation the array carries one set bit per indexed
+/// block (1/8 density), so a uniform-random rsum probe rejects with
+/// probability ~7/8 in a single masked load.
+///
+/// # Invariants
+///
+/// - [`Self::insert`] only ever sets bits; it never clears them.
+/// - [`Self::contains`] returns `true` for every rsum that was previously
+///   passed to [`Self::insert`]: the filter is one-sided, so missed matches
+///   are impossible by construction.
+/// - [`Self::clear`] resets the bit array to all zeros without releasing the
+///   backing allocation, mirroring [`super::DeltaSignatureIndex::rebuild`]'s
+///   reuse of the tag table.
+#[derive(Clone, Debug)]
+pub(super) struct BitHash {
+    bits: Vec<u64>,
+    mask: u32,
+}
+
+impl BitHash {
+    /// Builds a bithash sized for the requested block count.
+    ///
+    /// The bit count is the smallest power of two `>= 32 * n_blocks`,
+    /// clamped to `[2^MIN_LOG2_BITS, 2^MAX_LOG2_BITS]`. The result is always
+    /// a multiple of 64 bits, so the [`u64`] backing store has no tail
+    /// padding to special-case.
+    pub(super) fn with_block_count(n_blocks: usize) -> Self {
+        let log2_bits = log2_bits_for(n_blocks);
+        let total_bits = 1usize << log2_bits;
+        let words = total_bits / u64::BITS as usize;
+        let mask = ((total_bits - 1) as u64 & u32::MAX as u64) as u32;
+        Self {
+            bits: vec![0u64; words],
+            mask,
+        }
+    }
+
+    /// Records the presence of a block with the given packed rolling sum.
+    ///
+    /// `rsum` is the 32-bit value returned by
+    /// [`checksums::RollingDigest::value`]. Mirrors zsync's
+    /// `bithash[(h & bithashmask) >> 3] |= 1 << (h & 7)`.
+    #[inline]
+    pub(super) fn insert(&mut self, rsum: u32) {
+        let (word_index, bit_index) = self.locate(rsum);
+        self.bits[word_index] |= 1u64 << bit_index;
+    }
+
+    /// Reports whether the given rolling sum may correspond to an indexed block.
+    ///
+    /// Returns `true` for every previously inserted rsum (no false
+    /// negatives). May return `true` for rsums that were never inserted
+    /// (false positives), but at the design density bound these account for
+    /// roughly 1/8 of uniform-random probes.
+    #[inline]
+    pub(super) fn contains(&self, rsum: u32) -> bool {
+        let (word_index, bit_index) = self.locate(rsum);
+        (self.bits[word_index] >> bit_index) & 1 == 1
+    }
+
+    /// Resets every bit, preserving the backing allocation.
+    ///
+    /// Used by [`super::DeltaSignatureIndex::rebuild`] to recycle the bithash
+    /// across per-segment INC_RECURSE rebuilds without re-allocating.
+    #[inline]
+    pub(super) fn clear(&mut self) {
+        for word in &mut self.bits {
+            *word = 0;
+        }
+    }
+
+    /// Returns the fraction of bits currently set, in `[0.0, 1.0]`.
+    ///
+    /// Useful for the `bench-bithash` rejection-rate harness described in
+    /// `docs/design/zsync-bithash.md` section 7. Cheap on small bithashes,
+    /// linear in the bit count for large ones; not on any hot path.
+    #[allow(dead_code)]
+    pub(super) fn utilization(&self) -> f64 {
+        let set: u32 = self.bits.iter().map(|w| w.count_ones()).sum();
+        let total = (self.bits.len() as u64) * u64::BITS as u64;
+        if total == 0 {
+            0.0
+        } else {
+            f64::from(set) / total as f64
+        }
+    }
+
+    /// Decomposes an rsum into `(word_index, bit_within_word)`.
+    ///
+    /// The low 6 bits of the masked rsum select the bit inside the 64-bit
+    /// word; the next bits up to `log2(total_bits)` select the word. This is
+    /// the natural extension of zsync's byte/bit decomposition to a `u64`
+    /// backing store, and it preserves the property that the low 3 bits of
+    /// `rsum` drive the in-byte bit selection.
+    #[inline]
+    fn locate(&self, rsum: u32) -> (usize, u32) {
+        let masked = (rsum & self.mask) as usize;
+        let bit_index = (masked & (u64::BITS as usize - 1)) as u32;
+        let word_index = masked >> 6;
+        (word_index, bit_index)
+    }
+}
+
+/// Returns the `log2` of the chosen bit-array size for a block count.
+///
+/// Picks the smallest exponent `k` with `2^k >= 32 * n_blocks` (the `4x`
+/// bucket factor times zsync's `8x` bithash factor), then clamps into
+/// `[MIN_LOG2_BITS, MAX_LOG2_BITS]`.
+fn log2_bits_for(n_blocks: usize) -> u32 {
+    let target_bits = (n_blocks as u64).saturating_mul(1u64 << (BITHASH_BITS + 2));
+    let log2 = if target_bits <= 1 {
+        MIN_LOG2_BITS
+    } else {
+        // Smallest k with 2^k >= target_bits is `64 - leading_zeros(target_bits - 1)`.
+        let raw = u64::BITS - (target_bits - 1).leading_zeros();
+        raw.max(MIN_LOG2_BITS)
+    };
+    log2.min(MAX_LOG2_BITS)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn min_size_is_clamped() {
+        let bh = BitHash::with_block_count(0);
+        assert_eq!(bh.bits.len(), 1usize << (MIN_LOG2_BITS - 6));
+        assert_eq!(bh.mask as u64, (1u64 << MIN_LOG2_BITS) - 1);
+    }
+
+    #[test]
+    fn max_size_is_capped() {
+        let bh = BitHash::with_block_count(usize::MAX);
+        assert_eq!(bh.bits.len(), 1usize << (MAX_LOG2_BITS - 6));
+        assert_eq!(bh.mask as u64, (1u64 << MAX_LOG2_BITS) - 1);
+    }
+
+    #[test]
+    fn insert_then_contains_round_trip() {
+        let mut bh = BitHash::with_block_count(1024);
+        for rsum in [0u32, 1, 0xDEAD_BEEF, 0xFFFF_FFFF, 0xBC00_F800] {
+            bh.insert(rsum);
+            assert!(bh.contains(rsum), "rsum {rsum:#x} should be present");
+        }
+    }
+
+    #[test]
+    fn clear_resets_all_bits() {
+        let mut bh = BitHash::with_block_count(1024);
+        bh.insert(42);
+        bh.insert(0xCAFEBABE);
+        assert!(bh.contains(42));
+        bh.clear();
+        assert!(!bh.contains(42));
+        assert!(!bh.contains(0xCAFEBABE));
+        assert_eq!(bh.utilization(), 0.0);
+    }
+
+    #[test]
+    fn utilization_is_bounded_by_one_eighth_at_saturation() {
+        let n_blocks = 4096usize;
+        let mut bh = BitHash::with_block_count(n_blocks);
+        for i in 0..n_blocks as u64 {
+            // Spread the rsums across the address space using a cheap mixer
+            // so we approximate the uniform-random density bound.
+            let rsum = (i.wrapping_mul(0x9E37_79B9_7F4A_7C15) & u32::MAX as u64) as u32;
+            bh.insert(rsum);
+        }
+        let util = bh.utilization();
+        // The design target is 1/8 = 0.125 with N inserts into 8N bits.
+        // Allow a 5% absolute slack for finite-size variance.
+        assert!(util <= 0.175, "utilization {util} exceeds 1/8 + slack");
+    }
+}

--- a/crates/match/src/index/bithash_tests.rs
+++ b/crates/match/src/index/bithash_tests.rs
@@ -1,0 +1,130 @@
+//! Property tests for the [`super::bithash::BitHash`] prefilter.
+//!
+//! Pin the contract from `docs/design/zsync-bithash.md` section 5: the
+//! bithash is one-sided, so for every block actually inserted into the
+//! [`super::DeltaSignatureIndex`], the rolling-checksum probe MUST still
+//! find it after the bithash gate is enabled. False positives are allowed;
+//! false negatives are a correctness regression.
+
+use std::num::{NonZeroU8, NonZeroU32};
+
+use proptest::prelude::*;
+
+use protocol::ProtocolVersion;
+use signature::SignatureLayoutParams;
+use signature::{SignatureAlgorithm, calculate_signature_layout, generate_file_signature};
+
+use super::DeltaSignatureIndex;
+use super::bithash::BitHash;
+
+/// Block length that always produces full-length blocks across the basis.
+const TEST_BLOCK_LENGTH: u32 = 700;
+
+/// Strong-checksum length used by all the property cases.
+const STRONG_LEN: u8 = 16;
+
+/// Builds a [`DeltaSignatureIndex`] over the supplied basis bytes.
+fn build_index(data: &[u8]) -> Option<DeltaSignatureIndex> {
+    let params = SignatureLayoutParams::new(
+        data.len() as u64,
+        Some(NonZeroU32::new(TEST_BLOCK_LENGTH).unwrap()),
+        ProtocolVersion::NEWEST,
+        NonZeroU8::new(STRONG_LEN).unwrap(),
+    );
+    let layout = calculate_signature_layout(params).ok()?;
+    let signature = generate_file_signature(data, layout, SignatureAlgorithm::Md4).ok()?;
+    DeltaSignatureIndex::from_signature(&signature, SignatureAlgorithm::Md4)
+}
+
+/// Strategy generating basis files of one to eight full blocks plus an
+/// optional partial trailer. Each byte is independently random so the basis
+/// covers the signed-byte rolling-checksum range, which is the regime PR
+/// #3560 pinned for the index.
+fn basis_strategy() -> impl Strategy<Value = Vec<u8>> {
+    (1usize..=8).prop_flat_map(|n_blocks| {
+        let total = n_blocks * TEST_BLOCK_LENGTH as usize;
+        proptest::collection::vec(any::<u8>(), total..=total)
+    })
+}
+
+proptest! {
+    /// The bithash gate MUST NOT cause a missed match on any indexed block.
+    ///
+    /// For every full-length block of the random basis, calling
+    /// [`DeltaSignatureIndex::find_match_bytes`] with the corresponding
+    /// rolling digest and the original window MUST return `Some(_)`. A
+    /// `None` here would mean the bithash dropped a match that was already
+    /// in the lookup table.
+    #[test]
+    fn bithash_never_misses_inserted_block(data in basis_strategy()) {
+        let index = build_index(&data).expect("index from random basis");
+        let block_length = index.block_length();
+
+        let n_full = data.len() / block_length;
+        for i in 0..n_full {
+            let start = i * block_length;
+            let window = &data[start..start + block_length];
+            let digest = index.block(i).rolling();
+
+            // Contiguous probe.
+            let found_bytes = index.find_match_bytes(digest, window);
+            prop_assert!(
+                found_bytes.is_some(),
+                "bithash dropped block {i} on the contiguous path",
+            );
+
+            // Split probe at every offset, including the boundaries.
+            for split in [0usize, 1, block_length / 2, block_length - 1, block_length] {
+                let (first, second) = window.split_at(split);
+                let found_slices = index.find_match_slices(digest, first, second);
+                prop_assert!(
+                    found_slices.is_some(),
+                    "bithash dropped block {i} on the split path at split={split}",
+                );
+            }
+        }
+    }
+
+    /// Standalone bithash invariant: every inserted rsum is reported present.
+    ///
+    /// Drives the [`BitHash`] type directly with arbitrary `(n_blocks, rsums)`
+    /// pairs to confirm the no-false-negative contract independently of the
+    /// surrounding index.
+    #[test]
+    fn bithash_contains_every_inserted_rsum(
+        n_blocks in 1usize..=4096,
+        rsums in proptest::collection::vec(any::<u32>(), 1..=512),
+    ) {
+        let mut bh = BitHash::with_block_count(n_blocks);
+        for &rsum in &rsums {
+            bh.insert(rsum);
+        }
+        for &rsum in &rsums {
+            prop_assert!(
+                bh.contains(rsum),
+                "bithash dropped previously-inserted rsum {rsum:#x}",
+            );
+        }
+    }
+
+    /// `clear` must preserve the no-false-negative contract for any rsums
+    /// inserted after the reset, even when bits left from earlier inserts
+    /// would otherwise alias.
+    #[test]
+    fn bithash_clear_then_reinsert_round_trips(
+        first in proptest::collection::vec(any::<u32>(), 1..=256),
+        second in proptest::collection::vec(any::<u32>(), 1..=256),
+    ) {
+        let mut bh = BitHash::with_block_count(2048);
+        for &rsum in &first {
+            bh.insert(rsum);
+        }
+        bh.clear();
+        for &rsum in &second {
+            bh.insert(rsum);
+        }
+        for &rsum in &second {
+            prop_assert!(bh.contains(rsum));
+        }
+    }
+}

--- a/crates/match/src/index/builder.rs
+++ b/crates/match/src/index/builder.rs
@@ -2,21 +2,23 @@
 //!
 //! Provides [`from_signature`](DeltaSignatureIndex::from_signature) and
 //! [`rebuild`](DeltaSignatureIndex::rebuild) methods that populate the tag
-//! table and lookup map from a [`FileSignature`].
+//! table, bithash prefilter, and lookup map from a [`FileSignature`].
 
 use rustc_hash::FxHashMap;
 
 use signature::{FileSignature, SignatureAlgorithm, SignatureBlock};
 
-use super::{DeltaSignatureIndex, TAG_TABLE_SIZE};
+use super::{BitHash, DeltaSignatureIndex, TAG_TABLE_SIZE};
 
-/// Shared helper that indexes full-length blocks into the tag table and lookup map.
+/// Shared helper that indexes full-length blocks into the tag table, bithash,
+/// and lookup map.
 ///
 /// Returns `true` if at least one full-length block was indexed.
 fn populate_index(
     blocks: &[SignatureBlock],
     block_length: usize,
     tag_table: &mut [bool],
+    bithash: &mut BitHash,
     lookup: &mut FxHashMap<(u16, u16), Vec<usize>>,
 ) -> bool {
     let mut has_full_blocks = false;
@@ -27,6 +29,7 @@ fn populate_index(
         has_full_blocks = true;
         let digest = block.rolling();
         tag_table[digest.sum1() as usize] = true;
+        bithash.insert(digest.value());
         lookup
             .entry((digest.sum1(), digest.sum2()))
             .or_default()
@@ -53,8 +56,15 @@ impl DeltaSignatureIndex {
         let mut lookup: FxHashMap<(u16, u16), Vec<usize>> =
             FxHashMap::with_capacity_and_hasher(blocks.len(), Default::default());
         let mut tag_table = vec![false; TAG_TABLE_SIZE];
+        let mut bithash = BitHash::with_block_count(blocks.len());
 
-        if !populate_index(&blocks, block_length, &mut tag_table, &mut lookup) {
+        if !populate_index(
+            &blocks,
+            block_length,
+            &mut tag_table,
+            &mut bithash,
+            &mut lookup,
+        ) {
             return None;
         }
 
@@ -65,6 +75,7 @@ impl DeltaSignatureIndex {
             blocks,
             lookup,
             tag_table,
+            bithash,
         })
     }
 
@@ -88,11 +99,13 @@ impl DeltaSignatureIndex {
         self.blocks.extend_from_slice(signature.blocks());
         self.lookup.clear();
         self.tag_table.iter_mut().for_each(|v| *v = false);
+        self.bithash.clear();
 
         populate_index(
             &self.blocks,
             block_length,
             &mut self.tag_table,
+            &mut self.bithash,
             &mut self.lookup,
         )
     }

--- a/crates/match/src/index/mod.rs
+++ b/crates/match/src/index/mod.rs
@@ -7,8 +7,11 @@
 //! Uses [`FxHashMap`] for 2-5x faster lookups compared to std HashMap,
 //! optimized for small integer keys like `(u16, u16)`.
 
+mod bithash;
 mod builder;
 
+#[cfg(test)]
+mod bithash_tests;
 #[cfg(test)]
 mod tests;
 
@@ -19,6 +22,8 @@ use rustc_hash::FxHashMap;
 use checksums::RollingDigest;
 
 use signature::{SignatureAlgorithm, SignatureBlock};
+
+use bithash::BitHash;
 
 /// Size of the tag table for quick rolling checksum rejection (2^16 entries).
 ///
@@ -45,6 +50,12 @@ pub struct DeltaSignatureIndex {
     /// Tag table for O(1) rejection using sum1 (low 16 bits of rolling checksum).
     /// upstream: match.c - `tag_table[s1]` check before hash probe.
     tag_table: Vec<bool>,
+    /// Bithash prefilter mixing both rolling-sum halves.
+    ///
+    /// Sized to roughly 8x the rsum-bucket count (~1 byte per indexed block),
+    /// the bithash rejects ~7/8 of post-tag misses before the FxHashMap walk.
+    /// Mirrors zsync's `librcksum/rsum.c:362-366` probe expression.
+    bithash: BitHash,
 }
 
 impl DeltaSignatureIndex {
@@ -83,6 +94,13 @@ impl DeltaSignatureIndex {
         // upstream: match.c - tag_table[s1] fast-path rejects most non-matching
         // positions before the more expensive hash probe.
         if !self.tag_table[digest.sum1() as usize] {
+            return None;
+        }
+
+        // zsync-style bithash prefilter: rejects ~7/8 of post-tag misses
+        // using both sum halves before the FxHashMap probe. One-sided, so
+        // never produces a false negative.
+        if !self.bithash.contains(digest.value()) {
             return None;
         }
 
@@ -159,6 +177,10 @@ impl DeltaSignatureIndex {
         }
 
         if !self.tag_table[digest.sum1() as usize] {
+            return None;
+        }
+
+        if !self.bithash.contains(digest.value()) {
             return None;
         }
 


### PR DESCRIPTION
## Summary

- Add zsync-inspired bithash prefilter (`crates/match/src/index/bithash.rs`) to `DeltaSignatureIndex`. Sized to ~8x the rsum-bucket count per `docs/design/zsync-bithash.md` section 1, populated alongside `tag_table` in `populate_index`, and probed in both `find_match_bytes` and `find_match_slices` between the tag_table gate and the FxHashMap walk.
- Wire `BitHash::clear()` into `DeltaSignatureIndex::rebuild` so the INC_RECURSE per-segment rebuild path recycles the bit array without re-allocating, mirroring the existing `tag_table` reset.
- Property tests (`bithash_tests.rs`, proptest 1.4) pin the no-false-negative contract end-to-end (every inserted basis block is still found through both probe paths) and at the `BitHash` level (every inserted rsum survives `contains`, including after `clear` + reinsert).

## Wire-compat

In-memory only. No signature payload, NDX framing, capability string, multiplex frame, golden-byte fixture, or interop matrix is touched. The only observable effect is reduced receiver CPU during delta search.

## Test plan

- [ ] `nextest run -p matching --all-features` (CI)
- [ ] fmt + clippy (CI)
- [ ] Windows / macOS / Linux musl matrices (CI)
- [ ] Interop matrix vs upstream 3.0.9 / 3.1.3 / 3.4.1 (CI)