### PR TITLE
feat(engine): wire adaptive buffer controller into pool acquisition path

### DIFF
--- a/crates/engine/src/local_copy/buffer_pool/pool.rs
+++ b/crates/engine/src/local_copy/buffer_pool/pool.rs
@@ -535,6 +535,69 @@ impl<A: BufferAllocator> BufferPool<A> {
         }
     }
 
+    /// Acquires a buffer whose size is driven by the PID controller.
+    ///
+    /// When a [`buffer controller`](Self::with_buffer_controller) is enabled,
+    /// the returned buffer is sized to
+    /// [`recommended_buffer_size`](Self::recommended_buffer_size) - the PID
+    /// output that tracks the throughput setpoint. When no controller is
+    /// present, this falls back to file-size-based adaptive sizing via
+    /// [`acquire_adaptive_from`](Self::acquire_adaptive_from).
+    ///
+    /// This is the preferred acquisition method for the transfer pipeline:
+    /// it feeds the controller's recommendation into the actual I/O buffer
+    /// size, closing the feedback loop between throughput observation and
+    /// buffer allocation.
+    ///
+    /// The controller recommendation is clamped between `min_size` and
+    /// `max_size` (configured at controller build time). If the recommended
+    /// size matches the pool's default `buffer_size`, the thread-local cache
+    /// and central pool are reused. Otherwise a fresh buffer is allocated at
+    /// the recommended size and resized back to the pool default on return.
+    #[must_use]
+    pub fn acquire_controlled_from(pool: Arc<Self>, file_size: u64) -> BufferGuard<A> {
+        let desired = if pool.buffer_controller.is_some() {
+            pool.recommended_buffer_size()
+        } else {
+            adaptive_buffer_size(file_size)
+        };
+
+        if desired == pool.buffer_size {
+            return Self::acquire_from(pool);
+        }
+
+        pool.wait_and_reserve_memory(desired);
+        let buffer = pool.allocator.allocate(desired);
+        BufferGuard {
+            buffer: Some(buffer),
+            pool,
+        }
+    }
+
+    /// Acquires a controller-driven buffer (borrows self).
+    ///
+    /// Borrowed variant of [`acquire_controlled_from`](Self::acquire_controlled_from).
+    /// Returns a guard with a lifetime tied to `self`.
+    #[must_use]
+    pub fn acquire_controlled(&self, file_size: u64) -> BorrowedBufferGuard<'_, A> {
+        let desired = if self.buffer_controller.is_some() {
+            self.recommended_buffer_size()
+        } else {
+            adaptive_buffer_size(file_size)
+        };
+
+        if desired == self.buffer_size {
+            return self.acquire();
+        }
+
+        self.wait_and_reserve_memory(desired);
+        let buffer = self.allocator.allocate(desired);
+        BorrowedBufferGuard {
+            buffer: Some(buffer),
+            pool: self,
+        }
+    }
+
     /// Acquires a buffer from the pool (borrows self).
     ///
     /// **Note:** This method returns a guard with a lifetime tied to `self`.

--- a/crates/engine/src/local_copy/buffer_pool/tests.rs
+++ b/crates/engine/src/local_copy/buffer_pool/tests.rs
@@ -2077,3 +2077,250 @@ fn controller_concurrent_record_and_recommend() {
         h.join().expect("thread panicked");
     }
 }
