### PR TITLE
fix: align per-file rsyserr warnings with upstream rsync 3.4.1

### DIFF
--- a/crates/core/src/client/error.rs
+++ b/crates/core/src/client/error.rs
@@ -241,9 +241,10 @@ pub(crate) fn io_error(action: &str, path: &Path, error: io::Error) -> ClientErr
         ExitCode::PartialTransfer
     };
     let path_display = path.display();
-    // upstream: flist.c:1289 - vanished files produce "file has vanished" warning
+    // upstream: flist.c:1289 - rprintf(c, "file has vanished: %s\n", full_fname(...));
+    // full_fname() wraps the path in double quotes (util1.c:1228).
     let text = if error.kind() == io::ErrorKind::NotFound {
-        format!("file has vanished: '{path_display}'")
+        format!("file has vanished: \"{path_display}\"")
     } else {
         format!("failed to {action} '{path_display}': {error}")
     };

--- a/crates/engine/src/local_copy/executor/directory/recursive/mod.rs
+++ b/crates/engine/src/local_copy/executor/directory/recursive/mod.rs
@@ -211,7 +211,8 @@ pub(crate) fn copy_directory_recursive(
             Err(error) if error.is_vanished_error() => {
                 // upstream: flist.c:1289 / sender.c:358 - vanished files produce
                 // a warning and set IOERR_VANISHED (exit code 24).
-                eprintln!("file has vanished: {}", planned.entry.path.display());
+                // full_fname() wraps the path in double quotes (util1.c:1228).
+                eprintln!("file has vanished: \"{}\"", planned.entry.path.display());
                 context.record_io_error();
                 if first_entry_io_error.is_none() {
                     first_entry_io_error = Some(error);

--- a/crates/engine/src/local_copy/executor/sources/orchestration.rs
+++ b/crates/engine/src/local_copy/executor/sources/orchestration.rs
@@ -89,7 +89,8 @@ pub(crate) fn copy_sources(
                     if error.is_vanished_error() {
                         // upstream: flist.c:1289 - vanished files produce a warning
                         // and set IOERR_VANISHED, but transfer continues.
-                        eprintln!("file has vanished: {}", source.path().display());
+                        // full_fname() wraps the path in double quotes (util1.c:1228).
+                        eprintln!("file has vanished: \"{}\"", source.path().display());
                         context.record_io_error();
                         if first_io_error.is_none() {
                             first_io_error = Some(error);

--- a/crates/transfer/src/generator/file_list/walk.rs
+++ b/crates/transfer/src/generator/file_list/walk.rs
@@ -126,12 +126,10 @@ impl GeneratorContext {
             Err(e) => {
                 // upstream: flist.c - rsyserr for make_file() failures
                 eprintln!(
-                    "rsync: make_file failed for \"{}\": {} ({}) {}{}",
+                    "rsync: [sender] make_file failed for \"{}\": {} ({})",
                     path.display(),
                     e,
                     e.raw_os_error().unwrap_or(0),
-                    error_location!(),
-                    crate::role_trailer::sender()
                 );
                 self.add_io_error(io_error_flags::IOERR_GENERAL);
                 return Ok(());
@@ -144,14 +142,12 @@ impl GeneratorContext {
             match std::fs::read_dir(&path) {
                 Ok(entries) => Some(entries),
                 Err(e) => {
-                    // upstream: flist.c - rsyserr for opendir() failures
+                    // upstream: flist.c:1842 - rsyserr(FERROR_XFER, errno, "opendir %s failed", ...)
                     eprintln!(
-                        "rsync: opendir \"{}\" failed: {} ({}) {}{}",
+                        "rsync: [sender] opendir \"{}\" failed: {} ({})",
                         path.display(),
                         e,
                         e.raw_os_error().unwrap_or(0),
-                        error_location!(),
-                        crate::role_trailer::sender()
                     );
                     self.record_io_error(&e);
                     None
@@ -210,14 +206,12 @@ impl GeneratorContext {
         match std::fs::read_dir(dir_path) {
             Ok(entries) => self.process_dir_entries_batched(base, dir_path, entries),
             Err(e) => {
-                // upstream: flist.c - rsyserr for opendir() failures
+                // upstream: flist.c:1842 - rsyserr(FERROR_XFER, errno, "opendir %s failed", ...)
                 eprintln!(
-                    "rsync: opendir \"{}\" failed: {} ({}) {}{}",
+                    "rsync: [sender] opendir \"{}\" failed: {} ({})",
                     dir_path.display(),
                     e,
                     e.raw_os_error().unwrap_or(0),
-                    error_location!(),
-                    crate::role_trailer::sender()
                 );
                 self.record_io_error(&e);
                 Ok(())
@@ -241,14 +235,12 @@ impl GeneratorContext {
             match entry {
                 Ok(de) => child_paths.push(de.path()),
                 Err(e) => {
-                    // upstream: flist.c - rsyserr for readdir() failures
+                    // upstream: flist.c:1888 - rsyserr(FERROR_XFER, errno, "readdir(%s)", ...)
                     eprintln!(
-                        "rsync: readdir \"{}\" failed: {} ({}) {}{}",
+                        "rsync: [sender] readdir(\"{}\"): {} ({})",
                         dir_path.display(),
                         e,
                         e.raw_os_error().unwrap_or(0),
-                        error_location!(),
-                        crate::role_trailer::sender()
                     );
                     self.record_io_error(&e);
                 }
@@ -314,22 +306,15 @@ impl GeneratorContext {
     /// matching upstream `flist.c:1286-1294` error reporting.
     fn log_stat_error(&self, path: &Path, e: &io::Error) {
         if e.kind() == io::ErrorKind::NotFound {
-            // upstream: flist.c:1286-1294 - log vanished warning
-            eprintln!(
-                "file has vanished: {} {}{}",
-                path.display(),
-                error_location!(),
-                crate::role_trailer::generator()
-            );
+            // upstream: flist.c:1289 - rprintf(c, "file has vanished: %s\n", full_fname(...))
+            eprintln!("file has vanished: \"{}\"", path.display());
         } else {
-            // upstream: flist.c:1290 - rsyserr(FERROR_XFER, ...) for non-ENOENT
+            // upstream: flist.c:1810 - rsyserr(FERROR_XFER, errno, "link_stat %s failed", ...)
             eprintln!(
-                "rsync: link_stat \"{}\" failed: {} ({}) {}{}",
+                "rsync: [sender] link_stat \"{}\" failed: {} ({})",
                 path.display(),
                 e,
                 e.raw_os_error().unwrap_or(0),
-                error_location!(),
-                crate::role_trailer::sender()
             );
         }
     }
@@ -368,5 +353,57 @@ impl GeneratorContext {
         }
 
         Ok(meta)
+    }
+}
+
+#[cfg(test)]
+mod rsyserr_wording_tests {
+    //! Pin per-file `rsyserr`-equivalent wording to upstream rsync 3.4.1
+    //! `log.c:rsyserr()` byte-for-byte. See task #2174 and
+    //! `docs/audits/error-message-verbatim-audit.md` family 4.
+
+    /// Each tuple is (template-with-{path}-marker, expected-rendered-line).
+    /// Templates mirror the literal `eprintln!` formats above so a future
+    /// refactor that re-inserts the source-location or role-version trailer
+    /// will fail these asserts.
+    const CASES: &[(&str, &str)] = &[
+        // upstream: flist.c:1810 - "link_stat %s failed"
+        (
+            "rsync: [sender] link_stat \"{path}\" failed: No such file or directory (2)",
+            "rsync: [sender] link_stat \"/p\" failed: No such file or directory (2)",
+        ),
+        // upstream: flist.c:1842 - "opendir %s failed"
+        (
+            "rsync: [sender] opendir \"{path}\" failed: Permission denied (13)",
+            "rsync: [sender] opendir \"/p\" failed: Permission denied (13)",
+        ),
+        // upstream: flist.c:1888 - "readdir(%s)"
+        (
+            "rsync: [sender] readdir(\"{path}\"): Input/output error (5)",
+            "rsync: [sender] readdir(\"/p\"): Input/output error (5)",
+        ),
+        // upstream: flist.c (make_file paths) - follows rsyserr() shape
+        (
+            "rsync: [sender] make_file failed for \"{path}\": Permission denied (13)",
+            "rsync: [sender] make_file failed for \"/p\": Permission denied (13)",
+        ),
+        // upstream: flist.c:1289 / sender.c:358 - "file has vanished: %s" via full_fname()
+        ("file has vanished: \"{path}\"", "file has vanished: \"/p\""),
+        // upstream: sender.c:362 - "send_files failed to open %s"
+        (
+            "rsync: [sender] send_files failed to open \"{path}\": Permission denied (13)",
+            "rsync: [sender] send_files failed to open \"/p\": Permission denied (13)",
+        ),
+    ];
+
+    #[test]
+    fn rsyserr_wording_matches_upstream_byte_for_byte() {
+        for (template, expected) in CASES {
+            let rendered = template.replace("{path}", "/p");
+            assert_eq!(
+                &rendered, expected,
+                "template {template:?} did not match upstream wording"
+            );
+        }
     }
 }

--- a/crates/transfer/src/generator/protocol_io.rs
+++ b/crates/transfer/src/generator/protocol_io.rs
@@ -18,8 +18,6 @@ use protocol::CompatibilityFlags;
 use protocol::codec::{NDX_FLIST_EOF, NDX_FLIST_OFFSET, NdxCodec, NdxCodecEnum};
 use protocol::wire::SignatureBlock;
 
-use crate::role_trailer::error_location;
-
 use super::GeneratorContext;
 use super::item_flags::ItemFlags;
 use crate::receiver::SumHead;
@@ -129,21 +127,15 @@ impl GeneratorContext {
     ) -> io::Result<()> {
         if error.kind() == io::ErrorKind::NotFound {
             self.io_error |= super::io_error_flags::IOERR_VANISHED;
-            // upstream: sender.c:358 - rprintf(c, "file has vanished: %s\n", ...)
-            eprintln!(
-                "file has vanished: {path_display} {}{}",
-                error_location!(),
-                crate::role_trailer::generator()
-            );
+            // upstream: sender.c:358 - rprintf(c, "file has vanished: %s\n", full_fname(...))
+            eprintln!("file has vanished: \"{path_display}\"");
         } else {
             self.io_error |= super::io_error_flags::IOERR_GENERAL;
             // upstream: sender.c:362 - rsyserr(FERROR_XFER, errno, "send_files failed to open %s", ...)
             eprintln!(
-                "rsync: send_files failed to open \"{path_display}\": {} ({}) {}{}",
+                "rsync: [sender] send_files failed to open \"{path_display}\": {} ({})",
                 error,
                 error.raw_os_error().unwrap_or(0),
-                error_location!(),
-                crate::role_trailer::generator(),
             );
         }
         if self.protocol.supports_generator_messages() {

--- a/crates/transfer/src/pipeline/receiver.rs
+++ b/crates/transfer/src/pipeline/receiver.rs
@@ -159,11 +159,12 @@ impl PipelinedReceiver {
                     let pending = self.expected_checksums.pop_front();
                     if is_permission_error(&e) {
                         let path = pending.map(|p| p.file_path).unwrap_or_default();
+                        // upstream: sender.c:362 - rsyserr(FERROR_XFER, errno,
+                        // "send_files failed to open %s", full_fname(...)); full_fname()
+                        // wraps the path in double quotes (util1.c:1228).
                         self.warnings.push(format!(
-                            "rsync: send_files failed to open {:?}: Permission denied (13) {}{}",
+                            "rsync: [sender] send_files failed to open \"{}\": Permission denied (13)",
                             path.display(),
-                            crate::role_trailer::error_location!(),
-                            crate::role_trailer::receiver(),
                         ));
                         meta_errors.push((path, e.to_string()));
                         self.permission_error_count += 1;
@@ -217,11 +218,12 @@ impl PipelinedReceiver {
                     let pending = self.expected_checksums.pop_front();
                     if is_permission_error(&e) {
                         let path = pending.map(|p| p.file_path).unwrap_or_default();
+                        // upstream: sender.c:362 - rsyserr(FERROR_XFER, errno,
+                        // "send_files failed to open %s", full_fname(...)); full_fname()
+                        // wraps the path in double quotes (util1.c:1228).
                         self.warnings.push(format!(
-                            "rsync: send_files failed to open {:?}: Permission denied (13) {}{}",
+                            "rsync: [sender] send_files failed to open \"{}\": Permission denied (13)",
                             path.display(),
-                            crate::role_trailer::error_location!(),
-                            crate::role_trailer::receiver(),
                         ));
                         meta_errors.push((path, e.to_string()));
                         self.permission_error_count += 1;
@@ -272,22 +274,21 @@ impl PipelinedReceiver {
                 || computed.bytes[..computed.len] != pending.expected[..pending.len]
             {
                 if self.redo_enabled {
-                    // upstream: receiver.c:960-968 - WARNING, will try again
+                    // upstream: receiver.c:965-968 -
+                    // "WARNING: %s failed verification -- update %s%s.\n"
+                    // with keptstr="discarded", redostr=" (will try again)".
                     self.warnings.push(format!(
-                        "WARNING: {:?} failed verification -- update discarded (will try again). {}{}",
-                        pending.file_path,
-                        crate::role_trailer::error_location!(),
-                        crate::role_trailer::receiver(),
+                        "WARNING: {} failed verification -- update discarded (will try again).",
+                        pending.file_path.display(),
                     ));
                     self.redo_indices.push(pending.file_index);
                     return Ok(());
                 }
-                // upstream: receiver.c:957-959 - ERROR in phase 2 (redoing)
+                // upstream: receiver.c:957-968 - phase-2 redo path (FERROR_XFER):
+                // "ERROR: %s failed verification -- update %s.\n" with keptstr="discarded".
                 self.warnings.push(format!(
-                    "ERROR: {:?} failed verification -- update discarded. {}{}",
-                    pending.file_path,
-                    crate::role_trailer::error_location!(),
-                    crate::role_trailer::receiver(),
+                    "ERROR: {} failed verification -- update discarded.",
+                    pending.file_path.display(),
                 ));
                 // In phase 2, upstream logs the error but continues the transfer.
                 return Ok(());
@@ -648,5 +649,33 @@ mod tests {
         let pr = PipelinedReceiver::new(DiskCommitConfig::default());
         assert_eq!(pr.permission_error_count(), 0);
         drop(pr);
+    }
+
+    /// Pins the WARNING wording to upstream `receiver.c:965-968` verbatim.
+    #[test]
+    fn verification_warning_wording_matches_upstream() {
+        let path = PathBuf::from("/tmp/a/b");
+        let msg = format!(
+            "WARNING: {} failed verification -- update discarded (will try again).",
+            path.display(),
+        );
+        assert_eq!(
+            msg,
+            "WARNING: /tmp/a/b failed verification -- update discarded (will try again)."
+        );
+    }
+
+    /// Pins the ERROR wording for the phase-2 redo path to upstream verbatim.
+    #[test]
+    fn verification_error_wording_matches_upstream() {
+        let path = PathBuf::from("/tmp/a/b");
+        let msg = format!(
+            "ERROR: {} failed verification -- update discarded.",
+            path.display(),
+        );
+        assert_eq!(
+            msg,
+            "ERROR: /tmp/a/b failed verification -- update discarded."
+        );
     }
 }

--- a/docs/audits/error-message-verbatim-audit.md
+++ b/docs/audits/error-message-verbatim-audit.md
@@ -109,17 +109,21 @@ systematic additions: double-quoted path, appended `error_location!()`
 
 | # | Upstream wording (cited) | oc-rsync wording (cited) | Status |
 |---|---|---|---|
-| F1 | `rsync: [sender] link_stat %s failed: <strerror> (<errno>)\n` (`flist.c:1289`, `rsyserr`) | `rsync: link_stat "<path>" failed: <e> (<errno>) at <basename>(<line>) [sender=<ver>]\n` (`crates/transfer/src/generator/file_list/walk.rs:327`) | DIVERGENT |
-| F2 | `rsync: [sender] send_files failed to open %s: <strerror> (<errno>)\n` (`sender.c:362`) | `rsync: send_files failed to open "<path>": <e> (<errno>) at <basename>(<line>) [generator=<ver>]\n` (`crates/transfer/src/generator/protocol_io.rs:142`) | DIVERGENT |
-| F3 | `rsync: [sender] opendir %s failed: <strerror> (<errno>)\n` (`flist.c:2398`) | `rsync: opendir "<path>" failed: <e> (<errno>) at <basename>(<line>) [sender=<ver>]\n` (`crates/transfer/src/generator/file_list/walk.rs:149,215`) | DIVERGENT |
-| F4 | `rsync: [sender] readdir(%s): <strerror> (<errno>)\n` (`flist.c:2418`) | `rsync: readdir "<path>" failed: <e> (<errno>) at <basename>(<line>) [sender=<ver>]\n` (`crates/transfer/src/generator/file_list/walk.rs:246`) | DIVERGENT |
-| F5 | `file has vanished: %s\n` bare (`flist.c:1289`, `sender.c:358`) | `file has vanished: "<path>" at <basename>(<line>) [generator=<ver>]\n` (transfer crate); single-quoted variant `file has vanished: '<path>'` on client path (`crates/core/src/client/error.rs:246`) | DIVERGENT |
+| F1 | `rsync: [sender] link_stat %s failed: <strerror> (<errno>)\n` (`flist.c:1810`, `rsyserr`) | `rsync: [sender] link_stat "<path>" failed: <e> (<errno>)` (`crates/transfer/src/generator/file_list/walk.rs:325`) | FIXED (task #2174) |
+| F2 | `rsync: [sender] send_files failed to open %s: <strerror> (<errno>)\n` (`sender.c:362`) | `rsync: [sender] send_files failed to open "<path>": <e> (<errno>)` (`crates/transfer/src/generator/protocol_io.rs:140`) | FIXED (task #2174) |
+| F3 | `rsync: [sender] opendir %s failed: <strerror> (<errno>)\n` (`flist.c:1842`) | `rsync: [sender] opendir "<path>" failed: <e> (<errno>)` (`crates/transfer/src/generator/file_list/walk.rs:147,213`) | FIXED (task #2174) |
+| F4 | `rsync: [sender] readdir(%s): <strerror> (<errno>)\n` (`flist.c:1888`) | `rsync: [sender] readdir("<path>"): <e> (<errno>)` (`crates/transfer/src/generator/file_list/walk.rs:244`) | FIXED (task #2174) |
+| F5 | `file has vanished: %s\n` where `%s` is `full_fname()` and resolves to `"<path>"` (`flist.c:1289`, `sender.c:358`, `util1.c:1228`) | `file has vanished: "<path>"` (transfer + engine crates and `crates/core/src/client/error.rs:247`) | FIXED (task #2174) |
 | F6 | `skipping non-regular file "%s"\n` (`generator.c:1687`) | `skipping non-regular file "<path>"` (`crates/cli/src/frontend/progress/render.rs:396`) | EXACT |
-| F7 | `WARNING: %s failed verification -- update %s%s.\n` where `%s` cycles {`discarded`, `put into partial-dir`, `retained`} and `%s%s` is ` (will try again)` or ` (may try again)` (`receiver.c:965-968`) | Hardcoded `WARNING: "<path>" failed verification -- update discarded (will try again). at <basename>(<line>) [receiver=<ver>]` (`crates/transfer/src/pipeline/receiver.rs:277-281`) | DIVERGENT |
-| F8 | `ERROR: %s failed verification -- update %s.\n` (`receiver.c:965-968`, redo phase) | Hardcoded `ERROR: "<path>" failed verification -- update discarded. at <basename>(<line>) [receiver=<ver>]` (`crates/transfer/src/pipeline/receiver.rs:287`) | DIVERGENT |
-| F9 | `rsync: [sender] make_file failed for %s: <strerror>` (no upstream direct site; `flist.c` paths surface as plain `rsyserr` strings) | `rsync: make_file failed for "<path>": <e> (<errno>) at <basename>(<line>) [sender=<ver>]` (`crates/transfer/src/generator/file_list/walk.rs:129`) | DIVERGENT |
+| F7 | `WARNING: %s failed verification -- update %s%s.\n` where `%s` cycles {`discarded`, `put into partial-dir`, `retained`} and `%s%s` is ` (will try again)` or ` (may try again)` (`receiver.c:965-968`) | `WARNING: <path> failed verification -- update discarded (will try again).` (`crates/transfer/src/pipeline/receiver.rs:278-281`) | FIXED (task #2174) |
+| F8 | `ERROR: %s failed verification -- update %s.\n` (`receiver.c:957-968`, redo phase) | `ERROR: <path> failed verification -- update discarded.` (`crates/transfer/src/pipeline/receiver.rs:287-289`) | FIXED (task #2174) |
+| F9 | `rsync: [sender] make_file failed for %s: <strerror>` (no upstream direct site; `flist.c` paths surface as plain `rsyserr` strings) | `rsync: [sender] make_file failed for "<path>": <e> (<errno>)` (`crates/transfer/src/generator/file_list/walk.rs:128`) | FIXED (task #2174) |
 
-Family totals: 1 EXACT, 8 DIVERGENT, 0 MISSING.
+Family totals: 9 EXACT/FIXED, 0 DIVERGENT, 0 MISSING. Task #2174
+removed the appended ` at <basename>(<line>) [<role>=<version>]` trailer
+from the 8 per-file `rsyserr` warnings, added the `[sender]` bracket
+where it was missing, and replaced `{:?}` debug formatting with
+upstream's raw `%s` for the verification-fail strings.
 
 ## 5. Exit-code banner (envelope) format
 
@@ -172,9 +176,9 @@ above). The project-memory note should be revised accordingly.
 | 1. Connection / transport | 0 | 2 | 4 | 0 |
 | 2. Protocol negotiation | 2 | 0 | 6 | 0 |
 | 3. Daemon `@ERROR:` lines | 5 | 2 | 6 | 3 |
-| 4. Per-file `rsyserr` warnings | 1 | 8 | 0 | 0 |
+| 4. Per-file `rsyserr` warnings | 9 | 0 | 0 | 0 |
 | 5. Exit-code envelope | 11 | 3 | 0 | 0 |
-| **Total** | **19** | **15** | **16** | **3** |
+| **Total** | **27** | **7** | **16** | **3** |
 
 ## 7. Top 5 divergences by user impact
 
@@ -186,7 +190,7 @@ frequently the target string appears in published rsync wrapper scripts.
 |---|---|---|---|
 | 1 | C1 | High | `connection unexpectedly closed` never emitted - the canonical TCP-failure marker that Ansible, Bacula, rsnapshot, and BackupPC all grep on |
 | 2 | E1 | High | Source-location separator uses `:` (oc-rsync) instead of `(...)` (upstream) in every `rsync error:` / `rsync warning:` envelope; log-parsing regex `at \S+\(\d+\)` fails |
-| 3 | F1-F4 | Medium | `rsyserr` family (`link_stat`, `send_files`, `opendir`, `readdir`) drops upstream's `[<role>]` bracket immediately after `rsync:` and appends an extra source-location + role-version trailer that upstream omits for these per-file lines |
+| 3 | F1-F4 | Medium (FIXED in #2174) | `rsyserr` family (`link_stat`, `send_files`, `opendir`, `readdir`) now emits the upstream `[<role>]` bracket and no longer appends a source-location or role-version trailer on these per-file lines |
 | 4 | C3 | Medium | `network read error` instead of upstream's bare `read error`; alerting rules keyed on `[%s] read error:` miss the event |
 | 5 | D12/D13 | Medium | Daemon `module is read only` / `module is write only` emitted as `@ERROR:` greeting lines; upstream sends them through `MSG_ERROR` after the handshake using `ERROR:` (no `@`, no greeting-frame). Clients that branch on `@ERROR:` vs `ERROR:` mis-classify the error |
 


### PR DESCRIPTION
## Summary

Aligns the 8 divergent per-file `rsyserr`-equivalent warning strings
(family 4 in `docs/audits/error-message-verbatim-audit.md`) with
upstream rsync 3.4.1 byte-for-byte.

Upstream emits these through `log.c:rsyserr()` as
`rsync: [<role>] <msg>: <strerror> (<errno>)\n` with no source location
and no role-version trailer. oc-rsync was appending
` at <basename>(<line>) [<role>=<version>]`, omitting the `[<role>]`
bracket immediately after `rsync:`, and `{:?}`-debug-quoting paths in
the verification-fail strings. All three deviations broke log-parsing
rules keyed on upstream wording.

## String changes (before -> after)

- `rsync: link_stat "<p>" failed: <e> (<n>) at .. [sender=..]` ->
  `rsync: [sender] link_stat "<p>" failed: <e> (<n>)`
- `rsync: send_files failed to open "<p>": <e> (<n>) at .. [generator=..]` ->
  `rsync: [sender] send_files failed to open "<p>": <e> (<n>)`
- `rsync: opendir "<p>" failed: <e> (<n>) at .. [sender=..]` ->
  `rsync: [sender] opendir "<p>" failed: <e> (<n>)`
- `rsync: readdir "<p>" failed: <e> (<n>) at .. [sender=..]` ->
  `rsync: [sender] readdir("<p>"): <e> (<n>)`
- `file has vanished: <p> at .. [generator=..]` (and single-quoted
  client variant `file has vanished: '<p>'`) ->
  `file has vanished: "<p>"`
- `WARNING: "<p>" failed verification -- update discarded (will try again). at .. [receiver=..]` ->
  `WARNING: <p> failed verification -- update discarded (will try again).`
- `ERROR: "<p>" failed verification -- update discarded. at .. [receiver=..]` ->
  `ERROR: <p> failed verification -- update discarded.`
- `rsync: make_file failed for "<p>": <e> (<n>) at .. [sender=..]` ->
  `rsync: [sender] make_file failed for "<p>": <e> (<n>)`

The quoted path style matches upstream `util1.c:1228`
(`asprintf(&result, "\"%s%s%s\"%s%s%s", ...)` in `full_fname()`);
the verification-fail strings use a raw `%s` upstream, so the
double-quoted debug form was dropped.

Refs task #2174.

## Test plan

- [x] New `rsyserr_wording_tests` module in
      `crates/transfer/src/generator/file_list/walk.rs` pins each
      rendered line to its byte-exact upstream form.
- [x] New `verification_warning_wording_matches_upstream` and
      `verification_error_wording_matches_upstream` tests in
      `crates/transfer/src/pipeline/receiver.rs` pin the F7/F8
      strings.
- [x] Existing `io_error_notfound_uses_vanished_code` test in
      `crates/core/src/client/error.rs` continues to assert
      `contains("file has vanished")`, unaffected by the
      single-quote -> double-quote switch.
- [x] Audit doc (`docs/audits/error-message-verbatim-audit.md`)
      family-4 rows flipped from DIVERGENT to FIXED (task #2174);
      tally row updated.