### PR TITLE
feat: promote whole_file=1 when --checksum-choice=none

### DIFF
--- a/crates/cli/src/frontend/command_builder/sections/build_base_command/transfer.rs
+++ b/crates/cli/src/frontend/command_builder/sections/build_base_command/transfer.rs
@@ -133,7 +133,7 @@ pub(super) fn add_transfer_args(command: ClapCommand) -> ClapCommand {
                 .visible_alias("cc")
                 .value_name("ALGO")
                 .help(
-                    "Select the strong checksum algorithm (auto, md4, md5, xxh64, xxh3, or xxh128).",
+                    "Select the strong checksum algorithm (auto, none, md4, md5, xxh64, xxh3, or xxh128). `none` forces whole-file transfer.",
                 )
                 .num_args(1)
                 .action(ArgAction::Set)

--- a/crates/cli/src/frontend/help.rs
+++ b/crates/cli/src/frontend/help.rs
@@ -53,7 +53,7 @@ pub(super) fn help_text(program_name: ProgramName) -> String {
             "      --backup-dir=DIR  Store backups inside DIR instead of alongside the destination.\n",
             "      --suffix=SUFFIX  Append SUFFIX to backup names (default '~').\n",
             "  -c, --checksum   Skip updates for files that already match by checksum.\n",
-            "      --checksum-choice=ALGO  Select the strong checksum algorithm (auto, md4, md5, xxh64, xxh3, or xxh128).\n",
+            "      --checksum-choice=ALGO  Select the strong checksum algorithm (auto, none, md4, md5, xxh64, xxh3, or xxh128). `none` forces whole-file transfer.\n",
             "      --checksum-seed=NUM  Use NUM as the checksum seed for xxhash algorithms.\n",
             "      --size-only  Skip files whose size matches the destination, ignoring timestamps.\n",
             "      --ignore-times  Disable quick checks based on size and modification time (treat all files as changed).\n",

--- a/crates/cli/tests/option_combinations_flags.rs
+++ b/crates/cli/tests/option_combinations_flags.rs
@@ -98,6 +98,24 @@ fn test_compress_level_zero_disables_compression() {
 }
 
 #[test]
+fn test_checksum_choice_none_parses() {
+    // upstream: options.c:740-741 accepts `none` as a checksum-choice value.
+    let args = parse_args(["oc-rsync", "--checksum-choice=none", "src", "dest"]).unwrap();
+    let choice = args.checksum_choice.expect("checksum_choice must be set");
+    assert!(
+        choice.transfer_is_none(),
+        "--checksum-choice=none should select the none transfer algorithm"
+    );
+}
+
+#[test]
+fn test_checksum_choice_none_via_cc_alias() {
+    let args = parse_args(["oc-rsync", "--cc=none", "src", "dest"]).unwrap();
+    let choice = args.checksum_choice.expect("checksum_choice must be set");
+    assert!(choice.transfer_is_none());
+}
+
+#[test]
 fn test_no_compression_by_default() {
     let args = parse_args(["oc-rsync", "src", "dest"]).unwrap();
     assert!(!args.compress, "Compression should be disabled by default");

--- a/crates/core/src/client/config/builder/mod.rs
+++ b/crates/core/src/client/config/builder/mod.rs
@@ -309,8 +309,22 @@ impl ClientConfigBuilder {
     }
 
     /// Finalises the builder and constructs a [`ClientConfig`].
+    ///
+    /// Performs upstream-compatible promotions before materialising the
+    /// config:
+    ///
+    /// - `--checksum-choice=none` promotes `whole_file` to `Some(true)`.
+    ///   Mirrors upstream `checksum.c:197-198`, which assigns
+    ///   `whole_file = 1` whenever the negotiated transfer checksum is
+    ///   `CSUM_NONE`. The delta pipeline cannot run without a transfer
+    ///   checksum, so whole-file transfer is the only valid mode.
     #[must_use]
-    pub fn build(self) -> ClientConfig {
+    pub fn build(mut self) -> ClientConfig {
+        // upstream: checksum.c:197-198 parse_checksum_choice() forces
+        // `whole_file = 1` unconditionally when `xfer_sum_nni->num == CSUM_NONE`.
+        if self.checksum_choice.transfer_is_none() {
+            self.whole_file = Some(true);
+        }
         ClientConfig {
             transfer_args: self.transfer_args,
             dry_run: self.dry_run,

--- a/crates/core/src/client/config/builder/tests.rs
+++ b/crates/core/src/client/config/builder/tests.rs
@@ -1368,6 +1368,31 @@ fn whole_file_sets_false() {
 }
 
 #[test]
+fn checksum_choice_none_promotes_whole_file() {
+    // upstream: checksum.c:197-198 - CSUM_NONE forces whole_file = 1.
+    let choice = StrongChecksumChoice::parse("none").unwrap();
+    let config = builder().checksum_choice(choice).build();
+    assert_eq!(config.whole_file_raw(), Some(true));
+    assert!(config.whole_file());
+}
+
+#[test]
+fn checksum_choice_none_overrides_explicit_no_whole_file() {
+    // upstream: checksum.c:198 assigns `whole_file = 1` unconditionally,
+    // overriding any user-supplied `--no-whole-file`.
+    let choice = StrongChecksumChoice::parse("none").unwrap();
+    let config = builder().whole_file(false).checksum_choice(choice).build();
+    assert_eq!(config.whole_file_raw(), Some(true));
+}
+
+#[test]
+fn checksum_choice_md5_leaves_whole_file_untouched() {
+    let choice = StrongChecksumChoice::parse("md5").unwrap();
+    let config = builder().checksum_choice(choice).build();
+    assert_eq!(config.whole_file_raw(), None);
+}
+
+#[test]
 fn block_size_override_sets_value() {
     let size = NonZeroU32::new(4096).unwrap();
     let config = builder().block_size_override(Some(size)).build();

--- a/crates/core/src/client/config/enums/checksum.rs
+++ b/crates/core/src/client/config/enums/checksum.rs
@@ -9,6 +9,12 @@ use engine::signature::SignatureAlgorithm;
 pub enum StrongChecksumAlgorithm {
     /// Automatically selects the negotiated algorithm (locally resolved to MD5).
     Auto,
+    /// No transfer checksum; disables delta and forces whole-file transfers.
+    ///
+    /// Mirrors upstream `CSUM_NONE` (see `checksum.c:63`). When selected as the
+    /// transfer algorithm, upstream `checksum.c:197-198` unconditionally sets
+    /// `whole_file = 1`.
+    None,
     /// MD4 strong checksum.
     Md4,
     /// MD5 strong checksum.
@@ -34,7 +40,11 @@ impl StrongChecksumAlgorithm {
                     seed_config: Md5Seed::none(),
                 }
             }
-            StrongChecksumAlgorithm::Md4 => SignatureAlgorithm::Md4,
+            // `none` disables delta (whole_file is forced upstream), but a
+            // signature algorithm is still required by the engine's type
+            // signature. MD4 matches upstream's default fallback semantics
+            // and is never actually computed when whole-file is in effect.
+            StrongChecksumAlgorithm::None | StrongChecksumAlgorithm::Md4 => SignatureAlgorithm::Md4,
             StrongChecksumAlgorithm::Sha1 => SignatureAlgorithm::Sha1,
             StrongChecksumAlgorithm::Xxh64 => SignatureAlgorithm::Xxh64 { seed: 0 },
             StrongChecksumAlgorithm::Xxh3 => SignatureAlgorithm::Xxh3 { seed: 0 },
@@ -47,6 +57,7 @@ impl StrongChecksumAlgorithm {
     pub const fn canonical_name(self) -> &'static str {
         match self {
             StrongChecksumAlgorithm::Auto => "auto",
+            StrongChecksumAlgorithm::None => "none",
             StrongChecksumAlgorithm::Md4 => "md4",
             StrongChecksumAlgorithm::Md5 => "md5",
             StrongChecksumAlgorithm::Sha1 => "sha1",
@@ -64,6 +75,7 @@ impl StrongChecksumAlgorithm {
     pub const fn to_protocol_algorithm(self) -> Option<protocol::ChecksumAlgorithm> {
         match self {
             StrongChecksumAlgorithm::Auto => None,
+            StrongChecksumAlgorithm::None => Some(protocol::ChecksumAlgorithm::None),
             StrongChecksumAlgorithm::Md4 => Some(protocol::ChecksumAlgorithm::MD4),
             StrongChecksumAlgorithm::Md5 => Some(protocol::ChecksumAlgorithm::MD5),
             StrongChecksumAlgorithm::Sha1 => Some(protocol::ChecksumAlgorithm::SHA1),
@@ -112,6 +124,7 @@ impl StrongChecksumChoice {
         let normalized = label.trim().to_ascii_lowercase();
         match normalized.as_str() {
             "auto" => Ok(StrongChecksumAlgorithm::Auto),
+            "none" => Ok(StrongChecksumAlgorithm::None),
             "md4" => Ok(StrongChecksumAlgorithm::Md4),
             "md5" => Ok(StrongChecksumAlgorithm::Md5),
             "sha1" => Ok(StrongChecksumAlgorithm::Sha1),
@@ -157,6 +170,18 @@ impl StrongChecksumChoice {
         }
     }
 
+    /// Reports whether the transfer algorithm is the `none` sentinel.
+    ///
+    /// Upstream `checksum.c:197-198` forces `whole_file = 1` whenever the
+    /// negotiated transfer checksum is `CSUM_NONE`. The config builder uses
+    /// this to promote `whole_file` at build time so the delta pipeline is
+    /// never engaged when the user explicitly disables the transfer
+    /// checksum.
+    #[must_use]
+    pub const fn transfer_is_none(self) -> bool {
+        matches!(self.transfer, StrongChecksumAlgorithm::None)
+    }
+
     /// Returns the transfer algorithm as a protocol-layer override for negotiation.
     ///
     /// When the transfer algorithm is [`Auto`](StrongChecksumAlgorithm::Auto), returns
@@ -192,11 +217,13 @@ mod tests {
             assert_eq!(StrongChecksumAlgorithm::Xxh64.canonical_name(), "xxh64");
             assert_eq!(StrongChecksumAlgorithm::Xxh3.canonical_name(), "xxh3");
             assert_eq!(StrongChecksumAlgorithm::Xxh128.canonical_name(), "xxh128");
+            assert_eq!(StrongChecksumAlgorithm::None.canonical_name(), "none");
         }
 
         #[test]
         fn to_signature_algorithm() {
             let _ = StrongChecksumAlgorithm::Auto.to_signature_algorithm();
+            let _ = StrongChecksumAlgorithm::None.to_signature_algorithm();
             let _ = StrongChecksumAlgorithm::Md4.to_signature_algorithm();
             let _ = StrongChecksumAlgorithm::Md5.to_signature_algorithm();
             let _ = StrongChecksumAlgorithm::Sha1.to_signature_algorithm();
@@ -270,6 +297,30 @@ mod tests {
         #[test]
         fn parse_invalid_returns_error() {
             assert!(StrongChecksumChoice::parse("invalid").is_err());
+        }
+
+        #[test]
+        fn parse_none() {
+            // upstream: checksum.c:63 - { CSUM_NONE, 0, "none", NULL }.
+            let choice = StrongChecksumChoice::parse("none").unwrap();
+            assert_eq!(choice.transfer(), StrongChecksumAlgorithm::None);
+            assert_eq!(choice.file(), StrongChecksumAlgorithm::None);
+            assert!(choice.transfer_is_none());
+            assert_eq!(choice.to_argument(), "none");
+            assert_eq!(
+                choice.transfer_protocol_override(),
+                Some(protocol::ChecksumAlgorithm::None),
+            );
+        }
+
+        #[test]
+        fn transfer_is_none_false_for_other_algorithms() {
+            assert!(
+                !StrongChecksumChoice::parse("md5")
+                    .unwrap()
+                    .transfer_is_none()
+            );
+            assert!(!StrongChecksumChoice::default().transfer_is_none());
         }
 
         #[test]

--- a/docs/audits/compatibility-flags-mutual-exclusion-matrix.md
+++ b/docs/audits/compatibility-flags-mutual-exclusion-matrix.md
@@ -78,9 +78,10 @@ protocol gating if any, and (c) oc-rsync's plumbing for the flag.
 - **oc-rsync.** Stored as `ServerConfigBuilder::checksum_choice`
   (`crates/transfer/src/config/builder.rs:75`) and
   `ClientConfigBuilder::checksum_choice`
-  (`crates/core/src/client/config/builder/mod.rs:179`). No
-  validator promotes `whole_file` when the chosen algorithm is
-  `None`. See gap G1 in section 4.
+  (`crates/core/src/client/config/builder/mod.rs:179`).
+  `ClientConfigBuilder::build` promotes `whole_file` to `Some(true)`
+  when `checksum_choice.transfer_is_none()` returns true, mirroring
+  upstream `checksum.c:197-198`. See G1 (resolved) in section 4.
 
 ### 1.3 `--inplace`
 
@@ -203,10 +204,10 @@ Legend:
 | (row x col) | `--checksum` | `--checksum-choice=none` | `--inplace` | `--whole-file` | `--no-whole-file` | `--append` | `--append-verify` | `--partial` | `--partial-dir=DIR` | `--delay-updates` | `--temp-dir=DIR` |
 |---|---|---|---|---|---|---|---|---|---|---|---|
 | `--checksum` | - | OK | OK | OK | OK | OK | OK | OK | OK | OK | OK |
-| `--checksum-choice=none` | OK | - | OK | OK->fix [a] | ERR [a] | OK | OK | OK | OK | OK | OK |
+| `--checksum-choice=none` | OK | - | OK | OK [a] | OK [a] | OK | OK | OK | OK | OK | OK |
 | `--inplace` | OK | OK | - | OK | OK | OK [b] | OK [b] | OK [c] | ERR [d] | ERR [e] | OK [f] |
-| `--whole-file` | OK | OK->fix [a] | OK | - | ERR (tri-state) | ERR [g] | ERR [g] | OK | OK | OK | OK |
-| `--no-whole-file` | OK | ERR [a] | OK | ERR (tri-state) | - | OK | OK | OK | OK | OK | OK |
+| `--whole-file` | OK | OK [a] | OK | - | ERR (tri-state) | ERR [g] | ERR [g] | OK | OK | OK | OK |
+| `--no-whole-file` | OK | OK [a] | OK | ERR (tri-state) | - | OK | OK | OK | OK | OK | OK |
 | `--append` | OK | OK | OK [b] | ERR [g] | OK | - | OK | OK [c] | ERR [h] | ERR [i] | OK |
 | `--append-verify` | OK | OK | OK [b] | ERR [g] | OK | OK | - | OK [c] | ERR [h] | ERR [i] | OK |
 | `--partial` | OK | OK | OK [c] | OK | OK | OK [c] | OK [c] | - | OK->fix [j] | OK->fix [j] | OK |
@@ -220,8 +221,10 @@ Footnote validation sites:
   (`target/interop/upstream-src/rsync-3.4.1/checksum.c:197-198`). A
   caller-supplied `--no-whole-file` therefore contradicts the algorithm
   choice. Upstream emits no error in `options.c`; the contradiction
-  manifests later in `parse_checksum_choice`. oc-rsync currently
-  performs neither the silent promotion nor the rejection: see gap G1.
+  manifests later in `parse_checksum_choice`. oc-rsync mirrors upstream
+  exactly: `ClientConfigBuilder::build` promotes `whole_file` to
+  `Some(true)` whenever `checksum_choice.transfer_is_none()` returns
+  true, silently overriding `--no-whole-file`. See G1 (RESOLVED).
 - [b] `--append` sets `inplace = 1` upstream
   (`options.c:2392`). The `--inplace` and `--append`/`--append-verify`
   pair is therefore redundant but accepted (`options.c:2406`). oc-rsync
@@ -303,7 +306,7 @@ Conformance tests:
 
 Ordered by user-facing impact.
 
-### G1 - `--checksum-choice=none` does not promote `--whole-file`
+### G1 - `--checksum-choice=none` does not promote `--whole-file` (RESOLVED)
 
 - **Upstream behaviour.**
   `target/interop/upstream-src/rsync-3.4.1/checksum.c:197-198` sets
@@ -312,14 +315,19 @@ Ordered by user-facing impact.
   `target/interop/upstream-src/rsync-3.4.1/options.c:1981-1987`, this
   means a user who passes `--checksum-choice=none` ends up with a
   whole-file transfer even if they did not pass `-W`.
-- **oc-rsync behaviour.** `ChecksumAlgorithm::None` is recognised at
-  `crates/transfer/src/shared/checksum.rs:146` and falls back to MD4
-  semantics for seed compatibility, but no code path promotes
-  `whole_file` to `Some(true)`. The pair `--checksum-choice=none
-  --no-whole-file` therefore yields a delta transfer that has no
-  strong checksum, which violates upstream's invariant.
-- **Impact.** Wire divergence (oc-rsync runs the delta algorithm
-  where upstream sends literal data); silent.
+- **oc-rsync behaviour (resolved).**
+  `StrongChecksumAlgorithm::None` is recognised by the parser
+  (`crates/core/src/client/config/enums/checksum.rs`) and
+  `ClientConfigBuilder::build` promotes `whole_file` to `Some(true)`
+  whenever `checksum_choice.transfer_is_none()` returns true. The
+  promotion is unconditional, matching upstream's silent override of
+  `--no-whole-file`.
+- **Status.** Resolved in #2139/#2140/#2141. Regression tests live in
+  `crates/core/src/client/config/builder/tests.rs`
+  (`checksum_choice_none_promotes_whole_file`,
+  `checksum_choice_none_overrides_explicit_no_whole_file`) and
+  `crates/cli/tests/option_combinations_flags.rs`
+  (`test_checksum_choice_none_parses`).
 
 ### G2 - `--inplace --partial-dir` cannot be enabled even when peer advertises `CF_INPLACE_PARTIAL_DIR`
 
@@ -381,12 +389,11 @@ Ordered by user-facing impact.
    test in `tests.rs:1055-1116`.
 3. The fix needs no protocol or wire changes; it is purely a
    config-time check.
-4. G1 (`--checksum-choice=none` -> `whole_file`) and G2
-   (`CF_INPLACE_PARTIAL_DIR` runtime relaxation) are tracked as
-   follow-ups because they require either a checksum-negotiation
-   callback or threading the negotiated `CF_*` bits back into the
-   builder, both of which exceed the scope of a single conflict-cell
-   audit.
+4. G1 (`--checksum-choice=none` -> `whole_file`) is resolved (see
+   section 4). G2 (`CF_INPLACE_PARTIAL_DIR` runtime relaxation) is
+   tracked as a follow-up because it requires threading the negotiated
+   `CF_*` bits back into the builder, which exceeds the scope of a
+   single conflict-cell audit.
 5. G4 is internal API only; defer until the rename-batch path is
    refactored independently.
 

--- a/docs/oc-rsync.1.md
+++ b/docs/oc-rsync.1.md
@@ -598,8 +598,10 @@ NEON) are used where available, with automatic scalar fallbacks.
 :   Skip compressing files with suffixes in *LIST*.
 
 **--checksum-choice**=*ALGO*
-:   Select the strong checksum algorithm. Valid values: **auto**, **md4**,
-    **md5**, **xxh64**, **xxh3**, **xxh128**. Also available as **--cc**.
+:   Select the strong checksum algorithm. Valid values: **auto**, **none**,
+    **md4**, **md5**, **xxh64**, **xxh3**, **xxh128**. Also available as
+    **--cc**. **none** disables the transfer checksum and forces
+    **--whole-file** (mirrors upstream `checksum.c:197-198`).
 
 **--checksum-seed**=*NUM*
 :   Set the checksum seed for xxhash-based algorithms.


### PR DESCRIPTION
## Summary

- Closes G1 from the compatibility-flags mutual-exclusion audit.
- Adds `StrongChecksumAlgorithm::None` and accepts `--checksum-choice=none` (case-insensitive, also via `--cc=none`), forwarding the value to remote peers.
- `ClientConfigBuilder::build` now promotes `whole_file` to `Some(true)` whenever `checksum_choice.transfer_is_none()`, mirroring upstream `target/interop/upstream-src/rsync-3.4.1/checksum.c:197-198`:

  ```c
  if (xfer_sum_nni->num == CSUM_NONE)
      whole_file = 1;
  ```

  The assignment is unconditional upstream, so an explicit `--no-whole-file` is silently overridden. The delta pipeline cannot run without a transfer checksum, so whole-file is the only valid mode.

Refs #2139, #2140, #2141.

## Test plan

- [x] `cargo fmt --all` clean.
- [ ] CI: `fmt + clippy`.
- [ ] CI: nextest covers new unit tests in `crates/core/src/client/config/builder/tests.rs` (`checksum_choice_none_promotes_whole_file`, `checksum_choice_none_overrides_explicit_no_whole_file`, `checksum_choice_md5_leaves_whole_file_untouched`) and `crates/core/src/client/config/enums/checksum.rs` (`parse_none`, `transfer_is_none_false_for_other_algorithms`).
- [ ] CI: nextest covers new CLI integration tests in `crates/cli/tests/option_combinations_flags.rs` (`test_checksum_choice_none_parses`, `test_checksum_choice_none_via_cc_alias`).
- [ ] CI: cross-platform matrix (Linux musl, macOS, Windows).
- [ ] CI: interop suite confirms `--checksum-choice=none` round-trips against upstream rsync 3.4.1.

## Diff scope

8 files, +146 / -29.