### PR TITLE
feat(engine): expose ReorderBuffer stall-duration and queue-depth metrics (#1885)

### DIFF
--- a/crates/engine/src/concurrent_delta/mod.rs
+++ b/crates/engine/src/concurrent_delta/mod.rs
@@ -181,7 +181,7 @@ pub mod work_queue;
 
 pub use adaptive::{AdaptiveCapacityPolicy, ReorderStats};
 pub use consumer::DeltaConsumer;
-pub use reorder::ReorderBuffer;
+pub use reorder::{Metrics as ReorderMetrics, ReorderBuffer};
 pub use spill::{SpillCodec, SpillError, SpillStats, SpillableReorderBuffer};
 pub use strategy::{DeltaStrategy, DeltaTransferStrategy, WholeFileStrategy};
 pub use types::{DeltaResult, DeltaResultStatus, DeltaWork, DeltaWorkKind, FileNdx};

--- a/crates/engine/src/concurrent_delta/reorder/mod.rs
+++ b/crates/engine/src/concurrent_delta/reorder/mod.rs
@@ -26,8 +26,30 @@
 //! sees files in file-list order.
 
 use std::collections::VecDeque;
+use std::time::{Duration, Instant};
 
 use super::adaptive::{AdaptiveCapacityPolicy, AdaptiveState, ReorderStats};
+
+/// Snapshot of [`ReorderBuffer`] diagnostic counters.
+///
+/// Returned by [`ReorderBuffer::metrics`]. All fields are cumulative across
+/// the buffer's lifetime except [`current_depth`](Self::current_depth), which
+/// reflects the instantaneous occupancy at the moment of capture.
+///
+/// These counters help operators diagnose pipeline stalls without resorting
+/// to ad hoc instrumentation. Stall duration grows whenever an out-of-order
+/// item is buffered ahead of the next expected sequence; max depth records
+/// the high-water mark of buffered items observed since construction.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct Metrics {
+    /// Total wall-clock time the buffer spent waiting for the next expected
+    /// sequence while at least one out-of-order item was buffered.
+    pub stall_duration: Duration,
+    /// Instantaneous number of items currently buffered.
+    pub current_depth: usize,
+    /// High-water mark of buffered items observed since construction.
+    pub max_depth: usize,
+}
 
 /// Collects out-of-order items and yields them in sequence order.
 ///
@@ -93,6 +115,14 @@ pub struct ReorderBuffer<T> {
     bypass: bool,
     /// FIFO queue used in bypass mode. Empty when `bypass` is `false`.
     bypass_queue: VecDeque<T>,
+    /// High-water mark of `count` observed since construction.
+    max_depth: usize,
+    /// Accumulated time spent stalled waiting for `next_expected` while
+    /// out-of-order items were buffered.
+    stall_duration: Duration,
+    /// Marker recording when the current stall began. `Some` iff the buffer
+    /// is currently stalled (count > 0 and the `next_expected` slot is empty).
+    stall_started_at: Option<Instant>,
 }
 
 /// Error returned when the reorder buffer is at capacity.
@@ -130,6 +160,9 @@ impl<T> ReorderBuffer<T> {
             adaptive: None,
             bypass: false,
             bypass_queue: VecDeque::new(),
+            max_depth: 0,
+            stall_duration: Duration::ZERO,
+            stall_started_at: None,
         }
     }
 
@@ -170,6 +203,9 @@ impl<T> ReorderBuffer<T> {
             adaptive: None,
             bypass: true,
             bypass_queue: VecDeque::new(),
+            max_depth: 0,
+            stall_duration: Duration::ZERO,
+            stall_started_at: None,
         }
     }
 
