### PR TITLE
fix: replicate protocol-mismatch wording from upstream rsync 3.4.1

### DIFF
--- a/crates/protocol/src/error.rs
+++ b/crates/protocol/src/error.rs
@@ -33,7 +33,17 @@ pub enum NegotiationError {
         peer_versions: Vec<u8>,
     },
     /// The peer advertised a protocol version outside the upstream supported range.
-    #[error("peer advertised unsupported rsync protocol version {version} (valid range {oldest}-{newest})", version = .0, oldest = ProtocolVersion::supported_range_bounds().0, newest = ProtocolVersion::supported_range_bounds().1)]
+    ///
+    /// The Display rendering is byte-identical to upstream rsync 3.4.1's two
+    /// `FERROR` lines emitted from `compat.c:620-621` when `remote_protocol`
+    /// falls outside `[MIN_PROTOCOL_VERSION, MAX_PROTOCOL_VERSION]`. Backup
+    /// monitoring tools grep for this exact wording, so changing it would
+    /// break interop. The offending version is preserved on the variant and
+    /// reachable via [`NegotiationError::unsupported_version`].
+    // upstream: compat.c:618-623 (start_protocol)
+    #[error(
+        "protocol version mismatch -- is your shell clean?\n(see the rsync manpage for an explanation)"
+    )]
     UnsupportedVersion(u32),
     /// A legacy ASCII daemon greeting could not be parsed.
     #[error("malformed legacy rsync daemon greeting: {input:?}")]
@@ -109,14 +119,18 @@ mod tests {
     }
 
     #[test]
-    fn display_mentions_supported_range_for_unsupported_versions() {
+    fn display_matches_upstream_verbatim_for_unsupported_versions() {
+        // upstream: compat.c:620-621 emits these two FERROR lines verbatim
+        // (`protocol version mismatch -- is your shell clean?\n` followed by
+        // `(see the rsync manpage for an explanation)\n`). Backup monitoring
+        // tools grep for this exact wording.
         let err = NegotiationError::UnsupportedVersion(27);
-        let rendered = err.to_string();
-
-        assert!(rendered.contains("peer advertised unsupported rsync protocol version 27"));
-        assert!(rendered.contains("valid range"));
-        assert!(rendered.contains(&ProtocolVersion::OLDEST.as_u8().to_string()));
-        assert!(rendered.contains(&ProtocolVersion::NEWEST.as_u8().to_string()));
+        assert_eq!(
+            err.to_string(),
+            "protocol version mismatch -- is your shell clean?\n\
+             (see the rsync manpage for an explanation)"
+        );
+        assert_eq!(err.unsupported_version(), Some(27));
     }
 
     #[test]

--- a/crates/protocol/src/version/tests/protocol/negotiation.rs
+++ b/crates/protocol/src/version/tests/protocol/negotiation.rs
@@ -570,15 +570,21 @@ fn version_32_feature_profile() {
     );
 }
 
-/// Verifies `UnsupportedVersion` error message includes version range.
+/// Verifies `UnsupportedVersion` error message matches upstream wording.
+///
+/// upstream: compat.c:618-623 (start_protocol). The message is intentionally
+/// version-agnostic; the rejected version is reachable via the variant data
+/// through `unsupported_version()` for structured callers.
 #[test]
