### PR TITLE
feat: accept bare numeric --info=N levels (upstream parity)

### DIFF
--- a/crates/cli/src/frontend/execution/flags/info.rs
+++ b/crates/cli/src/frontend/execution/flags/info.rs
@@ -28,35 +28,41 @@ pub(crate) struct InfoFlagSettings {
 
 impl InfoFlagSettings {
     const fn enable_all(&mut self) {
-        self.progress = ProgressSetting::PerFile;
-        self.stats = Some(1);
-        self.name = Some(NameOutputLevel::UpdatedOnly);
-        self.backup = Some(1);
-        self.copy = Some(1);
-        self.del = Some(1);
-        self.flist = Some(1);
-        self.misc = Some(1);
-        self.mount = Some(1);
-        self.nonreg = Some(1);
-        self.remove = Some(1);
-        self.skip = Some(1);
-        self.symsafe = Some(1);
+        self.enable_all_at_level(1);
+    }
+
+    // upstream: options.c parse_output_words - the "all<N>" token sets every
+    // flag to level `min(N, max_for_that_flag)`. Per-flag caps mirror the
+    // hard limits enforced in `apply()` below (progress 2, stats 3, flist 2,
+    // misc 2, skip 2, others 1).
+    const fn enable_all_at_level(&mut self, level: u8) {
+        self.progress = match level {
+            0 => ProgressSetting::Disabled,
+            1 => ProgressSetting::PerFile,
+            _ => ProgressSetting::Overall,
+        };
+        self.stats = Some(if level > 3 { 3 } else { level });
+        self.name = match level {
+            0 => Some(NameOutputLevel::Disabled),
+            1 => Some(NameOutputLevel::UpdatedOnly),
+            _ => Some(NameOutputLevel::UpdatedAndUnchanged),
+        };
+        let cap2 = if level > 2 { 2 } else { level };
+        self.flist = Some(cap2);
+        self.misc = Some(cap2);
+        self.skip = Some(cap2);
+        let cap1 = if level > 1 { 1 } else { level };
+        self.backup = Some(cap1);
+        self.copy = Some(cap1);
+        self.del = Some(cap1);
+        self.mount = Some(cap1);
+        self.nonreg = Some(cap1);
+        self.remove = Some(cap1);
+        self.symsafe = Some(cap1);
     }
 
     const fn disable_all(&mut self) {
-        self.progress = ProgressSetting::Disabled;
-        self.stats = Some(0);
-        self.name = Some(NameOutputLevel::Disabled);
-        self.backup = Some(0);
-        self.copy = Some(0);
-        self.del = Some(0);
-        self.flist = Some(0);
-        self.misc = Some(0);
-        self.mount = Some(0);
-        self.nonreg = Some(0);
-        self.remove = Some(0);
-        self.skip = Some(0);
-        self.symsafe = Some(0);
+        self.enable_all_at_level(0);
     }
 
     pub(super) fn apply(&mut self, token: &str, display: &str) -> Result<(), Message> {
@@ -67,13 +73,23 @@ impl InfoFlagSettings {
             return Ok(());
         }
 
-        if lower == "all" || lower == "1" {
+        if lower == "all" {
             self.enable_all();
             return Ok(());
         }
 
-        if lower == "none" || lower == "0" {
+        if lower == "none" {
             self.disable_all();
+            return Ok(());
+        }
+
+        // upstream: options.c parse_output_words accepts "all<N>" (e.g. "all2")
+        // to set every flag to level N. As a usability extension, oc-rsync
+        // also accepts a bare integer token like "--info=2" with the same
+        // semantics. Per-flag caps are applied by `enable_all_at_level`.
+        if !lower.is_empty() && lower.bytes().all(|b| b.is_ascii_digit()) {
+            let level = lower.parse::<u8>().unwrap_or(u8::MAX);
+            self.enable_all_at_level(level);
             return Ok(());
         }
 

--- a/crates/cli/src/frontend/execution/flags/tests.rs
+++ b/crates/cli/src/frontend/execution/flags/tests.rs
@@ -815,3 +815,80 @@ fn debug_help_text_mentions_all_and_none() {
     assert!(DEBUG_HELP_TEXT.contains("all"));
     assert!(DEBUG_HELP_TEXT.contains("none"));
 }
+
+// upstream: options.c parse_output_words - "all<N>" sets every flag to
+// level N (per-flag clamped). oc-rsync accepts a bare "<N>" token as a
+// usability extension with the same semantics.
+#[test]
+fn info_flag_numeric_2_enables_all_at_level_2() {
+    let mut settings = InfoFlagSettings::default();
+    settings.apply("2", "2").unwrap();
+    assert_eq!(settings.progress, ProgressSetting::Overall);
+    assert_eq!(settings.stats, Some(2));
+    assert_eq!(settings.name, Some(NameOutputLevel::UpdatedAndUnchanged));
+    assert_eq!(settings.flist, Some(2));
+    assert_eq!(settings.misc, Some(2));
+    assert_eq!(settings.skip, Some(2));
+    // Flags with max level 1 stay clamped at 1.
+    assert_eq!(settings.backup, Some(1));
+    assert_eq!(settings.copy, Some(1));
+    assert_eq!(settings.del, Some(1));
+    assert_eq!(settings.mount, Some(1));
+    assert_eq!(settings.nonreg, Some(1));
+    assert_eq!(settings.remove, Some(1));
+    assert_eq!(settings.symsafe, Some(1));
+}
+
+#[test]
+fn info_flag_numeric_3_clamps_per_flag() {
+    let mut settings = InfoFlagSettings::default();
+    settings.apply("3", "3").unwrap();
+    // STATS supports level 3.
+    assert_eq!(settings.stats, Some(3));
+    // PROGRESS, NAME, FLIST, MISC, SKIP clamp at 2.
+    assert_eq!(settings.progress, ProgressSetting::Overall);
+    assert_eq!(settings.name, Some(NameOutputLevel::UpdatedAndUnchanged));
+    assert_eq!(settings.flist, Some(2));
+    assert_eq!(settings.misc, Some(2));
+    assert_eq!(settings.skip, Some(2));
+    // Boolean flags clamp at 1.
+    assert_eq!(settings.copy, Some(1));
+}
+
+#[test]
+fn info_flag_numeric_then_named_override() {
+    let mut settings = InfoFlagSettings::default();
+    settings.apply("2", "2").unwrap();
+    settings.apply("name0", "name0").unwrap();
+    assert_eq!(settings.name, Some(NameOutputLevel::Disabled));
+    // Other flags retained from the numeric pre-fill.
+    assert_eq!(settings.stats, Some(2));
+}
+
+#[test]
+fn parse_info_flags_numeric_then_named_in_one_arg() {
+    let values = vec![OsString::from("2,name0")];
+    let result = parse_info_flags(&values).unwrap();
+    assert_eq!(result.name, Some(NameOutputLevel::Disabled));
+    assert_eq!(result.stats, Some(2));
+    assert_eq!(result.flist, Some(2));
+}
+
+#[test]
+fn info_flag_numeric_high_value_saturates() {
+    // Out-of-range integers saturate at per-flag caps rather than erroring.
+    let mut settings = InfoFlagSettings::default();
+    settings.apply("99", "99").unwrap();
+    assert_eq!(settings.stats, Some(3));
+    assert_eq!(settings.flist, Some(2));
+    assert_eq!(settings.copy, Some(1));
+}
+
+#[test]
+fn info_flag_numeric_overflow_does_not_panic() {
+    // A value that overflows u8 falls back to u8::MAX inside the parser,
+    // which still saturates to per-flag caps.
+    let mut settings = InfoFlagSettings::default();
+    settings.apply("999", "999").unwrap();
+    assert_eq!(settings.stats, Some(3));
+}

--- a/docs/audits/info-flags-verbosity-matrix.md
+++ b/docs/audits/info-flags-verbosity-matrix.md
@@ -227,11 +227,13 @@ no `info_log!(Foo, 2, ...)` (or `3`) in production paths.
 `apply()` in `info.rs:70-78` honours both, but with one wrinkle: the
 "all" arm sets `progress = PerFile` (level 1) and `stats = Some(1)`. It
 matches upstream `parse_output_words("all", lev=1)` in spirit. Upstream
-additionally accepts bare digit tokens like `--info=2` (`isDigit(str)`
-at `options.c:439`) to set `lev=2` with `len=0` (i.e. "all flags to
-level 2"). oc-rsync's `apply()` only accepts `"1"` and `"0"` as
-all/none synonyms (line 70-78); `--info=2` falls into
-`parse_flag_and_level` and is rejected as unknown.
+accepts `all<N>` (e.g. `all2`) to set every flag to level N (per-flag
+clamped via the `lev > MAX_OUT_LEVEL` ceiling in
+`options.c parse_output_words`). oc-rsync additionally accepts a bare
+`<N>` token like `--info=2` with the same semantics as a usability
+extension; the dispatch flows through `enable_all_at_level(N)` so the
+per-flag caps stay in lockstep with the per-token validation in
+`apply()`.
 
 ### 4.3 `no<flag>` / `-<flag>` negation
 
@@ -289,7 +291,7 @@ re-evaluated and the implementation already matches upstream.
 | I9  | MISC 2    | Low      | OPEN   | Upstream emits "Setting --timeout=N to match server" at `io.c:1536-1537`; oc-rsync only emits MISC-1 errors. |
 | I10 | SKIP 2    | Low      | OPEN   | Upstream emits the "(type change)" / "(sum change)" suffix at `generator.c:1387`; oc-rsync's SKIP emissions never include the suffix. |
 | I11 | All       | Medium   | OPEN   | `should_show_*` and the parse-cap layer collapse level 2/3 to level 1 because no production code differentiates levels beyond `> 0`. Closing I1-I10 individually addresses this category. |
-| I12 | All       | Low      | OPEN   | `--info=2` (bare digit) accepted by upstream (`options.c:439`) as "set all flags to level 2"; oc-rsync rejects it (`info.rs:80-82`). |
+| I12 | All       | Low      | RESOLVED | `--info=N` (bare digit) now accepted as a usability extension; oc-rsync's `apply()` in `info.rs` delegates to `enable_all_at_level(N)` with the same per-flag caps as upstream's `all<N>` token (`options.c parse_output_words`). |
 | I13 | All       | Low      | OPEN   | `--info=no<flag>` / `--info=-<flag>` accepted by oc-rsync only; upstream rejects unknown tokens. Diverges in the rejection direction (oc-rsync more permissive). |
 | I14 | All       | Low      | OPEN   | Unknown-token message text differs: upstream `Unknown --info item: "FOO"`, oc-rsync `invalid --info flag 'FOO': use --info=help for supported flags`. Same exit code (1). |
 | I15 | All       | Low      | OPEN   | Server-side mode (`am_server`) should suppress unknown-token errors (`options.c:465`); oc-rsync errors unconditionally. |
@@ -334,8 +336,9 @@ re-evaluated and the implementation already matches upstream.
 
 ### P3 - Parser polish
 
-8. **I12 - bare digit token**: extend `apply()` to accept `"2"`/`"3"`
-   as "all flags to level N" synonyms.
+8. **I12 - bare digit token** (RESOLVED): `apply()` now accepts any pure
+   digit token (`"2"`, `"3"`, ...) and routes it through
+   `enable_all_at_level(N)` to mirror upstream `all<N>` per-flag caps.
 9. **I14 / I15 - unknown-token text and server tolerance**: align the
    string to `Unknown --info item: "FOO"` and short-circuit when
    running as server.


### PR DESCRIPTION
## Summary

- Treat a bare digit token (`--info=2`, `--info=3`, ...) as a synonym for upstream's `all<N>` syntax. Every info flag is set to `min(N, max_for_that_flag)` via a new `enable_all_at_level` helper.
- Per-flag caps mirror `options.c parse_output_words` (progress 2, stats 3, name/flist/misc/skip 2, others 1), so the bare-numeric path shares the same ceilings as the named tokens.
- Mark audit item I12 in `docs/audits/info-flags-verbosity-matrix.md` as RESOLVED.

Refs #2166.

Upstream reference: `target/interop/upstream-src/rsync-3.4.1/options.c:427` (`parse_output_words`), `options.c:444-453` for the per-flag caps and the `all<N>` token handling.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p cli --all-targets --no-deps -- -D warnings`
- [x] New unit tests:
  - `info_flag_numeric_2_enables_all_at_level_2` - all flags clamp to their max-for-this-flag at level 2.
  - `info_flag_numeric_3_clamps_per_flag` - STATS goes to 3, others clamp to 2 or 1 per upstream caps.
  - `info_flag_numeric_then_named_override` - subsequent named token (`name0`) overrides the numeric pre-fill.
  - `parse_info_flags_numeric_then_named_in_one_arg` - `--info=2,name0` parsed in one arg.
  - `info_flag_numeric_high_value_saturates` and `info_flag_numeric_overflow_does_not_panic` - oversized values saturate at per-flag caps.