### PR TITLE
feat(fast_io): add splice/vmsplice zero-copy path for network-to-disk transfers

### DIFF
--- a/crates/fast_io/benches/splice_pipe.rs
+++ b/crates/fast_io/benches/splice_pipe.rs
@@ -1,22 +1,14 @@
-//! Benchmark skeleton for the splice/vmsplice SSH-stdio investigation.
+//! Benchmark for splice/vmsplice zero-copy transfer paths.
 //!
-//! Tracks oc-rsync task #1860. The audit doc lives at
-//! `docs/audits/splice-ssh-stdio.md`. This bench provides a baseline so that
-//! once the splice driver lands (`fast_io::splice_pipe`, see follow-up
-//! #1861), a measurable delta can be reported against the read/write loop
-//! that oc-rsync uses today on the SSH-stdio sender path.
+//! Compares three data movement strategies for writing file/buffer data
+//! through a pipe (simulating the SSH stdio path):
 //!
-//! Two benches are defined inside the `splice_pipe` group:
-//!
-//! - `read_write_baseline` - a real file -> pipe transfer using
-//!   `read(2)` + `write_all(2)` with a 64 KiB buffer. This mirrors the
-//!   current sender code path (modulo the multiplex envelope) and produces
-//!   the comparison baseline for future splice work.
-//! - `splice_baseline` - a placeholder slot that today just records a
-//!   constant. It exists so that the criterion group has a stable identity
-//!   on Linux and so that follow-up patches can drop the splice driver into
-//!   place without changing the report layout. The body is intentionally
-//!   trivial; replace it once #1861 lands.
+//! - `read_write_baseline` - standard `read(2)` + `write_all(2)` with a
+//!   64 KiB buffer. This mirrors the existing sender code path.
+//! - `splice_transfer` - `splice(file_fd, pipe) + splice(pipe, dest_fd)`
+//!   zero-copy path via [`fast_io::splice::SplicePipe`].
+//! - `vmsplice_transfer` - `vmsplice(buf, pipe) + splice(pipe, dest_fd)`
+//!   for transferring an in-memory buffer to a file without userspace copy.
 //!
 //! Cross-platform: the meaningful code is gated to Linux. On other targets
 //! the bench compiles to an empty criterion main so that
