### PR TITLE
perf(transfer): wire io_uring RENAMEAT2/LINKAT into disk-commit path (#1924)

### DIFF
--- a/crates/transfer/src/disk_commit/process.rs
+++ b/crates/transfer/src/disk_commit/process.rs
@@ -296,6 +296,11 @@ fn make_writer<'a>(
 }
 
 /// Performs backup, atomic rename, and inplace truncation after writing.
+///
+/// When io_uring is available (Linux 5.11+ with `IORING_OP_RENAMEAT`), the
+/// temp-file rename is submitted as an io_uring SQE instead of a synchronous
+/// `rename(2)` syscall. Falls back to `std::fs::rename` on all other
+/// platforms or when the kernel lacks the opcode.
 fn commit_file(
     begin: &BeginMessage,
     config: &DiskCommitConfig,
@@ -309,7 +314,7 @@ fn commit_file(
     }
 
     if needs_rename {
-        fs::rename(cleanup_guard.path(), &begin.file_path)?;
+        rename_with_io_uring_fallback(cleanup_guard.path(), &begin.file_path)?;
     } else if begin.is_inplace {
         // upstream: receiver.c:340 - set_file_length(fd, F_LENGTH(file))
         // In append mode, bytes_written only counts newly received data -
@@ -324,6 +329,21 @@ fn commit_file(
     }
     cleanup_guard.keep();
     Ok(())
+}
+
+/// Renames a temp file to its final destination, trying io_uring first.
+///
+/// On Linux 5.11+ with io_uring RENAMEAT2 support, submits the rename as an
+/// `IORING_OP_RENAMEAT` SQE. Falls back to `std::fs::rename` when io_uring
+/// is unavailable (non-Linux, old kernel, or feature not compiled in).
+///
+/// This mirrors the pattern used in `engine::local_copy::executor::file::guard`
+/// for local-copy temp-file commits.
+fn rename_with_io_uring_fallback(old_path: &Path, new_path: &Path) -> io::Result<()> {
+    if let Some(result) = fast_io::try_rename_via_io_uring(old_path, new_path) {
+        return result;
+    }
+    fs::rename(old_path, new_path)
 }
 
 /// Applies metadata, ACLs, and xattrs after file commit.
@@ -438,4 +458,75 @@ fn finalize_checksum(verifier: Option<ChecksumVerifier>) -> Option<ComputedCheck
         let len = v.finalize_into(&mut buf);
         ComputedChecksum { bytes: buf, len }
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Verifies the io_uring RENAMEAT2 fallback renames a file regardless of
+    /// whether io_uring handles it or `std::fs::rename` does.
+    #[test]
+    fn rename_with_io_uring_fallback_moves_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("rename_src.txt");
+        let dst = dir.path().join("rename_dst.txt");
+
+        fs::write(&src, b"io_uring rename data").unwrap();
+
+        rename_with_io_uring_fallback(&src, &dst).unwrap();
+
+        assert!(!src.exists());
+        assert!(dst.exists());
+        assert_eq!(fs::read(&dst).unwrap(), b"io_uring rename data");
+    }
+
+    /// Verifies the rename replaces an existing destination file.
+    #[test]
+    fn rename_with_io_uring_fallback_replaces_existing() {
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("rename_replace_src.txt");
+        let dst = dir.path().join("rename_replace_dst.txt");
+
+        fs::write(&src, b"new data").unwrap();
+        fs::write(&dst, b"old data").unwrap();
+
+        rename_with_io_uring_fallback(&src, &dst).unwrap();
+
+        assert!(!src.exists());
+        assert_eq!(fs::read(&dst).unwrap(), b"new data");
+    }
+
+    /// Verifies the rename fails with an error when the source does not exist.
+    #[test]
+    fn rename_with_io_uring_fallback_fails_for_missing_source() {
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("missing_src.txt");
+        let dst = dir.path().join("rename_fail_dst.txt");
+
+        let result = rename_with_io_uring_fallback(&src, &dst);
+        assert!(result.is_err());
+    }
+
+    /// Verifies consistent io_uring availability for RENAMEAT2 across calls.
+    #[test]
+    fn rename_io_uring_availability_consistent() {
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("avail_src.txt");
+        let dst1 = dir.path().join("avail_dst1.txt");
+        let dst2 = dir.path().join("avail_dst2.txt");
+        fs::write(&src, b"data").unwrap();
+
+        let first = fast_io::try_rename_via_io_uring(&src, &dst1).is_some();
+        // If first call consumed the file, recreate it.
+        if first {
+            fs::write(&src, b"data").unwrap();
+            let _ = fs::remove_file(&dst1);
+        }
+        let second = fast_io::try_rename_via_io_uring(&src, &dst2).is_some();
+        assert_eq!(
+            first, second,
+            "io_uring RENAMEAT2 availability must be consistent"
+        );
+    }
 }

