### PR TITLE
feat(transfer): wire --debug=FUZZY producer emissions (3.4.1 parity)

### DIFF
--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -159,6 +159,7 @@ pub mod fuzzy {
     //! Re-exports from the [`matching`] crate for backward compatibility.
     pub use matching::{
         FUZZY_LEVEL_1, FUZZY_LEVEL_2, FuzzyMatch, FuzzyMatcher, compute_similarity_score,
+        trace_fuzzy_basis_selected, trace_fuzzy_distance, trace_fuzzy_size_mtime_match,
     };
 }
 
@@ -190,7 +191,10 @@ pub use concurrent_delta::{
 pub use error::{EngineError, EngineResult};
 
 /// Fuzzy matching for finding similar basis files.
-pub use fuzzy::{FUZZY_LEVEL_1, FUZZY_LEVEL_2, FuzzyMatch, FuzzyMatcher, compute_similarity_score};
+pub use fuzzy::{
+    FUZZY_LEVEL_1, FUZZY_LEVEL_2, FuzzyMatch, FuzzyMatcher, compute_similarity_score,
+    trace_fuzzy_basis_selected, trace_fuzzy_distance, trace_fuzzy_size_mtime_match,
+};
 
 /// Hardlink detection and resolution.
 pub use hardlink::{HardlinkAction, HardlinkGroup, HardlinkKey, HardlinkResolver, HardlinkTracker};

--- a/crates/matching/src/fuzzy/mod.rs
+++ b/crates/matching/src/fuzzy/mod.rs
@@ -54,8 +54,10 @@
 
 mod scoring;
 mod search;
+mod trace;
 
 pub use scoring::compute_similarity_score;
+pub use trace::{trace_fuzzy_basis_selected, trace_fuzzy_distance, trace_fuzzy_size_mtime_match};
 
 use std::path::PathBuf;
 

--- a/crates/matching/src/fuzzy/search.rs
+++ b/crates/matching/src/fuzzy/search.rs
@@ -12,6 +12,7 @@ use std::fs;
 use std::path::Path;
 
 use super::scoring::compute_similarity_score;
+use super::trace::trace_fuzzy_distance;
 use super::{FUZZY_LEVEL_2, FuzzyMatch, FuzzyMatcher};
 
 impl FuzzyMatcher {
@@ -128,6 +129,11 @@ fn search_directory(
 
         let score =
             compute_similarity_score(target_name, &candidate_name, target_size, metadata.len());
+
+        // upstream: generator.c:884 - emit a per-candidate FUZZY,2 distance
+        // line so log parsers see each candidate considered, even those
+        // below the selection threshold.
+        trace_fuzzy_distance(&candidate_name, score);
 
         if score >= min_score {
             update_best_match(&mut best_match, FuzzyMatch { path, score }, min_score);

--- a/crates/matching/src/fuzzy/trace.rs
+++ b/crates/matching/src/fuzzy/trace.rs
@@ -102,9 +102,8 @@ mod tests {
         trace_fuzzy_basis_selected("dir/report_2024.csv", "dir/report_2023.csv");
         let msgs = fuzzy_messages();
         assert!(
-            msgs.iter().any(
-                |m| m == "fuzzy basis selected for dir/report_2024.csv: dir/report_2023.csv"
-            ),
+            msgs.iter()
+                .any(|m| m == "fuzzy basis selected for dir/report_2024.csv: dir/report_2023.csv"),
             "expected upstream-format FUZZY,1 emission, got {msgs:?}"
         );
     }

--- a/crates/matching/src/fuzzy/trace.rs
+++ b/crates/matching/src/fuzzy/trace.rs
@@ -1,0 +1,157 @@
+//! `--debug=FUZZY` producer emissions for fuzzy basis matching.
+//!
+//! Mirrors upstream rsync's `generator.c` `DEBUG_GTE(FUZZY, N)` output so
+//! wire-comparable diagnostics align across implementations.
+//!
+//! # Upstream Reference
+//!
+//! - `generator.c:1775` - `"fuzzy basis selected for %s: %s"` (level 1).
+//! - `generator.c:847`  - `"fuzzy size/modtime match for %s"` (level 2).
+//! - `generator.c:884`  - `"fuzzy distance for %s = %d.%05d"` (level 2).
+
+use logging::debug_log;
+
+/// Emits the level 1 announcement when a fuzzy basis is selected for a target.
+///
+/// Matches upstream rsync exactly:
+/// ```text
+/// fuzzy basis selected for path/to/target: path/to/basis
+/// ```
+///
+/// upstream: generator.c:1775-1778.
+#[inline]
+pub fn trace_fuzzy_basis_selected(target: &str, basis: &str) {
+    debug_log!(Fuzzy, 1, "fuzzy basis selected for {}: {}", target, basis);
+}
+
+/// Emits the level 2 size/modtime fast-path hit for a candidate.
+///
+/// Matches upstream rsync exactly:
+/// ```text
+/// fuzzy size/modtime match for path/to/candidate
+/// ```
+///
+/// upstream: generator.c:847-848.
+#[inline]
+pub fn trace_fuzzy_size_mtime_match(candidate: &str) {
+    debug_log!(Fuzzy, 2, "fuzzy size/modtime match for {}", candidate);
+}
+
+/// Emits the level 2 distance line for a scored candidate.
+///
+/// Upstream encodes `dist` as a 32-bit fixed-point value (high 16 bits =
+/// integer part, low 16 bits = fractional part) and prints it as
+/// `%d.%05d`. Our scoring function returns a single u32 score where higher
+/// is better; we surface it under the upstream format string with the
+/// integer slot occupied by the score and the fractional slot zeroed so
+/// log parsers built for upstream output continue to work.
+///
+/// Matches upstream rsync format:
+/// ```text
+/// fuzzy distance for path/to/candidate = 42.00000
+/// ```
+///
+/// upstream: generator.c:884-887.
+#[inline]
+pub fn trace_fuzzy_distance(candidate: &str, score: u32) {
+    debug_log!(
+        Fuzzy,
+        2,
+        "fuzzy distance for {} = {}.{:05}",
+        candidate,
+        score,
+        0
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use logging::{DebugFlag, DiagnosticEvent, VerbosityConfig, drain_events, init};
+
+    /// Initializes the logger with the given FUZZY debug level and drains
+    /// any preexisting events from prior tests.
+    fn setup_fuzzy(level: u8) {
+        let mut cfg = VerbosityConfig::default();
+        cfg.debug.fuzzy = level;
+        init(cfg);
+        let _ = drain_events();
+    }
+
+    /// Collects FUZZY debug messages emitted since the last drain.
+    fn fuzzy_messages() -> Vec<String> {
+        drain_events()
+            .into_iter()
+            .filter_map(|event| match event {
+                DiagnosticEvent::Debug {
+                    flag: DebugFlag::Fuzzy,
+                    message,
+                    ..
+                } => Some(message),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// Pins the level 1 emission to upstream's format byte-for-byte.
+    ///
+    /// upstream: generator.c:1775-1778.
+    #[test]
+    fn fuzzy_basis_selected_matches_upstream() {
+        setup_fuzzy(1);
+        trace_fuzzy_basis_selected("dir/report_2024.csv", "dir/report_2023.csv");
+        let msgs = fuzzy_messages();
+        assert!(
+            msgs.iter().any(
+                |m| m == "fuzzy basis selected for dir/report_2024.csv: dir/report_2023.csv"
+            ),
+            "expected upstream-format FUZZY,1 emission, got {msgs:?}"
+        );
+    }
+
+    /// Level 1 emissions must not fire when FUZZY debug is disabled.
+    #[test]
+    fn fuzzy_basis_selected_gated_by_level() {
+        setup_fuzzy(0);
+        trace_fuzzy_basis_selected("a", "b");
+        assert!(fuzzy_messages().is_empty());
+    }
+
+    /// Pins the level 2 distance emission format.
+    ///
+    /// upstream: generator.c:884-887.
+    #[test]
+    fn fuzzy_distance_matches_upstream_format() {
+        setup_fuzzy(2);
+        trace_fuzzy_distance("dir/sibling.txt", 42);
+        let msgs = fuzzy_messages();
+        assert!(
+            msgs.iter()
+                .any(|m| m == "fuzzy distance for dir/sibling.txt = 42.00000"),
+            "expected upstream-format FUZZY,2 distance line, got {msgs:?}"
+        );
+    }
+
+    /// Level 2 emissions must not fire when only FUZZY,1 is enabled.
+    #[test]
+    fn fuzzy_distance_gated_at_level_2() {
+        setup_fuzzy(1);
+        trace_fuzzy_distance("a", 1);
+        assert!(fuzzy_messages().is_empty());
+    }
+
+    /// Pins the level 2 size/modtime fast-path emission format.
+    ///
+    /// upstream: generator.c:847-848.
+    #[test]
+    fn fuzzy_size_mtime_match_matches_upstream() {
+        setup_fuzzy(2);
+        trace_fuzzy_size_mtime_match("dir/cache.bin");
+        let msgs = fuzzy_messages();
+        assert!(
+            msgs.iter()
+                .any(|m| m == "fuzzy size/modtime match for dir/cache.bin"),
+            "expected upstream-format FUZZY,2 size/modtime line, got {msgs:?}"
+        );
+    }
+}

--- a/crates/matching/src/lib.rs
+++ b/crates/matching/src/lib.rs
@@ -27,7 +27,10 @@ pub mod optimized_search;
 mod ring_buffer;
 mod script;
 
-pub use fuzzy::{FUZZY_LEVEL_1, FUZZY_LEVEL_2, FuzzyMatch, FuzzyMatcher, compute_similarity_score};
+pub use fuzzy::{
+    FUZZY_LEVEL_1, FUZZY_LEVEL_2, FuzzyMatch, FuzzyMatcher, compute_similarity_score,
+    trace_fuzzy_basis_selected, trace_fuzzy_distance, trace_fuzzy_size_mtime_match,
+};
 pub use generator::{DeltaGenerator, generate_delta};
 pub use index::{DeltaSignatureIndex, MatchedBlocks};
 pub use script::{DeltaScript, DeltaToken, apply_delta};

--- a/crates/transfer/src/receiver/basis.rs
+++ b/crates/transfer/src/receiver/basis.rs
@@ -9,7 +9,7 @@ use std::num::NonZeroU8;
 use std::path::PathBuf;
 
 use engine::delta::{SignatureLayoutParams, calculate_signature_layout};
-use engine::fuzzy::FuzzyMatcher;
+use engine::fuzzy::{FuzzyMatcher, trace_fuzzy_basis_selected};
 use engine::signature::{FileSignature, generate_file_signature};
 use protocol::ProtocolVersion;
 
@@ -173,6 +173,13 @@ fn try_fuzzy_match(
 
     let fuzzy_matcher = FuzzyMatcher::with_level(fuzzy_level).with_fuzzy_basis_dirs(basis_dirs);
     let fuzzy_match = fuzzy_matcher.find_fuzzy_basis(target_name, dest_dir, target_size)?;
+    // upstream: generator.c:1775 - announce the selected fuzzy basis at
+    // FUZZY,1 the moment the matcher returns a candidate, before we attempt
+    // to open it.
+    trace_fuzzy_basis_selected(
+        &relative_path.display().to_string(),
+        &fuzzy_match.path.display().to_string(),
+    );
     try_open_file(&fuzzy_match.path)
 }
 

--- a/crates/transfer/tests/fuzzy_level2_basis_search.rs
+++ b/crates/transfer/tests/fuzzy_level2_basis_search.rs
@@ -414,9 +414,10 @@ fn fuzzy_basis_selection_emits_debug_fuzzy_line() {
         .collect();
 
     assert!(
-        msgs.iter()
-            .any(|m| m.starts_with("fuzzy basis selected for report_v2.bin: ")
-                && m.contains("report_v1.bin")),
+        msgs.iter().any(
+            |m| m.starts_with("fuzzy basis selected for report_v2.bin: ")
+                && m.contains("report_v1.bin")
+        ),
         "expected upstream-format FUZZY,1 selection line; got {msgs:?}"
     );
 }

--- a/crates/transfer/tests/fuzzy_level2_basis_search.rs
+++ b/crates/transfer/tests/fuzzy_level2_basis_search.rs
@@ -354,3 +354,69 @@ fn whole_file_bypasses_fuzzy_search() {
         "whole_file mode should bypass all basis file search"
     );
 }
+
+/// Verifies that `--debug=FUZZY` level 1 emits the upstream-format
+/// `"fuzzy basis selected for ..."` line whenever the receiver basis search
+/// selects a fuzzy candidate.
+///
+/// upstream: generator.c:1775-1778 - `DEBUG_GTE(FUZZY, 1)` branch in
+/// `recv_generator()`.
+#[test]
+fn fuzzy_basis_selection_emits_debug_fuzzy_line() {
+    use logging::{DebugFlag, DiagnosticEvent, VerbosityConfig, drain_events, init};
+
+    let temp = TempDir::new().expect("create temp dir");
+    let dest_dir = temp.path().join("dest");
+    std::fs::create_dir_all(&dest_dir).expect("create dest");
+
+    // Seed a similar-named candidate in the destination directory so the
+    // fuzzy matcher returns a hit.
+    let content = generate_content(8_192, 0x37);
+    std::fs::write(dest_dir.join("report_v1.bin"), &content).expect("write basis");
+
+    let target_path = dest_dir.join("report_v2.bin");
+    let relative_path = Path::new("report_v2.bin");
+
+    let mut cfg = VerbosityConfig::default();
+    cfg.debug.fuzzy = 1;
+    init(cfg);
+    let _ = drain_events();
+
+    let config = BasisFileConfig {
+        file_path: &target_path,
+        dest_dir: &dest_dir,
+        relative_path,
+        target_size: content.len() as u64,
+        fuzzy_level: 1,
+        reference_directories: &[],
+        protocol: protocol::ProtocolVersion::try_from(32u8).unwrap(),
+        checksum_length: NonZeroU8::new(16).unwrap(),
+        checksum_algorithm: signature::SignatureAlgorithm::Md4,
+        whole_file: false,
+    };
+
+    let result = find_basis_file_with_config(&config);
+    assert!(
+        !result.is_empty(),
+        "fuzzy level 1 should locate report_v1.bin as a basis"
+    );
+
+    let msgs: Vec<String> = drain_events()
+        .into_iter()
+        .filter_map(|event| match event {
+            DiagnosticEvent::Debug {
+                flag: DebugFlag::Fuzzy,
+                message,
+                ..
+            } => Some(message),
+            _ => None,
+        })
+        .collect();
+
+    assert!(
+        msgs.iter()
+            .any(|m| m.starts_with("fuzzy basis selected for report_v2.bin: ")
+                && m.contains("report_v1.bin")),
+        "expected upstream-format FUZZY,1 selection line; got {msgs:?}"
+    );
+}


### PR DESCRIPTION
## Summary

- Wires the previously inert `--debug=FUZZY` flag to actual producer emissions matching upstream rsync 3.4.1's `generator.c` byte-for-byte.
- Emits the `"fuzzy basis selected for <target>: <basis>"` headline at FUZZY,1 inside the receiver basis search whenever `FuzzyMatcher` returns a candidate.
- Emits a per-candidate `"fuzzy distance for <name> = <score>.00000"` line at FUZZY,2 inside the directory scan, plus an exported `trace_fuzzy_size_mtime_match` helper ready for the size+mtime fast path.

## Test plan

- [x] Unit tests pin each FUZZY emission shape and verify the level-gating in `crates/matching/src/fuzzy/trace.rs`.
- [x] Receiver integration test `fuzzy_basis_selection_emits_debug_fuzzy_line` drives `find_basis_file_with_config` under FUZZY=1 and asserts the upstream-format selection line lands on the diagnostic bus.
- [ ] CI: fmt+clippy, nextest (stable), Windows, macOS, Linux musl.

Closes #2185