### PR TITLE
feat(matching): wire --debug=HASH producer emissions (3.4.1 parity)

### DIFF
--- a/crates/matching/src/index/builder.rs
+++ b/crates/matching/src/index/builder.rs
@@ -7,6 +7,7 @@
 use signature::{FileSignature, SignatureAlgorithm, SignatureBlock};
 
 use super::compact_lookup::CompactLookup;
+use super::trace::{HashtableRole, trace_created, trace_growing};
 use super::{BitHash, DeltaSignatureIndex, TAG_TABLE_SIZE};
 
 /// Shared helper that indexes full-length blocks into the tag table, bithash,
@@ -41,17 +42,38 @@ impl DeltaSignatureIndex {
     /// reported by the layout. Files that produce fewer than one full block
     /// therefore return `None`, mirroring upstream rsync's behaviour of
     /// disabling the rolling checksum pipeline for very small payloads.
+    ///
+    /// The returned index emits its `--debug=HASH` create line with the
+    /// default `HashtableRole::Sender` prefix - upstream's `who_am_i()`
+    /// returns `"sender"` for the side that calls `build_hash_table`.
+    /// Callers operating from a different role (receiver-side local
+    /// delta apply, generator-side fixtures) should pass an explicit
+    /// role via [`Self::from_signature_with_role`].
     pub fn from_signature(
         signature: &FileSignature,
         algorithm: SignatureAlgorithm,
+    ) -> Option<Self> {
+        Self::from_signature_with_role(signature, algorithm, HashtableRole::Sender)
+    }
+
+    /// Builds a signature index, attributing `--debug=HASH` emissions to
+    /// the provided role.
+    ///
+    /// Mirrors upstream rsync's `who_am_i()` prefix on the
+    /// `created hashtable` line emitted from `hashtable.c:45-53`.
+    pub fn from_signature_with_role(
+        signature: &FileSignature,
+        algorithm: SignatureAlgorithm,
+        role: HashtableRole,
     ) -> Option<Self> {
         let block_length = signature.layout().block_length().get() as usize;
         let strong_length = usize::from(signature.layout().strong_sum_length().get());
         let blocks: Vec<SignatureBlock> = signature.blocks().to_vec();
 
-        let mut lookup = CompactLookup::with_capacity(blocks.len());
+        let requested = blocks.len();
+        let mut lookup = CompactLookup::with_capacity(requested);
         let mut tag_table = vec![false; TAG_TABLE_SIZE];
-        let mut bithash = BitHash::with_block_count(blocks.len());
+        let mut bithash = BitHash::with_block_count(requested);
 
         if !populate_index(
             &blocks,
@@ -63,7 +85,8 @@ impl DeltaSignatureIndex {
             return None;
         }
 
-        Some(Self {
+        let size = lookup.capacity();
+        let index = Self {
             block_length,
             strong_length,
             algorithm,
@@ -71,7 +94,14 @@ impl DeltaSignatureIndex {
             lookup,
             tag_table,
             bithash,
-        })
+            role,
+            last_traced_size: size,
+        };
+        // upstream: hashtable.c:45-53 - one HASH,1 emission per hashtable
+        // creation, with optional `req:` prefix when the rounded-up size
+        // differs from the caller's requested capacity.
+        trace_created(role, index.identifier(), requested, size);
+        Some(index)
     }
 
     /// Rebuilds the index in-place from a new signature, reusing the
@@ -96,12 +126,26 @@ impl DeltaSignatureIndex {
         self.tag_table.iter_mut().for_each(|v| *v = false);
         self.bithash.clear();
 
-        populate_index(
+        let ok = populate_index(
             &self.blocks,
             block_length,
             &mut self.tag_table,
             &mut self.bithash,
             &mut self.lookup,
-        )
+        );
+
+        if ok {
+            let size = self.lookup.capacity();
+            // upstream: hashtable.c:100-103 - emit when the bucket count
+            // changes from the previously traced value. Our `rebuild`
+            // reuses the same allocation when possible, so the size only
+            // ever differs when the caller's signature width changes.
+            if size != self.last_traced_size {
+                trace_growing(self.role, self.identifier(), size);
+                self.last_traced_size = size;
+            }
+        }
+
+        ok
     }
 }

--- a/crates/matching/src/index/compact_lookup.rs
+++ b/crates/matching/src/index/compact_lookup.rs
@@ -128,7 +128,6 @@ impl CompactLookup {
     }
 
     /// Returns the total number of slots (always a power of two).
-    #[allow(dead_code)]
     pub(super) fn capacity(&self) -> usize {
         (self.mask as usize) + 1
     }

--- a/crates/matching/src/index/mod.rs
+++ b/crates/matching/src/index/mod.rs
@@ -12,6 +12,7 @@ mod bithash;
 mod builder;
 mod compact_lookup;
 mod matched_blocks;
+mod trace;
 
 #[cfg(test)]
 mod bithash_tests;
@@ -29,6 +30,10 @@ use signature::{SignatureAlgorithm, SignatureBlock};
 use bithash::BitHash;
 use compact_lookup::CompactLookup;
 pub use matched_blocks::MatchedBlocks;
+pub use trace::{
+    HASH_KEY_BITS, HashtableRole, trace_created as trace_hashtable_created,
+    trace_destroyed as trace_hashtable_destroyed, trace_growing as trace_hashtable_growing,
+};
 
 /// Size of the tag table for quick rolling checksum rejection (2^16 entries).
 ///
@@ -61,9 +66,29 @@ pub struct DeltaSignatureIndex {
     /// the bithash rejects ~7/8 of post-tag misses before the hash probe.
     /// Mirrors zsync's `librcksum/rsum.c:362-366` probe expression.
     bithash: BitHash,
+    /// Role used for `--debug=HASH` `[<role>]` prefixes on the create,
+    /// grow, and destroy lifecycle emissions. Mirrors upstream
+    /// `who_am_i()` (`hashtable.c:51,61,101`).
+    role: HashtableRole,
+    /// Slot count tracked across rebuilds for the matching destroy emission.
+    last_traced_size: usize,
 }
 
 impl DeltaSignatureIndex {
+    /// Returns the role used for `--debug=HASH` `[<role>]` prefixes.
+    #[must_use]
+    pub const fn role(&self) -> HashtableRole {
+        self.role
+    }
+
+    /// Overrides the role used in subsequent HASH emissions.
+    ///
+    /// Useful for call sites that build the index in a generic helper
+    /// and only learn the actual `who_am_i()` value later.
+    pub fn set_role(&mut self, role: HashtableRole) {
+        self.role = role;
+    }
+
     /// Returns the canonical block length expressed in bytes.
     #[must_use]
     pub const fn block_length(&self) -> usize {
@@ -122,8 +147,9 @@ impl DeltaSignatureIndex {
             return None;
         }
 
-        // zsync-style one-sided bithash prefilter (no false negatives)
-        // rejects ~7/8 of post-tag misses before the hash-table probe.
+        // zsync-style bithash prefilter: rejects ~7/8 of post-tag misses
+        // using both sum halves before the hash-table probe. One-sided, so
+        // never produces a false negative.
         if !self.bithash.contains(digest.value()) {
             return None;
         }
@@ -318,5 +344,32 @@ impl DeltaSignatureIndex {
             offset = end;
         }
         run
+    }
+}
+
+impl Drop for DeltaSignatureIndex {
+    /// Emits `--debug=HASH` level 1 destroy diagnostic, mirroring upstream
+    /// rsync's `hashtable_destroy` (`hashtable.c:60-63`).
+    ///
+    /// Clones produced by `#[derive(Clone)]` carry the same `role` and
+    /// `last_traced_size`, so each clone's drop fires an independent
+    /// upstream-format line - the count matches the create count when
+    /// callers honour the `Drop` contract.
+    fn drop(&mut self) {
+        let id = self.identifier();
+        trace::trace_destroyed(self.role, id, self.last_traced_size);
+    }
+}
+
+impl DeltaSignatureIndex {
+    /// Returns a stable identifier for `--debug=HASH` emissions.
+    ///
+    /// Upstream prints `(long)tbl` (the heap address of the hashtable
+    /// struct). We approximate that with the address of the index's
+    /// own struct so the create/destroy emissions for a single index
+    /// share the same identifier.
+    #[inline]
+    pub(super) fn identifier(&self) -> usize {
+        self as *const Self as usize
     }
 }

--- a/crates/matching/src/index/trace.rs
+++ b/crates/matching/src/index/trace.rs
@@ -1,0 +1,244 @@
+//! `--debug=HASH` producer emissions for the delta signature hash table.
+//!
+//! Mirrors upstream rsync's `hashtable.c` `DEBUG_GTE(HASH, 1)` output so
+//! wire-comparable diagnostics align across implementations.
+//!
+//! # Upstream Reference
+//!
+//! - `hashtable.c:45-53`  - created hashtable emission.
+//! - `hashtable.c:60-63`  - destroyed hashtable emission.
+//! - `hashtable.c:100-103` - growing hashtable emission.
+//!
+//! Upstream prepends a `[<role>]` prefix derived from `who_am_i()`. The
+//! [`HashtableRole`] enum exposes the same vocabulary so callers can pass
+//! the role explicitly without depending on the protocol crate.
+
+use logging::debug_log;
+
+/// Process role used as the `[<role>]` prefix in HASH emissions.
+///
+/// Mirrors upstream's `who_am_i()` return strings (`sender`,
+/// `receiver`, `generator`) without pulling in a heavier dependency.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HashtableRole {
+    /// Sender role - builds the index after receiving signatures.
+    Sender,
+    /// Receiver role - builds the index during local delta apply.
+    Receiver,
+    /// Generator role - builds the index while emitting signatures.
+    Generator,
+}
+
+impl HashtableRole {
+    /// Returns the upstream-equivalent string for the role.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Sender => "sender",
+            Self::Receiver => "receiver",
+            Self::Generator => "generator",
+        }
+    }
+}
+
+impl std::fmt::Display for HashtableRole {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Width, in bits, of the hash key stored in the delta signature index.
+///
+/// The index packs `(sum1, sum2)` into a single `u32`, matching upstream's
+/// 32-bit key family (`HT_KEY32`) used for non-`hashlittle2`-style tables.
+pub const HASH_KEY_BITS: u32 = 32;
+
+/// Traces hashtable creation (level 1).
+///
+/// Matches upstream rsync exactly:
+/// ```text
+/// [sender] created hashtable 7f00aa00 (size: 4096, keys: 32-bit)
+/// ```
+///
+/// When the requested capacity differs from the rounded-up table size, the
+/// upstream variant inserts a `req: <n>, ` prefix inside the parentheses:
+/// ```text
+/// [sender] created hashtable 7f00aa00 (req: 50, size: 64, keys: 32-bit)
+/// ```
+///
+/// upstream: hashtable.c:45-53.
+#[inline]
+pub fn trace_created(role: HashtableRole, id: usize, requested: usize, size: usize) {
+    if requested != size {
+        debug_log!(
+            Hash,
+            1,
+            "[{}] created hashtable {:x} (req: {}, size: {}, keys: {}-bit)",
+            role,
+            id,
+            requested,
+            size,
+            HASH_KEY_BITS
+        );
+    } else {
+        debug_log!(
+            Hash,
+            1,
+            "[{}] created hashtable {:x} (size: {}, keys: {}-bit)",
+            role,
+            id,
+            size,
+            HASH_KEY_BITS
+        );
+    }
+}
+
+/// Traces hashtable destruction (level 1).
+///
+/// Matches upstream rsync exactly:
+/// ```text
+/// [sender] destroyed hashtable 7f00aa00 (size: 4096, keys: 32-bit)
+/// ```
+///
+/// upstream: hashtable.c:60-63.
+#[inline]
+pub fn trace_destroyed(role: HashtableRole, id: usize, size: usize) {
+    debug_log!(
+        Hash,
+        1,
+        "[{}] destroyed hashtable {:x} (size: {}, keys: {}-bit)",
+        role,
+        id,
+        size,
+        HASH_KEY_BITS
+    );
+}
+
+/// Traces hashtable growth (level 1).
+///
+/// Matches upstream rsync exactly:
+/// ```text
+/// [sender] growing hashtable 7f00aa00 (size: 8192, keys: 32-bit)
+/// ```
+///
+/// upstream: hashtable.c:100-103.
+#[inline]
+pub fn trace_growing(role: HashtableRole, id: usize, size: usize) {
+    debug_log!(
+        Hash,
+        1,
+        "[{}] growing hashtable {:x} (size: {}, keys: {}-bit)",
+        role,
+        id,
+        size,
+        HASH_KEY_BITS
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use logging::{DebugFlag, DiagnosticEvent, VerbosityConfig, drain_events, init};
+
+    fn setup_hash(level: u8) {
+        let mut cfg = VerbosityConfig::default();
+        cfg.debug.hash = level;
+        init(cfg);
+        let _ = drain_events();
+    }
+
+    fn hash_messages() -> Vec<String> {
+        drain_events()
+            .into_iter()
+            .filter_map(|event| match event {
+                DiagnosticEvent::Debug {
+                    flag: DebugFlag::Hash,
+                    message,
+                    ..
+                } => Some(message),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// Pins the level 1 created emission to upstream's format byte-for-byte
+    /// when the requested capacity matches the rounded-up size.
+    ///
+    /// upstream: hashtable.c:45-53.
+    #[test]
+    fn created_matches_upstream_format_no_req() {
+        setup_hash(1);
+        trace_created(HashtableRole::Sender, 0x7f00_aa00, 4096, 4096);
+        let msgs = hash_messages();
+        assert!(
+            msgs.iter()
+                .any(|m| m == "[sender] created hashtable 7f00aa00 (size: 4096, keys: 32-bit)"),
+            "expected upstream-format HASH,1 created emission, got {msgs:?}"
+        );
+    }
+
+    /// Pins the level 1 created emission with the `req:` prefix when the
+    /// requested capacity differs from the rounded-up size.
+    ///
+    /// upstream: hashtable.c:46-50.
+    #[test]
+    fn created_matches_upstream_format_with_req() {
+        setup_hash(1);
+        trace_created(HashtableRole::Receiver, 0x4242, 50, 64);
+        let msgs = hash_messages();
+        assert!(
+            msgs.iter().any(
+                |m| m == "[receiver] created hashtable 4242 (req: 50, size: 64, keys: 32-bit)"
+            ),
+            "expected upstream-format HASH,1 created emission with req prefix, got {msgs:?}"
+        );
+    }
+
+    /// Pins the level 1 destroyed emission to upstream's format.
+    ///
+    /// upstream: hashtable.c:60-63.
+    #[test]
+    fn destroyed_matches_upstream_format() {
+        setup_hash(1);
+        trace_destroyed(HashtableRole::Generator, 0xdead, 256);
+        let msgs = hash_messages();
+        assert!(
+            msgs.iter()
+                .any(|m| m == "[generator] destroyed hashtable dead (size: 256, keys: 32-bit)"),
+            "expected upstream-format HASH,1 destroyed emission, got {msgs:?}"
+        );
+    }
+
+    /// Pins the level 1 growing emission to upstream's format.
+    ///
+    /// upstream: hashtable.c:100-103.
+    #[test]
+    fn growing_matches_upstream_format() {
+        setup_hash(1);
+        trace_growing(HashtableRole::Sender, 0xfeed, 8192);
+        let msgs = hash_messages();
+        assert!(
+            msgs.iter()
+                .any(|m| m == "[sender] growing hashtable feed (size: 8192, keys: 32-bit)"),
+            "expected upstream-format HASH,1 growing emission, got {msgs:?}"
+        );
+    }
+
+    /// HASH emissions must not fire when the flag is disabled.
+    #[test]
+    fn gated_by_debug_flag() {
+        setup_hash(0);
+        trace_created(HashtableRole::Sender, 1, 1, 1);
+        trace_destroyed(HashtableRole::Sender, 1, 1);
+        trace_growing(HashtableRole::Sender, 1, 1);
+        assert!(hash_messages().is_empty());
+    }
+
+    /// Role display strings match upstream `who_am_i()` vocabulary.
+    #[test]
+    fn role_display_matches_who_am_i() {
+        assert_eq!(HashtableRole::Sender.to_string(), "sender");
+        assert_eq!(HashtableRole::Receiver.to_string(), "receiver");
+        assert_eq!(HashtableRole::Generator.to_string(), "generator");
+    }
+}

--- a/crates/matching/src/lib.rs
+++ b/crates/matching/src/lib.rs
@@ -32,5 +32,8 @@ pub use fuzzy::{
     trace_fuzzy_basis_selected, trace_fuzzy_distance, trace_fuzzy_size_mtime_match,
 };
 pub use generator::{DeltaGenerator, generate_delta};
-pub use index::{DeltaSignatureIndex, MatchedBlocks};
+pub use index::{
+    DeltaSignatureIndex, HASH_KEY_BITS, HashtableRole, MatchedBlocks, trace_hashtable_created,
+    trace_hashtable_destroyed, trace_hashtable_growing,
+};
 pub use script::{DeltaScript, DeltaToken, apply_delta};

--- a/crates/matching/tests/debug_hash_emissions.rs
+++ b/crates/matching/tests/debug_hash_emissions.rs
@@ -1,0 +1,96 @@
+//! Integration test for `--debug=HASH` producer emissions wired into the
+//! [`DeltaSignatureIndex`] lifecycle.
+//!
+//! Drives the `from_signature` builder under `debug.hash = 1` and asserts that
+//! the upstream-format `created hashtable ...` line fires through the real
+//! [`logging`] channel - the same code path users hit when running
+//! `oc-rsync --debug=HASH`.
+
+use std::num::NonZeroU8;
+
+use logging::{DebugFlag, DiagnosticEvent, VerbosityConfig, drain_events, init};
+use matching::DeltaSignatureIndex;
+use protocol::ProtocolVersion;
+use signature::{
+    SignatureAlgorithm, SignatureLayoutParams, calculate_signature_layout, generate_file_signature,
+};
+
+/// Initializes logging with HASH debug at level 1 and clears any pending
+/// events so assertions can focus on emissions produced by the test body.
+fn init_hash_level_1() {
+    let mut cfg = VerbosityConfig::default();
+    cfg.debug.hash = 1;
+    init(cfg);
+    let _ = drain_events();
+}
+
+/// Collects HASH debug messages emitted since the last drain.
+fn hash_messages() -> Vec<String> {
+    drain_events()
+        .into_iter()
+        .filter_map(|event| match event {
+            DiagnosticEvent::Debug {
+                flag: DebugFlag::Hash,
+                message,
+                ..
+            } => Some(message),
+            _ => None,
+        })
+        .collect()
+}
+
+/// Builds a signature with at least one full-length block so the index
+/// construction path runs to completion.
+fn build_signature() -> signature::FileSignature {
+    let data = vec![b'a'; 4096];
+    let params = SignatureLayoutParams::new(
+        data.len() as u64,
+        None,
+        ProtocolVersion::NEWEST,
+        NonZeroU8::new(16).unwrap(),
+    );
+    let layout = calculate_signature_layout(params).expect("layout");
+    generate_file_signature(data.as_slice(), layout, SignatureAlgorithm::Md4).expect("signature")
+}
+
+/// Exercises `DeltaSignatureIndex::from_signature` under `--debug=HASH` and
+/// asserts the upstream-format created emission fires.
+///
+/// upstream: hashtable.c:45-53.
+#[test]
+fn from_signature_emits_created_under_debug_hash() {
+    init_hash_level_1();
+
+    let signature = build_signature();
+    let _index =
+        DeltaSignatureIndex::from_signature(&signature, SignatureAlgorithm::Md4).expect("index");
+
+    let msgs = hash_messages();
+    assert!(
+        msgs.iter().any(|m| m.starts_with("[sender] created hashtable ")
+            && m.ends_with(", keys: 32-bit)")),
+        "expected upstream-format HASH,1 created emission from from_signature, got {msgs:?}"
+    );
+}
+
+/// Drops a constructed index and asserts the matching destroyed emission
+/// fires through the [`Drop`] impl.
+///
+/// upstream: hashtable.c:60-63.
+#[test]
+fn drop_emits_destroyed_under_debug_hash() {
+    init_hash_level_1();
+
+    let signature = build_signature();
+    let index =
+        DeltaSignatureIndex::from_signature(&signature, SignatureAlgorithm::Md4).expect("index");
+    drop(index);
+
+    let msgs = hash_messages();
+    assert!(
+        msgs.iter()
+            .any(|m| m.starts_with("[sender] destroyed hashtable ")
+                && m.ends_with(", keys: 32-bit)")),
+        "expected upstream-format HASH,1 destroyed emission from Drop, got {msgs:?}"
+    );
+}

--- a/docs/audits/debug-flags-verbosity-matrix.md
+++ b/docs/audits/debug-flags-verbosity-matrix.md
@@ -130,7 +130,7 @@ Producer counts come from
 | FLIST      | 4 | 4 | W_SND\|W_REC | Debug file-list operations (levels 1-4) | `crates/flist/src/file_list_walker.rs:32,89,101,119,130,241`, `crates/transfer/src/generator/file_list/{inc_recurse.rs:46,mod.rs:103,219}`, `crates/transfer/src/generator/transfer.rs:188,202,212,217`, `crates/transfer/src/receiver/file_list.rs:154,215,226`, `crates/protocol/src/flist/sort.rs:208,375`, `crates/protocol/src/flist/incremental/{ready_entry.rs,mod.rs}`, `crates/protocol/src/flist/read/{flags.rs,metadata.rs,mod.rs,name.rs}` (23 sites covering levels 1-4) | impl |
 | FUZZY      | 2 | 2 | W_REC | Debug fuzzy scoring (levels 1-2) | none | missing |
 | GENR       | 1 | u8::MAX | W_REC | Debug generator functions | `crates/transfer/src/receiver/transfer.rs:setup_transfer` (1 site at level 1), `crates/transfer/src/receiver/transfer/candidates.rs:build_files_to_transfer` (1 site at level 1), `crates/transfer/src/receiver/transfer/phases.rs:exchange_phase_done` and `:finalize_transfer` (3 sites at level 1, upstream-verbatim wording from `generator.c:1234,2260,2356,2367,2393,2436`) | impl (D14 RESOLVED) |
-| HASH       | 1 | u8::MAX | W_SND\|W_REC | Debug hashtable code | none | missing |
+| HASH       | 1 | u8::MAX | W_SND\|W_REC | Debug hashtable code | `crates/matching/src/index/trace.rs` (created/destroyed/growing helpers) wired into `DeltaSignatureIndex::from_signature_with_role`, `:rebuild`, and `Drop` (3 sites at level 1, upstream-verbatim wording from `hashtable.c:45-53,60-63,100-103`) | impl (G3 partial - HASH RESOLVED) |
 | HLINK      | 3 (help says 1-3) | 3 | W_SND\|W_REC | Debug hard-link actions (levels 1-3) | none | missing |
 | ICONV      | 2 | 2 | W_CLI\|W_SRV | Debug iconv character conversions (levels 1-2) | `crates/core/src/client/config/iconv.rs:resolve_converter` (1 site at level 1, upstream-verbatim wording from `rsync.c:142-145`); helper emissions for the level-2 message-charset probe live in `crates/protocol/src/iconv/trace.rs` (upstream `rsync.c:99-110`). | impl (G3 partial - ICONV RESOLVED) |
 | IO         | 4 | 4 | W_CLI\|W_SRV | Debug I/O routines (levels 1-4) | `crates/transfer/src/disk_commit/thread.rs:117,125,132,149,153,155` plus `tracing::*(target: "rsync::io", ...)` in `crates/protocol/src/debug_io.rs`, `crates/fast_io/src/debug_io.rs`, `crates/rsync_io/src/debug_io.rs` (`debug_io.rs` trace funcs not called from production - see gap G3) | partial (levels 1 and 3 emitted via `debug_log!`; trace-func helpers unwired) |
@@ -144,9 +144,9 @@ Producer counts come from
 Total: 24 upstream `DEBUG_*` flags, matching `COUNT_DEBUG = DEBUG_TIME + 1`
 (`rsync.h:1462`). Status roll-up:
 
-- **impl**: 11 - ACL, BACKUP, DUP, FILTER, FLIST, GENR, ICONV, NSTR, OWN, SEND, TIME.
+- **impl**: 12 - ACL, BACKUP, DUP, FILTER, FLIST, GENR, HASH, ICONV, NSTR, OWN, SEND, TIME.
 - **partial**: 7 - CONNECT, DEL, DELTASUM, EXIT, IO, PROTO, RECV.
-- **missing**: 6 - BIND, CHDIR, CMD, FUZZY, HASH, HLINK.
+- **missing**: 5 - BIND, CHDIR, CMD, FUZZY, HLINK.
 
 `SEND` (D13) is now wired into the generator's send loop with the
 five upstream-verbatim messages from `sender.c send_files` (lines
@@ -302,7 +302,7 @@ requested level before the event materialises.
 |----|----------|--------|-------------|
 | G1 | Low | open | `ALL<N>` and `NONE0` syntactic forms are rejected as unknown tokens (`flags/debug.rs:279`). Upstream accepts them (`options.c:443-445`, `:452-453`, `:450-451`) and applies the trailing digit. Fix: extend `DebugFlagSettings::apply` to detect `all<digit>` and `none<digit>` before falling through to `parse_flag_and_level`, then call `enable_all_to_level(N)` / `disable_all()`. Cap N at 4 to match `MAX_OUT_LEVEL`. |
 | G2 | Low | open | Per-flag cap missing for upstream-max-1 flags. `acl`, `bind`, `chdir`, `dup`, `genr`, `hash`, `nstr`, `proto`, `recv`, `send` accept any `u8` value (no `if level > N` guard in `flags/debug.rs::apply`). Upstream silently clamps to `MAX_OUT_LEVEL = 4`. Fix: add `if level > 4 { return Err(debug_flag_error(display)); }` guards on those arms, or a single shared cap before the per-flag dispatch. |
-| G3 | High | open | 6 flags have no production producer (BIND, CHDIR, CMD, FUZZY, HASH, HLINK). The previously listed ACL, BACKUP, GENR, ICONV, NSTR, OWN, and SEND emissions are now wired (D14, I-ACL, I-ICONV, NSTR follow-up, OWN follow-up, D13 RESOLVED, BACKUP RESOLVED). Owning crates for the remaining producers: `metadata` (HLINK), `engine` (FUZZY), `transfer`/`rsync_io` (BIND, CMD), `checksums` (HASH), `core` (CHDIR). |
+| G3 | High | open | 5 flags have no production producer (BIND, CHDIR, CMD, FUZZY, HLINK). The previously listed ACL, BACKUP, GENR, HASH, ICONV, NSTR, OWN, and SEND emissions are now wired (D14, I-ACL, I-ICONV, NSTR follow-up, OWN follow-up, D13 RESOLVED, BACKUP RESOLVED, HASH RESOLVED). Owning crates for the remaining producers: `metadata` (HLINK), `engine` (FUZZY), `transfer`/`rsync_io` (BIND, CMD), `core` (CHDIR). |
 | G4 | Low | open | `limit_output_verbosity` (upstream `options.c:527-553`) is not implemented. User-supplied per-flag levels are not clamped to the peer's `-v` ceiling during option exchange. Mitigation: implement on `server_options` parsing path and re-run the ladder with `LIMIT_PRIORITY` to compute the cap. |
 | G5 | Low | open | `make_output_option` (upstream `options.c:340-425`) is not implemented. Remote command forwarding of user-priority debug flags relies on raw passthrough rather than upstream's deduplicated `--debug=ALL2,NONREG0,...` style. User-visible effect is limited to the exact command string the peer sees in `ps` output. |
 | G6 | Low | open | `--debug=help` text omits the per-verbosity summary block (`0)`, `1)`, ..., `5)`) that upstream's `output_item_help` prints at `options.c:499-509`. Cosmetic but useful for discovery. |
@@ -319,7 +319,7 @@ requested level before the event materialises.
 | CHDIR | `crates/core/src/client/path/` and `crates/daemon/src/jail/` | After every `chdir()` syscall. Upstream emits in `util1.c:do_chdir`. |
 | CMD | `crates/cli/src/frontend/execution/drive/options.rs` | When `--server` argv is built and when SSH command line is constructed. Upstream emits in `options.c:server_options` and `pipe.c:do_cmd`. |
 | FUZZY | `crates/transfer/src/generator/fuzzy.rs` (if present, else `match` crate) | When a fuzzy basis is selected. Upstream emits in `generator.c:find_fuzzy`. |
-| HASH | `crates/checksums/src/strong/` and `crates/match/src/hashtable.rs` | At hashtable construction and lookup. Upstream emits in `match.c:build_hash_table`. |
+| HASH | wired in `crates/matching/src/index/builder.rs::from_signature_with_role` (created at level 1), `:rebuild` (growing at level 1), and `crates/matching/src/index/mod.rs::Drop` (destroyed at level 1). Helpers live in `crates/matching/src/index/trace.rs` and mirror upstream `hashtable.c:45-53,60-63,100-103`. |
 | HLINK | `crates/transfer/src/receiver/directory/links.rs` (extend existing RECV emitter) | When a hardlink master/follower is resolved. Upstream emits in `hlink.c:hard_link_one`. |
 | ICONV | wired in `crates/core/src/client/config/iconv.rs::resolve_converter` (level 1) with helpers in `crates/protocol/src/iconv/trace.rs` for the level-2 message-charset probe. Upstream emits at `rsync.c:99-110,142-145` (`setup_iconv`); none of upstream's emissions live in `flist.c`. |
 | NSTR | `crates/rsync_io/src/negotiation/` | During server/client capability string exchange. Upstream emits in `compat.c:set_allow_inc_recurse` and friends. |


### PR DESCRIPTION
## Summary

- Wires `--debug=HASH` byte-for-byte emissions for the delta signature
  hashtable lifecycle (`created`/`growing`/`destroyed`), matching upstream
  rsync 3.4.1's `hashtable.c` `DEBUG_GTE(HASH, 1)` wording verbatim
  including the optional `req:` prefix when the rounded-up power-of-two
  slot count differs from the requested entry count.
- Adds `crates/matching/src/index/trace.rs` with helpers
  (`trace_created`, `trace_destroyed`, `trace_growing`) and a
  `HashtableRole` enum mirroring upstream `who_am_i()` (`sender`,
  `receiver`, `generator`). Pinning tests cover format, level gating,
  and role display strings.
- Wires the helpers into `DeltaSignatureIndex::from_signature` (via a
  new `from_signature_with_role` entry that captures the requested vs
  rounded-up slot count), `:rebuild` (growing emission on size change),
  and the new `Drop` impl (destroyed emission).
- Updates `docs/audits/debug-flags-verbosity-matrix.md`: rolls HASH
  from `missing` to `impl`, bumps the impl counter from 11 to 12,
  drops missing from 6 to 5, and refreshes the G3 gap and per-flag
  insertion-plan rows.

## Test plan

- [ ] CI: fmt + clippy
- [ ] CI: nextest (stable) - new `crates/matching/tests/debug_hash_emissions.rs`
      integration tests
- [ ] CI: Windows, macOS, Linux musl matrix
- [ ] Existing matching unit tests in `crates/matching/src/index/{trace,tests}.rs`

Closes #2187