### PR TITLE
feat: server-side tolerance for unknown --info tokens (upstream parity)

### DIFF
--- a/crates/cli/src/frontend/execution/flags/debug.rs
+++ b/crates/cli/src/frontend/execution/flags/debug.rs
@@ -6,7 +6,7 @@ use core::{
 };
 
 /// Parsed `--debug` flag settings controlling diagnostic output levels.
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub(crate) struct DebugFlagSettings {
     pub(crate) acl: Option<u8>,
     pub(crate) backup: Option<u8>,

--- a/crates/cli/src/frontend/execution/flags/info.rs
+++ b/crates/cli/src/frontend/execution/flags/info.rs
@@ -60,6 +60,25 @@ impl InfoFlagSettings {
     }
 
     pub(super) fn apply(&mut self, token: &str, display: &str) -> Result<(), Message> {
+        self.apply_with_mode(token, display, false)
+    }
+
+    /// Applies a single `--info` token.
+    ///
+    /// When `am_server` is `true`, an unrecognised token is silently
+    /// accepted instead of producing an error, mirroring upstream rsync's
+    /// `parse_output_words()` (`options.c:465`) where the
+    /// `if (len && !words[j].name && !am_server)` guard skips the
+    /// `RERR_SYNTAX` exit. This preserves cross-version compatibility when a
+    /// newer client forwards info tokens this server build does not know.
+    ///
+    /// upstream: options.c parse_output_words
+    pub(super) fn apply_with_mode(
+        &mut self,
+        token: &str,
+        display: &str,
+        am_server: bool,
+    ) -> Result<(), Message> {
         let lower = token.to_ascii_lowercase();
 
         if lower == "help" {
@@ -158,6 +177,9 @@ impl InfoFlagSettings {
                 self.symsafe = Some(level);
                 Ok(())
             }
+            // upstream: options.c parse_output_words - server mode silently
+            // skips unknown tokens; client mode errors so users see typos.
+            _ if am_server => Ok(()),
             _ => Err(info_flag_error(display)),
         }
     }
@@ -201,6 +223,26 @@ fn info_flag_error(display: &str) -> Message {
 
 /// Parses `--info` flag values into resolved settings.
 pub(crate) fn parse_info_flags(values: &[OsString]) -> Result<InfoFlagSettings, Message> {
+    parse_info_flags_inner(values, false)
+}
+
+/// Parses `--info` flag values in server mode, silently ignoring unknown tokens.
+///
+/// Upstream rsync's `parse_output_words()` checks `!am_server` before raising
+/// `Unknown --info item` (`options.c:465`). The server side accepts whatever
+/// the (possibly newer) client forwards so the connection survives across
+/// version skew. The client-side parser still rejects unknown tokens via
+/// [`parse_info_flags`] so typos surface at the source.
+///
+/// upstream: options.c parse_output_words
+pub(crate) fn parse_info_flags_server(values: &[OsString]) -> Result<InfoFlagSettings, Message> {
+    parse_info_flags_inner(values, true)
+}
+
+fn parse_info_flags_inner(
+    values: &[OsString],
+    am_server: bool,
+) -> Result<InfoFlagSettings, Message> {
     let mut settings = InfoFlagSettings::default();
     for value in values {
         let text = value.to_string_lossy();
@@ -218,7 +260,7 @@ pub(crate) fn parse_info_flags(values: &[OsString]) -> Result<InfoFlagSettings, 
                 );
             }
 
-            settings.apply(token, token)?;
+            settings.apply_with_mode(token, token, am_server)?;
         }
     }
 

--- a/crates/cli/src/frontend/execution/flags/info.rs
+++ b/crates/cli/src/frontend/execution/flags/info.rs
@@ -59,6 +59,7 @@ impl InfoFlagSettings {
         self.symsafe = Some(0);
     }
 
+    #[cfg(test)]
     pub(super) fn apply(&mut self, token: &str, display: &str) -> Result<(), Message> {
         self.apply_with_mode(token, display, false)
     }

