### PR TITLE
feat(cli): add --rayon-threads and --tokio-threads tunables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -668,6 +668,7 @@ dependencies = [
  "metadata",
  "predicates",
  "protocol",
+ "rayon",
  "rsync_io",
  "rustix 1.1.4",
  "serial_test",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -53,6 +53,7 @@ compress = { path = "../compress", default-features = false }
 metadata = { path = "../metadata", default-features = false }
 rsync_io = { path = "../rsync_io", package = "rsync_io" }
 fast_io = { path = "../fast_io", default-features = false }
+rayon = { workspace = true }
 time = { version = "0.3", default-features = false, features = ["formatting", "macros", "local-offset", "std"] }
 tempfile = "3.15"
 tracing = { workspace = true }

--- a/crates/cli/src/frontend/arguments/parsed_args/mod.rs
+++ b/crates/cli/src/frontend/arguments/parsed_args/mod.rs
@@ -542,4 +542,15 @@ pub struct ParsedArgs {
 
     /// `--jump-host` - comma-separated proxy-jump hosts (forwarded as `ssh -J`).
     pub jump_host: Option<OsString>,
+
+    /// `--rayon-threads` - cap rayon worker pool to N threads (1-1024).
+    ///
+    /// `None` keeps rayon's default (one worker per logical CPU).
+    pub rayon_threads: Option<u32>,
+
+    /// `--tokio-threads` - cap async (tokio) runtime to N threads (1-1024).
+    ///
+    /// `None` keeps tokio's default. Only effective when async features are
+    /// enabled at build time; otherwise the value is parsed and discarded.
+    pub tokio_threads: Option<u32>,
 }

--- a/crates/cli/src/frontend/arguments/parser/mod.rs
+++ b/crates/cli/src/frontend/arguments/parser/mod.rs
@@ -187,6 +187,9 @@ where
         None => None,
     };
 
+    let rayon_threads = parse_thread_count(&mut matches, "rayon-threads")?;
+    let tokio_threads = parse_thread_count(&mut matches, "tokio-threads")?;
+
     let modify_window = match matches.remove_one::<OsString>("modify-window") {
         Some(value) => {
             let s = value.to_string_lossy();
@@ -793,5 +796,47 @@ where
         ssh_ipv6,
         ssh_port,
         jump_host,
+        rayon_threads,
+        tokio_threads,
     })
+}
+
+/// Maximum thread count accepted by `--rayon-threads` / `--tokio-threads`.
+///
+/// Mirrors the sanity ceiling applied by the broader thread-tunable surface
+/// (`crossbeam`/`tokio` historically reject very large pools at runtime).
+const MAX_THREAD_COUNT: u32 = 1024;
+
+/// Parses a thread-count CLI option (`--rayon-threads`, `--tokio-threads`).
+///
+/// Accepts a positive base-10 integer in the inclusive range `1..=1024`.
+/// Returns `Ok(None)` when the option was not supplied, allowing callers
+/// to keep the runtime's own default thread count.
+fn parse_thread_count(
+    matches: &mut clap::ArgMatches,
+    flag: &'static str,
+) -> Result<Option<u32>, clap::Error> {
+    let Some(value) = matches.remove_one::<OsString>(flag) else {
+        return Ok(None);
+    };
+    let raw = value.to_string_lossy();
+    match raw.parse::<u32>() {
+        Ok(0) => Err(clap::Error::raw(
+            clap::error::ErrorKind::ValueValidation,
+            format!(
+                "invalid --{flag} value '{raw}': must be a positive integer (1-{MAX_THREAD_COUNT})\n"
+            ),
+        )),
+        Ok(n) if n > MAX_THREAD_COUNT => Err(clap::Error::raw(
+            clap::error::ErrorKind::ValueValidation,
+            format!("invalid --{flag} value '{raw}': must not exceed {MAX_THREAD_COUNT}\n"),
+        )),
+        Ok(n) => Ok(Some(n)),
+        Err(_) => Err(clap::Error::raw(
+            clap::error::ErrorKind::ValueValidation,
+            format!(
+                "invalid --{flag} value '{raw}': must be a positive integer (1-{MAX_THREAD_COUNT})\n"
+            ),
+        )),
+    }
 }

