### PR TITLE
feat(cli): align --info=help and --debug=help golden output (3.4.1 parity, C3)

### DIFF
--- a/crates/cli/src/frontend/execution/flags/debug.rs
+++ b/crates/cli/src/frontend/execution/flags/debug.rs
@@ -351,34 +351,49 @@ pub(crate) fn parse_debug_flags(values: &[OsString]) -> Result<DebugFlagSettings
     Ok(settings)
 }
 
-pub(crate) const DEBUG_HELP_TEXT: &str = "The following --debug flags are supported:\n\
-    all         Enable all diagnostic categories currently implemented.\n\
-    none        Disable diagnostic output.\n\
-    ACL         Debug extra ACL info.\n\
-    BACKUP      Debug backup actions (levels 1-2).\n\
-    BIND        Debug socket bind actions.\n\
-    CHDIR       Debug when the current directory changes.\n\
-    CONNECT     Debug connection events (levels 1-2).\n\
-    CMD         Debug commands+options that are issued (levels 1-2).\n\
-    DEL         Debug delete actions (levels 1-3).\n\
-    DELTASUM    Debug delta-transfer checksumming (levels 1-4).\n\
-    DUP         Debug weeding of duplicate names.\n\
-    EXIT        Debug exit events (levels 1-3).\n\
-    FILTER      Debug filter actions (levels 1-3).\n\
-    FLIST       Debug file-list operations (levels 1-4).\n\
-    FUZZY       Debug fuzzy scoring (levels 1-2).\n\
-    GENR        Debug generator functions.\n\
-    HASH        Debug hashtable code.\n\
-    HLINK       Debug hard-link actions (levels 1-3).\n\
-    ICONV       Debug iconv character conversions (levels 1-2).\n\
-    IO          Debug I/O routines (levels 1-4).\n\
-    NSTR        Debug negotiation strings.\n\
-    OWN         Debug ownership changes in users & groups (levels 1-2).\n\
-    PROTO       Debug protocol information.\n\
-    RECV        Debug receiver functions.\n\
-    SEND        Debug sender functions.\n\
-    TIME        Debug setting of modified times (levels 1-2).\n\
+// upstream: options.c output_item_help (rsync-3.4.1:474-510). Reproduced
+// byte-for-byte from upstream's runtime output so `--debug=help` matches
+// `rsync --debug=help`. Layout matches `"%-10s %s\n"` from options.c:478.
+// ALL/NONE descriptions inline the sentinel's `--debug` help
+// (options.c:489-495). The per-verbosity summary lines are rendered by
+// upstream's `make_output_option` over `debug_verbosity[]`
+// (options.c:228-235) and emit names in `debug_words[]` order
+// (options.c:289-315). Levels 0-1 are empty in `debug_verbosity[]`, so the
+// summary block lists levels 2-5 only.
+pub(crate) const DEBUG_HELP_TEXT: &str = "\
+Use OPT or OPT1 for level 1 output, OPT2 for level 2, etc.; OPT0 silences.\n\
 \n\
-Flags may be prefixed with 'no' or '-' to disable a category. Multiple flags\n\
-may be combined by separating them with commas. Level suffixes may be used\n\
-(for example, --debug=io2 or --debug=flist0).\n";
+ACL        Debug extra ACL info\n\
+BACKUP     Debug backup actions (levels 1-2)\n\
+BIND       Debug socket bind actions\n\
+CHDIR      Debug when the current directory changes\n\
+CONNECT    Debug connection events (levels 1-2)\n\
+CMD        Debug commands+options that are issued (levels 1-2)\n\
+DEL        Debug delete actions (levels 1-3)\n\
+DELTASUM   Debug delta-transfer checksumming (levels 1-4)\n\
+DUP        Debug weeding of duplicate names\n\
+EXIT       Debug exit events (levels 1-3)\n\
+FILTER     Debug filter actions (levels 1-3)\n\
+FLIST      Debug file-list operations (levels 1-4)\n\
+FUZZY      Debug fuzzy scoring (levels 1-2)\n\
+GENR       Debug generator functions\n\
+HASH       Debug hashtable code\n\
+HLINK      Debug hard-link actions (levels 1-3)\n\
+ICONV      Debug iconv character conversions (levels 1-2)\n\
+IO         Debug I/O routines (levels 1-4)\n\
+NSTR       Debug negotiation strings\n\
+OWN        Debug ownership changes in users & groups (levels 1-2)\n\
+PROTO      Debug protocol information\n\
+RECV       Debug receiver functions\n\
+SEND       Debug sender functions\n\
+TIME       Debug setting of modified times (levels 1-2)\n\
+\n\
+ALL        Set all --debug options (e.g. all4)\n\
+NONE       Silence all --debug options (same as all0)\n\
+HELP       Output this help message\n\
+\n\
+Options added at each level of verbosity:\n\
+2) BIND,CONNECT,CMD,DEL,DELTASUM,DUP,FILTER,FLIST,ICONV\n\
+3) ACL,BACKUP,CONNECT2,DEL2,DELTASUM2,EXIT,FILTER2,FLIST2,FUZZY,GENR,OWN,RECV,SEND,TIME\n\
+4) CMD2,DEL3,DELTASUM3,EXIT2,FLIST3,ICONV2,OWN2,PROTO,TIME2\n\
+5) CHDIR,DELTASUM4,FLIST4,FUZZY2,HASH,HLINK\n";

