### PR TITLE
feat(transfer): instrument writer.flush rate (INC_RECURSE I3)

### DIFF
--- a/crates/transfer/src/generator/mod.rs
+++ b/crates/transfer/src/generator/mod.rs
@@ -88,6 +88,7 @@ mod protocol_io;
 mod tests;
 mod transfer;
 
+use std::io::{self, Write};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
@@ -200,6 +201,34 @@ pub fn ndx_convert_totals() -> (u64, u64) {
         NDX_CONVERT_CALLS.load(Ordering::Relaxed),
         NDX_CONVERT_CMPS.load(Ordering::Relaxed),
     )
+}
+
+/// Total `writer.flush()` invocations on the generator transfer hot path across
+/// all generator transfers in this process. Diagnostic counter for sender-side
+/// INC_RECURSE (#2198, I3) - quantifies how often the sender forces a flush
+/// per file and per NDX-control echo, relative to the file count.
+///
+/// Sampled at end-of-transfer in `GeneratorContext::run` via
+/// [`flush_rate_totals`] and emitted via `tracing::debug!`.
+static FLUSH_CALLS: AtomicU64 = AtomicU64::new(0);
+
+/// Records a flush invocation on the generator transfer hot path. Used by the
+/// transfer loop (per-iteration, NDX_DONE echo, dry-run, final NDX_DONE) to
+/// bump [`FLUSH_CALLS`] for INC_RECURSE diagnostic I3 (#2198).
+pub(crate) fn flush_with_count<W: Write>(writer: &mut W) -> io::Result<()> {
+    FLUSH_CALLS.fetch_add(1, Ordering::Relaxed);
+    writer.flush()
+}
+
+/// Snapshot of the global generator flush counter.
+///
+/// Returns the cumulative number of `writer.flush()` calls recorded by
+/// [`flush_with_count`]. Used by the generator finalize path to emit an
+/// end-of-transfer diagnostic line and by unit tests that assert the counter
+/// monotonically grows.
+#[must_use]
+pub fn flush_rate_totals() -> u64 {
+    FLUSH_CALLS.load(Ordering::Relaxed)
 }
 
 /// A pending file list sub-segment for incremental recursion sending.

--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -308,6 +308,46 @@ fn ndx_convert_partition_point_depth_grows() {
 }
 
 #[test]
