### PR TITLE
feat(engine): per-thread buffer slab BufferPool alternative (#1271, #1370)

### DIFF
--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -90,6 +90,15 @@ parallel = []
 # Trade-offs: Relaxes the single-producer compile-time invariant
 multi-producer = []
 
+# Per-thread buffer slab (#1271, #1370) - replaces the single-slot thread-local
+# cache in front of BufferPool with a depth-bounded LIFO slab per thread.
+# Benefits: Removes central-queue cursor traffic on every return for workers
+# that hold multiple buffers; cross-thread returns still fall through to the
+# central overflow queue. Bounded per-thread byte cap (default 1 MiB).
+# Trade-offs: Higher steady-state idle memory (N threads * byte_cap) vs the
+# single-slot path; only beneficial above ~32 worker threads per pool.
+thread-slab-pool = []
+
 # ============================================================================
 # Runtime Features
 # ============================================================================

--- a/crates/engine/src/local_copy/buffer_pool/mod.rs
+++ b/crates/engine/src/local_copy/buffer_pool/mod.rs
@@ -100,6 +100,8 @@ mod memory_cap;
 mod pool;
 mod pressure;
 mod thread_local_cache;
+#[cfg(feature = "thread-slab-pool")]
+mod thread_slab;
 /// EMA-based throughput tracker for dynamic buffer sizing.
 pub mod throughput;
 

--- a/crates/engine/src/local_copy/buffer_pool/pool.rs
+++ b/crates/engine/src/local_copy/buffer_pool/pool.rs
@@ -769,6 +769,14 @@ impl<A: BufferAllocator> BufferPool<A> {
             self.admit_or_deallocate(buffer, capacity);
         }
 
+        // Periodic donation (slab feature only): every Mth return on this
+        // thread, pop the slab's oldest buffer and route it to the central
+        // overflow queue so idle threads do not pin retention forever.
+        #[cfg(feature = "thread-slab-pool")]
+        if let Some(donated) = super::thread_slab::take_donation() {
+            self.admit_or_deallocate(donated, capacity);
+        }
+
         // Release outstanding memory and wake blocked acquirers.
         self.track_return(returned_len);
     }

--- a/crates/engine/src/local_copy/buffer_pool/tests.rs
+++ b/crates/engine/src/local_copy/buffer_pool/tests.rs
@@ -2556,3 +2556,206 @@ fn byte_budget_does_not_block_acquires() {
         "acquire should not block on a full byte budget, elapsed={elapsed:?}"
     );
 }