--- a/crates/cli/src/frontend/arguments/parser/tests.rs
+++ b/crates/cli/src/frontend/arguments/parser/tests.rs
@@ -609,3 +609,81 @@ fn no_cow_then_cow_last_wins() {
     let parsed = parse_test_args(["--no-cow", "--cow", "src/", "dst/"]).expect("parse");
     assert_eq!(parsed.cow_policy, fast_io::CowPolicy::Auto);
 }
+
+#[test]
+fn rayon_threads_accepts_positive_value() {
+    let parsed = parse_test_args(["--rayon-threads", "8", "src/", "dst/"]).expect("parse");
+    assert_eq!(parsed.rayon_threads, Some(8));
+}
+
+#[test]
+fn rayon_threads_defaults_to_none() {
+    let parsed = parse_test_args(["src/", "dst/"]).expect("parse");
+    assert!(parsed.rayon_threads.is_none());
+}
+
+#[test]
+fn rayon_threads_rejects_zero() {
+    let err = parse_test_args(["--rayon-threads", "0", "src/", "dst/"]).unwrap_err();
+    let message = err.to_string();
+    assert!(message.contains("--rayon-threads"));
+    assert!(message.contains("positive"));
+}
+
+#[test]
+fn rayon_threads_rejects_excessive_value() {
+    let err = parse_test_args(["--rayon-threads", "1025", "src/", "dst/"]).unwrap_err();
+    let message = err.to_string();
+    assert!(message.contains("--rayon-threads"));
+    assert!(message.contains("1024"));
+}
+
+#[test]
+fn rayon_threads_rejects_non_numeric() {
+    let err = parse_test_args(["--rayon-threads", "many", "src/", "dst/"]).unwrap_err();
+    let message = err.to_string();
+    assert!(message.contains("--rayon-threads"));
+    assert!(message.contains("'many'"));
+}
+
+#[test]
+fn tokio_threads_accepts_positive_value() {
+    let parsed = parse_test_args(["--tokio-threads", "4", "src/", "dst/"]).expect("parse");
+    assert_eq!(parsed.tokio_threads, Some(4));
+}
+
+#[test]
+fn tokio_threads_defaults_to_none() {
+    let parsed = parse_test_args(["src/", "dst/"]).expect("parse");
+    assert!(parsed.tokio_threads.is_none());
+}
+
+#[test]
+fn tokio_threads_rejects_zero() {
+    let err = parse_test_args(["--tokio-threads", "0", "src/", "dst/"]).unwrap_err();
+    let message = err.to_string();
+    assert!(message.contains("--tokio-threads"));
+    assert!(message.contains("positive"));
+}
+
+#[test]
+fn tokio_threads_rejects_excessive_value() {
+    let err = parse_test_args(["--tokio-threads", "9999", "src/", "dst/"]).unwrap_err();
+    let message = err.to_string();
+    assert!(message.contains("--tokio-threads"));
+    assert!(message.contains("1024"));
+}
+
+#[test]
+fn tokio_threads_rejects_non_numeric() {
+    let err = parse_test_args(["--tokio-threads", "abc", "src/", "dst/"]).unwrap_err();
+    let message = err.to_string();
+    assert!(message.contains("--tokio-threads"));
+    assert!(message.contains("'abc'"));
+}
+
+#[test]
+fn rayon_threads_accepts_max_value() {
+    let parsed = parse_test_args(["--rayon-threads", "1024", "src/", "dst/"]).expect("parse");
+    assert_eq!(parsed.rayon_threads, Some(1024));
+}

