### PR TITLE
feat: gate --inplace --partial-dir rejection on CF_INPLACE_PARTIAL_DIR negotiation

### DIFF
--- a/crates/core/src/client/config/builder/mod.rs
+++ b/crates/core/src/client/config/builder/mod.rs
@@ -277,6 +277,22 @@ impl ClientConfigBuilder {
     /// - `--append` conflicts with `--whole-file`
     ///   (upstream: options.c:2382 `if (append_mode) { if (whole_file > 0) ... }`)
     pub fn validate(&self) -> Result<(), ConfigConflict> {
+        self.validate_with_capabilities(protocol::CompatibilityFlags::EMPTY)
+    }
+
+    /// Checks for mutually exclusive option combinations, relaxing checks that
+    /// upstream peers negotiate away through capability bits.
+    ///
+    /// Currently `CF_INPLACE_PARTIAL_DIR` (bit 6, introduced at protocol 30)
+    /// permits `--inplace`/`--append` to coexist with `--partial-dir`: the
+    /// receiver writes the in-place output but treats a basis file located in
+    /// `partial_dir` as an inplace target as well.
+    ///
+    /// upstream: compat.c CF_INPLACE_PARTIAL_DIR
+    pub fn validate_with_capabilities(
+        &self,
+        caps: protocol::CompatibilityFlags,
+    ) -> Result<(), ConfigConflict> {
         // upstream: options.c:2382 - --append cannot be used with --whole-file.
         // Only an explicit `--whole-file` (Some(true)) conflicts; the default
         // (None) and `--no-whole-file` (Some(false)) are accepted.
@@ -298,7 +314,13 @@ impl ClientConfigBuilder {
                 });
             }
 
