### PR TITLE
fix: drop non-upstream I/O backend line from --stats block

### DIFF
--- a/crates/cli/src/frontend/progress/render.rs
+++ b/crates/cli/src/frontend/progress/render.rs
@@ -1,7 +1,6 @@
 use std::io::{self, Write};
 
 use core::client::{ClientEvent, ClientEventKind, ClientSummary, HumanReadableMode};
-use fast_io::{is_io_uring_available, sqpoll_fell_back};
 
 use super::format::{
     compute_rate, describe_event_kind, event_matches_name_level, format_list_permissions,
@@ -201,6 +200,12 @@ pub(crate) fn emit_progress<W: Write + ?Sized>(
 }
 
 /// Emits a statistics summary mirroring the subset of counters supported by the local engine.
+///
+/// Line ordering, label spelling, and the trailing blank line before the totals
+/// trailer follow upstream rsync's `output_summary` (`main.c:416-465`). The
+/// helper deliberately omits the upstream leading `\n` (`main.c:419`) because
+/// the caller (`emit_transfer_summary`) emits a blank line between prior
+/// output blocks and the stats block.
 pub(crate) fn emit_stats<W: Write + ?Sized>(
     summary: &ClientSummary,
     stdout: &mut W,
@@ -285,7 +290,6 @@ pub(crate) fn emit_stats<W: Write + ?Sized>(
     )?;
     writeln!(stdout, "Total bytes sent: {bytes_sent_display}")?;
     writeln!(stdout, "Total bytes received: {bytes_received_display}")?;
-    writeln!(stdout, "I/O backend: {}", io_backend_label())?;
     writeln!(stdout)?;
 
     emit_totals(summary, stdout, human_readable, dry_run)
@@ -479,41 +483,4 @@ pub(crate) fn emit_verbose<W: Write + ?Sized>(
         }
     }
     Ok(())
-}
-
-/// Returns a human-readable label describing the I/O backend in use.
-///
-/// On Linux with io_uring available, reports whether SQPOLL mode is active
-/// or whether it fell back to standard submission. On non-Linux or when
-/// io_uring is unavailable, reports "standard I/O".
-fn io_backend_label() -> &'static str {
-    if is_io_uring_available() {
-        if sqpoll_fell_back() {
-            "io_uring"
-        } else {
-            "io_uring (SQPOLL)"
-        }
-    } else {
-        "standard I/O"
-    }
-}
-
-#[cfg(test)]
-mod io_backend_tests {
-    use super::*;
-
-    #[test]
-    fn io_backend_label_returns_known_value() {
-        let label = io_backend_label();
-        assert!(
-            label == "standard I/O" || label == "io_uring" || label == "io_uring (SQPOLL)",
-            "unexpected io_backend_label: {label}"
-        );
-    }
-
-    #[cfg(not(target_os = "linux"))]
-    #[test]
-    fn io_backend_label_is_standard_on_non_linux() {
-        assert_eq!(io_backend_label(), "standard I/O");
-    }
 }

--- a/docs/audits/stats-block-format-audit.md
+++ b/docs/audits/stats-block-format-audit.md
@@ -39,8 +39,7 @@ Upstream (`target/interop/upstream-src/rsync-3.4.1/`):
 
 oc-rsync:
 
-- `crates/cli/src/frontend/progress/render.rs` - `emit_stats`, `emit_totals`,
-  `io_backend_label`.
+- `crates/cli/src/frontend/progress/render.rs` - `emit_stats`, `emit_totals`.
 - `crates/cli/src/frontend/progress/format/size.rs` - `format_size`,
   `format_decimal_bytes`, `format_human_bytes`.
 - `crates/cli/src/frontend/progress/format/rate.rs` - `format_summary_rate`,
@@ -399,22 +398,18 @@ Total bytes received: {bytes_received_display}
 
 Parity: **OK**, same `--human-readable` off-by-one.
 
-### EXTRA: I/O backend
+### EXTRA: I/O backend (FIXED)
 
