### PR TITLE
bench(matching): zsync prefilter, seq-match, prune workloads (#2063, #2067, #2071)

### DIFF
--- a/crates/matching/Cargo.toml
+++ b/crates/matching/Cargo.toml
@@ -31,6 +31,13 @@ checksums = { path = "../checksums", default-features = false }
 default = []
 # Structured logging instrumentation for performance analysis
 tracing = ["dep:tracing"]
+# Internal benchmark scaffolding: exposes additional accessors and toggles
+# used only by the bench harnesses in `benches/`. Never enabled by default,
+# never propagated to workspace `default-features`, the CLI `features`
+# table, or the daemon. There is no way to turn it on from a release
+# `oc-rsync` invocation. See `docs/design/zsync-bithash.md` section 7 and
+# `docs/design/zsync-prune.md` benchmark plan.
+bench-internal = []
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }
@@ -45,3 +52,18 @@ harness = false
 [[bench]]
 name = "profiling_analysis"
 harness = false
+
+[[bench]]
+name = "bithash_rejection"
+harness = false
+required-features = ["bench-internal"]
+
+[[bench]]
+name = "seq_match_redundant"
+harness = false
+required-features = ["bench-internal"]
+
+[[bench]]
+name = "prune_duplicate_heavy"
+harness = false
+required-features = ["bench-internal"]

