### PR TITLE
feat(fast_io): vmsplice zero-copy writer behind --features vmsplice (#1361)

### DIFF
--- a/crates/fast_io/Cargo.toml
+++ b/crates/fast_io/Cargo.toml
@@ -66,6 +66,13 @@ copy_file_range = []
 # This feature is kept as an empty alias for compatibility.
 syscall_batch = []
 
+# vmsplice: Linux-only zero-copy file writer that moves a userspace buffer to a
+# regular file via `vmsplice(2)` + `splice(2)`. Default off until benchmarks on
+# the trigger workload (kernel < 5.6 or io_uring disabled, large literal tokens,
+# splice-capable filesystem) justify promotion. See
+# docs/design/splice-vmsplice-zero-copy.md.
+vmsplice = []
+
 [target.'cfg(windows)'.dependencies]
 # CopyFileExW for Windows-optimized file copy with no-buffering support;
 # Win32_Networking_WinSock added for WSARecv/WSASend in iocp::socket (#1928);

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -95,6 +95,7 @@ pub mod sendfile;
 pub mod socket_options;
 pub mod splice;
 pub mod syscall_batch;
+pub mod vmsplice_writer;
 
 pub mod macos_io;
 
@@ -176,6 +177,7 @@ pub use splice::{
     SplicePipe, is_splice_available, is_splice_enabled, recv_fd_to_file, try_splice_to_file,
     try_vmsplice_to_file,
 };
+pub use vmsplice_writer::{VMSPLICE_MIN_CHUNK, VmspliceFileWriter};
 
 pub use macos_io::{
     F_NOCACHE_THRESHOLD, MAX_IOV_COUNT, MacosWriter, apply_sequential_read_hint, is_nocache_set,

--- a/crates/fast_io/src/vmsplice_writer.rs
+++ b/crates/fast_io/src/vmsplice_writer.rs
@@ -1,0 +1,403 @@
+//! Zero-copy file writer that pushes already-demuxed literal chunks into a
+//! destination file via `vmsplice(2)` + `splice(2)`.
+//!
+//! This module is the disk-write tail of integration shape B in
+//! `docs/design/splice-vmsplice-zero-copy.md`: a userspace `Vec<u8>` payload
+//! has already been read off the multiplex layer and the caller wants to land
+//! the bytes in the page cache without paying a userspace-to-kernel `memcpy`.
+//!
+//! # Layering
+//!
+//! ```text
+//! caller buffer (&[u8]) -> vmsplice -> pipe (kernel) -> splice -> file_fd
+//! ```
+//!
+//! A single [`crate::splice::SplicePipe`] is held per writer for the lifetime
+//! of one file so the pipe pair is reused across chunks; this matches step 3
+//! of the design doc's implementation sequencing and keeps the fd budget at
+//! two for the pipe plus one for the destination file.
+//!
+//! # When to use
+//!
+//! Per the design doc, the vmsplice path only wins over a buffered `write(2)`
+//! or io_uring `WRITE_FIXED` when:
+//!
+//! - `io_uring` is unavailable or disabled, and
+//! - The chunk is large enough to clear the per-`vmsplice` pipe-buffer ceiling
+//!   and amortise the two-syscall pair (>= 64 KiB), and
+//! - The chunk pointer is page-aligned so the kernel can move whole pages by
+//!   reference instead of falling back to an internal copy.
+//!
+//! On Linux with the `vmsplice` feature, [`VmspliceFileWriter::write_chunk`]
+//! enforces those gates and falls back to [`std::fs::File::write_all`]
+//! otherwise. Any kernel-side rejection (`ErrorKind::Unsupported`,
+//! `InvalidInput` mapped from `EINVAL`) also drops to the fallback so
+//! unsupported filesystems (tmpfs/FUSE/NFS) keep working.
+//!
+//! # Feature gate
+//!
+//! The full implementation is compiled only on `cfg(all(target_os = "linux",
+//! feature = "vmsplice"))`. On every other configuration the module exposes a
+//! stub type whose constructor and `write_chunk` return
+//! [`std::io::ErrorKind::Unsupported`], so callers can write
+//! platform-independent code that compiles everywhere. The feature is
+//! default-off until benchmarks on the trigger workload justify promotion.
+
+use std::fs::File;
+use std::io;
+
+#[cfg(all(target_os = "linux", feature = "vmsplice"))]
+use std::os::fd::{AsRawFd, RawFd};
+
+#[cfg(all(target_os = "linux", feature = "vmsplice"))]
+use crate::splice::{DEFAULT_PIPE_CAPACITY, SplicePipe, is_splice_available};
+
+/// Minimum chunk size at which the vmsplice path is attempted.
+///
+/// Below this threshold the two-syscall pair (`vmsplice` + `splice`) costs
+/// more than a single buffered `write(2)`. 64 KiB matches the default Linux
+/// pipe-buffer capacity and the [`crate::splice`] module's
+/// `SPLICE_THRESHOLD`.
+pub const VMSPLICE_MIN_CHUNK: usize = 64 * 1024;
+
+/// Page size assumed for the alignment check.
+///
+/// 4 KiB matches every Linux target tier-1 architecture (`x86_64`, `aarch64`,
+/// `i686`, `armv7`). On targets with a larger native page size the check is
+/// conservative: a 16 KiB-aligned buffer is also 4 KiB-aligned, so it still
+/// takes the fast path; a 4 KiB-aligned buffer on a 16 KiB-page kernel would
+/// take the fast path and vmsplice would internally copy, which is correct
+/// (no UB) just not zero-copy.
+#[cfg(all(target_os = "linux", feature = "vmsplice"))]
+const ASSUMED_PAGE_SIZE: usize = 4096;
+
+/// Writer that vmsplices userspace chunks into a destination file via an
+/// owned [`SplicePipe`].
+///
+/// Construct one per destination file; the pipe pair is reused across all
+/// chunks written to that file. Drop the writer (or call [`Self::into_file`])
+/// before renaming or fsyncing the underlying file - the pipe and the file
+/// are independent fds, so neither operation depends on the other, but the
+/// caller still owns ordering.
+#[cfg(all(target_os = "linux", feature = "vmsplice"))]
+pub struct VmspliceFileWriter {
+    pipe: SplicePipe,
+    file: File,
+    dest_fd: RawFd,
+}
+
+#[cfg(all(target_os = "linux", feature = "vmsplice"))]
+impl VmspliceFileWriter {
+    /// Wraps `file` with a freshly created pipe of the default capacity.
+    ///
+    /// # Errors
+    ///
+    /// Returns the error from [`SplicePipe::with_capacity`] when the pipe
+    /// pair cannot be created (typically an `RLIMIT_NOFILE` exhaustion).
+    pub fn new(file: File) -> io::Result<Self> {
+        let pipe = SplicePipe::with_capacity(DEFAULT_PIPE_CAPACITY)?;
+        let dest_fd = file.as_raw_fd();
+        Ok(Self {
+            pipe,
+            file,
+            dest_fd,
+        })
+    }
+
+    /// Returns the actual pipe buffer capacity in bytes.
+    ///
+    /// The kernel may have granted less than [`DEFAULT_PIPE_CAPACITY`] when
+    /// the process lacks `CAP_SYS_RESOURCE` or `/proc/sys/fs/pipe-max-size`
+    /// is lower.
+    #[must_use]
+    pub fn pipe_capacity(&self) -> usize {
+        self.pipe.capacity()
+    }
+
+    /// Returns the destination file descriptor.
+    #[must_use]
+    pub fn dest_fd(&self) -> RawFd {
+        self.dest_fd
+    }
+
+    /// Returns a reference to the destination file.
+    #[must_use]
+    pub fn file(&self) -> &File {
+        &self.file
+    }
+
+    /// Consumes the writer and returns the destination file.
+    ///
+    /// The owned pipe is dropped; the file is returned to the caller for any
+    /// further fsync, truncate, or rename step.
+    pub fn into_file(self) -> File {
+        self.file
+    }
+
+    /// Writes `chunk` to the destination file, taking the vmsplice path when
+    /// it is expected to be zero-copy and falling back to a buffered write
+    /// otherwise.
+    ///
+    /// The vmsplice path is selected when **all** of the following hold:
+    ///
+    /// - The kernel reports `splice(2)` available
+    ///   ([`is_splice_available`] returns `true`).
+    /// - `chunk.len() >= VMSPLICE_MIN_CHUNK` (>= 64 KiB).
+    /// - The chunk pointer is page-aligned.
+    ///
+    /// Any other case, plus any kernel-side rejection
+    /// (`ErrorKind::Unsupported`, `EINVAL` mapped to `InvalidInput`), routes
+    /// to [`File::write_all`].
+    ///
+    /// # Errors
+    ///
+    /// Returns the error from either path. The vmsplice path falls back to
+    /// the write path on `Unsupported`/`InvalidInput`; any other error from
+    /// `vmsplice`/`splice` propagates directly.
+    pub fn write_chunk(&mut self, chunk: &[u8]) -> io::Result<usize> {
+        use std::io::Write;
+
+        if chunk.is_empty() {
+            return Ok(0);
+        }
+
+        if Self::should_vmsplice(chunk) {
+            match self.pipe.vmsplice_to_file(chunk, self.dest_fd) {
+                Ok(n) if n == chunk.len() => return Ok(n),
+                Ok(n) => {
+                    // Short transfer (e.g. pipe-capacity short of chunk): write
+                    // the tail via the fallback path so the caller observes a
+                    // full write.
+                    self.file.write_all(&chunk[n..])?;
+                    return Ok(chunk.len());
+                }
+                Err(e)
+                    if matches!(
+                        e.kind(),
+                        io::ErrorKind::Unsupported | io::ErrorKind::InvalidInput
+                    ) =>
+                {
+                    // Fall through to the buffered write path.
+                }
+                Err(e) => return Err(e),
+            }
+        }
+
+        self.file.write_all(chunk)?;
+        Ok(chunk.len())
+    }
+
+    /// Returns whether `chunk` is eligible for the vmsplice fast path.
+    fn should_vmsplice(chunk: &[u8]) -> bool {
+        if chunk.len() < VMSPLICE_MIN_CHUNK {
+            return false;
+        }
+        if (chunk.as_ptr() as usize) % ASSUMED_PAGE_SIZE != 0 {
+            return false;
+        }
+        is_splice_available()
+    }
+}
+
+/// Stub for non-Linux platforms or when the `vmsplice` feature is disabled.
+///
+/// Every constructor and write method returns
+/// [`std::io::ErrorKind::Unsupported`], allowing callers to compile a single
+/// code path everywhere and probe availability at runtime.
+#[cfg(not(all(target_os = "linux", feature = "vmsplice")))]
+pub struct VmspliceFileWriter {
+    _private: (),
+}
+
+#[cfg(not(all(target_os = "linux", feature = "vmsplice")))]
+impl VmspliceFileWriter {
+    /// Stub: always returns [`io::ErrorKind::Unsupported`].
+    pub fn new(_file: File) -> io::Result<Self> {
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "vmsplice writer requires Linux and the `vmsplice` cargo feature",
+        ))
+    }
+
+    /// Stub: returns 0.
+    #[must_use]
+    pub fn pipe_capacity(&self) -> usize {
+        0
+    }
+
+    /// Stub: always returns [`io::ErrorKind::Unsupported`].
+    pub fn write_chunk(&mut self, _chunk: &[u8]) -> io::Result<usize> {
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "vmsplice writer requires Linux and the `vmsplice` cargo feature",
+        ))
+    }
+}
+
+#[cfg(all(test, target_os = "linux", feature = "vmsplice"))]
+mod linux_tests {
+    use super::*;
+    use std::fs::OpenOptions;
+    use std::io::Read;
+
+    /// Allocates a `Vec<u8>` whose backing pointer is page-aligned.
+    ///
+    /// `Vec<u8>` carries the default `u8` alignment (1), so the standard
+    /// allocator is free to place the buffer anywhere. This helper allocates
+    /// with an explicit page-aligned `Layout`, fills the bytes, and hands
+    /// the allocation to a `Vec` via `from_raw_parts` so the test can pass
+    /// the buffer to [`VmspliceFileWriter::write_chunk`] and have the
+    /// allocator free it on drop with the matching layout.
+    #[allow(unsafe_code)]
+    fn page_aligned_vec(len: usize, fill: u8) -> Vec<u8> {
+        assert!(len > 0, "page_aligned_vec requires non-zero length");
+        let layout = std::alloc::Layout::from_size_align(len, ASSUMED_PAGE_SIZE)
+            .expect("layout for page-aligned buffer");
+        // SAFETY: layout has non-zero size and a valid power-of-two alignment.
+        // The allocation is handed to a Vec via from_raw_parts with matching
+        // capacity, so the global allocator will free it with the same layout
+        // on drop.
+        let ptr = unsafe { std::alloc::alloc(layout) };
+        assert!(!ptr.is_null(), "allocation failed");
+        // SAFETY: ptr is non-null and the allocation is len bytes; write_bytes
+        // initialises every byte. The resulting Vec owns the allocation with
+        // capacity == len, matching what alloc returned. Vec<u8> uses the
+        // global allocator and frees with the original layout when dropped.
+        unsafe {
+            std::ptr::write_bytes(ptr, fill, len);
+            Vec::from_raw_parts(ptr, len, len)
+        }
+    }
+
+    fn read_back(path: &std::path::Path) -> Vec<u8> {
+        let mut buf = Vec::new();
+        File::open(path)
+            .expect("reopen output")
+            .read_to_end(&mut buf)
+            .expect("read output");
+        buf
+    }
+
+    #[test]
+    fn writes_one_mib_chunk_byte_equal() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.path().join("vmsplice_1mib.bin");
+        let file = OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .open(&path)
+            .expect("create file");
+
+        let mut writer = VmspliceFileWriter::new(file).expect("vmsplice writer");
+        let chunk = page_aligned_vec(1024 * 1024, 0xAB);
+        let n = writer.write_chunk(&chunk).expect("write_chunk 1 MiB");
+        assert_eq!(n, chunk.len());
+        drop(writer);
+
+        let actual = read_back(&path);
+        assert_eq!(actual.len(), chunk.len());
+        assert_eq!(actual, chunk);
+    }
+
+    #[test]
+    fn small_chunk_falls_back_to_write() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.path().join("vmsplice_4kib.bin");
+        let file = OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .open(&path)
+            .expect("create file");
+
+        let mut writer = VmspliceFileWriter::new(file).expect("vmsplice writer");
+        // 4 KiB is below VMSPLICE_MIN_CHUNK, so should_vmsplice returns false
+        // and the fallback write path runs regardless of alignment.
+        let chunk = vec![0x5Au8; 4096];
+        assert!(!VmspliceFileWriter::should_vmsplice(&chunk));
+
+        let n = writer.write_chunk(&chunk).expect("write_chunk 4 KiB");
+        assert_eq!(n, chunk.len());
+        drop(writer);
+
+        let actual = read_back(&path);
+        assert_eq!(actual, chunk);
+    }
+
+    #[test]
+    fn unaligned_large_chunk_falls_back() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.path().join("vmsplice_unaligned.bin");
+        let file = OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .open(&path)
+            .expect("create file");
+
+        let mut writer = VmspliceFileWriter::new(file).expect("vmsplice writer");
+        // Build a backing buffer one page longer than the slice we hand to
+        // the writer, then slice from offset 1 so the data pointer is
+        // guaranteed misaligned to ASSUMED_PAGE_SIZE.
+        let mut backing = page_aligned_vec(128 * 1024 + ASSUMED_PAGE_SIZE, 0u8);
+        for (i, b) in backing.iter_mut().enumerate() {
+            *b = (i & 0xFF) as u8;
+        }
+        let unaligned = &backing[1..1 + 128 * 1024];
+        assert!(!VmspliceFileWriter::should_vmsplice(unaligned));
+
+        let n = writer
+            .write_chunk(unaligned)
+            .expect("write_chunk unaligned");
+        assert_eq!(n, unaligned.len());
+        drop(writer);
+
+        let actual = read_back(&path);
+        assert_eq!(actual, unaligned);
+    }
+
+    #[test]
+    fn empty_chunk_is_noop() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.path().join("vmsplice_empty.bin");
+        let file = OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .open(&path)
+            .expect("create file");
+
+        let mut writer = VmspliceFileWriter::new(file).expect("vmsplice writer");
+        let n = writer.write_chunk(&[]).expect("write_chunk empty");
+        assert_eq!(n, 0);
+        drop(writer);
+
+        let actual = read_back(&path);
+        assert!(actual.is_empty());
+    }
+}
+
+#[cfg(all(test, not(all(target_os = "linux", feature = "vmsplice"))))]
+mod stub_tests {
+    use super::*;
+    use std::fs::OpenOptions;
+
+    #[test]
+    fn stub_constructor_returns_unsupported() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.path().join("stub.bin");
+        let file = OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .open(&path)
+            .expect("create file");
+
+        let err = match VmspliceFileWriter::new(file) {
+            Ok(_) => panic!("stub should fail"),
+            Err(e) => e,
+        };
+        assert_eq!(err.kind(), io::ErrorKind::Unsupported);
+    }
+}