@@ -31,7 +23,7 @@ use criterion::{Criterion, criterion_group, criterion_main};
 fn bench_splice_pipe(c: &mut Criterion) {
     use std::fs::File;
     use std::io::{Read, Write};
-    use std::os::fd::{FromRawFd, IntoRawFd, OwnedFd};
+    use std::os::fd::{AsRawFd, FromRawFd, IntoRawFd, OwnedFd};
     use std::thread;
 
     use criterion::{BenchmarkId, Throughput};
@@ -94,6 +86,13 @@ fn bench_splice_pipe(c: &mut Criterion) {
         (write_end, drain)
     }
 
+    /// Creates a destination temp file and returns (file, raw_fd).
+    fn make_dest_file() -> (NamedTempFile, i32) {
+        let file = NamedTempFile::new().expect("create dest temp file");
+        let fd = file.as_file().as_raw_fd();
+        (file, fd)
+    }
+
     /// Drives the read/write baseline once. Reads `payload` from start to end
     /// into a 64 KiB buffer and writes it through `writer` (a pipe).
     fn run_read_write(payload: &NamedTempFile, writer: OwnedFd) {
@@ -133,19 +132,48 @@ fn bench_splice_pipe(c: &mut Criterion) {
         );
     }
 
-    eprintln!(
-        "splice_pipe::splice_baseline is a placeholder; tracking #1861 \
-         for the real fast_io::splice_pipe driver"
-    );
-    for &(label, size) in SIZES {
-        group.throughput(Throughput::Bytes(size as u64));
-        group.bench_with_input(
-            BenchmarkId::new("splice_baseline", label),
-            &size,
-            |b, &size| {
-                b.iter(|| black_box(size as u64));
-            },
-        );
+    // splice(2) bench: file -> splice -> pipe -> splice -> dest file.
+    if fast_io::splice::is_splice_available() {
+        for &(label, size) in SIZES {
+            let payload = create_payload(size);
+            group.throughput(Throughput::Bytes(size as u64));
+            group.bench_with_input(BenchmarkId::new("splice_transfer", label), &(), |b, _| {
+                b.iter_with_setup(
+                    || {
+                        let src = File::open(payload.path()).expect("open payload");
+                        let (dest, dest_fd) = make_dest_file();
+                        (src, dest, dest_fd)
+                    },
+                    |(src, _dest, dest_fd)| {
+                        let src_fd = src.as_raw_fd();
+                        let n = fast_io::splice::try_splice_to_file(src_fd, dest_fd, size)
+                            .expect("splice_to_file");
+                        black_box(n);
+                    },
+                );
+            });
+        }
+
+        // vmsplice(2) bench: in-memory buffer -> vmsplice -> pipe -> splice -> dest file.
+        for &(label, size) in SIZES {
+            let buf: Vec<u8> = (0..size).map(|i| (i % 251) as u8).collect();
+            group.throughput(Throughput::Bytes(size as u64));
+            group.bench_with_input(BenchmarkId::new("vmsplice_transfer", label), &(), |b, _| {
+                b.iter_with_setup(
+                    || {
+                        let (dest, dest_fd) = make_dest_file();
+                        (dest, dest_fd)
+                    },
+                    |(_dest, dest_fd)| {
+                        let n = fast_io::splice::try_vmsplice_to_file(&buf, dest_fd)
+                            .expect("vmsplice_to_file");
+                        black_box(n);
+                    },
+                );
+            });
+        }
+    } else {
+        eprintln!("splice(2) not available on this kernel - skipping splice/vmsplice benches");
     }
 
     group.finish();

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -141,7 +141,12 @@ pub use kernel_version::{
 pub use refs_detect::{clear_refs_cache, is_refs_filesystem};
 pub use sendfile::send_file_to_fd_with_policy;
 pub use socket_options::set_socket_int_option;
-pub use splice::{is_splice_available, is_splice_enabled, recv_fd_to_file, try_splice_to_file};
+#[cfg(target_os = "linux")]
+pub use splice::DEFAULT_PIPE_CAPACITY;
+pub use splice::{
+    SplicePipe, is_splice_available, is_splice_enabled, recv_fd_to_file, try_splice_to_file,
+    try_vmsplice_to_file,
+};
 
 pub use mmap_reader::MmapReader;
 pub use o_tmpfile::{

--- a/crates/fast_io/src/splice.rs
+++ b/crates/fast_io/src/splice.rs
@@ -1,8 +1,8 @@
 //! Zero-copy socket-to-disk transfer using `splice`/`vmsplice` syscalls.
 //!
 //! This module provides high-performance network-to-file transfer using Linux's
-//! `splice` syscall when available, with automatic fallback to standard read/write
-//! on other platforms or when the syscall fails.
+//! `splice` and `vmsplice` syscalls when available, with automatic fallback to
+//! standard read/write on other platforms or when the syscalls fail.
 //!
 //! # How it works
 //!
@@ -16,27 +16,38 @@
 //! This requires two `splice` calls per chunk but avoids any userspace buffer
 //! copies, keeping the data entirely in kernel pages.
 //!
+//! `vmsplice(2)` moves userspace memory pages into a pipe without copying.
+//! Combined with `splice`, this enables zero-copy buffer-to-file transfer:
+//!
+//! ```text
+//! userspace buffer -> vmsplice -> pipe (kernel buffer) -> splice -> file_fd
+//! ```
+//!
 //! # API Layers
 //!
 //! - [`try_splice_to_file`] - Low-level: attempts `splice(2)` only, returns error
 //!   on unsupported platforms or syscall failure. Callers must handle fallback.
+//! - [`try_vmsplice_to_file`] - Low-level: moves a userspace buffer into a file
+//!   via `vmsplice(2)` + `splice(2)`. Returns error on unsupported platforms.
 //! - [`recv_fd_to_file`] - High-level: tries `splice(2)` for transfers >= 64KB,
 //!   automatically falls back to buffered `read`/`write` on failure or for small
 //!   transfers. Analogous to [`crate::sendfile::send_file_to_fd`] for the receive
 //!   direction.
+//! - [`SplicePipe`] - RAII pipe pair with configurable buffer size, usable as the
+//!   intermediary for both `splice` and `vmsplice` operations.
 //!
 //! # Platform Support
 //!
-//! - **Linux 2.6.17+**: Uses `splice` for zero-copy socket-to-file transfer
+//! - **Linux 2.6.17+**: Uses `splice`/`vmsplice` for zero-copy transfer
 //! - **Other platforms**: Falls back to buffered `read`/`write` (via `recv_fd_to_file`)
-//!   or returns `Unsupported` error (via `try_splice_to_file`)
+//!   or returns `Unsupported` error (via `try_splice_to_file`, `try_vmsplice_to_file`)
 //!
 //! # Performance Characteristics
 //!
 //! - For transfers < 64KB: `recv_fd_to_file` uses read/write directly (lower overhead)
 //! - For transfers >= 64KB: `splice` avoids userspace copies entirely
-//! - Pipe buffer size defaults to 64KB on most Linux kernels (tunable via
-//!   `/proc/sys/fs/pipe-max-size`)
+//! - Pipe buffer size defaults to 1MB (configurable via [`SplicePipe::with_capacity`]),
+//!   falling back gracefully if `fcntl(F_SETPIPE_SZ)` is denied
 //! - Uses `SPLICE_F_MOVE | SPLICE_F_MORE` flags for optimal page migration
 //!
 //! # Example
@@ -75,6 +86,15 @@ const SPLICE_CHUNK_SIZE: usize = 64 * 1024;
 /// of avoiding a userspace copy. Matches the sendfile threshold.
 #[cfg(target_os = "linux")]
 const SPLICE_THRESHOLD: u64 = 64 * 1024;
+
+/// Default pipe buffer size requested via `fcntl(F_SETPIPE_SZ)`.
+///
+/// 1MB provides a good balance between throughput (fewer splice loops per
+/// large transfer) and memory usage. The kernel may grant less if the
+/// process lacks `CAP_SYS_RESOURCE` or the requested size exceeds
+/// `/proc/sys/fs/pipe-max-size`.
+#[cfg(target_os = "linux")]
+pub const DEFAULT_PIPE_CAPACITY: usize = 1024 * 1024;
 
 /// Returns whether `splice(2)` is available on the current system.
 ///
@@ -185,7 +205,27 @@ pub fn try_splice_to_file(
         ));
     }
 
-    let pipe = SplicePipe::new()?;
+    let pipe = SplicePipe::with_capacity(DEFAULT_PIPE_CAPACITY)?;
+    splice_fd_to_file_via_pipe(&pipe, socket_fd, file_fd, len)
+}
+
+/// Drives the two-phase splice loop: source fd -> pipe -> dest fd.
+///
+/// Handles EINTR by retrying the interrupted syscall. Handles short splices
+/// by looping until the requested bytes are drained from the pipe.
+///
+/// This is the shared core used by both [`try_splice_to_file`] and
+/// [`SplicePipe::splice_to_file`].
+#[cfg(target_os = "linux")]
+#[allow(unsafe_code)]
+fn splice_fd_to_file_via_pipe(
+    pipe: &SplicePipe,
+    source_fd: std::os::fd::RawFd,
+    dest_fd: std::os::fd::RawFd,
+    len: usize,
+) -> std::io::Result<usize> {
+    use std::io;
+
     let flags = libc::SPLICE_F_MOVE | libc::SPLICE_F_MORE;
     let mut total: usize = 0;
     let mut remaining = len;
@@ -193,31 +233,37 @@ pub fn try_splice_to_file(
     while remaining > 0 {
         let chunk = remaining.min(SPLICE_CHUNK_SIZE);
 
-        // Phase 1: splice from socket into the pipe write end.
-        // SAFETY: socket_fd is assumed valid by the caller (documented precondition).
+        // Phase 1: splice from source into the pipe write end.
+        // SAFETY: source_fd is assumed valid by the caller (documented precondition).
         // pipe.write_fd is valid because SplicePipe owns it and has not been dropped.
         // Null offset pointers use current file position.
-        let spliced_in = unsafe {
-            libc::splice(
-                socket_fd,
-                std::ptr::null_mut(),
-                pipe.write_fd,
-                std::ptr::null_mut(),
-                chunk,
-                flags,
-            )
+        let spliced_in = loop {
+            let result = unsafe {
+                libc::splice(
+                    source_fd,
+                    std::ptr::null_mut(),
+                    pipe.write_fd,
+                    std::ptr::null_mut(),
+                    chunk,
+                    flags,
+                )
+            };
+            if result < 0 {
+                let err = io::Error::last_os_error();
+                if err.kind() == io::ErrorKind::Interrupted {
+                    continue; // Retry on EINTR
+                }
+                if total == 0 {
+                    return Err(err);
+                }
+                // Partial transfer - return what we have
+                return Ok(total);
+            }
+            break result;
         };
 
-        if spliced_in < 0 {
-            let err = io::Error::last_os_error();
-            if total == 0 {
-                return Err(err);
-            }
-            // Partial transfer - return what we have
-            return Ok(total);
-        }
         if spliced_in == 0 {
-            // EOF on socket
+            // EOF on source
             break;
         }
 
@@ -225,39 +271,161 @@ pub fn try_splice_to_file(
 
         // Phase 2: splice from the pipe read end into the file.
         // Must drain exactly bytes_in_pipe to avoid pipe deadlock.
-        let mut pipe_remaining = bytes_in_pipe;
-        while pipe_remaining > 0 {
-            // SAFETY: pipe.read_fd is valid (owned by SplicePipe). file_fd is assumed
-            // valid by the caller. Null offset pointers use current file position.
-            let spliced_out = unsafe {
-                libc::splice(
-                    pipe.read_fd,
-                    std::ptr::null_mut(),
-                    file_fd,
-                    std::ptr::null_mut(),
-                    pipe_remaining,
-                    flags,
-                )
-            };
-
-            if spliced_out < 0 {
-                return Err(io::Error::last_os_error());
-            }
-            if spliced_out == 0 {
-                return Err(io::Error::new(
-                    io::ErrorKind::WriteZero,
-                    "splice to file returned 0 bytes",
-                ));
-            }
-
-            pipe_remaining -= spliced_out as usize;
-        }
+        drain_pipe_to_fd(pipe, dest_fd, bytes_in_pipe)?;
 
         total += bytes_in_pipe;
         remaining -= bytes_in_pipe;
     }
 
     Ok(total)
+}
+
+/// Drains `len` bytes from the pipe read end into `dest_fd` via `splice(2)`.
+///
+/// Handles EINTR by retrying. Returns an error if the pipe produces zero
+/// bytes (unexpected EOF on the pipe).
+#[cfg(target_os = "linux")]
+#[allow(unsafe_code)]
+fn drain_pipe_to_fd(
+    pipe: &SplicePipe,
+    dest_fd: std::os::fd::RawFd,
+    len: usize,
+) -> std::io::Result<()> {
+    use std::io;
+
+    let flags = libc::SPLICE_F_MOVE | libc::SPLICE_F_MORE;
+    let mut pipe_remaining = len;
+
+    while pipe_remaining > 0 {
+        // SAFETY: pipe.read_fd is valid (owned by SplicePipe). dest_fd is assumed
+        // valid by the caller. Null offset pointers use current file position.
+        let spliced_out = unsafe {
+            libc::splice(
+                pipe.read_fd,
+                std::ptr::null_mut(),
+                dest_fd,
+                std::ptr::null_mut(),
+                pipe_remaining,
+                flags,
+            )
+        };
+
+        if spliced_out < 0 {
+            let err = io::Error::last_os_error();
+            if err.kind() == io::ErrorKind::Interrupted {
+                continue; // Retry on EINTR
+            }
+            return Err(err);
+        }
+        if spliced_out == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::WriteZero,
+                "splice to file returned 0 bytes",
+            ));
+        }
+
+        pipe_remaining -= spliced_out as usize;
+    }
+
+    Ok(())
+}
+
+/// Transfers a userspace buffer to a file using `vmsplice(2)` + `splice(2)`.
+///
+/// The transfer path is: `buffer -> vmsplice -> pipe -> splice -> file_fd`,
+/// avoiding a userspace-to-kernel copy for the buffer contents. The kernel
+/// references the buffer pages directly via `vmsplice(2)` and then moves
+/// them to the destination file via `splice(2)`.
+///
+/// # Arguments
+///
+/// * `buf` - Source buffer to transfer. Must remain valid and unmodified until
+///   this function returns (the kernel references the pages in-flight).
+/// * `file_fd` - Destination file descriptor (must be a regular file or pipe)
+///
+/// # Returns
+///
+/// The number of bytes actually transferred.
+///
+/// # Errors
+///
+/// Returns an error if:
+/// - `splice`/`vmsplice` is not supported on this platform (`ErrorKind::Unsupported`)
+/// - Pipe creation fails
+/// - An I/O error occurs during transfer
+///
+/// # Platform Support
+///
+/// - **Linux 2.6.17+**: Full implementation using `vmsplice(2)` + `splice(2)`
+/// - **Other platforms**: Always returns `Unsupported` error
+#[cfg(target_os = "linux")]
+#[allow(unsafe_code)]
+pub fn try_vmsplice_to_file(buf: &[u8], file_fd: std::os::fd::RawFd) -> std::io::Result<usize> {
+    use std::io;
+
+    if buf.is_empty() {
+        return Ok(0);
+    }
+
+    if !is_splice_available() {
+        return Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "splice/vmsplice not available on this kernel",
+        ));
+    }
+
+    let pipe = SplicePipe::with_capacity(DEFAULT_PIPE_CAPACITY)?;
+    let mut total: usize = 0;
+    let mut remaining = buf.len();
+
+    while remaining > 0 {
+        let offset = total;
+        let chunk = remaining.min(SPLICE_CHUNK_SIZE);
+
+        // Phase 1: vmsplice the buffer slice into the pipe write end.
+        // SAFETY: The iovec points to buf[offset..offset+chunk], which is valid
+        // for the duration of this call. pipe.write_fd is valid (owned by SplicePipe).
+        // SPLICE_F_MORE hints that more data follows within this transfer.
+        let iov = libc::iovec {
+            iov_base: buf[offset..].as_ptr() as *mut libc::c_void,
+            iov_len: chunk,
+        };
+
+        let vspliced = loop {
+            let result = unsafe { libc::vmsplice(pipe.write_fd, &iov, 1, libc::SPLICE_F_MORE) };
+            if result < 0 {
+                let err = io::Error::last_os_error();
+                if err.kind() == io::ErrorKind::Interrupted {
+                    continue; // Retry on EINTR
+                }
+                return Err(err);
+            }
+            break result as usize;
+        };
+
+        if vspliced == 0 {
+            break;
+        }
+
+        // Phase 2: splice from the pipe read end into the file.
+        // Must drain exactly vspliced bytes - the kernel holds a reference to
+        // the buffer pages until the pipe consumer reads them.
+        drain_pipe_to_fd(&pipe, file_fd, vspliced)?;
+
+        total += vspliced;
+        remaining -= vspliced;
+    }
+
+    Ok(total)
+}
+
+/// Stub for non-Linux platforms - always returns `Unsupported`.
+#[cfg(not(target_os = "linux"))]
+pub fn try_vmsplice_to_file(_buf: &[u8], _file_fd: i32) -> std::io::Result<usize> {
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "vmsplice is only available on Linux",
+    ))
 }
 
 /// Stub for non-Linux platforms - always returns `Unsupported`.
