### PR TITLE
refactor(engine): add SparseWriter decorator for zero-region interception (#2132)

### DIFF
--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -215,7 +215,7 @@ pub use local_copy::{
     LocalCopyError, LocalCopyErrorKind, LocalCopyOptions, LocalCopyOptionsBuilder, LocalCopyPlan,
     LocalCopySummary, ReferenceDirectory, ReferenceDirectoryKind, SkipCompressList,
     SkipCompressParseError, SparseDetectStrategy, SparseDetector, SparseReader, SparseRegion,
-    SparseWriter, compute_backup_path,
+    SparseWriteStats, SparseWriter, ZeroScanStrategy, compute_backup_path,
 };
 
 /// File signature generation for delta transfers.

--- a/crates/engine/src/local_copy/context.rs
+++ b/crates/engine/src/local_copy/context.rs
@@ -31,10 +31,10 @@ use super::{
     LocalCopyArgumentError, LocalCopyError, LocalCopyErrorKind, LocalCopyExecution,
     LocalCopyMetadata, LocalCopyOptions, LocalCopyProgress, LocalCopyRecord,
     LocalCopyRecordHandler, LocalCopyReport, LocalCopySummary, ReferenceDirectory,
-    SparseWriteState, compute_backup_path, copy_entry_to_backup, delete_extraneous_entries,
-    filter_program_local_error, follow_symlink_metadata, load_dir_merge_rules_recursive,
-    map_metadata_error, remove_source_entry_if_requested, resolve_dir_merge_path, should_skip_copy,
-    write_sparse_chunk,
+    SparseWriteState, SparseWriter, compute_backup_path, copy_entry_to_backup,
+    delete_extraneous_entries, filter_program_local_error, follow_symlink_metadata,
+    load_dir_merge_rules_recursive, map_metadata_error, remove_source_entry_if_requested,
+    resolve_dir_merge_path, should_skip_copy, write_sparse_chunk,
 };
 use crate::delta::DeltaSignatureIndex;
 use crate::signature::SignatureBlock;

--- a/crates/engine/src/local_copy/context_impl/transfer.rs
+++ b/crates/engine/src/local_copy/context_impl/transfer.rs
@@ -301,9 +301,15 @@ impl<'a> CopyContext<'a> {
             return Ok(FileCopyOutcome::new(copied, None));
         }
 
+        if sparse {
+            return self.copy_file_contents_sparse(
+                reader, writer, buffer, compress, source, destination, relative,
+                total_size, initial_bytes, expected_remaining, start,
+            );
+        }
+
         let mut total_bytes: u64 = 0;
         let mut literal_bytes: u64 = 0;
-        let mut sparse_state = SparseWriteState::default();
         let mut compressor = self.start_compressor(compress, source)?;
         let mut compressed_progress: u64 = 0;
         // 1MB interval amortizes clock_gettime syscalls across the copy loop.
@@ -331,14 +337,9 @@ impl<'a> CopyContext<'a> {
                 break;
             }
 
-            let written = if sparse {
-                write_sparse_chunk(writer, &mut sparse_state, &buffer[..read], destination)?
-            } else {
-                writer.write_all(&buffer[..read]).map_err(|error| {
-                    LocalCopyError::io("copy file", destination, error)
-                })?;
-                read
-            };
+            writer.write_all(&buffer[..read]).map_err(|error| {
+                LocalCopyError::io("copy file", destination, error)
+            })?;
 
             self.register_progress();
 
@@ -361,12 +362,7 @@ impl<'a> CopyContext<'a> {
 
             total_bytes = total_bytes.saturating_add(read as u64);
             bytes_since_timeout_check = bytes_since_timeout_check.saturating_add(read as u64);
-            let literal_delta = if sparse {
-                read as u64
-            } else {
-                written as u64
-            };
-            literal_bytes = literal_bytes.saturating_add(literal_delta);
+            literal_bytes = literal_bytes.saturating_add(read as u64);
             // Only compute elapsed time if we have an observer to report to
             if self.observer.is_some() {
                 let progressed = initial_bytes.saturating_add(total_bytes);
@@ -374,17 +370,115 @@ impl<'a> CopyContext<'a> {
             }
         }
 
-        if sparse {
-            let final_position = sparse_state.finish(writer, destination)?;
-            writer.set_len(final_position).map_err(|error| {
-                LocalCopyError::io(
-                    "truncate destination file",
-                    destination.to_path_buf(),
-                    error,
-                )
+        let outcome = if let Some(encoder) = compressor {
+            let compressed_total = encoder.finish().map_err(|error| {
+                LocalCopyError::io("compress file", source, error)
             })?;
             self.register_progress();
+            let delta = compressed_total.saturating_sub(compressed_progress);
+            self.register_limiter_bytes(delta);
+            FileCopyOutcome::new(literal_bytes, Some(compressed_total))
+        } else {
+            FileCopyOutcome::new(literal_bytes, None)
+        };
+
+        Ok(outcome)
+    }
+
+    /// Sparse variant of `copy_file_contents` using the `SparseWriter` decorator.
+    ///
+    /// Wraps the destination writer in a `SparseWriter` that transparently
+    /// converts zero runs into seeks, producing sparse files on supported
+    /// filesystems. The decorator is consumed at finalization, returning
+    /// the final stream position for `set_len`.
+    #[allow(clippy::too_many_arguments)]
+    fn copy_file_contents_sparse(
+        &mut self,
+        reader: &mut fs::File,
+        writer: &mut fs::File,
+        buffer: &mut [u8],
+        compress: bool,
+        source: &Path,
+        destination: &Path,
+        relative: &Path,
+        total_size: u64,
+        initial_bytes: u64,
+        expected_remaining: u64,
+        start: Instant,
+    ) -> Result<FileCopyOutcome, LocalCopyError> {
+        let mut total_bytes: u64 = 0;
+        let mut literal_bytes: u64 = 0;
+        let mut sparse_writer = SparseWriter::new(&mut *writer);
+        let mut compressor = self.start_compressor(compress, source)?;
+        let mut compressed_progress: u64 = 0;
+        const TIMEOUT_CHECK_INTERVAL: u64 = 1024 * 1024;
+        let mut bytes_since_timeout_check: u64 = 0;
+
+        loop {
+            if total_bytes >= expected_remaining {
+                break;
+            }
+            if bytes_since_timeout_check >= TIMEOUT_CHECK_INTERVAL {
+                self.enforce_timeout()?;
+                bytes_since_timeout_check = 0;
+            }
+            let chunk_len = if let Some(limiter) = self.limiter.as_ref() {
+                limiter.recommended_read_size(buffer.len())
+            } else {
+                buffer.len()
+            };
+
+            let read = reader
+                .read(&mut buffer[..chunk_len])
+                .map_err(|error| LocalCopyError::io("copy file", source, error))?;
+            if read == 0 {
+                break;
+            }
+
+            sparse_writer.write_all(&buffer[..read]).map_err(|error| {
+                LocalCopyError::io("copy file", destination, error)
+            })?;
+
+            self.register_progress();
+
+            let mut compressed_delta = None;
+            if let Some(encoder) = compressor.as_mut() {
+                encoder.write(&buffer[..read]).map_err(|error| {
+                    LocalCopyError::io("compress file", source, error)
+                })?;
+                let total = encoder.bytes_written();
+                let delta = total.saturating_sub(compressed_progress);
+                compressed_progress = total;
+                compressed_delta = Some(delta);
+            }
+
+            if let Some(delta) = compressed_delta {
+                self.register_limiter_bytes(delta);
+            } else {
+                self.register_limiter_bytes(read as u64);
+            }
+
+            total_bytes = total_bytes.saturating_add(read as u64);
+            bytes_since_timeout_check = bytes_since_timeout_check.saturating_add(read as u64);
+            literal_bytes = literal_bytes.saturating_add(read as u64);
+            if self.observer.is_some() {
+                let progressed = initial_bytes.saturating_add(total_bytes);
+                self.notify_progress(relative, Some(total_size), progressed, start.elapsed());
+            }
         }
+
+        let (inner, final_position, _stats) =
+            sparse_writer.finish_and_position().map_err(|error| {
+                LocalCopyError::io("finish sparse writer", destination.to_path_buf(), error)
+            })?;
+        inner.set_len(final_position).map_err(|error| {
+            LocalCopyError::io(
+                "truncate destination file",
+                destination.to_path_buf(),
+                error,
+            )
+        })?;
+        self.register_progress();
 
         let outcome = if let Some(encoder) = compressor {
             let compressed_total = encoder.finish().map_err(|error| {

--- a/crates/engine/src/local_copy/executor/file/mod.rs
+++ b/crates/engine/src/local_copy/executor/file/mod.rs
@@ -28,5 +28,8 @@ pub(crate) use paths::partial_destination_path;
 pub(crate) use paths::temporary_destination_path;
 #[cfg(test)]
 pub(crate) use preallocate::maybe_preallocate_destination;
-pub use sparse::{SparseDetectStrategy, SparseDetector, SparseReader, SparseRegion, SparseWriter};
+pub use sparse::{
+    SparseDetectStrategy, SparseDetector, SparseReader, SparseRegion, SparseWriteStats,
+    SparseWriter, ZeroScanStrategy,
+};
 pub(crate) use sparse::{SparseWriteState, write_sparse_chunk};

--- a/crates/engine/src/local_copy/executor/file/sparse/mod.rs
+++ b/crates/engine/src/local_copy/executor/file/sparse/mod.rs
@@ -18,7 +18,7 @@ mod tests;
 
 pub use detect::SparseDetector;
 pub use reader::SparseReader;
-pub use writer::SparseWriter;
+pub use writer::{SparseWriteStats, SparseWriter, ZeroScanStrategy};
 
 /// Selects the mechanism used by [`SparseReader::detect_holes`] to identify
 /// sparse regions in a file.

--- a/crates/engine/src/local_copy/executor/file/sparse/tests.rs
+++ b/crates/engine/src/local_copy/executor/file/sparse/tests.rs
@@ -2110,16 +2110,13 @@ fn sparse_detector_default_threshold() {
 #[test]
 fn sparse_writer_basic_write() {
     let file = NamedTempFile::new().expect("temp file");
-    let mut writer = super::SparseWriter::new(
-        file.as_file().try_clone().expect("clone"),
-        false, // Dense mode
-    );
+    let mut writer = super::SparseWriter::new(file.as_file().try_clone().expect("clone"));
 
-    writer.write_region(0, b"hello").expect("write");
-    writer.write_region(10, b"world").expect("write");
-    writer.finish(15).expect("finish");
+    writer.write_all(b"hello").expect("write");
+    writer.write_all(&[0u8; 5]).expect("write zeros");
+    writer.write_all(b"world").expect("write");
+    writer.finish().expect("finish");
 
-    // Verify contents
     let mut file_handle = file.reopen().expect("reopen");
     let mut contents = Vec::new();
     file_handle.read_to_end(&mut contents).expect("read");
@@ -2131,18 +2128,16 @@ fn sparse_writer_basic_write() {
 #[test]
 fn sparse_writer_sparse_mode() {
     let file = NamedTempFile::new().expect("temp file");
-    let mut writer = super::SparseWriter::new(
-        file.as_file().try_clone().expect("clone"),
-        true, // Sparse mode
-    );
+    let mut writer = super::SparseWriter::new(file.as_file().try_clone().expect("clone"));
 
-    // Build the data as one sequential write
     let mut data = vec![b'A'];
     data.extend_from_slice(&vec![0u8; super::SPARSE_WRITE_SIZE * 2]);
     data.push(b'B');
 
-    writer.write_region(0, &data).expect("write");
-    writer.finish(data.len() as u64).expect("finish");
+    writer.write_all(&data).expect("write");
+    let (mut inner, _stats) = writer.finish().expect("finish");
+    let pos = inner.stream_position().expect("pos");
+    inner.set_len(pos).expect("set_len");
 
     // Verify contents
     let mut file_handle = file.reopen().expect("reopen");
@@ -2159,10 +2154,9 @@ fn sparse_writer_sparse_mode() {
 #[test]
 fn sparse_writer_empty_data() {
     let file = NamedTempFile::new().expect("temp file");
-    let mut writer = super::SparseWriter::new(file.as_file().try_clone().expect("clone"), true);
+    let writer = super::SparseWriter::new(file.as_file().try_clone().expect("clone"));
 
-    writer.write_region(0, &[]).expect("write empty");
-    writer.finish(0).expect("finish");
+    writer.finish().expect("finish");
 
     let metadata = file.as_file().metadata().expect("metadata");
     assert_eq!(metadata.len(), 0);
@@ -2171,11 +2165,10 @@ fn sparse_writer_empty_data() {
 #[test]
 fn sparse_writer_file_accessors() {
     let file = NamedTempFile::new().expect("temp file");
-    let mut writer = super::SparseWriter::new(file.as_file().try_clone().expect("clone"), false);
+    let mut writer = super::SparseWriter::new(file.as_file().try_clone().expect("clone"));
 
-    // Test accessors
-    let _file_ref: &fs::File = writer.file();
-    let _file_mut: &mut fs::File = writer.file_mut();
+    let _file_ref: &fs::File = writer.inner();
+    let _file_mut: &mut fs::File = writer.inner_mut();
 }
 
 #[test]

--- a/crates/engine/src/local_copy/executor/file/sparse/tests.rs
+++ b/crates/engine/src/local_copy/executor/file/sparse/tests.rs
@@ -1,8 +1,9 @@
 use super::detect::{leading_zero_run, trailing_zero_run};
 use super::hole_punch::{punch_hole, write_zeros_fallback};
 use super::state::{SparseWriteState, write_sparse_chunk};
+use super::writer::{SparseWriteStats, SparseWriter, ZeroScanStrategy};
 use std::fs;
-use std::io::{Read, Seek, SeekFrom, Write};
+use std::io::{Cursor, Read, Seek, SeekFrom, Write};
 use tempfile::NamedTempFile;
 
 #[test]
@@ -2547,4 +2548,361 @@ fn sparse_reader_with_none_strategy_handles_empty_file() {
     let regions = SparseReader::detect_holes_with(file.as_file(), SparseDetectStrategy::None)
         .expect("detect holes");
     assert!(regions.is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// SparseWriter decorator tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn sparse_writer_all_zero_buffer_produces_only_seeks() {
+    let mut cursor = Cursor::new(vec![0u8; 8192]);
+    let mut sw = SparseWriter::new(&mut cursor);
+
+    sw.write_all(&[0u8; 4096]).expect("write zeros");
+
+    let stats = sw.stats();
+    // All zeros are accumulated as pending, not yet seeked
+    assert_eq!(stats.bytes_written, 0);
+    // Finish flushes the pending zeros as a seek
+    let (_, final_pos, final_stats) = sw.finish_and_position().expect("finish");
+    assert_eq!(final_pos, 4096);
+    assert_eq!(final_stats.bytes_written, 0);
+    assert_eq!(final_stats.bytes_seeked, 4096);
+    assert_eq!(final_stats.zero_runs_detected, 1);
+}
+
+#[test]
+fn sparse_writer_all_nonzero_buffer_produces_only_writes() {
+    let mut cursor = Cursor::new(vec![0u8; 8192]);
+    let mut sw = SparseWriter::new(&mut cursor);
+
+    let data = vec![0xAA; 4096];
+    sw.write_all(&data).expect("write non-zero data");
+
+    let (_, _final_pos, stats) = sw.finish_and_position().expect("finish");
+    assert_eq!(stats.bytes_written, 4096);
+    assert_eq!(stats.bytes_seeked, 0);
+    assert_eq!(stats.zero_runs_detected, 0);
+}
+
+#[test]
+fn sparse_writer_mixed_data_splits_seeks_and_writes() {
+    let mut cursor = Cursor::new(vec![0u8; 16384]);
+    let mut sw = SparseWriter::new(&mut cursor);
+
+    // Write: 10 bytes of data, 100 bytes of zeros, 10 bytes of data
+    let mut buf = Vec::new();
+    buf.extend_from_slice(&[0xAA; 10]);
+    buf.extend_from_slice(&[0u8; 100]);
+    buf.extend_from_slice(&[0xBB; 10]);
+
+    sw.write_all(&buf).expect("write mixed data");
+
+    let (_, _final_pos, stats) = sw.finish_and_position().expect("finish");
+    // Both data segments should be written (zeros below threshold are written too)
+    assert!(stats.bytes_written > 0);
+
+    // Verify the actual content
+    let content = cursor.into_inner();
+    assert!(content[..10].iter().all(|&b| b == 0xAA));
+    assert!(content[10..110].iter().all(|&b| b == 0));
+    assert!(content[110..120].iter().all(|&b| b == 0xBB));
+}
+
+#[test]
+fn sparse_writer_zero_run_at_buffer_boundaries() {
+    let mut cursor = Cursor::new(vec![0u8; 16384]);
+    let mut sw = SparseWriter::new(&mut cursor);
+
+    // First write: data ending with zeros
+    let mut first = vec![0xCC; 10];
+    first.extend_from_slice(&[0u8; 90]);
+    sw.write_all(&first).expect("first write");
+
+    // Second write: starts with zeros then data
+    let mut second = vec![0u8; 50];
+    second.extend_from_slice(&[0xDD; 20]);
+    sw.write_all(&second).expect("second write");
+
+    let (_, _final_pos, stats) = sw.finish_and_position().expect("finish");
+    assert!(stats.bytes_written > 0);
+
+    // Verify boundary handling: zeros should be accumulated across writes
+    let content = cursor.into_inner();
+    assert!(content[..10].iter().all(|&b| b == 0xCC));
+    assert!(content[10..150].iter().all(|&b| b == 0));
+    assert!(content[150..170].iter().all(|&b| b == 0xDD));
+}
+
+#[test]
+fn sparse_writer_statistics_tracking() {
+    let mut cursor = Cursor::new(vec![0u8; 65536]);
+    let mut sw = SparseWriter::new(&mut cursor);
+
+    // Write some data
+    sw.write_all(&[0xFF; 100]).expect("write data");
+
+    let stats1 = sw.stats();
+    assert_eq!(stats1.bytes_written, 100);
+    assert_eq!(stats1.bytes_seeked, 0);
+
+    // Write zeros
+    sw.write_all(&[0u8; 200]).expect("write zeros");
+
+    let stats2 = sw.stats();
+    // Zeros are pending, not yet seeked
+    assert_eq!(stats2.bytes_written, 100);
+    assert_eq!(stats2.bytes_seeked, 0);
+
+    // Write more data (triggers flush of pending zeros as seek)
+    sw.write_all(&[0xEE; 50]).expect("write more data");
+
+    let stats3 = sw.stats();
+    assert_eq!(stats3.bytes_written, 150);
+    assert_eq!(stats3.bytes_seeked, 200);
+    assert_eq!(stats3.zero_runs_detected, 1);
+
+    let (_, _, final_stats) = sw.finish_and_position().expect("finish");
+    assert_eq!(final_stats.bytes_written, 150);
+    assert_eq!(final_stats.bytes_seeked, 200);
+    assert_eq!(final_stats.zero_runs_detected, 1);
+}
+
+#[test]
+fn sparse_writer_minimum_zero_run_threshold_below_chunk() {
+    // When zero runs are below SPARSE_WRITE_SIZE, they should still be detected
+    // within chunks - the scanning operates per-chunk with leading/trailing
+    // zero detection within each chunk.
+    let mut cursor = Cursor::new(vec![0u8; 65536]);
+    let mut sw = SparseWriter::new(&mut cursor);
+
+    // Write data, then zeros less than chunk size, then data
+    sw.write_all(&[0xAA; 5]).expect("write start");
+    sw.write_all(&[0u8; 500]).expect("write short zeros");
+    sw.write_all(&[0xBB; 5]).expect("write end");
+
+    let (_, _, stats) = sw.finish_and_position().expect("finish");
+    // Short zero runs are still detected and seeked
+    assert!(stats.bytes_seeked > 0 || stats.bytes_written >= 10);
+    // The data portions should definitely be written
+    assert!(stats.bytes_written >= 10);
+}
+
+#[test]
+fn sparse_writer_empty_write_is_noop() {
+    let mut cursor = Cursor::new(vec![0u8; 256]);
+    let mut sw = SparseWriter::new(&mut cursor);
+
+    let written = sw.write(&[]).expect("empty write");
+    assert_eq!(written, 0);
+
+    let (_, _, stats) = sw.finish_and_position().expect("finish");
+    assert_eq!(stats.bytes_written, 0);
+    assert_eq!(stats.bytes_seeked, 0);
+    assert_eq!(stats.zero_runs_detected, 0);
+}
+
+#[test]
+fn sparse_writer_with_byte_level_strategy() {
+    let mut cursor = Cursor::new(vec![0u8; 8192]);
+    let mut sw = SparseWriter::with_strategy(&mut cursor, ZeroScanStrategy::ByteLevel);
+
+    // Same test as SIMD but with byte-level scanning
+    let mut data = vec![0xAA; 10];
+    data.extend_from_slice(&[0u8; 200]);
+    data.extend_from_slice(&[0xBB; 10]);
+
+    sw.write_all(&data).expect("write data");
+
+    let (_, _, stats) = sw.finish_and_position().expect("finish");
+    assert!(stats.bytes_written >= 20);
+
+    // Verify content is correct
+    let content = cursor.into_inner();
+    assert!(content[..10].iter().all(|&b| b == 0xAA));
+    assert!(content[10..210].iter().all(|&b| b == 0));
+    assert!(content[210..220].iter().all(|&b| b == 0xBB));
+}
+
+#[test]
+fn sparse_writer_simd_and_byte_level_produce_same_result() {
+    let mut buf = vec![0xCC; 50];
+    buf.extend_from_slice(&[0u8; 300]);
+    buf.extend_from_slice(&[0xDD; 50]);
+    buf.extend_from_slice(&[0u8; 100]);
+    buf.extend_from_slice(&[0xEE; 30]);
+
+    let mut cursor_simd = Cursor::new(vec![0u8; 2048]);
+    let mut sw_simd = SparseWriter::with_strategy(&mut cursor_simd, ZeroScanStrategy::Simd);
+    sw_simd.write_all(&buf).expect("simd write");
+    let (_, pos_simd, _) = sw_simd.finish_and_position().expect("simd finish");
+
+    let mut cursor_byte = Cursor::new(vec![0u8; 2048]);
+    let mut sw_byte = SparseWriter::with_strategy(&mut cursor_byte, ZeroScanStrategy::ByteLevel);
+    sw_byte.write_all(&buf).expect("byte write");
+    let (_, pos_byte, _) = sw_byte.finish_and_position().expect("byte finish");
+
+    assert_eq!(pos_simd, pos_byte);
+    assert_eq!(cursor_simd.into_inner(), cursor_byte.into_inner());
+}
+
+#[test]
+fn sparse_writer_implements_write_trait() {
+    // Verify the decorator works as a Write impl
+    fn write_through<W: Write>(w: &mut W, data: &[u8]) -> std::io::Result<()> {
+        w.write_all(data)
+    }
+
+    let mut cursor = Cursor::new(vec![0u8; 256]);
+    let mut sw = SparseWriter::new(&mut cursor);
+
+    write_through(&mut sw, b"hello").expect("write through trait");
+
+    let (_, pos, stats) = sw.finish_and_position().expect("finish");
+    assert_eq!(pos, 5);
+    assert_eq!(stats.bytes_written, 5);
+}
+
+#[test]
+fn sparse_writer_seek_flushes_pending_zeros() {
+    let mut cursor = Cursor::new(vec![0u8; 8192]);
+    let mut sw = SparseWriter::new(&mut cursor);
+
+    // Write some data
+    sw.write_all(&[0xFF; 10]).expect("write data");
+    // Write zeros (accumulated as pending)
+    sw.write_all(&[0u8; 100]).expect("write zeros");
+    // Seek should flush pending zeros
+    sw.seek(SeekFrom::Start(500)).expect("seek");
+
+    let stats = sw.stats();
+    assert_eq!(stats.bytes_seeked, 100);
+    assert_eq!(stats.zero_runs_detected, 1);
+
+    let (_, _, _) = sw.finish_and_position().expect("finish");
+}
+
+#[test]
+fn sparse_writer_large_zero_run_across_multiple_writes() {
+    let mut cursor = Cursor::new(vec![0u8; 131072]);
+    let mut sw = SparseWriter::new(&mut cursor);
+
+    // Write data, then many small zero writes that accumulate into a large run
+    sw.write_all(&[0xAA; 10]).expect("write data");
+
+    for _ in 0..100 {
+        sw.write_all(&[0u8; 100]).expect("write zeros");
+    }
+
+    sw.write_all(&[0xBB; 10]).expect("write end data");
+
+    let (_, _, stats) = sw.finish_and_position().expect("finish");
+    assert_eq!(stats.bytes_written, 20);
+    assert_eq!(stats.bytes_seeked, 10_000);
+    assert_eq!(stats.zero_runs_detected, 1);
+
+    let content = cursor.into_inner();
+    assert!(content[..10].iter().all(|&b| b == 0xAA));
+    assert!(content[10..10010].iter().all(|&b| b == 0));
+    assert!(content[10010..10020].iter().all(|&b| b == 0xBB));
+}
+
+#[test]
+fn sparse_writer_finish_returns_inner_writer() {
+    let mut cursor = Cursor::new(vec![0u8; 256]);
+    let mut sw = SparseWriter::new(&mut cursor);
+
+    sw.write_all(b"test").expect("write");
+
+    let (inner, stats) = sw.finish().expect("finish");
+    assert_eq!(stats.bytes_written, 4);
+    // inner is &mut Cursor, verify it's accessible
+    assert_eq!(inner.position(), 4);
+}
+
+#[test]
+fn sparse_writer_into_inner_without_flush() {
+    let mut cursor = Cursor::new(vec![0u8; 256]);
+    let mut sw = SparseWriter::new(&mut cursor);
+
+    sw.write_all(&[0u8; 100]).expect("write zeros");
+
+    // into_inner discards pending zeros
+    let inner = sw.into_inner();
+    // Position should still be at 0 since zeros were accumulated, not seeked
+    assert_eq!(inner.position(), 0);
+}
+
+#[test]
+fn sparse_writer_multiple_zero_runs_tracked() {
+    let mut cursor = Cursor::new(vec![0u8; 65536]);
+    let mut sw = SparseWriter::new(&mut cursor);
+
+    // Pattern: data, zeros, data, zeros, data
+    sw.write_all(&[0xAA; 10]).expect("data 1");
+    sw.write_all(&[0u8; 50]).expect("zeros 1");
+    sw.write_all(&[0xBB; 10]).expect("data 2");
+    sw.write_all(&[0u8; 75]).expect("zeros 2");
+    sw.write_all(&[0xCC; 10]).expect("data 3");
+
+    let (_, _, stats) = sw.finish_and_position().expect("finish");
+    assert_eq!(stats.bytes_written, 30);
+    assert_eq!(stats.bytes_seeked, 125);
+    assert_eq!(stats.zero_runs_detected, 2);
+}
+
+#[test]
+fn sparse_writer_with_real_file() {
+    let mut file = NamedTempFile::new().expect("temp file");
+
+    {
+        let mut sw = SparseWriter::new(file.as_file_mut());
+
+        // Write data, zeros, data
+        sw.write_all(b"START").expect("write start");
+        sw.write_all(&[0u8; 1000]).expect("write zeros");
+        sw.write_all(b"END").expect("write end");
+
+        let (inner, final_pos, stats) = sw.finish_and_position().expect("finish");
+        inner.set_len(final_pos).expect("set length");
+
+        assert_eq!(stats.bytes_written, 8);
+        assert_eq!(stats.bytes_seeked, 1000);
+    }
+
+    // Verify file content
+    file.as_file_mut().seek(SeekFrom::Start(0)).expect("rewind");
+    let mut content = vec![0u8; 1008];
+    file.as_file_mut()
+        .read_exact(&mut content)
+        .expect("read back");
+
+    assert_eq!(&content[..5], b"START");
+    assert!(content[5..1005].iter().all(|&b| b == 0));
+    assert_eq!(&content[1005..1008], b"END");
+}
+
+#[test]
+fn sparse_writer_stats_default() {
+    let stats = SparseWriteStats::default();
+    assert_eq!(stats.bytes_written, 0);
+    assert_eq!(stats.bytes_seeked, 0);
+    assert_eq!(stats.zero_runs_detected, 0);
+}
+
+#[test]
+fn sparse_writer_inner_access() {
+    let mut cursor = Cursor::new(vec![0u8; 256]);
+    let sw = SparseWriter::new(&mut cursor);
+
+    // inner() returns reference
+    let _ref = sw.inner();
+
+    let (_, _) = sw.finish().expect("finish");
+}
+
+#[test]
+fn zero_scan_strategy_default_is_simd() {
+    assert_eq!(ZeroScanStrategy::default(), ZeroScanStrategy::Simd);
 }

--- a/crates/engine/src/local_copy/executor/file/sparse/writer.rs
+++ b/crates/engine/src/local_copy/executor/file/sparse/writer.rs
@@ -1,130 +1,309 @@
-//! High-level sparse file writer wrapping a standard `File`.
+//! Sparse file writer decorator for transparent zero-region interception.
 //!
-//! Provides a [`Write`] implementation that transparently creates filesystem
-//! holes for zero-filled regions when sparse mode is enabled.
+//! Provides a [`SparseWriter`] decorator that wraps any `Write + Seek` writer
+//! and intercepts write calls to scan for zero regions. Detected zero runs are
+//! converted to seeks (creating filesystem holes) instead of writing zeroes,
+//! producing sparse files on supported filesystems.
+//!
+//! upstream: fileio.c:write_sparse() - sparse write with seek-past-zeros
 
-use std::fs;
 use std::io::{self, Seek, SeekFrom, Write};
 
-use super::state::{SparseWriteState, write_sparse_chunk};
+use super::{leading_zero_run, trailing_zero_run};
 
-/// Wrapper around a file for writing with sparse support.
+/// Strategy for scanning data buffers to identify zero regions.
 ///
-/// This wraps a standard `File` and provides high-level methods for writing
-/// files with automatic sparse hole creation. When sparse mode is enabled,
-/// zero-filled regions are efficiently stored as holes using filesystem
-/// mechanisms (seek or fallocate).
+/// Controls how [`SparseWriter`] detects runs of zero bytes. The choice affects
+/// throughput for different data patterns and alignment characteristics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ZeroScanStrategy {
+    /// SIMD-accelerated scanning via `fast_io::zero_detect`.
+    ///
+    /// Uses AVX2 (32 bytes/iter), SSE2/NEON (16 bytes/iter), or scalar `u128`
+    /// (16 bytes/iter) depending on platform. Best for large, aligned buffers.
+    #[default]
+    Simd,
+    /// Byte-level scanning. Simpler and suitable for small or unaligned buffers
+    /// where SIMD setup overhead would dominate.
+    ByteLevel,
+}
+
+/// Statistics tracked by [`SparseWriter`] during sparse writes.
+///
+/// Provides insight into how effectively the sparse writer is converting zero
+/// runs into holes, useful for diagnostics and performance tuning.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct SparseWriteStats {
+    /// Total bytes written to the inner writer (non-zero data).
+    pub bytes_written: u64,
+    /// Total bytes skipped via seeking (zero regions converted to holes).
+    pub bytes_seeked: u64,
+    /// Number of distinct zero runs detected and converted to seeks.
+    pub zero_runs_detected: u64,
+}
+
+/// Sparse file writer decorator that wraps any `Write + Seek` writer.
+///
+/// Intercepts [`Write::write`] calls and scans for contiguous zero-byte regions.
+/// When a zero run is detected, it is accumulated and later flushed as a seek
+/// (creating a filesystem hole) rather than written as data. Non-zero data is
+/// delegated to the inner writer.
+///
+/// The decorator maintains the single-seek-per-zero-run invariant: consecutive
+/// zero bytes are accumulated across multiple write calls and flushed as a
+/// single seek when non-zero data arrives or at finalization.
+///
+/// # Zero-detection strategies
+///
+/// - [`ZeroScanStrategy::Simd`] (default) - SIMD-accelerated via `fast_io`
+/// - [`ZeroScanStrategy::ByteLevel`] - byte-by-byte scanning
 ///
 /// # Examples
 ///
 /// ```no_run
 /// use std::fs::File;
+/// use std::io::Write;
 /// use engine::SparseWriter;
 ///
 /// let file = File::create("output.bin").unwrap();
-/// let mut writer = SparseWriter::new(file, true);
+/// let mut writer = SparseWriter::new(file);
 ///
-/// // Write data - zeros will automatically become holes if sparse is enabled
-/// writer.write_region(0, b"hello").unwrap();
-/// writer.write_region(1000, &[0u8; 10000]).unwrap(); // This becomes a hole
-/// writer.write_region(11000, b"world").unwrap();
+/// // Write data - zeros become holes, non-zero data is written normally
+/// writer.write_all(b"hello").unwrap();
+/// writer.write_all(&[0u8; 10000]).unwrap(); // Accumulated as pending seek
+/// writer.write_all(b"world").unwrap();       // Flushes pending seek, then writes
 ///
-/// writer.finish(11005).unwrap();
+/// let stats = writer.stats();
+/// writer.finish().unwrap();
 /// ```
-pub struct SparseWriter {
-    file: fs::File,
-    sparse_enabled: bool,
-    state: SparseWriteState,
+pub struct SparseWriter<W> {
+    inner: W,
+    /// Accumulated zero bytes pending flush as a seek.
+    pending_zeros: u64,
+    /// Chunk size for zero-run scanning within write buffers.
+    chunk_size: usize,
+    /// Zero-detection strategy.
+    scan_strategy: ZeroScanStrategy,
+    /// Write statistics.
+    stats: SparseWriteStats,
 }
 
-impl SparseWriter {
-    /// Creates a new sparse writer wrapping the given file.
+/// Default chunk size for sparse scanning, matching upstream rsync's CHUNK_SIZE.
+const DEFAULT_CHUNK_SIZE: usize = super::SPARSE_WRITE_SIZE;
+
+impl<W: Write + Seek> SparseWriter<W> {
+    /// Creates a new sparse writer wrapping the given writer.
     ///
-    /// # Arguments
-    ///
-    /// * `file` - The file to write to
-    /// * `sparse_enabled` - Whether to create sparse holes for zero regions
+    /// Uses SIMD-accelerated zero detection and the default chunk size (32 KB).
     #[must_use]
-    pub fn new(file: fs::File, sparse_enabled: bool) -> Self {
+    pub fn new(inner: W) -> Self {
         Self {
-            file,
-            sparse_enabled,
-            state: SparseWriteState::default(),
+            inner,
+            pending_zeros: 0,
+            chunk_size: DEFAULT_CHUNK_SIZE,
+            scan_strategy: ZeroScanStrategy::default(),
+            stats: SparseWriteStats::default(),
         }
     }
 
-    /// Writes a region of data at the specified offset.
+    /// Creates a sparse writer with a specific zero-detection strategy.
+    #[must_use]
+    pub fn with_strategy(inner: W, strategy: ZeroScanStrategy) -> Self {
+        Self {
+            inner,
+            pending_zeros: 0,
+            chunk_size: DEFAULT_CHUNK_SIZE,
+            scan_strategy: strategy,
+            stats: SparseWriteStats::default(),
+        }
+    }
+
+    /// Returns a snapshot of the current write statistics.
+    #[must_use]
+    pub const fn stats(&self) -> SparseWriteStats {
+        self.stats
+    }
+
+    /// Returns a reference to the inner writer.
+    pub const fn inner(&self) -> &W {
+        &self.inner
+    }
+
+    /// Returns a mutable reference to the inner writer.
     ///
-    /// If sparse mode is enabled, zero-filled portions of the data will be
-    /// converted to holes. Otherwise, all data is written densely.
+    /// Use with care - direct writes bypass sparse detection.
+    pub fn inner_mut(&mut self) -> &mut W {
+        &mut self.inner
+    }
+
+    /// Consumes the sparse writer and returns the inner writer.
     ///
-    /// Note: For correct sparse handling, regions must be written sequentially
-    /// and contiguously. Non-sequential writes may not create proper holes.
+    /// Any pending zero run is discarded. Call [`finish`](Self::finish) first
+    /// to flush pending zeros.
+    pub fn into_inner(self) -> W {
+        self.inner
+    }
+
+    /// Flushes any pending zero run by seeking forward in the inner writer.
     ///
-    /// # Arguments
-    ///
-    /// * `offset` - File offset where this data should be written
-    /// * `data` - The data to write
-    ///
-    /// # Returns
-    ///
-    /// An I/O error if the write fails.
-    pub fn write_region(&mut self, offset: u64, data: &[u8]) -> io::Result<()> {
-        if data.is_empty() {
+    /// This maintains the single-seek-per-zero-run invariant: all accumulated
+    /// zeros are flushed as one seek operation.
+    fn flush_pending_zeros(&mut self) -> io::Result<()> {
+        if self.pending_zeros == 0 {
             return Ok(());
         }
 
-        if self.sparse_enabled {
-            self.file
-                .seek(SeekFrom::Start(offset))
-                .map_err(|e| io::Error::new(e.kind(), format!("seek to offset {offset}: {e}")))?;
-
-            let path = std::path::Path::new("");
-            write_sparse_chunk(&mut self.file, &mut self.state, data, path)
-                .map_err(io::Error::other)?;
-        } else {
-            self.file
-                .seek(SeekFrom::Start(offset))
-                .map_err(|e| io::Error::new(e.kind(), format!("seek to offset {offset}: {e}")))?;
-            self.file.write_all(data)?;
+        let mut remaining = self.pending_zeros;
+        while remaining > 0 {
+            let step = remaining.min(i64::MAX as u64);
+            self.inner.seek(SeekFrom::Current(step as i64))?;
+            remaining -= step;
         }
 
+        self.stats.bytes_seeked = self.stats.bytes_seeked.saturating_add(self.pending_zeros);
+        self.pending_zeros = 0;
         Ok(())
     }
 
-    /// Finishes writing and sets the final file size.
+    /// Returns the leading zero count using the configured scan strategy.
+    fn leading_zeros(&self, data: &[u8]) -> usize {
+        match self.scan_strategy {
+            ZeroScanStrategy::Simd => leading_zero_run(data),
+            ZeroScanStrategy::ByteLevel => leading_zero_run_byte_level(data),
+        }
+    }
+
+    /// Returns the trailing zero count using the configured scan strategy.
+    fn trailing_zeros(&self, data: &[u8]) -> usize {
+        match self.scan_strategy {
+            ZeroScanStrategy::Simd => trailing_zero_run(data),
+            ZeroScanStrategy::ByteLevel => trailing_zero_run_byte_level(data),
+        }
+    }
+
+    /// Writes a chunk of data with sparse zero-run detection.
     ///
-    /// Any pending sparse zeros are flushed, and the file is truncated to the
-    /// specified size. After this call, the writer should not be used again.
-    ///
-    /// # Arguments
-    ///
-    /// * `total_size` - The final size of the file in bytes
-    ///
-    /// # Returns
-    ///
-    /// An I/O error if finishing fails.
-    pub fn finish(mut self, total_size: u64) -> io::Result<()> {
-        if self.sparse_enabled {
-            let path = std::path::Path::new("");
-            self.state
-                .finish(&mut self.file, path)
-                .map_err(io::Error::other)?;
+    /// Processes the buffer in `chunk_size` segments, detecting leading and
+    /// trailing zero runs in each segment. Zero runs are accumulated rather
+    /// than written, and flushed as seeks when non-zero data follows.
+    fn write_sparse(&mut self, buf: &[u8]) -> io::Result<usize> {
+        if buf.is_empty() {
+            return Ok(0);
         }
 
-        self.file.set_len(total_size)?;
-        self.file.sync_all()?;
+        let mut offset = 0;
 
-        Ok(())
+        while offset < buf.len() {
+            let segment_end = (offset + self.chunk_size).min(buf.len());
+            let segment = &buf[offset..segment_end];
+
+            let leading = self.leading_zeros(segment);
+            self.pending_zeros = self.pending_zeros.saturating_add(leading as u64);
+
+            if leading == segment.len() {
+                offset = segment_end;
+                continue;
+            }
+
+            let trailing = self.trailing_zeros(&segment[leading..]);
+            let data_start = offset + leading;
+            let data_end = segment_end - trailing;
+
+            if data_end > data_start {
+                // Count zero runs: a new zero run was detected if pending > 0
+                // before this flush (meaning we accumulated some zeros that are
+                // now being flushed).
+                if self.pending_zeros > 0 {
+                    self.stats.zero_runs_detected = self.stats.zero_runs_detected.saturating_add(1);
+                }
+                self.flush_pending_zeros()?;
+                self.inner.write_all(&buf[data_start..data_end])?;
+                let written_len = (data_end - data_start) as u64;
+                self.stats.bytes_written = self.stats.bytes_written.saturating_add(written_len);
+            }
+
+            self.pending_zeros = trailing as u64;
+            offset = segment_end;
+        }
+
+        Ok(buf.len())
     }
 
-    /// Returns a reference to the underlying file.
-    pub fn file(&self) -> &fs::File {
-        &self.file
+    /// Finalizes sparse writing by flushing any remaining pending zeros.
+    ///
+    /// Returns the final stream position after all pending zeros have been
+    /// flushed. The caller should use this position to set the file length
+    /// (via `set_len`) to materialize trailing holes.
+    ///
+    /// # Errors
+    ///
+    /// Returns an I/O error if seeking or querying the stream position fails.
+    pub fn finish(mut self) -> io::Result<(W, SparseWriteStats)> {
+        if self.pending_zeros > 0 {
+            self.stats.zero_runs_detected = self.stats.zero_runs_detected.saturating_add(1);
+        }
+        self.flush_pending_zeros()?;
+        let stats = self.stats;
+        Ok((self.inner, stats))
     }
 
-    /// Returns a mutable reference to the underlying file.
-    pub fn file_mut(&mut self) -> &mut fs::File {
-        &mut self.file
+    /// Finalizes and returns the final file position.
+    ///
+    /// Flushes pending zeros and returns the stream position for `set_len`.
+    pub fn finish_and_position(mut self) -> io::Result<(W, u64, SparseWriteStats)> {
+        if self.pending_zeros > 0 {
+            self.stats.zero_runs_detected = self.stats.zero_runs_detected.saturating_add(1);
+        }
+        self.flush_pending_zeros()?;
+        let pos = self.inner.stream_position()?;
+        let stats = self.stats;
+        Ok((self.inner, pos, stats))
     }
+}
+
+impl<W: Write + Seek> Write for SparseWriter<W> {
+    /// Writes data with sparse zero-run interception.
+    ///
+    /// Zero regions are accumulated as pending seeks rather than written to the
+    /// inner writer. Non-zero regions trigger a flush of any pending seeks
+    /// followed by the actual write. Always reports the full buffer length as
+    /// consumed, matching upstream rsync's `write_sparse()` semantics.
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.write_sparse(buf)
+    }
+
+    /// Flushes the inner writer.
+    ///
+    /// Note: this does not flush pending zeros - they are flushed when non-zero
+    /// data arrives or at finalization via [`finish`](Self::finish).
+    fn flush(&mut self) -> io::Result<()> {
+        self.inner.flush()
+    }
+}
+
+impl<W: Write + Seek> Seek for SparseWriter<W> {
+    /// Seeks in the underlying writer after flushing any pending zeros.
+    ///
+    /// Pending zeros must be flushed before a seek to maintain correct file
+    /// position tracking.
+    fn seek(&mut self, pos: SeekFrom) -> io::Result<u64> {
+        if self.pending_zeros > 0 {
+            self.stats.zero_runs_detected = self.stats.zero_runs_detected.saturating_add(1);
+        }
+        self.flush_pending_zeros()?;
+        self.inner.seek(pos)
+    }
+}
+
+/// Byte-level leading zero run detection.
+///
+/// Simple byte-by-byte scan for environments where SIMD overhead is not
+/// justified (small buffers, testing).
+fn leading_zero_run_byte_level(data: &[u8]) -> usize {
+    data.iter().take_while(|&&b| b == 0).count()
+}
+
+/// Byte-level trailing zero run detection.
+fn trailing_zero_run_byte_level(data: &[u8]) -> usize {
+    data.iter().rev().take_while(|&&b| b == 0).count()
 }

--- a/crates/engine/src/local_copy/executor/mod.rs
+++ b/crates/engine/src/local_copy/executor/mod.rs
@@ -22,8 +22,8 @@ pub(crate) use file::{
 };
 pub use file::{
     DestinationWriteGuard, PartialFileManager, PartialMode, SparseDetectStrategy, SparseDetector,
-    SparseReader, SparseRegion, SparseWriter, compute_backup_path, remove_existing_destination,
-    remove_incomplete_destination,
+    SparseReader, SparseRegion, SparseWriteStats, SparseWriter, ZeroScanStrategy,
+    compute_backup_path, remove_existing_destination, remove_incomplete_destination,
 };
 #[cfg(test)]
 pub(crate) use file::{

--- a/crates/engine/src/local_copy/mod.rs
+++ b/crates/engine/src/local_copy/mod.rs
@@ -132,8 +132,8 @@ pub(crate) use dir_merge::{
 pub(crate) use executor::*;
 pub use executor::{
     DestinationWriteGuard, PartialFileManager, PartialMode, SparseDetectStrategy, SparseDetector,
-    SparseReader, SparseRegion, SparseWriter, compute_backup_path, remove_existing_destination,
-    remove_incomplete_destination,
+    SparseReader, SparseRegion, SparseWriteStats, SparseWriter, ZeroScanStrategy,
+    compute_backup_path, remove_existing_destination, remove_incomplete_destination,
 };
 
 pub(crate) use hard_links::HardLinkTracker;


### PR DESCRIPTION
## Summary

- Refactors `SparseWriter` from a concrete `fs::File` wrapper with region-based API into a generic `SparseWriter<W: Write + Seek>` decorator that transparently intercepts write calls to scan for zero regions
- Adds `ZeroScanStrategy` enum (SIMD-accelerated default, byte-level alternative) for configurable zero-detection
- Adds `SparseWriteStats` for tracking bytes written, bytes seeked, and zero runs detected
- Wires the decorator into the whole-file copy path (`copy_file_contents_sparse`), replacing manual `SparseWriteState` management
- Delta transfer path retains `write_sparse_chunk` for its interleaved literal/block-match I/O pattern
- Adds 20 tests covering all-zero, all-nonzero, mixed data, buffer boundaries, statistics tracking, strategy parity, Write trait usage, seek flushing, and real file I/O

## Test plan

- [ ] All existing sparse tests pass (zero-run detection, hole punching, state machine)
- [ ] New decorator tests: all-zero produces only seeks, all-nonzero produces only writes
- [ ] Mixed data correctly splits seeks and writes with content verification
- [ ] Zero runs at buffer boundaries accumulated across multiple write calls
- [ ] Statistics tracking accurate throughout write lifecycle
- [ ] SIMD and byte-level strategies produce identical output
- [ ] Write trait usable polymorphically
- [ ] Seek flushes pending zeros before repositioning
- [ ] Real file I/O produces correct sparse content
- [ ] CI: fmt, clippy, nextest, all platforms