-oc-rsync (`render.rs:284`):
+Previously oc-rsync emitted an extra `I/O backend: <label>` line after
+`Total bytes received:` (`render.rs` pre-fix line 288), where `<label>` was
+one of `"standard I/O"`, `"io_uring"`, or `"io_uring (SQPOLL)"`. Upstream
+emits no such line, so byte-equivalent log parsers treated it as garbage.
 
-```
-I/O backend: {io_backend_label()}
-```
+This line and its `io_backend_label()` helper have been removed. The block
+now ends at `Total bytes received:` followed by the trailer-separator
+blank line, matching upstream's `main.c:447-452` exactly.
 
-Where `io_backend_label()` returns one of `"standard I/O"`, `"io_uring"`,
-or `"io_uring (SQPOLL)"`.
-
-Upstream emits no such line. This is a non-upstream addition that scripts
-parsing the stats block for byte-equivalent output will treat as garbage.
-
-Parity: **EXTRA - drift.** Should be removed or gated behind an
-oc-rsync-specific verbosity / debug flag.
+Parity: **OK.**
 
 ### Block separator before totals
 
@@ -422,14 +417,11 @@ Upstream (`main.c:452`): `rprintf(FCLIENT, "\n");` between the stats body
 and the totals. Always emits a blank line at this point when
 `INFO_GTE(STATS, 1)`.
 
-oc-rsync: writes `writeln!(stdout)?` at `render.rs:285` after the I/O
-backend line. The blank line is unconditional in `emit_stats`, so the
-separator does land before the totals - but it currently follows the
-spurious "I/O backend" line, not the upstream final line ("Total bytes
-received").
+oc-rsync writes `writeln!(stdout)?` in `emit_stats` after the final
+`Total bytes received:` line, so the separator lands in the same place
+upstream emits it.
 
-Parity: **OK** (blank line present), but only because of the extra line.
-Removing "I/O backend" preserves the parity intentionally.
+Parity: **OK.**
 
 ### 14. sent/received/rate one-liner
 
@@ -590,7 +582,7 @@ Counting each distinct line-level deviation:
 13. `File list generation time` - no thousands separator on integer part.
 14. `File list transfer time` - no `flist_buildtime != 0` gate.
 15. `File list transfer time` - no thousands separator.
-16. `I/O backend` line - extra, non-upstream.
+16. `I/O backend` line - extra, non-upstream. (**FIXED**)
 17. Bytes/sec - "UNKNOWN" sentinel missing.
 18. Bytes/sec - half-second divisor offset missing.
 19. Bytes/sec - no thousands separator on rate value at default.
@@ -598,14 +590,13 @@ Counting each distinct line-level deviation:
 21. Trailer - `(BATCH ONLY)` branch missing.
 22. Locale-aware `get_number_separator` not implemented.
 
-Total discrepancies: **22**.
+Total discrepancies: **22** (1 fixed, 21 open).
 
 ## Recommendations
 
 In rough priority order (highest user-visible drift first):
 
-1. Remove the `I/O backend:` line from the stats body, or move it behind a
-   debug-only verbosity that does not collide with `--stats` consumers.
+1. ~~Remove the `I/O backend:` line from the stats body.~~ **Done.**
 2. Switch byte/count formatting defaults so oc-rsync's level 0
    (`Disabled`) maps to upstream's level 1 (current behaviour matches
    only by coincidence on the byte-count rows). Reserve `--human-readable`

--- a/docs/audits/stats-block-format.md
+++ b/docs/audits/stats-block-format.md
@@ -67,7 +67,7 @@ Three parallel formatters exist:
 | Deleted files per-type | yes | **bare integer** | none | none |
 | `flist_buildtime==0` suppresses lines 11-12 | yes | no | no | yes |
 | `Total bytes sent/received` | `human_num` (commas) | `format_size`/`HumanReadableMode` | commas | commas |
