### PR TITLE
bench(rsync_io): AES-GCM vs ChaCha20-Poly1305 throughput at SSH payload sizes (#1632)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -522,6 +522,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead 0.5.2",
+ "chacha20 0.9.1",
+ "cipher 0.4.4",
+ "poly1305",
+ "zeroize",
+]
+
+[[package]]
 name = "checksums"
 version = "0.6.2"
 dependencies = [
@@ -592,6 +605,7 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common 0.1.7",
  "inout 0.1.4",
+ "zeroize",
 ]
 
 [[package]]
@@ -926,6 +940,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array 0.14.7",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -3099,6 +3114,9 @@ dependencies = [
 name = "rsync_io"
 version = "0.6.2"
 dependencies = [
+ "aes-gcm 0.10.3",
+ "chacha20poly1305",
+ "criterion",
  "is-terminal",
  "logging",
  "memchr",

--- a/crates/rsync_io/Cargo.toml
+++ b/crates/rsync_io/Cargo.toml
@@ -36,3 +36,10 @@ proptest = "1.4"
 rand = "0.10"
 tempfile = "3.15"
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "net"] }
+criterion = { version = "0.8", features = ["html_reports"] }
+aes-gcm = "0.10"
+chacha20poly1305 = "0.10"
+
+[[bench]]
+name = "ssh_cipher"
+harness = false

