### PR TITLE
docs(design): evaluate Chain-of-Responsibility for zero-copy path selection (#2133)

### DIFF
--- a/docs/design/zero-copy-chain-of-responsibility.md
+++ b/docs/design/zero-copy-chain-of-responsibility.md
@@ -1,95 +1,157 @@
-# Zero-copy file copy: Chain-of-Responsibility refactor (#2133)
+# Zero-copy file copy: Chain-of-Responsibility evaluation (#2133)
 
-This note proposes refactoring the platform-specific zero-copy dispatch in
-`crates/fast_io/` from linear `cfg`-gated branches into an explicit
-Chain-of-Responsibility composed of trait objects, with a memoised "winning
-handler" cache so successful probes are not repeated per file. The change is
-internal to `fast_io`; no public API surface changes, no wire-format changes,
-no upstream-compatibility changes.
+This note evaluates whether the platform-specific zero-copy dispatch in
+`crates/fast_io/src/platform_copy/` should be refactored from its current
+`#[cfg]`-gated cascade into an explicit Chain-of-Responsibility composed of
+trait objects.
 
-## 1. Inventory of zero-copy paths in `fast_io`
+The architecture patterns catalogue lists Chain-of-Responsibility as a
+registered pattern (used today by `FilterChain` for include/exclude rule
+evaluation). Whole-file copy dispatch is the only other place in the tree
+that walks a sequence of conditional handlers, so the question is reasonable.
+The conclusion is: do not refactor. Keep the cfg-cascade. Apply two targeted,
+small improvements (memoise the last winner, dedupe the cleanup helper)
+without introducing the trait.
 
-The crate currently implements seven distinct kernel zero-copy / CoW primitives
-plus a portable read/write fallback. The list below is exhaustive against
-`crates/fast_io/src/`:
+## 1. Current state: inventory of zero-copy paths
 
-| Primitive | File | Direction | Platform | Threshold | Method tag |
-|-----------|------|-----------|----------|-----------|------------|
-| `FICLONE` ioctl | `platform_copy/dispatch.rs::try_ficlone_impl` | file -> file (CoW) | Linux 4.5+, Btrfs/XFS/bcachefs | none (O(1)) | `CopyMethod::Ficlone` |
-| `copy_file_range(2)` | `copy_file_range.rs::try_copy_file_range` | file -> file | Linux 4.5+ same-fs / 5.3+ cross-fs | `>= 64 KiB` | `CopyMethod::CopyFileRange` |
-| `sendfile(2)` | `sendfile.rs::send_file_to_fd` | file -> socket | Linux | `>= 64 KiB` (`SENDFILE_THRESHOLD`) | n/a (returns bytes) |
-| `splice(2)` (via pipe) | `splice.rs::try_splice_to_file` / `recv_fd_to_file` | socket -> file | Linux 2.6.17+ | `>= 64 KiB` | n/a |
-| `clonefile(2)` | `platform_copy/dispatch.rs::clonefile_impl` | file -> file (CoW) | macOS, APFS only | none (O(1)) | `CopyMethod::Clonefile` |
-| `fcopyfile(3)` (`COPYFILE_DATA`) | `platform_copy/dispatch.rs::fcopyfile_impl` | file -> file | macOS, all FS | none | `CopyMethod::Copyfile` |
-| `CopyFileExW` | `platform_copy/dispatch.rs::try_copy_file_ex` | file -> file | Windows | `> 4 MiB` enables `COPY_FILE_NO_BUFFERING` | `CopyMethod::CopyFileEx` |
-| `FSCTL_DUPLICATE_EXTENTS_TO_FILE` | `platform_copy/dispatch.rs::try_refs_reflink_impl` | file -> file (CoW) | Windows + ReFS | none (O(1), cluster-aligned) | `CopyMethod::ReFsReflink` |
-| io_uring batched read/write | `copy_file_range.rs::try_io_uring_copy` | file -> file | Linux 5.6+ + `io_uring` feature | `>= 256 KiB` (`IO_URING_COPY_THRESHOLD`) | n/a |
-| `std::fs::copy` | `platform_copy/dispatch.rs` (every fall-through) | file -> file | all | always | `CopyMethod::StandardCopy` |
+The crate currently implements eight distinct kernel zero-copy or CoW
+primitives plus the portable `std::fs::copy` fallback. The table below is
+exhaustive against `crates/fast_io/src/`.
 
-Sendfile and splice live on a different axis (socket endpoint) and are out of
-scope for the file-to-file chain proposed below; they retain their own
-single-tier-with-fallback structure inside `sendfile.rs` and `splice.rs`.
+| Primitive | File:line | Direction | Platform | Threshold | Method tag |
+|-----------|-----------|-----------|----------|-----------|------------|
+| `FICLONE` ioctl | `platform_copy/dispatch.rs:693` (`try_ficlone_impl`) | file -> file (CoW) | Linux 4.5+, Btrfs/XFS/bcachefs | none (O(1)) | `CopyMethod::Ficlone` |
+| `copy_file_range(2)` | `copy_file_range.rs:142` (`try_copy_file_range`, Linux); see also `copy_file_contents` at `copy_file_range.rs:86` | file -> file | Linux 4.5+ same-fs / 5.3+ cross-fs | `>= 64 KiB` (`COPY_FILE_RANGE_THRESHOLD`, `copy_file_range.rs:46`) | `CopyMethod::CopyFileRange` |
+| io_uring batched read/write | `copy_file_range.rs:142` (`try_io_uring_copy`) | file -> file | Linux 5.6+ + `io_uring` feature | `>= 256 KiB` (`IO_URING_COPY_THRESHOLD`, `copy_file_range.rs:41`) | n/a (returns bytes) |
+| `clonefile(2)` | `platform_copy/dispatch.rs:138` (`clonefile_impl`) | file -> file (CoW) | macOS, APFS only | none (O(1)) | `CopyMethod::Clonefile` |
+| `fcopyfile(3)` (`COPYFILE_DATA`) | `platform_copy/dispatch.rs:173` (`fcopyfile_impl`) | file -> file | macOS, all FS | none | `CopyMethod::Copyfile` |
+| `CopyFileExW` | `platform_copy/dispatch.rs:217` (`try_copy_file_ex`) | file -> file | Windows | `> 4 MiB` enables `COPY_FILE_NO_BUFFERING` (`platform_copy/dispatch.rs:95`) | `CopyMethod::CopyFileEx` |
+| `FSCTL_DUPLICATE_EXTENTS_TO_FILE` | `platform_copy/dispatch.rs:283` (`try_refs_reflink_impl`); range variant at `platform_copy/dispatch.rs:499` | file -> file (CoW) | Windows + ReFS | none (O(1), cluster-aligned) | `CopyMethod::ReFsReflink` |
+| `std::fs::copy` | `platform_copy/dispatch.rs:45`, `:82`, `:115`, `:128` (every fall-through site) | file -> file | all | always | `CopyMethod::StandardCopy` |
 
-## 2. Current dispatch logic (linear `cfg` branches)
+Two further zero-copy primitives live on a different axis (file <-> socket)
+and are outside the file-to-file chain considered here:
 
-The file-to-file dispatch is currently three monolithic, platform-gated
-functions inside `crates/fast_io/src/platform_copy/dispatch.rs`:
+- `sendfile(2)` - `sendfile.rs::send_file_to_fd` (file -> socket).
+- `splice(2)` via pipe - `splice.rs::try_splice_to_file`, `recv_fd_to_file`
+  (socket -> file).
 
-- `#[cfg(target_os = "linux")] platform_copy_impl` - tries `FICLONE`, then
-  (above 64 KiB) `copy_file_range`, then `std::fs::copy`. Each branch hard-codes
-  cleanup of the destination on failure (`std::fs::remove_file(dst)`).
-- `#[cfg(target_os = "macos")] platform_copy_impl` - tries `clonefile`, then
+These have their own single-tier-with-fallback structure and do not share
+the file-to-file dispatch shape.
+
+The IOCP and io_uring file factories under `iocp/` and `io_uring/` are
+batched-async I/O pipelines, not single-call zero-copy primitives. They sit
+above the chain (the chain is invoked per-file inside whatever
+reader/writer pair the factory hands back) and are also outside the scope.
+
+### Current dispatch structure
+
+The file-to-file dispatch is three platform-gated functions inside
+`crates/fast_io/src/platform_copy/dispatch.rs`:
+
+- `platform_copy_impl` for Linux (`dispatch.rs:17`): tries `FICLONE`, then
+  (above 64 KiB) `copy_file_range`, then `std::fs::copy`.
+- `platform_copy_impl` for macOS (`dispatch.rs:55`): tries `clonefile`, then
   `fcopyfile`, then `std::fs::copy`.
-- `#[cfg(target_os = "windows")] platform_copy_impl` - probes ReFS via
+- `platform_copy_impl` for Windows (`dispatch.rs:92`): probes ReFS via
   `is_refs_filesystem`, conditionally tries `FSCTL_DUPLICATE_EXTENTS_TO_FILE`,
   then `CopyFileExW`, then `std::fs::copy`. Above 4 MiB it sets
   `COPY_FILE_NO_BUFFERING` on the `CopyFileExW` call.
-- `#[cfg(not(any(...)))] platform_copy_impl` - always `std::fs::copy`.
+- `platform_copy_impl` for other platforms (`dispatch.rs:122`): always
+  `std::fs::copy`.
 
-Inside `crates/fast_io/src/copy_file_range.rs::copy_file_contents` there is a
-second linear chain ordered by size threshold: io_uring (>= 256 KiB) ->
-`copy_file_range` (>= 64 KiB) -> `copy_file_contents_readwrite`. The two
-chains are independent: the platform copy chain calls the size-tier chain only
-on Linux when the size threshold is met.
+The dispatch is reached through the `PlatformCopy` trait
+(`platform_copy/types.rs:122`) - already a Strategy Pattern with
+`DefaultPlatformCopy`, `NoCowPlatformCopy`, and `NoZeroCopyPlatformCopy`
+implementations swappable at runtime. The `--no-cow` CLI flag selects
+`NoCowPlatformCopy`; `ZeroCopyPolicy::Disabled` selects
+`NoZeroCopyPlatformCopy`.
 
-### Problems with the current shape
+A second linear chain lives in `copy_file_range.rs::copy_file_contents`
+(`copy_file_range.rs:86-98`), ordered by size threshold:
 
-1. Adding a new primitive (e.g. `splice` for file-to-file via two `splice`
-   calls, or BSD `copy_file_range`) requires editing every platform branch and
-   threading another threshold constant through `copy_file_contents`.
-2. The threshold constants (`64 KiB`, `256 KiB`, `4 MiB`) are hard-coded inside
-   the dispatch fns, not on the primitive. Tuning requires editing both files.
-3. The "remove the partial destination on failure" cleanup is duplicated at
-   every fall-through site.
-4. There is no memoisation. If `clonefile` returns `EXDEV` (cross-device) on
-   the first file of a 100k-file recursive transfer, every subsequent file
-   pays the failed-syscall cost just to learn the same answer.
-5. The `NoCowPlatformCopy` variant
-   (`crates/fast_io/src/platform_copy/mod.rs:106`) and any future filtered
-   strategy (e.g. `FicloneOnly` for synthetic benchmarks) must duplicate the
-   whole impl rather than skipping a single handler.
-6. Tests currently reach into `dispatch.rs` private helpers (`try_ficlone_impl`,
-   `clonefile_impl`, ...) to exercise individual paths. A trait-based design
-   lets each handler be tested in isolation against a `MockHandler`.
+```
+io_uring (>= 256 KiB) -> copy_file_range (>= 64 KiB) -> readwrite fallback
+```
 
-## 3. Proposal: `CopyHandler` trait + chain
+The two chains are independent: the platform copy chain calls into the
+size-tier chain only on Linux when the destination handle and source handle
+have been opened by `platform_copy_impl` itself.
 
-Introduce one trait with a single fallible method:
+## 2. Decision points and fallback testing
+
+| Step | Trigger | Cleanup on fail | Next step |
+|------|---------|-----------------|-----------|
+| Linux: `FICLONE` (`dispatch.rs:22`) | always tried | `std::fs::remove_file(dst)` (`dispatch.rs:25`) | `copy_file_range` (if size >= 64 KiB) |
+| Linux: `copy_file_range` (`dispatch.rs:35`) | `size_hint >= 64 KiB` | `std::fs::remove_file(dst)` (`dispatch.rs:40`) | `std::fs::copy` |
+| Linux: `std::fs::copy` (`dispatch.rs:45`) | always | propagates error | terminal |
+| macOS: `clonefile` (`dispatch.rs:61`) | always tried | `std::fs::remove_file(dst)` (`dispatch.rs:66`) | `fcopyfile` |
+| macOS: `fcopyfile` (`dispatch.rs:72`) | always tried | `std::fs::remove_file(dst)` (`dispatch.rs:78`) | `std::fs::copy` |
+| macOS: `std::fs::copy` (`dispatch.rs:82`) | always | propagates error | terminal |
+| Windows: `is_refs_filesystem` probe (`dispatch.rs:97`) | always | n/a | gates ReFS reflink |
+| Windows: `FSCTL_DUPLICATE_EXTENTS_TO_FILE` (`dispatch.rs:101`) | on ReFS only | `std::fs::remove_file(dst)` (`dispatch.rs:104`) | `CopyFileExW` |
+| Windows: `CopyFileExW` (`dispatch.rs:111`) | always | `std::fs::remove_file(dst)` + std::fs::copy (`dispatch.rs:114-117`) | `std::fs::copy` |
+| Windows: `std::fs::copy` (`dispatch.rs:116`) | on `CopyFileExW` fail | propagates error | terminal |
+
+### Are fallback edges tested?
+
+`crates/fast_io/src/platform_copy/tests.rs` covers:
+
+- `platform_copy_falls_through_ficlone_failure` (`tests.rs:317`) - runs
+  `DefaultPlatformCopy::copy_file` on tmpfs and asserts the result is one of
+  `Ficlone | CopyFileRange | StandardCopy`. This exercises the FICLONE ->
+  copy_file_range -> std::fs::copy edges as observed externally.
+- `ficlone_returns_unsupported_on_non_linux` (`tests.rs:265`).
+- `ficlone_graceful_fallback_on_tmpfs` (`tests.rs:275`).
+- `ficlone_fails_on_missing_source` (`tests.rs:306`).
+- `clonefile_returns_unsupported_on_non_macos` (`tests.rs:348`).
+- `fcopyfile_returns_unsupported_on_non_macos` (`tests.rs:358`).
+- `clonefile_copies_data` (`tests.rs:368`).
+- `clonefile_fails_when_dst_exists` (`tests.rs:394`).
+- `clonefile_fails_on_missing_source` (`tests.rs:407`).
+- `default_platform_copy_*` for small / empty / large / binary / nonexistent /
+  overwrite cases (`tests.rs:72-172`).
+- `parity_default_vs_std_fs_copy` (`tests.rs:232`).
+
+Gaps in the existing coverage:
+
+- The Windows `is_refs_filesystem == false` path that skips
+  `FSCTL_DUPLICATE_EXTENTS_TO_FILE` entirely is exercised by the
+  platform-conditional cfg, but there is no test that injects a "ReFS says yes
+  but `DeviceIoControl` returns `ERROR_INVALID_DEVICE_REQUEST`" failure and
+  verifies the fall-through to `CopyFileExW`. The cfg-guard plus the lack of
+  a mockable seam makes this hard to fuzz on CI runners.
+- The Windows `CopyFileExW` failure -> `std::fs::copy` retry
+  (`dispatch.rs:114-117`) is only covered by the platform-portable path
+  tests; there is no targeted negative test for `CopyFileExW` returning 0.
+- No test asserts that `std::fs::remove_file(dst)` actually runs on each
+  fall-through edge. A handler returning `Err` while leaving a partial
+  destination behind would silently break the next handler that expects
+  "destination must not exist" (notably `clonefile` on macOS).
+
+These gaps are real and should be filled, but they exist independently of
+whether dispatch is a cfg-cascade or a CoR chain.
+
+## 3. Chain-of-Responsibility variant
+
+The trait-and-chain refactor would introduce one trait with two methods:
 
 ```rust
-// crates/fast_io/src/platform_copy/handler.rs
+// hypothetical: crates/fast_io/src/platform_copy/handler.rs
 
-pub(crate) trait CopyHandler: Send + Sync + std::fmt::Debug {
-    /// Returns `Ok(Some(bytes))` if this handler successfully copied the file,
-    /// `Ok(None)` if the handler is not applicable to this (src, dst, size)
-    /// triple (e.g. ReFS handler on NTFS, FICLONE under threshold), and
-    /// `Err(_)` if the handler attempted the copy and the kernel refused.
+pub(crate) trait ZeroCopyHandler: Send + Sync + std::fmt::Debug {
+    /// Returns:
+    /// - `Ok(Some(bytes))` if this handler successfully copied the file,
+    /// - `Ok(None)` if the handler is not applicable to this triple (e.g.
+    ///   ReFS handler on NTFS, FICLONE under a tunable threshold),
+    /// - `Err(_)` if the handler attempted the copy and the kernel refused.
     ///
-    /// On `Err`, the caller is responsible for cleaning up any partial
-    /// destination before invoking the next handler.
+    /// On `Err`, the chain runner cleans up any partial destination before
+    /// invoking the next handler.
     fn try_copy(&self, ctx: &CopyCtx<'_>) -> io::Result<Option<u64>>;
 
-    /// Stable identifier used for memoisation and for the `CopyMethod` tag.
+    /// Stable identifier used for the `CopyMethod` tag and for telemetry.
     fn method(&self) -> CopyMethod;
 }
 
@@ -100,224 +162,199 @@ pub(crate) struct CopyCtx<'a> {
 }
 ```
 
-The chain is a `&'static [&'static dyn CopyHandler]` selected per-platform at
-compile time, walked in order:
+A per-platform `&'static [&'static dyn ZeroCopyHandler]` is walked in order:
 
 ```rust
-pub(super) fn run_chain(ctx: &CopyCtx<'_>) -> io::Result<CopyResult> {
+fn run_chain(ctx: &CopyCtx<'_>) -> io::Result<CopyResult> {
     for handler in chain_for_platform() {
         match handler.try_copy(ctx) {
             Ok(Some(bytes)) => return Ok(CopyResult::new(bytes, handler.method())),
-            Ok(None) => continue,                        // not applicable
+            Ok(None) => continue,                          // not applicable
             Err(_) => {
-                let _ = std::fs::remove_file(ctx.dst);    // cleanup, then fall through
+                let _ = std::fs::remove_file(ctx.dst);     // cleanup
                 continue;
             }
         }
     }
-    unreachable!("chain must end with StdCopyHandler which never returns None or Err for valid paths")
+    unreachable!("chain ends in StdCopyHandler which never returns None or Err")
 }
 ```
 
-The semantic split between `Ok(None)` ("skip me, I do not apply") and `Err`
-("I tried and failed, clean up") is the key piece - it lets the chain encode
-threshold gating and platform gating (`ReFsHandler` returns `Ok(None)` when
-the destination is on NTFS) without conflating them with kernel errors. It
-also fixes a subtle issue in the current code: today, a `FICLONE` failure on
-ext4 produces a partial empty destination; the handler returns `Err`, the
-chain cleans up, and the caller proceeds. The current code already does this
-manually but inconsistently (`platform_copy_impl` does, `copy_file_contents`
-does not).
-
-### Per-platform chain composition
+Chain composition (still cfg-gated, just on slice construction instead of
+function body):
 
 ```rust
 #[cfg(target_os = "linux")]
-fn chain_for_platform() -> &'static [&'static dyn CopyHandler] {
-    &[&FicloneHandler, &IoUringHandler, &CopyFileRangeHandler, &StdCopyHandler]
+fn chain_for_platform() -> &'static [&'static dyn ZeroCopyHandler] {
+    &[&FicloneHandler, &CopyFileRangeHandler, &StdCopyHandler]
 }
 
 #[cfg(target_os = "macos")]
-fn chain_for_platform() -> &'static [&'static dyn CopyHandler] {
+fn chain_for_platform() -> &'static [&'static dyn ZeroCopyHandler] {
     &[&ClonefileHandler, &FcopyfileHandler, &StdCopyHandler]
 }
 
 #[cfg(target_os = "windows")]
-fn chain_for_platform() -> &'static [&'static dyn CopyHandler] {
+fn chain_for_platform() -> &'static [&'static dyn ZeroCopyHandler] {
     &[&RefsReflinkHandler, &CopyFileExHandler, &StdCopyHandler]
 }
-
-#[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
-fn chain_for_platform() -> &'static [&'static dyn CopyHandler] {
-    &[&StdCopyHandler]
-}
 ```
 
-`NoCowPlatformCopy` becomes a chain consisting of `&[&StdCopyHandler]`. A
-`--bench-only-ficlone` flag (hypothetical) becomes `&[&FicloneHandler,
-&StdCopyHandler]`. No code duplication.
+In this variant, threshold constants (`64 KiB`, `256 KiB`, `4 MiB`) move
+onto the handler that uses them; each handler is independently re-tunable
+without editing dispatch.
 
-### Concrete chain (the canonical reference)
+## 4. Pros of adopting Chain-of-Responsibility
 
-Per the task brief, the canonical chain is
+- **Testability**: each handler is a stand-alone unit that can be tested
+  against a tempdir without going through the full `PlatformCopy` trait.
+  Mock handlers can be inserted into the chain to validate ordering and
+  fall-through edges (covering the gaps listed in section 2).
+- **Per-call telemetry hook**: the chain runner is a single function, so
+  emitting "handler X attempted, returned Y" trace events is one
+  modification rather than one per cfg-gated body.
+- **Runtime ordering tweaks**: a hypothetical `--prefer=copy_file_range`
+  flag or `OC_RSYNC_DISABLE_HANDLER=ficlone` env var becomes a slice filter
+  rather than a new `cfg!` branch.
+- **Reduces duplicate cleanup**: the four `let _ = std::fs::remove_file(dst);`
+  call sites collapse into one inside `run_chain`.
+- **Encodes the "skip vs failed" semantic**: today the cfg-cascade conflates
+  "FICLONE returned `EXDEV` because the destination is on a different
+  mount" with "FICLONE returned `EOPNOTSUPP` because the FS does not support
+  reflinks" - both come back as `Err`. The `Ok(None)` vs `Err` split lets
+  handlers express "I do not apply, do not bother cleaning up" cleanly.
+- **`NoCowPlatformCopy` simplifies**: instead of duplicating the whole
+  `PlatformCopy` impl (`platform_copy/mod.rs:106-129`), it becomes a chain
+  of `&[&StdCopyHandler]`. Future filtered strategies (e.g. `FicloneOnly`
+  for synthetic benchmarks) get the same treatment.
 
-```text
-FicloneHandler -> CopyFileRangeHandler -> SendfileHandler -> StdCopyHandler
-```
+## 5. Cons of adopting Chain-of-Responsibility
 
-This is the Linux-shaped exemplar used in the trait doc-string and in the
-property test that exercises chain ordering. macOS and Windows diverge in
-which handlers are present and in what order, but the contract (try-CoW-first,
-try-zero-copy-second, fall-back-to-portable-last) is identical. `Sendfile`
-appears in the canonical chain only as the file-to-pipe primitive that the
-disk-commit path may eventually wire up; for whole-file copy it is currently
-not in the live chain because the destination is a regular file, not a socket.
-The doc string makes the distinction explicit.
+- **The dispatch is already short and clear**. The three platform branches
+  in `dispatch.rs:17-119` total about 100 LoC including comments. They read
+  top-to-bottom as "try fast path, on failure clean up and try next". A
+  trait + chain runner + eight handler structs is more code, not less.
+- **Per-platform handlers still need `#[cfg]` guards** because they call
+  into platform-specific FFI (`libc::clonefile`, `rustix::fs::ioctl_ficlone`,
+  `windows_sys::Win32::Storage::FileSystem::CopyFileExW`). The cfg surface
+  moves from `dispatch.rs` into eight handler modules; it does not vanish.
+  The non-Linux stub for `FicloneHandler` is exactly as ugly as the
+  non-Linux stub for `try_ficlone_impl` (`dispatch.rs:707-713`).
+- **Dynamic dispatch overhead is real but negligible for whole-file copy**
+  - one vtable call per file. Not a correctness concern, listed for
+  completeness.
+- **Abstraction tax for a closed set**. The handler population is fixed by
+  what kernels expose. New primitives appear roughly once per Windows /
+  Linux / macOS release cycle (years, not months). The "open for extension"
+  benefit of the pattern is overstated for this domain.
+- **`PlatformCopy` is already a Strategy**. The trait surface
+  (`types.rs:122`) is the swappable interface. Pushing another swappable
+  interface one level deeper risks the
+  "Strategy-of-Strategies-of-Strategies" anti-pattern where every step is a
+  trait and the call graph requires three indirections to read.
+- **The size-tier chain in `copy_file_range.rs:86` is genuinely different**.
+  It is invoked on already-open `File` handles, not paths; merging it into
+  the path-based handler chain would require either opening files twice
+  or smuggling open handles through `CopyCtx`. The two chains are easier to
+  reason about as two chains.
+- **Memoisation does not need a refactor**. The "remember the last winning
+  handler" optimisation - which is the only behavioural change that would
+  meaningfully improve hot paths - can be added to `DefaultPlatformCopy` as
+  an `AtomicUsize` field plus a `match` inside the existing
+  `platform_copy_impl`. No trait required.
 
-### Threshold gating moves onto the handler
+## 6. Recommendation: do not refactor
 
-```rust
-struct CopyFileRangeHandler;
+Keep the current cfg-cascade. The Chain-of-Responsibility pattern is a
+sound fit for chains of policy-style decisions whose population grows over
+time and whose handlers compose against a single value type. `FilterChain`
+in the filters crate is the textbook case - thousands of rules, all sharing
+the same `Path` input. Whole-file copy is the opposite: a fixed, small set
+of primitives, each tied to a specific platform with platform-specific FFI,
+each with its own error taxonomy. The pattern provides no leverage here
+that the existing Strategy-based `PlatformCopy` trait does not already
+provide at the right altitude.
 
-impl CopyHandler for CopyFileRangeHandler {
-    fn try_copy(&self, ctx: &CopyCtx<'_>) -> io::Result<Option<u64>> {
-        if ctx.size_hint < 64 * 1024 { return Ok(None); }
-        let src = File::open(ctx.src)?;
-        let dst = File::create(ctx.dst)?;
-        match crate::copy_file_range::raw_copy_file_range(&src, &dst, ctx.size_hint) {
-            Ok(bytes) => Ok(Some(bytes)),
-            Err(e) => Err(e),
-        }
-    }
+The two real shortcomings of the current code - duplicate cleanup at every
+fall-through site, no memoisation of the winning handler - are both fixable
+without the pattern.
 
-    fn method(&self) -> CopyMethod { CopyMethod::CopyFileRange }
-}
-```
+### Targeted improvements (instead of the refactor)
 
-The 64 KiB / 256 KiB / 4 MiB constants live next to the handler that uses
-them; each handler is independently re-tunable. The `copy_file_contents`
-function in `copy_file_range.rs` becomes a thin wrapper that constructs
-`CopyCtx` and walks the chain - the duplicate inner chain inside that file is
-removed.
+1. **Extract a `cleanup_partial_destination` helper** in
+   `platform_copy/dispatch.rs`. Replace the four
+   `let _ = std::fs::remove_file(dst);` calls (`dispatch.rs:25, 40, 66, 78,
+   104, 114`) with one helper call each. Cost: ~10 LoC saved, zero
+   abstraction added.
+2. **Add an `AtomicUsize` "last winner" cache to `DefaultPlatformCopy`**.
+   On entry, branch to the previously-winning method first; on success keep
+   the index; on failure fall through to the linear cascade and update the
+   index from the new winner. Cost: ~15 LoC inside the existing
+   `platform_copy_impl` functions, no trait surface change. Benefit: on
+   100k-file recursive transfers where FICLONE consistently fails (ext4
+   destination), files 2..N skip the failed-syscall probe.
+3. **Add the negative tests called out in section 2** - inject a
+   `CopyFileExW` failure (by passing an unwritable destination) and assert
+   the cascade reaches `std::fs::copy`; assert
+   `std::fs::remove_file(dst)` actually runs on each fall-through edge.
 
-## 4. Memoisation strategy for the successful handler
+These three changes capture every meaningful benefit attributed to the CoR
+refactor at a fraction of the diff size and without introducing dynamic
+dispatch in the I/O hot path.
 
-A single bulk transfer (recursive directory copy, daemon module pull, etc.)
-typically involves N files on the same source filesystem and the same
-destination filesystem. The platform-handler outcome for the first file is
-overwhelmingly the outcome for files 2..N. We exploit this with a three-tier
-cache.
+### When to revisit
 
-### Tier 1: per-call cache (the cheap one)
+Reopen the CoR question if any one of the following becomes true:
 
-`run_chain` does not memoise on its own; the wrapper `PlatformCopy` impl does:
+- The handler count on a single platform crosses 5 (today: 3 on Linux, 3 on
+  macOS, 3 on Windows after counting ReFS, `CopyFileExW`, and the stdlib
+  fallback).
+- A runtime-tunable preference order becomes a product requirement
+  (`--prefer=copy_file_range`, env-var disablement of named handlers, a
+  daemon config knob).
+- The size-tier chain in `copy_file_range.rs` and the path-based chain in
+  `dispatch.rs` start sharing primitives in both directions, making the
+  current two-chain split untenable.
 
-```rust
-pub struct DefaultPlatformCopy {
-    last_winner: AtomicUsize,    // index into chain_for_platform(), or usize::MAX
-}
-```
+Until one of those triggers fires, the cfg-cascade is the right design.
 
-Before iterating the chain, `copy_file` looks at `last_winner`. If it is a
-valid index, that handler is tried first; on `Ok(Some(_))` we keep the index;
-on `Ok(None)` or `Err` we fall back to the linear chain walk and update
-`last_winner` with the first handler that returns `Ok(Some(_))`.
+## 7. Cross-references
 
-Two writes are tolerated under contention - the cache is advisory, never
-required for correctness. `AtomicUsize` with `Relaxed` ordering is sufficient
-because the only invariant is "this index is in-bounds for the static chain
-slice", and the slice is `'static`.
+The following open tasks would each add a candidate handler if CoR were
+adopted. Under the do-not-refactor recommendation, they each instead extend
+the existing `dispatch.rs` per-platform `platform_copy_impl` function or
+add a new file-to-socket primitive in `sendfile.rs` / `splice.rs`:
 
-For the FICLONE-then-fail-on-ext4 cold path described in section 2, the second
-file pays one atomic load (free), one in-bounds branch, calls
-`StdCopyHandler::try_copy` directly, returns `Ok(Some(_))`, and stores the
-index. Files 3..N pay only the atomic load + branch.
+- **#1389 Windows ReFS reflink** - already landed as
+  `try_refs_reflink_impl` (`dispatch.rs:283`) and integrated into the
+  Windows cascade. See `docs/design/windows-refs-reflink.md`.
+- **#1414 Windows `CopyFileEx`** - already landed as `try_copy_file_ex`
+  (`dispatch.rs:217`) and integrated into the Windows cascade. See
+  `docs/design/windows-copyfileex-impl.md` and
+  `docs/design/windows-copyfileex-platform-copy.md`.
+- **#1749 Windows `CopyFileEx` parity** - ongoing parity hardening against
+  upstream behaviour; modifies the existing
+  `try_copy_file_ex` flag selection (`dispatch.rs:235-239`). No new handler.
+- **#1932 IOCP wiring** - lives one altitude above the file-to-file
+  dispatch. IOCP factories produce reader/writer pairs that the chain is
+  invoked against per file; IOCP is not itself a member of the chain.
+- **#2131 Windows `FSCTL_SET_ZERO_DATA` hole punching** - a write-side
+  sparse-region primitive (see `docs/design/windows-fsctl-set-zero-data.md`),
+  not a file copy primitive. It would attach to the receiver's sparse-write
+  path, not to `platform_copy_impl`.
+- **#2130 Windows `TransmitFile`** - a file-to-socket zero-copy primitive
+  (see `docs/design/windows-transmitfile.md`). It would extend
+  `sendfile.rs`'s send-side dispatch, not the file-to-file cascade.
 
-### Tier 2: filesystem-keyed sticky cache (optional, gated)
+## 8. References
 
-For workloads that interleave multiple destination filesystems (a daemon
-serving modules from `/mnt/btrfs/...` and `/mnt/ext4/...` to the same
-process), a single per-process winner is wrong for half the files. The
-upgrade is keyed by the destination's `(st_dev, st_ino_of_parent)`:
-
-```rust
-struct StickyCache {
-    map: parking_lot::Mutex<lru::LruCache<(u64, u64), usize>>,
-}
-```
-
-Capacity 32 covers any realistic mount tree; `LruCache` evicts cold entries.
-The `(dev, parent_ino)` key is cheap (`statx` on the destination's parent
-directory) and stable across renames within the same directory. This tier is
-gated behind a feature or runtime flag and is not in the initial change.
-
-### Tier 3: handler self-memoisation (already present, unchanged)
-
-`refs_detect::is_refs_filesystem` already caches its answer per-volume via
-`OnceLock` inside the `refs_detect` module. The kernel-version probe used by
-`io_uring` is similarly cached. These remain. The chain refactor does not
-change handler-internal caches.
-
-### What we deliberately do not memoise
-
-- The `size_hint` threshold check. It is one integer compare; caching it is
-  net-negative.
-- Handler applicability by platform. Already done at compile time via the
-  `chain_for_platform()` const slice.
-- The `CopyMethod` returned from `try_copy`. Always derived from the handler
-  type - no dynamic dispatch on success.
-
-### Cache invalidation
-
-The Tier 1 cache is invalidated implicitly: any handler that returns
-`Ok(None)` or `Err` while cached as the winner causes the wrapper to fall
-through to the linear chain walk and re-elect a winner. This handles the
-"destination filesystem changed mid-process" case (rare, but legal: a new
-mount on top of an existing path).
-
-## 5. Migration plan
-
-1. Introduce `crates/fast_io/src/platform_copy/handler.rs` with the trait and
-   the eight concrete handlers. Each handler is a unit struct that calls into
-   the existing private `*_impl` functions in `dispatch.rs`. No behaviour
-   change yet.
-2. Replace the body of `dispatch::platform_copy_impl` with `run_chain`. Delete
-   the per-platform monolithic functions.
-3. Add the Tier 1 `AtomicUsize` cache in `DefaultPlatformCopy`. Behaviour
-   change: the second file in a recursive copy skips the failed-FICLONE probe.
-4. Move threshold constants from `dispatch.rs` and `copy_file_range.rs` onto
-   the handlers. Delete the duplicate inner chain in
-   `copy_file_contents`; have it call `run_chain` directly.
-5. Add unit tests per handler against a fixture filesystem (tempfile dir +
-   small file + large file). Add a chain-ordering property test that asserts
-   each handler is invoked in the documented order until one returns
-   `Ok(Some(_))`.
-6. Re-run the existing `crates/fast_io/src/platform_copy/tests.rs` suite
-   unchanged - the public `PlatformCopy` API is unchanged, so the tests pass
-   without edits.
-
-The change is invisible to consumers of `fast_io` (the `engine` and
-`transfer` crates). No public API moves; no `Cargo.toml` changes; no feature
-flag changes.
-
-## 6. Out of scope
-
-- Sendfile and splice retain their existing single-tier-plus-fallback shape.
-  Their direction (file <-> socket) makes them a different state machine; the
-  Chain-of-Responsibility refactor is for the file -> file dispatch only. A
-  later note can apply the same trait to the file <-> socket pipeline if the
-  number of primitives there grows past two.
-- The `iocp` and `io_uring` submission-mode logic inside their respective
-  modules. Those are batched-async pipelines, not single-call zero-copy
-  primitives, and the trait shape does not match.
-- Wire-protocol behaviour. None of the handlers participate in the rsync wire
-  protocol; they are below the `engine` crate's delta executor.
-
-## 7. References
-
-- Existing dispatch: `crates/fast_io/src/platform_copy/dispatch.rs`
-- Existing types: `crates/fast_io/src/platform_copy/types.rs::PlatformCopy`
-- Inner size-tier chain: `crates/fast_io/src/copy_file_range.rs::copy_file_contents`
+- Current dispatch: `crates/fast_io/src/platform_copy/dispatch.rs`
+- Strategy trait: `crates/fast_io/src/platform_copy/types.rs` (line 122)
+- `PlatformCopy` impls: `crates/fast_io/src/platform_copy/mod.rs` (lines
+  71-129), `crates/fast_io/src/platform_copy/no_zero_copy.rs`
+- Size-tier inner chain: `crates/fast_io/src/copy_file_range.rs` (lines
+  86-124)
 - ReFS filesystem probe: `crates/fast_io/src/refs_detect.rs`
-- `NoCowPlatformCopy` example of an alternate chain:
-  `crates/fast_io/src/platform_copy/mod.rs`
+- Fall-through tests: `crates/fast_io/src/platform_copy/tests.rs`
+- Pattern catalogue entry: `docs/architecture/design-patterns-catalog.md`
+  (Strategy and Chain of Responsibility sections)


### PR DESCRIPTION
## Summary

- Inventories all eight zero-copy file-to-file primitives in `fast_io` (FICLONE, copy_file_range, io_uring batched copy, clonefile, fcopyfile, CopyFileExW, FSCTL_DUPLICATE_EXTENTS_TO_FILE, std::fs::copy) with file:line citations into `crates/fast_io/src/platform_copy/dispatch.rs`.
- Maps every decision point and fallback edge in the current cfg-cascade dispatch and audits which fall-through edges have test coverage.
- Sketches a `ZeroCopyHandler` trait + per-platform static chain variant and weighs pros (testability, telemetry hook, dedupe of cleanup) against cons (the dispatch is already 100 LoC, cfg-guards do not vanish, `PlatformCopy` is already a Strategy, the size-tier chain in `copy_file_range.rs` does not share its shape).
- Recommends keeping the cfg-cascade and capturing the only real wins (last-winner memoisation, cleanup helper extraction) with about 25 LoC of in-place edits rather than a trait refactor.
- Cross-references #1389 (ReFS reflink), #1414 / #1749 (CopyFileExW), #1932 (IOCP), #2131 (FSCTL_SET_ZERO_DATA), #2130 (TransmitFile) and explains why each fits under the cascade rather than as a new chain member.

## Test plan

- [x] Doc-only change, no code touched.
- [x] All `file:line` citations verified against `crates/fast_io/src/platform_copy/dispatch.rs`, `types.rs`, `mod.rs`, `tests.rs`, and `crates/fast_io/src/copy_file_range.rs`.
- [x] No em-dashes; hyphens throughout.