### PR TITLE
feat(logging): wire --info=NAME level 2 emissions in copy/link/del paths

### DIFF
--- a/crates/engine/src/local_copy/executor/file/copy/links.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/links.rs
@@ -11,6 +11,8 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
+use logging::info_log;
+
 use crate::local_copy::overrides::create_hard_link;
 use crate::local_copy::{
     CopyContext, CreatedEntryKind, LocalCopyAction, LocalCopyChangeSet, LocalCopyError,
@@ -108,6 +110,16 @@ pub(super) fn process_links(
             }
         }
 
+        // upstream: hlink.c:236 - rprintf(code, "%s => %s\n", fname, realname)
+        // emitted at INFO_GTE(NAME, 1) when a hard link is created via --link-dest.
+        info_log!(
+            Name,
+            1,
+            "{} => {}",
+            record_path.display(),
+            link_target.display()
+        );
+
         context.record_hard_link(metadata, destination);
         context.summary_mut().record_hard_link();
         let metadata_snapshot = LocalCopyMetadata::from_metadata(metadata, None);
@@ -168,6 +180,16 @@ pub(super) fn process_links(
             }
         }
 
+        // upstream: hlink.c:236 - "%s => %s" at INFO_GTE(NAME, 1) when an
+        // already-copied inode is hard-linked into place.
+        info_log!(
+            Name,
+            1,
+            "{} => {}",
+            record_path.display(),
+            existing_target.display()
+        );
+
         context.record_hard_link(metadata, destination);
         context.summary_mut().record_hard_link();
         let metadata_snapshot = LocalCopyMetadata::from_metadata(metadata, None);
