### PR TITLE
feat(transfer): wire --debug=BACKUP producer emissions (3.4.1 parity)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2225,6 +2225,7 @@ dependencies = [
  "exacl",
  "filetime",
  "libc",
+ "logging",
  "protocol",
  "rustix",
  "tempfile",

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -219,7 +219,9 @@ pub use local_copy::{
     LocalCopyError, LocalCopyErrorKind, LocalCopyOptions, LocalCopyOptionsBuilder, LocalCopyPlan,
     LocalCopySummary, ReferenceDirectory, ReferenceDirectoryKind, SkipCompressList,
     SkipCompressParseError, SparseDetectStrategy, SparseDetector, SparseReader, SparseRegion,
-    SparseWriteStats, SparseWriter, ZeroScanStrategy, compute_backup_path,
+    SparseWriteStats, SparseWriter, ZeroScanStrategy, compute_backup_path, trace_make_backup_copy,
+    trace_make_backup_device, trace_make_backup_hlink, trace_make_backup_rename,
+    trace_make_backup_symlink,
 };
 
 /// File signature generation for delta transfers.

--- a/crates/engine/src/local_copy/context.rs
+++ b/crates/engine/src/local_copy/context.rs
@@ -34,7 +34,8 @@ use super::{
     SparseWriteState, SparseWriter, compute_backup_path, copy_entry_to_backup,
     delete_extraneous_entries, filter_program_local_error, follow_symlink_metadata,
     load_dir_merge_rules_recursive, map_metadata_error, remove_source_entry_if_requested,
-    resolve_dir_merge_path, should_skip_copy, symlink_target_is_safe, write_sparse_chunk,
+    resolve_dir_merge_path, should_skip_copy, symlink_target_is_safe, trace_make_backup_copy,
+    trace_make_backup_rename, trace_make_backup_symlink, write_sparse_chunk,
 };
 use crate::delta::DeltaSignatureIndex;
 use crate::signature::SignatureBlock;
@@ -369,6 +370,19 @@ pub(crate) enum CreatedEntryKind {
     Fifo,
     Device,
     HardLink,
+}
+
+/// Strategy used to place an existing destination into the backup
+/// location. Mirrors upstream rsync's `make_backup` success branches
+/// (RENAME / COPY / SYMLINK / DEVICE / HLINK) for `--debug=BACKUP`
+/// reporting; oc-rsync's local-copy executor exercises only RENAME,
+/// COPY (cross-device fallback for regular files), and SYMLINK
+/// (cross-device fallback for symlinks).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum BackupStrategy {
+    Rename,
+    Copy,
+    Symlink,
 }
 
 include!("context_impl/state.rs");

--- a/crates/engine/src/local_copy/context_impl/state.rs
+++ b/crates/engine/src/local_copy/context_impl/state.rs
@@ -497,8 +497,11 @@ impl<'a> CopyContext<'a> {
                 .map_err(|error| LocalCopyError::io("create backup directory", parent, error))?;
         }
 
-        match fs::rename(destination, &backup_path) {
-            Ok(()) => {}
+        // Track which backup strategy succeeded so we can emit the matching
+        // upstream `--debug=BACKUP` trace (RENAME, COPY, or SYMLINK).
+        // upstream: backup.c:link_or_rename and the fall-through copy_file path.
+        let strategy = match fs::rename(destination, &backup_path) {
+            Ok(()) => BackupStrategy::Rename,
             Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
             Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
                 if let Err(remove_error) = fs::remove_file(&backup_path)
@@ -513,6 +516,7 @@ impl<'a> CopyContext<'a> {
                 fs::rename(destination, &backup_path).map_err(|rename_error| {
                     LocalCopyError::io("create backup", backup_path.clone(), rename_error)
                 })?;
+                BackupStrategy::Rename
             }
             Err(error) if error.kind() == io::ErrorKind::CrossesDevices => {
                 // upstream: backup.c:290 - when copying across devices, the
@@ -538,10 +542,26 @@ impl<'a> CopyContext<'a> {
                     }
                 }
                 copy_entry_to_backup(destination, &backup_path, file_type)?;
+                if file_type.is_symlink() {
+                    BackupStrategy::Symlink
+                } else {
+                    BackupStrategy::Copy
+                }
             }
             Err(error) => {
                 return Err(LocalCopyError::io("create backup", backup_path, error));
             }
+        };
+
+        // upstream: backup.c:201-202,216-217,299-300,333-334 - DEBUG_GTE(BACKUP, 1)
+        // emits one of HLINK/RENAME/SYMLINK/COPY per success path. oc-rsync's
+        // local-copy executor uses rename as the primary strategy and falls back
+        // to copy or symlink across filesystem boundaries.
+        let destination_display = destination.display().to_string();
+        match strategy {
+            BackupStrategy::Rename => trace_make_backup_rename(&destination_display),
+            BackupStrategy::Copy => trace_make_backup_copy(&destination_display),
+            BackupStrategy::Symlink => trace_make_backup_symlink(&destination_display),
         }
 
         // upstream: backup.c:352 - INFO_GTE(BACKUP, 1) fires on success label

