### PR TITLE
feat(progress): render stalled-transfer remaining-time as upstream

### DIFF
--- a/crates/cli/src/frontend/progress/format/remaining.rs
+++ b/crates/cli/src/frontend/progress/format/remaining.rs
@@ -75,6 +75,15 @@ impl RemainingTimeEstimator {
 
     /// Computes the remaining seconds required to copy `total - ofs` bytes at
     /// the rate measured between the oldest retained sample and `now`.
+    ///
+    /// Mirrors upstream's `rate ? ... : 0.0` ternary in `progress.c:105`: when
+    /// the window is primed but no bytes were transferred over it (a stalled
+    /// transfer), upstream sets `remain = 0.0`, which renders as `0:00:00`
+    /// rather than the `??:??:??` placeholder. Returning `Some(0.0)` here keeps
+    /// the rendered output byte-identical to upstream during a stall instead
+    /// of extrapolating an ETA from stale samples.
+    ///
+    /// upstream: progress.c:102-105 rprint_progress
     pub(crate) fn remaining_seconds(&self, now: Instant, ofs: u64, total: u64) -> Option<f64> {
         let oldest = self.samples[self.oldest]?;
         let bytes_left = total.checked_sub(ofs)?;
@@ -83,22 +92,27 @@ impl RemainingTimeEstimator {
         }
         let bytes_delta = ofs.checked_sub(oldest.ofs)?;
         if bytes_delta == 0 {
-            return None;
+            // Stalled window: upstream's `rate ? ... : 0.0` collapses to 0.0,
+            // which renders as `0:00:00`. See `progress.c:105`.
+            return Some(0.0);
         }
         let elapsed = now.saturating_duration_since(oldest.at).as_secs_f64();
         if elapsed <= 0.0 {
-            return None;
+            return Some(0.0);
         }
         let rate = bytes_delta as f64 / elapsed;
         if rate <= 0.0 {
-            return None;
+            return Some(0.0);
         }
         Some(bytes_left as f64 / rate)
     }
 
     /// Renders the remaining time as `H:MM:SS` (matching upstream's
     /// `%4u:%02u:%02u`, progress.c:121-122), or the `??:??:??` placeholder
-    /// when no rate is available or the value exceeds upstream's clamp.
+    /// when the value exceeds upstream's `9999*3600`-second clamp. A stalled
+    /// window (zero throughput over the retained samples) renders as
+    /// `0:00:00`, mirroring upstream's `remain = rate ? ... : 0.0` collapse
+    /// in `progress.c:105`.
     pub(crate) fn render(&self, now: Instant, ofs: u64, total: u64) -> String {
         match self.remaining_seconds(now, ofs, total) {
             Some(secs) if secs.is_finite() && secs >= 0.0 => {
@@ -275,6 +289,56 @@ mod tests {
             rendered.chars().filter(|c| *c == ':').count() == 2,
             "rendered={rendered}"
         );
+    }
+
+    /// Stalled transfer: the window is primed and rotates across several
+    /// ticks, but `ofs` never advances. Upstream collapses to
+    /// `remain = 0.0` -> `0:00:00`; we must do the same instead of
+    /// extrapolating from older samples or emitting `??:??:??`.
+    /// upstream: progress.c:102-125 rprint_progress
+    #[test]
+    fn stall_mid_transfer_renders_as_upstream() {
+        let mut est = RemainingTimeEstimator::new();
+        let t0 = Instant::now();
+        est.observe(t0, 100);
+        est.observe(at(t0, 1), 100);
+        est.observe(at(t0, 2), 100);
+        est.observe(at(t0, 3), 100);
+        let secs = est
+            .remaining_seconds(at(t0, 3), 100, 10_000)
+            .expect("stall yields Some(0.0)");
+        assert_eq!(secs, 0.0, "stall should mirror upstream's remain=0.0");
+        assert_eq!(est.render(at(t0, 3), 100, 10_000), "0:00:00");
+    }
+
+    /// After a stall, resuming throughput must repopulate the window so the
+    /// estimator switches back to a live ETA rather than continuing to report
+    /// `0:00:00`. Verifies the ring rotation keeps working through the dip.
+    #[test]
+    fn stall_then_recovery_returns_live_eta() {
+        let mut est = RemainingTimeEstimator::new();
+        let t0 = Instant::now();
+        est.observe(t0, 0);
+        for sec in 1..=4 {
+            est.observe(at(t0, sec), 0);
+        }
+        assert_eq!(est.render(at(t0, 4), 0, 10_000), "0:00:00");
+        // Resume at 1 MB/s for long enough to flush the stalled samples out
+        // of the 5-slot window.
+        let rate: u64 = 1_000_000;
+        let mut ofs = 0u64;
+        for sec in 5..=15 {
+            ofs += rate;
+            est.observe(at(t0, sec), ofs);
+        }
+        let secs = est
+            .remaining_seconds(at(t0, 15), ofs, ofs + 10 * rate)
+            .expect("rate available after recovery");
+        assert!(
+            (secs - 10.0).abs() < 1.0,
+            "expected ~10s after recovery, got {secs}"
+        );
+        assert_ne!(est.render(at(t0, 15), ofs, ofs + 10 * rate), "??:??:??");
     }
 
     /// Property-style sweep: feed a bursty throughput pattern and assert the

--- a/docs/audits/progress-line-format-audit.md
+++ b/docs/audits/progress-line-format-audit.md
@@ -133,6 +133,23 @@ When `INFO_GTE(PROGRESS, 2)`:
 19. **No `want_progress_now` / `instant_progress` equivalent**: upstream forces a single tick when external code sets the flag (e.g. before printing a non-progress line). We have no path to flush a final tick out of band.
 20. **No 1500 ms backfill of the start anchor**: upstream's `ph_start` heuristic seeds from the previous file's last sample if recent (`progress.c:208-218`). Our `overall_start` is fixed at observer construction (`progress.rs:181`) and per-file elapsed comes from the engine, so the boundary case (long pause then resume) reports a low rate for the first second of the new file.
 
+## 4a. Stalled-Transfer Remaining-Time Rendering
+
+### Upstream (`progress.c:102-125`)
+
+- After computing `rate` from the window delta, upstream picks `remain` with the ternary `remain = rate ? (double) (size - ofs) / rate / 1000.0 : 0.0;` (`progress.c:105`). When the oldest retained sample's `ofs` equals the current `ofs` (a stalled window: network paused, sender starved, etc.), `rate` collapses to `0` and `remain` becomes `0.0`.
+- The render guard `if (remain < 0 || remain > 9999.0 * 3600.0)` (`progress.c:118`) is false for `remain == 0.0`, so the line prints `   0:00:00` rather than the `??:??:??` placeholder.
+- The placeholder is reserved for the negative-ETA branch and the >9999h clamp; a true stall renders as `0:00:00`.
+
+### Ours
+
+- `RemainingTimeEstimator::remaining_seconds` returns `Some(0.0)` when the window is primed and `bytes_delta == 0` (`format/remaining.rs`), mirroring upstream's ternary collapse.
+- `render` then emits `0:00:00`, byte-identical to upstream's snprintf output (minus upstream's left-padded width, which is restored by `live.rs`'s `{:>10}` field formatter).
+
+### Discrepancies
+
+D7. **Stalled-transfer rendering** (RESOLVED): `remaining_seconds` returns `Some(0.0)` on a primed-but-stalled window so the rendered line matches upstream's `   0:00:00` output during a stall. Previously the function returned `None`, which rendered `??:??:??` and diverged from upstream. upstream: progress.c:105 rprint_progress.
+
 ## 5. Final Summary Line ("sent X bytes ...")
 
 ### Upstream (`main.c:451-461`)
@@ -183,7 +200,8 @@ total size is {total_size_display}  speedup is {speedup:.2}{dry_run_suffix}
 | 4 | Rate divisor base | `progress.c:108-111` | `rate.rs:81-87` | major |
 | 5 | ETA vs elapsed | `progress.c:97-105` | `live.rs:117-124,161-168` | RESOLVED |
 | 6 | ETA width | `progress.c:121-122` | `format/remaining.rs:106-114` | RESOLVED |
-| 7 | In-flight tail | `progress.c:100` | `live.rs:103-106` | major |
+| 7 | Stalled-transfer remaining-time | `progress.c:105` | `format/remaining.rs::remaining_seconds` | RESOLVED |
+| 7b | In-flight tail | `progress.c:100` | `live.rs:103-106` | major |
 | 8 | `to-chk` vs `ir-chk` | `progress.c:78-82` | `live.rs:106`, `render.rs:192` | major |
 | 9 | xfr#N counter source | `progress.c:78-82` | `progress.rs:215-217` | major |
 | 10 | First-tick path line vs CR | `progress.c:129`, `progress.c:158-165` | `live.rs:79-101` | minor |
@@ -205,9 +223,10 @@ total size is {total_size_display}  speedup is {speedup:.2}{dry_run_suffix}
 | 26 | Leading blank line | `main.c:452` | `render.rs:83-89` (caller-driven) | minor |
 | 27 | Speedup grouping | `main.c:459` | `render.rs:326` | minor |
 
-Total discrepancies recorded: **27** (one row, #25, agrees by coincidence).
-Resolved to date: D5, D6, D17, D18 (sliding-window remaining-time estimator;
-see `crates/cli/src/frontend/progress/format/remaining.rs`).
+Total discrepancies recorded: **28** (one row, #25, agrees by coincidence).
+Resolved to date: D5, D6, D7, D17, D18 (sliding-window remaining-time
+estimator and stalled-transfer rendering; see
+`crates/cli/src/frontend/progress/format/remaining.rs`).
 
 ## 7. Verification Recipe
 


### PR DESCRIPTION
## Summary

- When `RemainingTimeEstimator` is primed but the window shows zero bytes over the retained samples (a stalled transfer), return `Some(0.0)` so the line renders as `0:00:00` instead of `??:??:??`. Mirrors upstream's `remain = rate ? ... : 0.0` collapse in `progress.c:105` (upstream rsync 3.4.1).
- Cover the elapsed-zero and zero-rate guards with the same `Some(0.0)` branch so a degenerate window never produces a placeholder that upstream would never emit.
- Add unit tests for the stall mid-transfer case (`[100, 100, 100]` over `[t=1, t=2, t=3]` -> `0:00:00`) and post-stall recovery (window flushes, ETA returns to a live value).
- Update `docs/audits/progress-line-format-audit.md`: add section 4a and mark **D7 RESOLVED**.

Closes #2202.

Reference: `target/interop/upstream-src/rsync-3.4.1/progress.c:105` (the `remain = rate ? ... : 0.0` ternary that produces upstream's stall output).

## Test plan

- [ ] CI: fmt + clippy
- [ ] CI: nextest (stable, beta, nightly)
- [ ] CI: Linux musl / macOS / Windows matrices
- [ ] New unit tests: `stall_mid_transfer_renders_as_upstream`, `stall_then_recovery_returns_live_eta` in `crates/cli/src/frontend/progress/format/remaining.rs`