### PR TITLE
test(interop): ACL/xattr round-trip parity with upstream rsync 3.4.1

### DIFF
--- a/tests/acl_xattr_roundtrip_linux.rs
+++ b/tests/acl_xattr_roundtrip_linux.rs
@@ -1,0 +1,312 @@
+//! Linux round-trip parity: POSIX ACLs + NFSv4 ACLs + xattrs vs upstream
+//! rsync 3.4.1 with `-aAX`.
+//!
+//! Builds a source tree under `/tmp`, stamps each file with a mix of
+//! - POSIX access ACLs and default ACLs (`setfacl -m u:nobody:rwx,d:u:nobody:rwx`),
+//! - user xattrs (`user.test.color=blue`), and
+//! - system xattrs where the kernel permits them,
+//!
+//! then runs the tree through two round-trips:
+//! - `oc-rsync -aAX src/ dst1/` then `rsync -aAX dst1/ dst2/`
+//! - `rsync -aAX src/ dst1/` then `oc-rsync -aAX dst1/ dst2/`
+//!
+//! After each round-trip the harness compares per-path ACL text and xattr
+//! key/value pairs between `src/` and `dst2/`. A divergence here points at
+//! a wire-format incompatibility between the two implementations.
+//!
+//! GATE: `OC_RSYNC_METADATA_INTEROP=1`. Skips cleanly when unset or when
+//! the surrounding tooling/filesystem cannot satisfy the fixture.
+//!
+//! Upstream source references:
+//! - `acls.c:rsync_xal_h2l()` / `rsync_xal_l2h()` - host/wire ACL conversion.
+//! - `xattrs.c:rsync_xal_get()` / `rsync_xal_set()` - xattr enumeration.
+
+#![cfg(target_os = "linux")]
+
+mod integration;
+
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use integration::acl_xattr_interop_harness::{
+    GATE_ENV_VAR, MetadataRecord, aax_args, command_on_path, diff_snapshots, gate_enabled,
+    locate_oc_rsync, locate_upstream_rsync, make_scratch, run_rsync, skip, snapshot,
+};
+
+/// Tools the Linux fixture needs in `PATH`. Missing any of them -> skip.
+const REQUIRED_TOOLS: &[&str] = &["setfacl", "getfacl", "setfattr", "getfattr"];
+
+#[test]
+fn acl_xattr_roundtrip_linux_oc_then_upstream() {
+    let Some(ctx) = TestContext::try_setup() else {
+        return;
+    };
+    let TestContext {
+        _dir,
+        src,
+        dst1,
+        dst2,
+        oc_bin,
+        upstream_bin,
+    } = ctx;
+
+    // Leg 1: oc-rsync sender -> dst1.
+    run_rsync(&oc_bin, &aax_args(&src, &dst1)).expect("oc-rsync src -> dst1 failed");
+    // Leg 2: upstream rsync sender -> dst2.
+    run_rsync(&upstream_bin, &aax_args(&dst1, &dst2)).expect("upstream dst1 -> dst2 failed");
+
+    let src_snap = snapshot(&src, collect_record).expect("snapshot src");
+    let dst_snap = snapshot(&dst2, collect_record).expect("snapshot dst2");
+    let diff = diff_snapshots("src", &src_snap, "dst2", &dst_snap);
+    assert!(
+        diff.is_empty(),
+        "oc-rsync->upstream round-trip metadata divergence:\n{}",
+        diff.join("\n")
+    );
+}
+
+#[test]
+fn acl_xattr_roundtrip_linux_upstream_then_oc() {
+    let Some(ctx) = TestContext::try_setup() else {
+        return;
+    };
+    let TestContext {
+        _dir,
+        src,
+        dst1,
+        dst2,
+        oc_bin,
+        upstream_bin,
+    } = ctx;
+
+    // Leg 1: upstream rsync sender -> dst1.
+    run_rsync(&upstream_bin, &aax_args(&src, &dst1)).expect("upstream src -> dst1 failed");
+    // Leg 2: oc-rsync sender -> dst2.
+    run_rsync(&oc_bin, &aax_args(&dst1, &dst2)).expect("oc-rsync dst1 -> dst2 failed");
+
+    let src_snap = snapshot(&src, collect_record).expect("snapshot src");
+    let dst_snap = snapshot(&dst2, collect_record).expect("snapshot dst2");
+    let diff = diff_snapshots("src", &src_snap, "dst2", &dst_snap);
+    assert!(
+        diff.is_empty(),
+        "upstream->oc-rsync round-trip metadata divergence:\n{}",
+        diff.join("\n")
+    );
+}
+
+/// Per-test setup state. Returns `None` after logging the skip reason
+/// whenever a precondition fails.
+struct TestContext {
+    _dir: integration::helpers::TestDir,
+    src: PathBuf,
+    dst1: PathBuf,
+    dst2: PathBuf,
+    oc_bin: PathBuf,
+    upstream_bin: PathBuf,
+}
+
+impl TestContext {
+    fn try_setup() -> Option<Self> {
+        if !gate_enabled() {
+            skip(&format!(
+                "{GATE_ENV_VAR} not set to 1; opt in to run ACL/xattr interop tests"
+            ));
+            return None;
+        }
+        for tool in REQUIRED_TOOLS {
+            if !command_on_path(tool) {
+                skip(&format!(
+                    "required tool not on PATH: {tool} (install acl + attr packages)"
+                ));
+                return None;
+            }
+        }
+        let oc_bin = match locate_oc_rsync() {
+            Some(p) => p,
+            None => {
+                skip("oc-rsync binary not located");
+                return None;
+            }
+        };
+        let upstream_bin = match locate_upstream_rsync() {
+            Some(p) => p,
+            None => {
+                skip(
+                    "no upstream rsync found (set OC_RSYNC_UPSTREAM or install \
+                     target/interop/upstream-install/<ver>/bin/rsync)",
+                );
+                return None;
+            }
+        };
+
+        let (dir, src, dst1, dst2) = match make_scratch() {
+            Ok(t) => t,
+            Err(e) => {
+                skip(&format!("could not create scratch dir: {e}"));
+                return None;
+            }
+        };
+
+        if let Err(reason) = build_fixture(&src) {
+            skip(&format!(
+                "fixture build failed (likely no ACL/xattr support on tmpfs): {reason}"
+            ));
+            return None;
+        }
+
+        Some(Self {
+            _dir: dir,
+            src,
+            dst1,
+            dst2,
+            oc_bin,
+            upstream_bin,
+        })
+    }
+}
+
+/// Populate the source tree and stamp each entry with the test metadata.
+///
+/// Returns `Err` if any setfacl/setfattr probe fails: that signals the
+/// fixture cannot run on this filesystem (e.g. tmpfs without ACL support)
+/// and the caller should skip rather than fail.
+fn build_fixture(src: &Path) -> io::Result<()> {
+    // Tree layout: a few files plus a nested directory so we exercise both
+    // access ACLs (files) and default ACLs (directories).
+    fs::create_dir_all(src.join("nested"))?;
+    fs::write(src.join("flat.txt"), b"flat-content")?;
+    fs::write(src.join("nested/deep.txt"), b"deep-content")?;
+    fs::write(src.join("nested/extra.bin"), b"\x00\x01\x02\x03ABCD")?;
+
+    // POSIX access ACLs on files. `nobody` is universally present on Linux
+    // base systems; if not, setfacl errors out and we skip.
+    set_posix_acl(&src.join("flat.txt"), "u:nobody:rwx", false)?;
+    set_posix_acl(&src.join("nested/deep.txt"), "u:nobody:rwx", false)?;
+    // Access + default ACLs on the directory.
+    set_posix_acl(&src.join("nested"), "u:nobody:rwx", false)?;
+    set_posix_acl(&src.join("nested"), "u:nobody:rwx", true)?;
+
+    // User xattrs on all files. System xattrs require root, so we only
+    // probe `security.test` and ignore failure: the fixture stays valid
+    // either way.
+    set_user_xattr(&src.join("flat.txt"), "user.test.color", "blue")?;
+    set_user_xattr(&src.join("nested/deep.txt"), "user.test.color", "red")?;
+    set_user_xattr(&src.join("nested/extra.bin"), "user.test.color", "green")?;
+    set_user_xattr(&src.join("nested/extra.bin"), "user.test.shape", "octagon")?;
+
+    Ok(())
+}
+
+/// Apply a POSIX ACL entry via `setfacl`. `default` flips to `setfacl -d`.
+fn set_posix_acl(path: &Path, entry: &str, default: bool) -> io::Result<()> {
+    let mut cmd = Command::new("setfacl");
+    if default {
+        cmd.arg("-d");
+    }
+    cmd.arg("-m").arg(entry).arg(path);
+    let output = cmd.output()?;
+    if !output.status.success() {
+        return Err(io::Error::other(format!(
+            "setfacl {} {} failed: {}",
+            if default { "-d -m" } else { "-m" },
+            entry,
+            String::from_utf8_lossy(&output.stderr).trim()
+        )));
+    }
+    Ok(())
+}
+
+/// Apply a user-namespace xattr via `setfattr`.
+fn set_user_xattr(path: &Path, name: &str, value: &str) -> io::Result<()> {
+    let output = Command::new("setfattr")
+        .arg("-n")
+        .arg(name)
+        .arg("-v")
+        .arg(value)
+        .arg(path)
+        .output()?;
+    if !output.status.success() {
+        return Err(io::Error::other(format!(
+            "setfattr -n {} -v {} failed: {}",
+            name,
+            value,
+            String::from_utf8_lossy(&output.stderr).trim()
+        )));
+    }
+    Ok(())
+}
+
+/// Build a `MetadataRecord` for one path by shelling out to `getfacl` and
+/// `getfattr`. Output is normalised so two records compare equal exactly
+/// when the on-disk metadata matches.
+fn collect_record(abs: &Path, rel: &Path) -> io::Result<MetadataRecord> {
+    Ok(MetadataRecord {
+        rel: rel.to_path_buf(),
+        xattrs: read_xattrs(abs)?,
+        acl_text: read_acl_text(abs)?,
+    })
+}
+
+fn read_xattrs(path: &Path) -> io::Result<Vec<(String, String)>> {
+    // `-d` dumps values, `-m -` matches all names (no `user.` filter), `-e hex`
+    // round-trips binary safely. `--no-dereference` mirrors rsync's policy of
+    // operating on the link itself.
+    let output = Command::new("getfattr")
+        .arg("-d")
+        .arg("-m")
+        .arg("-")
+        .arg("-e")
+        .arg("hex")
+        .arg("--no-dereference")
+        .arg("--absolute-names")
+        .arg(path)
+        .output()?;
+    if !output.status.success() {
+        return Err(io::Error::other(format!(
+            "getfattr on {} failed: {}",
+            path.display(),
+            String::from_utf8_lossy(&output.stderr).trim()
+        )));
+    }
+    let body = String::from_utf8_lossy(&output.stdout);
+    let mut pairs = Vec::new();
+    for line in body.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        if let Some((k, v)) = line.split_once('=') {
+            pairs.push((k.to_string(), v.trim_matches('"').to_string()));
+        }
+    }
+    pairs.sort();
+    Ok(pairs)
+}
+
+fn read_acl_text(path: &Path) -> io::Result<String> {
+    // `-p` keeps relative paths verbatim, `--omit-header` drops the per-file
+    // comment block. We strip the residual `# file:` style metadata lines to
+    // keep the diff focused on ACEs, not paths or umask hints.
+    let output = Command::new("getfacl")
+        .arg("-p")
+        .arg("--omit-header")
+        .arg(path)
+        .output()?;
+    if !output.status.success() {
+        return Err(io::Error::other(format!(
+            "getfacl on {} failed: {}",
+            path.display(),
+            String::from_utf8_lossy(&output.stderr).trim()
+        )));
+    }
+    let body = String::from_utf8_lossy(&output.stdout);
+    let mut lines: Vec<&str> = body
+        .lines()
+        .map(str::trim_end)
+        .filter(|l| !l.is_empty() && !l.starts_with('#'))
+        .collect();
+    lines.sort();
+    Ok(lines.join("\n"))
+}

