### PR TITLE
bench(engine): parallel-deterministic-delete pipeline perf (#2282, #2283, #2284)

### DIFF
--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -178,3 +178,15 @@ harness = false
 [[bench]]
 name = "delete_plan_map_contention"
 harness = false
+
+[[bench]]
+name = "delete_plan_compute"
+harness = false
+
+[[bench]]
+name = "delete_emitter_unlink"
+harness = false
+
+[[bench]]
+name = "delete_end_to_end"
+harness = false

--- a/crates/engine/benches/delete_emitter_unlink.rs
+++ b/crates/engine/benches/delete_emitter_unlink.rs
@@ -1,0 +1,117 @@
+//! Criterion micro-benchmark: emitter dispatch overhead at scale.
+//!
+//! # Why this exists
+//!
+//! Task DDP-I2 (#2283). `engine::delete::DeleteEmitter::emit_all` is
+//! the single-threaded drain that consumes a pre-populated
+//! `DeletePlanMap` in `DirTraversalCursor` order, issuing one
+//! `DeleteFs` call per planned entry. The pipeline assumes the
+//! emitter's dispatch overhead is negligible relative to the kernel's
+//! `unlink(2)` cost; this bench measures the dispatch path in
+//! isolation by routing every call through `RecordingDeleteFs`, which
+//! never touches disk.
+//!
+//! Together with `delete_plan_compute.rs` (DDP-I1, #2282) and
+//! `delete_end_to_end.rs` (DDP-I3, #2284), this feeds the DDP-F3
+//! decision: if the end-to-end pipeline stays within 5% of the legacy
+//! batched sweep, the legacy `handle_post_transfer_deletions` code
+//! path can be removed.
+//!
+//! # Workloads (Criterion group `delete_emitter_unlink`)
+//!
+//! - `emit_all/10k_extras_100_dirs`
+//! - `emit_all/100k_extras_100_dirs`
+//! - `emit_all/1M_extras_100_dirs`
+//!
+//! Each iteration rebuilds a fresh `DeletePlanMap`, `DirTraversalCursor`,
+//! and `DeleteEmitter`, then drives `emit_all` to completion. Map and
+//! plan construction live outside the timed section via
+//! `iter_batched`. The bench captures pure dispatch overhead, not
+//! disk I/O.
+//!
+//! Run: `cargo bench -p engine --bench delete_emitter_unlink`
+
+#![deny(unsafe_code)]
+#![cfg(unix)]
+
+use std::ffi::OsString;
+use std::path::PathBuf;
+
+use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+
+use engine::delete::{
+    DeleteEmitter, DeleteEntry, DeleteEntryKind, DeletePlan, DeletePlanMap, DirTraversalCursor,
+    RecordingDeleteFs,
+};
+use protocol::flist::FileEntry;
+
+/// Number of directories the fixture spreads extras across.
+const DIR_COUNT: usize = 100;
+
+/// Scales swept by the bench. Each value is the total number of extras
+/// across all directories.
+const SCALES: &[(&str, usize)] = &[
+    ("10k_extras_100_dirs", 10_000),
+    ("100k_extras_100_dirs", 100_000),
+    ("1M_extras_100_dirs", 1_000_000),
+];
+
+/// Builds a pre-populated `DeletePlanMap` and a primed cursor for the
+/// given total extras spread across `DIR_COUNT` directories.
+///
+/// Each directory `root/d{i}` carries `total / DIR_COUNT` plain file
+/// extras. The cursor is observed for the root so it yields every
+/// directory in upstream order before `emit_all` is invoked.
+fn build_inputs(total_extras: usize) -> (DeletePlanMap, DirTraversalCursor) {
+    let per_dir = total_extras / DIR_COUNT;
+    let plans = DeletePlanMap::with_capacity(DIR_COUNT + 1);
+    plans.insert(DeletePlan::new(PathBuf::from("root")));
+
+    let mut children = Vec::with_capacity(DIR_COUNT);
+    for d in 0..DIR_COUNT {
+        let dir = PathBuf::from(format!("root/d{d:03}"));
+        let mut plan = DeletePlan::new(dir.clone());
+        for n in 0..per_dir {
+            plan.push(DeleteEntry::new(
+                OsString::from(format!("f{n:07}.dat")),
+                DeleteEntryKind::File,
+            ));
+        }
+        plans.insert(plan);
+        children.push(FileEntry::new_directory(dir, 0o755));
+    }
+
+    let mut cursor = DirTraversalCursor::new(PathBuf::from("root"));
+    cursor.observe_segment(PathBuf::from("root"), &children);
+    // Each child dir has no further descendants in this fixture.
+    for d in 0..DIR_COUNT {
+        let dir = PathBuf::from(format!("root/d{d:03}"));
+        cursor.observe_segment(dir, &[]);
+    }
+    (plans, cursor)
+}
+
+fn bench_emit_all(c: &mut Criterion) {
+    let mut group = c.benchmark_group("delete_emitter_unlink");
+
+    for &(label, total_extras) in SCALES {
+        group.throughput(Throughput::Elements(total_extras as u64));
+        let id = BenchmarkId::new("emit_all", label);
+        group.bench_function(id, |b| {
+            b.iter_batched(
+                || build_inputs(total_extras),
+                |(plans, cursor)| {
+                    let mut emitter = DeleteEmitter::new(RecordingDeleteFs::new(), plans, cursor);
+                    emitter.emit_all().expect("emit_all succeeds");
+                    std::hint::black_box(emitter.stats());
+                },
+                BatchSize::LargeInput,
+            );
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_emit_all);
+criterion_main!(benches);

--- a/crates/engine/benches/delete_end_to_end.rs
+++ b/crates/engine/benches/delete_end_to_end.rs
@@ -1,0 +1,225 @@
+//! Criterion bench: end-to-end parallel-deterministic delete pipeline
+//! vs the legacy single-threaded batched sweep.
+//!
+//! # Why this exists
+//!
+//! Task DDP-I3 (#2284). Together with `delete_plan_compute.rs`
+//! (DDP-I1, #2282) and `delete_emitter_unlink.rs` (DDP-I2, #2283),
+//! this bench feeds the DDP-F3 (batched sweep removal) decision: if
+//! the new pipeline lands within 5% of the legacy path on a realistic
+//! 100K-file shape, the legacy `handle_post_transfer_deletions` code
+//! in `crates/engine/src/local_copy/executor/directory/recursive/`
+//! can be retired safely.
+//!
+//! # Two paths under test
+//!
+//! - **Parallel deterministic delete** (`parallel_deterministic_delete_during_100k_files`):
+//!   phase 1 runs `engine::delete::compute_extras` across every
+//!   directory in a rayon scope (parallel), builds one
+//!   `DeletePlan` per dir, sorts it, and publishes it into a
+//!   `DeletePlanMap`. Phase 2 runs the single-threaded
+//!   `DeleteEmitter::emit_all`, which routes through `RealDeleteFs`
+//!   and actually unlinks the extras.
+//! - **Legacy batched sweep** (`legacy_batched_delete_during_100k_files`):
+//!   a faithful reproduction of the wall-clock cost model of
+//!   `crates/engine/src/local_copy/executor/directory/recursive/deletion.rs::handle_post_transfer_deletions`
+//!   ->`delete_extraneous_entries` (in
+//!   `crates/engine/src/local_copy/executor/cleanup.rs`). The legacy
+//!   path is `pub(crate)` and threaded through a `CopyContext` that
+//!   cannot be assembled from a bench crate, so this bench reproduces
+//!   its observable algorithm: a single thread visits every
+//!   directory, walks `fs::read_dir`, subtracts the keep set, and
+//!   `fs::remove_file`s each extra in turn. That matches the
+//!   syscalls the production path issues; the only thing missing is
+//!   the `CopyContext` bookkeeping, which contributes a constant
+//!   per-entry overhead independent of the parallel-vs-serial axis
+//!   this bench is comparing.
+//!
+//! # Workload
+//!
+//! 100 directories with 1000 files each (100K files total). 10% of the
+//! files per directory are extras (~10K extras total). The remaining
+//! files are present in the segment / keep set and must survive both
+//! sweeps. Each iteration starts from a freshly populated tempdir so
+//! the two paths see identical filesystem state.
+//!
+//! Run: `cargo bench -p engine --bench delete_end_to_end`
+
+#![deny(unsafe_code)]
+#![cfg(unix)]
+
+use criterion::{BatchSize, Criterion, Throughput, criterion_group, criterion_main};
+use rayon::ThreadPoolBuilder;
+use rayon::prelude::*;
+use std::collections::HashSet;
+use std::ffi::OsString;
+use std::fs::{self, File};
+use std::path::{Path, PathBuf};
+use tempfile::TempDir;
+
+use engine::delete::{
+    DeleteEmitter, DeletePlan, DeletePlanMap, DirTraversalCursor, RealDeleteFs, compute_extras,
+};
+use protocol::flist::FileEntry;
+
+/// Directories per iteration.
+const DIR_COUNT: usize = 100;
+
+/// Files per directory before the sweep.
+const FILES_PER_DIR: usize = 1_000;
+
+/// Fraction of files (per dir) that are extras and should be deleted.
+const EXTRAS_PERCENT: usize = 10;
+
+/// Threads used by the parallel `compute_extras` phase. 8 is the
+/// midpoint of the `delete_plan_compute` sweep and matches the scaling
+/// curve sweet spot most CI hosts can reproduce.
+const PARALLEL_THREADS: usize = 8;
+
+/// One pre-built work item describing one directory's keep set and
+/// destination path.
+struct DirSpec {
+    dest: PathBuf,
+    segment: Vec<FileEntry>,
+    keep: HashSet<OsString>,
+}
+
+/// Builds the on-disk fixture and the per-directory work items.
+///
+/// Each dir gets `FILES_PER_DIR` files. The first
+/// `FILES_PER_DIR * (100 - EXTRAS_PERCENT) / 100` files are listed in
+/// the segment / keep set (and thus survive); the trailing files are
+/// the extras both sweeps must delete.
+fn build_fixture(root_dir: &Path) -> Vec<DirSpec> {
+    let keep_per_dir = FILES_PER_DIR * (100 - EXTRAS_PERCENT) / 100;
+    let mut specs = Vec::with_capacity(DIR_COUNT);
+    for d in 0..DIR_COUNT {
+        let dest = root_dir.join(format!("d{d:03}"));
+        fs::create_dir(&dest).expect("create dest dir");
+        let mut segment = Vec::with_capacity(keep_per_dir);
+        let mut keep = HashSet::with_capacity(keep_per_dir);
+        for f in 0..FILES_PER_DIR {
+            let name = format!("f{f:04}.dat");
+            File::create(dest.join(&name)).expect("create file");
+            if f < keep_per_dir {
+                segment.push(FileEntry::new_file(PathBuf::from(&name), 0, 0o644));
+                keep.insert(OsString::from(&name));
+            }
+        }
+        specs.push(DirSpec {
+            dest,
+            segment,
+            keep,
+        });
+    }
+    specs
+}
+
+/// Runs the new pipeline: parallel `compute_extras` + serial emitter.
+fn run_pipeline(pool: &rayon::ThreadPool, specs: &[DirSpec], root: &Path) {
+    let plans = DeletePlanMap::with_capacity(DIR_COUNT + 1);
+    plans.insert(DeletePlan::new(root.to_path_buf()));
+
+    pool.install(|| {
+        specs.par_iter().for_each(|spec| {
+            let extras = compute_extras(&spec.dest, &spec.segment).expect("compute_extras");
+            let mut plan = DeletePlan::from_extras(spec.dest.clone(), extras);
+            plan.sort_by_name();
+            plans.insert(plan);
+        });
+    });
+
+    // Stage the cursor so it yields every populated directory.
+    let mut cursor = DirTraversalCursor::new(root.to_path_buf());
+    let children: Vec<FileEntry> = specs
+        .iter()
+        .map(|s| FileEntry::new_directory(s.dest.clone(), 0o755))
+        .collect();
+    cursor.observe_segment(root.to_path_buf(), &children);
+    for spec in specs.iter() {
+        cursor.observe_segment(spec.dest.clone(), &[]);
+    }
+
+    let mut emitter = DeleteEmitter::new(RealDeleteFs, plans, cursor);
+    emitter.emit_all().expect("emit_all");
+    std::hint::black_box(emitter.stats());
+}
+
+/// Single-threaded equivalent of the legacy `delete_extraneous_entries`
+/// sweep. Walks every directory in turn, computes the set diff against
+/// the keep set, and removes each extra via `fs::remove_file`. Matches
+/// the syscall shape of the production path
+/// (`crates/engine/src/local_copy/executor/cleanup.rs`) without the
+/// `CopyContext` plumbing the bench cannot assemble.
+fn run_legacy_sweep(specs: &[DirSpec]) {
+    let mut total_removed = 0u64;
+    for spec in specs {
+        let read_dir = fs::read_dir(&spec.dest).expect("read_dir");
+        for entry in read_dir {
+            let entry = entry.expect("dir entry");
+            let name = entry.file_name();
+            if spec.keep.contains(name.as_os_str()) {
+                continue;
+            }
+            let file_type = entry.file_type().expect("file_type");
+            let path = spec.dest.join(&name);
+            if file_type.is_dir() {
+                fs::remove_dir_all(&path).expect("remove_dir_all");
+            } else {
+                fs::remove_file(&path).expect("remove_file");
+            }
+            total_removed += 1;
+        }
+    }
+    std::hint::black_box(total_removed);
+}
+
+fn bench_end_to_end(c: &mut Criterion) {
+    let extras_per_dir = FILES_PER_DIR * EXTRAS_PERCENT / 100;
+    let total_extras = (DIR_COUNT * extras_per_dir) as u64;
+
+    let mut group = c.benchmark_group("delete_end_to_end");
+    group.throughput(Throughput::Elements(total_extras));
+    group.sample_size(20);
+
+    group.bench_function("parallel_deterministic_delete_during_100k_files", |b| {
+        let pool = ThreadPoolBuilder::new()
+            .num_threads(PARALLEL_THREADS)
+            .build()
+            .expect("rayon pool");
+        b.iter_batched(
+            || {
+                let tmp = TempDir::new().expect("tempdir");
+                let specs = build_fixture(tmp.path());
+                (tmp, specs)
+            },
+            |(tmp, specs)| {
+                run_pipeline(&pool, &specs, tmp.path());
+                drop(specs);
+                drop(tmp);
+            },
+            BatchSize::PerIteration,
+        );
+    });
+
+    group.bench_function("legacy_batched_delete_during_100k_files", |b| {
+        b.iter_batched(
+            || {
+                let tmp = TempDir::new().expect("tempdir");
+                let specs = build_fixture(tmp.path());
+                (tmp, specs)
+            },
+            |(tmp, specs)| {
+                run_legacy_sweep(&specs);
+                drop(specs);
+                drop(tmp);
+            },
+            BatchSize::PerIteration,
+        );
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_end_to_end);
+criterion_main!(benches);

--- a/crates/engine/benches/delete_plan_compute.rs
+++ b/crates/engine/benches/delete_plan_compute.rs
@@ -1,0 +1,161 @@
+//! Criterion micro-benchmark: parallel `compute_extras` scaling.
+//!
+//! # Why this exists
+//!
+//! Task DDP-I1 (#2282). `engine::delete::compute_extras` is phase 1 of
+//! the parallel-deterministic-delete pipeline: per directory, list the
+//! destination, subtract the segment's basenames, classify the survivors.
+//! Each call is independent across directories, so the pipeline runs
+//! them through a rayon scope. This bench measures how that scaling
+//! actually looks on a realistic shape (1000 dirs, 100 files per dir,
+//! 50% extras per dir) at 1/4/8/16 threads, and pins the single-thread
+//! baseline next to the sweep so the speedup is unambiguous.
+//!
+//! Together with `delete_emitter_unlink.rs` (DDP-I2, #2283) and
+//! `delete_end_to_end.rs` (DDP-I3, #2284), this feeds the DDP-F3
+//! decision: if the end-to-end pipeline stays within 5% of the legacy
+//! batched sweep, the legacy `handle_post_transfer_deletions` code path
+//! can be removed.
+//!
+//! # Workloads (Criterion group `delete_plan_compute`)
+//!
+//! - `parallel_compute_extras_100k_files_1k_dirs/1_threads`
+//! - `parallel_compute_extras_100k_files_1k_dirs/4_threads`
+//! - `parallel_compute_extras_100k_files_1k_dirs/8_threads`
+//! - `parallel_compute_extras_100k_files_1k_dirs/16_threads`
+//! - `serial_compute_extras_baseline`
+//!
+//! Each iteration walks every dir, runs `compute_extras`, and discards
+//! the result. The fixture is built once per `Criterion::bench_function`
+//! call (held in a `TempDir`) so the timed loop only does work the
+//! pipeline would do.
+//!
+//! Run: `cargo bench -p engine --bench delete_plan_compute`
+
+#![deny(unsafe_code)]
+#![cfg(unix)]
+
+use std::fs::File;
+use std::path::PathBuf;
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use rayon::ThreadPoolBuilder;
+use rayon::prelude::*;
+use tempfile::TempDir;
+
+use engine::delete::compute_extras;
+use protocol::flist::FileEntry;
+
+/// Number of synthetic directories built by the fixture.
+const DIR_COUNT: usize = 1_000;
+
+/// Number of entries created per directory. Each dir ends up with this
+/// many files on disk.
+const FILES_PER_DIR: usize = 100;
+
+/// Fraction of on-disk entries (per directory) that are *not* present in
+/// the segment, i.e. extras. With `FILES_PER_DIR = 100` and a 50%
+/// extras ratio the fixture exposes 50 extras per dir, ~50k extras
+/// total across the 1000 dirs.
+const EXTRAS_PERCENT: usize = 50;
+
+/// Thread counts swept for the parallel compute_extras workload.
+const THREAD_COUNTS: &[usize] = &[1, 4, 8, 16];
+
+/// One pre-built per-directory work item: the dest dir path and the
+/// matching flist segment (the files that should *not* be deleted).
+struct DirWorkItem {
+    dest: PathBuf,
+    segment: Vec<FileEntry>,
+}
+
+/// Builds a synthetic fixture rooted at `root_dir`.
+///
+/// For each of `DIR_COUNT` subdirectories we create `FILES_PER_DIR`
+/// regular files on disk and emit a segment listing the
+/// `(100 - EXTRAS_PERCENT)%` files that should be retained. The
+/// resulting `DirWorkItem` slice is exactly what the segment-dispatch
+/// phase of the pipeline would feed `compute_extras`.
+fn build_fixture(root_dir: &std::path::Path) -> Vec<DirWorkItem> {
+    let mut items = Vec::with_capacity(DIR_COUNT);
+    let keep_per_dir = FILES_PER_DIR * (100 - EXTRAS_PERCENT) / 100;
+    for d in 0..DIR_COUNT {
+        let dest = root_dir.join(format!("d{d:04}"));
+        std::fs::create_dir(&dest).expect("create dest dir");
+        let mut segment = Vec::with_capacity(keep_per_dir);
+        for f in 0..FILES_PER_DIR {
+            let name = format!("f{f:03}.dat");
+            File::create(dest.join(&name)).expect("create file");
+            if f < keep_per_dir {
+                segment.push(FileEntry::new_file(PathBuf::from(&name), 0, 0o644));
+            }
+        }
+        items.push(DirWorkItem { dest, segment });
+    }
+    items
+}
+
+/// Runs `compute_extras` across every dir in the fixture sequentially.
+fn run_serial(items: &[DirWorkItem]) {
+    for item in items {
+        let extras = compute_extras(&item.dest, &item.segment).expect("compute_extras");
+        // Touch the result so the optimizer cannot elide the work.
+        std::hint::black_box(extras);
+    }
+}
+
+/// Runs `compute_extras` across every dir in the fixture in parallel
+/// via the supplied rayon pool.
+fn run_parallel(pool: &rayon::ThreadPool, items: &[DirWorkItem]) {
+    pool.install(|| {
+        items.par_iter().for_each(|item| {
+            let extras = compute_extras(&item.dest, &item.segment).expect("compute_extras");
+            std::hint::black_box(extras);
+        });
+    });
+}
+
+fn bench_serial_baseline(c: &mut Criterion) {
+    let mut group = c.benchmark_group("delete_plan_compute");
+    let total_files = (DIR_COUNT * FILES_PER_DIR) as u64;
+    group.throughput(Throughput::Elements(total_files));
+
+    group.bench_function("serial_compute_extras_baseline", |b| {
+        let tmp = TempDir::new().expect("tempdir");
+        let items = build_fixture(tmp.path());
+        b.iter(|| run_serial(&items));
+    });
+
+    group.finish();
+}
+
+fn bench_parallel_sweep(c: &mut Criterion) {
+    let mut group = c.benchmark_group("delete_plan_compute");
+    let total_files = (DIR_COUNT * FILES_PER_DIR) as u64;
+    group.throughput(Throughput::Elements(total_files));
+
+    for &threads in THREAD_COUNTS {
+        let id = BenchmarkId::new(
+            "parallel_compute_extras_100k_files_1k_dirs",
+            format!("{threads}_threads"),
+        );
+        group.bench_function(id, |b| {
+            let pool = ThreadPoolBuilder::new()
+                .num_threads(threads)
+                .build()
+                .expect("rayon pool");
+            let tmp = TempDir::new().expect("tempdir");
+            let items = build_fixture(tmp.path());
+            b.iter(|| run_parallel(&pool, &items));
+            // Keep `tmp` alive across the iter loop above; drop here so
+            // the fixture is torn down before the next bench cell runs.
+            drop(items);
+            drop(tmp);
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_serial_baseline, bench_parallel_sweep);
+criterion_main!(benches);


### PR DESCRIPTION
## Summary

Adds three criterion benches for the parallel-deterministic-delete (DDP) pipeline and registers the matching `[[bench]]` entries in `crates/engine/Cargo.toml`. Numbers from these three feed the DDP-F3 (batched-sweep removal) go/no-go check: if the end-to-end pipeline lands within 5% of the legacy single-threaded sweep, the legacy `handle_post_transfer_deletions` code path can be retired safely.

- **`delete_plan_compute`** (#2282) - phase-1 `compute_extras` scaling.
  - `parallel_compute_extras_100k_files_1k_dirs/{1,4,8,16}_threads`: 1000 dirs * 100 files-per-dir fixture with 50% extras per dir, driven through a rayon pool sized to the swept thread count.
  - `serial_compute_extras_baseline`: the same workload single-threaded for a direct speedup ratio.
- **`delete_emitter_unlink`** (#2283) - phase-2 `DeleteEmitter::emit_all` dispatch overhead.
  - `emit_all/{10k,100k,1M}_extras_100_dirs`: pre-populates a `DeletePlanMap`, primes the `DirTraversalCursor`, and times `emit_all` routed through `RecordingDeleteFs`. The recorder never touches disk, so the measurement isolates dispatch cost from kernel `unlink(2)` cost.
- **`delete_end_to_end`** (#2284) - full pipeline vs legacy sweep on a 100K-file tempdir with 10% extras.
  - `parallel_deterministic_delete_during_100k_files`: parallel `compute_extras` (8 threads) + serial emitter via `RealDeleteFs`.
  - `legacy_batched_delete_during_100k_files`: single-threaded read-dir-then-unlink sweep that mirrors the syscall shape of `crates/engine/src/local_copy/executor/cleanup.rs::delete_extraneous_entries`. The production helper is `pub(crate)` and threaded through a `CopyContext` that cannot be assembled from a bench crate; the bench reproduces its observable algorithm so the wall-clock comparison stays apples-to-apples on the variable that actually matters (parallel vs serial).

All three bench files start with `#![cfg(unix)]` to match the `criterion` dev-dep gating already in place for the engine crate. No new dev-dependencies were added.

## Test plan

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings`
- [ ] `cargo bench -p engine --bench delete_plan_compute -- --quick` smoke run
- [ ] `cargo bench -p engine --bench delete_emitter_unlink -- --quick` smoke run
- [ ] `cargo bench -p engine --bench delete_end_to_end -- --quick` smoke run
- [ ] CI fmt+clippy, nextest (stable), Windows, macOS, Linux musl all green