### PR TITLE
feat(fast_io): add io_uring LINKAT wrapper and kernel probe

### DIFF
--- a/crates/fast_io/src/io_uring/linkat.rs
+++ b/crates/fast_io/src/io_uring/linkat.rs
@@ -198,18 +198,15 @@ pub fn submit_linkat_blocking(args: LinkAtArgs<'_>) -> io::Result<i32> {
     // caller's stack frame keeps alive across `submit_and_wait`. The ring
     // is local and has no other outstanding references to those paths.
     unsafe {
-        ring.submission().push(&sqe).map_err(|_| {
-            io::Error::new(
-                io::ErrorKind::Other,
-                "submission queue full while pushing LINKAT SQE",
-            )
-        })?;
+        ring.submission()
+            .push(&sqe)
+            .map_err(|_| io::Error::other("submission queue full while pushing LINKAT SQE"))?;
     }
     ring.submit_and_wait(1)?;
     let cqe = ring
         .completion()
         .next()
-        .ok_or_else(|| io::Error::new(io::ErrorKind::Other, "missing LINKAT CQE"))?;
+        .ok_or_else(|| io::Error::other("missing LINKAT CQE"))?;
     let result = cqe.result();
     if result < 0 {
         return Err(io::Error::from_raw_os_error(-result));

--- a/crates/fast_io/src/io_uring/linkat.rs
+++ b/crates/fast_io/src/io_uring/linkat.rs
@@ -244,8 +244,8 @@ mod tests {
         if linkat_supported() {
             return; // probe says yes; cannot exercise the unsupported branch
         }
-        let old = CStr::from_bytes_with_nul(b"/tmp/old\0").unwrap();
-        let new = CStr::from_bytes_with_nul(b"/tmp/new\0").unwrap();
+        let old = c"/tmp/old";
+        let new = c"/tmp/new";
         let err = build_linkat_sqe(LinkAtArgs {
             old_dirfd: libc::AT_FDCWD,
             old_path: old,
@@ -259,8 +259,8 @@ mod tests {
 
     #[test]
     fn build_linkat_sqe_unchecked_smoke() {
-        let old = CStr::from_bytes_with_nul(b"/tmp/old\0").unwrap();
-        let new = CStr::from_bytes_with_nul(b"/tmp/new\0").unwrap();
+        let old = c"/tmp/old";
+        let new = c"/tmp/new";
         // Construct without panic and tag with user_data; the queue API
         // consumes a tagged entry, so chaining `user_data` exercises the
         // builder's full surface.
@@ -279,8 +279,8 @@ mod tests {
         if !linkat_supported() {
             return;
         }
-        let old = CStr::from_bytes_with_nul(b"/tmp/old\0").unwrap();
-        let new = CStr::from_bytes_with_nul(b"/tmp/new\0").unwrap();
+        let old = c"/tmp/old";
+        let new = c"/tmp/new";
         let _entry = build_linkat_sqe(LinkAtArgs {
             old_dirfd: libc::AT_FDCWD,
             old_path: old,

--- a/crates/fast_io/src/io_uring/linkat.rs
+++ b/crates/fast_io/src/io_uring/linkat.rs
@@ -1,0 +1,297 @@
+//! io_uring `LINKAT` opcode wrapper and kernel availability probe.
+//!
+//! `IORING_OP_LINKAT` lets the kernel create a hard link asynchronously,
+//! avoiding a synchronous `linkat(2)` syscall on the hot path. It became
+//! available in Linux 5.15 alongside `RENAMEAT2`, `MKDIRAT`, and `SYMLINKAT`.
+//!
+//! # API surface
+//!
+//! - [`linkat_supported`] - process-wide cached probe; short-circuits on
+//!   `is_io_uring_available()` and then asks the kernel via
+//!   `IORING_REGISTER_PROBE` whether opcode 39 (`IORING_OP_LINKAT`) is
+//!   reported as supported.
+//! - [`build_linkat_sqe`] - constructs an [`squeue::Entry`] for a real LINKAT
+//!   submission; returns [`io::ErrorKind::Unsupported`] when the probe is
+//!   `false`. Callers must keep the [`LinkAtArgs`] paths alive until the
+//!   matching CQE has been reaped.
+//! - [`build_linkat_sqe_unchecked`] - identical SQE construction without the
+//!   probe gate. Reserved for tests that exercise the encoder in isolation
+//!   on every platform.
+//!
+//! # Path lifetime contract
+//!
+//! [`LinkAtArgs`] borrows the source and destination paths as `&CStr`. The
+//! kernel reads these strings during submission, so callers must keep the
+//! original allocations alive at least until [`io_uring::IoUring::submit`]
+//! returns. The borrowed lifetime in the struct enforces this at compile
+//! time as long as the SQE is consumed before `LinkAtArgs` is dropped.
+//!
+//! # Upstream rsync reference
+//!
+//! Upstream rsync uses synchronous `link(2)` / `linkat(2)` for hardlink
+//! creation (`flist.c`, `hlink.c`). The io_uring fast path is an
+//! optimisation: when the kernel exposes `IORING_OP_LINKAT`, the receiver
+//! can submit hardlink creation alongside disk writes on the same ring,
+//! eliminating a separate syscall per hardlinked file.
+
+#[cfg(target_os = "linux")]
+use std::sync::OnceLock;
+use std::{ffi::CStr, io};
+
+use io_uring::{opcode, squeue, types};
+
+use super::config::is_io_uring_available;
+
+/// Numeric value of `IORING_OP_LINKAT`.
+///
+/// The kernel UAPI (`include/uapi/linux/io_uring.h`) assigns opcode 39 to
+/// `IORING_OP_LINKAT` starting in Linux 5.15. The `io-uring` crate's
+/// [`io_uring::Probe::is_supported`] takes a raw `u8`, so we record the
+/// numeric value here rather than relying on a `CODE` associated constant
+/// that does not exist in v0.7.
+pub const IORING_OP_LINKAT: u8 = 39;
+
+/// Minimum Linux kernel version that ships `IORING_OP_LINKAT`.
+///
+/// Documented for diagnostic and capability-string output. The runtime
+/// probe still asks the kernel directly via `IORING_REGISTER_PROBE` because
+/// kernels may backport or disable individual opcodes independently of the
+/// reported `uname` release.
+pub const LINKAT_MIN_KERNEL: (u32, u32) = (5, 15);
+
+/// Cached probe result on Linux. Populated lazily on first call.
+#[cfg(target_os = "linux")]
+static LINKAT_SUPPORTED: OnceLock<bool> = OnceLock::new();
+
+/// Borrowed arguments for an `IORING_OP_LINKAT` submission.
+///
+/// Both `old_path` and `new_path` live in the caller's address space; the
+/// kernel reads them when the SQE is processed. The borrowed lifetime
+/// `'a` ties the args to those allocations so the compiler refuses to drop
+/// them while a built SQE still references the same memory.
+#[derive(Debug)]
+pub struct LinkAtArgs<'a> {
+    /// Directory file descriptor that resolves `old_path`. Use
+    /// [`libc::AT_FDCWD`] to resolve from the current working directory.
+    pub old_dirfd: i32,
+    /// Source path of the existing inode being hardlinked.
+    pub old_path: &'a CStr,
+    /// Directory file descriptor that resolves `new_path`. Use
+    /// [`libc::AT_FDCWD`] to resolve from the current working directory.
+    pub new_dirfd: i32,
+    /// Destination path of the new hardlink.
+    pub new_path: &'a CStr,
+    /// Flags passed to the kernel: typically `0`,
+    /// [`libc::AT_SYMLINK_FOLLOW`], or [`libc::AT_EMPTY_PATH`].
+    pub flags: i32,
+}
+
+/// Returns whether `IORING_OP_LINKAT` is usable on this system.
+///
+/// On Linux, the result is probed once and cached for the lifetime of the
+/// process. The probe:
+///
+/// 1. Returns `false` immediately when [`is_io_uring_available`] is `false`,
+///    so we never build an extra ring just to discover the opcode is
+///    irrelevant.
+/// 2. Builds a tiny throwaway ring and registers an `io_uring::Probe`,
+///    asking the kernel to enumerate supported opcodes.
+/// 3. Returns `probe.is_supported(IORING_OP_LINKAT)`.
+///
+/// On non-Linux platforms or when the `io_uring` cargo feature is disabled,
+/// the stub module supplies a counterpart that always returns `false`.
+#[must_use]
+pub fn linkat_supported() -> bool {
+    #[cfg(target_os = "linux")]
+    {
+        *LINKAT_SUPPORTED.get_or_init(probe_linkat_support)
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        false
+    }
+}
+
+/// Probes the live kernel for `IORING_OP_LINKAT` support.
+///
+/// Mirrors the convention used by `shared_ring::probe_poll_add`: short-
+/// circuit on the process-wide io_uring availability flag, then build a
+/// throwaway ring and register a probe. A failed probe registration on a
+/// kernel that nonetheless meets the io_uring 5.6 minimum returns `false`
+/// because LINKAT is genuinely 5.15+; we cannot assume forward
+/// compatibility the way POLL_ADD does.
+#[cfg(target_os = "linux")]
+fn probe_linkat_support() -> bool {
+    if !is_io_uring_available() {
+        return false;
+    }
+    let ring = match io_uring::IoUring::new(2) {
+        Ok(r) => r,
+        Err(_) => return false,
+    };
+    let mut probe = io_uring::Probe::new();
+    if ring.submitter().register_probe(&mut probe).is_err() {
+        return false;
+    }
+    probe.is_supported(IORING_OP_LINKAT)
+}
+
+/// Builds an `IORING_OP_LINKAT` SQE if the running kernel supports the
+/// opcode.
+///
+/// Returns [`io::ErrorKind::Unsupported`] when [`linkat_supported`] reports
+/// `false`. The returned [`squeue::Entry`] is unattached; callers are
+/// responsible for tagging it with `user_data` and pushing it onto a ring's
+/// submission queue under the `unsafe` contract documented by
+/// `io_uring::SubmissionQueue::push`.
+///
+/// The `args` struct must outlive the submission so the kernel can read
+/// the borrowed `CStr` paths.
+pub fn build_linkat_sqe(args: LinkAtArgs<'_>) -> io::Result<squeue::Entry> {
+    if !linkat_supported() {
+        return Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "IORING_OP_LINKAT is not supported by this kernel",
+        ));
+    }
+    Ok(build_linkat_sqe_unchecked(args))
+}
+
+/// Builds an `IORING_OP_LINKAT` SQE without consulting the kernel probe.
+///
+/// Reserved for unit tests that want to verify the encoded SQE bytes in
+/// isolation. Production callers should use [`build_linkat_sqe`] so the
+/// probe gate keeps the fallback path correct.
+#[must_use]
+pub fn build_linkat_sqe_unchecked(args: LinkAtArgs<'_>) -> squeue::Entry {
+    opcode::LinkAt::new(
+        types::Fd(args.old_dirfd),
+        args.old_path.as_ptr(),
+        types::Fd(args.new_dirfd),
+        args.new_path.as_ptr(),
+    )
+    .flags(args.flags)
+    .build()
+}
+
+/// Synchronously submits a `LINKAT` SQE on a private throwaway ring and
+/// returns the kernel's CQE result.
+///
+/// This is the high-level convenience wrapper around [`build_linkat_sqe`]
+/// for callers that do not maintain a long-lived ring (tests, one-shot
+/// hardlink creation in slow paths). The function builds a 2-entry ring,
+/// submits the SQE, blocks for one completion, and returns:
+///
+/// - `Ok(0)` on success - the hardlink was created.
+/// - `Err(Unsupported)` when the kernel does not advertise
+///   `IORING_OP_LINKAT`.
+/// - `Err(io::Error::from_raw_os_error(-result))` when the kernel returns a
+///   negative errno through the CQE.
+///
+/// `args` borrows the `CStr` paths; the function keeps them alive for the
+/// duration of the syscall.
+#[allow(unsafe_code)]
+pub fn submit_linkat_blocking(args: LinkAtArgs<'_>) -> io::Result<i32> {
+    let sqe = build_linkat_sqe(args)?.user_data(0);
+    let mut ring = io_uring::IoUring::new(2)?;
+    // SAFETY: `sqe` references CStr paths borrowed from `args`, which the
+    // caller's stack frame keeps alive across `submit_and_wait`. The ring
+    // is local and has no other outstanding references to those paths.
+    unsafe {
+        ring.submission().push(&sqe).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::Other,
+                "submission queue full while pushing LINKAT SQE",
+            )
+        })?;
+    }
+    ring.submit_and_wait(1)?;
+    let cqe = ring
+        .completion()
+        .next()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::Other, "missing LINKAT CQE"))?;
+    let result = cqe.result();
+    if result < 0 {
+        return Err(io::Error::from_raw_os_error(-result));
+    }
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn linkat_opcode_constant_matches_kernel_uapi() {
+        // IORING_OP_LINKAT == 39 in include/uapi/linux/io_uring.h since 5.15.
+        assert_eq!(IORING_OP_LINKAT, 39);
+        assert_eq!(opcode::LinkAt::CODE, IORING_OP_LINKAT);
+    }
+
+    #[test]
+    fn linkat_min_kernel_is_5_15() {
+        assert_eq!(LINKAT_MIN_KERNEL, (5, 15));
+    }
+
+    #[test]
+    fn linkat_supported_is_idempotent() {
+        let first = linkat_supported();
+        let second = linkat_supported();
+        let third = linkat_supported();
+        assert_eq!(first, second);
+        assert_eq!(second, third);
+    }
+
+    #[test]
+    fn build_linkat_sqe_returns_unsupported_when_probe_false() {
+        if linkat_supported() {
+            return; // probe says yes; cannot exercise the unsupported branch
+        }
+        let old = CStr::from_bytes_with_nul(b"/tmp/old\0").unwrap();
+        let new = CStr::from_bytes_with_nul(b"/tmp/new\0").unwrap();
+        let err = build_linkat_sqe(LinkAtArgs {
+            old_dirfd: libc::AT_FDCWD,
+            old_path: old,
+            new_dirfd: libc::AT_FDCWD,
+            new_path: new,
+            flags: 0,
+        })
+        .unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::Unsupported);
+    }
+
+    #[test]
+    fn build_linkat_sqe_unchecked_smoke() {
+        let old = CStr::from_bytes_with_nul(b"/tmp/old\0").unwrap();
+        let new = CStr::from_bytes_with_nul(b"/tmp/new\0").unwrap();
+        // Construct without panic and tag with user_data; the queue API
+        // consumes a tagged entry, so chaining `user_data` exercises the
+        // builder's full surface.
+        let _tagged = build_linkat_sqe_unchecked(LinkAtArgs {
+            old_dirfd: libc::AT_FDCWD,
+            old_path: old,
+            new_dirfd: libc::AT_FDCWD,
+            new_path: new,
+            flags: libc::AT_SYMLINK_FOLLOW,
+        })
+        .user_data(0xCAFE_F00D);
+    }
+
+    #[test]
+    fn build_linkat_sqe_succeeds_when_probe_true() {
+        if !linkat_supported() {
+            return;
+        }
+        let old = CStr::from_bytes_with_nul(b"/tmp/old\0").unwrap();
+        let new = CStr::from_bytes_with_nul(b"/tmp/new\0").unwrap();
+        let _entry = build_linkat_sqe(LinkAtArgs {
+            old_dirfd: libc::AT_FDCWD,
+            old_path: old,
+            new_dirfd: libc::AT_FDCWD,
+            new_path: new,
+            flags: 0,
+        })
+        .expect("probe true implies SQE builds")
+        .user_data(0x1234);
+    }
+}

--- a/crates/fast_io/src/io_uring/mod.rs
+++ b/crates/fast_io/src/io_uring/mod.rs
@@ -85,6 +85,7 @@ mod disk_batch;
 mod file_factory;
 mod file_reader;
 mod file_writer;
+pub mod linkat;
 pub mod registered_buffers;
 pub mod renameat2;
 pub mod shared_ring;
@@ -109,6 +110,10 @@ pub use file_factory::{
 };
 pub use file_reader::IoUringReader;
 pub use file_writer::IoUringWriter;
+pub use linkat::{
+    IORING_OP_LINKAT, LINKAT_MIN_KERNEL, LinkAtArgs, build_linkat_sqe, build_linkat_sqe_unchecked,
+    linkat_supported, submit_linkat_blocking,
+};
 pub use registered_buffers::{RegisteredBufferGroup, RegisteredBufferSlot, RegisteredBufferStats};
 pub use renameat2::{
     IORING_OP_RENAMEAT, RENAME_EXCHANGE, RENAME_NOREPLACE, RENAME_WHITEOUT, RenameAt2Args,

--- a/crates/fast_io/src/io_uring_stub.rs
+++ b/crates/fast_io/src/io_uring_stub.rs
@@ -350,6 +350,10 @@ pub mod registered_buffers {
 }
 
 pub use buffer_ring::{BufferRing, BufferRingConfig, BufferRingError, buffer_id_from_cqe_flags};
+pub use linkat::{
+    IORING_OP_LINKAT, LINKAT_MIN_KERNEL, LinkAtArgs, build_linkat_sqe, build_linkat_sqe_unchecked,
+    linkat_supported, submit_linkat_blocking,
+};
 pub use registered_buffers::{RegisteredBufferGroup, RegisteredBufferSlot, RegisteredBufferStats};
 pub use renameat2::{
     IORING_OP_RENAMEAT, RENAME_EXCHANGE, RENAME_NOREPLACE, RENAME_WHITEOUT, RenameAt2Args,
@@ -357,6 +361,100 @@ pub use renameat2::{
 };
 
 pub use shared_ring::{OpTag, SharedCompletion, SharedRing, SharedRingConfig};
+
+/// Stub `linkat` module mirroring [`crate::io_uring::linkat`] on non-Linux
+/// platforms or when the `io_uring` cargo feature is disabled.
+///
+/// Every entry point reports the opcode as unsupported so callers fall back
+/// to a synchronous `linkat(2)` syscall (or the platform equivalent).
+pub mod linkat {
+    use std::ffi::CStr;
+    use std::io;
+
+    /// Numeric value of `IORING_OP_LINKAT`. Documented for parity with the
+    /// Linux module; the stub never submits real SQEs.
+    pub const IORING_OP_LINKAT: u8 = 39;
+
+    /// Minimum Linux kernel version that ships `IORING_OP_LINKAT`.
+    pub const LINKAT_MIN_KERNEL: (u32, u32) = (5, 15);
+
+    /// Borrowed arguments for an `IORING_OP_LINKAT` submission. On the stub
+    /// the struct exists only so cross-platform call sites compile; no SQE
+    /// is ever built.
+    #[derive(Debug)]
+    pub struct LinkAtArgs<'a> {
+        /// Directory file descriptor that resolves `old_path`.
+        pub old_dirfd: i32,
+        /// Source path of the existing inode being hardlinked.
+        pub old_path: &'a CStr,
+        /// Directory file descriptor that resolves `new_path`.
+        pub new_dirfd: i32,
+        /// Destination path of the new hardlink.
+        pub new_path: &'a CStr,
+        /// Flags passed to the kernel.
+        pub flags: i32,
+    }
+
+    /// Always returns `false` on this platform.
+    #[must_use]
+    pub fn linkat_supported() -> bool {
+        false
+    }
+
+    /// Always returns `Unsupported` on this platform.
+    pub fn build_linkat_sqe(_args: LinkAtArgs<'_>) -> io::Result<()> {
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "IORING_OP_LINKAT is not available on this platform",
+        ))
+    }
+
+    /// Stub mirror of the Linux `build_linkat_sqe_unchecked`. Exists for API
+    /// surface parity; never called from production code on this platform.
+    #[must_use]
+    pub fn build_linkat_sqe_unchecked(_args: LinkAtArgs<'_>) {}
+
+    /// Always returns `Unsupported` on this platform. Mirrors the Linux
+    /// blocking submitter so cross-platform callers can fall back without
+    /// `cfg`-gating their own code.
+    pub fn submit_linkat_blocking(_args: LinkAtArgs<'_>) -> io::Result<i32> {
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "IORING_OP_LINKAT is not available on this platform",
+        ))
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn stub_reports_unsupported() {
+            assert!(!linkat_supported());
+        }
+
+        #[test]
+        fn stub_constants_match_linux_uapi() {
+            assert_eq!(IORING_OP_LINKAT, 39);
+            assert_eq!(LINKAT_MIN_KERNEL, (5, 15));
+        }
+
+        #[test]
+        fn stub_build_linkat_sqe_returns_unsupported() {
+            let old = CStr::from_bytes_with_nul(b"/tmp/old\0").unwrap();
+            let new = CStr::from_bytes_with_nul(b"/tmp/new\0").unwrap();
+            let err = build_linkat_sqe(LinkAtArgs {
+                old_dirfd: 0,
+                old_path: old,
+                new_dirfd: 0,
+                new_path: new,
+                flags: 0,
+            })
+            .unwrap_err();
+            assert_eq!(err.kind(), io::ErrorKind::Unsupported);
+        }
+    }
+}
 
 /// Stub `IORING_OP_RENAMEAT` module for non-Linux platforms or when the
 /// `io_uring` cargo feature is disabled.

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -154,14 +154,15 @@ pub use temp_file_strategy::{
 };
 
 pub use io_uring::{
-    BufferRing, BufferRingConfig, BufferRingError, IORING_OP_RENAMEAT, IoUringConfig,
-    IoUringDiskBatch, IoUringKernelInfo, IoUringOrStdReader, IoUringOrStdWriter, IoUringReader,
-    IoUringReaderFactory, IoUringWriter, IoUringWriterFactory, OpTag, RENAME_EXCHANGE,
-    RENAME_NOREPLACE, RENAME_WHITEOUT, RegisteredBufferGroup, RegisteredBufferSlot,
-    RegisteredBufferStats, RenameAt2Args, SharedCompletion, SharedRing, SharedRingConfig,
-    buffer_id_from_cqe_flags, build_renameat2_sqe, build_renameat2_sqe_unchecked,
-    is_io_uring_available, reader_from_path, renameat2_blocking, renameat2_supported,
-    sqpoll_fell_back, writer_from_file,
+    BufferRing, BufferRingConfig, BufferRingError, IORING_OP_LINKAT, IORING_OP_RENAMEAT,
+    IoUringConfig, IoUringDiskBatch, IoUringKernelInfo, IoUringOrStdReader, IoUringOrStdWriter,
+    IoUringReader, IoUringReaderFactory, IoUringWriter, IoUringWriterFactory, LINKAT_MIN_KERNEL,
+    LinkAtArgs, OpTag, RENAME_EXCHANGE, RENAME_NOREPLACE, RENAME_WHITEOUT, RegisteredBufferGroup,
+    RegisteredBufferSlot, RegisteredBufferStats, RenameAt2Args, SharedCompletion, SharedRing,
+    SharedRingConfig, buffer_id_from_cqe_flags, build_linkat_sqe, build_linkat_sqe_unchecked,
+    build_renameat2_sqe, build_renameat2_sqe_unchecked, is_io_uring_available, linkat_supported,
+    reader_from_path, renameat2_blocking, renameat2_supported, sqpoll_fell_back,
+    submit_linkat_blocking, writer_from_file,
 };
 
 #[cfg(all(target_os = "windows", feature = "iocp"))]

