### PR TITLE
ci: wire enforce_limits as informational check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,8 @@ on:
       - 'crates/**'
       - 'src/**'
       - 'tests/**'
-      - 'tools/ci/**'
+      - 'tools/**'
+      - 'xtask/**'
       - 'Cargo.toml'
       - 'Cargo.lock'
       - '.github/workflows/ci.yml'
@@ -22,7 +23,8 @@ on:
       - 'crates/**'
       - 'src/**'
       - 'tests/**'
-      - 'tools/ci/**'
+      - 'tools/**'
+      - 'xtask/**'
       - 'Cargo.toml'
       - 'Cargo.lock'
       - '.github/workflows/ci.yml'
@@ -88,6 +90,38 @@ jobs:
 
       - name: Clippy
         run: cargo clippy --locked --workspace --all-targets --all-features --no-deps
+
+  # ===========================================================================
+  # Enforce LoC Limits - Informational (non-blocking) check
+  # ---------------------------------------------------------------------------
+  # Runs `cargo xtask enforce-limits` to surface files that exceed the per-file
+  # line limits in `tools/line_limits.toml` (workspace default 650). Marked
+  # `continue-on-error: true` while the 19 over-limit files documented in
+  # `docs/audits/module-loc-audit-session.md` are being decomposed. Promote to
+  # a required check once the over-limit count reaches zero.
+  # ===========================================================================
+  enforce-limits:
+    name: enforce-limits (informational)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' || github.event_name == 'push'
+    timeout-minutes: 10
+    continue-on-error: true
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install Rust (stable)
+        uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
+        with:
+          shared-key: ci-${{ runner.os }}-cargo-${{ env.CACHE_VERSION }}-${{ hashFiles('**/Cargo.toml') }}
+          key: enforce-limits
+
+      - name: Run enforce-limits
+        run: cargo xtask enforce-limits
 
   # ===========================================================================
   # Test Job - Full test suite on Linux with toolchain matrix

--- a/docs/audits/module-loc-audit-session.md
+++ b/docs/audits/module-loc-audit-session.md
@@ -1,5 +1,8 @@
 # Module LoC Enforcement Audit
 
+> **Status:** Wired into CI as informational on 2026-05-18; flip to required
+> once over-limit count reaches zero.
+
 `tools/enforce_limits.sh` invokes `cargo xtask enforce-limits`, which walks every
 `.rs` file outside `target/` and `.git/` and fails when a file exceeds either an
 explicit override in `tools/line_limits.toml` or the workspace default of
@@ -247,6 +250,10 @@ fix: move the `mod tests` (if present) into `async_ssh_transport/tests.rs`.
   `count_file_lines` behaviour.
 - 305 additional files (not touched in the last 100 commits) currently fail the
   check. They are out of scope for this audit but should be tracked separately
-  before `enforce-limits` is wired into CI.
-- Until decomposition lands, `enforce-limits` should be invoked manually before
-  publishing a release branch so the warn-threshold output is visible.
+  before `enforce-limits` is promoted to a required CI check.
+- `enforce-limits` runs in CI as an informational (non-blocking) job
+  (`continue-on-error: true`) on every push and pull request. Promote to a
+  required check on branch protection once the over-limit count reaches zero.
+- Until decomposition lands, contributors can also invoke `enforce-limits`
+  manually before publishing a release branch so the warn-threshold output is
+  visible locally.


### PR DESCRIPTION
## Summary

- Add a new `enforce-limits (informational)` job to `.github/workflows/ci.yml` that runs `cargo xtask enforce-limits` on every push and pull request. The job is marked `continue-on-error: true` so it surfaces over-limit files without gating merges while the 19 entries in `docs/audits/module-loc-audit-session.md` are decomposed.
- Expand the workflow `paths` filter from `tools/ci/**` to `tools/**` and add `xtask/**` so changes to `tools/enforce_limits.sh`, `tools/line_limits.toml`, or the `xtask enforce-limits` command itself trigger CI.
- Update `docs/audits/module-loc-audit-session.md` with a status header recording the wiring date and the criterion for promoting the job to a required check (over-limit count reaches zero), and refresh the operational notes to match.

## Test plan

- [ ] CI lint, nextest, platform, and interop jobs pass unchanged.
- [ ] The new `enforce-limits (informational)` job runs and reports current overshoot output; failure does not block the PR.
- [ ] Confirm the job triggers on `xtask/**` and `tools/**` changes (verified via path filter update).
- [ ] Once over-limit count reaches zero, follow up by removing `continue-on-error` and adding the job to branch-protection required checks.