--- a/crates/cli/src/frontend/command_builder/sections/transfer_behavior_options.rs
+++ b/crates/cli/src/frontend/command_builder/sections/transfer_behavior_options.rs
@@ -300,6 +300,24 @@ pub(crate) fn add_transfer_behavior_options(command: ClapCommand) -> ClapCommand
                     .value_parser(OsStringValueParser::new()),
             )
             .arg(
+                Arg::new("rayon-threads")
+                    .long("rayon-threads")
+                    .value_name("N")
+                    .help("Cap the rayon worker pool to N threads (1-1024).")
+                    .num_args(1)
+                    .value_parser(OsStringValueParser::new()),
+            )
+            .arg(
+                Arg::new("tokio-threads")
+                    .long("tokio-threads")
+                    .value_name("N")
+                    .help(
+                        "Cap the async (tokio) runtime to N threads (1-1024); requires async features.",
+                    )
+                    .num_args(1)
+                    .value_parser(OsStringValueParser::new()),
+            )
+            .arg(
                 Arg::new("backup")
                     .long("backup")
                     .short('b')

--- a/crates/cli/src/frontend/defaults.rs
+++ b/crates/cli/src/frontend/defaults.rs
@@ -29,7 +29,7 @@ pub(super) const SUPPORTED_OPTIONS_LIST: &str = concat!(
     "--chown, --usermap, --groupmap, --chmod, --executability/-E, --perms/-p, --no-perms, --times/-t, --no-times, ",
     "--atimes/-U, --no-atimes, --crtimes/-N, --no-crtimes, --omit-dir-times, --no-omit-dir-times, --omit-link-times, --no-omit-link-times, ",
     "--acls/-A, --no-acls, --xattrs/-X, --no-xattrs, ",
-    "--numeric-ids, --no-numeric-ids"
+    "--numeric-ids, --no-numeric-ids, --rayon-threads, --tokio-threads"
 );
 
 /// Format string used for `--itemize-changes` output.

--- a/crates/cli/src/frontend/execution/drive/config.rs
+++ b/crates/cli/src/frontend/execution/drive/config.rs
@@ -1,7 +1,7 @@
 #![deny(unsafe_code)]
 
 use std::ffi::OsString;
-use std::num::NonZeroU32;
+use std::num::{NonZeroU32, NonZeroUsize};
 use std::path::PathBuf;
 use std::time::SystemTime;
 
@@ -37,6 +37,8 @@ pub(crate) struct ConfigInputs {
     pub(crate) min_size_limit: Option<u64>,
     pub(crate) max_size_limit: Option<u64>,
     pub(crate) block_size_override: Option<NonZeroU32>,
+    pub(crate) rayon_threads: Option<NonZeroUsize>,
+    pub(crate) tokio_threads: Option<NonZeroUsize>,
     pub(crate) max_alloc: Option<u64>,
     pub(crate) backup: bool,
     pub(crate) backup_dir: Option<PathBuf>,
@@ -179,6 +181,8 @@ pub(crate) fn build_base_config(mut inputs: ConfigInputs) -> ClientConfigBuilder
         .min_file_size(inputs.min_size_limit)
         .max_file_size(inputs.max_size_limit)
         .block_size_override(inputs.block_size_override)
+        .rayon_threads(inputs.rayon_threads)
+        .tokio_threads(inputs.tokio_threads)
         .max_alloc(inputs.max_alloc)
         .backup(inputs.backup)
         .backup_directory(inputs.backup_dir.clone())

--- a/crates/cli/src/frontend/execution/drive/mod.rs
+++ b/crates/cli/src/frontend/execution/drive/mod.rs
@@ -5,6 +5,7 @@ mod metadata;
 mod module_listing;
 mod options;
 mod summary;
+mod thread_tunables;
 mod validation;
 #[cfg(test)]
 pub(crate) use validation::CONNECT_PROGRAM_DAEMON_ONLY_MESSAGE;

--- a/crates/cli/src/frontend/execution/drive/thread_tunables.rs
+++ b/crates/cli/src/frontend/execution/drive/thread_tunables.rs
@@ -1,0 +1,55 @@
+//! Process-wide thread-pool tunables wired up during CLI startup.
+//!
+//! `--rayon-threads` is applied here via `rayon::ThreadPoolBuilder::build_global`,
+//! which must run before any rayon work begins. `--tokio-threads` is honoured
+//! when the async transports are constructed; this module provides the helper
+//! used by those construction sites.
+
+#![deny(unsafe_code)]
+
+use std::io::Write;
+use std::num::NonZeroUsize;
+
+use core::message::Role;
+use core::rsync_error;
+use logging_sink::MessageSink;
+
+/// Installs the requested rayon worker count for the lifetime of the process.
+///
+/// `rayon::ThreadPoolBuilder::build_global` may only succeed once per process.
+/// Subsequent invocations or a pool that has already been initialised by
+/// another caller leave the existing pool in place; the failure is reported
+/// to `stderr` as a non-fatal warning so transfers continue with the default
+/// thread count.
+pub(crate) fn install_rayon_thread_count<Err>(threads: NonZeroUsize, stderr: &mut MessageSink<Err>)
+where
+    Err: Write,
+{
+    if let Err(error) = rayon::ThreadPoolBuilder::new()
+        .num_threads(threads.get())
+        .build_global()
+    {
+        let message = rsync_error!(
+            1,
+            "failed to set --rayon-threads={}: {error}",
+            threads.get()
+        )
+        .with_role(Role::Client);
+        let _ = stderr.write(&message);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use logging_sink::MessageSink;
+
+    #[test]
+    fn install_rayon_thread_count_does_not_panic_when_already_initialised() {
+        // The global rayon pool may already be initialised by another test.
+        // The helper must report the error (or a no-op) without panicking.
+        let mut buf: Vec<u8> = Vec::new();
+        let mut sink = MessageSink::new(&mut buf);
+        install_rayon_thread_count(NonZeroUsize::new(2).expect("2 is non-zero"), &mut sink);
+    }
+}

--- a/crates/cli/src/frontend/execution/drive/workflow/run.rs
+++ b/crates/cli/src/frontend/execution/drive/workflow/run.rs
@@ -26,6 +26,7 @@ use logging::VerbosityConfig;
 use logging_sink::MessageSink;
 use std::fs::{File, OpenOptions};
 use std::io::{self, Write};
+use std::num::NonZeroUsize;
 use std::path::PathBuf;
 
 #[cfg(unix)]
@@ -212,6 +213,8 @@ where
         ssh_ipv6: _ssh_ipv6,
         ssh_port: _ssh_port,
         jump_host,
+        rayon_threads,
+        tokio_threads,
     } = parsed;
 
     let password_file = password_file.map(PathBuf::from);
@@ -231,6 +234,12 @@ where
 
     let verbosity_config = VerbosityConfig::from_verbose_level(verbosity);
     logging::init(verbosity_config);
+
+    let rayon_thread_count = rayon_threads.and_then(|n| NonZeroUsize::new(n as usize));
+    let tokio_thread_count = tokio_threads.and_then(|n| NonZeroUsize::new(n as usize));
+    if let Some(threads) = rayon_thread_count {
+        super::super::thread_tunables::install_rayon_thread_count(threads, stderr);
+    }
 
     if let Err(code) = validate_stdin_sources_conflict(&password_file, &files_from, stderr) {
         return code;
@@ -665,6 +674,8 @@ where
         min_size_limit,
         max_size_limit,
         block_size_override,
+        rayon_threads: rayon_thread_count,
+        tokio_threads: tokio_thread_count,
         max_alloc: max_alloc_limit,
         backup,
         backup_dir: backup_dir.map(PathBuf::from),

--- a/crates/cli/src/frontend/help.rs
+++ b/crates/cli/src/frontend/help.rs
@@ -47,6 +47,8 @@ pub(super) fn help_text(program_name: ProgramName) -> String {
             "      --max-size=SIZE  Skip files larger than SIZE.\n",
             "      --max-alloc=SIZE  Cap memory allocation at SIZE bytes (K=1024, M=1024^2, G=1024^3, T=1024^4, P=1024^5, E=1024^6; KB/MB/GB use powers of 1000; KiB/MiB/GiB are explicit binary; default 1G; 0 is rejected).\n",
             "      --block-size=SIZE  Force the delta-transfer block size to SIZE bytes.\n",
+            "      --rayon-threads=N  Cap the rayon worker pool to N threads (1-1024).\n",
+            "      --tokio-threads=N  Cap the async (tokio) runtime to N threads (1-1024); requires async features.\n",
             "  -b, --backup    Create backups before overwriting or deleting existing entries.\n",
             "      --backup-dir=DIR  Store backups inside DIR instead of alongside the destination.\n",
             "      --suffix=SUFFIX  Append SUFFIX to backup names (default '~').\n",

--- a/crates/core/src/client/config/builder/mod.rs
+++ b/crates/core/src/client/config/builder/mod.rs
@@ -1,6 +1,6 @@
 use std::ffi::OsString;
 use std::fmt;
-use std::num::NonZeroU32;
+use std::num::{NonZeroU32, NonZeroUsize};
 use std::path::PathBuf;
 use std::time::SystemTime;
 
@@ -145,6 +145,8 @@ pub struct ClientConfigBuilder {
     min_file_size: Option<u64>,
     max_file_size: Option<u64>,
     block_size_override: Option<NonZeroU32>,
+    rayon_threads: Option<NonZeroUsize>,
+    tokio_threads: Option<NonZeroUsize>,
     max_alloc: Option<u64>,
     modify_window: Option<u64>,
     remove_source_files: bool,
@@ -305,6 +307,8 @@ impl ClientConfigBuilder {
             min_file_size: self.min_file_size,
             max_file_size: self.max_file_size,
             block_size_override: self.block_size_override,
+            rayon_threads: self.rayon_threads,
+            tokio_threads: self.tokio_threads,
             max_alloc: self.max_alloc,
             modify_window: self.modify_window,
             remove_source_files: self.remove_source_files,

--- a/crates/core/src/client/config/builder/performance.rs
+++ b/crates/core/src/client/config/builder/performance.rs
@@ -1,5 +1,5 @@
 use super::*;
-use std::num::NonZeroU32;
+use std::num::{NonZeroU32, NonZeroUsize};
 
 impl ClientConfigBuilder {
     builder_setter! {
@@ -102,6 +102,23 @@ impl ClientConfigBuilder {
         /// Applies an explicit delta-transfer block size override.
         #[doc(alias = "--block-size")]
         block_size_override: Option<NonZeroU32>,
+    }
+
+    builder_setter! {
+        /// Caps the rayon worker pool to a fixed thread count.
+        ///
+        /// `None` keeps rayon's default of one worker per logical CPU.
+        #[doc(alias = "--rayon-threads")]
+        rayon_threads: Option<NonZeroUsize>,
+    }
+
+    builder_setter! {
+        /// Caps the async (tokio) runtime worker count.
+        ///
+        /// `None` keeps tokio's own defaults. The value is honoured only when
+        /// async transports are enabled at build time.
+        #[doc(alias = "--tokio-threads")]
+        tokio_threads: Option<NonZeroUsize>,
     }
 
     builder_setter! {

--- a/crates/core/src/client/config/builder/tests.rs
+++ b/crates/core/src/client/config/builder/tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::client::config::FilterRuleKind;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
-use std::num::{NonZeroU32, NonZeroU64};
+use std::num::{NonZeroU32, NonZeroU64, NonZeroUsize};
 use std::time::{Duration, SystemTime};
 
 fn builder() -> ClientConfigBuilder {
@@ -1336,6 +1336,40 @@ fn block_size_override_none_clears_value() {
         .block_size_override(None)
         .build();
     assert!(config.block_size_override().is_none());
+}
+
+#[test]
+fn rayon_threads_sets_value() {
+    let threads = NonZeroUsize::new(8).unwrap();
+    let config = builder().rayon_threads(Some(threads)).build();
+    assert_eq!(config.rayon_threads(), Some(threads));
+}
+
+#[test]
+fn rayon_threads_none_clears_value() {
+    let threads = NonZeroUsize::new(8).unwrap();
+    let config = builder()
+        .rayon_threads(Some(threads))
+        .rayon_threads(None)
+        .build();
+    assert!(config.rayon_threads().is_none());
+}
+
+#[test]
+fn tokio_threads_sets_value() {
+    let threads = NonZeroUsize::new(4).unwrap();
+    let config = builder().tokio_threads(Some(threads)).build();
+    assert_eq!(config.tokio_threads(), Some(threads));
+}
+
+#[test]
+fn tokio_threads_none_clears_value() {
+    let threads = NonZeroUsize::new(4).unwrap();
+    let config = builder()
+        .tokio_threads(Some(threads))
+        .tokio_threads(None)
+        .build();
+    assert!(config.tokio_threads().is_none());
 }
 
 #[test]

--- a/crates/core/src/client/config/client/mod.rs
+++ b/crates/core/src/client/config/client/mod.rs
@@ -1,5 +1,5 @@
 use std::ffi::{OsStr, OsString};
-use std::num::NonZeroU32;
+use std::num::{NonZeroU32, NonZeroUsize};
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime};
 
@@ -68,6 +68,8 @@ pub struct ClientConfig {
     pub(super) min_file_size: Option<u64>,
     pub(super) max_file_size: Option<u64>,
     pub(super) block_size_override: Option<NonZeroU32>,
+    pub(super) rayon_threads: Option<NonZeroUsize>,
+    pub(super) tokio_threads: Option<NonZeroUsize>,
     pub(super) max_alloc: Option<u64>,
     pub(super) modify_window: Option<u64>,
     pub(super) remove_source_files: bool,
@@ -230,6 +232,8 @@ impl Default for ClientConfig {
             min_file_size: None,
             max_file_size: None,
             block_size_override: None,
+            rayon_threads: None,
+            tokio_threads: None,
             max_alloc: None,
             modify_window: None,
             remove_source_files: false,

--- a/crates/core/src/client/config/client/performance.rs
+++ b/crates/core/src/client/config/client/performance.rs
@@ -1,5 +1,5 @@
 use super::*;
-use std::num::NonZeroU32;
+use std::num::{NonZeroU32, NonZeroUsize};
 
 impl ClientConfig {
     /// Reports whether compression was requested for transfers.
@@ -113,6 +113,24 @@ impl ClientConfig {
         self.block_size_override
     }
 
+    /// Returns the requested rayon worker count, if any.
+    ///
+    /// `None` keeps rayon's default (one worker per logical CPU). Applied
+    /// once during process startup via `rayon::ThreadPoolBuilder::build_global`.
+    #[doc(alias = "--rayon-threads")]
+    pub const fn rayon_threads(&self) -> Option<NonZeroUsize> {
+        self.rayon_threads
+    }
+
+    /// Returns the requested tokio worker count, if any.
+    ///
+    /// `None` keeps tokio's defaults. Honoured only when async transports
+    /// are enabled at build time.
+    #[doc(alias = "--tokio-threads")]
+    pub const fn tokio_threads(&self) -> Option<NonZeroUsize> {
+        self.tokio_threads
+    }
+
     /// Returns the configured `--max-alloc` cap in bytes, if any.
     ///
     /// When set, the global buffer pool tracks outstanding (checked-out)
@@ -219,6 +237,18 @@ mod tests {
     fn block_size_override_default_is_none() {
         let config = default_config();
         assert!(config.block_size_override().is_none());
+    }
+
+    #[test]
+    fn rayon_threads_default_is_none() {
+        let config = default_config();
+        assert!(config.rayon_threads().is_none());
+    }
+
+    #[test]
+    fn tokio_threads_default_is_none() {
+        let config = default_config();
+        assert!(config.tokio_threads().is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Adds `--rayon-threads=N` and `--tokio-threads=N` CLI tunables (1-1024) for capping the local rayon worker pool and async tokio runtime worker count.
- `--rayon-threads` calls `rayon::ThreadPoolBuilder::build_global()` at the top of the execute path before any rayon work begins; failure to install (e.g. pool already initialised) is reported as a non-fatal warning so transfers continue with the default thread count.
- `--tokio-threads` is plumbed through `ParsedArgs` -> `ConfigInputs` -> `ClientConfigBuilder` -> `ClientConfig` so async transports (gated behind the `async` feature) can honour the cap when they are constructed.
- Validation rejects `0` and values exceeding `1024`; non-numeric input is rejected with the offending token quoted in the error.
- Both flags are local-only and intentionally not forwarded to the remote peer.

## Test plan

- [ ] `cargo nextest run -p cli --all-features -E 'test(rayon_threads) | test(tokio_threads)'`
- [ ] `cargo nextest run -p core --all-features -E 'test(rayon_threads) | test(tokio_threads)'`
- [ ] CI green on fmt+clippy, nextest (stable), Windows, macOS, Linux musl