### PR TITLE
docs(design): mmap vs SQPOLL+READ_FIXED for basis reads + bench scaffold

### DIFF
--- a/crates/fast_io/Cargo.toml
+++ b/crates/fast_io/Cargo.toml
@@ -119,6 +119,15 @@ name = "iouring_sqpoll_vs_regular"
 harness = false
 required-features = ["io_uring"]
 
+# Linux-only bench: mmap vs IORING_OP_READ_FIXED + SQPOLL on a 1 GiB
+# basis-read workload. Gated by OC_RSYNC_BENCH_IOURING_RING=1 and
+# OC_RSYNC_BENCH_IOURING_SQPOLL=1 (the latter only for the read_fixed cell;
+# the mmap cell needs no gate). Resolves the design tension documented in
+# docs/design/mmap-vs-sqpoll-conflict-resolution.md (follow-up to #2158).
+[[bench]]
+name = "mmap_vs_read_fixed_basis"
+harness = false
+
 # Windows-only bench: IOCP writer path (IocpDiskBatch) vs std::fs and
 # BufWriter baselines across 4 KiB / 64 KiB / 1 MiB payloads. The bench
 # file is cfg-gated to `target_os = "windows"` and the `iocp` feature; on

--- a/crates/fast_io/benches/mmap_vs_read_fixed_basis.rs
+++ b/crates/fast_io/benches/mmap_vs_read_fixed_basis.rs
@@ -1,0 +1,501 @@
+//! mmap vs `IORING_OP_READ_FIXED` + SQPOLL on a 1 GiB basis-read workload.
+//!
+//! Tracking issue: oc-rsync follow-up to #2158 (SQPOLL defensive disable
+//! when `mmap_basis_active`). Companion document:
+//! `docs/design/mmap-vs-sqpoll-conflict-resolution.md`.
+//!
+//! # What this bench measures
+//!
+//! The two cells synthesise the basis-file read pattern that the
+//! `DeltaApplicator` issues during delta application
+//! (`crates/transfer/src/delta_apply/applicator.rs:161-176`). The basis
+//! file is 1 GiB; each iteration issues a fixed number of random reads
+//! of 1 KiB to 64 KiB at random offsets, mirroring how the delta
+//! algorithm jumps around the basis file as it splices unchanged blocks
+//! into the destination.
+//!
+//! - `mmap_basis_read`: opens the basis file via `memmap2::MmapOptions`
+//!   and dereferences `mmap[off..off+len]` for each read. This is the
+//!   current `MmapStrategy` path
+//!   (`crates/transfer/src/map_file/mmap.rs:27, 38`) when the upstream
+//!   selector lets mmap through.
+//! - `read_fixed_basis_with_sqpoll`: opens the basis file and reads via
+//!   `IORING_OP_READ_FIXED` against a `RegisteredBufferGroup`-equivalent
+//!   set of page-aligned heap buffers, on a ring built with
+//!   `IORING_SETUP_SQPOLL`. This is the option-1 candidate from the
+//!   design doc.
+//!
+//! # Hypothesis
+//!
+//! mmap wins on warm-cache, random-access workloads because dereferencing
+//! a populated page is a single load instruction with no syscall.
+//! `READ_FIXED` + SQPOLL wins on cold-cache or large working-set
+//! workloads because the SQPOLL kthread reaps SQEs without the
+//! per-batch `io_uring_enter(2)` and `READ_FIXED` skips
+//! `iov_iter_get_pages` on each submission. The crossover point is
+//! workload-dependent; this bench is designed to surface it for the
+//! 1 GiB basis-file case.
+//!
+//! # When to run
+//!
+//! Linux 5.13+ for unprivileged SQPOLL; 5.6-5.12 requires `CAP_SYS_NICE`
+//! and the bench will skip cleanly when the kernel rejects the request.
+//!
+//! ```sh
+//! OC_RSYNC_BENCH_IOURING_RING=1 \
+//! OC_RSYNC_BENCH_IOURING_SQPOLL=1 \
+//!   cargo bench -p fast_io --bench mmap_vs_read_fixed_basis
+//! ```
+//!
+//! Without either gate the bench prints a skip line and exits 0.
+//!
+//! # What the numbers inform
+//!
+//! Outcome -> action (see `docs/design/mmap-vs-sqpoll-conflict-resolution.md`
+//! section "Trigger conditions"):
+//!
+//! - `read_fixed_basis_with_sqpoll` >= `mmap_basis_read`: adopt option 1
+//!   (drop mmap for SQPOLL-enabled basis reads, use READ_FIXED).
+//! - Within +/- 10%: still option 1; SQPOLL syscall savings amortise.
+//! - Regression > 10%: adopt option 2 (size-threshold heuristic) and
+//!   tune the threshold from the per-chunk-size breakdown below.
+//!
+//! # CI gating
+//!
+//! All measurement code is gated on
+//! `cfg(all(target_os = "linux", feature = "io_uring"))`; the macOS,
+//! Windows, and feature-off builds compile to a stub `main` that prints
+//! a skip line. The `Cargo.toml` `[[bench]]` entry does not declare
+//! `required-features` because the stub `main` keeps the bench
+//! compilable on every host.
+
+#[cfg(all(target_os = "linux", feature = "io_uring"))]
+use std::alloc::{Layout, alloc_zeroed, dealloc};
+#[cfg(all(target_os = "linux", feature = "io_uring"))]
+use std::env;
+#[cfg(all(target_os = "linux", feature = "io_uring"))]
+use std::fs::{File, OpenOptions};
+#[cfg(all(target_os = "linux", feature = "io_uring"))]
+use std::io::Write;
+#[cfg(all(target_os = "linux", feature = "io_uring"))]
+use std::os::unix::io::AsRawFd;
+#[cfg(all(target_os = "linux", feature = "io_uring"))]
+use std::path::PathBuf;
+#[cfg(all(target_os = "linux", feature = "io_uring"))]
+use std::ptr::NonNull;
+
+#[cfg(all(target_os = "linux", feature = "io_uring"))]
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+#[cfg(all(target_os = "linux", feature = "io_uring"))]
+use io_uring::{IoUring, opcode, types};
+#[cfg(all(target_os = "linux", feature = "io_uring"))]
+use memmap2::MmapOptions;
+#[cfg(all(target_os = "linux", feature = "io_uring"))]
+use tempfile::TempDir;
+
+/// Basis-file size. Sized at 1 GiB to match the design-doc workload and
+/// to ensure the working set exceeds typical page-cache residence on a
+/// CI runner so cold-page costs are visible.
+#[cfg(all(target_os = "linux", feature = "io_uring"))]
+const BASIS_BYTES: u64 = 1024 * 1024 * 1024;
+
+/// Number of reads per iteration. The design doc calls for 100
+/// iterations; Criterion controls iteration count via `sample_size`,
+/// and each iteration issues this many reads. Total bench wall time
+/// stays reasonable under the configured `sample_size(10)` on an NVMe
+/// host.
+#[cfg(all(target_os = "linux", feature = "io_uring"))]
+const READS_PER_ITER: usize = 100;
+
+/// Minimum read size. Matches the lower bound of the delta-apply COPY
+/// token range; smaller copies are folded into the LITERAL stream.
+#[cfg(all(target_os = "linux", feature = "io_uring"))]
+const MIN_READ: usize = 1024;
+
+/// Maximum read size. Matches `IoUringConfig::buffer_size` for the
+/// large-file preset (`crates/fast_io/src/io_uring_common.rs:151`),
+/// so registered-buffer slots can hold any single read without
+/// chunking.
+#[cfg(all(target_os = "linux", feature = "io_uring"))]
+const MAX_READ: usize = 64 * 1024;
+
+/// SQ entries. Sized larger than the per-iteration submission count
+/// chunk so the ring never blocks on `submit_and_wait` for
+/// backpressure rather than for kernel completion latency.
+#[cfg(all(target_os = "linux", feature = "io_uring"))]
+const SQ_ENTRIES: u32 = 256;
+
+/// SQPOLL kernel-thread idle timeout in milliseconds. Matches the
+/// production default in `IoUringConfig::sqpoll_idle_ms` so the bench
+/// is representative of what callers actually configure.
+#[cfg(all(target_os = "linux", feature = "io_uring"))]
+const SQPOLL_IDLE_MS: u32 = 100;
+
+/// Number of registered buffers. One per concurrent in-flight read,
+/// matching the small-files preset
+/// (`crates/fast_io/src/io_uring_common.rs:174`).
+#[cfg(all(target_os = "linux", feature = "io_uring"))]
+const REG_BUF_COUNT: usize = 8;
+
+/// Shared env-var gate. Set to `1` to actually run any io_uring cell.
+#[cfg(all(target_os = "linux", feature = "io_uring"))]
+const ENABLE_ENV: &str = "OC_RSYNC_BENCH_IOURING_RING";
+
+/// SQPOLL-specific gate. Set to `1` (in addition to `ENABLE_ENV`) to
+/// run the SQPOLL cell. Kept separate so unprivileged hosts can still
+/// run the mmap cell without attempting SQPOLL setup.
+#[cfg(all(target_os = "linux", feature = "io_uring"))]
+const SQPOLL_ENV: &str = "OC_RSYNC_BENCH_IOURING_SQPOLL";
+
+/// Linear-congruential pseudo-random generator. Deterministic so the
+/// two cells exercise the exact same offset / size pattern across
+/// iterations. Borrowed from Numerical Recipes; full-period 2^64.
+#[cfg(all(target_os = "linux", feature = "io_uring"))]
+struct Lcg(u64);
+
+#[cfg(all(target_os = "linux", feature = "io_uring"))]
+impl Lcg {
+    fn new(seed: u64) -> Self {
+        Self(
+            seed.wrapping_mul(6_364_136_223_846_793_005)
+                .wrapping_add(1_442_695_040_888_963_407),
+        )
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        self.0 = self
+            .0
+            .wrapping_mul(6_364_136_223_846_793_005)
+            .wrapping_add(1_442_695_040_888_963_407);
+        self.0
+    }
+}
+
+/// Generates the random `(offset, len)` plan shared by both cells.
+///
+/// Both bench cells consume the exact same plan to make wall-time
+/// deltas attributable to dispatch style rather than offset choice.
+#[cfg(all(target_os = "linux", feature = "io_uring"))]
+fn build_plan(seed: u64) -> Vec<(u64, usize)> {
+    let mut rng = Lcg::new(seed);
+    let mut plan = Vec::with_capacity(READS_PER_ITER);
+    for _ in 0..READS_PER_ITER {
+        let len_range = (MAX_READ - MIN_READ) as u64;
+        let len = MIN_READ + (rng.next_u64() % len_range) as usize;
+        let max_off = BASIS_BYTES - len as u64;
+        let off = rng.next_u64() % max_off;
+        plan.push((off, len));
+    }
+    plan
+}
+
+/// Writes a 1 GiB pseudo-random basis file at `path`. Streamed via
+/// 1 MiB chunks so peak RSS stays bounded.
+#[cfg(all(target_os = "linux", feature = "io_uring"))]
+fn build_basis(path: &PathBuf) {
+    let mut f = File::create(path).expect("basis create");
+    let chunk_size = 1024 * 1024usize;
+    let mut buf = vec![0u8; chunk_size];
+    let mut rng = Lcg::new(0xCAFE_F00D_DEAD_BEEFu64);
+    let mut remaining = BASIS_BYTES;
+    while remaining > 0 {
+        let take = remaining.min(chunk_size as u64) as usize;
+        for b in buf[..take].iter_mut() {
+            *b = (rng.next_u64() & 0xff) as u8;
+        }
+        f.write_all(&buf[..take]).expect("basis write");
+        remaining -= take as u64;
+    }
+    f.sync_all().expect("basis sync");
+}
+
+/// Returns `true` when the kernel accepts a plain `io_uring_setup(2)`.
+#[cfg(all(target_os = "linux", feature = "io_uring"))]
+fn io_uring_usable() -> bool {
+    IoUring::new(SQ_ENTRIES).is_ok()
+}
+
+/// Returns `true` when the kernel accepts `io_uring_setup(2)` with
+/// `IORING_SETUP_SQPOLL`. Without `CAP_SYS_NICE` on pre-5.13 kernels
+/// this returns `false` and the SQPOLL cell skips.
+#[cfg(all(target_os = "linux", feature = "io_uring"))]
+fn sqpoll_usable() -> bool {
+    IoUring::<io_uring::squeue::Entry>::builder()
+        .setup_sqpoll(SQPOLL_IDLE_MS)
+        .build(SQ_ENTRIES)
+        .is_ok()
+}
+
+#[cfg(all(target_os = "linux", feature = "io_uring"))]
+fn iouring_enabled() -> bool {
+    matches!(env::var(ENABLE_ENV), Ok(v) if v == "1") && io_uring_usable()
+}
+
+#[cfg(all(target_os = "linux", feature = "io_uring"))]
+fn sqpoll_enabled() -> bool {
+    iouring_enabled() && matches!(env::var(SQPOLL_ENV), Ok(v) if v == "1") && sqpoll_usable()
+}
+
+/// Owns a set of page-aligned heap buffers registered with the ring
+/// via `IORING_REGISTER_BUFFERS`. Mirrors the production
+/// `RegisteredBufferGroup` shape
+/// (`crates/fast_io/src/io_uring/registered_buffers/registry.rs`) at
+/// the minimum complexity needed for this bench.
+#[cfg(all(target_os = "linux", feature = "io_uring"))]
+struct RegBufs {
+    ptrs: Vec<NonNull<u8>>,
+    layout: Layout,
+}
+
+#[cfg(all(target_os = "linux", feature = "io_uring"))]
+impl RegBufs {
+    fn new(count: usize, buf_size: usize) -> Self {
+        let layout = Layout::from_size_align(buf_size, 4096).expect("layout");
+        let mut ptrs = Vec::with_capacity(count);
+        for _ in 0..count {
+            // SAFETY: layout has non-zero size (buf_size > 0) and a
+            // valid power-of-two alignment (4096). NonNull::new returns
+            // None only on allocation failure, which we surface as a
+            // panic since this is bench setup.
+            let raw = unsafe { alloc_zeroed(layout) };
+            ptrs.push(NonNull::new(raw).expect("alloc"));
+        }
+        Self { ptrs, layout }
+    }
+
+    fn iovecs(&self) -> Vec<libc::iovec> {
+        self.ptrs
+            .iter()
+            .map(|p| libc::iovec {
+                iov_base: p.as_ptr().cast(),
+                iov_len: self.layout.size(),
+            })
+            .collect()
+    }
+}
+
+#[cfg(all(target_os = "linux", feature = "io_uring"))]
+impl Drop for RegBufs {
+    fn drop(&mut self) {
+        for p in self.ptrs.drain(..) {
+            // SAFETY: each pointer was returned by alloc_zeroed with
+            // the same layout we now pass to dealloc. The ring is
+            // dropped before the RegBufs (Criterion drops captured
+            // setup state in LIFO order), so the kernel no longer
+            // references the pages by the time we free.
+            unsafe { dealloc(p.as_ptr(), self.layout) };
+        }
+    }
+}
+
+/// Issues `(off, len)` reads via the mmap path. Sums the first and
+/// last byte of each window into a black-box accumulator so the
+/// optimiser cannot elide the dereference.
+///
+/// # Panics
+///
+/// Panics if `MmapOptions::map` rejects the file (typical on a host
+/// without enough virtual address space or where the file vanished
+/// between basis creation and the read), or if a planned `(off, len)`
+/// pair would index past the mapped region (cannot happen unless
+/// `build_plan` is changed without updating `BASIS_BYTES`). Surfaced
+/// via `expect(..)` so the regression aborts the sample rather than
+/// producing a silently skewed number.
+#[cfg(all(target_os = "linux", feature = "io_uring"))]
+fn run_mmap(file: &File, plan: &[(u64, usize)]) -> u64 {
+    // SAFETY: file is a freshly opened read-only fd referring to a
+    // regular file on local storage; both preconditions of
+    // MmapOptions::map.
+    let mmap = unsafe { MmapOptions::new().map(file) }.expect("mmap");
+    let mut acc: u64 = 0;
+    for &(off, len) in plan {
+        let slice = &mmap[off as usize..off as usize + len];
+        acc = acc.wrapping_add(slice[0] as u64);
+        acc = acc.wrapping_add(slice[len - 1] as u64);
+    }
+    acc
+}
+
+/// Issues `(off, len)` reads via `IORING_OP_READ_FIXED` on a SQPOLL
+/// ring. Sums the first and last byte of each completed buffer into a
+/// black-box accumulator.
+///
+/// # Panics
+///
+/// Panics if `submission().push` rejects an SQE (only possible if the
+/// ring's submission queue overflows, which would indicate
+/// `SQ_ENTRIES` is mis-sized for `REG_BUF_COUNT`), if
+/// `submit_and_wait` returns an error (kernel rejected the
+/// submission - the bench cannot proceed without completions), or if
+/// a CQE reports a negative result (kernel read error - typically EIO
+/// on a faulty storage device). Surfaced via `expect(..)` so the
+/// regression aborts the sample rather than producing a silently
+/// skewed number.
+#[cfg(all(target_os = "linux", feature = "io_uring"))]
+fn run_read_fixed(ring: &mut IoUring, file: &File, bufs: &RegBufs, plan: &[(u64, usize)]) -> u64 {
+    let fd = types::Fd(file.as_raw_fd());
+    let mut acc: u64 = 0;
+    // Process the plan in rounds of REG_BUF_COUNT submissions; one
+    // registered buffer per in-flight SQE.
+    for round in plan.chunks(REG_BUF_COUNT) {
+        let n = round.len() as u32;
+        for (i, &(off, len)) in round.iter().enumerate() {
+            let slot = i % REG_BUF_COUNT;
+            let entry =
+                opcode::ReadFixed::new(fd, bufs.ptrs[slot].as_ptr(), len as u32, slot as u16)
+                    .offset(off)
+                    .build()
+                    .user_data(i as u64);
+            // SAFETY: the registered buffer at `slot` is valid for
+            // the duration of submit_and_wait below; the kernel
+            // dereferences the pointer only between push and the
+            // matching CQE arrival, which is fully contained in this
+            // round.
+            unsafe {
+                ring.submission()
+                    .push(&entry)
+                    .expect("submission queue full");
+            }
+        }
+        ring.submit_and_wait(n as usize).expect("submit_and_wait");
+        let mut got = 0u32;
+        while got < n {
+            let cqe = ring.completion().next().expect("missing CQE");
+            let res = cqe.result();
+            assert!(res >= 0, "read_fixed CQE error: {}", -res);
+            let idx = cqe.user_data() as usize;
+            let slot = idx % REG_BUF_COUNT;
+            let len = round[idx].1;
+            // SAFETY: the registered buffer at `slot` is alive for
+            // the entirety of the round; we read the first and last
+            // byte of the chunk the kernel just wrote.
+            unsafe {
+                let p = bufs.ptrs[slot].as_ptr();
+                acc = acc.wrapping_add(*p as u64);
+                acc = acc.wrapping_add(*p.add(len - 1) as u64);
+            }
+            got += 1;
+        }
+    }
+    acc
+}
+
+/// Runs the `mmap_basis_read` cell. Establishes the mmap baseline.
+///
+/// # Panics
+///
+/// Panics if bench setup or measurement fails: `TempDir::new` cannot
+/// create a scratch directory, `OpenOptions::open` rejects the basis
+/// file, or `run_mmap` (which forwards mmap and slice-index errors)
+/// fails. Surfaced via `expect(..)` so the regression aborts the
+/// sample rather than producing a silently skewed number.
+#[cfg(all(target_os = "linux", feature = "io_uring"))]
+fn bench_mmap(c: &mut Criterion) {
+    let mut group = c.benchmark_group("mmap_vs_read_fixed_basis");
+    group.sample_size(10);
+    group.throughput(Throughput::Elements(READS_PER_ITER as u64));
+
+    group.bench_function("mmap_basis_read", |b| {
+        let dir = TempDir::new().expect("tempdir");
+        let basis = dir.path().join("basis.bin");
+        build_basis(&basis);
+        b.iter_with_setup(
+            || {
+                let file = OpenOptions::new()
+                    .read(true)
+                    .open(&basis)
+                    .expect("basis open");
+                let plan = build_plan(0xA5A5_5A5Au64);
+                (file, plan)
+            },
+            |(file, plan)| {
+                criterion::black_box(run_mmap(&file, &plan));
+            },
+        );
+        drop(dir);
+    });
+
+    group.finish();
+}
+
+/// Runs the `read_fixed_basis_with_sqpoll` cell. Skips cleanly when
+/// the host kernel rejects SQPOLL setup or the SQPOLL gate env var is
+/// unset.
+///
+/// # Panics
+///
+/// Panics if bench setup or measurement fails: `TempDir::new` cannot
+/// create a scratch directory, the SQPOLL ring builder rejects the
+/// request on a host that previously reported SQPOLL as usable, the
+/// registered-buffer registration syscall fails, or `run_read_fixed`
+/// (which forwards SQE submission and CQE errors) fails. Surfaced via
+/// `expect(..)` so the regression aborts the sample rather than
+/// producing a silently skewed number.
+#[cfg(all(target_os = "linux", feature = "io_uring"))]
+fn bench_read_fixed_sqpoll(c: &mut Criterion) {
+    if !sqpoll_enabled() {
+        eprintln!(
+            "Skipping mmap_vs_read_fixed_basis::read_fixed_basis_with_sqpoll: set \
+             {ENABLE_ENV}=1 and {SQPOLL_ENV}=1 on a Linux host where IORING_SETUP_SQPOLL \
+             is accepted (5.13+ unprivileged, or CAP_SYS_NICE on 5.6-5.12)."
+        );
+        return;
+    }
+
+    let mut group = c.benchmark_group("mmap_vs_read_fixed_basis");
+    group.sample_size(10);
+    group.throughput(Throughput::Elements(READS_PER_ITER as u64));
+
+    group.bench_function("read_fixed_basis_with_sqpoll", |b| {
+        let dir = TempDir::new().expect("tempdir");
+        let basis = dir.path().join("basis.bin");
+        build_basis(&basis);
+        b.iter_with_setup(
+            || {
+                let file = OpenOptions::new()
+                    .read(true)
+                    .open(&basis)
+                    .expect("basis open");
+                let mut ring = IoUring::<io_uring::squeue::Entry>::builder()
+                    .setup_sqpoll(SQPOLL_IDLE_MS)
+                    .build(SQ_ENTRIES)
+                    .expect("sqpoll ring");
+                let bufs = RegBufs::new(REG_BUF_COUNT, MAX_READ);
+                let iovecs = bufs.iovecs();
+                // SAFETY: iovecs reference page-aligned heap buffers
+                // owned by `bufs` for the lifetime of the ring; the
+                // ring is dropped before bufs by virtue of LIFO drop
+                // order in the captured tuple.
+                unsafe {
+                    ring.submitter()
+                        .register_buffers(&iovecs)
+                        .expect("register_buffers");
+                }
+                let plan = build_plan(0xA5A5_5A5Au64);
+                (file, ring, bufs, plan)
+            },
+            |(file, mut ring, bufs, plan)| {
+                criterion::black_box(run_read_fixed(&mut ring, &file, &bufs, &plan));
+            },
+        );
+        drop(dir);
+    });
+
+    group.finish();
+}
+
+#[cfg(all(target_os = "linux", feature = "io_uring"))]
+criterion_group!(
+    mmap_vs_read_fixed_basis,
+    bench_mmap,
+    bench_read_fixed_sqpoll,
+);
+#[cfg(all(target_os = "linux", feature = "io_uring"))]
+criterion_main!(mmap_vs_read_fixed_basis);
+
+#[cfg(not(all(target_os = "linux", feature = "io_uring")))]
+fn main() {
+    eprintln!(
+        "mmap_vs_read_fixed_basis: skipped (Linux-only bench; requires the `io_uring` feature)"
+    );
+}

