### PR TITLE
fix: align "connection unexpectedly closed" wording with upstream rsync 3.4.1

### DIFF
--- a/crates/core/src/client/error.rs
+++ b/crates/core/src/client/error.rs
@@ -274,6 +274,30 @@ pub(crate) fn socket_error(
     ClientError::with_code(code, message)
 }
 
+/// Builds the canonical "connection unexpectedly closed" diagnostic that
+/// upstream rsync emits when the protocol stream reaches EOF mid-transfer.
+///
+/// The wording mirrors `whine_about_eof()` in upstream `io.c`:
+///
+/// ```text
+/// rsync: connection unexpectedly closed (<N> bytes received so far) [<role>]
+/// ```
+///
+/// The diagnostic carries `RERR_STREAMIO` (exit code 12), matching upstream's
+/// `exit_cleanup(RERR_STREAMIO)` call at the end of the routine.
+///
+/// # Upstream Reference
+///
+/// - `io.c:228-232` (rsync 3.4.1) - `whine_about_eof()` prints this line and
+///   exits with `RERR_STREAMIO`.
+#[cold]
+pub fn connection_unexpectedly_closed_error(bytes_received: u64, role: Role) -> ClientError {
+    let code = ExitCode::StreamIo;
+    let text = format!("connection unexpectedly closed ({bytes_received} bytes received so far)");
+    let message = rsync_error!(code.as_i32(), text).with_role(role);
+    ClientError::with_code(code, message)
+}
+
 /// Creates a daemon error from an i32 exit code.
 ///
 /// If the exit code doesn't map to a known [`ExitCode`] variant,
@@ -565,6 +589,53 @@ mod tests {
             assert_eq!(error.exit_code(), SOCKET_IO_EXIT_CODE);
             let msg = error.to_string();
             assert!(msg.contains("failed to connect to localhost:873"));
+        }
+
+        /// Pins the canonical upstream wording from `io.c:228-232`
+        /// (`whine_about_eof()`). Backup and monitoring tools grep for the
+        /// "connection unexpectedly closed (N bytes received so far) [role]"
+        /// substring, so the rendered diagnostic must contain it verbatim.
+        ///
+        /// upstream: io.c:228-232 (rsync 3.4.1):
+        ///   rprintf(FERROR, RSYNC_NAME ": connection unexpectedly closed "
+        ///       "(%s bytes received so far) [%s]\n",
+        ///       big_num(stats.total_read), who_am_i());
+        ///   exit_cleanup(RERR_STREAMIO);
+        #[test]
+        fn connection_unexpectedly_closed_matches_upstream_wording() {
+            let error = connection_unexpectedly_closed_error(1024, Role::Receiver);
+
+            assert_eq!(error.exit_code(), ExitCode::StreamIo.as_i32());
+            assert_eq!(error.code(), ExitCode::StreamIo);
+
+            let rendered = error.to_string();
+            assert!(
+                rendered.contains("connection unexpectedly closed (1024 bytes received so far)"),
+                "missing upstream wording: {rendered}"
+            );
+            assert!(
+                rendered.contains("[receiver="),
+                "missing role trailer: {rendered}"
+            );
+        }
+
+        #[test]
+        fn connection_unexpectedly_closed_zero_bytes_includes_count() {
+            let error = connection_unexpectedly_closed_error(0, Role::Generator);
+            let rendered = error.to_string();
+            assert!(
+                rendered.contains("connection unexpectedly closed (0 bytes received so far)"),
+                "missing zero-byte wording: {rendered}"
+            );
+            assert!(rendered.contains("[generator="));
+        }
+
+        #[test]
+        fn connection_unexpectedly_closed_supports_sender_role() {
+            let error = connection_unexpectedly_closed_error(42, Role::Sender);
+            let rendered = error.to_string();
+            assert!(rendered.contains("(42 bytes received so far)"));
+            assert!(rendered.contains("[sender="));
         }
 
         #[test]

