### PR TITLE
docs: verify --dirs long option present (3.4.2 parity)

### DIFF
--- a/crates/cli/src/frontend/tests/parse_args_recognises_recursive.rs
+++ b/crates/cli/src/frontend/tests/parse_args_recognises_recursive.rs
@@ -138,6 +138,31 @@ fn parse_args_recognises_dirs_flag() {
 }
 
 #[test]
+fn parse_args_dirs_short_and_long_are_equivalent() {
+    // upstream 3.4.2 NEWS: "Added the missing --dirs long option."
+    // oc-rsync exposes both -d and --dirs via the same clap entry
+    // (see crates/cli/src/frontend/command_builder/sections/build_base_command/transfer.rs).
+    let from_short = parse_args([
+        OsString::from(RSYNC),
+        OsString::from("-d"),
+        OsString::from("source"),
+        OsString::from("dest"),
+    ])
+    .expect("parse -d");
+
+    let from_long = parse_args([
+        OsString::from(RSYNC),
+        OsString::from("--dirs"),
+        OsString::from("source"),
+        OsString::from("dest"),
+    ])
+    .expect("parse --dirs");
+
+    assert_eq!(from_short.dirs, Some(true));
+    assert_eq!(from_short.dirs, from_long.dirs);
+}
+
+#[test]
 fn parse_args_recognises_no_dirs_flag() {
     let parsed = parse_args([
         OsString::from(RSYNC),

--- a/docs/audits/upstream-3.4.2-dirs-option-parity.md
+++ b/docs/audits/upstream-3.4.2-dirs-option-parity.md
@@ -1,0 +1,70 @@
+# Upstream 3.4.2 parity: `--dirs` long option
+
+Tracking issue: #2216. Verified 2026-05-14 against `origin/master`.
+
+## 1. Upstream change
+
+The rsync 3.4.2 NEWS file records the following parity fix:
+
+> Added the missing `--dirs` long option.
+
+Prior to 3.4.2, upstream rsync accepted only the short form `-d`; the long
+form `--dirs` was documented but not wired into `long_options[]` in
+`options.c`. The 3.4.2 release closes that gap so both spellings are
+accepted.
+
+## 2. oc-rsync status: already at parity
+
+oc-rsync exposes both `-d` and `--dirs` from a single clap arg
+definition. No code change is required.
+
+Clap entry:
+
+- File: `crates/cli/src/frontend/command_builder/sections/build_base_command/transfer.rs`
+- Lines 50-57:
+
+```rust
+Arg::new("dirs")
+    .long("dirs")
+    .short('d')
+    .help("Copy directory entries even when recursion is disabled.")
+    .action(ArgAction::SetTrue)
+    .overrides_with("no-dirs"),
+```
+
+The negated mirror `--no-dirs` (with visible alias `--no-d`) immediately
+follows at lines 58-65. Both flags resolve into the same tri-state value
+via `tri_state_flag_negative_first(&matches, "dirs", "no-dirs")` in
+`crates/cli/src/frontend/arguments/parser/mod.rs:145`, which writes to
+`ParsedArgs::dirs: Option<bool>`.
+
+## 3. Supported-options list
+
+`SUPPORTED_OPTIONS_LIST` in `crates/cli/src/frontend/defaults.rs:10`
+already advertises both spellings:
+
+```
+--dirs/-d, --no-dirs, ...
+```
+
+The help / unknown-option diagnostic surfaces this string verbatim, so
+users see `--dirs/-d` as a recognised flag.
+
+## 4. Test coverage
+
+Existing coverage in
+`crates/cli/src/frontend/tests/parse_args_recognises_recursive.rs`:
+
+- `parse_args_recognises_dirs_flag` - exercises `--dirs`.
+- `parse_args_recognises_no_dirs_flag` - exercises `--no-dirs`.
+- `parse_args_prefers_last_dirs_toggle` - last-wins between
+  `--dirs` and `--no-dirs`.
+- `parse_args_dirs_short_and_long_are_equivalent` (new) - confirms
+  `-d` and `--dirs` produce the same `parsed.dirs` value, locking the
+  3.4.2 parity claim into the test suite.
+
+## 5. Conclusion
+
+No production code change required. oc-rsync has accepted both `-d` and
+`--dirs` since the clap definition was introduced. The newly added
+unit test guards against future regression.


### PR DESCRIPTION
## Summary

Upstream rsync 3.4.2 NEWS records: *"Added the missing `--dirs` long option."* This PR verifies that oc-rsync already accepts both `-d` and `--dirs` and locks the parity into the test suite.

The single clap arg definition at `crates/cli/src/frontend/command_builder/sections/build_base_command/transfer.rs:50-57` exposes both spellings:

```rust
Arg::new("dirs")
    .long("dirs")
    .short('d')
    .help("Copy directory entries even when recursion is disabled.")
    .action(ArgAction::SetTrue)
    .overrides_with("no-dirs"),
```

`SUPPORTED_OPTIONS_LIST` (`crates/cli/src/frontend/defaults.rs:10`) already lists `--dirs/-d`.

## Changes

- New audit doc: `docs/audits/upstream-3.4.2-dirs-option-parity.md` citing the clap entry, the `SUPPORTED_OPTIONS_LIST` line, and the tri-state parser binding.
- New test `parse_args_dirs_short_and_long_are_equivalent` in `crates/cli/src/frontend/tests/parse_args_recognises_recursive.rs` asserting `-d` and `--dirs` parse to identical `ParsedArgs::dirs` values.

No production code change required.

Refs #2216

## Test plan

- [ ] `fmt+clippy` passes
- [ ] `nextest (stable)` passes - new test `parse_args_dirs_short_and_long_are_equivalent` exercises both spellings
- [ ] Windows / macOS / Linux musl stable runners green