### PR TITLE
fix(transfer): preserve relative path prefix on single-source daemon push

### DIFF
--- a/crates/transfer/src/generator/file_list/mod.rs
+++ b/crates/transfer/src/generator/file_list/mod.rs
@@ -61,8 +61,26 @@ impl GeneratorContext {
         self.file_list.reserve(FLIST_START);
         self.full_paths.reserve(FLIST_START);
 
+        let relative_paths = self.config.flags.relative;
+        // upstream: flist.c:send_implied_dirs() - every parent directory of a
+        // --relative source must be present in the file list so the receiver
+        // can find it via flist_find_name() (generator.c:1313). We track
+        // emitted ancestors across sources to avoid duplicate entries.
+        let mut implied_ancestors: HashSet<PathBuf> = HashSet::new();
         for base_path in base_paths {
-            self.walk_path(base_path, base_path.clone())?;
+            // upstream: flist.c:2316 - --relative splits on "/./" so the dir
+            // before the anchor is the base and everything after is the
+            // transmitted relative name. Without an anchor the entire path is
+            // the relative name (with the leading "/" stripped post-sort).
+            let (base, path) = if relative_paths {
+                relative_walk_base(base_path)
+            } else {
+                (base_path.clone(), base_path.clone())
+            };
+            if relative_paths {
+                self.emit_implied_parents(&base, &path, &mut implied_ancestors)?;
+            }
+            self.walk_path(&base, path)?;
         }
 
         // upstream: flist.c:f_name_cmp() - sort both arrays via indirect permutation.
@@ -224,6 +242,113 @@ impl GeneratorContext {
 
         Ok(count)
     }
+
+    /// Emits a directory entry for every implied ancestor of a `--relative`
+    /// source path between `base` and `path`.
+    ///
+    /// Without inc-recurse, upstream rsync requires every parent directory of
+    /// a relative source to be present in the file list so the receiver's
+    /// `flist_find_name()` lookup at `generator.c:1313` succeeds. This walks
+    /// from the path closest to `base` down to the source itself (exclusive),
+    /// stat-ing each ancestor and recording it once via `implied_seen` to
+    /// deduplicate across multiple source arguments.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `flist.c:1901-1980` - `send_implied_dirs()`
+    /// - `generator.c:1300-1315` - parent dir presence check
+    fn emit_implied_parents(
+        &mut self,
+        base: &Path,
+        path: &Path,
+        implied_seen: &mut HashSet<PathBuf>,
+    ) -> io::Result<()> {
+        let relative = path.strip_prefix(base).unwrap_or(path);
+        let parent = match relative.parent() {
+            Some(p) if !p.as_os_str().is_empty() => p,
+            _ => return Ok(()),
+        };
+
+        // Build ancestor list from shallowest to deepest, excluding the
+        // source path itself (which walk_path will record).
+        let mut ancestors: Vec<PathBuf> = Vec::new();
+        let mut current = parent.to_path_buf();
+        loop {
+            ancestors.push(current.clone());
+            match current.parent() {
+                Some(p) if !p.as_os_str().is_empty() => current = p.to_path_buf(),
+                _ => break,
+            }
+        }
+
+        for relative_ancestor in ancestors.into_iter().rev() {
+            if !implied_seen.insert(relative_ancestor.clone()) {
+                continue;
+            }
+            let full = base.join(&relative_ancestor);
+            let meta = match std::fs::symlink_metadata(&full) {
+                Ok(m) if m.is_dir() => m,
+                _ => continue,
+            };
+            if let Ok(entry) = self.create_entry(&full, relative_ancestor, &meta) {
+                self.push_file_item(entry, full);
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Splits a source path for `--relative` mode into (base, full path).
+///
+/// Mirrors upstream rsync's `--relative` handling in `flist.c:2316-2350`:
+///
+/// - When the path contains `/./`, everything before the anchor becomes the
+///   base (treated as `dir` upstream) and everything after becomes the
+///   transmitted relative name.
+/// - Without an anchor, the entire path is the relative name. Absolute paths
+///   keep their root; the receiver strips the leading `/` post-sort
+///   (`flist.c:3071-3084`). Relative paths use `.` as the base so
+///   `strip_prefix` yields the original path verbatim.
+///
+/// The returned `base` is what `walk_path` strips from each child path to
+/// compute its wire-side relative name.
+fn relative_walk_base(path: &Path) -> (PathBuf, PathBuf) {
+    // upstream: flist.c:2316 - `if ((p = strstr(fbuf, "/./")) != NULL)`
+    if let Some(anchor) = find_dot_dir_anchor(path) {
+        let path_str = path.as_os_str().to_string_lossy();
+        let (head, tail) = path_str.split_at(anchor);
+        // Skip the "/./" separator (3 chars) and any extra leading slashes.
+        let rest = tail[3..].trim_start_matches('/');
+        let base = if head.is_empty() {
+            PathBuf::from("/")
+        } else {
+            PathBuf::from(head)
+        };
+        let full = if rest.is_empty() {
+            base.clone()
+        } else {
+            base.join(rest)
+        };
+        return (base, full);
+    }
+
+    // upstream: flist.c:2329 - no "/./" anchor: the entire path is the
+    // relative name. Use "/" as base for absolute paths (the leading slash is
+    // stripped by the receiver per flist.c:3071) and "." for relative paths.
+    let base = if path.has_root() {
+        PathBuf::from("/")
+    } else {
+        PathBuf::from(".")
+    };
+    (base, path.to_path_buf())
+}
+
+/// Locates the byte offset of `/./` in a path, used as the `--relative`
+/// anchor separator.
+fn find_dot_dir_anchor(path: &Path) -> Option<usize> {
+    let s = path.as_os_str().to_str()?;
+    s.find("/./")
 }
 
 /// Applies a source-based permutation to two parallel slices in-place.

--- a/crates/transfer/src/generator/file_list/walk.rs
+++ b/crates/transfer/src/generator/file_list/walk.rs
@@ -43,10 +43,14 @@ impl GeneratorContext {
             }
         };
 
-        self.walk_path_with_metadata(base, path, metadata)
+        self.walk_path_with_metadata(base, path, metadata, true)
     }
 
     /// Walks a path with pre-resolved metadata, skipping the initial stat call.
+    ///
+    /// `is_top_level` is `true` only for the direct source arguments; recursive
+    /// descents into directory children always pass `false`. The flag controls
+    /// whether the directory entry receives `XMIT_TOP_DIR` (upstream `FLAG_TOP_DIR`).
     ///
     /// This is the inner implementation shared by [`walk_path`] (which resolves
     /// metadata itself) and the batched-stat path (which pre-resolves metadata
@@ -56,6 +60,7 @@ impl GeneratorContext {
         base: &Path,
         path: PathBuf,
         metadata: std::fs::Metadata,
+        is_top_level: bool,
     ) -> io::Result<()> {
         let relative = path.strip_prefix(base).unwrap_or(&path).to_path_buf();
 
@@ -121,7 +126,7 @@ impl GeneratorContext {
             }
         }
 
-        let entry = match self.create_entry(&path, relative, &metadata) {
+        let mut entry = match self.create_entry(&path, relative, &metadata) {
             Ok(e) => e,
             Err(e) => {
                 // upstream: flist.c - rsyserr for make_file() failures
@@ -135,6 +140,17 @@ impl GeneratorContext {
                 return Ok(());
             }
         };
+
+        // upstream: flist.c:2287 - top-level source directories carry
+        // FLAG_TOP_DIR so delete_in_dir() can scope deletions. Under
+        // --relative the directory entry has a non-empty relative name (e.g.
+        // "tmp/dbg/src/usr/bin") instead of ".", but it still needs the flag.
+        if is_top_level && metadata.is_dir() {
+            entry.set_flags(protocol::flist::FileFlags::new(
+                protocol::flist::XMIT_TOP_DIR,
+                0,
+            ));
+        }
 
         // upstream: flist.c:send_file_list() - scan directory before recording entry
         let should_recurse = metadata.is_dir() && self.config.flags.recursive;
@@ -288,7 +304,7 @@ impl GeneratorContext {
                         }
                     }
 
-                    self.walk_path_with_metadata(base, path, meta)?;
+                    self.walk_path_with_metadata(base, path, meta, false)?;
                 }
                 Err(e) => {
                     self.log_stat_error(&path, &e);

--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -2199,7 +2199,11 @@ mod files_from {
         );
         // Every parent ancestor must be present so the receiver can resolve
         // generator.c:1313 parent-lookup without ABORTING.
-        for ancestor in src_dir.ancestors().skip(1).take_while(|p| p.parent().is_some()) {
+        for ancestor in src_dir
+            .ancestors()
+            .skip(1)
+            .take_while(|p| p.parent().is_some())
+        {
             let rel = ancestor.strip_prefix("/").unwrap().to_string_lossy();
             if rel.is_empty() {
                 continue;
@@ -2223,10 +2227,7 @@ mod files_from {
         std::fs::write(leaf.join("ar"), b"x").unwrap();
 
         // Construct path with explicit "/./" separator.
-        let src_with_anchor = PathBuf::from(format!(
-            "{}/./usr/bin",
-            anchored.to_string_lossy()
-        ));
+        let src_with_anchor = PathBuf::from(format!("{}/./usr/bin", anchored.to_string_lossy()));
 
         let handshake = test_handshake();
         let mut config = test_config();

--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -2161,6 +2161,124 @@ mod files_from {
         assert!(names.contains(&"."), "expected dot entry in {names:?}");
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn relative_absolute_source_preserves_full_prefix() {
+        // upstream: flist.c:2329 - no "/./" anchor on an absolute source path
+        // sends the entire path (minus the leading slash, stripped post-sort
+        // by the receiver) as the relative name. Regression test for #4074.
+        let temp_dir = TempDir::new().unwrap();
+        let src_dir = temp_dir.path().join("usr").join("bin");
+        std::fs::create_dir_all(&src_dir).unwrap();
+        std::fs::write(src_dir.join("ar"), b"x").unwrap();
+
+        let handshake = test_handshake();
+        let mut config = test_config();
+        config.flags.relative = true;
+        config.flags.recursive = true;
+        config.args = vec![OsString::from(&src_dir)];
+        let mut ctx = GeneratorContext::new(&handshake, config);
+
+        ctx.build_file_list(&[src_dir.clone()]).unwrap();
+        let names: Vec<String> = ctx
+            .file_list()
+            .iter()
+            .map(|e| e.path().to_string_lossy().into_owned())
+            .collect();
+
+        // The transmitted relative name for the source directory must contain
+        // the parent components (e.g. ".../usr/bin"), not collapse to ".".
+        let temp_suffix = src_dir.strip_prefix("/").unwrap().to_string_lossy();
+        assert!(
+            names.iter().any(|n| n == &temp_suffix),
+            "expected source dir relative name {temp_suffix:?} in {names:?}"
+        );
+        assert!(
+            names.iter().any(|n| n.ends_with("usr/bin/ar")),
+            "expected child to retain path prefix in {names:?}"
+        );
+        // Every parent ancestor must be present so the receiver can resolve
+        // generator.c:1313 parent-lookup without ABORTING.
+        for ancestor in src_dir.ancestors().skip(1).take_while(|p| p.parent().is_some()) {
+            let rel = ancestor.strip_prefix("/").unwrap().to_string_lossy();
+            if rel.is_empty() {
+                continue;
+            }
+            assert!(
+                names.iter().any(|n| n == &rel),
+                "missing implied parent {rel:?} in {names:?}"
+            );
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn relative_dot_anchor_splits_base_and_relative() {
+        // upstream: flist.c:2316 - `/./` anchor splits source: dir before the
+        // anchor is treated as the base, the rest becomes the relative name.
+        let temp_dir = TempDir::new().unwrap();
+        let anchored = temp_dir.path().join("root");
+        let leaf = anchored.join("usr").join("bin");
+        std::fs::create_dir_all(&leaf).unwrap();
+        std::fs::write(leaf.join("ar"), b"x").unwrap();
+
+        // Construct path with explicit "/./" separator.
+        let src_with_anchor = PathBuf::from(format!(
+            "{}/./usr/bin",
+            anchored.to_string_lossy()
+        ));
+
+        let handshake = test_handshake();
+        let mut config = test_config();
+        config.flags.relative = true;
+        config.flags.recursive = true;
+        let mut ctx = GeneratorContext::new(&handshake, config);
+        ctx.build_file_list(&[src_with_anchor]).unwrap();
+
+        let names: Vec<String> = ctx
+            .file_list()
+            .iter()
+            .map(|e| e.path().to_string_lossy().into_owned())
+            .collect();
+        assert!(
+            names.iter().any(|n| n == "usr/bin"),
+            "expected anchored relative name 'usr/bin' in {names:?}"
+        );
+        assert!(
+            names.iter().any(|n| n == "usr/bin/ar"),
+            "expected child 'usr/bin/ar' in {names:?}"
+        );
+        assert!(
+            names.iter().any(|n| n == "usr"),
+            "expected implied parent 'usr' in {names:?}"
+        );
+    }
+
+    #[test]
+    fn non_relative_mode_uses_basename() {
+        // Without --relative, a directory source still collapses to "." with
+        // children named by basename only. Guards against the relative-mode
+        // fix accidentally changing default behaviour.
+        let temp_dir = TempDir::new().unwrap();
+        let src_dir = temp_dir.path().join("payload");
+        std::fs::create_dir_all(&src_dir).unwrap();
+        std::fs::write(src_dir.join("file.txt"), b"x").unwrap();
+
+        let handshake = test_handshake();
+        let mut config = test_config();
+        config.flags.relative = false;
+        config.flags.recursive = true;
+        let mut ctx = GeneratorContext::new(&handshake, config);
+        ctx.build_file_list(&[src_dir]).unwrap();
+
+        let names: Vec<&str> = ctx.file_list().iter().map(|e| e.name()).collect();
+        assert!(names.contains(&"."), "expected '.' entry in {names:?}");
+        assert!(
+            names.contains(&"file.txt"),
+            "expected 'file.txt' in {names:?}"
+        );
+    }
+
     #[test]
     fn build_file_list_with_base_skips_missing_files() {
         let temp_dir = TempDir::new().unwrap();


### PR DESCRIPTION
## Summary

- Single (and multi) source `oc-rsync -Raz /abs/path rsync://daemon/module/` now writes files under the expected `module/abs/path/...` layout instead of stripping the prefix and dumping basenames at the module root.
- `build_file_list` derives the walk base per source so the transmitted relative name matches upstream `flist.c:2316-2350`: split on the `/./` anchor when present, otherwise use `/` for absolute paths and `.` for relative ones.
- Every implied ancestor between the base and the source is now emitted in the file list, matching `flist.c:send_implied_dirs()` and satisfying the receiver's parent-lookup check at `generator.c:1313` (which otherwise ABORTs with "invalid path from sender").
- The top-of-source directory keeps `XMIT_TOP_DIR` so `--delete` still scopes deletions correctly even when its relative name is no longer `.`.

The bug also affected the multi-source case (the issue report was inaccurate on that point); the same fix covers both. Local destinations and non-`-R` pushes are unchanged.

Refs #2242
Closes #4074

## Test plan

- [x] `cargo test -p transfer --lib generator::tests::` (all 130 generator tests pass, 192 with file_list integration tests)
- [x] Reproduction against upstream rsync 3.4.1 daemon in container:
  - `oc-rsync -Raz /tmp/dbg/src/usr/bin rsync://localhost:8730/module/` -> `dst/tmp/dbg/src/usr/bin/{ar,arch,bash}` (matches upstream byte-for-byte)
  - Multi-source `... /usr/bin /usr/lib ...` -> both prefixes preserved
  - `/./` anchor: `/tmp/dbg/src/./usr/bin` -> `dst/usr/bin/...`
  - Relative source `cd /tmp/dbg2 && oc-rsync -Raz usr/bin ...` -> `dst/usr/bin/...`
  - No `-R`: `oc-rsync -az /tmp/dbg/src/usr/bin ...` -> `dst/{ar,arch,bash}` (unchanged)
  - `-R --delete`: behaviour matches upstream
- [x] CI: fmt+clippy, nextest (Linux/macOS/Windows/musl)