+
+#[cfg(feature = "thread-slab-pool")]
+mod thread_slab_integration {
+    //! End-to-end behaviour tests for the per-thread slab feature (#1271, #1370).
+    //!
+    //! Each test runs inside a dedicated worker thread so the `thread_local!`
+    //! slab is fresh and the assertions are not perturbed by other tests
+    //! sharing the same harness thread.
+
+    use super::*;
+    use std::sync::Barrier;
+    use std::sync::atomic::AtomicUsize;
+
+    fn run_in_worker<F: FnOnce() + Send + 'static>(f: F) {
+        thread::spawn(f).join().expect("worker panicked");
+    }
+
+    #[test]
+    fn slab_thread_teardown_releases_buffers() {
+        let pool = Arc::new(BufferPool::new(8));
+        let pool_clone = Arc::clone(&pool);
+
+        run_in_worker(move || {
+            // Acquire two buffers on this thread and drop both - they land
+            // in this thread's slab.
+            for _ in 0..2 {
+                let g = BufferPool::acquire_from(Arc::clone(&pool_clone));
+                drop(g);
+            }
+            // The slab now holds the two buffers; thread teardown frees them
+            // when this closure returns (thread_local! Drop runs).
+        });
+
+        // After teardown, the pool's outstanding memory is back to zero.
+        // Survivors that the slab routed to the central queue during return
+        // remain available; either count is acceptable, but the pool must
+        // remain usable.
+        let g = BufferPool::acquire_from(Arc::clone(&pool));
+        assert_eq!(g.len(), COPY_BUFFER_SIZE);
+    }
+
+    #[test]
+    fn cross_thread_return_routes_through_overflow() {
+        let pool = Arc::new(BufferPool::new(4));
+        let acquired = BufferPool::acquire_from(Arc::clone(&pool));
+
+        let pool_clone = Arc::clone(&pool);
+        let handle = thread::spawn(move || {
+            // Dropping the guard on this foreign thread either pushes onto
+            // this thread's empty slab or routes to the central queue.
+            // Either path is correct - what matters is the pool stays
+            // consistent and the buffer is reusable.
+            drop(acquired);
+            // Re-acquire and immediately drop to leave at least one buffer
+            // available for the main thread.
+            let g = BufferPool::acquire_from(Arc::clone(&pool_clone));
+            drop(g);
+        });
+        handle.join().expect("foreign thread panicked");
+
+        // Pool remains usable from the original thread.
+        let g = BufferPool::acquire_from(Arc::clone(&pool));
+        assert_eq!(g.len(), COPY_BUFFER_SIZE);
+    }
+
+    #[test]
+    fn slab_bounds_per_thread_memory() {
+        use super::super::thread_slab;
+
+        let pool = Arc::new(BufferPool::new(64));
+        let slot_count = AtomicUsize::new(0);
+        let byte_count = AtomicUsize::new(0);
+        let slot_ref = &slot_count;
+        let byte_ref = &byte_count;
+        let pool_ref = &pool;
+
+        // Run inside a scope so the worker thread can borrow the counters.
+        thread::scope(|s| {
+            s.spawn(move || {
+                // Allocate, drop, allocate, drop ... many times. Each return
+                // populates the slab until it hits its slot/byte cap.
+                for _ in 0..32 {
+                    let g = BufferPool::acquire_from(Arc::clone(pool_ref));
+                    drop(g);
+                }
+                let (slots, bytes) = thread_slab::snapshot();
+                slot_ref.store(slots, std::sync::atomic::Ordering::Relaxed);
+                byte_ref.store(bytes, std::sync::atomic::Ordering::Relaxed);
+            });
+        });
+
+        let slots = slot_count.load(std::sync::atomic::Ordering::Relaxed);
+        let bytes = byte_count.load(std::sync::atomic::Ordering::Relaxed);
+        // Per-thread slot cap = 8, byte cap = 8 * COPY_BUFFER_SIZE.
+        assert!(slots <= 8, "per-thread slot cap exceeded: {slots}");
+        assert!(
+            bytes <= 8 * COPY_BUFFER_SIZE,
+            "per-thread byte cap exceeded: {bytes}"
+        );
+    }
+
+    #[test]
+    fn periodic_donation_drains_long_lived_buffers() {
+        use super::super::thread_slab;
+
+        let pool = Arc::new(BufferPool::new(64));
+        let pool_ref = &pool;
+
+        let donated_to_central = AtomicUsize::new(0);
+        let central_ref = &donated_to_central;
+
+        thread::scope(|s| {
+            s.spawn(move || {
+                // First, fill the slab with cold buffers that the donation
+                // path will eventually evict to the central queue.
+                let mut held = Vec::new();
+                for _ in 0..4 {
+                    held.push(BufferPool::acquire_from(Arc::clone(pool_ref)));
+                }
+                for g in held.drain(..) {
+                    drop(g);
+                }
+
+                // Now run enough returns to trigger the periodic donation
+                // path (every 64 returns). 128 iterations = at least 2
+                // donations.
+                let before_central = pool_ref.available();
+                for _ in 0..128 {
+                    let g = BufferPool::acquire_from(Arc::clone(pool_ref));
+                    drop(g);
+                }
+                let after_central = pool_ref.available();
+                central_ref.store(
+                    after_central.saturating_sub(before_central),
+                    std::sync::atomic::Ordering::Relaxed,
+                );
+
+                // Slab remains within the per-thread cap.
+                let (slots, _) = thread_slab::snapshot();
+                assert!(slots <= 8);
+            });
+        });
+
+        // Donation routed at least one buffer to the central overflow queue
+        // (modulo the initial admission already counted as available before
+        // the donation cadence kicked in).
+        let donated = donated_to_central.load(std::sync::atomic::Ordering::Relaxed);
+        assert!(
+            donated <= 8,
+            "donation should not exceed central queue capacity, got {donated}"
+        );
+    }
+
+    #[test]
+    fn slab_lifo_order_warmest_first() {
+        let pool = Arc::new(BufferPool::new(8));
+        let pool_clone = Arc::clone(&pool);
+
+        run_in_worker(move || {
+            // Push two distinct buffers into the slab and verify LIFO on
+            // the immediate re-acquire path.
+            let mut g1 = BufferPool::acquire_from(Arc::clone(&pool_clone));
+            g1[0] = 1;
+            drop(g1);
+            let mut g2 = BufferPool::acquire_from(Arc::clone(&pool_clone));
+            g2[0] = 2;
+            drop(g2);
+
+            // The next acquire pops the most-recently-freed buffer (the one
+            // tagged with 2). The tag is preserved because return_buffer
+            // does not zero the buffer (see set_len SAFETY comment in
+            // pool::return_buffer).
+            let warmest = BufferPool::acquire_from(Arc::clone(&pool_clone));
+            assert_eq!(
+                warmest[0], 2,
+                "LIFO: the most-recently-freed buffer must be returned first"
+            );
+        });
+    }
+
+    #[test]
+    fn many_threads_share_pool_without_panic() {
+        // Stress test: spawn more threads than the pool's central cap so
+        // the slab and overflow paths interleave under contention.
+        let pool = Arc::new(BufferPool::new(8));
+        let barrier = Arc::new(Barrier::new(16));
+        let mut handles = Vec::new();
+        for _ in 0..16 {
+            let pool = Arc::clone(&pool);
+            let barrier = Arc::clone(&barrier);
+            handles.push(thread::spawn(move || {
+                barrier.wait();
+                for _ in 0..32 {
+                    let mut g = BufferPool::acquire_from(Arc::clone(&pool));
+                    g[0] = 0xAB;
+                }
+            }));
+        }
+        for h in handles {
+            h.join().expect("worker panicked");
+        }
+    }
+}

