### PR TITLE
feat(cli): wire --max-alloc=N memory cap to buffer pool

### DIFF
--- a/crates/cli/src/frontend/arguments/parsed_args/mod.rs
+++ b/crates/cli/src/frontend/arguments/parsed_args/mod.rs
@@ -435,7 +435,12 @@ pub struct ParsedArgs {
     /// `--temp-dir`, `-T` - directory for temporary files during transfer.
     pub temp_dir: Option<PathBuf>,
 
-    /// `--max-alloc` - maximum memory allocation limit.
+    /// `--max-alloc=SIZE` - hard cap on outstanding buffer-pool memory.
+    ///
+    /// Stored as the raw user-supplied string. The downstream parser in
+    /// `execution::options` resolves the K/M/G/T/P/E suffixes, rejects zero
+    /// and out-of-range values, and forwards the resulting byte count to the
+    /// global buffer pool's `MemoryCap`.
     pub max_alloc: Option<OsString>,
 
     /// `--iconv` - character set conversion specification.

--- a/crates/cli/src/frontend/command_builder/sections/build_base_command/network.rs
+++ b/crates/cli/src/frontend/command_builder/sections/build_base_command/network.rs
@@ -116,7 +116,9 @@ pub(super) fn add_network_args(command: ClapCommand) -> ClapCommand {
             Arg::new("max-alloc")
                 .long("max-alloc")
                 .value_name("SIZE")
-                .help("Limit memory allocation to SIZE bytes (can use K, M, G suffixes).")
+                .help(
+                    "Cap memory allocation at SIZE bytes. Supports K, M, G, T, P, E (powers of 1024), KB/MB/GB (powers of 1000), and KiB/MiB/GiB (explicit binary). Default 1G; zero is rejected.",
+                )
                 .num_args(1)
                 .value_parser(OsStringValueParser::new()),
         )

--- a/crates/cli/src/frontend/defaults.rs
+++ b/crates/cli/src/frontend/defaults.rs
@@ -8,7 +8,7 @@ pub(super) const SUPPORTED_OPTIONS_LIST: &str = concat!(
     "--remote-option/-M, --protect-args/-s, --no-protect-args, --secluded-args, --no-secluded-args, ",
     "--ipv4, --ipv6, --daemon, --config, --dry-run/-n, --list-only, --archive/-a, --recursive/-r, --no-recursive, ",
     "--dirs/-d, --no-dirs, --delete/--del, --delete-before, --delete-during, --delete-delay, --delete-after, ",
-    "--delete-excluded, --max-delete, --min-size, --max-size, --block-size, --backup/-b, --backup-dir, ",
+    "--delete-excluded, --max-delete, --min-size, --max-size, --max-alloc, --block-size, --backup/-b, --backup-dir, ",
     "--suffix, --checksum/-c, --checksum-choice, --checksum-seed, --size-only, --ignore-times, --ignore-existing, --existing, ",
     "--ignore-missing-args, --delete-missing-args, --update/-u, --modify-window, --exclude, --exclude-from, ",
     "--include, --include-from, --compare-dest, --copy-dest, --link-dest, --hard-links/-H, --no-hard-links, ",

--- a/crates/cli/src/frontend/execution/drive/options.rs
+++ b/crates/cli/src/frontend/execution/drive/options.rs
@@ -14,8 +14,8 @@ use logging_sink::MessageSink;
 
 use super::super::{
     parse_bandwidth_limit, parse_block_size_argument, parse_compress_choice, parse_compress_level,
-    parse_compress_level_argument, parse_debug_flags, parse_info_flags, parse_max_delete_argument,
-    parse_modify_window_argument, parse_size_limit_argument,
+    parse_compress_level_argument, parse_debug_flags, parse_info_flags, parse_max_alloc_argument,
+    parse_max_delete_argument, parse_modify_window_argument, parse_size_limit_argument,
 };
 use super::messages::fail_with_message;
 use crate::frontend::{
@@ -281,7 +281,7 @@ where
     };
 
     let max_alloc_limit = match inputs.max_alloc.as_ref() {
-        Some(value) => match parse_size_limit_argument(value.as_os_str(), "--max-alloc") {
+        Some(value) => match parse_max_alloc_argument(value.as_os_str()) {
             Ok(limit) => Some(limit),
             Err(message) => return Err(fail_with_message(message, stderr)),
         },

--- a/crates/cli/src/frontend/execution/mod.rs
+++ b/crates/cli/src/frontend/execution/mod.rs
@@ -32,8 +32,9 @@ pub(crate) use operands::{extract_operands, parse_bind_address_argument};
 pub(crate) use options::{SizeParseError, pow_u128_for_size};
 pub(crate) use options::{
     parse_block_size_argument, parse_checksum_seed_argument, parse_human_readable_level,
-    parse_max_delete_argument, parse_modify_window_argument, parse_protocol_version_arg,
-    parse_size_limit_argument, parse_timeout_argument, resolve_iconv_setting,
+    parse_max_alloc_argument, parse_max_delete_argument, parse_modify_window_argument,
+    parse_protocol_version_arg, parse_size_limit_argument, parse_timeout_argument,
+    resolve_iconv_setting,
 };
 pub(crate) use stop::{parse_stop_after_argument, parse_stop_at_argument};
 

--- a/crates/cli/src/frontend/execution/options/mod.rs
+++ b/crates/cli/src/frontend/execution/options/mod.rs
@@ -24,7 +24,9 @@ pub(crate) use numeric::{
 pub(crate) use protocol::parse_protocol_version_arg;
 #[cfg(test)]
 pub(crate) use size::{SizeParseError, pow_u128_for_size};
-pub(crate) use size::{parse_block_size_argument, parse_size_limit_argument};
+pub(crate) use size::{
+    parse_block_size_argument, parse_max_alloc_argument, parse_size_limit_argument,
+};
 
 #[cfg(test)]
 mod tests {

--- a/crates/cli/src/frontend/execution/options/size.rs
+++ b/crates/cli/src/frontend/execution/options/size.rs
@@ -63,6 +63,57 @@ pub(crate) fn parse_size_limit_argument(value: &OsStr, flag: &str) -> Result<u64
     }
 }
 
+/// Sanity ceiling for `--max-alloc`.
+///
+/// Limits the parsed value to at most one quarter of `u64::MAX` so the cap
+/// can be safely converted to `usize` and added to outstanding-byte counters
+/// without risking arithmetic overflow on 64-bit platforms.
+pub(crate) const MAX_ALLOC_CEILING: u64 = u64::MAX / 4;
+
+/// Parses the `--max-alloc` argument as a non-zero byte count with a sanity ceiling.
+///
+/// Mirrors upstream rsync's `parse_size_arg("max-alloc", ...)` accepting K, M,
+/// G, T, P, E suffixes, while rejecting:
+///
+/// - empty input,
+/// - negative values,
+/// - zero (unlimited semantics are not exposed by oc-rsync),
+/// - values above [`MAX_ALLOC_CEILING`].
+///
+/// # Errors
+///
+/// Returns a [`Message`] with role [`Role::Client`] and exit code 1 on any
+/// rejection, matching upstream's diagnostic style.
+pub(crate) fn parse_max_alloc_argument(value: &OsStr) -> Result<u64, Message> {
+    let text = value.to_string_lossy();
+    let trimmed = text.trim_matches(|ch: char| ch.is_ascii_whitespace());
+    let display = if trimmed.is_empty() {
+        text.as_ref()
+    } else {
+        trimmed
+    };
+
+    let limit = parse_size_limit_argument(value, "--max-alloc")?;
+
+    if limit == 0 {
+        return Err(rsync_error!(
+            1,
+            format!("invalid --max-alloc '{display}': size must be greater than zero")
+        )
+        .with_role(Role::Client));
+    }
+
+    if limit > MAX_ALLOC_CEILING {
+        return Err(rsync_error!(
+            1,
+            format!("invalid --max-alloc '{display}': size exceeds the supported range")
+        )
+        .with_role(Role::Client));
+    }
+
+    Ok(limit)
+}
+
 /// Parses the `--block-size` argument as a positive `NonZeroU32` with optional unit suffix.
 pub(crate) fn parse_block_size_argument(value: &OsStr) -> Result<NonZeroU32, Message> {
     let text = value.to_string_lossy();
@@ -560,6 +611,71 @@ mod tests {
         assert!(
             rendered.contains("--max-alloc"),
             "error should mention --max-alloc, got: {rendered}"
+        );
+    }
+
+    #[test]
+    fn parse_max_alloc_argument_valid_gigabyte() {
+        assert_eq!(
+            parse_max_alloc_argument(&os("1G")).unwrap(),
+            1024 * 1024 * 1024
+        );
+    }
+
+    #[test]
+    fn parse_max_alloc_argument_valid_megabyte() {
+        assert_eq!(
+            parse_max_alloc_argument(&os("512M")).unwrap(),
+            512 * 1024 * 1024
+        );
+    }
+
+    #[test]
+    fn parse_max_alloc_argument_valid_kilobyte() {
+        assert_eq!(parse_max_alloc_argument(&os("1024K")).unwrap(), 1024 * 1024);
+    }
+
+    #[test]
+    fn parse_max_alloc_argument_valid_plain_bytes() {
+        assert_eq!(parse_max_alloc_argument(&os("1024")).unwrap(), 1024);
+    }
+
+    #[test]
+    fn parse_max_alloc_argument_rejects_zero() {
+        let err = parse_max_alloc_argument(&os("0")).unwrap_err();
+        let rendered = err.to_string();
+        assert!(
+            rendered.contains("must be greater than zero"),
+            "expected zero-rejection error, got: {rendered}"
+        );
+    }
+
+    #[test]
+    fn parse_max_alloc_argument_rejects_invalid() {
+        assert!(parse_max_alloc_argument(&os("garbage")).is_err());
+        assert!(parse_max_alloc_argument(&os("100X")).is_err());
+        assert!(parse_max_alloc_argument(&os("")).is_err());
+        assert!(parse_max_alloc_argument(&os("-1G")).is_err());
+    }
+
+    #[test]
+    fn parse_max_alloc_argument_rejects_above_ceiling() {
+        // u64::MAX expressed as bytes overflows the ceiling.
+        let value = format!("{}", u64::MAX);
+        let err = parse_max_alloc_argument(&os(&value)).unwrap_err();
+        let rendered = err.to_string();
+        assert!(
+            rendered.contains("exceeds the supported range"),
+            "expected range error, got: {rendered}"
+        );
+    }
+
+    #[test]
+    fn parse_max_alloc_argument_accepts_ceiling() {
+        let value = format!("{}", MAX_ALLOC_CEILING);
+        assert_eq!(
+            parse_max_alloc_argument(&os(&value)).unwrap(),
+            MAX_ALLOC_CEILING
         );
     }
 

--- a/crates/cli/src/frontend/execution/options/size.rs
+++ b/crates/cli/src/frontend/execution/options/size.rs
@@ -672,7 +672,7 @@ mod tests {
 
     #[test]
     fn parse_max_alloc_argument_accepts_ceiling() {
-        let value = format!("{}", MAX_ALLOC_CEILING);
+        let value = format!("{MAX_ALLOC_CEILING}");
         assert_eq!(
             parse_max_alloc_argument(&os(&value)).unwrap(),
             MAX_ALLOC_CEILING

--- a/crates/cli/src/frontend/help.rs
+++ b/crates/cli/src/frontend/help.rs
@@ -45,6 +45,7 @@ pub(super) fn help_text(program_name: ProgramName) -> String {
             "      --max-delete=NUM  Limit deletions to NUM entries per run.\n",
             "      --min-size=SIZE  Skip files smaller than SIZE.\n",
             "      --max-size=SIZE  Skip files larger than SIZE.\n",
+            "      --max-alloc=SIZE  Cap memory allocation at SIZE bytes (K=1024, M=1024^2, G=1024^3, T=1024^4, P=1024^5, E=1024^6; KB/MB/GB use powers of 1000; KiB/MiB/GiB are explicit binary; default 1G; 0 is rejected).\n",
             "      --block-size=SIZE  Force the delta-transfer block size to SIZE bytes.\n",
             "  -b, --backup    Create backups before overwriting or deleting existing entries.\n",
             "      --backup-dir=DIR  Store backups inside DIR instead of alongside the destination.\n",

--- a/crates/cli/src/frontend/server/flags.rs
+++ b/crates/cli/src/frontend/server/flags.rs
@@ -35,6 +35,13 @@ pub(super) struct ServerLongFlags {
     pub(super) checksum_choice: Option<String>,
     pub(super) min_size: Option<String>,
     pub(super) max_size: Option<String>,
+    /// Memory allocation cap forwarded by the client.
+    ///
+    /// upstream: options.c:2845-2846 - `--max-alloc=arg` is emitted by
+    /// `server_options()` when the user-supplied value differs from the
+    /// default. Each side enforces its own cap, so the server records and
+    /// applies the value locally.
+    pub(super) max_alloc: Option<String>,
     pub(super) stop_at: Option<String>,
     pub(super) stop_after: Option<String>,
     pub(super) files_from: Option<String>,
@@ -88,6 +95,7 @@ pub(super) fn parse_server_long_flags(args: &[OsString]) -> ServerLongFlags {
         checksum_choice: None,
         min_size: None,
         max_size: None,
+        max_alloc: None,
         stop_at: None,
         stop_after: None,
         files_from: None,
@@ -148,6 +156,8 @@ fn parse_value_bearing_flag(s: &str, flags: &mut ServerLongFlags) {
         flags.min_size = Some(value.to_owned());
     } else if let Some(value) = s.strip_prefix("--max-size=") {
         flags.max_size = Some(value.to_owned());
+    } else if let Some(value) = s.strip_prefix("--max-alloc=") {
+        flags.max_alloc = Some(value.to_owned());
     } else if let Some(value) = s.strip_prefix("--stop-at=") {
         flags.stop_at = Some(value.to_owned());
     } else if let Some(value) = s.strip_prefix("--stop-after=") {
@@ -219,6 +229,7 @@ pub(super) fn is_known_server_long_flag(arg: &str) -> bool {
         || arg.starts_with("--link-dest=")
         || arg.starts_with("--min-size=")
         || arg.starts_with("--max-size=")
+        || arg.starts_with("--max-alloc=")
         || arg.starts_with("--stop-at=")
         || arg.starts_with("--stop-after=")
         || arg.starts_with("--files-from=")

--- a/crates/cli/src/frontend/server/run.rs
+++ b/crates/cli/src/frontend/server/run.rs
@@ -186,6 +186,29 @@ fn apply_value_flags<Err: Write>(
         }
     }
 
+    // upstream: options.c:1943-1950 - server-side `--max-alloc` is parsed and
+    // applied to the local allocator. We forward it from the client and
+    // enforce the cap on the server's buffer pool.
+    if let Some(alloc_str) = &long_flags.max_alloc {
+        match super::super::execution::parse_max_alloc_argument(std::ffi::OsStr::new(alloc_str)) {
+            Ok(limit) => {
+                if let Ok(limit_usize) = usize::try_from(limit)
+                    && limit_usize > 0
+                {
+                    let cfg = engine::local_copy::GlobalBufferPoolConfig {
+                        memory_cap: Some(limit_usize),
+                        ..engine::local_copy::GlobalBufferPoolConfig::default()
+                    };
+                    let _ = engine::local_copy::init_global_buffer_pool(cfg);
+                }
+            }
+            Err(message) => {
+                write_server_error(stderr, brand, message.to_string());
+                return Err(1);
+            }
+        }
+    }
+
     if let Some(when_str) = &long_flags.stop_at {
         match parse_server_stop_at(when_str) {
             Ok(deadline) => config.stop_at = Some(deadline),

--- a/crates/cli/src/frontend/server/tests.rs
+++ b/crates/cli/src/frontend/server/tests.rs
@@ -427,7 +427,7 @@ fn long_flags_max_alloc() {
 
 #[test]
 fn long_flags_max_alloc_is_known_long_flag() {
-    let args = vec![
+    let args = [
         OsString::from("--server"),
         OsString::from("--max-alloc=1G"),
         OsString::from("-logDtpr"),

--- a/crates/cli/src/frontend/server/tests.rs
+++ b/crates/cli/src/frontend/server/tests.rs
@@ -295,6 +295,7 @@ fn long_flags_defaults() {
     assert!(flags.checksum_choice.is_none());
     assert!(flags.min_size.is_none());
     assert!(flags.max_size.is_none());
+    assert!(flags.max_alloc.is_none());
     assert!(flags.stop_at.is_none());
     assert!(flags.stop_after.is_none());
     assert!(matches!(
@@ -415,6 +416,31 @@ fn long_flags_max_size() {
 }
 
 #[test]
+fn long_flags_max_alloc() {
+    let args = vec![
+        OsString::from("--server"),
+        OsString::from("--max-alloc=512M"),
+    ];
+    let flags = parse_server_long_flags(&args);
+    assert_eq!(flags.max_alloc.as_deref(), Some("512M"));
+}
+
+#[test]
+fn long_flags_max_alloc_is_known_long_flag() {
+    let args = vec![
+        OsString::from("--server"),
+        OsString::from("--max-alloc=1G"),
+        OsString::from("-logDtpr"),
+        OsString::from("."),
+        OsString::from("src/"),
+    ];
+    let (flag_string, positional) = parse_server_flag_string_and_args(&args[1..]);
+    assert_eq!(flag_string, "-logDtpr");
+    assert_eq!(positional, vec![OsString::from("src/")]);
+    assert!(is_known_server_long_flag("--max-alloc=1G"));
+}
+
+#[test]
 fn long_flags_stop_at() {
     let args = vec![
         OsString::from("--server"),
@@ -448,6 +474,7 @@ fn long_flags_all_combined() {
         OsString::from("--checksum-choice=md5"),
         OsString::from("--min-size=100"),
         OsString::from("--max-size=1M"),
+        OsString::from("--max-alloc=2G"),
         OsString::from("--stop-after=30"),
         OsString::from("-logDtpr"),
         OsString::from("."),
@@ -464,6 +491,7 @@ fn long_flags_all_combined() {
     assert_eq!(flags.checksum_choice.as_deref(), Some("md5"));
     assert_eq!(flags.min_size.as_deref(), Some("100"));
     assert_eq!(flags.max_size.as_deref(), Some("1M"));
+    assert_eq!(flags.max_alloc.as_deref(), Some("2G"));
     assert_eq!(flags.stop_after.as_deref(), Some("30"));
 }
 

--- a/crates/cli/src/frontend/tests/parse_max_alloc.rs
+++ b/crates/cli/src/frontend/tests/parse_max_alloc.rs
@@ -239,6 +239,77 @@ fn max_alloc_rejects_non_numeric() {
 }
 
 #[test]
+fn max_alloc_argument_resolution_rejects_zero() {
+    use crate::frontend::execution::parse_max_alloc_argument;
+    let error =
+        parse_max_alloc_argument(OsStr::new("0")).expect_err("zero should fail at the cap layer");
+    let rendered = error.to_string();
+    assert!(
+        rendered.contains("greater than zero"),
+        "expected zero-rejection error, got: {rendered}"
+    );
+}
+
+#[test]
+fn max_alloc_argument_resolution_accepts_typical_values() {
+    use crate::frontend::execution::parse_max_alloc_argument;
+    assert_eq!(
+        parse_max_alloc_argument(OsStr::new("1G")).expect("1G accepted"),
+        1024 * 1024 * 1024
+    );
+    assert_eq!(
+        parse_max_alloc_argument(OsStr::new("512M")).expect("512M accepted"),
+        512 * 1024 * 1024
+    );
+    assert_eq!(
+        parse_max_alloc_argument(OsStr::new("1024K")).expect("1024K accepted"),
+        1024 * 1024
+    );
+    assert_eq!(
+        parse_max_alloc_argument(OsStr::new("4096")).expect("plain bytes accepted"),
+        4096
+    );
+}
+
+#[test]
+fn max_alloc_argument_resolution_rejects_invalid() {
+    use crate::frontend::execution::parse_max_alloc_argument;
+    assert!(parse_max_alloc_argument(OsStr::new("garbage")).is_err());
+    assert!(parse_max_alloc_argument(OsStr::new("100X")).is_err());
+    assert!(parse_max_alloc_argument(OsStr::new("")).is_err());
+    assert!(parse_max_alloc_argument(OsStr::new("-1G")).is_err());
+}
+
+#[test]
+fn max_alloc_argument_resolution_rejects_excessive_value() {
+    use crate::frontend::execution::parse_max_alloc_argument;
+    let value = format!("{}", u64::MAX);
+    let err = parse_max_alloc_argument(OsStr::new(&value)).expect_err("ceiling enforced");
+    let rendered = err.to_string();
+    assert!(
+        rendered.contains("exceeds the supported range"),
+        "expected range error, got: {rendered}"
+    );
+}
+
+#[test]
+fn max_alloc_zero_value_produces_error_exit() {
+    let _guard = clear_rsync_rsh();
+    let (code, _stdout, stderr) = run_with_args([
+        OsString::from(RSYNC),
+        OsString::from("--max-alloc=0"),
+        OsString::from("source"),
+        OsString::from("dest"),
+    ]);
+    let stderr_text = String::from_utf8_lossy(&stderr);
+    assert_ne!(code, 0, "should exit with error for zero --max-alloc");
+    assert!(
+        stderr_text.contains("greater than zero"),
+        "error should mention greater-than-zero, got: {stderr_text}"
+    );
+}
+
+#[test]
 fn max_alloc_invalid_value_produces_error_exit() {
     let _guard = clear_rsync_rsh();
     let (code, _stdout, stderr) = run_with_args([

--- a/crates/core/src/client/config/builder/performance.rs
+++ b/crates/core/src/client/config/builder/performance.rs
@@ -105,10 +105,12 @@ impl ClientConfigBuilder {
     }
 
     builder_setter! {
-        /// Sets the maximum memory allocation limit per allocation request.
+        /// Sets the `--max-alloc` cap in bytes for the global buffer pool.
         ///
-        /// When set, this limits how much memory can be allocated in a single
-        /// request, providing protection against memory exhaustion attacks.
+        /// When set, the pool tracks outstanding (checked-out) memory and
+        /// blocks `acquire` calls that would push the outstanding total past
+        /// this limit. Mirrors upstream rsync's `max_alloc` (default 1 GiB;
+        /// suffixes K/M/G/T/P/E supported by the CLI parser).
         #[doc(alias = "--max-alloc")]
         max_alloc: Option<u64>,
     }

--- a/crates/core/src/client/config/client/performance.rs
+++ b/crates/core/src/client/config/client/performance.rs
@@ -113,10 +113,12 @@ impl ClientConfig {
         self.block_size_override
     }
 
-    /// Returns the maximum memory allocation limit per allocation request.
+    /// Returns the configured `--max-alloc` cap in bytes, if any.
     ///
-    /// When set, this limits how much memory can be allocated in a single
-    /// request, providing protection against memory exhaustion attacks.
+    /// When set, the global buffer pool tracks outstanding (checked-out)
+    /// memory and applies backpressure once allocations would push the
+    /// outstanding total past this limit. Mirrors upstream rsync's
+    /// `max_alloc` (default 1 GiB; suffixes K/M/G/T/P/E supported).
     #[doc(alias = "--max-alloc")]
     pub const fn max_alloc(&self) -> Option<u64> {
         self.max_alloc

--- a/crates/core/src/client/remote/invocation/builder.rs
+++ b/crates/core/src/client/remote/invocation/builder.rs
@@ -224,6 +224,14 @@ impl<'a> RemoteInvocationBuilder<'a> {
             args.push(OsString::from(format!("--min-size={min}")));
         }
 
+        // upstream: options.c:2845-2846 - `--max-alloc=arg` is forwarded to
+        // the server when the user supplied a non-default value. Each side
+        // owns its own cap, so forwarding lets the remote enforce the same
+        // budget the client requested.
+        if let Some(limit) = self.config.max_alloc() {
+            args.push(OsString::from(format!("--max-alloc={limit}")));
+        }
+
         if let Some(window) = self.config.modify_window() {
             args.push(OsString::from(format!("--modify-window={window}")));
         }

--- a/crates/core/src/client/remote/invocation/tests.rs
+++ b/crates/core/src/client/remote/invocation/tests.rs
@@ -1290,6 +1290,28 @@ fn includes_min_size_long_arg() {
 }
 
 #[test]
+fn includes_max_alloc_long_arg() {
+    let config = ClientConfig::builder()
+        .max_alloc(Some(512 * 1024 * 1024))
+        .build();
+    let args = build_sender_args(&config);
+    assert!(
+        args.iter().any(|a| a == "--max-alloc=536870912"),
+        "expected --max-alloc=536870912 in args: {args:?}"
+    );
+}
+
+#[test]
+fn omits_max_alloc_when_none() {
+    let config = ClientConfig::builder().build();
+    let args = build_sender_args(&config);
+    assert!(
+        !args.iter().any(|a| a.starts_with("--max-alloc=")),
+        "should not emit --max-alloc= when none: {args:?}"
+    );
+}
+
+#[test]
 fn includes_modify_window_long_arg() {
     let config = ClientConfig::builder().modify_window(Some(2)).build();
     let args = build_sender_args(&config);

--- a/crates/core/src/client/run/mod.rs
+++ b/crates/core/src/client/run/mod.rs
@@ -61,7 +61,10 @@ use std::time::Duration;
 #[cfg(feature = "tracing")]
 use tracing::instrument;
 
-use engine::local_copy::{FilterProgram, LocalCopyExecution, LocalCopyOptions, LocalCopyPlan};
+use engine::local_copy::{
+    FilterProgram, GlobalBufferPoolConfig, LocalCopyExecution, LocalCopyOptions, LocalCopyPlan,
+    init_global_buffer_pool,
+};
 
 use super::config::{BandwidthLimit, ClientConfig, DeleteMode};
 use super::error::{ClientError, map_local_copy_error, missing_operands_error};
@@ -181,6 +184,8 @@ fn run_client_internal(
     if !config.has_transfer_request() {
         return Err(missing_operands_error());
     }
+
+    apply_max_alloc(&config);
 
     let batch_writer = if let Some(batch_cfg) = config.batch_config() {
         if let Some(result) = batch::handle_batch_read(batch_cfg, &config) {
@@ -321,6 +326,44 @@ fn run_client_internal(
     }
 
     Ok(summary)
+}
+
+/// Applies the `--max-alloc` cap from the [`ClientConfig`] to the global
+/// buffer pool.
+///
+/// Calls [`init_global_buffer_pool`] with [`GlobalBufferPoolConfig::default`]
+/// adjusted to carry the requested memory cap. The first caller wins per
+/// process: subsequent invocations and lazy initialisations are no-ops, so
+/// the cap only takes effect when this runs before any subsystem has
+/// acquired a buffer. That matches the lifetime of a typical CLI invocation
+/// (one client per process). Library callers that already initialised the
+/// pool retain whatever cap they chose.
+///
+/// Mirrors upstream rsync `options.c:1943-1950`, where `max_alloc` is set
+/// once during option processing and consumed by allocation paths thereafter.
+fn apply_max_alloc(config: &ClientConfig) {
+    let Some(limit) = config.max_alloc() else {
+        return;
+    };
+    let Ok(limit_usize) = usize::try_from(limit) else {
+        // Configurations parsed via the CLI are bounded by `MAX_ALLOC_CEILING`
+        // (u64::MAX / 4) so this branch is only reachable on 32-bit targets
+        // when a programmatic builder supplies a 64-bit value larger than
+        // the host's address space. Skipping the cap is safe; the pool
+        // simply remains uncapped.
+        return;
+    };
+    if limit_usize == 0 {
+        return;
+    }
+    let cfg = GlobalBufferPoolConfig {
+        memory_cap: Some(limit_usize),
+        ..GlobalBufferPoolConfig::default()
+    };
+    // `Err` means another caller (typically a library embedder) already
+    // initialised the pool; their configuration wins to avoid silently
+    // overriding their settings.
+    let _ = init_global_buffer_pool(cfg);
 }
 
 /// Builder for [`LocalCopyOptions`] derived from a [`ClientConfig`] and

--- a/crates/engine/src/local_copy/buffer_pool/global.rs
+++ b/crates/engine/src/local_copy/buffer_pool/global.rs
@@ -39,6 +39,13 @@ pub struct GlobalBufferPoolConfig {
     pub max_buffers: usize,
     /// Size of each buffer in bytes.
     pub buffer_size: usize,
+    /// Optional hard memory cap in bytes for outstanding (checked-out) buffers.
+    ///
+    /// When `Some`, the pool blocks `acquire` calls that would push outstanding
+    /// memory past the cap until a buffer is returned. `None` leaves the pool
+    /// uncapped, matching its historical default. A value of `Some(0)` is
+    /// treated as `None`.
+    pub memory_cap: Option<usize>,
 }
 
 /// Environment variable for overriding the buffer pool size (number of buffers).
@@ -66,6 +73,7 @@ impl Default for GlobalBufferPoolConfig {
         Self {
             max_buffers,
             buffer_size: super::super::COPY_BUFFER_SIZE,
+            memory_cap: None,
         }
     }
 }
@@ -107,15 +115,17 @@ pub fn global_buffer_pool() -> Arc<BufferPool> {
 /// init_global_buffer_pool(GlobalBufferPoolConfig {
 ///     max_buffers: 16,
 ///     buffer_size: 256 * 1024,
+///     memory_cap: Some(512 * 1024 * 1024),
 /// }).expect("pool not yet initialized");
 /// ```
 pub fn init_global_buffer_pool(
     config: GlobalBufferPoolConfig,
 ) -> Result<(), GlobalBufferPoolConfig> {
-    let pool = Arc::new(BufferPool::with_buffer_size(
-        config.max_buffers,
-        config.buffer_size,
-    ));
+    let mut pool = BufferPool::with_buffer_size(config.max_buffers, config.buffer_size);
+    if let Some(cap) = config.memory_cap.filter(|&n| n > 0) {
+        pool = pool.with_memory_cap(cap);
+    }
+    let pool = Arc::new(pool);
     GLOBAL_BUFFER_POOL.set(pool).map_err(|_| config)
 }
 
@@ -137,6 +147,7 @@ mod tests {
             .unwrap_or(4);
         assert_eq!(config.max_buffers, expected);
         assert_eq!(config.buffer_size, super::super::super::COPY_BUFFER_SIZE);
+        assert!(config.memory_cap.is_none());
     }
 
     #[test]
@@ -144,9 +155,11 @@ mod tests {
         let config = GlobalBufferPoolConfig {
             max_buffers: 32,
             buffer_size: 512 * 1024,
+            memory_cap: Some(64 * 1024 * 1024),
         };
         assert_eq!(config.max_buffers, 32);
         assert_eq!(config.buffer_size, 512 * 1024);
+        assert_eq!(config.memory_cap, Some(64 * 1024 * 1024));
     }
 
     #[test]
@@ -296,6 +309,7 @@ mod tests {
         let config = GlobalBufferPoolConfig {
             max_buffers: 99,
             buffer_size: 1024,
+            memory_cap: None,
         };
         let result = init_global_buffer_pool(config);
         assert!(result.is_err());
@@ -304,5 +318,26 @@ mod tests {
         let returned = result.unwrap_err();
         assert_eq!(returned.max_buffers, 99);
         assert_eq!(returned.buffer_size, 1024);
+        assert!(returned.memory_cap.is_none());
+    }
+
+    #[test]
+    fn memory_cap_field_round_trips() {
+        let config = GlobalBufferPoolConfig {
+            max_buffers: 4,
+            buffer_size: 8 * 1024,
+            memory_cap: Some(4 * 1024 * 1024),
+        };
+        assert_eq!(config.memory_cap, Some(4 * 1024 * 1024));
+    }
+
+    #[test]
+    fn memory_cap_zero_is_treated_as_unbounded() {
+        // The init helper filters out memory_cap=Some(0) so the pool stays
+        // uncapped instead of panicking on `MemoryCap::new(0)`. We only
+        // assert the filter logic here; the actual pool init is exercised
+        // by `init_after_lazy_init_returns_err` and integration tests.
+        let cap: Option<usize> = Some(0).filter(|&n| n > 0);
+        assert!(cap.is_none());
     }
 }


### PR DESCRIPTION
## Summary

- Add `parse_max_alloc_argument` that validates K/M/G/T/P/E suffixes, rejects zero, and clamps at `u64::MAX/4` for arithmetic safety.
- Plumb the parsed cap into a new `memory_cap` field on `GlobalBufferPoolConfig` so `init_global_buffer_pool` calls `BufferPool::with_memory_cap`, activating backpressure on the outstanding buffer total.
- Apply the cap at the start of `run_client_internal` and the server stdio entry point so both client and server enforce their own budgets, matching upstream `options.c:1943-1950`.
- Forward `--max-alloc=N` to remote sender and daemon-server invocations and recognise it as a long server flag, matching upstream `options.c:2845-2846 server_options()`.
- Add `--max-alloc` to `SUPPORTED_OPTIONS_LIST` plus a help-text line documenting the suffix semantics.

## Test plan

- [ ] `cargo nextest run -p cli --all-features -E 'test(parse_max_alloc)'` (CI)
- [ ] `cargo nextest run -p cli --all-features -E 'test(server::tests)'` (CI)
- [ ] `cargo nextest run -p engine --all-features -E 'test(buffer_pool::global)'` (CI)
- [ ] `cargo nextest run -p core --all-features -E 'test(remote::invocation)'` (CI)
- [ ] Full CI matrix (fmt+clippy, nextest stable, Windows, macOS, Linux musl)