### PR TITLE
feat(engine): DeletePlan, DeletePlanMap, DirTraversalCursor for parallel deterministic delete (#2253, #2254)

### DIFF
--- a/crates/engine/src/delete/mod.rs
+++ b/crates/engine/src/delete/mod.rs
@@ -1,0 +1,35 @@
+//! Data structures for the parallel-deterministic-delete pipeline.
+//!
+//! This module hosts the foundational types described in
+//! `docs/design/parallel-deterministic-delete.md` (PR #4257). The data
+//! structures here are added in isolation; the receiver and emitter wiring
+//! that consumes them lands in later tasks in the DDP series.
+//!
+//! # Components
+//!
+//! - [`DeletePlan`] - a sorted, frozen list of destination entries to
+//!   delete in one directory. Plan order matches upstream
+//!   `delete_in_dir`'s reverse iteration of `compare_file_entries`
+//!   ascending order.
+//! - [`DeletePlanMap`] - a concurrent map keyed by destination-relative
+//!   directory path. Workers publish [`DeletePlan`] values into the map
+//!   from rayon segment-dispatch threads; the single emitter pulls them
+//!   out in upstream traversal order.
+//! - [`DirTraversalCursor`] - yields directories in upstream's depth-first,
+//!   `f_name_cmp`-ascending order. Backed by a tree built from observed
+//!   flist segments.
+//!
+//! # Upstream Reference
+//!
+//! - `target/interop/upstream-src/rsync-3.4.1/generator.c:272-387`
+//!   (`delete_in_dir`, `do_delete_pass`).
+//! - `target/interop/upstream-src/rsync-3.4.1/flist.c:3217-3343`
+//!   (`f_name_cmp`).
+
+mod plan;
+mod plan_map;
+mod traversal;
+
+pub use plan::{DeleteEntry, DeleteEntryKind, DeletePlan, HardlinkCohortId};
+pub use plan_map::DeletePlanMap;
+pub use traversal::DirTraversalCursor;

--- a/crates/engine/src/delete/plan.rs
+++ b/crates/engine/src/delete/plan.rs
@@ -1,0 +1,409 @@
+//! `DeletePlan` and the entry types it holds.
+//!
+//! A [`DeletePlan`] is the per-directory work item produced by phase 1 of
+//! the parallel-deterministic-delete pipeline (`compute_extras`) and
+//! consumed by phase 2 (the single emitter). Plans are publish-once: once
+//! a worker hands one to the [`super::DeletePlanMap`] it is frozen.
+//!
+//! # Ordering
+//!
+//! Inside a plan, entries are ordered to match upstream
+//! `delete_in_dir`'s loop (`generator.c:320`), which iterates the sorted
+//! destination directory list in reverse. Callers obtain that ordering by
+//! sorting with [`super::super::delete::DeletePlan::sort_by_name`], which
+//! uses upstream's `f_name_cmp` ascending and then reverses the slice in
+//! place.
+//!
+//! # Hardlink Cohort
+//!
+//! Each [`DeleteEntry`] optionally carries a [`HardlinkCohortId`]. The
+//! delete sweep itself does not consult the hardlink table to choose what
+//! to remove (see section 6 of
+//! `docs/design/parallel-deterministic-delete.md`), but the cohort id is
+//! tracked here so downstream diagnostics and the emitter can tag
+//! itemize lines, attribute deletions to a leader, and avoid double-stat
+//! work when the leader has already been seen. `None` means the entry is
+//! not part of any tracked hardlink group.
+
+use std::cmp::Ordering;
+use std::ffi::OsString;
+use std::path::PathBuf;
+
+use protocol::flist::{FileEntry, FileType, f_name_cmp};
+
+/// Identifier shared by all destination-side entries that belong to the
+/// same hardlink group (same `(dev, ino)` pair).
+///
+/// Wraps the leader's file-list index, matching upstream's
+/// `first_ndx` field on `struct hlink` (upstream: `hlink.c`). Using a
+/// distinct newtype keeps callers from accidentally mixing a cohort id
+/// with an unrelated file index.
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+pub struct HardlinkCohortId(pub u32);
+
+impl HardlinkCohortId {
+    /// Wraps a leader file-list index as a hardlink cohort id.
+    #[must_use]
+    pub const fn new(leader_ndx: u32) -> Self {
+        Self(leader_ndx)
+    }
+
+    /// Returns the wrapped leader index.
+    #[must_use]
+    pub const fn get(self) -> u32 {
+        self.0
+    }
+}
+
+/// Type category of a destination-side entry slated for deletion.
+///
+/// Mirrors the buckets tracked by [`protocol::stats::DeleteStats`]: each
+/// successful deletion increments exactly one counter. Devices collapse
+/// block and character devices into a single bucket the same way
+/// `DeleteStats::devices` does.
+///
+/// # Upstream Reference
+///
+/// - `stats.deleted_files` / `stats.deleted_dirs` /
+///   `stats.deleted_symlinks` / `stats.deleted_devices` /
+///   `stats.deleted_specials` in upstream `main.c` and `generator.c`.
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+pub enum DeleteEntryKind {
+    /// Regular file (`S_IFREG`).
+    File,
+    /// Directory (`S_IFDIR`).
+    Dir,
+    /// Symbolic link (`S_IFLNK`).
+    Symlink,
+    /// Block or character device (`S_IFBLK` / `S_IFCHR`).
+    Device,
+    /// FIFO or Unix domain socket (`S_IFIFO` / `S_IFSOCK`).
+    Special,
+}
+
+impl DeleteEntryKind {
+    /// Classifies a [`FileType`] into the matching delete-stats bucket.
+    ///
+    /// Unknown or unmapped modes fall through to [`Self::File`] so the
+    /// emitter still produces a deterministic itemize line.
+    #[must_use]
+    pub const fn from_file_type(ft: FileType) -> Self {
+        match ft {
+            FileType::Regular => Self::File,
+            FileType::Directory => Self::Dir,
+            FileType::Symlink => Self::Symlink,
+            FileType::BlockDevice | FileType::CharDevice => Self::Device,
+            FileType::Fifo | FileType::Socket => Self::Special,
+        }
+    }
+}
+
+/// A single destination-side entry slated for deletion.
+///
+/// The [`DeletePlan`] keeps the entries in upstream `delete_in_dir`
+/// emission order. Each entry carries the leaf [`OsString`] name (relative
+/// to the plan's directory), the kind for stats bookkeeping, and an
+/// optional hardlink-cohort tag.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct DeleteEntry {
+    /// Leaf filename inside the plan's directory.
+    pub name: OsString,
+    /// Category bucket used by `DeleteStats` and itemize formatting.
+    pub kind: DeleteEntryKind,
+    /// Hardlink cohort the entry belongs to, if any. `None` means the
+    /// destination entry is not part of a tracked hardlink group.
+    pub hardlink_cohort: Option<HardlinkCohortId>,
+}
+
+impl DeleteEntry {
+    /// Constructs a plain entry with no hardlink cohort attached.
+    #[must_use]
+    pub fn new(name: OsString, kind: DeleteEntryKind) -> Self {
+        Self {
+            name,
+            kind,
+            hardlink_cohort: None,
+        }
+    }
+
+    /// Constructs an entry tagged with a hardlink cohort id.
+    #[must_use]
+    pub fn with_cohort(name: OsString, kind: DeleteEntryKind, cohort: HardlinkCohortId) -> Self {
+        Self {
+            name,
+            kind,
+            hardlink_cohort: Some(cohort),
+        }
+    }
+}
+
+/// Sorted, frozen list of destination entries to delete in one directory.
+///
+/// Construct an unsorted plan with [`Self::new`], append entries via
+/// [`Self::push`], then call [`Self::sort_by_name`] to lock in
+/// upstream's per-directory ordering. The plan tracks whether
+/// [`Self::sort_by_name`] has been called so callers can assert the
+/// ordering invariant before publication.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct DeletePlan {
+    /// Destination-relative directory the plan applies to.
+    pub directory: PathBuf,
+    /// Entries to delete. The slice is in upstream emission order
+    /// (`f_name_cmp` ascending, reversed) once [`Self::sort_by_name`]
+    /// has been called.
+    pub extras: Vec<DeleteEntry>,
+    sorted: bool,
+}
+
+impl DeletePlan {
+    /// Creates an empty plan for the given destination-relative directory.
+    #[must_use]
+    pub fn new(directory: PathBuf) -> Self {
+        Self {
+            directory,
+            extras: Vec::new(),
+            sorted: false,
+        }
+    }
+
+    /// Creates a plan pre-populated with the given extras.
+    ///
+    /// The plan is marked unsorted; callers must invoke
+    /// [`Self::sort_by_name`] before publication.
+    #[must_use]
+    pub fn from_extras(directory: PathBuf, extras: Vec<DeleteEntry>) -> Self {
+        Self {
+            directory,
+            extras,
+            sorted: false,
+        }
+    }
+
+    /// Appends one entry to the plan and marks it unsorted.
+    pub fn push(&mut self, entry: DeleteEntry) {
+        self.extras.push(entry);
+        self.sorted = false;
+    }
+
+    /// Returns the number of entries in the plan.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.extras.len()
+    }
+
+    /// Returns `true` when the plan has no entries.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.extras.is_empty()
+    }
+
+    /// Reports whether [`Self::sort_by_name`] has been called since the
+    /// last mutation.
+    #[must_use]
+    pub fn is_sorted(&self) -> bool {
+        self.sorted
+    }
+
+    /// Sorts the entries into upstream `delete_in_dir` emission order.
+    ///
+    /// Order is `f_name_cmp` ascending applied to a temporary
+    /// [`FileEntry`] per entry (using the plan's `directory` as the
+    /// parent), then reversed in place. The sort is unstable to match
+    /// upstream's `qsort` choice (upstream:
+    /// `flist.c:3217-3343`, `generator.c:320`).
+    pub fn sort_by_name(&mut self) {
+        let dir = &self.directory;
+        self.extras.sort_unstable_by(|a, b| {
+            f_name_cmp(&entry_as_file_entry(dir, a), &entry_as_file_entry(dir, b))
+        });
+        // Upstream's `delete_in_dir` iterates the sorted dirlist in
+        // reverse (`for (i = dirlist->used; i--; )`), so the emission
+        // order is `f_name_cmp` ascending reversed.
+        self.extras.reverse();
+        self.sorted = true;
+    }
+
+    /// Convenience: returns the comparator that orders two [`DeleteEntry`]
+    /// values in upstream ascending order under the plan's directory.
+    /// Useful for callers that want to merge externally sorted candidate
+    /// lists without rebuilding [`FileEntry`] values.
+    #[must_use]
+    pub fn ascending_order(&self, a: &DeleteEntry, b: &DeleteEntry) -> Ordering {
+        let dir = &self.directory;
+        f_name_cmp(&entry_as_file_entry(dir, a), &entry_as_file_entry(dir, b))
+    }
+}
+
+/// Builds a transient [`FileEntry`] for one [`DeleteEntry`] so that
+/// [`f_name_cmp`] can score it against another entry in the same
+/// directory. The entry's mode is set from its `kind` so a directory
+/// vs file disambiguation could be layered on later by `sort.rs`'s
+/// protocol-29-aware comparator; the foundational `f_name_cmp` itself
+/// ignores the mode.
+fn entry_as_file_entry(dir: &std::path::Path, e: &DeleteEntry) -> FileEntry {
+    let full = dir.join(&e.name);
+    match e.kind {
+        DeleteEntryKind::Dir => FileEntry::new_directory(full, 0o755),
+        DeleteEntryKind::Symlink => FileEntry::new_symlink(full, std::path::PathBuf::from("")),
+        DeleteEntryKind::File | DeleteEntryKind::Device | DeleteEntryKind::Special => {
+            FileEntry::new_file(full, 0, 0o644)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn file_entry(name: &str) -> DeleteEntry {
+        DeleteEntry::new(OsString::from(name), DeleteEntryKind::File)
+    }
+
+    #[test]
+    fn cohort_id_roundtrips() {
+        let id = HardlinkCohortId::new(42);
+        assert_eq!(id.get(), 42);
+        assert_eq!(id, HardlinkCohortId(42));
+    }
+
+    #[test]
+    fn entry_kind_from_file_type_maps_all_variants() {
+        assert_eq!(
+            DeleteEntryKind::from_file_type(FileType::Regular),
+            DeleteEntryKind::File
+        );
+        assert_eq!(
+            DeleteEntryKind::from_file_type(FileType::Directory),
+            DeleteEntryKind::Dir
+        );
+        assert_eq!(
+            DeleteEntryKind::from_file_type(FileType::Symlink),
+            DeleteEntryKind::Symlink
+        );
+        assert_eq!(
+            DeleteEntryKind::from_file_type(FileType::BlockDevice),
+            DeleteEntryKind::Device
+        );
+        assert_eq!(
+            DeleteEntryKind::from_file_type(FileType::CharDevice),
+            DeleteEntryKind::Device
+        );
+        assert_eq!(
+            DeleteEntryKind::from_file_type(FileType::Fifo),
+            DeleteEntryKind::Special
+        );
+        assert_eq!(
+            DeleteEntryKind::from_file_type(FileType::Socket),
+            DeleteEntryKind::Special
+        );
+    }
+
+    #[test]
+    fn entry_constructors_set_cohort_correctly() {
+        let plain = DeleteEntry::new(OsString::from("x"), DeleteEntryKind::File);
+        assert!(plain.hardlink_cohort.is_none());
+        let tagged = DeleteEntry::with_cohort(
+            OsString::from("y"),
+            DeleteEntryKind::File,
+            HardlinkCohortId::new(7),
+        );
+        assert_eq!(tagged.hardlink_cohort, Some(HardlinkCohortId::new(7)));
+    }
+
+    #[test]
+    fn new_plan_is_empty_and_unsorted() {
+        let plan = DeletePlan::new(PathBuf::from("sub"));
+        assert!(plan.is_empty());
+        assert_eq!(plan.len(), 0);
+        assert!(!plan.is_sorted());
+    }
+
+    #[test]
+    fn push_marks_plan_unsorted() {
+        let mut plan = DeletePlan::new(PathBuf::from("sub"));
+        plan.push(file_entry("a"));
+        plan.sort_by_name();
+        assert!(plan.is_sorted());
+        plan.push(file_entry("b"));
+        assert!(!plan.is_sorted());
+    }
+
+    #[test]
+    fn sort_by_name_matches_upstream_reverse_order() {
+        // Upstream `delete_in_dir` walks the sorted dirlist in reverse,
+        // so for plain ASCII names the emission order is descending.
+        let mut plan = DeletePlan::new(PathBuf::from("sub"));
+        for n in ["c", "a", "d", "b"] {
+            plan.push(file_entry(n));
+        }
+        plan.sort_by_name();
+        let names: Vec<&str> = plan
+            .extras
+            .iter()
+            .map(|e| e.name.to_str().unwrap())
+            .collect();
+        // Ascending `f_name_cmp` would be [a, b, c, d]; reversed -> [d, c, b, a].
+        assert_eq!(names, vec!["d", "c", "b", "a"]);
+        assert!(plan.is_sorted());
+    }
+
+    #[test]
+    fn sort_preserves_cohort_tags() {
+        let cohort = HardlinkCohortId::new(5);
+        let mut plan = DeletePlan::new(PathBuf::from("sub"));
+        plan.push(DeleteEntry::with_cohort(
+            OsString::from("z"),
+            DeleteEntryKind::File,
+            cohort,
+        ));
+        plan.push(DeleteEntry::new(OsString::from("a"), DeleteEntryKind::File));
+        plan.sort_by_name();
+        // Reversed ascending -> z first, then a.
+        assert_eq!(plan.extras[0].name, OsString::from("z"));
+        assert_eq!(plan.extras[0].hardlink_cohort, Some(cohort));
+        assert_eq!(plan.extras[1].name, OsString::from("a"));
+        assert_eq!(plan.extras[1].hardlink_cohort, None);
+    }
+
+    #[test]
+    fn sort_orders_mixed_kinds_byte_wise() {
+        // f_name_cmp is byte-wise; the kind does not influence the sort
+        // key. Names alone decide.
+        let mut plan = DeletePlan::new(PathBuf::from("d"));
+        plan.push(DeleteEntry::new(OsString::from("b"), DeleteEntryKind::Dir));
+        plan.push(DeleteEntry::new(
+            OsString::from("a"),
+            DeleteEntryKind::Symlink,
+        ));
+        plan.push(DeleteEntry::new(
+            OsString::from("c"),
+            DeleteEntryKind::Special,
+        ));
+        plan.sort_by_name();
+        let names: Vec<&str> = plan
+            .extras
+            .iter()
+            .map(|e| e.name.to_str().unwrap())
+            .collect();
+        assert_eq!(names, vec!["c", "b", "a"]);
+    }
+
+    #[test]
+    fn ascending_order_matches_f_name_cmp() {
+        let plan = DeletePlan::new(PathBuf::from("d"));
+        let a = file_entry("aaa");
+        let b = file_entry("bbb");
+        assert_eq!(plan.ascending_order(&a, &b), Ordering::Less);
+        assert_eq!(plan.ascending_order(&b, &a), Ordering::Greater);
+        assert_eq!(plan.ascending_order(&a, &a), Ordering::Equal);
+    }
+
+    #[test]
+    fn from_extras_takes_unsorted_input() {
+        let entries = vec![file_entry("z"), file_entry("a")];
+        let plan = DeletePlan::from_extras(PathBuf::from("d"), entries);
+        assert_eq!(plan.len(), 2);
+        assert!(!plan.is_sorted());
+    }
+}

--- a/crates/engine/src/delete/plan_map.rs
+++ b/crates/engine/src/delete/plan_map.rs
@@ -1,0 +1,262 @@
+//! Concurrent map of per-directory [`DeletePlan`] values.
+//!
+//! Phase 1 of the parallel-deterministic-delete pipeline produces one
+//! [`DeletePlan`] per content directory from rayon worker threads; phase 2
+//! drains them on the single emitter thread in upstream traversal order.
+//! [`DeletePlanMap`] is the rendezvous between the two phases.
+//!
+//! # Concurrent Map Choice
+//!
+//! This first cut uses [`std::sync::Mutex`] wrapping
+//! [`std::collections::HashMap`]. The choice is deliberate:
+//!
+//! - It pulls in no new dependency. The workspace's `dashmap` crate is
+//!   already available, but adding it to the `engine` crate's dependency
+//!   set increases compile time and surface area for a hot module that
+//!   does not yet have a measured bottleneck.
+//! - Insert and remove operations are O(1) on the hot path. The lock is
+//!   held only for the map operation itself; no I/O or sorting happens
+//!   under the lock.
+//! - Phase 1 publishes a plan exactly once per directory, and phase 2
+//!   drains it exactly once. The expected contention pattern is
+//!   short-lived, with at most as many concurrent writers as the rayon
+//!   worker pool and exactly one reader.
+//!
+//! The bench-driven selection between [`std::sync::Mutex`] +
+//! [`HashMap`](std::collections::HashMap), [`dashmap::DashMap`], and a
+//! sharded [`HashMap`](std::collections::HashMap) is tracked as task
+//! DDP-B4. Swap the inner type without changing the public surface of
+//! this module.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use super::plan::DeletePlan;
+
+/// Concurrent map from destination-relative directory path to its
+/// publish-once [`DeletePlan`].
+///
+/// All methods are thread-safe. The map is intended to be wrapped in
+/// [`std::sync::Arc`] and shared between the rayon workers that compute
+/// extras and the single emitter that consumes them.
+#[derive(Debug, Default)]
+pub struct DeletePlanMap {
+    // NOTE(DDP-B4): single global Mutex is the simplest correct backing
+    // store. Bench against `dashmap::DashMap` and a sharded variant
+    // before promoting either into the engine crate.
+    inner: Mutex<HashMap<PathBuf, DeletePlan>>,
+}
+
+impl DeletePlanMap {
+    /// Creates an empty map.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            inner: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Creates an empty map with the given pre-allocated capacity.
+    #[must_use]
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            inner: Mutex::new(HashMap::with_capacity(capacity)),
+        }
+    }
+
+    /// Inserts a plan, indexed by `plan.directory`.
+    ///
+    /// Returns the previously published plan for the same directory, if
+    /// any. A non-`None` return indicates the publish-once invariant has
+    /// been violated and the caller should treat it as a bug.
+    pub fn insert(&self, plan: DeletePlan) -> Option<DeletePlan> {
+        let key = plan.directory.clone();
+        self.inner
+            .lock()
+            .expect("DeletePlanMap mutex poisoned")
+            .insert(key, plan)
+    }
+
+    /// Removes and returns the plan for `dir`, if any.
+    ///
+    /// The emitter calls this exactly once per directory after the
+    /// [`super::DirTraversalCursor`] yields the directory and the plan
+    /// has been published. Returns `None` if the slot is empty.
+    pub fn take(&self, dir: &Path) -> Option<DeletePlan> {
+        self.inner
+            .lock()
+            .expect("DeletePlanMap mutex poisoned")
+            .remove(dir)
+    }
+
+    /// Reports whether the map has no published plans right now.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.inner
+            .lock()
+            .expect("DeletePlanMap mutex poisoned")
+            .is_empty()
+    }
+
+    /// Returns the number of plans currently published in the map.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.inner
+            .lock()
+            .expect("DeletePlanMap mutex poisoned")
+            .len()
+    }
+
+    /// Returns `true` when a plan for `dir` is currently published.
+    ///
+    /// Useful for tests and for the emitter to distinguish "not yet
+    /// produced" from "already consumed". For draining, prefer
+    /// [`Self::take`].
+    #[must_use]
+    pub fn contains(&self, dir: &Path) -> bool {
+        self.inner
+            .lock()
+            .expect("DeletePlanMap mutex poisoned")
+            .contains_key(dir)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::thread;
+
+    use super::*;
+    use crate::delete::plan::{DeleteEntry, DeleteEntryKind};
+
+    fn make_plan(dir: &str) -> DeletePlan {
+        let mut plan = DeletePlan::new(PathBuf::from(dir));
+        plan.push(DeleteEntry::new(
+            std::ffi::OsString::from(format!("{dir}-entry")),
+            DeleteEntryKind::File,
+        ));
+        plan
+    }
+
+    #[test]
+    fn new_map_is_empty() {
+        let map = DeletePlanMap::new();
+        assert!(map.is_empty());
+        assert_eq!(map.len(), 0);
+    }
+
+    #[test]
+    fn insert_and_take_roundtrip() {
+        let map = DeletePlanMap::new();
+        let plan = make_plan("sub");
+        assert!(map.insert(plan.clone()).is_none());
+        assert!(!map.is_empty());
+        assert_eq!(map.len(), 1);
+        assert!(map.contains(Path::new("sub")));
+        let taken = map.take(Path::new("sub")).expect("plan present");
+        assert_eq!(taken.directory, plan.directory);
+        assert_eq!(taken.extras.len(), 1);
+        assert!(map.is_empty());
+        assert!(!map.contains(Path::new("sub")));
+    }
+
+    #[test]
+    fn take_missing_returns_none() {
+        let map = DeletePlanMap::new();
+        assert!(map.take(Path::new("missing")).is_none());
+    }
+
+    #[test]
+    fn duplicate_insert_returns_previous() {
+        let map = DeletePlanMap::new();
+        let first = make_plan("dup");
+        let mut second = make_plan("dup");
+        second.push(DeleteEntry::new(
+            std::ffi::OsString::from("extra"),
+            DeleteEntryKind::Dir,
+        ));
+        assert!(map.insert(first).is_none());
+        let displaced = map.insert(second.clone());
+        assert!(displaced.is_some(), "duplicate insert displaces previous");
+        let current = map.take(Path::new("dup")).expect("plan present");
+        assert_eq!(current.extras.len(), 2);
+    }
+
+    #[test]
+    fn with_capacity_preallocates() {
+        // Capacity is a hint; we can only assert correctness of the
+        // resulting map.
+        let map = DeletePlanMap::with_capacity(8);
+        assert!(map.is_empty());
+        for i in 0..8 {
+            map.insert(make_plan(&format!("d{i}")));
+        }
+        assert_eq!(map.len(), 8);
+    }
+
+    #[test]
+    fn concurrent_inserts_all_visible() {
+        // Spawn N writers, each publishing a distinct directory. After
+        // joining, every plan must be retrievable via take().
+        const THREADS: usize = 16;
+        const PER_THREAD: usize = 32;
+        let map = Arc::new(DeletePlanMap::new());
+        let mut handles = Vec::new();
+        for t in 0..THREADS {
+            let map = Arc::clone(&map);
+            handles.push(thread::spawn(move || {
+                for i in 0..PER_THREAD {
+                    let dir = format!("t{t}/d{i}");
+                    let plan = make_plan(&dir);
+                    assert!(
+                        map.insert(plan).is_none(),
+                        "no two writers share a directory"
+                    );
+                }
+            }));
+        }
+        for h in handles {
+            h.join().expect("writer joined");
+        }
+        assert_eq!(map.len(), THREADS * PER_THREAD);
+        for t in 0..THREADS {
+            for i in 0..PER_THREAD {
+                let dir = PathBuf::from(format!("t{t}/d{i}"));
+                let plan = map.take(&dir).expect("plan retrievable");
+                assert_eq!(plan.directory, dir);
+            }
+        }
+        assert!(map.is_empty());
+    }
+
+    #[test]
+    fn concurrent_take_does_not_lose_plans() {
+        // Pre-populate, then drain from multiple threads. Use an atomic
+        // counter to ensure every plan was taken exactly once.
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        const N: usize = 256;
+        let map = Arc::new(DeletePlanMap::new());
+        for i in 0..N {
+            map.insert(make_plan(&format!("d{i}")));
+        }
+        let taken = Arc::new(AtomicUsize::new(0));
+        let mut handles = Vec::new();
+        for _ in 0..8 {
+            let map = Arc::clone(&map);
+            let taken = Arc::clone(&taken);
+            handles.push(thread::spawn(move || {
+                for i in 0..N {
+                    if map.take(Path::new(&format!("d{i}"))).is_some() {
+                        taken.fetch_add(1, Ordering::Relaxed);
+                    }
+                }
+            }));
+        }
+        for h in handles {
+            h.join().expect("reader joined");
+        }
+        assert_eq!(taken.load(Ordering::Relaxed), N);
+        assert!(map.is_empty());
+    }
+}

