### PR TITLE
docs: document Windows NTFS ACL behaviour and lossy cases (#2313)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,18 +32,18 @@ All transfer modes (local, SSH, daemon), delta algorithm, metadata preservation,
 | **Reference dirs** | `--compare-dest`, `--link-dest`, `--copy-dest` |
 | **Options** | `--delay-updates`, `--inplace`, `--partial`, `--iconv`, fuzzy matching |
 | **I/O** | io_uring (Linux 5.6+), `copy_file_range`, `clonefile` (macOS), adaptive buffers |
-| **Platforms** | Linux, macOS (full); Windows (ACLs, xattrs via NTFS ADS, IOCP socket I/O; no symlinks/devices) |
+| **Platforms** | Linux, macOS (full); Windows (NTFS DACL partial, xattrs via NTFS ADS, IOCP socket I/O; no symlinks/devices) |
 
 ### Platform Support
 
-The primary platform is Linux. macOS is well-supported with parity for all metadata, ACL, and xattr features, including AppleDouble (`._foo`) resource-fork preservation. Windows builds and runs core transfer modes with native ACLs (via `windows-rs` `GetSecurityInfo`/`SetSecurityInfo`), xattrs (via NTFS Alternate Data Streams), and IOCP socket I/O (`WSARecv`/`WSASend`); symlinks and POSIX device nodes remain stubbed.
+The primary platform is Linux. macOS is well-supported with parity for all metadata, ACL, and xattr features, including AppleDouble (`._foo`) resource-fork preservation. Windows builds and runs core transfer modes with NTFS DACL preservation (via `windows-rs` `GetNamedSecurityInfoW`/`SetNamedSecurityInfoW`, currently Tier 1C partial - see the **--acls** entry in `docs/oc-rsync.1.md` and `docs/design/windows-ntfs-acl-support.md` for the documented lossy cases), xattrs (via NTFS Alternate Data Streams), and IOCP socket I/O (`WSARecv`/`WSASend`); symlinks and POSIX device nodes remain stubbed.
 
 | Feature | Linux | macOS | Windows | Notes |
 |---------|:-----:|:-----:|:-------:|-------|
 | Permissions (`-p`) | ✓ | ✓ | ⚠ | Windows preserves only the read-only flag; POSIX mode bits are not applicable. |
 | Times (`-t`) | ✓ | ✓ | ✓ | Nanosecond precision via the `filetime` crate on all platforms. |
 | File ownership (`-o`/`-g`, uid/gid) | ✓ | ✓ | ✗ | `apply_ownership_from_entry` is a no-op on non-Unix; uid/gid mapping is Unix-only. |
-| ACLs (`-A`) | ✓ | ✓ | ✓ | Uses `exacl` on Linux/macOS/FreeBSD; Windows uses `windows-rs` `GetSecurityInfo`/`SetSecurityInfo` for native NTFS ACL round-trip. |
+| ACLs (`-A`) | ✓ | ✓ | ⚠ | Uses `exacl` on Linux/macOS/FreeBSD. Windows uses `windows-rs` `GetNamedSecurityInfoW`/`SetNamedSecurityInfoW` for NTFS DACL round-trip (Tier 1C partial): deny ACEs, inherited ACEs, the SACL, non-`rwx` access bits, and unresolvable SIDs are dropped with a one-time warning. SDDL fidelity payload, `--audit-acls`, `--fail-on-windows-acl-loss`, and `--windows-acls` are planned. See `docs/design/windows-ntfs-acl-support.md` and the **--acls** entry in `docs/oc-rsync.1.md`. |
 | Extended attributes (`-X`) | ✓ | ✓ | ✓ | Linux/macOS via the `xattr` crate (macOS adds AppleDouble resource-fork support); Windows stores xattrs as NTFS Alternate Data Streams. |
 | Hardlinks (`-H`) | ✓ | ✓ | ✓ | Uses portable `std::fs::hard_link`; works on NTFS. |
 | Symbolic links | ✓ | ✓ | ✗ | `create_symlinks` is `cfg(not(unix))` no-op; symlink entries are skipped on Windows. |

--- a/docs/oc-rsync.1.md
+++ b/docs/oc-rsync.1.md
@@ -276,10 +276,82 @@ NEON) are used where available, with automatic scalar fallbacks.
 :   Disable creation time preservation.
 
 **-A**, **--acls**
