### PR TITLE
feat(fast_io): io_uring SEND_ZC network zero-copy primitive (#1832)

### DIFF
--- a/crates/fast_io/src/io_uring/mod.rs
+++ b/crates/fast_io/src/io_uring/mod.rs
@@ -95,6 +95,7 @@ pub mod linkat;
 pub mod linked_chain;
 pub mod registered_buffers;
 pub mod renameat2;
+pub mod send_zc;
 pub mod session_pool;
 pub mod shared_ring;
 mod socket_factory;
@@ -130,6 +131,7 @@ pub use linked_chain::{CqeResult, LinkedChain, read_then_write};
 pub use registered_buffers::{
     RegisteredBufferGroup, RegisteredBufferSlot, RegisteredBufferStats, RegisteredBufferStatus,
 };
+pub use send_zc::{is_supported as send_zc_supported, try_send_zc};
 
 /// Internal re-exports of the underlying `io-uring` crate types used by
 /// `#[doc(hidden)]` test helpers (see `registered_buffers::submit_read_fixed_batch`).

--- a/crates/fast_io/src/io_uring/send_zc.rs
+++ b/crates/fast_io/src/io_uring/send_zc.rs
@@ -1,0 +1,320 @@
+//! `IORING_OP_SEND_ZC` zero-copy socket-send primitive (Linux 6.0+).
+//!
+//! A regular `IORING_OP_SEND` posts one CQE per submission: the byte count or
+//! `-errno`. `IORING_OP_SEND_ZC` posts **two CQEs** per submission:
+//!
+//! 1. **Transfer CQE** - posted when the data has been queued for transmit.
+//!    `IORING_CQE_F_MORE` is set in `flags()` to signal "more CQEs with this
+//!    `user_data` will follow", and `result()` carries the byte count (or
+//!    `-errno`) exactly like a regular SEND.
+//! 2. **Notification CQE** - posted once the kernel has released its
+//!    reference to the user pages. `IORING_CQE_F_NOTIF` is set in `flags()`;
+//!    `result()` is unused.
+//!
+//! The buffer passed to a SEND_ZC submission must remain valid and unmodified
+//! until the notification CQE arrives. This module enforces that contract by
+//! blocking on both CQEs before returning. Callers therefore see SEND_ZC as
+//! a synchronous primitive even though the kernel performs the page release
+//! asynchronously.
+//!
+//! See `docs/design/iouring-send-zc.md` for the full design.
+
+use std::io;
+use std::os::unix::io::RawFd;
+use std::sync::atomic::{AtomicI8, Ordering};
+
+use io_uring::{IoUring as RawIoUring, opcode, types};
+
+/// CQE flag set on the transfer CQE; signals a notification CQE will follow.
+const IORING_CQE_F_MORE: u32 = 1 << 1;
+
+/// CQE flag set on the notification CQE.
+const IORING_CQE_F_NOTIF: u32 = 1 << 3;
+
+/// Sentinel `user_data` mask used to keep the SEND_ZC submission from
+/// colliding with other CQEs draining on the same ring.
+///
+/// Callers pass any 56-bit value; the high byte is reserved for a future
+/// `OpTag::SendZc` tag. Keeping the encoding internal lets the probe-helper
+/// route both CQEs through the same `user_data` match.
+const USER_DATA_MASK: u64 = (1u64 << 56) - 1;
+
+/// Cached `IORING_OP_SEND_ZC` support, populated lazily by [`is_supported`].
+///
+/// Three-state: `0` = not yet probed, `1` = supported, `-1` = unsupported.
+static SEND_ZC_SUPPORTED: AtomicI8 = AtomicI8::new(0);
+
+/// Returns `true` when the running kernel advertises `IORING_OP_SEND_ZC`.
+///
+/// Uses `IORING_REGISTER_PROBE` on a throwaway 4-entry ring, mirroring the
+/// `count_supported_ops` cache in [`super::config`]. Distros backport features
+/// and container runtimes lie about kernel versions, so the opcode probe is
+/// preferred over a `uname()` floor check.
+///
+/// The result is cached in a process-wide atomic so subsequent calls are a
+/// single relaxed load.
+#[must_use]
+pub fn is_supported() -> bool {
+    match SEND_ZC_SUPPORTED.load(Ordering::Relaxed) {
+        1 => return true,
+        -1 => return false,
+        _ => {}
+    }
+
+    let supported = probe_send_zc();
+    SEND_ZC_SUPPORTED.store(if supported { 1 } else { -1 }, Ordering::Relaxed);
+    supported
+}
+
+/// One-shot probe: build a tiny ring, register a probe, check the opcode bit.
+///
+/// Returns `false` whenever the kernel rejects the probe entirely - the
+/// caller treats both "kernel too old" and "probe blocked" as "unsupported"
+/// because both surface as `io::ErrorKind::Unsupported` in the fall-back
+/// path. Diagnostic separation lives in the existing
+/// `config_detail::io_uring_kernel_info` reporter.
+fn probe_send_zc() -> bool {
+    let Ok(ring) = RawIoUring::new(4) else {
+        return false;
+    };
+    let mut probe = io_uring::Probe::new();
+    if ring.submitter().register_probe(&mut probe).is_err() {
+        return false;
+    }
+    probe.is_supported(opcode::SendZc::CODE)
+}
+
+/// Submits one `IORING_OP_SEND_ZC` SQE and drains both CQEs synchronously.
+///
+/// Returns the byte count from the transfer CQE on success. Errors:
+///
+/// - `io::ErrorKind::Unsupported` if the running kernel does not advertise
+///   `IORING_OP_SEND_ZC` (see [`is_supported`]).
+/// - `io::ErrorKind::InvalidInput` if `buf` is empty (matches `send(2)`
+///   semantics: SEND_ZC with `len = 0` is documented as
+///   implementation-defined and is not exercised by any production caller).
+/// - The OS error from the transfer CQE if the kernel reports a negative
+///   result.
+///
+/// `user_data` is masked to 56 bits internally; the high byte is reserved
+/// for a future `OpTag::SendZc` tag.
+///
+/// # Invariants
+///
+/// The function does not return until both the transfer CQE
+/// (`IORING_CQE_F_MORE` set) and the notification CQE (`IORING_CQE_F_NOTIF`
+/// set) have been observed. By the time the caller regains control, the
+/// kernel has released its reference to `buf` and the slice may be reused
+/// or dropped immediately.
+pub fn try_send_zc(
+    ring: &mut RawIoUring,
+    fd: RawFd,
+    buf: &[u8],
+    user_data: u64,
+) -> io::Result<usize> {
+    if buf.is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "SEND_ZC requires a non-empty buffer",
+        ));
+    }
+    if !is_supported() {
+        return Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "IORING_OP_SEND_ZC is not supported on this kernel",
+        ));
+    }
+
+    let tagged = user_data & USER_DATA_MASK;
+    let entry = opcode::SendZc::new(types::Fd(fd), buf.as_ptr(), buf.len() as u32)
+        .build()
+        .user_data(tagged);
+
+    // SAFETY: `buf` is borrowed for the full lifetime of this call. We drain
+    // both CQEs (transfer + notification) below before returning, so the
+    // kernel is guaranteed to have released the page reference by the time
+    // the caller regains control. The SQE references no other memory.
+    unsafe {
+        ring.submission()
+            .push(&entry)
+            .map_err(|_| io::Error::other("submission queue full"))?;
+    }
+
+    let mut transfer_result: Option<i32> = None;
+    let mut saw_notification = false;
+
+    while transfer_result.is_none() || !saw_notification {
+        // Block for at least one CQE if the queue is empty; otherwise drain
+        // what's already queued before re-entering the kernel.
+        if ring.completion().is_empty() {
+            ring.submit_and_wait(1)?;
+        }
+
+        while let Some(cqe) = ring.completion().next() {
+            if cqe.user_data() != tagged {
+                // CQE belongs to an unrelated SQE on the same ring; ignore
+                // it. Real callers route those through their own demux.
+                continue;
+            }
+            classify_cqe(
+                cqe.result(),
+                cqe.flags(),
+                &mut transfer_result,
+                &mut saw_notification,
+            );
+            if transfer_result.is_some() && saw_notification {
+                break;
+            }
+        }
+    }
+
+    let result = transfer_result.expect("transfer CQE present once loop exits");
+    if result < 0 {
+        return Err(io::Error::from_raw_os_error(-result));
+    }
+    Ok(result as usize)
+}
+
+/// Classifies a SEND_ZC CQE into the transfer or notification slot.
+///
+/// Splitting this off keeps [`try_send_zc`] readable and gives the unit
+/// tests a tiny pure function to assert against without spinning up a real
+/// ring. The function takes raw `result` and `flags` fields so callers can
+/// route through any CQE shape (32-byte or 16-byte) without coupling to a
+/// concrete entry type.
+fn classify_cqe(
+    result: i32,
+    flags: u32,
+    transfer_result: &mut Option<i32>,
+    saw_notification: &mut bool,
+) {
+    if flags & IORING_CQE_F_NOTIF != 0 {
+        *saw_notification = true;
+        return;
+    }
+    // The transfer CQE has `IORING_CQE_F_MORE` set when a notification will
+    // follow. If the kernel posts a transfer error without a notification
+    // (e.g., EBADF before any data is queued), `IORING_CQE_F_MORE` is
+    // cleared and there is no second CQE; record the result and synthesise
+    // the missing notification so the wait loop terminates.
+    *transfer_result = Some(result);
+    if flags & IORING_CQE_F_MORE == 0 {
+        *saw_notification = true;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Read;
+    use std::net::{TcpListener, TcpStream};
+    use std::os::unix::io::AsRawFd;
+    use std::thread;
+    use std::time::Duration;
+
+    use super::super::config::IoUringConfig;
+
+    #[test]
+    fn probe_cache_is_stable() {
+        let first = is_supported();
+        let second = is_supported();
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn classify_notification_cqe() {
+        let mut transfer = None;
+        let mut notif = false;
+        classify_cqe(0, IORING_CQE_F_NOTIF, &mut transfer, &mut notif);
+        assert!(notif);
+        assert!(transfer.is_none());
+    }
+
+    #[test]
+    fn classify_transfer_cqe_with_more_flag() {
+        let mut transfer = None;
+        let mut notif = false;
+        classify_cqe(4096, IORING_CQE_F_MORE, &mut transfer, &mut notif);
+        assert_eq!(transfer, Some(4096));
+        assert!(!notif);
+    }
+
+    #[test]
+    fn classify_transfer_cqe_error_without_notification() {
+        // Kernel posts an error transfer CQE with `IORING_CQE_F_MORE`
+        // cleared when the submission fails before any data is queued.
+        let mut transfer = None;
+        let mut notif = false;
+        classify_cqe(-libc::EBADF, 0, &mut transfer, &mut notif);
+        assert_eq!(transfer, Some(-libc::EBADF));
+        assert!(notif, "missing F_MORE must synthesise the notification");
+    }
+
+    #[test]
+    fn send_zc_rejects_empty_buffer() {
+        // Empty-buffer rejection short-circuits before any io_uring call,
+        // so a ring is built only to satisfy the borrowed-argument shape.
+        let mut ring = match RawIoUring::new(4) {
+            Ok(r) => r,
+            Err(_) => return, // io_uring unavailable on this host
+        };
+        let err = try_send_zc(&mut ring, 0, &[], 0).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+    }
+
+    /// Round-trips 64 KiB over a loopback TCP pair via `try_send_zc` and
+    /// verifies both the byte content and that the notification CQE was
+    /// observed (the call would not return otherwise).
+    #[test]
+    fn send_zc_roundtrip_64kib_loopback() {
+        if !super::super::config::is_io_uring_available() {
+            println!("skipping: io_uring unavailable on this host");
+            return;
+        }
+        if !is_supported() {
+            println!("skipping: IORING_OP_SEND_ZC unsupported on this kernel");
+            return;
+        }
+
+        let listener = match TcpListener::bind("127.0.0.1:0") {
+            Ok(l) => l,
+            Err(e) => {
+                println!("skipping: cannot bind loopback ({e})");
+                return;
+            }
+        };
+        let addr = listener.local_addr().unwrap();
+        let reader_thread = thread::spawn(move || {
+            let (mut peer, _) = listener.accept().unwrap();
+            peer.set_read_timeout(Some(Duration::from_secs(10)))
+                .unwrap();
+            let mut received = Vec::with_capacity(64 * 1024);
+            let mut tmp = [0u8; 8192];
+            while received.len() < 64 * 1024 {
+                let n = peer.read(&mut tmp).unwrap();
+                if n == 0 {
+                    break;
+                }
+                received.extend_from_slice(&tmp[..n]);
+            }
+            received
+        });
+
+        let sender = TcpStream::connect(addr).unwrap();
+        let mut ring = IoUringConfig::default().build_ring().unwrap();
+        let payload: Vec<u8> = (0..64 * 1024).map(|i| (i & 0xff) as u8).collect();
+
+        let mut sent_total = 0usize;
+        while sent_total < payload.len() {
+            let n = try_send_zc(&mut ring, sender.as_raw_fd(), &payload[sent_total..], 0x42)
+                .expect("SEND_ZC succeeds on loopback");
+            assert!(n > 0, "kernel reported zero bytes sent");
+            sent_total += n;
+        }
+        drop(sender);
+
+        let received = reader_thread.join().unwrap();
+        assert_eq!(received.len(), payload.len());
+        assert_eq!(received, payload, "round-tripped bytes must match");
+    }
+}

--- a/crates/fast_io/src/io_uring/socket_writer.rs
+++ b/crates/fast_io/src/io_uring/socket_writer.rs
@@ -7,19 +7,32 @@ use io_uring::IoUring as RawIoUring;
 
 use super::batching::{sqe_fd, submit_send_batch, try_register_fd};
 use super::config::IoUringConfig;
+use super::send_zc;
 
-/// io_uring-based socket writer using `IORING_OP_SEND`.
+/// Payload-length floor below which `IORING_OP_SEND_ZC` is skipped in favour
+/// of regular `IORING_OP_SEND`.
+///
+/// SEND_ZC pins the user pages via `get_user_pages_fast` and waits for the
+/// notification CQE before reusing the slot; for sub-page sends the
+/// page-pin overhead dominates and SEND_ZC loses to plain SEND. 16 KiB is
+/// the threshold from `docs/design/iouring-send-zc.md` section 5
+/// (workload B regression guard).
+const SEND_ZC_MIN_BYTES: usize = 16 * 1024;
+
+/// io_uring-based socket writer using `IORING_OP_SEND` (and optionally
+/// `IORING_OP_SEND_ZC`).
 ///
 /// Replaces direct `write()` calls on `TcpStream` by batching sends through
 /// the io_uring ring. Maintains an internal write buffer, flushing via
 /// batched send SQEs.
 ///
-/// `SEND_ZC` is gated by [`IoUringConfig::allow_send_zc`] - currently
-/// `false` for both `Auto` and `Disabled` policies, so this writer always
-/// emits regular `IORING_OP_SEND` SQEs. When the
-/// [`ZeroCopyPolicy::Enabled`](crate::ZeroCopyPolicy::Enabled) opt-in path
-/// is wired through the registered-buffer ring, `allow_send_zc` will switch
-/// to selecting `IORING_OP_SEND_ZC` here.
+/// When [`IoUringConfig::allow_send_zc`] is set and the running kernel
+/// advertises `IORING_OP_SEND_ZC` (Linux 6.0+), the big-write fast path
+/// switches to the zero-copy primitive. Sub-page writes stay on regular
+/// `IORING_OP_SEND` because SEND_ZC's page-pin overhead loses to SEND for
+/// small payloads. The kernel probe in [`send_zc::is_supported`] is cached
+/// process-wide; an unsupported result silently degrades to SEND so the
+/// writer never blocks startup on the probe outcome.
 pub struct IoUringSocketWriter {
     ring: RawIoUring,
     fd: RawFd,
@@ -28,8 +41,10 @@ pub struct IoUringSocketWriter {
     buffer_pos: usize,
     buffer_size: usize,
     sq_entries: u32,
-    #[allow(dead_code)]
-    allow_send_zc: bool,
+    /// True when the configured policy permits SEND_ZC **and** the running
+    /// kernel advertises `IORING_OP_SEND_ZC`. Resolved once at construction
+    /// so the hot path never re-probes.
+    send_zc_active: bool,
 }
 
 impl IoUringSocketWriter {
@@ -40,6 +55,7 @@ impl IoUringSocketWriter {
     pub fn from_raw_fd(fd: RawFd, config: &IoUringConfig) -> io::Result<Self> {
         let ring = config.build_ring()?;
         let fixed_fd_slot = try_register_fd(&ring, fd, config.register_files);
+        let send_zc_active = config.allow_send_zc() && send_zc::is_supported();
 
         Ok(Self {
             ring,
@@ -49,33 +65,76 @@ impl IoUringSocketWriter {
             buffer_pos: 0,
             buffer_size: config.buffer_size,
             sq_entries: config.sq_entries,
-            allow_send_zc: config.allow_send_zc(),
+            send_zc_active,
         })
     }
 
-    /// Flushes the internal buffer via batched `IORING_OP_SEND` submissions.
+    /// Returns `true` when this writer will attempt `IORING_OP_SEND_ZC` for
+    /// payloads at or above [`SEND_ZC_MIN_BYTES`]. Exposed for diagnostics
+    /// and tests; the production hot path consults the field directly.
+    #[must_use]
+    pub fn send_zc_active(&self) -> bool {
+        self.send_zc_active
+    }
+
+    /// Submits `data` via SEND_ZC when policy + kernel + payload size all
+    /// agree, falling back to the batched SEND path on `Unsupported` or
+    /// when SEND_ZC is disabled. Returns the byte count actually sent.
+    fn submit_send(&mut self, data: &[u8]) -> io::Result<usize> {
+        if self.send_zc_active && data.len() >= SEND_ZC_MIN_BYTES {
+            match send_zc::try_send_zc(&mut self.ring, self.fd, data, 0) {
+                Ok(n) => return Ok(n),
+                Err(e) if e.kind() == io::ErrorKind::Unsupported => {
+                    // Stop trying SEND_ZC for the lifetime of this writer:
+                    // the kernel cache already memoised the negative probe,
+                    // but turning off the per-writer flag avoids a futile
+                    // syscall on every subsequent flush.
+                    self.send_zc_active = false;
+                }
+                Err(e) => return Err(e),
+            }
+        }
+        let fd = sqe_fd(self.fd, self.fixed_fd_slot);
+        submit_send_batch(
+            &mut self.ring,
+            fd,
+            data,
+            self.buffer_size,
+            self.sq_entries as usize,
+            self.fixed_fd_slot,
+        )
+    }
+
+    /// Flushes the internal buffer via SEND_ZC or batched SEND submissions.
     fn flush_buffer(&mut self) -> io::Result<()> {
         if self.buffer_pos == 0 {
             return Ok(());
         }
 
-        let fd = sqe_fd(self.fd, self.fixed_fd_slot);
         let len = self.buffer_pos;
-
-        let sent = submit_send_batch(
-            &mut self.ring,
-            fd,
-            &self.buffer[..len],
-            self.buffer_size,
-            self.sq_entries as usize,
-            self.fixed_fd_slot,
-        )?;
-
-        if sent != len {
-            return Err(io::Error::new(
-                io::ErrorKind::WriteZero,
-                "batched send incomplete",
-            ));
+        let mut sent_total = 0;
+        while sent_total < len {
+            // SAFETY: `as_ptr()` returns a pointer into `self.buffer`, whose
+            // backing storage lives until `self` is dropped. The slice
+            // bounds are `sent_total..len`, both bounded by
+            // `self.buffer_size`. We rebuild the slice on each iteration so
+            // it does not alias the `&mut self` borrow consumed by
+            // `submit_send`. SEND_ZC's `try_send_zc` waits for the
+            // notification CQE before returning, so the kernel has released
+            // its page reference by the time we regain control; SEND
+            // copies bytes into kernel socket buffers synchronously and is
+            // similarly safe to call on a borrowed slice.
+            let chunk = unsafe {
+                std::slice::from_raw_parts(self.buffer.as_ptr().add(sent_total), len - sent_total)
+            };
+            let n = self.submit_send(chunk)?;
+            if n == 0 {
+                return Err(io::Error::new(
+                    io::ErrorKind::WriteZero,
+                    "batched send incomplete",
+                ));
+            }
+            sent_total += n;
         }
 
         self.buffer_pos = 0;
@@ -98,15 +157,11 @@ impl Write for IoUringSocketWriter {
         self.flush_buffer()?;
 
         if buf.len() >= self.buffer_size {
-            let fd = sqe_fd(self.fd, self.fixed_fd_slot);
-            let sent = submit_send_batch(
-                &mut self.ring,
-                fd,
-                buf,
-                self.buffer_size,
-                self.sq_entries as usize,
-                self.fixed_fd_slot,
-            )?;
+            // Caller's slice is borrowed for the lifetime of this call;
+            // `submit_send` either copies via SEND or waits for the SEND_ZC
+            // notification CQE before returning, so the caller is free to
+            // reuse `buf` once we return.
+            let sent = self.submit_send(buf)?;
             return Ok(sent);
         }
 

--- a/crates/fast_io/src/io_uring_stub.rs
+++ b/crates/fast_io/src/io_uring_stub.rs
@@ -613,6 +613,38 @@ pub mod statx {
     }
 }
 
+/// Stub `IORING_OP_SEND_ZC` module mirroring the Linux module on non-Linux
+/// platforms or when the `io_uring` cargo feature is disabled.
+///
+/// [`is_supported`] always returns `false` and [`try_send_zc`] always returns
+/// `Unsupported`. This keeps cross-platform call sites (and the socket
+/// writer's fallback path) compiling without `cfg`-gating each reference.
+pub mod send_zc {
+    use std::io;
+    use std::os::unix::io::RawFd;
+
+    /// Always returns `false` on this platform.
+    #[must_use]
+    pub fn is_supported() -> bool {
+        false
+    }
+
+    /// Always returns `Unsupported` on this platform.
+    pub fn try_send_zc(
+        _ring: &mut (),
+        _fd: RawFd,
+        _buf: &[u8],
+        _user_data: u64,
+    ) -> io::Result<usize> {
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "IORING_OP_SEND_ZC is not available on this platform",
+        ))
+    }
+}
+
+pub use send_zc::is_supported as send_zc_supported;
+
 /// Stub shared-ring module mirroring the Linux module on non-Linux platforms
 /// or when the `io_uring` cargo feature is disabled.
 ///

--- a/docs/design/iouring-send-zc.md
+++ b/docs/design/iouring-send-zc.md
@@ -1,6 +1,10 @@
 # IORING_OP_SEND_ZC for network zero-copy on kernel >= 6.0
 
-Tracking issue: #1832. Status: design, implementation deferred.
+Tracking issue: #1832. Status: primitive landed in
+`crates/fast_io/src/io_uring/send_zc.rs` and wired into
+`IoUringSocketWriter::submit_send` behind `ZeroCopyPolicy::Enabled` /
+`IoUringConfig::allow_send_zc`. The pin-counted pool described in
+section 3 remains future work for #4218.
 Companion to the borrowed-slice audit (#4218,
 `docs/design/iouring-borrowed-slice-consumer.md`) and the daemon TCP
 socket I/O work tracked at #1876


### PR DESCRIPTION
## Summary

- Adds `crates/fast_io/src/io_uring/send_zc.rs` exposing `try_send_zc(ring, fd, buf, user_data)` that submits an `IORING_OP_SEND_ZC` SQE and drains both the transfer CQE (`IORING_CQE_F_MORE`) and the notification CQE (`IORING_CQE_F_NOTIF`) before returning. Kernel support is probed via `IORING_REGISTER_PROBE` on first call and cached in a process-wide atomic; unsupported kernels surface `io::ErrorKind::Unsupported`.
- Wires `IoUringSocketWriter::submit_send` to attempt SEND_ZC first when `IoUringConfig::allow_send_zc()` is true and the payload is at least 16 KiB (workload-B regression guard from `docs/design/iouring-send-zc.md` section 5), falling back to the existing `IORING_OP_SEND` batch path on `Unsupported`.
- Mirrors the API in the non-Linux stub so cross-platform callers compile without `cfg`-gating; updates the design doc to reflect the landed primitive.

## Test plan

- [x] `cargo fmt --all`
- [ ] CI: fmt+clippy
- [ ] CI: nextest (stable) - covers `send_zc::tests::*` on the Linux runners (classify-CQE state machine, empty-buffer rejection, 64 KiB loopback round-trip)
- [ ] CI: Windows / macOS / Linux musl - stub path compiles