### PR TITLE
refactor(engine): extract spill/error.rs (SPL-2 #2324)

### DIFF
--- a/crates/engine/src/concurrent_delta/spill/error.rs
+++ b/crates/engine/src/concurrent_delta/spill/error.rs
@@ -1,0 +1,90 @@
+//! Error type for the spill-to-tempfile layer.
+//!
+//! Producers should treat any [`SpillError::Io`] as fatal for the affected
+//! transfer: ENOSPC, missing spill directories, and partial writes all
+//! indicate that the disk backing the reorder buffer can no longer be
+//! trusted. The receiver maps these to exit code 11 ([`FileIo`]) so the
+//! transfer aborts with the same semantics as upstream rsync's I/O failures.
+//!
+//! [`FileIo`]: https://github.com/RsyncProject/rsync/blob/master/errcode.h
+
+use std::io;
+
+use super::super::reorder::CapacityExceeded;
+
+/// Errors surfaced by the spill layer.
+///
+/// Producers should treat any [`SpillError::Io`] as fatal for the affected
+/// transfer: ENOSPC, missing spill directories, and partial writes all
+/// indicate that the disk backing the reorder buffer can no longer be
+/// trusted. The receiver maps these to exit code 11 ([`FileIo`]) so the
+/// transfer aborts with the same semantics as upstream rsync's I/O failures.
+///
+/// [`UnsupportedCompression`](Self::UnsupportedCompression) is surfaced when a
+/// spill file written by a `spill-compression` build is read by a default
+/// build that has no codec available - the on-disk tag byte advertises the
+/// algorithm so we fail loudly rather than decode garbage.
+///
+/// [`FileIo`]: https://github.com/RsyncProject/rsync/blob/master/errcode.h
+#[derive(Debug)]
+pub enum SpillError {
+    /// Capacity bound from the underlying ring buffer was exceeded.
+    Capacity(CapacityExceeded),
+    /// Disk I/O failed while reading or writing spilled items.
+    Io(io::Error),
+    /// On-disk record advertises a compression algorithm this build cannot
+    /// decode. Holds the unknown tag byte for diagnostics.
+    UnsupportedCompression(u8),
+}
+
+impl SpillError {
+    /// Returns the underlying I/O error if this is an I/O failure.
+    #[must_use]
+    pub fn io_error(&self) -> Option<&io::Error> {
+        match self {
+            SpillError::Io(e) => Some(e),
+            SpillError::Capacity(_) | SpillError::UnsupportedCompression(_) => None,
+        }
+    }
+
+    /// Returns `true` if this error indicates the disk is out of space.
+    #[must_use]
+    pub fn is_out_of_space(&self) -> bool {
+        self.io_error()
+            .is_some_and(|e| e.kind() == io::ErrorKind::StorageFull)
+    }
+}
+
+impl std::fmt::Display for SpillError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SpillError::Capacity(_) => write!(f, "reorder buffer capacity exceeded"),
+            SpillError::Io(e) => write!(f, "reorder spill I/O failed: {e}"),
+            SpillError::UnsupportedCompression(tag) => write!(
+                f,
+                "reorder spill record uses compression tag 0x{tag:02x} not supported by this build"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for SpillError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            SpillError::Capacity(_) | SpillError::UnsupportedCompression(_) => None,
+            SpillError::Io(e) => Some(e),
+        }
+    }
+}
+
+impl From<CapacityExceeded> for SpillError {
+    fn from(e: CapacityExceeded) -> Self {
+        SpillError::Capacity(e)
+    }
+}
+
+impl From<io::Error> for SpillError {
+    fn from(e: io::Error) -> Self {
+        SpillError::Io(e)
+    }
+}

