### PR TITLE
refactor(checksums): add SAFETY comments to SIMD unsafe blocks (audit followup)

### DIFF
--- a/crates/checksums/src/rolling/checksum/neon.rs
+++ b/crates/checksums/src/rolling/checksum/neon.rs
@@ -149,5 +149,9 @@ pub(crate) fn accumulate_chunk_neon_for_tests(
         return accumulate_chunk_scalar_raw(s1, s2, len, chunk);
     }
 
+    // SAFETY: NEON availability was verified above via `neon_available()`
+    // (`is_aarch64_feature_detected!("neon")` cached in a `OnceLock`).
+    // `chunk` is a valid `&[u8]` borrow; the implementation processes 16-byte
+    // blocks with bounds checks and falls back to scalar for any remainder.
     unsafe { accumulate_chunk_neon_impl(s1, s2, len, chunk) }
 }

--- a/crates/checksums/src/rolling/checksum/x86.rs
+++ b/crates/checksums/src/rolling/checksum/x86.rs
@@ -324,6 +324,11 @@ pub(crate) fn accumulate_chunk_sse2_for_tests(
     len: usize,
     chunk: &[u8],
 ) -> (u32, u32, usize) {
+    // SAFETY: SSE2 is part of the x86_64 baseline ABI, so the `target_feature
+    // = "sse2"` precondition on `accumulate_chunk_sse2` is always satisfied
+    // here. `chunk` is a valid `&[u8]` borrow; the SIMD implementation uses
+    // unaligned loads (`_mm_loadu_si128`) and bounds-checks each 16-byte
+    // block before consuming it, falling back to scalar for the remainder.
     unsafe { accumulate_chunk_sse2(s1, s2, len, chunk) }
 }
 
@@ -334,5 +339,11 @@ pub(crate) fn accumulate_chunk_avx2_for_tests(
     len: usize,
     chunk: &[u8],
 ) -> (u32, u32, usize) {
+    // SAFETY: This helper is only invoked from tests gated on
+    // `is_x86_feature_detected!("avx2")`, satisfying the `target_feature =
+    // "avx2"` precondition of `accumulate_chunk_avx2`. `chunk` is a valid
+    // `&[u8]` borrow; the SIMD implementation uses unaligned loads
+    // (`_mm256_loadu_si256`) and bounds-checks each 32-byte block before
+    // consuming it, falling back to scalar for any remainder.
     unsafe { accumulate_chunk_avx2(s1, s2, len, chunk) }
 }

--- a/crates/checksums/src/simd_batch/md4/simd/avx2.rs
+++ b/crates/checksums/src/simd_batch/md4/simd/avx2.rs
@@ -245,6 +245,12 @@ mod tests {
             b"test input 7",
         ];
 
