### PR TITLE
fix(protocol): handle multiplex MSG_NO_SEND (code 109) on receiver (#2250)

### DIFF
--- a/crates/cli/src/frontend/server/flags.rs
+++ b/crates/cli/src/frontend/server/flags.rs
@@ -83,6 +83,15 @@ pub(super) struct ServerLongFlags {
     /// `make_output_option(info_words, info_levels, ...)`, so the server
     /// receives `--info=...` whenever the client has non-default info levels.
     pub(super) info: Vec<OsString>,
+    /// Explicit compression algorithm forwarded by the client.
+    ///
+    /// upstream: options.c:2800-2805 - `server_options()` emits long-form
+    /// `--new-compress` (zlibx), `--old-compress` (zlib), or
+    /// `--compress-choice=ALGO` (zstd/lz4) whenever the negotiated codec is
+    /// not the default CPRES_ZLIB carried by the compact `-z` flag. Capturing
+    /// the value here lets the server bypass vstring negotiation and use the
+    /// same algorithm as the client.
+    pub(super) compress_choice: Option<String>,
 }
 
 /// Parses all long-form flags from the server argument list.
@@ -122,6 +131,7 @@ pub(super) fn parse_server_long_flags(args: &[OsString]) -> ServerLongFlags {
         timeout: None,
         reference_directories: Vec::new(),
         info: Vec::new(),
+        compress_choice: None,
     };
 
     for arg in args {
@@ -151,6 +161,12 @@ pub(super) fn parse_server_long_flags(args: &[OsString]) -> ServerLongFlags {
             "--ignore-existing" => flags.ignore_existing = true,
             // upstream: options.c:2833 - --existing (--ignore-non-existing) sent as long-form arg
             "--existing" | "--ignore-non-existing" => flags.existing_only = true,
+            // upstream: options.c:2800-2805 - non-ZLIB compression algorithms
+            // come across the wire as bare long flags. Mapping them to the
+            // wire-name strings keeps parity with how the daemon path resolves
+            // CompressionAlgorithm in `transfer::run_server_with_handshake`.
+            "--new-compress" => flags.compress_choice = Some("zlibx".to_owned()),
+            "--old-compress" => flags.compress_choice = Some("zlib".to_owned()),
             _ => {
                 parse_value_bearing_flag(&s, &mut flags);
             }
@@ -188,6 +204,13 @@ fn parse_value_bearing_flag(s: &str, flags: &mut ServerLongFlags) {
         flags.timeout = Some(value.to_owned());
     } else if let Some(value) = s.strip_prefix("--io-uring-depth=") {
         flags.io_uring_depth = Some(value.to_owned());
+    // upstream: options.c:2800-2805 - `--compress-choice=ALGO` / `--zc=ALGO`
+    // names the negotiated codec when it is not the default CPRES_ZLIB.
+    } else if let Some(value) = s
+        .strip_prefix("--compress-choice=")
+        .or_else(|| s.strip_prefix("--zc="))
+    {
+        flags.compress_choice = Some(value.to_owned());
     // upstream: options.c:2928-2931 - server_options() forwards info levels.
     // Capture the raw value so run_server_mode can parse it tolerantly via
     // parse_info_flags_server (mirroring `am_server` in parse_output_words).
@@ -245,8 +268,12 @@ pub(super) fn is_known_server_long_flag(arg: &str) -> bool {
             | "--existing"
             | "--ignore-non-existing"
     ) || arg == "-s"
+        || arg == "--new-compress"
+        || arg == "--old-compress"
         || arg.starts_with("--checksum-seed=")
         || arg.starts_with("--checksum-choice=")
+        || arg.starts_with("--compress-choice=")
+        || arg.starts_with("--zc=")
         || arg.starts_with("--compare-dest=")
         || arg.starts_with("--copy-dest=")
         || arg.starts_with("--link-dest=")

--- a/crates/cli/src/frontend/server/run.rs
+++ b/crates/cli/src/frontend/server/run.rs
@@ -142,6 +142,27 @@ where
         }
     }
 
+    // upstream: options.c:2800-2805 - `--compress-choice`, `--new-compress`, and
+    // `--old-compress` carry the explicit codec when the negotiated algorithm is
+    // not the default CPRES_ZLIB. Without forwarding it into `ServerConfig`, the
+    // SSH server path skips compression entirely (handshake.client_args is None
+    // in SSH mode), so the receiver tries to decode upstream's compressed token
+    // stream as plain tokens and eventually misaligns onto a multiplex frame
+    // boundary.
+    if let Some(name) = &long_flags.compress_choice {
+        match protocol::CompressionAlgorithm::parse(name) {
+            Ok(algo) => config.connection.compress_choice = Some(algo),
+            Err(e) => {
+                write_server_error(
+                    stderr,
+                    program_brand,
+                    format!("invalid compression algorithm '{name}': {e}"),
+                );
+                return 1;
+            }
+        }
+    }
+
     match run_server_stdio(config, &mut stdin, stdout, None) {
         Ok(_stats) => 0,
         Err(e) => {

--- a/crates/cli/src/frontend/server/tests.rs
+++ b/crates/cli/src/frontend/server/tests.rs
@@ -801,3 +801,66 @@ fn parse_server_args_iconv_and_timeout_strip_to_dest() {
     assert_eq!(flags, "-vlogDtpre.iLsfxCIvu");
     assert_eq!(pos_args, vec![OsString::from("dest/")]);
 }
+
+#[test]
+fn is_known_server_long_flag_compression_choices() {
+    // upstream: options.c:2809-2814 - server_options() emits these whenever the
+    // negotiated codec is not the default CPRES_ZLIB carried by the compact `-z`
+    // flag. Without them in the known list, the dest path is silently corrupted
+    // (same failure mode as the iconv/timeout regression above).
+    assert!(is_known_server_long_flag("--new-compress"));
+    assert!(is_known_server_long_flag("--old-compress"));
+    assert!(is_known_server_long_flag("--compress-choice=zstd"));
+    assert!(is_known_server_long_flag("--compress-choice=zlib"));
+    assert!(is_known_server_long_flag("--zc=lz4"));
+}
+
+#[test]
+fn parse_server_long_flags_captures_compress_choice() {
+    let args = vec![
+        OsString::from("--server"),
+        OsString::from("--compress-choice=zstd"),
+    ];
+    let flags = parse_server_long_flags(&args);
+    assert_eq!(flags.compress_choice.as_deref(), Some("zstd"));
+}
+
+#[test]
+fn parse_server_long_flags_compress_choice_zc_alias() {
+    let args = vec![OsString::from("--server"), OsString::from("--zc=lz4")];
+    let flags = parse_server_long_flags(&args);
+    assert_eq!(flags.compress_choice.as_deref(), Some("lz4"));
+}
+
+#[test]
+fn parse_server_long_flags_new_compress_maps_to_zlibx() {
+    let args = vec![OsString::from("--server"), OsString::from("--new-compress")];
+    let flags = parse_server_long_flags(&args);
+    assert_eq!(flags.compress_choice.as_deref(), Some("zlibx"));
+}
+
+#[test]
+fn parse_server_long_flags_old_compress_maps_to_zlib() {
+    let args = vec![OsString::from("--server"), OsString::from("--old-compress")];
+    let flags = parse_server_long_flags(&args);
+    assert_eq!(flags.compress_choice.as_deref(), Some("zlib"));
+}
+
+#[test]
+fn parse_server_args_compress_choice_strips_from_dest() {
+    // Regression: with `-z` upstream picks the highest priority codec (ZSTD on
+    // protocol 32) and sends `--compress-choice=zstd`. Before the fix this fell
+    // through to positional args, corrupting the destination path identically to
+    // the iconv/timeout regression.
+    let args = vec![
+        OsString::from("--server"),
+        OsString::from("-vlogDtpre.iLsfxCIvuz"),
+        OsString::from("--compress-choice=zstd"),
+        OsString::from("--timeout=10"),
+        OsString::from("."),
+        OsString::from("dest/"),
+    ];
+    let (flags, pos_args) = parse_server_flag_string_and_args(&args);
+    assert_eq!(flags, "-vlogDtpre.iLsfxCIvuz");
+    assert_eq!(pos_args, vec![OsString::from("dest/")]);
+}

--- a/crates/transfer/src/lib.rs
+++ b/crates/transfer/src/lib.rs
@@ -370,7 +370,11 @@ pub fn run_server_with_handshake<W: Write>(
         let choice = config.connection.compress_choice.map(|algo| algo.as_str());
         (config.flags.compress || choice.is_some(), choice)
     } else if let Some(args) = handshake.client_args.as_deref() {
-        // Check compact flag strings for 'z' (CPRES_ZLIB only)
+        // Daemon-mode server: client args are the verbatim argv emitted by
+        // upstream's server_options() before they were parsed into ServerConfig.
+        // Scan them directly so the daemon path mirrors upstream's compat.c logic.
+
+        // Check compact flag strings for 'z' (CPRES_ZLIB only).
         let has_z = args
             .iter()
             .any(|arg| arg.starts_with('-') && !arg.starts_with("--") && arg.contains('z'));
@@ -393,7 +397,16 @@ pub fn run_server_with_handshake<W: Write>(
 
         (has_z || choice.is_some(), choice)
     } else {
-        (false, None)
+        // SSH server mode: handshake.client_args is None because the CLI
+        // frontend has already parsed the argv into ServerConfig. Recover the
+        // compression intent from the parsed flag string (`config.flags.compress`
+        // for `-z`) and the explicit `--compress-choice` / `--new-compress` /
+        // `--old-compress` long options preserved on `config.connection`.
+        // upstream: options.c:2696-2805 - server_options() emits `-z` in the
+        // compact arg string for CPRES_ZLIB, and the long-form variants for
+        // other algorithms. Both flow through to ServerConfig here.
+        let choice = config.connection.compress_choice.map(|algo| algo.as_str());
+        (config.flags.compress || choice.is_some(), choice)
     };
 
     // upstream: compat.c:543 - compression vstrings are only exchanged when

--- a/tools/ci/run_interop.sh
+++ b/tools/ci/run_interop.sh
@@ -3582,13 +3582,25 @@ WRAPPER
 
   _cz_verify "oc->upstream(-z,ssh)" "$cz_src" "$cz_dest_up" || return 1
 
-  # Direction (b) (upstream sender -> oc-rsync receiver with -z over SSH) is
-  # deferred: oc-rsync server currently rejects upstream's multiplex code 109
-  # in this configuration. The push direction above covers the round-trip
-  # compression encoding/decoding path; the reverse direction is tracked
-  # separately and will be re-enabled once the server-side multiplex handler
-  # accepts the upstream code path.
-  echo "    pull direction (upstream -> oc-rsync -z over SSH) deferred"
+  # --- Direction (b): upstream sender -> oc-rsync receiver, with -z over SSH ---
+  # Upstream drives the transfer and spawns oc-rsync as the receiver with the
+  # -z flag forwarded. The receiver must accept the multiplex frames emitted
+  # by upstream's sender path (including MSG_NO_SEND on file-open failure)
+  # while decoding the compressed token stream.
+  local rc2=0
+  timeout "$hard_timeout" "$upstream_binary" -avz \
+      --rsh="$fake_rsh" --rsync-path="$oc_bin" \
+      --timeout=10 \
+      "${cz_src}/" "fakehost:${cz_dest_oc}/" \
+      >"${log}.compress-ssh-up-oc.out" 2>"${log}.compress-ssh-up-oc.err" || rc2=$?
+
+  if [[ $rc2 -ne 0 ]]; then
+    echo "    upstream -> oc-rsync SSH/local -z pull failed (exit=$rc2)"
+    echo "    stderr: $(head -5 "${log}.compress-ssh-up-oc.err")"
+    return 1
+  fi
+
+  _cz_verify "upstream->oc(-z,ssh)" "$cz_src" "$cz_dest_oc" || return 1
 
   return 0
 }


### PR DESCRIPTION
## Summary

When oc-rsync runs as the receiver of an SSH push (`upstream-rsync -avz --rsh=... --rsync-path=oc-rsync`), the receiver rejects upstream's stream with `unknown multiplexed message code 109`. Investigation traced this to compression negotiation, not to MSG_NO_SEND dispatch directly: the SSH server path leaves `handshake.client_args = None`, so the `do_compression` detection in `transfer::run_server_with_handshake` falls into `(false, None)` and the receiver runs with a Plain token reader. Upstream's sender, meanwhile, is emitting deflated tokens, so the receiver misreads flag bytes as plain 4-byte literals. The misalignment eventually lands on a multiplex frame whose tag decodes through `MPLEX_BASE` to the displayed "code 109" surface error.

The fix has two parts:

- Parse `--new-compress`, `--old-compress`, `--compress-choice=ALGO`, and `--zc=ALGO` in the server-mode CLI front-end. Upstream's `server_options()` (`options.c:2809-2814`) emits these whenever the negotiated codec is not the default `CPRES_ZLIB`. Without recognising them they corrupt the destination path (same regression class as the iconv/timeout fix). Forward the parsed algorithm into `config.connection.compress_choice` in `run_server_mode`.
- Add a third arm to the `do_compression` selector in `run_server_with_handshake` for the SSH server path. Recover the compression intent from `config.flags.compress` (set when the compact flag string contains `z`) and from `config.connection.compress_choice`. The daemon-mode and client-mode arms are unchanged.

The MSG_NO_SEND (code 102 / wire tag 109) handler already exists in `MultiplexReader::dispatch_message`, so this fix targets the root cause that lets a NO_SEND-shaped byte sequence reach the envelope decoder at all.

Re-enables direction (b) of `test_compress_ssh_interop` (upstream sender to oc-rsync receiver with `-z`) and adds unit tests for the new server-flag parsing.

## Test plan
- [ ] `cargo fmt --all -- --check` (verified locally)
- [ ] `cargo clippy --workspace --all-features --no-deps -- -D warnings` (verified locally for cli + transfer)
- [ ] `cargo nextest run -p cli --all-features` (server-mode tests pass locally)
- [ ] CI: `Interop Validation` (`test_compress_ssh_interop`) succeeds in both directions
- [ ] CI: cross-platform matrices (Linux musl, macOS, Windows)