### PR TITLE
fix: align --debug=nstr negotiation wording with upstream rsync 3.4.1

### DIFF
--- a/crates/protocol/src/negotiation/capabilities/negotiate.rs
+++ b/crates/protocol/src/negotiation/capabilities/negotiate.rs
@@ -240,6 +240,16 @@ pub fn negotiate_capabilities_with_override(
     // The greeting is just informational; the actual selection uses vstrings.
     let _ = is_daemon_mode; // Exchange happens in all modes when do_negotiation=true
 
+    // upstream: compat.c:521-525 send_negotiate_str
+    // Server emits "Server <type> list (on server): <list>", client emits
+    // "Client <type> list (on client): <list>" at DEBUG_GTE(NSTR, am_server?3:2).
+    let (local_side, remote_side, local_lc) = if is_server {
+        ("Server", "Client", "server")
+    } else {
+        ("Client", "Server", "client")
+    };
+    let send_level = if is_server { 3 } else { 2 };
+
     // Send our supported algorithm lists. upstream: compat.c:541-544
     // When --checksum-choice overrides the selection, advertise only that
     // algorithm (upstream options.c replaces valid_checksums with the user's
@@ -248,24 +258,42 @@ pub fn negotiate_capabilities_with_override(
         Some(algo) => algo.as_str().to_owned(),
         None => SUPPORTED_CHECKSUMS.join(" "),
     };
-    debug_log!(Proto, 2, "sending checksum list: {}", checksum_list);
+    debug_log!(
+        Nstr,
+        send_level,
+        "{local_side} checksum list (on {local_lc}): {checksum_list}"
+    );
     write_vstring(stdout, &checksum_list)?;
 
     if send_compression {
         let compression_list = supported_compressions().join(" ");
-        debug_log!(Proto, 2, "sending compression list: {}", compression_list);
+        debug_log!(
+            Nstr,
+            send_level,
+            "{local_side} compress list (on {local_lc}): {compression_list}"
+        );
         write_vstring(stdout, &compression_list)?;
     }
 
     stdout.flush()?;
 
-    // Read the remote side's algorithm lists. upstream: compat.c:546-564
+    // Read the remote side's algorithm lists. upstream: compat.c:373-378
+    // recv_negotiate_str emits "<remote> <type> list (on <local>): <list>"
+    // at DEBUG_GTE(NSTR, am_server?3:2).
     let remote_checksum_list = read_vstring(stdin)?;
-    debug_log!(Proto, 2, "received checksum list: {}", remote_checksum_list);
+    debug_log!(
+        Nstr,
+        send_level,
+        "{remote_side} checksum list (on {local_lc}): {remote_checksum_list}"
+    );
 
     let remote_compression_list = if send_compression {
         let list = read_vstring(stdin)?;
-        debug_log!(Proto, 2, "received compression list: {}", list);
+        debug_log!(
+            Nstr,
+            send_level,
+            "{remote_side} compress list (on {local_lc}): {list}"
+        );
         Some(list)
     } else {
         None
@@ -312,13 +340,25 @@ pub fn negotiate_capabilities_with_override(
         CompressionAlgorithm::None
     };
 
+    // upstream: compat.c:866 "Client negotiated <type>: <name>"
+    // (NSTR level 1, daemon auth checksum; we reuse the wording for the
+    // bidirectional checksum negotiation summary).
+    let nego_level = if is_server { 3 } else { 1 };
     debug_log!(
-        Proto,
-        1,
-        "negotiated checksum={}, compression={}",
-        checksum.as_str(),
-        compression.as_str()
+        Nstr,
+        nego_level,
+        "{local_side} negotiated checksum: {}",
+        checksum.as_str()
     );
+    // upstream: compat.c:215 "<side> negotiated compress: <name> (level <N>)"
+    if compression != CompressionAlgorithm::None {
+        debug_log!(
+            Nstr,
+            nego_level,
+            "{local_side} negotiated compress: {}",
+            compression.as_str()
+        );
+    }
     Ok(NegotiationResult {
         checksum,
         compression,

--- a/crates/protocol/src/negotiation/capabilities/tests.rs
+++ b/crates/protocol/src/negotiation/capabilities/tests.rs
@@ -179,6 +179,105 @@ fn test_vstring_max_nstr_strlen_limit_accepts_boundary() {
     assert_eq!(received, boundary);
 }
 
+/// Confirms `--debug=nstr` emits the exact wording used by upstream rsync
+/// 3.4.1 (compat.c:373-378, 521-525, 866) for the client-side bidirectional
+/// negotiation exchange.
+#[test]
+fn test_negotiate_nstr_messages_match_upstream_wording_client() {
+    use logging::{DebugFlag, DiagnosticEvent, VerbosityConfig, drain_events, init};
+
+    let mut cfg = VerbosityConfig::default();
+    cfg.debug.nstr = 2;
+    init(cfg);
+    let _ = drain_events();
+
+    let protocol = ProtocolVersion::try_from(32).unwrap();
+    let client_response = b"\x03md5\x04zlib";
+    let mut stdin = &client_response[..];
+    let mut stdout = Vec::new();
+
+    let _ = negotiate_capabilities(protocol, &mut stdin, &mut stdout, true, true, false, false)
+        .unwrap();
+
+    let messages: Vec<String> = drain_events()
+        .into_iter()
+        .filter_map(|event| match event {
+            DiagnosticEvent::Debug { flag, message, .. } if flag == DebugFlag::Nstr => {
+                Some(message)
+            }
+            _ => None,
+        })
+        .collect();
+
+    assert!(
+        messages
+            .iter()
+            .any(|m| m.starts_with("Client checksum list (on client): ")),
+        "missing upstream client send wording: {messages:?}"
+    );
+    assert!(
+        messages
+            .iter()
+            .any(|m| m.starts_with("Client compress list (on client): ")),
+        "missing upstream client compress send wording: {messages:?}"
+    );
+    assert!(
+        messages
+            .iter()
+            .any(|m| m == "Server checksum list (on client): md5"),
+        "missing upstream server recv wording: {messages:?}"
+    );
+    assert!(
+        messages
+            .iter()
+            .any(|m| m == "Server compress list (on client): zlib"),
+        "missing upstream server compress recv wording: {messages:?}"
+    );
+}
+
+/// Confirms `--debug=nstr` level 1 emits upstream's per-side "negotiated"
+/// summary (compat.c:215, 866) using exact wording.
+#[test]
+fn test_negotiate_nstr_summary_matches_upstream_wording_client() {
+    use logging::{DebugFlag, DiagnosticEvent, VerbosityConfig, drain_events, init};
+
+    let mut cfg = VerbosityConfig::default();
+    cfg.debug.nstr = 1;
+    init(cfg);
+    let _ = drain_events();
+
+    let protocol = ProtocolVersion::try_from(32).unwrap();
+    let client_response = b"\x03md5\x04zlib";
+    let mut stdin = &client_response[..];
+    let mut stdout = Vec::new();
+
+    let _ = negotiate_capabilities(protocol, &mut stdin, &mut stdout, true, true, false, false)
+        .unwrap();
+
+    let messages: Vec<String> = drain_events()
+        .into_iter()
+        .filter_map(|event| match event {
+            DiagnosticEvent::Debug { flag, message, .. } if flag == DebugFlag::Nstr => {
+                Some(message)
+            }
+            _ => None,
+        })
+        .collect();
+
+    assert!(
+        messages
+            .iter()
+            .any(|m| m == "Client negotiated checksum: md5"),
+        "missing upstream level-1 checksum summary: {messages:?}"
+    );
+    assert!(
+        messages
+            .iter()
+            .any(|m| m == "Client negotiated compress: zlib"),
+        "missing upstream level-1 compress summary: {messages:?}"
+    );
+}
+
 #[test]
 fn test_vstring_two_byte_format() {
     // Test vstring encoding for length > 127

--- a/crates/protocol/src/negotiation/capabilities/tests.rs
+++ b/crates/protocol/src/negotiation/capabilities/tests.rs
@@ -202,7 +202,7 @@ fn test_negotiate_nstr_messages_match_upstream_wording_client() {
     let messages: Vec<String> = drain_events()
         .into_iter()
         .filter_map(|event| match event {
-            DiagnosticEvent::Debug { flag, message, .. } if flag == DebugFlag::Nstr => {
+            DiagnosticEvent::Debug { flag: DebugFlag::Nstr, message, .. } => {
                 Some(message)
             }
             _ => None,
@@ -257,7 +257,7 @@ fn test_negotiate_nstr_summary_matches_upstream_wording_client() {
     let messages: Vec<String> = drain_events()
         .into_iter()
         .filter_map(|event| match event {
-            DiagnosticEvent::Debug { flag, message, .. } if flag == DebugFlag::Nstr => {
+            DiagnosticEvent::Debug { flag: DebugFlag::Nstr, message, .. } => {
                 Some(message)
             }
             _ => None,

--- a/crates/protocol/src/negotiation/capabilities/tests.rs
+++ b/crates/protocol/src/negotiation/capabilities/tests.rs
@@ -202,9 +202,11 @@ fn test_negotiate_nstr_messages_match_upstream_wording_client() {
     let messages: Vec<String> = drain_events()
         .into_iter()
         .filter_map(|event| match event {
-            DiagnosticEvent::Debug { flag: DebugFlag::Nstr, message, .. } => {
-                Some(message)
-            }
+            DiagnosticEvent::Debug {
+                flag: DebugFlag::Nstr,
+                message,
+                ..
+            } => Some(message),
             _ => None,
         })
         .collect();
@@ -257,9 +259,11 @@ fn test_negotiate_nstr_summary_matches_upstream_wording_client() {
     let messages: Vec<String> = drain_events()
         .into_iter()
         .filter_map(|event| match event {
-            DiagnosticEvent::Debug { flag: DebugFlag::Nstr, message, .. } => {
-                Some(message)
-            }
+            DiagnosticEvent::Debug {
+                flag: DebugFlag::Nstr,
+                message,
+                ..
+            } => Some(message),
             _ => None,
         })
         .collect();

--- a/docs/audits/cli-argument-parity-vs-rsync-manpage.md
+++ b/docs/audits/cli-argument-parity-vs-rsync-manpage.md
@@ -322,12 +322,15 @@ PARTIAL gap closures and parity polish identified during this audit:
    User impact: **rare**, but breaks discovery for new users learning
    the `info`/`debug` category names.
 
-4. **`--debug=nstr` negotiation message wording.**
-   Upstream prints `Client compress: zstd (level 3)`; oc-rsync prints
-   a slightly different wording. Tools that grep `--debug=nstr` for
-   negotiated codec/checksum lose parity. Align the wording in
-   `crates/transfer/src/pipeline/` and add a debug-output snapshot
-   test. User impact: **rare**, scoped to debugging harnesses.
+4. **`--debug=nstr` negotiation message wording.** RESOLVED. Wording
+   in `crates/protocol/src/negotiation/capabilities/negotiate.rs`
+   now matches upstream `compat.c:215,373-378,521-525,866`
+   verbatim (`Client/Server <type> list (on <side>): <list>` and
+   `Client/Server negotiated <type>: <name>`) on the `Nstr` debug
+   target. Unit tests in
+   `crates/protocol/src/negotiation/capabilities/tests.rs` assert
+   the exact wire strings. User impact: **rare**, scoped to
+   debugging harnesses.
 
 5. **`--stop-at=y-m-dTh:m` timezone parity.**
    Upstream parses local time (`util2.c::parse_time`). oc-rsync's

--- a/docs/audits/debug-flags-verbosity-matrix.md
+++ b/docs/audits/debug-flags-verbosity-matrix.md
@@ -134,7 +134,7 @@ Producer counts come from
 | HLINK      | 3 (help says 1-3) | 3 | W_SND\|W_REC | Debug hard-link actions (levels 1-3) | none | missing |
 | ICONV      | 2 | 2 | W_CLI\|W_SRV | Debug iconv character conversions (levels 1-2) | none | missing |
 | IO         | 4 | 4 | W_CLI\|W_SRV | Debug I/O routines (levels 1-4) | `crates/transfer/src/disk_commit/thread.rs:117,125,132,149,153,155` plus `tracing::*(target: "rsync::io", ...)` in `crates/protocol/src/debug_io.rs`, `crates/fast_io/src/debug_io.rs`, `crates/rsync_io/src/debug_io.rs` (`debug_io.rs` trace funcs not called from production - see gap G3) | partial (levels 1 and 3 emitted via `debug_log!`; trace-func helpers unwired) |
-| NSTR       | 2 | u8::MAX | W_CLI\|W_SRV | Debug negotiation strings | none | missing |
+| NSTR       | 2 | u8::MAX | W_CLI\|W_SRV | Debug negotiation strings | `crates/protocol/src/negotiation/capabilities/negotiate.rs` (6 sites covering levels 1-3, upstream-verbatim wording from `compat.c:215,373-378,521-525,866`) | impl |
 | OWN        | 2 | 2 | W_REC | Debug ownership changes in users & groups (levels 1-2) | none | missing |
 | PROTO      | 1 | u8::MAX | W_CLI\|W_SRV | Debug protocol information | `crates/protocol/src/negotiation/capabilities/negotiate.rs`, `crates/protocol/src/multiplex/io/send.rs`, `crates/protocol/src/multiplex/io/recv.rs` (6 sites at levels 1-2) | partial (level 2 not in upstream range) |
 | RECV       | 1 | u8::MAX | W_REC | Debug receiver functions | `crates/transfer/src/receiver/directory/links.rs:264` (1 site at level 2) | partial (level 2 not in upstream range) |
@@ -144,10 +144,10 @@ Producer counts come from
 Total: 24 upstream `DEBUG_*` flags, matching `COUNT_DEBUG = DEBUG_TIME + 1`
 (`rsync.h:1462`). Status roll-up:
 
-- **impl**: 4 - DUP, FILTER, FLIST, TIME.
+- **impl**: 5 - DUP, FILTER, FLIST, NSTR, TIME.
 - **partial**: 7 - CONNECT, DEL, DELTASUM, EXIT, IO, PROTO, RECV.
-- **missing**: 13 - ACL, BACKUP, BIND, CHDIR, CMD, FUZZY, GENR, HASH,
-  HLINK, ICONV, NSTR, OWN, SEND.
+- **missing**: 12 - ACL, BACKUP, BIND, CHDIR, CMD, FUZZY, GENR, HASH,
+  HLINK, ICONV, OWN, SEND.
 
 `SEND` is a notable case: the subsystem module
 (`crates/engine/src/local_copy/debug_send.rs`) is fully implemented


### PR DESCRIPTION
## Summary

`--debug=nstr` was emitting bespoke wording on the `Proto` debug target.
Upstream rsync 3.4.1 gates the equivalent diagnostics on `DEBUG_NSTR`
(`compat.c:215, 373-378, 521-525, 866`) with very specific phrasing that
interop harnesses grep for. This PR rewires the four emission sites in
`negotiate_capabilities_with_override` onto the `Nstr` target and adopts
upstream's verbatim wording.

### Strings changed

| Old (Proto target) | New (Nstr target, upstream wording) | Upstream ref |
|---|---|---|
| `sending checksum list: <list>` | `Client/Server checksum list (on client/server): <list>` | `compat.c:521-525` |
| `sending compression list: <list>` | `Client/Server compress list (on client/server): <list>` | `compat.c:521-525` |
| `received checksum list: <list>` | `Server/Client checksum list (on client/server): <list>` | `compat.c:373-378` |
| `received compression list: <list>` | `Server/Client compress list (on client/server): <list>` | `compat.c:373-378` |
| `negotiated checksum=<X>, compression=<Y>` | `Client/Server negotiated checksum: <X>` + `Client/Server negotiated compress: <Y>` | `compat.c:215, 866` |

Level gating mirrors upstream's `am_server`-aware selection: `am_server ? 3 : 2`
for the list exchange and `am_server ? 3 : 1` for the negotiated summary.

Two unit tests in `crates/protocol/src/negotiation/capabilities/tests.rs`
assert the exact wire strings on a client-side negotiation. Audit
`docs/audits/cli-argument-parity-vs-rsync-manpage.md` C4 is marked
RESOLVED and the NSTR row in `docs/audits/debug-flags-verbosity-matrix.md`
rolls up to `impl`.

Refs #2178.

## Test plan

- [ ] CI: fmt + clippy
- [ ] CI: nextest (stable) - new tests
  `test_negotiate_nstr_messages_match_upstream_wording_client`
  and `test_negotiate_nstr_summary_matches_upstream_wording_client`
- [ ] CI: Windows, macOS, Linux musl