### PR TITLE
feat: scope --info=no/-<flag> negation to internal use only

### DIFF
--- a/crates/cli/src/frontend/execution/flags/info.rs
+++ b/crates/cli/src/frontend/execution/flags/info.rs
@@ -208,6 +208,14 @@ impl InfoFlagSettings {
         "skip", "stats", "symsafe",
     ];
 
+    // Internal-only extension: `no<flag>` and `-<flag>` are accepted as a
+    // negation form mapping to level 0 (e.g. `noprogress` == `progress0`).
+    // Upstream rsync 3.4.1's `parse_output_words` (`options.c:427`) does NOT
+    // implement this prefix; it relies on the `flag0` suffix instead. The
+    // forms remain accepted for backwards compatibility and to tolerate
+    // server-mode token forwarding, but they are intentionally not advertised
+    // in `--info=help` (see `INFO_HELP_TEXT`) so users do not rely on a
+    // non-portable spelling. New code should prefer the suffix form.
     pub(super) fn parse_flag_and_level<'a>(&self, input: &'a str) -> (&'a str, u8) {
         let base = input.trim_end_matches(|c: char| c.is_ascii_digit());
         if base != input {
@@ -301,5 +309,4 @@ pub(crate) const INFO_HELP_TEXT: &str = "The following --info flags are supporte
     STATS       Mention statistics at end of run (levels 1-3).\n\
     SYMSAFE     Mention symlinks that are unsafe.\n\
 \n\
-Flags may be written with 'no' or '-' prefixes (for example, --info=noprogress).\n\
 Level suffixes may be used (for example, --info=stats2 or --info=flist0).\n";

--- a/crates/cli/src/frontend/execution/flags/tests.rs
+++ b/crates/cli/src/frontend/execution/flags/tests.rs
@@ -832,6 +832,42 @@ fn info_help_text_mentions_all_and_none() {
     assert!(INFO_HELP_TEXT.contains("none"));
 }
 
+// `no<flag>` / `-<flag>` are an internal-only extension not present in
+// upstream rsync 3.4.1 (`options.c parse_output_words`); they must not be
+// advertised in `--info=help` so users do not rely on a non-portable form.
+#[test]
+fn info_help_text_does_not_advertise_no_or_dash_prefix() {
+    assert!(
+        !INFO_HELP_TEXT.contains("noprogress"),
+        "INFO_HELP_TEXT must not advertise the 'no<flag>' extension"
+    );
+    assert!(
+        !INFO_HELP_TEXT.contains("'no'"),
+        "INFO_HELP_TEXT must not advertise the 'no' prefix"
+    );
+    assert!(
+        !INFO_HELP_TEXT.contains("'-'"),
+        "INFO_HELP_TEXT must not advertise the '-' prefix"
+    );
+}
+
+// Parser must still accept the internal-only `no<flag>` / `-<flag>` forms
+// for backwards compatibility and server-mode token forwarding even though
+// they are no longer advertised in `--info=help`.
+#[test]
+fn info_flag_no_prefix_still_accepted_after_help_scrub() {
+    let mut settings = InfoFlagSettings::default();
+    settings.apply("noprogress", "noprogress").unwrap();
+    assert_eq!(settings.progress, ProgressSetting::Disabled);
+}
+
+#[test]
+fn info_flag_dash_prefix_still_accepted_after_help_scrub() {
+    let mut settings = InfoFlagSettings::default();
+    settings.apply("-progress", "-progress").unwrap();
+    assert_eq!(settings.progress, ProgressSetting::Disabled);
+}
+
 #[test]
 fn debug_help_text_lists_all_keywords() {
     let keywords = [

--- a/docs/audits/info-flags-verbosity-matrix.md
+++ b/docs/audits/info-flags-verbosity-matrix.md
@@ -237,12 +237,15 @@ per-flag caps stay in lockstep with the per-token validation in
 
 ### 4.3 `no<flag>` / `-<flag>` negation
 
-`crates/cli/src/frontend/execution/flags/info.rs:184-188` accepts the
-`no` and `-` prefixes by stripping them and treating the level as `0`.
-Upstream lacks this codepath in `parse_output_words`; it relies on
-`stats0` etc. The diversion is invisible because both ultimately set
-the level to zero, but the rsync man page (`rsync.1.md:419`) uses the
-suffix form only.
+`crates/cli/src/frontend/execution/flags/info.rs::parse_flag_and_level`
+accepts the `no` and `-` prefixes by stripping them and treating the
+level as `0`. Upstream lacks this codepath in `parse_output_words`; it
+relies on `stats0` etc. The diversion is invisible because both
+ultimately set the level to zero, but the rsync man page
+(`rsync.1.md:419`) uses the suffix form only. The forms are retained for
+backwards compatibility and tolerance of server-mode token forwarding,
+but are no longer advertised in `--info=help`; the suffix form is the
+only spelling shown to users.
 
 ### 4.4 Unknown-token error code
 
@@ -292,7 +295,7 @@ re-evaluated and the implementation already matches upstream.
 | I10 | SKIP 2    | Low      | OPEN   | Upstream emits the "(type change)" / "(sum change)" suffix at `generator.c:1387`; oc-rsync's SKIP emissions never include the suffix. |
 | I11 | All       | Medium   | OPEN   | `should_show_*` and the parse-cap layer collapse level 2/3 to level 1 because no production code differentiates levels beyond `> 0`. Closing I1-I10 individually addresses this category. |
 | I12 | All       | Low      | RESOLVED | `--info=N` (bare digit) now accepted as a usability extension; oc-rsync's `apply()` in `info.rs` delegates to `enable_all_at_level(N)` with the same per-flag caps as upstream's `all<N>` token (`options.c parse_output_words`). |
-| I13 | All       | Low      | OPEN   | `--info=no<flag>` / `--info=-<flag>` accepted by oc-rsync only; upstream rejects unknown tokens. Diverges in the rejection direction (oc-rsync more permissive). |
+| I13 | All       | Low      | RESOLVED | `--info=no<flag>` / `--info=-<flag>` are an internal-only extension not advertised in `--info=help`; the parser still accepts them for backwards compatibility and server-mode token forwarding, but the user-facing surface only shows the upstream suffix form. |
 | I14 | All       | Low      | OPEN   | Unknown-token message text differs: upstream `Unknown --info item: "FOO"`, oc-rsync `invalid --info flag 'FOO': use --info=help for supported flags`. Same exit code (1). |
 | I15 | All       | Low      | OPEN   | Server-side mode (`am_server`) should suppress unknown-token errors (`options.c:465`); oc-rsync errors unconditionally. |
 | I16 | All       | Low      | OPEN   | Priority field (`DEFAULT/HELP/USER/LIMIT`, `options.c:249-252`) not modelled; later daemon-imposed limits cannot lower user-set levels. |


### PR DESCRIPTION
## Summary

- Upstream rsync 3.4.1's `parse_output_words` (`options.c:427`) does not implement the `no<flag>` or `-<flag>` negation prefixes for `--info=`. The supported user-facing spelling is the suffix form (e.g. `--info=progress0`, `--info=stats0`).
- The parser continues to accept the prefix forms for backwards compatibility and to tolerate server-mode token forwarding when oc-rsync invokes itself or its daemon. The `--info=help` output no longer advertises them.
- Added comment on `parse_flag_and_level` documenting the internal-only status and added tests that pin both the help-text scrub and the parser's continued acceptance of the prefix forms.
- Updated `docs/audits/info-flags-verbosity-matrix.md` to mark I13 RESOLVED.

Resolves #2167.

## Test plan

- [ ] `cargo nextest run -p cli --all-features -E 'test(info_flag)'` passes in CI
- [ ] `cargo nextest run -p cli --all-features -E 'test(info_help)'` passes in CI
- [ ] CI fmt + clippy clean