### PR TITLE
feat(generator): instrument first-byte latency in send_file_list (INC_RECURSE I1)

### DIFF
--- a/crates/transfer/src/generator/mod.rs
+++ b/crates/transfer/src/generator/mod.rs
@@ -89,7 +89,7 @@ mod tests;
 mod transfer;
 
 use std::path::PathBuf;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use ::filters::FilterChain;
 use protocol::codec::{MonotonicNdxWriter, NdxCodecEnum};
@@ -228,6 +228,12 @@ struct TransferTiming {
     flist_xfer_start: Option<Instant>,
     /// When file list transfer ended (for flist_xfertime statistic).
     flist_xfer_end: Option<Instant>,
+    /// Elapsed time from `send_file_list` entry to the first byte hitting the
+    /// wire. Diagnostic counter for sender-side INC_RECURSE (#2089) - tracks
+    /// how long the receiver waits before observing any file list data.
+    ///
+    /// upstream: flist.c send_file_list / send_dir_name first-byte timing
+    flist_first_byte_latency: Option<Duration>,
     /// Total bytes read from network during transfer (for total_read statistic).
     total_bytes_read: u64,
 }
@@ -240,6 +246,7 @@ impl TransferTiming {
             flist_build_end: None,
             flist_xfer_start: None,
             flist_xfer_end: None,
+            flist_first_byte_latency: None,
             total_bytes_read: 0,
         }
     }