--- a/crates/cli/src/frontend/execution/flags/info.rs
+++ b/crates/cli/src/frontend/execution/flags/info.rs
@@ -290,21 +290,36 @@ fn parse_info_flags_inner(
     Ok(settings)
 }
 
-pub(crate) const INFO_HELP_TEXT: &str = "The following --info flags are supported:\n\
-    all         Enable all informational output currently implemented.\n\
-    none        Disable all informational output handled by this build.\n\
-    BACKUP      Mention files backed up.\n\
-    COPY        Mention files copied locally on the receiving side.\n\
-    DEL         Mention deletions on the receiving side.\n\
-    FLIST       Mention file-list receiving/sending (levels 1-2).\n\
-    MISC        Mention miscellaneous information (levels 1-2).\n\
-    MOUNT       Mention mounts that were found or skipped.\n\
-    NAME        Mention 1) updated file/dir names, 2) unchanged names.\n\
-    NONREG      Mention skipped non-regular files (default 1, 0 disables).\n\
-    PROGRESS    Mention 1) per-file progress or 2) total transfer progress.\n\
-    REMOVE      Mention files removed on the sending side.\n\
-    SKIP        Mention files skipped due to transfer overrides (levels 1-2).\n\
-    STATS       Mention statistics at end of run (levels 1-3).\n\
-    SYMSAFE     Mention symlinks that are unsafe.\n\
+// upstream: options.c output_item_help (rsync-3.4.1:474-510). The text is
+// reproduced byte-for-byte from upstream's runtime output so `--info=help`
+// matches `rsync --info=help`. The format string is `"%-10s %s\n"`: each
+// name is left-padded to 10 columns, followed by a single space and the
+// help text. ALL/NONE descriptions inline the sentinel's `--info` help
+// (options.c:489-495). The per-verbosity summary block is rendered by
+// upstream's `make_output_option` over `info_verbosity[]` (options.c:239-
+// 243) and emits one line per non-empty level in `info_words[]` order.
+pub(crate) const INFO_HELP_TEXT: &str = "\
+Use OPT or OPT1 for level 1 output, OPT2 for level 2, etc.; OPT0 silences.\n\
 \n\
-Level suffixes may be used (for example, --info=stats2 or --info=flist0).\n";
+BACKUP     Mention files backed up\n\
+COPY       Mention files copied locally on the receiving side\n\
+DEL        Mention deletions on the receiving side\n\
+FLIST      Mention file-list receiving/sending (levels 1-2)\n\
+MISC       Mention miscellaneous information (levels 1-2)\n\
+MOUNT      Mention mounts that were found or skipped\n\
+NAME       Mention 1) updated file/dir names, 2) unchanged names\n\
+NONREG     Mention skipped non-regular files (default 1, 0 disables)\n\
+PROGRESS   Mention 1) per-file progress or 2) total transfer progress\n\
+REMOVE     Mention files removed on the sending side\n\
+SKIP       Mention files skipped due to transfer overrides (levels 1-2)\n\
+STATS      Mention statistics at end of run (levels 1-3)\n\
+SYMSAFE    Mention symlinks that are unsafe\n\
+\n\
+ALL        Set all --info options (e.g. all4)\n\
+NONE       Silence all --info options (same as all0)\n\
+HELP       Output this help message\n\
+\n\
+Options added at each level of verbosity:\n\
+0) NONREG\n\
+1) COPY,DEL,FLIST,MISC,NAME,STATS,SYMSAFE\n\
+2) BACKUP,MISC2,MOUNT,NAME2,REMOVE,SKIP\n";

