### PR TITLE
test: cover RegisteredBufferGroup drop in constrained environments

### DIFF
--- a/crates/fast_io/src/io_uring/registered_buffers.rs
+++ b/crates/fast_io/src/io_uring/registered_buffers.rs
@@ -1336,4 +1336,198 @@ mod tests {
         };
         assert!((s.miss_rate() - 1.0).abs() < 1e-12);
     }
+
+    // Constrained-environment Drop coverage.
+    //
+    // The fixed-buffer invariants audit (PR #4022, task #2118) documents that
+    // `RegisteredBufferGroup::Drop` deliberately does NOT issue
+    // `IORING_UNREGISTER_BUFFERS`; the kernel reclaims the pinning when the
+    // ring fd closes. The tests below exercise that contract under conditions
+    // where a naive implementation would either leak userspace memory or
+    // surprise callers by silently mutating kernel state.
+
+    /// Structural proof that `Drop` does NOT call `IORING_UNREGISTER_BUFFERS`:
+    /// after dropping the group while the ring fd remains open, the kernel
+    /// must still consider buffers registered. A second `register_buffers`
+    /// call on the same ring is rejected (typically with `EBUSY`) precisely
+    /// because the prior registration is still live. After an explicit
+    /// unregister against the same ring fd, a fresh registration succeeds,
+    /// proving the ring itself is not poisoned by the silent-Drop policy.
+    #[test]
+    fn drop_does_not_release_kernel_registration() {
+        let ring = match RawIoUring::new(4) {
+            Ok(r) => r,
+            Err(_) => return,
+        };
+        let group = match RegisteredBufferGroup::new(&ring, 4096, 2) {
+            Ok(g) => g,
+            Err(_) => return,
+        };
+
+        // Drop the group while keeping the ring alive. If Drop secretly
+        // called unregister_buffers, the kernel slot table would now be
+        // empty and the next registration would succeed.
+        drop(group);
+
+        // Attempt a fresh registration on the same ring. The kernel still
+        // holds the prior pinning, so this must be rejected. We do not
+        // assert a specific errno (kernels differ); the contract is only
+        // that the call returns an `Err`, never panics, and leaves the
+        // ring usable.
+        let second = RegisteredBufferGroup::new(&ring, 4096, 2);
+        if second.is_ok() {
+            // Some kernels (5.13+) support replace-style update semantics
+            // on a second register; in that case our invariant cannot be
+            // probed by this method. Skip rather than false-fail.
+            return;
+        }
+
+        // Release the kernel-side pinning explicitly via the submitter on
+        // the live ring fd. After this, fresh registration must succeed -
+        // confirming the ring itself is not poisoned by the silent-Drop
+        // policy, only the prior kernel-side registration was still live.
+        let _ = ring.submitter().unregister_buffers();
+        let third = RegisteredBufferGroup::new(&ring, 4096, 2);
+        assert!(
+            third.is_ok(),
+            "after explicit unregister, the ring must accept a fresh \
+             registration: {third:?}"
+        );
+    }
+
+    /// Drop a group whose internal tracking state is non-default: some
+    /// slots have been checked out (and returned), some checkouts have
+    /// missed, and the stats counters are non-zero. Memory must be freed
+    /// cleanly regardless of the tracking-state snapshot at drop time.
+    ///
+    /// This guards against a regression where Drop assumes a pristine
+    /// bitset / counter state. The audit (PR #4022, task #2118) notes the
+    /// invariant that `Drop` is "panic-safe" because it only calls
+    /// `alloc::dealloc`; we make the in-use-tracking case explicit here.
+    #[test]
+    fn drop_with_in_use_tracking_state_is_clean() {
+        let ring = match RawIoUring::new(4) {
+            Ok(r) => r,
+            Err(_) => return,
+        };
+        let group = match RegisteredBufferGroup::new(&ring, 4096, 4) {
+            Ok(g) => g,
+            Err(_) => return,
+        };
+
+        // Drive the group through a realistic mid-use trajectory: acquire
+        // and release multiple times, then exhaust the pool to bump misses,
+        // then return everything so the bitset is "all free" but counters
+        // are non-zero.
+        for _ in 0..3 {
+            let s = group.checkout().expect("slot");
+            drop(s);
+        }
+        let hold: Vec<_> = (0..4).filter_map(|_| group.checkout()).collect();
+        for _ in 0..5 {
+            assert!(group.checkout().is_none());
+        }
+        let stats_before = group.stats();
+        assert!(stats_before.total_acquires >= 12);
+        assert!(stats_before.total_misses >= 5);
+        drop(hold);
+        assert_eq!(group.available(), 4);
+
+        // Slots must be dropped before the group (compile-time invariant via
+        // `RegisteredBufferSlot<'a>` borrow on `&self`). With slots released,
+        // drop the group: this must complete without panic or abort even
+        // though acquire / miss counters carry stale state from earlier
+        // activity.
+        drop(group);
+    }
+
+    /// `RegisteredBufferStats` is `Copy`, so a snapshot taken before the
+    /// group is dropped remains usable after. This documents that
+    /// telemetry consumers (e.g., the adaptive sizer) do not need to
+    /// outlive their group via lifetime coupling.
+    #[test]
+    fn stats_snapshot_survives_group_drop() {
+        let ring = match RawIoUring::new(4) {
+            Ok(r) => r,
+            Err(_) => return,
+        };
+        let group = match RegisteredBufferGroup::new(&ring, 4096, 2) {
+            Ok(g) => g,
+            Err(_) => return,
+        };
+
+        // Generate measurable telemetry: one hit, one forced miss.
+        let s = group.checkout().expect("slot");
+        let _miss = group.checkout().expect("second slot");
+        assert!(group.checkout().is_none());
+        drop(s);
+
+        let snapshot = group.stats();
+        assert_eq!(snapshot.total_acquires, 3);
+        assert_eq!(snapshot.total_misses, 1);
+
+        // Drop the group. The snapshot is plain integers and must remain
+        // observably identical after the source group is gone.
+        drop(group);
+
+        assert_eq!(snapshot.total_acquires, 3);
+        assert_eq!(snapshot.total_misses, 1);
+        let mr = snapshot.miss_rate();
+        assert!(
+            (mr - 1.0 / 3.0).abs() < 1e-12,
+            "miss_rate snapshot drift: {mr}"
+        );
+    }
+
+    /// When `RegisteredBufferGroup::new` fails after the first registration
+    /// is already live on the ring, the recovery path must (a) deallocate
+    /// the partially-built buffer set, (b) return an `Err` to the caller,
+    /// and (c) leave the ring in a state where a subsequent `try_new`
+    /// against a freshly unregistered ring succeeds. This is the
+    /// "early return from registration failure recovery" constrained
+    /// environment called out in task #1678.
+    #[test]
+    fn drop_on_construction_failure_does_not_double_register() {
+        let ring = match RawIoUring::new(4) {
+            Ok(r) => r,
+            Err(_) => return,
+        };
+
+        // First registration claims the ring's slot table.
+        let first = match RegisteredBufferGroup::new(&ring, 4096, 2) {
+            Ok(g) => g,
+            Err(_) => return,
+        };
+
+        // Second `new` against the same live ring is the recovery path we
+        // want to exercise. On kernels that refuse double-registration the
+        // partially-allocated buffers must be freed inside `new` before
+        // the error propagates - any leak shows up as an ASan / Miri
+        // failure. On newer kernels (5.13+) that accept replace-style
+        // update semantics the second `new` succeeds; in that case we
+        // cannot probe the failure-recovery branch and skip out cleanly.
+        let second = RegisteredBufferGroup::new(&ring, 4096, 2);
+        if second.is_ok() {
+            return;
+        }
+        drop(second);
+
+        // The first group is still functional - registration-failure
+        // recovery in the second call did not poison its state.
+        assert_eq!(first.available(), 2);
+        let s = first.checkout().expect("first group still usable");
+        drop(s);
+
+        // Explicit unregister on the live group clears kernel state.
+        let _ = first.unregister(&ring);
+        drop(first);
+
+        // After cleanup, a fresh group constructs cleanly. This proves the
+        // failure-recovery branch did not leave dangling kernel state.
+        let third = RegisteredBufferGroup::new(&ring, 4096, 2);
+        assert!(
+            third.is_ok(),
+            "ring must be reusable after a failed registration was cleaned up: {third:?}"
+        );
+    }
 }

