### PR TITLE
chore: track rsync 3.4.2 in interop matrix alongside 3.4.1

### DIFF
--- a/.github/workflows/_interop.yml
+++ b/.github/workflows/_interop.yml
@@ -10,7 +10,7 @@ on:
       upstream_rsync_version:
         description: 'Upstream rsync version for cache key'
         type: string
-        default: '3.4.1'
+        default: '3.4.2'
       rust_toolchain:
         description: 'Rust toolchain version'
         type: string

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -69,21 +69,21 @@ jobs:
         id: cache-rsync
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
-          path: target/interop/upstream-src/rsync-3.4.1
-          key: upstream-rsync-3.4.1-${{ runner.os }}-full
+          path: target/interop/upstream-src/rsync-3.4.2
+          key: upstream-rsync-3.4.2-${{ runner.os }}-full
 
-      - name: Build upstream rsync 3.4.1
+      - name: Build upstream rsync 3.4.2
         if: steps.cache-rsync.outputs.cache-hit != 'true'
         run: |
           set -euo pipefail
           mkdir -p target/interop/upstream-src
           cd target/interop/upstream-src
 
-          if [ ! -d rsync-3.4.1 ]; then
-            curl -L https://download.samba.org/pub/rsync/src/rsync-3.4.1.tar.gz | tar xz
+          if [ ! -d rsync-3.4.2 ]; then
+            curl -L https://download.samba.org/pub/rsync/src/rsync-3.4.2.tar.gz | tar xz
           fi
 
-          cd rsync-3.4.1
+          cd rsync-3.4.2
           if [ ! -f rsync ]; then
             ./configure
             make -j$(nproc)
@@ -99,7 +99,7 @@ jobs:
           ssh -o StrictHostKeyChecking=no localhost true
 
       - name: Install upstream rsync to PATH
-        run: sudo cp target/interop/upstream-src/rsync-3.4.1/rsync /usr/local/bin/rsync
+        run: sudo cp target/interop/upstream-src/rsync-3.4.2/rsync /usr/local/bin/rsync
 
       - name: Run benchmark
         id: benchmark

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -479,5 +479,5 @@ jobs:
     uses: ./.github/workflows/_interop.yml
     with:
       cache_version: ${{ vars.CACHE_VERSION || 'v1' }}
-      upstream_rsync_version: ${{ vars.UPSTREAM_RSYNC_VERSION || '3.4.1' }}
+      upstream_rsync_version: ${{ vars.UPSTREAM_RSYNC_VERSION || '3.4.2' }}
       timeout_minutes: 30

--- a/.github/workflows/interop-validation.yml
+++ b/.github/workflows/interop-validation.yml
@@ -36,7 +36,7 @@ env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: "-D warnings"
   CACHE_VERSION: ${{ vars.CACHE_VERSION || 'v1' }}
-  UPSTREAM_RSYNC_VERSION: ${{ vars.UPSTREAM_RSYNC_VERSION || '3.4.1' }}
+  UPSTREAM_RSYNC_VERSION: ${{ vars.UPSTREAM_RSYNC_VERSION || '3.4.2' }}
 
 jobs:
   validate-exit-codes:

--- a/.github/workflows/known-failures.yml
+++ b/.github/workflows/known-failures.yml
@@ -51,9 +51,9 @@ jobs:
           path: |
             target/interop/upstream-src
             target/interop/upstream-install
-          key: upstream-rsync-3.4.1-${{ runner.os }}-${{ hashFiles('tools/ci/run_interop.sh') }}
+          key: upstream-rsync-3.4.2-${{ runner.os }}-${{ hashFiles('tools/ci/run_interop.sh') }}
           restore-keys: |
-            upstream-rsync-3.4.1-${{ runner.os }}-
+            upstream-rsync-3.4.2-${{ runner.os }}-
 
       - name: Build upstream rsync
         if: steps.cache-rsync.outputs.cache-hit != 'true'