--- a/crates/transfer/Cargo.toml
+++ b/crates/transfer/Cargo.toml
@@ -93,6 +93,13 @@ io_uring = ["fast_io/io_uring"]
 # Benefits: Overlapped async file I/O via kernel completion ports
 iocp = ["fast_io/iocp"]
 
+# vmsplice zero-copy disk writer for already-demuxed literal chunks
+# (Linux-only). Selected by the disk-commit thread when io_uring/IOCP are not
+# in play and the chunk is large + page-aligned; otherwise falls back to the
+# buffered writer. Default off until benchmarks justify promotion. See
+# docs/design/splice-vmsplice-zero-copy.md.
+vmsplice = ["fast_io/vmsplice"]
+
 # ============================================================================
 # Protocol Features
 # ============================================================================

--- a/crates/transfer/src/disk_commit/process.rs
+++ b/crates/transfer/src/disk_commit/process.rs
@@ -309,6 +309,16 @@ fn make_writer<'a>(
             )));
         }
     }
+    // vmsplice path: only when neither io_uring nor IOCP claimed the file. It
+    // gates per-chunk inside VmspliceFileWriter, falling back to plain write
+    // for chunks below 64 KiB or with unaligned pointers - the design doc's
+    // shape B. Sparse and append require Seek, so they keep using Buffered.
+    #[cfg(all(target_os = "linux", feature = "vmsplice"))]
+    {
+        if !use_sparse && append_offset == 0 {
+            return Ok(Writer::Vmsplice(fast_io::VmspliceFileWriter::new(file)?));
+        }
+    }
     Ok(Writer::Buffered(ReusableBufWriter::new(file, write_buf)))
 }
 

