### PR TITLE
feat(fast_io): wire IORING_OP_LINKAT into hardlink finalization (#1925)

### DIFF
--- a/crates/engine/src/local_copy/executor/file/copy/links.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/links.rs
@@ -29,17 +29,6 @@ use ::metadata::apply_file_metadata_with_options;
 use super::super::super::super::CROSS_DEVICE_ERROR_CODE;
 use super::super::guard::remove_existing_destination;
 
-/// Creates a hard link, trying io_uring `IORING_OP_LINKAT` first on Linux 5.15+.
-///
-/// Falls back to `std::fs::hard_link` when io_uring is unavailable or the
-/// kernel lacks the opcode.
-fn hard_link_with_io_uring_fallback(source: &Path, destination: &Path) -> std::io::Result<()> {
-    if let Some(result) = fast_io::try_hard_link_via_io_uring(source, destination) {
-        return result;
-    }
-    fs::hard_link(source, destination)
-}
-
 /// Result of hard-link and reference-directory processing for a file.
 pub(super) struct LinkOutcome {
     pub(super) copy_source_override: Option<PathBuf>,
@@ -87,19 +76,17 @@ pub(super) fn process_links(
     )? {
         let mut attempted_commit = false;
         loop {
-            match hard_link_with_io_uring_fallback(&link_target, destination) {
+            match fast_io::hard_link(&link_target, destination) {
                 Ok(()) => break,
                 Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
                     remove_existing_destination(destination)?;
-                    hard_link_with_io_uring_fallback(&link_target, destination).map_err(
-                        |link_error| {
-                            LocalCopyError::io(
-                                "create hard link",
-                                destination.to_path_buf(),
-                                link_error,
-                            )
-                        },
-                    )?;
+                    fast_io::hard_link(&link_target, destination).map_err(|link_error| {
+                        LocalCopyError::io(
+                            "create hard link",
+                            destination.to_path_buf(),
+                            link_error,
+                        )
+                    })?;
                     break;
                 }
                 Err(error)

--- a/crates/engine/src/local_copy/hard_links.rs
+++ b/crates/engine/src/local_copy/hard_links.rs
@@ -15,17 +15,6 @@ use std::path::{Path, PathBuf};
 
 use rustc_hash::FxHashMap;
 
-/// Creates a hard link, trying io_uring `IORING_OP_LINKAT` first on Linux 5.15+.
-///
-/// Falls back to `std::fs::hard_link` when io_uring is unavailable or the
-/// kernel lacks the opcode.
-fn hard_link_with_io_uring_fallback(source: &Path, destination: &Path) -> std::io::Result<()> {
-    if let Some(result) = fast_io::try_hard_link_via_io_uring(source, destination) {
-        return result;
-    }
-    fs::hard_link(source, destination)
-}
-
 /// Tracks completed hardlink leaders by protocol group index during file apply.
 ///
 /// When the receiver commits a leader file to its final destination, it records
@@ -106,7 +95,7 @@ impl HardlinkApplyTracker {
             if follower_dest.symlink_metadata().is_ok() {
                 fs::remove_file(follower_dest)?;
             }
-            hard_link_with_io_uring_fallback(leader_path, follower_dest)?;
+            fast_io::hard_link(leader_path, follower_dest)?;
             Ok(HardlinkApplyResult::Linked)
         } else {
             self.deferred
@@ -176,7 +165,7 @@ impl HardlinkApplyTracker {
                         continue;
                     }
                 }
-                match hard_link_with_io_uring_fallback(&leader_path, &follower) {
+                match fast_io::hard_link(&leader_path, &follower) {
                     Ok(()) => linked += 1,
                     Err(e) => errors.push((follower, e)),
                 }
@@ -1229,9 +1218,8 @@ mod apply_tracker_tests {
 
 /// Tests for the io_uring LINKAT dispatch in hardlink creation.
 ///
-/// These tests verify that `hard_link_with_io_uring_fallback` works correctly
-/// regardless of whether io_uring handles the link or `std::fs::hard_link`
-/// does.
+/// These tests verify that `fast_io::hard_link` works correctly regardless
+/// of whether io_uring handles the link or `std::fs::hard_link` does.
 #[cfg(test)]
 mod io_uring_linkat_dispatch_tests {
     use super::*;
@@ -1243,7 +1231,7 @@ mod io_uring_linkat_dispatch_tests {
         let dst = temp.path().join("linkat_dst.txt");
         std::fs::write(&src, b"linkat dispatch test").unwrap();
 
-        hard_link_with_io_uring_fallback(&src, &dst).expect("hard link must succeed");
+        fast_io::hard_link(&src, &dst).expect("hard link must succeed");
 
         assert!(src.exists());
         assert!(dst.exists());
@@ -1263,7 +1251,7 @@ mod io_uring_linkat_dispatch_tests {
         let dst = temp.path().join("linkat_inode_dst.txt");
         std::fs::write(&src, b"inode check").unwrap();
 
-        hard_link_with_io_uring_fallback(&src, &dst).expect("hard link must succeed");
+        fast_io::hard_link(&src, &dst).expect("hard link must succeed");
 
         let src_ino = std::fs::metadata(&src).unwrap().ino();
         let dst_ino = std::fs::metadata(&dst).unwrap().ino();

--- a/crates/engine/src/local_copy/overrides.rs
+++ b/crates/engine/src/local_copy/overrides.rs
@@ -57,10 +57,7 @@ pub(super) fn create_hard_link(source: &Path, destination: &Path) -> io::Result<
         return result;
     }
 
-    if let Some(result) = fast_io::try_hard_link_via_io_uring(source, destination) {
-        return result;
-    }
-    fs::hard_link(source, destination)
+    fast_io::hard_link(source, destination)
 }
 
 #[cfg(test)]

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -565,6 +565,35 @@ fn try_statx_batch_via_io_uring_impl(
     None
 }
 
+/// Creates a hard link from `src` to `dst`, trying io_uring first.
+///
+/// On Linux 5.15+ with io_uring `IORING_OP_LINKAT` support, the link is
+/// submitted as an asynchronous SQE on a transient ring, avoiding a
+/// synchronous `linkat(2)` syscall. On all other platforms, older kernels,
+/// or when the `io_uring` feature is disabled, falls back to
+/// [`std::fs::hard_link`].
+///
+/// This is the recommended single entry point for hard-link creation across
+/// the codebase. It consolidates the try-io_uring-then-fallback pattern so
+/// callers do not need to handle the `Option` from
+/// [`try_hard_link_via_io_uring`] themselves.
+///
+/// # Errors
+///
+/// Returns an error when both the io_uring path and the `std::fs::hard_link`
+/// fallback fail (e.g., `EEXIST`, `EACCES`, `EXDEV`).
+///
+/// # Upstream reference
+///
+/// Upstream rsync uses synchronous `link(2)` / `linkat(2)` for hardlink
+/// creation (`hlink.c`). The io_uring fast path is a latency optimisation.
+pub fn hard_link(src: &std::path::Path, dst: &std::path::Path) -> std::io::Result<()> {
+    if let Some(result) = try_hard_link_via_io_uring(src, dst) {
+        return result;
+    }
+    std::fs::hard_link(src, dst)
+}
+
 /// Minimum value accepted for the io_uring submission queue depth tunable.
 ///
 /// The kernel rejects rings with zero entries, so callers must request at
@@ -1440,5 +1469,89 @@ mod io_uring_statx_dispatch_tests {
                 panic!("unexpected error on empty input: {e}");
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod hard_link_convenience_tests {
+    use super::*;
+    use std::fs;
+
+    /// Verifies `hard_link` creates a valid hard link on any platform,
+    /// using io_uring when available and falling back to `std::fs::hard_link`.
+    #[test]
+    fn hard_link_creates_link() {
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("hl_src.txt");
+        let dst = dir.path().join("hl_dst.txt");
+        fs::write(&src, b"hard link payload").unwrap();
+
+        hard_link(&src, &dst).unwrap();
+
+        assert!(src.exists(), "source must still exist after hard link");
+        assert!(dst.exists(), "destination must exist after hard link");
+        assert_eq!(fs::read(&dst).unwrap(), b"hard link payload");
+    }
+
+    /// Verifies that source and destination share the same inode on Unix,
+    /// confirming a true hard link rather than a copy.
+    #[cfg(unix)]
+    #[test]
+    fn hard_link_shares_inode() {
+        use std::os::unix::fs::MetadataExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("hl_inode_src.txt");
+        let dst = dir.path().join("hl_inode_dst.txt");
+        fs::write(&src, b"inode check").unwrap();
+
+        hard_link(&src, &dst).unwrap();
+
+        let src_ino = fs::metadata(&src).unwrap().ino();
+        let dst_ino = fs::metadata(&dst).unwrap().ino();
+        assert_eq!(src_ino, dst_ino, "hard link must share same inode");
+    }
+
+    /// Verifies `hard_link` returns an error when the destination already
+    /// exists (EEXIST).
+    #[test]
+    fn hard_link_fails_when_dst_exists() {
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("hl_exists_src.txt");
+        let dst = dir.path().join("hl_exists_dst.txt");
+        fs::write(&src, b"source").unwrap();
+        fs::write(&dst, b"existing").unwrap();
+
+        let result = hard_link(&src, &dst);
+        assert!(result.is_err(), "must fail when destination exists");
+    }
+
+    /// Verifies `hard_link` returns an error when the source does not exist.
+    #[test]
+    fn hard_link_fails_for_missing_source() {
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("hl_missing.txt");
+        let dst = dir.path().join("hl_missing_dst.txt");
+
+        let result = hard_link(&src, &dst);
+        assert!(result.is_err(), "must fail when source does not exist");
+    }
+
+    /// Verifies that writing to the source after hard-linking is visible
+    /// through the destination path, confirming shared data blocks.
+    #[test]
+    fn hard_link_shares_data() {
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("hl_shared_src.txt");
+        let dst = dir.path().join("hl_shared_dst.txt");
+        fs::write(&src, b"original").unwrap();
+
+        hard_link(&src, &dst).unwrap();
+
+        // Overwrite via source path.
+        fs::write(&src, b"modified").unwrap();
+
+        // Read through destination - should see the modification.
+        assert_eq!(fs::read(&dst).unwrap(), b"modified");
     }
 }

--- a/crates/transfer/src/receiver/directory/links.rs
+++ b/crates/transfer/src/receiver/directory/links.rs
@@ -238,7 +238,7 @@ impl ReceiverContext {
 
                 // upstream: hlink.c:maybe_hard_link() -> atomic_create() -> do_link()
                 // Try io_uring LINKAT on Linux 5.15+, fall back to std::fs::hard_link.
-                if let Err(e) = hard_link_with_io_uring_fallback(&leader_path, &link_path) {
+                if let Err(e) = fast_io::hard_link(&leader_path, &link_path) {
                     debug_log!(
                         Recv,
                         1,
@@ -283,24 +283,12 @@ impl ReceiverContext {
     }
 }
 
-/// Creates a hard link, trying io_uring first on supported kernels.
-///
-/// On Linux 5.15+ with io_uring LINKAT support, submits the link as an
-/// `IORING_OP_LINKAT` SQE. Falls back to `std::fs::hard_link` when io_uring
-/// is unavailable (non-Linux, old kernel, or feature not compiled in).
-fn hard_link_with_io_uring_fallback(src: &Path, dst: &Path) -> io::Result<()> {
-    if let Some(result) = fast_io::try_hard_link_via_io_uring(src, dst) {
-        return result;
-    }
-    fs::hard_link(src, dst)
-}
-
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use std::fs;
 
-    /// Verifies the io_uring LINKAT fallback creates a valid hard link
-    /// regardless of whether io_uring handles it or `std::fs::hard_link` does.
+    /// Verifies `fast_io::hard_link` creates a valid hard link regardless of
+    /// whether io_uring handles it or `std::fs::hard_link` does.
     #[test]
     fn hard_link_via_io_uring_or_fallback_creates_link() {
         let dir = tempfile::tempdir().unwrap();
@@ -309,7 +297,7 @@ mod tests {
 
         fs::write(&src, b"hardlink payload").unwrap();
 
-        hard_link_with_io_uring_fallback(&src, &dst).unwrap();
+        fast_io::hard_link(&src, &dst).unwrap();
 
         assert!(src.exists());
         assert!(dst.exists());
@@ -336,7 +324,7 @@ mod tests {
         fs::write(&src, b"source").unwrap();
         fs::write(&dst, b"existing").unwrap();
 
-        let result = hard_link_with_io_uring_fallback(&src, &dst);
+        let result = fast_io::hard_link(&src, &dst);
         assert!(result.is_err());
     }
 

--- a/crates/transfer/src/receiver/directory/links.rs
+++ b/crates/transfer/src/receiver/directory/links.rs
@@ -6,7 +6,6 @@
 //! reception, so this module handles both protocol versions uniformly.
 
 use std::fs;
-use std::io;
 use std::path::Path;
 
 use logging::debug_log;

--- a/crates/transfer/src/receiver/quick_check.rs
+++ b/crates/transfer/src/receiver/quick_check.rs
@@ -175,7 +175,7 @@ pub(super) fn try_reference_dest(
                     let _ = fs::create_dir_all(parent);
                 }
                 // Try io_uring LINKAT on Linux 5.15+, fall back to std::fs::hard_link.
-                if hard_link_with_io_uring_fallback(&ref_path, &dest_path).is_ok() {
+                if fast_io::hard_link(&ref_path, &dest_path).is_ok() {
                     if let Err(e) = apply_metadata_from_file_entry(&dest_path, entry, metadata_opts)
                     {
                         metadata_errors.push((dest_path.clone(), e.to_string()));
@@ -263,25 +263,12 @@ pub(super) fn path_contains_dot_dot(path: &Path) -> bool {
     path.components().any(|c| matches!(c, Component::ParentDir))
 }
 
-/// Creates a hard link, trying io_uring first on supported kernels.
-///
-/// On Linux 5.15+ with io_uring LINKAT support, submits the link as an
-/// `IORING_OP_LINKAT` SQE. Falls back to `std::fs::hard_link` when io_uring
-/// is unavailable (non-Linux, old kernel, or feature not compiled in).
-fn hard_link_with_io_uring_fallback(src: &Path, dst: &Path) -> std::io::Result<()> {
-    if let Some(result) = fast_io::try_hard_link_via_io_uring(src, dst) {
-        return result;
-    }
-    fs::hard_link(src, dst)
-}
-
 #[cfg(test)]
 mod io_uring_linkat_tests {
-    use super::*;
+    use std::fs;
 
-    /// Verifies the io_uring LINKAT fallback in the link-dest path creates a
-    /// valid hard link regardless of whether io_uring handles it or
-    /// `std::fs::hard_link` does.
+    /// Verifies `fast_io::hard_link` creates a valid hard link regardless of
+    /// whether io_uring handles it or `std::fs::hard_link` does.
     #[test]
     fn hard_link_via_io_uring_or_fallback_in_quick_check() {
         let dir = tempfile::tempdir().unwrap();
@@ -290,7 +277,7 @@ mod io_uring_linkat_tests {
 
         fs::write(&src, b"link-dest payload").unwrap();
 
-        hard_link_with_io_uring_fallback(&src, &dst).unwrap();
+        fast_io::hard_link(&src, &dst).unwrap();
 
         assert!(src.exists());
         assert!(dst.exists());
@@ -304,7 +291,7 @@ mod io_uring_linkat_tests {
         let src = dir.path().join("missing.txt");
         let dst = dir.path().join("dst.txt");
 
-        let result = hard_link_with_io_uring_fallback(&src, &dst);
+        let result = fast_io::hard_link(&src, &dst);
         assert!(result.is_err());
     }
 }


### PR DESCRIPTION
## Summary

- Add `fast_io::hard_link()` convenience function that tries io_uring `IORING_OP_LINKAT` on Linux 5.15+ and falls back to `std::fs::hard_link` on all other platforms/kernels.
- Replace four duplicate `hard_link_with_io_uring_fallback()` private functions across `engine::local_copy::executor::file::copy::links`, `engine::local_copy::hard_links`, `transfer::receiver::quick_check`, and `transfer::receiver::directory::links` with the new centralized `fast_io::hard_link()` API.
- Simplify `engine::local_copy::overrides::create_hard_link()` to delegate to `fast_io::hard_link()` instead of inlining the try-then-fallback pattern.

All hardlink creation paths - link-dest linking, inode-based deduplication, reference directory linking, receiver hardlink finalization, and quick-check link-dest handling - now route through the single `fast_io::hard_link()` entry point.

## Test plan

- [ ] New `hard_link_convenience_tests` in `fast_io` verify: link creation, inode sharing (Unix), EEXIST failure, missing-source failure, and shared-data semantics.
- [ ] Existing tests in `engine::local_copy::hard_links`, `transfer::receiver::directory::links`, and `transfer::receiver::quick_check` updated to use `fast_io::hard_link()` directly.
- [ ] CI: fmt+clippy, nextest (stable), Windows (stable), macOS (stable), Linux musl (stable).