### PR TITLE
feat(transfer): wire IORING_OP_RENAMEAT2 into remaining temp-file commit paths (#1924)

### DIFF
--- a/crates/transfer/src/receiver/transfer.rs
+++ b/crates/transfer/src/receiver/transfer.rs
@@ -439,7 +439,14 @@ impl ReceiverContext {
                 fs::rename(&file_path, &backup_path)?;
             }
 
-            fs::rename(temp_guard.path(), &file_path)?;
+            // On Linux 5.11+ with io_uring, submits IORING_OP_RENAMEAT instead of
+            // synchronous rename(2). Falls back to std::fs::rename on all other
+            // platforms or when the kernel lacks the opcode.
+            if let Some(result) = fast_io::try_rename_via_io_uring(temp_guard.path(), &file_path) {
+                result?;
+            } else {
+                fs::rename(temp_guard.path(), &file_path)?;
+            }
             temp_guard.keep();
 
             if let Err(meta_err) =

--- a/crates/transfer/src/transfer_ops/response.rs
+++ b/crates/transfer/src/transfer_ops/response.rs
@@ -278,7 +278,14 @@ pub fn process_file_response<R: Read>(
 
     if needs_rename {
         // Atomic rename: temp file to final destination.
-        fs::rename(cleanup_guard.path(), &file_path)?;
+        // On Linux 5.11+ with io_uring, submits IORING_OP_RENAMEAT instead of
+        // synchronous rename(2). Falls back to std::fs::rename on all other
+        // platforms or when the kernel lacks the opcode.
+        if let Some(result) = fast_io::try_rename_via_io_uring(cleanup_guard.path(), &file_path) {
+            result?;
+        } else {
+            fs::rename(cleanup_guard.path(), &file_path)?;
+        }
     } else if ctx.config.inplace {
         // Inplace: truncate to final size.
         // upstream: receiver.c:340 - set_file_length(fd, F_LENGTH(file))


### PR DESCRIPTION
## Summary

- Wire `fast_io::try_rename_via_io_uring()` into the two remaining synchronous temp-file commit paths that still used plain `std::fs::rename()`:
  - `transfer_ops::response::process_file_response()` - non-pipelined receiver path
  - `receiver::transfer` - synchronous receiver transfer loop
- On Linux 5.11+ with io_uring available, temp-file renames now submit `IORING_OP_RENAMEAT` instead of synchronous `rename(2)` in all transfer paths
- Falls back to `std::fs::rename` on non-Linux, older kernels, or when io_uring is disabled
- Completes the io_uring rename coverage started in #3981 (engine guard) and #3992 (disk_commit pipeline)

## Test plan

- [ ] `cargo fmt --all -- --check` passes
- [ ] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` passes
- [ ] CI: nextest on Linux (stable) - exercises io_uring path on supported kernels
- [ ] CI: macOS (stable) - exercises fallback path (no io_uring)
- [ ] CI: Windows (stable) - exercises fallback path (no io_uring)
- [ ] CI: Linux musl (stable) - exercises io_uring or fallback depending on kernel
- [ ] Existing `rename_with_io_uring_fallback` and `try_rename_via_io_uring` unit tests in `disk_commit/process.rs` and `fast_io/src/lib.rs` continue to pass
- [ ] Interop tests validate end-to-end temp-file commit correctness on all platforms