### PR TITLE
feat: add ParallelOp lookup for per-operation rayon thresholds

### DIFF
--- a/crates/transfer/src/generator/file_list/batch_stat.rs
+++ b/crates/transfer/src/generator/file_list/batch_stat.rs
@@ -12,7 +12,7 @@
 use std::fs;
 use std::path::PathBuf;
 
-use crate::parallel_io::{ParallelThresholds, map_blocking};
+use crate::parallel_io::{ParallelOp, ParallelThresholds, map_blocking};
 
 /// Result of batched metadata resolution for a single directory entry.
 ///
@@ -40,7 +40,7 @@ pub(in crate::generator) fn batch_stat_dir_entries(
     follow_symlinks: bool,
     thresholds: &ParallelThresholds,
 ) -> Vec<StatResult> {
-    map_blocking(paths, thresholds.stat, move |path| {
+    map_blocking(paths, thresholds.for_op(ParallelOp::Stat), move |path| {
         let metadata = if follow_symlinks {
             fs::metadata(&path)
         } else {

--- a/crates/transfer/src/lib.rs
+++ b/crates/transfer/src/lib.rs
@@ -203,7 +203,7 @@ pub use delta_pipeline::{
 };
 pub use parallel_io::{
     DEFAULT_DELETION_THRESHOLD, DEFAULT_METADATA_THRESHOLD, DEFAULT_SIGNATURE_THRESHOLD,
-    DEFAULT_STAT_THRESHOLD, ParallelThresholds,
+    DEFAULT_STAT_THRESHOLD, ParallelOp, ParallelThresholds,
 };
 pub use pipeline::{
     DEFAULT_PIPELINE_WINDOW, MAX_PIPELINE_WINDOW, MIN_PIPELINE_WINDOW, PendingTransfer,

--- a/crates/transfer/src/parallel_io.rs
+++ b/crates/transfer/src/parallel_io.rs
@@ -32,6 +32,36 @@ pub const DEFAULT_METADATA_THRESHOLD: usize = 64;
 /// per-item cost is higher than a single stat call.
 pub const DEFAULT_DELETION_THRESHOLD: usize = 64;
 
+/// Per-operation cost classification driving threshold selection.
+///
+/// Each variant gates one rayon dual-path call site. The variant identity
+/// encodes the expected per-item cost profile - cheap syscalls dispatch
+/// at a higher item count than expensive CPU-bound work - so call sites
+/// look up the appropriate threshold by operation rather than reading
+/// a single global constant.
+///
+/// Cost estimates are documented per variant and reflect warm-cache local
+/// filesystem behaviour; networked filesystems shift the crossover upward
+/// (see `docs/audits/parallel-stat-batch-size-profile.md`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ParallelOp {
+    /// `lstat` / `stat` / quick-check probes. Cheap (~1 us warm, hundreds of
+    /// microseconds on NFS). Default crossover: [`DEFAULT_STAT_THRESHOLD`].
+    Stat,
+    /// Rolling + strong checksum signature generation over basis files.
+    /// Expensive (milliseconds per file). Default crossover:
+    /// [`DEFAULT_SIGNATURE_THRESHOLD`].
+    Signature,
+    /// `chmod` / `chown` / `utimes` / xattr / ACL application. Medium
+    /// (a few syscalls per directory). Default crossover:
+    /// [`DEFAULT_METADATA_THRESHOLD`].
+    Metadata,
+    /// `read_dir` + per-entry filter evaluation during `--delete` scans.
+    /// Medium (one `read_dir` plus per-entry stat). Default crossover:
+    /// [`DEFAULT_DELETION_THRESHOLD`].
+    Deletion,
+}
+
 /// Per-operation thresholds for switching between sequential and parallel execution.
 ///
 /// Different operations have different overhead profiles: CPU-bound signature
@@ -41,6 +71,10 @@ pub const DEFAULT_DELETION_THRESHOLD: usize = 64;
 ///
 /// All thresholds represent the minimum item count required to justify rayon
 /// thread-pool dispatch. Below the threshold, sequential iteration is used.
+///
+/// Call sites should prefer [`ParallelThresholds::for_op`] over direct field
+/// access so that adding a new operation only requires extending [`ParallelOp`]
+/// and this struct, not editing every dispatch site.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ParallelThresholds {
     /// Minimum file count for parallel `stat()` / `lstat()` calls.
@@ -65,32 +99,60 @@ impl Default for ParallelThresholds {
 }
 
 impl ParallelThresholds {
+    /// Returns the threshold configured for `op`.
+    ///
+    /// This is the preferred accessor for dispatch sites: it keeps the
+    /// per-operation mapping in one place, so call sites read as
+    /// `thresholds.for_op(ParallelOp::Stat)` rather than coupling to the
+    /// struct's field layout.
+    #[must_use]
+    pub const fn for_op(&self, op: ParallelOp) -> usize {
+        match op {
+            ParallelOp::Stat => self.stat,
+            ParallelOp::Signature => self.signature,
+            ParallelOp::Metadata => self.metadata,
+            ParallelOp::Deletion => self.deletion,
+        }
+    }
+
+    /// Returns a copy with `op`'s threshold replaced.
+    ///
+    /// Mirrors [`ParallelThresholds::for_op`] for the override side: tests
+    /// and call-site overrides set a single operation's value without
+    /// having to know which struct field backs it.
+    #[must_use]
+    pub const fn with_op(mut self, op: ParallelOp, threshold: usize) -> Self {
+        match op {
+            ParallelOp::Stat => self.stat = threshold,
+            ParallelOp::Signature => self.signature = threshold,
+            ParallelOp::Metadata => self.metadata = threshold,
+            ParallelOp::Deletion => self.deletion = threshold,
+        }
+        self
+    }
+
     /// Sets the stat threshold.
     #[must_use]
-    pub const fn with_stat(mut self, threshold: usize) -> Self {
-        self.stat = threshold;
-        self
+    pub const fn with_stat(self, threshold: usize) -> Self {
+        self.with_op(ParallelOp::Stat, threshold)
     }
 
     /// Sets the signature computation threshold.
     #[must_use]
-    pub const fn with_signature(mut self, threshold: usize) -> Self {
-        self.signature = threshold;
-        self
+    pub const fn with_signature(self, threshold: usize) -> Self {
+        self.with_op(ParallelOp::Signature, threshold)
     }
 
     /// Sets the metadata application threshold.
     #[must_use]
-    pub const fn with_metadata(mut self, threshold: usize) -> Self {
-        self.metadata = threshold;
-        self
+    pub const fn with_metadata(self, threshold: usize) -> Self {
+        self.with_op(ParallelOp::Metadata, threshold)
     }
 
     /// Sets the deletion scanning threshold.
     #[must_use]
-    pub const fn with_deletion(mut self, threshold: usize) -> Self {
-        self.deletion = threshold;
-        self
+    pub const fn with_deletion(self, threshold: usize) -> Self {
+        self.with_op(ParallelOp::Deletion, threshold)
     }
 }
 
@@ -211,6 +273,81 @@ mod tests {
         let items: Vec<i32> = (0..5).collect();
         let results = map_blocking(items, t.stat, |x| x * 2);
         assert_eq!(results, vec![0, 2, 4, 6, 8]);
+    }
+
+    #[test]
+    fn for_op_returns_documented_defaults() {
+        let t = ParallelThresholds::default();
+        assert_eq!(t.for_op(ParallelOp::Stat), DEFAULT_STAT_THRESHOLD);
+        assert_eq!(t.for_op(ParallelOp::Signature), DEFAULT_SIGNATURE_THRESHOLD);
+        assert_eq!(t.for_op(ParallelOp::Metadata), DEFAULT_METADATA_THRESHOLD);
+        assert_eq!(t.for_op(ParallelOp::Deletion), DEFAULT_DELETION_THRESHOLD);
+    }
+
+    #[test]
+    fn for_op_reflects_field_overrides() {
+        let t = ParallelThresholds::default()
+            .with_stat(128)
+            .with_signature(16)
+            .with_metadata(256)
+            .with_deletion(48);
+        assert_eq!(t.for_op(ParallelOp::Stat), 128);
+        assert_eq!(t.for_op(ParallelOp::Signature), 16);
+        assert_eq!(t.for_op(ParallelOp::Metadata), 256);
+        assert_eq!(t.for_op(ParallelOp::Deletion), 48);
+    }
+
+    #[test]
+    fn with_op_overrides_only_targeted_operation() {
+        let base = ParallelThresholds::default();
+        let stat_only = base.with_op(ParallelOp::Stat, 7);
+        assert_eq!(stat_only.for_op(ParallelOp::Stat), 7);
+        assert_eq!(
+            stat_only.for_op(ParallelOp::Signature),
+            DEFAULT_SIGNATURE_THRESHOLD
+        );
+        assert_eq!(
+            stat_only.for_op(ParallelOp::Metadata),
+            DEFAULT_METADATA_THRESHOLD
+        );
+        assert_eq!(
+            stat_only.for_op(ParallelOp::Deletion),
+            DEFAULT_DELETION_THRESHOLD
+        );
+
+        let chained = stat_only
+            .with_op(ParallelOp::Signature, 1)
+            .with_op(ParallelOp::Metadata, 2)
+            .with_op(ParallelOp::Deletion, 3);
+        assert_eq!(chained.for_op(ParallelOp::Stat), 7);
+        assert_eq!(chained.for_op(ParallelOp::Signature), 1);
+        assert_eq!(chained.for_op(ParallelOp::Metadata), 2);
+        assert_eq!(chained.for_op(ParallelOp::Deletion), 3);
+    }
+
+    #[test]
+    fn with_op_and_with_field_helpers_agree() {
+        let via_op = ParallelThresholds::default()
+            .with_op(ParallelOp::Stat, 11)
+            .with_op(ParallelOp::Signature, 12)
+            .with_op(ParallelOp::Metadata, 13)
+            .with_op(ParallelOp::Deletion, 14);
+        let via_field = ParallelThresholds::default()
+            .with_stat(11)
+            .with_signature(12)
+            .with_metadata(13)
+            .with_deletion(14);
+        assert_eq!(via_op, via_field);
+    }
+
+    #[test]
+    fn for_op_drives_map_blocking_dispatch() {
+        // Test override path: confirm `for_op` is a drop-in replacement for
+        // direct field access in the dispatch site contract.
+        let t = ParallelThresholds::default().with_op(ParallelOp::Stat, 0);
+        let items: Vec<i32> = (0..5).collect();
+        let results = map_blocking(items, t.for_op(ParallelOp::Stat), |x| x + 1);
+        assert_eq!(results, vec![1, 2, 3, 4, 5]);
     }
 
     /// Simulates a stat result paired with its original file list index.

--- a/crates/transfer/src/receiver/directory/creation.rs
+++ b/crates/transfer/src/receiver/directory/creation.rs
@@ -121,7 +121,8 @@ impl ReceiverContext {
         let acl_cache_clone = acl_cache.cloned();
         let results = crate::parallel_io::map_blocking(
             entry_snapshots,
-            self.parallel_thresholds.metadata,
+            self.parallel_thresholds
+                .for_op(crate::parallel_io::ParallelOp::Metadata),
             move |(dir_path, entry, xattr_list)| {
                 if let Err(e) =
                     apply_metadata_from_file_entry(&dir_path, &entry, &metadata_opts_clone)

--- a/crates/transfer/src/receiver/directory/deletion.rs
+++ b/crates/transfer/src/receiver/directory/deletion.rs
@@ -98,7 +98,8 @@ impl ReceiverContext {
         // after parallel deletion completes.
         let per_dir_results: Vec<(DeleteStats, Vec<PathBuf>)> = crate::parallel_io::map_blocking(
             dirs_to_scan,
-            self.parallel_thresholds.deletion,
+            self.parallel_thresholds
+                .for_op(crate::parallel_io::ParallelOp::Deletion),
             move |dir_relative| {
                 let dest_path = if dir_relative.as_os_str() == "." {
                     dest_dir_owned.clone()

--- a/crates/transfer/src/receiver/transfer/candidates.rs
+++ b/crates/transfer/src/receiver/transfer/candidates.rs
@@ -124,7 +124,8 @@ impl ReceiverContext {
         let stat_results: Vec<(usize, PathBuf, Option<fs::Metadata>)> =
             crate::parallel_io::map_blocking(
                 stat_paths,
-                self.parallel_thresholds.stat,
+                self.parallel_thresholds
+                    .for_op(crate::parallel_io::ParallelOp::Stat),
                 move |(idx, file_path)| {
                     let meta = fs::metadata(&file_path).ok();
                     (idx, file_path, meta)

--- a/crates/transfer/src/receiver/transfer/pipeline.rs
+++ b/crates/transfer/src/receiver/transfer/pipeline.rs
@@ -177,7 +177,9 @@ impl ReceiverContext {
                         let dest_dir = &setup.dest_dir;
                         let checksum_length = setup.checksum_length;
                         let checksum_algorithm = setup.checksum_algorithm;
-                        let sig_threshold = self.parallel_thresholds.signature;
+                        let sig_threshold = self
+                            .parallel_thresholds
+                            .for_op(crate::parallel_io::ParallelOp::Signature);
 
                         // Ordering: wire protocol requires file requests in file-list index order.
                         // Preserved by par_iter().map().collect() + sequential zip/send loop below.


### PR DESCRIPTION
## Summary
- Replaces direct field access on `ParallelThresholds` with a `ParallelOp` enum plus `for_op()` / `with_op()` accessors so dispatch sites read `thresholds.for_op(ParallelOp::Stat)` instead of coupling to the struct's field layout.
- Defaults preserved (stat=64, signature=32, metadata=64, deletion=64). Existing `with_stat` / `with_signature` / `with_metadata` / `with_deletion` builders delegate to `with_op` so call sites and tests need no migration.
- Updates the five production dispatch sites: generator batch stat, receiver candidate stat, receiver signature dispatch, receiver metadata apply, receiver deletion scan.

## Context
Closes #1554. Extends the per-workload sizing precedent set by the adaptive work-queue capacity change (PR #4012, `engine::concurrent_delta::work_queue::capacity`) from delta dispatch to all rayon dual-path call sites: stat, signature, metadata, deletion. Aligns with the design note at `docs/design/per-op-adaptive-thresholds.md` and the profiling plan at `docs/audits/parallel-stat-batch-size-profile.md`.

## Test plan
- [ ] `cargo nextest run -p transfer --all-features -E 'test(parallel)'`
- [ ] `cargo nextest run -p transfer --all-features -E 'test(thresholds)'`
- [ ] `cargo nextest run -p transfer --all-features -E 'test(for_op)'`
- [ ] CI: fmt+clippy, nextest (stable), Windows, macOS, Linux musl