### PR TITLE
docs(metadata): rustdoc cleanup of mapping module

### DIFF
--- a/crates/metadata/src/mapping/name_mapping.rs
+++ b/crates/metadata/src/mapping/name_mapping.rs
@@ -69,8 +69,9 @@ impl NameMapping {
 
     /// Finds the first matching rule for the given identifier.
     ///
-    /// Caches the name lookup result across rule evaluations to avoid
-    /// redundant system calls.
+    /// Rules are evaluated in declaration order - first match wins. The
+    /// associated name is looked up at most once per call and cached across
+    /// rule evaluations to avoid redundant system calls.
     pub(super) fn resolve_rule(&self, identifier: u32) -> io::Result<Option<&MappingRule>> {
         if self.rules.is_empty() {
             return Ok(None);

--- a/crates/metadata/src/mapping/parse.rs
+++ b/crates/metadata/src/mapping/parse.rs
@@ -12,11 +12,13 @@ use super::types::{MappingKind, MappingMatcher, MappingParseError, MappingTarget
 
 /// Parses the source (left-hand) side of a mapping entry.
 ///
-/// Recognizes:
+/// Recognized in priority order:
 /// - `*` as a wildcard-all matcher
 /// - Numeric values or ranges (e.g., `100`, `100-200`)
 /// - Glob patterns containing `*`, `?`, or `[`
-/// - Exact name strings
+/// - Otherwise, treated as an exact name string
+///
+/// An empty source is rejected with a [`MappingParseError`].
 pub(crate) fn parse_matcher(
     kind: MappingKind,
     source: &str,
@@ -46,8 +48,9 @@ pub(crate) fn parse_matcher(
 
 /// Parses a numeric value or range from a source string.
 ///
-/// Returns `Some((start, end))` for both single values (where `start == end`)
-/// and ranges. Reversed ranges are normalized so `start <= end`.
+/// Returns `Some((start, end))` for single values (where `start == end`) and
+/// `start-end` ranges. Reversed ranges (`end-start`) are normalized so
+/// `start <= end`. Returns `None` for any non-numeric or malformed input.
 pub(super) fn parse_numeric_range(source: &str) -> Option<(u32, u32)> {
     let mut parts = source.split('-');
     let start = parts.next()?;

--- a/crates/metadata/src/mapping/types.rs
+++ b/crates/metadata/src/mapping/types.rs
@@ -74,8 +74,9 @@ pub(crate) enum MappingMatcher {
 impl MappingMatcher {
     /// Tests whether the given identifier matches this matcher.
     ///
-    /// The `name_lookup` closure is called lazily only when the matcher
-    /// requires name resolution.
+    /// `name_lookup` is invoked lazily and only by name-based variants
+    /// ([`Self::ExactName`], [`Self::Pattern`]). Numeric and wildcard-all
+    /// variants never trigger a name resolution.
     pub(crate) fn matches<F>(&self, identifier: u32, mut name_lookup: F) -> io::Result<bool>
     where
         F: FnMut() -> io::Result<Option<String>>,
@@ -112,6 +113,9 @@ pub(crate) enum MappingTarget {
 
 impl MappingTarget {
     /// Resolves this target to a UID.
+    ///
+    /// Returns [`io::ErrorKind::NotFound`] if a name target cannot be
+    /// resolved on the receiver.
     pub(crate) fn resolve_uid(&self) -> io::Result<RawUid> {
         match self {
             Self::Id(id) => Ok(*id as RawUid),
@@ -126,6 +130,9 @@ impl MappingTarget {
     }
 
     /// Resolves this target to a GID.
+    ///
+    /// Returns [`io::ErrorKind::NotFound`] if a name target cannot be
+    /// resolved on the receiver.
     pub(crate) fn resolve_gid(&self) -> io::Result<RawGid> {
         match self {
             Self::Id(id) => Ok(*id as RawGid),

--- a/crates/metadata/src/mapping/wildcard.rs
+++ b/crates/metadata/src/mapping/wildcard.rs
@@ -8,6 +8,8 @@
 
 /// Tests whether `text` matches a wildcard `pattern`.
 ///
+/// Operates on raw bytes so non-UTF-8 names are handled losslessly.
+///
 /// Supported metacharacters:
 /// - `*` matches zero or more characters
 /// - `?` matches exactly one character


### PR DESCRIPTION
## Summary
- Tighten rustdoc on `crates/metadata/src/mapping/` (`name_mapping.rs`, `parse.rs`, `types.rs`, `wildcard.rs`).
- Make first-match-wins semantic explicit on `NameMapping::resolve_rule`, document name-cache scope (one lookup per call).
- Clarify `parse_matcher` priority order, empty-source rejection, and `parse_numeric_range` return cases.
- Document `MappingTarget::resolve_uid`/`resolve_gid` `NotFound` error path and that `MappingMatcher::matches` only invokes the name lookup for name-based variants.
- Note that `wildcard_matches` operates on raw bytes for non-UTF-8 safety.

## Test plan
- [ ] CI fmt + clippy
- [ ] CI nextest (stable)
- [ ] CI Windows / macOS / Linux musl