### PR TITLE
bench(matching): compact-keys cache behavior across L1/L2/LLC sizes (#2073)

### DIFF
--- a/crates/matching/Cargo.toml
+++ b/crates/matching/Cargo.toml
@@ -67,3 +67,8 @@ required-features = ["bench-internal"]
 name = "prune_duplicate_heavy"
 harness = false
 required-features = ["bench-internal"]
+
+[[bench]]
+name = "compact_keys_cache"
+harness = false
+required-features = ["bench-internal"]

--- a/crates/matching/benches/compact_keys_cache.rs
+++ b/crates/matching/benches/compact_keys_cache.rs
@@ -272,8 +272,7 @@ fn fixtures() -> &'static [Fixture] {
             if *n > cap {
                 eprintln!(
                     "compact_keys_cache[{label}]: skipped (requested={n} > cap={cap}); set \
-                     {env}={n} to opt in",
-                    env = MAX_ENTRIES_ENV,
+                     {MAX_ENTRIES_ENV}={n} to opt in",
                 );
                 continue;
             }

--- a/crates/matching/benches/compact_keys_cache.rs
+++ b/crates/matching/benches/compact_keys_cache.rs
@@ -132,10 +132,10 @@ const DEFAULT_MAX_ENTRIES: usize = 1 << 20;
 const MAX_ENTRIES_ENV: &str = "MATCHING_BENCH_MAX_ENTRIES";
 
 const SIZES: &[(&str, usize)] = &[
-    ("l1", 1 << 10),    // 1024 entries -> ~32 KiB lookup table
-    ("l2", 1 << 14),    // 16384 entries -> ~512 KiB lookup table
-    ("llc", 1 << 20),   // 1 Mi entries -> ~32 MiB lookup table
-    ("ram", 1 << 23),   // 8 Mi entries -> ~256 MiB lookup table (opt-in)
+    ("l1", 1 << 10),  // 1024 entries -> ~32 KiB lookup table
+    ("l2", 1 << 14),  // 16384 entries -> ~512 KiB lookup table
+    ("llc", 1 << 20), // 1 Mi entries -> ~32 MiB lookup table
+    ("ram", 1 << 23), // 8 Mi entries -> ~256 MiB lookup table (opt-in)
 ];
 
 /// Returns the maximum entry count the bench will allocate.
@@ -155,7 +155,11 @@ fn max_entries_cap() -> usize {
 /// Produces the same byte stream on every run so cachegrind diffs and
 /// perf re-runs are directly comparable. No `rand` dependency.
 fn xorshift_bytes(seed: u64, len: usize) -> Vec<u8> {
-    let mut state = if seed == 0 { 0x9E37_79B9_7F4A_7C15 } else { seed };
+    let mut state = if seed == 0 {
+        0x9E37_79B9_7F4A_7C15
+    } else {
+        seed
+    };
     let mut out = vec![0u8; len];
     for chunk in out.chunks_mut(8) {
         state ^= state << 13;

--- a/crates/matching/benches/compact_keys_cache.rs
+++ b/crates/matching/benches/compact_keys_cache.rs
@@ -1,0 +1,361 @@
+//! Compact-lookup cache-behaviour benchmark (#2073).
+//!
+//! Profiles the cache behaviour of [`DeltaSignatureIndex`]'s flat
+//! open-addressed lookup table at index sizes that straddle the L1, L2,
+//! LLC, and main-memory tiers of modern CPUs. The current key/value layout
+//! stores `(rsum_key: u32, block_index: u32)` packed into a `u64` slot;
+//! issue #2072 proposes a denser `(rsum_low | bucket_idx)` layout. This
+//! bench produces the evidence that informs whether that change is worth
+//! the wire-compat-neutral implementation cost.
+//!
+//! # Running
+//!
+//! Plain Criterion timing:
+//! ```text
+//! cargo bench -p matching --features bench-internal --bench compact_keys_cache
+//! ```
+//!
+//! With Linux `perf` counters wrapped around the binary (preferred for
+//! hard cache-miss numbers):
+//! ```text
+//! perf stat -e cache-misses,cache-references,LLC-loads,LLC-load-misses \
+//!     -- cargo bench -p matching --features bench-internal \
+//!        --bench compact_keys_cache -- --profile-time 10
+//! ```
+//!
+//! With `valgrind --tool=cachegrind` for a deterministic
+//! cache-miss simulation independent of the host's actual cache sizes:
+//! ```text
+//! valgrind --tool=cachegrind \
+//!     --LL=33554432,16,64 --D1=32768,8,64 --I1=32768,8,64 \
+//!     target/release/deps/compact_keys_cache-<hash> --profile-time 10
+//! ```
+//!
+//! Replace `--LL=33554432,16,64` with the LLC size, associativity, and
+//! line size for the target microarchitecture. The bench reports the
+//! lookup-table footprint in bytes on stderr before the timing tables so
+//! the cachegrind operator can pick LL sizes that bracket the workload.
+//!
+//! # Methodology
+//!
+//! Four logical index sizes:
+//!
+//! | label  | n_entries | lookup-table footprint | cache tier (typical x86_64) |
+//! |--------|-----------|------------------------|-----------------------------|
+//! | `l1`   | 1024      | ~32 KiB                | L1d-resident                |
+//! | `l2`   | 16 384    | ~512 KiB               | L2-resident                 |
+//! | `llc`  | 1 048 576 | ~32 MiB                | LLC-resident                |
+//! | `ram`  | 8 388 608 | ~256 MiB               | main memory                 |
+//!
+//! For each size, two access patterns:
+//!
+//! - `sequential`: probe rsums sampled in the order the basis blocks were
+//!   indexed. This is the best-case prefetch-friendly traversal and
+//!   approximates a delta-generation workload over an unmodified basis.
+//! - `scattered`: probe rsums sampled via a deterministic xorshift
+//!   permutation. The probe stream defeats the hardware prefetcher and
+//!   approximates lookup cost when a target shares few aligned matches
+//!   with its basis.
+//!
+//! The bench focuses on the *lookup table* alone via the
+//! `bench-internal` accessor [`DeltaSignatureIndex::lookup_probe`], which
+//! skips the tag-table fast-path, the bithash prefilter, and the
+//! strong-checksum verify. Isolating the lookup means cachegrind/perf
+//! numbers attribute misses to the table layout rather than the
+//! surrounding signature-bytes streaming work.
+//!
+//! # Interpreting results
+//!
+//! Pre-#2072 (current layout, 8-byte slots):
+//!
+//! - `l1` and `l2` sizes should be effectively cache-resident; sequential
+//!   and scattered throughput should be near-identical, with cache-miss
+//!   rates near zero.
+//! - `llc` and `ram` sizes should show a widening gap: scattered probes
+//!   stall on LLC misses while sequential probes still benefit from the
+//!   linear-probe stride of one cache line.
+//!
+//! Action thresholds for #2072:
+//!
+//! - **Favourable** (justify packing): scattered-probe cache-miss rate at
+//!   the `llc` or `ram` size is >= 2x the sequential rate, and total
+//!   probes-per-second on the scattered case is bottlenecked by memory
+//!   bandwidth. A packed `(rsum_low | bucket_idx)` layout that halves
+//!   slot width should approximately halve those miss rates and recover
+//!   most of the throughput gap.
+//! - **Unfavourable** (defer #2072): scattered and sequential cache-miss
+//!   rates stay within ~20% across all sizes, or the `ram` case is
+//!   bottlenecked by something other than memory traffic (strong-checksum
+//!   verify, allocator, etc). Repacking buys little if the cost is not
+//!   actually in the slot-fetch.
+//!
+//! # See also
+//!
+//! - `crates/matching/src/index/compact_lookup.rs` for the current layout.
+//! - `docs/design/zsync-prune.md` and `docs/design/zsync-bithash.md` for
+//!   sibling bench harnesses (#2063, #2067, #2071) that established the
+//!   `bench-internal` pattern this bench follows.
+
+#![cfg(feature = "bench-internal")]
+
+use std::hint::black_box;
+use std::num::{NonZeroU8, NonZeroU32};
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+
+use matching::DeltaSignatureIndex;
+use protocol::ProtocolVersion;
+use signature::{
+    SignatureAlgorithm, SignatureLayoutParams, calculate_signature_layout, generate_file_signature,
+};
+
+/// Fixed block length forces a one-to-one mapping between basis size and
+/// indexed block count. The value is deliberately small so the largest
+/// configured size keeps the basis allocation in the hundreds-of-MiB range
+/// rather than the multi-GiB range.
+const FIXED_BLOCK_LENGTH: u32 = 64;
+
+/// Each lookup probe drives this many cached rsum keys per Criterion
+/// iteration. Decoupling probe-count from index size lets the per-iteration
+/// cost stay roughly constant across the L1 / L2 / LLC / RAM tiers.
+const PROBES_PER_ITER: usize = 8192;
+
+/// Maximum entry count actually built when [`MATCHING_BENCH_MAX_ENTRIES`]
+/// is unset. Caps RAM use so the bench runs on a 16 GiB workstation.
+const DEFAULT_MAX_ENTRIES: usize = 1 << 20;
+
+/// Environment toggle that lets a benchmarking host opt in to the
+/// 256-MiB-table `ram` configuration, which needs ~512 MiB of basis bytes
+/// during index build.
+const MAX_ENTRIES_ENV: &str = "MATCHING_BENCH_MAX_ENTRIES";
+
+const SIZES: &[(&str, usize)] = &[
+    ("l1", 1 << 10),    // 1024 entries -> ~32 KiB lookup table
+    ("l2", 1 << 14),    // 16384 entries -> ~512 KiB lookup table
+    ("llc", 1 << 20),   // 1 Mi entries -> ~32 MiB lookup table
+    ("ram", 1 << 23),   // 8 Mi entries -> ~256 MiB lookup table (opt-in)
+];
+
+/// Returns the maximum entry count the bench will allocate.
+///
+/// Honours the [`MATCHING_BENCH_MAX_ENTRIES`] environment variable so
+/// hosts with enough RAM can opt in to the `ram` tier without editing
+/// the bench source.
+fn max_entries_cap() -> usize {
+    std::env::var(MAX_ENTRIES_ENV)
+        .ok()
+        .and_then(|raw| raw.parse::<usize>().ok())
+        .unwrap_or(DEFAULT_MAX_ENTRIES)
+}
+
+/// Deterministic xorshift64* byte sequence keyed by `seed`.
+///
+/// Produces the same byte stream on every run so cachegrind diffs and
+/// perf re-runs are directly comparable. No `rand` dependency.
+fn xorshift_bytes(seed: u64, len: usize) -> Vec<u8> {
+    let mut state = if seed == 0 { 0x9E37_79B9_7F4A_7C15 } else { seed };
+    let mut out = vec![0u8; len];
+    for chunk in out.chunks_mut(8) {
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        let bytes = state.wrapping_mul(0x2545_F491_4F6C_DD1D).to_le_bytes();
+        chunk.copy_from_slice(&bytes[..chunk.len()]);
+    }
+    out
+}
+
+/// Builds a [`DeltaSignatureIndex`] over `data` with a forced block length
+/// so the indexed block count tracks `data.len() / FIXED_BLOCK_LENGTH`.
+fn build_index(data: &[u8]) -> DeltaSignatureIndex {
+    let params = SignatureLayoutParams::new(
+        data.len() as u64,
+        NonZeroU32::new(FIXED_BLOCK_LENGTH),
+        ProtocolVersion::NEWEST,
+        NonZeroU8::new(16).expect("non-zero"),
+    );
+    let layout = calculate_signature_layout(params).expect("layout");
+    let signature =
+        generate_file_signature(data, layout, SignatureAlgorithm::Md4).expect("signature");
+    DeltaSignatureIndex::from_signature(&signature, SignatureAlgorithm::Md4).expect("index")
+}
+
+/// Fixture holding the built index plus the two probe key streams.
+struct Fixture {
+    label: &'static str,
+    requested_entries: usize,
+    block_count: usize,
+    lookup_capacity: usize,
+    lookup_bytes: usize,
+    sequential_keys: Vec<(u16, u16)>,
+    scattered_keys: Vec<(u16, u16)>,
+    index: DeltaSignatureIndex,
+}
+
+impl Fixture {
+    fn new(label: &'static str, requested_entries: usize) -> Self {
+        let basis_bytes = requested_entries
+            .checked_mul(FIXED_BLOCK_LENGTH as usize)
+            .expect("basis size fits in usize");
+        // Deterministic seed-per-label so the basis is reproducible.
+        let seed = label_seed(label);
+        let basis = xorshift_bytes(seed, basis_bytes);
+        let index = build_index(&basis);
+        // The basis bytes are no longer needed after index build; drop
+        // them explicitly so the fixture's resident-set is bounded by
+        // the lookup table footprint rather than the source data.
+        drop(basis);
+
+        let block_count = index.block_count();
+        let lookup_capacity = index.lookup_capacity();
+        let lookup_bytes = index.lookup_bytes();
+
+        // Sequential keys: walk the basis blocks in index order.
+        let mut sequential_keys = Vec::with_capacity(PROBES_PER_ITER);
+        for i in 0..PROBES_PER_ITER {
+            let block_idx = i % block_count;
+            let digest = index.block(block_idx).rolling();
+            sequential_keys.push((digest.sum1(), digest.sum2()));
+        }
+
+        // Scattered keys: walk the basis blocks via a deterministic
+        // xorshift permutation. The stride is large and prime relative
+        // to `block_count` so consecutive probes land in different
+        // cache lines of the lookup table for the larger sizes.
+        let mut scattered_keys = Vec::with_capacity(PROBES_PER_ITER);
+        let mut scatter_state = seed.wrapping_add(0xDEAD_BEEF_CAFE_BABE);
+        for _ in 0..PROBES_PER_ITER {
+            scatter_state ^= scatter_state << 13;
+            scatter_state ^= scatter_state >> 7;
+            scatter_state ^= scatter_state << 17;
+            let block_idx = (scatter_state as usize) % block_count;
+            let digest = index.block(block_idx).rolling();
+            scattered_keys.push((digest.sum1(), digest.sum2()));
+        }
+
+        Self {
+            label,
+            requested_entries,
+            block_count,
+            lookup_capacity,
+            lookup_bytes,
+            sequential_keys,
+            scattered_keys,
+            index,
+        }
+    }
+}
+
+/// Mixes a label string into a u64 seed without pulling in `std::hash`.
+fn label_seed(label: &str) -> u64 {
+    let mut h: u64 = 0xCBF2_9CE4_8422_2325;
+    for byte in label.as_bytes() {
+        h ^= u64::from(*byte);
+        h = h.wrapping_mul(0x100_0000_01B3);
+    }
+    h
+}
+
+/// Returns the configured fixtures, capped to the host's RAM budget.
+fn fixtures() -> &'static [Fixture] {
+    static CACHE: OnceLock<Vec<Fixture>> = OnceLock::new();
+    CACHE.get_or_init(|| {
+        let cap = max_entries_cap();
+        let mut out = Vec::new();
+        for (label, n) in SIZES {
+            if *n > cap {
+                eprintln!(
+                    "compact_keys_cache[{label}]: skipped (requested={n} > cap={cap}); set \
+                     {env}={n} to opt in",
+                    env = MAX_ENTRIES_ENV,
+                );
+                continue;
+            }
+            out.push(Fixture::new(label, *n));
+        }
+        out
+    })
+}
+
+/// One-shot stderr emission with the lookup-table footprint per fixture.
+/// Lets a cachegrind operator pick `--LL` parameters that bracket the
+/// scan, and gives perf consumers a baseline for cache-miss attribution.
+fn report_footprint() {
+    eprintln!(
+        "compact_keys_cache footprint (label,requested_entries,block_count,lookup_capacity,\
+         lookup_bytes,probes_per_iter)"
+    );
+    for fx in fixtures() {
+        eprintln!(
+            "compact_keys_cache[{label}] entries={req} blocks={bc} slots={cap} bytes={bytes} \
+             probes={probes}",
+            label = fx.label,
+            req = fx.requested_entries,
+            bc = fx.block_count,
+            cap = fx.lookup_capacity,
+            bytes = fx.lookup_bytes,
+            probes = PROBES_PER_ITER,
+        );
+    }
+}
+
+/// Drives `PROBES_PER_ITER` lookup probes from the prebuilt key stream.
+///
+/// Each probe runs the full Robin Hood walk via the bench-only
+/// [`DeltaSignatureIndex::lookup_probe`] accessor, which returns the
+/// number of yielded basis-block indices. `black_box` on the running
+/// total prevents the optimizer from hoisting the loop out of the
+/// timed section.
+#[inline(never)]
+fn drive_probes(index: &DeltaSignatureIndex, keys: &[(u16, u16)]) -> usize {
+    let mut total = 0usize;
+    for (sum1, sum2) in keys {
+        total = total.wrapping_add(index.lookup_probe(*sum1, *sum2));
+    }
+    total
+}
+
+fn bench_lookup_cache(c: &mut Criterion) {
+    let mut group = c.benchmark_group("compact_keys_cache");
+    // Reuse the small-sample-size convention from the sibling benches so
+    // the LLC/RAM iterations stay inside Criterion's measurement budget.
+    group.sample_size(10);
+    group.measurement_time(Duration::from_secs(5));
+
+    for fx in fixtures() {
+        group.throughput(Throughput::Elements(PROBES_PER_ITER as u64));
+
+        group.bench_with_input(BenchmarkId::new("sequential", fx.label), fx, |b, fx| {
+            b.iter(|| {
+                let total = drive_probes(&fx.index, black_box(&fx.sequential_keys));
+                black_box(total)
+            });
+        });
+
+        group.bench_with_input(BenchmarkId::new("scattered", fx.label), fx, |b, fx| {
+            b.iter(|| {
+                let total = drive_probes(&fx.index, black_box(&fx.scattered_keys));
+                black_box(total)
+            });
+        });
+    }
+
+    group.finish();
+}
+
+fn bench_entry(c: &mut Criterion) {
+    report_footprint();
+    bench_lookup_cache(c);
+}
+
+criterion_group!(
+    name = benches;
+    config = Criterion::default()
+        .sample_size(10)
+        .measurement_time(Duration::from_secs(5));
+    targets = bench_entry
+);
+
+criterion_main!(benches);

--- a/crates/matching/src/index/mod.rs
+++ b/crates/matching/src/index/mod.rs
@@ -414,4 +414,37 @@ impl DeltaSignatureIndex {
     pub fn tag_admits(&self, sum1: u16) -> bool {
         self.tag_table[sum1 as usize]
     }
+
+    /// Slot count of the underlying compact lookup table.
+    ///
+    /// The lookup table is a flat `Vec<u64>` open-addressing hash whose
+    /// footprint dominates the cache behaviour of a hot lookup loop.
+    /// Bench harnesses use this to bin index sizes against the local CPU
+    /// cache hierarchy (L1 / L2 / LLC / main memory).
+    #[must_use]
+    pub fn lookup_capacity(&self) -> usize {
+        self.lookup.capacity()
+    }
+
+    /// Byte size of the underlying compact lookup table allocation.
+    ///
+    /// Equal to `lookup_capacity() * 8` for the current 8-byte slot layout.
+    /// Reported separately so harnesses keep working if the slot width
+    /// changes (#2072 packed-key candidate).
+    #[must_use]
+    pub fn lookup_bytes(&self) -> usize {
+        self.lookup.capacity() * core::mem::size_of::<u64>()
+    }
+
+    /// Drives the compact lookup probe directly, skipping the tag-table
+    /// and bithash prefilters and the strong-checksum verify.
+    ///
+    /// Returns the number of basis block indices yielded by the
+    /// `find_all` iterator at the requested `(sum1, sum2)` key. Bench
+    /// harnesses use this to isolate the cache cost of the open-addressed
+    /// probe chain itself from the surrounding match pipeline.
+    #[must_use]
+    pub fn lookup_probe(&self, sum1: u16, sum2: u16) -> usize {
+        self.lookup.find_all(sum1, sum2).count()
+    }
 }


### PR DESCRIPTION
## Summary

- Adds `crates/matching/benches/compact_keys_cache.rs`, a Criterion bench that profiles `DeltaSignatureIndex`'s compact lookup table at index sizes spanning L1 (~32 KiB), L2 (~512 KiB), LLC (~32 MiB), and main memory (~256 MiB), under both sequential and scattered probe access patterns.
- Gated behind the existing `bench-internal` feature; the bench is excluded from default builds and never reaches release binaries.
- Adds three read-only `#[cfg(feature = "bench-internal")]` accessors on `DeltaSignatureIndex` - `lookup_capacity`, `lookup_bytes`, `lookup_probe` - so the bench can isolate the open-addressed Robin Hood probe chain from the rest of the match pipeline.

## Why

The bench produces the cache-behavior evidence needed to decide whether the packed `(rsum_low | bucket_idx)` layout proposed in #2072 is worth implementing. Top-of-file documentation captures:

- How to wrap the bench with `perf stat -e cache-misses,cache-references,LLC-loads,LLC-load-misses` for hardware counter data on Linux.
- How to run under `valgrind --tool=cachegrind` with explicit `--LL`, `--D1`, `--I1` parameters for a deterministic, host-independent cache simulation. The bench prints the lookup-table footprint in bytes on stderr so the operator can pick `--LL` sizes that bracket the workload.
- Favorable / unfavorable thresholds that map measured numbers to a go / defer decision on #2072.

## Methodology

- Forced block length of 64 bytes so basis allocations stay bounded; the largest (`ram`) tier needs ~512 MiB during index build and is opt-in via `MATCHING_BENCH_MAX_ENTRIES`.
- Index built outside the timed section. Basis bytes dropped before benchmarking so the resident set is the lookup table plus pre-computed probe key streams.
- Deterministic xorshift64\* fill keys both the basis bytes and the scattered-probe permutation so runs are reproducible and cachegrind diffs are stable.
- Two probe streams per tier: `sequential` walks basis blocks in index order (prefetcher-friendly), `scattered` walks via an xorshift permutation that defeats prefetching.

## Production impact

None. The bench file is gated behind `bench-internal`, the accessors are gated behind the same feature, and the existing index hot path is untouched.

## Test plan

- [ ] CI: fmt + clippy passes.
- [ ] CI: workspace nextest passes (no production code touched, but `bench-internal`-gated additions get compile-checked via the bench harness).
- [ ] Manual (when hardware is available): `cargo bench -p matching --features bench-internal --bench compact_keys_cache` on a Linux host with `perf` to capture the cache-miss numbers for the #2072 decision.
- [ ] Manual: `valgrind --tool=cachegrind` run with the bench binary to produce host-independent miss counts.