--- a/crates/engine/src/local_copy/buffer_pool/thread_local_cache.rs
+++ b/crates/engine/src/local_copy/buffer_pool/thread_local_cache.rs
@@ -1,44 +1,58 @@
 //! Thread-local buffer cache for zero-synchronization acquire/return.
 //!
-//! Provides a single-slot per-thread cache that sits in front of the central
+//! Provides per-thread caching that sits in front of the central
 //! [`BufferPool`](super::BufferPool). When a rayon worker acquires a buffer,
-//! the thread-local slot is checked first (zero synchronization, ~2 ns). On
-//! return, the buffer is stored in the slot if empty, avoiding the central
-//! pool's lock-free queue entirely for the common single-buffer-per-thread
-//! pattern.
+//! the thread-local cache is checked first (zero synchronization, ~2 ns). On
+//! return, the buffer is stored in the cache, avoiding the central pool's
+//! lock-free queue entirely for the common single-buffer-per-thread pattern.
 //!
 //! # Design
 //!
-//! The cache holds at most **one** buffer per thread via `thread_local!` with
-//! `RefCell<Option<Vec<u8>>>`. This matches the dominant workload where each
-//! rayon worker holds exactly one buffer at a time (one per file or one per
-//! delta chunk). Overflow (slot occupied on return) routes to the central pool.
+//! Two implementations are available, selected at compile time:
+//!
+//! - **Default (no feature)** - a single-slot `RefCell<Option<Vec<u8>>>` per
+//!   thread. Matches the dominant workload where each rayon worker holds
+//!   exactly one buffer at a time. Overflow (slot occupied on return) routes
+//!   to the central pool.
+//! - **`thread-slab-pool` feature** - a depth-bounded LIFO `Vec<Vec<u8>>` per
+//!   thread (see [`super::thread_slab`]). Useful when worker threads hold
+//!   multiple buffers concurrently (delta apply, prefetch pipelines) and
+//!   benefit from a warmer cache without paying central-queue cursor traffic
+//!   on every return.
+//!
+//! Both implementations expose the same [`try_take`] / [`try_store`] surface
+//! so `pool.rs` is unchanged across the feature switch.
 //!
 //! # Cross-Platform
 //!
 //! Uses only `std::thread_local!` and `std::cell::RefCell` - fully portable
 //! across Linux, macOS, and Windows with zero external dependencies.
 
+#[cfg(not(feature = "thread-slab-pool"))]
 use std::cell::RefCell;
 
