### PR TITLE
ci: wire unsafe SAFETY comment audit as informational check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,31 @@ jobs:
         run: cargo xtask enforce-limits
 
   # ===========================================================================
+  # Unsafe SAFETY Comment Audit - Informational (non-blocking) check
+  # ---------------------------------------------------------------------------
+  # Runs `tools/audit/unsafe_safety_comment_audit.py` to surface `unsafe { ... }`
+  # blocks that lack a SAFETY justification or whose justification is a
+  # placeholder (TODO/FIXME/empty). Marked `continue-on-error: true` while the
+  # outstanding `fast_io` and `checksums` violations documented in
+  # `docs/audits/unsafe-safety-comment-audit.md` are being addressed. Promote to
+  # a required check once the violation count reaches zero (or a documented
+  # threshold) and the script exits non-zero on regression.
+  # ===========================================================================
+  unsafe-safety-comment-audit:
+    name: unsafe-safety-comment-audit (informational)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' || github.event_name == 'push'
+    timeout-minutes: 5
+    continue-on-error: true
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Run unsafe SAFETY comment audit
+        run: python3 tools/audit/unsafe_safety_comment_audit.py
+
+  # ===========================================================================
   # Test Job - Full test suite on Linux with toolchain matrix
   # ===========================================================================
   test:

--- a/docs/audits/unsafe-safety-comment-audit.md
+++ b/docs/audits/unsafe-safety-comment-audit.md
@@ -1,5 +1,8 @@
 # Unsafe Block SAFETY Comment Audit
 
+> Status: Wired into CI as informational on 2026-05-18; flip to required once
+> violation count reaches 0 (or documented threshold).
+
 ## Scope
 
 Workspace-wide audit of `unsafe { ... }` expression blocks for SAFETY comments


### PR DESCRIPTION
## Summary

- Add `unsafe-safety-comment-audit (informational)` job to `.github/workflows/ci.yml` mirroring the `enforce-limits` pattern. Runs `python3 tools/audit/unsafe_safety_comment_audit.py` on every PR/push with `continue-on-error: true` so it surfaces missing/placeholder `// SAFETY:` annotations without blocking merges.
- Record CI wire-up status at the top of `docs/audits/unsafe-safety-comment-audit.md` with a note to flip to required once the violation count reaches zero (or a documented threshold).
- Promote to a required check once outstanding `fast_io` and `checksums` violations land (PRs in flight).

## Test plan

- [ ] CI runs the new `unsafe-safety-comment-audit (informational)` job on this PR.
- [ ] Job completes successfully (script exits 0 today; informational status preserved).
- [ ] `enforce-limits` and other required checks remain green.