### PR TITLE
feat(core): wire missing RERR exit codes (#2114)

### DIFF
--- a/crates/core/src/client/remote/ssh_transfer.rs
+++ b/crates/core/src/client/remote/ssh_transfer.rs
@@ -498,6 +498,8 @@ pub(super) fn map_child_exit_status(status: std::process::ExitStatus) -> ExitCod
     }
 
     match status.code() {
+        // upstream: main.c:1591 - shell exit codes mapped to RERR_CMD_*
+        Some(126) => ExitCode::CommandRun,
         Some(127) => ExitCode::CommandNotFound,
         Some(255) => ExitCode::CommandFailed,
         Some(code) => ExitCode::from_i32(code).unwrap_or(ExitCode::PartialTransfer),
@@ -795,6 +797,13 @@ mod tests {
         fn maps_exit_127_to_command_not_found() {
             let status = exit_status_for_code(127);
             assert_eq!(map_child_exit_status(status), ExitCode::CommandNotFound);
+        }
+
+        #[cfg(unix)]
+        #[test]
+        fn maps_exit_126_to_command_run() {
+            let status = exit_status_for_code(126);
+            assert_eq!(map_child_exit_status(status), ExitCode::CommandRun);
         }
 
         #[cfg(unix)]

--- a/crates/core/src/exit_code/codes.rs
+++ b/crates/core/src/exit_code/codes.rs
@@ -258,6 +258,7 @@ impl ExitCode {
     ///   `BrokenPipe`, `AddrInUse`, `AddrNotAvailable`, `NotConnected` - `SocketIo`
     /// - `TimedOut` - `Timeout`
     /// - `UnexpectedEof`, `InvalidData` - `StreamIo`
+    /// - `Unsupported` - `Unsupported`
     /// - `Interrupted` by signal - `Signal`
     /// - All other I/O errors - `FileIo`
     #[must_use]
@@ -282,6 +283,8 @@ impl ExitCode {
             ErrorKind::UnexpectedEof | ErrorKind::InvalidData => Self::StreamIo,
 
             ErrorKind::Interrupted => Self::Signal,
+
+            ErrorKind::Unsupported => Self::Unsupported,
 
             _ => Self::FileIo,
         }

--- a/crates/core/src/exit_code/tests.rs
+++ b/crates/core/src/exit_code/tests.rs
@@ -231,6 +231,14 @@ fn from_io_error_maps_signal_interruption() {
 }
 
 #[test]
+fn from_io_error_maps_unsupported_to_unsupported() {
+    use std::io::{Error, ErrorKind};
+
+    let err = Error::from(ErrorKind::Unsupported);
+    assert_eq!(ExitCode::from_io_error(&err), ExitCode::Unsupported);
+}
+
+#[test]
 fn from_io_error_defaults_to_file_io() {
     use std::io::{Error, ErrorKind};
 

--- a/crates/daemon/src/daemon.rs
+++ b/crates/daemon/src/daemon.rs
@@ -46,6 +46,7 @@ use core::{
         parse_bandwidth_limit,
     },
     branding::{self, Brand, manifest},
+    exit_code::ExitCode,
     message::{Message, Role},
     rsync_error, rsync_info, rsync_warning,
     server::{

--- a/crates/daemon/src/daemon/sections/module_access/helpers.rs
+++ b/crates/daemon/src/daemon/sections/module_access/helpers.rs
@@ -64,11 +64,14 @@ pub(crate) fn open_log_sink(path: &Path, brand: Brand) -> Result<SharedLogSink, 
 }
 
 /// Creates a [`DaemonError`] for log file open failures.
+///
+/// upstream: log.c:163 - log-open failures produce RERR_MESSAGEIO (13).
 fn log_file_error(path: &Path, error: io::Error) -> DaemonError {
-    DaemonError::new(
-        FEATURE_UNAVAILABLE_EXIT_CODE,
+    let code = ExitCode::MessageIo;
+    DaemonError::with_code(
+        code,
         rsync_error!(
-            FEATURE_UNAVAILABLE_EXIT_CODE,
+            code.as_i32(),
             format!("failed to open log file '{}': {}", path.display(), error)
         )
         .with_role(Role::Daemon),

--- a/crates/daemon/src/daemon/sections/module_access/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_access/tests.rs
@@ -284,12 +284,13 @@ mod module_access_tests {
 
     // Tests for error file functions
 
+    /// upstream: log.c:163 - log-open failures produce RERR_MESSAGEIO (13).
     #[test]
     fn log_file_error_creates_daemon_error_with_correct_code() {
         let path = std::path::Path::new("/tmp/test.log");
         let io_err = std::io::Error::new(std::io::ErrorKind::PermissionDenied, "test error");
         let err = log_file_error(path, io_err);
-        assert_eq!(err.exit_code(), FEATURE_UNAVAILABLE_EXIT_CODE);
+        assert_eq!(err.exit_code(), core::exit_code::ExitCode::MessageIo.as_i32());
     }
 
     #[test]

--- a/crates/daemon/src/tests.rs
+++ b/crates/daemon/src/tests.rs
@@ -68,6 +68,7 @@ use crate::daemon::{
 use core::{
     bandwidth::{BandwidthLimiter, LimiterChange},
     branding::{self, Brand},
+    exit_code::ExitCode,
 };
 
 // Import from protocol
@@ -111,6 +112,7 @@ include!("tests/chunks/help_flag_renders_static_help_snapshot.rs");
 include!("tests/chunks/legacy_daemon_greeting_digest_list_varies_by_protocol.rs");
 include!("tests/chunks/legacy_daemon_greeting_has_single_newline.rs");
 include!("tests/chunks/legacy_daemon_greeting_includes_version_and_digests.rs");
+include!("tests/chunks/log_file_open_failure_returns_message_io.rs");
 include!("tests/chunks/log_module_bandwidth_change_ignores_unchanged.rs");
 include!("tests/chunks/log_module_bandwidth_change_logs_disable.rs");
 include!("tests/chunks/log_module_bandwidth_change_logs_updates.rs");

--- a/crates/daemon/src/tests/chunks/log_file_open_failure_returns_message_io.rs
+++ b/crates/daemon/src/tests/chunks/log_file_open_failure_returns_message_io.rs
@@ -1,0 +1,9 @@
+/// upstream: log.c:163 - daemon log-open failures produce RERR_MESSAGEIO (13).
+#[test]
+fn log_file_open_failure_returns_message_io() {
+    let dir = tempfile::tempdir().expect("create tempdir");
+    let nonexistent = dir.path().join("no/such/dir/log.txt");
+    let err = open_log_sink(&nonexistent, Brand::Oc).unwrap_err();
+    assert_eq!(err.code(), ExitCode::MessageIo);
+    assert!(err.to_string().contains("failed to open log file"));
+}

--- a/crates/transfer/src/setup/restrictions.rs
+++ b/crates/transfer/src/setup/restrictions.rs
@@ -95,7 +95,7 @@ pub fn apply_protocol_restrictions(
         // upstream compat.c:655-661 - ACLs require protocol 30+
         if flags.preserve_acls && !flags.local_server {
             return Err(io::Error::new(
-                io::ErrorKind::InvalidInput,
+                io::ErrorKind::Unsupported,
                 format!("--acls requires protocol 30 or higher (negotiated {version})."),
             ));
         }
@@ -103,7 +103,7 @@ pub fn apply_protocol_restrictions(
         // upstream compat.c:662-668 - xattrs require protocol 30+
         if flags.preserve_xattrs && !flags.local_server {
             return Err(io::Error::new(
-                io::ErrorKind::InvalidInput,
+                io::ErrorKind::Unsupported,
                 format!("--xattrs requires protocol 30 or higher (negotiated {version})."),
             ));
         }
@@ -123,7 +123,7 @@ pub fn apply_protocol_restrictions(
         // upstream compat.c:679-685 - fuzzy requires 29+
         if flags.fuzzy_basis {
             return Err(io::Error::new(
-                io::ErrorKind::InvalidInput,
+                io::ErrorKind::Unsupported,
                 format!("--fuzzy requires protocol 29 or higher (negotiated {version})."),
             ));
         }
@@ -131,7 +131,7 @@ pub fn apply_protocol_restrictions(
         // upstream compat.c:687-693 - basis_dir + inplace requires 29+
         if flags.basis_dir_count > 0 && flags.inplace {
             return Err(io::Error::new(
-                io::ErrorKind::InvalidInput,
+                io::ErrorKind::Unsupported,
                 format!(
                     "--compare-dest/--copy-dest/--link-dest with --inplace requires \
                      protocol 29 or higher (negotiated {version})."
@@ -142,7 +142,7 @@ pub fn apply_protocol_restrictions(
         // upstream compat.c:695-701 - multiple basis dirs require 29+
         if flags.basis_dir_count > 1 {
             return Err(io::Error::new(
-                io::ErrorKind::InvalidInput,
+                io::ErrorKind::Unsupported,
                 format!(
                     "Using more than one --compare-dest/--copy-dest/--link-dest option \
                      requires protocol 29 or higher (negotiated {version})."
@@ -153,7 +153,7 @@ pub fn apply_protocol_restrictions(
         // upstream compat.c:703-709 - prune-empty-dirs requires 29+
         if flags.prune_empty_dirs {
             return Err(io::Error::new(
-                io::ErrorKind::InvalidInput,
+                io::ErrorKind::Unsupported,
                 format!(
                     "--prune-empty-dirs requires protocol 29 or higher (negotiated {version})."
                 ),


### PR DESCRIPTION
## Summary

- **CommandRun(126)**: add explicit match arm in `map_child_exit_status` for shell exit 126, mirroring the existing 127/255 handling pattern. While `from_i32(126)` already resolved correctly via the fallback, the explicit arm matches upstream rsync's `main.c:1591` convention and makes the mapping visible.
- **Unsupported(4)**: map `io::ErrorKind::Unsupported` to `ExitCode::Unsupported` in `from_io_error`, and change `apply_protocol_restrictions` to use `ErrorKind::Unsupported` so protocol feature rejections (ACLs below proto 30, xattrs below proto 30, fuzzy/basis-dir/prune below proto 29) produce exit code 4 instead of 11.
- **MessageIo(13)**: change daemon `log_file_error` from `FEATURE_UNAVAILABLE(1)` to `MessageIo(13)` per upstream `log.c:163`.

## Test plan

- [x] New test `maps_exit_126_to_command_run` in `ssh_transfer.rs` child exit status tests
- [x] New test `from_io_error_maps_unsupported_to_unsupported` in `exit_code/tests.rs`
- [x] New test `log_file_open_failure_returns_message_io` in `daemon/tests.rs`
- [x] Updated existing `log_file_error_creates_daemon_error_with_correct_code` to expect exit code 13
- [x] All 245 affected tests pass across core, transfer, and daemon crates
- [x] Full workspace clippy clean (pre-existing `fast_io` stub warning unrelated)