@@ -210,6 +232,10 @@ pub(super) fn process_links(
     {
         match decision {
             ReferenceDecision::Skip => {
+                // upstream: generator.c:1010,1133 / rsync.c:676 - "is uptodate"
+                // emitted at INFO_GTE(NAME, 2) when a reference-directory match
+                // means no transfer is needed.
+                info_log!(Name, 2, "{} is uptodate", record_path.display());
                 context.summary_mut().record_regular_file_matched();
                 let metadata_snapshot = LocalCopyMetadata::from_metadata(metadata, None);
                 let total_bytes = Some(metadata_snapshot.len());
@@ -313,6 +339,9 @@ pub(super) fn process_links(
                     )?;
                     #[cfg(all(any(unix, windows), feature = "acl"))]
                     sync_acls_if_requested(preserve_acls, mode, source, destination, true)?;
+                    // upstream: hlink.c:236 - "%s => %s" at INFO_GTE(NAME, 1)
+                    // when a hard link is created from a reference directory.
+                    info_log!(Name, 1, "{} => {}", record_path.display(), path.display());
                     context.record_hard_link(metadata, destination);
                     context.summary_mut().record_hard_link();
                     let metadata_snapshot = LocalCopyMetadata::from_metadata(metadata, None);
@@ -350,4 +379,73 @@ pub(super) fn process_links(
         copy_source_override,
         completed: false,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    //! Pinning tests for `--info=NAME` level 1/2 emissions in the local-copy
+    //! link path. Strings are matched byte-for-byte against upstream rsync.
+    //!
+    //! upstream: log.c log_item / send_directory NAME emissions
+    //! upstream: hlink.c:236 ("=>"), generator.c:1010/1133 ("is uptodate").
+
+    use logging::{
+        DiagnosticEvent, InfoFlag, VerbosityConfig, drain_events, info_log, init,
+    };
+
+    fn init_name_level(level: u8) {
+        let mut cfg = VerbosityConfig::default();
+        cfg.info.name = level;
+        init(cfg);
+        let _ = drain_events();
+    }
+
+    fn name_messages() -> Vec<String> {
+        drain_events()
+            .into_iter()
+            .filter_map(|event| match event {
+                DiagnosticEvent::Info {
+                    flag: InfoFlag::Name,
+                    message,
+                    ..
+                } => Some(message),
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn local_copy_hard_link_emission_matches_upstream() {
+        // upstream: hlink.c:236 - "%s => %s" at INFO_GTE(NAME, 1)
+        init_name_level(1);
+        info_log!(Name, 1, "{} => {}", "out/file.txt", "ref/file.txt");
+        let msgs = name_messages();
+        assert!(
+            msgs.iter().any(|m| m == "out/file.txt => ref/file.txt"),
+            "missing upstream hardlink => wording: {msgs:?}"
+        );
+    }
+
+    #[test]
+    fn local_copy_uptodate_emission_matches_upstream() {
+        // upstream: rsync.c:672-676 - "%s is uptodate" at INFO_GTE(NAME, 2)
+        init_name_level(2);
+        info_log!(Name, 2, "{} is uptodate", "out/file.txt");
+        let msgs = name_messages();
+        assert!(
+            msgs.iter().any(|m| m == "out/file.txt is uptodate"),
+            "missing upstream `is uptodate` wording: {msgs:?}"
+        );
+    }
+
+    #[test]
+    fn local_copy_uptodate_suppressed_below_level_two() {
+        // upstream: rsync.c:672 - INFO_GTE(NAME, 2) gates the emission
+        init_name_level(1);
+        info_log!(Name, 2, "{} is uptodate", "out/file.txt");
+        assert!(
+            name_messages().is_empty(),
+            "uptodate emission must be gated at NAME level 2"
+        );
+    }
 }

--- a/crates/engine/src/local_copy/executor/file/copy/links.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/links.rs
@@ -389,9 +389,7 @@ mod tests {
     //! upstream: log.c log_item / send_directory NAME emissions
     //! upstream: hlink.c:236 ("=>"), generator.c:1010/1133 ("is uptodate").
 
-    use logging::{
-        DiagnosticEvent, InfoFlag, VerbosityConfig, drain_events, info_log, init,
-    };
+    use logging::{DiagnosticEvent, InfoFlag, VerbosityConfig, drain_events, info_log, init};
 
     fn init_name_level(level: u8) {
         let mut cfg = VerbosityConfig::default();

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/execute.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/execute.rs
@@ -11,7 +11,7 @@ use std::io::{Seek, SeekFrom};
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
-use logging::debug_log;
+use logging::{debug_log, info_log};
 
 use ::metadata::MetadataOptions;
 
@@ -712,6 +712,10 @@ fn record_metadata_only_skip(
         record_path.display(),
         reason
     );
+    // upstream: rsync.c:672-676 - rprintf(FCLIENT, "%s is uptodate\n", fname)
+    // at INFO_GTE(NAME, 2) when a quick-check or content-equal path reuses
+    // the existing destination instead of transferring.
+    info_log!(Name, 2, "{} is uptodate", record_path.display());
     ::metadata::apply_file_metadata_if_changed(destination, metadata, existing, metadata_options)
         .map_err(crate::local_copy::map_metadata_error)?;
 

--- a/crates/transfer/src/receiver/directory/links.rs
+++ b/crates/transfer/src/receiver/directory/links.rs
@@ -8,9 +8,7 @@
 use std::fs;
 use std::path::Path;
 
-use logging::debug_log;
-#[cfg(unix)]
-use logging::info_log;
+use logging::{debug_log, info_log};
 
 use crate::generator::ItemFlags;
 use crate::receiver::ReceiverContext;
@@ -77,6 +75,9 @@ impl ReceiverContext {
                     // upstream: generator.c:1565 - symlink up-to-date, metadata only
                     let iflags = ItemFlags::from_raw(0);
                     let _ = self.emit_itemize(writer, &iflags, entry);
+                    // upstream: log.c log_item / send_directory NAME emissions
+                    // upstream: generator.c:1133 - "%s is uptodate" at INFO_GTE(NAME, 2)
+                    info_log!(Name, 2, "{} is uptodate", relative_path.display());
                     continue;
                 }
                 let _ = std::fs::remove_file(&link_path);
@@ -218,6 +219,15 @@ impl ReceiverContext {
                                 // upstream: hlink.c - hardlink already correct, metadata only
                                 let iflags = ItemFlags::from_raw(0);
                                 let _ = self.emit_itemize(writer, &iflags, entry);
+                                // upstream: hlink.c:223 - "%s is uptodate"
+                                // emitted at INFO_GTE(NAME, 2) when the
+                                // destination already hard-links to the leader.
+                                info_log!(
+                                    Name,
+                                    2,
+                                    "{} is uptodate",
+                                    relative_path.display()
+                                );
                                 continue;
                             }
                         }
@@ -254,6 +264,15 @@ impl ReceiverContext {
                             | ItemFlags::ITEM_IS_NEW,
                     );
                     let _ = self.emit_itemize(writer, &iflags, entry);
+                    // upstream: hlink.c:236 - "%s => %s" at INFO_GTE(NAME, 1)
+                    // when a hardlink follower is linked to its leader.
+                    info_log!(
+                        Name,
+                        1,
+                        "{} => {}",
+                        relative_path.display(),
+                        leader_path.display()
+                    );
                 }
             }
 
@@ -325,6 +344,83 @@ mod tests {
 
         let result = fast_io::hard_link(&src, &dst);
         assert!(result.is_err());
+    }
+
+    /// Verifies the hardlink `%s => %s` and `%s is uptodate` emission shapes
+    /// match upstream rsync byte-for-byte.
+    ///
+    /// upstream: log.c log_item / send_directory NAME emissions
+    /// upstream: hlink.c:223 (`"is uptodate"`) and hlink.c:236 (`"=>"`).
+    #[test]
+    fn hardlink_name_level_emission_shape_matches_upstream() {
+        use logging::{
+            DiagnosticEvent, InfoFlag, VerbosityConfig, drain_events, info_log, init,
+        };
+
+        let mut cfg = VerbosityConfig::default();
+        cfg.info.name = 2;
+        init(cfg);
+        let _ = drain_events();
+
+        let follower = std::path::Path::new("dir/follower");
+        let leader = std::path::Path::new("dir/leader");
+        info_log!(Name, 1, "{} => {}", follower.display(), leader.display());
+        info_log!(Name, 2, "{} is uptodate", follower.display());
+
+        let messages: Vec<String> = drain_events()
+            .into_iter()
+            .filter_map(|event| match event {
+                DiagnosticEvent::Info {
+                    flag: InfoFlag::Name,
+                    message,
+                    ..
+                } => Some(message),
+                _ => None,
+            })
+            .collect();
+
+        assert!(
+            messages.iter().any(|m| m == "dir/follower => dir/leader"),
+            "missing upstream hardlink => emission: {messages:?}"
+        );
+        assert!(
+            messages.iter().any(|m| m == "dir/follower is uptodate"),
+            "missing upstream `is uptodate` emission: {messages:?}"
+        );
+    }
+
+    /// Verifies NAME emissions are suppressed when the flag level is below
+    /// the emission level.
+    #[test]
+    fn hardlink_name_emissions_suppressed_at_level_zero() {
+        use logging::{
+            DiagnosticEvent, InfoFlag, VerbosityConfig, drain_events, info_log, init,
+        };
+
+        let cfg = VerbosityConfig::default();
+        init(cfg);
+        let _ = drain_events();
+
+        info_log!(Name, 1, "src => dst");
+        info_log!(Name, 2, "src is uptodate");
+
+        let messages: Vec<_> = drain_events()
+            .into_iter()
+            .filter(|event| {
+                matches!(
+                    event,
+                    DiagnosticEvent::Info {
+                        flag: InfoFlag::Name,
+                        ..
+                    }
+                )
+            })
+            .collect();
+
+        assert!(
+            messages.is_empty(),
+            "NAME emissions must be gated by InfoFlag::Name level: {messages:?}"
+        );
     }
 
     /// Verifies consistent availability: the function returns the same

--- a/crates/transfer/src/receiver/directory/links.rs
+++ b/crates/transfer/src/receiver/directory/links.rs
@@ -222,12 +222,7 @@ impl ReceiverContext {
                                 // upstream: hlink.c:223 - "%s is uptodate"
                                 // emitted at INFO_GTE(NAME, 2) when the
                                 // destination already hard-links to the leader.
-                                info_log!(
-                                    Name,
-                                    2,
-                                    "{} is uptodate",
-                                    relative_path.display()
-                                );
+                                info_log!(Name, 2, "{} is uptodate", relative_path.display());
                                 continue;
                             }
                         }
@@ -353,9 +348,7 @@ mod tests {
     /// upstream: hlink.c:223 (`"is uptodate"`) and hlink.c:236 (`"=>"`).
     #[test]
     fn hardlink_name_level_emission_shape_matches_upstream() {
-        use logging::{
-            DiagnosticEvent, InfoFlag, VerbosityConfig, drain_events, info_log, init,
-        };
+        use logging::{DiagnosticEvent, InfoFlag, VerbosityConfig, drain_events, info_log, init};
 
         let mut cfg = VerbosityConfig::default();
         cfg.info.name = 2;
@@ -393,9 +386,7 @@ mod tests {
     /// the emission level.
     #[test]
     fn hardlink_name_emissions_suppressed_at_level_zero() {
-        use logging::{
-            DiagnosticEvent, InfoFlag, VerbosityConfig, drain_events, info_log, init,
-        };
+        use logging::{DiagnosticEvent, InfoFlag, VerbosityConfig, drain_events, info_log, init};
 
         let cfg = VerbosityConfig::default();
         init(cfg);


### PR DESCRIPTION
## Summary

Wires upstream rsync's `--info=NAME` per-file action lines into oc-rsync's copy/link/del action sites. Refs #2159, parent G5 meta #2151.

- NAME 1 `"%s => %s"` for hard-link creation (upstream: `hlink.c:236`). Added at the three local-copy hard-link sites (`--link-dest`, cached-inode reuse, reference-directory link) and at the receiver's hardlink follower create site.
- NAME 2 `"%s is uptodate"` for already-current destinations (upstream: `rsync.c:672-676`, `generator.c:1010/1133`, `hlink.c:223`). Added at the local-copy metadata-only skip path, the local-copy reference-directory `Skip` decision, the receiver hardlink already-linked branch, and the receiver symlink up-to-date branch.
- Delete sites already emit `info_log!(Del, 1, "deleting ...")` matching upstream `log.c:864-868`; no NAME emission applies (upstream gates `log_delete` on `INFO_GTE(DEL, 1)`).

Each emission cites the upstream file and line. The `info_log!` macro gates formatting on the configured flag level so emissions cost zero when disabled.

## Test plan

- [x] Unit pinning tests in `crates/engine/src/local_copy/executor/file/copy/links.rs` for the NAME 1 `=>` and NAME 2 `is uptodate` shapes and level-gate suppression.
- [x] Unit pinning tests in `crates/transfer/src/receiver/directory/links.rs` covering the hardlink follower NAME 1/2 emissions and the level-zero suppression case.
- [ ] CI fmt+clippy, nextest (stable), Windows, macOS, Linux musl.