### PR TITLE
feat(engine): receiver-side flist segment hook publishing DeletePlans (#2257)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1261,6 +1261,7 @@ dependencies = [
  "criterion",
  "crossbeam-channel",
  "crossbeam-queue",
+ "dashmap",
  "fast_io",
  "filetime",
  "filters",

--- a/crates/engine/src/delete/context.rs
+++ b/crates/engine/src/delete/context.rs
@@ -1,0 +1,334 @@
+//! Receiver-driver glue between the flist segment consumer and the
+//! parallel-deterministic-delete pipeline's phase-1 producers.
+//!
+//! [`DeleteContext`] is the shared handle the receiver threads through to
+//! the per-segment hook. For each INC_RECURSE segment that lands on the
+//! receiver, the hook calls [`DeleteContext::observe_segment_for_delete`]
+//! with the segment's content directory and entries. The context computes
+//! per-directory extras via [`compute_extras`], wraps them in a sorted
+//! [`DeletePlan`], and publishes the plan into a shared [`DeletePlanMap`]
+//! for the (not-yet-wired) emitter to drain.
+//!
+//! The same call also records the segment's child directories in a shared
+//! [`DirTraversalCursor`] so the emitter can yield directories in upstream
+//! traversal order without re-walking the flist.
+//!
+//! # Concurrency
+//!
+//! The plan map is already lock-free at the publisher boundary; the
+//! traversal cursor is single-threaded by construction, so it lives behind
+//! a [`Mutex`]. The lock is held only for the duration of one
+//! `observe_segment` call (no I/O, no sorting), which matches the design
+//! note in `traversal.rs` that the cursor is contention-tolerant in this
+//! shape.
+//!
+//! # Scope
+//!
+//! This module deliberately does not unlink anything, mutate
+//! `DeleteStats`, or emit itemize lines. Those live on the emitter side
+//! and are wired in tasks DDP-E1-E5. Publishing plans into the map is a
+//! pure observation: if no consumer is attached, the map fills and the
+//! receiver finalizes normally on the existing batched-sweep code path.
+
+use std::io;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+use protocol::flist::FileEntry;
+
+use super::extras::compute_extras;
+use super::plan::DeletePlan;
+use super::plan_map::DeletePlanMap;
+use super::traversal::DirTraversalCursor;
+
+/// Shared receiver-side handle that ties the flist segment consumer to
+/// the parallel-deterministic-delete pipeline's plan map and traversal
+/// cursor.
+///
+/// Construct one per transfer rooted at the destination directory, then
+/// thread it through the receiver's INC_RECURSE segment hook. The
+/// receiver calls [`Self::observe_segment_for_delete`] once per arriving
+/// segment.
+///
+/// # Fields
+///
+/// - `plan_map` is shared with the (future) emitter thread.
+/// - `cursor` is shared with the emitter to coordinate traversal order.
+/// - `dest_root` is the destination root the receiver writes into; all
+///   per-segment directory paths are resolved relative to it.
+/// - `enabled` is the master switch. When `false`,
+///   [`Self::observe_segment_for_delete`] is a no-op, so callers can
+///   wire the context unconditionally and let it stay dormant when the
+///   transfer is not in a delete mode.
+#[derive(Debug)]
+pub struct DeleteContext {
+    /// Concurrent map keyed by destination-relative directory path that
+    /// receives one [`DeletePlan`] per observed segment.
+    pub plan_map: Arc<DeletePlanMap>,
+    /// Cursor that records child directories per segment so the emitter
+    /// can yield directories in upstream `f_name_cmp` ascending order.
+    pub cursor: Mutex<DirTraversalCursor>,
+    /// Absolute (or transfer-relative) destination root. Used to resolve
+    /// per-segment relative directories into the paths that
+    /// [`compute_extras`] passes to `read_dir`.
+    pub dest_root: PathBuf,
+    /// Master switch. `false` makes [`Self::observe_segment_for_delete`]
+    /// a no-op so callers can wire the context unconditionally.
+    pub enabled: bool,
+}
+
+impl DeleteContext {
+    /// Constructs a new context rooted at `dest_root`.
+    ///
+    /// The traversal cursor is rooted at the empty relative path
+    /// (matching the destination root itself, which upstream
+    /// `delete_in_dir` visits first). When `enabled` is false, the
+    /// context is a pass-through: workers may still call
+    /// [`Self::observe_segment_for_delete`], but no plans land in the
+    /// map.
+    #[must_use]
+    pub fn new(plan_map: Arc<DeletePlanMap>, dest_root: PathBuf, enabled: bool) -> Self {
+        Self {
+            plan_map,
+            cursor: Mutex::new(DirTraversalCursor::new(PathBuf::new())),
+            dest_root,
+            enabled,
+        }
+    }
+
+    /// Constructs a context whose traversal cursor is rooted at
+    /// `cursor_root` rather than the empty path.
+    ///
+    /// Useful when the caller wants the emitter to begin its drain at a
+    /// specific subtree (for example, when the transfer's source is a
+    /// single directory below the destination root).
+    #[must_use]
+    pub fn with_cursor_root(
+        plan_map: Arc<DeletePlanMap>,
+        dest_root: PathBuf,
+        cursor_root: PathBuf,
+        enabled: bool,
+    ) -> Self {
+        Self {
+            plan_map,
+            cursor: Mutex::new(DirTraversalCursor::new(cursor_root)),
+            dest_root,
+            enabled,
+        }
+    }
+
+    /// Observes one flist segment from the receiver and publishes the
+    /// corresponding [`DeletePlan`] into the plan map.
+    ///
+    /// `dir` is the segment's destination-relative content directory.
+    /// `entries` is the segment's full child list (files + dirs +
+    /// symlinks + everything else). The same slice is forwarded to the
+    /// traversal cursor so it can record child directories for the
+    /// emitter's depth-first walk.
+    ///
+    /// # Behaviour
+    ///
+    /// 1. When `self.enabled` is `false`, returns `Ok(())` without any
+    ///    side effect.
+    /// 2. Resolves `self.dest_root.join(dir)` and calls
+    ///    [`compute_extras`] to obtain the unsorted candidate list.
+    /// 3. Wraps the candidates in a [`DeletePlan`] and calls
+    ///    [`DeletePlan::sort_by_name`] to lock in upstream emission
+    ///    order.
+    /// 4. Inserts the plan into [`Self::plan_map`] keyed by `dir`.
+    /// 5. Records the segment's children in [`Self::cursor`] via
+    ///    [`DirTraversalCursor::observe_segment`].
+    ///
+    /// # Errors
+    ///
+    /// Propagates I/O errors from [`compute_extras`] when the
+    /// destination directory cannot be read. The receiver caller is
+    /// expected to log + continue rather than abort the transfer (the
+    /// existing batched-sweep path will still run), matching upstream's
+    /// `io_error |= 1` behaviour for `read_dir` failures.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the cursor mutex is poisoned. A poisoned mutex
+    /// indicates an unrecoverable bug in the emitter side and is
+    /// treated the same way the plan map treats poisoned state.
+    pub fn observe_segment_for_delete(&self, dir: &Path, entries: &[FileEntry]) -> io::Result<()> {
+        if !self.enabled {
+            return Ok(());
+        }
+
+        let dest_dir = self.dest_root.join(dir);
+        let extras = compute_extras(&dest_dir, entries)?;
+        let mut plan = DeletePlan::from_extras(dir.to_path_buf(), extras);
+        plan.sort_by_name();
+        self.plan_map.insert(plan);
+
+        self.cursor
+            .lock()
+            .expect("DeleteContext cursor mutex poisoned")
+            .observe_segment(dir.to_path_buf(), entries);
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs::File;
+    use std::path::PathBuf;
+
+    use protocol::flist::FileEntry;
+    use tempfile::TempDir;
+
+    use super::*;
+
+    fn touch(dir: &Path, name: &str) {
+        File::create(dir.join(name)).expect("touch");
+    }
+
+    fn flist_file(name: &str) -> FileEntry {
+        FileEntry::new_file(PathBuf::from(name), 0, 0o644)
+    }
+
+    fn flist_dir(name: &str) -> FileEntry {
+        FileEntry::new_directory(PathBuf::from(name), 0o755)
+    }
+
+    #[test]
+    fn disabled_context_publishes_nothing() {
+        let dir = TempDir::new().unwrap();
+        touch(dir.path(), "extra");
+        let map = Arc::new(DeletePlanMap::new());
+        let ctx = DeleteContext::new(Arc::clone(&map), dir.path().to_path_buf(), false);
+
+        ctx.observe_segment_for_delete(Path::new(""), &[flist_file("kept")])
+            .expect("disabled is a no-op");
+
+        assert!(map.is_empty());
+        let mut cursor = ctx.cursor.lock().unwrap();
+        // Even with no observations, the root is still emitted, and the
+        // second call drains the now-empty stack and reports exhaustion.
+        assert_eq!(cursor.next_ready(), Some(PathBuf::new()));
+        assert_eq!(cursor.next_ready(), None);
+        assert!(cursor.is_exhausted());
+    }
+
+    #[test]
+    fn enabled_context_publishes_sorted_plan_and_records_children() {
+        // dest layout:
+        //   <root>/sub/a   <- in segment (kept)
+        //   <root>/sub/b   <- extra (to delete)
+        //   <root>/sub/c   <- in segment (kept)
+        //   <root>/sub/d   <- extra (to delete)
+        let dir = TempDir::new().unwrap();
+        let sub = dir.path().join("sub");
+        std::fs::create_dir(&sub).unwrap();
+        for n in ["a", "b", "c", "d"] {
+            touch(&sub, n);
+        }
+
+        let map = Arc::new(DeletePlanMap::new());
+        let ctx = DeleteContext::new(Arc::clone(&map), dir.path().to_path_buf(), true);
+
+        // Observe the root segment first so the cursor's depth-first
+        // walk knows "sub" is a child of the (empty) root. Without
+        // this, "sub/nested" is recorded but never reached during
+        // emission.
+        std::fs::create_dir_all(dir.path().join("placeholder")).unwrap();
+        let root_segment = vec![flist_dir("sub")];
+        ctx.observe_segment_for_delete(Path::new(""), &root_segment)
+            .expect("root observe ok");
+
+        let segment = vec![flist_file("a"), flist_file("c"), flist_dir("nested")];
+        ctx.observe_segment_for_delete(Path::new("sub"), &segment)
+            .expect("observe ok");
+
+        assert!(map.contains(Path::new("sub")));
+        let plan = map.take(Path::new("sub")).expect("plan present");
+        assert!(plan.is_sorted());
+        // After sort_by_name, plan-order is reverse of f_name_cmp
+        // ascending, so b, d -> d, b.
+        let names: Vec<&std::ffi::OsStr> = plan.extras.iter().map(|e| e.name.as_os_str()).collect();
+        assert_eq!(
+            names,
+            vec![std::ffi::OsStr::new("d"), std::ffi::OsStr::new("b"),]
+        );
+
+        // Cursor should have recorded "sub/nested" as a child of "sub".
+        let mut cursor = ctx.cursor.lock().unwrap();
+        let seq: Vec<PathBuf> = std::iter::from_fn(|| cursor.next_ready()).collect();
+        assert!(seq.contains(&PathBuf::from("sub/nested")));
+    }
+
+    #[test]
+    fn accumulates_plans_across_segments() {
+        let root = TempDir::new().unwrap();
+        for sub in ["s1", "s2", "s3"] {
+            let p = root.path().join(sub);
+            std::fs::create_dir(&p).unwrap();
+            touch(&p, "keeper");
+            touch(&p, "trash");
+        }
+
+        let map = Arc::new(DeletePlanMap::new());
+        let ctx = DeleteContext::new(Arc::clone(&map), root.path().to_path_buf(), true);
+
+        for sub in ["s1", "s2", "s3"] {
+            let entries = vec![flist_file("keeper")];
+            ctx.observe_segment_for_delete(Path::new(sub), &entries)
+                .expect("observe ok");
+        }
+
+        assert_eq!(map.len(), 3);
+        for sub in ["s1", "s2", "s3"] {
+            let plan = map.take(Path::new(sub)).expect("plan present");
+            assert_eq!(plan.extras.len(), 1);
+            assert_eq!(plan.extras[0].name, std::ffi::OsString::from("trash"));
+        }
+    }
+
+    #[test]
+    fn missing_destination_dir_surfaces_io_error() {
+        let root = TempDir::new().unwrap();
+        let map = Arc::new(DeletePlanMap::new());
+        let ctx = DeleteContext::new(Arc::clone(&map), root.path().to_path_buf(), true);
+
+        let err = ctx
+            .observe_segment_for_delete(Path::new("does-not-exist"), &[])
+            .expect_err("missing dir is an error");
+        assert_eq!(err.kind(), io::ErrorKind::NotFound);
+        // Nothing should have been published on failure.
+        assert!(map.is_empty());
+    }
+
+    #[test]
+    fn with_cursor_root_uses_provided_root() {
+        let root = TempDir::new().unwrap();
+        let map = Arc::new(DeletePlanMap::new());
+        let ctx = DeleteContext::with_cursor_root(
+            Arc::clone(&map),
+            root.path().to_path_buf(),
+            PathBuf::from("from_here"),
+            true,
+        );
+
+        let mut cursor = ctx.cursor.lock().unwrap();
+        assert_eq!(cursor.next_ready(), Some(PathBuf::from("from_here")));
+    }
+
+    #[test]
+    fn empty_segment_still_publishes_plan_for_dest_only_entries() {
+        let root = TempDir::new().unwrap();
+        touch(root.path(), "ghost1");
+        touch(root.path(), "ghost2");
+
+        let map = Arc::new(DeletePlanMap::new());
+        let ctx = DeleteContext::new(Arc::clone(&map), root.path().to_path_buf(), true);
+        ctx.observe_segment_for_delete(Path::new(""), &[])
+            .expect("observe ok");
+
+        let plan = map.take(Path::new("")).expect("plan present");
+        assert_eq!(plan.extras.len(), 2);
+        assert!(plan.is_sorted());
+    }
+}

--- a/crates/engine/src/delete/mod.rs
+++ b/crates/engine/src/delete/mod.rs
@@ -8,39 +8,31 @@
 //! # Components
 //!
 //! - [`DeletePlan`] - a sorted, frozen list of destination entries to
-//!   delete in one directory. Plan order matches upstream
-//!   `delete_in_dir`'s reverse iteration of `compare_file_entries`
-//!   ascending order.
+//!   delete in one directory.
 //! - [`DeletePlanMap`] - a concurrent map keyed by destination-relative
-//!   directory path. Workers publish [`DeletePlan`] values into the map
-//!   from rayon segment-dispatch threads; the single emitter pulls them
-//!   out in upstream traversal order.
+//!   directory path.
 //! - [`DirTraversalCursor`] - yields directories in upstream's depth-first,
-//!   `f_name_cmp`-ascending order. Backed by a tree built from observed
-//!   flist segments.
+//!   `f_name_cmp`-ascending order.
 //! - [`emitter`] - single-threaded drain that consumes [`DeletePlanMap`]
-//!   entries in [`DirTraversalCursor`] order, issuing one unlink per
-//!   planned entry. Guarantees the wall-clock event sequence (`unlink`
-//!   syscall order, `*deleting` itemize lines, `NDX_DEL_STATS` framing)
-//!   matches upstream rsync 3.4.1 byte for byte.
+//!   entries in [`DirTraversalCursor`] order.
 //! - [`CohortIndex`] - read-only hardlink cohort snapshot built per
-//!   INC_RECURSE segment and shared by `std::sync::Arc` across phase-1
-//!   [`compute_extras_with_cohorts`] workers and the single emitter.
-//!   Powers cohort-aware itemize bookkeeping without changing the
-//!   unlink decision (upstream `delete.c:130-225` always unlinks; the
-//!   kernel reconciles ref counts).
+//!   INC_RECURSE segment.
+//! - [`DeleteContext`] - receiver-side shared state that owns the
+//!   [`DeletePlanMap`] + [`DirTraversalCursor`] and exposes
+//!   `observe_segment_for_delete` to publish a [`DeletePlan`] per
+//!   incoming INC_RECURSE segment.
 //!
 //! # Upstream Reference
 //!
 //! - `target/interop/upstream-src/rsync-3.4.1/generator.c:272-387`
 //!   (`delete_in_dir`, `do_delete_pass`).
 //! - `target/interop/upstream-src/rsync-3.4.1/delete.c:82-225`
-//!   (`delete_item`, dispatch by `S_ISDIR` / `S_ISLNK` / `IS_DEVICE` /
-//!   `IS_SPECIAL`).
+//!   (`delete_item`).
 //! - `target/interop/upstream-src/rsync-3.4.1/flist.c:3217-3343`
 //!   (`f_name_cmp`).
 
 mod cohort_index;
+mod context;
 pub mod emitter;
 mod extras;
 mod plan;
@@ -48,6 +40,7 @@ mod plan_map;
 mod traversal;
 
 pub use cohort_index::CohortIndex;
+pub use context::DeleteContext;
 pub use emitter::{
     CohortDeleteRecord, DeleteEmitter, DeleteEvent, DeleteFs, EMITTER_PARTIAL_EXIT_CODE,
     EMITTER_VANISHED_EXIT_CODE, EmitterErrorPolicy, RealDeleteFs, RecordingDeleteFs,

--- a/crates/transfer/src/receiver/file_list.rs
+++ b/crates/transfer/src/receiver/file_list.rs
@@ -212,6 +212,14 @@ impl ReceiverContext {
             // upstream: flist.c:2931 - ndx_start = prev->ndx_start + prev->used + 1
             self.ndx_segments.push((flat_start, seg_ndx_start));
 
+            // DDP-B3 (#2257): if a parallel-deterministic-delete context
+            // is attached, publish a DeletePlan for this segment's
+            // content directory into the shared DeletePlanMap. Failures
+            // are logged + skipped; the legacy batched-sweep path
+            // remains the active delete driver until the emitter wiring
+            // lands (tasks DDP-E1-E5).
+            self.publish_segment_to_delete_pipeline(dir_ndx, flat_start);
+
             debug_log!(
                 Flist,
                 2,
@@ -437,6 +445,71 @@ impl ReceiverContext {
         }
 
         removed
+    }
+
+    /// Publishes one INC_RECURSE segment into the parallel-deterministic-
+    /// delete pipeline, if a [`engine::delete::DeleteContext`] has been
+    /// attached via [`super::ReceiverContext::set_delete_context`].
+    ///
+    /// `dir_ndx` is the wire NDX of the segment's parent directory (the
+    /// content directory the segment describes). `flat_start` is the
+    /// flat-array index where this segment's entries begin in
+    /// `self.file_list`; the entries slice is
+    /// `self.file_list[flat_start..]`.
+    ///
+    /// # Behaviour
+    ///
+    /// - When no context is attached, returns immediately.
+    /// - Otherwise, resolves the parent directory's destination-relative
+    ///   path via [`Self::wire_to_flat_ndx`] and
+    ///   [`protocol::flist::FileEntry::path`], then forwards the segment
+    ///   to [`engine::delete::DeleteContext::observe_segment_for_delete`].
+    /// - I/O failures from `compute_extras` are logged at level 2 and
+    ///   swallowed; the legacy batched-sweep path remains the
+    ///   authoritative delete driver, so a transient read_dir error here
+    ///   does not abort the transfer.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `generator.c:272-347` `delete_in_dir()` - per-directory extras
+    ///   computation that this hook publishes a plan for.
+    pub(in crate::receiver) fn publish_segment_to_delete_pipeline(
+        &self,
+        dir_ndx: i32,
+        flat_start: usize,
+    ) {
+        let Some(ctx) = self.delete_ctx.as_ref() else {
+            return;
+        };
+        let Some(parent_flat) = self.wire_to_flat_ndx(dir_ndx) else {
+            debug_log!(
+                Flist,
+                2,
+                "delete pipeline: dir_ndx={} did not resolve to a flat index; skipping segment publish",
+                dir_ndx
+            );
+            return;
+        };
+        let Some(parent) = self.file_list.get(parent_flat) else {
+            debug_log!(
+                Flist,
+                2,
+                "delete pipeline: parent flat_idx={} out of range; skipping segment publish",
+                parent_flat
+            );
+            return;
+        };
+        let dir = parent.path().to_path_buf();
+        let entries = &self.file_list[flat_start..];
+        if let Err(err) = ctx.observe_segment_for_delete(&dir, entries) {
+            debug_log!(
+                Flist,
+                2,
+                "delete pipeline: observe_segment_for_delete({}) failed: {}; legacy sweep will still run",
+                dir.display(),
+                err
+            );
+        }
     }
 
     /// Creates an incremental file list receiver for streaming processing.

--- a/crates/transfer/src/receiver/mod.rs
+++ b/crates/transfer/src/receiver/mod.rs
@@ -53,6 +53,7 @@ use protocol::idlist::IdList;
 use protocol::{CompatibilityFlags, NegotiationResult, ProtocolVersion};
 
 use engine::HardlinkApplyTracker;
+use engine::delete::DeleteContext;
 
 use crate::config::ServerConfig;
 use crate::delta_pipeline::{ReceiverDeltaPipeline, SequentialDeltaPipeline};
@@ -235,6 +236,19 @@ pub struct ReceiverContext {
     /// Different operations have different overhead profiles: CPU-bound signature
     /// computation benefits from parallelism at lower counts than I/O-bound stat calls.
     parallel_thresholds: ParallelThresholds,
+    /// Optional handle into the parallel-deterministic-delete pipeline.
+    ///
+    /// When `Some`, the receiver publishes a [`engine::delete::DeletePlan`]
+    /// for every INC_RECURSE segment via
+    /// [`DeleteContext::observe_segment_for_delete`]. The plans accumulate
+    /// in the shared [`engine::delete::DeletePlanMap`] for the (not-yet-
+    /// active) emitter to drain. When `None`, the receiver behaves
+    /// identically to the legacy batched-sweep path; nothing in the
+    /// segment loop calls into the delete pipeline.
+    ///
+    /// This is wired by task DDP-B3 (#2257) and consumed by the emitter
+    /// wiring in tasks DDP-E1-E5.
+    delete_ctx: Option<Arc<DeleteContext>>,
 }
 
 impl ReceiverContext {
@@ -280,7 +294,67 @@ impl ReceiverContext {
             flist_io_error: 0,
             delta_pipeline: Some(Box::new(SequentialDeltaPipeline::new())),
             parallel_thresholds: ParallelThresholds::default(),
+            delete_ctx: None,
         }
+    }
+
+    /// Attaches a [`DeleteContext`] to the receiver.
+    ///
+    /// When set, the receiver's per-segment hook publishes one
+    /// [`engine::delete::DeletePlan`] per INC_RECURSE segment into the
+    /// context's shared [`engine::delete::DeletePlanMap`]. Plans
+    /// accumulate for later consumption by the emitter (tasks
+    /// DDP-E1-E5); the legacy batched-sweep path remains active and
+    /// continues to drive observable deletions until the emitter takes
+    /// over.
+    ///
+    /// Pass `None` to detach the context. Must be called before
+    /// [`run`](Self::run) - the context is consumed on each segment.
+    pub fn set_delete_context(&mut self, ctx: Option<Arc<DeleteContext>>) {
+        self.delete_ctx = ctx;
+    }
+
+    /// Returns a clone of the current [`DeleteContext`] handle, if any.
+    #[must_use]
+    pub fn delete_context(&self) -> Option<Arc<DeleteContext>> {
+        self.delete_ctx.as_ref().map(Arc::clone)
+    }
+
+    /// Converts a wire NDX value to a flat file list array index.
+    ///
+    /// Inverse of [`Self::flat_to_wire_ndx`]. Walks the segment table
+    /// (`ndx_segments`) to find the segment owning `wire_ndx` and
+    /// computes the flat offset within it. Returns `None` when the wire
+    /// NDX falls outside every segment's range (for example NDX 0 under
+    /// INC_RECURSE, which is reserved).
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `flist.c:2931` - segment table layout used to do the inverse
+    ///   mapping.
+    pub(in crate::receiver) fn wire_to_flat_ndx(&self, wire_ndx: i32) -> Option<usize> {
+        let segments = &self.ndx_segments;
+        // Find the segment whose `ndx_start` is <= wire_ndx.
+        let seg_idx = segments
+            .partition_point(|&(_, ns)| ns <= wire_ndx)
+            .checked_sub(1)?;
+        let (flat_start, ndx_start) = segments[seg_idx];
+        if wire_ndx < ndx_start {
+            return None;
+        }
+        let offset = (wire_ndx - ndx_start) as usize;
+        let flat_idx = flat_start + offset;
+        // Bound by the next segment's flat_start (or file_list len for
+        // the last segment), so we never return an index past the end
+        // of the segment we located.
+        let seg_end = segments
+            .get(seg_idx + 1)
+            .map(|&(start, _)| start)
+            .unwrap_or(self.file_list.len());
+        if flat_idx >= seg_end {
+            return None;
+        }
+        Some(flat_idx)
     }
 
     /// Replaces the delta dispatch pipeline.

--- a/crates/transfer/src/receiver/tests.rs
+++ b/crates/transfer/src/receiver/tests.rs
@@ -3897,3 +3897,153 @@ fn receiver_ndx_convert_partition_point_depth_grows() {
         N * per_call_depth
     );
 }
+
+/// Verifies that [`super::ReceiverContext::wire_to_flat_ndx`] is the
+/// inverse of [`super::ReceiverContext::flat_to_wire_ndx`] across a
+/// multi-segment table built up by INC_RECURSE.
+#[test]
+fn wire_to_flat_ndx_round_trips_with_flat_to_wire() {
+    let handshake = test_handshake();
+    let config = test_config();
+    let mut ctx = ReceiverContext::new(&handshake, config);
+
+    // Simulate INC_RECURSE: initial segment (0, 1) plus two extras.
+    ctx.ndx_segments = vec![(0, 1), (5, 7), (12, 15)];
+    ctx.file_list = (0..18)
+        .map(|i| FileEntry::new_file(PathBuf::from(format!("f{i}")), 0, 0o644))
+        .collect();
+
+    for flat in 0..18usize {
+        let wire = ctx.flat_to_wire_ndx(flat);
+        assert_eq!(
+            ctx.wire_to_flat_ndx(wire),
+            Some(flat),
+            "round-trip failed at flat={flat} wire={wire}"
+        );
+    }
+
+    // Out-of-range wire NDXes (the reserved 0 under INC_RECURSE and any
+    // value above the last segment's max) must return None.
+    assert_eq!(ctx.wire_to_flat_ndx(0), None);
+    assert_eq!(ctx.wire_to_flat_ndx(i32::MAX), None);
+}
+
+/// DDP-B3 (#2257) integration check: a synthetic INC_RECURSE state with
+/// a `DeleteContext` attached publishes one [`engine::delete::DeletePlan`]
+/// per segment into the shared [`engine::delete::DeletePlanMap`], and the
+/// emitter-side traversal cursor records the segment's child directories.
+#[test]
+fn delete_pipeline_hook_publishes_one_plan_per_segment() {
+    use std::sync::Arc;
+
+    use engine::delete::{DeleteContext, DeletePlanMap};
+
+    // Build a destination tree with extras the receiver should plan to
+    // delete:
+    //   <root>/sub1/keep
+    //   <root>/sub1/extra
+    //   <root>/sub2/keep
+    //   <root>/sub2/extra
+    let tmp = tempfile::TempDir::new().unwrap();
+    for sub in ["sub1", "sub2"] {
+        let dir = tmp.path().join(sub);
+        std::fs::create_dir(&dir).unwrap();
+        std::fs::write(dir.join("keep"), b"").unwrap();
+        std::fs::write(dir.join("extra"), b"").unwrap();
+    }
+
+    let handshake = test_handshake();
+    let config = test_config();
+    let mut ctx = ReceiverContext::new(&handshake, config);
+
+    // Build a flist matching what the receiver would have after the
+    // initial segment plus two INC_RECURSE segments. Segment table is
+    // laid out so wire NDX 1 -> "sub1", wire NDX 2 -> "sub2".
+    ctx.file_list = vec![
+        FileEntry::new_directory(PathBuf::from("sub1"), 0o755),
+        FileEntry::new_directory(PathBuf::from("sub2"), 0o755),
+        // sub1 segment entries (flat 2..=3)
+        FileEntry::new_file(PathBuf::from("keep"), 0, 0o644),
+        FileEntry::new_directory(PathBuf::from("nested1"), 0o755),
+        // sub2 segment entries (flat 4..=5)
+        FileEntry::new_file(PathBuf::from("keep"), 0, 0o644),
+        FileEntry::new_directory(PathBuf::from("nested2"), 0o755),
+    ];
+    // Initial segment owns wire 1..=2 at flat 0..=1; segments owning
+    // wire 4..=5 at flat 2..=3, then 7..=8 at flat 4..=5.
+    ctx.ndx_segments = vec![(0, 1), (2, 4), (4, 7)];
+
+    let map = Arc::new(DeletePlanMap::new());
+    let delete_ctx = Arc::new(DeleteContext::new(
+        Arc::clone(&map),
+        tmp.path().to_path_buf(),
+        true,
+    ));
+    ctx.set_delete_context(Some(Arc::clone(&delete_ctx)));
+
+    // Observe the synthetic root segment first so the traversal cursor
+    // knows sub1 and sub2 are children of the root. The receiver
+    // normally does this implicitly when `receive_file_list` lands the
+    // initial flist; here we feed it directly so the cursor walk in
+    // the assertion below can descend into both subtrees.
+    delete_ctx
+        .observe_segment_for_delete(
+            std::path::Path::new(""),
+            &[
+                FileEntry::new_directory(PathBuf::from("sub1"), 0o755),
+                FileEntry::new_directory(PathBuf::from("sub2"), 0o755),
+            ],
+        )
+        .expect("root observe ok");
+
+    // dir_ndx wire 1 -> "sub1" segment at flat_start 2
+    ctx.publish_segment_to_delete_pipeline(1, 2);
+    // dir_ndx wire 2 -> "sub2" segment at flat_start 4
+    ctx.publish_segment_to_delete_pipeline(2, 4);
+
+    assert_eq!(
+        map.len(),
+        3,
+        "root + two segments -> three plans (root, sub1, sub2)"
+    );
+    // Drop the root plan so the rest of the assertions focus on sub1
+    // and sub2 alone.
+    let _ = map.take(std::path::Path::new(""));
+    let sub1_plan = map.take(std::path::Path::new("sub1")).expect("sub1 plan");
+    let sub2_plan = map.take(std::path::Path::new("sub2")).expect("sub2 plan");
+
+    let sub1_names: Vec<&std::ffi::OsStr> = sub1_plan
+        .extras
+        .iter()
+        .map(|e| e.name.as_os_str())
+        .collect();
+    let sub2_names: Vec<&std::ffi::OsStr> = sub2_plan
+        .extras
+        .iter()
+        .map(|e| e.name.as_os_str())
+        .collect();
+    assert_eq!(sub1_names, vec![std::ffi::OsStr::new("extra")]);
+    assert_eq!(sub2_names, vec![std::ffi::OsStr::new("extra")]);
+
+    // Cursor should have learned about nested1 + nested2 as child dirs.
+    let mut cursor = delete_ctx.cursor.lock().unwrap();
+    let seq: Vec<PathBuf> = std::iter::from_fn(|| cursor.next_ready()).collect();
+    assert!(seq.contains(&PathBuf::from("sub1/nested1")));
+    assert!(seq.contains(&PathBuf::from("sub2/nested2")));
+}
+
+/// DDP-B3 (#2257): with no [`engine::delete::DeleteContext`] attached,
+/// the segment hook is a no-op even when invoked directly.
+#[test]
+fn delete_pipeline_hook_is_noop_when_no_context_attached() {
+    let handshake = test_handshake();
+    let config = test_config();
+    let mut ctx = ReceiverContext::new(&handshake, config);
+    ctx.file_list = vec![FileEntry::new_directory(PathBuf::from("sub"), 0o755)];
+    ctx.ndx_segments = vec![(0, 1)];
+
+    // Should not panic, should not touch any external state. The
+    // absence of a DeleteContext means publish is a pure return.
+    ctx.publish_segment_to_delete_pipeline(1, 1);
+    assert!(ctx.delete_context().is_none());
+}


### PR DESCRIPTION
## Summary

- Adds `engine::delete::DeleteContext`, the shared handle the receiver threads through to the parallel-deterministic-delete pipeline's phase-1 producers. For each INC_RECURSE segment, `observe_segment_for_delete` computes per-directory extras, wraps them in a sorted `DeletePlan`, publishes the plan into the shared `DeletePlanMap`, and records the segment's child directories in the emitter-side `DirTraversalCursor`.
- Wires the new context into the receiver's per-segment loop (`receive_extra_file_lists`) via `ReceiverContext::publish_segment_to_delete_pipeline`, gated on a new `delete_ctx: Option<Arc<DeleteContext>>` field. The field defaults to `None`, so the legacy batched-sweep path is unchanged unless callers opt in via `set_delete_context`.
- Adds a `wire_to_flat_ndx` helper as the inverse of `flat_to_wire_ndx`, used to resolve the segment's parent directory wire NDX to a flat index in `file_list`.

The emitter wiring that consumes published plans is intentionally deferred to tasks DDP-E1-E5; this PR only publishes plans into the map.

## Test plan

- [x] `cargo test -p engine --lib delete::context` - 6 new unit tests pass (disabled is a no-op, enabled publishes sorted plan + records children, accumulates across segments, missing dest dir surfaces NotFound, custom cursor root, empty segment still publishes plan for dest-only entries).
- [x] `cargo test -p transfer --lib receiver::` - 226 receiver tests pass, including the three new tests (`wire_to_flat_ndx_round_trips_with_flat_to_wire`, `delete_pipeline_hook_publishes_one_plan_per_segment`, `delete_pipeline_hook_is_noop_when_no_context_attached`).
- [x] `cargo clippy -p engine -p transfer --all-features --no-deps` - clean.
- [x] `cargo fmt --all -- --check` - clean.