### PR TITLE
feat(transfer): add ReorderBuffer stall-duration and queue-depth metrics

### DIFF
--- a/crates/transfer/src/reorder_buffer.rs
+++ b/crates/transfer/src/reorder_buffer.rs
@@ -21,15 +21,66 @@
 //! This buffer restores sequential ordering after parallel delta dispatch.
 
 use std::collections::BTreeMap;
+use std::time::Instant;
 
 /// Default window size for the bounded reorder buffer.
 pub const DEFAULT_WINDOW_SIZE: u64 = 64;
+
+/// Snapshot of reorder buffer stall and depth metrics.
+///
+/// Returned by [`BoundedReorderBuffer::metrics`]. All counters are monotonically
+/// non-decreasing over the buffer's lifetime except `current_depth`, which
+/// tracks the instantaneous queue depth.
+///
+/// The stall duration measures head-of-line blocking: how long items waited
+/// because their predecessor had not yet arrived. High stall counts with
+/// large mean durations indicate the parallel dispatch is bottlenecked on
+/// a slow straggler, and the parallel threshold or window size may need tuning.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ReorderBufferStats {
+    /// Number of items currently buffered (awaiting delivery).
+    pub current_depth: u64,
+    /// High-water mark of buffered items across the buffer's lifetime.
+    pub peak_depth: u64,
+    /// Number of distinct stall episodes. A stall begins when a non-head
+    /// item is inserted into an empty buffer (the head slot is missing),
+    /// and ends when `next_expected` advances (the head arrives and drains).
+    pub stall_count: u64,
+    /// Cumulative wall-clock nanoseconds spent in stall episodes.
+    pub total_stall_nanos: u64,
+    /// Total number of items delivered in-order from the buffer.
+    pub items_delivered: u64,
+}
+
+impl ReorderBufferStats {
+    /// Returns the mean stall duration in nanoseconds.
+    ///
+    /// Returns zero when no stalls have occurred, avoiding division by zero.
+    #[must_use]
+    pub const fn mean_stall_nanos(&self) -> u64 {
+        if self.stall_count == 0 {
+            0
+        } else {
+            self.total_stall_nanos / self.stall_count
+        }
+    }
+}
+
+/// Clock function type used by the reorder buffer for stall timing.
+///
+/// Defaults to [`Instant::now`]. Tests can inject a deterministic clock
+/// via [`BoundedReorderBuffer::with_clock`] for reproducible stall
+/// duration assertions.
+type ClockFn = Box<dyn Fn() -> Instant + Send>;
 
 /// Bounded sliding-window reorder buffer with backpressure.
 ///
 /// Guarantees in-order delivery while bounding memory to at most
 /// `window_size` buffered items. Producers that exceed the window
 /// receive a backpressure signal to throttle submission.
+///
+/// Tracks stall-duration and queue-depth metrics for pipeline tuning.
+/// Use [`metrics`](Self::metrics) to retrieve a snapshot of counters.
 ///
 /// # Invariant
 ///
@@ -52,7 +103,6 @@ pub const DEFAULT_WINDOW_SIZE: u64 = 64;
 /// let drained = buf.insert(0, "a").unwrap();
 /// assert_eq!(drained, vec!["a", "b", "c"]);
 /// ```
