### PR TITLE
feat(metadata): wire --debug=ACL producer emissions (3.4.1 parity)

### DIFF
--- a/crates/metadata/Cargo.toml
+++ b/crates/metadata/Cargo.toml
@@ -53,5 +53,6 @@ xattr = ["dep:xattr"]
 acl = ["dep:exacl"]
 
 [dev-dependencies]
+logging = { path = "../logging" }
 tempfile = "3.15"
 test-support = { path = "../test-support" }

--- a/crates/metadata/src/acl_exacl.rs
+++ b/crates/metadata/src/acl_exacl.rs
@@ -57,7 +57,9 @@ use std::path::Path;
 #[cfg(any(target_os = "linux", target_os = "freebsd"))]
 use exacl::AclOption;
 use exacl::{AclEntry, AclEntryKind, Perm, getfacl, setfacl};
-use protocol::acl::{AclCache, IdAccess, NAME_IS_USER, NO_ENTRY, RsyncAcl};
+use protocol::acl::{
+    AclCache, IdAccess, NAME_IS_USER, NO_ENTRY, RsyncAcl, trace_default_perms_for_dir,
+};
 
 use crate::MetadataError;
 
@@ -642,6 +644,90 @@ pub fn apply_acls_from_cache(
     Ok(())
 }
 
