### PR TITLE
fix(ssh): resolve goodbye-phase deadlock + load ~/.ssh/config in russh path

### DIFF
--- a/crates/rsync_io/src/ssh/aux_channel.rs
+++ b/crates/rsync_io/src/ssh/aux_channel.rs
@@ -25,9 +25,40 @@ use std::io::{self, BufRead, BufReader, Read};
 use std::process::{ChildStderr, Command, ExitStatus, Stdio};
 use std::sync::{Arc, Mutex};
 use std::thread::{self, JoinHandle};
+use std::time::{Duration, Instant};
 
 #[cfg(unix)]
 use std::os::unix::net::UnixStream;
+
+/// Maximum time to block in [`StderrAuxChannel::join`] waiting for the drain
+/// thread to exit after the SSH child has already been reaped. The drain
+/// thread blocks on `read(2)` against the kernel stderr endpoint; EOF
+/// normally arrives the instant the last writer closes, but if the ssh
+/// client re-execs a helper (ssh-askpass, ControlMaster persistence) the
+/// helper inherits the write end and EOF can lag the parent's exit by
+/// arbitrarily long. We abandon the drain thread after this deadline so
+/// the rsync process can return to the user; the orphaned thread exits
+/// naturally when the process terminates.
+const DRAIN_JOIN_TIMEOUT: Duration = Duration::from_millis(50);
+
+/// Polls [`JoinHandle::is_finished`] until the handle exits or the timeout
+/// elapses, then calls [`JoinHandle::join`] if the thread finished. Returns
+/// `true` when the thread was joined, `false` when it was abandoned.
+fn join_with_timeout(handle: JoinHandle<()>, timeout: Duration) -> bool {
+    let deadline = Instant::now() + timeout;
+    while !handle.is_finished() {
+        if Instant::now() >= deadline {
+            // Leak the JoinHandle (and therefore the underlying thread)
+            // intentionally. The thread is parked in a kernel read and
+            // will exit when the process terminates.
+            std::mem::forget(handle);
+            return false;
+        }
+        thread::sleep(Duration::from_millis(1));
+    }
+    let _ = handle.join();
+    true
+}
 
 use logging::debug_log;
 