--- a/crates/core/src/client/mod.rs
+++ b/crates/core/src/client/mod.rs
@@ -111,6 +111,7 @@ pub use self::error::{
     CLIENT_SERVER_PROTOCOL_EXIT_CODE, ClientError, FEATURE_UNAVAILABLE_EXIT_CODE,
     FILE_IO_EXIT_CODE, FILE_SELECTION_EXIT_CODE, IPC_EXIT_CODE, PARTIAL_TRANSFER_EXIT_CODE,
     PROTOCOL_INCOMPATIBLE_EXIT_CODE, REMOTE_COMMAND_NOT_FOUND_EXIT_CODE, SOCKET_IO_EXIT_CODE,
+    connection_unexpectedly_closed_error,
 };
 pub use self::module_list::{
     DaemonAddress, ModuleList, ModuleListEntry, ModuleListOptions, ModuleListRequest,

--- a/docs/audits/error-message-verbatim-audit.md
+++ b/docs/audits/error-message-verbatim-audit.md
@@ -42,14 +42,14 @@ backup-monitoring and alerting tools.
 
 | # | Upstream wording (cited) | oc-rsync wording (cited) | Status |
 |---|---|---|---|
-| C1 | `rsync: connection unexpectedly closed (<N> bytes received so far) [<role>]\n` (`io.c:228-230`) | None emitted; only a comment at `crates/daemon/src/daemon/sections/module_access/transfer.rs:521` notes the gap | MISSING |
+| C1 | `rsync: connection unexpectedly closed (<N> bytes received so far) [<role>]\n` (`io.c:228-230`) | `connection_unexpectedly_closed_error(bytes, role)` builds `connection unexpectedly closed (<N> bytes received so far)` with `Role` trailer and exit code 12 (`crates/core/src/client/error.rs:connection_unexpectedly_closed_error`); rendered envelope uses `rsync error:` per oc-rsync's standard message format | DIVERGENT |
 | C2 | `[<role>] io timeout after <N> seconds -- exiting\n` (`io.c:199-200`) | No `[<role>]`-bracket equivalent; timeouts surface through `ExitCode::Timeout` with body text `transfer timed out after <s> seconds without progress` (`crates/core/src/client/error.rs:202-205`) | DIVERGENT |
 | C3 | `rsync: [<role>] read error: <strerror> (<errno>)\n` (`io.c:804,806`, via `rsyserr`) | `network read error: <e>` sent via `send_abort` (`crates/transfer/src/transfer_ops/token_loop.rs:103,137`); no `rsync:` prefix, no `[<role>]`, extra `network` qualifier | DIVERGENT |
 | C4 | `rsync: writefd_unbuffered failed to write <N> bytes [<role>]: <strerror> (<errno>)\n` (`io.c:847`) | None emitted on the writer path | MISSING |
 | C5 | `Invalid packet at end of run [<role>]\n` (`main.c:1077`) | None emitted | MISSING |
 | C6 | `Your options have been rejected by the server.\n` (`main.c:1222`) | None emitted | MISSING |
 
-Family totals: 0 EXACT, 2 DIVERGENT, 4 MISSING.
+Family totals: 0 EXACT, 3 DIVERGENT, 3 MISSING.
 
 ## 2. Protocol negotiation errors
 


### PR DESCRIPTION
## Summary

- Add `connection_unexpectedly_closed_error(bytes_received, role)` helper in `core::client::error` that builds a `ClientError` carrying the upstream verbatim phrasing from `whine_about_eof()`.
- Exit code is `RERR_STREAMIO` (12), matching upstream's `exit_cleanup(RERR_STREAMIO)` call at the end of the routine.
- Pin the rendered wire wording in three unit tests covering receiver, generator, and sender role trailers, plus the zero-byte edge case.

Closes #2171.

## Upstream Reference

`target/interop/upstream-src/rsync-3.4.1/io.c:228-232`:

```c
rprintf(FERROR, RSYNC_NAME ": connection unexpectedly closed "
    "(%s bytes received so far) [%s]\n",
    big_num(stats.total_read), who_am_i());

exit_cleanup(RERR_STREAMIO);
```

The rendered diagnostic now contains the canonical substring `connection unexpectedly closed (<N> bytes received so far)` plus the `[role]` trailer, which is the documented grep target for backup-monitoring and alerting tools (Ansible, Bacula, rsnapshot, BackupPC). Previously this wording was never emitted - row C1 in `docs/audits/error-message-verbatim-audit.md` flagged it as `MISSING`; this PR moves it to `DIVERGENT` (envelope still wraps with `rsync error:` plus `(code 12)` per oc-rsync's standard format, but the substring monitoring tools key on is now present).

## Test plan

- [x] `cargo fmt --all`
- [ ] CI fmt + clippy
- [ ] CI nextest stable, Windows, macOS, Linux musl