### PR TITLE
feat(fast_io): add io_uring RENAMEAT2 wrapper and kernel probe

### DIFF
--- a/crates/fast_io/src/io_uring/mod.rs
+++ b/crates/fast_io/src/io_uring/mod.rs
@@ -86,6 +86,7 @@ mod file_factory;
 mod file_reader;
 mod file_writer;
 pub mod registered_buffers;
+pub mod renameat2;
 pub mod shared_ring;
 mod socket_factory;
 mod socket_reader;
@@ -109,6 +110,10 @@ pub use file_factory::{
 pub use file_reader::IoUringReader;
 pub use file_writer::IoUringWriter;
 pub use registered_buffers::{RegisteredBufferGroup, RegisteredBufferSlot, RegisteredBufferStats};
+pub use renameat2::{
+    IORING_OP_RENAMEAT, RENAME_EXCHANGE, RENAME_NOREPLACE, RENAME_WHITEOUT, RenameAt2Args,
+    build_renameat2_sqe, build_renameat2_sqe_unchecked, renameat2_blocking, renameat2_supported,
+};
 pub use shared_ring::{OpTag, SharedCompletion, SharedRing, SharedRingConfig};
 pub use socket_factory::{
     IoUringOrStdSocketReader, IoUringOrStdSocketWriter, socket_reader_from_fd,

--- a/crates/fast_io/src/io_uring/renameat2.rs
+++ b/crates/fast_io/src/io_uring/renameat2.rs
@@ -1,0 +1,279 @@
+//! `IORING_OP_RENAMEAT` (RENAMEAT2) submission helpers and kernel probe.
+//!
+//! `IORING_OP_RENAMEAT` was added in Linux 5.11 and exposes the same
+//! capabilities as the userspace `renameat2(2)` syscall, including the
+//! `RENAME_NOREPLACE`, `RENAME_EXCHANGE`, and `RENAME_WHITEOUT` flags. This
+//! module wraps `io_uring::opcode::RenameAt` with an availability probe that
+//! mirrors the patterns already used for `IORING_OP_POLL_ADD`
+//! (see [`super::shared_ring`]) and the splice syscall
+//! (see [`crate::splice::is_splice_available`]).
+//!
+//! # Probe semantics
+//!
+//! [`renameat2_supported`] returns `true` only when both:
+//!
+//! 1. [`is_io_uring_available`] reports the base subsystem usable, and
+//! 2. `IORING_REGISTER_PROBE` reports opcode 35 (`IORING_OP_RENAMEAT`)
+//!    as supported.
+//!
+//! The result is cached in a `OnceLock` so subsequent calls are a single
+//! atomic load. When the probe registration itself fails (extremely old
+//! kernels or seccomp-restricted environments) the probe falls back to
+//! `false` because, unlike `POLL_ADD`, RENAMEAT was added much later than
+//! the io_uring subsystem itself and cannot be safely assumed.
+//!
+//! # SQE construction
+//!
+//! [`build_renameat2_sqe`] returns an [`io_uring::squeue::Entry`] with no
+//! `user_data` set; callers tag the entry with their own demux scheme via
+//! [`io_uring::squeue::Entry::user_data`]. The CStr borrows must outlive
+//! the SQE submission and the kernel completion (the io-uring crate enforces
+//! this with the `RenameAt` builder accepting raw `*const c_char`).
+//!
+//! # Upstream reference
+//!
+//! Upstream rsync uses `renameat(2)` for atomic temp-file commits in
+//! `generator.c:rename_tmp_file()`. The `RENAME_NOREPLACE` flag matches
+//! the `--ignore-existing` invariant; `RENAME_EXCHANGE` allows atomic swap
+//! of two existing names without deleting either. `RENAME_WHITEOUT` is an
+//! overlayfs-only primitive included for completeness because the kernel
+//! UAPI exposes all three flags through the same syscall and SQE field.
+
+use std::ffi::CStr;
+use std::io;
+use std::os::raw::c_int;
+use std::sync::OnceLock;
+
+use io_uring::{IoUring as RawIoUring, opcode, squeue, types};
+
+use super::config::is_io_uring_available;
+
+pub use libc::{RENAME_EXCHANGE, RENAME_NOREPLACE, RENAME_WHITEOUT};
+
+/// `IORING_OP_RENAMEAT` opcode number.
+///
+/// Hard-coded because `io_uring::Probe::is_supported` takes a raw `u8` and
+/// the io-uring 0.7 crate does not expose a `CODE` constant on
+/// `opcode::RenameAt`. The value matches `include/uapi/linux/io_uring.h`
+/// (kernel 5.11+).
+pub const IORING_OP_RENAMEAT: u8 = 35;
+
+/// Cached result of the RENAMEAT2 opcode probe.
+static RENAMEAT2_SUPPORTED: OnceLock<bool> = OnceLock::new();
+
+/// Returns whether `IORING_OP_RENAMEAT` is usable on this kernel.
+///
+/// The result is probed once and cached for the lifetime of the process.
+/// Returns `false` immediately when the base io_uring subsystem is
+/// unavailable, when probe registration fails, or when the probe explicitly
+/// reports the opcode as unsupported. On non-Linux platforms the stub in
+/// [`crate::io_uring_stub`] always returns `false`.
+#[must_use]
+pub fn renameat2_supported() -> bool {
+    *RENAMEAT2_SUPPORTED.get_or_init(probe_renameat2_support)
+}
+
+/// Probes opcode 35 by building a transient ring and calling
+/// `IORING_REGISTER_PROBE`.
+fn probe_renameat2_support() -> bool {
+    if !is_io_uring_available() {
+        return false;
+    }
+    let ring = match RawIoUring::new(2) {
+        Ok(r) => r,
+        Err(_) => return false,
+    };
+    let mut probe = io_uring::Probe::new();
+    if ring.submitter().register_probe(&mut probe).is_err() {
+        // Probe registration itself is not supported. Unlike POLL_ADD which
+        // predates the probe API, RENAMEAT was added in 5.11 (probe API in
+        // 5.6) so a missing probe means a kernel old enough to lack
+        // RENAMEAT entirely.
+        return false;
+    }
+    probe.is_supported(IORING_OP_RENAMEAT)
+}
+
+/// Borrowed arguments for an `IORING_OP_RENAMEAT` submission.
+///
+/// All paths are borrowed `&CStr` so callers retain ownership of the path
+/// storage and the borrow checker enforces that the storage outlives the
+/// `RenameAt2Args`. The directory file descriptors follow the standard
+/// `*at` syscall convention (`AT_FDCWD` for cwd-relative paths).
+#[derive(Debug, Clone, Copy)]
+pub struct RenameAt2Args<'a> {
+    /// Directory fd that `old_path` is resolved against (`AT_FDCWD` for cwd).
+    pub old_dir_fd: c_int,
+    /// Old path; must outlive the SQE submission and completion.
+    pub old_path: &'a CStr,
+    /// Directory fd that `new_path` is resolved against (`AT_FDCWD` for cwd).
+    pub new_dir_fd: c_int,
+    /// New path; must outlive the SQE submission and completion.
+    pub new_path: &'a CStr,
+    /// Bitwise OR of [`RENAME_NOREPLACE`], [`RENAME_EXCHANGE`], and
+    /// [`RENAME_WHITEOUT`]. Zero is a plain rename equivalent to
+    /// `renameat(2)`.
+    pub flags: u32,
+}
+
+/// Builds an `IORING_OP_RENAMEAT` SQE after verifying kernel support.
+///
+/// Returns [`io::ErrorKind::Unsupported`] when [`renameat2_supported`]
+/// reports `false`, so callers can fall back to a synchronous
+/// `renameat2(2)` call (or to plain `renameat(2)` for `flags == 0`).
+///
+/// The returned entry has no `user_data` set; the caller is expected to tag
+/// it via [`io_uring::squeue::Entry::user_data`] before pushing it onto a
+/// submission queue.
+pub fn build_renameat2_sqe(args: RenameAt2Args<'_>) -> io::Result<squeue::Entry> {
+    if !renameat2_supported() {
+        return Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "IORING_OP_RENAMEAT is not supported on this kernel",
+        ));
+    }
+    Ok(build_renameat2_sqe_unchecked(args))
+}
+
+/// Builds an `IORING_OP_RENAMEAT` SQE without consulting the kernel probe.
+///
+/// Exposed for unit tests that need to exercise the SQE wiring (encoded
+/// opcode, flags field, dirfd handling) without depending on whether the
+/// host kernel actually supports the opcode. Production callers should use
+/// [`build_renameat2_sqe`] so missing kernel support is surfaced as a
+/// proper [`io::ErrorKind::Unsupported`] rather than as a deferred CQE
+/// `-EINVAL`.
+#[must_use]
+pub fn build_renameat2_sqe_unchecked(args: RenameAt2Args<'_>) -> squeue::Entry {
+    opcode::RenameAt::new(
+        types::Fd(args.old_dir_fd),
+        args.old_path.as_ptr(),
+        types::Fd(args.new_dir_fd),
+        args.new_path.as_ptr(),
+    )
+    .flags(args.flags)
+    .build()
+}
+
+/// Synchronously submits a RENAMEAT2 SQE on a transient io_uring instance
+/// and returns the kernel's CQE result.
+///
+/// This is a convenience wrapper used by tests and by callers that do not
+/// want to manage their own ring lifecycle. The CQE result is returned
+/// verbatim (negative `-errno` on failure, `0` on success). On kernels
+/// without RENAMEAT support, returns [`io::ErrorKind::Unsupported`].
+///
+/// The ring is dropped when the call returns, so callers driving
+/// many renames should build their own ring and reuse it via
+/// [`build_renameat2_sqe`] for amortised submission cost.
+pub fn renameat2_blocking(args: RenameAt2Args<'_>) -> io::Result<i32> {
+    let entry = build_renameat2_sqe(args)?.user_data(0);
+    let mut ring = RawIoUring::new(2)?;
+    // SAFETY: `entry` borrows the CStrs in `args`, which outlive this call
+    // because they outlive the function (caller holds the borrow). The
+    // SQE is consumed in-kernel by submit_and_wait(1) before we return.
+    unsafe {
+        ring.submission()
+            .push(&entry)
+            .map_err(|_| io::Error::other("submission queue full"))?;
+    }
+    ring.submit_and_wait(1)?;
+    let cqe = ring.completion().next().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::Other,
+            "submit_and_wait(1) returned but no CQE was reaped",
+        )
+    })?;
+    Ok(cqe.result())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::CString;
+
+    #[test]
+    fn opcode_constant_matches_kernel_uapi() {
+        // Sanity check against the kernel UAPI value. If the io-uring crate
+        // ever exposes a `CODE` associated constant for `opcode::RenameAt`,
+        // this assert keeps that path honest as well.
+        assert_eq!(IORING_OP_RENAMEAT, 35);
+    }
+
+    #[test]
+    fn libc_flags_are_re_exported() {
+        // Re-export verification: the constants must be addressable via
+        // this module so callers do not have to depend on libc directly.
+        assert_eq!(RENAME_NOREPLACE, libc::RENAME_NOREPLACE);
+        assert_eq!(RENAME_EXCHANGE, libc::RENAME_EXCHANGE);
+        assert_eq!(RENAME_WHITEOUT, libc::RENAME_WHITEOUT);
+        // The kernel UAPI assigns these distinct bit positions.
+        assert_eq!(RENAME_NOREPLACE, 1);
+        assert_eq!(RENAME_EXCHANGE, 2);
+        assert_eq!(RENAME_WHITEOUT, 4);
+    }
+
+    #[test]
+    fn probe_is_idempotent() {
+        // Caching contract: the probe value must not change between calls.
+        let first = renameat2_supported();
+        let second = renameat2_supported();
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn probe_implies_io_uring_available() {
+        // Logical implication: RENAMEAT support is impossible without the
+        // base subsystem.
+        if renameat2_supported() {
+            assert!(is_io_uring_available());
+        }
+    }
+
+    #[test]
+    fn unchecked_sqe_smoke() {
+        // Ensure SQE construction does not panic and accepts every flag
+        // combination the kernel UAPI exposes. We do not submit the SQE;
+        // this exercises only the io-uring crate's builder.
+        let old = CString::new("/tmp/oc-rsync-renameat2-old").unwrap();
+        let new = CString::new("/tmp/oc-rsync-renameat2-new").unwrap();
+        for flags in [
+            0,
+            RENAME_NOREPLACE,
+            RENAME_EXCHANGE,
+            RENAME_WHITEOUT,
+            RENAME_NOREPLACE | RENAME_WHITEOUT,
+        ] {
+            let args = RenameAt2Args {
+                old_dir_fd: libc::AT_FDCWD,
+                old_path: &old,
+                new_dir_fd: libc::AT_FDCWD,
+                new_path: &new,
+                flags,
+            };
+            let _entry = build_renameat2_sqe_unchecked(args);
+        }
+    }
+
+    #[test]
+    fn checked_sqe_matches_probe() {
+        // The checked builder must agree with the cached probe: it returns
+        // `Ok` exactly when the probe is true, and `Unsupported` otherwise.
+        let old = CString::new("/tmp/oc-rsync-renameat2-old").unwrap();
+        let new = CString::new("/tmp/oc-rsync-renameat2-new").unwrap();
+        let args = RenameAt2Args {
+            old_dir_fd: libc::AT_FDCWD,
+            old_path: &old,
+            new_dir_fd: libc::AT_FDCWD,
+            new_path: &new,
+            flags: 0,
+        };
+        match build_renameat2_sqe(args) {
+            Ok(_) => assert!(renameat2_supported()),
+            Err(e) => {
+                assert!(!renameat2_supported());
+                assert_eq!(e.kind(), io::ErrorKind::Unsupported);
+            }
+        }
+    }
+}