--- a/crates/transfer/src/disk_commit/writer.rs
+++ b/crates/transfer/src/disk_commit/writer.rs
@@ -153,6 +153,13 @@ pub(super) enum Writer<'a> {
     },
     #[cfg(target_os = "macos")]
     Macos(fast_io::MacosWriter),
+    /// vmsplice zero-copy writer for already-demuxed literal chunks. Selected
+    /// only when `io_uring` is not engaged (Linux + `vmsplice` feature, non-
+    /// sparse, non-append). Per-chunk it falls back to a buffered write when
+    /// the chunk is small or unaligned. See `fast_io::VmspliceFileWriter` and
+    /// `docs/design/splice-vmsplice-zero-copy.md`.
+    #[cfg(all(target_os = "linux", feature = "vmsplice"))]
+    Vmsplice(fast_io::VmspliceFileWriter),
 }
 
 impl<'a> Writer<'a> {
@@ -180,6 +187,11 @@ impl<'a> Writer<'a> {
                 debug_assert!(false, "sparse mode must select buffered writer");
                 unreachable!("sparse mode must select buffered writer")
             }
+            #[cfg(all(target_os = "linux", feature = "vmsplice"))]
+            Writer::Vmsplice(_) => {
+                debug_assert!(false, "sparse mode must select buffered writer");
+                unreachable!("sparse mode must select buffered writer")
+            }
         }
     }
 
