### PR TITLE
ci: nightly differential filter fuzzer schedule (#1293)

### DIFF
--- a/.github/workflows/filter-fuzzer-overnight.yml
+++ b/.github/workflows/filter-fuzzer-overnight.yml
@@ -1,0 +1,162 @@
+# Differential Filter Fuzzer - Overnight Schedule
+#
+# Runs both differential filter fuzz targets nightly to accumulate the
+# equivalent of a 24h soak across roughly 1.7 days without monopolising the
+# CI fleet for a full day at a time.
+#
+# Budget:
+#   - FUZZ_DURATION seconds per target (default 3600s = 1h).
+#   - Two targets per run -> ~2h per night.
+#   - Over a week -> ~14h per target, ~28h aggregate (>24h cumulative).
+#
+# Findings:
+#   - Any file under fuzz/artifacts/ uploads as a workflow artifact and the
+#     job fails so triage starts the next morning.
+#   - See docs/process/filter-fuzzer-24h-cumulative.md for the triage flow
+#     and how to dispatch a longer manual soak.
+
+name: Filter Fuzzer Overnight
+
+on:
+  schedule:
+    # Nightly at 02:00 UTC: low contention with daytime CI traffic.
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+    inputs:
+      duration:
+        description: 'Seconds per fuzz target (default 3600 = 1h)'
+        required: false
+        default: '3600'
+
+concurrency:
+  group: filter-fuzzer-overnight
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  FUZZ_DURATION: ${{ github.event.inputs.duration || '3600' }}
+
+jobs:
+  fuzz:
+    name: ${{ matrix.target }}
+    runs-on: ubuntu-latest
+    # Each target budget + 30 minutes for build/upstream/setup overhead.
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: filter_differential
+            runner: run_filter_fuzz.sh
+            env_var: FUZZ_SECONDS
+          - target: filter_rules_vs_upstream
+            runner: run_filter_differential_fuzz.sh
+            env_var: FUZZ_DURATION
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
+        with:
+          toolchain: stable
+
+      - name: Install nightly Rust
+        uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
+        with:
+          toolchain: nightly
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
+        with:
+          shared-key: ci-${{ runner.os }}-cargo-v1-${{ hashFiles('**/Cargo.lock') }}
+          key: filter-fuzzer-${{ matrix.target }}
+
+      - name: Cache APT packages
+        uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05 # v1.6.0
+        with:
+          packages: build-essential pkg-config zlib1g-dev curl autoconf automake libtool libacl1-dev libattr1-dev
+          version: v1
+
+      - name: Install cargo-fuzz
+        run: cargo +nightly install cargo-fuzz --locked
+
+      - name: Cache upstream rsync
+        id: cache-rsync
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            target/interop/upstream-src
+            target/interop/upstream-install
+          key: upstream-rsync-3.4.2-${{ runner.os }}-${{ hashFiles('tools/ci/run_interop.sh') }}
+          restore-keys: |
+            upstream-rsync-3.4.2-${{ runner.os }}-
+
+      - name: Build upstream rsync
+        if: steps.cache-rsync.outputs.cache-hit != 'true'
+        run: bash tools/ci/run_interop.sh build-only
+
+      - name: Locate upstream rsync
+        id: upstream
+        run: |
+          set -euo pipefail
+          for candidate in \
+              "${GITHUB_WORKSPACE}/target/interop/upstream-install/3.4.2/bin/rsync" \
+              "${GITHUB_WORKSPACE}/target/interop/upstream-install/3.4.1/bin/rsync"; do
+              if [[ -x "${candidate}" ]]; then
+                  echo "upstream=${candidate}" >>"$GITHUB_OUTPUT"
+                  echo "located upstream rsync at ${candidate}"
+                  exit 0
+              fi
+          done
+          echo "error: no upstream rsync binary built" >&2
+          exit 1
+
+      - name: Run ${{ matrix.target }}
+        env:
+          OC_RSYNC_UPSTREAM_BIN: ${{ steps.upstream.outputs.upstream }}
+        run: |
+          set -uo pipefail
+          export ${{ matrix.env_var }}="${FUZZ_DURATION}"
+          bash tools/ci/${{ matrix.runner }}
+          status=$?
+          echo "runner_status=${status}" >>"$GITHUB_ENV"
+          exit "${status}"
+
+      - name: Collect artifacts metadata
+        if: always()
+        run: |
+          set -euo pipefail
+          mkdir -p fuzz-report
+          if [[ -d fuzz/artifacts ]]; then
+              find fuzz/artifacts -mindepth 1 -type f -printf '%p\t%s\n' \
+                  >fuzz-report/inventory.tsv || true
+          fi
+          if [[ -s fuzz-report/inventory.tsv ]]; then
+              echo "findings recorded:" >&2
+              cat fuzz-report/inventory.tsv >&2
+          else
+              echo "no findings recorded" >fuzz-report/inventory.tsv
+          fi
+
+      - name: Upload fuzz artifacts
+        if: always() && hashFiles('fuzz/artifacts/**') != ''
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: filter-fuzz-artifacts-${{ matrix.target }}-${{ github.run_id }}
+          retention-days: 30
+          path: |
+            fuzz/artifacts/**
+            fuzz-report/**
+
+      - name: Fail if findings were uploaded
+        if: always() && hashFiles('fuzz/artifacts/**') != ''
+        run: |
+          echo "Fuzzer recorded artifacts under fuzz/artifacts/. Triage with"
+          echo "tools/ci/triage_fuzz_artifact.sh - see"
+          echo "docs/process/filter-fuzzer-24h-cumulative.md."
+          exit 1

--- a/docs/process/filter-fuzzer-24h-cumulative.md
+++ b/docs/process/filter-fuzzer-24h-cumulative.md
@@ -1,0 +1,90 @@
+# 24h Cumulative Filter Fuzzer Schedule
+
+The differential filter fuzz targets (`filter_differential` and
+`filter_rules_vs_upstream`) exist to flush out divergences between oc-rsync's
+filter engine and upstream rsync 3.4.x. The original requirement was a single
+24h soak. A single contiguous 24h run is hostile to shared CI: it blocks one
+runner for a full day, can be evicted partway, and produces a long, hard-to-
+attribute log.
+
+This page describes how the workflow trades a contiguous 24h block for a
+nightly cadence that accumulates more than 24h of fuzzing per target per week.
+
+## Schedule
+
+- Workflow: `.github/workflows/filter-fuzzer-overnight.yml`
+- Cron: `0 2 * * *` (every day at 02:00 UTC)
+- Matrix: two targets per run, each fuzzed for `FUZZ_DURATION` seconds
+  (default 3600 = 1 hour).
+- Per night: ~2h of fuzz time (1h per target), plus build/upstream setup.
+- Per week: ~14h per target, ~28h aggregate.
+
+A 24h cumulative budget is therefore reached every 1.7 days. Any single
+finding is recorded and triaged the next morning, instead of being buried at
+the end of a day-long run.
+
+## Why nightly rather than a single 24h job
+
+- GitHub-hosted runners cap at 6h per job. A 24h soak would have to be
+  stitched together across four sequential jobs anyway.
+- A nightly cadence keeps the corpus warm (libFuzzer reuses prior coverage
+  via the `fuzz/corpus/<target>/` directory) and means a regression introduced
+  on day N is caught on night N+1 rather than 24h+rebuild later.
+- Failures interrupt only a 90-minute window of capacity, so a hung target
+  cannot starve other CI tenants.
+
+## Findings flow
+
+1. Workflow runs `tools/ci/run_filter_fuzz.sh` and
+   `tools/ci/run_filter_differential_fuzz.sh` for each target.
+2. If a crash or divergence reproducer lands under `fuzz/artifacts/`:
+   - The job uploads `fuzz/artifacts/**` and a `fuzz-report/inventory.tsv`
+     listing all reproducers + sizes as the workflow artifact
+     `filter-fuzz-artifacts-<target>-<run_id>`, retained for 30 days.
+   - The job fails so the morning triage notification fires.
+3. Download the artifact and feed each reproducer into
+   `tools/ci/triage_fuzz_artifact.sh <path>` to replay it locally against the
+   same fuzz target.
+4. File a bug, fix the divergence, then re-run the failing target with
+   `FUZZ_DURATION` bumped (see below) to confirm the fix holds.
+
+## Manual longer soak
+
+Use `workflow_dispatch` to run a longer soak on demand without touching the
+cron schedule:
+
+```sh
+# 4-hour run per target (~8h total wall-clock):
+gh workflow run filter-fuzzer-overnight.yml -f duration=14400
+
+# Full 24h soak per target (24h total per matrix slot; needs a self-hosted
+# runner or split across multiple dispatches because GitHub-hosted runners
+# cap at 6h):
+gh workflow run filter-fuzzer-overnight.yml -f duration=86400
+```
+
+The dispatched value flows into the matrix via the `FUZZ_DURATION` /
+`FUZZ_SECONDS` environment variables that the runner scripts already honour.
+
+## Local reproduction
+
+For interactive triage, the runner scripts respect the same env vars:
+
+```sh
+FUZZ_SECONDS=600 bash tools/ci/run_filter_fuzz.sh
+FUZZ_DURATION=600 bash tools/ci/run_filter_differential_fuzz.sh
+```
+
+Both require:
+
+- `cargo +nightly` (rustup `toolchain install nightly`)
+- `cargo-fuzz` (`cargo install cargo-fuzz`)
+- An upstream rsync binary discoverable via `OC_RSYNC_UPSTREAM_BIN` or
+  `target/interop/upstream-install/3.4.{1,2}/bin/rsync`.
+
+## Tracking
+
+This schedule subsumes the original "run for 24h" requirement on task #1293.
+The PR opening the workflow links back to #1293; subsequent triage PRs that
+fix individual findings should reference the artifact name and the upstream
+behaviour they restore.

--- a/tools/ci/triage_fuzz_artifact.sh
+++ b/tools/ci/triage_fuzz_artifact.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# triage_fuzz_artifact.sh - reproduce a crash artifact from one of the
+# differential filter fuzz targets locally.
+#
+# The overnight fuzz workflow uploads any reproducers under
+# fuzz/artifacts/<target>/... as a workflow artifact. Download the artifact,
+# extract it, and feed each reproducer path to this script. The target is
+# inferred from the path; pass --target to override.
+#
+# Usage:
+#   bash tools/ci/triage_fuzz_artifact.sh fuzz/artifacts/filter_differential/crash-abc
+#   bash tools/ci/triage_fuzz_artifact.sh --target filter_rules_vs_upstream ./crash-abc
+#
+# Exit codes:
+#   0   reproducer ran cleanly (no divergence reproduced - investigate flake)
+#   1   reproducer triggered the recorded divergence (expected during triage)
+#   2   invalid invocation or missing tooling
+
+set -uo pipefail
+
+usage() {
+    cat >&2 <<'USAGE'
+Usage: triage_fuzz_artifact.sh [--target <name>] <artifact-path>
+
+Reproduces a libFuzzer crash artifact against one of the differential filter
+fuzz targets (filter_differential or filter_rules_vs_upstream).
+USAGE
+    exit 2
+}
+
+target=""
+artifact=""
+while (($#)); do
+    case "$1" in
+        --target)
+            shift
+            [[ $# -gt 0 ]] || usage
+            target="$1"
+            ;;
+        --target=*)
+            target="${1#--target=}"
+            ;;
+        -h|--help)
+            usage
+            ;;
+        --)
+            shift
+            artifact="${1:-}"
+            break
+            ;;
+        -*)
+            echo "error: unknown flag $1" >&2
+            usage
+            ;;
+        *)
+            if [[ -z "${artifact}" ]]; then
+                artifact="$1"
+            else
+                echo "error: unexpected extra positional argument: $1" >&2
+                usage
+            fi
+            ;;
+    esac
+    shift
+done
+
+[[ -n "${artifact}" ]] || usage
+
+if [[ ! -f "${artifact}" ]]; then
+    echo "error: artifact not found: ${artifact}" >&2
+    exit 2
+fi
+
+workspace_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+fuzz_dir="${workspace_root}/fuzz"
+
+if [[ -z "${target}" ]]; then
+    case "${artifact}" in
+        *filter_rules_vs_upstream*) target="filter_rules_vs_upstream" ;;
+        *filter_differential*)      target="filter_differential" ;;
+        *)
+            echo "error: cannot infer fuzz target from path; pass --target" >&2
+            exit 2
+            ;;
+    esac
+fi
+
+case "${target}" in
+    filter_differential|filter_rules_vs_upstream) ;;
+    *)
+        echo "error: unknown target '${target}'" >&2
+        exit 2
+        ;;
+esac
+
+if ! command -v cargo >/dev/null 2>&1; then
+    echo "error: cargo is required" >&2
+    exit 2
+fi
+if ! cargo +nightly --version >/dev/null 2>&1; then
+    echo "error: nightly toolchain required (rustup toolchain install nightly)" >&2
+    exit 2
+fi
+if ! cargo +nightly fuzz --help >/dev/null 2>&1; then
+    echo "error: cargo-fuzz required (cargo install cargo-fuzz)" >&2
+    exit 2
+fi
+
+upstream="${OC_RSYNC_UPSTREAM_BIN:-}"
+if [[ -z "${upstream}" ]]; then
+    for candidate in \
+        "${workspace_root}/target/interop/upstream-install/3.4.2/bin/rsync" \
+        "${workspace_root}/target/interop/upstream-install/3.4.1/bin/rsync" \
+        /opt/homebrew/bin/rsync \
+        /usr/local/bin/rsync \
+        /usr/bin/rsync; do
+        if [[ -x "${candidate}" ]]; then
+            upstream="${candidate}"
+            break
+        fi
+    done
+fi
+if [[ -z "${upstream}" ]]; then
+    echo "warning: no upstream rsync binary discovered; the differential" >&2
+    echo "         compare will be skipped. Set OC_RSYNC_UPSTREAM_BIN or run" >&2
+    echo "         tools/ci/run_interop.sh." >&2
+fi
+
+# Resolve the artifact to an absolute path before changing directories.
+case "${artifact}" in
+    /*) artifact_abs="${artifact}" ;;
+    *)  artifact_abs="$(cd "$(dirname "${artifact}")" && pwd)/$(basename "${artifact}")" ;;
+esac
+
+echo "target:        ${target}"
+echo "artifact:      ${artifact_abs}"
+echo "upstream:      ${upstream:-<none>}"
+
+cd "${fuzz_dir}"
+set +e
+env OC_RSYNC_UPSTREAM_BIN="${upstream}" \
+    cargo +nightly fuzz run "${target}" "${artifact_abs}"
+status=$?
+set -e
+
+if [[ ${status} -eq 0 ]]; then
+    echo "reproducer ran cleanly - the divergence did not trigger; check whether"
+    echo "the fix is already in tree or whether the reproducer is flaky."
+    exit 0
+fi
+echo "reproducer triggered failure (exit ${status}); see libFuzzer output above."
+exit 1


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/filter-fuzzer-overnight.yml` that runs both differential filter fuzz targets (`filter_differential`, `filter_rules_vs_upstream`) nightly at 02:00 UTC for `FUZZ_DURATION` seconds each (default 3600 = 1h per target, ~2h per run).
- Uploads any reproducers under `fuzz/artifacts/**` as a retained workflow artifact and fails the job so triage is unmissable; supports `workflow_dispatch` with a `duration` input for longer manual soaks.
- Adds `docs/process/filter-fuzzer-24h-cumulative.md` explaining the cumulative-24h interpretation (~14h/target/week, >24h aggregate every 1.7 days), the triage flow, and how to dispatch a longer manual run.
- Adds `tools/ci/triage_fuzz_artifact.sh` to replay a downloaded reproducer locally against the inferred fuzz target.

## Cumulative 24h interpretation

The original task asked for a 24h soak. GitHub-hosted runners cap at 6h per job and a contiguous 24h block would have to be stitched together regardless. Running both targets for 1h every night accumulates ~14h per target per week (~28h aggregate), exceeding the 24h budget every 1.7 days while keeping each window short enough to fit on shared CI and catch regressions the morning after they land.

## Test plan

- [ ] Wait for the next scheduled run (or trigger via `gh workflow run filter-fuzzer-overnight.yml`) and confirm both matrix legs build, locate the upstream binary, and report `no divergence detected within 3600s` (or upload artifacts if any appear).
- [ ] Confirm a manual `workflow_dispatch` with `duration=600` honours the override.
- [ ] Locally, run `FUZZ_SECONDS=60 bash tools/ci/run_filter_fuzz.sh` and `FUZZ_DURATION=60 bash tools/ci/run_filter_differential_fuzz.sh` to verify the underlying scripts still work, then exercise `tools/ci/triage_fuzz_artifact.sh` against any reproducer that lands.