--- a/crates/fast_io/src/io_uring/renameat2.rs
+++ b/crates/fast_io/src/io_uring/renameat2.rs
@@ -178,12 +178,10 @@ pub fn renameat2_blocking(args: RenameAt2Args<'_>) -> io::Result<i32> {
             .map_err(|_| io::Error::other("submission queue full"))?;
     }
     ring.submit_and_wait(1)?;
-    let cqe = ring.completion().next().ok_or_else(|| {
-        io::Error::new(
-            io::ErrorKind::Other,
-            "submit_and_wait(1) returned but no CQE was reaped",
-        )
-    })?;
+    let cqe = ring
+        .completion()
+        .next()
+        .ok_or_else(|| io::Error::other("submit_and_wait(1) returned but no CQE was reaped"))?;
     Ok(cqe.result())
 }
 

--- a/crates/fast_io/src/io_uring_stub.rs
+++ b/crates/fast_io/src/io_uring_stub.rs
@@ -351,8 +351,89 @@ pub mod registered_buffers {
 
 pub use buffer_ring::{BufferRing, BufferRingConfig, BufferRingError, buffer_id_from_cqe_flags};
 pub use registered_buffers::{RegisteredBufferGroup, RegisteredBufferSlot, RegisteredBufferStats};
+pub use renameat2::{
+    IORING_OP_RENAMEAT, RENAME_EXCHANGE, RENAME_NOREPLACE, RENAME_WHITEOUT, RenameAt2Args,
+    build_renameat2_sqe, build_renameat2_sqe_unchecked, renameat2_blocking, renameat2_supported,
+};
 
 pub use shared_ring::{OpTag, SharedCompletion, SharedRing, SharedRingConfig};
+
+/// Stub `IORING_OP_RENAMEAT` module for non-Linux platforms or when the
+/// `io_uring` cargo feature is disabled.
+///
+/// Mirrors the public surface of `crate::io_uring::renameat2`:
+/// `renameat2_supported()` is always `false`, `build_renameat2_sqe`
+/// returns `io::ErrorKind::Unsupported`, and the libc rename flags are
+/// re-exported under their stable kernel-UAPI values so callers can name
+/// them without `cfg`-gating.
+pub mod renameat2 {
+    use std::ffi::CStr;
+    use std::io;
+    use std::os::raw::c_int;
+
+    /// `IORING_OP_RENAMEAT` opcode number. Stable across kernels.
+    pub const IORING_OP_RENAMEAT: u8 = 35;
+
+    /// `RENAME_NOREPLACE` flag value (kernel UAPI constant).
+    pub const RENAME_NOREPLACE: u32 = 1;
+    /// `RENAME_EXCHANGE` flag value (kernel UAPI constant).
+    pub const RENAME_EXCHANGE: u32 = 2;
+    /// `RENAME_WHITEOUT` flag value (kernel UAPI constant).
+    pub const RENAME_WHITEOUT: u32 = 4;
+
+    /// Stub argument struct mirroring [`crate::io_uring::renameat2::RenameAt2Args`].
+    #[derive(Debug, Clone, Copy)]
+    pub struct RenameAt2Args<'a> {
+        /// Directory fd that `old_path` is resolved against.
+        pub old_dir_fd: c_int,
+        /// Old path (CStr borrow).
+        pub old_path: &'a CStr,
+        /// Directory fd that `new_path` is resolved against.
+        pub new_dir_fd: c_int,
+        /// New path (CStr borrow).
+        pub new_path: &'a CStr,
+        /// Bitwise OR of `RENAME_NOREPLACE`, `RENAME_EXCHANGE`,
+        /// `RENAME_WHITEOUT`.
+        pub flags: u32,
+    }
+
+    /// Stub opaque SQE returned by [`build_renameat2_sqe_unchecked`] on
+    /// platforms that lack io_uring. Carries no kernel state; exists only
+    /// so cross-platform code compiles.
+    #[derive(Debug, Clone, Copy)]
+    pub struct StubSqe {
+        _private: (),
+    }
+
+    /// Always returns `false` on this platform.
+    #[must_use]
+    pub fn renameat2_supported() -> bool {
+        false
+    }
+
+    /// Always returns `Unsupported` on this platform.
+    pub fn build_renameat2_sqe(_args: RenameAt2Args<'_>) -> io::Result<StubSqe> {
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "IORING_OP_RENAMEAT is not available on this platform",
+        ))
+    }
+
+    /// Returns a stub SQE; only useful as a constructor smoke test on
+    /// non-Linux platforms.
+    #[must_use]
+    pub fn build_renameat2_sqe_unchecked(_args: RenameAt2Args<'_>) -> StubSqe {
+        StubSqe { _private: () }
+    }
+
+    /// Always returns `Unsupported` on this platform.
+    pub fn renameat2_blocking(_args: RenameAt2Args<'_>) -> io::Result<i32> {
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "IORING_OP_RENAMEAT is not available on this platform",
+        ))
+    }
+}
 
 /// Stub shared-ring module mirroring [`crate::io_uring::shared_ring`] on
 /// non-Linux platforms or when the `io_uring` cargo feature is disabled.
