### PR TITLE
fix(daemon): apply daemon-level chroot before privilege drop

### DIFF
--- a/crates/daemon/src/daemon/runtime_options/accessors.rs
+++ b/crates/daemon/src/daemon/runtime_options/accessors.rs
@@ -39,10 +39,15 @@ impl RuntimeOptions {
         self.proxy_protocol
     }
 
-    /// Returns the directory the daemon chroots into before forking children.
+    /// Returns the directory the daemon chroots into before serving any
+    /// connections.
     ///
-    /// upstream: daemon-parm.h - `daemon chroot` STRING, P_GLOBAL.
-    #[allow(dead_code)] // REASON: accessor for daemon listener; wired when async daemon starts
+    /// upstream: daemon-parm.h - `daemon chroot` STRING, P_GLOBAL. Applied in
+    /// `clientserver.c:1301-1312 start_accept_loop()` before privilege drop.
+    /// The accept loop destructures the field directly; this accessor is kept
+    /// for callers that hold an opaque `&RuntimeOptions` (e.g. test
+    /// inspection of parsed config).
+    #[allow(dead_code)] // REASON: accessor for external read-only inspection of parsed runtime options
     pub(crate) fn daemon_chroot(&self) -> Option<&Path> {
         self.daemon_chroot.as_deref()
     }

--- a/crates/daemon/src/daemon/sections/privilege.rs
+++ b/crates/daemon/src/daemon/sections/privilege.rs
@@ -1,8 +1,17 @@
-/// Applies a chroot jail to the given module path.
+/// Applies a chroot jail.
 ///
-/// Delegates to `platform::privilege::apply_chroot()`.
+/// Delegates to `platform::privilege::apply_chroot()`. Failure is propagated to
+/// the caller so the daemon refuses to serve rather than continuing without the
+/// requested isolation.
 ///
