### PR TITLE
feat(transfer): instrument prepare_pending_acl cost (INC_RECURSE I5)

### DIFF
--- a/crates/transfer/src/generator/mod.rs
+++ b/crates/transfer/src/generator/mod.rs
@@ -232,8 +232,8 @@ pub fn flush_rate_totals() -> u64 {
 }
 
 /// Total invocations of `prepare_pending_acl` across all generator transfers
-/// in this process. Diagnostic counter for sender-side INC_RECURSE (#2200, I5)
-/// - quantifies how often the per-entry ACL prep fires per segment relative to
+/// in this process. Diagnostic counter for sender-side INC_RECURSE (#2200, I5);
+/// quantifies how often the per-entry ACL prep fires per segment relative to
 /// the file count.
 ///
 /// Sampled at end-of-transfer in `GeneratorContext::run` via
@@ -242,7 +242,7 @@ static PREPARE_ACL_CALLS: AtomicU64 = AtomicU64::new(0);
 
 /// Cumulative elapsed time spent inside `prepare_pending_acl`, in nanoseconds,
 /// summed across every invocation. Diagnostic counter for sender-side
-/// INC_RECURSE (#2200, I5) - lets operators see when filesystem ACL reads
+/// INC_RECURSE (#2200, I5); lets operators see when filesystem ACL reads
 /// become a measurable share of segment-encoding time.
 static PREPARE_ACL_ELAPSED_NS: AtomicU64 = AtomicU64::new(0);
 

--- a/crates/transfer/src/generator/mod.rs
+++ b/crates/transfer/src/generator/mod.rs
@@ -231,6 +231,45 @@ pub fn flush_rate_totals() -> u64 {
     FLUSH_CALLS.load(Ordering::Relaxed)
 }
 
+/// Total invocations of `prepare_pending_acl` across all generator transfers
+/// in this process. Diagnostic counter for sender-side INC_RECURSE (#2200, I5)
+/// - quantifies how often the per-entry ACL prep fires per segment relative to
+/// the file count.
+///
+/// Sampled at end-of-transfer in `GeneratorContext::run` via
+/// [`prepare_acl_totals`] and emitted via `tracing::debug!`.
+static PREPARE_ACL_CALLS: AtomicU64 = AtomicU64::new(0);
+
+/// Cumulative elapsed time spent inside `prepare_pending_acl`, in nanoseconds,
+/// summed across every invocation. Diagnostic counter for sender-side
+/// INC_RECURSE (#2200, I5) - lets operators see when filesystem ACL reads
+/// become a measurable share of segment-encoding time.
+static PREPARE_ACL_ELAPSED_NS: AtomicU64 = AtomicU64::new(0);
+
+/// Records one `prepare_pending_acl` invocation and adds its elapsed wall
+/// time (in nanoseconds, saturating to `u64::MAX`) to the cumulative counter.
+/// Used by `GeneratorContext::prepare_pending_acl` to bump
+/// [`PREPARE_ACL_CALLS`] / [`PREPARE_ACL_ELAPSED_NS`] for INC_RECURSE
+/// diagnostic I5 (#2200).
+pub(crate) fn record_prepare_acl(elapsed: Duration) {
+    PREPARE_ACL_CALLS.fetch_add(1, Ordering::Relaxed);
+    let ns = u64::try_from(elapsed.as_nanos()).unwrap_or(u64::MAX);
+    PREPARE_ACL_ELAPSED_NS.fetch_add(ns, Ordering::Relaxed);
+}
+
+/// Snapshot of the global `prepare_pending_acl` counters.
+///
+/// Returns `(call_count, cumulative_elapsed_ns)`. Used by the generator
+/// finalize path to emit an end-of-transfer diagnostic line and by unit tests
+/// that assert the counters monotonically grow.
+#[must_use]
+pub fn prepare_acl_totals() -> (u64, u64) {
+    (
+        PREPARE_ACL_CALLS.load(Ordering::Relaxed),
+        PREPARE_ACL_ELAPSED_NS.load(Ordering::Relaxed),
+    )
+}
+
 /// A pending file list sub-segment for incremental recursion sending.
 ///
 /// References entries in `GeneratorContext::file_list` by range rather than

