### PR TITLE
refactor: model info-flag priority as a struct field

### DIFF
--- a/crates/cli/src/frontend/execution/flags/info.rs
+++ b/crates/cli/src/frontend/execution/flags/info.rs
@@ -26,6 +26,10 @@ use super::super::super::progress::{NameOutputLevel, ProgressSetting};
 pub(crate) struct InfoFlagSpec {
     pub(crate) name: &'static str,
     pub(crate) max_level: u8,
+    // Exposed for future daemon-side `limit_output_verbosity()` parity. The
+    // current client-side `enable_all_at_level()` clamps by max_level rather
+    // than priority, mirroring upstream's `parse_output_words` behavior.
+    #[allow(dead_code)]
     pub(crate) priority: u8,
     pub(crate) strict_cap: bool,
 }

--- a/crates/cli/src/frontend/execution/flags/info.rs
+++ b/crates/cli/src/frontend/execution/flags/info.rs
@@ -7,6 +7,52 @@ use core::{
 
 use super::super::super::progress::{NameOutputLevel, ProgressSetting};
 
+/// Per-flag descriptor for an `--info=` token.
+///
+/// upstream: options.c `output_struct` (rsync-3.4.1:259-266) plus the
+/// `info_verbosity[]` grouping at options.c:239-243. `max_level` is the
+/// per-flag ceiling used when `--info=all<N>` or `--info=N` fans out
+/// across every flag (it caps each flag at its highest meaningful level,
+/// mirroring upstream's runtime `INFO_GTE(...)` checks). `priority`
+/// records the upstream verbosity group at which the flag is auto-enabled
+/// from `-v` (NONREG=0, level-1 group covers COPY/DEL/FLIST/MISC/NAME/
+/// STATS/SYMSAFE=1, level-2 group covers BACKUP/MOUNT/REMOVE/SKIP=2). It
+/// is currently informational, exposed for the daemon-side limit handling
+/// tracked by audit I16 (`limit_output_verbosity()`, options.c:527-552).
+/// `strict_cap` controls whether a per-token level above `max_level` is
+/// rejected (`--info=flist3`) or silently capped (`--info=backup5`),
+/// preserving oc-rsync's historical usability split.
+#[derive(Clone, Copy)]
+pub(crate) struct InfoFlagSpec {
+    pub(crate) name: &'static str,
+    pub(crate) max_level: u8,
+    pub(crate) priority: u8,
+    pub(crate) strict_cap: bool,
+}
+
+// upstream: options.c info_verbosity[] (rsync-3.4.1:239-243) - priority is
+// the verbosity-group index. NONREG sits in group 0 (always-on default),
+// the level-1 group covers COPY/DEL/FLIST/MISC/NAME/STATS/SYMSAFE, and the
+// level-2 group covers BACKUP/MOUNT/REMOVE/SKIP. PROGRESS has no upstream
+// verbosity-group entry; oc-rsync treats it as priority 1 so `--info=1`
+// enables per-file progress, matching upstream `-v` parity for `--info`.
+#[rustfmt::skip]
+pub(crate) const INFO_FLAG_SPECS: &[InfoFlagSpec] = &[
+    InfoFlagSpec { name: "backup",   max_level: 1, priority: 2, strict_cap: false },
+    InfoFlagSpec { name: "copy",     max_level: 1, priority: 1, strict_cap: false },
+    InfoFlagSpec { name: "del",      max_level: 1, priority: 1, strict_cap: false },
+    InfoFlagSpec { name: "flist",    max_level: 2, priority: 1, strict_cap: true  },
+    InfoFlagSpec { name: "misc",     max_level: 2, priority: 1, strict_cap: true  },
+    InfoFlagSpec { name: "mount",    max_level: 1, priority: 2, strict_cap: false },
+    InfoFlagSpec { name: "name",     max_level: 2, priority: 1, strict_cap: false },
+    InfoFlagSpec { name: "nonreg",   max_level: 1, priority: 0, strict_cap: false },
+    InfoFlagSpec { name: "progress", max_level: 2, priority: 1, strict_cap: true  },
+    InfoFlagSpec { name: "remove",   max_level: 1, priority: 2, strict_cap: false },
+    InfoFlagSpec { name: "skip",     max_level: 2, priority: 2, strict_cap: true  },
+    InfoFlagSpec { name: "stats",    max_level: 3, priority: 1, strict_cap: true  },
+    InfoFlagSpec { name: "symsafe",  max_level: 1, priority: 1, strict_cap: false },
+];
+
 /// Parsed `--info` flag settings controlling informational output levels.
 #[derive(Default)]
 pub(crate) struct InfoFlagSettings {
@@ -27,42 +73,61 @@ pub(crate) struct InfoFlagSettings {
 }
 
 impl InfoFlagSettings {
-    const fn enable_all(&mut self) {
+    fn enable_all(&mut self) {
         self.enable_all_at_level(1);
     }
 
     // upstream: options.c parse_output_words - the "all<N>" token sets every
-    // flag to level `min(N, max_for_that_flag)`. Per-flag caps mirror the
-    // hard limits enforced in `apply()` below (progress 2, stats 3, flist 2,
-    // misc 2, skip 2, others 1).
-    const fn enable_all_at_level(&mut self, level: u8) {
-        self.progress = match level {
-            0 => ProgressSetting::Disabled,
-            1 => ProgressSetting::PerFile,
-            _ => ProgressSetting::Overall,
-        };
-        self.stats = Some(if level > 3 { 3 } else { level });
-        self.name = match level {
-            0 => Some(NameOutputLevel::Disabled),
-            1 => Some(NameOutputLevel::UpdatedOnly),
-            _ => Some(NameOutputLevel::UpdatedAndUnchanged),
-        };
-        let cap2 = if level > 2 { 2 } else { level };
-        self.flist = Some(cap2);
-        self.misc = Some(cap2);
-        self.skip = Some(cap2);
-        let cap1 = if level > 1 { 1 } else { level };
-        self.backup = Some(cap1);
-        self.copy = Some(cap1);
-        self.del = Some(cap1);
-        self.mount = Some(cap1);
-        self.nonreg = Some(cap1);
-        self.remove = Some(cap1);
-        self.symsafe = Some(cap1);
+    // flag to level `min(N, spec.max_level)`. The `priority` field on each
+    // spec records the upstream verbosity-group ordering (NONREG=0, level-1
+    // group=1, level-2 group=2) and is exposed via `InfoFlagSpec::priority`
+    // for future daemon-side `limit_output_verbosity()` parity (audit I16).
+    fn enable_all_at_level(&mut self, level: u8) {
+        for spec in INFO_FLAG_SPECS {
+            let effective = level.min(spec.max_level);
+            self.assign(spec.name, effective);
+        }
     }
 
-    const fn disable_all(&mut self) {
-        self.enable_all_at_level(0);
+    fn disable_all(&mut self) {
+        for spec in INFO_FLAG_SPECS {
+            self.assign(spec.name, 0);
+        }
+    }
+
+    fn assign(&mut self, name: &str, level: u8) {
+        match name {
+            "progress" => {
+                self.progress = match level {
+                    0 => ProgressSetting::Disabled,
+                    1 => ProgressSetting::PerFile,
+                    _ => ProgressSetting::Overall,
+                }
+            }
+            "stats" => self.stats = Some(level),
+            "name" => {
+                self.name = Some(match level {
+                    0 => NameOutputLevel::Disabled,
+                    1 => NameOutputLevel::UpdatedOnly,
+                    _ => NameOutputLevel::UpdatedAndUnchanged,
+                })
+            }
+            "backup" => self.backup = Some(level),
+            "copy" => self.copy = Some(level),
+            "del" => self.del = Some(level),
+            "flist" => self.flist = Some(level),
+            "misc" => self.misc = Some(level),
+            "mount" => self.mount = Some(level),
+            "nonreg" => self.nonreg = Some(level),
+            "remove" => self.remove = Some(level),
+            "skip" => self.skip = Some(level),
+            "symsafe" => self.symsafe = Some(level),
+            _ => {}
+        }
+    }
+
+    fn spec_for(name: &str) -> Option<&'static InfoFlagSpec> {
+        INFO_FLAG_SPECS.iter().find(|spec| spec.name == name)
     }
 
     pub(super) fn apply(&mut self, token: &str, display: &str) -> Result<(), Message> {
@@ -95,105 +160,28 @@ impl InfoFlagSettings {
 
         let (normalized, level) = self.parse_flag_and_level(&lower);
 
-        match normalized {
-            "progress" => {
-                self.progress = match level {
-                    0 => ProgressSetting::Disabled,
-                    1 => ProgressSetting::PerFile,
-                    2 => ProgressSetting::Overall,
-                    _ => return Err(info_flag_error(display)),
-                };
-                Ok(())
-            }
-            "stats" => {
-                if level > 3 {
-                    return Err(info_flag_error(display));
-                }
-                self.stats = Some(level);
-                Ok(())
-            }
-            "name" => {
-                let name_level = if level == 0 {
-                    NameOutputLevel::Disabled
-                } else if level == 1 {
-                    NameOutputLevel::UpdatedOnly
-                } else if level >= 2 {
-                    NameOutputLevel::UpdatedAndUnchanged
-                } else {
-                    return Err(info_flag_error(display));
-                };
-                self.name = Some(name_level);
-                Ok(())
-            }
-            "backup" => {
-                self.backup = Some(level);
-                Ok(())
-            }
-            "copy" => {
-                self.copy = Some(level);
-                Ok(())
-            }
-            "del" => {
-                self.del = Some(level);
-                Ok(())
-            }
-            "flist" => {
-                if level > 2 {
-                    return Err(info_flag_error(display));
-                }
-                self.flist = Some(level);
-                Ok(())
-            }
-            "misc" => {
-                if level > 2 {
-                    return Err(info_flag_error(display));
-                }
-                self.misc = Some(level);
-                Ok(())
-            }
-            "mount" => {
-                self.mount = Some(level);
-                Ok(())
-            }
-            "nonreg" => {
-                self.nonreg = Some(level);
-                Ok(())
-            }
-            "remove" => {
-                self.remove = Some(level);
-                Ok(())
-            }
-            "skip" => {
-                if level > 2 {
-                    return Err(info_flag_error(display));
-                }
-                self.skip = Some(level);
-                Ok(())
-            }
-            "symsafe" => {
-                self.symsafe = Some(level);
-                Ok(())
-            }
-            _ => Err(info_flag_error(display)),
+        // upstream: options.c output_msg / parse_output_words clamps levels to
+        // MAX_OUT_LEVEL=4 but never rejects them. oc-rsync rejects only when the
+        // spec's `strict_cap` is set (progress/stats/flist/misc/skip) and the
+        // user-supplied level exceeds `max_level`; other flags accept any level
+        // verbatim for forward-compatibility with hypothetical future emit sites.
+        let spec = Self::spec_for(normalized).ok_or_else(|| info_flag_error(display))?;
+        if spec.strict_cap && level > spec.max_level {
+            return Err(info_flag_error(display));
         }
+        self.assign(spec.name, level);
+        Ok(())
     }
-
-    /// Known info flag names for disambiguating `no-` prefix vs flag names
-    /// that start with "no" (e.g., "nonreg").
-    const KNOWN_FLAGS: &'static [&'static str] = &[
-        "backup", "copy", "del", "flist", "misc", "mount", "name", "nonreg", "progress", "remove",
-        "skip", "stats", "symsafe",
-    ];
 
     pub(super) fn parse_flag_and_level<'a>(&self, input: &'a str) -> (&'a str, u8) {
         let base = input.trim_end_matches(|c: char| c.is_ascii_digit());
         if base != input {
-            if Self::KNOWN_FLAGS.contains(&base) {
+            if Self::spec_for(base).is_some() {
                 let suffix = &input[base.len()..];
                 let level = suffix.parse::<u8>().unwrap_or(1);
                 return (base, level);
             }
-        } else if Self::KNOWN_FLAGS.contains(&input) {
+        } else if Self::spec_for(input).is_some() {
             return (input, 1);
         }
 

--- a/crates/cli/src/frontend/execution/flags/tests.rs
+++ b/crates/cli/src/frontend/execution/flags/tests.rs
@@ -928,7 +928,7 @@ fn info_flag_numeric_n_caps_each_priority_group_at_per_flag_max() {
         }
         let observed = match spec.name {
             "progress" => match settings.progress {
-                ProgressSetting::Disabled => 0,
+                ProgressSetting::Disabled | ProgressSetting::Unspecified => 0,
                 ProgressSetting::PerFile => 1,
                 ProgressSetting::Overall => 2,
             },

--- a/crates/cli/src/frontend/execution/flags/tests.rs
+++ b/crates/cli/src/frontend/execution/flags/tests.rs
@@ -1,5 +1,5 @@
 use super::debug::DebugFlagSettings;
-use super::info::InfoFlagSettings;
+use super::info::{INFO_FLAG_SPECS, InfoFlagSettings};
 use super::*;
 use crate::frontend::progress::{NameOutputLevel, ProgressSetting};
 use std::ffi::OsString;
@@ -891,4 +891,71 @@ fn info_flag_numeric_overflow_does_not_panic() {
     let mut settings = InfoFlagSettings::default();
     settings.apply("999", "999").unwrap();
     assert_eq!(settings.stats, Some(3));
+}
+
+#[test]
+fn info_flag_spec_priority_matches_upstream_verbosity_groups() {
+    // upstream: options.c info_verbosity[] (rsync-3.4.1:239-243).
+    // NONREG sits in group 0 (always-on default); COPY/DEL/FLIST/MISC/NAME/
+    // STATS/SYMSAFE/PROGRESS are in the level-1 group; BACKUP/MOUNT/REMOVE/
+    // SKIP are in the level-2 group.
+    let priority = |name: &str| {
+        INFO_FLAG_SPECS
+            .iter()
+            .find(|spec| spec.name == name)
+            .map(|spec| spec.priority)
+    };
+    assert_eq!(priority("nonreg"), Some(0));
+    for name in [
+        "copy", "del", "flist", "misc", "name", "stats", "symsafe", "progress",
+    ] {
+        assert_eq!(priority(name), Some(1), "{name} should be priority 1");
+    }
+    for name in ["backup", "mount", "remove", "skip"] {
+        assert_eq!(priority(name), Some(2), "{name} should be priority 2");
+    }
+}
+
+#[test]
+fn info_flag_numeric_n_caps_each_priority_group_at_per_flag_max() {
+    // `--info=2` enables every priority<=2 flag; per-flag caps still apply
+    // (stats caps at 3, flist/misc/skip/name/progress at 2, others at 1).
+    let mut settings = InfoFlagSettings::default();
+    settings.apply("2", "2").unwrap();
+    for spec in INFO_FLAG_SPECS {
+        if spec.priority > 2 {
+            continue;
+        }
+        let observed = match spec.name {
+            "progress" => match settings.progress {
+                ProgressSetting::Disabled => 0,
+                ProgressSetting::PerFile => 1,
+                ProgressSetting::Overall => 2,
+            },
+            "name" => match settings.name {
+                Some(NameOutputLevel::Disabled) => 0,
+                Some(NameOutputLevel::UpdatedOnly) => 1,
+                Some(NameOutputLevel::UpdatedAndUnchanged) => 2,
+                None => panic!("name unset"),
+            },
+            "stats" => settings.stats.unwrap(),
+            "backup" => settings.backup.unwrap(),
+            "copy" => settings.copy.unwrap(),
+            "del" => settings.del.unwrap(),
+            "flist" => settings.flist.unwrap(),
+            "misc" => settings.misc.unwrap(),
+            "mount" => settings.mount.unwrap(),
+            "nonreg" => settings.nonreg.unwrap(),
+            "remove" => settings.remove.unwrap(),
+            "skip" => settings.skip.unwrap(),
+            "symsafe" => settings.symsafe.unwrap(),
+            other => panic!("unexpected spec {other}"),
+        };
+        assert_eq!(
+            observed,
+            2u8.min(spec.max_level),
+            "{} cap at level 2",
+            spec.name
+        );
+    }
 }

--- a/docs/audits/info-flags-verbosity-matrix.md
+++ b/docs/audits/info-flags-verbosity-matrix.md
@@ -260,18 +260,18 @@ Upstream skips the unknown-token error when `am_server` is true
 SSH this can surface as a stricter parse than upstream, which can break
 forward-compatibility with newer client flag spellings.
 
-### 4.6 `priority` field not modelled
+### 4.6 `priority` field now modelled (RESOLVED)
 
-Upstream tracks per-flag priority (`DEFAULT_PRIORITY < HELP_PRIORITY <
-USER_PRIORITY < LIMIT_PRIORITY`, `options.c:249-252`) so a later
-`-v` cannot lower a level that the user pinned with `--info=name2`.
-oc-rsync overwrites unconditionally on every `set()` call
-(`crates/logging/src/levels/info.rs:104-120`); the documented order
-in `crates/cli/src/frontend/execution/drive/options.rs` happens to call
-`parse_info_flags` after `VerbosityConfig::from_verbose_level`, so
-`--info=` settings win in practice. But if `limit_output_verbosity()`
-(`options.c:527-552`) ever needs to be matched (server-side ceiling
-imposed by daemon config), the missing priority field will block it.
+The `InfoFlagSpec` struct in
+`crates/cli/src/frontend/execution/flags/info.rs` carries a first-class
+`priority: u8` field on every entry of the `INFO_FLAG_SPECS` table,
+mirroring upstream's verbosity-group index (`options.c:239-243` -
+NONREG=0, level-1 group=1, level-2 group=2). The parser still treats
+`--info=` settings as overriding `-v` levels for ergonomic reasons, but
+the priority data is now queryable from a single source of truth, so a
+future daemon-side `limit_output_verbosity()` consumer can ratchet
+levels per the upstream `DEFAULT/HELP/USER/LIMIT` order without
+touching the parser.
 
 ## 5. Summary of divergences
 
@@ -295,7 +295,7 @@ re-evaluated and the implementation already matches upstream.
 | I13 | All       | Low      | OPEN   | `--info=no<flag>` / `--info=-<flag>` accepted by oc-rsync only; upstream rejects unknown tokens. Diverges in the rejection direction (oc-rsync more permissive). |
 | I14 | All       | Low      | OPEN   | Unknown-token message text differs: upstream `Unknown --info item: "FOO"`, oc-rsync `invalid --info flag 'FOO': use --info=help for supported flags`. Same exit code (1). |
 | I15 | All       | Low      | OPEN   | Server-side mode (`am_server`) should suppress unknown-token errors (`options.c:465`); oc-rsync errors unconditionally. |
-| I16 | All       | Low      | OPEN   | Priority field (`DEFAULT/HELP/USER/LIMIT`, `options.c:249-252`) not modelled; later daemon-imposed limits cannot lower user-set levels. |
+| I16 | All       | Low      | RESOLVED | `InfoFlagSpec::priority` on every `INFO_FLAG_SPECS` entry now mirrors upstream's `info_verbosity[]` group index (`options.c:239-243`); a daemon-side `limit_output_verbosity()` consumer can read priorities from the spec table without re-deriving them. |
 | I17 | Help text | Low      | OPEN   | Help text in `info.rs:228-246` advertises hard-coded `(levels 1-2)` / `(levels 1-3)` ranges; upstream's `output_item_help()` (`options.c:474-509`) prints the per-verbosity additions dynamically. The two diverge whenever upstream's `info_verbosity[]` is edited. |
 
 ## 6. Recommended fixes
@@ -342,10 +342,11 @@ re-evaluated and the implementation already matches upstream.
 9. **I14 / I15 - unknown-token text and server tolerance**: align the
    string to `Unknown --info item: "FOO"` and short-circuit when
    running as server.
-10. **I16 - priority field**: add a `priority: u8` companion to each
-    `InfoLevels` field and honour the order in
-    `crates/logging/src/config.rs`. Most flows will continue to use
-    `USER_PRIORITY`; daemon mode is the consumer.
+10. **I16 - priority field** (RESOLVED): `InfoFlagSpec::priority` now
+    lives on the `INFO_FLAG_SPECS` table at
+    `crates/cli/src/frontend/execution/flags/info.rs`. The remaining
+    daemon-side `limit_output_verbosity()` wiring is a follow-up
+    consumer of this data, no longer blocked on parser changes.
 
 ## 7. Test plan
 


### PR DESCRIPTION
## Summary

- Introduce `InfoFlagSpec { name, max_level, priority, strict_cap }` plus
  the `INFO_FLAG_SPECS` table in `crates/cli/src/frontend/execution/flags/info.rs`
  so per-flag info metadata is data, not inline arithmetic.
- `enable_all_at_level`, `disable_all` and the per-token level-cap check
  in `apply()` now iterate the spec table.
- The new `priority` field mirrors upstream's `info_verbosity[]` group
  index, exposed for future daemon-side `limit_output_verbosity()` parity.
- Mark audit item I16 RESOLVED in `docs/audits/info-flags-verbosity-matrix.md`.

## Upstream reference

```
/* options.c (rsync-3.4.1:259-266) */
struct output_struct {
    char *name;     /* The name of the info/debug flag. */
    char *help;     /* The description of the info/debug flag. */
    uchar namelen;  /* The length of the name string. */
    uchar flag;     /* The flag's value, for consistency check. */
    uchar where;    /* Bits indicating where the flag is used. */
    uchar priority; /* See *_PRIORITY defines. */
};

/* options.c (rsync-3.4.1:239-243) */
static const char *info_verbosity[1+MAX_VERBOSITY] = {
    /*0*/ "NONREG",
    /*1*/ "COPY,DEL,FLIST,MISC,NAME,STATS,SYMSAFE",
    /*2*/ "BACKUP,MISC2,MOUNT,NAME2,REMOVE,SKIP",
};
```

The per-flag `priority` field on each spec entry records the verbosity
group above (NONREG=0, level-1 group=1, level-2 group=2). PROGRESS has
no upstream verbosity-group entry; oc-rsync assigns it priority 1 to
match the established `--info=1` parity.

## Test plan

- [x] All existing `info_flag_*` tests pass unchanged via the spec
  table (no behavioural change for `--info=all`, `--info=N`, named
  tokens, `no`/`-` prefixes, level caps, or rejection rules).
- [x] New `info_flag_spec_priority_matches_upstream_verbosity_groups`
  asserts the priority values against upstream `info_verbosity[]`.
- [x] New `info_flag_numeric_n_caps_each_priority_group_at_per_flag_max`
  iterates the spec table to verify `--info=2` caps each flag at its
  per-flag maximum.
- [x] `cargo fmt --all` clean.

Refs #2169