@@ -197,6 +233,36 @@ impl<T> ReorderBuffer<T> {
     #[must_use]
     pub const fn is_passthrough(&self) -> bool {
         self.bypass
+    }
+
+    /// Records a depth observation against the high-water mark.
+    fn observe_depth(&mut self) {
+        if self.count > self.max_depth {
+            self.max_depth = self.count;
+        }
+    }
+
+    /// Updates the stall timer to reflect the current buffer state.
+    ///
+    /// The buffer is "stalled" whenever it holds at least one item but the
+    /// slot for `next_expected` is empty - i.e., callers are waiting on a
+    /// gap. `Instant::now()` is only invoked on the edges (stall start and
+    /// stall end), keeping steady-state inserts allocation-free.
+    fn refresh_stall_state(&mut self) {
+        if self.bypass {
+            return;
+        }
+        let stalled = self.count > 0 && self.slots[self.head].is_none();
+        match (stalled, self.stall_started_at) {
+            (true, None) => {
+                self.stall_started_at = Some(Instant::now());
+            }
+            (false, Some(started)) => {
+                self.stall_duration = self.stall_duration.saturating_add(started.elapsed());
+                self.stall_started_at = None;
+            }
+            _ => {}
+        }
     }
 
     /// Computes the ring buffer index for a given sequence number.
@@ -232,6 +298,7 @@ impl<T> ReorderBuffer<T> {
         if self.bypass {
             self.bypass_queue.push_back(item);
             self.count += 1;
+            self.observe_depth();
             return Ok(());
         }
         // Adaptive policy may grow the ring before insert to avoid the error.
@@ -249,6 +316,8 @@ impl<T> ReorderBuffer<T> {
                 self.high_water_offset = offset_plus_one;
             }
         }
+        self.observe_depth();
+        self.refresh_stall_state();
         self.maybe_adapt_capacity();
         Ok(())
     }
@@ -345,6 +414,7 @@ impl<T> ReorderBuffer<T> {
         if self.count == 0 {
             self.high_water_offset = 0;
         }
+        self.refresh_stall_state();
         Some(item)
     }
 
@@ -381,6 +451,29 @@ impl<T> ReorderBuffer<T> {
         self.capacity
     }
 
+    /// Returns a snapshot of diagnostic counters for the buffer.
+    ///
+    /// The returned [`Metrics`] captures the cumulative stall duration, the
+    /// instantaneous occupancy, and the high-water mark of buffered items.
+    /// Operators can poll this method to surface pipeline-stall diagnostics
+    /// without instrumenting the hot path themselves.
+    ///
+    /// If a stall is currently in progress, the time since the stall began
+    /// is included in the reported duration so consumers see a monotonically
+    /// non-decreasing total even between stall-end events.
+    #[must_use]
+    pub fn metrics(&self) -> Metrics {
+        let in_flight = self
+            .stall_started_at
+            .map(|t| t.elapsed())
+            .unwrap_or_default();
+        Metrics {
+            stall_duration: self.stall_duration.saturating_add(in_flight),
+            current_depth: self.count,
+            max_depth: self.max_depth,
+        }
+    }
+
     /// Returns adaptive capacity counters (grow/shrink event totals plus the
     /// current capacity). Counters are zero for fixed-capacity buffers.
     #[must_use]
@@ -410,6 +503,7 @@ impl<T> ReorderBuffer<T> {
         if self.bypass {
             self.bypass_queue.push_back(item);
             self.count += 1;
+            self.observe_depth();
             return;
         }
         if let Some(idx) = self.slot_index(sequence) {
@@ -437,6 +531,8 @@ impl<T> ReorderBuffer<T> {
                 self.high_water_offset = offset_plus_one;
             }
         }
+        self.observe_depth();
+        self.refresh_stall_state();
     }
 
     /// Grows the ring buffer to at least `min_capacity` slots.
@@ -493,6 +589,7 @@ impl<T> ReorderBuffer<T> {
         self.count -= 1;
         // Do not adjust high_water_offset here - it remains valid as an
         // upper bound. The adaptive policy will naturally recalibrate.
+        self.refresh_stall_state();
         Some(item)
     }
 

--- a/crates/engine/src/concurrent_delta/reorder/tests.rs
+++ b/crates/engine/src/concurrent_delta/reorder/tests.rs
@@ -1154,3 +1154,177 @@ mod passthrough_tests {
         assert!(drained[2].needs_retry());
     }
 }