-#[derive(Debug)]
 #[must_use]
 pub struct BoundedReorderBuffer<T> {
     /// Next sequence number expected for in-order delivery.
@@ -61,6 +111,18 @@ pub struct BoundedReorderBuffer<T> {
     window_size: u64,
     /// Out-of-order items waiting for gaps to fill.
     pending: BTreeMap<u64, T>,
+    /// High-water mark of `pending.len()` across the buffer's lifetime.
+    peak_depth: u64,
+    /// Number of distinct stall episodes.
+    stall_count: u64,
+    /// Cumulative nanoseconds spent in stall episodes.
+    total_stall_nanos: u64,
+    /// Total items delivered via `drain_consecutive`.
+    items_delivered: u64,
+    /// Start instant of the current stall episode, if any.
+    stall_start: Option<Instant>,
+    /// Clock source for stall timing.
+    clock: ClockFn,
 }
 
 /// Items drained from the buffer in sequence order.
@@ -97,18 +159,54 @@ impl std::fmt::Display for BackpressureError {
 
 impl std::error::Error for BackpressureError {}
 
+impl<T: std::fmt::Debug> std::fmt::Debug for BoundedReorderBuffer<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BoundedReorderBuffer")
+            .field("next_expected", &self.next_expected)
+            .field("window_size", &self.window_size)
+            .field("pending", &self.pending)
+            .field("peak_depth", &self.peak_depth)
+            .field("stall_count", &self.stall_count)
+            .field("total_stall_nanos", &self.total_stall_nanos)
+            .field("items_delivered", &self.items_delivered)
+            .field("stall_active", &self.stall_start.is_some())
+            .finish()
+    }
+}
+
 impl<T> BoundedReorderBuffer<T> {
     /// Creates a new bounded reorder buffer with the given window size.
+    ///
+    /// Uses [`Instant::now`] as the clock source for stall timing.
     ///
     /// # Panics
     ///
     /// Panics if `window_size` is zero.
     pub fn new(window_size: u64) -> Self {
+        Self::with_clock(window_size, Box::new(Instant::now))
+    }
+
+    /// Creates a new bounded reorder buffer with a custom clock source.
+    ///
+    /// The `clock` function is called to obtain timestamps for stall duration
+    /// measurement. Tests can inject a deterministic clock for reproducible
+    /// assertions on stall timing.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `window_size` is zero.
+    pub fn with_clock(window_size: u64, clock: ClockFn) -> Self {
         assert!(window_size > 0, "window size must be non-zero");
         Self {
             next_expected: 0,
             window_size,
             pending: BTreeMap::new(),
+            peak_depth: 0,
+            stall_count: 0,
+            total_stall_nanos: 0,
+            items_delivered: 0,
+            stall_start: None,
+            clock,
         }
     }
 
@@ -121,6 +219,10 @@ impl<T> BoundedReorderBuffer<T> {
     /// Returns `Err(BackpressureError)` if `seq` is outside the window. Items
     /// with `seq < next_expected` (already delivered) are silently ignored and
     /// return an empty drain.
+    ///
+    /// Stall metrics are updated on each call: a stall episode begins when
+    /// a non-head item is inserted into an empty buffer, and ends when the
+    /// head item arrives and triggers a drain.
     ///
     /// # Errors
     ///
@@ -141,8 +243,34 @@ impl<T> BoundedReorderBuffer<T> {
             });
         }
 
+        // Detect stall start: inserting a non-head item into an empty buffer
+        // means the head is missing and subsequent items will block.
+        let was_empty = self.pending.is_empty();
+        if was_empty && seq != self.next_expected && self.stall_start.is_none() {
+            self.stall_start = Some((self.clock)());
+            self.stall_count += 1;
+        }
+
         self.pending.insert(seq, item);
-        Ok(self.drain_consecutive())
+
+        // Update peak depth after insertion.
+        let depth = self.pending.len() as u64;
+        if depth > self.peak_depth {
+            self.peak_depth = depth;
+        }
+
+        let prev_expected = self.next_expected;
+        let drained = self.drain_consecutive();
+
+        // If the drain advanced next_expected, the stall (if any) has ended.
+        if self.next_expected > prev_expected {
+            if let Some(start) = self.stall_start.take() {
+                let elapsed = (self.clock)().duration_since(start);
+                self.total_stall_nanos += elapsed.as_nanos() as u64;
+            }
+        }
+
+        Ok(drained)
     }
 
     /// Drains all consecutive items starting from `next_expected`.
@@ -151,8 +279,25 @@ impl<T> BoundedReorderBuffer<T> {
         while let Some(item) = self.pending.remove(&self.next_expected) {
             items.push(item);
             self.next_expected += 1;
+            self.items_delivered += 1;
         }
         items
+    }
+
+    /// Returns a snapshot of stall-duration and queue-depth metrics.
+    ///
+    /// The returned stats reflect the cumulative state since the buffer was
+    /// created. All counters are monotonically non-decreasing except
+    /// `current_depth`, which tracks the instantaneous queue depth.
+    #[must_use]
+    pub fn metrics(&self) -> ReorderBufferStats {
+        ReorderBufferStats {
+            current_depth: self.pending.len() as u64,
+            peak_depth: self.peak_depth,
+            stall_count: self.stall_count,
+            total_stall_nanos: self.total_stall_nanos,
+            items_delivered: self.items_delivered,
+        }
     }
 
     /// Returns the next sequence number expected for in-order delivery.
