### PR TITLE
feat: filter-rule sender-side (s) and receiver-side (r) directive modifiers

### DIFF
--- a/crates/filters/src/merge/parse.rs
+++ b/crates/filters/src/merge/parse.rs
@@ -81,6 +81,7 @@ fn parse_rule_line_expanded(
     let (mods, pattern) = parse_modifiers(rest);
 
     if mods.word_split && !pattern.is_empty() {
+        validate_side_modifiers(action_char, &mods, line, source_path, line_num)?;
         let patterns: Vec<&str> = pattern.split_whitespace().collect();
         if patterns.is_empty() {
             return Err(MergeFileError::parse_error(
@@ -165,6 +166,42 @@ impl RuleModifiers {
     }
 }
 
+/// Rejects `s` or `r` modifiers when the rule prefix already implies a side.
+///
+/// Matches upstream's `prefix_specifies_side` guard: prefixes `H`/`S`
+/// (sender-side hide/show) and `P`/`R` (receiver-side protect/risk) bind the
+/// rule to a single side, so combining them with the modifier counterpart is a
+/// syntax error.
+///
+/// upstream: exclude.c parse_filter_str (rsync-3.4.2) lines 1269-1278
+fn validate_side_modifiers(
+    action_char: char,
+    mods: &RuleModifiers,
+    line: &str,
+    source_path: &Path,
+    line_num: usize,
+) -> Result<(), MergeFileError> {
+    let prefix_side = matches!(action_char, 'H' | 'S' | 'P' | 'R');
+    if !prefix_side {
+        return Ok(());
+    }
+    let conflict = if mods.sender_only {
+        Some('s')
+    } else if mods.receiver_only {
+        Some('r')
+    } else {
+        None
+    };
+    if let Some(ch) = conflict {
+        return Err(MergeFileError::parse_error(
+            source_path,
+            line_num,
+            format!("invalid modifier '{ch}' on side-specific filter rule: {line}"),
+        ));
+    }
+    Ok(())
+}
+
 /// Parses modifiers from a string following the action character.
 ///
 /// Returns the parsed modifiers and the remaining string (pattern).
@@ -234,41 +271,48 @@ impl ShortFormAction {
 
 /// Tries to parse a short-form rule (single character prefix like `+`, `-`, `P`).
 ///
-/// Returns `Some(rule)` if the line matches a short-form pattern, `None` otherwise.
+/// Returns `Ok(Some(rule))` if the line matches a short-form pattern,
+/// `Ok(None)` if no prefix matched, or `Err` if a recognised prefix was paired
+/// with an invalid modifier (e.g. `Hr`, `Sr`, `Ps`, `Rs`).
 ///
 /// upstream: exclude.c:parse_filter_str() - short-form prefix handling
-fn try_parse_short_form(line: &str) -> Option<FilterRule> {
-    let (rest, action) = if let Some(r) = line.strip_prefix('+') {
-        (r, ShortFormAction::Include)
+fn try_parse_short_form(
+    line: &str,
+    source_path: &Path,
+    line_num: usize,
+) -> Result<Option<FilterRule>, MergeFileError> {
+    let (rest, action, prefix_char) = if let Some(r) = line.strip_prefix('+') {
+        (r, ShortFormAction::Include, '+')
     } else if let Some(r) = line.strip_prefix('-') {
-        (r, ShortFormAction::Exclude)
+        (r, ShortFormAction::Exclude, '-')
     } else if let Some(r) = line.strip_prefix('P') {
-        (r, ShortFormAction::Protect)
+        (r, ShortFormAction::Protect, 'P')
     } else if let Some(r) = line.strip_prefix('R') {
-        (r, ShortFormAction::Risk)
+        (r, ShortFormAction::Risk, 'R')
     } else if let Some(r) = line.strip_prefix('.') {
-        (r, ShortFormAction::Merge)
+        (r, ShortFormAction::Merge, '.')
     } else if let Some(r) = line.strip_prefix(':') {
-        (r, ShortFormAction::DirMerge)
+        (r, ShortFormAction::DirMerge, ':')
     } else if let Some(r) = line.strip_prefix('H') {
-        (r, ShortFormAction::Hide)
+        (r, ShortFormAction::Hide, 'H')
     } else if let Some(r) = line.strip_prefix('S') {
-        (r, ShortFormAction::Show)
+        (r, ShortFormAction::Show, 'S')
     } else {
-        return None;
+        return Ok(None);
     };
 
     let (mods, pattern) = parse_modifiers(rest);
     if pattern.is_empty() {
-        return None;
+        return Ok(None);
     }
+    validate_side_modifiers(prefix_char, &mods, line, source_path, line_num)?;
 
     let rule = action.to_rule(pattern);
-    Some(if action.supports_mods() {
+    Ok(Some(if action.supports_mods() {
         mods.apply(rule)
     } else {
         rule
-    })
+    }))
 }
 
 /// Tries to parse a long-form rule (keyword prefix like `include`, `exclude`).
@@ -314,7 +358,7 @@ fn parse_rule_line(
         return Ok(FilterRule::clear());
     }
 
-    if let Some(rule) = try_parse_short_form(line) {
+    if let Some(rule) = try_parse_short_form(line, source_path, line_num)? {
         return Ok(rule);
     }
 

--- a/crates/filters/src/merge/tests.rs
+++ b/crates/filters/src/merge/tests.rs
@@ -638,3 +638,79 @@ fn read_rules_recursive_mixed_with_dir_merge() {
     assert_eq!(rules[0].action(), FilterAction::DirMerge);
     assert_eq!(rules[1].action(), FilterAction::Include);
 }
+
+// upstream: exclude.c parse_filter_str (rsync-3.4.2) lines 1269-1278 — the
+// `s` and `r` modifiers gate which side a rule fires on. These tests pin
+// down the three-state parsing surface (both, sender-only, receiver-only)
+// and the `prefix_specifies_side` rejection.
+
+#[test]
+fn parse_include_default_both_sides() {
+    let rules = parse_rules("+ foo", Path::new("test")).unwrap();
+    assert!(rules[0].applies_to_sender());
+    assert!(rules[0].applies_to_receiver());
+}
+
+#[test]
+fn parse_include_receiver_only() {
+    let rules = parse_rules("+r foo", Path::new("test")).unwrap();
+    assert!(!rules[0].applies_to_sender());
+    assert!(rules[0].applies_to_receiver());
+}
+
+#[test]
+fn parse_include_sender_only() {
+    let rules = parse_rules("+s foo", Path::new("test")).unwrap();
+    assert!(rules[0].applies_to_sender());
+    assert!(!rules[0].applies_to_receiver());
+}
+
+#[test]
+fn parse_exclude_receiver_only() {
+    let rules = parse_rules("-r *.tmp", Path::new("test")).unwrap();
+    assert_eq!(rules[0].action(), FilterAction::Exclude);
+    assert!(!rules[0].applies_to_sender());
+    assert!(rules[0].applies_to_receiver());
+}
+
+#[test]
+fn parse_both_side_modifiers_collapses_to_both() {
+    // Upstream treats setting both FILTRULE_SENDER_SIDE and FILTRULE_RECEIVER_SIDE
+    // as equivalent to setting neither (see exclude.c send_rules elide computation
+    // at lines 1605-1612). Our parser matches that semantics.
+    let rules = parse_rules("+sr foo", Path::new("test")).unwrap();
+    assert!(rules[0].applies_to_sender());
+    assert!(rules[0].applies_to_receiver());
+}
+
+#[test]
+fn parse_rejects_s_modifier_on_side_specific_prefix() {
+    // upstream: exclude.c parse_filter_str sets `prefix_specifies_side` for
+    // H/S/P/R prefixes and rejects 's' or 'r' modifiers on them.
+    for line in ["Hs foo", "Ss foo", "Ps foo", "Rs foo"] {
+        let err = parse_rules(line, Path::new("test")).unwrap_err();
+        assert!(
+            err.message.contains("invalid modifier 's'"),
+            "expected rejection for `{line}`, got `{}`",
+            err.message
+        );
+    }
+}
+
+#[test]
+fn parse_rejects_r_modifier_on_side_specific_prefix() {
+    for line in ["Hr foo", "Sr foo", "Pr foo", "Rr foo"] {
+        let err = parse_rules(line, Path::new("test")).unwrap_err();
+        assert!(
+            err.message.contains("invalid modifier 'r'"),
+            "expected rejection for `{line}`, got `{}`",
+            err.message
+        );
+    }
+}
+
+#[test]
+fn parse_rejects_side_modifier_with_word_split_on_side_prefix() {
+    let err = parse_rules("Hsw foo bar", Path::new("test")).unwrap_err();
+    assert!(err.message.contains("invalid modifier 's'"));
+}

--- a/crates/filters/tests/filter_rule_syntax.rs
+++ b/crates/filters/tests/filter_rule_syntax.rs
@@ -908,10 +908,14 @@ mod combined_filter_types {
 
     #[test]
     fn modifiers_on_different_rule_types() {
+        // Note: side-specific prefixes (H/S/P/R) implicitly bind their side,
+        // so adding an `s`/`r` modifier is redundant and upstream rejects it
+        // (see exclude.c:1269-1278 prefix_specifies_side). `P!` alone already
+        // implies receiver-only; `H!p` is sender-only.
         let rules = parse_rules(
             "+!p special.txt\n\
              -!s *.hidden\n\
-             P!r /protected\n\
+             P! /protected\n\
              H!p *.secret",
             Path::new("test"),
         )

--- a/docs/audits/filter-sender-receiver-directives-2127.md
+++ b/docs/audits/filter-sender-receiver-directives-2127.md
@@ -1,0 +1,58 @@
+# Audit: filter-rule sender (`s`) and receiver (`r`) modifiers
+
+Status: RESOLVED in #2127.
+Upstream reference: `target/interop/upstream-src/rsync-3.4.2/exclude.c`.
+
+## Scope
+
+This audit verifies that oc-rsync recognises upstream rsync's `s` (sender-side)
+and `r` (receiver-side) filter-rule modifiers and that the rule fires only on
+the matching side at evaluation time.
+
+## Upstream behaviour
+
+`exclude.c` parses two rule-side flag bits on `filter_rule`:
+
+- `FILTRULE_SENDER_SIDE` (set by the `s` modifier or by the `H`/`S` prefix at
+  lines 1194-1200).
+- `FILTRULE_RECEIVER_SIDE` (set by the `r` modifier or by the `P`/`R` prefix
+  at lines 1201-1207).
+
+The modifiers are suffix flags placed between the action character and the
+pattern, e.g. `-r *.tmp` or `+s logs/**`. When both bits are set on the same
+rule (`-sr *.tmp`), upstream's `send_rules` elide computation at lines
+1605-1612 cancels them out: the rule transmits and fires on both sides, which
+is identical to setting neither bit.
+
+A side-specifying prefix (`H`, `S`, `P`, `R`) sets `prefix_specifies_side` at
+parse time (lines 1199, 1206) and any subsequent `s` or `r` modifier is a
+syntax error (lines 1269-1278). For example `Hr foo` is rejected.
+
+## oc-rsync implementation map
+
+| Concern | Location |
+|---------|----------|
+| Side fields on the rule struct | `crates/filters/src/rule.rs` -- `applies_to_sender`, `applies_to_receiver` |
+| Builder API | `FilterRule::with_sender`, `with_receiver`, `with_sides` |
+| Modifier parsing | `crates/filters/src/merge/parse.rs::parse_modifiers` (`s`, `r` chars) |
+| Prefix-side validation | `crates/filters/src/merge/parse.rs::validate_side_modifiers` |
+| Evaluate-time gating | `crates/filters/src/decision.rs` (`applies_to_sender`/`applies_to_receiver` predicates) |
+| Wire encoding | `crates/protocol/src/filters/prefix.rs` (emits `s`/`r` under protocol >= 29) |
+
+## Test coverage
+
+- Unit: `crates/filters/src/merge/tests.rs` -- `parse_include_default_both_sides`,
+  `parse_include_sender_only`, `parse_include_receiver_only`,
+  `parse_both_side_modifiers_collapses_to_both`,
+  `parse_rejects_s_modifier_on_side_specific_prefix`,
+  `parse_rejects_r_modifier_on_side_specific_prefix`,
+  `parse_rejects_side_modifier_with_word_split_on_side_prefix`.
+- Integration: `crates/filters/tests/sender_receiver_sides.rs` covers
+  show/hide, protect/risk, and mixed combinations through `FilterSet::allows`
+  and `allows_deletion`.
+
+## Wire compatibility
+
+No wire-format changes. Encoding of the `s`/`r` modifier on the wire is
+gated by `protocol_version >= 29` per `exclude.c` lines 1567 and 1570; the
+oc-rsync encoder mirrors that check in `prefix.rs::build_rule_prefix`.


### PR DESCRIPTION
## Summary

- Adopt upstream rsync's `prefix_specifies_side` guard so the merge-file
  parser rejects `s` and `r` modifiers when the rule prefix already binds a
  side (`H`/`S` for sender, `P`/`R` for receiver). Combinations like
  `Hr foo`, `Sr foo`, `Pr foo`, and `Rs foo` are now syntax errors, matching
  upstream `exclude.c:1269-1278` (rsync-3.4.2).
- The modifier parsing surface (`+r`, `+s`, `-r`, `-s`, plus the existing
  `H`/`S`/`P`/`R` prefixes) and the evaluate-time gate against
  `applies_to_sender` / `applies_to_receiver` were already wired; this PR
  closes the validation gap and pins it down with unit tests.
- New audit doc records the implementation map and upstream parity.

Closes #2127.

## Test plan

- [x] `cargo fmt --all`
- [ ] CI: fmt + clippy
- [ ] CI: nextest (stable) on Linux, macOS, Windows, Linux musl
- [ ] CI: interop validation