### PR TITLE
refactor: clean up restatement/decorative comments in new session modules

### DIFF
--- a/crates/engine/src/delete/context.rs
+++ b/crates/engine/src/delete/context.rs
@@ -460,8 +460,6 @@ mod tests {
         FileEntry::new_directory(path, 0o755)
     }
 
-    // --- observe_segment_for_delete (DDP-B3 surface) ---------------------
-
     #[test]
     fn disabled_context_publishes_nothing() {
         let dir = TempDir::new().unwrap();
@@ -587,8 +585,6 @@ mod tests {
         assert_eq!(plan.extras.len(), 2);
         assert!(plan.is_sorted());
     }
-
-    // --- timing-mode drain surface (DDP-E1-E5) --------------------------
 
     #[test]
     fn timing_predicates_partition_modes() {

--- a/crates/engine/src/delete/emitter.rs
+++ b/crates/engine/src/delete/emitter.rs
@@ -46,10 +46,6 @@ use super::cohort_index::CohortIndex;
 use super::plan::HardlinkCohortId;
 use super::{DeleteEntryKind, DeletePlan, DeletePlanMap, DirTraversalCursor};
 
-// ----------------------------------------------------------------------------
-// Upstream exit-code constants surfaced by this module.
-// ----------------------------------------------------------------------------
-
 /// Exit code for partial transfers caused by an I/O failure during the
 /// delete pass. Mirrors upstream `errcode.h::RERR_PARTIAL` and
 /// `core::exit_code::ExitCode::PartialTransfer`.
@@ -58,10 +54,6 @@ pub const EMITTER_PARTIAL_EXIT_CODE: i32 = 23;
 /// Exit code reported when a destination entry vanished mid-pass. Mirrors
 /// upstream `errcode.h::RERR_VANISHED` and `core::exit_code::ExitCode::Vanished`.
 pub const EMITTER_VANISHED_EXIT_CODE: i32 = 24;
-
-// ----------------------------------------------------------------------------
-// DeleteFs trait and implementations.
-// ----------------------------------------------------------------------------
 
 /// Filesystem operations the emitter needs to issue a deletion.
 ///
@@ -249,10 +241,6 @@ impl DeleteFs for RecordingDeleteFs {
     }
 }
 
-// ----------------------------------------------------------------------------
-// Error policy.
-// ----------------------------------------------------------------------------
-
 /// Policy controlling how the emitter reacts to per-entry I/O failures.
 ///
 /// Mirrors upstream rsync's `--ignore-errors` and continue-on-error
@@ -288,10 +276,6 @@ impl Default for EmitterErrorPolicy {
         }
     }
 }
-
-// ----------------------------------------------------------------------------
-// Emitter.
-// ----------------------------------------------------------------------------
 
 /// Single-threaded drain task that issues deletions for one transfer.
 ///
@@ -702,11 +686,6 @@ mod tests {
         FileEntry::new_directory(path, 0o755)
     }
 
-    // ------------------------------------------------------------------
-    // Scripted DeleteFs that fails configured paths with configured
-    // errors. Used by the error-policy tests below.
-    // ------------------------------------------------------------------
-
     /// Failure plan: for each (path, errno) pair, the next call against
     /// that path returns the matching error before falling back to the
     /// recording behaviour.
@@ -784,12 +763,6 @@ mod tests {
             self.inner.remove_dir_all(path)
         }
     }
-
-    // ------------------------------------------------------------------
-    // DDP-C1 scaffold tests (kept here verbatim - the dispatch matrix
-    // is still the load-bearing invariant for the upstream-parity check
-    // in section 9.1 of the design).
-    // ------------------------------------------------------------------
 
     #[test]
     fn empty_plan_map_returns_immediately() {
@@ -983,10 +956,6 @@ mod tests {
         assert!(!file.exists());
         assert!(!dir.exists());
     }
-
-    // ------------------------------------------------------------------
-    // DDP-C4 (#2262) - new unit tests for synthetic plan sequences.
-    // ------------------------------------------------------------------
 
     #[test]
     fn mixed_kind_plan_preserves_input_dispatch_order() {
@@ -1282,15 +1251,11 @@ mod tests {
         assert_eq!(emitter.exit_code(), 0);
     }
 
-    // ------------------------------------------------------------------
-    // DDP-D2 (#2264) - hardlink-aware delete via CohortIndex snapshot.
-    //
     // Per `docs/design/hardlink-delete-audit.md` Option A and upstream
     // `delete.c:130-225`, the emitter still unlinks every destination
     // path even when the cohort retains other refs (the kernel
     // reconciles ref counts). The snapshot powers cohort-aware itemize
     // bookkeeping via `cohort_records`, not the unlink decision itself.
-    // ------------------------------------------------------------------
 
     fn tagged_entry(name: &str, kind: DeleteEntryKind, cohort: HardlinkCohortId) -> DeleteEntry {
         DeleteEntry::with_cohort(OsString::from(name), kind, cohort)


### PR DESCRIPTION
## Summary

- Audited new modules added this session (delete pipeline, io_uring helpers, async SSH/listener) for restatement comments, debug checkpoints, decorative banners, and commented-out code per the repo's comment-cleanup rules.
- Only the delete pipeline had violations: long `// -------` banner separators around impl/struct/trait blocks and inside the test module. Removed them, since rustdoc on each item already conveys the structure.
- Preserved every comment that cites upstream rsync source, documents a safety invariant, explains a workaround, or scaffolds non-obvious test setup.

## Audit findings

| Module group | Status |
|--------------|--------|
| `crates/engine/src/delete/{cohort_index,context,emitter,extras,mod,plan,plan_map,traversal}.rs` | Banner separators removed from `emitter.rs` (7 blocks) and `context.rs` (2 blocks). Everything else is upstream/invariant/test-context commentary that adds value. |
| `crates/fast_io/src/io_uring/{cancel,linked_chain,send_zc,session_pool}.rs` | Clean. All `//` comments document SAFETY invariants, kernel-version quirks, or test rationale. |
| `crates/rsync_io/src/ssh/{async_transport,connect,embedded/sync_bridge}.rs` | Clean. Comments cover Drop/EOF semantics, RFC references, and runtime-nesting workarounds. |
| `crates/daemon/src/async_listener.rs` | Clean. Comments explain the tokio<->std bridge invariants and graceful-shutdown polling. |

## Test plan

- [x] `cargo fmt --all` clean.
- [ ] CI: fmt+clippy, nextest stable, Windows, macOS, Linux musl.