### PR TITLE
feat: wire io_uring RENAMEAT2 and LINKAT into production paths

### DIFF
--- a/crates/engine/src/local_copy/executor/file/copy/links.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/links.rs
@@ -29,6 +29,17 @@ use ::metadata::apply_file_metadata_with_options;
 use super::super::super::super::CROSS_DEVICE_ERROR_CODE;
 use super::super::guard::remove_existing_destination;
 
+/// Creates a hard link, trying io_uring `IORING_OP_LINKAT` first on Linux 5.15+.
+///
+/// Falls back to `std::fs::hard_link` when io_uring is unavailable or the
+/// kernel lacks the opcode.
+fn hard_link_with_io_uring_fallback(source: &Path, destination: &Path) -> std::io::Result<()> {
+    if let Some(result) = fast_io::try_hard_link_via_io_uring(source, destination) {
+        return result;
+    }
+    fs::hard_link(source, destination)
+}
+
 /// Result of hard-link and reference-directory processing for a file.
 pub(super) struct LinkOutcome {
     pub(super) copy_source_override: Option<PathBuf>,
@@ -76,17 +87,19 @@ pub(super) fn process_links(
     )? {
         let mut attempted_commit = false;
         loop {
-            match fs::hard_link(&link_target, destination) {
+            match hard_link_with_io_uring_fallback(&link_target, destination) {
                 Ok(()) => break,
                 Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
                     remove_existing_destination(destination)?;
-                    fs::hard_link(&link_target, destination).map_err(|link_error| {
-                        LocalCopyError::io(
-                            "create hard link",
-                            destination.to_path_buf(),
-                            link_error,
-                        )
-                    })?;
+                    hard_link_with_io_uring_fallback(&link_target, destination).map_err(
+                        |link_error| {
+                            LocalCopyError::io(
+                                "create hard link",
+                                destination.to_path_buf(),
+                                link_error,
+                            )
+                        },
+                    )?;
                     break;
                 }
                 Err(error)

--- a/crates/engine/src/local_copy/executor/file/guard.rs
+++ b/crates/engine/src/local_copy/executor/file/guard.rs
@@ -301,15 +301,34 @@ impl DestinationWriteGuard {
 
     /// Commits a named temp file via rename with retry logic.
     ///
+    /// On Linux 5.11+ with io_uring available, the rename is submitted as an
+    /// `IORING_OP_RENAMEAT` SQE instead of a synchronous `rename(2)` syscall.
+    /// Falls back to `std::fs::rename` on all other platforms or when the
+    /// kernel lacks the opcode.
+    ///
     /// upstream: `util1.c:robust_rename()` - retry up to 4 times on `ETXTBSY`.
     fn commit_named_temp_file(&self, temp_path: PathBuf) -> Result<(), LocalCopyError> {
         let mut tries = 4u32;
         loop {
-            match fs::rename(&temp_path, &self.final_path) {
+            let rename_result = if let Some(result) =
+                fast_io::try_rename_via_io_uring(&temp_path, &self.final_path)
+            {
+                result
+            } else {
+                fs::rename(&temp_path, &self.final_path)
+            };
+            match rename_result {
                 Ok(()) => return Ok(()),
                 Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
                     remove_existing_destination(&self.final_path)?;
-                    fs::rename(&temp_path, &self.final_path).map_err(|rename_error| {
+                    let retry_result = if let Some(result) =
+                        fast_io::try_rename_via_io_uring(&temp_path, &self.final_path)
+                    {
+                        result
+                    } else {
+                        fs::rename(&temp_path, &self.final_path)
+                    };
+                    retry_result.map_err(|rename_error| {
                         LocalCopyError::io(self.finalise_action(), temp_path.clone(), rename_error)
                     })?;
                     return Ok(());
@@ -761,6 +780,73 @@ mod tests {
             assert!(!dest.exists());
             let count = fs::read_dir(temp.path()).expect("read_dir").count();
             assert_eq!(count, 0);
+        }
+    }
+
+    /// Tests for the io_uring RENAMEAT2 dispatch in `commit_named_temp_file`.
+    ///
+    /// These tests verify that the guard commits correctly regardless of
+    /// whether io_uring handles the rename or the fallback `std::fs::rename`
+    /// does. The dispatch is transparent to callers.
+    mod io_uring_rename_dispatch {
+        use super::*;
+
+        #[test]
+        fn commit_succeeds_via_io_uring_or_fallback() {
+            let temp = tempdir().expect("tempdir");
+            let dest = temp.path().join("iouring_rename.txt");
+
+            let (guard, mut file) =
+                DestinationWriteGuard::new(&dest, false, None, None).expect("guard");
+            file.write_all(b"io_uring rename test").expect("write");
+            drop(file);
+
+            guard.commit().expect("commit must succeed");
+
+            assert!(dest.exists());
+            assert_eq!(
+                fs::read_to_string(&dest).expect("read"),
+                "io_uring rename test"
+            );
+        }
+
+        #[test]
+        fn commit_replaces_existing_via_io_uring_or_fallback() {
+            let temp = tempdir().expect("tempdir");
+            let dest = temp.path().join("iouring_replace.txt");
+
+            fs::write(&dest, b"old content").expect("write existing");
+
+            let (guard, mut file) =
+                DestinationWriteGuard::new(&dest, false, None, None).expect("guard");
+            file.write_all(b"new via io_uring or fallback")
+                .expect("write");
+            drop(file);
+
+            guard.commit().expect("commit must succeed");
+
+            assert_eq!(
+                fs::read_to_string(&dest).expect("read"),
+                "new via io_uring or fallback"
+            );
+        }
+
+        #[test]
+        fn try_rename_via_io_uring_returns_consistent_availability() {
+            let dir = tempfile::tempdir().unwrap();
+            let src = dir.path().join("probe_src.txt");
+            let dst1 = dir.path().join("probe_dst1.txt");
+            let dst2 = dir.path().join("probe_dst2.txt");
+            fs::write(&src, b"data").unwrap();
+
+            let first = fast_io::try_rename_via_io_uring(&src, &dst1).is_some();
+            // If first call consumed the file, recreate.
+            if first {
+                fs::write(&src, b"data").unwrap();
+                let _ = fs::remove_file(&dst1);
+            }
+            let second = fast_io::try_rename_via_io_uring(&src, &dst2).is_some();
+            assert_eq!(first, second, "availability must be consistent");
         }
     }
 }

--- a/crates/engine/src/local_copy/hard_links.rs
+++ b/crates/engine/src/local_copy/hard_links.rs
@@ -15,6 +15,17 @@ use std::path::{Path, PathBuf};
 
 use rustc_hash::FxHashMap;
 
+/// Creates a hard link, trying io_uring `IORING_OP_LINKAT` first on Linux 5.15+.
+///
+/// Falls back to `std::fs::hard_link` when io_uring is unavailable or the
+/// kernel lacks the opcode.
+fn hard_link_with_io_uring_fallback(source: &Path, destination: &Path) -> std::io::Result<()> {
+    if let Some(result) = fast_io::try_hard_link_via_io_uring(source, destination) {
+        return result;
+    }
+    fs::hard_link(source, destination)
+}
+
 /// Tracks completed hardlink leaders by protocol group index during file apply.
 ///
 /// When the receiver commits a leader file to its final destination, it records
@@ -95,7 +106,7 @@ impl HardlinkApplyTracker {
             if follower_dest.symlink_metadata().is_ok() {
                 fs::remove_file(follower_dest)?;
             }
-            fs::hard_link(leader_path, follower_dest)?;
+            hard_link_with_io_uring_fallback(leader_path, follower_dest)?;
             Ok(HardlinkApplyResult::Linked)
         } else {
             self.deferred
@@ -165,7 +176,7 @@ impl HardlinkApplyTracker {
                         continue;
                     }
                 }
-                match fs::hard_link(&leader_path, &follower) {
+                match hard_link_with_io_uring_fallback(&leader_path, &follower) {
                     Ok(()) => linked += 1,
                     Err(e) => errors.push((follower, e)),
                 }
@@ -1213,5 +1224,115 @@ mod apply_tracker_tests {
 
         // nlink should be 11 (1 leader + 10 followers)
         assert_eq!(std::fs::metadata(&leader).unwrap().nlink(), 11);
+    }
+}
+
+/// Tests for the io_uring LINKAT dispatch in hardlink creation.
+///
+/// These tests verify that `hard_link_with_io_uring_fallback` works correctly
+/// regardless of whether io_uring handles the link or `std::fs::hard_link`
+/// does.
+#[cfg(test)]
+mod io_uring_linkat_dispatch_tests {
+    use super::*;
+
+    #[test]
+    fn hard_link_via_io_uring_or_fallback_creates_link() {
+        let temp = test_support::create_tempdir();
+        let src = temp.path().join("linkat_src.txt");
+        let dst = temp.path().join("linkat_dst.txt");
+        std::fs::write(&src, b"linkat dispatch test").unwrap();
+
+        hard_link_with_io_uring_fallback(&src, &dst).expect("hard link must succeed");
+
+        assert!(src.exists());
+        assert!(dst.exists());
+        assert_eq!(
+            std::fs::read_to_string(&dst).unwrap(),
+            "linkat dispatch test"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn hard_link_via_io_uring_or_fallback_shares_inode() {
+        use std::os::unix::fs::MetadataExt;
+
+        let temp = test_support::create_tempdir();
+        let src = temp.path().join("linkat_inode_src.txt");
+        let dst = temp.path().join("linkat_inode_dst.txt");
+        std::fs::write(&src, b"inode check").unwrap();
+
+        hard_link_with_io_uring_fallback(&src, &dst).expect("hard link must succeed");
+
+        let src_ino = std::fs::metadata(&src).unwrap().ino();
+        let dst_ino = std::fs::metadata(&dst).unwrap().ino();
+        assert_eq!(src_ino, dst_ino, "hard link must share same inode");
+    }
+
+    #[test]
+    fn apply_follower_uses_io_uring_or_fallback() {
+        let temp = test_support::create_tempdir();
+        let leader = temp.path().join("leader_dispatch.txt");
+        let follower = temp.path().join("follower_dispatch.txt");
+        std::fs::write(&leader, b"dispatch content").unwrap();
+
+        let mut tracker = HardlinkApplyTracker::new();
+        tracker.record_leader(42, leader.clone());
+
+        let result = tracker.apply_follower(42, &follower).unwrap();
+        assert_eq!(result, HardlinkApplyResult::Linked);
+        assert_eq!(
+            std::fs::read_to_string(&follower).unwrap(),
+            "dispatch content"
+        );
+    }
+
+    #[test]
+    fn resolve_deferred_uses_io_uring_or_fallback() {
+        let temp = test_support::create_tempdir();
+        let leader = temp.path().join("deferred_leader.txt");
+        let follower1 = temp.path().join("deferred_f1.txt");
+        let follower2 = temp.path().join("deferred_f2.txt");
+
+        std::fs::write(&leader, b"deferred content").unwrap();
+
+        let mut tracker = HardlinkApplyTracker::new();
+        tracker.record_leader(77, leader.clone());
+        tracker
+            .deferred
+            .entry(77)
+            .or_default()
+            .push(follower1.clone());
+        tracker
+            .deferred
+            .entry(77)
+            .or_default()
+            .push(follower2.clone());
+
+        let (linked, errors) = tracker.resolve_deferred();
+        assert_eq!(linked, 2);
+        assert!(errors.is_empty());
+        assert_eq!(
+            std::fs::read_to_string(&follower1).unwrap(),
+            "deferred content"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&follower2).unwrap(),
+            "deferred content"
+        );
+    }
+
+    #[test]
+    fn try_hard_link_via_io_uring_returns_consistent_availability() {
+        let dir = test_support::create_tempdir();
+        let src = dir.path().join("probe_src.txt");
+        let dst1 = dir.path().join("probe_dst1.txt");
+        let dst2 = dir.path().join("probe_dst2.txt");
+        std::fs::write(&src, b"data").unwrap();
+
+        let first = fast_io::try_hard_link_via_io_uring(&src, &dst1).is_some();
+        let second = fast_io::try_hard_link_via_io_uring(&src, &dst2).is_some();
+        assert_eq!(first, second, "availability must be consistent");
     }
 }

--- a/crates/engine/src/local_copy/overrides.rs
+++ b/crates/engine/src/local_copy/overrides.rs
@@ -41,6 +41,12 @@ where
     result
 }
 
+/// Creates a hard link from `source` to `destination`.
+///
+/// On Linux 5.15+ with io_uring available, the link is submitted as an
+/// `IORING_OP_LINKAT` SQE instead of a synchronous `link(2)` syscall.
+/// Falls back to `std::fs::hard_link` on all other platforms or when the
+/// kernel lacks the opcode.
 pub(super) fn create_hard_link(source: &Path, destination: &Path) -> io::Result<()> {
     #[cfg(test)]
     if let Some(result) = HARD_LINK_OVERRIDE.with(|cell| {
@@ -51,6 +57,9 @@ pub(super) fn create_hard_link(source: &Path, destination: &Path) -> io::Result<
         return result;
     }
 
+    if let Some(result) = fast_io::try_hard_link_via_io_uring(source, destination) {
+        return result;
+    }
     fs::hard_link(source, destination)
 }
 

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -376,6 +376,131 @@ pub fn platform_io_capabilities() -> Vec<&'static str> {
     caps
 }
 
+/// Attempts to rename a file via io_uring `IORING_OP_RENAMEAT`.
+///
+/// On Linux with kernel 5.11+ and io_uring available, submits a blocking
+/// RENAMEAT2 SQE on a transient ring and returns the result. On all other
+/// platforms, or when the kernel lacks the opcode, returns `None` so the
+/// caller can fall back to `std::fs::rename`.
+///
+/// This follows the same try-or-fallback pattern used by the splice and
+/// copy-file-range paths: the caller checks the `Option` and falls through
+/// to the portable implementation when `None` is returned.
+///
+/// # Errors
+///
+/// Returns `Some(Err(...))` when io_uring is available and the rename was
+/// submitted but the kernel returned an error (e.g., `ENOENT`, `EACCES`).
+#[must_use]
+pub fn try_rename_via_io_uring(
+    old_path: &std::path::Path,
+    new_path: &std::path::Path,
+) -> Option<std::io::Result<()>> {
+    try_rename_via_io_uring_impl(old_path, new_path)
+}
+
+#[cfg(all(target_os = "linux", feature = "io_uring"))]
+fn try_rename_via_io_uring_impl(
+    old_path: &std::path::Path,
+    new_path: &std::path::Path,
+) -> Option<std::io::Result<()>> {
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt;
+
+    if !renameat2_supported() {
+        return None;
+    }
+    let old_c = match CString::new(old_path.as_os_str().as_bytes()) {
+        Ok(c) => c,
+        Err(_) => return Some(Err(std::io::Error::other("path contains interior NUL"))),
+    };
+    let new_c = match CString::new(new_path.as_os_str().as_bytes()) {
+        Ok(c) => c,
+        Err(_) => return Some(Err(std::io::Error::other("path contains interior NUL"))),
+    };
+    let args = RenameAt2Args {
+        old_dir_fd: libc::AT_FDCWD,
+        old_path: &old_c,
+        new_dir_fd: libc::AT_FDCWD,
+        new_path: &new_c,
+        flags: 0,
+    };
+    match renameat2_blocking(args) {
+        Ok(result) if result < 0 => Some(Err(std::io::Error::from_raw_os_error(-result))),
+        Ok(_) => Some(Ok(())),
+        Err(e) if e.kind() == std::io::ErrorKind::Unsupported => None,
+        Err(e) => Some(Err(e)),
+    }
+}
+
+#[cfg(not(all(target_os = "linux", feature = "io_uring")))]
+fn try_rename_via_io_uring_impl(
+    _old_path: &std::path::Path,
+    _new_path: &std::path::Path,
+) -> Option<std::io::Result<()>> {
+    None
+}
+
+/// Attempts to create a hard link via io_uring `IORING_OP_LINKAT`.
+///
+/// On Linux with kernel 5.15+ and io_uring available, submits a blocking
+/// LINKAT SQE on a transient ring and returns the result. On all other
+/// platforms, or when the kernel lacks the opcode, returns `None` so the
+/// caller can fall back to `std::fs::hard_link`.
+///
+/// # Errors
+///
+/// Returns `Some(Err(...))` when io_uring is available and the link was
+/// submitted but the kernel returned an error (e.g., `EEXIST`, `EACCES`).
+#[must_use]
+pub fn try_hard_link_via_io_uring(
+    src_path: &std::path::Path,
+    dst_path: &std::path::Path,
+) -> Option<std::io::Result<()>> {
+    try_hard_link_via_io_uring_impl(src_path, dst_path)
+}
+
+#[cfg(all(target_os = "linux", feature = "io_uring"))]
+fn try_hard_link_via_io_uring_impl(
+    src_path: &std::path::Path,
+    dst_path: &std::path::Path,
+) -> Option<std::io::Result<()>> {
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt;
+
+    if !linkat_supported() {
+        return None;
+    }
+    let old_c = match CString::new(src_path.as_os_str().as_bytes()) {
+        Ok(c) => c,
+        Err(_) => return Some(Err(std::io::Error::other("path contains interior NUL"))),
+    };
+    let new_c = match CString::new(dst_path.as_os_str().as_bytes()) {
+        Ok(c) => c,
+        Err(_) => return Some(Err(std::io::Error::other("path contains interior NUL"))),
+    };
+    let args = LinkAtArgs {
+        old_dirfd: libc::AT_FDCWD,
+        old_path: &old_c,
+        new_dirfd: libc::AT_FDCWD,
+        new_path: &new_c,
+        flags: 0,
+    };
+    match submit_linkat_blocking(args) {
+        Ok(_) => Some(Ok(())),
+        Err(e) if e.kind() == std::io::ErrorKind::Unsupported => None,
+        Err(e) => Some(Err(e)),
+    }
+}
+
+#[cfg(not(all(target_os = "linux", feature = "io_uring")))]
+fn try_hard_link_via_io_uring_impl(
+    _src_path: &std::path::Path,
+    _dst_path: &std::path::Path,
+) -> Option<std::io::Result<()>> {
+    None
+}
+
 /// Minimum value accepted for the io_uring submission queue depth tunable.
 ///
 /// The kernel rejects rings with zero entries, so callers must request at
@@ -1049,5 +1174,132 @@ mod io_uring_fallback_tests {
             matches!(writer, IoUringOrStdWriter::Std(_)),
             "sized writer must be Std variant on non-Linux"
         );
+    }
+}
+
+#[cfg(test)]
+mod io_uring_rename_dispatch_tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn try_rename_via_io_uring_renames_or_returns_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("rename_src.txt");
+        let dst = dir.path().join("rename_dst.txt");
+        fs::write(&src, b"rename payload").unwrap();
+
+        match try_rename_via_io_uring(&src, &dst) {
+            Some(Ok(())) => {
+                // io_uring path succeeded - verify file moved.
+                assert!(!src.exists());
+                assert_eq!(fs::read(&dst).unwrap(), b"rename payload");
+            }
+            Some(Err(e)) => {
+                panic!("io_uring rename returned error: {e}");
+            }
+            None => {
+                // Not available on this platform/kernel - file untouched.
+                assert!(src.exists());
+                assert!(!dst.exists());
+            }
+        }
+    }
+
+    #[test]
+    fn try_rename_via_io_uring_returns_none_consistently() {
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("consistency_src.txt");
+        let dst = dir.path().join("consistency_dst.txt");
+        fs::write(&src, b"data").unwrap();
+
+        let first = try_rename_via_io_uring(&src, &dst).is_some();
+        // If first call consumed the file, recreate for second probe.
+        if first {
+            fs::write(&src, b"data").unwrap();
+            let _ = fs::remove_file(&dst);
+        }
+        let second = try_rename_via_io_uring(&src, &dst).is_some();
+        assert_eq!(
+            first, second,
+            "availability must be consistent across calls"
+        );
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    #[test]
+    fn try_rename_via_io_uring_returns_none_on_non_linux() {
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("non_linux_src.txt");
+        let dst = dir.path().join("non_linux_dst.txt");
+        fs::write(&src, b"data").unwrap();
+
+        assert!(
+            try_rename_via_io_uring(&src, &dst).is_none(),
+            "must return None on non-Linux platforms"
+        );
+        assert!(src.exists(), "source must be untouched");
+    }
+}
+
+#[cfg(test)]
+mod io_uring_hard_link_dispatch_tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn try_hard_link_via_io_uring_links_or_returns_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("link_src.txt");
+        let dst = dir.path().join("link_dst.txt");
+        fs::write(&src, b"link payload").unwrap();
+
+        match try_hard_link_via_io_uring(&src, &dst) {
+            Some(Ok(())) => {
+                // io_uring path succeeded - verify hard link created.
+                assert!(src.exists());
+                assert!(dst.exists());
+                assert_eq!(fs::read(&dst).unwrap(), b"link payload");
+            }
+            Some(Err(e)) => {
+                panic!("io_uring hard_link returned error: {e}");
+            }
+            None => {
+                // Not available on this platform/kernel.
+                assert!(src.exists());
+                assert!(!dst.exists());
+            }
+        }
+    }
+
+    #[test]
+    fn try_hard_link_via_io_uring_returns_none_consistently() {
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("link_consistency_src.txt");
+        let dst1 = dir.path().join("link_consistency_dst1.txt");
+        let dst2 = dir.path().join("link_consistency_dst2.txt");
+        fs::write(&src, b"data").unwrap();
+
+        let first = try_hard_link_via_io_uring(&src, &dst1).is_some();
+        let second = try_hard_link_via_io_uring(&src, &dst2).is_some();
+        assert_eq!(
+            first, second,
+            "availability must be consistent across calls"
+        );
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    #[test]
+    fn try_hard_link_via_io_uring_returns_none_on_non_linux() {
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("non_linux_link_src.txt");
+        let dst = dir.path().join("non_linux_link_dst.txt");
+        fs::write(&src, b"data").unwrap();
+
+        assert!(
+            try_hard_link_via_io_uring(&src, &dst).is_none(),
+            "must return None on non-Linux platforms"
+        );
+        assert!(!dst.exists(), "destination must not exist");
     }
 }


### PR DESCRIPTION
## Summary

- Wire `IORING_OP_RENAMEAT` (kernel 5.11+) into the temp-file commit path (`DestinationWriteGuard::commit_named_temp_file`), replacing synchronous `rename(2)` when io_uring is available
- Wire `IORING_OP_LINKAT` (kernel 5.15+) into all hardlink creation paths (`HardlinkApplyTracker::apply_follower`, `resolve_deferred`, `create_hard_link` override, and `--link-dest` linking), replacing synchronous `link(2)` when io_uring is available
- Add `try_rename_via_io_uring()` and `try_hard_link_via_io_uring()` convenience functions to `fast_io` that return `Option<io::Result<()>>` for transparent fallback
- All paths fall back to `std::fs::rename` / `std::fs::hard_link` on non-Linux, older kernels, or when io_uring is disabled
- Cross-platform: `#[cfg]`-gated implementations return `None` on non-Linux; no compilation impact on macOS/Windows

Closes #1924, closes #1925.

## Test plan

- [ ] Verify `cargo fmt --all -- --check` passes
- [ ] Verify `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` passes
- [ ] CI: nextest on Linux (stable) - exercises io_uring path on supported kernels
- [ ] CI: macOS (stable) - exercises fallback path, no io_uring
- [ ] CI: Windows (stable) - exercises fallback path, no io_uring
- [ ] CI: Linux musl (stable) - exercises io_uring or fallback depending on kernel
- [ ] New tests in `fast_io`: `io_uring_rename_dispatch_tests`, `io_uring_hard_link_dispatch_tests`
- [ ] New tests in `engine`: `io_uring_rename_dispatch` (guard), `io_uring_linkat_dispatch_tests` (hard_links)