### PR TITLE
docs(core): rustdoc cleanup of message module

### DIFF
--- a/crates/core/src/message/message_impl/constructors.rs
+++ b/crates/core/src/message/message_impl/constructors.rs
@@ -9,7 +9,7 @@ impl Message {
     /// Higher layers typically construct diagnostics through the
     /// severity-specific helpers such as [`Message::info`], [`Message::warning`],
     /// or [`Message::error`]. This constructor allows callers to generate
-    /// messages dynamically when the severity is only known at runtime—for
+    /// messages dynamically when the severity is only known at runtime - for
     /// example when mapping upstream exit-code tables. The message starts without
     /// an associated exit code or source location so additional context can be
     /// layered on afterwards.

--- a/crates/core/src/message/scratch.rs
+++ b/crates/core/src/message/scratch.rs
@@ -59,7 +59,7 @@ impl MessageScratch {
     ///
     /// The helper reuses the thread-local storage maintained by this module so callers can render
     /// multiple messages without explicitly storing a [`MessageScratch`]. When the thread-local
-    /// instance is temporarily unavailable—such as when the current thread already borrowed it—the
+    /// instance is temporarily unavailable - such as when the current thread already borrowed it - the
     /// function transparently falls back to a fresh buffer. This mirrors the strategy used by
     /// [`Message::render_to`](crate::message::Message::render_to) and
     /// [`Message::to_bytes`](crate::message::Message::to_bytes), ensuring consistent performance

--- a/crates/core/src/message/segments/mod.rs
+++ b/crates/core/src/message/segments/mod.rs
@@ -2,8 +2,8 @@
 //!
 //! The [`MessageSegments`] type exposes the low-level representation that the
 //! logging subsystem streams into stdout/stderr. This submodule keeps the
-//! implementation split across focussed files so that each area – iterators,
-//! vectored I/O, and buffer-friendly helpers – remains under the workspace line
+//! implementation split across focussed files so that each area - iterators,
+//! vectored I/O, and buffer-friendly helpers - remains under the workspace line
 //! limits while still providing comprehensive rustdoc coverage.
 
 mod base;

--- a/crates/core/src/message/tests/part7.rs
+++ b/crates/core/src/message/tests/part7.rs
@@ -1,5 +1,3 @@
-// Comprehensive path normalization tests
-
 #[test]
 fn normalize_path_handles_relative_paths() {
     let normalized = normalize_path(Path::new("foo/bar/baz.txt"));


### PR DESCRIPTION
## Summary

Follow-up to PR #3606 (task #2012). Removes remaining stylistic deviations from rustdoc and code comments in `crates/core/src/message/`:

- Replace em-dashes/en-dashes with hyphens in three rustdoc blocks (`scratch.rs`, `message_impl/constructors.rs`, `segments/mod.rs`).
- Delete the decorative banner comment at the top of `tests/part7.rs`.

No code logic changes; preserves all upstream rsync references verbatim.

## Test plan
- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings`
- [ ] `cargo nextest run -p core --all-features`