### PR TITLE
fix(transfer): remove dead flist_done_remaining increment after EOF

### DIFF
--- a/crates/transfer/src/generator/transfer.rs
+++ b/crates/transfer/src/generator/transfer.rs
@@ -450,6 +450,10 @@ impl GeneratorContext {
         }
 
         // Flush any remaining INC_RECURSE segments and send NDX_FLIST_EOF.
+        // No need to track flist_done_remaining here: the EOF flush is the
+        // final write loop in this function, so the counter is never read
+        // again. Mid-transfer increments at line ~435 are still needed for
+        // the in-loop accounting at line ~158.
         if inc_recurse && !self.incremental.flist_eof_sent {
             for seg in scheduler.remaining() {
                 self.encode_and_send_segment(
@@ -459,7 +463,6 @@ impl GeneratorContext {
                     &mut flist_ndx_codec,
                 )?;
                 segments_sent += 1;
-                flist_done_remaining += 1;
             }
             self.send_flist_eof(&mut *writer, &mut flist_ndx_codec, segments_sent)?;
         }


### PR DESCRIPTION
## Summary

`crates/transfer/src/generator/transfer.rs:462` has a `flist_done_remaining += 1;` inside the INC_RECURSE EOF-flush loop that's never read — the function returns immediately after `send_flist_eof()`. The counter is only meaningful mid-transfer where it tracks outstanding acks (line ~158 decrements it on each NDX_DONE response).

Discovered via the macOS rustup-run CI fix (#4063) which exposes the project to newer stable rustc that flags this under `-D warnings`. Stable 1.88.0 doesn't catch it; stable 1.96.0+ does.

Removing the dead store. The fix is independent of #4063 — once this lands, #4063's macOS jobs should also go green.

## Test plan

- [ ] CI green on all required checks
- [ ] No behavior change (dead store had no observable effect)