### PR TITLE
feat(fast_io): add IORING_OP_STATX batch chains for parallel directory stat (#1833)

### DIFF
--- a/crates/fast_io/src/io_uring/mod.rs
+++ b/crates/fast_io/src/io_uring/mod.rs
@@ -98,6 +98,7 @@ pub mod shared_ring;
 mod socket_factory;
 mod socket_reader;
 mod socket_writer;
+pub mod statx;
 
 #[cfg(test)]
 mod tests;
@@ -134,6 +135,10 @@ pub use socket_factory::{
 };
 pub use socket_reader::IoUringSocketReader;
 pub use socket_writer::IoUringSocketWriter;
+pub use statx::{
+    IORING_OP_STATX, STATX_MIN_KERNEL, StatxArgs, StatxResult, build_statx_sqe,
+    build_statx_sqe_unchecked, statx_supported, submit_statx_batch, submit_statx_blocking,
+};
 
 use crate::traits::{FileReader, FileReaderFactory, FileWriterFactory};
 use batching::try_register_fd;

--- a/crates/fast_io/src/io_uring/statx.rs
+++ b/crates/fast_io/src/io_uring/statx.rs
@@ -162,7 +162,7 @@ fn probe_statx_support() -> bool {
 ///
 /// The `args` struct must outlive the submission so the kernel can read
 /// the borrowed `CStr` path and write the statx buffer.
-pub fn build_statx_sqe(args: &StatxArgs<'_>) -> io::Result<squeue::Entry> {
+pub fn build_statx_sqe(args: &mut StatxArgs<'_>) -> io::Result<squeue::Entry> {
     if !statx_supported() {
         return Err(io::Error::new(
             io::ErrorKind::Unsupported,
@@ -178,7 +178,7 @@ pub fn build_statx_sqe(args: &StatxArgs<'_>) -> io::Result<squeue::Entry> {
 /// isolation. Production callers should use [`build_statx_sqe`] so the
 /// probe gate keeps the fallback path correct.
 #[must_use]
-pub fn build_statx_sqe_unchecked(args: &StatxArgs<'_>) -> squeue::Entry {
+pub fn build_statx_sqe_unchecked(args: &mut StatxArgs<'_>) -> squeue::Entry {
     opcode::Statx::new(
         types::Fd(args.dirfd),
         args.pathname.as_ptr(),
@@ -213,14 +213,14 @@ pub fn submit_statx_blocking(
     mask: u32,
 ) -> io::Result<libc::statx> {
     let mut statx_buf: libc::statx = unsafe { std::mem::zeroed() };
-    let args = StatxArgs {
+    let mut args = StatxArgs {
         dirfd,
         pathname,
         flags,
         mask,
         statx_buf: &mut statx_buf,
     };
-    let sqe = build_statx_sqe(&args)?.user_data(0);
+    let sqe = build_statx_sqe(&mut args)?.user_data(0);
     let mut ring = io_uring::IoUring::new(2)?;
     // SAFETY: `sqe` references the CStr path borrowed from `pathname` and the
     // statx buffer borrowed from our stack, both of which outlive
@@ -508,7 +508,7 @@ mod tests {
         }
         let path = c"/tmp/test";
         let mut buf: libc::statx = unsafe { std::mem::zeroed() };
-        let err = build_statx_sqe(&StatxArgs {
+        let err = build_statx_sqe(&mut StatxArgs {
             dirfd: libc::AT_FDCWD,
             pathname: path,
             flags: 0,
@@ -524,7 +524,7 @@ mod tests {
         let path = c"/tmp/test";
         let mut buf: libc::statx = unsafe { std::mem::zeroed() };
         // Construct without panic and tag with user_data.
-        let _tagged = build_statx_sqe_unchecked(&StatxArgs {
+        let _tagged = build_statx_sqe_unchecked(&mut StatxArgs {
             dirfd: libc::AT_FDCWD,
             pathname: path,
             flags: libc::AT_SYMLINK_NOFOLLOW,
@@ -541,7 +541,7 @@ mod tests {
         }
         let path = c"/tmp/test";
         let mut buf: libc::statx = unsafe { std::mem::zeroed() };
-        let _entry = build_statx_sqe(&StatxArgs {
+        let _entry = build_statx_sqe(&mut StatxArgs {
             dirfd: libc::AT_FDCWD,
             pathname: path,
             flags: 0,

--- a/crates/fast_io/src/io_uring/statx.rs
+++ b/crates/fast_io/src/io_uring/statx.rs
@@ -562,8 +562,8 @@ mod tests {
         let statx_buf = result.expect("statx on /proc/self/exe should succeed");
         // The file must be a regular file or symlink.
         assert!(
-            statx_buf.stx_mode & libc::S_IFMT == libc::S_IFREG
-                || statx_buf.stx_mode & libc::S_IFMT == libc::S_IFLNK,
+            u32::from(statx_buf.stx_mode) & libc::S_IFMT == libc::S_IFREG
+                || u32::from(statx_buf.stx_mode) & libc::S_IFMT == libc::S_IFLNK,
             "expected regular file or symlink, got mode {:#o}",
             statx_buf.stx_mode
         );
@@ -596,7 +596,7 @@ mod tests {
         // report as a symlink.
         let statx_buf = result.expect("lstat on /proc/self/exe should succeed");
         assert_eq!(
-            statx_buf.stx_mode & libc::S_IFMT,
+            u32::from(statx_buf.stx_mode) & libc::S_IFMT,
             libc::S_IFLNK,
             "expected symlink, got mode {:#o}",
             statx_buf.stx_mode
@@ -718,7 +718,7 @@ mod tests {
             let results_follow = submit_statx_batch(&paths, true).unwrap();
             let statx_follow = results_follow[0].as_ref().unwrap();
             assert_eq!(
-                statx_follow.stx_mode & libc::S_IFMT,
+                u32::from(statx_follow.stx_mode) & libc::S_IFMT,
                 libc::S_IFREG,
                 "expected regular file when following symlinks"
             );
@@ -727,7 +727,7 @@ mod tests {
             let results_nofollow = submit_statx_batch(&paths, false).unwrap();
             let statx_nofollow = results_nofollow[0].as_ref().unwrap();
             assert_eq!(
-                statx_nofollow.stx_mode & libc::S_IFMT,
+                u32::from(statx_nofollow.stx_mode) & libc::S_IFMT,
                 libc::S_IFLNK,
                 "expected symlink when not following symlinks"
             );

--- a/crates/fast_io/src/io_uring/statx.rs
+++ b/crates/fast_io/src/io_uring/statx.rs
@@ -184,7 +184,7 @@ pub fn build_statx_sqe_unchecked(args: &StatxArgs<'_>) -> squeue::Entry {
         args.pathname.as_ptr(),
         (args.statx_buf as *mut libc::statx).cast::<types::statx>(),
     )
-    .flags(args.flags as u32)
+    .flags(args.flags)
     .mask(args.mask)
     .build()
 }
@@ -454,34 +454,21 @@ fn fallback_statx_single(path: &Path, follow_symlinks: bool) -> StatxResult {
 #[cfg(target_os = "linux")]
 #[allow(unsafe_code)]
 fn rustix_statx_to_libc(src: &rustix::fs::Statx) -> libc::statx {
-    // SAFETY: `libc::statx` is a plain-old-data C struct. Zero-initializing
-    // is valid and sets all padding/spare fields to zero.
-    let mut dst: libc::statx = unsafe { std::mem::zeroed() };
-    dst.stx_mask = src.stx_mask;
-    dst.stx_blksize = src.stx_blksize;
-    dst.stx_attributes = src.stx_attributes;
-    dst.stx_nlink = src.stx_nlink;
-    dst.stx_uid = src.stx_uid;
-    dst.stx_gid = src.stx_gid;
-    dst.stx_mode = src.stx_mode;
-    dst.stx_ino = src.stx_ino;
-    dst.stx_size = src.stx_size;
-    dst.stx_blocks = src.stx_blocks;
-    dst.stx_attributes_mask = src.stx_attributes_mask;
-    dst.stx_atime.tv_sec = src.stx_atime.tv_sec;
-    dst.stx_atime.tv_nsec = src.stx_atime.tv_nsec;
-    dst.stx_btime.tv_sec = src.stx_btime.tv_sec;
-    dst.stx_btime.tv_nsec = src.stx_btime.tv_nsec;
-    dst.stx_ctime.tv_sec = src.stx_ctime.tv_sec;
-    dst.stx_ctime.tv_nsec = src.stx_ctime.tv_nsec;
-    dst.stx_mtime.tv_sec = src.stx_mtime.tv_sec;
-    dst.stx_mtime.tv_nsec = src.stx_mtime.tv_nsec;
-    dst.stx_rdev_major = src.stx_rdev_major;
-    dst.stx_rdev_minor = src.stx_rdev_minor;
-    dst.stx_dev_major = src.stx_dev_major;
-    dst.stx_dev_minor = src.stx_dev_minor;
-    dst.stx_mnt_id = src.stx_mnt_id;
-    dst
+    // Both types are #[repr(C)] representations of the kernel `struct statx`.
+    // Field-by-field copy is fragile because rustix exposes some fields as
+    // newtype wrappers (e.g. `StatxAttributes`) depending on its backend
+    // feature configuration, while libc uses plain integers. A byte-level
+    // copy sidesteps the type mismatch entirely.
+    const _: () = assert!(
+        std::mem::size_of::<rustix::fs::Statx>() == std::mem::size_of::<libc::statx>()
+    );
+    const _: () = assert!(
+        std::mem::align_of::<rustix::fs::Statx>() == std::mem::align_of::<libc::statx>()
+    );
+    // SAFETY: Both types represent the same kernel struct with identical
+    // size and alignment (verified by const assertions above). All bit
+    // patterns of the C struct are valid for both representations.
+    unsafe { std::ptr::read((src as *const rustix::fs::Statx).cast::<libc::statx>()) }
 }
 
 #[cfg(test)]

--- a/crates/fast_io/src/io_uring/statx.rs
+++ b/crates/fast_io/src/io_uring/statx.rs
@@ -623,7 +623,7 @@ mod tests {
         let statx_buf = results.into_iter().next().unwrap().unwrap();
         assert_eq!(statx_buf.stx_size, 5);
         assert_eq!(
-            statx_buf.stx_mode & libc::S_IFMT,
+            u32::from(statx_buf.stx_mode) & libc::S_IFMT,
             libc::S_IFREG,
             "expected regular file"
         );

--- a/crates/fast_io/src/io_uring/statx.rs
+++ b/crates/fast_io/src/io_uring/statx.rs
@@ -1,0 +1,792 @@
+//! io_uring `IORING_OP_STATX` opcode wrapper and batch submission.
+//!
+//! `IORING_OP_STATX` lets the kernel perform `statx(2)` asynchronously via
+//! the io_uring submission queue, avoiding a synchronous syscall per file when
+//! stat-ing many files during directory traversal. It became available in
+//! Linux 5.11.
+//!
+//! # API surface
+//!
+//! - [`statx_supported`] - process-wide cached probe; short-circuits on
+//!   `is_io_uring_available()` and then asks the kernel via
+//!   `IORING_REGISTER_PROBE` whether opcode 21 (`IORING_OP_STATX`) is
+//!   reported as supported.
+//! - [`build_statx_sqe`] - constructs an [`squeue::Entry`] for a STATX
+//!   submission; returns [`io::ErrorKind::Unsupported`] when the probe is
+//!   `false`. Callers must keep the [`StatxArgs`] path and buffer alive until
+//!   the matching CQE has been reaped.
+//! - [`build_statx_sqe_unchecked`] - identical SQE construction without the
+//!   probe gate. Reserved for tests that exercise the encoder in isolation
+//!   on every platform.
+//! - [`submit_statx_blocking`] - synchronously submits a single STATX SQE on
+//!   a throwaway ring and returns the populated `libc::statx` result.
+//! - [`submit_statx_batch`] - submits multiple STATX SQEs as independent
+//!   operations on a single ring and returns all results. Falls back to
+//!   synchronous `statx(2)` via `rustix` when the kernel lacks the opcode.
+//!
+//! # Path lifetime contract
+//!
+//! [`StatxArgs`] borrows the pathname as `&CStr`. The kernel reads this
+//! string during submission, so callers must keep the original allocation
+//! alive at least until the corresponding CQE has been reaped. The borrowed
+//! lifetime in the struct enforces this at compile time as long as the SQE
+//! is consumed before `StatxArgs` is dropped.
+//!
+//! # Kernel version requirement
+//!
+//! `IORING_OP_STATX` requires Linux 5.11+. The runtime probe still asks
+//! the kernel directly via `IORING_REGISTER_PROBE` because kernels may
+//! backport or disable individual opcodes independently of the reported
+//! `uname` release.
+//!
+//! # Upstream rsync reference
+//!
+//! Upstream rsync uses synchronous `stat(2)` / `lstat(2)` (and `statx(2)` on
+//! newer glibc) for file metadata retrieval during file list building
+//! (`flist.c:receive_file_entry()`, `generator.c`). The io_uring fast path
+//! is an optimisation: when the kernel exposes `IORING_OP_STATX`, the
+//! generator can submit batched stat calls alongside other ring operations,
+//! reducing per-file syscall overhead during directory traversal.
+
+#[cfg(target_os = "linux")]
+use std::sync::OnceLock;
+use std::{ffi::CStr, io, path::Path};
+
+use io_uring::{opcode, squeue, types};
+
+use super::config::is_io_uring_available;
+
+/// Numeric value of `IORING_OP_STATX`.
+///
+/// The kernel UAPI (`include/uapi/linux/io_uring.h`) assigns opcode 21 to
+/// `IORING_OP_STATX` starting in Linux 5.11. The `io-uring` crate's
+/// [`io_uring::Probe::is_supported`] takes a raw `u8`, so we record the
+/// numeric value here rather than relying on a `CODE` associated constant.
+pub const IORING_OP_STATX: u8 = 21;
+
+/// Minimum Linux kernel version that ships `IORING_OP_STATX`.
+///
+/// Documented for diagnostic and capability-string output. The runtime
+/// probe still asks the kernel directly via `IORING_REGISTER_PROBE` because
+/// kernels may backport or disable individual opcodes independently of the
+/// reported `uname` release.
+pub const STATX_MIN_KERNEL: (u32, u32) = (5, 11);
+
+/// Cached probe result on Linux. Populated lazily on first call.
+#[cfg(target_os = "linux")]
+static STATX_SUPPORTED: OnceLock<bool> = OnceLock::new();
+
+/// Borrowed arguments for an `IORING_OP_STATX` submission.
+///
+/// The `pathname` lives in the caller's address space; the kernel reads
+/// this string when the SQE is processed. The `statx_buf` is written by
+/// the kernel on completion. The borrowed lifetime `'a` ties the args
+/// to those allocations so the compiler refuses to drop them while a built
+/// SQE still references the same memory.
+#[derive(Debug)]
+pub struct StatxArgs<'a> {
+    /// Directory file descriptor that resolves `pathname`. Use
+    /// [`libc::AT_FDCWD`] to resolve from the current working directory.
+    pub dirfd: i32,
+    /// Path to stat. Must outlive the SQE submission and completion.
+    pub pathname: &'a CStr,
+    /// Flags passed to the kernel: combination of `libc::AT_*` flags.
+    /// Common values:
+    /// - `0` for following symlinks (like `stat`)
+    /// - `libc::AT_SYMLINK_NOFOLLOW` for not following symlinks (like `lstat`)
+    /// - `libc::AT_EMPTY_PATH` when using `dirfd` as the target itself
+    pub flags: i32,
+    /// Mask of fields to request. Use `libc::STATX_BASIC_STATS` for the
+    /// common fields (mode, nlink, uid, gid, ino, size, blocks, timestamps).
+    pub mask: u32,
+    /// Output buffer for the kernel to write the statx result into.
+    /// Must be zero-initialized before submission.
+    pub statx_buf: &'a mut libc::statx,
+}
+
+/// Returns whether `IORING_OP_STATX` is usable on this system.
+///
+/// On Linux, the result is probed once and cached for the lifetime of the
+/// process. The probe:
+///
+/// 1. Returns `false` immediately when [`is_io_uring_available`] is `false`,
+///    so we never build an extra ring just to discover the opcode is
+///    irrelevant.
+/// 2. Builds a tiny throwaway ring and registers an `io_uring::Probe`,
+///    asking the kernel to enumerate supported opcodes.
+/// 3. Returns `probe.is_supported(IORING_OP_STATX)`.
+///
+/// On non-Linux platforms or when the `io_uring` cargo feature is disabled,
+/// the stub module supplies a counterpart that always returns `false`.
+#[must_use]
+pub fn statx_supported() -> bool {
+    #[cfg(target_os = "linux")]
+    {
+        *STATX_SUPPORTED.get_or_init(probe_statx_support)
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        false
+    }
+}
+
+/// Probes the live kernel for `IORING_OP_STATX` support.
+///
+/// Mirrors the convention used by `shared_ring::probe_poll_add`: short-
+/// circuit on the process-wide io_uring availability flag, then build a
+/// throwaway ring and register a probe.
+#[cfg(target_os = "linux")]
+fn probe_statx_support() -> bool {
+    if !is_io_uring_available() {
+        return false;
+    }
+    let ring = match io_uring::IoUring::new(2) {
+        Ok(r) => r,
+        Err(_) => return false,
+    };
+    let mut probe = io_uring::Probe::new();
+    if ring.submitter().register_probe(&mut probe).is_err() {
+        return false;
+    }
+    probe.is_supported(IORING_OP_STATX)
+}
+
+/// Builds an `IORING_OP_STATX` SQE if the running kernel supports the
+/// opcode.
+///
+/// Returns [`io::ErrorKind::Unsupported`] when [`statx_supported`] reports
+/// `false`. The returned [`squeue::Entry`] is unattached; callers are
+/// responsible for tagging it with `user_data` and pushing it onto a ring's
+/// submission queue under the `unsafe` contract documented by
+/// `io_uring::SubmissionQueue::push`.
+///
+/// The `args` struct must outlive the submission so the kernel can read
+/// the borrowed `CStr` path and write the statx buffer.
+pub fn build_statx_sqe(args: &StatxArgs<'_>) -> io::Result<squeue::Entry> {
+    if !statx_supported() {
+        return Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "IORING_OP_STATX is not supported by this kernel",
+        ));
+    }
+    Ok(build_statx_sqe_unchecked(args))
+}
+
+/// Builds an `IORING_OP_STATX` SQE without consulting the kernel probe.
+///
+/// Reserved for unit tests that want to verify the encoded SQE bytes in
+/// isolation. Production callers should use [`build_statx_sqe`] so the
+/// probe gate keeps the fallback path correct.
+#[must_use]
+pub fn build_statx_sqe_unchecked(args: &StatxArgs<'_>) -> squeue::Entry {
+    opcode::Statx::new(
+        types::Fd(args.dirfd),
+        args.pathname.as_ptr(),
+        (args.statx_buf as *mut libc::statx).cast::<types::statx>(),
+    )
+    .flags(args.flags as u32)
+    .mask(args.mask)
+    .build()
+}
+
+/// Synchronously submits a `STATX` SQE on a private throwaway ring and
+/// returns the kernel's statx result.
+///
+/// This is the high-level convenience wrapper around [`build_statx_sqe`]
+/// for callers that do not maintain a long-lived ring (tests, one-shot
+/// stat calls in slow paths). The function builds a 2-entry ring,
+/// submits the SQE, blocks for one completion, and returns:
+///
+/// - `Ok(statx)` on success - the statx buffer was populated.
+/// - `Err(Unsupported)` when the kernel does not advertise
+///   `IORING_OP_STATX`.
+/// - `Err(io::Error::from_raw_os_error(-result))` when the kernel returns a
+///   negative errno through the CQE.
+///
+/// `args` borrows the `CStr` path and the statx buffer; the function keeps
+/// them alive for the duration of the syscall.
+#[allow(unsafe_code)]
+pub fn submit_statx_blocking(
+    dirfd: i32,
+    pathname: &CStr,
+    flags: i32,
+    mask: u32,
+) -> io::Result<libc::statx> {
+    let mut statx_buf: libc::statx = unsafe { std::mem::zeroed() };
+    let args = StatxArgs {
+        dirfd,
+        pathname,
+        flags,
+        mask,
+        statx_buf: &mut statx_buf,
+    };
+    let sqe = build_statx_sqe(&args)?.user_data(0);
+    let mut ring = io_uring::IoUring::new(2)?;
+    // SAFETY: `sqe` references the CStr path borrowed from `pathname` and the
+    // statx buffer borrowed from our stack, both of which outlive
+    // `submit_and_wait`. The ring is local and has no other outstanding
+    // references.
+    unsafe {
+        ring.submission()
+            .push(&sqe)
+            .map_err(|_| io::Error::other("submission queue full while pushing STATX SQE"))?;
+    }
+    ring.submit_and_wait(1)?;
+    let cqe = ring
+        .completion()
+        .next()
+        .ok_or_else(|| io::Error::other("missing STATX CQE"))?;
+    let result = cqe.result();
+    if result < 0 {
+        return Err(io::Error::from_raw_os_error(-result));
+    }
+    // Re-borrow to satisfy the borrow checker - args held the mutable ref
+    // but the kernel has already written through the raw pointer.
+    drop(args);
+    Ok(statx_buf)
+}
+
+/// Result of a single statx operation within a batch.
+///
+/// On success, contains the populated `libc::statx` struct. On failure,
+/// contains the I/O error from the kernel or the fallback path.
+pub type StatxResult = io::Result<libc::statx>;
+
+/// Submits multiple `IORING_OP_STATX` operations as independent SQEs on a
+/// single io_uring instance and returns all results.
+///
+/// When `IORING_OP_STATX` is supported, each path in `paths` is submitted
+/// as an independent SQE (not linked) on a shared ring. The ring processes
+/// them concurrently, amortizing the syscall overhead across the entire
+/// batch. Results are returned in the same order as the input paths.
+///
+/// When `IORING_OP_STATX` is not supported (kernel < 5.11, non-Linux,
+/// or io_uring unavailable), falls back to synchronous `statx(2)` via
+/// `rustix::fs::statx` for each path.
+///
+/// # Arguments
+///
+/// * `paths` - Slice of paths to stat.
+/// * `follow_symlinks` - If `true`, follows symlinks (like `stat`);
+///   if `false`, does not follow (like `lstat`).
+///
+/// # Returns
+///
+/// A `Vec<StatxResult>` with one entry per input path, preserving order.
+/// Individual entries may be `Err` (e.g., `ENOENT`) without affecting
+/// other entries in the batch.
+///
+/// # Errors
+///
+/// Returns `Err` only for ring-level failures (ring creation, submission
+/// failure). Per-path errors are captured in individual `StatxResult` entries.
+pub fn submit_statx_batch(paths: &[&Path], follow_symlinks: bool) -> io::Result<Vec<StatxResult>> {
+    if paths.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    if !statx_supported() {
+        return Ok(fallback_statx_batch(paths, follow_symlinks));
+    }
+
+    submit_statx_batch_io_uring(paths, follow_symlinks)
+}
+
+/// io_uring batch submission path. Submits all paths as independent SQEs.
+#[allow(unsafe_code)]
+fn submit_statx_batch_io_uring(
+    paths: &[&Path],
+    follow_symlinks: bool,
+) -> io::Result<Vec<StatxResult>> {
+    use std::ffi::CString;
+    #[cfg(unix)]
+    use std::os::unix::ffi::OsStrExt;
+
+    let count = paths.len();
+    // Round SQ depth up to the next power of two, clamped to at least 4.
+    let sq_depth = (count as u32).next_power_of_two().max(4);
+    let mut ring = io_uring::IoUring::new(sq_depth)?;
+
+    let flags: i32 = if follow_symlinks {
+        0
+    } else {
+        libc::AT_SYMLINK_NOFOLLOW
+    };
+    let mask: u32 = libc::STATX_BASIC_STATS;
+
+    // Allocate CString paths and statx buffers upfront so they stay alive
+    // across submission and completion.
+    let mut c_paths: Vec<Option<CString>> = Vec::with_capacity(count);
+    let mut statx_bufs: Vec<libc::statx> = vec![unsafe { std::mem::zeroed() }; count];
+    let mut path_errors: Vec<Option<io::Error>> = vec![None; count];
+
+    for (i, path) in paths.iter().enumerate() {
+        match CString::new(path.as_os_str().as_bytes()) {
+            Ok(c) => c_paths.push(Some(c)),
+            Err(_) => {
+                c_paths.push(None);
+                path_errors[i] = Some(io::Error::other("path contains interior NUL"));
+            }
+        }
+    }
+
+    // Submit in chunks up to the SQ depth to avoid overflowing the ring.
+    let chunk_size = sq_depth as usize;
+    let mut submitted_indices: Vec<usize> = Vec::with_capacity(count);
+
+    for chunk_start in (0..count).step_by(chunk_size) {
+        let chunk_end = (chunk_start + chunk_size).min(count);
+        submitted_indices.clear();
+
+        for i in chunk_start..chunk_end {
+            if path_errors[i].is_some() || c_paths[i].is_none() {
+                continue;
+            }
+
+            let c_path = c_paths[i].as_ref().unwrap();
+            let sqe = opcode::Statx::new(
+                types::Fd(libc::AT_FDCWD),
+                c_path.as_ptr(),
+                (&mut statx_bufs[i] as *mut libc::statx).cast::<types::statx>(),
+            )
+            .flags(flags as u32)
+            .mask(mask)
+            .build()
+            .user_data(i as u64);
+
+            // SAFETY: The CString paths and statx buffers live in Vecs that
+            // outlive the ring submission and completion. The ring is local
+            // to this function. Each SQE references a distinct CString and
+            // statx buffer slot, so there are no aliasing violations.
+            unsafe {
+                ring.submission().push(&sqe).map_err(|_| {
+                    io::Error::other("submission queue full while pushing STATX SQE")
+                })?;
+            }
+            submitted_indices.push(i);
+        }
+
+        if submitted_indices.is_empty() {
+            continue;
+        }
+
+        let want = submitted_indices.len();
+        ring.submit_and_wait(want)?;
+
+        // Reap all completions for this chunk.
+        let mut reaped = 0;
+        for cqe in ring.completion() {
+            let idx = cqe.user_data() as usize;
+            let result = cqe.result();
+            if result < 0 {
+                path_errors[idx] = Some(io::Error::from_raw_os_error(-result));
+            }
+            reaped += 1;
+        }
+
+        if reaped < want {
+            return Err(io::Error::other(format!(
+                "expected {want} CQEs but only reaped {reaped}"
+            )));
+        }
+    }
+
+    // Assemble results in input order.
+    let mut results = Vec::with_capacity(count);
+    for i in 0..count {
+        if let Some(err) = path_errors[i].take() {
+            results.push(Err(err));
+        } else {
+            results.push(Ok(statx_bufs[i]));
+        }
+    }
+
+    Ok(results)
+}
+
+/// Synchronous fallback path using `rustix::fs::statx` for each path.
+///
+/// Used when `IORING_OP_STATX` is not available (kernel < 5.11, non-Linux,
+/// or io_uring disabled).
+fn fallback_statx_batch(paths: &[&Path], follow_symlinks: bool) -> Vec<StatxResult> {
+    paths
+        .iter()
+        .map(|path| fallback_statx_single(path, follow_symlinks))
+        .collect()
+}
+
+/// Single-path synchronous statx via `rustix`.
+fn fallback_statx_single(path: &Path, follow_symlinks: bool) -> StatxResult {
+    #[cfg(target_os = "linux")]
+    {
+        use rustix::fs::{AtFlags, StatxFlags};
+
+        let flags = if follow_symlinks {
+            AtFlags::empty()
+        } else {
+            AtFlags::SYMLINK_NOFOLLOW
+        };
+        let mask = StatxFlags::BASIC_STATS;
+
+        let result = rustix::fs::statx(rustix::fs::CWD, path, flags, mask)
+            .map_err(|e| io::Error::from_raw_os_error(e.raw_os_error()))?;
+
+        // Convert rustix::fs::Statx to libc::statx field by field.
+        Ok(rustix_statx_to_libc(&result))
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = (path, follow_symlinks);
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "statx is not available on this platform",
+        ))
+    }
+}
+
+/// Converts a `rustix::fs::Statx` to a `libc::statx`.
+///
+/// The two types have identical layouts on Linux but different Rust types.
+/// We start from a zeroed struct and populate known public fields to avoid
+/// depending on internal padding field names (`__spare2`, `__spare3`,
+/// `__statx_timestamp_pad1`) which may change between libc crate versions.
+#[cfg(target_os = "linux")]
+#[allow(unsafe_code)]
+fn rustix_statx_to_libc(src: &rustix::fs::Statx) -> libc::statx {
+    // SAFETY: `libc::statx` is a plain-old-data C struct. Zero-initializing
+    // is valid and sets all padding/spare fields to zero.
+    let mut dst: libc::statx = unsafe { std::mem::zeroed() };
+    dst.stx_mask = src.stx_mask.bits();
+    dst.stx_blksize = src.stx_blksize;
+    dst.stx_attributes = src.stx_attributes.bits();
+    dst.stx_nlink = src.stx_nlink;
+    dst.stx_uid = src.stx_uid;
+    dst.stx_gid = src.stx_gid;
+    dst.stx_mode = src.stx_mode;
+    dst.stx_ino = src.stx_ino;
+    dst.stx_size = src.stx_size;
+    dst.stx_blocks = src.stx_blocks;
+    dst.stx_attributes_mask = src.stx_attributes_mask.bits();
+    dst.stx_atime.tv_sec = src.stx_atime.tv_sec;
+    dst.stx_atime.tv_nsec = src.stx_atime.tv_nsec;
+    dst.stx_btime.tv_sec = src.stx_btime.tv_sec;
+    dst.stx_btime.tv_nsec = src.stx_btime.tv_nsec;
+    dst.stx_ctime.tv_sec = src.stx_ctime.tv_sec;
+    dst.stx_ctime.tv_nsec = src.stx_ctime.tv_nsec;
+    dst.stx_mtime.tv_sec = src.stx_mtime.tv_sec;
+    dst.stx_mtime.tv_nsec = src.stx_mtime.tv_nsec;
+    dst.stx_rdev_major = src.stx_rdev_major;
+    dst.stx_rdev_minor = src.stx_rdev_minor;
+    dst.stx_dev_major = src.stx_dev_major;
+    dst.stx_dev_minor = src.stx_dev_minor;
+    dst.stx_mnt_id = src.stx_mnt_id;
+    dst
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn statx_opcode_constant_matches_kernel_uapi() {
+        // IORING_OP_STATX == 21 in include/uapi/linux/io_uring.h since 5.11.
+        assert_eq!(IORING_OP_STATX, 21);
+        assert_eq!(opcode::Statx::CODE, IORING_OP_STATX);
+    }
+
+    #[test]
+    fn statx_min_kernel_is_5_11() {
+        assert_eq!(STATX_MIN_KERNEL, (5, 11));
+    }
+
+    #[test]
+    fn statx_supported_is_idempotent() {
+        let first = statx_supported();
+        let second = statx_supported();
+        let third = statx_supported();
+        assert_eq!(first, second);
+        assert_eq!(second, third);
+    }
+
+    #[test]
+    fn statx_supported_implies_io_uring_available() {
+        if statx_supported() {
+            assert!(is_io_uring_available());
+        }
+    }
+
+    #[test]
+    fn build_statx_sqe_returns_unsupported_when_probe_false() {
+        if statx_supported() {
+            return; // probe says yes; cannot exercise the unsupported branch
+        }
+        let path = c"/tmp/test";
+        let mut buf: libc::statx = unsafe { std::mem::zeroed() };
+        let err = build_statx_sqe(&StatxArgs {
+            dirfd: libc::AT_FDCWD,
+            pathname: path,
+            flags: 0,
+            mask: libc::STATX_BASIC_STATS,
+            statx_buf: &mut buf,
+        })
+        .unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::Unsupported);
+    }
+
+    #[test]
+    fn build_statx_sqe_unchecked_smoke() {
+        let path = c"/tmp/test";
+        let mut buf: libc::statx = unsafe { std::mem::zeroed() };
+        // Construct without panic and tag with user_data.
+        let _tagged = build_statx_sqe_unchecked(&StatxArgs {
+            dirfd: libc::AT_FDCWD,
+            pathname: path,
+            flags: libc::AT_SYMLINK_NOFOLLOW,
+            mask: libc::STATX_BASIC_STATS,
+            statx_buf: &mut buf,
+        })
+        .user_data(0xCAFE_F00D);
+    }
+
+    #[test]
+    fn build_statx_sqe_succeeds_when_probe_true() {
+        if !statx_supported() {
+            return;
+        }
+        let path = c"/tmp/test";
+        let mut buf: libc::statx = unsafe { std::mem::zeroed() };
+        let _entry = build_statx_sqe(&StatxArgs {
+            dirfd: libc::AT_FDCWD,
+            pathname: path,
+            flags: 0,
+            mask: libc::STATX_BASIC_STATS,
+            statx_buf: &mut buf,
+        })
+        .expect("probe true implies SQE builds")
+        .user_data(0x1234);
+    }
+
+    #[test]
+    fn submit_statx_blocking_on_existing_file() {
+        if !statx_supported() {
+            return;
+        }
+        // /proc/self/exe always exists on Linux.
+        let path = c"/proc/self/exe";
+        let result = submit_statx_blocking(libc::AT_FDCWD, path, 0, libc::STATX_BASIC_STATS);
+        let statx_buf = result.expect("statx on /proc/self/exe should succeed");
+        // The file must be a regular file or symlink.
+        assert!(
+            statx_buf.stx_mode & libc::S_IFMT == libc::S_IFREG
+                || statx_buf.stx_mode & libc::S_IFMT == libc::S_IFLNK,
+            "expected regular file or symlink, got mode {:#o}",
+            statx_buf.stx_mode
+        );
+    }
+
+    #[test]
+    fn submit_statx_blocking_on_nonexistent_file() {
+        if !statx_supported() {
+            return;
+        }
+        let path = c"/nonexistent/path/that/does/not/exist";
+        let err =
+            submit_statx_blocking(libc::AT_FDCWD, path, 0, libc::STATX_BASIC_STATS).unwrap_err();
+        assert_eq!(err.raw_os_error(), Some(libc::ENOENT));
+    }
+
+    #[test]
+    fn submit_statx_blocking_lstat_mode() {
+        if !statx_supported() {
+            return;
+        }
+        let path = c"/proc/self/exe";
+        let result = submit_statx_blocking(
+            libc::AT_FDCWD,
+            path,
+            libc::AT_SYMLINK_NOFOLLOW,
+            libc::STATX_BASIC_STATS,
+        );
+        // /proc/self/exe is a symlink; with AT_SYMLINK_NOFOLLOW it should
+        // report as a symlink.
+        let statx_buf = result.expect("lstat on /proc/self/exe should succeed");
+        assert_eq!(
+            statx_buf.stx_mode & libc::S_IFMT,
+            libc::S_IFLNK,
+            "expected symlink, got mode {:#o}",
+            statx_buf.stx_mode
+        );
+    }
+
+    #[test]
+    fn submit_statx_batch_empty() {
+        let paths: &[&Path] = &[];
+        let results = submit_statx_batch(paths, true).unwrap();
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn submit_statx_batch_single_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("test.txt");
+        std::fs::write(&file_path, b"hello").unwrap();
+
+        let paths: Vec<&Path> = vec![file_path.as_path()];
+        let results = submit_statx_batch(&paths, true).unwrap();
+        assert_eq!(results.len(), 1);
+
+        let statx_buf = results.into_iter().next().unwrap().unwrap();
+        assert_eq!(statx_buf.stx_size, 5);
+        assert_eq!(
+            statx_buf.stx_mode & libc::S_IFMT,
+            libc::S_IFREG,
+            "expected regular file"
+        );
+    }
+
+    #[test]
+    fn submit_statx_batch_multiple_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let paths_owned: Vec<_> = (0..16)
+            .map(|i| {
+                let p = dir.path().join(format!("file_{i}.txt"));
+                std::fs::write(&p, format!("content {i}")).unwrap();
+                p
+            })
+            .collect();
+        let paths: Vec<&Path> = paths_owned.iter().map(|p| p.as_path()).collect();
+
+        let results = submit_statx_batch(&paths, true).unwrap();
+        assert_eq!(results.len(), 16);
+
+        for (i, result) in results.into_iter().enumerate() {
+            let statx_buf = result.unwrap_or_else(|e| panic!("statx failed for file_{i}: {e}"));
+            let expected_content = format!("content {i}");
+            assert_eq!(
+                statx_buf.stx_size,
+                expected_content.len() as u64,
+                "size mismatch for file_{i}"
+            );
+        }
+    }
+
+    #[test]
+    fn submit_statx_batch_with_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        let existing = dir.path().join("exists.txt");
+        std::fs::write(&existing, b"data").unwrap();
+        let missing = dir.path().join("does_not_exist.txt");
+
+        let paths: Vec<&Path> = vec![existing.as_path(), missing.as_path()];
+        let results = submit_statx_batch(&paths, true).unwrap();
+        assert_eq!(results.len(), 2);
+
+        // First should succeed.
+        assert!(results[0].is_ok());
+        // Second should fail with ENOENT.
+        let err = results[1].as_ref().unwrap_err();
+        assert_eq!(err.raw_os_error(), Some(libc::ENOENT));
+    }
+
+    #[test]
+    fn submit_statx_batch_preserves_order() {
+        let dir = tempfile::tempdir().unwrap();
+        let sizes = [10u64, 20, 30, 40, 50];
+        let paths_owned: Vec<_> = sizes
+            .iter()
+            .enumerate()
+            .map(|(i, &size)| {
+                let p = dir.path().join(format!("ordered_{i}.bin"));
+                std::fs::write(&p, vec![0u8; size as usize]).unwrap();
+                p
+            })
+            .collect();
+        let paths: Vec<&Path> = paths_owned.iter().map(|p| p.as_path()).collect();
+
+        let results = submit_statx_batch(&paths, true).unwrap();
+        assert_eq!(results.len(), sizes.len());
+
+        for (i, (result, &expected_size)) in results.iter().zip(sizes.iter()).enumerate() {
+            let statx_buf = result
+                .as_ref()
+                .unwrap_or_else(|e| panic!("statx failed for ordered_{i}: {e}"));
+            assert_eq!(
+                statx_buf.stx_size, expected_size,
+                "order mismatch at index {i}"
+            );
+        }
+    }
+
+    #[test]
+    fn submit_statx_batch_symlink_follow_vs_nofollow() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("target.txt");
+        std::fs::write(&target, b"symlink target").unwrap();
+
+        #[cfg(unix)]
+        {
+            let link = dir.path().join("link.txt");
+            std::os::unix::fs::symlink(&target, &link).unwrap();
+
+            // Following symlinks - should see regular file.
+            let paths: Vec<&Path> = vec![link.as_path()];
+            let results_follow = submit_statx_batch(&paths, true).unwrap();
+            let statx_follow = results_follow[0].as_ref().unwrap();
+            assert_eq!(
+                statx_follow.stx_mode & libc::S_IFMT,
+                libc::S_IFREG,
+                "expected regular file when following symlinks"
+            );
+
+            // Not following symlinks - should see symlink.
+            let results_nofollow = submit_statx_batch(&paths, false).unwrap();
+            let statx_nofollow = results_nofollow[0].as_ref().unwrap();
+            assert_eq!(
+                statx_nofollow.stx_mode & libc::S_IFMT,
+                libc::S_IFLNK,
+                "expected symlink when not following symlinks"
+            );
+        }
+    }
+
+    #[test]
+    fn kernel_version_probe_is_consistent_with_min_kernel() {
+        // If statx is supported, the kernel must be >= 5.11.
+        if statx_supported() {
+            let release = super::super::config::config_detail::get_kernel_release_string();
+            if let Some(release) = release {
+                if let Some((major, minor)) =
+                    super::super::config::config_detail::parse_kernel_version(&release)
+                {
+                    assert!(
+                        (major, minor) >= STATX_MIN_KERNEL,
+                        "statx probe says supported but kernel {major}.{minor} < 5.11"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn fallback_statx_batch_produces_results() {
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("fallback_test.txt");
+        std::fs::write(&file_path, b"fallback").unwrap();
+
+        let paths: Vec<&Path> = vec![file_path.as_path()];
+        let results = fallback_statx_batch(&paths, true);
+        assert_eq!(results.len(), 1);
+
+        #[cfg(target_os = "linux")]
+        {
+            let statx_buf = results.into_iter().next().unwrap().unwrap();
+            assert_eq!(statx_buf.stx_size, 8);
+        }
+
+        #[cfg(not(target_os = "linux"))]
+        {
+            assert!(results[0].is_err());
+        }
+    }
+}

--- a/crates/fast_io/src/io_uring/statx.rs
+++ b/crates/fast_io/src/io_uring/statx.rs
@@ -459,12 +459,10 @@ fn rustix_statx_to_libc(src: &rustix::fs::Statx) -> libc::statx {
     // newtype wrappers (e.g. `StatxAttributes`) depending on its backend
     // feature configuration, while libc uses plain integers. A byte-level
     // copy sidesteps the type mismatch entirely.
-    const _: () = assert!(
-        std::mem::size_of::<rustix::fs::Statx>() == std::mem::size_of::<libc::statx>()
-    );
-    const _: () = assert!(
-        std::mem::align_of::<rustix::fs::Statx>() == std::mem::align_of::<libc::statx>()
-    );
+    const _: () =
+        assert!(std::mem::size_of::<rustix::fs::Statx>() == std::mem::size_of::<libc::statx>());
+    const _: () =
+        assert!(std::mem::align_of::<rustix::fs::Statx>() == std::mem::align_of::<libc::statx>());
     // SAFETY: Both types represent the same kernel struct with identical
     // size and alignment (verified by const assertions above). All bit
     // patterns of the C struct are valid for both representations.

--- a/crates/fast_io/src/io_uring/statx.rs
+++ b/crates/fast_io/src/io_uring/statx.rs
@@ -318,7 +318,7 @@ fn submit_statx_batch_io_uring(
     // across submission and completion.
     let mut c_paths: Vec<Option<CString>> = Vec::with_capacity(count);
     let mut statx_bufs: Vec<libc::statx> = vec![unsafe { std::mem::zeroed() }; count];
-    let mut path_errors: Vec<Option<io::Error>> = vec![None; count];
+    let mut path_errors: Vec<Option<io::Error>> = (0..count).map(|_| None).collect();
 
     for (i, path) in paths.iter().enumerate() {
         match CString::new(path.as_os_str().as_bytes()) {
@@ -349,7 +349,7 @@ fn submit_statx_batch_io_uring(
                 c_path.as_ptr(),
                 (&mut statx_bufs[i] as *mut libc::statx).cast::<types::statx>(),
             )
-            .flags(flags as u32)
+            .flags(flags)
             .mask(mask)
             .build()
             .user_data(i as u64);
@@ -457,9 +457,9 @@ fn rustix_statx_to_libc(src: &rustix::fs::Statx) -> libc::statx {
     // SAFETY: `libc::statx` is a plain-old-data C struct. Zero-initializing
     // is valid and sets all padding/spare fields to zero.
     let mut dst: libc::statx = unsafe { std::mem::zeroed() };
-    dst.stx_mask = src.stx_mask.bits();
+    dst.stx_mask = src.stx_mask;
     dst.stx_blksize = src.stx_blksize;
-    dst.stx_attributes = src.stx_attributes.bits();
+    dst.stx_attributes = src.stx_attributes;
     dst.stx_nlink = src.stx_nlink;
     dst.stx_uid = src.stx_uid;
     dst.stx_gid = src.stx_gid;
@@ -467,7 +467,7 @@ fn rustix_statx_to_libc(src: &rustix::fs::Statx) -> libc::statx {
     dst.stx_ino = src.stx_ino;
     dst.stx_size = src.stx_size;
     dst.stx_blocks = src.stx_blocks;
-    dst.stx_attributes_mask = src.stx_attributes_mask.bits();
+    dst.stx_attributes_mask = src.stx_attributes_mask;
     dst.stx_atime.tv_sec = src.stx_atime.tv_sec;
     dst.stx_atime.tv_nsec = src.stx_atime.tv_nsec;
     dst.stx_btime.tv_sec = src.stx_btime.tv_sec;

--- a/crates/fast_io/src/io_uring/statx.rs
+++ b/crates/fast_io/src/io_uring/statx.rs
@@ -213,36 +213,35 @@ pub fn submit_statx_blocking(
     mask: u32,
 ) -> io::Result<libc::statx> {
     let mut statx_buf: libc::statx = unsafe { std::mem::zeroed() };
-    let mut args = StatxArgs {
-        dirfd,
-        pathname,
-        flags,
-        mask,
-        statx_buf: &mut statx_buf,
-    };
-    let sqe = build_statx_sqe(&mut args)?.user_data(0);
-    let mut ring = io_uring::IoUring::new(2)?;
-    // SAFETY: `sqe` references the CStr path borrowed from `pathname` and the
-    // statx buffer borrowed from our stack, both of which outlive
-    // `submit_and_wait`. The ring is local and has no other outstanding
-    // references.
-    unsafe {
-        ring.submission()
-            .push(&sqe)
-            .map_err(|_| io::Error::other("submission queue full while pushing STATX SQE"))?;
+    {
+        let mut args = StatxArgs {
+            dirfd,
+            pathname,
+            flags,
+            mask,
+            statx_buf: &mut statx_buf,
+        };
+        let sqe = build_statx_sqe(&mut args)?.user_data(0);
+        let mut ring = io_uring::IoUring::new(2)?;
+        // SAFETY: `sqe` references the CStr path borrowed from `pathname` and
+        // the statx buffer borrowed from our stack, both of which outlive
+        // `submit_and_wait`. The ring is local and has no other outstanding
+        // references.
+        unsafe {
+            ring.submission()
+                .push(&sqe)
+                .map_err(|_| io::Error::other("submission queue full while pushing STATX SQE"))?;
+        }
+        ring.submit_and_wait(1)?;
+        let cqe = ring
+            .completion()
+            .next()
+            .ok_or_else(|| io::Error::other("missing STATX CQE"))?;
+        let result = cqe.result();
+        if result < 0 {
+            return Err(io::Error::from_raw_os_error(-result));
+        }
     }
-    ring.submit_and_wait(1)?;
-    let cqe = ring
-        .completion()
-        .next()
-        .ok_or_else(|| io::Error::other("missing STATX CQE"))?;
-    let result = cqe.result();
-    if result < 0 {
-        return Err(io::Error::from_raw_os_error(-result));
-    }
-    // Re-borrow to satisfy the borrow checker - args held the mutable ref
-    // but the kernel has already written through the raw pointer.
-    drop(args);
     Ok(statx_buf)
 }
 

--- a/crates/fast_io/src/io_uring_stub.rs
+++ b/crates/fast_io/src/io_uring_stub.rs
@@ -386,6 +386,10 @@ pub use renameat2::{
 };
 
 pub use shared_ring::{OpTag, SharedCompletion, SharedRing, SharedRingConfig};
+pub use statx::{
+    IORING_OP_STATX, STATX_MIN_KERNEL, StatxArgs, StatxResult, build_statx_sqe,
+    build_statx_sqe_unchecked, statx_supported, submit_statx_batch, submit_statx_blocking,
+};
 
 /// Stub `linkat` module mirroring [`crate::io_uring::linkat`] on non-Linux
 /// platforms or when the `io_uring` cargo feature is disabled.
@@ -555,6 +559,132 @@ pub mod renameat2 {
             io::ErrorKind::Unsupported,
             "IORING_OP_RENAMEAT is not available on this platform",
         ))
+    }
+}
+
+/// Stub `IORING_OP_STATX` module for non-Linux platforms or when the
+/// `io_uring` cargo feature is disabled.
+///
+/// Mirrors the public surface of `crate::io_uring::statx`:
+/// `statx_supported()` is always `false`, `build_statx_sqe` returns
+/// `io::ErrorKind::Unsupported`, and `submit_statx_batch` falls back to
+/// returning `Unsupported` errors for all paths.
+pub mod statx {
+    use std::ffi::CStr;
+    use std::io;
+    use std::path::Path;
+
+    /// Numeric value of `IORING_OP_STATX`. Documented for parity with the
+    /// Linux module; the stub never submits real SQEs.
+    pub const IORING_OP_STATX: u8 = 21;
+
+    /// Minimum Linux kernel version that ships `IORING_OP_STATX`.
+    pub const STATX_MIN_KERNEL: (u32, u32) = (5, 11);
+
+    /// Borrowed arguments for an `IORING_OP_STATX` submission. On the stub
+    /// the struct exists only so cross-platform call sites compile; no SQE
+    /// is ever built.
+    #[derive(Debug)]
+    pub struct StatxArgs<'a> {
+        /// Directory file descriptor that resolves `pathname`.
+        pub dirfd: i32,
+        /// Path to stat.
+        pub pathname: &'a CStr,
+        /// Flags passed to the kernel.
+        pub flags: i32,
+        /// Mask of fields to request.
+        pub mask: u32,
+        /// Output buffer (unused on this platform).
+        pub statx_buf: &'a mut [u8; 256],
+    }
+
+    /// Result of a single statx operation within a batch.
+    pub type StatxResult = io::Result<()>;
+
+    /// Always returns `false` on this platform.
+    #[must_use]
+    pub fn statx_supported() -> bool {
+        false
+    }
+
+    /// Always returns `Unsupported` on this platform.
+    pub fn build_statx_sqe(_args: &StatxArgs<'_>) -> io::Result<()> {
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "IORING_OP_STATX is not available on this platform",
+        ))
+    }
+
+    /// Stub mirror of the Linux `build_statx_sqe_unchecked`. Exists for API
+    /// surface parity; never called from production code on this platform.
+    pub fn build_statx_sqe_unchecked(_args: &StatxArgs<'_>) {}
+
+    /// Always returns `Unsupported` on this platform.
+    pub fn submit_statx_blocking(
+        _dirfd: i32,
+        _pathname: &CStr,
+        _flags: i32,
+        _mask: u32,
+    ) -> io::Result<()> {
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "IORING_OP_STATX is not available on this platform",
+        ))
+    }
+
+    /// Always returns `Unsupported` for each path on this platform.
+    pub fn submit_statx_batch(
+        paths: &[&Path],
+        _follow_symlinks: bool,
+    ) -> io::Result<Vec<StatxResult>> {
+        Ok(paths
+            .iter()
+            .map(|_| {
+                Err(io::Error::new(
+                    io::ErrorKind::Unsupported,
+                    "statx is not available on this platform",
+                ))
+            })
+            .collect())
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn stub_reports_unsupported() {
+            assert!(!statx_supported());
+        }
+
+        #[test]
+        fn stub_constants_match_linux_uapi() {
+            assert_eq!(IORING_OP_STATX, 21);
+            assert_eq!(STATX_MIN_KERNEL, (5, 11));
+        }
+
+        #[test]
+        fn stub_submit_statx_batch_returns_unsupported_for_each_path() {
+            let dir = tempfile::tempdir().unwrap();
+            let p1 = dir.path().join("a.txt");
+            let p2 = dir.path().join("b.txt");
+            std::fs::write(&p1, b"a").unwrap();
+            std::fs::write(&p2, b"b").unwrap();
+
+            let paths: Vec<&Path> = vec![p1.as_path(), p2.as_path()];
+            let results = submit_statx_batch(&paths, true).unwrap();
+            assert_eq!(results.len(), 2);
+            for result in results {
+                assert_eq!(result.unwrap_err().kind(), io::ErrorKind::Unsupported);
+            }
+        }
+
+        #[test]
+        fn stub_submit_statx_batch_empty() {
+            let paths: &[&Path] = &[];
+            let results = submit_statx_batch(paths, true).unwrap();
+            assert!(results.is_empty());
+        }
     }
 }
 
@@ -1953,5 +2083,39 @@ mod tests {
             libc::close(fd_a);
             libc::close(fd_b);
         }
+    }
+
+    #[test]
+    fn statx_unsupported_on_stub_platform() {
+        assert!(!statx_supported());
+    }
+
+    #[test]
+    fn statx_constants_match_kernel_uapi() {
+        assert_eq!(IORING_OP_STATX, 21);
+        assert_eq!(STATX_MIN_KERNEL, (5, 11));
+    }
+
+    #[test]
+    fn statx_submit_batch_returns_unsupported_for_each_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let p1 = dir.path().join("stub_a.txt");
+        let p2 = dir.path().join("stub_b.txt");
+        std::fs::write(&p1, b"a").unwrap();
+        std::fs::write(&p2, b"b").unwrap();
+
+        let paths: Vec<&std::path::Path> = vec![p1.as_path(), p2.as_path()];
+        let results = submit_statx_batch(&paths, true).unwrap();
+        assert_eq!(results.len(), 2);
+        for result in results {
+            assert_eq!(result.unwrap_err().kind(), io::ErrorKind::Unsupported);
+        }
+    }
+
+    #[test]
+    fn statx_submit_batch_empty_on_stub() {
+        let paths: &[&std::path::Path] = &[];
+        let results = submit_statx_batch(paths, true).unwrap();
+        assert!(results.is_empty());
     }
 }

--- a/crates/fast_io/src/io_uring_stub.rs
+++ b/crates/fast_io/src/io_uring_stub.rs
@@ -608,7 +608,7 @@ pub mod statx {
     }
 
     /// Always returns `Unsupported` on this platform.
-    pub fn build_statx_sqe(_args: &StatxArgs<'_>) -> io::Result<()> {
+    pub fn build_statx_sqe(_args: &mut StatxArgs<'_>) -> io::Result<()> {
         Err(io::Error::new(
             io::ErrorKind::Unsupported,
             "IORING_OP_STATX is not available on this platform",
@@ -617,7 +617,7 @@ pub mod statx {
 
     /// Stub mirror of the Linux `build_statx_sqe_unchecked`. Exists for API
     /// surface parity; never called from production code on this platform.
-    pub fn build_statx_sqe_unchecked(_args: &StatxArgs<'_>) {}
+    pub fn build_statx_sqe_unchecked(_args: &mut StatxArgs<'_>) {}
 
     /// Always returns `Unsupported` on this platform.
     pub fn submit_statx_blocking(

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -161,15 +161,17 @@ pub use temp_file_strategy::{
 
 pub use io_uring::{
     BufferRing, BufferRingConfig, BufferRingError, IORING_OP_LINKAT, IORING_OP_RENAMEAT,
-    IoUringConfig, IoUringDiskBatch, IoUringKernelInfo, IoUringOrStdReader, IoUringOrStdWriter,
-    IoUringReader, IoUringReaderFactory, IoUringWriter, IoUringWriterFactory, LINKAT_MIN_KERNEL,
-    LinkAtArgs, OpTag, RENAME_EXCHANGE, RENAME_NOREPLACE, RENAME_WHITEOUT, RegisteredBufferGroup,
-    RegisteredBufferSlot, RegisteredBufferStats, RenameAt2Args, SharedCompletion, SharedRing,
-    SharedRingConfig, buffer_id_from_cqe_flags, build_linkat_sqe, build_linkat_sqe_unchecked,
-    build_renameat2_sqe, build_renameat2_sqe_unchecked, is_io_uring_available, linkat_supported,
-    pbuf_ring_supported, reader_from_path, reader_from_path_with_depth, renameat2_blocking,
-    renameat2_supported, sqpoll_fell_back, submit_linkat_blocking, writer_from_file,
-    writer_from_file_with_depth,
+    IORING_OP_STATX, IoUringConfig, IoUringDiskBatch, IoUringKernelInfo, IoUringOrStdReader,
+    IoUringOrStdWriter, IoUringReader, IoUringReaderFactory, IoUringWriter, IoUringWriterFactory,
+    LINKAT_MIN_KERNEL, LinkAtArgs, OpTag, RENAME_EXCHANGE, RENAME_NOREPLACE, RENAME_WHITEOUT,
+    RegisteredBufferGroup, RegisteredBufferSlot, RegisteredBufferStats, RenameAt2Args,
+    STATX_MIN_KERNEL, SharedCompletion, SharedRing, SharedRingConfig, StatxArgs, StatxResult,
+    buffer_id_from_cqe_flags, build_linkat_sqe, build_linkat_sqe_unchecked, build_renameat2_sqe,
+    build_renameat2_sqe_unchecked, build_statx_sqe, build_statx_sqe_unchecked,
+    is_io_uring_available, linkat_supported, pbuf_ring_supported, reader_from_path,
+    reader_from_path_with_depth, renameat2_blocking, renameat2_supported, sqpoll_fell_back,
+    statx_supported, submit_linkat_blocking, submit_statx_batch, submit_statx_blocking,
+    writer_from_file, writer_from_file_with_depth,
 };
 
 #[cfg(all(target_os = "windows", feature = "iocp"))]
@@ -503,6 +505,52 @@ fn try_hard_link_via_io_uring_impl(
     _src_path: &std::path::Path,
     _dst_path: &std::path::Path,
 ) -> Option<std::io::Result<()>> {
+    None
+}
+
+/// Attempts to stat files via io_uring `IORING_OP_STATX` batch submission.
+///
+/// On Linux with kernel 5.11+ and io_uring available, submits all paths
+/// as independent STATX SQEs on a single ring and returns the results.
+/// On all other platforms, or when the kernel lacks the opcode, returns
+/// `None` so the caller can fall back to synchronous stat calls.
+///
+/// # Arguments
+///
+/// * `paths` - Slice of paths to stat.
+/// * `follow_symlinks` - If `true`, follows symlinks (like `stat`);
+///   if `false`, does not follow (like `lstat`).
+///
+/// # Returns
+///
+/// - `Some(Ok(results))` when io_uring statx is available and all
+///   submissions succeeded (individual paths may still have errors).
+/// - `None` when io_uring statx is not available on this platform/kernel.
+/// - `Some(Err(...))` for ring-level failures.
+#[must_use]
+pub fn try_statx_batch_via_io_uring(
+    paths: &[&std::path::Path],
+    follow_symlinks: bool,
+) -> Option<std::io::Result<Vec<StatxResult>>> {
+    try_statx_batch_via_io_uring_impl(paths, follow_symlinks)
+}
+
+#[cfg(all(target_os = "linux", feature = "io_uring"))]
+fn try_statx_batch_via_io_uring_impl(
+    paths: &[&std::path::Path],
+    follow_symlinks: bool,
+) -> Option<std::io::Result<Vec<StatxResult>>> {
+    if !statx_supported() {
+        return None;
+    }
+    Some(submit_statx_batch(paths, follow_symlinks))
+}
+
+#[cfg(not(all(target_os = "linux", feature = "io_uring")))]
+fn try_statx_batch_via_io_uring_impl(
+    _paths: &[&std::path::Path],
+    _follow_symlinks: bool,
+) -> Option<std::io::Result<Vec<StatxResult>>> {
     None
 }
 
@@ -1306,5 +1354,77 @@ mod io_uring_hard_link_dispatch_tests {
             "must return None on non-Linux platforms"
         );
         assert!(!dst.exists(), "destination must not exist");
+    }
+}
+
+#[cfg(test)]
+mod io_uring_statx_dispatch_tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn try_statx_batch_via_io_uring_stats_or_returns_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("statx_dispatch.txt");
+        fs::write(&file, b"dispatch payload").unwrap();
+
+        let paths: Vec<&std::path::Path> = vec![file.as_path()];
+        match try_statx_batch_via_io_uring(&paths, true) {
+            Some(Ok(results)) => {
+                assert_eq!(results.len(), 1);
+                assert!(results[0].is_ok(), "existing file should succeed");
+            }
+            Some(Err(e)) => {
+                panic!("io_uring statx batch returned ring error: {e}");
+            }
+            None => {
+                // Not available on this platform/kernel.
+            }
+        }
+    }
+
+    #[test]
+    fn try_statx_batch_via_io_uring_returns_none_consistently() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("statx_consistency.txt");
+        fs::write(&file, b"data").unwrap();
+
+        let paths: Vec<&std::path::Path> = vec![file.as_path()];
+        let first = try_statx_batch_via_io_uring(&paths, true).is_some();
+        let second = try_statx_batch_via_io_uring(&paths, true).is_some();
+        assert_eq!(
+            first, second,
+            "availability must be consistent across calls"
+        );
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    #[test]
+    fn try_statx_batch_via_io_uring_returns_none_on_non_linux() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("non_linux_statx.txt");
+        fs::write(&file, b"data").unwrap();
+
+        let paths: Vec<&std::path::Path> = vec![file.as_path()];
+        assert!(
+            try_statx_batch_via_io_uring(&paths, true).is_none(),
+            "must return None on non-Linux platforms"
+        );
+    }
+
+    #[test]
+    fn try_statx_batch_via_io_uring_empty_input() {
+        let paths: Vec<&std::path::Path> = vec![];
+        match try_statx_batch_via_io_uring(&paths, true) {
+            Some(Ok(results)) => {
+                assert!(results.is_empty());
+            }
+            None => {
+                // Not available on this platform.
+            }
+            Some(Err(e)) => {
+                panic!("unexpected error on empty input: {e}");
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Add `IORING_OP_STATX` (opcode 21) wrapper in `fast_io` following the existing `RENAMEAT2`/`LINKAT` pattern, with `OnceLock`-cached kernel probe for Linux 5.11+
- Implement `submit_statx_batch()` for multi-path batch submission with chunked SQ processing and automatic fallback to synchronous `rustix::fs::statx` on older kernels
- Add non-Linux stub in `io_uring_stub.rs` and top-level `try_statx_batch_via_io_uring()` convenience dispatch in `lib.rs`

## Test plan

- [ ] CI passes on Linux (fmt, clippy, nextest)
- [ ] CI passes on macOS and Windows (stub path compiles, `statx_supported()` returns false)
- [ ] Verify opcode constant (21) matches `io_uring::opcode::Statx::CODE`
- [ ] Verify kernel probe is idempotent and consistent with minimum kernel version
- [ ] Verify batch results preserve input order across 16 concurrent paths
- [ ] Verify per-path errors (ENOENT) do not affect other entries in the batch
- [ ] Verify symlink follow vs nofollow semantics in batch path
- [ ] Verify fallback path produces correct results when io_uring STATX is unavailable