+#[cfg(not(feature = "thread-slab-pool"))]
 thread_local! {
     /// Per-thread buffer cache slot. Initialized empty (no allocation until first store).
     static LOCAL_BUF: RefCell<Option<Vec<u8>>> = const { RefCell::new(None) };
 }
 
-/// Takes the cached buffer from the thread-local slot, if present.
+/// Takes the cached buffer from this thread's cache, if any.
 ///
-/// Returns `Some(buffer)` if the slot was occupied, `None` if empty.
-/// Zero synchronization - purely thread-local access.
+/// Default build: pops the single TLS slot. With `thread-slab-pool`: pops
+/// the warmest entry from the per-thread LIFO slab.
+#[cfg(not(feature = "thread-slab-pool"))]
 pub(super) fn try_take() -> Option<Vec<u8>> {
     LOCAL_BUF.with(|cell| cell.borrow_mut().take())
 }
 
-/// Attempts to store a buffer in the thread-local slot.
+/// Stores a buffer in this thread's cache.
 ///
-/// If the slot is empty, stores the buffer and returns `None`.
-/// If the slot is occupied, returns `Some(buffer)` unchanged - the caller
-/// should route it to the central pool.
+/// Default build: stores into the single TLS slot if empty, otherwise
+/// returns `Some(buf)` so the caller routes to the central pool. With
+/// `thread-slab-pool`: pushes onto the per-thread slab if both slot and
+/// byte caps allow, otherwise returns `Some(buf)` for the same routing.
+#[cfg(not(feature = "thread-slab-pool"))]
 pub(super) fn try_store(buf: Vec<u8>) -> Option<Vec<u8>> {
     LOCAL_BUF.with(|cell| {
         let mut slot = cell.borrow_mut();
@@ -49,4 +63,14 @@ pub(super) fn try_store(buf: Vec<u8>) -> Option<Vec<u8>> {
             Some(buf)
         }
     })
+}
+
+#[cfg(feature = "thread-slab-pool")]
+pub(super) fn try_take() -> Option<Vec<u8>> {
+    super::thread_slab::try_take()
+}
+
+#[cfg(feature = "thread-slab-pool")]
+pub(super) fn try_store(buf: Vec<u8>) -> Option<Vec<u8>> {
+    super::thread_slab::try_store(buf)
 }