-| Extra `I/O backend: ...` line | absent | **emitted at line 15** | absent | absent |
+| Extra `I/O backend: ...` line | absent | FIXED (removed) | absent | absent |
 | Speed divisor | `0.5+(end-start)` wall-clock | wall-clock elapsed | `flist_build+flist_xfer` (**wrong**) | same wrong divisor |
 | Speedup `comma_dnum(...,2)` | yes (commas) | matches | matches | `{:.2}` no commas |
 | `(DRY RUN)` suffix | yes | yes | absent | absent |
@@ -93,30 +93,29 @@ Add per-formatter unit tests pinning trailing `\n` and leading blank line.
 
 ## 5. Known divergences worth tracking
 
-1. **`I/O backend:` line** (`render.rs:284`). Not in upstream. Move
-   behind a non-default info word or drop from `--stats`.
-2. **`dev` bucket merged with `special`** in `emit_stats`.
-3. **Deletion per-type breakdown missing**; emitted as bare integer.
-4. **Leading blank line missing** before `Number of files:`.
-5. **Protocol-version gating absent** for created (>=29) / deleted (>=31).
-6. **`flist_buildtime == 0` suppression absent** in `emit_stats` and
-   `stats_format`; upstream omits both timing lines together.
-7. **`bytes/sec` divisor wrong** in `stats_format` and
-   `protocol::stats::display` (file-list timing instead of wall-clock).
-8. **No trailing `\n`** from `stats_format::format` and `Display for
-   TransferStats`.
-9. **`--no-human-readable` ignored on stats path** (commas hardcoded).
-10. **Speedup uses `{:.2}`** in `protocol::stats::display`, losing the
-    thousands separators upstream emits via `comma_dnum`.
-11. **`(BATCH ONLY)` suffix missing** from `emit_stats` trailer.
-12. **Three duplicate formatters.** Consolidate into one `StatsFormatter`
-    shared between the live path and goldens.
+Status legend: FIXED in this audit; OPEN remains a divergence; CLOSED was
+re-evaluated and the implementation already matches upstream.
+
+| ID | Severity | Status | Description |
+|----|----------|--------|-------------|
+| S1 | Low | FIXED | `I/O backend:` line (`render.rs:288`) is not in upstream's `output_summary`; removed so the stats block ends at `Total bytes received:` and the blank line precedes the trailer as upstream emits at `main.c:452`. |
+| S2 | Low | OPEN | `dev` bucket merged with `special` in `emit_stats`; upstream emits `dev` and `special` separately. |
+| S3 | Low | OPEN | Deletion per-type breakdown missing; emitted as bare integer. |
+| S4 | Low | OPEN | Leading blank line missing before `Number of files:` (upstream `main.c:419`). |
+| S5 | Low | OPEN | Protocol-version gating absent for created (>=29) / deleted (>=31). |
+| S6 | Medium | OPEN | `flist_buildtime == 0` suppression absent in `emit_stats` and `stats_format`; upstream omits both timing lines together. |
+| S7 | High | OPEN | `bytes/sec` divisor wrong in `stats_format` and `protocol::stats::display` (file-list timing instead of wall-clock). |
+| S8 | Low | OPEN | No trailing `\n` from `stats_format::format` and `Display for TransferStats`. |
+| S9 | Medium | OPEN | `--no-human-readable` ignored on stats path (commas hardcoded). |
+| S10 | Low | OPEN | Speedup uses `{:.2}` in `protocol::stats::display`, losing thousands separators upstream emits via `comma_dnum`. |
+| S11 | Low | OPEN | `(BATCH ONLY)` suffix missing from `emit_stats` trailer. |
+| S12 | Low | OPEN | Three duplicate formatters; consolidate into one `StatsFormatter` shared between the live path and goldens. |
 
 ## References
 
 - Upstream: `main.c::output_summary` (416-465); `inums.h`;
   `lib/compat.c::do_big_num` (170-246), `do_big_dnum` (252-).
-- oc-rsync: `crates/cli/src/frontend/progress/render.rs::emit_stats`
-  (200-288), `emit_totals` (291-328);
+- oc-rsync: `crates/cli/src/frontend/progress/render.rs::emit_stats`,
+  `emit_totals`;
   `crates/cli/src/frontend/stats_format.rs` (136-263);
   `crates/protocol/src/stats/display.rs` (49-184).