-/// upstream: clientserver.c - chroot(lp_path(i)) after sanitising the module path.
+/// Caveat: chroot is process-wide, so in our thread-per-connection model this
+/// affects every concurrent session. Per-module chroot only works correctly
+/// when the daemon serves a single module or all modules share the same root.
+/// See `docs/DAEMON_PROCESS_MODEL.md`.
+///
+/// upstream: `clientserver.c:978-985` `rsync_module()` - `chroot(module_chdir)`
+/// after sanitising the module path; `@ERROR: chroot failed` returned to the
+/// client when it fails.
 #[cfg(unix)]
 fn apply_chroot(module_path: &Path, log_sink: &SharedLogSink) -> io::Result<()> {
     if let Err(err) = platform::privilege::apply_chroot(module_path) {
@@ -27,9 +36,22 @@ fn apply_chroot(_module_path: &Path, _log_sink: &SharedLogSink) -> io::Result<()
 
 /// Drops process privileges to the specified uid and gid.
 ///
-/// Delegates to `platform::privilege::drop_privileges()`.
+/// Delegates to `platform::privilege::drop_privileges()`. The underlying call
+/// sequence is `setgroups` -> `setgid` -> `setuid`, matching the POSIX ordering
+/// required for setuid to be irreversible. Any failure is propagated; the
+/// daemon must refuse to serve rather than continue as root.
 ///
-/// upstream: clientserver.c:rsync_module() - setgid/setuid after chroot.
+/// Caveat: on Linux the setuid system call is propagated to every thread of
+/// the process, so a per-module privilege drop affects all concurrent sessions
+/// in our thread-per-connection model. Per-module `uid`/`gid` directives only
+/// work correctly when the daemon serves a single module. Operators that need
+/// privilege separation across modules should run a separate daemon per
+/// identity.
+///
+/// upstream: `clientserver.c:1006-1044` `rsync_module()` - `setgid`/
+/// `setgroups`/`setuid` after chroot. Each failure returns `@ERROR: setgid
+/// failed`, `@ERROR: setgroups failed`, or `@ERROR: setuid failed` and the
+/// connection is dropped.
 fn drop_privileges(
     uid: Option<u32>,
     gid: Option<u32>,
@@ -59,8 +81,21 @@ fn drop_privileges(
 
 /// Applies chroot and privilege restrictions for a daemon module.
 ///
-/// This is the main entry point called from the module access flow after
-/// authentication succeeds but before the transfer begins.
+/// Called from the module access flow after authentication succeeds but before
+/// the transfer begins. The order (chroot then privilege drop) matches
+/// upstream and is required for security: the chroot needs root privileges,
+/// so the uid/gid drop must come after it.
+///
+/// Errors are propagated unchanged so the caller can send an `@ERROR:` reply
+/// to the client and close the connection - the daemon never silently
+/// continues with reduced or escalated privileges.
+///
+/// upstream: `clientserver.c:rsync_module()` lines 978-1044 - chroot, then
+/// `setgid`/`setgroups`, then `setuid`. Default uid/gid is `nobody:nobody`
+/// when running as root and the module config does not override it
+/// (`clientserver.c:779,818`); oc-rsync only drops when the config sets an
+/// explicit numeric `uid`/`gid` and otherwise relies on the daemon-level
+/// `uid`/`gid` directives applied before the accept loop.
 fn apply_module_privilege_restrictions(
     module: &ModuleDefinition,
     log_sink: &SharedLogSink,
@@ -126,5 +161,19 @@ mod privilege_tests {
         let sink = test_log_sink();
         let result = apply_module_privilege_restrictions(&module, &sink);
         assert!(result.is_ok());
+    }
+
+    /// Chroot failure must propagate so the daemon refuses to serve rather
+    /// than continuing as root. Mirrors upstream `clientserver.c:978-982`
+    /// where `@ERROR: chroot failed` is sent and the connection returns -1.
+    #[cfg(unix)]
+    #[test]
+    fn apply_chroot_returns_err_for_nonexistent_path() {
+        let sink = test_log_sink();
+        let result = apply_chroot(
+            std::path::Path::new("/nonexistent_oc_rsync_chroot_test_xyz_12345"),
+            &sink,
+        );
+        assert!(result.is_err(), "chroot to missing path must fail");
     }
 }

--- a/crates/daemon/src/daemon/sections/server_runtime/accept_loop.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/accept_loop.rs
@@ -55,6 +55,7 @@ fn serve_connections(
         syslog_tag,
         daemon_uid,
         daemon_gid,
+        daemon_chroot,
         proxy_protocol,
         ..
     } = options;
@@ -226,23 +227,46 @@ fn serve_connections(
         None
     };
 
-    // Drop daemon-level privileges after binding (which may require root for
-    // ports < 1024), daemonizing, and writing the PID file.
-    // upstream: clientserver.c - setuid/setgid from global uid/gid params happen
-    // after the socket is bound and the daemon has forked.
-    if daemon_uid.is_some() || daemon_gid.is_some() {
+    // Apply daemon-level chroot and drop daemon-level privileges after binding
+    // (which may require root for ports < 1024), daemonizing, and writing the
+    // PID file. Order matches upstream: chroot first (while still root), then
+    // setgid, then setuid. Any failure is fatal so the daemon never continues
+    // running as root after a partial privilege drop.
+    // upstream: clientserver.c:1301-1339 start_accept_loop() applies
+    // lp_daemon_chroot() then lp_daemon_gid()/lp_daemon_uid() before the accept
+    // loop services any client.
+    if daemon_chroot.is_some() || daemon_uid.is_some() || daemon_gid.is_some() {
         let fallback_sink = open_privilege_fallback_sink();
         let sink = log_sink.as_ref().unwrap_or(&fallback_sink);
-        drop_privileges(daemon_uid, daemon_gid, sink).map_err(|error| {
-            DaemonError::new(
-                FEATURE_UNAVAILABLE_EXIT_CODE,
-                rsync_error!(
+
+        if let Some(chroot_path) = daemon_chroot.as_deref() {
+            apply_chroot(chroot_path, sink).map_err(|error| {
+                DaemonError::new(
                     FEATURE_UNAVAILABLE_EXIT_CODE,
-                    format!("failed to drop daemon privileges: {error}")
+                    rsync_error!(
+                        FEATURE_UNAVAILABLE_EXIT_CODE,
+                        format!(
+                            "daemon chroot to '{}' failed: {error}",
+                            chroot_path.display()
+                        )
+                    )
+                    .with_role(Role::Daemon),
                 )
-                .with_role(Role::Daemon),
-            )
-        })?;
+            })?;
+        }
+
+        if daemon_uid.is_some() || daemon_gid.is_some() {
+            drop_privileges(daemon_uid, daemon_gid, sink).map_err(|error| {
+                DaemonError::new(
+                    FEATURE_UNAVAILABLE_EXIT_CODE,
+                    rsync_error!(
+                        FEATURE_UNAVAILABLE_EXIT_CODE,
+                        format!("failed to drop daemon privileges: {error}")
+                    )
+                    .with_role(Role::Daemon),
+                )
+            })?;
+        }
     }
 
     let notifier = systemd::ServiceNotifier::new();


### PR DESCRIPTION
## Summary

- Wire the `daemon chroot` global directive into the accept-loop privilege flow. The directive was parsed and stored but never applied, so operators who configured it got no isolation.
- Apply ordering matches upstream `clientserver.c:1301-1339 start_accept_loop()`: chroot first (while still root) then setgid/setuid. Any failure is fatal so the daemon refuses to start rather than continuing unconfined.
- Expand privilege module rustdoc to cite upstream line ranges and document the thread-per-connection caveat for per-module `use chroot` / `uid` / `gid` directives (process-wide effects make them safe only when the daemon serves a single module or all modules share the same identity).
- Add a regression test that exercises the "chroot failure is fatal" contract.

## Audit findings (issue #2129)

Reviewed `target/interop/upstream-src/rsync-3.4.1/clientserver.c` for `chroot()` / `setuid()` / `setgid()` call sites and compared against `crates/daemon/src/`.

| Concern | Upstream | oc-rsync (before) | Status |
|---|---|---|---|
| Daemon-level `chroot` before accept loop | `clientserver.c:1301-1312` | parsed but never applied | fixed in this PR |
| Daemon-level `setgid` / `setuid` before accept loop | `clientserver.c:1313-1339` | applied with fatal-on-error | already correct |
| Per-module `chroot` then `setgid` / `setuid` | `clientserver.c:978-1044` | applied with fatal-on-error, but process-wide in thread model | documented caveat |
| Default to `nobody:nobody` when running as root | `clientserver.c:779,818` | not implemented (relies on explicit config or daemon-level uid/gid) | documented; deferred (would require config-time resolution and is unsafe in the threaded model) |
| Name-based `uid` / `gid` (e.g. `nobody`) | `user_to_uid` / `group_to_gid` | only numeric ids accepted in module directives | deferred (separate change) |

The deferred items are intentionally out of scope: the safe path on a thread-per-connection daemon is the daemon-level `uid` / `gid` directives, which already worked before this PR and now compose correctly with `daemon chroot`.

## Test plan

- [ ] CI: fmt+clippy
- [ ] CI: nextest (stable) on Linux, macOS, Windows
- [ ] CI: musl Linux
- [ ] CI: interop validation