### PR TITLE
feat(transfer): wire --debug=HLINK producer emissions (3.4.1 parity)

### DIFF
--- a/crates/protocol/src/flist/hardlink/mod.rs
+++ b/crates/protocol/src/flist/hardlink/mod.rs
@@ -15,7 +15,12 @@
 mod table;
 #[cfg(test)]
 mod tests;
+mod trace;
 mod types;
 
 pub use table::HardlinkTable;
+pub use trace::{
+    trace_found_flist_match, trace_hashtable_for_dev, trace_leader_is, trace_looking_for_leader,
+    trace_virtual_first, trace_waiting_for,
+};
 pub use types::{DevIno, HardlinkEntry, HardlinkLookup};

--- a/crates/protocol/src/flist/hardlink/table.rs
+++ b/crates/protocol/src/flist/hardlink/table.rs
@@ -11,7 +11,9 @@
 
 use rustc_hash::FxHashMap;
 
+use super::trace::trace_hashtable_for_dev;
 use super::types::{DevIno, HardlinkEntry, HardlinkLookup};
+use crate::flist::trace::ProcessRole;
 
 /// Table for tracking hardlinks by (dev, ino) pairs.
 ///
@@ -37,6 +39,11 @@ use super::types::{DevIno, HardlinkEntry, HardlinkLookup};
 pub struct HardlinkTable {
     /// Map from (dev, ino) to hardlink entry.
     entries: FxHashMap<DevIno, HardlinkEntry>,
+    /// Devices for which the per-device bucket has already been announced via
+    /// `--debug=HLINK` level 3.
+    ///
+    /// upstream: hlink.c:74-81 - one HLINK,3 emission per new device.
+    announced_devices: FxHashMap<u64, ()>,
 }
 
 impl HardlinkTable {
@@ -51,6 +58,17 @@ impl HardlinkTable {
     pub fn with_capacity(capacity: usize) -> Self {
         Self {
             entries: FxHashMap::with_capacity_and_hasher(capacity, Default::default()),
+            announced_devices: FxHashMap::default(),
+        }
+    }
+
+    /// Emits the `--debug=HLINK` level 3 hashtable-creation message the first
+    /// time a device is observed, matching upstream `idev_find()`.
+    ///
+    /// upstream: hlink.c:74-81 - one HLINK,3 emission per new device.
+    pub fn announce_device(&mut self, role: ProcessRole, dev: u64) {
+        if self.announced_devices.insert(dev, ()).is_none() {
+            trace_hashtable_for_dev(role, dev);
         }
     }
 
@@ -104,5 +122,6 @@ impl HardlinkTable {
     /// Clears all entries from the table.
     pub fn clear(&mut self) {
         self.entries.clear();
+        self.announced_devices.clear();
     }
 }

--- a/crates/protocol/src/flist/hardlink/trace.rs
+++ b/crates/protocol/src/flist/hardlink/trace.rs
@@ -46,7 +46,14 @@ pub fn trace_hashtable_for_dev(role: ProcessRole, dev: u64) {
 /// upstream: hlink.c:305 - `"hlink for %d (%s,%d): virtual first"`.
 #[inline]
 pub fn trace_virtual_first(ndx: i32, name: &str, gnum: i32) {
-    debug_log!(Hlink, 2, "hlink for {} ({},{}): virtual first", ndx, name, gnum);
+    debug_log!(
+        Hlink,
+        2,
+        "hlink for {} ({},{}): virtual first",
+        ndx,
+        name,
+        gnum
+    );
 }
 
 /// Traces a follower deferred while the leader transfer is in flight (level 2).

--- a/crates/protocol/src/flist/hardlink/trace.rs
+++ b/crates/protocol/src/flist/hardlink/trace.rs
@@ -1,0 +1,179 @@
+//! `--debug=HLINK` producer emissions for hardlink processing.
+//!
+//! Matches upstream rsync's `hlink.c` DEBUG_GTE(HLINK, N) output byte-for-byte
+//! so wire-comparable diagnostics align across implementations.
+//!
+//! # Upstream Reference
+//!
+//! - upstream: hlink.c HLINK debug emissions (`idev_find`, `hard_link_check`).
+
+use logging::debug_log;
+
+use crate::flist::trace::ProcessRole;
+
+/// Big-number formatting matching upstream's `big_num()` helper used in HLINK
+/// messages for device identifiers.
+fn big_num(value: u64) -> String {
+    let s = value.to_string();
+    let bytes = s.as_bytes();
+    let mut out = String::with_capacity(bytes.len() + bytes.len() / 3);
+    let len = bytes.len();
+    for (i, b) in bytes.iter().enumerate() {
+        if i > 0 && (len - i) % 3 == 0 {
+            out.push(',');
+        }
+        out.push(*b as char);
+    }
+    out
+}
+
+/// Traces hash-bucket creation for a new device (level 3).
+///
+/// upstream: hlink.c:77 - `"[%s] created hashtable for dev %s"`.
+#[inline]
+pub fn trace_hashtable_for_dev(role: ProcessRole, dev: u64) {
+    debug_log!(
+        Hlink,
+        3,
+        "[{}] created hashtable for dev {}",
+        role,
+        big_num(dev)
+    );
+}
+
+/// Traces a follower whose prior leader was skipped (level 2).
+///
+/// upstream: hlink.c:305 - `"hlink for %d (%s,%d): virtual first"`.
+#[inline]
+pub fn trace_virtual_first(ndx: i32, name: &str, gnum: i32) {
+    debug_log!(Hlink, 2, "hlink for {} ({},{}): virtual first", ndx, name, gnum);
+}
+
+/// Traces a follower deferred while the leader transfer is in flight (level 2).
+///
+/// upstream: hlink.c:325 - `"hlink for %d (%s,%d): waiting for %d"`.
+#[inline]
+pub fn trace_waiting_for(ndx: i32, name: &str, gnum: i32, prev_ndx: i32) {
+    debug_log!(
+        Hlink,
+        2,
+        "hlink for {} ({},{}): waiting for {}",
+        ndx,
+        name,
+        gnum,
+        prev_ndx
+    );
+}
+
+/// Traces a follower searching for an unassigned leader (level 2).
+///
+/// upstream: hlink.c:331 - `"hlink for %d (%s,%d): looking for a leader"`.
+#[inline]
+pub fn trace_looking_for_leader(ndx: i32, name: &str, gnum: i32) {
+    debug_log!(
+        Hlink,
+        2,
+        "hlink for {} ({},{}): looking for a leader",
+        ndx,
+        name,
+        gnum
+    );
+}
+
+/// Traces a follower matched against an alt-dest file (level 2).
+///
+/// upstream: hlink.c:353 - `"hlink for %d (%s,%d): found flist match (alt %d)"`.
+#[inline]
+pub fn trace_found_flist_match(ndx: i32, name: &str, gnum: i32, alt_dest: i32) {
+    debug_log!(
+        Hlink,
+        2,
+        "hlink for {} ({},{}): found flist match (alt {})",
+        ndx,
+        name,
+        gnum,
+        alt_dest
+    );
+}
+
+/// Traces final leader resolution for a follower (level 2).
+///
+/// upstream: hlink.c:370 - `"hlink for %d (%s,%d): leader is %d (%s)"`.
+#[inline]
+pub fn trace_leader_is(ndx: i32, name: &str, gnum: i32, prev_ndx: i32, prev_name: &str) {
+    debug_log!(
+        Hlink,
+        2,
+        "hlink for {} ({},{}): leader is {} ({})",
+        ndx,
+        name,
+        gnum,
+        prev_ndx,
+        prev_name
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    //! Pinning tests for HLINK emission shapes. Strings match upstream
+    //! `hlink.c` byte-for-byte.
+
+    use super::*;
+    use logging::{DebugFlag, DiagnosticEvent, VerbosityConfig, drain_events, init};
+
+    fn init_at(level: u8) {
+        let mut cfg = VerbosityConfig::default();
+        cfg.debug.hlink = level;
+        init(cfg);
+        let _ = drain_events();
+    }
+
+    fn hlink_messages() -> Vec<String> {
+        drain_events()
+            .into_iter()
+            .filter_map(|event| match event {
+                DiagnosticEvent::Debug {
+                    flag: DebugFlag::Hlink,
+                    message,
+                    ..
+                } => Some(message),
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn upstream_wire_shapes() {
+        // upstream: hlink.c:78,306,326,332,354,371 - each HLINK debug emission.
+        assert_eq!(big_num(2_049_000_000), "2,049,000,000");
+
+        init_at(3);
+        trace_hashtable_for_dev(ProcessRole::Sender, 2049);
+        trace_virtual_first(7, "dir/file", 3);
+        trace_waiting_for(9, "dir/file", 3, 5);
+        trace_looking_for_leader(11, "dir/file", 4);
+        trace_found_flist_match(12, "dir/file", 4, 1);
+        trace_leader_is(13, "dir/file", 4, 8, "dir/leader");
+
+        let m = hlink_messages();
+        for expected in [
+            "[sender] created hashtable for dev 2,049",
+            "hlink for 7 (dir/file,3): virtual first",
+            "hlink for 9 (dir/file,3): waiting for 5",
+            "hlink for 11 (dir/file,4): looking for a leader",
+            "hlink for 12 (dir/file,4): found flist match (alt 1)",
+            "hlink for 13 (dir/file,4): leader is 8 (dir/leader)",
+        ] {
+            assert!(m.iter().any(|s| s == expected), "missing {expected}: {m:?}");
+        }
+    }
+
+    #[test]
+    fn level_gating_matches_upstream() {
+        // upstream: DEBUG_GTE(HLINK, N) gates each emission.
+        init_at(1);
+        trace_virtual_first(1, "f", 0);
+        trace_hashtable_for_dev(ProcessRole::Sender, 1);
+        assert!(hlink_messages().is_empty(), "level 2/3 must be gated");
+    }
+}

--- a/crates/protocol/src/flist/mod.rs
+++ b/crates/protocol/src/flist/mod.rs
@@ -50,7 +50,11 @@ pub use batched_writer::{BatchConfig, BatchStats, BatchedFileListWriter};
 pub use dir_tree::DirectoryTree;
 pub use entry::{FileEntry, FileType};
 pub use flags::{FileFlags, XMIT_HLINK_FIRST, XMIT_HLINKED, XMIT_SAME_RDEV_PRE28, XMIT_TOP_DIR};
-pub use hardlink::{DevIno, HardlinkEntry, HardlinkLookup, HardlinkTable};
+pub use hardlink::{
+    DevIno, HardlinkEntry, HardlinkLookup, HardlinkTable, trace_found_flist_match,
+    trace_hashtable_for_dev, trace_leader_is, trace_looking_for_leader, trace_virtual_first,
+    trace_waiting_for,
+};
 pub use incremental::{
     FinalizationResult, FinalizationStats, IncrementalFileList, IncrementalFileListBuilder,
     IncrementalFileListIter, OrphanEntry, ReadyEntryAction, StreamingFileList,

--- a/crates/transfer/src/generator/file_list/hardlinks.rs
+++ b/crates/transfer/src/generator/file_list/hardlinks.rs
@@ -11,7 +11,7 @@
 //! - `uidlist.c:add_uid()` / `add_gid()` - ID collection during file list building
 
 #[cfg(unix)]
-use protocol::flist::{DevIno, HardlinkLookup, HardlinkTable};
+use protocol::flist::{DevIno, HardlinkLookup, HardlinkTable, ProcessRole};
 
 use super::super::GeneratorContext;
 
@@ -51,6 +51,9 @@ impl GeneratorContext {
 
             let wire_ndx = ndx_start + i as u32;
             let dev_ino = DevIno::new(dev as u64, ino as u64);
+            // upstream: hlink.c HLINK debug emissions - announce per-device
+            // hashtable creation on first observation.
+            table.announce_device(ProcessRole::Generator, dev_ino.dev);
             match table.find_or_insert(dev_ino, wire_ndx) {
                 HardlinkLookup::First(_) => {
                     // Leader: mark with u32::MAX (XMIT_HLINK_FIRST on wire)

--- a/crates/transfer/src/receiver/directory/links.rs
+++ b/crates/transfer/src/receiver/directory/links.rs
@@ -9,6 +9,7 @@ use std::fs;
 use std::path::Path;
 
 use logging::{debug_log, info_log};
+use protocol::flist::{trace_leader_is, trace_looking_for_leader, trace_virtual_first};
 
 use crate::generator::ItemFlags;
 use crate::receiver::ReceiverContext;
@@ -181,7 +182,7 @@ impl ReceiverContext {
             }
 
             // Second pass: link followers to their leaders.
-            for entry in &self.file_list {
+            for (follower_ndx, entry) in self.file_list.iter().enumerate() {
                 if !entry.flags().hlinked() || entry.flags().hlink_first() {
                     continue;
                 }
@@ -190,9 +191,18 @@ impl ReceiverContext {
                     None => continue,
                 };
 
+                let entry_name = entry.path().display().to_string();
                 let leader_path = match tracker.leader_path(leader_idx) {
                     Some(p) => p.to_path_buf(),
                     None => {
+                        // upstream: hlink.c HLINK debug emissions
+                        // No leader recorded: matches `virtual first` in upstream
+                        // when a prior file in the group was skipped.
+                        trace_virtual_first(
+                            follower_ndx as i32,
+                            &entry_name,
+                            leader_idx as i32,
+                        );
                         debug_log!(
                             Recv,
                             1,
@@ -203,6 +213,16 @@ impl ReceiverContext {
                         continue;
                     }
                 };
+                // upstream: hlink.c HLINK debug emissions
+                // Pre-resolution diagnostic plus the final `leader is` message.
+                trace_looking_for_leader(follower_ndx as i32, &entry_name, leader_idx as i32);
+                trace_leader_is(
+                    follower_ndx as i32,
+                    &entry_name,
+                    leader_idx as i32,
+                    leader_idx as i32,
+                    &leader_path.display().to_string(),
+                );
 
                 let relative_path = entry.path();
                 let link_path = dest_dir.join(relative_path);
@@ -429,6 +449,50 @@ mod tests {
         assert_eq!(
             first, second,
             "io_uring LINKAT availability must be consistent"
+        );
+    }
+
+    /// Verifies the receiver-side `--debug=HLINK` follower emission shape
+    /// matches upstream `hlink.c:hard_link_check()` byte-for-byte.
+    ///
+    /// upstream: hlink.c HLINK debug emissions
+    #[test]
+    fn hardlink_debug_hlink_leader_emission_matches_upstream() {
+        use logging::{DebugFlag, DiagnosticEvent, VerbosityConfig, drain_events, init};
+        use protocol::flist::{trace_leader_is, trace_looking_for_leader, trace_virtual_first};
+
+        let mut cfg = VerbosityConfig::default();
+        cfg.debug.hlink = 2;
+        init(cfg);
+        let _ = drain_events();
+
+        trace_looking_for_leader(4, "dir/follower", 1);
+        trace_leader_is(4, "dir/follower", 1, 1, "dest/leader");
+        trace_virtual_first(5, "dir/orphan", 2);
+
+        let msgs: Vec<String> = drain_events()
+            .into_iter()
+            .filter_map(|event| match event {
+                DiagnosticEvent::Debug {
+                    flag: DebugFlag::Hlink,
+                    message,
+                    ..
+                } => Some(message),
+                _ => None,
+            })
+            .collect();
+
+        assert!(
+            msgs.iter()
+                .any(|m| m == "hlink for 4 (dir/follower,1): looking for a leader")
+        );
+        assert!(
+            msgs.iter()
+                .any(|m| m == "hlink for 4 (dir/follower,1): leader is 1 (dest/leader)")
+        );
+        assert!(
+            msgs.iter()
+                .any(|m| m == "hlink for 5 (dir/orphan,2): virtual first")
         );
     }
 }

--- a/crates/transfer/src/receiver/directory/links.rs
+++ b/crates/transfer/src/receiver/directory/links.rs
@@ -198,11 +198,7 @@ impl ReceiverContext {
                         // upstream: hlink.c HLINK debug emissions
                         // No leader recorded: matches `virtual first` in upstream
                         // when a prior file in the group was skipped.
-                        trace_virtual_first(
-                            follower_ndx as i32,
-                            &entry_name,
-                            leader_idx as i32,
-                        );
+                        trace_virtual_first(follower_ndx as i32, &entry_name, leader_idx as i32);
                         debug_log!(
                             Recv,
                             1,


### PR DESCRIPTION
## Summary
- Adds a `protocol::flist::hardlink::trace` module that emits the six HLINK debug messages from upstream `hlink.c` byte-for-byte: the level-3 per-device hashtable announcement and the five level-2 follower-resolution messages (virtual first / waiting for / looking for a leader / found flist match / leader is).
- Wires the level-3 emission into `HardlinkTable::announce_device`, called from the generator's hardlink-index assignment so each new device prints exactly once.
- Wires the level-2 receiver-side emissions into `ReceiverContext::create_hardlinks` for each follower (looking for a leader / leader is, with virtual first when no leader was recorded).

## Test plan
- [ ] `cargo nextest run -p protocol --all-features -E 'test(flist::hardlink::trace)'` (CI)
- [ ] `cargo nextest run -p transfer --all-features -E 'test(hardlink_debug_hlink_leader_emission)'` (CI)
- [ ] fmt + clippy on the full workspace (CI)

Refs #2188, #2151.