### PR TITLE
fix(engine): prevent PID controller integral test saturation

### DIFF
--- a/crates/engine/src/local_copy/buffer_pool/buffer_controller.rs
+++ b/crates/engine/src/local_copy/buffer_pool/buffer_controller.rs
@@ -352,7 +352,10 @@ mod tests {
     fn integral_term_eliminates_steady_state_error_after_repeated_low_samples() {
         // Pure-P would leave a residual offset; the integrator should keep
         // pushing the buffer up across repeated identical low samples.
-        let ctrl = ControllerConfig::new(lan_setpoint())
+        // Use a moderate setpoint (1 MB/s) so the integral accumulates
+        // gradually without saturating the anti-windup clamp or hitting
+        // max_size on the first step.
+        let ctrl = ControllerConfig::new(1_000_000)
             .gains(0.0, 0.5, 0.0)
             .min_size(16 * 1024)
             .max_size(4 * 1024 * 1024)


### PR DESCRIPTION
## Summary

- Fix `integral_term_eliminates_steady_state_error_after_repeated_low_samples` test that fails deterministically across all platforms
- Root cause: 100 MB/s setpoint with K_i=0.5 causes the integral contribution (5.2 MB) to exceed the 4 MB anti-windup clamp on the first step, immediately pushing the buffer to max_size - subsequent iterations cannot grow further, failing the monotonic-growth assertion
- Reduce setpoint to 1 MB/s so the integral accumulates gradually (50 KB/step) without saturating

## Test plan

- [ ] Verify `integral_term_eliminates_steady_state_error_after_repeated_low_samples` passes on all CI platforms (Linux, macOS, Windows)
- [ ] Verify no other buffer_controller tests regress