### PR TITLE
bench(windows): throughput comparison vs upstream MSYS2 rsync

### DIFF
--- a/.github/workflows/_benchmark-windows.yml
+++ b/.github/workflows/_benchmark-windows.yml
@@ -1,0 +1,165 @@
+name: Benchmark (Windows throughput)
+
+# Reusable workflow: Windows throughput comparison between oc-rsync
+# (built with the iocp fast-path enabled) and the upstream MSYS2 rsync
+# binary, driven by hyperfine.
+#
+# This is a soft signal, NOT a required check. Windows runners have
+# more wall-clock variance than Linux runners, and hyperfine's tail
+# latency on `windows-latest` is a known noise source. We surface the
+# numbers as artefacts and a step summary; we do not gate merges on
+# them.
+#
+# Counterpart of `_interop-windows.yml` (PR #4297) which covers
+# correctness on the same toolchain. This workflow covers throughput.
+
+on:
+  workflow_call:
+    inputs:
+      cache_version:
+        description: 'Cache version for invalidation'
+        type: string
+        default: 'v1'
+      rust_toolchain:
+        description: 'Rust toolchain version'
+        type: string
+        default: 'stable'
+      timeout_minutes:
+        description: 'Job timeout in minutes'
+        type: number
+        default: 60
+      warmup_runs:
+        description: 'Hyperfine warmup runs'
+        type: number
+        default: 1
+      measured_runs:
+        description: 'Hyperfine measured runs'
+        type: number
+        default: 3
+      large_file_mib:
+        description: 'Size of the single large fixture file (MiB)'
+        type: number
+        default: 1024
+      small_file_count:
+        description: 'Number of small fixture files'
+        type: number
+        default: 10000
+  workflow_dispatch:
+    inputs:
+      warmup_runs:
+        description: 'Hyperfine warmup runs'
+        type: number
+        default: 1
+      measured_runs:
+        description: 'Hyperfine measured runs'
+        type: number
+        default: 3
+      large_file_mib:
+        description: 'Size of the single large fixture file (MiB)'
+        type: number
+        default: 1024
+      small_file_count:
+        description: 'Number of small fixture files'
+        type: number
+        default: 10000
+
+permissions:
+  contents: read
+
+jobs:
+  benchmark-windows:
+    name: throughput vs MSYS2 rsync (Windows, best-effort)
+    runs-on: windows-latest
+    timeout-minutes: ${{ inputs.timeout_minutes || 60 }}
+    # Best-effort: wall-clock variance on hosted Windows runners makes
+    # this a poor merge-gate. Treat the numbers as a regression sniff.
+    continue-on-error: true
+
+    env:
+      CARGO_TERM_COLOR: always
+      RUSTFLAGS: "-D warnings"
+      RUST_BACKTRACE: "full"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install Rust (${{ inputs.rust_toolchain || 'stable' }})
+        uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
+        with:
+          toolchain: ${{ inputs.rust_toolchain || 'stable' }}
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
+        with:
+          shared-key: ci-${{ runner.os }}-cargo-${{ inputs.cache_version || 'v1' }}-${{ hashFiles('**/Cargo.lock') }}
+          key: benchmark-windows
+
+      # iocp is in the workspace default-features list, but we pass it
+      # explicitly so a future default-features change does not silently
+      # drop the fast path from the benchmark binary.
+      - name: Build oc-rsync (release, iocp)
+        run: cargo build --locked --release --features iocp --bin oc-rsync
+
+      - name: Install MSYS2 with rsync + hyperfine
+        uses: msys2/setup-msys2@61f9e5e925871ba6c9e3e8da24ede83ea27fa91f # v2.27.0
+        with:
+          msystem: MSYS
+          update: false
+          install: >-
+            rsync
+            hyperfine
+            diffutils
+            coreutils
+
+      - name: Run throughput benchmark
+        shell: msys2 {0}
+        env:
+          OC_RSYNC: ${{ github.workspace }}/target/release/oc-rsync.exe
+          UPSTREAM_RSYNC: rsync
+          BENCH_WARMUP: ${{ inputs.warmup_runs || 1 }}
+          BENCH_RUNS: ${{ inputs.measured_runs || 3 }}
+          BENCH_LARGE_MIB: ${{ inputs.large_file_mib || 1024 }}
+          BENCH_SMALL_COUNT: ${{ inputs.small_file_count || 10000 }}
+          BENCH_OUT_DIR: ${{ github.workspace }}/bench-out
+        run: |
+          oc=$(cygpath -u "$OC_RSYNC")
+          export OC_RSYNC="$oc"
+          out=$(cygpath -u "$BENCH_OUT_DIR")
+          export BENCH_OUT_DIR="$out"
+          bash scripts/windows_throughput_bench.sh
+
+      - name: Summarise results
+        if: always()
+        shell: msys2 {0}
+        run: |
+          set -eu
+          out=$(cygpath -u "${{ github.workspace }}/bench-out")
+          if [ ! -d "$out" ]; then
+              echo "No bench-out directory; benchmark was likely skipped." \
+                  >> "$GITHUB_STEP_SUMMARY"
+              exit 0
+          fi
+          {
+              echo "## Windows throughput benchmark"
+              echo ""
+              for f in "$out"/*.json; do
+                  [ -f "$f" ] || continue
+                  echo "### $(basename "$f" .json)"
+                  echo ""
+                  echo '```json'
+                  cat "$f"
+                  echo ''
+                  echo '```'
+                  echo ""
+              done
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload throughput report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: windows-throughput-bench
+          retention-days: 30
+          if-no-files-found: ignore
+          path: bench-out/*.json

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -4,6 +4,10 @@ on:
   push:
     tags:
       - "v[0-9]*.[0-9]*.[0-9]*"
+  schedule:
+    # Weekly Windows throughput sniff. Sunday 04:17 UTC keeps it well
+    # clear of the daily release-cross and interop schedules.
+    - cron: '17 4 * * 0'
   workflow_dispatch:
     inputs:
       baseline_tag:
@@ -212,3 +216,11 @@ jobs:
         run: |
           TAG="${{ steps.release_tag.outputs.tag }}"
           gh release upload "$TAG" benchmark.png benchmark_results.json benchmark_report.md --clobber
+
+  # Windows throughput sniff: runs on tag, weekly schedule, and manual
+  # dispatch. Best-effort (continue-on-error in the reusable workflow);
+  # not wired into branch protection. See docs/benchmarks/windows-throughput.md
+  # for how to read the JSON artefacts.
+  windows-throughput:
+    name: Windows throughput (vs MSYS2 rsync)
+    uses: ./.github/workflows/_benchmark-windows.yml

--- a/docs/benchmarks/windows-throughput.md
+++ b/docs/benchmarks/windows-throughput.md
@@ -1,0 +1,124 @@
+# Windows throughput benchmark
+
+This page documents the `Benchmark (Windows throughput)` workflow
+(`.github/workflows/_benchmark-windows.yml`) and its driver script
+(`scripts/windows_throughput_bench.sh`). The job compares wall-clock
+throughput of `oc-rsync.exe` (built with `--release --features iocp`)
+against the upstream MSYS2 `rsync` package on a `windows-latest`
+runner. It uses [hyperfine] for measurement.
+
+The Windows correctness story is covered separately by the
+`Interop Tests (Windows)` workflow (`_interop-windows.yml`); this
+job covers performance.
+
+[hyperfine]: https://github.com/sharkdp/hyperfine
+
+## When does it run?
+
+- Tag push (`v*.*.*`).
+- Weekly cron (Sundays, 04:17 UTC).
+- Manual `workflow_dispatch` from the Benchmark workflow.
+
+The job is intentionally **not** in the required-checks list. Hosted
+Windows runners have visibly higher wall-clock variance than Linux
+runners, so blocking merges on a single hyperfine sample would create
+false negatives. Treat the numbers as a regression sniff, not a gate.
+
+## What does it measure?
+
+Two scenarios, each driven by hyperfine with `--warmup 1 --runs 3`
+(tunable via workflow inputs):
+
+| Scenario      | Fixture                                  | What it stresses                   |
+|---------------|------------------------------------------|------------------------------------|
+| `large_1gib`  | One 1 GiB file of `/dev/urandom`         | Bulk-copy bandwidth, IOCP fast path|
+| `small_10000` | 10000 x 4 KiB files across 100 sub-dirs  | Per-file overhead, flist walk      |
+
+Each measured iteration starts from a wiped destination via hyperfine's
+`--prepare`, so we report full-copy throughput (not no-op quick-check).
+
+## Reading the JSON report
+
+Hyperfine writes one JSON file per scenario into `bench-out/`:
+
+```
+bench-out/
+  large_1gib.json
+  small_10000.json
+```
+
+Each file contains a `results` array, one entry per `--command-name`:
+
+```jsonc
+{
+  "results": [
+    {
+      "command": "oc-rsync",
+      "mean":   12.43,        // seconds
+      "stddev": 0.31,
+      "median": 12.38,
+      "min":    12.05,
+      "max":    13.01,
+      "times":  [12.05, 12.38, 13.01]
+    },
+    {
+      "command": "upstream-rsync",
+      "mean":   14.20,
+      "...":    "..."
+    }
+  ]
+}
+```
+
+Compute the throughput ratio as
+`mean(upstream-rsync) / mean(oc-rsync)`. A value of `1.0` means parity;
+`> 1.0` means oc-rsync is faster, `< 1.0` means it is slower.
+
+## Acceptable performance bands
+
+These bands are guidance for the Windows runner only. Linux
+measurements live in the main `benchmark.yml` job and have their own
+targets.
+
+| Scenario      | Acceptable band (oc-rsync vs upstream)             |
+|---------------|----------------------------------------------------|
+| `large_1gib`  | Within **20%** of upstream wall-clock (>= 0.83x)   |
+| `small_10000` | Within **50%** of upstream wall-clock (>= 0.67x)   |
+
+Rationale: the single-large-file scenario is dominated by raw I/O, so
+the IOCP fast path should hold us close to upstream. The small-files
+scenario is dominated by per-file syscall overhead and metadata work
+on NTFS, where MSYS2/Cygwin's path-translation layer is the variable
+we cannot control. A 50% band catches regressions without flagging
+runner noise.
+
+Sustained operation outside the band on the weekly cron is a signal,
+not a fault. Repeat locally before opening a regression issue:
+
+```sh
+# From an MSYS2 shell on a Windows host.
+BENCH_RUNS=5 BENCH_WARMUP=2 \
+  OC_RSYNC=/c/path/to/target/release/oc-rsync.exe \
+  bash scripts/windows_throughput_bench.sh
+```
+
+## Tuning knobs
+
+The reusable workflow exposes these inputs (all optional):
+
+- `warmup_runs` (default 1)
+- `measured_runs` (default 3)
+- `large_file_mib` (default 1024)
+- `small_file_count` (default 10000)
+- `timeout_minutes` (default 60)
+
+The driver script honours the matching environment variables
+(`BENCH_WARMUP`, `BENCH_RUNS`, `BENCH_LARGE_MIB`, `BENCH_SMALL_COUNT`,
+`BENCH_SMALL_KIB`, `BENCH_OUT_DIR`) for local invocation.
+
+## Why MSYS2 upstream?
+
+MSYS2 ships a current `rsync >= 3.2` on a Cygwin-style runtime. It is
+the most reliable way to get a real upstream rsync on a Windows
+GitHub runner; the Chocolatey `rsync` package is unmaintained. This
+matches the choice made by the Windows correctness interop workflow.

--- a/scripts/windows_throughput_bench.sh
+++ b/scripts/windows_throughput_bench.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env sh
+# windows_throughput_bench.sh
+#
+# Windows throughput benchmark for oc-rsync vs upstream MSYS2 rsync.
+# Runs under MSYS2 bash on a Windows GitHub runner (or any MSYS2 shell).
+#
+# Generates a fixture (1 GiB single file + 10000 small files) and drives
+# hyperfine to measure wall-clock time for a full local push from src/ to
+# dst/ with both binaries. Output is a JSON report per scenario that
+# downstream tooling can ingest.
+#
+# This script is intentionally best-effort: it skips with exit 0 (and a
+# clear log line) if any required tool is missing so that we never block
+# CI on Windows runner provisioning quirks.
+#
+# Required environment / tooling:
+#   - bash (POSIX sh compatible; runs under MSYS2 on Windows)
+#   - hyperfine (https://github.com/sharkdp/hyperfine)
+#   - oc-rsync.exe (built with --release; iocp is on by default)
+#   - upstream rsync (MSYS2 package `rsync`)
+#
+# Optional environment overrides:
+#   OC_RSYNC          Path to oc-rsync.exe (default: target/release/oc-rsync.exe)
+#   UPSTREAM_RSYNC    Path or name of upstream rsync (default: rsync)
+#   BENCH_OUT_DIR     Directory for JSON reports (default: bench-out)
+#   BENCH_WARMUP      Hyperfine warmup runs (default: 1)
+#   BENCH_RUNS        Hyperfine measured runs (default: 3)
+#   BENCH_LARGE_MIB   Size of the single large file in MiB (default: 1024)
+#   BENCH_SMALL_COUNT Number of small files (default: 10000)
+#   BENCH_SMALL_KIB   Size of each small file in KiB (default: 4)
+
+set -eu
+
+log() {
+    printf '[windows-throughput-bench] %s\n' "$*"
+}
+
+skip() {
+    log "SKIP: $*"
+    exit 0
+}
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+OC_RSYNC="${OC_RSYNC:-${PROJECT_ROOT}/target/release/oc-rsync.exe}"
+UPSTREAM_RSYNC="${UPSTREAM_RSYNC:-rsync}"
+BENCH_OUT_DIR="${BENCH_OUT_DIR:-${PROJECT_ROOT}/bench-out}"
+BENCH_WARMUP="${BENCH_WARMUP:-1}"
+BENCH_RUNS="${BENCH_RUNS:-3}"
+BENCH_LARGE_MIB="${BENCH_LARGE_MIB:-1024}"
+BENCH_SMALL_COUNT="${BENCH_SMALL_COUNT:-10000}"
+BENCH_SMALL_KIB="${BENCH_SMALL_KIB:-4}"
+
+# Tool checks (skip rather than fail to keep CI green on missing deps).
+if ! command -v hyperfine >/dev/null 2>&1; then
+    skip "hyperfine not on PATH; install via MSYS2 (pacman -S hyperfine) or cargo install hyperfine"
+fi
+if ! command -v dd >/dev/null 2>&1; then
+    skip "dd not on PATH; install MSYS2 coreutils"
+fi
+if [ ! -x "$OC_RSYNC" ] && ! command -v "$OC_RSYNC" >/dev/null 2>&1; then
+    skip "oc-rsync not found at: $OC_RSYNC"
+fi
+if ! command -v "$UPSTREAM_RSYNC" >/dev/null 2>&1; then
+    skip "upstream rsync not on PATH ($UPSTREAM_RSYNC); install MSYS2 rsync package"
+fi
+
+mkdir -p "$BENCH_OUT_DIR"
+
+log "oc-rsync      : $OC_RSYNC"
+log "upstream rsync: $UPSTREAM_RSYNC"
+log "warmup runs   : $BENCH_WARMUP"
+log "measured runs : $BENCH_RUNS"
+log "output dir    : $BENCH_OUT_DIR"
+
+WORKROOT="$(mktemp -d 2>/dev/null || mktemp -d -t 'win-throughput')"
+trap 'rm -rf "$WORKROOT"' EXIT INT TERM
+
+# ----------------------------------------------------------------------------
+# Fixture 1: single large file (default 1 GiB).
+# ----------------------------------------------------------------------------
+LARGE_SRC="$WORKROOT/large/src"
+LARGE_DST_OC="$WORKROOT/large/dst_oc"
+LARGE_DST_UP="$WORKROOT/large/dst_up"
+mkdir -p "$LARGE_SRC" "$LARGE_DST_OC" "$LARGE_DST_UP"
+
+log "generating large fixture: ${BENCH_LARGE_MIB} MiB"
+dd if=/dev/urandom of="$LARGE_SRC/large.bin" bs=1048576 count="$BENCH_LARGE_MIB" status=none
+
+# ----------------------------------------------------------------------------
+# Fixture 2: many small files (default 10000 x 4 KiB).
+# ----------------------------------------------------------------------------
+SMALL_SRC="$WORKROOT/small/src"
+SMALL_DST_OC="$WORKROOT/small/dst_oc"
+SMALL_DST_UP="$WORKROOT/small/dst_up"
+mkdir -p "$SMALL_SRC" "$SMALL_DST_OC" "$SMALL_DST_UP"
+
+log "generating small-files fixture: ${BENCH_SMALL_COUNT} x ${BENCH_SMALL_KIB} KiB"
+i=1
+while [ "$i" -le "$BENCH_SMALL_COUNT" ]; do
+    # Bucket into 100 sub-dirs to avoid one huge directory hot-spot.
+    bucket=$(( i % 100 ))
+    bdir="$SMALL_SRC/d$bucket"
+    [ -d "$bdir" ] || mkdir -p "$bdir"
+    dd if=/dev/urandom of="$bdir/f$i.bin" bs=1024 count="$BENCH_SMALL_KIB" status=none
+    i=$(( i + 1 ))
+done
+
+run_scenario() {
+    scenario="$1"
+    src="$2"
+    dst_oc="$3"
+    dst_up="$4"
+    out_json="$BENCH_OUT_DIR/${scenario}.json"
+
+    log "running scenario: $scenario -> $out_json"
+
+    # `--prepare` runs before every measured iteration, ensuring a clean
+    # destination so we measure full-copy throughput, not no-op quick-check.
+    # `--ignore-failure` is omitted: any non-zero exit should fail the bench.
+    hyperfine \
+        --warmup "$BENCH_WARMUP" \
+        --runs "$BENCH_RUNS" \
+        --export-json "$out_json" \
+        --command-name "oc-rsync" \
+            --prepare "rm -rf '$dst_oc'/* '$dst_oc'/.[!.]* 2>/dev/null || true" \
+            "'$OC_RSYNC' -a '$src/' '$dst_oc/'" \
+        --command-name "upstream-rsync" \
+            --prepare "rm -rf '$dst_up'/* '$dst_up'/.[!.]* 2>/dev/null || true" \
+            "'$UPSTREAM_RSYNC' -a '$src/' '$dst_up/'"
+}
+
+run_scenario "large_1gib"   "$LARGE_SRC" "$LARGE_DST_OC" "$LARGE_DST_UP"
+run_scenario "small_10000"  "$SMALL_SRC" "$SMALL_DST_OC" "$SMALL_DST_UP"
+
+log "done. reports in: $BENCH_OUT_DIR"
+ls -la "$BENCH_OUT_DIR"


### PR DESCRIPTION
## Summary

Adds a best-effort Windows throughput benchmark that complements the
correctness story from PR #4297 (Windows interop). Same MSYS2-based
toolchain; uses hyperfine to compare wall-clock time of
`oc-rsync.exe --features iocp` vs upstream `rsync` from MSYS2.

- New driver `scripts/windows_throughput_bench.sh` (POSIX sh, runs
  under MSYS2 bash). Generates a 1 GiB single file plus a
  10000 x 4 KiB tree, then drives hyperfine and exports JSON.
  Skips gracefully if hyperfine / oc-rsync / upstream rsync are
  missing.
- New reusable workflow `.github/workflows/_benchmark-windows.yml`:
  installs MSYS2 (`rsync`, `hyperfine`, `diffutils`, `coreutils`),
  builds with `--release --features iocp`, runs the driver, uploads
  per-scenario JSON as the `windows-throughput-bench` artefact.
  60-minute timeout, `continue-on-error: true`.
- Wires the reusable workflow into `benchmark.yml` as a child job on
  tag push, weekly cron (Sun 04:17 UTC), and manual dispatch. Not
  added to required CI to keep wall-clock variance from blocking
  merges.
- New `docs/benchmarks/windows-throughput.md` covering JSON layout,
  the ratio computation, and acceptable bands (within 20% for the
  single large file; within 50% for the small-files tree).

## Test plan

- [ ] Trigger via `workflow_dispatch` on this branch and confirm the
      job completes within the 60-minute budget on `windows-latest`.
- [ ] Verify the `windows-throughput-bench` artefact contains
      `large_1gib.json` and `small_10000.json` with non-empty
      `results[].times` arrays.
- [ ] Confirm the step summary renders both JSON blobs.
- [ ] Re-run locally on a Windows host with
      `BENCH_RUNS=5 BENCH_WARMUP=2 bash scripts/windows_throughput_bench.sh`
      and check the ratios sit inside the bands documented in
      `docs/benchmarks/windows-throughput.md`.
- [ ] Confirm existing `_interop-windows.yml` workflow is unchanged
      and still passes.