@@ -418,26 +586,44 @@ fn copy_fd_to_fd(
     Ok(total)
 }
 
-/// RAII wrapper around a pipe pair created for splice intermediary use.
+/// RAII wrapper around a pipe pair created for splice/vmsplice intermediary use.
 ///
 /// The pipe is created with `O_CLOEXEC` to prevent fd leaks across `exec`.
-/// Both ends are closed on drop.
+/// Both ends are closed on drop. The pipe buffer size can be enlarged via
+/// [`SplicePipe::with_capacity`] to reduce the number of splice loop iterations
+/// for large transfers.
+///
+/// # Usage
+///
+/// ```no_run
+/// # #[cfg(target_os = "linux")]
+/// # {
+/// use fast_io::splice::SplicePipe;
+///
+/// let pipe = SplicePipe::with_capacity(1024 * 1024).unwrap();
+/// println!("pipe capacity: {} bytes", pipe.capacity());
+/// # }
+/// ```
 #[cfg(target_os = "linux")]
-struct SplicePipe {
+pub struct SplicePipe {
     /// Read end of the pipe (data flows out to the destination file).
     read_fd: i32,
     /// Write end of the pipe (data flows in from the source socket).
     write_fd: i32,
+    /// Actual pipe buffer capacity after `fcntl(F_SETPIPE_SZ)`.
+    capacity: usize,
 }
 
 #[cfg(target_os = "linux")]
+#[allow(unsafe_code)]
 impl SplicePipe {
-    /// Creates a new pipe pair with `O_CLOEXEC` set.
+    /// Creates a new pipe pair with `O_CLOEXEC` set and the default kernel
+    /// pipe buffer size (typically 64KB on most Linux kernels).
     ///
     /// # Errors
     ///
     /// Returns an error if `pipe2(2)` fails (e.g., fd limit reached).
-    fn new() -> std::io::Result<Self> {
+    pub fn new() -> std::io::Result<Self> {
         let mut fds = [0i32; 2];
         // SAFETY: fds is a valid [i32; 2] array. pipe2 writes two valid file
         // descriptors on success. O_CLOEXEC prevents leaking fds across exec.
@@ -445,10 +631,169 @@ impl SplicePipe {
         if result < 0 {
             return Err(std::io::Error::last_os_error());
         }
+
+        // Query the actual pipe capacity the kernel assigned.
+        // SAFETY: fds[1] is a valid pipe fd. F_GETPIPE_SZ returns the buffer
+        // size in bytes as a positive integer.
+        let capacity = unsafe { libc::fcntl(fds[1], libc::F_GETPIPE_SZ) };
+        let capacity = if capacity > 0 {
+            capacity as usize
+        } else {
+            // Fallback: assume the common default of 64KB.
+            64 * 1024
+        };
+
         Ok(Self {
             read_fd: fds[0],
             write_fd: fds[1],
+            capacity,
         })
+    }
+
+    /// Creates a new pipe pair and attempts to enlarge the buffer to
+    /// `requested_capacity` bytes via `fcntl(F_SETPIPE_SZ)`.
+    ///
+    /// The kernel may grant a smaller buffer if the process lacks
+    /// `CAP_SYS_RESOURCE` or the requested size exceeds
+    /// `/proc/sys/fs/pipe-max-size`. The actual capacity is always
+    /// queryable via [`SplicePipe::capacity`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `pipe2(2)` fails. A failed `F_SETPIPE_SZ` is
+    /// silently ignored - the pipe remains usable at its default capacity.
+    pub fn with_capacity(requested_capacity: usize) -> std::io::Result<Self> {
+        let mut pipe = Self::new()?;
+
+        if requested_capacity > pipe.capacity {
+            // SAFETY: pipe.write_fd is a valid pipe fd. F_SETPIPE_SZ sets the
+            // pipe buffer to at least `requested_capacity` bytes. The kernel
+            // rounds up to the nearest page boundary and may cap at pipe-max-size.
+            let actual = unsafe {
+                libc::fcntl(pipe.write_fd, libc::F_SETPIPE_SZ, requested_capacity as i32)
+            };
+            if actual > 0 {
+                pipe.capacity = actual as usize;
+            }
+            // If fcntl failed, pipe.capacity stays at the default - still usable.
+        }
+
+        Ok(pipe)
+    }
+
+    /// Returns the actual pipe buffer capacity in bytes.
+    ///
+    /// This reflects what the kernel granted, which may differ from the
+    /// requested capacity if `fcntl(F_SETPIPE_SZ)` was capped or failed.
+    #[must_use]
+    pub fn capacity(&self) -> usize {
+        self.capacity
+    }
+
+    /// Returns the read end file descriptor.
+    ///
+    /// The returned fd is valid for the lifetime of this `SplicePipe`.
+    #[must_use]
+    pub fn read_fd(&self) -> i32 {
+        self.read_fd
+    }
+
+    /// Returns the write end file descriptor.
+    ///
+    /// The returned fd is valid for the lifetime of this `SplicePipe`.
+    #[must_use]
+    pub fn write_fd(&self) -> i32 {
+        self.write_fd
+    }
+
+    /// Splices data from `source_fd` to `dest_fd` using this pipe as the
+    /// intermediary.
+    ///
+    /// This is equivalent to [`try_splice_to_file`] but reuses an existing
+    /// pipe, avoiding the overhead of creating and destroying a pipe pair
+    /// per transfer. Useful when performing many small splice operations.
+    ///
+    /// # Arguments
+    ///
+    /// * `source_fd` - Source file descriptor (must be a socket or pipe)
+    /// * `dest_fd` - Destination file descriptor (regular file or pipe)
+    /// * `len` - Number of bytes to transfer
+    ///
+    /// # Returns
+    ///
+    /// The number of bytes actually transferred.
+    pub fn splice_to_file(
+        &self,
+        source_fd: std::os::fd::RawFd,
+        dest_fd: std::os::fd::RawFd,
+        len: usize,
+    ) -> std::io::Result<usize> {
+        splice_fd_to_file_via_pipe(self, source_fd, dest_fd, len)
+    }
+
+    /// Transfers a userspace buffer to a file via `vmsplice(2)` + `splice(2)`
+    /// using this pipe as the intermediary.
+    ///
+    /// The buffer pages are referenced by the kernel in-flight. The caller
+    /// must not modify `buf` until this function returns.
+    ///
+    /// # Arguments
+    ///
+    /// * `buf` - Source buffer to transfer
+    /// * `dest_fd` - Destination file descriptor (regular file or pipe)
+    ///
+    /// # Returns
+    ///
+    /// The number of bytes actually transferred.
+    pub fn vmsplice_to_file(
+        &self,
+        buf: &[u8],
+        dest_fd: std::os::fd::RawFd,
+    ) -> std::io::Result<usize> {
+        use std::io;
+
+        if buf.is_empty() {
+            return Ok(0);
+        }
+
+        let mut total: usize = 0;
+        let mut remaining = buf.len();
+
+        while remaining > 0 {
+            let offset = total;
+            let chunk = remaining.min(SPLICE_CHUNK_SIZE);
+
+            let iov = libc::iovec {
+                iov_base: buf[offset..].as_ptr() as *mut libc::c_void,
+                iov_len: chunk,
+            };
+
+            // SAFETY: The iovec points to buf[offset..offset+chunk], which is
+            // valid for the duration of this call. self.write_fd is a valid pipe
+            // fd owned by this SplicePipe.
+            let vspliced = loop {
+                let result = unsafe { libc::vmsplice(self.write_fd, &iov, 1, libc::SPLICE_F_MORE) };
+                if result < 0 {
+                    let err = io::Error::last_os_error();
+                    if err.kind() == io::ErrorKind::Interrupted {
+                        continue;
+                    }
+                    return Err(err);
+                }
+                break result as usize;
+            };
+
+            if vspliced == 0 {
+                break;
+            }
+
+            drain_pipe_to_fd(self, dest_fd, vspliced)?;
+
+            total += vspliced;
+            remaining -= vspliced;
+        }
+
+        Ok(total)
     }
 }
 
@@ -462,6 +807,61 @@ impl Drop for SplicePipe {
             libc::close(self.read_fd);
             libc::close(self.write_fd);
         }
+    }
+}
+
+/// Stub type for non-Linux platforms.
+///
+/// All methods return `Unsupported` errors. This allows consumers to write
+/// platform-independent code that compiles everywhere.
+#[cfg(not(target_os = "linux"))]
+pub struct SplicePipe {
+    _private: (),
+}
+
+#[cfg(not(target_os = "linux"))]
+impl SplicePipe {
+    /// Stub: always returns `Unsupported` on non-Linux.
+    pub fn new() -> std::io::Result<Self> {
+        Err(std::io::Error::new(
+            std::io::ErrorKind::Unsupported,
+            "SplicePipe is only available on Linux",
+        ))
+    }
+
+    /// Stub: always returns `Unsupported` on non-Linux.
+    pub fn with_capacity(_requested_capacity: usize) -> std::io::Result<Self> {
+        Err(std::io::Error::new(
+            std::io::ErrorKind::Unsupported,
+            "SplicePipe is only available on Linux",
+        ))
+    }
+
+    /// Stub: returns 0.
+    #[must_use]
+    pub fn capacity(&self) -> usize {
+        0
+    }
+
+    /// Stub: always returns `Unsupported` on non-Linux.
+    pub fn splice_to_file(
+        &self,
+        _source_fd: i32,
+        _dest_fd: i32,
+        _len: usize,
+    ) -> std::io::Result<usize> {
+        Err(std::io::Error::new(
+            std::io::ErrorKind::Unsupported,
+            "splice is only available on Linux",
+        ))
+    }
+
+    /// Stub: always returns `Unsupported` on non-Linux.
+    pub fn vmsplice_to_file(&self, _buf: &[u8], _dest_fd: i32) -> std::io::Result<usize> {
+        Err(std::io::Error::new(
+            std::io::ErrorKind::Unsupported,
+            "vmsplice is only available on Linux",
+        ))
     }
 }
 
@@ -483,6 +883,22 @@ mod tests {
         let result = try_splice_to_file(0, 0, 1024);
         assert!(result.is_err());
         assert_eq!(result.unwrap_err().kind(), std::io::ErrorKind::Unsupported);
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    #[test]
+    fn test_vmsplice_unavailable_on_non_linux() {
+        let data = b"test data";
+        let result = try_vmsplice_to_file(data, 0);
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().kind(), std::io::ErrorKind::Unsupported);
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    #[test]
+    fn test_splice_pipe_unavailable_on_non_linux() {
+        assert!(SplicePipe::new().is_err());
+        assert!(SplicePipe::with_capacity(1024).is_err());
     }
 
     #[cfg(not(unix))]
@@ -589,9 +1005,9 @@ mod tests {
             let pipe = SplicePipe::new();
             assert!(pipe.is_ok(), "pipe2 should succeed");
             let pipe = pipe.unwrap();
-            assert!(pipe.read_fd >= 0);
-            assert!(pipe.write_fd >= 0);
-            assert_ne!(pipe.read_fd, pipe.write_fd);
+            assert!(pipe.read_fd() >= 0);
+            assert!(pipe.write_fd() >= 0);
+            assert_ne!(pipe.read_fd(), pipe.write_fd());
             // Drop closes both fds
         }
 
@@ -600,8 +1016,8 @@ mod tests {
             // Verify we can create and drop multiple pipes without fd leaks.
             for _ in 0..100 {
                 let pipe = SplicePipe::new().unwrap();
-                assert!(pipe.read_fd >= 0);
-                assert!(pipe.write_fd >= 0);
+                assert!(pipe.read_fd() >= 0);
+                assert!(pipe.write_fd() >= 0);
             }
         }
 
@@ -1006,6 +1422,174 @@ mod tests {
             let mut file_content = Vec::new();
             dest.read_to_end(&mut file_content).unwrap();
             assert_eq!(file_content, content);
+        }
+
+        #[test]
+        fn test_splice_pipe_with_capacity() {
+            let pipe = SplicePipe::with_capacity(1024 * 1024).unwrap();
+            // The kernel may round up or cap the value, but capacity should
+            // be at least the default (64KB on most kernels).
+            assert!(pipe.capacity() >= 64 * 1024);
+            assert!(pipe.read_fd() >= 0);
+            assert!(pipe.write_fd() >= 0);
+            assert_ne!(pipe.read_fd(), pipe.write_fd());
+        }
+
+        #[test]
+        fn test_splice_pipe_default_capacity() {
+            let pipe = SplicePipe::new().unwrap();
+            // Default pipe capacity is 64KB on most Linux kernels.
+            assert!(pipe.capacity() > 0);
+        }
+
+        #[test]
+        fn test_splice_pipe_reuse() {
+            if !is_splice_available() {
+                return;
+            }
+
+            let pipe = SplicePipe::with_capacity(DEFAULT_PIPE_CAPACITY).unwrap();
+
+            // Perform two sequential transfers through the same pipe.
+            for i in 0u8..2 {
+                let content: Vec<u8> = (0..128).map(|j| j.wrapping_add(i * 64)).collect();
+                let mut dest = NamedTempFile::new().unwrap();
+
+                let (recv_fd, writer) = socketpair_with_writer(content.clone());
+
+                use std::os::fd::AsRawFd;
+                let spliced = pipe
+                    .splice_to_file(recv_fd, dest.as_file().as_raw_fd(), content.len())
+                    .unwrap();
+
+                unsafe { libc::close(recv_fd) };
+                writer.join().expect("writer thread should succeed");
+
+                assert_eq!(spliced, content.len());
+
+                dest.seek(SeekFrom::Start(0)).unwrap();
+                let mut file_content = Vec::new();
+                dest.read_to_end(&mut file_content).unwrap();
+                assert_eq!(file_content, content);
+            }
+        }
+
+        #[test]
+        fn test_vmsplice_small_buffer() {
+            if !is_splice_available() {
+                return;
+            }
+
+            let content = b"Testing vmsplice: buffer to file via pipe intermediary";
+            let mut dest = NamedTempFile::new().unwrap();
+
+            use std::os::fd::AsRawFd;
+            let transferred = try_vmsplice_to_file(content, dest.as_file().as_raw_fd()).unwrap();
+
+            assert_eq!(transferred, content.len());
+
+            dest.seek(SeekFrom::Start(0)).unwrap();
+            let mut file_content = Vec::new();
+            dest.read_to_end(&mut file_content).unwrap();
+            assert_eq!(file_content, content);
+        }
+
+        #[test]
+        fn test_vmsplice_empty_buffer() {
+            if !is_splice_available() {
+                return;
+            }
+
+            let mut dest = NamedTempFile::new().unwrap();
+
+            use std::os::fd::AsRawFd;
+            let transferred = try_vmsplice_to_file(&[], dest.as_file().as_raw_fd()).unwrap();
+
+            assert_eq!(transferred, 0);
+
+            dest.seek(SeekFrom::Start(0)).unwrap();
+            let mut file_content = Vec::new();
+            dest.read_to_end(&mut file_content).unwrap();
+            assert!(file_content.is_empty());
+        }
+
+        #[test]
+        fn test_vmsplice_large_buffer() {
+            if !is_splice_available() {
+                return;
+            }
+
+            // 512KB - multiple splice chunks worth of data.
+            let size = 512 * 1024;
+            let content: Vec<u8> = (0..size).map(|i| (i % 256) as u8).collect();
+            let mut dest = NamedTempFile::new().unwrap();
+
+            use std::os::fd::AsRawFd;
+            let transferred = try_vmsplice_to_file(&content, dest.as_file().as_raw_fd()).unwrap();
+
+            assert_eq!(transferred, size);
+
+            dest.seek(SeekFrom::Start(0)).unwrap();
+            let mut file_content = Vec::new();
+            dest.read_to_end(&mut file_content).unwrap();
+            assert_eq!(file_content.len(), content.len());
+            assert_eq!(file_content, content);
+        }
+
+        #[test]
+        fn test_vmsplice_exact_chunk_boundary() {
+            if !is_splice_available() {
+                return;
+            }
+
+            // Exactly SPLICE_CHUNK_SIZE bytes.
+            let size = SPLICE_CHUNK_SIZE;
+            let content: Vec<u8> = (0..size).map(|i| (i % 256) as u8).collect();
+            let mut dest = NamedTempFile::new().unwrap();
+
+            use std::os::fd::AsRawFd;
+            let transferred = try_vmsplice_to_file(&content, dest.as_file().as_raw_fd()).unwrap();
+
+            assert_eq!(transferred, size);
+
+            dest.seek(SeekFrom::Start(0)).unwrap();
+            let mut file_content = Vec::new();
+            dest.read_to_end(&mut file_content).unwrap();
+            assert_eq!(file_content, content);
+        }
+
+        #[test]
+        fn test_vmsplice_via_splice_pipe() {
+            if !is_splice_available() {
+                return;
+            }
+
+            let content = b"Testing vmsplice through SplicePipe method";
+            let pipe = SplicePipe::with_capacity(DEFAULT_PIPE_CAPACITY).unwrap();
+            let mut dest = NamedTempFile::new().unwrap();
+
+            use std::os::fd::AsRawFd;
+            let transferred = pipe
+                .vmsplice_to_file(content, dest.as_file().as_raw_fd())
+                .unwrap();
+
+            assert_eq!(transferred, content.len());
+
+            dest.seek(SeekFrom::Start(0)).unwrap();
+            let mut file_content = Vec::new();
+            dest.read_to_end(&mut file_content).unwrap();
+            assert_eq!(file_content, content);
+        }
+
+        #[test]
+        fn test_vmsplice_invalid_fd_returns_error() {
+            if !is_splice_available() {
+                return;
+            }
+
+            let content = b"test data for invalid fd";
+            let result = try_vmsplice_to_file(content, -1);
+            assert!(result.is_err());
         }
     }
 }

