### PR TITLE
fix(protocol): reject negative compressed-stream token values (3.4.2 parity)

### DIFF
--- a/crates/protocol/src/wire/compressed_token/lz4_codec.rs
+++ b/crates/protocol/src/wire/compressed_token/lz4_codec.rs
@@ -341,6 +341,14 @@ impl Lz4TokenDecoder {
             let mut buf = [0u8; 4];
             reader.read_exact(&mut buf)?;
             self.rx_token = i32::from_le_bytes(buf);
+            // upstream: token.c:844-847 (3.4.2) - reject negative absolute
+            // token to prevent block-index wrap into the valid range.
+            if self.rx_token < 0 {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "invalid token number in compressed stream",
+                ));
+            }
 
             if flag & 1 != 0 {
                 let mut run_buf = [0u8; 2];

--- a/crates/protocol/src/wire/compressed_token/tests.rs
+++ b/crates/protocol/src/wire/compressed_token/tests.rs
@@ -1442,3 +1442,59 @@ fn compressed_batch_multi_file_delta_roundtrip() {
     assert_eq!(f2_blocks, vec![0]);
     assert_eq!(f2_literals, f2_lit);
 }
+
+/// Regression test for task #2225 / upstream 3.4.2 token.c fix.
+///
+/// A peer sending `TOKEN_LONG` followed by a negative `i32` previously
+/// wrapped the wire value into a large `u32` block index. After the
+/// run-length expansion repeatedly incremented `rx_token`, the index
+/// could wrap back into a valid basis-block range and the receiver
+/// would copy the wrong block. Upstream 3.4.2 rejects the negative
+/// wire value at the decoder with `RERR_PROTOCOL`; oc-rsync now mirrors
+/// that by returning `io::ErrorKind::InvalidData`.
+///
+/// Reference: upstream `token.c:595-598` (zlib), `token.c:844-847`
+/// (zlibx/lz4), `token.c:1013-1016` (zstd).
+fn assert_rejects_negative_token(mut decoder: CompressedTokenDecoder) {
+    let mut wire = Vec::new();
+    wire.push(TOKEN_LONG);
+    wire.extend_from_slice(&(-1i32).to_le_bytes());
+
+    let mut cursor = Cursor::new(&wire);
+    let err = decoder
+        .recv_token(&mut cursor)
+        .expect_err("decoder must reject negative token");
+    assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    assert_eq!(err.to_string(), "invalid token number in compressed stream");
+}
+
+#[test]
+fn zlib_decoder_rejects_negative_absolute_token() {
+    assert_rejects_negative_token(CompressedTokenDecoder::new());
+}
+
+#[cfg(feature = "zstd")]
+#[test]
+fn zstd_decoder_rejects_negative_absolute_token() {
+    assert_rejects_negative_token(CompressedTokenDecoder::new_zstd().unwrap());
+}
+
+#[cfg(feature = "lz4")]
+#[test]
+fn lz4_decoder_rejects_negative_absolute_token() {
+    assert_rejects_negative_token(CompressedTokenDecoder::new_lz4());
+}
+
+#[test]
+fn zlib_decoder_rejects_i32_min_token() {
+    let mut decoder = CompressedTokenDecoder::new();
+    let mut wire = Vec::new();
+    wire.push(TOKEN_LONG);
+    wire.extend_from_slice(&i32::MIN.to_le_bytes());
+
+    let mut cursor = Cursor::new(&wire);
+    let err = decoder
+        .recv_token(&mut cursor)
+        .expect_err("decoder must reject i32::MIN");
+    assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+}

--- a/crates/protocol/src/wire/compressed_token/zlib_codec.rs
+++ b/crates/protocol/src/wire/compressed_token/zlib_codec.rs
@@ -414,6 +414,14 @@ impl ZlibTokenDecoder {
             let mut buf = [0u8; 4];
             reader.read_exact(&mut buf)?;
             self.rx_token = i32::from_le_bytes(buf);
+            // upstream: token.c:595-598 (3.4.2) - reject negative absolute
+            // token to prevent block-index wrap into the valid range.
+            if self.rx_token < 0 {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "invalid token number in compressed stream",
+                ));
+            }
 
             if flag & 1 != 0 {
                 let mut run_buf = [0u8; 2];

--- a/crates/protocol/src/wire/compressed_token/zstd_codec.rs
+++ b/crates/protocol/src/wire/compressed_token/zstd_codec.rs
@@ -455,6 +455,14 @@ impl ZstdTokenDecoder {
             let mut buf = [0u8; 4];
             reader.read_exact(&mut buf)?;
             self.rx_token = i32::from_le_bytes(buf);
+            // upstream: token.c:1013-1016 (3.4.2) - reject negative absolute
+            // token to prevent block-index wrap into the valid range.
+            if self.rx_token < 0 {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "invalid token number in compressed stream",
+                ));
+            }
 
             if flag & 1 != 0 {
                 let mut run_buf = [0u8; 2];

--- a/docs/audits/upstream-3.4.2-token-decoder-parity.md
+++ b/docs/audits/upstream-3.4.2-token-decoder-parity.md
@@ -1,0 +1,162 @@
+# Compressed-stream token decoder parity vs rsync 3.4.2
+
+Tracks task #2225. Audits oc-rsync's compressed-token wire decoder
+against the fix introduced in upstream rsync 3.4.2 for the
+compressed-stream token decoder: "Reject negative token values in the
+compressed-stream token decoder; a negative value could cause callers
+to misinterpret a missing data pointer as literal data."
+
+## 1. Upstream 3.4.2 change
+
+The fix lives in `token.c`. In 3.4.1 the absolute-token branch read a
+32-bit token from the wire and returned `-1 - rx_token` to the caller
+without validating the sign:
+
+```c
+/* 3.4.1 token.c:589-593 (recv_deflated_token) */
+if (flag & TOKEN_REL) {
+    rx_token += flag & 0x3f;
+    flag >>= 6;
+} else
+    rx_token = read_int(f);
+```
+
+3.4.2 adds an explicit bounds check in all three deflated-stream
+receivers (`recv_deflated_token` for `CPRES_ZLIB`,
+`recv_compressed_token` for `CPRES_ZLIBX`/`SUPPORT_LZ4`, and
+`recv_zstd_token` for `CPRES_ZSTD`). The same guard is repeated at each
+site:
+
+```c
+/* 3.4.2 token.c:589-599 (recv_deflated_token); matching guards at
+ * token.c:843-848 (recv_compressed_token) and
+ * token.c:1012-1017 (recv_zstd_token). */
+if (flag & TOKEN_REL) {
+    rx_token += flag & 0x3f;
+    flag >>= 6;
+} else {
+    rx_token = read_int(f);
+    if (rx_token < 0) {
+        rprintf(FERROR, "invalid token number in compressed stream\n");
+        exit_cleanup(RERR_PROTOCOL);
+    }
+}
+```
+
+Failure path: `RERR_PROTOCOL` (exit code 12) with a fixed message on
+`FERROR`. The check runs before `recv_*_token` returns, so the caller
+in `receiver.c:315` never sees the malformed value.
+
+Why the misinterpretation hazard exists upstream: `recv_token()`
+multiplexes one `int32` return for three states. A positive return is
+literal length, with `*data` pointing into the per-call decompress
+buffer; a negative return is a block match (`-1 - rx_token`); zero is
+EOF. If a peer sends `rx_token = -1`, the function returns
+`-1 - (-1) = 0`, terminating the receive loop with the file partially
+filled. If a peer sends `rx_token = -N` for `N >= 2`, the function
+returns `N - 1`, which the receiver treats as a literal length and
+copies `N - 1` bytes from whatever `*data` happens to reference (the
+last block-match output pointer, freed buffer, or `NULL` depending on
+state).
+
+## 2. oc-rsync decoder sites audited
+
+oc-rsync uses a tagged enum (`CompressedToken::{Literal, BlockMatch,
+End}`) instead of upstream's signed-`int32` multiplexing, so the
+"missing data pointer as literal data" misinterpretation cannot occur
+by construction. The block-index field is still derived from a wire
+`i32`, however, and an attacker-controlled negative wire value silently
+wraps to a large `u32` block index.
+
+### 2.1 `crates/protocol/src/wire/compressed_token/zlib_codec.rs:413`
+
+`ZlibTokenDecoder::recv_token`, `TOKEN_LONG` branch. Reads 4 bytes,
+decodes as `i32`, stores in `self.rx_token`, returns
+`CompressedToken::BlockMatch(self.rx_token as u32)`. No sign check on
+the wire value before the cast.
+
+**Verdict: NEEDS FIX.** A negative wire value wraps to a large `u32`
+block index. Downstream consumers
+(`transfer/src/transfer_ops/token_loop.rs:157`,
+`transfer/src/transfer_ops/response.rs:214`,
+`transfer/src/receiver/transfer.rs:337`) catch out-of-range indices,
+so memory safety is preserved. However, when the absolute token is
+followed by a `TOKENRUN_LONG` run count, the decoder pre-increments
+`self.rx_token` on each subsequent `BlockMatch` emission
+(`zlib_codec.rs:315`). After enough increments, a negative starting
+token wraps back into the valid block-index range, the bounds check
+passes, and the receiver copies the wrong basis block. The final
+file-level checksum still fails, so the attack is limited to forcing
+re-transfers and corrupting partial output, but the decoder loses
+upstream parity and the error appears at a later layer with a less
+specific message.
+
+### 2.2 `crates/protocol/src/wire/compressed_token/zstd_codec.rs:454`
+
+`ZstdTokenDecoder::recv_token`, `TOKEN_LONG` branch. Identical shape
+and identical hazard to 2.1. **Verdict: NEEDS FIX.**
+
+### 2.3 `crates/protocol/src/wire/compressed_token/lz4_codec.rs:340`
+
+`Lz4TokenDecoder::recv_token`, `TOKEN_LONG` branch. Identical shape
+and identical hazard to 2.1. **Verdict: NEEDS FIX.**
+
+### 2.4 `crates/transfer/src/token_reader.rs:130`
+
+`PlainTokenReader::read_token` for the uncompressed path. Branches on
+`token.cmp(&0)` explicitly; `Less` is interpreted as a block match
+(`-(token + 1) as usize`), matching upstream's `recv_token` return
+convention. There is no multiplexed pointer here - the caller receives
+a typed `DeltaToken::BlockRef(usize)` and goes through the same
+bounds-checking consumers. **Verdict: SAFE.**
+
+### 2.5 `crates/protocol/src/wire/delta/token.rs:208`
+
+`read_token` for plain wire delta. Returns `Option<i32>` and leaves
+interpretation to the caller; no pointer multiplexing. **Verdict:
+SAFE.**
+
+### 2.6 `TOKEN_REL` accumulator branches
+
+`zlib_codec.rs:402`, `zstd_codec.rs:443`, `lz4_codec.rs:329` accumulate
+`rx_token += rel` where `rel` is the low 6 bits of the flag byte
+(range 0..=63). The accumulator can only become negative after the
+absolute-token branch has stored a malformed value. Adding the
+absolute-token guard (2.1-2.3) is sufficient to close this path.
+
+## 3. Divergence summary
+
+| Site | Negative wire value rejected? |
+|------|-------------------------------|
+| upstream 3.4.1 `recv_*_token` | No |
+| upstream 3.4.2 `recv_*_token` | Yes (`RERR_PROTOCOL`) |
+| oc-rsync compressed decoders (before #2225) | No |
+| oc-rsync compressed decoders (after #2225) | Yes (`io::ErrorKind::InvalidData`) |
+| oc-rsync plain `PlainTokenReader::read_token` | N/A (explicit signed dispatch, no aliasing) |
+
+## 4. Remediation in this PR
+
+All three compressed codecs gain a sign check immediately after
+`i32::from_le_bytes`, mirroring upstream 3.4.2:
+
+```rust
+self.rx_token = i32::from_le_bytes(buf);
+if self.rx_token < 0 {
+    return Err(io::Error::new(
+        io::ErrorKind::InvalidData,
+        "invalid token number in compressed stream",
+    ));
+}
+```
+
+The message text matches upstream's `rprintf(FERROR, ...)` string
+exactly so wire-protocol tests can grep for it across implementations.
+The Rust error converts to exit code 12 (`RERR_PROTOCOL`) through the
+existing `io::Error` -> `EngineError` mapping, matching upstream's
+`exit_cleanup(RERR_PROTOCOL)` semantics.
+
+A single regression test
+(`crates/protocol/src/wire/compressed_token/tests.rs`) exercises the
+new guard for zlib, zstd, and lz4 by feeding a hand-built byte sequence
+that places `-1i32` after `TOKEN_LONG` and asserting the decoder
+returns `InvalidData` with the upstream-compatible message.


### PR DESCRIPTION
## Summary

Mirrors the upstream rsync 3.4.2 fix in `token.c` that rejects negative
absolute token values in the compressed-stream decoder
([token.c:595-598, 844-847, 1013-1016](https://github.com/RsyncProject/rsync/blob/v3.4.2/token.c#L595-L598)).
Upstream's `recv_token()` multiplexes literal length, block index, and
EOF into a single `int32` return; a negative wire value could alias a
positive return and cause the receiver to misinterpret a missing data
pointer as literal data.

oc-rsync uses a typed `CompressedToken` enum, so the literal-vs-block
aliasing cannot occur by construction. However, all three compressed
codecs (zlib, zstd, lz4) silently wrapped a negative `i32` to a large
`u32` block index. Combined with `TOKENRUN_LONG` run-length expansion,
a malicious starting offset could wrap back into the valid block-index
range and force the receiver to copy the wrong basis block (resulting
in checksum failure and silent corruption of partial output rather
than a memory-safety issue).

Each compressed codec now rejects negative absolute tokens at the
decoder layer with `io::ErrorKind::InvalidData` and the upstream error
string `"invalid token number in compressed stream"`, which maps to
exit code 12 (`RERR_PROTOCOL`) at the engine boundary.

The full audit (including a divergence table and a note on the
`TOKEN_REL` accumulator branches) is in
`docs/audits/upstream-3.4.2-token-decoder-parity.md`.

Refs #2225.

## Test plan

- [ ] `cargo nextest run -p protocol -E 'test(rejects_negative)'`
- [ ] `cargo nextest run -p protocol -E 'test(compressed_token)'` for full module regression
- [ ] CI fmt+clippy, nextest (stable), Windows, macOS, Linux musl