### PR TITLE
bench: profile Arc<Mutex<Vec>> contention in parallel-stat path (#1192)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4066,6 +4066,7 @@ dependencies = [
  "checksums",
  "compress",
  "criterion",
+ "crossbeam-channel",
  "crossbeam-queue",
  "engine",
  "fast_io",

--- a/crates/transfer/Cargo.toml
+++ b/crates/transfer/Cargo.toml
@@ -120,6 +120,7 @@ test-support = { path = "../test-support" }
 criterion = "0.8"
 proptest = "1.4"
 rand = "0.9"
+crossbeam-channel = { workspace = true }
 
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dev-dependencies]
 filetime = "0.2"
@@ -138,4 +139,8 @@ harness = false
 
 [[bench]]
 name = "reorder_buffer_large_scale"
+harness = false
+
+[[bench]]
+name = "parallel_stat_collector_contention"
 harness = false

--- a/crates/transfer/benches/parallel_stat_collector_contention.rs
+++ b/crates/transfer/benches/parallel_stat_collector_contention.rs
@@ -1,0 +1,252 @@
+//! Criterion micro-benchmark: collector contention under the parallel-stat
+//! fan-in pattern, parameterised on item count and rayon worker count.
+//!
+//! # Why this exists
+//!
+//! `crates/transfer/src/parallel_io.rs::map_blocking` is the rayon-backed
+//! parallel-stat dispatcher used by the receiver and generator when the
+//! file list crosses `ParallelThresholds::stat` (default 64 entries). It
+//! currently collects results via `into_par_iter().map(f).collect()`,
+//! which delegates to rayon's lock-free split-and-merge reducer.
+//!
+//! Several issues (#1192, #1271, #1297, #1370, #1682) ask whether moving
+//! to (or back to) a shared `Arc<Mutex<Vec<R>>>` collector would simplify
+//! the code, and how much throughput that would cost at 100K+ files on
+//! 8/16-core hosts. The static audit in
+//! `docs/audits/arc-mutex-vec-parallel-stat-contention.md` answers the
+//! "where is it used today" question; this bench answers the matching
+//! "how much would a regression cost" question with numbers, so future
+//! reviewers can reject naive refactors with evidence rather than memory.
+//!
+//! # What it measures
+//!
+//! Per-item collector cost for four append strategies when N rayon workers
+//! each push N_items / N records into a shared sink:
+//!
+//! 1. `Arc<Mutex<Vec<R>>>` - one shared mutex, the worst-case baseline.
+//! 2. Sharded `Vec<Mutex<Vec<R>>>` indexed by `rayon::current_thread_index()`
+//!    - matches the `WorkQueueReceiver::drain_parallel` pattern.
+//! 3. `crossbeam_queue::SegQueue<R>` - lock-free, unbounded baseline.
+//! 4. `crossbeam_channel::unbounded()` MPSC - the other common drop-in.
+//!
+//! Item count is fixed at 100K to model the receiver hot path; worker
+//! counts sweep `{1, 4, 8, 16}` so the report shows the contention curve
+//! crossing each scaling regime.
+//!
+//! # Expected outcome and the action it informs
+//!
+//! At T=1 all four shapes converge: the shared `Mutex<Vec>` wins by a
+//! small margin because there is no atomic or queue node overhead at all.
+//! As T grows, the single `Arc<Mutex<Vec>>` is expected to flatten (or
+//! regress) past T=4-8 once the per-item critical section saturates the
+//! mutex. The sharded `Mutex<Vec>` and lock-free queues should keep
+//! scaling close to linear.
+//!
+//! Action this evidence informs:
+//!
+//! - If `Arc<Mutex<Vec>>` collapses at T=8 with a delta > ~20% versus
+//!   the sharded variant, any future PR that proposes a shared mutex on
+//!   the parallel-stat collector path must include a measurement that
+//!   shows why this bench does not apply to it. (e.g., the lock is held
+//!   for a few cycles or the collector is hit < 1k times per transfer.)
+//! - If the crossover stays above T=16, the shared mutex remains a
+//!   viable simplification for any new collector under 100K items.
+//! - The numbers form the baseline for the lock-free replacement work
+//!   tracked in #1271 (sharded queue) and #1370 (per-thread fold).
+//!
+//! Run: `cargo bench -p transfer -- parallel_stat_collector_contention`
+
+#![deny(unsafe_code)]
+
+use std::hint::black_box;
+use std::sync::{Arc, Mutex};
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use crossbeam_queue::SegQueue;
+use rayon::ThreadPoolBuilder;
+
+/// Item count modelling the receiver's 100K-file parallel-stat workload.
+///
+/// 100K matches the upper end of the hot path described in
+/// `docs/audits/arc-mutex-vec-contention.md` and `MEMORY.md` ("Parallel
+/// stat: `PARALLEL_STAT_THRESHOLD = 64`"). Keeping this constant rather
+/// than a parameter lets the per-thread-count rows of the criterion
+/// report be compared apples-to-apples.
+const ITEMS: usize = 100_000;
+
+/// Worker counts to sweep: covers serial baseline, mid-range laptops,
+/// and high-core server hosts. The Mac Studio M2 Ultra reference machine
+/// in the audit doc uses 16+ rayon threads, which is the upper bound here.
+const WORKER_COUNTS: &[usize] = &[1, 4, 8, 16];
+
+/// Stand-in for a stat result. Two pointer-sized fields keep the per-item
+/// payload representative of `(PathBuf-like, file_size)` without dragging
+/// in real allocations that would dominate the measurement.
+#[derive(Clone, Copy)]
+struct StatRecord {
+    index: u64,
+    size: u64,
+}
+
+impl StatRecord {
+    #[inline]
+    fn synth(i: usize) -> Self {
+        Self {
+            index: i as u64,
+            // Touch a derived field so the compiler cannot fold the loop
+            // to a constant store.
+            size: (i as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15),
+        }
+    }
+}
+
+/// Returns a rayon pool sized to `threads`. We build a private pool per
+/// bench so the global pool's worker count cannot skew the measurement.
+fn make_pool(threads: usize) -> rayon::ThreadPool {
+    ThreadPoolBuilder::new()
+        .num_threads(threads)
+        .thread_name(|i| format!("bench-collector-{i}"))
+        .build()
+        .expect("failed to build rayon pool")
+}
+
+/// Drives `body` from `threads` workers, partitioning `ITEMS` evenly. The
+/// last worker absorbs any remainder so the total push count is always
+/// exactly `ITEMS`.
+fn fan_out<F>(pool: &rayon::ThreadPool, threads: usize, body: F)
+where
+    F: Fn(usize, usize) + Sync,
+{
+    pool.scope(|s| {
+        let per_worker = ITEMS / threads;
+        let remainder = ITEMS % threads;
+        for w in 0..threads {
+            let count = if w == threads - 1 {
+                per_worker + remainder
+            } else {
+                per_worker
+            };
+            let body = &body;
+            s.spawn(move |_| body(w, count));
+        }
+    });
+}
+
+/// Baseline: every worker pushes into a single shared `Mutex<Vec<R>>`.
+/// This is the shape #1192 asks us to characterise.
+fn shared_mutex(pool: &rayon::ThreadPool, threads: usize) -> usize {
+    let sink: Arc<Mutex<Vec<StatRecord>>> = Arc::new(Mutex::new(Vec::with_capacity(ITEMS)));
+    fan_out(pool, threads, |worker, count| {
+        let base = worker * (ITEMS / threads);
+        for i in 0..count {
+            let rec = StatRecord::synth(base + i);
+            let mut guard = sink.lock().expect("collector mutex poisoned");
+            guard.push(rec);
+        }
+    });
+    let len = sink.lock().expect("collector mutex poisoned").len();
+    black_box(len)
+}
+
+/// Sharded `Mutex<Vec<R>>` indexed by rayon worker id, matching
+/// `WorkQueueReceiver::drain_parallel`. Contention drops to the cost of
+/// one mutex per worker.
+fn sharded_mutex(pool: &rayon::ThreadPool, threads: usize) -> usize {
+    let shards: Arc<Vec<Mutex<Vec<StatRecord>>>> = Arc::new(
+        (0..threads)
+            .map(|_| Mutex::new(Vec::with_capacity(ITEMS / threads + 1)))
+            .collect(),
+    );
+    fan_out(pool, threads, |worker, count| {
+        let shard_idx = rayon::current_thread_index().unwrap_or(worker) % threads;
+        let base = worker * (ITEMS / threads);
+        for i in 0..count {
+            let rec = StatRecord::synth(base + i);
+            let mut guard = shards[shard_idx].lock().expect("shard mutex poisoned");
+            guard.push(rec);
+        }
+    });
+    let total: usize = shards
+        .iter()
+        .map(|m| m.lock().expect("shard mutex poisoned").len())
+        .sum();
+    black_box(total)
+}
+
+/// Lock-free unbounded queue. Stand-in for any `SegQueue`-backed sink.
+fn seg_queue(pool: &rayon::ThreadPool, threads: usize) -> usize {
+    let queue: Arc<SegQueue<StatRecord>> = Arc::new(SegQueue::new());
+    fan_out(pool, threads, |worker, count| {
+        let base = worker * (ITEMS / threads);
+        for i in 0..count {
+            queue.push(StatRecord::synth(base + i));
+        }
+    });
+    let mut drained = 0usize;
+    while queue.pop().is_some() {
+        drained += 1;
+    }
+    black_box(drained)
+}
+
+/// `crossbeam_channel::unbounded` MPSC. Different lock-free design
+/// (Chase-Lev-style deque inside crossbeam) than `SegQueue`; included so
+/// both common drop-ins are present in the report.
+fn unbounded_channel(pool: &rayon::ThreadPool, threads: usize) -> usize {
+    let (tx, rx) = crossbeam_channel::unbounded::<StatRecord>();
+    fan_out(pool, threads, |worker, count| {
+        let base = worker * (ITEMS / threads);
+        for i in 0..count {
+            tx.send(StatRecord::synth(base + i))
+                .expect("collector channel closed");
+        }
+    });
+    drop(tx);
+    let mut drained = 0usize;
+    while rx.recv().is_ok() {
+        drained += 1;
+    }
+    black_box(drained)
+}
+
+/// Registers one bench group per collector shape, parametric on the rayon
+/// worker count. Throughput is reported in elements/sec so the reader can
+/// read "items/sec" directly off the criterion summary.
+fn bench_collectors(c: &mut Criterion) {
+    let mut group = c.benchmark_group("parallel_stat_collector_contention");
+    group.throughput(Throughput::Elements(ITEMS as u64));
+    group.sample_size(20);
+
+    for &threads in WORKER_COUNTS {
+        let pool = make_pool(threads);
+
+        group.bench_with_input(
+            BenchmarkId::new("arc_mutex_vec", format!("T{threads}")),
+            &threads,
+            |b, &t| b.iter(|| shared_mutex(&pool, t)),
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("sharded_mutex_vec", format!("T{threads}")),
+            &threads,
+            |b, &t| b.iter(|| sharded_mutex(&pool, t)),
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("crossbeam_seg_queue", format!("T{threads}")),
+            &threads,
+            |b, &t| b.iter(|| seg_queue(&pool, t)),
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("crossbeam_unbounded_channel", format!("T{threads}")),
+            &threads,
+            |b, &t| b.iter(|| unbounded_channel(&pool, t)),
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_collectors);
+criterion_main!(benches);

--- a/docs/audits/parallel-stat-collection.md
+++ b/docs/audits/parallel-stat-collection.md
@@ -1,0 +1,123 @@
+# Parallel-stat result collection: what the code actually does (#1192)
+
+Audit answers a single question raised by #1192:
+
+> The receiver's parallel-stat path is suspected of using
+> `Arc<Mutex<Vec<...>>>` to collect results from rayon workers. At 100K+
+> files and 8+ cores this would be a contention bottleneck. Is it?
+
+Short answer: **no production parallel-stat call site uses
+`Arc<Mutex<Vec<...>>>` to collect results.** The collector is rayon's
+built-in lock-free reducer, which split-and-merges per-thread vectors
+without ever sharing a mutex. The two `Mutex<Vec<_>>` production sites
+that do exist (SSH stderr capture and `WorkQueueReceiver::drain_parallel`)
+are off the parallel-stat path or already sharded.
+
+## Inventory of parallel-stat call sites
+
+`grep -rn 'par_iter\|into_par_iter' crates/flist crates/transfer crates/engine`
+returns the following metadata-collection call sites. Every one of them
+collects through rayon's built-in reducer.
+
+| Site | Shape | Collector |
+|------|-------|-----------|
+| `crates/flist/src/parallel.rs:83` (`map_entries_parallel`) | `entries.par_iter().map(f).collect()` | rayon reducer |
+| `crates/flist/src/parallel.rs:105` (`collect_paths_chunked_parallel` inner stat) | `.par_iter().map(...).collect()` | rayon reducer |
+| `crates/flist/src/parallel.rs:132` (`collect_paths_then_metadata_parallel`) | `paths.into_par_iter().map(stat).collect()` | rayon reducer |
+| `crates/flist/src/parallel.rs:206` (`collect_lazy_parallel`) | `paths.into_par_iter().map(lazy).collect()` | rayon reducer |
+| `crates/flist/src/parallel.rs:266` (`collect_with_batched_stats`) | `.into_par_iter().map(batched).collect()` | rayon reducer (cache shards live in `BatchedStatCache`, not on the collector) |
+| `crates/transfer/src/parallel_io.rs:186` (`map_blocking`) | `items.into_par_iter().map(f).collect()` | rayon reducer (the single dispatcher used by the receiver and generator parallel-stat code) |
+| `crates/transfer/src/receiver/transfer/pipeline.rs:188` (signature pre-fetch) | `.par_iter().map(...).collect()` | rayon reducer |
+| `crates/engine/src/local_copy/executor/directory/support.rs:106` (parallel directory stat) | `.into_par_iter().map(...).collect()` | rayon reducer |
+| `crates/engine/src/local_copy/executor/directory/parallel_planner.rs:100` (parallel planning) | `.par_iter().enumerate().map(...).collect()` | rayon reducer |
+
+None of these allocate an `Arc<Mutex<Vec<_>>>` and push into it from
+workers. Rayon's `collect::<Vec<_>>()` implementation builds per-thread
+`Vec`s in `ParallelExtend::par_extend` and concatenates them in the
+join-tree. Workers never share a mutex during the collection step.
+
+## Production `Mutex<Vec<_>>` sites that exist (none on parallel-stat path)
+
+`grep -rn 'Arc<Mutex<Vec\|Mutex<Vec\|Mutex::new(Vec' crates/ --include='*.rs' | grep -v tests`
+finds two non-test producers in shipping code:
+
+| File | Role | Hot path? |
+|------|------|-----------|
+| `crates/rsync_io/src/ssh/aux_channel.rs:99,148` | Bounded SSH stderr ring buffer (cap 64 KiB) | No - one drain thread per SSH child; not in any parallel-stat path |
+| `crates/engine/src/concurrent_delta/work_queue/drain.rs:63` | `WorkQueueReceiver::drain_parallel` per-rayon-thread shards | Yes for delta work items, but sharded by `rayon::current_thread_index()` so contention is structurally near zero |
+
+Neither sits on the receiver's parallel-stat path. Both are documented
+in `docs/audits/arc-mutex-vec-parallel-stat-contention.md`.
+
+## Why the rayon reducer wins by default
+
+`Vec::<R>::par_extend` operates as follows in rayon 1.x (see `rayon/src/iter/extend.rs`):
+
+1. Each worker accumulates into its own `Vec<R>` allocated from the local
+   heap. No coordination.
+2. When two workers join via `rayon::join`, the smaller `Vec` is
+   `Vec::append`-ed onto the larger one by the joining thread.
+3. The join tree concatenates upward until the root holds the full result.
+
+The only synchronisation cost is rayon's own work-stealing deque (one
+atomic CAS per task steal, not per item). The collector contributes
+zero locks per item, which is what makes the `par_iter().collect()`
+pattern strictly faster than `Arc<Mutex<Vec<R>>>` for any non-trivial
+worker count.
+
+## Adjacent shared-state under parallel stat
+
+The one shared mutable structure that workers do touch during
+`collect_with_batched_stats` is the metadata cache:
+
+- `crates/flist/src/batched_stat/cache.rs:28-44` -
+  `Arc<[Mutex<HashMap<PathBuf, Arc<Metadata>>>; 16]>`.
+
+Sixteen-shard hash cache, locked per shard. Expected contention per shard
+is approximately `n_threads / 16`. At 32 rayon threads the FNV hash plus
+`Mutex::lock` cost begins to compete with the underlying stat syscall
+(see audit doc, section 2.1). This is **not** a `Vec` collector, so it
+is out of scope for #1192, but the same measurement plan applies and is
+captured in `docs/audits/arc-mutex-vec-contention.md`.
+
+## Microbench backing this audit
+
+`crates/transfer/benches/parallel_stat_collector_contention.rs` parametrises
+four append strategies (`Arc<Mutex<Vec>>`, sharded `Mutex<Vec>`,
+`crossbeam_queue::SegQueue`, `crossbeam_channel::unbounded`) over 100K
+items at 1, 4, 8, and 16 rayon workers. Run with:
+
+```sh
+cargo bench -p transfer -- parallel_stat_collector_contention
+```
+
+Throughput is reported in elements/sec. The numbers are the baseline
+against which any future proposal to introduce a shared `Mutex<Vec>` on
+this path must be measured.
+
+## Conclusion
+
+The premise of #1192 - "Arc<Mutex<Vec>> is the parallel-stat collector"
+- is incorrect against current master. The collector is rayon's lock-free
+reducer; no shared mutex sits on the per-item path. The microbench
+quantifies what the cost would be if a future change introduced one.
+
+The remaining contention candidate under parallel stat is the 16-shard
+`BatchedStatCache`, tracked separately by the measurement plan in
+`docs/audits/arc-mutex-vec-contention.md` and the dashmap/parking_lot
+comparisons in `docs/audits/arc-mutex-vec-parallel-stat-static.md`.
+
+## References
+
+- `crates/transfer/src/parallel_io.rs` - single dispatcher for parallel stat.
+- `crates/flist/src/parallel.rs` - flist build-time parallel collectors.
+- `crates/flist/src/batched_stat/cache.rs` - 16-shard metadata cache.
+- `crates/transfer/benches/parallel_stat_collector_contention.rs` - the
+  matching microbench produced for #1192.
+- `docs/audits/arc-mutex-vec-parallel-stat-contention.md` - per-site
+  contention analysis.
+- `docs/audits/arc-mutex-vec-contention.md` - static audit and decision
+  criteria for any future replacement.
+- `docs/audits/parallel-stat-batch-size-profile.md` - threshold tuning
+  for the parallel-stat dispatcher.
+- Issue #1192 - tracking item.


### PR DESCRIPTION
## Summary

- Add criterion microbench (`crates/transfer/benches/parallel_stat_collector_contention.rs`) profiling four result-collection strategies (shared `Arc<Mutex<Vec>>`, sharded `Mutex<Vec>` by rayon worker id, `crossbeam_queue::SegQueue`, `crossbeam_channel::unbounded`) at 100K items across 1/4/8/16 rayon workers. Throughput is reported in elements/sec via `BenchmarkGroup::throughput(Throughput::Elements)`, so the report directly names the worker count at which the single shared mutex saturates.
- Document that the shipping parallel-stat path (`crates/transfer/src/parallel_io.rs::map_blocking`) does not use `Arc<Mutex<Vec>>` today; it collects via `into_par_iter().map(f).collect()`, which delegates to rayon's lock-free reducer. New audit at `docs/audits/parallel-stat-collection.md` inventories every parallel-stat call site, lists the two production `Mutex<Vec>` sites that exist (both off the parallel-stat path), and explains why the rayon reducer wins by default.
- Add `crossbeam-channel` as a dev-dependency for the transfer crate (already a workspace dep used by engine).

## Why

Tracking issue #1192 asked whether the receiver's parallel-stat result collector is an `Arc<Mutex<Vec>>` bottleneck under 100K+ files on 8+ core hosts. Static audit shows it is not; the bench produces the numerical evidence needed to reject any future PR that proposes reintroducing the pattern (related: #1271, #1297, #1370, #1682). The microbench does not change runtime behaviour.

## Test plan

- [ ] CI green on all required matrices (fmt+clippy, nextest stable, Windows stable, macOS stable, Linux musl stable).
- [ ] `cargo bench -p transfer -- parallel_stat_collector_contention` runs to completion locally for at least one reviewer.
- [ ] Bench output confirms the expected curve: `arc_mutex_vec` flattens or regresses past T=4-8 while `sharded_mutex_vec` and the lock-free queues continue scaling.