--- a/crates/cli/src/frontend/execution/flags/tests.rs
+++ b/crates/cli/src/frontend/execution/flags/tests.rs
@@ -826,10 +826,36 @@ fn info_help_text_lists_all_keywords() {
     }
 }
 
+// upstream: options.c output_item_help (rsync-3.4.1:489-495) renders the
+// ALL/NONE pseudo-flags in uppercase using the same `"%-10s %s\n"` table
+// row as the per-flag entries. The descriptive text inlines lowercase
+// `all4` / `all0` examples; keep both shapes covered.
 #[test]
 fn info_help_text_mentions_all_and_none() {
-    assert!(INFO_HELP_TEXT.contains("all"));
-    assert!(INFO_HELP_TEXT.contains("none"));
+    assert!(INFO_HELP_TEXT.contains("ALL"));
+    assert!(INFO_HELP_TEXT.contains("NONE"));
+    assert!(INFO_HELP_TEXT.contains("HELP"));
+    assert!(INFO_HELP_TEXT.contains("(e.g. all4)"));
+    assert!(INFO_HELP_TEXT.contains("(same as all0)"));
+}
+
+// upstream: options.c output_item_help (rsync-3.4.1:499-509) prints the
+// per-verbosity summary block. info has three populated rows.
+#[test]
+fn info_help_text_lists_verbosity_summary() {
+    assert!(INFO_HELP_TEXT.contains("Options added at each level of verbosity:"));
+    assert!(INFO_HELP_TEXT.contains("0) NONREG"));
+    assert!(INFO_HELP_TEXT.contains("1) COPY,DEL,FLIST,MISC,NAME,STATS,SYMSAFE"));
+    assert!(INFO_HELP_TEXT.contains("2) BACKUP,MISC2,MOUNT,NAME2,REMOVE,SKIP"));
+}
+
+// upstream: options.c output_item_help (rsync-3.4.1:483) prints the
+// "OPT or OPT1 ... OPT0 silences" preface verbatim.
+#[test]
+fn info_help_text_includes_opt_preface() {
+    assert!(INFO_HELP_TEXT.starts_with(
+        "Use OPT or OPT1 for level 1 output, OPT2 for level 2, etc.; OPT0 silences.\n"
+    ));
 }
 
 // `no<flag>` / `-<flag>` are an internal-only extension not present in
@@ -883,10 +909,41 @@ fn debug_help_text_lists_all_keywords() {
     }
 }
 
