### PR TITLE
release: v0.6.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,7 +169,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "apple-fs"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "libc",
  "nix",
@@ -236,7 +236,7 @@ dependencies = [
 
 [[package]]
 name = "bandwidth"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "memchr",
  "proptest",
@@ -264,7 +264,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "batch"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "filetime",
  "metadata",
@@ -286,7 +286,7 @@ dependencies = [
 
 [[package]]
 name = "bin"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "assert_cmd",
  "checksums",
@@ -382,7 +382,7 @@ dependencies = [
 
 [[package]]
 name = "branding"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -523,7 +523,7 @@ dependencies = [
 
 [[package]]
 name = "checksums"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "crc32c",
  "criterion",
@@ -647,7 +647,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "apple-fs",
  "assert_cmd",
@@ -704,7 +704,7 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "compress"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "flate2",
  "lz4_flex",
@@ -726,7 +726,7 @@ checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "core"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "bandwidth",
  "base64",
@@ -1008,7 +1008,7 @@ dependencies = [
 
 [[package]]
 name = "daemon"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "bandwidth",
  "base64",
@@ -1218,7 +1218,7 @@ dependencies = [
 
 [[package]]
 name = "embedding"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "cli",
  "core",
@@ -1236,7 +1236,7 @@ dependencies = [
 
 [[package]]
 name = "engine"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "apple-fs",
  "bandwidth",
@@ -1260,7 +1260,7 @@ dependencies = [
  "rayon",
  "rustc-hash",
  "rustix",
- "signature 0.6.1",
+ "signature 0.6.2",
  "tempfile",
  "test-support",
  "thiserror 2.0.18",
@@ -1312,7 +1312,7 @@ dependencies = [
 
 [[package]]
 name = "fast_io"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "criterion",
  "filetime",
@@ -1352,7 +1352,7 @@ dependencies = [
 
 [[package]]
 name = "filters"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "globset",
  "logging",
@@ -1383,7 +1383,7 @@ dependencies = [
 
 [[package]]
 name = "flist"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "libc",
  "logging",
@@ -2117,7 +2117,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "logging"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -2127,7 +2127,7 @@ dependencies = [
 
 [[package]]
 name = "logging-sink"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "core",
  "syslog",
@@ -2153,7 +2153,7 @@ dependencies = [
 
 [[package]]
 name = "matching"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "checksums",
  "criterion",
@@ -2161,7 +2161,7 @@ dependencies = [
  "proptest",
  "protocol",
  "rustc-hash",
- "signature 0.6.1",
+ "signature 0.6.2",
  "tempfile",
  "thiserror 2.0.18",
  "tracing",
@@ -2219,7 +2219,7 @@ dependencies = [
 
 [[package]]
 name = "metadata"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "apple-fs",
  "exacl",
@@ -2664,7 +2664,7 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "platform"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "libc",
  "nix",
@@ -2853,7 +2853,7 @@ dependencies = [
 
 [[package]]
 name = "protocol"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "bytes",
  "compress",
@@ -3097,7 +3097,7 @@ dependencies = [
 
 [[package]]
 name = "rsync_io"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "is-terminal",
  "logging",
@@ -3588,7 +3588,7 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "checksums",
  "protocol",
@@ -3765,7 +3765,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-support"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "tempfile",
 ]
@@ -4042,7 +4042,7 @@ dependencies = [
 
 [[package]]
 name = "transfer"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "apple-fs",
  "checksums",
@@ -4061,7 +4061,7 @@ dependencies = [
  "protocol",
  "rand 0.9.4",
  "rayon",
- "signature 0.6.1",
+ "signature 0.6.2",
  "tempfile",
  "test-support",
  "thiserror 2.0.18",
@@ -4426,7 +4426,7 @@ dependencies = [
 
 [[package]]
 name = "windows-gnu-eh"
-version = "0.6.1"
+version = "0.6.2"
 
 [[package]]
 name = "windows-implement"
@@ -4770,7 +4770,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anstyle",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -173,7 +173,7 @@ edition = "2024"
 rust-version = "1.88"
 authors = ["Ofer Chen <skewers.irises.3b@icloud.com>"]
 license = "GPL-3.0-or-later"
-version = "0.6.1"
+version = "0.6.2"
 repository = "https://github.com/oferchen/rsync"
 
 [workspace.dependencies]
@@ -347,7 +347,7 @@ strip = false
 [workspace.metadata.oc_rsync]
 brand = "oc"
 upstream_version = "3.4.2"
-rust_version = "0.6.1"
+rust_version = "0.6.2"
 protocol = 32
 client_bin = "oc-rsync"
 daemon_bin = "oc-rsync"

--- a/README.md
+++ b/README.md
@@ -57,53 +57,64 @@ Legend: ✓ supported, ⚠ partial or not yet wired, ✗ not implemented.
 
 ### What's New (v0.6.2)
 
-**Protocol & interop**
-- INC_RECURSE sender enabled by default for both push and pull directions
-- Rolling checksum now sign-extends bytes to match upstream's `schar` semantics, fixing block-match parity at protocol >= 30
-- `--jump-host` for multi-hop SSH transports, with a dedicated proxy-jump interop test against upstream 3.4.1
+**Bug fixes**
+- `--include='*/'` followed by `--exclude='*'` now allows directory traversal while excluding leaf files, matching upstream byte-for-byte (#4107). Slash modifiers are stripped before wire serialisation and rebuilt on the receiver.
+- `--relative` single-source daemon-push path stripping aligned with upstream (#4074)
 
-**Charset translation (`--iconv`)**
-- End-to-end iconv pipeline: file list ingest (receiver) and emit (sender), symlink targets, `--files-from`, and secluded args all flow through `FilenameConverter`
-- Client-side resolver now uses UTF-8 as the wire charset, matching upstream `rsync.c:130-140`
-- `--iconv` forwarded to remote rsync server args (SSH) and to daemon args (`rsync://`), mirroring upstream `options.c:2716-2723`
-- Server-mode flag parser recognises `--iconv=` and `--timeout=` so they no longer leak into positional args and corrupt the destination path
-- Daemon module `charset =` directive wires per-module iconv into the runtime
-- Golden byte tests for iconv-converted filenames; live interop test against upstream 3.4.1
+**`--info` producer emissions (upstream parity)**
+- `--info=NONREG` (default-on) reports skipped non-regular source files (`generator.c:1687`)
+- `--info=MOUNT` reports `--one-file-system` mount-boundary skips (`flist.c:1319`, `generator.c:325`)
+- `--info=SYMSAFE` reports unsafe symlink rejections (`backup.c:291`, `flist.c:216`)
+- `--info=BACKUP` reports `--backup` rename successes (`backup.c:352`)
+- `--info=COPY` reports `--copy-dest`/`--link-dest`/`--compare-dest` alt-base resolution (`generator.c:919`)
+- `--info=STATS` level 1/2/3 distinction restored - level 1 emits only the trailing summary, level 2 adds the file-count detail block, level 3 surfaces heap stats (`main.c:416-465`)
 
-**Daemon**
-- `fake super = yes` module directive consumed by daemon and transfer paths
-- `charset =` module directive wired into the iconv runtime
+**`--debug` producer emissions (upstream parity)**
+- `--debug=ACL` daemon-side default-ACL probes (`acls.c:1133-1134`)
+- `--debug=BACKUP` rename/replace/cross-device internal decisions
+- `--debug=BIND` `socket()`/`bind()` failure diagnostics per address family (`socket.c:432-470`)
+- `--debug=CHDIR` post-`chroot` `change_dir` notice in the daemon (`util1.c:1168-1169`)
+- `--debug=CMD` SSH command construction and secluded-args transmission (`util1.c:98-117`, `pipe.c:54-55`)
+- `--debug=FUZZY` fuzzy basis selection (`generator.c`)
+- `--debug=GENR` generator entry points
+- `--debug=HASH` delta-signature hashtable lifecycle (`hashtable.c:45-103`)
+- `--debug=HLINK` (previously merged) hardlink resolution
+- `--debug=ICONV` iconv setup/probe lines (`rsync.c:99-145`)
+- `--debug=OWN` uid/gid lookup and `chown` diagnostics (`rsync.c:537-545`, `uidlist.c:287-291`)
+- `--info=help` / `--debug=help` golden output now byte-matches upstream (`options.c:499-509`)
 
-**Windows platform**
-- Native NTFS ACL round-trip (`-A`) via `windows-rs` `GetSecurityInfo` / `SetSecurityInfo`
-- Extended attributes (`-X`) stored as NTFS Alternate Data Streams
-- IOCP socket I/O via `WSARecv` / `WSASend` for daemon and SSH transports
+**INC_RECURSE instrumentation (sender-side)**
+- First-byte latency in `send_file_list`
+- `wire_to_flat_ndx` / `flat_to_wire_ndx` partition_point counters
+- `writer.flush()` call-rate on the transfer hot path
+- `prepare_pending_acl` per-segment call count and elapsed time
+- `encode_and_send_segment` per-segment dispatch counter
 
-**macOS platform**
-- AppleDouble (`._` resource-fork sidecars) wire-compatible with upstream rsync
+**Compression**
+- `--compress-threads=N` flag wires through to `ZSTD_c_nbWorkers` for multi-threaded zstd (3.4.2 parity)
 
-**Compatibility**
-- `--fake-super` mode for unprivileged metadata preservation via xattrs, with `am_root` forced false so ownership is encoded in `user.rsync.%stat` rather than applied
-- `-oBatchMode=yes` injection now gated on `is_ssh_program()` so non-OpenSSH transports (e.g. `rsh`) are no longer corrupted
+**Checksums**
+- SIMD vs scalar self-test added (cargo-fuzz target + unit test) cross-validating AVX2, SSE2, NEON, and scalar implementations at startup (3.4.2 parity)
 
-**Performance**
-- io_uring shared submission ring across reader and writer worker pools
-- io_uring SEND-path deadlock eliminated under sustained TCP back-pressure
+**Upstream interop**
+- Pinned upstream interop matrix bumped to rsync **3.4.2** (in addition to 3.0.9, 3.1.3, 3.4.1)
+- Scheduled GitHub Actions watcher for new upstream releases
 
-**Security & code quality**
-- `SensitiveBytes` uses the `zeroize` crate to scrub daemon credentials and auth secrets on drop
-- Safe `syslog` crate replaces hand-rolled FFI in the logging-sink crate
-- `setsockopt` FFI consolidated into the `fast_io` crate per the unsafe-code policy
+**Code quality**
+- Comment audit pass across all 25 workspace crates: restating comments removed, public-item `///` rustdoc applied, every `// upstream:` source reference preserved
+- Removed redundant `#[must_use]` from `Result`/`Option` returning functions across the workspace (#2123)
+- Filter-rule sender-side directive support
+- Compressed-stream negative-token decoder hardened against 3.4.2 regression pattern
 
-**Testing & CI**
-- Property tests added for compress codec round-trip, rolling-checksum SIMD/scalar parity, FilterChain precedence/anchoring, and bwlimit rate/burst pacing
-- CI fail-fast guard rejects stale `Cargo.lock`
-- `standalone:delta-stats` and `iconv-local-ssh` cleared from `KNOWN_FAILURES`
+**Daemon & metadata**
+- Daemon `chrono::Local` pre-initialised before `chroot` so timezone-aware log timestamps survive jail entry (3.4.2 parity)
+- `--open-noatime` properly propagated through sender source-file opens (3.4.2 parity)
+- ACL ID mapping audited against 3.4.2 non-root mapping fix (#618)
+- `clean_fname()` buffer underflow, xattr qsort parity, allocator-zeroing, and Y2038 paths all audited against 3.4.2
 
 **Documentation**
-- SSH transport timeout coverage matrix
-- Eliminate-path matrix for `tools/ci/known_failures.conf`
-- Audit confirming filter rules match upstream's iconv policy
+- Deployment / TLS guide expanded
+- Filter-flags audit, info-flags audit, and debug-flags-verbosity matrix kept current
 
 ### Interop Testing
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Binary name: **`oc-rsync`** - installs alongside system `rsync` without conflict
 
 ## Status
 
-**Release:** 0.6.1 (alpha) - Wire-compatible drop-in replacement for rsync 3.4.2 (and 3.4.1, protocols 28-32).
+**Release:** 0.6.2 (alpha) - Wire-compatible drop-in replacement for rsync 3.4.2 (and 3.4.1, protocols 28-32).
 
 All transfer modes (local, SSH, daemon), delta algorithm, metadata preservation, incremental recursion, and compression are complete. Interop tested against upstream rsync 3.0.9, 3.1.3, and 3.4.1.
 
@@ -55,7 +55,7 @@ The primary platform is Linux. macOS is well-supported with parity for all metad
 
 Legend: ✓ supported, ⚠ partial or not yet wired, ✗ not implemented.
 
-### What's New (v0.6.1)
+### What's New (v0.6.2)
 
 **Protocol & interop**
 - INC_RECURSE sender enabled by default for both push and pull directions

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.6.x   | :white_check_mark: |
+| 0.6.x   | :white_check_mark: (current: 0.6.2) |
 | 0.5.x   | :warning: critical fixes only |
 | < 0.5   | :x:                |
 
@@ -39,7 +39,7 @@ oc-rsync leverages Rust's memory safety to eliminate entire vulnerability classe
 ### Unsafe Code Policy
 
 Crates that enforce `#![deny(unsafe_code)]` with no allow-listed exceptions:
-- `daemon`, `cli`, `core`, `transfer`, `batch`, `filters`, `signature`, `match`, `bandwidth`, `logging`, `logging-sink`, `branding`, `rsync_io`, `compress`, `apple-fs`, `flist` - business logic, parsers, orchestration, and high-level I/O wrappers
+- `daemon`, `cli`, `core`, `transfer`, `batch`, `filters`, `signature`, `matching`, `bandwidth`, `logging`, `logging-sink`, `branding`, `rsync_io`, `compress`, `apple-fs`, `flist`, `embedding`, `test-support` - business logic, parsers, orchestration, and high-level I/O wrappers
 
 Crates with `#![deny(unsafe_code)]` and targeted `#[allow(unsafe_code)]` for documented FFI/SIMD boundaries:
 - `metadata` - Ownership and privilege FFI (UID/GID lookup via `getpwuid_r`/`getgrnam_r`, `setuid`/`setgid`, `setattrlist`)
@@ -69,11 +69,31 @@ oc-rsync monitors upstream rsync CVEs to verify continued non-applicability. Rec
 | CVE-2024-12088 | --safe-links bypass | Mitigated | Rust path handling |
 | CVE-2024-12747 | Symlink race condition | Mitigated | TOCTOU is OS-level |
 
+### Upstream rsync 3.4.2 audits
+
+In v0.6.2 the codebase was audited against every fix that landed in upstream rsync 3.4.2 (released 2026). The equivalent code paths were verified safe in oc-rsync:
+
+- Compressed-stream negative-token decoder bounds (#2225)
+- Xattr `qsort` element-count parity (#2226)
+- `clean_fname()` buffer-underflow parity (#2227)
+- Allocator zeroing pattern (calloc + realloc-expand) (#2228)
+- Y2038 safety in syscall paths (Int32x32To64 equivalent) (#2229)
+- ACL ID mapping for non-root users (#2230, closes #618)
+- FreeBSD many-xattrs handling parity (#2231)
+- "Directory has vanished" error path (#2232)
+- Removal of multiple leading slashes (#2233)
+- Daemon `chrono::Local` pre-init before `chroot` (#2234)
+- `--open-noatime` propagation through sender source-file opens (#2236)
+- AVX2 `get_checksum1` `mul_one` uninitialised-regression audit (#2222)
+- MD4 `get_checksum2` `buf1` uninitialised-regression audit (#2223)
+- SIMD vs scalar self-test that cross-validates AVX2/SSE2/NEON paths at startup (#2224)
+
 ### Monitoring Process
 
 1. **Subscribe to rsync-announce**: https://lists.samba.org/mailman/listinfo/rsync-announce
 2. **Monitor NVD**: https://nvd.nist.gov/vuln/search?query=rsync
 3. **GitHub Security Advisories**: Watch this repository for security advisories
+4. **Scheduled CI watcher**: `tools/ci/check_upstream_release.sh` runs weekly via GitHub Actions and opens a tracking issue when a new upstream rsync release ships, so new CVEs are surfaced automatically
 
 ### When New CVEs Are Published
 
@@ -86,17 +106,20 @@ For each new upstream rsync CVE:
 
 ## Fuzzing
 
-The protocol crate includes cargo-fuzz targets for security-critical parsing:
+The repo ships cargo-fuzz targets for security-critical parsing and SIMD parity:
 
 ```bash
-cd crates/protocol/fuzz
+cd fuzz
 cargo +nightly fuzz run fuzz_varint
 cargo +nightly fuzz run fuzz_delta
 cargo +nightly fuzz run fuzz_multiplex_frame
 cargo +nightly fuzz run fuzz_legacy_greeting
+cargo +nightly fuzz run simd_checksum_parity
 ```
 
-See `crates/protocol/fuzz/README.md` for detailed fuzzing instructions.
+`simd_checksum_parity` cross-validates the AVX2, SSE2, NEON, and scalar
+rolling/strong checksum paths against random inputs (see #2103). See `fuzz/README.md`
+for detailed fuzzing instructions.
 
 ## Hardening Notes
 


### PR DESCRIPTION
Version bump for v0.6.2 release.

Notable changes since v0.6.1:
- Fix #4107 --include/\*--exclude precedence (PR #4111)
- Restore --info=STATS level 1/2/3 distinction (PR #4106)
- Wire --info producer emissions: NONREG, MOUNT, SYMSAFE, BACKUP, COPY (PRs #4113-#4116)
- Wire --debug producer emissions: FUZZY, GENR, ICONV, ACL, BACKUP, OWN, HASH, CHDIR, CMD, BIND (PRs #4109-#4146)
- INC_RECURSE instrumentation: NDX partition counters, flush rate, prepare_pending_acl, encode_and_send_segment (PRs #4120, #4121, #4142, #4143)
- Align --info=help / --debug=help golden output (PR #4147)
- Comment audit pass across all 25 crates (PRs #4124-#4140)