@@ -815,6 +822,13 @@ pub struct GeneratorStats {
     pub flist_buildtime_ms: u64,
     /// File list transfer time in milliseconds (upstream: `stats.flist_xfertime`).
     pub flist_xfertime_ms: u64,
+    /// Elapsed time from `send_file_list` entry to the first byte written to
+    /// the wire. Diagnostic counter for sender-side INC_RECURSE (#2089).
+    ///
+    /// `None` when `send_file_list` was never invoked or no bytes were written.
+    ///
+    /// upstream: flist.c send_file_list / send_dir_name first-byte timing
+    pub flist_first_byte_latency: Option<Duration>,
     /// Accumulated deletion statistics from the receiver via `NDX_DEL_STATS`.
     pub delete_stats: DeleteStats,
     /// Accumulated I/O error flags from file list building and transfer.

--- a/crates/transfer/src/generator/protocol_io.rs
+++ b/crates/transfer/src/generator/protocol_io.rs
@@ -10,10 +10,10 @@
 //! - `uidlist.c:407-414` - `send_id_lists()` for name-based ownership
 //! - `sender.c:120` - `receive_sums()` reads signature blocks
 
-use std::io::{self, Read, Write};
-use std::time::Instant;
+use std::io::{self, IoSlice, Read, Write};
+use std::time::{Duration, Instant};
 
-use logging::{PhaseTimer, debug_log};
+use logging::{PhaseTimer, debug_log, info_log};
 use protocol::CompatibilityFlags;
 use protocol::codec::{NDX_FLIST_EOF, NDX_FLIST_OFFSET, NdxCodec, NdxCodecEnum};
 use protocol::wire::SignatureBlock;
@@ -206,7 +206,8 @@ impl GeneratorContext {
     pub fn send_file_list<W: Write>(&mut self, writer: &mut W) -> io::Result<usize> {
         let _t = PhaseTimer::new("file-list-send");
         // upstream: stats.flist_xfertime
-        self.timing.flist_xfer_start = Some(Instant::now());
+        let entry_instant = Instant::now();
+        self.timing.flist_xfer_start = Some(entry_instant);
 
         let mut flist_writer = self.build_flist_writer();
 
@@ -220,6 +221,11 @@ impl GeneratorContext {
             .map_or(0, |&(_, ndx_start)| ndx_start);
         flist_writer.set_first_ndx(initial_ndx_start);
 
+        // Wrap the wire writer in a first-byte latency probe. Cost is one
+        // branch per buffered write call - no per-entry sampling.
+        // upstream: flist.c send_file_list / send_dir_name first-byte timing
+        let mut probed = FirstByteWriter::new(writer, entry_instant);
+
         // When INC_RECURSE, only send initial segment entries; the rest
         // are sent via the SegmentScheduler during the transfer loop.
         let count = self
@@ -229,7 +235,7 @@ impl GeneratorContext {
         for i in 0..count {
             let entry = &self.file_list[i];
             self.prepare_pending_acl(entry, i, &mut flist_writer);
-            flist_writer.write_entry(writer, entry)?;
+            flist_writer.write_entry(&mut probed, entry)?;
         }
 
         // upstream: flist.c:2518 - write io_error with end marker (SAFE_FILE_LIST)
@@ -238,14 +244,48 @@ impl GeneratorContext {
         } else {
             None
         };
-        flist_writer.write_end(writer, io_error_for_end)?;
-        writer.flush()?;
+        flist_writer.write_end(&mut probed, io_error_for_end)?;
+        probed.flush()?;
+
+        let first_byte_latency = probed.first_byte_latency();
 
         // upstream: flist.c:send_file_entry() uses static variables - cache writer
         // to preserve compression state across sub-lists.
         self.incremental.flist_writer_cache = Some(flist_writer);
 
         self.timing.flist_xfer_end = Some(Instant::now());
+        self.timing.flist_first_byte_latency = first_byte_latency;
+
+        if let Some(latency) = first_byte_latency {
+            // INC_RECURSE diagnostic I1: time from function entry to first
+            // wire byte. Surfaced at -vv (info=flist1) and -v --info=stats3.
+            info_log!(
+                Flist,
+                1,
+                "send_file_list first-byte latency: {} us",
+                latency.as_micros()
+            );
+            info_log!(
+                Stats,
+                3,
+                "file list first-byte latency: {} us",
+                latency.as_micros()
+            );
+            debug_log!(
+                Flist,
+                2,
+                "send_file_list first-byte latency: {:?} ({} entries)",
+                latency,
+                count
+            );
+            #[cfg(feature = "tracing")]
+            ::tracing::info!(
+                target: "rsync::flist",
+                latency_us = latency.as_micros() as u64,
+                entries = count,
+                "send_file_list first-byte latency"
+            );
+        }
 
         Ok(self.file_list.len())
     }
@@ -431,5 +471,58 @@ pub fn calculate_duration_ms(start: Option<Instant>, end: Option<Instant>) -> u6
     match (start, end) {
         (Some(s), Some(e)) => e.duration_since(s).as_millis() as u64,
         _ => 0,
+    }
+}
+
+/// `Write` adapter that records the elapsed time until the first non-empty
+/// write reaches the underlying writer.
+///
+/// Used by [`GeneratorContext::send_file_list`] to instrument the gap between
+/// function entry and the first wire byte. This is INC_RECURSE diagnostic
+/// counter I1 (#2196) - the receiver-visible startup latency of the file
+/// list stream.
+///
+/// upstream: flist.c send_file_list / send_dir_name first-byte timing
+struct FirstByteWriter<'w, W: Write> {
+    inner: &'w mut W,
+    entry: Instant,
+    first_byte_latency: Option<Duration>,
+}
+
+impl<'w, W: Write> FirstByteWriter<'w, W> {
+    fn new(inner: &'w mut W, entry: Instant) -> Self {
+        Self {
+            inner,
+            entry,
+            first_byte_latency: None,
+        }
+    }
+
+    fn first_byte_latency(&self) -> Option<Duration> {
+        self.first_byte_latency
+    }
+
+    fn record(&mut self, n: usize) {
+        if n > 0 && self.first_byte_latency.is_none() {
+            self.first_byte_latency = Some(self.entry.elapsed());
+        }
+    }
+}
+
+impl<W: Write> Write for FirstByteWriter<'_, W> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let n = self.inner.write(buf)?;
+        self.record(n);
+        Ok(n)
+    }
+
+    fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
+        let n = self.inner.write_vectored(bufs)?;
+        self.record(n);
+        Ok(n)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.inner.flush()
     }
 }

--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -206,6 +206,50 @@ fn send_single_file_entry() {
 }
 
 #[test]