-fn unsupported_version_error_includes_range() {
+fn unsupported_version_error_matches_upstream() {
     let err = NegotiationError::UnsupportedVersion(27);
     let msg = err.to_string();
 
-    assert!(msg.contains("27"), "error should mention version 27");
-    assert!(msg.contains("28"), "error should mention min version 28");
-    assert!(msg.contains("32"), "error should mention max version 32");
+    assert_eq!(
+        msg,
+        "protocol version mismatch -- is your shell clean?\n(see the rsync manpage for an explanation)",
+    );
+    assert_eq!(err.unsupported_version(), Some(27));
 }
 
 /// Verifies `NoMutualProtocol` error message includes peer versions.

--- a/crates/protocol/tests/protocol_version_selection.rs
+++ b/crates/protocol/tests/protocol_version_selection.rs
@@ -558,17 +558,19 @@ fn error_all_invalid_versions() {
 }
 
 /// Test error message content.
+///
+/// upstream: compat.c:620-621 emits the two-line wording verbatim. We mirror
+/// it byte-for-byte. The rejected version is preserved on the variant and
+/// accessible via `unsupported_version()` for callers that need it.
 #[test]
-fn error_message_includes_version_range() {
+fn error_message_matches_upstream_verbatim() {
     let err = NegotiationError::UnsupportedVersion(27);
-    let msg = err.to_string();
-
-    // Should mention the version
-    assert!(msg.contains("27"), "Error should mention version 27");
-
-    // Should mention the valid range
-    assert!(msg.contains("28"), "Error should mention min version 28");
-    assert!(msg.contains("32"), "Error should mention max version 32");
+    assert_eq!(
+        err.to_string(),
+        "protocol version mismatch -- is your shell clean?\n\
+         (see the rsync manpage for an explanation)"
+    );
+    assert_eq!(err.unsupported_version(), Some(27));
 }
 
 /// Comprehensive feature matrix test for all supported versions.

--- a/docs/audits/error-message-verbatim-audit.md
+++ b/docs/audits/error-message-verbatim-audit.md
@@ -59,7 +59,7 @@ mapped to exit code 2 (`RERR_PROTOCOL`).
 
 | # | Upstream wording (cited) | oc-rsync wording (cited) | Status |
 |---|---|---|---|
-| P1 | `protocol version mismatch -- is your shell clean?\n` followed by `(see the rsync manpage for an explanation)\n` (`compat.c:620-621`) | `peer advertised unsupported rsync protocol version <N> (valid range <oldest>-<newest>)` (`crates/protocol/src/error.rs:36-37`, `NegotiationError::UnsupportedVersion`) | DIVERGENT |
+| P1 | `protocol version mismatch -- is your shell clean?\n` followed by `(see the rsync manpage for an explanation)\n` (`compat.c:620-621`) | `protocol version mismatch -- is your shell clean?\n(see the rsync manpage for an explanation)` (`crates/protocol/src/error.rs`, `NegotiationError::UnsupportedVersion`) | EXACT (FIXED #2172) |
 | P2 | `The protocol version in the batch file is too new (%d > %d).\n` (`compat.c:609-610`) | None emitted on the batch-read path | MISSING |
 | P3 | `--protocol must be at least %d on the %s.\n` (`compat.c:629-630`) | None emitted | MISSING |
 | P4 | `--protocol must be no more than %d on the %s.\n` (`compat.c:634-635`) | None emitted | MISSING |
@@ -68,7 +68,7 @@ mapped to exit code 2 (`RERR_PROTOCOL`).
 | P7 | `unexpected tag %d [%s%s]\n` (`io.c:1703`) | None emitted | MISSING |
 | P8 | `your client does not support one of our daemon-auth checksums: %s\n` (`compat.c:872`) | None emitted | MISSING |
 
-Family totals: 1 EXACT, 1 DIVERGENT, 6 MISSING.
+Family totals: 2 EXACT, 0 DIVERGENT, 6 MISSING.
 
 ## 3. Daemon `@ERROR:` wire lines
 
@@ -170,11 +170,11 @@ above). The project-memory note should be revised accordingly.
 | Family | EXACT | DIVERGENT | MISSING | Extra |
 |---|---:|---:|---:|---:|
 | 1. Connection / transport | 0 | 2 | 4 | 0 |
-| 2. Protocol negotiation | 1 | 1 | 6 | 0 |
+| 2. Protocol negotiation | 2 | 0 | 6 | 0 |
 | 3. Daemon `@ERROR:` lines | 5 | 2 | 6 | 3 |
 | 4. Per-file `rsyserr` warnings | 1 | 8 | 0 | 0 |
 | 5. Exit-code envelope | 11 | 3 | 0 | 0 |
-| **Total** | **18** | **16** | **16** | **3** |
+| **Total** | **19** | **15** | **16** | **3** |
 
 ## 7. Top 5 divergences by user impact
 


### PR DESCRIPTION
## Summary

- Replicates upstream rsync 3.4.1's protocol-mismatch wording verbatim
  in `NegotiationError::UnsupportedVersion`, so the Display rendering is
  byte-identical to the two `FERROR` lines emitted from
  `compat.c:620-621`.
- Preserves the rejected version on the variant; callers that need it
  can still recover it via `NegotiationError::unsupported_version()`.
- Marks audit row P1 as `EXACT (FIXED #2172)` in
  `docs/audits/error-message-verbatim-audit.md` and updates the family
  tally accordingly.

Closes #2172.

## Upstream reference

`target/interop/upstream-src/rsync-3.4.1/compat.c:618-623` (start_protocol):

```c
if (remote_protocol < MIN_PROTOCOL_VERSION
 || remote_protocol > MAX_PROTOCOL_VERSION) {
    rprintf(FERROR,"protocol version mismatch -- is your shell clean?\n");
    rprintf(FERROR,"(see the rsync manpage for an explanation)\n");
    exit_cleanup(RERR_PROTOCOL);
}
```

Exit semantics (`RERR_PROTOCOL` = 2) are unchanged.

## Test plan

- [x] `cargo fmt --all -- --check`
- [ ] CI: fmt+clippy
- [ ] CI: nextest (stable) - covers updated unit test
  `display_matches_upstream_verbatim_for_unsupported_versions` and
  integration test `error_message_matches_upstream_verbatim`
- [ ] CI: Windows, macOS, Linux musl