### PR TITLE
fix(transfer): silence dead_code on parallel stat bench fixture

### DIFF
--- a/crates/transfer/benches/parallel_stat_collector_contention.rs
+++ b/crates/transfer/benches/parallel_stat_collector_contention.rs
@@ -83,6 +83,7 @@ const WORKER_COUNTS: &[usize] = &[1, 4, 8, 16];
 /// payload representative of `(PathBuf-like, file_size)` without dragging
 /// in real allocations that would dominate the measurement.
 #[derive(Clone, Copy)]
+#[allow(dead_code)]
 struct StatRecord {
     index: u64,
     size: u64,


### PR DESCRIPTION
Fixes CI clippy regression on master after #4170 merge: `error: fields `index` and `size` are never read` in the bench's StatRecord fixture. Adds `#[allow(dead_code)]` since the fields are payload representation, not measured access.