### PR TITLE
feat(progress): overflow sentinel and ir-chk prefix (D9/D10 parity)

### DIFF
--- a/crates/cli/src/frontend/progress/format/rate.rs
+++ b/crates/cli/src/frontend/progress/format/rate.rs
@@ -229,4 +229,36 @@ mod tests {
         let rate = compute_rate(500, Duration::from_millis(500)).unwrap();
         assert!((rate - 1000.0).abs() < 0.001);
     }
+
+    /// Upstream `rprint_progress` (progress.c:108-116) caps its unit scaling
+    /// at `GB/s` and never substitutes a sentinel for the rate field. The
+    /// numeric value is printed verbatim with the `%7.2f` format, growing
+    /// the field width when the value exceeds 7 chars. We mirror this:
+    /// extreme rates stay in `GB/s` units with no placeholder substitution.
+    /// upstream: progress.c:108-116 rprint_progress
+    #[test]
+    fn progress_rate_has_no_overflow_sentinel() {
+        let huge = 1_000_000_000_000.0_f64; // 1 TB/s
+        let rendered = format_progress_rate_decimal(huge);
+        assert!(
+            rendered.ends_with("GB/s"),
+            "extreme rates must remain in GB/s units: {rendered}"
+        );
+        assert!(!rendered.contains("??"), "no sentinel for rate: {rendered}");
+    }
+
+    /// Verifies the three upstream rate tiers (`kB/s`, `MB/s`, `GB/s`) using
+    /// base-1024 scaling. upstream: progress.c:108-116 rprint_progress.
+    #[test]
+    fn progress_rate_unit_tiers_mirror_upstream() {
+        // Below 1024 B/s prints in kB/s with the fractional value.
+        let kb = format_progress_rate_decimal(512.0);
+        assert!(kb.ends_with("kB/s"), "{kb}");
+        // 1 MiB/s prints in MB/s.
+        let mb = format_progress_rate_decimal(1024.0 * 1024.0);
+        assert!(mb.ends_with("MB/s"), "{mb}");
+        // 1 GiB/s prints in GB/s.
+        let gb = format_progress_rate_decimal(1024.0 * 1024.0 * 1024.0);
+        assert!(gb.ends_with("GB/s"), "{gb}");
+    }
 }

--- a/crates/cli/src/frontend/progress/format/remaining.rs
+++ b/crates/cli/src/frontend/progress/format/remaining.rs
@@ -376,4 +376,48 @@ mod tests {
             "secs={secs} not in [{lower}, {upper}]"
         );
     }
+
+    /// Upstream renders the time overflow as `"  ??:??:??"` (10 chars, two
+    /// leading spaces inside the buffer; see `progress.c:119`). Our `render()`
+    /// returns the 8-character `"??:??:??"` and relies on the caller's
+    /// 10-wide right-aligned field to pad the leading spaces. Verify the
+    /// final on-the-wire form is byte-equivalent.
+    /// upstream: progress.c:118-119 rprint_progress
+    #[test]
+    fn overflow_sentinel_matches_upstream_after_padding() {
+        let mut est = RemainingTimeEstimator::new();
+        let t0 = Instant::now();
+        est.observe(t0, 0);
+        est.observe(t0 + Duration::from_secs(1), 1);
+        let rendered = est.render(t0 + Duration::from_secs(1), 1, u64::MAX);
+        assert_eq!(rendered, "??:??:??");
+        let on_wire = format!("{rendered:>10}");
+        assert_eq!(on_wire, "  ??:??:??");
+        assert_eq!(on_wire.len(), 10);
+    }
+
+    /// Boundary case at the upstream clamp threshold (`9999 * 3600` seconds).
+    /// Exactly at the limit must still render numerically; one second past
+    /// must collapse to the sentinel.
+    /// upstream: progress.c:118 rprint_progress
+    #[test]
+    fn overflow_boundary_exact_vs_off_by_one() {
+        // Construct synthetic samples so the computed `remain` lands precisely
+        // at the boundary, then one second beyond it.
+        let mut est = RemainingTimeEstimator::new();
+        let t0 = Instant::now();
+        est.observe(t0, 0);
+        est.observe(t0 + Duration::from_secs(1), 1);
+        let at_limit = MAX_REMAINING_SECS;
+        let over_limit = MAX_REMAINING_SECS + 1;
+        // Rate is 1 B/s; bytes_left = `at_limit` yields remain == at_limit.
+        assert_ne!(
+            est.render(t0 + Duration::from_secs(1), 1, 1 + at_limit),
+            "??:??:??"
+        );
+        assert_eq!(
+            est.render(t0 + Duration::from_secs(1), 1, 1 + over_limit),
+            "??:??:??"
+        );
+    }
 }