--- a/crates/transfer/src/disk_commit/tests.rs
+++ b/crates/transfer/src/disk_commit/tests.rs
@@ -413,3 +413,122 @@ fn whole_file_coalesced() {
     h.file_tx.send(FileMessage::Shutdown).unwrap();
     h.join_handle.join().unwrap();
 }
+
+/// Verifies the io_uring rename dispatch in `commit_file`: the temp-file
+/// rename must succeed regardless of whether io_uring handles it or the
+/// `std::fs::rename` fallback does. This exercises the same path as
+/// production remote transfers.
+#[test]
+fn commit_file_rename_via_io_uring_or_fallback() {
+    let dir = test_support::create_tempdir();
+    let file_path = dir.path().join("iouring_rename_commit.dat");
+
+    let config = DiskCommitConfig {
+        io_uring_policy: fast_io::IoUringPolicy::Auto,
+        ..DiskCommitConfig::default()
+    };
+    let h = spawn_disk_thread(config);
+
+    h.file_tx
+        .send(FileMessage::Begin(Box::new(BeginMessage {
+            file_path: file_path.clone(),
+            target_size: 14,
+            file_entry_index: 0,
+            checksum_verifier: None,
+            is_device_target: false,
+            is_inplace: false,
+            append_offset: 0,
+            xattr_list: None,
+        })))
+        .unwrap();
+
+    h.file_tx
+        .send(FileMessage::Chunk(b"rename content".to_vec()))
+        .unwrap();
+    h.file_tx.send(FileMessage::Commit).unwrap();
+
+    let result = h.result_rx.recv().unwrap().unwrap();
+    assert_eq!(result.bytes_written, 14);
+
+    assert!(file_path.exists());
+    assert_eq!(fs::read(&file_path).unwrap(), b"rename content");
+
+    h.file_tx.send(FileMessage::Shutdown).unwrap();
+    h.join_handle.join().unwrap();
+}
+
+/// Verifies the io_uring rename works when replacing an existing destination.
+#[test]
+fn commit_file_rename_replaces_existing_via_io_uring_or_fallback() {
+    let dir = test_support::create_tempdir();
+    let file_path = dir.path().join("iouring_replace.dat");
+
+    fs::write(&file_path, b"old content").unwrap();
+
+    let config = DiskCommitConfig {
+        io_uring_policy: fast_io::IoUringPolicy::Auto,
+        ..DiskCommitConfig::default()
+    };
+    let h = spawn_disk_thread(config);
+
+    h.file_tx
+        .send(FileMessage::Begin(Box::new(BeginMessage {
+            file_path: file_path.clone(),
+            target_size: 11,
+            file_entry_index: 0,
+            checksum_verifier: None,
+            is_device_target: false,
+            is_inplace: false,
+            append_offset: 0,
+            xattr_list: None,
+        })))
+        .unwrap();
+
+    h.file_tx
+        .send(FileMessage::Chunk(b"new content".to_vec()))
+        .unwrap();
+    h.file_tx.send(FileMessage::Commit).unwrap();
+
+    let result = h.result_rx.recv().unwrap().unwrap();
+    assert_eq!(result.bytes_written, 11);
+    assert_eq!(fs::read(&file_path).unwrap(), b"new content");
+
+    h.file_tx.send(FileMessage::Shutdown).unwrap();
+    h.join_handle.join().unwrap();
+}
+
+/// Verifies the whole-file path also uses the io_uring rename dispatch.
+#[test]
+fn whole_file_commit_via_io_uring_or_fallback() {
+    let dir = test_support::create_tempdir();
+    let file_path = dir.path().join("whole_iouring.dat");
+
+    let config = DiskCommitConfig {
+        io_uring_policy: fast_io::IoUringPolicy::Auto,
+        ..DiskCommitConfig::default()
+    };
+    let h = spawn_disk_thread(config);
+
+    h.file_tx
+        .send(FileMessage::WholeFile {
+            begin: Box::new(BeginMessage {
+                file_path: file_path.clone(),
+                target_size: 13,
+                file_entry_index: 0,
+                checksum_verifier: None,
+                is_device_target: false,
+                is_inplace: false,
+                append_offset: 0,
+                xattr_list: None,
+            }),
+            data: b"whole iouring".to_vec(),
+        })
+        .unwrap();
+
+    let result = h.result_rx.recv().unwrap().unwrap();
+    assert_eq!(result.bytes_written, 13);
+    assert_eq!(fs::read(&file_path).unwrap(), b"whole iouring");
+
+    h.file_tx.send(FileMessage::Shutdown).unwrap();
+    h.join_handle.join().unwrap();
+}