@@ -562,6 +707,276 @@ mod tests {
                     outcome.is_ok(),
                     "producer body panicked under abort",
                 );
+            }
+        }
+    }
+
+    /// Tests for stall-duration and queue-depth metrics.
+    mod metrics_tests {
+        use super::*;
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicU64, Ordering};
+        use std::time::{Duration, Instant};
+
+        /// Builds a deterministic clock that advances by `step` on each call.
+        ///
+        /// Returns a boxed closure suitable for `BoundedReorderBuffer::with_clock`.
+        /// The clock starts at `Instant::now()` and increments monotonically.
+        fn fake_clock(step: Duration) -> ClockFn {
+            let base = Instant::now();
+            let counter = Arc::new(AtomicU64::new(0));
+            Box::new(move || {
+                let n = counter.fetch_add(1, Ordering::Relaxed);
+                base + step * n as u32
+            })
+        }
+
+        #[test]
+        fn in_order_delivery_no_stall() {
+            let mut buf: BoundedReorderBuffer<&str> =
+                BoundedReorderBuffer::with_clock(8, fake_clock(Duration::from_millis(10)));
+
+            buf.insert(0, "a").unwrap();
+            buf.insert(1, "b").unwrap();
+            buf.insert(2, "c").unwrap();
+            buf.insert(3, "d").unwrap();
+
+            let m = buf.metrics();
+            assert_eq!(
+                m.stall_count, 0,
+                "in-order delivery must produce zero stalls"
+            );
+            assert_eq!(m.total_stall_nanos, 0);
+            assert_eq!(m.mean_stall_nanos(), 0);
+            assert_eq!(m.items_delivered, 4);
+            assert_eq!(m.current_depth, 0);
+            // Each in-order insert momentarily has depth 1 before draining.
+            assert_eq!(m.peak_depth, 1);
+        }
+
+        #[test]
+        fn out_of_order_produces_stall() {
+            let step = Duration::from_millis(100);
+            let mut buf: BoundedReorderBuffer<&str> =
+                BoundedReorderBuffer::with_clock(8, fake_clock(step));
+
+            // Insert seq 3 first - stall begins (non-head into empty buffer).
+            // Clock call 0: entry check, clock call 1: after drain (no drain).
+            buf.insert(3, "d").unwrap();
+            buf.insert(1, "b").unwrap();
+            buf.insert(2, "c").unwrap();
+
+            let m = buf.metrics();
+            assert_eq!(m.stall_count, 1, "one stall episode expected");
+            assert_eq!(m.current_depth, 3);
+            assert_eq!(m.peak_depth, 3);
+            assert_eq!(m.items_delivered, 0);
+            assert!(
+                m.total_stall_nanos == 0,
+                "stall not yet resolved - total should be 0"
+            );
+
+            // Insert seq 0 - fills the gap, stall ends, all 4 drain.
+            buf.insert(0, "a").unwrap();
+
+            let m = buf.metrics();
+            assert_eq!(m.stall_count, 1);
+            assert_eq!(m.items_delivered, 4);
+            assert_eq!(m.current_depth, 0);
+            assert_eq!(m.peak_depth, 4);
+            assert!(
+                m.total_stall_nanos > 0,
+                "stall resolved - total_stall_nanos must be positive"
+            );
+        }
+
+        #[test]
+        fn multiple_stall_episodes() {
+            let mut buf: BoundedReorderBuffer<u64> =
+                BoundedReorderBuffer::with_clock(16, fake_clock(Duration::from_millis(50)));
+
+            // Episode 1: insert seq 2, then 1, then 0.
+            buf.insert(2, 2).unwrap();
+            buf.insert(1, 1).unwrap();
+            buf.insert(0, 0).unwrap();
+
+            let m = buf.metrics();
+            assert_eq!(m.stall_count, 1);
+            assert_eq!(m.items_delivered, 3);
+            assert!(m.total_stall_nanos > 0);
+
+            // Episode 2: insert seq 5, then 4, then 3.
+            buf.insert(5, 5).unwrap();
+            buf.insert(4, 4).unwrap();
+            buf.insert(3, 3).unwrap();
+
+            let m = buf.metrics();
+            assert_eq!(m.stall_count, 2, "two distinct stall episodes");
+            assert_eq!(m.items_delivered, 6);
+        }
+
+        #[test]
+        fn peak_depth_monotonically_nondecreasing() {
+            let mut buf: BoundedReorderBuffer<u64> = BoundedReorderBuffer::new(64);
+
+            let mut last_peak = 0u64;
+
+            // Insert in reverse order 0..50 to build up depth.
+            for i in (0..50).rev() {
+                buf.insert(i, i).unwrap();
+                let m = buf.metrics();
+                assert!(
+                    m.peak_depth >= last_peak,
+                    "peak_depth must be monotonically non-decreasing: {} < {}",
+                    m.peak_depth,
+                    last_peak
+                );
+                last_peak = m.peak_depth;
+            }
+
+            assert_eq!(last_peak, 50, "peak should reach 50 items");
+
+            // After full drain, peak stays at 50.
+            let m = buf.metrics();
+            assert_eq!(m.peak_depth, 50);
+            assert_eq!(m.current_depth, 0);
+        }
+
+        #[test]
+        fn queue_depth_tracks_buffered_count() {
+            let mut buf: BoundedReorderBuffer<&str> = BoundedReorderBuffer::new(16);
+
+            buf.insert(3, "d").unwrap();
+            assert_eq!(buf.metrics().current_depth, 1);
+
+            buf.insert(5, "f").unwrap();
+            assert_eq!(buf.metrics().current_depth, 2);
+
+            buf.insert(4, "e").unwrap();
+            assert_eq!(buf.metrics().current_depth, 3);
+
+            // Insert head - drains 0 items since 0 is missing, but seq 3 is
+            // head-adjacent. Actually next_expected is 0, so inserting 3,5,4
+            // leaves the head at 0. Nothing drains.
+            assert_eq!(buf.metrics().current_depth, 3);
+            assert_eq!(buf.metrics().current_depth, buf.buffered_count() as u64);
+        }
+
+        #[test]
+        fn items_delivered_counts_all_drained() {
+            let mut buf: BoundedReorderBuffer<u64> = BoundedReorderBuffer::new(8);
+
+            for i in 0..5 {
+                buf.insert(i, i).unwrap();
+            }
+            assert_eq!(buf.metrics().items_delivered, 5);
+
+            // Insert more after gap.
+            buf.insert(7, 7).unwrap();
+            buf.insert(6, 6).unwrap();
+            buf.insert(5, 5).unwrap();
+            assert_eq!(buf.metrics().items_delivered, 8);
+        }
+
+        #[test]
+        fn mean_stall_nanos_derived_correctly() {
+            let stats = ReorderBufferStats {
+                current_depth: 0,
+                peak_depth: 5,
+                stall_count: 4,
+                total_stall_nanos: 1_000_000,
+                items_delivered: 10,
+            };
+            assert_eq!(stats.mean_stall_nanos(), 250_000);
+        }
+
+        #[test]
+        fn mean_stall_nanos_zero_when_no_stalls() {
+            let stats = ReorderBufferStats::default();
+            assert_eq!(stats.mean_stall_nanos(), 0);
+        }
+
+        #[test]
+        fn stale_insert_does_not_affect_metrics() {
+            let mut buf: BoundedReorderBuffer<u64> = BoundedReorderBuffer::new(8);
+            buf.insert(0, 0).unwrap();
+            buf.insert(1, 1).unwrap();
+
+            let m_before = buf.metrics();
+
+            // Stale insert (seq 0 already delivered).
+            buf.insert(0, 99).unwrap();
+
+            let m_after = buf.metrics();
+            assert_eq!(m_before.stall_count, m_after.stall_count);
+            assert_eq!(m_before.peak_depth, m_after.peak_depth);
+            assert_eq!(m_before.items_delivered, m_after.items_delivered);
+        }
+
+        /// Property test: monotonic counters across random permutations.
+        mod prop_metrics {
+            use super::*;
+            use proptest::prelude::*;
+
+            proptest! {
+                #[test]
+                fn counters_monotonic_across_permutation(n in 1u64..128) {
+                    let window = n.max(1);
+                    let mut buf = BoundedReorderBuffer::new(window);
+
+                    let mut indices: Vec<u64> = (0..n).collect();
+                    indices.reverse();
+
+                    let mut prev_stall_count = 0u64;
+                    let mut prev_peak = 0u64;
+                    let mut prev_total_stall = 0u64;
+
+                    for seq in indices {
+                        buf.insert(seq, seq).unwrap();
+                        let m = buf.metrics();
+
+                        prop_assert!(
+                            m.stall_count >= prev_stall_count,
+                            "stall_count must be monotonically non-decreasing"
+                        );
+                        prop_assert!(
+                            m.peak_depth >= prev_peak,
+                            "peak_depth must be monotonically non-decreasing"
+                        );
+                        prop_assert!(
+                            m.total_stall_nanos >= prev_total_stall,
+                            "total_stall_nanos must be monotonically non-decreasing"
+                        );
+                        prop_assert!(
+                            m.peak_depth >= m.current_depth,
+                            "peak_depth must be >= current_depth"
+                        );
+
+                        prev_stall_count = m.stall_count;
+                        prev_peak = m.peak_depth;
+                        prev_total_stall = m.total_stall_nanos;
+                    }
+
+                    // After full drain, all items delivered.
+                    let final_m = buf.metrics();
+                    prop_assert_eq!(final_m.items_delivered, n);
+                    prop_assert_eq!(final_m.current_depth, 0);
+                }
+
+                #[test]
+                fn identity_permutation_zero_stalls(n in 1u64..128) {
+                    let window = n.max(1);
+                    let mut buf = BoundedReorderBuffer::new(window);
+
+                    for seq in 0..n {
+                        buf.insert(seq, seq).unwrap();
+                    }
+
+                    let m = buf.metrics();
+                    prop_assert_eq!(m.stall_count, 0, "identity permutation must have zero stalls");
+                    prop_assert_eq!(m.total_stall_nanos, 0);
+                    prop_assert_eq!(m.items_delivered, n);
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

- Add `ReorderBufferStats` struct with five counters: `current_depth`, `peak_depth`, `stall_count`, `total_stall_nanos`, and `items_delivered` to the `BoundedReorderBuffer` in the transfer crate
- Instrument `insert()` to track stall episodes (head-of-line blocking when a non-head item arrives into an empty buffer) and queue depth high-water marks
- Add `metrics()` accessor returning a snapshot of all counters, plus `mean_stall_nanos()` derived accessor
- Support deterministic clock injection via `with_clock()` constructor for reproducible test assertions on stall timing

Implements the observability layer from the design note in `docs/design/reorderbuffer-metrics-and-bypass.md` (Part A). This is a prerequisite for the bypass optimization (#1886) - the metrics confirm whether head-of-line stalls are significant enough to justify bypassing the reorder buffer when `--delay-updates` is off.

## Test plan

- [x] `in_order_delivery_no_stall` - verifies zero stalls and zero stall time for sequential insertion
- [x] `out_of_order_produces_stall` - verifies stall count increments and stall duration accumulates when head is missing
- [x] `multiple_stall_episodes` - verifies distinct stall episodes are counted independently
- [x] `peak_depth_monotonically_nondecreasing` - verifies peak depth never decreases across insertions and drains
- [x] `queue_depth_tracks_buffered_count` - verifies `current_depth` matches `buffered_count()`
- [x] `items_delivered_counts_all_drained` - verifies delivery counter accuracy
- [x] `mean_stall_nanos_derived_correctly` - verifies arithmetic on the derived accessor
- [x] `stale_insert_does_not_affect_metrics` - verifies already-delivered sequence numbers do not perturb counters
- [x] Property test: `counters_monotonic_across_permutation` - all counters are monotonically non-decreasing across reversed permutations
- [x] Property test: `identity_permutation_zero_stalls` - identity permutation always produces zero stalls
- [x] All 25 existing reorder buffer tests continue to pass