--- a/.github/workflows/release-cross.yml
+++ b/.github/workflows/release-cross.yml
@@ -477,7 +477,7 @@ jobs:
           {
             printf 'pkgname = oc-rsync\n'
             printf 'pkgver = %s\n' "${PKGVER}"
-            printf 'pkgdesc = Pure-Rust implementation of rsync, wire-compatible with upstream 3.4.1\n'
+            printf 'pkgdesc = Pure-Rust implementation of rsync, wire-compatible with upstream 3.4.2\n'
             printf 'url = https://github.com/oferchen/rsync\n'
             printf 'builddate = %s\n' "$(date +%s)"
             printf 'packager = oc-rsync CI <ci@github.com>\n'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -346,7 +346,7 @@ strip = false
 
 [workspace.metadata.oc_rsync]
 brand = "oc"
-upstream_version = "3.4.1"
+upstream_version = "3.4.2"
 rust_version = "0.6.1"
 protocol = 32
 client_bin = "oc-rsync"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # oc-rsync
 
-`rsync` re-implemented in Rust. Wire-compatible with upstream rsync 3.4.1 (protocol 32), works as a drop-in replacement.
+`rsync` re-implemented in Rust. Wire-compatible with upstream rsync 3.4.2 (and back-compat with 3.4.1, protocol 32), works as a drop-in replacement.
 
 Binary name: **`oc-rsync`** - installs alongside system `rsync` without conflict.
 
@@ -12,7 +12,7 @@ Binary name: **`oc-rsync`** - installs alongside system `rsync` without conflict
 
 ## Status
 
-**Release:** 0.6.1 (alpha) - Wire-compatible drop-in replacement for rsync 3.4.1 (protocols 28-32).
+**Release:** 0.6.1 (alpha) - Wire-compatible drop-in replacement for rsync 3.4.2 (and 3.4.1, protocols 28-32).
 
 All transfer modes (local, SSH, daemon), delta algorithm, metadata preservation, incremental recursion, and compression are complete. Interop tested against upstream rsync 3.0.9, 3.1.3, and 3.4.1.
 
@@ -107,7 +107,7 @@ Legend: ✓ supported, ⚠ partial or not yet wired, ✗ not implemented.
 
 ### Interop Testing
 
-Tested against upstream rsync **3.0.9**, **3.1.3**, and **3.4.1** in CI across protocols 28-32. Both push and pull directions verified for 30+ scenarios covering transfer modes, deletion, compression, metadata, reference dirs, file selection, batch roundtrip, path handling, device nodes, and daemon auth.
+Tested against upstream rsync **3.0.9**, **3.1.3**, **3.4.1**, and **3.4.2** in CI across protocols 28-32. Both push and pull directions verified for 30+ scenarios covering transfer modes, deletion, compression, metadata, reference dirs, file selection, batch roundtrip, path handling, device nodes, and daemon auth.
 
 ### Performance
 

--- a/scripts/benchmark_1gb.sh
+++ b/scripts/benchmark_1gb.sh
@@ -20,7 +20,11 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 OC_RSYNC="${OC_RSYNC:-${PROJECT_ROOT}/target/release/oc-rsync}"
-UPSTREAM_RSYNC="${UPSTREAM_RSYNC:-${PROJECT_ROOT}/target/interop/upstream-install/3.4.1/bin/rsync}"
+DEFAULT_UPSTREAM_RSYNC="${PROJECT_ROOT}/target/interop/upstream-install/3.4.2/bin/rsync"
+if [[ ! -x "${DEFAULT_UPSTREAM_RSYNC}" ]]; then
+    DEFAULT_UPSTREAM_RSYNC="${PROJECT_ROOT}/target/interop/upstream-install/3.4.1/bin/rsync"
+fi
+UPSTREAM_RSYNC="${UPSTREAM_RSYNC:-${DEFAULT_UPSTREAM_RSYNC}}"
 RUNS="${RUNS:-3}"
 BLOCK_SIZE="${BLOCK_SIZE:-131072}"
 

--- a/scripts/benchmark_container.sh
+++ b/scripts/benchmark_container.sh
@@ -3,7 +3,7 @@
 #
 # Usage: ./scripts/benchmark_container.sh [--runs N]
 #
-# Builds oc-rsync (release) and upstream rsync 3.4.1 inside a Debian container,
+# Builds oc-rsync (release) and upstream rsync 3.4.2 inside a Debian container,
 # then runs the benchmark suite and prints the report.
 
 set -euo pipefail
@@ -21,7 +21,7 @@ CONTAINER_ENGINE="${CONTAINER_ENGINE:-podman}"
 IMAGE_NAME="oc-rsync-bench"
 CONTAINER_NAME="oc-rsync-bench-run"
 
-echo "=== oc-rsync vs upstream rsync 3.4.1 — Linux Container Benchmark ==="
+echo "=== oc-rsync vs upstream rsync 3.4.2 — Linux Container Benchmark ==="
 echo "Container engine: $CONTAINER_ENGINE"
 echo "Runs per test: $RUNS"
 echo ""

--- a/scripts/benchmark_hyperfine.sh
+++ b/scripts/benchmark_hyperfine.sh
@@ -16,14 +16,17 @@
 #
 # Requirements:
 #   - hyperfine: cargo install hyperfine
-#   - Upstream rsync built in target/interop/upstream-install/3.4.1/
+#   - Upstream rsync built in target/interop/upstream-install/3.4.2/ (or 3.4.1/)
 #   - oc-rsync built with: cargo build --release
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-UPSTREAM="${PROJECT_ROOT}/target/interop/upstream-install/3.4.1/bin/rsync"
+UPSTREAM="${PROJECT_ROOT}/target/interop/upstream-install/3.4.2/bin/rsync"
+if [[ ! -x "${UPSTREAM}" ]]; then
+    UPSTREAM="${PROJECT_ROOT}/target/interop/upstream-install/3.4.1/bin/rsync"
+fi
 OC_RSYNC="${PROJECT_ROOT}/target/release/oc-rsync"
 
 # Defaults

--- a/scripts/benchmark_remote.sh
+++ b/scripts/benchmark_remote.sh
@@ -2,7 +2,7 @@
 # Remote rsync:// benchmark comparing multiple versions.
 #
 # Compares:
-#   - Upstream rsync 3.4.1
+#   - Upstream rsync 3.4.2 (fallback: 3.4.1)
 #   - oc-rsync v0.5.2
 #   - oc-rsync v0.5.3
 #   - oc-rsync dev (current codebase)
@@ -20,7 +20,7 @@
 #
 # Requirements:
 #   - hyperfine: cargo install hyperfine
-#   - Upstream rsync 3.4.1
+#   - Upstream rsync 3.4.2 (fallback: 3.4.1)
 #   - oc-rsync builds
 
 set -euo pipefail
@@ -29,7 +29,10 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 # Binary paths
-UPSTREAM="${PROJECT_ROOT}/target/interop/upstream-install/3.4.1/bin/rsync"
+UPSTREAM="${PROJECT_ROOT}/target/interop/upstream-install/3.4.2/bin/rsync"
+if [[ ! -x "${UPSTREAM}" ]]; then
+    UPSTREAM="${PROJECT_ROOT}/target/interop/upstream-install/3.4.1/bin/rsync"
+fi
 OC_V052="${PROJECT_ROOT}/target/oc-rsync-v0.5.2"
 OC_V053="${PROJECT_ROOT}/target/oc-rsync-v0.5.3"
 OC_DEV="${PROJECT_ROOT}/target/release/oc-rsync"

--- a/scripts/benchmark_startup.sh
+++ b/scripts/benchmark_startup.sh
@@ -15,7 +15,7 @@
 #
 # Environment:
 #   OC_RSYNC          Path to oc-rsync binary (default: target/release/oc-rsync)
-#   UPSTREAM_RSYNC    Path to upstream rsync binary (default: target/interop/upstream-install/3.4.1/bin/rsync)
+#   UPSTREAM_RSYNC    Path to upstream rsync binary (default: target/interop/upstream-install/3.4.2/bin/rsync, fallback 3.4.1)
 
 set -euo pipefail
 
@@ -23,7 +23,11 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 OC_RSYNC="${OC_RSYNC:-${PROJECT_ROOT}/target/release/oc-rsync}"
-UPSTREAM_RSYNC="${UPSTREAM_RSYNC:-${PROJECT_ROOT}/target/interop/upstream-install/3.4.1/bin/rsync}"
+DEFAULT_UPSTREAM_RSYNC="${PROJECT_ROOT}/target/interop/upstream-install/3.4.2/bin/rsync"
+if [[ ! -x "${DEFAULT_UPSTREAM_RSYNC}" ]]; then
+    DEFAULT_UPSTREAM_RSYNC="${PROJECT_ROOT}/target/interop/upstream-install/3.4.1/bin/rsync"
+fi
+UPSTREAM_RSYNC="${UPSTREAM_RSYNC:-${DEFAULT_UPSTREAM_RSYNC}}"
 
 ITERATIONS=100
 WARMUP=10

--- a/scripts/profile_transfer.sh
+++ b/scripts/profile_transfer.sh
@@ -11,7 +11,7 @@
 #   ./scripts/profile_transfer.sh [--perf] [--flamegraph]
 #
 # Requirements:
-#   - Upstream rsync built in target/interop/upstream-install/3.4.1/
+#   - Upstream rsync built in target/interop/upstream-install/3.4.2/ (or 3.4.1/)
 #   - oc-rsync built with: cargo build --release
 #   - For perf: linux-tools-common
 #   - For flamegraph: cargo install flamegraph
@@ -28,7 +28,10 @@ NC='\033[0m'
 # Paths
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-UPSTREAM="${PROJECT_ROOT}/target/interop/upstream-install/3.4.1/bin/rsync"
+UPSTREAM="${PROJECT_ROOT}/target/interop/upstream-install/3.4.2/bin/rsync"
+if [[ ! -x "${UPSTREAM}" ]]; then
+    UPSTREAM="${PROJECT_ROOT}/target/interop/upstream-install/3.4.1/bin/rsync"
+fi
 OC_RSYNC="${PROJECT_ROOT}/target/release/oc-rsync"
 
 # Options

--- a/scripts/rsync-interop-server.sh
+++ b/scripts/rsync-interop-server.sh
@@ -3,7 +3,7 @@
 # ---------------------------------------------------------------------------
 # WHAT WAS DONE / WHY:
 # - Ensures workspace oc-rsync is built.
-# - Ensures upstream rsync 3.0.9 / 3.1.3 / 3.4.1 exist (Debian/Ubuntu-first, source fallback).
+# - Ensures upstream rsync 3.0.9 / 3.1.3 / 3.4.1 / 3.4.2 exist (Debian/Ubuntu-first, source fallback).
 # - Starts per-version daemons:
 #     * oc-rsync --daemon on a unique port
 #     * upstream rsync --daemon on the next port
@@ -35,7 +35,7 @@ upstream_install_root="${workspace_root}/target/interop/upstream-install"
 run_root="${workspace_root}/target/interop/run"
 readonly target_dir upstream_src_root upstream_install_root run_root
 
-versions=(3.0.9 3.1.3 3.4.1)
+versions=(3.0.9 3.1.3 3.4.1 3.4.2)
 readonly versions
 
 rsync_repo_url="https://github.com/RsyncProject/rsync.git"
@@ -95,6 +95,9 @@ build_version_url() {
       ;;
     3.4.1)
       printf '%s/pool/main/r/rsync/rsync_3.4.1+ds1-6_%s.deb\n' "${DEBIAN_MIRROR}" "${arch}"
+      ;;
+    3.4.2)
+      printf '%s/pool/main/r/rsync/rsync_3.4.2+ds1-1_%s.deb\n' "${DEBIAN_MIRROR}" "${arch}"
       ;;
     *)
       printf '%s/pool/main/r/rsync/rsync_%s-1_%s.deb\n' "${DEBIAN_MIRROR}" "${version}" "${arch}"