--- a/crates/transfer/src/receiver/directory/links.rs
+++ b/crates/transfer/src/receiver/directory/links.rs
@@ -6,6 +6,7 @@
 //! reception, so this module handles both protocol versions uniformly.
 
 use std::fs;
+use std::io;
 use std::path::Path;
 
 use logging::debug_log;
@@ -236,7 +237,8 @@ impl ReceiverContext {
                 }
 
                 // upstream: hlink.c:maybe_hard_link() -> atomic_create() -> do_link()
-                if let Err(e) = fs::hard_link(&leader_path, &link_path) {
+                // Try io_uring LINKAT on Linux 5.15+, fall back to std::fs::hard_link.
+                if let Err(e) = hard_link_with_io_uring_fallback(&leader_path, &link_path) {
                     debug_log!(
                         Recv,
                         1,
@@ -278,5 +280,81 @@ impl ReceiverContext {
         // Protocol 28-29 hardlinks are normalized to hardlink_idx/hlink_first
         // during file list reception (normalize_pre30_hardlinks), so the
         // protocol 30+ path above handles both versions uniformly.
+    }
+}
+
+/// Creates a hard link, trying io_uring first on supported kernels.
+///
+/// On Linux 5.15+ with io_uring LINKAT support, submits the link as an
+/// `IORING_OP_LINKAT` SQE. Falls back to `std::fs::hard_link` when io_uring
+/// is unavailable (non-Linux, old kernel, or feature not compiled in).
+fn hard_link_with_io_uring_fallback(src: &Path, dst: &Path) -> io::Result<()> {
+    if let Some(result) = fast_io::try_hard_link_via_io_uring(src, dst) {
+        return result;
+    }
+    fs::hard_link(src, dst)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Verifies the io_uring LINKAT fallback creates a valid hard link
+    /// regardless of whether io_uring handles it or `std::fs::hard_link` does.
+    #[test]
+    fn hard_link_via_io_uring_or_fallback_creates_link() {
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("link_src.txt");
+        let dst = dir.path().join("link_dst.txt");
+
+        fs::write(&src, b"hardlink payload").unwrap();
+
+        hard_link_with_io_uring_fallback(&src, &dst).unwrap();
+
+        assert!(src.exists());
+        assert!(dst.exists());
+        assert_eq!(fs::read(&dst).unwrap(), b"hardlink payload");
+
+        // Verify they share the same inode (both point to same data).
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::MetadataExt;
+            let src_meta = fs::metadata(&src).unwrap();
+            let dst_meta = fs::metadata(&dst).unwrap();
+            assert_eq!(src_meta.ino(), dst_meta.ino());
+        }
+    }
+
+    /// Verifies that attempting to hard link to an existing destination fails
+    /// with an appropriate error (io_uring or fallback path).
+    #[test]
+    fn hard_link_via_io_uring_or_fallback_fails_when_dst_exists() {
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("link_src_exists.txt");
+        let dst = dir.path().join("link_dst_exists.txt");
+
+        fs::write(&src, b"source").unwrap();
+        fs::write(&dst, b"existing").unwrap();
+
+        let result = hard_link_with_io_uring_fallback(&src, &dst);
+        assert!(result.is_err());
+    }
+
+    /// Verifies consistent availability: the function returns the same
+    /// path (io_uring vs fallback) across multiple calls.
+    #[test]
+    fn hard_link_io_uring_availability_consistent() {
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("consistency_src.txt");
+        let dst1 = dir.path().join("consistency_dst1.txt");
+        let dst2 = dir.path().join("consistency_dst2.txt");
+        fs::write(&src, b"data").unwrap();
+
+        let first = fast_io::try_hard_link_via_io_uring(&src, &dst1).is_some();
+        let second = fast_io::try_hard_link_via_io_uring(&src, &dst2).is_some();
+        assert_eq!(
+            first, second,
+            "io_uring LINKAT availability must be consistent"
+        );
     }
 }

--- a/crates/transfer/src/receiver/quick_check.rs
+++ b/crates/transfer/src/receiver/quick_check.rs
@@ -174,7 +174,8 @@ pub(super) fn try_reference_dest(
                 if let Some(parent) = dest_path.parent() {
                     let _ = fs::create_dir_all(parent);
                 }
-                if fs::hard_link(&ref_path, &dest_path).is_ok() {
+                // Try io_uring LINKAT on Linux 5.15+, fall back to std::fs::hard_link.
+                if hard_link_with_io_uring_fallback(&ref_path, &dest_path).is_ok() {
                     if let Err(e) = apply_metadata_from_file_entry(&dest_path, entry, metadata_opts)
                     {
                         metadata_errors.push((dest_path.clone(), e.to_string()));
@@ -260,4 +261,50 @@ fn file_checksum_matches(
 /// - `util1.c`: `clean_fname()` with `CFN_REFUSE_DOT_DOT_DIRS`
 pub(super) fn path_contains_dot_dot(path: &Path) -> bool {
     path.components().any(|c| matches!(c, Component::ParentDir))
+}
+
+/// Creates a hard link, trying io_uring first on supported kernels.
+///
+/// On Linux 5.15+ with io_uring LINKAT support, submits the link as an
+/// `IORING_OP_LINKAT` SQE. Falls back to `std::fs::hard_link` when io_uring
+/// is unavailable (non-Linux, old kernel, or feature not compiled in).
+fn hard_link_with_io_uring_fallback(src: &Path, dst: &Path) -> std::io::Result<()> {
+    if let Some(result) = fast_io::try_hard_link_via_io_uring(src, dst) {
+        return result;
+    }
+    fs::hard_link(src, dst)
+}
+
+#[cfg(test)]
+mod io_uring_linkat_tests {
+    use super::*;
+
+    /// Verifies the io_uring LINKAT fallback in the link-dest path creates a
+    /// valid hard link regardless of whether io_uring handles it or
+    /// `std::fs::hard_link` does.
+    #[test]
+    fn hard_link_via_io_uring_or_fallback_in_quick_check() {
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("linkdest_src.txt");
+        let dst = dir.path().join("linkdest_dst.txt");
+
+        fs::write(&src, b"link-dest payload").unwrap();
+
+        hard_link_with_io_uring_fallback(&src, &dst).unwrap();
+
+        assert!(src.exists());
+        assert!(dst.exists());
+        assert_eq!(fs::read(&dst).unwrap(), b"link-dest payload");
+    }
+
+    /// Verifies the fallback correctly fails when the source does not exist.
+    #[test]
+    fn hard_link_fails_for_missing_source() {
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("missing.txt");
+        let dst = dir.path().join("dst.txt");
+
+        let result = hard_link_with_io_uring_fallback(&src, &dst);
+        assert!(result.is_err());
+    }
 }


### PR DESCRIPTION
## Summary

- Wire existing `fast_io::try_rename_via_io_uring()` into the transfer crate's disk-commit thread for temp-file renames after writes, matching the pattern already used in the engine crate's local-copy executor
- Wire existing `fast_io::try_hard_link_via_io_uring()` into both hardlink creation paths: follower hard links in `receiver::directory::links` and link-dest hard links in `receiver::quick_check`
- On Linux 5.11+ (RENAMEAT2) and 5.15+ (LINKAT), these operations are submitted as io_uring SQEs instead of synchronous `rename(2)` / `link(2)` syscalls; all other platforms fall back to `std::fs` transparently

## Test plan

- [ ] New unit tests for `rename_with_io_uring_fallback` verify rename succeeds, replaces existing files, and fails for missing source
- [ ] New unit tests for `hard_link_with_io_uring_fallback` in both links.rs and quick_check.rs verify hard link creation, inode sharing (Unix), and error on existing destination
- [ ] New integration tests via `spawn_disk_thread` exercise the full commit path with io_uring Auto policy
- [ ] Consistency tests verify io_uring availability does not change between calls
- [ ] All tests pass on non-Linux (macOS, Windows) via the transparent `None` fallback from `try_rename_via_io_uring` / `try_hard_link_via_io_uring`
- [ ] CI: fmt+clippy, nextest (stable), Windows, macOS, Linux musl

Closes #1924, closes #1925