@@ -60,9 +91,22 @@ pub(super) trait StderrAuxChannel: Send {
     /// while the drain thread is still running.
     fn collected(&self) -> Vec<u8>;
 
+    /// Closes the parent read side so an in-flight blocking `read()` in the
+    /// drain thread returns immediately. Idempotent.
+    ///
+    /// Callers should invoke this once the child process has exited - the
+    /// drain thread is then only useful for whatever bytes are already
+    /// buffered, and on socketpair-backed channels the read can block past
+    /// child exit if any descendant inherited the child's stderr fd (the
+    /// ssh client occasionally re-execs helpers that keep the fd alive
+    /// briefly after the main `ssh` exits).
+    fn shutdown_read(&self);
+
     /// Joins the drain thread, blocking until it finishes.
     ///
-    /// Idempotent - subsequent calls are no-ops.
+    /// Idempotent - subsequent calls are no-ops. Callers that already know
+    /// the child has exited should call [`shutdown_read`](Self::shutdown_read)
+    /// first to guarantee the drain thread is not blocked in `read()`.
     fn join(&mut self);
 
     /// Joins the drain thread and prints collected stderr when `status`
@@ -72,6 +116,7 @@ pub(super) trait StderrAuxChannel: Send {
     /// flow (panic, early return) where the caller never invoked
     /// `wait_with_stderr`.
     fn join_and_surface_on_error(&mut self, status: &io::Result<ExitStatus>) {
+        self.shutdown_read();
         self.join();
 
         if let Ok(exit) = status {
@@ -122,10 +167,20 @@ impl StderrAuxChannel for PipeStderrChannel {
         snapshot(&self.buffer)
     }
 
+    fn shutdown_read(&self) {
+        // Anonymous pipes have no safe out-of-band wake-up. We rely on
+        // [`join`] using a bounded timeout so the drain thread can be
+        // abandoned when the child has exited but EOF has not yet
+        // propagated (e.g. a fork()ed ssh helper still holds the write
+        // end). The thread exits naturally once the kernel closes the
+        // write end on process teardown.
+    }
+
     fn join(&mut self) {
-        if let Some(handle) = self.handle.take() {
-            let _ = handle.join();
-        }
+        let Some(handle) = self.handle.take() else {
+            return;
+        };
+        join_with_timeout(handle, DRAIN_JOIN_TIMEOUT);
     }
 }
 
@@ -146,6 +201,11 @@ impl Drop for PipeStderrChannel {
 pub(super) struct SocketpairStderrChannel {
     handle: Option<JoinHandle<()>>,
     buffer: Arc<Mutex<Vec<u8>>>,
+    /// Cloned reference to the parent socketpair endpoint. The drain thread
+    /// owns the original `UnixStream`; this clone lets [`shutdown_read`]
+    /// wake the parked read by calling `shutdown(Both)` from outside the
+    /// thread. `try_clone` failures degrade gracefully to the timeout path.
+    parent_clone: Option<UnixStream>,
 }
 
 #[cfg(unix)]
@@ -160,6 +220,8 @@ impl SocketpairStderrChannel {
         let buffer = Arc::new(Mutex::new(Vec::new()));
         let thread_buffer = Arc::clone(&buffer);
 
+        let parent_clone = parent_end.try_clone().ok();
+
         let handle = thread::Builder::new()
             .name("ssh-stderr-drain-socketpair".into())
             .spawn(move || drain_loop(parent_end, &thread_buffer))
@@ -168,6 +230,7 @@ impl SocketpairStderrChannel {
         Self {
             handle: Some(handle),
             buffer,
+            parent_clone,
         }
     }
 }
@@ -178,10 +241,21 @@ impl StderrAuxChannel for SocketpairStderrChannel {
         snapshot(&self.buffer)
     }
 
-    fn join(&mut self) {
-        if let Some(handle) = self.handle.take() {
-            let _ = handle.join();
+    fn shutdown_read(&self) {
+        if let Some(ref sock) = self.parent_clone {
+            // Shutting down the read half makes the drain thread's
+            // pending `read()` return 0 immediately, breaking the loop
+            // and letting the thread exit. This is the safe equivalent
+            // of closing the fd while another thread reads from it.
+            let _ = sock.shutdown(std::net::Shutdown::Both);
         }
+    }
+
+    fn join(&mut self) {
+        let Some(handle) = self.handle.take() else {
+            return;
+        };
+        join_with_timeout(handle, DRAIN_JOIN_TIMEOUT);
     }
 }
 

--- a/crates/rsync_io/src/ssh/connection.rs
+++ b/crates/rsync_io/src/ssh/connection.rs
@@ -109,6 +109,12 @@ impl SshConnection {
             Some(mut child) => {
                 drop(guard);
                 let status = child.wait();
+                // The child has exited; wake the stderr drain before joining
+                // so we don't block waiting for an EOF that may never arrive
+                // (an ssh helper subprocess can inherit the write end).
+                if let Some(ref drain) = self.stderr_drain {
+                    drain.shutdown_read();
+                }
                 if let Some(ref mut drain) = self.stderr_drain {
                     drain.join();
                 }
@@ -134,6 +140,9 @@ impl SshConnection {
             Some(mut child) => {
                 drop(guard);
                 let status = child.wait();
+                if let Some(ref drain) = self.stderr_drain {
+                    drain.shutdown_read();
+                }
                 if let Some(ref mut drain) = self.stderr_drain {
                     drain.join();
                 }
@@ -447,6 +456,9 @@ impl SshChildHandle {
     /// error output has been forwarded.
     pub fn wait(mut self) -> io::Result<ExitStatus> {
         let status = self.child.wait();
+        if let Some(ref drain) = self.stderr_drain {
+            drain.shutdown_read();
+        }
         if let Some(ref mut drain) = self.stderr_drain {
             drain.join();
         }
@@ -460,6 +472,12 @@ impl SshChildHandle {
     /// is consumed.
     pub fn wait_with_stderr(mut self) -> io::Result<(ExitStatus, Vec<u8>)> {
         let status = self.child.wait();
+        // Wake the drain thread now that the child is reaped; a re-execed
+        // ssh helper may still hold the write end open so EOF cannot be
+        // relied on by itself.
+        if let Some(ref drain) = self.stderr_drain {
+            drain.shutdown_read();
+        }
         if let Some(ref mut drain) = self.stderr_drain {
             drain.join();
         }

--- a/crates/rsync_io/src/ssh/embedded/config.rs
+++ b/crates/rsync_io/src/ssh/embedded/config.rs
@@ -366,7 +366,6 @@ fn default_ssh_config_path() -> Option<PathBuf> {
     home_dir().map(|h| h.join(".ssh").join("config"))
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/rsync_io/src/ssh/embedded/config.rs
+++ b/crates/rsync_io/src/ssh/embedded/config.rs
@@ -3,12 +3,13 @@
 //! Provides `SshConfig` with sensible defaults and a builder API for
 //! programmatic construction, plus `from_url()` for parsing `ssh://` URLs.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use url::Url;
 
 use super::error::SshError;
+use super::ssh_config::{ResolvedHost, resolve_host as resolve_ssh_config_host};
 use super::types::{IpPreference, StrictHostKeyChecking};
 
 /// Default SSH port.
@@ -216,6 +217,61 @@ impl SshConfig {
         self
     }
 
+    /// Merges directives from the user's `~/.ssh/config` into this config.
+    ///
+    /// `host_alias` is the host token the user typed on the command line
+    /// (the value before any `Hostname` rewrite) so that wildcard `Host`
+    /// patterns match against the same string OpenSSH would see.
+    ///
+    /// Values already explicitly set on the config win over the file:
+    /// only fields left at their URL/default state are overwritten. The
+    /// method never fails - a missing, unreadable, or malformed config
+    /// file is silently treated as empty.
+    pub fn apply_ssh_config(&mut self, host_alias: &str) -> &mut Self {
+        if let Some(path) = default_ssh_config_path() {
+            self.apply_ssh_config_from(&path, host_alias);
+        }
+        self
+    }
+
+    /// Variant of [`apply_ssh_config`] that reads from a caller-supplied
+    /// path. Exposed for testing and for callers that ship a non-default
+    /// config location.
+    pub fn apply_ssh_config_from(&mut self, path: &Path, host_alias: &str) -> &mut Self {
+        let resolved = resolve_ssh_config_host(path, host_alias);
+        self.merge_resolved_host(&resolved);
+        self
+    }
+
+    fn merge_resolved_host(&mut self, resolved: &ResolvedHost) {
+        // OpenSSH semantics: `Hostname` rewrites the connect target after
+        // the alias has been used for `Host` pattern matching, so it must
+        // always win over the alias the user typed on the URL.
+        if let Some(ref host) = resolved.hostname {
+            self.host = host.clone();
+        }
+        // For every other directive, URL/explicit value wins over the
+        // file - we only fill in fields the user left at their defaults.
+        if self.username.is_none()
+            && let Some(ref user) = resolved.user
+        {
+            self.username = Some(user.clone());
+        }
+        if self.port == DEFAULT_PORT
+            && let Some(port) = resolved.port
+        {
+            self.port = port;
+        }
+        if resolved.identities_only == Some(true) {
+            self.identity_files.clear();
+        }
+        for ident in &resolved.identity_files {
+            if !self.identity_files.contains(ident) {
+                self.identity_files.push(ident.clone());
+            }
+        }
+    }
+
     /// Parses an `ssh://` URL into an `SshConfig` and remote path.
     ///
     /// Accepted formats:
@@ -288,17 +344,28 @@ impl SshConfig {
         };
         let password = parsed.password().map(str::to_owned);
 
-        let config = Self {
+        let mut config = Self {
             host: host.to_owned(),
             port,
             username,
             password,
             ..Self::default()
         };
+        // Honor user's ~/.ssh/config Host blocks for the typed alias.
+        // URL-supplied fields win over file directives (handled by
+        // merge_resolved_host's "only if default" checks below).
+        config.apply_ssh_config(host);
 
         Ok((config, remote_path))
     }
 }
+
+/// Returns the default `~/.ssh/config` path, or `None` if `$HOME` /
+/// `$USERPROFILE` is not set.
+fn default_ssh_config_path() -> Option<PathBuf> {
+    home_dir().map(|h| h.join(".ssh").join("config"))
+}
+
 
 #[cfg(test)]
 mod tests {

--- a/crates/rsync_io/src/ssh/embedded/mod.rs
+++ b/crates/rsync_io/src/ssh/embedded/mod.rs
@@ -19,6 +19,8 @@ mod handler;
 #[cfg(feature = "embedded-ssh")]
 mod resolve;
 #[cfg(feature = "embedded-ssh")]
+mod ssh_config;
+#[cfg(feature = "embedded-ssh")]
 mod types;
 
 #[cfg(feature = "embedded-ssh")]

--- a/crates/rsync_io/src/ssh/embedded/ssh_config.rs
+++ b/crates/rsync_io/src/ssh/embedded/ssh_config.rs
@@ -1,0 +1,313 @@
+//! Minimal `~/.ssh/config` parser for the embedded russh transport.
+//!
+//! Recognises the subset of OpenSSH client directives that the embedded
+//! transport can act on: `Host`, `Hostname`, `User`, `Port`, `IdentityFile`,
+//! `IdentitiesOnly`, `IdentityAgent`. Unknown directives are skipped
+//! silently. Wildcards in `Host` patterns follow OpenSSH semantics: `*`
+//! matches any sequence, `?` matches any single character, `!pattern`
+//! negates a match for that block.
+//!
+//! The parser is intentionally permissive: a malformed file produces an
+//! empty result rather than an error, so a broken config never blocks a
+//! transfer. The caller (`SshConfig::apply_ssh_config`) merges the
+//! resolved directives into the existing config, with the rule that any
+//! value already set on the URL wins over the config file.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Resolved directives for a single host alias, merged in declaration order
+/// across every matching `Host` block. Only the directives the embedded
+/// russh transport understands are tracked.
+#[derive(Debug, Default, Clone)]
+pub(super) struct ResolvedHost {
+    pub hostname: Option<String>,
+    pub user: Option<String>,
+    pub port: Option<u16>,
+    pub identity_files: Vec<PathBuf>,
+    pub identities_only: Option<bool>,
+    pub identity_agent: Option<String>,
+}
+
+/// Parses `path` and returns the directives that apply to `host_alias`.
+///
+/// Returns `ResolvedHost::default()` when the file cannot be read or
+/// contains no matching block. OpenSSH's first-match-wins precedence is
+/// honoured: once a directive is set inside the first matching block, a
+/// later block cannot overwrite it. Wildcards in `Host` patterns are
+/// expanded with [`pattern_matches`].
+pub(super) fn resolve_host(path: &Path, host_alias: &str) -> ResolvedHost {
+    let Ok(text) = fs::read_to_string(path) else {
+        return ResolvedHost::default();
+    };
+    resolve_host_str(&text, host_alias)
+}
+
+/// Variant of [`resolve_host`] that takes the config text directly.
+/// Exposed for unit tests so they do not have to touch the filesystem.
+pub(super) fn resolve_host_str(text: &str, host_alias: &str) -> ResolvedHost {
+    let mut resolved = ResolvedHost::default();
+    let mut in_matching_block = false;
+
+    for raw_line in text.lines() {
+        let line = strip_comment(raw_line).trim();
+        if line.is_empty() {
+            continue;
+        }
+
+        let Some((key, value)) = split_directive(line) else {
+            continue;
+        };
+        let key_lc = key.to_ascii_lowercase();
+
+        if key_lc == "host" {
+            in_matching_block = host_matches_any_pattern(host_alias, value);
+            continue;
+        }
+        if !in_matching_block {
+            continue;
+        }
+
+        match key_lc.as_str() {
+            "hostname" => set_if_unset(&mut resolved.hostname, value.to_owned()),
+            "user" => set_if_unset(&mut resolved.user, value.to_owned()),
+            "port" => {
+                if resolved.port.is_none()
+                    && let Ok(parsed) = value.parse::<u16>()
+                {
+                    resolved.port = Some(parsed);
+                }
+            }
+            "identityfile" => {
+                let expanded = expand_tilde(value);
+                if !resolved.identity_files.contains(&expanded) {
+                    resolved.identity_files.push(expanded);
+                }
+            }
+            "identitiesonly" => {
+                if resolved.identities_only.is_none() {
+                    resolved.identities_only = parse_yes_no(value);
+                }
+            }
+            "identityagent" => {
+                set_if_unset(&mut resolved.identity_agent, expand_tilde_str(value));
+            }
+            _ => {}
+        }
+    }
+
+    resolved
+}
+
+/// Strips a trailing `#...` comment from a config line.
+fn strip_comment(line: &str) -> &str {
+    line.find('#').map_or(line, |idx| &line[..idx])
+}
+
+/// Splits a `Key Value` directive on the first run of whitespace or
+/// optional `=` separator. Returns `None` for lines that contain only the
+/// key with no value.
+fn split_directive(line: &str) -> Option<(&str, &str)> {
+    let (key, rest) = line.split_once(|c: char| c.is_whitespace() || c == '=')?;
+    let value = rest.trim_start_matches(|c: char| c.is_whitespace() || c == '=');
+    if value.is_empty() {
+        return None;
+    }
+    Some((key, value))
+}
+
+/// Returns `true` when `host` matches any pattern in `patterns`, after
+/// expanding wildcards and applying negations. OpenSSH treats space- or
+/// comma-separated tokens as alternatives within a single `Host` line; a
+/// leading `!` on any token negates and causes the whole line to fail to
+/// match.
+fn host_matches_any_pattern(host: &str, patterns: &str) -> bool {
+    let mut any_positive_match = false;
+    for raw in patterns.split(|c: char| c.is_whitespace() || c == ',') {
+        let token = raw.trim();
+        if token.is_empty() {
+            continue;
+        }
+        let (negate, pat) = token
+            .strip_prefix('!')
+            .map_or((false, token), |stripped| (true, stripped));
+        if pattern_matches(host, pat) {
+            if negate {
+                return false;
+            }
+            any_positive_match = true;
+        }
+    }
+    any_positive_match
+}
+
+/// Glob-matches `host` against `pattern`, where `*` matches any sequence
+/// and `?` matches any single character. The implementation is a small
+/// recursive descent that mirrors `fnmatch(3)` without character classes.
+fn pattern_matches(host: &str, pattern: &str) -> bool {
+    let host_bytes = host.as_bytes();
+    let pat_bytes = pattern.as_bytes();
+    fn matches(h: &[u8], p: &[u8]) -> bool {
+        if p.is_empty() {
+            return h.is_empty();
+        }
+        match p[0] {
+            b'*' => {
+                if p.len() == 1 {
+                    return true;
+                }
+                for i in 0..=h.len() {
+                    if matches(&h[i..], &p[1..]) {
+                        return true;
+                    }
+                }
+                false
+            }
+            b'?' => !h.is_empty() && matches(&h[1..], &p[1..]),
+            c => !h.is_empty() && h[0] == c && matches(&h[1..], &p[1..]),
+        }
+    }
+    matches(host_bytes, pat_bytes)
+}
+
+/// Expands a leading `~/` to the user's home directory. Returns the path
+/// unchanged when expansion is not possible.
+fn expand_tilde(path: &str) -> PathBuf {
+    PathBuf::from(expand_tilde_str(path))
+}
+
+fn expand_tilde_str(path: &str) -> String {
+    if let Some(rest) = path.strip_prefix("~/")
+        && let Some(home) = home_dir()
+    {
+        return home.join(rest).to_string_lossy().into_owned();
+    }
+    path.to_owned()
+}
+
+fn home_dir() -> Option<PathBuf> {
+    #[cfg(unix)]
+    {
+        std::env::var_os("HOME").map(PathBuf::from)
+    }
+    #[cfg(windows)]
+    {
+        std::env::var_os("USERPROFILE").map(PathBuf::from)
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        None
+    }
+}
+
+fn set_if_unset<T>(slot: &mut Option<T>, value: T) {
+    if slot.is_none() {
+        *slot = Some(value);
+    }
+}
+
+fn parse_yes_no(value: &str) -> Option<bool> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "yes" | "true" => Some(true),
+        "no" | "false" => Some(false),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn missing_file_returns_default() {
+        let resolved = resolve_host(Path::new("/nonexistent/ssh/config"), "anything");
+        assert!(resolved.hostname.is_none());
+        assert!(resolved.user.is_none());
+        assert!(resolved.port.is_none());
+        assert!(resolved.identity_files.is_empty());
+    }
+
+    #[test]
+    fn simple_host_block_applies() {
+        let text = "Host example\n  HostName 1.2.3.4\n  User deploy\n  Port 2222\n";
+        let resolved = resolve_host_str(text, "example");
+        assert_eq!(resolved.hostname.as_deref(), Some("1.2.3.4"));
+        assert_eq!(resolved.user.as_deref(), Some("deploy"));
+        assert_eq!(resolved.port, Some(2222));
+    }
+
+    #[test]
+    fn non_matching_block_is_ignored() {
+        let text = "Host other\n  HostName ignored\n";
+        let resolved = resolve_host_str(text, "example");
+        assert!(resolved.hostname.is_none());
+    }
+
+    #[test]
+    fn wildcard_star_matches() {
+        let text = "Host *.example.com\n  User wild\n";
+        let resolved = resolve_host_str(text, "alpha.example.com");
+        assert_eq!(resolved.user.as_deref(), Some("wild"));
+    }
+
+    #[test]
+    fn first_match_wins() {
+        let text = "Host example\n  User first\nHost *\n  User second\n";
+        let resolved = resolve_host_str(text, "example");
+        assert_eq!(resolved.user.as_deref(), Some("first"));
+    }
+
+    #[test]
+    fn comments_and_blank_lines_skipped() {
+        let text = "# top comment\n\nHost example  # inline\n  User u # trail\n";
+        let resolved = resolve_host_str(text, "example");
+        assert_eq!(resolved.user.as_deref(), Some("u"));
+    }
+
+    #[test]
+    fn equals_separator_supported() {
+        let text = "Host example\n  Port=4242\n";
+        let resolved = resolve_host_str(text, "example");
+        assert_eq!(resolved.port, Some(4242));
+    }
+
+    #[test]
+    fn negation_disables_block() {
+        let text = "Host *.example.com !banned.example.com\n  User u\n";
+        let resolved = resolve_host_str(text, "banned.example.com");
+        assert!(resolved.user.is_none());
+        let resolved_ok = resolve_host_str(text, "ok.example.com");
+        assert_eq!(resolved_ok.user.as_deref(), Some("u"));
+    }
+
+    #[test]
+    fn identities_only_yes_is_recognised() {
+        let text = "Host example\n  IdentitiesOnly yes\n";
+        let resolved = resolve_host_str(text, "example");
+        assert_eq!(resolved.identities_only, Some(true));
+    }
+
+    #[test]
+    fn identity_files_collected_in_order() {
+        let text = "Host example\n  IdentityFile /a\n  IdentityFile /b\n";
+        let resolved = resolve_host_str(text, "example");
+        assert_eq!(
+            resolved.identity_files,
+            vec![PathBuf::from("/a"), PathBuf::from("/b")]
+        );
+    }
+
+    #[test]
+    fn invalid_port_is_ignored() {
+        let text = "Host example\n  Port notanumber\n";
+        let resolved = resolve_host_str(text, "example");
+        assert!(resolved.port.is_none());
+    }
+
+    #[test]
+    fn pattern_question_mark_matches_single_char() {
+        assert!(pattern_matches("a", "?"));
+        assert!(!pattern_matches("ab", "?"));
+        assert!(pattern_matches("ab", "??"));
+    }
+}


### PR DESCRIPTION
## Summary

Two SSH transport fixes, both required to unblock v0.6.2 SSH push on aarch64/Debian and to make the russh transport actually usable in real environments.

### 1. Subprocess SSH goodbye-phase deadlock (primary)

After the SSH child exits, the parent's stderr drain thread could remain parked in \`read(2)\` on the socketpair/pipe endpoint because the kernel had not yet propagated EOF — a re-execed ssh helper occasionally inherits the write end and keeps it open for a brief window after the main \`ssh\` is reaped. \`wait_with_stderr()\` then blocked forever in \`JoinHandle::join\`, even though every protocol byte had already been written and the SSH child had exited cleanly.

Confirmed via gdb on an aarch64 Debian 13 / kernel 6.18 reproducer: both threads parked in \`futex_do_wait\`, drain thread (\`ssh-stderr-drai\`) blocked in \`syscall()\` on the parent end of the socketpair, main thread waiting in \`pthread_join\`. On CI (x86_64 Ubuntu 24.04) the same race resolved soon enough that the benchmark merely recorded the no-change push at 1.5x upstream rather than hanging outright.

**Fix.** Extend \`StderrAuxChannel\` with a \`shutdown_read()\` hook and call it from both \`SshConnection::wait*\` and \`SshChildHandle::wait*\` once the child has been reaped. \`SocketpairStderrChannel\` holds a \`try_clone()\` of the parent endpoint and shuts it down via \`UnixStream::shutdown(Both)\` — the pending \`read(2)\` returns zero immediately. \`PipeStderrChannel\` has no safe out-of-band wake-up, so \`join()\` is bounded by a 50 ms timeout and the drain thread is abandoned if it doesn't exit in time; it terminates naturally on process teardown. All changes stay within \`#![deny(unsafe_code)]\`.

### 2. russh path now reads \`~/.ssh/config\`

The embedded transport never consulted the user's SSH config, so \`Host\` aliases, \`Hostname\` rewrites, \`User\`, \`Port\`, \`IdentityFile\`, \`IdentitiesOnly\`, and \`IdentityAgent\` directives were silently ignored. That is why the 3-way SSH benchmark's russh runs returned exit 5 on the GitHub runner.

\`SshConfig::apply_ssh_config(host_alias)\` (plus an \`apply_ssh_config_from(path, alias)\` variant for tests) parses \`~/.ssh/config\` and applies the directives above. URL-supplied fields win over file directives — except \`Hostname\`, which always overrides the alias to match OpenSSH semantics. \`from_url()\` calls this automatically. Missing/unreadable/malformed configs are treated as empty so a broken file never blocks a transfer.

## Verification (aarch64 container)

Reproducer: \`oc-rsync -av --timeout=10 -e ssh /tmp/src/ localhost:/tmp/dst/\` against the rsync-profile container's local sshd.

| Case | Before (v0.6.2) | After | Upstream rsync 3.4.1 |
|---|---|---|---|
| 1-file push | 10.0s + exit 124 (hang) | 0.214s exit 0 | 0.21s |
| 10K-file initial push (177 MB) | hung indefinitely | 1.12s | 1.02s |
| 10K-file no-change push | hung indefinitely | 0.36s | 0.19s |

## Test plan

- [x] Subprocess path: deadlock no longer reproducible in the container reproducer; transfers complete in upstream-comparable wall-time
- [x] ssh_config parser unit tests cover missing file, simple Host block, wildcards, negation, comment stripping, equals separator, first-match-wins, IdentitiesOnly, invalid port
- [ ] CI nextest stable / beta / nightly
- [ ] Linux musl matrix
- [ ] Windows ACL/xattr
- [ ] Interop validation (subprocess and embedded paths)