+/// Computes the default permission bits a child of `dir` should inherit.
+///
+/// Mirrors upstream rsync's `default_perms_for_dir` (`acls.c:1083-1139`):
+///
+/// 1. Start from `ACCESSPERMS & ~umask` (the POSIX default).
+/// 2. Read the directory's default POSIX ACL.
+/// 3. When the ACL has a `user_obj` entry, fold its bits into the returned
+///    permission mask via `rsync_acl_get_perms`.
+/// 4. When `--debug=ACL` is at level 1, emit `got ACL-based default perms %o
+///    for directory %s` (`acls.c:1133-1134`).
+///
+/// Unsupported filesystems and missing default ACLs both fall back to the
+/// umask-derived default without emitting; only the successful ACL lookup
+/// produces the upstream debug line.
+///
+/// On platforms that do not expose POSIX default ACLs (e.g. macOS), this
+/// function returns the umask-derived default and never emits, matching the
+/// `#ifdef SUPPORT_ACLS` gating at `generator.c:1337-1340`.
+///
+/// # Upstream Reference
+///
+/// - `acls.c:1083-1139` `default_perms_for_dir`
+/// - `generator.c:1337-1340` and `receiver.c:846-851` - the two call sites
+///   that fold the returned bits into `dest_mode()` when `--perms` is off.
+#[allow(clippy::module_name_repetitions)]
+#[must_use]
+pub fn default_perms_for_dir(dir: &Path, orig_umask: u32) -> u32 {
+    // upstream: acls.c:1093 - perms = ACCESSPERMS & ~orig_umask
+    let default_perms = 0o777u32 & !(orig_umask & 0o777);
+
+    #[cfg(any(target_os = "linux", target_os = "freebsd"))]
+    {
+        let dir_label = dir.to_string_lossy();
+        let entries = match getfacl(dir, Some(AclOption::DEFAULT_ACL)) {
+            Ok(e) => e,
+            Err(_) => return default_perms,
+        };
+
+        if entries.is_empty() {
+            return default_perms;
+        }
+
+        // upstream: acls.c:1131 - racl.user_obj != NO_ENTRY guard
+        let mut user_obj_perms: Option<u8> = None;
+        let mut group_obj_perms: Option<u8> = None;
+        let mut other_obj_perms: Option<u8> = None;
+        for entry in &entries {
+            let perms = exacl_perms_to_rsync(entry.perms);
+            match entry.kind {
+                AclEntryKind::User if entry.name.is_empty() && user_obj_perms.is_none() => {
+                    user_obj_perms = Some(perms);
+                }
+                AclEntryKind::Group if entry.name.is_empty() && group_obj_perms.is_none() => {
+                    group_obj_perms = Some(perms);
+                }
+                AclEntryKind::Other if other_obj_perms.is_none() => {
+                    other_obj_perms = Some(perms);
+                }
+                _ => {}
+            }
+        }
+
+        let Some(user_obj) = user_obj_perms else {
+            return default_perms;
+        };
+        // upstream: acls.c:1132 - perms = rsync_acl_get_perms(&racl)
+        //   = (user_obj << 6) | (group_obj << 3) | other_obj
+        let perms = (u32::from(user_obj) << 6)
+            | (u32::from(group_obj_perms.unwrap_or(0)) << 3)
+            | u32::from(other_obj_perms.unwrap_or(0));
+        // upstream: acls.c:1133-1134 - DEBUG_GTE(ACL, 1) emission
+        trace_default_perms_for_dir(perms, &dir_label);
+        return perms;
+    }
+
+    #[cfg(not(any(target_os = "linux", target_os = "freebsd")))]
+    {
+        // macOS and other targets without POSIX default ACLs: no emission,
+        // matches upstream's `#ifdef SUPPORT_ACLS` guard at generator.c:1337.
+        let _ = dir;
+        default_perms
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -875,5 +961,123 @@ mod tests {
         // Index 99 does not exist - should be a no-op, not an error
         let result = apply_acls_from_cache(&file, &cache, 99, None, true, Some(0o644));
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn default_perms_for_dir_no_acl_returns_umask_default() {
+        // No default ACL: upstream returns ACCESSPERMS & ~orig_umask without
+        // emitting `DEBUG_GTE(ACL, 1)`.
+        let dir = tempdir().expect("tempdir");
+        let target = dir.path().join("no_default_acl");
+        std::fs::create_dir(&target).expect("create dir");
+
+        assert_eq!(default_perms_for_dir(&target, 0o022), 0o755);
+        assert_eq!(default_perms_for_dir(&target, 0o077), 0o700);
+        assert_eq!(default_perms_for_dir(&target, 0), 0o777);
+    }
+
+    #[test]
+    fn default_perms_for_dir_missing_dir_returns_umask_default() {
+        // getfacl error path: upstream falls back to umask-derived default
+        // and never emits. Verify the same here.
+        let dir = tempdir().expect("tempdir");
+        let missing = dir.path().join("nonexistent");
+
+        assert_eq!(default_perms_for_dir(&missing, 0o022), 0o755);
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "freebsd"))]
+    #[test]
+    fn default_perms_for_dir_emits_when_default_acl_present() {
+        // upstream: acls.c:1131-1134 - DEBUG_GTE(ACL, 1) fires when the
+        // directory's default ACL unpacked into a user_obj entry.
+        use logging::{DebugFlag, DiagnosticEvent, VerbosityConfig, drain_events, init};
+
+        let dir = tempdir().expect("tempdir");
+        let target = dir.path().join("with_default_acl");
+        std::fs::create_dir(&target).expect("create dir");
+
+        // Install a default ACL: user::rwx, group::r-x, other::r-x.
+        let default_entries = vec![
+            exacl::AclEntry::allow_user("", Perm::READ | Perm::WRITE | Perm::EXECUTE, None),
+            exacl::AclEntry::allow_group("", Perm::READ | Perm::EXECUTE, None),
+            exacl::AclEntry::allow_other(Perm::READ | Perm::EXECUTE, None),
+        ];
+        if setfacl(&[&target], &default_entries, Some(AclOption::DEFAULT_ACL)).is_err() {
+            // Filesystem doesn't support default ACLs (e.g., tmpfs without acl mount).
+            // Skip the emission assertion; this is the same fallback upstream takes.
+            return;
+        }
+
+        let mut cfg = VerbosityConfig::default();
+        cfg.debug.acl = 1;
+        init(cfg);
+        let _ = drain_events();
+
+        let perms = default_perms_for_dir(&target, 0o022);
+        assert_eq!(perms, 0o755);
+
+        let messages: Vec<String> = drain_events()
+            .into_iter()
+            .filter_map(|event| match event {
+                DiagnosticEvent::Debug {
+                    flag: DebugFlag::Acl,
+                    message,
+                    ..
+                } => Some(message),
+                _ => None,
+            })
+            .collect();
+        let expected = format!(
+            "got ACL-based default perms 755 for directory {}",
+            target.display()
+        );
+        assert!(
+            messages.iter().any(|m| m == &expected),
+            "expected emission {expected:?}, got {messages:?}"
+        );
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "freebsd"))]
+    #[test]
+    fn default_perms_for_dir_no_emission_when_disabled() {
+        // upstream: DEBUG_GTE(ACL, 1) is gated; level 0 suppresses the line
+        // even when the default ACL unpacks successfully.
+        use logging::{DebugFlag, DiagnosticEvent, VerbosityConfig, drain_events, init};
+
+        let dir = tempdir().expect("tempdir");
+        let target = dir.path().join("with_default_acl_silent");
+        std::fs::create_dir(&target).expect("create dir");
+
+        let default_entries = vec![
+            exacl::AclEntry::allow_user("", Perm::READ | Perm::WRITE | Perm::EXECUTE, None),
+            exacl::AclEntry::allow_group("", Perm::READ, None),
+            exacl::AclEntry::allow_other(Perm::empty(), None),
+        ];
+        if setfacl(&[&target], &default_entries, Some(AclOption::DEFAULT_ACL)).is_err() {
+            return;
+        }
+
+        let mut cfg = VerbosityConfig::default();
+        cfg.debug.acl = 0;
+        init(cfg);
+        let _ = drain_events();
+
+        let _ = default_perms_for_dir(&target, 0o022);
+        let messages: Vec<String> = drain_events()
+            .into_iter()
+            .filter_map(|event| match event {
+                DiagnosticEvent::Debug {
+                    flag: DebugFlag::Acl,
+                    message,
+                    ..
+                } => Some(message),
+                _ => None,
+            })
+            .collect();
+        assert!(
+            messages.is_empty(),
+            "ACL debug must be suppressed at level 0, got {messages:?}"
+        );
     }
 }

