### PR TITLE
feat: wire MacosWriter into the disk-commit dispatcher

### DIFF
--- a/crates/fast_io/src/macos_io.rs
+++ b/crates/fast_io/src/macos_io.rs
@@ -130,6 +130,15 @@ impl MacosWriter {
         self.bytes_written
     }
 
+    /// Flushes pending buffers and fsyncs the underlying file.
+    ///
+    /// Drains any accumulated `writev` buffers and then calls `sync_all` on
+    /// the file descriptor so the data is persisted to durable storage.
+    pub fn sync(&mut self) -> io::Result<()> {
+        self.flush_writev()?;
+        self.file.sync_all()
+    }
+
     /// Attempts to set `F_NOCACHE` on the file descriptor.
     ///
     /// Returns `true` on success, `false` if `fcntl` fails (e.g., on a
@@ -410,6 +419,12 @@ impl MacosWriter {
     #[must_use]
     pub fn bytes_written(&self) -> u64 {
         self.bytes_written
+    }
+
+    /// Flushes buffered data and fsyncs the underlying file.
+    pub fn sync(&mut self) -> io::Result<()> {
+        self.inner.flush()?;
+        self.inner.get_ref().sync_all()
     }
 }
 

--- a/crates/transfer/src/disk_commit/process.rs
+++ b/crates/transfer/src/disk_commit/process.rs
@@ -47,6 +47,7 @@ pub(super) fn process_file(
         iocp_batch,
         config.use_sparse,
         begin.append_offset,
+        begin.target_size,
     )?;
 
     let mut sparse_state = if config.use_sparse {
@@ -164,6 +165,7 @@ pub(super) fn process_whole_file(
         iocp_batch,
         config.use_sparse,
         begin.append_offset,
+        begin.target_size,
     )?;
     let bytes_written = data.len() as u64;
 
@@ -249,19 +251,25 @@ fn open_output_file(
 }
 
 /// Constructs the per-file [`Writer`] dispatching between batched async
-/// submission (io_uring on Linux, IOCP on Windows) and the buffered fallback.
+/// submission (io_uring on Linux, IOCP on Windows), the macOS `F_NOCACHE` +
+/// `writev` writer, and the buffered fallback.
 ///
-/// Selects a batched backend when (a) the disk thread holds an active batch,
-/// (b) sparse mode is disabled, and (c) the file does not start at a non-zero
-/// offset (append mode). Sparse mode requires `Seek`, which the batch writers
-/// do not provide.
+/// Selects a non-buffered backend when (a) the disk thread holds an active
+/// batch (Linux/Windows) or the target is macOS, (b) sparse mode is disabled,
+/// and (c) the file does not start at a non-zero offset (append mode). Sparse
+/// mode requires `Seek`, which none of these writers provide.
 ///
 /// Append mode opens the file and seeks past existing content via
 /// [`std::io::Seek::seek`]. The batch writers issue submissions with absolute
 /// offsets starting at 0 and ignore the file position, so they would
-/// overwrite the existing prefix with zeros. Append mode therefore always
-/// falls back to the buffered writer, which honors the seek via
-/// `Write::write_all` on the underlying `File`.
+/// overwrite the existing prefix with zeros. [`fast_io::MacosWriter`]
+/// likewise issues writes from the current position without preserving the
+/// seek. Append mode therefore always falls back to the buffered writer,
+/// which honors the seek via `Write::write_all` on the underlying `File`.
+///
+/// On macOS, `MacosWriter::from_file` uses `size_hint` to decide whether to
+/// set `F_NOCACHE` (only for files >= 1 MiB), preserving the page cache for
+/// small files. `size_hint` is the receiver-known target size.
 ///
 /// On the batched paths, `batch.begin_file(file)` registers the file with the
 /// backend; the matching `commit_file` happens via [`Writer::finish`].
@@ -273,6 +281,7 @@ fn make_writer<'a>(
     iocp_batch: Option<&'a mut fast_io::IocpDiskBatch>,
     use_sparse: bool,
     append_offset: u64,
+    size_hint: u64,
 ) -> io::Result<Writer<'a>> {
     #[cfg(all(target_os = "linux", feature = "io_uring"))]
     {
@@ -290,6 +299,14 @@ fn make_writer<'a>(
                 batch.begin_file(file)?;
                 return Ok(Writer::Iocp { batch });
             }
