### PR TITLE
ci(macos): extend coverage to metadata + apple-fs crates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -402,7 +402,13 @@ jobs:
         run: |
           # Run macOS-specific crates only (core, engine, cli have platform code).
           # Full test suite runs on Linux; macOS validates platform-specific paths.
-          rustup run ${{ matrix.toolchain }} cargo nextest run --locked -p core -p engine -p cli --all-features
+          # metadata covers the Darwin acl_exacl branch and the macOS timestamp
+          # path in crates/metadata/src/apply/timestamps.rs. apple-fs covers the
+          # AppleDouble round-trip plus the macOS-only resource fork pipeline.
+          # Tests that need root self-skip via geteuid() (see acl_handling.rs)
+          # and the resource-fork test probes xattr support and skips on
+          # filesystems that do not support it (e.g. FAT-mounted /tmp).
+          rustup run ${{ matrix.toolchain }} cargo nextest run --locked -p core -p engine -p cli -p metadata -p apple-fs --all-features
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
## Summary

Closes gap G4 from `docs/audits/cross-platform-ci-coverage.md`.

- The macOS `nextest` step ran only `-p core -p engine -p cli`, leaving the Darwin `acl_exacl` ACL path, the macOS-specific timestamp branches in `crates/metadata/src/apply/timestamps.rs`, and the Apple Double round-trip pipeline in `crates/apple-fs` untested.
- The companion `windows-acl-xattr` job already covers `-p metadata` on Windows; this change brings macOS to parity by appending `-p metadata -p apple-fs` to the macOS nextest invocation.
- Environment-dependent tests already self-skip in-test: ACL tests that need root check `geteuid()` (see `crates/metadata/tests/acl_handling.rs::apply_from_cache_unmapped_user_id_does_not_fail_transfer`), and the macOS resource fork test probes `xattr::set` and bails out when the underlying filesystem rejects xattrs (e.g. FAT-mounted `/tmp`).

## Tests now covered on macOS CI

- `crates/metadata/tests/acl_handling.rs` - exercises `acl_exacl` (Darwin POSIX-ish ACL API).
- `crates/metadata/tests/uidgid_integration.rs` - exercises Darwin `getpwnam_r`/`getgrnam_r` wrappers.
- `crates/metadata/tests/timestamp_2038.rs` - hits the `cfg(target_os = "macos")` branches.
- `crates/apple-fs/tests/apple_double_round_trip.rs` - cross-platform sidecar bytes plus the `cfg(target_os = "macos")` resource-fork pipeline.

## Test plan

- [ ] CI `macOS (stable)` passes with the new `-p metadata -p apple-fs` packages included.
- [ ] CI `macOS (beta)` and `macOS (nightly)` continue to pass (or fail only for reasons unrelated to the new coverage; both are `continue-on-error`).
- [ ] No new tests are added; the changed surface is workflow only.