### PR TITLE
refactor(engine): remove legacy batched delete sweep (DDP-F3 #2272)

### DIFF
--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -99,13 +99,6 @@ multi-producer = []
 # single-slot path; only beneficial above ~32 worker threads per pool.
 thread-slab-pool = []
 
-# Legacy batched delete sweep - opt-in fallback to the pre-DDP-E code path
-# Benefits: Lets operators flip back to the batched sweep while the
-#   parallel-deterministic-delete emitter is bedding in.
-# Trade-offs: Diverges from upstream rsync's per-directory unlink order;
-#   slated for removal in DDP-F3.
-legacy-batched-delete = []
-
 # ============================================================================
 # Runtime Features
 # ============================================================================

--- a/crates/engine/benches/delete_end_to_end.rs
+++ b/crates/engine/benches/delete_end_to_end.rs
@@ -5,11 +5,11 @@
 //!
 //! Task DDP-I3 (#2284). Together with `delete_plan_compute.rs`
 //! (DDP-I1, #2282) and `delete_emitter_unlink.rs` (DDP-I2, #2283),
-//! this bench feeds the DDP-F3 (batched sweep removal) decision: if
-//! the new pipeline lands within 5% of the legacy path on a realistic
-//! 100K-file shape, the legacy `handle_post_transfer_deletions` code
-//! in `crates/engine/src/local_copy/executor/directory/recursive/`
-//! can be retired safely.
+//! this bench fed the DDP-F3 (batched sweep removal, #2272) decision.
+//! With the legacy production path retired, the legacy arm here now
+//! serves only as a reference syscall-shape baseline so regressions in
+//! the parallel pipeline can still be compared against the original
+//! single-threaded cost model.
 //!
 //! # Two paths under test
 //!
@@ -20,20 +20,18 @@
 //!   `DeletePlanMap`. Phase 2 runs the single-threaded
 //!   `DeleteEmitter::emit_all`, which routes through `RealDeleteFs`
 //!   and actually unlinks the extras.
-//! - **Legacy batched sweep** (`legacy_batched_delete_during_100k_files`):
-//!   a faithful reproduction of the wall-clock cost model of
-//!   `crates/engine/src/local_copy/executor/directory/recursive/deletion.rs::handle_post_transfer_deletions`
-//!   ->`delete_extraneous_entries` (in
-//!   `crates/engine/src/local_copy/executor/cleanup.rs`). The legacy
-//!   path is `pub(crate)` and threaded through a `CopyContext` that
-//!   cannot be assembled from a bench crate, so this bench reproduces
-//!   its observable algorithm: a single thread visits every
-//!   directory, walks `fs::read_dir`, subtracts the keep set, and
-//!   `fs::remove_file`s each extra in turn. That matches the
-//!   syscalls the production path issues; the only thing missing is
-//!   the `CopyContext` bookkeeping, which contributes a constant
+//! - **Legacy batched sweep baseline** (`legacy_batched_delete_during_100k_files`):
+//!   a faithful reproduction of the wall-clock cost model that
+//!   `delete_extraneous_entries` (in
+//!   `crates/engine/src/local_copy/executor/cleanup.rs`) used to ship
+//!   before DDP-F3 removed it. A single thread visits every directory,
+//!   walks `fs::read_dir`, subtracts the keep set, and
+//!   `fs::remove_file`s each extra in turn. That matches the syscalls
+//!   the legacy production path used to issue; the only thing missing
+//!   is the `CopyContext` bookkeeping, which contributed a constant
 //!   per-entry overhead independent of the parallel-vs-serial axis
-//!   this bench is comparing.
+//!   this bench compares. Retained as a reference baseline; no
+//!   production code path matches this shape any more.
 //!
 //! # Workload
 //!

--- a/crates/engine/src/delete/context.rs
+++ b/crates/engine/src/delete/context.rs
@@ -27,9 +27,8 @@
 //! | `--delete-delay` | per-dir inside the copy walk          | [`DeleteContext::emit_all`] after all renames commit |
 //! | `--delete-excluded` (layered) | upstream of [`compute_extras`] - filter-excluded entries are appended to the segment-extras set | per timing mode above |
 //!
-//! The legacy batched sweep stays compiled behind
-//! `cfg(feature = "legacy-batched-delete")` (off by default). Task DDP-F3
-//! removes that path entirely in a follow-up.
+//! The legacy batched sweep was retired in DDP-F3 (#2272); the emitter
+//! is now the sole production unlink path for every timing mode.
 //!
 //! # Concurrency
 //!

--- a/crates/engine/src/local_copy/executor/cleanup.rs
+++ b/crates/engine/src/local_copy/executor/cleanup.rs
@@ -9,10 +9,8 @@ use std::time::Duration;
 
 use logging::{debug_log, info_log};
 
-#[cfg(not(feature = "legacy-batched-delete"))]
-use crate::delete::RealDeleteFs;
 use crate::delete::{
-    DeleteContext, DeleteEntry, DeleteEntryKind, DeleteFs, DeletePlan, EmitterTiming,
+    DeleteContext, DeleteEntry, DeleteEntryKind, DeleteFs, DeletePlan, EmitterTiming, RealDeleteFs,
 };
 use crate::local_copy::{CopyContext, LocalCopyAction, LocalCopyError, LocalCopyRecord};
 
@@ -41,32 +39,23 @@ fn normalize_filename_for_compare(name: &OsStr) -> OsString {
 ///
 /// # Implementation path
 ///
-/// Routes through [`delete_extraneous_entries_via_emitter`] by default so
-/// the [`crate::delete::DeleteEmitter`] is the live unlink path for every
-/// `--delete-*` timing mode (DDP-E1..E5, #2265-#2269). With the
-/// `legacy-batched-delete` cargo feature on, falls back to the pre-DDP-E
-/// batched sweep retained for emergency rollback; that path is removed
-/// in DDP-F3.
+/// Routes through [`delete_extraneous_entries_via_emitter`] so the
+/// [`crate::delete::DeleteEmitter`] is the live unlink path for every
+/// `--delete-*` timing mode (DDP-E1..E5, #2265-#2269). The legacy
+/// pre-DDP-E batched sweep was removed in DDP-F3 (#2272).
 pub(crate) fn delete_extraneous_entries<S: AsRef<OsStr>>(
     context: &mut CopyContext,
     destination: &Path,
     relative: Option<&Path>,
     source_entries: &[S],
 ) -> Result<(), LocalCopyError> {
-    #[cfg(feature = "legacy-batched-delete")]
-    {
-        delete_extraneous_entries_batched(context, destination, relative, source_entries)
-    }
-    #[cfg(not(feature = "legacy-batched-delete"))]
-    {
-        delete_extraneous_entries_via_emitter(
-            context,
-            destination,
-            relative,
-            source_entries,
-            &RealDeleteFs,
-        )
-    }
+    delete_extraneous_entries_via_emitter(
+        context,
+        destination,
+        relative,
+        source_entries,
+        &RealDeleteFs,
+    )
 }
 
 /// Emitter-backed deletion: computes the per-directory plan, hands it to
@@ -83,8 +72,7 @@ pub(crate) fn delete_extraneous_entries<S: AsRef<OsStr>>(
 /// `fs` is parameterised so tests can substitute
 /// [`crate::delete::RecordingDeleteFs`] and observe the unlink sequence
 /// without touching the filesystem.
-#[cfg_attr(feature = "legacy-batched-delete", allow(dead_code))]
-pub(crate) fn delete_extraneous_entries_via_emitter<S: AsRef<OsStr>, F: DeleteFs>(
+fn delete_extraneous_entries_via_emitter<S: AsRef<OsStr>, F: DeleteFs>(
     context: &mut CopyContext,
     destination: &Path,
     relative: Option<&Path>,
@@ -118,7 +106,7 @@ pub(crate) fn delete_extraneous_entries_via_emitter<S: AsRef<OsStr>, F: DeleteFs
     ctx.plans.insert(plan.clone());
 
     // Run side-effects (records, summary, backup) BEFORE dispatch so the
-    // dry-run path is observably identical to the legacy sweep. Then
+    // dry-run path is observably identical to a live unlink. Then
     // (unless dry-run) hand the plan to the emitter for the actual
     // syscalls.
     apply_delete_side_effects(context, destination, relative, &plan)?;
@@ -147,7 +135,6 @@ pub(crate) fn delete_extraneous_entries_via_emitter<S: AsRef<OsStr>, F: DeleteFs
 /// `destination` does not exist (e.g. removed between traversal and
 /// dispatch); the caller treats that as a no-op, matching upstream's
 /// continue-on-vanished behaviour.
-#[cfg_attr(feature = "legacy-batched-delete", allow(dead_code))]
 fn build_plan_for_directory<S: AsRef<OsStr>>(
     context: &mut CopyContext,
     destination: &Path,
@@ -239,7 +226,6 @@ fn build_plan_for_directory<S: AsRef<OsStr>>(
 /// [`crate::delete::extras::compute_extras`]: regular files, dirs,
 /// symlinks, devices, FIFOs/sockets each fall into their own
 /// [`DeleteEntryKind`] bucket; anything else collapses to `File`.
-#[cfg_attr(feature = "legacy-batched-delete", allow(dead_code))]
 fn classify_kind(file_type: fs::FileType) -> DeleteEntryKind {
     if file_type.is_symlink() {
         return DeleteEntryKind::Symlink;
@@ -265,13 +251,12 @@ fn classify_kind(file_type: fs::FileType) -> DeleteEntryKind {
 
 /// Runs the per-entry side effects (backup, summary counter, itemize
 /// log, [`LocalCopyRecord`]) for every entry in `plan`. Runs BEFORE the
-/// emitter dispatches so dry-run output and event ordering match the
-/// legacy sweep byte-for-byte.
+/// emitter dispatches so dry-run output and event ordering match upstream
+/// rsync byte-for-byte.
 ///
 /// Directories recurse into their contents so per-entry counters match
 /// upstream's `delete_in_dir` walk (one count per leaf, mirroring
 /// `target/interop/upstream-src/rsync-3.4.1/generator.c:272-347`).
-#[cfg_attr(feature = "legacy-batched-delete", allow(dead_code))]
 fn apply_delete_side_effects(
     context: &mut CopyContext,
     destination: &Path,
@@ -329,7 +314,6 @@ fn apply_delete_side_effects(
 /// summary counters before the emitter wipes the directory via
 /// `remove_dir_all`. Matches upstream's per-entry counting in
 /// `delete_in_dir`.
-#[cfg_attr(feature = "legacy-batched-delete", allow(dead_code))]
 fn record_directory_subtree(
     context: &mut CopyContext,
     dir_path: &Path,
@@ -378,321 +362,6 @@ fn record_directory_subtree(
         ));
         context.register_progress();
     }
-    Ok(())
-}
-
-/// Legacy pre-DDP-E batched sweep. Retained behind
-/// `cfg(feature = "legacy-batched-delete")` for emergency rollback; slated
-/// for removal in DDP-F3. Identical behaviour to the original
-/// `delete_extraneous_entries`.
-#[cfg(feature = "legacy-batched-delete")]
-pub(crate) fn delete_extraneous_entries_batched<S: AsRef<OsStr>>(
-    context: &mut CopyContext,
-    destination: &Path,
-    relative: Option<&Path>,
-    source_entries: &[S],
-) -> Result<(), LocalCopyError> {
-    let mut skipped_due_to_limit = 0u64;
-    // Build HashSet of normalized filenames for cross-platform comparison.
-    // On macOS, normalizes to NFC so NFD names from read_dir match NFC source names.
-    let keep: HashSet<OsString> = source_entries
-        .iter()
-        .map(|s| normalize_filename_for_compare(s.as_ref()))
-        .collect();
-
-    let read_dir = match fs::read_dir(destination) {
-        Ok(iter) => iter,
-        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
-        Err(error) => {
-            return Err(LocalCopyError::io(
-                "read destination directory",
-                destination.to_path_buf(),
-                error,
-            ));
-        }
-    };
-
-    // When --partial-dir is configured with a relative path, protect it from
-    // deletion.  Upstream rsync avoids deleting the partial-dir directory so
-    // that partial files survive across invocations even when --delete is
-    // active.  Absolute partial-dir paths live outside the destination tree
-    // and do not need protection.
-    let protected_partial_dir_name: Option<OsString> = context
-        .partial_directory_path()
-        .filter(|p| p.is_relative())
-        .and_then(|p| p.file_name())
-        .map(OsStr::to_os_string);
-
-    for entry in read_dir {
-        context.enforce_timeout()?;
-        let entry = entry
-            .map_err(|error| LocalCopyError::io("read destination entry", destination, error))?;
-        let name = entry.file_name();
-        let normalized_name = normalize_filename_for_compare(&name);
-
-        if keep.contains(&normalized_name) {
-            continue;
-        }
-
-        // Protect relative partial-dir from deletion (upstream rsync behavior).
-        if let Some(ref protected) = protected_partial_dir_name {
-            if normalized_name == *protected {
-                continue;
-            }
-        }
-
-        let name_path = PathBuf::from(name.as_os_str());
-        let path = destination.join(&name_path);
-        let entry_relative = match relative {
-            Some(base) => base.join(&name_path),
-            None => name_path.clone(),
-        };
-
-        let file_type = entry.file_type().map_err(|error| {
-            LocalCopyError::io("inspect extraneous destination entry", path.clone(), error)
-        })?;
-
-        if !context.allows_deletion(entry_relative.as_path(), file_type.is_dir()) {
-            debug_log!(
-                Filter,
-                2,
-                "filter protected {} from deletion",
-                entry_relative.display()
-            );
-            continue;
-        }
-
-        if let Some(limit) = context.options().max_deletion_limit()
-            && context.summary().items_deleted() >= limit
-        {
-            skipped_due_to_limit = skipped_due_to_limit.saturating_add(1);
-            continue;
-        }
-
-        if context.mode().is_dry_run() {
-            if file_type.is_dir() {
-                delete_directory_tree_recursive(
-                    context,
-                    &path,
-                    &entry_relative,
-                    &mut skipped_due_to_limit,
-                )?;
-            }
-            context.summary_mut().record_deletion();
-            context.record(LocalCopyRecord::new(
-                entry_relative,
-                LocalCopyAction::EntryDeleted,
-                0,
-                None,
-                Duration::default(),
-                None,
-            ));
-            context.register_progress();
-            continue;
-        }
-
-        context.backup_existing_entry(&path, Some(entry_relative.as_path()), file_type)?;
-        if file_type.is_dir() {
-            // upstream: generator.c:delete_in_dir() - recursively delete
-            // directory contents first, counting each item individually,
-            // then remove the now-empty directory.
-            delete_directory_tree_recursive(
-                context,
-                &path,
-                &entry_relative,
-                &mut skipped_due_to_limit,
-            )?;
-            info_log!(Del, 1, "deleting directory {}", entry_relative.display());
-            match fs::remove_dir(&path) {
-                Ok(()) => {}
-                Err(error) if error.kind() == io::ErrorKind::NotFound => {}
-                Err(error) => {
-                    return Err(LocalCopyError::io(
-                        "remove extraneous directory",
-                        path,
-                        error,
-                    ));
-                }
-            }
-        } else {
-            info_log!(Del, 1, "deleting {}", entry_relative.display());
-            remove_extraneous_path(&path, file_type)?;
-        }
-        context.summary_mut().record_deletion();
-        context.record(LocalCopyRecord::new(
-            entry_relative,
-            LocalCopyAction::EntryDeleted,
-            0,
-            None,
-            Duration::default(),
-            None,
-        ));
-        context.register_progress();
-    }
-
-    if skipped_due_to_limit > 0 {
-        info_log!(
-            Del,
-            1,
-            "max deletions reached, skipping {} remaining",
-            skipped_due_to_limit
-        );
-        return Err(LocalCopyError::delete_limit_exceeded(skipped_due_to_limit));
-    }
-
-    Ok(())
-}
-
-#[cfg(feature = "legacy-batched-delete")]
-fn remove_extraneous_path(path: &Path, file_type: fs::FileType) -> Result<(), LocalCopyError> {
-    let context = if file_type.is_dir() {
-        "remove extraneous directory"
-    } else {
-        "remove extraneous entry"
-    };
-
-    let result = if file_type.is_dir() {
-        fs::remove_dir_all(path)
-    } else {
-        fs::remove_file(path)
-    };
-
-    match result {
-        Ok(()) => Ok(()),
-        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
-        Err(error) => Err(LocalCopyError::io(context, path, error)),
-    }
-}
-
-/// Recursively deletes an extraneous directory, recording each item
-/// individually in the deletion count and event log.
-///
-/// Unlike `remove_dir_all` (which counts as a single deletion), this mirrors
-/// upstream rsync's `delete_in_dir()` behavior: it descends into the directory
-/// tree, deletes files first, then removes the empty directories bottom-up,
-/// counting each item as a separate deletion.
-#[cfg(feature = "legacy-batched-delete")]
-fn delete_directory_tree_recursive(
-    context: &mut CopyContext,
-    dir_path: &Path,
-    dir_relative: &Path,
-    skipped_due_to_limit: &mut u64,
-) -> Result<(), LocalCopyError> {
-    let read_dir = match fs::read_dir(dir_path) {
-        Ok(iter) => iter,
-        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
-        Err(error) => {
-            return Err(LocalCopyError::io(
-                "read extraneous directory",
-                dir_path.to_path_buf(),
-                error,
-            ));
-        }
-    };
-
-    for entry in read_dir {
-        context.enforce_timeout()?;
-        let entry = entry.map_err(|error| {
-            LocalCopyError::io("read extraneous directory entry", dir_path, error)
-        })?;
-        let name = entry.file_name();
-        let child_path = dir_path.join(&name);
-        let child_relative = dir_relative.join(&name);
-
-        let file_type = entry.file_type().map_err(|error| {
-            LocalCopyError::io(
-                "inspect extraneous directory entry",
-                child_path.clone(),
-                error,
-            )
-        })?;
-
-        if !context.allows_deletion(child_relative.as_path(), file_type.is_dir()) {
-            debug_log!(
-                Filter,
-                2,
-                "filter protected {} from deletion",
-                child_relative.display()
-            );
-            continue;
-        }
-
-        if let Some(limit) = context.options().max_deletion_limit()
-            && context.summary().items_deleted() >= limit
-        {
-            *skipped_due_to_limit = skipped_due_to_limit.saturating_add(1);
-            continue;
-        }
-
-        if context.mode().is_dry_run() {
-            if file_type.is_dir() {
-                delete_directory_tree_recursive(
-                    context,
-                    &child_path,
-                    &child_relative,
-                    skipped_due_to_limit,
-                )?;
-            }
-            context.summary_mut().record_deletion();
-            context.record(LocalCopyRecord::new(
-                child_relative,
-                LocalCopyAction::EntryDeleted,
-                0,
-                None,
-                Duration::default(),
-                None,
-            ));
-            context.register_progress();
-            continue;
-        }
-
-        context.backup_existing_entry(&child_path, Some(child_relative.as_path()), file_type)?;
-
-        if file_type.is_dir() {
-            delete_directory_tree_recursive(
-                context,
-                &child_path,
-                &child_relative,
-                skipped_due_to_limit,
-            )?;
-            info_log!(Del, 1, "deleting directory {}", child_relative.display());
-            match fs::remove_dir(&child_path) {
-                Ok(()) => {}
-                Err(error) if error.kind() == io::ErrorKind::NotFound => {}
-                Err(error) => {
-                    return Err(LocalCopyError::io(
-                        "remove extraneous directory",
-                        child_path,
-                        error,
-                    ));
-                }
-            }
-        } else {
-            info_log!(Del, 1, "deleting {}", child_relative.display());
-            match fs::remove_file(&child_path) {
-                Ok(()) => {}
-                Err(error) if error.kind() == io::ErrorKind::NotFound => {}
-                Err(error) => {
-                    return Err(LocalCopyError::io(
-                        "remove extraneous entry",
-                        child_path,
-                        error,
-                    ));
-                }
-            }
-        }
-        context.summary_mut().record_deletion();
-        context.record(LocalCopyRecord::new(
-            child_relative,
-            LocalCopyAction::EntryDeleted,
-            0,
-            None,
-            Duration::default(),
-            None,
-        ));
-        context.register_progress();
-    }
-
     Ok(())
 }
 

--- a/crates/engine/src/local_copy/executor/mod.rs
+++ b/crates/engine/src/local_copy/executor/mod.rs
@@ -8,10 +8,6 @@ mod sources;
 mod special;
 mod util;
 
-#[cfg(not(feature = "legacy-batched-delete"))]
-#[allow(unused_imports)]
-// REASON: kept available for direct tests that bypass the public wrapper
-pub(crate) use cleanup::delete_extraneous_entries_via_emitter;
 pub(crate) use cleanup::{delete_extraneous_entries, remove_source_entry_if_requested};
 pub(crate) use directory::ChecksumCache;
 pub(crate) use directory::{

--- a/docs/design/ddp-f3-sweep-removal-readiness.md
+++ b/docs/design/ddp-f3-sweep-removal-readiness.md
@@ -1,6 +1,17 @@
 # DDP-F3: legacy batched-sweep removal readiness audit (#2272)
 
-Status: audit only - removal does NOT land in this document.
+Status: SHIPPED. The five-step removal plan in section 7 has landed:
+the `legacy-batched-delete` cargo feature is gone from
+`crates/engine/Cargo.toml`; `delete_extraneous_entries_batched`,
+`remove_extraneous_path`, and `delete_directory_tree_recursive` are
+deleted from `crates/engine/src/local_copy/executor/cleanup.rs`; and
+`delete_extraneous_entries` now unconditionally routes through the
+emitter helper. The sections below are preserved as a historical record
+of the gating analysis. The "Recommendation" in section 6 was overridden
+to maximise feature throughput; if DDP-G/H interop surfaces a regression,
+the removal commit is a single `git revert` away.
+
+Original status: audit only - removal does NOT land in this document.
 
 This audit captures the inventory of code that PR #4280 fences behind
 `cfg(feature = "legacy-batched-delete")`, the trigger conditions that

--- a/docs/design/parallel-deterministic-delete.md
+++ b/docs/design/parallel-deterministic-delete.md
@@ -580,6 +580,13 @@ step has its own task tag inside the #2252-#2285 range.
    audit references in `docs/architecture/delete-during.md` and
    `docs/design/delete-during-strict-order-gate.md`.
 
+   - DDP-F3 (#2272): SHIPPED. The `legacy-batched-delete` cargo feature
+     and the pre-DDP-E batched sweep helpers
+     (`delete_extraneous_entries_batched`, `remove_extraneous_path`,
+     `delete_directory_tree_recursive`) are removed from
+     `crates/engine`. The emitter is now the sole production unlink
+     path for every `--delete-*` timing mode.
+
 ## 11. Cross-references
 
 - Supersedes: #1940, `docs/design/delete-during-strict-order-gate.md`.


### PR DESCRIPTION
## Summary

- Retires the legacy batched delete sweep path. The `DeleteEmitter` pipeline has been the live unlink path for every `--delete-*` timing mode since PR #4280, fenced behind the off-by-default `legacy-batched-delete` cargo feature for emergency rollback. This change removes that feature and the dead code it gated, per the five-step plan in `docs/design/ddp-f3-sweep-removal-readiness.md`.
- Net diff: -380 / +53 across 7 files. The bulk of the deletion is in `crates/engine/src/local_copy/executor/cleanup.rs` (three helpers gone: `delete_extraneous_entries_batched`, `remove_extraneous_path`, `delete_directory_tree_recursive`). The public wrapper `delete_extraneous_entries` now unconditionally routes through the emitter; the emitter helper itself is downgraded to a private function (no external callers).
- Refreshes the bench module doc in `delete_end_to_end.rs` and adds a SHIPPED note to `docs/design/parallel-deterministic-delete.md` step 5 and a SHIPPED status header to the readiness audit doc.

## Rollback

Every change is additive (gate deletions + dead-code wipes). If DDP-G/H interop surfaces a regression in the emitter under one of the four rollback classes called out in section 4 of the readiness audit, this commit is a single `git revert` away from restoring the fallback.

## Test plan

- [x] `cargo check -p engine` (default features) - clean.
- [x] `cargo check -p engine --all-features` - clean.
- [x] `cargo check -p engine --features legacy-batched-delete` - errors with "unknown feature" (smoke test that proves removal completed).
- [x] `cargo fmt --all` - clean.
- [ ] CI: fmt+clippy, nextest stable, Windows, macOS, Linux musl all green.
- [ ] CI: `OC_RSYNC_DELETE_INTEROP=1` per-mode interop suite (DDP-E1..E5) passes on the post-merge run.

Closes #2272.