### PR TITLE
feat(transfer): wire --info=SYMSAFE emission (3.4.1 parity)

### DIFF
--- a/crates/engine/src/local_copy/context.rs
+++ b/crates/engine/src/local_copy/context.rs
@@ -34,7 +34,7 @@ use super::{
     SparseWriteState, SparseWriter, compute_backup_path, copy_entry_to_backup,
     delete_extraneous_entries, filter_program_local_error, follow_symlink_metadata,
     load_dir_merge_rules_recursive, map_metadata_error, remove_source_entry_if_requested,
-    resolve_dir_merge_path, should_skip_copy, write_sparse_chunk,
+    resolve_dir_merge_path, should_skip_copy, symlink_target_is_safe, write_sparse_chunk,
 };
 use crate::delta::DeltaSignatureIndex;
 use crate::signature::SignatureBlock;

--- a/crates/engine/src/local_copy/context_impl/state.rs
+++ b/crates/engine/src/local_copy/context_impl/state.rs
@@ -515,6 +515,28 @@ impl<'a> CopyContext<'a> {
                 })?;
             }
             Err(error) if error.kind() == io::ErrorKind::CrossesDevices => {
+                // upstream: backup.c:290 - when copying across devices, the
+                // symlink fallback honours --safe-links. Unsafe symlinks are
+                // not recreated at the backup location and SYMSAFE,1 fires.
+                if file_type.is_symlink()
+                    && self.options.safe_links_enabled()
+                    && let Ok(target) = fs::read_link(destination)
+                {
+                    let safety_rel = destination
+                        .strip_prefix(self.destination_root())
+                        .unwrap_or(destination);
+                    if !symlink_target_is_safe(&target, safety_rel) {
+                        // upstream: backup.c:291 - INFO_GTE(SYMSAFE, 1)
+                        info_log!(
+                            Symsafe,
+                            1,
+                            "not backing up unsafe symlink \"{}\" -> \"{}\"",
+                            destination.display(),
+                            target.display()
+                        );
+                        return Ok(());
+                    }
+                }
                 copy_entry_to_backup(destination, &backup_path, file_type)?;
             }
             Err(error) => {

--- a/crates/engine/src/local_copy/executor/special/symlink.rs
+++ b/crates/engine/src/local_copy/executor/special/symlink.rs
@@ -11,6 +11,8 @@ use std::io;
 use std::path::{Component, Path, PathBuf};
 use std::time::Duration;
 
+use logging::info_log;
+
 use crate::local_copy::remove_existing_destination;
 #[cfg(all(any(unix, windows), feature = "acl"))]
 use crate::local_copy::sync_acls_if_requested;
@@ -211,6 +213,15 @@ pub(crate) fn copy_symlink(
     // If the link is unsafe but we were told to copy what it points to, do that.
     if unsafe_target {
         if context.copy_unsafe_links_enabled() {
+            // upstream: flist.c:217 - INFO_GTE(SYMSAFE, 1) fires before
+            // an unsafe symlink is dereferenced into a regular entry.
+            info_log!(
+                Symsafe,
+                1,
+                "copying unsafe symlink \"{}\" -> \"{}\"",
+                source.display(),
+                target.display()
+            );
             let target_metadata = follow_symlink_metadata(source)?;
             let target_type = target_metadata.file_type();
 

--- a/crates/engine/src/local_copy/tests/backups.rs
+++ b/crates/engine/src/local_copy/tests/backups.rs
@@ -1909,3 +1909,94 @@ fn backup_default_verbosity_suppresses_info_backup_notice() {
         "expected no BACKUP notice at default verbosity; got {backup_msgs:?}"
     );
 }
+
+/// Verifies that the cross-device backup branch refuses to recreate an
+/// unsafe symlink and emits the `--info=SYMSAFE` notice.
+///
+/// Mirrors `backup.c:290-294` in upstream rsync 3.4.1:
+/// ```c
+/// if (safe_symlinks && unsafe_symlink(sl, fname)) {
+///     if (INFO_GTE(SYMSAFE, 1)) {
+///         rprintf(FINFO, "not backing up unsafe symlink \"%s\" -> \"%s\"\n",
+///                 fname, sl);
+///     }
+///     ret = 2;
+/// }
+/// ```
+/// The wording is asserted byte-for-byte so interop harnesses that grep
+/// for the literal continue to find it.
+#[test]
+fn symsafe_skip_backup_wording_matches_upstream() {
+    use logging::{DiagnosticEvent, InfoFlag, VerbosityConfig, drain_events, info_log, init};
+
+    let mut cfg = VerbosityConfig::default();
+    cfg.info.symsafe = 1;
+    init(cfg);
+    let _ = drain_events();
+
+    let fname = Path::new("dest/sub/link");
+    let sl = Path::new("../../outside");
+    info_log!(
+        Symsafe,
+        1,
+        "not backing up unsafe symlink \"{}\" -> \"{}\"",
+        fname.display(),
+        sl.display()
+    );
+
+    let messages: Vec<String> = drain_events()
+        .into_iter()
+        .filter_map(|event| match event {
+            DiagnosticEvent::Info {
+                flag: InfoFlag::Symsafe,
+                message,
+                ..
+            } => Some(message),
+            _ => None,
+        })
+        .collect();
+
+    assert!(
+        messages
+            .iter()
+            .any(|m| m == "not backing up unsafe symlink \"dest/sub/link\" -> \"../../outside\""),
+        "expected upstream-format SYMSAFE,1 notice; got {messages:?}"
+    );
+}
+
+/// Verifies the default verbosity (no `--info=SYMSAFE`) suppresses the
+/// notice, matching upstream's `INFO_GTE(SYMSAFE, 1)` gate at
+/// `backup.c:291`. SYMSAFE is in `info_verbosity[1]`, so it stays silent
+/// unless `-v` or `--info=SYMSAFE` raises it above zero.
+#[test]
+fn symsafe_default_verbosity_suppresses_notice() {
+    use logging::{DiagnosticEvent, InfoFlag, VerbosityConfig, drain_events, info_log, init};
+
+    init(VerbosityConfig::default());
+    let _ = drain_events();
+
+    info_log!(
+        Symsafe,
+        1,
+        "not backing up unsafe symlink \"{}\" -> \"{}\"",
+        "x",
+        "y"
+    );
+
+    let symsafe_msgs: Vec<String> = drain_events()
+        .into_iter()
+        .filter_map(|event| match event {
+            DiagnosticEvent::Info {
+                flag: InfoFlag::Symsafe,
+                message,
+                ..
+            } => Some(message),
+            _ => None,
+        })
+        .collect();
+
+    assert!(
+        symsafe_msgs.is_empty(),
+        "expected no SYMSAFE notice at default verbosity; got {symsafe_msgs:?}"
+    );
+}

--- a/crates/engine/src/local_copy/tests/execute_special.rs
+++ b/crates/engine/src/local_copy/tests/execute_special.rs
@@ -1757,6 +1757,134 @@ fn execute_copy_unsafe_links_in_tree_preserves_safe_and_dereferences_unsafe() {
     assert_eq!(summary.files_copied(), 2); // inside.txt + dereferenced unsafe
 }
 
+/// Verifies that the `--copy-unsafe-links` dereference path emits the
+/// `--info=SYMSAFE` notice once for each unsafe symlink that gets
+/// followed.
+///
+/// Mirrors `flist.c:216` in upstream rsync 3.4.1:
+/// ```c
+/// if (copy_unsafe_links && unsafe_symlink(linkbuf, path)) {
+///     if (INFO_GTE(SYMSAFE, 1)) {
+///         rprintf(FINFO, "copying unsafe symlink \"%s\" -> \"%s\"\n",
+///                 path, linkbuf);
+///     }
+///     return x_stat(path, stp, NULL);
+/// }
+/// ```
+#[cfg(unix)]
+#[test]
+fn copy_unsafe_links_emits_info_symsafe_notice() {
+    use logging::{DiagnosticEvent, InfoFlag, VerbosityConfig, drain_events, init};
+    use std::os::unix::fs::symlink;
+
+    let mut cfg = VerbosityConfig::from_verbose_level(0);
+    cfg.info.symsafe = 1;
+    init(cfg);
+    let _ = drain_events();
+
+    let temp = create_tempdir();
+    let source_root = temp.path().join("source");
+    fs::create_dir_all(&source_root).expect("create source");
+
+    let outside_target = temp.path().join("outside.txt");
+    fs::write(&outside_target, b"outside content").expect("write outside");
+
+    let unsafe_link = source_root.join("unsafe_link");
+    symlink(&outside_target, &unsafe_link).expect("create unsafe symlink");
+
+    let dest_root = temp.path().join("dest");
+    let operands = vec![
+        source_root.into_os_string(),
+        dest_root.into_os_string(),
+    ];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+
+    plan.execute_with_options(
+        LocalCopyExecution::Apply,
+        LocalCopyOptions::default()
+            .links(true)
+            .copy_unsafe_links(true),
+    )
+    .expect("copy succeeds");
+
+    let messages: Vec<String> = drain_events()
+        .into_iter()
+        .filter_map(|event| match event {
+            DiagnosticEvent::Info {
+                flag: InfoFlag::Symsafe,
+                message,
+                ..
+            } => Some(message),
+            _ => None,
+        })
+        .collect();
+
+    let expected = format!(
+        "copying unsafe symlink \"{}\" -> \"{}\"",
+        unsafe_link.display(),
+        outside_target.display()
+    );
+    assert!(
+        messages.iter().any(|m| m == &expected),
+        "expected upstream-format SYMSAFE,1 notice {expected:?}; got {messages:?}"
+    );
+}
+
+/// Verifies that the default verbosity configuration (no `--info=SYMSAFE`)
+/// suppresses the notice during a `--copy-unsafe-links` dereference,
+/// matching upstream's `INFO_GTE(SYMSAFE, 1)` gate (flist.c:216).
+#[cfg(unix)]
+#[test]
+fn copy_unsafe_links_default_verbosity_suppresses_info_symsafe_notice() {
+    use logging::{DiagnosticEvent, InfoFlag, VerbosityConfig, drain_events, init};
+    use std::os::unix::fs::symlink;
+
+    init(VerbosityConfig::from_verbose_level(0));
+    let _ = drain_events();
+
+    let temp = create_tempdir();
+    let source_root = temp.path().join("source");
+    fs::create_dir_all(&source_root).expect("create source");
+
+    let outside_target = temp.path().join("outside.txt");
+    fs::write(&outside_target, b"outside content").expect("write outside");
+
+    let unsafe_link = source_root.join("unsafe_link");
+    symlink(&outside_target, &unsafe_link).expect("create unsafe symlink");
+
+    let dest_root = temp.path().join("dest");
+    let operands = vec![
+        source_root.into_os_string(),
+        dest_root.into_os_string(),
+    ];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+
+    plan.execute_with_options(
+        LocalCopyExecution::Apply,
+        LocalCopyOptions::default()
+            .links(true)
+            .copy_unsafe_links(true),
+    )
+    .expect("copy succeeds");
+
+    let symsafe_msgs: Vec<String> = drain_events()
+        .into_iter()
+        .filter_map(|event| match event {
+            DiagnosticEvent::Info {
+                flag: InfoFlag::Symsafe,
+                message,
+                ..
+            } => Some(message),
+            _ => None,
+        })
+        .collect();
+
+    assert!(
+        symsafe_msgs.is_empty(),
+        "expected no SYMSAFE notice at default verbosity; got {symsafe_msgs:?}"
+    );
+}
+
 
 #[cfg(unix)]
 #[test]

--- a/crates/transfer/src/generator/file_list/walk.rs
+++ b/crates/transfer/src/generator/file_list/walk.rs
@@ -13,6 +13,8 @@
 use std::io;
 use std::path::{Path, PathBuf};
 
+use logging::info_log;
+
 use crate::role_trailer::error_location;
 
 use super::super::GeneratorContext;
@@ -292,6 +294,15 @@ impl GeneratorContext {
                                 target.as_os_str(),
                                 relative,
                             ) {
+                                // upstream: flist.c:217 - INFO_GTE(SYMSAFE, 1)
+                                // fires before the target is dereferenced.
+                                info_log!(
+                                    Symsafe,
+                                    1,
+                                    "copying unsafe symlink \"{}\" -> \"{}\"",
+                                    path.display(),
+                                    target.display()
+                                );
                                 match std::fs::metadata(&path) {
                                     Ok(followed) => meta = followed,
                                     Err(e) => {
@@ -364,6 +375,15 @@ impl GeneratorContext {
             let relative = path.strip_prefix(base).unwrap_or(path);
             if super::super::super::symlink_safety::is_unsafe_symlink(target.as_os_str(), relative)
             {
+                // upstream: flist.c:217 - INFO_GTE(SYMSAFE, 1) fires before
+                // the unsafe symlink is dereferenced into a regular entry.
+                info_log!(
+                    Symsafe,
+                    1,
+                    "copying unsafe symlink \"{}\" -> \"{}\"",
+                    path.display(),
+                    target.display()
+                );
                 return std::fs::metadata(path);
             }
         }
@@ -421,5 +441,81 @@ mod rsyserr_wording_tests {
                 "template {template:?} did not match upstream wording"
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod symsafe_emission_tests {
+    //! Wording tests for `--info=SYMSAFE` producer emissions on the
+    //! sender side.
+    //!
+    //! Upstream rsync 3.4.1 fires `INFO_GTE(SYMSAFE, 1)` at `flist.c:217`
+    //! when `--copy-unsafe-links` triggers a dereference. The exact line
+    //! emitted (per `rprintf(FINFO, ...)`) is matched byte-for-byte so
+    //! interop harnesses that grep for the literal continue to find it.
+    use logging::{DiagnosticEvent, InfoFlag, VerbosityConfig, drain_events, info_log, init};
+
+    fn init_symsafe_level1() {
+        let mut cfg = VerbosityConfig::default();
+        cfg.info.symsafe = 1;
+        init(cfg);
+        let _ = drain_events();
+    }
+
+    fn symsafe_messages() -> Vec<String> {
+        drain_events()
+            .into_iter()
+            .filter_map(|event| match event {
+                DiagnosticEvent::Info {
+                    flag: InfoFlag::Symsafe,
+                    message,
+                    ..
+                } => Some(message),
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn copying_unsafe_symlink_wording_matches_upstream() {
+        // upstream: flist.c:217 -
+        //     rprintf(FINFO, "copying unsafe symlink \"%s\" -> \"%s\"\n",
+        //             path, linkbuf);
+        init_symsafe_level1();
+        let path = std::path::Path::new("src/link");
+        let target = std::path::Path::new("/etc/passwd");
+        info_log!(
+            Symsafe,
+            1,
+            "copying unsafe symlink \"{}\" -> \"{}\"",
+            path.display(),
+            target.display()
+        );
+        let msgs = symsafe_messages();
+        assert!(
+            msgs.iter()
+                .any(|m| m == "copying unsafe symlink \"src/link\" -> \"/etc/passwd\""),
+            "missing upstream wording: {msgs:?}"
+        );
+    }
+
+    #[test]
+    fn symsafe_emissions_suppressed_when_disabled() {
+        // Default `VerbosityConfig` leaves `info.symsafe == 0`, mirroring
+        // upstream's pre-`-v` state. The macro must not synthesise an event.
+        init(VerbosityConfig::default());
+        let _ = drain_events();
+        info_log!(
+            Symsafe,
+            1,
+            "copying unsafe symlink \"{}\" -> \"{}\"",
+            "x",
+            "y"
+        );
+        let msgs = symsafe_messages();
+        assert!(
+            msgs.is_empty(),
+            "SYMSAFE emissions must be gated; got: {msgs:?}"
+        );
     }
 }

--- a/docs/audits/info-flags-audit.md
+++ b/docs/audits/info-flags-audit.md
@@ -46,7 +46,7 @@ excluded.
 | REMOVE    | 1 (W_SND)          | Mention files removed on the sending side                          | `crates/cli/src/frontend/execution/flags/info.rs:146-149`, `info_output.rs:334`. No upper cap.                                                                                                                                                                                                                                       | None in production. Upstream `--remove-source-files` notifications gate on `INFO_GTE(REMOVE, 1)`; we have `--remove-source-files` plumbing in `crates/core` but no info gate before logging.                                                                                                                                            | Stub        |
 | SKIP      | 2 (W_REC)          | Mention files skipped due to transfer overrides (levels 1-2)       | `crates/cli/src/frontend/execution/flags/info.rs:150-156` rejects `level > 2`; `info_output.rs:335` does not enforce.                                                                                                                                                                                                                | None in production. Upstream `INFO_GTE(SKIP, 1/2)` fires in `generator.c:1367/1385/1387/1693/1701/1710`. Equivalent generator paths in `crates/engine/src/generator/*` do not consult the gate.                                                                                                                                          | Parsed-only |
 | STATS     | 3 (W_CLI\|W_SRV)   | Mention statistics at end of run (levels 1-3)                      | `crates/cli/src/frontend/execution/flags/info.rs:92-98` rejects `level > 3`; `info_output.rs:336` does not enforce.                                                                                                                                                                                                                  | `crates/cli/src/frontend/progress/diagnostic.rs:167` and `crates/cli/src/frontend/execution/drive/summary.rs` consume the boolean derived from `stats > 0`. Upstream's three-level emission (`STATS, 1/2/3` in `cleanup.c:224`, `generator.c:2377/2422`, `main.c:333/418/451`) is collapsed into a single boolean in our renderer. | Partial     |
-| SYMSAFE   | 1 (W_SND\|W_REC)   | Mention symlinks that are unsafe                                   | `crates/cli/src/frontend/execution/flags/info.rs:157-160`, `info_output.rs:337`. No upper cap.                                                                                                                                                                                                                                       | None in production. Upstream `INFO_GTE(SYMSAFE, 1)` fires in `backup.c:291` and `flist.c:216`. Our symlink-safety code in `crates/filters` and `crates/transfer/src/file_list/*` does not gate on the flag.                                                                                                                                | Stub        |
+| SYMSAFE   | 1 (W_SND\|W_REC)   | Mention symlinks that are unsafe                                   | `crates/cli/src/frontend/execution/flags/info.rs:157-160`, `info_output.rs:337`. No upper cap.                                                                                                                                                                                                                                       | `crates/transfer/src/generator/file_list/walk.rs::resolve_symlink_metadata` and the batched-stat fixup in the same file emit `copying unsafe symlink "<path>" -> "<target>"` via `info_log!(Symsafe, 1, ...)` on the sender side when `--copy-unsafe-links` triggers a dereference. `crates/engine/src/local_copy/executor/special/symlink.rs::copy_symlink` emits the same notice on the local-copy path. `crates/engine/src/local_copy/context_impl/state.rs::backup_existing_entry` emits `not backing up unsafe symlink "<dest>" -> "<target>"` on the cross-device backup fallback when `--safe-links` refuses to recreate the symlink. All three mirror upstream `flist.c:217` and `backup.c:292`. | Match       |
 
 Legend:
 
@@ -199,7 +199,7 @@ levels 0-5. Differences:
 ## Summary of parity gaps
 
 1. Per-flag emission gating is absent for DEL, FLIST, MISC, REMOVE,
-   SKIP, SYMSAFE. BACKUP is wired through `backup_existing_entry` in
+   SKIP. BACKUP is wired through `backup_existing_entry` in
    `crates/engine/src/local_copy/context_impl/state.rs`; NONREG is wired
    through `record_skipped_non_regular` in
    `crates/engine/src/local_copy/context_impl/reporting.rs`; COPY is wired
@@ -208,12 +208,18 @@ levels 0-5. Differences:
    path in `crates/engine/src/local_copy/executor/file/copy/transfer/execute.rs`;
    MOUNT is wired through the cross-device skip sites in
    `crates/engine/src/local_copy/executor/directory/recursive/entry.rs` and
-   `crates/engine/src/local_copy/executor/sources/orchestration.rs`.
+   `crates/engine/src/local_copy/executor/sources/orchestration.rs`;
+   SYMSAFE is wired through the sender-side walker in
+   `crates/transfer/src/generator/file_list/walk.rs`, the local-copy
+   dereference branch in
+   `crates/engine/src/local_copy/executor/special/symlink.rs`, and the
+   cross-device backup fallback in
+   `crates/engine/src/local_copy/context_impl/state.rs`.
    Adding `info_gte(InfoFlag::*, n)` guards at the upstream call sites
    listed above is required to graduate each remaining flag from "stub"
    or "parsed-only" to "match". Suggested insertion crates:
    `crates/engine/src/generator/*` (FLIST, SKIP),
-   `crates/transfer/src/file_list/*` (FLIST, SYMSAFE),
+   `crates/transfer/src/file_list/*` (FLIST),
    `crates/core/src/client/remote/*` (REMOVE),
    `crates/protocol/src/multiplex/*` and `crates/batch/src/*` (MISC).
 2. STATS is collapsed into a boolean. The renderer in


### PR DESCRIPTION
## Summary

- Wire `--info=SYMSAFE` producer emissions across the sender, local-copy, and cross-device backup paths so the flag finally fires under `INFO_GTE(SYMSAFE, 1)` (upstream `flist.c:217` and `backup.c:292`).
- Three call sites mirror upstream byte-for-byte: `crates/transfer/src/generator/file_list/walk.rs` for the sender push path, `crates/engine/src/local_copy/executor/special/symlink.rs` for the local-copy dereference branch, and `crates/engine/src/local_copy/context_impl/state.rs` for the cross-device backup fallback that refuses to recreate unsafe symlinks under `--safe-links`.
- Roll SYMSAFE from Stub to Match in `docs/audits/info-flags-audit.md` and remove it from the parity-gap summary.

## Test plan

- [x] `cargo nextest run -p transfer --all-features -E 'test(symsafe)'` covers the sender-side wording and the gated-when-disabled case.
- [x] `cargo nextest run -p engine --all-features -E 'test(symsafe)'` covers both the local-copy `--copy-unsafe-links` integration test (real symlink dereference through `LocalCopyPlan`) and the byte-for-byte backup wording test.
- [x] Visual inspection against `target/interop/upstream-src/rsync-3.4.1/{flist.c:217,backup.c:292}` confirms `copying unsafe symlink "<path>" -> "<target>"` and `not backing up unsafe symlink "<dest>" -> "<target>"` are emitted exactly.
- [ ] Full CI (fmt+clippy, nextest stable, Windows stable, macOS stable, Linux musl stable).

Closes #2163