### PR TITLE
feat(transfer): bypass ReorderBuffer when delay-updates is off (#1886)

### DIFF
--- a/crates/engine/src/concurrent_delta/consumer.rs
+++ b/crates/engine/src/concurrent_delta/consumer.rs
@@ -124,14 +124,37 @@ impl DeltaConsumer {
     ///
     /// # Panics
     ///
-    /// Panics if `reorder_capacity` is zero.
+    /// Panics if `reorder_capacity` is zero and `bypass_reorder` is `false`.
     #[must_use]
     pub fn spawn(rx: WorkQueueReceiver, reorder_capacity: usize) -> Self {
+        Self::spawn_inner(rx, reorder_capacity, false)
+    }
+
+    /// Spawns background threads that drain the work queue in parallel
+    /// and deliver results in arrival order, bypassing reordering.
+    ///
+    /// Identical to [`spawn`](Self::spawn) except the internal
+    /// [`ReorderBuffer`] operates in passthrough mode. Items are forwarded
+    /// to the consumer in the order they complete rather than submission
+    /// order. This eliminates reorder overhead when strict file-list
+    /// ordering is unnecessary - for example, when `--delay-updates` is
+    /// off and files are committed immediately.
+    #[must_use]
+    pub fn spawn_bypass(rx: WorkQueueReceiver) -> Self {
+        Self::spawn_inner(rx, 0, true)
+    }
+
+    /// Internal spawn implementation shared by ordered and bypass paths.
+    fn spawn_inner(rx: WorkQueueReceiver, reorder_capacity: usize, bypass: bool) -> Self {
         let (result_tx, result_rx) = mpsc::channel();
 
         // Bounded channel between drain and reorder threads. Capacity matches
         // reorder buffer so workers can stay ahead without unbounded buffering.
-        let stream_capacity = reorder_capacity.max(rayon::current_num_threads() * 2);
+        let stream_capacity = if bypass {
+            rayon::current_num_threads() * 2
+        } else {
+            reorder_capacity.max(rayon::current_num_threads() * 2)
+        };
         let (stream_tx, stream_rx) = crossbeam_channel::bounded::<DeltaResult>(stream_capacity);
 
         // Thread 1: runs rayon::scope, streaming results as workers complete.
@@ -142,11 +165,16 @@ impl DeltaConsumer {
             })
             .expect("failed to spawn delta-drain thread");
 
-        // Thread 2: receives streamed results, reorders, forwards in sequence order.
+        // Thread 2: receives streamed results, reorders (or passes through),
+        // and forwards to the consumer channel.
         let handle = thread::Builder::new()
             .name("delta-reorder".to_string())
             .spawn(move || {
-                let mut reorder = ReorderBuffer::new(reorder_capacity);
+                let mut reorder = if bypass {
+                    ReorderBuffer::passthrough()
+                } else {
+                    ReorderBuffer::new(reorder_capacity)
+                };
 
                 for result in stream_rx {
                     // Insert may fail if buffer is at capacity. Drain ready
@@ -592,5 +620,85 @@ mod tests {
 
         assert!(consumer.try_recv().is_none());
         consumer.join().unwrap();
+    }
+
+    #[test]
+    fn bypass_delivers_all_results() {
+        let (tx, rx) = spawn_producer(50);
+        let producer = std::thread::spawn(move || send_items(&tx, 50));
+
+        let consumer = DeltaConsumer::spawn_bypass(rx);
+        let results: Vec<DeltaResult> = consumer.iter().collect();
+        producer.join().unwrap();
+
+        assert_eq!(results.len(), 50);
+        // All items delivered - verify by collecting ndx values.
+        let mut ndx_values: Vec<u32> = results.iter().map(|r| r.ndx().get()).collect();
+        ndx_values.sort_unstable();
+        let expected: Vec<u32> = (0..50).collect();
+        assert_eq!(ndx_values, expected);
+    }
+
+    #[test]
+    fn bypass_empty_queue_yields_no_results() {
+        let (tx, rx) = spawn_producer(1);
+        drop(tx);
+
+        let consumer = DeltaConsumer::spawn_bypass(rx);
+        let results: Vec<DeltaResult> = consumer.iter().collect();
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn bypass_single_item() {
+        let (tx, rx) = spawn_producer(1);
+        tx.send(DeltaWork::whole_file(42, PathBuf::from("/dst/single"), 128).with_sequence(0))
+            .unwrap();
+        drop(tx);
+
+        let consumer = DeltaConsumer::spawn_bypass(rx);
+        let results: Vec<DeltaResult> = consumer.iter().collect();
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].ndx().get(), 42);
+        assert_eq!(results[0].bytes_written(), 128);
+    }
+
+    #[test]
+    fn bypass_join_succeeds() {
+        let (tx, rx) = spawn_producer(10);
+        let producer = std::thread::spawn(move || send_items(&tx, 10));
+
+        let consumer = DeltaConsumer::spawn_bypass(rx);
+        let results: Vec<DeltaResult> = consumer.iter().collect();
+        producer.join().unwrap();
+
+        assert_eq!(results.len(), 10);
+        consumer.join().unwrap();
+    }
+
+    #[test]
+    fn bypass_large_batch_delivers_all() {
+        let count = 500u32;
+        let (tx, rx) = work_queue::bounded_with_capacity(32);
+
+        let producer = std::thread::spawn(move || {
+            for i in 0..count {
+                let work =
+                    DeltaWork::whole_file(i, PathBuf::from("/dst"), 64).with_sequence(u64::from(i));
+                tx.send(work).unwrap();
+            }
+        });
+
+        let consumer = DeltaConsumer::spawn_bypass(rx);
+        let results: Vec<DeltaResult> = consumer.into_iter().collect();
+        producer.join().unwrap();
+
+        assert_eq!(results.len(), count as usize);
+        // Verify all items present (order may differ from submission).
+        let mut ndx_values: Vec<u32> = results.iter().map(|r| r.ndx().get()).collect();
+        ndx_values.sort_unstable();
+        let expected: Vec<u32> = (0..count).collect();
+        assert_eq!(ndx_values, expected);
     }
 }

--- a/crates/engine/src/concurrent_delta/reorder.rs
+++ b/crates/engine/src/concurrent_delta/reorder.rs
@@ -25,6 +25,8 @@
 //! invariant that post-processing (checksum verification, metadata commit)
 //! sees files in file-list order.
 
+use std::collections::VecDeque;
+
 use super::adaptive::{AdaptiveCapacityPolicy, AdaptiveState, ReorderStats};
 
 /// Collects out-of-order items and yields them in sequence order.
@@ -80,6 +82,17 @@ pub struct ReorderBuffer<T> {
     /// Optional adaptive capacity scaling state. `None` preserves the
     /// historical fixed-capacity behaviour.
     adaptive: Option<AdaptiveState>,
+    /// When `true`, items pass through without sequence-based reordering.
+    ///
+    /// In bypass mode, [`insert`](Self::insert) appends to a FIFO queue and
+    /// [`next_in_order`](Self::next_in_order) pops from its front. Sequence
+    /// numbers are ignored - items are delivered in insertion order. This
+    /// eliminates the O(1)-per-item ring buffer overhead when strict ordering
+    /// is unnecessary (e.g., `--delay-updates` is off and files are committed
+    /// immediately upon completion).
+    bypass: bool,
+    /// FIFO queue used in bypass mode. Empty when `bypass` is `false`.
+    bypass_queue: VecDeque<T>,
 }
 
 /// Error returned when the reorder buffer is at capacity.
@@ -115,6 +128,48 @@ impl<T> ReorderBuffer<T> {
             capacity,
             high_water_offset: 0,
             adaptive: None,
+            bypass: false,
+            bypass_queue: VecDeque::new(),
+        }
+    }
+
+    /// Creates a passthrough buffer that skips sequence-based reordering.
+    ///
+    /// In passthrough mode, items are delivered in insertion order regardless
+    /// of their sequence numbers. This is an optimization for transfers where
+    /// strict file-list ordering is unnecessary - for example, when
+    /// `--delay-updates` is off and each file is committed immediately upon
+    /// completion.
+    ///
+    /// The buffer allocates no ring buffer slots. All items flow through a
+    /// lightweight FIFO queue, eliminating the per-item overhead of sequence
+    /// tracking, slot indexing, and gap detection.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use engine::concurrent_delta::reorder::ReorderBuffer;
+    ///
+    /// let mut buf: ReorderBuffer<&str> = ReorderBuffer::passthrough();
+    ///
+    /// // Items are delivered in insertion order, not sequence order.
+    /// buf.insert(2, "third").unwrap();
+    /// buf.insert(0, "first").unwrap();
+    /// assert_eq!(buf.next_in_order(), Some("third"));
+    /// assert_eq!(buf.next_in_order(), Some("first"));
+    /// ```
+    #[must_use]
+    pub fn passthrough() -> Self {
+        Self {
+            slots: Vec::new().into_boxed_slice(),
+            head: 0,
+            next_expected: 0,
+            count: 0,
+            capacity: 0,
+            high_water_offset: 0,
+            adaptive: None,
+            bypass: true,
+            bypass_queue: VecDeque::new(),
         }
     }
 
@@ -133,6 +188,15 @@ impl<T> ReorderBuffer<T> {
         let mut buf = Self::new(policy.min);
         buf.adaptive = Some(AdaptiveState::new(policy));
         buf
+    }
+
+    /// Returns `true` if the buffer is in passthrough (bypass) mode.
+    ///
+    /// In passthrough mode, items are delivered in insertion order without
+    /// sequence-based reordering.
+    #[must_use]
+    pub const fn is_passthrough(&self) -> bool {
+        self.bypass
     }
 
     /// Computes the ring buffer index for a given sequence number.
@@ -165,6 +229,11 @@ impl<T> ReorderBuffer<T> {
     /// Returns [`CapacityExceeded`] when the buffer is full or the sequence
     /// offset exceeds capacity.
     pub fn insert(&mut self, sequence: u64, item: T) -> Result<(), CapacityExceeded> {
+        if self.bypass {
+            self.bypass_queue.push_back(item);
+            self.count += 1;
+            return Ok(());
+        }
         // Adaptive policy may grow the ring before insert to avoid the error.
         if self.adaptive.is_some() && self.slot_index(sequence).is_none() {
             self.try_adaptive_preinsert_grow(sequence);
@@ -260,6 +329,12 @@ impl<T> ReorderBuffer<T> {
     /// advances the expected counter and head pointer. Returns `None` if
     /// that item has not yet been inserted.
     pub fn next_in_order(&mut self) -> Option<T> {
+        if self.bypass {
+            let item = self.bypass_queue.pop_front()?;
+            self.count -= 1;
+            self.next_expected += 1;
+            return Some(item);
+        }
         let item = self.slots[self.head].take()?;
         self.head = (self.head + 1) % self.capacity;
         self.next_expected += 1;
@@ -332,6 +407,11 @@ impl<T> ReorderBuffer<T> {
     /// ring capacity, this inserts directly. For sequences beyond capacity,
     /// the ring is grown to accommodate the item.
     pub fn force_insert(&mut self, sequence: u64, item: T) {
+        if self.bypass {
+            self.bypass_queue.push_back(item);
+            self.count += 1;
+            return;
+        }
         if let Some(idx) = self.slot_index(sequence) {
             if self.slots[idx].is_none() {
                 self.count += 1;
@@ -404,6 +484,10 @@ impl<T> ReorderBuffer<T> {
     /// Returns `None` if the sequence is outside the current window or if
     /// the slot is empty.
     pub fn take(&mut self, sequence: u64) -> Option<T> {
+        if self.bypass {
+            // Bypass mode does not support indexed extraction.
+            return None;
+        }
         let idx = self.slot_index(sequence)?;
         let item = self.slots[idx].take()?;
         self.count -= 1;
@@ -425,6 +509,12 @@ impl<T> ReorderBuffer<T> {
     /// were never inserted - a fatal correctness violation.
     pub fn finish(self) {
         if self.count > 0 {
+            if self.bypass {
+                panic!(
+                    "ReorderBuffer (bypass): {} items remain undelivered",
+                    self.count,
+                );
+            }
             // Find the first occupied slot to report the gap.
             let mut first_seq = self.next_expected;
             for i in 0..self.capacity {
@@ -1419,5 +1509,201 @@ mod adaptive_tests {
         }
         let expected: Vec<u64> = (0..n).collect();
         assert_eq!(collected, expected);
+    }
+}
+
+#[cfg(test)]
+mod passthrough_tests {
+    use super::*;
+
+    #[test]
+    fn passthrough_delivers_in_insertion_order() {
+        let mut buf: ReorderBuffer<&str> = ReorderBuffer::passthrough();
+        assert!(buf.is_passthrough());
+
+        // Insert out of sequence order.
+        buf.insert(2, "third").unwrap();
+        buf.insert(0, "first").unwrap();
+        buf.insert(1, "second").unwrap();
+
+        // Items come out in insertion order, not sequence order.
+        assert_eq!(buf.next_in_order(), Some("third"));
+        assert_eq!(buf.next_in_order(), Some("first"));
+        assert_eq!(buf.next_in_order(), Some("second"));
+        assert_eq!(buf.next_in_order(), None);
+    }
+
+    #[test]
+    fn passthrough_insert_never_returns_capacity_exceeded() {
+        let mut buf: ReorderBuffer<u64> = ReorderBuffer::passthrough();
+        // Even very large sequence numbers succeed - no ring buffer bounds.
+        assert!(buf.insert(u64::MAX - 1, 999).is_ok());
+        assert!(buf.insert(0, 0).is_ok());
+        assert_eq!(buf.buffered_count(), 2);
+    }
+
+    #[test]
+    fn passthrough_drain_ready_yields_all_items() {
+        let mut buf: ReorderBuffer<u64> = ReorderBuffer::passthrough();
+        buf.insert(5, 50).unwrap();
+        buf.insert(3, 30).unwrap();
+        buf.insert(1, 10).unwrap();
+
+        let drained: Vec<u64> = buf.drain_ready().collect();
+        assert_eq!(drained, vec![50, 30, 10]);
+        assert!(buf.is_empty());
+    }
+
+    #[test]
+    fn passthrough_force_insert_appends_to_queue() {
+        let mut buf: ReorderBuffer<&str> = ReorderBuffer::passthrough();
+        buf.force_insert(10, "forced");
+        buf.force_insert(5, "also_forced");
+
+        assert_eq!(buf.buffered_count(), 2);
+        assert_eq!(buf.next_in_order(), Some("forced"));
+        assert_eq!(buf.next_in_order(), Some("also_forced"));
+    }
+
+    #[test]
+    fn passthrough_is_empty_and_count() {
+        let mut buf: ReorderBuffer<i32> = ReorderBuffer::passthrough();
+        assert!(buf.is_empty());
+        assert_eq!(buf.buffered_count(), 0);
+
+        buf.insert(0, 42).unwrap();
+        assert!(!buf.is_empty());
+        assert_eq!(buf.buffered_count(), 1);
+
+        buf.next_in_order();
+        assert!(buf.is_empty());
+        assert_eq!(buf.buffered_count(), 0);
+    }
+
+    #[test]
+    fn passthrough_finish_succeeds_when_drained() {
+        let mut buf: ReorderBuffer<u64> = ReorderBuffer::passthrough();
+        buf.insert(0, 0).unwrap();
+        buf.insert(1, 1).unwrap();
+        let _: Vec<_> = buf.drain_ready().collect();
+        buf.finish(); // no panic
+    }
+
+    #[test]
+    #[should_panic(expected = "items remain undelivered")]
+    fn passthrough_finish_panics_with_pending_items() {
+        let mut buf: ReorderBuffer<u64> = ReorderBuffer::passthrough();
+        buf.insert(0, 0).unwrap();
+        buf.finish();
+    }
+
+    #[test]
+    fn passthrough_take_returns_none() {
+        let mut buf: ReorderBuffer<u64> = ReorderBuffer::passthrough();
+        buf.insert(0, 42).unwrap();
+        // Take is not supported in bypass mode.
+        assert!(buf.take(0).is_none());
+        // Item is still in the queue.
+        assert_eq!(buf.buffered_count(), 1);
+    }
+
+    #[test]
+    fn passthrough_capacity_is_zero() {
+        let buf: ReorderBuffer<u64> = ReorderBuffer::passthrough();
+        assert_eq!(buf.capacity(), 0);
+    }
+
+    #[test]
+    fn passthrough_stats_show_no_adaptive_events() {
+        let buf: ReorderBuffer<u64> = ReorderBuffer::passthrough();
+        let stats = buf.stats();
+        assert_eq!(stats.grow_events, 0);
+        assert_eq!(stats.shrink_events, 0);
+        assert_eq!(stats.capacity, 0);
+    }
+
+    #[test]
+    fn passthrough_next_expected_advances() {
+        let mut buf: ReorderBuffer<u64> = ReorderBuffer::passthrough();
+        assert_eq!(buf.next_expected(), 0);
+
+        buf.insert(5, 50).unwrap();
+        buf.next_in_order();
+        assert_eq!(buf.next_expected(), 1);
+
+        buf.insert(3, 30).unwrap();
+        buf.insert(1, 10).unwrap();
+        let _: Vec<_> = buf.drain_ready().collect();
+        assert_eq!(buf.next_expected(), 3);
+    }
+
+    #[test]
+    fn passthrough_large_batch() {
+        let mut buf: ReorderBuffer<u64> = ReorderBuffer::passthrough();
+
+        // Insert 1000 items with arbitrary sequence numbers.
+        for i in 0..1000u64 {
+            buf.insert(999 - i, i).unwrap();
+        }
+        assert_eq!(buf.buffered_count(), 1000);
+
+        let drained: Vec<u64> = buf.drain_ready().collect();
+        assert_eq!(drained.len(), 1000);
+        // Values are in insertion order (0, 1, 2, ..., 999).
+        for (i, &val) in drained.iter().enumerate() {
+            assert_eq!(val, i as u64);
+        }
+    }
+
+    #[test]
+    fn passthrough_interleaved_insert_and_drain() {
+        let mut buf: ReorderBuffer<u64> = ReorderBuffer::passthrough();
+
+        buf.insert(0, 100).unwrap();
+        assert_eq!(buf.next_in_order(), Some(100));
+
+        buf.insert(5, 200).unwrap();
+        buf.insert(3, 300).unwrap();
+        assert_eq!(buf.next_in_order(), Some(200));
+        assert_eq!(buf.next_in_order(), Some(300));
+        assert!(buf.is_empty());
+    }
+
+    #[test]
+    fn non_passthrough_flag_is_false() {
+        let buf: ReorderBuffer<u64> = ReorderBuffer::new(4);
+        assert!(!buf.is_passthrough());
+    }
+
+    /// Verifies that `DeltaResult` items flow through passthrough mode
+    /// without sequence-based reordering.
+    #[test]
+    fn passthrough_delta_result_integration() {
+        use crate::concurrent_delta::types::DeltaResult;
+
+        let mut buf: ReorderBuffer<DeltaResult> = ReorderBuffer::passthrough();
+
+        // Simulate three workers completing: seq 2 first, then 0, then 1.
+        let r2 = DeltaResult::success(20, 2000, 500, 1500).with_sequence(2);
+        let r0 = DeltaResult::success(10, 1000, 300, 700).with_sequence(0);
+        let r1 = DeltaResult::needs_redo(15, "checksum mismatch".to_string()).with_sequence(1);
+
+        buf.insert(r2.sequence(), r2).unwrap();
+        buf.insert(r0.sequence(), r0).unwrap();
+        buf.insert(r1.sequence(), r1).unwrap();
+
+        let drained: Vec<DeltaResult> = buf.drain_ready().collect();
+        assert_eq!(drained.len(), 3);
+
+        // Insertion order preserved - seq 2 first, then 0, then 1.
+        assert_eq!(drained[0].sequence(), 2);
+        assert_eq!(drained[0].ndx().get(), 20);
+
+        assert_eq!(drained[1].sequence(), 0);
+        assert_eq!(drained[1].ndx().get(), 10);
+
+        assert_eq!(drained[2].sequence(), 1);
+        assert_eq!(drained[2].ndx().get(), 15);
+        assert!(drained[2].needs_retry());
     }
 }

--- a/crates/transfer/src/delta_pipeline.rs
+++ b/crates/transfer/src/delta_pipeline.rs
@@ -217,6 +217,25 @@ impl ParallelDeltaPipeline {
             consumer: Some(consumer),
         }
     }
+
+    /// Creates a parallel pipeline that bypasses reorder buffering.
+    ///
+    /// Results are delivered in completion order rather than submission order.
+    /// This eliminates reorder overhead when strict file-list ordering is
+    /// unnecessary - for example, when `--delay-updates` is off and files
+    /// are committed immediately upon completion.
+    #[must_use]
+    pub fn new_bypass(worker_count: usize) -> Self {
+        let capacity = worker_count.saturating_mul(2).max(2);
+        let (work_tx, work_rx) = work_queue::bounded_with_capacity(capacity);
+        let consumer = DeltaConsumer::spawn_bypass(work_rx);
+
+        Self {
+            next_sequence: 0,
+            work_tx: Some(work_tx),
+            consumer: Some(consumer),
+        }
+    }
 }
 
 impl ReceiverDeltaPipeline for ParallelDeltaPipeline {
@@ -288,6 +307,8 @@ pub struct ThresholdDeltaPipeline {
     threshold: usize,
     /// Current operating mode.
     mode: ThresholdMode,
+    /// When `true`, the parallel pipeline bypasses reorder buffering.
+    bypass_reorder: bool,
 }
 
 impl std::fmt::Debug for ThresholdDeltaPipeline {
@@ -299,6 +320,7 @@ impl std::fmt::Debug for ThresholdDeltaPipeline {
         f.debug_struct("ThresholdDeltaPipeline")
             .field("threshold", &self.threshold)
             .field("mode", &mode_label)
+            .field("bypass_reorder", &self.bypass_reorder)
             .finish()
     }
 }
@@ -310,6 +332,7 @@ impl ThresholdDeltaPipeline {
         Self {
             threshold,
             mode: ThresholdMode::Buffering(Vec::new()),
+            bypass_reorder: false,
         }
     }
 
@@ -319,10 +342,29 @@ impl ThresholdDeltaPipeline {
         Self::new(DEFAULT_PARALLEL_THRESHOLD)
     }
 
+    /// Creates a threshold pipeline that bypasses reorder buffering.
+    ///
+    /// When the threshold is reached and parallel mode activates, the
+    /// internal [`ParallelDeltaPipeline`] delivers results in completion
+    /// order rather than submission order. This eliminates reorder overhead
+    /// when strict file-list ordering is unnecessary.
+    #[must_use]
+    pub fn new_bypass(threshold: usize) -> Self {
+        Self {
+            threshold,
+            mode: ThresholdMode::Buffering(Vec::new()),
+            bypass_reorder: true,
+        }
+    }
+
     /// Promotes from buffering to parallel mode, flushing buffered items.
     fn promote_to_parallel(&mut self, buffered: Vec<DeltaWork>) -> io::Result<()> {
         let worker_count = rayon::current_num_threads();
-        let mut parallel = ParallelDeltaPipeline::new(worker_count);
+        let mut parallel = if self.bypass_reorder {
+            ParallelDeltaPipeline::new_bypass(worker_count)
+        } else {
+            ParallelDeltaPipeline::new(worker_count)
+        };
         for item in buffered {
             parallel.submit_work(item)?;
         }
@@ -1217,5 +1259,116 @@ mod tests {
             assert_eq!(r.ndx().get(), i as u32);
             assert!(r.is_success());
         }
+    }
+
+    #[test]
+    fn parallel_bypass_delivers_all_results() {
+        let mut pipeline = ParallelDeltaPipeline::new_bypass(2);
+        for i in 0..20u32 {
+            let work =
+                DeltaWork::whole_file(i, PathBuf::from(format!("/dest/{i}")), u64::from(i) * 100);
+            pipeline.submit_work(work).unwrap();
+        }
+
+        let results = Box::new(pipeline).flush();
+        assert_eq!(results.len(), 20);
+        // All items present (order may differ from submission in bypass mode).
+        let mut ndx_values: Vec<u32> = results.iter().map(|r| r.ndx().get()).collect();
+        ndx_values.sort_unstable();
+        let expected: Vec<u32> = (0..20).collect();
+        assert_eq!(ndx_values, expected);
+        for r in &results {
+            assert!(r.is_success());
+        }
+    }
+
+    #[test]
+    fn parallel_bypass_empty_pipeline() {
+        let pipeline = ParallelDeltaPipeline::new_bypass(2);
+        let results = Box::new(pipeline).flush();
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn parallel_bypass_single_item() {
+        let mut pipeline = ParallelDeltaPipeline::new_bypass(2);
+        let work = DeltaWork::whole_file(42, PathBuf::from("/dest/single"), 256);
+        pipeline.submit_work(work).unwrap();
+
+        let results = Box::new(pipeline).flush();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].ndx().get(), 42);
+        assert_eq!(results[0].bytes_written(), 256);
+    }
+
+    #[test]
+    fn parallel_bypass_trait_object_works() {
+        let mut pipeline: Box<dyn ReceiverDeltaPipeline> =
+            Box::new(ParallelDeltaPipeline::new_bypass(2));
+        for i in 0..5u32 {
+            let work = DeltaWork::whole_file(i, PathBuf::from(format!("/dest/{i}")), 100);
+            pipeline.submit_work(work).unwrap();
+        }
+
+        let results = pipeline.flush();
+        assert_eq!(results.len(), 5);
+        let mut ndx_values: Vec<u32> = results.iter().map(|r| r.ndx().get()).collect();
+        ndx_values.sort_unstable();
+        assert_eq!(ndx_values, vec![0, 1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn threshold_bypass_below_threshold_uses_sequential() {
+        let mut pipeline = ThresholdDeltaPipeline::new_bypass(10);
+        for i in 0..5u32 {
+            let work = DeltaWork::whole_file(i, PathBuf::from(format!("/dest/{i}")), 100);
+            pipeline.submit_work(work).unwrap();
+        }
+
+        // Below threshold, items are buffered and processed sequentially.
+        assert!(pipeline.poll_result().is_none());
+
+        let results = Box::new(pipeline).flush();
+        assert_eq!(results.len(), 5);
+        for (i, r) in results.iter().enumerate() {
+            assert_eq!(r.ndx().get(), i as u32);
+            assert!(r.is_success());
+        }
+    }
+
+    #[test]
+    fn threshold_bypass_at_threshold_switches_to_parallel_bypass() {
+        let threshold = 5;
+        let mut pipeline = ThresholdDeltaPipeline::new_bypass(threshold);
+        for i in 0..10u32 {
+            let work = DeltaWork::whole_file(i, PathBuf::from(format!("/dest/{i}")), 64);
+            pipeline.submit_work(work).unwrap();
+        }
+
+        assert!(matches!(pipeline.mode, ThresholdMode::Parallel(_)));
+
+        let results = Box::new(pipeline).flush();
+        assert_eq!(results.len(), 10);
+        let mut ndx_values: Vec<u32> = results.iter().map(|r| r.ndx().get()).collect();
+        ndx_values.sort_unstable();
+        let expected: Vec<u32> = (0..10).collect();
+        assert_eq!(ndx_values, expected);
+    }
+
+    #[test]
+    fn parallel_bypass_large_batch() {
+        let mut pipeline = ParallelDeltaPipeline::new_bypass(4);
+        let count = 200u32;
+        for i in 0..count {
+            let work = DeltaWork::whole_file(i, PathBuf::from(format!("/dest/{i}")), 32);
+            pipeline.submit_work(work).unwrap();
+        }
+
+        let results = Box::new(pipeline).flush();
+        assert_eq!(results.len(), count as usize);
+        let mut ndx_values: Vec<u32> = results.iter().map(|r| r.ndx().get()).collect();
+        ndx_values.sort_unstable();
+        let expected: Vec<u32> = (0..count).collect();
+        assert_eq!(ndx_values, expected);
     }
 }

--- a/crates/transfer/src/reorder_buffer.rs
+++ b/crates/transfer/src/reorder_buffer.rs
@@ -20,7 +20,7 @@
 //! upstream: receiver.c:recv_files() processes files in file-list order.
 //! This buffer restores sequential ordering after parallel delta dispatch.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, VecDeque};
 use std::time::Instant;
 
 /// Default window size for the bounded reorder buffer.
@@ -123,6 +123,15 @@ pub struct BoundedReorderBuffer<T> {
     stall_start: Option<Instant>,
     /// Clock source for stall timing.
     clock: ClockFn,
+    /// When `true`, items pass through without sequence-based reordering.
+    ///
+    /// In bypass mode, [`insert`](Self::insert) appends to a FIFO queue and
+    /// returns items immediately. Sequence numbers are ignored. This
+    /// eliminates BTreeMap overhead when strict ordering is unnecessary
+    /// (e.g., `--delay-updates` is off and files are committed immediately).
+    bypass: bool,
+    /// FIFO queue used in bypass mode. Empty when `bypass` is `false`.
+    bypass_queue: VecDeque<T>,
 }
 
 /// Items drained from the buffer in sequence order.
@@ -170,6 +179,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for BoundedReorderBuffer<T> {
             .field("total_stall_nanos", &self.total_stall_nanos)
             .field("items_delivered", &self.items_delivered)
             .field("stall_active", &self.stall_start.is_some())
+            .field("bypass", &self.bypass)
             .finish()
     }
 }
@@ -184,6 +194,48 @@ impl<T> BoundedReorderBuffer<T> {
     /// Panics if `window_size` is zero.
     pub fn new(window_size: u64) -> Self {
         Self::with_clock(window_size, Box::new(Instant::now))
+    }
+
+    /// Creates a passthrough buffer that skips sequence-based reordering.
+    ///
+    /// In passthrough mode, items are delivered in insertion order regardless
+    /// of their sequence numbers. This is an optimization for transfers where
+    /// strict file-list ordering is unnecessary - for example, when
+    /// `--delay-updates` is off and each file is committed immediately upon
+    /// completion.
+    ///
+    /// The buffer allocates no BTreeMap entries. All items flow through a
+    /// lightweight FIFO queue, eliminating per-item overhead of sequence
+    /// tracking, gap detection, and stall measurement.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use transfer::reorder_buffer::BoundedReorderBuffer;
+    ///
+    /// let mut buf: BoundedReorderBuffer<&str> = BoundedReorderBuffer::passthrough();
+    ///
+    /// // Items are delivered in insertion order, not sequence order.
+    /// let d = buf.insert(2, "third").unwrap();
+    /// assert_eq!(d, vec!["third"]);
+    ///
+    /// let d = buf.insert(0, "first").unwrap();
+    /// assert_eq!(d, vec!["first"]);
+    /// ```
+    pub fn passthrough() -> Self {
+        Self {
+            next_expected: 0,
+            window_size: 0,
+            pending: BTreeMap::new(),
+            peak_depth: 0,
+            stall_count: 0,
+            total_stall_nanos: 0,
+            items_delivered: 0,
+            stall_start: None,
+            clock: Box::new(Instant::now),
+            bypass: true,
+            bypass_queue: VecDeque::new(),
+        }
     }
 
     /// Creates a new bounded reorder buffer with a custom clock source.
@@ -207,7 +259,18 @@ impl<T> BoundedReorderBuffer<T> {
             items_delivered: 0,
             stall_start: None,
             clock,
+            bypass: false,
+            bypass_queue: VecDeque::new(),
         }
+    }
+
+    /// Returns `true` if the buffer is in passthrough (bypass) mode.
+    ///
+    /// In passthrough mode, items are delivered in insertion order without
+    /// sequence-based reordering.
+    #[must_use]
+    pub const fn is_passthrough(&self) -> bool {
+        self.bypass
     }
 
     /// Inserts an item and returns any consecutive items ready for delivery.
@@ -229,6 +292,10 @@ impl<T> BoundedReorderBuffer<T> {
     /// Returns [`BackpressureError`] when `seq >= next_expected + window_size`.
     #[must_use = "drained items must be processed to maintain ordering"]
     pub fn insert(&mut self, seq: u64, item: T) -> Result<DrainedItems<T>, BackpressureError> {
+        if self.bypass {
+            self.items_delivered += 1;
+            return Ok(vec![item]);
+        }
         // Already delivered - ignore duplicate/stale submissions.
         if seq < self.next_expected {
             return Ok(Vec::new());
@@ -978,6 +1045,108 @@ mod tests {
                     prop_assert_eq!(m.items_delivered, n);
                 }
             }
+        }
+    }
+
+    /// Tests for passthrough (bypass) mode.
+    mod passthrough_tests {
+        use super::*;
+
+        #[test]
+        fn passthrough_delivers_immediately() {
+            let mut buf: BoundedReorderBuffer<&str> = BoundedReorderBuffer::passthrough();
+            assert!(buf.is_passthrough());
+
+            let d = buf.insert(5, "hello").unwrap();
+            assert_eq!(d, vec!["hello"]);
+
+            let d = buf.insert(0, "world").unwrap();
+            assert_eq!(d, vec!["world"]);
+        }
+
+        #[test]
+        fn passthrough_no_backpressure() {
+            let mut buf: BoundedReorderBuffer<u64> = BoundedReorderBuffer::passthrough();
+            // Any sequence number is accepted.
+            let d = buf.insert(u64::MAX - 1, 999).unwrap();
+            assert_eq!(d, vec![999]);
+        }
+
+        #[test]
+        fn passthrough_no_reordering() {
+            let mut buf: BoundedReorderBuffer<&str> = BoundedReorderBuffer::passthrough();
+
+            // Insert out of order: 2, 0, 1.
+            let d = buf.insert(2, "c").unwrap();
+            assert_eq!(d, vec!["c"]);
+
+            let d = buf.insert(0, "a").unwrap();
+            assert_eq!(d, vec!["a"]);
+
+            let d = buf.insert(1, "b").unwrap();
+            assert_eq!(d, vec!["b"]);
+        }
+
+        #[test]
+        fn passthrough_metrics_track_delivery() {
+            let mut buf: BoundedReorderBuffer<u64> = BoundedReorderBuffer::passthrough();
+            buf.insert(0, 10).unwrap();
+            buf.insert(1, 20).unwrap();
+            buf.insert(2, 30).unwrap();
+
+            let m = buf.metrics();
+            assert_eq!(m.items_delivered, 3);
+            assert_eq!(m.current_depth, 0);
+            assert_eq!(m.peak_depth, 0);
+            assert_eq!(m.stall_count, 0);
+            assert_eq!(m.total_stall_nanos, 0);
+        }
+
+        #[test]
+        fn passthrough_buffered_count_is_zero() {
+            let mut buf: BoundedReorderBuffer<u64> = BoundedReorderBuffer::passthrough();
+            buf.insert(0, 42).unwrap();
+            // Items pass through immediately - nothing buffered.
+            assert_eq!(buf.buffered_count(), 0);
+            assert!(buf.is_empty());
+        }
+
+        #[test]
+        fn passthrough_window_size_is_zero() {
+            let buf: BoundedReorderBuffer<u64> = BoundedReorderBuffer::passthrough();
+            assert_eq!(buf.window_size(), 0);
+        }
+
+        #[test]
+        fn passthrough_next_expected_stays_zero() {
+            let mut buf: BoundedReorderBuffer<u64> = BoundedReorderBuffer::passthrough();
+            buf.insert(0, 10).unwrap();
+            buf.insert(1, 20).unwrap();
+            // In bypass mode, next_expected is not advanced.
+            assert_eq!(buf.next_expected(), 0);
+        }
+
+        #[test]
+        fn passthrough_large_batch() {
+            let mut buf: BoundedReorderBuffer<u64> = BoundedReorderBuffer::passthrough();
+            let mut all_drained = Vec::new();
+
+            for i in 0..500u64 {
+                let d = buf.insert(499 - i, i).unwrap();
+                all_drained.extend(d);
+            }
+
+            assert_eq!(all_drained.len(), 500);
+            // Values arrive in insertion order (0, 1, 2, ..., 499).
+            for (i, &val) in all_drained.iter().enumerate() {
+                assert_eq!(val, i as u64);
+            }
+        }
+
+        #[test]
+        fn non_passthrough_flag_is_false() {
+            let buf: BoundedReorderBuffer<u64> = BoundedReorderBuffer::new(4);
+            assert!(!buf.is_passthrough());
         }
     }
 }

--- a/crates/transfer/src/reorder_buffer.rs
+++ b/crates/transfer/src/reorder_buffer.rs
@@ -20,7 +20,7 @@
 //! upstream: receiver.c:recv_files() processes files in file-list order.
 //! This buffer restores sequential ordering after parallel delta dispatch.
 
-use std::collections::{BTreeMap, VecDeque};
+use std::collections::BTreeMap;
 use std::time::Instant;
 
 /// Default window size for the bounded reorder buffer.
@@ -125,13 +125,11 @@ pub struct BoundedReorderBuffer<T> {
     clock: ClockFn,
     /// When `true`, items pass through without sequence-based reordering.
     ///
-    /// In bypass mode, [`insert`](Self::insert) appends to a FIFO queue and
-    /// returns items immediately. Sequence numbers are ignored. This
-    /// eliminates BTreeMap overhead when strict ordering is unnecessary
-    /// (e.g., `--delay-updates` is off and files are committed immediately).
+    /// In bypass mode, [`insert`](Self::insert) returns items immediately.
+    /// Sequence numbers are ignored. This eliminates BTreeMap overhead when
+    /// strict ordering is unnecessary (e.g., `--delay-updates` is off and
+    /// files are committed immediately).
     bypass: bool,
-    /// FIFO queue used in bypass mode. Empty when `bypass` is `false`.
-    bypass_queue: VecDeque<T>,
 }
 
 /// Items drained from the buffer in sequence order.
@@ -234,7 +232,6 @@ impl<T> BoundedReorderBuffer<T> {
             stall_start: None,
             clock: Box::new(Instant::now),
             bypass: true,
-            bypass_queue: VecDeque::new(),
         }
     }
 
@@ -260,7 +257,6 @@ impl<T> BoundedReorderBuffer<T> {
             stall_start: None,
             clock,
             bypass: false,
-            bypass_queue: VecDeque::new(),
         }
     }
 


### PR DESCRIPTION
## Summary

- Add `passthrough()` constructor and `is_passthrough()` accessor to both `ReorderBuffer` (engine crate) and `BoundedReorderBuffer` (transfer crate) that skip sequence-based reordering, delivering items in insertion order via a lightweight `VecDeque` FIFO queue
- Wire bypass through `DeltaConsumer::spawn_bypass()`, `ParallelDeltaPipeline::new_bypass()`, and `ThresholdDeltaPipeline::new_bypass()` so callers can opt in based on `--delay-updates` configuration
- When `--delay-updates` is off, files are committed immediately upon completion - strict file-list ordering is unnecessary, and the bypass eliminates per-item ring buffer slot indexing and BTreeMap overhead

## Test plan

- [x] Passthrough mode delivers items in insertion order regardless of sequence numbers
- [x] Passthrough insert never returns `CapacityExceeded` / `BackpressureError`
- [x] `drain_ready()` yields all items from the FIFO queue in passthrough mode
- [x] `force_insert()` appends to the queue in passthrough mode
- [x] `finish()` succeeds when drained, panics when items remain (passthrough)
- [x] `take()` returns `None` in passthrough mode (indexed extraction not supported)
- [x] `is_passthrough()` returns correct value for both modes
- [x] Metrics track delivery count in passthrough mode (BoundedReorderBuffer)
- [x] `DeltaConsumer::spawn_bypass()` delivers all results from parallel workers
- [x] `ParallelDeltaPipeline::new_bypass()` delivers all results via trait object
- [x] `ThresholdDeltaPipeline::new_bypass()` falls back to sequential below threshold, uses bypass parallel above
- [x] Large batch (500+ items) stress tests for both bypass consumer and pipeline
- [x] DeltaResult integration test verifies passthrough preserves all result fields