### PR TITLE
feat: reject --append with --whole-file at config build time

### DIFF
--- a/crates/cli/tests/mutually_exclusive_options.rs
+++ b/crates/cli/tests/mutually_exclusive_options.rs
@@ -230,3 +230,39 @@ fn test_multiple_usermap_concatenation_preserves_order() {
     let args = result.expect("multiple --usermap should succeed");
     assert_eq!(args.usermap, Some("a:b,c:d".into()));
 }
+
+#[test]
+fn test_append_and_whole_file_rejected() {
+    // upstream: options.c:2382 - --append cannot be used with --whole-file.
+    // Both flags parse cleanly individually; the conflict surfaces at config
+    // build time and is reported through the rsync syntax-error path
+    // (exit code 1).
+    let mut stdout = Vec::new();
+    let mut stderr = Vec::new();
+    let code = cli::run(
+        ["oc-rsync", "--append", "--whole-file", "src", "dest"],
+        &mut stdout,
+        &mut stderr,
+    );
+
+    assert_eq!(code, 1, "expected RERR_SYNTAX (exit code 1)");
+    let stderr_text = String::from_utf8_lossy(&stderr);
+    assert!(
+        stderr_text.contains("--append") && stderr_text.contains("--whole-file"),
+        "stderr should name both conflicting flags, got: {stderr_text}"
+    );
+    assert!(
+        stderr_text.contains("cannot be used with"),
+        "stderr should use upstream phrasing, got: {stderr_text}"
+    );
+}
+
+#[test]
+fn test_append_and_no_whole_file_accepted() {
+    // The companion `--no-whole-file` form must remain accepted.
+    let result = parse_args(["oc-rsync", "--append", "--no-whole-file", "src", "dest"]);
+    assert!(
+        result.is_ok(),
+        "--append --no-whole-file should parse without conflict"
+    );
+}

