### PR TITLE
fix: correct CF_AVOID_XATTR_OPTIM semantic inversion in receiver

### DIFF
--- a/crates/transfer/src/receiver/transfer.rs
+++ b/crates/transfer/src/receiver/transfer.rs
@@ -214,9 +214,10 @@ impl ReceiverContext {
                 reader,
                 &mut ndx_read_codec,
                 self.config.flags.xattrs,
-                self.compat_flags.is_some_and(|f| {
-                    f.contains(protocol::CompatibilityFlags::AVOID_XATTR_OPTIMIZATION)
-                }),
+                self.protocol.as_u8() >= 31
+                    && self.compat_flags.is_some_and(|f| {
+                        !f.contains(protocol::CompatibilityFlags::AVOID_XATTR_OPTIMIZATION)
+                    }),
             )?;
 
             debug_assert_eq!(

--- a/crates/transfer/src/receiver/transfer/pipeline.rs
+++ b/crates/transfer/src/receiver/transfer/pipeline.rs
@@ -86,9 +86,10 @@ impl ReceiverContext {
             io_uring_policy: self.config.write.io_uring_policy,
             io_uring_depth: self.config.write.io_uring_depth,
             preserve_xattrs: self.config.flags.xattrs,
-            want_xattr_optim: self.compat_flags.is_some_and(|f| {
-                f.contains(protocol::CompatibilityFlags::AVOID_XATTR_OPTIMIZATION)
-            }),
+            want_xattr_optim: self.protocol.as_u8() >= 31
+                && self.compat_flags.is_some_and(|f| {
+                    !f.contains(protocol::CompatibilityFlags::AVOID_XATTR_OPTIMIZATION)
+                }),
             append: self.config.flags.append,
         };
 
@@ -415,9 +416,10 @@ impl ReceiverContext {
         let mut ndx_read_codec = create_ndx_codec(self.protocol.as_u8());
         let write_iflags = self.protocol.supports_iflags();
         let preserve_xattrs = self.config.flags.xattrs;
-        let want_xattr_optim = self
-            .compat_flags
-            .is_some_and(|f| f.contains(protocol::CompatibilityFlags::AVOID_XATTR_OPTIMIZATION));
+        let want_xattr_optim = self.protocol.as_u8() >= 31
+            && self.compat_flags.is_some_and(|f| {
+                !f.contains(protocol::CompatibilityFlags::AVOID_XATTR_OPTIMIZATION)
+            });
 
         for &(file_idx, file_entry, _) in files_to_transfer {
             // upstream: generator.c:1925 - write_ndx(f_out, ndx)


### PR DESCRIPTION
## Summary

- Fix inverted `want_xattr_optim` logic in 3 receiver sites - upstream `compat.c:746` sets optimization wanted when the AVOID bit is **not** set, but oc-rsync was computing the opposite
- Add missing `protocol >= 31` gate per upstream `compat.c:746`
- Both peers always advertise the 'x' capability, so the AVOID bit is always set in practice, making the old code incorrectly enable xattr optimization during `--xattrs --hard-links` transfers

## Test plan

- [ ] CI passes (fmt, clippy, nextest, all platforms)
- [ ] Verify `--xattrs` interop with upstream rsync 3.4.1