### PR TITLE
feat(generator): wire --debug=GENR producer emissions (3.4.1 parity)

### DIFF
--- a/crates/transfer/src/receiver/mod.rs
+++ b/crates/transfer/src/receiver/mod.rs
@@ -263,7 +263,7 @@ impl ReceiverContext {
     /// # Upstream Reference
     ///
     /// - `generator.c:2321` - `ndx = i + cur_flist->ndx_start`
-    fn flat_to_wire_ndx(&self, flat_idx: usize) -> i32 {
+    pub(in crate::receiver) fn flat_to_wire_ndx(&self, flat_idx: usize) -> i32 {
         let seg_idx = self
             .ndx_segments
             .partition_point(|&(start, _)| start <= flat_idx)

--- a/crates/transfer/src/receiver/transfer.rs
+++ b/crates/transfer/src/receiver/transfer.rs
@@ -14,7 +14,7 @@ use std::io::{self, Read, Write};
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use logging::{PhaseTimer, info_log};
+use logging::{PhaseTimer, debug_log, info_log};
 use protocol::codec::{MonotonicNdxWriter, NdxCodec, create_ndx_codec};
 use protocol::flist::FileEntry;
 use protocol::stats::DeleteStats;
@@ -846,6 +846,12 @@ impl ReceiverContext {
         &mut self,
         reader: crate::reader::ServerReader<R>,
     ) -> io::Result<(crate::reader::ServerReader<R>, usize, PipelineSetup)> {
+        // upstream: generator.c:2260-2261 - emitted at the top of generate_files,
+        // just before the per-segment dispatch loop. The receiver-side transfer
+        // setup is the closest analog (every `run*` entry point routes through
+        // setup_transfer).
+        debug_log!(Genr, 1, "generator starting pid={}", std::process::id());
+
         let mut reader = if self.should_activate_input_multiplex() {
             reader.activate_multiplex().map_err(|e| {
                 io::Error::new(

--- a/crates/transfer/src/receiver/transfer/candidates.rs
+++ b/crates/transfer/src/receiver/transfer/candidates.rs
@@ -14,7 +14,7 @@ use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
-use logging::info_log;
+use logging::{debug_gte, debug_log, info_log};
 use metadata::{MetadataOptions, apply_metadata_with_cached_stat};
 use protocol::flist::FileEntry;
 
@@ -44,6 +44,17 @@ impl ReceiverContext {
         stats: &mut TransferStats,
         acl_cache: Option<&protocol::acl::AclCache>,
     ) -> Vec<(usize, &'a FileEntry, PathBuf)> {
+        // upstream: generator.c:1234-1235 - "recv_generator(%s,%d)" emitted at
+        // the top of recv_generator() for every file the generator considers
+        // (regular files, directories, symlinks, devices, specials). Skipping
+        // the loop when the flag is off keeps the hot path allocation-free.
+        if debug_gte(logging::DebugFlag::Genr, 1) {
+            for (flat_idx, entry) in self.file_list.iter().enumerate() {
+                let ndx = self.flat_to_wire_ndx(flat_idx);
+                debug_log!(Genr, 1, "recv_generator({},{})", entry.path().display(), ndx);
+            }
+        }
+
         // Phase A: Filter candidates (cheap, in-memory checks only).
         let daemon_filters = self.daemon_filter_set();
         let candidates: Vec<(usize, &FileEntry)> = self

--- a/crates/transfer/src/receiver/transfer/candidates.rs
+++ b/crates/transfer/src/receiver/transfer/candidates.rs
@@ -51,7 +51,13 @@ impl ReceiverContext {
         if debug_gte(logging::DebugFlag::Genr, 1) {
             for (flat_idx, entry) in self.file_list.iter().enumerate() {
                 let ndx = self.flat_to_wire_ndx(flat_idx);
-                debug_log!(Genr, 1, "recv_generator({},{})", entry.path().display(), ndx);
+                debug_log!(
+                    Genr,
+                    1,
+                    "recv_generator({},{})",
+                    entry.path().display(),
+                    ndx
+                );
             }
         }
 

--- a/crates/transfer/src/receiver/transfer/phases.rs
+++ b/crates/transfer/src/receiver/transfer/phases.rs
@@ -12,6 +12,7 @@
 
 use std::io::{self, Read, Write};
 
+use logging::debug_log;
 use protocol::CompatibilityFlags;
 use protocol::codec::{
     NDX_DEL_STATS, NDX_DONE, NdxCodec, NdxCodecEnum, ProtocolCodec, create_ndx_codec,
@@ -52,20 +53,40 @@ impl ReceiverContext {
                 self.read_expected_ndx_done(ndx_read_codec, reader, "segment completion")?;
             }
 
-            for _phase in 2..=max_phase {
+            // upstream: generator.c:2355-2357 - phase++ then "generate_files phase=%d"
+            // The first `phase++` after the per-segment loop advances 0 -> 1.
+            let mut phase: i32 = 1;
+            debug_log!(Genr, 1, "generate_files phase={}", phase);
+
+            for _phase_step in 2..=max_phase {
                 ndx_write_codec.write_ndx_done(&mut *writer)?;
                 writer.flush()?;
                 self.read_expected_ndx_done(ndx_read_codec, reader, "phase transition")?;
+                // upstream: generator.c:2366-2368 - phase++ on each additional
+                // iteration (covers the redo phase).
+                phase += 1;
+                debug_log!(Genr, 1, "generate_files phase={}", phase);
             }
 
             ndx_write_codec.write_ndx_done(&mut *writer)?;
             writer.flush()?;
+
+            // upstream: generator.c:2391-2394 - protocol >= 29 emits a final
+            // phase=3 for the delay-updates pass. INC_RECURSE implies
+            // protocol >= 30, so this always fires once on this branch.
+            if self.protocol.supports_multi_phase() {
+                phase += 1;
+                debug_log!(Genr, 1, "generate_files phase={}", phase);
+            }
         } else {
             let mut phase: i32 = 0;
             loop {
                 ndx_write_codec.write_ndx_done(&mut *writer)?;
                 writer.flush()?;
                 phase += 1;
+                // upstream: generator.c:2355-2357, 2366-2368, 2392-2394
+                // "generate_files phase=%d" emitted after each phase++.
+                debug_log!(Genr, 1, "generate_files phase={}", phase);
                 if phase > max_phase {
                     break;
                 }
@@ -197,6 +218,118 @@ impl ReceiverContext {
 
         self.handle_goodbye(reader, writer, &mut ndx_write_codec, &mut ndx_read_codec)?;
 
+        // upstream: generator.c:2436-2437 - "generate_files finished" emitted at
+        // the bottom of generate_files() after the final goodbye handshake.
+        debug_log!(Genr, 1, "generate_files finished");
+
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod genr_debug_emission_tests {
+    //! Wording tests for `--debug=GENR` producer emissions.
+    //!
+    //! Each test asserts the exact wire string that upstream rsync 3.4.1
+    //! emits from `generator.c generate_files` and `recv_generator` under
+    //! `DEBUG_GTE(GENR, 1)`. Strings are matched byte-for-byte because
+    //! interop harnesses grep for these literals.
+
+    use logging::{DebugFlag, DiagnosticEvent, VerbosityConfig, debug_log, drain_events, init};
+    use std::path::PathBuf;
+
+    fn init_genr_level1() {
+        let mut cfg = VerbosityConfig::default();
+        cfg.debug.genr = 1;
+        init(cfg);
+        let _ = drain_events();
+    }
+
+    fn genr_messages() -> Vec<String> {
+        drain_events()
+            .into_iter()
+            .filter_map(|event| match event {
+                DiagnosticEvent::Debug {
+                    flag: DebugFlag::Genr,
+                    message,
+                    ..
+                } => Some(message),
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn generator_starting_matches_upstream() {
+        // upstream: generator.c:2260-2261 - "generator starting pid=%d"
+        init_genr_level1();
+        let pid: u32 = 12345;
+        debug_log!(Genr, 1, "generator starting pid={}", pid);
+        let msgs = genr_messages();
+        assert!(
+            msgs.iter().any(|m| m == "generator starting pid=12345"),
+            "missing upstream wording: {msgs:?}"
+        );
+    }
+
+    #[test]
+    fn recv_generator_per_file_matches_upstream() {
+        // upstream: generator.c:1234-1235 - "recv_generator(%s,%d)"
+        init_genr_level1();
+        let name = PathBuf::from("dir/file.txt");
+        let ndx: i32 = 7;
+        debug_log!(Genr, 1, "recv_generator({},{})", name.display(), ndx);
+        let msgs = genr_messages();
+        assert!(
+            msgs.iter().any(|m| m == "recv_generator(dir/file.txt,7)"),
+            "missing upstream wording: {msgs:?}"
+        );
+    }
+
+    #[test]
+    fn generate_files_phase_matches_upstream() {
+        // upstream: generator.c:2355-2357, 2366-2368, 2392-2394
+        // "generate_files phase=%d" - the phase counter advances 1 -> 2 -> 3
+        // across the regular, redo, and protocol-29+ delay-updates phases.
+        init_genr_level1();
+        for phase in 1..=3 {
+            debug_log!(Genr, 1, "generate_files phase={}", phase);
+        }
+        let msgs = genr_messages();
+        for phase in 1..=3 {
+            let expected = format!("generate_files phase={phase}");
+            assert!(
+                msgs.iter().any(|m| m == &expected),
+                "missing upstream wording {expected:?}: {msgs:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn generate_files_finished_matches_upstream() {
+        // upstream: generator.c:2436-2437 - "generate_files finished"
+        init_genr_level1();
+        debug_log!(Genr, 1, "generate_files finished");
+        let msgs = genr_messages();
+        assert!(
+            msgs.iter().any(|m| m == "generate_files finished"),
+            "missing upstream wording: {msgs:?}"
+        );
+    }
+
+    #[test]
+    fn genr_emissions_suppressed_when_disabled() {
+        let cfg = VerbosityConfig::default();
+        init(cfg);
+        let _ = drain_events();
+        debug_log!(Genr, 1, "generator starting pid=1");
+        debug_log!(Genr, 1, "recv_generator(foo,0)");
+        debug_log!(Genr, 1, "generate_files phase=1");
+        debug_log!(Genr, 1, "generate_files finished");
+        let msgs = genr_messages();
+        assert!(
+            msgs.is_empty(),
+            "Genr debug emissions must be gated; got: {msgs:?}"
+        );
     }
 }

--- a/docs/audits/debug-flags-verbosity-matrix.md
+++ b/docs/audits/debug-flags-verbosity-matrix.md
@@ -129,7 +129,7 @@ Producer counts come from
 | FILTER     | 3 | 3 | W_SND\|W_REC | Debug filter actions (levels 1-3) | `crates/filters/src/decision.rs:69,71`, `crates/filters/src/compiled/rule.rs:43,60,68,74` (5 sites covering levels 1-3) | impl |
 | FLIST      | 4 | 4 | W_SND\|W_REC | Debug file-list operations (levels 1-4) | `crates/flist/src/file_list_walker.rs:32,89,101,119,130,241`, `crates/transfer/src/generator/file_list/{inc_recurse.rs:46,mod.rs:103,219}`, `crates/transfer/src/generator/transfer.rs:188,202,212,217`, `crates/transfer/src/receiver/file_list.rs:154,215,226`, `crates/protocol/src/flist/sort.rs:208,375`, `crates/protocol/src/flist/incremental/{ready_entry.rs,mod.rs}`, `crates/protocol/src/flist/read/{flags.rs,metadata.rs,mod.rs,name.rs}` (23 sites covering levels 1-4) | impl |
 | FUZZY      | 2 | 2 | W_REC | Debug fuzzy scoring (levels 1-2) | none | missing |
-| GENR       | 1 | u8::MAX | W_REC | Debug generator functions | none on `rsync::genr`; bridge accepts `rsync::generator` alias (`tracing_bridge.rs:113-119`) but no producer emits on either target | missing |
+| GENR       | 1 | u8::MAX | W_REC | Debug generator functions | `crates/transfer/src/receiver/transfer.rs:setup_transfer` (1 site at level 1), `crates/transfer/src/receiver/transfer/candidates.rs:build_files_to_transfer` (1 site at level 1), `crates/transfer/src/receiver/transfer/phases.rs:exchange_phase_done` and `:finalize_transfer` (3 sites at level 1, upstream-verbatim wording from `generator.c:1234,2260,2356,2367,2393,2436`) | impl (D14 RESOLVED) |
 | HASH       | 1 | u8::MAX | W_SND\|W_REC | Debug hashtable code | none | missing |
 | HLINK      | 3 (help says 1-3) | 3 | W_SND\|W_REC | Debug hard-link actions (levels 1-3) | none | missing |
 | ICONV      | 2 | 2 | W_CLI\|W_SRV | Debug iconv character conversions (levels 1-2) | none | missing |
@@ -144,9 +144,9 @@ Producer counts come from
 Total: 24 upstream `DEBUG_*` flags, matching `COUNT_DEBUG = DEBUG_TIME + 1`
 (`rsync.h:1462`). Status roll-up:
 
-- **impl**: 6 - DUP, FILTER, FLIST, NSTR, SEND, TIME.
+- **impl**: 7 - DUP, FILTER, FLIST, GENR, NSTR, SEND, TIME.
 - **partial**: 7 - CONNECT, DEL, DELTASUM, EXIT, IO, PROTO, RECV.
-- **missing**: 11 - ACL, BACKUP, BIND, CHDIR, CMD, FUZZY, GENR, HASH,
+- **missing**: 10 - ACL, BACKUP, BIND, CHDIR, CMD, FUZZY, HASH,
   HLINK, ICONV, OWN.
 
 `SEND` (D13) is now wired into the generator's send loop with the
@@ -303,12 +303,12 @@ requested level before the event materialises.
 |----|----------|--------|-------------|
 | G1 | Low | open | `ALL<N>` and `NONE0` syntactic forms are rejected as unknown tokens (`flags/debug.rs:279`). Upstream accepts them (`options.c:443-445`, `:452-453`, `:450-451`) and applies the trailing digit. Fix: extend `DebugFlagSettings::apply` to detect `all<digit>` and `none<digit>` before falling through to `parse_flag_and_level`, then call `enable_all_to_level(N)` / `disable_all()`. Cap N at 4 to match `MAX_OUT_LEVEL`. |
 | G2 | Low | open | Per-flag cap missing for upstream-max-1 flags. `acl`, `bind`, `chdir`, `dup`, `genr`, `hash`, `nstr`, `proto`, `recv`, `send` accept any `u8` value (no `if level > N` guard in `flags/debug.rs::apply`). Upstream silently clamps to `MAX_OUT_LEVEL = 4`. Fix: add `if level > 4 { return Err(debug_flag_error(display)); }` guards on those arms, or a single shared cap before the per-flag dispatch. |
-| G3 | High | open | 13 flags have no production producer (ACL, BACKUP, BIND, CHDIR, CMD, FUZZY, GENR, HASH, HLINK, ICONV, NSTR, OWN, SEND). Of these, SEND has a complete subsystem module (`debug_send.rs`) whose public trace helpers are never called from production code paths; only its own unit tests invoke them. Owning crates for the missing producers: `metadata` (ACL, OWN, HLINK), `engine` (BACKUP, FUZZY, GENR), `transfer`/`rsync_io` (BIND, CMD, ICONV, NSTR), `checksums` (HASH), `core` (CHDIR), `engine`/`transfer` (SEND wiring). |
+| G3 | High | open | 10 flags have no production producer (ACL, BACKUP, BIND, CHDIR, CMD, FUZZY, HASH, HLINK, ICONV, OWN). The previously listed GENR, NSTR, and SEND emissions are now wired (D14, NSTR follow-up, D13 RESOLVED). Owning crates for the remaining producers: `metadata` (ACL, OWN, HLINK), `engine` (BACKUP, FUZZY), `transfer`/`rsync_io` (BIND, CMD, ICONV), `checksums` (HASH), `core` (CHDIR). |
 | G4 | Low | open | `limit_output_verbosity` (upstream `options.c:527-553`) is not implemented. User-supplied per-flag levels are not clamped to the peer's `-v` ceiling during option exchange. Mitigation: implement on `server_options` parsing path and re-run the ladder with `LIMIT_PRIORITY` to compute the cap. |
 | G5 | Low | open | `make_output_option` (upstream `options.c:340-425`) is not implemented. Remote command forwarding of user-priority debug flags relies on raw passthrough rather than upstream's deduplicated `--debug=ALL2,NONREG0,...` style. User-visible effect is limited to the exact command string the peer sees in `ps` output. |
 | G6 | Low | open | `--debug=help` text omits the per-verbosity summary block (`0)`, `1)`, ..., `5)`) that upstream's `output_item_help` prints at `options.c:499-509`. Cosmetic but useful for discovery. |
 | G7 | Medium | open | Partial-level coverage: `DEL`, `DELTASUM`, `EXIT` emit at a single level rather than spanning the upstream range (1-3 for DEL/EXIT, 1-4 for DELTASUM). `IO` emits at levels 1 and 3 but skips 2 and 4. `CONNECT`, `PROTO`, `RECV` emit at levels not in the upstream range (CONNECT 3, PROTO 2, RECV 2). Fix: align the emission level numbers with upstream by walking the `DEBUG_GTE(<FLAG>, N)` call sites in the upstream tree and ensuring oc-rsync emits at each N. |
-| G8 | Low | open | `generator` -> `genr` alias in the bridge (`tracing_bridge.rs:113-119`) is one-way; no producer emits on either target. Wiring `rsync::genr` emissions from `crates/transfer/src/generator/*` would lift GENR to impl. |
+| G8 | Low | resolved | `generator` -> `genr` alias in the bridge (`tracing_bridge.rs:113-119`) is still one-way, but `--debug=GENR` now has direct `debug_log!(Genr, 1, ...)` producers in `crates/transfer/src/receiver/transfer.rs`, `:transfer/candidates.rs`, and `:transfer/phases.rs`, covering the seven upstream `generator.c` emission sites. |
 
 ## 10. Per-flag insertion plan for the missing producers
 
@@ -320,7 +320,6 @@ requested level before the event materialises.
 | CHDIR | `crates/core/src/client/path/` and `crates/daemon/src/jail/` | After every `chdir()` syscall. Upstream emits in `util1.c:do_chdir`. |
 | CMD | `crates/cli/src/frontend/execution/drive/options.rs` | When `--server` argv is built and when SSH command line is constructed. Upstream emits in `options.c:server_options` and `pipe.c:do_cmd`. |
 | FUZZY | `crates/transfer/src/generator/fuzzy.rs` (if present, else `match` crate) | When a fuzzy basis is selected. Upstream emits in `generator.c:find_fuzzy`. |
-| GENR | `crates/transfer/src/generator/mod.rs` | At each phase boundary of the generator loop. Upstream emits in `generator.c:generate_files`. |
 | HASH | `crates/checksums/src/strong/` and `crates/match/src/hashtable.rs` | At hashtable construction and lookup. Upstream emits in `match.c:build_hash_table`. |
 | HLINK | `crates/transfer/src/receiver/directory/links.rs` (extend existing RECV emitter) | When a hardlink master/follower is resolved. Upstream emits in `hlink.c:hard_link_one`. |
 | ICONV | `crates/protocol/src/iconv/` | When iconv conversion succeeds or fails. Upstream emits in `flist.c` near send/recv name paths. |


### PR DESCRIPTION
## Summary

- Wires `--debug=GENR` to emit the seven upstream rsync 3.4.1 diagnostics from `generator.c` (`recv_generator`, `generator starting pid`, `generate_files phase`, `generate_files finished`).
- Emissions go through `debug_log!(Genr, 1, ...)` at the receiver-side transfer entry (`setup_transfer`), the per-file recv_generator analog (`build_files_to_transfer`), and the phase ladder (`exchange_phase_done` / `finalize_transfer`).
- Per-file emission is gated behind `debug_gte` so the loop is skipped entirely when the flag is off.
- The non-inc_recurse phase loop emits at each `phase++`, matching upstream lines 2356/2367/2393. The inc_recurse branch emits three times when `supports_multi_phase` is true (protocol >= 30, which inc_recurse already requires).
- Audit doc rolls GENR from missing to impl and marks G8 RESOLVED.

Closes #2186.

## Test plan

- [ ] CI fmt+clippy passes
- [ ] CI nextest (stable) passes the new `genr_debug_emission_tests` module (5 tests)
- [ ] Windows / macOS / Linux musl matrices green