### PR TITLE
docs(rsync_io+batch+platform): comment audit pass (#1843)

### DIFF
--- a/crates/rsync_io/src/binary/handshake.rs
+++ b/crates/rsync_io/src/binary/handshake.rs
@@ -9,17 +9,10 @@ use super::BinaryHandshakeParts;
 
 /// Result of completing the binary rsync protocol negotiation.
 ///
-/// The structure mirrors the legacy daemon helper but targets transports that
-/// use the binary handshake (e.g. remote-shell sessions). It exposes the
-/// negotiated protocol version together with the remote peer's advertisement
-/// while retaining the replaying stream so higher layers can continue the
-/// exchange without losing buffered bytes consumed during negotiation
-/// detection.
-///
-/// When the underlying transport implements [`Clone`], the handshake can be
-/// cloned to stage multiple views of the same negotiated session. The cloned
-/// value retains the replay buffer and metadata so both instances continue in
-/// lockstep without rereading from the transport.
+/// Targets transports that use the binary handshake (e.g. remote-shell
+/// sessions). Exposes the negotiated protocol version and the remote peer's
+/// advertisement while retaining the replaying stream so higher layers can
+/// continue the exchange without losing buffered bytes.
 #[derive(Clone, Debug)]
 pub struct BinaryHandshake<R> {
     stream: NegotiatedStream<R>,
@@ -51,9 +44,8 @@ impl<R> BinaryHandshake<R> {
 
     /// Returns the protocol version the local peer advertised to the remote side.
     ///
-    /// Binary negotiations transmit the caller's desired protocol (subject to `--protocol` caps) before
-    /// the remote advertisement is read. Capturing the value allows diagnostics to reference both sides
-    /// of the negotiation without requiring the original caller to stash the requested version.
+    /// Captured here so diagnostics can reference both sides of the negotiation
+    /// (subject to `--protocol` caps).
     #[doc(alias = "--protocol")]
     #[must_use]
     pub const fn local_advertised_protocol(&self) -> ProtocolVersion {
@@ -62,12 +54,10 @@ impl<R> BinaryHandshake<R> {
 
     /// Returns the compatibility flags advertised by the remote peer.
     ///
-    /// Compatibility flags are exchanged after the protocol negotiation when
-    /// both sides speak the binary handshake (protocol 30 or newer). They
-    /// describe optional behaviours supported by the sender. Upstream rsync
-    /// propagates future bits even when the local build does not understand
-    /// their semantics; callers can use [`CompatibilityFlags::has_unknown_bits`]
-    /// to detect that condition and surface downgraded diagnostics.
+    /// Exchanged after protocol negotiation when both sides speak the binary
+    /// handshake (protocol 30+). Upstream rsync propagates future bits even
+    /// when their semantics are unknown; use [`CompatibilityFlags::has_unknown_bits`]
+    /// to detect that condition.
     #[must_use]
     pub const fn remote_compatibility_flags(&self) -> CompatibilityFlags {
         self.remote_compatibility_flags
@@ -90,61 +80,9 @@ impl<R> BinaryHandshake<R> {
 
     /// Reports whether the caller's desired cap reduced the negotiated protocol version.
     ///
-    /// Upstream rsync clamps the negotiated protocol to the minimum of the peer's advertisement and
-    /// the caller's requested cap (as configured via `--protocol`). When the requested value is
-    /// lower than the remote protocol, the transfer is forced to speak the older version. This
-    /// helper exposes that condition so higher layers can surface diagnostics or adjust feature
-    /// negotiation in parity with the C implementation.
-    ///
-    /// # Examples
-    ///
-    /// Force the negotiation to protocol 29 even though the peer advertises 31. The helper reports
-    /// that the user-imposed cap took effect, mirroring the observable behaviour of
-    /// `rsync --protocol=29`.
-    ///
-    /// ```
-    /// use protocol::ProtocolVersion;
-    /// use rsync_io::negotiate_binary_session;
-    /// use std::io::{self, Cursor, Read, Write};
-    ///
-    /// #[derive(Debug)]
-    /// struct Loopback {
-    ///     reader: Cursor<Vec<u8>>,
-    ///     written: Vec<u8>,
-    /// }
-    ///
-    /// impl Loopback {
-    ///     fn new(advertised: ProtocolVersion) -> Self {
-    ///         let bytes = u32::from(advertised.as_u8()).to_le_bytes();
-    ///         Self { reader: Cursor::new(bytes.to_vec()), written: Vec::new() }
-    ///     }
-    /// }
-    ///
-    /// impl Read for Loopback {
-    ///     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-    ///         self.reader.read(buf)
-    ///     }
-    /// }
-    ///
-    /// impl Write for Loopback {
-    ///     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-    ///         self.written.extend_from_slice(buf);
-    ///         Ok(buf.len())
-    ///     }
-    ///
-    ///     fn flush(&mut self) -> io::Result<()> {
-    ///         Ok(())
-    ///     }
-    /// }
-    ///
-    /// let remote = ProtocolVersion::from_supported(31).unwrap();
-    /// let desired = ProtocolVersion::from_supported(29).unwrap();
-    /// let transport = Loopback::new(remote);
-    /// let handshake = negotiate_binary_session(transport, desired).unwrap();
-    ///
-    /// assert!(handshake.local_protocol_was_capped());
-    /// assert_eq!(handshake.negotiated_protocol(), desired);
-    /// ```
+    /// Upstream rsync clamps the negotiated protocol to the minimum of the
+    /// peer's advertisement and the caller's `--protocol` cap. Returns `true`
+    /// when the cap forced a downgrade.
     #[doc(alias = "--protocol")]
     #[must_use]
     pub const fn local_protocol_was_capped(&self) -> bool {
@@ -171,11 +109,8 @@ impl<R> BinaryHandshake<R> {
 
     /// Rehydrates a [`NegotiationPrologueSniffer`] using the captured negotiation snapshot.
     ///
-    /// The helper invokes [`NegotiationPrologueSniffer::rehydrate_from_parts`] with the buffered
-    /// transcript captured during negotiation, mirroring the functionality available via
-    /// [`BinaryHandshakeParts::stream_parts`]. Callers that retain the handshake wrapper can
-    /// therefore rebuild sniffers without unpacking the parts structure or replaying the underlying
-    /// transport, matching the ergonomics provided by the session-level helpers.
+    /// Invokes [`NegotiationPrologueSniffer::rehydrate_from_parts`] without
+    /// unpacking the parts structure or replaying the underlying transport.
     pub fn rehydrate_sniffer(
         &self,
         sniffer: &mut NegotiationPrologueSniffer,
@@ -254,10 +189,8 @@ impl<R> BinaryHandshake<R> {
 
     /// Reconstructs a [`BinaryHandshake`] from its components.
     ///
-    /// The helper complements [`Self::into_components`] by allowing callers to temporarily extract
-    /// the handshake metadata and replaying stream and later rebuild the wrapper without rerunning
-    /// the negotiation. Debug builds assert that the supplied stream captured a binary negotiation
-    /// so mismatched variants are detected early.
+    /// Complements [`Self::into_components`]. Debug builds assert that the
+    /// supplied stream captured a binary negotiation.
     #[must_use]
     pub fn from_components(
         remote_advertised: u32,
@@ -283,11 +216,8 @@ impl<R> BinaryHandshake<R> {
 
     /// Maps the inner transport while preserving the negotiated metadata.
     ///
-    /// This helper forwards to [`NegotiatedStream::map_inner`], allowing callers to
-    /// install additional instrumentation or adapters around the underlying
-    /// transport without losing the negotiated protocol versions. The replay
-    /// buffer captured during negotiation is retained so higher layers can
-    /// resume reading or writing immediately after the transformation.
+    /// Forwards to [`NegotiatedStream::map_inner`]; the replay buffer captured
+    /// during negotiation is retained.
     #[must_use]
     pub fn map_stream_inner<F, T>(self, map: F) -> BinaryHandshake<T>
     where
@@ -312,8 +242,8 @@ impl<R> BinaryHandshake<R> {
 
     /// Attempts to transform the inner transport while preserving the negotiated metadata.
     ///
-    /// The closure returns the replacement reader on success or a tuple containing the error and
-    /// original reader on failure, mirroring [`NegotiatedStream::try_map_inner`].
+    /// On failure the closure returns `(error, original_reader)`, mirroring
+    /// [`NegotiatedStream::try_map_inner`].
     pub fn try_map_stream_inner<F, T, E>(
         self,
         map: F,
@@ -351,10 +281,7 @@ impl<R> BinaryHandshake<R> {
 
     /// Decomposes the handshake into the negotiated protocol metadata and replaying stream parts.
     ///
-    /// Returning [`NegotiatedStreamParts`] allows higher layers to temporarily take ownership of
-    /// the buffered negotiation bytes (for example to wrap the underlying transport) without
-    /// dropping the recorded remote advertisement. The tuple mirrors
-    /// [`Self::into_components`], but hands back the split representation so callers can inspect or
+    /// Hands back a [`NegotiatedStreamParts`] so callers can inspect or
     /// transform the inner reader before reassembling a [`NegotiatedStream`].
     #[must_use]
     pub fn into_stream_parts(
@@ -387,11 +314,8 @@ impl<R> BinaryHandshake<R> {
 
     /// Reconstructs a [`BinaryHandshake`] from previously extracted stream parts.
     ///
-    /// Higher layers occasionally need to stash the negotiated protocol metadata while they wrap the
-    /// underlying transport with instrumentation or adapters. This helper accepts the values returned
-    /// by [`Self::into_stream_parts`] and rebuilds the handshake without rerunning the negotiation or
-    /// replaying buffered bytes. The negotiation decision is asserted in debug builds so binary and
-    /// legacy parts cannot be mixed inadvertently.
+    /// Accepts values returned by [`Self::into_stream_parts`]. Debug builds
+    /// assert the negotiation decision so binary and legacy parts cannot mix.
     #[must_use]
     pub fn from_stream_parts(
         remote_advertised: u32,

--- a/crates/rsync_io/src/daemon/types/handshake.rs
+++ b/crates/rsync_io/src/daemon/types/handshake.rs
@@ -8,14 +8,9 @@ use std::collections::TryReserveError;
 
 /// Result of performing the legacy ASCII daemon negotiation.
 ///
-/// The structure exposes the negotiated protocol version together with the
-/// parsed greeting metadata while retaining the replaying stream so higher
-/// layers can continue consuming control messages or file lists.
-///
-/// When the underlying transport implements [`Clone`], the handshake can be
-/// cloned to stage multiple consumers for the same negotiated session. The
-/// replay buffer, greeting, and negotiated protocol are duplicated so both
-/// instances progress independently without rereading from the transport.
+/// Exposes the negotiated protocol version and parsed greeting while retaining
+/// the replaying stream so higher layers can continue consuming control
+/// messages or file lists.
 #[doc(alias = "@RSYNCD")]
 #[derive(Clone, Debug)]
 pub struct LegacyDaemonHandshake<R> {
@@ -33,9 +28,8 @@ impl<R> LegacyDaemonHandshake<R> {
 
     /// Returns the protocol version the client advertised to the daemon.
     ///
-    /// For the legacy exchange the client echoes the final negotiated protocol back to the server, so
-    /// this value mirrors [`Self::negotiated_protocol`] while exposing the same API surface as the
-    /// binary handshake helpers that track the client's advertisement explicitly.
+    /// Mirrors [`Self::negotiated_protocol`] (the legacy client echoes the
+    /// final value); exposed for API symmetry with the binary handshake.
     #[doc(alias = "--protocol")]
     #[must_use]
     pub const fn local_advertised_protocol(&self) -> ProtocolVersion {
@@ -77,58 +71,9 @@ impl<R> LegacyDaemonHandshake<R> {
 
     /// Reports whether the caller's desired cap reduced the negotiated protocol version.
     ///
-    /// The negotiated protocol equals the minimum of the daemon's advertised protocol and the
-    /// caller's requested cap (configured via `--protocol`). When the caller limits the session to an
-    /// older version, certain protocol features become unavailable. This helper mirrors upstream
-    /// rsync by exposing that condition so higher layers can render matching diagnostics.
-    ///
-    /// # Examples
-    ///
-    /// Limit the daemon negotiation to protocol 29 even though the server banner advertises 31.
-    ///
-    /// ```
-    /// use protocol::ProtocolVersion;
-    /// use rsync_io::negotiate_legacy_daemon_session;
-    /// use std::io::{self, Cursor, Read, Write};
-    ///
-    /// #[derive(Debug)]
-    /// struct MemoryTransport {
-    ///     reader: Cursor<Vec<u8>>,
-    ///     written: Vec<u8>,
-    ///     flushes: usize,
-    /// }
-    ///
-    /// impl MemoryTransport {
-    ///     fn new(input: &[u8]) -> Self {
-    ///         Self { reader: Cursor::new(input.to_vec()), written: Vec::new(), flushes: 0 }
-    ///     }
-    /// }
-    ///
-    /// impl Read for MemoryTransport {
-    ///     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-    ///         self.reader.read(buf)
-    ///     }
-    /// }
-    ///
-    /// impl Write for MemoryTransport {
-    ///     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-    ///         self.written.extend_from_slice(buf);
-    ///         Ok(buf.len())
-    ///     }
-    ///
-    ///     fn flush(&mut self) -> io::Result<()> {
-    ///         self.flushes += 1;
-    ///         Ok(())
-    ///     }
-    /// }
-    ///
-    /// let desired = ProtocolVersion::from_supported(29).unwrap();
-    /// let transport = MemoryTransport::new(b"@RSYNCD: 31.0\n");
-    /// let handshake = negotiate_legacy_daemon_session(transport, desired).unwrap();
-    ///
-    /// assert!(handshake.local_protocol_was_capped());
-    /// assert_eq!(handshake.negotiated_protocol(), desired);
-    /// ```
+    /// The negotiated protocol equals the minimum of the daemon's advertisement
+    /// and the caller's `--protocol` cap. Returns `true` when the cap forced a
+    /// downgrade.
     #[doc(alias = "--protocol")]
     #[must_use]
     pub const fn local_protocol_was_capped(&self) -> bool {
@@ -174,11 +119,8 @@ impl<R> LegacyDaemonHandshake<R> {
 
     /// Rehydrates a [`NegotiationPrologueSniffer`] using the captured negotiation snapshot.
     ///
-    /// The helper mirrors the functionality exposed by
-    /// [`LegacyDaemonHandshakeParts::stream_parts`], reusing
-    /// [`NegotiationPrologueSniffer::rehydrate_from_parts`] with the buffered transcript captured
-    /// during negotiation. Callers can therefore rebuild sniffers without decomposing the session
-    /// into parts or replaying the underlying transport.
+    /// Invokes [`NegotiationPrologueSniffer::rehydrate_from_parts`] without
+    /// decomposing the session into parts or replaying the underlying transport.
     pub fn rehydrate_sniffer(
         &self,
         sniffer: &mut NegotiationPrologueSniffer,

--- a/crates/rsync_io/src/daemon/types/parts.rs
+++ b/crates/rsync_io/src/daemon/types/parts.rs
@@ -5,32 +5,9 @@ use protocol::{LegacyDaemonGreetingOwned, ProtocolVersion};
 
 /// Decomposed components of a [`LegacyDaemonHandshake`].
 ///
-/// The structure groups the parsed greeting, negotiated protocol, and replaying
-/// stream parts so callers can temporarily take ownership of the components
-/// while instrumenting the transport.
-///
-/// # Examples
-///
-/// ```
-/// use protocol::ProtocolVersion;
-/// use rsync_io::{negotiate_legacy_daemon_session, LegacyDaemonHandshakeParts};
-/// use std::io::Cursor;
-///
-/// let transport = Cursor::new(b"@RSYNCD: 31.0\n".to_vec());
-/// let handshake = negotiate_legacy_daemon_session(transport, ProtocolVersion::NEWEST).unwrap();
-///
-/// let parts = handshake.into_parts();
-/// assert_eq!(
-///     parts.server_protocol(),
-///     ProtocolVersion::from_supported(31).unwrap()
-/// );
-///
-/// let rebuilt = parts.into_handshake();
-/// assert_eq!(
-///     rebuilt.server_protocol(),
-///     ProtocolVersion::from_supported(31).unwrap()
-/// );
-/// ```
+/// Groups the parsed greeting, negotiated protocol, and replaying stream parts
+/// so callers can temporarily take ownership of the components while
+/// instrumenting the transport.
 #[doc(alias = "@RSYNCD")]
 #[derive(Clone, Debug)]
 pub struct LegacyDaemonHandshakeParts<R> {
@@ -78,9 +55,8 @@ impl<R> LegacyDaemonHandshakeParts<R> {
 
     /// Returns the protocol version the client advertised to the daemon.
     ///
-    /// For the legacy handshake the client echoes the final negotiated protocol back to the server, so
-    /// the value mirrors [`Self::negotiated_protocol`] but is exposed explicitly to keep the API shape
-    /// aligned with the binary negotiation helpers.
+    /// Mirrors [`Self::negotiated_protocol`] (the legacy handshake echoes the
+    /// final value); exposed explicitly to match the binary helper shape.
     #[doc(alias = "--protocol")]
     #[must_use]
     pub const fn local_advertised_protocol(&self) -> ProtocolVersion {
@@ -88,10 +64,6 @@ impl<R> LegacyDaemonHandshakeParts<R> {
     }
 
     /// Reports whether the daemon advertised a protocol newer than the supported range.
-    ///
-    /// The helper mirrors [`LegacyDaemonHandshake::remote_protocol_was_clamped`] so callers that
-    /// operate on the decomposed parts retain access to the same diagnostics without rebuilding the
-    /// wrapper first.
     #[must_use]
     pub const fn remote_protocol_was_clamped(&self) -> bool {
         self.remote_advertisement().was_clamped()
@@ -108,10 +80,8 @@ impl<R> LegacyDaemonHandshakeParts<R> {
 
     /// Reports whether the negotiated protocol was reduced by the caller-provided cap.
     ///
-    /// This complements [`LegacyDaemonHandshake::local_protocol_was_capped`] when higher layers
-    /// inspect the parts structure before reconstructing the handshake. The check mirrors
-    /// `rsync --protocol=<version>`: if the caller requests an older protocol than the daemon
-    /// advertised, the negotiated session is forced to run at the downgraded version.
+    /// Mirrors `rsync --protocol=<version>`: when the caller requests an older
+    /// protocol than the daemon advertised the session is forced to downgrade.
     #[doc(alias = "--protocol")]
     #[must_use]
     pub const fn local_protocol_was_capped(&self) -> bool {
@@ -138,126 +108,8 @@ impl<R> LegacyDaemonHandshakeParts<R> {
 
     /// Maps the inner transport while preserving the negotiated metadata and greeting.
     ///
-    /// The helper mirrors [`LegacyDaemonHandshake::map_stream_inner`] but operates on the
-    /// decomposed parts, making it convenient to wrap the underlying transport before rebuilding
-    /// the handshake. The replay buffer and parsed greeting remain intact so higher layers can
-    /// continue processing daemon responses without rerunning the negotiation.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use protocol::ProtocolVersion;
-    /// use rsync_io::{negotiate_legacy_daemon_session, LegacyDaemonHandshakeParts};
-    /// use std::io::{self, Cursor, Read, Write};
-    ///
-    /// #[derive(Debug)]
-    /// struct MemoryTransport {
-    ///     reader: Cursor<Vec<u8>>,
-    ///     written: Vec<u8>,
-    ///     flushes: usize,
-    /// }
-    ///
-    /// impl MemoryTransport {
-    ///     fn new(input: &[u8]) -> Self {
-    ///         Self {
-    ///             reader: Cursor::new(input.to_vec()),
-    ///             written: Vec::new(),
-    ///             flushes: 0,
-    ///         }
-    ///     }
-    ///
-    ///     fn written(&self) -> &[u8] {
-    ///         &self.written
-    ///     }
-    ///
-    ///     fn flushes(&self) -> usize {
-    ///         self.flushes
-    ///     }
-    /// }
-    ///
-    /// impl Read for MemoryTransport {
-    ///     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-    ///         self.reader.read(buf)
-    ///     }
-    /// }
-    ///
-    /// impl Write for MemoryTransport {
-    ///     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-    ///         self.written.extend_from_slice(buf);
-    ///         Ok(buf.len())
-    ///     }
-    ///
-    ///     fn flush(&mut self) -> io::Result<()> {
-    ///         self.flushes += 1;
-    ///         Ok(())
-    ///     }
-    /// }
-    ///
-    /// #[derive(Debug)]
-    /// struct Instrumented {
-    ///     inner: MemoryTransport,
-    ///     writes: Vec<u8>,
-    ///     flushes: usize,
-    /// }
-    ///
-    /// impl Instrumented {
-    ///     fn new(inner: MemoryTransport) -> Self {
-    ///         Self {
-    ///             inner,
-    ///             writes: Vec::new(),
-    ///             flushes: 0,
-    ///         }
-    ///     }
-    ///
-    ///     fn writes(&self) -> &[u8] {
-    ///         &self.writes
-    ///     }
-    ///
-    ///     fn flushes(&self) -> usize {
-    ///         self.flushes
-    ///     }
-    ///
-    ///     fn into_inner(self) -> MemoryTransport {
-    ///         self.inner
-    ///     }
-    /// }
-    ///
-    /// impl Read for Instrumented {
-    ///     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-    ///         self.inner.read(buf)
-    ///     }
-    /// }
-    ///
-    /// impl Write for Instrumented {
-    ///     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-    ///         self.writes.extend_from_slice(buf);
-    ///         self.inner.write(buf)
-    ///     }
-    ///
-    ///     fn flush(&mut self) -> io::Result<()> {
-    ///         self.flushes += 1;
-    ///         self.inner.flush()
-    ///     }
-    /// }
-    ///
-    /// let transport = MemoryTransport::new(b"@RSYNCD: 31.0\n");
-    /// let parts = negotiate_legacy_daemon_session(transport, ProtocolVersion::NEWEST)
-    ///     .expect("handshake succeeds")
-    ///     .into_parts();
-    ///
-    /// let instrumented = parts.map_stream_inner(Instrumented::new);
-    /// assert_eq!(instrumented.server_protocol(), ProtocolVersion::from_supported(31).unwrap());
-    ///
-    /// let mut handshake = instrumented.into_handshake();
-    /// handshake.stream_mut().write_all(b"OK\n").unwrap();
-    /// handshake.stream_mut().flush().unwrap();
-    ///
-    /// let instrumented = handshake.into_stream().into_inner();
-    /// assert_eq!(instrumented.writes(), b"OK\n");
-    /// assert_eq!(instrumented.flushes(), 1);
-    /// let inner = instrumented.into_inner();
-    /// assert_eq!(inner.written(), b"@RSYNCD: 31.0\nOK\n");
-    /// ```
+    /// Counterpart to [`LegacyDaemonHandshake::map_stream_inner`] operating on
+    /// the decomposed parts. The replay buffer and parsed greeting are retained.
     #[must_use]
     pub fn map_stream_inner<F, T>(self, map: F) -> LegacyDaemonHandshakeParts<T>
     where
@@ -278,67 +130,8 @@ impl<R> LegacyDaemonHandshakeParts<R> {
 
     /// Attempts to transform the inner transport while preserving the negotiated metadata.
     ///
-    /// On success the new transport replaces the previous one and the replay buffer remains
-    /// available. If the mapping fails, the original parts structure is returned alongside the
-    /// error so callers can continue using the negotiated session without repeating the handshake.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use protocol::ProtocolVersion;
-    /// use rsync_io::{negotiate_legacy_daemon_session, LegacyDaemonHandshakeParts};
-    /// use std::io::{self, Cursor, Read, Write};
-    ///
-    /// #[derive(Debug)]
-    /// struct MemoryTransport {
-    ///     reader: Cursor<Vec<u8>>,
-    ///     written: Vec<u8>,
-    ///     flushes: usize,
-    /// }
-    ///
-    /// impl MemoryTransport {
-    ///     fn new(input: &[u8]) -> Self {
-    ///         Self {
-    ///             reader: Cursor::new(input.to_vec()),
-    ///             written: Vec::new(),
-    ///             flushes: 0,
-    ///         }
-    ///     }
-    /// }
-    ///
-    /// impl Read for MemoryTransport {
-    ///     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-    ///         self.reader.read(buf)
-    ///     }
-    /// }
-    ///
-    /// impl Write for MemoryTransport {
-    ///     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-    ///         self.written.extend_from_slice(buf);
-    ///         Ok(buf.len())
-    ///     }
-    ///
-    ///     fn flush(&mut self) -> io::Result<()> {
-    ///         self.flushes += 1;
-    ///         Ok(())
-    ///     }
-    /// }
-    ///
-    /// let transport = MemoryTransport::new(b"@RSYNCD: 31.0\n");
-    /// let parts = negotiate_legacy_daemon_session(transport, ProtocolVersion::NEWEST)
-    ///     .expect("handshake succeeds")
-    ///     .into_parts();
-    ///
-    /// let err = parts
-    ///     .try_map_stream_inner(|inner| -> Result<MemoryTransport, (io::Error, MemoryTransport)> {
-    ///         Err((io::Error::new(io::ErrorKind::Other, "wrap failed"), inner))
-    ///     })
-    ///     .expect_err("mapping fails");
-    /// assert_eq!(err.error().kind(), io::ErrorKind::Other);
-    ///
-    /// let restored = err.into_original().into_handshake();
-    /// assert_eq!(restored.server_protocol(), ProtocolVersion::from_supported(31).unwrap());
-    /// ```
+    /// On failure the original parts structure is returned alongside the error
+    /// so callers can continue using the negotiated session.
     pub fn try_map_stream_inner<F, T, E>(
         self,
         map: F,
@@ -367,31 +160,7 @@ impl<R> LegacyDaemonHandshakeParts<R> {
     /// Decomposes the parts structure into the parsed greeting, negotiated protocol, and
     /// replaying stream.
     ///
-    /// The tuple mirrors [`LegacyDaemonHandshake::into_components`] but operates on the decomposed
-    /// representation returned by [`LegacyDaemonHandshake::into_parts`]. Higher layers can therefore
-    /// inspect the greeting metadata or wrap the replaying stream without first rebuilding the full
-    /// handshake wrapper.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use protocol::{NegotiationPrologue, ProtocolVersion};
-    /// use rsync_io::negotiate_legacy_daemon_session;
-    /// use std::io::Cursor;
-    ///
-    /// let transport = Cursor::new(b"@RSYNCD: 31.0\n".to_vec());
-    /// let parts = negotiate_legacy_daemon_session(transport, ProtocolVersion::NEWEST)
-    ///     .expect("legacy negotiation succeeds")
-    ///     .into_parts();
-    ///
-    /// let expected_protocol = parts.server_protocol();
-    /// let (greeting, negotiated_protocol, stream_parts) = parts.into_components();
-    ///
-    /// assert_eq!(greeting.protocol(), expected_protocol);
-    /// assert_eq!(negotiated_protocol, expected_protocol);
-    /// assert_eq!(stream_parts.decision(), NegotiationPrologue::LegacyAscii);
-    /// assert_eq!(stream_parts.sniffed_prefix_len(), protocol::LEGACY_DAEMON_PREFIX_LEN);
-    /// ```
+    /// Owned counterpart to [`LegacyDaemonHandshake::into_components`].
     #[must_use]
     pub fn into_components(
         self,

--- a/crates/rsync_io/src/negotiation/stream/buffer_access.rs
+++ b/crates/rsync_io/src/negotiation/stream/buffer_access.rs
@@ -25,23 +25,9 @@ impl<R> NegotiatedStream<R> {
 
     /// Collects the buffered negotiation transcript into an owned [`Vec<u8>`].
     ///
-    /// The helper mirrors [`Self::buffered`] but allocates a new vector sized exactly for the
-    /// captured transcript. It reserves the necessary capacity via [`Vec::try_reserve_exact`]
-    /// internally, propagating allocation failures as [`TryReserveError`]. Callers that need to own
-    /// the replay bytes-for example to stash them in a log or retry a handshake-can use this method
-    /// without first preparing a scratch buffer.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use rsync_io::sniff_negotiation_stream;
-    /// use std::io::Cursor;
-    ///
-    /// let stream = sniff_negotiation_stream(Cursor::new(b"@RSYNCD: 31.0\nreply".to_vec()))
-    ///     .expect("sniff succeeds");
-    /// let owned = stream.buffered_to_vec().expect("allocation succeeds");
-    /// assert_eq!(owned.as_slice(), stream.buffered());
-    /// ```
+    /// Allocates a new vector sized exactly for the captured transcript via
+    /// [`Vec::try_reserve_exact`], propagating allocation failures as
+    /// [`TryReserveError`].
     pub fn buffered_to_vec(&self) -> Result<Vec<u8>, TryReserveError> {
         NegotiationBufferAccess::buffered_to_vec(self)
     }
@@ -58,37 +44,16 @@ impl<R> NegotiatedStream<R> {
 
     /// Copies the buffered negotiation data into a caller-provided vector without consuming it.
     ///
-    /// The helper mirrors [`Self::buffered`] but writes into an owned [`Vec<u8>`], allowing callers
-    /// to reuse heap storage between sessions. Any additional capacity required to hold the
-    /// buffered bytes is reserved via [`Vec::try_reserve`], so allocation failures are surfaced
-    /// through [`TryReserveError`]. The vector is cleared before the bytes are appended, matching
-    /// upstream rsync's behaviour where replay buffers replace any previous contents.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use rsync_io::sniff_negotiation_stream;
-    /// use std::io::Cursor;
-    ///
-    /// let stream = sniff_negotiation_stream(Cursor::new(b"@RSYNCD: 31.0\nreply".to_vec()))
-    ///     .expect("sniff succeeds");
-    /// let mut replay = Vec::new();
-    /// stream
-    ///     .copy_buffered_into_vec(&mut replay)
-    ///     .expect("vector can reserve space for replay bytes");
-    /// assert_eq!(replay.as_slice(), stream.buffered());
-    /// ```
+    /// The vector is cleared before the bytes are appended; capacity is reserved
+    /// via [`Vec::try_reserve`], so allocation failures surface as [`TryReserveError`].
     pub fn copy_buffered_into_vec(&self, target: &mut Vec<u8>) -> Result<usize, TryReserveError> {
         NegotiationBufferAccess::copy_buffered_into_vec(self, target)
     }
 
     /// Copies the unread portion of the buffered negotiation data into `target` without consuming it.
     ///
-    /// The helper mirrors [`Self::copy_buffered_into_vec`] but restricts the copy to the bytes that
-    /// have not yet been replayed. This is useful when higher layers only need access to the
-    /// remaining transcript (for example to resume reading the legacy greeting) while ignoring the
-    /// already-consumed prefix. The destination vector is cleared before the bytes are appended and
-    /// resized as necessary using [`Vec::try_reserve`].
+    /// Restricts the copy to bytes that have not yet been replayed. The vector
+    /// is cleared before the bytes are appended and resized via [`Vec::try_reserve`].
     pub fn copy_buffered_remaining_into_vec(
         &self,
         target: &mut Vec<u8>,
@@ -98,60 +63,23 @@ impl<R> NegotiatedStream<R> {
 
     /// Collects the unread portion of the buffered negotiation transcript into a new [`Vec<u8>`].
     ///
-    /// The helper mirrors [`Self::buffered_remainder`] but returns an owned buffer containing only
-    /// the bytes that still need to be replayed. Allocation failures are reported via
-    /// [`TryReserveError`], matching the semantics of [`Self::buffered_to_vec`].
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use rsync_io::sniff_negotiation_stream;
-    /// use std::io::Cursor;
-    ///
-    /// let stream = sniff_negotiation_stream(Cursor::new(b"@RSYNCD: 31.0\nreply".to_vec()))
-    ///     .expect("sniff succeeds");
-    /// let remainder = stream
-    ///     .buffered_remaining_to_vec()
-    ///     .expect("allocation succeeds");
-    /// assert_eq!(remainder.as_slice(), stream.buffered_remainder());
-    /// ```
+    /// Returns an owned buffer containing only bytes that still need to be replayed.
+    /// Allocation failures surface as [`TryReserveError`].
     pub fn buffered_remaining_to_vec(&self) -> Result<Vec<u8>, TryReserveError> {
         NegotiationBufferAccess::buffered_remaining_to_vec(self)
     }
 
     /// Appends the buffered negotiation data to a caller-provided vector without consuming it.
     ///
-    /// The helper is identical to [`Self::copy_buffered_into_vec`] except that it preserves any
-    /// existing contents in `target`. This is useful for log buffers that accumulate handshake
-    /// transcripts alongside additional context. The vector reserves enough capacity to fit the
-    /// buffered bytes via [`Vec::try_reserve`]; on success the method returns the number of bytes
-    /// appended. The replay cursor remains unchanged so callers may continue reading from the
-    /// stream afterwards.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use rsync_io::sniff_negotiation_stream;
-    /// use std::io::Cursor;
-    ///
-    /// let stream = sniff_negotiation_stream(Cursor::new(b"@RSYNCD: 31.0\nreply".to_vec()))
-    ///     .expect("sniff succeeds");
-    /// let mut log = b"log: ".to_vec();
-    /// stream
-    ///     .extend_buffered_into_vec(&mut log)
-    ///     .expect("vector can reserve space for replay bytes");
-    /// assert_eq!(log, b"log: @RSYNCD:");
-    /// ```
+    /// Like [`Self::copy_buffered_into_vec`] but preserves any existing contents
+    /// in `target`. The replay cursor is unchanged.
     pub fn extend_buffered_into_vec(&self, target: &mut Vec<u8>) -> Result<usize, TryReserveError> {
         NegotiationBufferAccess::extend_buffered_into_vec(self, target)
     }
 
     /// Appends the unread portion of the buffered negotiation transcript to `target` without consuming it.
     ///
-    /// The helper is the remaining-byte counterpart to [`Self::extend_buffered_into_vec`]. It reserves
-    /// space for and appends only the bytes that have not yet been replayed, leaving any previously
-    /// consumed prefix untouched. This mirrors upstream rsync's behaviour where diagnostics frequently
-    /// record just the pending handshake payload.
+    /// Remaining-byte counterpart to [`Self::extend_buffered_into_vec`].
     pub fn extend_buffered_remaining_into_vec(
         &self,
         target: &mut Vec<u8>,
@@ -161,12 +89,8 @@ impl<R> NegotiatedStream<R> {
 
     /// Returns the sniffed negotiation prefix together with any buffered remainder.
     ///
-    /// The tuple mirrors the view exposed by
-    /// [`protocol::NegotiationPrologueSniffer::buffered_split`],
-    /// allowing higher layers to borrow both slices simultaneously when staging replay
-    /// buffers. The first element contains the portion of the canonical prefix that has not
-    /// yet been replayed, while the second slice exposes any additional payload that
-    /// arrived alongside the detection bytes and remains buffered.
+    /// The first element is the unread portion of the canonical prefix; the
+    /// second is any additional payload captured alongside the detection bytes.
     #[must_use]
     pub fn buffered_split(&self) -> (&[u8], &[u8]) {
         NegotiationBufferAccess::buffered_split(self)
@@ -180,25 +104,9 @@ impl<R> NegotiatedStream<R> {
 
     /// Returns how many buffered bytes have already been replayed.
     ///
-    /// The counter starts at zero and increases as callers consume data through
-    /// [`std::io::Read::read`], [`std::io::Read::read_vectored`], or
-    /// [`std::io::BufRead::consume`]. Once it matches [`Self::buffered_len`], the
-    /// replay buffer has been exhausted and subsequent reads operate on the inner transport.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use rsync_io::sniff_negotiation_stream;
-    /// use std::io::{Cursor, Read};
-    ///
-    /// let mut stream = sniff_negotiation_stream(Cursor::new(b"@RSYNCD: 31.0\nreply".to_vec()))
-    ///     .expect("sniff succeeds");
-    /// assert_eq!(stream.buffered_consumed(), 0);
-    ///
-    /// let mut buf = [0u8; 4];
-    /// stream.read(&mut buf).expect("buffered bytes are available");
-    /// assert_eq!(stream.buffered_consumed(), 4);
-    /// ```
+    /// Increases as callers consume data via [`std::io::Read::read`],
+    /// [`std::io::Read::read_vectored`], or [`std::io::BufRead::consume`].
+    /// Once it matches [`Self::buffered_len`] the replay buffer is exhausted.
     #[must_use]
     pub fn buffered_consumed(&self) -> usize {
         NegotiationBufferAccess::buffered_consumed(self)
@@ -206,11 +114,7 @@ impl<R> NegotiatedStream<R> {
 
     /// Returns the portion of the buffered negotiation transcript that has already been replayed.
     ///
-    /// The slice mirrors [`Self::buffered_consumed`] but exposes the actual bytes that were drained
-    /// from the replay buffer. This is useful for diagnostics that need to log the full transcript or
-    /// for higher layers that compare the consumed prefix against known greetings without
-    /// recalculating slice ranges manually. The returned slice is empty until data is read from the
-    /// [`NegotiatedStream`].
+    /// Empty until data is read from the [`NegotiatedStream`].
     #[must_use]
     pub fn buffered_consumed_slice(&self) -> &[u8] {
         NegotiationBufferAccess::buffered_consumed_slice(self)
@@ -218,11 +122,8 @@ impl<R> NegotiatedStream<R> {
 
     /// Returns the length of the sniffed negotiation prefix.
     ///
-    /// The value is the number of bytes that were required to classify the
-    /// negotiation prologue. For legacy ASCII handshakes it matches the length
-    /// of the canonical `@RSYNCD:` prefix. The method complements
-    /// [`Self::sniffed_prefix_remaining`], which tracks how many of those bytes
-    /// have yet to be replayed.
+    /// For legacy ASCII handshakes this matches the length of the canonical
+    /// `@RSYNCD:` prefix. Pairs with [`Self::sniffed_prefix_remaining`].
     #[must_use]
     pub const fn sniffed_prefix_len(&self) -> usize {
         self.buffer_storage().sniffed_prefix_len()
@@ -230,10 +131,8 @@ impl<R> NegotiatedStream<R> {
 
     /// Returns how many bytes from the sniffed negotiation prefix remain buffered.
     ///
-    /// The value decreases as callers consume the replay data (for example via
-    /// [`std::io::Read::read`] or [`std::io::BufRead::consume`]). A return value of zero indicates that
-    /// the entire detection prefix has been drained and subsequent reads operate
-    /// directly on the inner transport.
+    /// Decreases as callers consume the replay data. Zero means the detection
+    /// prefix has been drained and subsequent reads operate on the inner transport.
     #[must_use]
     pub fn sniffed_prefix_remaining(&self) -> usize {
         NegotiationBufferAccess::sniffed_prefix_remaining(self)
@@ -241,11 +140,8 @@ impl<R> NegotiatedStream<R> {
 
     /// Reports whether the canonical legacy negotiation prefix has been fully buffered.
     ///
-    /// For legacy daemon sessions this becomes `true` once the entire `@RSYNCD:` marker has been
-    /// captured during negotiation sniffing. Binary negotiations never observe that prefix, so the
-    /// method returns `false` for them. The return value is unaffected by how many buffered bytes
-    /// have already been consumed, allowing higher layers to detect whether they may replay the
-    /// prefix into the legacy greeting parser without issuing additional reads from the transport.
+    /// `true` once the entire `@RSYNCD:` marker has been captured. Binary
+    /// negotiations always return `false`. Unaffected by consumption.
     #[must_use]
     pub fn legacy_prefix_complete(&self) -> bool {
         NegotiationBufferAccess::legacy_prefix_complete(self)
@@ -259,31 +155,8 @@ impl<R> NegotiatedStream<R> {
 
     /// Returns the portion of the buffered negotiation data that has not been consumed yet.
     ///
-    /// The slice begins at the current replay cursor and includes any unread bytes from the
-    /// sniffed negotiation prefix followed by buffered payload that arrived alongside the
-    /// detection prologue. It mirrors [`std::io::BufRead::fill_buf`] behaviour without requiring a
-    /// mutable
-    /// reference, which is useful when callers only need to inspect the remaining transcript for
-    /// logging or diagnostics.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use rsync_io::sniff_negotiation_stream;
-    /// use std::io::{Cursor, Read};
-    ///
-    /// let mut stream =
-    ///     sniff_negotiation_stream(Cursor::new(b"@RSYNCD: 31.0\nreply".to_vec()))
-    ///         .expect("sniff succeeds");
-    /// let expected = stream.buffered().to_vec();
-    /// assert_eq!(stream.buffered_remaining_slice(), expected.as_slice());
-    ///
-    /// let mut consumed = [0u8; 4];
-    /// stream
-    ///     .read_exact(&mut consumed)
-    ///     .expect("buffered bytes are readable");
-    /// assert_eq!(stream.buffered_remaining_slice(), &expected[4..]);
-    /// ```
+    /// Mirrors [`std::io::BufRead::fill_buf`] but takes `&self` so callers can
+    /// inspect the remaining transcript without borrowing mutably.
     #[must_use]
     pub fn buffered_remaining_slice(&self) -> &[u8] {
         NegotiationBufferAccess::buffered_remaining_slice(self)
@@ -291,10 +164,8 @@ impl<R> NegotiatedStream<R> {
 
     /// Returns the unread portion of the buffered negotiation data as vectored slices.
     ///
-    /// The slices mirror [`Self::buffered_remaining_slice`] but expose the replay data in a form
-    /// that integrates with vectored writers. When the sniffed prefix has been partially consumed,
-    /// the first slice covers the remaining prefix bytes while the second slice contains any
-    /// buffered payload.
+    /// When the sniffed prefix has been partially consumed, the first slice
+    /// covers remaining prefix bytes and the second slice covers buffered payload.
     #[must_use]
     pub fn buffered_remaining_vectored(&self) -> NegotiationBufferedSlices<'_> {
         NegotiationBufferAccess::buffered_remaining_vectored(self)
@@ -302,60 +173,23 @@ impl<R> NegotiatedStream<R> {
 
     /// Copies the buffered negotiation prefix and any captured remainder into `target`.
     ///
-    /// The helper provides read-only access to the bytes that were observed while detecting the
-    /// negotiation style without consuming them. Callers can therefore inspect, log, or cache the
-    /// handshake transcript while continuing to rely on the replaying [`std::io::Read`] implementation
-    /// for
-    /// subsequent parsing. The destination vector is cleared before new data is written; its
-    /// capacity is grown as needed and the resulting length is returned for convenience.
+    /// The destination vector is cleared before new data is written; capacity is
+    /// grown as needed and the resulting length is returned.
     ///
     /// # Errors
     ///
-    /// Propagates [`TryReserveError`] when the destination vector cannot be grown to hold the
-    /// buffered bytes. On failure `target` retains its previous contents so callers can recover or
-    /// surface the allocation error.
+    /// Propagates [`TryReserveError`] when the vector cannot be grown. On
+    /// failure `target` retains its previous contents.
     pub fn copy_buffered_into(&self, target: &mut Vec<u8>) -> Result<usize, TryReserveError> {
         NegotiationBufferAccess::copy_buffered_into(self, target)
     }
 
     /// Copies the buffered negotiation data into the provided vectored buffers without consuming it.
     ///
-    /// The helper mirrors [`Self::copy_buffered_into_slice`] but operates on a slice of
-    /// [`IoSliceMut`], allowing callers to scatter the replay bytes across multiple scratch buffers
-    /// without reallocating. This is particularly useful when staging transcript snapshots inside
-    /// pre-allocated ring buffers or logging structures while keeping the replay cursor untouched.
-    ///
     /// # Errors
     ///
-    /// Returns [`BufferedCopyTooSmall`] when the combined capacity of `bufs` is smaller than the
-    /// buffered negotiation payload. On success the buffers are populated sequentially and the total
-    /// number of written bytes is returned.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use rsync_io::sniff_negotiation_stream;
-    /// use std::io::{Cursor, IoSliceMut};
-    ///
-    /// let stream = sniff_negotiation_stream(Cursor::new(b"@RSYNCD: 31.0\nreply".to_vec()))
-    ///     .expect("sniff succeeds");
-    /// let expected = stream.buffered().to_vec();
-    /// let mut head = [0u8; 12];
-    /// let mut tail = [0u8; 32];
-    /// let mut bufs = [IoSliceMut::new(&mut head), IoSliceMut::new(&mut tail)];
-    /// let copied = stream
-    ///     .copy_buffered_into_vectored(&mut bufs)
-    ///     .expect("buffers are large enough");
-    ///
-    /// let prefix_len = head.len().min(copied);
-    /// let mut assembled = Vec::new();
-    /// assembled.extend_from_slice(&head[..prefix_len]);
-    /// let remainder_len = copied - prefix_len;
-    /// if remainder_len > 0 {
-    ///     assembled.extend_from_slice(&tail[..remainder_len]);
-    /// }
-    /// assert_eq!(assembled, expected);
-    /// ```
+    /// Returns [`BufferedCopyTooSmall`] when the combined capacity of `bufs` is
+    /// smaller than the buffered negotiation payload.
     pub fn copy_buffered_into_vectored(
         &self,
         bufs: &mut [IoSliceMut<'_>],
@@ -373,11 +207,8 @@ impl<R> NegotiatedStream<R> {
 
     /// Copies the buffered negotiation data into the caller-provided slice without consuming it.
     ///
-    /// This mirrors [`Self::copy_buffered_into`] but avoids reallocating a [`Vec`]. Callers that
-    /// stage replay data on the stack or inside fixed-size scratch buffers can therefore reuse
-    /// their storage while keeping the sniffed bytes untouched. When the destination cannot hold
-    /// the buffered data, a [`BufferedCopyTooSmall`] error is returned and the slice remains
-    /// unchanged.
+    /// Returns [`BufferedCopyTooSmall`] when the destination is too small; the
+    /// slice is left unchanged on failure.
     pub fn copy_buffered_into_slice(
         &self,
         target: &mut [u8],
@@ -387,9 +218,8 @@ impl<R> NegotiatedStream<R> {
 
     /// Copies the unread portion of the buffered negotiation data into `target` without consuming it.
     ///
-    /// Unlike [`Self::copy_buffered_into_slice`], which copies the entire transcript, this helper
-    /// restricts the operation to bytes that have not yet been replayed. The slice remains unchanged
-    /// when it is too small to hold the remaining payload.
+    /// Restricts the operation to bytes that have not yet been replayed; the
+    /// slice is left unchanged on failure.
     pub fn copy_buffered_remaining_into_slice(
         &self,
         target: &mut [u8],
@@ -399,9 +229,8 @@ impl<R> NegotiatedStream<R> {
 
     /// Copies the buffered negotiation data into a caller-provided array without consuming it.
     ///
-    /// The helper mirrors [`Self::copy_buffered_into_slice`] but accepts a fixed-size array
-    /// directly, allowing stack-allocated scratch storage to be reused without converting it into a
-    /// mutable slice at the call site.
+    /// Like [`Self::copy_buffered_into_slice`] but accepts a fixed-size array
+    /// to avoid an explicit conversion at the call site.
     pub fn copy_buffered_into_array<const N: usize>(
         &self,
         target: &mut [u8; N],
@@ -419,9 +248,7 @@ impl<R> NegotiatedStream<R> {
 
     /// Streams the buffered negotiation data into the provided writer without consuming it.
     ///
-    /// The buffered bytes are written exactly once, mirroring upstream rsync's behaviour when the
-    /// handshake transcript is echoed into logs or diagnostics. Any I/O error reported by the
-    /// writer is propagated unchanged.
+    /// Any I/O error reported by the writer is propagated unchanged.
     pub fn copy_buffered_into_writer<W: Write>(&self, target: &mut W) -> io::Result<usize> {
         NegotiationBufferAccess::copy_buffered_into_writer(self, target)
     }

--- a/crates/rsync_io/src/session/parts/accessors.rs
+++ b/crates/rsync_io/src/session/parts/accessors.rs
@@ -15,19 +15,12 @@ impl<R> SessionHandshakeParts<R> {
     }
 
     /// Reports whether the extracted handshake originated from a binary negotiation.
-    ///
-    /// The helper mirrors [`crate::session::SessionHandshake::is_binary`], keeping the
-    /// convenience available even after the handshake has been decomposed into
-    /// its parts.
     #[must_use]
     pub const fn is_binary(&self) -> bool {
         matches!(self, SessionHandshakeParts::Binary(_))
     }
 
     /// Reports whether the extracted handshake originated from the legacy ASCII negotiation.
-    ///
-    /// This mirrors [`crate::session::SessionHandshake::is_legacy`] and returns `true` when the
-    /// parts were produced from a legacy `@RSYNCD:` daemon exchange.
     #[must_use]
     pub const fn is_legacy(&self) -> bool {
         matches!(self, SessionHandshakeParts::Legacy(_))

--- a/crates/rsync_io/src/session/parts/ownership.rs
+++ b/crates/rsync_io/src/session/parts/ownership.rs
@@ -10,64 +10,8 @@ use super::state::{BinaryHandshakeComponents, HandshakePartsResult, LegacyHandsh
 impl<R> SessionHandshakeParts<R> {
     /// Releases the parts structure and returns the replaying stream parts captured during negotiation.
     ///
-    /// The returned [`NegotiatedStreamParts`] retain the buffered prologue, decision, and transport,
-    /// allowing callers to inspect or transform the replay data without first rebuilding a
-    /// [`crate::session::SessionHandshake`]. This mirrors [`Self::stream`] for owned access and keeps the
-    /// high-level API aligned with the variant-specific helpers exposed by
-    /// [`BinaryHandshakeParts`] and [`LegacyDaemonHandshakeParts`].
-    ///
-    /// # Examples
-    ///
-    /// Reconstruct a binary negotiation and extract the replaying stream parts while preserving the
-    /// buffered handshake prefix.
-    ///
-    /// ```
-    /// use protocol::ProtocolVersion;
-    /// use rsync_io::negotiate_session;
-    /// use std::io::{self, Cursor, Read, Write};
-    ///
-    /// #[derive(Clone, Debug)]
-    /// struct Loopback {
-    ///     reader: Cursor<Vec<u8>>,
-    ///     written: Vec<u8>,
-    /// }
-    ///
-    /// impl Loopback {
-    ///     fn new(advertisement: [u8; 4]) -> Self {
-    ///         Self {
-    ///             reader: Cursor::new(advertisement.to_vec()),
-    ///             written: Vec::new(),
-    ///         }
-    ///     }
-    /// }
-    ///
-    /// impl Read for Loopback {
-    ///     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-    ///         self.reader.read(buf)
-    ///     }
-    /// }
-    ///
-    /// impl Write for Loopback {
-    ///     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-    ///         self.written.extend_from_slice(buf);
-    ///         Ok(buf.len())
-    ///     }
-    ///
-    ///     fn flush(&mut self) -> io::Result<()> {
-    ///         Ok(())
-    ///     }
-    /// }
-    ///
-    /// let remote = ProtocolVersion::from_supported(31).unwrap();
-    /// let transport = Loopback::new(u32::from(remote.as_u8()).to_le_bytes());
-    /// let parts = negotiate_session(transport, ProtocolVersion::NEWEST)
-    ///     .unwrap()
-    ///     .into_stream_parts();
-    /// let stream_parts = parts.clone().into_stream_parts();
-    ///
-    /// assert_eq!(stream_parts.decision(), parts.decision());
-    /// assert_eq!(stream_parts.buffered(), parts.stream().buffered());
-    /// ```
+    /// The returned [`NegotiatedStreamParts`] retain the buffered prologue,
+    /// decision, and transport. Owned counterpart to [`Self::stream`].
     #[must_use]
     pub fn into_stream_parts(self) -> NegotiatedStreamParts<R> {
         match self {
@@ -153,11 +97,7 @@ impl<R> SessionHandshakeParts<R> {
 
     /// Consumes the parts structure, returning the binary handshake parts when available.
     ///
-    /// The helper mirrors [`Self::into_binary`] but rebuilds the strongly typed
-    /// [`BinaryHandshakeParts`] wrapper so callers can reuse convenience
-    /// accessors without recreating the full [`BinaryHandshake`]. Returning the
-    /// original value on mismatch matches the ergonomics of [`TryFrom`]
-    /// conversions provided elsewhere in the crate.
+    /// Returns the original value on mismatch, matching [`TryFrom`] ergonomics.
     pub fn into_binary_parts(self) -> Result<BinaryHandshakeParts<R>, SessionHandshakeParts<R>> {
         match self {
             SessionHandshakeParts::Binary(parts) => Ok(parts),
@@ -178,11 +118,8 @@ impl<R> SessionHandshakeParts<R> {
 
     /// Consumes the parts structure, returning the legacy handshake parts when available.
     ///
-    /// The returned [`LegacyDaemonHandshakeParts`] retains the parsed greeting
-    /// and negotiated protocol while exposing the additional helper methods
-    /// implemented by the legacy-specific wrapper. Returning the original value
-    /// when the negotiation was binary mirrors the ergonomics of
-    /// [`Self::into_legacy`] and the [`TryFrom`] conversions below.
+    /// Returns the original value on mismatch, matching [`Self::into_legacy`]
+    /// and [`TryFrom`] ergonomics.
     pub fn into_legacy_parts(
         self,
     ) -> Result<LegacyDaemonHandshakeParts<R>, SessionHandshakeParts<R>> {

--- a/crates/rsync_io/src/session/parts/state.rs
+++ b/crates/rsync_io/src/session/parts/state.rs
@@ -22,16 +22,10 @@ pub(super) type HandshakePartsResult<T, R> = Result<T, SessionHandshakeParts<R>>
 
 /// Components extracted from a [crate::session::SessionHandshake].
 ///
-/// The structure mirrors the variant-specific handshake wrappers so callers can
-/// temporarily take ownership of the buffered negotiation bytes while keeping
-/// the negotiated protocol metadata. The parts can be converted back into a
-/// [crate::session::SessionHandshake] via [crate::session::SessionHandshake::from_stream_parts] or the
-/// [`From`] implementation. The enum directly embeds
-/// [`BinaryHandshakeParts`] and [`LegacyDaemonHandshakeParts`], delegating to
-/// their helpers so protocol diagnostics remain centralised in the
-/// variant-specific implementations. Variant-specific conversions are also
-/// exposed via [`From`] and [`TryFrom`] so binary or legacy wrappers can be
-/// promoted or recovered without manual pattern matching.
+/// Lets callers temporarily take ownership of the buffered negotiation bytes
+/// while keeping the negotiated protocol metadata. Convert back via
+/// [crate::session::SessionHandshake::from_stream_parts], [`From`], or
+/// [`TryFrom`].
 #[derive(Clone, Debug)]
 pub enum SessionHandshakeParts<R> {
     /// Binary handshake metadata and replaying stream parts.
@@ -43,77 +37,9 @@ pub enum SessionHandshakeParts<R> {
 impl<R> SessionHandshakeParts<R> {
     /// Constructs [`SessionHandshakeParts`] from binary handshake components.
     ///
-    /// This complements [`Self::into_binary`] by enabling callers to rebuild the decomposed
-    /// representation after temporarily taking ownership of the raw protocol numbers and
-    /// [`NegotiatedStreamParts`]. The helper delegates to
-    /// [`BinaryHandshake::from_stream_parts`] so the reconstruction path exercises the exact same
-    /// validation as the variant-specific wrapper. Debug builds therefore continue to assert that
-    /// the supplied stream captured a binary negotiation, mirroring the protections provided by
-    /// [`BinaryHandshakeParts`].
-    ///
-    /// # Examples
-    ///
-    /// Rebuild a binary session from its components after wrapping the underlying transport:
-    ///
-    /// ```
-    /// use protocol::ProtocolVersion;
-    /// use rsync_io::{negotiate_session_parts, SessionHandshakeParts};
-    /// use std::io::{self, Cursor, Read, Write};
-    ///
-    /// #[derive(Clone, Debug)]
-    /// struct Loopback {
-    ///     reader: Cursor<Vec<u8>>,
-    ///     writes: Vec<u8>,
-    /// }
-    ///
-    /// impl Loopback {
-    ///     fn new(advertised: ProtocolVersion) -> Self {
-    ///         let bytes = u32::from(advertised.as_u8()).to_le_bytes();
-    ///         Self { reader: Cursor::new(bytes.to_vec()), writes: Vec::new() }
-    ///     }
-    /// }
-    ///
-    /// impl Read for Loopback {
-    ///     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-    ///         self.reader.read(buf)
-    ///     }
-    /// }
-    ///
-    /// impl Write for Loopback {
-    ///     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-    ///         self.writes.extend_from_slice(buf);
-    ///         Ok(buf.len())
-    ///     }
-    ///
-    ///     fn flush(&mut self) -> io::Result<()> {
-    ///         Ok(())
-    ///     }
-    /// }
-    ///
-    /// let remote = ProtocolVersion::from_supported(31).unwrap();
-    /// let parts = negotiate_session_parts(Loopback::new(remote), ProtocolVersion::NEWEST)
-    ///     .expect("binary negotiation succeeds");
-    /// let (
-    ///     remote_advertised,
-    ///     remote_protocol,
-    ///     local_advertised,
-    ///     negotiated,
-    ///     remote_flags,
-    ///     stream_parts,
-    /// ) = parts.clone().into_binary().expect("binary components");
-    ///
-    /// let rebuilt = SessionHandshakeParts::from_binary_components(
-    ///     remote_advertised,
-    ///     remote_protocol,
-    ///     local_advertised,
-    ///     negotiated,
-    ///     remote_flags,
-    ///     stream_parts,
-    /// );
-    ///
-    /// assert!(rebuilt.is_binary());
-    /// assert_eq!(rebuilt.negotiated_protocol(), negotiated);
-    /// ```
+    /// Complements [`Self::into_binary`]. Delegates to
+    /// [`BinaryHandshake::from_stream_parts`] so debug builds assert that the
+    /// supplied stream captured a binary negotiation.
     #[must_use]
     pub fn from_binary_components(
         remote_advertised: u32,
@@ -138,62 +64,9 @@ impl<R> SessionHandshakeParts<R> {
 
     /// Constructs [`SessionHandshakeParts`] from legacy daemon handshake components.
     ///
-    /// The helper mirrors [`Self::into_legacy`] by reassembling the parts after the caller temporarily
-    /// extracts the parsed greeting, negotiated protocol, and replaying stream. Internally the
-    /// function delegates to [`LegacyDaemonHandshake::from_stream_parts`], ensuring the legacy
-    /// reconstruction path performs the same validation (including debug assertions that the stream
-    /// captured a legacy negotiation) as the dedicated wrapper type.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use protocol::ProtocolVersion;
-    /// use rsync_io::{negotiate_session_parts, SessionHandshakeParts};
-    /// use std::io::{self, Cursor, Read, Write};
-    ///
-    /// #[derive(Clone, Debug)]
-    /// struct Loopback {
-    ///     reader: Cursor<Vec<u8>>,
-    ///     writes: Vec<u8>,
-    /// }
-    ///
-    /// impl Loopback {
-    ///     fn new() -> Self {
-    ///         Self { reader: Cursor::new(b"@RSYNCD: 31.0\n".to_vec()), writes: Vec::new() }
-    ///     }
-    /// }
-    ///
-    /// impl Read for Loopback {
-    ///     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-    ///         self.reader.read(buf)
-    ///     }
-    /// }
-    ///
-    /// impl Write for Loopback {
-    ///     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-    ///         self.writes.extend_from_slice(buf);
-    ///         Ok(buf.len())
-    ///     }
-    ///
-    ///     fn flush(&mut self) -> io::Result<()> {
-    ///         Ok(())
-    ///     }
-    /// }
-    ///
-    /// let parts = negotiate_session_parts(Loopback::new(), ProtocolVersion::NEWEST)
-    ///     .expect("legacy negotiation succeeds");
-    /// let (greeting, negotiated, stream_parts) =
-    ///     parts.clone().into_legacy().expect("legacy components");
-    ///
-    /// let rebuilt = SessionHandshakeParts::from_legacy_components(
-    ///     greeting,
-    ///     negotiated,
-    ///     stream_parts,
-    /// );
-    ///
-    /// assert!(rebuilt.is_legacy());
-    /// assert_eq!(rebuilt.negotiated_protocol(), negotiated);
-    /// ```
+    /// Complements [`Self::into_legacy`]. Delegates to
+    /// [`LegacyDaemonHandshake::from_stream_parts`] so debug builds assert that
+    /// the supplied stream captured a legacy negotiation.
     #[must_use]
     pub fn from_legacy_components(
         server_greeting: LegacyDaemonGreetingOwned,


### PR DESCRIPTION
Partial progress on #1843 (rsync_io, batch, platform crates).

## Summary
- Trim verbose rustdoc paragraphs in `rsync_io` handshake, parts, and negotiation wrappers
- Remove overlong runnable examples that duplicated upstream type descriptions
- Preserve every `upstream:` reference and load-bearing safety/invariant comment verbatim
- Net change: 102 insertions, 837 deletions across 7 files

## Test plan
- [ ] fmt+clippy
- [ ] nextest (stable)
- [ ] Windows (stable)
- [ ] macOS (stable)
- [ ] Linux musl (stable)