### PR TITLE
docs(protocol): comment audit pass (#1843)

### DIFF
--- a/crates/protocol/src/debug_trace.rs
+++ b/crates/protocol/src/debug_trace.rs
@@ -61,10 +61,8 @@ impl<R: Read> TracingReader<R> {
         let sequence = TRACE_COUNTER.fetch_add(1, Ordering::SeqCst);
 
         if config.enabled {
-            // Create trace directory if it doesn't exist
             let _ = std::fs::create_dir_all(&config.trace_dir);
 
-            // Write header file
             let header_path = format!(
                 "{}/{}_read_{:04}_header.txt",
                 config.trace_dir, config.prefix, sequence
@@ -142,10 +140,8 @@ impl<W: Write> TracingWriter<W> {
         let sequence = TRACE_COUNTER.fetch_add(1, Ordering::SeqCst);
 
         if config.enabled {
-            // Create trace directory if it doesn't exist
             let _ = std::fs::create_dir_all(&config.trace_dir);
 
-            // Write header file
             let header_path = format!(
                 "{}/{}_write_{:04}_header.txt",
                 config.trace_dir, config.prefix, sequence

--- a/crates/protocol/src/envelope/tests/message_code_comprehensive.rs
+++ b/crates/protocol/src/envelope/tests/message_code_comprehensive.rs
@@ -1,17 +1,9 @@
-// Comprehensive tests for MessageCode and LogCode handling
-//
-// These tests verify:
-// - Wire format compatibility with upstream rsync 3.4.1
-// - Complete coverage of all message code variants
-// - Edge cases in parsing, formatting, and conversion
-// - Semantic correctness of message classification
-// - Cross-component integration between MessageCode and LogCode
+//! Comprehensive tests for MessageCode and LogCode handling, covering wire
+//! format compatibility with upstream rsync 3.4.1, complete variant coverage,
+//! parsing/conversion edge cases, and cross-component integration.
 
 use super::*;
 use std::collections::HashMap;
-
-// Wire Format Compatibility Tests
-// These tests verify that our message codes match upstream rsync's exact values
 
 /// Verifies that all message codes have the exact numeric values expected by
 /// upstream rsync 3.4.1. These values are defined in rsync.h and must match

--- a/crates/protocol/src/flist/dir_tree.rs
+++ b/crates/protocol/src/flist/dir_tree.rs
@@ -104,7 +104,6 @@ impl DirectoryTree {
             self.nodes[sibling].next_sibling = Some(node_idx);
         }
 
-        // Set cursor to first real node if not yet set
         if self.cursor.is_none() {
             self.cursor = Some(node_idx);
         }

--- a/crates/protocol/src/flist/read/flags.rs
+++ b/crates/protocol/src/flist/read/flags.rs
@@ -90,7 +90,6 @@ impl FileListReader {
             return Ok(FlagsResult::EndOfList);
         }
 
-        // Read extended flags
         // upstream: flist.c:2628 - extended flags only exist in protocol >= 28.
         // In protocol < 28, bit 2 is XMIT_SAME_RDEV_pre28, not XMIT_EXTENDED_FLAGS.
         let (ext_byte, ext16_byte) = if use_varint {
@@ -123,7 +122,6 @@ impl FileListReader {
             return Ok(FlagsResult::IoError(error));
         }
 
-        // Build flags structure
         let flags = if ext_byte != 0 || ext16_byte != 0 || (primary_byte & XMIT_EXTENDED_FLAGS) != 0
         {
             FileFlags::new_with_extended16(primary_byte, ext_byte, ext16_byte)

--- a/crates/protocol/src/flist/sort.rs
+++ b/crates/protocol/src/flist/sort.rs
@@ -127,27 +127,26 @@ fn compare_with_keys(bytes_a: &[u8], key_a: &SortKey, bytes_b: &[u8], key_b: &So
     let a_is_dir = key_a.is_dir;
     let b_is_dir = key_b.is_dir;
 
-    // Compare byte by byte, treating directory names as having implicit '/'
+    // Compare byte by byte, treating directory names as having an implicit
+    // trailing '/' (so `dir` compares as `dir/`).
     let mut i = 0;
     loop {
-        // Get effective byte at position i, with implicit '/' for directories at end
         let ch_a = if i < bytes_a.len() {
             bytes_a[i]
         } else if i == bytes_a.len() && a_is_dir {
-            b'/' // Implicit trailing slash for directory
+            b'/'
         } else {
-            0 // Past end
+            0
         };
 
         let ch_b = if i < bytes_b.len() {
             bytes_b[i]
         } else if i == bytes_b.len() && b_is_dir {
-            b'/' // Implicit trailing slash for directory
+            b'/'
         } else {
-            0 // Past end
+            0
         };
 
-        // Check for end condition
         let a_done = i > bytes_a.len() || (i == bytes_a.len() && !a_is_dir);
         let b_done = i > bytes_b.len() || (i == bytes_b.len() && !b_is_dir);
 

--- a/crates/protocol/src/flist/trace.rs
+++ b/crates/protocol/src/flist/trace.rs
@@ -176,32 +176,21 @@ pub fn output_flist(role: ProcessRole, entries: &[FileEntry], first_ndx: i32) {
 /// ```
 #[inline]
 pub fn output_flist_entry(role: ProcessRole, ndx: i32, entry: &FileEntry) {
-    // Build the path string
     let name_str = entry.name();
-
-    // Determine if this is root (empty path or ".")
     let is_root = name_str.is_empty() || name_str == ".";
     let root_marker = if is_root { "root " } else { "" };
-
-    // Add trailing slash for directories
     let trailing = if entry.is_dir() && !name_str.ends_with('/') {
         "/"
     } else {
         ""
     };
-
-    // Format length with commas
     let len_str = format_number(entry.size() as usize);
-
-    // Format UID/GID
     let uid_str = entry
         .uid()
         .map_or(String::new(), |uid| format!(" uid={uid}"));
     let gid_str = entry
         .gid()
         .map_or(String::new(), |gid| format!(" gid={gid}"));
-
-    // Get flags value
     let flags = entry.flags();
     let flags_value = flags.primary as u32 | ((flags.extended as u32) << 8);
 

--- a/crates/protocol/src/xattr/list.rs
+++ b/crates/protocol/src/xattr/list.rs
@@ -162,8 +162,6 @@ impl FromIterator<XattrEntry> for XattrList {
 mod tests {
     use super::*;
 
-    // --- Constructor tests ---
-
     #[test]
     fn new_creates_empty_list() {
         let list = XattrList::new();
@@ -211,8 +209,6 @@ mod tests {
         assert_eq!(list.len(), 2);
     }
 
-    // --- Push and len/is_empty ---
-
     #[test]
     fn push_increments_len() {
         let mut list = XattrList::new();
@@ -237,8 +233,6 @@ mod tests {
         assert_eq!(list.entries()[1].name(), b"user.a");
         assert_eq!(list.entries()[2].name(), b"user.b");
     }
-
-    // --- Entries accessors ---
 
     #[test]
     fn entries_returns_all_entries() {
@@ -273,8 +267,6 @@ mod tests {
         let mut list = XattrList::new();
         assert!(list.entries_mut().is_empty());
     }
-
-    // --- Iterators ---
 
     #[test]
     fn iter_yields_all_entries_in_order() {
@@ -366,8 +358,6 @@ mod tests {
         assert_eq!(count, 2);
     }
 
-    // --- FromIterator ---
-
     #[test]
     fn from_iterator_collects_entries() {
         let entries = vec![
@@ -395,8 +385,6 @@ mod tests {
         assert_eq!(list.len(), 1);
         assert_eq!(list.entries()[0].name(), b"user.only");
     }
-
-    // --- Abbreviated tracking ---
 
     #[test]
     fn has_abbreviated_empty_list() {
@@ -473,8 +461,6 @@ mod tests {
         assert_eq!(list.abbreviated_indices(), vec![0, 1]);
     }
 
-    // --- Todo tracking ---
-
     #[test]
     fn todo_indices_empty_list() {
         let list = XattrList::new();
@@ -513,8 +499,6 @@ mod tests {
 
         assert_eq!(list.todo_indices(), vec![0, 1]);
     }
-
-    // --- mark_todo ---
 
     #[test]
     fn mark_todo_first_index() {
@@ -571,8 +555,6 @@ mod tests {
         assert!(list.entries()[0].state().needs_send());
         assert_eq!(list.todo_indices(), vec![0]);
     }
-
-    // --- set_full_value ---
 
     #[test]
     fn set_full_value_resolves_abbreviation() {
@@ -631,8 +613,6 @@ mod tests {
         assert_eq!(list.abbreviated_indices(), vec![1]);
         assert!(list.has_abbreviated());
     }
-
-    // --- sort_by_name ---
 
     #[test]
     fn sort_by_name_empty_list() {
@@ -734,8 +714,6 @@ mod tests {
         assert_eq!(list.entries()[2].name(), b"user.z");
     }
 
-    // --- find_by_name ---
-
     #[test]
     fn find_by_name_exists() {
         let mut list = XattrList::new();
@@ -789,8 +767,6 @@ mod tests {
         assert!(list.find_by_name(b"notempty").is_none());
     }
 
-    // --- find_index_by_name ---
-
     #[test]
     fn find_index_by_name_all_positions() {
         let mut list = XattrList::new();
@@ -827,8 +803,6 @@ mod tests {
         assert_eq!(list.find_index_by_name(b"user.dup"), Some(0));
     }
 
-    // --- Clone / PartialEq / Debug ---
-
     #[test]
     fn clone_produces_equal_list() {
         let mut list = XattrList::new();
@@ -863,8 +837,6 @@ mod tests {
         assert!(debug.contains("XattrList"));
     }
 
-    // --- Many entries ---
-
     #[test]
     fn many_entries_push_and_access() {
         let mut list = XattrList::new();
@@ -897,8 +869,6 @@ mod tests {
 
         assert_eq!(list.find_index_by_name(b"user.attr025"), Some(25));
     }
-
-    // --- Combined state transitions ---
 
     #[test]
     fn mark_todo_then_check_todo_indices() {


### PR DESCRIPTION
Partial progress on #1843 (protocol crate scope only). Other crates in follow-ups.

## Summary
- Delete restatement and decorative comments in `crates/protocol/src/**`
- Preserve every `upstream:` reference, safety/invariant note, and rustdoc on public items
- Convert one stale `//` file header in the message-code tests to `//!`
- No behavior changes; comments-only pass

## Files touched
- `debug_trace.rs` - drop two restatement comments next to obvious calls
- `envelope/tests/message_code_comprehensive.rs` - convert top-of-file `//` block to `//!`, drop a decorative banner
- `flist/dir_tree.rs` - drop a cursor restatement
- `flist/read/flags.rs` - drop two action-restatement comments above blocks with `upstream:` notes
- `flist/sort.rs` - tighten an inline restatement, drop trailing duplicate annotations
- `flist/trace.rs` - drop six echoey step comments in `output_flist_entry`
- `xattr/list.rs` - drop 15 decorative `// --- section ---` test banners

## Test plan
- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings`
- [ ] `cargo nextest run -p protocol --all-features` (CI)