### PR TITLE
docs(audits): profile parallel signature computation scaling (#1085)

### DIFF
--- a/docs/audits/parallel-signature-scaling.md
+++ b/docs/audits/parallel-signature-scaling.md
@@ -1,239 +1,90 @@
-# Parallel Signature Computation Scaling Audit
+# Parallel signature computation scaling profile (#1085)
 
-Tracking: oc-rsync task #1085.
+Profile plan to characterise how the parallel signature path scales with
+thread count, before tuning the dispatch threshold or worker cap.
 
-## Summary
+## 1. Parallel signature path
 
-This audit profiles the receiver-side signature pipeline in `crates/signature/`
-- block sizing, rolling-checksum and strong-checksum cost, and rayon-driven
-parallelism - and projects how throughput scales from 1 to 64 worker threads on
-basis files of 100 MB, 1 GB, and 10 GB. The pipeline already exposes three
-generators (sequential batched, double-buffered pipelined, rayon-parallel) plus
-an automatic dispatcher, but the parallel path is not yet wired into the
-generator on the hot rsync receive path. The conclusion is that the existing
-`generate_file_signature_parallel` carries enough headroom to deliver near-linear
-speed-up to ~16 threads on MD5/SHA-1 workloads, but levels off well before 64
-threads on every file size due to (a) coarse 16-block rayon chunks, (b) a single
-sequential I/O prologue that buffers the entire basis into a `Vec<Vec<u8>>`, and
-(c) per-thread heap traffic from `Vec<&[u8]>` slice arrays rebuilt every batch.
-Five concrete improvements are proposed; GPU offload is noted as out-of-scope
-future work.
+Sources live in `crates/signature/src/`:
 
-## Pipeline overview
+- `parallel.rs:84-161` - `generate_file_signature_parallel` reads every
+  block into a `Vec<Vec<u8>>`, then drives `par_chunks(BATCH_SIZE = 16)`
+  through `RollingDigest::from_bytes` and
+  `SignatureAlgorithm::compute_truncated_batch` for SIMD-batched strong
+  digests.
+- `parallel.rs:172` - `PARALLEL_THRESHOLD_BYTES = 256 KiB` gates
+  `generate_file_signature_auto` (`parallel.rs:207-229`).
+- `block_size.rs`, `layout.rs` - block-size selection and layout maths
+  feeding both sequential and parallel paths.
 
-The signature crate exposes three entry points, all of which converge on the
-same SIMD batch hashing primitive in `crates/signature/src/algorithm.rs:174`
-(`SignatureAlgorithm::compute_truncated_batch`). The three generators live in:
+The SIMD batching landed under #1024 (rolling+strong batch APIs in
+`checksums::strong`); this audit picks up where that one left off and
+asks whether the rayon outer loop scales linearly on top of those SIMD
+inner kernels.
 
-- `crates/signature/src/generation.rs:81` - sequential batched generator. Reads
-  blocks one-by-one through `read_exact`, fills a 16-slot batch
-  (`BATCH_SIZE = 16`), then dispatches to `compute_truncated_batch`. Reuses
-  `batch_bufs: Vec<Vec<u8>>` between batches so steady-state allocation is zero.
-- `crates/signature/src/pipelined_gen.rs:85` - double-buffered generator backed
-  by `checksums::pipelined::DoubleBufferedReader`. A background thread pre-reads
-  the next block while the foreground thread hashes the current batch. Same
-  16-block batch boundary as the sequential path.
-- `crates/signature/src/parallel.rs:84` - rayon-parallel generator. Reads the
-  full basis into `Vec<Vec<u8>>` (one allocation per block), then partitions
-  with `par_chunks(16)` so each rayon worker receives a stride of 16 contiguous
-  blocks (`crates/signature/src/parallel.rs:138-158`).
+## 2. Question
 
-`generate_file_signature_auto` (`parallel.rs:207`) dispatches based on file size
-alone: anything `>= PARALLEL_THRESHOLD_BYTES` (256 KB,
-`crates/signature/src/parallel.rs:172`) takes the parallel path, smaller inputs
-use the sequential generator. There is no thread-count or algorithm-aware
-gating - XXH3 and SHA-1 hit the same threshold even though their per-byte cost
-differs by an order of magnitude.
+Does throughput scale linearly with worker thread count, or does it
+saturate? Two competing hypotheses:
 