+        }
+    }
+    #[cfg(target_os = "macos")]
+    {
+        if !use_sparse && append_offset == 0 {
+            return Ok(Writer::Macos(fast_io::MacosWriter::from_file(
+                file, size_hint,
+            )));
         }
     }
     Ok(Writer::Buffered(ReusableBufWriter::new(file, write_buf)))
@@ -506,6 +523,80 @@ mod tests {
 
         let result = rename_with_io_uring_fallback(&src, &dst);
         assert!(result.is_err());
+    }
+
+    /// Verifies `make_writer` selects [`Writer::Macos`] when sparse mode is
+    /// disabled and `append_offset` is zero, so the `F_NOCACHE` + `writev`
+    /// optimization is engaged on the common write path.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn make_writer_selects_macos_for_non_sparse_zero_offset() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("macos_writer_select.bin");
+        let file = fs::File::create(&path).unwrap();
+        let mut write_buf = Vec::with_capacity(256 * 1024);
+
+        let writer = make_writer(
+            file,
+            &mut write_buf,
+            None,
+            None,
+            /* use_sparse */ false,
+            /* append_offset */ 0,
+            /* size_hint */ 0,
+        )
+        .unwrap();
+
+        assert!(
+            matches!(writer, Writer::Macos(_)),
+            "macOS non-sparse zero-offset writes must select Writer::Macos"
+        );
+    }
+
+    /// Verifies `make_writer` falls back to [`Writer::Buffered`] when sparse
+    /// mode or append mode is active on macOS, preserving `Seek` semantics.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn make_writer_falls_back_to_buffered_when_seek_required() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // Sparse mode forces buffered.
+        let sparse_path = dir.path().join("sparse.bin");
+        let sparse_file = fs::File::create(&sparse_path).unwrap();
+        let mut sparse_buf = Vec::with_capacity(256 * 1024);
+        let sparse_writer = make_writer(
+            sparse_file,
+            &mut sparse_buf,
+            None,
+            None,
+            /* use_sparse */ true,
+            /* append_offset */ 0,
+            /* size_hint */ 0,
+        )
+        .unwrap();
+        assert!(
+            matches!(sparse_writer, Writer::Buffered(_)),
+            "sparse mode must select Writer::Buffered"
+        );
+
+        // Append mode forces buffered.
+        let append_path = dir.path().join("append.bin");
+        let append_file = fs::File::create(&append_path).unwrap();
+        let mut append_buf = Vec::with_capacity(256 * 1024);
+        let append_writer = make_writer(
+            append_file,
+            &mut append_buf,
+            None,
+            None,
+            /* use_sparse */ false,
+            /* append_offset */ 4096,
+            /* size_hint */ 0,
+        )
+        .unwrap();
+        assert!(
+            matches!(append_writer, Writer::Buffered(_)),
+            "append mode must select Writer::Buffered"
+        );
     }
 
     /// Verifies consistent io_uring availability for RENAMEAT2 across calls.

--- a/crates/transfer/src/disk_commit/writer.rs
+++ b/crates/transfer/src/disk_commit/writer.rs
@@ -134,10 +134,13 @@ impl Seek for ReusableBufWriter<'_> {
 /// 256 KB buffer. `IoUring` borrows the disk thread's persistent
 /// [`fast_io::IoUringDiskBatch`] which has already been registered with the
 /// active file via `begin_file`. `Iocp` is the Windows analogue, borrowing
-/// the persistent [`fast_io::IocpDiskBatch`].
+/// the persistent [`fast_io::IocpDiskBatch`]. `Macos` wraps the file in
+/// [`fast_io::MacosWriter`], which pairs `F_NOCACHE` (for files above 1 MiB)
+/// with `writev(2)` scatter-gather flushes.
 ///
-/// Sparse mode requires `Seek`, which neither batch writer provides, so
-/// callers must select `Buffered` whenever `use_sparse` is set.
+/// Sparse mode requires `Seek`, which none of `IoUring`, `Iocp`, or `Macos`
+/// provide, so callers must select `Buffered` whenever `use_sparse` is set
+/// or `append_offset` is non-zero.
 pub(super) enum Writer<'a> {
     Buffered(ReusableBufWriter<'a>),
     #[cfg(all(target_os = "linux", feature = "io_uring"))]
@@ -148,6 +151,8 @@ pub(super) enum Writer<'a> {
     Iocp {
         batch: &'a mut fast_io::IocpDiskBatch,
     },
+    #[cfg(target_os = "macos")]
+    Macos(fast_io::MacosWriter),
 }
 
 impl<'a> Writer<'a> {
@@ -170,6 +175,11 @@ impl<'a> Writer<'a> {
                 debug_assert!(false, "sparse mode must select buffered writer");
                 unreachable!("sparse mode must select buffered writer")
             }
+            #[cfg(target_os = "macos")]
+            Writer::Macos(_) => {
+                debug_assert!(false, "sparse mode must select buffered writer");
+                unreachable!("sparse mode must select buffered writer")
+            }
         }
     }
 
