### PR TITLE
feat: add buffer recycling to checksum pipeline

### DIFF
--- a/crates/checksums/src/pipelined/mod.rs
+++ b/crates/checksums/src/pipelined/mod.rs
@@ -8,7 +8,7 @@
 //! │                    Double-Buffered Checksum Pipeline                     │
 //! ├──────────────────────────────────────────────────────────────────────────┤
 //! │                                                                          │
-//! │  Time →                                                                  │
+//! │  Time ->                                                                 │
 //! │                                                                          │
 //! │  Without pipelining (sequential):                                        │
 //! │  ┌────────┐ ┌──────────────┐ ┌────────┐ ┌──────────────┐                │
@@ -24,6 +24,15 @@
 //! │                                                                          │
 //! └──────────────────────────────────────────────────────────────────────────┘
 //! ```
+//!
+//! # Buffer Recycling
+//!
+//! The double-buffered reader pre-allocates two buffers and recycles them
+//! between the I/O thread and the main thread via a return channel. After the
+//! main thread finishes processing a block, the buffer is sent back to the
+//! I/O thread for reuse, eliminating per-block heap allocations on the hot
+//! path. If the main thread has not yet returned a buffer, the I/O thread
+//! allocates a fresh one as a fallback to avoid stalling.
 //!
 //! # Performance Benefits
 //!