@@ -1238,6 +1319,63 @@ mod tests {
     #[test]
     fn io_uring_unavailable_on_stub_platform() {
         assert!(!is_io_uring_available());
+    }
+
+    #[test]
+    fn renameat2_unsupported_on_stub_platform() {
+        assert!(!renameat2_supported());
+    }
+
+    #[test]
+    fn renameat2_constants_match_kernel_uapi() {
+        assert_eq!(IORING_OP_RENAMEAT, 35);
+        assert_eq!(RENAME_NOREPLACE, 1);
+        assert_eq!(RENAME_EXCHANGE, 2);
+        assert_eq!(RENAME_WHITEOUT, 4);
+    }
+
+    #[test]
+    fn renameat2_build_sqe_returns_unsupported_on_stub() {
+        let old = std::ffi::CString::new("/tmp/stub-old").unwrap();
+        let new = std::ffi::CString::new("/tmp/stub-new").unwrap();
+        let args = RenameAt2Args {
+            old_dir_fd: -100, // AT_FDCWD value, kernel-stable
+            old_path: &old,
+            new_dir_fd: -100,
+            new_path: &new,
+            flags: 0,
+        };
+        let err = build_renameat2_sqe(args).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::Unsupported);
+    }
+
+    #[test]
+    fn renameat2_unchecked_returns_stub_sqe() {
+        let old = std::ffi::CString::new("/tmp/stub-old").unwrap();
+        let new = std::ffi::CString::new("/tmp/stub-new").unwrap();
+        let args = RenameAt2Args {
+            old_dir_fd: -100,
+            old_path: &old,
+            new_dir_fd: -100,
+            new_path: &new,
+            flags: RENAME_NOREPLACE | RENAME_EXCHANGE,
+        };
+        let _stub = build_renameat2_sqe_unchecked(args);
+    }
+
+    #[test]
+    fn renameat2_blocking_returns_unsupported_on_stub() {
+        let old = std::ffi::CString::new("/tmp/stub-old").unwrap();
+        let new = std::ffi::CString::new("/tmp/stub-new").unwrap();
+        let args = RenameAt2Args {
+            old_dir_fd: -100,
+            old_path: &old,
+            new_dir_fd: -100,
+            new_path: &new,
+            flags: 0,
+        };
+        let err = renameat2_blocking(args).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::Unsupported);
     }
 
     #[test]

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -154,12 +154,14 @@ pub use temp_file_strategy::{
 };
 
 pub use io_uring::{
-    BufferRing, BufferRingConfig, BufferRingError, IoUringConfig, IoUringDiskBatch,
-    IoUringKernelInfo, IoUringOrStdReader, IoUringOrStdWriter, IoUringReader, IoUringReaderFactory,
-    IoUringWriter, IoUringWriterFactory, OpTag, RegisteredBufferGroup, RegisteredBufferSlot,
-    RegisteredBufferStats, SharedCompletion, SharedRing, SharedRingConfig,
-    buffer_id_from_cqe_flags, is_io_uring_available, reader_from_path, sqpoll_fell_back,
-    writer_from_file,
+    BufferRing, BufferRingConfig, BufferRingError, IORING_OP_RENAMEAT, IoUringConfig,
+    IoUringDiskBatch, IoUringKernelInfo, IoUringOrStdReader, IoUringOrStdWriter, IoUringReader,
+    IoUringReaderFactory, IoUringWriter, IoUringWriterFactory, OpTag, RENAME_EXCHANGE,
+    RENAME_NOREPLACE, RENAME_WHITEOUT, RegisteredBufferGroup, RegisteredBufferSlot,
+    RegisteredBufferStats, RenameAt2Args, SharedCompletion, SharedRing, SharedRingConfig,
+    buffer_id_from_cqe_flags, build_renameat2_sqe, build_renameat2_sqe_unchecked,
+    is_io_uring_available, reader_from_path, renameat2_blocking, renameat2_supported,
+    sqpoll_fell_back, writer_from_file,
 };
 
 #[cfg(all(target_os = "windows", feature = "iocp"))]

