### PR TITLE
perf(engine): BufferPool byte-budget cap to bound memory under large buffers

### DIFF
--- a/crates/engine/src/local_copy/buffer_pool/global.rs
+++ b/crates/engine/src/local_copy/buffer_pool/global.rs
@@ -46,6 +46,13 @@ pub struct GlobalBufferPoolConfig {
     /// uncapped, matching its historical default. A value of `Some(0)` is
     /// treated as `None`.
     pub memory_cap: Option<usize>,
+    /// Optional byte-budget cap for buffers retained in the central pool.
+    ///
+    /// When `Some`, returned buffers are only kept if pooled bytes plus the
+    /// buffer's capacity stay within the budget. Otherwise the buffer is
+    /// deallocated. `None` preserves count-only behavior. A value of `Some(0)`
+    /// is treated as `None`.
+    pub pooled_bytes_budget: Option<u64>,
 }
 
 /// Environment variable for overriding the buffer pool size (number of buffers).
@@ -74,6 +81,7 @@ impl Default for GlobalBufferPoolConfig {
             max_buffers,
             buffer_size: super::super::COPY_BUFFER_SIZE,
             memory_cap: None,
+            pooled_bytes_budget: None,
         }
     }
 }
@@ -116,6 +124,7 @@ pub fn global_buffer_pool() -> Arc<BufferPool> {
 ///     max_buffers: 16,
 ///     buffer_size: 256 * 1024,
 ///     memory_cap: Some(512 * 1024 * 1024),
+///     pooled_bytes_budget: Some(32 * 1024 * 1024),
 /// }).expect("pool not yet initialized");
 /// ```
 pub fn init_global_buffer_pool(
@@ -124,6 +133,9 @@ pub fn init_global_buffer_pool(
     let mut pool = BufferPool::with_buffer_size(config.max_buffers, config.buffer_size);
     if let Some(cap) = config.memory_cap.filter(|&n| n > 0) {
         pool = pool.with_memory_cap(cap);
+    }
+    if let Some(budget) = config.pooled_bytes_budget.filter(|&n| n > 0) {
+        pool = pool.with_pooled_bytes_budget(budget);
     }
     let pool = Arc::new(pool);
     GLOBAL_BUFFER_POOL.set(pool).map_err(|_| config)
@@ -148,6 +160,7 @@ mod tests {
         assert_eq!(config.max_buffers, expected);
         assert_eq!(config.buffer_size, super::super::super::COPY_BUFFER_SIZE);
         assert!(config.memory_cap.is_none());
+        assert!(config.pooled_bytes_budget.is_none());
     }
 
     #[test]
@@ -156,10 +169,12 @@ mod tests {
             max_buffers: 32,
             buffer_size: 512 * 1024,
             memory_cap: Some(64 * 1024 * 1024),
+            pooled_bytes_budget: Some(16 * 1024 * 1024),
         };
         assert_eq!(config.max_buffers, 32);
         assert_eq!(config.buffer_size, 512 * 1024);
         assert_eq!(config.memory_cap, Some(64 * 1024 * 1024));
+        assert_eq!(config.pooled_bytes_budget, Some(16 * 1024 * 1024));
     }
 
     #[test]
@@ -310,6 +325,7 @@ mod tests {
             max_buffers: 99,
             buffer_size: 1024,
             memory_cap: None,
+            pooled_bytes_budget: None,
         };
         let result = init_global_buffer_pool(config);
         assert!(result.is_err());
@@ -319,6 +335,7 @@ mod tests {
         assert_eq!(returned.max_buffers, 99);
         assert_eq!(returned.buffer_size, 1024);
         assert!(returned.memory_cap.is_none());
+        assert!(returned.pooled_bytes_budget.is_none());
     }
 
     #[test]
@@ -327,6 +344,7 @@ mod tests {
             max_buffers: 4,
             buffer_size: 8 * 1024,
             memory_cap: Some(4 * 1024 * 1024),
+            pooled_bytes_budget: None,
         };
         assert_eq!(config.memory_cap, Some(4 * 1024 * 1024));
     }
@@ -338,6 +356,14 @@ mod tests {
         // assert the filter logic here; the actual pool init is exercised
         // by `init_after_lazy_init_returns_err` and integration tests.
         let cap: Option<usize> = Some(0).filter(|&n| n > 0);
+        assert!(cap.is_none());
+    }
+
+    #[test]
+    fn pooled_bytes_budget_zero_is_treated_as_unbounded() {
+        // The init helper filters out pooled_bytes_budget=Some(0) so the pool
+        // stays uncapped instead of panicking on `with_pooled_bytes_budget(0)`.
+        let cap: Option<u64> = Some(0).filter(|&n| n > 0);
         assert!(cap.is_none());
     }
 }

