### PR TITLE
docs: update delete architecture references to parallel-deterministic-delete model (#2285)

### DIFF
--- a/docs/UPSTREAM_COMPARISON.md
+++ b/docs/UPSTREAM_COMPARISON.md
@@ -513,16 +513,31 @@ If literal:
 
 ## 16. Delete Handling
 
-**Reference:** `crates/transfer/src/generator.rs`, `crates/protocol/src/stats.rs`
+**Reference:** `crates/transfer/src/generator.rs`,
+`crates/transfer/src/receiver/directory/deletion.rs`,
+`crates/protocol/src/stats.rs`
+
+### Architecture
+
+oc-rsync's receiver uses a two-phase parallel-deterministic delete
+pipeline: rayon workers compute per-directory delete plans in parallel
+(`compute_extras`), and a single emitter thread walks directories in
+upstream depth-first order to perform every `unlink`, emit every
+`*deleting` itemize line, and update every counter. The emitter
+preserves upstream rsync 3.4.1's wall-clock event sequence
+byte-for-byte while keeping candidate computation parallel. See
+[`docs/architecture/delete-during.md`](architecture/delete-during.md)
+and the full specification in
+[`docs/design/parallel-deterministic-delete.md`](design/parallel-deterministic-delete.md).
 
 ### Delete Modes
 
 | Mode | Flag | Behavior |
 |------|------|----------|
-| Before | `--delete-before` | Delete before transfer |
-| During | `--delete` | Delete while processing |
-| Delay | `--delete-delay` | Record, delete after |
-| After | `--delete-after` | Delete after transfer |
+| Before | `--delete-before` | Emitter drains plans for the whole tree before transfer |
+| During | `--delete` / `--delete-during` | Emitter interleaves per directory with the transfer loop |
+| Delay | `--delete-delay` | Emitter buffers plans during transfer, replays at finalisation |
+| After | `--delete-after` | Emitter drains plans after the transfer loop |
 
 ### Wire Protocol
 

--- a/docs/architecture/delete-during.md
+++ b/docs/architecture/delete-during.md
@@ -1,155 +1,147 @@
-# `--delete-during` ordering: oc-rsync vs upstream rsync 3.4.1
+# Receiver deletion model: parallel-deterministic two-phase pipeline
 
-This document captures the audit findings for issues #1893 and #1894. It
-contrasts the per-directory interleaved deletion model used by upstream rsync
-3.4.1 with the batched pre-transfer sweep used by oc-rsync, calls out the
-behavioural differences a user can observe, and lists the follow-up work
-required to close any gap.
+This document describes oc-rsync's deletion architecture and how it
+matches upstream rsync 3.4.1's observable ordering byte-for-byte while
+preserving internal parallelism. The design is specified in
+[`docs/design/parallel-deterministic-delete.md`](../design/parallel-deterministic-delete.md);
+this page is the architectural overview.
 
-`--delete-during` removes destination entries that no longer exist on the
-sender. Upstream interleaves the deletion with the transfer of each
-directory; oc-rsync performs a single sweep before any file content is sent.
-Both approaches converge on the same final filesystem state for a successful
-transfer. The difference matters for failure modes, observability, and
-filter-rule semantics.
+`--delete` (and its phase variants `--delete-before`, `--delete-during`,
+`--delete-delay`, `--delete-after`) removes destination entries that no
+longer exist on the sender. The implementation parallelises candidate
+computation across rayon workers and serialises every observable side
+effect through a single emitter thread that walks directories in
+upstream depth-first order.
 
-## Upstream behaviour
+## Two-phase model
 
-Upstream rsync runs deletion as part of the generator's main loop. For each
-directory entry returned by `recv_generator()`, the generator immediately
-calls `delete_in_dir()` before generating signatures or transfer requests
-for the files inside that directory. The relevant entry points are:
-
-- `generator.c::recv_generator()` -- per-entry dispatch from the generator
-  loop. Calls `delete_in_dir()` on every directory it visits.
-- `generator.c::delete_in_dir()` -- enumerates the destination directory,
-  matches entries against the in-memory file list for that directory, and
-  removes anything not present.
-- `rsync.c::do_delete()` (a.k.a. `delete_item()` in newer trees) -- shared
-  removal primitive used by all delete modes.
-
-Key properties of the upstream model:
-
-1. **Phase ordering is interleaved per directory.** The generator emits
-   `Delete(dir_A) -> Transfer(dir_A) -> Delete(dir_B) -> Transfer(dir_B)`.
-   Files inside `dir_A` are written into a directory whose extraneous
-   entries have already been removed.
-2. **Single-threaded, deterministic order.** Deletion uses reverse
-   iteration of the destination directory list and is dispatched from the
-   generator's serial loop. Itemize output (`*deleting`) appears in a
-   stable, reproducible order for a given input.
-3. **Filter rules re-evaluate per directory.** Because deletion runs after
-   the per-directory `.rsync-filter` and any merge files have been
-   loaded for that directory, protect/risk and per-dir merge rules apply
-   at deletion time exactly as they do at transfer time.
-4. **Errors are logged and the transfer continues.** A failed
-   `delete_item()` is reported via the message log and the generator
-   proceeds to the next entry. The transfer does not abort on a
-   deletion error.
-
-## oc-rsync behaviour
-
-oc-rsync performs deletion as a single batch sweep that runs before any
-file content is selected for transfer. The dispatch site is in
-`crates/transfer/src/receiver/transfer.rs` (line 532 at
-`run_pipelined`):
-
-```rust
-if self.config.flags.delete {
-    let (ds, exceeded) = self.delete_extraneous_files(&setup.dest_dir, writer)?;
-    delete_stats = ds;
-    delete_limit_exceeded = exceeded;
-}
+```
+                  +-----------------+      +------------------+
+   flist segment  | compute_extras  |---->-| DeletePlan(D)    |
+   arrives (#N)   | (rayon worker)  |      +------------------+
+                  +-----------------+               |
+                                                    v
+                  +-----------------+      +------------------+
+   flist segment  | compute_extras  |---->-| DeletePlan(D')   |
+   arrives (#N+1) | (rayon worker)  |      +------------------+
+                  +-----------------+               |
+                                                    v
+                  +---------------------------------------+
+                  | DeletePlanMap (keyed by dir relpath)  |
+                  +---------------------------------------+
+                                    |
+                                    v
+                  +---------------------------------------+
+                  | DirTraversalCursor (upstream order)   |
+                  +---------------------------------------+
+                                    |
+                                    v
+                  +---------------------------------------+
+                  | single emitter thread:                |
+                  |   for each dir in upstream order      |
+                  |     await DeletePlan(D)               |
+                  |     for each entry in plan order      |
+                  |       unlink, itemize, stat++         |
+                  +---------------------------------------+
 ```
 
-This call sits between the metadata pre-pass (directory creation and
-symlink materialization at lines 522 and 527) and the file-candidate
-construction (`build_files_to_transfer` at line 544). The deletion logic
-itself lives in `crates/transfer/src/receiver/directory/deletion.rs`.
+### Phase 1: parallel `compute_extras`
 
-Key properties of the oc-rsync model:
+For every arriving file-list segment, rayon workers compute the set of
+destination entries that are not present in the sender's listing for
+each content directory inside the segment. Each worker:
 
-1. **Phase ordering is batched.** The receiver runs a metadata phase, then
-   a single deletion phase that walks every directory at once, then the
-   transfer phase. There is no per-directory interleave.
-2. **Parallel and non-deterministic delete order.** Directories are
-   dispatched through `crate::parallel_io::map_blocking` using
-   `tokio::spawn_blocking` once the count exceeds
-   `DEFAULT_DELETION_THRESHOLD = 64`
-   (`crates/transfer/src/parallel_io.rs:33`). Below the threshold, the
-   sweep falls back to a sequential loop; above it, the order in which
-   directories are scanned (and therefore the order of `*deleting`
-   itemize lines) depends on worker scheduling.
-3. **Filter snapshot is taken once at the start.** The deletion workers
-   share an `Arc<FilterChain>` cloned from the receiver's global rules
-   (`deletion.rs:93`). Per-directory `.rsync-filter` merge files are not
-   re-read inside the deletion sweep -- only the rules already loaded
-   when deletion begins are evaluated.
-4. **Error semantics differ.** `delete_extraneous_files` returns
-   `io::Result`, and `?` at line 532 propagates the error up the
-   `run_pipelined` stack. Per-entry `read_dir`/`remove` failures inside
-   the worker are swallowed and the directory is skipped, but a failure
-   in the surrounding orchestration aborts the transfer rather than
-   logging and continuing.
+1. Snapshots the destination directory's `read_dir` output.
+2. Computes `extras(D) = readdir(D) - segment_entries(D)`, intersected
+   with the `FilterChain::allows_deletion()` snapshot in effect for
+   that directory (including any `.rsync-filter` merge files loaded by
+   `enter_directory` for that subtree).
+3. Sorts the result with `compare_file_entries` (our port of upstream
+   `f_name_cmp`), then reverses the order to match upstream's
+   `delete_in_dir()` decrementing iteration.
+4. Publishes the result as a `DeletePlan` into `DeletePlanMap`, keyed
+   by the directory's relative path.
 
-## Differences
+Workers are pure: read-only `read_dir`/`stat`, immutable flist,
+immutable filter chain snapshot. They never call `unlink`, never emit
+itemize output, and never mutate shared state beyond the single
+publish into `DeletePlanMap`.
 
-| Aspect              | Upstream 3.4.1                            | oc-rsync                                                |
-| ------------------- | ----------------------------------------- | ------------------------------------------------------- |
-| Phase ordering      | Interleaved per directory                 | Batched sweep before transfer                           |
-| Determinism         | Reverse-iteration single-threaded         | `tokio::spawn_blocking` workers above 64-dir threshold  |
-| Filter evaluation   | Re-evaluated per directory (merge files)  | Single snapshot of `FilterChain` for the whole sweep    |
-| Error handling      | Logged, transfer continues                | Orchestration error may propagate via `?` and abort     |
-| Itemize order       | Stable for a given input                  | Worker-scheduling dependent above the parallel threshold |
-| Final filesystem state | Identical for successful transfers     | Identical for successful transfers                      |
+### Phase 2: single emitter
 
-The risk surface is therefore concentrated in three areas:
+A single drain task owns every observable side effect. It walks
+directories in upstream depth-first traversal order via
+`DirTraversalCursor`; for each directory `D` it blocks until
+`DeletePlanMap[D]` is ready, then:
 
-1. **Error propagation.** A user who relied on upstream's "delete failures
-   do not stop the transfer" behaviour may see oc-rsync abort earlier.
-2. **Observable delete order.** Tooling that scrapes
-   `--itemize-changes` for `*deleting` lines must not assume a stable
-   order on oc-rsync.
-3. **Per-dir merge files.** Users whose `.rsync-filter` merge files would
-   protect a file in directory `B` only after a deeper merge file in
-   directory `B/.rsync-filter` is loaded see different behaviour: upstream
-   honours the deeper merge file because deletion runs after it loads;
-   oc-rsync evaluates only the snapshot taken before deletion.
+- Evaluates `--max-delete` and per-entry filter rules in upstream
+  order.
+- Calls `unlink`/`rmdir`/recursive removal.
+- Emits the `*deleting` itemize line via `writer.send_msg_info`.
+- Updates `DeleteStats` (files, dirs, symlinks, devices, specials) and
+  `io_error` exactly where upstream sets them.
 
-## Recommendation
+Because every observable effect happens on one thread in upstream
+order, the wall-clock event sequence (unlink syscall order, itemize
+emission order, `MSG_INFO` framing order) matches upstream
+byte-for-byte.
 
-- Document the batching model in the CHANGELOG and the `oc-rsync(1)` man
-  page so users do not assume per-directory interleave (#1894).
-- Add an interop test that mixes new and deleted entries across multiple
-  directories to assert final-state parity with upstream.
-- Investigate whether real-world `.rsync-filter` users see different
-  outcomes; capture cases with deep per-dir merge files.
-- Consider an opt-in `--delete-strict-order` flag that forces the
-  sequential, deterministic upstream order if user-visible delete
-  ordering or per-directory filter re-evaluation is required for
-  parity.
-- Audit `delete_extraneous_files` error paths to align with upstream's
-  "log and continue" policy where an abort is not strictly necessary.
+## Upstream parity guarantees
+
+| Aspect                 | Upstream 3.4.1                            | oc-rsync                                                 |
+| ---------------------- | ----------------------------------------- | -------------------------------------------------------- |
+| Phase ordering         | Interleaved per directory                 | Same: emitter walks directories in upstream order        |
+| Determinism            | Reverse-iteration single-threaded         | Same: single emitter, plans reverse-sorted by `f_name_cmp` |
+| Filter evaluation      | Re-evaluated per directory (merge files)  | Same: each `DeletePlan` is built against the per-dir snapshot |
+| Error handling         | Logged, transfer continues                | Same: emitter logs per-entry `delete_item()` failures and continues |
+| Itemize order          | Stable for a given input                  | Same: emitter is single-threaded                         |
+| Final filesystem state | Deterministic                             | Same                                                     |
+
+**Conformance: matches upstream.** No user-visible flag controls this
+behaviour; parity is the default.
+
+## Phase-mode handling
+
+- `--delete-before`: emitter drains plans for the whole tree before
+  the transfer loop begins.
+- `--delete-during` (default for `--delete`): emitter interleaves with
+  the transfer loop, draining plans for each directory just as
+  upstream's generator visits it.
+- `--delete-delay`: emitter buffers plans during the transfer and
+  replays them in upstream order at finalisation, mirroring
+  `do_delayed_deletions()`.
+- `--delete-after`: emitter drains plans after the transfer loop
+  completes.
+
+In every mode the per-directory plan is computed once during phase 1
+and the emitter is the only thread that mutates state.
 
 ## Upstream references
 
 - `generator.c::recv_generator()` -- per-entry generator dispatch.
-- `generator.c::delete_in_dir()` -- per-directory delete enumeration.
+- `generator.c::delete_in_dir()` -- per-directory delete enumeration
+  (reverse iteration).
 - `generator.c::do_delete_pass()` -- full-tree sweep used by
   `--delete-before`.
+- `generator.c::do_delayed_deletions()` -- replay path used by
+  `--delete-delay`.
 - `rsync.c::do_delete()` / `delete_item()` -- shared removal primitive.
-- `main.c` deletion-count check that enforces `--max-delete`.
 
 ## oc-rsync references
 
-- `crates/transfer/src/receiver/transfer.rs:532` -- delete entry point in
-  `run_pipelined`.
-- `crates/transfer/src/receiver/directory/deletion.rs:40` --
-  `delete_extraneous_files` definition; documents the parallel scan and
-  `--max-delete` enforcement.
-- `crates/transfer/src/receiver/directory/deletion.rs:93` -- single
-  filter-chain snapshot shared across workers.
-- `crates/transfer/src/receiver/directory/deletion.rs:99` --
-  `parallel_io::map_blocking` dispatch.
-- `crates/transfer/src/parallel_io.rs:33` --
-  `DEFAULT_DELETION_THRESHOLD = 64`, the parallel cutoff.
+- Design specification:
+  [`docs/design/parallel-deterministic-delete.md`](../design/parallel-deterministic-delete.md)
+- Receiver hook into the segment-dispatch loop:
+  `crates/transfer/src/receiver/file_list.rs` (`receive_extra_file_lists`).
+- Plan publication and emitter coordination:
+  `crates/transfer/src/receiver/directory/deletion.rs`.
+- Upstream `f_name_cmp` port:
+  `crates/protocol/src/flist/sort.rs::compare_file_entries`.
+
+## History
+
+This document supersedes the earlier audit (#1893) of the batched
+pre-transfer sweep and the opt-in `--delete-strict-order` gate design
+(#1940). Both approaches were replaced by the two-phase model
+(#2251 - #2285); the strict-order flag is no longer part of the CLI
+surface and the batched code path no longer exists.

--- a/docs/audits/iconv-filter-rules.md
+++ b/docs/audits/iconv-filter-rules.md
@@ -96,7 +96,7 @@ operate on local-charset names by construction:
    `FilterChain::allows()` before any iconv conversion.
 2. The receiver applies `ic_recv` inside the file-list reader, so by the
    time the file list reaches the filter chain (during
-   `--delete-excluded` pruning, deletion sweeps, or the local-copy
+   `--delete-excluded` pruning, the per-directory delete pipeline, or the local-copy
    executor), the names are already local-charset.
 3. Pattern strings are stored verbatim, exactly as upstream stores them.
 

--- a/docs/design/delete-during-strict-order-gate.md
+++ b/docs/design/delete-during-strict-order-gate.md
@@ -1,10 +1,22 @@
-# `--delete-strict-order` opt-in gate (#1940)
+# `--delete-strict-order` opt-in gate (#1940) - SUPERSEDED
 
-Status: Design (task #1940; cites audit #1893, follow-up #1894)
+> **Status: SUPERSEDED.** This design is retained for historical
+> context only. The opt-in `--delete-strict-order` flag was replaced
+> by the always-on two-phase parallel-deterministic delete model
+> specified in
+> [`docs/design/parallel-deterministic-delete.md`](parallel-deterministic-delete.md)
+> (tasks #2251 - #2285). The flag is removed from the CLI surface;
+> upstream per-directory ordering is the default and only behaviour.
+> See
+> [`docs/architecture/delete-during.md`](../architecture/delete-during.md)
+> for the current architecture.
+
+Status: Design (task #1940; cites audit #1893, follow-up #1894) - superseded
 Audience: transfer, cli, filters maintainers
-Scope: introduce an opt-in `--delete-strict-order` flag that forces
-oc-rsync's `--delete-during` path onto upstream's per-directory
-interleaved order, without changing the default batched behaviour.
+Scope (historical): introduce an opt-in `--delete-strict-order` flag
+that forces oc-rsync's `--delete-during` path onto upstream's
+per-directory interleaved order, without changing the default batched
+behaviour.
 
 ## 1. Current `--delete-during` behaviour (#1893 audit)
 

--- a/docs/oc-rsync.1.md
+++ b/docs/oc-rsync.1.md
@@ -509,7 +509,7 @@ NEON) are used where available, with automatic scalar fallbacks.
 :   Remove extraneous destination files after transfers complete.
 
 **--delete-excluded**
-:   Remove excluded destination files during deletion sweeps.
+:   Remove excluded destination files during deletion.
 
 **--max-delete**=*NUM*
 :   Limit the number of deletions that may occur per run.


### PR DESCRIPTION
## Summary

- Rewrites `docs/architecture/delete-during.md` to describe the two-phase parallel-deterministic delete model (parallel `compute_extras` workers + single emitter walking directories in upstream depth-first order), replacing the prior batched-pre-transfer-sweep description.
- Marks `docs/design/delete-during-strict-order-gate.md` (the old opt-in `--delete-strict-order` proposal) as SUPERSEDED with a pointer to `docs/design/parallel-deterministic-delete.md` and to the rewritten architecture page.
- Adds an architecture summary plus per-mode emitter behaviour to `docs/UPSTREAM_COMPARISON.md` section 16, linking to the design spec.
- Softens generic "deletion sweep" wording in `docs/oc-rsync.1.md` (`--delete-excluded` description) and `docs/audits/iconv-filter-rules.md` so neither implies a batched sweep.

All updated docs converge on:

- Two phases: parallel candidate computation, then single-thread emit.
- Upstream-event-order guarantee for `unlink`, itemize, and `MSG_INFO`.
- Cross-link to `docs/design/parallel-deterministic-delete.md` as the source of truth.
- No more `--delete-strict-order` (only historical mentions remain, clearly labelled).

Doc-only change. `cargo fmt --all` ran clean (no Rust files touched).

## Test plan

- [ ] Render `docs/architecture/delete-during.md` and confirm the link to `docs/design/parallel-deterministic-delete.md` resolves.
- [ ] Confirm `docs/design/delete-during-strict-order-gate.md` is clearly marked SUPERSEDED at the top.
- [ ] Confirm `docs/UPSTREAM_COMPARISON.md` section 16 renders with the new architecture paragraph and mode table.
- [ ] `grep -rn "delete-strict-order\|batched.*delete\|delete sweep" docs/ README.md` returns only intentional historical mentions inside the two design docs and the architecture page's history note.