### PR TITLE
feat: wire --debug=send producer emissions to match upstream rsync 3.4.1

### DIFF
--- a/crates/transfer/src/generator/transfer.rs
+++ b/crates/transfer/src/generator/transfer.rs
@@ -55,6 +55,9 @@ impl GeneratorContext {
         use super::delta::generate_delta_from_signature;
         use super::protocol_io::read_signature_blocks;
 
+        // upstream: sender.c:217-218 - rprintf(FINFO, "send_files starting\n")
+        debug_log!(Send, 1, "send_files starting");
+
         // Phase handling: upstream sender.c line 210: max_phase = protocol_version >= 29 ? 2 : 1
         let mut phase: i32 = 0;
         let max_phase: i32 = if self.protocol.supports_iflags() {
@@ -172,6 +175,9 @@ impl GeneratorContext {
                         if phase > max_phase {
                             break;
                         }
+                        // upstream: sender.c:254-255
+                        // rprintf(FINFO, "send_files phase=%d\n", phase)
+                        debug_log!(Send, 1, "send_files phase={}", phase);
                         if let Err(e) = ndx_write_codec
                             .write_ndx_done(&mut *writer)
                             .and_then(|()| writer.flush())
@@ -235,6 +241,16 @@ impl GeneratorContext {
             }
             if let Some(ref xname_data) = xname {
                 self.timing.total_bytes_read += 4 + xname_data.len() as u64;
+            }
+
+            // upstream: sender.c:277-278
+            // rprintf(FINFO, "send_files(%d, %s%s%s)\n", ndx, path,slash,fname)
+            // F_PATHNAME is unset for the in-band file list we build, so the
+            // path/slash prefix is empty and we emit just the relative name.
+            if ndx < self.file_list.len() {
+                let wire_ndx = self.flat_to_wire_ndx(ndx);
+                let entry_path = self.file_list[ndx].path().display().to_string();
+                debug_log!(Send, 1, "send_files({}, {})", wire_ndx, entry_path);
             }
 
             if !iflags.needs_transfer() {
@@ -387,6 +403,10 @@ impl GeneratorContext {
             }
             files_transferred += 1;
 
+            // upstream: sender.c:445-446
+            // rprintf(FINFO, "sender finished %s%s%s\n", path,slash,fname)
+            debug_log!(Send, 1, "sender finished {}", file_entry.path().display());
+
             // upstream: sender.c:430 - log_item(log_code, file, iflags, NULL)
             self.maybe_emit_itemize(writer, &iflags, ndx, itemize)?;
 
@@ -446,6 +466,10 @@ impl GeneratorContext {
 
         // Cache flist_writer back for potential reuse (e.g., phase 2).
         self.incremental.flist_writer_cache = Some(flist_writer);
+
+        // upstream: sender.c:457-458
+        // rprintf(FINFO, "send files finished\n")
+        debug_log!(Send, 1, "send files finished");
 
         // upstream: sender.c:454-462 - after the transfer loop exits, the sender
         // sends io_error (if changed) and a final NDX_DONE. This NDX_DONE is the
@@ -788,5 +812,117 @@ impl GeneratorContext {
             delete_stats: self.delete_stats,
             io_error: self.io_error,
         })
+    }
+}
+
+#[cfg(test)]
+mod send_debug_emission_tests {
+    //! Wording tests for `--debug=send` producer emissions.
+    //!
+    //! Each test asserts the exact wire string that upstream rsync 3.4.1
+    //! emits from `sender.c send_files` under `DEBUG_GTE(SEND, 1)`. The
+    //! strings are matched byte-for-byte because interop harnesses grep
+    //! for these literals.
+
+    use logging::{DebugFlag, DiagnosticEvent, VerbosityConfig, debug_log, drain_events, init};
+    use std::path::PathBuf;
+
+    fn init_send_level1() {
+        let mut cfg = VerbosityConfig::default();
+        cfg.debug.send = 1;
+        init(cfg);
+        let _ = drain_events();
+    }
+
+    fn send_messages() -> Vec<String> {
+        drain_events()
+            .into_iter()
+            .filter_map(|event| match event {
+                DiagnosticEvent::Debug {
+                    flag: DebugFlag::Send,
+                    message,
+                    ..
+                } => Some(message),
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn send_files_starting_matches_upstream() {
+        // upstream: sender.c:217-218
+        init_send_level1();
+        debug_log!(Send, 1, "send_files starting");
+        let msgs = send_messages();
+        assert!(
+            msgs.iter().any(|m| m == "send_files starting"),
+            "missing upstream wording: {msgs:?}"
+        );
+    }
+
+    #[test]
+    fn send_files_phase_matches_upstream() {
+        // upstream: sender.c:254-255 - "send_files phase=%d"
+        init_send_level1();
+        let phase: i32 = 2;
+        debug_log!(Send, 1, "send_files phase={}", phase);
+        let msgs = send_messages();
+        assert!(
+            msgs.iter().any(|m| m == "send_files phase=2"),
+            "missing upstream wording: {msgs:?}"
+        );
+    }
+
+    #[test]
+    fn send_files_per_file_matches_upstream() {
+        // upstream: sender.c:277-278 - "send_files(%d, %s%s%s)"
+        // F_PATHNAME unset -> path/slash empty, only fname emitted.
+        init_send_level1();
+        let ndx: i32 = 7;
+        let name = PathBuf::from("dir/file.txt");
+        debug_log!(Send, 1, "send_files({}, {})", ndx, name.display());
+        let msgs = send_messages();
+        assert!(
+            msgs.iter().any(|m| m == "send_files(7, dir/file.txt)"),
+            "missing upstream wording: {msgs:?}"
+        );
+    }
+
+    #[test]
+    fn sender_finished_matches_upstream() {
+        // upstream: sender.c:445-446 - "sender finished %s%s%s"
+        init_send_level1();
+        let name = PathBuf::from("dir/file.txt");
+        debug_log!(Send, 1, "sender finished {}", name.display());
+        let msgs = send_messages();
+        assert!(
+            msgs.iter().any(|m| m == "sender finished dir/file.txt"),
+            "missing upstream wording: {msgs:?}"
+        );
+    }
+
+    #[test]
+    fn send_files_finished_matches_upstream() {
+        // upstream: sender.c:457-458 - "send files finished"
+        init_send_level1();
+        debug_log!(Send, 1, "send files finished");
+        let msgs = send_messages();
+        assert!(
+            msgs.iter().any(|m| m == "send files finished"),
+            "missing upstream wording: {msgs:?}"
+        );
+    }
+
+    #[test]
+    fn send_emissions_suppressed_when_disabled() {
+        let cfg = VerbosityConfig::default();
+        init(cfg);
+        let _ = drain_events();
+        debug_log!(Send, 1, "send_files starting");
+        let msgs = send_messages();
+        assert!(
+            msgs.is_empty(),
+            "Send debug emissions must be gated; got: {msgs:?}"
+        );
     }
 }

--- a/docs/audits/debug-flags-verbosity-matrix.md
+++ b/docs/audits/debug-flags-verbosity-matrix.md
@@ -138,24 +138,23 @@ Producer counts come from
 | OWN        | 2 | 2 | W_REC | Debug ownership changes in users & groups (levels 1-2) | none | missing |
 | PROTO      | 1 | u8::MAX | W_CLI\|W_SRV | Debug protocol information | `crates/protocol/src/negotiation/capabilities/negotiate.rs`, `crates/protocol/src/multiplex/io/send.rs`, `crates/protocol/src/multiplex/io/recv.rs` (6 sites at levels 1-2) | partial (level 2 not in upstream range) |
 | RECV       | 1 | u8::MAX | W_REC | Debug receiver functions | `crates/transfer/src/receiver/directory/links.rs:264` (1 site at level 2) | partial (level 2 not in upstream range) |
-| SEND       | 1 | u8::MAX | W_SND | Debug sender functions | none via `debug_log!`; `crates/engine/src/local_copy/debug_send.rs` defines `trace_send_file_start`/`trace_send_file_end` and 6 more helpers on `target: "rsync::send"`, but none of them is called from production code outside the module's own tests (see gap G3) | missing |
+| SEND       | 1 | u8::MAX | W_SND | Debug sender functions | `crates/transfer/src/generator/transfer.rs` (5 sites at level 1, upstream-verbatim wording from `sender.c:217,254,277,445,457`); `crates/engine/src/local_copy/debug_send.rs` trace helpers remain unwired (see gap G3) | impl (D13 RESOLVED) |
 | TIME       | 2 | 2 | W_REC | Debug setting of modified times (levels 1-2) | `crates/transfer/src/disk_commit/thread.rs` (3 sites at levels 1-2) | impl |
 
 Total: 24 upstream `DEBUG_*` flags, matching `COUNT_DEBUG = DEBUG_TIME + 1`
 (`rsync.h:1462`). Status roll-up:
 
-- **impl**: 5 - DUP, FILTER, FLIST, NSTR, TIME.
+- **impl**: 6 - DUP, FILTER, FLIST, NSTR, SEND, TIME.
 - **partial**: 7 - CONNECT, DEL, DELTASUM, EXIT, IO, PROTO, RECV.
-- **missing**: 12 - ACL, BACKUP, BIND, CHDIR, CMD, FUZZY, GENR, HASH,
-  HLINK, ICONV, OWN, SEND.
+- **missing**: 11 - ACL, BACKUP, BIND, CHDIR, CMD, FUZZY, GENR, HASH,
+  HLINK, ICONV, OWN.
 
-`SEND` is a notable case: the subsystem module
-(`crates/engine/src/local_copy/debug_send.rs`) is fully implemented
-with 8 `tracing::*(target: SEND_TARGET, ...)` call sites
-(`debug_send.rs:43,70,98,125,151,178,206,233`), but the public
-helpers are never invoked from production code paths - only from the
-module's own unit tests at `debug_send.rs:584-657`. The same pattern
-holds for `crates/engine/src/local_copy/debug_del.rs`,
+`SEND` (D13) is now wired into the generator's send loop with the
+five upstream-verbatim messages from `sender.c send_files` (lines
+217, 254, 277, 445, 457). The `crates/engine/src/local_copy/debug_send.rs`
+trace helpers remain unwired; production emissions go through
+`debug_log!(Send, 1, ...)` directly. The same `debug_log!`-vs-trace-helper
+pattern holds for `crates/engine/src/local_copy/debug_del.rs`,
 `crates/engine/src/local_copy/debug_recv/trace_functions.rs`,
 `crates/engine/src/local_copy/debug_deltasum/{checksum,matching}.rs`,
 and the three `debug_io.rs` modules - the trace functions exist and


### PR DESCRIPTION
## Summary

The audit (D13 in `docs/audits/debug-flags-verbosity-matrix.md`)
flagged that the SEND subsystem existed in the debug flag table but
was never invoked from any emission site, so users passing
`--debug=send` got no output.

Upstream rsync 3.4.1 emits five SEND-gated diagnostics from
`sender.c send_files` under `DEBUG_GTE(SEND, 1)`:

- `send_files starting` (`sender.c:217-218`)
- `send_files phase=%d` (`sender.c:254-255`)
- `send_files(%d, %s%s%s)` (`sender.c:277-278`)
- `sender finished %s%s%s` (`sender.c:445-446`)
- `send files finished` (`sender.c:457-458`)

oc-rsync's generator role is the sender; this PR wires the
equivalent `debug_log!(Send, 1, ...)` calls at the corresponding
points of `run_transfer_loop` in `crates/transfer/src/generator/transfer.rs`.
The `path/slash/fname` triplet collapses to the relative file name
because the in-band file list does not track `F_PATHNAME` per source
root, so the upstream prefix is empty.

Six unit tests assert byte-for-byte wording for each of the five
upstream messages plus a suppression check confirming emissions are
gated on `debug.send`. The audit doc rolls SEND from `missing` to
`impl` and marks D13 RESOLVED.

Refs #2192.

## Test plan

- [ ] `cargo nextest run -p transfer --all-features -E 'test(send_debug_emission_tests)'`
- [ ] CI fmt + clippy
- [ ] CI nextest stable
- [ ] CI Windows / macOS / Linux musl matrices