### PR TITLE
docs(design): SSH transport async followups: default flip, decouple delta, backpressure (#1890, #1891, #1892)

### DIFF
--- a/docs/design/ssh-async-default-linux.md
+++ b/docs/design/ssh-async-default-linux.md
@@ -1,0 +1,260 @@
+# SSH Transport: Make `async-ssh` the Default on Linux
+
+Tracking issue: #1890. Followup to `docs/design/ssh-transport-async-io-eval.md`
+(the umbrella eval) and the hybrid recommendation it adopts (option (a) for
+the daemon, option (b) for the CLI).
+
+This document does not re-litigate which executor (tokio), which bridge
+(`tokio::process::ChildStdin`/`ChildStdout` for the subprocess path,
+`russh::ChannelStream` for embedded), or which migration sequencing
+(`async-migration-plan.md`) the workspace has already committed to. It
+narrows one open question:
+
+> When does the synchronous SSH transport stop being the default on Linux,
+> and what is the runway between "opt-in behind `--features async-ssh`" and
+> "compiled in by default, used by default"?
+
+The umbrella eval (section 8, "Promotion default") states the final answer:
+"stay deferred" until five trigger conditions hold simultaneously. This
+document sharpens those five into measurable gates, lists the Linux-only
+surface that gets flipped, and writes the five-step rollout against the
+existing tokio infrastructure.
+
+## 1. Why Linux first
+
+The umbrella eval treats the async surface as platform-uniform: tokio runs
+on Linux, macOS, and Windows; `tokio::process::Child` reaps `SIGCHLD` on
+Unix and synthesises named pipes on Windows for IOCP compatibility. The
+platform-uniform story holds for correctness. It does not hold for the
+performance gate.
+
+Linux is the platform where:
+
+- The async daemon listener (#1935) lands first and is already production
+  scope; `daemon-tokio-async-listener-impl.md` is Linux-shaped.
+- The SSH-async bench (`crates/rsync_io/benches/ssh_sync_vs_async.rs`,
+  added in PR #4251) runs deterministically on the CI runners we control
+  (the cell uses `tokio::task::spawn_blocking` over a userspace-throttled
+  loopback `TcpStream`, not real `sshd`).
+- io_uring (`crates/fast_io/src/io_uring/`) is the disk-side complement
+  the async pump composes with; the cross-platform stub
+  (`fast_io::io_uring_stub`) makes the pairing meaningless on non-Linux
+  for the gate workloads.
+- The thread-elimination win named in the umbrella eval section 2's
+  fan-out row (`>= 20% wall clock`) is Linux-first because the rayon
+  pool + blocking pool already share `num_cpus` accounting via the
+  rayon bridge (#1751); macOS and Windows have not been measured.
+
+Linux is the only platform where all five umbrella-eval triggers can be
+observed against shipped code by the time #4242 (the async eval) lands.
+Flipping the default elsewhere stays deferred behind the same feature
+gate until each platform passes the same bench bar in section 4 below.
+
+## 2. What "default on Linux" means concretely
+
+Three layers of "default" exist; this section names the one we flip.
+
+| Layer | State before | State after this PR's eventual implementation |
+|-------|--------------|------------------------------------------------|
+| `Cargo.toml` `default-features` | `embedded-ssh, async` already there; `async-ssh` absent | `async-ssh` added to `default-features` on Linux via a target-cfg |
+| Runtime `RSYNC_ASYNC_SSH` env var | Honoured when set to `1`; unset means sync | Honoured; unset means async (Linux) / sync (other platforms) |
+| Internal `SshTransport` dispatch | `SshConnection::connect_with_config` (sync) | `AsyncSshTransport::connect_with_config` (async) on Linux when `async-ssh` is active and the env var is not `=0` |
+
+The flip is the third row: the `core::client::remote` dispatch switches
+from the sync builder to the async builder under the Linux + `async-ssh`
+cfg. The first row is the Cargo-level enabler. The second row is the
+escape hatch users hit with `RSYNC_ASYNC_SSH=0` if their environment
+trips a regression.
+
+Crucially, the sync path stays compiled and tested. The flip is a default,
+not a deletion. The umbrella eval section 8 trigger 1 (async daemon
+listener stable for one release cycle) is the gate that lets us
+contemplate sync-path deletion in a later release; this document does
+not.
+
+## 3. Trigger conditions, made measurable
+
+The umbrella eval section 8 lists five triggers in prose. Each one is
+re-stated below with the numeric bar that decides pass / fail and the
+artifact in the tree that produces the measurement.
+
+### 3.1 Trigger A: async daemon shipped and stable
+
+**Bar**: #1935 merged and present in at least one tagged release. No
+P0 or P1 issue filed against the async daemon listener for the duration
+of one release cycle (typically 6 - 12 weeks). The release notes for the
+cycle in question contain no `fix:`-prefixed entry that touches
+`crates/daemon/src/` runtime code.
+
+**Artifact**: `gh release view` for the prior tag; `gh issue list
+--label bug --search "daemon async"` returns zero open at the time of
+flip.
+
+### 3.2 Trigger B: embedded russh covers the parity matrix
+
+**Bar**: #1796 and #1797 merged. The embedded-ssh feature passes the
+OpenSSH-parity matrix declared in `async-ssh-evaluation.md` open
+question 1 (cipher set, kex algorithm set, host key types,
+known-hosts file format, agent forwarding off, key-file auth on).
+Specifically: the `crates/rsync_io/src/ssh/embedded/tests.rs` matrix
+exits 0 against an upstream `sshd` 9.x in CI.
+
+**Artifact**: a CI job under `.github/workflows/` named
+`embedded-ssh-parity.yml` that runs the matrix on each PR; the job is
+green at the time of flip.
+
+### 3.3 Trigger C: SSH-async bench shows a real win
+
+**Bar**: at least one row in `ssh_sync_vs_async.rs` shows
+`async_spawnblocking_transfer/<size>` faster than
+`sync_transfer/<size>` by `>= 10%` wall clock, measured at the
+`SLOW_LINK_NS_PER_BYTE = 200` setting that approximates a transatlantic
+RTT. No LAN row (with `SLOW_LINK_NS_PER_BYTE = 0`, runnable via an env
+var override the bench will accept) regresses by more than 3%. The
+result is reproducible across at least three CI runner classes
+(`ubuntu-latest`, `ubuntu-22.04-arm`, the project's self-hosted Linux
+runner if present).
+
+**Artifact**: `cargo bench -p rsync_io --bench ssh_sync_vs_async`
+JSON output checked into `target/criterion-history/` for the comparison
+commits, plus a markdown summary appended to the release notes that
+flip the default.
+
+The bench today covers a narrow shape (loopback `TcpStream`,
+`spawn_blocking` shim, not the real async pump). Trigger C must be
+re-evaluated against the real pump (the `AsyncSshConnection` from
+#1806 once it lands); the existing bench is a *lower bound* on the
+win, not the final measurement.
+
+### 3.4 Trigger D: runtime-flavour comparison
+
+**Bar**: the umbrella eval section 7.1 runs, with all three variants
+(sync, option (a) shared `rt-multi-thread`, option (b) per-connection
+`current_thread`) measured. Hybrid recommendation holds: option (b)
+within 5% of option (a) on the fan-out row, option (b) at least 50%
+RSS reduction on single-connection CLI rows.
+
+**Artifact**: a follow-up bench file
+`crates/rsync_io/benches/ssh_runtime_flavour.rs` modelled on
+`ssh_sync_vs_async.rs`, with the three variants as separate cells.
+Result table in this document's section 8 (filled in when the bench
+lands).
+
+### 3.5 Trigger E: bridge-cost probe
+
+**Bar**: the umbrella eval section 7.2 micro-bench shows
+`tokio::process::ChildStdin`/`ChildStdout` within 5% of
+`AsyncFd`-over-raw-FD. If the gap exceeds 5%, the escape hatch in
+umbrella eval section 5.1 becomes a real fork that must ship before
+the default flips, and trigger E gates on the fork shipping rather
+than on the original ChildStdin path winning.
+
+**Artifact**: micro-bench cell added to
+`crates/rsync_io/benches/ssh_sync_vs_async.rs` (the existing file, to
+avoid bench proliferation).
+
+All five must be green simultaneously. A regression in any one row
+reverts the default to sync via `Cargo.toml` and a `RSYNC_ASYNC_SSH=0`
+hint in the release notes.
+
+## 4. Migration: five steps
+
+The umbrella eval section 9 sequences the five steps to *implement*
+async SSH. This document sequences the five steps to *flip the default*
+once that implementation has shipped.
+
+1. **Add the Linux target-cfg `default-features` entry.** Edit the
+   workspace `Cargo.toml` to add `async-ssh` to the binary crate's
+   `[target.'cfg(target_os = "linux")'.dependencies]` `default-features`
+   set. No code change. Gate: `cargo build --target
+   x86_64-unknown-linux-gnu` produces a binary that links tokio in by
+   default; `cargo build --target x86_64-apple-darwin` and
+   `cargo build --target x86_64-pc-windows-msvc` do not (CI matrix
+   verifies). Tracking: this PR's eventual implementation issue.
+
+2. **Wire the runtime dispatch on Linux.** In
+   `crates/core/src/client/remote/`, branch on
+   `cfg(all(target_os = "linux", feature = "async-ssh"))` to call
+   `AsyncSshTransport::connect_with_config` (from umbrella eval
+   step 1) instead of `SshConnection::connect_with_config` (PR #4266).
+   Gate: the interop harness (`tools/ci/run_interop.sh`) against
+   upstream rsync 3.0.9, 3.1.3, 3.4.1 passes with the async dispatch.
+   Cross-platform: macOS and Windows CI cells stay on the sync path.
+
+3. **Add the `RSYNC_ASYNC_SSH=0` escape hatch.** At the dispatch
+   point in step 2, honour `RSYNC_ASYNC_SSH=0` to force the sync path
+   even when compiled in by default. Document the env var in
+   `crates/cli/src/frontend/arguments/parsed_args/mod.rs` and the
+   `oc-rsync(1)` man page generator (`xtask/src/commands/docs/`).
+   Gate: a CLI integration test invokes both `RSYNC_ASYNC_SSH=0
+   oc-rsync ...` and unset, asserts both succeed against a loopback
+   sshd.
+
+4. **Bench, fill the trigger table, ship behind a beta flag.** Run
+   triggers C, D, E. If all pass, ship the Linux default flip in a
+   release marked beta (per the `project_beta_status_notify.md`
+   convention). Beta runtime is one release cycle minimum. Gate:
+   release notes for that cycle contain zero `fix:` entries against
+   `crates/rsync_io/src/ssh/` or `crates/core/src/client/remote/`.
+
+5. **Promote to default-default.** Drop the beta marker; the Linux
+   default is async. The sync path stays compiled (`--no-default-features`
+   plus `--features sync-ssh` builds it, where `sync-ssh` is added in
+   step 1 as the inverse default). Gate: clean release with no
+   regressions filed against the async path during the beta cycle;
+   the umbrella eval section 8 trigger 1 (one release cycle of
+   stability) is satisfied for the async SSH path itself.
+
+The five steps are strictly serial. Any step that fails its gate
+stops the promotion and leaves the sync path as the Linux default.
+A failed step does not undo the prior steps; the feature-gate
+infrastructure remains in place for the next attempt.
+
+## 5. Risk: existing sync-path users
+
+The sync path is what every release before the flip has shipped. Users
+in three classes carry the risk:
+
+1. **Embedders.** Anyone using `oc-rsync` as a library inside their own
+   tokio app already sees the sync transport. Flipping the default
+   introduces a second tokio runtime in their process unless they opt
+   into the hybrid daemon shape (umbrella eval option (a)). The escape
+   hatch is `RSYNC_ASYNC_SSH=0` plus, for library users, a
+   `disable_async_ssh()` builder method on the public `CoreConfig`
+   surface that overrides the env var.
+
+2. **CI users with locked-down network policies.** Tokio's mio reactor
+   opens an epoll FD plus a small set of eventfd descriptors at runtime
+   construction. Sandboxed CI environments that whitelist syscalls may
+   refuse the construction outright. The mitigation is the
+   `RSYNC_ASYNC_SSH=0` env var plus a clear error message at runtime
+   construction failure that names the env var as the workaround.
+
+3. **Users on long-lived SSH sessions with custom keepalive shapes.**
+   The umbrella eval section 6.1 collapses the keepalive watchdog
+   into `tokio::time::timeout`. Users who today set
+   `RSYNC_SSH_KEEPALIVE_*` env vars (if any exist; verify before flip)
+   keep the same behaviour because the watchdog implementation lives
+   in `crates/rsync_io/src/ssh/connect.rs` and is preserved across
+   the sync / async boundary.
+
+The classes are mitigated, not eliminated. The cfg / feature gate
+during rollout (steps 1 - 4 above) is the structural mitigation:
+users who hit a regression flip back to sync without recompiling,
+and the next release cycle decides whether the regression class is
+real or one-off.
+
+## 6. Open questions deferred to implementation
+
+- The exact name of the inverse feature (`sync-ssh` vs `force-sync-ssh`)
+  pending convention check against existing feature names in
+  `Cargo.toml`. Punt to step 1's PR review.
+- Whether `RSYNC_ASYNC_SSH` is the right env var name. Existing env
+  vars use `OC_RSYNC_*` prefix
+  (`OC_RSYNC_SSH_NET` in `connect.rs:446`); align step 3 with that
+  convention. Likely final name: `OC_RSYNC_SSH_ASYNC`.
+- Whether the Linux `default-features` toggle applies to musl as well
+  as glibc. Probable yes; verify against the Linux musl CI cell when
+  step 1 lands.
+
+These are scoped to the implementation PRs, not to this design.

--- a/docs/design/ssh-decouple-delta-from-socket-read.md
+++ b/docs/design/ssh-decouple-delta-from-socket-read.md
@@ -1,0 +1,385 @@
+# SSH Transport: Decouple Delta Apply from the Socket Read
+
+Tracking issue: #1891. Followup to `docs/design/ssh-transport-async-io-eval.md`
+(the umbrella eval) and the hybrid recommendation it adopts. See also
+`ssh-async-default-linux.md` (#1890) for when the async surface flips on
+by default.
+
+## 1. Today: the socket read drives the delta apply
+
+The receive direction inside the SSH transport runs as one logical
+pipeline:
+
+```
+ChildStdout (sync Read) -> multiplex demux -> token apply -> disk write
+                          [single thread; back-pressured by network]
+```
+
+The thread that reads frames out of `ChildStdout` is the same thread
+that decodes the multiplex header, switches on `MSG_*`, applies the
+token to the basis file (the delta-apply step in
+`crates/engine/src/`), and either schedules the resulting bytes onto
+the SPSC pipeline (`crates/transfer/src/pipeline/spsc.rs`) for the
+disk-commit thread or, on the local-write fast path, writes them
+itself. The umbrella eval section 6 names this thread the "receiver"
+and section 6.4 confirms the disk-commit thread stays sync.
+
+The coupling is hard. When delta apply on frame N blocks (basis-file
+read, CPU work on a large literal, brief lock on the buffer pool),
+the next `read(2)` on the socket does not issue until apply completes.
+The kernel pipe buffer absorbs a bounded amount of upstream data, but
+upstream rsync's sender is back-pressured by it within ~64 KiB on
+Linux. Both halves stall together.
+
+The umbrella eval section 6.2 identifies this as the dominant per-frame
+contribution to the high-RTT bench prediction (8 - 12% wall clock at
+100 ms RTT). The umbrella eval's recommendation handles the read /
+write overlap *between* network and disk via async at the transport
+boundary. It does not break the within-direction coupling between the
+socket reader and the delta applier. That is what this document
+addresses.
+
+## 2. Proposal: two threads, one bounded queue
+
+Split the receive pipeline at the multiplex-demux output:
+
+```
+ChildStdout (AsyncRead) -> demux -> bounded queue -> apply -> disk write
+                          [reader thread]   [applier thread]
+```
+
+The reader thread does only: read frame header, read payload, decode
+`MSG_*` tag, enqueue `(tag, payload_bytes)` onto a bounded
+`crossbeam-channel::Sender`. It does no apply work, no disk I/O, no
+basis-file lookup. When the queue is full it blocks on `send` and the
+socket read naturally back-pressures.
+
+The applier thread does only: pop `(tag, payload_bytes)` off the
+queue, dispatch on tag, apply the token to the basis file, either
+schedule a write on the SPSC pipeline or write directly. When the
+queue is empty it blocks on `recv` and the disk-write half goes idle.
+
+The two threads connect via one bounded queue. Queue depth is the
+sole tuning knob and (by section 5 below) the user-visible
+back-pressure control.
+
+## 3. Benefits
+
+### 3.1 Socket reads progress while apply is busy
+
+Concrete win: on a 16 MiB literal-copy frame where the receiver is
+basis-reading a fragmented destination file, apply takes order of
+10 ms but the socket has ~30 ms of upstream data buffered behind it.
+Today, the next read(2) waits for apply. With the split, the reader
+drains the next several frames into the queue and parks on `send`
+only when the queue is genuinely full. The sender side never observes
+the disk-apply stall, which means upstream rsync's per-flush
+sendto() boundary stays in its predictable cadence rather than
+stuttering. The bench (`crates/rsync_io/benches/ssh_sync_vs_async.rs`
+when extended with a frame-cadence cell, see section 7) measures
+the throughput uplift.
+
+### 3.2 CPU and I/O run in parallel
+
+The reader thread is I/O-bound. The applier thread is mixed: CPU
+(memcpy literal bytes, advance the rolling-hash window for COPY
+tokens) plus I/O (basis read, write). On a typical core, they
+saturate different units (network NIC vs disk + L1/L2) and the wall
+clock collapses toward `max(network_time, apply_time)` rather than
+the sum.
+
+The umbrella eval section 2 predicts 10 - 20% wall clock on the
+"LAN + slow rotational disk, 1 GiB file" row. That row already
+benefits from the existing SPSC pipeline between apply and disk; the
+new gain here is on the multiplex-demux to apply link, which is not
+buffered today.
+
+### 3.3 Composes with the async transport flip
+
+When `ssh-async-default-linux.md` (#1890) ships, the reader thread is
+already an async task on the SSH transport's tokio runtime. The split
+makes the applier thread the natural `spawn_blocking` boundary the
+umbrella eval section 3.3 names. Without the split, the boundary is
+inside a single function and harder to enforce.
+
+### 3.4 Recovery from transient apply slowdowns
+
+A long literal frame followed by short COPY frames currently lets the
+sender's batching collapse: the receiver does not read the next
+header until the literal apply completes. With the split, the queue
+absorbs the short COPY frames during the literal apply and dispatches
+them back-to-back when the applier returns. The sender's batching is
+preserved.
+
+## 4. Costs
+
+### 4.1 One extra thread per active SSH receive
+
+On a CLI invocation (single SSH connection) the cost is one extra
+`std::thread::spawn` per transfer. RSS overhead is the thread stack
+(~8 KiB resident, ~8 MiB virtual on Linux default) plus the
+`crossbeam-channel` queue allocation (bounded; see section 5).
+Order of 16 KiB resident; negligible against the multi-MiB working
+set the SSH transport already holds.
+
+On the daemon (fan-out N connections), N extra threads. With the
+async daemon option (a) from the umbrella eval, the applier threads
+can collapse into a rayon pool or a single shared blocking pool: each
+applier is a CPU-or-disk-bound task and rayon's work-stealing keeps N
+of them busy on `num_cpus` workers. The exact pool choice is
+deferred to the implementation; the simplest version (one
+`std::thread::spawn` per connection) is the gate criterion in
+section 6.
+
+### 4.2 Queue tuning
+
+A bounded queue has two failure modes. Depth too small and the reader
+stalls on `send` whenever apply is slow, defeating the point. Depth
+too large and the queue absorbs unbounded memory under pathological
+sender pressure.
+
+The queue holds `(tag, payload_bytes)` where `payload_bytes` is
+either a `Vec<u8>` or (preferably) a `bytes::Bytes` slice from a
+shared frame pool. Worst-case per entry is the multiplex max payload
+(`MAX_PAYLOAD_LENGTH = 16 MiB` from
+`crates/protocol/src/envelope/constants.rs:5`). A queue of depth 4
+already permits 64 MiB of in-flight bytes in the worst case; a
+depth of 8 permits 128 MiB.
+
+Default depth: 4. Rationale: typical frame size is 8 KiB
+(`MplexWriter::DEFAULT_MAX_FRAME_SIZE` in
+`crates/protocol/src/multiplex/writer.rs:88`), so depth 4 buffers
+~32 KiB of typical traffic, matching the Linux default pipe buffer
+size; the rare 16 MiB literal frame consumes one slot. Tunable via
+the `--ssh-max-in-flight-bytes` flag in section 5 by deriving
+queue depth from `max_bytes / typical_frame_size`.
+
+### 4.3 Ordering risk for multiplex tags
+
+Upstream rsync's multiplex demux is strictly in-order across all
+`MSG_*` tags. `MSG_DATA` carries delta tokens that must be applied
+sequentially. `MSG_INFO`, `MSG_WARNING`, `MSG_ERROR`,
+`MSG_ERROR_XFER` carry log lines that the receiver writes to its own
+stderr in protocol-order so the upstream sender's interleaving is
+preserved. `MSG_STATS`, `MSG_DONE`, `MSG_FLIST_EOF` are control
+boundaries.
+
+The queue must preserve insertion order across tags. A single bounded
+FIFO (`crossbeam-channel::bounded`) does this trivially. A
+per-tag-class queue (one for `MSG_DATA`, one for everything else)
+would not; rejected for that reason. Section 5 codifies the choice.
+
+### 4.4 Error propagation
+
+On the sync path today, an error during apply is returned up the
+single thread's call stack and ends the transfer with the appropriate
+`ExitCode`. With the split, the applier thread must report errors
+back to the reader thread (which is doing the SSH-side cleanup) and
+the orchestration layer (which decides the exit code). Section 5
+defines the error channel.
+
+## 5. Detailed design
+
+### 5.1 Queue type
+
+`crossbeam-channel::bounded::<DemuxedFrame>(depth)`. Rationale:
+
+- The umbrella eval section 6.4 stays sync downstream of the async
+  pump. The applier thread is sync; an async queue (`tokio::sync::mpsc`)
+  would force `block_on` calls on the applier side, which the
+  migration plan R3 forbids.
+- `crossbeam-channel` is already in the workspace, used by
+  `crates/transfer/src/pipeline/spsc.rs` and a handful of other
+  paths. Approved for measurably lower syscall overhead than
+  `std::sync::mpsc`.
+- Bounded variants give the back-pressure semantics for free.
+  `send` blocks when full; `recv` blocks when empty.
+
+```rust
+struct DemuxedFrame {
+    tag: MultiplexTag,           // MSG_DATA, MSG_INFO, ...
+    payload: bytes::Bytes,       // refcounted slice from frame pool
+}
+```
+
+`bytes::Bytes` instead of `Vec<u8>` so the reader can hand the
+applier a slice of a larger frame-pool buffer without copying. A
+follow-up optimisation; v1 ships with `Vec<u8>` and the pool comes
+later.
+
+### 5.2 Backpressure semantics
+
+Three back-pressure paths exist; the split preserves all three:
+
+1. **Network -> reader**: TCP receive window plus the SSH pipe buffer.
+   Unchanged by this design.
+2. **Reader -> applier**: the bounded queue. New. When full, reader
+   parks on `send`; the next `read(2)` is delayed; the kernel pipe
+   buffer fills; upstream's `write(2)` blocks; upstream sender
+   stalls.
+3. **Applier -> disk**: the SPSC pipeline
+   (`crates/transfer/src/pipeline/spsc.rs`) for non-direct-write
+   paths, or the `direct-write` synchronous write for the fast path.
+   Unchanged.
+
+The three back-pressure paths daisy-chain. The user-visible knob
+(`--ssh-max-in-flight-bytes`, see #1892) controls path 2's capacity;
+paths 1 and 3 are fixed by kernel and protocol.
+
+### 5.3 MSG_DATA vs MSG_INFO ordering
+
+The queue is one FIFO. All tags share it. The applier thread
+dispatches by tag *after* popping:
+
+```rust
+match frame.tag {
+    MultiplexTag::Data => apply_delta(&frame.payload, ...)?,
+    MultiplexTag::Info => write_info_line(&frame.payload)?,
+    MultiplexTag::Warning => write_warning_line(&frame.payload)?,
+    MultiplexTag::Error | MultiplexTag::ErrorXfer => {
+        report_error(&frame.payload)?;
+    }
+    MultiplexTag::Stats => record_stats(&frame.payload)?,
+    MultiplexTag::Done => break Ok(()),
+    // ... other MSG_* tags handled the same way
+}
+```
+
+Sequential dispatch on the applier thread preserves upstream order
+across tags. No reordering, no per-tag prioritisation, no fast path
+for control messages. The cost is that a `MSG_INFO` log line behind
+a slow `MSG_DATA` apply waits for the apply; the umpstream sender's
+ordering is exact, so this matches sender intent.
+
+### 5.4 Error propagation
+
+The applier returns its result on a dedicated `Result<(), Error>`
+oneshot channel:
+
+```rust
+let (err_tx, err_rx) = oneshot::channel::<Result<(), TransferError>>();
+let applier = thread::spawn(move || {
+    let result = run_applier(queue_rx, ...);
+    let _ = err_tx.send(result);
+});
+```
+
+The reader thread runs to EOF (or `MSG_DONE`), closes the queue
+sender, joins the applier, and propagates whichever error fires
+first:
+
+- If apply fails mid-stream, the applier's `Err` is on `err_rx`. The
+  reader stops issuing frames (the queue drains), the applier exits,
+  the reader returns the applier's error to orchestration.
+- If the socket read fails, the reader closes the queue sender. The
+  applier sees `Recv(Disconnected)`, finishes any in-queue frames if
+  it can, and returns. The reader returns the I/O error.
+- If both fail, the reader's I/O error wins (it is the proximate
+  cause; the apply error is logged at `debug!` level for diagnosis).
+
+`oneshot` here is `crossbeam-channel::bounded(1)`, not the tokio
+oneshot, to keep the applier sync.
+
+The `SshChildHandle::Drop` reaping behaviour from
+`crates/rsync_io/src/ssh/connection.rs:492` is unchanged; the
+applier's lifetime is strictly nested inside the
+`SshConnection`'s, so child process cleanup runs after both threads
+have joined.
+
+### 5.5 Cancellation
+
+The reader is cancelled by closing the queue sender. The applier is
+cancelled by closing the queue receiver (which the reader can do by
+dropping its `Sender`) or by the applier itself checking a
+cooperative cancellation token between frames. The umbrella eval
+section 3.3 risk 2 (`spawn_blocking` cancellation gap) does not apply
+here because both threads are plain `std::thread`; the reader's
+ownership of the queue sender is the cancellation token.
+
+When `ssh-async-default-linux.md` flips the reader to an async task,
+the applier remains a `spawn_blocking` task that checks a
+`CancellationToken` (`tokio_util::sync::CancellationToken`) at each
+queue pop. The migration plan R7 cancellation-discipline rule
+applies; the applier checks the token between frames.
+
+## 6. Five-step implementation plan
+
+1. **Land the `DemuxedFrame` type and the queue plumbing.** Add the
+   bounded queue and the applier thread, but route both ends from
+   the existing sync receiver: the reader stays
+   `crates/rsync_io/src/ssh/connection.rs` style, the applier is a
+   new `std::thread::spawn` in
+   `crates/core/src/client/remote/`. Gate: the existing interop
+   suite (`tools/ci/run_interop.sh`) passes with the split active
+   and the default queue depth.
+
+2. **Wire MSG_DATA dispatch first; control messages stay inline.**
+   The applier only handles `MSG_DATA`; other tags are still
+   processed on the reader thread immediately on demux. Gate: a
+   delta-apply micro-bench cell added to
+   `crates/engine/benches/` shows no regression vs the unsplit path
+   on the LAN-loopback row, and a bench on a 100 ms RTT shaped link
+   shows the predicted 8 - 12% win.
+
+3. **Move control messages onto the queue.** All `MSG_*` tags go
+   through the queue; the applier dispatches by tag. Gate: golden
+   ordering tests in `crates/protocol/tests/golden/` for an
+   interleaved `MSG_INFO` + `MSG_DATA` stream show the applier emits
+   them in original order.
+
+4. **Tune the queue depth and add the env-var knob.** Default depth
+   = 4 (rationale in section 4.2). Add `OC_RSYNC_SSH_QUEUE_DEPTH`
+   env var as an internal override during the rollout. Gate: bench
+   sweep on `[1, 2, 4, 8, 16]` queue depths picks 4 as the wall-clock
+   knee on the high-RTT row without exceeding the memory budget on
+   the worst-case literal-frame row.
+
+5. **Integrate with #1892's `--ssh-max-in-flight-bytes` flag.**
+   Replace `OC_RSYNC_SSH_QUEUE_DEPTH` with the user-facing flag
+   that derives queue depth from `max_bytes / typical_frame_size`,
+   with the floor described in #1892's "failure modes" section
+   (`max(N, MAX_FRAME_SIZE)`). Gate: the trigger-condition matrix
+   in `ssh-async-default-linux.md` section 3 is updated to include
+   this design as a prerequisite for trigger C.
+
+The five steps land in separate PRs. Steps 1 - 3 can land before
+the async transport flip; step 4 is the bench-driven tuning; step
+5 lands together with #1892.
+
+## 7. Trigger conditions
+
+This design lands when all hold:
+
+- **Trigger 1**: the umbrella eval's recommendation has shipped
+  (`AsyncSshConnection` from #1806). The split makes the most
+  sense alongside an async reader; landing it on the sync path is
+  still net positive but harder to justify against the extra
+  thread cost.
+- **Trigger 2**: the bench cell in section 6 step 2 shows the
+  high-RTT row beats unsplit by `>= 8%` wall clock. If the win is
+  smaller, the extra thread is not justified; the design is
+  shelved.
+- **Trigger 3**: the ordering goldens in section 6 step 3 pass on
+  all three CI platforms. Cross-platform thread scheduling
+  differences must not perturb tag interleaving.
+- **Trigger 4**: the rayon pool or shared blocking pool option for
+  daemon fan-out (section 4.1) is sized correctly; the daemon
+  bench from `daemon-tokio-async-listener-impl.md` shows no
+  thread-pool exhaustion at the target fan-out.
+
+If trigger 2 fails, the design is shelved and `connection.rs` stays
+single-threaded on the receive side. If triggers 3 or 4 fail, the
+design lands but with `default-features = ["sync-applier"]` until
+the failure is resolved.
+
+## 8. Open questions deferred to implementation
+
+- Whether the applier thread should be a `crossbeam_utils::thread::scope`
+  scoped thread or a long-lived `std::thread::spawn`. Probably scoped
+  for join discipline; verify at step 1.
+- Whether the frame-pool slice optimisation (section 5.1 v2) is worth
+  the complexity. Defer to bench data from step 4.
+- How the design interacts with `--inplace`. The applier writes to
+  the basis file directly under `--inplace`; the SPSC pipeline path
+  is bypassed. The split is orthogonal but the bench matrix in step
+  4 must include an `--inplace` row.

--- a/docs/design/ssh-explicit-backpressure-controls.md
+++ b/docs/design/ssh-explicit-backpressure-controls.md
@@ -1,0 +1,366 @@
+# SSH Transport: Explicit Backpressure Controls
+
+Tracking issue: #1892. Followup to `docs/design/ssh-transport-async-io-eval.md`
+(the umbrella eval), `ssh-async-default-linux.md` (#1890), and
+`ssh-decouple-delta-from-socket-read.md` (#1891). This document
+specifies the user-visible knob (`--ssh-max-in-flight-bytes`) and the
+internal mechanism that enforces it.
+
+## 1. Why an explicit knob
+
+The umbrella eval and #1891 together leave back-pressure implicit:
+
+- Network -> reader: kernel TCP receive window and pipe buffer.
+- Reader -> applier: bounded `crossbeam-channel` queue at the
+  multiplex-demux output (#1891 section 5.2).
+- Applier -> disk: SPSC pipeline
+  (`crates/transfer/src/pipeline/spsc.rs`).
+
+All three are sized by defaults baked at compile time. The umbrella
+eval's hybrid recommendation gives the SSH transport a tokio runtime
+on Linux; the runtime amortises the buffering across many concurrent
+connections in the daemon shape (option (a)). On the daemon, the sum
+of per-connection in-flight buffers is the metric that matters:
+operators want a cap on total transport memory, not on each
+connection separately.
+
+`--ssh-max-in-flight-bytes=N` is that cap, per connection. It is the
+single number that sets:
+
+- The reader -> applier queue depth derived from #1891 section 5.2.
+- The multiplex writer's outstanding-bytes ceiling on the *send*
+  side.
+- The advisory hint published to the bench harness so trigger C in
+  `ssh-async-default-linux.md` section 3.3 can be measured.
+
+Without an explicit knob, the only path to tune memory pressure is
+recompilation. With the knob, an operator can shrink memory at the
+cost of throughput (small N) or accept more memory for higher
+high-RTT throughput (large N) without rebuilding.
+
+## 2. CLI surface
+
+```
+--ssh-max-in-flight-bytes=N
+```
+
+Accepts `N` in the same suffix grammar as
+`--max-size` and `--min-size` (bytes, optional `K`/`M`/`G` suffix).
+Default value: `4M` (4 MiB). Rationale in section 4 below.
+
+Alias env var: `OC_RSYNC_SSH_MAX_IN_FLIGHT_BYTES=N`. Matches the
+existing `OC_RSYNC_SSH_NET` convention from
+`crates/rsync_io/src/ssh/connect.rs:446`.
+
+CLI flag wins over env var. Both default to `4M`.
+
+The flag is feature-gated on `async-ssh` because the back-pressure
+machinery is part of the async transport (the sync transport
+back-pressures on socket reads, with no separate buffer to size).
+Without `async-ssh`, passing the flag prints a warning and is
+ignored; the warning text names the feature.
+
+Documented in:
+
+- `crates/cli/src/frontend/arguments/parsed_args/mod.rs` alongside
+  the existing `--ssh-*` flags (lines 559 - 580).
+- `xtask/src/commands/docs/` man-page generator.
+
+## 3. Internal: counting semaphore at the multiplex writer
+
+The mechanism is a counting semaphore that tracks "bytes outstanding
+on the wire and in transport-side buffers". The cap is N. Three
+sites consume from the semaphore; one releases.
+
+Consumers:
+
+1. **Multiplex writer enqueue**. Before
+   `MultiplexWriter::write_frame` issues the underlying
+   `AsyncWrite::write_all`, it `acquire`s `frame.len()` permits. If
+   fewer than `frame.len()` permits are available, the write parks
+   on the semaphore. This back-pressures the upstream rsync sender
+   via the SSH pipe / TCP receive window.
+
+2. **Reader -> applier queue at the receiving side** (#1891).
+   `frame.len()` permits acquired when the frame is enqueued, held
+   until the applier finishes processing and the bytes are committed
+   to disk (or released to the SPSC pipeline if the SPSC ownership
+   transfer is the commitment point).
+
+3. **In-flight bytes inside the SPSC pipeline**. If the SPSC slot
+   currently in the disk-commit thread's hand carries bytes that
+   were originally counted against the semaphore, those bytes
+   remain in-flight until written. The SPSC implementation owns the
+   release point.
+
+Releases:
+
+- After `MultiplexWriter::write_frame` completes the underlying
+  `write_all`, it releases `frame.len()` permits.
+- After the applier dispatches a `MSG_DATA` frame and the bytes are
+  either committed to disk or transferred to the SPSC pipeline
+  (whichever is the agreed boundary), it releases `frame.len()`
+  permits.
+
+```rust
+struct InFlightSemaphore {
+    /// Total permits. Equal to --ssh-max-in-flight-bytes.
+    capacity: usize,
+    /// Permits available.
+    available: tokio::sync::Semaphore,
+}
+
+impl InFlightSemaphore {
+    fn new(capacity: usize) -> Self {
+        Self {
+            capacity,
+            available: tokio::sync::Semaphore::new(capacity),
+        }
+    }
+
+    async fn acquire(&self, bytes: usize) -> InFlightPermit {
+        let bytes = bytes.min(self.capacity);
+        let permit = self.available.acquire_many(bytes as u32).await
+            .expect("semaphore never closed");
+        InFlightPermit { _permit: permit }
+    }
+}
+
+struct InFlightPermit {
+    _permit: tokio::sync::SemaphorePermit<'_>,
+}
+// Dropping the permit releases the bytes.
+```
+
+`tokio::sync::Semaphore` chosen because the multiplex writer is
+async; the applier consumes via a sync facade
+(`Handle::current().block_on(sem.acquire(...))` is forbidden by
+migration plan R3; instead the applier accepts permits handed off
+from the reader thread, where the reader thread - already async
+under #1890 - acquires them).
+
+A purely sync alternative is `crossbeam-utils::sync::WaitGroup` or
+a plain `std::sync::Mutex<usize>` plus `Condvar`; rejected because
+the multiplex writer side is async by the time this design ships
+(after #1890 flips the Linux default).
+
+### 3.1 Daemon vs CLI scope
+
+On the daemon (umbrella eval option (a)), each `SshConnection`
+owns its own `InFlightSemaphore`. The flag value applies *per
+connection*. The daemon operator wanting a process-wide cap
+multiplies by the expected fan-out; this design does not add a
+process-wide cap because the operator's natural cap is the
+listener's connection limit
+(`daemon-tokio-async-listener-impl.md`).
+
+On the CLI (umbrella eval option (b)), one connection per
+invocation; the flag is the process cap.
+
+## 4. Default value: 4 MiB
+
+The 4 MiB default is picked to match typical TCP window-scaled
+receive buffer sizes on modern Linux:
+
+- Linux default `net.core.rmem_default` is 208 KiB; `rmem_max` is
+  4 MiB on most stock kernels. With TCP window scaling, the
+  per-socket receive buffer reaches that ceiling under bandwidth
+  pressure.
+- 4 MiB also matches the kernel pipe buffer ceiling reachable
+  via `fcntl(F_SETPIPE_SZ)` without `CAP_SYS_RESOURCE`.
+
+Setting the semaphore equal to the typical TCP receive buffer
+sizes the in-flight bytes envelope to one "network round" of data:
+enough to saturate the BDP on a typical link (1 Gbps * 30 ms = 3.75
+MiB, just under 4 MiB), without absorbing more than the kernel
+already buffers per-socket.
+
+For the high-RTT trigger row (`SLOW_LINK_NS_PER_BYTE = 200`,
+~50 ms RTT) the BDP is small (1 Mbps * 50 ms = 6.25 KiB);
+4 MiB is comfortably enough.
+
+For the fan-out daemon row (100 concurrent connections), the
+aggregate in-flight cap is 400 MiB. Operators concerned about
+that aggregate can shrink the per-connection cap to e.g. 1 MiB
+without losing performance on individual high-RTT transfers
+(the BDP fits in 1 MiB on most links of interest).
+
+## 5. Interaction with #1891 queue depth
+
+The reader -> applier queue from #1891 section 5.2 is one
+component of the in-flight bytes envelope. Translation:
+
+```
+queue_depth = max(1, max_in_flight_bytes / typical_frame_size)
+```
+
+where `typical_frame_size = MplexWriter::DEFAULT_MAX_FRAME_SIZE =
+8192` (from `crates/protocol/src/multiplex/writer.rs:88`).
+
+With the 4 MiB default, queue depth = `4 * 1024 * 1024 / 8192 =
+512` frames. This is much larger than the default depth of 4 from
+#1891 section 4.2; the two are reconciled as follows.
+
+The queue depth in #1891 is a *count* bound. The semaphore here is
+a *byte* bound. The applier respects both: it dequeues when the
+queue has an entry, but the *write* / *apply* commits release
+semaphore permits in byte units. A 16 MiB literal frame consumes
+16 MiB of semaphore permits regardless of queue depth.
+
+The combined bound is: at most `min(queue_depth, ceil(N / 1)) =
+queue_depth` *frames* in flight, summing to at most `N` *bytes*.
+The semaphore is the strict bound; the queue is a smaller
+capacity bound that prevents pathological per-frame fragmentation.
+
+For implementation, the queue from #1891 step 4 (configurable
+depth) becomes a derived value of `N`. Operators set `N`; queue
+depth follows.
+
+## 6. Failure modes
+
+### 6.1 Deadlock when N is smaller than one frame
+
+A frame larger than N can never acquire its permits and blocks the
+reader thread forever. The applier, waiting on the queue, also
+blocks forever. Classic deadlock.
+
+The multiplex protocol allows frames up to
+`MAX_PAYLOAD_LENGTH = 16 MiB` (from
+`crates/protocol/src/envelope/constants.rs:5`). Setting
+N < 16 MiB risks the deadlock on any frame that uses the full
+payload.
+
+**Mitigation**: enforce `effective_N = max(user_N, MAX_PAYLOAD_LENGTH)`
+at config-build time. The user's CLI value is preserved for logging
+purposes; the semaphore is sized to `effective_N`.
+
+The CLI parser logs a warning when `user_N < MAX_PAYLOAD_LENGTH`:
+
+```
+warning: --ssh-max-in-flight-bytes=N is below the multiplex max
+frame size (16M). The effective cap is 16M; small frames will
+still observe N-sized back-pressure on the cumulative inflight.
+```
+
+The wording explicitly says "the effective cap is 16M" so an
+operator who set `--ssh-max-in-flight-bytes=512K` understands
+that a single 8 MiB literal frame will still pass through.
+
+### 6.2 Permit leak under panic
+
+If the applier panics mid-frame, the `InFlightPermit` is dropped
+and the permits are released. No leak. Verified by a panic-isolation
+test (similar to the rayon bridge discipline named in
+`tokio-spawn-blocking-rayon.md`).
+
+If the reader panics with permits held, the same Drop logic
+releases. The applier sees `Recv(Disconnected)` on the queue and
+exits cleanly.
+
+### 6.3 Cancellation during permit hold
+
+Tokio's `Semaphore::acquire_many` future is cancel-safe. If the
+async reader task is cancelled mid-acquire, no permits are taken.
+If cancelled after acquire but before release, the `InFlightPermit`
+drops on cancellation cleanup and releases the permits.
+
+The umbrella eval section 3.3 risk 2 (`spawn_blocking` cancellation
+gap) does not apply because the applier on the sync side holds
+permits handed off by the reader, not acquired directly. The
+reader's cancellation propagates by dropping the permit before the
+applier sees it.
+
+### 6.4 N = 0 or negative
+
+The CLI parser rejects `N <= 0` with an exit-code-1 argument error.
+Section 6.1's mitigation kicks in for any positive N below
+`MAX_PAYLOAD_LENGTH`.
+
+### 6.5 Memory-pressure cascade
+
+When N is set very small (e.g. 64 KiB), section 6.1 raises
+`effective_N` to 16 MiB and back-pressure becomes loose. Operators
+who genuinely need tighter memory caps must address it at a higher
+layer (`ulimit`, cgroups), not via this flag. The warning in 6.1
+makes this clear.
+
+## 7. Five-step implementation plan
+
+1. **Add the CLI flag and env var.** Plumb
+   `--ssh-max-in-flight-bytes=N` and
+   `OC_RSYNC_SSH_MAX_IN_FLIGHT_BYTES=N` through
+   `crates/cli/src/frontend/arguments/` into `CoreConfig`. Default
+   `4 * 1024 * 1024`. Gate: a parser test for the suffix grammar
+   and a precedence test (CLI > env > default).
+
+2. **Implement `InFlightSemaphore` in `rsync_io`.** Add the type
+   from section 3 to a new module
+   `crates/rsync_io/src/ssh/inflight.rs`. Gate: unit tests for
+   acquire / release / drop, plus a panic-isolation test that
+   confirms permits are returned when the holder panics.
+
+3. **Wire the semaphore into the multiplex writer.** Hook
+   `InFlightSemaphore::acquire` into
+   `MultiplexWriter::write_frame`. Release on completion. Gate: an
+   integration test sends a 16 MiB frame through a 4 MiB-capped
+   writer and confirms the effective cap rises to 16 MiB (per
+   section 6.1). A second test confirms two concurrent 2 MiB frames
+   serialise through a 3 MiB cap.
+
+4. **Wire the semaphore into the #1891 reader -> applier path.**
+   The reader acquires permits on dequeue from the SSH read and
+   hands them to the applier alongside the frame. Applier releases
+   on apply completion. Gate: a memory cap test confirms that
+   sustained 16 MiB literal frames keep the resident bytes under
+   `effective_N + slack` (slack = one frame for the in-flight
+   acquire).
+
+5. **Derive #1891's queue depth from the flag and document the
+   interaction.** Replace the standalone `OC_RSYNC_SSH_QUEUE_DEPTH`
+   env var from #1891 step 4 with the derivation in section 5.
+   Update `ssh-async-default-linux.md` section 3.3 trigger C to
+   measure the bench with the default `--ssh-max-in-flight-bytes=4M`.
+   Gate: a bench sweep over `[1M, 4M, 16M, 64M]` confirms 4 MiB is
+   the wall-clock knee on the high-RTT trigger row, with smaller
+   values losing throughput and larger values not adding measurable
+   wins.
+
+Steps 1 - 2 can land before #1891. Steps 3 - 4 require #1891 to be
+in. Step 5 lands together with the bench-driven decision in
+`ssh-async-default-linux.md` step 4.
+
+## 8. Trigger conditions
+
+This design lands when all hold:
+
+- **Trigger 1**: #1891's reader -> applier split has shipped (or
+  ships in the same PR series). The semaphore is most useful when
+  it scopes both the writer and the receiver-side queue; landing
+  it on the writer alone is half the win.
+- **Trigger 2**: the bench in step 5 confirms 4 MiB is the
+  reasonable default. If the bench picks a different knee (e.g.
+  the high-RTT trigger row wants 16 MiB), the default changes; the
+  flag's existence does not.
+- **Trigger 3**: no platform regression in the queue derivation
+  on macOS / Windows once the async transport ships there.
+  Until then, the flag is honoured on Linux only (matching
+  `ssh-async-default-linux.md`); on other platforms it is parsed,
+  logged, and ignored.
+
+If trigger 2 picks a much larger default (>= 64 MiB), revisit
+section 4: the rationale stops matching the kernel TCP buffer
+sizing and the design's premise (couple the cap to one BDP)
+needs restating. Likely the bench shows the BDP argument holds
+and the default lands within an order of magnitude of 4 MiB.
+
+## 9. Open questions deferred to implementation
+
+- Whether the flag should accept `--ssh-max-in-flight-bytes=0`
+  to mean "unbounded" (i.e. only the kernel buffers apply). Rejected
+  in this design (section 6.4); revisit if operators request it.
+- Whether the daemon should expose an aggregate cap across all
+  connections. Defer to a separate design once the per-connection
+  cap is shipped and operator feedback names the need.
+- Whether the bytes accounted include the multiplex 4-byte header.
+  Lean towards yes (the header occupies pipe-buffer bytes too); the
+  step 3 PR resolves on review.


### PR DESCRIPTION
## Summary

Three followup design notes to the umbrella `docs/design/ssh-transport-async-io-eval.md`. Each lands a separate concern flagged in that eval but deferred from it. Bundled into one PR for review economy.

- **`docs/design/ssh-async-default-linux.md` (#1890)** - when and how to flip the Linux SSH transport default from sync to async. Names the cfg/feature gate, the `OC_RSYNC_SSH_ASYNC=0` escape hatch, the 5 measurable trigger conditions (async daemon stable, embedded russh parity, SSH-async bench wins, runtime-flavour comparison, bridge-cost probe), and the 5-step rollout with per-step gates.
- **`docs/design/ssh-decouple-delta-from-socket-read.md` (#1891)** - split the SSH socket reader from the delta applier via a bounded `crossbeam-channel` queue. Specifies `DemuxedFrame { tag, payload }`, the single-FIFO ordering rule for `MSG_DATA` vs `MSG_INFO`, the oneshot error channel, default queue depth = 4, and the 5-step plan that lands MSG_DATA dispatch before control messages.
- **`docs/design/ssh-explicit-backpressure-controls.md` (#1892)** - the `--ssh-max-in-flight-bytes=N` CLI flag plus `OC_RSYNC_SSH_MAX_IN_FLIGHT_BYTES` env var, implemented as a `tokio::sync::Semaphore` at the multiplex writer and the #1891 reader-to-applier queue. Default 4 MiB to match the typical TCP receive buffer / BDP. Pins the `max(N, MAX_PAYLOAD_LENGTH)` floor that prevents single-frame deadlock, and ties queue depth to `N / typical_frame_size`.

Each doc carries a 5-step impl plan and a trigger-condition section. No code changes.

## Test plan

- [ ] CI: workflows (no compile / no test impact; docs-only change).
- [ ] `cargo fmt --all --check` clean.
- [ ] No references to forbidden terms in the new files.
- [ ] Cross-links between the three docs and back to the umbrella eval resolve.