--- a/tests/acl_xattr_roundtrip_macos.rs
+++ b/tests/acl_xattr_roundtrip_macos.rs
@@ -1,0 +1,265 @@
+//! macOS round-trip parity: Apple-specific xattrs vs upstream rsync 3.4.1
+//! with `-aAX`.
+//!
+//! Apple stamps user-facing data into xattrs that drive Finder behaviour:
+//! - `com.apple.FinderInfo` - 32-byte fixed-size icon/colour record.
+//! - `com.apple.metadata:_kMDItemUserTags` - bplist of user tags.
+//! - `com.apple.ResourceFork` - legacy resource fork blob.
+//!
+//! macOS POSIX ACLs exist but the userland surface is extremely limited
+//! (`chmod +a`, `ls -le`) and the kernel re-canonicalises ACEs aggressively,
+//! making byte-level diffs noisy. This test focuses on xattrs only.
+//!
+//! Round-trips both directions through upstream `rsync` (commonly installed
+//! via Homebrew on `/opt/homebrew/bin/rsync` or `/usr/local/bin/rsync`):
+//! - `oc-rsync -aAX src/ dst1/` then `rsync -aAX dst1/ dst2/`
+//! - `rsync -aAX src/ dst1/` then `oc-rsync -aAX dst1/ dst2/`
+//!
+//! GATE: `OC_RSYNC_METADATA_INTEROP=1`. Skips cleanly when unset or when
+//! the surrounding tooling cannot satisfy the fixture.
+
+#![cfg(target_os = "macos")]
+
+mod integration;
+
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use integration::acl_xattr_interop_harness::{
+    GATE_ENV_VAR, MetadataRecord, aax_args, command_on_path, diff_snapshots, gate_enabled,
+    locate_oc_rsync, locate_upstream_rsync, make_scratch, run_rsync, skip, snapshot,
+};
+
+/// macOS Finder requires exactly 32 bytes for `com.apple.FinderInfo`. We
+/// stamp a recognisable but inert payload (no type/creator) so Finder will
+/// not try to rewrite it on access.
+const FINDER_INFO_HEX: &str = concat!(
+    "00000000", "00000000", "00000000", "00000000", "00000000", "00000000", "00000000", "00000000",
+);
+
+/// Opaque blob substituted for `_kMDItemUserTags`. The round-trip only
+/// needs both sides to preserve the bytes verbatim; Finder treats anything
+/// it cannot parse as "no tags", which is harmless for the test fixture.
+const USER_TAGS_HEX: &str = "62706c697374303049696e7465726f7000496d6574616461746100";
+
+/// Token resource fork. macOS preserves arbitrary opaque bytes here so any
+/// stable blob round-trips fine for the parity check.
+const RESOURCE_FORK_HEX: &str = "deadbeefcafef00d0123456789abcdef";
+
+#[test]
+fn acl_xattr_roundtrip_macos_oc_then_upstream() {
+    let Some(ctx) = TestContext::try_setup() else {
+        return;
+    };
+    let TestContext {
+        _dir,
+        src,
+        dst1,
+        dst2,
+        oc_bin,
+        upstream_bin,
+    } = ctx;
+
+    run_rsync(&oc_bin, &aax_args(&src, &dst1)).expect("oc-rsync src -> dst1 failed");
+    run_rsync(&upstream_bin, &aax_args(&dst1, &dst2)).expect("upstream dst1 -> dst2 failed");
+
+    let src_snap = snapshot(&src, collect_record).expect("snapshot src");
+    let dst_snap = snapshot(&dst2, collect_record).expect("snapshot dst2");
+    let diff = diff_snapshots("src", &src_snap, "dst2", &dst_snap);
+    assert!(
+        diff.is_empty(),
+        "oc-rsync->upstream round-trip xattr divergence:\n{}",
+        diff.join("\n")
+    );
+}
+
+#[test]
+fn acl_xattr_roundtrip_macos_upstream_then_oc() {
+    let Some(ctx) = TestContext::try_setup() else {
+        return;
+    };
+    let TestContext {
+        _dir,
+        src,
+        dst1,
+        dst2,
+        oc_bin,
+        upstream_bin,
+    } = ctx;
+
+    run_rsync(&upstream_bin, &aax_args(&src, &dst1)).expect("upstream src -> dst1 failed");
+    run_rsync(&oc_bin, &aax_args(&dst1, &dst2)).expect("oc-rsync dst1 -> dst2 failed");
+
+    let src_snap = snapshot(&src, collect_record).expect("snapshot src");
+    let dst_snap = snapshot(&dst2, collect_record).expect("snapshot dst2");
+    let diff = diff_snapshots("src", &src_snap, "dst2", &dst_snap);
+    assert!(
+        diff.is_empty(),
+        "upstream->oc-rsync round-trip xattr divergence:\n{}",
+        diff.join("\n")
+    );
+}
+
+struct TestContext {
+    _dir: integration::helpers::TestDir,
+    src: PathBuf,
+    dst1: PathBuf,
+    dst2: PathBuf,
+    oc_bin: PathBuf,
+    upstream_bin: PathBuf,
+}
+
+impl TestContext {
+    fn try_setup() -> Option<Self> {
+        if !gate_enabled() {
+            skip(&format!(
+                "{GATE_ENV_VAR} not set to 1; opt in to run ACL/xattr interop tests"
+            ));
+            return None;
+        }
+        if !command_on_path("xattr") {
+            skip("xattr not on PATH (ship with macOS base; check PATH sanitisation)");
+            return None;
+        }
+        let oc_bin = match locate_oc_rsync() {
+            Some(p) => p,
+            None => {
+                skip("oc-rsync binary not located");
+                return None;
+            }
+        };
+        let upstream_bin = match locate_upstream_rsync() {
+            Some(p) => p,
+            None => {
+                skip(
+                    "no upstream rsync found (install via brew or set OC_RSYNC_UPSTREAM); \
+                     Apple-shipped rsync is too old for protocol 32",
+                );
+                return None;
+            }
+        };
+
+        let (dir, src, dst1, dst2) = match make_scratch() {
+            Ok(t) => t,
+            Err(e) => {
+                skip(&format!("could not create scratch dir: {e}"));
+                return None;
+            }
+        };
+
+        if let Err(reason) = build_fixture(&src) {
+            skip(&format!(
+                "fixture build failed (filesystem may not preserve Apple xattrs): {reason}"
+            ));
+            return None;
+        }
+
+        Some(Self {
+            _dir: dir,
+            src,
+            dst1,
+            dst2,
+            oc_bin,
+            upstream_bin,
+        })
+    }
+}
+
+fn build_fixture(src: &Path) -> io::Result<()> {
+    fs::create_dir_all(src.join("nested"))?;
+    fs::write(src.join("flat.txt"), b"flat-content")?;
+    fs::write(src.join("nested/deep.txt"), b"deep-content")?;
+
+    set_apple_xattr(
+        &src.join("flat.txt"),
+        "com.apple.FinderInfo",
+        FINDER_INFO_HEX,
+    )?;
+    set_apple_xattr(
+        &src.join("flat.txt"),
+        "com.apple.metadata:_kMDItemUserTags",
+        USER_TAGS_HEX,
+    )?;
+    set_apple_xattr(
+        &src.join("nested/deep.txt"),
+        "com.apple.ResourceFork",
+        RESOURCE_FORK_HEX,
+    )?;
+    set_apple_xattr(
+        &src.join("nested/deep.txt"),
+        "com.apple.FinderInfo",
+        FINDER_INFO_HEX,
+    )?;
+    Ok(())
+}
+
+/// Write a hex-encoded xattr via `xattr -wx <name> <hex> <path>`. The `-x`
+/// flag is the documented way to feed binary values without shell-escape
+/// hell.
+fn set_apple_xattr(path: &Path, name: &str, hex_value: &str) -> io::Result<()> {
+    let output = Command::new("xattr")
+        .arg("-wx")
+        .arg(name)
+        .arg(hex_value)
+        .arg(path)
+        .output()?;
+    if !output.status.success() {
+        return Err(io::Error::other(format!(
+            "xattr -wx {} ... {} failed: {}",
+            name,
+            path.display(),
+            String::from_utf8_lossy(&output.stderr).trim()
+        )));
+    }
+    Ok(())
+}
+
+/// Build a `MetadataRecord` per file by listing xattrs and reading each one
+/// in hex. macOS POSIX ACL state is intentionally omitted; see the module
+/// docstring.
+fn collect_record(abs: &Path, rel: &Path) -> io::Result<MetadataRecord> {
+    let names_output = Command::new("xattr").arg(abs).output()?;
+    if !names_output.status.success() {
+        return Err(io::Error::other(format!(
+            "xattr list on {} failed: {}",
+            abs.display(),
+            String::from_utf8_lossy(&names_output.stderr).trim()
+        )));
+    }
+    let mut xattrs = Vec::new();
+    for name in String::from_utf8_lossy(&names_output.stdout).lines() {
+        let name = name.trim();
+        if name.is_empty() {
+            continue;
+        }
+        let value_output = Command::new("xattr")
+            .arg("-px")
+            .arg(name)
+            .arg(abs)
+            .output()?;
+        if !value_output.status.success() {
+            return Err(io::Error::other(format!(
+                "xattr -px {} on {} failed: {}",
+                name,
+                abs.display(),
+                String::from_utf8_lossy(&value_output.stderr).trim()
+            )));
+        }
+        // `-px` returns a multi-line hex dump with embedded whitespace.
+        // Strip all whitespace for stable byte-level comparison.
+        let hex: String = String::from_utf8_lossy(&value_output.stdout)
+            .chars()
+            .filter(|c| !c.is_whitespace())
+            .collect();
+        xattrs.push((name.to_string(), hex));
+    }
+    xattrs.sort();
+    Ok(MetadataRecord {
+        rel: rel.to_path_buf(),
+        xattrs,
+        // macOS ACLs intentionally not included; see module docstring.
+        acl_text: String::new(),
+    })
+}