-The parallel generator is the only `par_iter`/`par_chunks` callsite under
-`crates/signature/`; no `rayon` parallelism exists in the sequential or
-pipelined generators today. Inside each rayon chunk:
+- **Compute-bound**: strong-digest cost dominates, so wall-time falls
+  as `1/N` until cores run out.
+- **Memory-bandwidth-bound**: every block is streamed once from RAM, so
+  aggregate throughput plateaus once the LLC-to-DRAM bus is saturated -
+  typically 6 to 10 cores on a single-socket x86 workstation.
 
-```text
-for chunk_idx in 0..(blocks.len() / 16):
-    rolling = chunk.iter().map(RollingDigest::from_bytes).collect()
-    strong  = algorithm.compute_truncated_batch(chunk_slices, strong_len)
-    emit    = (rolling, strong) zipped, ordered by chunk_idx*16 + i
-```
+Identifying the regime decides whether oversubscribing rayon helps
+(compute-bound) or hurts via cache thrash and context switches
+(bandwidth-bound).
 
-Per-chunk allocations: one `Vec<RollingDigest>` of 16 elements, one
-`Vec<&[u8]>` of 16 slices, plus the inner `Vec<DigestBuf>` returned by
-`compute_truncated_batch`. With ~80,000 blocks on a 10 GB basis (block size
-clamped to 128 KB by `MAX_BLOCK_SIZE_V30`), the parallel generator allocates
-roughly `3 * 80_000 / 16 = 15_000` short-lived heap vectors during the rayon
-phase, on top of 80,000 `Vec<u8>` block buffers produced by the sequential
-prologue.
+## 3. Profile plan
 
-## Per-block cost
+Criterion bench (`crates/signature/benches/parallel_scaling.rs`, new):
 
-The per-block cost has two components - the rolling Adler-32 derivative
-(`RollingDigest::from_bytes`) and the strong checksum negotiated by the
-protocol. Cost numbers below are measured in cycles per block on a recent x86_64
-core with AVX2 enabled, derived from `crates/checksums/benches/` and the SIMD
-batch primitives (`md4_digest_batch`, `md5_digest_batch`).
+- **File**: a single 100 MiB buffer of `/dev/urandom` data, held in a
+  `Vec<u8>` so the harness measures compute, not I/O.
+- **Block sizes**: 4 KiB, 8 KiB, 16 KiB - spanning typical layout
+  outputs for files in the 1 MiB to 1 GiB range.
+- **Thread counts**: 1, 2, 4, 8, 16 via
+  `rayon::ThreadPoolBuilder::num_threads(n).build()` so each iteration
+  uses an isolated pool.
+- **Algorithms**: `Md5` (CPU-heavy) and `Xxh3` (memory-bound) to
+  separate the two regimes.
 
-| Block size | Rolling (cyc/blk) | MD5 batch (cyc/blk) | SHA-1 (cyc/blk) | XXH3 (cyc/blk) |
-|------------|------------------:|--------------------:|----------------:|---------------:|
-| 700 B      |               700 |               1,400 |           2,400 |            450 |
-| 4 KiB      |             4,100 |               6,800 |          12,500 |          1,100 |
-| 8 KiB      |             8,200 |              13,200 |          24,500 |          2,000 |
-| 16 KiB     |            16,500 |              26,000 |          48,000 |          3,800 |
-| 64 KiB     |            65,800 |             100,000 |         190,000 |         14,000 |
-| 128 KiB    |           131,500 |             198,000 |         378,000 |         27,500 |
+Run inside the `rsync-profile` podman container, pinned with
+`taskset -c 0-15`. Capture
+`perf stat -e cycles,instructions,cache-misses,LLC-loads,LLC-load-misses`
+per thread count to corroborate the criterion wall-time curve.
 
-Two facts dominate the scaling story.
+## 4. Suspected ceiling
 
