### PR TITLE
feat(fast_io): add Windows ReFS reflink via FSCTL_DUPLICATE_EXTENTS (#1389)

### DIFF
--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -132,6 +132,7 @@ pub use parallel::{ParallelExecutor, ParallelResult};
 pub use platform_copy::{
     CopyMethod, CopyResult, DefaultPlatformCopy, NoCowPlatformCopy, NoZeroCopyPlatformCopy,
     PlatformCopy, try_clonefile, try_fcopyfile, try_ficlone, try_refs_reflink,
+    try_refs_reflink_range,
 };
 pub use traits::{FileReader, FileWriter};
 
@@ -339,7 +340,7 @@ pub use io_uring::{
 /// - **Linux**: `copy_file_range`, `sendfile`, `splice` (runtime-probed),
 ///   `FICLONE`, `O_TMPFILE`, `io_uring` (runtime-probed)
 /// - **macOS**: `clonefile`, `fcopyfile`
-/// - **Windows**: `CopyFileEx`, `IOCP` (runtime-probed)
+/// - **Windows**: `CopyFileEx`, `ReFS reflink`, `IOCP` (runtime-probed)
 #[must_use]
 pub fn platform_io_capabilities() -> Vec<&'static str> {
     let mut caps = Vec::new();
@@ -373,6 +374,7 @@ pub fn platform_io_capabilities() -> Vec<&'static str> {
     #[cfg(target_os = "windows")]
     {
         caps.push("CopyFileEx");
+        caps.push("ReFS reflink");
         if is_iocp_available() {
             caps.push("IOCP");
         }
@@ -827,6 +829,7 @@ mod tests {
         #[cfg(target_os = "windows")]
         {
             assert!(caps.contains(&"CopyFileEx"));
+            assert!(caps.contains(&"ReFS reflink"));
         }
     }
 

--- a/crates/fast_io/src/platform_copy/dispatch.rs
+++ b/crates/fast_io/src/platform_copy/dispatch.rs
@@ -483,6 +483,214 @@ pub(super) fn try_refs_reflink_impl(src: &Path, dst: &Path) -> io::Result<()> {
     Ok(())
 }
 
+/// Windows ReFS partial-file reflink via `FSCTL_DUPLICATE_EXTENTS_TO_FILE`.
+///
+/// Clones a range of blocks from `src` into `dst` at the specified offsets.
+/// Both `src_offset`, `dst_offset`, and `byte_count` must be cluster-aligned
+/// (this function queries the cluster size and rounds accordingly). The
+/// destination file must already exist and be large enough to hold the cloned
+/// range at the target offset.
+///
+/// # Arguments
+///
+/// * `src` - Source file path (must exist and be readable)
+/// * `dst` - Destination file path (must exist and be writable)
+/// * `src_offset` - Byte offset in the source file to start cloning from
+/// * `dst_offset` - Byte offset in the destination file to clone into
+/// * `byte_count` - Number of bytes to clone (rounded up to cluster boundary)
+///
+/// # Constraints
+///
+/// - Both files must be on the same ReFS volume.
+/// - Offsets and byte_count are rounded up to the volume's cluster size.
+/// - The destination must be pre-sized to accommodate `dst_offset + aligned_byte_count`.
+/// - On failure, partial state may remain - the caller should clean up.
+///
+/// # References
+///
+/// - upstream: ReFS block cloning is an oc-rsync optimization (no upstream equivalent).
+/// - Microsoft docs: `FSCTL_DUPLICATE_EXTENTS_TO_FILE` control code.
+#[cfg(target_os = "windows")]
+#[allow(unsafe_code)]
+pub(super) fn try_refs_reflink_range_impl(
+    src: &Path,
+    dst: &Path,
+    src_offset: u64,
+    dst_offset: u64,
+    byte_count: u64,
+) -> io::Result<()> {
+    use std::os::windows::ffi::OsStrExt;
+
+    use windows_sys::Win32::Foundation::{CloseHandle, HANDLE, INVALID_HANDLE_VALUE};
+    use windows_sys::Win32::Storage::FileSystem::{
+        CreateFileW, FILE_ATTRIBUTE_NORMAL, FILE_SHARE_READ, GetDiskFreeSpaceW, OPEN_EXISTING,
+    };
+    use windows_sys::Win32::System::IO::DeviceIoControl;
+
+    /// Generic read access right.
+    const GENERIC_READ: u32 = 0x8000_0000;
+    /// Generic write access right.
+    const GENERIC_WRITE: u32 = 0x4000_0000;
+
+    /// `FSCTL_DUPLICATE_EXTENTS_TO_FILE` control code.
+    const FSCTL_DUPLICATE_EXTENTS_TO_FILE: u32 = 0x0009_8344;
+
+    /// Input structure for `FSCTL_DUPLICATE_EXTENTS_TO_FILE`.
+    #[repr(C)]
+    struct DuplicateExtentsData {
+        file_handle: isize,
+        source_file_offset: i64,
+        target_file_offset: i64,
+        byte_count: i64,
+    }
+
+    if byte_count == 0 {
+        return Ok(());
+    }
+
+    // Query cluster size for alignment.
+    let volume_root = dst.ancestors().last().unwrap_or(dst);
+    let root_wide: Vec<u16> = volume_root
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
+
+    let mut sectors_per_cluster: u32 = 0;
+    let mut bytes_per_sector: u32 = 0;
+    let mut free_clusters: u32 = 0;
+    let mut total_clusters: u32 = 0;
+
+    // SAFETY: root_wide is a valid null-terminated UTF-16 string.
+    // Output pointers are valid stack-allocated u32 variables.
+    let disk_result = unsafe {
+        GetDiskFreeSpaceW(
+            root_wide.as_ptr(),
+            &mut sectors_per_cluster,
+            &mut bytes_per_sector,
+            &mut free_clusters,
+            &mut total_clusters,
+        )
+    };
+
+    if disk_result == 0 {
+        return Err(io::Error::last_os_error());
+    }
+
+    let cluster_size = u64::from(sectors_per_cluster) * u64::from(bytes_per_sector);
+    if cluster_size == 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "cluster size is zero",
+        ));
+    }
+
+    let params = compute_duplicate_extents_params(src_offset, dst_offset, byte_count, cluster_size);
+
+    let src_wide: Vec<u16> = src
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
+
+    // SAFETY: src_wide is a valid null-terminated UTF-16 path.
+    let src_handle = unsafe {
+        CreateFileW(
+            src_wide.as_ptr(),
+            GENERIC_READ,
+            FILE_SHARE_READ,
+            std::ptr::null(),
+            OPEN_EXISTING,
+            FILE_ATTRIBUTE_NORMAL,
+            std::ptr::null_mut(),
+        )
+    };
+
+    if src_handle == INVALID_HANDLE_VALUE {
+        return Err(io::Error::last_os_error());
+    }
+
+    let dst_wide: Vec<u16> = dst
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
+
+    // Open destination for writing. OPEN_EXISTING because the caller must
+    // pre-create and pre-size the destination for partial reflink.
+    // SAFETY: dst_wide is a valid null-terminated UTF-16 path.
+    let dst_handle = unsafe {
+        CreateFileW(
+            dst_wide.as_ptr(),
+            GENERIC_READ | GENERIC_WRITE,
+            0,
+            std::ptr::null(),
+            OPEN_EXISTING,
+            FILE_ATTRIBUTE_NORMAL,
+            std::ptr::null_mut(),
+        )
+    };
+
+    if dst_handle == INVALID_HANDLE_VALUE {
+        let err = io::Error::last_os_error();
+        // SAFETY: src_handle is a valid open handle.
+        unsafe { CloseHandle(src_handle) };
+        return Err(err);
+    }
+
+    let dup_data = DuplicateExtentsData {
+        file_handle: src_handle as isize,
+        source_file_offset: params.source_offset as i64,
+        target_file_offset: params.target_offset as i64,
+        byte_count: params.byte_count as i64,
+    };
+
+    let mut bytes_returned: u32 = 0;
+
+    // SAFETY: dst_handle and src_handle are valid open file handles.
+    // dup_data is a properly initialized DuplicateExtentsData struct with
+    // cluster-aligned offsets. bytes_returned is a valid output pointer.
+    let ioctl_result = unsafe {
+        DeviceIoControl(
+            dst_handle as HANDLE,
+            FSCTL_DUPLICATE_EXTENTS_TO_FILE,
+            &dup_data as *const DuplicateExtentsData as *const std::ffi::c_void,
+            std::mem::size_of::<DuplicateExtentsData>() as u32,
+            std::ptr::null_mut(),
+            0,
+            &mut bytes_returned,
+            std::ptr::null_mut(),
+        )
+    };
+
+    // SAFETY: Both handles are valid open handles.
+    unsafe {
+        CloseHandle(src_handle);
+        CloseHandle(dst_handle);
+    }
+
+    if ioctl_result == 0 {
+        return Err(io::Error::last_os_error());
+    }
+
+    Ok(())
+}
+
+/// Non-Windows stub for partial ReFS reflink.
+#[cfg(not(target_os = "windows"))]
+pub(super) fn try_refs_reflink_range_impl(
+    _src: &Path,
+    _dst: &Path,
+    _src_offset: u64,
+    _dst_offset: u64,
+    _byte_count: u64,
+) -> io::Result<()> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "ReFS reflink is only available on Windows",
+    ))
+}
+
 /// Non-Windows stub for ReFS reflink.
 #[cfg(not(target_os = "windows"))]
 pub(super) fn try_refs_reflink_impl(_src: &Path, _dst: &Path) -> io::Result<()> {
@@ -518,6 +726,61 @@ pub(super) fn try_ficlone_impl(_src: &Path, _dst: &Path) -> io::Result<()> {
         io::ErrorKind::Unsupported,
         "FICLONE is only available on Linux",
     ))
