### PR TITLE
feat(transfer): add wire_to_flat_ndx partition_point counters (INC_RECURSE I4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2225,6 +2225,7 @@ dependencies = [
  "exacl",
  "filetime",
  "libc",
+ "logging",
  "protocol",
  "rustix",
  "tempfile",

--- a/crates/protocol/src/acl/trace.rs
+++ b/crates/protocol/src/acl/trace.rs
@@ -96,6 +96,9 @@ mod tests {
         trace_default_perms_for_dir(0o750, "/var/spool");
         let m = acl_messages();
         assert_eq!(m.len(), 1);
-        assert_eq!(m[0], "got ACL-based default perms 750 for directory /var/spool");
+        assert_eq!(
+            m[0],
+            "got ACL-based default perms 750 for directory /var/spool"
+        );
     }
 }

--- a/crates/transfer/src/generator/mod.rs
+++ b/crates/transfer/src/generator/mod.rs
@@ -89,6 +89,7 @@ mod tests;
 mod transfer;
 
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
 use ::filters::FilterChain;
@@ -161,6 +162,45 @@ pub mod io_error_flags {
 /// - `flist.c:46` - `#define MIN_FILECNT_LOOKAHEAD 1000`
 /// - `sender.c:send_files()` line 250 - `send_extra_file_list(f, MIN_FILECNT_LOOKAHEAD)`
 pub const MIN_FILECNT_LOOKAHEAD: usize = 1000;
+
+/// Total invocations of `wire_to_flat_ndx` + `flat_to_wire_ndx` across all
+/// generator transfers in this process. Diagnostic counter for sender-side
+/// INC_RECURSE (#2199, I4) - quantifies how often the NDX conversion hot path
+/// fires per transfer relative to the file count.
+///
+/// Sampled at end-of-transfer in `GeneratorContext::run` via
+/// [`ndx_convert_totals`] and emitted via `tracing::debug!`.
+static NDX_CONVERT_CALLS: AtomicU64 = AtomicU64::new(0);
+
+/// Cumulative `partition_point` comparison depth (approximated as
+/// `floor(log2(len)) + 1`) summed across every NDX conversion call.
+/// Diagnostic counter for sender-side INC_RECURSE (#2199, I4) - lets
+/// operators see when the segment table grows large enough for the
+/// binary-search cost to matter.
+static NDX_CONVERT_CMPS: AtomicU64 = AtomicU64::new(0);
+
+/// Approximate number of comparisons a binary search performs on a sorted
+/// slice of length `len`. Returns `floor(log2(len)) + 1`, matching the worst
+/// case of `[T]::partition_point` on the segment table.
+fn partition_point_depth(len: usize) -> u64 {
+    if len == 0 {
+        return 0;
+    }
+    u64::from((len as u64).ilog2()) + 1
+}
+
+/// Snapshot of the global NDX conversion counters.
+///
+/// Returns `(call_count, cumulative_partition_point_depth)`. Used by the
+/// generator finalize path to emit an end-of-transfer diagnostic line and by
+/// unit tests that assert the counters monotonically grow.
+#[must_use]
+pub fn ndx_convert_totals() -> (u64, u64) {
+    (
+        NDX_CONVERT_CALLS.load(Ordering::Relaxed),
+        NDX_CONVERT_CMPS.load(Ordering::Relaxed),
+    )
+}
 
 /// A pending file list sub-segment for incremental recursion sending.
 ///
@@ -461,31 +501,39 @@ impl GeneratorContext {
     ///
     /// Uses `partition_point` for O(log n) lookup, matching `flat_to_wire_ndx`.
     ///
+    /// Updates the [`NDX_CONVERT_CALLS`] / [`NDX_CONVERT_CMPS`] counters used
+    /// for INC_RECURSE diagnostic I4 (#2199).
+    ///
     /// # Upstream Reference
     ///
     /// - `rsync.c:424` - `i = ndx - cur_flist->ndx_start`
     fn wire_to_flat_ndx(&self, wire_ndx: i32) -> usize {
-        let seg_idx = self
-            .incremental
-            .ndx_segments
+        let segments = &self.incremental.ndx_segments;
+        NDX_CONVERT_CALLS.fetch_add(1, Ordering::Relaxed);
+        NDX_CONVERT_CMPS.fetch_add(partition_point_depth(segments.len()), Ordering::Relaxed);
+        let seg_idx = segments
             .partition_point(|&(_, ndx_start)| ndx_start <= wire_ndx)
             .saturating_sub(1);
-        let (flat_start, ndx_start) = self.incremental.ndx_segments[seg_idx];
+        let (flat_start, ndx_start) = segments[seg_idx];
         flat_start + (wire_ndx - ndx_start) as usize
     }
 
     /// Converts a flat file list array index to a wire NDX value.
     ///
+    /// Updates the [`NDX_CONVERT_CALLS`] / [`NDX_CONVERT_CMPS`] counters used
+    /// for INC_RECURSE diagnostic I4 (#2199).
+    ///
     /// # Upstream Reference
     ///
     /// - `generator.c:2321` - `ndx = i + cur_flist->ndx_start`
     fn flat_to_wire_ndx(&self, flat_idx: usize) -> i32 {
-        let seg_idx = self
-            .incremental
-            .ndx_segments
+        let segments = &self.incremental.ndx_segments;
+        NDX_CONVERT_CALLS.fetch_add(1, Ordering::Relaxed);
+        NDX_CONVERT_CMPS.fetch_add(partition_point_depth(segments.len()), Ordering::Relaxed);
+        let seg_idx = segments
             .partition_point(|&(start, _)| start <= flat_idx)
             - 1;
-        let (flat_start, ndx_start) = self.incremental.ndx_segments[seg_idx];
+        let (flat_start, ndx_start) = segments[seg_idx];
         ndx_start + (flat_idx - flat_start) as i32
     }
 

--- a/crates/transfer/src/generator/mod.rs
+++ b/crates/transfer/src/generator/mod.rs
@@ -530,9 +530,7 @@ impl GeneratorContext {
         let segments = &self.incremental.ndx_segments;
         NDX_CONVERT_CALLS.fetch_add(1, Ordering::Relaxed);
         NDX_CONVERT_CMPS.fetch_add(partition_point_depth(segments.len()), Ordering::Relaxed);
-        let seg_idx = segments
-            .partition_point(|&(start, _)| start <= flat_idx)
-            - 1;
+        let seg_idx = segments.partition_point(|&(start, _)| start <= flat_idx) - 1;
         let (flat_start, ndx_start) = segments[seg_idx];
         ndx_start + (flat_idx - flat_start) as i32
     }

--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -250,6 +250,64 @@ fn send_file_list_first_byte_latency_recorded_for_empty_list() {
 }
 
 #[test]
+fn ndx_convert_call_counter_increments() {
+    // INC_RECURSE diagnostic I4 (#2199): every wire_to_flat_ndx /
+    // flat_to_wire_ndx invocation must bump the global call counter. The
+    // assertion uses >= because the counter is shared across the process and
+    // other tests may run concurrently.
+    use super::ndx_convert_totals;
+
+    let (_handshake, ctx) = test_generator();
+    let (calls_before, _) = ndx_convert_totals();
+
+    let _ = ctx.wire_to_flat_ndx(0);
+    let _ = ctx.flat_to_wire_ndx(0);
+    let _ = ctx.flat_to_wire_ndx(0);
+
+    let (calls_after, _) = ndx_convert_totals();
+    assert!(
+        calls_after >= calls_before + 3,
+        "expected at least 3 new ndx_convert calls (before={calls_before}, after={calls_after})"
+    );
+}
+
+#[test]
+fn ndx_convert_partition_point_depth_grows() {
+    // INC_RECURSE diagnostic I4 (#2199): the cumulative partition_point depth
+    // must monotonically grow as the segment table is queried. A 4-segment
+    // table adds depth(4)=3 per call, so N calls add at least N*3. The
+    // assertion uses >= because the counter is shared across the process.
+    use super::{ndx_convert_totals, partition_point_depth};
+
+    let (_handshake, mut ctx) = test_generator();
+    // Default ndx_segments has one entry; extend it to four so each query
+    // contributes a measurably larger partition_point depth.
+    ctx.incremental.ndx_segments.push((10, 11));
+    ctx.incremental.ndx_segments.push((20, 22));
+    ctx.incremental.ndx_segments.push((30, 33));
+
+    let per_call_depth = partition_point_depth(ctx.incremental.ndx_segments.len());
+    assert!(
+        per_call_depth >= 3,
+        "expected partition_point_depth(4) >= 3, got {per_call_depth}"
+    );
+
+    const N: u64 = 8;
+    let (_, cmps_before) = ndx_convert_totals();
+    for _ in 0..N {
+        let _ = ctx.flat_to_wire_ndx(0);
+    }
+    let (_, cmps_after) = ndx_convert_totals();
+
+    assert!(
+        cmps_after >= cmps_before + N * per_call_depth,
+        "cumulative partition_point depth should grow by at least {} \
+         (before={cmps_before}, after={cmps_after})",
+        N * per_call_depth
+    );
+}
+
+#[test]
 fn build_and_send_round_trip() {
     use crate::receiver::ReceiverContext;
 

--- a/crates/transfer/src/generator/transfer.rs
+++ b/crates/transfer/src/generator/transfer.rs
@@ -812,6 +812,26 @@ impl GeneratorContext {
         let flist_xfertime =
             calculate_duration_ms(self.timing.flist_xfer_start, self.timing.flist_xfer_end);
 
+        // INC_RECURSE diagnostic I4 (#2199): emit cumulative NDX conversion
+        // call count and partition_point comparison depth. Aggregated across
+        // all generator transfers in this process so operators can see how
+        // hot the wire/flat conversion path is relative to file counts.
+        let (ndx_calls, ndx_cmps) = super::ndx_convert_totals();
+        debug_log!(
+            Genr,
+            1,
+            "generator ndx_convert totals: calls={} partition_point_depth={}",
+            ndx_calls,
+            ndx_cmps
+        );
+        #[cfg(feature = "tracing")]
+        ::tracing::debug!(
+            target: "rsync::generator::ndx_convert",
+            calls = ndx_calls,
+            partition_point_depth = ndx_cmps,
+            "generator ndx_convert totals"
+        );
+
         Ok(GeneratorStats {
             files_listed: file_count,
             files_transferred: transfer_result.files_transferred,

--- a/crates/transfer/src/receiver/mod.rs
+++ b/crates/transfer/src/receiver/mod.rs
@@ -43,6 +43,7 @@ use std::collections::HashMap;
 use std::num::NonZeroU8;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use filters::{FilterChain, FilterSet};
 use protocol::acl::AclCache;
@@ -88,6 +89,45 @@ const REDO_CHECKSUM_LENGTH: NonZeroU8 =
 pub(crate) use crate::parallel_io::ParallelThresholds;
 
 use signature;
+
+/// Total invocations of [`ReceiverContext::flat_to_wire_ndx`] across all
+/// receiver transfers in this process. Diagnostic counter for receiver-side
+/// INC_RECURSE (#2199, I4) - quantifies how often the wire/flat conversion
+/// hot path fires per transfer relative to the file count.
+///
+/// Sampled at end-of-transfer in the receiver finalize path via
+/// [`ndx_convert_totals`] and emitted via `tracing::debug!`.
+static NDX_CONVERT_CALLS: AtomicU64 = AtomicU64::new(0);
+
+/// Cumulative `partition_point` comparison depth (approximated as
+/// `floor(log2(len)) + 1`) summed across every NDX conversion call.
+/// Diagnostic counter for receiver-side INC_RECURSE (#2199, I4) - lets
+/// operators see when the segment table grows large enough for the
+/// binary-search cost to matter.
+static NDX_CONVERT_CMPS: AtomicU64 = AtomicU64::new(0);
+
+/// Approximate number of comparisons a binary search performs on a sorted
+/// slice of length `len`. Returns `floor(log2(len)) + 1`, matching the worst
+/// case of `[T]::partition_point` on the segment table.
+fn partition_point_depth(len: usize) -> u64 {
+    if len == 0 {
+        return 0;
+    }
+    u64::from((len as u64).ilog2()) + 1
+}
+
+/// Snapshot of the global NDX conversion counters.
+///
+/// Returns `(call_count, cumulative_partition_point_depth)`. Used by the
+/// receiver finalize path to emit an end-of-transfer diagnostic line and by
+/// unit tests that assert the counters monotonically grow.
+#[must_use]
+pub fn ndx_convert_totals() -> (u64, u64) {
+    (
+        NDX_CONVERT_CALLS.load(Ordering::Relaxed),
+        NDX_CONVERT_CMPS.load(Ordering::Relaxed),
+    )
+}
 
 /// Context for the receiver role during a transfer.
 ///
@@ -260,15 +300,20 @@ impl ReceiverContext {
 
     /// Converts a flat file list array index to a wire NDX value.
     ///
+    /// Updates the [`NDX_CONVERT_CALLS`] / [`NDX_CONVERT_CMPS`] counters used
+    /// for INC_RECURSE diagnostic I4 (#2199).
+    ///
     /// # Upstream Reference
     ///
     /// - `generator.c:2321` - `ndx = i + cur_flist->ndx_start`
     pub(in crate::receiver) fn flat_to_wire_ndx(&self, flat_idx: usize) -> i32 {
-        let seg_idx = self
-            .ndx_segments
+        let segments = &self.ndx_segments;
+        NDX_CONVERT_CALLS.fetch_add(1, Ordering::Relaxed);
+        NDX_CONVERT_CMPS.fetch_add(partition_point_depth(segments.len()), Ordering::Relaxed);
+        let seg_idx = segments
             .partition_point(|&(start, _)| start <= flat_idx)
             - 1;
-        let (flat_start, ndx_start) = self.ndx_segments[seg_idx];
+        let (flat_start, ndx_start) = segments[seg_idx];
         ndx_start + (flat_idx - flat_start) as i32
     }
 

--- a/crates/transfer/src/receiver/mod.rs
+++ b/crates/transfer/src/receiver/mod.rs
@@ -310,9 +310,7 @@ impl ReceiverContext {
         let segments = &self.ndx_segments;
         NDX_CONVERT_CALLS.fetch_add(1, Ordering::Relaxed);
         NDX_CONVERT_CMPS.fetch_add(partition_point_depth(segments.len()), Ordering::Relaxed);
-        let seg_idx = segments
-            .partition_point(|&(start, _)| start <= flat_idx)
-            - 1;
+        let seg_idx = segments.partition_point(|&(start, _)| start <= flat_idx) - 1;
         let (flat_start, ndx_start) = segments[seg_idx];
         ndx_start + (flat_idx - flat_start) as i32
     }

--- a/crates/transfer/src/receiver/tests.rs
+++ b/crates/transfer/src/receiver/tests.rs
@@ -3835,3 +3835,65 @@ fn receive_file_list_ignore_errors_suppresses_io_error() {
         "ignore_errors should suppress io_error accumulation"
     );
 }
+
+#[test]
+fn receiver_ndx_convert_call_counter_increments() {
+    // INC_RECURSE diagnostic I4 (#2199): every flat_to_wire_ndx invocation
+    // must bump the global call counter. The assertion uses >= because the
+    // counter is shared across the process and other tests may run
+    // concurrently.
+    use super::ndx_convert_totals;
+
+    let handshake = test_handshake();
+    let config = test_config();
+    let ctx = ReceiverContext::new(&handshake, config);
+
+    let (calls_before, _) = ndx_convert_totals();
+
+    let _ = ctx.flat_to_wire_ndx(0);
+    let _ = ctx.flat_to_wire_ndx(0);
+    let _ = ctx.flat_to_wire_ndx(0);
+
+    let (calls_after, _) = ndx_convert_totals();
+    assert!(
+        calls_after >= calls_before + 3,
+        "expected at least 3 new ndx_convert calls (before={calls_before}, after={calls_after})"
+    );
+}
+
+#[test]
+fn receiver_ndx_convert_partition_point_depth_grows() {
+    // INC_RECURSE diagnostic I4 (#2199): the cumulative partition_point depth
+    // must monotonically grow as the segment table is queried. A 4-segment
+    // table contributes at least depth(4)=3 per call. Uses >= because the
+    // counter is shared across the process.
+    use super::{ndx_convert_totals, partition_point_depth};
+
+    let handshake = test_handshake();
+    let config = test_config();
+    let mut ctx = ReceiverContext::new(&handshake, config);
+    // Default ndx_segments has one entry; extend it to four.
+    ctx.ndx_segments.push((10, 11));
+    ctx.ndx_segments.push((20, 22));
+    ctx.ndx_segments.push((30, 33));
+
+    let per_call_depth = partition_point_depth(ctx.ndx_segments.len());
+    assert!(
+        per_call_depth >= 3,
+        "expected partition_point_depth(4) >= 3, got {per_call_depth}"
+    );
+
+    const N: u64 = 8;
+    let (_, cmps_before) = ndx_convert_totals();
+    for _ in 0..N {
+        let _ = ctx.flat_to_wire_ndx(0);
+    }
+    let (_, cmps_after) = ndx_convert_totals();
+
+    assert!(
+        cmps_after >= cmps_before + N * per_call_depth,
+        "cumulative partition_point depth should grow by at least {} \
+         (before={cmps_before}, after={cmps_after})",
+        N * per_call_depth
+    );
+}

--- a/crates/transfer/src/receiver/transfer/phases.rs
+++ b/crates/transfer/src/receiver/transfer/phases.rs
@@ -222,6 +222,25 @@ impl ReceiverContext {
         // the bottom of generate_files() after the final goodbye handshake.
         debug_log!(Genr, 1, "generate_files finished");
 
+        // INC_RECURSE diagnostic I4 (#2199): emit cumulative NDX conversion
+        // call count and partition_point comparison depth from the receiver
+        // side. Aggregated across all receiver transfers in this process.
+        let (ndx_calls, ndx_cmps) = crate::receiver::ndx_convert_totals();
+        debug_log!(
+            Genr,
+            1,
+            "receiver ndx_convert totals: calls={} partition_point_depth={}",
+            ndx_calls,
+            ndx_cmps
+        );
+        #[cfg(feature = "tracing")]
+        ::tracing::debug!(
+            target: "rsync::receiver::ndx_convert",
+            calls = ndx_calls,
+            partition_point_depth = ndx_cmps,
+            "receiver ndx_convert totals"
+        );
+
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary
- Adds INC_RECURSE diagnostic counter I4: two process-global `AtomicU64`s per side that track every `wire_to_flat_ndx` / `flat_to_wire_ndx` call and the cumulative `partition_point` comparison depth.
- Emits the totals at end-of-transfer (generator finalize and receiver `finalize_transfer`) via `debug_log!(Genr, 1, ...)` and, under the optional `tracing` feature, `tracing::debug!` at `rsync::generator::ndx_convert` / `rsync::receiver::ndx_convert`.
- Exposes a `ndx_convert_totals()` free function in both `transfer::generator` and `transfer::receiver` returning `(call_count, cumulative_partition_point_depth)`. No CLI flag, no wire-format change, no change to existing function signatures.

## Test plan
- [ ] CI: `cargo nextest run -p transfer` exercises the four new unit tests (two per side) asserting the call counter increments and the cumulative partition_point depth grows under N invocations against a known-size segment table.
- [ ] CI: fmt + clippy + Windows + macOS + musl matrix on the new atomic-counter code and the new finalize-path debug emissions.
- [ ] Interop suite remains untouched (no protocol or CLI changes).

Closes #2199