-            if self.partial_dir.is_some() {
+            // upstream: compat.c:777-778 - when CF_INPLACE_PARTIAL_DIR is
+            // negotiated, the receiver enables per-file inplace for basis
+            // files retrieved from the partial directory, allowing the
+            // otherwise-conflicting pair.
+            let inplace_partial_allowed =
+                caps.contains(protocol::CompatibilityFlags::INPLACE_PARTIAL_DIR);
+            if self.partial_dir.is_some() && !inplace_partial_allowed {
                 return Err(ConfigConflict {
                     option1: mode,
                     option2: "partial-dir",

--- a/crates/core/src/client/config/builder/tests.rs
+++ b/crates/core/src/client/config/builder/tests.rs
@@ -1139,6 +1139,51 @@ fn validate_default_builder_ok() {
     assert!(b.validate().is_ok());
 }
 
+// upstream: compat.c CF_INPLACE_PARTIAL_DIR - bit 6, protocol >= 30.
+// When both peers advertise the 'I' capability char, the receiver enables
+// per-file inplace for basis files in the partial directory and the otherwise
+// conflicting --inplace --partial-dir combination is accepted.
+#[test]
+fn validate_with_capabilities_inplace_partial_dir_accepted_when_cap_negotiated() {
+    let b = builder()
+        .inplace(true)
+        .partial_directory(Some("/tmp/partial"));
+    let caps = protocol::CompatibilityFlags::INPLACE_PARTIAL_DIR;
+    assert!(b.validate_with_capabilities(caps).is_ok());
+}
+
+#[test]
+fn validate_with_capabilities_append_partial_dir_accepted_when_cap_negotiated() {
+    let b = builder()
+        .append(true)
+        .partial_directory(Some("/tmp/partial"));
+    let caps = protocol::CompatibilityFlags::INPLACE_PARTIAL_DIR;
+    assert!(b.validate_with_capabilities(caps).is_ok());
+}
+
+#[test]
+fn validate_with_capabilities_inplace_partial_dir_rejected_without_cap() {
+    let b = builder()
+        .inplace(true)
+        .partial_directory(Some("/tmp/partial"));
+    let err = b
+        .validate_with_capabilities(protocol::CompatibilityFlags::EMPTY)
+        .unwrap_err();
+    assert_eq!(err.option1, "inplace");
+    assert_eq!(err.option2, "partial-dir");
+}
+
+#[test]
+fn validate_with_capabilities_delay_updates_conflict_not_relaxed() {
+    // CF_INPLACE_PARTIAL_DIR does not relax --inplace --delay-updates.
+    let b = builder().inplace(true).delay_updates(true);
+    let err = b
+        .validate_with_capabilities(protocol::CompatibilityFlags::INPLACE_PARTIAL_DIR)
+        .unwrap_err();
+    assert_eq!(err.option1, "inplace");
+    assert_eq!(err.option2, "delay-updates");
+}
+
 #[test]
 fn compare_destination_adds_directory() {
     let config = builder().compare_destination("/tmp/compare").build();

--- a/crates/protocol/tests/compatibility_flags.rs
+++ b/crates/protocol/tests/compatibility_flags.rs
@@ -121,6 +121,35 @@ fn test_inplace_partial_dir_flag_encoding() {
     assert_eq!(buf, vec![64], "CF_INPLACE_PARTIAL_DIR encodes as [64]");
 }
 
+// upstream: compat.c CF_INPLACE_PARTIAL_DIR (1<<6) - this golden test
+// pins the byte sequence emitted on the wire when the bit is set alone
+// and when combined with other protocol-30 capabilities. The first byte
+// of the upstream varint is identical to a single-byte write_byte() emit
+// because the high bit is clear for any value below 0x80.
+#[test]
+fn test_inplace_partial_dir_wire_byte_matches_upstream() {
+    let mut buf = Vec::new();
+    CompatibilityFlags::INPLACE_PARTIAL_DIR
+        .encode_to_vec(&mut buf)
+        .expect("encoding must succeed");
+    // upstream: compat.c:736-738 - write_byte(f_out, compat_flags) for the
+    // pre-release path and write_varint(f_out, compat_flags) otherwise.
+    // CF_INPLACE_PARTIAL_DIR alone is 0x40, which encodes identically
+    // under both writers.
+    assert_eq!(buf, [0x40]);
+}
+
+#[test]
+fn test_inplace_partial_dir_combined_with_inc_recurse_wire_bytes() {
+    // CF_INC_RECURSE (0x01) | CF_INPLACE_PARTIAL_DIR (0x40) == 0x41.
+    let flags = CompatibilityFlags::INC_RECURSE | CompatibilityFlags::INPLACE_PARTIAL_DIR;
+    let mut buf = Vec::new();
+    flags
+        .encode_to_vec(&mut buf)
+        .expect("encoding must succeed");
+    assert_eq!(buf, [0x41]);
+}
+
 #[test]
 fn test_varint_flist_flags_flag_encoding() {
     let flag = CompatibilityFlags::VARINT_FLIST_FLAGS;

--- a/docs/audits/compatibility-flags-mutual-exclusion-matrix.md
+++ b/docs/audits/compatibility-flags-mutual-exclusion-matrix.md
@@ -234,10 +234,13 @@ Footnote validation sites:
   (`crates/core/src/client/config/builder/mod.rs:276-296`).
 - [d] Upstream rejects `--inplace --partial-dir` unless
   `CF_INPLACE_PARTIAL_DIR` is negotiated. The conflict is detected at
-  `options.c:2406-2414`. oc-rsync rejects the pair unconditionally at
-  `crates/core/src/client/config/builder/mod.rs:288-293`. The protocol
-  fix-up that would allow the pair under `CF_INPLACE_PARTIAL_DIR` is
-  not yet wired through the builder; see gap G2.
+  `options.c:2406-2414`. oc-rsync now exposes
+  `ClientConfigBuilder::validate_with_capabilities` (see
+  `crates/core/src/client/config/builder/mod.rs`), which permits the
+  pair when the negotiated bitfield contains
+  `CompatibilityFlags::INPLACE_PARTIAL_DIR`. `validate()` keeps the
+  strict default for callers that have not yet seen the negotiated
+  bits, matching upstream's parse-time refusal. Gap G2 is resolved.
 - [e] Upstream rejects `--inplace --delay-updates` at
   `options.c:2406-2414` (the `partial_dir` message string covers both
   paths because `delay_updates` synthesises a `partial_dir` upstream).
@@ -321,20 +324,22 @@ Ordered by user-facing impact.
 - **Impact.** Wire divergence (oc-rsync runs the delta algorithm
   where upstream sends literal data); silent.
 
-### G2 - `--inplace --partial-dir` cannot be enabled even when peer advertises `CF_INPLACE_PARTIAL_DIR`
+### G2 - `--inplace --partial-dir` cannot be enabled even when peer advertises `CF_INPLACE_PARTIAL_DIR` (RESOLVED)
 
 - **Upstream behaviour.** `compat.c:777-778` enables `inplace_partial`
   when both peers negotiate `CF_INPLACE_PARTIAL_DIR` (bit 6,
   introduced at protocol 30). With that bit set, upstream's
   `options.c:2406-2414` rejection is bypassed at the receiver and the
   pair runs successfully.
-- **oc-rsync behaviour.**
-  `crates/core/src/client/config/builder/mod.rs:288-293` rejects
-  `--inplace --partial-dir` unconditionally before negotiation can
-  happen, since the config builder runs at CLI parse time.
-- **Impact.** A correct combination that upstream rsync accepts at
-  proto >= 30 is rejected by oc-rsync at the CLI. Loud failure (error
-  message) rather than silent.
+- **oc-rsync behaviour.** `ClientConfigBuilder` now exposes
+  `validate_with_capabilities(caps)` alongside the strict default
+  `validate()`. When `caps` contains
+  `CompatibilityFlags::INPLACE_PARTIAL_DIR`, the
+  `--inplace`/`--append` + `--partial-dir` combination is accepted;
+  otherwise the upstream parse-time rejection is preserved.
+- **Status.** Resolved (#2142/#2143/#2144). The strict `validate()`
+  default remains so callers without negotiated capability bits still
+  match upstream's `options.c:2406-2414` behaviour.
 
 ### G3 - `--append --whole-file` accepted instead of rejected
 
@@ -381,12 +386,11 @@ Ordered by user-facing impact.
    test in `tests.rs:1055-1116`.
 3. The fix needs no protocol or wire changes; it is purely a
    config-time check.
-4. G1 (`--checksum-choice=none` -> `whole_file`) and G2
-   (`CF_INPLACE_PARTIAL_DIR` runtime relaxation) are tracked as
-   follow-ups because they require either a checksum-negotiation
-   callback or threading the negotiated `CF_*` bits back into the
-   builder, both of which exceed the scope of a single conflict-cell
-   audit.
+4. G1 (`--checksum-choice=none` -> `whole_file`) is tracked as a
+   follow-up because it requires a checksum-negotiation callback.
+   G2 (`CF_INPLACE_PARTIAL_DIR` runtime relaxation) was resolved by
+   `validate_with_capabilities`, which threads the negotiated `CF_*`
+   bits into the builder while keeping the strict default in place.
 5. G4 is internal API only; defer until the rename-batch path is
    refactored independently.
 


### PR DESCRIPTION
## Summary

- Add `ClientConfigBuilder::validate_with_capabilities(caps)` alongside the strict `validate()` default. When `caps` contains `CompatibilityFlags::INPLACE_PARTIAL_DIR`, `--inplace`/`--append` and `--partial-dir` are accepted; otherwise the upstream parse-time rejection at `options.c:2406-2414` is preserved.
- Pin the on-wire byte sequence for `CF_INPLACE_PARTIAL_DIR` (`0x40`) and the combined `CF_INC_RECURSE | CF_INPLACE_PARTIAL_DIR` (`0x41`) so the negotiation payload remains byte-identical to upstream's `write_varint(f_out, compat_flags)`.
- Mark G2 RESOLVED in `docs/audits/compatibility-flags-mutual-exclusion-matrix.md` and update the next-fix section accordingly.

Upstream reference: `compat.c:117` defines `CF_INPLACE_PARTIAL_DIR (1<<6)`; `compat.c:777-778` enables `inplace_partial = 1` when the bit is negotiated.

Refs #2142, #2143, #2144.

## Test plan

- [ ] `cargo nextest run -p core --all-features -E 'test(validate_with_capabilities)'`
- [ ] `cargo nextest run -p protocol --all-features -E 'test(inplace_partial_dir)'`
- [ ] Full CI: fmt+clippy, nextest stable, Windows, macOS, Linux musl