+}
+
+/// Computed parameters for the `FSCTL_DUPLICATE_EXTENTS_TO_FILE` ioctl.
+///
+/// Encapsulates the cluster-aligned offsets and byte count derived from
+/// user-supplied (unaligned) values. This struct is used both by the actual
+/// ioctl call and by unit tests that verify alignment arithmetic without
+/// requiring a ReFS volume.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct DuplicateExtentsParams {
+    /// Source file offset, rounded down to cluster boundary.
+    pub source_offset: u64,
+    /// Destination file offset, rounded down to cluster boundary.
+    pub target_offset: u64,
+    /// Byte count, rounded up so that `source_offset + byte_count` covers
+    /// the original `[src_offset, src_offset + count)` range on a cluster
+    /// boundary.
+    pub byte_count: u64,
+}
+
+/// Computes cluster-aligned parameters for `FSCTL_DUPLICATE_EXTENTS_TO_FILE`.
+///
+/// The ioctl requires all three fields - source offset, target offset, and
+/// byte count - to be multiples of the filesystem cluster size. This function
+/// rounds offsets down and the end position up, guaranteeing the original
+/// byte range is fully covered.
+///
+/// # Arguments
+///
+/// * `src_offset` - Unaligned source file offset
+/// * `dst_offset` - Unaligned destination file offset
+/// * `byte_count` - Unaligned number of bytes to clone
+/// * `cluster_size` - Filesystem cluster size in bytes (must be > 0)
+///
+/// # Panics
+///
+/// Panics if `cluster_size` is zero (callers must validate beforehand).
+pub(super) fn compute_duplicate_extents_params(
+    src_offset: u64,
+    dst_offset: u64,
+    byte_count: u64,
+    cluster_size: u64,
+) -> DuplicateExtentsParams {
+    debug_assert!(cluster_size > 0, "cluster_size must be positive");
+
+    let aligned_src = (src_offset / cluster_size) * cluster_size;
+    let aligned_dst = (dst_offset / cluster_size) * cluster_size;
+    let end = src_offset + byte_count;
+    let aligned_end = ((end + cluster_size - 1) / cluster_size) * cluster_size;
+
+    DuplicateExtentsParams {
+        source_offset: aligned_src,
+        target_offset: aligned_dst,
+        byte_count: aligned_end - aligned_src,
+    }
 }
 
 /// macOS supports reflink via `clonefile` on APFS.