@@ -193,6 +205,8 @@ impl<'a> Writer<'a> {
             Writer::Iocp { batch } => batch.write_data(data),
             #[cfg(target_os = "macos")]
             Writer::Macos(w) => w.write_all(data),
+            #[cfg(all(target_os = "linux", feature = "vmsplice"))]
+            Writer::Vmsplice(w) => w.write_chunk(data).map(|_| ()),
         }
     }
 
@@ -230,6 +244,19 @@ impl<'a> Writer<'a> {
                     })
                 }
             }
+            #[cfg(all(target_os = "linux", feature = "vmsplice"))]
+            Writer::Vmsplice(w) => {
+                // vmsplice writes go straight to the file fd via the kernel,
+                // so there is no userspace buffer to flush. The fsync, when
+                // requested, syncs the file the writer owns.
+                if do_fsync {
+                    w.file().sync_all().map_err(|e| {
+                        io::Error::new(e.kind(), format!("fsync failed for {file_path:?}: {e}"))
+                    })
+                } else {
+                    Ok(())
+                }
+            }
         }
     }
 
@@ -243,7 +270,7 @@ impl<'a> Writer<'a> {
     #[cfg_attr(
         not(any(
             all(target_os = "linux", feature = "io_uring"),
-            all(target_os = "windows", feature = "iocp")
+            all(target_os = "windows", feature = "iocp"),
         )),
         allow(unused_variables)
     )]