@@ -168,6 +171,12 @@ try_fetch_deb_generic() {
       ;;
     3.4.1)
       candidates=("${DEBIAN_MIRROR}/pool/main/r/rsync/rsync_3.4.1+ds1-5_${arch}.deb")
+      ;;
+    3.4.2)
+      candidates=(
+        "${DEBIAN_MIRROR}/pool/main/r/rsync/rsync_3.4.2+ds1-2_${arch}.deb"
+        "${DEBIAN_MIRROR}/pool/main/r/rsync/rsync_3.4.2-1_${arch}.deb"
+      )
       ;;
     *)
       candidates=("${DEBIAN_MIRROR}/pool/main/r/rsync/rsync_${version}-1_${arch}.deb")

--- a/scripts/run_arch_benchmark_container.sh
+++ b/scripts/run_arch_benchmark_container.sh
@@ -4,7 +4,7 @@
 # Usage:
 #   ./scripts/run_arch_benchmark_container.sh [--runs N] [--json] [--profile]
 #
-# Builds upstream rsync 3.4.1 + oc-rsync v0.5.8 + oc-rsync HEAD inside
+# Builds upstream rsync 3.4.2 + oc-rsync v0.5.8 + oc-rsync HEAD inside
 # an Arch Linux container, then runs the full benchmark matrix.
 #
 # Modes:

--- a/scripts/run_full_benchmark_container.sh
+++ b/scripts/run_full_benchmark_container.sh
@@ -3,7 +3,7 @@
 #
 # Usage: ./scripts/run_full_benchmark_container.sh [--runs N] [--json]
 #
-# Builds upstream rsync 3.4.1 + oc-rsync (current HEAD) inside
+# Builds upstream rsync 3.4.2 + oc-rsync (current HEAD) inside
 # an Arch Linux container, then runs the full benchmark matrix.
 
 set -euo pipefail

--- a/tests/batch_interop_test.sh
+++ b/tests/batch_interop_test.sh
@@ -9,14 +9,14 @@
 # batches with CPRES_ZLIB dictionary sync). Cross-tool interop from oc-rsync
 # to upstream is limited because oc-rsync uses a different batch body format.
 #