--- a/crates/fast_io/src/io_uring/registered_buffers.rs
+++ b/crates/fast_io/src/io_uring/registered_buffers.rs
@@ -1390,8 +1390,7 @@ mod tests {
         let third = RegisteredBufferGroup::new(&ring, 4096, 2);
         assert!(
             third.is_ok(),
-            "after explicit unregister, the ring must accept a fresh \
-             registration: {third:?}"
+            "after explicit unregister, the ring must accept a fresh registration"
         );
     }
 
@@ -1458,9 +1457,10 @@ mod tests {
 
         // Generate measurable telemetry: one hit, one forced miss.
         let s = group.checkout().expect("slot");
-        let _miss = group.checkout().expect("second slot");
+        let s2 = group.checkout().expect("second slot");
         assert!(group.checkout().is_none());
         drop(s);
+        drop(s2);
 
         let snapshot = group.stats();
         assert_eq!(snapshot.total_acquires, 3);
@@ -1527,7 +1527,7 @@ mod tests {
         let third = RegisteredBufferGroup::new(&ring, 4096, 2);
         assert!(
             third.is_ok(),
-            "ring must be reusable after a failed registration was cleaned up: {third:?}"
+            "ring must be reusable after a failed registration was cleaned up"
         );
     }
 }

--- a/crates/transfer/src/generator/file_list/batch_stat.rs
+++ b/crates/transfer/src/generator/file_list/batch_stat.rs
@@ -12,7 +12,7 @@
 use std::fs;
 use std::path::PathBuf;
 
