### PR TITLE
refactor(core): remove dead helper in async_ssh_transport per clippy waiver audit

### DIFF
--- a/crates/core/src/client/remote/async_ssh_transport.rs
+++ b/crates/core/src/client/remote/async_ssh_transport.rs
@@ -39,7 +39,7 @@
 //! pulls in `rsync_io/async-ssh` and `dep:tokio`). Default builds remain
 //! on the synchronous transport.
 
-use std::ffi::{OsStr, OsString};
+use std::ffi::OsString;
 use std::io;
 use std::sync::mpsc as std_mpsc;
 use std::sync::{Arc, Mutex};
@@ -47,7 +47,7 @@ use std::time::{Duration, Instant};
 
 use engine::batch::BatchWriter;
 use rsync_io::channel_adapter::{ChannelReader, ChannelWriter};
-use rsync_io::ssh::{AsyncSshTransport, SshConnectConfig, parse_ssh_operand};
+use rsync_io::ssh::{AsyncSshTransport, SshConnectConfig};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::runtime::Builder;
 use tokio::sync::mpsc as tokio_mpsc;
@@ -556,14 +556,6 @@ fn run_blocking_server(
     }
 }
 
-/// Returns `true` when the given operand string designates an SSH-style
-/// remote. Wrapper around [`parse_ssh_operand`] used in tests to confirm
-/// the same operand vocabulary the sync path accepts is recognised here.
-#[allow(dead_code)] // REASON: reserved for upcoming dispatch helpers.
-fn looks_like_ssh_operand(operand: &str) -> bool {
-    parse_ssh_operand(OsStr::new(operand)).is_ok()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -627,13 +619,6 @@ mod tests {
         for v in ["0", "false", "off", "no", "", "True", "YES", "ON"] {
             assert!(!is_truthy_env_value(v), "expected falsey for {v:?}");
         }
-    }
-
-    #[test]
-    fn looks_like_ssh_operand_accepts_user_host_path() {
-        assert!(looks_like_ssh_operand("backup@example.com:/data"));
-        assert!(looks_like_ssh_operand("example.com:/data"));
-        assert!(!looks_like_ssh_operand("/local/path"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Delete the `looks_like_ssh_operand` wrapper in `crates/core/src/client/remote/async_ssh_transport.rs` along with its `#[allow(dead_code)]` waiver and self-referential unit test.
- Drop the now-unused `OsStr` and `parse_ssh_operand` imports.
- Addresses the top-priority entry from the clippy waiver audit (PR #4304, `docs/audits/clippy-waiver-audit-session.md`): the waiver was justified only by a speculative "upcoming dispatch helpers" comment, with no caller in production. Per the no-waivers policy, the cleaner option is to delete the dead helper.

## Test plan
- [ ] CI: fmt+clippy
- [ ] CI: nextest (stable)
- [ ] CI: Windows / macOS / Linux musl