### PR TITLE
feat: add top-level cargo-fuzz harness for protocol wire parser

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -163,6 +163,7 @@ members = [
 ]
 exclude = [
     "crates/protocol/fuzz",
+    "fuzz",
     "tools/dhat-profile",
 ]
 resolver = "2"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "oc-rsync-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2024"
+rust-version = "1.88"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+
+[dependencies.protocol]
+path = "../crates/protocol"
+
+[[bin]]
+name = "protocol_wire"
+path = "fuzz_targets/protocol_wire.rs"
+test = false
+doc = false
+bench = false
+
+# Standalone workspace - excluded from the root workspace so that
+# `cargo build` does not pull libfuzzer-sys into ordinary builds.
+[workspace]

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -1,0 +1,70 @@
+# oc-rsync Fuzz Harnesses
+
+Top-level [cargo-fuzz](https://github.com/rust-fuzz/cargo-fuzz) workspace for
+the parts of oc-rsync that consume bytes from untrusted peers. The protocol
+parser sits behind every network connection, so any panic uncovered here is a
+potential remote denial-of-service vector at minimum.
+
+A per-crate fuzz workspace also exists at `crates/protocol/fuzz/` with more
+specialised targets (varint, delta, legacy greeting). The harness in this
+directory is the recommended starting point for new contributors and for CI
+integration.
+
+## Prerequisites
+
+```bash
+rustup toolchain install nightly
+cargo install cargo-fuzz
+```
+
+`cargo-fuzz` requires nightly Rust because it links against libFuzzer using
+unstable compiler flags.
+
+## Available targets
+
+| Target          | Entry point                                          |
+| --------------- | ---------------------------------------------------- |
+| `protocol_wire` | `protocol::BorrowedMessageFrames` (multiplex frames) |
+
+## Running
+
+From the repository root:
+
+```bash
+cargo +nightly fuzz run protocol_wire
+```
+
+Useful flags:
+
+```bash
+# Cap a single run at 60 seconds (handy for smoke checks).
+cargo +nightly fuzz run protocol_wire -- -max_total_time=60
+
+# Run with a corpus directory of seed inputs.
+mkdir -p fuzz/corpus/protocol_wire
+cargo +nightly fuzz run protocol_wire fuzz/corpus/protocol_wire
+```
+
+Crashes are written to `fuzz/artifacts/protocol_wire/`. Reproduce a crash by
+re-running the target with the artifact path appended.
+
+## Adding more targets
+
+Drop a new file into `fuzz/fuzz_targets/` and add a matching `[[bin]]` entry
+in `fuzz/Cargo.toml`. Keep targets minimal: a `fuzz_target!` block that hands
+the input slice to a single public parser function is enough. libFuzzer's
+coverage-guided search takes care of reaching deeper code paths.
+
+Good candidates for future targets:
+
+- File list decoding (`protocol::flist`)
+- Filter rule parsing (`protocol::filters`)
+- Varint and varlong decoders
+- ACL and xattr wire decoders
+
+## Workspace integration
+
+The `fuzz/` crate is intentionally not part of the root Cargo workspace.
+`libfuzzer-sys` requires nightly-only linker flags and would otherwise break
+`cargo build` for ordinary contributors. It is listed under `workspace.exclude`
+in the root `Cargo.toml`.

--- a/fuzz/fuzz_targets/protocol_wire.rs
+++ b/fuzz/fuzz_targets/protocol_wire.rs
@@ -1,0 +1,33 @@
+#![no_main]
+
+//! Top-level fuzz target for the rsync wire protocol parser.
+//!
+//! Feeds arbitrary bytes from libFuzzer into the highest-level multiplex
+//! frame decoder. The decoder accepts untrusted bytes from network peers,
+//! so any panic discovered here represents a potential remote attack
+//! surface. Coverage-guided exploration takes care of fanning the input
+//! out across the underlying header, payload-length, and message-code
+//! validation paths.
+//!
+//! Additional targets (varint, file list, delta, filter rules, ...)
+//! belong in sibling files under `fuzz/fuzz_targets/`.
+
+use libfuzzer_sys::fuzz_target;
+
+use protocol::BorrowedMessageFrames;
+
+fuzz_target!(|data: &[u8]| {
+    // Walk every frame in the buffer so libFuzzer explores both the
+    // single-frame and multi-frame parser states. Errors are expected on
+    // malformed input - only panics constitute a finding.
+    for frame in BorrowedMessageFrames::new(data) {
+        match frame {
+            Ok(frame) => {
+                let _ = frame.code();
+                let _ = frame.payload_len();
+                let _ = frame.payload();
+            }
+            Err(_) => break,
+        }
+    }
+});


### PR DESCRIPTION
## Summary

- Scaffolds a top-level `fuzz/` crate following the canonical cargo-fuzz layout, with a single minimal target (`protocol_wire`) that drives `protocol::BorrowedMessageFrames` against arbitrary bytes from libFuzzer.
- The multiplex frame decoder is the highest-level entry point that consumes bytes from network peers, so coverage-guided exploration fans out into header validation, payload-length checks, and message-code decoding without needing per-path harnesses.
- Excludes the fuzz crate from the root workspace so `libfuzzer-sys` does not leak into ordinary `cargo build` runs. A complementary `crates/protocol/fuzz/` workspace already ships specialised targets (varint, delta, legacy greeting); the new top-level harness is the recommended starting point for new contributors and for CI integration.

## Motivation

The protocol parser handles untrusted bytes from network peers. A malformed packet from a hostile sender could exploit a parser bug. Upstream rsync ships no published fuzzing harness despite the same attack surface, so adding one on the Rust side is a clear hardening win. This PR sets up the scaffold; actual long-running fuzz campaigns and corpus seeding are tracked separately.

## Follow-up work

- #1195 - seed an adversarial corpus
- #1291 - filter rule fuzz target
- #1293 - 24h sustained fuzz run in CI
- #1304 - dedicated wire-format fuzz target
- #2103 - SIMD parity fuzz target

## Test plan

- [ ] `cargo +nightly fuzz run protocol_wire -- -max_total_time=60` smoke-runs cleanly locally
- [ ] `cargo build --workspace` still succeeds (fuzz crate is excluded from the root workspace)
- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings`