### PR TITLE
docs: comment audit cleanup across remaining files

### DIFF
--- a/crates/cli/src/frontend/tests/output_parity.rs
+++ b/crates/cli/src/frontend/tests/output_parity.rs
@@ -753,7 +753,7 @@ fn parity_itemize_string_is_eleven_chars_for_non_delete() {
 
 #[test]
 fn parity_itemize_unchanged_file_shows_dots() {
-    // upstream: log.c:735-744 — all-dots collapse to spaces for '.', 'h', 'c' update types
+    // upstream: log.c:735-744 - all-dots collapse to spaces for '.', 'h', 'c' update types
     let event = ClientEvent::for_test(
         PathBuf::from("unchanged.txt"),
         ClientEventKind::MetadataReused,
@@ -2228,7 +2228,7 @@ fn parity_info_flag_skip_shows_skip_messages() {
     );
 
     // When files are identical, --info=skip should show that files were skipped.
-    // The file was identical so no transfer needed — either skip message or empty output
+    // The file was identical so no transfer needed - either skip message or empty output
     // is acceptable (upstream rsync only shows skip at level >= 1 when there's a reason).
     let _ = combined;
     assert_eq!(code, 0, "--info=skip should not cause errors");

--- a/crates/cli/src/frontend/tests/stop.rs
+++ b/crates/cli/src/frontend/tests/stop.rs
@@ -52,7 +52,7 @@ fn stop_at_argument_rejects_past_time() {
     let now = OffsetDateTime::now_local().expect("local time");
 
     // Skip near midnight: subtracting 1 minute wraps to 23:59 which the
-    // parser treats as 23:59 *today* — that is in the future at 00:00.
+    // parser treats as 23:59 *today* - that is in the future at 00:00.
     if now.hour() == 0 && now.minute() < 5 {
         return;
     }

--- a/crates/cli/tests/output_parity.rs
+++ b/crates/cli/tests/output_parity.rs
@@ -244,7 +244,7 @@ fn itemize_new_file_format() {
 
 #[test]
 fn itemize_unchanged_file_format() {
-    // upstream: log.c:735-744 — all-dots collapse to spaces for '.', 'h', 'c' update types
+    // upstream: log.c:735-744 - all-dots collapse to spaces for '.', 'h', 'c' update types
     let change = ItemizeChange::new()
         .with_update_type(UpdateType::NotUpdated)
         .with_file_type(FileType::RegularFile);

--- a/crates/core/src/auth/mod.rs
+++ b/crates/core/src/auth/mod.rs
@@ -104,7 +104,7 @@ pub const SUPPORTED_DAEMON_DIGESTS: &[DaemonAuthDigest; 5] = &[
 
 /// Returns the authentication digests appropriate for the given protocol version.
 ///
-/// upstream: csprotocol.txt — digest negotiation rules depend on protocol era:
+/// upstream: csprotocol.txt - digest negotiation rules depend on protocol era:
 ///
 /// - **Protocol >= 31**: all digests (SHA-512, SHA-256, SHA-1, MD5, MD4).
 ///   Rsync 3.2.7 introduced the digest list in the greeting for protocol 31+.
@@ -153,7 +153,7 @@ pub fn parse_daemon_digest_list(list: Option<&str>) -> Vec<DaemonAuthDigest> {
 /// When no advertised digest matches, falls back based on `protocol_version`:
 /// MD5 for protocol >= 30, MD4 for protocol < 30.
 ///
-/// upstream: compat.c:858 — `protocol_version >= 30 ? "md5" : "md4"`
+/// upstream: compat.c:858 - `protocol_version >= 30 ? "md5" : "md4"`
 #[must_use]
 pub fn select_daemon_digest(
     advertised: &[DaemonAuthDigest],
@@ -165,14 +165,14 @@ pub fn select_daemon_digest(
         }
     }
 
-    // upstream: compat.c:858 — when no daemon_auth_choices are configured the default
+    // upstream: compat.c:858 - when no daemon_auth_choices are configured the default
     // digest depends on the negotiated protocol version.
     default_legacy_digest(protocol_version)
 }
 
 /// Returns the protocol-version-appropriate legacy digest.
 ///
-/// upstream: compat.c:858 — `protocol_version >= 30 ? "md5" : "md4"`
+/// upstream: compat.c:858 - `protocol_version >= 30 ? "md5" : "md4"`
 #[must_use]
 pub const fn default_legacy_digest(protocol_version: u8) -> DaemonAuthDigest {
     if protocol_version >= 30 {
@@ -241,7 +241,7 @@ pub fn verify_daemon_auth_response(
         .filter(|digest| {
             // When the protocol version is known and the response is ambiguous (MD4/MD5),
             // only try the protocol-appropriate digest.
-            // upstream: compat.c:858 — protocol_version >= 30 ? "md5" : "md4"
+            // upstream: compat.c:858 - protocol_version >= 30 ? "md5" : "md4"
             if let Some(version) = protocol_version {
                 if candidates.len() > 1 {
                     let expected = default_legacy_digest(version);

--- a/crates/core/src/client/config/builder/selection.rs
+++ b/crates/core/src/client/config/builder/selection.rs
@@ -57,8 +57,8 @@ impl ClientConfigBuilder {
     ///
     /// # Upstream Reference
     ///
-    /// - `options.c:2447-2490` — files_from parsing
-    /// - `options.c:2944-2956` — server_options() forwarding
+    /// - `options.c:2447-2490` - files_from parsing
+    /// - `options.c:2944-2956` - server_options() forwarding
     #[must_use]
     pub fn files_from(mut self, source: super::FilesFromSource) -> Self {
         self.files_from = source;

--- a/crates/core/src/client/config/client/selection.rs
+++ b/crates/core/src/client/config/client/selection.rs
@@ -147,7 +147,7 @@ impl ClientConfig {
     ///
     /// # Upstream Reference
     ///
-    /// - `options.c:2447-2490` — files_from parsing
+    /// - `options.c:2447-2490` - files_from parsing
     #[must_use]
     #[doc(alias = "--files-from")]
     pub fn files_from(&self) -> &FilesFromSource {

--- a/crates/core/src/client/remote/flags.rs
+++ b/crates/core/src/client/remote/flags.rs
@@ -93,7 +93,7 @@ pub(crate) fn build_server_flag_string(config: &ClientConfig) -> String {
     if effective_dirs && !effective_recursive {
         flags.push('d');
     }
-    // upstream: options.c:2622 — whole_file, but not when --append is active
+    // upstream: options.c:2622 - whole_file, but not when --append is active
     // (append requires delta transfer to append only new data)
     if config.whole_file() && !config.append() {
         flags.push('W');
@@ -116,7 +116,7 @@ pub(crate) fn build_server_flag_string(config: &ClientConfig) -> String {
     if config.preserve_crtimes() {
         flags.push('N');
     }
-    // upstream: options.c:764 — 'L' = copy_links (resolve symlinks).
+    // upstream: options.c:764 - 'L' = copy_links (resolve symlinks).
     if config.copy_links() {
         flags.push('L');
     }

--- a/crates/core/src/client/remote/invocation/builder.rs
+++ b/crates/core/src/client/remote/invocation/builder.rs
@@ -458,7 +458,7 @@ impl<'a> RemoteInvocationBuilder<'a> {
     fn build_flag_string(&self) -> String {
         let mut flags = String::from("-");
 
-        // upstream: options.c:2169-2188 — when --files-from is active, upstream
+        // upstream: options.c:2169-2188 - when --files-from is active, upstream
         // sets recurse=0, xfer_dirs=1, relative_paths=1. Suppress 'r' and imply
         // 'R' to match this behaviour.
         let files_from_active = self.config.files_from().is_active();

--- a/crates/daemon/src/daemon.rs
+++ b/crates/daemon/src/daemon.rs
@@ -108,12 +108,12 @@ const SOCKET_TIMEOUT: Duration = Duration::from_secs(10);
 const HANDSHAKE_ERROR_PAYLOAD: &str = "@ERROR: daemon functionality is unavailable in this build";
 /// Error payload sent when a host is denied access to a module.
 ///
-/// upstream: clientserver.c:733 — `@ERROR: access denied to %s from %s (%s)\n`
+/// upstream: clientserver.c:733 - `@ERROR: access denied to %s from %s (%s)\n`
 /// where args are (name, host, addr).
 const ACCESS_DENIED_PAYLOAD: &str = "@ERROR: access denied to {module} from {host} ({addr})";
 /// Error payload sent when authentication fails on a protected module.
 ///
-/// upstream: clientserver.c:762 — `@ERROR: auth failed on module %s\n`
+/// upstream: clientserver.c:762 - `@ERROR: auth failed on module %s\n`
 const AUTH_FAILED_PAYLOAD: &str = "@ERROR: auth failed on module {module}";
 /// Error payload returned when a requested module does not exist.
 const UNKNOWN_MODULE_PAYLOAD: &str = "@ERROR: Unknown module '{module}'";

--- a/crates/daemon/src/daemon/multiplex_stream.rs
+++ b/crates/daemon/src/daemon/multiplex_stream.rs
@@ -82,14 +82,14 @@ impl<R: Read> Read for MultiplexReader<R> {
                     return Ok(to_copy);
                 }
                 protocol::MessageCode::Info | protocol::MessageCode::Client => {
-                    // upstream: log.c:rwrite() — FINFO and FCLIENT go to stdout
+                    // upstream: log.c:rwrite() - FINFO and FCLIENT go to stdout
                     if let Ok(msg) = std::str::from_utf8(&self.buffer) {
                         print!("{}", msg);
                         let _ = io::stdout().flush();
                     }
                 }
                 protocol::MessageCode::Warning | protocol::MessageCode::Log => {
-                    // upstream: log.c:rwrite() — FWARNING to stderr, FLOG to daemon log
+                    // upstream: log.c:rwrite() - FWARNING to stderr, FLOG to daemon log
                     if let Ok(msg) = std::str::from_utf8(&self.buffer) {
                         eprint!("{}", msg);
                     }
@@ -98,13 +98,13 @@ impl<R: Read> Read for MultiplexReader<R> {
                 | protocol::MessageCode::ErrorXfer
                 | protocol::MessageCode::ErrorSocket
                 | protocol::MessageCode::ErrorUtf8 => {
-                    // upstream: log.c:rwrite() — FERROR* to stderr
+                    // upstream: log.c:rwrite() - FERROR* to stderr
                     if let Ok(msg) = std::str::from_utf8(&self.buffer) {
                         eprint!("{}", msg);
                     }
                 }
                 protocol::MessageCode::ErrorExit => {
-                    // upstream: io.c:1663-1701 — MSG_ERROR_EXIT carries a
+                    // upstream: io.c:1663-1701 - MSG_ERROR_EXIT carries a
                     // 4-byte exit code and triggers _exit_cleanup(val).
                     let exit_code = if self.buffer.len() == 4 {
                         i32::from_le_bytes([

--- a/crates/daemon/src/daemon/sections/config_parsing/tests.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing/tests.rs
@@ -1292,7 +1292,7 @@ mod config_parsing_tests {
         let file = write_config(&config);
         let result = parse_config_modules(file.path()).expect("parse succeeds");
 
-        // No global 'use chroot' directive — default is true
+        // No global 'use chroot' directive - default is true
         assert!(result.modules[0].use_chroot);
     }
 

--- a/crates/daemon/src/daemon/sections/greeting.rs
+++ b/crates/daemon/src/daemon/sections/greeting.rs
@@ -8,7 +8,7 @@
 /// - **Protocol < 30**: md4 only. MD5 was introduced in protocol 30; no digest
 ///   list is appended since legacy clients do not expect one.
 ///
-/// upstream: csprotocol.txt — the daemon greeting carries the digest list that
+/// upstream: csprotocol.txt - the daemon greeting carries the digest list that
 /// informs the client which challenge/response algorithms the server accepts.
 pub(crate) fn legacy_daemon_greeting_for_protocol(version: ProtocolVersion) -> String {
     let mut greeting =

--- a/crates/daemon/src/daemon/sections/module_parsing.rs
+++ b/crates/daemon/src/daemon/sections/module_parsing.rs
@@ -14,7 +14,7 @@ fn parse_daemon_option(payload: &str) -> Option<&str> {
 
 /// Options that cannot be refused via wildcard-only patterns.
 ///
-/// upstream: clientserver.c — `parse_refuse_options()` marks certain options as
+/// upstream: clientserver.c - `parse_refuse_options()` marks certain options as
 /// "vital": they can only be refused by explicit name, not via `*` or other
 /// glob wildcards. This prevents administrators from accidentally breaking the
 /// protocol handshake by refusing all options with `*`.
@@ -47,7 +47,7 @@ const VITAL_OPTIONS: &[&str] = &[
 /// Vital options (e.g., `--server`, `--sender`, `--dry-run`) cannot be refused
 /// by wildcard patterns and require explicit naming.
 ///
-/// upstream: clientserver.c — `check_refuse_options()` with fnmatch semantics.
+/// upstream: clientserver.c - `check_refuse_options()` with fnmatch semantics.
 fn refused_option<'a>(module: &ModuleDefinition, options: &'a [String]) -> Option<&'a str> {
     if module.refuse_options.is_empty() {
         return None;
@@ -72,7 +72,7 @@ fn refused_option<'a>(module: &ModuleDefinition, options: &'a [String]) -> Optio
 /// When a pattern contains glob metacharacters (`*`, `?`, `[`), vital options
 /// are exempt from matching.
 ///
-/// upstream: clientserver.c — refuse list is evaluated with fnmatch(3) semantics;
+/// upstream: clientserver.c - refuse list is evaluated with fnmatch(3) semantics;
 /// vital options are skipped during wildcard expansion.
 fn is_option_refused(refuse_list: &[String], canonical: &str) -> bool {
     let mut refused = false;
@@ -86,7 +86,7 @@ fn is_option_refused(refuse_list: &[String], canonical: &str) -> bool {
 
         let is_glob = pattern.contains('*') || pattern.contains('?') || pattern.contains('[');
 
-        // upstream: clientserver.c — vital options are immune to wildcard patterns
+        // upstream: clientserver.c - vital options are immune to wildcard patterns
         if is_glob && is_vital_option(canonical) {
             continue;
         }

--- a/crates/daemon/src/daemon/sections/session_runtime.rs
+++ b/crates/daemon/src/daemon/sections/session_runtime.rs
@@ -259,7 +259,7 @@ fn handle_legacy_session(
             Err(_) => {}
         }
 
-        // upstream: clientserver.c:1357-1368 — the daemon checks if the first
+        // upstream: clientserver.c:1357-1368 - the daemon checks if the first
         // non-@RSYNCD line is `#early_input=<len>`. If so, it reads <len> bytes
         // of raw data and then reads the next line as the module name.
         if let Some(data) = read_early_input(&line, &mut reader)? {
@@ -318,12 +318,12 @@ fn handle_legacy_session(
 
 /// Command prefix for the early-input protocol message.
 ///
-/// upstream: clientserver.c — `#define EARLY_INPUT_CMD "#early_input="`
+/// upstream: clientserver.c - `#define EARLY_INPUT_CMD "#early_input="`
 const EARLY_INPUT_CMD: &str = "#early_input=";
 
 /// Maximum early-input data size in bytes.
 ///
-/// upstream: rsync.h — `BIGPATHBUFLEN` is `MAXPATHLEN + 1024` (typically 5120).
+/// upstream: rsync.h - `BIGPATHBUFLEN` is `MAXPATHLEN + 1024` (typically 5120).
 const EARLY_INPUT_MAX_SIZE: usize = 5120;
 
 /// Checks whether `line` is an `#early_input=<len>` command and, if so, reads
@@ -333,7 +333,7 @@ const EARLY_INPUT_MAX_SIZE: usize = 5120;
 /// data was read successfully, `Ok(None)` when the line is not an early-input
 /// command, or an I/O error if reading fails or the length is invalid.
 ///
-/// upstream: clientserver.c:1357-1364 — `rsync_module()` reads early input data
+/// upstream: clientserver.c:1357-1364 - `rsync_module()` reads early input data
 /// and stores it for later delivery to the pre-xfer exec script.
 fn read_early_input(
     line: &str,

--- a/crates/daemon/src/daemon/sections/xfer_exec.rs
+++ b/crates/daemon/src/daemon/sections/xfer_exec.rs
@@ -65,7 +65,7 @@ fn build_xfer_command(command: &str, ctx: &XferExecContext<'_>) -> ProcessComman
 /// upstream-compatible environment variables. If the command exits non-zero,
 /// returns an error indicating the connection should be denied.
 ///
-/// Upstream: `clientserver.c` — `early_exec()` runs early in the connection,
+/// Upstream: `clientserver.c` - `early_exec()` runs early in the connection,
 /// before authentication and argument exchange.
 fn run_early_exec(
     command: &str,
@@ -112,7 +112,7 @@ fn run_early_exec(
 /// where `write_buf(write_fd, early_input, early_input_len)` pipes client-sent
 /// early-input data to the pre-xfer exec script.
 ///
-/// Upstream: `clientserver.c` — `pre_exec()` / `write_pre_exec_args()` runs
+/// Upstream: `clientserver.c` - `pre_exec()` / `write_pre_exec_args()` runs
 /// the command and pipes early-input data to its stdin.
 fn run_pre_xfer_exec(
     command: &str,
@@ -132,7 +132,7 @@ fn run_pre_xfer_exec(
     let mut child = cmd.spawn()?;
 
     // Pipe early-input data to the child's stdin, then close it.
-    // upstream: clientserver.c:583-584 — write_buf(write_fd, early_input, early_input_len)
+    // upstream: clientserver.c:583-584 - write_buf(write_fd, early_input, early_input_len)
     if let Some(data) = early_input {
         if let Some(mut stdin) = child.stdin.take() {
             // Best-effort write; ignore broken pipe if the child exits early.
@@ -172,7 +172,7 @@ fn run_pre_xfer_exec(
 /// set to the transfer's exit code. Failures are logged but do not change the
 /// transfer exit status.
 ///
-/// Upstream: `clientserver.c` — `post_exec()` runs the command after the
+/// Upstream: `clientserver.c` - `post_exec()` runs the command after the
 /// transfer completes, regardless of success or failure.
 fn run_post_xfer_exec(
     command: &str,

--- a/crates/daemon/src/tests/chunks/daemon_negotiation_authentication.rs
+++ b/crates/daemon/src/tests/chunks/daemon_negotiation_authentication.rs
@@ -175,7 +175,7 @@ fn daemon_negotiation_auth_denies_wrong_password() {
         .expect("send wrong credentials");
     stream.flush().expect("flush");
 
-    // upstream: clientserver.c:762 — auth failure sends
+    // upstream: clientserver.c:762 - auth failure sends
     // "@ERROR: auth failed on module %s\n"
     line.clear();
     reader.read_line(&mut line).expect("response");
@@ -270,7 +270,7 @@ fn daemon_negotiation_auth_denies_unknown_user() {
         .expect("send unknown user");
     stream.flush().expect("flush");
 
-    // upstream: clientserver.c:762 — auth failure sends
+    // upstream: clientserver.c:762 - auth failure sends
     // "@ERROR: auth failed on module %s\n"
     line.clear();
     reader.read_line(&mut line).expect("response");
@@ -417,7 +417,7 @@ fn daemon_negotiation_auth_denies_empty_credentials() {
         .expect("send empty credentials");
     stream.flush().expect("flush");
 
-    // upstream: clientserver.c:762 — auth failure sends
+    // upstream: clientserver.c:762 - auth failure sends
     // "@ERROR: auth failed on module %s\n"
     line.clear();
     reader.read_line(&mut line).expect("response");

--- a/crates/daemon/src/tests/chunks/daemon_negotiation_error_handling.rs
+++ b/crates/daemon/src/tests/chunks/daemon_negotiation_error_handling.rs
@@ -241,7 +241,7 @@ fn daemon_negotiation_error_refused_options() {
             );
         }
         Err(e) if e.kind() == std::io::ErrorKind::ConnectionReset => {
-            // Daemon closed the connection — acceptable outcome for refused options.
+            // Daemon closed the connection - acceptable outcome for refused options.
         }
         Err(e) => panic!("unexpected I/O error: {e}"),
     }

--- a/crates/daemon/src/tests/chunks/daemon_negotiation_module_listing.rs
+++ b/crates/daemon/src/tests/chunks/daemon_negotiation_module_listing.rs
@@ -44,8 +44,8 @@ fn daemon_negotiation_module_list_sends_capabilities_before_ok() {
         "Expected CAP response, got: {line}"
     );
 
-    // upstream: no @RSYNCD: OK before module listing — go straight to modules.
-    // Read module listing — upstream: clientserver.c:1254 uses %-15s\t%s\n format
+    // upstream: no @RSYNCD: OK before module listing - go straight to modules.
+    // Read module listing - upstream: clientserver.c:1254 uses %-15s\t%s\n format
     line.clear();
     reader.read_line(&mut line).expect("module listing");
     assert_eq!(line, "test           \t\n", "Expected %-15s aligned module, got: {line}");
@@ -176,7 +176,7 @@ fn daemon_negotiation_module_list_includes_comments() {
     line.clear();
     reader.read_line(&mut line).expect("module");
 
-    // upstream: clientserver.c:1254 — %-15s\t%s\n format
+    // upstream: clientserver.c:1254 - %-15s\t%s\n format
     assert_eq!(
         line, "mymod          \tThis is a comment\n",
         "Module listing should use %-15s alignment, got: {line}"

--- a/crates/daemon/src/tests/chunks/legacy_daemon_greeting_digest_list_varies_by_protocol.rs
+++ b/crates/daemon/src/tests/chunks/legacy_daemon_greeting_digest_list_varies_by_protocol.rs
@@ -1,6 +1,6 @@
 /// Protocol 32 greeting includes all five supported digest algorithms.
 ///
-/// upstream: csprotocol.txt — protocol 32 requires the digest list and all
+/// upstream: csprotocol.txt - protocol 32 requires the digest list and all
 /// algorithms introduced through protocol 31 (SHA-512, SHA-256, SHA-1) are
 /// present alongside MD5 and MD4.
 #[test]
@@ -46,10 +46,10 @@ fn legacy_daemon_greeting_protocol_31_includes_all_digests() {
     );
 }
 
-/// Protocol 30 greeting includes only MD5 and MD4 — SHA-family digests were
+/// Protocol 30 greeting includes only MD5 and MD4 - SHA-family digests were
 /// not available before protocol 31.
 ///
-/// upstream: csprotocol.txt — protocol 30-31 default to "md5" when the digest
+/// upstream: csprotocol.txt - protocol 30-31 default to "md5" when the digest
 /// list is absent.
 #[test]
 fn legacy_daemon_greeting_protocol_30_includes_md5_and_md4_only() {

--- a/crates/daemon/src/tests/chunks/run_daemon_auth_failure_rejects_wrong_credentials.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_auth_failure_rejects_wrong_credentials.rs
@@ -75,7 +75,7 @@ fn run_daemon_auth_failure_rejects_wrong_credentials() {
     assert!(!challenge.is_empty());
 
     // Send wrong credentials - compute MD5 digest with wrong password.
-    // upstream: authenticate() in authenticate.c — client sends
+    // upstream: authenticate() in authenticate.c - client sends
     // "username base64(MD5(password + challenge))\n"
     let wrong_password = "wrongpassword";
     let mut digest_input = Vec::new();
@@ -91,7 +91,7 @@ fn run_daemon_auth_failure_rejects_wrong_credentials() {
         .expect("send wrong credentials");
     stream.flush().expect("flush wrong credentials");
 
-    // upstream: clientserver.c:762 — auth failure sends
+    // upstream: clientserver.c:762 - auth failure sends
     // "@ERROR: auth failed on module %s\n"
     line.clear();
     reader.read_line(&mut line).expect("denied message");

--- a/crates/daemon/src/tests/chunks/run_daemon_config_flag_overrides_default_path.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_config_flag_overrides_default_path.rs
@@ -6,7 +6,7 @@
 /// connection. Both the separated (`--config FILE`) and inline (`--config=FILE`)
 /// forms are validated.
 ///
-/// upstream: main.c — `--config=FILE` overrides the compiled-in default path.
+/// upstream: main.c - `--config=FILE` overrides the compiled-in default path.
 #[test]
 fn run_daemon_config_flag_overrides_default_path() {
     let _lock = ENV_LOCK.lock().expect("env lock");

--- a/crates/daemon/src/tests/chunks/run_daemon_denies_module_when_host_not_allowed.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_denies_module_when_host_not_allowed.rs
@@ -36,7 +36,7 @@ fn run_daemon_denies_module_when_host_not_allowed() {
     stream.write_all(b"docs\n").expect("send module request");
     stream.flush().expect("flush module request");
 
-    // upstream: clientserver.c:733 — access denied sends
+    // upstream: clientserver.c:733 - access denied sends
     // "@ERROR: access denied to %s from %s (%s)\n" with (name, host, addr)
     // The host may be resolved to "localhost" or remain as "127.0.0.1"
     // depending on the system's DNS configuration.

--- a/crates/daemon/src/tests/chunks/run_daemon_enforces_module_connection_limit.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_enforces_module_connection_limit.rs
@@ -107,7 +107,7 @@ fn run_daemon_enforces_module_connection_limit() {
     first_reader
         .read_line(&mut line)
         .expect("first denial message");
-    // upstream: clientserver.c:762 — auth failure uses
+    // upstream: clientserver.c:762 - auth failure uses
     // "@ERROR: auth failed on module %s\n"
     assert!(line.starts_with("@ERROR: auth failed on module"));
 

--- a/crates/daemon/src/tests/chunks/run_daemon_panic_isolation_keeps_daemon_alive.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_panic_isolation_keeps_daemon_alive.rs
@@ -61,7 +61,7 @@ fn run_daemon_panic_isolation_keeps_daemon_alive() {
             }
             discard.clear();
         }
-    } // bad stream dropped here — worker thread has already finished
+    } // bad stream dropped here - worker thread has already finished
 
     // If catch_unwind isolation had failed the daemon would have exited and
     // connect_with_retries would time out.

--- a/crates/daemon/src/tests/chunks/run_daemon_rejects_push_to_read_only_module.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_rejects_push_to_read_only_module.rs
@@ -58,14 +58,14 @@ fn run_daemon_rejects_push_to_read_only_module() {
 
     // Send client arguments that indicate a push (no --sender flag means
     // the server must act as receiver, which conflicts with read-only).
-    // upstream: options.c:server_options() — server args are null-terminated
+    // upstream: options.c:server_options() - server args are null-terminated
     // for protocol >= 30.
     stream
         .write_all(b"--server\0-logDtpr\0.\0readonly/\0\0")
         .expect("send client args");
     stream.flush().expect("flush client args");
 
-    // upstream: clientserver.c — daemon rejects with
+    // upstream: clientserver.c - daemon rejects with
     // "@ERROR: module is read only"
     line.clear();
     reader.read_line(&mut line).expect("error message");

--- a/crates/daemon/src/tests/chunks/run_daemon_requests_authentication_for_protected_module.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_requests_authentication_for_protected_module.rs
@@ -71,7 +71,7 @@ fn run_daemon_requests_authentication_for_protected_module() {
     stream.write_all(b"\n").expect("send empty credentials");
     stream.flush().expect("flush empty credentials");
 
-    // upstream: clientserver.c:762 — auth failure sends
+    // upstream: clientserver.c:762 - auth failure sends
     // "@ERROR: auth failed on module %s\n"
     line.clear();
     reader.read_line(&mut line).expect("denied message");

--- a/crates/engine/src/local_copy/executor/cleanup.rs
+++ b/crates/engine/src/local_copy/executor/cleanup.rs
@@ -140,7 +140,7 @@ pub(crate) fn delete_extraneous_entries<S: AsRef<OsStr>>(
 
         context.backup_existing_entry(&path, Some(entry_relative.as_path()), file_type)?;
         if file_type.is_dir() {
-            // upstream: generator.c:delete_in_dir() — recursively delete
+            // upstream: generator.c:delete_in_dir() - recursively delete
             // directory contents first, counting each item individually,
             // then remove the now-empty directory.
             delete_directory_tree_recursive(

--- a/crates/engine/src/local_copy/executor/directory/planner.rs
+++ b/crates/engine/src/local_copy/executor/directory/planner.rs
@@ -90,7 +90,7 @@ fn decide_entry_action(
     keep_name: &mut bool,
 ) -> Result<EntryAction, LocalCopyError> {
     if !context.allows(relative_path, effective_type.is_dir()) {
-        // upstream: flist.c:flist_sort_and_clean() — when -m is active,
+        // upstream: flist.c:flist_sort_and_clean() - when -m is active,
         // directories excluded by non-dir-specific rules are still traversed
         // so that file-level include rules can rescue their contents.
         if effective_type.is_dir()
@@ -183,7 +183,7 @@ pub(crate) fn plan_directory_entries<'a>(
         let entry_metadata = &entry.metadata;
         let entry_type = entry_metadata.file_type();
 
-        // upstream: flist.c:make_file() — skip entries with bogus zero st_mode
+        // upstream: flist.c:make_file() - skip entries with bogus zero st_mode
         #[cfg(unix)]
         {
             use std::os::unix::fs::MetadataExt;
@@ -416,7 +416,7 @@ fn plan_directory_entries_with_prefetch<'a>(
         let entry_metadata = &entry.metadata;
         let entry_type = entry_metadata.file_type();
 
-        // upstream: flist.c:make_file() — skip entries with bogus zero st_mode
+        // upstream: flist.c:make_file() - skip entries with bogus zero st_mode
         #[cfg(unix)]
         {
             use std::os::unix::fs::MetadataExt;

--- a/crates/engine/src/local_copy/executor/file/comparison.rs
+++ b/crates/engine/src/local_copy/executor/file/comparison.rs
@@ -36,7 +36,7 @@ pub(crate) fn destination_is_newer(
             // difference is strictly less than the modify window.
             // upstream: (source - dest) < modify_window
             Ok(diff) => diff < modify_window,
-            // Source is older than destination — always skip.
+            // Source is older than destination - always skip.
             Err(_) => true,
         },
         _ => false,

--- a/crates/engine/src/local_copy/executor/file/copy/mod.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/mod.rs
@@ -68,7 +68,7 @@ pub(crate) fn copy_file(
     context.summary_mut().record_regular_file_total();
     context.summary_mut().record_total_bytes(file_size);
 
-    // upstream: generator.c:recv_generator() — skip files outside size range
+    // upstream: generator.c:recv_generator() - skip files outside size range
     if let Some(min_limit) = context.min_file_size_limit()
         && file_size < min_limit
     {

--- a/crates/engine/src/local_copy/executor/special/device.rs
+++ b/crates/engine/src/local_copy/executor/special/device.rs
@@ -218,7 +218,7 @@ pub(crate) fn copy_device(
     #[cfg(not(unix))]
     {
         // Windows / non-Unix: we can’t actually create a device node.
-        // Do nothing here — the rest (metadata + bookkeeping) still runs so the code compiles.
+        // Do nothing here - the rest (metadata + bookkeeping) still runs so the code compiles.
     }
 
     context.register_created_path(

--- a/crates/engine/src/local_copy/executor/special/symlink.rs
+++ b/crates/engine/src/local_copy/executor/special/symlink.rs
@@ -135,7 +135,7 @@ pub(crate) fn copy_symlink(
     let raw_target = fs::read_link(source)
         .map_err(|error| LocalCopyError::io("read symbolic link", source, error))?;
 
-    // upstream: clientserver.c — on the sender side, unmunge already-munged
+    // upstream: clientserver.c - on the sender side, unmunge already-munged
     // targets so safety checks and comparisons work on the real path.
     let target = if munge_links {
         let raw_str = raw_target.to_string_lossy();
@@ -389,7 +389,7 @@ pub(crate) fn copy_symlink(
         return Ok(());
     }
 
-    // upstream: clientserver.c — on the receiver side, munge the target so
+    // upstream: clientserver.c - on the receiver side, munge the target so
     // it cannot resolve outside the module root.
     let write_target = if munge_links {
         PathBuf::from(::metadata::munge_symlink(&target.to_string_lossy()))

--- a/crates/engine/src/local_copy/options/staging.rs
+++ b/crates/engine/src/local_copy/options/staging.rs
@@ -11,7 +11,7 @@ use crate::local_copy::executor::SparseDetectStrategy;
 /// Subdirectory name used by upstream rsync for staging files when
 /// `--delay-updates` is active and no explicit `--partial-dir` is given.
 ///
-/// upstream: options.c — `static char tmp_partialdir[] = ".~tmp~";`
+/// upstream: options.c - `static char tmp_partialdir[] = ".~tmp~";`
 pub const DELAY_UPDATES_PARTIAL_DIR: &str = ".~tmp~";
 
 impl LocalCopyOptions {
@@ -69,7 +69,7 @@ impl LocalCopyOptions {
     /// staging directory is automatically set to `.~tmp~` to match upstream
     /// rsync behaviour.
     ///
-    /// upstream: options.c — `if (delay_updates && !partial_dir) partial_dir = tmp_partialdir;`
+    /// upstream: options.c - `if (delay_updates && !partial_dir) partial_dir = tmp_partialdir;`
     #[must_use]
     #[doc(alias = "--delay-updates")]
     pub fn delay_updates(mut self, delay: bool) -> Self {

--- a/crates/engine/src/local_copy/tests/execute_ignore_times.rs
+++ b/crates/engine/src/local_copy/tests/execute_ignore_times.rs
@@ -299,7 +299,7 @@ fn ignore_times_with_size_only_skips_same_size() {
         )
         .expect("copy succeeds");
 
-    // size_only wins over ignore_times — file is NOT transferred
+    // size_only wins over ignore_times - file is NOT transferred
     assert_eq!(summary.files_copied(), 0);
     assert_eq!(summary.regular_files_total(), 1);
     assert_eq!(
@@ -341,7 +341,7 @@ fn size_only_wins_over_ignore_times_with_same_content() {
         )
         .expect("copy with ignore_times");
 
-    // size_only wins over ignore_times — file is NOT transferred
+    // size_only wins over ignore_times - file is NOT transferred
     assert_eq!(summary_with.files_copied(), 0);
     assert_eq!(fs::read(&destination).expect("read dest"), content);
 }

--- a/crates/engine/src/local_copy/tests/execute_modify_window.rs
+++ b/crates/engine/src/local_copy/tests/execute_modify_window.rs
@@ -445,7 +445,7 @@ fn modify_window_with_update_skips_when_dest_newer_within_window_despite_size_di
     let source = temp.path().join("source.txt");
     let destination = temp.path().join("dest.txt");
 
-    // Different sizes — but --update should still skip because dest is newer
+    // Different sizes - but --update should still skip because dest is newer
     fs::write(&source, b"source data").expect("write source");
     fs::write(&destination, b"dest").expect("write dest");
 
@@ -562,7 +562,7 @@ fn modify_window_with_update_skips_when_source_slightly_newer_within_window() {
 }
 
 /// When source is newer than dest by exactly the window, `--update` does
-/// NOT skip — the source is definitively newer.
+/// NOT skip - the source is definitively newer.
 /// upstream: `source - dest = 2`, NOT `< 2` -> proceed with copy
 #[test]
 fn modify_window_with_update_copies_when_source_at_exact_window_boundary() {

--- a/crates/engine/src/local_copy/tests/execute_sparse.rs
+++ b/crates/engine/src/local_copy/tests/execute_sparse.rs
@@ -136,7 +136,7 @@ fn execute_inplace_disables_sparse_writes() {
     let dense_blocks = dense_meta.blocks();
     let sparse_blocks = sparse_meta.blocks();
     // Allow a small tolerance for filesystem allocation differences (delayed
-    // allocation, alignment, etc.) — the key property is that inplace mode
+    // allocation, alignment, etc.) - the key property is that inplace mode
     // does not create large sparse holes.
     let tolerance = (dense_blocks / 10).max(8);
     assert!(

--- a/crates/fast_io/src/sendfile.rs
+++ b/crates/fast_io/src/sendfile.rs
@@ -153,13 +153,13 @@ pub fn send_file_to_fd(source: &File, dest_fd: i32, length: u64) -> io::Result<u
     copy_via_fd_write(source, dest_fd, length)
 }
 
-/// Stub for non-Linux unix platforms — uses libc::write fallback.
+/// Stub for non-Linux unix platforms - uses libc::write fallback.
 #[cfg(all(unix, not(target_os = "linux")))]
 pub fn send_file_to_fd(source: &File, dest_fd: i32, length: u64) -> io::Result<u64> {
     copy_via_fd_write(source, dest_fd, length)
 }
 
-/// Stub for non-unix platforms — raw fd is not meaningful.
+/// Stub for non-unix platforms - raw fd is not meaningful.
 #[cfg(not(unix))]
 pub fn send_file_to_fd(source: &File, _dest_fd: i32, length: u64) -> io::Result<u64> {
     send_file_to_writer(source, &mut io::sink(), length)
@@ -334,7 +334,7 @@ fn copy_via_fd_write(source: &File, dest_fd: i32, length: u64) -> io::Result<u64
     Ok(total)
 }
 
-/// Stub for non-Linux unix platforms — uses libc::write.
+/// Stub for non-Linux unix platforms - uses libc::write.
 #[cfg(all(unix, not(target_os = "linux")))]
 fn copy_via_fd_write(source: &File, dest_fd: i32, length: u64) -> io::Result<u64> {
     let mut reader = io::BufReader::new(source);

--- a/crates/fast_io/src/syscall_batch.rs
+++ b/crates/fast_io/src/syscall_batch.rs
@@ -17,7 +17,7 @@
 //!
 //! - **Linux**: Uses `statx()` for improved metadata operations in batched path
 //! - **Other Unix**: Batched path uses standard library calls with grouping optimization
-//! - **Non-Unix (Windows)**: Portable fallbacks — `filetime` crate for timestamps,
+//! - **Non-Unix (Windows)**: Portable fallbacks - `filetime` crate for timestamps,
 //!   readonly attribute mapping for permissions
 //!
 //! # Performance Characteristics

--- a/crates/flist/src/parallel.rs
+++ b/crates/flist/src/parallel.rs
@@ -49,7 +49,7 @@ pub fn collect_entries(walker: FileListWalker) -> Result<Vec<FileListEntry>, Fil
 /// Collects all file list entries sequentially from the walker.
 #[deprecated(
     since = "0.6.0",
-    note = "renamed to `collect_entries` — this function is sequential"
+    note = "renamed to `collect_entries` - this function is sequential"
 )]
 pub fn collect_parallel(walker: FileListWalker) -> Result<Vec<FileListEntry>, FileListError> {
     collect_entries(walker)
@@ -628,7 +628,7 @@ mod tests {
     fn collect_paths_chunked_large_chunk() {
         let temp = create_test_tree();
 
-        // Chunk larger than total paths — single batch
+        // Chunk larger than total paths - single batch
         let result = collect_paths_chunked_parallel(temp.path().to_path_buf(), false, 1000);
         let entries = result.unwrap();
 

--- a/crates/flist/tests/special_characters.rs
+++ b/crates/flist/tests/special_characters.rs
@@ -1713,7 +1713,7 @@ fn each_ascii_printable_separately() {
         }
     }
 
-    // Count actual files on disk — on case-insensitive filesystems (default
+    // Count actual files on disk - on case-insensitive filesystems (default
     // macOS APFS) A.txt and a.txt are the same file, so the count is lower.
     let actual_files: usize = fs::read_dir(&root).unwrap().count();
 

--- a/crates/metadata/src/acl_exacl.rs
+++ b/crates/metadata/src/acl_exacl.rs
@@ -320,7 +320,7 @@ pub fn get_rsync_acl(path: &Path, mode: u32, is_default: bool) -> RsyncAcl {
 /// # Upstream Reference
 ///
 /// Matches upstream rsync's behavior when the source has no extended
-/// ACL entries — the destination retains only base owner/group/other entries.
+/// ACL entries - the destination retains only base owner/group/other entries.
 fn reset_acl_from_mode(path: &Path) -> Result<(), MetadataError> {
     #[cfg(any(target_os = "linux", target_os = "freebsd"))]
     {

--- a/crates/metadata/src/copy_as.rs
+++ b/crates/metadata/src/copy_as.rs
@@ -17,9 +17,9 @@
 //!
 //! # Upstream Reference
 //!
-//! - `rsync.c:do_as_root()` — switches euid/egid before privileged operations
-//! - `rsync.c:undo_as_root()` — restores original euid/egid
-//! - `main.c` — `--copy-as` parsing and initial identity resolution
+//! - `rsync.c:do_as_root()` - switches euid/egid before privileged operations
+//! - `rsync.c:undo_as_root()` - restores original euid/egid
+//! - `main.c` - `--copy-as` parsing and initial identity resolution
 
 use std::ffi::OsStr;
 use std::io;
@@ -179,7 +179,7 @@ impl Drop for CopyAsGuard {
 ///
 /// # Upstream Reference
 ///
-/// - `rsync.c:do_as_root()` — same ordering: egid first, then euid
+/// - `rsync.c:do_as_root()` - same ordering: egid first, then euid
 #[cfg(unix)]
 #[allow(unsafe_code)]
 pub fn switch_effective_ids(ids: &CopyAsIds) -> io::Result<CopyAsGuard> {

--- a/crates/metadata/src/nfsv4_acl_stub.rs
+++ b/crates/metadata/src/nfsv4_acl_stub.rs
@@ -32,11 +32,11 @@ pub enum AceType {
     Deny = 1,
 }
 
-/// NFSv4 ACE flags (stub — bitflags not needed for no-op).
+/// NFSv4 ACE flags (stub - bitflags not needed for no-op).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct AceFlags(pub u32);
 
-/// NFSv4 access mask (stub — bitflags not needed for no-op).
+/// NFSv4 access mask (stub - bitflags not needed for no-op).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct AccessMask(pub u32);
 

--- a/crates/protocol/src/envelope/message_code.rs
+++ b/crates/protocol/src/envelope/message_code.rs
@@ -200,7 +200,7 @@ impl MessageCode {
     /// `ErrorSocket`, `ErrorUtf8`, and `ErrorExit`. Useful for counting remote
     /// errors received through the multiplex channel.
     ///
-    /// upstream: io.c — `FERROR*` codes map to these message types.
+    /// upstream: io.c - `FERROR*` codes map to these message types.
     #[inline]
     #[must_use]
     pub const fn is_error(self) -> bool {

--- a/crates/protocol/src/files_from.rs
+++ b/crates/protocol/src/files_from.rs
@@ -26,12 +26,12 @@
 //!
 //! # Upstream Reference
 //!
-//! - `io.c:forward_filesfrom_data()` — reads from local fd and writes to socket
-//! - `io.c:start_filesfrom_forwarding()` — initializes forwarding state
-//! - `io.c:read_line()` (RL_CONVERT branch) — reader-side iconv
-//! - `compat.c:799-806` — `filesfrom_convert` gating (`protect_args && files_from`)
-//! - `flist.c:send_file_list()` — sender reads filenames from `filesfrom_fd`
-//! - `options.c:server_options()` — sends `--files-from` args to server
+//! - `io.c:forward_filesfrom_data()` - reads from local fd and writes to socket
+//! - `io.c:start_filesfrom_forwarding()` - initializes forwarding state
+//! - `io.c:read_line()` (RL_CONVERT branch) - reader-side iconv
+//! - `compat.c:799-806` - `filesfrom_convert` gating (`protect_args && files_from`)
+//! - `flist.c:send_file_list()` - sender reads filenames from `filesfrom_fd`
+//! - `options.c:server_options()` - sends `--files-from` args to server
 
 use std::borrow::Cow;
 use std::io::{self, Read, Write};
@@ -49,13 +49,13 @@ use crate::iconv::FilenameConverter;
 /// When `iconv` is `Some`, each NUL-separated entry is transcoded with
 /// [`FilenameConverter::local_to_remote`] before being written to the wire,
 /// mirroring upstream `forward_filesfrom_data`'s `iconvbufs(ic_send, ...)`
-/// call. When `iconv` is `None`, bytes are forwarded verbatim — equivalent
+/// call. When `iconv` is `None`, bytes are forwarded verbatim - equivalent
 /// to upstream's `ic_send == (iconv_t)-1` case.
 ///
 /// # Upstream Reference
 ///
-/// - `io.c:forward_filesfrom_data()` — the core forwarding loop
-/// - `compat.c:799-806` — `filesfrom_convert` gating predicate
+/// - `io.c:forward_filesfrom_data()` - the core forwarding loop
+/// - `compat.c:799-806` - `filesfrom_convert` gating predicate
 pub fn forward_files_from<R: Read, W: Write>(
     reader: &mut R,
     writer: &mut W,
@@ -76,7 +76,7 @@ pub fn forward_files_from<R: Read, W: Write>(
 
         let chunk = &mut buf[..n];
 
-        // upstream: io.c:397-403 — transform CR and/or LF into '\0'.
+        // upstream: io.c:397-403 - transform CR and/or LF into '\0'.
         if !eol_nulls {
             for byte in chunk.iter_mut() {
                 if *byte == b'\n' || *byte == b'\r' {
@@ -92,7 +92,7 @@ pub fn forward_files_from<R: Read, W: Write>(
                     current_entry.clear();
                     last_emitted_nul = true;
                 }
-                // upstream: io.c:456-482 — collapse runs of consecutive '\0'.
+                // upstream: io.c:456-482 - collapse runs of consecutive '\0'.
             } else {
                 current_entry.push(byte);
             }
@@ -106,7 +106,7 @@ pub fn forward_files_from<R: Read, W: Write>(
         last_emitted_nul = true;
     }
 
-    // upstream: io.c:379 — write_buf(iobuf.out_fd, "\0\0", ff_lastchar ? 2 : 1).
+    // upstream: io.c:379 - write_buf(iobuf.out_fd, "\0\0", ff_lastchar ? 2 : 1).
     if last_emitted_nul {
         writer.write_all(b"\0")?;
     } else {
@@ -147,7 +147,7 @@ fn write_filesfrom_entry<W: Write>(
 /// [`FilenameConverter::remote_to_local`] before being decoded into a
 /// `String`, mirroring upstream `read_line(RL_CONVERT)`'s
 /// `iconvbufs(ic_recv, ...)` call. When `iconv` is `None`, wire bytes are
-/// decoded verbatim — equivalent to upstream's `ic_recv == (iconv_t)-1`
+/// decoded verbatim - equivalent to upstream's `ic_recv == (iconv_t)-1`
 /// case.
 ///
 /// This is used by the sender process to receive the file list from the
@@ -155,10 +155,10 @@ fn write_filesfrom_entry<W: Write>(
 ///
 /// # Upstream Reference
 ///
-/// - `flist.c:2262` — `read_line(filesfrom_fd, fbuf, sizeof fbuf, rl_flags)`
+/// - `flist.c:2262` - `read_line(filesfrom_fd, fbuf, sizeof fbuf, rl_flags)`
 ///   with `RL_EOL_NULLS` set when `reading_remotely`
-/// - `io.c:read_line()` (RL_CONVERT branch) — `iconvbufs(ic_recv, ...)`
-/// - `compat.c:799-806` — `filesfrom_convert` gating predicate
+/// - `io.c:read_line()` (RL_CONVERT branch) - `iconvbufs(ic_recv, ...)`
+/// - `compat.c:799-806` - `filesfrom_convert` gating predicate
 pub fn read_files_from_stream<R: Read>(
     reader: &mut R,
     iconv: Option<&FilenameConverter>,
@@ -170,7 +170,7 @@ pub fn read_files_from_stream<R: Read>(
     loop {
         let n = reader.read(&mut byte_buf)?;
         if n == 0 {
-            // Unexpected EOF — flush any pending entry then return.
+            // Unexpected EOF - flush any pending entry then return.
             if !current.is_empty() {
                 push_decoded_filename(&mut filenames, &current, iconv);
                 current.clear();
@@ -204,7 +204,7 @@ fn push_decoded_filename(out: &mut Vec<String>, raw: &[u8], iconv: Option<&Filen
     let bytes: Cow<'_, [u8]> = match iconv {
         Some(converter) => match converter.remote_to_local(raw) {
             Ok(cow) => cow,
-            // upstream: ICB_INCLUDE_BAD — keep the bad bytes rather than abort.
+            // upstream: ICB_INCLUDE_BAD - keep the bad bytes rather than abort.
             Err(_) => Cow::Borrowed(raw),
         },
         None => Cow::Borrowed(raw),

--- a/crates/protocol/src/flist/dir_tree.rs
+++ b/crates/protocol/src/flist/dir_tree.rs
@@ -6,8 +6,8 @@
 //!
 //! # Upstream Reference
 //!
-//! - `flist.c:add_dirs_to_tree()` — builds tree from directory entries
-//! - `flist.c:send_extra_file_list()` — traverses tree depth-first via
+//! - `flist.c:add_dirs_to_tree()` - builds tree from directory entries
+//! - `flist.c:send_extra_file_list()` - traverses tree depth-first via
 //!   `DIR_FIRST_CHILD`, `DIR_NEXT_SIBLING`, `DIR_PARENT` macros
 
 /// A node in the directory tree representing a directory whose contents
@@ -51,7 +51,7 @@ impl DirectoryTree {
     /// Creates a new empty directory tree with a virtual root node.
     #[must_use]
     pub fn new() -> Self {
-        // Virtual root node — never yielded, serves as parent for top-level dirs
+        // Virtual root node - never yielded, serves as parent for top-level dirs
         let root = DirNode {
             dir_ndx: usize::MAX,
             path: String::new(),
@@ -133,7 +133,7 @@ impl DirectoryTree {
             self.cursor = Some(child);
             self.depth += 1;
         } else {
-            // No children — go to next sibling, or backtrack to parent's sibling
+            // No children - go to next sibling, or backtrack to parent's sibling
             let mut current = cursor;
             loop {
                 if let Some(sibling) = self.nodes[current].next_sibling {

--- a/crates/protocol/src/flist/intern.rs
+++ b/crates/protocol/src/flist/intern.rs
@@ -13,7 +13,7 @@
 //!
 //! # Thread Safety
 //!
-//! `PathInterner` is not `Sync` — it is designed for single-threaded use during
+//! `PathInterner` is not `Sync` - it is designed for single-threaded use during
 //! sequential file list decoding. The interned `Arc<Path>` values are `Send + Sync`
 //! and can be freely shared across threads after interning.
 

--- a/crates/protocol/src/flist/segment.rs
+++ b/crates/protocol/src/flist/segment.rs
@@ -5,9 +5,9 @@
 //!
 //! # Upstream Reference
 //!
-//! - `flist.c:flist_new()` — allocates sub-lists with `ndx_start` offsets
-//! - `flist.c:send_extra_file_list()` — sends one segment per directory
-//! - `rsync.h:285-288` — NDX_FLIST_OFFSET constant
+//! - `flist.c:flist_new()` - allocates sub-lists with `ndx_start` offsets
+//! - `flist.c:send_extra_file_list()` - sends one segment per directory
+//! - `rsync.h:285-288` - NDX_FLIST_OFFSET constant
 
 #![allow(dead_code)]
 
@@ -120,7 +120,7 @@ impl SegmentedFileList {
     /// Computes the `ndx_start` for the next segment.
     ///
     /// Upstream: `cur_flist->ndx_start + cur_flist->used` (flist.c recv_file_list).
-    /// No gap between segments — each starts immediately after the previous.
+    /// No gap between segments - each starts immediately after the previous.
     #[must_use]
     pub fn next_ndx_start(&self) -> i32 {
         if let Some(last) = self.segments.last() {
@@ -205,7 +205,7 @@ mod tests {
         assert_eq!(sfl.total_entries(), 3);
         assert_eq!(sfl.segment_count(), 2);
 
-        // Lookup by NDX — contiguous ranges, no gaps
+        // Lookup by NDX - contiguous ranges, no gaps
         assert_eq!(sfl.get_by_ndx(0).unwrap().name(), "file1.txt");
         assert_eq!(sfl.get_by_ndx(1).unwrap().name(), "file2.txt");
         assert_eq!(sfl.get_by_ndx(2).unwrap().name(), "subdir/a.txt");

--- a/crates/protocol/src/flist/state.rs
+++ b/crates/protocol/src/flist/state.rs
@@ -10,7 +10,7 @@
 //! - `flist.c`: `static char lastname[MAXPATHLEN]` and `static int*` state variables
 //!   used across `send_file_entry()` / `recv_file_entry()` calls
 
-/// upstream: rsync.h `MAXPATHLEN` — maximum path length for file list name compression.
+/// upstream: rsync.h `MAXPATHLEN` - maximum path length for file list name compression.
 const MAXPATHLEN: usize = 4096;
 
 /// Compression state for sequential file list processing.

--- a/crates/protocol/src/negotiation/capabilities/negotiate.rs
+++ b/crates/protocol/src/negotiation/capabilities/negotiate.rs
@@ -202,7 +202,7 @@ pub fn negotiate_capabilities_with_override(
     // When FALSE, upstream uses pre-filled defaults without any wire protocol exchange.
     if !do_negotiation {
         // Use protocol 30+ defaults without sending or reading anything.
-        // upstream: compat.c:194 — when -z is active but no vstring negotiation,
+        // upstream: compat.c:194 - when -z is active but no vstring negotiation,
         // parse_compress_choice() defaults to CPRES_ZLIB.
         let checksum = checksum_override.unwrap_or(ChecksumAlgorithm::MD5);
         // upstream: compat.c:194 - when no vstring negotiation and no explicit
@@ -358,7 +358,7 @@ pub(super) fn choose_checksum_algorithm(
     } else {
         // Client: iterate our local list, first item also in server's (remote)
         // list wins. This gives client preference order priority.
-        // upstream: compat.c:349-354 — client continues iterating to find the
+        // upstream: compat.c:349-354 - client continues iterating to find the
         // local item with the best (lowest) position in our own list.
         for &local in SUPPORTED_CHECKSUMS {
             if remote_items.contains(&local) {
@@ -368,7 +368,7 @@ pub(super) fn choose_checksum_algorithm(
         }
     }
 
-    // upstream: compat.c:383-406 — failure to negotiate is a hard error
+    // upstream: compat.c:383-406 - failure to negotiate is a hard error
     Err(io::Error::new(
         io::ErrorKind::InvalidData,
         format!("failed to negotiate a common checksum algorithm (remote offers: {remote_list})"),

--- a/crates/protocol/src/negotiation/capabilities/tests.rs
+++ b/crates/protocol/src/negotiation/capabilities/tests.rs
@@ -2527,7 +2527,7 @@ fn test_choose_checksum_server_picks_first_client_match() {
 #[test]
 fn test_choose_checksum_client_picks_best_local_preference() {
     // Client iterates its own local list, picks first item also in server's list.
-    // upstream: compat.c:349-354 — client finds lowest local position among matches.
+    // upstream: compat.c:349-354 - client finds lowest local position among matches.
     // Server sends: md5 xxh128 xxh3
     // Client supports: xxh128 xxh3 xxh64 md5 md4 sha1 none
     // Client iterates local list: xxh128 is first local item in server's list → picks xxh128

--- a/crates/protocol/src/wire/vectored.rs
+++ b/crates/protocol/src/wire/vectored.rs
@@ -63,7 +63,7 @@ fn write_vectored_impl<W: Write>(writer: &mut W, buffers: &[&[u8]]) -> io::Resul
                         slices = &slices[1..];
                     }
                     if remaining > 0 && !slices.is_empty() {
-                        // Partial write of a slice — fall back to sequential for remainder
+                        // Partial write of a slice - fall back to sequential for remainder
                         let partial_buf = &chunk[chunk.len() - slices.len()][remaining..];
                         writer.write_all(partial_buf)?;
                         total += partial_buf.len() as u64;

--- a/crates/protocol/tests/compressed_token_interop.rs
+++ b/crates/protocol/tests/compressed_token_interop.rs
@@ -10,12 +10,12 @@
 //! ## Wire Format Reference (upstream token.c lines 321-329)
 //!
 //! ```text
-//! END_FLAG      = 0x00  — end of file marker
-//! TOKEN_LONG    = 0x20  — followed by 32-bit LE token number
-//! TOKENRUN_LONG = 0x21  — followed by 32-bit LE token + 16-bit LE run count
-//! DEFLATED_DATA = 0x40  — + 6-bit high len, then low len byte, then compressed data
-//! TOKEN_REL     = 0x80  — + 6-bit relative token number
-//! TOKENRUN_REL  = 0xC0  — + 6-bit relative token + 16-bit LE run count
+//! END_FLAG      = 0x00  - end of file marker
+//! TOKEN_LONG    = 0x20  - followed by 32-bit LE token number
+//! TOKENRUN_LONG = 0x21  - followed by 32-bit LE token + 16-bit LE run count
+//! DEFLATED_DATA = 0x40  - + 6-bit high len, then low len byte, then compressed data
+//! TOKEN_REL     = 0x80  - + 6-bit relative token number
+//! TOKENRUN_REL  = 0xC0  - + 6-bit relative token + 16-bit LE run count
 //! ```
 //!
 //! ## Testing Strategy
@@ -83,7 +83,7 @@ enum TestToken {
 }
 
 // ===========================================================================
-// Section 1: Golden byte tests — verify decoder handles upstream wire format
+// Section 1: Golden byte tests - verify decoder handles upstream wire format
 // ===========================================================================
 
 /// Upstream rsync signals end-of-file with a single END_FLAG (0x00) byte.
@@ -379,7 +379,7 @@ fn golden_mixed_literal_and_block_match() {
 }
 
 // ===========================================================================
-// Section 2: Encoder format tests — verify our encoder produces upstream format
+// Section 2: Encoder format tests - verify our encoder produces upstream format
 // ===========================================================================
 
 /// Verify the encoder writes END_FLAG (0x00) as the final byte.
@@ -536,7 +536,7 @@ fn encoder_run_length_boundary_65535() {
 }
 
 // ===========================================================================
-// Section 3: Round-trip tests — encode then decode with various data patterns
+// Section 3: Round-trip tests - encode then decode with various data patterns
 // ===========================================================================
 
 /// Round-trip: empty file (no literals, no blocks, just END_FLAG).
@@ -764,7 +764,7 @@ fn decoder_reuse_across_files() {
     }
 }
 
-/// Exactly CHUNK_SIZE (32 KiB) of literal data — the boundary where the
+/// Exactly CHUNK_SIZE (32 KiB) of literal data - the boundary where the
 /// encoder flushes its first chunk.
 #[test]
 fn roundtrip_exactly_chunk_size() {
@@ -775,7 +775,7 @@ fn roundtrip_exactly_chunk_size() {
     assert!(blocks.is_empty());
 }
 
-/// One byte less than CHUNK_SIZE — data stays in buffer until finish().
+/// One byte less than CHUNK_SIZE - data stays in buffer until finish().
 #[test]
 fn roundtrip_chunk_size_minus_one() {
     let data = vec![0xCDu8; 32 * 1024 - 1];
@@ -785,7 +785,7 @@ fn roundtrip_chunk_size_minus_one() {
     assert!(blocks.is_empty());
 }
 
-/// One byte more than CHUNK_SIZE — triggers a flush mid-stream, with one byte
+/// One byte more than CHUNK_SIZE - triggers a flush mid-stream, with one byte
 /// remaining for the next chunk.
 #[test]
 fn roundtrip_chunk_size_plus_one() {
@@ -863,7 +863,7 @@ fn protocol_version_30_and_31_both_produce_valid_wire_format() {
 /// rx_token becomes N+1. Multiple TOKEN_REL encodings in sequence must
 /// each account for this increment.
 ///
-/// Reference: token.c line 599 `return -1 - rx_token;` — the decoder
+/// Reference: token.c line 599 `return -1 - rx_token;` - the decoder
 /// returns the token value and the caller (in upstream) knows that
 /// rx_token has already been incremented.
 #[test]

--- a/crates/protocol/tests/daemon_negotiation.rs
+++ b/crates/protocol/tests/daemon_negotiation.rs
@@ -512,7 +512,7 @@ fn test_e2e_empty_buffer_error() {
 
     // Client tries to read from empty buffer (but first sends its own data)
     let mut client_output = Vec::new();
-    let mut client_input = &b""[..]; // Empty buffer — will fail after sending
+    let mut client_input = &b""[..]; // Empty buffer - will fail after sending
 
     let result = negotiate_capabilities(
         protocol,
@@ -846,7 +846,7 @@ fn test_e2e_buffer_reuse() {
     let first_size = shared_buffer.len();
     let first_data = shared_buffer.clone();
 
-    // Second negotiation — should produce identical output
+    // Second negotiation - should produce identical output
     shared_buffer.clear();
     let mut server_input = &peer_data[..];
     negotiate_capabilities(

--- a/crates/protocol/tests/golden_handshakes.rs
+++ b/crates/protocol/tests/golden_handshakes.rs
@@ -17,7 +17,7 @@ use protocol::{
 
 // ---------------------------------------------------------------------------
 // Server greeting wire format
-// upstream: clientserver.c — start_daemon(), sends "@RSYNCD: <ver>.0\n"
+// upstream: clientserver.c - start_daemon(), sends "@RSYNCD: <ver>.0\n"
 // ---------------------------------------------------------------------------
 
 #[test]
@@ -57,7 +57,7 @@ fn golden_server_greeting_protocol_28() {
 
 // ---------------------------------------------------------------------------
 // Greeting parsing
-// upstream: clientserver.c — start_inband_exchange() parses the greeting
+// upstream: clientserver.c - start_inband_exchange() parses the greeting
 // ---------------------------------------------------------------------------
 
 #[test]
@@ -94,7 +94,7 @@ fn golden_greeting_byte_exact_format() {
 
 // ---------------------------------------------------------------------------
 // Multiplex frame header encoding
-// upstream: io.c — mplex_write(), MPLEX_BASE=7, tag=(code+MPLEX_BASE)<<24 | len
+// upstream: io.c - mplex_write(), MPLEX_BASE=7, tag=(code+MPLEX_BASE)<<24 | len
 // ---------------------------------------------------------------------------
 
 #[test]
@@ -237,7 +237,7 @@ fn golden_mplex_decode_roundtrip_all_codes() {
 
 // ---------------------------------------------------------------------------
 // Varint encoding (protocol 30+)
-// upstream: io.c — write_varint() / read_varint()
+// upstream: io.c - write_varint() / read_varint()
 // ---------------------------------------------------------------------------
 
 #[test]
@@ -365,7 +365,7 @@ fn golden_varint_negative_128() {
 
 // ---------------------------------------------------------------------------
 // Fixed 4-byte integer encoding (write_int / read_int, all protocol versions)
-// upstream: io.c — write_int() / read_int()
+// upstream: io.c - write_int() / read_int()
 // ---------------------------------------------------------------------------
 
 #[test]
@@ -422,7 +422,7 @@ fn golden_write_int_256() {
 
 // ---------------------------------------------------------------------------
 // Longint encoding (protocol < 30)
-// upstream: io.c — write_longint() / read_longint()
+// upstream: io.c - write_longint() / read_longint()
 // ---------------------------------------------------------------------------
 
 #[test]
@@ -490,7 +490,7 @@ fn golden_longint_very_large() {
 
 // ---------------------------------------------------------------------------
 // Varlong30 encoding (protocol 30+)
-// upstream: io.c — write_varlong() / read_varlong() with min_bytes parameter
+// upstream: io.c - write_varlong() / read_varlong() with min_bytes parameter
 // ---------------------------------------------------------------------------
 
 #[test]
@@ -558,7 +558,7 @@ fn golden_varlong30_unix_timestamp_min3() {
 
 // ---------------------------------------------------------------------------
 // Compatibility flags wire format
-// upstream: compat.c — send/recv compatibility flags as varint
+// upstream: compat.c - send/recv compatibility flags as varint
 // ---------------------------------------------------------------------------
 
 #[test]
@@ -657,7 +657,7 @@ fn golden_compat_flags_all_known() {
 
 // ---------------------------------------------------------------------------
 // Transfer stats wire format
-// upstream: main.c — output_summary(), stats exchanged via varlong30(min_bytes=3)
+// upstream: main.c - output_summary(), stats exchanged via varlong30(min_bytes=3)
 // ---------------------------------------------------------------------------
 
 #[test]
@@ -758,7 +758,7 @@ fn golden_stats_swap_perspective() {
 
 // ---------------------------------------------------------------------------
 // File list XMIT flags encoding
-// upstream: rsync.h — XMIT_* constants, also mirrored in wire::file_entry
+// upstream: rsync.h - XMIT_* constants, also mirrored in wire::file_entry
 // ---------------------------------------------------------------------------
 
 #[test]
@@ -841,7 +841,7 @@ fn golden_xmit_file_entry_first_in_list() {
 
 // ---------------------------------------------------------------------------
 // Varint encoding for file list flags (VARINT_FLIST_FLAGS mode)
-// upstream: flist.c — send_file_entry() / recv_file_entry()
+// upstream: flist.c - send_file_entry() / recv_file_entry()
 // ---------------------------------------------------------------------------
 
 #[test]
@@ -880,7 +880,7 @@ fn golden_varint_flist_flags_with_extended() {
 
 // ---------------------------------------------------------------------------
 // File list end-of-list marker
-// upstream: flist.c — a zero byte marks end of file list (non-incremental)
+// upstream: flist.c - a zero byte marks end of file list (non-incremental)
 // ---------------------------------------------------------------------------
 
 #[test]
@@ -894,7 +894,7 @@ fn golden_flist_end_marker() {
 
 // ---------------------------------------------------------------------------
 // Checksum header (SumHead) wire format
-// upstream: match.c / sender.c — sum_head: count, blength, s2length, remainder
+// upstream: match.c / sender.c - sum_head: count, blength, s2length, remainder
 // Each field is write_int() = 4-byte LE i32, total 16 bytes
 // ---------------------------------------------------------------------------
 
@@ -954,7 +954,7 @@ fn golden_sum_head_typical() {
 
 // ---------------------------------------------------------------------------
 // Multiplex header decode from raw bytes
-// upstream: io.c — read_a_msg() reads 4-byte LE header
+// upstream: io.c - read_a_msg() reads 4-byte LE header
 // ---------------------------------------------------------------------------
 
 #[test]
@@ -1035,7 +1035,7 @@ fn golden_mplex_reject_tag_zero() {
 
 // ---------------------------------------------------------------------------
 // Delete stats wire format
-// upstream: generator.c — send_delete_stats() uses varint for each count
+// upstream: generator.c - send_delete_stats() uses varint for each count
 // ---------------------------------------------------------------------------
 
 #[test]
@@ -1095,7 +1095,7 @@ fn golden_delete_stats_large_counts() {
 
 // ---------------------------------------------------------------------------
 // Varint sequence encoding (multiple values in a stream)
-// upstream: io.c — sequential varint reads/writes in protocol 30+
+// upstream: io.c - sequential varint reads/writes in protocol 30+
 // ---------------------------------------------------------------------------
 
 #[test]
@@ -1131,7 +1131,7 @@ fn golden_varint_sequence() {
 
 // ---------------------------------------------------------------------------
 // Protocol version feature queries
-// upstream: compat.c — feature gates based on protocol version
+// upstream: compat.c - feature gates based on protocol version
 // ---------------------------------------------------------------------------
 
 #[test]
@@ -1169,7 +1169,7 @@ fn golden_protocol_version_features() {
 
 // ---------------------------------------------------------------------------
 // Message code numeric values match upstream enum msgcode
-// upstream: rsync.h — enum msgcode
+// upstream: rsync.h - enum msgcode
 // ---------------------------------------------------------------------------
 
 #[test]
@@ -1216,7 +1216,7 @@ fn golden_message_header_len_is_4() {
 
 // ---------------------------------------------------------------------------
 // Encoding consistency: varint30_int dispatches correctly by protocol version
-// upstream: io.h — write_varint30() / read_varint30() inline wrappers
+// upstream: io.h - write_varint30() / read_varint30() inline wrappers
 // ---------------------------------------------------------------------------
 
 #[test]
@@ -1266,7 +1266,7 @@ fn golden_varint30_int_proto32_uses_varint() {
 
 // ---------------------------------------------------------------------------
 // Legacy daemon protocol prefix constant
-// upstream: clientserver.c — RSYNCD_PREFIX "@RSYNCD: "
+// upstream: clientserver.c - RSYNCD_PREFIX "@RSYNCD: "
 // ---------------------------------------------------------------------------
 
 #[test]

--- a/crates/rsync_io/src/daemon/types/handshake.rs
+++ b/crates/rsync_io/src/daemon/types/handshake.rs
@@ -202,7 +202,7 @@ impl<R> LegacyDaemonHandshake<R> {
     ///
     /// Debug builds assert that the supplied stream captured a legacy ASCII negotiation so a binary
     /// session cannot be rewrapped accidentally. Higher layers can therefore temporarily take
-    /// ownership of the components—for example to wrap the transport with timeouts—before
+    /// ownership of the components-for example to wrap the transport with timeouts-before
     /// reassembling the handshake without replaying the daemon greeting.
     #[must_use]
     pub fn from_components(

--- a/crates/rsync_io/src/negotiation/stream/base.rs
+++ b/crates/rsync_io/src/negotiation/stream/base.rs
@@ -17,7 +17,7 @@ use super::super::{NegotiationBuffer, NegotiationBufferAccess};
 ///
 /// When the inner reader implements [`Clone`], the entire [`NegotiatedStream`]
 /// can be cloned. The clone retains the buffered negotiation bytes and replay
-/// cursor so both instances continue independently—matching upstream helpers
+/// cursor so both instances continue independently-matching upstream helpers
 /// that occasionally need to inspect the handshake transcript while preserving
 /// the original transport for continued use.
 #[derive(Clone, Debug)]

--- a/crates/rsync_io/src/negotiation/stream/buffer_access.rs
+++ b/crates/rsync_io/src/negotiation/stream/buffer_access.rs
@@ -28,7 +28,7 @@ impl<R> NegotiatedStream<R> {
     /// The helper mirrors [`Self::buffered`] but allocates a new vector sized exactly for the
     /// captured transcript. It reserves the necessary capacity via [`Vec::try_reserve_exact`]
     /// internally, propagating allocation failures as [`TryReserveError`]. Callers that need to own
-    /// the replay bytes—for example to stash them in a log or retry a handshake—can use this method
+    /// the replay bytes-for example to stash them in a log or retry a handshake-can use this method
     /// without first preparing a scratch buffer.
     ///
     /// # Examples

--- a/crates/rsync_io/src/session/handshake/negotiate.rs
+++ b/crates/rsync_io/src/session/handshake/negotiate.rs
@@ -138,8 +138,8 @@ where
 ///
 /// This convenience wrapper mirrors [`negotiate_session_from_stream`] but immediately converts the
 /// resulting [`SessionHandshake`] into [`SessionHandshakeParts`]. Callers that already possess a
-/// [`NegotiatedStream`]—for instance after invoking
-/// [`sniff_negotiation_stream`](crate::sniff_negotiation_stream)—can therefore obtain the replaying
+/// [`NegotiatedStream`]-for instance after invoking
+/// [`sniff_negotiation_stream`](crate::sniff_negotiation_stream)-can therefore obtain the replaying
 /// stream parts and negotiated metadata without rebuilding the handshake manually.
 ///
 /// # Errors

--- a/crates/transfer/src/flags.rs
+++ b/crates/transfer/src/flags.rs
@@ -246,10 +246,10 @@ impl ParsedServerFlags {
             b'R' => self.relative = true,
             b'P' => self.partial = true,
             b'u' => self.update = true,
-            // upstream: options.c:2613 — 'b' = backup.
+            // upstream: options.c:2613 - 'b' = backup.
             b'b' => self.backup = true,
             b'N' => self.crtimes = true,
-            // upstream: options.c:764 — 'L' = copy_links (resolve symlinks).
+            // upstream: options.c:764 - 'L' = copy_links (resolve symlinks).
             b'L' => self.copy_links = true,
             // upstream: options.c:764 - fuzzy_basis++ for each 'y'
             b'y' => self.fuzzy_level = self.fuzzy_level.saturating_add(1),

--- a/crates/transfer/src/lib.rs
+++ b/crates/transfer/src/lib.rs
@@ -360,7 +360,7 @@ pub fn run_server_with_handshake<W: Write>(
     // client reads silently); SSH mode uses bidirectional exchange.
     let is_daemon_mode = config.connection.client_mode || handshake.client_args.is_some();
 
-    // upstream: compat.c — do_compression is set by -z (short option) or by
+    // upstream: compat.c - do_compression is set by -z (short option) or by
     // --new-compress, --old-compress, --compress-choice=ALGO (long options).
     // upstream: options.c:2704 only puts 'z' in argstr for CPRES_ZLIB.
     // For zlibx, zstd, lz4, upstream sends long options instead.
@@ -506,12 +506,12 @@ pub fn run_server_with_handshake<W: Write>(
         writer = writer.activate_multiplex()?;
     }
 
-    // upstream: exclude.c:1650 — am_sender && !receiver_wants_list skips sending.
+    // upstream: exclude.c:1650 - am_sender && !receiver_wants_list skips sending.
     // Push mode applies exclusion locally in the generator; only delete/prune
     // needs the filter list on the wire.
     let receiver_wants_filter_list = config.flags.delete || config.flags.prune_empty_dirs;
 
-    // upstream: main.c:1258 — daemon sender always calls recv_filter_list(f_in).
+    // upstream: main.c:1258 - daemon sender always calls recv_filter_list(f_in).
     let should_send_filter_list = if config.connection.client_mode {
         match config.role {
             ServerRole::Generator => receiver_wants_filter_list,
@@ -530,7 +530,7 @@ pub fn run_server_with_handshake<W: Write>(
         writer.flush()?;
     }
 
-    // upstream: main.c:1354-1356 — after sending filter list, forward
+    // upstream: main.c:1354-1356 - after sending filter list, forward
     // pre-read --files-from data to the remote daemon's generator so it
     // can build the file list from the forwarded filenames.
     // This applies only in client-mode pull (Receiver), where the daemon's
@@ -542,7 +542,7 @@ pub fn run_server_with_handshake<W: Write>(
         }
     }
 
-    // upstream: main.c:1249-1250 — server sends MSG_IO_TIMEOUT to client.
+    // upstream: main.c:1249-1250 - server sends MSG_IO_TIMEOUT to client.
     if !config.connection.client_mode
         && let Some(timeout_secs) = handshake.io_timeout
         && handshake.protocol.supports_extended_goodbye()
@@ -575,7 +575,7 @@ pub fn run_server_with_handshake<W: Write>(
     match config.role {
         ServerRole::Receiver => {
             let mut ctx = ReceiverContext::new(&handshake, config);
-            // upstream: io.c:859 — stats.total_written tracking
+            // upstream: io.c:859 - stats.total_written tracking
             let mut counting_writer = writer::CountingWriter::new(&mut writer);
             let mut stats = ctx.run(chained_reader, &mut counting_writer, progress)?;
             stats.bytes_sent = counting_writer.bytes_written();

--- a/crates/transfer/src/temp_guard.rs
+++ b/crates/transfer/src/temp_guard.rs
@@ -7,8 +7,8 @@
 //!
 //! # Upstream Reference
 //!
-//! - `receiver.c:get_tmpname()` — temp file path construction
-//! - `receiver.c:open_tmpfile()` → `syscall.c:do_mkstemp()` — atomic creation
+//! - `receiver.c:get_tmpname()` - temp file path construction
+//! - `receiver.c:open_tmpfile()` → `syscall.c:do_mkstemp()` - atomic creation
 
 use std::fs;
 use std::io;
@@ -44,8 +44,8 @@ const NAME_MAX: usize = 255;
 ///
 /// # Arguments
 ///
-/// * `dest` — Final destination path for the file.
-/// * `temp_dir` — Optional `--temp-dir` directory.
+/// * `dest` - Final destination path for the file.
+/// * `temp_dir` - Optional `--temp-dir` directory.
 ///
 /// # Returns
 ///
@@ -112,12 +112,12 @@ fn truncate_utf8_safe(s: &str, max_len: usize) -> String {
 ///
 /// # Arguments
 ///
-/// * `dest` — Final destination path.
-/// * `temp_dir` — Optional `--temp-dir`.
+/// * `dest` - Final destination path.
+/// * `temp_dir` - Optional `--temp-dir`.
 ///
 /// # Returns
 ///
-/// A tuple of `(File, TempFileGuard)` — the open file handle and an RAII guard
+/// A tuple of `(File, TempFileGuard)` - the open file handle and an RAII guard
 /// that cleans up the temp file on drop unless `keep()` is called.
 pub fn open_tmpfile(dest: &Path, temp_dir: Option<&Path>) -> io::Result<(fs::File, TempFileGuard)> {
     let template = get_tmpname(dest, temp_dir)?;
@@ -129,14 +129,14 @@ pub fn open_tmpfile(dest: &Path, temp_dir: Option<&Path>) -> io::Result<(fs::Fil
 
         match fs::OpenOptions::new()
             .write(true)
-            .create_new(true) // O_EXCL — fail if exists
+            .create_new(true) // O_EXCL - fail if exists
             .open(&concrete_path)
         {
             Ok(file) => {
                 return Ok((file, TempFileGuard::new(concrete_path)));
             }
             Err(ref e) if e.kind() == io::ErrorKind::AlreadyExists => {
-                // Collision — try another random suffix
+                // Collision - try another random suffix
                 continue;
             }
             Err(ref e) if e.kind() == io::ErrorKind::NotFound => {
@@ -201,7 +201,7 @@ impl TempFileGuard {
         }
     }
 
-    /// Mark the temp file as successful — don't delete on drop.
+    /// Mark the temp file as successful - don't delete on drop.
     #[inline]
     pub const fn keep(&mut self) {
         self.keep_on_drop = true;
@@ -217,7 +217,7 @@ impl TempFileGuard {
 impl Drop for TempFileGuard {
     fn drop(&mut self) {
         if !self.keep_on_drop {
-            // Best-effort cleanup — ignore errors since:
+            // Best-effort cleanup - ignore errors since:
             // 1. File might not exist (never created)
             // 2. File might already be deleted (renamed away)
             // 3. We're in a drop context (can't propagate errors)
@@ -497,7 +497,7 @@ mod tests {
             let (_file, guard) = open_tmpfile(&dest, None).unwrap();
             temp_path = guard.path().to_path_buf();
             assert!(temp_path.exists());
-            // guard dropped here — file should be deleted
+            // guard dropped here - file should be deleted
         }
 
         assert!(!temp_path.exists());

--- a/crates/transfer/src/token_reader.rs
+++ b/crates/transfer/src/token_reader.rs
@@ -39,7 +39,7 @@ pub enum DeltaToken {
     Literal(LiteralData),
     /// Copy a block from the basis file at the given index.
     BlockRef(usize),
-    /// End of file marker — no more tokens follow.
+    /// End of file marker - no more tokens follow.
     End,
 }
 
@@ -117,7 +117,7 @@ impl TokenReader {
     /// Reads the next token from the stream.
     ///
     /// For plain mode, reads a 4-byte i32 and returns the token type.
-    /// Literal tokens return `LiteralData::Pending` — the caller must
+    /// Literal tokens return `LiteralData::Pending` - the caller must
     /// read the data bytes from the stream.
     ///
     /// For compressed mode, delegates to `CompressedTokenDecoder::recv_token()`
@@ -152,7 +152,7 @@ impl TokenReader {
 
     /// Feeds block data into the decompressor's dictionary after a block match.
     ///
-    /// Only needed for compressed mode — keeps the decompressor's dictionary
+    /// Only needed for compressed mode - keeps the decompressor's dictionary
     /// synchronized with the sender's compressor. In plain mode this is a no-op.
     ///
     /// Must be called after processing each `BlockRef` token with the actual


### PR DESCRIPTION
## Summary

- Convert em-dashes to hyphens across 63 Rust source files in `crates/` (182 occurrences) to align with the project writing style policy (hyphens, not em-dashes, in prose output).
- All affected lines are comments, doc comments, or attribute notes; no code logic changes.
- Upstream reference comments (`// upstream: ...`) and arrow characters (`→`) are preserved.

## Test plan

- [x] No em-dashes remain in `crates/**/*.rs` (verified via `grep -r`).
- [x] No string-literal or byte-literal content modified beyond a single `#[deprecated]` `note` attribute (which is prose).
- [ ] CI: fmt+clippy, nextest (stable), Windows, macOS, Linux musl.