### PR TITLE
refactor: promote --delay-updates partial_dir at config build time

### DIFF
--- a/crates/engine/src/local_copy/options/builder/setters_staging.rs
+++ b/crates/engine/src/local_copy/options/builder/setters_staging.rs
@@ -33,19 +33,12 @@ impl LocalCopyOptionsBuilder {
 
     /// Enables delay-updates mode.
     ///
-    /// When enabled and no explicit `partial_dir` has been set, the staging
-    /// directory defaults to `.~tmp~` matching upstream rsync behaviour.
+    /// The implicit `partial_dir` promotion to `.~tmp~` is performed once at
+    /// [`super::LocalCopyOptionsBuilder::build`] time, mirroring upstream
+    /// rsync's option finalisation in `options.c`.
     #[must_use]
     pub fn delay_updates(mut self, enabled: bool) -> Self {
         self.delay_updates = enabled;
-        if enabled {
-            self.partial = true;
-            if self.partial_dir.is_none() {
-                self.partial_dir = Some(PathBuf::from(
-                    crate::local_copy::options::staging::DELAY_UPDATES_PARTIAL_DIR,
-                ));
-            }
-        }
         self
     }
 

--- a/crates/engine/src/local_copy/options/builder/tests.rs
+++ b/crates/engine/src/local_copy/options/builder/tests.rs
@@ -389,6 +389,42 @@ mod staging_options {
     }
 
     #[test]
+    fn delay_updates_finalisation_sets_default_partial_dir() {
+        use std::path::Path;
+
+        use crate::local_copy::options::staging::DELAY_UPDATES_PARTIAL_DIR;
+
+        let options = LocalCopyOptionsBuilder::new()
+            .delay_updates(true)
+            .build()
+            .expect("valid options");
+
+        assert_eq!(
+            options.partial_directory_path(),
+            Some(Path::new(DELAY_UPDATES_PARTIAL_DIR)),
+            "build() must promote partial_dir to the upstream default when \
+             --delay-updates is set and no explicit --partial-dir was supplied",
+        );
+    }
+
+    #[test]
+    fn delay_updates_finalisation_preserves_explicit_partial_dir() {
+        use std::path::Path;
+
+        let options = LocalCopyOptionsBuilder::new()
+            .partial_dir(Some("/custom/staging"))
+            .delay_updates(true)
+            .build()
+            .expect("valid options");
+
+        assert_eq!(
+            options.partial_directory_path(),
+            Some(Path::new("/custom/staging")),
+            "explicit --partial-dir must survive build() finalisation",
+        );
+    }
+
+    #[test]
     fn inplace_enables() {
         let options = LocalCopyOptionsBuilder::new()
             .inplace(true)

--- a/crates/engine/src/local_copy/options/builder/validation.rs
+++ b/crates/engine/src/local_copy/options/builder/validation.rs
@@ -88,9 +88,13 @@ impl LocalCopyOptionsBuilder {
     ///
     /// This is useful when you know the configuration is valid or want
     /// to skip validation for performance reasons.
+    ///
+    /// Performs the `--delay-updates` implicit `partial_dir` finalisation
+    /// once, deterministically, so engine code never has to re-derive it.
+    /// upstream: options.c - `if (delay_updates && !partial_dir) partial_dir = tmp_partialdir;`
     #[must_use]
     pub fn build_unchecked(self) -> LocalCopyOptions {
-        LocalCopyOptions {
+        let mut options = LocalCopyOptions {
             delete: self.delete,
             delete_timing: self.delete_timing,
             delete_excluded: self.delete_excluded,
@@ -190,7 +194,9 @@ impl LocalCopyOptionsBuilder {
             log_file: self.log_file,
             log_file_format: self.log_file_format,
             platform_copy: self.platform_copy,
-        }
+        };
+        options.apply_delay_updates_partial_dir_default();
+        options
     }
 }
 

--- a/crates/engine/src/local_copy/options/staging.rs
+++ b/crates/engine/src/local_copy/options/staging.rs
@@ -66,21 +66,34 @@ impl LocalCopyOptions {
     /// Requests that updated files be renamed into place after the transfer completes.
     ///
     /// When enabled and no explicit `--partial-dir` has been configured, the
-    /// staging directory is automatically set to `.~tmp~` to match upstream
+    /// staging directory is finalised to `.~tmp~` via
+    /// [`Self::apply_delay_updates_partial_dir_default`] to match upstream
     /// rsync behaviour.
-    ///
-    /// upstream: options.c - `if (delay_updates && !partial_dir) partial_dir = tmp_partialdir;`
     #[must_use]
     #[doc(alias = "--delay-updates")]
     pub fn delay_updates(mut self, delay: bool) -> Self {
         self.delay_updates = delay;
-        if delay {
+        self.apply_delay_updates_partial_dir_default();
+        self
+    }
+
+    /// Promotes the staging directory to `.~tmp~` when `--delay-updates` is
+    /// enabled and no explicit `--partial-dir` has been configured.
+    ///
+    /// This is the single source of truth for the promotion rule and is
+    /// idempotent. It is invoked from the [`Self::delay_updates`] setter and
+    /// from `LocalCopyOptionsBuilder::build_unchecked` as a finalisation step
+    /// so the promotion happens deterministically before any engine code
+    /// observes the options.
+    ///
+    /// upstream: options.c - `if (delay_updates && !partial_dir) partial_dir = tmp_partialdir;`
+    pub(in crate::local_copy::options) fn apply_delay_updates_partial_dir_default(&mut self) {
+        if self.delay_updates {
             self.partial = true;
             if self.partial_dir.is_none() {
                 self.partial_dir = Some(PathBuf::from(DELAY_UPDATES_PARTIAL_DIR));
             }
         }
-        self
     }
 
     /// Requests that updated files be flushed to stable storage once writing completes.


### PR DESCRIPTION
## Summary

Audit follow-up (tasks #2148 / #2149 / #2150): the `--delay-updates`
implicit `partial_dir` promotion to `.~tmp~` previously lived in two
places - the `LocalCopyOptions::delay_updates` setter (engine struct)
and the `LocalCopyOptionsBuilder::delay_updates` setter. Once the
builder is the canonical construction path, the engine-layer promotion
is redundant and risks divergence if either copy drifts.

This change moves the rule into a single helper,
`LocalCopyOptions::apply_delay_updates_partial_dir_default`, and runs
it once as a finalisation step inside
`LocalCopyOptionsBuilder::build_unchecked()` so the promotion happens
deterministically before any engine code observes the options. The
builder setter is now a plain field setter.

The struct-level fluent setter continues to delegate to the same helper
so existing direct callers (engine integration tests) keep working
without churn.

upstream: `options.c:2403` - `if (delay_updates && !partial_dir) partial_dir = tmp_partialdir;`

## Test plan

- [ ] CI: fmt + clippy
- [ ] CI: nextest (stable) - Linux / macOS / Windows / musl
- [ ] New builder tests `delay_updates_finalisation_sets_default_partial_dir` and `delay_updates_finalisation_preserves_explicit_partial_dir` pass
- [ ] Existing `delay_updates_enables_partial` and the broader `execute_delay_updates` suite remain green