+fn send_file_list_records_first_byte_latency() {
+    // INC_RECURSE diagnostic I1 (#2196): the first-byte timer must fire when
+    // send_file_list writes any wire bytes.
+    let (_handshake, mut ctx) = test_generator();
+    let entry = protocol::flist::FileEntry::new_file("probe.txt".into(), 42, 0o644);
+    ctx.file_list.push(entry);
+
+    let mut output = Vec::new();
+    ctx.send_file_list(&mut output).unwrap();
+
+    let latency = ctx
+        .timing
+        .flist_first_byte_latency
+        .expect("first-byte latency must be recorded when wire bytes are written");
+    // Instant::elapsed() is monotonic and the gap from entry through
+    // build_flist_writer + write_entry + flush spans many syscalls; the
+    // sampled duration is non-zero on every supported platform.
+    assert!(
+        latency > std::time::Duration::ZERO,
+        "first-byte latency should be a non-zero elapsed duration, got {latency:?}"
+    );
+    assert!(
+        ctx.timing.flist_xfer_start.is_some(),
+        "flist_xfer_start must also be set"
+    );
+}
+
+#[test]
+fn send_file_list_first_byte_latency_recorded_for_empty_list() {
+    // Even with no entries, send_file_list writes a one-byte end marker, so
+    // the first-byte probe should still fire.
+    let (_handshake, mut ctx) = test_generator();
+
+    let mut output = Vec::new();
+    ctx.send_file_list(&mut output).unwrap();
+
+    assert_eq!(output, vec![0u8]);
+    assert!(
+        ctx.timing.flist_first_byte_latency.is_some(),
+        "first-byte latency should be recorded once the end marker is flushed"
+    );
+}
+
+#[test]
 fn build_and_send_round_trip() {
     use crate::receiver::ReceiverContext;
 

--- a/crates/transfer/src/generator/transfer.rs
+++ b/crates/transfer/src/generator/transfer.rs
@@ -819,6 +819,7 @@ impl GeneratorContext {
             bytes_read: self.timing.total_bytes_read,
             flist_buildtime_ms: flist_buildtime,
             flist_xfertime_ms: flist_xfertime,
+            flist_first_byte_latency: self.timing.flist_first_byte_latency,
             delete_stats: self.delete_stats,
             io_error: self.io_error,
         })


### PR DESCRIPTION
## Summary

Adds INC_RECURSE diagnostic counter **I1** from the sender-side INC_RECURSE re-enablement plan (#2089): the elapsed time from `send_file_list()` entry to the first wire byte the receiver can observe.

A lightweight `FirstByteWriter` wraps the wire writer for the duration of `send_file_list`. It samples `Instant::now()` exactly once - on the first non-empty write - and records the resulting `Duration`. Per-entry overhead is one already-populated `Option` check; there is no per-entry sampling.

The latency is surfaced through every existing diagnostic channel:

- `TransferTiming.flist_first_byte_latency` (internal field on `GeneratorContext`)
- `GeneratorStats.flist_first_byte_latency` (public API for downstream consumers)
- `info_log!(Flist, 1, ...)` - visible at `-v --info=flist1`
- `info_log!(Stats, 3, ...)` - visible at `-v --info=stats3` per the task spec
- `debug_log!(Flist, 2, ...)` with the entry count for context
- `tracing::info!(target = "rsync::flist", latency_us, entries, ...)` when the `tracing` feature is enabled

upstream: `flist.c` `send_file_list` / `send_dir_name` first-byte timing.

Closes #2196. Refs parent #2089.

## Test plan

- [x] Added `send_file_list_records_first_byte_latency`: pushes one synthesized `FileEntry`, calls `send_file_list`, asserts `flist_first_byte_latency` is `Some(d)` with `d > Duration::ZERO`.
- [x] Added `send_file_list_first_byte_latency_recorded_for_empty_list`: verifies the probe still fires when only the one-byte end marker is written.
- [x] `git diff --stat` reports 160 insertions / 8 deletions across 4 files, under the 200-line budget.
- [ ] CI: fmt + clippy, nextest (stable), Windows, macOS, Linux musl.