--- a/docs/design/hardware-priority-order.md
+++ b/docs/design/hardware-priority-order.md
@@ -367,9 +367,11 @@ acceleration:
 
 ### 8.2 Verbose Output (`-vv`)
 
-The transfer summary printed at the end of a `-vv` run includes an
-**I/O backend** line showing the active backend for the session:
-`standard I/O`, `io_uring`, or `io_uring (SQPOLL)`.
+The transfer summary printed at the end of a `-vv` run intentionally
+mirrors upstream rsync's `--stats` body byte-for-byte
+(`target/interop/upstream-src/rsync-3.4.1/main.c:416-465`), so it does
+not include an `I/O backend` line. Use the runtime diagnostic functions
+below or `--version` (Section 8.1) to inspect the active backend.
 
 **Source:** `crates/cli/src/frontend/progress/render.rs`
 


### PR DESCRIPTION
## Summary

- Upstream rsync's `output_summary` (`target/interop/upstream-src/rsync-3.4.1/main.c:416-465`) ends the `--stats` body at `Total bytes received:` followed by a blank line, then the `sent ... received ...` / `total size is ...` trailer.
- The Rust `emit_stats` helper in `crates/cli/src/frontend/progress/render.rs` appended an extra `I/O backend: <label>` line between `Total bytes received:` and the trailer separator. Any tool parsing the stats block by fixed offsets or by treating every `Label: value` row as authoritative saw garbage after the upstream-known fields.
- Companion to #4010 (progress line widths) and #3971 (initial stats audit doc). Closes the largest open divergence from `docs/audits/stats-block-format.md` (S1) and `docs/audits/stats-block-format-audit.md` (item 16).

## Field layout vs upstream (stats body)

| # | Upstream `main.c` line | Label |
|---|------------------------|-------|
| 1 | 420 | `Number of files:` |
| 2 | 422 (proto >= 29) | `Number of created files:` |
| 3 | 424 (proto >= 31) | `Number of deleted files:` |
| 4 | 425 | `Number of regular files transferred:` |
| 5 | 427 | `Total file size:` |
| 6 | 429 | `Total transferred file size:` |
| 7 | 431 | `Literal data:` |
| 8 | 433 | `Matched data:` |
| 9 | 435 | `File list size:` |
| 10 | 438 (flist_buildtime != 0) | `File list generation time:` |
| 11 | 441 (same gate) | `File list transfer time:` |
| 12 | 445 | `Total bytes sent:` |
| 13 | 447 | `Total bytes received:` |
| - | 452 | (blank line) |
| 14 | 453 | `sent ... received ... bytes/sec` |
| 15 | 457 | `total size is ... speedup is ...` |

The previous oc-rsync output inserted `I/O backend: ...` between rows 13 and the blank line at line 452; this change removes that insertion so the byte ordering matches upstream exactly.

## Notes

- Backend visibility is preserved: `--version` (Section 8.1 of `docs/design/hardware-priority-order.md`) and `fast_io::is_io_uring_available()` / `fast_io::sqpoll_fell_back()` remain the supported ways to inspect the active backend.
- `docs/audits/stats-block-format.md` and `docs/audits/stats-block-format-audit.md` flip the `I/O backend` entry to FIXED and re-summarise the remaining open divergences.
- The audit doc still tracks 21 open divergences (label spellings already match; the remaining items are formatter parity, protocol gating, locale awareness, etc.).

## Test plan

- [ ] CI: fmt + clippy
- [ ] CI: nextest (stable) - `output_parity::parity_stats_output_*`, `verbose`, `human_readable_format`, `info_debug` already pin every upstream label and order without asserting the removed line
- [ ] CI: Windows / macOS / Linux musl
- [ ] Manual byte comparison vs upstream rsync 3.4.1 once a benchmark slot frees up: `diff <(rsync --stats ...) <(oc-rsync --stats ...)`