--- a/crates/engine/src/local_copy/executor/file/backup_trace.rs
+++ b/crates/engine/src/local_copy/executor/file/backup_trace.rs
@@ -1,0 +1,177 @@
+//! `--debug=BACKUP` producer emissions for backup actions.
+//!
+//! Mirrors upstream rsync's `backup.c` `DEBUG_GTE(BACKUP, 1)` output
+//! byte-for-byte so wire-comparable diagnostics align across
+//! implementations.
+//!
+//! # Upstream Reference
+//!
+//! All upstream emissions are level 1 (gated by `DEBUG_GTE(BACKUP, 1)`)
+//! and fire on the success branch of each backup placement strategy in
+//! `make_backup` / `link_or_rename`:
+//!
+//! - `backup.c:201-202` - `"make_backup: HLINK %s successful.\n"`
+//! - `backup.c:216-217` - `"make_backup: RENAME %s successful.\n"`
+//! - `backup.c:282-283` - `"make_backup: DEVICE %s successful.\n"`
+//! - `backup.c:299-300` - `"make_backup: SYMLINK %s successful.\n"`
+//! - `backup.c:333-334` - `"make_backup: COPY %s successful.\n"`
+//!
+//! The flag table entry at `options.c:289` is
+//! `DEBUG_WORD(BACKUP, W_REC, "Debug backup actions (levels 1-2)")`.
+//! Upstream's help text mentions a level 2 but only level 1 sites exist
+//! in `backup.c`; this module mirrors that reality. `%s` is the source
+//! filename as it was passed to `make_backup`.
+
+use logging::debug_log;
+
+/// Emits the `make_backup: HLINK <fname> successful.` notice when an
+/// existing destination is preserved via `link(2)` into the backup
+/// location.
+///
+/// upstream: `backup.c:201-202` -
+/// `"make_backup: HLINK %s successful.\n"`. Fires on the success branch
+/// of `do_link(from, to)` inside `link_or_rename` when `prefer_rename`
+/// is false and the kernel supports linking the source's file type.
+#[inline]
+pub fn trace_make_backup_hlink(fname: &str) {
+    debug_log!(Backup, 1, "make_backup: HLINK {} successful.", fname);
+}
+
+/// Emits the `make_backup: RENAME <fname> successful.` notice when an
+/// existing destination is moved into the backup location via
+/// `rename(2)`.
+///
+/// upstream: `backup.c:216-217` -
+/// `"make_backup: RENAME %s successful.\n"`. Fires on the success
+/// branch of `do_rename(from, to)` inside `link_or_rename`.
+#[inline]
+pub fn trace_make_backup_rename(fname: &str) {
+    debug_log!(Backup, 1, "make_backup: RENAME {} successful.", fname);
+}
+
+/// Emits the `make_backup: DEVICE <fname> successful.` notice when an
+/// existing device or special file is recreated in the backup location
+/// via `mknod(2)`.
+///
+/// upstream: `backup.c:282-283` -
+/// `"make_backup: DEVICE %s successful.\n"`. Fires after `do_mknod`
+/// succeeds for a device or special file under `--devices` /
+/// `--specials`.
+#[inline]
+pub fn trace_make_backup_device(fname: &str) {
+    debug_log!(Backup, 1, "make_backup: DEVICE {} successful.", fname);
+}
+
+/// Emits the `make_backup: SYMLINK <fname> successful.` notice when a
+/// symbolic link is recreated in the backup location via `symlink(2)`.
+///
+/// upstream: `backup.c:299-300` -
+/// `"make_backup: SYMLINK %s successful.\n"`. Fires after `do_symlink`
+/// succeeds when the source is a symlink and `--links` is on.
+#[inline]
+pub fn trace_make_backup_symlink(fname: &str) {
+    debug_log!(Backup, 1, "make_backup: SYMLINK {} successful.", fname);
+}
+
+/// Emits the `make_backup: COPY <fname> successful.` notice when a
+/// regular file is copied into the backup location after a rename
+/// crosses a filesystem boundary or another fast-path fails.
+///
+/// upstream: `backup.c:333-334` -
+/// `"make_backup: COPY %s successful.\n"`. Fires after the fallback
+/// `copy_file` succeeds for a regular file.
+#[inline]
+pub fn trace_make_backup_copy(fname: &str) {
+    debug_log!(Backup, 1, "make_backup: COPY {} successful.", fname);
+}
+
+#[cfg(test)]
+mod tests {
+    //! Pinning tests for BACKUP emission shapes. Strings match upstream
+    //! `backup.c` byte-for-byte.
+
+    use super::*;
+    use logging::{DebugFlag, DiagnosticEvent, VerbosityConfig, drain_events, init};
+
+    fn init_at(level: u8) {
+        let mut cfg = VerbosityConfig::default();
+        cfg.debug.backup = level;
+        init(cfg);
+        let _ = drain_events();
+    }
+
+    fn backup_messages() -> Vec<String> {
+        drain_events()
+            .into_iter()
+            .filter_map(|event| match event {
+                DiagnosticEvent::Debug {
+                    flag: DebugFlag::Backup,
+                    message,
+                    ..
+                } => Some(message),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// Pins every BACKUP debug line to upstream `backup.c` byte-for-byte.
+    #[test]
+    fn upstream_wire_shapes() {
+        // upstream: backup.c:201-202, :216-217, :282-283, :299-300, :333-334
+        init_at(1);
+        trace_make_backup_hlink("src/file.txt");
+        trace_make_backup_rename("src/file.txt");
+        trace_make_backup_device("/dev/null0");
+        trace_make_backup_symlink("link/target");
+        trace_make_backup_copy("nested/big.bin");
+
+        let m = backup_messages();
+        for expected in [
+            "make_backup: HLINK src/file.txt successful.",
+            "make_backup: RENAME src/file.txt successful.",
+            "make_backup: DEVICE /dev/null0 successful.",
+            "make_backup: SYMLINK link/target successful.",
+            "make_backup: COPY nested/big.bin successful.",
+        ] {
+            assert!(m.iter().any(|s| s == expected), "missing {expected}: {m:?}");
+        }
+    }
+
+    /// Level 0 must suppress every emission.
+    ///
+    /// upstream: `DEBUG_GTE(BACKUP, 1)` gates each emission at level 1
+    /// or higher; the default `-v0` ladder leaves the flag at 0.
+    #[test]
+    fn level_zero_suppresses() {
+        init_at(0);
+        trace_make_backup_hlink("a");
+        trace_make_backup_rename("a");
+        trace_make_backup_device("a");
+        trace_make_backup_symlink("a");
+        trace_make_backup_copy("a");
+        assert!(backup_messages().is_empty(), "level 0 must suppress emissions");
+    }
+
+    /// Level 1 enables every site - matches `-vvv` and `--debug=BACKUP`.
+    #[test]
+    fn level_one_enables_all_sites() {
+        init_at(1);
+        trace_make_backup_rename("path/a");
+        let m = backup_messages();
+        assert_eq!(m.len(), 1);
+        assert_eq!(m[0], "make_backup: RENAME path/a successful.");
+    }
+
+    /// Levels above 1 still fire (the help text advertises levels 1-2
+    /// even though upstream's tree has no level-2 sites). This pins the
+    /// upper bound behaviour so future level-2 additions extend, not
+    /// regress, the matrix.
+    #[test]
+    fn level_two_still_emits_level_one_sites() {
+        init_at(2);
+        trace_make_backup_copy("x");
+        let m = backup_messages();
+        assert_eq!(m.len(), 1);
+        assert_eq!(m[0], "make_backup: COPY x successful.");
+    }
+}

--- a/crates/engine/src/local_copy/executor/file/backup_trace.rs
+++ b/crates/engine/src/local_copy/executor/file/backup_trace.rs
@@ -149,7 +149,10 @@ mod tests {
         trace_make_backup_device("a");
         trace_make_backup_symlink("a");
         trace_make_backup_copy("a");
-        assert!(backup_messages().is_empty(), "level 0 must suppress emissions");
+        assert!(
+            backup_messages().is_empty(),
+            "level 0 must suppress emissions"
+        );
     }
 
     /// Level 1 enables every site - matches `-vvv` and `--debug=BACKUP`.

--- a/crates/engine/src/local_copy/executor/file/mod.rs
+++ b/crates/engine/src/local_copy/executor/file/mod.rs
@@ -2,6 +2,7 @@
 
 mod append;
 mod backup;
+mod backup_trace;
 mod comparison;
 mod copy;
 mod guard;
@@ -12,6 +13,10 @@ mod sparse;
 
 pub use backup::compute_backup_path;
 pub(crate) use backup::copy_entry_to_backup;
+pub use backup_trace::{
+    trace_make_backup_copy, trace_make_backup_device, trace_make_backup_hlink,
+    trace_make_backup_rename, trace_make_backup_symlink,
+};
 #[cfg(test)]
 pub(crate) use comparison::files_checksum_match;
 pub(crate) use comparison::{CopyComparison, DEFAULT_XXH64_DEDUP_SIZE_LIMIT, should_skip_copy};

--- a/crates/engine/src/local_copy/executor/mod.rs
+++ b/crates/engine/src/local_copy/executor/mod.rs
@@ -24,6 +24,8 @@ pub use file::{
     DestinationWriteGuard, PartialFileManager, PartialMode, SparseDetectStrategy, SparseDetector,
     SparseReader, SparseRegion, SparseWriteStats, SparseWriter, ZeroScanStrategy,
     compute_backup_path, remove_existing_destination, remove_incomplete_destination,
+    trace_make_backup_copy, trace_make_backup_device, trace_make_backup_hlink,
+    trace_make_backup_rename, trace_make_backup_symlink,
 };
 #[cfg(test)]
 pub(crate) use file::{

--- a/crates/engine/src/local_copy/mod.rs
+++ b/crates/engine/src/local_copy/mod.rs
@@ -134,6 +134,8 @@ pub use executor::{
     DestinationWriteGuard, PartialFileManager, PartialMode, SparseDetectStrategy, SparseDetector,
     SparseReader, SparseRegion, SparseWriteStats, SparseWriter, ZeroScanStrategy,
     compute_backup_path, remove_existing_destination, remove_incomplete_destination,
+    trace_make_backup_copy, trace_make_backup_device, trace_make_backup_hlink,
+    trace_make_backup_rename, trace_make_backup_symlink,
 };
 
 pub(crate) use hard_links::HardLinkTracker;

--- a/crates/engine/tests/debug_backup_emissions.rs
+++ b/crates/engine/tests/debug_backup_emissions.rs
@@ -1,0 +1,122 @@
+//! Integration tests for `--debug=BACKUP` producer emissions on the
+//! local-copy executor path.
+//!
+//! Confirms the upstream wire shapes from `backup.c` materialise through the
+//! actual `LocalCopyPlan::execute_with_options` flow when `--backup` is
+//! enabled, and that level-0 gating suppresses them.
+//!
+//! # Upstream Reference
+//!
+//! - `backup.c:216-217` - `"make_backup: RENAME %s successful.\n"` fires
+//!   on the success branch of `do_rename(from, to)` inside `link_or_rename`,
+//!   which is the strategy oc-rsync's local-copy executor exercises by
+//!   default when `--backup` is on and the destination shares a
+//!   filesystem with the backup location.
+
+use std::ffi::OsString;
+use std::fs;
+
+use engine::local_copy::{LocalCopyExecution, LocalCopyOptions, LocalCopyPlan};
+use logging::{DebugFlag, DiagnosticEvent, VerbosityConfig, drain_events, init};
+use tempfile::tempdir;
+
+/// Collects every BACKUP debug emission since the last drain.
+fn backup_debug_messages() -> Vec<String> {
+    drain_events()
+        .into_iter()
+        .filter_map(|event| match event {
+            DiagnosticEvent::Debug {
+                flag: DebugFlag::Backup,
+                message,
+                ..
+            } => Some(message),
+            _ => None,
+        })
+        .collect()
+}
+
+/// Drives a full local-copy that overwrites an existing destination with
+/// `--backup --suffix=~` and confirms the RENAME debug line fires at
+/// level 1 with upstream's exact wording.
+///
+/// upstream: backup.c:216-217 - `DEBUG_GTE(BACKUP, 1)` on the RENAME
+/// success branch of `link_or_rename`.
+#[test]
+fn local_copy_backup_emits_rename_debug_line() {
+    let mut cfg = VerbosityConfig::default();
+    cfg.debug.backup = 1;
+    init(cfg);
+    let _ = drain_events();
+
+    let temp = tempdir().expect("tempdir");
+    let source = temp.path().join("source");
+    let dest = temp.path().join("dest");
+    fs::create_dir_all(&source).expect("create source");
+    fs::create_dir_all(&dest).expect("create dest");
+    fs::write(source.join("file.txt"), b"updated payload").expect("write source");
+
+    let dest_root = dest.join("source");
+    fs::create_dir_all(&dest_root).expect("create dest root");
+    let existing = dest_root.join("file.txt");
+    fs::write(&existing, b"original payload").expect("write dest");
+
+    let operands = vec![source.into_os_string(), dest.into_os_string()];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+    let options = LocalCopyOptions::default()
+        .backup(true)
+        .with_backup_suffix(Some(OsString::from("~")));
+
+    plan.execute_with_options(LocalCopyExecution::Apply, options)
+        .expect("copy succeeds");
+
+    let expected = format!("make_backup: RENAME {} successful.", existing.display());
+    let messages = backup_debug_messages();
+    assert!(
+        messages.iter().any(|m| m == &expected),
+        "expected upstream-format BACKUP,1 RENAME line {expected:?}; got {messages:?}"
+    );
+
+    assert!(
+        dest_root.join("file.txt~").exists(),
+        "backup file should be written next to destination"
+    );
+}
+
+/// Same scenario as above but with `--debug=BACKUP` disabled. No BACKUP
+/// debug lines should fire even though the rename still happens.
+#[test]
+fn backup_debug_level_zero_suppresses_emission() {
+    init(VerbosityConfig::default());
+    let _ = drain_events();
+
+    let temp = tempdir().expect("tempdir");
+    let source = temp.path().join("source");
+    let dest = temp.path().join("dest");
+    fs::create_dir_all(&source).expect("create source");
+    fs::create_dir_all(&dest).expect("create dest");
+    fs::write(source.join("file.txt"), b"updated payload").expect("write source");
+
+    let dest_root = dest.join("source");
+    fs::create_dir_all(&dest_root).expect("create dest root");
+    fs::write(dest_root.join("file.txt"), b"original payload").expect("write dest");
+
+    let operands = vec![source.into_os_string(), dest.into_os_string()];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+    let options = LocalCopyOptions::default()
+        .backup(true)
+        .with_backup_suffix(Some(OsString::from("~")));
+
+    plan.execute_with_options(LocalCopyExecution::Apply, options)
+        .expect("copy succeeds");
+
+    let messages = backup_debug_messages();
+    assert!(
+        messages.is_empty(),
+        "level 0 must suppress BACKUP debug emissions; got {messages:?}"
+    );
+
+    assert!(
+        dest_root.join("file.txt~").exists(),
+        "rename should still occur regardless of debug flag"
+    );
+}

--- a/crates/protocol/src/acl/trace.rs
+++ b/crates/protocol/src/acl/trace.rs
@@ -96,6 +96,9 @@ mod tests {
         trace_default_perms_for_dir(0o750, "/var/spool");
         let m = acl_messages();
         assert_eq!(m.len(), 1);
-        assert_eq!(m[0], "got ACL-based default perms 750 for directory /var/spool");
+        assert_eq!(
+            m[0],
+            "got ACL-based default perms 750 for directory /var/spool"
+        );
     }
 }

--- a/crates/transfer/src/disk_commit/process.rs
+++ b/crates/transfer/src/disk_commit/process.rs
@@ -8,7 +8,7 @@ use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
 
-use engine::compute_backup_path;
+use engine::{compute_backup_path, trace_make_backup_rename};
 use protocol::acl::AclCache;
 
 use crate::delta_apply::{ChecksumVerifier, SparseWriteState};
@@ -445,7 +445,8 @@ fn apply_metadata_acls_and_xattrs(
 ///
 /// Mirrors upstream `backup.c:make_backup()` which renames the existing file
 /// to the backup path. Parent directories are created if needed when using
-/// `--backup-dir`.
+/// `--backup-dir`. On success, emits the upstream `--debug=BACKUP` RENAME
+/// notice (`backup.c:216-217`).
 fn make_backup(file_path: &Path, config: &BackupConfig) -> io::Result<()> {
     if !file_path.exists() {
         return Ok(());
@@ -465,7 +466,11 @@ fn make_backup(file_path: &Path, config: &BackupConfig) -> io::Result<()> {
         }
     }
 
-    fs::rename(file_path, &backup_path)
+    fs::rename(file_path, &backup_path)?;
+    // upstream: backup.c:216-217 - DEBUG_GTE(BACKUP, 1) on the RENAME success
+    // branch of link_or_rename. disk_commit always uses rename here.
+    trace_make_backup_rename(&file_path.display().to_string());
+    Ok(())
 }
 
 /// Finalizes a checksum verifier into a `ComputedChecksum`.

--- a/crates/transfer/src/receiver/transfer.rs
+++ b/crates/transfer/src/receiver/transfer.rs
@@ -438,6 +438,9 @@ impl ReceiverContext {
                     }
                 }
                 fs::rename(&file_path, &backup_path)?;
+                // upstream: backup.c:216-217 - DEBUG_GTE(BACKUP, 1) on RENAME
+                // success branch of link_or_rename.
+                engine::trace_make_backup_rename(&file_path.display().to_string());
             }
 
             // On Linux 5.11+ with io_uring, submits IORING_OP_RENAMEAT instead of

--- a/docs/audits/debug-flags-verbosity-matrix.md
+++ b/docs/audits/debug-flags-verbosity-matrix.md
@@ -1,6 +1,6 @@
 # `--debug=FLAGS` verbosity matrix vs upstream rsync 3.4.1
 
-Tracking issue: #2113. Last verified: 2026-05-14 against `origin/master`.
+Tracking issue: #2113. Last verified: 2026-05-16 against `origin/master`.
 
 Companion audits in the output-family series:
 
@@ -117,7 +117,7 @@ Producer counts come from
 | Flag       | Upstream `DEBUG_GTE` max | oc-rsync cap | Side bits | Upstream `debug_words[]` help (verbatim) | Production producers | Status |
 |------------|:------------------------:|:------------:|-----------|------------------------------------------|----------------------|--------|
 | ACL        | 1 | u8::MAX | W_SND\|W_REC | Debug extra ACL info | `crates/metadata/src/acl_exacl.rs::default_perms_for_dir` (1 site at level 1, upstream-verbatim wording from `acls.c:1133-1134`), invoked from `crates/transfer/src/receiver/directory/creation.rs::create_directories` when `acls && !perms` (upstream `generator.c:1337-1340`). Helper lives in `crates/protocol/src/acl/trace.rs`. | impl (G3 partial - ACL RESOLVED) |
-| BACKUP     | 1 (help says 1-2) | 2 | W_REC | Debug backup actions (levels 1-2) | none | missing |
+| BACKUP     | 1 (help says 1-2) | 2 | W_REC | Debug backup actions (levels 1-2) | `crates/engine/src/local_copy/context_impl/state.rs::backup_existing_entry` (3 sites at level 1, RENAME/COPY/SYMLINK selected by strategy), `crates/transfer/src/disk_commit/process.rs::make_backup` (1 site at level 1, RENAME), `crates/transfer/src/receiver/transfer.rs` (1 site at level 1, RENAME). Helpers in `crates/engine/src/local_copy/executor/file/backup_trace.rs` cover all five upstream strategies (HLINK/RENAME/DEVICE/SYMLINK/COPY) at upstream-verbatim wording from `backup.c:201,216,282,299,333`. | impl (G3 partial - BACKUP RESOLVED) |
 | BIND       | 1 | u8::MAX | W_CLI | Debug socket bind actions | none | missing |
 | CHDIR      | 1 | u8::MAX | W_CLI\|W_SRV | Debug when the current directory changes | none | missing |
 | CMD        | 2 | 2 | W_CLI | Debug commands+options that are issued (levels 1-2) | none | missing |
@@ -144,9 +144,9 @@ Producer counts come from
 Total: 24 upstream `DEBUG_*` flags, matching `COUNT_DEBUG = DEBUG_TIME + 1`
 (`rsync.h:1462`). Status roll-up:
 
-- **impl**: 9 - ACL, DUP, FILTER, FLIST, GENR, ICONV, NSTR, SEND, TIME.
+- **impl**: 10 - ACL, BACKUP, DUP, FILTER, FLIST, GENR, ICONV, NSTR, SEND, TIME.
 - **partial**: 7 - CONNECT, DEL, DELTASUM, EXIT, IO, PROTO, RECV.
-- **missing**: 8 - BACKUP, BIND, CHDIR, CMD, FUZZY, HASH, HLINK, OWN.
+- **missing**: 7 - BIND, CHDIR, CMD, FUZZY, HASH, HLINK, OWN.
 
 `SEND` (D13) is now wired into the generator's send loop with the
 five upstream-verbatim messages from `sender.c send_files` (lines
@@ -302,7 +302,7 @@ requested level before the event materialises.
 |----|----------|--------|-------------|
 | G1 | Low | open | `ALL<N>` and `NONE0` syntactic forms are rejected as unknown tokens (`flags/debug.rs:279`). Upstream accepts them (`options.c:443-445`, `:452-453`, `:450-451`) and applies the trailing digit. Fix: extend `DebugFlagSettings::apply` to detect `all<digit>` and `none<digit>` before falling through to `parse_flag_and_level`, then call `enable_all_to_level(N)` / `disable_all()`. Cap N at 4 to match `MAX_OUT_LEVEL`. |
 | G2 | Low | open | Per-flag cap missing for upstream-max-1 flags. `acl`, `bind`, `chdir`, `dup`, `genr`, `hash`, `nstr`, `proto`, `recv`, `send` accept any `u8` value (no `if level > N` guard in `flags/debug.rs::apply`). Upstream silently clamps to `MAX_OUT_LEVEL = 4`. Fix: add `if level > 4 { return Err(debug_flag_error(display)); }` guards on those arms, or a single shared cap before the per-flag dispatch. |
-| G3 | High | open | 8 flags have no production producer (BACKUP, BIND, CHDIR, CMD, FUZZY, HASH, HLINK, OWN). The previously listed ACL, GENR, ICONV, NSTR, and SEND emissions are now wired (D14, I-ACL, I-ICONV, NSTR follow-up, D13 RESOLVED). Owning crates for the remaining producers: `metadata` (OWN, HLINK), `engine` (BACKUP, FUZZY), `transfer`/`rsync_io` (BIND, CMD), `checksums` (HASH), `core` (CHDIR). |
+| G3 | High | open | 7 flags have no production producer (BIND, CHDIR, CMD, FUZZY, HASH, HLINK, OWN). The previously listed ACL, BACKUP, GENR, ICONV, NSTR, and SEND emissions are now wired (D14, I-ACL, I-ICONV, NSTR follow-up, D13 RESOLVED, BACKUP RESOLVED). Owning crates for the remaining producers: `metadata` (OWN, HLINK), `engine` (FUZZY), `transfer`/`rsync_io` (BIND, CMD), `checksums` (HASH), `core` (CHDIR). |
 | G4 | Low | open | `limit_output_verbosity` (upstream `options.c:527-553`) is not implemented. User-supplied per-flag levels are not clamped to the peer's `-v` ceiling during option exchange. Mitigation: implement on `server_options` parsing path and re-run the ladder with `LIMIT_PRIORITY` to compute the cap. |
 | G5 | Low | open | `make_output_option` (upstream `options.c:340-425`) is not implemented. Remote command forwarding of user-priority debug flags relies on raw passthrough rather than upstream's deduplicated `--debug=ALL2,NONREG0,...` style. User-visible effect is limited to the exact command string the peer sees in `ps` output. |
 | G6 | Low | open | `--debug=help` text omits the per-verbosity summary block (`0)`, `1)`, ..., `5)`) that upstream's `output_item_help` prints at `options.c:499-509`. Cosmetic but useful for discovery. |
@@ -314,7 +314,7 @@ requested level before the event materialises.
 | Flag | Suggested insertion crate | Suggested call site |
 |------|---------------------------|---------------------|
 | ACL  | wired in `crates/metadata/src/acl_exacl.rs::default_perms_for_dir` (level 1) with the helper in `crates/protocol/src/acl/trace.rs`; invoked from `crates/transfer/src/receiver/directory/creation.rs::create_directories` per unique parent when `acls && !perms`. Upstream emits at `acls.c:1133-1134` only (sole `DEBUG_GTE(ACL, 1)` site); the audit's earlier `make_acl()`/`set_acl()` guidance was incorrect - neither function carries an `ACL` debug emission in `acls.c`. |
-| BACKUP | `crates/engine/src/local_copy/backup.rs` | Before each backup file rename. Upstream emits in `backup.c:make_bak_dir`. |
+| BACKUP | wired in `crates/engine/src/local_copy/context_impl/state.rs::backup_existing_entry` (RENAME/COPY/SYMLINK at level 1), `crates/transfer/src/disk_commit/process.rs::make_backup` (RENAME at level 1), and `crates/transfer/src/receiver/transfer.rs` (RENAME at level 1). Helpers in `crates/engine/src/local_copy/executor/file/backup_trace.rs` mirror upstream `backup.c:201,216,282,299,333` (the five success branches of `make_backup` / `link_or_rename`). DEVICE and HLINK helpers are available for future wiring of `--specials`/`--devices` and `--link-dest` backup paths. |
 | BIND | `crates/rsync_io/src/socket/` | After `bind()` succeeds on the listener. Upstream emits in `socket.c:open_socket_in`. |
 | CHDIR | `crates/core/src/client/path/` and `crates/daemon/src/jail/` | After every `chdir()` syscall. Upstream emits in `util1.c:do_chdir`. |
 | CMD | `crates/cli/src/frontend/execution/drive/options.rs` | When `--server` argv is built and when SSH command line is constructed. Upstream emits in `options.c:server_options` and `pipe.c:do_cmd`. |


### PR DESCRIPTION
## Summary

- Adds byte-for-byte BACKUP debug emissions matching upstream rsync 3.4.1's `backup.c`. All five upstream success branches (HLINK / RENAME / DEVICE / SYMLINK / COPY) are exposed as helpers in `crates/engine/src/local_copy/executor/file/backup_trace.rs`; the three strategies oc-rsync exercises today (RENAME, COPY, SYMLINK) are wired into the production backup paths.
- Production wiring:
  - `crates/engine/src/local_copy/context_impl/state.rs::backup_existing_entry` selects RENAME / COPY / SYMLINK based on the strategy that succeeded.
  - `crates/transfer/src/disk_commit/process.rs::make_backup` emits RENAME on successful `fs::rename`.
  - `crates/transfer/src/receiver/transfer.rs` emits RENAME on the receiver's pre-overwrite rename branch.
- `docs/audits/debug-flags-verbosity-matrix.md` rolls BACKUP from missing to impl, drops the G3 producer-gap count from 8 to 7, and refreshes the insertion-plan table.

## Test plan

- [ ] CI: fmt + clippy
- [ ] CI: nextest (stable) Linux musl, macOS, Windows
- [ ] Verify `cargo nextest run -p engine -E 'test(debug_backup_emissions)'` (CI) passes the new integration tests
- [ ] Verify `cargo nextest run -p engine -E 'test(backup_trace)'` (CI) passes the wire-shape pinning tests

Closes #2181