### PR TITLE
fix(filters): strip slash modifiers before sending filter rules

### DIFF
--- a/crates/core/src/client/remote/flags.rs
+++ b/crates/core/src/client/remote/flags.rs
@@ -131,6 +131,16 @@ pub(crate) fn build_server_flag_string(config: &ClientConfig) -> String {
 ///
 /// Maps [`FilterRuleSpec`] (client-side representation) to [`FilterRuleWireFormat`]
 /// (protocol wire representation) for transmission to the remote server.
+///
+/// The `FilterRuleWireFormat::pattern` field stores the bare pattern with the
+/// leading `/` (anchored) and trailing `/` (directory-only) stripped. Those
+/// modifiers are encoded as separate flags and re-emitted by the wire
+/// serializer; leaving them in the pattern produces a double `/` on the wire
+/// (e.g. `*//` for `--include='*/'`) which upstream rsync misinterprets.
+///
+/// upstream: `exclude.c:1238-1240` - leading `/` is parsed as the
+/// `FILTRULE_ABS_PATH` modifier. `exclude.c:get_rule_prefix()` (and
+/// `serialize_rule` here) re-append the trailing `/` for directory-only rules.
 pub(crate) fn build_wire_format_rules(
     client_rules: &[FilterRuleSpec],
 ) -> Result<Vec<FilterRuleWireFormat>, ClientError> {
@@ -147,11 +157,12 @@ pub(crate) fn build_wire_format_rules(
             FilterRuleKind::ExcludeIfPresent => {
                 // upstream: ExcludeIfPresent is transmitted as Exclude with 'e' flag
                 // (FILTRULE_EXCLUDE_SELF).
+                let (pattern, anchored, directory_only) = split_pattern_modifiers(spec.pattern());
                 wire_rules.push(FilterRuleWireFormat {
                     rule_type: RuleType::Exclude,
-                    pattern: spec.pattern().to_owned(),
-                    anchored: spec.pattern().starts_with('/'),
-                    directory_only: spec.pattern().ends_with('/'),
+                    pattern,
+                    anchored,
+                    directory_only,
                     no_inherit: false,
                     cvs_exclude: false,
                     word_split: false,
@@ -167,11 +178,12 @@ pub(crate) fn build_wire_format_rules(
             }
         };
 
+        let (pattern, anchored, directory_only) = split_pattern_modifiers(spec.pattern());
         let mut wire_rule = FilterRuleWireFormat {
             rule_type,
-            pattern: spec.pattern().to_owned(),
-            anchored: spec.pattern().starts_with('/'),
-            directory_only: spec.pattern().ends_with('/'),
+            pattern,
+            anchored,
+            directory_only,
             no_inherit: false,
             cvs_exclude: false,
             word_split: false,
@@ -193,6 +205,23 @@ pub(crate) fn build_wire_format_rules(
     }
 
     Ok(wire_rules)
+}
+
+/// Separates anchor (`/`) and directory (`/`) modifiers from the pattern body.
+///
+/// Returns `(pattern, anchored, directory_only)` where `pattern` excludes both
+/// the leading and trailing `/` when present. Bare `/` (which represents both
+/// modifiers on the root) is preserved as the pattern so it round-trips through
+/// the wire correctly.
+fn split_pattern_modifiers(raw: &str) -> (String, bool, bool) {
+    if raw == "/" {
+        return (raw.to_owned(), true, false);
+    }
+    let anchored = raw.starts_with('/');
+    let directory_only = raw.len() > 1 && raw.ends_with('/');
+    let start = usize::from(anchored);
+    let end = raw.len() - usize::from(directory_only);
+    (raw[start..end].to_owned(), anchored, directory_only)
 }
 
 /// Applies common server flags from client configuration to a server config.
@@ -351,7 +380,10 @@ mod tests {
 
         assert_eq!(rules.len(), 1);
         assert!(rules[0].anchored);
-        assert_eq!(rules[0].pattern, "/tmp");
+        // The leading `/` becomes the `anchored` flag and is stripped from
+        // the pattern body so that the wire serializer does not emit it
+        // twice (once as the prefix modifier and once as a literal).
+        assert_eq!(rules[0].pattern, "tmp");
     }
 
     #[test]
@@ -361,7 +393,52 @@ mod tests {
 
         assert_eq!(rules.len(), 1);
         assert!(rules[0].directory_only);
-        assert_eq!(rules[0].pattern, "cache/");
+        // Trailing `/` becomes the `directory_only` flag; the pattern body
+        // is the bare name so that serialization appends a single slash on
+        // the wire (otherwise upstream sees `cache//` and misparses it).
+        assert_eq!(rules[0].pattern, "cache");
+    }
+
+    #[test]
+    fn directory_only_wildcard_round_trips_without_double_slash() {
+        // upstream: `--include='*/'` produces wire bytes `+ */` with one
+        // trailing slash. Storing the slash both in the pattern and via
+        // the `directory_only` flag would double-encode it on the wire and
+        // cause upstream rsync to treat the rule as `*/` instead of `*`,
+        // matching only at depth 1 and breaking deeper directory traversal
+        // when combined with a trailing `--exclude='*'`.
+        let spec = FilterRuleSpec::include("*/");
+        let rules = build_wire_format_rules(&[spec]).expect("should convert dir wildcard");
+
+        assert_eq!(rules.len(), 1);
+        assert!(rules[0].directory_only);
+        assert_eq!(rules[0].pattern, "*");
+    }
+
+    #[test]
+    fn anchored_directory_only_preserves_both_flags() {
+        let spec = FilterRuleSpec::exclude("/build/");
+        let rules =
+            build_wire_format_rules(&[spec]).expect("should convert anchored directory rule");
+
+        assert_eq!(rules.len(), 1);
+        assert!(rules[0].anchored);
+        assert!(rules[0].directory_only);
+        assert_eq!(rules[0].pattern, "build");
+    }
+
+    #[test]
+    fn bare_root_slash_is_preserved() {
+        // `/` is the rare degenerate case where the slash is both anchored
+        // and (formally) directory-only. Keep the slash in the pattern so
+        // the wire is not empty after stripping.
+        let spec = FilterRuleSpec::exclude("/");
+        let rules = build_wire_format_rules(&[spec]).expect("should convert bare slash rule");
+
+        assert_eq!(rules.len(), 1);
+        assert!(rules[0].anchored);
+        assert!(!rules[0].directory_only);
+        assert_eq!(rules[0].pattern, "/");
     }
 
     #[test]

--- a/crates/filters/tests/include_then_exclude_all.rs
+++ b/crates/filters/tests/include_then_exclude_all.rs
@@ -1,0 +1,79 @@
+//! Regression tests for the `--include=*/ --include=<ext>... --exclude=*`
+//! idiom commonly used by RPKI/CRL mirroring tools and similar selective
+//! transfers. Replicates the issue reproducer that traversed directories
+//! incorrectly when `--exclude=*` swallowed the trailing-slash directory
+//! include.
+//!
+//! upstream: `exclude.c:rule_matches()` enforces `FILTRULE_DIRECTORY` so
+//! that `*/` rules only match directory entries, allowing recursion into
+//! them even when a later `*` exclude would otherwise hide everything.
+
+use filters::{FilterRule, FilterSet};
+use std::path::Path;
+
+/// Builds the exact rule list from the original bug report.
+fn rpki_style_rules() -> FilterSet {
+    FilterSet::from_rules([
+        FilterRule::include("*/"),
+        FilterRule::include("*.cer"),
+        FilterRule::include("*.crl"),
+        FilterRule::include("*.mft"),
+        FilterRule::include("*.roa"),
+        FilterRule::include("*.asa"),
+        FilterRule::include("*.tak"),
+        FilterRule::include("*.spl"),
+        FilterRule::exclude("*"),
+    ])
+    .unwrap()
+}
+
+#[test]
+fn directories_traverse_under_trailing_slash_include() {
+    let set = rpki_style_rules();
+
+    // Root-level and nested directories must remain visible so the walker
+    // can descend into them and evaluate the file rules inside.
+    assert!(set.allows(Path::new("subdir"), true));
+    assert!(set.allows(Path::new("deep/nested"), true));
+    assert!(set.allows(Path::new("a/b/c/d"), true));
+}
+
+#[test]
+fn extension_includes_match_at_any_depth() {
+    let set = rpki_style_rules();
+
+    assert!(set.allows(Path::new("foo.cer"), false));
+    assert!(set.allows(Path::new("bar.crl"), false));
+    assert!(set.allows(Path::new("subdir/inner.cer"), false));
+    assert!(set.allows(Path::new("deep/nested/cert.roa"), false));
+    assert!(set.allows(Path::new("publish/repo/manifest.mft"), false));
+}
+
+#[test]
+fn unrelated_files_are_excluded_by_terminal_star() {
+    let set = rpki_style_rules();
+
+    assert!(!set.allows(Path::new("readme.txt"), false));
+    assert!(!set.allows(Path::new("subdir/notes.txt"), false));
+    assert!(!set.allows(Path::new("deep/nested/skip.log"), false));
+}
+
+#[test]
+fn directory_only_include_does_not_swallow_files_with_same_name() {
+    let set = rpki_style_rules();
+
+    // A file (not a directory) called "subdir" must not be smuggled in by
+    // the `*/` rule. Upstream applies `FILTRULE_DIRECTORY` so the rule
+    // does not match when `is_dir` is false.
+    assert!(!set.allows(Path::new("subdir"), false));
+}
+
+#[test]
+fn empty_include_list_with_only_exclude_star_still_drops_everything() {
+    // Sanity: removing the directory include collapses the chain to the
+    // terminal exclude, which should reject every basename at every depth.
+    let set = FilterSet::from_rules([FilterRule::exclude("*")]).unwrap();
+
+    assert!(!set.allows(Path::new("foo.cer"), false));
+    assert!(!set.allows(Path::new("nested/foo.cer"), false));
+}

--- a/crates/protocol/src/filters/wire.rs
+++ b/crates/protocol/src/filters/wire.rs
@@ -528,6 +528,34 @@ mod tests {
         assert_eq!(parsed[0].pattern, "cache");
     }
 
+    /// Pattern stored on `FilterRuleWireFormat` must omit the trailing `/`
+    /// because `serialize_rule` re-appends it for directory-only rules.
+    /// Storing both produces `*//` on the wire, which upstream parses as
+    /// the pattern `*/` (slash-bearing, anchored-style) and breaks the
+    /// `--include='*/' --exclude='*'` directory-traversal idiom.
+    ///
+    /// upstream: `exclude.c:923` - patterns with internal slashes are
+    /// treated as anchored matches.
+    #[test]
+    fn directory_only_wildcard_emits_single_trailing_slash() {
+        let protocol = ProtocolVersion::from_supported(32).unwrap();
+        let rule = FilterRuleWireFormat::include("*".to_owned()).with_directory_only(true);
+
+        let mut buf = Vec::new();
+        write_filter_list(&mut buf, std::slice::from_ref(&rule), protocol).unwrap();
+
+        // 4-byte length prefix + payload + 4-byte zero terminator.
+        // Payload must be exactly `+ */` (4 bytes) - one trailing slash.
+        assert_eq!(&buf[..4], &4i32.to_le_bytes()[..]);
+        assert_eq!(&buf[4..8], b"+ */");
+        assert_eq!(&buf[8..], &0i32.to_le_bytes()[..]);
+
+        let parsed = read_filter_list(&mut &buf[..], protocol).unwrap();
+        assert_eq!(parsed.len(), 1);
+        assert!(parsed[0].directory_only);
+        assert_eq!(parsed[0].pattern, "*");
+    }
+
     #[test]
     fn sender_side_filter_v29() {
         let protocol = ProtocolVersion::from_supported(29).unwrap();

--- a/crates/transfer/src/generator/filters.rs
+++ b/crates/transfer/src/generator/filters.rs
@@ -271,8 +271,7 @@ impl GeneratorContext {
 /// the pattern string. This restores them so downstream rule compilation
 /// observes the user's original intent.
 fn reconstruct_pattern(wire_rule: &FilterRuleWireFormat) -> String {
-    let mut pattern =
-        String::with_capacity(wire_rule.pattern.len() + 2);
+    let mut pattern = String::with_capacity(wire_rule.pattern.len() + 2);
     if wire_rule.anchored && !wire_rule.pattern.starts_with('/') {
         pattern.push('/');
     }

--- a/crates/transfer/src/generator/filters.rs
+++ b/crates/transfer/src/generator/filters.rs
@@ -184,12 +184,24 @@ impl GeneratorContext {
         let mut merge_configs = Vec::new();
 
         for wire_rule in wire_rules {
-            // Convert wire RuleType to FilterRule
+            // The wire format stores the bare pattern in `pattern` and carries
+            // the anchored / directory-only modifiers as separate flags. The
+            // `filters` crate, however, encodes those modifiers as leading and
+            // trailing `/` in the pattern string itself, so reattach them
+            // before constructing the rule. Without this, `--include='*/'`
+            // would be received as the plain pattern `*` and lose its
+            // directory-only semantics, leading to a subsequent `--exclude='*'`
+            // swallowing directories that the user intended to traverse.
+            //
+            // upstream: exclude.c:get_rule_prefix() encodes anchored as the
+            // `/` modifier and directory-only as a trailing slash on the
+            // pattern body.
+            let reconstructed_pattern = reconstruct_pattern(wire_rule);
             let mut rule = match wire_rule.rule_type {
-                RuleType::Include => FilterRule::include(&wire_rule.pattern),
-                RuleType::Exclude => FilterRule::exclude(&wire_rule.pattern),
-                RuleType::Protect => FilterRule::protect(&wire_rule.pattern),
-                RuleType::Risk => FilterRule::risk(&wire_rule.pattern),
+                RuleType::Include => FilterRule::include(reconstructed_pattern),
+                RuleType::Exclude => FilterRule::exclude(reconstructed_pattern),
+                RuleType::Protect => FilterRule::protect(reconstructed_pattern),
+                RuleType::Risk => FilterRule::risk(reconstructed_pattern),
                 RuleType::Clear => {
                     // Clear rule removes all previous rules
                     rules.push(
@@ -231,13 +243,8 @@ impl GeneratorContext {
                 rule = rule.with_negate(true);
             }
 
-            if wire_rule.anchored {
-                rule = rule.anchor_to_root();
-            }
-
-            // Note: directory_only, no_inherit, cvs_exclude, word_split, exclude_from_merge
-            // are pattern modifiers handled by the filters crate during compilation
-            // We store them in the pattern itself as upstream does
+            // Note: no_inherit, cvs_exclude, word_split, exclude_from_merge
+            // are pattern modifiers handled by the filters crate during compilation.
 
             rules.push(rule);
         }
@@ -255,6 +262,25 @@ impl GeneratorContext {
 
         Ok((filter_set, merge_configs))
     }
+}
+
+/// Reassembles the pattern body with leading/trailing `/` modifiers re-applied.
+///
+/// Wire format separates the anchored (`/`) and directory-only (`/`) modifiers
+/// from the pattern body, while the `filters` crate expects them embedded in
+/// the pattern string. This restores them so downstream rule compilation
+/// observes the user's original intent.
+fn reconstruct_pattern(wire_rule: &FilterRuleWireFormat) -> String {
+    let mut pattern =
+        String::with_capacity(wire_rule.pattern.len() + 2);
+    if wire_rule.anchored && !wire_rule.pattern.starts_with('/') {
+        pattern.push('/');
+    }
+    pattern.push_str(&wire_rule.pattern);
+    if wire_rule.directory_only && !pattern.ends_with('/') {
+        pattern.push('/');
+    }
+    pattern
 }
 
 /// Converts a wire-format DirMerge rule into a `DirMergeConfig`.


### PR DESCRIPTION
## Summary

PR #4108 was supposed to merge this fix but the squash-merge inadvertently merged content from #4106 (info-stats) instead. This PR re-opens the actual filter precedence fix.

**Root cause**: `FilterRuleWireFormat` carries the leading `/` (anchored) and trailing `/` (directory-only) as separate boolean flags, but `build_wire_format_rules` was leaving those slashes in the pattern body. The wire serializer then re-emitted the trailing slash on top of the pattern, producing `+sr *//` for a plain `--include='*/'`. Upstream rsync parsed the doubled slash as part of the pattern, demoting `*` (matches any directory at any depth) into the depth-1 anchored form `*/`, so the subsequent `--exclude='*'` swallowed every nested directory.

**Reproduction confirmed**: A daemon transfer that should produce 8 entries returned only 2. After the fix the oc-rsync output matches upstream byte-for-byte.

## Changes

- `crates/core/src/client/remote/flags.rs` - added `split_pattern_modifiers` and stripped leading/trailing slashes into the flag fields
- `crates/transfer/src/generator/filters.rs` - added `reconstruct_pattern` so the receiver-side local FilterChain rebuilds the pattern with its modifier slashes restored
- `crates/protocol/src/filters/wire.rs` - regression test locking the wire payload for `--include='*/'` to exactly `+ */`
- `crates/filters/tests/include_then_exclude_all.rs` - new regression suite exercising the user-visible rule list

## Test plan

- [x] Unit: `crates/core/src/client/remote/flags.rs` flag-extraction tests
- [x] Wire: `crates/protocol/src/filters/wire.rs` payload regression
- [x] Integration: `crates/filters/tests/include_then_exclude_all.rs` precedence suite
- [ ] CI green across stable/beta/nightly + Windows/macOS/musl + interop

Closes #4107