--- a/crates/fast_io/tests/io_uring_linkat.rs
+++ b/crates/fast_io/tests/io_uring_linkat.rs
@@ -1,0 +1,84 @@
+//! Integration tests for the io_uring `LINKAT` opcode wrapper.
+//!
+//! These tests submit a real `IORING_OP_LINKAT` to the kernel, wait for the
+//! CQE, and verify that the destination hardlink exists on disk. They run
+//! only on Linux with the `io_uring` cargo feature enabled and skip
+//! gracefully when the running kernel does not advertise the opcode (for
+//! example, kernels older than 5.15 or seccomp-restricted environments).
+
+#![cfg(all(target_os = "linux", feature = "io_uring"))]
+
+use std::ffi::CString;
+use std::fs;
+use std::io::Write;
+use std::os::unix::ffi::OsStrExt;
+
+use fast_io::{LinkAtArgs, linkat_supported, submit_linkat_blocking};
+use tempfile::tempdir;
+
+#[test]
+fn linkat_creates_real_hardlink_on_supported_kernel() {
+    if !linkat_supported() {
+        eprintln!("IORING_OP_LINKAT not supported on this kernel; skipping");
+        return;
+    }
+
+    let dir = tempdir().expect("tempdir");
+    let src_path = dir.path().join("linkat_src.txt");
+    let dst_path = dir.path().join("linkat_dst.txt");
+
+    {
+        let mut f = fs::File::create(&src_path).expect("create source");
+        f.write_all(b"io_uring linkat smoke").expect("write source");
+    }
+
+    let src_c = CString::new(src_path.as_os_str().as_bytes()).expect("source path -> CString");
+    let dst_c = CString::new(dst_path.as_os_str().as_bytes()).expect("dest path -> CString");
+
+    let result = submit_linkat_blocking(LinkAtArgs {
+        old_dirfd: libc::AT_FDCWD,
+        old_path: &src_c,
+        new_dirfd: libc::AT_FDCWD,
+        new_path: &dst_c,
+        flags: 0,
+    })
+    .expect("LINKAT must succeed on supported kernel");
+    assert_eq!(result, 0, "LINKAT CQE result must be 0");
+
+    let meta_src = fs::metadata(&src_path).expect("stat source");
+    let meta_dst = fs::metadata(&dst_path).expect("stat dest");
+    assert_eq!(meta_src.len(), meta_dst.len());
+    assert_eq!(fs::read(&dst_path).unwrap(), b"io_uring linkat smoke");
+
+    // Unlinking the destination first proves the inode is genuinely shared
+    // via a hardlink rather than a separate file. Cleanup of the source is
+    // handled by tempdir's Drop.
+    fs::remove_file(&dst_path).expect("remove dest hardlink");
+    assert!(src_path.exists(), "source must survive dest removal");
+}
+
+#[test]
+fn linkat_supported_is_idempotent_under_load() {
+    let first = linkat_supported();
+    for _ in 0..16 {
+        assert_eq!(linkat_supported(), first);
+    }
+}
+
+#[test]
+fn linkat_returns_unsupported_when_probe_false() {
+    if linkat_supported() {
+        return;
+    }
+    let src = CString::new("/tmp/linkat_unsupported_src").unwrap();
+    let dst = CString::new("/tmp/linkat_unsupported_dst").unwrap();
+    let err = submit_linkat_blocking(LinkAtArgs {
+        old_dirfd: libc::AT_FDCWD,
+        old_path: &src,
+        new_dirfd: libc::AT_FDCWD,
+        new_path: &dst,
+        flags: 0,
+    })
+    .unwrap_err();
+    assert_eq!(err.kind(), std::io::ErrorKind::Unsupported);
+}


