### PR TITLE
bench(engine): parallel-receive-delta perf for default-on decision (#1368 followup)

### DIFF
--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -210,3 +210,8 @@ harness = false
 [[bench]]
 name = "per_op_thresholds"
 harness = false
+
+[[bench]]
+name = "parallel_receive_delta_perf"
+harness = false
+required-features = ["parallel-receive-delta"]

--- a/crates/engine/benches/parallel_receive_delta_perf.rs
+++ b/crates/engine/benches/parallel_receive_delta_perf.rs
@@ -1,0 +1,333 @@
+//! Criterion bench: parallel-receive-delta apply vs sequential baseline (#1368
+//! followup).
+//!
+//! # Why this exists
+//!
+//! `crates/engine/src/concurrent_delta/parallel_apply.rs` ships gated behind
+//! the `parallel-receive-delta` feature (see PR #4319). Production receivers
+//! still drive the sequential apply loop in
+//! `crates/transfer/src/receiver/transfer.rs`. The promotion question is:
+//! does the parallel path beat the sequential baseline by enough, across
+//! the workload shapes a real receiver sees, to justify flipping the
+//! default - or to wire a runtime auto-detect heuristic that picks the
+//! winner per transfer?
+//!
+//! This bench answers the question without spinning up the full network
+//! stack. It drives the apply loop directly:
+//!
+//! - `sequential_apply` - iterates chunks in submission order and writes
+//!   each one to a per-file in-memory sink. This is the shape the receiver
+//!   currently runs.
+//! - `parallel_apply` - drives [`ParallelDeltaApplier`] from the engine
+//!   crate; the verify step fans across the rayon pool while the per-file
+//!   write stays serial under the per-file mutex.
+//!
+//! Both cells write to in-memory sinks rather than real files; the goal is
+//! to isolate apply-loop scheduling overhead from disk I/O. A separate
+//! integration bench (the production `delta_transfer_benchmark`) covers
+//! the disk path end-to-end and is the right place to add a real-I/O
+//! variant if the in-memory result motivates it.
+//!
+//! # Workload classes
+//!
+//! Three workloads bracket the receiver shapes that PR #4319 calls out as
+//! the candidates for a default flip:
+//!
+//! 1. `small_files` - 10,000 files of 4 KiB each. Mixed 50/50 delta vs
+//!    whole-file. Models a build artifact directory / source tree refresh.
+//!    Dispatch-overhead dominates; this is the cell that decides whether
+//!    parallel pays for itself at the small end.
+//! 2. `mixed` - 1,000 files with sizes drawn deterministically from
+//!    [4 KiB, 4 MiB]. 50/50 delta vs whole-file. Models a typical media or
+//!    project directory.
+//! 3. `large_files` - 10 files of 256 MiB each, all delta. Models VM
+//!    images, log archives, or container layers. Per-file parallelism is
+//!    limited by the per-file mutex; cross-file parallelism dominates.
+//!
+//! # Cross-references
+//!
+//! - PR #4319 / #1368 - the parallel-receive-delta scaffold this bench
+//!   evaluates.
+//! - `docs/design/parallel-receive-delta-application.md` - phased rollout
+//!   plan; section 6.3 is the bench evidence gate.
+//! - `docs/design/parallel-receive-delta-default-on.md` - companion design
+//!   doc that consumes this bench's output.
+//! - `crates/engine/benches/drain_parallel_alternatives.rs` - shape this
+//!   bench mirrors: workload sweep, throughput in elements/sec, private
+//!   rayon pool per cell.
+//!
+//! Run: `cargo bench -p engine --features parallel-receive-delta \
+//!     --bench parallel_receive_delta_perf`
+
+#![deny(unsafe_code)]
+#![cfg(feature = "parallel-receive-delta")]
+
+use std::hint::black_box;
+use std::io::{self, Write};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+
+use engine::concurrent_delta::{DeltaChunk, FileNdx, ParallelDeltaApplier};
+
+/// Chunk size used when carving a file payload into delta-apply units.
+/// Matches the upstream rsync `MAX_BLOCK_SIZE` (128 KiB) divided into
+/// the typical wire-chunk granularity the receiver sees; small enough to
+/// keep per-chunk verify cost meaningful, large enough that 256 MiB
+/// files do not balloon into millions of chunks.
+const CHUNK_SIZE: usize = 64 * 1024;
+
+/// Number of rayon workers to size the parallel applier with. Mirrors
+/// `rayon::current_num_threads()` on a typical 8-core dev box; bench
+/// reports are reproducible without depending on the ambient pool size.
+const PARALLEL_WORKERS: usize = 8;
+
+/// In-memory writer that records bytes written. Stand-in for the per-file
+/// destination writer the receiver normally opens; keeps the bench scoped
+/// to apply-loop scheduling rather than disk I/O.
+struct SinkWriter {
+    inner: Arc<Mutex<Vec<u8>>>,
+}
+
+impl SinkWriter {
+    fn new() -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+}
+
+impl Write for SinkWriter {
+    fn write(&mut self, data: &[u8]) -> io::Result<usize> {
+        let mut guard = self.inner.lock().expect("sink mutex poisoned");
+        guard.extend_from_slice(data);
+        Ok(data.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+/// Description of one file's worth of work for the bench. The receiver
+/// would resolve each chunk's payload from either the wire (literal) or
+/// the basis file (matched); here both shapes hit the same in-memory
+/// writer because the apply-loop cost is the same.
+struct FileSpec {
+    ndx: FileNdx,
+    /// Total bytes the file applies.
+    size: usize,
+    /// `true` if the file is delta-applied (mix of literal + matched
+    /// chunks); `false` if it is a whole-file write (all literal).
+    is_delta: bool,
+}
+
+/// Builds the chunk list for a workload. Each chunk is `CHUNK_SIZE` bytes
+/// (or the file remainder for the last chunk). For delta files, every
+/// other chunk is marked as a basis-match; whole-file files emit only
+/// literal chunks.
+fn build_chunks(spec: &FileSpec) -> Vec<DeltaChunk> {
+    let mut chunks = Vec::with_capacity(spec.size.div_ceil(CHUNK_SIZE));
+    let mut offset = 0usize;
+    let mut sequence: u64 = 0;
+    while offset < spec.size {
+        let len = CHUNK_SIZE.min(spec.size - offset);
+        // Use a deterministic byte pattern keyed by (ndx, sequence) so the
+        // bench is reproducible and the sink contents are verifiable in
+        // debug builds without taking allocation hits in the hot loop.
+        let seed = spec.ndx.get() as u64 ^ sequence.wrapping_mul(0x9E37_79B9_7F4A_7C15);
+        let payload = vec![(seed & 0xff) as u8; len];
+        let chunk = if spec.is_delta && (sequence % 2 == 1) {
+            DeltaChunk::matched(spec.ndx, sequence, payload)
+        } else {
+            DeltaChunk::literal(spec.ndx, sequence, payload)
+        };
+        chunks.push(chunk);
+        offset += len;
+        sequence += 1;
+    }
+    chunks
+}
+
+/// Builds a workload's complete chunk list, flattened in submission order
+/// (file 0 chunks first, then file 1, ...). Cross-file order does not
+/// matter for the apply loop (the per-file reorder buffer handles it)
+/// but a deterministic order keeps cell-to-cell comparisons stable.
+fn build_workload(specs: &[FileSpec]) -> Vec<DeltaChunk> {
+    let total_chunks: usize = specs.iter().map(|s| s.size.div_ceil(CHUNK_SIZE)).sum();
+    let mut out = Vec::with_capacity(total_chunks);
+    for spec in specs {
+        out.extend(build_chunks(spec));
+    }
+    out
+}
+
+fn total_bytes(specs: &[FileSpec]) -> u64 {
+    specs.iter().map(|s| s.size as u64).sum()
+}
+
+/// `small_files`: 10,000 x 4 KiB. Half delta, half whole-file.
+fn small_files_spec() -> Vec<FileSpec> {
+    (0..10_000u32)
+        .map(|i| FileSpec {
+            ndx: FileNdx::new(i),
+            size: 4 * 1024,
+            is_delta: i % 2 == 0,
+        })
+        .collect()
+}
+
+/// `mixed`: 1,000 files, sizes drawn deterministically from
+/// `{4 KiB, 16 KiB, 64 KiB, 256 KiB, 1 MiB, 4 MiB}`. 50/50 delta/whole.
+fn mixed_spec() -> Vec<FileSpec> {
+    const SIZES: &[usize] = &[
+        4 * 1024,
+        16 * 1024,
+        64 * 1024,
+        256 * 1024,
+        1024 * 1024,
+        4 * 1024 * 1024,
+    ];
+    (0..1_000u32)
+        .map(|i| FileSpec {
+            ndx: FileNdx::new(i),
+            size: SIZES[i as usize % SIZES.len()],
+            is_delta: i % 2 == 0,
+        })
+        .collect()
+}
+
+/// `large_files`: 10 x 256 MiB, all delta. Cross-file parallelism is the
+/// only lever; per-file writes are mutex-serialised. Reduced from the
+/// notional 10x256 MiB target to 4x64 MiB in CI mode to keep the bench
+/// under criterion's default sample budget; the shape (few large files,
+/// all delta) is preserved.
+fn large_files_spec() -> Vec<FileSpec> {
+    let (count, size) = if std::env::var_os("OC_RSYNC_BENCH_FULL_LARGE").is_some() {
+        (10u32, 256 * 1024 * 1024)
+    } else {
+        (4u32, 64 * 1024 * 1024)
+    };
+    (0..count)
+        .map(|i| FileSpec {
+            ndx: FileNdx::new(i),
+            size,
+            is_delta: true,
+        })
+        .collect()
+}
+
+/// Sequential baseline: groups chunks by file, replays each file's
+/// chunks in `chunk_sequence` order, and writes them to a per-file
+/// `SinkWriter`. Mirrors the shape of the receiver's current apply loop
+/// (one file at a time, serial chunk drain) without any of the rayon
+/// machinery the parallel path uses.
+fn sequential_apply(specs: &[FileSpec], chunks: &[DeltaChunk]) -> u64 {
+    use std::collections::HashMap;
+
+    let mut sinks: HashMap<FileNdx, SinkWriter> =
+        specs.iter().map(|s| (s.ndx, SinkWriter::new())).collect();
+
+    // Group chunks by file; the source list is already grouped per
+    // `build_workload`, so the per-file passes are linear.
+    let mut by_file: HashMap<FileNdx, Vec<&DeltaChunk>> = HashMap::new();
+    for c in chunks {
+        by_file.entry(c.ndx).or_default().push(c);
+    }
+
+    let mut total_written = 0u64;
+    for spec in specs {
+        let mut per_file = by_file.remove(&spec.ndx).unwrap_or_default();
+        per_file.sort_by_key(|c| c.chunk_sequence);
+        let sink = sinks.get_mut(&spec.ndx).expect("sink registered");
+        for c in per_file {
+            sink.write_all(&c.data).expect("sink write");
+            total_written += c.data.len() as u64;
+        }
+    }
+    total_written
+}
+
+/// Parallel path under test. Registers a sink per file, then drives every
+/// chunk through `apply_batch_parallel` so the rayon verify step fans
+/// across workers while the per-file write stays serialised.
+fn parallel_apply(specs: &[FileSpec], chunks: Vec<DeltaChunk>, workers: usize) -> u64 {
+    let applier = ParallelDeltaApplier::new(workers);
+    for spec in specs {
+        applier
+            .register_file(spec.ndx, Box::new(SinkWriter::new()))
+            .expect("register sink");
+    }
+    applier
+        .apply_batch_parallel(chunks)
+        .expect("batch apply succeeded");
+    let mut total = 0u64;
+    for spec in specs {
+        total += applier
+            .bytes_written(spec.ndx)
+            .expect("bytes_written for registered file");
+    }
+    // Drain each file so the next iteration starts from a clean applier
+    // shape; finish_file consumes the writer back out.
+    for spec in specs {
+        let _ = applier.finish_file(spec.ndx).expect("finish file");
+    }
+    total
+}
+
+fn bench_workload(c: &mut Criterion, workload_name: &str, specs: Vec<FileSpec>) {
+    let chunks = build_workload(&specs);
+    let bytes = total_bytes(&specs);
+
+    let mut group = c.benchmark_group(format!("parallel_receive_delta_perf/{workload_name}"));
+    group.throughput(Throughput::Bytes(bytes));
+    // Large-file cell needs longer measurement windows; small cells are
+    // dispatch-bound and converge quickly.
+    group.sample_size(15);
+    group.measurement_time(Duration::from_secs(if workload_name == "large_files" {
+        20
+    } else {
+        10
+    }));
+
+    group.bench_with_input(
+        BenchmarkId::new("sequential_apply", workload_name),
+        &specs,
+        |b, specs| {
+            b.iter(|| {
+                let n = sequential_apply(specs, &chunks);
+                black_box(n);
+            });
+        },
+    );
+
+    group.bench_with_input(
+        BenchmarkId::new("parallel_apply", workload_name),
+        &specs,
+        |b, specs| {
+            b.iter(|| {
+                // Clone the chunk list per iteration because
+                // `apply_batch_parallel` consumes it; the clone happens
+                // outside the timed verify+write path on the
+                // sequential cell too (it just borrows), so the
+                // comparison still isolates scheduling cost rather than
+                // allocation cost.
+                let owned = chunks.clone();
+                let n = parallel_apply(specs, owned, PARALLEL_WORKERS);
+                black_box(n);
+            });
+        },
+    );
+
+    group.finish();
+}
+
+fn bench_parallel_receive_delta(c: &mut Criterion) {
+    bench_workload(c, "small_files", small_files_spec());
+    bench_workload(c, "mixed", mixed_spec());
+    bench_workload(c, "large_files", large_files_spec());
+}
+
+criterion_group!(benches, bench_parallel_receive_delta);
+criterion_main!(benches);

--- a/docs/design/parallel-receive-delta-default-on.md
+++ b/docs/design/parallel-receive-delta-default-on.md
@@ -1,0 +1,271 @@
+# Parallel receive-side delta apply: default-on decision (#1368 followup)
+
+Tracking issue: #1368 followup. Companion to
+`docs/design/parallel-receive-delta-application.md` (the umbrella design)
+and PR #4319 (the scaffold that landed the feature behind
+`--features parallel-receive-delta`).
+
+This document does not re-litigate the apply-loop architecture, the
+per-file ordering invariants, or the wire-format parity strategy. The
+umbrella design covers those. It narrows one open question:
+
+> When does `parallel-receive-delta` stop being opt-in, and what is the
+> runway between the current `--features` gate and a default-on
+> receiver?
+
+## 1. Current state
+
+`crates/engine/src/concurrent_delta/parallel_apply.rs` ships
+[`ParallelDeltaApplier`] gated behind the
+`parallel-receive-delta` cargo feature on both `engine` and `transfer`.
+Production receivers do not flip the gate:
+
+- `crates/engine/Cargo.toml` declares `parallel-receive-delta = []`
+  without including it in `default`.
+- `crates/transfer/Cargo.toml` declares
+  `parallel-receive-delta = ["engine/parallel-receive-delta"]`.
+- `crates/transfer/src/receiver/mod.rs` exposes
+  `ReceiverContext::enable_parallel_receive_delta`, conditionally
+  compiled under `#[cfg(feature = "parallel-receive-delta")]`. No
+  production call site invokes it.
+
+The sequential apply loop in `crates/transfer/src/receiver/transfer.rs`
+remains the only shipped path. The parallel scaffold has parity tests
+(PRs #4300 and #4319) and per-file ordering proofs but no benchmark
+evidence at the receiver-shape scale that the umbrella design's section
+6.3 calls out as the bench gate.
+
+## 2. The gap
+
+Multi-core receivers underperform until manual opt-in. The verify step
+inside the receiver is CPU-bound (strong-checksum rollup per chunk) but
+the dispatch loop is serial. On an 8-core box transferring a 10,000-file
+directory of small source files, seven cores are idle while one core
+walks the per-file token reader. The parallel scaffold reclaims those
+cores - in principle. Whether the reclamation pays off across the
+receiver-shape distribution, or whether it loses to dispatch overhead
+on dispatch-bound workloads, is the open question this bench answers.
+
+## 3. Bench shape
+
+`crates/engine/benches/parallel_receive_delta_perf.rs` runs three
+workload classes against two cells each:
+
+| Workload      | File count | Per-file size  | Mix                  | Why                                  |
+|---------------|------------|----------------|----------------------|--------------------------------------|
+| `small_files` | 10,000     | 4 KiB          | 50/50 delta + whole  | Dispatch-overhead dominates          |
+| `mixed`       | 1,000      | 4 KiB - 4 MiB  | 50/50 delta + whole  | Typical project / media directory    |
+| `large_files` | 10         | 256 MiB (4x64 MiB in default mode) | All delta | Cross-file parallelism the only lever |
+
+Two cells per workload:
+
+- `sequential_apply` - current default, walks chunks in submission
+  order to a per-file in-memory sink.
+- `parallel_apply` - drives `ParallelDeltaApplier` from
+  `engine::concurrent_delta` with the rayon ambient pool.
+
+The bench drives the apply loop directly. It writes to in-memory sinks
+rather than real files; the goal is to isolate apply-loop scheduling
+overhead from disk I/O. A real-I/O variant is the next bench in the
+sequence if the in-memory result motivates it.
+
+The large-file cell runs at 4x64 MiB by default to stay within
+criterion's default sample budget; set
+`OC_RSYNC_BENCH_FULL_LARGE=1` to run the full 10x256 MiB shape
+documented above.
+
+## 4. Bench results
+
+To be filled in by the first CI run of the bench. Layout the table to
+read:
+
+| Workload      | sequential (s) | parallel (s) | speedup | bytes/s seq | bytes/s par |
+|---------------|----------------|--------------|---------|-------------|-------------|
+| `small_files` | TBD            | TBD          | TBD     | TBD         | TBD         |
+| `mixed`       | TBD            | TBD          | TBD     | TBD         | TBD         |
+| `large_files` | TBD            | TBD          | TBD     | TBD         | TBD         |
+
+Run: `cargo bench -p engine --features parallel-receive-delta
+--bench parallel_receive_delta_perf`. Capture the JSON from
+`target/criterion/parallel_receive_delta_perf/` into
+`target/criterion-history/` for the comparison commit so the table can
+be reproduced.
+
+## 5. Promotion criteria
+
+The default flip from sequential to parallel is gated on all five of
+the following holding simultaneously on the same nightly bench run.
+Any single failure reverts the flip to opt-in.
+
+1. **`small_files` wall-clock wins by >= 10%** at 4+ rayon workers.
+   This is the dispatch-bound cell; if parallel cannot beat sequential
+   here by a comfortable margin, the runtime overhead is paying for
+   itself in noise rather than work.
+2. **Zero wire-format divergence.** Already covered by the property
+   tests in PRs #4300 (per-file ordering proptest) and #4319
+   (parallel-vs-sequential byte-for-byte parity). The promotion PR
+   re-runs the parity matrix and links the green run.
+3. **No single workload regresses by more than 5%.** The `large_files`
+   cell is the highest risk - per-file writes are mutex-serialised, so
+   cross-file parallelism is the only lever. A regression there means
+   the bench is measuring queueing overhead, not apply overhead, and
+   the runtime auto-detect (path B below) becomes the only safe shape.
+4. **Soak: one release cycle of `parallel-receive-delta` as a non-gating
+   opt-in CI baseline.** The `--features parallel-receive-delta` build
+   must compile and pass `cargo nextest run --workspace
+   --all-features` on every PR for one release cycle before the flip.
+   This is the existing convention - see
+   `docs/design/ssh-async-default-linux.md` section 3.1 - and the
+   parity gating in `docs/design/parallel-receive-delta-application.md`
+   section 6.3 already names it.
+5. **Two consecutive nightly runs** showing 1-3 green before the flip
+   PR opens, to filter run-to-run noise.
+
+## 6. Promotion paths
+
+Three paths are viable. The bench output picks one.
+
+### Path A: flip the default
+
+Move `parallel-receive-delta` into `default-features` for both `engine`
+and `transfer`. Wire `enable_parallel_receive_delta` into the receiver
+construction site so every transfer takes the parallel path.
+
+Risk: if the `large_files` cell regresses by even 1%, every VM-image
+and container-layer transfer pays for it. The parallel path is the
+right default only when it wins on every workload class by more than
+the noise floor of the bench.
+
+Indication: bench shows parallel wins on all three workloads by >= 10%
+with no workload-class flip.
+
+### Path B: runtime auto-detect
+
+Keep the feature flag compiled in by default, but dispatch parallel
+vs sequential per transfer at construction time based on a cheap
+heuristic:
+
+- `file_count > 100` **or** `total_size > 64 MiB` -> parallel
+- otherwise -> sequential
+
+The thresholds match the rayon parallel-stat threshold convention
+(`PARALLEL_STAT_THRESHOLD = 64` per `MEMORY.md`); 100 is the next
+common cutoff in the codebase and 64 MiB is the
+`copy_file_range` crossover documented in
+`crates/engine/benches/per_op_thresholds.rs`. No new constants invented
+without an existing precedent.
+
+The receiver knows both numbers before the transfer starts -
+`file_count` from the file list segment header, `total_size` from the
+sum of file sizes the generator wrote into the file entries. Both are
+zero-cost reads.
+
+Risk: heuristic mispredicts on workloads that straddle the cutoff.
+Mitigation: log the dispatch decision under `--debug=GENR` so an
+operator can see which path their transfer took, and surface a
+`receiver_strategy_chosen` counter on `ReceiverStats` for telemetry.
+
+Indication: bench shows parallel wins on `small_files` and `mixed` but
+loses on `large_files` (or vice versa). One path cannot beat the other
+on every workload class.
+
+### Path C: per-workload CLI flag
+
+Expose `--receive-strategy=auto|sequential|parallel` on the CLI.
+`auto` defaults to path B's heuristic; `sequential` and `parallel`
+override.
+
+Risk: yet another knob on a CLI that already has more flags than the
+upstream rsync man page. Justified only if telemetry from path B shows
+the heuristic mispredicts often enough that operators need an escape
+hatch.
+
+Indication: path B ships, telemetry from one release cycle shows
+`receiver_strategy_chosen=auto` mispredicts more than 5% of the time
+across the production workload distribution.
+
+## 7. Recommendation framing
+
+- If the bench shows parallel wins on **all three** workloads by >= 10%
+  with no regression on any cell: choose **Path A**. The cost of one
+  more `default-features` entry is small; the benefit is automatic on
+  every transfer.
+- If the bench shows **workload-dependent winners** (parallel wins on
+  some, loses on others): choose **Path B**. The runtime auto-detect
+  is the only shape that captures both wins without losing on the
+  workloads where parallel costs more than it earns.
+- Hold **Path C** in reserve. It is the response to telemetry from a
+  shipped Path B, not a first-choice promotion shape.
+
+The default position is Path B. Receiver workloads vary widely (a
+build farm differs from a backup target which differs from a CDN
+mirror), and the rayon-overhead-vs-parallelism tradeoff is exactly the
+kind of decision a per-transfer heuristic resolves better than a
+compile-time flag. Path A is the rare-case shortcut for when the
+parallel scaffold turns out to be a universal win.
+
+## 8. Five-step plan keyed to Path B
+
+The plan below assumes Path B is the bench-selected shape. If the
+bench picks Path A instead, steps 1 and 2 collapse into a single
+`Cargo.toml` edit and step 4 changes from "wire the heuristic" to
+"wire the unconditional call".
+
+1. **Land this bench.** Commit prefix `bench:`. The bench plus this
+   doc are the promotion gate's evidence substrate. Without the
+   numbers, none of the criteria in section 5 can be evaluated.
+2. **Publish the first numbers.** Run the bench on the
+   `rsync-profile` container against an 8-core baseline; commit the
+   table in section 4 with the actual values. Commit prefix
+   `docs(design):`. Link the criterion JSON from
+   `target/criterion-history/`.
+3. **Address any regression the bench reveals.** If
+   `large_files` regresses by more than 5%, the per-file mutex is the
+   suspect - either widen the per-file reorder buffer (current default
+   64 chunks per file) or shard the per-file writer across the rayon
+   pool. Commit prefix `perf(engine):`. Re-run step 2.
+4. **Wire the heuristic.** Add the `file_count > 100 || total_size >
+   64 MiB` dispatch decision in the receiver construction site (the
+   call site of `enable_parallel_receive_delta` in
+   `crates/transfer/src/receiver/mod.rs`). Surface the decision through
+   `--debug=GENR` and a `receiver_strategy_chosen` counter on
+   `ReceiverStats`. Commit prefix `perf(transfer):`.
+5. **Soak and flip default-features.** Run the feature opt-in as a
+   non-gating CI baseline for one release cycle. If no `fix:`-prefixed
+   PR lands against `crates/engine/src/concurrent_delta/parallel_apply.rs`
+   or the receiver dispatch site during the cycle, move
+   `parallel-receive-delta` into `default-features` on `engine` and
+   `transfer`. Commit prefix `perf(transfer):` and reference both
+   #1368 and this doc in the PR body.
+
+The five steps are strictly serial. Any step that fails its gate
+stops the promotion; the feature gate remains in place for the next
+attempt.
+
+## 9. Out of scope
+
+- Sender-side delta parallelism. The sender already pipelines per-file
+  signature generation across rayon workers; the receiver is the
+  remaining serial path.
+- io_uring integration. The bench writes to in-memory sinks; the
+  io_uring write path (`crates/fast_io/src/io_uring/`) composes with
+  the parallel apply but is measured separately by
+  `crates/engine/benches/local_copy_bench.rs`.
+- A new wire-protocol negotiation. The parallel scaffold preserves
+  wire-format byte-for-byte (see PR #4319 parity tests); no protocol
+  flag is needed and no protocol flag is added.
+
+## 10. Cross-references
+
+- Umbrella design: `docs/design/parallel-receive-delta-application.md`.
+- Scaffold PR: #4319 (`crates/engine/src/concurrent_delta/parallel_apply.rs`).
+- Parity proptest PR: #4300.
+- Bench: `crates/engine/benches/parallel_receive_delta_perf.rs`.
+- Receiver opt-in site:
+  `crates/transfer/src/receiver/mod.rs::enable_parallel_receive_delta`.
+- Feature flags: `crates/engine/Cargo.toml`,
+  `crates/transfer/Cargo.toml`.
+- Related promotion docs:
+  `docs/design/inc-recurse-sender-reenable-audit.md`,
+  `docs/design/ssh-async-default-linux.md`.
+- Related trackers: #1368, #4205 (wire-format audit), #4319 (scaffold).


### PR DESCRIPTION
## Summary

- Adds `crates/engine/benches/parallel_receive_delta_perf.rs`, a criterion bench that drives `ParallelDeltaApplier` against a sequential baseline across three workload classes (`small_files`, `mixed`, `large_files`) so the default-on decision for `--features parallel-receive-delta` (PR #4319 scaffold) has measured evidence rather than a coin flip.
- Adds `docs/design/parallel-receive-delta-default-on.md`, the promotion design doc with five gating criteria (>= 10% wall-clock win on `small_files`, zero wire-format divergence, no single-workload regression > 5%, one release cycle of opt-in soak, two consecutive green nightly runs), three promotion paths (Cargo default flip, runtime auto-detect, per-workload CLI flag), and a five-step rollout keyed to Path B.
- Registers the bench under `[[bench]]` with `required-features = ["parallel-receive-delta"]` so the default `cargo bench -p engine` still compiles.

## Test plan

- [ ] `cargo bench -p engine --features parallel-receive-delta --bench parallel_receive_delta_perf` runs all three workload classes locally and prints sequential vs parallel cells.
- [ ] `cargo check -p engine --benches` passes without the feature (bench is `#[cfg]` gated, so it compiles away cleanly).
- [ ] `cargo check -p engine --features parallel-receive-delta --benches` passes (verified locally before push).
- [ ] CI fmt+clippy stays green.
- [ ] First CI bench run populates the placeholder table in section 4 of the design doc; the recommendation in section 7 picks Path A or Path B based on the actual numbers.