--- a/crates/engine/src/concurrent_delta/spill/mod.rs
+++ b/crates/engine/src/concurrent_delta/spill/mod.rs
@@ -62,7 +62,11 @@ use std::fs;
 use std::io::{self, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 
-use super::reorder::{CapacityExceeded, ReorderBuffer};
+use super::reorder::ReorderBuffer;
+
+mod error;
+
+pub use error::SpillError;
 
 /// Environment-variable overrides for [`SpillPolicy`] fields at runtime.
 pub mod env;
@@ -109,83 +113,6 @@ const SPILL_TAG_RAW: u8 = 0x00;
 /// when this tag is observed in a build without the `spill-compression`
 /// feature, instead of attempting to decode garbage.
 const SPILL_TAG_ZSTD: u8 = 0x01;
-
-/// Errors surfaced by the spill layer.
-///
-/// Producers should treat any [`SpillError::Io`] as fatal for the affected
-/// transfer: ENOSPC, missing spill directories, and partial writes all
-/// indicate that the disk backing the reorder buffer can no longer be
-/// trusted. The receiver maps these to exit code 11 ([`FileIo`]) so the
-/// transfer aborts with the same semantics as upstream rsync's I/O failures.
-///
-/// [`UnsupportedCompression`](Self::UnsupportedCompression) is surfaced when a
-/// spill file written by a `spill-compression` build is read by a default
-/// build that has no codec available - the on-disk tag byte advertises the
-/// algorithm so we fail loudly rather than decode garbage.
-///
-/// [`FileIo`]: https://github.com/RsyncProject/rsync/blob/master/errcode.h
-#[derive(Debug)]
-pub enum SpillError {
-    /// Capacity bound from the underlying ring buffer was exceeded.
-    Capacity(CapacityExceeded),
-    /// Disk I/O failed while reading or writing spilled items.
-    Io(io::Error),
-    /// On-disk record advertises a compression algorithm this build cannot
-    /// decode. Holds the unknown tag byte for diagnostics.
-    UnsupportedCompression(u8),
-}
-
-impl SpillError {
-    /// Returns the underlying I/O error if this is an I/O failure.
-    #[must_use]
-    pub fn io_error(&self) -> Option<&io::Error> {
-        match self {
-            SpillError::Io(e) => Some(e),
-            SpillError::Capacity(_) | SpillError::UnsupportedCompression(_) => None,
-        }
-    }
-
-    /// Returns `true` if this error indicates the disk is out of space.
-    #[must_use]
-    pub fn is_out_of_space(&self) -> bool {
-        self.io_error()
-            .is_some_and(|e| e.kind() == io::ErrorKind::StorageFull)
-    }
-}
-
-impl std::fmt::Display for SpillError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            SpillError::Capacity(_) => write!(f, "reorder buffer capacity exceeded"),
-            SpillError::Io(e) => write!(f, "reorder spill I/O failed: {e}"),
-            SpillError::UnsupportedCompression(tag) => write!(
-                f,
-                "reorder spill record uses compression tag 0x{tag:02x} not supported by this build"
-            ),
-        }
-    }
-}
-
-impl std::error::Error for SpillError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            SpillError::Capacity(_) | SpillError::UnsupportedCompression(_) => None,
-            SpillError::Io(e) => Some(e),
-        }
-    }
-}
-
-impl From<CapacityExceeded> for SpillError {
-    fn from(e: CapacityExceeded) -> Self {
-        SpillError::Capacity(e)
-    }
-}
-
-impl From<io::Error> for SpillError {
-    fn from(e: io::Error) -> Self {
-        SpillError::Io(e)
-    }
-}
 
 /// Codec for serializing and deserializing items to the spill file.
 ///
@@ -1014,6 +941,7 @@ fn decode_payload<T: SpillCodec>(tag: u8, payload: Vec<u8>) -> Result<T, SpillEr
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::concurrent_delta::reorder::CapacityExceeded;
 
     // Simple SpillCodec for u64 used in tests.
     impl SpillCodec for u64 {


### PR DESCRIPTION
## Summary

- First step of the spill.rs decomposition plan documented in `docs/audits/spill-rs-decomposition-plan.md` (PR #4337).
- Promotes `crates/engine/src/concurrent_delta/spill.rs` to a directory module (`spill/mod.rs`) and extracts the smallest leaf - the `SpillError` enum plus its `Display`, `Error`, and `From` impls - into a dedicated `spill/error.rs` (78 lines).
- Public surface is unchanged: `engine::concurrent_delta::spill::SpillError` and the re-exports from `concurrent_delta/mod.rs` continue to resolve via `pub use error::SpillError`.

## Test plan

- [x] `cargo check -p engine --all-features --tests` passes locally (no new warnings).
- [x] `cargo fmt --all` clean.
- [ ] CI: fmt+clippy, nextest (stable), Windows, macOS, Linux musl.

Refs SPL-2 #2324.