--- a/crates/engine/src/local_copy/buffer_pool/pool.rs
+++ b/crates/engine/src/local_copy/buffer_pool/pool.rs
@@ -109,6 +109,24 @@ pub struct BufferPool<A: BufferAllocator = DefaultAllocator> {
     /// every adaptive-resize evaluation. Thread-local cached buffers are
     /// not counted against this limit.
     soft_capacity: AtomicUsize,
+    /// Optional byte-budget cap for the central pool.
+    ///
+    /// When `Some`, a returned buffer is only admitted if
+    /// `pooled_bytes + buffer.capacity()` is within the budget. Otherwise
+    /// the buffer is deallocated. The cap is hybrid with `soft_capacity`:
+    /// whichever fires first prevents admission.
+    ///
+    /// Defending against very-large adaptive buffers that would otherwise
+    /// blow through the count-based cap. A value of `None` preserves the
+    /// historical count-only behavior.
+    pooled_bytes_budget: Option<u64>,
+    /// Total `capacity()` of buffers currently held in the central queue.
+    ///
+    /// Maintained alongside `central_count` so the byte-budget check on
+    /// return can be performed atomically. Always present so callers that
+    /// configure no byte cap pay only a single relaxed atomic update per
+    /// admit/pop - negligible compared to the cost of the queue operation.
+    pooled_bytes: AtomicU64,
     /// Size of each buffer in bytes.
     buffer_size: usize,
     /// Allocation strategy for creating and disposing of buffers.
@@ -184,6 +202,8 @@ impl BufferPool {
             buffers: ArrayQueue::new(queue_capacity(max_buffers)),
             central_count: AtomicUsize::new(0),
             soft_capacity: AtomicUsize::new(max_buffers),
+            pooled_bytes_budget: None,
+            pooled_bytes: AtomicU64::new(0),
             buffer_size: COPY_BUFFER_SIZE,
             allocator: DefaultAllocator,
             memory_cap: None,
@@ -210,6 +230,8 @@ impl BufferPool {
             buffers: ArrayQueue::new(queue_capacity(max_buffers)),
             central_count: AtomicUsize::new(0),
             soft_capacity: AtomicUsize::new(max_buffers),
+            pooled_bytes_budget: None,
+            pooled_bytes: AtomicU64::new(0),
             buffer_size,
             allocator: DefaultAllocator,
             memory_cap: None,
@@ -241,6 +263,8 @@ impl<A: BufferAllocator> BufferPool<A> {
             buffers: ArrayQueue::new(queue_capacity(max_buffers)),
             central_count: AtomicUsize::new(0),
             soft_capacity: AtomicUsize::new(max_buffers),
+            pooled_bytes_budget: None,
+            pooled_bytes: AtomicU64::new(0),
             buffer_size,
             allocator,
             memory_cap: None,
@@ -271,6 +295,33 @@ impl<A: BufferAllocator> BufferPool<A> {
     #[must_use]
     pub fn with_memory_cap(mut self, max_bytes: usize) -> Self {
         self.memory_cap = Some(MemoryCap::new(max_bytes));
+        self
+    }
+
+    /// Sets a byte-budget cap on the central pool's retained memory.
+    ///
+    /// When configured, a returned buffer is only kept if the total pooled
+    /// bytes plus the buffer's capacity would stay within `max_bytes`.
+    /// Otherwise the buffer is deallocated instead of pooled. This bounds
+    /// the pool's resident memory regardless of how large individual
+    /// adaptive buffers grow - a use case the count-based soft cap alone
+    /// cannot defend against.
+    ///
+    /// The cap is hybrid with the count-based soft capacity: whichever
+    /// fires first prevents admission. Thread-local cached buffers (one
+    /// slot per thread) are not counted against this budget since they
+    /// are conceptually "in use" by their owning thread.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `max_bytes` is zero.
+    #[must_use]
+    pub fn with_pooled_bytes_budget(mut self, max_bytes: u64) -> Self {
+        assert!(
+            max_bytes > 0,
+            "pooled bytes budget must be greater than zero"
+        );
+        self.pooled_bytes_budget = Some(max_bytes);
         self
     }
 
@@ -728,6 +779,16 @@ impl<A: BufferAllocator> BufferPool<A> {
     /// hard capacity is at least [`DEFAULT_QUEUE_CAPACITY`] >= any soft
     /// cap). On rejection (count >= capacity), the buffer is deallocated.
     fn admit_or_deallocate(&self, buffer: Vec<u8>, capacity: usize) {
+        let buffer_bytes = buffer.capacity() as u64;
+        // Byte-budget check: a single large buffer can blow through the
+        // count-based cap, so reject up-front when the budget is set and
+        // this buffer alone would exceed remaining headroom.
+        if let Some(budget) = self.pooled_bytes_budget
+            && self.pooled_bytes.load(Ordering::Relaxed).saturating_add(buffer_bytes) > budget
+        {
+            self.allocator.deallocate(buffer);
+            return;
+        }
         let mut current = self.central_count.load(Ordering::Relaxed);
         loop {
             if current >= capacity {
@@ -741,6 +802,7 @@ impl<A: BufferAllocator> BufferPool<A> {
                 Ordering::Relaxed,
             ) {
                 Ok(_) => {
+                    self.pooled_bytes.fetch_add(buffer_bytes, Ordering::Relaxed);
                     // Slot reserved - push must succeed because the queue's
                     // hard capacity is >= any value central_count can reach.
                     if let Err(buffer) = self.buffers.push(buffer) {
@@ -748,6 +810,7 @@ impl<A: BufferAllocator> BufferPool<A> {
                         // deallocate. Unreachable given the queue sizing
                         // invariant in `queue_capacity`.
                         self.central_count.fetch_sub(1, Ordering::Relaxed);
+                        self.pooled_bytes.fetch_sub(buffer_bytes, Ordering::Relaxed);
                         self.allocator.deallocate(buffer);
                     }
                     return;
@@ -768,6 +831,8 @@ impl<A: BufferAllocator> BufferPool<A> {
         match self.buffers.pop() {
             Some(buffer) => {
                 self.central_count.fetch_sub(1, Ordering::Relaxed);
+                self.pooled_bytes
+                    .fetch_sub(buffer.capacity() as u64, Ordering::Relaxed);
                 self.total_hits.fetch_add(1, Ordering::Relaxed);
                 if let Some(pressure) = &self.pressure {
                     pressure.record_hit();
@@ -814,6 +879,8 @@ impl<A: BufferAllocator> BufferPool<A> {
                     match self.buffers.pop() {
                         Some(buf) => {
                             self.central_count.fetch_sub(1, Ordering::Relaxed);
+                            self.pooled_bytes
+                                .fetch_sub(buf.capacity() as u64, Ordering::Relaxed);
                             self.allocator.deallocate(buf);
                         }
                         None => break,
@@ -873,6 +940,22 @@ impl<A: BufferAllocator> BufferPool<A> {
     /// Returns the configured memory cap in bytes, or `None` if uncapped.
     pub fn memory_cap(&self) -> Option<usize> {
         self.memory_cap.as_ref().map(|cap| cap.limit())
+    }
+
+    /// Returns the configured byte budget for retained buffers, or `None` if uncapped.
+    #[must_use]
+    pub fn pooled_bytes_budget(&self) -> Option<u64> {
+        self.pooled_bytes_budget
+    }
+
+    /// Returns the total `capacity()` of buffers currently held in the central queue.
+    ///
+    /// Excludes thread-local cached buffers. Primarily useful for testing
+    /// and observability. The returned value is a relaxed snapshot that
+    /// may briefly race with concurrent admissions and pops.
+    #[must_use]
+    pub fn pooled_bytes(&self) -> u64 {
+        self.pooled_bytes.load(Ordering::Relaxed)
     }
 
     /// Returns `true` if adaptive resizing is enabled.

--- a/crates/engine/src/local_copy/buffer_pool/pool.rs
+++ b/crates/engine/src/local_copy/buffer_pool/pool.rs
@@ -784,7 +784,11 @@ impl<A: BufferAllocator> BufferPool<A> {
         // count-based cap, so reject up-front when the budget is set and
         // this buffer alone would exceed remaining headroom.
         if let Some(budget) = self.pooled_bytes_budget
-            && self.pooled_bytes.load(Ordering::Relaxed).saturating_add(buffer_bytes) > budget
+            && self
+                .pooled_bytes
+                .load(Ordering::Relaxed)
+                .saturating_add(buffer_bytes)
+                > budget
         {
             self.allocator.deallocate(buffer);
             return;

--- a/crates/engine/src/local_copy/buffer_pool/tests.rs
+++ b/crates/engine/src/local_copy/buffer_pool/tests.rs
@@ -2330,8 +2330,7 @@ fn pooled_bytes_budget_drops_oversized_buffers() {
     // Tight byte budget (16 KB) with generous count cap (8). Holding two
     // 1 MB adaptive buffers concurrently and dropping both forces one
     // through the central admission path. The byte budget rejects it.
-    let pool =
-        Arc::new(BufferPool::with_buffer_size(8, 4096).with_pooled_bytes_budget(16 * 1024));
+    let pool = Arc::new(BufferPool::with_buffer_size(8, 4096).with_pooled_bytes_budget(16 * 1024));
 
     let b1 = BufferPool::acquire_adaptive_from(Arc::clone(&pool), 300 * 1024 * 1024);
     let b2 = BufferPool::acquire_adaptive_from(Arc::clone(&pool), 300 * 1024 * 1024);

--- a/crates/engine/src/local_copy/buffer_pool/tests.rs
+++ b/crates/engine/src/local_copy/buffer_pool/tests.rs
@@ -2324,3 +2324,94 @@ fn controlled_acquire_end_to_end_feedback_loop() {
         "buffer size should stabilize in feedback loop: min={min_s}, max={max_s}, mean={mean}, range_pct={range_pct:.2}"
     );
 }
+
+#[test]
+fn pooled_bytes_budget_drops_oversized_buffers() {
+    // Tight byte budget (16 KB) with generous count cap (8). Holding two
+    // 1 MB adaptive buffers concurrently and dropping both forces one
+    // through the central admission path. The byte budget rejects it.
+    let pool =
+        Arc::new(BufferPool::with_buffer_size(8, 4096).with_pooled_bytes_budget(16 * 1024));
+
+    let b1 = BufferPool::acquire_adaptive_from(Arc::clone(&pool), 300 * 1024 * 1024);
+    let b2 = BufferPool::acquire_adaptive_from(Arc::clone(&pool), 300 * 1024 * 1024);
+    assert!(b1.capacity() >= ADAPTIVE_BUFFER_HUGE);
+    assert!(b2.capacity() >= ADAPTIVE_BUFFER_HUGE);
+    drop(b1);
+    drop(b2);
+
+    // Central queue must reject the oversize buffer; the TLS slot may
+    // hold the other but it is not counted against `pooled_bytes`.
+    assert_eq!(pool.available(), 0);
+    assert!(
+        pool.pooled_bytes() <= pool.pooled_bytes_budget().unwrap(),
+        "pooled_bytes={} exceeded budget={}",
+        pool.pooled_bytes(),
+        pool.pooled_bytes_budget().unwrap()
+    );
+}
+
+#[test]
+fn pooled_bytes_budget_high_retains_normally() {
+    // Generous byte budget admits buffers up to the count cap. Hold 16
+    // buffers concurrently to bypass the single-slot TLS cache and
+    // exercise central admission for every drop.
+    let pool = Arc::new(
+        BufferPool::with_buffer_size(4, 4096).with_pooled_bytes_budget(1024 * 1024),
+    );
+    let guards: Vec<_> = (0..16)
+        .map(|_| BufferPool::acquire_from(Arc::clone(&pool)))
+        .collect();
+    drop(guards);
+
+    // The count cap fires before the byte budget. All four slots stay
+    // populated and pooled_bytes equals 4 * 4096.
+    assert_eq!(pool.available(), 4);
+    assert!(pool.pooled_bytes() <= pool.pooled_bytes_budget().unwrap());
+    assert!(pool.pooled_bytes() >= 4 * 4096);
+}
+
+#[test]
+fn count_cap_still_enforced_without_byte_budget() {
+    // Regression: with no byte budget the historical count-only behavior
+    // remains in effect. Three returns into a 2-slot pool retain two.
+    let pool = BufferPool::new(2);
+    assert!(pool.pooled_bytes_budget().is_none());
+
+    let b1 = pool.acquire();
+    let b2 = pool.acquire();
+    let b3 = pool.acquire();
+    drop(b1);
+    drop(b2);
+    drop(b3);
+
+    assert_eq!(pool.available(), 2);
+}
+
+#[test]
+fn pooled_bytes_tracks_admission_and_pop() {
+    let pool = Arc::new(BufferPool::with_buffer_size(4, 4096));
+    assert_eq!(pool.pooled_bytes(), 0);
+
+    // Burst-acquire to force all returns through the central queue.
+    let guards: Vec<_> = (0..16)
+        .map(|_| BufferPool::acquire_from(Arc::clone(&pool)))
+        .collect();
+    drop(guards);
+    assert_eq!(pool.available(), 4);
+    assert!(pool.pooled_bytes() >= 4 * 4096);
+
+    // Draining the queue must decrement pooled_bytes back to zero.
+    let drained: Vec<_> = (0..4)
+        .map(|_| BufferPool::acquire_from(Arc::clone(&pool)))
+        .collect();
+    assert_eq!(pool.available(), 0);
+    assert_eq!(pool.pooled_bytes(), 0);
+    drop(drained);
+}
+
+#[test]
+#[should_panic(expected = "pooled bytes budget must be greater than zero")]
+fn pooled_bytes_budget_rejects_zero() {
+    let _ = BufferPool::new(4).with_pooled_bytes_budget(0);
+}

--- a/crates/engine/src/local_copy/buffer_pool/tests.rs
+++ b/crates/engine/src/local_copy/buffer_pool/tests.rs
@@ -2355,9 +2355,8 @@ fn pooled_bytes_budget_high_retains_normally() {
     // Generous byte budget admits buffers up to the count cap. Hold 16
     // buffers concurrently to bypass the single-slot TLS cache and
     // exercise central admission for every drop.
-    let pool = Arc::new(
-        BufferPool::with_buffer_size(4, 4096).with_pooled_bytes_budget(1024 * 1024),
-    );
+    let pool =
+        Arc::new(BufferPool::with_buffer_size(4, 4096).with_pooled_bytes_budget(1024 * 1024));
     let guards: Vec<_> = (0..16)
         .map(|_| BufferPool::acquire_from(Arc::clone(&pool)))
         .collect();

--- a/crates/engine/src/local_copy/buffer_pool/tests.rs
+++ b/crates/engine/src/local_copy/buffer_pool/tests.rs
@@ -2334,8 +2334,11 @@ fn pooled_bytes_budget_drops_oversized_buffers() {
 
     let b1 = BufferPool::acquire_adaptive_from(Arc::clone(&pool), 300 * 1024 * 1024);
     let b2 = BufferPool::acquire_adaptive_from(Arc::clone(&pool), 300 * 1024 * 1024);
-    assert!(b1.capacity() >= ADAPTIVE_BUFFER_HUGE);
-    assert!(b2.capacity() >= ADAPTIVE_BUFFER_HUGE);
+    // BufferGuard derefs to &[u8]; the slice length reflects the requested
+    // adaptive size and is sufficient to confirm the fixture before exercising
+    // the budget rejection path on drop.
+    assert!(b1.len() >= ADAPTIVE_BUFFER_HUGE);
+    assert!(b2.len() >= ADAPTIVE_BUFFER_HUGE);
     drop(b1);
     drop(b2);
 


### PR DESCRIPTION
## Summary

- Add optional `pooled_bytes_budget` field to `BufferPool` that caps the total `capacity()` of buffers retained in the central queue.
- Hybrid with existing count-based soft cap: whichever fires first prevents admission. Defends against very-large adaptive buffers (e.g. 1 MB `ADAPTIVE_BUFFER_HUGE`) blowing through the count-only ceiling.
- Threaded through `GlobalBufferPoolConfig::pooled_bytes_budget`; default `None` preserves the historical count-only behavior so existing callers see no change.
- Atomic `pooled_bytes` counter updated on every admit and pop; relaxed ordering keeps the overhead at one extra add/sub per central-queue operation.

Refs #2245.

## Test plan

- [ ] `pooled_bytes_budget_drops_oversized_buffers`: 1 MB buffers + 16 KB budget; central queue stays empty and pooled bytes stay within budget.
- [ ] `pooled_bytes_budget_high_retains_normally`: generous budget; count cap fires first and pool fills its slots.
- [ ] `count_cap_still_enforced_without_byte_budget`: regression test for existing count-only path.
- [ ] `pooled_bytes_tracks_admission_and_pop`: pooled-byte counter increments on admit and decrements on pop.
- [ ] `pooled_bytes_budget_rejects_zero`: `with_pooled_bytes_budget(0)` panics.
- [ ] `pooled_bytes_budget_zero_is_treated_as_unbounded` in `global.rs`: filter logic mirrors `memory_cap=Some(0)`.