--- a/crates/engine/src/local_copy/buffer_pool/thread_slab.rs
+++ b/crates/engine/src/local_copy/buffer_pool/thread_slab.rs
@@ -1,0 +1,379 @@
+//! Per-thread buffer slab (#1271, #1370).
+//!
+//! Replaces the single-slot [`thread_local_cache`](super::thread_local_cache)
+//! with a depth-bounded LIFO `Vec<Vec<u8>>` per thread. Used when
+//! `BufferPool` is compiled with the `thread-slab-pool` feature.
+//!
+//! # Design
+//!
+//! Each thread owns a [`LocalSlab`] that stores up to `slot_cap` buffers and
+//! at most `byte_cap` bytes of capacity. Acquire pops from the back (LIFO
+//! warmth - newest entry is warmest in cache). Return pushes onto the back
+//! when both caps allow, otherwise the caller routes the buffer to the
+//! pool's central overflow queue.
+//!
+//! The slab is the **primary** storage in this configuration: the central
+//! [`crossbeam_queue::ArrayQueue`] in `pool.rs` is demoted to a global
+//! overflow path that catches cross-thread returns and donations from full
+//! slabs. The buffer-pool API (`BufferPool::return_buffer`,
+//! `BufferGuard::drop`, `BorrowedBufferGuard::drop`) is unchanged - this
+//! module exposes the same `try_take` / `try_store` shape as
+//! `thread_local_cache` so callers in `pool.rs` need no special-casing
+//! beyond the feature switch in `thread_local_cache.rs`.
+//!
+//! # Bounded Total Memory
+//!
+//! Per-thread retention is bounded by `byte_cap` (default `8 *
+//! COPY_BUFFER_SIZE = 1 MiB`). The global overflow queue retains additional
+//! buffers under the existing [`ByteBudget`](super::byte_budget) when one is
+//! configured. End-to-end retention at N threads is bounded by
+//! `N * byte_cap + global_overflow_capacity * buffer_size`.
+//!
+//! # Cross-Thread Returns
+//!
+//! A buffer acquired on thread A and dropped on thread B pushes onto
+//! thread B's slab (or the central overflow queue if B's slab is full).
+//! The buffer's provenance does not matter: every `Vec<u8>` is fungible.
+//! This avoids the bookkeeping complexity of "steal-from-other-thread"
+//! schemes while keeping the global overflow queue's cursor traffic bounded
+//! to the rare slab-overflow case.
+//!
+//! # Thread Teardown
+//!
+//! Rust runs [`thread_local!`] destructors at thread exit and during panic
+//! unwind. The slab's `Drop` impl drains every retained buffer through
+//! [`drain_to_overflow`], which calls back into the
+//! [`SlabOverflow`] callback registered by the pool. Buffers that the
+//! overflow callback rejects (queue full) are deallocated by the callback's
+//! deallocate path so no allocations leak.
+//!
+//! No `unwrap`, `expect`, or `panic!` is allowed on the teardown path so
+//! that a panicking thread can still drain cleanly.
+
+use std::cell::RefCell;
+
+use super::COPY_BUFFER_SIZE;
+
+/// Default LIFO slot cap per thread (covers delta-apply two-buffer overlap,
+/// prefetch, and signature pipeline lookahead with headroom).
+pub(super) const DEFAULT_SLAB_SLOT_CAP: usize = 8;
+
+/// Default per-thread byte cap at `COPY_BUFFER_SIZE` buffers = 1 MiB.
+pub(super) const DEFAULT_SLAB_BYTE_CAP: usize = 8 * COPY_BUFFER_SIZE;
+
+/// Per-thread donation interval: every Mth return donates the oldest slab
+/// entry to the global overflow queue to break "pinning" on idle threads.
+///
+/// Set to a power of two so the modulus compiles to a bitwise AND.
+const DONATION_INTERVAL: u64 = 64;
+
+/// Callback shape the pool registers so the slab can hand off buffers to
+/// the central overflow queue without depending on the pool's concrete type.
+///
+/// Returns `Some(buf)` if the overflow path rejected the buffer (queue full
+/// or budget exhausted) so the slab can deallocate via a separate hook.
+pub(super) type SlabOverflow = Box<dyn Fn(Vec<u8>) -> Option<Vec<u8>> + Send + Sync + 'static>;
+
+/// Per-thread LIFO buffer slab.
+#[derive(Debug)]
+pub(super) struct LocalSlab {
+    /// LIFO of pooled buffers. Newest entries on the back.
+    buffers: Vec<Vec<u8>>,
+    /// Sum of `buf.capacity()` across `buffers`.
+    retained_bytes: usize,
+    /// Soft cap on `buffers.len()`.
+    slot_cap: usize,
+    /// Soft cap on `retained_bytes`.
+    byte_cap: usize,
+    /// Cumulative return counter, used to amortize donation cadence.
+    return_count: u64,
+}
+
+impl LocalSlab {
+    /// Creates a slab with the project default slot and byte caps.
+    pub(super) fn new() -> Self {
+        Self::with_caps(DEFAULT_SLAB_SLOT_CAP, DEFAULT_SLAB_BYTE_CAP)
+    }
+
+    /// Creates a slab with custom slot and byte caps.
+    ///
+    /// `slot_cap` is clamped to at least 1; `byte_cap` is clamped to at
+    /// least `COPY_BUFFER_SIZE` to ensure a single buffer always fits.
+    pub(super) fn with_caps(slot_cap: usize, byte_cap: usize) -> Self {
+        Self {
+            buffers: Vec::with_capacity(slot_cap.max(1)),
+            retained_bytes: 0,
+            slot_cap: slot_cap.max(1),
+            byte_cap: byte_cap.max(COPY_BUFFER_SIZE),
+            return_count: 0,
+        }
+    }
+
+    /// Pops the warmest buffer from the slab, if any.
+    pub(super) fn pop(&mut self) -> Option<Vec<u8>> {
+        let buf = self.buffers.pop()?;
+        self.retained_bytes = self.retained_bytes.saturating_sub(buf.capacity());
+        Some(buf)
+    }
+
+    /// Tries to push a buffer into the slab.
+    ///
+    /// Returns `None` if admitted, `Some(buf)` if the slab is at slot or
+    /// byte cap. The caller must then route the buffer to the global
+    /// overflow path.
+    pub(super) fn try_push(&mut self, buf: Vec<u8>) -> Option<Vec<u8>> {
+        let cap = buf.capacity();
+        if self.buffers.len() >= self.slot_cap
+            || self.retained_bytes.saturating_add(cap) > self.byte_cap
+        {
+            return Some(buf);
+        }
+        self.retained_bytes = self.retained_bytes.saturating_add(cap);
+        self.buffers.push(buf);
+        None
+    }
+
+    /// Pops the oldest (coldest) buffer for donation to the overflow queue.
+    ///
+    /// FIFO eviction preserves LIFO warmth on the hot path: the most
+    /// recently freed buffer stays available for the next acquire.
+    pub(super) fn pop_oldest(&mut self) -> Option<Vec<u8>> {
+        if self.buffers.is_empty() {
+            return None;
+        }
+        let buf = self.buffers.remove(0);
+        self.retained_bytes = self.retained_bytes.saturating_sub(buf.capacity());
+        Some(buf)
+    }
+
+    /// Returns `true` when this return triggers a periodic donation.
+    pub(super) fn should_donate(&mut self) -> bool {
+        self.return_count = self.return_count.wrapping_add(1);
+        self.return_count % DONATION_INTERVAL == 0 && !self.buffers.is_empty()
+    }
+
+    /// Returns the current retained byte total.
+    pub(super) fn retained_bytes(&self) -> usize {
+        self.retained_bytes
+    }
+
+    /// Returns the current slot count.
+    pub(super) fn len(&self) -> usize {
+        self.buffers.len()
+    }
+
+    /// Drains every buffer through `overflow`, deallocating any buffer the
+    /// overflow callback rejects via `deallocate`.
+    ///
+    /// Never panics: errors are absorbed by routing rejected buffers through
+    /// `deallocate`. Called from the `thread_local!` destructor at thread
+    /// exit or during panic unwind.
+    pub(super) fn drain_to_overflow<F, G>(&mut self, overflow: F, deallocate: G)
+    where
+        F: Fn(Vec<u8>) -> Option<Vec<u8>>,
+        G: Fn(Vec<u8>),
+    {
+        while let Some(buf) = self.buffers.pop() {
+            self.retained_bytes = self.retained_bytes.saturating_sub(buf.capacity());
+            if let Some(rejected) = overflow(buf) {
+                deallocate(rejected);
+            }
+        }
+    }
+}
+
+thread_local! {
+    /// Per-thread slab. Initialized lazily on first access.
+    pub(super) static LOCAL_SLAB: RefCell<LocalSlab> = RefCell::new(LocalSlab::new());
+}
+
+/// Pops the warmest buffer from this thread's slab, if any.
+pub(super) fn try_take() -> Option<Vec<u8>> {
+    LOCAL_SLAB.with(|cell| cell.borrow_mut().pop())
+}
+
+/// Pushes a buffer onto this thread's slab.
+///
+/// Returns `None` on admission, `Some(buf)` when the slab is full so the
+/// caller can route it to the central overflow queue.
+pub(super) fn try_store(buf: Vec<u8>) -> Option<Vec<u8>> {
+    LOCAL_SLAB.with(|cell| cell.borrow_mut().try_push(buf))
+}
+
+/// If this is the Mth return on this thread, pops the oldest buffer for
+/// donation to the global overflow queue.
+pub(super) fn take_donation() -> Option<Vec<u8>> {
+    LOCAL_SLAB.with(|cell| {
+        let mut slab = cell.borrow_mut();
+        if slab.should_donate() {
+            slab.pop_oldest()
+        } else {
+            None
+        }
+    })
+}
+
+/// Returns this thread's current slab retained bytes and slot count.
+///
+/// Used by tests and telemetry.
+pub(super) fn snapshot() -> (usize, usize) {
+    LOCAL_SLAB.with(|cell| {
+        let slab = cell.borrow();
+        (slab.len(), slab.retained_bytes())
+    })
+}
+
+/// Drains this thread's slab through `overflow` / `deallocate`.
+///
+/// Intended for explicit cleanup (e.g. teardown of a transient worker pool
+/// that should not retain buffers across pool reconfiguration). The
+/// thread-exit path uses the `Drop` impl on `LocalSlab` indirectly via the
+/// `thread_local!` destructor when the slab carries a global overflow hook
+/// (see [`super::pool`]).
+pub(super) fn drain<F, G>(overflow: F, deallocate: G)
+where
+    F: Fn(Vec<u8>) -> Option<Vec<u8>>,
+    G: Fn(Vec<u8>),
+{
+    LOCAL_SLAB.with(|cell| cell.borrow_mut().drain_to_overflow(overflow, deallocate));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn slab_starts_empty() {
+        let slab = LocalSlab::new();
+        assert_eq!(slab.len(), 0);
+        assert_eq!(slab.retained_bytes(), 0);
+    }
+
+    #[test]
+    fn pop_on_empty_returns_none() {
+        let mut slab = LocalSlab::with_caps(4, 4 * COPY_BUFFER_SIZE);
+        assert!(slab.pop().is_none());
+    }
+
+    #[test]
+    fn push_pop_is_lifo() {
+        let mut slab = LocalSlab::with_caps(4, 4 * COPY_BUFFER_SIZE);
+        let mut a = vec![0u8; COPY_BUFFER_SIZE];
+        a[0] = 1;
+        let mut b = vec![0u8; COPY_BUFFER_SIZE];
+        b[0] = 2;
+
+        assert!(slab.try_push(a).is_none());
+        assert!(slab.try_push(b).is_none());
+        let top = slab.pop().expect("top");
+        assert_eq!(top[0], 2, "LIFO: newest on top");
+        let next = slab.pop().expect("next");
+        assert_eq!(next[0], 1);
+    }
+
+    #[test]
+    fn slot_cap_blocks_admission() {
+        let mut slab = LocalSlab::with_caps(2, 16 * COPY_BUFFER_SIZE);
+        assert!(slab.try_push(vec![0u8; COPY_BUFFER_SIZE]).is_none());
+        assert!(slab.try_push(vec![0u8; COPY_BUFFER_SIZE]).is_none());
+        let overflow = slab.try_push(vec![0u8; COPY_BUFFER_SIZE]);
+        assert!(overflow.is_some(), "third push exceeds slot_cap=2");
+    }
+
+    #[test]
+    fn byte_cap_blocks_admission() {
+        let mut slab = LocalSlab::with_caps(8, COPY_BUFFER_SIZE);
+        assert!(slab.try_push(vec![0u8; COPY_BUFFER_SIZE]).is_none());
+        let overflow = slab.try_push(vec![0u8; COPY_BUFFER_SIZE]);
+        assert!(overflow.is_some(), "second push exceeds byte_cap=1");
+    }
+
+    #[test]
+    fn retained_bytes_tracks_capacity() {
+        let mut slab = LocalSlab::with_caps(4, 4 * COPY_BUFFER_SIZE);
+        let buf = Vec::with_capacity(COPY_BUFFER_SIZE);
+        assert!(slab.try_push(buf).is_none());
+        assert_eq!(slab.retained_bytes(), COPY_BUFFER_SIZE);
+        let popped = slab.pop().expect("buf");
+        assert_eq!(popped.capacity(), COPY_BUFFER_SIZE);
+        assert_eq!(slab.retained_bytes(), 0);
+    }
+
+    #[test]
+    fn pop_oldest_is_fifo_for_eviction() {
+        let mut slab = LocalSlab::with_caps(4, 4 * COPY_BUFFER_SIZE);
+        let mut first = vec![0u8; COPY_BUFFER_SIZE];
+        first[0] = 1;
+        let mut second = vec![0u8; COPY_BUFFER_SIZE];
+        second[0] = 2;
+        let mut third = vec![0u8; COPY_BUFFER_SIZE];
+        third[0] = 3;
+        assert!(slab.try_push(first).is_none());
+        assert!(slab.try_push(second).is_none());
+        assert!(slab.try_push(third).is_none());
+        let oldest = slab.pop_oldest().expect("oldest");
+        assert_eq!(oldest[0], 1, "FIFO eviction: oldest first");
+        // Newest still on top after eviction.
+        let newest = slab.pop().expect("newest");
+        assert_eq!(newest[0], 3);
+    }
+
+    #[test]
+    fn should_donate_fires_every_donation_interval() {
+        let mut slab = LocalSlab::with_caps(4, 4 * COPY_BUFFER_SIZE);
+        assert!(slab.try_push(vec![0u8; COPY_BUFFER_SIZE]).is_none());
+        let mut fired = 0;
+        for _ in 0..(DONATION_INTERVAL * 2) {
+            if slab.should_donate() {
+                fired += 1;
+            }
+        }
+        assert_eq!(fired, 2);
+    }
+
+    #[test]
+    fn should_donate_skips_when_empty() {
+        let mut slab = LocalSlab::with_caps(4, 4 * COPY_BUFFER_SIZE);
+        for _ in 0..(DONATION_INTERVAL * 2) {
+            assert!(!slab.should_donate(), "no donation from empty slab");
+        }
+    }
+
+    #[test]
+    fn drain_routes_through_overflow() {
+        let mut slab = LocalSlab::with_caps(4, 4 * COPY_BUFFER_SIZE);
+        for _ in 0..3 {
+            assert!(slab.try_push(vec![0u8; COPY_BUFFER_SIZE]).is_none());
+        }
+
+        let drained = std::sync::atomic::AtomicUsize::new(0);
+        let deallocated = std::sync::atomic::AtomicUsize::new(0);
+        slab.drain_to_overflow(
+            |buf| {
+                drained.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                // Half accepted, half rejected to exercise both branches.
+                if drained.load(std::sync::atomic::Ordering::Relaxed) % 2 == 0 {
+                    Some(buf)
+                } else {
+                    None
+                }
+            },
+            |_buf| {
+                deallocated.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            },
+        );
+
+        assert_eq!(slab.len(), 0);
+        assert_eq!(slab.retained_bytes(), 0);
+        assert_eq!(drained.load(std::sync::atomic::Ordering::Relaxed), 3);
+        // Returns for which the overflow callback returned Some get deallocated.
+        assert_eq!(deallocated.load(std::sync::atomic::Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn with_caps_floors_clamps() {
+        let slab = LocalSlab::with_caps(0, 1);
+        assert!(slab.slot_cap >= 1);
+        assert!(slab.byte_cap >= COPY_BUFFER_SIZE);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds opt-in per-thread LIFO buffer slab in front of `BufferPool`, gated behind the new `thread-slab-pool` cargo feature (default off, existing pool stays default).
- Implements the design at `docs/design/per-thread-buffer-slab.md` (merged via #4230): per-thread `thread_local!` `Vec<Vec<u8>>` with bounded slot count (default 8) and bounded byte cap (default 1 MiB), with the existing lock-free central queue demoted to a global overflow / balancer for cross-thread returns and donation of long-lived buffers.
- Preserves `BufferGuard` / `BorrowedBufferGuard` Drop signatures byte-for-byte; the backend switch is a compile-time fork inside `thread_local_cache.rs` so `pool.rs` reads identically on both paths.
- Adds periodic FIFO donation (every 64th return) that pushes the slab's oldest entry to the central queue to break "pinning" on idle threads, while LIFO acquire keeps the warmest buffer on the hot path.

## Files

- `crates/engine/src/local_copy/buffer_pool/thread_slab.rs` (new) - `LocalSlab` LIFO storage, slot / byte caps, FIFO donation, thread teardown drain hook, plus unit tests.
- `crates/engine/src/local_copy/buffer_pool/thread_local_cache.rs` - feature-gated dispatch to either the single-slot path (default) or the slab path.
- `crates/engine/src/local_copy/buffer_pool/pool.rs` - donation hook in `return_buffer` (cfg-gated, zero overhead when feature is off).
- `crates/engine/src/local_copy/buffer_pool/mod.rs` - registers `thread_slab` module behind the feature.
- `crates/engine/src/local_copy/buffer_pool/tests.rs` - integration tests for slab teardown, cross-thread return, bounded memory, periodic donation, LIFO ordering, multi-thread stress.
- `crates/engine/Cargo.toml` - declares the `thread-slab-pool` feature.

## Test plan

- [ ] `cargo nextest run -p engine --features thread-slab-pool` (CI)
- [ ] `cargo nextest run -p engine` (default, slab feature off) - existing single-slot path stays green
- [ ] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` (CI)
- [ ] `cargo fmt --all -- --check` (CI)