### PR TITLE
feat(transfer): instrument encode_and_send_segment dispatch (INC_RECURSE I2)

### DIFF
--- a/crates/transfer/src/generator/mod.rs
+++ b/crates/transfer/src/generator/mod.rs
@@ -270,6 +270,47 @@ pub fn prepare_acl_totals() -> (u64, u64) {
     )
 }
 
+/// Total invocations of `encode_and_send_segment` across all generator
+/// transfers in this process. Diagnostic counter for sender-side INC_RECURSE
+/// (#2197, I2); quantifies how often per-directory segments are dispatched
+/// from the transfer loop and the segment scheduler, relative to the file
+/// count and the `MIN_FILECNT_LOOKAHEAD` throttling threshold.
+///
+/// Sampled at end-of-transfer in `GeneratorContext::run` via
+/// [`segment_dispatch_totals`] and emitted via `tracing::debug!`.
+static SEGMENT_DISPATCH_CALLS: AtomicU64 = AtomicU64::new(0);
+
+/// Cumulative elapsed time spent inside `encode_and_send_segment`, in
+/// nanoseconds, summed across every invocation. Diagnostic counter for
+/// sender-side INC_RECURSE (#2197, I2); lets operators see what share of the
+/// transfer wall time is spent encoding and pushing sub-list bytes onto the
+/// wire.
+static SEGMENT_DISPATCH_ELAPSED_NS: AtomicU64 = AtomicU64::new(0);
+
+/// Records one `encode_and_send_segment` invocation and adds its elapsed wall
+/// time (in nanoseconds, saturating to `u64::MAX`) to the cumulative counter.
+/// Used by `GeneratorContext::encode_and_send_segment` to bump
+/// [`SEGMENT_DISPATCH_CALLS`] / [`SEGMENT_DISPATCH_ELAPSED_NS`] for
+/// INC_RECURSE diagnostic I2 (#2197).
+pub(crate) fn record_segment_dispatch(elapsed: Duration) {
+    SEGMENT_DISPATCH_CALLS.fetch_add(1, Ordering::Relaxed);
+    let ns = u64::try_from(elapsed.as_nanos()).unwrap_or(u64::MAX);
+    SEGMENT_DISPATCH_ELAPSED_NS.fetch_add(ns, Ordering::Relaxed);
+}
+
+/// Snapshot of the global `encode_and_send_segment` counters.
+///
+/// Returns `(call_count, cumulative_elapsed_ns)`. Used by the generator
+/// finalize path to emit an end-of-transfer diagnostic line and by unit tests
+/// that assert the counters monotonically grow.
+#[must_use]
+pub fn segment_dispatch_totals() -> (u64, u64) {
+    (
+        SEGMENT_DISPATCH_CALLS.load(Ordering::Relaxed),
+        SEGMENT_DISPATCH_ELAPSED_NS.load(Ordering::Relaxed),
+    )
+}
+
 /// A pending file list sub-segment for incremental recursion sending.
 ///
 /// References entries in `GeneratorContext::file_list` by range rather than