--- a/crates/rsync_io/benches/ssh_cipher.rs
+++ b/crates/rsync_io/benches/ssh_cipher.rs
@@ -1,0 +1,213 @@
+//! crates/rsync_io/benches/ssh_cipher.rs
+//!
+//! Throughput comparison: AES-128-GCM vs AES-256-GCM vs ChaCha20-Poly1305 at
+//! typical SSH packet sizes (16 KiB, 64 KiB, 1 MiB).
+//!
+//! The embedded SSH transport selects ciphers via
+//! `rsync_io::ssh::embedded::cipher::default_ciphers`, preferring AES-GCM when
+//! the CPU advertises hardware AES (AES-NI on x86_64, ARMv8 Crypto Extensions
+//! on aarch64) and falling back to ChaCha20-Poly1305 otherwise. This benchmark
+//! exercises the raw AEAD primitives `aes-gcm` and `chacha20poly1305` use so
+//! the cipher-selection heuristic can be validated against measured throughput.
+//!
+//! # Hardware coverage on CI
+//!
+//! - **Linux x86_64 / Linux musl x86_64:** AES-NI is universally present, so
+//!   AES-GCM wins by a large margin and the heuristic's "prefer AES-GCM" path
+//!   matches reality.
+//! - **macOS aarch64 (Apple Silicon):** ARMv8 Cryptography Extensions are
+//!   always available, so AES-GCM again wins and the heuristic's preference
+//!   is correct.
+//! - **Windows x86_64:** Same as Linux x86_64 - AES-NI present.
+//!
+//! The case the heuristic is designed for - aarch64 without ARM AES crypto
+//! extensions (low-end embedded boards, some virtualised guests) - is **not**
+//! exercised by any GitHub Actions runner. Reproducing the "ChaCha20 wins"
+//! result therefore requires running this benchmark on real hardware such as
+//! a Raspberry Pi 3 / Pi Zero 2 or a cloud instance with AES extensions
+//! disabled (`-cpu cortex-a53,-aes` under QEMU).
+//!
+//! # Forcing a pure-software path
+//!
+//! The `aes-gcm` and `chacha20poly1305` crates dispatch to hardware AES /
+//! `vaes` automatically when the target architecture and CPU features allow.
+//! There is no portable runtime switch to disable that dispatch. To exercise
+//! the pure-software AES path the benchmark must be built and run on a host
+//! without AES-NI / ARM AES, or under an emulator that does not expose those
+//! features. The benchmark therefore reports whichever code path the crate's
+//! own runtime detection selects on the host CPU.
+//!
+//! Run with:
+//!
+//! ```text
+//! cargo bench -p rsync_io --bench ssh_cipher
+//! ```
+
+use std::hint::black_box;
+use std::time::Duration;
+
+use aes_gcm::aead::{Aead, KeyInit};
+use aes_gcm::{Aes128Gcm, Aes256Gcm, Key as AesKey, Nonce as AesNonce};
+use chacha20poly1305::{ChaCha20Poly1305, Key as ChaChaKey, Nonce as ChaChaNonce};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use rand::RngExt;
+
+/// SSH packet sizes spanning the typical traffic distribution: 16 KiB matches
+/// the default channel window granularity, 64 KiB is the maximum SSH packet,
+/// and 1 MiB models bulk file transfer where the same key streams many
+/// packets back-to-back.
+const PACKET_SIZES: &[usize] = &[16 * 1024, 64 * 1024, 1024 * 1024];
+
+/// Returns a buffer of `size` random bytes used as the plaintext input for
+/// each benchmarked AEAD primitive. Uses the thread-local RNG so the input is
+/// incompressible.
+fn random_plaintext(size: usize) -> Vec<u8> {
+    let mut buf = vec![0u8; size];
+    rand::rng().fill(&mut buf[..]);
+    buf
+}
+
+/// Returns `N` random bytes from the thread-local RNG. Used to build cipher
+/// keys and nonces of arbitrary fixed size.
+fn random_bytes<const N: usize>() -> [u8; N] {
+    let mut buf = [0u8; N];
+    rand::rng().fill(&mut buf[..]);
+    buf
+}
+
+/// Benchmarks AES-128-GCM encrypt and decrypt at the configured packet sizes.
+fn bench_aes_128_gcm(c: &mut Criterion) {
+    let key_bytes: [u8; 16] = random_bytes();
+    let key = AesKey::<Aes128Gcm>::from_slice(&key_bytes);
+    let cipher = Aes128Gcm::new(key);
+    let nonce_bytes: [u8; 12] = random_bytes();
+    let nonce = AesNonce::from_slice(&nonce_bytes);
+
+    let mut encrypt = c.benchmark_group("aes_128_gcm/encrypt");
+    for &size in PACKET_SIZES {
+        let plaintext = random_plaintext(size);
+        encrypt.throughput(Throughput::Bytes(size as u64));
+        encrypt.bench_with_input(BenchmarkId::from_parameter(size), &plaintext, |b, pt| {
+            b.iter(|| {
+                let ct = cipher
+                    .encrypt(nonce, black_box(pt.as_slice()))
+                    .expect("aes-128-gcm encryption");
+                black_box(ct);
+            });
+        });
+    }
+    encrypt.finish();
+
+    let mut decrypt = c.benchmark_group("aes_128_gcm/decrypt");
+    for &size in PACKET_SIZES {
+        let plaintext = random_plaintext(size);
+        let ciphertext = cipher
+            .encrypt(nonce, plaintext.as_slice())
+            .expect("aes-128-gcm encryption for decrypt bench");
+        decrypt.throughput(Throughput::Bytes(size as u64));
+        decrypt.bench_with_input(BenchmarkId::from_parameter(size), &ciphertext, |b, ct| {
+            b.iter(|| {
+                let pt = cipher
+                    .decrypt(nonce, black_box(ct.as_slice()))
+                    .expect("aes-128-gcm decryption");
+                black_box(pt);
+            });
+        });
+    }
+    decrypt.finish();
+}
+
+/// Benchmarks AES-256-GCM encrypt and decrypt at the configured packet sizes.
+fn bench_aes_256_gcm(c: &mut Criterion) {
+    let key_bytes: [u8; 32] = random_bytes();
+    let key = AesKey::<Aes256Gcm>::from_slice(&key_bytes);
+    let cipher = Aes256Gcm::new(key);
+    let nonce_bytes: [u8; 12] = random_bytes();
+    let nonce = AesNonce::from_slice(&nonce_bytes);
+
+    let mut encrypt = c.benchmark_group("aes_256_gcm/encrypt");
+    for &size in PACKET_SIZES {
+        let plaintext = random_plaintext(size);
+        encrypt.throughput(Throughput::Bytes(size as u64));
+        encrypt.bench_with_input(BenchmarkId::from_parameter(size), &plaintext, |b, pt| {
+            b.iter(|| {
+                let ct = cipher
+                    .encrypt(nonce, black_box(pt.as_slice()))
+                    .expect("aes-256-gcm encryption");
+                black_box(ct);
+            });
+        });
+    }
+    encrypt.finish();
+
+    let mut decrypt = c.benchmark_group("aes_256_gcm/decrypt");
+    for &size in PACKET_SIZES {
+        let plaintext = random_plaintext(size);
+        let ciphertext = cipher
+            .encrypt(nonce, plaintext.as_slice())
+            .expect("aes-256-gcm encryption for decrypt bench");
+        decrypt.throughput(Throughput::Bytes(size as u64));
+        decrypt.bench_with_input(BenchmarkId::from_parameter(size), &ciphertext, |b, ct| {
+            b.iter(|| {
+                let pt = cipher
+                    .decrypt(nonce, black_box(ct.as_slice()))
+                    .expect("aes-256-gcm decryption");
+                black_box(pt);
+            });
+        });
+    }
+    decrypt.finish();
+}
+
+/// Benchmarks ChaCha20-Poly1305 encrypt and decrypt at the configured packet
+/// sizes. This is the cipher the SSH layer prefers when the CPU lacks hardware
+/// AES.
+fn bench_chacha20_poly1305(c: &mut Criterion) {
+    let key_bytes: [u8; 32] = random_bytes();
+    let key = ChaChaKey::from_slice(&key_bytes);
+    let cipher = ChaCha20Poly1305::new(key);
+    let nonce_bytes: [u8; 12] = random_bytes();
+    let nonce = ChaChaNonce::from_slice(&nonce_bytes);
+
+    let mut encrypt = c.benchmark_group("chacha20_poly1305/encrypt");
+    for &size in PACKET_SIZES {
+        let plaintext = random_plaintext(size);
+        encrypt.throughput(Throughput::Bytes(size as u64));
+        encrypt.bench_with_input(BenchmarkId::from_parameter(size), &plaintext, |b, pt| {
+            b.iter(|| {
+                let ct = cipher
+                    .encrypt(nonce, black_box(pt.as_slice()))
+                    .expect("chacha20-poly1305 encryption");
+                black_box(ct);
+            });
+        });
+    }
+    encrypt.finish();
+
+    let mut decrypt = c.benchmark_group("chacha20_poly1305/decrypt");
+    for &size in PACKET_SIZES {
+        let plaintext = random_plaintext(size);
+        let ciphertext = cipher
+            .encrypt(nonce, plaintext.as_slice())
+            .expect("chacha20-poly1305 encryption for decrypt bench");
+        decrypt.throughput(Throughput::Bytes(size as u64));
+        decrypt.bench_with_input(BenchmarkId::from_parameter(size), &ciphertext, |b, ct| {
+            b.iter(|| {
+                let pt = cipher
+                    .decrypt(nonce, black_box(ct.as_slice()))
+                    .expect("chacha20-poly1305 decryption");
+                black_box(pt);
+            });
+        });
+    }
+    decrypt.finish();
+}
+
+criterion_group! {
+    name = ssh_cipher_benches;
+    config = Criterion::default()
+        .warm_up_time(Duration::from_millis(500))
+        .measurement_time(Duration::from_secs(3));
+    targets = bench_aes_128_gcm, bench_aes_256_gcm, bench_chacha20_poly1305
+}
+criterion_main!(ssh_cipher_benches);