-# Known upstream bug: rsync 3.4.1 cannot read back its own compressed delta
+# Known upstream bug: rsync 3.4.1+ cannot read back its own compressed delta
 # batch files due to missing inflate dictionary synchronization in the batch
 # reader (token.c:608). oc-rsync does not have this limitation.
 #
 # Environment variable overrides:
 #   OC_RSYNC              - path to oc-rsync binary
 #   UPSTREAM_INSTALL_ROOT - root of upstream installs (expects {version}/bin/rsync)
-#   UPSTREAM_VERSIONS     - space-separated list of versions (default: "3.0.9 3.1.3 3.4.1")
+#   UPSTREAM_VERSIONS     - space-separated list of versions (default: "3.0.9 3.1.3 3.4.1 3.4.2")
 
 set -euo pipefail
 
@@ -27,7 +27,7 @@ WORKSPACE_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 # Paths (overridable via environment)
 OC_RSYNC="${OC_RSYNC:-${WORKSPACE_ROOT}/target/release/oc-rsync}"
 UPSTREAM_INSTALL_ROOT="${UPSTREAM_INSTALL_ROOT:-${WORKSPACE_ROOT}/target/interop/upstream-install}"
-UPSTREAM_VERSIONS="${UPSTREAM_VERSIONS:-3.0.9 3.1.3 3.4.1}"
+UPSTREAM_VERSIONS="${UPSTREAM_VERSIONS:-3.0.9 3.1.3 3.4.1 3.4.2}"
 
 # Create a temp directory with cleanup trap
 TEST_DIR="$(mktemp -d)"
