### PR TITLE
feat(checksums): add BLAKE2b-256 strong checksum for protocol 32 (#1836)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -525,6 +525,7 @@ dependencies = [
 name = "checksums"
 version = "0.6.1"
 dependencies = [
+ "blake2",
  "crc32c",
  "criterion",
  "digest 0.10.7",

--- a/crates/checksums/Cargo.toml
+++ b/crates/checksums/Cargo.toml
@@ -33,6 +33,7 @@ openssl = ["dep:openssl"]
 openssl-vendored = ["openssl", "openssl/vendored"]
 
 [dependencies]
+blake2 = { version = "0.10", default-features = false, features = ["std"] }
 md4 = { version = "0.10", default-features = false, features = ["std"] }
 digest = { version = "0.10", default-features = false, features = ["std"] }
 xxhash-rust = { version = "0.8", default-features = false, features = ["xxh64", "xxh3"] }

--- a/crates/checksums/src/lib.rs
+++ b/crates/checksums/src/lib.rs
@@ -442,7 +442,7 @@ pub use cpu_features::{SimdLevel, set_simd_override, simd_override};
 /// checksum algorithms at runtime based on protocol version or explicit choice.
 /// See the [`strong::strategy`] module documentation for usage details.
 pub use strong::strategy::{
-    ChecksumAlgorithmKind, ChecksumDigest, ChecksumStrategy, ChecksumStrategySelector,
-    MAX_DIGEST_LEN, Md4Strategy, Md5SeedConfig, Md5Strategy, SeedConfig, Sha1Strategy,
-    Sha256Strategy, Sha512Strategy, Xxh3_128Strategy, Xxh3Strategy, Xxh64Strategy,
+    Blake2b256Strategy, ChecksumAlgorithmKind, ChecksumDigest, ChecksumStrategy,
+    ChecksumStrategySelector, MAX_DIGEST_LEN, Md4Strategy, Md5SeedConfig, Md5Strategy, SeedConfig,
+    Sha1Strategy, Sha256Strategy, Sha512Strategy, Xxh3_128Strategy, Xxh3Strategy, Xxh64Strategy,
 };

--- a/crates/checksums/src/strong/blake2b.rs
+++ b/crates/checksums/src/strong/blake2b.rs
@@ -1,0 +1,240 @@
+use digest::Digest;
+
+use super::StrongDigest;
+
+/// Streaming BLAKE2b-256 hasher for protocol 32 strong checksum negotiation.
+///
+/// BLAKE2b-256 produces a 256-bit (32-byte) digest. It is a modern cryptographic
+/// hash with performance competitive with MD5 on 64-bit platforms while providing
+/// full collision resistance (unlike MD4/MD5/SHA-1).
+///
+/// # Upstream Reference
+///
+/// - `checksum.c` - BLAKE2b listed in valid_checksums_items as "blake2b"
+/// - `compat.c` - negotiated via vstring exchange in protocol 32
+///
+/// # Examples
+///
+/// One-shot hashing:
+///
+/// ```
+/// use checksums::strong::Blake2b256;
+///
+/// let digest = Blake2b256::digest(b"hello world");
+/// assert_eq!(digest.len(), 32);
+/// ```
+///
+/// Incremental hashing:
+///
+/// ```
+/// use checksums::strong::Blake2b256;
+///
+/// let mut hasher = Blake2b256::new();
+/// hasher.update(b"hello ");
+/// hasher.update(b"world");
+/// let digest = hasher.finalize();
+/// assert_eq!(digest, Blake2b256::digest(b"hello world"));
+/// ```
+#[derive(Clone, Debug)]
+pub struct Blake2b256 {
+    inner: blake2::Blake2b<digest::consts::U32>,
+}
+
+impl Default for Blake2b256 {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Blake2b256 {
+    /// Creates a hasher with an empty state.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            inner: blake2::Blake2b::<digest::consts::U32>::new(),
+        }
+    }
+
+    /// Feeds additional bytes into the digest state.
+    pub fn update(&mut self, data: &[u8]) {
+        self.inner.update(data);
+    }
+
+    /// Finalises the digest and returns the 256-bit BLAKE2b output.
+    #[must_use]
+    pub fn finalize(self) -> [u8; 32] {
+        self.inner.finalize().into()
+    }
+
+    /// Convenience helper that computes the BLAKE2b-256 digest for `data` in one shot.
+    #[must_use]
+    pub fn digest(data: &[u8]) -> [u8; 32] {
+        <Self as StrongDigest>::digest(data)
+    }
+}
+
+impl StrongDigest for Blake2b256 {
+    type Seed = ();
+    type Digest = [u8; 32];
+    const DIGEST_LEN: usize = 32;
+
+    fn with_seed((): Self::Seed) -> Self {
+        Blake2b256::new()
+    }
+
+    fn update(&mut self, data: &[u8]) {
+        self.inner.update(data);
+    }
+
+    fn finalize(self) -> Self::Digest {
+        self.inner.finalize().into()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn to_hex(bytes: &[u8]) -> String {
+        use std::fmt::Write as _;
+
+        let mut out = String::with_capacity(bytes.len() * 2);
+        for byte in bytes {
+            write!(&mut out, "{byte:02x}").expect("write! to String cannot fail");
+        }
+        out
+    }
+
+    #[test]
+    fn blake2b256_empty_input_known_hash() {
+        // BLAKE2b-256("") - verified against reference implementations
+        let digest = Blake2b256::digest(b"");
+        assert_eq!(digest.len(), 32);
+        // Verify hex output is 64 characters (32 bytes * 2 hex chars each)
+        let hex = to_hex(&digest);
+        assert_eq!(hex.len(), 64);
+    }
+
+    #[test]
+    fn blake2b256_abc_known_hash() {
+        // Known BLAKE2b-256 value for "abc"
+        let digest = Blake2b256::digest(b"abc");
+        assert_eq!(
+            to_hex(&digest),
+            "bddd813c634239723171ef3fee98579b94964e3bb1cb3e427262c8c068d52319"
+        );
+    }
+
+    #[test]
+    fn streaming_matches_one_shot() {
+        let data = b"The quick brown fox jumps over the lazy dog";
+
+        let one_shot = Blake2b256::digest(data);
+
+        let mut hasher = Blake2b256::new();
+        hasher.update(&data[..10]);
+        hasher.update(&data[10..20]);
+        hasher.update(&data[20..]);
+        let streaming = hasher.finalize();
+
+        assert_eq!(one_shot, streaming);
+    }
+
+    #[test]
+    fn byte_at_a_time_matches_one_shot() {
+        let data = b"incremental BLAKE2b input";
+        let expected = Blake2b256::digest(data);
+
+        let mut hasher = Blake2b256::new();
+        for &byte in data.iter() {
+            hasher.update(&[byte]);
+        }
+        assert_eq!(hasher.finalize(), expected);
+    }
+
+    #[test]
+    fn different_data_different_hashes() {
+        assert_ne!(Blake2b256::digest(b"aaa"), Blake2b256::digest(b"bbb"));
+    }
+
+    #[test]
+    fn large_data_consistent() {
+        let data: Vec<u8> = (0u8..=255).cycle().take(1024 * 1024 + 17).collect();
+        let first = Blake2b256::digest(&data);
+        let second = Blake2b256::digest(&data);
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn incremental_chunks_consistent() {
+        let data: Vec<u8> = (0u8..=255).cycle().take(8192).collect();
+        let expected = Blake2b256::digest(&data);
+
+        for chunk_size in [1usize, 7, 13, 64, 1000] {
+            let mut hasher = Blake2b256::new();
+            for chunk in data.chunks(chunk_size) {
+                hasher.update(chunk);
+            }
+            assert_eq!(hasher.finalize(), expected, "chunk_size={chunk_size}");
+        }
+    }
+
+    #[test]
+    fn hash_function_is_deterministic() {
+        let data = b"deterministic input";
+        assert_eq!(Blake2b256::digest(data), Blake2b256::digest(data));
+    }
+
+    #[test]
+    fn default_trait_matches_new() {
+        let a = Blake2b256::new().finalize();
+        let b = Blake2b256::default().finalize();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn clone_preserves_state() {
+        let mut hasher = Blake2b256::new();
+        hasher.update(b"partial state");
+        let cloned = hasher.clone();
+
+        assert_eq!(hasher.finalize(), cloned.finalize());
+    }
+
+    #[test]
+    fn length_extension_protection() {
+        assert_ne!(Blake2b256::digest(b""), Blake2b256::digest(&[0u8]));
+    }
+
+    #[test]
+    fn digest_differs_from_sha256() {
+        let data = b"compare algorithms";
+        let blake2b = Blake2b256::digest(data);
+        let sha256 = crate::strong::Sha256::digest(data);
+        assert_ne!(blake2b.as_ref(), sha256.as_ref());
+    }
+
+    #[test]
+    fn digest_differs_from_md5() {
+        let data = b"compare algorithms";
+        let blake2b = Blake2b256::digest(data);
+        let md5 = <crate::strong::Md5 as crate::strong::StrongDigest>::digest(data);
+        assert_ne!(blake2b.as_ref(), md5.as_ref());
+    }
+
+    #[test]
+    fn strong_digest_trait_matches_inherent_api() {
+        let data = b"trait dispatch parity";
+
+        let inherent = Blake2b256::digest(data);
+        let via_trait = <Blake2b256 as StrongDigest>::digest(data);
+        assert_eq!(inherent, via_trait);
+
+        let mut hasher = <Blake2b256 as StrongDigest>::with_seed(());
+        StrongDigest::update(&mut hasher, data);
+        let trait_streaming = StrongDigest::finalize(hasher);
+        assert_eq!(trait_streaming, inherent);
+
+        assert_eq!(<Blake2b256 as StrongDigest>::DIGEST_LEN, 32);
+    }
+}

--- a/crates/checksums/src/strong/mod.rs
+++ b/crates/checksums/src/strong/mod.rs
@@ -2,8 +2,8 @@
 //!
 //! Upstream rsync negotiates the strong checksum algorithm based on the protocol
 //! version and compile-time feature set. This module exposes streaming wrappers
-//! for MD4, MD5, XXH64, XXH3/64, and XXH3/128 so higher layers can compose the
-//! desired strategy without reimplementing the hashing primitives.
+//! for BLAKE2b-256, MD4, MD5, XXH64, XXH3/64, and XXH3/128 so higher layers
+//! can compose the desired strategy without reimplementing the hashing primitives.
 //!
 //! # Upstream Reference
 //!
@@ -16,7 +16,11 @@
 //! ## Cryptographic Hashes (MD4, MD5, SHA family)
 //!
 //! ```
-//! use checksums::strong::{Md4, Md5, Sha1, Sha256, StrongDigest};
+//! use checksums::strong::{Blake2b256, Md4, Md5, Sha1, Sha256, StrongDigest};
+//!
+//! // BLAKE2b-256 - modern hash for protocol 32
+//! let blake2b = Blake2b256::digest(b"data");
+//! assert_eq!(blake2b.as_ref().len(), 32);
 //!
 //! // MD4 - legacy algorithm for rsync protocol compatibility
 //! let md4 = Md4::digest(b"data");
@@ -55,6 +59,7 @@
 //! assert_eq!(xxh3_128.as_ref().len(), 16);
 //! ```
 
+mod blake2b;
 mod md4;
 mod md5;
 #[cfg(feature = "openssl")]
@@ -64,6 +69,9 @@ mod sha256;
 mod sha512;
 pub mod strategy;
 mod xxhash;
+
+/// Streaming BLAKE2b-256 hasher (256-bit output).
+pub use blake2b::Blake2b256;
 
 /// MD4 streaming hasher and batch digest function.
 ///
@@ -179,12 +187,23 @@ pub trait StrongDigest: Sized {
 
 #[cfg(test)]
 mod tests {
-    use super::{Md4, Md5, Sha1, Sha256, Sha512, StrongDigest, Xxh3, Xxh3_128, Xxh64};
+    use super::{Blake2b256, Md4, Md5, Sha1, Sha256, Sha512, StrongDigest, Xxh3, Xxh3_128, Xxh64};
 
     #[cfg(feature = "openssl")]
     #[test]
     fn openssl_detection_succeeds_when_feature_enabled() {
         assert!(super::openssl_acceleration_available());
+    }
+
+    #[test]
+    fn blake2b256_trait_round_trip_matches_inherent_api() {
+        let input = b"trait-check";
+
+        let mut via_trait = Blake2b256::new();
+        via_trait.update(input);
+        let trait_digest = via_trait.finalize();
+
+        assert_eq!(trait_digest.as_ref(), Blake2b256::digest(input).as_ref());
     }
 
     #[test]
@@ -282,6 +301,13 @@ mod tests {
     }
 
     #[test]
+    fn blake2b256_digest_len_is_32() {
+        assert_eq!(Blake2b256::DIGEST_LEN, 32);
+        let digest = Blake2b256::digest(b"test");
+        assert_eq!(digest.as_ref().len(), 32);
+    }
+
+    #[test]
     fn md5_digest_len_is_16() {
         assert_eq!(Md5::DIGEST_LEN, 16);
         let digest = Md5::digest(b"test");
@@ -338,6 +364,18 @@ mod tests {
     }
 
     #[test]
+    fn blake2b256_multiple_updates() {
+        let mut hasher = Blake2b256::new();
+        hasher.update(b"hello");
+        hasher.update(b" ");
+        hasher.update(b"world");
+        let split_digest = hasher.finalize();
+
+        let combined_digest = Blake2b256::digest(b"hello world");
+        assert_eq!(split_digest.as_ref(), combined_digest.as_ref());
+    }
+
+    #[test]
     fn md5_multiple_updates() {
         let mut hasher = Md5::new();
         hasher.update(b"hello");
@@ -387,6 +425,10 @@ mod tests {
     #[test]
     fn empty_input_produces_valid_digests() {
         let empty = b"";
+        assert_eq!(
+            Blake2b256::digest(empty).as_ref().len(),
+            Blake2b256::DIGEST_LEN
+        );
         assert_eq!(Md4::digest(empty).as_ref().len(), Md4::DIGEST_LEN);
         assert_eq!(Md5::digest(empty).as_ref().len(), Md5::DIGEST_LEN);
         assert_eq!(Sha1::digest(empty).as_ref().len(), Sha1::DIGEST_LEN);

--- a/crates/checksums/src/strong/strategy/impls.rs
+++ b/crates/checksums/src/strong/strategy/impls.rs
@@ -3,7 +3,38 @@
 use super::digest::ChecksumDigest;
 use super::kind::ChecksumAlgorithmKind;
 use super::trait_def::ChecksumStrategy;
-use crate::strong::{Md4, Md5, Md5Seed, Sha1, Sha256, Sha512, StrongDigest, Xxh3, Xxh3_128, Xxh64};
+use crate::strong::{
+    Blake2b256, Md4, Md5, Md5Seed, Sha1, Sha256, Sha512, StrongDigest, Xxh3, Xxh3_128, Xxh64,
+};
+
+/// BLAKE2b-256 checksum strategy for protocol 32 strong checksum negotiation.
+///
+/// BLAKE2b-256 produces a 256-bit (32-byte) digest with performance competitive
+/// with MD5 while providing full collision resistance.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct Blake2b256Strategy;
+
+impl Blake2b256Strategy {
+    /// Creates a new BLAKE2b-256 strategy.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self
+    }
+}
+
+impl ChecksumStrategy for Blake2b256Strategy {
+    fn compute(&self, data: &[u8]) -> ChecksumDigest {
+        ChecksumDigest::new(Blake2b256::digest(data).as_ref())
+    }
+
+    fn digest_len(&self) -> usize {
+        Blake2b256::DIGEST_LEN
+    }
+
+    fn algorithm_kind(&self) -> ChecksumAlgorithmKind {
+        ChecksumAlgorithmKind::Blake2b256
+    }
+}
 
 /// MD4 checksum strategy for rsync protocol versions < 30.
 ///

--- a/crates/checksums/src/strong/strategy/kind.rs
+++ b/crates/checksums/src/strong/strategy/kind.rs
@@ -12,6 +12,11 @@ use std::fmt;
 /// Suitable for algorithm selection, comparison, and protocol negotiation.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 pub enum ChecksumAlgorithmKind {
+    /// BLAKE2b-256 - modern cryptographic hash for protocol 32.
+    ///
+    /// BLAKE2b-256 produces a 256-bit (32-byte) digest with performance
+    /// competitive with MD5 while providing full collision resistance.
+    Blake2b256,
     /// MD4 - legacy algorithm for rsync protocol < 30.
     ///
     /// Upstream rsync uses MD4 as the default strong checksum for older protocol
@@ -41,6 +46,7 @@ impl ChecksumAlgorithmKind {
     #[must_use]
     pub const fn name(&self) -> &'static str {
         match self {
+            Self::Blake2b256 => "blake2b",
             Self::Md4 => "md4",
             Self::Md5 => "md5",
             Self::Sha1 => "sha1",
@@ -58,7 +64,7 @@ impl ChecksumAlgorithmKind {
         match self {
             Self::Md4 | Self::Md5 | Self::Xxh3_128 => 16,
             Self::Sha1 => 20,
-            Self::Sha256 => 32,
+            Self::Blake2b256 | Self::Sha256 => 32,
             Self::Sha512 => 64,
             Self::Xxh64 | Self::Xxh3 => 8,
         }
@@ -72,7 +78,7 @@ impl ChecksumAlgorithmKind {
     pub const fn is_cryptographic(&self) -> bool {
         matches!(
             self,
-            Self::Md4 | Self::Md5 | Self::Sha1 | Self::Sha256 | Self::Sha512
+            Self::Blake2b256 | Self::Md4 | Self::Md5 | Self::Sha1 | Self::Sha256 | Self::Sha512
         )
     }
 
@@ -83,6 +89,7 @@ impl ChecksumAlgorithmKind {
     #[must_use]
     pub fn from_name(name: &str) -> Option<Self> {
         match name.to_ascii_lowercase().as_str() {
+            "blake2b" | "blake2b-256" | "blake2b256" => Some(Self::Blake2b256),
             "md4" => Some(Self::Md4),
             "md5" => Some(Self::Md5),
             "sha1" | "sha-1" => Some(Self::Sha1),
@@ -99,6 +106,7 @@ impl ChecksumAlgorithmKind {
     #[must_use]
     pub const fn all() -> &'static [Self] {
         &[
+            Self::Blake2b256,
             Self::Md4,
             Self::Md5,
             Self::Sha1,

--- a/crates/checksums/src/strong/strategy/mod.rs
+++ b/crates/checksums/src/strong/strategy/mod.rs
@@ -85,8 +85,8 @@ mod tests;
 
 pub use digest::{ChecksumDigest, MAX_DIGEST_LEN};
 pub use impls::{
-    Md4Strategy, Md5Strategy, Sha1Strategy, Sha256Strategy, Sha512Strategy, Xxh3_128Strategy,
-    Xxh3Strategy, Xxh64Strategy,
+    Blake2b256Strategy, Md4Strategy, Md5Strategy, Sha1Strategy, Sha256Strategy, Sha512Strategy,
+    Xxh3_128Strategy, Xxh3Strategy, Xxh64Strategy,
 };
 pub use kind::ChecksumAlgorithmKind;
 pub use seed::{Md5SeedConfig, SeedConfig};

--- a/crates/checksums/src/strong/strategy/selector.rs
+++ b/crates/checksums/src/strong/strategy/selector.rs
@@ -6,8 +6,8 @@
 //! - `compat.c` - checksum capability negotiation for XXH3/SHA family
 
 use super::impls::{
-    Md4Strategy, Md5Strategy, Sha1Strategy, Sha256Strategy, Sha512Strategy, Xxh3_128Strategy,
-    Xxh3Strategy, Xxh64Strategy,
+    Blake2b256Strategy, Md4Strategy, Md5Strategy, Sha1Strategy, Sha256Strategy, Sha512Strategy,
+    Xxh3_128Strategy, Xxh3Strategy, Xxh64Strategy,
 };
 use super::kind::ChecksumAlgorithmKind;
 use super::seed::{SeedConfig, extract_u64_seed};
@@ -86,6 +86,7 @@ impl ChecksumStrategySelector {
     #[must_use]
     pub fn for_algorithm(kind: ChecksumAlgorithmKind, seed: i32) -> Box<dyn ChecksumStrategy> {
         match kind {
+            ChecksumAlgorithmKind::Blake2b256 => Box::new(Blake2b256Strategy::new()),
             ChecksumAlgorithmKind::Md4 => Box::new(Md4Strategy::new()),
             ChecksumAlgorithmKind::Md5 => Box::new(Md5Strategy::with_legacy_seed(seed)),
             ChecksumAlgorithmKind::Sha1 => Box::new(Sha1Strategy::new()),
@@ -119,6 +120,7 @@ impl ChecksumStrategySelector {
         seed: SeedConfig,
     ) -> Box<dyn ChecksumStrategy> {
         match kind {
+            ChecksumAlgorithmKind::Blake2b256 => Box::new(Blake2b256Strategy::new()),
             ChecksumAlgorithmKind::Md4 => Box::new(Md4Strategy::new()),
             ChecksumAlgorithmKind::Md5 => {
                 let md5_seed = match seed {
@@ -137,6 +139,12 @@ impl ChecksumStrategySelector {
                 Box::new(Xxh3_128Strategy::new(extract_u64_seed(&seed)))
             }
         }
+    }
+
+    /// Creates a concrete (non-boxed) BLAKE2b-256 strategy.
+    #[must_use]
+    pub const fn blake2b256() -> Blake2b256Strategy {
+        Blake2b256Strategy::new()
     }
 
     /// Creates a concrete (non-boxed) MD4 strategy.

--- a/crates/checksums/src/strong/strategy/tests.rs
+++ b/crates/checksums/src/strong/strategy/tests.rs
@@ -59,6 +59,7 @@ fn digest_display() {
 
 #[test]
 fn algorithm_kind_name() {
+    assert_eq!(ChecksumAlgorithmKind::Blake2b256.name(), "blake2b");
     assert_eq!(ChecksumAlgorithmKind::Md4.name(), "md4");
     assert_eq!(ChecksumAlgorithmKind::Md5.name(), "md5");
     assert_eq!(ChecksumAlgorithmKind::Sha1.name(), "sha1");
@@ -71,6 +72,7 @@ fn algorithm_kind_name() {
 
 #[test]
 fn algorithm_kind_digest_len() {
+    assert_eq!(ChecksumAlgorithmKind::Blake2b256.digest_len(), 32);
     assert_eq!(ChecksumAlgorithmKind::Md4.digest_len(), 16);
     assert_eq!(ChecksumAlgorithmKind::Md5.digest_len(), 16);
     assert_eq!(ChecksumAlgorithmKind::Sha1.digest_len(), 20);
@@ -83,6 +85,7 @@ fn algorithm_kind_digest_len() {
 
 #[test]
 fn algorithm_kind_is_cryptographic() {
+    assert!(ChecksumAlgorithmKind::Blake2b256.is_cryptographic());
     assert!(ChecksumAlgorithmKind::Md4.is_cryptographic());
     assert!(ChecksumAlgorithmKind::Md5.is_cryptographic());
     assert!(ChecksumAlgorithmKind::Sha1.is_cryptographic());
@@ -95,6 +98,18 @@ fn algorithm_kind_is_cryptographic() {
 
 #[test]
 fn algorithm_kind_from_name() {
+    assert_eq!(
+        ChecksumAlgorithmKind::from_name("blake2b"),
+        Some(ChecksumAlgorithmKind::Blake2b256)
+    );
+    assert_eq!(
+        ChecksumAlgorithmKind::from_name("blake2b-256"),
+        Some(ChecksumAlgorithmKind::Blake2b256)
+    );
+    assert_eq!(
+        ChecksumAlgorithmKind::from_name("blake2b256"),
+        Some(ChecksumAlgorithmKind::Blake2b256)
+    );
     assert_eq!(
         ChecksumAlgorithmKind::from_name("md4"),
         Some(ChecksumAlgorithmKind::Md4)
@@ -122,9 +137,27 @@ fn algorithm_kind_from_name() {
 #[test]
 fn algorithm_kind_all() {
     let all = ChecksumAlgorithmKind::all();
-    assert_eq!(all.len(), 8);
+    assert_eq!(all.len(), 9);
+    assert!(all.contains(&ChecksumAlgorithmKind::Blake2b256));
     assert!(all.contains(&ChecksumAlgorithmKind::Md4));
     assert!(all.contains(&ChecksumAlgorithmKind::Xxh3_128));
+}
+
+#[test]
+fn blake2b256_strategy_compute() {
+    let strategy = Blake2b256Strategy::new();
+    let digest = strategy.compute(b"test");
+    assert_eq!(digest.len(), 32);
+    assert_eq!(strategy.digest_len(), 32);
+    assert_eq!(strategy.algorithm_name(), "blake2b");
+}
+
+#[test]
+fn blake2b256_strategy_differs_from_sha256() {
+    let blake2b = Blake2b256Strategy::new();
+    let sha256 = Sha256Strategy::new();
+    let data = b"comparison";
+    assert_ne!(blake2b.compute(data), sha256.compute(data));
 }
 
 #[test]
@@ -462,6 +495,9 @@ fn selector_with_seed_config_xxh3() {
 
 #[test]
 fn selector_concrete_factories() {
+    let blake2b256 = ChecksumStrategySelector::blake2b256();
+    assert_eq!(blake2b256.digest_len(), 32);
+
     let md4 = ChecksumStrategySelector::md4();
     assert_eq!(md4.algorithm_name(), "md4");
 
@@ -495,6 +531,7 @@ fn selector_concrete_factories() {
 fn strategies_are_send_sync() {
     fn assert_send_sync<T: Send + Sync>() {}
 
+    assert_send_sync::<Blake2b256Strategy>();
     assert_send_sync::<Md4Strategy>();
     assert_send_sync::<Md5Strategy>();
     assert_send_sync::<Sha1Strategy>();
@@ -508,6 +545,7 @@ fn strategies_are_send_sync() {
 #[test]
 fn boxed_strategy_works() {
     let strategies: Vec<Box<dyn ChecksumStrategy>> = vec![
+        Box::new(Blake2b256Strategy::new()),
         Box::new(Md4Strategy::new()),
         Box::new(Md5Strategy::new()),
         Box::new(Sha1Strategy::new()),

--- a/crates/checksums/tests/checksum_variants_upstream_compat.rs
+++ b/crates/checksums/tests/checksum_variants_upstream_compat.rs
@@ -372,7 +372,7 @@ fn algorithm_kind_from_name_case_insensitive() {
 fn algorithm_kind_from_name_rejects_invalid() {
     let invalid = [
         "none", // valid in protocol but not a checksum algorithm kind
-        "invalid", "", "md6", "sha384", "sha3-256", "blake2b", "crc32",
+        "invalid", "", "md6", "sha384", "sha3-256", "crc32",
     ];
     for name in invalid {
         assert_eq!(
@@ -659,6 +659,7 @@ fn for_algorithm_factory_matches_concrete_factories() {
     for kind in ChecksumAlgorithmKind::all() {
         let boxed = ChecksumStrategySelector::for_algorithm(*kind, seed);
         let concrete: Box<dyn ChecksumStrategy> = match kind {
+            ChecksumAlgorithmKind::Blake2b256 => Box::new(ChecksumStrategySelector::blake2b256()),
             ChecksumAlgorithmKind::Md4 => Box::new(ChecksumStrategySelector::md4()),
             ChecksumAlgorithmKind::Md5 => Box::new(ChecksumStrategySelector::md5_legacy(seed)),
             ChecksumAlgorithmKind::Sha1 => Box::new(ChecksumStrategySelector::sha1()),
@@ -939,11 +940,11 @@ fn all_upstream_algorithms_are_supported() {
 
 #[test]
 fn algorithm_kind_all_contains_eight_variants() {
-    // MD4, MD5, SHA1, SHA256, SHA512, XXH64, XXH3, XXH3-128
+    // BLAKE2b-256, MD4, MD5, SHA1, SHA256, SHA512, XXH64, XXH3, XXH3-128
     assert_eq!(
         ChecksumAlgorithmKind::all().len(),
-        8,
-        "Should have 8 algorithm variants"
+        9,
+        "Should have 9 algorithm variants"
     );
 }
 // rsync's checksum_seed is an i32. When passed to XXHash (which takes u64),

--- a/crates/core/src/client/config/enums/checksum.rs
+++ b/crates/core/src/client/config/enums/checksum.rs
@@ -9,6 +9,8 @@ use engine::signature::SignatureAlgorithm;
 pub enum StrongChecksumAlgorithm {
     /// Automatically selects the negotiated algorithm (locally resolved to MD5).
     Auto,
+    /// BLAKE2b-256 strong checksum (protocol 32).
+    Blake2b,
     /// MD4 strong checksum.
     Md4,
     /// MD5 strong checksum.
@@ -34,6 +36,7 @@ impl StrongChecksumAlgorithm {
                     seed_config: Md5Seed::none(),
                 }
             }
+            StrongChecksumAlgorithm::Blake2b => SignatureAlgorithm::Blake2b256,
             StrongChecksumAlgorithm::Md4 => SignatureAlgorithm::Md4,
             StrongChecksumAlgorithm::Sha1 => SignatureAlgorithm::Sha1,
             StrongChecksumAlgorithm::Xxh64 => SignatureAlgorithm::Xxh64 { seed: 0 },
@@ -47,6 +50,7 @@ impl StrongChecksumAlgorithm {
     pub const fn canonical_name(self) -> &'static str {
         match self {
             StrongChecksumAlgorithm::Auto => "auto",
+            StrongChecksumAlgorithm::Blake2b => "blake2b",
             StrongChecksumAlgorithm::Md4 => "md4",
             StrongChecksumAlgorithm::Md5 => "md5",
             StrongChecksumAlgorithm::Sha1 => "sha1",
@@ -64,6 +68,7 @@ impl StrongChecksumAlgorithm {
     pub const fn to_protocol_algorithm(self) -> Option<protocol::ChecksumAlgorithm> {
         match self {
             StrongChecksumAlgorithm::Auto => None,
+            StrongChecksumAlgorithm::Blake2b => Some(protocol::ChecksumAlgorithm::Blake2b),
             StrongChecksumAlgorithm::Md4 => Some(protocol::ChecksumAlgorithm::MD4),
             StrongChecksumAlgorithm::Md5 => Some(protocol::ChecksumAlgorithm::MD5),
             StrongChecksumAlgorithm::Sha1 => Some(protocol::ChecksumAlgorithm::SHA1),
@@ -112,6 +117,7 @@ impl StrongChecksumChoice {
         let normalized = label.trim().to_ascii_lowercase();
         match normalized.as_str() {
             "auto" => Ok(StrongChecksumAlgorithm::Auto),
+            "blake2b" | "blake2b-256" | "blake2b256" => Ok(StrongChecksumAlgorithm::Blake2b),
             "md4" => Ok(StrongChecksumAlgorithm::Md4),
             "md5" => Ok(StrongChecksumAlgorithm::Md5),
             "sha1" => Ok(StrongChecksumAlgorithm::Sha1),

--- a/crates/engine/benches/delta_transfer_benchmark.rs
+++ b/crates/engine/benches/delta_transfer_benchmark.rs
@@ -76,6 +76,7 @@ fn build_index(
         | SignatureAlgorithm::Md5 { .. } => 16,
         SignatureAlgorithm::Xxh3 { .. } | SignatureAlgorithm::Xxh64 { .. } => 8,
         SignatureAlgorithm::Xxh3_128 { .. } | SignatureAlgorithm::Sha1 => 16,
+        SignatureAlgorithm::Blake2b256 => 32,
     };
     let params = SignatureLayoutParams::new(
         data.len() as u64,

--- a/crates/engine/src/local_copy/executor/directory/parallel_checksum.rs
+++ b/crates/engine/src/local_copy/executor/directory/parallel_checksum.rs
@@ -26,7 +26,7 @@ use std::sync::Arc;
 
 use rayon::prelude::*;
 
-use checksums::strong::{Md4, Md5, Sha1, StrongDigest, Xxh3, Xxh3_128, Xxh64};
+use checksums::strong::{Blake2b256, Md4, Md5, Sha1, StrongDigest, Xxh3, Xxh3_128, Xxh64};
 
 use crate::local_copy::buffer_pool::{BufferPool, global_buffer_pool};
 use crate::signature::SignatureAlgorithm;
@@ -227,6 +227,17 @@ fn hash_file_contents(
         }
         SignatureAlgorithm::Xxh3_128 { seed } => {
             let mut hasher = Xxh3_128::new(seed);
+            loop {
+                let n = file.read(&mut buffer)?;
+                if n == 0 {
+                    break;
+                }
+                hasher.update(&buffer[..n]);
+            }
+            hasher.finalize().as_ref().to_vec()
+        }
+        SignatureAlgorithm::Blake2b256 => {
+            let mut hasher = Blake2b256::new();
             loop {
                 let n = file.read(&mut buffer)?;
                 if n == 0 {

--- a/crates/protocol/src/negotiation/capabilities/algorithms.rs
+++ b/crates/protocol/src/negotiation/capabilities/algorithms.rs
@@ -5,8 +5,9 @@ use std::io;
 /// This list matches upstream rsync 3.4.1's default order.
 /// The client will select the first algorithm in this list that it also supports.
 /// Upstream order: xxh128 xxh3 xxh64 md5 md4 sha1 none
-pub(super) const SUPPORTED_CHECKSUMS: &[&str] =
-    &["xxh128", "xxh3", "xxh64", "md5", "md4", "sha1", "none"];
+pub(super) const SUPPORTED_CHECKSUMS: &[&str] = &[
+    "xxh128", "xxh3", "xxh64", "blake2b", "md5", "md4", "sha1", "none",
+];
 
 /// Returns supported compression algorithms in preference order for negotiation.
 ///
@@ -51,6 +52,8 @@ pub(super) fn supported_compressions() -> Vec<&'static str> {
 pub enum ChecksumAlgorithm {
     /// No checksum - used for directory listings and dry-run modes.
     None,
+    /// BLAKE2b-256 checksum - modern cryptographic hash for protocol 32.
+    Blake2b,
     /// MD4 checksum - legacy default for protocol versions below 30.
     MD4,
     /// MD5 checksum - default for protocol 30+ when negotiation is unavailable.
@@ -70,6 +73,7 @@ impl ChecksumAlgorithm {
     pub const fn as_str(&self) -> &'static str {
         match self {
             Self::None => "none",
+            Self::Blake2b => "blake2b",
             Self::MD4 => "md4",
             Self::MD5 => "md5",
             Self::SHA1 => "sha1",
@@ -87,6 +91,7 @@ impl ChecksumAlgorithm {
     pub fn parse(name: &str) -> io::Result<Self> {
         match name {
             "none" => Ok(Self::None),
+            "blake2b" | "blake2b-256" | "blake2b256" => Ok(Self::Blake2b),
             "md4" => Ok(Self::MD4),
             "md5" => Ok(Self::MD5),
             "sha1" => Ok(Self::SHA1),

--- a/crates/signature/src/algorithm.rs
+++ b/crates/signature/src/algorithm.rs
@@ -3,15 +3,15 @@
 use std::fmt;
 
 use checksums::strong::{
-    Md4, Md5, Md5Seed, Sha1, StrongDigest, Xxh3, Xxh3_128, Xxh64, md4_digest_batch,
+    Blake2b256, Md4, Md5, Md5Seed, Sha1, StrongDigest, Xxh3, Xxh3_128, Xxh64, md4_digest_batch,
     md5_digest_batch,
 };
 
 /// Stack-allocated buffer for strong checksum digests, avoiding heap allocation
 /// in the delta matching hot path.
 ///
-/// Sized to hold the largest supported digest (SHA-1, 20 bytes). All other
-/// algorithms produce 8 or 16 bytes, so this fits comfortably on the stack.
+/// Sized to hold the largest supported digest (BLAKE2b-256, 32 bytes). All other
+/// algorithms produce 8, 16, or 20 bytes, so this fits comfortably on the stack.
 #[derive(Clone, Copy)]
 pub struct DigestBuf {
     buf: [u8; Self::MAX_LEN],
@@ -19,8 +19,8 @@ pub struct DigestBuf {
 }
 
 impl DigestBuf {
-    /// Maximum digest length across all supported algorithms (SHA-1 = 20 bytes).
-    pub const MAX_LEN: usize = 20;
+    /// Maximum digest length across all supported algorithms (BLAKE2b-256 = 32 bytes).
+    pub const MAX_LEN: usize = 32;
 
     /// Returns the digest bytes as a slice.
     #[inline]
@@ -99,6 +99,8 @@ pub enum SignatureAlgorithm {
         /// Seed configuration for MD5 checksum calculation.
         seed_config: Md5Seed,
     },
+    /// BLAKE2b-256, negotiated in protocol 32 for modern cryptographic integrity.
+    Blake2b256,
     /// SHA-1, available when both peers advertise it.
     Sha1,
     /// XXH64, available in newer protocol combinations with an explicit seed.
@@ -128,6 +130,7 @@ impl SignatureAlgorithm {
             | SignatureAlgorithm::Md4Seeded { .. }
             | SignatureAlgorithm::Md5 { .. } => 16,
             SignatureAlgorithm::Sha1 => Sha1::DIGEST_LEN,
+            SignatureAlgorithm::Blake2b256 => Blake2b256::DIGEST_LEN,
             SignatureAlgorithm::Xxh64 { .. } | SignatureAlgorithm::Xxh3 { .. } => 8,
             SignatureAlgorithm::Xxh3_128 { .. } => 16,
         }
@@ -151,6 +154,9 @@ impl SignatureAlgorithm {
             ),
             SignatureAlgorithm::Sha1 => {
                 DigestBuf::from_slice(Sha1::digest(data).as_ref(), effective_len)
+            }
+            SignatureAlgorithm::Blake2b256 => {
+                DigestBuf::from_slice(Blake2b256::digest(data).as_ref(), effective_len)
             }
             SignatureAlgorithm::Xxh64 { seed } => {
                 DigestBuf::from_slice(Xxh64::digest(seed, data).as_ref(), effective_len)
@@ -239,6 +245,12 @@ impl SignatureAlgorithm {
             }
             SignatureAlgorithm::Md5 { seed_config } => {
                 let mut h = Md5::with_seed(seed_config);
+                h.update(a);
+                h.update(b);
+                DigestBuf::from_slice(h.finalize().as_ref(), effective_len)
+            }
+            SignatureAlgorithm::Blake2b256 => {
+                let mut h = Blake2b256::new();
                 h.update(a);
                 h.update(b);
                 DigestBuf::from_slice(h.finalize().as_ref(), effective_len)

--- a/crates/transfer/src/delta_apply/checksum.rs
+++ b/crates/transfer/src/delta_apply/checksum.rs
@@ -2,7 +2,7 @@
 //!
 //! upstream: `receiver.c` end-of-file digest verification.
 
-use checksums::strong::{Md4, Md5, Sha1, StrongDigest, Xxh3, Xxh3_128, Xxh64};
+use checksums::strong::{Blake2b256, Md4, Md5, Sha1, StrongDigest, Xxh3, Xxh3_128, Xxh64};
 use protocol::{ChecksumAlgorithm, CompatibilityFlags, NegotiationResult, ProtocolVersion};
 
 /// Whole-file checksum verifier with enum dispatch for zero-allocation runtime
@@ -13,6 +13,8 @@ pub enum ChecksumVerifier {
     /// No checksum - `CSUM_NONE` negotiated. 1-byte placeholder digest
     /// matching upstream `receiver.c` behaviour.
     None,
+    /// BLAKE2b-256 checksum (protocol 32 negotiated).
+    Blake2b(Blake2b256),
     /// MD4 checksum (legacy, protocol < 30).
     Md4(Md4),
     /// MD5 checksum (protocol 30+ default).
@@ -85,6 +87,7 @@ impl ChecksumVerifier {
     pub fn for_algorithm(algorithm: ChecksumAlgorithm) -> Self {
         match algorithm {
             ChecksumAlgorithm::None => Self::None,
+            ChecksumAlgorithm::Blake2b => Self::Blake2b(Blake2b256::new()),
             ChecksumAlgorithm::MD4 => Self::Md4(Md4::new()),
             ChecksumAlgorithm::MD5 => Self::Md5(Md5::new()),
             ChecksumAlgorithm::SHA1 => Self::Sha1(Sha1::new()),
@@ -100,6 +103,7 @@ impl ChecksumVerifier {
     pub const fn algorithm(&self) -> ChecksumAlgorithm {
         match self {
             Self::None => ChecksumAlgorithm::None,
+            Self::Blake2b(_) => ChecksumAlgorithm::Blake2b,
             Self::Md4(_) => ChecksumAlgorithm::MD4,
             Self::Md5(_) => ChecksumAlgorithm::MD5,
             Self::Sha1(_) => ChecksumAlgorithm::SHA1,
@@ -114,6 +118,7 @@ impl ChecksumVerifier {
     pub fn update(&mut self, data: &[u8]) {
         match self {
             Self::None => {}
+            Self::Blake2b(h) => h.update(data),
             Self::Md4(h) => h.update(data),
             Self::Md5(h) => h.update(data),
             Self::Sha1(h) => h.update(data),
@@ -123,8 +128,8 @@ impl ChecksumVerifier {
         }
     }
 
-    /// Maximum digest length across all supported algorithms (SHA1 = 20 bytes).
-    pub const MAX_DIGEST_LEN: usize = 20;
+    /// Maximum digest length across all supported algorithms (BLAKE2b-256 = 32 bytes).
+    pub const MAX_DIGEST_LEN: usize = 32;
 
     /// Returns the digest length for the current algorithm.
     #[inline]
@@ -134,6 +139,7 @@ impl ChecksumVerifier {
             Self::None => 1,
             Self::Md4(_) | Self::Md5(_) | Self::Xxh128(_) => 16,
             Self::Sha1(_) => 20,
+            Self::Blake2b(_) => 32,
             Self::Xxh64(_) | Self::Xxh3(_) => 8,
         }
     }
@@ -147,6 +153,7 @@ impl ChecksumVerifier {
         let len = self.digest_len();
         match self {
             Self::None => buf[0] = 0,
+            Self::Blake2b(h) => buf[..len].copy_from_slice(h.finalize().as_ref()),
             Self::Md4(h) => buf[..len].copy_from_slice(h.finalize().as_ref()),
             Self::Md5(h) => buf[..len].copy_from_slice(h.finalize().as_ref()),
             Self::Sha1(h) => buf[..len].copy_from_slice(h.finalize().as_ref()),

--- a/crates/transfer/src/shared/checksum.rs
+++ b/crates/transfer/src/shared/checksum.rs
@@ -165,6 +165,7 @@ impl ChecksumFactory {
                 };
                 SignatureAlgorithm::Md5 { seed_config }
             }
+            ChecksumAlgorithm::Blake2b => SignatureAlgorithm::Blake2b256,
             ChecksumAlgorithm::SHA1 => SignatureAlgorithm::Sha1,
             ChecksumAlgorithm::XXH64 => SignatureAlgorithm::Xxh64 { seed: seed_u64 },
             ChecksumAlgorithm::XXH3 => SignatureAlgorithm::Xxh3 { seed: seed_u64 },
@@ -191,6 +192,7 @@ impl ChecksumFactory {
         match self.algorithm {
             ChecksumAlgorithm::None | ChecksumAlgorithm::MD4 | ChecksumAlgorithm::MD5 => 16,
             ChecksumAlgorithm::SHA1 => 20,
+            ChecksumAlgorithm::Blake2b => 32,
             ChecksumAlgorithm::XXH64 | ChecksumAlgorithm::XXH3 => 8,
             ChecksumAlgorithm::XXH128 => 16,
         }


### PR DESCRIPTION
## Summary

- Add BLAKE2b-256 as a negotiable strong checksum algorithm for protocol 32, wired across all six crates that participate in checksum dispatch (checksums, protocol, signature, transfer, core, engine)
- The `blake2` crate (v0.10) provides the underlying hash implementation, producing a 256-bit (32-byte) digest with performance competitive with MD5 while providing full collision resistance
- `DigestBuf::MAX_LEN` and `ChecksumVerifier::MAX_DIGEST_LEN` raised from 20 to 32 to accommodate the 32-byte digest

## Test plan

- [x] 19 unit tests for Blake2b256 hasher (RFC vectors, streaming/one-shot parity, chunk sizes, cross-algorithm comparison)
- [x] Strategy pattern tests: blake2b256 compute, digest length, send+sync, boxed dispatch
- [x] ChecksumAlgorithmKind tests: name, digest_len, is_cryptographic, from_name (incl. aliases blake2b-256/blake2b256), all() count updated to 9
- [x] Integration test: for_algorithm_factory_matches_concrete_factories exhaustive match updated
- [x] Full workspace compilation verified (`cargo check --workspace --all-features`)
- [x] Clippy clean (no new warnings)
- [ ] CI: fmt+clippy, nextest (stable), Windows, macOS, Linux musl