-:   Preserve POSIX ACLs when supported (Unix only).
+:   Preserve POSIX ACLs on Linux, macOS, and FreeBSD via `exacl`.
+
+    On Windows, **--acls** preserves the NTFS discretionary ACL (DACL) via
+    `GetNamedSecurityInfoW`/`SetNamedSecurityInfoW`. The Windows path is a
+    Tier 1C partial implementation: it interoperates with upstream rsync
+    and POSIX peers through the standard cross-platform ACL wire format,
+    but it cannot represent every NTFS construct losslessly. The following
+    losses are documented and emit a one-time warning per transfer:
+
+      - **Deny ACEs are dropped.** POSIX has no deny equivalent, so explicit
+        `ACCESS_DENIED_ACE_TYPE` entries are silently omitted from the wire
+        payload.
+      - **Inherited ACEs are not transmitted.** ACEs with the
+        `INHERITED_ACE` flag are skipped; the receiver relies on the
+        destination's own inheritance chain. Mirrors how POSIX default ACLs
+        are handled as a separate stream.
+      - **The system ACL (SACL) is skipped** unless the planned
+        **--audit-acls** flag is passed and the sender holds
+        `SE_SECURITY_NAME`. Audit ACEs cannot ride the cross-platform
+        payload.
+      - **Non-`rwx` access bits collapse.** `FILE_GENERIC_READ`/`WRITE`/`EXECUTE`
+        map cleanly to `r`/`w`/`x`. Bits outside that triplet (`DELETE`,
+        `WRITE_DAC`, `WRITE_OWNER`, `SYNCHRONIZE`, generic bits) are
+        dropped on send and re-synthesised as `FILE_GENERIC_*` plus
+        `SYNCHRONIZE` on receive.
+      - **Unresolvable SIDs are dropped.** Trustee SIDs that
+        `LookupAccountSidW` cannot translate to an account name are omitted
+        from the cross-platform payload; on receive, names that
+        `LookupAccountNameW` cannot resolve cause the ACE to be dropped
+        with a warning.
+
+    The cross-platform payload is the standard upstream byte stream
+    (varint count, per-entry tag, permission triplet, optional name). A
+    second, opt-in payload encoding the full NTFS security descriptor as
+    SDDL on the existing xattr stream under
+    `user.win32.security_descriptor` is planned (see
+    **--windows-acls** below). SDDL is the textual form produced and
+    consumed by `ConvertSecurityDescriptorToStringSecurityDescriptorW`;
+    Windows-to-Windows transfers may use it for higher fidelity while
+    remaining backward-compatible with peers that only understand the
+    cross-platform payload.
+
+    See `docs/design/windows-ntfs-acl-support.md` for the full mapping
+    matrix, hardlink handling, and the implementation roadmap.
 
 **--no-acls**
-:   Disable POSIX ACL preservation.
+:   Disable ACL preservation.
+
+**--audit-acls** (planned)
+:   On Windows, request that the sender read the system ACL (SACL) in
+    addition to the DACL. Requires the `SE_SECURITY_NAME` privilege; the
+    sender skips the SACL with a warning when the privilege probe fails.
+    SACL contents are carried only in the SDDL fidelity payload (see
+    **--windows-acls**), never in the cross-platform payload. Not yet
+    wired; see `docs/design/windows-ntfs-acl-support.md` section 4.2.
+
+**--fail-on-windows-acl-loss** (planned)
+:   On Windows, abort the transfer with exit code 23 (partial transfer)
+    when an NTFS DACL contains deny ACEs, audit ACEs, inherited ACEs that
+    cannot be expressed in POSIX, or owner/group SIDs the receiver cannot
+    resolve. Use this when a transfer must either preserve the source
+    DACL verbatim or fail loudly rather than silently lower to POSIX
+    rwx. Not yet wired; see `docs/design/windows-ntfs-acl-support.md`
+    section 4.3.
+
+**--windows-acls** (planned)
+:   On Windows, opt in to the Windows-to-Windows SDDL fidelity payload in
+    addition to the cross-platform payload. When both peers advertise the
+    `W` capability bit, the sender writes the full NTFS security
+    descriptor as SDDL into the `user.win32.security_descriptor` xattr
+    via `ConvertSecurityDescriptorToStringSecurityDescriptorW`, and the
+    receiver reconstructs the descriptor verbatim via
+    `ConvertStringSecurityDescriptorToSecurityDescriptorW`. Falls back to
+    the cross-platform payload when either peer does not advertise `W`.
+    Not yet wired; see `docs/design/windows-ntfs-acl-support.md` section
+    4.2.
 
 **-X**, **--xattrs**
 :   Preserve extended attributes when supported (Unix only).

