### PR TITLE
feat(fast_io): apply F_NOCACHE hint on macOS source-file reads

### DIFF
--- a/crates/engine/src/local_copy/executor/file/copy/transfer/open.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/open.rs
@@ -4,6 +4,12 @@
 //! updating access times during transfers. This mirrors upstream rsync behavior
 //! in `sender.c`. On other platforms, `O_NOATIME` is unavailable and the flag
 //! is silently ignored.
+//!
+//! On macOS, large source files additionally receive an
+//! `fcntl(fd, F_NOCACHE, 1)` advisory hint via `fast_io::apply_sequential_read_hint`.
+//! This is the macOS analogue of Linux's `posix_fadvise(POSIX_FADV_DONTNEED)`:
+//! the data is read once for a transfer and will not be revisited, so leaving
+//! it in the unified buffer cache evicts unrelated hot pages.
 
 use std::fs;
 use std::io;
@@ -29,14 +35,34 @@ static FSYNC_CALL_COUNT: AtomicUsize = AtomicUsize::new(0);
 /// When `use_noatime` is true and the platform supports it, the file is opened
 /// with `O_NOATIME` to preserve access timestamps. If the `O_NOATIME` open
 /// fails with a permission-related error, falls back to a normal open.
+///
+/// On macOS the resulting handle additionally receives the sequential-read
+/// advisory (`F_NOCACHE`) for files at or above
+/// `fast_io::F_NOCACHE_THRESHOLD`. The handle is queried for its size via
+/// `metadata()` so callers do not need to know it. The hint is best-effort:
+/// filesystems that reject the flag silently fall back to cached I/O.
 pub(in crate::local_copy) fn open_source_file(
     path: &Path,
     use_noatime: bool,
 ) -> io::Result<fs::File> {
-    if use_noatime && let Some(file) = try_open_noatime(path)? {
-        return Ok(file);
+    let file = if use_noatime && let Some(file) = try_open_noatime(path)? {
+        file
+    } else {
+        fs::File::open(path)?
+    };
+    apply_macos_read_hint(&file);
+    Ok(file)
+}
+
+/// Applies the macOS `F_NOCACHE` advisory hint for sequential source reads.
+///
+/// Best-effort: errors and non-macOS platforms are silently ignored. The
+/// helper queries the file's own metadata for the size hint so the call site
+/// stays small.
+fn apply_macos_read_hint(file: &fs::File) {
+    if let Ok(metadata) = file.metadata() {
+        let _ = fast_io::apply_sequential_read_hint(file, metadata.len());
     }
-    fs::File::open(path)
 }
 
 /// Attempts to open a file with `O_NOATIME` on Linux/Android.
@@ -86,4 +112,40 @@ fn record_fsync_call() {
 #[allow(dead_code)]
 pub(crate) fn take_fsync_call_count() -> usize {
     FSYNC_CALL_COUNT.swap(0, Ordering::Relaxed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Read;
+
+    #[test]
+    fn open_source_file_returns_readable_handle() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("source.bin");
+        std::fs::write(&path, b"payload").unwrap();
+
+        let mut file = open_source_file(&path, false).expect("open source");
+        let mut contents = Vec::new();
+        file.read_to_end(&mut contents).unwrap();
+        assert_eq!(contents, b"payload");
+    }
+
+    #[test]
+    fn open_source_file_large_file_succeeds_with_hint() {
+        // The macOS `F_NOCACHE` hint runs through `apply_macos_read_hint` for
+        // every successful open. Verify the helper does not perturb reads even
+        // for files above the threshold. On non-macOS platforms the hint is a
+        // no-op and the test still validates the open path.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("large_source.bin");
+        let payload = vec![0xABu8; (fast_io::F_NOCACHE_THRESHOLD + 16) as usize];
+        std::fs::write(&path, &payload).unwrap();
+
+        let mut file = open_source_file(&path, false).expect("open large source");
+        let mut contents = Vec::new();
+        file.read_to_end(&mut contents).unwrap();
+        assert_eq!(contents.len(), payload.len());
+        assert_eq!(contents, payload);
+    }
 }

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -158,7 +158,8 @@ pub use splice::{
 };
 
 pub use macos_io::{
-    F_NOCACHE_THRESHOLD, MAX_IOV_COUNT, MacosWriter, is_nocache_set, set_nocache, writev_buffers,
+    F_NOCACHE_THRESHOLD, MAX_IOV_COUNT, MacosWriter, apply_sequential_read_hint, is_nocache_set,
+    set_nocache, writev_buffers,
 };
 
 pub use mmap_reader::MmapReader;

--- a/crates/fast_io/src/macos_io.rs
+++ b/crates/fast_io/src/macos_io.rs
@@ -365,6 +365,58 @@ pub fn set_nocache(file: &std::fs::File) -> bool {
     ret != -1
 }
 
+/// Applies the macOS sequential-read advisory to a source file descriptor.
+///
+/// For large files read end-to-end (rsync's sender / local-copy path), the
+/// unified buffer cache adds no benefit: each byte is read once and the data
+/// will not be revisited soon. Without a hint, a single tree-wide transfer
+/// can evict every other working set from the cache. macOS exposes
+/// `fcntl(fd, F_NOCACHE, 1)` for exactly this case - it is the equivalent of
+/// Linux's `posix_fadvise(POSIX_FADV_DONTNEED)` / `POSIX_FADV_NOREUSE`.
+///
+/// `F_RDADVISE` is intentionally **not** invoked here. That fcntl prefetches
+/// a specific extent range (`struct radvisory { ra_offset, ra_count }`) and
+/// is appropriate when the caller knows precisely which bytes will be read.
+/// rsync's delta algorithm seeks unpredictably through the basis file, so a
+/// blanket `F_RDADVISE` could waste prefetch bandwidth. Callers that already
+/// know they will stream the file end-to-end can drive prefetch separately.
+///
+/// The hint is applied only when `size_hint >= F_NOCACHE_THRESHOLD`. Smaller
+/// files fit comfortably in the cache and may legitimately be re-read.
+///
+/// Returns `true` when the hint was applied. Returns `false` when the file
+/// is below the threshold, when the platform is not macOS, or when the
+/// `fcntl` call fails (e.g., on a filesystem that rejects the flag). Failure
+/// is silent because the hint is advisory.
+///
+/// # Reference
+///
+/// Apple's `fcntl(2)` man page documents `F_NOCACHE`:
+/// "Turns data caching off/on. A non-zero value in arg turns data caching
+///  off. A value of zero in arg turns data caching on."
+#[cfg(target_os = "macos")]
+#[allow(unsafe_code)]
+pub fn apply_sequential_read_hint(file: &std::fs::File, size_hint: u64) -> bool {
+    use std::os::unix::io::AsRawFd;
+
+    if size_hint < F_NOCACHE_THRESHOLD {
+        return false;
+    }
+    let fd = file.as_raw_fd();
+    // SAFETY: `fd` is a valid open file descriptor borrowed from `file`.
+    // `F_NOCACHE` with argument 1 is well-defined on macOS and cannot
+    // corrupt the descriptor or kernel state; failure returns -1 with errno
+    // set, which we surface as `false`.
+    let ret = unsafe { libc::fcntl(fd, libc::F_NOCACHE, 1) };
+    ret != -1
+}
+
+/// Stub for non-macOS platforms. Always returns `false`.
+#[cfg(not(target_os = "macos"))]
+pub fn apply_sequential_read_hint(_file: &std::fs::File, _size_hint: u64) -> bool {
+    false
+}
+
 /// Queries whether `F_NOCACHE` is currently set on a file descriptor.
 ///
 /// macOS does not provide a direct query API for `F_NOCACHE` - the `fcntl`
@@ -827,6 +879,37 @@ mod tests {
 
         let content = std::fs::read(&path).unwrap();
         assert_eq!(&content, b"data");
+    }
+
+    #[test]
+    fn apply_sequential_read_hint_below_threshold_returns_false() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("small_source.bin");
+        std::fs::write(&path, b"tiny").unwrap();
+
+        let file = std::fs::File::open(&path).unwrap();
+        // Below the threshold the hint is intentionally not applied,
+        // regardless of platform.
+        assert!(!apply_sequential_read_hint(&file, 512));
+    }
+
+    #[test]
+    fn apply_sequential_read_hint_large_file_matches_platform() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("large_source.bin");
+        std::fs::write(&path, b"placeholder").unwrap();
+
+        let file = std::fs::File::open(&path).unwrap();
+        let applied = apply_sequential_read_hint(&file, F_NOCACHE_THRESHOLD);
+
+        // On macOS the fcntl call should succeed for a regular file on a
+        // local filesystem. On every other platform the helper is a stub
+        // and must return false.
+        #[cfg(target_os = "macos")]
+        assert!(applied);
+
+        #[cfg(not(target_os = "macos"))]
+        assert!(!applied);
     }
 
     #[test]