--- a/crates/transfer/src/generator/protocol_io.rs
+++ b/crates/transfer/src/generator/protocol_io.rs
@@ -298,11 +298,32 @@ impl GeneratorContext {
     /// 3. Write end-of-list marker (0 byte)
     /// 4. Update NDX translation table
     ///
+    /// Updates the `SEGMENT_DISPATCH_CALLS` / `SEGMENT_DISPATCH_ELAPSED_NS`
+    /// counters used for INC_RECURSE diagnostic I2 (#2197). The timer wraps
+    /// the entire body so the zero-entry early-return path is still accounted
+    /// for in the per-transfer dispatch count.
+    ///
     /// # Upstream Reference
     ///
     /// - `flist.c:send_extra_file_list()` - sends one directory's entries
     /// - `flist.c:2931` - `ndx_start = prev->ndx_start + prev->used + 1`
     pub(super) fn encode_and_send_segment<W: Write>(
+        &mut self,
+        writer: &mut W,
+        segment: &super::PendingSegment,
+        flist_writer: &mut protocol::flist::FileListWriter,
+        ndx_codec: &mut NdxCodecEnum,
+    ) -> io::Result<()> {
+        let started = Instant::now();
+        let result = self.encode_and_send_segment_inner(writer, segment, flist_writer, ndx_codec);
+        super::record_segment_dispatch(started.elapsed());
+        result
+    }
+
+    /// Body of [`Self::encode_and_send_segment`] without the timing wrapper,
+    /// so the counter updates remain in a single place and the elapsed window
+    /// excludes only the `Instant::now()` pair itself.
+    fn encode_and_send_segment_inner<W: Write>(
         &mut self,
         writer: &mut W,
         segment: &super::PendingSegment,

--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -393,6 +393,51 @@ fn prepare_acl_totals_observable_without_prep() {
 }
 
 #[test]
+fn segment_dispatch_call_counter_increments() {
+    // INC_RECURSE diagnostic I2 (#2197): every record_segment_dispatch
+    // invocation must bump the global SEGMENT_DISPATCH_CALLS counter. The
+    // assertion uses >= because the counter is shared across the process and
+    // other tests may run concurrently.
+    use super::{record_segment_dispatch, segment_dispatch_totals};
+    use std::time::Duration;
+
+    let (calls_before, ns_before) = segment_dispatch_totals();
+
+    record_segment_dispatch(Duration::from_nanos(150));
+    record_segment_dispatch(Duration::from_nanos(250));
+    record_segment_dispatch(Duration::from_nanos(350));
+
+    let (calls_after, ns_after) = segment_dispatch_totals();
+    assert!(
+        calls_after >= calls_before + 3,
+        "expected at least 3 new segment dispatch calls (before={calls_before}, after={calls_after})"
+    );
+    assert!(
+        ns_after >= ns_before + 750,
+        "cumulative elapsed_ns should grow by at least 750 \
+         (before={ns_before}, after={ns_after})"
+    );
+}
+
+#[test]
+fn segment_dispatch_totals_observable_without_dispatch() {
+    // INC_RECURSE diagnostic I2 (#2197): the totals snapshot must be readable
+    // without dispatching any segment. Constructing a generator must not bump
+    // the counter on its own, so two adjacent reads with no intervening
+    // record_segment_dispatch call must return identical values.
+    use super::segment_dispatch_totals;
+
+    let (_handshake, _ctx) = test_generator();
+    let first = segment_dispatch_totals();
+    let second = segment_dispatch_totals();
+
+    assert_eq!(
+        first, second,
+        "segment_dispatch_totals must be a pure read (first={first:?}, second={second:?})"
+    );
+}
+
+#[test]
 fn build_and_send_round_trip() {
     use crate::receiver::ReceiverContext;
 

--- a/crates/transfer/src/generator/transfer.rs
+++ b/crates/transfer/src/generator/transfer.rs
@@ -872,6 +872,27 @@ impl GeneratorContext {
             "generator prepare_pending_acl totals"
         );
 
+        // INC_RECURSE diagnostic I2 (#2197): emit cumulative
+        // encode_and_send_segment dispatch count and elapsed wall time.
+        // Aggregated across all generator transfers in this process so
+        // operators can see how often per-directory sub-lists are flushed to
+        // the wire and what share of transfer time their encoding consumes.
+        let (segment_calls, segment_elapsed_ns) = super::segment_dispatch_totals();
+        debug_log!(
+            Genr,
+            1,
+            "generator encode_and_send_segment totals: calls={} elapsed_ns={}",
+            segment_calls,
+            segment_elapsed_ns
+        );
+        #[cfg(feature = "tracing")]
+        ::tracing::debug!(
+            target: "rsync::generator::segment_dispatch",
+            calls = segment_calls,
+            elapsed_ns = segment_elapsed_ns,
+            "generator encode_and_send_segment totals"
+        );
+
         Ok(GeneratorStats {
             files_listed: file_count,
             files_transferred: transfer_result.files_transferred,


### PR DESCRIPTION
## Summary
- Adds INC_RECURSE diagnostic counter I2 (#2197): two process-global `AtomicU64` counters that track every `encode_and_send_segment` invocation on the generator file-list path and the cumulative wall time spent inside the helper across all generator transfers.
- Counters fire from a single `record_segment_dispatch` helper bumped from `encode_and_send_segment` itself; the timer wraps the body via `Instant::now()`, so the zero-entry early-return path is still counted while contributing a near-zero ns delta.
- Totals are sampled in `GeneratorContext::run` via `segment_dispatch_totals()` in the same finalize block used by PR #4103 (I1 first-byte latency), PR #4120 (I4 NDX `partition_point`), PR #4121 (I3 flush rate) and PR #4142 (I5 `prepare_pending_acl`), and emitted via `debug_log!(Genr, 1, ...)` plus an optional `tracing::debug!` event on `rsync::generator::segment_dispatch`.

No new CLI flag, no wire-format change, no change to the public `encode_and_send_segment` signature.

## Test plan
- [x] `cargo fmt --all`
- [ ] CI: fmt+clippy
- [ ] CI: nextest (stable) - new tests `segment_dispatch_call_counter_increments` and `segment_dispatch_totals_observable_without_dispatch` in `crates/transfer/src/generator/tests.rs`
- [ ] CI: Windows, macOS, Linux musl

Closes #2197