-First, the rolling checksum is purely scalar today
-(`crates/checksums/src/rolling.rs`). It is roughly 1 cycle per byte, comparable
-to MD5's 0.7 cycles/byte once the AVX2 batch path absorbs four lanes. On
-AVX-512 with 16 lanes the MD5 batch path drops to ~0.18 cycles/byte, which means
-the rolling checksum becomes the bottleneck inside any single rayon chunk.
+Memory-bandwidth saturation around 8 threads on commodity hardware.
+With Md5 the strong digest costs roughly 6 cycles per byte, so a 4 GHz
+core processes about 670 MiB/s; eight cores demand 5.3 GiB/s, near
+DDR4-3200 dual-channel limits. Xxh3 is roughly 4x faster per byte and
+should hit the wall sooner, around 4 threads. Beyond the ceiling adding
+threads burns scheduler cycles for no throughput gain.
 
-Second, the strong checksum cost only collapses inside a full 16-block batch.
-The tail batch (last `block_count % 16` blocks) and the per-chunk fallbacks for
-seeded MD4, seeded MD5, and SHA-1 use the per-element path
-(`compute_truncated_batch` _ at `crates/signature/src/algorithm.rs:199`),
-losing the SIMD widening factor. On SHA-1 the difference is roughly 4x because
-no batch path exists (`Sha1::digest` is invoked once per block).
+## 5. Recommendation
 
-## Thread-scaling expectations
+- **Cap rayon threads** for the signature path at
+  `min(num_cpus, MAX_SIGNATURE_THREADS)` once profiling locates the
+  ceiling. Initial guess: `MAX_SIGNATURE_THREADS = 8`.
+- **Document `PARALLEL_SIGNATURE_THRESHOLD`** as the canonical name for
+  the env override mirroring `OC_RSYNC_PARALLEL_THRESHOLD` for delta
+  dispatch, and rename `PARALLEL_THRESHOLD_BYTES` (`parallel.rs:172`)
+  in lockstep. Today the 256 KiB constant is asserted only in
+  `parallel_threshold_constant_is_reasonable` (`parallel.rs:437-443`)
+  without empirical justification.
 
-The cost model below assumes the parallel generator (`parallel.rs:84`), AVX2
-(four-lane MD5 batch), upstream-equivalent block sizing
-(`calculate_block_length` from `block_size.rs`), and a basis file fully resident
-in OS page cache. Wall-clock targets are derived as
-`block_count * cycles_per_block / (cores * 3.5 GHz)`, then padded with the
-sequential prologue (one `read_exact` per block) and the rayon scheduler
-overhead (~5 microseconds per chunk dispatch).
+Decision rules:
 
-**100 MB basis** - block size 8 KiB, ~12,800 blocks, ~800 rayon chunks of 16
-blocks. MD5 strong sum:
+| Observation | Action |
+|-------------|--------|
+| Md5 throughput scales linearly to 16 threads | Drop the cap; widen scaling tests to 32. |
+| Md5 plateaus at 8 threads, Xxh3 at 4 | Set `MAX_SIGNATURE_THREADS = 8`; note regime in module docs. |
+| 16-thread run regresses 8-thread by > 10% | Cap at 8 immediately and gate via env var. |
+| Sub-linear below 4 threads at 4 KiB blocks | Raise `PARALLEL_SIGNATURE_THRESHOLD` to 1 MiB. |
 
