### PR TITLE
feat(engine): wire SpillableReorderBuffer with bounded-memory threshold (#1884)

### DIFF
--- a/crates/engine/src/concurrent_delta/config.rs
+++ b/crates/engine/src/concurrent_delta/config.rs
@@ -1,0 +1,114 @@
+//! Runtime configuration for the concurrent delta pipeline.
+//!
+//! [`ConcurrentDeltaConfig`] aggregates the knobs that tune the
+//! [`DeltaConsumer`](super::consumer::DeltaConsumer) without changing its
+//! public type signature. The only knob today is
+//! [`spill_threshold_bytes`](ConcurrentDeltaConfig::spill_threshold_bytes),
+//! which opts the consumer into bounded-memory spill-to-tempfile via
+//! [`SpillableReorderBuffer`](super::spill::SpillableReorderBuffer).
+//!
+//! # Defaults
+//!
+//! [`ConcurrentDeltaConfig::default`] returns a configuration that mirrors
+//! the historical behaviour: bare [`ReorderBuffer`](super::reorder::ReorderBuffer)
+//! with no spill layer. Set `spill_threshold_bytes` to opt in.
+
+use std::path::PathBuf;
+
+/// Tunable runtime knobs for the concurrent delta pipeline.
+///
+/// Pass an instance to [`DeltaConsumer::spawn_with_config`](super::consumer::DeltaConsumer::spawn_with_config)
+/// to override the historical fixed-capacity reorder behaviour. The default
+/// value preserves backwards compatibility - no spill, no extra plumbing.
+#[derive(Debug, Clone, Default)]
+pub struct ConcurrentDeltaConfig {
+    /// Optional memory budget for the reorder buffer in bytes.
+    ///
+    /// `None` (the default) keeps the consumer on the bare
+    /// [`ReorderBuffer`](super::reorder::ReorderBuffer) path - inserts that
+    /// overflow the ring fall back to capacity doubling. `Some(threshold)`
+    /// switches the consumer to
+    /// [`SpillableReorderBuffer`](super::spill::SpillableReorderBuffer): when
+    /// the estimated in-memory footprint exceeds `threshold`, the oldest
+    /// (highest-sequence) buffered items are written to a tempfile so the
+    /// in-memory ring stays bounded.
+    pub spill_threshold_bytes: Option<u64>,
+    /// Optional explicit on-disk scratch directory for spilled items.
+    ///
+    /// Only consulted when `spill_threshold_bytes` is `Some`. `None` uses the
+    /// default `SpooledTempFile` backend, which keeps spills in memory up to
+    /// 1 MB before rolling over to a system tempfile.
+    pub spill_dir: Option<PathBuf>,
+}
+
+impl ConcurrentDeltaConfig {
+    /// Returns a configuration that disables the spill layer.
+    ///
+    /// Equivalent to [`ConcurrentDeltaConfig::default`].
+    #[must_use]
+    pub fn off() -> Self {
+        Self::default()
+    }
+
+    /// Returns a configuration that enables the spill layer with the given
+    /// byte threshold.
+    #[must_use]
+    pub fn with_spill_threshold(threshold_bytes: u64) -> Self {
+        Self {
+            spill_threshold_bytes: Some(threshold_bytes),
+            spill_dir: None,
+        }
+    }
+
+    /// Sets an explicit on-disk scratch directory for spilled items.
+    #[must_use]
+    pub fn with_spill_dir(mut self, dir: PathBuf) -> Self {
+        self.spill_dir = Some(dir);
+        self
+    }
+
+    /// Returns `true` when the spill layer is configured to engage.
+    #[must_use]
+    pub const fn spill_enabled(&self) -> bool {
+        self.spill_threshold_bytes.is_some()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_disables_spill() {
+        let cfg = ConcurrentDeltaConfig::default();
+        assert!(!cfg.spill_enabled());
+        assert!(cfg.spill_threshold_bytes.is_none());
+        assert!(cfg.spill_dir.is_none());
+    }
+
+    #[test]
+    fn off_matches_default() {
+        let a = ConcurrentDeltaConfig::off();
+        let b = ConcurrentDeltaConfig::default();
+        assert_eq!(a.spill_threshold_bytes, b.spill_threshold_bytes);
+        assert_eq!(a.spill_dir, b.spill_dir);
+    }
+
+    #[test]
+    fn with_spill_threshold_enables_spill() {
+        let cfg = ConcurrentDeltaConfig::with_spill_threshold(16 * 1024);
+        assert!(cfg.spill_enabled());
+        assert_eq!(cfg.spill_threshold_bytes, Some(16 * 1024));
+        assert!(cfg.spill_dir.is_none());
+    }
+
+    #[test]
+    fn with_spill_dir_records_directory() {
+        let cfg = ConcurrentDeltaConfig::with_spill_threshold(64 * 1024)
+            .with_spill_dir(PathBuf::from("/tmp/spill"));
+        assert_eq!(
+            cfg.spill_dir.as_deref(),
+            Some(std::path::Path::new("/tmp/spill"))
+        );
+    }
+}

--- a/crates/engine/src/concurrent_delta/consumer.rs
+++ b/crates/engine/src/concurrent_delta/consumer.rs
@@ -44,13 +44,50 @@
 //! dispatch so downstream processing (checksum verification, temp-file
 //! commit, metadata application) sees files in file-list order.
 
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::mpsc;
 use std::thread::{self, JoinHandle};
 
+use super::config::ConcurrentDeltaConfig;
 use super::reorder::ReorderBuffer;
+use super::spill::{SpillError, SpillableReorderBuffer};
 use super::strategy;
 use super::types::DeltaResult;
 use super::work_queue::WorkQueueReceiver;
+
+/// Selects the reorder backend driven by [`DeltaConsumer::spawn_inner`].
+///
+/// Encoded as an enum rather than two booleans so future modes (e.g.
+/// hybrid memory + spill with adaptive sizing) can extend the variant set
+/// without churning the call sites.
+enum ReorderMode {
+    /// Bypass mode: passthrough FIFO, no sequence reordering.
+    Bypass,
+    /// Bare in-memory ring with the historical doubling fallback on overflow.
+    Bare { capacity: usize },
+    /// Bounded-memory ring with spill-to-tempfile when the byte threshold is
+    /// exceeded. `dir` is `None` for the default `SpooledTempFile` backend.
+    Spillable {
+        capacity: usize,
+        threshold: usize,
+        dir: Option<PathBuf>,
+    },
+}
+
+/// Snapshot of consumer-side counters surfaced for diagnostics.
+///
+/// Mirrors [`SpillStats`](super::spill::SpillStats) for operators that only
+/// hold a [`DeltaConsumer`] handle. All counters are cumulative across the
+/// consumer's lifetime; values are zero when the spill layer is not engaged.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct DeltaConsumerStats {
+    /// Cumulative count of items written to the spill tempfile.
+    ///
+    /// Always zero when the consumer was spawned without a spill threshold.
+    pub spill_events: u64,
+}
 
 /// Ordered consumer that drains a [`WorkQueueReceiver`] in parallel and
 /// yields [`DeltaResult`] items in sequence order.
@@ -99,6 +136,9 @@ pub struct DeltaConsumer {
     result_rx: mpsc::Receiver<DeltaResult>,
     /// Handle to the background consumer thread.
     handle: Option<JoinHandle<()>>,
+    /// Shared counter incremented by the reorder thread on each spill-to-disk
+    /// event. Exposed via [`DeltaConsumer::stats`].
+    spill_events: Arc<AtomicU64>,
 }
 
 impl DeltaConsumer {
@@ -127,7 +167,12 @@ impl DeltaConsumer {
     /// Panics if `reorder_capacity` is zero and `bypass_reorder` is `false`.
     #[must_use]
     pub fn spawn(rx: WorkQueueReceiver, reorder_capacity: usize) -> Self {
-        Self::spawn_inner(rx, reorder_capacity, false)
+        Self::spawn_inner(
+            rx,
+            ReorderMode::Bare {
+                capacity: reorder_capacity,
+            },
+        )
     }
 
     /// Spawns background threads that drain the work queue in parallel
@@ -141,19 +186,56 @@ impl DeltaConsumer {
     /// off and files are committed immediately.
     #[must_use]
     pub fn spawn_bypass(rx: WorkQueueReceiver) -> Self {
-        Self::spawn_inner(rx, 0, true)
+        Self::spawn_inner(rx, ReorderMode::Bypass)
     }
 
-    /// Internal spawn implementation shared by ordered and bypass paths.
-    fn spawn_inner(rx: WorkQueueReceiver, reorder_capacity: usize, bypass: bool) -> Self {
+    /// Spawns background threads honouring a runtime
+    /// [`ConcurrentDeltaConfig`].
+    ///
+    /// When `cfg.spill_threshold_bytes` is `Some`, the reorder thread is
+    /// backed by a [`SpillableReorderBuffer`] instead of the bare ring
+    /// buffer. Items past the in-memory byte threshold spill to a tempfile;
+    /// they are reloaded transparently as the delivery cursor reaches them.
+    /// When the threshold is `None`, behaviour matches [`spawn`].
+    ///
+    /// `reorder_capacity` is the in-memory ring window. A good default is
+    /// the total number of expected items, or at least
+    /// `2 * rayon::current_num_threads()`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `reorder_capacity` is zero.
+    #[must_use]
+    pub fn spawn_with_config(
+        rx: WorkQueueReceiver,
+        reorder_capacity: usize,
+        cfg: ConcurrentDeltaConfig,
+    ) -> Self {
+        let mode = match cfg.spill_threshold_bytes {
+            Some(threshold) => ReorderMode::Spillable {
+                capacity: reorder_capacity,
+                threshold: usize::try_from(threshold).unwrap_or(usize::MAX),
+                dir: cfg.spill_dir,
+            },
+            None => ReorderMode::Bare {
+                capacity: reorder_capacity,
+            },
+        };
+        Self::spawn_inner(rx, mode)
+    }
+
+    /// Internal spawn implementation shared by all factory paths.
+    fn spawn_inner(rx: WorkQueueReceiver, mode: ReorderMode) -> Self {
         let (result_tx, result_rx) = mpsc::channel();
+        let spill_events = Arc::new(AtomicU64::new(0));
 
         // Bounded channel between drain and reorder threads. Capacity matches
         // reorder buffer so workers can stay ahead without unbounded buffering.
-        let stream_capacity = if bypass {
-            rayon::current_num_threads() * 2
-        } else {
-            reorder_capacity.max(rayon::current_num_threads() * 2)
+        let stream_capacity = match &mode {
+            ReorderMode::Bypass => rayon::current_num_threads() * 2,
+            ReorderMode::Bare { capacity } | ReorderMode::Spillable { capacity, .. } => {
+                (*capacity).max(rayon::current_num_threads() * 2)
+            }
         };
         let (stream_tx, stream_rx) = crossbeam_channel::bounded::<DeltaResult>(stream_capacity);
 
@@ -167,46 +249,36 @@ impl DeltaConsumer {
 
         // Thread 2: receives streamed results, reorders (or passes through),
         // and forwards to the consumer channel.
+        let spill_events_thread = Arc::clone(&spill_events);
         let handle = thread::Builder::new()
             .name("delta-reorder".to_string())
             .spawn(move || {
-                let mut reorder = if bypass {
-                    ReorderBuffer::passthrough()
-                } else {
-                    ReorderBuffer::new(reorder_capacity)
-                };
-
-                for result in stream_rx {
-                    // Insert may fail if buffer is at capacity. Drain ready
-                    // items first to free space before retrying.
-                    while reorder.insert(result.sequence(), result.clone()).is_err() {
-                        let mut drained_any = false;
-                        for ready in reorder.drain_ready() {
-                            drained_any = true;
-                            if result_tx.send(ready).is_err() {
+                match mode {
+                    ReorderMode::Bypass => {
+                        run_bare_loop(stream_rx, &result_tx, ReorderBuffer::passthrough());
+                    }
+                    ReorderMode::Bare { capacity } => {
+                        run_bare_loop(stream_rx, &result_tx, ReorderBuffer::new(capacity));
+                    }
+                    ReorderMode::Spillable {
+                        capacity,
+                        threshold,
+                        dir,
+                    } => {
+                        let buf = match build_spillable(capacity, threshold, dir) {
+                            Ok(buf) => buf,
+                            Err(e) => {
+                                // Construction failed (e.g., spill dir cannot be
+                                // created). Surface as a single failed result so
+                                // the receiver maps to exit code 11 and aborts.
+                                let _ = result_tx.send(DeltaResult::failed(
+                                    0u32,
+                                    format!("spill backend unavailable: {e}"),
+                                ));
                                 return;
                             }
-                        }
-                        if !drained_any {
-                            // Buffer full but next_expected is not buffered.
-                            // Force insert to break the deadlock.
-                            reorder.force_insert(result.sequence(), result.clone());
-                            break;
-                        }
-                    }
-
-                    // Forward any newly available contiguous run.
-                    for ready in reorder.drain_ready() {
-                        if result_tx.send(ready).is_err() {
-                            return;
-                        }
-                    }
-                }
-
-                // Drain remaining items after the stream closes.
-                for ready in reorder.drain_ready() {
-                    if result_tx.send(ready).is_err() {
-                        return;
+                        };
+                        run_spillable_loop(stream_rx, &result_tx, buf, &spill_events_thread);
                     }
                 }
 
@@ -218,6 +290,19 @@ impl DeltaConsumer {
         Self {
             result_rx,
             handle: Some(handle),
+            spill_events,
+        }
+    }
+
+    /// Returns a snapshot of consumer-side diagnostic counters.
+    ///
+    /// Currently exposes the cumulative spill-to-disk event count from the
+    /// background reorder thread. Safe to call from any thread while the
+    /// consumer is running; the counters are updated lock-free.
+    #[must_use]
+    pub fn stats(&self) -> DeltaConsumerStats {
+        DeltaConsumerStats {
+            spill_events: self.spill_events.load(Ordering::Relaxed),
         }
     }
 
@@ -272,6 +357,170 @@ impl IntoIterator for DeltaConsumer {
             rx: self.result_rx,
             _handle: self.handle,
         }
+    }
+}
+
+/// Constructs a [`SpillableReorderBuffer`] backed by the configured backend.
+fn build_spillable(
+    capacity: usize,
+    threshold: usize,
+    dir: Option<PathBuf>,
+) -> std::io::Result<SpillableReorderBuffer<DeltaResult>> {
+    match dir {
+        Some(d) => SpillableReorderBuffer::with_spill_dir(capacity, threshold, d),
+        None => Ok(SpillableReorderBuffer::new(capacity, threshold)),
+    }
+}
+
+/// Reorder loop for the bare [`ReorderBuffer`] backend (passthrough or
+/// ring-buffer mode). Mirrors the historical control flow: drain ready items
+/// to free space, force-insert if the buffer is full and the head is missing.
+fn run_bare_loop(
+    stream_rx: crossbeam_channel::Receiver<DeltaResult>,
+    result_tx: &mpsc::Sender<DeltaResult>,
+    mut reorder: ReorderBuffer<DeltaResult>,
+) {
+    for result in stream_rx {
+        while reorder.insert(result.sequence(), result.clone()).is_err() {
+            let mut drained_any = false;
+            for ready in reorder.drain_ready() {
+                drained_any = true;
+                if result_tx.send(ready).is_err() {
+                    return;
+                }
+            }
+            if !drained_any {
+                // Buffer full but next_expected is not buffered.
+                // Force insert to break the deadlock.
+                reorder.force_insert(result.sequence(), result.clone());
+                break;
+            }
+        }
+
+        for ready in reorder.drain_ready() {
+            if result_tx.send(ready).is_err() {
+                return;
+            }
+        }
+    }
+
+    for ready in reorder.drain_ready() {
+        if result_tx.send(ready).is_err() {
+            return;
+        }
+    }
+}
+
+/// Reorder loop for the bounded-memory [`SpillableReorderBuffer`] backend.
+///
+/// The spill layer handles overflow internally: when the byte threshold is
+/// exceeded, the buffer serialises the oldest (highest-sequence) items to a
+/// tempfile and reloads them transparently on drain. The legacy
+/// "force_insert as deadlock breaker" branch is gone - capacity exhaustion
+/// becomes a spill rather than unbounded ring growth.
+///
+/// Spill-side I/O failures (ENOSPC, missing temp directory, encoder error)
+/// are mapped to a [`DeltaResult::failed`] for the offending sequence, which
+/// the receiver maps to upstream rsync exit code 11 (`FileIo`) so the
+/// transfer aborts with the same semantics as a direct I/O failure.
+fn run_spillable_loop(
+    stream_rx: crossbeam_channel::Receiver<DeltaResult>,
+    result_tx: &mpsc::Sender<DeltaResult>,
+    mut reorder: SpillableReorderBuffer<DeltaResult>,
+    spill_events: &Arc<AtomicU64>,
+) {
+    let mut prev_spill = reorder.spill_stats().spill_events;
+
+    for result in stream_rx {
+        let ndx = result.ndx();
+        loop {
+            match reorder.insert(result.sequence(), result.clone()) {
+                Ok(()) => break,
+                Err(SpillError::Capacity(_)) => {
+                    // Drain ready items first to free a ring slot.
+                    let mut drained_any = false;
+                    match reorder.drain_ready() {
+                        Ok(items) => {
+                            for ready in items {
+                                drained_any = true;
+                                if result_tx.send(ready).is_err() {
+                                    return;
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            let _ = result_tx.send(DeltaResult::failed(
+                                ndx,
+                                format!("spill reload failed: {e}"),
+                            ));
+                            return;
+                        }
+                    }
+                    if !drained_any {
+                        // The head is missing and the ring is full. Force the
+                        // insert; the spill layer keeps memory bounded by
+                        // displacing higher-sequence items to disk.
+                        if let Err(e) = reorder.force_insert(result.sequence(), result.clone()) {
+                            let _ = result_tx
+                                .send(DeltaResult::failed(ndx, format!("spill write failed: {e}")));
+                            return;
+                        }
+                        break;
+                    }
+                }
+                Err(SpillError::Io(e)) => {
+                    let _ = result_tx
+                        .send(DeltaResult::failed(ndx, format!("spill write failed: {e}")));
+                    return;
+                }
+            }
+        }
+
+        // Publish any newly accumulated spill events to the shared counter.
+        let now_spill = reorder.spill_stats().spill_events;
+        if now_spill != prev_spill {
+            spill_events.fetch_add(now_spill - prev_spill, Ordering::Relaxed);
+            prev_spill = now_spill;
+        }
+
+        match reorder.drain_ready() {
+            Ok(items) => {
+                for ready in items {
+                    if result_tx.send(ready).is_err() {
+                        return;
+                    }
+                }
+            }
+            Err(e) => {
+                let _ = result_tx.send(DeltaResult::failed(
+                    ndx,
+                    format!("spill reload failed: {e}"),
+                ));
+                return;
+            }
+        }
+    }
+
+    // Final drain after the stream closes.
+    match reorder.drain_ready() {
+        Ok(items) => {
+            for ready in items {
+                if result_tx.send(ready).is_err() {
+                    return;
+                }
+            }
+        }
+        Err(e) => {
+            let _ = result_tx.send(DeltaResult::failed(
+                0u32,
+                format!("spill reload failed: {e}"),
+            ));
+        }
+    }
+
+    let final_spill = reorder.spill_stats().spill_events;
+    if final_spill != prev_spill {
+        spill_events.fetch_add(final_spill - prev_spill, Ordering::Relaxed);
     }
 }
 
@@ -699,5 +948,132 @@ mod tests {
         ndx_values.sort_unstable();
         let expected: Vec<u32> = (0..count).collect();
         assert_eq!(ndx_values, expected);
+    }
+
+    // ---- SpillableReorderBuffer wiring tests (task #1884) ----
+
+    /// Drives a large adversarial workload through the spill-enabled
+    /// consumer: 1000 sequenced items sent in reverse, with a 16 KiB
+    /// in-memory budget that must force the spill machinery to engage.
+    /// Verifies all items come out in order, none are lost, and the
+    /// spill_events counter records the disk activity.
+    #[test]
+    fn spillable_consumer_preserves_order_under_pressure() {
+        const COUNT: u32 = 1000;
+        const THRESHOLD: u64 = 16 * 1024;
+
+        let (tx, rx) = work_queue::bounded_with_capacity(COUNT as usize);
+
+        // Send items in reverse so the first arriving sequences are far ahead
+        // of next_expected. This maximises the buffered ring and forces the
+        // byte budget to overflow well before drain catches up.
+        let producer = std::thread::spawn(move || {
+            for seq in (0..COUNT).rev() {
+                let work = DeltaWork::whole_file(seq, PathBuf::from("/dst"), 64)
+                    .with_sequence(u64::from(seq));
+                tx.send(work).unwrap();
+            }
+        });
+
+        let cfg = ConcurrentDeltaConfig::with_spill_threshold(THRESHOLD);
+        let consumer = DeltaConsumer::spawn_with_config(rx, COUNT as usize, cfg);
+        let results: Vec<DeltaResult> = consumer.iter().collect();
+        let stats = consumer.stats();
+        producer.join().unwrap();
+
+        assert_eq!(results.len(), COUNT as usize, "all items must be delivered");
+        for (i, r) in results.iter().enumerate() {
+            assert_eq!(
+                r.sequence(),
+                i as u64,
+                "out of order at position {i}: got seq {}",
+                r.sequence()
+            );
+            assert!(r.is_success(), "result at {i} should be success");
+        }
+        assert!(
+            stats.spill_events > 0,
+            "16 KiB budget against 1000 items must trigger spills, got {}",
+            stats.spill_events
+        );
+    }
+
+    /// Baseline comparison: the spill-enabled and non-spill paths must deliver
+    /// the same sequence of result payloads byte-for-byte. The spill layer is
+    /// a local-only memory-bound, never a wire-protocol change.
+    #[test]
+    fn spillable_consumer_matches_bare_output_byte_for_byte() {
+        const COUNT: u32 = 256;
+
+        fn run(cfg: Option<ConcurrentDeltaConfig>) -> Vec<DeltaResult> {
+            let (tx, rx) = work_queue::bounded_with_capacity(COUNT as usize);
+            let producer = std::thread::spawn(move || {
+                for seq in (0..COUNT).rev() {
+                    let work = DeltaWork::whole_file(seq, PathBuf::from("/dst"), 64)
+                        .with_sequence(u64::from(seq));
+                    tx.send(work).unwrap();
+                }
+            });
+            let consumer = match cfg {
+                Some(c) => DeltaConsumer::spawn_with_config(rx, COUNT as usize, c),
+                None => DeltaConsumer::spawn(rx, COUNT as usize),
+            };
+            let out: Vec<DeltaResult> = consumer.iter().collect();
+            producer.join().unwrap();
+            out
+        }
+
+        let baseline = run(None);
+        let spilled = run(Some(ConcurrentDeltaConfig::with_spill_threshold(8 * 1024)));
+
+        assert_eq!(baseline.len(), spilled.len(), "result counts must match");
+        for (i, (a, b)) in baseline.iter().zip(spilled.iter()).enumerate() {
+            assert_eq!(a.sequence(), b.sequence(), "sequence mismatch at {i}");
+            assert_eq!(a.ndx().get(), b.ndx().get(), "ndx mismatch at {i}");
+            assert_eq!(a.bytes_written(), b.bytes_written(), "bytes_written at {i}");
+            assert_eq!(a.literal_bytes(), b.literal_bytes(), "literal at {i}");
+            assert_eq!(a.matched_bytes(), b.matched_bytes(), "matched at {i}");
+            assert_eq!(a.is_success(), b.is_success(), "status at {i}");
+
+            // SpillCodec round-trips the binary encoding the spill layer uses;
+            // identical encodings prove the payloads are byte-equivalent.
+            use crate::concurrent_delta::SpillCodec;
+            let mut buf_a = Vec::new();
+            let mut buf_b = Vec::new();
+            a.encode(&mut buf_a).unwrap();
+            b.encode(&mut buf_b).unwrap();
+            assert_eq!(buf_a, buf_b, "encoded payload differs at {i}");
+        }
+    }
+
+    #[test]
+    fn spawn_with_config_off_matches_spawn() {
+        let cfg = ConcurrentDeltaConfig::off();
+        assert!(!cfg.spill_enabled());
+
+        let (tx, rx) = spawn_producer(64);
+        let producer = std::thread::spawn(move || send_items(&tx, 64));
+        let consumer = DeltaConsumer::spawn_with_config(rx, 64, cfg);
+        let results: Vec<DeltaResult> = consumer.iter().collect();
+        let stats = consumer.stats();
+        producer.join().unwrap();
+
+        assert_eq!(results.len(), 64);
+        for (i, r) in results.iter().enumerate() {
+            assert_eq!(r.sequence(), i as u64);
+        }
+        assert_eq!(stats.spill_events, 0, "off-config must not spill");
+    }
+
+    #[test]
+    fn stats_zero_when_spill_disabled() {
+        let (tx, rx) = spawn_producer(5);
+        let producer = std::thread::spawn(move || send_items(&tx, 5));
+        let consumer = DeltaConsumer::spawn(rx, 16);
+        let _: Vec<DeltaResult> = consumer.iter().collect();
+        let stats = consumer.stats();
+        producer.join().unwrap();
+
+        assert_eq!(stats.spill_events, 0);
     }
 }

--- a/crates/engine/src/concurrent_delta/mod.rs
+++ b/crates/engine/src/concurrent_delta/mod.rs
@@ -170,6 +170,7 @@
 //! - `transfer::pipeline` for the pipelined receiver architecture
 
 pub mod adaptive;
+pub mod config;
 pub mod consumer;
 #[cfg(test)]
 mod multi_producer_audit;
@@ -180,7 +181,8 @@ mod types;
 pub mod work_queue;
 
 pub use adaptive::{AdaptiveCapacityPolicy, ReorderStats};
-pub use consumer::DeltaConsumer;
+pub use config::ConcurrentDeltaConfig;
+pub use consumer::{DeltaConsumer, DeltaConsumerStats};
 pub use reorder::{Metrics as ReorderMetrics, ReorderBuffer};
 pub use spill::{SpillCodec, SpillError, SpillStats, SpillableReorderBuffer};
 pub use strategy::{DeltaStrategy, DeltaTransferStrategy, WholeFileStrategy};

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -184,8 +184,9 @@ pub use delta::{
 
 /// Concurrent delta pipeline work-item, result, and strategy types.
 pub use concurrent_delta::{
-    AdaptiveCapacityPolicy, DeltaResult, DeltaResultStatus, DeltaStrategy, DeltaTransferStrategy,
-    DeltaWork, DeltaWorkKind, FileNdx, ReorderBuffer, ReorderStats, WholeFileStrategy,
+    AdaptiveCapacityPolicy, ConcurrentDeltaConfig, DeltaConsumerStats, DeltaResult,
+    DeltaResultStatus, DeltaStrategy, DeltaTransferStrategy, DeltaWork, DeltaWorkKind, FileNdx,
+    ReorderBuffer, ReorderStats, WholeFileStrategy,
 };
 
 /// Common error types for engine operations.


### PR DESCRIPTION
## Summary

- Adds `ConcurrentDeltaConfig` with an opt-in `spill_threshold_bytes` knob and a new `DeltaConsumer::spawn_with_config` constructor that swaps the bare `ReorderBuffer` for the existing `SpillableReorderBuffer` when the threshold is set.
- Replaces the legacy `force_insert` deadlock-breaker fallback with a proper spill: capacity pressure now displaces the highest-sequence items to a tempfile (`SpooledTempFile` by default, with an explicit `spill_dir` override) instead of doubling the ring forever.
- Exposes spill activity through an `AtomicU64` accessible via `DeltaConsumer::stats()` -> `DeltaConsumerStats { spill_events }`. Spill I/O failures map to `DeltaResult::failed`, which the receiver already translates to upstream exit code 11 (`FileIo`).

The default path (`spawn`, `spawn_bypass`, and `spawn_with_config(.., ConcurrentDeltaConfig::default())`) is bit-for-bit identical to the prior behaviour. The wire protocol is unchanged - the spill layer is strictly receiver-local memory management.

## Test plan

- [x] Synthetic 1000-item / 16 KiB-budget adversarial drive: `spillable_consumer_preserves_order_under_pressure` verifies in-order delivery and `spill_events > 0`.
- [x] Byte-for-byte parity vs the non-spilling baseline: `spillable_consumer_matches_bare_output_byte_for_byte` encodes each delivered `DeltaResult` via `SpillCodec` and asserts identical payloads against the bare-`ReorderBuffer` baseline.
- [x] Default-off path: `spawn_with_config_off_matches_spawn` and `stats_zero_when_spill_disabled` confirm `spawn_with_config(.., ConcurrentDeltaConfig::off())` matches `spawn(..)` exactly and reports zero spill events.
- [x] `ConcurrentDeltaConfig` unit tests cover `default`, `off`, `with_spill_threshold`, `with_spill_dir`, and `spill_enabled`.
- [x] `cargo fmt --all` clean.