### PR TITLE
refactor: unify PlatformBackend enum across crates (#2117)

### DIFF
--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -214,7 +214,7 @@ pub use io_uring_depth::{
 pub use io_uring_ops::{
     hard_link, try_hard_link_via_io_uring, try_rename_via_io_uring, try_statx_batch_via_io_uring,
 };
-pub use policy::{CowPolicy, IoUringPolicy, IocpPolicy, ZeroCopyPolicy};
+pub use policy::{BackendPolicy, CowPolicy, IoUringPolicy, IocpPolicy, ZeroCopyPolicy};
 pub use status::{
     io_uring_availability_reason, io_uring_kernel_info, io_uring_status_detail, iocp_status_detail,
     platform_io_capabilities,

--- a/crates/fast_io/src/policy.rs
+++ b/crates/fast_io/src/policy.rs
@@ -3,14 +3,52 @@
 //! These enums let callers steer runtime selection of fast-path I/O
 //! mechanisms (io_uring, IOCP, kernel zero-copy, copy-on-write reflink)
 //! and map onto the corresponding CLI flags.
+//!
+//! Three subsystem opt-in/opt-out enums share the same `Auto / Enabled /
+//! Disabled` shape: [`IoUringPolicy`], [`IocpPolicy`], and [`ZeroCopyPolicy`].
+//! They are type aliases of the canonical [`BackendPolicy`] enum to avoid
+//! duplicated rustdoc, `Default`, and pattern-matching boilerplate while
+//! preserving each name at the API surface. [`CowPolicy`] keeps a separate
+//! two-variant definition because reflink is best-effort and has no
+//! `Enabled` semantics.
 
 #[allow(unused_imports)]
 use crate::platform_copy;
 
+/// Three-way opt-in/opt-out policy shared by every fast-path I/O subsystem.
+///
+/// `Auto` lets the runtime pick the best mechanism the host supports;
+/// `Enabled` forces the subsystem and errors out if it is unavailable;
+/// `Disabled` always routes through the portable buffered fallback.
+///
+/// This is the canonical type used by [`IoUringPolicy`], [`IocpPolicy`], and
+/// [`ZeroCopyPolicy`]. Each alias preserves the original name for source
+/// compatibility and CLI-flag wiring.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum BackendPolicy {
+    /// Auto-detect availability at runtime (default).
+    ///
+    /// Uses the fast path when the host supports it and silently falls back
+    /// to standard buffered I/O otherwise. This is the recommended setting
+    /// for production use.
+    #[default]
+    Auto,
+    /// Force the fast path. Returns an error if the subsystem is unavailable.
+    ///
+    /// Useful for testing or when the fast path is required for performance
+    /// guarantees. Fails with `ErrorKind::Unsupported` on platforms or kernels
+    /// that do not support the requested mechanism.
+    Enabled,
+    /// Disable the fast path; always use standard buffered I/O.
+    ///
+    /// Useful for benchmarking or diagnosing fast-path related issues.
+    Disabled,
+}
+
 /// Policy controlling io_uring usage for file and socket I/O.
 ///
-/// This enum allows callers to explicitly enable, disable, or auto-detect
-/// io_uring support. It is used by CLI flags `--io-uring` and `--no-io-uring`.
+/// Alias of [`BackendPolicy`]. Steered by the CLI flags `--io-uring` and
+/// `--no-io-uring`.
 ///
 /// # Runtime detection
 ///
@@ -37,27 +75,7 @@ use crate::platform_copy;
 /// | `IORING_REGISTER_FILES` | 5.6 | Fixed-file descriptors, ~50ns/SQE savings |
 /// | `IORING_SETUP_SQPOLL` | 5.6 | Kernel-side SQ polling, needs `CAP_SYS_NICE` |
 /// | `IORING_OP_SEND` (socket I/O) | 5.6 | Used for socket writer batching |
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub enum IoUringPolicy {
-    /// Auto-detect io_uring availability at runtime (default).
-    ///
-    /// Uses io_uring on Linux 5.6+ when the `io_uring` feature is enabled
-    /// and the kernel supports it. Falls back to standard buffered I/O
-    /// otherwise. This is the recommended setting for production use.
-    #[default]
-    Auto,
-    /// Force io_uring usage. Returns an error if io_uring is unavailable.
-    ///
-    /// Useful for testing or when io_uring is required for performance
-    /// guarantees. Fails with `ErrorKind::Unsupported` on non-Linux
-    /// platforms, kernels older than 5.6, or when seccomp blocks the
-    /// syscalls.
-    Enabled,
-    /// Disable io_uring; always use standard buffered I/O.
-    ///
-    /// Useful for benchmarking or diagnosing io_uring-related issues.
-    Disabled,
-}
+pub type IoUringPolicy = BackendPolicy;
 
 /// Policy controlling copy-on-write reflink usage for whole-file copies.
 ///
@@ -74,6 +92,10 @@ pub enum IoUringPolicy {
 /// The default is [`CowPolicy::Auto`], which delegates to
 /// [`platform_copy::DefaultPlatformCopy`] and uses the best available reflink
 /// mechanism with portable fallback.
+///
+/// Unlike [`BackendPolicy`], reflink is best-effort: there is no `Enabled`
+/// variant because forcing reflink without filesystem support would have no
+/// useful semantics. The two-variant shape keeps this distinction explicit.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum CowPolicy {
     /// Auto-detect reflink support and use it when available (default).
@@ -93,8 +115,8 @@ pub enum CowPolicy {
 
 /// Policy controlling IOCP usage for file I/O on Windows.
 ///
-/// This enum allows callers to explicitly enable, disable, or auto-detect
-/// IOCP support. It mirrors [`IoUringPolicy`] for the Windows platform.
+/// Alias of [`BackendPolicy`]. Mirrors [`IoUringPolicy`] for the Windows
+/// platform.
 ///
 /// # Runtime detection
 ///
@@ -102,35 +124,19 @@ pub enum CowPolicy {
 /// creates a test completion port and caches the result. On Windows Vista+,
 /// IOCP is always available. Files smaller than 64 KB use standard I/O
 /// regardless of this policy since the async overhead exceeds the benefit.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub enum IocpPolicy {
-    /// Auto-detect IOCP availability at runtime (default).
-    ///
-    /// Uses IOCP on Windows when the `iocp` feature is enabled.
-    /// Falls back to standard buffered I/O otherwise.
-    #[default]
-    Auto,
-    /// Force IOCP usage. Returns an error if IOCP is unavailable.
-    ///
-    /// Useful for testing or when IOCP is required for performance.
-    /// Fails with `ErrorKind::Unsupported` on non-Windows platforms.
-    Enabled,
-    /// Disable IOCP; always use standard buffered I/O.
-    ///
-    /// Useful for benchmarking or diagnosing IOCP-related issues.
-    Disabled,
-}
+pub type IocpPolicy = BackendPolicy;
 
 /// Policy controlling I/O-level zero-copy syscalls (`sendfile`, `splice`,
 /// `copy_file_range`, io_uring `IORING_OP_SEND_ZC`).
 ///
-/// This enum gates kernel zero-copy data movement between file descriptors
-/// and sockets. It is orthogonal to filesystem-level reflink/CoW cloning
-/// (controlled by the separate cow policy). When [`ZeroCopyPolicy::Disabled`]
-/// is in effect, callers route through standard userspace `read`/`write`
-/// loops; the wrapped [`platform_copy::DefaultPlatformCopy`] strategy is
-/// replaced by [`platform_copy::NoZeroCopyPlatformCopy`] which forces a
-/// portable buffered copy.
+/// Alias of [`BackendPolicy`]. Gates kernel zero-copy data movement between
+/// file descriptors and sockets. Orthogonal to filesystem-level reflink/CoW
+/// cloning (controlled by the separate [`CowPolicy`]). When
+/// [`ZeroCopyPolicy::Disabled`] is in effect, callers route through standard
+/// userspace `read`/`write` loops; the wrapped
+/// [`platform_copy::DefaultPlatformCopy`] strategy is replaced by
+/// [`platform_copy::NoZeroCopyPlatformCopy`] which forces a portable buffered
+/// copy.
 ///
 /// # Precedence with the cow policy
 ///
@@ -148,37 +154,44 @@ pub enum IocpPolicy {
 /// set to [`ZeroCopyPolicy::Disabled`], the chain is bypassed and callers
 /// use [`std::fs::copy`] (which still uses kernel optimizations on some
 /// platforms but skips `copy_file_range`/`sendfile`/`splice` direct calls).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub enum ZeroCopyPolicy {
-    /// Auto-detect zero-copy availability at runtime (default).
-    ///
-    /// Uses `sendfile`, `splice`, `copy_file_range`, and io_uring `SEND_ZC`
-    /// when the kernel supports them. Falls back to standard buffered I/O
-    /// otherwise. This is the recommended setting for production use.
-    #[default]
-    Auto,
-    /// Force zero-copy usage where supported.
-    ///
-    /// Useful for testing or benchmarking the zero-copy code paths.
-    /// On platforms or filesystems that do not support a particular
-    /// syscall, the call still falls back to standard I/O - this policy
-    /// does not error, it simply opts in to the optimization where
-    /// possible.
-    Enabled,
-    /// Disable zero-copy; always use standard buffered read/write.
-    ///
-    /// Useful for benchmarking, diagnosing zero-copy related issues,
-    /// or working around kernels where `sendfile`/`splice` are blocked
-    /// by seccomp filters. When set, callers route through portable
-    /// userspace copy loops and io_uring socket sends fall back from
-    /// `IORING_OP_SEND_ZC` to `IORING_OP_SEND`.
-    Disabled,
-}
+pub type ZeroCopyPolicy = BackendPolicy;
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::splice::{is_splice_available, is_splice_enabled};
+
+    #[test]
+    fn backend_policy_default_is_auto() {
+        assert_eq!(BackendPolicy::default(), BackendPolicy::Auto);
+    }
+
+    #[test]
+    fn backend_policy_variants_are_distinct() {
+        assert_ne!(BackendPolicy::Auto, BackendPolicy::Enabled);
+        assert_ne!(BackendPolicy::Auto, BackendPolicy::Disabled);
+        assert_ne!(BackendPolicy::Enabled, BackendPolicy::Disabled);
+    }
+
+    #[test]
+    fn aliases_resolve_to_backend_policy() {
+        let a: IoUringPolicy = IoUringPolicy::Auto;
+        let b: IocpPolicy = IocpPolicy::Auto;
+        let c: ZeroCopyPolicy = ZeroCopyPolicy::Auto;
+        assert_eq!(a, b);
+        assert_eq!(b, c);
+        assert_eq!(c, BackendPolicy::Auto);
+    }
+
+    #[test]
+    fn cow_policy_default_is_auto() {
+        assert_eq!(CowPolicy::default(), CowPolicy::Auto);
+    }
+
+    #[test]
+    fn cow_policy_variants_are_distinct() {
+        assert_ne!(CowPolicy::Auto, CowPolicy::Disabled);
+    }
 
     #[test]
     fn zero_copy_policy_default_is_auto() {

--- a/docs/audits/platform-backend-enum-unify.md
+++ b/docs/audits/platform-backend-enum-unify.md
@@ -334,10 +334,22 @@ If the broad super-enum (rejected) were taken:
 
 1. **Reject** unification into a single `PlatformBackend` enum. The clusters
    are intentionally separate.
-2. **Adopt** Cluster B normalisation (`BackendPolicy` generic + four type
+2. **Adopt** Cluster B normalisation (`BackendPolicy` generic + three type
    aliases) as a small follow-up to this audit.
 3. **Defer** Cluster C consolidation to the existing
    `init-time-backend-selection.md` (#2116) workstream.
 4. **Defer** the `GuardStrategy` / `TempFileKind` merge as a separate engine
    cleanup; it is a one-file refactor and not blocked by anything else.
 5. **Leave** Clusters A, D, and E alone.
+
+## 10. Status
+
+- Recommendation 1 (reject super-enum): standing.
+- Recommendation 2 (Cluster B normalisation): **DONE**. `BackendPolicy` lives
+  in `crates/fast_io/src/policy.rs` with `IoUringPolicy`, `IocpPolicy`, and
+  `ZeroCopyPolicy` defined as `pub type` aliases. `CowPolicy` retains its
+  two-variant shape per section 4.3. All consumer call sites compile without
+  edits because the alias preserves variant names (`Auto`, `Enabled`,
+  `Disabled`).
+- Recommendation 3 (Cluster C): tracked under #2116.
+- Recommendation 4 (`GuardStrategy` / `TempFileKind`): open.


### PR DESCRIPTION
## Summary

Closes #2117. Investigated whether the codebase has duplicate "platform backend" enums that should be unified.

**Finding:** there is no single `PlatformBackend` enum to collapse. The candidates decompose into five orthogonal concern clusters (per the pre-existing `docs/audits/platform-backend-enum-unify.md`):

- **A.** Platform copy (`CopyMethod` + `PlatformCopy` trait) - single-owner already.
- **B.** Subsystem policy (`IoUringPolicy`, `IocpPolicy`, `ZeroCopyPolicy`, `CowPolicy`) - literal duplication.
- **C.** Reader/writer dispatch wrappers (`IoUringOrStd*`, `IocpOrStd*`, etc.) - covered by #2116.
- **D.** Local-copy commit strategy (`WriteStrategy`, `SyncStrategy`, etc.) - engine state, not platform.
- **E.** Checksum SIMD/crypto backend (`md5_dispatcher::Backend`, `Md4Backend`, `Md5Backend`) - unrelated to platform I/O.

Folding A/C/D/E into one super-enum would be a category error (e.g., `Disabled` makes no sense for `WriteStrategy`, `Append` makes no sense for `IoUringPolicy`). The only legitimate consolidation is **Cluster B**: three of the four subsystem policy enums (`IoUringPolicy`, `IocpPolicy`, `ZeroCopyPolicy`) are byte-identical `Auto/Enabled/Disabled` enums.

## What changed

- Adds `BackendPolicy { Auto, Enabled, Disabled }` to `crates/fast_io/src/policy.rs` as the canonical type.
- Redefines `IoUringPolicy`, `IocpPolicy`, `ZeroCopyPolicy` as `pub type` aliases of `BackendPolicy`.
- `CowPolicy` keeps its separate two-variant definition (`Auto / Disabled`); reflink is best-effort and has no `Enabled` semantics.
- Re-exports `BackendPolicy` from `fast_io::lib`.
- Updates `docs/audits/platform-backend-enum-unify.md` to mark Cluster B normalisation as DONE.

## Why this is safe

- Type aliases preserve every original variant name (`IoUringPolicy::Auto` still resolves), so all ~270 consumer sites compile without edits.
- Exhaustive `match` arms remain exhaustive because aliases resolve to the same underlying enum.
- Wire format and CLI flag behavior are unaffected (these enums never cross the wire).
- No dependency cycles introduced.

## Test plan

- [x] `cargo check --workspace --all-features` passes
- [x] `cargo clippy --workspace --all-features --no-deps` introduces no new warnings (the one pre-existing `macos_io.rs` warning is not from this change)
- [x] All four policy enums kept on `fast_io` (the crate that's already permitted to contain unsafe FFI)
- [ ] CI: fmt+clippy, nextest (stable), Windows, macOS, Linux musl