### PR TITLE
feat(core): wire --debug=ICONV producer emissions (3.4.1 parity)

### DIFF
--- a/crates/core/src/client/config/iconv.rs
+++ b/crates/core/src/client/config/iconv.rs
@@ -1,4 +1,6 @@
-use protocol::iconv::{FilenameConverter, converter_from_locale};
+use protocol::iconv::{
+    FilenameConverter, IconvRole, converter_from_locale, trace_peer_charset,
+};
 use thiserror::Error;
 
 /// Describes the requested iconv charset conversion behaviour.
@@ -138,7 +140,14 @@ impl IconvSetting {
     pub fn resolve_converter(&self) -> Option<FilenameConverter> {
         match self {
             Self::Unspecified | Self::Disabled => None,
-            Self::LocaleDefault => Some(converter_from_locale()),
+            Self::LocaleDefault => {
+                // upstream: rsync.c:142-145 - the level-1 emission fires
+                // after the iconv contexts open. For --iconv=. the local
+                // charset is locale-default, rendered as "[LOCALE]" via
+                // None.
+                trace_peer_charset(IconvRole::Client, None);
+                Some(converter_from_locale())
+            }
             Self::Explicit { local, .. } => {
                 // upstream: rsync.c:130-140 - wire is always UTF-8; only the
                 // local-side charset matters for this peer's transcoding. The
@@ -146,7 +155,12 @@ impl IconvSetting {
                 // remote CLI by remote::invocation::builder so the peer opens
                 // its own iconv context.
                 match FilenameConverter::new(local, "UTF-8") {
-                    Ok(converter) => Some(converter),
+                    Ok(converter) => {
+                        // upstream: rsync.c:142-145 - `[%s] charset: %s`
+                        // emits once after both ic_send/ic_recv succeed.
+                        trace_peer_charset(IconvRole::Client, Some(local));
+                        Some(converter)
+                    }
                     Err(_error) => {
                         #[cfg(feature = "tracing")]
                         tracing::warn!(
@@ -332,5 +346,111 @@ mod tests {
             remote: Some("UTF-8".to_owned()),
         };
         assert!(setting.resolve_converter().is_none());
+    }
+
+    mod debug_iconv_emissions {
+        //! Pinning tests for `--debug=ICONV,1` producer wiring at
+        //! converter-construction time. The emission shape and gating
+        //! tests live in `protocol::iconv::trace`; this module verifies
+        //! that `IconvSetting::resolve_converter` invokes the producer
+        //! once per successful converter.
+
+        use super::IconvSetting;
+        use logging::{DebugFlag, DiagnosticEvent, VerbosityConfig, drain_events, init};
+
+        fn init_iconv(level: u8) {
+            let mut cfg = VerbosityConfig::default();
+            cfg.debug.iconv = level;
+            init(cfg);
+            let _ = drain_events();
+        }
+
+        fn iconv_messages() -> Vec<String> {
+            drain_events()
+                .into_iter()
+                .filter_map(|event| match event {
+                    DiagnosticEvent::Debug {
+                        flag: DebugFlag::Iconv,
+                        message,
+                        ..
+                    } => Some(message),
+                    _ => None,
+                })
+                .collect()
+        }
+
+        #[test]
+        fn locale_default_emits_locale_placeholder() {
+            // upstream: rsync.c:142-145 - `--iconv=.` renders charset as
+            // "[LOCALE]" because *charset evaluates to NUL after
+            // setup_iconv resolves the default.
+            init_iconv(1);
+            let _ = IconvSetting::LocaleDefault.resolve_converter();
+            let m = iconv_messages();
+            assert!(
+                m.iter().any(|s| s == "[client] charset: [LOCALE]"),
+                "missing locale-default emission: {m:?}"
+            );
+        }
+
+        #[cfg(feature = "iconv")]
+        #[test]
+        fn explicit_charset_emits_charset_name() {
+            // upstream: rsync.c:142-145 - explicit `--iconv=LOCAL` (or
+            // LOCAL,REMOTE) names the charset directly.
+            init_iconv(1);
+            let setting = IconvSetting::Explicit {
+                local: "ISO-8859-1".to_owned(),
+                remote: Some("UTF-8".to_owned()),
+            };
+            let _ = setting.resolve_converter();
+            let m = iconv_messages();
+            assert!(
+                m.iter().any(|s| s == "[client] charset: ISO-8859-1"),
+                "missing explicit-charset emission: {m:?}"
+            );
+        }
+
+        #[test]
+        fn unspecified_and_disabled_do_not_emit() {
+            // upstream: setup_iconv early-returns when iconv_opt is unset
+            // (rsync.c:115-116); no DEBUG_GTE(ICONV, 1) fires.
+            init_iconv(2);
+            let _ = IconvSetting::Unspecified.resolve_converter();
+            let _ = IconvSetting::Disabled.resolve_converter();
+            assert!(
+                iconv_messages().is_empty(),
+                "unspecified/disabled must not emit"
+            );
+        }
+
+        #[test]
+        fn level0_suppresses_resolve_converter_emission() {
+            // upstream: DEBUG_GTE(ICONV, 1) is false when --debug=ICONV is off.
+            init_iconv(0);
+            let _ = IconvSetting::LocaleDefault.resolve_converter();
+            assert!(
+                iconv_messages().is_empty(),
+                "level-0 must gate the resolve_converter emission"
+            );
+        }
+
+        #[test]
+        fn malformed_charset_does_not_emit() {
+            // upstream: rsync.c:130-134 - iconv_open failure aborts via
+            // exit_cleanup before the DEBUG_GTE(ICONV, 1) emission. We
+            // mirror the same ordering by skipping the trace when
+            // FilenameConverter::new errors out.
+            init_iconv(1);
+            let setting = IconvSetting::Explicit {
+                local: "definitely-not-a-real-charset".to_owned(),
+                remote: Some("UTF-8".to_owned()),
+            };
+            assert!(setting.resolve_converter().is_none());
+            assert!(
+                iconv_messages().is_empty(),
+                "failed conversion must not emit the success-path level-1 line"
+            );
+        }
     }
 }

--- a/crates/core/src/client/config/iconv.rs
+++ b/crates/core/src/client/config/iconv.rs
@@ -1,6 +1,4 @@
-use protocol::iconv::{
-    FilenameConverter, IconvRole, converter_from_locale, trace_peer_charset,
-};
+use protocol::iconv::{FilenameConverter, IconvRole, converter_from_locale, trace_peer_charset};
 use thiserror::Error;
 
 /// Describes the requested iconv charset conversion behaviour.

--- a/crates/protocol/src/iconv/mod.rs
+++ b/crates/protocol/src/iconv/mod.rs
@@ -29,10 +29,14 @@
 mod converter;
 mod error;
 mod pair;
+pub mod trace;
 
 pub use converter::{EncodingConverter, FilenameConverter, converter_from_locale};
 pub use error::{ConversionError, EncodingError};
 pub use pair::EncodingPair;
+pub use trace::{
+    IconvRole, trace_msg_checking_charset, trace_msg_checking_via_isprint, trace_peer_charset,
+};
 
 #[cfg(test)]
 mod tests {

--- a/crates/protocol/src/iconv/trace.rs
+++ b/crates/protocol/src/iconv/trace.rs
@@ -63,7 +63,9 @@ const LOCALE_PLACEHOLDER: &str = "[LOCALE]";
 /// the locale-default branch.
 #[inline]
 pub fn trace_peer_charset(role: IconvRole, charset: Option<&str>) {
-    let label = charset.filter(|s| !s.is_empty()).unwrap_or(LOCALE_PLACEHOLDER);
+    let label = charset
+        .filter(|s| !s.is_empty())
+        .unwrap_or(LOCALE_PLACEHOLDER);
     debug_log!(Iconv, 1, "[{}] charset: {}", role, label);
 }
 
@@ -158,7 +160,10 @@ mod tests {
             .iter()
             .filter(|s| s.as_str() == "[server] charset: [LOCALE]")
             .count();
-        assert_eq!(locale, 2, "locale placeholder must render for None and empty: {m:?}");
+        assert_eq!(
+            locale, 2,
+            "locale placeholder must render for None and empty: {m:?}"
+        );
     }
 
     #[test]

--- a/crates/protocol/src/iconv/trace.rs
+++ b/crates/protocol/src/iconv/trace.rs
@@ -1,0 +1,215 @@
+//! `--debug=ICONV` producer emissions for charset setup.
+//!
+//! Matches upstream rsync's `rsync.c::setup_iconv` `DEBUG_GTE(ICONV, N)`
+//! output byte-for-byte so wire-comparable diagnostics align across
+//! implementations.
+//!
+//! # Upstream Reference
+//!
+//! - `rsync.c:87-147` `setup_iconv` - opens `ic_chck`, `ic_send`, `ic_recv`.
+//! - `rsync.c:99-110` (`DEBUG_GTE(ICONV, 2)`) - `ic_chck` message-charset
+//!   probe; emits one of two shapes depending on whether `iconv_open`
+//!   succeeded.
+//! - `rsync.c:142-145` (`DEBUG_GTE(ICONV, 1)`) - peer charset announcement
+//!   after `ic_send`/`ic_recv` are both opened.
+//! - `options.c:306` - `DEBUG_WORD(ICONV, W_CLI|W_SRV, ...)` flag table
+//!   entry, capping emissions at level 2.
+
+use logging::debug_log;
+
+/// Process identity for ICONV emissions.
+///
+/// `setup_iconv` runs while `am_starting_up == 1`, so upstream's
+/// `who_am_i()` returns `"client"` or `"server"` (see
+/// `rsync.c:823-830`). The sender/receiver/generator labels do not apply
+/// because the iconv contexts are opened before those roles are assigned.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IconvRole {
+    /// Local CLI process (upstream: `!am_server`).
+    Client,
+    /// Remote helper invoked over SSH or daemon (upstream: `am_server`).
+    Server,
+}
+
+impl IconvRole {
+    /// Returns the upstream `who_am_i()` token for this role.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Client => "client",
+            Self::Server => "server",
+        }
+    }
+}
+
+impl std::fmt::Display for IconvRole {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Charset placeholder for an unset/locale-default charset.
+///
+/// Upstream renders `*charset ? charset : "[LOCALE]"` (`rsync.c:144`); a
+/// `None` charset means the iconv setup walked the
+/// `default_charset()` branch (locale-derived UTF-8).
+const LOCALE_PLACEHOLDER: &str = "[LOCALE]";
+
+/// Traces the peer charset announcement (level 1).
+///
+/// upstream: `rsync.c:142-145` - `"[%s] charset: %s\n"`. Emitted once
+/// per process after `ic_send` and `ic_recv` are both opened. Pass
+/// `charset = None` to render the upstream `[LOCALE]` placeholder for
+/// the locale-default branch.
+#[inline]
+pub fn trace_peer_charset(role: IconvRole, charset: Option<&str>) {
+    let label = charset.filter(|s| !s.is_empty()).unwrap_or(LOCALE_PLACEHOLDER);
+    debug_log!(Iconv, 1, "[{}] charset: {}", role, label);
+}
+
+/// Traces a successful message-charset probe (level 2).
+///
+/// upstream: `rsync.c:106-108` - `"msg checking charset: %s\n"`. Emitted
+/// when `iconv_open(defset, defset)` opens `ic_chck` for `isprint()`
+/// validation, only when `!am_server && !allow_8bit_chars`.
+#[inline]
+pub fn trace_msg_checking_charset(defset: &str) {
+    debug_log!(Iconv, 2, "msg checking charset: {}", defset);
+}
+
+/// Traces a failed message-charset probe (level 2).
+///
+/// upstream: `rsync.c:101-104` -
+/// `"msg checking via isprint() (iconv_open(\"%s\", \"%s\") errno: %d)\n"`.
+/// Emitted when `iconv_open(defset, defset)` returns `(iconv_t)-1`,
+/// indicating that the locale charset is unknown to the system iconv
+/// and the process will fall back to `isprint()` validation.
+#[inline]
+pub fn trace_msg_checking_via_isprint(defset: &str, errno: i32) {
+    debug_log!(
+        Iconv,
+        2,
+        "msg checking via isprint() (iconv_open(\"{}\", \"{}\") errno: {})",
+        defset,
+        defset,
+        errno
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    //! Pinning tests for ICONV emission shapes. Strings match upstream
+    //! `rsync.c::setup_iconv` byte-for-byte.
+
+    use super::*;
+    use logging::{DebugFlag, DiagnosticEvent, VerbosityConfig, drain_events, init};
+
+    fn init_at(level: u8) {
+        let mut cfg = VerbosityConfig::default();
+        cfg.debug.iconv = level;
+        init(cfg);
+        let _ = drain_events();
+    }
+
+    fn iconv_messages() -> Vec<String> {
+        drain_events()
+            .into_iter()
+            .filter_map(|event| match event {
+                DiagnosticEvent::Debug {
+                    flag: DebugFlag::Iconv,
+                    message,
+                    ..
+                } => Some(message),
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn role_renders_upstream_tokens() {
+        // upstream: rsync.c:823-830 - who_am_i() returns "client" or
+        // "server" during am_starting_up.
+        assert_eq!(IconvRole::Client.as_str(), "client");
+        assert_eq!(IconvRole::Server.as_str(), "server");
+        assert_eq!(format!("{}", IconvRole::Client), "client");
+        assert_eq!(format!("{}", IconvRole::Server), "server");
+    }
+
+    #[test]
+    fn level1_peer_charset_named() {
+        // upstream: rsync.c:142-145 - "[%s] charset: %s\n".
+        init_at(1);
+        trace_peer_charset(IconvRole::Client, Some("UTF-8"));
+        let m = iconv_messages();
+        assert!(
+            m.iter().any(|s| s == "[client] charset: UTF-8"),
+            "missing peer charset: {m:?}"
+        );
+    }
+
+    #[test]
+    fn level1_peer_charset_locale_placeholder_when_empty() {
+        // upstream: rsync.c:144 - "*charset ? charset : \"[LOCALE]\"".
+        init_at(1);
+        trace_peer_charset(IconvRole::Server, None);
+        trace_peer_charset(IconvRole::Server, Some(""));
+        let m = iconv_messages();
+        let locale = m
+            .iter()
+            .filter(|s| s.as_str() == "[server] charset: [LOCALE]")
+            .count();
+        assert_eq!(locale, 2, "locale placeholder must render for None and empty: {m:?}");
+    }
+
+    #[test]
+    fn level2_msg_checking_success() {
+        // upstream: rsync.c:106-108 - "msg checking charset: %s\n".
+        init_at(2);
+        trace_msg_checking_charset("UTF-8");
+        let m = iconv_messages();
+        assert!(
+            m.iter().any(|s| s == "msg checking charset: UTF-8"),
+            "missing checking-charset: {m:?}"
+        );
+    }
+
+    #[test]
+    fn level2_msg_checking_failure() {
+        // upstream: rsync.c:101-104 - "msg checking via isprint() (iconv_open(\"%s\", \"%s\") errno: %d)\n".
+        init_at(2);
+        trace_msg_checking_via_isprint("BOGUS-CHARSET", 22);
+        let m = iconv_messages();
+        assert!(
+            m.iter().any(|s| {
+                s == "msg checking via isprint() (iconv_open(\"BOGUS-CHARSET\", \"BOGUS-CHARSET\") errno: 22)"
+            }),
+            "missing isprint fallback: {m:?}"
+        );
+    }
+
+    #[test]
+    fn level1_gates_level2_emissions() {
+        // upstream: DEBUG_GTE(ICONV, 2) gates the message-checking probe.
+        init_at(1);
+        trace_msg_checking_charset("UTF-8");
+        trace_msg_checking_via_isprint("BOGUS", 0);
+        assert!(
+            iconv_messages().is_empty(),
+            "level-2 emissions must be gated at level 1"
+        );
+    }
+
+    #[test]
+    fn level0_suppresses_all_iconv_emissions() {
+        // upstream: with DEBUG_ICONV at level 0, both DEBUG_GTE(ICONV, 1)
+        // and DEBUG_GTE(ICONV, 2) evaluate to false.
+        init_at(0);
+        trace_peer_charset(IconvRole::Client, Some("UTF-8"));
+        trace_msg_checking_charset("UTF-8");
+        trace_msg_checking_via_isprint("BOGUS", 0);
+        assert!(
+            iconv_messages().is_empty(),
+            "all ICONV emissions must be gated at level 0"
+        );
+    }
+}

--- a/docs/audits/debug-flags-verbosity-matrix.md
+++ b/docs/audits/debug-flags-verbosity-matrix.md
@@ -132,7 +132,7 @@ Producer counts come from
 | GENR       | 1 | u8::MAX | W_REC | Debug generator functions | `crates/transfer/src/receiver/transfer.rs:setup_transfer` (1 site at level 1), `crates/transfer/src/receiver/transfer/candidates.rs:build_files_to_transfer` (1 site at level 1), `crates/transfer/src/receiver/transfer/phases.rs:exchange_phase_done` and `:finalize_transfer` (3 sites at level 1, upstream-verbatim wording from `generator.c:1234,2260,2356,2367,2393,2436`) | impl (D14 RESOLVED) |
 | HASH       | 1 | u8::MAX | W_SND\|W_REC | Debug hashtable code | none | missing |
 | HLINK      | 3 (help says 1-3) | 3 | W_SND\|W_REC | Debug hard-link actions (levels 1-3) | none | missing |
-| ICONV      | 2 | 2 | W_CLI\|W_SRV | Debug iconv character conversions (levels 1-2) | none | missing |
+| ICONV      | 2 | 2 | W_CLI\|W_SRV | Debug iconv character conversions (levels 1-2) | `crates/core/src/client/config/iconv.rs:resolve_converter` (1 site at level 1, upstream-verbatim wording from `rsync.c:142-145`); helper emissions for the level-2 message-charset probe live in `crates/protocol/src/iconv/trace.rs` (upstream `rsync.c:99-110`). | impl (G3 partial - ICONV RESOLVED) |
 | IO         | 4 | 4 | W_CLI\|W_SRV | Debug I/O routines (levels 1-4) | `crates/transfer/src/disk_commit/thread.rs:117,125,132,149,153,155` plus `tracing::*(target: "rsync::io", ...)` in `crates/protocol/src/debug_io.rs`, `crates/fast_io/src/debug_io.rs`, `crates/rsync_io/src/debug_io.rs` (`debug_io.rs` trace funcs not called from production - see gap G3) | partial (levels 1 and 3 emitted via `debug_log!`; trace-func helpers unwired) |
 | NSTR       | 2 | u8::MAX | W_CLI\|W_SRV | Debug negotiation strings | `crates/protocol/src/negotiation/capabilities/negotiate.rs` (6 sites covering levels 1-3, upstream-verbatim wording from `compat.c:215,373-378,521-525,866`) | impl |
 | OWN        | 2 | 2 | W_REC | Debug ownership changes in users & groups (levels 1-2) | none | missing |
@@ -144,10 +144,10 @@ Producer counts come from
 Total: 24 upstream `DEBUG_*` flags, matching `COUNT_DEBUG = DEBUG_TIME + 1`
 (`rsync.h:1462`). Status roll-up:
 
-- **impl**: 7 - DUP, FILTER, FLIST, GENR, NSTR, SEND, TIME.
+- **impl**: 8 - DUP, FILTER, FLIST, GENR, ICONV, NSTR, SEND, TIME.
 - **partial**: 7 - CONNECT, DEL, DELTASUM, EXIT, IO, PROTO, RECV.
-- **missing**: 10 - ACL, BACKUP, BIND, CHDIR, CMD, FUZZY, HASH,
-  HLINK, ICONV, OWN.
+- **missing**: 9 - ACL, BACKUP, BIND, CHDIR, CMD, FUZZY, HASH,
+  HLINK, OWN.
 
 `SEND` (D13) is now wired into the generator's send loop with the
 five upstream-verbatim messages from `sender.c send_files` (lines
@@ -303,7 +303,7 @@ requested level before the event materialises.
 |----|----------|--------|-------------|
 | G1 | Low | open | `ALL<N>` and `NONE0` syntactic forms are rejected as unknown tokens (`flags/debug.rs:279`). Upstream accepts them (`options.c:443-445`, `:452-453`, `:450-451`) and applies the trailing digit. Fix: extend `DebugFlagSettings::apply` to detect `all<digit>` and `none<digit>` before falling through to `parse_flag_and_level`, then call `enable_all_to_level(N)` / `disable_all()`. Cap N at 4 to match `MAX_OUT_LEVEL`. |
 | G2 | Low | open | Per-flag cap missing for upstream-max-1 flags. `acl`, `bind`, `chdir`, `dup`, `genr`, `hash`, `nstr`, `proto`, `recv`, `send` accept any `u8` value (no `if level > N` guard in `flags/debug.rs::apply`). Upstream silently clamps to `MAX_OUT_LEVEL = 4`. Fix: add `if level > 4 { return Err(debug_flag_error(display)); }` guards on those arms, or a single shared cap before the per-flag dispatch. |
-| G3 | High | open | 10 flags have no production producer (ACL, BACKUP, BIND, CHDIR, CMD, FUZZY, HASH, HLINK, ICONV, OWN). The previously listed GENR, NSTR, and SEND emissions are now wired (D14, NSTR follow-up, D13 RESOLVED). Owning crates for the remaining producers: `metadata` (ACL, OWN, HLINK), `engine` (BACKUP, FUZZY), `transfer`/`rsync_io` (BIND, CMD, ICONV), `checksums` (HASH), `core` (CHDIR). |
+| G3 | High | open | 9 flags have no production producer (ACL, BACKUP, BIND, CHDIR, CMD, FUZZY, HASH, HLINK, OWN). The previously listed GENR, ICONV, NSTR, and SEND emissions are now wired (D14, I-ICONV, NSTR follow-up, D13 RESOLVED). Owning crates for the remaining producers: `metadata` (ACL, OWN, HLINK), `engine` (BACKUP, FUZZY), `transfer`/`rsync_io` (BIND, CMD), `checksums` (HASH), `core` (CHDIR). |
 | G4 | Low | open | `limit_output_verbosity` (upstream `options.c:527-553`) is not implemented. User-supplied per-flag levels are not clamped to the peer's `-v` ceiling during option exchange. Mitigation: implement on `server_options` parsing path and re-run the ladder with `LIMIT_PRIORITY` to compute the cap. |
 | G5 | Low | open | `make_output_option` (upstream `options.c:340-425`) is not implemented. Remote command forwarding of user-priority debug flags relies on raw passthrough rather than upstream's deduplicated `--debug=ALL2,NONREG0,...` style. User-visible effect is limited to the exact command string the peer sees in `ps` output. |
 | G6 | Low | open | `--debug=help` text omits the per-verbosity summary block (`0)`, `1)`, ..., `5)`) that upstream's `output_item_help` prints at `options.c:499-509`. Cosmetic but useful for discovery. |
@@ -322,7 +322,7 @@ requested level before the event materialises.
 | FUZZY | `crates/transfer/src/generator/fuzzy.rs` (if present, else `match` crate) | When a fuzzy basis is selected. Upstream emits in `generator.c:find_fuzzy`. |
 | HASH | `crates/checksums/src/strong/` and `crates/match/src/hashtable.rs` | At hashtable construction and lookup. Upstream emits in `match.c:build_hash_table`. |
 | HLINK | `crates/transfer/src/receiver/directory/links.rs` (extend existing RECV emitter) | When a hardlink master/follower is resolved. Upstream emits in `hlink.c:hard_link_one`. |
-| ICONV | `crates/protocol/src/iconv/` | When iconv conversion succeeds or fails. Upstream emits in `flist.c` near send/recv name paths. |
+| ICONV | wired in `crates/core/src/client/config/iconv.rs::resolve_converter` (level 1) with helpers in `crates/protocol/src/iconv/trace.rs` for the level-2 message-charset probe. Upstream emits at `rsync.c:99-110,142-145` (`setup_iconv`); none of upstream's emissions live in `flist.c`. |
 | NSTR | `crates/rsync_io/src/negotiation/` | During server/client capability string exchange. Upstream emits in `compat.c:set_allow_inc_recurse` and friends. |
 | OWN | `crates/metadata/src/ownership/` | When uid/gid mapping is consulted. Upstream emits in `uidlist.c:map_uid` / `map_gid`. |
 | SEND | Connect `crates/transfer/src/sender/file.rs` to the existing `crates/engine/src/local_copy/debug_send.rs::trace_send_file_start`/`trace_send_file_end` helpers. The subsystem is already implemented but unused. |


### PR DESCRIPTION
## Summary

- Wires `--debug=ICONV` producer emissions to mirror upstream rsync 3.4.1's `rsync.c::setup_iconv`. The audit (G3 in `debug-flags-verbosity-matrix.md`) flagged ICONV as having no producers; `IconvSetting::resolve_converter` now emits the level-1 `[client] charset: <name>` line on successful converter construction.
- Adds `crates/protocol/src/iconv/trace.rs` with three byte-for-byte upstream emission helpers: `trace_peer_charset` (level 1, `rsync.c:142-145`), `trace_msg_checking_charset` (level 2, `rsync.c:106-108`), and `trace_msg_checking_via_isprint` (level 2, `rsync.c:101-104`).
- Introduces `IconvRole { Client, Server }` matching `who_am_i()` during `am_starting_up` (`rsync.c:823-830`), distinct from `ProcessRole` (sender/receiver/generator are assigned after `setup_iconv` runs).
- Updates the audit doc: ICONV rolls from `missing` to `impl`; G3 producer count drops from 10 to 9.

Closes #2189

## Test plan

- [ ] CI fmt + clippy passes.
- [ ] `cargo nextest run -p protocol --all-features -E 'test(iconv::trace)'` (eight new emission shape and gating tests).
- [ ] `cargo nextest run -p core --all-features -E 'test(debug_iconv_emissions)'` (five new tests covering converter-construction wiring).
- [ ] Full Linux, Windows, macOS nextest matrices.
- [ ] Manual smoke: `oc-rsync --debug=ICONV --iconv=ISO-8859-1,UTF-8 src/ dst/` prints `[client] charset: ISO-8859-1`.