### PR TITLE
fix(metadata): make --copy-as fail loudly on Windows (#2175)

### DIFF
--- a/crates/metadata/Cargo.toml
+++ b/crates/metadata/Cargo.toml
@@ -35,6 +35,8 @@ apple-fs = { path = "../apple-fs" }
 
 # Windows ACL support via Win32 GetSecurityInfo/SetSecurityInfo.
 # Mirrors upstream rsync acls.c semantics over NTFS DACLs.
+# Win32_System_Threading is required for OpenProcessToken/GetCurrentProcess
+# used by the --copy-as privilege probe in copy_as.rs.
 [target.'cfg(windows)'.dependencies]
 windows = { version = "0.62", features = [
     "Win32_Foundation",
@@ -42,6 +44,7 @@ windows = { version = "0.62", features = [
     "Win32_Security_Authorization",
     "Win32_Storage_FileSystem",
     "Win32_System_SystemServices",
+    "Win32_System_Threading",
 ] }
 
 [features]

--- a/crates/metadata/src/copy_as.rs
+++ b/crates/metadata/src/copy_as.rs
@@ -132,6 +132,7 @@ fn resolve_group_by_name(name: &str) -> io::Result<u32> {
 /// errors from `Drop`; however, if the original identity cannot be restored,
 /// subsequent file operations will use the switched identity.
 #[cfg(unix)]
+#[derive(Debug)]
 pub struct CopyAsGuard {
     original_euid: u32,
     original_egid: u32,
@@ -238,6 +239,7 @@ pub fn switch_effective_ids(ids: &CopyAsIds) -> io::Result<CopyAsGuard> {
 /// and downstream callers can hold an `Option<CopyAsGuard>` without
 /// `cfg`-gating their own code.
 #[cfg(not(unix))]
+#[derive(Debug)]
 pub struct CopyAsGuard {
     _private: (),
 }

--- a/crates/metadata/src/copy_as.rs
+++ b/crates/metadata/src/copy_as.rs
@@ -13,7 +13,16 @@
 //! - **Unix**: Uses `seteuid(2)` / `setegid(2)` via libc. Requires the
 //!   process to be running as root (euid 0) or to possess `CAP_SETUID` /
 //!   `CAP_SETGID`.
-//! - **Non-Unix**: Provides no-op stubs that log a warning and succeed.
+//! - **Windows**: Returns a descriptive `Unsupported` error. The POSIX
+//!   `--copy-as=USER` flow takes no password and assumes the process can
+//!   change effective identity without one (root or a `CAP_SETUID`
+//!   capability). The Win32 equivalent is `LogonUserW` +
+//!   `ImpersonateLoggedOnUser`, which generally requires either a
+//!   password (not exposed by `--copy-as`) or `SeTcbPrivilege` /
+//!   `SeImpersonatePrivilege` plus an S4U logon. We surface a clear
+//!   error rather than silently dropping the option; full token
+//!   impersonation is tracked as a follow-up.
+//! - **Other non-Unix**: Returns `Unsupported`.
 //!
 //! # Upstream Reference
 //!
@@ -221,22 +230,159 @@ pub fn switch_effective_ids(ids: &CopyAsIds) -> io::Result<CopyAsGuard> {
     })
 }
 
-/// No-op guard for non-Unix platforms.
+/// Placeholder guard for non-Unix platforms.
 ///
-/// Since effective UID/GID switching is not supported outside Unix, this
-/// guard does nothing on construction or drop.
+/// On Windows and other non-Unix targets, [`switch_effective_ids`] currently
+/// fails before any switch occurs, so this struct is never constructed at
+/// runtime. It exists so the public type alias compiles on every platform
+/// and downstream callers can hold an `Option<CopyAsGuard>` without
+/// `cfg`-gating their own code.
 #[cfg(not(unix))]
 pub struct CopyAsGuard {
     _private: (),
 }
 
-/// No-op privilege switch for non-Unix platforms.
+/// Attempts to switch the calling process identity on Windows.
 ///
-/// Always succeeds and returns a no-op guard. The `--copy-as` option has
-/// no effect on non-Unix platforms.
-#[cfg(not(unix))]
+/// The POSIX `--copy-as` contract is "drop to USER[:GROUP] without a
+/// password". On Windows this maps to `LogonUserW` +
+/// `ImpersonateLoggedOnUser`, which either needs the target user's
+/// password (not exposed by the CLI flag) or `SeTcbPrivilege` /
+/// `SeImpersonatePrivilege` plus an S4U logon. Until the
+/// `CopyAsIds`-driven impersonation flow is wired through to the
+/// `platform::privilege::drop_privileges_windows` helper, this function
+/// probes the calling process token for `SeImpersonatePrivilege` and
+/// returns a descriptive error in both branches so users see a loud
+/// failure instead of a silent no-op.
+///
+/// # Errors
+///
+/// - `ErrorKind::PermissionDenied` when the process token lacks
+///   `SeImpersonatePrivilege`.
+/// - `ErrorKind::Unsupported` when the privilege is present (token
+///   impersonation flow is not yet wired to this entry point).
+/// - Lower-level `io::Error::other` if the probe itself fails
+///   (for example, `OpenProcessToken` returns an error).
+///
+/// # Upstream Reference
+///
+/// - `rsync.c:do_as_root()` - POSIX equivalent that this routine mirrors.
+#[cfg(windows)]
+#[allow(unsafe_code)]
 pub fn switch_effective_ids(_ids: &CopyAsIds) -> io::Result<CopyAsGuard> {
-    Ok(CopyAsGuard { _private: () })
+    if has_impersonate_privilege()? {
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "--copy-as on Windows requires LogonUserW + ImpersonateLoggedOnUser \
+             token impersonation, which is not yet wired. The calling process \
+             has SeImpersonatePrivilege; rerun the transfer on a Unix host or \
+             track the follow-up for S4U logon support.",
+        ))
+    } else {
+        Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "--copy-as on Windows requires SeImpersonatePrivilege (or a \
+             password-based LogonUserW flow, which --copy-as does not \
+             accept). Grant the privilege via secpol.msc -> Local Policies \
+             -> User Rights Assignment -> 'Impersonate a client after \
+             authentication', or rerun the transfer on a Unix host.",
+        ))
+    }
+}
+
+/// Probes the calling process token for `SeImpersonatePrivilege`.
+///
+/// Returns `Ok(true)` when the privilege is present and enabled or
+/// enabled-by-default, `Ok(false)` when absent, or an `io::Error`
+/// wrapping the last OS error when the Win32 calls fail.
+///
+/// # Safety
+///
+/// Each `unsafe` block here calls a well-documented Win32 API exactly
+/// once with locally owned, correctly aligned out-pointers. The token
+/// handle is closed via the `CloseHandleGuard` RAII helper so the
+/// privilege probe is leak-free even on error paths.
+#[cfg(windows)]
+#[allow(unsafe_code)]
+fn has_impersonate_privilege() -> io::Result<bool> {
+    use windows::Win32::Foundation::{CloseHandle, HANDLE, LUID};
+    use windows::Win32::Security::{
+        LUID_AND_ATTRIBUTES, LookupPrivilegeValueW, PRIVILEGE_SET, PrivilegeCheck,
+        SE_IMPERSONATE_NAME, SE_PRIVILEGE_ENABLED, TOKEN_QUERY,
+    };
+    use windows::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
+    use windows::core::{BOOL, PCWSTR};
+
+    // Win32 `PRIVILEGE_SET.Control` flag: require every listed privilege
+    // to be held. The constant is not exported as a named symbol by the
+    // `windows` crate (winnt.h `PRIVILEGE_SET_ALL_NECESSARY` == 1).
+    const PRIVILEGE_SET_ALL_NECESSARY: u32 = 1;
+
+    // RAII wrapper that closes the process token on drop, including
+    // when an early `?` propagates an error.
+    struct CloseHandleGuard(HANDLE);
+    impl Drop for CloseHandleGuard {
+        fn drop(&mut self) {
+            if !self.0.is_invalid() {
+                // SAFETY: the handle came from OpenProcessToken and is
+                // still valid until this Drop runs.
+                unsafe {
+                    let _ = CloseHandle(self.0);
+                }
+            }
+        }
+    }
+
+    let mut token = HANDLE::default();
+    // SAFETY: GetCurrentProcess returns a pseudo-handle that does not
+    // require closing. OpenProcessToken writes the real token handle
+    // into `token`, which we then own and close via the RAII guard.
+    unsafe {
+        OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut token)
+            .map_err(|err| io::Error::other(format!("OpenProcessToken failed: {err}")))?;
+    }
+    let _token_guard = CloseHandleGuard(token);
+
+    // Resolve the SeImpersonatePrivilege LUID on the local system.
+    let mut luid = LUID::default();
+    // SAFETY: SE_IMPERSONATE_NAME is a static null-terminated wide
+    // string from the `windows` crate; PCWSTR::null() requests the
+    // local system; `luid` is a local out-parameter we own.
+    unsafe {
+        LookupPrivilegeValueW(PCWSTR::null(), SE_IMPERSONATE_NAME, &mut luid)
+            .map_err(|err| io::Error::other(format!("LookupPrivilegeValueW failed: {err}")))?;
+    }
+
+    let mut privilege_set = PRIVILEGE_SET {
+        PrivilegeCount: 1,
+        Control: PRIVILEGE_SET_ALL_NECESSARY,
+        Privilege: [LUID_AND_ATTRIBUTES {
+            Luid: luid,
+            Attributes: SE_PRIVILEGE_ENABLED,
+        }],
+    };
+    let mut result = BOOL(0);
+    // SAFETY: `token` is a valid TOKEN_QUERY handle (kept alive by the
+    // RAII guard); `privilege_set` is a properly initialised
+    // single-entry structure we own; `result` is a local BOOL we own.
+    unsafe {
+        PrivilegeCheck(token, &mut privilege_set, &mut result)
+            .map_err(|err| io::Error::other(format!("PrivilegeCheck failed: {err}")))?;
+    }
+
+    Ok(result.0 != 0)
+}
+
+/// Privilege switch for non-Unix, non-Windows targets.
+///
+/// Returns `Unsupported` so callers surface a loud error instead of
+/// silently dropping `--copy-as`.
+#[cfg(not(any(unix, windows)))]
+pub fn switch_effective_ids(_ids: &CopyAsIds) -> io::Result<CopyAsGuard> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "--copy-as is not supported on this platform",
+    ))
 }
 
 #[cfg(not(unix))]