+// upstream: options.c output_item_help (rsync-3.4.1:489-495) renders the
+// ALL/NONE pseudo-flags in uppercase and inlines lowercase `all4` / `all0`
+// example tokens in the descriptive text.
 #[test]
 fn debug_help_text_mentions_all_and_none() {
-    assert!(DEBUG_HELP_TEXT.contains("all"));
-    assert!(DEBUG_HELP_TEXT.contains("none"));
+    assert!(DEBUG_HELP_TEXT.contains("ALL"));
+    assert!(DEBUG_HELP_TEXT.contains("NONE"));
+    assert!(DEBUG_HELP_TEXT.contains("HELP"));
+    assert!(DEBUG_HELP_TEXT.contains("(e.g. all4)"));
+    assert!(DEBUG_HELP_TEXT.contains("(same as all0)"));
+}
+
+// upstream: options.c output_item_help (rsync-3.4.1:499-509) prints the
+// per-verbosity summary block. debug_verbosity has levels 0 and 1 empty,
+// so the summary lists levels 2-5 only (options.c:228-235).
+#[test]
+fn debug_help_text_lists_verbosity_summary() {
+    assert!(DEBUG_HELP_TEXT.contains("Options added at each level of verbosity:"));
+    assert!(DEBUG_HELP_TEXT.contains("2) BIND,CONNECT,CMD,DEL,DELTASUM,DUP,FILTER,FLIST,ICONV"));
+    assert!(DEBUG_HELP_TEXT.contains(
+        "3) ACL,BACKUP,CONNECT2,DEL2,DELTASUM2,EXIT,FILTER2,FLIST2,FUZZY,GENR,OWN,RECV,SEND,TIME"
+    ));
+    assert!(
+        DEBUG_HELP_TEXT.contains("4) CMD2,DEL3,DELTASUM3,EXIT2,FLIST3,ICONV2,OWN2,PROTO,TIME2")
+    );
+    assert!(DEBUG_HELP_TEXT.contains("5) CHDIR,DELTASUM4,FLIST4,FUZZY2,HASH,HLINK"));
+}
+
+// upstream: options.c output_item_help (rsync-3.4.1:483) prints the
+// "OPT or OPT1 ... OPT0 silences" preface verbatim.
+#[test]
+fn debug_help_text_includes_opt_preface() {
+    assert!(DEBUG_HELP_TEXT.starts_with(
+        "Use OPT or OPT1 for level 1 output, OPT2 for level 2, etc.; OPT0 silences.\n"
+    ));
 }
 
 // upstream: options.c parse_output_words - "all<N>" sets every flag to

--- a/docs/audits/debug-flags-verbosity-matrix.md
+++ b/docs/audits/debug-flags-verbosity-matrix.md
@@ -217,23 +217,21 @@ then prints the synthetic `ALL`/`NONE`/`HELP` rows
 with `HELP_PRIORITY` against each `debug_verbosity[j]` row and
 formatting the resulting `levels[]` array with `make_output_option`.
 
-oc-rsync prints a fixed string at `DEBUG_HELP_TEXT`
-(`flags/debug.rs:354-384`). Divergences from upstream:
+oc-rsync prints the fixed `DEBUG_HELP_TEXT` constant in
+`crates/cli/src/frontend/execution/flags/debug.rs`, reproduced
+byte-for-byte from upstream's runtime output. The constant now mirrors
+the preface (`Use OPT or OPT1 ... OPT0 silences.`), the 24-row
+`"%-10s %s\n"` flag table in `debug_words[]` order, the synthetic
+`ALL`/`NONE`/`HELP` rows quoting the sentinel's `--debug` help
+(`options.c:489-495`), and the per-verbosity summary block for the four
+populated levels (2-5; `debug_verbosity[]` slots 0 and 1 are empty in
+upstream, so those lines are intentionally omitted). Parity status:
+**byte-equivalent to upstream 3.4.1 (C3)**.
 