@@ -266,6 +293,8 @@ impl<'a> Writer<'a> {
             }),
             #[cfg(target_os = "macos")]
             Writer::Macos(_) => Ok(()),
+            #[cfg(all(target_os = "linux", feature = "vmsplice"))]
+            Writer::Vmsplice(_) => Ok(()),
         }
     }
 }


### PR DESCRIPTION
## Summary

- Add `VmspliceFileWriter` in `crates/fast_io/src/vmsplice_writer.rs`. The writer owns a `SplicePipe` per destination file and pushes already-demuxed literal `Vec<u8>` chunks through `vmsplice(2) + splice(2)`, gating per-chunk on `>= 64 KiB` and a page-aligned pointer. Anything below the gate, plus any kernel-side rejection (`Unsupported`, `EINVAL`), falls back to `File::write_all`.
- New cargo feature `vmsplice` on `fast_io` (default off) plus a matching forwarding feature on `transfer`. On non-Linux or without the feature, a stub type returns `ErrorKind::Unsupported` so callers compile uniformly.
- Wire the writer as an optional path in `disk_commit::make_writer`. It is selected only when neither io_uring nor IOCP claims the file and the path is non-sparse, non-append; sparse and append keep using the buffered writer because they need `Seek`.

This is shape B from `docs/design/splice-vmsplice-zero-copy.md`, the only viable splice integration point given the multiplex framing in the receiver. The design recommends defer, so the feature stays default off until benchmarks on the trigger workload justify promotion (kernel < 5.6 or io_uring unavailable, large literal tokens, splice-capable filesystem). See `docs/design/splice-vmsplice-zero-copy.md` for the full rationale and trigger conditions.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo check -p fast_io` (default features)
- [x] `cargo check -p fast_io --features vmsplice`
- [x] `cargo check -p fast_io --no-default-features` (stub path)
- [x] `cargo check -p transfer --features vmsplice`
- [x] `cargo clippy -p fast_io --features vmsplice --no-deps` (no new lints from vmsplice_writer)
- [x] Unit tests added under `vmsplice_writer::linux_tests`: 1 MiB page-aligned write byte-equality, 4 KiB fallback byte-equality, 128 KiB unaligned fallback byte-equality, empty-chunk no-op.
- [x] Stub test under `vmsplice_writer::stub_tests`: non-Linux / feature-off constructor returns `ErrorKind::Unsupported`.
- [ ] CI: fmt + clippy, nextest (stable), Windows, macOS, Linux musl.