### PR TITLE
docs(audits): #1601 push-to-CI task closeout

### DIFF
--- a/docs/audits/task-1601-status.md
+++ b/docs/audits/task-1601-status.md
@@ -1,0 +1,60 @@
+# Task #1601 status - "Push to CI and monitor" closeout
+
+Tracking task: #1601. Audit date: 2026-05-17. Audit scope: determine
+whether the task title "Push to CI and monitor" still maps to any
+outstanding work, or whether it can be closed as obsolete.
+
+## What #1601 was about
+
+The only artifact in this repository carrying the `#1601` reference is
+GitHub PR #1601 - "Split protocol envelope tests into modular suites"
+(merged 2025-10-29, commit `9faba892b`). That PR refactored
+`crates/protocol/src/envelope/tests.rs` into focused submodules
+(`codes.rs`, `conversions.rs`, `header.rs`, `properties.rs`, `mod.rs`)
+and removed the matching `tools/line_limits.toml` override. The PR
+landed cleanly via the standard CI flow and is fully merged.
+
+The task title "Push to CI and monitor" does not appear in:
+
+- any commit message, PR title, or PR body across all refs
+  (`git log --all --grep` returns only the envelope-tests PR);
+- any file under `docs/`, `docs/audits/`, `docs/plans/`, or
+  `docs/investigations/` (full-tree `grep -rln` returns no matches);
+- any GitHub workflow under `.github/workflows/`
+  (none of the 17 workflows contain the phrase "monitor" or
+  "Push to CI");
+- any sibling task note - no companion tracking document references
+  task #1601 as a follow-up or precondition.
+
+The phrase therefore reads as a placeholder scratch-task from the
+session that produced PR #1601, describing the trivial final step of
+that PR's normal flow ("push the branch, watch CI, merge"). It was
+never promoted into a tracked work item.
+
+## Current status
+
+Obsolete. The underlying PR is merged. The "push and monitor" action
+described by the title is fully covered by the standing project
+workflow (feature branch -> push -> `gh pr create` -> wait for
+required checks -> merge via `gh pr merge`) and by the required-checks
+gate on the `master` branch (fmt+clippy, nextest stable, Windows
+stable, macOS stable, Linux musl stable). No bespoke "monitor"
+tooling, dashboard, or workflow was ever scoped under this task id.
+
+## Recommendation
+
+Close as obsolete. Rationale:
+
+1. The only concrete deliverable bearing the `#1601` id (PR #1601) is
+   merged and shipped; there is no follow-up work attached to it.
+2. The task title describes a generic action ("push to CI and
+   monitor") that is already the standard workflow documented in the
+   project guide and enforced by branch protection. Reifying it as a
+   standalone task adds no information and no work.
+3. No companion doc, workflow, or sibling task points back to #1601
+   as a precondition, so closing it strands nothing.
+
+No subtasks need to be created. If a future need arises for an
+explicit CI-monitoring tool (for example a watcher that pages on red
+required checks), it should be filed as a fresh task with concrete
+acceptance criteria rather than revived under this stale title.


### PR DESCRIPTION
## Summary
- Audit task #1601 titled "Push to CI and monitor"; the only artifact with that id is the already-merged envelope-tests PR #1601 (`9faba892b`, 2025-10-29).
- No docs, workflows, or sibling tasks reference the title or treat it as outstanding work; the action is fully covered by the standing branch-protection / required-checks process.
- Recommend closing as obsolete; no subtasks needed. Future CI-monitoring needs should be filed as a fresh task with concrete acceptance criteria.

## Test plan
- [x] `docs/audits/task-1601-status.md` stays under the 100-line cap (61 lines).
- [x] `cargo fmt --all` clean (no code touched).
- [x] No forbidden references; hyphens only.