### PR TITLE
docs(transfer): rustdoc cleanup of delta_apply

### DIFF
--- a/crates/transfer/src/delta_apply/applicator.rs
+++ b/crates/transfer/src/delta_apply/applicator.rs
@@ -127,8 +127,8 @@ pub struct DeltaApplicator<'a> {
     sparse_state: Option<SparseWriteState>,
     checksum_verifier: ChecksumVerifier,
     basis_signature: Option<&'a FileSignature>,
-    /// Cached basis file mapper, opened once and reused for all block references.
-    /// Uses `AdaptiveMapStrategy` on Unix, `BufferedMap` on Windows.
+    /// Cached basis file mapper, opened once and reused for all block
+    /// references. Strategy resolved per [`BasisWriterKind`] and target OS.
     basis_map: Option<MapFile<BasisMapStrategy>>,
     /// Reusable buffer for literal token data to avoid per-token allocations.
     token_buffer: TokenBuffer,

--- a/crates/transfer/src/delta_apply/checksum.rs
+++ b/crates/transfer/src/delta_apply/checksum.rs
@@ -1,15 +1,14 @@
 //! Checksum verification for delta transfer integrity.
 //!
-//! Uses enum dispatch for zero-allocation runtime algorithm selection.
-//! Mirrors upstream rsync's checksum verification in `receiver.c`.
+//! upstream: `receiver.c` end-of-file digest verification.
 
 use checksums::strong::{Md4, Md5, Sha1, StrongDigest, Xxh3, Xxh3_128, Xxh64};
 use protocol::{ChecksumAlgorithm, CompatibilityFlags, NegotiationResult, ProtocolVersion};
 
-/// Checksum verifier for delta transfer integrity verification.
+/// Whole-file checksum verifier with enum dispatch for zero-allocation runtime
+/// algorithm selection.
 ///
-/// Uses enum dispatch for zero-allocation runtime algorithm selection.
-/// Mirrors upstream rsync's checksum verification in `receiver.c`.
+/// Mirrors upstream rsync's whole-file checksum verification in `receiver.c`.
 pub enum ChecksumVerifier {
     /// No checksum - `CSUM_NONE` negotiated. 1-byte placeholder digest
     /// matching upstream `receiver.c` behaviour.

--- a/crates/transfer/src/delta_apply/sparse.rs
+++ b/crates/transfer/src/delta_apply/sparse.rs
@@ -1,18 +1,15 @@
-//! Sparse file write state tracker.
+//! Sparse file write state tracker for hole optimization during delta apply.
 //!
-//! Tracks pending runs of zeros that should become holes in the output file
-//! rather than being written as data. Mirrors upstream rsync's `write_sparse()`
-//! behavior in `fileio.c`.
+//! upstream: `fileio.c` `write_sparse()`.
 
 use std::io::{self, Seek, SeekFrom, Write};
 
 use crate::constants::{CHUNK_SIZE, leading_zero_count, trailing_zero_count};
 
-/// State tracker for sparse file writing.
+/// Tracks pending runs of zeros so they become holes in the output file rather
+/// than being written as data.
 ///
-/// Tracks pending runs of zeros that should become holes in the output file
-/// rather than being written as data. Mirrors upstream rsync's `write_sparse()`
-/// behavior in `fileio.c`.
+/// Mirrors upstream rsync's `write_sparse()` behaviour in `fileio.c`.
 #[derive(Debug, Default)]
 pub struct SparseWriteState {
     pending_zeros: u64,


### PR DESCRIPTION
## Summary
- Trim duplicated module/type doc prose in `delta_apply/sparse.rs` and `delta_apply/checksum.rs`; module docs now point to upstream, type docs describe the type.
- Correct stale `Windows` reference on `DeltaApplicator::basis_map` field doc to describe the actual policy resolution.
- Preserve every `// upstream: ...` reference verbatim.

## Test plan
- [ ] CI: fmt + clippy
- [ ] CI: nextest (stable)