### PR TITLE
feat(engine): hardlink-aware delete via CohortIndex snapshot (#2264)

### DIFF
--- a/crates/engine/src/delete/cohort_index.rs
+++ b/crates/engine/src/delete/cohort_index.rs
@@ -1,0 +1,449 @@
+//! Read-only hardlink-cohort snapshot consumed by the delete pipeline.
+//!
+//! [`CohortIndex`] is the Option A artefact from
+//! `docs/design/hardlink-delete-audit.md` section 7.1. It is built once per
+//! INC_RECURSE segment from a frozen `&[FileEntry]` slice, wrapped in an
+//! [`std::sync::Arc`], and shared by reference across all phase-1
+//! [`super::compute_extras_with_cohorts`] workers and the single phase-2
+//! [`super::DeleteEmitter`]. The index is immutable for its lifetime: the
+//! "phase-1 workers are pure readers" invariant is encoded in the type
+//! system rather than enforced by discipline.
+//!
+//! # What it tracks
+//!
+//! For each source-side hardlink cohort visible in the segment, the index
+//! records:
+//!
+//! - a stable [`super::HardlinkCohortId`] (the leader's wire NDX);
+//! - the source-side basename of every member, so the delete worker can
+//!   tag a candidate extra by name without re-statting;
+//! - the source-side `(dev, ino)` of every member that ships the
+//!   protocol-29 hardlink_dev/ino fields, so a worker that already holds a
+//!   destination `stat()` can confirm cohort membership;
+//! - the count of source-side refs per cohort, used by
+//!   [`CohortIndex::surviving_refs_in_cohort`] to answer "how many
+//!   destination paths in this cohort will the upstream still expect".
+//!
+//! # Why no locks
+//!
+//! The audit identifies four races (R1-R4) that would appear if phase-1
+//! workers shared a mutable hardlink table. By construction every method
+//! on [`CohortIndex`] takes `&self` and the underlying maps are populated
+//! exactly once at build time and never mutated afterwards. Cloning the
+//! [`std::sync::Arc`] is the only operation workers need.
+//!
+//! # Upstream reference
+//!
+//! - `target/interop/upstream-src/rsync-3.4.1/hlink.c:59-65`
+//!   (`init_hard_links`): builds the dev/ino table before the delete
+//!   sweep runs.
+//! - `target/interop/upstream-src/rsync-3.4.1/hlink.c:186-208`
+//!   (`match_hard_links`): freezes leader assignments before
+//!   `do_delete_pass`.
+//! - `target/interop/upstream-src/rsync-3.4.1/delete.c:130-225`
+//!   (`delete_item`): the dispatch is unconditional `do_unlink`; the
+//!   kernel reconciles ref counts. Our [`CohortIndex`] therefore exists
+//!   to power itemize tagging and cohort-aware diagnostics, not to skip
+//!   the unlink syscall.
+
+use std::collections::HashMap;
+use std::ffi::{OsStr, OsString};
+use std::path::Path;
+use std::sync::Arc;
+
+use protocol::flist::FileEntry;
+use rustc_hash::FxHashMap;
+
+use super::plan::HardlinkCohortId;
+
+/// Read-only snapshot of the hardlink cohort layout for one INC_RECURSE
+/// segment.
+///
+/// Built via [`CohortIndex::build_from_flist_segment`] at the boundary
+/// between file-list reception and delete dispatch. Phase-1 workers and
+/// the single emitter read the snapshot through [`std::sync::Arc`]
+/// clones; no method on this type mutates the underlying maps.
+#[derive(Debug, Default)]
+pub struct CohortIndex {
+    /// Basename -> cohort id. Populated for every source-side hardlinked
+    /// member observed in the segment. Used by
+    /// [`CohortIndex::cohort_of`].
+    by_name: HashMap<OsString, HardlinkCohortId>,
+    /// `(dev, ino)` -> cohort id. Populated only for entries that ship
+    /// the protocol-29 hardlink_dev/ino fields. Used by callers that
+    /// already hold a destination `stat()` and want to confirm cohort
+    /// identity without re-walking the file list. Matches upstream's
+    /// `dev_tbl` indexing.
+    by_dev_ino: FxHashMap<(u64, u64), HardlinkCohortId>,
+    /// Cohort id -> count of source-side refs in this segment. The
+    /// emitter uses this through
+    /// [`CohortIndex::surviving_refs_in_cohort`] to label the itemize
+    /// line when only a subset of a cohort's destination paths is being
+    /// removed.
+    cohort_sizes: FxHashMap<HardlinkCohortId, u32>,
+}
+
+impl CohortIndex {
+    /// Builds a fresh snapshot from one frozen flist segment slice.
+    ///
+    /// The slice must already be in its final form for the segment;
+    /// callers typically invoke this once per INC_RECURSE segment after
+    /// `match_hard_links` has assigned leader indices. See section 9 of
+    /// `docs/design/hardlink-delete-audit.md` for the integration point.
+    ///
+    /// Returns an [`std::sync::Arc`] so the caller can hand the snapshot
+    /// to rayon workers and to the emitter without an extra clone.
+    ///
+    /// # Cohort identity
+    ///
+    /// Each member of a cohort carries the leader's flist index in
+    /// `FileEntry::hardlink_idx()`. The leader itself reports
+    /// [`u32::MAX`] (upstream's "first occurrence" marker) and is
+    /// identified by its position in the segment - the index of the
+    /// leader entry within the segment is used as the cohort id so the
+    /// id is stable across both leader and followers.
+    #[must_use]
+    pub fn build_from_flist_segment(entries: &[FileEntry]) -> Arc<Self> {
+        let mut leader_for_idx: FxHashMap<u32, HardlinkCohortId> = FxHashMap::default();
+        let mut by_name: HashMap<OsString, HardlinkCohortId> = HashMap::new();
+        let mut by_dev_ino: FxHashMap<(u64, u64), HardlinkCohortId> = FxHashMap::default();
+        let mut cohort_sizes: FxHashMap<HardlinkCohortId, u32> = FxHashMap::default();
+
+        // First pass: identify leaders. A leader's `hardlink_idx()`
+        // returns `Some(u32::MAX)` in the upstream encoding. We mint the
+        // cohort id from the leader's position in the segment so that
+        // followers carrying the same wire NDX can be matched against
+        // it.
+        for (position, entry) in entries.iter().enumerate() {
+            if entry.hardlink_idx() == Some(u32::MAX) {
+                let cohort = HardlinkCohortId::new(position as u32);
+                leader_for_idx.insert(position as u32, cohort);
+                Self::record(
+                    entry,
+                    cohort,
+                    &mut by_name,
+                    &mut by_dev_ino,
+                    &mut cohort_sizes,
+                );
+            }
+        }
+
+        // Second pass: attach every follower to its leader. Followers
+        // carry the leader's flist index in `hardlink_idx()`.
+        for entry in entries.iter() {
+            let Some(leader_ndx) = entry.hardlink_idx() else {
+                continue;
+            };
+            if leader_ndx == u32::MAX {
+                // Already handled as a leader above.
+                continue;
+            }
+            let Some(&cohort) = leader_for_idx.get(&leader_ndx) else {
+                // Cross-segment follower (the leader lives in an earlier
+                // segment). The audit's INC_RECURSE rebuild contract
+                // covers this: each segment owns its own cohort space
+                // and cross-segment cohorts surface in the segment that
+                // carries the leader. Skip rather than mint a synthetic
+                // id.
+                continue;
+            };
+            Self::record(
+                entry,
+                cohort,
+                &mut by_name,
+                &mut by_dev_ino,
+                &mut cohort_sizes,
+            );
+        }
+
+        Arc::new(Self {
+            by_name,
+            by_dev_ino,
+            cohort_sizes,
+        })
+    }
+
+    /// Looks up the cohort id for a destination basename.
+    ///
+    /// Returns `Some` only when the segment carries a source-side
+    /// hardlinked member with the same basename. This is the lookup the
+    /// delete worker performs when stat'ing an extras candidate to
+    /// decide whether the itemize line should carry a cohort tag.
+    #[must_use]
+    pub fn cohort_of(&self, name: &OsStr) -> Option<HardlinkCohortId> {
+        self.by_name.get(name).copied()
+    }
+
+    /// Looks up the cohort id by destination `(dev, ino)`.
+    ///
+    /// Available only when the segment carried protocol-29 hardlink
+    /// dev/ino fields. Returns `None` if the segment is post-protocol-30
+    /// (which omits per-entry dev/ino) or if the destination inode does
+    /// not match any source-side cohort.
+    #[must_use]
+    pub fn cohort_by_dev_ino(&self, dev: u64, ino: u64) -> Option<HardlinkCohortId> {
+        self.by_dev_ino.get(&(dev, ino)).copied()
+    }
+
+    /// Returns the count of source-side refs the segment expects to keep
+    /// for the cohort.
+    ///
+    /// Phase-2 uses this to decide whether the per-path itemize line
+    /// should be tagged as "last ref" or as one of several. The count
+    /// reflects source-side membership only - destination-side ref
+    /// counts are the kernel's responsibility, mirroring upstream
+    /// `delete.c:130-225` where every unlink is unconditional.
+    #[must_use]
+    pub fn surviving_refs_in_cohort(&self, cohort: HardlinkCohortId) -> u32 {
+        self.cohort_sizes.get(&cohort).copied().unwrap_or(0)
+    }
+
+    /// Returns the total number of distinct cohorts in this snapshot.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.cohort_sizes.len()
+    }
+
+    /// Returns `true` when no source-side cohorts were observed in this
+    /// segment.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.cohort_sizes.is_empty()
+    }
+
+    /// Inserts one cohort member into the indexes. Pulled out so the
+    /// leader and follower passes share the same bookkeeping; private to
+    /// keep the publish-once invariant.
+    fn record(
+        entry: &FileEntry,
+        cohort: HardlinkCohortId,
+        by_name: &mut HashMap<OsString, HardlinkCohortId>,
+        by_dev_ino: &mut FxHashMap<(u64, u64), HardlinkCohortId>,
+        cohort_sizes: &mut FxHashMap<HardlinkCohortId, u32>,
+    ) {
+        if let Some(name) = basename_of(entry.path()) {
+            by_name.insert(name, cohort);
+        }
+        if let (Some(dev), Some(ino)) = (entry.hardlink_dev(), entry.hardlink_ino()) {
+            // Casts to u64 are safe: upstream uses unsigned dev/ino on
+            // the wire and the i64 type is the protocol-29 carrier.
+            by_dev_ino.insert((dev as u64, ino as u64), cohort);
+        }
+        let count = cohort_sizes.entry(cohort).or_insert(0);
+        *count = count.saturating_add(1);
+    }
+}
+
+/// Extracts a leaf basename from a relative path, returning `None` for
+/// the degenerate empty path. Matches the segment-basename rule already
+/// used by [`super::compute_extras`].
+fn basename_of(path: &Path) -> Option<OsString> {
+    path.file_name().map(OsStr::to_os_string)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn leader(name: &str) -> FileEntry {
+        let mut entry = FileEntry::new_file(PathBuf::from(name), 0, 0o644);
+        entry.set_hardlink_idx(u32::MAX);
+        entry
+    }
+
+    fn leader_with_dev_ino(name: &str, dev: i64, ino: i64) -> FileEntry {
+        let mut entry = leader(name);
+        entry.set_hardlink_dev(dev);
+        entry.set_hardlink_ino(ino);
+        entry
+    }
+
+    fn follower(name: &str, leader_idx: u32) -> FileEntry {
+        let mut entry = FileEntry::new_file(PathBuf::from(name), 0, 0o644);
+        entry.set_hardlink_idx(leader_idx);
+        entry
+    }
+
+    fn follower_with_dev_ino(name: &str, leader_idx: u32, dev: i64, ino: i64) -> FileEntry {
+        let mut entry = follower(name, leader_idx);
+        entry.set_hardlink_dev(dev);
+        entry.set_hardlink_ino(ino);
+        entry
+    }
+
+    #[test]
+    fn empty_segment_yields_empty_index() {
+        let index = CohortIndex::build_from_flist_segment(&[]);
+        assert!(index.is_empty());
+        assert_eq!(index.len(), 0);
+        assert!(index.cohort_of(OsStr::new("missing")).is_none());
+        assert!(index.cohort_by_dev_ino(1, 2).is_none());
+    }
+
+    #[test]
+    fn non_hardlinked_segment_yields_empty_index() {
+        // A plain file with no hardlink_idx set must not register a
+        // cohort; FileEntry::hardlink_idx() returns None in that case.
+        let entries = vec![
+            FileEntry::new_file(PathBuf::from("a"), 0, 0o644),
+            FileEntry::new_file(PathBuf::from("b"), 0, 0o644),
+        ];
+        let index = CohortIndex::build_from_flist_segment(&entries);
+        assert!(index.is_empty());
+        assert!(index.cohort_of(OsStr::new("a")).is_none());
+    }
+
+    #[test]
+    fn single_leader_registers_one_cohort_of_size_one() {
+        let entries = vec![leader("solo")];
+        let index = CohortIndex::build_from_flist_segment(&entries);
+        let cohort = index
+            .cohort_of(OsStr::new("solo"))
+            .expect("leader registers by name");
+        assert_eq!(cohort, HardlinkCohortId::new(0));
+        assert_eq!(index.surviving_refs_in_cohort(cohort), 1);
+        assert_eq!(index.len(), 1);
+    }
+
+    #[test]
+    fn leader_and_followers_share_cohort_id() {
+        // Leader at position 0; followers point at NDX 0.
+        let entries = vec![leader("leader"), follower("ref1", 0), follower("ref2", 0)];
+        let index = CohortIndex::build_from_flist_segment(&entries);
+        let cohort = index
+            .cohort_of(OsStr::new("leader"))
+            .expect("leader present");
+        assert_eq!(index.cohort_of(OsStr::new("ref1")), Some(cohort));
+        assert_eq!(index.cohort_of(OsStr::new("ref2")), Some(cohort));
+        assert_eq!(index.surviving_refs_in_cohort(cohort), 3);
+        assert_eq!(index.len(), 1);
+    }
+
+    #[test]
+    fn surviving_refs_counts_only_source_side_refs() {
+        // The source has 2 refs in this cohort; destination ref counts
+        // are explicitly out of scope (kernel handles them at unlink).
+        let entries = vec![leader("a"), follower("b", 0)];
+        let index = CohortIndex::build_from_flist_segment(&entries);
+        let cohort = index.cohort_of(OsStr::new("a")).unwrap();
+        assert_eq!(index.surviving_refs_in_cohort(cohort), 2);
+        // Unknown cohort id returns 0.
+        assert_eq!(
+            index.surviving_refs_in_cohort(HardlinkCohortId::new(999)),
+            0,
+        );
+    }
+
+    #[test]
+    fn multiple_distinct_cohorts_are_isolated() {
+        // Two leaders at positions 0 and 2, followers at 1 and 3.
+        let entries = vec![
+            leader("g1_leader"),
+            follower("g1_member", 0),
+            leader("g2_leader"),
+            follower("g2_member", 2),
+        ];
+        let index = CohortIndex::build_from_flist_segment(&entries);
+        let g1 = index.cohort_of(OsStr::new("g1_leader")).unwrap();
+        let g2 = index.cohort_of(OsStr::new("g2_leader")).unwrap();
+        assert_ne!(g1, g2);
+        assert_eq!(g1, HardlinkCohortId::new(0));
+        assert_eq!(g2, HardlinkCohortId::new(2));
+        assert_eq!(index.cohort_of(OsStr::new("g1_member")), Some(g1));
+        assert_eq!(index.cohort_of(OsStr::new("g2_member")), Some(g2));
+        assert_eq!(index.surviving_refs_in_cohort(g1), 2);
+        assert_eq!(index.surviving_refs_in_cohort(g2), 2);
+        assert_eq!(index.len(), 2);
+    }
+
+    #[test]
+    fn cross_segment_follower_without_leader_is_skipped() {
+        // A follower pointing at a leader index that does not exist in
+        // this segment (e.g. cross-segment INC_RECURSE) must not mint a
+        // ghost cohort. The audit's per-segment rebuild contract relies
+        // on this.
+        let entries = vec![follower("orphan", 999)];
+        let index = CohortIndex::build_from_flist_segment(&entries);
+        assert!(index.is_empty());
+        assert!(index.cohort_of(OsStr::new("orphan")).is_none());
+    }
+
+    #[test]
+    fn dev_ino_lookup_returns_cohort_when_protocol_29_fields_present() {
+        let entries = vec![
+            leader_with_dev_ino("a", 5, 100),
+            follower_with_dev_ino("b", 0, 5, 100),
+        ];
+        let index = CohortIndex::build_from_flist_segment(&entries);
+        let cohort = index.cohort_by_dev_ino(5, 100).expect("dev/ino indexed");
+        assert_eq!(index.cohort_of(OsStr::new("a")), Some(cohort));
+        assert_eq!(index.cohort_of(OsStr::new("b")), Some(cohort));
+    }
+
+    #[test]
+    fn dev_ino_lookup_returns_none_when_fields_absent() {
+        // Protocol-30+ entries do not ship hardlink_dev/ino. The by-name
+        // lookup still works.
+        let entries = vec![leader("a"), follower("b", 0)];
+        let index = CohortIndex::build_from_flist_segment(&entries);
+        assert!(index.cohort_by_dev_ino(0, 0).is_none());
+        assert!(index.cohort_of(OsStr::new("a")).is_some());
+    }
+
+    #[test]
+    fn segment_with_basename_in_subdirectory_indexes_by_leaf() {
+        // The set-subtraction logic in compute_extras matches on
+        // basenames; the cohort index must agree so a tag-by-name
+        // lookup against a flat dest listing finds the cohort.
+        let mut entry = FileEntry::new_file(PathBuf::from("sub/dir/leader.txt"), 0, 0o644);
+        entry.set_hardlink_idx(u32::MAX);
+        let index = CohortIndex::build_from_flist_segment(&[entry]);
+        assert!(index.cohort_of(OsStr::new("leader.txt")).is_some());
+        assert!(index.cohort_of(OsStr::new("sub/dir/leader.txt")).is_none());
+    }
+
+    #[test]
+    fn entry_with_empty_path_is_skipped() {
+        // Defensive: a degenerate row with no basename must not panic
+        // and must not pollute the by-name map with an empty key.
+        let mut leader_entry = FileEntry::new_file(PathBuf::new(), 0, 0o644);
+        leader_entry.set_hardlink_idx(u32::MAX);
+        let index = CohortIndex::build_from_flist_segment(&[leader_entry]);
+        // The cohort still exists (size tracking is by id), but no
+        // lookup-by-name can hit it.
+        assert_eq!(index.len(), 1);
+        assert!(index.cohort_of(OsStr::new("")).is_none());
+    }
+
+    #[test]
+    fn arc_snapshot_is_shareable_across_threads() {
+        let entries = vec![leader("a"), follower("b", 0)];
+        let index = CohortIndex::build_from_flist_segment(&entries);
+        let mut handles = Vec::new();
+        for _ in 0..8 {
+            let index = Arc::clone(&index);
+            handles.push(std::thread::spawn(move || {
+                assert!(index.cohort_of(OsStr::new("a")).is_some());
+                assert!(index.cohort_of(OsStr::new("b")).is_some());
+                let cohort = index.cohort_of(OsStr::new("a")).unwrap();
+                assert_eq!(index.surviving_refs_in_cohort(cohort), 2);
+            }));
+        }
+        for h in handles {
+            h.join().expect("worker joined");
+        }
+    }
+
+    #[test]
+    fn snapshot_is_not_mutated_after_build() {
+        // The publish-once invariant: every observable method takes
+        // &self, so once the Arc is handed out the only mutation
+        // possible is replacing the Arc wholesale (per-segment rebuild).
+        let entries = vec![leader("a"), follower("b", 0)];
+        let index = CohortIndex::build_from_flist_segment(&entries);
+        let first_len = index.len();
+        let _other = Arc::clone(&index);
+        assert_eq!(index.len(), first_len);
+    }
+}

