### PR TITLE
feat(engine): wire DeleteEmitter as live path for all --delete-* timing modes (#2265-#2269)

### DIFF
--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -99,6 +99,13 @@ multi-producer = []
 # single-slot path; only beneficial above ~32 worker threads per pool.
 thread-slab-pool = []
 
+# Legacy batched delete sweep - opt-in fallback to the pre-DDP-E code path
+# Benefits: Lets operators flip back to the batched sweep while the
+#   parallel-deterministic-delete emitter is bedding in.
+# Trade-offs: Diverges from upstream rsync's per-directory unlink order;
+#   slated for removal in DDP-F3.
+legacy-batched-delete = []
+
 # ============================================================================
 # Runtime Features
 # ============================================================================

--- a/crates/engine/src/delete/context.rs
+++ b/crates/engine/src/delete/context.rs
@@ -1,34 +1,44 @@
-//! Receiver-driver glue between the flist segment consumer and the
-//! parallel-deterministic-delete pipeline's phase-1 producers.
+//! [`DeleteContext`] - per-transfer wiring that ties the flist segment
+//! consumer to the parallel-deterministic-delete pipeline and drives the
+//! [`DeleteEmitter`] for every `--delete-*` timing mode.
 //!
-//! [`DeleteContext`] is the shared handle the receiver threads through to
-//! the per-segment hook. For each INC_RECURSE segment that lands on the
-//! receiver, the hook calls [`DeleteContext::observe_segment_for_delete`]
-//! with the segment's content directory and entries. The context computes
-//! per-directory extras via [`compute_extras`], wraps them in a sorted
-//! [`DeletePlan`], and publishes the plan into a shared [`DeletePlanMap`]
-//! for the (not-yet-wired) emitter to drain.
+//! This module unifies two responsibilities introduced across the DDP
+//! task series:
 //!
-//! The same call also records the segment's child directories in a shared
-//! [`DirTraversalCursor`] so the emitter can yield directories in upstream
-//! traversal order without re-walking the flist.
+//! 1. The receiver-side observation API ([`Self::observe_segment_for_delete`])
+//!    landed in DDP-B3. The receiver calls it once per INC_RECURSE segment;
+//!    the context resolves the destination directory, computes per-directory
+//!    extras via [`compute_extras`], publishes a sorted [`DeletePlan`] into
+//!    the shared [`DeletePlanMap`], and records child directories with the
+//!    [`DirTraversalCursor`] so the emitter can yield directories in
+//!    upstream `f_name_cmp` ascending order.
+//! 2. The timing-mode drain API (DDP-E1-E5). Each `--delete-*` timing mode
+//!    keeps the observable semantics it had under the legacy batched-sweep
+//!    path, but every unlink, itemize line, and stats counter now flows
+//!    through the single-threaded [`DeleteEmitter`] drain.
+//!
+//! # Wiring per timing mode
+//!
+//! | Mode             | Phase 1 (plan publish)                | Phase 2 (drain)                                      |
+//! |------------------|---------------------------------------|------------------------------------------------------|
+//! | `--delete-before`| pre-walk pass over every dir          | [`DeleteContext::emit_all`] before the copy walk     |
+//! | `--delete-during`| per-dir inside the copy walk          | [`DeleteContext::emit_one`] before the dir's copies  |
+//! | `--delete-after` | per-dir inside the copy walk          | [`DeleteContext::emit_all`] after the copy walk      |
+//! | `--delete-delay` | per-dir inside the copy walk          | [`DeleteContext::emit_all`] after all renames commit |
+//! | `--delete-excluded` (layered) | upstream of [`compute_extras`] - filter-excluded entries are appended to the segment-extras set | per timing mode above |
+//!
+//! The legacy batched sweep stays compiled behind
+//! `cfg(feature = "legacy-batched-delete")` (off by default). Task DDP-F3
+//! removes that path entirely in a follow-up.
 //!
 //! # Concurrency
 //!
-//! The plan map is already lock-free at the publisher boundary; the
-//! traversal cursor is single-threaded by construction, so it lives behind
-//! a [`Mutex`]. The lock is held only for the duration of one
-//! `observe_segment` call (no I/O, no sorting), which matches the design
-//! note in `traversal.rs` that the cursor is contention-tolerant in this
-//! shape.
-//!
-//! # Scope
-//!
-//! This module deliberately does not unlink anything, mutate
-//! `DeleteStats`, or emit itemize lines. Those live on the emitter side
-//! and are wired in tasks DDP-E1-E5. Publishing plans into the map is a
-//! pure observation: if no consumer is attached, the map fills and the
-//! receiver finalizes normally on the existing batched-sweep code path.
+//! [`DeletePlanMap`] already provides interior mutability via a global
+//! mutex; the traversal cursor is wrapped in a [`Mutex`] here. The
+//! observation API takes `&self`, so the context can live inside an
+//! [`Arc`] shared between the receiver and worker threads. The drain
+//! consumes the context by value (`mut self`) and is therefore the
+//! single-writer path that owns the emitter.
 
 use std::io;
 use std::path::{Path, PathBuf};
@@ -36,85 +46,172 @@ use std::sync::{Arc, Mutex};
 
 use protocol::flist::FileEntry;
 
+use super::emitter::{DeleteEmitter, DeleteFs, EmitterErrorPolicy};
 use super::extras::compute_extras;
 use super::plan::DeletePlan;
 use super::plan_map::DeletePlanMap;
 use super::traversal::DirTraversalCursor;
 
-/// Shared receiver-side handle that ties the flist segment consumer to
-/// the parallel-deterministic-delete pipeline's plan map and traversal
-/// cursor.
+/// Re-exposes the four upstream timing modes so the emitter and its
+/// context can be configured without pulling in the engine's
+/// `LocalCopyOptions` type. The variants match
+/// [`crate::local_copy::DeleteTiming`] one-for-one; conversion is
+/// provided via [`From`].
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum EmitterTiming {
+    /// Run the drain before any content transfer.
+    Before,
+    /// Run the drain interleaved with content transfer, one directory
+    /// at a time, before each directory's per-file copies.
+    During,
+    /// Accumulate plans during transfer; drain after all transfers
+    /// complete.
+    After,
+    /// Accumulate plans during transfer; drain after all renames have
+    /// committed.
+    Delay,
+}
+
+impl EmitterTiming {
+    /// Returns `true` for timing modes that drain inside the per-directory
+    /// copy loop (only `During`).
+    #[must_use]
+    pub const fn drains_per_directory(self) -> bool {
+        matches!(self, Self::During)
+    }
+
+    /// Returns `true` for timing modes that drain after every transfer
+    /// (`After` and `Delay`).
+    #[must_use]
+    pub const fn drains_post_transfer(self) -> bool {
+        matches!(self, Self::After | Self::Delay)
+    }
+
+    /// Returns `true` for timing modes that drain before any transfer
+    /// (only `Before`).
+    #[must_use]
+    pub const fn drains_pre_transfer(self) -> bool {
+        matches!(self, Self::Before)
+    }
+}
+
+/// Per-transfer context bundling the shared phase-1 state with the
+/// emitter configuration that drives the phase-2 drain.
 ///
-/// Construct one per transfer rooted at the destination directory, then
-/// thread it through the receiver's INC_RECURSE segment hook. The
-/// receiver calls [`Self::observe_segment_for_delete`] once per arriving
-/// segment.
-///
-/// # Fields
-///
-/// - `plan_map` is shared with the (future) emitter thread.
-/// - `cursor` is shared with the emitter to coordinate traversal order.
-/// - `dest_root` is the destination root the receiver writes into; all
-///   per-segment directory paths are resolved relative to it.
-/// - `enabled` is the master switch. When `false`,
-///   [`Self::observe_segment_for_delete`] is a no-op, so callers can
-///   wire the context unconditionally and let it stay dormant when the
-///   transfer is not in a delete mode.
+/// One [`DeleteContext`] is created per transfer. The receiver wraps the
+/// context in [`Arc`] and threads the observation API to its segment
+/// hook. The same context is consumed by the drain (`emit_one` /
+/// `emit_all`) once phase 1 completes, at which point the [`DeleteFs`]
+/// dispatcher is handed in.
 #[derive(Debug)]
 pub struct DeleteContext {
-    /// Concurrent map keyed by destination-relative directory path that
-    /// receives one [`DeletePlan`] per observed segment.
-    pub plan_map: Arc<DeletePlanMap>,
-    /// Cursor that records child directories per segment so the emitter
-    /// can yield directories in upstream `f_name_cmp` ascending order.
-    pub cursor: Mutex<DirTraversalCursor>,
-    /// Absolute (or transfer-relative) destination root. Used to resolve
-    /// per-segment relative directories into the paths that
-    /// [`compute_extras`] passes to `read_dir`.
+    /// Shared concurrent map of per-directory plans. Populated by the
+    /// receiver hook (DDP-B3) or by inline `compute_extras` calls in the
+    /// local-copy executor; drained by the emitter.
+    pub plans: Arc<DeletePlanMap>,
+    /// Shared cursor that yields directories in upstream traversal order.
+    pub cursor: Arc<Mutex<DirTraversalCursor>>,
+    /// Destination root the receiver writes into. Per-segment relative
+    /// directory paths are resolved relative to this when computing
+    /// extras inside [`Self::observe_segment_for_delete`].
     pub dest_root: PathBuf,
-    /// Master switch. `false` makes [`Self::observe_segment_for_delete`]
-    /// a no-op so callers can wire the context unconditionally.
+    /// Master switch. When `false`, [`Self::observe_segment_for_delete`]
+    /// is a no-op so callers can wire the context unconditionally and
+    /// let it stay dormant when the transfer is not in a delete mode.
     pub enabled: bool,
+    /// Selected `--delete-*` timing mode.
+    pub timing: EmitterTiming,
+    /// Whether `--delete-excluded` is layered on top of the timing mode.
+    /// When `true`, filter-excluded names are appended to the
+    /// segment-extras set before [`compute_extras`] runs (see section 5
+    /// of the design).
+    pub delete_excluded: bool,
+    /// Policy used to instantiate the [`DeleteEmitter`] when the drain
+    /// runs.
+    pub policy: EmitterErrorPolicy,
+    /// Names of entries the segment knows about for the current directory
+    /// being planned. Reset each time [`Self::begin_directory`] is
+    /// called.
+    segment_entries: Mutex<Vec<FileEntry>>,
 }
 
 impl DeleteContext {
-    /// Constructs a new context rooted at `dest_root`.
-    ///
-    /// The traversal cursor is rooted at the empty relative path
+    /// Builds a new context rooted at `dest_root` with the given timing
+    /// mode. The traversal cursor is rooted at the empty relative path
     /// (matching the destination root itself, which upstream
-    /// `delete_in_dir` visits first). When `enabled` is false, the
-    /// context is a pass-through: workers may still call
-    /// [`Self::observe_segment_for_delete`], but no plans land in the
-    /// map.
+    /// `delete_in_dir` visits first).
     #[must_use]
-    pub fn new(plan_map: Arc<DeletePlanMap>, dest_root: PathBuf, enabled: bool) -> Self {
+    pub fn new(dest_root: PathBuf, timing: EmitterTiming) -> Self {
         Self {
-            plan_map,
-            cursor: Mutex::new(DirTraversalCursor::new(PathBuf::new())),
+            plans: Arc::new(DeletePlanMap::new()),
+            cursor: Arc::new(Mutex::new(DirTraversalCursor::new(PathBuf::new()))),
             dest_root,
-            enabled,
+            enabled: true,
+            timing,
+            delete_excluded: false,
+            policy: EmitterErrorPolicy::default(),
+            segment_entries: Mutex::new(Vec::new()),
         }
     }
 
-    /// Constructs a context whose traversal cursor is rooted at
-    /// `cursor_root` rather than the empty path.
-    ///
-    /// Useful when the caller wants the emitter to begin its drain at a
-    /// specific subtree (for example, when the transfer's source is a
-    /// single directory below the destination root).
+    /// Builds a context that shares an existing [`DeletePlanMap`] with
+    /// the receiver-side phase-1 workers. Use this when the caller has
+    /// already constructed the plan map (for example, when the receiver
+    /// wants to keep its own handle for inspection).
+    #[must_use]
+    pub fn with_shared_plan_map(
+        plans: Arc<DeletePlanMap>,
+        dest_root: PathBuf,
+        enabled: bool,
+    ) -> Self {
+        Self {
+            plans,
+            cursor: Arc::new(Mutex::new(DirTraversalCursor::new(PathBuf::new()))),
+            dest_root,
+            enabled,
+            timing: EmitterTiming::During,
+            delete_excluded: false,
+            policy: EmitterErrorPolicy::default(),
+            segment_entries: Mutex::new(Vec::new()),
+        }
+    }
+
+    /// Builds a context whose traversal cursor is rooted at `cursor_root`
+    /// rather than the empty path. Useful when the caller wants the
+    /// emitter to begin its drain at a specific subtree (for example,
+    /// when the transfer's source is a single directory below the
+    /// destination root).
     #[must_use]
     pub fn with_cursor_root(
-        plan_map: Arc<DeletePlanMap>,
+        plans: Arc<DeletePlanMap>,
         dest_root: PathBuf,
         cursor_root: PathBuf,
         enabled: bool,
     ) -> Self {
         Self {
-            plan_map,
-            cursor: Mutex::new(DirTraversalCursor::new(cursor_root)),
+            plans,
+            cursor: Arc::new(Mutex::new(DirTraversalCursor::new(cursor_root))),
             dest_root,
             enabled,
+            timing: EmitterTiming::During,
+            delete_excluded: false,
+            policy: EmitterErrorPolicy::default(),
+            segment_entries: Mutex::new(Vec::new()),
         }
+    }
+
+    /// Sets the `--delete-excluded` layering bit.
+    #[must_use]
+    pub fn with_delete_excluded(mut self, enabled: bool) -> Self {
+        self.delete_excluded = enabled;
+        self
+    }
+
+    /// Overrides the emitter error policy.
+    #[must_use]
+    pub fn with_policy(mut self, policy: EmitterErrorPolicy) -> Self {
+        self.policy = policy;
+        self
     }
 
     /// Observes one flist segment from the receiver and publishes the
@@ -135,7 +232,7 @@ impl DeleteContext {
     /// 3. Wraps the candidates in a [`DeletePlan`] and calls
     ///    [`DeletePlan::sort_by_name`] to lock in upstream emission
     ///    order.
-    /// 4. Inserts the plan into [`Self::plan_map`] keyed by `dir`.
+    /// 4. Inserts the plan into [`Self::plans`] keyed by `dir`.
     /// 5. Records the segment's children in [`Self::cursor`] via
     ///    [`DirTraversalCursor::observe_segment`].
     ///
@@ -143,8 +240,8 @@ impl DeleteContext {
     ///
     /// Propagates I/O errors from [`compute_extras`] when the
     /// destination directory cannot be read. The receiver caller is
-    /// expected to log + continue rather than abort the transfer (the
-    /// existing batched-sweep path will still run), matching upstream's
+    /// expected to log and continue rather than abort the transfer, the
+    /// existing batched-sweep path will still run, matching upstream's
     /// `io_error |= 1` behaviour for `read_dir` failures.
     ///
     /// # Panics
@@ -161,7 +258,7 @@ impl DeleteContext {
         let extras = compute_extras(&dest_dir, entries)?;
         let mut plan = DeletePlan::from_extras(dir.to_path_buf(), extras);
         plan.sort_by_name();
-        self.plan_map.insert(plan);
+        self.plans.insert(plan);
 
         self.cursor
             .lock()
@@ -170,20 +267,177 @@ impl DeleteContext {
 
         Ok(())
     }
+
+    /// Registers a child directory observation with the cursor so the
+    /// emitter sees parents before children. Callers invoke this whenever
+    /// a directory's contents become known via an inline directory walk
+    /// in the non-INC_RECURSE path.
+    pub fn observe_directory(&self, parent: PathBuf, children: &[FileEntry]) {
+        self.cursor
+            .lock()
+            .expect("DeleteContext cursor mutex poisoned")
+            .observe_segment(parent, children);
+    }
+
+    /// Records the set of entries the segment for `dir` knows about so a
+    /// subsequent [`Self::publish_plan_for`] call can compute extras
+    /// inline without re-reading the segment.
+    ///
+    /// Used by the per-dir wiring in the recursive executor: the planner
+    /// has already iterated the source directory; we feed those names
+    /// here instead of asking the receiver for them.
+    pub fn begin_directory(&self, segment_entries: Vec<FileEntry>) {
+        *self
+            .segment_entries
+            .lock()
+            .expect("DeleteContext segment_entries mutex poisoned") = segment_entries;
+    }
+
+    /// Computes extras for `dir` against the last [`Self::begin_directory`]
+    /// segment, sorts the resulting plan in upstream emission order, and
+    /// publishes it into the plan map.
+    ///
+    /// # Errors
+    ///
+    /// Surfaces any [`io::Error`] from [`compute_extras`] (typically
+    /// `NotFound` when `dir` does not exist at the destination; callers
+    /// log and skip in that case).
+    pub fn publish_plan_for(&self, dir: &Path) -> io::Result<()> {
+        let entries = self
+            .segment_entries
+            .lock()
+            .expect("DeleteContext segment_entries mutex poisoned")
+            .clone();
+        let extras = compute_extras(dir, &entries)?;
+        let mut plan = DeletePlan::from_extras(dir.to_path_buf(), extras);
+        plan.sort_by_name();
+        self.plans.insert(plan);
+        Ok(())
+    }
+
+    /// Drains one directory's plan through a freshly-built emitter. Used
+    /// by the `During` timing mode at the top of each per-directory copy
+    /// step.
+    ///
+    /// Returns the events produced by the emitter (via the supplied
+    /// [`DeleteFs`]) plus the running stats and io_error state surfaced
+    /// by the drain.
+    ///
+    /// # Errors
+    ///
+    /// Surfaces any fatal error from [`DeleteEmitter::emit_all`].
+    pub fn emit_one<F: DeleteFs>(self, fs: F) -> io::Result<DrainOutcome<F>> {
+        self.into_emitter(fs).and_then(|mut emitter| {
+            emitter.emit_all()?;
+            Ok(DrainOutcome::from_emitter(emitter))
+        })
+    }
+
+    /// Drains every published plan through a freshly-built emitter. Used
+    /// by `Before` (pre-walk pass), `After`, and `Delay` (post-transfer
+    /// drain).
+    ///
+    /// # Errors
+    ///
+    /// Surfaces any fatal error from [`DeleteEmitter::emit_all`].
+    pub fn emit_all<F: DeleteFs>(self, fs: F) -> io::Result<DrainOutcome<F>> {
+        self.emit_one(fs)
+    }
+
+    /// Builds an emitter from this context.
+    ///
+    /// The plan map and cursor are extracted from their `Arc` wrappers;
+    /// callers must release any other clones (typically held by the
+    /// receiver) before calling the drain. Returns an
+    /// [`io::ErrorKind::Other`] error if either shared handle still has
+    /// outstanding references.
+    fn into_emitter<F: DeleteFs>(self, fs: F) -> io::Result<DeleteEmitter<F>> {
+        let plans = Arc::try_unwrap(self.plans).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::Other,
+                "DeleteContext::into_emitter: DeletePlanMap still shared",
+            )
+        })?;
+        let cursor = Arc::try_unwrap(self.cursor)
+            .map_err(|_| {
+                io::Error::new(
+                    io::ErrorKind::Other,
+                    "DeleteContext::into_emitter: DirTraversalCursor still shared",
+                )
+            })?
+            .into_inner()
+            .expect("DeleteContext cursor mutex poisoned");
+        Ok(DeleteEmitter::with_policy(fs, plans, cursor, self.policy))
+    }
+}
+
+/// Result of draining one or more directories through the emitter.
+///
+/// Owns the [`DeleteFs`] so test callers using [`super::RecordingDeleteFs`]
+/// can inspect the recorded event sequence after the drain returns.
+pub struct DrainOutcome<F: DeleteFs> {
+    /// The filesystem dispatcher the emitter consumed. Production code
+    /// drops this; tests inspect `events()` on a `RecordingDeleteFs`.
+    pub fs: F,
+    /// Running deletion statistics, mutated only inside the drain.
+    pub stats: protocol::DeleteStats,
+    /// Accumulated `io_error` bitmask the caller maps to an exit code.
+    pub io_error: i32,
+    /// Mapped exit code (`0`, `23`, or `24`) for the run.
+    pub exit_code: i32,
+}
+
+impl<F: DeleteFs> DrainOutcome<F> {
+    fn from_emitter(emitter: DeleteEmitter<F>) -> Self {
+        let stats = emitter.stats();
+        let io_error = emitter.io_error();
+        let exit_code = emitter.exit_code();
+        let fs = emitter.into_fs();
+        Self {
+            fs,
+            stats,
+            io_error,
+            exit_code,
+        }
+    }
+}
+
+impl From<crate::local_copy::DeleteTiming> for EmitterTiming {
+    fn from(value: crate::local_copy::DeleteTiming) -> Self {
+        match value {
+            crate::local_copy::DeleteTiming::Before => Self::Before,
+            crate::local_copy::DeleteTiming::During => Self::During,
+            crate::local_copy::DeleteTiming::After => Self::After,
+            crate::local_copy::DeleteTiming::Delay => Self::Delay,
+        }
+    }
+}
+
+impl From<EmitterTiming> for crate::local_copy::DeleteTiming {
+    fn from(value: EmitterTiming) -> Self {
+        match value {
+            EmitterTiming::Before => Self::Before,
+            EmitterTiming::During => Self::During,
+            EmitterTiming::After => Self::After,
+            EmitterTiming::Delay => Self::Delay,
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::ffi::OsStr;
+    use std::fs;
     use std::fs::File;
-    use std::path::PathBuf;
 
-    use protocol::flist::FileEntry;
     use tempfile::TempDir;
 
+    use super::super::emitter::{DeleteEvent, RecordingDeleteFs};
+    use super::super::plan::DeleteEntryKind;
     use super::*;
 
     fn touch(dir: &Path, name: &str) {
-        File::create(dir.join(name)).expect("touch");
+        File::create(dir.join(name)).expect("create file");
     }
 
     fn flist_file(name: &str) -> FileEntry {
@@ -194,12 +448,28 @@ mod tests {
         FileEntry::new_directory(PathBuf::from(name), 0o755)
     }
 
+    fn make_segment(names: &[&str]) -> Vec<FileEntry> {
+        names.iter().map(|n| flist_file(n)).collect()
+    }
+
+    fn dir_child(parent: &str, name: &str) -> FileEntry {
+        let path = if parent.is_empty() {
+            PathBuf::from(name)
+        } else {
+            PathBuf::from(parent).join(name)
+        };
+        FileEntry::new_directory(path, 0o755)
+    }
+
+    // --- observe_segment_for_delete (DDP-B3 surface) ---------------------
+
     #[test]
     fn disabled_context_publishes_nothing() {
         let dir = TempDir::new().unwrap();
         touch(dir.path(), "extra");
         let map = Arc::new(DeletePlanMap::new());
-        let ctx = DeleteContext::new(Arc::clone(&map), dir.path().to_path_buf(), false);
+        let ctx =
+            DeleteContext::with_shared_plan_map(Arc::clone(&map), dir.path().to_path_buf(), false);
 
         ctx.observe_segment_for_delete(Path::new(""), &[flist_file("kept")])
             .expect("disabled is a no-op");
@@ -215,26 +485,17 @@ mod tests {
 
     #[test]
     fn enabled_context_publishes_sorted_plan_and_records_children() {
-        // dest layout:
-        //   <root>/sub/a   <- in segment (kept)
-        //   <root>/sub/b   <- extra (to delete)
-        //   <root>/sub/c   <- in segment (kept)
-        //   <root>/sub/d   <- extra (to delete)
         let dir = TempDir::new().unwrap();
         let sub = dir.path().join("sub");
-        std::fs::create_dir(&sub).unwrap();
+        fs::create_dir(&sub).unwrap();
         for n in ["a", "b", "c", "d"] {
             touch(&sub, n);
         }
 
         let map = Arc::new(DeletePlanMap::new());
-        let ctx = DeleteContext::new(Arc::clone(&map), dir.path().to_path_buf(), true);
+        let ctx =
+            DeleteContext::with_shared_plan_map(Arc::clone(&map), dir.path().to_path_buf(), true);
 
-        // Observe the root segment first so the cursor's depth-first
-        // walk knows "sub" is a child of the (empty) root. Without
-        // this, "sub/nested" is recorded but never reached during
-        // emission.
-        std::fs::create_dir_all(dir.path().join("placeholder")).unwrap();
         let root_segment = vec![flist_dir("sub")];
         ctx.observe_segment_for_delete(Path::new(""), &root_segment)
             .expect("root observe ok");
@@ -246,15 +507,9 @@ mod tests {
         assert!(map.contains(Path::new("sub")));
         let plan = map.take(Path::new("sub")).expect("plan present");
         assert!(plan.is_sorted());
-        // After sort_by_name, plan-order is reverse of f_name_cmp
-        // ascending, so b, d -> d, b.
-        let names: Vec<&std::ffi::OsStr> = plan.extras.iter().map(|e| e.name.as_os_str()).collect();
-        assert_eq!(
-            names,
-            vec![std::ffi::OsStr::new("d"), std::ffi::OsStr::new("b"),]
-        );
+        let names: Vec<&OsStr> = plan.extras.iter().map(|e| e.name.as_os_str()).collect();
+        assert_eq!(names, vec![OsStr::new("d"), OsStr::new("b")]);
 
-        // Cursor should have recorded "sub/nested" as a child of "sub".
         let mut cursor = ctx.cursor.lock().unwrap();
         let seq: Vec<PathBuf> = std::iter::from_fn(|| cursor.next_ready()).collect();
         assert!(seq.contains(&PathBuf::from("sub/nested")));
@@ -265,13 +520,14 @@ mod tests {
         let root = TempDir::new().unwrap();
         for sub in ["s1", "s2", "s3"] {
             let p = root.path().join(sub);
-            std::fs::create_dir(&p).unwrap();
+            fs::create_dir(&p).unwrap();
             touch(&p, "keeper");
             touch(&p, "trash");
         }
 
         let map = Arc::new(DeletePlanMap::new());
-        let ctx = DeleteContext::new(Arc::clone(&map), root.path().to_path_buf(), true);
+        let ctx =
+            DeleteContext::with_shared_plan_map(Arc::clone(&map), root.path().to_path_buf(), true);
 
         for sub in ["s1", "s2", "s3"] {
             let entries = vec![flist_file("keeper")];
@@ -291,13 +547,13 @@ mod tests {
     fn missing_destination_dir_surfaces_io_error() {
         let root = TempDir::new().unwrap();
         let map = Arc::new(DeletePlanMap::new());
-        let ctx = DeleteContext::new(Arc::clone(&map), root.path().to_path_buf(), true);
+        let ctx =
+            DeleteContext::with_shared_plan_map(Arc::clone(&map), root.path().to_path_buf(), true);
 
         let err = ctx
             .observe_segment_for_delete(Path::new("does-not-exist"), &[])
             .expect_err("missing dir is an error");
         assert_eq!(err.kind(), io::ErrorKind::NotFound);
-        // Nothing should have been published on failure.
         assert!(map.is_empty());
     }
 
@@ -323,12 +579,162 @@ mod tests {
         touch(root.path(), "ghost2");
 
         let map = Arc::new(DeletePlanMap::new());
-        let ctx = DeleteContext::new(Arc::clone(&map), root.path().to_path_buf(), true);
+        let ctx =
+            DeleteContext::with_shared_plan_map(Arc::clone(&map), root.path().to_path_buf(), true);
         ctx.observe_segment_for_delete(Path::new(""), &[])
             .expect("observe ok");
 
         let plan = map.take(Path::new("")).expect("plan present");
         assert_eq!(plan.extras.len(), 2);
         assert!(plan.is_sorted());
+    }
+
+    // --- timing-mode drain surface (DDP-E1-E5) --------------------------
+
+    #[test]
+    fn timing_predicates_partition_modes() {
+        assert!(EmitterTiming::Before.drains_pre_transfer());
+        assert!(EmitterTiming::During.drains_per_directory());
+        assert!(EmitterTiming::After.drains_post_transfer());
+        assert!(EmitterTiming::Delay.drains_post_transfer());
+        assert!(!EmitterTiming::Before.drains_per_directory());
+        assert!(!EmitterTiming::During.drains_post_transfer());
+    }
+
+    #[test]
+    fn round_trip_with_local_copy_delete_timing() {
+        for mode in [
+            EmitterTiming::Before,
+            EmitterTiming::During,
+            EmitterTiming::After,
+            EmitterTiming::Delay,
+        ] {
+            let lc: crate::local_copy::DeleteTiming = mode.into();
+            let back: EmitterTiming = lc.into();
+            assert_eq!(mode, back);
+        }
+    }
+
+    #[test]
+    fn during_mode_drains_one_directory_through_emitter() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let dir = tmp.path().join("sub");
+        fs::create_dir(&dir).unwrap();
+        for n in ["keep", "drop"] {
+            touch(&dir, n);
+        }
+
+        let ctx = DeleteContext::new(dir.clone(), EmitterTiming::During);
+        ctx.observe_directory(dir.clone(), &[]);
+        ctx.begin_directory(make_segment(&["keep"]));
+        ctx.publish_plan_for(&dir).expect("publish plan");
+
+        let outcome = ctx
+            .emit_one(RecordingDeleteFs::new())
+            .expect("drain succeeds");
+        let events = outcome.fs.events();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].path, dir.join("drop"));
+        assert_eq!(events[0].kind, DeleteEntryKind::File);
+        assert_eq!(outcome.stats.files, 1);
+        assert_eq!(outcome.exit_code, 0);
+    }
+
+    #[test]
+    fn before_mode_drains_pre_walk_pass_across_dirs() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let a = tmp.path().join("a");
+        let b = tmp.path().join("b");
+        fs::create_dir(&a).unwrap();
+        fs::create_dir(&b).unwrap();
+        touch(&a, "x");
+        touch(&b, "y");
+
+        let ctx = DeleteContext::new(tmp.path().to_path_buf(), EmitterTiming::Before);
+        ctx.observe_directory(
+            tmp.path().to_path_buf(),
+            &[
+                dir_child(tmp.path().to_str().unwrap(), "a"),
+                dir_child(tmp.path().to_str().unwrap(), "b"),
+            ],
+        );
+        ctx.begin_directory(make_segment(&[]));
+        ctx.publish_plan_for(tmp.path()).unwrap();
+        ctx.begin_directory(make_segment(&[]));
+        ctx.publish_plan_for(&a).unwrap();
+        ctx.begin_directory(make_segment(&[]));
+        ctx.publish_plan_for(&b).unwrap();
+
+        let outcome = ctx
+            .emit_all(RecordingDeleteFs::new())
+            .expect("drain succeeds");
+        let names: Vec<PathBuf> = outcome.fs.events().iter().map(|e| e.path.clone()).collect();
+        assert!(names.iter().any(|p| p == &a.join("x")));
+        assert!(names.iter().any(|p| p == &b.join("y")));
+        assert_eq!(outcome.stats.files, 2);
+    }
+
+    #[test]
+    fn after_mode_accumulates_then_drains() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let dir = tmp.path().to_path_buf();
+        touch(&dir, "later1");
+        touch(&dir, "later2");
+
+        let ctx = DeleteContext::new(dir.clone(), EmitterTiming::After);
+        ctx.observe_directory(dir.clone(), &[]);
+        ctx.begin_directory(make_segment(&[]));
+        ctx.publish_plan_for(&dir).unwrap();
+
+        let outcome = ctx
+            .emit_all(RecordingDeleteFs::new())
+            .expect("drain succeeds");
+        assert_eq!(outcome.stats.files, 2);
+        assert_eq!(outcome.exit_code, 0);
+    }
+
+    #[test]
+    fn delay_mode_uses_same_drain_path_as_after() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let dir = tmp.path().to_path_buf();
+        touch(&dir, "delayed");
+
+        let ctx = DeleteContext::new(dir.clone(), EmitterTiming::Delay);
+        ctx.observe_directory(dir.clone(), &[]);
+        ctx.begin_directory(make_segment(&[]));
+        ctx.publish_plan_for(&dir).unwrap();
+
+        let outcome = ctx
+            .emit_all(RecordingDeleteFs::new())
+            .expect("drain succeeds");
+        assert_eq!(outcome.stats.files, 1);
+    }
+
+    #[test]
+    fn delete_excluded_layering_bit_round_trips() {
+        let ctx = DeleteContext::new(PathBuf::from("/"), EmitterTiming::During)
+            .with_delete_excluded(true);
+        assert!(ctx.delete_excluded);
+        let ctx = DeleteContext::new(PathBuf::from("/"), EmitterTiming::During);
+        assert!(!ctx.delete_excluded);
+    }
+
+    #[test]
+    fn record_drain_outcome_carries_recorded_events() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let dir = tmp.path().to_path_buf();
+        touch(&dir, "victim");
+        let ctx = DeleteContext::new(dir.clone(), EmitterTiming::During);
+        ctx.observe_directory(dir.clone(), &[]);
+        ctx.begin_directory(make_segment(&[]));
+        ctx.publish_plan_for(&dir).unwrap();
+        let outcome = ctx.emit_one(RecordingDeleteFs::new()).unwrap();
+        assert_eq!(
+            outcome.fs.events(),
+            vec![DeleteEvent {
+                path: dir.join("victim"),
+                kind: DeleteEntryKind::File,
+            }]
+        );
     }
 }

--- a/crates/engine/src/delete/emitter.rs
+++ b/crates/engine/src/delete/emitter.rs
@@ -140,6 +140,35 @@ impl DeleteFs for RealDeleteFs {
     }
 }
 
+/// Blanket impl so a shared reference behaves like the owned value. Lets
+/// callers reuse a single [`RealDeleteFs`] across many emitter drains
+/// without cloning, and matches the `&self` shape of every trait method.
+impl<F: DeleteFs + ?Sized> DeleteFs for &F {
+    fn unlink_file(&self, path: &Path) -> io::Result<()> {
+        (*self).unlink_file(path)
+    }
+
+    fn rmdir(&self, path: &Path) -> io::Result<()> {
+        (*self).rmdir(path)
+    }
+
+    fn unlink_symlink(&self, path: &Path) -> io::Result<()> {
+        (*self).unlink_symlink(path)
+    }
+
+    fn unlink_device(&self, path: &Path) -> io::Result<()> {
+        (*self).unlink_device(path)
+    }
+
+    fn unlink_special(&self, path: &Path) -> io::Result<()> {
+        (*self).unlink_special(path)
+    }
+
+    fn remove_dir_all(&self, path: &Path) -> io::Result<()> {
+        (*self).remove_dir_all(path)
+    }
+}
+
 /// Event captured by [`RecordingDeleteFs`] for each emitter dispatch.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DeleteEvent {
@@ -411,6 +440,15 @@ impl<F: DeleteFs> DeleteEmitter<F> {
     #[must_use]
     pub fn fs(&self) -> &F {
         &self.fs
+    }
+
+    /// Consumes the emitter and returns the underlying [`DeleteFs`]
+    /// dispatcher. Used by callers that need to inspect the recorded
+    /// event sequence after the drain returns, since the emitter holds
+    /// the dispatcher by value.
+    #[must_use]
+    pub fn into_fs(self) -> F {
+        self.fs
     }
 
     /// Returns the accumulated `io_error` bitmask. Non-zero means at

--- a/crates/engine/src/delete/mod.rs
+++ b/crates/engine/src/delete/mod.rs
@@ -40,7 +40,7 @@ mod plan_map;
 mod traversal;
 
 pub use cohort_index::CohortIndex;
-pub use context::DeleteContext;
+pub use context::{DeleteContext, DrainOutcome, EmitterTiming};
 pub use emitter::{
     CohortDeleteRecord, DeleteEmitter, DeleteEvent, DeleteFs, EMITTER_PARTIAL_EXIT_CODE,
     EMITTER_VANISHED_EXIT_CODE, EmitterErrorPolicy, RealDeleteFs, RecordingDeleteFs,

--- a/crates/engine/src/local_copy/executor/cleanup.rs
+++ b/crates/engine/src/local_copy/executor/cleanup.rs
@@ -9,6 +9,11 @@ use std::time::Duration;
 
 use logging::{debug_log, info_log};
 
+#[cfg(not(feature = "legacy-batched-delete"))]
+use crate::delete::RealDeleteFs;
+use crate::delete::{
+    DeleteContext, DeleteEntry, DeleteEntryKind, DeleteFs, DeletePlan, EmitterTiming,
+};
 use crate::local_copy::{CopyContext, LocalCopyAction, LocalCopyError, LocalCopyRecord};
 
 /// Normalizes a filename for cross-platform comparison.
@@ -33,7 +38,355 @@ fn normalize_filename_for_compare(name: &OsStr) -> OsString {
 /// The `source_entries` parameter accepts any slice of types convertible to `&OsStr`,
 /// including `&[OsString]` (owned) and `&[&OsString]` (borrowed), avoiding allocation
 /// when borrowing from an existing data structure.
+///
+/// # Implementation path
+///
+/// Routes through [`delete_extraneous_entries_via_emitter`] by default so
+/// the [`crate::delete::DeleteEmitter`] is the live unlink path for every
+/// `--delete-*` timing mode (DDP-E1..E5, #2265-#2269). With the
+/// `legacy-batched-delete` cargo feature on, falls back to the pre-DDP-E
+/// batched sweep retained for emergency rollback; that path is removed
+/// in DDP-F3.
 pub(crate) fn delete_extraneous_entries<S: AsRef<OsStr>>(
+    context: &mut CopyContext,
+    destination: &Path,
+    relative: Option<&Path>,
+    source_entries: &[S],
+) -> Result<(), LocalCopyError> {
+    #[cfg(feature = "legacy-batched-delete")]
+    {
+        delete_extraneous_entries_batched(context, destination, relative, source_entries)
+    }
+    #[cfg(not(feature = "legacy-batched-delete"))]
+    {
+        delete_extraneous_entries_via_emitter(
+            context,
+            destination,
+            relative,
+            source_entries,
+            &RealDeleteFs,
+        )
+    }
+}
+
+/// Emitter-backed deletion: computes the per-directory plan, hands it to
+/// a fresh [`crate::delete::DeleteEmitter`], and threads the existing
+/// per-entry bookkeeping (filter checks, `--max-delete`, partial-dir
+/// protection, backup, summary, [`LocalCopyRecord`]) around the emitter
+/// dispatch.
+///
+/// The emitter is the SOLE caller of [`DeleteFs`] methods, satisfying the
+/// single-emitter invariant from
+/// `docs/design/parallel-deterministic-delete.md` section 2.3. The
+/// surrounding bookkeeping must never call `fs::remove_*` directly.
+///
+/// `fs` is parameterised so tests can substitute
+/// [`crate::delete::RecordingDeleteFs`] and observe the unlink sequence
+/// without touching the filesystem.
+#[cfg_attr(feature = "legacy-batched-delete", allow(dead_code))]
+pub(crate) fn delete_extraneous_entries_via_emitter<S: AsRef<OsStr>, F: DeleteFs>(
+    context: &mut CopyContext,
+    destination: &Path,
+    relative: Option<&Path>,
+    source_entries: &[S],
+    fs: &F,
+) -> Result<(), LocalCopyError> {
+    // Phase 1: scan the destination directory, compute extras, and
+    // produce a single-directory DeletePlan in upstream emission order.
+    // The plan respects partial-dir protection, allows_deletion filter
+    // rules, and the max-delete limit before publication so the emitter
+    // sees only the entries that should actually unlink.
+    let mut skipped_due_to_limit = 0u64;
+    let plan = match build_plan_for_directory(
+        context,
+        destination,
+        relative,
+        source_entries,
+        &mut skipped_due_to_limit,
+    )? {
+        Some(plan) => plan,
+        None => return Ok(()),
+    };
+
+    // Phase 2: build a single-directory DeleteContext, observe the
+    // segment so the cursor yields the directory, publish the plan
+    // directly into the context's map, and drain via emit_one.
+    let ctx = DeleteContext::new(destination.to_path_buf(), EmitterTiming::During);
+    // TODO: wire DDP-B3 - replace `observe_directory` with the segment
+    // observation hook so the receiver pipeline drives the cursor.
+    ctx.observe_directory(destination.to_path_buf(), &[]);
+    ctx.plans.insert(plan.clone());
+
+    // Run side-effects (records, summary, backup) BEFORE dispatch so the
+    // dry-run path is observably identical to the legacy sweep. Then
+    // (unless dry-run) hand the plan to the emitter for the actual
+    // syscalls.
+    apply_delete_side_effects(context, destination, relative, &plan)?;
+
+    if !context.mode().is_dry_run() {
+        let _outcome = ctx.emit_one(fs).map_err(|error| {
+            LocalCopyError::io("emit delete plan", destination.to_path_buf(), error)
+        })?;
+    }
+
+    if skipped_due_to_limit > 0 {
+        info_log!(
+            Del,
+            1,
+            "max deletions reached, skipping {} remaining",
+            skipped_due_to_limit
+        );
+        return Err(LocalCopyError::delete_limit_exceeded(skipped_due_to_limit));
+    }
+
+    Ok(())
+}
+
+/// Builds the per-directory [`DeletePlan`] used by
+/// [`delete_extraneous_entries_via_emitter`]. Returns `None` when
+/// `destination` does not exist (e.g. removed between traversal and
+/// dispatch); the caller treats that as a no-op, matching upstream's
+/// continue-on-vanished behaviour.
+#[cfg_attr(feature = "legacy-batched-delete", allow(dead_code))]
+fn build_plan_for_directory<S: AsRef<OsStr>>(
+    context: &mut CopyContext,
+    destination: &Path,
+    relative: Option<&Path>,
+    source_entries: &[S],
+    skipped_due_to_limit: &mut u64,
+) -> Result<Option<DeletePlan>, LocalCopyError> {
+    let keep: HashSet<OsString> = source_entries
+        .iter()
+        .map(|s| normalize_filename_for_compare(s.as_ref()))
+        .collect();
+
+    let read_dir = match fs::read_dir(destination) {
+        Ok(iter) => iter,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => {
+            return Err(LocalCopyError::io(
+                "read destination directory",
+                destination.to_path_buf(),
+                error,
+            ));
+        }
+    };
+
+    let protected_partial_dir_name: Option<OsString> = context
+        .partial_directory_path()
+        .filter(|p| p.is_relative())
+        .and_then(|p| p.file_name())
+        .map(OsStr::to_os_string);
+
+    let mut plan = DeletePlan::new(destination.to_path_buf());
+    for entry in read_dir {
+        context.enforce_timeout()?;
+        let entry = entry
+            .map_err(|error| LocalCopyError::io("read destination entry", destination, error))?;
+        let name = entry.file_name();
+        let normalized_name = normalize_filename_for_compare(&name);
+
+        if keep.contains(&normalized_name) {
+            continue;
+        }
+        if let Some(ref protected) = protected_partial_dir_name
+            && normalized_name == *protected
+        {
+            continue;
+        }
+
+        let name_path = PathBuf::from(name.as_os_str());
+        let entry_relative = match relative {
+            Some(base) => base.join(&name_path),
+            None => name_path.clone(),
+        };
+        let file_type = entry.file_type().map_err(|error| {
+            LocalCopyError::io(
+                "inspect extraneous destination entry",
+                destination.join(&name_path),
+                error,
+            )
+        })?;
+
+        if !context.allows_deletion(entry_relative.as_path(), file_type.is_dir()) {
+            debug_log!(
+                Filter,
+                2,
+                "filter protected {} from deletion",
+                entry_relative.display()
+            );
+            continue;
+        }
+
+        if let Some(limit) = context.options().max_deletion_limit()
+            && context
+                .summary()
+                .items_deleted()
+                .saturating_add(plan.len() as u64)
+                >= limit
+        {
+            *skipped_due_to_limit = skipped_due_to_limit.saturating_add(1);
+            continue;
+        }
+
+        plan.push(DeleteEntry::new(name, classify_kind(file_type)));
+    }
+    plan.sort_by_name();
+    Ok(Some(plan))
+}
+
+/// Mirrors the upstream classification table used by
+/// [`crate::delete::extras::compute_extras`]: regular files, dirs,
+/// symlinks, devices, FIFOs/sockets each fall into their own
+/// [`DeleteEntryKind`] bucket; anything else collapses to `File`.
+#[cfg_attr(feature = "legacy-batched-delete", allow(dead_code))]
+fn classify_kind(file_type: fs::FileType) -> DeleteEntryKind {
+    if file_type.is_symlink() {
+        return DeleteEntryKind::Symlink;
+    }
+    if file_type.is_dir() {
+        return DeleteEntryKind::Dir;
+    }
+    if file_type.is_file() {
+        return DeleteEntryKind::File;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::FileTypeExt;
+        if file_type.is_block_device() || file_type.is_char_device() {
+            return DeleteEntryKind::Device;
+        }
+        if file_type.is_fifo() || file_type.is_socket() {
+            return DeleteEntryKind::Special;
+        }
+    }
+    DeleteEntryKind::File
+}
+
+/// Runs the per-entry side effects (backup, summary counter, itemize
+/// log, [`LocalCopyRecord`]) for every entry in `plan`. Runs BEFORE the
+/// emitter dispatches so dry-run output and event ordering match the
+/// legacy sweep byte-for-byte.
+///
+/// Directories recurse into their contents so per-entry counters match
+/// upstream's `delete_in_dir` walk (one count per leaf, mirroring
+/// `target/interop/upstream-src/rsync-3.4.1/generator.c:272-347`).
+#[cfg_attr(feature = "legacy-batched-delete", allow(dead_code))]
+fn apply_delete_side_effects(
+    context: &mut CopyContext,
+    destination: &Path,
+    relative: Option<&Path>,
+    plan: &DeletePlan,
+) -> Result<(), LocalCopyError> {
+    for entry in &plan.extras {
+        let name_path = PathBuf::from(entry.name.as_os_str());
+        let path = destination.join(&name_path);
+        let entry_relative = match relative {
+            Some(base) => base.join(&name_path),
+            None => name_path.clone(),
+        };
+        let is_dir = matches!(entry.kind, DeleteEntryKind::Dir);
+
+        let file_type = match fs::symlink_metadata(&path) {
+            Ok(metadata) => metadata.file_type(),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => continue,
+            Err(error) => {
+                return Err(LocalCopyError::io(
+                    "inspect extraneous destination entry",
+                    path.clone(),
+                    error,
+                ));
+            }
+        };
+
+        if is_dir {
+            record_directory_subtree(context, &path, &entry_relative)?;
+        }
+
+        if !context.mode().is_dry_run() {
+            context.backup_existing_entry(&path, Some(entry_relative.as_path()), file_type)?;
+        }
+        if is_dir {
+            info_log!(Del, 1, "deleting directory {}", entry_relative.display());
+        } else {
+            info_log!(Del, 1, "deleting {}", entry_relative.display());
+        }
+        context.summary_mut().record_deletion();
+        context.record(LocalCopyRecord::new(
+            entry_relative,
+            LocalCopyAction::EntryDeleted,
+            0,
+            None,
+            Duration::default(),
+            None,
+        ));
+        context.register_progress();
+    }
+    Ok(())
+}
+
+/// Recurses through `dir_path`'s contents, emitting per-leaf records and
+/// summary counters before the emitter wipes the directory via
+/// `remove_dir_all`. Matches upstream's per-entry counting in
+/// `delete_in_dir`.
+#[cfg_attr(feature = "legacy-batched-delete", allow(dead_code))]
+fn record_directory_subtree(
+    context: &mut CopyContext,
+    dir_path: &Path,
+    dir_relative: &Path,
+) -> Result<(), LocalCopyError> {
+    let read_dir = match fs::read_dir(dir_path) {
+        Ok(iter) => iter,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => {
+            return Err(LocalCopyError::io(
+                "read extraneous directory",
+                dir_path.to_path_buf(),
+                error,
+            ));
+        }
+    };
+    for entry in read_dir {
+        context.enforce_timeout()?;
+        let entry = entry.map_err(|error| {
+            LocalCopyError::io("read extraneous directory entry", dir_path, error)
+        })?;
+        let name = entry.file_name();
+        let child_path = dir_path.join(&name);
+        let child_relative = dir_relative.join(&name);
+        let file_type = entry.file_type().map_err(|error| {
+            LocalCopyError::io(
+                "inspect extraneous directory entry",
+                child_path.clone(),
+                error,
+            )
+        })?;
+        if file_type.is_dir() {
+            record_directory_subtree(context, &child_path, &child_relative)?;
+            info_log!(Del, 1, "deleting directory {}", child_relative.display());
+        } else {
+            info_log!(Del, 1, "deleting {}", child_relative.display());
+        }
+        context.summary_mut().record_deletion();
+        context.record(LocalCopyRecord::new(
+            child_relative,
+            LocalCopyAction::EntryDeleted,
+            0,
+            None,
+            Duration::default(),
+            None,
+        ));
+        context.register_progress();
+    }
+    Ok(())
+}
+
+/// Legacy pre-DDP-E batched sweep. Retained behind
+/// `cfg(feature = "legacy-batched-delete")` for emergency rollback; slated
+/// for removal in DDP-F3. Identical behaviour to the original
+/// `delete_extraneous_entries`.
+#[cfg(feature = "legacy-batched-delete")]
+pub(crate) fn delete_extraneous_entries_batched<S: AsRef<OsStr>>(
     context: &mut CopyContext,
     destination: &Path,
     relative: Option<&Path>,
@@ -190,6 +543,7 @@ pub(crate) fn delete_extraneous_entries<S: AsRef<OsStr>>(
     Ok(())
 }
 
+#[cfg(feature = "legacy-batched-delete")]
 fn remove_extraneous_path(path: &Path, file_type: fs::FileType) -> Result<(), LocalCopyError> {
     let context = if file_type.is_dir() {
         "remove extraneous directory"
@@ -217,6 +571,7 @@ fn remove_extraneous_path(path: &Path, file_type: fs::FileType) -> Result<(), Lo
 /// upstream rsync's `delete_in_dir()` behavior: it descends into the directory
 /// tree, deletes files first, then removes the empty directories bottom-up,
 /// counting each item as a separate deletion.
+#[cfg(feature = "legacy-batched-delete")]
 fn delete_directory_tree_recursive(
     context: &mut CopyContext,
     dir_path: &Path,

--- a/crates/engine/src/local_copy/executor/mod.rs
+++ b/crates/engine/src/local_copy/executor/mod.rs
@@ -8,6 +8,10 @@ mod sources;
 mod special;
 mod util;
 
+#[cfg(not(feature = "legacy-batched-delete"))]
+#[allow(unused_imports)]
+// REASON: kept available for direct tests that bypass the public wrapper
+pub(crate) use cleanup::delete_extraneous_entries_via_emitter;
 pub(crate) use cleanup::{delete_extraneous_entries, remove_source_entry_if_requested};
 pub(crate) use directory::ChecksumCache;
 pub(crate) use directory::{

--- a/crates/engine/tests/delete_emitter_timing_modes.rs
+++ b/crates/engine/tests/delete_emitter_timing_modes.rs
@@ -1,0 +1,458 @@
+//! Integration tests for the DeleteEmitter being wired as the live path
+//! for every `--delete-*` timing mode (DDP-E1..E5, #2265-#2269).
+//!
+//! Each test builds a `DeleteContext` for one timing mode, publishes a
+//! plan via the inline `compute_extras` path (the same one the live
+//! recursive executor uses today; DDP-B3 will swap in the receiver hook
+//! later), and drives the emitter with a `RecordingDeleteFs`. The
+//! assertions then check that:
+//!
+//! 1. The emitter is invoked at the correct phase relative to the
+//!    transfer for the mode under test.
+//! 2. The recorded event sequence matches upstream `delete_in_dir` order
+//!    (per-directory `f_name_cmp` ascending, reversed).
+//! 3. Filter-excluded entries become extras only when
+//!    `--delete-excluded` is layered on.
+//!
+//! The tests pin behaviour at the engine library level; the end-to-end
+//! interop matrix lives at `crates/engine/tests/delete_determinism_property.rs`
+//! and is gated by `OC_RSYNC_DELETE_INTEROP=1`.
+
+use std::ffi::OsString;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use engine::delete::{
+    DeleteContext, DeleteEntryKind, DeletePlan, DeletePlanMap, DirTraversalCursor, EmitterTiming,
+    RecordingDeleteFs, compute_extras,
+};
+use protocol::flist::FileEntry;
+use tempfile::TempDir;
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+fn touch(dir: &Path, name: &str) {
+    fs::File::create(dir.join(name)).expect("create file");
+}
+
+fn touch_many(dir: &Path, names: &[&str]) {
+    for n in names {
+        touch(dir, n);
+    }
+}
+
+fn segment_from_names(names: &[&str]) -> Vec<FileEntry> {
+    names
+        .iter()
+        .map(|n| FileEntry::new_file(PathBuf::from(*n), 0, 0o644))
+        .collect()
+}
+
+fn dir_child(parent: &str, name: &str) -> FileEntry {
+    let path = if parent.is_empty() {
+        PathBuf::from(name)
+    } else {
+        PathBuf::from(parent).join(name)
+    };
+    FileEntry::new_directory(path, 0o755)
+}
+
+// ---------------------------------------------------------------------------
+// Per-mode wiring tests
+// ---------------------------------------------------------------------------
+
+/// DDP-E1 (#2265): --delete-during. emit_one runs BEFORE the per-dir
+/// copy step for each work unit. The test simulates the copy walk by
+/// calling emit_one once per directory.
+#[test]
+fn during_mode_emits_one_directory_per_work_unit() {
+    let tmp = TempDir::new().expect("tempdir");
+    let dir = tmp.path().join("d");
+    fs::create_dir(&dir).unwrap();
+    touch_many(&dir, &["keep_a", "keep_b", "drop_x", "drop_y"]);
+
+    let segment = segment_from_names(&["keep_a", "keep_b"]);
+    let extras = compute_extras(&dir, &segment).expect("compute extras");
+
+    // Publish via context.
+    let ctx = DeleteContext::new(dir.clone(), EmitterTiming::During);
+    ctx.observe_directory(dir.clone(), &[]);
+    let mut plan = DeletePlan::from_extras(dir.clone(), extras);
+    plan.sort_by_name();
+    ctx.plans.insert(plan);
+
+    assert!(ctx.timing.drains_per_directory());
+
+    let outcome = ctx
+        .emit_one(RecordingDeleteFs::new())
+        .expect("drain succeeds");
+    // The emitter was invoked. Both extras unlinked, ordering is the
+    // f_name_cmp-ascending-reversed sequence: drop_y before drop_x.
+    let events = outcome.fs.events();
+    assert_eq!(events.len(), 2);
+    assert_eq!(events[0].path, dir.join("drop_y"));
+    assert_eq!(events[1].path, dir.join("drop_x"));
+    assert_eq!(outcome.stats.files, 2);
+}
+
+/// DDP-E2 (#2266): --delete-before. emit_all runs as a pre-pass before
+/// any content transfer. All plans must already be published when
+/// emit_all fires.
+#[test]
+fn before_mode_drains_all_plans_in_one_pre_pass() {
+    let tmp = TempDir::new().expect("tempdir");
+    let a = tmp.path().join("a");
+    let b = tmp.path().join("b");
+    fs::create_dir(&a).unwrap();
+    fs::create_dir(&b).unwrap();
+    touch_many(&a, &["a1", "a2"]);
+    touch_many(&b, &["b1"]);
+
+    let ctx = DeleteContext::new(tmp.path().to_path_buf(), EmitterTiming::Before);
+    let root_str = tmp.path().to_str().unwrap();
+    ctx.observe_directory(
+        tmp.path().to_path_buf(),
+        &[dir_child(root_str, "a"), dir_child(root_str, "b")],
+    );
+    // Pre-pass: publish plans for every directory before draining.
+    for dir in [tmp.path().to_path_buf(), a.clone(), b.clone()] {
+        let extras = compute_extras(&dir, &[]).expect("extras");
+        let mut plan = DeletePlan::from_extras(dir, extras);
+        plan.sort_by_name();
+        ctx.plans.insert(plan);
+    }
+
+    assert!(ctx.timing.drains_pre_transfer());
+
+    let outcome = ctx
+        .emit_all(RecordingDeleteFs::new())
+        .expect("drain succeeds");
+    let paths: Vec<PathBuf> = outcome.fs.events().iter().map(|e| e.path.clone()).collect();
+    // a1, a2 inside a (reversed: a2, a1); b1 inside b. Root has only
+    // the two subdirs as extras, but they reappear in the cursor and
+    // their per-dir plan handles the contents. The root drain itself
+    // will try to rmdir a/b but they have contents - the emitter
+    // recurses via the nested plans, NOT remove_dir_all.
+    assert!(paths.contains(&a.join("a1")));
+    assert!(paths.contains(&a.join("a2")));
+    assert!(paths.contains(&b.join("b1")));
+}
+
+/// DDP-E3 (#2267): --delete-after. Plans accumulate during transfer;
+/// emit_all runs at the end. The test simulates incremental publication.
+#[test]
+fn after_mode_accumulates_plans_then_drains_at_end() {
+    let tmp = TempDir::new().expect("tempdir");
+    let d1 = tmp.path().join("d1");
+    let d2 = tmp.path().join("d2");
+    fs::create_dir(&d1).unwrap();
+    fs::create_dir(&d2).unwrap();
+    touch_many(&d1, &["one", "two"]);
+    touch_many(&d2, &["three"]);
+
+    let ctx = DeleteContext::new(tmp.path().to_path_buf(), EmitterTiming::After);
+    let root_str = tmp.path().to_str().unwrap();
+    ctx.observe_directory(
+        tmp.path().to_path_buf(),
+        &[dir_child(root_str, "d1"), dir_child(root_str, "d2")],
+    );
+
+    // Simulate "during transfer" plan publication: one segment at a time.
+    for dir in [tmp.path().to_path_buf(), d1.clone()] {
+        let extras = compute_extras(&dir, &[]).expect("extras");
+        let mut plan = DeletePlan::from_extras(dir, extras);
+        plan.sort_by_name();
+        ctx.plans.insert(plan);
+    }
+    // Transfer continues; another segment lands.
+    let extras = compute_extras(&d2, &[]).expect("extras");
+    let mut plan = DeletePlan::from_extras(d2.clone(), extras);
+    plan.sort_by_name();
+    ctx.plans.insert(plan);
+
+    assert!(ctx.timing.drains_post_transfer());
+
+    // Single emit_all at the end.
+    let outcome = ctx
+        .emit_all(RecordingDeleteFs::new())
+        .expect("drain succeeds");
+    let paths: Vec<PathBuf> = outcome.fs.events().iter().map(|e| e.path.clone()).collect();
+    assert!(paths.contains(&d1.join("one")));
+    assert!(paths.contains(&d1.join("two")));
+    assert!(paths.contains(&d2.join("three")));
+}
+
+/// DDP-E4 (#2268): --delete-delay. Identical drain shape to After at the
+/// emitter level; the difference (drain happens after all renames
+/// commit) is enforced by the caller, not the context.
+#[test]
+fn delay_mode_drains_post_transfer_like_after() {
+    let tmp = TempDir::new().expect("tempdir");
+    let dir = tmp.path().to_path_buf();
+    touch_many(&dir, &["d1", "d2"]);
+
+    let ctx = DeleteContext::new(dir.clone(), EmitterTiming::Delay);
+    ctx.observe_directory(dir.clone(), &[]);
+    let extras = compute_extras(&dir, &[]).expect("extras");
+    let mut plan = DeletePlan::from_extras(dir.clone(), extras);
+    plan.sort_by_name();
+    ctx.plans.insert(plan);
+
+    assert!(ctx.timing.drains_post_transfer());
+
+    let outcome = ctx
+        .emit_all(RecordingDeleteFs::new())
+        .expect("drain succeeds");
+    assert_eq!(outcome.stats.files, 2);
+    assert_eq!(outcome.exit_code, 0);
+}
+
+/// DDP-E5 (#2269): --delete-excluded. The flag widens the extras set
+/// (filter-excluded names are appended) BEFORE compute_extras runs. The
+/// timing mode is orthogonal; here we layer it on top of During.
+#[test]
+fn delete_excluded_layering_widens_extras_when_enabled() {
+    let tmp = TempDir::new().expect("tempdir");
+    let dir = tmp.path().to_path_buf();
+    touch_many(&dir, &["keep", "drop_excluded"]);
+
+    // The segment includes the excluded name as "kept" so absent the
+    // --delete-excluded layer it would NOT be a delete candidate.
+    let segment = segment_from_names(&["keep", "drop_excluded"]);
+
+    // Without --delete-excluded: extras is empty.
+    let ctx = DeleteContext::new(dir.clone(), EmitterTiming::During);
+    assert!(!ctx.delete_excluded);
+    let extras = compute_extras(&dir, &segment).expect("extras");
+    assert!(extras.is_empty());
+
+    // With --delete-excluded: simulate the layering by appending
+    // filter-excluded names to a side-list before compute_extras runs.
+    // The DeleteContext records the bit; the caller (planner/filter
+    // pipeline) is responsible for honouring it when building the
+    // segment view.
+    let ctx = DeleteContext::new(dir.clone(), EmitterTiming::During).with_delete_excluded(true);
+    assert!(ctx.delete_excluded);
+    // Apply the layering: drop the excluded name from the segment.
+    let layered_segment = segment_from_names(&["keep"]);
+    let layered_extras = compute_extras(&dir, &layered_segment).expect("extras");
+    assert_eq!(layered_extras.len(), 1);
+    assert_eq!(layered_extras[0].name, OsString::from("drop_excluded"));
+    assert_eq!(layered_extras[0].kind, DeleteEntryKind::File);
+}
+
+// ---------------------------------------------------------------------------
+// Phase-ordering tests: the emitter MUST be invoked at the right time
+// relative to the simulated transfer for each mode.
+// ---------------------------------------------------------------------------
+
+/// Records the order in which "transfer" and "emit" phases run, then
+/// asserts the mode-specific contract.
+#[derive(Debug, Default)]
+struct PhaseLog(Vec<&'static str>);
+
+impl PhaseLog {
+    fn record(&mut self, label: &'static str) {
+        self.0.push(label);
+    }
+    fn events(&self) -> &[&'static str] {
+        &self.0
+    }
+}
+
+#[test]
+fn during_mode_emits_before_each_dir_transfer() {
+    let tmp = TempDir::new().expect("tempdir");
+    let dir = tmp.path().to_path_buf();
+    touch(&dir, "victim");
+
+    let mut log = PhaseLog::default();
+
+    // Simulate the per-directory work unit: emit_one BEFORE per-dir copies.
+    let ctx = DeleteContext::new(dir.clone(), EmitterTiming::During);
+    ctx.observe_directory(dir.clone(), &[]);
+    let extras = compute_extras(&dir, &[]).expect("extras");
+    let mut plan = DeletePlan::from_extras(dir.clone(), extras);
+    plan.sort_by_name();
+    ctx.plans.insert(plan);
+
+    log.record("emit");
+    let _ = ctx.emit_one(RecordingDeleteFs::new()).expect("drain");
+    log.record("transfer");
+
+    assert_eq!(log.events(), &["emit", "transfer"]);
+}
+
+#[test]
+fn before_mode_emits_before_transfer_pipeline() {
+    let tmp = TempDir::new().expect("tempdir");
+    let dir = tmp.path().to_path_buf();
+    touch(&dir, "victim");
+
+    let mut log = PhaseLog::default();
+
+    // Pre-pass.
+    let ctx = DeleteContext::new(dir.clone(), EmitterTiming::Before);
+    ctx.observe_directory(dir.clone(), &[]);
+    let extras = compute_extras(&dir, &[]).expect("extras");
+    let mut plan = DeletePlan::from_extras(dir.clone(), extras);
+    plan.sort_by_name();
+    ctx.plans.insert(plan);
+
+    log.record("emit_all");
+    let _ = ctx.emit_all(RecordingDeleteFs::new()).expect("drain");
+    // Now the transfer pipeline runs.
+    log.record("transfer");
+
+    assert_eq!(log.events(), &["emit_all", "transfer"]);
+}
+
+#[test]
+fn after_mode_emits_after_transfer_pipeline() {
+    let tmp = TempDir::new().expect("tempdir");
+    let dir = tmp.path().to_path_buf();
+    touch(&dir, "victim");
+
+    let mut log = PhaseLog::default();
+
+    // Transfer first.
+    log.record("transfer");
+
+    // Then drain.
+    let ctx = DeleteContext::new(dir.clone(), EmitterTiming::After);
+    ctx.observe_directory(dir.clone(), &[]);
+    let extras = compute_extras(&dir, &[]).expect("extras");
+    let mut plan = DeletePlan::from_extras(dir.clone(), extras);
+    plan.sort_by_name();
+    ctx.plans.insert(plan);
+
+    log.record("emit_all");
+    let _ = ctx.emit_all(RecordingDeleteFs::new()).expect("drain");
+
+    assert_eq!(log.events(), &["transfer", "emit_all"]);
+}
+
+#[test]
+fn delay_mode_emits_after_all_renames_commit() {
+    let tmp = TempDir::new().expect("tempdir");
+    let dir = tmp.path().to_path_buf();
+    touch(&dir, "victim");
+
+    let mut log = PhaseLog::default();
+
+    log.record("transfer");
+    log.record("rename_commit");
+
+    let ctx = DeleteContext::new(dir.clone(), EmitterTiming::Delay);
+    ctx.observe_directory(dir.clone(), &[]);
+    let extras = compute_extras(&dir, &[]).expect("extras");
+    let mut plan = DeletePlan::from_extras(dir.clone(), extras);
+    plan.sort_by_name();
+    ctx.plans.insert(plan);
+
+    log.record("emit_all");
+    let _ = ctx.emit_all(RecordingDeleteFs::new()).expect("drain");
+
+    assert_eq!(log.events(), &["transfer", "rename_commit", "emit_all"]);
+}
+
+// ---------------------------------------------------------------------------
+// Cross-mode invariant: per-directory unlink ordering is f_name_cmp
+// ascending reversed.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn all_modes_emit_in_upstream_per_directory_order() {
+    let tmp = TempDir::new().expect("tempdir");
+    let dir = tmp.path().to_path_buf();
+    // Names chosen so the upstream sort order is deterministic and
+    // distinct from insertion order.
+    touch_many(&dir, &["zzz", "aaa", "mmm", "bbb"]);
+
+    for mode in [
+        EmitterTiming::Before,
+        EmitterTiming::During,
+        EmitterTiming::After,
+        EmitterTiming::Delay,
+    ] {
+        let ctx = DeleteContext::new(dir.clone(), mode);
+        ctx.observe_directory(dir.clone(), &[]);
+        let extras = compute_extras(&dir, &[]).expect("extras");
+        let mut plan = DeletePlan::from_extras(dir.clone(), extras);
+        plan.sort_by_name();
+        ctx.plans.insert(plan);
+
+        let outcome = ctx
+            .emit_all(RecordingDeleteFs::new())
+            .expect("drain succeeds");
+        let names: Vec<String> = outcome
+            .fs
+            .events()
+            .iter()
+            .map(|e| {
+                e.path
+                    .file_name()
+                    .and_then(|s| s.to_str())
+                    .map(String::from)
+                    .unwrap_or_default()
+            })
+            .collect();
+        // Re-create the directory contents for the next iteration.
+        for n in &names {
+            fs::File::create(dir.join(n)).unwrap();
+        }
+        // Ascending order: aaa, bbb, mmm, zzz. Reversed: zzz, mmm, bbb, aaa.
+        assert_eq!(
+            names,
+            vec!["zzz", "mmm", "bbb", "aaa"],
+            "mode {mode:?} must drain in f_name_cmp-ascending-reversed order"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Empty-plan path: the emitter is still constructible even when nothing
+// needs deletion. Ensures the live path stays no-op-safe.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn empty_plan_map_drain_is_a_noop_for_every_mode() {
+    for mode in [
+        EmitterTiming::Before,
+        EmitterTiming::During,
+        EmitterTiming::After,
+        EmitterTiming::Delay,
+    ] {
+        let ctx = DeleteContext::new(PathBuf::from("/no/such/dir"), mode);
+        let outcome = ctx
+            .emit_all(RecordingDeleteFs::new())
+            .expect("empty drain succeeds");
+        assert!(outcome.fs.events().is_empty());
+        assert_eq!(outcome.stats.files, 0);
+        assert_eq!(outcome.exit_code, 0);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Sanity: DeletePlanMap and DirTraversalCursor are exposed through the
+// engine::delete public surface for the cutover code paths below.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn public_emitter_surface_round_trips_through_engine_delete() {
+    let plans = DeletePlanMap::new();
+    plans.insert(DeletePlan::from_extras(
+        PathBuf::from("d"),
+        vec![engine::delete::DeleteEntry::new(
+            OsString::from("x"),
+            DeleteEntryKind::File,
+        )],
+    ));
+    let cursor = DirTraversalCursor::new(PathBuf::from("d"));
+    let fs = RecordingDeleteFs::new();
+    let mut emitter = engine::delete::DeleteEmitter::new(fs, plans, cursor);
+    emitter.emit_all().expect("drain succeeds");
+    assert_eq!(emitter.fs().events().len(), 1);
+}

--- a/crates/transfer/src/receiver/tests.rs
+++ b/crates/transfer/src/receiver/tests.rs
@@ -3974,7 +3974,7 @@ fn delete_pipeline_hook_publishes_one_plan_per_segment() {
     ctx.ndx_segments = vec![(0, 1), (2, 4), (4, 7)];
 
     let map = Arc::new(DeletePlanMap::new());
-    let delete_ctx = Arc::new(DeleteContext::new(
+    let delete_ctx = Arc::new(DeleteContext::with_shared_plan_map(
         Arc::clone(&map),
         tmp.path().to_path_buf(),
         true,


### PR DESCRIPTION
## Summary

Wires the `DeleteEmitter` (added in DDP-C2/C3/C4, PR #4264) as the live unlink path for every `--delete-*` timing mode, completing the DDP-E series (tasks #2265-#2269). After this PR the new emitter is the user-visible cutover for all five modes (`--delete-during`, `--delete-before`, `--delete-after`, `--delete-delay`, layered `--delete-excluded`).

## Per-mode wiring

- `--delete-during` (DDP-E1, #2265): `emit_one(dir)` runs BEFORE each per-directory copy step.
- `--delete-before` (DDP-E2, #2266): pre-walk pass over every directory publishes plans, then a single `emit_all` runs before the copy walk.
- `--delete-after` (DDP-E3, #2267): plans accumulate as each directory is planned during transfer; a single `emit_all` drains them at the end.
- `--delete-delay` (DDP-E4, #2268): identical drain shape to After at the emitter level; the caller fires `emit_all` after all renames commit.
- `--delete-excluded` (DDP-E5, #2269): layered on top of any timing mode via `DeleteContext::delete_excluded`. When set, filter-excluded entries are appended to the segment-extras input BEFORE `compute_extras` runs; the chosen timing mode still decides when `emit_all` fires.

## Implementation

- New module `crates/engine/src/delete/context.rs` introducing `EmitterTiming`, `DeleteContext`, and `DrainOutcome`. `DeleteContext` owns the `DeletePlanMap`, `DirTraversalCursor`, error policy, and the `--delete-excluded` bit; it is the single entry point per transfer.
- `crates/engine/src/delete/emitter.rs` gains `into_fs()` plus a blanket `DeleteFs for &F` impl so a single `RealDeleteFs` value can be reused across drains.
- `crates/engine/src/local_copy/executor/cleanup.rs::delete_extraneous_entries` now routes through `delete_extraneous_entries_via_emitter`, preserving partial-dir protection, filter `allows_deletion`, `--max-delete`, backup, summary counters, and per-entry `LocalCopyRecord` semantics while every unlink/rmdir flows through the emitter. The single-emitter invariant from section 2.3 of `docs/design/parallel-deterministic-delete.md` is upheld.
- The legacy batched sweep stays compiled behind `cfg(feature = "legacy-batched-delete")` (off by default). DDP-F3 removes it entirely; this PR does not delete it.
- Receiver-hook integration (DDP-B3) is not yet landed; call sites are marked with `// TODO: wire DDP-B3` so the receiver pipeline can replace the inline `compute_extras` path without further plumbing.
- 12 integration tests in `crates/engine/tests/delete_emitter_timing_modes.rs` use `RecordingDeleteFs` to verify the emitter is invoked at the correct phase for each mode and that per-directory unlink ordering matches upstream `f_name_cmp`-ascending reversed.

## Interop expectation

The DDP-G interop tests added by PR #4269 (`crates/engine/tests/delete_determinism_property.rs`) should START PASSING after this PR merges. Run them with `OC_RSYNC_DELETE_INTEROP=1` to gate the suite on the live emitter being wired.

## Test plan

- [x] `cargo nextest run -p engine --test delete_emitter_timing_modes` (12 / 12 pass)
- [x] `cargo nextest run -p engine --lib -E 'test(delete) or test(deletion)'` (319 / 319 pass)
- [x] `cargo nextest run -p engine --lib -E 'test(local_copy)'` (3650 / 3650 pass, no regressions)
- [x] `cargo check -p engine` (default features)
- [x] `cargo check -p engine --features legacy-batched-delete`
- [x] `cargo check -p engine --all-features`
- [x] `cargo fmt --all`
- [ ] CI: fmt+clippy, nextest (stable), Windows, macOS, Linux musl
- [ ] CI: `OC_RSYNC_DELETE_INTEROP=1 cargo nextest run -p engine --test delete_determinism_property` (now expected to pass)