@@ -287,6 +296,220 @@ mod tests {
                 DoubleBufferedReader::with_size_hint(Cursor::new(data), config, Some(1024 * 1024));
 
             let _ = reader.next_block().unwrap();
+        }
+    }
+
+    /// Verifies that pipelined (double-buffered) checksums produce identical
+    /// results to sequential (single-buffer) checksums across various file
+    /// sizes, including smaller-than-block, exact-block, multi-block, and
+    /// partial-last-block cases.
+    #[test]
+    fn pipelined_matches_sequential_various_sizes() {
+        let block_size = 64 * 1024;
+        let sizes: &[usize] = &[
+            0,                  // empty
+            1,                  // single byte
+            100,                // smaller than block
+            block_size - 1,     // one less than block
+            block_size,         // exact block boundary
+            block_size + 1,     // one more than block
+            block_size * 3,     // exact multiple
+            block_size * 3 + 7, // partial last block
+            block_size * 10,    // many blocks
+        ];
+
+        for &size in sizes {
+            let data: Vec<u8> = (0..size).map(|i| (i % 251) as u8).collect();
+
+            let pipelined_config = PipelineConfig::default()
+                .with_block_size(block_size)
+                .with_min_file_size(0)
+                .with_enabled(true);
+            let sequential_config = pipelined_config.with_enabled(false);
+
+            let pipelined = compute_checksums_pipelined::<Md5, _>(
+                Cursor::new(data.clone()),
+                pipelined_config,
+                Some(size as u64),
+            )
+            .unwrap();
+
+            let sequential = compute_checksums_pipelined::<Md5, _>(
+                Cursor::new(data),
+                sequential_config,
+                Some(size as u64),
+            )
+            .unwrap();
+
+            assert_eq!(
+                pipelined.len(),
+                sequential.len(),
+                "block count mismatch for size {size}"
+            );
+            for (i, (p, s)) in pipelined.iter().zip(sequential.iter()).enumerate() {
+                assert_eq!(
+                    p.rolling, s.rolling,
+                    "rolling mismatch at block {i} for size {size}"
+                );
+                assert_eq!(
+                    p.strong.as_ref(),
+                    s.strong.as_ref(),
+                    "strong mismatch at block {i} for size {size}"
+                );
+                assert_eq!(p.len, s.len, "len mismatch at block {i} for size {size}");
+            }
+        }
+    }
+
+    /// Exercises the sync-mode buffer reuse path by reading multiple blocks
+    /// in synchronous mode and verifying all data is correct.
+    #[test]
+    fn sync_mode_reuses_buffer() {
+        let data: Vec<u8> = (0..200).map(|i| (i % 256) as u8).collect();
+        let config = PipelineConfig::default()
+            .with_block_size(50)
+            .with_enabled(false);
+
+        let mut reader = DoubleBufferedReader::new(Cursor::new(data.clone()), config);
+
+        let mut collected = Vec::new();
+        while let Some(block) = reader.next_block().unwrap() {
+            collected.extend_from_slice(block);
+        }
+        assert_eq!(collected, data);
+    }
+
+    /// Verifies that many blocks worth of data are correctly read and
+    /// checksummed in pipelined mode with buffer recycling.
+    #[test]
+    fn many_blocks_pipelined_recycling() {
+        let block_size = 1024;
+        let num_blocks = 100;
+        let data: Vec<u8> = (0..block_size * num_blocks)
+            .map(|i| (i % 256) as u8)
+            .collect();
+
+        let config = PipelineConfig::default()
+            .with_block_size(block_size)
+            .with_min_file_size(0);
+
+        let checksums = compute_checksums_pipelined::<Md5, _>(
+            Cursor::new(data.clone()),
+            config,
+            Some(data.len() as u64),
+        )
+        .unwrap();
+
+        assert_eq!(checksums.len(), num_blocks);
+
+        for (i, cs) in checksums.iter().enumerate() {
+            let start = i * block_size;
+            let end = start + block_size;
+            let block = &data[start..end];
+
+            let expected_rolling = RollingDigest::from_bytes(block);
+            let expected_strong = Md5::digest(block);
+
+            assert_eq!(
+                cs.rolling, expected_rolling,
+                "rolling mismatch at block {i}"
+            );
+            assert_eq!(
+                cs.strong.as_ref(),
+                expected_strong.as_ref(),
+                "strong mismatch at block {i}"
+            );
+        }
+    }
+
+    /// Verifies data integrity when file size is smaller than one block and
+    /// pipelining is forced.
+    #[test]
+    fn single_byte_pipelined() {
+        let data = vec![0x42u8; 1];
+        let config = PipelineConfig::default()
+            .with_block_size(64 * 1024)
+            .with_min_file_size(0);
+
+        let checksums =
+            compute_checksums_pipelined::<Md5, _>(Cursor::new(data.clone()), config, Some(1))
+                .unwrap();
+
+        assert_eq!(checksums.len(), 1);
+        assert_eq!(checksums[0].len, 1);
+        assert_eq!(checksums[0].rolling, RollingDigest::from_bytes(&data));
+    }
+}
+
+#[cfg(test)]
+mod property_tests {
+    use super::*;
+    use crate::RollingDigest;
+    use crate::strong::Md5;
+    use proptest::prelude::*;
+    use std::io::Cursor;
+
+    proptest! {
+        /// Property: for any random data and block size, pipelined checksums
+        /// must be identical to sequential checksums.
+        #[test]
+        fn pipelined_equals_sequential(
+            data in prop::collection::vec(any::<u8>(), 0..512 * 1024),
+            block_size in (64usize..=128 * 1024).prop_map(|s| s.max(1)),
+        ) {
+            let pipelined_config = PipelineConfig::default()
+                .with_block_size(block_size)
+                .with_min_file_size(0)
+                .with_enabled(true);
+            let sequential_config = pipelined_config.with_enabled(false);
+
+            let pipelined = compute_checksums_pipelined::<Md5, _>(
+                Cursor::new(data.clone()),
+                pipelined_config,
+                Some(data.len() as u64),
+            )
+            .unwrap();
+
+            let sequential = compute_checksums_pipelined::<Md5, _>(
+                Cursor::new(data.clone()),
+                sequential_config,
+                Some(data.len() as u64),
+            )
+            .unwrap();
+
+            prop_assert_eq!(pipelined.len(), sequential.len());
+            for (p, s) in pipelined.iter().zip(sequential.iter()) {
+                prop_assert_eq!(p.rolling, s.rolling);
+                prop_assert_eq!(p.strong.as_ref(), s.strong.as_ref());
+                prop_assert_eq!(p.len, s.len);
+            }
+        }
+
+        /// Property: collected data from the double-buffered reader equals
+        /// the original input data, regardless of pipelining mode.
+        #[test]
+        fn reader_collects_all_data(
+            data in prop::collection::vec(any::<u8>(), 0..256 * 1024),
+            block_size in (64usize..=64 * 1024).prop_map(|s| s.max(1)),
+            pipelined in any::<bool>(),
+        ) {
+            let config = PipelineConfig::default()
+                .with_block_size(block_size)
+                .with_min_file_size(0)
+                .with_enabled(pipelined);
+
+            let mut reader = DoubleBufferedReader::with_size_hint(
+                Cursor::new(data.clone()),
+                config,
+                Some(data.len() as u64),
+            );
+
+            let mut collected = Vec::new();
+            while let Some(block) = reader.next_block().unwrap() {
+                collected.extend_from_slice(block);
+            }
+
+            prop_assert_eq!(collected, data);
         }
     }
 }