--- a/crates/engine/src/delete/emitter.rs
+++ b/crates/engine/src/delete/emitter.rs
@@ -38,10 +38,12 @@
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
 use protocol::DeleteStats;
 
+use super::cohort_index::CohortIndex;
+use super::plan::HardlinkCohortId;
 use super::{DeleteEntryKind, DeletePlan, DeletePlanMap, DirTraversalCursor};
 
 // ----------------------------------------------------------------------------
@@ -275,6 +277,22 @@ pub struct DeleteEmitter<F: DeleteFs> {
     plans: DeletePlanMap,
     cursor: DirTraversalCursor,
     policy: EmitterErrorPolicy,
+    /// Read-only hardlink-cohort snapshot for the active INC_RECURSE
+    /// segment. When `Some`, every successful delete dispatch records a
+    /// cohort-tagged trace so callers can attach cohort information to
+    /// itemize lines without re-statting. The dispatch itself is
+    /// unchanged - matching upstream `delete.c:130-225`, every extras
+    /// path is unlinked unconditionally and the kernel reconciles ref
+    /// counts. The snapshot is wrapped in [`Arc`] so the same value can
+    /// be shared with phase-1 workers.
+    cohort_index: Option<Arc<CohortIndex>>,
+    /// Sequence of cohort-tagged dispatches recorded during
+    /// [`Self::emit_all`]. Each entry pairs the delete event with the
+    /// cohort id (if the entry carried one) and the source-side ref
+    /// count for that cohort at snapshot time. Populated only when the
+    /// cohort index is attached; otherwise stays empty so the legacy
+    /// code path pays no overhead.
+    cohort_log: Vec<CohortDeleteRecord>,
     /// Accumulated non-fatal I/O error state. Bit 0 mirrors upstream's
     /// `IOERR_GENERAL`; the field is exposed via [`Self::io_error`] for
     /// callers that need to compute the final exit code.
@@ -284,6 +302,29 @@ pub struct DeleteEmitter<F: DeleteFs> {
     /// arrives. `None` while the cursor is fully drained or not yet
     /// blocked.
     pending: Option<PathBuf>,
+}
+
+/// One cohort-aware delete dispatch record.
+///
+/// Produced by the emitter when a [`super::DeleteEntry`] carries a
+/// [`HardlinkCohortId`] and a [`CohortIndex`] is attached. The record
+/// pairs the destination path with the cohort tag and the source-side
+/// ref count for the cohort at snapshot time, giving callers enough
+/// information to format an upstream-style itemize line.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CohortDeleteRecord {
+    /// Destination path the emitter dispatched against.
+    pub path: PathBuf,
+    /// Entry kind that drove the dispatch.
+    pub kind: DeleteEntryKind,
+    /// Cohort the entry belonged to (`None` if the destination was not
+    /// part of any tracked cohort even though the index was attached).
+    pub cohort: Option<HardlinkCohortId>,
+    /// Source-side ref count for the cohort at snapshot time, or `0`
+    /// when no cohort tag was present. Mirrors upstream's
+    /// `match_hard_links` view of "how many links the upstream sent for
+    /// this cohort".
+    pub surviving_source_refs: u32,
 }
 
 /// Upstream `IOERR_GENERAL`: the only bit the delete pass currently sets.
