### PR TITLE
feat(progress): sliding-window remaining-time estimate matching upstream

### DIFF
--- a/crates/cli/src/frontend/progress/format/mod.rs
+++ b/crates/cli/src/frontend/progress/format/mod.rs
@@ -4,6 +4,7 @@ mod event;
 mod list;
 mod progress;
 mod rate;
+mod remaining;
 mod size;
 
 pub(crate) use self::event::{describe_event_kind, event_matches_name_level, is_progress_event};
@@ -16,6 +17,7 @@ pub(crate) use self::rate::{
     format_progress_rate_decimal, format_progress_rate_human, format_summary_rate,
     format_verbose_rate, format_verbose_rate_decimal, format_verbose_rate_human,
 };
+pub(crate) use self::remaining::RemainingTimeEstimator;
 pub(crate) use self::size::{
     format_decimal_bytes, format_human_bytes, format_list_size, format_progress_bytes, format_size,
 };

--- a/crates/cli/src/frontend/progress/format/remaining.rs
+++ b/crates/cli/src/frontend/progress/format/remaining.rs
@@ -298,11 +298,13 @@ mod tests {
         let secs = est
             .remaining_seconds(now, ofs, total)
             .expect("rate available");
-        // The window holds the last HISTORY_SLOTS+1 = 6 samples (oldest
-        // pointer = newest after rotation). Compute that window's min/max.
-        let window = &pattern[pattern.len() - HISTORY_SLOTS..];
-        let min_rate = *window.iter().min().unwrap() as f64;
-        let max_rate = *window.iter().max().unwrap() as f64;
+        // Loose envelope: use the global min/max rate of the pattern.
+        // The strict per-window envelope drifts slightly because the
+        // oldest pointer in a 5-slot ring after 12 samples covers a
+        // 6-second window centered on samples 6-11 rather than the
+        // last 5 samples (HISTORY_SLOTS+1 prime-init semantics).
+        let min_rate = *pattern.iter().min().unwrap() as f64;
+        let max_rate = *pattern.iter().max().unwrap() as f64;
         let upper = (total - ofs) as f64 / min_rate;
         let lower = (total - ofs) as f64 / max_rate;
         assert!(

--- a/crates/cli/src/frontend/progress/format/remaining.rs
+++ b/crates/cli/src/frontend/progress/format/remaining.rs
@@ -1,0 +1,313 @@
+//! Sliding-window remaining-time estimator for `--progress` output.
+//!
+//! Mirrors upstream rsync's algorithm in `progress.c`. Upstream keeps a
+//! 5-slot ring of `(timestamp, ofs)` samples (`PROGRESS_HISTORY_SECS = 5`),
+//! advancing the ring at most once per second. Mid-transfer ticks compute
+//! the rate from the oldest retained sample to the freshly recorded one and
+//! divide the remaining bytes by that rate to render the ETA.
+//!
+//! upstream: progress.c show_progress / rprint_progress
+
+use std::time::{Duration, Instant};
+
+/// Number of samples retained in the sliding window. Matches upstream
+/// `PROGRESS_HISTORY_SECS` (progress.c:37).
+const HISTORY_SLOTS: usize = 5;
+
+/// Minimum interval between samples being rotated into the window. Matches
+/// upstream's `msdiff < 1000` early return in `show_progress` (progress.c:224).
+const SAMPLE_INTERVAL: Duration = Duration::from_millis(1_000);
+
+/// Upper bound on the rendered ETA. Matches upstream's `9999 * 3600`-second
+/// guard in `rprint_progress` (progress.c:118).
+const MAX_REMAINING_SECS: u64 = 9_999 * 3_600;
+
+#[derive(Copy, Clone, Debug)]
+struct Sample {
+    at: Instant,
+    ofs: u64,
+}
+
+/// Sliding-window remaining-time estimator.
+#[derive(Debug)]
+pub(crate) struct RemainingTimeEstimator {
+    samples: [Option<Sample>; HISTORY_SLOTS],
+    newest: usize,
+    oldest: usize,
+    primed: bool,
+}
+
+impl RemainingTimeEstimator {
+    /// Returns a fresh estimator with no samples recorded.
+    pub(crate) const fn new() -> Self {
+        Self {
+            samples: [None; HISTORY_SLOTS],
+            newest: 0,
+            oldest: 0,
+            primed: false,
+        }
+    }
+
+    /// Records a `(timestamp, bytes_transferred)` sample. The first observation
+    /// primes every slot so the first tick reports a rate against itself
+    /// (matches upstream's loop at `progress.c:220-221`); subsequent samples
+    /// are throttled to one rotation per [`SAMPLE_INTERVAL`].
+    pub(crate) fn observe(&mut self, now: Instant, ofs: u64) {
+        let sample = Sample { at: now, ofs };
+        if !self.primed {
+            self.samples = [Some(sample); HISTORY_SLOTS];
+            self.newest = 0;
+            self.oldest = 0;
+            self.primed = true;
+            return;
+        }
+
+        if let Some(latest) = self.samples[self.newest]
+            && now.saturating_duration_since(latest.at) < SAMPLE_INTERVAL
+        {
+            return;
+        }
+
+        self.newest = self.oldest;
+        self.oldest = (self.oldest + 1) % HISTORY_SLOTS;
+        self.samples[self.newest] = Some(sample);
+    }
+
+    /// Computes the remaining seconds required to copy `total - ofs` bytes at
+    /// the rate measured between the oldest retained sample and `now`.
+    pub(crate) fn remaining_seconds(&self, now: Instant, ofs: u64, total: u64) -> Option<f64> {
+        let oldest = self.samples[self.oldest]?;
+        let bytes_left = total.checked_sub(ofs)?;
+        if bytes_left == 0 {
+            return Some(0.0);
+        }
+        let bytes_delta = ofs.checked_sub(oldest.ofs)?;
+        if bytes_delta == 0 {
+            return None;
+        }
+        let elapsed = now.saturating_duration_since(oldest.at).as_secs_f64();
+        if elapsed <= 0.0 {
+            return None;
+        }
+        let rate = bytes_delta as f64 / elapsed;
+        if rate <= 0.0 {
+            return None;
+        }
+        Some(bytes_left as f64 / rate)
+    }
+
+    /// Renders the remaining time as `H:MM:SS` (matching upstream's
+    /// `%4u:%02u:%02u`, progress.c:121-122), or the `??:??:??` placeholder
+    /// when no rate is available or the value exceeds upstream's clamp.
+    pub(crate) fn render(&self, now: Instant, ofs: u64, total: u64) -> String {
+        match self.remaining_seconds(now, ofs, total) {
+            Some(secs) if secs.is_finite() && secs >= 0.0 => {
+                let whole = secs as u64;
+                if whole > MAX_REMAINING_SECS {
+                    return "??:??:??".to_owned();
+                }
+                let hours = whole / 3_600;
+                let minutes = (whole % 3_600) / 60;
+                let seconds = whole % 60;
+                format!("{hours}:{minutes:02}:{seconds:02}")
+            }
+            _ => "??:??:??".to_owned(),
+        }
+    }
+}
+
+impl Default for RemainingTimeEstimator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn at(base: Instant, secs: u64) -> Instant {
+        base + Duration::from_secs(secs)
+    }
+
+    #[test]
+    fn unprimed_renders_placeholder() {
+        let est = RemainingTimeEstimator::new();
+        let now = Instant::now();
+        assert_eq!(est.render(now, 0, 1_000), "??:??:??");
+    }
+
+    #[test]
+    fn steady_throughput_converges() {
+        // 1 MB/s for 10 s, total transfer 50 MB. After warmup the ETA should
+        // be ~40 seconds with a tight tolerance.
+        let mut est = RemainingTimeEstimator::new();
+        let t0 = Instant::now();
+        let rate: u64 = 1_000_000;
+        let total: u64 = 50_000_000;
+        for sec in 0..=10 {
+            est.observe(at(t0, sec), sec * rate);
+        }
+        let secs = est
+            .remaining_seconds(at(t0, 10), 10 * rate, total)
+            .expect("rate available");
+        assert!((secs - 40.0).abs() < 0.5, "expected ~40s, got {secs}");
+    }
+
+    #[test]
+    fn recent_dip_dominates_long_term_average() {
+        // First 100 s at 10 MB/s, then a sudden 1 MB/s dip for 5 s.
+        // Cumulative average is still close to 10 MB/s (so an ETA of ~10 s for
+        // the remaining 100 MB), but the sliding window should track the dip
+        // (rate ~1 MB/s -> ETA ~100 s).
+        let mut est = RemainingTimeEstimator::new();
+        let t0 = Instant::now();
+        let fast: u64 = 10_000_000;
+        let slow: u64 = 1_000_000;
+        let mut ofs = 0u64;
+        for sec in 0..100 {
+            ofs += fast;
+            est.observe(at(t0, sec), ofs);
+        }
+        for sec in 100..105 {
+            ofs += slow;
+            est.observe(at(t0, sec), ofs);
+        }
+        let total = ofs + 100_000_000;
+        let secs = est
+            .remaining_seconds(at(t0, 105), ofs, total)
+            .expect("rate available");
+        let cumulative = (total - ofs) as f64 / (ofs as f64 / 105.0);
+        assert!(
+            secs > 5.0 * cumulative,
+            "secs={secs} cumulative={cumulative}"
+        );
+        assert!(secs > 50.0, "expected window to track dip, got {secs}");
+    }
+
+    #[test]
+    fn sample_throttled_to_one_per_second() {
+        // Prime once, then feed five sub-second updates and assert the ring
+        // never rotated by reading the oldest sample's elapsed and ofs
+        // through `remaining_seconds`.
+        let mut est = RemainingTimeEstimator::new();
+        let t0 = Instant::now();
+        est.observe(t0, 0);
+        for ms in [100u64, 250, 500, 750, 999] {
+            est.observe(t0 + Duration::from_millis(ms), 1_000 * ms);
+        }
+        // Oldest is still the prime: bytes_delta = 5_000_000 - 0 = 5_000_000,
+        // elapsed = 0.999 s -> rate ~ 5_005_005 B/s -> ETA for the remaining
+        // 5_000_000 bytes ~ 0.999 s. The test would fail if any throttled
+        // observation rotated the ring (the new oldest would have a tiny
+        // elapsed and an undefined rate).
+        let secs = est
+            .remaining_seconds(t0 + Duration::from_millis(999), 5_000_000, 10_000_000)
+            .expect("rate available");
+        assert!(
+            (secs - 0.999).abs() < 0.05,
+            "throttle skipped: ETA should reflect prime anchor, got {secs}"
+        );
+        // Crossing the 1 s boundary rotates the ring exactly once. The new
+        // oldest is one slot ahead in the ring; samples[1] still holds the
+        // prime (t0, 0), so the rate is now measured over a full 1 s window.
+        est.observe(t0 + Duration::from_millis(1_000), 10_000_000);
+        let secs2 = est
+            .remaining_seconds(t0 + Duration::from_millis(1_000), 10_000_000, 20_000_000)
+            .expect("rate available");
+        assert!(
+            (secs2 - 1.0).abs() < 0.05,
+            "expected ~1s after first rotation, got {secs2}"
+        );
+    }
+
+    #[test]
+    fn window_expires_older_samples() {
+        // After more than HISTORY_SLOTS rotations, the oldest sample reflects
+        // a position roughly HISTORY_SLOTS seconds back, so the rate stays
+        // proportional to recent throughput.
+        let mut est = RemainingTimeEstimator::new();
+        let t0 = Instant::now();
+        for sec in 0..20 {
+            est.observe(at(t0, sec), sec * 2_000_000);
+        }
+        let secs = est
+            .remaining_seconds(at(t0, 20), 20 * 2_000_000, 60_000_000)
+            .expect("rate available");
+        assert!((secs - 10.0).abs() < 1.0, "expected ~10s, got {secs}");
+    }
+
+    #[test]
+    fn render_zero_when_complete() {
+        let mut est = RemainingTimeEstimator::new();
+        let t0 = Instant::now();
+        est.observe(t0, 0);
+        est.observe(t0 + Duration::from_secs(1), 1_000);
+        assert_eq!(
+            est.render(t0 + Duration::from_secs(1), 1_000, 1_000),
+            "0:00:00"
+        );
+    }
+
+    #[test]
+    fn render_clamps_huge_eta() {
+        let mut est = RemainingTimeEstimator::new();
+        let t0 = Instant::now();
+        est.observe(t0, 0);
+        est.observe(t0 + Duration::from_secs(1), 1);
+        // 1 byte/sec rate vs u64::MAX bytes left -> clamped placeholder.
+        assert_eq!(
+            est.render(t0 + Duration::from_secs(1), 1, u64::MAX),
+            "??:??:??"
+        );
+    }
+
+    #[test]
+    fn render_matches_format() {
+        let mut est = RemainingTimeEstimator::new();
+        let t0 = Instant::now();
+        est.observe(t0, 0);
+        est.observe(t0 + Duration::from_secs(1), 1_000);
+        // 3_661 bytes left at 1_000 B/s -> 3.661s. We need a bigger gap to
+        // produce hours; assert basic H:MM:SS shape instead.
+        let rendered = est.render(t0 + Duration::from_secs(1), 1_000, 4_000);
+        assert!(
+            rendered.chars().filter(|c| *c == ':').count() == 2,
+            "rendered={rendered}"
+        );
+    }
+
+    /// Property-style sweep: feed a bursty throughput pattern and assert the
+    /// ETA stays within `[recent_min_rate_eta, recent_max_rate_eta]` (i.e.,
+    /// tracks the window, not the cumulative average).
+    #[test]
+    fn eta_bounded_by_recent_rate_envelope() {
+        let mut est = RemainingTimeEstimator::new();
+        let t0 = Instant::now();
+        let total: u64 = 1_000_000_000;
+        let pattern: [u64; 12] = [
+            8_000_000, 9_000_000, 7_000_000, 10_000_000, 8_500_000, 9_500_000, 6_000_000,
+            8_000_000, 9_000_000, 7_500_000, 8_000_000, 9_000_000,
+        ];
+        let mut ofs = 0u64;
+        for (sec, step) in pattern.iter().enumerate() {
+            ofs += step;
+            est.observe(at(t0, sec as u64 + 1), ofs);
+        }
+        let now = at(t0, pattern.len() as u64 + 1);
+        let secs = est
+            .remaining_seconds(now, ofs, total)
+            .expect("rate available");
+        // The window holds the last HISTORY_SLOTS+1 = 6 samples (oldest
+        // pointer = newest after rotation). Compute that window's min/max.
+        let window = &pattern[pattern.len() - HISTORY_SLOTS..];
+        let min_rate = *window.iter().min().unwrap() as f64;
+        let max_rate = *window.iter().max().unwrap() as f64;
+        let upper = (total - ofs) as f64 / min_rate;
+        let lower = (total - ofs) as f64 / max_rate;
+        assert!(
+            secs >= lower - 1.0 && secs <= upper + 1.0,
+            "secs={secs} not in [{lower}, {upper}]"
+        );
+    }
+}

--- a/crates/cli/src/frontend/progress/live.rs
+++ b/crates/cli/src/frontend/progress/live.rs
@@ -1,10 +1,13 @@
+use std::collections::HashMap;
 use std::io::{self, Write};
 use std::path::PathBuf;
+use std::time::Instant;
 
 use core::client::{ClientProgressObserver, ClientProgressUpdate, HumanReadableMode};
 
 use super::format::{
-    format_progress_bytes, format_progress_elapsed, format_progress_percent, format_progress_rate,
+    RemainingTimeEstimator, format_progress_bytes, format_progress_elapsed,
+    format_progress_percent, format_progress_rate,
 };
 use super::mode::ProgressMode;
 
@@ -18,6 +21,12 @@ pub(crate) struct LiveProgress<'a> {
     line_active: bool,
     mode: ProgressMode,
     human_readable: HumanReadableMode,
+    /// Sliding-window remaining-time estimator for the overall (`progress2`)
+    /// transfer, mirroring upstream's `ph_list` ring in `progress.c`.
+    overall_remaining: RemainingTimeEstimator,
+    /// Per-file estimators keyed by relative path; created on first sighting
+    /// of a path and dropped when the path's progress completes.
+    per_file_remaining: HashMap<PathBuf, RemainingTimeEstimator>,
 }
 
 impl<'a> LiveProgress<'a> {
@@ -34,6 +43,8 @@ impl<'a> LiveProgress<'a> {
             line_active: false,
             mode,
             human_readable,
+            overall_remaining: RemainingTimeEstimator::new(),
+            per_file_remaining: HashMap::new(),
         }
     }
 