--- a/crates/checksums/src/pipelined/mod.rs
+++ b/crates/checksums/src/pipelined/mod.rs
@@ -444,7 +444,6 @@ mod tests {
 #[cfg(test)]
 mod property_tests {
     use super::*;
-    use crate::RollingDigest;
     use crate::strong::Md5;
     use proptest::prelude::*;
     use std::io::Cursor;

--- a/crates/checksums/src/pipelined/reader.rs
+++ b/crates/checksums/src/pipelined/reader.rs
@@ -2,6 +2,27 @@
 //!
 //! Spawns a background thread to read the next block while the main thread
 //! processes the current block, achieving I/O-computation overlap.
+//!
+//! # Buffer Recycling
+//!
+//! The reader uses exactly two pre-allocated buffers that swap roles between
+//! the I/O thread and the main thread. After the main thread finishes
+//! processing a block, the buffer is returned to the I/O thread for reuse
+//! via a recycling channel. This eliminates per-block heap allocations on
+//! the hot path.
+//!
+//! ```text
+//! ┌─────────────┐   IoMessage::Block(buf)   ┌───────────────┐
+//! │  I/O Thread  │ ─────────────────────────► │  Main Thread   │
+//! │  (reader)    │                            │  (checksums)   │
+//! │              │ ◄───────────────────────── │                │
+//! └─────────────┘   recycle channel (buf)    └───────────────┘
+//! ```
+//!
+//! If the recycle channel is empty (the main thread has not yet returned a
+//! buffer), the I/O thread allocates a fresh buffer as a fallback. This
+//! graceful degradation avoids blocking the I/O thread when the computation
+//! thread is slower than I/O.
 
 use std::io::{self, Read};
 use std::sync::mpsc::{self, Receiver, Sender};
@@ -24,6 +45,11 @@ enum IoMessage {
 /// Uses a background thread to read the next block while the main thread
 /// processes the current block. This overlaps I/O with computation.
 ///
+/// Two pre-allocated buffers are recycled between the I/O and main threads
+/// via a return channel, eliminating per-block heap allocations on the hot
+/// path. If the main thread has not yet returned a buffer, the I/O thread
+/// allocates a fresh one to avoid stalling.
+///
 /// # Thread Safety
 ///
 /// The reader spawns a background thread for I/O. The thread is automatically
@@ -31,12 +57,16 @@ enum IoMessage {
 pub struct DoubleBufferedReader<R> {
     config: PipelineConfig,
     receiver: Option<Receiver<IoMessage>>,
+    /// Channel for returning consumed buffers to the I/O thread.
+    recycle_sender: Option<Sender<Vec<u8>>>,
     io_thread: Option<JoinHandle<()>>,
     current_block: Option<Vec<u8>>,
     prefetched_block: Option<Vec<u8>>,
     eof_reached: bool,
     direct_reader: Option<R>,
     synchronous: bool,
+    /// Reusable buffer for synchronous mode to avoid per-block allocation.
+    sync_buffer: Option<Vec<u8>>,
 }
 
 impl<R: Read + Send + 'static> DoubleBufferedReader<R> {
@@ -60,34 +90,41 @@ impl<R: Read + Send + 'static> DoubleBufferedReader<R> {
             config.enabled && size_hint.is_none_or(|size| size >= config.min_file_size);
 
         if !should_pipeline {
+            let sync_buf = vec![0u8; config.block_size];
             return Self {
                 config,
                 receiver: None,
+                recycle_sender: None,
                 io_thread: None,
                 current_block: None,
                 prefetched_block: None,
                 eof_reached: false,
                 direct_reader: Some(reader),
                 synchronous: true,
+                sync_buffer: Some(sync_buf),
             };
         }
 
         let (sender, receiver) = mpsc::channel();
+        let (recycle_tx, recycle_rx) = mpsc::channel();
         let block_size = config.block_size;
 
-        // Read first block synchronously to have it ready immediately
+        // Pre-allocate the first of two buffers and read synchronously so
+        // the first `next_block()` call returns immediately.
         let mut first_block = vec![0u8; block_size];
         let first_read = match read_exact_or_eof(&mut reader, &mut first_block) {
             Ok(0) => {
                 return Self {
                     config,
                     receiver: None,
+                    recycle_sender: None,
                     io_thread: None,
                     current_block: None,
                     prefetched_block: None,
                     eof_reached: true,
                     direct_reader: None,
                     synchronous: false,
+                    sync_buffer: None,
                 };
             }
             Ok(n) => {
@@ -98,36 +135,41 @@ impl<R: Read + Send + 'static> DoubleBufferedReader<R> {
                 return Self {
                     config,
                     receiver: None,
+                    recycle_sender: None,
                     io_thread: None,
                     current_block: None,
                     prefetched_block: None,
                     eof_reached: true,
                     direct_reader: Some(reader),
                     synchronous: true,
+                    sync_buffer: None,
                 };
             }
         };
 
         let io_thread = thread::spawn(move || {
-            io_thread_main(reader, sender, block_size);
+            io_thread_main(reader, sender, recycle_rx, block_size);
         });
 
         Self {
             config,
             receiver: Some(receiver),
+            recycle_sender: Some(recycle_tx),
             io_thread: Some(io_thread),
             current_block: first_read,
             prefetched_block: None,
             eof_reached: false,
             direct_reader: None,
             synchronous: false,
+            sync_buffer: None,
         }
     }
 
     /// Returns the next block of data, or `None` if EOF reached.
     ///
     /// Returns data that was pre-read while the previous block was being
-    /// processed, then initiates reading the next block.
+    /// processed, then initiates reading the next block. The previously
+    /// returned buffer is recycled back to the I/O thread for reuse.
     ///
     /// # Errors
     ///
@@ -139,6 +181,11 @@ impl<R: Read + Send + 'static> DoubleBufferedReader<R> {
 
         if self.synchronous {
             return self.next_block_sync();
+        }
+
+        // Recycle the previously consumed buffer back to the I/O thread.
+        if let Some(old_buf) = self.prefetched_block.take() {
+            self.recycle_buffer(old_buf);
         }
 
         let current = self.current_block.take();
@@ -173,13 +220,34 @@ impl<R: Read + Send + 'static> DoubleBufferedReader<R> {
     }
 
     /// Synchronous block reading for small files.
+    ///
+    /// Reuses a single pre-allocated buffer across calls, avoiding per-block
+    /// heap allocation. The buffer cycles through `sync_buffer` (idle) ->
+    /// `current_block` (in use by caller) -> `sync_buffer` (reclaimed on
+    /// next call).
     fn next_block_sync(&mut self) -> io::Result<Option<&[u8]>> {
         if let Some(ref mut reader) = self.direct_reader {
-            let mut buffer = vec![0u8; self.config.block_size];
-            let bytes_read = read_exact_or_eof(reader, &mut buffer)?;
+            // Reclaim the buffer from the previous call if it was not already
+            // returned to sync_buffer (it lives in current_block while the
+            // caller holds a reference).
+            let mut buffer = self
+                .current_block
+                .take()
+                .or_else(|| self.sync_buffer.take())
+                .unwrap_or_else(|| vec![0u8; self.config.block_size]);
+
+            // Restore full capacity for reading. The buffer may have been
+            // truncated for a short final block on a previous call.
+            let block_size = self.config.block_size;
+            if buffer.len() < block_size {
+                buffer.resize(block_size, 0);
+            }
+
+            let bytes_read = read_exact_or_eof(reader, &mut buffer[..block_size])?;
 
             if bytes_read == 0 {
                 self.eof_reached = true;
+                self.sync_buffer = Some(buffer);
                 return Ok(None);
             }
 
@@ -189,6 +257,17 @@ impl<R: Read + Send + 'static> DoubleBufferedReader<R> {
         } else {
             self.eof_reached = true;
             Ok(None)
+        }
+    }
+
+    /// Sends a consumed buffer back to the I/O thread for reuse.
+    ///
+    /// If the recycle channel is disconnected (I/O thread has exited), the
+    /// buffer is silently dropped.
+    fn recycle_buffer(&self, buffer: Vec<u8>) {
+        if let Some(ref tx) = self.recycle_sender {
+            // Ignore send errors - the I/O thread may have already exited.
+            let _ = tx.send(buffer);
         }
     }
 
@@ -207,8 +286,9 @@ impl<R: Read + Send + 'static> DoubleBufferedReader<R> {
 
 impl<R> Drop for DoubleBufferedReader<R> {
     fn drop(&mut self) {
-        // Drop receiver first to signal I/O thread to stop
+        // Drop channels first to signal I/O thread to stop.
         drop(self.receiver.take());
+        drop(self.recycle_sender.take());
 
         if let Some(handle) = self.io_thread.take() {
             let _ = handle.join();
@@ -217,9 +297,31 @@ impl<R> Drop for DoubleBufferedReader<R> {
 }
 
 /// Main loop for the background I/O thread.
-fn io_thread_main<R: Read>(mut reader: R, sender: Sender<IoMessage>, block_size: usize) {
+///
+/// Tries to reuse buffers returned via `recycle_rx` before allocating fresh
+/// ones. This keeps heap allocations to a minimum during steady-state
+/// operation with two recycled buffers.
+fn io_thread_main<R: Read>(
+    mut reader: R,
+    sender: Sender<IoMessage>,
+    recycle_rx: Receiver<Vec<u8>>,
+    block_size: usize,
+) {
     loop {
-        let mut buffer = vec![0u8; block_size];
+        // Try to reuse a recycled buffer. If none is available (main thread
+        // still processing), allocate a fresh buffer as fallback. This avoids
+        // blocking the I/O thread on the main thread's computation speed.
+        let mut buffer = match recycle_rx.try_recv() {
+            Ok(mut buf) => {
+                // Restore full capacity for reading. The main thread may have
+                // truncated the buffer for a short final block.
+                if buf.len() < block_size {
+                    buf.resize(block_size, 0);
+                }
+                buf
+            }
+            Err(_) => vec![0u8; block_size],
+        };
 
         match read_exact_or_eof(&mut reader, &mut buffer) {
             Ok(0) => {


### PR DESCRIPTION
## Summary

- Add a recycle channel (`Sender<Vec<u8>>`) from the main thread back to the I/O thread so consumed buffers are reused instead of allocating fresh ones on every block read
- In pipelined mode, the I/O thread calls `try_recv` on the recycle channel before each read - if a buffer is available it is reused, otherwise a fresh buffer is allocated as fallback to avoid stalling
- In synchronous mode, a single pre-allocated buffer is reclaimed from `current_block` on each call, cycling through idle/in-use/reclaimed without allocation after initial setup
- Add comprehensive tests covering various file sizes (empty, sub-block, exact boundary, partial last block, 100 blocks) and property tests verifying pipelined and sequential checksums always match for random data

Closes #1759

## Test plan

- [ ] CI passes on all platforms (Linux, macOS, Windows)
- [ ] `pipelined_matches_sequential_various_sizes` covers 9 size variants including edge cases
- [ ] `many_blocks_pipelined_recycling` exercises 100 blocks of buffer recycling
- [ ] `sync_mode_reuses_buffer` verifies synchronous buffer reuse
- [ ] Property test `pipelined_equals_sequential` verifies equivalence for random data up to 512 KiB
- [ ] Property test `reader_collects_all_data` verifies no data loss for random data in both modes
- [ ] Existing comprehensive tests and benchmarks pass unchanged (API is backward-compatible)