### PR DESCRIPTION
## Summary

- Adds `crates/rsync_io/benches/ssh_cipher.rs`, a Criterion benchmark that measures AES-128-GCM, AES-256-GCM, and ChaCha20-Poly1305 encrypt/decrypt throughput at 16 KiB, 64 KiB, and 1 MiB packet sizes - the three sizes that dominate real SSH traffic.
- Validates the cipher-selection heuristic in `ssh::embedded::cipher::default_ciphers` (prefer AES-GCM when hardware AES is present, otherwise ChaCha20-Poly1305) by exercising the same RustCrypto primitives the heuristic targets: `aes-gcm = "0.10"` and `chacha20poly1305 = "0.10"`.
- Documents in a top-of-file comment which CI runners produce meaningful comparisons. All current GitHub Actions runners have hardware AES (AES-NI on x86_64, ARMv8 Crypto Extensions on Apple Silicon), so they will show AES-GCM dominance - the expected case. The "ChaCha20 wins on AES-less ARM" outcome the heuristic is designed for requires real hardware such as a Raspberry Pi 3 / Pi Zero 2, or QEMU `-cpu cortex-a53,-aes`, neither of which CI runs.

## Notes

- Bench only - no production code changes.
- The `aes-gcm` and `chacha20poly1305` crates dispatch to hardware backends automatically; there is no portable runtime switch to force pure-software AES. The benchmark therefore reports whichever path the crate's own feature detection selects on the host CPU. This is called out in the file header.
- `aes-gcm` was already a transitive dependency via `russh`; `chacha20poly1305` (the unified AEAD wrapper) is new, but its underlying `chacha20` and `poly1305` building blocks were already in the lockfile.

## Test plan

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy -p rsync_io --benches --all-features --no-deps -- -D warnings`
- [ ] `cargo bench -p rsync_io --bench ssh_cipher -- --test` (smoke run on every CI runner)
- [ ] On macOS aarch64 / Linux x86_64 CI: confirm AES-GCM throughput at 64 KiB exceeds ChaCha20-Poly1305 (hardware AES present)
- [ ] Run manually on aarch64 without ARM Crypto Extensions to validate the fallback assumption