--- a/crates/metadata/src/acl_noop.rs
+++ b/crates/metadata/src/acl_noop.rs
@@ -65,6 +65,18 @@ pub fn apply_acls_from_cache(
     Ok(())
 }
 
+/// Returns the umask-derived default permissions for `dir`.
+///
+/// Platforms without POSIX default-ACL support fall straight through to the
+/// `ACCESSPERMS & ~umask` baseline; no `--debug=ACL` line is emitted because
+/// upstream guards `default_perms_for_dir` behind `#ifdef SUPPORT_ACLS`
+/// (`generator.c:1337-1340`).
+#[allow(clippy::module_name_repetitions)]
+#[must_use]
+pub fn default_perms_for_dir(_dir: &Path, orig_umask: u32) -> u32 {
+    0o777u32 & !(orig_umask & 0o777)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/metadata/src/acl_stub.rs
+++ b/crates/metadata/src/acl_stub.rs
@@ -102,6 +102,18 @@ pub fn apply_acls_from_cache(
     Ok(())
 }
 
+/// Returns the umask-derived default permissions for `dir`.
+///
+/// iOS/tvOS/watchOS lack POSIX default-ACL support, so this stub returns
+/// `ACCESSPERMS & ~umask` without emitting `--debug=ACL` output. Mirrors
+/// upstream's `#ifdef SUPPORT_ACLS` guard at `generator.c:1337-1340`.
+#[allow(clippy::module_name_repetitions)]
+#[must_use]
+pub fn default_perms_for_dir(dir: &Path, orig_umask: u32) -> u32 {
+    let _ = dir;
+    0o777u32 & !(orig_umask & 0o777)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/metadata/src/acl_windows.rs
+++ b/crates/metadata/src/acl_windows.rs
@@ -476,6 +476,19 @@ pub fn apply_acls_from_cache(
     apply_rsync_acl_to_path(destination, &reconstructed)
 }
 
+/// Returns the umask-derived default permissions for `dir`.
+///
+/// Windows lacks POSIX default ACLs, so this returns `ACCESSPERMS & ~umask`
+/// without emitting `--debug=ACL` output. Mirrors upstream's `#ifdef
+/// SUPPORT_ACLS` guard at `generator.c:1337-1340`, which only consults the
+/// directory's default ACL on POSIX targets.
+#[allow(clippy::module_name_repetitions)]
+#[must_use]
+pub fn default_perms_for_dir(dir: &Path, orig_umask: u32) -> u32 {
+    let _ = dir;
+    0o777u32 & !(orig_umask & 0o777)
+}
+
 /// Restores stripped permission entries from `mode`, mirroring the
 /// receiver-side logic in `acl_exacl::reconstruct_acl`.
 ///

--- a/crates/metadata/src/lib.rs
+++ b/crates/metadata/src/lib.rs
@@ -160,16 +160,16 @@ pub mod fake_super;
     feature = "acl",
     any(target_os = "linux", target_os = "macos", target_os = "freebsd")
 ))]
