### PR TITLE
docs(transfer): rustdoc cleanup of config module

### DIFF
--- a/crates/transfer/src/config/mod.rs
+++ b/crates/transfer/src/config/mod.rs
@@ -287,7 +287,7 @@ pub struct ServerConfig {
     ///
     /// # Upstream Reference
     ///
-    /// - `clientserver.c:rsync_module()` — builds `daemon_filter_list` from
+    /// - `clientserver.c:rsync_module()` - builds `daemon_filter_list` from
     ///   `lp_filter()`, `lp_include()`, `lp_exclude()`, `lp_include_from()`,
     ///   `lp_exclude_from()` before the transfer starts.
     pub daemon_filter_rules: Vec<FilterRuleWireFormat>,


### PR DESCRIPTION
## Summary

- Replace em-dash with hyphen in `daemon_filter_rules` rustdoc to follow the project style guide.

The previous comment-cleanup pass on this module (originally tracked under issue #1954) was lost during the recent master history rewrite. The bulk of that work is already reflected in the file's content; this PR is the residual style fix.

## Test plan

- [ ] CI: fmt + clippy
- [ ] CI: nextest (stable)
- [ ] CI: Windows / macOS / Linux musl matrices