--- a/tests/integration/acl_xattr_interop_harness.rs
+++ b/tests/integration/acl_xattr_interop_harness.rs
@@ -1,0 +1,280 @@
+//! Shared harness for ACL/xattr round-trip interop tests vs upstream rsync 3.4.1.
+//!
+//! These tests stage a directory tree carrying rich metadata (POSIX ACLs,
+//! NFSv4 ACLs where supported, user/system xattrs), bounce it through a
+//! sequence of `oc-rsync` and upstream `rsync` invocations using `-aAX`, and
+//! diff the surviving metadata against the original. The harness covers both
+//! directions:
+//!
+//! - `oc-rsync` then upstream `rsync` (oc-rsync sender, upstream receiver).
+//! - upstream `rsync` then `oc-rsync` (upstream sender, oc-rsync receiver).
+//!
+//! ## Skip conditions
+//!
+//! The harness skips cleanly (no test failure) when:
+//! - The `OC_RSYNC_METADATA_INTEROP` env var is not set to `1`.
+//! - An upstream `rsync` binary is not available.
+//! - The oc-rsync binary cannot be located.
+//! - Per-OS metadata tools are missing (`setfacl`/`getfacl`/`setfattr`/
+//!   `getfattr` on Linux, `xattr` on macOS).
+//! - The backing filesystem rejects the metadata operations (no ACL/xattr
+//!   support on `/tmp`).
+//!
+//! ## Comparison model
+//!
+//! Equivalence is recursive over the tree, anchored at the destination root.
+//! For each file the harness collects a canonicalised metadata record
+//! (sorted xattr key/value list, ACL text dump) and asserts byte-identical
+//! records between source and final destination. Order of xattr enumeration
+//! is not guaranteed by either implementation, so all comparisons sort
+//! before diffing.
+//!
+//! Upstream source references:
+//! - `acls.c:send_acl()` / `acls.c:receive_acl()` - POSIX/NFSv4 ACL wire.
+//! - `xattrs.c:send_xattr()` / `xattrs.c:receive_xattr()` - xattr wire.
+
+#![cfg(unix)]
+#![allow(dead_code)]
+
+use std::collections::BTreeMap;
+use std::env;
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output, Stdio};
+use std::time::Duration;
+
+use super::helpers::{TestDir, spawn_with_timeout};
+
+/// Environment variable that gates execution. Tests skip when this is unset
+/// (or not equal to "1"). Set when running the metadata interop suite.
+pub const GATE_ENV_VAR: &str = "OC_RSYNC_METADATA_INTEROP";
+
+/// Wall-clock timeout for any single rsync invocation in the round-trip.
+pub const RUN_TIMEOUT: Duration = Duration::from_secs(180);
+
+/// Convenience: log a skip reason and return from the test cleanly.
+pub fn skip(reason: &str) {
+    eprintln!("skip: {reason}");
+}
+
+/// Check whether the gate env var is set to "1".
+pub fn gate_enabled() -> bool {
+    env::var(GATE_ENV_VAR).ok().as_deref() == Some("1")
+}
+
+/// Check `command -v <cmd>` on PATH.
+pub fn command_on_path(cmd: &str) -> bool {
+    Command::new("sh")
+        .arg("-c")
+        .arg(format!("command -v {cmd} >/dev/null 2>&1"))
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+/// Locate the oc-rsync binary built by cargo. Walks the standard places
+/// nextest exposes plus the workspace `target/{debug,release,dist}` layout.
+pub fn locate_oc_rsync() -> Option<PathBuf> {
+    if let Some(env_path) = env::var_os("CARGO_BIN_EXE_oc-rsync") {
+        let path = PathBuf::from(env_path);
+        if path.is_file() {
+            return Some(path);
+        }
+    }
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    for profile in ["debug", "release", "dist"] {
+        let candidate = manifest_dir.join("target").join(profile).join("oc-rsync");
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+/// Locate an upstream rsync binary. Honours `OC_RSYNC_UPSTREAM`, then the
+/// `target/interop/upstream-install/<ver>/bin/rsync` cache, then `which`.
+pub fn locate_upstream_rsync() -> Option<PathBuf> {
+    if let Some(p) = env::var_os("OC_RSYNC_UPSTREAM") {
+        let path = PathBuf::from(p);
+        if path.is_file() {
+            return Some(path);
+        }
+    }
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    for version in ["3.4.2", "3.4.1", "3.1.3", "3.0.9"] {
+        let in_tree = manifest_dir
+            .join("target/interop/upstream-install")
+            .join(version)
+            .join("bin/rsync");
+        if in_tree.is_file() {
+            return Some(in_tree);
+        }
+    }
+    let which = Command::new("sh")
+        .arg("-c")
+        .arg("command -v rsync 2>/dev/null")
+        .output()
+        .ok()?;
+    if !which.status.success() {
+        return None;
+    }
+    let path = PathBuf::from(String::from_utf8(which.stdout).ok()?.trim());
+    if path.is_file() { Some(path) } else { None }
+}
+
+/// Run an rsync-style binary with the canonical metadata flag set and
+/// fail-fast on a non-zero exit.
+pub fn run_rsync(bin: &Path, args: &[String]) -> io::Result<Output> {
+    let mut cmd = Command::new(bin);
+    cmd.args(args);
+    cmd.stdin(Stdio::null());
+    cmd.stdout(Stdio::piped());
+    cmd.stderr(Stdio::piped());
+    let output = spawn_with_timeout(cmd, RUN_TIMEOUT)?;
+    if !output.status.success() {
+        return Err(io::Error::other(format!(
+            "{} {:?} exited with {:?}\nstdout:\n{}\nstderr:\n{}",
+            bin.display(),
+            args,
+            output.status.code(),
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        )));
+    }
+    Ok(output)
+}
+
+/// Build the standard `-aAX` argv for transferring `src/` into `dst`.
+///
+/// The trailing slash on the source is essential: it preserves the "copy
+/// contents" semantic so paths line up across the four legs of the
+/// round-trip.
+pub fn aax_args(src: &Path, dst: &Path) -> Vec<String> {
+    vec![
+        "-aAX".to_string(),
+        "--numeric-ids".to_string(),
+        format!("{}/", src.display()),
+        dst.to_string_lossy().into_owned(),
+    ]
+}
+
+/// Provision the standard scratch layout: `<tmp>/src`, `<tmp>/dst1`,
+/// `<tmp>/dst2`. Returns the three paths plus the owning `TestDir`.
+pub fn make_scratch() -> io::Result<(TestDir, PathBuf, PathBuf, PathBuf)> {
+    let dir = TestDir::new()?;
+    let src = dir.mkdir("src")?;
+    let dst1 = dir.mkdir("dst1")?;
+    let dst2 = dir.mkdir("dst2")?;
+    Ok((dir, src, dst1, dst2))
+}
+
+/// A canonicalised metadata record for one file/directory.
+///
+/// `xattrs` and `acl_text` are sorted/normalised so two records compare
+/// equal exactly when their on-disk metadata is equivalent for the purposes
+/// of the interop assertion.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MetadataRecord {
+    /// Path relative to the tree root.
+    pub rel: PathBuf,
+    /// Sorted list of `(key, value)` xattr pairs, hex-encoded values.
+    pub xattrs: Vec<(String, String)>,
+    /// ACL text dump (`getfacl -p` style) with comment lines stripped, or
+    /// an empty string when the platform has no POSIX ACL tooling.
+    pub acl_text: String,
+}
+
+/// Build a sorted `BTreeMap<rel_path, MetadataRecord>` by walking `root`.
+pub fn snapshot<F>(root: &Path, mut collect: F) -> io::Result<BTreeMap<PathBuf, MetadataRecord>>
+where
+    F: FnMut(&Path, &Path) -> io::Result<MetadataRecord>,
+{
+    let mut out = BTreeMap::new();
+    walk(root, root, &mut |abs, rel| {
+        let rec = collect(abs, rel)?;
+        out.insert(rel.to_path_buf(), rec);
+        Ok(())
+    })?;
+    Ok(out)
+}
+
+fn walk(
+    base: &Path,
+    current: &Path,
+    visit: &mut dyn FnMut(&Path, &Path) -> io::Result<()>,
+) -> io::Result<()> {
+    for entry in fs::read_dir(current)? {
+        let entry = entry?;
+        let abs = entry.path();
+        let rel = abs.strip_prefix(base).unwrap_or(&abs).to_path_buf();
+        visit(&abs, &rel)?;
+        let ft = entry.file_type()?;
+        if ft.is_dir() {
+            walk(base, &abs, visit)?;
+        }
+    }
+    Ok(())
+}
+
+/// Diff two metadata snapshots, returning a list of human-readable
+/// mismatches. Empty result means the snapshots agree.
+pub fn diff_snapshots(
+    left_label: &str,
+    left: &BTreeMap<PathBuf, MetadataRecord>,
+    right_label: &str,
+    right: &BTreeMap<PathBuf, MetadataRecord>,
+) -> Vec<String> {
+    let mut errors = Vec::new();
+    for path in left.keys() {
+        if !right.contains_key(path) {
+            errors.push(format!(
+                "{}: path {} present in {} only",
+                path.display(),
+                path.display(),
+                left_label
+            ));
+        }
+    }
+    for path in right.keys() {
+        if !left.contains_key(path) {
+            errors.push(format!(
+                "{}: path {} present in {} only",
+                path.display(),
+                path.display(),
+                right_label
+            ));
+        }
+    }
+    for (path, l) in left {
+        let Some(r) = right.get(path) else { continue };
+        if l.xattrs != r.xattrs {
+            errors.push(format!(
+                "xattr mismatch at {}\n  {}: {:?}\n  {}: {:?}",
+                path.display(),
+                left_label,
+                l.xattrs,
+                right_label,
+                r.xattrs,
+            ));
+        }
+        if l.acl_text != r.acl_text {
+            errors.push(format!(
+                "ACL mismatch at {}\n  {}:\n{}\n  {}:\n{}",
+                path.display(),
+                left_label,
+                indent(&l.acl_text),
+                right_label,
+                indent(&r.acl_text),
+            ));
+        }
+    }
+    errors
+}
+
+fn indent(s: &str) -> String {
+    s.lines()
+        .map(|line| format!("    {line}"))
+        .collect::<Vec<_>>()
+        .join("\n")
+}

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -4,3 +4,6 @@ pub mod helpers;
 
 #[cfg(unix)]
 pub mod delete_event_order_harness;
+
+#[cfg(unix)]
+pub mod acl_xattr_interop_harness;


### PR DESCRIPTION
## Summary

- Adds two opt-in interop tests that bounce a metadata-rich tree through `oc-rsync` and upstream rsync 3.4.1 in both directions, then diff per-path ACL text and xattr key/value pairs against the original tree.
- Linux fixture (`tests/acl_xattr_roundtrip_linux.rs`) carries POSIX access/default ACLs (`setfacl -m u:nobody:rwx,d:u:nobody:rwx`) plus user-namespace xattrs (`user.test.color`, `user.test.shape`); read back via `getfacl --omit-header` and `getfattr -d -m - -e hex`.
- macOS fixture (`tests/acl_xattr_roundtrip_macos.rs`) carries `com.apple.FinderInfo` (32-byte), `com.apple.metadata:_kMDItemUserTags`, and `com.apple.ResourceFork` written with `xattr -wx` and read back with `xattr -px`. macOS POSIX ACLs are skipped (kernel re-canonicalisation makes byte diffs noisy).
- Shared harness in `tests/integration/acl_xattr_interop_harness.rs` centralises env-var gating, upstream/oc-rsync binary discovery (same pattern as the delete-event-order suite), scratch layout, and snapshot diffing.

## Scenarios per test file

Both files run two `#[test]` cases each:

| Direction | Leg 1 | Leg 2 |
| --- | --- | --- |
| `oc_then_upstream` | `oc-rsync -aAX src/ dst1/` | `rsync -aAX dst1/ dst2/` |
| `upstream_then_oc` | `rsync -aAX src/ dst1/` | `oc-rsync -aAX dst1/ dst2/` |

Then diff snapshots(`src`) against snapshots(`dst2`).

## Env-var gate

All four tests opt in via `OC_RSYNC_METADATA_INTEROP=1` and skip cleanly (no failure) when:

- the env var is unset,
- upstream `rsync` cannot be located (honours `OC_RSYNC_UPSTREAM`, then `target/interop/upstream-install/<ver>/bin/rsync`, then `PATH`),
- the oc-rsync binary cannot be located,
- per-OS metadata tools are missing (`setfacl`/`getfacl`/`setfattr`/`getfattr` on Linux, `xattr` on macOS), or
- the backing filesystem rejects ACL/xattr writes during fixture setup.

## Test plan

- [ ] CI fmt+clippy passes (tests are `#![cfg]`-gated per OS so the off-target build still parses)
- [ ] CI nextest stable passes (tests skip without the env var, default CI does not set it)
- [ ] Manual run on Linux: `OC_RSYNC_METADATA_INTEROP=1 cargo nextest run -E 'test(acl_xattr_roundtrip_linux)'` succeeds when an upstream rsync and `acl` + `attr` packages are installed
- [ ] Manual run on macOS: `OC_RSYNC_METADATA_INTEROP=1 cargo nextest run -E 'test(acl_xattr_roundtrip_macos)'` succeeds when an upstream rsync is on `PATH` (e.g. `brew install rsync`)