### PR TITLE
docs(engine): comment audit pass (#1843)

### DIFF
--- a/crates/engine/src/concurrent_delta/types.rs
+++ b/crates/engine/src/concurrent_delta/types.rs
@@ -445,11 +445,7 @@ impl DeltaResult {
     }
 }
 
-// ---------------------------------------------------------------------------
-// SpillCodec implementation for DeltaResult
-// ---------------------------------------------------------------------------
-//
-// Binary format (all little-endian):
+// Binary spill format for `DeltaResult` (all little-endian):
 //   [u32  ndx]
 //   [u64  sequence]
 //   [u64  bytes_written]
@@ -458,7 +454,6 @@ impl DeltaResult {
 //   [u8   status_tag]     0 = Success, 1 = NeedsRedo, 2 = Failed
 //   [u32  reason_len]     (only if status_tag != 0)
 //   [u8*  reason_bytes]   (only if status_tag != 0)
-
 impl super::spill::SpillCodec for DeltaResult {
     fn encode(&self, w: &mut dyn std::io::Write) -> std::io::Result<()> {
         w.write_all(&self.ndx.get().to_le_bytes())?;

--- a/crates/engine/src/local_copy/buffer_pool/pressure.rs
+++ b/crates/engine/src/local_copy/buffer_pool/pressure.rs
@@ -132,7 +132,6 @@ impl PressureTracker {
 
         let miss_rate = misses as f64 / total as f64;
 
-        // High miss rate: pool is too small.
         if miss_rate > MISS_RATE_GROW_THRESHOLD {
             let new_capacity = (current_capacity * GROW_FACTOR).min(MAX_CAPACITY);
             if new_capacity > current_capacity {
@@ -141,16 +140,15 @@ impl PressureTracker {
             return ResizeAction::Hold;
         }
 
-        // Low utilization: pool is too large.
         let utilization = if current_capacity > 0 {
             current_available as f64 / current_capacity as f64
         } else {
             0.0
         };
 
-        // Only shrink when the pool is mostly idle AND miss rate is low.
-        // The low miss rate check prevents shrinking when all buffers are
-        // checked out (available = 0, utilization = 0) but demand is high.
+        // Only shrink when the pool is mostly idle AND the miss rate is low.
+        // The miss-rate gate prevents shrinking when buffers are all checked
+        // out (available = 0, utilization = 0) but demand is high.
         let _ = hits; // Suppress unused warning; hits contribute to total.
         if utilization < UTILIZATION_SHRINK_THRESHOLD && miss_rate < MISS_RATE_GROW_THRESHOLD / 2.0
         {

--- a/crates/engine/src/local_copy/clonefile.rs
+++ b/crates/engine/src/local_copy/clonefile.rs
@@ -134,7 +134,6 @@ fn try_clonefile_impl(src: &Path, dst: &Path) -> io::Result<()> {
     use std::ffi::CString;
     use std::os::unix::ffi::OsStrExt;
 
-    // Convert paths to C strings
     let src_c = CString::new(src.as_os_str().as_bytes()).map_err(|_| {
         io::Error::new(
             io::ErrorKind::InvalidInput,
@@ -144,10 +143,9 @@ fn try_clonefile_impl(src: &Path, dst: &Path) -> io::Result<()> {
     let dst_c = CString::new(dst.as_os_str().as_bytes())
         .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "dest path contains null byte"))?;
 
-    // Call clonefile(src, dst, 0)
-    // Flag 0 means no special options (CLONE_NOFOLLOW = 1 could be used for symlinks)
-    // SAFETY: We're passing valid C strings to clonefile. The syscall is safe to call
-    // with valid paths. Any errors are returned via errno and converted to io::Error.
+    // SAFETY: Passing valid C strings to clonefile. Flag 0 means no special
+    // options (CLONE_NOFOLLOW = 1 could be used for symlinks). Errors are
+    // returned via errno and converted to io::Error.
     let ret = unsafe { libc::clonefile(src_c.as_ptr(), dst_c.as_ptr(), 0) };
 
     if ret == 0 {

--- a/crates/engine/src/local_copy/deferred_sync.rs
+++ b/crates/engine/src/local_copy/deferred_sync.rs
@@ -89,7 +89,7 @@ impl DeferredSync {
     pub fn new(strategy: SyncStrategy) -> Self {
         let threshold = match strategy {
             SyncStrategy::Batched(n) => n,
-            _ => 100, // Default threshold
+            _ => 100,
         };
 
         Self {
@@ -132,9 +132,7 @@ impl DeferredSync {
             SyncStrategy::Batched(_) | SyncStrategy::Deferred => {
                 self.pending_files.push(path);
             }
-            SyncStrategy::None => {
-                // No-op
-            }
+            SyncStrategy::None => {}
         }
         Ok(())
     }
@@ -166,12 +164,9 @@ impl DeferredSync {
     /// on error.
     pub fn flush(&mut self) -> io::Result<()> {
         match self.strategy {
-            SyncStrategy::None => {
-                // No-op
-            }
-            SyncStrategy::Immediate => {
-                // Already synced immediately
-            }
+            // `None` and `Immediate` need no flush: the former never queues,
+            // the latter already synced at register-time.
+            SyncStrategy::None | SyncStrategy::Immediate => {}
             SyncStrategy::DirectoryLevel => {
                 self.flush_directories()?;
             }
@@ -187,7 +182,9 @@ impl DeferredSync {
 
     /// Flushes pending files.
     fn flush_files(&self) -> io::Result<()> {
-        // If we have many files, try to use syncfs for efficiency
+        // For large batches, syncfs() amortises the syscall cost across the
+        // entire filesystem in one call. Fall back to per-file fsync on
+        // platforms without syncfs or when the call fails.
         #[cfg(target_os = "linux")]
         if self.pending_files.len() > 10 {
             if let Some(first) = self.pending_files.first() {
@@ -197,10 +194,9 @@ impl DeferredSync {
             }
         }
 
-        // Fall back to individual syncs
         for path in &self.pending_files {
             if let Err(e) = sync_file(path) {
-                // Log but continue - file might have been moved/deleted
+                // A vanished file is not a fatal sync error; skip and continue.
                 if e.kind() != io::ErrorKind::NotFound {
                     return Err(e);
                 }
@@ -252,8 +248,10 @@ impl Default for DeferredSync {
 }
 
 /// Syncs a single file to disk.
+///
+/// Opens the file read+write because Windows `FlushFileBuffers` requires write
+/// access; a read-only handle silently no-ops the flush.
 fn sync_file(path: &Path) -> io::Result<()> {
-    // On Windows, FlushFileBuffers requires write access; read-only won't work.
     let file = std::fs::OpenOptions::new()
         .read(true)
         .write(true)
@@ -287,7 +285,6 @@ fn sync_filesystem(path: &Path) -> io::Result<()> {
 #[cfg(not(target_os = "linux"))]
 #[allow(dead_code)] // REASON: call site is cfg-gated to linux; this stub used only in tests
 fn sync_filesystem(_path: &Path) -> io::Result<()> {
-    // Not available on this platform
     Err(io::Error::new(
         io::ErrorKind::Unsupported,
         "syncfs not available",

--- a/crates/engine/src/local_copy/executor/directory/recursive/batch.rs
+++ b/crates/engine/src/local_copy/executor/directory/recursive/batch.rs
@@ -2,8 +2,8 @@
 //!
 //! When `--write-batch` is active, each transferred entry is serialized into
 //! the protocol's file-list wire format for later replay.
-
-// upstream: batch.c:write_batch_flist_info()
+//!
+//! upstream: batch.c:write_batch_flist_info()
 
 use std::fs;
 use std::path::{Path, PathBuf};

--- a/crates/engine/src/local_copy/executor/directory/support.rs
+++ b/crates/engine/src/local_copy/executor/directory/support.rs
@@ -72,7 +72,8 @@ fn read_directory_entries_sorted_sequential(
 fn read_directory_entries_sorted_parallel(
     path: &Path,
 ) -> Result<Vec<DirectoryEntry>, LocalCopyError> {
-    // Phase 1: Collect paths sequentially (read_dir iteration must be sequential)
+    // Phase 1: Collect paths sequentially - read_dir iteration is inherently
+    // sequential on every platform.
     let read_dir =
         fs::read_dir(path).map_err(|error| LocalCopyError::io("read directory", path, error))?;
 
@@ -83,7 +84,6 @@ fn read_directory_entries_sorted_parallel(
         pending.push((entry.file_name(), entry.path()));
     }
 
-    // For small directories, use sequential metadata fetching to avoid overhead
     if pending.len() < PARALLEL_THRESHOLD {
         let mut entries = Vec::with_capacity(pending.len());
         for (file_name, entry_path) in pending {
@@ -100,9 +100,8 @@ fn read_directory_entries_sorted_parallel(
         return Ok(entries);
     }
 
-    // Ordering: local copy requires deterministic directory listing order.
-    // Parallel metadata fetch loses traversal order, so sort_unstable_by() is
-    // applied after collection. Omitting the sort produces non-deterministic copies.
+    // Parallel metadata fetch loses traversal order; sort is applied after
+    // collection so local copies stay deterministic.
     let results: Vec<Result<DirectoryEntry, (PathBuf, std::io::Error)>> = pending
         .into_par_iter()
         .map(
@@ -117,7 +116,6 @@ fn read_directory_entries_sorted_parallel(
         )
         .collect();
 
-    // Collect results, returning first error encountered
     let mut entries = Vec::with_capacity(results.len());
     for result in results {
         match result {
@@ -132,7 +130,6 @@ fn read_directory_entries_sorted_parallel(
         }
     }
 
-    // Sort to maintain deterministic ordering (parallel fetch order is non-deterministic)
     entries.sort_unstable_by(|a, b| compare_file_names(&a.file_name, &b.file_name));
     Ok(entries)
 }
@@ -154,7 +151,7 @@ fn compare_file_names(left: &OsStr, right: &OsStr) -> Ordering {
     {
         use std::os::windows::ffi::OsStrExt;
 
-        // Direct iterator comparison avoids two Vec allocations per comparison
+        // Iterator comparison avoids two Vec allocations per call.
         left.encode_wide().cmp(right.encode_wide())
     }
 

--- a/crates/engine/src/local_copy/executor/file/backup.rs
+++ b/crates/engine/src/local_copy/executor/file/backup.rs
@@ -2,8 +2,8 @@
 //!
 //! Computes backup paths (with optional suffix and directory prefix) and
 //! creates the backup copy or symlink before the destination is overwritten.
-
-// upstream: backup.c:make_backup() - backup path computation and creation
+//!
+//! upstream: backup.c:make_backup() - backup path computation and creation
 
 use std::ffi::{OsStr, OsString};
 use std::fs;

--- a/crates/engine/src/local_copy/executor/file/copy/existing.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/existing.rs
@@ -2,8 +2,8 @@
 //!
 //! Evaluates whether a file should be skipped based on modification time
 //! comparison or the presence of an existing destination file.
-
-// upstream: generator.c:recv_generator() - update and ignore-existing checks
+//!
+//! upstream: generator.c:recv_generator() - update and ignore-existing checks
 
 use std::fs;
 use std::path::Path;

--- a/crates/engine/src/local_copy/executor/file/copy/links.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/links.rs
@@ -3,9 +3,9 @@
 //!
 //! Attempts to satisfy a file transfer via hard link or reference copy before
 //! falling back to a full data transfer.
-
-// upstream: generator.c - hard_link_one(), do_hard_links logic
-// upstream: generator.c - find_fuzzy(), compare_dest handling
+//!
+//! upstream: generator.c - hard_link_one(), do_hard_links logic
+//! upstream: generator.c - find_fuzzy(), compare_dest handling
 
 use std::fs;
 use std::path::{Path, PathBuf};

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/write_strategy.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/write_strategy.rs
@@ -135,7 +135,8 @@ pub(in crate::local_copy) fn open_destination_writer(
             Ok(file)
         }
         WriteStrategy::Inplace => {
-            // For inplace with delta, do NOT truncate - we read existing blocks
+            // Inplace + delta must NOT truncate: the existing blocks are the
+            // basis the delta reads from.
             let should_truncate = delta_signature.is_none();
             fs::OpenOptions::new()
                 .create(true)

--- a/crates/engine/src/local_copy/executor/file/guard.rs
+++ b/crates/engine/src/local_copy/executor/file/guard.rs
@@ -3,8 +3,8 @@
 //! Provides [`DestinationWriteGuard`] which manages the lifecycle of a
 //! temporary file during transfer: creation, writing, and atomic rename
 //! to the final destination on commit.
-
-// upstream: receiver.c:recv_files() - temp file creation and rename
+//!
+//! upstream: receiver.c:recv_files() - temp file creation and rename
 
 use std::fs;
 use std::io;

--- a/crates/engine/src/local_copy/executor/file/preallocate.rs
+++ b/crates/engine/src/local_copy/executor/file/preallocate.rs
@@ -2,8 +2,8 @@
 //!
 //! Uses `fallocate(2)` on Linux to reserve contiguous disk space before
 //! writing file data, falling back to a no-op on other platforms.
-
-// upstream: receiver.c - preallocate support via --preallocate
+//!
+//! upstream: receiver.c - preallocate support via --preallocate
 
 use std::fs;
 #[cfg(unix)]

--- a/crates/engine/src/local_copy/executor/file/sparse/hole_punch.rs
+++ b/crates/engine/src/local_copy/executor/file/sparse/hole_punch.rs
@@ -51,47 +51,39 @@ pub(crate) fn punch_hole(
         return Ok(());
     }
 
-    // Ensure position doesn't exceed i64::MAX for fallocate
+    // fallocate's offset/length args are signed; fall back when either would
+    // overflow i64.
     if pos > i64::MAX as u64 || len > i64::MAX as u64 {
         return write_zeros_fallback(file, path, len);
     }
 
     let fd = file.as_fd();
 
-    // Strategy 1: Try PUNCH_HOLE | KEEP_SIZE (creates actual filesystem hole)
+    // Strategy 1: PUNCH_HOLE | KEEP_SIZE creates an actual filesystem hole.
     let punch_flags = FallocateFlags::PUNCH_HOLE | FallocateFlags::KEEP_SIZE;
     match fallocate(fd, punch_flags, pos, len) {
         Ok(()) => {
-            // Seek to pos + len after successful hole punch
             file.seek(SeekFrom::Start(pos + len))
                 .map_err(|e| LocalCopyError::io("seek after hole punch", path, e))?;
             return Ok(());
         }
-        Err(Errno::OPNOTSUPP | Errno::NOSYS | Errno::INVAL) => {
-            // PUNCH_HOLE not supported, try ZERO_RANGE
-        }
-        Err(_errno) => {
-            // Unexpected error, fall through to ZERO_RANGE fallback
-        }
+        Err(Errno::OPNOTSUPP | Errno::NOSYS | Errno::INVAL) => {}
+        Err(_) => {}
     }
 
-    // Strategy 2: Try ZERO_RANGE (zeroes range without allocation on some systems)
+    // Strategy 2: ZERO_RANGE zeroes the range without allocation on some
+    // filesystems.
     match fallocate(fd, FallocateFlags::ZERO_RANGE, pos, len) {
         Ok(()) => {
-            // Seek to pos + len after successful zero range
             file.seek(SeekFrom::Start(pos + len))
                 .map_err(|e| LocalCopyError::io("seek after zero range", path, e))?;
             return Ok(());
         }
-        Err(Errno::OPNOTSUPP | Errno::NOSYS | Errno::INVAL) => {
-            // ZERO_RANGE not supported, fall back to writing zeros
-        }
-        Err(_errno) => {
-            // Unexpected error, fall through to write zeros
-        }
+        Err(Errno::OPNOTSUPP | Errno::NOSYS | Errno::INVAL) => {}
+        Err(_) => {}
     }
 
-    // Strategy 3: Write zeros (universal but allocates space)
+    // Strategy 3: write zeros - universal but allocates disk space.
     write_zeros_fallback(file, path, len)
 }
 
@@ -116,7 +108,6 @@ pub(crate) fn punch_hole(
         return Ok(());
     }
 
-    // Seek to the starting position before writing zeros
     file.seek(SeekFrom::Start(pos))
         .map_err(|e| LocalCopyError::io("seek before writing zeros", path, e))?;
 

--- a/crates/engine/src/local_copy/executor/special/device.rs
+++ b/crates/engine/src/local_copy/executor/special/device.rs
@@ -2,8 +2,8 @@
 //!
 //! Recreates block and character device nodes at the destination using
 //! `mknod(2)`, with optional hard-link deduplication to earlier devices.
-
-// upstream: receiver.c - device node handling, syscall.c:do_mknod()
+//!
+//! upstream: receiver.c - device node handling, syscall.c:do_mknod()
 
 use std::fs;
 use std::io;

--- a/crates/engine/src/local_copy/executor/special/fifo.rs
+++ b/crates/engine/src/local_copy/executor/special/fifo.rs
@@ -2,8 +2,8 @@
 //!
 //! Recreates FIFOs at the destination using `mkfifo(3)`, with optional
 //! hard-link deduplication to earlier FIFOs.
-
-// upstream: receiver.c - FIFO handling, syscall.c:do_mknod()
+//!
+//! upstream: receiver.c - FIFO handling, syscall.c:do_mknod()
 
 use std::fs;
 use std::io;

--- a/crates/engine/src/local_copy/executor/special/symlink.rs
+++ b/crates/engine/src/local_copy/executor/special/symlink.rs
@@ -3,8 +3,8 @@
 //! Recreates symlinks at the destination, optionally munging unsafe targets
 //! (absolute paths or `..` escapes) when `--safe-links` or `--munge-links`
 //! is active.
-
-// upstream: receiver.c - symlink handling, syscall.c:do_symlink()
+//!
+//! upstream: receiver.c - symlink handling, syscall.c:do_symlink()
 
 use std::fs;
 use std::io;

--- a/crates/engine/src/local_copy/pipelined_state.rs
+++ b/crates/engine/src/local_copy/pipelined_state.rs
@@ -174,32 +174,26 @@ impl PipelineController {
     /// 3. Read more entries
     /// 4. Process responses
     pub fn next_priority(&self) -> Option<PipelinePriority> {
-        // Error state is terminal
         if matches!(self.state, PipelineState::Error(_)) {
             return None;
         }
 
-        // Check if complete
         if self.is_complete() {
             return None;
         }
 
-        // Priority 1: Process ready entries
         if self.has_ready_entries() {
             return Some(PipelinePriority::ProcessReadyEntries);
         }
 
-        // Priority 2: Fill pipeline (if not full and wire not exhausted)
         if self.can_fill() {
             return Some(PipelinePriority::FillPipeline);
         }
 
-        // Priority 3: Read more entries (if wire not exhausted and pipeline not empty)
         if !self.wire_exhausted && !self.pending_entries.is_empty() {
             return Some(PipelinePriority::ReadMoreEntries);
         }
 
-        // Priority 4: Process responses
         if self.has_pending_responses() {
             return Some(PipelinePriority::ProcessOneResponse);
         }


### PR DESCRIPTION
## Summary

Partial progress on #1843 (engine crate scope only).

Applies the codebase comment cleanup rules to production source files
under `crates/engine/src/`:

- Consolidate orphan `// upstream:` references that sat just below a
  module doc block into the doc block itself so the reference travels
  with the rustdoc instead of being orphaned.
- Replace decorative banner/divider comments with regular rustdoc.
- Drop restatement comments that echo the next line of code.
- Tighten a couple of `SAFETY:` blocks that had mechanically duplicated
  context.

Touches only `crates/engine/src/**`; no test files are modified, and
no code paths change (comments-only). Tests, ACL/xattr blocks, and the
documented escape-hatch wording around `force_insert` in
`concurrent_delta/consumer.rs` are preserved verbatim.

## Test plan

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings`
- [ ] `cargo nextest run -p engine --all-features` (CI)