+        // SAFETY: AVX2 availability was verified above via
+        // `is_x86_feature_detected!("avx2")`, satisfying the
+        // `target_feature = "avx2"` precondition of `digest_x8`. `inputs` is
+        // a fixed-length array of 8 valid `&[u8]` borrows; `digest_x8`
+        // internally bounds-checks each lane and falls back to scalar for
+        // lengths above `MAX_INPUT_SIZE`.
         let results = unsafe { digest_x8(&inputs) };
 
         for (i, input) in inputs.iter().enumerate() {
@@ -287,6 +293,11 @@ mod tests {
             "31d6cfe0d16ae931b73c59d7e0c089c0",
         ];
 
+        // SAFETY: AVX2 availability was verified above via
+        // `is_x86_feature_detected!("avx2")`, satisfying the
+        // `target_feature = "avx2"` precondition of `digest_x8`. `inputs` is
+        // a fixed-length array of 8 valid `&[u8]` borrows that outlive the
+        // call; `digest_x8` bounds-checks each lane.
         let results = unsafe { digest_x8(&inputs) };
 
         for i in 0..8 {
@@ -319,6 +330,11 @@ mod tests {
             &input0, &input1, &input2, &input3, &input4, &input5, &input6, &input7,
         ];
 
+        // SAFETY: AVX2 availability was verified above via
+        // `is_x86_feature_detected!("avx2")`, satisfying the
+        // `target_feature = "avx2"` precondition of `digest_x8`. `inputs`
+        // borrows 8 owned `Vec<u8>` buffers that outlive the call;
+        // `digest_x8` bounds-checks each lane independently.
         let results = unsafe { digest_x8(&inputs) };
 
         for (i, input) in inputs.iter().enumerate() {

--- a/crates/checksums/src/simd_batch/md4/simd/avx512.rs
+++ b/crates/checksums/src/simd_batch/md4/simd/avx512.rs
@@ -433,6 +433,11 @@ mod tests {
             b"test input 15",
         ];
 
+        // SAFETY: AVX-512F and AVX-512BW availability were verified above
+        // via `is_x86_feature_detected!`, satisfying the
+        // `target_feature = "avx512f,avx512bw"` precondition of
+        // `digest_x16`. `inputs` is a fixed-length array of 16 valid
+        // `&[u8]` borrows; `digest_x16` bounds-checks each lane.
         let results = unsafe { digest_x16(&inputs) };
 
         for (i, input) in inputs.iter().enumerate() {
@@ -491,6 +496,11 @@ mod tests {
             "bde52cb31de33e46245e05fbdbd6fb24",
         ];
 
+        // SAFETY: AVX-512F and AVX-512BW availability were verified above
+        // via `is_x86_feature_detected!`, satisfying the
+        // `target_feature = "avx512f,avx512bw"` precondition of
+        // `digest_x16`. `inputs` is a fixed-length array of 16 valid
+        // `&[u8]` borrows that outlive the call.
         let results = unsafe { digest_x16(&inputs) };
 
         for i in 0..16 {
@@ -532,6 +542,11 @@ mod tests {
             &input9, &input10, &input11, &input12, &input13, &input14, &input15,
         ];
 
+        // SAFETY: AVX-512F and AVX-512BW availability were verified above
+        // via `is_x86_feature_detected!`, satisfying the
+        // `target_feature = "avx512f,avx512bw"` precondition of
+        // `digest_x16`. `inputs` borrows 16 owned `Vec<u8>` buffers that
+        // outlive the call; `digest_x16` bounds-checks each lane.
         let results = unsafe { digest_x16(&inputs) };
 
         for (i, input) in inputs.iter().enumerate() {

--- a/crates/checksums/src/simd_batch/md4/simd/neon.rs
+++ b/crates/checksums/src/simd_batch/md4/simd/neon.rs
@@ -275,6 +275,10 @@ mod tests {
     fn neon_md4_matches_scalar() {
         let inputs: [&[u8]; 4] = [b"", b"a", b"abc", b"message digest"];
 
+        // SAFETY: NEON is mandatory on aarch64 (ARMv8-A baseline), so
+        // `digest_x4`'s "NEON available" precondition holds whenever this
+        // module is compiled in (gated by `#[cfg(target_arch = "aarch64")]`).
+        // `inputs` is a fixed-length array of 4 valid `&[u8]` borrows.
         let results = unsafe { digest_x4(&inputs) };
 
         for (i, input) in inputs.iter().enumerate() {
@@ -299,6 +303,10 @@ mod tests {
             "d9130a8164549fe818874806e1c7014b",
         ];
 
+        // SAFETY: NEON is mandatory on aarch64 (ARMv8-A baseline), so
+        // `digest_x4`'s "NEON available" precondition holds whenever this
+        // module is compiled in. `inputs` is a fixed-length array of 4
+        // valid `&[u8]` borrows that outlive the call.
         let results = unsafe { digest_x4(&inputs) };
 
         for i in 0..4 {
@@ -320,6 +328,10 @@ mod tests {
 
         let inputs: [&[u8]; 4] = [&input0, &input1, &input2, &input3];
 
+        // SAFETY: NEON is mandatory on aarch64 (ARMv8-A baseline), so
+        // `digest_x4`'s "NEON available" precondition holds whenever this
+        // module is compiled in. `inputs` borrows 4 owned `Vec<u8>` buffers
+        // that outlive the call; `digest_x4` bounds-checks each lane.
         let results = unsafe { digest_x4(&inputs) };
 
         for (i, input) in inputs.iter().enumerate() {

--- a/crates/checksums/src/simd_batch/md4/simd/sse2.rs
+++ b/crates/checksums/src/simd_batch/md4/simd/sse2.rs
@@ -292,6 +292,10 @@ mod tests {
     fn sse2_md4_matches_scalar() {
         let inputs: [&[u8]; 4] = [b"", b"a", b"abc", b"message digest"];
 
+        // SAFETY: SSE2 is part of the x86_64 baseline ABI, so the
+        // `target_feature = "sse2"` precondition of `digest_x4` is always
+        // satisfied on every x86_64 CPU. `inputs` is a fixed-length array
+        // of 4 valid `&[u8]` borrows; `digest_x4` bounds-checks each lane.
         let results = unsafe { digest_x4(&inputs) };
 
         for (i, input) in inputs.iter().enumerate() {
@@ -316,6 +320,10 @@ mod tests {
             "d9130a8164549fe818874806e1c7014b",
         ];
 
+        // SAFETY: SSE2 is part of the x86_64 baseline ABI, so the
+        // `target_feature = "sse2"` precondition of `digest_x4` always
+        // holds. `inputs` is a fixed-length array of 4 valid `&[u8]`
+        // borrows that outlive the call.
         let results = unsafe { digest_x4(&inputs) };
 
         for i in 0..4 {
@@ -336,6 +344,10 @@ mod tests {
 
         let inputs: [&[u8]; 4] = [&input0, &input1, &input2, &input3];
 
+        // SAFETY: SSE2 is part of the x86_64 baseline ABI, so the
+        // `target_feature = "sse2"` precondition of `digest_x4` always
+        // holds. `inputs` borrows 4 owned `Vec<u8>` buffers that outlive
+        // the call; `digest_x4` bounds-checks each lane.
         let results = unsafe { digest_x4(&inputs) };
 
         for (i, input) in inputs.iter().enumerate() {

--- a/crates/checksums/src/simd_batch/md5_simd/avx2.rs
+++ b/crates/checksums/src/simd_batch/md5_simd/avx2.rs
@@ -316,6 +316,12 @@ mod tests {
             b"test input 7",
         ];
 
+        // SAFETY: AVX2 availability was verified above via
+        // `is_x86_feature_detected!("avx2")`, satisfying the
+        // `target_feature = "avx2"` precondition of `digest_x8`. `inputs`
+        // is a fixed-length array of 8 valid `&[u8]` borrows; `digest_x8`
+        // internally bounds-checks each lane and falls back to scalar
+        // for lengths above `MAX_INPUT_SIZE`.
         let results = unsafe { digest_x8(&inputs) };
 
         for (i, input) in inputs.iter().enumerate() {
@@ -358,6 +364,11 @@ mod tests {
             "d41d8cd98f00b204e9800998ecf8427e",
         ];
 
+        // SAFETY: AVX2 availability was verified above via
+        // `is_x86_feature_detected!("avx2")`, satisfying the
+        // `target_feature = "avx2"` precondition of `digest_x8`. `inputs`
+        // is a fixed-length array of 8 valid `&[u8]` borrows that outlive
+        // the call.
         let results = unsafe { digest_x8(&inputs) };
 
         for i in 0..8 {
@@ -390,6 +401,11 @@ mod tests {
             &input0, &input1, &input2, &input3, &input4, &input5, &input6, &input7,
         ];
 
+        // SAFETY: AVX2 availability was verified above via
+        // `is_x86_feature_detected!("avx2")`, satisfying the
+        // `target_feature = "avx2"` precondition of `digest_x8`. `inputs`
+        // borrows 8 owned `Vec<u8>` buffers that outlive the call;
+        // `digest_x8` bounds-checks each lane independently.
         let results = unsafe { digest_x8(&inputs) };
 
         for (i, input) in inputs.iter().enumerate() {

--- a/crates/checksums/src/simd_batch/md5_simd/avx512.rs
+++ b/crates/checksums/src/simd_batch/md5_simd/avx512.rs
@@ -1159,6 +1159,11 @@ mod tests {
             b"test input 15",
         ];
 
+        // SAFETY: AVX-512F and AVX-512BW availability were verified above
+        // via `is_x86_feature_detected!`, satisfying the
+        // `target_feature = "avx512f,avx512bw"` precondition of
+        // `digest_x16`. `inputs` is a fixed-length array of 16 valid
+        // `&[u8]` borrows; `digest_x16` bounds-checks each lane.
         let results = unsafe { digest_x16(&inputs) };
 
         for (i, input) in inputs.iter().enumerate() {
@@ -1219,6 +1224,11 @@ mod tests {
             "0cc175b9c0f1b6a831c399e269772661",
         ];
 
+        // SAFETY: AVX-512F and AVX-512BW availability were verified above
+        // via `is_x86_feature_detected!`, satisfying the
+        // `target_feature = "avx512f,avx512bw"` precondition of
+        // `digest_x16`. `inputs` is a fixed-length array of 16 valid
+        // `&[u8]` borrows that outlive the call.
         let results = unsafe { digest_x16(&inputs) };
 
         for i in 0..16 {
@@ -1262,6 +1272,11 @@ mod tests {
             &input9, &input10, &input11, &input12, &input13, &input14, &input15,
         ];
 
+        // SAFETY: AVX-512F and AVX-512BW availability were verified above
+        // via `is_x86_feature_detected!`, satisfying the
+        // `target_feature = "avx512f,avx512bw"` precondition of
+        // `digest_x16`. `inputs` borrows 16 owned `Vec<u8>` buffers that
+        // outlive the call; `digest_x16` bounds-checks each lane.
         let results = unsafe { digest_x16(&inputs) };
 
         for (i, input) in inputs.iter().enumerate() {

--- a/crates/checksums/src/simd_batch/md5_simd/neon.rs
+++ b/crates/checksums/src/simd_batch/md5_simd/neon.rs
@@ -341,6 +341,10 @@ mod tests {
     fn neon_md5_matches_scalar() {
         let inputs: [&[u8]; 4] = [b"", b"a", b"abc", b"message digest"];
 
+        // SAFETY: NEON is mandatory on aarch64 (ARMv8-A baseline), so
+        // `digest_x4`'s "NEON available" precondition holds whenever this
+        // module is compiled in (gated by `#[cfg(target_arch = "aarch64")]`).
+        // `inputs` is a fixed-length array of 4 valid `&[u8]` borrows.
         let results = unsafe { digest_x4(&inputs) };
 
         for (i, input) in inputs.iter().enumerate() {
@@ -365,6 +369,10 @@ mod tests {
             "f96b697d7cb7938d525a2f31aaf161d0",
         ];
 
+        // SAFETY: NEON is mandatory on aarch64 (ARMv8-A baseline), so
+        // `digest_x4`'s "NEON available" precondition holds whenever this
+        // module is compiled in. `inputs` is a fixed-length array of 4
+        // valid `&[u8]` borrows that outlive the call.
         let results = unsafe { digest_x4(&inputs) };
 
         for i in 0..4 {
@@ -385,6 +393,11 @@ mod tests {
 
         let inputs: [&[u8]; 4] = [&input0, &input1, &input2, &input3];
 
+        // SAFETY: NEON is mandatory on aarch64 (ARMv8-A baseline), so
+        // `digest_x4`'s "NEON available" precondition holds whenever this
+        // module is compiled in. `inputs` borrows 4 owned `Vec<u8>`
+        // buffers that outlive the call; `digest_x4` bounds-checks each
+        // lane.
         let results = unsafe { digest_x4(&inputs) };
 
         for (i, input) in inputs.iter().enumerate() {

--- a/crates/checksums/src/simd_batch/md5_simd/sse2.rs
+++ b/crates/checksums/src/simd_batch/md5_simd/sse2.rs
@@ -409,6 +409,10 @@ mod tests {
     fn sse2_matches_scalar() {
         let inputs: [&[u8]; 4] = [b"", b"a", b"abc", b"message digest"];
 
+        // SAFETY: SSE2 is part of the x86_64 baseline ABI, so the
+        // `target_feature = "sse2"` precondition of `digest_x4` always
+        // holds on every x86_64 CPU. `inputs` is a fixed-length array of
+        // 4 valid `&[u8]` borrows; `digest_x4` bounds-checks each lane.
         let results = unsafe { digest_x4(&inputs) };
 
         for (i, input) in inputs.iter().enumerate() {
@@ -433,6 +437,10 @@ mod tests {
             "f96b697d7cb7938d525a2f31aaf161d0",
         ];
 
+        // SAFETY: SSE2 is part of the x86_64 baseline ABI, so the
+        // `target_feature = "sse2"` precondition of `digest_x4` always
+        // holds. `inputs` is a fixed-length array of 4 valid `&[u8]`
+        // borrows that outlive the call.
         let results = unsafe { digest_x4(&inputs) };
 
         for i in 0..4 {
@@ -453,6 +461,10 @@ mod tests {
 
         let inputs: [&[u8]; 4] = [&input0, &input1, &input2, &input3];
 
+        // SAFETY: SSE2 is part of the x86_64 baseline ABI, so the
+        // `target_feature = "sse2"` precondition of `digest_x4` always
+        // holds. `inputs` borrows 4 owned `Vec<u8>` buffers that outlive
+        // the call; `digest_x4` bounds-checks each lane.
         let results = unsafe { digest_x4(&inputs) };
 
         for (i, input) in inputs.iter().enumerate() {

--- a/crates/checksums/src/simd_batch/md5_simd/sse41.rs
+++ b/crates/checksums/src/simd_batch/md5_simd/sse41.rs
@@ -388,6 +388,11 @@ mod tests {
         }
 
         let inputs: [&[u8]; 4] = [b"", b"a", b"abc", b"message digest"];
+        // SAFETY: SSE4.1 availability was verified above via
+        // `is_x86_feature_detected!("sse4.1")`, satisfying the
+        // `target_feature = "sse4.1"` precondition of `digest_x4`.
+        // `inputs` is a fixed-length array of 4 valid `&[u8]` borrows;
+        // `digest_x4` bounds-checks each lane.
         let results = unsafe { digest_x4(&inputs) };
 
         for (i, input) in inputs.iter().enumerate() {
@@ -414,6 +419,11 @@ mod tests {
             "f96b697d7cb7938d525a2f31aaf161d0",
         ];
 
+        // SAFETY: SSE4.1 availability was verified above via
+        // `is_x86_feature_detected!("sse4.1")`, satisfying the
+        // `target_feature = "sse4.1"` precondition of `digest_x4`.
+        // `inputs` is a fixed-length array of 4 valid `&[u8]` borrows
+        // that outlive the call.
         let results = unsafe { digest_x4(&inputs) };
 
         for i in 0..4 {

--- a/crates/checksums/src/simd_batch/md5_simd/ssse3.rs
+++ b/crates/checksums/src/simd_batch/md5_simd/ssse3.rs
@@ -390,6 +390,11 @@ mod tests {
         }
 
         let inputs: [&[u8]; 4] = [b"", b"a", b"abc", b"message digest"];
+        // SAFETY: SSSE3 availability was verified above via
+        // `is_x86_feature_detected!("ssse3")`, satisfying the
+        // `target_feature = "ssse3"` precondition of `digest_x4`.
+        // `inputs` is a fixed-length array of 4 valid `&[u8]` borrows;
+        // `digest_x4` bounds-checks each lane.
         let results = unsafe { digest_x4(&inputs) };
 
         for (i, input) in inputs.iter().enumerate() {
@@ -416,6 +421,11 @@ mod tests {
             "f96b697d7cb7938d525a2f31aaf161d0",
         ];
 
+        // SAFETY: SSSE3 availability was verified above via
+        // `is_x86_feature_detected!("ssse3")`, satisfying the
+        // `target_feature = "ssse3"` precondition of `digest_x4`.
+        // `inputs` is a fixed-length array of 4 valid `&[u8]` borrows
+        // that outlive the call.
         let results = unsafe { digest_x4(&inputs) };
 
         for i in 0..4 {

--- a/docs/audits/unsafe-safety-comment-audit.md
+++ b/docs/audits/unsafe-safety-comment-audit.md
@@ -20,7 +20,7 @@ Methodology:
 5. Cross-reference each crate against the permitted-unsafe list in
    `CLAUDE.md`.
 
-The audit script is checked in at `tools/audit_unsafe.py`.
+The audit script is checked in at `tools/audit/unsafe_safety_comment_audit.py`.
 
 ## Permitted vs. forbidden crates
 
@@ -78,9 +78,11 @@ serialise environment-variable mutations during tests).
 
 ## Missing SAFETY comments
 
-`CLAUDE.md` requires every `unsafe { ... }` block to be preceded by a SAFETY
-comment explaining the invariants the caller relies on. After the quick-win
-fixes in this PR the violation count dropped from **356** down to **176**.
+The unsafe-code policy requires every `unsafe { ... }` block to be preceded by
+a SAFETY comment explaining the invariants the caller relies on. After the
+quick-win fixes shipped in the earlier audit PR the violation count dropped
+from **356** down to **176**, and the follow-up SIMD pass in this PR brings it
+further to **145**.
 
 | Crate            | Missing (before) | Missing (after) | Notes |
 |------------------|-----------------:|----------------:|-------|
@@ -92,15 +94,15 @@ fixes in this PR the violation count dropped from **356** down to **176**.
 | `flist`          | 8                | 0               | Fixed: `batched_stat/dir_stat.rs` and `batched_stat/statx_support.rs` (`fstatat`/`statx` syscalls + zeroed POD buffers). |
 | `metadata`       | 16               | 0               | Fixed: `permission_tests.rs` (`umask`), `copy_as.rs` (`geteuid`/`getegid`), `apply/timestamps.rs` (zeroed `attrlist`). |
 | `platform`       | 14               | 0               | Fixed: `signal.rs` (`SetConsoleCtrlHandler`), `env.rs` (test-only env mutations under `TEST_LOCK`). |
-| `checksums`      | 31               | 31              | Outstanding. All 31 are test calls to `unsafe fn digest_xN(&inputs)` and `unsafe fn accumulate_chunk_*`. Recommendation: add a single SAFETY block per test function referencing the relevant `target_feature` precondition (`SSE2` is x86_64 baseline, NEON is mandatory on aarch64, AVX2/AVX-512/SSSE3/SSE4.1 are runtime-detected before the test runs). Mechanical follow-up. |
+| `checksums`      | 31               | 0               | Fixed in the SIMD follow-up: rolling-checksum `accumulate_chunk_{neon,sse2,avx2}` wrappers plus every MD4/MD5 batched-lane test (`digest_x4`/`x8`/`x16` for NEON, SSE2, SSSE3, SSE4.1, AVX2, AVX-512). Each SAFETY note cites the CPU feature gate (runtime `is_x86_feature_detected!` for AVX2/AVX-512/SSSE3/SSE4.1, baseline SSE2 on x86_64, mandatory NEON on aarch64) plus slice validity. |
 | `fast_io`        | 222              | 124             | Outstanding. Heaviest concentrations: `splice.rs` (50), `sendfile.rs` (24), `io_uring/buffer_ring.rs` (13), `io_uring/statx.rs` (5), test fixtures (`splice_integration.rs`, `io_uring_stub/tests.rs`, `iocp_*_integration.rs`). Recommendation: most are pure libc `pipe`/`close`/`socketpair` test scaffolding and warrant a single SAFETY note per helper function rather than per call. The 13 ring-buffer pointer arithmetic blocks in `buffer_ring.rs` deserve full per-block invariants because they manipulate kernel-shared memory. |
 | `windows-gnu-eh` | 13               | 13              | Outstanding. The crate's documentation covers the load-and-cache pattern but individual blocks lack SAFETY notes. Recommendation: add a SAFETY note at the top of each `extern "system"` resolver explaining (1) module-handle lifetime semantics, (2) function-pointer transmute conditions, and (3) thread-safety of the `OnceLock` cache. |
 
-After the fixes in this PR: **571 unsafe blocks, 176 still missing SAFETY
-comments** (-180, -50.5%). All seven crates listed as "Fixed" above now have
-zero outstanding violations.
+After the SIMD follow-up: **571 unsafe blocks, 145 still missing SAFETY
+comments** (-211 vs. the original 356, -59%). All eight crates listed as
+"Fixed" above (now including `checksums`) have zero outstanding violations.
 
-## Fixes applied in this PR
+## Fixes applied in the original audit PR
 
 The following files were updated with SAFETY justifications:
 
@@ -121,6 +123,21 @@ The following files were updated with SAFETY justifications:
 - `crates/platform/src/env.rs`
 - `crates/platform/src/signal.rs`
 
+## Fixes applied in the SIMD follow-up
+
+- `crates/checksums/src/rolling/checksum/neon.rs`
+- `crates/checksums/src/rolling/checksum/x86.rs`
+- `crates/checksums/src/simd_batch/md4/simd/avx2.rs`
+- `crates/checksums/src/simd_batch/md4/simd/avx512.rs`
+- `crates/checksums/src/simd_batch/md4/simd/neon.rs`
+- `crates/checksums/src/simd_batch/md4/simd/sse2.rs`
+- `crates/checksums/src/simd_batch/md5_simd/avx2.rs`
+- `crates/checksums/src/simd_batch/md5_simd/avx512.rs`
+- `crates/checksums/src/simd_batch/md5_simd/neon.rs`
+- `crates/checksums/src/simd_batch/md5_simd/sse2.rs`
+- `crates/checksums/src/simd_batch/md5_simd/sse41.rs`
+- `crates/checksums/src/simd_batch/md5_simd/ssse3.rs`
+
 Common patterns documented:
 
 - **Env-guard helpers** (10 sites). `std::env::{set_var, remove_var}` became
@@ -136,27 +153,25 @@ Common patterns documented:
 
 ## Follow-up tasks
 
-1. **checksums SIMD tests** (31 blocks). Add per-test-function SAFETY blocks
-   citing the relevant target-feature gate.
-2. **fast_io splice/sendfile test scaffolding** (~74 blocks). Add one SAFETY
+1. **fast_io splice/sendfile test scaffolding** (~74 blocks). Add one SAFETY
    block per helper (most blocks are duplicate `libc::close(fd)` calls that
    share the same justification: the fd was created by the test and is no
    longer in use).
-3. **fast_io `io_uring/buffer_ring.rs` pointer arithmetic** (13 blocks).
+2. **fast_io `io_uring/buffer_ring.rs` pointer arithmetic** (13 blocks).
    Document the kernel-shared mmap region invariants (entry count, alignment,
    tail update ordering).
-4. **windows-gnu-eh resolver chain** (13 blocks). Document the
+3. **windows-gnu-eh resolver chain** (13 blocks). Document the
    `OnceLock`-cached `GetProcAddress` lifecycle once at the top of the
    resolver helpers.
-5. **Policy follow-up**: either migrate the unsafe code in `platform`,
+4. **Policy follow-up**: either migrate the unsafe code in `platform`,
    `windows-gnu-eh`, `core`, `cli`, `flist`, `daemon`, `embedding`, and
-   `branding` into the permitted crates, or extend the `CLAUDE.md` allowlist
+   `branding` into the permitted crates, or extend the unsafe-code allowlist
    with explicit, narrow exceptions.
 
 ## Reproducing the audit
 
 ```sh
-python3 tools/audit_unsafe.py
+python3 tools/audit/unsafe_safety_comment_audit.py
 ```
 
 The script prints per-crate block counts, total counts, and a violations table


### PR DESCRIPTION
## Summary

Follow-up to the earlier unsafe-block audit. Adds SAFETY comments to the
31 remaining `unsafe { ... }` blocks in `crates/checksums/` flagged by
`tools/audit/unsafe_safety_comment_audit.py`.

Each SAFETY note cites:

- the CPU feature gate that satisfies the callee's `target_feature`
  precondition (runtime `is_x86_feature_detected!` for AVX2/AVX-512/SSSE3/
  SSE4.1, baseline SSE2 on x86_64, mandatory NEON on aarch64);
- the validity and lifetime of the slice arguments handed to the SIMD
  helpers; and
- the bounds-checking and scalar-fallback contract upheld by the callee.

Covers the rolling-checksum `accumulate_chunk_{neon,sse2,avx2}` wrappers
plus every MD4 and MD5 batched-lane test (`digest_x4`, `digest_x8`,
`digest_x16` across NEON, SSE2, SSSE3, SSE4.1, AVX2, AVX-512).

Workspace audit total drops from **176** to **145** violations;
`checksums` goes from **31** to **0**. No code semantics change - comments
only - and `docs/audits/unsafe-safety-comment-audit.md` is refreshed with
the new totals and the SIMD follow-up file list.

## Test plan

- [x] `python3 tools/audit/unsafe_safety_comment_audit.py` reports
      0 checksums violations (down from 31).
- [x] `cargo fmt --all` clean.
- [ ] CI: fmt+clippy, nextest (stable), Windows, macOS, Linux musl.