### PR TITLE
fix(protocol): match upstream print_child_argv space pattern

### DIFF
--- a/crates/protocol/src/cmd/trace.rs
+++ b/crates/protocol/src/cmd/trace.rs
@@ -57,9 +57,10 @@ fn quote_arg(arg: &OsStr) -> String {
 #[must_use]
 pub fn print_child_argv<S: AsRef<OsStr>>(prefix: &str, argv: &[S]) -> String {
     let mut out = String::from(prefix);
+    out.push(' ');
     for arg in argv {
-        out.push(' ');
         out.push_str(&quote_arg(arg.as_ref()));
+        out.push(' ');
     }
     out.push(' ');
     out.push_str(&format!("({} args)", argv.len()));


### PR DESCRIPTION
## Summary

- Fix \`print_child_argv\` to push trailing space after each argv element instead of leading space, matching upstream \`util1.c:99-117\`.
- Restores byte-equivalent CMD trace output: \"prefix \" + \"arg \" repeated + \" (N args)\" (double space before the count).
- Unblocks four pre-existing master test failures in \`crates/protocol/src/cmd/trace.rs\`: \`print_child_argv_matches_upstream_layout\`, \`print_child_argv_with_empty_argv\`, \`opening_connection_matches_upstream_format\`, \`helpers_accept_os_string_argv\`.

## Test plan

- [x] Implementation matches upstream \`rsync-3.4.2/util1.c\` line for line.
- [ ] CI nextest passes on stable/beta/nightly.
- [ ] All four pinning tests pass.