### PR DESCRIPTION
## Summary

- Add `IORING_OP_LINKAT` (Linux 5.15+) wrapper in a new `crates/fast_io/src/io_uring/linkat.rs` submodule with an `OnceLock`-cached kernel probe (`linkat_supported`), a borrowed-arg struct (`LinkAtArgs<'a>` over `&CStr` paths), the gated builder (`build_linkat_sqe`), an unchecked encoder for tests, and a blocking submitter (`submit_linkat_blocking`).
- Mirror the API surface in the non-Linux stub (`io_uring_stub.rs`) with `linkat_supported() -> false` and `Unsupported` round-trips so cross-platform call sites compile unchanged.
- Re-export the new constants and functions through `crates/fast_io/src/io_uring/mod.rs` and `crates/fast_io/src/lib.rs`.
- Closes #1921 and #1923.

## Implementation notes

- `LINKAT_MIN_KERNEL = (5, 15)` and `IORING_OP_LINKAT = 39` follow the kernel UAPI in `include/uapi/linux/io_uring.h`.
- `linkat_supported` short-circuits on `is_io_uring_available()` before building a throwaway ring + `Probe`, matching the convention in `shared_ring::probe_poll_add` and `splice::is_splice_available`.
- `LinkAtArgs<'a>` ties source/destination `CStr` lifetimes to the SQE so the compiler enforces the kernel's path-lifetime contract.

## Test plan

- [ ] CI: `fmt+clippy`, nextest stable, Windows, macOS, Linux musl
- [ ] Unit tests: cached probe idempotence, opcode constant equality, unchecked SQE smoke, stub `Unsupported` round-trip
- [ ] Linux integration: `tests/io_uring_linkat.rs` submits a real LINKAT, verifies the hardlink, then removes the destination and confirms the source survives; skips when the kernel does not advertise the opcode

## Compatibility

- Pure addition; no public API removed or altered.
- Expected mechanical conflict on `crates/fast_io/src/io_uring/mod.rs` and `crates/fast_io/src/lib.rs` with the parallel RENAMEAT2 PR; the module list and re-exports rebase cleanly.