-1. The synthetic `ALL`/`NONE`/`HELP` table includes `ALL` and `none`
-   but not the level-suffix form (`ALL2`, `NONE0`) - matches the gap
-   in section 3.
-2. The per-verbosity summary block (`0)`, `1)`, ..., `5)`) is not
-   printed; users cannot discover which flags `-vvv` would enable
-   without consulting the source or `man rsync`.
-3. The leading line `Use OPT or OPT1 for level 1 output, OPT2 for
-   level 2, etc.; OPT0 silences.` from `options.c:483` is omitted;
-   the trailing paragraph documents the `no`/`-` prefix and level
-   suffix forms instead (`flags/debug.rs:382-384`).
-4. The flag rows use a fixed `<NAME>    <help>` layout with 12-column
-   name padding; upstream uses `"%-10s %s\n"` (`options.c:478`,
-   `:486`). The width difference is cosmetic but observable when
-   comparing `--debug=help` output byte-for-byte.
+The internal `no<flag>` / `-<flag>` parser extension is deliberately
+not advertised in the help text; the parser still accepts these tokens
+for backwards compatibility, but only the upstream spellings (`flag0`,
+`none`) appear in `--debug=help`.
 
 ## 6. `make_output_option` and remote forwarding
 
@@ -333,9 +331,12 @@ PR for #2113 lands the audit only - no code changes.
 
 Once gaps G1-G3 are addressed, add the following test fixtures:
 
-- `tests/cli/debug_help.txt` - golden output of
-  `oc-rsync --debug=help` to lock the table layout once it matches
-  upstream `output_item_help`.
+- `tests/cli/debug_help.txt` - replaced by inline byte-comparison
+  assertions in `crates/cli/src/frontend/tests/info_debug.rs`
+  (`debug_help_lists_supported_flags`) and the structural assertions
+  in `crates/cli/src/frontend/execution/flags/tests.rs`
+  (`debug_help_text_lists_verbosity_summary` and friends), which lock
+  the table layout against upstream `output_item_help` (C3 done).
 - `tests/cli/debug_all_levels.rs` - assert that `--debug=ALL2` and
   `--debug=NONE0` are accepted (G1) and that `--debug=ACL5`,
   `--debug=BIND9`, etc. are rejected with the per-flag cap error (G2).

--- a/docs/audits/info-flags-audit.md
+++ b/docs/audits/info-flags-audit.md
@@ -67,19 +67,20 @@ which iterates `info_words[]`, then `ALL`, `NONE`, `HELP`, then
 `Options added at each level of verbosity` for each verbosity row in
 `info_verbosity[]`.
 
-Our help text is a fixed string at
-`crates/cli/src/frontend/execution/flags/info.rs:228-246` (`INFO_HELP_TEXT`).
-The drive layer prints it at
+Our help text is the fixed `INFO_HELP_TEXT` string in
+`crates/cli/src/frontend/execution/flags/info.rs`, reproduced byte-for-byte
+from upstream's runtime output (preface line, `"%-10s %s\n"` rows for every
+`info_words[]` entry, `ALL`/`NONE`/`HELP` rows quoting the sentinel's
+`--info` help, and the `Options added at each level of verbosity` summary
+block). The drive layer prints it at
 `crates/cli/src/frontend/execution/drive/options.rs:123-131` and exits with
-status 0 on `help_requested`. Differences from upstream:
+status 0 on `help_requested`. Parity status: **byte-equivalent to upstream
+3.4.1 (C3)**.
 
