### PR TITLE
test(fuzz): add multiplex/flist/decompressor fuzz targets (#2317, #2319, #2321)

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -22,6 +22,11 @@ path = "../crates/checksums"
 [dependencies.filters]
 path = "../crates/filters"
 
+[dependencies.compress]
+path = "../crates/compress"
+default-features = false
+features = ["zstd", "zlib-ng"]
+
 [[bin]]
 name = "protocol_wire"
 path = "fuzz_targets/protocol_wire.rs"
@@ -46,6 +51,34 @@ bench = false
 [[bin]]
 name = "filter_rules_vs_upstream"
 path = "fuzz_targets/filter_rules_vs_upstream.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "multiplex_frame_parse"
+path = "fuzz_targets/multiplex_frame_parse.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "flist_entry_decode"
+path = "fuzz_targets/flist_entry_decode.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "decompressor_zstd"
+path = "fuzz_targets/decompressor_zstd.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "decompressor_zlib"
+path = "fuzz_targets/decompressor_zlib.rs"
 test = false
 doc = false
 bench = false

--- a/fuzz/fuzz_targets/decompressor_zlib.rs
+++ b/fuzz/fuzz_targets/decompressor_zlib.rs
@@ -1,0 +1,72 @@
+#![no_main]
+
+//! Fuzz target for the raw deflate streaming decompressor.
+//!
+//! rsync's wire compression uses raw deflate (no zlib header / Adler-32
+//! trailer) per upstream `deflateInit2(..., -MAX_WBITS, ...)`. The same
+//! decoder is the entry point regardless of whether the backend resolves to
+//! `zlib-ng`, `zlib-rs`, or `miniz_oxide` at build time, so this target
+//! provides feature-agnostic coverage of the decode path.
+//!
+//! Invariants enforced per input:
+//!
+//! 1. The decoder may return an error but must never panic.
+//! 2. Output size must not exceed 100x the compressed input - any larger
+//!    ratio indicates an unbounded expansion that could be weaponised as a
+//!    DoS vector (zip bomb).
+//!
+//! # Running
+//!
+//! ```bash
+//! cargo +nightly fuzz run decompressor_zlib
+//! ```
+
+use std::io::Read;
+
+use libfuzzer_sys::fuzz_target;
+
+use compress::zlib::{CountingZlibDecoder, decompress_to_vec};
+
+/// Hard cap on the expansion ratio. See `decompressor_zstd` for rationale.
+const MAX_RATIO: u64 = 100;
+/// Absolute cap on bytes pulled out of the streaming decoder so we cannot
+/// stall the fuzzer when an input expands without bound before the ratio
+/// check fires.
+const READ_BUDGET: u64 = 8 * 1024 * 1024;
+
+fuzz_target!(|data: &[u8]| {
+    // Streaming decoder path.
+    let mut decoder = CountingZlibDecoder::new(data);
+    let mut sink = Vec::new();
+    let limit = std::cmp::min(
+        READ_BUDGET,
+        (data.len() as u64)
+            .saturating_mul(MAX_RATIO)
+            .saturating_add(1),
+    );
+    let _ = (&mut decoder).take(limit).read_to_end(&mut sink);
+    assert_expansion_bounded(data.len(), sink.len());
+
+    // One-shot helper path. Guarded by an input-size ceiling because the
+    // helper has no internal expansion cap - a zip-bomb stream could
+    // otherwise blow the fuzzer's memory budget before the ratio check
+    // fires.
+    if data.len() <= 4096 {
+        if let Ok(out) = decompress_to_vec(data) {
+            assert_expansion_bounded(data.len(), out.len());
+        }
+    }
+});
+
+/// Enforce the 100x expansion ceiling. Zero-length input is allowed to
+/// produce up to a single byte of output before the ratio check kicks in,
+/// which keeps the assertion honest for the degenerate empty-stream case.
+fn assert_expansion_bounded(input_len: usize, output_len: usize) {
+    let allowed = (input_len as u64)
+        .saturating_mul(MAX_RATIO)
+        .saturating_add(1);
+    assert!(
+        (output_len as u64) <= allowed,
+        "deflate expansion exceeded {MAX_RATIO}x ceiling: input={input_len} output={output_len}",
+    );
+}

--- a/fuzz/fuzz_targets/decompressor_zstd.rs
+++ b/fuzz/fuzz_targets/decompressor_zstd.rs
@@ -1,0 +1,72 @@
+#![no_main]
+
+//! Fuzz target for the zstd streaming decompressor.
+//!
+//! Compressed input received over the rsync wire is fully untrusted: a
+//! malicious peer can craft a frame that triggers excessive memory use
+//! (zip-bomb) or an arithmetic edge case inside the decoder. This target
+//! drives [`CountingZstdDecoder`] with arbitrary bytes and the convenience
+//! [`decompress_to_vec`] helper, then enforces two invariants:
+//!
+//! 1. The decoder may return an error but must never panic.
+//! 2. The total decompressed size must not exceed 100x the compressed
+//!    input - any larger ratio indicates an unbounded expansion that
+//!    could be weaponised as a DoS vector.
+//!
+//! # Running
+//!
+//! ```bash
+//! cargo +nightly fuzz run decompressor_zstd
+//! ```
+
+use std::io::Read;
+
+use libfuzzer_sys::fuzz_target;
+
+use compress::zstd::{CountingZstdDecoder, decompress_to_vec};
+
+/// Hard cap on the expansion ratio. Upstream zstd's worst-case "compressed
+/// nothing" ratio is well below this bound for any well-formed payload.
+const MAX_RATIO: u64 = 100;
+/// Absolute cap on bytes pulled out of the streaming decoder so we cannot
+/// stall the fuzzer when an input expands without bound before the ratio
+/// check fires.
+const READ_BUDGET: u64 = 8 * 1024 * 1024;
+
+fuzz_target!(|data: &[u8]| {
+    // Streaming decoder path.
+    if let Ok(mut decoder) = CountingZstdDecoder::new(data) {
+        let mut sink = Vec::new();
+        let limit = std::cmp::min(
+            READ_BUDGET,
+            (data.len() as u64)
+                .saturating_mul(MAX_RATIO)
+                .saturating_add(1),
+        );
+        let _ = (&mut decoder).take(limit).read_to_end(&mut sink);
+        assert_expansion_bounded(data.len(), sink.len());
+    }
+
+    // One-shot helper path. Guarded by an input-size ceiling because the
+    // helper has no internal expansion cap - a zip-bomb frame could
+    // otherwise blow the fuzzer's memory budget before the ratio check
+    // fires.
+    if data.len() <= 4096 {
+        if let Ok(out) = decompress_to_vec(data) {
+            assert_expansion_bounded(data.len(), out.len());
+        }
+    }
+});
+
+/// Enforce the 100x expansion ceiling. Zero-length input is allowed to
+/// produce up to a single byte of output before the ratio check kicks in,
+/// which keeps the assertion honest for the degenerate empty-frame case.
+fn assert_expansion_bounded(input_len: usize, output_len: usize) {
+    let allowed = (input_len as u64)
+        .saturating_mul(MAX_RATIO)
+        .saturating_add(1);
+    assert!(
+        (output_len as u64) <= allowed,
+        "zstd expansion exceeded {MAX_RATIO}x ceiling: input={input_len} output={output_len}",
+    );
+}

--- a/fuzz/fuzz_targets/flist_entry_decode.rs
+++ b/fuzz/fuzz_targets/flist_entry_decode.rs
@@ -1,0 +1,111 @@
+#![no_main]
+
+//! Fuzz target for the rsync file-list entry decoder.
+//!
+//! `recv_file_entry` (upstream: `flist.c:recv_file_entry()`) is the most
+//! complex parser in the protocol: a single byte stream that carries XMIT
+//! flag bits, run-length-encoded path suffixes, varint-encoded sizes, and
+//! optionally interned hardlink / ACL / xattr indexes. The wire format
+//! diverges between legacy (`protocol < 30`) and INC_RECURSE-capable
+//! (`protocol >= 30`) sessions, and many preserve flags toggle additional
+//! trailing fields.
+//!
+//! This target uses [`Arbitrary`] to flip between the two wire-format
+//! "modes" and to randomise the preserve flag matrix so libFuzzer can
+//! explore every conditional branch in the decoder. Errors are expected on
+//! malformed inputs; only panics constitute a finding.
+//!
+//! # Running
+//!
+//! ```bash
+//! cargo +nightly fuzz run flist_entry_decode
+//! ```
+
+use std::io::Cursor;
+
+use arbitrary::{Arbitrary, Unstructured};
+use libfuzzer_sys::fuzz_target;
+
+use protocol::flist::{FileListReader, read_file_entry};
+use protocol::{CompatibilityFlags, ProtocolVersion};
+
+/// Wire format mode selector. Legacy mode pins the reader to protocol 28
+/// (pre-INC_RECURSE). INC_RECURSE mode pins it to protocol 30 with the
+/// `CF_INC_RECURSE` capability flag asserted so the decoder takes the
+/// segmented-list path.
+#[derive(Arbitrary, Debug)]
+enum Mode {
+    Legacy,
+    IncRecurse,
+}
+
+/// Random preserve-flag matrix. Each toggle gates a trailing field in the
+/// wire encoding, so flipping them changes the byte budget the decoder
+/// expects per entry.
+#[derive(Arbitrary, Debug)]
+struct PreserveFlags {
+    uid: bool,
+    gid: bool,
+    links: bool,
+    devices: bool,
+    specials: bool,
+    hard_links: bool,
+    atimes: bool,
+    crtimes: bool,
+    checksum_len: u8,
+    acls: bool,
+    xattrs: bool,
+}
+
+#[derive(Arbitrary, Debug)]
+struct Input {
+    mode: Mode,
+    flags: PreserveFlags,
+    payload: Vec<u8>,
+}
+
+fuzz_target!(|data: &[u8]| {
+    let mut u = Unstructured::new(data);
+    let Ok(input) = Input::arbitrary(&mut u) else {
+        // Even without a structured wrap, hammer the convenience function
+        // with the raw bytes under both protocols.
+        decode_raw(data);
+        return;
+    };
+
+    let (protocol, compat) = match input.mode {
+        Mode::Legacy => (ProtocolVersion::V28, CompatibilityFlags::EMPTY),
+        Mode::IncRecurse => (ProtocolVersion::V30, CompatibilityFlags::INC_RECURSE),
+    };
+
+    let mut reader = FileListReader::with_compat_flags(protocol, compat)
+        .with_preserve_uid(input.flags.uid)
+        .with_preserve_gid(input.flags.gid)
+        .with_preserve_links(input.flags.links)
+        .with_preserve_devices(input.flags.devices)
+        .with_preserve_specials(input.flags.specials)
+        .with_preserve_hard_links(input.flags.hard_links)
+        .with_preserve_atimes(input.flags.atimes)
+        .with_preserve_crtimes(input.flags.crtimes)
+        .with_always_checksum(usize::from(input.flags.checksum_len % 33))
+        .with_preserve_acls(input.flags.acls)
+        .with_preserve_xattrs(input.flags.xattrs);
+
+    let mut cursor = Cursor::new(input.payload.as_slice());
+    // Drain entries until end-of-list or first parse error - the decoder
+    // must not panic for any byte sequence.
+    while let Ok(Some(_entry)) = reader.read_entry(&mut cursor) {}
+
+    // Also feed the raw fuzzer bytes through the convenience function so
+    // libFuzzer rewards coverage of the stateless entry-point path.
+    decode_raw(data);
+});
+
+/// Hammer the stateless [`read_file_entry`] helper against the raw input
+/// under both legacy and INC_RECURSE protocol versions.
+fn decode_raw(data: &[u8]) {
+    for protocol in [ProtocolVersion::V28, ProtocolVersion::V30] {
+        let mut cursor = Cursor::new(data);
+        let _ = read_file_entry(&mut cursor, protocol);
+    }
+}

--- a/fuzz/fuzz_targets/multiplex_frame_parse.rs
+++ b/fuzz/fuzz_targets/multiplex_frame_parse.rs
@@ -1,0 +1,106 @@
+#![no_main]
+
+//! Fuzz target for the multiplex `MSG_*` frame header parser.
+//!
+//! The 4-byte little-endian envelope header is the very first thing every
+//! peer parses on a multiplexed stream. A panic here is a remote attack
+//! surface, so we fuzz it directly via [`MessageHeader::decode`] / `from_raw`
+//! and via the higher-level [`BorrowedMessageFrames`] walker that wraps the
+//! same parser plus payload-length validation.
+//!
+//! Two input modes are alternated based on the first byte of the fuzzer
+//! input so coverage-guided search explores both "raw header bytes" and
+//! "structured (code, payload_len) pairs that may or may not be valid". The
+//! structured path lets libFuzzer find divergences between `from_raw` and
+//! `decode` that a purely byte-oriented harness would only stumble onto by
+//! chance.
+//!
+//! # Running
+//!
+//! ```bash
+//! cargo +nightly fuzz run multiplex_frame_parse
+//! ```
+
+use arbitrary::{Arbitrary, Unstructured};
+use libfuzzer_sys::fuzz_target;
+
+use protocol::{BorrowedMessageFrames, MESSAGE_HEADER_LEN, MessageHeader};
+
+/// Structured input mirroring the on-wire shape: a 32-bit raw header plus
+/// trailing payload bytes. The fuzzer explores oversized lengths, invalid
+/// tag bytes (below `MPLEX_BASE`), and unknown message codes through the
+/// derived [`Arbitrary`] implementation.
+#[derive(Arbitrary, Debug)]
+struct StructuredHeader {
+    raw: u32,
+    trailing: Vec<u8>,
+}
+
+fuzz_target!(|data: &[u8]| {
+    parse_raw_bytes(data);
+    parse_structured(data);
+});
+
+/// Feed the raw byte stream into both the single-shot [`MessageHeader`]
+/// decoder and the frame walker. Both refuse to panic on any input.
+fn parse_raw_bytes(data: &[u8]) {
+    let _ = MessageHeader::decode(data);
+
+    if data.len() >= MESSAGE_HEADER_LEN {
+        let mut buf = [0u8; MESSAGE_HEADER_LEN];
+        buf.copy_from_slice(&data[..MESSAGE_HEADER_LEN]);
+        let raw = u32::from_le_bytes(buf);
+        let _ = MessageHeader::from_raw(raw);
+    }
+
+    for frame in BorrowedMessageFrames::new(data) {
+        match frame {
+            Ok(frame) => {
+                let _ = frame.code();
+                let _ = frame.payload_len();
+                let _ = frame.payload();
+            }
+            Err(_) => break,
+        }
+    }
+}
+
+/// Build a structured (raw header, trailing payload) pair via [`Arbitrary`]
+/// and exercise both decode entry points so the fuzzer can target the
+/// validation matrix (oversized payloads, invalid tags, unknown codes).
+fn parse_structured(data: &[u8]) {
+    let mut u = Unstructured::new(data);
+    let Ok(input) = StructuredHeader::arbitrary(&mut u) else {
+        return;
+    };
+
+    let encoded = input.raw.to_le_bytes();
+    let decoded_bytes = MessageHeader::decode(&encoded);
+    let decoded_raw = MessageHeader::from_raw(input.raw);
+
+    // Both entry points must agree byte-for-byte on success and failure.
+    match (decoded_bytes, decoded_raw) {
+        (Ok(a), Ok(b)) => {
+            assert_eq!(a.code(), b.code());
+            assert_eq!(a.payload_len(), b.payload_len());
+            assert_eq!(a.encode_raw(), b.encode_raw());
+        }
+        (Err(_), Err(_)) => {}
+        (a, b) => panic!("decode/from_raw disagree: bytes={a:?} raw={b:?}"),
+    }
+
+    // Compose a synthetic frame and run it through the streaming walker.
+    let mut wire = Vec::with_capacity(MESSAGE_HEADER_LEN + input.trailing.len());
+    wire.extend_from_slice(&encoded);
+    wire.extend_from_slice(&input.trailing);
+    for frame in BorrowedMessageFrames::new(&wire) {
+        match frame {
+            Ok(frame) => {
+                let _ = frame.code();
+                let _ = frame.payload_len();
+                let _ = frame.payload();
+            }
+            Err(_) => break,
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds four coverage-guided fuzz targets covering parsers and decoders that consume untrusted bytes from a remote peer. Bundled in a single PR to avoid `fuzz/Cargo.toml` conflicts between FCV-4, FCV-6, and FCV-8.

- **`multiplex_frame_parse`** (FCV-4, closes #2317) - `MessageHeader::decode` and `from_raw`, plus the `BorrowedMessageFrames` walker. Uses `Arbitrary` to construct structured `(raw, payload)` pairs alongside raw byte coverage; asserts the two header entry points agree on success/failure.
- **`flist_entry_decode`** (FCV-6, closes #2319) - `FileListReader` and `read_file_entry` under both legacy (`protocol 28`) and INC_RECURSE (`protocol 30` + `CF_INC_RECURSE`) wire formats. `Arbitrary`-driven preserve-flag matrix toggles UID/GID/links/devices/specials/hard_links/atimes/crtimes/checksum/acls/xattrs so the decoder's conditional trailing-field paths are all reachable.
- **`decompressor_zstd`** and **`decompressor_zlib`** (FCV-8, closes #2321) - `CountingZstdDecoder` and `CountingZlibDecoder` streaming paths plus the `decompress_to_vec` helpers. Enforce a 100x expansion ceiling per input to surface zip-bomb-class panics; an 8 MiB read budget caps streaming output, and the helper path is gated on a 4 KiB input ceiling so a malicious frame cannot exhaust the fuzzer's memory budget before the assertion fires.

Adds `compress` as a fuzz dependency (`zstd` + `zlib-ng` features) and registers four `[[bin]]` entries in `fuzz/Cargo.toml`.

## Test plan

- [ ] `cargo +nightly fuzz build` succeeds for all four new targets.
- [ ] `cargo +nightly fuzz run multiplex_frame_parse -- -max_total_time=30` exits clean.
- [ ] `cargo +nightly fuzz run flist_entry_decode -- -max_total_time=30` exits clean.
- [ ] `cargo +nightly fuzz run decompressor_zstd -- -max_total_time=30` exits clean.
- [ ] `cargo +nightly fuzz run decompressor_zlib -- -max_total_time=30` exits clean.
- [ ] CI fmt + clippy + nextest pass.