### PR TITLE
feat(metadata): wire --debug=OWN producer emissions (3.4.1 parity)

### DIFF
--- a/crates/metadata/src/apply/ownership.rs
+++ b/crates/metadata/src/apply/ownership.rs
@@ -14,6 +14,8 @@ use crate::id_lookup::{map_gid, map_uid};
 #[cfg(unix)]
 use crate::ownership;
 #[cfg(unix)]
+use protocol::idlist::{trace_set_gid, trace_set_uid};
+#[cfg(unix)]
 use rustix::fs::{self as unix_fs, AtFlags, CWD};
 #[cfg(unix)]
 use rustix::process::{RawGid, RawUid};
@@ -23,6 +25,37 @@ use std::io;
 use std::os::fd::BorrowedFd;
 #[cfg(unix)]
 use std::os::unix::fs::MetadataExt;
+
+/// Emits the upstream level-1 `set uid of`/`set gid of` traces for a chown.
+///
+/// upstream: `rsync.c:535-545` - `DEBUG_GTE(OWN, 1)` block emitted from
+/// `set_file_attrs` before `do_lchown`. The trace fires only for the fields
+/// that actually change against `existing`; when `existing` is unknown we
+/// emit using `from = 0` to match upstream's behaviour for fresh inodes
+/// where `sxp->st` is the just-allocated stat block.
+#[cfg(unix)]
+fn trace_chown_change(
+    destination: &Path,
+    owner: Option<unix_fs::Uid>,
+    group: Option<unix_fs::Gid>,
+    existing: Option<&fs::Metadata>,
+) {
+    let path = destination.display().to_string();
+    if let Some(new_uid) = owner {
+        let new_raw: u32 = new_uid.as_raw();
+        let from = existing.map(|m| m.uid()).unwrap_or(new_raw);
+        if from != new_raw {
+            trace_set_uid(&path, from, new_raw);
+        }
+    }
+    if let Some(new_gid) = group {
+        let new_raw: u32 = new_gid.as_raw();
+        let from = existing.map(|m| m.gid()).unwrap_or(new_raw);
+        if from != new_raw {
+            trace_set_gid(&path, from, new_raw);
+        }
+    }
+}
 
 /// Resolves the target UID and GID after applying overrides, mappings, and
 /// numeric-id rules. Returns `(None, None)` when no ownership change is
@@ -134,6 +167,9 @@ pub(super) fn set_owner_like(
             AtFlags::SYMLINK_NOFOLLOW
         };
 
+        // upstream: rsync.c:535-546 - DEBUG_GTE(OWN, 1) fires before do_lchown.
+        trace_chown_change(destination, owner, group, existing);
+
         unix_fs::chownat(CWD, destination, owner, group, flags).map_err(|error| {
             MetadataError::new("preserve ownership", destination, io::Error::from(error))
         })?
@@ -171,6 +207,9 @@ pub(super) fn set_owner_like_with_fd(
             return Ok(());
         }
     }
