### PR TITLE
feat(cli): add --simd flag for runtime SIMD level override

### DIFF
--- a/crates/checksums/src/cpu_features.rs
+++ b/crates/checksums/src/cpu_features.rs
@@ -286,8 +286,7 @@ mod tests {
             assert_eq!(
                 SimdLevel::parse_cli(level.as_cli_str()),
                 Some(level),
-                "round trip for {:?}",
-                level
+                "round trip for {level:?}"
             );
         }
     }
@@ -317,7 +316,7 @@ mod tests {
             SimdFeature::Sse2,
             SimdFeature::Neon,
         ] {
-            assert!(allowed(SimdLevel::Auto, feature), "auto: {:?}", feature);
+            assert!(allowed(SimdLevel::Auto, feature), "auto: {feature:?}");
         }
     }
 
@@ -331,7 +330,7 @@ mod tests {
             SimdFeature::Sse2,
             SimdFeature::Neon,
         ] {
-            assert!(!allowed(SimdLevel::None, feature), "none: {:?}", feature);
+            assert!(!allowed(SimdLevel::None, feature), "none: {feature:?}");
         }
     }
 
@@ -363,7 +362,7 @@ mod tests {
             SimdFeature::Ssse3,
             SimdFeature::Sse2,
         ] {
-            assert!(!allowed(SimdLevel::Neon, feature), "neon vs {:?}", feature);
+            assert!(!allowed(SimdLevel::Neon, feature), "neon vs {feature:?}");
         }
         assert!(allowed(SimdLevel::Neon, SimdFeature::Neon));
     }
@@ -379,12 +378,7 @@ mod tests {
             SimdLevel::None,
         ] {
             let byte = level_to_byte(level);
-            assert_eq!(
-                byte_to_level(byte),
-                Some(level),
-                "round trip for {:?}",
-                level
-            );
+            assert_eq!(byte_to_level(byte), Some(level), "round trip for {level:?}");
         }
     }
 