@@ -181,6 +191,8 @@ impl<'a> Writer<'a> {
             Writer::IoUring { batch } => batch.write_data(data),
             #[cfg(all(target_os = "windows", feature = "iocp"))]
             Writer::Iocp { batch } => batch.write_data(data),
+            #[cfg(target_os = "macos")]
+            Writer::Macos(w) => w.write_all(data),
         }
     }
 
@@ -206,6 +218,18 @@ impl<'a> Writer<'a> {
             Writer::IoUring { .. } => Ok(()),
             #[cfg(all(target_os = "windows", feature = "iocp"))]
             Writer::Iocp { .. } => Ok(()),
+            #[cfg(target_os = "macos")]
+            Writer::Macos(w) => {
+                if do_fsync {
+                    w.sync().map_err(|e| {
+                        io::Error::new(e.kind(), format!("fsync failed for {file_path:?}: {e}"))
+                    })
+                } else {
+                    w.flush().map_err(|e| {
+                        io::Error::other(format!("flush failed for {file_path:?}: {e}"))
+                    })
+                }
+            }
         }
     }
 
@@ -240,6 +264,8 @@ impl<'a> Writer<'a> {
                     format!("IOCP commit failed for {file_path:?}: {e}"),
                 )
             }),
+            #[cfg(target_os = "macos")]
+            Writer::Macos(_) => Ok(()),
         }
     }
 }


### PR DESCRIPTION
## Summary

- Adds a `Writer::Macos(MacosWriter)` variant in `crates/transfer/src/disk_commit/writer.rs`, guarded by `#[cfg(target_os = "macos")]`.
- Extends `make_writer` in `crates/transfer/src/disk_commit/process.rs` with a macOS arm that wraps the per-file `File` in `fast_io::MacosWriter::from_file(file, target_size)` when `!use_sparse && append_offset == 0`, mirroring the existing io_uring and IOCP arms.
- Adds `MacosWriter::sync()` so the dispatcher's `flush_and_sync(do_fsync, ...)` can drain pending `writev` buffers and `fsync` the underlying file.

## Motivation

`MacosWriter` (`crates/fast_io/src/macos_io.rs`) has shipped for a while: it pairs `F_NOCACHE` (above the 1 MiB threshold) with `writev(2)` flushes (up to 64 iovecs). It is re-exported from `crates/fast_io/src/lib.rs`, but the disk-commit thread still constructs `ReusableBufWriter` directly on macOS, so the optimization has zero callers in the workspace.

The audit at `docs/audits/macos-fastio-fallback.md` (PR #4008, task #1652) called out this gap and recommended exactly the wiring in this PR as the fix for #1657.

## Behaviour

- macOS, non-sparse, `append_offset == 0`: routes through `Writer::Macos(MacosWriter)`. Files >= 1 MiB get `F_NOCACHE` (page-cache bypass for tree-wide transfers larger than RAM); writes >= 256 KiB flush via `writev` covering up to 64 iovecs per syscall.
- macOS, sparse or `append_offset != 0`: falls through to `Writer::Buffered(ReusableBufWriter)`. `MacosWriter` does not implement `Seek` and would not preserve the file position used by sparse/append mode.
- Other platforms: unchanged. The macOS arm is gated; `Writer::Macos` does not exist off-target.

## Test plan

- [ ] CI fmt + clippy across all platforms.
- [ ] `cargo nextest run -p transfer` on macOS picks up `make_writer_selects_macos_for_non_sparse_zero_offset` and `make_writer_falls_back_to_buffered_when_seek_required`.
- [ ] Linux/Windows builds remain unchanged - the macOS arm is `#[cfg(target_os = "macos")]` and the dispatcher signature only adds a `size_hint: u64` parameter.

## References

- Audit: `docs/audits/macos-fastio-fallback.md` (PR #4008).
- Task: #1657 - wire `F_NOCACHE` + `writev` into disk-commit.
- Closes #1652 cleanly per the audit's section 4.1 recommendation.