--- a/crates/cli/src/frontend/execution/flags/info.rs
+++ b/crates/cli/src/frontend/execution/flags/info.rs
@@ -8,7 +8,7 @@ use core::{
 use super::super::super::progress::{NameOutputLevel, ProgressSetting};
 
 /// Parsed `--info` flag settings controlling informational output levels.
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub(crate) struct InfoFlagSettings {
     pub(crate) progress: ProgressSetting,
     pub(crate) stats: Option<u8>,

--- a/crates/cli/src/frontend/execution/flags/mod.rs
+++ b/crates/cli/src/frontend/execution/flags/mod.rs
@@ -5,4 +5,4 @@ mod info;
 mod tests;
 
 pub(crate) use debug::{DEBUG_HELP_TEXT, parse_debug_flags};
-pub(crate) use info::{INFO_HELP_TEXT, parse_info_flags};
+pub(crate) use info::{INFO_HELP_TEXT, parse_info_flags, parse_info_flags_server};

--- a/crates/cli/src/frontend/execution/flags/tests.rs
+++ b/crates/cli/src/frontend/execution/flags/tests.rs
@@ -97,6 +97,43 @@ fn parse_info_flags_comma_separated() {
     assert_eq!(result.stats, Some(1));
 }
 
+// upstream: options.c parse_output_words - the client-side parser rejects
+// unknown info tokens so users see typos at their source.
+#[test]
+fn parse_info_flags_client_rejects_unknown_token() {
+    let values = vec![OsString::from("future_unknown_flag")];
+    let err = parse_info_flags(&values).expect_err("client mode must reject unknown tokens");
+    assert!(
+        err.text().contains("future_unknown_flag"),
+        "error text should name the offending token: {}",
+        err.text()
+    );
+}
+
+// upstream: options.c parse_output_words - the `!am_server` guard means the
+// server side silently accepts unknown tokens, preserving compatibility when
+// a newer client forwards info names this build has not learned yet.
+#[test]
+fn parse_info_flags_server_accepts_unknown_token() {
+    let values = vec![OsString::from("future_unknown_flag")];
+    let settings =
+        parse_info_flags_server(&values).expect("server mode must accept unknown tokens");
+    assert_eq!(settings.progress, ProgressSetting::Unspecified);
+    assert_eq!(settings.stats, None);
+}
+
+// Server-mode tolerance must still apply known tokens; only the unknown
+// portion is skipped. Mirrors upstream's per-token loop in
+// parse_output_words().
+#[test]
+fn parse_info_flags_server_mixes_known_and_unknown() {
+    let values = vec![OsString::from("progress,future_unknown_flag,stats")];
+    let settings = parse_info_flags_server(&values)
+        .expect("server mode must accept unknown tokens alongside known ones");
+    assert_eq!(settings.progress, ProgressSetting::PerFile);
+    assert_eq!(settings.stats, Some(1));
+}
+
 #[test]
 fn debug_flag_parse_flag_and_level_default() {
     let settings = DebugFlagSettings::default();

--- a/crates/cli/src/frontend/execution/mod.rs
+++ b/crates/cli/src/frontend/execution/mod.rs
@@ -25,7 +25,9 @@ pub(crate) use file_list::{
     load_file_list_operands, operand_is_remote, resolve_file_list_entries,
     resolve_files_from_source,
 };
-pub(crate) use flags::{DEBUG_HELP_TEXT, INFO_HELP_TEXT, parse_debug_flags, parse_info_flags};
+pub(crate) use flags::{
+    DEBUG_HELP_TEXT, INFO_HELP_TEXT, parse_debug_flags, parse_info_flags, parse_info_flags_server,
+};
 pub(crate) use module_list::render_module_list;
 pub(crate) use operands::{extract_operands, parse_bind_address_argument};
 #[cfg(test)]

--- a/crates/cli/src/frontend/server/flags.rs
+++ b/crates/cli/src/frontend/server/flags.rs
@@ -77,6 +77,12 @@ pub(super) struct ServerLongFlags {
     /// Reference directories for basis file lookup.
     /// upstream: options.c:2915-2923 - `--compare-dest`, `--copy-dest`, `--link-dest`
     pub(super) reference_directories: Vec<ReferenceDirectory>,
+    /// Raw `--info=FLAGS` values forwarded by the client.
+    ///
+    /// upstream: options.c:2928-2931 - `server_options()` emits the output of
+    /// `make_output_option(info_words, info_levels, ...)`, so the server
+    /// receives `--info=...` whenever the client has non-default info levels.
+    pub(super) info: Vec<OsString>,
 }
 
 /// Parses all long-form flags from the server argument list.
@@ -115,6 +121,7 @@ pub(super) fn parse_server_long_flags(args: &[OsString]) -> ServerLongFlags {
         iconv: None,
         timeout: None,
         reference_directories: Vec::new(),
+        info: Vec::new(),
     };
 
     for arg in args {
@@ -181,6 +188,11 @@ fn parse_value_bearing_flag(s: &str, flags: &mut ServerLongFlags) {
         flags.timeout = Some(value.to_owned());
     } else if let Some(value) = s.strip_prefix("--io-uring-depth=") {
         flags.io_uring_depth = Some(value.to_owned());
+    // upstream: options.c:2928-2931 - server_options() forwards info levels.
+    // Capture the raw value so run_server_mode can parse it tolerantly via
+    // parse_info_flags_server (mirroring `am_server` in parse_output_words).
+    } else if let Some(value) = s.strip_prefix("--info=") {
+        flags.info.push(OsString::from(value));
     // upstream: options.c:2915-2923 - reference directory args
     } else if let Some(value) = s.strip_prefix("--compare-dest=") {
         flags.reference_directories.push(ReferenceDirectory::new(
@@ -248,4 +260,5 @@ pub(super) fn is_known_server_long_flag(arg: &str) -> bool {
         || arg.starts_with("--iconv=")
         || arg.starts_with("--timeout=")
         || arg.starts_with("--io-uring-depth=")
+        || arg.starts_with("--info=")
 }

--- a/crates/cli/src/frontend/server/run.rs
+++ b/crates/cli/src/frontend/server/run.rs
@@ -91,6 +91,17 @@ where
         return code;
     }
 
+    // upstream: options.c parse_output_words - server-side info parsing
+    // silently ignores unknown tokens so a newer client can forward names
+    // this build has not learned yet. The well-formed empty/level errors
+    // still surface so malformed input is not swallowed entirely.
+    if !long_flags.info.is_empty()
+        && let Err(message) = super::super::execution::parse_info_flags_server(&long_flags.info)
+    {
+        write_server_error(stderr, program_brand, message.text().to_owned());
+        return 1;
+    }
+
     // Boolean and move-only flags applied after value parsing releases its borrow.
     config.deletion.ignore_errors = long_flags.ignore_errors;
     config.write.fsync = long_flags.fsync;

--- a/crates/cli/src/frontend/server/tests.rs
+++ b/crates/cli/src/frontend/server/tests.rs
@@ -414,6 +414,27 @@ fn long_flags_io_uring_depth_default_is_none() {
     assert!(flags.io_uring_depth.is_none());
 }
 
+// upstream: options.c:2928-2931 - server_options() forwards --info=FLAGS so
+// the server must recognise it as a long flag and not let it leak into the
+// positional path list.
+#[test]
+fn long_flags_info_is_captured() {
+    let args = vec![
+        OsString::from("--server"),
+        OsString::from("--info=PROGRESS,STATS"),
+    ];
+    let flags = parse_server_long_flags(&args);
+    assert_eq!(
+        flags
+            .info
+            .iter()
+            .map(|s| s.to_string_lossy().into_owned())
+            .collect::<Vec<_>>(),
+        vec!["PROGRESS,STATS".to_owned()],
+    );
+    assert!(is_known_server_long_flag("--info=PROGRESS,STATS"));
+}
+
 #[test]
 fn long_flags_write_devices() {
     let args = vec![

--- a/crates/cli/src/frontend/tests/info_debug.rs
+++ b/crates/cli/src/frontend/tests/info_debug.rs
@@ -199,7 +199,7 @@ fn info_negation_forms() {
 #[test]
 fn info_rejects_empty_segments() {
     let flags = vec![OsString::from("progress,,stats")];
-    let error = parse_info_flags(&flags).err().expect("parse should fail");
+    let error = parse_info_flags(&flags).expect_err("parse should fail");
     assert!(error.to_string().contains("--info flag must not be empty"));
 }
 
@@ -290,7 +290,7 @@ fn debug_all_and_none() {
 #[test]
 fn debug_rejects_empty_segments() {
     let flags = vec![OsString::from("deltasum,,io")];
-    let error = parse_debug_flags(&flags).err().expect("parse should fail");
+    let error = parse_debug_flags(&flags).expect_err("parse should fail");
     assert!(error.to_string().contains("--debug flag must not be empty"));
 }
 

--- a/crates/cli/src/frontend/tests/info_debug.rs
+++ b/crates/cli/src/frontend/tests/info_debug.rs
@@ -151,9 +151,7 @@ fn info_flist_levels() {
     assert_eq!(settings.flist, Some(2));
 
     let flags = vec![OsString::from("flist3")];
-    let error = parse_info_flags(&flags)
-        .err()
-        .expect("should reject level 3");
+    let error = parse_info_flags(&flags).expect_err("should reject level 3");
     assert!(error.to_string().contains("invalid --info flag"));
 }
 
@@ -172,9 +170,7 @@ fn info_stats_levels() {
     assert_eq!(settings.stats, Some(3));
 
     let flags = vec![OsString::from("stats4")];
-    let error = parse_info_flags(&flags)
-        .err()
-        .expect("should reject level 4");
+    let error = parse_info_flags(&flags).expect_err("should reject level 4");
     assert!(error.to_string().contains("invalid --info flag"));
 }
 
@@ -227,9 +223,7 @@ fn debug_flist_levels() {
     assert_eq!(settings.flist, Some(4));
 
     let flags = vec![OsString::from("flist5")];
-    let error = parse_debug_flags(&flags)
-        .err()
-        .expect("should reject level 5");
+    let error = parse_debug_flags(&flags).expect_err("should reject level 5");
     assert!(error.to_string().contains("invalid --debug flag"));
 }
 
@@ -248,9 +242,7 @@ fn debug_io_levels() {
     assert_eq!(settings.io, Some(4));
 
     let flags = vec![OsString::from("io5")];
-    let error = parse_debug_flags(&flags)
-        .err()
-        .expect("should reject level 5");
+    let error = parse_debug_flags(&flags).expect_err("should reject level 5");
     assert!(error.to_string().contains("invalid --debug flag"));
 }
 


### PR DESCRIPTION
## Summary

Make oc-rsync's `--info=` parser tolerate unknown tokens when running on the server side, matching upstream rsync's `parse_output_words()` (`options.c:465`). The client-side parser keeps erroring on unknown tokens so typos still surface at the source.

This preserves cross-version compatibility: a newer client can forward info names this build has not learned yet without breaking the transfer.

## Upstream reference

```c
// rsync-3.4.1/options.c:465-469 - parse_output_words()
if (len && !words[j].name && !am_server) {
    rprintf(FERROR, "Unknown %s item: \"%.*s\"\n",
        words[j].help, len, str);
    exit_cleanup(RERR_SYNTAX);
}
```

The `!am_server` clause is the entire mechanism: known tokens still apply on either side, but the `Unknown ...` exit only fires on the client.

## Changes

- `parse_info_flags_server()` is a new entry point that calls the shared parser with `am_server=true`; `InfoFlagSettings::apply_with_mode()` skips the unknown-token error in that mode while still rejecting malformed inputs (empty tokens, out-of-range levels for known names).
- Server-mode argument parsing now recognises `--info=FLAGS`, captures the raw values, and validates them via `parse_info_flags_server`. Before this change the argument leaked into the positional path list because `is_known_server_long_flag` did not know about it.

## Test plan

- [ ] `parse_info_flags_client_rejects_unknown_token` - client mode still errors with `Unknown --info item ...`
- [ ] `parse_info_flags_server_accepts_unknown_token` - server mode silently accepts an unknown token
- [ ] `parse_info_flags_server_mixes_known_and_unknown` - known tokens still apply in server mode when unknown ones are interleaved
- [ ] `long_flags_info_is_captured` - server-mode argument parser captures `--info=FLAGS` instead of dropping it into positional args

Refs #2168