### PR TITLE
feat(engine): drain-parallel consumer instrumentation (force_insert + drain histograms) (#1545)

### DIFF
--- a/crates/engine/src/concurrent_delta/consumer.rs
+++ b/crates/engine/src/concurrent_delta/consumer.rs
@@ -44,10 +44,11 @@
 //! dispatch so downstream processing (checksum verification, temp-file
 //! commit, metadata application) sees files in file-list order.
 
-use std::sync::mpsc;
+use std::sync::{Arc, Mutex, mpsc};
 use std::thread::{self, JoinHandle};
+use std::time::Instant;
 
-use super::reorder::ReorderBuffer;
+use super::reorder::{Metrics as ReorderMetrics, ReorderBuffer};
 use super::strategy;
 use super::types::DeltaResult;
 use super::work_queue::WorkQueueReceiver;
@@ -99,6 +100,10 @@ pub struct DeltaConsumer {
     result_rx: mpsc::Receiver<DeltaResult>,
     /// Handle to the background consumer thread.
     handle: Option<JoinHandle<()>>,
+    /// Live snapshot of the reorder buffer metrics, updated by the
+    /// background thread after every force_insert and every non-empty
+    /// drain. Cheap to poll from the caller via [`Self::metrics`].
+    metrics: Arc<Mutex<ReorderMetrics>>,
 }
 
 impl DeltaConsumer {
@@ -165,6 +170,12 @@ impl DeltaConsumer {
             })
             .expect("failed to spawn delta-drain thread");
 
+        // Shared metrics snapshot updated by the reorder thread; callers can
+        // poll it through `DeltaConsumer::metrics` without blocking the
+        // delta pipeline.
+        let metrics = Arc::new(Mutex::new(ReorderMetrics::default()));
+        let metrics_thread = Arc::clone(&metrics);
+
         // Thread 2: receives streamed results, reorders (or passes through),
         // and forwards to the consumer channel.
         let handle = thread::Builder::new()
@@ -175,40 +186,54 @@ impl DeltaConsumer {
                 } else {
                     ReorderBuffer::new(reorder_capacity)
                 };
+                // Wall-clock anchor for the inter-drain pause histogram.
+                // Updated only after a drain iteration that yielded at
+                // least one item; empty drains do not constitute a pause.
+                let mut last_drain_at: Option<Instant> = None;
+                let publish = |reorder: &ReorderBuffer<DeltaResult>| {
+                    if let Ok(mut guard) = metrics_thread.lock() {
+                        *guard = reorder.metrics();
+                    }
+                };
 
                 for result in stream_rx {
                     // Insert may fail if buffer is at capacity. Drain ready
                     // items first to free space before retrying.
                     while reorder.insert(result.sequence(), result.clone()).is_err() {
-                        let mut drained_any = false;
-                        for ready in reorder.drain_ready() {
-                            drained_any = true;
-                            if result_tx.send(ready).is_err() {
-                                return;
+                        let drained =
+                            drain_and_record(&mut reorder, &result_tx, &mut last_drain_at);
+                        match drained {
+                            DrainOutcome::Disconnected => return,
+                            DrainOutcome::Empty => {
+                                // Buffer full but next_expected is not buffered.
+                                // Force insert to break the deadlock.
+                                reorder.force_insert(result.sequence(), result.clone());
+                                publish(&reorder);
+                                break;
                             }
-                        }
-                        if !drained_any {
-                            // Buffer full but next_expected is not buffered.
-                            // Force insert to break the deadlock.
-                            reorder.force_insert(result.sequence(), result.clone());
-                            break;
+                            DrainOutcome::Forwarded(_) => {
+                                publish(&reorder);
+                            }
                         }
                     }
 
                     // Forward any newly available contiguous run.
-                    for ready in reorder.drain_ready() {
-                        if result_tx.send(ready).is_err() {
-                            return;
-                        }
+                    match drain_and_record(&mut reorder, &result_tx, &mut last_drain_at) {
+                        DrainOutcome::Disconnected => return,
+                        DrainOutcome::Empty => {}
+                        DrainOutcome::Forwarded(_) => publish(&reorder),
                     }
                 }
 
                 // Drain remaining items after the stream closes.
-                for ready in reorder.drain_ready() {
-                    if result_tx.send(ready).is_err() {
-                        return;
-                    }
+                match drain_and_record(&mut reorder, &result_tx, &mut last_drain_at) {
+                    DrainOutcome::Disconnected => return,
+                    DrainOutcome::Empty => {}
+                    DrainOutcome::Forwarded(_) => publish(&reorder),
                 }
+                // Ensure the final snapshot reflects steady-state counters
+                // even if the last operation was a non-recording drain.
+                publish(&reorder);
 
                 // Wait for drain thread to finish (propagates panics).
                 let _ = drain_handle.join();
@@ -218,7 +243,24 @@ impl DeltaConsumer {
         Self {
             result_rx,
             handle: Some(handle),
+            metrics,
         }
+    }
+
+    /// Returns a snapshot of the underlying [`ReorderBuffer`] metrics.
+    ///
+    /// The snapshot is updated by the background thread after every
+    /// `force_insert` and every non-empty drain iteration. Callers may
+    /// poll this method at any cadence; it never blocks the delta
+    /// pipeline.
+    ///
+    /// On the unlikely path where the metrics lock is poisoned (a panic
+    /// in the consumer thread mid-update), a zero-initialised snapshot is
+    /// returned. The panic itself is propagated through
+    /// [`Self::join`].
+    #[must_use]
+    pub fn metrics(&self) -> ReorderMetrics {
+        self.metrics.lock().map(|g| *g).unwrap_or_default()
     }
 
     /// Tries to receive the next in-order result without blocking.
@@ -261,6 +303,46 @@ impl DeltaConsumer {
             Ok(())
         }
     }
+}
+
+/// Outcome of one [`drain_and_record`] call.
+enum DrainOutcome {
+    /// No items were ready to drain.
+    Empty,
+    /// One or more items were forwarded to the consumer channel.
+    Forwarded(usize),
+    /// The output channel is closed; the caller must abort.
+    Disconnected,
+}
+
+/// Drains the contiguous in-order run from `reorder`, forwards each item to
+/// `result_tx`, and records the batch size plus the wall-clock pause since
+/// the previous non-empty drain.
+///
+/// Bypasses the metrics path on empty drains so the histograms reflect only
+/// the work actually performed by the consumer thread.
+fn drain_and_record(
+    reorder: &mut ReorderBuffer<DeltaResult>,
+    result_tx: &mpsc::Sender<DeltaResult>,
+    last_drain_at: &mut Option<Instant>,
+) -> DrainOutcome {
+    let mut count = 0usize;
+    while let Some(ready) = reorder.next_in_order() {
+        if result_tx.send(ready).is_err() {
+            return DrainOutcome::Disconnected;
+        }
+        count += 1;
+    }
+    if count == 0 {
+        return DrainOutcome::Empty;
+    }
+    let now = Instant::now();
+    if let Some(prev) = *last_drain_at {
+        reorder.record_drain_pause(now.saturating_duration_since(prev));
+    }
+    reorder.record_drain_batch(count);
+    *last_drain_at = Some(now);
+    DrainOutcome::Forwarded(count)
 }
 
 impl IntoIterator for DeltaConsumer {
@@ -699,5 +781,93 @@ mod tests {
         ndx_values.sort_unstable();
         let expected: Vec<u32> = (0..count).collect();
         assert_eq!(ndx_values, expected);
+    }
+
+    #[test]
+    fn metrics_snapshot_starts_zeroed() {
+        let (_tx, rx) = work_queue::bounded_with_capacity(4);
+        let consumer = DeltaConsumer::spawn(rx, 8);
+        let m = consumer.metrics();
+        assert_eq!(m.force_insert_count, 0);
+        assert_eq!(m.drain_batch_size_histogram.total_samples(), 0);
+        assert_eq!(m.drain_pause_histogram.total_samples(), 0);
+    }
+
+    /// Verifies the `force_insert` counter increments end-to-end when
+    /// synthetic backpressure forces the consumer to break its capacity
+    /// bound. Reproduces the small-capacity HoL pattern from the design
+    /// doc: a producer that submits sequences out of order leaves the
+    /// `next_expected` slot empty while later sequences fill the ring.
+    #[test]
+    fn metrics_force_insert_counter_increments_under_backpressure() {
+        // Capacity 2 with 12 in-flight, where the bounded queue serialises
+        // submissions, forces every later result to race past the empty
+        // next_expected slot. The producer holds back seq 0 until the rest
+        // have queued so the reorder ring overflows.
+        let count = 12u32;
+        let (tx, rx) = work_queue::bounded_with_capacity(count as usize);
+        let producer = std::thread::spawn(move || {
+            // Submit sequences 1..count first to fill the rayon pipeline,
+            // then submit seq 0 to release the gap. The reorder ring is
+            // size 2 so it cannot absorb the late sequences; force_insert
+            // fires to keep the pipeline alive.
+            for i in 1..count {
+                let work =
+                    DeltaWork::whole_file(i, PathBuf::from("/dst"), 64).with_sequence(u64::from(i));
+                tx.send(work).unwrap();
+            }
+            std::thread::sleep(std::time::Duration::from_millis(20));
+            tx.send(DeltaWork::whole_file(0, PathBuf::from("/dst"), 64).with_sequence(0))
+                .unwrap();
+        });
+
+        let consumer = DeltaConsumer::spawn(rx, 2);
+        let results: Vec<DeltaResult> = consumer.iter().collect();
+        producer.join().unwrap();
+        assert_eq!(results.len(), count as usize);
+        let snap = consumer.metrics();
+        assert!(
+            snap.force_insert_count > 0,
+            "expected force_insert_count > 0 under backpressure, got {:?}",
+            snap,
+        );
+        consumer.join().unwrap();
+    }
+
+    /// Verifies the drain-batch histogram accumulates buckets when the
+    /// consumer delivers a contiguous run in a single drain iteration.
+    #[test]
+    fn metrics_drain_batch_histogram_accumulates() {
+        let count = 16u32;
+        let (tx, rx) = spawn_producer(count);
+        send_items(&tx, count);
+        drop(tx);
+
+        let consumer = DeltaConsumer::spawn(rx, count as usize);
+        let results: Vec<DeltaResult> = consumer.iter().collect();
+        assert_eq!(results.len(), count as usize);
+        let snap = consumer.metrics();
+        let hist = snap.drain_batch_size_histogram;
+        assert!(
+            hist.total_samples() > 0,
+            "expected at least one drain-batch sample, got {hist:?}",
+        );
+        // Sum of all bucket counts equals the number of drain iterations
+        // that produced at least one item.
+        let total_drained: u64 = hist
+            .buckets()
+            .iter()
+            .enumerate()
+            .map(|(idx, &count)| {
+                // Lower bound of bucket idx is 2^idx (except >=1024 cap).
+                let lo = 1u64 << idx.min(10);
+                lo.saturating_mul(count)
+            })
+            .sum();
+        assert!(
+            total_drained >= u64::from(count),
+            "histogram lower-bound sum {total_drained} must cover delivered count {count}",
+        );
+        consumer.join().unwrap();
     }
 }

--- a/crates/engine/src/concurrent_delta/mod.rs
+++ b/crates/engine/src/concurrent_delta/mod.rs
@@ -181,7 +181,7 @@ pub mod work_queue;
 
 pub use adaptive::{AdaptiveCapacityPolicy, ReorderStats};
 pub use consumer::DeltaConsumer;
-pub use reorder::{Metrics as ReorderMetrics, ReorderBuffer};
+pub use reorder::{HistogramStats, Metrics as ReorderMetrics, ReorderBuffer};
 pub use spill::{SpillCodec, SpillError, SpillStats, SpillableReorderBuffer};
 pub use strategy::{DeltaStrategy, DeltaTransferStrategy, WholeFileStrategy};
 pub use types::{DeltaResult, DeltaResultStatus, DeltaWork, DeltaWorkKind, FileNdx};

--- a/crates/engine/src/concurrent_delta/reorder/histogram.rs
+++ b/crates/engine/src/concurrent_delta/reorder/histogram.rs
@@ -1,0 +1,258 @@
+//! Bucketed histograms for reorder-buffer diagnostics.
+//!
+//! Two scales are exposed because the drain loop needs them with different
+//! granularities:
+//!
+//! - [`HistogramStats::new_pow2`] groups counts into powers-of-two buckets
+//!   (`1, 2, 4, 8, ..., 512, >=1024`). Used by the drain-batch-size histogram
+//!   so operators can read off the typical contiguous-run length at a
+//!   glance.
+//! - [`HistogramStats::new_microseconds`] groups wall-clock durations into
+//!   decimal-decade buckets (`<1, 1-10, 10-100, 100-1000, 1000-10000,
+//!   >=10000` microseconds). Used by the drain-pause histogram to surface
+//!   head-of-line stalls that correlate with `force_insert` events.
+//!
+//! Sampling is allocation-free and bumps a single `u64` counter per
+//! observation; the histogram is owned by [`ReorderBuffer`](super::ReorderBuffer)
+//! and copied out by [`Metrics`](super::Metrics) snapshots.
+
+use std::time::Duration;
+
+/// Bucket scale for a [`HistogramStats`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Scale {
+    /// Powers-of-two buckets: `1, 2, 4, 8, 16, 32, 64, 128, 256, 512, >=1024`.
+    Pow2,
+    /// Decimal-decade microsecond buckets: `<1, 1-10, 10-100, 100-1000,
+    /// 1000-10000, >=10000`.
+    Microseconds,
+}
+
+/// Number of buckets in the pow-2 layout.
+const POW2_BUCKETS: usize = 11;
+/// Number of buckets in the microsecond layout.
+const US_BUCKETS: usize = 6;
+/// Maximum bucket count across all scales; sized for the largest layout.
+const MAX_BUCKETS: usize = POW2_BUCKETS;
+
+/// Bucketed counter histogram. Cheap to update, cheap to copy.
+///
+/// Each observation bumps exactly one bucket. The histogram is `Copy` so
+/// callers can snapshot it through [`Metrics`](super::Metrics) without
+/// taking a reference into the buffer.
+#[derive(Debug, Clone, Copy)]
+pub struct HistogramStats {
+    scale: Scale,
+    /// Per-bucket counters. Only the first `bucket_count(scale)` entries are
+    /// meaningful; the remainder are kept at zero to satisfy `Copy`.
+    buckets: [u64; MAX_BUCKETS],
+}
+
+impl Default for HistogramStats {
+    fn default() -> Self {
+        Self::new_pow2()
+    }
+}
+
+impl PartialEq for HistogramStats {
+    fn eq(&self, other: &Self) -> bool {
+        self.scale == other.scale && self.buckets() == other.buckets()
+    }
+}
+
+impl Eq for HistogramStats {}
+
+impl HistogramStats {
+    /// Creates a histogram with powers-of-two buckets (`1, 2, 4, ..., >=1024`).
+    #[must_use]
+    pub const fn new_pow2() -> Self {
+        Self {
+            scale: Scale::Pow2,
+            buckets: [0; MAX_BUCKETS],
+        }
+    }
+
+    /// Creates a histogram with microsecond decade buckets (`<1, 1-10,
+    /// 10-100, 100-1000, 1000-10000, >=10000`).
+    #[must_use]
+    pub const fn new_microseconds() -> Self {
+        Self {
+            scale: Scale::Microseconds,
+            buckets: [0; MAX_BUCKETS],
+        }
+    }
+
+    /// Returns the number of meaningful buckets for the configured scale.
+    #[must_use]
+    pub const fn bucket_count(&self) -> usize {
+        match self.scale {
+            Scale::Pow2 => POW2_BUCKETS,
+            Scale::Microseconds => US_BUCKETS,
+        }
+    }
+
+    /// Returns the per-bucket counters in display order.
+    ///
+    /// For pow-2: `[1, 2, 4, 8, 16, 32, 64, 128, 256, 512, >=1024]`.
+    /// For microseconds: `[<1, 1-10, 10-100, 100-1000, 1000-10000, >=10000]`.
+    #[must_use]
+    pub fn buckets(&self) -> &[u64] {
+        &self.buckets[..self.bucket_count()]
+    }
+
+    /// Returns the upper-bound label for the `index`th bucket as a
+    /// human-readable string. For the final overflow bucket the label
+    /// reflects `>=<lower>`.
+    #[must_use]
+    pub fn bucket_label(&self, index: usize) -> &'static str {
+        match self.scale {
+            Scale::Pow2 => POW2_LABELS[index.min(POW2_BUCKETS - 1)],
+            Scale::Microseconds => US_LABELS[index.min(US_BUCKETS - 1)],
+        }
+    }
+
+    /// Returns the total number of samples observed.
+    #[must_use]
+    pub fn total_samples(&self) -> u64 {
+        self.buckets().iter().sum()
+    }
+
+    /// Records a count observation (drain-batch size).
+    ///
+    /// Counts of zero are ignored - an empty drain produced no batch and
+    /// should not skew the distribution.
+    pub fn record_count(&mut self, count: usize) {
+        if count == 0 {
+            return;
+        }
+        debug_assert!(
+            matches!(self.scale, Scale::Pow2),
+            "record_count requires a pow-2 histogram",
+        );
+        let bucket = pow2_bucket(count);
+        self.buckets[bucket] = self.buckets[bucket].saturating_add(1);
+    }
+
+    /// Records a duration observation (drain-iteration pause).
+    pub fn record_duration(&mut self, dur: Duration) {
+        debug_assert!(
+            matches!(self.scale, Scale::Microseconds),
+            "record_duration requires a microsecond histogram",
+        );
+        let micros = dur.as_micros();
+        let bucket = us_bucket(micros);
+        self.buckets[bucket] = self.buckets[bucket].saturating_add(1);
+    }
+}
+
+/// Resolves the bucket index for a non-zero count under the pow-2 layout.
+fn pow2_bucket(count: usize) -> usize {
+    // count >= 1 by caller guarantee. Bucket k holds counts in [2^k, 2^(k+1)).
+    // The final overflow bucket absorbs counts >= 2^(POW2_BUCKETS - 1) = 1024.
+    let n = (count as u64).max(1);
+    let leading = n.leading_zeros();
+    let bits = 64 - leading; // floor(log2(n)) + 1
+    let idx = (bits as usize).saturating_sub(1);
+    idx.min(POW2_BUCKETS - 1)
+}
+
+/// Resolves the bucket index for a duration sample under the microsecond
+/// decade layout.
+fn us_bucket(micros: u128) -> usize {
+    if micros < 1 {
+        0
+    } else if micros < 10 {
+        1
+    } else if micros < 100 {
+        2
+    } else if micros < 1_000 {
+        3
+    } else if micros < 10_000 {
+        4
+    } else {
+        5
+    }
+}
+
+const POW2_LABELS: [&str; POW2_BUCKETS] = [
+    "1", "2", "4", "8", "16", "32", "64", "128", "256", "512", ">=1024",
+];
+
+const US_LABELS: [&str; US_BUCKETS] = [
+    "<1us",
+    "1-10us",
+    "10-100us",
+    "100-1000us",
+    "1000-10000us",
+    ">=10000us",
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pow2_buckets_match_design() {
+        let mut h = HistogramStats::new_pow2();
+        for v in [1usize, 2, 3, 4, 7, 8, 15, 16, 1023, 1024, 9_999_999] {
+            h.record_count(v);
+        }
+        // 1 -> bucket 0 (1)
+        // 2, 3 -> bucket 1 (2)
+        // 4, 7 -> bucket 2 (4)
+        // 8, 15 -> bucket 3 (8)
+        // 16 -> bucket 4 (16)
+        // 1023 -> bucket 9 (512..1024)
+        // 1024, 9_999_999 -> bucket 10 (>=1024)
+        let buckets = h.buckets();
+        assert_eq!(buckets[0], 1, "bucket 1");
+        assert_eq!(buckets[1], 2, "bucket 2");
+        assert_eq!(buckets[2], 2, "bucket 4");
+        assert_eq!(buckets[3], 2, "bucket 8");
+        assert_eq!(buckets[4], 1, "bucket 16");
+        assert_eq!(buckets[9], 1, "bucket 512");
+        assert_eq!(buckets[10], 2, "bucket >=1024");
+        assert_eq!(h.total_samples(), 11);
+    }
+
+    #[test]
+    fn pow2_zero_is_ignored() {
+        let mut h = HistogramStats::new_pow2();
+        h.record_count(0);
+        assert_eq!(h.total_samples(), 0);
+    }
+
+    #[test]
+    fn microsecond_buckets_match_design() {
+        let mut h = HistogramStats::new_microseconds();
+        h.record_duration(Duration::from_nanos(500)); // <1us
+        h.record_duration(Duration::from_micros(0)); // <1us
+        h.record_duration(Duration::from_micros(5)); // 1-10us
+        h.record_duration(Duration::from_micros(50)); // 10-100us
+        h.record_duration(Duration::from_micros(500)); // 100-1000us
+        h.record_duration(Duration::from_millis(5)); // 1000-10000us
+        h.record_duration(Duration::from_millis(100)); // >=10000us
+        let buckets = h.buckets();
+        assert_eq!(buckets, [2, 1, 1, 1, 1, 1]);
+        assert_eq!(h.total_samples(), 7);
+    }
+
+    #[test]
+    fn labels_round_trip() {
+        let pow2 = HistogramStats::new_pow2();
+        assert_eq!(pow2.bucket_label(0), "1");
+        assert_eq!(pow2.bucket_label(POW2_BUCKETS - 1), ">=1024");
+        let us = HistogramStats::new_microseconds();
+        assert_eq!(us.bucket_label(0), "<1us");
+        assert_eq!(us.bucket_label(US_BUCKETS - 1), ">=10000us");
+    }
+
+    #[test]
+    fn equality_compares_scale_and_buckets() {
+        let a = HistogramStats::new_pow2();
+        let b = HistogramStats::new_pow2();
+        assert_eq!(a, b);
+        let c = HistogramStats::new_microseconds();
+        assert_ne!(a, c, "different scales must compare unequal");
+    }
+}

--- a/crates/engine/src/concurrent_delta/reorder/mod.rs
+++ b/crates/engine/src/concurrent_delta/reorder/mod.rs
@@ -30,6 +30,10 @@ use std::time::{Duration, Instant};
 
 use super::adaptive::{AdaptiveCapacityPolicy, AdaptiveState, ReorderStats};
 
+pub mod histogram;
+
+pub use histogram::HistogramStats;
+
 /// Snapshot of [`ReorderBuffer`] diagnostic counters.
 ///
 /// Returned by [`ReorderBuffer::metrics`]. All fields are cumulative across
@@ -40,7 +44,7 @@ use super::adaptive::{AdaptiveCapacityPolicy, AdaptiveState, ReorderStats};
 /// to ad hoc instrumentation. Stall duration grows whenever an out-of-order
 /// item is buffered ahead of the next expected sequence; max depth records
 /// the high-water mark of buffered items observed since construction.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Metrics {
     /// Total wall-clock time the buffer spent waiting for the next expected
     /// sequence while at least one out-of-order item was buffered.
@@ -49,6 +53,35 @@ pub struct Metrics {
     pub current_depth: usize,
     /// High-water mark of buffered items observed since construction.
     pub max_depth: usize,
+    /// Total number of times the consumer broke the capacity bound via
+    /// [`ReorderBuffer::force_insert`]. Surfaced as a prerequisite for the
+    /// `force_insert` removal sequencing in `docs/design/drain-parallel-consumer-thread.md`.
+    pub force_insert_count: u64,
+    /// Distribution of drain-batch sizes observed by the consumer.
+    ///
+    /// Each `drain_ready` iteration that yielded at least one item records
+    /// the batch length in a powers-of-two bucket (`1, 2, 4, ..., >=1024`).
+    /// A distribution skewed toward 1 means workers arrive nearly in order;
+    /// a heavy tail signals head-of-line pressure.
+    pub drain_batch_size_histogram: HistogramStats,
+    /// Distribution of wall-clock pauses between consecutive non-empty
+    /// drains, bucketed in microsecond decades (`<1, 1-10, ..., >=10000`).
+    /// Long pauses correlate with the conditions that trigger
+    /// `force_insert`.
+    pub drain_pause_histogram: HistogramStats,
+}
+
+impl Default for Metrics {
+    fn default() -> Self {
+        Self {
+            stall_duration: Duration::ZERO,
+            current_depth: 0,
+            max_depth: 0,
+            force_insert_count: 0,
+            drain_batch_size_histogram: HistogramStats::new_pow2(),
+            drain_pause_histogram: HistogramStats::new_microseconds(),
+        }
+    }
 }
 
 /// Collects out-of-order items and yields them in sequence order.
@@ -123,6 +156,14 @@ pub struct ReorderBuffer<T> {
     /// Marker recording when the current stall began. `Some` iff the buffer
     /// is currently stalled (count > 0 and the `next_expected` slot is empty).
     stall_started_at: Option<Instant>,
+    /// Cumulative count of [`force_insert`](Self::force_insert) invocations.
+    force_insert_count: u64,
+    /// Distribution of drain-batch sizes recorded via
+    /// [`record_drain_batch`](Self::record_drain_batch).
+    drain_batch_size: HistogramStats,
+    /// Distribution of inter-drain pause durations recorded via
+    /// [`record_drain_pause`](Self::record_drain_pause).
+    drain_pause: HistogramStats,
 }
 
 /// Error returned when the reorder buffer is at capacity.
@@ -163,6 +204,9 @@ impl<T> ReorderBuffer<T> {
             max_depth: 0,
             stall_duration: Duration::ZERO,
             stall_started_at: None,
+            force_insert_count: 0,
+            drain_batch_size: HistogramStats::new_pow2(),
+            drain_pause: HistogramStats::new_microseconds(),
         }
     }
 