--- a/crates/transfer/src/generator/protocol_io.rs
+++ b/crates/transfer/src/generator/protocol_io.rs
@@ -364,11 +364,30 @@ impl GeneratorContext {
     /// and passes them to the writer via `set_pending_acl`. The writer will
     /// strip base permission entries before sending.
     ///
+    /// Updates the `PREPARE_ACL_CALLS` / `PREPARE_ACL_ELAPSED_NS` counters
+    /// used for INC_RECURSE diagnostic I5 (#2200). The timer wraps the entire
+    /// body so the no-op early-return path is still accounted for in the
+    /// per-segment call count.
+    ///
     /// # Upstream Reference
     ///
     /// Mirrors `flist.c:1627-1656` where `get_acl()` reads filesystem ACLs
     /// and `send_acl()` strips and sends them.
     fn prepare_pending_acl(
+        &self,
+        entry: &protocol::flist::FileEntry,
+        index: usize,
+        flist_writer: &mut protocol::flist::FileListWriter,
+    ) {
+        let started = Instant::now();
+        self.prepare_pending_acl_inner(entry, index, flist_writer);
+        super::record_prepare_acl(started.elapsed());
+    }
+
+    /// Body of [`Self::prepare_pending_acl`] without the timing wrapper, so
+    /// the counter updates remain in a single place and the elapsed window
+    /// excludes only the `Instant::now()` pair itself.
+    fn prepare_pending_acl_inner(
         &self,
         entry: &protocol::flist::FileEntry,
         index: usize,

--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -348,6 +348,51 @@ fn flush_rate_totals_is_observable_without_flushing() {
 }
 
 #[test]
+fn prepare_acl_call_counter_increments() {
+    // INC_RECURSE diagnostic I5 (#2200): every record_prepare_acl invocation
+    // must bump the global PREPARE_ACL_CALLS counter. The assertion uses >=
+    // because the counter is shared across the process and other tests may
+    // run concurrently.
+    use super::{prepare_acl_totals, record_prepare_acl};
+    use std::time::Duration;
+
+    let (calls_before, ns_before) = prepare_acl_totals();
+
+    record_prepare_acl(Duration::from_nanos(100));
+    record_prepare_acl(Duration::from_nanos(200));
+    record_prepare_acl(Duration::from_nanos(300));
+
+    let (calls_after, ns_after) = prepare_acl_totals();
+    assert!(
+        calls_after >= calls_before + 3,
+        "expected at least 3 new prepare_acl calls (before={calls_before}, after={calls_after})"
+    );
+    assert!(
+        ns_after >= ns_before + 600,
+        "cumulative elapsed_ns should grow by at least 600 \
+         (before={ns_before}, after={ns_after})"
+    );
+}
+
+#[test]
+fn prepare_acl_totals_observable_without_prep() {
+    // INC_RECURSE diagnostic I5 (#2200): the totals snapshot must be readable
+    // without triggering any ACL prep. Constructing a generator must not bump
+    // the counter on its own, so two adjacent reads with no intervening
+    // record_prepare_acl call must return identical values.
+    use super::prepare_acl_totals;
+
+    let (_handshake, _ctx) = test_generator();
+    let first = prepare_acl_totals();
+    let second = prepare_acl_totals();
+
+    assert_eq!(
+        first, second,
+        "prepare_acl_totals must be a pure read (first={first:?}, second={second:?})"
+    );
+}
+
+#[test]
 fn build_and_send_round_trip() {
     use crate::receiver::ReceiverContext;
 

--- a/crates/transfer/src/generator/transfer.rs
+++ b/crates/transfer/src/generator/transfer.rs
@@ -851,6 +851,27 @@ impl GeneratorContext {
             "generator writer.flush totals"
         );
 
+        // INC_RECURSE diagnostic I5 (#2200): emit cumulative
+        // prepare_pending_acl call count and elapsed wall time. Aggregated
+        // across all generator transfers in this process so operators can
+        // see how often per-entry ACL prep fires per segment and what share
+        // of segment-encoding time it consumes.
+        let (acl_calls, acl_elapsed_ns) = super::prepare_acl_totals();
+        debug_log!(
+            Genr,
+            1,
+            "generator prepare_pending_acl totals: calls={} elapsed_ns={}",
+            acl_calls,
+            acl_elapsed_ns
+        );
+        #[cfg(feature = "tracing")]
+        ::tracing::debug!(
+            target: "rsync::generator::prepare_acl",
+            calls = acl_calls,
+            elapsed_ns = acl_elapsed_ns,
+            "generator prepare_pending_acl totals"
+        );
+
         Ok(GeneratorStats {
             files_listed: file_count,
             files_transferred: transfer_result.files_transferred,


### PR DESCRIPTION
## Summary

- Adds INC_RECURSE diagnostic counter I5 (#2200): two process-global `AtomicU64` counters that track every `prepare_pending_acl` invocation on the generator file-list path and the cumulative wall time spent inside the helper.
- The counters fire from a single `record_prepare_acl` helper bumped from `prepare_pending_acl` itself, which wraps the existing body in an `Instant::now()` pair. The early-return path (`entry.is_symlink()` or `!flags.acls`) is still counted so per-segment call rate stays comparable to entry count, but contributes a near-zero ns delta.
- Totals are sampled in `GeneratorContext::run` via `prepare_acl_totals()` in the same finalize block used by PR #4103 (I1 first-byte latency), PR #4120 (I4 NDX partition_point) and PR #4121 (I3 flush rate), and emitted via `debug_log!(Genr, 1, ...)` plus a `tracing::debug!` event on `rsync::generator::prepare_acl` when the optional `tracing` feature is enabled.
- No new CLI flag, no wire-format change, no change to the public `prepare_pending_acl` signature.

## Test plan

- [ ] `cargo nextest run -p transfer --all-features -E 'test(prepare_acl)'` covers both new unit tests.
- [ ] CI fmt+clippy, nextest (stable), Windows, macOS, Linux musl all pass.
- [ ] Manual smoke: run a recursive transfer with `--acls -vv --debug=GENR` and confirm the new `generator prepare_pending_acl totals: calls=N elapsed_ns=M` line is emitted at end-of-transfer.

Closes #2200