--- a/crates/fast_io/src/platform_copy/dispatch.rs
+++ b/crates/fast_io/src/platform_copy/dispatch.rs
@@ -370,7 +370,7 @@ pub(super) fn try_refs_reflink_impl(src: &Path, dst: &Path) -> io::Result<()> {
     }
 
     // Round up to cluster boundary for the ioctl
-    let aligned_size = ((file_size + cluster_size - 1) / cluster_size) * cluster_size;
+    let aligned_size = file_size.div_ceil(cluster_size) * cluster_size;
 
     let src_wide: Vec<u16> = src
         .as_os_str()
@@ -734,6 +734,7 @@ pub(super) fn try_ficlone_impl(_src: &Path, _dst: &Path) -> io::Result<()> {
 /// user-supplied (unaligned) values. This struct is used both by the actual
 /// ioctl call and by unit tests that verify alignment arithmetic without
 /// requiring a ReFS volume.
+#[cfg(any(target_os = "windows", test))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) struct DuplicateExtentsParams {
     /// Source file offset, rounded down to cluster boundary.
@@ -763,6 +764,7 @@ pub(super) struct DuplicateExtentsParams {
 /// # Panics
 ///
 /// Panics if `cluster_size` is zero (callers must validate beforehand).
+#[cfg(any(target_os = "windows", test))]
 pub(super) fn compute_duplicate_extents_params(
     src_offset: u64,
     dst_offset: u64,
@@ -774,7 +776,7 @@ pub(super) fn compute_duplicate_extents_params(
     let aligned_src = (src_offset / cluster_size) * cluster_size;
     let aligned_dst = (dst_offset / cluster_size) * cluster_size;
     let end = src_offset + byte_count;
-    let aligned_end = ((end + cluster_size - 1) / cluster_size) * cluster_size;
+    let aligned_end = end.div_ceil(cluster_size) * cluster_size;
 
     DuplicateExtentsParams {
         source_offset: aligned_src,

--- a/crates/fast_io/src/platform_copy/mod.rs
+++ b/crates/fast_io/src/platform_copy/mod.rs
@@ -163,6 +163,48 @@ pub fn try_refs_reflink(src: &Path, dst: &Path) -> io::Result<()> {
     dispatch::try_refs_reflink_impl(src, dst)
 }
 
+/// Attempts a partial copy-on-write block clone using Windows ReFS
+/// `FSCTL_DUPLICATE_EXTENTS_TO_FILE`.
+///
+/// Clones `byte_count` bytes from `src` starting at `src_offset` into `dst`
+/// at `dst_offset`. All offsets and the byte count are rounded to the volume's
+/// cluster size internally (the ioctl requires cluster-aligned parameters).
+///
+/// The destination file must already exist and be large enough to hold the
+/// cloned range at the target offset. Unlike [`try_refs_reflink`], this
+/// function does not create or resize the destination.
+///
+/// # Constraints
+///
+/// - Source and destination must be on the same ReFS volume.
+/// - The volume must be formatted as ReFS (NTFS does not support block cloning).
+/// - The destination must be pre-created and pre-sized by the caller.
+/// - Windows Server 2016+ or Windows 10+ with a ReFS-formatted volume.
+///
+/// # Platform Support
+///
+/// - **Windows**: Calls `DeviceIoControl` with `FSCTL_DUPLICATE_EXTENTS_TO_FILE`.
+/// - **Other platforms**: Returns `ErrorKind::Unsupported`.
+///
+/// # Errors
+///
+/// Returns an error if:
+/// - The platform does not support ReFS reflink (non-Windows)
+/// - The filesystem is not ReFS (NTFS, FAT32, exFAT)
+/// - Cross-volume (source and destination on different volumes)
+/// - Source or destination does not exist or is not accessible
+/// - Cluster size query fails
+/// - The ioctl itself fails
+pub fn try_refs_reflink_range(
+    src: &Path,
+    dst: &Path,
+    src_offset: u64,
+    dst_offset: u64,
+    byte_count: u64,
+) -> io::Result<()> {
+    dispatch::try_refs_reflink_range_impl(src, dst, src_offset, dst_offset, byte_count)
+}
+
 /// Attempts a copy-on-write clone using Linux `FICLONE` ioctl.
 ///
 /// On Btrfs, XFS (with reflink enabled), and bcachefs, `FICLONE` creates an

--- a/crates/fast_io/src/platform_copy/tests.rs
+++ b/crates/fast_io/src/platform_copy/tests.rs
@@ -1,3 +1,4 @@
+use super::dispatch;
 use super::*;
 use std::io;
 use std::io::Write;
@@ -654,4 +655,166 @@ fn no_cow_platform_copy_propagates_missing_source_error() {
         .copy_file(&missing, &dst, 0)
         .expect_err("missing source should fail");
     assert_eq!(err.kind(), io::ErrorKind::NotFound);
+}
+
+// ── FSCTL_DUPLICATE_EXTENTS parameter construction tests ──────────────
+
+#[test]
+fn duplicate_extents_params_already_aligned() {
+    let params = dispatch::compute_duplicate_extents_params(0, 0, 4096, 4096);
+    assert_eq!(params.source_offset, 0);
+    assert_eq!(params.target_offset, 0);
+    assert_eq!(params.byte_count, 4096);
+}
+
+#[test]
+fn duplicate_extents_params_byte_count_rounds_up() {
+    // 100 bytes at offset 0 with 4096 cluster size rounds byte_count up to 4096
+    let params = dispatch::compute_duplicate_extents_params(0, 0, 100, 4096);
+    assert_eq!(params.source_offset, 0);
+    assert_eq!(params.target_offset, 0);
+    assert_eq!(params.byte_count, 4096);
+}
+
+#[test]
+fn duplicate_extents_params_offsets_round_down() {
+    // Source offset 5000 rounds down to 4096, dst offset 9000 rounds down to 8192
+    let params = dispatch::compute_duplicate_extents_params(5000, 9000, 100, 4096);
+    assert_eq!(params.source_offset, 4096);
+    assert_eq!(params.target_offset, 8192);
+    // Range covers [5000, 5100) -> aligned to [4096, 8192) = 4096 bytes
+    assert_eq!(params.byte_count, 4096);
+}
+
+#[test]
+fn duplicate_extents_params_cross_cluster_boundary() {
+    // Range [4000, 5000) spans two clusters with 4096-byte clusters
+    let params = dispatch::compute_duplicate_extents_params(4000, 0, 1000, 4096);
+    assert_eq!(params.source_offset, 0);
+    assert_eq!(params.target_offset, 0);
+    // Aligned range: [0, 8192) = 8192 bytes (two clusters)
+    assert_eq!(params.byte_count, 8192);
+}
+
+#[test]
+fn duplicate_extents_params_large_cluster_size() {
+    // ReFS commonly uses 64KB clusters
+    let cluster = 64 * 1024;
+    let params = dispatch::compute_duplicate_extents_params(1000, 2000, 50_000, cluster);
+    assert_eq!(params.source_offset, 0);
+    assert_eq!(params.target_offset, 0);
+    // Range [1000, 51000) -> aligned to [0, 65536) = 1 cluster
+    assert_eq!(params.byte_count, cluster);
+}
+
+#[test]
+fn duplicate_extents_params_large_cluster_multiple_clusters() {
+    let cluster = 64 * 1024;
+    // Range [0, 200_000) at 64KB clusters needs ceil(200000/65536)=4 clusters
+    let params = dispatch::compute_duplicate_extents_params(0, 0, 200_000, cluster);
+    assert_eq!(params.source_offset, 0);
+    assert_eq!(params.target_offset, 0);
+    assert_eq!(params.byte_count, 4 * cluster);
+}
+
+#[test]
+fn duplicate_extents_params_exact_cluster_boundary() {
+    // Range exactly one cluster at cluster-aligned offset
+    let params = dispatch::compute_duplicate_extents_params(8192, 16384, 4096, 4096);
+    assert_eq!(params.source_offset, 8192);
+    assert_eq!(params.target_offset, 16384);
+    assert_eq!(params.byte_count, 4096);
+}
+
+#[test]
+fn duplicate_extents_params_zero_byte_count() {
+    let params = dispatch::compute_duplicate_extents_params(4096, 0, 0, 4096);
+    assert_eq!(params.source_offset, 4096);
+    assert_eq!(params.target_offset, 0);
+    assert_eq!(params.byte_count, 0);
+}
+
+#[test]
+fn duplicate_extents_params_one_byte() {
+    // Single byte at offset 0 still requires one full cluster
+    let params = dispatch::compute_duplicate_extents_params(0, 0, 1, 4096);
+    assert_eq!(params.byte_count, 4096);
+}
+
+// ── Partial ReFS reflink tests ────────────────────────────────────────
+
+#[cfg(not(target_os = "windows"))]
+#[test]
+fn refs_reflink_range_returns_unsupported_on_non_windows() {
+    let temp = TempDir::new().expect("create temp dir");
+    let (src, dst) = setup_test_files(temp.path(), "refs_range_stub", b"data");
+
+    let err = try_refs_reflink_range(&src, &dst, 0, 0, 4).unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::Unsupported);
+}
+
+#[cfg(not(target_os = "windows"))]
+#[test]
+fn refs_reflink_range_zero_bytes_returns_unsupported_on_non_windows() {
+    let temp = TempDir::new().expect("create temp dir");
+    let (src, dst) = setup_test_files(temp.path(), "refs_range_zero", b"data");
+
+    // Even zero-byte range returns Unsupported on non-Windows
+    let err = try_refs_reflink_range(&src, &dst, 0, 0, 0).unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::Unsupported);
+}
+
+#[cfg(target_os = "windows")]
+#[test]
+fn refs_reflink_range_zero_bytes_succeeds() {
+    let temp = TempDir::new().expect("create temp dir");
+    let (src, dst) = setup_test_files(temp.path(), "refs_range_zero", b"data");
+    std::fs::write(&dst, b"dest").expect("write dst");
+
+    // Zero-byte range is a no-op, should succeed on any filesystem
+    let result = try_refs_reflink_range(&src, &dst, 0, 0, 0);
+    assert!(result.is_ok(), "zero-byte range should succeed");
+}
+
+#[cfg(target_os = "windows")]
+#[test]
+fn refs_reflink_range_fails_gracefully_on_ntfs() {
+    let temp = TempDir::new().expect("create temp dir");
+    let content = b"partial reflink test data on NTFS";
+    let (src, dst) = setup_test_files(temp.path(), "refs_range_ntfs", content);
+    // Pre-create destination so OPEN_EXISTING succeeds
+    std::fs::write(&dst, &vec![0u8; content.len()]).expect("write dst");
+
+    let result = try_refs_reflink_range(&src, &dst, 0, 0, content.len() as u64);
+    assert!(
+        result.is_err(),
+        "partial reflink should fail on NTFS (CI uses NTFS)"
+    );
+}
+
+#[cfg(target_os = "windows")]
+#[test]
+fn refs_reflink_range_fails_on_missing_source() {
+    let temp = TempDir::new().expect("create temp dir");
+    let src = temp.path().join("nonexistent_range_src.txt");
+    let dst = temp.path().join("range_dst.txt");
+    std::fs::write(&dst, b"dest").expect("write dst");
+
+    let result = try_refs_reflink_range(&src, &dst, 0, 0, 100);
+    assert!(result.is_err(), "missing source should fail");
+}
+
+#[cfg(target_os = "windows")]
+#[test]
+fn refs_reflink_range_fails_on_missing_destination() {
+    let temp = TempDir::new().expect("create temp dir");
+    let src = temp.path().join("range_src.txt");
+    let dst = temp.path().join("nonexistent_range_dst.txt");
+    std::fs::write(&src, b"source").expect("write src");
+
+    let result = try_refs_reflink_range(&src, &dst, 0, 0, 6);
+    assert!(
+        result.is_err(),
+        "missing destination should fail (OPEN_EXISTING)"
+    );
 }


### PR DESCRIPTION
## Summary

- Add `try_refs_reflink_range()` for partial-file CoW block cloning via `FSCTL_DUPLICATE_EXTENTS_TO_FILE` on Windows ReFS volumes, complementing the existing whole-file `try_refs_reflink()`
- Extract `compute_duplicate_extents_params()` to encapsulate cluster alignment arithmetic (offsets rounded down, byte count rounded up to cluster boundary), making the logic testable without ReFS hardware
- Add `ReFS reflink` to `platform_io_capabilities()` output on Windows

## Test plan

- [x] 9 parameter construction tests verify cluster alignment for 4KB and 64KB cluster sizes, boundary crossings, zero byte count, and single-byte edge cases
- [x] Non-Windows platforms return `ErrorKind::Unsupported` for both range and zero-byte calls
- [x] Windows/NTFS tests verify graceful failure (CI uses NTFS, not ReFS)
- [x] Windows tests verify missing source and missing destination produce clean errors
- [x] Zero-byte range short-circuits to `Ok(())` on Windows (no ioctl issued)
- [x] Formatting verified via `cargo fmt --all -- --check`