### PR TITLE
docs: SSH stderr audit + socketpair channel design (#2370, #2371)

### DIFF
--- a/docs/audits/ssh-stderr-handling.md
+++ b/docs/audits/ssh-stderr-handling.md
@@ -1,0 +1,201 @@
+# SSH stderr handling audit (SSE-1, #2370)
+
+Tracker: #2370. No code changes - documentation only.
+
+Scope: catalogue every call site in `crates/rsync_io/src/ssh/` that
+creates, configures, drains, surfaces, or shuts down the SSH subprocess
+stderr stream. Feeds the design doc `docs/design/socketpair-stderr-channel.md`
+(SSE-2, #2371) and the implementation tasks SSE-3..SSE-7.
+
+Related audits already on disk (do not repeat their content here):
+
+- `docs/audits/ssh-socketpair-claim-verification.md` (#1902) - wire vs
+  stderr topology confirmation.
+- `docs/audits/ssh-socketpair-vs-pipes.md` (#1938) - rationale for keeping
+  anonymous pipes on the wire.
+- `docs/audits/ssh-process-management.md` - lifecycle of `SshChildHandle`
+  and zombie-reap invariants.
+
+## 1. Module map
+
+`crates/rsync_io/src/ssh/`:
+
+| File                  | Role for stderr                                                                 |
+|-----------------------|---------------------------------------------------------------------------------|
+| `aux_channel.rs`      | The trait `StderrAuxChannel`, both backends, drain loop, factory functions.     |
+| `builder.rs`          | The single sync spawn site that wires stderr through the factory functions.    |
+| `connection.rs`       | Owns `BoxedStderrChannel` on `SshConnection` and `SshChildHandle`; joins/surfaces. |
+| `async_transport.rs`  | Async (tokio) spawn site - currently bypasses the channel entirely.            |
+| `mod.rs`              | Re-exports; comment block records the socketpair-on-Unix decision.             |
+| `connect.rs`          | Argv composition only; never touches stderr.                                   |
+
+## 2. Sync path: configuration -> drain -> surface
+
+### 2.1 Stderr endpoint configuration
+
+`aux_channel.rs:337-365` (`configure_stderr_channel`)
+
+- Unix: calls `UnixStream::pair()`. On success, converts the child end via
+  `OwnedFd -> Stdio` (safe stdlib path, no FFI) and installs it as the
+  child's stderr; returns the parent end. On failure, falls back to
+  `Stdio::piped()` and returns `None`.
+- Non-Unix: unconditionally `Stdio::piped()`, returns `None`.
+
+Sole caller: `builder.rs:339` inside `SshCommand::spawn`.
+
+### 2.2 Channel construction
+
+`aux_channel.rs:367-390` (`build_stderr_channel`)
+
+- `Some(parent_socketpair_end)` -> `SocketpairStderrChannel::spawn` (Unix
+  only).
+- Otherwise -> wraps the child's `ChildStderr` in `PipeStderrChannel::spawn`.
+- Both backends spawn a dedicated drain thread named
+  `ssh-stderr-drain-socketpair` or `ssh-stderr-drain-pipe`.
+
+Sole caller: `builder.rs:358`.
+
+### 2.3 Drain loop
+
+`aux_channel.rs:282-302` (`drain_loop<R: Read>`)
+
+- `BufReader::new(source)` wrapping either `ChildStderr` or `UnixStream`.
+- Reads with `read_until(b'\n', ...)` rather than `lines()` so non-UTF-8
+  payloads do not abort the drain (locale-encoded SSH messages, banner
+  bytes, etc.).
+- Forwards each line to the parent process stderr in real time via
+  `eprint!` plus a `debug_log!(Connect, 3, ...)`.
+- Appends to a bounded buffer (sliding-window) via `append_bounded`.
+- Exits on `Ok(0)` (EOF) or on any `Err(_)` (broken pipe, child exited).
+
+### 2.4 Bounded buffer
+
+`aux_channel.rs:65-70, 304-321`
+
+- `STDERR_BUFFER_CAP = 64 * 1024` (matches typical OS pipe buffer).
+- `append_bounded` drops oldest bytes when the total exceeds the cap.
+- `snapshot` returns a `Vec<u8>` clone under the `Mutex` for read-side
+  access (`collected()`).
+
+### 2.5 Shutdown and join policy
+
+`aux_channel.rs:42-61, 95-110, 165-191, 238-267`
+
+- `DRAIN_JOIN_TIMEOUT = 50ms`. `join_with_timeout` polls
+  `JoinHandle::is_finished` then either joins or **leaks the
+  `JoinHandle`**. The deliberate leak handles the case where an ssh
+  helper subprocess (ssh-askpass, ControlMaster persistence) inherits
+  the write end and EOF therefore lags the parent's exit arbitrarily.
+- `PipeStderrChannel::shutdown_read` is a no-op (anonymous pipes have no
+  out-of-band wake-up); the bounded `join_with_timeout` is the safety
+  net.
+- `SocketpairStderrChannel::shutdown_read` calls
+  `sock.shutdown(Both)` on a `try_clone` of the parent endpoint; the
+  drain thread's parked `read()` returns 0 immediately, the loop exits,
+  and `join` completes.
+- Both backends are `Drop`-safe and `join` is idempotent.
+
+### 2.6 Surface-on-error
+
+`aux_channel.rs:118-134` (`StderrAuxChannel::join_and_surface_on_error`)
+
+- Default trait method, used from `Drop` impls on `SshConnection`
+  (`connection.rs:577-585`) and `SshChildHandle` (`connection.rs:510-512`).
+- Shuts down the read end, joins the drain, and if `status.is_err() ==
+  false && !status.success()`, writes the captured bytes to local
+  stderr with `eprintln!("ssh process exited with status {exit}:\n{trimmed}")`.
+
+### 2.7 Owners
+
+- `SshConnection.stderr_drain: Option<BoxedStderrChannel>`
+  (`connection.rs:37`).
+- `SshChildHandle.stderr_drain: Option<BoxedStderrChannel>`
+  (`connection.rs:398`).
+- Transferred on `SshConnection::split` (`connection.rs:205-213`).
+- Inspected via `stderr_output()` on both types
+  (`connection.rs:90-94, 446-451`).
+- Joined inside `wait` and `wait_with_stderr` on both types
+  (`connection.rs:105-160, 457-490`).
+
+## 3. Async path: stderr today
+
+`async_transport.rs:53, 116-122`
+
+- Uses `tokio::process::Command`.
+- `command.stderr(Stdio::inherit())` - the child's stderr is wired
+  straight through to the parent's fd 2.
+- No drain task. No bounded buffer. No surface-on-error policy.
+- No way for the caller to retrieve "the stderr we just printed".
+- `kill_on_drop(true)` reaps the child but does not capture stderr.
+
+Doc comment at `async_transport.rs:18-21` explicitly records that the
+async drain and connect-watchdog are deferred. This audit confirms the
+deferral: every behaviour the sync path documents (real-time forwarding,
+bounded capture, surface-on-error, deadlock avoidance) is absent on the
+async path. The synchronous and asynchronous transports are not
+behaviourally equivalent for stderr today.
+
+## 4. Behaviour matrix
+
+| Concern                                  | Sync (`builder.rs::spawn`) | Async (`async_transport.rs`)        |
+|------------------------------------------|----------------------------|--------------------------------------|
+| Endpoint                                 | socketpair (Unix) / pipe   | parent fd 2 (inherit)                |
+| Drain                                    | dedicated thread           | none (kernel copies to terminal)     |
+| Real-time forwarding                     | per-line `eprint!`         | direct write by child to parent fd 2 |
+| Bounded capture                          | 64 KiB sliding window      | none                                 |
+| Snapshot accessor                        | `stderr_output()`          | none                                 |
+| Surface-on-error                         | `Drop` impl                | none                                 |
+| Multi-line buffering                     | `read_until(b'\n')`        | n/a                                  |
+| Wake on shutdown                         | `Shutdown::Both` (socket); timeout (pipe) | n/a                   |
+| Bounded join                             | 50 ms timeout, then leak   | n/a                                  |
+| Cross-platform                           | yes (pipe fallback)        | yes (inherit on all platforms)       |
+| Event-loop integrable                    | socket-only, not wired in  | no                                   |
+
+## 5. Findings
+
+1. The sync path already uses `socketpair(AF_UNIX, SOCK_STREAM, 0)` on
+   Unix; only the parent-side **read strategy** (a parked drain thread)
+   is the legacy bit. The socket descriptor is the right primitive for
+   future event-loop registration.
+2. The pipe fallback is non-removable: it is the only stderr path on
+   Windows and the FD-exhaustion contingency on Unix.
+3. The async transport does not participate in any stderr policy. Adding
+   parity is the SSE-3..SSE-7 work.
+4. The drain thread per connection is the only thread the sync stderr
+   path spawns. Moving it onto an existing event loop removes one
+   thread per concurrent SSH transfer.
+5. Multi-line buffering is line-delimited (`read_until(b'\n')`) and
+   `String::from_utf8_lossy` is used at print time; binary payloads are
+   captured but rendered with replacement characters. This is upstream-
+   matching behaviour and must be preserved by any new design.
+6. `join_and_surface_on_error` is the only entry that writes to local
+   stderr from a `Drop` impl; new designs must keep its idempotency
+   (drain `take()`s the `JoinHandle`).
+
+## 6. Call-site index (file:line)
+
+| Concern                          | Site                                                   |
+|----------------------------------|--------------------------------------------------------|
+| Trait + buffer cap               | `crates/rsync_io/src/ssh/aux_channel.rs:65,87`         |
+| Pipe backend spawn               | `crates/rsync_io/src/ssh/aux_channel.rs:147-163`       |
+| Pipe backend shutdown            | `crates/rsync_io/src/ssh/aux_channel.rs:170-184`       |
+| Socketpair backend spawn         | `crates/rsync_io/src/ssh/aux_channel.rs:211-236`       |
+| Socketpair backend shutdown      | `crates/rsync_io/src/ssh/aux_channel.rs:244-259`       |
+| Drain loop                       | `crates/rsync_io/src/ssh/aux_channel.rs:282-302`       |
+| Bounded append                   | `crates/rsync_io/src/ssh/aux_channel.rs:306-316`       |
+| Surface-on-error                 | `crates/rsync_io/src/ssh/aux_channel.rs:118-134`       |
+| Endpoint configurator            | `crates/rsync_io/src/ssh/aux_channel.rs:337-365`       |
+| Channel factory                  | `crates/rsync_io/src/ssh/aux_channel.rs:372-390`       |
+| Sync spawn wiring                | `crates/rsync_io/src/ssh/builder.rs:308-367`           |
+| Owner on connection              | `crates/rsync_io/src/ssh/connection.rs:30-69`          |
+| Snapshot accessor (conn)         | `crates/rsync_io/src/ssh/connection.rs:89-94`          |
+| Drain shutdown + join in wait    | `crates/rsync_io/src/ssh/connection.rs:112-128`        |
+| wait_with_stderr                 | `crates/rsync_io/src/ssh/connection.rs:136-160`        |
+| Transfer drain to child handle   | `crates/rsync_io/src/ssh/connection.rs:205-213`        |
+| Drop surface (conn)              | `crates/rsync_io/src/ssh/connection.rs:562-585`        |
+| Owner on child handle            | `crates/rsync_io/src/ssh/connection.rs:396-400`        |
+| Snapshot accessor (handle)       | `crates/rsync_io/src/ssh/connection.rs:446-451`        |
+| Drain shutdown + join (handle)   | `crates/rsync_io/src/ssh/connection.rs:457-489`        |
+| Drop surface (handle)            | `crates/rsync_io/src/ssh/connection.rs:492-513`        |
+| Async stderr (inherit)           | `crates/rsync_io/src/ssh/async_transport.rs:118`       |
+| Async deferral note              | `crates/rsync_io/src/ssh/async_transport.rs:18-21`     |

--- a/docs/design/socketpair-stderr-channel.md
+++ b/docs/design/socketpair-stderr-channel.md
@@ -1,0 +1,192 @@
+# Socketpair stderr channel design (SSE-2, #2371)
+
+Tracker: #2371. Companion to `docs/audits/ssh-stderr-handling.md`
+(SSE-1, #2370). No code changes in this PR.
+
+Companion docs:
+
+- `docs/audits/ssh-socketpair-claim-verification.md` (#1902) - confirms
+  the wire is two anonymous pipes and stderr is one `AF_UNIX`
+  socketpair today.
+- `docs/audits/ssh-single-socketpair-bidirectional.md` (#1687) - rules
+  out a single bidirectional socketpair for the wire path; this design
+  inherits that conclusion and applies only to stderr.
+
+## 1. Goal
+
+Bring the async transport to parity with the sync transport for stderr
+handling, and prepare both transports to drive the drain off a shared
+event loop instead of a dedicated thread per connection.
+
+Non-goals: replacing the wire (stdin/stdout) pipes; changing the
+protocol the remote sees; changing upstream-matching real-time
+forwarding semantics.
+
+## 2. Pipe vs socketpair trade-off
+
+Both kernel objects deliver a stream of bytes from the child's fd 2.
+The trade-off matters only for the parent-side **read strategy** -
+specifically how the parent waits for bytes without burning a thread.
+
+| Property                                | Anonymous pipe (`pipe(2)`)    | UNIX socketpair (`socketpair(AF_UNIX, SOCK_STREAM, 0)`) |
+|-----------------------------------------|-------------------------------|---------------------------------------------------------|
+| Cross-platform availability             | Linux, macOS, Windows         | Unix only; Windows must simulate                        |
+| Direction                               | Unidirectional                | Bidirectional                                           |
+| Default kernel buffer                   | 64 KiB (Linux)                | ~208 KiB (Linux); platform-dependent                    |
+| Back-pressure on full buffer            | child blocks in `write(2)`    | child blocks in `send(2)` (same effect)                 |
+| Non-blocking with `O_NONBLOCK`          | yes                           | yes                                                     |
+| Out-of-band wake (parent side)          | none (must close write end)   | `shutdown(SHUT_RD)`/`shutdown(SHUT_RDWR)`               |
+| Registers with `epoll`/`kqueue`         | yes (read-only fd)            | yes (full socket semantics)                             |
+| Registers with tokio `AsyncFd`          | yes (via `OwnedFd`)           | yes (via `UnixStream`)                                  |
+| Registers with Windows IOCP             | named-pipe shim only          | not native; TCP loopback shim                           |
+| Same primitive on the wire today        | yes (stdin, stdout)           | no                                                      |
+| Failure mode if FD-exhausted at spawn   | n/a (pipe is the fallback)    | falls back to pipe                                      |
+
+The two-line summary:
+
+- **Pipe**: simpler, no out-of-band wake, parent must close the write
+  end or rely on a bounded read timeout to unstick a stuck drain.
+- **Socketpair**: bidirectional, larger default buffer on Linux,
+  integrates cleanly with epoll/kqueue/IOCP-style event loops, supports
+  `shutdown(2)` as the safe wake-up mechanism.
+
+Conclusion: keep the existing dual-backend design. Socketpair on Unix,
+pipe fallback on Windows and on FD-exhaustion. The async transport
+should consume the same trait (`StderrAuxChannel`) the sync transport
+already exposes.
+
+## 3. Cross-platform construction
+
+### 3.1 Unix
+
+`socketpair(AF_UNIX, SOCK_STREAM, 0)` via `std::os::unix::net::UnixStream::pair`.
+Hand the child end to the spawned process as fd 2; retain the parent
+end on this side. This is already implemented in
+`aux_channel.rs::configure_stderr_channel`.
+
+### 3.2 Windows
+
+`socketpair(2)` does not exist on Win32. The behaviourally equivalent
+construction is:
+
+1. Bind a `TcpListener` to `127.0.0.1:0` with an explicit address-reuse
+   policy that prevents port hijacking.
+2. `connect` to the listener address from the same process.
+3. `accept` the inbound connection.
+4. Hand the **accepted** socket to the child by duplicating it onto its
+   stderr handle via the existing Windows process-spawn API in
+   `fast_io`.
+5. Close the listener immediately after `accept` returns.
+6. Retain the **connecting** socket on the parent side; this is the
+   `AsyncRead`-capable handle.
+
+The shim must:
+
+- Refuse to bind to any address other than `127.0.0.1` (no external
+  exposure).
+- Apply a 1-second handshake timeout to defend against another local
+  process racing the connection.
+- Fall back to `Stdio::piped()` on any failure, identical to the Unix
+  FD-exhaustion path.
+
+The Windows construction is implemented in the existing pattern used
+elsewhere in the workspace (no new unsafe in `rsync_io`). It is gated
+behind the same feature flag (Section 6) until verified on the CI
+Windows runner.
+
+## 4. AsyncSshTransport integration
+
+The async transport currently uses `Stdio::inherit()` for stderr. The
+target shape is:
+
+1. `AsyncSshTransport` gains an `Option<StderrAuxChannel>` field with
+   the same role it has on `SshConnection`.
+2. Construction uses the same `configure_stderr_channel` /
+   `build_stderr_channel` factories the sync path uses, but with a
+   tokio-aware backend variant: `TokioSocketpairStderrChannel` wraps
+   `tokio::net::UnixStream` (or the Windows shim) and drives the drain
+   loop as a `tokio::spawn` task instead of a `std::thread`.
+3. The drain task:
+   - reads with `tokio::io::AsyncBufReadExt::read_until(b'\n', ...)`,
+   - forwards each line to `tokio::io::stderr()` (so it interleaves
+     with other tokio writers correctly),
+   - appends to the same bounded `Arc<Mutex<Vec<u8>>>` buffer
+     (`STDERR_BUFFER_CAP` unchanged),
+   - exits on EOF or on a `oneshot` shutdown signal.
+4. `AsyncSshTransport::wait` awaits a `oneshot::Sender::send(())` to
+   wake the drain task before awaiting `child.wait()`, mirroring the
+   sync path's `shutdown_read` + `join` sequence.
+5. `AsyncSshTransport::stderr_output()` is added with the same
+   signature and semantics as `SshConnection::stderr_output()`.
+6. A `warnings: tokio::sync::mpsc::UnboundedSender<StderrLine>`
+   sender is offered as an optional construction-time hook so future
+   callers (interactive UI, structured logger) can subscribe to each
+   line as it is captured, without breaking the existing
+   `stderr_output()` snapshot accessor.
+
+The new tokio backend implements `StderrAuxChannel` so the trait stays
+the single seam both transports observe. The sync path is unchanged.
+
+## 5. Drain to ring buffer + warning channel
+
+The existing bounded `Vec<u8>` already behaves as a 64 KiB sliding
+window. The new design retains that exactly. The optional warning
+channel is layered on top of the buffer write, not in place of it:
+
+```text
+read_until(b'\n')
+   |
+   |--> append_bounded(&buffer, &line)              // unchanged path
+   |--> if let Some(tx) = warnings { tx.send(line) } // new, optional
+   |--> eprint!("{lossy_text}")                     // unchanged path
+```
+
+The warning channel is `try_send`; a slow consumer never blocks the
+drain. Dropped warnings increment a counter exposed through the
+`stderr_output()` snapshot accessor so callers can detect loss.
+
+## 6. Backwards compatibility
+
+Feature flag in `crates/rsync_io/Cargo.toml`:
+
+```toml
+[features]
+ssh-socketpair-stderr = []  # default off
+```
+
+- **Off (default)**: behaviour is exactly what `master` ships today.
+  Sync path keeps its current dual-backend selection. Async path keeps
+  `Stdio::inherit()`.
+- **On**: the async path additionally constructs a
+  `TokioSocketpairStderrChannel`; the sync path's selection is
+  unaffected (it already uses the socketpair when available).
+
+The flag stays default-off until SSE-7 ships parity tests for the
+async path on Linux, macOS, and the Windows TCP-shim. Promotion to
+default-on is a separate PR with a one-line `Cargo.toml` change.
+
+No public type is renamed, removed, or has its signature changed by
+this design. Adding `AsyncSshTransport::stderr_output()` is purely
+additive.
+
+## 7. Implementation plan (SSE-3..SSE-7)
+
+| Task   | Scope                                                                                  | Status |
+|--------|----------------------------------------------------------------------------------------|--------|
+| SSE-3  | Add the feature flag and a `TokioSocketpairStderrChannel` (Unix) implementing `StderrAuxChannel` via `tokio::net::UnixStream`. No call-site changes yet; cover the new type with unit tests that mirror `socketpair_channel_collects_stderr_data`, `socketpair_channel_handles_non_utf8_bytes`, `socketpair_channel_bounded_buffer_caps_memory`. | not started |
+| SSE-4  | Wire `AsyncSshTransport::execute_remote_rsync` to call `configure_stderr_channel` + `build_stderr_channel` behind the flag; add `stderr_output()`, `wait_with_stderr()`. Replace `Stdio::inherit()` only when the channel is constructed; leave the inherit path as a fallback when the factory returns `None`. | not started |
+| SSE-5  | Implement the Windows TCP-loopback shim in `aux_channel.rs` under `#[cfg(windows)]`. Add bind-address and handshake-timeout safeguards; fall back to `Stdio::piped()` on any error. Cover with a Windows-only integration test that spawns a `cmd /C echo ... 1>&2` child and asserts capture. | not started |
+| SSE-6  | Add the optional warning channel (`UnboundedSender<StderrLine>`) and the dropped-warning counter to the shared buffer snapshot. Extend `stderr_output()` to surface the counter as a structured side-channel without altering the existing `Vec<u8>` return shape. | not started |
+| SSE-7  | Parity tests: a matrix that runs an end-to-end transfer against the local interop daemon under both flag states and asserts identical captured-stderr bytes, identical surface-on-error output, and identical exit-code propagation. Flip the flag default to on once green on Linux, macOS, Windows. | not started |
+
+Each task is independently mergeable behind the feature flag.
+
+## 8. Risks and mitigations
+
+| Risk                                                                                       | Mitigation                                                                                                       |
+|--------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------|
+| Windows TCP shim is racy / opens an exposure surface                                       | Bind `127.0.0.1` only, handshake timeout, fall back to pipe; SSE-5 lands behind the feature flag.                |
+| Tokio drain task survives past child reap (ssh-askpass / ControlMaster keeps write end)    | `oneshot` shutdown + `tokio::time::timeout` on the join, mirroring `DRAIN_JOIN_TIMEOUT` from the sync path.      |
+| Warning channel back-pressure stalls the drain                                              | `try_send` only; dropped warnings counted and surfaced through the snapshot accessor.                            |
+| Behavioural drift between sync and async after promotion to default-on                     | Single `StderrAuxChannel` trait; parity tests (SSE-7) run the same input through both transports and diff bytes.|
+| Feature-flag combinatorial explosion in CI                                                 | Only one new flag (`ssh-socketpair-stderr`); CI matrix gains a single additional column.                         |


### PR DESCRIPTION
## Summary

- Adds `docs/audits/ssh-stderr-handling.md` (SSE-1, #2370): per-call-site audit of how `crates/rsync_io/src/ssh/` configures, drains, surfaces, and shuts down the SSH subprocess stderr stream, with a sync-vs-async behaviour matrix.
- Adds `docs/design/socketpair-stderr-channel.md` (SSE-2, #2371): pipe-vs-socketpair trade-off, cross-platform construction (Unix `socketpair(2)`, Windows TCP-loopback shim), `AsyncSshTransport` integration plan, optional warning channel, default-off `ssh-socketpair-stderr` feature flag, and a five-step rollout keyed to SSE-3..SSE-7.
- No code changes. The existing `StderrAuxChannel` trait in `aux_channel.rs` is the seam the new tokio backend slots into.

## Test plan

- [ ] `cargo fmt --all -- --check`
- [ ] Markdown renders cleanly on GitHub
- [ ] All file/line citations resolve at the referenced commit
- [ ] No references to disallowed terms in either doc