### PR TITLE
docs(audits): xattr sort element-count parity vs 3.4.2

### DIFF
--- a/crates/protocol/src/xattr/cache.rs
+++ b/crates/protocol/src/xattr/cache.rs
@@ -676,6 +676,39 @@ mod tests {
     }
 
     #[test]
+    fn receive_entries_sorted_after_skips() {
+        // upstream: xattrs.c qsort_cmp - 3.4.2 fix uses temp_xattr.count, not
+        // the wire count. Verifies that entries skipped via `continue` (here,
+        // the rsync.%stat internal attr at preserve_xattrs == 1) do not leave
+        // an unsorted tail in the cached XattrList.
+        let mut cache = XattrCache::new();
+        let mut buf = Vec::new();
+
+        let rpre = RSYNC_PREFIX;
+        let internal_name = format!("{rpre}%stat");
+        write_literal_xattr(
+            &mut buf,
+            &[
+                (b"zeta", b"z"),
+                (internal_name.as_bytes(), b"internal"),
+                (b"alpha", b"a"),
+                (b"middle", b"m"),
+            ],
+        );
+
+        let mut cursor = Cursor::new(buf);
+        cache.receive_xattr(&mut cursor, false, 1).unwrap();
+
+        let list = cache.get(0).unwrap();
+        // Internal entry filtered, remaining three sorted by local name.
+        assert_eq!(list.len(), 3);
+        let names: Vec<&[u8]> = list.entries().iter().map(|e| e.name()).collect();
+        let mut sorted = names.clone();
+        sorted.sort();
+        assert_eq!(names, sorted);
+    }
+
+    #[test]
     fn is_rsync_internal_attr_detection() {
         let rpre = RSYNC_PREFIX;
         let stat_name = format!("{rpre}%stat").into_bytes();

--- a/docs/audits/upstream-3.4.2-xattr-qsort-parity.md
+++ b/docs/audits/upstream-3.4.2-xattr-qsort-parity.md
@@ -1,0 +1,68 @@
+# Upstream 3.4.2 xattr qsort element-count parity
+
+## Upstream change
+
+Upstream 3.4.1 `xattrs.c:864` invoked `qsort` over `receive_xattr()`'s entry
+buffer using `count` - the wire-encoded entry count - as the element count:
+
+```c
+if (need_sort && count > 1)
+    qsort(temp_xattr.items, count, sizeof (rsync_xa), rsync_xal_compare_names);
+```
+
+The receive loop may drop entries via `continue` (filter exclusion at line
+815, non-root-namespace at 824, ENV-strip at 845, `rsync.%` internal at
+851). Each skip leaves `temp_xattr.count < count`, so sorting `count`
+elements walked past the populated tail into uninitialised slots of the
+`item_list` backing buffer, producing a non-deterministic ordering for the
+list cached by `rsync_xal_store()`. Subsequent transfers comparing the
+list against a freshly-built one diverged on order, breaking the abbreviated
+xattr cache and corrupting wire output on the next file with the same
+xattr set.
+
+3.4.2 fixes both the guard and the qsort length to use the actual stored
+count:
+
+```c
+if (need_sort && temp_xattr.count > 1)
+    qsort(temp_xattr.items, temp_xattr.count, sizeof (rsync_xa),
+          rsync_xal_compare_names);
+```
+
+The companion qsort at `xattrs.c:297` already used `xalp->count` and is
+unchanged.
+
+## oc-rsync sort sites audited
+
+| Site | Path | Verdict |
+|------|------|---------|
+| Send-side collection sort | `crates/metadata/src/xattr.rs:148` | Safe. `entries.sort_unstable_by` operates on the populated `Vec<XattrEntry>`; no separate element-count parameter exists. |
+| Receive-side post-translation sort | `crates/protocol/src/xattr/cache.rs:220` calls `XattrList::sort_by_name` | Safe. `sort_by_name` (`crates/protocol/src/xattr/list.rs:117`) sorts `self.entries` (the `Vec` built by `push` after every `continue` filter). Length is the `Vec`'s own state. |
+| Free-function helper | `XattrList::sort_by_name` | Safe. Uses `sort_unstable_by` on a `Vec`. |
+
+Rust's `Vec::sort_unstable_by` borrows the slice's true length, so the C
+bug class - passing a stale element count alongside a pointer - cannot
+manifest. Every sort site sorts the same `Vec` that received the `push`
+calls, never an external counter.
+
+Comparator parity: every site uses `a.name().cmp(b.name())` over the raw
+name bytes (`Vec<u8>`), which is the lexicographic byte ordering produced
+by `strcmp` on NUL-terminated names with no embedded NULs (upstream
+guarantees trailing NUL at `xattrs.c:803`). The wire encoder strips the
+NUL before storing in the `Vec`, so the trailing byte is absent from both
+keys and `cmp` yields the same order `strcmp` would on the
+NUL-terminated upstream representation.
+
+## Verdict
+
+No divergence. The Rust receive path is structurally immune to the
+upstream off-by-element-count bug. A regression test was added to lock
+in the invariant that sorting is correct after `continue`-skipped
+entries.
+
+## Test added
+
+`crates/protocol/src/xattr/cache.rs` -
+`receive_entries_sorted_after_skips`: feeds a literal xattr set where the
+internal `rsync.%stat` entry is filtered out at `preserve_xattrs == 1`,
+then verifies the remaining tail is sorted by local name.


### PR DESCRIPTION
## Summary

- Audits oc-rsync xattr sort paths against the upstream 3.4.2 fix in
  `xattrs.c:receive_xattr()` that switched the qsort length from the
  wire-encoded entry count to `temp_xattr.count`. The upstream bug left
  an unsorted tail in the cached xattr list whenever the receive loop
  skipped entries via `continue` (filter, namespace, rsync internal).
- Verdict: no divergence. The Rust send-side (`crates/metadata/src/xattr.rs`)
  and the receive-side (`crates/protocol/src/xattr/cache.rs` calling
  `XattrList::sort_by_name`) both sort the populated `Vec` directly. The
  off-by-element-count class is structurally impossible because Rust's
  `Vec::sort_unstable_by` borrows the slice's true length.
- Adds a regression test that exercises the skip-then-sort path: a
  literal xattr set with an `rsync.%stat` entry filtered out at
  `preserve_xattrs == 1`, verifying the remaining tail is sorted.

Refs #2226.

## Test plan

- [ ] CI nextest covers `receive_entries_sorted_after_skips` on Linux,
      macOS, and Windows hosts.