+
+mod metrics_tests {
+    use super::super::*;
+    use std::thread::sleep;
+    use std::time::Duration;
+
+    #[test]
+    fn metrics_start_zeroed() {
+        let buf: ReorderBuffer<u32> = ReorderBuffer::new(8);
+        let m = buf.metrics();
+        assert_eq!(m.stall_duration, Duration::ZERO);
+        assert_eq!(m.current_depth, 0);
+        assert_eq!(m.max_depth, 0);
+    }
+
+    #[test]
+    fn in_order_inserts_record_no_stall() {
+        let mut buf: ReorderBuffer<u32> = ReorderBuffer::new(8);
+        buf.insert(0, 0).unwrap();
+        buf.insert(1, 1).unwrap();
+        buf.insert(2, 2).unwrap();
+        let m = buf.metrics();
+        assert_eq!(m.stall_duration, Duration::ZERO);
+        assert_eq!(m.current_depth, 3);
+        assert_eq!(m.max_depth, 3);
+    }
+
+    #[test]
+    fn max_depth_tracks_high_water() {
+        let mut buf: ReorderBuffer<u32> = ReorderBuffer::new(16);
+        for i in 0..5 {
+            buf.insert(i, i as u32).unwrap();
+        }
+        assert_eq!(buf.metrics().max_depth, 5);
+        // Drain three; depth falls but high-water stays.
+        for _ in 0..3 {
+            let _ = buf.next_in_order();
+        }
+        let m = buf.metrics();
+        assert_eq!(m.current_depth, 2);
+        assert_eq!(m.max_depth, 5);
+    }
+
+    #[test]
+    fn out_of_order_insert_accumulates_stall_until_gap_closes() {
+        let mut buf: ReorderBuffer<&'static str> = ReorderBuffer::new(8);
+        // Seq 1 arrives first; next_expected is 0 so the buffer stalls.
+        buf.insert(1, "second").unwrap();
+        // Pre-close snapshot: stall has begun and is non-zero after a wait.
+        sleep(Duration::from_millis(10));
+        let mid = buf.metrics();
+        assert!(
+            mid.stall_duration >= Duration::from_millis(10),
+            "expected stall >= 10ms while gap open, got {:?}",
+            mid.stall_duration,
+        );
+        assert_eq!(mid.current_depth, 1);
+        assert_eq!(mid.max_depth, 1);
+        // Close the gap; stall accumulates to the closing event and stops.
+        buf.insert(0, "first").unwrap();
+        let after_close = buf.metrics();
+        assert!(after_close.stall_duration >= mid.stall_duration);
+        assert_eq!(after_close.current_depth, 2);
+        assert_eq!(after_close.max_depth, 2);
+        // Draining all items must not extend stall further.
+        let _ = buf.next_in_order();
+        let _ = buf.next_in_order();
+        let drained = buf.metrics();
+        // Allow microsecond jitter from the close event being recorded slightly
+        // after the snapshot was taken.
+        assert!(
+            drained.stall_duration >= after_close.stall_duration,
+            "stall must be monotonic",
+        );
+        // Once the buffer is empty, further sleeps don't grow the counter.
+        let before_idle = drained.stall_duration;
+        sleep(Duration::from_millis(10));
+        let after_idle = buf.metrics().stall_duration;
+        assert_eq!(
+            after_idle, before_idle,
+            "idle buffer must not accumulate stall time",
+        );
+    }
+
+    #[test]
+    fn multiple_stalls_accumulate() {
+        let mut buf: ReorderBuffer<u32> = ReorderBuffer::new(8);
+        // First stall window.
+        buf.insert(1, 1).unwrap();
+        sleep(Duration::from_millis(5));
+        buf.insert(0, 0).unwrap();
+        let first = buf.metrics().stall_duration;
+        assert!(first >= Duration::from_millis(5));
+        // Drain everything; idle.
+        while buf.next_in_order().is_some() {}
+        // Second stall window with a fresh gap.
+        buf.insert(3, 3).unwrap();
+        sleep(Duration::from_millis(5));
+        buf.insert(2, 2).unwrap();
+        let second = buf.metrics().stall_duration;
+        assert!(
+            second >= first + Duration::from_millis(5),
+            "second stall must add to the first: first={first:?} second={second:?}",
+        );
+    }
+
+    #[test]
+    fn stall_continues_across_take_when_gap_remains() {
+        let mut buf: ReorderBuffer<u32> = ReorderBuffer::new(8);
+        // Two out-of-order items leave a gap at seq 0.
+        buf.insert(1, 1).unwrap();
+        buf.insert(2, 2).unwrap();
+        sleep(Duration::from_millis(5));
+        // Removing seq 2 via take() does not close the gap.
+        let taken = buf.take(2);
+        assert_eq!(taken, Some(2));
+        sleep(Duration::from_millis(5));
+        // Close the gap; total stall should cover both sleeps.
+        buf.insert(0, 0).unwrap();
+        let m = buf.metrics();
+        assert!(
+            m.stall_duration >= Duration::from_millis(10),
+            "expected >=10ms stall across take(), got {:?}",
+            m.stall_duration,
+        );
+    }
+
+    #[test]
+    fn metrics_snapshot_includes_in_flight_stall() {
+        let mut buf: ReorderBuffer<u32> = ReorderBuffer::new(8);
+        buf.insert(1, 1).unwrap();
+        sleep(Duration::from_millis(5));
+        let snap_a = buf.metrics();
+        sleep(Duration::from_millis(5));
+        let snap_b = buf.metrics();
+        assert!(
+            snap_b.stall_duration > snap_a.stall_duration,
+            "in-flight stall snapshots must increase: a={:?} b={:?}",
+            snap_a.stall_duration,
+            snap_b.stall_duration,
+        );
+    }
+
+    #[test]
+    fn force_insert_tracks_depth_and_stall() {
+        let mut buf: ReorderBuffer<u32> = ReorderBuffer::new(2);
+        // force_insert past capacity grows the ring and registers a stall.
+        buf.force_insert(3, 30);
+        sleep(Duration::from_millis(5));
+        let mid = buf.metrics();
+        assert_eq!(mid.current_depth, 1);
+        assert_eq!(mid.max_depth, 1);
+        assert!(mid.stall_duration >= Duration::from_millis(5));
+        // Closing the gap stops the stall counter from growing further.
+        for seq in 0..3 {
+            buf.force_insert(seq, seq as u32 * 10);
+        }
+        let closed = buf.metrics();
+        assert_eq!(closed.max_depth, 4);
+    }
+
+    #[test]
+    fn passthrough_tracks_depth_only() {
+        let mut buf: ReorderBuffer<u32> = ReorderBuffer::passthrough();
+        buf.insert(5, 50).unwrap();
+        buf.insert(3, 30).unwrap();
+        sleep(Duration::from_millis(5));
+        let m = buf.metrics();
+        // Bypass mode has no sequence gap, so stalls never engage.
+        assert_eq!(m.stall_duration, Duration::ZERO);
+        assert_eq!(m.current_depth, 2);
+        assert_eq!(m.max_depth, 2);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `ReorderBuffer::metrics()` returning a `Metrics { stall_duration, current_depth, max_depth }` snapshot so operators can diagnose pipeline stalls without ad hoc instrumentation. Feeds the spill-to-tempfile diagnostics tracked in #1884.
- `Instant::now` is sampled only on stall edges (gap opens, gap closes); steady-state in-order inserts pay no extra syscall.
- Max-depth and stall counters are reused across `insert`, `next_in_order`, `force_insert`, and `take`. Bypass / passthrough mode reports depth only since it does not reorder.
- Re-exports the new type as `ReorderMetrics` from `engine::concurrent_delta` alongside the existing `ReorderBuffer` re-export.

## Test plan
- [x] `command cargo fmt --all -- --check`
- [x] `command cargo clippy -p engine --all-features --all-targets --no-deps -- -D warnings`
- [x] `command cargo nextest run -p engine --all-features -E 'test(concurrent_delta::reorder)'` (68 tests, including the 9 new `metrics_tests` cases)

Closes #1885