### PR TITLE
chore: consolidate common deps into workspace + align stale versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,9 +122,9 @@ mimalloc = { workspace = true }
 [dev-dependencies]
 assert_cmd = "2.0"
 core = { path = "crates/core" }
-filetime = "0.2"
-libc = "0.2"
-tempfile = "3.15"
+filetime = { workspace = true }
+libc = { workspace = true }
+tempfile = { workspace = true }
 checksums = { path = "crates/checksums" }
 protocol = { path = "crates/protocol" }
 
@@ -213,6 +213,36 @@ rpassword = "7"
 is-terminal = "0.4"
 # Secure memory zeroization - audited, widely deployed RAII wrapper
 zeroize = "1"
+# Error derive macro - workspace-wide pin keeps every crate on the same major
+thiserror = "2.0"
+# Temporary file/dir helpers - dev-dep across nearly every crate
+tempfile = "3.15"
+# Raw POSIX/Windows C types - shared across platform-specific code
+libc = "0.2"
+# Substring search helpers (memchr/memmem) - protocol/io hot paths
+memchr = "2.7"
+# Microbenchmark harness - dev-dep across nine crates
+criterion = { version = "0.8", features = ["html_reports"] }
+# Property-based testing - dev-dep across eight crates
+proptest = "1.8"
+# Random number generator - dev-dep across checksums/transfer/rsync_io benches and tests
+rand = "0.10"
+# Lock-free MPMC queues - used by engine/transfer for reorder/work pipelines
+crossbeam-queue = "0.3"
+# Pure-Rust DEFLATE - codec backbone for protocol/compress and xtask packaging
+flate2 = "1.0"
+# File modification time helpers - metadata, engine async, dev tests
+filetime = "0.2"
+# Low-level socket configuration - shared by core and daemon listeners
+socket2 = "0.6"
+# TOML parser - branding/xtask build + tooling
+toml = "1.1"
+# CLI argument parser - shared by cli/daemon/xtask binaries
+clap = { version = "4.5", features = ["std"] }
+# Base64 codec - daemon auth + core module list parsing
+base64 = "0.22"
+# Modern syscall wrappers - used by core, engine, metadata, fast_io
+rustix = "1.1"
 
 [workspace.metadata.docs.rs]
 all-features = true

--- a/crates/apple-fs/Cargo.toml
+++ b/crates/apple-fs/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 version.workspace = true
 
 [dependencies]