--- a/crates/cli/src/frontend/progress/live.rs
+++ b/crates/cli/src/frontend/progress/live.rs
@@ -129,9 +129,13 @@ impl<'a> ClientProgressObserver for LiveProgress<'a> {
                     write!(self.writer, "\r")?;
                 }
 
+                // upstream: progress.c:80 - chk-prefix is "to" once the file
+                // list is complete, "ir" while INC_RECURSE sub-lists are still
+                // arriving on the wire.
+                let chk_prefix = if update.flist_eof() { "to" } else { "ir" };
                 write!(
                     self.writer,
-                    "{size_field} {percent_field} {rate_field} {time_field} (xfr#{xfr_index}, to-chk={remaining}/{total})"
+                    "{size_field} {percent_field} {rate_field} {time_field} (xfr#{xfr_index}, {chk_prefix}-chk={remaining}/{total})"
                 )?;
 
                 if update.is_final() {
@@ -174,9 +178,13 @@ impl<'a> ClientProgressObserver for LiveProgress<'a> {
                     write!(self.writer, "\r")?;
                 }
 
+                // upstream: progress.c:80 - chk-prefix is "to" once the file
+                // list is complete, "ir" while INC_RECURSE sub-lists are still
+                // arriving on the wire.
+                let chk_prefix = if update.flist_eof() { "to" } else { "ir" };
                 write!(
                     self.writer,
-                    "{size_field} {percent_field} {rate_field} {time_field} (xfr#{xfr_index}, to-chk={remaining}/{total})"
+                    "{size_field} {percent_field} {rate_field} {time_field} (xfr#{xfr_index}, {chk_prefix}-chk={remaining}/{total})"
                 )?;
 
                 if final_tick {
@@ -196,5 +204,68 @@ impl<'a> ClientProgressObserver for LiveProgress<'a> {
             }
             Err(error) => self.record_error(error),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::client::{ClientEvent, ClientEventKind};
+    use engine::local_copy::LocalCopyChangeSet;
+    use std::path::PathBuf;
+    use std::time::Duration;
+
+    fn make_update(flist_eof: bool) -> ClientProgressUpdate {
+        let event = ClientEvent::for_test(
+            PathBuf::from("file.bin"),
+            ClientEventKind::DataCopied,
+            true,
+            None,
+            LocalCopyChangeSet::new(),
+        );
+        ClientProgressUpdate::from_transfer_event(
+            event,
+            1,
+            3,
+            Some(2_048),
+            1_024,
+            Duration::from_secs(1),
+            flist_eof,
+        )
+    }
+
+    /// upstream: progress.c:78-82 - the per-file trailer prints `to-chk` once
+    /// the file list is complete, `ir-chk` while INC_RECURSE sub-lists are
+    /// still arriving.
+    #[test]
+    fn per_file_renders_to_chk_when_flist_complete() {
+        let mut buf: Vec<u8> = Vec::new();
+        {
+            let mut live = LiveProgress::new(
+                &mut buf,
+                ProgressMode::PerFile,
+                HumanReadableMode::Disabled,
+            );
+            live.on_progress(&make_update(true));
+        }
+        let output = String::from_utf8(buf).expect("utf8");
+        assert!(output.contains("to-chk="), "missing to-chk: {output}");
+        assert!(!output.contains("ir-chk="), "unexpected ir-chk: {output}");
+    }
+
+    #[test]
+    fn per_file_renders_ir_chk_when_flist_pending() {
+        let mut buf: Vec<u8> = Vec::new();
+        {
+            let mut live = LiveProgress::new(
+                &mut buf,
+                ProgressMode::PerFile,
+                HumanReadableMode::Disabled,
+            );
+            live.on_progress(&make_update(false));
+        }
+        let output = String::from_utf8(buf).expect("utf8");
+        assert!(output.contains("ir-chk="), "missing ir-chk: {output}");
+        assert!(!output.contains("to-chk="), "unexpected to-chk: {output}");
     }
 }

--- a/crates/cli/src/frontend/progress/live.rs
+++ b/crates/cli/src/frontend/progress/live.rs
@@ -241,11 +241,8 @@ mod tests {
     fn per_file_renders_to_chk_when_flist_complete() {
         let mut buf: Vec<u8> = Vec::new();
         {
-            let mut live = LiveProgress::new(
-                &mut buf,
-                ProgressMode::PerFile,
-                HumanReadableMode::Disabled,
-            );
+            let mut live =
+                LiveProgress::new(&mut buf, ProgressMode::PerFile, HumanReadableMode::Disabled);
             live.on_progress(&make_update(true));
         }
         let output = String::from_utf8(buf).expect("utf8");
@@ -257,11 +254,8 @@ mod tests {
     fn per_file_renders_ir_chk_when_flist_pending() {
         let mut buf: Vec<u8> = Vec::new();
         {
-            let mut live = LiveProgress::new(
-                &mut buf,
-                ProgressMode::PerFile,
-                HumanReadableMode::Disabled,
-            );
+            let mut live =
+                LiveProgress::new(&mut buf, ProgressMode::PerFile, HumanReadableMode::Disabled);
             live.on_progress(&make_update(false));
         }
         let output = String::from_utf8(buf).expect("utf8");

--- a/crates/core/src/client/progress.rs
+++ b/crates/core/src/client/progress.rs
@@ -135,7 +135,7 @@ impl ClientProgressUpdate {
     ///
     /// Used by the SSH/daemon transfer adapter to convert per-file progress
     /// events from the transfer crate into client progress updates.
-    pub(crate) fn from_transfer_event(
+    pub fn from_transfer_event(
         event: ClientEvent,
         files_done: usize,
         total_files: usize,

--- a/crates/core/src/client/progress.rs
+++ b/crates/core/src/client/progress.rs
@@ -54,6 +54,7 @@ pub struct ClientProgressUpdate {
     overall_transferred: u64,
     overall_total_bytes: Option<u64>,
     overall_elapsed: Duration,
+    flist_eof: bool,
 }
 
 impl ClientProgressUpdate {
@@ -108,6 +109,19 @@ impl ClientProgressUpdate {
     pub const fn overall_elapsed(&self) -> Duration {
         self.overall_elapsed
     }
+
+    /// Reports whether the file list is complete (no more INC_RECURSE
+    /// sub-lists pending).
+    ///
+    /// Mirrors upstream's `flist_eof` flag, which controls whether the
+    /// per-file progress line ends with `to-chk=...` (complete) or
+    /// `ir-chk=...` (incremental-recursive still in flight).
+    ///
+    /// upstream: progress.c:79-82 rprint_progress
+    #[must_use]
+    pub const fn flist_eof(&self) -> bool {
+        self.flist_eof
+    }
 }
 
 /// Observer invoked for each progress update generated during client execution.
@@ -128,6 +142,7 @@ impl ClientProgressUpdate {
         total_bytes: Option<u64>,
         overall_transferred: u64,
         overall_elapsed: Duration,
+        flist_eof: bool,
     ) -> Self {
         Self {
             event,
@@ -139,6 +154,7 @@ impl ClientProgressUpdate {
             overall_transferred,
             overall_total_bytes: None,
             overall_elapsed,
+            flist_eof,
         }
     }
 }
@@ -239,6 +255,9 @@ impl<'a> LocalCopyRecordHandler for ClientProgressForwarder<'a> {
             overall_transferred: self.overall_transferred,
             overall_total_bytes: self.overall_total_bytes,
             overall_elapsed: self.overall_start.elapsed(),
+            // Local copies enumerate the file list eagerly before transferring,
+            // so the list is always complete when progress is emitted.
+            flist_eof: true,
         };
 
         self.observer.on_progress(&update);
@@ -279,6 +298,9 @@ impl<'a> LocalCopyRecordHandler for ClientProgressForwarder<'a> {
             overall_transferred: self.overall_transferred,
             overall_total_bytes: self.overall_total_bytes,
             overall_elapsed: self.overall_start.elapsed(),
+            // Local copies do not use INC_RECURSE: the file list is enumerated
+            // eagerly before any progress event is emitted.
+            flist_eof: true,
         };
 
         self.observer.on_progress(&update);
@@ -313,6 +335,7 @@ mod tests {
             overall_transferred: 5000,
             overall_total_bytes: Some(10000),
             overall_elapsed: Duration::from_secs(5),
+            flist_eof: true,
         }
     }
 
@@ -387,5 +410,35 @@ mod tests {
         observer.on_progress(&update);
 
         assert_eq!(updates, vec![5]);
+    }
+
+    /// upstream: progress.c:79-82 - `flist_eof ? "to" : "ir"` switches the
+    /// chk-prefix on the trailing per-file summary. Verify the flag is
+    /// surfaced through the public accessor.
+    #[test]
+    fn flist_eof_default_true_matches_completed_list() {
+        let update = create_test_update(10, 5, 5, true);
+        assert!(update.flist_eof());
+    }
+
+    #[test]
+    fn flist_eof_can_be_false_for_inc_recurse() {
+        let event = ClientEvent::from_progress(
+            Path::new("a"),
+            0,
+            None,
+            Duration::ZERO,
+            Arc::from(Path::new("/d")),
+        );
+        let update = ClientProgressUpdate::from_transfer_event(
+            event,
+            1,
+            2,
+            None,
+            0,
+            Duration::ZERO,
+            false,
+        );
+        assert!(!update.flist_eof());
     }
 }

--- a/crates/core/src/client/progress.rs
+++ b/crates/core/src/client/progress.rs
@@ -430,15 +430,8 @@ mod tests {
             Duration::ZERO,
             Arc::from(Path::new("/d")),
         );
-        let update = ClientProgressUpdate::from_transfer_event(
-            event,
-            1,
-            2,
-            None,
-            0,
-            Duration::ZERO,
-            false,
-        );
+        let update =
+            ClientProgressUpdate::from_transfer_event(event, 1, 2, None, 0, Duration::ZERO, false);
         assert!(!update.flist_eof());
     }
 }

--- a/crates/core/src/client/remote/embedded_ssh_transfer.rs
+++ b/crates/core/src/client/remote/embedded_ssh_transfer.rs
@@ -408,6 +408,7 @@ impl TransferProgressCallback for ServerProgressAdapter<'_> {
             event.total_file_bytes,
             self.overall_transferred,
             self.start.elapsed(),
+            event.flist_eof,
         );
 
         self.observer.on_progress(&update);

--- a/crates/core/src/client/remote/ssh_transfer.rs
+++ b/crates/core/src/client/remote/ssh_transfer.rs
@@ -80,6 +80,7 @@ impl TransferProgressCallback for ServerProgressAdapter<'_> {
             event.total_file_bytes,
             self.overall_transferred,
             self.start.elapsed(),
+            event.flist_eof,
         );
 
         self.observer.on_progress(&update);

--- a/crates/transfer/src/generator/transfer.rs
+++ b/crates/transfer/src/generator/transfer.rs
@@ -414,12 +414,16 @@ impl GeneratorContext {
             self.maybe_emit_itemize(writer, &iflags, ndx, itemize)?;
 
             if let Some(cb) = progress.as_mut() {
+                // upstream: progress.c:80 - "to" once the final sub-list has been
+                // sent, "ir" while more sub-lists are still pending.
+                let flist_eof = !inc_recurse || self.incremental.flist_eof_sent;
                 let event = super::super::TransferProgressEvent {
                     path: file_entry.path(),
                     file_bytes: bytes_sent,
                     total_file_bytes: Some(file_entry.size()),
                     files_done: files_transferred,
                     total_files: self.file_list.len(),
+                    flist_eof,
                 };
                 cb.on_file_transferred(&event);
             }

--- a/crates/transfer/src/progress.rs
+++ b/crates/transfer/src/progress.rs
@@ -22,6 +22,14 @@ pub struct TransferProgressEvent<'a> {
     pub files_done: usize,
     /// Total number of files to transfer.
     pub total_files: usize,
+    /// Whether the file list is complete (no more INC_RECURSE sub-lists pending).
+    ///
+    /// Mirrors upstream's global `flist_eof` flag, which controls the
+    /// `to-chk` vs `ir-chk` suffix on the per-file progress line.
+    ///
+    /// upstream: progress.c:79-82 rprint_progress - prints
+    /// `flist_eof ? "to" : "ir"` as the chk prefix.
+    pub flist_eof: bool,
 }
 
 /// Callback trait for transfer progress reporting.

--- a/crates/transfer/src/receiver/transfer/pipeline.rs
+++ b/crates/transfer/src/receiver/transfer/pipeline.rs
@@ -358,6 +358,11 @@ impl ReceiverContext {
                         total_file_bytes: Some(file_entry.size()),
                         files_done: files_transferred,
                         total_files,
+                        // Receiver-side INC_RECURSE collects every sub-list via
+                        // `receive_extra_file_lists` before the pipeline begins,
+                        // so the file list is always complete when progress is
+                        // emitted. upstream: progress.c:79-82 rprint_progress.
+                        flist_eof: true,
                     };
                     cb.on_file_transferred(&event);
                 }


### PR DESCRIPTION
## Summary

Close two upstream-parity gaps in `--progress` rendering:

- **Time overflow sentinel** (#2203): verify the `??:??:??` placeholder rendered by `RemainingTimeEstimator::render` is byte-for-byte equivalent to upstream's `"  ??:??:??"` after the 10-wide right-aligned field padding applied at the call sites. Confirm the rate field has no overflow sentinel upstream (`progress.c:108-116` only scales units up to `GB/s`, no placeholder), and document this in tests. Add boundary tests around the `9999 * 3600`-second clamp.
- **`ir-chk` chk-prefix** (#2204): plumb `flist_eof` through `TransferProgressEvent` and `ClientProgressUpdate` so the per-file trailer switches between `to-chk=A/B` and `ir-chk=A/B`, matching upstream's `flist_eof ? "to" : "ir"` selection (`progress.c:79-82`). The sender plumbs the live generator state (`self.incremental.flist_eof_sent`); the receiver and the local-copy forwarder set `true` because they collect the full file list before emitting progress events.

Closes #2203
Closes #2204

## Test plan

- [ ] CI: `cargo fmt --check`, clippy, nextest (Linux/macOS/Windows/musl).
- [ ] `cli::progress::format::remaining::tests::overflow_sentinel_matches_upstream_after_padding`
- [ ] `cli::progress::format::remaining::tests::overflow_boundary_exact_vs_off_by_one`
- [ ] `cli::progress::format::rate::tests::progress_rate_has_no_overflow_sentinel`
- [ ] `cli::progress::format::rate::tests::progress_rate_unit_tiers_mirror_upstream`
- [ ] `cli::progress::live::tests::per_file_renders_to_chk_when_flist_complete`
- [ ] `cli::progress::live::tests::per_file_renders_ir_chk_when_flist_pending`
- [ ] `core::client::progress::tests::flist_eof_default_true_matches_completed_list`
- [ ] `core::client::progress::tests::flist_eof_can_be_false_for_inc_recurse`