--- a/docs/operator-migration-guide-vNEXT.md
+++ b/docs/operator-migration-guide-vNEXT.md
@@ -327,6 +327,38 @@ grows by `N_threads * byte_cap` (default 1 MiB). Operators running
 with more than 32 worker threads per pool will see lower contention
 and slightly higher RSS.
 
+## 6a. Windows NTFS ACL behaviour
+
+`--acls`/`-A` now works on Windows targets via
+`GetNamedSecurityInfoW`/`SetNamedSecurityInfoW`, but the implementation
+is a Tier 1C partial path. Operators migrating Windows workloads should
+budget for the documented lossy cases before flipping `-A` on:
+
+- Explicit deny ACEs are dropped on send.
+- Inherited ACEs are not transmitted; the destination inheritance chain
+  takes over.
+- The system ACL (SACL) is skipped unless the planned **--audit-acls**
+  flag is passed and `SE_SECURITY_NAME` is held.
+- Non-`rwx` access bits (`DELETE`, `WRITE_DAC`, `WRITE_OWNER`, generic
+  bits) collapse to `r`/`w`/`x` plus `SYNCHRONIZE` on receive.
+- Trustee SIDs that cannot be translated to or from an account name are
+  dropped with a one-time warning.
+
+The cross-platform payload remains byte-compatible with upstream rsync
+and POSIX peers. The planned **--windows-acls** opt-in adds a higher-
+fidelity SDDL payload over the existing xattr stream for Windows-to-
+Windows transfers, and **--fail-on-windows-acl-loss** turns the lossy
+cases into a hard failure (exit code 23) for environments that need to
+preserve every NTFS ACE verbatim or abort. None of these three flags
+ship in this release; track `docs/design/windows-ntfs-acl-support.md`
+section 4 for the rollout schedule.
+
+The full mapping matrix, hardlink-safe DACL application rules, and the
+SDDL wire format details are in
+`docs/design/windows-ntfs-acl-support.md`. The user-facing
+**--acls** entry in `docs/oc-rsync.1.md` enumerates the lossy cases
+alongside the flag synopsis.
+
 ## 7. Rollback procedure
 
 If a regression surfaces in vNEXT, pin to the previous release. The
@@ -407,3 +439,4 @@ next.
 | io_uring session ring pool                     | `docs/design/iouring-session-ring-pool.md`                              |
 | io_uring per-thread rings                      | `docs/design/iouring-per-thread-rings.md`                               |
 | Cross-platform CI coverage                     | `docs/audits/cross-platform-ci-coverage.md`                             |
+| Windows NTFS ACL support                       | `docs/design/windows-ntfs-acl-support.md`                               |


### PR DESCRIPTION
## Summary

- Expand the `--acls`/`-A` entry in `docs/oc-rsync.1.md` to spell out the Tier 1C Windows DACL behaviour: deny ACEs dropped, inherited ACEs skipped, SACL gated on `--audit-acls`, non-`rwx` access bits collapsed to `r`/`w`/`x` plus `SYNCHRONIZE`, and unresolvable SIDs dropped with a one-time warning.
- Document `--audit-acls`, `--fail-on-windows-acl-loss`, and `--windows-acls` as planned flags, including the SDDL wire-format payload over the `user.win32.security_descriptor` xattr.
- Mark the README platform-support row as `partial` for Windows ACLs and add a new section 6a to `docs/operator-migration-guide-vNEXT.md` covering operator impact, plus an appendix link.
- Cross-link `docs/design/windows-ntfs-acl-support.md` from all three surfaces so operators land on the full mapping matrix.

## Test plan

- [x] `cargo fmt --all` (no-op for docs-only change).
- [ ] `markdownlint` and CI doc builds pass (rendered by CI).
- [ ] Spot-check the man page output (`pandoc docs/oc-rsync.1.md -s -t man | man -l -`) renders the new `--acls`, `--audit-acls`, `--fail-on-windows-acl-loss`, and `--windows-acls` entries.