### PR TITLE
feat(ci): 3-way SSH transport benchmark (upstream vs oc-rsync subprocess vs russh)

### DIFF
--- a/.github/scripts/benchmark.py
+++ b/.github/scripts/benchmark.py
@@ -124,15 +124,18 @@ OPENSSL_TESTS = [
     },
 ]
 
-# SSH transport comparison: subprocess `ssh` (host:path operand) vs embedded
-# russh (`ssh://` URI operand). Only run if OC_RSYNC_RUSSH is set.
+# SSH transport comparison: upstream rsync over OpenSSH subprocess, oc-rsync
+# over OpenSSH subprocess (`host:path` operand), and oc-rsync over embedded
+# russh (`ssh://host/path` URI operand). Only run if OC_RSYNC_RUSSH is set.
 # The default oc-rsync binary handles the subprocess form; the russh-built
-# binary handles the URI form via the embedded transport.
+# binary handles the URI form via the embedded transport. Upstream rsync is
+# always invoked through OpenSSH.
 RUSSH_TESTS = [
     {
         "id": "ssh_transport_pull_initial",
         "name": "Initial pull",
         "mode": "ssh_transport",
+        "upstream_args": "-av --timeout=30 localhost:{src}/ {dst}/",
         "subprocess_args": "-av --timeout=30 localhost:{src}/ {dst}/",
         "russh_args": "-av --timeout=30 ssh://localhost{src}/ {dst}/",
         "reset": True,
@@ -141,6 +144,7 @@ RUSSH_TESTS = [
         "id": "ssh_transport_pull_nochange",
         "name": "No-change pull",
         "mode": "ssh_transport",
+        "upstream_args": "-av --timeout=30 localhost:{src}/ {dst}/",
         "subprocess_args": "-av --timeout=30 localhost:{src}/ {dst}/",
         "russh_args": "-av --timeout=30 ssh://localhost{src}/ {dst}/",
         "reset": False,
@@ -149,6 +153,7 @@ RUSSH_TESTS = [
         "id": "ssh_transport_push_initial",
         "name": "Initial push",
         "mode": "ssh_transport",
+        "upstream_args": "-av --timeout=30 {src}/ localhost:{dst}/",
         "subprocess_args": "-av --timeout=30 {src}/ localhost:{dst}/",
         "russh_args": "-av --timeout=30 {src}/ ssh://localhost{dst}/",
         "reset": True,
@@ -157,6 +162,7 @@ RUSSH_TESTS = [
         "id": "ssh_transport_push_nochange",
         "name": "No-change push",
         "mode": "ssh_transport",
+        "upstream_args": "-av --timeout=30 {src}/ localhost:{dst}/",
         "subprocess_args": "-av --timeout=30 {src}/ localhost:{dst}/",
         "russh_args": "-av --timeout=30 {src}/ ssh://localhost{dst}/",
         "reset": False,
@@ -558,25 +564,31 @@ def main():
                 file=sys.stderr,
             )
 
-        # SSH transport: subprocess vs embedded russh
+        # SSH transport: 3-way comparison
+        #   1. upstream rsync over OpenSSH subprocess (host:path)
+        #   2. oc-rsync over OpenSSH subprocess (host:path)
+        #   3. oc-rsync over embedded russh (ssh://host/path)
         if OC_RSYNC_RUSSH and os.path.isfile(OC_RSYNC_RUSSH):
-            print("Running SSH transport (subprocess vs russh)...", file=sys.stderr)
+            print(
+                "Running SSH transport (upstream vs oc-rsync subprocess vs russh)...",
+                file=sys.stderr,
+            )
+            dst_upstream_pull = f"{tmpdir}/dst_upstream_pull"
             dst_sub_pull = f"{tmpdir}/dst_sub_pull"
             dst_russh_pull = f"{tmpdir}/dst_russh_pull"
+            dst_upstream_push = f"{tmpdir}/dst_upstream_push"
             dst_sub_push = f"{tmpdir}/dst_sub_push"
             dst_russh_push = f"{tmpdir}/dst_russh_push"
 
             def reset_transport_pull():
-                shutil.rmtree(dst_sub_pull, ignore_errors=True)
-                shutil.rmtree(dst_russh_pull, ignore_errors=True)
-                os.makedirs(dst_sub_pull, exist_ok=True)
-                os.makedirs(dst_russh_pull, exist_ok=True)
+                for d in (dst_upstream_pull, dst_sub_pull, dst_russh_pull):
+                    shutil.rmtree(d, ignore_errors=True)
+                    os.makedirs(d, exist_ok=True)
 
             def reset_transport_push():
-                shutil.rmtree(dst_sub_push, ignore_errors=True)
-                shutil.rmtree(dst_russh_push, ignore_errors=True)
-                os.makedirs(dst_sub_push, exist_ok=True)
-                os.makedirs(dst_russh_push, exist_ok=True)
+                for d in (dst_upstream_push, dst_sub_push, dst_russh_push):
+                    shutil.rmtree(d, ignore_errors=True)
+                    os.makedirs(d, exist_ok=True)
 
             for test in RUSSH_TESTS:
                 test_id = test["id"]
@@ -593,33 +605,49 @@ def main():
                         reset_transport_pull()
 
                 if is_push:
+                    upstream_dst = dst_upstream_push
                     sub_dst, russh_dst = dst_sub_push, dst_russh_push
                 else:
+                    upstream_dst = dst_upstream_pull
                     sub_dst, russh_dst = dst_sub_pull, dst_russh_pull
 
+                upstream_args = test["upstream_args"].format(src=src, dst=upstream_dst)
                 sub_args = test["subprocess_args"].format(src=src, dst=sub_dst)
                 russh_args = test["russh_args"].format(src=src, dst=russh_dst)
 
+                upstream_result = benchmark(f"{UPSTREAM} {upstream_args}")
                 sub_result = benchmark(f"{OC_RSYNC} {sub_args}")
                 russh_result = benchmark(f"{OC_RSYNC_RUSSH} {russh_args}")
 
-                ratio = (
+                ratio_russh_vs_sub = (
                     russh_result["mean"] / sub_result["mean"]
                     if sub_result["mean"] > 0
                     else 0
                 )
+                ratio_sub_vs_upstream = (
+                    sub_result["mean"] / upstream_result["mean"]
+                    if upstream_result["mean"] > 0
+                    else 0
+                )
 
-                # "upstream" field repurposed as the subprocess baseline so the
-                # report/chart can render this as a two-bar comparison without
-                # special-casing the data shape.
+                # The new fields `upstream_ssh`, `oc_subprocess`, `oc_russh`
+                # describe the 3-way comparison directly. The legacy `upstream`,
+                # `oc_rsync`, and `ratio` fields are kept (subprocess vs russh)
+                # so older chart/report renderers continue to work unchanged.
                 results["tests"].append(
                     {
                         "id": test_id,
                         "name": name,
                         "mode": mode,
+                        "upstream_ssh": upstream_result,
+                        "oc_subprocess": sub_result,
+                        "oc_russh": russh_result,
+                        "ratio_russh_vs_sub": round(ratio_russh_vs_sub, 2),
+                        "ratio_sub_vs_upstream": round(ratio_sub_vs_upstream, 2),
+                        # Backwards-compat shape for two-bar renderers.
                         "upstream": sub_result,
                         "oc_rsync": russh_result,
-                        "ratio": round(ratio, 2),
+                        "ratio": round(ratio_russh_vs_sub, 2),
                     }
                 )
         elif OC_RSYNC_RUSSH:

--- a/.github/scripts/benchmark_chart.py
+++ b/.github/scripts/benchmark_chart.py
@@ -58,6 +58,7 @@ COLOR_PURE_RUST = "#58a6ff"
 COLOR_OPENSSL = "#d2a8ff"
 COLOR_STD_IO = "#da8b45"
 COLOR_IO_URING = "#3fb950"
+COLOR_SSH_UPSTREAM = "#6e7681"
 COLOR_SSH_SUBPROCESS = "#56d4dd"
 COLOR_SSH_RUSSH = "#ffa657"
 COLOR_TITLE = "#e6edf3"
@@ -94,7 +95,9 @@ MODE_LABELS = {
     "memory": "Memory Usage",
     "checksum_openssl": "Checksum: OpenSSL vs Pure Rust",
     "io_uring": "io_uring vs Standard I/O",
-    "ssh_transport": "SSH Transport: Subprocess vs russh",
+    "ssh_transport": (
+        "SSH Transport: upstream vs oc-rsync subprocess vs oc-rsync russh"
+    ),
 }
 MODE_CLI_HINTS = {
     "local": "rsync -av src/ dst/",
@@ -110,7 +113,10 @@ MODE_CLI_HINTS = {
     "memory": "rsync -av (peak RSS measurement)",
     "checksum_openssl": "rsync -avc src/ dst/",
     "io_uring": "--io-uring vs --no-io-uring",
-    "ssh_transport": "host:path (subprocess) vs ssh://host/path (russh)",
+    "ssh_transport": (
+        "upstream ssh vs oc-rsync host:path (subprocess) "
+        "vs oc-rsync ssh://host/path (russh)"
+    ),
 }
 
 # Modes where bars represent alternative labels instead of upstream vs oc-rsync
@@ -138,13 +144,24 @@ class BarSpec:
 
 @dataclass(frozen=True)
 class TestPair:
-    """A pair of bars (upstream + oc-rsync) for one test scenario."""
+    """A pair of bars (upstream + oc-rsync) for one test scenario.
+
+    Some modes (e.g. the 3-way SSH transport comparison) include an optional
+    third bar and a second ratio annotation. When `third` is set:
+      - `upstream` carries the first leg (e.g. upstream rsync over ssh)
+      - `oc_rsync` carries the second leg (e.g. oc-rsync subprocess ssh)
+      - `third` carries the third leg (e.g. oc-rsync embedded russh)
+      - `ratio` annotates third vs oc_rsync (russh / subprocess)
+      - `ratio_secondary` annotates oc_rsync vs upstream (oc-sub / upstream)
+    """
 
     name: str
     upstream: BarSpec
     oc_rsync: BarSpec
     ratio: float
     center_y: float
+    third: BarSpec | None = None
+    ratio_secondary: float | None = None
 
 
 @dataclass(frozen=True)
@@ -174,13 +191,23 @@ class ChartLayout:
 # ---------------------------------------------------------------------------
 
 
+def _is_three_way_ssh(mode: str, t: dict) -> bool:
+    """True when this row should render as the 3-way SSH transport bar group."""
+    return mode in SSH_TRANSPORT_MODES and "upstream_ssh" in t
+
+
 def compute_layout(tests_by_mode: dict[str, list[dict]]) -> ChartLayout:
     """Compute y-positions for every element and overall chart dimensions."""
     all_times = []
-    for mode_tests in tests_by_mode.values():
+    for mode, mode_tests in tests_by_mode.items():
         for t in mode_tests:
-            all_times.append(t["upstream"]["mean"])
-            all_times.append(t["oc_rsync"]["mean"])
+            if _is_three_way_ssh(mode, t):
+                all_times.append(t["upstream_ssh"]["mean"])
+                all_times.append(t["oc_subprocess"]["mean"])
+                all_times.append(t["oc_russh"]["mean"])
+            else:
+                all_times.append(t["upstream"]["mean"])
+                all_times.append(t["oc_rsync"]["mean"])
 
     max_time = max(all_times) if all_times else 1.0
     scale = BAR_AREA_WIDTH / (max_time * 1.1)
@@ -209,36 +236,90 @@ def compute_layout(tests_by_mode: dict[str, list[dict]]) -> ChartLayout:
             if j > 0:
                 y += GROUP_GAP
 
+            three_way = _is_three_way_ssh(mode, t)
+
             up_y = y
             oc_y = y + BAR_HEIGHT + BAR_GAP
-            center_y = y + BAR_HEIGHT + BAR_GAP / 2
+            third_y = y + 2 * (BAR_HEIGHT + BAR_GAP)
 
-            up_w = max(t["upstream"]["mean"] * scale, MIN_BAR_WIDTH)
-            oc_w = max(t["oc_rsync"]["mean"] * scale, MIN_BAR_WIDTH)
+            if three_way:
+                # Center vertically between bar 1 and bar 3.
+                center_y = y + (3 * BAR_HEIGHT + 2 * BAR_GAP) / 2
+            else:
+                center_y = y + BAR_HEIGHT + BAR_GAP / 2
+
+            if three_way:
+                up_t = t["upstream_ssh"]["mean"]
+                oc_t = t["oc_subprocess"]["mean"]
+                third_t = t["oc_russh"]["mean"]
+            else:
+                up_t = t["upstream"]["mean"]
+                oc_t = t["oc_rsync"]["mean"]
+                third_t = None
+
+            up_w = max(up_t * scale, MIN_BAR_WIDTH)
+            oc_w = max(oc_t * scale, MIN_BAR_WIDTH)
+            third_w = (
+                max(third_t * scale, MIN_BAR_WIDTH) if third_t is not None else None
+            )
 
             if mode in OPENSSL_MODES:
                 bar1_color, bar1_label = COLOR_PURE_RUST, "pure Rust"
                 bar2_color, bar2_label = COLOR_OPENSSL, "OpenSSL"
+                bar3_color, bar3_label = None, None
             elif mode in IO_URING_MODES:
                 bar1_color, bar1_label = COLOR_STD_IO, "standard I/O"
                 bar2_color, bar2_label = COLOR_IO_URING, "io_uring"
+                bar3_color, bar3_label = None, None
             elif mode in SSH_TRANSPORT_MODES:
-                bar1_color, bar1_label = COLOR_SSH_SUBPROCESS, "subprocess"
-                bar2_color, bar2_label = COLOR_SSH_RUSSH, "russh"
+                if three_way:
+                    bar1_color, bar1_label = (
+                        COLOR_SSH_UPSTREAM, "upstream (ssh subprocess)"
+                    )
+                    bar2_color, bar2_label = (
+                        COLOR_SSH_SUBPROCESS, "oc-rsync (ssh subprocess)"
+                    )
+                    bar3_color, bar3_label = (
+                        COLOR_SSH_RUSSH, "oc-rsync (russh embedded)"
+                    )
+                else:
+                    bar1_color, bar1_label = COLOR_SSH_SUBPROCESS, "subprocess"
+                    bar2_color, bar2_label = COLOR_SSH_RUSSH, "russh"
+                    bar3_color, bar3_label = None, None
             else:
                 bar1_color, bar1_label = COLOR_UPSTREAM, "upstream"
                 bar2_color, bar2_label = COLOR_OC_RSYNC, "oc-rsync"
+                bar3_color, bar3_label = None, None
+
+            third_bar = None
+            ratio_secondary = None
+            if three_way and third_w is not None and bar3_color is not None:
+                third_bar = BarSpec(
+                    third_y, third_w, third_t, bar3_color, bar3_label
+                )
+                # Primary ratio = russh / oc subprocess.
+                # Secondary ratio = oc subprocess / upstream.
+                ratio_primary = t.get("ratio_russh_vs_sub", t.get("ratio", 0.0))
+                ratio_secondary = t.get("ratio_sub_vs_upstream", 0.0)
+            else:
+                ratio_primary = t.get("ratio", 0.0)
 
             pairs.append(
                 TestPair(
                     name=t["name"],
-                    upstream=BarSpec(up_y, up_w, t["upstream"]["mean"], bar1_color, bar1_label),
-                    oc_rsync=BarSpec(oc_y, oc_w, t["oc_rsync"]["mean"], bar2_color, bar2_label),
-                    ratio=t["ratio"],
+                    upstream=BarSpec(up_y, up_w, up_t, bar1_color, bar1_label),
+                    oc_rsync=BarSpec(oc_y, oc_w, oc_t, bar2_color, bar2_label),
+                    ratio=ratio_primary,
                     center_y=center_y,
+                    third=third_bar,
+                    ratio_secondary=ratio_secondary,
                 )
             )
-            y += 2 * BAR_HEIGHT + BAR_GAP
+
+            if three_way:
+                y += 3 * BAR_HEIGHT + 2 * BAR_GAP
+            else:
+                y += 2 * BAR_HEIGHT + BAR_GAP
 
         groups.append(ModeGroup(
             label=MODE_LABELS[mode],
@@ -390,6 +471,8 @@ class ChartBuilder:
             )
             self._add_bar(pair.upstream, scale)
             self._add_bar(pair.oc_rsync, scale)
+            if pair.third is not None:
+                self._add_bar(pair.third, scale)
             self._add_speedup(pair)
 
     def add_legend(
@@ -398,6 +481,7 @@ class ChartBuilder:
         has_openssl: bool = False,
         has_io_uring: bool = False,
         has_ssh_transport: bool = False,
+        has_ssh_3way: bool = False,
     ) -> None:
         cx = CHART_WIDTH / 2
         self._parts.append(f'<g transform="translate({cx - 160}, {y:.0f})">')
@@ -447,18 +531,50 @@ class ChartBuilder:
         if has_ssh_transport:
             row += 1
             ry = row * 18
-            self._parts.append(
-                f'<rect x="0" y="{ry}" width="12" height="12" rx="2" fill="{COLOR_SSH_SUBPROCESS}"/>'
-            )
-            self._parts.append(
-                f'<text x="16" y="{ry + 10}" font-size="11" fill="{COLOR_LABEL}">SSH subprocess</text>'
-            )
-            self._parts.append(
-                f'<rect x="170" y="{ry}" width="12" height="12" rx="2" fill="{COLOR_SSH_RUSSH}"/>'
-            )
-            self._parts.append(
-                f'<text x="186" y="{ry + 10}" font-size="11" fill="{COLOR_LABEL}">SSH russh (embedded)</text>'
-            )
+            if has_ssh_3way:
+                self._parts.append(
+                    f'<rect x="0" y="{ry}" width="12" height="12" rx="2" '
+                    f'fill="{COLOR_SSH_UPSTREAM}"/>'
+                )
+                self._parts.append(
+                    f'<text x="16" y="{ry + 10}" font-size="11" '
+                    f'fill="{COLOR_LABEL}">upstream rsync (ssh)</text>'
+                )
+                self._parts.append(
+                    f'<rect x="170" y="{ry}" width="12" height="12" rx="2" '
+                    f'fill="{COLOR_SSH_SUBPROCESS}"/>'
+                )
+                self._parts.append(
+                    f'<text x="186" y="{ry + 10}" font-size="11" '
+                    f'fill="{COLOR_LABEL}">oc-rsync (ssh subprocess)</text>'
+                )
+                row += 1
+                ry = row * 18
+                self._parts.append(
+                    f'<rect x="0" y="{ry}" width="12" height="12" rx="2" '
+                    f'fill="{COLOR_SSH_RUSSH}"/>'
+                )
+                self._parts.append(
+                    f'<text x="16" y="{ry + 10}" font-size="11" '
+                    f'fill="{COLOR_LABEL}">oc-rsync (russh embedded)</text>'
+                )
+            else:
+                self._parts.append(
+                    f'<rect x="0" y="{ry}" width="12" height="12" rx="2" '
+                    f'fill="{COLOR_SSH_SUBPROCESS}"/>'
+                )
+                self._parts.append(
+                    f'<text x="16" y="{ry + 10}" font-size="11" '
+                    f'fill="{COLOR_LABEL}">SSH subprocess</text>'
+                )
+                self._parts.append(
+                    f'<rect x="170" y="{ry}" width="12" height="12" rx="2" '
+                    f'fill="{COLOR_SSH_RUSSH}"/>'
+                )
+                self._parts.append(
+                    f'<text x="186" y="{ry + 10}" font-size="11" '
+                    f'fill="{COLOR_LABEL}">SSH russh (embedded)</text>'
+                )
         self._parts.append("</g>")
 
     def render(self) -> str:
@@ -493,12 +609,29 @@ class ChartBuilder:
     def _add_speedup(self, pair: TestPair) -> None:
         text, color = ratio_text(pair.ratio)
         x = CHART_WIDTH - RIGHT_MARGIN + 10
-        y = pair.center_y + 4
-        self._parts.append(
-            f'<text x="{x}" y="{y:.1f}" '
-            f'font-size="11" font-weight="600" fill="{color}">'
-            f"{escape(text)}</text>"
-        )
+        if pair.ratio_secondary is not None:
+            # Stack two ratios for the 3-way comparison: oc-sub vs upstream
+            # above, russh vs oc-sub below.
+            sec_text, sec_color = ratio_text(pair.ratio_secondary)
+            y_top = pair.center_y - 4
+            y_bot = pair.center_y + 12
+            self._parts.append(
+                f'<text x="{x}" y="{y_top:.1f}" '
+                f'font-size="10" font-weight="600" fill="{sec_color}">'
+                f"oc/up {escape(sec_text)}</text>"
+            )
+            self._parts.append(
+                f'<text x="{x}" y="{y_bot:.1f}" '
+                f'font-size="10" font-weight="600" fill="{color}">'
+                f"ru/oc {escape(text)}</text>"
+            )
+        else:
+            y = pair.center_y + 4
+            self._parts.append(
+                f'<text x="{x}" y="{y:.1f}" '
+                f'font-size="11" font-weight="600" fill="{color}">'
+                f"{escape(text)}</text>"
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -515,9 +648,16 @@ def generate_chart(data: dict) -> str:
     has_openssl = any(m in OPENSSL_MODES for m in tests_by_mode)
     has_io_uring = any(m in IO_URING_MODES for m in tests_by_mode)
     has_ssh_transport = any(m in SSH_TRANSPORT_MODES for m in tests_by_mode)
+    has_ssh_3way = any(
+        m in SSH_TRANSPORT_MODES and any("upstream_ssh" in t for t in ts)
+        for m, ts in tests_by_mode.items()
+    )
     layout = compute_layout(tests_by_mode)
 
-    extra_legend_rows = int(has_openssl) + int(has_io_uring) + int(has_ssh_transport)
+    extra_legend_rows = (
+        int(has_openssl) + int(has_io_uring) + int(has_ssh_transport)
+        + int(has_ssh_3way)
+    )
     extra_legend = extra_legend_rows * 18
     chart_height = layout.chart_height + extra_legend
 
@@ -541,6 +681,7 @@ def generate_chart(data: dict) -> str:
         has_openssl,
         has_io_uring,
         has_ssh_transport,
+        has_ssh_3way,
     )
 
     return builder.render()

--- a/.github/scripts/benchmark_report.py
+++ b/.github/scripts/benchmark_report.py
@@ -25,7 +25,9 @@ IO_URING_MODES = {
 }
 
 SSH_TRANSPORT_MODES = {
-    "ssh_transport": "SSH Transport: Subprocess vs russh",
+    "ssh_transport": (
+        "SSH Transport: upstream vs oc-rsync subprocess vs oc-rsync russh"
+    ),
 }
 
 EXTRA_MODES = {
@@ -119,22 +121,62 @@ def main():
 
         print()
 
-    # SSH transport: subprocess vs embedded russh
+    # SSH transport: 3-way (upstream vs oc-rsync subprocess vs oc-rsync russh)
+    # when the new fields are present; otherwise fall back to the legacy
+    # subprocess-vs-russh 2-bar render.
     for mode, label in SSH_TRANSPORT_MODES.items():
         tests = by_mode.get(mode, [])
         if not tests:
             continue
 
-        print(f"### {label}\n")
-        print("| Test | Subprocess (ssh) | Embedded (russh) | Ratio |")
-        print("|------|------------------|------------------|-------|")
+        three_way = all("upstream_ssh" in t for t in tests)
 
-        for t in tests:
-            sub = t["upstream"]["mean"]
-            russh = t["oc_rsync"]["mean"]
-            ratio = t["ratio"]
-            ind = ratio_indicator(ratio)
-            print(f"| {t['name']} | {sub:.3f}s | {russh:.3f}s | {ind} {ratio:.2f}x |")
+        print(f"### {label}\n")
+        if three_way:
+            print(
+                "| Test "
+                "| Upstream (ssh) "
+                "| oc-rsync (ssh) "
+                "| oc-rsync (russh) "
+                "| oc-sub / upstream "
+                "| russh / oc-sub |"
+            )
+            print(
+                "|------"
+                "|----------------"
+                "|----------------"
+                "|------------------"
+                "|-------------------"
+                "|----------------|"
+            )
+            for t in tests:
+                up = t["upstream_ssh"]["mean"]
+                sub = t["oc_subprocess"]["mean"]
+                russh = t["oc_russh"]["mean"]
+                r_sub = t.get("ratio_sub_vs_upstream", 0.0)
+                r_russh = t.get("ratio_russh_vs_sub", 0.0)
+                ind_sub = ratio_indicator(r_sub)
+                ind_russh = ratio_indicator(r_russh)
+                print(
+                    f"| {t['name']} "
+                    f"| {up:.3f}s "
+                    f"| {sub:.3f}s "
+                    f"| {russh:.3f}s "
+                    f"| {ind_sub} {r_sub:.2f}x "
+                    f"| {ind_russh} {r_russh:.2f}x |"
+                )
+        else:
+            print("| Test | Subprocess (ssh) | Embedded (russh) | Ratio |")
+            print("|------|------------------|------------------|-------|")
+            for t in tests:
+                sub = t["upstream"]["mean"]
+                russh = t["oc_rsync"]["mean"]
+                ratio = t["ratio"]
+                ind = ratio_indicator(ratio)
+                print(
+                    f"| {t['name']} | {sub:.3f}s | {russh:.3f}s "
+                    f"| {ind} {ratio:.2f}x |"
+                )
 
         print()
 

--- a/docs/benchmarks/ssh-transport-3way.md
+++ b/docs/benchmarks/ssh-transport-3way.md
@@ -1,0 +1,72 @@
+# SSH transport 3-way benchmark
+
+The release benchmark suite (`.github/scripts/benchmark.py`) now compares
+three SSH transports side by side for every SSH workload:
+
+1. **Upstream rsync 3.4.1 over OpenSSH subprocess** - reference baseline.
+   Invoked with `host:path` operands, lets rsync fork `ssh` exactly as a
+   user would on the command line.
+2. **oc-rsync over OpenSSH subprocess** - same `host:path` operands, same
+   external `ssh` binary, but the rsync implementation is oc-rsync.
+   Isolates rsync-side cost from SSH-side cost.
+3. **oc-rsync over embedded russh** - `ssh://host/path` URI operands route
+   the transfer through the in-process russh client built into the
+   `embedded-ssh` feature. Skips the `ssh` subprocess entirely.
+
+The 2-bar `oc-rsync subprocess vs russh` view is preserved for backwards
+compatibility (legacy fields `upstream`, `oc_rsync`, `ratio` in the JSON;
+2-bar render in the chart and report). The 3-way view adds three fields
+to each `ssh_transport` row in `benchmark_results.json`:
+
+| Field | Meaning |
+|-------|---------|
+| `upstream_ssh` | timing for upstream rsync over OpenSSH subprocess |
+| `oc_subprocess` | timing for oc-rsync over OpenSSH subprocess |
+| `oc_russh` | timing for oc-rsync over embedded russh |
+| `ratio_sub_vs_upstream` | `oc_subprocess.mean / upstream_ssh.mean` |
+| `ratio_russh_vs_sub` | `oc_russh.mean / oc_subprocess.mean` |
+
+## What to read from it
+
+- **oc-sub / upstream** answers: "how does oc-rsync's per-file and per-block
+  work compare to upstream rsync, with the SSH layer held constant?"
+  A ratio below 1.0 means oc-rsync is faster than upstream rsync over the
+  same OpenSSH pipe. This isolates the engine / protocol / I/O work from
+  any SSH transport differences.
+- **russh / oc-sub** answers: "what does the embedded SSH transport cost
+  or save versus shelling out to OpenSSH?" A ratio below 1.0 means the
+  in-process russh transport beats fork/exec-ing `ssh`. Both legs use the
+  same oc-rsync engine, so this isolates SSH transport overhead from
+  rsync work.
+
+If both ratios are below 1.0, oc-rsync is faster than upstream at both
+layers (engine and transport). If `oc-sub / upstream` is at parity and
+`russh / oc-sub` is below 1.0, the savings come purely from skipping
+`ssh` fork/exec, framing, and pipe overhead. If `russh / oc-sub` is
+above 1.0, the embedded russh transport is paying a measurable cost
+versus OpenSSH (cipher implementation, lack of `splice`, etc.) and may
+warrant further profiling.
+
+## Gating
+
+The 3-way comparison only runs when:
+
+- `OC_RSYNC_RUSSH` points to a binary built with the `embedded-ssh`
+  feature, and
+- the binary exists on disk.
+
+The CI workflow `.github/workflows/benchmark.yml` already builds an
+`oc-rsync-russh` binary for this purpose. The 3-way path is otherwise
+skipped, so local runs without `embedded-ssh` are unaffected.
+
+## Republishing the chart for an existing release
+
+To regenerate the chart for an already-tagged release with the new
+comparison, dispatch the benchmark workflow against that tag:
+
+```sh
+gh workflow run benchmark.yml -f target_tag=v0.6.2
+```
+
+The workflow rebuilds all three binaries, runs the benchmark, and
+overwrites `benchmark.svg` / `benchmark.png` attached to the release.


### PR DESCRIPTION
## Summary

- Extends the release benchmark (`.github/scripts/benchmark.py`) to compare three SSH transports per workload: upstream rsync over OpenSSH subprocess, oc-rsync over OpenSSH subprocess, and oc-rsync over embedded russh. Isolates rsync engine cost from SSH transport cost.
- Adds new JSON fields (`upstream_ssh`, `oc_subprocess`, `oc_russh`, `ratio_sub_vs_upstream`, `ratio_russh_vs_sub`) while preserving the legacy 2-bar shape (`upstream`, `oc_rsync`, `ratio`) so older chart/report consumers keep working.
- Updates `benchmark_report.py` and `benchmark_chart.py` to render a 3-column table and 3-bar chart for the new comparison, with 2-bar fallback when the new fields are absent.
- Adds `docs/benchmarks/ssh-transport-3way.md` describing the comparison and how to interpret the two ratios.

Gated by `OC_RSYNC_RUSSH`; the existing benchmark workflow already builds an `oc-rsync-russh` binary with the `embedded-ssh` feature.

To republish the chart for an existing release with the new comparison:

```sh
gh workflow run benchmark.yml -f target_tag=v0.6.2
```

## Test plan

- [x] `python3 -m py_compile` all three modified scripts.
- [x] Local smoke test of `benchmark_report.py` and `benchmark_chart.py` against a synthetic 3-way `benchmark_results.json` (3-bar render).
- [x] Local smoke test against a legacy 2-bar `benchmark_results.json` (fallback render).
- [ ] CI: tag-triggered or `workflow_dispatch` run of the Benchmark workflow exercises the full 3-way path end-to-end.