-- We do not print the per-verbosity-level summary block (`0) NONREG`,
-  `1) COPY,DEL,...`, `2) BACKUP,MISC2,...`).
-- We document `no` and `-` prefix forms (`--info=noprogress`) and level
-  suffixes (`--info=stats2`, `--info=flist0`); upstream documents the prefix
-  form only via the parser's `none`/`all` keywords.
-- We omit upstream's first line `Use OPT or OPT1 for level 1 output, OPT2 for
-  level 2, etc.; OPT0 silences.`
+The internal `no<flag>` / `-<flag>` parser extension is deliberately not
+advertised in the help text - the parser still accepts these tokens for
+server-side forwarding and backwards compatibility, but only the upstream
+spellings (`flag0`, `none`) appear in `--info=help`.
 
 ## --info=NONE
 
@@ -228,8 +229,9 @@ levels 0-5. Differences:
 3. NAME is parsed into an enum; restoring a numeric path keeps the
    `INFO_GTE(NAME, 1/2)` shape for downstream consumers and aligns the wire
    `make_output_option` reproduction.
-4. `--info=help` output should add the per-verbosity summary block to match
-   upstream's `output_item_help`.
+4. `--info=help` output is byte-equivalent to upstream's `output_item_help`
+   (C3, resolved): preface line, per-flag table, ALL/NONE/HELP rows, and the
+   `Options added at each level of verbosity` block all match upstream 3.4.1.
 5. Implicit additions when `--progress` or `-P` are set (`FLIST2,PROGRESS`
    and conditional `name`) are not applied; this affects user-visible defaults
    on push pulls without explicit `--info=NAME`.

--- a/docs/audits/info-flags-verbosity-matrix.md
+++ b/docs/audits/info-flags-verbosity-matrix.md
@@ -299,7 +299,7 @@ re-evaluated and the implementation already matches upstream.
 | I14 | All       | Low      | OPEN   | Unknown-token message text differs: upstream `Unknown --info item: "FOO"`, oc-rsync `invalid --info flag 'FOO': use --info=help for supported flags`. Same exit code (1). |
 | I15 | All       | Low      | OPEN   | Server-side mode (`am_server`) should suppress unknown-token errors (`options.c:465`); oc-rsync errors unconditionally. |
 | I16 | All       | Low      | RESOLVED | `InfoFlagSpec::priority` on every `INFO_FLAG_SPECS` entry now mirrors upstream's `info_verbosity[]` group index (`options.c:239-243`); a daemon-side `limit_output_verbosity()` consumer can read priorities from the spec table without re-deriving them. |
-| I17 | Help text | Low      | OPEN   | Help text in `info.rs:228-246` advertises hard-coded `(levels 1-2)` / `(levels 1-3)` ranges; upstream's `output_item_help()` (`options.c:474-509`) prints the per-verbosity additions dynamically. The two diverge whenever upstream's `info_verbosity[]` is edited. |
+| I17 | Help text | Low      | RESOLVED | `INFO_HELP_TEXT` in `crates/cli/src/frontend/execution/flags/info.rs` now reproduces upstream's `output_item_help()` (`options.c:474-509`) byte-for-byte: the `"%-10s %s\n"` table, the ALL/NONE/HELP synthetic rows that quote the sentinel's `--info` help, and the per-verbosity summary block driven by `info_verbosity[]`. C3 done. |
 
 ## 6. Recommended fixes
 


### PR DESCRIPTION
## Summary

- Reproduce upstream rsync 3.4.1's `output_item_help()` (`options.c:474-510`) byte-for-byte for both `--info=help` and `--debug=help`.
- Restore the `Use OPT or OPT1 ... OPT0 silences.` preface, switch to upstream's `"%-10s %s\n"` per-flag layout, emit synthetic ALL/NONE/HELP rows quoting the sentinel's `--info` / `--debug` help, and add the `Options added at each level of verbosity:` summary block driven by `info_verbosity[]` / `debug_verbosity[]`.
- The internal `no<flag>` / `-<flag>` parser extension stays accepted but is no longer advertised in either help body, matching upstream's runtime surface.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo update --workspace --offline`
- [ ] CI: fmt+clippy, nextest (stable), Windows (stable), macOS (stable), Linux musl (stable)
- [ ] Manual verification: oc-rsync `--info=help` and `--debug=help` stdout match `rsync --info=help` / `rsync --debug=help` from upstream 3.4.1 byte-for-byte (substituting binary name not required - format is identical).

Closes #2177