--- a/crates/fast_io/src/splice.rs
+++ b/crates/fast_io/src/splice.rs
@@ -1452,7 +1452,7 @@ mod tests {
 
             // Perform two sequential transfers through the same pipe.
             for i in 0u8..2 {
-                let content: Vec<u8> = (0..128).map(|j| j.wrapping_add(i * 64)).collect();
+                let content: Vec<u8> = (0..128u8).map(|j| j.wrapping_add(i * 64)).collect();
                 let mut dest = NamedTempFile::new().unwrap();
 
                 let (recv_fd, writer) = socketpair_with_writer(content.clone());


### PR DESCRIPTION
## Summary

- Add `vmsplice(2)` support for zero-copy userspace-buffer-to-file transfer via `try_vmsplice_to_file()`, complementing the existing `splice(2)` socket-to-file path
- Make `SplicePipe` public with configurable pipe buffer size (default 1MB via `fcntl(F_SETPIPE_SZ)`) and add `splice_to_file()`/`vmsplice_to_file()` instance methods for pipe reuse across transfers
- Add EINTR handling to all splice/vmsplice loops (previously missing - signals could cause spurious failures)
- Refactor internal splice logic into `splice_fd_to_file_via_pipe()` and `drain_pipe_to_fd()` helpers shared by both the free functions and `SplicePipe` methods
- Provide non-Linux stub implementations returning `ErrorKind::Unsupported` for cross-platform compilation
- Replace benchmark placeholder with real `splice_transfer` and `vmsplice_transfer` benches alongside the `read_write_baseline`

Closes #1361.

## Test plan

- [ ] CI passes on Linux (splice/vmsplice tests exercise the real syscalls)
- [ ] CI passes on macOS (non-Linux stub tests verify `Unsupported` errors for `try_splice_to_file`, `try_vmsplice_to_file`, `SplicePipe::new()`)
- [ ] CI passes on Windows (non-unix stub tests verify `Unsupported` for `recv_fd_to_file`)
- [ ] Verify `cargo bench -p fast_io --bench splice_pipe` runs on Linux and reports throughput for all three strategies