--- a/crates/fast_io/tests/io_uring_renameat2.rs
+++ b/crates/fast_io/tests/io_uring_renameat2.rs
@@ -1,0 +1,158 @@
+//! Integration tests for the `IORING_OP_RENAMEAT` (RENAMEAT2) wrapper.
+//!
+//! These tests exercise the real kernel path via [`fast_io::renameat2_blocking`],
+//! which builds and submits a single SQE on a transient ring and reaps the
+//! resulting CQE. The whole suite is a no-op on non-Linux platforms or when
+//! the `io_uring` cargo feature is disabled.
+//!
+//! Each test short-circuits to a successful skip when
+//! [`fast_io::renameat2_supported`] reports `false`, so kernels older than
+//! 5.11 (or environments where seccomp blocks io_uring) do not produce
+//! spurious failures.
+
+#![cfg(all(target_os = "linux", feature = "io_uring"))]
+
+use std::ffi::CString;
+use std::fs;
+use std::io::Write;
+use std::os::unix::ffi::OsStrExt;
+
+use fast_io::{
+    RENAME_EXCHANGE, RENAME_NOREPLACE, RenameAt2Args, build_renameat2_sqe, is_io_uring_available,
+    renameat2_blocking, renameat2_supported,
+};
+
+#[test]
+fn renameat2_renames_a_real_file() {
+    if !renameat2_supported() {
+        eprintln!("skipping: IORING_OP_RENAMEAT not supported on this kernel");
+        return;
+    }
+    assert!(is_io_uring_available());
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let src = dir.path().join("renameat2-src");
+    let dst = dir.path().join("renameat2-dst");
+    fs::write(&src, b"renameat2 payload").expect("seed source file");
+
+    let src_c = CString::new(src.as_os_str().as_bytes()).expect("nul-free path");
+    let dst_c = CString::new(dst.as_os_str().as_bytes()).expect("nul-free path");
+
+    let args = RenameAt2Args {
+        old_dir_fd: libc::AT_FDCWD,
+        old_path: &src_c,
+        new_dir_fd: libc::AT_FDCWD,
+        new_path: &dst_c,
+        flags: 0,
+    };
+    let cqe_result = renameat2_blocking(args).expect("blocking submit must succeed");
+    assert_eq!(cqe_result, 0, "RENAMEAT CQE returned errno {cqe_result}");
+
+    assert!(!src.exists(), "source must be unlinked after rename");
+    assert!(dst.exists(), "destination must exist after rename");
+    let content = fs::read(&dst).expect("destination readable");
+    assert_eq!(content, b"renameat2 payload");
+}
+
+#[test]
+fn renameat2_noreplace_rejects_existing_destination() {
+    if !renameat2_supported() {
+        eprintln!("skipping: IORING_OP_RENAMEAT not supported on this kernel");
+        return;
+    }
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let src = dir.path().join("noreplace-src");
+    let dst = dir.path().join("noreplace-dst");
+    fs::write(&src, b"src").expect("seed source");
+    {
+        let mut f = fs::File::create(&dst).expect("seed destination");
+        f.write_all(b"dst").expect("write");
+    }
+
+    let src_c = CString::new(src.as_os_str().as_bytes()).expect("nul-free");
+    let dst_c = CString::new(dst.as_os_str().as_bytes()).expect("nul-free");
+
+    let args = RenameAt2Args {
+        old_dir_fd: libc::AT_FDCWD,
+        old_path: &src_c,
+        new_dir_fd: libc::AT_FDCWD,
+        new_path: &dst_c,
+        flags: RENAME_NOREPLACE,
+    };
+    let cqe_result = renameat2_blocking(args).expect("blocking submit must succeed");
+    assert_eq!(
+        cqe_result,
+        -libc::EEXIST,
+        "RENAME_NOREPLACE must fail with -EEXIST when destination exists"
+    );
+    assert_eq!(fs::read(&src).unwrap(), b"src");
+    assert_eq!(fs::read(&dst).unwrap(), b"dst");
+}
+
+#[test]
+fn renameat2_exchange_swaps_two_files() {
+    if !renameat2_supported() {
+        eprintln!("skipping: IORING_OP_RENAMEAT not supported on this kernel");
+        return;
+    }
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let a = dir.path().join("exchange-a");
+    let b = dir.path().join("exchange-b");
+    fs::write(&a, b"AAAA").expect("seed a");
+    fs::write(&b, b"BBBB").expect("seed b");
+
+    let a_c = CString::new(a.as_os_str().as_bytes()).expect("nul-free");
+    let b_c = CString::new(b.as_os_str().as_bytes()).expect("nul-free");
+
+    let args = RenameAt2Args {
+        old_dir_fd: libc::AT_FDCWD,
+        old_path: &a_c,
+        new_dir_fd: libc::AT_FDCWD,
+        new_path: &b_c,
+        flags: RENAME_EXCHANGE,
+    };
+    let cqe_result = renameat2_blocking(args).expect("blocking submit must succeed");
+    if cqe_result == -libc::EINVAL {
+        // Some filesystems (older overlayfs, certain tmpfs configurations)
+        // report EXCHANGE as unsupported even when the kernel opcode itself
+        // is available. Treat this as a skip rather than a failure.
+        eprintln!("skipping exchange test: filesystem does not support RENAME_EXCHANGE");
+        return;
+    }
+    assert_eq!(
+        cqe_result, 0,
+        "RENAME_EXCHANGE CQE returned errno {cqe_result}"
+    );
+
+    assert_eq!(fs::read(&a).unwrap(), b"BBBB", "a must now hold b's data");
+    assert_eq!(fs::read(&b).unwrap(), b"AAAA", "b must now hold a's data");
+}
+
+#[test]
+fn renameat2_supported_is_idempotent() {
+    let first = renameat2_supported();
+    let second = renameat2_supported();
+    assert_eq!(first, second);
+}
+
+#[test]
+fn build_renameat2_sqe_agrees_with_probe() {
+    let old = CString::new("/tmp/probe-agreement-old").unwrap();
+    let new = CString::new("/tmp/probe-agreement-new").unwrap();
+    let args = RenameAt2Args {
+        old_dir_fd: libc::AT_FDCWD,
+        old_path: &old,
+        new_dir_fd: libc::AT_FDCWD,
+        new_path: &new,
+        flags: 0,
+    };
+    let result = build_renameat2_sqe(args);
+    if renameat2_supported() {
+        assert!(result.is_ok());
+    } else {
+        let err = result.unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::Unsupported);
+    }
+}