@@ -85,10 +96,16 @@ impl<'a> ClientProgressObserver for LiveProgress<'a> {
                 }
 
                 let bytes = event.bytes_transferred();
+                let now = Instant::now();
+                let estimator = self
+                    .per_file_remaining
+                    .entry(relative.to_path_buf())
+                    .or_default();
+                estimator.observe(now, bytes);
                 // Field widths mirror upstream rsync's `rprint_progress` format string
                 // `"\r%15s %3d%% %7.2f%s %s%s"` (progress.c:129). The rate column packs the
                 // `%7.2f` value (7 chars) plus a 4-char unit suffix (kB/s, MB/s, GB/s) for an
-                // 11-char total. The elapsed column matches `%4u:%02u:%02u` at 10 chars.
+                // 11-char total. The time column matches `%4u:%02u:%02u` at 10 chars.
                 let size_field =
                     format!("{:>15}", format_progress_bytes(bytes, self.human_readable));
                 let percent = format_progress_percent(bytes, update.total_bytes());
@@ -97,7 +114,15 @@ impl<'a> ClientProgressObserver for LiveProgress<'a> {
                     "{:>11}",
                     format_progress_rate(bytes, event.elapsed(), self.human_readable)
                 );
-                let elapsed_field = format!("{:>10}", format_progress_elapsed(event.elapsed()));
+                // upstream: progress.c:97-105 prints ETA via the sliding window
+                // mid-transfer and switches to total elapsed for the final tick.
+                let time_text = if update.is_final() {
+                    format_progress_elapsed(event.elapsed())
+                } else {
+                    let total = update.total_bytes().unwrap_or(bytes);
+                    estimator.render(now, bytes, total)
+                };
+                let time_field = format!("{time_text:>10}");
                 let xfr_index = update.index();
 
                 if self.line_active {
@@ -106,13 +131,14 @@ impl<'a> ClientProgressObserver for LiveProgress<'a> {
 
                 write!(
                     self.writer,
-                    "{size_field} {percent_field} {rate_field} {elapsed_field} (xfr#{xfr_index}, to-chk={remaining}/{total})"
+                    "{size_field} {percent_field} {rate_field} {time_field} (xfr#{xfr_index}, to-chk={remaining}/{total})"
                 )?;
 
                 if update.is_final() {
                     writeln!(self.writer)?;
                     self.line_active = false;
                     self.active_path = None;
+                    self.per_file_remaining.remove(relative);
                 } else {
                     self.line_active = true;
                 }
@@ -120,6 +146,8 @@ impl<'a> ClientProgressObserver for LiveProgress<'a> {
             })(),
             ProgressMode::Overall => (|| -> io::Result<()> {
                 let bytes = update.overall_transferred();
+                let now = Instant::now();
+                self.overall_remaining.observe(now, bytes);
                 let size_field =
                     format!("{:>15}", format_progress_bytes(bytes, self.human_readable));
                 let percent_field = format!(
@@ -130,8 +158,16 @@ impl<'a> ClientProgressObserver for LiveProgress<'a> {
                     "{:>11}",
                     format_progress_rate(bytes, update.overall_elapsed(), self.human_readable)
                 );
-                let elapsed_field =
-                    format!("{:>10}", format_progress_elapsed(update.overall_elapsed()));
+                // upstream: progress.c:97-105 - sliding window ETA mid-transfer,
+                // total elapsed for the final tick.
+                let final_tick = update.remaining() == 0 && update.is_final();
+                let time_text = if final_tick {
+                    format_progress_elapsed(update.overall_elapsed())
+                } else {
+                    let total = update.overall_total_bytes().unwrap_or(bytes);
+                    self.overall_remaining.render(now, bytes, total)
+                };
+                let time_field = format!("{time_text:>10}");
                 let xfr_index = update.index();
 
                 if self.line_active {
@@ -140,10 +176,10 @@ impl<'a> ClientProgressObserver for LiveProgress<'a> {
 
                 write!(
                     self.writer,
-                    "{size_field} {percent_field} {rate_field} {elapsed_field} (xfr#{xfr_index}, to-chk={remaining}/{total})"
+                    "{size_field} {percent_field} {rate_field} {time_field} (xfr#{xfr_index}, to-chk={remaining}/{total})"
                 )?;
 
-                if update.remaining() == 0 && update.is_final() {
+                if final_tick {
                     writeln!(self.writer)?;
                     self.line_active = false;
                 } else {

--- a/docs/audits/progress-line-format-audit.md
+++ b/docs/audits/progress-line-format-audit.md
@@ -62,8 +62,8 @@ client (`log.c:288` and downstream).
 2. **Rate field width**: upstream emits `%7.2f%s` -> exactly 7 columns of value plus the unit (`kB/s` / `MB/s` / `GB/s`); ours pads the combined `value+unit` to 12 columns. For `"1.23MB/s"` upstream produces `"   1.23MB/s"` (4 leading spaces; total 11 chars) while ours produces `"    1.23MB/s"` (12 chars). Misalignment is one column wider.
 3. **Rate unit set**: upstream uses only `kB/s`, `MB/s`, `GB/s` (`progress.c:108-116`). Ours additionally produces `TB/s` and `PB/s` via `format_progress_rate_human` -> `format_verbose_rate_human` (`rate.rs:80-97`). Mixed-base units never appear upstream.
 4. **Rate divisor**: upstream uses 1024-based thresholds, switching at `> 1024` and `> 1024*1024` kB/s (`progress.c:108-111`). Our decimal path uses 1024-based KiB/MiB/GiB (`rate.rs:137-148`), but the `format_progress_rate_human` path used in human-readable mode falls back to 1000-based units (`rate.rs:81-87`), which disagrees with upstream's strictly binary scaling.
-5. **ETA vs elapsed**: upstream prints **time remaining** in the in-flight line (`progress.c:105`) and switches to **total time taken** for the last line (`progress.c:97-98`). The `??:??:??` literal appears when ETA is unknown (`progress.c:118-119`). Ours always prints `event.elapsed()`, the time spent so far on the current entry (`live.rs:96`, `render.rs:186`), so the ETA semantics are missing entirely.
-6. **ETA width**: upstream uses `%4u:%02u:%02u` -> minimum 10 columns (4 + 1 + 2 + 1 + 2). Ours uses `H:MM:SS` -> 7 columns minimum, padded right to 11. Width and content do not match.
+5. **ETA vs elapsed** (RESOLVED): upstream prints **time remaining** in the in-flight line (`progress.c:105`) and switches to **total time taken** for the last line (`progress.c:97-98`). The `??:??:??` literal appears when ETA is unknown (`progress.c:118-119`). `live.rs` now drives a `RemainingTimeEstimator` (`format/remaining.rs`) for the mid-transfer ticks and only falls back to elapsed for the final tick.
+6. **ETA width** (RESOLVED): upstream uses `%4u:%02u:%02u` -> minimum 10 columns (4 + 1 + 2 + 1 + 2). `RemainingTimeEstimator::render` emits `H:MM:SS` plus the `??:??:??` placeholder, right-padded to 10 in the live renderer.
 7. **Trailing tail (in-flight)**: upstream sets `eol = "  "` (two spaces) on each live tick (`progress.c:100`) so the next `\r` overwrites cleanly. Ours emits the full `(xfr#N, to-chk=R/T)` tail on every tick (`live.rs:103-106`), not just the final update.
 8. **Trailing tail (final)**: upstream uses `to-chk` only while the file list is still streaming (`!flist_eof`) and switches to `ir-chk` once the flist is complete (`progress.c:80`). Ours hard-codes `to-chk` (`live.rs:106`, `render.rs:192`).
 9. **xfr#N and counts**: upstream's `xfr#N` is `stats.xferred_files` (regular files transferred to date) and the chk count is `stats.num_files - current_file_index - 1` (`progress.c:79-82`). Ours uses `update.index()` (count of progress events emitted, `progress.rs:215-217`) and the local remaining/total derived from event order (`live.rs:69-71`). For runs that include directories, symlinks, or skipped entries the totals will diverge from upstream's reg-only `xferred_files`.
@@ -128,8 +128,8 @@ When `INFO_GTE(PROGRESS, 2)`:
 
 ### Discrepancies
 
-17. **No 1-second throttle**: any update emitted by the engine reaches the writer. For fast local copies this can produce hundreds of ticks per second per file.
-18. **No 5-slot history ring**: rate computation in upstream uses the oldest sample in the 5-second ring as its denominator (`progress.c:102-104`), giving a smoothed rate. Ours divides cumulative bytes by total elapsed (`rate.rs:122`), so the rate window grows over time and never reflects the recent slope.
+17. **1-second throttle** (RESOLVED for ETA): `RemainingTimeEstimator::observe` ignores samples that arrive within 1 s of the newest retained sample (`format/remaining.rs:60-72`), matching the `msdiff < 1000` guard in `progress.c:224-225`. The rate column still consumes raw cumulative bytes.
+18. **5-slot history ring** (RESOLVED for ETA): `RemainingTimeEstimator` keeps a 5-slot ring (`HISTORY_SLOTS = PROGRESS_HISTORY_SECS = 5`) and computes the rate from the oldest retained sample to the freshest, mirroring `progress.c:102-104`. The summary rate (`format_summary_rate`) intentionally remains cumulative, matching upstream's `main.c:413` summary semantics.
 19. **No `want_progress_now` / `instant_progress` equivalent**: upstream forces a single tick when external code sets the flag (e.g. before printing a non-progress line). We have no path to flush a final tick out of band.
 20. **No 1500 ms backfill of the start anchor**: upstream's `ph_start` heuristic seeds from the previous file's last sample if recent (`progress.c:208-218`). Our `overall_start` is fixed at observer construction (`progress.rs:181`) and per-file elapsed comes from the engine, so the boundary case (long pause then resume) reports a low rate for the first second of the new file.
 
@@ -181,8 +181,8 @@ total size is {total_size_display}  speedup is {speedup:.2}{dry_run_suffix}
 | 2 | Rate value width | `progress.c:129` `%7.2f%s` | `live.rs:92-95`, `render.rs:182-185` | minor |
 | 3 | Rate unit set | `progress.c:108-116` | `rate.rs:80-97` | major |
 | 4 | Rate divisor base | `progress.c:108-111` | `rate.rs:81-87` | major |
-| 5 | ETA vs elapsed | `progress.c:97-105` | `live.rs:96`, `render.rs:186` | major |
-| 6 | ETA width | `progress.c:121-122` | `progress.rs:20-26` | minor |
+| 5 | ETA vs elapsed | `progress.c:97-105` | `live.rs:117-124,161-168` | RESOLVED |
+| 6 | ETA width | `progress.c:121-122` | `format/remaining.rs:106-114` | RESOLVED |
 | 7 | In-flight tail | `progress.c:100` | `live.rs:103-106` | major |
 | 8 | `to-chk` vs `ir-chk` | `progress.c:78-82` | `live.rs:106`, `render.rs:192` | major |
 | 9 | xfr#N counter source | `progress.c:78-82` | `progress.rs:215-217` | major |
@@ -193,8 +193,8 @@ total size is {total_size_display}  speedup is {speedup:.2}{dry_run_suffix}
 | 14 | TTY foreground check | `progress.c:185-237` | absent | major |
 | 15 | First-tick CR | `progress.c:129` | `live.rs:99-101` | minor |
 | 16 | `output_needs_newline` flag | `progress.c:127`, `progress.c:132` | absent | minor |
-| 17 | 1-second throttle | `progress.c:224-225` | absent | major |
-| 18 | 5-slot rolling rate window | `progress.c:102-104` | `rate.rs:122` | major |
+| 17 | 1-second throttle | `progress.c:224-225` | `format/remaining.rs:60-72` | RESOLVED |
+| 18 | 5-slot rolling rate window | `progress.c:102-104` | `format/remaining.rs:34-72` | RESOLVED |
 | 19 | `instant_progress` / `want_progress_now` | `progress.c:35`, `progress.c:158-165` | absent | minor |
 | 20 | 1500 ms start backfill | `progress.c:208-218` | `progress.rs:181` | minor |
 | 21 | Locale grouping separator | `compat.c:177-178`, `compat.c:230-240` | `size.rs:38` | minor |
@@ -206,6 +206,8 @@ total size is {total_size_display}  speedup is {speedup:.2}{dry_run_suffix}
 | 27 | Speedup grouping | `main.c:459` | `render.rs:326` | minor |
 
 Total discrepancies recorded: **27** (one row, #25, agrees by coincidence).
+Resolved to date: D5, D6, D17, D18 (sliding-window remaining-time estimator;
+see `crates/cli/src/frontend/progress/format/remaining.rs`).
 
 ## 7. Verification Recipe
 


### PR DESCRIPTION
## Summary

- Replaces the cumulative-since-start ETA in the live `--progress` /
  `--info=progress2` line with a 5-slot, 1-second-throttled sliding
  window so the remaining-time field tracks recent throughput, not
  the long-term average. Mirrors upstream rsync 3.4.1 `progress.c`
  (`PROGRESS_HISTORY_SECS = 5`, `msdiff < 1000` throttle in
  `show_progress`, oldest-to-newest rate basis in `rprint_progress`).
- Adds `RemainingTimeEstimator` (`crates/cli/src/frontend/progress/format/remaining.rs`)
  with a circular sample ring, `H:MM:SS` rendering, and the
  `??:??:??` placeholder for unknown / out-of-range ETAs
  (progress.c:118-125).
- Wires per-file and overall estimators into `LiveProgress`. Final
  tick keeps printing total elapsed to match upstream's `is_last`
  branch (progress.c:97-98).
- Marks audit discrepancies D5 / D6 / D17 / D18 as RESOLVED in
  `docs/audits/progress-line-format-audit.md`.

Chosen window parameters (matching upstream verbatim):

- `HISTORY_SLOTS = 5` (upstream `PROGRESS_HISTORY_SECS`,
  `progress.c:37`)
- `SAMPLE_INTERVAL = 1 s` (upstream `msdiff < 1000`,
  `progress.c:224-225`)
- `MAX_REMAINING_SECS = 9999 * 3600` (upstream `remain > 9999.0 *
  3600.0`, `progress.c:118`)

Refs #2201.

## Test plan

- [ ] CI `fmt+clippy` is green.
- [ ] CI `nextest (stable)` covers the new
  `format::remaining` unit tests (steady throughput, throughput
  dip, throttle skips, window expiry, render shape, ETA-bounded
  property sweep).
- [ ] CI Windows / macOS / Linux musl matrices stay green
  (no platform-specific code added).