--- a/crates/matching/benches/bithash_rejection.rs
+++ b/crates/matching/benches/bithash_rejection.rs
@@ -1,0 +1,326 @@
+//! Bithash prefilter rejection-rate benchmark (#2063).
+//!
+//! Measures the rejection rate of the bithash prefilter described in
+//! `docs/design/zsync-bithash.md` section 7. The bithash is a one-sided
+//! filter sized to roughly 8x the rsum-bucket count, so its design target
+//! is a rejection rate of `~0.875` on uniform-random misses.
+//!
+//! Run with:
+//! ```
+//! cargo bench -p matching --features bench-internal --bench bithash_rejection
+//! ```
+//!
+//! # What this benchmark reports
+//!
+//! Two complementary quantities, both written to stdout before the
+//! Criterion timing tables:
+//!
+//! 1. **Static utilization** of the bithash after the basis is indexed.
+//!    Reported as the fraction of set bits in the bit array; rejection
+//!    on uniform-random probes converges to `1.0 - utilization`.
+//! 2. **Observed rejection rate** when scanning a *target* file across
+//!    the basis at one-byte-aligned offsets. Two target classes drive
+//!    the matrix:
+//!    - `target = basis` (sequential 100% match): rejection rate is
+//!      close to 0 because most rolling-hash positions land on an
+//!      indexed block.
+//!    - `target = random` (100% miss): rejection rate is dominated by
+//!      the bithash and converges to the design 7/8 bound at large
+//!      block counts.
+//!
+//! # Methodology notes
+//!
+//! - Basis sizes: 1 MiB, 16 MiB, 128 MiB. Default block size.
+//! - Probes are computed via [`RollingDigest::from_bytes`] over a
+//!   contiguous slice of the target at the current cursor; this matches
+//!   the rolling-hash advance pattern in
+//!   `crates/matching/src/generator.rs` without re-running the full
+//!   delta loop.
+//! - The "post-tag" qualifier in the design doc means probes that pass
+//!   the `tag_table` gate. The bench reports rejection both unconditionally
+//!   and post-tag, using the [`DeltaSignatureIndex::tag_admits`] and
+//!   [`DeltaSignatureIndex::bithash_admits`] accessors exposed under
+//!   `bench-internal`.
+
+#![cfg(feature = "bench-internal")]
+
+use std::hint::black_box;
+use std::num::NonZeroU8;
+use std::sync::OnceLock;
+
+use checksums::RollingDigest;
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+
+use matching::DeltaSignatureIndex;
+use protocol::ProtocolVersion;
+use signature::{
+    SignatureAlgorithm, SignatureLayoutParams, calculate_signature_layout, generate_file_signature,
+};
+
+const BASIS_SIZES: &[(usize, &str)] = &[
+    (1 << 20, "1MiB"),
+    (16 << 20, "16MiB"),
+    (128 << 20, "128MiB"),
+];
+
+/// Deterministic pseudo-random byte sequence keyed by `seed`.
+///
+/// Uses a 64-bit LCG so the bench is reproducible without a `rand`
+/// dependency. The mixer is the same SplitMix64 step used in the wider
+/// workspace test helpers.
+fn pseudo_random_bytes(seed: u64, len: usize) -> Vec<u8> {
+    let mut state = seed.wrapping_add(0x9E37_79B9_7F4A_7C15);
+    let mut out = vec![0u8; len];
+    for chunk in out.chunks_mut(8) {
+        state = state.wrapping_add(0x9E37_79B9_7F4A_7C15);
+        let mut z = state;
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+        z ^= z >> 31;
+        let bytes = z.to_le_bytes();
+        chunk.copy_from_slice(&bytes[..chunk.len()]);
+    }
+    out
+}
+
+/// Deterministic byte sequence keyed by a small mixer so the basis is
+/// not all-zero (which would make the bithash trivial).
+fn structured_basis(seed: u64, len: usize) -> Vec<u8> {
+    // Mix two streams so the basis has visible structure (the low byte
+    // moves slowly, the high byte fast) without being purely random.
+    let mut out = vec![0u8; len];
+    let mut a = seed.wrapping_add(0xDEAD_BEEF);
+    for (i, byte) in out.iter_mut().enumerate() {
+        a = a.wrapping_mul(0x5DEE_CE66D).wrapping_add(0xB);
+        *byte = ((a >> 16) ^ (i as u64)) as u8;
+    }
+    out
+}
+
+fn build_index(data: &[u8]) -> DeltaSignatureIndex {
+    let params = SignatureLayoutParams::new(
+        data.len() as u64,
+        None,
+        ProtocolVersion::NEWEST,
+        NonZeroU8::new(16).expect("non-zero"),
+    );
+    let layout = calculate_signature_layout(params).expect("layout");
+    let signature =
+        generate_file_signature(data, layout, SignatureAlgorithm::Md4).expect("signature");
+    DeltaSignatureIndex::from_signature(&signature, SignatureAlgorithm::Md4).expect("index")
+}
+
+/// Cached basis + index per size, so each Criterion sample reuses the
+/// same expensive setup. Static utilization is computed once and reported
+/// the first time a size is touched.
+fn fixture_for(size: usize, label: &str) -> &'static Fixture {
+    static CACHE: OnceLock<Vec<(usize, Fixture)>> = OnceLock::new();
+    let cache = CACHE.get_or_init(|| {
+        BASIS_SIZES
+            .iter()
+            .map(|(sz, lbl)| (*sz, Fixture::new(*sz, lbl)))
+            .collect()
+    });
+    &cache
+        .iter()
+        .find(|(sz, _)| *sz == size)
+        .unwrap_or_else(|| panic!("missing fixture for {label}"))
+        .1
+}
+
+struct Fixture {
+    basis: Vec<u8>,
+    target_random: Vec<u8>,
+    index: DeltaSignatureIndex,
+    block_len: usize,
+    utilization: f64,
+}
+
+impl Fixture {
+    fn new(size: usize, label: &str) -> Self {
+        let basis = structured_basis(0xA5A5_A5A5_A5A5_A5A5, size);
+        let target_random = pseudo_random_bytes(0x1234_5678_DEAD_BEEF, size);
+        let index = build_index(&basis);
+        let block_len = index.block_length();
+        let block_count = index.block_count();
+        let utilization = index.bithash_utilization();
+        eprintln!(
+            "bithash[{label}]: blocks={block_count} block_len={block_len} \
+             utilization={utilization:.4} predicted_rejection_uniform={pred:.4}",
+            pred = 1.0 - utilization,
+        );
+        Self {
+            basis,
+            target_random,
+            index,
+            block_len,
+            utilization,
+        }
+    }
+}
+
+/// Walks `target` at single-byte strides counting tag-admit, bithash-admit,
+/// and final probe outcomes. Returns `(probes, tag_admits, bithash_admits,
+/// full_matches)`.
+///
+/// `stride` lets the caller subsample large basis sizes so the bench
+/// stays under Criterion's measurement budget; the rejection ratios are
+/// stride-invariant under uniform sampling.
+fn count_admits(
+    target: &[u8],
+    index: &DeltaSignatureIndex,
+    block_len: usize,
+    stride: usize,
+) -> (u64, u64, u64, u64) {
+    if target.len() < block_len {
+        return (0, 0, 0, 0);
+    }
+    let mut probes = 0u64;
+    let mut tag_admits = 0u64;
+    let mut bithash_admits = 0u64;
+    let mut full_matches = 0u64;
+    let last = target.len() - block_len;
+    let mut pos = 0usize;
+    while pos <= last {
+        let window = &target[pos..pos + block_len];
+        let digest = RollingDigest::from_bytes(window);
+        probes += 1;
+        if index.tag_admits(digest.sum1()) {
+            tag_admits += 1;
+            if index.bithash_admits(digest.value()) {
+                bithash_admits += 1;
+                if index.find_match_bytes(digest, window).is_some() {
+                    full_matches += 1;
+                }
+            }
+        }
+        pos += stride;
+    }
+    (probes, tag_admits, bithash_admits, full_matches)
+}
+
+fn bench_static_rejection(c: &mut Criterion) {
+    let mut group = c.benchmark_group("bithash_static");
+
+    for (size, label) in BASIS_SIZES {
+        let fixture = fixture_for(*size, label);
+        group.bench_with_input(
+            BenchmarkId::new("utilization_probe", label),
+            &fixture.utilization,
+            |b, util| {
+                b.iter(|| black_box(*util));
+            },
+        );
+    }
+
+    group.finish();
+}
+
+fn bench_observed_rejection(c: &mut Criterion) {
+    let mut group = c.benchmark_group("bithash_observed");
+    group.sample_size(10);
+
+    for (size, label) in BASIS_SIZES {
+        let fixture = fixture_for(*size, label);
+        // Stride caps the per-iteration work for the 128 MiB case so the
+        // bench stays inside the default Criterion measurement budget.
+        let stride = match *size {
+            n if n <= 1 << 20 => 1,
+            n if n <= 16 << 20 => 16,
+            _ => 256,
+        };
+
+        // 100% match path: target == basis. The rolling hash hits an
+        // indexed block at every offset, so rejection is near zero.
+        group.throughput(Throughput::Bytes(
+            fixture.basis.len() as u64 / stride as u64,
+        ));
+        group.bench_with_input(
+            BenchmarkId::new("match_basis_equals_target", label),
+            &(fixture, stride),
+            |b, (fx, stride)| {
+                b.iter(|| {
+                    let (probes, tag, bit, full) =
+                        count_admits(&fx.basis, &fx.index, fx.block_len, *stride);
+                    black_box((probes, tag, bit, full));
+                });
+            },
+        );
+
+        // 100% miss path: target is uncorrelated random data. Most
+        // probes hit the tag table by chance (~1/2 for 16-bit s1) but
+        // the bithash should reject ~7/8 of the survivors.
+        group.bench_with_input(
+            BenchmarkId::new("miss_random_target", label),
+            &(fixture, stride),
+            |b, (fx, stride)| {
+                b.iter(|| {
+                    let (probes, tag, bit, full) =
+                        count_admits(&fx.target_random, &fx.index, fx.block_len, *stride);
+                    black_box((probes, tag, bit, full));
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+/// Reports observed rejection rate as a one-shot stderr emission so the
+/// bench output captures concrete numbers without relying on Criterion's
+/// throughput tables. Runs once per basis size before the Criterion
+/// measurement loop.
+fn report_rejection_summary() {
+    eprintln!(
+        "bithash rejection summary (size,target,probes,tag_admits,bithash_admits,full_matches,\
+         tag_admit_rate,post_tag_bithash_reject_rate)"
+    );
+    for (size, label) in BASIS_SIZES {
+        let fixture = fixture_for(*size, label);
+        let stride = match *size {
+            n if n <= 1 << 20 => 1,
+            n if n <= 16 << 20 => 16,
+            _ => 256,
+        };
+        for (kind, data) in [
+            ("basis", fixture.basis.as_slice()),
+            ("random", fixture.target_random.as_slice()),
+        ] {
+            let (probes, tag, bit, full) =
+                count_admits(data, &fixture.index, fixture.block_len, stride);
+            let tag_rate = if probes == 0 {
+                0.0
+            } else {
+                tag as f64 / probes as f64
+            };
+            let post_tag_reject = if tag == 0 {
+                0.0
+            } else {
+                1.0 - (bit as f64 / tag as f64)
+            };
+            eprintln!(
+                "bithash[{label},{kind}] probes={probes} tag={tag} bithash={bit} full={full} \
+                 tag_admit_rate={tag_rate:.4} post_tag_reject={post_tag_reject:.4}"
+            );
+        }
+    }
+}
+
+/// Wraps the Criterion entry point so the rejection summary lands
+/// before the timing tables. `report_rejection_summary` is idempotent
+/// because the fixtures are cached in a `OnceLock`.
+fn bench_rejection_with_summary(c: &mut Criterion) {
+    report_rejection_summary();
+    bench_static_rejection(c);
+    bench_observed_rejection(c);
+}
+
+criterion_group!(
+    name = benches;
+    config = Criterion::default()
+        .sample_size(10)
+        .measurement_time(std::time::Duration::from_secs(5));
+    targets = bench_rejection_with_summary
+);
+
+criterion_main!(benches);

--- a/crates/matching/benches/prune_duplicate_heavy.rs
+++ b/crates/matching/benches/prune_duplicate_heavy.rs
@@ -1,0 +1,246 @@
+//! Prune-step throughput benchmark on duplicate-heavy basis (#2071).
+//!
+//! Exercises the matched-block pruning bitmap described in
+//! `docs/design/zsync-prune.md` on a VM-disk-image-style corpus where a
+//! large fraction of basis blocks are duplicate zero-filled blocks. With
+//! prune enabled, an emitted COPY for a zero block sets a bit so later
+//! probes against the same zero pattern skip the duplicate sibling.
+//!
+//! Run with:
+//! ```
+//! cargo bench -p matching --features bench-internal --bench prune_duplicate_heavy
+//! ```
+//!
+//! # Corpora
+//!
+//! - `zero_heavy_16MiB`: 16 MiB basis with ~70% zero-block extents,
+//!   approximating a sparse VM disk image. The remaining 30% is
+//!   structured non-zero data so the matcher is exercised beyond the
+//!   zero-block fast path.
+//! - `repeated_blocks_16MiB`: 16 MiB basis with a 4 KiB pattern tiled
+//!   `N` times, modelling the parent design's "synthetic 50% duplicate
+//!   density" corpus class scaled to a bench-friendly size.
+//! - `no_duplicates_16MiB`: 16 MiB of uncorrelated random bytes as the
+//!   parent design's zero-regression control.
+//!
+//! # What is measured
+//!
+//! For each corpus the bench runs [`DeltaGenerator::generate`] with the
+//! pruning bitmap enabled (production default) and disabled (via the
+//! bench-only [`DeltaGenerator::with_prune_matched`] toggle exposed
+//! under `bench-internal`). The Criterion output reports wall-clock
+//! match throughput for both configurations side by side, and a one-shot
+//! stderr summary names the copy / literal byte split for each
+//! configuration so the wire-equality of the output is observable.
+
+#![cfg(feature = "bench-internal")]
+
+use std::hint::black_box;
+use std::io::Cursor;
+use std::num::NonZeroU8;
+use std::sync::OnceLock;
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+
+use matching::{DeltaGenerator, DeltaScript, DeltaSignatureIndex, DeltaToken};
+use protocol::ProtocolVersion;
+use signature::{
+    SignatureAlgorithm, SignatureLayoutParams, calculate_signature_layout, generate_file_signature,
+};
+
+const BASIS_SIZE: usize = 16 << 20;
+
+/// Builds a VM-disk-image-style basis: roughly `zero_fraction` of the
+/// bytes are zero-filled extents, the rest is structured non-zero data.
+/// The zero extents are large enough (multiple block lengths) that
+/// consecutive basis blocks share identical content and therefore exercise
+/// the duplicate-sibling code path the prune step targets.
+fn zero_heavy_basis(seed: u64, size: usize, zero_fraction: f64) -> Vec<u8> {
+    let zero_bytes = (size as f64 * zero_fraction) as usize;
+    let mut out = vec![0u8; size];
+    // Fill the tail with structured non-zero data.
+    let mut state = seed.wrapping_add(0xA5A5_A5A5_A5A5_A5A5);
+    for byte in out.iter_mut().skip(zero_bytes) {
+        state = state.wrapping_mul(0x5DEE_CE66D).wrapping_add(0xB);
+        // Bias the byte away from zero so the prune step is the dominant
+        // duplicate source rather than incidental zeros in the tail.
+        let b = ((state >> 16) | 1) as u8;
+        *byte = b;
+    }
+    out
+}
+
+/// Builds a basis with a single 4 KiB pattern tiled across the file,
+/// producing maximum duplicate density.
+fn repeated_blocks_basis(size: usize) -> Vec<u8> {
+    const PATTERN: usize = 4096;
+    let mut pattern = vec![0u8; PATTERN];
+    for (i, byte) in pattern.iter_mut().enumerate() {
+        *byte = ((i.wrapping_mul(2654435761)) ^ 0xC3) as u8;
+    }
+    let mut out = Vec::with_capacity(size + PATTERN);
+    while out.len() < size {
+        out.extend_from_slice(&pattern);
+    }
+    out.truncate(size);
+    out
+}
+
+/// Builds an uncorrelated random basis as the zero-regression control.
+fn random_basis(seed: u64, size: usize) -> Vec<u8> {
+    let mut state = seed.wrapping_add(0x9E37_79B9_7F4A_7C15);
+    let mut out = vec![0u8; size];
+    for chunk in out.chunks_mut(8) {
+        state = state.wrapping_add(0x9E37_79B9_7F4A_7C15);
+        let mut z = state;
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+        z ^= z >> 31;
+        let bytes = z.to_le_bytes();
+        chunk.copy_from_slice(&bytes[..chunk.len()]);
+    }
+    out
+}
+
+fn build_index(data: &[u8]) -> DeltaSignatureIndex {
+    let params = SignatureLayoutParams::new(
+        data.len() as u64,
+        None,
+        ProtocolVersion::NEWEST,
+        NonZeroU8::new(16).expect("non-zero"),
+    );
+    let layout = calculate_signature_layout(params).expect("layout");
+    let signature =
+        generate_file_signature(data, layout, SignatureAlgorithm::Md4).expect("signature");
+    DeltaSignatureIndex::from_signature(&signature, SignatureAlgorithm::Md4).expect("index")
+}
+
+struct Fixture {
+    label: &'static str,
+    basis: Vec<u8>,
+    target: Vec<u8>,
+    index: DeltaSignatureIndex,
+}
+
+impl Fixture {
+    fn new(label: &'static str, basis: Vec<u8>) -> Self {
+        // Target = basis (same content). Duplicate-heavy match where every
+        // probe at a duplicate position has many candidate siblings.
+        let target = basis.clone();
+        let index = build_index(&basis);
+        Self {
+            label,
+            basis,
+            target,
+            index,
+        }
+    }
+}
+
+fn fixtures() -> &'static [Fixture] {
+    static CACHE: OnceLock<Vec<Fixture>> = OnceLock::new();
+    CACHE.get_or_init(|| {
+        vec![
+            Fixture::new(
+                "zero_heavy_16MiB",
+                zero_heavy_basis(0xDEAD_BEEF_CAFE_BABE, BASIS_SIZE, 0.7),
+            ),
+            Fixture::new("repeated_blocks_16MiB", repeated_blocks_basis(BASIS_SIZE)),
+            Fixture::new(
+                "no_duplicates_16MiB",
+                random_basis(0xC0FF_EE00_FACE_F00D, BASIS_SIZE),
+            ),
+        ]
+    })
+}
+
+fn count_tokens(script: &DeltaScript) -> (u64, u64, u64, u64) {
+    let mut copies = 0u64;
+    let mut copy_bytes = 0u64;
+    let mut literals = 0u64;
+    let mut literal_bytes = 0u64;
+    for token in script.tokens() {
+        match token {
+            DeltaToken::Copy { len, .. } => {
+                copies += 1;
+                copy_bytes += *len as u64;
+            }
+            DeltaToken::Literal(bytes) => {
+                literals += 1;
+                literal_bytes += bytes.len() as u64;
+            }
+        }
+    }
+    (copies, literals, literal_bytes, copy_bytes)
+}
+
+fn run(fx: &Fixture, prune: bool) -> DeltaScript {
+    DeltaGenerator::new()
+        .with_prune_matched(prune)
+        .generate(Cursor::new(&fx.target), &fx.index)
+        .expect("generate")
+}
+
+fn report_summary() {
+    eprintln!(
+        "prune summary (corpus,prune,basis_bytes,target_bytes,copy_tokens,literal_tokens,\
+         literal_bytes,copy_bytes)"
+    );
+    for fx in fixtures() {
+        for prune in [false, true] {
+            let script = run(fx, prune);
+            let (copies, literals, literal_bytes, copy_bytes) = count_tokens(&script);
+            eprintln!(
+                "prune[{label},prune={prune}] basis={bsz} target={tsz} copy={cp} lit={lt} \
+                 lit_bytes={lb} copy_bytes={cb}",
+                label = fx.label,
+                bsz = fx.basis.len(),
+                tsz = fx.target.len(),
+                cp = copies,
+                lt = literals,
+                lb = literal_bytes,
+                cb = copy_bytes,
+            );
+        }
+    }
+}
+
+fn bench_prune_throughput(c: &mut Criterion) {
+    let mut group = c.benchmark_group("prune_throughput");
+    group.sample_size(10);
+
+    for fx in fixtures() {
+        group.throughput(Throughput::Bytes(fx.target.len() as u64));
+
+        group.bench_with_input(BenchmarkId::new("no_prune", fx.label), fx, |b, fx| {
+            b.iter(|| {
+                let script = run(fx, false);
+                black_box(script)
+            });
+        });
+
+        group.bench_with_input(BenchmarkId::new("prune", fx.label), fx, |b, fx| {
+            b.iter(|| {
+                let script = run(fx, true);
+                black_box(script)
+            });
+        });
+    }
+
+    group.finish();
+}
+
+fn bench_prune_entry(c: &mut Criterion) {
+    report_summary();
+    bench_prune_throughput(c);
+}
+
+criterion_group!(
+    name = benches;
+    config = Criterion::default()
+        .sample_size(10)
+        .measurement_time(std::time::Duration::from_secs(5));
+    targets = bench_prune_entry
+);
+
+criterion_main!(benches);

--- a/crates/matching/benches/seq_match_redundant.rs
+++ b/crates/matching/benches/seq_match_redundant.rs
@@ -1,0 +1,260 @@
+//! Sequential-match throughput benchmark on highly redundant basis (#2067).
+//!
+//! Exercises the `want_i` adjacent-block hint path
+//! (`crates/matching/src/index/mod.rs::check_block_match_slices` plus the
+//! generator's match loop) on corpora where consecutive basis blocks are
+//! the most likely next match. The benchmark plan binding in
+//! `docs/design/zsync-seq-match.md` calls for log-file-style and
+//! tar-archive-style corpora, plus a random control.
+//!
+//! Run with:
+//! ```
+//! cargo bench -p matching --features bench-internal --bench seq_match_redundant
+//! ```
+//!
+//! # Corpora
+//!
+//! - `log_like`: 16 MiB of repeated newline-terminated log lines with a
+//!   monotonic counter, mirroring an append-only log fixture.
+//! - `tar_like`: 16 MiB of a small "record" block tiled with subtle
+//!   per-record header deltas. Approximates a tar archive of nearly
+//!   identical files without depending on the `tar` crate.
+//! - `random_control`: 16 MiB of uncorrelated random bytes. Confirms
+//!   the seq-match shortcut adds negligible overhead when it cannot fire.
+//!
+//! # What is measured
+//!
+//! For each corpus the bench reports:
+//! - **Match throughput** of [`generate_delta`] when target = basis
+//!   plus a handful of small mutations. This is the canonical seq-match
+//!   hot path: long match streaks separated by short literal runs.
+//! - **Token counts** (copy / literal) emitted as a one-shot stderr
+//!   summary, so the seq-match win is observable in the bench output
+//!   even without wired counters.
+
+#![cfg(feature = "bench-internal")]
+
+use std::hint::black_box;
+use std::io::Cursor;
+use std::num::NonZeroU8;
+use std::sync::OnceLock;
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+
+use matching::{DeltaScript, DeltaSignatureIndex, DeltaToken, generate_delta};
+use protocol::ProtocolVersion;
+use signature::{
+    SignatureAlgorithm, SignatureLayoutParams, calculate_signature_layout, generate_file_signature,
+};
+
+const BASIS_SIZE: usize = 16 << 20;
+
+/// Builds a log-file-style basis: repeated newline-terminated records
+/// with a monotonic counter so the bytes are not literally identical
+/// but the byte sequence is highly compressible.
+fn log_like_basis(size: usize) -> Vec<u8> {
+    let mut out = Vec::with_capacity(size + 128);
+    let mut counter: u64 = 0;
+    while out.len() < size {
+        let secs = counter % 60;
+        let millis = counter % 1000;
+        let request_id = counter.wrapping_mul(0x9E37_79B9_7F4A_7C15);
+        let line = format!(
+            "2026-05-16T00:00:{secs:02}.{millis:03}Z INFO \
+             request_id={request_id:016x} status=200 path=/api/items/{counter}\n",
+        );
+        out.extend_from_slice(line.as_bytes());
+        counter = counter.wrapping_add(1);
+    }
+    out.truncate(size);
+    out
+}
+
+/// Builds a tar-archive-style basis by tiling a 4 KiB record with a
+/// per-record header delta. Approximates an archive of many nearly
+/// identical small files without pulling in a tar crate.
+fn tar_like_basis(size: usize) -> Vec<u8> {
+    const RECORD: usize = 4096;
+    let mut record_template = vec![0u8; RECORD];
+    // Fill the body with a fixed pattern so consecutive records have
+    // identical interiors but distinct headers.
+    for (i, byte) in record_template.iter_mut().enumerate().skip(64) {
+        *byte = ((i.wrapping_mul(31337)) ^ 0xAB) as u8;
+    }
+    let mut out = Vec::with_capacity(size + RECORD);
+    let mut record_index: u64 = 0;
+    while out.len() < size {
+        let header = format!("file{record_index:010}.bin\0size=0000004096\0mtime=1700000000\0");
+        let mut record = record_template.clone();
+        let header_bytes = header.as_bytes();
+        let copy_len = header_bytes.len().min(RECORD);
+        record[..copy_len].copy_from_slice(&header_bytes[..copy_len]);
+        out.extend_from_slice(&record);
+        record_index = record_index.wrapping_add(1);
+    }
+    out.truncate(size);
+    out
+}
+
+/// Builds an uncorrelated random basis as a regression control.
+fn random_basis(seed: u64, size: usize) -> Vec<u8> {
+    let mut state = seed.wrapping_add(0x9E37_79B9_7F4A_7C15);
+    let mut out = vec![0u8; size];
+    for chunk in out.chunks_mut(8) {
+        state = state.wrapping_add(0x9E37_79B9_7F4A_7C15);
+        let mut z = state;
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+        z ^= z >> 31;
+        let bytes = z.to_le_bytes();
+        chunk.copy_from_slice(&bytes[..chunk.len()]);
+    }
+    out
+}
+
+/// Produces a target that is mostly identical to `basis` with a few
+/// small mutations at evenly spaced offsets. This is the canonical
+/// "append-only with patches" workload that exercises long seq-match
+/// streaks broken by short literal runs.
+fn mutate_basis(basis: &[u8], num_patches: usize, patch_size: usize) -> Vec<u8> {
+    let mut out = basis.to_vec();
+    if num_patches == 0 || basis.is_empty() {
+        return out;
+    }
+    let spacing = basis.len() / (num_patches + 1);
+    for k in 0..num_patches {
+        let start = (k + 1) * spacing;
+        let end = (start + patch_size).min(out.len());
+        if start >= end {
+            continue;
+        }
+        for byte in &mut out[start..end] {
+            *byte = byte.wrapping_add(0x5A);
+        }
+    }
+    out
+}
+
+fn build_index(data: &[u8]) -> DeltaSignatureIndex {
+    let params = SignatureLayoutParams::new(
+        data.len() as u64,
+        None,
+        ProtocolVersion::NEWEST,
+        NonZeroU8::new(16).expect("non-zero"),
+    );
+    let layout = calculate_signature_layout(params).expect("layout");
+    let signature =
+        generate_file_signature(data, layout, SignatureAlgorithm::Md4).expect("signature");
+    DeltaSignatureIndex::from_signature(&signature, SignatureAlgorithm::Md4).expect("index")
+}
+
+struct Fixture {
+    label: &'static str,
+    basis: Vec<u8>,
+    target: Vec<u8>,
+    index: DeltaSignatureIndex,
+}
+
+impl Fixture {
+    fn new(label: &'static str, basis: Vec<u8>) -> Self {
+        // 8 patches of 256 bytes each: roughly 0.012% perturbation,
+        // matching the "append-only with small edits" workload class.
+        let target = mutate_basis(&basis, 8, 256);
+        let index = build_index(&basis);
+        Self {
+            label,
+            basis,
+            target,
+            index,
+        }
+    }
+}
+
+fn fixtures() -> &'static [Fixture] {
+    static CACHE: OnceLock<Vec<Fixture>> = OnceLock::new();
+    CACHE.get_or_init(|| {
+        vec![
+            Fixture::new("log_like", log_like_basis(BASIS_SIZE)),
+            Fixture::new("tar_like", tar_like_basis(BASIS_SIZE)),
+            Fixture::new(
+                "random_control",
+                random_basis(0xC0FF_EE00_DEAD_BEEF, BASIS_SIZE),
+            ),
+        ]
+    })
+}
+
+fn count_tokens(script: &DeltaScript) -> (u64, u64, u64, u64) {
+    let mut copies = 0u64;
+    let mut copy_bytes = 0u64;
+    let mut literals = 0u64;
+    let mut literal_bytes = 0u64;
+    for token in script.tokens() {
+        match token {
+            DeltaToken::Copy { len, .. } => {
+                copies += 1;
+                copy_bytes += *len as u64;
+            }
+            DeltaToken::Literal(bytes) => {
+                literals += 1;
+                literal_bytes += bytes.len() as u64;
+            }
+        }
+    }
+    (copies, literals, literal_bytes, copy_bytes)
+}
+
+fn report_token_summary() {
+    eprintln!(
+        "seq_match summary (corpus,basis_bytes,target_bytes,copy_tokens,literal_tokens,\
+         literal_bytes,copy_bytes_estimated)"
+    );
+    for fx in fixtures() {
+        let script = generate_delta(Cursor::new(&fx.target), &fx.index).expect("generate");
+        let (copies, literals, literal_bytes, copy_bytes) = count_tokens(&script);
+        eprintln!(
+            "seq_match[{label}] basis={bsz} target={tsz} copy={cp} lit={lt} lit_bytes={lb} \
+             copy_bytes={cb}",
+            label = fx.label,
+            bsz = fx.basis.len(),
+            tsz = fx.target.len(),
+            cp = copies,
+            lt = literals,
+            lb = literal_bytes,
+            cb = copy_bytes,
+        );
+    }
+}
+
+fn bench_match_throughput(c: &mut Criterion) {
+    let mut group = c.benchmark_group("seq_match_throughput");
+    group.sample_size(10);
+
+    for fx in fixtures() {
+        group.throughput(Throughput::Bytes(fx.target.len() as u64));
+        group.bench_with_input(BenchmarkId::new("generate_delta", fx.label), fx, |b, fx| {
+            b.iter(|| {
+                let script =
+                    generate_delta(Cursor::new(black_box(&fx.target)), &fx.index).expect("script");
+                black_box(script)
+            });
+        });
+    }
+
+    group.finish();
+}
+
+fn bench_seq_match_entry(c: &mut Criterion) {
+    report_token_summary();
+    bench_match_throughput(c);
+}
+
+criterion_group!(
+    name = benches;
+    config = Criterion::default()
+        .sample_size(10)
+        .measurement_time(std::time::Duration::from_secs(5));
+    targets = bench_seq_match_entry
+);
+
+criterion_main!(benches);

--- a/crates/matching/src/generator.rs
+++ b/crates/matching/src/generator.rs
@@ -66,7 +66,7 @@ pub struct DeltaGenerator {
     /// Test-only knob disabling the matched-block pruning bitmap so the
     /// property tests can compare prune-on against prune-off output. The
     /// production path always prunes; see `docs/design/zsync-prune.md`.
-    #[cfg(test)]
+    #[cfg(any(test, feature = "bench-internal"))]
     prune_matched: bool,
 }
 
@@ -76,7 +76,7 @@ impl DeltaGenerator {
     pub const fn new() -> Self {
         Self {
             buffer_len: DEFAULT_BUFFER_LEN,
-            #[cfg(test)]
+            #[cfg(any(test, feature = "bench-internal"))]
             prune_matched: true,
         }
     }
@@ -96,6 +96,21 @@ impl DeltaGenerator {
     #[cfg(test)]
     #[must_use]
     pub(crate) fn with_prune_matched(mut self, enabled: bool) -> Self {
+        self.prune_matched = enabled;
+        self
+    }
+
+    /// Bench-only switch mirroring [`Self::with_prune_matched`], used by
+    /// the harness in `crates/matching/benches/prune_duplicate_heavy.rs`
+    /// to compare prune-on against prune-off match throughput on
+    /// duplicate-heavy basis data.
+    ///
+    /// Behind the internal `bench-internal` feature flag so the surface
+    /// never reaches release builds. See `docs/design/zsync-prune.md`
+    /// benchmark plan binding (#2071) for the methodology.
+    #[cfg(all(not(test), feature = "bench-internal"))]
+    #[must_use]
+    pub fn with_prune_matched(mut self, enabled: bool) -> Self {
         self.prune_matched = enabled;
         self
     }
@@ -153,9 +168,9 @@ impl DeltaGenerator {
         // basis indices; the bitmap leaves those siblings findable until each
         // is consumed independently. See docs/design/zsync-prune.md.
         let mut matched_blocks = MatchedBlocks::with_block_count(index.block_count());
-        #[cfg(test)]
+        #[cfg(any(test, feature = "bench-internal"))]
         let prune_matched = self.prune_matched;
-        #[cfg(not(test))]
+        #[cfg(not(any(test, feature = "bench-internal")))]
         let prune_matched = true;
 
         let mut buffer = vec![0u8; self.buffer_len.max(block_len)];

--- a/crates/matching/src/index/bithash.rs
+++ b/crates/matching/src/index/bithash.rs
@@ -118,9 +118,13 @@ impl BitHash {
 
     /// Returns the fraction of bits currently set, in `[0.0, 1.0]`.
     ///
-    /// Useful for the `bench-bithash` rejection-rate harness described in
+    /// Useful for the `bench-internal` rejection-rate harness described in
     /// `docs/design/zsync-bithash.md` section 7. Cheap on small bithashes,
-    /// linear in the bit count for large ones; not on any hot path.
+    /// linear in the bit count for large ones; not on any hot path. The
+    /// `#[allow(dead_code)]` keeps default release builds quiet: the
+    /// accessor is referenced only by the `bench-internal`-gated
+    /// `DeltaSignatureIndex::bithash_utilization` in `index/mod.rs` and
+    /// by the unit tests in `bithash_tests.rs`.
     #[allow(dead_code)]
     pub(super) fn utilization(&self) -> f64 {
         let set: u32 = self.bits.iter().map(|w| w.count_ones()).sum();

--- a/crates/matching/src/index/mod.rs
+++ b/crates/matching/src/index/mod.rs
@@ -375,3 +375,43 @@ impl DeltaSignatureIndex {
         self as *const Self as usize
     }
 }
+
+/// Bench-only accessors used by the harnesses in `crates/matching/benches/`.
+///
+/// Behind the internal `bench-internal` feature flag so the surface never
+/// reaches release builds. See `docs/design/zsync-bithash.md` section 7
+/// for the rejection-rate methodology these accessors support.
+#[cfg(feature = "bench-internal")]
+impl DeltaSignatureIndex {
+    /// Returns the fraction of bithash bits currently set, in `[0.0, 1.0]`.
+    ///
+    /// At saturation the bithash carries one set bit per indexed block
+    /// (1/8 density target), so a uniform-random rsum probe rejects with
+    /// probability roughly `1.0 - utilization`.
+    #[must_use]
+    pub fn bithash_utilization(&self) -> f64 {
+        self.bithash.utilization()
+    }
+
+    /// Returns `true` when the bithash prefilter would let `rsum` through
+    /// to the strong-checksum verify step.
+    ///
+    /// Mirrors the inner `bithash.contains(...)` probe in
+    /// [`Self::find_match_bytes_filtered`], without the tag-table or
+    /// strong-checksum work. Lets the bench harness count rejection rate
+    /// without instrumenting the production hot path.
+    #[must_use]
+    pub fn bithash_admits(&self, rsum: u32) -> bool {
+        self.bithash.contains(rsum)
+    }
+
+    /// Returns `true` when the `tag_table` would let `sum1` through to
+    /// the bithash probe.
+    ///
+    /// Mirrors the first-line tag-table gate so the bench can isolate
+    /// post-tag bithash rejection from the upstream-style fast path.
+    #[must_use]
+    pub fn tag_admits(&self, sum1: u16) -> bool {
+        self.tag_table[sum1 as usize]
+    }
+}


### PR DESCRIPTION
## Summary

Adds three Criterion harnesses under a new internal `bench-internal` feature flag that exposes the minimum surface needed to measure the zsync-inspired matching insertion points without affecting release builds.

- `crates/matching/benches/bithash_rejection.rs` (#2063): measures the bithash prefilter rejection rate at 1/16/128 MiB basis sizes against matching and random targets. Reports static utilization plus observed post-tag rejection rate via the new `bithash_utilization`, `bithash_admits`, and `tag_admits` accessors.
- `crates/matching/benches/seq_match_redundant.rs` (#2067): measures `generate_delta` throughput on log-file, tar-archive, and random-control corpora with a target that is basis plus a handful of small mutations, exercising the `want_i` adjacent-match hint path on highly redundant data.
- `crates/matching/benches/prune_duplicate_heavy.rs` (#2071): measures match throughput with the matched-block pruning bitmap on and off across a zero-heavy VM-disk-style basis, a repeated-blocks synthetic corpus, and a no-duplicates regression control.

## Surface impact

The new `bench-internal` feature exposes only:

- `DeltaSignatureIndex::bithash_utilization`, `bithash_admits`, `tag_admits` (read-only accessors used by the rejection-rate harness).
- `DeltaGenerator::with_prune_matched` (mirror of the existing test-only toggle, used by the prune harness).

Never enabled by default, never propagated to workspace `default-features`, the CLI `features` table, or the daemon. There is no way to turn it on from a release `oc-rsync` invocation. Matches the bench scaffolding contracts in `docs/design/zsync-bithash.md` section 7 and `docs/design/zsync-prune.md`.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p matching --all-targets --no-deps -- -D warnings`
- [x] `cargo clippy -p matching --all-targets --features bench-internal --no-deps -- -D warnings`
- [x] `cargo nextest run -p matching` (318 pass, 3 skipped)
- [x] `cargo nextest run -p matching --features bench-internal` (318 pass, 3 skipped)
- [x] `cargo check --workspace --all-features`
- [x] `cargo check -p matching --benches --features bench-internal`
- [ ] CI: full nextest matrix, Windows, macOS, Linux musl, fmt+clippy