--- a/docs/audits/macos-fastio-fallback.md
+++ b/docs/audits/macos-fastio-fallback.md
@@ -221,15 +221,23 @@ writer at `crates/transfer/src/disk_commit/writer.rs:142` still
 constructs `ReusableBufWriter` directly from
 `std::fs::File`; nothing branches to `MacosWriter` on macOS.
 
-### 3.4 Whole-file copy: no `posix_fadvise`/`F_NOCACHE` hint
+### 3.4 Whole-file copy: no `posix_fadvise`/`F_NOCACHE` hint (M3 RESOLVED)
 
 When `clonefile` and `fcopyfile` both fail and the chain drops to
 `std::fs::copy` (`platform_copy/dispatch.rs:93`), the userspace
 buffered copy runs through the unified buffer cache. For tree-wide
 copies larger than RAM this evicts hot pages for the rest of the
-run. No `F_NOCACHE` hint is set anywhere in the macOS path. Cheap
-to add at the call site once `MacosWriter` is wired in (section
-4.1).
+run.
+
+**Resolved (#2154):** The local-copy executor now applies the macOS
+sequential-read advisory at source-file open. The helper lives at
+`crates/fast_io/src/macos_io.rs::apply_sequential_read_hint` and is
+wired into `crates/engine/src/local_copy/executor/file/copy/transfer/open.rs::open_source_file`.
+Files at or above `F_NOCACHE_THRESHOLD` (1 MiB) receive
+`fcntl(fd, F_NOCACHE, 1)`, the macOS analogue of Linux's
+`posix_fadvise(POSIX_FADV_DONTNEED)`. `F_RDADVISE` is deliberately
+not used: it requires a known `(ra_offset, ra_count)` extent and
+rsync's delta algorithm seeks unpredictably through the basis file.
 
 ### 3.5 Network-to-disk path: no `sendfile`
 


### PR DESCRIPTION
## Summary

- Adds `fast_io::apply_sequential_read_hint(&File, size_hint)` that issues `fcntl(fd, F_NOCACHE, 1)` on macOS for files at or above `F_NOCACHE_THRESHOLD` (1 MiB). The helper is a no-op on every other platform and silently ignores `fcntl` failure on filesystems that reject the flag.
- Wires the hint into `open_source_file` in the local-copy transfer executor so every source file opened for a transfer receives the advisory automatically. The hint is the macOS analogue of Linux's `posix_fadvise(POSIX_FADV_DONTNEED)` / `POSIX_FADV_NOREUSE` and keeps unrelated hot pages in the unified buffer cache during tree-wide transfers larger than RAM.
- `F_RDADVISE` is intentionally not used. Apple's `fcntl(2)` man page documents `F_RDADVISE` as a prefetch hint that requires a known `(ra_offset, ra_count)` extent in `struct radvisory`. rsync's delta algorithm seeks unpredictably through the basis file, so a blanket `F_RDADVISE` would waste prefetch bandwidth.
- Marks M3 RESOLVED in `docs/audits/macos-fastio-fallback.md` and links the implementation.

## Man-page citation

> `F_NOCACHE` - Turns data caching off/on. A non-zero value in arg turns data caching off. A value of zero in arg turns data caching on.
>
> `F_RDADVISE` - Issue an advisory read async with no copy to user. ... arg points to a `radvisory` structure containing the requested offset and length.

(Apple `fcntl(2)`, Darwin 24 / macOS 15.)

Closes #2154.

## Test plan

- [ ] CI fmt+clippy passes.
- [ ] CI nextest (stable) passes on macOS, Linux, Windows.
- [ ] New unit tests `apply_sequential_read_hint_*` and `open_source_file_*` run green on the macOS runner.