+fn flush_with_count_increments_global_counter() {
+    // INC_RECURSE diagnostic I3 (#2198): every flush on the generator
+    // transfer hot path must bump the global FLUSH_CALLS counter. The
+    // assertion uses >= because the counter is shared across the process and
+    // other tests may run concurrently.
+    use super::{flush_rate_totals, flush_with_count};
+
+    let before = flush_rate_totals();
+
+    let mut sink: Vec<u8> = Vec::new();
+    flush_with_count(&mut sink).unwrap();
+    flush_with_count(&mut sink).unwrap();
+    flush_with_count(&mut sink).unwrap();
+
+    let after = flush_rate_totals();
+    assert!(
+        after >= before + 3,
+        "expected at least 3 new flush calls (before={before}, after={after})"
+    );
+}
+
+#[test]
+fn flush_rate_totals_is_observable_without_flushing() {
+    // INC_RECURSE diagnostic I3 (#2198): the totals snapshot must be readable
+    // without triggering any flush. Constructing a generator must not bump
+    // the counter on its own, so two adjacent reads with no intervening
+    // flush_with_count call must return identical values.
+    use super::flush_rate_totals;
+
+    let (_handshake, _ctx) = test_generator();
+    let first = flush_rate_totals();
+    let second = flush_rate_totals();
+
+    assert_eq!(
+        first, second,
+        "flush_rate_totals must be a pure read (first={first}, second={second})"
+    );
+}
+
+#[test]
 fn build_and_send_round_trip() {
     use crate::receiver::ReceiverContext;
 

--- a/crates/transfer/src/generator/transfer.rs
+++ b/crates/transfer/src/generator/transfer.rs
@@ -28,7 +28,8 @@ use super::delta::{
 use super::item_flags::ItemFlags;
 use super::protocol_io::calculate_duration_ms;
 use super::{
-    GeneratorContext, GeneratorStats, SegmentScheduler, TransferLoopResult, is_early_close_error,
+    GeneratorContext, GeneratorStats, SegmentScheduler, TransferLoopResult, flush_with_count,
+    is_early_close_error,
 };
 use crate::delta_config::DeltaGeneratorConfig;
 use crate::receiver::SumHead;
@@ -135,7 +136,7 @@ impl GeneratorContext {
             // for input via select(). Our Read/Write traits are independent, so
             // we must explicitly flush before blocking on read to prevent deadlock
             // when buffered delta data hasn't reached the receiver yet.
-            writer.flush()?;
+            flush_with_count(writer)?;
 
             // upstream: sender.c:210-462 - read NDX request from receiver
             let ndx = match ndx_read_codec.read_ndx(&mut *reader) {
@@ -159,7 +160,7 @@ impl GeneratorContext {
                             flist_done_remaining -= 1;
                             if let Err(e) = ndx_write_codec
                                 .write_ndx_done(&mut *writer)
-                                .and_then(|()| writer.flush())
+                                .and_then(|()| flush_with_count(&mut *writer))
                             {
                                 if tolerant && is_early_close_error(&e) {
                                     break;
@@ -180,7 +181,7 @@ impl GeneratorContext {
                         debug_log!(Send, 1, "send_files phase={}", phase);
                         if let Err(e) = ndx_write_codec
                             .write_ndx_done(&mut *writer)
-                            .and_then(|()| writer.flush())
+                            .and_then(|()| flush_with_count(&mut *writer))
                         {
                             if tolerant && is_early_close_error(&e) {
                                 break;
@@ -275,7 +276,7 @@ impl GeneratorContext {
                     cb.on_itemize(&format!("{name}\n"));
                 }
                 files_transferred += 1;
-                writer.flush()?;
+                flush_with_count(writer)?;
                 continue;
             }
 
@@ -487,7 +488,7 @@ impl GeneratorContext {
         // goodbye handshake. Without it, the client hangs waiting for this marker.
         if let Err(e) = ndx_write_codec
             .write_ndx_done(&mut *writer)
-            .and_then(|()| writer.flush())
+            .and_then(|()| flush_with_count(&mut *writer))
         {
             if !(tolerant && is_early_close_error(&e)) {
                 return Err(e);
@@ -830,6 +831,24 @@ impl GeneratorContext {
             calls = ndx_calls,
             partition_point_depth = ndx_cmps,
             "generator ndx_convert totals"
+        );
+
+        // INC_RECURSE diagnostic I3 (#2198): emit cumulative writer.flush()
+        // call count from the generator transfer hot path. Aggregated across
+        // all generator transfers in this process so operators can see how
+        // often the sender forces a flush relative to file counts.
+        let flush_calls = super::flush_rate_totals();
+        debug_log!(
+            Send,
+            1,
+            "generator writer.flush totals: calls={}",
+            flush_calls
+        );
+        #[cfg(feature = "tracing")]
+        ::tracing::debug!(
+            target: "rsync::generator::flush_rate",
+            calls = flush_calls,
+            "generator writer.flush totals"
         );
 
         Ok(GeneratorStats {


### PR DESCRIPTION
Closes #2198

## Summary

- Adds a process-global `AtomicU64` flush counter for the generator transfer hot path, bumped via a single `flush_with_count()` helper that replaces the five hot-path `writer.flush()` sites in `run_transfer_loop()` (per-iteration NDX flush, NDX_DONE flist-free echo, NDX_DONE phase-transition echo, dry-run per-file flush, final NDX_DONE goodbye).
- Surfaces totals at end-of-transfer in `GeneratorContext::run` via `flush_rate_totals()`, emitting `debug_log!(Send, 1, ...)` plus a `tracing::debug!` event when the optional `tracing` feature is enabled. No CLI flag, no wire-format change, no public hot-path signature change.
- Two unit tests: one asserts the counter increments by at least N after N `flush_with_count` calls (>= guards against concurrent test runs sharing the static), the other asserts that constructing a generator alone does not bump the counter.

## Test plan

- [ ] CI: fmt + clippy
- [ ] CI: nextest (stable) - `flush_with_count_increments_global_counter` + `flush_rate_totals_is_observable_without_flushing`
- [ ] CI: Windows / macOS / Linux musl