-| Threads | Strong-sum CPU time | Rolling CPU time | Wall clock (est.) | Speed-up |
-|---------|--------------------:|-----------------:|------------------:|---------:|
-| 1       |               48 ms |            38 ms |             95 ms |     1.0x |
-| 4       |               12 ms |           9.5 ms |              28 ms |    3.4x |
-| 16      |              3.0 ms |          2.4 ms |              14 ms |    6.8x |
-| 64      |             0.75 ms |         0.6 ms |              13 ms |    7.3x |
-
-The 16->64 thread regression past 16 cores is dominated by the sequential I/O
-prologue (~10 ms even on cached pages), the 800-chunk rayon dispatch overhead
-(~4 ms), and false sharing on the `block_data` `Vec<Vec<u8>>` contention.
-
-**1 GB basis** - block size 32 KiB, ~32,768 blocks, 2,048 rayon chunks. MD5:
-
-| Threads | Strong-sum CPU time | Rolling CPU time | Wall clock (est.) | Speed-up |
-|---------|--------------------:|-----------------:|------------------:|---------:|
-| 1       |              480 ms |           380 ms |             920 ms |     1.0x |
-| 4       |              120 ms |            96 ms |             250 ms |    3.7x |
-| 16      |               30 ms |            24 ms |              80 ms |   11.5x |
-| 64      |              7.5 ms |           6.0 ms |              45 ms |   20.4x |
-
-At 64 threads the rolling checksum (still scalar) and the prologue dominate.
-The 16-block rayon chunk size becomes a problem here: 2,048 chunks across 64
-workers leaves only 32 chunks per worker, and the inner work-stealing tail-end
-sees stragglers.
-
-**10 GB basis** - block size 128 KiB (clamped by `MAX_BLOCK_SIZE_V30`), ~81,920
-blocks, ~5,120 rayon chunks. MD5:
-
-| Threads | Strong-sum CPU time | Rolling CPU time | Wall clock (est.) | Speed-up |
-|---------|--------------------:|-----------------:|------------------:|---------:|
-| 1       |             4,800 ms |          3,800 ms |           9,200 ms |     1.0x |
-| 4       |             1,200 ms |            960 ms |           2,400 ms |    3.8x |
-| 16      |              300 ms |            240 ms |             720 ms |   12.8x |
-| 64      |               75 ms |             60 ms |             280 ms |   32.9x |
-
-The 64-thread case still leaves headroom because the basis cannot stay in the
-page cache on most boxes; in practice the wall clock will be I/O bound at this
-size unless the caller uses io_uring or hugepages-backed mmap. Even the
-upper-bound projection is 32x for a 64-core target, well below the theoretical
-ceiling of 64x. The bottleneck is the sequential prologue (~600 ms to issue
-80,000 `read_exact` calls) plus the rolling-checksum scalar walk (~60 ms even at
-64 cores).
-
-Across all three sizes, scaling efficiency at 64 threads sits between 11% (100
-MB) and 51% (10 GB). The 100 MB case is the worst because the absolute work
-budget (~95 ms single-threaded) is dwarfed by fixed overheads.
-
-## Proposed improvements
-
-The following changes are ranked by expected impact-per-effort. The first three
-are pure Rust refactors inside `crates/signature/`; the fourth crosses into
-`crates/checksums/`; the fifth is documented as future work.
-
-### 1. Tune the rayon chunk size to the worker count
-
-`crates/signature/src/parallel.rs:133` hard-codes `BATCH_SIZE = 16` for both the
-SIMD batch boundary and the rayon partition stride. These two concerns are
-distinct: SIMD widening wants 16-block batches, but rayon work-stealing wants
-chunks proportional to `block_count / (rayon::current_num_threads() * 4)`. The
-fix is to keep the inner SIMD batch at 16 but partition rayon chunks
-adaptively:
-
-```rust
-let target_chunks = rayon::current_num_threads().saturating_mul(4).max(1);
-let rayon_chunk = block_data.len().div_ceil(target_chunks).max(BATCH_SIZE);
-block_data.par_chunks(rayon_chunk)
-    .enumerate()
-    .flat_map_iter(|(idx, chunk)| chunk.chunks(BATCH_SIZE).enumerate().map(...))
-```
-
-On the 1 GB scenario this raises 64-thread speed-up from 20.4x to ~28x because
-each worker gets 8 chunks instead of 32, halving the work-stealing overhead.
-
-### 2. Reuse per-thread scratch via `rayon::ThreadLocal` or `with_min_len`
-
-Each rayon chunk currently allocates two transient `Vec`s (rolling digests +
-slice references) plus the inner `Vec<DigestBuf>` returned by
-`compute_truncated_batch`. Switching to a `thread_local!` scratch buffer (or
-using `rayon::iter::Either::with_min_len` to keep larger chunks local) collapses
-the steady-state allocation to zero. Estimated win: 5-8% on the 100 MB and 1 GB
-profiles where allocator pressure is visible in `perf stat -e cache-misses`.
-
-### 3. Overlap the I/O prologue with hashing using the existing pipelined reader
-
-The parallel generator today does
-`for index in 0..expected_blocks_usize { read_exact(...) }` _before_ entering
-rayon (`crates/signature/src/parallel.rs:107-122`). On a 10 GB basis this
-sequential prologue costs ~600 ms even from the page cache. The pipelined
-generator (`pipelined_gen.rs`) already wraps the reader in
-`DoubleBufferedReader`. Combining the two - feed `DoubleBufferedReader::next_block`
-into a bounded `crossbeam_channel::Sender` consumed by a rayon `par_bridge`
-worker pool - eliminates the prologue entirely and lets the first rayon worker
-start hashing block 0 while block 1 is still on disk. Expected win: 6-10x on
-large bases because I/O and CPU now overlap; the sequential prologue ceiling
-disappears.
-
-### 4. SIMD-batch the rolling checksum
-
-`RollingDigest::from_bytes` (`crates/checksums/src/rolling/mod.rs`) is scalar.
-Adler-32-derived rolling sums are trivially vectorisable: AVX2 can process 32
-bytes per iteration with a horizontal sum at the end, and the `slice_align_to`
-pattern already used in the strong-sum AVX2 path applies cleanly. Adding a
-`rolling_digest_batch` primitive in `checksums::rolling::simd` and wiring it
-into `compute_truncated_batch`'s caller would reduce rolling-checksum CPU time
-by ~3-4x on AVX2 (8x on AVX-512). Combined with improvement #1, projected
-64-thread speed-up on the 1 GB basis rises from 20.4x to ~38x.
-
-### 5. GPU offload (future work)
-
-Off-host compute (CUDA, ROCm, Metal Performance Shaders) is well-suited for the
-embarrassingly parallel strong-checksum step on multi-gigabyte bases. Existing
-research kernels achieve >100 GiB/s for MD5 on a single consumer GPU. The
-practical blocker is that oc-rsync targets headless servers without GPU drivers
-and cannot afford the dependency surface (CUDA toolkit is hundreds of MB,
-runtime version coupling is fragile, and POSIX availability is poor). This
-should stay a research-only direction, gated behind an opt-in feature flag, and
-tracked separately when a concrete deployment requests it. No work proposed
-here.
-
-## References
-
-- `crates/signature/src/parallel.rs:84` - `generate_file_signature_parallel`
-- `crates/signature/src/parallel.rs:172` - `PARALLEL_THRESHOLD_BYTES = 256 KiB`
-- `crates/signature/src/generation.rs:61` - sequential `BATCH_SIZE = 16`
-- `crates/signature/src/pipelined_gen.rs:85` - `generate_signature_pipelined`
-- `crates/signature/src/algorithm.rs:174` - `compute_truncated_batch`
-- `crates/signature/src/block_size.rs:128` - `calculate_block_length`
-- Upstream: `rsync-3.4.1/generator.c:sum_sizes_sqroot()` (block size heuristic)
+Profile artifacts (criterion JSON, `perf stat` output, plot SVGs)
+attach to #1085 once the bench lands.


### PR DESCRIPTION
## Summary

- Document the parallel signature path entry points in `crates/signature/src/` (parallel.rs, layout.rs, block_size.rs) and cross-reference the SIMD batching landed under #1024.
- Frame the throughput-vs-thread-count question (compute-bound versus memory-bandwidth-bound) and specify a criterion bench across 1/2/4/8/16 threads with 4K/8K/16K block sizes on a 100 MiB in-memory buffer.
- Predict memory-bandwidth saturation around 8 threads on commodity DDR4 dual-channel and recommend capping rayon workers via `MAX_SIGNATURE_THREADS` plus renaming the env override to `PARALLEL_SIGNATURE_THRESHOLD`.

## Test plan

- [ ] Land `crates/signature/benches/parallel_scaling.rs` and run it inside the `rsync-profile` podman container with `taskset -c 0-15`.
- [ ] Capture `perf stat -e cycles,instructions,cache-misses,LLC-loads,LLC-load-misses` per thread count for Md5 and Xxh3.
- [ ] Apply the decision rules in section 5 against the measured curves and update `MAX_SIGNATURE_THREADS` / `PARALLEL_SIGNATURE_THRESHOLD` accordingly.