@@ -310,9 +351,51 @@ impl<F: DeleteFs> DeleteEmitter<F> {
             plans,
             cursor,
             policy,
+            cohort_index: None,
+            cohort_log: Vec::new(),
             io_error: 0,
             pending: None,
         }
+    }
+
+    /// Builds an emitter that consults a hardlink-cohort snapshot for
+    /// every dispatch.
+    ///
+    /// Wiring a [`CohortIndex`] does not change which paths get
+    /// unlinked - upstream `delete.c:130-225` always issues
+    /// `do_unlink`, and the kernel reconciles ref counts. The snapshot
+    /// powers the emitter's cohort log (see [`Self::cohort_records`]),
+    /// which downstream itemize formatting consumes to tag deletions
+    /// with their leader cohort.
+    #[must_use]
+    pub fn with_cohort_index(
+        fs: F,
+        plans: DeletePlanMap,
+        cursor: DirTraversalCursor,
+        policy: EmitterErrorPolicy,
+        cohort_index: Arc<CohortIndex>,
+    ) -> Self {
+        let mut emitter = Self::with_policy(fs, plans, cursor, policy);
+        emitter.cohort_index = Some(cohort_index);
+        emitter
+    }
+
+    /// Returns the recorded cohort-aware dispatch log.
+    ///
+    /// Empty when no [`CohortIndex`] is attached or when no delete
+    /// dispatch has run yet. The slice is in dispatch order, matching
+    /// the syscall order the emitter issued.
+    #[must_use]
+    pub fn cohort_records(&self) -> &[CohortDeleteRecord] {
+        &self.cohort_log
+    }
+
+    /// Borrows the attached [`CohortIndex`], if any. Useful for tests
+    /// that want to assert the emitter is consulting the snapshot the
+    /// caller handed it.
+    #[must_use]
+    pub fn cohort_index(&self) -> Option<&Arc<CohortIndex>> {
+        self.cohort_index.as_ref()
     }
 
     /// Returns the running deletion statistics. The counter is mutated