--- a/crates/checksums/src/cpu_features.rs
+++ b/crates/checksums/src/cpu_features.rs
@@ -1,0 +1,396 @@
+//! Runtime SIMD level override for checksum dispatch.
+//!
+//! This module exposes a process-global override that lets callers pin SIMD
+//! dispatch to a specific instruction-set level (or force the scalar fallback)
+//! regardless of what the host CPU advertises. The CLI uses this to honour
+//! the `--simd=<level>` flag, and benchmarks/tests use it to exercise specific
+//! code paths.
+//!
+//! # Semantics
+//!
+//! - [`SimdLevel::Auto`] keeps the existing CPUID-based selection.
+//! - Any other variant caps the dispatcher at the requested level. The
+//!   dispatcher still verifies CPU support before activating a backend, so an
+//!   override that is wider than the host's capabilities silently degrades to
+//!   the next available backend.
+//! - [`SimdLevel::None`] forces the scalar reference path on every dispatcher.
+//!
+//! The override is set once via [`set_simd_override`] and read by every
+//! checksum dispatcher (rolling `x86`/`neon`, MD5 batch dispatcher) before
+//! consulting CPUID. Subsequent calls to [`set_simd_override`] succeed only
+//! when the value matches the previously set one - the override is a
+//! one-shot, process-global handshake established at startup. Tests can
+//! reset the override through the gated [`reset_simd_override_for_tests`]
+//! helper.
+//!
+//! The override is stored in a process-global [`AtomicU8`] so reads are
+//! lock-free on every dispatch.
+
+use std::sync::atomic::{AtomicU8, Ordering};
+
+/// SIMD instruction-set level the dispatcher should target.
+///
+/// `Auto` lets the dispatcher choose the widest backend the host CPU supports.
+/// Every other variant caps dispatch at that level (or forces scalar). The
+/// variants intentionally mirror the CLI surface: AVX-512, AVX2, SSE4 (x86
+/// only), NEON (aarch64 only), and `None` for scalar.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum SimdLevel {
+    /// Use CPUID-based detection (default behaviour).
+    #[default]
+    Auto,
+    /// Cap dispatch at AVX-512 (x86_64 only). Falls back to lower SIMD or
+    /// scalar on architectures without AVX-512.
+    Avx512,
+    /// Cap dispatch at AVX2 (x86_64 only). Falls back to scalar on other
+    /// architectures.
+    Avx2,
+    /// Cap dispatch at SSE4-class instructions (x86_64 only). Maps to the
+    /// SSE4.1/SSSE3/SSE2 family for the MD5 dispatcher and to SSE2 for the
+    /// rolling checksum (which has no SSE4 path).
+    Sse4,
+    /// Cap dispatch at NEON (aarch64 only). Falls back to scalar on other
+    /// architectures.
+    Neon,
+    /// Force the scalar reference path for every dispatcher.
+    None,
+}
+
+impl SimdLevel {
+    /// Parses a SIMD level from its CLI spelling.
+    ///
+    /// Accepts the canonical lower-case forms (`auto`, `avx512`, `avx2`,
+    /// `sse4`, `neon`, `none`) plus a small set of aliases (e.g. `avx-512`,
+    /// `sse4.1`) for human convenience. Returns `None` for unrecognised
+    /// spellings so the caller can render a CLI-appropriate error.
+    #[must_use]
+    pub fn parse_cli(value: &str) -> Option<Self> {
+        let normalized: String = value
+            .chars()
+            .filter(|c| !matches!(c, '-' | '_' | '.'))
+            .flat_map(char::to_lowercase)
+            .collect();
+
+        match normalized.as_str() {
+            "auto" => Some(Self::Auto),
+            "avx512" | "avx512f" | "avx512bw" => Some(Self::Avx512),
+            "avx2" => Some(Self::Avx2),
+            "sse4" | "sse41" | "sse4a" | "ssse3" | "sse2" => Some(Self::Sse4),
+            "neon" | "asimd" => Some(Self::Neon),
+            "none" | "off" | "scalar" | "disabled" => Some(Self::None),
+            _ => None,
+        }
+    }
+
+    /// Returns the canonical CLI spelling for this level.
+    #[must_use]
+    pub const fn as_cli_str(self) -> &'static str {
+        match self {
+            Self::Auto => "auto",
+            Self::Avx512 => "avx512",
+            Self::Avx2 => "avx2",
+            Self::Sse4 => "sse4",
+            Self::Neon => "neon",
+            Self::None => "none",
+        }
+    }
+}
+
+/// Subset of SIMD capabilities the dispatcher consults.
+///
+/// Each variant maps to a CPU feature gate the dispatcher verifies before
+/// activating a backend. The override layer answers
+/// [`feature_allowed`](self::feature_allowed) by intersecting the active
+/// override with the host's CPUID-detected capabilities.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SimdFeature {
+    /// AVX-512F + AVX-512BW (16-lane MD5 backend).
+    Avx512,
+    /// AVX2 (rolling checksum 32-byte loop, 8-lane MD5 backend).
+    Avx2,
+    /// SSE4.1 (4-lane MD5 backend with `blendv`).
+    Sse41,
+    /// SSSE3 (4-lane MD5 backend with `pshufb`).
+    Ssse3,
+    /// SSE2 baseline (rolling checksum 16-byte loop, 4-lane MD5 backend).
+    Sse2,
+    /// ARM NEON (aarch64 4-lane MD5 backend, 16-byte rolling-checksum loop).
+    Neon,
+}
+
+/// Sentinel byte indicating the override has not been installed.
+///
+/// Distinct from `SimdLevel::Auto as u8` so callers can distinguish "never
+/// set" (treated as `Auto` for dispatch) from "explicitly set to `Auto`".
+const UNINIT: u8 = u8::MAX;
+
+static OVERRIDE: AtomicU8 = AtomicU8::new(UNINIT);
+
+#[inline]
+const fn level_to_byte(level: SimdLevel) -> u8 {
+    match level {
+        SimdLevel::Auto => 0,
+        SimdLevel::Avx512 => 1,
+        SimdLevel::Avx2 => 2,
+        SimdLevel::Sse4 => 3,
+        SimdLevel::Neon => 4,
+        SimdLevel::None => 5,
+    }
+}
+
+#[inline]
+fn byte_to_level(byte: u8) -> Option<SimdLevel> {
+    Some(match byte {
+        0 => SimdLevel::Auto,
+        1 => SimdLevel::Avx512,
+        2 => SimdLevel::Avx2,
+        3 => SimdLevel::Sse4,
+        4 => SimdLevel::Neon,
+        5 => SimdLevel::None,
+        _ => return None,
+    })
+}
+
+/// Installs the process-wide SIMD level override.
+///
+/// Call this exactly once during startup, before any checksum dispatcher is
+/// consulted. Subsequent calls are accepted only when they request the same
+/// level, otherwise [`Err`] carries the previously-set value so the caller
+/// can render a diagnostic.
+///
+/// # Errors
+///
+/// Returns the previously-installed level when called more than once with a
+/// different value.
+pub fn set_simd_override(level: SimdLevel) -> Result<(), SimdLevel> {
+    let new_byte = level_to_byte(level);
+    match OVERRIDE.compare_exchange(UNINIT, new_byte, Ordering::SeqCst, Ordering::SeqCst) {
+        Ok(_) => Ok(()),
+        Err(existing_byte) => {
+            let existing = byte_to_level(existing_byte).unwrap_or(SimdLevel::Auto);
+            if existing == level {
+                Ok(())
+            } else {
+                Err(existing)
+            }
+        }
+    }
+}
+
+/// Returns the active SIMD override, defaulting to [`SimdLevel::Auto`].
+#[must_use]
+pub fn simd_override() -> SimdLevel {
+    let byte = OVERRIDE.load(Ordering::SeqCst);
+    if byte == UNINIT {
+        SimdLevel::Auto
+    } else {
+        byte_to_level(byte).unwrap_or(SimdLevel::Auto)
+    }
+}
+
+/// Clears any installed override and reinstalls the supplied value.
+///
+/// Reserved for tests; production code must use [`set_simd_override`] which
+/// preserves the one-shot contract. The helper is `#[doc(hidden)]` and lives
+/// behind a name that telegraphs its intended caller.
+#[doc(hidden)]
+pub fn reset_simd_override_for_tests(level: SimdLevel) {
+    OVERRIDE.store(level_to_byte(level), Ordering::SeqCst);
+}
+
+/// Clears the override entirely so subsequent reads see [`SimdLevel::Auto`].
+#[doc(hidden)]
+pub fn clear_simd_override_for_tests() {
+    OVERRIDE.store(UNINIT, Ordering::SeqCst);
+}
+
+/// Reports whether the requested SIMD feature is permitted by the active
+/// override.
+///
+/// A `true` result means the dispatcher may activate this backend if the host
+/// CPU also exposes the feature; the dispatcher must still consult CPUID. A
+/// `false` result means the override forbids this feature regardless of CPU
+/// support.
+///
+/// The mapping mirrors the CLI semantics:
+///
+/// | Override     | Avx512 | Avx2 | Sse41 | Ssse3 | Sse2 | Neon |
+/// |--------------|:------:|:----:|:-----:|:-----:|:----:|:----:|
+/// | `Auto`       | yes    | yes  | yes   | yes   | yes  | yes  |
+/// | `Avx512`     | yes    | yes  | yes   | yes   | yes  | yes  |
+/// | `Avx2`       | no     | yes  | yes   | yes   | yes  | no   |
+/// | `Sse4`       | no     | no   | yes   | yes   | yes  | no   |
+/// | `Neon`       | no     | no   | no    | no    | no   | yes  |
+/// | `None`       | no     | no   | no    | no    | no   | no   |
+#[must_use]
+pub fn feature_allowed(feature: SimdFeature) -> bool {
+    match (simd_override(), feature) {
+        (SimdLevel::Auto, _) => true,
+        (SimdLevel::None, _) => false,
+
+        (SimdLevel::Avx512, _) => true,
+
+        (SimdLevel::Avx2, SimdFeature::Avx512 | SimdFeature::Neon) => false,
+        (SimdLevel::Avx2, _) => true,
+
+        (SimdLevel::Sse4, SimdFeature::Sse41 | SimdFeature::Ssse3 | SimdFeature::Sse2) => true,
+        (SimdLevel::Sse4, _) => false,
+
+        (SimdLevel::Neon, SimdFeature::Neon) => true,
+        (SimdLevel::Neon, _) => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_canonical_cli_spellings() {
+        assert_eq!(SimdLevel::parse_cli("auto"), Some(SimdLevel::Auto));
+        assert_eq!(SimdLevel::parse_cli("avx512"), Some(SimdLevel::Avx512));
+        assert_eq!(SimdLevel::parse_cli("avx2"), Some(SimdLevel::Avx2));
+        assert_eq!(SimdLevel::parse_cli("sse4"), Some(SimdLevel::Sse4));
+        assert_eq!(SimdLevel::parse_cli("neon"), Some(SimdLevel::Neon));
+        assert_eq!(SimdLevel::parse_cli("none"), Some(SimdLevel::None));
+    }
+
+    #[test]
+    fn parses_aliases_and_case_variants() {
+        assert_eq!(SimdLevel::parse_cli("AVX-512"), Some(SimdLevel::Avx512));
+        assert_eq!(SimdLevel::parse_cli("AVX_2"), Some(SimdLevel::Avx2));
+        assert_eq!(SimdLevel::parse_cli("sse4.1"), Some(SimdLevel::Sse4));
+        assert_eq!(SimdLevel::parse_cli("ssse3"), Some(SimdLevel::Sse4));
+        assert_eq!(SimdLevel::parse_cli("ASIMD"), Some(SimdLevel::Neon));
+        assert_eq!(SimdLevel::parse_cli("Off"), Some(SimdLevel::None));
+        assert_eq!(SimdLevel::parse_cli("scalar"), Some(SimdLevel::None));
+    }
+
+    #[test]
+    fn rejects_unknown_levels() {
+        assert!(SimdLevel::parse_cli("avx1024").is_none());
+        assert!(SimdLevel::parse_cli("").is_none());
+        assert!(SimdLevel::parse_cli("yes").is_none());
+    }
+
+    #[test]
+    fn cli_strings_round_trip() {
+        for level in [
+            SimdLevel::Auto,
+            SimdLevel::Avx512,
+            SimdLevel::Avx2,
+            SimdLevel::Sse4,
+            SimdLevel::Neon,
+            SimdLevel::None,
+        ] {
+            assert_eq!(
+                SimdLevel::parse_cli(level.as_cli_str()),
+                Some(level),
+                "round trip for {:?}",
+                level
+            );
+        }
+    }
+
+    /// Pure-function table check that does not touch the global override.
+    fn allowed(level: SimdLevel, feature: SimdFeature) -> bool {
+        match (level, feature) {
+            (SimdLevel::Auto, _) => true,
+            (SimdLevel::None, _) => false,
+            (SimdLevel::Avx512, _) => true,
+            (SimdLevel::Avx2, SimdFeature::Avx512 | SimdFeature::Neon) => false,
+            (SimdLevel::Avx2, _) => true,
+            (SimdLevel::Sse4, SimdFeature::Sse41 | SimdFeature::Ssse3 | SimdFeature::Sse2) => true,
+            (SimdLevel::Sse4, _) => false,
+            (SimdLevel::Neon, SimdFeature::Neon) => true,
+            (SimdLevel::Neon, _) => false,
+        }
+    }
+
+    #[test]
+    fn auto_allows_everything() {
+        for feature in [
+            SimdFeature::Avx512,
+            SimdFeature::Avx2,
+            SimdFeature::Sse41,
+            SimdFeature::Ssse3,
+            SimdFeature::Sse2,
+            SimdFeature::Neon,
+        ] {
+            assert!(allowed(SimdLevel::Auto, feature), "auto: {:?}", feature);
+        }
+    }
+
+    #[test]
+    fn none_blocks_everything() {
+        for feature in [
+            SimdFeature::Avx512,
+            SimdFeature::Avx2,
+            SimdFeature::Sse41,
+            SimdFeature::Ssse3,
+            SimdFeature::Sse2,
+            SimdFeature::Neon,
+        ] {
+            assert!(!allowed(SimdLevel::None, feature), "none: {:?}", feature);
+        }
+    }
+
+    #[test]
+    fn avx2_caps_below_avx512() {
+        assert!(!allowed(SimdLevel::Avx2, SimdFeature::Avx512));
+        assert!(allowed(SimdLevel::Avx2, SimdFeature::Avx2));
+        assert!(allowed(SimdLevel::Avx2, SimdFeature::Sse41));
+        assert!(allowed(SimdLevel::Avx2, SimdFeature::Sse2));
+        assert!(!allowed(SimdLevel::Avx2, SimdFeature::Neon));
+    }
+
+    #[test]
+    fn sse4_only_allows_sse_family() {
+        assert!(!allowed(SimdLevel::Sse4, SimdFeature::Avx512));
+        assert!(!allowed(SimdLevel::Sse4, SimdFeature::Avx2));
+        assert!(allowed(SimdLevel::Sse4, SimdFeature::Sse41));
+        assert!(allowed(SimdLevel::Sse4, SimdFeature::Ssse3));
+        assert!(allowed(SimdLevel::Sse4, SimdFeature::Sse2));
+        assert!(!allowed(SimdLevel::Sse4, SimdFeature::Neon));
+    }
+
+    #[test]
+    fn neon_only_allows_neon() {
+        for feature in [
+            SimdFeature::Avx512,
+            SimdFeature::Avx2,
+            SimdFeature::Sse41,
+            SimdFeature::Ssse3,
+            SimdFeature::Sse2,
+        ] {
+            assert!(!allowed(SimdLevel::Neon, feature), "neon vs {:?}", feature);
+        }
+        assert!(allowed(SimdLevel::Neon, SimdFeature::Neon));
+    }
+
+    #[test]
+    fn level_byte_round_trip() {
+        for level in [
+            SimdLevel::Auto,
+            SimdLevel::Avx512,
+            SimdLevel::Avx2,
+            SimdLevel::Sse4,
+            SimdLevel::Neon,
+            SimdLevel::None,
+        ] {
+            let byte = level_to_byte(level);
+            assert_eq!(
+                byte_to_level(byte),
+                Some(level),
+                "round trip for {:?}",
+                level
+            );
+        }
+    }
+
+    #[test]
+    fn unknown_byte_decodes_to_none() {
+        assert_eq!(byte_to_level(UNINIT), None);
+        assert_eq!(byte_to_level(99), None);
+    }
+}

--- a/crates/checksums/src/lib.rs
+++ b/crates/checksums/src/lib.rs
@@ -358,6 +358,7 @@
 #![deny(missing_docs)]
 #![deny(rustdoc::broken_intra_doc_links)]
 
+pub mod cpu_features;
 pub mod crc32c;
 mod rolling;
 pub mod strong;
@@ -374,6 +375,15 @@ mod simd_parity_tests;
 /// - MD5: RFC 1321 test vectors pass
 /// - MD4: RFC 1320 test vectors pass
 pub(crate) mod simd_batch;
+
+/// Re-exports the MD5 backend selector used by integration tests of the
+/// runtime SIMD override. Hidden from rustdoc; production code must hash
+/// through [`crc32c`], [`strong`], or the higher-level `simd_batch` API.
+#[doc(hidden)]
+pub mod md5_backend {
+    pub use crate::simd_batch::Backend;
+    pub use crate::simd_batch::md5_dispatcher::Dispatcher;
+}
 
 /// Parallel checksum computation using rayon with automatic sequential fallback.
 pub mod parallel;
@@ -418,6 +428,13 @@ pub use strong::openssl_acceleration_available;
 /// providing automatic use of AVX2 (x86_64) or NEON (aarch64) instructions
 /// when available at runtime.
 pub use strong::xxh3_simd_available;
+
+/// Runtime SIMD level override (set via the `--simd` CLI flag).
+///
+/// See the [`cpu_features`] module for the override API and dispatch
+/// semantics. Re-exported here so callers can use `checksums::SimdLevel`
+/// without depending on the module path.
+pub use cpu_features::{SimdLevel, set_simd_override, simd_override};
 
 /// Re-exports from the [`strong::strategy`] module for runtime checksum algorithm selection.
 ///

--- a/crates/checksums/src/rolling/checksum/neon.rs
+++ b/crates/checksums/src/rolling/checksum/neon.rs
@@ -47,6 +47,7 @@
 #![allow(unsafe_op_in_unsafe_fn)]
 
 use super::accumulate_chunk_scalar_raw;
+use crate::cpu_features::{SimdFeature, feature_allowed};
 use core::arch::aarch64::{
     int16x8_t, vaddlvq_s16, vget_high_s8, vget_low_s8, vld1q_s16, vld1q_u8, vmovl_s8, vmulq_s16,
     vreinterpretq_s8_u8,
@@ -66,14 +67,20 @@ fn neon_available() -> bool {
     *NEON_AVAILABLE.get_or_init(|| std::arch::is_aarch64_feature_detected!("neon"))
 }
 
+/// Honours the CLI override on top of CPUID-style feature detection.
+#[inline]
+fn neon_enabled() -> bool {
+    neon_available() && feature_allowed(SimdFeature::Neon)
+}
+
 #[inline]
 pub(super) fn simd_available() -> bool {
-    neon_available()
+    neon_enabled()
 }
 
 #[inline]
 pub(super) fn accumulate_chunk(s1: u32, s2: u32, len: usize, chunk: &[u8]) -> (u32, u32, usize) {
-    if !neon_available() {
+    if !neon_enabled() {
         return accumulate_chunk_scalar_raw(s1, s2, len, chunk);
     }
 

--- a/crates/checksums/src/rolling/checksum/x86.rs
+++ b/crates/checksums/src/rolling/checksum/x86.rs
@@ -64,6 +64,7 @@ use core::arch::x86_64::{
     _mm256_set1_epi16, _mm256_storeu_si256,
 };
 
+use crate::cpu_features::{SimdFeature, feature_allowed};
 use std::sync::OnceLock;
 
 const SSE2_BLOCK_LEN: usize = 16;
@@ -85,9 +86,19 @@ fn cpu_features() -> FeatureLevel {
     })
 }
 
+/// Returns the AVX2/SSE2 capabilities permitted by both the CLI override and CPUID.
+#[inline]
+fn effective_features() -> FeatureLevel {
+    let detected = cpu_features();
+    FeatureLevel {
+        avx2: detected.avx2 && feature_allowed(SimdFeature::Avx2),
+        sse2: detected.sse2 && feature_allowed(SimdFeature::Sse2),
+    }
+}
+
 #[inline]
 pub(super) fn simd_available() -> bool {
-    let features = cpu_features();
+    let features = effective_features();
     features.avx2 || features.sse2
 }
 
@@ -98,7 +109,7 @@ pub(super) fn try_accumulate_chunk(
     len: usize,
     chunk: &[u8],
 ) -> Option<(u32, u32, usize)> {
-    let features = cpu_features();
+    let features = effective_features();
 
     if chunk.len() >= AVX2_BLOCK_LEN && features.avx2 {
         // SAFETY: AVX2 is available (checked above) and chunk.len() >= AVX2_BLOCK_LEN.

--- a/crates/checksums/src/simd_batch/md5_dispatcher.rs
+++ b/crates/checksums/src/simd_batch/md5_dispatcher.rs
@@ -21,6 +21,7 @@ use super::Digest;
 use super::md5_scalar as scalar;
 #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 use super::md5_simd as simd;
+use crate::cpu_features::{SimdFeature, feature_allowed};
 
 /// Available SIMD backends.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -92,6 +93,11 @@ impl Dispatcher {
     /// Dual-path feature detection: all variants are compiled on all platforms.
     /// On non-matching architectures the detection returns false, so the variant
     /// is never selected at runtime but the code path is still compiled.
+    ///
+    /// Each capability check is gated by the runtime SIMD override
+    /// ([`crate::cpu_features::feature_allowed`]) so the CLI `--simd` flag can
+    /// pin dispatch to a specific level even on hosts that advertise wider
+    /// SIMD support.
     fn detect_backend() -> Backend {
         if Self::has_avx512() {
             return Backend::Avx512;
@@ -118,6 +124,9 @@ impl Dispatcher {
     }
 
     fn has_avx512() -> bool {
+        if !feature_allowed(SimdFeature::Avx512) {
+            return false;
+        }
         #[cfg(target_arch = "x86_64")]
         {
             is_x86_feature_detected!("avx512f") && is_x86_feature_detected!("avx512bw")
@@ -129,6 +138,9 @@ impl Dispatcher {
     }
 
     fn has_avx2() -> bool {
+        if !feature_allowed(SimdFeature::Avx2) {
+            return false;
+        }
         #[cfg(target_arch = "x86_64")]
         {
             is_x86_feature_detected!("avx2")
@@ -140,6 +152,9 @@ impl Dispatcher {
     }
 
     fn has_sse41() -> bool {
+        if !feature_allowed(SimdFeature::Sse41) {
+            return false;
+        }
         #[cfg(target_arch = "x86_64")]
         {
             is_x86_feature_detected!("sse4.1")
@@ -151,6 +166,9 @@ impl Dispatcher {
     }
 
     fn has_ssse3() -> bool {
+        if !feature_allowed(SimdFeature::Ssse3) {
+            return false;
+        }
         #[cfg(target_arch = "x86_64")]
         {
             is_x86_feature_detected!("ssse3")
@@ -162,6 +180,9 @@ impl Dispatcher {
     }
 
     fn has_sse2() -> bool {
+        if !feature_allowed(SimdFeature::Sse2) {
+            return false;
+        }
         #[cfg(target_arch = "x86_64")]
         {
             // SSE2 is baseline for x86_64, always available
@@ -174,6 +195,9 @@ impl Dispatcher {
     }
 
     fn has_neon() -> bool {
+        if !feature_allowed(SimdFeature::Neon) {
+            return false;
+        }
         #[cfg(target_arch = "aarch64")]
         {
             // NEON is mandatory on aarch64

--- a/crates/checksums/src/simd_batch/mod.rs
+++ b/crates/checksums/src/simd_batch/mod.rs
@@ -14,7 +14,7 @@
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
-mod md5_dispatcher;
+pub(crate) mod md5_dispatcher;
 mod md5_scalar;
 #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 mod md5_simd;

--- a/crates/checksums/tests/simd_override.rs
+++ b/crates/checksums/tests/simd_override.rs
@@ -89,8 +89,7 @@ fn override_caps_md5_dispatcher_below_host_capability() {
         let backend = Dispatcher::detect().backend();
         assert!(
             !matches!(backend, Backend::Avx512 | Backend::Avx2),
-            "Sse4 override must not select AVX-class backends, got {:?}",
-            backend,
+            "Sse4 override must not select AVX-class backends, got {backend:?}",
         );
     });
 }
@@ -116,8 +115,7 @@ fn override_neon_blocks_x86_backends() {
                 backend,
                 Backend::Avx512 | Backend::Avx2 | Backend::Sse41 | Backend::Ssse3 | Backend::Sse2
             ),
-            "Neon override must not select x86 backends, got {:?}",
-            backend,
+            "Neon override must not select x86 backends, got {backend:?}",
         );
     });
 }

--- a/crates/checksums/tests/simd_override.rs
+++ b/crates/checksums/tests/simd_override.rs
@@ -1,0 +1,123 @@
+//! Integration tests covering the runtime SIMD level override.
+//!
+//! Each test in this binary mutates a single [`AtomicU8`] in
+//! [`checksums::cpu_features`]. The tests serialise on a shared mutex so
+//! that nextest's per-binary thread parallelism does not interleave their
+//! mutations. The binary is independent from the `checksums` unit tests, so
+//! installing `SimdLevel::None` here cannot trip an unrelated assertion in a
+//! parallel unit test.
+
+use std::sync::Mutex;
+
+use checksums::RollingChecksum;
+use checksums::SimdLevel;
+use checksums::cpu_features::{
+    clear_simd_override_for_tests, reset_simd_override_for_tests, simd_override,
+};
+use checksums::md5_backend::{Backend, Dispatcher};
+use checksums::simd_acceleration_available;
+
+static OVERRIDE_LOCK: Mutex<()> = Mutex::new(());
+
+fn with_override<R>(level: SimdLevel, body: impl FnOnce() -> R) -> R {
+    let _guard = OVERRIDE_LOCK.lock().expect("override mutex poisoned");
+    reset_simd_override_for_tests(level);
+    let result = body();
+    clear_simd_override_for_tests();
+    result
+}
+
+#[test]
+fn auto_override_does_not_disable_simd_when_available() {
+    with_override(SimdLevel::Auto, || {
+        let _ = simd_acceleration_available();
+        let _ = Dispatcher::detect().backend();
+        assert_eq!(simd_override(), SimdLevel::Auto);
+    });
+}
+
+#[test]
+fn none_override_disables_rolling_simd() {
+    with_override(SimdLevel::None, || {
+        assert!(
+            !simd_acceleration_available(),
+            "--simd=none must disable rolling-checksum SIMD"
+        );
+    });
+}
+
+#[test]
+fn none_override_forces_md5_scalar_backend() {
+    with_override(SimdLevel::None, || {
+        let dispatcher = Dispatcher::detect();
+        assert_eq!(
+            dispatcher.backend(),
+            Backend::Scalar,
+            "--simd=none must force the MD5 scalar dispatcher"
+        );
+    });
+}
+
+#[test]
+fn none_override_matches_auto_for_rolling_checksum_value() {
+    let mut data = Vec::with_capacity(8 * 1024);
+    for i in 0..data.capacity() {
+        data.push((i & 0xff) as u8);
+    }
+
+    let scalar_value = with_override(SimdLevel::None, || {
+        let mut rolling = RollingChecksum::new();
+        rolling.update(&data);
+        rolling.value()
+    });
+
+    let auto_value = with_override(SimdLevel::Auto, || {
+        let mut rolling = RollingChecksum::new();
+        rolling.update(&data);
+        rolling.value()
+    });
+
+    assert_eq!(
+        scalar_value, auto_value,
+        "scalar override must match auto-dispatch byte-for-byte"
+    );
+}
+
+#[test]
+fn override_caps_md5_dispatcher_below_host_capability() {
+    with_override(SimdLevel::Sse4, || {
+        let backend = Dispatcher::detect().backend();
+        assert!(
+            !matches!(backend, Backend::Avx512 | Backend::Avx2),
+            "Sse4 override must not select AVX-class backends, got {:?}",
+            backend,
+        );
+    });
+}
+
+#[test]
+fn override_avx2_blocks_avx512() {
+    with_override(SimdLevel::Avx2, || {
+        let backend = Dispatcher::detect().backend();
+        assert_ne!(
+            backend,
+            Backend::Avx512,
+            "Avx2 override must not select AVX-512"
+        );
+    });
+}
+
+#[test]
+fn override_neon_blocks_x86_backends() {
+    with_override(SimdLevel::Neon, || {
+        let backend = Dispatcher::detect().backend();
+        assert!(
+            !matches!(
+                backend,
+                Backend::Avx512 | Backend::Avx2 | Backend::Sse41 | Backend::Ssse3 | Backend::Sse2
+            ),
+            "Neon override must not select x86 backends, got {:?}",
+            backend,
+        );
+    });
+}

--- a/crates/cli/src/frontend/arguments/parsed_args/mod.rs
+++ b/crates/cli/src/frontend/arguments/parsed_args/mod.rs
@@ -451,6 +451,14 @@ pub struct ParsedArgs {
     /// `--cow` / `--no-cow` - copy-on-write reflink policy for whole-file copies.
     pub cow_policy: fast_io::CowPolicy,
 
+    /// `--simd=<level>` - runtime override for SIMD checksum dispatch.
+    ///
+    /// `None` keeps the default CPUID-based selection
+    /// ([`checksums::SimdLevel::Auto`]). Any other value caps the dispatcher
+    /// at the requested level (or forces the scalar reference for
+    /// [`checksums::SimdLevel::None`]).
+    pub simd_override: Option<checksums::SimdLevel>,
+
     /// `--delay-updates` - use temp files and rename after all transfers complete.
     pub delay_updates: bool,
 

--- a/crates/cli/src/frontend/arguments/parser/mod.rs
+++ b/crates/cli/src/frontend/arguments/parser/mod.rs
@@ -480,6 +480,24 @@ where
     } else {
         fast_io::CowPolicy::Auto
     };
+    let simd_override = match matches.remove_one::<OsString>("simd") {
+        Some(value) => {
+            let text = value.to_string_lossy();
+            match checksums::SimdLevel::parse_cli(text.as_ref()) {
+                Some(level) => Some(level),
+                None => {
+                    return Err(clap::Error::raw(
+                        clap::error::ErrorKind::InvalidValue,
+                        format!(
+                            "invalid value '{text}' for '--simd <LEVEL>': \
+                             expected one of auto, avx512, avx2, sse4, neon, none\n"
+                        ),
+                    ));
+                }
+            }
+        }
+        None => None,
+    };
     let delay_updates = matches.get_flag("delay-updates") && !matches.get_flag("no-delay-updates");
     let partial_dir_cli = matches
         .remove_one::<OsString>("partial-dir")
@@ -784,6 +802,7 @@ where
         io_uring_depth,
         zero_copy_policy,
         cow_policy,
+        simd_override,
         delay_updates,
         partial_dir,
         temp_dir,

--- a/crates/cli/src/frontend/arguments/parser/tests.rs
+++ b/crates/cli/src/frontend/arguments/parser/tests.rs
@@ -616,3 +616,50 @@ fn zero_copy_is_independent_from_io_uring() {
     assert_eq!(parsed.zero_copy_policy, fast_io::ZeroCopyPolicy::Disabled);
     assert_eq!(parsed.io_uring_policy, fast_io::IoUringPolicy::Enabled);
 }
+
+#[test]
+fn simd_defaults_to_none() {
+    let parsed = parse_test_args(["src/", "dst/"]).expect("parse");
+    assert_eq!(parsed.simd_override, None);
+}
+
+#[test]
+fn simd_accepts_each_canonical_level() {
+    for (input, expected) in [
+        ("auto", checksums::SimdLevel::Auto),
+        ("avx512", checksums::SimdLevel::Avx512),
+        ("avx2", checksums::SimdLevel::Avx2),
+        ("sse4", checksums::SimdLevel::Sse4),
+        ("neon", checksums::SimdLevel::Neon),
+        ("none", checksums::SimdLevel::None),
+    ] {
+        let arg = format!("--simd={input}");
+        let parsed = parse_test_args([arg.as_str(), "src/", "dst/"])
+            .unwrap_or_else(|err| panic!("parse failed for {input}: {err}"));
+        assert_eq!(
+            parsed.simd_override,
+            Some(expected),
+            "level {input} parsed incorrectly",
+        );
+    }
+}
+
+#[test]
+fn simd_accepts_aliases() {
+    let parsed = parse_test_args(["--simd=AVX-512", "src/", "dst/"]).expect("parse");
+    assert_eq!(parsed.simd_override, Some(checksums::SimdLevel::Avx512));
+
+    let parsed = parse_test_args(["--simd=sse4.1", "src/", "dst/"]).expect("parse");
+    assert_eq!(parsed.simd_override, Some(checksums::SimdLevel::Sse4));
+
+    let parsed = parse_test_args(["--simd=scalar", "src/", "dst/"]).expect("parse");
+    assert_eq!(parsed.simd_override, Some(checksums::SimdLevel::None));
+}
+
+#[test]
+fn simd_rejects_unknown_levels() {
+    let result = parse_test_args(["--simd=avx1024", "src/", "dst/"]);
+    let err = result.expect_err("unknown level should fail");
+    assert!(err.to_string().contains("--simd"));
+    assert!(err.to_string().contains("avx1024"));
+}

--- a/crates/cli/src/frontend/command_builder/sections/transfer_behavior_options.rs
+++ b/crates/cli/src/frontend/command_builder/sections/transfer_behavior_options.rs
@@ -169,6 +169,20 @@ pub(crate) fn add_transfer_behavior_options(command: ClapCommand) -> ClapCommand
                     .value_parser(OsStringValueParser::new()),
             )
             .arg(
+                Arg::new("simd")
+                    .long("simd")
+                    .value_name("LEVEL")
+                    .help(
+                        "Force the SIMD level used by checksum dispatch. \
+                         LEVEL is one of auto (default, CPU autodetect), \
+                         avx512, avx2, sse4, neon, or none (scalar). \
+                         The override caps dispatch at the requested level; \
+                         backends that exceed the host's CPUID capabilities \
+                         degrade to the next available implementation.",
+                    )
+                    .value_parser(OsStringValueParser::new()),
+            )
+            .arg(
                 Arg::new("cow")
                     .long("cow")
                     .help(

--- a/crates/cli/src/frontend/defaults.rs
+++ b/crates/cli/src/frontend/defaults.rs
@@ -21,7 +21,7 @@ pub(super) const SUPPORTED_OPTIONS_LIST: &str = concat!(
     "--force, --no-force, --fuzzy/-y, --no-fuzzy, --msgs2stderr, --no-msgs2stderr, --8-bit-output, --outbuf, ",
     "--itemize-changes/-i, --no-itemize-changes, --out-format, --stats, --partial, --no-partial, --partial-dir, --temp-dir, --log-file, ",
     "--log-file-format, --delay-updates, --no-delay-updates, --whole-file/-W, --no-whole-file, --remove-source-files, ",
-    "--remove-sent-files, --append, --no-append, --append-verify, --preallocate, --fsync, --io-uring, --no-io-uring, --io-uring-depth, --cow, --no-cow, --zero-copy, --no-zero-copy, --inplace, --no-inplace, ",
+    "--remove-sent-files, --append, --no-append, --append-verify, --preallocate, --fsync, --io-uring, --no-io-uring, --io-uring-depth, --simd, --cow, --no-cow, --zero-copy, --no-zero-copy, --inplace, --no-inplace, ",
     "--human-readable/-h, --no-human-readable, -P, --sparse/-S, --no-sparse/--no-S, --sparse-detect, --links/-l, --no-links/--no-l, ",
     "--copy-links/-L, ",
     "--copy-unsafe-links, --safe-links, --copy-dirlinks/-k, --keep-dirlinks/-K, ",

--- a/crates/cli/src/frontend/execution/drive/workflow/run.rs
+++ b/crates/cli/src/frontend/execution/drive/workflow/run.rs
@@ -226,10 +226,12 @@ where
     {
         let message = rsync_error!(
             1,
-            "--simd: cannot change SIMD level after initialization \
-             (was {previous}, requested {level})",
-            previous = previous.as_cli_str(),
-            level = level.as_cli_str(),
+            format!(
+                "--simd: cannot change SIMD level after initialization \
+                 (was {}, requested {})",
+                previous.as_cli_str(),
+                level.as_cli_str(),
+            )
         )
         .with_role(Role::Client);
         return fail_with_message(message, stderr);

--- a/crates/cli/src/frontend/execution/drive/workflow/run.rs
+++ b/crates/cli/src/frontend/execution/drive/workflow/run.rs
@@ -175,6 +175,7 @@ where
         io_uring_depth,
         zero_copy_policy,
         cow_policy,
+        simd_override,
         delay_updates,
         partial_dir,
         temp_dir,
@@ -219,6 +220,20 @@ where
         rayon_threads,
         tokio_threads,
     } = parsed;
+
+    if let Some(level) = simd_override
+        && let Err(previous) = checksums::set_simd_override(level)
+    {
+        let message = rsync_error!(
+            1,
+            "--simd: cannot change SIMD level after initialization \
+             (was {previous}, requested {level})",
+            previous = previous.as_cli_str(),
+            level = level.as_cli_str(),
+        )
+        .with_role(Role::Client);
+        return fail_with_message(message, stderr);
+    }
 
     let password_file = password_file.map(PathBuf::from);
     let human_readable_setting = human_readable;

--- a/crates/cli/src/frontend/help.rs
+++ b/crates/cli/src/frontend/help.rs
@@ -144,6 +144,7 @@ pub(super) fn help_text(program_name: ProgramName) -> String {
             "      --io-uring   Force io_uring for file I/O (policy=enabled); error if unavailable. Default policy is auto: probe kernel and fall back to standard I/O.\n",
             "      --no-io-uring  Disable io_uring (policy=disabled); always use standard buffered I/O even when the kernel supports io_uring.\n",
             "      --io-uring-depth=N  Override io_uring submission queue depth (default 64); must be a power of two between 1 and 32768.\n",
+            "      --simd=LEVEL Force the SIMD level used by checksum dispatch (auto, avx512, avx2, sse4, neon, none).\n",
             "      --cow        Allow copy-on-write reflinks for whole-file copies (default).\n",
             "      --no-cow     Disable copy-on-write reflinks; always use the portable std::fs::copy fallback.\n",
             "      --zero-copy  Allow I/O-level zero-copy (sendfile, splice, copy_file_range, io_uring SEND_ZC) when supported by the kernel. This is the default (policy=auto/enabled).\n",


### PR DESCRIPTION
## Summary

- Adds a process-wide SIMD level override (`SimdLevel::{Auto, Avx512, Avx2, Sse4, Neon, None}`) in `checksums::cpu_features`, backed by a lock-free `AtomicU8` so dispatch reads stay zero-cost.
- Wires the override into the rolling-checksum x86 and NEON paths and into the MD5 batch dispatcher; every CPUID gate now consults `feature_allowed` before activating a backend.
- Surfaces the override on the command line via `--simd=<auto|avx512|avx2|sse4|neon|none>`. The CLI installs the override exactly once at workflow start and surfaces a clear diagnostic on conflicting installs.
- Adds parser unit tests for every variant plus aliases (`avx-512`, `sse4.1`, `scalar`, ...) and integration tests in `crates/checksums/tests/simd_override.rs` that verify pinning forces the expected dispatcher backend and that `none` reproduces scalar parity with `auto`.

## Test plan

- [ ] `cargo nextest run -p checksums --test simd_override` (CI)
- [ ] `cargo nextest run -p cli -E 'test(simd_)'` (CI)
- [ ] Confirm `--help` and `SUPPORTED_OPTIONS_LIST` advertise the new flag (CI help golden)