@@ -392,23 +538,51 @@ mod tests {
         assert_eq!(resolve_user("root").unwrap(), 0);
     }
 
-    #[cfg(not(unix))]
+    #[cfg(windows)]
     #[test]
-    fn non_unix_switch_returns_noop_guard() {
+    fn windows_switch_returns_descriptive_error() {
+        // The probe inspects the calling process token. CI runners
+        // typically do not hold SeImpersonatePrivilege, so the error
+        // should be PermissionDenied. Elevated runners may instead
+        // hit the Unsupported branch. Accept either outcome and
+        // assert the error message names the missing capability.
         let ids = CopyAsIds {
             uid: 1000,
             gid: Some(1000),
         };
-        let guard = switch_effective_ids(&ids);
-        assert!(guard.is_ok());
+        let err = switch_effective_ids(&ids).unwrap_err();
+        assert!(
+            matches!(
+                err.kind(),
+                io::ErrorKind::PermissionDenied | io::ErrorKind::Unsupported
+            ),
+            "unexpected error kind {:?}: {err}",
+            err.kind()
+        );
+        let msg = err.to_string();
+        assert!(
+            msg.contains("--copy-as"),
+            "error message should mention --copy-as: {msg}"
+        );
     }
 
-    #[cfg(not(unix))]
+    #[cfg(windows)]
     #[test]
-    fn non_unix_switch_without_group_returns_noop_guard() {
+    fn windows_switch_without_group_returns_error() {
         let ids = CopyAsIds { uid: 0, gid: None };
-        let guard = switch_effective_ids(&ids);
-        assert!(guard.is_ok());
+        let err = switch_effective_ids(&ids).unwrap_err();
+        assert!(matches!(
+            err.kind(),
+            io::ErrorKind::PermissionDenied | io::ErrorKind::Unsupported
+        ));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_privilege_probe_does_not_panic() {
+        // Whatever the answer, the probe must complete without panicking
+        // and without leaking the process token.
+        let _ = has_impersonate_privilege().expect("privilege probe should succeed");
     }
 
     #[cfg(not(unix))]
@@ -439,17 +613,5 @@ mod tests {
         let spec = OsString::from("0:wheel");
         let err = parse_copy_as_spec(&spec).unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::Unsupported);
-    }
-
-    #[cfg(not(unix))]
-    #[test]
-    fn non_unix_guard_drop_is_noop() {
-        let ids = CopyAsIds {
-            uid: 1000,
-            gid: Some(1000),
-        };
-        let guard = switch_effective_ids(&ids).unwrap();
-        drop(guard);
-        // No panic or side effects from drop
     }
 }

--- a/docs/audits/cli-argument-parity-vs-rsync-manpage.md
+++ b/docs/audits/cli-argument-parity-vs-rsync-manpage.md
@@ -171,7 +171,7 @@ form is from the same `0. \`--flag\`, \`-x\`` line in the man page.
 | `--old-args` | - | yes | yes | rsync.1.md:2440 | command_builder/sections |
 | `--secluded-args` | `-s` | yes | yes | rsync.1.md:2472 | build_base_command/network.rs:61 (`--protect-args` + alias `secluded-args`) |
 | `--trust-sender` | - | yes | yes | rsync.1.md:2511 | build_base_command/privileges.rs:39 |
-| `--copy-as=USER[:GROUP]` | - | yes | **PARTIAL** | rsync.1.md:2547 | transfer_behavior_options.rs:597 (no-op on Windows; see metadata/src/copy_as.rs:237) |
+| `--copy-as=USER[:GROUP]` | - | yes | **PARTIAL** | rsync.1.md:2547 | transfer_behavior_options.rs:597 (Windows returns a descriptive error from `switch_effective_ids` until `LogonUserW` impersonation is wired through `CopyAsIds`; see metadata/src/copy_as.rs:270) |
 | `--temp-dir=DIR` | `-T` | yes | yes | rsync.1.md:2586 | transfer_behavior_options.rs:15 (alias `--tmp-dir`) |
 | `--fuzzy` | `-y` | yes | yes | rsync.1.md:2622 | build_base_command/transfer.rs:233 |
 | `--compare-dest=DIR` | - | yes | yes | rsync.1.md:2638 | command_builder/sections |
@@ -250,7 +250,7 @@ platform.
 
 | option | what works | gap | severity | follow-up |
 |--------|-----------|-----|----------|-----------|
-| `--copy-as=USER[:GROUP]` | POSIX `setuid`/`setgid` switching on Linux, macOS, BSD via `crates/metadata/src/copy_as.rs:48-222`. Spec parsing and validation succeed on every platform. | On Windows the guard is a no-op (`crates/metadata/src/copy_as.rs:228-240`). Token impersonation through `LogonUserW` + `ImpersonateLoggedOnUser` is not wired, so the flag silently has no effect on Windows receivers. | rare (Windows-only edge case; receiver-side privilege drop) | gate behind `windows-rs` token APIs; emit a startup warning instead of silent no-op |
+| `--copy-as=USER[:GROUP]` | POSIX `setuid`/`setgid` switching on Linux, macOS, BSD via `crates/metadata/src/copy_as.rs:48-222`. Spec parsing and validation succeed on every platform. On Windows, `switch_effective_ids` probes the calling process token for `SeImpersonatePrivilege` and returns a descriptive `io::Error` (`PermissionDenied` when the privilege is absent, `Unsupported` when present), turning the previous silent no-op into a loud failure (`crates/metadata/src/copy_as.rs:270-290`). | Token impersonation through `LogonUserW` + `ImpersonateLoggedOnUser` is still not wired through `CopyAsIds` (the building block already exists in `crates/platform/src/privilege.rs:142`), so the flag cannot drive an actual identity switch on Windows yet. | rare (Windows-only edge case; receiver-side privilege drop) | thread `CopyAsIds` (or account name) through `platform::privilege::drop_privileges_windows` and replace the descriptive error with a real impersonation flow |
 | `--skip-compress=LIST` | Argument is parsed and stored in `core::client::config` (`connection_and_logging_options.rs:106`). Forwarded over the wire to the remote peer for compatibility. | Per-file codec switching is a no-op in upstream rsync 3.4.1 itself (man-page line 2822: "no compression method currently supports per-file compression changes, so this option has no effect"). oc-rsync mirrors the no-op intentionally to stay wire-compatible. | not user-visible (matches upstream) | None - revisit only if upstream introduces per-file codec switching |
 
 ## EXTRA options (oc-only)
@@ -298,11 +298,13 @@ There are no missing options. The five highest-impact follow-ups are
 PARTIAL gap closures and parity polish identified during this audit:
 
 1. **`--copy-as` Windows token impersonation (PARTIAL).**
-   Wire `LogonUserW` + `ImpersonateLoggedOnUser` through the `windows`
-   crate in `crates/metadata/src/copy_as.rs:228-240`. Until then, emit
-   a startup warning on Windows when `--copy-as` is supplied so users
-   are not silently surprised. User impact: **rare**, but failure mode
-   is silent on a major platform.
+   The Windows path no longer silently succeeds: `switch_effective_ids`
+   probes the calling process token for `SeImpersonatePrivilege` and
+   returns a descriptive `io::Error` (`crates/metadata/src/copy_as.rs:270-290`).
+   The remaining work is to thread the resolved account through
+   `crates/platform/src/privilege.rs:142` (which already implements
+   `LogonUserW` + `ImpersonateLoggedOnUser`) so the flag drives a real
+   identity switch on Windows. User impact: **rare** (Windows-only).
 
 2. **Help-output byte parity for `-a` parenthetical.**
    Upstream's `--help` ends the `-a` line with `(no -A,-X,-U,-N,-H)`.


### PR DESCRIPTION
## Summary

Previously, `--copy-as=USER[:GROUP]` was a **silent no-op** on Windows. `switch_effective_ids` in `crates/metadata/src/copy_as.rs` returned an immediate no-op guard on non-Unix targets, so the flag appeared to succeed while the receiver kept running under the caller's identity.

This PR converts the silent no-op into a **loud, descriptive error** on Windows, per the C1 remediation target in the CLI parity audit (#2175, ranked top in `docs/audits/cli-argument-parity-vs-rsync-manpage.md`).

The implementation:

- Adds a `#[cfg(windows)]` `switch_effective_ids` that probes the calling process token for `SeImpersonatePrivilege` via `OpenProcessToken` + `LookupPrivilegeValueW` + `PrivilegeCheck`, using the `windows` 0.62 crate.
- Returns `io::ErrorKind::PermissionDenied` when the privilege is absent, with `secpol.msc` guidance for granting it.
- Returns `io::ErrorKind::Unsupported` when the privilege is present, noting that the `LogonUserW` + `ImpersonateLoggedOnUser` flow is not yet wired through `CopyAsIds`. The lower-level Win32 building block already exists in `crates/platform/src/privilege.rs:142` (`windows_impersonate`), so the follow-up is to thread the resolved account through that helper.
- Splits the previous `#[cfg(not(unix))]` block into a Windows-specific path and a `#[cfg(not(any(unix, windows)))]` fallback that also returns `Unsupported` rather than silently succeeding.
- Adds three Windows-only unit tests exercising both error branches and the privilege probe directly.
- Pulls `Win32_System_Threading` into the `metadata` crate's `windows-rs` feature list for `OpenProcessToken` / `GetCurrentProcess`.
- Refreshes the CLI parity audit row so the PARTIAL state for `--copy-as` reflects the new loud-failure semantics.

All `unsafe` blocks live in the `metadata` crate (already on the allow-list per the project's unsafe policy) and carry SAFETY comments. The token handle is closed via an RAII `CloseHandleGuard` so the probe is leak-free even on the error paths.

This is the **Option C** first PR from the task description: deliver user-visible behavior on Windows (a clear error vs silent no-op) without committing to a particular privilege model. **Option A/B** (actual S4U-based impersonation or password-less `LsaLogonUser`) is left as a follow-up, tracked by the existing entry in `docs/audits/cli-argument-parity-vs-rsync-manpage.md`.

## Related

- Task #2175 (C1 from PR #4032 CLI parity audit).
- `docs/audits/cli-argument-parity-vs-rsync-manpage.md` (PARTIAL row + remediation list updated in this PR).

## Test plan

- [x] `cargo fmt --all -- --check` passes.
- [ ] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` (CI).
- [ ] Linux nextest (CI, stable) - confirms Unix path still compiles and existing tests pass.
- [ ] Windows nextest (CI, stable) - confirms the new Windows path compiles and the new `windows_switch_returns_descriptive_error`, `windows_switch_without_group_returns_error`, and `windows_privilege_probe_does_not_panic` tests pass.
- [ ] macOS nextest (CI, stable) - confirms the `#[cfg(not(any(unix, windows)))]` fallback does not interfere (macOS is `unix`).
- [ ] Linux musl (CI, stable).