--- a/crates/engine/src/delete/traversal.rs
+++ b/crates/engine/src/delete/traversal.rs
@@ -125,24 +125,35 @@ impl DirTraversalCursor {
             return Some(self.root.clone());
         }
 
-        while let Some(frame) = self.stack.last_mut() {
-            let kids = self.child_dirs.get(&frame.dir);
-            match kids {
-                Some(list) if frame.next_child_ix < list.len() => {
-                    let next = list[frame.next_child_ix].clone();
-                    frame.next_child_ix += 1;
+        loop {
+            // Inspect the top frame without holding a mutable borrow
+            // across the subsequent `self.stack.push` / `pop` calls.
+            let (dir, ix) = match self.stack.last() {
+                Some(frame) => (frame.dir.clone(), frame.next_child_ix),
+                None => return None,
+            };
+            let next_child = self
+                .child_dirs
+                .get(&dir)
+                .and_then(|list| list.get(ix).cloned());
+            match next_child {
+                Some(next) => {
+                    // Advance the parent's child-iterator, then descend.
+                    if let Some(top) = self.stack.last_mut() {
+                        top.next_child_ix = ix + 1;
+                    }
                     self.stack.push(Frame {
                         dir: next.clone(),
                         next_child_ix: 0,
                     });
                     return Some(next);
                 }
-                _ => {
+                None => {
+                    // No more children for this directory; backtrack.
                     self.stack.pop();
                 }
             }
         }
-        None
     }
 
     /// Returns `true` when the cursor has emitted everything it can.

--- a/crates/engine/src/delete/traversal.rs
+++ b/crates/engine/src/delete/traversal.rs
@@ -1,0 +1,366 @@
+//! [`DirTraversalCursor`] - yields directories in upstream traversal order.
+//!
+//! The cursor reproduces upstream rsync's depth-first walk over the
+//! sender's flist (`generator.c:2282-2354`,
+//! `do_delete_pass`/`delete_in_dir`). Each parent's child directories are
+//! emitted in `f_name_cmp` ascending order, the root is emitted first,
+//! and the cursor descends fully into one subtree before moving on to the
+//! next sibling.
+//!
+//! # Single-Threaded By Construction
+//!
+//! Only the emitter thread holds a [`DirTraversalCursor`]. The phase-1
+//! workers publish their observations via a separate channel; the
+//! emitter folds them in by calling [`DirTraversalCursor::observe_segment`]
+//! before consuming the corresponding directory.
+//!
+//! # Observation Order
+//!
+//! `observe_segment` calls may arrive in any order; the cursor sorts the
+//! children of each parent every time the set grows, so out-of-order
+//! observation does not affect the emission order. The only constraint is
+//! that a directory's children MUST be observed before that directory
+//! itself is consumed via [`DirTraversalCursor::next_ready`]. Observing
+//! children after the parent has been advanced past is treated as a
+//! programmer error; the late children are silently ignored.
+
+use std::collections::HashMap;
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+
+use protocol::flist::{FileEntry, FileType, f_name_cmp};
+
+/// One frame on the DFS stack: a directory currently being iterated and
+/// the index of its next-to-emit child.
+#[derive(Debug)]
+struct Frame {
+    dir: PathBuf,
+    next_child_ix: usize,
+}
+
+/// Yields directories in upstream's depth-first, `f_name_cmp`-ascending
+/// order so the emitter drains [`super::DeletePlanMap`] in the same order
+/// upstream walks the flist.
+///
+/// The cursor is single-threaded by construction. The emitter creates one
+/// for the transfer root and threads it through phase-2 dispatch.
+#[derive(Debug)]
+pub struct DirTraversalCursor {
+    /// Destination-relative root directory; emitted first.
+    root: PathBuf,
+    /// For each parent directory, the sorted list of child directories.
+    child_dirs: HashMap<PathBuf, Vec<PathBuf>>,
+    /// DFS stack of frames currently being iterated.
+    stack: Vec<Frame>,
+    /// `true` once the root has been emitted from `next_ready`.
+    root_emitted: bool,
+}
+
+impl DirTraversalCursor {
+    /// Creates a cursor rooted at `root`.
+    ///
+    /// The first call to [`Self::next_ready`] returns `Some(root)`.
+    #[must_use]
+    pub fn new(root: PathBuf) -> Self {
+        Self {
+            root,
+            child_dirs: HashMap::new(),
+            stack: Vec::new(),
+            root_emitted: false,
+        }
+    }
+
+    /// Records the directory children observed in one flist segment.
+    ///
+    /// `dir` is the destination-relative parent directory the segment
+    /// describes. `children` is the segment's full child set; the cursor
+    /// keeps only those entries whose [`FileType`] is
+    /// [`FileType::Directory`] and stores each one as a path of the form
+    /// `dir.join(child_basename)`.
+    ///
+    /// Calling `observe_segment` multiple times for the same `dir` is
+    /// permitted: children unions, no duplicates, and the stored list is
+    /// re-sorted in `f_name_cmp` order. Late observations after the
+    /// parent has been advanced past are silently dropped from the
+    /// emission sequence (the entry is still recorded in `child_dirs`,
+    /// but the iteration stack will not revisit the parent).
+    pub fn observe_segment(&mut self, dir: PathBuf, children: &[FileEntry]) {
+        let entry = self.child_dirs.entry(dir.clone()).or_default();
+        for child in children {
+            if !matches!(child.file_type(), FileType::Directory) {
+                continue;
+            }
+            let basename = child_basename(child);
+            if basename.is_empty() {
+                continue;
+            }
+            let full = if dir.as_os_str().is_empty() || dir == Path::new(".") {
+                PathBuf::from(&basename)
+            } else {
+                dir.join(&basename)
+            };
+            if !entry.iter().any(|p| p == &full) {
+                entry.push(full);
+            }
+        }
+        sort_paths_by_f_name_cmp(entry);
+    }
+
+    /// Returns the next directory whose parent has already been emitted.
+    ///
+    /// Order matches upstream's depth-first walk: parent before children,
+    /// siblings in `f_name_cmp` ascending order. Returns `None` when the
+    /// tree is exhausted (root emitted and stack empty).
+    ///
+    /// # Panics
+    ///
+    /// Does not panic. Internal invariants are upheld by construction.
+    pub fn next_ready(&mut self) -> Option<PathBuf> {
+        if !self.root_emitted {
+            self.root_emitted = true;
+            self.stack.push(Frame {
+                dir: self.root.clone(),
+                next_child_ix: 0,
+            });
+            return Some(self.root.clone());
+        }
+
+        while let Some(frame) = self.stack.last_mut() {
+            let kids = self.child_dirs.get(&frame.dir);
+            match kids {
+                Some(list) if frame.next_child_ix < list.len() => {
+                    let next = list[frame.next_child_ix].clone();
+                    frame.next_child_ix += 1;
+                    self.stack.push(Frame {
+                        dir: next.clone(),
+                        next_child_ix: 0,
+                    });
+                    return Some(next);
+                }
+                _ => {
+                    self.stack.pop();
+                }
+            }
+        }
+        None
+    }
+
+    /// Returns `true` when the cursor has emitted everything it can.
+    #[must_use]
+    pub fn is_exhausted(&self) -> bool {
+        self.root_emitted && self.stack.is_empty()
+    }
+}
+
+/// Sorts a list of paths in-place using `f_name_cmp` over a transient
+/// [`FileEntry`] per path. Treats each path as a directory entry so the
+/// comparator sees the same `dirname` / `basename` split it would for a
+/// real flist row.
+fn sort_paths_by_f_name_cmp(paths: &mut [PathBuf]) {
+    paths.sort_unstable_by(|a, b| {
+        let ea = FileEntry::new_directory(a.clone(), 0o755);
+        let eb = FileEntry::new_directory(b.clone(), 0o755);
+        f_name_cmp(&ea, &eb)
+    });
+}
+
+/// Returns the leaf component of a [`FileEntry`]'s path as an
+/// [`OsString`]. Empty when the path itself is empty.
+fn child_basename(entry: &FileEntry) -> OsString {
+    entry
+        .path()
+        .file_name()
+        .map(OsString::from)
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use protocol::flist::FileEntry;
+
+    fn dir_entry(name: &str) -> FileEntry {
+        FileEntry::new_directory(PathBuf::from(name), 0o755)
+    }
+
+    fn file_entry(name: &str) -> FileEntry {
+        FileEntry::new_file(PathBuf::from(name), 0, 0o644)
+    }
+
+    #[test]
+    fn empty_cursor_yields_only_root() {
+        let mut cursor = DirTraversalCursor::new(PathBuf::from("root"));
+        assert_eq!(cursor.next_ready(), Some(PathBuf::from("root")));
+        assert_eq!(cursor.next_ready(), None);
+        assert!(cursor.is_exhausted());
+    }
+
+    #[test]
+    fn single_level_emits_children_in_ascending_order() {
+        let mut cursor = DirTraversalCursor::new(PathBuf::from("root"));
+        cursor.observe_segment(
+            PathBuf::from("root"),
+            &[
+                dir_entry("root/c"),
+                dir_entry("root/a"),
+                dir_entry("root/b"),
+            ],
+        );
+        let seq: Vec<PathBuf> = std::iter::from_fn(|| cursor.next_ready()).collect();
+        assert_eq!(
+            seq,
+            vec![
+                PathBuf::from("root"),
+                PathBuf::from("root/a"),
+                PathBuf::from("root/b"),
+                PathBuf::from("root/c"),
+            ]
+        );
+    }
+
+    #[test]
+    fn observe_segments_out_of_order_yields_depth_first_f_name_cmp_order() {
+        // Tree:   root
+        //         |- a
+        //         |   |- x
+        //         |   `- y
+        //         `- b
+        let mut cursor = DirTraversalCursor::new(PathBuf::from("root"));
+        // Observe in deliberately scrambled order.
+        cursor.observe_segment(
+            PathBuf::from("root/a"),
+            &[dir_entry("root/a/y"), dir_entry("root/a/x")],
+        );
+        cursor.observe_segment(
+            PathBuf::from("root"),
+            &[dir_entry("root/b"), dir_entry("root/a")],
+        );
+        // Re-observing the same parent with the same children is a no-op.
+        cursor.observe_segment(PathBuf::from("root/a"), &[dir_entry("root/a/x")]);
+        let seq: Vec<PathBuf> = std::iter::from_fn(|| cursor.next_ready()).collect();
+        assert_eq!(
+            seq,
+            vec![
+                PathBuf::from("root"),
+                PathBuf::from("root/a"),
+                PathBuf::from("root/a/x"),
+                PathBuf::from("root/a/y"),
+                PathBuf::from("root/b"),
+            ]
+        );
+        assert!(cursor.is_exhausted());
+    }
+
+    #[test]
+    fn non_directory_children_are_ignored() {
+        let mut cursor = DirTraversalCursor::new(PathBuf::from("root"));
+        cursor.observe_segment(
+            PathBuf::from("root"),
+            &[
+                dir_entry("root/sub"),
+                file_entry("root/file.txt"),
+                FileEntry::new_symlink(PathBuf::from("root/link"), PathBuf::from("target")),
+            ],
+        );
+        let seq: Vec<PathBuf> = std::iter::from_fn(|| cursor.next_ready()).collect();
+        assert_eq!(seq, vec![PathBuf::from("root"), PathBuf::from("root/sub")]);
+    }
+
+    #[test]
+    fn duplicate_observations_do_not_double_emit() {
+        let mut cursor = DirTraversalCursor::new(PathBuf::from("root"));
+        cursor.observe_segment(PathBuf::from("root"), &[dir_entry("root/a")]);
+        cursor.observe_segment(PathBuf::from("root"), &[dir_entry("root/a")]);
+        cursor.observe_segment(PathBuf::from("root"), &[dir_entry("root/a")]);
+        let seq: Vec<PathBuf> = std::iter::from_fn(|| cursor.next_ready()).collect();
+        assert_eq!(seq, vec![PathBuf::from("root"), PathBuf::from("root/a")]);
+    }
+
+    #[test]
+    fn deeper_tree_emits_full_depth_first_order() {
+        // root/a/x/q, root/a/x/p, root/a/y, root/b, root/c/m
+        let mut cursor = DirTraversalCursor::new(PathBuf::from("root"));
+        cursor.observe_segment(
+            PathBuf::from("root"),
+            &[
+                dir_entry("root/c"),
+                dir_entry("root/a"),
+                dir_entry("root/b"),
+            ],
+        );
+        cursor.observe_segment(
+            PathBuf::from("root/a"),
+            &[dir_entry("root/a/y"), dir_entry("root/a/x")],
+        );
+        cursor.observe_segment(
+            PathBuf::from("root/a/x"),
+            &[dir_entry("root/a/x/q"), dir_entry("root/a/x/p")],
+        );
+        cursor.observe_segment(PathBuf::from("root/c"), &[dir_entry("root/c/m")]);
+        let seq: Vec<PathBuf> = std::iter::from_fn(|| cursor.next_ready()).collect();
+        assert_eq!(
+            seq,
+            vec![
+                PathBuf::from("root"),
+                PathBuf::from("root/a"),
+                PathBuf::from("root/a/x"),
+                PathBuf::from("root/a/x/p"),
+                PathBuf::from("root/a/x/q"),
+                PathBuf::from("root/a/y"),
+                PathBuf::from("root/b"),
+                PathBuf::from("root/c"),
+                PathBuf::from("root/c/m"),
+            ]
+        );
+    }
+
+    #[test]
+    fn cursor_handles_root_with_no_observations() {
+        let mut cursor = DirTraversalCursor::new(PathBuf::from("."));
+        assert!(!cursor.is_exhausted());
+        assert_eq!(cursor.next_ready(), Some(PathBuf::from(".")));
+        assert_eq!(cursor.next_ready(), None);
+        assert!(cursor.is_exhausted());
+    }
+
+    #[test]
+    fn high_byte_basenames_use_unsigned_byte_order() {
+        // f_name_cmp is unsigned-byte; "z" (0x7A) sorts before any name
+        // starting with a high byte like 0xC3.
+        #[cfg(unix)]
+        {
+            use std::ffi::OsStr;
+            use std::os::unix::ffi::OsStrExt;
+            let high = PathBuf::from(OsStr::from_bytes(b"root/\xC3\xA9_other"));
+            let z = PathBuf::from("root/z");
+            let mut cursor = DirTraversalCursor::new(PathBuf::from("root"));
+            cursor.observe_segment(
+                PathBuf::from("root"),
+                &[
+                    FileEntry::new_directory(high.clone(), 0o755),
+                    FileEntry::new_directory(z.clone(), 0o755),
+                ],
+            );
+            let seq: Vec<PathBuf> = std::iter::from_fn(|| cursor.next_ready()).collect();
+            assert_eq!(seq, vec![PathBuf::from("root"), z, high]);
+        }
+        #[cfg(not(unix))]
+        {
+            // Same property over ASCII names: 'A' (0x41) < 'z' (0x7A).
+            let mut cursor = DirTraversalCursor::new(PathBuf::from("root"));
+            cursor.observe_segment(
+                PathBuf::from("root"),
+                &[dir_entry("root/z"), dir_entry("root/A")],
+            );
+            let seq: Vec<PathBuf> = std::iter::from_fn(|| cursor.next_ready()).collect();
+            assert_eq!(
+                seq,
+                vec![
+                    PathBuf::from("root"),
+                    PathBuf::from("root/A"),
+                    PathBuf::from("root/z"),
+                ]
+            );
+        }
+    }
+}

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -129,6 +129,7 @@
 pub mod async_io;
 
 pub mod concurrent_delta;
+pub mod delete;
 pub mod delta;
 pub mod error;
 pub mod hardlink;


### PR DESCRIPTION
## Summary

Adds the data-structure foundation for the parallel-deterministic-delete
pipeline (DDP-A3, DDP-A4) described in
`docs/design/parallel-deterministic-delete.md` (PR #4257). Three new
modules under `crates/engine/src/delete/`. Pure types; no callers yet
(phase-1 and phase-2 wiring lands in #2255-#2278).

- `plan.rs` - `DeletePlan` (sorted, frozen per-directory work item),
  `DeleteEntry`, `DeleteEntryKind` (mirrors `DeleteStats` buckets), and
  a `HardlinkCohortId` newtype. `sort_by_name()` uses upstream's
  `f_name_cmp` (PR #4256) ascending then reverses in place, matching
  `delete_in_dir`'s decrementing loop (`generator.c:320`).
- `plan_map.rs` - `DeletePlanMap`, the publish-once concurrent
  rendezvous between phase-1 workers and the phase-2 emitter. API:
  `insert`, `take`, `is_empty`, `len`, `contains`.
- `traversal.rs` - `DirTraversalCursor`, yields directories in
  upstream's depth-first `f_name_cmp`-ascending order. Backed by a
  tree built from observed flist segments via `observe_segment()`;
  `next_ready()` returns the next directory whose parent has been
  emitted (or the root on the first call).

## Concurrent-Map Choice

`DeletePlanMap` is backed by `std::sync::Mutex<HashMap<PathBuf, DeletePlan>>`.
This is the simplest correct backing store:

- No new dependency for the `engine` crate. The workspace's `dashmap`
  crate is already available (`Cargo.toml:203`), but pulling it into
  `engine` enlarges compile time and dependency surface for a module
  that has no measured bottleneck yet.
- Insert and take are O(1); no I/O happens under the lock.
- Phase 1 publishes one plan per directory and phase 2 takes it once,
  so contention is short-lived with at most rayon-worker-count
  concurrent writers and one reader.

The bench-driven choice between `Mutex<HashMap>`, `dashmap::DashMap`,
and a sharded `HashMap` is deferred to task DDP-B4 with a code-comment
pointer. The inner type can be swapped without changing the public
surface.

## Modules Added

- `crates/engine/src/delete/mod.rs`
- `crates/engine/src/delete/plan.rs`
- `crates/engine/src/delete/plan_map.rs`
- `crates/engine/src/delete/traversal.rs`
- `pub mod delete;` wired into `crates/engine/src/lib.rs`.

## Test plan

- [ ] CI green on the new branch (fmt+clippy, nextest stable, Windows,
      macOS, Linux musl).
- [ ] `plan.rs` unit tests:
  - `HardlinkCohortId` roundtrip.
  - `DeleteEntryKind::from_file_type` covers every `FileType` variant.
  - `DeleteEntry::new` and `DeleteEntry::with_cohort` set the cohort
    field correctly.
  - `DeletePlan::new` is empty, unsorted; `push` resets the sorted
    flag.
  - `sort_by_name` produces `f_name_cmp` ascending then reversed
    (descending for plain ASCII).
  - Sort preserves cohort tags and orders mixed kinds by name bytes
    only (no kind-based reordering).
  - `ascending_order` matches `f_name_cmp` for `Less`, `Greater`,
    `Equal`.
  - `from_extras` accepts a pre-built `Vec` and remains unsorted.
- [ ] `plan_map.rs` unit tests:
  - `new_map_is_empty`, `with_capacity` preallocation.
  - `insert` then `take` roundtrips.
  - `take` of a missing key returns `None`.
  - Duplicate `insert` displaces the previous value and returns it.
  - 16 threads x 32 inserts each remain fully retrievable.
  - Concurrent `take` across 8 threads drains every plan exactly once.
- [ ] `traversal.rs` unit tests:
  - Empty cursor yields only the root.
  - Single-level children emit in `f_name_cmp` ascending order.
  - Out-of-order segment observation still yields depth-first
    `f_name_cmp` order for the (root, a/, a/x/, a/y/, b/) tree.
  - Non-directory children are filtered out.
  - Duplicate observations do not duplicate emissions.
  - Deeper four-level tree emits the full depth-first sequence.
  - Cursor with no observations is exhausted after emitting the root.
  - Unix-only: high-byte basenames sort after ASCII per upstream's
    unsigned byte order.