-libc = "0.2"
+libc = { workspace = true }
 nix = { version = "0.31", default-features = false, features = ["fs"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
@@ -18,4 +18,4 @@ unicode-normalization = "0.1"
 xattr = "1.6"
 
 [dev-dependencies]
-tempfile = "3.15"
+tempfile = { workspace = true }

--- a/crates/bandwidth/Cargo.toml
+++ b/crates/bandwidth/Cargo.toml
@@ -22,12 +22,12 @@ test-support = []
 async = ["dep:tokio"]
 
 [dependencies]
-memchr = "2.7"
-thiserror = "2.0"
+memchr = { workspace = true }
+thiserror = { workspace = true }
 tokio = { workspace = true, optional = true, features = ["time"] }
 
 [dev-dependencies]
-proptest = "1.8"
+proptest = { workspace = true }
 tokio = { workspace = true, features = ["rt", "macros", "time"] }
 
 [[test]]

--- a/crates/batch/Cargo.toml
+++ b/crates/batch/Cargo.toml
@@ -13,11 +13,11 @@ repository.workspace = true
 zstd = ["protocol/zstd"]
 
 [dependencies]
-thiserror = "2.0"
+thiserror = { workspace = true }
 protocol = { path = "../protocol" }
 metadata = { path = "../metadata" }
-filetime = "0.2"
+filetime = { workspace = true }
 
 [dev-dependencies]
-tempfile = "3.15"
+tempfile = { workspace = true }
 protocol = { path = "../protocol" }

--- a/crates/branding/Cargo.toml
+++ b/crates/branding/Cargo.toml
@@ -13,12 +13,12 @@ build = "build.rs"
 path = "src/lib.rs"
 
 [dependencies]
-thiserror = "2.0"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+thiserror = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
 
 [dev-dependencies]
-toml = "1.1"
+toml = { workspace = true }
 
 [build-dependencies]
-toml = "1.1"
+toml = { workspace = true }

--- a/crates/checksums/Cargo.toml
+++ b/crates/checksums/Cargo.toml
@@ -39,9 +39,9 @@ xxhash-rust = { version = "0.8", default-features = false, features = ["xxh64", 
 # xxh3 crate provides runtime SIMD detection (AVX2 on x86_64, NEON on aarch64)
 xxh3 = { version = "0.1" }
 crc32c = { version = "0.6" }
-thiserror = "2.0"
+thiserror = { workspace = true }
 openssl = { version = "0.10", optional = true }
-rayon = { version = "1.10" }
+rayon = { workspace = true }
 fast_io = { path = "../fast_io", default-features = false }
 logging = { path = "../logging" }
 
@@ -60,10 +60,10 @@ sha1 = { version = "0.10", default-features = false, features = ["std"] }
 sha2 = { version = "0.10", default-features = false, features = ["std"] }
 
 [dev-dependencies]
-proptest = "1.4"
-criterion = { version = "0.8", features = ["html_reports"] }
-rand = "0.8"
-tempfile = "3.14"
+proptest = { workspace = true }
+criterion = { workspace = true }
+rand = { workspace = true }
+tempfile = { workspace = true }
 
 [[bench]]
 name = "checksums_benchmark"

--- a/crates/checksums/benches/checksums_benchmark.rs
+++ b/crates/checksums/benches/checksums_benchmark.rs
@@ -5,7 +5,7 @@
 //! Run with: `cargo bench -p checksums`
 
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
-use rand::Rng;
+use rand::RngExt;
 use std::hint::black_box;
 
 use checksums::RollingChecksum;
@@ -13,7 +13,7 @@ use checksums::strong::{Md4, Md5, Sha1, Sha256, Sha512, Xxh3, Xxh64};
 
 /// Generate random data of the specified size.
 fn generate_random_data(size: usize) -> Vec<u8> {
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
     let mut data = vec![0u8; size];
     rng.fill(&mut data[..]);
     data

--- a/crates/checksums/benches/parallel_benchmark.rs
+++ b/crates/checksums/benches/parallel_benchmark.rs
@@ -5,7 +5,7 @@
 //! Run with: `cargo bench -p checksums --features parallel`
 
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
-use rand::Rng;
+use rand::RngExt;
 use std::hint::black_box;
 
 use checksums::RollingChecksum;
@@ -16,7 +16,7 @@ use checksums::strong::{Md5, Sha256, Xxh3};
 
 /// Generate random data of the specified size.
 fn generate_random_data(size: usize) -> Vec<u8> {
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
     let mut data = vec![0u8; size];
     rng.fill(&mut data[..]);
     data

--- a/crates/checksums/benches/pipelined_benchmark.rs
+++ b/crates/checksums/benches/pipelined_benchmark.rs
@@ -5,7 +5,7 @@
 //! Run with: `cargo bench -p checksums -- pipelined`
 
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
-use rand::Rng;
+use rand::RngExt;
 use std::hint::black_box;
 use std::io::{Cursor, Read};
 
@@ -15,7 +15,7 @@ use checksums::strong::{Md4, Md5, Sha256, StrongDigest, Xxh3};
 
 /// Generate random data of the specified size.
 fn generate_random_data(size: usize) -> Vec<u8> {
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
     let mut data = vec![0u8; size];
     rng.fill(&mut data[..]);
     data

--- a/crates/checksums/src/simd_parity_tests.rs
+++ b/crates/checksums/src/simd_parity_tests.rs
@@ -326,8 +326,8 @@ mod md5_simd_parity {
     /// Test with pseudo-random data at various sizes.
     #[test]
     fn simd_md5_random_data_parity() {
-        use rand::Rng;
-        let mut rng = rand::thread_rng();
+        use rand::RngExt;
+        let mut rng = rand::rng();
 
         let sizes = [
             0, 1, 15, 16, 17, 31, 32, 33, 55, 56, 63, 64, 65, 127, 128, 129, 255, 256, 512, 1000,
@@ -335,7 +335,7 @@ mod md5_simd_parity {
         ];
 
         for &size in &sizes {
-            let data: Vec<u8> = (0..size).map(|_| rng.r#gen()).collect();
+            let data: Vec<u8> = (0..size).map(|_| rng.random()).collect();
             let inputs = vec![data.as_slice()];
 
             let batch_result = simd_batch::digest_batch(&inputs);
@@ -351,14 +351,14 @@ mod md5_simd_parity {
     /// Test batch of random data (multiple inputs at once).
     #[test]
     fn simd_md5_batch_random_data_parity() {
-        use rand::Rng;
-        let mut rng = rand::thread_rng();
+        use rand::RngExt;
+        let mut rng = rand::rng();
 
         // Generate 20 random inputs with varying sizes
         let inputs: Vec<Vec<u8>> = (0..20)
             .map(|_| {
-                let size = rng.gen_range(0..5000);
-                (0..size).map(|_| rng.r#gen()).collect()
+                let size = rng.random_range(0..5000);
+                (0..size).map(|_| rng.random()).collect()
             })
             .collect();
         let input_refs: Vec<&[u8]> = inputs.iter().map(|v| v.as_slice()).collect();
@@ -706,8 +706,8 @@ mod md4_simd_parity {
     /// Test with pseudo-random data at various sizes.
     #[test]
     fn simd_md4_random_data_parity() {
-        use rand::Rng;
-        let mut rng = rand::thread_rng();
+        use rand::RngExt;
+        let mut rng = rand::rng();
 
         let sizes = [
             0, 1, 15, 16, 17, 31, 32, 33, 55, 56, 63, 64, 65, 127, 128, 129, 255, 256, 512, 1000,
@@ -715,7 +715,7 @@ mod md4_simd_parity {
         ];
 
         for &size in &sizes {
-            let data: Vec<u8> = (0..size).map(|_| rng.r#gen()).collect();
+            let data: Vec<u8> = (0..size).map(|_| rng.random()).collect();
             let inputs = vec![data.as_slice()];
 
             let batch_result = md4::digest_batch(&inputs);
@@ -731,13 +731,13 @@ mod md4_simd_parity {
     /// Test batch of random data (multiple inputs at once).
     #[test]
     fn simd_md4_batch_random_data_parity() {
-        use rand::Rng;
-        let mut rng = rand::thread_rng();
+        use rand::RngExt;
+        let mut rng = rand::rng();
 
         let inputs: Vec<Vec<u8>> = (0..20)
             .map(|_| {
-                let size = rng.gen_range(0..5000);
-                (0..size).map(|_| rng.r#gen()).collect()
+                let size = rng.random_range(0..5000);
+                (0..size).map(|_| rng.random()).collect()
             })
             .collect();
         let input_refs: Vec<&[u8]> = inputs.iter().map(|v| v.as_slice()).collect();
@@ -976,13 +976,13 @@ mod xxh3_simd_parity {
     /// Test XXH3-64 with random data at various sizes.
     #[test]
     fn simd_xxh3_64_random_data_parity() {
-        use rand::Rng;
-        let mut rng = rand::thread_rng();
+        use rand::RngExt;
+        let mut rng = rand::rng();
 
         for _ in 0..50 {
-            let size = rng.gen_range(0..20_000);
-            let data: Vec<u8> = (0..size).map(|_| rng.r#gen()).collect();
-            let seed: u64 = rng.r#gen();
+            let size = rng.random_range(0..20_000);
+            let data: Vec<u8> = (0..size).map(|_| rng.random()).collect();
+            let seed: u64 = rng.random();
 
             let one_shot = Xxh3::digest(seed, &data);
 
@@ -1000,13 +1000,13 @@ mod xxh3_simd_parity {
     /// Test XXH3-128 with random data at various sizes.
     #[test]
     fn simd_xxh3_128_random_data_parity() {
-        use rand::Rng;
-        let mut rng = rand::thread_rng();
+        use rand::RngExt;
+        let mut rng = rand::rng();
 
         for _ in 0..50 {
-            let size = rng.gen_range(0..20_000);
-            let data: Vec<u8> = (0..size).map(|_| rng.r#gen()).collect();
-            let seed: u64 = rng.r#gen();
+            let size = rng.random_range(0..20_000);
+            let data: Vec<u8> = (0..size).map(|_| rng.random()).collect();
+            let seed: u64 = rng.random();
 
             let one_shot = Xxh3_128::digest(seed, &data);
 

--- a/crates/checksums/src/strong/md4_tests.rs
+++ b/crates/checksums/src/strong/md4_tests.rs
@@ -437,11 +437,11 @@ mod tests {
 
     #[test]
     fn md4_matches_reference_impl_random_data() {
-        use rand::Rng;
-        let mut rng = rand::thread_rng();
+        use rand::RngExt;
+        let mut rng = rand::rng();
 
         for size in [0, 1, 16, 63, 64, 65, 127, 128, 129, 255, 256, 1000, 10000] {
-            let data: Vec<u8> = (0..size).map(|_| rng.r#gen()).collect();
+            let data: Vec<u8> = (0..size).map(|_| rng.random()).collect();
             let our_digest = Md4::digest(&data);
             let ref_digest: [u8; 16] = md4::Md4::digest(&data).into();
             assert_eq!(our_digest, ref_digest, "Mismatch for size {size}");

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -43,7 +43,7 @@ iconv = ["core/iconv"]
 parallel = ["engine/lazy-metadata", "checksums/parallel"]
 
 [dependencies]
-clap = { version = "4.5.17", features = ["std"] }
+clap = { workspace = true }
 core = { path = "../core", default-features = false }
 engine = { path = "../engine", default-features = false }
 logging = { path = "../logging", features = ["tracing"] }
@@ -55,7 +55,7 @@ rsync_io = { path = "../rsync_io", package = "rsync_io" }
 fast_io = { path = "../fast_io", default-features = false }
 rayon = { workspace = true }
 time = { version = "0.3", default-features = false, features = ["formatting", "macros", "local-offset", "std"] }
-tempfile = "3.15"
+tempfile = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 
@@ -73,16 +73,16 @@ checksums = { path = "../checksums", default-features = false }
 [dev-dependencies]
 assert_cmd = "2.0"
 predicates = "3.1"
-filetime = "0.2"
-tempfile = "3.15"
+filetime = { workspace = true }
+tempfile = { workspace = true }
 test-support = { path = "../test-support" }
 filters = { path = "../filters" }
-rustix = { version = "1.1", features = ["fs"] }
-base64 = "0.22"
-libc = "0.2"
+rustix = { workspace = true, features = ["fs"] }
+base64 = { workspace = true }
+libc = { workspace = true }
 apple-fs = { path = "../apple-fs" }
 serial_test = "3.1"
-criterion = { version = "0.8", features = ["html_reports"] }
+criterion = { workspace = true }
 
 [[bench]]
 name = "startup_benchmark"

--- a/crates/compress/Cargo.toml
+++ b/crates/compress/Cargo.toml
@@ -29,7 +29,7 @@ zlib-rs = ["flate2/zlib-rs"]
 
 [dependencies]
 # Default: miniz_oxide (pure Rust fallback). zlib-ng/zlib-rs override via features.
-flate2 = "1.0"
+flate2 = { workspace = true }
 zstd = { version = "0.13", optional = true }
 lz4_flex = { version = "0.13", optional = true, default-features = false, features = ["frame", "safe-encode", "safe-decode"] }
-thiserror = "2.0"
+thiserror = { workspace = true }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -33,13 +33,13 @@ compress = { path = "../compress" }
 flist = { path = "../flist" }
 logging = { path = "../logging" }
 fast_io = { path = "../fast_io", default-features = false }
-thiserror = "2.0"
+thiserror = { workspace = true }
 tracing = { workspace = true, optional = true }
-libc = "0.2"
-base64 = "0.22"
-tempfile = "3.15"
-socket2 = "0.6"
-filetime = "0.2"
+libc = { workspace = true }
+base64 = { workspace = true }
+tempfile = { workspace = true }
+socket2 = { workspace = true }
+filetime = { workspace = true }
 branding = { path = "../branding" }
 tokio = { workspace = true, optional = true }
 zeroize = { workspace = true }
@@ -47,7 +47,7 @@ zeroize = { workspace = true }
 [target.'cfg(unix)'.dependencies]
 checksums = { path = "../checksums" }
 nix = { version = "0.31", default-features = false, features = ["user"] }
-rustix = { version = "1.1", features = ["process"] }
+rustix = { workspace = true, features = ["process"] }
 
 [target.'cfg(windows)'.dependencies]
 checksums = { path = "../checksums", default-features = false }
@@ -108,11 +108,11 @@ sd-notify = []
 tracing = ["dep:tracing"]
 
 [dev-dependencies]
-filetime = "0.2"
-tempfile = "3.15"
+filetime = { workspace = true }
+tempfile = { workspace = true }
 test-support = { path = "../test-support" }
 tracing-subscriber = { workspace = true }
-criterion = { version = "0.8", features = ["html_reports"] }
+criterion = { workspace = true }
 
 [[bench]]
 name = "transfer_benchmark"

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -35,8 +35,8 @@ acl = ["core/acl", "metadata/acl"]
 iconv = ["core/iconv", "protocol/iconv"]
 
 [dependencies]
-clap = { version = "4.5.49", features = ["std"] }
-base64 = "0.22"
+clap = { workspace = true }
+base64 = { workspace = true }
 dns-lookup = "3.0"
 compress = { path = "../compress" }
 core = { path = "../core", default-features = false }
@@ -45,15 +45,15 @@ platform = { path = "../platform" }
 protocol = { path = "../protocol" }
 logging-sink = { path = "../logging-sink" }
 fs2 = "0.4"
-socket2 = { version = "0.6", features = ["all"] }
-tempfile = "3.15"
+socket2 = { workspace = true, features = ["all"] }
+tempfile = { workspace = true }
 tokio = { workspace = true, optional = true, features = ["net", "io-util", "sync", "rt", "rt-multi-thread", "time", "macros"] }
 dashmap = { workspace = true, optional = true }
 tracing = { workspace = true, optional = true }
 
 [target.'cfg(not(windows))'.dependencies]
 checksums = { path = "../checksums" }
-libc = "0.2"
+libc = { workspace = true }
 
 # sd-notify is Linux-only (systemd notification)
 [target.'cfg(target_os = "linux")'.dependencies]
@@ -67,8 +67,8 @@ windows = { version = "0.62", features = [
 
 [dev-dependencies]
 bandwidth = { path = "../bandwidth", features = ["test-support"] }
-criterion = { version = "0.8", features = ["html_reports"] }
-filetime = "0.2"
+criterion = { workspace = true }
+filetime = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 
 [target.'cfg(unix)'.dev-dependencies]

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -25,18 +25,18 @@ signature = { path = "../signature" }
 matching = { path = "../matching" }
 batch = { path = "../batch" }
 fast_io = { path = "../fast_io", default-features = false }
-thiserror = "2.0"
+thiserror = { workspace = true }
 rayon = { workspace = true }
 crossbeam-channel = { workspace = true }
-crossbeam-queue = "0.3"
+crossbeam-queue = { workspace = true }
 tracing = { workspace = true, optional = true }
 globset = "0.4"
 jwalk = { workspace = true }
 rustc-hash = { workspace = true }
-rustix = { version = "1.1", features = ["fs", "process"] }
-tempfile = "3.15"
+rustix = { workspace = true, features = ["fs", "process"] }
+tempfile = { workspace = true }
 tokio = { workspace = true, optional = true, features = ["fs", "io-util", "sync", "rt"] }
-filetime = { version = "0.2", optional = true }
+filetime = { workspace = true, optional = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 apple-fs = { path = "../apple-fs" }
@@ -50,7 +50,7 @@ windows-sys = { version = "0.61", features = ["Win32_Storage_FileSystem"] }
 
 # libc is needed for O_NOATIME (Linux), clonefile (macOS), posix_fadvise, syncfs
 [target.'cfg(unix)'.dependencies]
-libc = "0.2"
+libc = { workspace = true }
 
 [features]
 default = ["zstd", "lz4", "xattr", "lazy-metadata"]
@@ -121,18 +121,18 @@ async = ["dep:tokio", "dep:filetime"]
 tracing = ["dep:tracing"]
 
 [dev-dependencies]
-filetime = "0.2"
-tempfile = "3.15"
+filetime = { workspace = true }
+tempfile = { workspace = true }
 test-support = { path = "../test-support" }
 bandwidth = { path = "../bandwidth", features = ["test-support"] }
 apple-fs = { path = "../apple-fs" }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
-proptest = "1.8"
+proptest = { workspace = true }
 
 [target.'cfg(unix)'.dev-dependencies]
 xattr = "1.6"
-libc = "0.2"
-criterion = { version = "0.8", features = ["html_reports"] }
+libc = { workspace = true }
+criterion = { workspace = true }
 dashmap = { workspace = true }
 
 [[bench]]

--- a/crates/fast_io/Cargo.toml
+++ b/crates/fast_io/Cargo.toml
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 rayon = { workspace = true }
 logging = { path = "../logging" }
-thiserror = "2.0"
+thiserror = { workspace = true }
 
 # Cached sorting with Schwartzian transform
 permutation = "0.4"
@@ -26,10 +26,10 @@ permutation = "0.4"
 memmap2 = "0.9"
 
 # libc is used for copy_file_range syscall on Linux (always compiled, runtime detection)
-libc = "0.2"
+libc = { workspace = true }
 
 # rustix is used for statx syscall on Linux (always compiled, runtime detection)
-rustix = { version = "1.1", features = ["fs"] }
+rustix = { workspace = true, features = ["fs"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 # Optional: io_uring support (Linux 5.6+)
@@ -81,11 +81,11 @@ vmsplice = []
 windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Networking_WinSock", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_IO", "Win32_System_Pipes", "Win32_System_Threading"] }
 
 [target.'cfg(not(unix))'.dependencies]
-filetime = "0.2"
+filetime = { workspace = true }
 
 [dev-dependencies]
-tempfile = "3.15"
-criterion = { version = "0.8", features = ["html_reports"] }
+tempfile = { workspace = true }
+criterion = { workspace = true }
 
 [[bench]]
 name = "io_optimizations"

--- a/crates/filters/Cargo.toml
+++ b/crates/filters/Cargo.toml
@@ -16,13 +16,13 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 globset = "0.4"
 logging = { path = "../logging" }
-thiserror = "2.0"
+thiserror = { workspace = true }
 tracing = { workspace = true, optional = true }
 
 [features]
 tracing = ["dep:tracing"]
 
 [dev-dependencies]
-proptest = "1.4"
-tempfile = "3.15"
+proptest = { workspace = true }
+tempfile = { workspace = true }
 test-support = { path = "../test-support" }

--- a/crates/flist/Cargo.toml
+++ b/crates/flist/Cargo.toml
@@ -16,21 +16,21 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 logging = { path = "../logging" }
-rayon = { version = "1.10", optional = true }
+rayon = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
-thiserror = "2.0"
+thiserror = { workspace = true }
 
 # For Unix syscalls (fstatat, statx) in batched_stat module
 [target.'cfg(unix)'.dependencies]
-libc = { version = "0.2", optional = true }
+libc = { workspace = true, optional = true }
 
 [dev-dependencies]
-tempfile = "3.15"
+tempfile = { workspace = true }
 test-support = { path = "../test-support" }
 
 [features]
 default = []
 # Parallel file list processing using rayon and batched syscalls
-parallel = ["rayon", "dep:libc"]
+parallel = ["dep:rayon", "dep:libc"]
 # Serialization support for file list types
 serde = ["dep:serde"]

--- a/crates/matching/Cargo.toml
+++ b/crates/matching/Cargo.toml
@@ -18,7 +18,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 signature = { path = "../signature" }
 logging = { path = "../logging" }
 rustc-hash = { workspace = true }
-thiserror = "2.0"
+thiserror = { workspace = true }
 tracing = { workspace = true, optional = true }
 
 [target.'cfg(not(windows))'.dependencies]
@@ -40,10 +40,10 @@ tracing = ["dep:tracing"]
 bench-internal = []
 
 [dev-dependencies]
-criterion = { version = "0.8", features = ["html_reports"] }
-proptest = "1.4"
+criterion = { workspace = true }
+proptest = { workspace = true }
 protocol = { path = "../protocol" }
-tempfile = "3.15"
+tempfile = { workspace = true }
 
 [[bench]]
 name = "delta_matching_benchmark"

--- a/crates/metadata/Cargo.toml
+++ b/crates/metadata/Cargo.toml
@@ -16,11 +16,11 @@ rustdoc-args = ["--cfg", "docsrs", "-D", "rustdoc::broken_intra_doc_links"]
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-filetime = "0.2"
+filetime = { workspace = true }
 protocol = { path = "../protocol" }
-rustix = { version = "1.1", features = ["fs", "process"] }
-libc = "0.2"
-thiserror = "2.0"
+rustix = { workspace = true, features = ["fs", "process"] }
+libc = { workspace = true }
+thiserror = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 xattr = { version = "1.6", optional = true }
@@ -54,5 +54,5 @@ acl = ["dep:exacl"]
 
 [dev-dependencies]
 logging = { path = "../logging" }
-tempfile = "3.15"
+tempfile = { workspace = true }
 test-support = { path = "../test-support" }

--- a/crates/platform/Cargo.toml
+++ b/crates/platform/Cargo.toml
@@ -10,10 +10,10 @@ repository.workspace = true
 publish = false
 
 [dependencies]
-thiserror = "2.0"
+thiserror = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
-libc = "0.2"
+libc = { workspace = true }
 nix = { version = "0.31", default-features = false, features = ["fs", "process", "user"] }
 signal-hook = "0.4"
 
@@ -29,4 +29,4 @@ windows = { version = "0.62", features = [
 ] }
 
 [dev-dependencies]
-tempfile = "3.15"
+tempfile = { workspace = true }

--- a/crates/protocol/Cargo.toml
+++ b/crates/protocol/Cargo.toml
@@ -37,25 +37,25 @@ bytes = { version = "1.9", optional = true }
 compress = { path = "../compress" }
 encoding_rs = { version = "0.8", optional = true }
 # Default: miniz_oxide (pure Rust fallback). zlib-ng/zlib-rs override via features.
-flate2 = "1.0"
+flate2 = { workspace = true }
 logging = { path = "../logging" }
 md-5 = { version = "0.10", default-features = false, features = ["std"] }
-memchr = "2.7"
+memchr = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true, optional = true }
-thiserror = "2.0"
+thiserror = { workspace = true }
 lz4_flex = { version = "0.13", optional = true, default-features = false, features = ["safe-encode", "safe-decode"] }
 zstd = { version = "0.13", optional = true }
-tokio = { version = "1.52", features = ["io-util"], optional = true }
-tokio-util = { version = "0.7", features = ["codec"], optional = true }
+tokio = { workspace = true, features = ["io-util"], optional = true }
+tokio-util = { workspace = true, features = ["codec"], optional = true }
 tracing = { workspace = true, optional = true }
 
 [dev-dependencies]
-criterion = { version = "0.8", features = ["html_reports"] }
-proptest = "1.4"
+criterion = { workspace = true }
+proptest = { workspace = true }
 serde_json = { workspace = true }
-tempfile = "3.15"
-tokio = { version = "1.52", features = ["macros", "rt"] }
+tempfile = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt"] }
 
 [[bench]]
 name = "delta_wire_benchmark"

--- a/crates/rsync_io/Cargo.toml
+++ b/crates/rsync_io/Cargo.toml
@@ -14,10 +14,10 @@ rustdoc-args = ["--cfg", "docsrs", "-D", "rustdoc::broken_intra_doc_links"]
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-thiserror = "2.0"
+thiserror = { workspace = true }
 protocol = { path = "../protocol" }
 logging = { path = "../logging" }
-memchr = "2.7"
+memchr = { workspace = true }
 shell-words = "1.1"
 russh = { workspace = true, optional = true }
 url = { workspace = true, optional = true }
@@ -32,11 +32,11 @@ embedded-ssh = ["dep:russh", "dep:url", "dep:rpassword", "dep:is-terminal", "dep
 async-ssh = ["dep:tokio"]
 
 [dev-dependencies]
-proptest = "1.4"
-rand = "0.10"
-tempfile = "3.15"
+proptest = { workspace = true }
+rand = { workspace = true }
+tempfile = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "rt", "macros", "net", "io-util"] }
-criterion = { version = "0.8", features = ["html_reports"] }
+criterion = { workspace = true }
 aes-gcm = "0.10"
 chacha20poly1305 = "0.10"
 

--- a/crates/signature/Cargo.toml
+++ b/crates/signature/Cargo.toml
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 protocol = { path = "../protocol" }
-thiserror = "2.0"
+thiserror = { workspace = true }
 tracing = { workspace = true, optional = true }
 rayon = { workspace = true }
 
@@ -35,4 +35,4 @@ tracing = ["dep:tracing"]
 parallel = []
 
 [dev-dependencies]
-tempfile = "3.15"
+tempfile = { workspace = true }

--- a/crates/test-support/Cargo.toml
+++ b/crates/test-support/Cargo.toml
@@ -10,4 +10,4 @@ publish = false
 description = "Shared test utilities for the oc-rsync workspace"
 
 [dependencies]
-tempfile = "3.15"
+tempfile = { workspace = true }

--- a/crates/transfer/Cargo.toml
+++ b/crates/transfer/Cargo.toml
@@ -23,9 +23,9 @@ filters = { path = "../filters" }
 compress = { path = "../compress" }
 logging = { path = "../logging" }
 fast_io = { path = "../fast_io", default-features = false }
-crossbeam-queue = "0.3"
+crossbeam-queue = { workspace = true }
 getrandom = "0.4"
-thiserror = "2.0"
+thiserror = { workspace = true }
 tracing = { workspace = true, optional = true }
 rayon = { workspace = true }
 tokio = { workspace = true, optional = true }
@@ -36,7 +36,7 @@ apple-fs = { path = "../apple-fs" }
 
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
 # libc is needed for O_NOATIME flag in source-file open (upstream syscall.c:228,687).
-libc = "0.2"
+libc = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 checksums = { path = "../checksums" }
@@ -128,15 +128,15 @@ async = ["dep:tokio", "dep:tokio-util"]
 tracing = ["dep:tracing"]
 
 [dev-dependencies]
-tempfile = "3.15"
+tempfile = { workspace = true }
 test-support = { path = "../test-support" }
-criterion = "0.8"
-proptest = "1.4"
-rand = "0.9"
+criterion = { workspace = true }
+proptest = { workspace = true }
+rand = { workspace = true }
 crossbeam-channel = { workspace = true }
 
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dev-dependencies]
-filetime = "0.2"
+filetime = { workspace = true }
 
 [[bench]]
 name = "map_file_benchmark"

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -11,16 +11,16 @@ publish = false
 anstyle = "1"
 anyhow = "1"
 camino = "1"
-clap = { version = "4.5", features = ["derive"] }
+clap = { workspace = true, features = ["derive"] }
 branding = { path = "../crates/branding" }
-toml = "1.1"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+toml = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
 cargo_metadata = "0.18"
-flate2 = "1.0.28"
+flate2 = { workspace = true }
 tar = "0.4"
 walkdir = "2"
 which = "8"
 toml_edit = "0.25"
-tempfile = "3.15"
+tempfile = { workspace = true }
 regex = "1"


### PR DESCRIPTION
## Summary

Follow-up to the dependency audit merged in #4317
(`docs/audits/workspace-dependency-audit.md`).

- Add 15 commonly-used deps to `[workspace.dependencies]` and rewrite
  per-crate declarations as `{ workspace = true, ... }`:
  `thiserror`, `tempfile`, `libc`, `memchr`, `criterion`, `proptest`,
  `rand`, `crossbeam-queue`, `flate2`, `filetime`, `socket2`, `toml`,
  `clap`, `base64`, `rustix`.
- Align stale dev-dep versions called out by the audit:
  - `rand` 0.8/0.9/0.10 -> 0.10 everywhere. Migrate the checksums
    tests and benches from the rand 0.8 API
    (`thread_rng`/`r#gen`/`gen_range`) to the 0.10 API
    (`rng()` / `random()` / `random_range` on the `RngExt` trait).
    The transfer reorder bench keeps using `SliceRandom::shuffle` and
    `SmallRng::seed_from_u64`; both remain on the 0.10 surface.
  - `proptest` 1.4 -> 1.8 in checksums, filters, matching, protocol,
    rsync_io, transfer (bandwidth/engine already used 1.8).
  - `tempfile` 3.14 -> 3.15 in checksums (matches everywhere else).
- Switch the `flist/parallel` feature from `rayon` to `dep:rayon` so
  the new workspace-optional declaration stays gated.

The audit doc lists `clap = "4.6"` as the target, but crates.io only
ships up to `4.5.x` and every consumer was already on `4.5`; the
workspace entry is `clap = { version = "4.5", features = ["std"] }`
so `xtask` adds `derive` on top via additive features.

## Test plan

- [ ] CI: fmt + clippy
- [ ] CI: nextest (stable) on Linux/macOS/Windows
- [ ] CI: Linux musl