+
+// --- Controlled acquire integration tests ---
+
+#[test]
+fn acquire_controlled_from_uses_controller_size() {
+    // When a buffer controller is enabled, acquire_controlled_from should
+    // return a buffer at the controller's recommended size, not the
+    // file-size-based adaptive size.
+    let pool = Arc::new(
+        BufferPool::new(4).with_buffer_controller(
+            super::ControllerConfig::new(100 * 1024 * 1024)
+                .min_size(16 * 1024)
+                .max_size(4 * 1024 * 1024),
+        ),
+    );
+
+    // The controller's initial size is midpoint of [16 KiB, 4 MiB].
+    let expected = pool.recommended_buffer_size();
+    assert!(expected > 16 * 1024);
+    assert!(expected < 4 * 1024 * 1024);
+
+    // For a tiny file, acquire_adaptive would give 8 KiB, but the
+    // controller should override with its recommended size.
+    let buf = BufferPool::acquire_controlled_from(Arc::clone(&pool), 1024);
+    assert_eq!(
+        buf.len(),
+        expected,
+        "controlled acquire should use controller's recommended size, not adaptive"
+    );
+}
+
+#[test]
+fn acquire_controlled_from_falls_back_to_adaptive_without_controller() {
+    // Without a controller, acquire_controlled_from should behave like
+    // acquire_adaptive_from.
+    let pool = Arc::new(BufferPool::new(4));
+
+    let buf_tiny = BufferPool::acquire_controlled_from(Arc::clone(&pool), 1024);
+    assert_eq!(buf_tiny.len(), ADAPTIVE_BUFFER_TINY);
+
+    let buf_large = BufferPool::acquire_controlled_from(Arc::clone(&pool), 100 * 1024 * 1024);
+    assert_eq!(buf_large.len(), ADAPTIVE_BUFFER_LARGE);
+}
+
+#[test]
+fn acquire_controlled_uses_pool_for_matching_size() {
+    // When the controller's recommended size happens to match the pool's
+    // default buffer size, the thread-local cache should be used.
+    let pool = Arc::new(
+        BufferPool::with_buffer_size(4, COPY_BUFFER_SIZE).with_buffer_controller(
+            super::ControllerConfig::new(100 * 1024 * 1024)
+                .min_size(COPY_BUFFER_SIZE)
+                .max_size(COPY_BUFFER_SIZE),
+        ),
+    );
+
+    // Controller is clamped to pool default -> uses TLS/pool path.
+    let buf = BufferPool::acquire_controlled_from(Arc::clone(&pool), 10 * 1024 * 1024);
+    assert_eq!(buf.len(), COPY_BUFFER_SIZE);
+}
+
+#[test]
+fn acquire_controlled_borrowed_variant() {
+    // Verify the borrowed acquire_controlled method works.
+    let pool = BufferPool::new(4).with_buffer_controller(
+        super::ControllerConfig::new(100 * 1024 * 1024)
+            .min_size(16 * 1024)
+            .max_size(4 * 1024 * 1024),
+    );
+
+    let expected = pool.recommended_buffer_size();
+    let buf = pool.acquire_controlled(1024);
+    assert_eq!(buf.len(), expected);
+}
+
+#[test]
+fn controlled_acquire_size_grows_when_throughput_below_setpoint() {
+    // Feed low-throughput samples so the controller grows the recommended
+    // buffer size, then verify acquire_controlled_from reflects the growth.
+    let setpoint = 100 * 1024 * 1024u64; // 100 MB/s
+    let pool = Arc::new(
+        BufferPool::new(4).with_buffer_controller(
+            super::ControllerConfig::new(setpoint)
+                .min_size(16 * 1024)
+                .max_size(4 * 1024 * 1024),
+        ),
+    );
+
+    let initial_size = pool.recommended_buffer_size();
+
+    // Record low throughput (1 MB/s << 100 MB/s setpoint).
+    for _ in 0..30 {
+        pool.record_transfer(10_000, std::time::Duration::from_millis(10));
+    }
+
+    let grown_size = pool.recommended_buffer_size();
+    assert!(
+        grown_size > initial_size,
+        "controller should grow buffer when throughput is below setpoint: initial={initial_size}, after={grown_size}"
+    );
+
+    // Controlled acquire should reflect the grown size.
+    let buf = BufferPool::acquire_controlled_from(Arc::clone(&pool), 1024);
+    assert_eq!(buf.len(), grown_size);
+}
+
+#[test]
+fn controlled_acquire_size_shrinks_when_throughput_above_setpoint() {
+    // Feed high-throughput samples so the controller shrinks the recommended
+    // buffer size, then verify acquire_controlled_from reflects the shrink.
+    let setpoint = 10 * 1024 * 1024u64; // 10 MB/s
+    let pool = Arc::new(
+        BufferPool::new(4).with_buffer_controller(
+            super::ControllerConfig::new(setpoint)
+                .min_size(16 * 1024)
+                .max_size(4 * 1024 * 1024),
+        ),
+    );
+
+    let initial_size = pool.recommended_buffer_size();
+
+    // Record high throughput (1 GB/s >> 10 MB/s setpoint).
+    for _ in 0..30 {
+        pool.record_transfer(10_000_000, std::time::Duration::from_millis(10));
+    }
+
+    let shrunk_size = pool.recommended_buffer_size();
+    assert!(
+        shrunk_size < initial_size,
+        "controller should shrink buffer when throughput is above setpoint: initial={initial_size}, after={shrunk_size}"
+    );
+
+    // Controlled acquire should reflect the shrunk size.
+    let buf = BufferPool::acquire_controlled_from(Arc::clone(&pool), 1024);
+    assert_eq!(buf.len(), shrunk_size);
+}
+
+#[test]
+fn controlled_acquire_returned_buffer_resized_to_pool_default() {
+    // A buffer acquired via acquire_controlled_from at a non-default size
+    // should be resized to the pool's default on return, so a subsequent
+    // standard acquire gets the correct size.
+    let pool = Arc::new(
+        BufferPool::new(4).with_buffer_controller(
+            super::ControllerConfig::new(100 * 1024 * 1024)
+                .min_size(16 * 1024)
+                .max_size(4 * 1024 * 1024),
+        ),
+    );
+
+    // Acquire a controlled buffer (likely non-default size).
+    {
+        let buf = BufferPool::acquire_controlled_from(Arc::clone(&pool), 1024);
+        let _len = buf.len(); // May differ from COPY_BUFFER_SIZE.
+    }
+
+    // Standard acquire should get a buffer at pool's default size.
+    let buf = BufferPool::acquire_from(Arc::clone(&pool));
+    assert_eq!(buf.len(), COPY_BUFFER_SIZE);
+}
+
+#[test]
+fn controlled_acquire_concurrent_safety() {
+    // Multiple threads acquire controlled buffers while another thread
+    // records throughput. All buffer sizes must stay within the
+    // controller's min/max bounds.
+    let min = 16 * 1024;
+    let max = 4 * 1024 * 1024;
+    let pool = Arc::new(
+        BufferPool::new(8).with_buffer_controller(
+            super::ControllerConfig::new(100 * 1024 * 1024)
+                .min_size(min)
+                .max_size(max),
+        ),
+    );
+
+    let mut handles = Vec::new();
+
+    // Writer threads record throughput.
+    for _ in 0..2 {
+        let pool = Arc::clone(&pool);
+        handles.push(thread::spawn(move || {
+            for _ in 0..200 {
+                pool.record_transfer(500_000, std::time::Duration::from_millis(10));
+            }
+        }));
+    }
+
+    // Reader threads acquire controlled buffers.
+    for _ in 0..4 {
+        let pool = Arc::clone(&pool);
+        handles.push(thread::spawn(move || {
+            for _ in 0..100 {
+                let buf = BufferPool::acquire_controlled_from(Arc::clone(&pool), 1024);
+                let len = buf.len();
+                assert!(len >= min, "controlled buffer below min: {len} < {min}");
+                assert!(len <= max, "controlled buffer above max: {len} > {max}");
+            }
+        }));
+    }
+
+    for h in handles {
+        h.join().expect("thread panicked");
+    }
+}
+
+#[test]
+fn controlled_acquire_end_to_end_feedback_loop() {
+    // End-to-end test: simulate a transfer loop where each iteration
+    // acquires a controlled buffer and records its throughput. The buffer
+    // size should converge toward a stable value.
+    let setpoint = 50 * 1024 * 1024u64; // 50 MB/s
+    let pool = Arc::new(
+        BufferPool::new(4).with_buffer_controller(
+            super::ControllerConfig::new(setpoint)
+                .min_size(16 * 1024)
+                .max_size(2 * 1024 * 1024),
+        ),
+    );
+
+    // Simulate steady 50 MB/s: 500 KB every 10 ms.
+    for _ in 0..100 {
+        let _buf = BufferPool::acquire_controlled_from(Arc::clone(&pool), 10 * 1024 * 1024);
+        pool.record_transfer(500_000, std::time::Duration::from_millis(10));
+    }
+
+    // Collect buffer sizes over the next 20 iterations.
+    let mut sizes = Vec::with_capacity(20);
+    for _ in 0..20 {
+        let buf = BufferPool::acquire_controlled_from(Arc::clone(&pool), 10 * 1024 * 1024);
+        sizes.push(buf.len());
+        pool.record_transfer(500_000, std::time::Duration::from_millis(10));
+    }
+
+    let min_s = *sizes.iter().min().unwrap();
+    let max_s = *sizes.iter().max().unwrap();
+    let mean = sizes.iter().sum::<usize>() / sizes.len();
+    let range_pct = if mean > 0 {
+        (max_s - min_s) as f64 / mean as f64
+    } else {
+        0.0
+    };
+    assert!(
+        range_pct < 0.20,
+        "buffer size should stabilize in feedback loop: min={min_s}, max={max_s}, mean={mean}, range_pct={range_pct:.2}"
+    );
+}

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/execute.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/execute.rs
@@ -375,7 +375,7 @@ pub(in crate::local_copy) fn execute_transfer(
 
     let mut pool_guard = if context.use_buffer_pool() {
         Some(
-            super::super::super::super::super::BufferPool::acquire_adaptive_from(
+            super::super::super::super::super::BufferPool::acquire_controlled_from(
                 context.buffer_pool(),
                 file_size,
             ),


### PR DESCRIPTION
## Summary

- Add `acquire_controlled_from` and `acquire_controlled` methods to `BufferPool` that use the PID controller's `recommended_buffer_size()` to determine I/O buffer sizes, closing the feedback loop between throughput observation and buffer allocation
- Update the transfer execution pipeline to use `acquire_controlled_from` instead of `acquire_adaptive_from`, enabling dynamic buffer sizing during file transfers
- Fall back to file-size-based adaptive sizing when no controller is configured, preserving backward compatibility

## Test plan

- [x] `acquire_controlled_from_uses_controller_size` - verifies controller recommendation overrides adaptive default
- [x] `acquire_controlled_from_falls_back_to_adaptive_without_controller` - verifies no-controller fallback matches `acquire_adaptive_from`
- [x] `acquire_controlled_uses_pool_for_matching_size` - verifies TLS/pool reuse when controller size matches pool default
- [x] `acquire_controlled_borrowed_variant` - verifies borrowed variant API
- [x] `controlled_acquire_size_grows_when_throughput_below_setpoint` - verifies buffer growth under low throughput
- [x] `controlled_acquire_size_shrinks_when_throughput_above_setpoint` - verifies buffer shrinkage under high throughput
- [x] `controlled_acquire_returned_buffer_resized_to_pool_default` - verifies return-path resizing
- [x] `controlled_acquire_concurrent_safety` - multi-threaded acquire with concurrent throughput recording
- [x] `controlled_acquire_end_to_end_feedback_loop` - full convergence test through pool API