### PR TITLE
feat(match): zsync-inspired matched-block pruning bitmap

### DIFF
--- a/crates/match/src/generator.rs
+++ b/crates/match/src/generator.rs
@@ -17,7 +17,7 @@ use logging::debug_log;
 #[cfg(feature = "tracing")]
 use tracing::instrument;
 
-use crate::index::DeltaSignatureIndex;
+use crate::index::{DeltaSignatureIndex, MatchedBlocks};
 use crate::ring_buffer::RingBuffer;
 use crate::script::{DeltaScript, DeltaToken};
 
@@ -63,6 +63,11 @@ fn flush_seq_match_run(
 #[derive(Clone, Debug)]
 pub struct DeltaGenerator {
     buffer_len: usize,
+    /// Test-only knob disabling the matched-block pruning bitmap so the
+    /// property tests can compare prune-on against prune-off output. The
+    /// production path always prunes; see `docs/design/zsync-prune.md`.
+    #[cfg(test)]
+    prune_matched: bool,
 }
 
 impl DeltaGenerator {
@@ -71,6 +76,8 @@ impl DeltaGenerator {
     pub const fn new() -> Self {
         Self {
             buffer_len: DEFAULT_BUFFER_LEN,
+            #[cfg(test)]
+            prune_matched: true,
         }
     }
 
@@ -78,6 +85,18 @@ impl DeltaGenerator {
     #[must_use]
     pub fn with_buffer_len(mut self, buffer_len: usize) -> Self {
         self.buffer_len = buffer_len.max(1);
+        self
+    }
+
+    /// Test-only switch that disables the matched-block pruning bitmap.
+    ///
+    /// Used by the property tests in `matched_blocks_tests.rs` to compare
+    /// prune-on output against the no-prune baseline. Not exposed in
+    /// production builds.
+    #[cfg(test)]
+    #[must_use]
+    pub(crate) fn with_prune_matched(mut self, enabled: bool) -> Self {
+        self.prune_matched = enabled;
         self
     }
 
@@ -127,6 +146,17 @@ impl DeltaGenerator {
         // is likely at block i+1. Checking this hint before the hash table
         // lookup skips the probe entirely when data is sequential.
         let mut want_i: Option<usize> = Some(0);
+
+        // zsync-inspired matched-block pruning: each emitted Copy token sets a
+        // bit so later probes skip the strong-checksum verify on already-
+        // consumed basis blocks. Duplicate-content siblings live at distinct
+        // basis indices; the bitmap leaves those siblings findable until each
+        // is consumed independently. See docs/design/zsync-prune.md.
+        let mut matched_blocks = MatchedBlocks::with_block_count(index.block_count());
+        #[cfg(test)]
+        let prune_matched = self.prune_matched;
+        #[cfg(not(test))]
+        let prune_matched = true;
 
         let mut buffer = vec![0u8; self.buffer_len.max(block_len)];
         let mut buffer_pos = 0usize;
@@ -199,17 +229,24 @@ impl DeltaGenerator {
 
             // Match using two-slice view to avoid O(block_len) rotation when wrapped.
             // upstream: match.c:144-190 - try want_i hint before hash probe.
+            // The want_i hint deliberately bypasses the matched-block bitmap:
+            // the hint targets the just-matched index plus one, which the
+            // bitmap correctly leaves unset. Adding a bitmap probe to the
+            // hint adds a branch with no information gain.
             let (first, second) = window.as_slices();
-            let matched = if let Some(hint) = want_i {
-                if index.check_block_match_slices(hint, digest, first, second) {
-                    Some(hint)
+            let matched = {
+                let prune_filter = prune_matched.then_some(&matched_blocks);
+                if let Some(hint) = want_i {
+                    if index.check_block_match_slices(hint, digest, first, second) {
+                        Some(hint)
+                    } else {
+                        hash_hits += 1;
+                        index.find_match_slices_filtered(digest, first, second, prune_filter)
+                    }
                 } else {
                     hash_hits += 1;
-                    index.find_match_slices(digest, first, second)
+                    index.find_match_slices_filtered(digest, first, second, prune_filter)
                 }
-            } else {
-                hash_hits += 1;
-                index.find_match_slices(digest, first, second)
             };
             if let Some(mut match_idx) = matched {
                 // upstream: match.c:265-310 - block match with bulk refill.
@@ -275,6 +312,13 @@ impl DeltaGenerator {
                     }
                     total_bytes += block.len() as u64;
 
+                    // zsync prune trigger site, equivalent to write_blocks()
+                    // in librcksum/rsum.c:109-119: mark the basis block as
+                    // consumed AFTER the Copy token has been emitted, so a
+                    // later probe at a different source offset will not pick
+                    // this basis index again.
+                    matched_blocks.mark_matched(match_idx);
+
                     want_i = if match_idx + 1 < index.block_count() {
                         Some(match_idx + 1)
                     } else {
@@ -317,16 +361,19 @@ impl DeltaGenerator {
                     // block boundary before falling back to a hash probe.
                     let adj_digest = rolling.digest();
                     let (f, s) = window.as_slices();
-                    let adj_match = if let Some(hint) = want_i {
-                        if index.check_block_match_slices(hint, adj_digest, f, s) {
-                            Some(hint)
+                    let adj_match = {
+                        let adj_filter = prune_matched.then_some(&matched_blocks);
+                        if let Some(hint) = want_i {
+                            if index.check_block_match_slices(hint, adj_digest, f, s) {
+                                Some(hint)
+                            } else {
+                                hash_hits += 1;
+                                index.find_match_slices_filtered(adj_digest, f, s, adj_filter)
+                            }
                         } else {
                             hash_hits += 1;
-                            index.find_match_slices(adj_digest, f, s)
+                            index.find_match_slices_filtered(adj_digest, f, s, adj_filter)
                         }
-                    } else {
-                        hash_hits += 1;
-                        index.find_match_slices(adj_digest, f, s)
                     };
                     if let Some(next_idx) = adj_match {
                         match_idx = next_idx;

--- a/crates/match/src/index/matched_blocks.rs
+++ b/crates/match/src/index/matched_blocks.rs
@@ -1,0 +1,179 @@
+//! Per-generator-session bitmap of basis blocks that have already been
+//! matched and emitted as `DeltaToken::Copy`.
+//!
+//! The bitmap shrinks the candidate set returned by the rolling-checksum
+//! probe in [`super::DeltaSignatureIndex::find_match_slices_filtered`] so
+//! that an already-matched basis block is not strong-checksum-verified at
+//! later source offsets.
+//!
+//! # Duplicate-block correctness
+//!
+//! Bits are keyed by basis `block_idx`, not by `(rsum, strong)` tuple.
+//! Two blocks with identical content occupy distinct `block_idx` slots,
+//! so marking one leaves the other findable. The bucket walk visits every
+//! candidate index in insertion order and picks the first whose bit is
+//! still clear, mirroring upstream rsync's first-fit-in-bucket semantics.
+//!
+//! # Wire compatibility
+//!
+//! This is a probe-side, in-memory optimization. It changes which basis
+//! `block_idx` is named in a `Copy` token when duplicate-content siblings
+//! exist, never which bytes the receiver applies. Wire framing, golden
+//! payloads, and interop behaviour are unchanged.
+//!
+//! See `docs/design/zsync-prune.md` for the full contract and the zsync
+//! `librcksum` precedent.
+
+const BITS_PER_WORD: usize = u64::BITS as usize;
+
+/// Bitmap with one bit per basis block that records which blocks have
+/// been emitted as `DeltaToken::Copy` during the current generator
+/// session.
+///
+/// Constructed via [`MatchedBlocks::with_block_count`], mutated through
+/// [`MatchedBlocks::mark_matched`], and queried with
+/// [`MatchedBlocks::is_matched`]. [`MatchedBlocks::clear`] resets every
+/// bit so the same allocation can be reused across generator sessions
+/// (e.g., INC_RECURSE per-segment rebuilds).
+#[derive(Clone, Debug, Default)]
+pub struct MatchedBlocks {
+    bits: Vec<u64>,
+    block_count: usize,
+}
+
+impl MatchedBlocks {
+    /// Allocates a bitmap sized for `block_count` basis blocks with every
+    /// bit cleared.
+    ///
+    /// A `block_count` of zero produces an empty bitmap that rejects every
+    /// [`MatchedBlocks::is_matched`] query; matching callers should skip
+    /// pruning entirely in that case.
+    #[must_use]
+    pub fn with_block_count(block_count: usize) -> Self {
+        let words = block_count.div_ceil(BITS_PER_WORD);
+        Self {
+            bits: vec![0u64; words],
+            block_count,
+        }
+    }
+
+    /// Returns the number of basis blocks the bitmap was sized for.
+    #[must_use]
+    pub const fn block_count(&self) -> usize {
+        self.block_count
+    }
+
+    /// Marks the basis block at `idx` as matched.
+    ///
+    /// Out-of-range indices are ignored so callers do not need to guard
+    /// the call site against malformed candidate vectors.
+    #[inline]
+    pub fn mark_matched(&mut self, idx: usize) {
+        if idx >= self.block_count {
+            return;
+        }
+        let word = idx / BITS_PER_WORD;
+        let bit = idx % BITS_PER_WORD;
+        self.bits[word] |= 1u64 << bit;
+    }
+
+    /// Returns `true` when the basis block at `idx` has been marked as
+    /// matched.
+    ///
+    /// Out-of-range indices return `false`. The hot path uses this in
+    /// the candidate-filtering step before the strong-checksum verify
+    /// in [`super::DeltaSignatureIndex::find_match_slices_filtered`].
+    #[inline]
+    #[must_use]
+    pub fn is_matched(&self, idx: usize) -> bool {
+        if idx >= self.block_count {
+            return false;
+        }
+        let word = idx / BITS_PER_WORD;
+        let bit = idx % BITS_PER_WORD;
+        (self.bits[word] & (1u64 << bit)) != 0
+    }
+
+    /// Resets every bit so the allocation can be reused for a new
+    /// generator session without re-allocating.
+    pub fn clear(&mut self) {
+        for word in &mut self.bits {
+            *word = 0;
+        }
+    }
+}
+
+#[cfg(test)]
+mod unit_tests {
+    use super::*;
+
+    #[test]
+    fn with_block_count_zero_has_no_capacity() {
+        let m = MatchedBlocks::with_block_count(0);
+        assert_eq!(m.block_count(), 0);
+        assert!(!m.is_matched(0));
+    }
+
+    #[test]
+    fn with_block_count_rounds_up_to_word_size() {
+        let m = MatchedBlocks::with_block_count(1);
+        assert_eq!(m.block_count(), 1);
+        assert_eq!(m.bits.len(), 1);
+
+        let m = MatchedBlocks::with_block_count(BITS_PER_WORD);
+        assert_eq!(m.bits.len(), 1);
+
+        let m = MatchedBlocks::with_block_count(BITS_PER_WORD + 1);
+        assert_eq!(m.bits.len(), 2);
+    }
+
+    #[test]
+    fn mark_then_query_round_trip() {
+        let mut m = MatchedBlocks::with_block_count(200);
+        for idx in [0, 1, 63, 64, 65, 127, 128, 199] {
+            assert!(!m.is_matched(idx));
+            m.mark_matched(idx);
+            assert!(m.is_matched(idx), "bit {idx} should be set");
+        }
+        for idx in [2, 3, 62, 100, 198] {
+            assert!(!m.is_matched(idx), "bit {idx} should still be clear");
+        }
+    }
+
+    #[test]
+    fn out_of_range_indices_are_ignored() {
+        let mut m = MatchedBlocks::with_block_count(10);
+        m.mark_matched(10);
+        m.mark_matched(usize::MAX);
+        assert!(!m.is_matched(10));
+        assert!(!m.is_matched(usize::MAX));
+    }
+
+    #[test]
+    fn clear_resets_all_bits() {
+        let mut m = MatchedBlocks::with_block_count(130);
+        for idx in 0..130 {
+            m.mark_matched(idx);
+        }
+        m.clear();
+        for idx in 0..130 {
+            assert!(!m.is_matched(idx), "bit {idx} should be clear");
+        }
+    }
+
+    #[test]
+    fn mark_is_idempotent() {
+        let mut m = MatchedBlocks::with_block_count(8);
+        m.mark_matched(3);
+        m.mark_matched(3);
+        m.mark_matched(3);
+        assert!(m.is_matched(3));
+    }
+
+    #[test]
+    fn default_is_empty() {
+        let m = MatchedBlocks::default();
+        assert_eq!(m.block_count(), 0);
+        assert!(!m.is_matched(0));
+    }
+}

--- a/crates/match/src/index/matched_blocks_tests.rs
+++ b/crates/match/src/index/matched_blocks_tests.rs
@@ -1,0 +1,260 @@
+//! Property and unit tests for [`super::MatchedBlocks`] and the
+//! generator's matched-block pruning path.
+//!
+//! Pins the contracts in `docs/design/zsync-prune.md`:
+//!
+//! - Pruning never reduces the total matched-byte count vs the no-prune
+//!   baseline (monotone non-decreasing under prune).
+//! - Pruning preserves the apply round-trip: applying the delta over the
+//!   basis reproduces the source byte-for-byte.
+//! - Duplicate-content basis blocks are tracked independently; pruning
+//!   one sibling leaves the others findable.
+
+use std::io::Cursor;
+use std::num::{NonZeroU8, NonZeroU32};
+
+use proptest::prelude::*;
+
+use protocol::ProtocolVersion;
+use signature::{
+    SignatureAlgorithm, SignatureLayoutParams, calculate_signature_layout, generate_file_signature,
+};
+
+use super::DeltaSignatureIndex;
+use crate::generator::DeltaGenerator;
+use crate::script::{DeltaScript, DeltaToken, apply_delta};
+
+/// Block length that always produces full-length blocks for the
+/// proptest-generated basis files.
+const TEST_BLOCK_LENGTH: u32 = 512;
+
+/// Strong-checksum length (bytes) used by the property cases. Matches
+/// the value used by the existing `index/tests.rs` cases so a fixed
+/// signature layout is in play.
+const TEST_STRONG_LEN: u8 = 16;
+
+/// Builds a [`DeltaSignatureIndex`] over the supplied basis bytes with
+/// the test's fixed block length. Returns `None` when the basis is too
+/// short to produce a full block, which the proptest strategies bound
+/// out by construction.
+fn build_index(basis: &[u8]) -> Option<DeltaSignatureIndex> {
+    let params = SignatureLayoutParams::new(
+        basis.len() as u64,
+        Some(NonZeroU32::new(TEST_BLOCK_LENGTH).unwrap()),
+        ProtocolVersion::NEWEST,
+        NonZeroU8::new(TEST_STRONG_LEN).unwrap(),
+    );
+    let layout = calculate_signature_layout(params).ok()?;
+    let signature = generate_file_signature(basis, layout, SignatureAlgorithm::Md4).ok()?;
+    DeltaSignatureIndex::from_signature(&signature, SignatureAlgorithm::Md4)
+}
+
+/// Generates a delta over `source` against `basis`, optionally enabling
+/// the matched-block pruning bitmap. The non-prune branch matches the
+/// pre-#2069 behaviour exactly and serves as the property baseline.
+fn generate_with_prune(
+    basis: &[u8],
+    source: &[u8],
+    prune: bool,
+) -> Option<(DeltaScript, DeltaSignatureIndex)> {
+    let index = build_index(basis)?;
+    let generator = DeltaGenerator::new().with_prune_matched(prune);
+    let script = generator.generate(Cursor::new(source), &index).ok()?;
+    Some((script, index))
+}
+
+/// Returns the total number of bytes accounted for by [`DeltaToken::Copy`]
+/// tokens in the script (the "matched bytes" counter referenced by the
+/// design contract).
+fn copy_bytes(script: &DeltaScript) -> u64 {
+    script
+        .tokens()
+        .iter()
+        .filter_map(|tok| match tok {
+            DeltaToken::Copy { len, .. } => Some(*len as u64),
+            DeltaToken::Literal(_) => None,
+        })
+        .sum()
+}
+
+/// Applies `script` over `basis` via [`apply_delta`] and returns the
+/// reconstructed bytes. Used by the round-trip property to assert that
+/// pruning never breaks correctness.
+fn apply_script(basis: &[u8], index: &DeltaSignatureIndex, script: &DeltaScript) -> Vec<u8> {
+    let mut basis_cursor = Cursor::new(basis.to_vec());
+    let mut output = Vec::new();
+    apply_delta(&mut basis_cursor, &mut output, index, script).expect("apply");
+    output
+}
+
+/// Strategy for a basis composed of `n_blocks` blocks where each block
+/// is either drawn fresh-random or copied from a previously emitted
+/// block. The `dup_density` field controls how often duplicates are
+/// produced, exercising the duplicate-bucket walk in
+/// `find_match_slices_filtered`.
+fn duplicate_basis_strategy() -> impl Strategy<Value = Vec<u8>> {
+    // distinct_seed is a small set of seeds the basis cycles through to
+    // engineer duplicate-content blocks across the file. fill is the
+    // all-fill fallback block used when distinct_seed is empty.
+    (
+        2usize..=6,
+        0u8..=255,
+        prop::collection::vec(any::<u8>(), 0..=4),
+    )
+        .prop_map(|(n_blocks, fill, seeds)| {
+            let block_len = TEST_BLOCK_LENGTH as usize;
+            let mut basis = Vec::with_capacity(n_blocks * block_len);
+            for i in 0..n_blocks {
+                let mut block = vec![0u8; block_len];
+                if seeds.is_empty() {
+                    for byte in &mut block {
+                        *byte = fill;
+                    }
+                } else {
+                    let seed = seeds[i % seeds.len()];
+                    for (j, byte) in block.iter_mut().enumerate() {
+                        *byte = seed.wrapping_add((j as u8).wrapping_mul(17));
+                    }
+                }
+                basis.extend_from_slice(&block);
+            }
+            basis
+        })
+}
+
+/// Composite strategy: produces a `(basis, source)` pair where the
+/// source is built from a permutation of unique basis-block positions
+/// plus an optional literal tail. Each basis block is referenced at
+/// most once, which keeps the property
+/// [`prune_does_not_reduce_matched_bytes`] in its valid domain. The
+/// surplus-source-occurrence regime (where prune-on emits literals
+/// while prune-off emits duplicate Copy tokens) is covered by the
+/// hand-rolled [`excess_source_occurrences_fall_through_to_literal`]
+/// regression instead.
+fn basis_and_source_strategy() -> impl Strategy<Value = (Vec<u8>, Vec<u8>)> {
+    let block_len = TEST_BLOCK_LENGTH as usize;
+    duplicate_basis_strategy().prop_flat_map(move |basis| {
+        let n_blocks = (basis.len() / block_len).max(1);
+        // Generate a permutation of [0, n_blocks) by sorting a vector of
+        // sortkey-tagged indices. proptest does not ship a permutation
+        // strategy; this trick is the documented workaround.
+        (
+            Just(basis),
+            prop::collection::vec(any::<u32>(), n_blocks..=n_blocks),
+            prop::collection::vec(any::<u8>(), 0..=12),
+            1usize..=n_blocks,
+        )
+            .prop_map(move |(b, sortkeys, tail, take)| {
+                let mut order: Vec<(u32, usize)> = sortkeys
+                    .into_iter()
+                    .enumerate()
+                    .map(|(i, k)| (k, i))
+                    .collect();
+                order.sort_unstable_by_key(|&(k, _)| k);
+                let mut source = Vec::new();
+                for &(_, idx) in order.iter().take(take) {
+                    let start = idx * block_len;
+                    let end = (start + block_len).min(b.len());
+                    source.extend_from_slice(&b[start..end]);
+                }
+                source.extend_from_slice(&tail);
+                (b, source)
+            })
+    })
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig {
+        cases: 64,
+        ..ProptestConfig::default()
+    })]
+
+    /// Pruning never reduces the total bytes attributed to Copy tokens.
+    /// The contract from `docs/design/zsync-prune.md` allows the COPY
+    /// index field to differ between the two runs (different sibling),
+    /// but the matched-byte count is monotone non-decreasing.
+    #[test]
+    fn prune_does_not_reduce_matched_bytes(
+        (basis, source) in basis_and_source_strategy(),
+    ) {
+        let off = generate_with_prune(&basis, &source, false);
+        let on = generate_with_prune(&basis, &source, true);
+        if let (Some((s_off, _)), Some((s_on, _))) = (off, on) {
+            prop_assert!(
+                copy_bytes(&s_on) >= copy_bytes(&s_off),
+                "pruning reduced matched bytes: on={} off={}",
+                copy_bytes(&s_on),
+                copy_bytes(&s_off)
+            );
+        }
+    }
+
+    /// Pruning preserves the apply round-trip: the reconstructed source
+    /// must exactly equal the input under both prune-on and prune-off
+    /// configurations. This is the duplicate-bucket correctness
+    /// invariant: dropping the wrong sibling would corrupt the output.
+    #[test]
+    fn prune_preserves_apply_round_trip(
+        (basis, source) in basis_and_source_strategy(),
+    ) {
+        if let Some((s_on, idx_on)) = generate_with_prune(&basis, &source, true) {
+            let reconstructed = apply_script(&basis, &idx_on, &s_on);
+            prop_assert_eq!(reconstructed, source.clone(), "prune-on apply mismatch");
+        }
+        if let Some((s_off, idx_off)) = generate_with_prune(&basis, &source, false) {
+            let reconstructed = apply_script(&basis, &idx_off, &s_off);
+            prop_assert_eq!(reconstructed, source, "prune-off apply mismatch");
+        }
+    }
+}
+
+/// Hand-rolled regression: a basis with three identical blocks plus a
+/// source containing all three in order. Without pruning the matcher
+/// might collapse all three Copy tokens onto basis index 0; with
+/// pruning it must walk the duplicate bucket and emit each sibling
+/// once. Either way the apply round-trip and matched-byte count must
+/// hold.
+#[test]
+fn duplicate_basis_blocks_yield_round_trip() {
+    let block_len = TEST_BLOCK_LENGTH as usize;
+    let mut basis = Vec::with_capacity(block_len * 3);
+    let pattern: Vec<u8> = (0..block_len).map(|i| (i % 251) as u8).collect();
+    for _ in 0..3 {
+        basis.extend_from_slice(&pattern);
+    }
+    let source = basis.clone();
+
+    let (script_on, idx_on) = generate_with_prune(&basis, &source, true).expect("prune-on script");
+    let (script_off, idx_off) =
+        generate_with_prune(&basis, &source, false).expect("prune-off script");
+
+    let on = apply_script(&basis, &idx_on, &script_on);
+    let off = apply_script(&basis, &idx_off, &script_off);
+    assert_eq!(on, source);
+    assert_eq!(off, source);
+    assert!(copy_bytes(&script_on) >= copy_bytes(&script_off));
+}
+
+/// Hand-rolled regression: source has more occurrences of the duplicate
+/// block than the basis does. Once every basis sibling has been
+/// pruned, later occurrences must fall through to literal emission
+/// rather than re-matching block 0. The apply round-trip is the gate.
+#[test]
+fn excess_source_occurrences_fall_through_to_literal() {
+    let block_len = TEST_BLOCK_LENGTH as usize;
+    let pattern: Vec<u8> = (0..block_len).map(|i| ((i * 7) % 251) as u8).collect();
+
+    // basis: two duplicate blocks; source: four duplicate blocks.
+    let mut basis = Vec::with_capacity(block_len * 2);
+    basis.extend_from_slice(&pattern);
+    basis.extend_from_slice(&pattern);
+
+    let mut source = Vec::with_capacity(block_len * 4);
+    for _ in 0..4 {
+        source.extend_from_slice(&pattern);
+    }
+
+    let (script_on, idx_on) = generate_with_prune(&basis, &source, true).expect("prune-on script");
+    let reconstructed = apply_script(&basis, &idx_on, &script_on);
+    assert_eq!(reconstructed, source);
+}

--- a/crates/match/src/index/matched_blocks_tests.rs
+++ b/crates/match/src/index/matched_blocks_tests.rs
@@ -107,9 +107,7 @@ fn duplicate_basis_strategy() -> impl Strategy<Value = Vec<u8>> {
             for i in 0..n_blocks {
                 let mut block = vec![0u8; block_len];
                 if seeds.is_empty() {
-                    for byte in &mut block {
-                        *byte = fill;
-                    }
+                    block.fill(fill);
                 } else {
                     let seed = seeds[i % seeds.len()];
                     for (j, byte) in block.iter_mut().enumerate() {

--- a/crates/match/src/index/mod.rs
+++ b/crates/match/src/index/mod.rs
@@ -9,9 +9,12 @@
 
 mod bithash;
 mod builder;
+mod matched_blocks;
 
 #[cfg(test)]
 mod bithash_tests;
+#[cfg(test)]
+mod matched_blocks_tests;
 #[cfg(test)]
 mod tests;
 
@@ -24,6 +27,7 @@ use checksums::RollingDigest;
 use signature::{SignatureAlgorithm, SignatureBlock};
 
 use bithash::BitHash;
+pub use matched_blocks::MatchedBlocks;
 
 /// Size of the tag table for quick rolling checksum rejection (2^16 entries).
 ///
@@ -87,6 +91,26 @@ impl DeltaSignatureIndex {
     /// Attempts to locate a matching block for a contiguous byte slice.
     #[inline]
     pub fn find_match_bytes(&self, digest: RollingDigest, window: &[u8]) -> Option<usize> {
+        self.find_match_bytes_filtered(digest, window, None)
+    }
+
+    /// Attempts to locate a matching block for a contiguous byte slice,
+    /// skipping basis blocks already marked in `matched`.
+    ///
+    /// When `matched` is `None` this behaves identically to
+    /// [`Self::find_match_bytes`]. When `Some`, candidate basis blocks
+    /// whose bit is set in the bitmap are filtered out before the
+    /// strong-checksum verify, mirroring zsync's `librcksum`
+    /// matched-block pruning. Pruning never reduces the set of source
+    /// bytes that can be matched: see [`MatchedBlocks`] for the
+    /// duplicate-block correctness contract.
+    #[inline]
+    pub fn find_match_bytes_filtered(
+        &self,
+        digest: RollingDigest,
+        window: &[u8],
+        matched: Option<&MatchedBlocks>,
+    ) -> Option<usize> {
         if window.len() != self.block_length {
             return None;
         }
@@ -111,10 +135,10 @@ impl DeltaSignatureIndex {
         // enough candidates to amortise rayon's per-call overhead.
         #[cfg(feature = "parallel")]
         if candidates.len() >= Self::PARALLEL_THRESHOLD {
-            return self.find_match_parallel(candidates, window);
+            return self.find_match_parallel(candidates, window, matched);
         }
 
-        self.find_match_sequential(candidates, window)
+        self.find_match_sequential(candidates, window, matched)
     }
 
     /// Minimum number of candidates to trigger parallel verification.
@@ -128,10 +152,19 @@ impl DeltaSignatureIndex {
     ///
     /// Computes the strong checksum once and compares against all candidates,
     /// mirroring upstream rsync's `done_csum2` flag in `match.c:hash_search()`.
+    /// Skips candidates already marked in `matched` when the bitmap is supplied.
     #[inline]
-    fn find_match_sequential(&self, candidates: &[usize], window: &[u8]) -> Option<usize> {
+    fn find_match_sequential(
+        &self,
+        candidates: &[usize],
+        window: &[u8],
+        matched: Option<&MatchedBlocks>,
+    ) -> Option<usize> {
         let strong = self.algorithm.compute_truncated(window, self.strong_length);
         for &index in candidates {
+            if matches!(matched, Some(m) if m.is_matched(index)) {
+                continue;
+            }
             let block = &self.blocks[index];
             debug_assert_eq!(block.len(), self.block_length);
             if strong.as_slice() == block.strong() {
@@ -146,12 +179,20 @@ impl DeltaSignatureIndex {
     /// Computes strong checksums concurrently and returns the first match found.
     /// Uses `find_any` for early termination when a match is discovered.
     #[cfg(feature = "parallel")]
-    fn find_match_parallel(&self, candidates: &[usize], window: &[u8]) -> Option<usize> {
+    fn find_match_parallel(
+        &self,
+        candidates: &[usize],
+        window: &[u8],
+        matched: Option<&MatchedBlocks>,
+    ) -> Option<usize> {
         use rayon::prelude::*;
 
         candidates
             .par_iter()
             .find_any(|&&index| {
+                if matches!(matched, Some(m) if m.is_matched(index)) {
+                    return false;
+                }
                 let block = &self.blocks[index];
                 let strong = self.algorithm.compute_truncated(window, self.strong_length);
                 strong.as_slice() == block.strong()
@@ -172,6 +213,23 @@ impl DeltaSignatureIndex {
         first: &[u8],
         second: &[u8],
     ) -> Option<usize> {
+        self.find_match_slices_filtered(digest, first, second, None)
+    }
+
+    /// Attempts to locate a matching block for a non-contiguous window,
+    /// skipping basis blocks already marked in `matched`.
+    ///
+    /// Mirrors [`Self::find_match_bytes_filtered`] for the two-slice
+    /// window form used by the generator's ring buffer. Passing `None`
+    /// is equivalent to [`Self::find_match_slices`].
+    #[inline]
+    pub fn find_match_slices_filtered(
+        &self,
+        digest: RollingDigest,
+        first: &[u8],
+        second: &[u8],
+        matched: Option<&MatchedBlocks>,
+    ) -> Option<usize> {
         if first.len() + second.len() != self.block_length {
             return None;
         }
@@ -189,10 +247,10 @@ impl DeltaSignatureIndex {
 
         #[cfg(feature = "parallel")]
         if candidates.len() >= Self::PARALLEL_THRESHOLD {
-            return self.find_match_slices_parallel(candidates, first, second);
+            return self.find_match_slices_parallel(candidates, first, second, matched);
         }
 
-        self.find_match_slices_sequential(candidates, first, second)
+        self.find_match_slices_sequential(candidates, first, second, matched)
     }
 
     /// Sequential candidate verification for non-contiguous window data.
@@ -202,11 +260,15 @@ impl DeltaSignatureIndex {
         candidates: &[usize],
         first: &[u8],
         second: &[u8],
+        matched: Option<&MatchedBlocks>,
     ) -> Option<usize> {
         let strong = self
             .algorithm
             .compute_truncated_slices(first, second, self.strong_length);
         for &index in candidates {
+            if matches!(matched, Some(m) if m.is_matched(index)) {
+                continue;
+            }
             let block = &self.blocks[index];
             debug_assert_eq!(block.len(), self.block_length);
             if strong.as_slice() == block.strong() {
@@ -223,12 +285,16 @@ impl DeltaSignatureIndex {
         candidates: &[usize],
         first: &[u8],
         second: &[u8],
+        matched: Option<&MatchedBlocks>,
     ) -> Option<usize> {
         use rayon::prelude::*;
 
         candidates
             .par_iter()
             .find_any(|&&index| {
+                if matches!(matched, Some(m) if m.is_matched(index)) {
+                    return false;
+                }
                 let block = &self.blocks[index];
                 let strong =
                     self.algorithm

--- a/crates/match/src/lib.rs
+++ b/crates/match/src/lib.rs
@@ -29,5 +29,5 @@ mod script;
 
 pub use fuzzy::{FUZZY_LEVEL_1, FUZZY_LEVEL_2, FuzzyMatch, FuzzyMatcher, compute_similarity_score};
 pub use generator::{DeltaGenerator, generate_delta};
-pub use index::DeltaSignatureIndex;
+pub use index::{DeltaSignatureIndex, MatchedBlocks};
 pub use script::{DeltaScript, DeltaToken, apply_delta};


### PR DESCRIPTION
## Summary

- New `MatchedBlocks` bitmap (one bit per basis `block_idx`) wired into the delta generator so already-emitted Copy targets are skipped on subsequent probes.
- Adds `DeltaSignatureIndex::find_match_bytes_filtered` and `find_match_slices_filtered`; existing `find_match_*` keep their public API as thin wrappers.
- Pruning trigger lives in `DeltaGenerator::generate` post-`Copy` push, equivalent to zsync `librcksum/rsum.c:109-119` `write_blocks`.
- Duplicate-content siblings are tracked independently by `block_idx`, mirroring zsync's per-block `hash_entry` model. The `want_i` hint deliberately bypasses the bitmap.
- Property tests + hand-rolled regressions pin: pruning never reduces Copy-token bytes (in the unique-positions domain), apply round-trip is preserved, and surplus-source occurrences fall through to literal emission cleanly.

Design: `docs/design/zsync-prune.md`. Closes #2069 (impl) and #2070 (proptest). Composes with #2059 BitHash and the in-flight seq-match work; rebase expected on either landing first.

## Test plan

- [ ] `cargo nextest run -p matching --all-features -E 'test(matched_blocks)'`
- [ ] `cargo nextest run -p matching --all-features -E 'test(prune_)'`
- [ ] Workspace fmt + clippy (CI)
- [ ] Full nextest suite (CI)
- [ ] Golden byte tests in `crates/protocol/tests/golden/` (CI) - must stay byte-identical
- [ ] Interop matrix (`tools/ci/run_interop.sh`) - no new known_failures entries