### PR TITLE
fix: align -a help parenthetical with upstream rsync 3.4.1

### DIFF
--- a/crates/cli/src/frontend/command_builder/sections/build_base_command/transfer.rs
+++ b/crates/cli/src/frontend/command_builder/sections/build_base_command/transfer.rs
@@ -12,7 +12,7 @@ pub(super) fn add_transfer_args(command: ClapCommand) -> ClapCommand {
             Arg::new("archive")
                 .long("archive")
                 .short('a')
-                .help("Enable archive mode (implies --owner, --group, --perms, and --times).")
+                .help("archive mode is -rlptgoD (no -A,-X,-U,-N,-H)")
                 .action(ArgAction::SetTrue),
         )
         .arg(

--- a/crates/cli/src/frontend/help.rs
+++ b/crates/cli/src/frontend/help.rs
@@ -31,7 +31,7 @@ pub(super) fn help_text(program_name: ProgramName) -> String {
             "      --config=FILE  Specify alternate daemon config file.\n",
             "  -n, --dry-run    Validate transfers without modifying the destination.\n",
             "      --list-only  List files without performing a transfer.\n",
-            "  -a, --archive    Enable archive mode (implies --owner, --group, --perms, --times, --devices, and --specials).\n",
+            "  -a, --archive    archive mode is -rlptgoD (no -A,-X,-U,-N,-H)\n",
             "  -r, --recursive  Recurse into directories.\n",
             "      --no-recursive  Disable directory recursion.\n",
             "  -d, --dirs      Copy directory entries even when recursion is disabled.\n",

--- a/crates/cli/src/frontend/tests/help.rs
+++ b/crates/cli/src/frontend/tests/help.rs
@@ -51,6 +51,19 @@ fn oc_help_mentions_config_option() {
 }
 
 #[test]
+fn archive_help_matches_upstream_parenthetical() {
+    // Upstream rsync 3.4.1 (help-rsync.h:10) renders the archive line as:
+    //   --archive, -a            archive mode is -rlptgoD (no -A,-X,-U,-N,-H)
+    // The parenthetical must match byte-for-byte for interop tooling that
+    // grep `--help` output by upstream wording.
+    let help = render_help(ProgramName::OcRsync);
+    assert!(
+        help.contains("archive mode is -rlptgoD (no -A,-X,-U,-N,-H)"),
+        "rendered help missing upstream archive wording: {help}"
+    );
+}
+
+#[test]
 fn supported_options_list_mentions_all_help_flags() {
     let help = render_help(ProgramName::OcRsync);
     let options = collect_options(&help);


### PR DESCRIPTION
## Summary

- Replace oc-rsync's custom `-a/--archive` help wording with upstream rsync 3.4.1's exact phrasing so `--help` output matches byte-for-byte.
- Add a regression test that asserts the rendered help contains the upstream parenthetical.

Upstream (`target/interop/upstream-src/rsync-3.4.1/help-rsync.h:10`):

```c
rprintf(F,"--archive, -a            archive mode is -rlptgoD (no -A,-X,-U,-N,-H)\n");
```

oc-rsync now renders the same string in both `help_text()` and the clap `--help` description, keeping interop tooling that greps man-page wording in sync.

Refs #2176.

## Test plan

- [ ] CI: fmt + clippy
- [ ] CI: nextest (`cargo nextest run -p cli -E 'test(archive_help_matches_upstream_parenthetical)'`)
- [ ] CI: nextest workspace (verifies `supported_options_list_mentions_all_help_flags` still passes with the new tokens `-A,-X,-U,-N,-H`)