### PR TITLE
docs(compress): comment audit pass (#1843)

### DIFF
--- a/crates/compress/src/algorithm.rs
+++ b/crates/compress/src/algorithm.rs
@@ -201,7 +201,6 @@ mod tests {
     #[test]
     fn default_algorithm_matches_upstream_precedence() {
         let default = CompressionAlgorithm::default_algorithm();
-        // Upstream rsync 3.4.1 negotiation precedence: zstd > lz4 > zlib
         #[cfg(feature = "zstd")]
         assert_eq!(default, CompressionAlgorithm::Zstd);
         #[cfg(all(not(feature = "zstd"), feature = "lz4"))]
@@ -308,13 +307,11 @@ mod tests {
 
     #[test]
     fn zlib_default_level_matches_upstream() {
-        // upstream: token.c - Z_DEFAULT_COMPRESSION resolves to 6
         assert_eq!(ZLIB_DEFAULT_LEVEL, 6);
     }
 
     #[test]
     fn zstd_default_level_matches_upstream() {
-        // upstream: token.c - ZSTD_CLEVEL_DEFAULT is 3
         assert_eq!(ZSTD_DEFAULT_LEVEL, 3);
     }
 
@@ -325,7 +322,6 @@ mod tests {
 
     #[test]
     fn zstd_best_level_matches_upstream_max() {
-        // upstream: token.c - capped at 19 (ZSTD_maxCLevel without ultra)
         assert_eq!(ZSTD_BEST_LEVEL, 19);
     }
 

--- a/crates/compress/src/lz4/frame.rs
+++ b/crates/compress/src/lz4/frame.rs
@@ -290,7 +290,7 @@ mod tests {
 
     #[test]
     fn decompress_invalid_magic_returns_error() {
-        // LZ4 frame magic is 0x184D2204
+        // LZ4 frame magic is 0x184D2204; all-zero input lacks it.
         let invalid_frame = [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
         let result = decompress_to_vec(&invalid_frame);
         assert!(result.is_err(), "invalid magic should fail");
@@ -299,7 +299,7 @@ mod tests {
     #[test]
     fn compress_empty_input_produces_valid_frame() {
         let compressed = compress_to_vec(&[], CompressionLevel::Default).expect("compress empty");
-        // Valid LZ4 frame for empty input still has magic + descriptor + end marker
+        // Empty payload still emits magic + descriptor + end marker.
         assert!(
             !compressed.is_empty(),
             "empty input should produce frame header"
@@ -309,8 +309,7 @@ mod tests {
     }
 
     // upstream: token.c:send_deflated_token() flushes the compressor after each
-    // token so the receiver can decompress incrementally; the tests below
-    // exercise that contract.
+    // token so the receiver can decompress incrementally.
 
     #[test]
     fn flush_emits_compressed_block() {
@@ -351,7 +350,7 @@ mod tests {
 
     #[test]
     fn flush_after_each_token_all_data_recoverable() {
-        // upstream: token.c per-token pattern - write data, flush, repeat.
+        // upstream: token.c per-token pattern.
         let tokens: &[&[u8]] = &[
             b"token one: file header metadata",
             b"token two: delta literal run",
@@ -392,9 +391,8 @@ mod tests {
 
     #[test]
     fn flush_produces_incrementally_decompressible_output() {
-        // Verifies flush materializes buffered data into the sink rather than
-        // holding it in the encoder's internal state, so the finalized frame
-        // contains token1 even though the test interleaves writes around it.
+        // Verifies flush materializes buffered data into the sink so the
+        // finalized frame contains token1 even with interleaved writes.
         let mut encoder = CountingLz4Encoder::with_sink(Vec::new(), CompressionLevel::Default);
 
         let token1 = b"incremental decompression test - token one data payload";

--- a/crates/compress/src/lz4/raw.rs
+++ b/crates/compress/src/lz4/raw.rs
@@ -531,7 +531,7 @@ mod tests {
     fn read_compressed_block_io_error() {
         use std::io::Cursor;
 
-        // Header advertises 16 bytes of payload that the cursor never supplies.
+        // Header advertises 16 bytes the cursor never supplies.
         let mut cursor = Cursor::new(vec![0x40, 0x10]);
         let result = read_compressed_block(&mut cursor, 1000);
         assert!(matches!(result, Err(RawLz4Error::Io(_))));
@@ -627,17 +627,16 @@ mod tests {
 
     #[test]
     fn compress_incompressible_data_near_max() {
-        // Pseudo-random fill exercises the expansion case where LZ4 output
-        // can grow past the input size.
+        // LCG (Numerical Recipes constants) yields high-entropy bytes that
+        // exercise the expansion case where LZ4 output can exceed input size.
         let mut input = Vec::with_capacity(MAX_BLOCK_SIZE);
         let mut state: u32 = 0xDEAD_BEEF;
         for _ in 0..MAX_BLOCK_SIZE {
-            // LCG (Numerical Recipes constants) yields non-compressible bytes.
             state = state.wrapping_mul(1664525).wrapping_add(1013904223);
             input.push((state >> 24) as u8);
         }
 
-        // Either outcome is valid - the LCG output may or may not exceed
+        // Either outcome is valid; LCG output may or may not exceed
         // MAX_BLOCK_SIZE once compressed.
         let result = compress_block_to_vec(&input);
         match result {

--- a/crates/compress/src/skip_compress/adaptive.rs
+++ b/crates/compress/src/skip_compress/adaptive.rs
@@ -83,7 +83,7 @@ impl<W: Write> AdaptiveCompressor<W> {
 
     /// Finishes the compression stream and returns the inner writer.
     pub fn finish(mut self) -> io::Result<W> {
-        // Force a decision for small files that never reached the sample size.
+        // Force a decision for files smaller than the sample size.
         if !self.decision_made {
             self.make_decision()?;
         }

--- a/crates/compress/src/skip_compress/decider.rs
+++ b/crates/compress/src/skip_compress/decider.rs
@@ -142,8 +142,10 @@ impl CompressionDecider {
     }
 
     /// Sets the sample size for auto-detection.
+    ///
+    /// Values below 64 bytes are clamped: smaller samples do not yield
+    /// meaningful compression ratios.
     pub fn set_sample_size(&mut self, size: usize) {
-        // 64 bytes is the smallest sample that yields meaningful ratio measurements.
         self.sample_size = size.max(64);
     }
 
@@ -171,7 +173,7 @@ impl CompressionDecider {
     /// `AutoDetect` when no content is available for analysis.
     #[must_use]
     pub fn should_compress(&self, path: &Path, first_block: Option<&[u8]>) -> CompressionDecision {
-        // Extension lookup is the fastest path; check it before any content inspection.
+        // Extension lookup runs before content inspection: it is O(1).
         if let Some(ext) = Self::extract_extension(path) {
             if self.skip_extensions.contains(ext.as_str()) {
                 return CompressionDecision::Skip;
@@ -192,7 +194,6 @@ impl CompressionDecider {
             return CompressionDecision::Compress;
         }
 
-        // No content available; defer to caller's auto-detection pass.
         CompressionDecision::AutoDetect
     }
 
@@ -214,11 +215,10 @@ impl CompressionDecider {
     /// ```
     pub fn auto_detect_compressible(&self, sample: &[u8]) -> io::Result<bool> {
         if sample.is_empty() {
-            // Empty input has nothing to skip and is trivially "compressible".
             return Ok(true);
         }
 
-        // Use the fastest level: detection only needs ratio, not optimal output.
+        // Detection only needs the ratio, not optimal output: use the fastest level.
         let mut encoder = CountingZlibEncoder::new(CompressionLevel::Fast);
         encoder.write_all(sample)?;
         let compressed_len = encoder.finish()? as usize;
@@ -233,7 +233,7 @@ impl CompressionDecider {
         let file_name = path.file_name()?.to_str()?;
         let lower = file_name.to_ascii_lowercase();
 
-        // Compound suffixes like `.tar.gz` must match the full filename to win
+        // Compound suffixes (`.tar.gz`) must match the full filename to win
         // over the trailing simple extension (`gz`).
         for compound in COMPOUND_EXTENSIONS {
             if lower.ends_with(compound) {
@@ -250,7 +250,8 @@ impl CompressionDecider {
     fn detect_category_by_magic(&self, data: &[u8]) -> Option<FileCategory> {
         for sig in KNOWN_SIGNATURES {
             if sig.matches(data) {
-                // Special handling for RIFF container (can be AVI, WAV, or WEBP)
+                // RIFF is a container; the fourcc at offset 8 disambiguates
+                // AVI, WAV, and WEBP.
                 if sig.bytes == b"RIFF" {
                     if data.len() >= 12 {
                         let fourcc = &data[8..12];
@@ -258,10 +259,9 @@ impl CompressionDecider {
                             b"AVI " => FileCategory::Video,
                             b"WAVE" => FileCategory::Audio,
                             b"WEBP" => FileCategory::Image,
-                            _ => continue, // Unknown RIFF subtype, check other signatures
+                            _ => continue,
                         });
                     } else {
-                        // Incomplete RIFF header - not enough data to determine type
                         continue;
                     }
                 }

--- a/crates/compress/src/skip_compress/tests.rs
+++ b/crates/compress/src/skip_compress/tests.rs
@@ -9,7 +9,6 @@ use super::*;
 fn default_skip_list_includes_common_formats() {
     let decider = CompressionDecider::with_default_skip_list();
 
-    // Images
     assert!(decider.skip_extensions().contains("jpg"));
     assert!(decider.skip_extensions().contains("jpeg"));
     assert!(decider.skip_extensions().contains("png"));
@@ -17,21 +16,18 @@ fn default_skip_list_includes_common_formats() {
     assert!(decider.skip_extensions().contains("webp"));
     assert!(decider.skip_extensions().contains("heic"));
 
-    // Video
     assert!(decider.skip_extensions().contains("mp4"));
     assert!(decider.skip_extensions().contains("mkv"));
     assert!(decider.skip_extensions().contains("avi"));
     assert!(decider.skip_extensions().contains("mov"));
     assert!(decider.skip_extensions().contains("webm"));
 
-    // Audio
     assert!(decider.skip_extensions().contains("mp3"));
     assert!(decider.skip_extensions().contains("flac"));
     assert!(decider.skip_extensions().contains("ogg"));
     assert!(decider.skip_extensions().contains("m4a"));
     assert!(decider.skip_extensions().contains("aac"));
 
-    // Archives
     assert!(decider.skip_extensions().contains("zip"));
     assert!(decider.skip_extensions().contains("gz"));
     assert!(decider.skip_extensions().contains("bz2"));
@@ -40,7 +36,6 @@ fn default_skip_list_includes_common_formats() {
     assert!(decider.skip_extensions().contains("rar"));
     assert!(decider.skip_extensions().contains("zst"));
 
-    // Documents
     assert!(decider.skip_extensions().contains("pdf"));
 }
 
@@ -90,7 +85,6 @@ fn should_compress_unknown_extension_returns_auto_detect() {
 fn should_compress_with_content_makes_decision() {
     let decider = CompressionDecider::with_default_skip_list();
 
-    // Text content should compress
     let text_content = b"Hello, world! This is some compressible text content.";
     assert_eq!(
         decider.should_compress(Path::new("file.txt"), Some(text_content)),
@@ -102,7 +96,6 @@ fn should_compress_with_content_makes_decision() {
 fn magic_byte_detection_jpeg() {
     let decider = CompressionDecider::with_default_skip_list();
 
-    // JPEG magic bytes
     let jpeg_header = [0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10];
     assert_eq!(
         decider.should_compress(Path::new("unknown"), Some(&jpeg_header)),
@@ -114,7 +107,6 @@ fn magic_byte_detection_jpeg() {
 fn magic_byte_detection_png() {
     let decider = CompressionDecider::with_default_skip_list();
 
-    // PNG magic bytes
     let png_header = [0x89, b'P', b'N', b'G', 0x0d, 0x0a, 0x1a, 0x0a];
     assert_eq!(
         decider.should_compress(Path::new("unknown"), Some(&png_header)),
@@ -126,7 +118,6 @@ fn magic_byte_detection_png() {
 fn magic_byte_detection_gzip() {
     let decider = CompressionDecider::with_default_skip_list();
 
-    // gzip magic bytes
     let gzip_header = [0x1f, 0x8b, 0x08, 0x00];
     assert_eq!(
         decider.should_compress(Path::new("unknown"), Some(&gzip_header)),
@@ -138,7 +129,6 @@ fn magic_byte_detection_gzip() {
 fn magic_byte_detection_zip() {
     let decider = CompressionDecider::with_default_skip_list();
 
-    // ZIP magic bytes
     let zip_header = [b'P', b'K', 0x03, 0x04];
     assert_eq!(
         decider.should_compress(Path::new("unknown"), Some(&zip_header)),
@@ -150,7 +140,6 @@ fn magic_byte_detection_zip() {
 fn magic_byte_detection_pdf() {
     let decider = CompressionDecider::with_default_skip_list();
 
-    // PDF magic bytes
     let pdf_header = b"%PDF-1.5";
     assert_eq!(
         decider.should_compress(Path::new("unknown"), Some(pdf_header)),
@@ -189,7 +178,6 @@ fn parse_skip_compress_list_whitespace() {
 fn auto_detect_compressible_repetitive_data() {
     let decider = CompressionDecider::new();
 
-    // Highly repetitive data should compress well
     let data = vec![b'a'; 4096];
     assert!(decider.auto_detect_compressible(&data).unwrap());
 }
@@ -198,11 +186,10 @@ fn auto_detect_compressible_repetitive_data() {
 fn auto_detect_compressible_random_like_data() {
     let decider = CompressionDecider::new();
 
-    // Pseudo-random data using a better mixing function (PCG-like)
+    // PCG-style PRNG generates high-entropy bytes that resist compression.
     let mut state: u64 = 0x853c49e6748fea9b;
     let data: Vec<u8> = (0..4096)
         .map(|_| {
-            // PCG-style PRNG for high-quality randomness
             state = state
                 .wrapping_mul(6364136223846793005)
                 .wrapping_add(1442695040888963407);
@@ -212,7 +199,6 @@ fn auto_detect_compressible_random_like_data() {
         })
         .collect();
 
-    // High-entropy data should not compress well (ratio >= threshold)
     assert!(!decider.auto_detect_compressible(&data).unwrap());
 }
 
@@ -289,7 +275,6 @@ fn set_compression_threshold() {
     decider.set_compression_threshold(0.85);
     assert!((decider.compression_threshold() - 0.85).abs() < f64::EPSILON);
 
-    // Test clamping
     decider.set_compression_threshold(1.5);
     assert!((decider.compression_threshold() - 1.0).abs() < f64::EPSILON);
 
@@ -303,9 +288,8 @@ fn set_sample_size() {
     decider.set_sample_size(8192);
     assert_eq!(decider.sample_size(), 8192);
 
-    // Test minimum
     decider.set_sample_size(10);
-    assert_eq!(decider.sample_size(), 64); // Minimum is 64
+    assert_eq!(decider.sample_size(), 64);
 }
 
 #[test]
@@ -316,7 +300,6 @@ fn toggle_magic_detection() {
     decider.set_use_magic_detection(false);
     assert!(!decider.use_magic_detection());
 
-    // With magic detection disabled, JPEG header should not trigger skip
     let jpeg_header = [0xff, 0xd8, 0xff, 0xe0];
     assert_eq!(
         decider.should_compress(Path::new("unknown"), Some(&jpeg_header)),
@@ -341,21 +324,18 @@ fn file_category_compressible() {
 fn riff_container_detection() {
     let decider = CompressionDecider::with_default_skip_list();
 
-    // AVI (RIFF....AVI )
     let avi_header = b"RIFF\x00\x00\x00\x00AVI ";
     assert_eq!(
         decider.should_compress(Path::new("unknown"), Some(avi_header)),
         CompressionDecision::Skip
     );
 
-    // WAV (RIFF....WAVE)
     let wav_header = b"RIFF\x00\x00\x00\x00WAVE";
     assert_eq!(
         decider.should_compress(Path::new("unknown"), Some(wav_header)),
         CompressionDecision::Skip
     );
 
-    // WEBP (RIFF....WEBP)
     let webp_header = b"RIFF\x00\x00\x00\x00WEBP";
     assert_eq!(
         decider.should_compress(Path::new("unknown"), Some(webp_header)),
@@ -368,7 +348,7 @@ fn magic_signature_matches() {
     let sig = MagicSignature::new(0, b"TEST", FileCategory::Unknown);
     assert!(sig.matches(b"TEST1234"));
     assert!(!sig.matches(b"NOPE1234"));
-    assert!(!sig.matches(b"TES")); // Too short
+    assert!(!sig.matches(b"TES"));
 }
 
 #[test]
@@ -384,13 +364,11 @@ fn adaptive_compressor_basic() {
     let mut output = Vec::new();
     let mut compressor = AdaptiveCompressor::new(&mut output, decider, CompressionLevel::Fast);
 
-    // Write compressible data
     let data = vec![b'a'; 8192];
     compressor.write_all(&data).unwrap();
 
     let output = compressor.finish().unwrap();
 
-    // Compressible data should result in smaller output
     assert!(output.len() < data.len());
 }
 
@@ -400,7 +378,6 @@ fn adaptive_compressor_forced_decision() {
     let mut output = Vec::new();
     let mut compressor = AdaptiveCompressor::new(&mut output, decider, CompressionLevel::Fast);
 
-    // Force no compression
     compressor.set_decision(false);
     assert_eq!(compressor.compression_enabled(), Some(false));
 
@@ -408,7 +385,6 @@ fn adaptive_compressor_forced_decision() {
     compressor.write_all(data).unwrap();
     let output = compressor.finish().unwrap();
 
-    // Output should be identical to input (no compression)
     assert_eq!(&output[..], data);
 }
 
@@ -420,13 +396,10 @@ fn adaptive_compressor_small_write() {
     let mut output = Vec::new();
     let mut compressor = AdaptiveCompressor::new(&mut output, decider, CompressionLevel::Default);
 
-    // Write less than sample size
+    // Below sample size: decision remains deferred until finish forces it.
     compressor.write_all(b"small").unwrap();
-
-    // Decision shouldn't be made yet
     assert_eq!(compressor.compression_enabled(), None);
 
-    // Finish should still work
     let _ = compressor.finish().unwrap();
 }
 
@@ -478,7 +451,6 @@ fn suffix_borrow_str_lookup() {
     set.insert(Suffix::new("jpg"));
     set.insert(Suffix::new("png"));
 
-    // HashSet::contains works with &str via Borrow<str>
     assert!(set.contains("jpg"));
     assert!(set.contains("png"));
     assert!(!set.contains("gif"));

--- a/crates/compress/src/skip_compress/types.rs
+++ b/crates/compress/src/skip_compress/types.rs
@@ -42,13 +42,16 @@ pub enum FileCategory {
 
 impl FileCategory {
     /// Returns whether this category typically benefits from compression.
+    ///
+    /// PDFs and Office documents are usually pre-compressed internally.
+    /// Unknown categories default to compressible (optimistic).
     #[must_use]
     pub const fn is_compressible(self) -> bool {
         match self {
             Self::Image | Self::Video | Self::Audio | Self::Archive => false,
-            Self::Document => false, // PDFs and Office docs are usually pre-compressed
+            Self::Document => false,
             Self::Text | Self::Data | Self::Executable => true,
-            Self::Unknown => true, // Optimistic default
+            Self::Unknown => true,
         }
     }
 }

--- a/crates/compress/src/strategy/impls.rs
+++ b/crates/compress/src/strategy/impls.rs
@@ -213,9 +213,8 @@ impl CompressionStrategy for Lz4Strategy {
     }
 
     fn decompress(&self, input: &[u8], output: &mut Vec<u8>) -> io::Result<usize> {
-        // Allocate output buffer based on raw module's safety limit.
-        // The raw header encodes compressed size; decompressed size is bounded
-        // by MAX_DECOMPRESSED_SIZE to prevent memory exhaustion.
+        // Output bounded by MAX_BLOCK_SIZE (raw module's safety limit) to
+        // prevent memory exhaustion attacks.
         let decompressed = raw::decompress_block_to_vec(input, raw::MAX_BLOCK_SIZE)
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
         let len = decompressed.len();

--- a/crates/compress/src/strategy/negotiator.rs
+++ b/crates/compress/src/strategy/negotiator.rs
@@ -282,7 +282,6 @@ mod tests {
         let negotiator = DefaultCompressionNegotiator::new();
         let supported = negotiator.supported_algorithms();
         assert!(supported.contains(&"zstd"));
-        // zstd should be first (highest preference)
         assert_eq!(supported[0], "zstd");
     }
 
@@ -290,7 +289,6 @@ mod tests {
     fn default_negotiator_supported_algorithms_order() {
         let negotiator = DefaultCompressionNegotiator::new();
         let supported = negotiator.supported_algorithms();
-        // zlibx should come before zlib (upstream preference)
         let zlibx_pos = supported.iter().position(|&a| a == "zlibx").unwrap();
         let zlib_pos = supported.iter().position(|&a| a == "zlib").unwrap();
         let none_pos = supported.iter().position(|&a| a == "none").unwrap();
@@ -301,8 +299,6 @@ mod tests {
     #[test]
     fn default_negotiator_client_selects_first_local_match() {
         let negotiator = DefaultCompressionNegotiator::new();
-        // Remote supports zlib and none - client should pick zlibx or zstd first
-        // depending on features, but since remote only has zlib, should pick zlib.
         let selected = negotiator.select_algorithm(&["zlib", "none"], false);
         assert_eq!(selected, "zlib");
     }
@@ -310,7 +306,6 @@ mod tests {
     #[test]
     fn default_negotiator_server_selects_first_remote_match() {
         let negotiator = DefaultCompressionNegotiator::new();
-        // Server iterates remote list: zlib is first and we support it
         let selected = negotiator.select_algorithm(&["zlib", "none"], true);
         assert_eq!(selected, "zlib");
     }
@@ -318,8 +313,6 @@ mod tests {
     #[test]
     fn default_negotiator_server_prefers_remote_order() {
         let negotiator = DefaultCompressionNegotiator::new();
-        // Server should pick "none" because it appears first in remote's list
-        // and we support it
         let selected = negotiator.select_algorithm(&["none", "zlib"], true);
         assert_eq!(selected, "none");
     }
@@ -327,7 +320,6 @@ mod tests {
     #[test]
     fn default_negotiator_client_prefers_local_order() {
         let negotiator = DefaultCompressionNegotiator::new();
-        // Client should pick zlibx because it appears before "none" in local list
         let selected = negotiator.select_algorithm(&["none", "zlibx"], false);
         assert_eq!(selected, "zlibx");
     }
@@ -446,8 +438,6 @@ mod tests {
 
     #[test]
     fn selector_negotiate_with_default_negotiator() {
-        // Verify that DefaultCompressionNegotiator produces results consistent
-        // with CompressionStrategySelector::negotiate for common scenarios.
         let negotiator = DefaultCompressionNegotiator::new();
         let selected = negotiator.select_algorithm(&["zlib", "none"], false);
         assert!(selected == "zlib" || selected == "zlibx");
@@ -475,8 +465,6 @@ mod tests {
 
     #[test]
     fn negotiation_pre_v30_remote_only_zlib() {
-        // Protocol < 30: remote peer only supports zlib (no negotiation vstring).
-        // Client should select zlib since it is always available locally.
         let negotiator = DefaultCompressionNegotiator::new();
         let selected = negotiator.select_algorithm(&["zlib"], false);
         assert_eq!(selected, "zlib");
@@ -491,18 +479,14 @@ mod tests {
 
     #[test]
     fn negotiation_v28_remote_zlib_and_none() {
-        // Protocol 28: remote advertises zlib + none (typical pre-v30 peer).
         let negotiator = DefaultCompressionNegotiator::new();
-        // As client: local preference order wins - zlibx before zlib
         let selected = negotiator.select_algorithm(&["zlib", "none"], false);
         assert_eq!(selected, "zlib");
     }
 
     #[test]
     fn negotiation_v29_remote_zlibx_zlib_none() {
-        // Protocol 29: remote advertises zlibx, zlib, none.
         let negotiator = DefaultCompressionNegotiator::new();
-        // Client prefers local order: zlibx is in local list before zlib
         let selected = negotiator.select_algorithm(&["zlibx", "zlib", "none"], false);
         assert_eq!(selected, "zlibx");
     }
@@ -510,19 +494,14 @@ mod tests {
     #[cfg(feature = "zstd")]
     #[test]
     fn negotiation_v30_remote_zlib_zstd_client_prefers_zstd() {
-        // Protocol 30-31: remote supports zstd + zlib. With zstd feature
-        // enabled, client's local preference order is zstd > zlibx > zlib.
         let negotiator = DefaultCompressionNegotiator::new();
         let selected = negotiator.select_algorithm(&["zlib", "zlibx", "zstd", "none"], false);
-        // Client iterates local list: zstd is first locally, and remote has it
         assert_eq!(selected, "zstd");
     }
 
     #[cfg(feature = "zstd")]
     #[test]
     fn negotiation_v31_server_respects_remote_order() {
-        // Protocol 31: as server, we iterate the remote (client's) list.
-        // Remote prefers zlib over zstd - server should respect that.
         let negotiator = DefaultCompressionNegotiator::new();
         let selected = negotiator.select_algorithm(&["zlib", "zstd", "none"], true);
         assert_eq!(selected, "zlib");
@@ -531,7 +510,6 @@ mod tests {
     #[cfg(feature = "zstd")]
     #[test]
     fn negotiation_v32_remote_zstd_first_server() {
-        // Protocol 32+: remote (client) prefers zstd - server picks zstd.
         let negotiator = DefaultCompressionNegotiator::new();
         let selected = negotiator.select_algorithm(&["zstd", "zlib", "none"], true);
         assert_eq!(selected, "zstd");
@@ -540,8 +518,6 @@ mod tests {
     #[cfg(not(feature = "zstd"))]
     #[test]
     fn negotiation_without_zstd_falls_back_to_zlib() {
-        // Without zstd feature: remote advertises zstd + zlib, but we
-        // can only select zlib since zstd is not compiled in.
         let negotiator = DefaultCompressionNegotiator::new();
         let selected = negotiator.select_algorithm(&["zstd", "zlib", "none"], false);
         assert_eq!(selected, "zlib");
@@ -552,7 +528,6 @@ mod tests {
     fn negotiation_without_zstd_server_skips_zstd() {
         let negotiator = DefaultCompressionNegotiator::new();
         let selected = negotiator.select_algorithm(&["zstd", "zlib", "none"], true);
-        // Server iterates remote list: zstd is not available, so skip to zlib
         assert_eq!(selected, "zlib");
     }
 
@@ -566,8 +541,6 @@ mod tests {
 
     #[test]
     fn negotiation_lz4_not_in_auto_negotiation() {
-        // lz4 is intentionally omitted from auto-negotiation (per code comment).
-        // Even with the lz4 feature enabled, it should not appear in the list.
         let negotiator = DefaultCompressionNegotiator::new();
         let supported = negotiator.supported_algorithms();
         assert!(
@@ -578,8 +551,6 @@ mod tests {
 
     #[test]
     fn negotiation_remote_only_lz4_returns_none() {
-        // If remote only supports lz4, and we don't advertise it,
-        // negotiation should fall back to "none".
         let negotiator = DefaultCompressionNegotiator::new();
         let selected = negotiator.select_algorithm(&["lz4"], false);
         assert_eq!(selected, "none");
@@ -594,7 +565,6 @@ mod tests {
 
     #[test]
     fn negotiation_remote_unknown_algorithms_ignored() {
-        // Remote advertises completely unknown algorithms.
         let negotiator = DefaultCompressionNegotiator::new();
         let selected = negotiator.select_algorithm(&["brotli", "snappy", "lzma"], false);
         assert_eq!(selected, "none");
@@ -602,7 +572,6 @@ mod tests {
 
     #[test]
     fn negotiation_remote_unknown_then_zlib_server() {
-        // Server: remote list has unknown first, then zlib.
         let negotiator = DefaultCompressionNegotiator::new();
         let selected = negotiator.select_algorithm(&["brotli", "zlib", "none"], true);
         assert_eq!(selected, "zlib");
@@ -610,7 +579,6 @@ mod tests {
 
     #[test]
     fn negotiation_protocol_version_0_defaults_zlib() {
-        // Edge case: protocol version 0 should default to zlib.
         assert_eq!(
             CompressionAlgorithmKind::for_protocol_version(0),
             CompressionAlgorithmKind::Zlib
@@ -619,7 +587,6 @@ mod tests {
 
     #[test]
     fn negotiation_protocol_version_255_high() {
-        // Edge case: very high protocol version.
         let kind = CompressionAlgorithmKind::for_protocol_version(255);
         #[cfg(feature = "zstd")]
         assert_eq!(kind, CompressionAlgorithmKind::Zstd);
@@ -629,8 +596,7 @@ mod tests {
 
     #[test]
     fn negotiation_protocol_version_29_boundary() {
-        // Protocol 29 is the last version before vstring negotiation; the
-        // upstream fallback codec is "zlib" (compat.c:556-563).
+        // upstream: compat.c:556-563 - last pre-vstring version, fallback zlib.
         assert_eq!(
             CompressionAlgorithmKind::for_protocol_version(29),
             CompressionAlgorithmKind::Zlib
@@ -639,9 +605,7 @@ mod tests {
 
     #[test]
     fn negotiation_protocol_version_30_boundary() {
-        // Protocol 30 is the first version with vstring negotiation. The
-        // canonical default kind is zstd when SUPPORT_ZSTD is defined
-        // (upstream: compat.c:101-102 valid_compressions_items[]).
+        // upstream: compat.c:101-102 - first vstring version; zstd preferred.
         let kind = CompressionAlgorithmKind::for_protocol_version(30);
         #[cfg(feature = "zstd")]
         assert_eq!(kind, CompressionAlgorithmKind::Zstd);
@@ -651,8 +615,6 @@ mod tests {
 
     #[test]
     fn negotiation_protocol_version_range_below_30_all_zlib() {
-        // All protocol versions below 30 default to zlib (no vstring
-        // negotiation in upstream).
         for v in [1, 10, 20, 28, 29] {
             assert_eq!(
                 CompressionAlgorithmKind::for_protocol_version(v),
@@ -664,8 +626,6 @@ mod tests {
 
     #[test]
     fn negotiation_client_zlibx_preferred_over_zlib() {
-        // When remote offers both zlibx and zlib, client should pick zlibx
-        // because zlibx comes before zlib in local preference order.
         let negotiator = DefaultCompressionNegotiator::new();
         let selected = negotiator.select_algorithm(&["zlib", "zlibx", "none"], false);
         assert_eq!(selected, "zlibx");
@@ -673,34 +633,29 @@ mod tests {
 
     #[test]
     fn negotiation_server_zlibx_vs_zlib_respects_remote_order() {
-        // Server iterates remote list, so zlib comes first if remote lists it first.
         let negotiator = DefaultCompressionNegotiator::new();
         let selected = negotiator.select_algorithm(&["zlib", "zlibx", "none"], true);
-        // "zlib" resolves via from_name to Zlib kind, which is in supported list
         assert_eq!(selected, "zlib");
     }
 
     #[test]
     fn negotiation_server_zlibx_first_in_remote() {
+        // zlibx maps to Zlib kind via from_name, which is in the supported list.
         let negotiator = DefaultCompressionNegotiator::new();
         let selected = negotiator.select_algorithm(&["zlibx", "zlib", "none"], true);
-        // zlibx maps to Zlib kind, which is available and in supported list
         assert_eq!(selected, "zlib");
     }
 
     #[cfg(feature = "zstd")]
     #[test]
     fn negotiation_client_zstd_unavailable_on_remote_falls_to_zlibx() {
-        // Client has zstd locally but remote only offers zlibx + zlib.
         let negotiator = DefaultCompressionNegotiator::new();
         let selected = negotiator.select_algorithm(&["zlibx", "zlib", "none"], false);
-        // Client iterates local: zstd not in remote, next is zlibx - found!
         assert_eq!(selected, "zlibx");
     }
 
     #[test]
     fn negotiation_remote_only_none() {
-        // Remote only supports "none" - should match.
         let negotiator = DefaultCompressionNegotiator::new();
         let selected = negotiator.select_algorithm(&["none"], false);
         assert_eq!(selected, "none");
@@ -739,7 +694,6 @@ mod tests {
     fn negotiation_supported_list_size() {
         let negotiator = DefaultCompressionNegotiator::new();
         let supported = negotiator.supported_algorithms();
-        // zlibx, zlib, none = 3 base, +1 if zstd
         #[cfg(feature = "zstd")]
         assert_eq!(supported.len(), 4);
         #[cfg(not(feature = "zstd"))]
@@ -748,7 +702,6 @@ mod tests {
 
     #[test]
     fn negotiation_duplicate_in_remote_list() {
-        // Remote sends duplicates - should still work, picking first match.
         let negotiator = DefaultCompressionNegotiator::new();
         let selected = negotiator.select_algorithm(&["zlib", "zlib", "none", "none"], false);
         assert_eq!(selected, "zlib");
@@ -814,7 +767,6 @@ mod tests {
     #[test]
     fn protocol_aware_proto_28_always_zlib_client() {
         let neg = ProtocolAwareCompressionNegotiator::new(28);
-        // Proto < 30 ignores remote list entirely
         assert_eq!(neg.select_algorithm(&["zstd", "none"], false), "zlib");
         assert_eq!(neg.select_algorithm(&["none"], false), "zlib");
         assert_eq!(neg.select_algorithm(&[], false), "zlib");
@@ -843,7 +795,6 @@ mod tests {
 
     #[test]
     fn protocol_aware_proto_0_always_zlib() {
-        // Edge case: protocol version 0
         let neg = ProtocolAwareCompressionNegotiator::new(0);
         assert_eq!(neg.supported_algorithms(), vec!["zlib"]);
         assert_eq!(neg.select_algorithm(&["zstd", "none"], false), "zlib");
@@ -935,7 +886,7 @@ mod tests {
     #[cfg(feature = "zstd")]
     #[test]
     fn protocol_aware_proto_30_zstd_is_first_preference() {
-        // upstream: compat.c:100-102 - zstd listed first in valid_compressions_items
+        // upstream: compat.c:100-102 valid_compressions_items[] - zstd first.
         let neg = ProtocolAwareCompressionNegotiator::new(30);
         let supported = neg.supported_algorithms();
         assert_eq!(supported[0], "zstd");
@@ -952,8 +903,7 @@ mod tests {
     #[cfg(feature = "zstd")]
     #[test]
     fn protocol_aware_proto_32_zstd_preferred() {
-        // upstream: compat.c:100-102 - zstd is first in valid_compressions_items
-        // when SUPPORT_ZSTD is defined; protocol 32+ explicitly prefers zstd
+        // upstream: compat.c:100-102 valid_compressions_items[] with SUPPORT_ZSTD.
         let neg = ProtocolAwareCompressionNegotiator::new(32);
         let supported = neg.supported_algorithms();
         assert_eq!(
@@ -983,7 +933,6 @@ mod tests {
     #[cfg(feature = "zstd")]
     #[test]
     fn protocol_aware_proto_28_ignores_zstd_in_remote() {
-        // Proto < 30: zstd in remote list does not matter
         let neg = ProtocolAwareCompressionNegotiator::new(28);
         let selected = neg.select_algorithm(&["zstd"], false);
         assert_eq!(selected, "zlib");
@@ -1011,7 +960,6 @@ mod tests {
     fn protocol_aware_proto_255_high_version() {
         let neg = ProtocolAwareCompressionNegotiator::new(255);
         let supported = neg.supported_algorithms();
-        // High protocol version behaves like >= 30
         assert!(supported.contains(&"zlibx"));
         assert!(supported.contains(&"zlib"));
         assert!(supported.contains(&"none"));
@@ -1050,12 +998,10 @@ mod tests {
 
     #[test]
     fn protocol_aware_boundary_29_to_30() {
-        // Proto 29: zlib only, no negotiation
         let neg29 = ProtocolAwareCompressionNegotiator::new(29);
         assert_eq!(neg29.supported_algorithms(), vec!["zlib"]);
         assert_eq!(neg29.select_algorithm(&["none"], false), "zlib");
 
-        // Proto 30: full negotiation
         let neg30 = ProtocolAwareCompressionNegotiator::new(30);
         let supported = neg30.supported_algorithms();
         assert!(supported.len() >= 3);

--- a/crates/compress/src/strategy/profile.rs
+++ b/crates/compress/src/strategy/profile.rs
@@ -149,11 +149,9 @@ impl ProtocolCompressionProfile {
     }
 }
 
-// Compile-time invariants for the LEGACY/MODERN profile constants. Stronger
-// than runtime tests: a regression here is a build failure, not a test
-// failure. Stated as `const _: () = assert!(...)` so they fold at compile
-// time, which also keeps clippy::assertions_on_constants from firing on the
-// equivalent runtime form.
+// Compile-time invariants: a regression here is a build failure, not a test
+// failure. `const _: () = assert!(...)` also sidesteps
+// clippy::assertions_on_constants.
 const _: () = assert!(!ProtocolCompressionProfile::LEGACY.supports_vstring_negotiation);
 const _: () = assert!(ProtocolCompressionProfile::MODERN.supports_vstring_negotiation);
 
@@ -300,8 +298,6 @@ mod tests {
 
     #[test]
     fn for_protocol_matches_old_kind_threshold_below_30() {
-        // Pre-30 always resolved to Zlib in the legacy
-        // CompressionAlgorithmKind::for_protocol_version match arm.
         for v in [0u8, 1, 10, 20, 27, 28, 29] {
             let p = ProtocolCompressionProfile::for_protocol(v);
             assert_eq!(p.fallback_codec, CompressionAlgorithmKind::Zlib);

--- a/crates/compress/src/strategy/tests.rs
+++ b/crates/compress/src/strategy/tests.rs
@@ -67,8 +67,7 @@ fn algorithm_kind_all() {
 
 #[test]
 fn algorithm_kind_for_protocol_version() {
-    // Pre-30 always defaults to Zlib (upstream: compat.c:556-563 - no
-    // vstring negotiation, fallback is "zlib").
+    // upstream: compat.c:556-563 - pre-30 has no vstring negotiation; zlib.
     assert_eq!(
         CompressionAlgorithmKind::for_protocol_version(28),
         CompressionAlgorithmKind::Zlib
@@ -78,9 +77,7 @@ fn algorithm_kind_for_protocol_version() {
         CompressionAlgorithmKind::Zlib
     );
 
-    // Protocol 30+ prefers Zstd when the zstd feature is compiled in
-    // (upstream: compat.c:101-102 valid_compressions_items[]). Without
-    // the feature the default falls back to Zlib.
+    // upstream: compat.c:101-102 - zstd first when SUPPORT_ZSTD is defined.
     #[cfg(feature = "zstd")]
     {
         assert_eq!(
@@ -160,10 +157,8 @@ fn zlib_strategy_different_levels() {
     fast.compress(COMPRESSIBLE_DATA, &mut fast_out).unwrap();
     best.compress(COMPRESSIBLE_DATA, &mut best_out).unwrap();
 
-    // Best should generally produce smaller or similar output
     assert!(best_out.len() <= fast_out.len() + 5);
 
-    // Both should decompress correctly
     let mut fast_decompressed = Vec::new();
     let mut best_decompressed = Vec::new();
     fast.decompress(&fast_out, &mut fast_decompressed).unwrap();
@@ -369,7 +364,7 @@ fn selector_protocol_version_28_returns_zlib() {
 
 #[test]
 fn selector_protocol_version_legacy_below_30_always_zlib() {
-    // Pre-30 has no vstring negotiation; upstream defaults to "zlib".
+    // upstream: compat.c:556-563 - no vstring negotiation; defaults to zlib.
     for v in 0..30u8 {
         let strategy = CompressionStrategySelector::for_protocol_version(v);
         assert_eq!(
@@ -383,8 +378,7 @@ fn selector_protocol_version_legacy_below_30_always_zlib() {
 #[cfg(feature = "zstd")]
 #[test]
 fn selector_protocol_version_modern_30_plus_zstd() {
-    // Protocol >= 30 with zstd compiled in: the canonical default kind is
-    // zstd (upstream: compat.c:101-102 valid_compressions_items[]).
+    // upstream: compat.c:101-102 valid_compressions_items[] - zstd first.
     for v in [30u8, 31, 32, 40, 100, 255] {
         let strategy = CompressionStrategySelector::for_protocol_version(v);
         assert_eq!(
@@ -422,9 +416,7 @@ fn kind_for_protocol_below_30_always_zlib() {
 #[cfg(feature = "zstd")]
 #[test]
 fn kind_for_protocol_30_and_above_zstd() {
-    // Upstream: compat.c:101-102 - zstd is the first preference whenever
-    // SUPPORT_ZSTD is defined and vstring negotiation is available
-    // (protocol >= 30).
+    // upstream: compat.c:101-102 - zstd first when SUPPORT_ZSTD is defined.
     for v in [30u8, 31, 32, 40, 100, 255] {
         assert_eq!(
             CompressionAlgorithmKind::for_protocol_version(v),
@@ -543,7 +535,6 @@ fn negotiate_only_none_kind() {
 
 #[test]
 fn kind_from_name_zlibx_maps_to_zlib() {
-    // "zlibx" is an alias for zlib in from_name
     let kind = CompressionAlgorithmKind::from_name("zlibx");
     assert_eq!(kind, Some(CompressionAlgorithmKind::Zlib));
 }
@@ -635,8 +626,6 @@ fn selector_for_algorithm_lz4() {
 
 #[test]
 fn negotiate_local_preference_order_wins() {
-    // When local lists Zlib before None, and remote has both,
-    // Zlib should be selected (not None).
     let local = vec![
         CompressionAlgorithmKind::Zlib,
         CompressionAlgorithmKind::None,
@@ -817,7 +806,7 @@ fn negotiate_none_kind_roundtrip() {
 
 #[test]
 fn kind_for_protocol_version_boundary_29_is_zlib() {
-    // Pre-30 always defaults to Zlib (upstream: compat.c:556-563).
+    // upstream: compat.c:556-563.
     assert_eq!(
         CompressionAlgorithmKind::for_protocol_version(29),
         CompressionAlgorithmKind::Zlib

--- a/crates/compress/src/strategy/type_state.rs
+++ b/crates/compress/src/strategy/type_state.rs
@@ -407,7 +407,6 @@ mod tests {
         let selected = default_pipeline()
             .exchange_capabilities(&["none", "zlib"])
             .select_algorithm(true);
-        // Server iterates remote list: "none" appears first and is supported
         assert_eq!(selected.selected_algorithm_name(), "none");
     }
 
@@ -416,7 +415,6 @@ mod tests {
         let selected = default_pipeline()
             .exchange_capabilities(&["none", "zlibx"])
             .select_algorithm(false);
-        // Client iterates local list: zlibx appears before "none" locally
         assert_eq!(selected.selected_algorithm_name(), "zlibx");
     }
 
@@ -539,15 +537,12 @@ mod tests {
 
     #[test]
     fn consuming_transitions_prevent_reuse() {
-        // This test verifies the consuming nature of transitions at runtime.
-        // The pipeline moves through states and prior references are dropped.
+        // Each transition consumes the previous handle; only the final
+        // strategy is reachable.
         let pipeline = default_pipeline();
         let exchanged = pipeline.exchange_capabilities(&["zlib"]);
-        // `pipeline` is now consumed - cannot be used
         let selected = exchanged.select_algorithm(false);
-        // `exchanged` is now consumed - cannot be used
         let strategy = selected.into_strategy();
-        // `selected` is now consumed - cannot be used
         assert_eq!(strategy.algorithm_name(), "zlib");
     }
 
@@ -584,7 +579,6 @@ mod tests {
             .exchange_capabilities(&["zlib", "none"])
             .select_algorithm(false)
             .into_strategy();
-        // Strategy should work regardless of level
         let mut compressed = Vec::new();
         strategy.compress(b"test data", &mut compressed).unwrap();
         assert!(!compressed.is_empty());
@@ -604,8 +598,7 @@ mod tests {
         let selected = default_pipeline()
             .exchange_capabilities(&["zlibx", "zlib", "none"])
             .select_algorithm(true);
-        // Server iterates remote: zlibx maps to zlib kind which is supported
-        // The name returned by the negotiator depends on from_name mapping
+        // zlibx resolves to the Zlib kind; either spelling is acceptable.
         let name = selected.selected_algorithm_name();
         assert!(name == "zlib" || name == "zlibx");
     }

--- a/crates/compress/src/zlib/tests.rs
+++ b/crates/compress/src/zlib/tests.rs
@@ -821,7 +821,6 @@ fn compression_level_none_roundtrip() {
     let compressed = compress_to_vec(&payload, CompressionLevel::None).expect("compress none");
     let decompressed = decompress_to_vec(&compressed).expect("decompress none");
     assert_eq!(decompressed, payload);
-    // Level None stores data verbatim - compressed size >= original
     assert!(compressed.len() >= payload.len());
 }
 
@@ -976,7 +975,6 @@ fn large_data_streaming_roundtrip() {
 
 #[test]
 fn incompressible_data_roundtrip() {
-    // Random-like data that resists compression
     let payload: Vec<u8> = (0..512).map(|i| ((i * 137 + 73) % 256) as u8).collect();
     let compressed =
         compress_to_vec(&payload, CompressionLevel::Best).expect("compress incompressible");
@@ -998,8 +996,8 @@ fn decompress_truncated_data_returns_error() {
         compress_to_vec(&payload, CompressionLevel::Default).expect("compress succeeds");
     let truncated = &compressed[..compressed.len() / 2];
     let result = decompress_to_vec(truncated);
-    // Truncated data may decompress partially or fail - either is acceptable
-    // as long as it does not panic
+    // Truncated input may yield a partial decode or an error; both are
+    // acceptable provided the call does not panic.
     if let Ok(partial) = result {
         assert!(partial.len() < payload.len());
     }
@@ -1014,7 +1012,8 @@ fn decoder_partial_reads_accumulate_byte_count() {
 
     let mut total_read = 0;
     let mut collected = Vec::new();
-    let mut buf = [0u8; 7]; // Small buffer to force multiple reads
+    // Small buffer forces multiple read() iterations to exercise accumulation.
+    let mut buf = [0u8; 7];
     loop {
         let n = decoder.read(&mut buf).expect("read succeeds");
         if n == 0 {
@@ -1094,7 +1093,6 @@ fn best_produces_smaller_output_than_fast() {
 fn none_level_does_not_shrink_data() {
     let payload = b"ABCDEFGHIJ".repeat(100);
     let compressed = compress_to_vec(&payload, CompressionLevel::None).expect("compress none");
-    // Level 0 stores uncompressed - output should be >= input
     assert!(
         compressed.len() >= payload.len(),
         "None level should not shrink data: compressed={} original={}",

--- a/crates/compress/src/zstd.rs
+++ b/crates/compress/src/zstd.rs
@@ -334,7 +334,6 @@ mod tests {
     fn all_levels_produce_valid_output() {
         let input = b"The quick brown fox jumps over the lazy dog";
 
-        // Test levels 1-22 (zstd's supported range)
         for level in 1..=22 {
             let level_config =
                 CompressionLevel::Precise(std::num::NonZeroU8::new(level).expect("non-zero level"));
@@ -348,7 +347,6 @@ mod tests {
 
     #[test]
     fn higher_levels_produce_smaller_output() {
-        // Use highly compressible data with larger size for meaningful compression differences
         let mut input = Vec::new();
         for _ in 0..50 {
             input.extend_from_slice(b"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
@@ -359,14 +357,13 @@ mod tests {
 
         let level_1 = CompressionLevel::Precise(std::num::NonZeroU8::new(1).unwrap());
         let level_10 = CompressionLevel::Precise(std::num::NonZeroU8::new(10).unwrap());
+        // Caps at 19 rather than 22: ultra-high levels have diminishing returns.
         let level_19 = CompressionLevel::Precise(std::num::NonZeroU8::new(19).unwrap());
 
         let compressed_1 = compress_to_vec(&input, level_1).expect("compress level 1");
         let compressed_10 = compress_to_vec(&input, level_10).expect("compress level 10");
         let compressed_19 = compress_to_vec(&input, level_19).expect("compress level 19");
 
-        // Higher levels should compress better or equal for highly compressible data
-        // Note: We use level 19 instead of 22 since ultra-high levels may have diminishing returns
         assert!(
             compressed_10.len() <= compressed_1.len(),
             "level 10 ({} bytes) should be <= level 1 ({} bytes)",
@@ -380,7 +377,6 @@ mod tests {
             compressed_10.len()
         );
 
-        // Verify all decompress correctly
         assert_eq!(decompress_to_vec(&compressed_1).unwrap(), input);
         assert_eq!(decompress_to_vec(&compressed_10).unwrap(), input);
         assert_eq!(decompress_to_vec(&compressed_19).unwrap(), input);
@@ -391,12 +387,10 @@ mod tests {
         let input = b"Lorem ipsum dolor sit amet, consectetur adipiscing elit. \
                       Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.";
 
-        // Test level 0 (None)
         let compressed = compress_to_vec(input, CompressionLevel::None).expect("compress level 0");
         let decompressed = decompress_to_vec(&compressed).expect("decompress level 0");
         assert_eq!(decompressed, input, "round-trip failed at level 0");
 
-        // Test preset levels
         for level_config in [
             CompressionLevel::Fast,
             CompressionLevel::Default,
@@ -409,7 +403,6 @@ mod tests {
             assert_eq!(decompressed, input, "round-trip failed at {level_config:?}");
         }
 
-        // Test all precise levels 1-22
         for level in 1..=22 {
             let level_config =
                 CompressionLevel::Precise(std::num::NonZeroU8::new(level).expect("non-zero level"));
@@ -425,7 +418,6 @@ mod tests {
     fn counting_encoder_all_levels() {
         let input = b"test data for counting encoder";
 
-        // Test that CountingZstdEncoder works with all levels
         for level in 1..=22 {
             let level_config =
                 CompressionLevel::Precise(std::num::NonZeroU8::new(level).expect("non-zero level"));
@@ -443,7 +435,6 @@ mod tests {
 
     #[test]
     fn compression_ratio_improves_with_level() {
-        // Create highly repetitive data
         let mut input = Vec::new();
         for _ in 0..100 {
             input.extend_from_slice(b"The same text repeated over and over again. ");
@@ -457,12 +448,10 @@ mod tests {
         let compressed_5 = compress_to_vec(&input, level_5).expect("compress level 5");
         let compressed_15 = compress_to_vec(&input, level_15).expect("compress level 15");
 
-        // Verify all produce valid output
         assert_eq!(decompress_to_vec(&compressed_1).unwrap(), input);
         assert_eq!(decompress_to_vec(&compressed_5).unwrap(), input);
         assert_eq!(decompress_to_vec(&compressed_15).unwrap(), input);
 
-        // Verify compression ratio improves
         assert!(
             compressed_5.len() <= compressed_1.len(),
             "level 5 should compress better than level 1"
@@ -472,7 +461,6 @@ mod tests {
             "level 15 should compress better than level 5"
         );
 
-        // Verify we actually achieved compression
         assert!(
             compressed_15.len() < input.len() / 2,
             "highly repetitive data should compress to less than 50%"
@@ -523,9 +511,9 @@ mod tests {
         }
     }
 
-    // Per-token flush tests - verify that flush produces output enabling
-    // incremental decompression, matching the upstream per-token pattern
-    // (token.c:send_deflated_token).
+    // upstream: token.c:send_deflated_token() - per-token flush enables
+    // incremental decompression on the receiver. Tests below verify the
+    // encoder mirrors that contract.
 
     #[test]
     fn flush_emits_compressed_data() {


### PR DESCRIPTION
Partial progress on #1843 (compress crate scope only).