### PR TITLE
fix(ci): benchmark script points to rsync-3.4.2 (matches workflow build)

### DIFF
--- a/.github/scripts/benchmark.py
+++ b/.github/scripts/benchmark.py
@@ -15,7 +15,7 @@ import sys
 import tempfile
 import time
 
-UPSTREAM = "target/interop/upstream-src/rsync-3.4.1/rsync"
+UPSTREAM = "target/interop/upstream-src/rsync-3.4.2/rsync"
 OC_RSYNC = "target/release/oc-rsync"
 OC_RSYNC_OPENSSL = os.environ.get("OC_RSYNC_OPENSSL", "")
 OC_RSYNC_RUSSH = os.environ.get("OC_RSYNC_RUSSH", "")


### PR DESCRIPTION
The Benchmark workflow on tag push failed for v0.6.2 because `.github/scripts/benchmark.py` hard-coded `target/interop/upstream-src/rsync-3.4.1/rsync` while `.github/workflows/benchmark.yml` builds upstream rsync at `rsync-3.4.2/`. Single-line update aligns the script with the workflow.