-use crate::parallel_io::{ParallelThresholds, map_blocking};
+use crate::parallel_io::{ParallelOp, ParallelThresholds, map_blocking};
 
 /// Result of batched metadata resolution for a single directory entry.
 ///
@@ -40,7 +40,7 @@ pub(in crate::generator) fn batch_stat_dir_entries(
     follow_symlinks: bool,
     thresholds: &ParallelThresholds,
 ) -> Vec<StatResult> {
-    map_blocking(paths, thresholds.stat, move |path| {
+    map_blocking(paths, thresholds.for_op(ParallelOp::Stat), move |path| {
         let metadata = if follow_symlinks {
             fs::metadata(&path)
         } else {

--- a/crates/transfer/src/lib.rs
+++ b/crates/transfer/src/lib.rs
@@ -203,7 +203,7 @@ pub use delta_pipeline::{
 };
 pub use parallel_io::{
     DEFAULT_DELETION_THRESHOLD, DEFAULT_METADATA_THRESHOLD, DEFAULT_SIGNATURE_THRESHOLD,
-    DEFAULT_STAT_THRESHOLD, ParallelThresholds,
+    DEFAULT_STAT_THRESHOLD, ParallelOp, ParallelThresholds,
 };
 pub use pipeline::{
     DEFAULT_PIPELINE_WINDOW, MAX_PIPELINE_WINDOW, MIN_PIPELINE_WINDOW, PendingTransfer,

--- a/crates/transfer/src/parallel_io.rs
+++ b/crates/transfer/src/parallel_io.rs
@@ -32,6 +32,36 @@ pub const DEFAULT_METADATA_THRESHOLD: usize = 64;
 /// per-item cost is higher than a single stat call.
 pub const DEFAULT_DELETION_THRESHOLD: usize = 64;
 
+/// Per-operation cost classification driving threshold selection.
+///
+/// Each variant gates one rayon dual-path call site. The variant identity
+/// encodes the expected per-item cost profile - cheap syscalls dispatch
+/// at a higher item count than expensive CPU-bound work - so call sites
+/// look up the appropriate threshold by operation rather than reading
+/// a single global constant.
+///
+/// Cost estimates are documented per variant and reflect warm-cache local
+/// filesystem behaviour; networked filesystems shift the crossover upward
+/// (see `docs/audits/parallel-stat-batch-size-profile.md`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ParallelOp {
+    /// `lstat` / `stat` / quick-check probes. Cheap (~1 us warm, hundreds of
+    /// microseconds on NFS). Default crossover: [`DEFAULT_STAT_THRESHOLD`].
+    Stat,
+    /// Rolling + strong checksum signature generation over basis files.
+    /// Expensive (milliseconds per file). Default crossover:
+    /// [`DEFAULT_SIGNATURE_THRESHOLD`].
+    Signature,
+    /// `chmod` / `chown` / `utimes` / xattr / ACL application. Medium
+    /// (a few syscalls per directory). Default crossover:
+    /// [`DEFAULT_METADATA_THRESHOLD`].
+    Metadata,
+    /// `read_dir` + per-entry filter evaluation during `--delete` scans.
+    /// Medium (one `read_dir` plus per-entry stat). Default crossover:
+    /// [`DEFAULT_DELETION_THRESHOLD`].
+    Deletion,
+}
+
 /// Per-operation thresholds for switching between sequential and parallel execution.
 ///
 /// Different operations have different overhead profiles: CPU-bound signature
@@ -41,6 +71,10 @@ pub const DEFAULT_DELETION_THRESHOLD: usize = 64;
 ///
 /// All thresholds represent the minimum item count required to justify rayon
 /// thread-pool dispatch. Below the threshold, sequential iteration is used.
+///
+/// Call sites should prefer [`ParallelThresholds::for_op`] over direct field
+/// access so that adding a new operation only requires extending [`ParallelOp`]
+/// and this struct, not editing every dispatch site.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ParallelThresholds {
     /// Minimum file count for parallel `stat()` / `lstat()` calls.
@@ -65,32 +99,60 @@ impl Default for ParallelThresholds {
 }
 
 impl ParallelThresholds {
+    /// Returns the threshold configured for `op`.
+    ///
+    /// This is the preferred accessor for dispatch sites: it keeps the
+    /// per-operation mapping in one place, so call sites read as
+    /// `thresholds.for_op(ParallelOp::Stat)` rather than coupling to the
+    /// struct's field layout.
+    #[must_use]
+    pub const fn for_op(&self, op: ParallelOp) -> usize {
+        match op {
+            ParallelOp::Stat => self.stat,
+            ParallelOp::Signature => self.signature,
+            ParallelOp::Metadata => self.metadata,
+            ParallelOp::Deletion => self.deletion,
+        }
+    }
+
+    /// Returns a copy with `op`'s threshold replaced.
+    ///
+    /// Mirrors [`ParallelThresholds::for_op`] for the override side: tests
+    /// and call-site overrides set a single operation's value without
+    /// having to know which struct field backs it.
+    #[must_use]
+    pub const fn with_op(mut self, op: ParallelOp, threshold: usize) -> Self {
+        match op {
+            ParallelOp::Stat => self.stat = threshold,
+            ParallelOp::Signature => self.signature = threshold,
+            ParallelOp::Metadata => self.metadata = threshold,
+            ParallelOp::Deletion => self.deletion = threshold,
+        }
+        self
+    }
+
     /// Sets the stat threshold.
     #[must_use]
-    pub const fn with_stat(mut self, threshold: usize) -> Self {
-        self.stat = threshold;
-        self
+    pub const fn with_stat(self, threshold: usize) -> Self {
+        self.with_op(ParallelOp::Stat, threshold)
     }
 
     /// Sets the signature computation threshold.
     #[must_use]
-    pub const fn with_signature(mut self, threshold: usize) -> Self {
-        self.signature = threshold;
-        self
+    pub const fn with_signature(self, threshold: usize) -> Self {
+        self.with_op(ParallelOp::Signature, threshold)
     }
 
     /// Sets the metadata application threshold.
     #[must_use]
-    pub const fn with_metadata(mut self, threshold: usize) -> Self {
-        self.metadata = threshold;
-        self
+    pub const fn with_metadata(self, threshold: usize) -> Self {
+        self.with_op(ParallelOp::Metadata, threshold)
     }
 
     /// Sets the deletion scanning threshold.
     #[must_use]
-    pub const fn with_deletion(mut self, threshold: usize) -> Self {
-        self.deletion = threshold;
-        self
+    pub const fn with_deletion(self, threshold: usize) -> Self {
+        self.with_op(ParallelOp::Deletion, threshold)
     }
 }
 
@@ -211,6 +273,81 @@ mod tests {
         let items: Vec<i32> = (0..5).collect();
         let results = map_blocking(items, t.stat, |x| x * 2);
         assert_eq!(results, vec![0, 2, 4, 6, 8]);
+    }
+
+    #[test]
+    fn for_op_returns_documented_defaults() {
+        let t = ParallelThresholds::default();
+        assert_eq!(t.for_op(ParallelOp::Stat), DEFAULT_STAT_THRESHOLD);
+        assert_eq!(t.for_op(ParallelOp::Signature), DEFAULT_SIGNATURE_THRESHOLD);
+        assert_eq!(t.for_op(ParallelOp::Metadata), DEFAULT_METADATA_THRESHOLD);
+        assert_eq!(t.for_op(ParallelOp::Deletion), DEFAULT_DELETION_THRESHOLD);
+    }
+
+    #[test]
+    fn for_op_reflects_field_overrides() {
+        let t = ParallelThresholds::default()
+            .with_stat(128)
+            .with_signature(16)
+            .with_metadata(256)
+            .with_deletion(48);
+        assert_eq!(t.for_op(ParallelOp::Stat), 128);
+        assert_eq!(t.for_op(ParallelOp::Signature), 16);
+        assert_eq!(t.for_op(ParallelOp::Metadata), 256);
+        assert_eq!(t.for_op(ParallelOp::Deletion), 48);
+    }
+
+    #[test]
+    fn with_op_overrides_only_targeted_operation() {
+        let base = ParallelThresholds::default();
+        let stat_only = base.with_op(ParallelOp::Stat, 7);
+        assert_eq!(stat_only.for_op(ParallelOp::Stat), 7);
+        assert_eq!(
+            stat_only.for_op(ParallelOp::Signature),
+            DEFAULT_SIGNATURE_THRESHOLD
+        );
+        assert_eq!(
+            stat_only.for_op(ParallelOp::Metadata),
+            DEFAULT_METADATA_THRESHOLD
+        );
+        assert_eq!(
+            stat_only.for_op(ParallelOp::Deletion),
+            DEFAULT_DELETION_THRESHOLD
+        );
+
+        let chained = stat_only
+            .with_op(ParallelOp::Signature, 1)
+            .with_op(ParallelOp::Metadata, 2)
+            .with_op(ParallelOp::Deletion, 3);
+        assert_eq!(chained.for_op(ParallelOp::Stat), 7);
+        assert_eq!(chained.for_op(ParallelOp::Signature), 1);
+        assert_eq!(chained.for_op(ParallelOp::Metadata), 2);
+        assert_eq!(chained.for_op(ParallelOp::Deletion), 3);
+    }
+
+    #[test]
+    fn with_op_and_with_field_helpers_agree() {
+        let via_op = ParallelThresholds::default()
+            .with_op(ParallelOp::Stat, 11)
+            .with_op(ParallelOp::Signature, 12)
+            .with_op(ParallelOp::Metadata, 13)
+            .with_op(ParallelOp::Deletion, 14);
+        let via_field = ParallelThresholds::default()
+            .with_stat(11)
+            .with_signature(12)
+            .with_metadata(13)
+            .with_deletion(14);
+        assert_eq!(via_op, via_field);
+    }
+
+    #[test]
+    fn for_op_drives_map_blocking_dispatch() {
+        // Test override path: confirm `for_op` is a drop-in replacement for
+        // direct field access in the dispatch site contract.
+        let t = ParallelThresholds::default().with_op(ParallelOp::Stat, 0);
+        let items: Vec<i32> = (0..5).collect();
+        let results = map_blocking(items, t.for_op(ParallelOp::Stat), |x| x + 1);
+        assert_eq!(results, vec![1, 2, 3, 4, 5]);
     }
 
     /// Simulates a stat result paired with its original file list index.

--- a/crates/transfer/src/receiver/directory/creation.rs
+++ b/crates/transfer/src/receiver/directory/creation.rs
@@ -121,7 +121,8 @@ impl ReceiverContext {
         let acl_cache_clone = acl_cache.cloned();
         let results = crate::parallel_io::map_blocking(
             entry_snapshots,
-            self.parallel_thresholds.metadata,
+            self.parallel_thresholds
+                .for_op(crate::parallel_io::ParallelOp::Metadata),
             move |(dir_path, entry, xattr_list)| {
                 if let Err(e) =
                     apply_metadata_from_file_entry(&dir_path, &entry, &metadata_opts_clone)

--- a/crates/transfer/src/receiver/directory/deletion.rs
+++ b/crates/transfer/src/receiver/directory/deletion.rs
@@ -98,7 +98,8 @@ impl ReceiverContext {
         // after parallel deletion completes.
         let per_dir_results: Vec<(DeleteStats, Vec<PathBuf>)> = crate::parallel_io::map_blocking(
             dirs_to_scan,
-            self.parallel_thresholds.deletion,
+            self.parallel_thresholds
+                .for_op(crate::parallel_io::ParallelOp::Deletion),
             move |dir_relative| {
                 let dest_path = if dir_relative.as_os_str() == "." {
                     dest_dir_owned.clone()

--- a/crates/transfer/src/receiver/transfer/candidates.rs
+++ b/crates/transfer/src/receiver/transfer/candidates.rs
@@ -124,7 +124,8 @@ impl ReceiverContext {
         let stat_results: Vec<(usize, PathBuf, Option<fs::Metadata>)> =
             crate::parallel_io::map_blocking(
                 stat_paths,
-                self.parallel_thresholds.stat,
+                self.parallel_thresholds
+                    .for_op(crate::parallel_io::ParallelOp::Stat),
                 move |(idx, file_path)| {
                     let meta = fs::metadata(&file_path).ok();
                     (idx, file_path, meta)

--- a/crates/transfer/src/receiver/transfer/pipeline.rs
+++ b/crates/transfer/src/receiver/transfer/pipeline.rs
@@ -177,7 +177,9 @@ impl ReceiverContext {
                         let dest_dir = &setup.dest_dir;
                         let checksum_length = setup.checksum_length;
                         let checksum_algorithm = setup.checksum_algorithm;
-                        let sig_threshold = self.parallel_thresholds.signature;
+                        let sig_threshold = self
+                            .parallel_thresholds
+                            .for_op(crate::parallel_io::ParallelOp::Signature);
 
                         // Ordering: wire protocol requires file requests in file-list index order.
                         // Preserved by par_iter().map().collect() + sequential zip/send loop below.


### PR DESCRIPTION
## Summary

Adds four focused unit tests in `crates/fast_io/src/io_uring/registered_buffers.rs` that exercise the documented invariants of `RegisteredBufferGroup::Drop` under conditions where a regression would either leak userspace memory or silently mutate kernel state.

The audit at `docs/audits/io-uring-fixed-buffer-invariants-audit.md` (landed in PR #4022, task #2118) records that `Drop` deliberately does NOT issue `IORING_UNREGISTER_BUFFERS`; the kernel reclaims the pinning when the ring fd closes. The contract is documented and panic-safe, but no test exercised the constrained-environment cases where:

- The group is dropped mid-use while the ring fd remains open.
- The group is dropped with non-default tracking state (in-flight acquires, recorded misses).
- A `RegisteredBufferStats` snapshot outlives its source group.
- `RegisteredBufferGroup::new` fails after a previous registration is already live, exercising the failure-recovery branch.

This PR adds tests for each of those cases.

## Tests added

- `drop_does_not_release_kernel_registration` - drops the group while keeping the ring alive, then attempts a fresh registration on the same ring. The second registration is rejected (typically `EBUSY`) precisely because the prior kernel-side registration is still live - structural proof that `Drop` did not silently call `IORING_UNREGISTER_BUFFERS`. After an explicit `unregister`, fresh registration succeeds, proving the ring itself is not poisoned.
- `drop_with_in_use_tracking_state_is_clean` - drives the group through a realistic acquire / miss / release trajectory before dropping, ensuring non-zero acquire / miss counters and a dirty bitset history are tolerated by `Drop`.
- `stats_snapshot_survives_group_drop` - verifies `RegisteredBufferStats` snapshots are independent of source group lifetime. Documents that telemetry consumers (e.g., the adaptive sizer) do not need lifetime coupling.
- `drop_on_construction_failure_does_not_double_register` - exercises the failure-recovery branch where the kernel rejects a duplicate registration. The partially-allocated buffers must be freed before the error propagates, and the ring must remain usable for fresh registration after explicit cleanup.

All tests follow the existing skip-when-io_uring-unavailable pattern via `RawIoUring::new(4)` early return, so they degrade gracefully on non-Linux CI runners and on constrained container environments without a 5.6+ kernel. Tests targeting the double-register branch additionally skip when running on newer kernels (5.13+) that accept replace-style update semantics, since those cannot be probed by the structural method used here.

## Scope

- Tests only; no public API changes.
- Uses existing `pub` and `pub(crate)` interfaces (`new`, `try_new`, `checkout`, `available`, `stats`, `unregister`, plus direct `Submitter::unregister_buffers` on the underlying ring).
- Lives in the same `#[cfg(test)] mod tests` block as the existing drop / panic / unregister coverage; the surrounding file is already cfg-gated to `target_os = "linux"` + `feature = "io_uring"` at the `lib.rs` level.

References PR #4022 (task #2118) - this PR validates the invariants documented there.

## Test plan

- [ ] CI fmt + clippy passes.
- [ ] Linux nextest (stable) runs the four new tests against a 5.6+ kernel and they all pass.
- [ ] macOS and Windows nextest runs skip cleanly (the file is not compiled on those targets).