+
+    // upstream: rsync.c:535-546 - DEBUG_GTE(OWN, 1) fires before do_lchown.
+    trace_chown_change(destination, owner, group, existing);
 
     unix_fs::fchown(fd, owner, group).map_err(|error| {
         MetadataError::new("preserve ownership", destination, io::Error::from(error))
@@ -270,6 +309,9 @@ pub(super) fn apply_ownership_from_entry(
         };
 
         if needs_chown {
+            // upstream: rsync.c:535-546 - DEBUG_GTE(OWN, 1) fires before do_lchown.
+            trace_chown_change(destination, owner, group, cached_meta);
+
             chownat(CWD, destination, owner, group, AtFlags::empty()).map_err(|error| {
                 MetadataError::new("preserve ownership", destination, io::Error::from(error))
             })?;
@@ -341,4 +383,136 @@ pub(super) fn apply_ownership_from_entry(
     _cached_meta: Option<&fs::Metadata>,
 ) -> Result<(), MetadataError> {
     Ok(())
+}
+
+#[cfg(all(test, unix))]
+mod own_debug_tests {
+    //! `--debug=OWN` level-1 emission tests for the chown helpers.
+    //!
+    //! These exercise the trace path without performing a real `chownat`
+    //! (which would require root). The helper resolves the uid/gid pair
+    //! and decides whether each side changed against `existing`; the
+    //! pinning is on the upstream wire shapes from `rsync.c:535-545`.
+
+    use super::*;
+    use logging::{DebugFlag, DiagnosticEvent, VerbosityConfig, drain_events, init};
+    use std::fs;
+    use std::path::PathBuf;
+    use tempfile::tempdir;
+
+    fn init_at(level: u8) {
+        let mut cfg = VerbosityConfig::default();
+        cfg.debug.own = level;
+        init(cfg);
+        let _ = drain_events();
+    }
+
+    fn own_messages() -> Vec<String> {
+        drain_events()
+            .into_iter()
+            .filter_map(|event| match event {
+                DiagnosticEvent::Debug {
+                    flag: DebugFlag::Own,
+                    message,
+                    ..
+                } => Some(message),
+                _ => None,
+            })
+            .collect()
+    }
+
+    fn fake_existing(path: &PathBuf) -> fs::Metadata {
+        fs::write(path, b"").expect("write probe");
+        fs::metadata(path).expect("probe metadata")
+    }
+
+    #[test]
+    fn level1_set_uid_emits_with_destination_path() {
+        // upstream: rsync.c:537-540 - "set uid of %s from %u to %u".
+        init_at(1);
+
+        let tmp = tempdir().expect("tempdir");
+        let path = tmp.path().join("probe");
+        let meta = fake_existing(&path);
+        let current_uid = meta.uid() as u64;
+        let new_uid = current_uid as u32 ^ 1; // any value distinct from current
+        let owner = Some(ownership::uid_from_raw(new_uid as RawUid));
+
+        trace_chown_change(&path, owner, None, Some(&meta));
+
+        let expected = format!(
+            "set uid of {} from {} to {}",
+            path.display(),
+            current_uid,
+            new_uid
+        );
+        let m = own_messages();
+        assert!(
+            m.iter().any(|s| s == &expected),
+            "missing {expected:?}, got {m:?}"
+        );
+    }
+
+    #[test]
+    fn level1_set_gid_emits_with_destination_path() {
+        // upstream: rsync.c:541-545 - "set gid of %s from %u to %u".
+        init_at(1);
+
+        let tmp = tempdir().expect("tempdir");
+        let path = tmp.path().join("probe");
+        let meta = fake_existing(&path);
+        let current_gid = meta.gid() as u64;
+        let new_gid = current_gid as u32 ^ 1;
+        let group = Some(ownership::gid_from_raw(new_gid as RawGid));
+
+        trace_chown_change(&path, None, group, Some(&meta));
+
+        let expected = format!(
+            "set gid of {} from {} to {}",
+            path.display(),
+            current_gid,
+            new_gid
+        );
+        let m = own_messages();
+        assert!(
+            m.iter().any(|s| s == &expected),
+            "missing {expected:?}, got {m:?}"
+        );
+    }
+
+    #[test]
+    fn level1_no_emission_when_uid_unchanged() {
+        // upstream: rsync.c:536-540 - `if (change_uid)` gates the uid trace.
+        init_at(1);
+
+        let tmp = tempdir().expect("tempdir");
+        let path = tmp.path().join("probe");
+        let meta = fake_existing(&path);
+        let same_uid = meta.uid() as u32;
+        let owner = Some(ownership::uid_from_raw(same_uid as RawUid));
+
+        trace_chown_change(&path, owner, None, Some(&meta));
+        assert!(
+            own_messages().is_empty(),
+            "uid unchanged must not emit the level-1 trace"
+        );
+    }
+
+    #[test]
+    fn level0_suppresses_set_uid_set_gid() {
+        // upstream: DEBUG_GTE(OWN, 1) is false when --debug=OWN is disabled.
+        init_at(0);
+
+        let tmp = tempdir().expect("tempdir");
+        let path = tmp.path().join("probe");
+        let meta = fake_existing(&path);
+        let owner = Some(ownership::uid_from_raw(((meta.uid() as u32) ^ 1) as RawUid));
+        let group = Some(ownership::gid_from_raw(((meta.gid() as u32) ^ 1) as RawGid));
+
+        trace_chown_change(&path, owner, group, Some(&meta));
+        assert!(
+            own_messages().is_empty(),
+            "level-0 must suppress all OWN traces"
+        );
+    }
 }

--- a/crates/protocol/src/idlist/mod.rs
+++ b/crates/protocol/src/idlist/mod.rs
@@ -24,6 +24,10 @@
 //! - `uidlist.c` - UID/GID list management
 //! - `io.h:21-43` - `read_varint30()`/`write_varint30()` inline functions
 
+pub mod trace;
+
+pub use trace::{IdKind, trace_id_maps_to, trace_process_gids, trace_set_gid, trace_set_uid};
+
 use std::collections::HashMap;
 use std::io::{self, Read, Write};
 
@@ -235,6 +239,31 @@ impl IdList {
     where
         F: Fn(&[u8]) -> Option<u32>,
     {
+        self.read_with_kind(reader, id0_names, protocol_version, None, name_to_id)
+    }
+
+    /// Reads an ID list from the wire, emitting `--debug=OWN` traces.
+    ///
+    /// Behaves identically to [`IdList::read`] but additionally fires the
+    /// upstream `DEBUG_GTE(OWN, 2)` per-entry trace for every id resolved.
+    /// Callers that want the mapping diagnostics pass `Some(IdKind::Uid)` or
+    /// `Some(IdKind::Gid)`; passing `None` is equivalent to [`IdList::read`].
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `uidlist.c:243-294` - `recv_add_id()` performs the resolution and
+    ///   emits `"%sid %u(%s) maps to %u"` at level 2 (line 287).
+    pub fn read_with_kind<R: Read + ?Sized, F>(
+        &mut self,
+        reader: &mut R,
+        id0_names: bool,
+        protocol_version: u8,
+        kind: Option<IdKind>,
+        name_to_id: F,
+    ) -> io::Result<()>
+    where
+        F: Fn(&[u8]) -> Option<u32>,
+    {
         // Read (id, name) pairs until id=0
         loop {
             // Use varint30 decoding (int for proto < 30, varint for proto >= 30)
@@ -246,6 +275,10 @@ impl IdList {
             let id = id_signed as u32;
 
             let (name, local_id) = self.read_name_and_resolve(reader, id, &name_to_id)?;
+            // upstream: uidlist.c:287-291 - `"%sid %u(%s) maps to %u"`.
+            if let Some(k) = kind {
+                trace_id_maps_to(k, id, name.as_deref(), local_id);
+            }
             self.entries.insert(id, IdEntry { name, local_id });
             self.order.push(id);
         }
@@ -253,6 +286,11 @@ impl IdList {
         // With ID0_NAMES, read id=0's name
         if id0_names {
             let (name, local_id) = self.read_name_and_resolve(reader, 0, &name_to_id)?;
+            // upstream: uidlist.c:287-291 - the id=0 entry is processed by the
+            // same `recv_add_id` path and therefore also fires the level-2 trace.
+            if let Some(k) = kind {
+                trace_id_maps_to(k, 0, name.as_deref(), local_id);
+            }
             self.entries.insert(0, IdEntry { name, local_id });
             self.order.push(0);
         }
@@ -516,5 +554,78 @@ mod tests {
         let mut buf = Vec::new();
         list.write(&mut buf, false, 30).unwrap();
         assert_eq!(buf, vec![0]); // Just terminator
+    }
+
+    #[test]
+    fn read_with_kind_emits_per_entry_trace() {
+        // upstream: uidlist.c:287-291 - "%sid %u(%s) maps to %u" fires for
+        // every recv_add_id, including the id=0 entry under ID0_NAMES.
+        use logging::{DebugFlag, DiagnosticEvent, VerbosityConfig, drain_events, init};
+
+        let mut cfg = VerbosityConfig::default();
+        cfg.debug.own = 2;
+        init(cfg);
+        let _ = drain_events();
+
+        // wire: varint(1), len(4), "root", varint(0), len(4), "root" (id=0 name)
+        let data = vec![1, 4, b'r', b'o', b'o', b't', 0, 4, b'r', b'o', b'o', b't'];
+        let mut list = IdList::new();
+        list.read_with_kind(&mut data.as_slice(), true, 30, Some(IdKind::Uid), |name| {
+            if name == b"root" { Some(0) } else { None }
+        })
+        .unwrap();
+
+        let messages: Vec<String> = drain_events()
+            .into_iter()
+            .filter_map(|event| match event {
+                DiagnosticEvent::Debug {
+                    flag: DebugFlag::Own,
+                    message,
+                    ..
+                } => Some(message),
+                _ => None,
+            })
+            .collect();
+        assert!(
+            messages.iter().any(|s| s == "uid 1(root) maps to 0"),
+            "missing uid 1 trace: {messages:?}"
+        );
+        assert!(
+            messages.iter().any(|s| s == "uid 0(root) maps to 0"),
+            "missing id=0 trace: {messages:?}"
+        );
+    }
+
+    #[test]
+    fn read_with_kind_none_suppresses_trace() {
+        // Passing `kind = None` must behave identically to `read` and
+        // not emit anything regardless of the configured debug level.
+        use logging::{DebugFlag, DiagnosticEvent, VerbosityConfig, drain_events, init};
+
+        let mut cfg = VerbosityConfig::default();
+        cfg.debug.own = 2;
+        init(cfg);
+        let _ = drain_events();
+
+        let data = vec![1, 4, b'r', b'o', b'o', b't', 0];
+        let mut list = IdList::new();
+        list.read_with_kind(&mut data.as_slice(), false, 30, None, |_| Some(0))
+            .unwrap();
+
+        let messages: Vec<String> = drain_events()
+            .into_iter()
+            .filter_map(|event| match event {
+                DiagnosticEvent::Debug {
+                    flag: DebugFlag::Own,
+                    message,
+                    ..
+                } => Some(message),
+                _ => None,
+            })
+            .collect();
+        assert!(
+            messages.is_empty(),
+            "kind=None must suppress OWN trace, got {messages:?}"
+        );
     }
 }

--- a/crates/protocol/src/idlist/trace.rs
+++ b/crates/protocol/src/idlist/trace.rs
@@ -1,0 +1,275 @@
+//! `--debug=OWN` producer emissions for uid/gid name <-> id mapping.
+//!
+//! Matches upstream rsync's `uidlist.c` and `rsync.c` `DEBUG_GTE(OWN, N)`
+//! output byte-for-byte so wire-comparable diagnostics align across
+//! implementations.
+//!
+//! # Upstream Reference
+//!
+//! - `uidlist.c:218-227` (`DEBUG_GTE(OWN, 2)`) - `is_in_group` probe of the
+//!   calling process's gid list. Emitted once per process when `--group`
+//!   ownership preservation runs without root and the gidset is built.
+//!   Shape: `"process has %d gid%s: %d %d ..."`.
+//! - `uidlist.c:287-291` (`DEBUG_GTE(OWN, 2)`) - `recv_add_id` per-entry
+//!   mapping trace. Emitted whenever the receiver adds a uid or gid to
+//!   the id list. Shape: `"%sid %u(%s) maps to %u"` where the leading
+//!   character is `'u'` for the uid list and `'g'` for the gid list.
+//! - `rsync.c:535-545` (`DEBUG_GTE(OWN, 1)`) - chown reporting from
+//!   `set_file_attrs`. Emitted once per file when the resolved uid or
+//!   gid differs from the destination's existing uid/gid. Shapes:
+//!   `"set uid of %s from %u to %u"` and `"set gid of %s from %u to %u"`.
+//! - `options.c:307` - `DEBUG_WORD(OWN, W_REC, "Debug ownership changes
+//!   in users & groups (levels 1-2)")` flag table entry, capping
+//!   emissions at level 2.
+
+use logging::debug_log;
+
+/// Identifies whether an emission refers to the uid list or the gid list.
+///
+/// Mirrors upstream's `idlist_ptr == &uidlist ? "u" : "g"` switch in
+/// `uidlist.c:289`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IdKind {
+    /// User-id list (upstream: `&uidlist`).
+    Uid,
+    /// Group-id list (upstream: `&gidlist`).
+    Gid,
+}
+
+impl IdKind {
+    /// Returns the upstream single-character prefix (`"u"` or `"g"`).
+    #[must_use]
+    pub const fn prefix(self) -> &'static str {
+        match self {
+            Self::Uid => "u",
+            Self::Gid => "g",
+        }
+    }
+
+    /// Returns the upstream lowercase word (`"uid"` or `"gid"`) used in
+    /// the level-1 chown trace.
+    #[must_use]
+    pub const fn word(self) -> &'static str {
+        match self {
+            Self::Uid => "uid",
+            Self::Gid => "gid",
+        }
+    }
+}
+
+/// Traces a single uid/gid mapping decision (level 2).
+///
+/// upstream: `uidlist.c:287-291` - `"%sid %u(%s) maps to %u\n"`. The `kind`
+/// argument selects the upstream `"u"`/`"g"` prefix, `remote_id` is the id
+/// that arrived from the peer, `name` is the resolved name (rendered as
+/// the empty string when `None`, matching upstream's `name ? name : ""`
+/// at `uidlist.c:252-253`), and `local_id` is the id the receiver will
+/// use locally.
+#[inline]
+pub fn trace_id_maps_to(kind: IdKind, remote_id: u32, name: Option<&[u8]>, local_id: u32) {
+    let name_str = name.map(|bytes| String::from_utf8_lossy(bytes));
+    let name_rendered: &str = name_str.as_deref().unwrap_or("");
+    debug_log!(
+        Own,
+        2,
+        "{}id {}({}) maps to {}",
+        kind.prefix(),
+        remote_id,
+        name_rendered,
+        local_id
+    );
+}
+
+/// Traces the calling process's supplementary group list (level 2).
+///
+/// upstream: `uidlist.c:218-227` - `"process has %d gid%s: %d %d ..."`.
+/// Emitted once per process from `is_in_group` after `getgroups` populates
+/// the gid set. The plural `"s"` is appended when `gids.len() != 1`,
+/// matching upstream's `ngroups == 1 ? "" : "s"` ternary.
+#[inline]
+pub fn trace_process_gids(gids: &[u32]) {
+    let plural = if gids.len() == 1 { "" } else { "s" };
+    let mut rendered = String::with_capacity(gids.len() * 6);
+    for gid in gids {
+        rendered.push(' ');
+        rendered.push_str(&gid.to_string());
+    }
+    debug_log!(
+        Own,
+        2,
+        "process has {} gid{}:{}",
+        gids.len(),
+        plural,
+        rendered
+    );
+}
+
+/// Traces a uid ownership change about to be applied (level 1).
+///
+/// upstream: `rsync.c:537-540` - `"set uid of %s from %u to %u\n"`.
+/// Emitted by `set_file_attrs` immediately before `do_lchown` when the
+/// resolved uid differs from the destination's existing uid.
+#[inline]
+pub fn trace_set_uid(fname: &str, from: u32, to: u32) {
+    debug_log!(Own, 1, "set uid of {} from {} to {}", fname, from, to);
+}
+
+/// Traces a gid ownership change about to be applied (level 1).
+///
+/// upstream: `rsync.c:541-545` - `"set gid of %s from %u to %u\n"`.
+/// Emitted by `set_file_attrs` immediately before `do_lchown` when the
+/// resolved gid differs from the destination's existing gid.
+#[inline]
+pub fn trace_set_gid(fname: &str, from: u32, to: u32) {
+    debug_log!(Own, 1, "set gid of {} from {} to {}", fname, from, to);
+}
+
+#[cfg(test)]
+mod tests {
+    //! Pinning tests for OWN emission shapes. Strings match upstream
+    //! `uidlist.c` and `rsync.c` byte-for-byte.
+
+    use super::*;
+    use logging::{DebugFlag, DiagnosticEvent, VerbosityConfig, drain_events, init};
+
+    fn init_at(level: u8) {
+        let mut cfg = VerbosityConfig::default();
+        cfg.debug.own = level;
+        init(cfg);
+        let _ = drain_events();
+    }
+
+    fn own_messages() -> Vec<String> {
+        drain_events()
+            .into_iter()
+            .filter_map(|event| match event {
+                DiagnosticEvent::Debug {
+                    flag: DebugFlag::Own,
+                    message,
+                    ..
+                } => Some(message),
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn kind_prefix_and_word_match_upstream() {
+        // upstream: uidlist.c:289 - `idlist_ptr == &uidlist ? "u" : "g"`.
+        assert_eq!(IdKind::Uid.prefix(), "u");
+        assert_eq!(IdKind::Gid.prefix(), "g");
+        // upstream: rsync.c:538,542 - `"set uid of"` / `"set gid of"`.
+        assert_eq!(IdKind::Uid.word(), "uid");
+        assert_eq!(IdKind::Gid.word(), "gid");
+    }
+
+    #[test]
+    fn level2_uid_maps_to_named() {
+        // upstream: uidlist.c:287-291 - "uid 1000(alice) maps to 500".
+        init_at(2);
+        trace_id_maps_to(IdKind::Uid, 1000, Some(b"alice"), 500);
+        let m = own_messages();
+        assert!(
+            m.iter().any(|s| s == "uid 1000(alice) maps to 500"),
+            "missing uid map: {m:?}"
+        );
+    }
+
+    #[test]
+    fn level2_gid_maps_to_named() {
+        // upstream: uidlist.c:287-291 with `idlist_ptr == &gidlist`.
+        init_at(2);
+        trace_id_maps_to(IdKind::Gid, 100, Some(b"users"), 20);
+        let m = own_messages();
+        assert!(
+            m.iter().any(|s| s == "gid 100(users) maps to 20"),
+            "missing gid map: {m:?}"
+        );
+    }
+
+    #[test]
+    fn level2_maps_to_empty_name() {
+        // upstream: uidlist.c:252-253 - `if (!name) name = ""`.
+        init_at(2);
+        trace_id_maps_to(IdKind::Uid, 0, None, 0);
+        trace_id_maps_to(IdKind::Gid, 42, Some(b""), 42);
+        let m = own_messages();
+        assert!(m.iter().any(|s| s == "uid 0() maps to 0"), "{m:?}");
+        assert!(m.iter().any(|s| s == "gid 42() maps to 42"), "{m:?}");
+    }
+
+    #[test]
+    fn level2_process_gids_singular() {
+        // upstream: uidlist.c:221 - `ngroups == 1 ? "" : "s"`.
+        init_at(2);
+        trace_process_gids(&[1000]);
+        let m = own_messages();
+        assert!(
+            m.iter().any(|s| s == "process has 1 gid: 1000"),
+            "missing singular gid line: {m:?}"
+        );
+    }
+
+    #[test]
+    fn level2_process_gids_plural() {
+        // upstream: uidlist.c:221-225 - "process has N gids: g1 g2 ...".
+        init_at(2);
+        trace_process_gids(&[0, 4, 100, 1000]);
+        let m = own_messages();
+        assert!(
+            m.iter().any(|s| s == "process has 4 gids: 0 4 100 1000"),
+            "missing plural gid line: {m:?}"
+        );
+    }
+
+    #[test]
+    fn level1_set_uid_emits() {
+        // upstream: rsync.c:537-540 - "set uid of %s from %u to %u".
+        init_at(1);
+        trace_set_uid("/tmp/dst", 1000, 0);
+        let m = own_messages();
+        assert!(
+            m.iter().any(|s| s == "set uid of /tmp/dst from 1000 to 0"),
+            "missing set-uid line: {m:?}"
+        );
+    }
+
+    #[test]
+    fn level1_set_gid_emits() {
+        // upstream: rsync.c:541-545 - "set gid of %s from %u to %u".
+        init_at(1);
+        trace_set_gid("./file", 100, 200);
+        let m = own_messages();
+        assert!(
+            m.iter().any(|s| s == "set gid of ./file from 100 to 200"),
+            "missing set-gid line: {m:?}"
+        );
+    }
+
+    #[test]
+    fn level1_gates_level2_emissions() {
+        // upstream: DEBUG_GTE(OWN, 2) gates the per-entry mapping.
+        init_at(1);
+        trace_id_maps_to(IdKind::Uid, 1, Some(b"r"), 1);
+        trace_process_gids(&[0]);
+        assert!(
+            own_messages().is_empty(),
+            "level-2 emissions must be gated at level 1"
+        );
+    }
+
+    #[test]
+    fn level0_suppresses_all_own_emissions() {
+        // upstream: with DEBUG_OWN at level 0, every DEBUG_GTE(OWN, N)
+        // evaluates to false.
+        init_at(0);
+        trace_id_maps_to(IdKind::Uid, 1, Some(b"r"), 1);
+        trace_process_gids(&[0]);
+        trace_set_uid("a", 0, 1);
+        trace_set_gid("a", 0, 1);
+        assert!(
+            own_messages().is_empty(),
+            "all OWN emissions must be gated at level 0"
+        );
+    }
+}

--- a/crates/transfer/src/receiver/file_list.rs
+++ b/crates/transfer/src/receiver/file_list.rs
@@ -263,18 +263,24 @@ impl ReceiverContext {
 
         // upstream: uidlist.c:467 - recv_uid_list()
         if self.config.flags.owner {
-            self.uid_list
-                .read(reader, id0_names, protocol_version, |name| {
-                    lookup_user_by_name(name).ok().flatten()
-                })?;
+            self.uid_list.read_with_kind(
+                reader,
+                id0_names,
+                protocol_version,
+                Some(protocol::idlist::IdKind::Uid),
+                |name| lookup_user_by_name(name).ok().flatten(),
+            )?;
         }
 
         // upstream: uidlist.c:471 - recv_gid_list()
         if self.config.flags.group {
-            self.gid_list
-                .read(reader, id0_names, protocol_version, |name| {
-                    lookup_group_by_name(name).ok().flatten()
-                })?;
+            self.gid_list.read_with_kind(
+                reader,
+                id0_names,
+                protocol_version,
+                Some(protocol::idlist::IdKind::Gid),
+                |name| lookup_group_by_name(name).ok().flatten(),
+            )?;
         }
 
         Ok(())
@@ -309,13 +315,23 @@ impl ReceiverContext {
         let protocol_version = self.protocol.as_u8();
 
         if self.config.flags.owner {
-            self.uid_list
-                .read(reader, id0_names, protocol_version, |_| None)?;
+            self.uid_list.read_with_kind(
+                reader,
+                id0_names,
+                protocol_version,
+                Some(protocol::idlist::IdKind::Uid),
+                |_| None,
+            )?;
         }
 
         if self.config.flags.group {
-            self.gid_list
-                .read(reader, id0_names, protocol_version, |_| None)?;
+            self.gid_list.read_with_kind(
+                reader,
+                id0_names,
+                protocol_version,
+                Some(protocol::idlist::IdKind::Gid),
+                |_| None,
+            )?;
         }
 
         Ok(())

--- a/docs/audits/debug-flags-verbosity-matrix.md
+++ b/docs/audits/debug-flags-verbosity-matrix.md
@@ -135,7 +135,7 @@ Producer counts come from
 | ICONV      | 2 | 2 | W_CLI\|W_SRV | Debug iconv character conversions (levels 1-2) | `crates/core/src/client/config/iconv.rs:resolve_converter` (1 site at level 1, upstream-verbatim wording from `rsync.c:142-145`); helper emissions for the level-2 message-charset probe live in `crates/protocol/src/iconv/trace.rs` (upstream `rsync.c:99-110`). | impl (G3 partial - ICONV RESOLVED) |
 | IO         | 4 | 4 | W_CLI\|W_SRV | Debug I/O routines (levels 1-4) | `crates/transfer/src/disk_commit/thread.rs:117,125,132,149,153,155` plus `tracing::*(target: "rsync::io", ...)` in `crates/protocol/src/debug_io.rs`, `crates/fast_io/src/debug_io.rs`, `crates/rsync_io/src/debug_io.rs` (`debug_io.rs` trace funcs not called from production - see gap G3) | partial (levels 1 and 3 emitted via `debug_log!`; trace-func helpers unwired) |
 | NSTR       | 2 | u8::MAX | W_CLI\|W_SRV | Debug negotiation strings | `crates/protocol/src/negotiation/capabilities/negotiate.rs` (6 sites covering levels 1-3, upstream-verbatim wording from `compat.c:215,373-378,521-525,866`) | impl |
-| OWN        | 2 | 2 | W_REC | Debug ownership changes in users & groups (levels 1-2) | none | missing |
+| OWN        | 2 | 2 | W_REC | Debug ownership changes in users & groups (levels 1-2) | `crates/metadata/src/apply/ownership.rs::trace_chown_change` invoked from `set_owner_like`, `set_owner_like_with_fd`, and `apply_ownership_from_entry` (3 sites at level 1, upstream-verbatim wording from `rsync.c:537-540,541-545`); `crates/protocol/src/idlist/mod.rs::IdList::read_with_kind` invoked from `crates/transfer/src/receiver/file_list.rs::receive_id_lists` (level 2, upstream-verbatim wording from `uidlist.c:287-291`). Helper lives in `crates/protocol/src/idlist/trace.rs`. | impl (G3 partial - OWN RESOLVED) |
 | PROTO      | 1 | u8::MAX | W_CLI\|W_SRV | Debug protocol information | `crates/protocol/src/negotiation/capabilities/negotiate.rs`, `crates/protocol/src/multiplex/io/send.rs`, `crates/protocol/src/multiplex/io/recv.rs` (6 sites at levels 1-2) | partial (level 2 not in upstream range) |
 | RECV       | 1 | u8::MAX | W_REC | Debug receiver functions | `crates/transfer/src/receiver/directory/links.rs:264` (1 site at level 2) | partial (level 2 not in upstream range) |
 | SEND       | 1 | u8::MAX | W_SND | Debug sender functions | `crates/transfer/src/generator/transfer.rs` (5 sites at level 1, upstream-verbatim wording from `sender.c:217,254,277,445,457`); `crates/engine/src/local_copy/debug_send.rs` trace helpers remain unwired (see gap G3) | impl (D13 RESOLVED) |
@@ -144,9 +144,9 @@ Producer counts come from
 Total: 24 upstream `DEBUG_*` flags, matching `COUNT_DEBUG = DEBUG_TIME + 1`
 (`rsync.h:1462`). Status roll-up:
 
-- **impl**: 10 - ACL, BACKUP, DUP, FILTER, FLIST, GENR, ICONV, NSTR, SEND, TIME.
+- **impl**: 11 - ACL, BACKUP, DUP, FILTER, FLIST, GENR, ICONV, NSTR, OWN, SEND, TIME.
 - **partial**: 7 - CONNECT, DEL, DELTASUM, EXIT, IO, PROTO, RECV.
-- **missing**: 7 - BIND, CHDIR, CMD, FUZZY, HASH, HLINK, OWN.
+- **missing**: 6 - BIND, CHDIR, CMD, FUZZY, HASH, HLINK.
 
 `SEND` (D13) is now wired into the generator's send loop with the
 five upstream-verbatim messages from `sender.c send_files` (lines
@@ -302,7 +302,7 @@ requested level before the event materialises.
 |----|----------|--------|-------------|
 | G1 | Low | open | `ALL<N>` and `NONE0` syntactic forms are rejected as unknown tokens (`flags/debug.rs:279`). Upstream accepts them (`options.c:443-445`, `:452-453`, `:450-451`) and applies the trailing digit. Fix: extend `DebugFlagSettings::apply` to detect `all<digit>` and `none<digit>` before falling through to `parse_flag_and_level`, then call `enable_all_to_level(N)` / `disable_all()`. Cap N at 4 to match `MAX_OUT_LEVEL`. |
 | G2 | Low | open | Per-flag cap missing for upstream-max-1 flags. `acl`, `bind`, `chdir`, `dup`, `genr`, `hash`, `nstr`, `proto`, `recv`, `send` accept any `u8` value (no `if level > N` guard in `flags/debug.rs::apply`). Upstream silently clamps to `MAX_OUT_LEVEL = 4`. Fix: add `if level > 4 { return Err(debug_flag_error(display)); }` guards on those arms, or a single shared cap before the per-flag dispatch. |
-| G3 | High | open | 7 flags have no production producer (BIND, CHDIR, CMD, FUZZY, HASH, HLINK, OWN). The previously listed ACL, BACKUP, GENR, ICONV, NSTR, and SEND emissions are now wired (D14, I-ACL, I-ICONV, NSTR follow-up, D13 RESOLVED, BACKUP RESOLVED). Owning crates for the remaining producers: `metadata` (OWN, HLINK), `engine` (FUZZY), `transfer`/`rsync_io` (BIND, CMD), `checksums` (HASH), `core` (CHDIR). |
+| G3 | High | open | 6 flags have no production producer (BIND, CHDIR, CMD, FUZZY, HASH, HLINK). The previously listed ACL, BACKUP, GENR, ICONV, NSTR, OWN, and SEND emissions are now wired (D14, I-ACL, I-ICONV, NSTR follow-up, OWN follow-up, D13 RESOLVED, BACKUP RESOLVED). Owning crates for the remaining producers: `metadata` (HLINK), `engine` (FUZZY), `transfer`/`rsync_io` (BIND, CMD), `checksums` (HASH), `core` (CHDIR). |
 | G4 | Low | open | `limit_output_verbosity` (upstream `options.c:527-553`) is not implemented. User-supplied per-flag levels are not clamped to the peer's `-v` ceiling during option exchange. Mitigation: implement on `server_options` parsing path and re-run the ladder with `LIMIT_PRIORITY` to compute the cap. |
 | G5 | Low | open | `make_output_option` (upstream `options.c:340-425`) is not implemented. Remote command forwarding of user-priority debug flags relies on raw passthrough rather than upstream's deduplicated `--debug=ALL2,NONREG0,...` style. User-visible effect is limited to the exact command string the peer sees in `ps` output. |
 | G6 | Low | open | `--debug=help` text omits the per-verbosity summary block (`0)`, `1)`, ..., `5)`) that upstream's `output_item_help` prints at `options.c:499-509`. Cosmetic but useful for discovery. |
@@ -323,7 +323,7 @@ requested level before the event materialises.
 | HLINK | `crates/transfer/src/receiver/directory/links.rs` (extend existing RECV emitter) | When a hardlink master/follower is resolved. Upstream emits in `hlink.c:hard_link_one`. |
 | ICONV | wired in `crates/core/src/client/config/iconv.rs::resolve_converter` (level 1) with helpers in `crates/protocol/src/iconv/trace.rs` for the level-2 message-charset probe. Upstream emits at `rsync.c:99-110,142-145` (`setup_iconv`); none of upstream's emissions live in `flist.c`. |
 | NSTR | `crates/rsync_io/src/negotiation/` | During server/client capability string exchange. Upstream emits in `compat.c:set_allow_inc_recurse` and friends. |
-| OWN | `crates/metadata/src/ownership/` | When uid/gid mapping is consulted. Upstream emits in `uidlist.c:map_uid` / `map_gid`. |
+| OWN | wired in `crates/metadata/src/apply/ownership.rs::trace_chown_change` (level 1) invoked from `set_owner_like`, `set_owner_like_with_fd`, and `apply_ownership_from_entry` immediately before each `chownat`/`fchown`; and in `crates/protocol/src/idlist/mod.rs::IdList::read_with_kind` (level 2) invoked from `crates/transfer/src/receiver/file_list.rs::receive_id_lists`. Helper lives in `crates/protocol/src/idlist/trace.rs`. Upstream emits at `rsync.c:535-545` (`set uid of`/`set gid of`) and `uidlist.c:287-291` (`%sid %u(%s) maps to %u`); the level-2 `process has N gids` probe at `uidlist.c:218-227` has no oc-rsync counterpart because the `is_in_group` machinery is not ported, so the helper exists for parity but is not wired. |
 | SEND | Connect `crates/transfer/src/sender/file.rs` to the existing `crates/engine/src/local_copy/debug_send.rs::trace_send_file_start`/`trace_send_file_end` helpers. The subsystem is already implemented but unused. |
 
 Each row is a follow-up task; this audit only enumerates them. The


### PR DESCRIPTION
## Summary

- Wire the upstream `DEBUG_GTE(OWN, N)` emissions for uid/gid mapping and chown reporting so `--debug=OWN` produces output that matches rsync 3.4.1 byte-for-byte.
- New helper `crates/protocol/src/idlist/trace.rs` exposes `IdKind`, `trace_id_maps_to`, `trace_process_gids`, `trace_set_uid`, `trace_set_gid` with upstream-verbatim wording.
- `IdList::read_with_kind` fires the level-2 `"%sid %u(%s) maps to %u"` line for every entry received; the receiver's `receive_id_lists` opts in for both uid and gid lists on Unix and non-Unix.
- `apply/ownership.rs::trace_chown_change` fires the level-1 `"set uid of"` / `"set gid of"` lines from `set_owner_like`, `set_owner_like_with_fd`, and `apply_ownership_from_entry` immediately before each `chownat`/`fchown`, gated by per-side change detection like upstream `set_file_attrs`.

## Upstream references

- `uidlist.c:287-291` - per-entry mapping trace from `recv_add_id`.
- `uidlist.c:218-227` - `is_in_group` gid-set probe (helper exists for parity; not wired because the underlying machinery is not ported).
- `rsync.c:535-545` - chown reporting block in `set_file_attrs`.
- `options.c:307` - flag table entry capping useful levels at 2.

## Doc updates

- `docs/audits/debug-flags-verbosity-matrix.md` rolls OWN from missing to impl, updates the producer summary (impl: 10, missing: 7), refreshes G3, and points the per-flag insertion table at the wired call sites.

## Test plan

- [x] `cargo nextest run -p protocol -E 'test(idlist::trace) or test(read_with_kind)'`
- [x] `cargo nextest run -p metadata -E 'test(own_debug)'`
- [x] `cargo nextest run -p transfer -E 'test(id_list) or test(idlist) or test(receive_id) or test(id_lists)'`
- [x] `cargo fmt --all --check`
- [x] `cargo clippy -p protocol -p metadata -p transfer --all-features --no-deps --tests`
- [ ] CI: full nextest matrix (stable + Windows + macOS + Linux musl)
- [ ] CI: interop validation against upstream 3.0.9 / 3.1.3 / 3.4.1

Closes #2191