### PR DESCRIPTION
## Summary

- Wraps `IORING_OP_RENAMEAT` (kernel 5.11+) in `crates/fast_io/src/io_uring/renameat2.rs` with a `OnceLock`-cached opcode probe (`renameat2_supported()`), a borrowed-path argument struct (`RenameAt2Args<'a>`), checked + unchecked SQE builders, and a `renameat2_blocking()` convenience that drives a transient ring end-to-end.
- Re-exports `RENAME_NOREPLACE`, `RENAME_EXCHANGE`, `RENAME_WHITEOUT` from libc so callers do not depend on libc directly.
- Mirrored stubs in `io_uring_stub.rs` keep the cross-platform surface identical: `renameat2_supported() -> false`, builders return `Unsupported`.
- Linux-gated integration test in `crates/fast_io/tests/io_uring_renameat2.rs` exercises a real rename, `RENAME_NOREPLACE` rejection (`-EEXIST`), and an exchange swap; each case skips gracefully when the probe reports unsupported.

Closes #1920
Closes #1922

## Test plan

- [ ] Linux/x86_64 nextest runs the full crate including the new integration test on a 5.11+ kernel.
- [ ] Linux/x86_64 nextest with `--no-default-features` skips the io_uring path and the stub tests cover the Unsupported round-trip.
- [ ] macOS / Windows nextest compiles the stub module and its tests.
- [ ] `cargo fmt --all -- --check` clean.
- [ ] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` clean.