### PR TITLE
feat: wire --compress-threads=N through to zstd ZSTD_c_nbWorkers (3.4.2 parity)

### DIFF
--- a/crates/compress/Cargo.toml
+++ b/crates/compress/Cargo.toml
@@ -17,6 +17,10 @@ targets = ["x86_64-unknown-linux-gnu"]
 [features]
 default = ["zstd", "lz4", "zlib-ng"]
 zstd = ["dep:zstd"]
+# Enables zstd multithreaded compression (ZSTD_c_nbWorkers / --compress-threads).
+# Adds a small build-time C dependency in zstd-sys; off by default to keep
+# minimal builds lean. Enable to honour `--compress-threads=N > 0`.
+zstdmt = ["zstd", "zstd/zstdmt"]
 lz4 = ["dep:lz4_flex"]
 # zlib-ng backend (C library with SIMD: SSE2, AVX2, NEON) - matches upstream rsync performance
 zlib-ng = ["flate2/zlib-ng"]

--- a/crates/compress/src/strategy/impls.rs
+++ b/crates/compress/src/strategy/impls.rs
@@ -99,6 +99,7 @@ impl CompressionStrategy for ZlibStrategy {
 #[derive(Clone, Copy, Debug)]
 pub struct ZstdStrategy {
     level: CompressionLevel,
+    workers: Option<std::num::NonZeroU8>,
 }
 
 #[cfg(feature = "zstd")]
@@ -106,13 +107,21 @@ impl ZstdStrategy {
     /// Creates a zstd strategy at the given compression level.
     #[must_use]
     pub const fn new(level: CompressionLevel) -> Self {
-        Self { level }
+        Self { level, workers: None }
     }
 
     /// Creates a Zstd strategy with default compression level.
     #[must_use]
     pub const fn with_default_level() -> Self {
         Self::new(CompressionLevel::Default)
+    }
+
+    /// Applies a `--compress-threads=N` request, forwarded to
+    /// `ZSTD_c_nbWorkers`. upstream: `token.c:701`.
+    #[must_use]
+    pub const fn with_workers(mut self, workers: Option<std::num::NonZeroU8>) -> Self {
+        self.workers = workers;
+        self
     }
 }
 
@@ -127,7 +136,8 @@ impl Default for ZstdStrategy {
 impl CompressionStrategy for ZstdStrategy {
     fn compress(&self, input: &[u8], output: &mut Vec<u8>) -> io::Result<usize> {
         let initial_len = output.len();
-        let mut encoder = CountingZstdEncoder::with_sink(output, self.level)?;
+        let mut encoder =
+            CountingZstdEncoder::with_sink_workers(output, self.level, self.workers)?;
         encoder.write(input)?;
         let (returned_output, _bytes_written) = encoder.finish_into_inner()?;
 

--- a/crates/compress/src/strategy/impls.rs
+++ b/crates/compress/src/strategy/impls.rs
@@ -107,7 +107,10 @@ impl ZstdStrategy {
     /// Creates a zstd strategy at the given compression level.
     #[must_use]
     pub const fn new(level: CompressionLevel) -> Self {
-        Self { level, workers: None }
+        Self {
+            level,
+            workers: None,
+        }
     }
 
     /// Creates a Zstd strategy with default compression level.
@@ -136,8 +139,7 @@ impl Default for ZstdStrategy {
 impl CompressionStrategy for ZstdStrategy {
     fn compress(&self, input: &[u8], output: &mut Vec<u8>) -> io::Result<usize> {
         let initial_len = output.len();
-        let mut encoder =
-            CountingZstdEncoder::with_sink_workers(output, self.level, self.workers)?;
+        let mut encoder = CountingZstdEncoder::with_sink_workers(output, self.level, self.workers)?;
         encoder.write(input)?;
         let (returned_output, _bytes_written) = encoder.finish_into_inner()?;
 

--- a/crates/compress/src/zstd.rs
+++ b/crates/compress/src/zstd.rs
@@ -8,11 +8,20 @@
 //! accounting to reuse the same code paths as zlib compression.
 
 use std::io::{self, BufReader, IoSliceMut, Read, Write};
+use std::num::NonZeroU8;
 
 use crate::algorithm::CompressionAlgorithm;
 use crate::common::{CountingSink, CountingWriter};
 use crate::zlib::CompressionLevel;
 use zstd::stream::{read::Decoder as ZstdDecoder, write::Encoder as ZstdEncoder};
+
+/// Indicates whether this build has multithreaded zstd compression compiled in.
+///
+/// `true` when the `zstdmt` Cargo feature is enabled, allowing
+/// `--compress-threads=N` (N > 0) to engage real zstd worker threads. `false`
+/// otherwise, in which case requesting workers returns
+/// [`std::io::ErrorKind::Unsupported`] so the caller can fall back gracefully.
+pub const SUPPORTS_MULTITHREAD: bool = cfg!(feature = "zstdmt");
 
 /// Streaming encoder that records the number of compressed bytes produced.
 pub struct CountingZstdEncoder<W = CountingSink>
@@ -37,6 +46,16 @@ impl CountingZstdEncoder<CountingSink> {
     /// ```
     pub fn new(level: CompressionLevel) -> io::Result<Self> {
         Self::with_sink(CountingSink, level)
+    }
+
+    /// Like [`new`](Self::new) but plumbs `--compress-threads=N` through to
+    /// zstd's `ZSTD_c_nbWorkers`. `None` matches upstream's
+    /// `do_compression_threads = 0` default.
+    pub fn new_with_workers(
+        level: CompressionLevel,
+        workers: Option<NonZeroU8>,
+    ) -> io::Result<Self> {
+        Self::with_sink_workers(CountingSink, level, workers)
     }
 
     /// Completes the stream and returns the total number of compressed bytes generated.
@@ -65,8 +84,25 @@ where
     /// assert!(bytes_written > 0);
     /// ```
     pub fn with_sink(sink: W, level: CompressionLevel) -> io::Result<Self> {
+        Self::with_sink_workers(sink, level, None)
+    }
+
+    /// Like [`with_sink`](Self::with_sink) but plumbs `--compress-threads=N`
+    /// through to `ZSTD_c_nbWorkers`. `None` keeps zstd single-threaded
+    /// (matches upstream's `do_compression_threads = 0` default). Requesting
+    /// `Some(_)` when the `zstdmt` Cargo feature is disabled returns
+    /// `Unsupported` so callers can fall back gracefully.
+    ///
+    /// upstream: `token.c:701`, `options.c:89`.
+    pub fn with_sink_workers(
+        sink: W,
+        level: CompressionLevel,
+        workers: Option<NonZeroU8>,
+    ) -> io::Result<Self> {
         let writer = CountingWriter::new(sink);
-        let encoder = ZstdEncoder::new(writer, zstd_level(level)).map_err(io::Error::other)?;
+        let mut encoder =
+            ZstdEncoder::new(writer, zstd_level(level)).map_err(io::Error::other)?;
+        configure_workers(&mut encoder, workers)?;
         Ok(Self { inner: encoder })
     }
 
@@ -218,6 +254,26 @@ pub fn decompress_into(input: &[u8], output: &mut Vec<u8>) -> io::Result<usize> 
 #[must_use]
 pub const fn default_algorithm() -> CompressionAlgorithm {
     CompressionAlgorithm::Zstd
+}
+
+// upstream: token.c:701 - ZSTD_CCtx_setParameter(zstd_cctx, ZSTD_c_nbWorkers, do_compression_threads).
+fn configure_workers<W: Write>(
+    encoder: &mut ZstdEncoder<'static, CountingWriter<W>>,
+    workers: Option<NonZeroU8>,
+) -> io::Result<()> {
+    let Some(n) = workers else { return Ok(()) };
+    #[cfg(feature = "zstdmt")]
+    {
+        encoder.multithread(u32::from(n.get())).map_err(io::Error::other)
+    }
+    #[cfg(not(feature = "zstdmt"))]
+    {
+        let _ = (encoder, n);
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "zstd multithreaded compression requires the `zstdmt` Cargo feature",
+        ))
+    }
 }
 
 // upstream: token.c:init_compression_level() - ZSTD_CLEVEL_DEFAULT is 3,
@@ -528,6 +584,27 @@ mod tests {
         let decompressed = decompress_to_vec(&compressed).expect("decompress");
         let expected: Vec<u8> = tokens.iter().flat_map(|t| t.iter().copied()).collect();
         assert_eq!(decompressed, expected);
+    }
+
+    #[test]
+    fn workers_path_round_trip_and_smoke() {
+        // None matches upstream's `do_compression_threads = 0`. Some(_) either
+        // succeeds under `zstdmt` or returns Unsupported - never silently drops.
+        for workers in [None, NonZeroU8::new(4)] {
+            let result = CountingZstdEncoder::with_sink_workers(
+                Vec::new(),
+                CompressionLevel::Default,
+                workers,
+            );
+            if workers.is_some() && !SUPPORTS_MULTITHREAD {
+                assert_eq!(result.unwrap_err().kind(), io::ErrorKind::Unsupported);
+                continue;
+            }
+            let mut encoder = result.expect("encoder");
+            encoder.write(b"payload").unwrap();
+            let (compressed, _) = encoder.finish_into_inner().unwrap();
+            assert_eq!(decompress_to_vec(&compressed).unwrap(), b"payload");
+        }
     }
 
     #[test]

--- a/crates/compress/src/zstd.rs
+++ b/crates/compress/src/zstd.rs
@@ -598,10 +598,17 @@ mod tests {
                 workers,
             );
             if workers.is_some() && !SUPPORTS_MULTITHREAD {
-                assert_eq!(result.unwrap_err().kind(), io::ErrorKind::Unsupported);
+                let err = match result {
+                    Ok(_) => panic!("expected Unsupported for {workers:?}"),
+                    Err(e) => e,
+                };
+                assert_eq!(err.kind(), io::ErrorKind::Unsupported);
                 continue;
             }
-            let mut encoder = result.expect("encoder");
+            let mut encoder = match result {
+                Ok(e) => e,
+                Err(e) => panic!("encoder construction failed: {e}"),
+            };
             encoder.write(b"payload").unwrap();
             let (compressed, _) = encoder.finish_into_inner().unwrap();
             assert_eq!(decompress_to_vec(&compressed).unwrap(), b"payload");

--- a/crates/compress/src/zstd.rs
+++ b/crates/compress/src/zstd.rs
@@ -100,8 +100,7 @@ where
         workers: Option<NonZeroU8>,
     ) -> io::Result<Self> {
         let writer = CountingWriter::new(sink);
-        let mut encoder =
-            ZstdEncoder::new(writer, zstd_level(level)).map_err(io::Error::other)?;
+        let mut encoder = ZstdEncoder::new(writer, zstd_level(level)).map_err(io::Error::other)?;
         configure_workers(&mut encoder, workers)?;
         Ok(Self { inner: encoder })
     }
@@ -264,7 +263,9 @@ fn configure_workers<W: Write>(
     let Some(n) = workers else { return Ok(()) };
     #[cfg(feature = "zstdmt")]
     {
-        encoder.multithread(u32::from(n.get())).map_err(io::Error::other)
+        encoder
+            .multithread(u32::from(n.get()))
+            .map_err(io::Error::other)
     }
     #[cfg(not(feature = "zstdmt"))]
     {

--- a/crates/core/src/client/run/mod.rs
+++ b/crates/core/src/client/run/mod.rs
@@ -528,6 +528,9 @@ impl<'a> LocalCopyOptionsBuilder<'a> {
             .with_skip_compress(config.skip_compress().clone())
             .compress(config.compress())
             .with_compression_level_override(config.compression_level())
+            // upstream: options.c:89 do_compression_threads, plumbed into
+            // ZSTD_c_nbWorkers by token.c:701 when zstd is selected.
+            .with_compression_threads(config.compression_threads())
     }
 
     fn apply_metadata_preservation(

--- a/crates/engine/src/local_copy/compressor.rs
+++ b/crates/engine/src/local_copy/compressor.rs
@@ -212,7 +212,11 @@ mod tests {
         if compress::zstd::SUPPORTS_MULTITHREAD {
             assert!(some.is_ok());
         } else {
-            assert_eq!(some.unwrap_err().kind(), io::ErrorKind::Unsupported);
+            let err = match some {
+                Ok(_) => panic!("expected Unsupported when zstdmt is off"),
+                Err(e) => e,
+            };
+            assert_eq!(err.kind(), io::ErrorKind::Unsupported);
         }
     }
 

--- a/crates/engine/src/local_copy/compressor.rs
+++ b/crates/engine/src/local_copy/compressor.rs
@@ -25,6 +25,7 @@ pub enum ActiveCompressor {
 
 impl ActiveCompressor {
     /// Creates a compressor for `algorithm` using the provided compression `level`.
+    #[cfg(test)]
     pub fn new(algorithm: CompressionAlgorithm, level: CompressionLevel) -> io::Result<Self> {
         Self::new_with_workers(algorithm, level, None)
     }

--- a/crates/engine/src/local_copy/compressor.rs
+++ b/crates/engine/src/local_copy/compressor.rs
@@ -1,4 +1,5 @@
 use std::io;
+use std::num::NonZeroU8;
 
 use compress::algorithm::CompressionAlgorithm;
 use compress::zlib::{CompressionLevel, CountingZlibEncoder};
@@ -25,20 +26,37 @@ pub enum ActiveCompressor {
 impl ActiveCompressor {
     /// Creates a compressor for `algorithm` using the provided compression `level`.
     pub fn new(algorithm: CompressionAlgorithm, level: CompressionLevel) -> io::Result<Self> {
+        Self::new_with_workers(algorithm, level, None)
+    }
+
+    /// Creates a compressor with an optional zstd worker thread count.
+    /// `workers` only affects zstd; other algorithms ignore the value.
+    /// upstream: `token.c:701` plumbs `do_compression_threads` into
+    /// `ZSTD_c_nbWorkers`.
+    pub fn new_with_workers(
+        algorithm: CompressionAlgorithm,
+        level: CompressionLevel,
+        workers: Option<NonZeroU8>,
+    ) -> io::Result<Self> {
         match algorithm {
             CompressionAlgorithm::Zlib => Ok(Self::Zlib(CountingZlibEncoder::new(level))),
             #[cfg(feature = "lz4")]
             CompressionAlgorithm::Lz4 => Ok(Self::Lz4(CountingLz4Encoder::new(level))),
             #[cfg(feature = "zstd")]
-            CompressionAlgorithm::Zstd => CountingZstdEncoder::new(level).map(Self::Zstd),
+            CompressionAlgorithm::Zstd => {
+                CountingZstdEncoder::new_with_workers(level, workers).map(Self::Zstd)
+            }
             #[allow(unreachable_patterns)]
-            _ => Err(io::Error::new(
-                io::ErrorKind::InvalidInput,
-                format!(
-                    "compression algorithm {} is not supported",
-                    algorithm.name()
-                ),
-            )),
+            _ => {
+                let _ = workers;
+                Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!(
+                        "compression algorithm {} is not supported",
+                        algorithm.name()
+                    ),
+                ))
+            }
         }
     }
 
@@ -171,6 +189,31 @@ mod tests {
         assert!(compressor.is_ok());
         let compressor = compressor.unwrap();
         assert!(matches!(compressor, ActiveCompressor::Zstd(_)));
+    }
+
+    #[cfg(feature = "zstd")]
+    #[test]
+    fn active_compressor_zstd_workers_dispatches_to_encoder() {
+        // None produces a single-threaded encoder. Some(_) either succeeds
+        // (zstdmt on) or returns Unsupported (zstdmt off). Never silently drops.
+        let none = ActiveCompressor::new_with_workers(
+            CompressionAlgorithm::Zstd,
+            CompressionLevel::Default,
+            None,
+        )
+        .expect("workers=None");
+        assert!(matches!(none, ActiveCompressor::Zstd(_)));
+
+        let some = ActiveCompressor::new_with_workers(
+            CompressionAlgorithm::Zstd,
+            CompressionLevel::Default,
+            NonZeroU8::new(4),
+        );
+        if compress::zstd::SUPPORTS_MULTITHREAD {
+            assert!(some.is_ok());
+        } else {
+            assert_eq!(some.unwrap_err().kind(), io::ErrorKind::Unsupported);
+        }
     }
 
     #[cfg(feature = "zstd")]

--- a/crates/engine/src/local_copy/context_impl/options.rs
+++ b/crates/engine/src/local_copy/context_impl/options.rs
@@ -371,6 +371,10 @@ impl<'a> CopyContext<'a> {
         self.options.compression_algorithm()
     }
 
+    pub(super) const fn compression_threads(&self) -> Option<std::num::NonZeroU8> {
+        self.options.compression_threads()
+    }
+
     pub(super) const fn block_size_override(&self) -> Option<NonZeroU32> {
         self.options.block_size_override()
     }

--- a/crates/engine/src/local_copy/context_impl/transfer.rs
+++ b/crates/engine/src/local_copy/context_impl/transfer.rs
@@ -8,11 +8,13 @@ impl<'a> CopyContext<'a> {
             return Ok(None);
         }
 
-        ActiveCompressor::new(self.compression_algorithm(), self.compression_level())
-            .map(Some)
-            .map_err(|error| {
-                LocalCopyError::io("initialise compression", source, error)
-            })
+        ActiveCompressor::new_with_workers(
+            self.compression_algorithm(),
+            self.compression_level(),
+            self.compression_threads(),
+        )
+        .map(Some)
+        .map_err(|error| LocalCopyError::io("initialise compression", source, error))
     }
 
     fn register_limiter_bytes(&mut self, bytes: u64) {

--- a/crates/engine/src/local_copy/options/builder/definition.rs
+++ b/crates/engine/src/local_copy/options/builder/definition.rs
@@ -61,6 +61,7 @@ pub struct LocalCopyOptionsBuilder {
     pub(super) compression_algorithm: CompressionAlgorithm,
     pub(super) compression_level_override: Option<CompressionLevel>,
     pub(super) compression_level: CompressionLevel,
+    pub(super) compression_threads: Option<std::num::NonZeroU8>,
     pub(super) skip_compress: SkipCompressList,
 
     pub(super) open_noatime: bool,
@@ -193,6 +194,7 @@ impl LocalCopyOptionsBuilder {
             compression_algorithm: CompressionAlgorithm::default_algorithm(),
             compression_level_override: None,
             compression_level: CompressionLevel::Default,
+            compression_threads: None,
             skip_compress: SkipCompressList::default(),
             open_noatime: false,
             whole_file: None,

--- a/crates/engine/src/local_copy/options/builder/validation.rs
+++ b/crates/engine/src/local_copy/options/builder/validation.rs
@@ -122,6 +122,7 @@ impl LocalCopyOptionsBuilder {
             compression_algorithm: self.compression_algorithm,
             compression_level_override: self.compression_level_override,
             compression_level: self.compression_level,
+            compression_threads: self.compression_threads,
             skip_compress: self.skip_compress,
             open_noatime: self.open_noatime,
             whole_file: self.whole_file,

--- a/crates/engine/src/local_copy/options/compression.rs
+++ b/crates/engine/src/local_copy/options/compression.rs
@@ -2,6 +2,7 @@
 //! `--compress-choice`, `--compress-level`, skip-compress suffix list) on
 //! [`LocalCopyOptions`].
 
+use std::num::NonZeroU8;
 use std::path::Path;
 
 use compress::algorithm::CompressionAlgorithm;
@@ -61,6 +62,22 @@ impl LocalCopyOptions {
     pub fn with_skip_compress(mut self, list: SkipCompressList) -> Self {
         self.skip_compress = list;
         self
+    }
+
+    /// Applies a `--compress-threads=N` request, forwarded to
+    /// `ZSTD_c_nbWorkers` when zstd is the active codec.
+    /// upstream: `options.c:89` / `token.c:701`.
+    #[must_use]
+    #[doc(alias = "--compress-threads")]
+    pub const fn with_compression_threads(mut self, workers: Option<NonZeroU8>) -> Self {
+        self.compression_threads = workers;
+        self
+    }
+
+    /// Returns the configured worker count for zstd compression, if any.
+    #[must_use]
+    pub const fn compression_threads(&self) -> Option<NonZeroU8> {
+        self.compression_threads
     }
 
     /// Returns whether compression is enabled for payload handling.
@@ -233,6 +250,17 @@ mod tests {
             .compress(false)
             .with_compression_algorithm(CompressionAlgorithm::Zstd);
         assert!(opts.effective_compression_algorithm().is_none());
+    }
+
+    #[test]
+    fn with_compression_threads_round_trips() {
+        assert_eq!(LocalCopyOptions::new().compression_threads(), None);
+        let opts = LocalCopyOptions::new().with_compression_threads(NonZeroU8::new(4));
+        assert_eq!(opts.compression_threads(), NonZeroU8::new(4));
+        assert_eq!(
+            opts.with_compression_threads(None).compression_threads(),
+            None
+        );
     }
 
     #[test]

--- a/crates/engine/src/local_copy/options/types.rs
+++ b/crates/engine/src/local_copy/options/types.rs
@@ -6,7 +6,7 @@
 //! and accessor submodules.
 
 use std::ffi::OsString;
-use std::num::{NonZeroU32, NonZeroU64};
+use std::num::{NonZeroU8, NonZeroU32, NonZeroU64};
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime};
@@ -110,6 +110,9 @@ pub struct LocalCopyOptions {
     pub(super) compression_algorithm: CompressionAlgorithm,
     pub(super) compression_level_override: Option<CompressionLevel>,
     pub(super) compression_level: CompressionLevel,
+    /// Worker count for `ZSTD_c_nbWorkers`, only meaningful for zstd.
+    /// upstream: `token.c:701`, `options.c:89`.
+    pub(super) compression_threads: Option<NonZeroU8>,
     pub(super) skip_compress: SkipCompressList,
     pub(super) open_noatime: bool,
     pub(super) whole_file: Option<bool>,
@@ -265,6 +268,7 @@ impl LocalCopyOptions {
             compression_algorithm: CompressionAlgorithm::default_algorithm(),
             compression_level_override: None,
             compression_level: CompressionLevel::Default,
+            compression_threads: None,
             skip_compress: SkipCompressList::default(),
             open_noatime: false,
             whole_file: None,

--- a/crates/transfer/src/compressed_writer.rs
+++ b/crates/transfer/src/compressed_writer.rs
@@ -617,13 +617,17 @@ mod tests {
                     workers,
                 );
                 if workers.is_some() && !compress::zstd::SUPPORTS_MULTITHREAD {
-                    assert_eq!(
-                        result.expect_err("zstdmt disabled").kind(),
-                        std::io::ErrorKind::Unsupported
-                    );
+                    let err = match result {
+                        Ok(_) => panic!("expected Unsupported when zstdmt is off"),
+                        Err(e) => e,
+                    };
+                    assert_eq!(err.kind(), std::io::ErrorKind::Unsupported);
                     continue;
                 }
-                let mut writer = result.expect("encoder");
+                let mut writer = match result {
+                    Ok(w) => w,
+                    Err(e) => panic!("encoder construction failed: {e}"),
+                };
                 writer.write_all(data).unwrap();
                 writer.finish().unwrap();
                 assert_eq!(zstd_decompress(&buf).unwrap(), data);

--- a/crates/transfer/src/compressed_writer.rs
+++ b/crates/transfer/src/compressed_writer.rs
@@ -5,6 +5,7 @@
 //! is applied after multiplex framing.
 
 use std::io::{self, IoSlice, Write};
+use std::num::NonZeroU8;
 
 use compress::algorithm::CompressionAlgorithm;
 use compress::zlib::{CompressionLevel, CountingZlibEncoder};
@@ -60,6 +61,18 @@ impl<W: Write> CompressedWriter<W> {
         algorithm: CompressionAlgorithm,
         level: CompressionLevel,
     ) -> io::Result<Self> {
+        Self::with_workers(inner, algorithm, level, None)
+    }
+
+    /// Like [`new`](Self::new) but plumbs `--compress-threads=N` through to
+    /// `ZSTD_c_nbWorkers` when zstd is the active codec. `workers` is ignored
+    /// for zlib and LZ4. upstream: `token.c:701`.
+    pub fn with_workers(
+        inner: W,
+        algorithm: CompressionAlgorithm,
+        level: CompressionLevel,
+        workers: Option<NonZeroU8>,
+    ) -> io::Result<Self> {
         // Buffer size matching upstream rsync's IO_BUFFER_SIZE (32KB)
         // This reduces flush frequency and improves compression ratio
         const BUFFER_SIZE: usize = 32 * 1024;
@@ -77,10 +90,13 @@ impl<W: Write> CompressedWriter<W> {
             #[cfg(feature = "zstd")]
             CompressionAlgorithm::Zstd => {
                 let sink = Vec::with_capacity(BUFFER_SIZE);
-                EncoderVariant::Zstd(CountingZstdEncoder::with_sink(sink, level)?)
+                EncoderVariant::Zstd(CountingZstdEncoder::with_sink_workers(
+                    sink, level, workers,
+                )?)
             }
             #[allow(unreachable_patterns)]
             _ => {
+                let _ = workers;
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidInput,
                     format!(
@@ -584,6 +600,34 @@ mod tests {
 
             let decompressed = zstd_decompress(&buf).unwrap();
             assert_eq!(decompressed, data);
+        }
+
+        #[test]
+        fn with_workers_round_trip_and_smoke() {
+            // None matches upstream's `do_compression_threads = 0`. Some(_)
+            // either succeeds under `zstdmt` or returns Unsupported - never
+            // panic, never silently drop the setting.
+            let data = b"zstd workers test";
+            for workers in [None, std::num::NonZeroU8::new(4)] {
+                let mut buf = Vec::new();
+                let result = CompressedWriter::with_workers(
+                    &mut buf,
+                    CompressionAlgorithm::Zstd,
+                    CompressionLevel::Default,
+                    workers,
+                );
+                if workers.is_some() && !compress::zstd::SUPPORTS_MULTITHREAD {
+                    assert_eq!(
+                        result.expect_err("zstdmt disabled").kind(),
+                        std::io::ErrorKind::Unsupported
+                    );
+                    continue;
+                }
+                let mut writer = result.expect("encoder");
+                writer.write_all(data).unwrap();
+                writer.finish().unwrap();
+                assert_eq!(zstd_decompress(&buf).unwrap(), data);
+            }
         }
 
         #[test]

--- a/crates/transfer/src/writer/server.rs
+++ b/crates/transfer/src/writer/server.rs
@@ -4,6 +4,7 @@
 //! transitions where the global I/O buffer state is modified at runtime.
 
 use std::io::{self, IoSlice, Write};
+use std::num::NonZeroU8;
 use std::sync::{Arc, Mutex};
 
 use compress::algorithm::CompressionAlgorithm;
@@ -75,6 +76,17 @@ impl<W: Write> ServerWriter<W> {
         algorithm: CompressionAlgorithm,
         level: CompressionLevel,
     ) -> io::Result<Self> {
+        self.activate_compression_with_workers(algorithm, level, None)
+    }
+
+    /// Like [`activate_compression`](Self::activate_compression) but plumbs
+    /// `--compress-threads=N` into `ZSTD_c_nbWorkers`. upstream: `token.c:701`.
+    pub fn activate_compression_with_workers(
+        self,
+        algorithm: CompressionAlgorithm,
+        level: CompressionLevel,
+        workers: Option<NonZeroU8>,
+    ) -> io::Result<Self> {
         match self {
             Self::Multiplex(mux) => {
                 // upstream: io.c:write_buf() tees data to batch_fd at the
@@ -83,7 +95,7 @@ impl<W: Write> ServerWriter<W> {
                 // compressed wire bytes, matching upstream behavior. The
                 // batch header records do_compression=true so replay knows
                 // to decompress.
-                let compressed = CompressedWriter::new(mux, algorithm, level)?;
+                let compressed = CompressedWriter::with_workers(mux, algorithm, level, workers)?;
                 Ok(Self::Compressed(compressed))
             }
             Self::Plain(_) => Err(io::Error::new(


### PR DESCRIPTION
## Summary

PR #4095 added `--compress-threads=N` parsing and stored the value in
`ClientConfig::compression_threads`, but nothing actually consumed it.
This change wires the value through to the zstd encoder so the flag
takes effect.

- `compress::zstd::CountingZstdEncoder` gains `new_with_workers` /
  `with_sink_workers` constructors that call `multithread(n)` (i.e.
  `ZSTD_c_nbWorkers`). A new `SUPPORTS_MULTITHREAD` constant exposes
  whether the build has the underlying C support compiled in.
- `engine::ActiveCompressor::new_with_workers` and
  `transfer::CompressedWriter::with_workers` propagate the value
  end-to-end. `LocalCopyOptions` gains `compression_threads`, populated
  from `ClientConfig::compression_threads` in `apply_compression`.
- Multithreaded zstd lives behind a `zstdmt` Cargo feature on the
  `compress` crate (off by default to keep minimal builds lean and
  avoid a forced C build cost). Requesting workers without the
  feature returns `io::ErrorKind::Unsupported`, so callers fail loudly
  instead of silently discarding the user's setting.

Mirrors upstream:
- `options.c:89` - `do_compression_threads = 0` (single-threaded default).
- `token.c:701` - `ZSTD_CCtx_setParameter(zstd_cctx, ZSTD_c_nbWorkers, do_compression_threads)`.

Refs #2239, parent #2217.

## Test plan

- [x] `compress::zstd::workers_path_round_trip_and_smoke` -
      round-trips `None` and verifies `Some(_)` either compresses or
      surfaces `Unsupported`.
- [x] `engine::compressor::active_compressor_zstd_workers_dispatches_to_encoder` -
      same dispatch contract at the engine layer.
- [x] `transfer::compressed_writer::zstd_tests::with_workers_round_trip_and_smoke` -
      end-to-end through the multiplexed writer.
- [x] `engine::options::compression::with_compression_threads_round_trips` -
      builder round-trip for the new option field.
- [ ] CI green (fmt+clippy, nextest stable, Windows, macOS, Linux musl).