--- a/docs/design/mmap-vs-sqpoll-conflict-resolution.md
+++ b/docs/design/mmap-vs-sqpoll-conflict-resolution.md
@@ -1,0 +1,284 @@
+# Resolving the mmap vs SQPOLL conflict on basis-file reads
+
+Tracking issue: oc-rsync follow-up to #2158.
+
+Companion documents already in tree:
+
+- `docs/design/basis-file-io-policy.md` (#1666) - selector rule that forbids
+  `MmapStrategy` whenever an io_uring writer is active on the same plan.
+- `docs/audits/io-uring-sqpoll-mmap-interaction.md` - re-verification of the
+  SQPOLL + mmap hazard that motivated #2158.
+- `docs/audits/mmap-page-fault-iouring-sqpoll.md` (#1661) - original kernel
+  page-fault analysis.
+- `docs/audits/iouring-sqpoll-bench-plan.md` (#1626) - SQPOLL bench plan
+  predating #2158.
+- `crates/fast_io/benches/iouring_sqpoll_vs_regular.rs` - existing SQPOLL
+  bench scaffold (small-file write workload).
+
+This document does not change any wired dispatch. The implementation is
+deferred until the bench scaffold added in this PR
+(`crates/fast_io/benches/mmap_vs_read_fixed_basis.rs`) produces data.
+
+## Current state: the defensive disable site
+
+`IoUringConfig::build_ring` refuses `setup_sqpoll(..)` whenever the caller
+has flagged `mmap_basis_active: true` on the same transfer plan:
+
+- `crates/fast_io/src/io_uring/config.rs:343-370` - the gate. The relevant
+  predicate is `let sqpoll_safe = sqpoll_requested && !self.mmap_basis_active;`
+  on line 345. When SQPOLL was requested but the mmap-basis flag is set,
+  the constructor emits a `debug_log!(Io, 1, ..)` warning, sets the global
+  `SQPOLL_FALLBACK` flag, and falls through to a plain (non-SQPOLL) ring
+  via `RawIoUring::new(self.sq_entries)`.
+- `crates/fast_io/src/io_uring_common.rs:110-118` - the `mmap_basis_active`
+  field on `IoUringConfig` and its doc-string. Same field appears on the
+  non-Linux stub for source-level parity.
+- `crates/fast_io/src/io_uring/config.rs:779-810` - the unit tests
+  `build_ring_sqpoll_with_mmap_basis_disables_sqpoll` and
+  `build_ring_no_sqpoll_with_mmap_basis_no_warning` pin the behaviour.
+
+The flag is set by callers that cannot prove the upstream selector
+(`AdaptiveMapStrategy::open_buffered` in
+`crates/transfer/src/map_file/adaptive.rs:70`) successfully forced
+`BufferedMap` for the basis file on this transfer plan. The flag is the
+last line of defence; the primary defence is the basis-file selector in
+`crates/transfer/src/delta_apply/applicator.rs:161-176`, which downgrades
+to `BufferedMap` whenever the writer is io_uring-backed.
+
+## Why the disable is correct
+
+Pairing `IORING_SETUP_SQPOLL` with a file-backed `mmap(2)` region is a
+documented kernel hazard. The SQPOLL kernel thread (`kthread`) services
+SQEs from a different `task_struct` than the userspace caller. It does
+not own the caller's `mm` (memory descriptor), so two failure modes
+appear when an SQE references a userspace address that lives in a
+file-backed VMA:
+
+1. **Cold-page faults bounce to `task_work`.** When the SQPOLL kthread
+   dereferences an mmap'd address whose PTE is not yet populated, the
+   fault handler cannot resolve it inside the kthread because the kthread
+   has no `mm`. The fault is queued onto `task_work` of the originating
+   user task, which only runs on the user task's return-to-userspace
+   boundary. On pre-6.x kernels this is a deadlock loop when the user
+   task is itself blocked waiting on the SQPOLL ring. See `io_uring(7)`
+   under `IORING_SETUP_SQPOLL`, kernel commit `b3a87e5b16cb` ("io_uring:
+   use poll for fixed buffers when SQPOLL is set"), and the long-form
+   analysis in `docs/audits/io_uring_sqpoll_mmap_pagefault.md`.
+
+2. **Concurrent truncation surfaces as in-kernel `SIGBUS`.** A third
+   party `truncate(2)` shrinks the backing file beneath the SQPOLL
+   kthread's iovec. The page-fault path delivers `SIGBUS` to the
+   originating task, which the user task did not expect because it
+   never made the offending syscall. Upstream rsync sidesteps this
+   class of bug by reading basis files via `read(2)` rather than
+   `mmap(2)` (`fileio.c:214-217`); see
+   `docs/design/basis-file-io-policy.md` section "Correctness against
+   concurrent truncation" for the upstream-fidelity reasoning.
+
+The defensive disable in `config.rs:343-370` is therefore correct: it
+removes the dangerous combination at ring-construction time, before any
+SQE is built. It is a configuration-time guard, never a runtime failure,
+and it surfaces the downgrade via `SQPOLL_FALLBACK` so callers can
+report it in diagnostics.
+
+## The design tension
+
+The defensive disable closes the hazard but creates a performance
+inversion that the bench scaffold added in this PR is designed to
+quantify:
+
+- **Large files benefit most from SQPOLL.** SQPOLL eliminates the
+  per-batch `io_uring_enter(2)` syscall. The win scales with submission
+  rate, and submission rate scales with file size at fixed chunk size.
+  A 1 GiB basis file delta-applied in 64 KiB chunks issues ~16 k reads;
+  removing the syscall on every batch matters proportionally.
+- **Large files are most likely mmap'd.** `AdaptiveMapStrategy::open`
+  selects `MmapStrategy` for files at or above `MMAP_THRESHOLD` (1 MiB),
+  precisely because mmap pays for itself only when amortised over a
+  large region (`crates/transfer/src/map_file/adaptive.rs:36-54`).
+- **Result.** Exactly the workloads that would benefit most from SQPOLL
+  are the workloads where the defensive disable trips. Today both
+  strategies are unconditionally bypassed for io_uring-backed writers:
+  the `DeltaApplicator` forces `BufferedMap` (no mmap), and SQPOLL
+  is off in every preset, so the inversion is latent. The moment a
+  caller turns SQPOLL on for a transfer with a large basis file, the
+  defensive disable activates and we lose the SQPOLL throughput win.
+
+## Resolution strategies
+
+Three resolutions are viable. Each removes the inversion by removing
+either the mmap dependency, the SQPOLL request, or both at the right
+granularity.
+
+### Option 1: Drop mmap for SQPOLL-enabled basis reads, use READ_FIXED
+
+Replace `MmapStrategy` for the basis file with
+`IORING_OP_READ_FIXED` against the existing `RegisteredBufferGroup`
+(`crates/fast_io/src/io_uring/registered_buffers/submit.rs:29-100`).
+Registered buffers are heap-backed pages pinned by the kernel via
+`get_user_pages_fast`; they are not file-backed VMAs, so the SQPOLL
+kthread can read into them without triggering the page-fault hazard
+above. The basis-file read becomes a normal kernel-async read into a
+pre-registered destination buffer, indistinguishable in shape from the
+delta-apply write path that already runs under io_uring.
+
+**Pros.**
+
+- Removes the race by removing the mmap. SQPOLL becomes free to enable
+  on the same plan.
+- Uses an existing, hardened code path (`submit_read_fixed_batch`).
+  No new SQE class, no new kernel surface, no new audit material.
+- Aligns the read and write paths on the same dispatch shape, so
+  `IoUringDiskBatch`-style batching can amortise across both.
+
+**Cons.**
+
+- Removes the userspace caching that mmap gives non-SQPOLL paths if we
+  go all-in. The parallel-checksum digest path
+  (`crates/checksums/src/parallel/files.rs:42, 237, 340`) currently
+  benefits from page-cache sharing across digest workers via mmap. A
+  blanket switch would force those readers onto explicit I/O.
+- The basis read becomes a kernel-async submission with SQE depth equal
+  to `MMAP_THRESHOLD / chunk_size`. For 1 MiB and 64 KiB that is 16
+  SQEs per window slide, which is fine, but tail latency on small
+  windows is now bounded by completion latency rather than page-cache
+  hit time.
+
+### Option 2: Size-threshold heuristic
+
+Keep `MmapStrategy` below a tunable size threshold `N` and force the
+buffered (`BufferedMap`) or `READ_FIXED` path above. The threshold
+captures the practical observation that mmap's setup cost
+amortises poorly on multi-GiB files, and that the SQPOLL benefit
+dominates at multi-GiB scale.
+
+**Pros.**
+
+- Pragmatic and tunable per host / per workload via the existing
+  `IoUringConfig` knobs.
+- Preserves mmap's win on the "small but eligible" basis files
+  (1 MiB to N MiB) where neither SQPOLL nor `READ_FIXED` are a clear
+  win.
+- Composes cleanly with the existing `AdaptiveMapStrategy::open_with_threshold`
+  entry point (`crates/transfer/src/map_file/adaptive.rs:45`).
+
+**Cons.**
+
+- The threshold is a magic number; it will drift as kernel versions
+  and storage stacks change.
+- Still relies on the operator to opt in to SQPOLL; if they do not,
+  the threshold buys nothing.
+
+### Option 3: Per-file dispatch on observed throughput
+
+Decide mmap vs SQPOLL+READ_FIXED per basis file based on size at open
+time plus rolling per-host throughput statistics. New basis files start
+on the size-threshold heuristic from option 2 and migrate toward the
+faster path as the running average accumulates evidence.
+
+**Pros.**
+
+- Captures genuine per-host variance (NVMe vs spinning rust, ext4 vs
+  XFS, kernel 5.6 vs 6.10).
+- Best long-term throughput once the statistics warm up.
+
+**Cons.**
+
+- More logic, more state to persist across transfers, more code paths
+  to audit. Per-file dispatch interacts non-trivially with the per-plan
+  `mmap_basis_active` flag.
+- Hard to test deterministically; the rolling statistics path is
+  inherently non-reproducible.
+- Cost only pays off on long-running transfers with many basis files.
+  CLI single-shot invocations rarely accumulate enough samples to
+  beat the static heuristic.
+
+## Recommendation
+
+**Adopt option 1 if and only if the bench scaffold added in this PR
+shows `IORING_OP_READ_FIXED` matches or exceeds `mmap` throughput on
+the 1 GiB random-read workload. Otherwise adopt option 2 with the
+threshold set at the smallest basis-file size where the bench shows a
+SQPOLL win exceeding 10%.**
+
+Rationale: option 1 is the minimal-surface fix. It deletes a dispatch
+mode rather than adding one, and it uses code paths that are already
+audited and tested. The only thing standing in its way is whether
+`READ_FIXED` can keep up with mmap on the read-heavy basis-apply
+pattern; that is exactly what the bench measures.
+
+Option 3 is explicitly out of scope until option 1 or 2 has shipped and
+real-world telemetry shows the static heuristic leaves measurable
+throughput on the table.
+
+## Trigger conditions
+
+Bench results from `crates/fast_io/benches/mmap_vs_read_fixed_basis.rs`
+gate the decision:
+
+| Bench result | Action |
+|---|---|
+| `read_fixed_basis_with_sqpoll` >= `mmap_basis_read` throughput | Adopt option 1. Implement per the plan below with `target = ReadFixed`. |
+| `read_fixed_basis_with_sqpoll` within -10% of `mmap_basis_read` | Adopt option 1. The SQPOLL syscall savings compensate the small per-read regression on long transfers; revisit if telemetry shows otherwise. |
+| `read_fixed_basis_with_sqpoll` regresses by >10% vs `mmap_basis_read` | Adopt option 2. Threshold-tune from the bench's per-chunk-size breakdown. |
+| Bench cannot run on the target host (kernel < 5.13, no `CAP_SYS_NICE`, etc.) | Hold the recommendation; keep the defensive disable. Re-run on a host that meets the prerequisites. |
+
+## Implementation plan (option 1)
+
+Each step is a separate PR for ease of review. Steps 2-5 are unblocked
+once step 1 lands.
+
+1. **Land this PR.** Adds the design doc and the bench scaffold. No
+   code change to live dispatch. CI runs the bench in skip mode (env
+   gates off) so the bench compiles on every PR but only executes when
+   an operator opts in.
+
+2. **Run the bench on a representative host.** Linux 6.x, NVMe, with
+   `OC_RSYNC_BENCH_IOURING_RING=1` and
+   `OC_RSYNC_BENCH_IOURING_SQPOLL=1` set. Record the per-chunk-size
+   throughput table in a follow-up audit entry under
+   `docs/audits/mmap-vs-read-fixed-basis-bench-results.md`. Pick the
+   resolution path per the trigger table above.
+
+3. **Wire the chosen path into `DeltaApplicator`.** Add a third arm
+   to the selector at `crates/transfer/src/delta_apply/applicator.rs:161-176`
+   that constructs a `RegisteredBufferGroup`-backed `MapStrategy`
+   implementation when SQPOLL is requested and the basis file exceeds
+   the threshold (option 1: threshold is "always"; option 2: threshold
+   is the bench-derived number). The new strategy lives next to
+   `BufferedMap` and `MmapStrategy` in `crates/transfer/src/map_file/`
+   and implements `MapStrategy::map_ptr` by issuing one
+   `submit_read_fixed_batch` per window slide.
+
+4. **Flip `mmap_basis_active` semantics.** With option 1 wired, the
+   flag stops being "we have an mmap on this plan, please disable
+   SQPOLL" and becomes "we have a file-backed mmap somewhere on this
+   plan, even non-basis (e.g. parallel checksum digest)". Re-audit the
+   call sites that set the flag and downgrade it to a no-op for the
+   basis-only path. Keep the gate in
+   `config.rs:343-370` for callers that still pass file-backed mmap
+   into the ring (the digest path; see audit
+   `docs/audits/io-uring-sqpoll-mmap-interaction.md` row "MmapReader
+   consumers - parallel checksum digest").
+
+5. **Enable SQPOLL on the io_uring receiver preset by default.** Flip
+   `sqpoll: true` on the receiver-side preset constructed in
+   `crates/transfer/src/disk_commit/config.rs` once steps 3 and 4 ship.
+   Validate with the existing
+   `iouring_sqpoll_vs_regular` bench plus the new
+   `mmap_vs_read_fixed_basis` bench on the same host. Roll back if
+   either regresses; the per-plan opt-in stays available via
+   `IoUringConfig::sqpoll`.
+
+## Non-goals
+
+- This document does not propose a wire-protocol change. The
+  basis-read dispatch is entirely a local concern.
+- This document does not propose changes to the non-basis mmap
+  consumers (parallel checksum digest, `BufferRing` provided-buffer
+  region, `IORING_OFF_PBUF_RING` mapping). Those remain governed by
+  `docs/audits/io-uring-sqpoll-mmap-interaction.md`.
+- This document does not propose dropping the defensive disable at
+  `config.rs:343-370`. The disable remains the load-bearing guard for
+  any future caller that combines SQPOLL with a file-backed mmap
+  outside the basis-read path.


### PR DESCRIPTION
## Summary

- Adds \`docs/design/mmap-vs-sqpoll-conflict-resolution.md\` covering the design tension left by #2158: the defensive SQPOLL disable when \`mmap_basis_active\` is set (\`crates/fast_io/src/io_uring/config.rs:343-370\`) trips precisely on the large basis files that would benefit most from SQPOLL.
- Walks through three resolutions (drop mmap for \`IORING_OP_READ_FIXED\` against registered buffers, size-threshold heuristic, per-file dispatch on observed throughput) and recommends option 1 conditional on bench data; otherwise option 2 tuned to the bench-derived crossover. Includes a five-step impl plan keyed to the bench output.
- Adds \`crates/fast_io/benches/mmap_vs_read_fixed_basis.rs\`, a Criterion bench scaffold with two cells (\`mmap_basis_read\`, \`read_fixed_basis_with_sqpoll\`) on a 1 GiB basis-file random-read workload. Both cells consume the same deterministic offset/length plan so wall-time deltas are attributable to dispatch style, not workload variance.
- Registers the bench in \`crates/fast_io/Cargo.toml\` with \`harness = false\`. The bench is Linux + \`io_uring\` feature gated and compiles to a stub \`main\` elsewhere; the SQPOLL cell skips cleanly without \`CAP_SYS_NICE\` on pre-5.13 kernels.
- No change to live dispatch. Implementation is deferred until the bench produces data on a representative Linux host with SQPOLL available.

## Test plan

- [ ] \`cargo fmt --all -- --check\` (clean locally; CI confirms).
- [ ] \`cargo build -p fast_io --benches\` on Linux with \`--features io_uring\` (CI nextest runs on Linux musl + macOS + Windows; bench compiles to the stub on non-Linux).
- [ ] On a Linux 5.13+ NVMe host with the env gates set, run \`OC_RSYNC_BENCH_IOURING_RING=1 OC_RSYNC_BENCH_IOURING_SQPOLL=1 cargo bench -p fast_io --bench mmap_vs_read_fixed_basis\` and record results in the follow-up audit entry referenced from the design doc's impl plan.