-pub use acl_exacl::{apply_acls_from_cache, get_rsync_acl, sync_acls};
+pub use acl_exacl::{apply_acls_from_cache, default_perms_for_dir, get_rsync_acl, sync_acls};
 
 #[cfg(all(
     feature = "acl",
     any(target_os = "ios", target_os = "tvos", target_os = "watchos")
 ))]
-pub use acl_stub::{apply_acls_from_cache, get_rsync_acl, sync_acls};
+pub use acl_stub::{apply_acls_from_cache, default_perms_for_dir, get_rsync_acl, sync_acls};
 
 #[cfg(all(feature = "acl", windows))]
-pub use acl_windows::{apply_acls_from_cache, get_rsync_acl, sync_acls};
+pub use acl_windows::{apply_acls_from_cache, default_perms_for_dir, get_rsync_acl, sync_acls};
 
 #[cfg(not(any(
     all(
@@ -185,7 +185,7 @@ pub use acl_windows::{apply_acls_from_cache, get_rsync_acl, sync_acls};
     ),
     all(feature = "acl", windows),
 )))]
-pub use acl_noop::{apply_acls_from_cache, get_rsync_acl, sync_acls};
+pub use acl_noop::{apply_acls_from_cache, default_perms_for_dir, get_rsync_acl, sync_acls};
 
 pub use apply::{
     apply_directory_metadata, apply_directory_metadata_with_options, apply_file_metadata,

--- a/crates/protocol/src/acl/mod.rs
+++ b/crates/protocol/src/acl/mod.rs
@@ -33,6 +33,7 @@
 mod constants;
 mod definition;
 mod entry;
+pub mod trace;
 mod wire;
 
 pub use constants::*;
@@ -40,6 +41,7 @@ pub use definition::{
     AclDefinition, AclEntry, AclPerms, AclTag, read_acl_definition, write_acl_definition,
 };
 pub use entry::{AclCache, AclTagType, IdAccess, IdaEntries, RsyncAcl, get_perms};
+pub use trace::trace_default_perms_for_dir;
 pub use wire::{
     AclType, RecvAclResult, receive_acl_cached, recv_acl, recv_ida_entries, recv_rsync_acl,
     send_acl, send_ida_entries, send_rsync_acl,

--- a/crates/protocol/src/acl/trace.rs
+++ b/crates/protocol/src/acl/trace.rs
@@ -1,0 +1,101 @@
+//! `--debug=ACL` producer emissions for POSIX ACL processing.
+//!
+//! Matches upstream rsync's `acls.c` `DEBUG_GTE(ACL, N)` output byte-for-byte
+//! so wire-comparable diagnostics align across implementations.
+//!
+//! # Upstream Reference
+//!
+//! - `acls.c:1083-1139` `default_perms_for_dir` - reads a parent directory's
+//!   default ACL to derive `dest_mode()`'s `dflt_perms` argument when
+//!   `--perms` is off (`generator.c:1338-1339`, `receiver.c:846-847`).
+//! - `acls.c:1133-1134` (`DEBUG_GTE(ACL, 1)`) - `"got ACL-based default perms
+//!   %o for directory %s\n"` - the sole upstream ACL debug emission.
+//! - `options.c:290` - `DEBUG_WORD(ACL, W_SND|W_REC, "Debug extra ACL info")`
+//!   flag table entry, capping the useful level at 1.
+
+use logging::debug_log;
+
+/// Traces ACL-derived default permission bits for a parent directory (level 1).
+///
+/// upstream: `acls.c:1133-1134` - `"got ACL-based default perms %o for
+/// directory %s\n"`. Emitted by `default_perms_for_dir` after the directory's
+/// default POSIX ACL unpacked successfully and yielded a `user_obj` entry the
+/// caller can fold into `dest_mode()`. The `perms` value renders as upstream's
+/// `%o` (octal, no leading zero, no width padding) and matches the permission
+/// bits extracted via `rsync_acl_get_perms(&racl)`.
+#[inline]
+pub fn trace_default_perms_for_dir(perms: u32, dir: &str) {
+    debug_log!(
+        Acl,
+        1,
+        "got ACL-based default perms {:o} for directory {}",
+        perms,
+        dir
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    //! Pinning tests for ACL emission shapes. Strings match upstream
+    //! `acls.c` byte-for-byte.
+
+    use super::*;
+    use logging::{DebugFlag, DiagnosticEvent, VerbosityConfig, drain_events, init};
+
+    fn init_at(level: u8) {
+        let mut cfg = VerbosityConfig::default();
+        cfg.debug.acl = level;
+        init(cfg);
+        let _ = drain_events();
+    }
+
+    fn acl_messages() -> Vec<String> {
+        drain_events()
+            .into_iter()
+            .filter_map(|event| match event {
+                DiagnosticEvent::Debug {
+                    flag: DebugFlag::Acl,
+                    message,
+                    ..
+                } => Some(message),
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn default_perms_wire_shape() {
+        // upstream: acls.c:1133-1134 - "got ACL-based default perms %o for directory %s"
+        init_at(1);
+        trace_default_perms_for_dir(0o755, "/tmp/dst");
+        trace_default_perms_for_dir(0o700, ".");
+        trace_default_perms_for_dir(0o644, "nested/sub");
+
+        let m = acl_messages();
+        for expected in [
+            "got ACL-based default perms 755 for directory /tmp/dst",
+            "got ACL-based default perms 700 for directory .",
+            "got ACL-based default perms 644 for directory nested/sub",
+        ] {
+            assert!(m.iter().any(|s| s == expected), "missing {expected}: {m:?}");
+        }
+    }
+
+    #[test]
+    fn level_gating_matches_upstream() {
+        // upstream: DEBUG_GTE(ACL, 1) - emission disabled at level 0.
+        init_at(0);
+        trace_default_perms_for_dir(0o755, "/tmp/dst");
+        assert!(acl_messages().is_empty(), "level 0 must suppress emission");
+    }
+
+    #[test]
+    fn level_one_emits() {
+        // upstream: DEBUG_GTE(ACL, 1) - first level enables emission.
+        init_at(1);
+        trace_default_perms_for_dir(0o750, "/var/spool");
+        let m = acl_messages();
+        assert_eq!(m.len(), 1);
+        assert_eq!(m[0], "got ACL-based default perms 750 for directory /var/spool");
+    }
+}

--- a/crates/transfer/src/receiver/directory/creation.rs
+++ b/crates/transfer/src/receiver/directory/creation.rs
@@ -73,8 +73,38 @@ impl ReceiverContext {
 
         let mut failed_dir_paths: std::collections::HashSet<PathBuf> =
             std::collections::HashSet::new();
+        // upstream: generator.c:1337-1340 - probe each new parent directory's
+        // default POSIX ACL when !preserve_perms so dest_mode() folds the bits
+        // in. The probe also drives the `DEBUG_GTE(ACL, 1)` emission in
+        // `acls.c:1133-1134`. Mirror the gating exactly: only probe when
+        // ACLs are preserved and the user did not pass --perms.
+        #[cfg(all(
+            feature = "acl",
+            any(target_os = "linux", target_os = "macos", target_os = "freebsd")
+        ))]
+        let probe_default_perms = self.config.flags.acls && !self.config.flags.perms;
+        #[cfg(all(
+            feature = "acl",
+            any(target_os = "linux", target_os = "macos", target_os = "freebsd")
+        ))]
+        let mut probed_parents: std::collections::HashSet<PathBuf> =
+            std::collections::HashSet::new();
         for (_, dir_path) in &dir_entries {
             if !dir_path.exists() {
+                #[cfg(all(
+                    feature = "acl",
+                    any(target_os = "linux", target_os = "macos", target_os = "freebsd")
+                ))]
+                if probe_default_perms {
+                    if let Some(parent) = dir_path.parent() {
+                        if probed_parents.insert(parent.to_path_buf()) {
+                            // upstream: generator.c:1339 dflt_perms = default_perms_for_dir(dn)
+                            // Pass umask = 0; upstream prints the ACL-derived bits, not
+                            // the umask-derived fallback, so the trace value is umask-independent.
+                            let _ = ::metadata::default_perms_for_dir(parent, 0);
+                        }
+                    }
+                }
                 if let Err(e) = fs::create_dir_all(dir_path) {
                     if e.kind() == io::ErrorKind::PermissionDenied {
                         // upstream: receiver.c - permission denied on mkdir is non-fatal,

--- a/docs/audits/debug-flags-verbosity-matrix.md
+++ b/docs/audits/debug-flags-verbosity-matrix.md
@@ -116,7 +116,7 @@ Producer counts come from
 
 | Flag       | Upstream `DEBUG_GTE` max | oc-rsync cap | Side bits | Upstream `debug_words[]` help (verbatim) | Production producers | Status |
 |------------|:------------------------:|:------------:|-----------|------------------------------------------|----------------------|--------|
-| ACL        | 1 | u8::MAX | W_SND\|W_REC | Debug extra ACL info | none | missing |
+| ACL        | 1 | u8::MAX | W_SND\|W_REC | Debug extra ACL info | `crates/metadata/src/acl_exacl.rs::default_perms_for_dir` (1 site at level 1, upstream-verbatim wording from `acls.c:1133-1134`), invoked from `crates/transfer/src/receiver/directory/creation.rs::create_directories` when `acls && !perms` (upstream `generator.c:1337-1340`). Helper lives in `crates/protocol/src/acl/trace.rs`. | impl (G3 partial - ACL RESOLVED) |
 | BACKUP     | 1 (help says 1-2) | 2 | W_REC | Debug backup actions (levels 1-2) | none | missing |
 | BIND       | 1 | u8::MAX | W_CLI | Debug socket bind actions | none | missing |
 | CHDIR      | 1 | u8::MAX | W_CLI\|W_SRV | Debug when the current directory changes | none | missing |
@@ -144,10 +144,9 @@ Producer counts come from
 Total: 24 upstream `DEBUG_*` flags, matching `COUNT_DEBUG = DEBUG_TIME + 1`
 (`rsync.h:1462`). Status roll-up:
 
-- **impl**: 8 - DUP, FILTER, FLIST, GENR, ICONV, NSTR, SEND, TIME.
+- **impl**: 9 - ACL, DUP, FILTER, FLIST, GENR, ICONV, NSTR, SEND, TIME.
 - **partial**: 7 - CONNECT, DEL, DELTASUM, EXIT, IO, PROTO, RECV.
-- **missing**: 9 - ACL, BACKUP, BIND, CHDIR, CMD, FUZZY, HASH,
-  HLINK, OWN.
+- **missing**: 8 - BACKUP, BIND, CHDIR, CMD, FUZZY, HASH, HLINK, OWN.
 
 `SEND` (D13) is now wired into the generator's send loop with the
 five upstream-verbatim messages from `sender.c send_files` (lines
@@ -303,7 +302,7 @@ requested level before the event materialises.
 |----|----------|--------|-------------|
 | G1 | Low | open | `ALL<N>` and `NONE0` syntactic forms are rejected as unknown tokens (`flags/debug.rs:279`). Upstream accepts them (`options.c:443-445`, `:452-453`, `:450-451`) and applies the trailing digit. Fix: extend `DebugFlagSettings::apply` to detect `all<digit>` and `none<digit>` before falling through to `parse_flag_and_level`, then call `enable_all_to_level(N)` / `disable_all()`. Cap N at 4 to match `MAX_OUT_LEVEL`. |
 | G2 | Low | open | Per-flag cap missing for upstream-max-1 flags. `acl`, `bind`, `chdir`, `dup`, `genr`, `hash`, `nstr`, `proto`, `recv`, `send` accept any `u8` value (no `if level > N` guard in `flags/debug.rs::apply`). Upstream silently clamps to `MAX_OUT_LEVEL = 4`. Fix: add `if level > 4 { return Err(debug_flag_error(display)); }` guards on those arms, or a single shared cap before the per-flag dispatch. |
-| G3 | High | open | 9 flags have no production producer (ACL, BACKUP, BIND, CHDIR, CMD, FUZZY, HASH, HLINK, OWN). The previously listed GENR, ICONV, NSTR, and SEND emissions are now wired (D14, I-ICONV, NSTR follow-up, D13 RESOLVED). Owning crates for the remaining producers: `metadata` (ACL, OWN, HLINK), `engine` (BACKUP, FUZZY), `transfer`/`rsync_io` (BIND, CMD), `checksums` (HASH), `core` (CHDIR). |
+| G3 | High | open | 8 flags have no production producer (BACKUP, BIND, CHDIR, CMD, FUZZY, HASH, HLINK, OWN). The previously listed ACL, GENR, ICONV, NSTR, and SEND emissions are now wired (D14, I-ACL, I-ICONV, NSTR follow-up, D13 RESOLVED). Owning crates for the remaining producers: `metadata` (OWN, HLINK), `engine` (BACKUP, FUZZY), `transfer`/`rsync_io` (BIND, CMD), `checksums` (HASH), `core` (CHDIR). |
 | G4 | Low | open | `limit_output_verbosity` (upstream `options.c:527-553`) is not implemented. User-supplied per-flag levels are not clamped to the peer's `-v` ceiling during option exchange. Mitigation: implement on `server_options` parsing path and re-run the ladder with `LIMIT_PRIORITY` to compute the cap. |
 | G5 | Low | open | `make_output_option` (upstream `options.c:340-425`) is not implemented. Remote command forwarding of user-priority debug flags relies on raw passthrough rather than upstream's deduplicated `--debug=ALL2,NONREG0,...` style. User-visible effect is limited to the exact command string the peer sees in `ps` output. |
 | G6 | Low | open | `--debug=help` text omits the per-verbosity summary block (`0)`, `1)`, ..., `5)`) that upstream's `output_item_help` prints at `options.c:499-509`. Cosmetic but useful for discovery. |
@@ -314,7 +313,7 @@ requested level before the event materialises.
 
 | Flag | Suggested insertion crate | Suggested call site |
 |------|---------------------------|---------------------|
-| ACL  | `crates/metadata/src/acl/` | After every ACL apply / read, on the `rsync::acl` target. Upstream emits in `acls.c:make_acl()` and `set_acl()`. |
+| ACL  | wired in `crates/metadata/src/acl_exacl.rs::default_perms_for_dir` (level 1) with the helper in `crates/protocol/src/acl/trace.rs`; invoked from `crates/transfer/src/receiver/directory/creation.rs::create_directories` per unique parent when `acls && !perms`. Upstream emits at `acls.c:1133-1134` only (sole `DEBUG_GTE(ACL, 1)` site); the audit's earlier `make_acl()`/`set_acl()` guidance was incorrect - neither function carries an `ACL` debug emission in `acls.c`. |
 | BACKUP | `crates/engine/src/local_copy/backup.rs` | Before each backup file rename. Upstream emits in `backup.c:make_bak_dir`. |
 | BIND | `crates/rsync_io/src/socket/` | After `bind()` succeeds on the listener. Upstream emits in `socket.c:open_socket_in`. |
 | CHDIR | `crates/core/src/client/path/` and `crates/daemon/src/jail/` | After every `chdir()` syscall. Upstream emits in `util1.c:do_chdir`. |


### PR DESCRIPTION
## Summary

- Add the upstream-verbatim `DEBUG_GTE(ACL, 1)` emission (`acls.c:1133-1134`,
  `"got ACL-based default perms %o for directory %s"`) via a new
  `trace_default_perms_for_dir` helper in `crates/protocol/src/acl/trace.rs`.
- Wire a production `default_perms_for_dir` helper in
  `crates/metadata/src/acl_exacl.rs` that reads the directory's POSIX default
  ACL through `exacl::getfacl`, folds the user/group/other entries into the
  permission bits (mirroring upstream's `rsync_acl_get_perms`), and fires the
  trace when a `user_obj` entry is present. Filesystem errors and missing
  default ACLs fall back to `ACCESSPERMS & ~umask` without emitting,
  matching upstream's silent fallback.
- Cross-platform stubs (`acl_noop.rs`, `acl_stub.rs`, `acl_windows.rs`)
  return the umask-derived default without emitting, mirroring upstream's
  `#ifdef SUPPORT_ACLS` guard.
- Invoke the helper from
  `crates/transfer/src/receiver/directory/creation.rs::create_directories`
  per unique new parent when `acls && !perms` (mirrors `generator.c:1337-1340`
  and `receiver.c:846-851`).
- Update `docs/audits/debug-flags-verbosity-matrix.md`: ACL rolls from
  missing to impl, G3 counter drops to 8, and the per-flag insertion table
  records the wired call site.

Closes #2180.

## Test plan

- [ ] CI: fmt + clippy across the workspace.
- [ ] CI: nextest on stable across Linux/macOS/Windows/musl.
- [ ] CI: new unit tests in `crates/protocol/src/acl/trace.rs` pin the
      upstream wire shape and level gating.
- [ ] CI: new unit tests in `crates/metadata/src/acl_exacl.rs` confirm
      the emission fires against a real default ACL on Linux/FreeBSD and
      is suppressed at level 0.