@@ -290,7 +290,7 @@ test_upstream_to_oc() {
 # =========================================================================
 # Compressed batch test: upstream writes compressed, oc-rsync reads
 #
-# Note: upstream rsync 3.4.1 has a limitation where the batch file format
+# Note: upstream rsync 3.4.1+ has a limitation where the batch file format
 # does not record which compression algorithm was used (only that
 # compression was active via bit 8 in stream flags). On read-batch,
 # upstream's parse_compress_choice() (compat.c:194-195) always assumes

--- a/tests/compress_interop_test.sh
+++ b/tests/compress_interop_test.sh
@@ -2,17 +2,17 @@
 # Compression Codec Interoperability Test Script
 #
 # Tests zstd, lz4, and zlibx compression compatibility between oc-rsync and
-# upstream rsync 3.4.1 using daemon mode. Both directions are tested:
+# upstream rsync 3.4.1+ using daemon mode. Both directions are tested:
 #   - oc-rsync client -> upstream rsync daemon
 #   - upstream rsync client -> oc-rsync daemon
 #
-# Prerequisites: upstream rsync 3.4.1 must be built with zstd and lz4 support.
+# Prerequisites: upstream rsync 3.4.1+ must be built with zstd and lz4 support.
 # The interop build script (tools/ci/run_interop.sh) handles this automatically.
 #
 # Environment variable overrides:
 #   OC_RSYNC              - path to oc-rsync binary
 #   UPSTREAM_INSTALL_ROOT - root of upstream installs (expects {version}/bin/rsync)
-#   UPSTREAM_VERSION      - upstream version to test against (default: "3.4.1")
+#   UPSTREAM_VERSION      - upstream version to test against (default: "3.4.2")
 
 set -euo pipefail
 
@@ -23,7 +23,7 @@ WORKSPACE_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 # Paths (overridable via environment)
 OC_RSYNC="${OC_RSYNC:-${WORKSPACE_ROOT}/target/release/oc-rsync}"
 UPSTREAM_INSTALL_ROOT="${UPSTREAM_INSTALL_ROOT:-${WORKSPACE_ROOT}/target/interop/upstream-install}"
-UPSTREAM_VERSION="${UPSTREAM_VERSION:-3.4.1}"
+UPSTREAM_VERSION="${UPSTREAM_VERSION:-3.4.2}"
 UPSTREAM_RSYNC="${UPSTREAM_INSTALL_ROOT}/${UPSTREAM_VERSION}/bin/rsync"
 
 # Daemon state

--- a/tests/filter_edge_cases_test.sh
+++ b/tests/filter_edge_cases_test.sh
@@ -2,7 +2,7 @@
 # Filter Edge Cases Interoperability Test Script
 #
 # Tests filter rule edge cases by comparing oc-rsync output against upstream
-# rsync 3.4.1. Each test creates source/dest trees, runs both tools with
+# rsync 3.4.1+. Each test creates source/dest trees, runs both tools with
 # identical arguments, and diffs the results.
 #
 # Environment variable overrides:
@@ -19,7 +19,11 @@ WORKSPACE_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 # Paths (overridable via environment)
 OC_RSYNC="${OC_RSYNC:-${WORKSPACE_ROOT}/target/release/oc-rsync}"
 UPSTREAM_INSTALL_ROOT="${UPSTREAM_INSTALL_ROOT:-${WORKSPACE_ROOT}/target/interop/upstream-install}"
-UPSTREAM_RSYNC="${UPSTREAM_RSYNC:-${UPSTREAM_INSTALL_ROOT}/3.4.1/bin/rsync}"
+DEFAULT_UPSTREAM_RSYNC="${UPSTREAM_INSTALL_ROOT}/3.4.2/bin/rsync"
+if [[ ! -x "${DEFAULT_UPSTREAM_RSYNC}" ]]; then
+    DEFAULT_UPSTREAM_RSYNC="${UPSTREAM_INSTALL_ROOT}/3.4.1/bin/rsync"
+fi
+UPSTREAM_RSYNC="${UPSTREAM_RSYNC:-${DEFAULT_UPSTREAM_RSYNC}}"
 
 # Create a temp directory with cleanup trap
 TEST_DIR="$(mktemp -d)"
@@ -539,7 +543,7 @@ main() {
 
     if [ ! -x "$UPSTREAM_RSYNC" ]; then
         log_error "upstream rsync binary not found or not executable: $UPSTREAM_RSYNC"
-        log_info "Set UPSTREAM_RSYNC or ensure upstream rsync 3.4.1 is installed."
+        log_info "Set UPSTREAM_RSYNC or ensure upstream rsync 3.4.1+ is installed."
         exit 1
     fi
 

--- a/tests/filter_interop_test.sh
+++ b/tests/filter_interop_test.sh
@@ -8,7 +8,7 @@
 # Environment variable overrides:
 #   OC_RSYNC              - path to oc-rsync binary
 #   UPSTREAM_INSTALL_ROOT - root of upstream installs (expects {version}/bin/rsync)
-#   UPSTREAM_VERSION      - upstream version to test against (default: "3.4.1")
+#   UPSTREAM_VERSION      - upstream version to test against (default: "3.4.2")
 
 set -euo pipefail
 
@@ -19,7 +19,7 @@ WORKSPACE_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 # Paths (overridable via environment)
 OC_RSYNC="${OC_RSYNC:-${WORKSPACE_ROOT}/target/release/oc-rsync}"
 UPSTREAM_INSTALL_ROOT="${UPSTREAM_INSTALL_ROOT:-${WORKSPACE_ROOT}/target/interop/upstream-install}"
-UPSTREAM_VERSION="${UPSTREAM_VERSION:-3.4.1}"
+UPSTREAM_VERSION="${UPSTREAM_VERSION:-3.4.2}"
 UPSTREAM_RSYNC="${UPSTREAM_INSTALL_ROOT}/${UPSTREAM_VERSION}/bin/rsync"
 
 # Create a temp directory with cleanup trap

--- a/tests/inc_recurse_interop_test.sh
+++ b/tests/inc_recurse_interop_test.sh
@@ -2,7 +2,7 @@
 # INC_RECURSE Interoperability Test Script
 #
 # Validates incremental recursion behavior between oc-rsync and upstream rsync
-# 3.4.1. Tests local transfers using both binaries to verify that recursive
+# 3.4.1+. Tests local transfers using both binaries to verify that recursive
 # directory walking, incremental updates, and deletions produce identical
 # results.
 #
@@ -10,7 +10,7 @@
 #   OC_RSYNC              - path to oc-rsync binary
 #   UPSTREAM_RSYNC        - path to upstream rsync binary
 #   UPSTREAM_INSTALL_ROOT - root of upstream installs (expects {version}/bin/rsync)
-#   UPSTREAM_VERSION      - upstream version to test (default: 3.4.1)
+#   UPSTREAM_VERSION      - upstream version to test (default: 3.4.2)
 
 set -euo pipefail
 
@@ -20,7 +20,7 @@ WORKSPACE_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 # Paths (overridable via environment)
 OC_RSYNC="${OC_RSYNC:-${WORKSPACE_ROOT}/target/release/oc-rsync}"
-UPSTREAM_VERSION="${UPSTREAM_VERSION:-3.4.1}"
+UPSTREAM_VERSION="${UPSTREAM_VERSION:-3.4.2}"
 UPSTREAM_INSTALL_ROOT="${UPSTREAM_INSTALL_ROOT:-${WORKSPACE_ROOT}/target/interop/upstream-install}"
 UPSTREAM_RSYNC="${UPSTREAM_RSYNC:-${UPSTREAM_INSTALL_ROOT}/${UPSTREAM_VERSION}/bin/rsync}"
 

--- a/tools/capture-handshakes.sh
+++ b/tools/capture-handshakes.sh
@@ -16,7 +16,7 @@ WORKSPACE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$WORKSPACE_ROOT"
 
 # Configuration
-UPSTREAM_VERSION="${UPSTREAM_VERSION:-3.4.1}"
+UPSTREAM_VERSION="${UPSTREAM_VERSION:-3.4.2}"
 UPSTREAM_BIN="target/interop/upstream-install/${UPSTREAM_VERSION}/bin/rsync"
 TEST_PORT=18873
 CAPTURE_IFACE="${CAPTURE_IFACE:-lo}"

--- a/tools/ci/check_known_failures.sh
+++ b/tools/ci/check_known_failures.sh
@@ -119,17 +119,21 @@ stop_daemon() {
 run_daemon_test() {
   local direction=$1 scenario_name=$2
 
-  local version="3.4.1"
+  local version="3.4.2"
   # For protocol-31 with upstream 3.0.9, use that version
   if [[ "$scenario_name" == "protocol-31" && "$direction" == "up" ]]; then
     version="3.0.9"
   fi
 
   local upstream_binary
-  upstream_binary=$(find_upstream_binary "$version") || {
+  upstream_binary=$(find_upstream_binary "$version") || upstream_binary=""
+  if [[ -z "$upstream_binary" && "$version" == "3.4.2" ]]; then
+    upstream_binary=$(find_upstream_binary "3.4.1") || upstream_binary=""
+  fi
+  if [[ -z "$upstream_binary" ]]; then
     echo "SKIP:no-binary"
     return 2
-  }
+  fi
 
   local oc_port upstream_port
   oc_port=$(alloc_port)
@@ -193,7 +197,7 @@ run_daemon_test() {
 run_standalone_test_by_name() {
   local name=$1
   local upstream_binary
-  upstream_binary=$(find_upstream_binary "3.4.1") || {
+  upstream_binary=$(find_upstream_binary "3.4.2") || upstream_binary=$(find_upstream_binary "3.4.1") || {
     echo "SKIP:no-binary"
     return 2
   }
@@ -254,7 +258,7 @@ run_standalone_test_by_name() {
       ;;
     iconv-upstream)
       # Reproducer for #1916: --iconv UTF-8/LATIN1 round-trip vs upstream
-      # rsync 3.4.1. Mirrors the standalone harness scenario but with a
+      # rsync 3.4.1+. Mirrors the standalone harness scenario but with a
       # minimal fixture so the dashboard can rerun quickly.
       local iu_src="${dest}/iconv-up-src"
       local iu_dest_oc="${dest}/iconv-up-dest-oc"
@@ -292,7 +296,7 @@ CONF
       cmp -s "${iu_src}/café.txt" "${iu_dest_oc}/café.txt" || return 1
       ;;
     upstream-compressed-batch-self-roundtrip)
-      # upstream rsync 3.4.1 cannot read back its own compressed delta batch
+      # upstream rsync 3.4.1+ cannot read back its own compressed delta batch
       # files. The batch writer records raw compressed tokens (zlib DEFLATED_DATA)
       # but the batch reader's inflate context lacks the dictionary sync that
       # see_deflate_token() provides during live transfers, causing "inflate

--- a/tools/ci/run_interop.sh
+++ b/tools/ci/run_interop.sh
@@ -5,6 +5,7 @@
 #     3.0.9  -> old-releases.ubuntu.com
 #     3.1.3  -> archive.ubuntu.com
 #     3.4.1  -> deb.debian.org (3.4.1+ds1-6)
+#     3.4.2  -> deb.debian.org (3.4.2+ds1-1, fallback to source if missing)
 # - Falls back to source build if the exact .deb for this arch is missing
 # - Starts oc-rsync --daemon on a non-privileged port by passing --port on the CLI
 set -euo pipefail
@@ -50,7 +51,7 @@ upstream_install_root="${workspace_root}/target/interop/upstream-install"
 interop_log_dir="${workspace_root}/target/interop/logs"
 
 # Versions we test against
-versions=(3.0.9 3.1.3 3.4.1)
+versions=(3.0.9 3.1.3 3.4.1 3.4.2)
 rsync_repo_url="https://github.com/RsyncProject/rsync.git"
 rsync_tarball_base_url="${RSYNC_TARBALL_BASE_URL:-https://rsync.samba.org/ftp/rsync/src}"
 
@@ -115,6 +116,9 @@ build_version_url() {
       ;;
     3.4.1)
       echo "${DEBIAN_MIRROR}/pool/main/r/rsync/rsync_3.4.1+ds1-6_${arch}.deb"
+      ;;
+    3.4.2)
+      echo "${DEBIAN_MIRROR}/pool/main/r/rsync/rsync_3.4.2+ds1-1_${arch}.deb"
       ;;
     *)
       echo "${DEBIAN_MIRROR}/pool/main/r/rsync/rsync_${version}-1_${arch}.deb"
@@ -196,6 +200,12 @@ try_fetch_deb_generic() {
     3.4.1)
       candidates+=(
         "${DEBIAN_MIRROR}/pool/main/r/rsync/rsync_3.4.1+ds1-5_${arch}.deb"
+      )
+      ;;
+    3.4.2)
+      candidates+=(
+        "${DEBIAN_MIRROR}/pool/main/r/rsync/rsync_3.4.2+ds1-2_${arch}.deb"
+        "${DEBIAN_MIRROR}/pool/main/r/rsync/rsync_3.4.2-1_${arch}.deb"
       )
       ;;
     *)
@@ -2199,7 +2209,7 @@ test_compressed_batch_delta_interop() {
 
   # Step 1: upstream rsync writes a compressed batch with delta transfers.
   # --no-whole-file forces delta mode even for local transfers.
-  # --compress-choice=zlib avoids an upstream bug where rsync 3.4.1 with zstd
+  # --compress-choice=zlib avoids an upstream bug where rsync 3.4.1+ with zstd
   # support negotiates zstd for local transfers, but --read-batch forces
   # CPRES_ZLIB decoder (compat.c:194), which can't inflate zstd-compressed data.
   if ! timeout "$hard_timeout" "$upstream_binary" -avI -z --no-whole-file \
@@ -3091,7 +3101,7 @@ test_iconv() {
   return 0
 }
 
-# #1916: --iconv daemon round-trip vs upstream rsync 3.4.1
+# #1916: --iconv daemon round-trip vs upstream rsync 3.4.1+
 #
 # # Wire semantics
 #
@@ -3285,7 +3295,7 @@ CONF
   return 0
 }
 
-# #1916: --iconv UTF-8/LATIN1 SSH/local-mode interop vs upstream rsync 3.4.1.
+# #1916: --iconv UTF-8/LATIN1 SSH/local-mode interop vs upstream rsync 3.4.1+.
 #
 # Companion to test_iconv_upstream_interop, which covers the daemon-mode side
 # of the same gap. SSH/local mode was bridged in PR #3458 by wiring
@@ -3592,7 +3602,7 @@ test_hardlinks_comprehensive() {
   return 0
 }
 
-# Comprehensive INC_RECURSE interop test against upstream rsync 3.4.1.
+# Comprehensive INC_RECURSE interop test against upstream rsync 3.4.1+.
 # Creates a deep nested directory structure (5 levels, 4 branches, 100+ files)
 # with mixed sizes, transfers with --inc-recursive, then verifies correctness.
 # Tests: (1) local oc-rsync transfer, (2) incremental re-sync (no re-transfer),
@@ -5501,7 +5511,7 @@ CONF
 
 # Zstd compression auto-negotiation interop test (PR #3081).
 # Validates that --compress-choice=zstd works in both daemon push directions
-# when both sides support zstd (rsync 3.4.1). Tests the negotiation path
+# when both sides support zstd (rsync 3.4.1+). Tests the negotiation path
 # where the client requests zstd and the daemon accepts it.
 test_zstd_negotiation() {
   local upstream_binary=$1 oc_bin=$2 src_dir=$3 work=$4 log=$5 \
@@ -9426,8 +9436,9 @@ run_comprehensive_interop_case() {
   write_upstream_conf "$ucf" "$upf" "$upstream_port" "$ud" "c-${tag}" "$up_identity"
 
   # Core scenarios run against all versions. Extended scenarios only run
-  # against 3.4.1 to keep CI within time limits (~45 scenarios x 3 versions
-  # x 2 directions = 270 transfers at ~10s each = 45 min for native alone).
+  # against 3.4.1+ (protocol 32) to keep CI within time limits (~45 scenarios
+  # x 3 versions x 2 directions = 270 transfers at ~10s each = 45 min for
+  # native alone).
   local -a scenarios=(
     "archive|-av|basic"
     "relative|-avR|basic"
@@ -9446,11 +9457,11 @@ run_comprehensive_interop_case() {
     "acls|-avA|acls"
   )
 
-  # Extended scenarios only for the newest upstream version (3.4.1).
+  # Extended scenarios only for the newest upstream versions (3.4.1+).
   # xattrs requires protocol >= 30 (upstream compat.c), so it only works
-  # against 3.4.1 (protocol 32), not 3.0.9 (protocol 28) or 3.1.3 (protocol 31
-  # but may lack --enable-xattr-support).
-  if [[ "${version}" == "3.4.1" ]]; then
+  # against 3.4.1/3.4.2 (protocol 32), not 3.0.9 (protocol 28) or 3.1.3
+  # (protocol 31 but may lack --enable-xattr-support).
+  if [[ "${version}" == "3.4.1" || "${version}" == "3.4.2" ]]; then
     scenarios+=(
       "xattrs|-avX|xattrs"
       "one-file-system|-avx|basic"
@@ -9499,7 +9510,7 @@ run_comprehensive_interop_case() {
     )
 
     # compress-choice scenarios gated on upstream binary support.
-    # Upstream rsync 3.4.1 may or may not have SUPPORT_LZ4/SUPPORT_ZSTD
+    # Upstream rsync 3.4.1+ may or may not have SUPPORT_LZ4/SUPPORT_ZSTD
     # compiled in, depending on whether liblz4-dev/libzstd-dev were present
     # at configure time (Debian package vs source build).
     local up_version_output
@@ -9755,11 +9766,20 @@ done
 echo "=== Parallel version tests complete ==="
 
 # =====================================================================
-# Protocol version forcing tests: all 5 protocols via upstream 3.4.1
+# Protocol version forcing tests: all 5 protocols via the newest
+# available upstream binary (3.4.2, falling back to 3.4.1).
 # Run sequentially to avoid port contention under CI load.
 # =====================================================================
-newest_binary="${upstream_install_root}/3.4.1/bin/rsync"
-if [[ -x "$newest_binary" ]]; then
+newest_label=""
+newest_binary=""
+for nv in 3.4.2 3.4.1; do
+  if [[ -x "${upstream_install_root}/${nv}/bin/rsync" ]]; then
+    newest_label="$nv"
+    newest_binary="${upstream_install_root}/${nv}/bin/rsync"
+    break
+  fi
+done
+if [[ -n "$newest_binary" ]]; then
   protos=(28 29 30 31 32)
   fp_warnings=()
 
@@ -9768,7 +9788,7 @@ if [[ -x "$newest_binary" ]]; then
     up_port=$(allocate_ephemeral_port)
     echo ""
     echo "=== Protocol ${proto} (forced via --protocol=${proto}) (ports: oc=${oc_port} up=${up_port}) ==="
-    if ! run_comprehensive_interop_case "3.4.1" "$newest_binary" \
+    if ! run_comprehensive_interop_case "$newest_label" "$newest_binary" \
         "$oc_port" "$up_port" "--protocol=${proto}"; then
       fp_warnings+=("proto${proto}")
     fi
@@ -9785,7 +9805,7 @@ if [[ -x "$newest_binary" ]]; then
 
   echo "=== Sequential protocol tests complete ==="
 else
-  echo "Skipping protocol forcing tests (3.4.1 binary unavailable)"
+  echo "Skipping protocol forcing tests (no 3.4.x binary available)"
 fi
 
 # =====================================================================
@@ -9796,8 +9816,14 @@ echo ""
 echo "=== Standalone Interop Tests ==="
 
 # Use the newest available upstream binary for standalone tests
-standalone_binary="${upstream_install_root}/3.4.1/bin/rsync"
-if [[ ! -x "$standalone_binary" ]]; then
+standalone_binary=""
+for nv in 3.4.2 3.4.1; do
+  if [[ -x "${upstream_install_root}/${nv}/bin/rsync" ]]; then
+    standalone_binary="${upstream_install_root}/${nv}/bin/rsync"
+    break
+  fi
+done
+if [[ -z "$standalone_binary" ]]; then
   # Fall back to any available version
   for v in "${versions[@]}"; do
     if [[ -x "${upstream_install_root}/${v}/bin/rsync" ]]; then

--- a/tools/ci/run_upstream_testsuite.sh
+++ b/tools/ci/run_upstream_testsuite.sh
@@ -16,13 +16,13 @@
 # Usage:
 #   tools/ci/run_upstream_testsuite.sh                # run all *.test
 #   WHICHTESTS=00-hello.test tools/ci/...sh           # run a single test
-#   UPSTREAM_VERSION=3.4.1 tools/ci/...sh             # pin upstream version
+#   UPSTREAM_VERSION=3.4.2 tools/ci/...sh             # pin upstream version
 #   PRESERVE_SCRATCH=yes tools/ci/...sh               # keep per-test scratch dirs
 
 set -euo pipefail
 
 workspace_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
-upstream_version="${UPSTREAM_VERSION:-3.4.1}"
+upstream_version="${UPSTREAM_VERSION:-3.4.2}"
 upstream_src_root="${workspace_root}/target/interop/upstream-src"
 upstream_src_dir="${upstream_src_root}/rsync-${upstream_version}"
 oc_rsync_bin="${OC_RSYNC_BIN:-${workspace_root}/target/release/oc-rsync}"

--- a/tools/run_upstream_client_interop_tests.sh
+++ b/tools/run_upstream_client_interop_tests.sh
@@ -2,7 +2,7 @@
 # Run upstream rsync client to oc-rsync daemon interoperability tests.
 #
 # This script runs the comprehensive test suite that verifies upstream rsync
-# clients (3.0.9, 3.1.3, 3.4.1) can successfully connect to and transfer files
+# clients (3.0.9, 3.1.3, 3.4.1, 3.4.2) can successfully connect to and transfer files
 # with the oc-rsync daemon implementation.
 #
 # Prerequisites:
@@ -10,6 +10,7 @@
 #    - target/interop/upstream-install/3.0.9/bin/rsync
 #    - target/interop/upstream-install/3.1.3/bin/rsync
 #    - target/interop/upstream-install/3.4.1/bin/rsync
+#    - target/interop/upstream-install/3.4.2/bin/rsync
 #
 # 2. oc-rsync binary must be built at:
 #    - target/release/oc-rsync (preferred)
@@ -117,6 +118,7 @@ check_prerequisites() {
     check_binary "target/interop/upstream-install/3.0.9/bin/rsync" "upstream rsync 3.0.9" || all_found=false
     check_binary "target/interop/upstream-install/3.1.3/bin/rsync" "upstream rsync 3.1.3" || all_found=false
     check_binary "target/interop/upstream-install/3.4.1/bin/rsync" "upstream rsync 3.4.1" || all_found=false
+    check_binary "target/interop/upstream-install/3.4.2/bin/rsync" "upstream rsync 3.4.2" || all_found=false
 
     echo ""
 

--- a/tools/simple-capture.sh
+++ b/tools/simple-capture.sh
@@ -5,7 +5,10 @@ set -euo pipefail
 WORKSPACE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$WORKSPACE_ROOT"
 
-UPSTREAM_BIN="target/interop/upstream-install/3.4.1/bin/rsync"
+UPSTREAM_BIN="target/interop/upstream-install/3.4.2/bin/rsync"
+if [[ ! -x "${UPSTREAM_BIN}" ]]; then
+    UPSTREAM_BIN="target/interop/upstream-install/3.4.1/bin/rsync"
+fi
 TEST_PORT=18873
 OUTPUT_DIR="tests/protocol_handshakes"
 

--- a/tools/strace-capture.sh
+++ b/tools/strace-capture.sh
@@ -5,7 +5,10 @@ set -euo pipefail
 WORKSPACE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$WORKSPACE_ROOT"
 
-UPSTREAM_BIN="target/interop/upstream-install/3.4.1/bin/rsync"
+UPSTREAM_BIN="target/interop/upstream-install/3.4.2/bin/rsync"
+if [[ ! -x "${UPSTREAM_BIN}" ]]; then
+    UPSTREAM_BIN="target/interop/upstream-install/3.4.1/bin/rsync"
+fi
 TEST_PORT=18873
 OUTPUT_DIR="tests/protocol_handshakes"
 


### PR DESCRIPTION
## Summary

Upstream rsync 3.4.2 was released 28 Apr 2026. Protocol number is unchanged at 32, so wire compatibility is preserved - this is plumbing only to start exercising oc-rsync against the latest upstream while keeping 3.4.1 in the matrix.

- Bumps `workspace.metadata.oc_rsync.upstream_version` to `3.4.2`.
- Adds `3.4.2` to interop version arrays in `tools/ci/run_interop.sh` and `scripts/rsync-interop-server.sh`, with Debian package URL patterns and a tarball-source fallback.
- Widens version-gated extended scenarios in `run_interop.sh` to run on both `3.4.1` and `3.4.2` since both speak protocol 32 (xattrs, INC_RECURSE, zstd, compress-choice, etc.).
- Prefers the 3.4.2 upstream binary in protocol-forcing and standalone interop sections, falling back to 3.4.1 when only the older binary is built.
- Updates default `UPSTREAM_RSYNC_VERSION` inputs in `ci.yml`, `interop-validation.yml`, and `_interop.yml` to `3.4.2`.
- Bumps `benchmark.yml` to build 3.4.2 from the samba.org tarball and refreshes the `known-failures.yml` cache key.
- Updates bench/profile/capture scripts (`scripts/benchmark_*.sh`, `scripts/profile_transfer.sh`, `tools/strace-capture.sh`, `tools/simple-capture.sh`, `tools/capture-handshakes.sh`) to default to 3.4.2 with a 3.4.1 fallback when the newer install root is absent.
- Refreshes `README.md` wording: wire-compatible with upstream 3.4.2 (and 3.4.1 back-compat), matrix now lists `3.0.9`, `3.1.3`, `3.4.1`, `3.4.2`.

## Files changed

- `Cargo.toml`
- `README.md`
- `.github/workflows/_interop.yml`, `benchmark.yml`, `ci.yml`, `interop-validation.yml`, `known-failures.yml`, `release-cross.yml`
- `tools/ci/run_interop.sh`, `tools/ci/check_known_failures.sh`, `tools/ci/run_upstream_testsuite.sh`
- `tools/run_upstream_client_interop_tests.sh`, `tools/strace-capture.sh`, `tools/simple-capture.sh`, `tools/capture-handshakes.sh`
- `scripts/rsync-interop-server.sh`, `scripts/benchmark_1gb.sh`, `scripts/benchmark_container.sh`, `scripts/benchmark_hyperfine.sh`, `scripts/benchmark_remote.sh`, `scripts/benchmark_startup.sh`, `scripts/profile_transfer.sh`, `scripts/run_arch_benchmark_container.sh`, `scripts/run_full_benchmark_container.sh`
- `tests/batch_interop_test.sh`, `tests/compress_interop_test.sh`, `tests/filter_edge_cases_test.sh`, `tests/filter_interop_test.sh`, `tests/inc_recurse_interop_test.sh`

29 files, +149/-81. No Rust source changes; protocol number stays at 32.

## Upstream notes

Upstream 3.4.2 NEWS (28 Apr 2026): https://download.samba.org/pub/rsync/src/rsync-3.4.2-NEWS - security-relevant fixes (PROXY v2 parser, xattr `qsort()` count, AVX2/MD4 initialisation, Y2038 in `syscall.c`, etc.). None affect wire format; protocol stays at 32.

This is plumbing only. Follow-up audit tasks (#2222-#2233) cover behavior-parity work against the new release.

## Test plan

- [ ] CI must pass interop for **both** 3.4.1 and 3.4.2 in the matrix (`tools/ci/run_interop.sh`).
- [ ] `benchmark.yml` builds and uses 3.4.2 from the samba.org tarball.
- [ ] `known-failures.yml` cache invalidation flows through cleanly (new key `upstream-rsync-3.4.2-*`).
- [ ] Protocol-forcing tests run against the newer binary when present and fall back to 3.4.1 otherwise.
- [ ] Daemon push/pull scenarios continue to pass for `3.0.9`, `3.1.3`, `3.4.1`, and `3.4.2`.