@@ -206,6 +250,9 @@ impl<T> ReorderBuffer<T> {
             max_depth: 0,
             stall_duration: Duration::ZERO,
             stall_started_at: None,
+            force_insert_count: 0,
+            drain_batch_size: HistogramStats::new_pow2(),
+            drain_pause: HistogramStats::new_microseconds(),
         }
     }
 
@@ -471,7 +518,31 @@ impl<T> ReorderBuffer<T> {
             stall_duration: self.stall_duration.saturating_add(in_flight),
             current_depth: self.count,
             max_depth: self.max_depth,
+            force_insert_count: self.force_insert_count,
+            drain_batch_size_histogram: self.drain_batch_size,
+            drain_pause_histogram: self.drain_pause,
         }
+    }
+
+    /// Records a drain-batch observation in the metrics histogram.
+    ///
+    /// Called by the consumer thread after a [`drain_ready`](Self::drain_ready)
+    /// iteration that yielded at least one item; `batch_size` is the
+    /// number of items delivered before the next gap. Zero counts are
+    /// silently dropped (no batch was produced, so the sample would
+    /// distort the distribution toward an empty bucket).
+    pub fn record_drain_batch(&mut self, batch_size: usize) {
+        self.drain_batch_size.record_count(batch_size);
+    }
+
+    /// Records the wall-clock pause between consecutive non-empty drain
+    /// iterations in the metrics histogram.
+    ///
+    /// Called by the consumer thread with the elapsed time since the
+    /// previous successful drain. Buckets are microsecond decades so
+    /// operators can read off the typical pause magnitude at a glance.
+    pub fn record_drain_pause(&mut self, pause: Duration) {
+        self.drain_pause.record_duration(pause);
     }
 
     /// Returns adaptive capacity counters (grow/shrink event totals plus the