--- a/crates/core/src/client/config/builder/mod.rs
+++ b/crates/core/src/client/config/builder/mod.rs
@@ -273,7 +273,19 @@ impl ClientConfigBuilder {
     /// - `--inplace` conflicts with `--partial-dir` and `--delay-updates`
     /// - `--append` conflicts with `--partial-dir` and `--delay-updates`
     ///   (upstream: `--append` sets `inplace = 1`, then the `inplace && partial_dir` check fires)
+    /// - `--append` conflicts with `--whole-file`
+    ///   (upstream: options.c:2382 `if (append_mode) { if (whole_file > 0) ... }`)
     pub fn validate(&self) -> Result<(), ConfigConflict> {
+        // upstream: options.c:2382 - --append cannot be used with --whole-file.
+        // Only an explicit `--whole-file` (Some(true)) conflicts; the default
+        // (None) and `--no-whole-file` (Some(false)) are accepted.
+        if self.append && self.whole_file == Some(true) {
+            return Err(ConfigConflict {
+                option1: "append",
+                option2: "whole-file",
+            });
+        }
+
         let is_inplace = self.inplace || self.append;
         if is_inplace {
             let mode = if self.append { "append" } else { "inplace" };

--- a/crates/core/src/client/config/builder/tests.rs
+++ b/crates/core/src/client/config/builder/tests.rs
@@ -1092,6 +1092,30 @@ fn validate_append_with_delay_updates_conflicts() {
 }
 
 #[test]
+fn validate_append_with_whole_file_conflicts() {
+    // upstream: options.c:2382 - --append cannot be used with --whole-file.
+    let b = builder().append(true).whole_file(true);
+    let err = b.validate().unwrap_err();
+    assert_eq!(err.option1, "append");
+    assert_eq!(err.option2, "whole-file");
+    assert_eq!(err.to_string(), "--append cannot be used with --whole-file");
+}
+
+#[test]
+fn validate_append_with_no_whole_file_ok() {
+    // Explicit `--no-whole-file` is the upstream-compatible companion to --append.
+    let b = builder().append(true).whole_file(false);
+    assert!(b.validate().is_ok());
+}
+
+#[test]
+fn validate_append_without_explicit_whole_file_ok() {
+    // Default (None) leaves auto-detection in place and does not conflict.
+    let b = builder().append(true);
+    assert!(b.validate().is_ok());
+}
+
+#[test]
 fn validate_inplace_without_conflicts_ok() {
     let b = builder().inplace(true);
     assert!(b.validate().is_ok());

--- a/crates/engine/src/local_copy/options/builder/tests.rs
+++ b/crates/engine/src/local_copy/options/builder/tests.rs
@@ -603,6 +603,40 @@ mod validation {
     }
 
     #[test]
+    fn append_and_whole_file_conflict() {
+        // upstream: options.c:2382 - --append cannot be used with --whole-file.
+        let result = LocalCopyOptionsBuilder::new()
+            .append(true)
+            .whole_file(true)
+            .build();
+
+        assert!(matches!(
+            result,
+            Err(BuilderError::ConflictingOptions {
+                option1: "append",
+                option2: "whole_file"
+            })
+        ));
+    }
+
+    #[test]
+    fn append_with_no_whole_file_ok() {
+        // Explicit `--no-whole-file` is the upstream-compatible companion to --append.
+        let result = LocalCopyOptionsBuilder::new()
+            .append(true)
+            .whole_file(false)
+            .build();
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn append_with_default_whole_file_ok() {
+        // Unset whole_file (None) leaves auto-detection to the engine.
+        let result = LocalCopyOptionsBuilder::new().append(true).build();
+        assert!(result.is_ok());
+    }
+
+    #[test]
     fn build_unchecked_skips_validation() {
         let options = LocalCopyOptionsBuilder::new()
             .size_only(true)

--- a/crates/engine/src/local_copy/options/builder/validation.rs
+++ b/crates/engine/src/local_copy/options/builder/validation.rs
@@ -21,6 +21,16 @@ impl LocalCopyOptionsBuilder {
             });
         }
 
+        // upstream: options.c:2382 - --append cannot be used with --whole-file.
+        // Only an explicit `whole_file = Some(true)` conflicts; the default
+        // (None) and `--no-whole-file` (Some(false)) are accepted.
+        if self.append && self.whole_file == Some(true) {
+            return Err(BuilderError::ConflictingOptions {
+                option1: "append",
+                option2: "whole_file",
+            });
+        }
+
         if let (Some(min), Some(max)) = (self.min_file_size, self.max_file_size) {
             if min > max {
                 return Err(BuilderError::InvalidCombination {


### PR DESCRIPTION
## Summary

- Upstream rsync (`options.c:2382`) rejects `--append --whole-file` at parse time with `RERR_SYNTAX` (exit code 1) and the message `--append cannot be used with --whole-file`. oc-rsync was silently accepting the combination, then producing inconsistent behavior at transfer time depending on which layer was reached first.
- Add the mutual-exclusion check to both validation layers that gate config construction so the conflict is rejected before any work begins:
  - `ClientConfigBuilder::validate` (core) - the primary path the CLI uses; surfaces a `ConfigConflict` whose `Display` matches upstream wording exactly.
  - `LocalCopyOptionsBuilder::validate` (engine) - keeps the engine-level builder in sync so programmatic embedders also reject the combination.
- Only an explicit `--whole-file` (`Some(true)`) conflicts; the default (`None`) and `--no-whole-file` (`Some(false)`) remain accepted so existing call sites that set the tri-state from auto-detection are unaffected.

## Motivation

Audit follow-up tasks #2145, #2146, #2147 flagged that the `--append --whole-file` combination must be rejected at config build time to mirror upstream rsync's syntax check (`options.c:2382`, function `parse_arguments`). Silent acceptance produced upstream-incompatible behaviour and made transfer-time diagnostics confusing.

## Test plan

- [x] `cargo fmt --all -- --check`
- [ ] `crates/engine/.../builder/tests.rs::append_and_whole_file_conflict` and the two accept-path tests (`append_with_no_whole_file_ok`, `append_with_default_whole_file_ok`).
- [ ] `crates/core/.../builder/tests.rs::validate_append_with_whole_file_conflicts` plus the accept-path companions; the error-string assertion locks the exact upstream wording.
- [ ] `crates/cli/tests/mutually_exclusive_options.rs::test_append_and_whole_file_rejected` drives `cli::run`, asserts exit code 1, and confirms the diagnostic names both flags using upstream phrasing.
- [ ] CI: fmt+clippy, nextest (stable), Windows, macOS, Linux musl.