@@ -401,7 +484,7 @@ impl<F: DeleteFs> DeleteEmitter<F> {
     fn drain_plan(&mut self, plan: &DeletePlan) -> io::Result<()> {
         for entry in &plan.extras {
             let full = plan.directory.join(&entry.name);
-            self.run_entry(entry.kind, &full)?;
+            self.run_entry(entry.kind, &full, entry.hardlink_cohort)?;
         }
         Ok(())
     }
@@ -411,10 +494,16 @@ impl<F: DeleteFs> DeleteEmitter<F> {
     /// returning `Err`; non-fatal failures under the default policy
     /// record `io_error` and return `Ok(())` so the caller's loop
     /// continues.
-    fn run_entry(&mut self, kind: DeleteEntryKind, path: &Path) -> io::Result<()> {
+    fn run_entry(
+        &mut self,
+        kind: DeleteEntryKind,
+        path: &Path,
+        cohort: Option<HardlinkCohortId>,
+    ) -> io::Result<()> {
         match self.dispatch(kind, path) {
             Ok(()) => {
                 Self::increment_stat(&mut self.stats, kind);
+                self.record_cohort_dispatch(path, kind, cohort);
                 Ok(())
             }
             Err(err) => {
@@ -431,6 +520,29 @@ impl<F: DeleteFs> DeleteEmitter<F> {
                 Ok(())
             }
         }
+    }
+
+    /// Appends one [`CohortDeleteRecord`] to the cohort log when a
+    /// [`CohortIndex`] is attached. The dispatch syscall itself has
+    /// already succeeded; this is pure bookkeeping.
+    fn record_cohort_dispatch(
+        &mut self,
+        path: &Path,
+        kind: DeleteEntryKind,
+        cohort: Option<HardlinkCohortId>,
+    ) {
+        let Some(index) = self.cohort_index.as_ref() else {
+            return;
+        };
+        let surviving_source_refs = cohort
+            .map(|c| index.surviving_refs_in_cohort(c))
+            .unwrap_or(0);
+        self.cohort_log.push(CohortDeleteRecord {
+            path: path.to_path_buf(),
+            kind,
+            cohort,
+            surviving_source_refs,
+        });
     }
 
     /// Dispatches one planned entry. Directories route through
@@ -1130,5 +1242,187 @@ mod tests {
         assert_eq!(emitter.fs().events().len(), after_first);
         assert_eq!(emitter.io_error(), 0);
         assert_eq!(emitter.exit_code(), 0);
+    }
+
+    // ------------------------------------------------------------------
+    // DDP-D2 (#2264) - hardlink-aware delete via CohortIndex snapshot.
+    //
+    // Per `docs/design/hardlink-delete-audit.md` Option A and upstream
+    // `delete.c:130-225`, the emitter still unlinks every destination
+    // path even when the cohort retains other refs (the kernel
+    // reconciles ref counts). The snapshot powers cohort-aware itemize
+    // bookkeeping via `cohort_records`, not the unlink decision itself.
+    // ------------------------------------------------------------------
+
+    fn tagged_entry(name: &str, kind: DeleteEntryKind, cohort: HardlinkCohortId) -> DeleteEntry {
+        DeleteEntry::with_cohort(OsString::from(name), kind, cohort)
+    }
+
+    /// Builds a `CohortIndex` from a synthetic segment with `dest_count`
+    /// source-side refs sharing one cohort. The leader's name is
+    /// `leader`; followers are `member0`, `member1`, etc.
+    fn cohort_index_for(leader: &str, member_count: usize) -> Arc<CohortIndex> {
+        let mut entries = Vec::with_capacity(1 + member_count);
+        let mut head = FileEntry::new_file(PathBuf::from(leader), 0, 0o644);
+        head.set_hardlink_idx(u32::MAX);
+        entries.push(head);
+        for i in 0..member_count {
+            let mut e = FileEntry::new_file(PathBuf::from(format!("member{i}")), 0, 0o644);
+            e.set_hardlink_idx(0);
+            entries.push(e);
+        }
+        CohortIndex::build_from_flist_segment(&entries)
+    }
+
+    #[test]
+    fn emitter_with_cohort_index_records_cohort_per_dispatch() {
+        // The destination has three refs in one cohort (`leader`,
+        // `member0`, `member1`); the source has two (`leader` and
+        // `member0`). Upstream's policy is to unlink all three dest
+        // paths; the cohort log must reflect that with cohort tags on
+        // the two known members and no tag on the third.
+        let cohort = HardlinkCohortId::new(0);
+        let index = cohort_index_for("leader", 1); // source = leader + member0
+        let plans = DeletePlanMap::new();
+        plans.insert(plan(
+            "d",
+            vec![
+                tagged_entry("leader", DeleteEntryKind::File, cohort),
+                tagged_entry("member0", DeleteEntryKind::File, cohort),
+                entry("member1", DeleteEntryKind::File),
+            ],
+        ));
+        let mut cursor = DirTraversalCursor::new(PathBuf::from("d"));
+        cursor.observe_segment(PathBuf::from("d"), &[]);
+
+        let mut emitter = DeleteEmitter::with_cohort_index(
+            RecordingDeleteFs::new(),
+            plans,
+            cursor,
+            EmitterErrorPolicy::default(),
+            Arc::clone(&index),
+        );
+        emitter.emit_all().expect("drain succeeds");
+
+        // The kernel-policy invariant: every dest path was unlinked
+        // (matches upstream `delete.c:130-225`).
+        let events = emitter.fs().events();
+        assert_eq!(events.len(), 3);
+        assert_eq!(events[0].path, PathBuf::from("d/leader"));
+        assert_eq!(events[1].path, PathBuf::from("d/member0"));
+        assert_eq!(events[2].path, PathBuf::from("d/member1"));
+
+        // The cohort log records the per-dispatch cohort tag.
+        let records = emitter.cohort_records();
+        assert_eq!(records.len(), 3);
+        assert_eq!(records[0].cohort, Some(cohort));
+        assert_eq!(records[0].surviving_source_refs, 2);
+        assert_eq!(records[1].cohort, Some(cohort));
+        assert_eq!(records[1].surviving_source_refs, 2);
+        // The orphan-on-the-dest gets no cohort tag.
+        assert_eq!(records[2].cohort, None);
+        assert_eq!(records[2].surviving_source_refs, 0);
+    }
+
+    #[test]
+    fn emitter_without_cohort_index_records_no_cohort_log() {
+        // Baseline: with no CohortIndex attached, the cohort log stays
+        // empty even when the plan carries cohort tags. This keeps the
+        // legacy hot path zero-overhead.
+        let cohort = HardlinkCohortId::new(7);
+        let plans = DeletePlanMap::new();
+        plans.insert(plan(
+            "d",
+            vec![tagged_entry("x", DeleteEntryKind::File, cohort)],
+        ));
+        let mut cursor = DirTraversalCursor::new(PathBuf::from("d"));
+        cursor.observe_segment(PathBuf::from("d"), &[]);
+
+        let mut emitter = DeleteEmitter::new(RecordingDeleteFs::new(), plans, cursor);
+        emitter.emit_all().expect("drain succeeds");
+
+        assert!(emitter.cohort_index().is_none());
+        assert!(emitter.cohort_records().is_empty());
+        assert_eq!(emitter.stats().files, 1);
+    }
+
+    #[test]
+    fn emitter_cohort_index_does_not_change_dispatch_order() {
+        // Attaching a CohortIndex must not perturb the syscall order -
+        // the cohort log is observer-only. The dispatch must match
+        // exactly what the no-cohort variant produces.
+        let cohort = HardlinkCohortId::new(0);
+        let index = cohort_index_for("leader", 2);
+
+        let baseline_plans = DeletePlanMap::new();
+        baseline_plans.insert(plan(
+            "d",
+            vec![
+                entry("leader", DeleteEntryKind::File),
+                entry("member0", DeleteEntryKind::File),
+                entry("member1", DeleteEntryKind::File),
+            ],
+        ));
+        let mut baseline_cursor = DirTraversalCursor::new(PathBuf::from("d"));
+        baseline_cursor.observe_segment(PathBuf::from("d"), &[]);
+        let mut baseline_emitter =
+            DeleteEmitter::new(RecordingDeleteFs::new(), baseline_plans, baseline_cursor);
+        baseline_emitter.emit_all().unwrap();
+        let baseline_events = baseline_emitter.fs().events();
+
+        let cohort_plans = DeletePlanMap::new();
+        cohort_plans.insert(plan(
+            "d",
+            vec![
+                tagged_entry("leader", DeleteEntryKind::File, cohort),
+                tagged_entry("member0", DeleteEntryKind::File, cohort),
+                tagged_entry("member1", DeleteEntryKind::File, cohort),
+            ],
+        ));
+        let mut cohort_cursor = DirTraversalCursor::new(PathBuf::from("d"));
+        cohort_cursor.observe_segment(PathBuf::from("d"), &[]);
+        let mut cohort_emitter = DeleteEmitter::with_cohort_index(
+            RecordingDeleteFs::new(),
+            cohort_plans,
+            cohort_cursor,
+            EmitterErrorPolicy::default(),
+            index,
+        );
+        cohort_emitter.emit_all().unwrap();
+        assert_eq!(cohort_emitter.fs().events(), baseline_events);
+    }
+
+    #[test]
+    fn cohort_log_skips_failed_dispatch() {
+        // A failed dispatch must NOT add a cohort record - the cohort
+        // log is meant to mirror successful syscalls (so it matches the
+        // emitter's stats counter, which is also success-only).
+        let cohort = HardlinkCohortId::new(0);
+        let index = cohort_index_for("leader", 0); // single-ref source
+        let fs = ScriptedDeleteFs::new().fail("d/leader", io::ErrorKind::Other);
+        let plans = DeletePlanMap::new();
+        plans.insert(plan(
+            "d",
+            vec![tagged_entry("leader", DeleteEntryKind::File, cohort)],
+        ));
+        let mut cursor = DirTraversalCursor::new(PathBuf::from("d"));
+        cursor.observe_segment(PathBuf::from("d"), &[]);
+
+        let mut emitter = DeleteEmitter::with_cohort_index(
+            fs,
+            plans,
+            cursor,
+            EmitterErrorPolicy::default(),
+            index,
+        );
+        emitter
+            .emit_all()
+            .expect("non-fatal failure keeps draining");
+
+        assert!(
+            emitter.cohort_records().is_empty(),
+            "failed dispatch must not appear in cohort log",
+        );
+        assert_eq!(emitter.io_error(), IOERR_GENERAL);
     }
 }

--- a/crates/engine/src/delete/extras.rs
+++ b/crates/engine/src/delete/extras.rs
@@ -30,9 +30,11 @@ use std::ffi::OsString;
 use std::fs;
 use std::io;
 use std::path::Path;
+use std::sync::Arc;
 
 use protocol::flist::FileEntry;
 
+use super::cohort_index::CohortIndex;
 use super::plan::{DeleteEntry, DeleteEntryKind};
 
 /// Lists `dest_dir`, subtracts every basename that appears in
@@ -74,6 +76,33 @@ pub fn compute_extras(
     dest_dir: &Path,
     segment_entries: &[FileEntry],
 ) -> io::Result<Vec<DeleteEntry>> {
+    compute_extras_with_cohorts(dest_dir, segment_entries, None)
+}
+
+/// Variant of [`compute_extras`] that attaches a hardlink cohort tag to
+/// each surviving entry whose destination basename matches a member of
+/// the supplied [`CohortIndex`].
+///
+/// The cohort tag has no effect on the unlink decision itself; matching
+/// upstream `delete.c:130-225`, every extras path is still unlinked
+/// unconditionally and the kernel reconciles ref counts. The tag exists
+/// so the [`super::DeleteEmitter`] can emit cohort-aware itemize lines
+/// without re-statting and so future diagnostics can distinguish a
+/// last-ref deletion from one of several in the same cohort.
+///
+/// `cohort_index = None` reproduces the original behaviour bit for bit
+/// and is the path taken by callers that have not yet plumbed the
+/// snapshot through.
+///
+/// # Errors
+///
+/// Same as [`compute_extras`]: any I/O failure on `read_dir` or
+/// per-entry `symlink_metadata` is surfaced to the caller.
+pub fn compute_extras_with_cohorts(
+    dest_dir: &Path,
+    segment_entries: &[FileEntry],
+    cohort_index: Option<&Arc<CohortIndex>>,
+) -> io::Result<Vec<DeleteEntry>> {
     let segment_names = segment_basenames(segment_entries);
     let read_dir = fs::read_dir(dest_dir)?;
     let mut extras = Vec::new();
@@ -85,7 +114,11 @@ pub fn compute_extras(
         }
         let metadata = fs::symlink_metadata(entry.path())?;
         let kind = classify(&metadata);
-        extras.push(DeleteEntry::new(name, kind));
+        let delete_entry = match cohort_index.and_then(|idx| idx.cohort_of(name.as_os_str())) {
+            Some(cohort) => DeleteEntry::with_cohort(name, kind, cohort),
+            None => DeleteEntry::new(name, kind),
+        };
+        extras.push(delete_entry);
     }
     Ok(extras)
 }
@@ -291,5 +324,78 @@ mod tests {
         let extras = compute_extras(dir.path(), &segment).unwrap();
         assert_eq!(extras.len(), 1);
         assert_eq!(extras[0].name, OsString::from("real"));
+    }
+
+    #[test]
+    fn compute_extras_with_cohorts_none_matches_baseline() {
+        // Passing `None` for the cohort index must reproduce the
+        // behaviour of the original compute_extras byte for bit.
+        let dir = TempDir::new().unwrap();
+        for n in ["a", "b", "c"] {
+            touch(dir.path(), n);
+        }
+        let segment = vec![flist_file("a")];
+        let baseline = compute_extras(dir.path(), &segment).unwrap();
+        let cohort_path = compute_extras_with_cohorts(dir.path(), &segment, None).unwrap();
+        let mut baseline_sorted = baseline.clone();
+        let mut cohort_sorted = cohort_path.clone();
+        baseline_sorted.sort_by(|a, b| a.name.cmp(&b.name));
+        cohort_sorted.sort_by(|a, b| a.name.cmp(&b.name));
+        assert_eq!(baseline_sorted, cohort_sorted);
+        for entry in &cohort_path {
+            assert!(entry.hardlink_cohort.is_none());
+        }
+    }
+
+    #[test]
+    fn compute_extras_with_cohorts_tags_matching_basenames() {
+        // The dest directory carries three extras; two of them share
+        // basenames with a hardlink cohort in the segment. Those two
+        // must come back tagged; the third must come back untagged.
+        let dir = TempDir::new().unwrap();
+        for n in ["alpha", "beta", "untagged"] {
+            touch(dir.path(), n);
+        }
+        // Build a cohort segment with the two names. The segment is
+        // separate from the segment we feed to compute_extras (which
+        // excludes nothing here) - the cohort index is built once at
+        // the receiver boundary, not derived from the same slice the
+        // delete worker uses for set subtraction.
+        let mut leader = FileEntry::new_file(PathBuf::from("alpha"), 0, 0o644);
+        leader.set_hardlink_idx(u32::MAX);
+        let mut member = FileEntry::new_file(PathBuf::from("beta"), 0, 0o644);
+        member.set_hardlink_idx(0);
+        let cohort_segment = vec![leader, member];
+        let index = CohortIndex::build_from_flist_segment(&cohort_segment);
+        let extras = compute_extras_with_cohorts(dir.path(), &[], Some(&index)).unwrap();
+        let by_name: std::collections::HashMap<_, _> = extras
+            .iter()
+            .map(|e| (e.name.clone(), e.hardlink_cohort))
+            .collect();
+        let alpha_cohort = by_name[&OsString::from("alpha")];
+        let beta_cohort = by_name[&OsString::from("beta")];
+        let untagged_cohort = by_name[&OsString::from("untagged")];
+        assert!(alpha_cohort.is_some());
+        assert_eq!(alpha_cohort, beta_cohort, "same cohort id for both members");
+        assert!(untagged_cohort.is_none());
+    }
+
+    #[test]
+    fn compute_extras_with_cohorts_leaves_non_cohort_entries_untagged() {
+        let dir = TempDir::new().unwrap();
+        for n in ["x", "y"] {
+            touch(dir.path(), n);
+        }
+        // Build a non-empty cohort index that has no overlap with the
+        // destination names. Every extras row must come back without a
+        // tag.
+        let mut leader = FileEntry::new_file(PathBuf::from("unrelated"), 0, 0o644);
+        leader.set_hardlink_idx(u32::MAX);
+        let index = CohortIndex::build_from_flist_segment(&[leader]);
+        let extras = compute_extras_with_cohorts(dir.path(), &[], Some(&index)).unwrap();
+        assert_eq!(extras.len(), 2);
+        for entry in extras {
+            assert!(entry.hardlink_cohort.is_none());
+        }
     }
 }

--- a/crates/engine/src/delete/mod.rs
+++ b/crates/engine/src/delete/mod.rs
@@ -23,6 +23,12 @@
 //!   planned entry. Guarantees the wall-clock event sequence (`unlink`
 //!   syscall order, `*deleting` itemize lines, `NDX_DEL_STATS` framing)
 //!   matches upstream rsync 3.4.1 byte for byte.
+//! - [`CohortIndex`] - read-only hardlink cohort snapshot built per
+//!   INC_RECURSE segment and shared by `std::sync::Arc` across phase-1
+//!   [`compute_extras_with_cohorts`] workers and the single emitter.
+//!   Powers cohort-aware itemize bookkeeping without changing the
+//!   unlink decision (upstream `delete.c:130-225` always unlinks; the
+//!   kernel reconciles ref counts).
 //!
 //! # Upstream Reference
 //!
@@ -34,17 +40,19 @@
 //! - `target/interop/upstream-src/rsync-3.4.1/flist.c:3217-3343`
 //!   (`f_name_cmp`).
 
+mod cohort_index;
 pub mod emitter;
 mod extras;
 mod plan;
 mod plan_map;
 mod traversal;
 
+pub use cohort_index::CohortIndex;
 pub use emitter::{
-    DeleteEmitter, DeleteEvent, DeleteFs, EMITTER_PARTIAL_EXIT_CODE, EMITTER_VANISHED_EXIT_CODE,
-    EmitterErrorPolicy, RealDeleteFs, RecordingDeleteFs,
+    CohortDeleteRecord, DeleteEmitter, DeleteEvent, DeleteFs, EMITTER_PARTIAL_EXIT_CODE,
+    EMITTER_VANISHED_EXIT_CODE, EmitterErrorPolicy, RealDeleteFs, RecordingDeleteFs,
 };
-pub use extras::compute_extras;
+pub use extras::{compute_extras, compute_extras_with_cohorts};
 pub use plan::{DeleteEntry, DeleteEntryKind, DeletePlan, HardlinkCohortId};
 pub use plan_map::DeletePlanMap;
 pub use traversal::DirTraversalCursor;


### PR DESCRIPTION
## Summary

- Implement Option A from `docs/design/hardlink-delete-audit.md` (#4265): a read-only `CohortIndex` snapshot is built per INC_RECURSE segment, wrapped in `Arc`, and shared across phase-1 `compute_extras` workers and the single phase-2 emitter. Phase-1 workers stay pure readers, closing races R1-R4 by construction.
- Mirror upstream `delete.c:130-225`: the unlink dispatch stays unconditional and the kernel reconciles ref counts. The cohort index powers cohort-aware itemize bookkeeping via the new `CohortDeleteRecord` accessor, not a skip-unlink decision.
- New surfaces: `delete::CohortIndex` (`build_from_flist_segment`, `cohort_of`, `cohort_by_dev_ino`, `surviving_refs_in_cohort`), `compute_extras_with_cohorts` overload tagging `DeleteEntry::hardlink_cohort`, and `DeleteEmitter::with_cohort_index` constructor plus `cohort_records` accessor.

## Implementation notes

- Cohort id is minted from the leader's position in the segment so leader (`hardlink_idx == u32::MAX`) and followers (pointing at the leader's wire NDX) end up with the same identifier.
- Cross-segment followers without a leader in the current segment are skipped: each INC_RECURSE segment owns its own cohort space, as the audit's per-segment rebuild contract requires.
- `compute_extras` is preserved bit-for-bit by delegating to `compute_extras_with_cohorts(.., None)`. The legacy hot path keeps zero overhead.
- The emitter's cohort log is populated only when an index is attached and only on successful dispatch, mirroring the stats counter's success-only semantics.

## Test plan

- [ ] `cargo nextest run -p engine --all-features -E 'test(delete::cohort_index)'`
- [ ] `cargo nextest run -p engine --all-features -E 'test(delete::extras::tests::compute_extras_with_cohorts)'`
- [ ] `cargo nextest run -p engine --all-features -E 'test(delete::emitter::tests::emitter_with_cohort_index)'`
- [ ] `cargo nextest run -p engine --all-features -E 'test(delete::emitter::tests::emitter_cohort_index_does_not_change_dispatch_order)'`
- [ ] `cargo nextest run -p engine --all-features -E 'test(delete::emitter::tests::cohort_log_skips_failed_dispatch)'`
- [ ] CI: fmt+clippy, nextest (stable), Windows, macOS, Linux musl