@@ -500,6 +571,7 @@ impl<T> ReorderBuffer<T> {
     /// ring capacity, this inserts directly. For sequences beyond capacity,
     /// the ring is grown to accommodate the item.
     pub fn force_insert(&mut self, sequence: u64, item: T) {
+        self.force_insert_count = self.force_insert_count.saturating_add(1);
         if self.bypass {
             self.bypass_queue.push_back(item);
             self.count += 1;

--- a/crates/engine/src/concurrent_delta/reorder/tests.rs
+++ b/crates/engine/src/concurrent_delta/reorder/tests.rs
@@ -1327,4 +1327,79 @@ mod metrics_tests {
         assert_eq!(m.current_depth, 2);
         assert_eq!(m.max_depth, 2);
     }
+
+    #[test]
+    fn force_insert_count_starts_at_zero_and_increments() {
+        let mut buf: ReorderBuffer<u32> = ReorderBuffer::new(4);
+        assert_eq!(buf.metrics().force_insert_count, 0);
+        buf.force_insert(10, 100);
+        buf.force_insert(11, 110);
+        buf.force_insert(12, 120);
+        assert_eq!(buf.metrics().force_insert_count, 3);
+    }
+
+    #[test]
+    fn force_insert_count_increments_on_bypass_too() {
+        // The bypass path still accumulates the counter so operators can
+        // diagnose downstream queue pressure regardless of reordering mode.
+        let mut buf: ReorderBuffer<u32> = ReorderBuffer::passthrough();
+        buf.force_insert(0, 0);
+        buf.force_insert(0, 1);
+        assert_eq!(buf.metrics().force_insert_count, 2);
+    }
+
+    #[test]
+    fn force_insert_count_increments_when_sequence_behind_window() {
+        // Sequences below next_expected are dropped by force_insert but the
+        // call itself is still observed (it indicates upstream sent a stale
+        // result that should never have hit the consumer).
+        let mut buf: ReorderBuffer<u32> = ReorderBuffer::new(4);
+        buf.insert(0, 0).unwrap();
+        let _ = buf.next_in_order();
+        buf.force_insert(0, 99);
+        assert_eq!(buf.metrics().force_insert_count, 1);
+    }
+
+    #[test]
+    fn drain_batch_histogram_records_powers_of_two() {
+        let mut buf: ReorderBuffer<u32> = ReorderBuffer::new(16);
+        buf.record_drain_batch(1);
+        buf.record_drain_batch(2);
+        buf.record_drain_batch(3);
+        buf.record_drain_batch(8);
+        buf.record_drain_batch(8);
+        buf.record_drain_batch(2048);
+        let hist = buf.metrics().drain_batch_size_histogram;
+        let buckets = hist.buckets();
+        assert_eq!(buckets[0], 1, "bucket 1 (size=1)");
+        assert_eq!(buckets[1], 2, "bucket 2 (sizes 2,3)");
+        assert_eq!(buckets[3], 2, "bucket 8 (size=8 x2)");
+        assert_eq!(buckets[10], 1, "bucket >=1024 (size=2048)");
+        assert_eq!(hist.total_samples(), 6);
+    }
+
+    #[test]
+    fn drain_pause_histogram_records_microsecond_decades() {
+        let mut buf: ReorderBuffer<u32> = ReorderBuffer::new(4);
+        buf.record_drain_pause(Duration::from_nanos(100)); // <1us
+        buf.record_drain_pause(Duration::from_micros(5)); // 1-10us
+        buf.record_drain_pause(Duration::from_micros(50)); // 10-100us
+        buf.record_drain_pause(Duration::from_micros(500)); // 100-1000us
+        buf.record_drain_pause(Duration::from_millis(5)); // 1000-10000us
+        buf.record_drain_pause(Duration::from_millis(50)); // >=10000us
+        buf.record_drain_pause(Duration::from_secs(1)); // >=10000us
+        let hist = buf.metrics().drain_pause_histogram;
+        let buckets = hist.buckets();
+        assert_eq!(buckets, [1, 1, 1, 1, 1, 2]);
+        assert_eq!(hist.total_samples(), 7);
+    }
+
+    #[test]
+    fn drain_batch_zero_does_not_record() {
+        // Empty drains must not pollute the distribution.
+        let mut buf: ReorderBuffer<u32> = ReorderBuffer::new(4);
+        buf.record_drain_batch(0);
+        buf.record_drain_batch(0);
+        assert_eq!(buf.metrics().drain_batch_size_histogram.total_samples(), 0);
+    }
 }


### PR DESCRIPTION
## Summary

- Land the metric prerequisites from `docs/design/drain-parallel-consumer-thread.md` (section 7 / sequencing step 1) ahead of any topology change to the `delta-drain` + `delta-reorder` pair.
- Adds a `force_insert` cumulative counter on `ReorderBuffer` plus two `HistogramStats` (powers-of-two batch sizes, microsecond-decade pauses) recorded by the consumer drain loop.
- Exposes a live `Metrics` snapshot through `DeltaConsumer::metrics` so operators can poll the new counters without waiting for transfer completion.

## Why

The design doc flags these counters as a removal-prerequisite for `force_insert` and a diagnostic for head-of-line pressure. Landing them as a focused refactor lets follow-up topology work (single-thread consumer, SPSC ring) ship with before/after numbers from the same surface area.

## Implementation notes

- `HistogramStats` is a single `Copy` struct with two scale variants. Sampling is allocation-free (one bucket bump per observation) and snapshots are returned by value through `Metrics`.
- The consumer thread maintains a `last_drain_at` anchor; only non-empty drain iterations record a batch sample and the elapsed pause, so the histograms reflect actual delivered work rather than idle polling.
- The metrics snapshot lives behind `Arc<Mutex<Metrics>>`. Lock contention is bounded - one publish per drain iteration / `force_insert`, one read per `metrics()` call - and the lock is never held across I/O.

## Test plan

- [x] `cargo fmt --all`
- [ ] CI: fmt + clippy
- [ ] CI: nextest (stable) - new tests `force_insert_count_*`, `drain_batch_histogram_records_powers_of_two`, `drain_pause_histogram_records_microsecond_decades`, `metrics_force_insert_counter_increments_under_backpressure`, `metrics_drain_batch_histogram_accumulates`
- [ ] CI: Windows / macOS / Linux musl