### PR TITLE
docs(design): io_uring data path - receive + send (#2362, #2363)

### DIFF
--- a/docs/design/iouring-receive-data-path.md
+++ b/docs/design/iouring-receive-data-path.md
@@ -1,0 +1,364 @@
+# io_uring receive data path: routing chunk writes through registered buffers
+
+Tracking task: IUD-2 (oc-rsync follow-up #2362). Implementation phases
+are keyed to IUD-5 (buffer-pool wiring) and IUD-8 (telemetry + rollout).
+
+Companion docs already in tree:
+
+- `docs/design/iouring-registered-buffer-adaptive-sizing.md` - registered
+  buffer group sizing and lifecycle.
+- `docs/design/iouring-adaptive-buffer-pool.md` - cross-thread buffer
+  pool that supplies the SPSC chunks today.
+- `docs/design/iouring-borrowed-slice-consumer.md` (#4218) - pin-counted
+  pool that this work must compose with.
+- `docs/design/iouring-per-thread-rings.md` (#1929) - per-thread ring
+  topology this writer will plug into when promoted.
+- `docs/design/mmap-vs-sqpoll-conflict-resolution.md` - the same READ_FIXED
+  primitive on the basis-file side; this design must not contradict the
+  SMR ruling that mmap pointers never enter io_uring SQEs.
+- `docs/design/basis-file-io-policy.md` - selector that downgrades the
+  basis to `BufferedMap` whenever an io_uring writer is active.
+
+This document does not change any wired dispatch. It specifies the next
+step: routing the bytes that the network thread hands to the disk-commit
+thread through `IORING_OP_WRITE_FIXED` against a registered-buffer group
+shared with the basis-file reader. The actual switch is gated by the new
+opt-in feature `iouring-data-writes` (default off) and lands as the
+patches enumerated in section 6.
+
+## 1. Current receive writer
+
+The receive path is two threads connected by a lock-free SPSC channel.
+
+### 1.1 Network thread (producer)
+
+- `crates/transfer/src/receiver/transfer.rs:55-70` runs the receiver
+  role. The pipelined path
+  (`crates/transfer/src/receiver/transfer/pipeline.rs`) parses delta
+  tokens via `TokenReader` (`crates/transfer/src/token_reader.rs`) and
+  resolves block-copy references against a `MapFile`
+  (`crates/transfer/src/map_file/mod.rs:55`).
+- For literal tokens the network thread pulls a recycled
+  `Vec<u8>` from the buffer pool
+  (`crates/transfer/src/pipeline/buffer_pool.rs`), copies the demuxed
+  bytes in, and sends it as `FileMessage::Chunk(Vec<u8>)`
+  (`crates/transfer/src/pipeline/messages.rs:21-45`).
+- For block-copy tokens the network thread reads from the basis
+  `MapFile` and emits the resulting slice via the same `Chunk`
+  message. The basis source is `BufferedMap` whenever io_uring is
+  active on the writer side
+  (`crates/transfer/src/delta_apply/applicator.rs:161-176`).
+
+### 1.2 Disk commit thread (consumer)
+
+- `crates/transfer/src/disk_commit/process.rs:32-118` drains the SPSC
+  channel one message at a time. `Chunk(Vec<u8>)` is forwarded to
+  `Writer::write_chunk` (`crates/transfer/src/disk_commit/writer.rs:199-211`),
+  which dispatches to one of:
+  - `Writer::Buffered` - `ReusableBufWriter` over `std::fs::File` with
+    a 256 KB reusable buffer
+    (`crates/transfer/src/disk_commit/writer.rs:71-122`).
+  - `Writer::IoUring` (Linux + `io_uring` feature) - delegates to
+    `IoUringDiskBatch::write_data`
+    (`crates/fast_io/src/io_uring/disk_batch.rs:124-149`), which
+    internally calls `submit_write_batch`
+    (`crates/fast_io/src/io_uring/batching.rs`) over its private 256 KB
+    staging buffer.
+  - `Writer::Iocp` (Windows + `iocp` feature) - peer of the above on
+    `IORING_OP_WRITEV` analogue.
+  - `Writer::Macos` - `MacosWriter` with `F_NOCACHE` + `writev(2)`.
+  - `Writer::Vmsplice` (Linux + `vmsplice` feature) - zero-copy splice
+    that fires only when neither io_uring nor IOCP claimed the file.
+
+- `make_writer` (`crates/transfer/src/disk_commit/process.rs:277-323`)
+  picks the variant. Sparse mode and non-zero `append_offset` force
+  `Buffered` because none of the batched backends implement `Seek`.
+- After draining a file, `Writer::flush_and_sync` and `Writer::finish`
+  (`crates/transfer/src/disk_commit/writer.rs:218-299`) run flush +
+  optional fsync + rename in the order matching upstream
+  `fileio.c:write_file()` and `receiver.c:finish_recv_file()`.
+
+### 1.3 The two memcpy hops we want to eliminate
+
+For literal tokens today, a byte travels:
+
+1. Socket -> demux -> token reader staging
+   (`crates/transfer/src/token_reader.rs`). Copy 1: kernel page cache to
+   user buffer via `read(2)`.
+2. Token reader -> recycled `Vec<u8>` from the buffer pool. Copy 2: the
+   `TokenBuffer::pull_literal` memcpy
+   (`crates/transfer/src/token_buffer.rs`).
+3. Network thread sends `FileMessage::Chunk(Vec<u8>)` -> SPSC; the buffer
+   itself is moved, no copy.
+4. Disk thread writes via `Writer::write_chunk`. For
+   `Writer::IoUring`, this is `IoUringDiskBatch::write_data` which
+   copies the chunk into its private 256 KB staging buffer before
+   submitting `IORING_OP_WRITE` SQEs
+   (`crates/fast_io/src/io_uring/disk_batch.rs:124-149`,
+   `crates/fast_io/src/io_uring/batching.rs::submit_write_batch`).
+   Copy 3: user buffer to kernel-bounce staging buffer.
+
+The kernel performs an additional copy inside `IORING_OP_WRITE` because
+the staging buffer is not registered: `get_user_pages_fast` pins the
+pages each submission, and the SQE carries an unfixed `iovec`. This
+write design replaces hop 4's user-side memcpy and removes the
+per-submission `get_user_pages` cost by handing the kernel a registered
+buffer index that points at the same memory the network thread filled.
+
+### 1.4 Coalesced `WholeFile` path
+
+The single-message `FileMessage::WholeFile { begin, data }` path
+(`crates/transfer/src/pipeline/messages.rs:32-37`) is taken when the
+entire file fits in one literal token. It folds Begin + one Chunk +
+Commit into one SPSC send. The data-path proposal must keep this fast
+path intact - it stays on `Writer::Buffered` because the file is
+typically small enough that registering a buffer is pure overhead. See
+section 4.4 for the threshold.
+
+## 2. Proposed: WRITE_FIXED-backed disk writer
+
+### 2.1 Topology
+
+Reuse the existing `RegisteredBufferGroup`
+(`crates/fast_io/src/io_uring/registered_buffers/registry.rs`). The
+buffer-pool layer already owns a fixed-size set of `Vec<u8>` slots; we
+add a parallel "registered-pool" that wraps those same allocations as
+io_uring fixed buffers, keyed by index. Each slot has:
+
+- A registered-buffer index (`buf_index: u16`) usable as the third
+  argument to `IORING_OP_WRITE_FIXED`.
+- A raw pointer + length stored in a `RegisteredBufferSlotInfo`
+  (`crates/fast_io/src/io_uring/registered_buffers/submit.rs:253-260`).
+- A pin reference count, mirroring the borrowed-slice consumer design
+  (#4218) so that the disk thread cannot recycle a slot while a
+  notification CQE is still outstanding.
+
+The disk-commit thread keeps the same `IoUringDiskBatch` instance it
+holds today, plus a new sibling `IoUringWriteFixedBatch` that takes
+ownership of pre-registered slots instead of allocating a private
+staging buffer.
+
+### 2.2 Submission flow per chunk
+
+When `feature = "iouring-data-writes"` is on and the chunk arrives via
+`FileMessage::Chunk(slot)` (a new variant carrying a registered-buffer
+handle rather than a bare `Vec<u8>`):
+
+1. The disk thread maps the slot's index to the file offset
+   (cumulative `bytes_written` for the active `ActiveFile`).
+2. It calls `submit_write_fixed_batch`
+   (`crates/fast_io/src/io_uring/registered_buffers/submit.rs:159-243`)
+   with the slot's `RegisteredBufferSlotInfo` and the current file fd
+   (already registered via `try_register_fd`).
+3. The submission helper pushes one `IORING_OP_WRITE_FIXED` SQE per
+   slot. It uses `submit_and_wait(submitted)` (synchronous) for the
+   first cut to match the current `submit_write_batch` semantics; the
+   batched / non-blocking path is enumerated in section 6.
+4. On CQE, the slot is returned to the pool. Pin count is decremented
+   so the network thread can reclaim it via the buffer-return channel
+   (`buf_return_tx` in `process.rs:32-118`).
+
+### 2.3 Backward compatibility: dispatch surface
+
+`Writer::IoUring` keeps its current variant. A new `Writer::IoUringFixed`
+variant is added:
+
+```text
+pub(super) enum Writer<'a> {
+    Buffered(ReusableBufWriter<'a>),
+    #[cfg(all(target_os = "linux", feature = "io_uring"))]
+    IoUring { batch: &'a mut fast_io::IoUringDiskBatch },
+    #[cfg(all(target_os = "linux", feature = "io_uring", feature = "iouring-data-writes"))]
+    IoUringFixed { batch: &'a mut fast_io::IoUringWriteFixedBatch },
+    // ... existing variants
+}
+```
+
+`make_writer` picks `IoUringFixed` when:
+
+- the registered-pool is available (the buffer pool succeeded in
+  registering its backing slots with the active ring), AND
+- `use_sparse` is false AND `append_offset == 0` AND
+  `begin.target_size >= IOURING_DATA_WRITES_MIN_BYTES` (default 64 KiB,
+  tunable via env, see section 4.4).
+
+Otherwise dispatch is unchanged, including the unregistered
+`Writer::IoUring` path. There is no scenario in which the new variant
+silently degrades a file that previously used `Writer::Buffered`.
+
+## 3. Ordering
+
+The write order is unchanged: `Begin -> Chunk* -> Commit | Abort`. The
+disk thread still processes one file at a time. The `WRITE_FIXED` SQEs
+within a single `Chunk` message complete out-of-order, but the helper
+already reassembles bytes-written by user-data index
+(`submit_write_fixed_batch:217-237`) and reports `batch_written` only
+after every CQE is drained. The next `Chunk` is not submitted until the
+previous batch has fully completed; sequential file offset is therefore
+preserved.
+
+Across files, `commit_file` (`disk_batch.rs:168-187`) drains the active
+file before calling `submit_fsync`. The new `IoUringWriteFixedBatch`
+follows the same shape: `commit_file` performs `flush_current` (drain),
+then `submit_fsync` (only when `do_fsync`), then detaches the fd.
+
+## 4. fsync placement, partial writes, and fallback
+
+### 4.1 fsync
+
+Identical to today. `commit_file(do_fsync)` issues an `IORING_OP_FSYNC`
+SQE against the same fd
+(`crates/fast_io/src/io_uring/disk_batch.rs:236-263`). The change does
+not move fsync earlier or later; durability semantics match upstream's
+`writefd` + `fsync()` pair in `receiver.c:finish_recv_file()`.
+
+### 4.2 Short writes
+
+`IORING_OP_WRITE_FIXED` may complete short on the same surfaces as
+`pwrite(2)` short writes: ENOSPC partial flushes, signal-interrupted
+NFS writes, FUSE backends that honour `direct_io`. The submission
+helper detects shorts by comparing each SQE's `requested_per_sqe` to
+its `actual_per_sqe` and advances `total_written` only through the
+contiguous prefix of fully-written SQEs
+(`submit.rs:217-237`). The outer loop resubmits the remaining bytes
+starting at the new offset. This is the same algorithm
+`submit_read_fixed_batch` (`submit.rs:29-152`) already uses on the read
+side.
+
+If a CQE returns a negative result, the helper converts it to
+`io::Error::from_raw_os_error(-result)` and the disk thread aborts the
+file via the existing `FileMessage::Abort` pathway. The partially
+written temp file is removed by `TempFileGuard::drop`
+(`crates/transfer/src/temp_guard.rs`).
+
+### 4.3 Fallback hierarchy
+
+The new path falls back in order:
+
+1. **No `iouring-data-writes` feature** -> existing `Writer::IoUring`
+   (unfixed) path, unchanged.
+2. **Feature on, but registration failed at ring construction**
+   (kernel < 5.6, `register_buffers` rejected, MEMLOCK rlimit too low)
+   -> `Writer::IoUring` unfixed path. The disk thread logs a one-line
+   `debug_log!(Io, 1, "registered buffer pool unavailable, falling
+   back to unfixed io_uring writer")` at startup, mirroring the
+   `RegisteredBufferStatus` provenance pattern from
+   `crates/fast_io/src/io_uring/file_writer.rs:42-47`.
+3. **Per-file ineligible** (sparse, append, file too small) ->
+   `Writer::Buffered`, unchanged.
+4. **Kernel error mid-transfer** (`ENOMEM`, `EAGAIN`) -> abort the
+   file; the receiver records a hard error. Same as today's io_uring
+   submission errors.
+
+### 4.4 Per-file size threshold
+
+`IOURING_DATA_WRITES_MIN_BYTES = 64 * 1024` by default. The selection
+follows two pressures: small files (under one wire chunk, ~32 KiB) ride
+the `WholeFile` coalesced path and never reach the chunk loop;
+medium files just above that threshold incur ring-side scheduling that
+costs more than the kernel-side `get_user_pages_fast` it saves.
+Telemetry from IUD-8 (section 6) will tighten this number after a real
+run.
+
+## 5. Feature flag and configuration
+
+`iouring-data-writes` (default off) lives on the `fast_io` crate and is
+re-exported by `transfer` through the same pass-through pattern as
+`io_uring`, `iocp`, `vmsplice`
+(`crates/fast_io/Cargo.toml:39-83`,
+`crates/transfer/Cargo.toml:88-101`):
+
+```text
+# fast_io/Cargo.toml
+iouring-data-writes = ["io_uring"]
+
+# transfer/Cargo.toml
+iouring-data-writes = ["io_uring", "fast_io/iouring-data-writes"]
+```
+
+The runtime selector additionally consults
+`OC_RSYNC_IOURING_DATA_WRITES` (`auto` / `force` / `off`). `auto` is
+the documented production value once the rollout completes; `force` is
+for benchmarks; `off` disables the path even when the feature is
+compiled in. The env var follows the same dispatch convention as
+`OC_RSYNC_BENCH_IOURING_RING`
+(`crates/fast_io/Cargo.toml:155`).
+
+## 6. Implementation plan
+
+The work is split into five PR-sized steps, keyed to IUD-5 (buffer pool
+wiring) and IUD-8 (telemetry + rollout).
+
+1. **IUD-5a: `IoUringWriteFixedBatch` skeleton.** Introduce the new
+   batch type in `crates/fast_io/src/io_uring/` next to
+   `IoUringDiskBatch`. API mirror: `new`, `try_new`, `begin_file`,
+   `write_data_fixed(slot: RegisteredBufferSlotInfo, len: usize)`,
+   `flush`, `commit_file`, `bytes_written*`. Tests: extend
+   `crates/fast_io/src/io_uring/tests.rs` with `commit`, multi-file,
+   drop-flush parity tests under the new feature. No production
+   wiring.
+
+2. **IUD-5b: Buffer-pool registration.** Teach the existing
+   buffer-pool allocator in `crates/transfer/src/pipeline/buffer_pool.rs`
+   to allocate slots that are page-aligned and large enough to satisfy
+   `io_uring_register_buffers(2)`. Add a `try_register_with_ring`
+   method that walks the slots, registers them, and stores the
+   per-slot `RegisteredBufferSlotInfo` alongside the existing
+   `Vec<u8>` payload. Provenance is captured in
+   `RegisteredBufferStatus` so operators can diagnose
+   `unsupported / rejected / disabled-by-config / disabled-by-rlimit`.
+
+3. **IUD-5c: New `FileMessage::FixedChunk` variant.** Add the variant
+   to `crates/transfer/src/pipeline/messages.rs:21-45`. The network
+   thread writes literal-token bytes directly into a registered slot
+   (no second memcpy) and sends `FixedChunk(slot_handle)`. The disk
+   thread dispatches `FixedChunk` to `Writer::IoUringFixed::write_chunk`
+   and returns the handle through `buf_return_tx`. The pre-existing
+   `Chunk(Vec<u8>)` variant is kept for the buffered, vmsplice, IOCP,
+   and macOS variants.
+
+4. **IUD-5d: `Writer::IoUringFixed` and selector update.** Extend
+   `Writer` in `crates/transfer/src/disk_commit/writer.rs:144-163` and
+   `make_writer` in `process.rs:277-323`. Add the eligibility checks
+   from section 2.3 and the size threshold from section 4.4. Default
+   the env-var selector to `auto`.
+
+5. **IUD-8: Telemetry + rollout gating.** Wire counters into the
+   existing `TransferStats`
+   (`crates/transfer/src/receiver/stats.rs`) for: chunks routed via
+   `WRITE_FIXED`, chunks routed via unfixed io_uring, chunks routed
+   via buffered fallback, registered-buffer slot-exhaustion fallbacks,
+   short-write retries. Wire a single-line `debug_log!(Io, 1, ..)`
+   on the first per-process degradation transition. Flip the
+   `OC_RSYNC_IOURING_DATA_WRITES` default to `auto` once benchmarks
+   from `crates/fast_io/benches/iouring_data_writes.rs` (added in
+   IUD-8) demonstrate non-regression on the workloads called out in
+   `crates/fast_io/Cargo.toml:111-160`.
+
+## 7. Interaction with the basis-file read primitive (SMR-3a)
+
+The basis-file reader (SMR-3a, `mmap-vs-sqpoll-conflict-resolution.md`
+section "Replacing mmap with READ_FIXED") plans to issue
+`IORING_OP_READ_FIXED` against the same registered-buffer pool. The two
+designs deliberately share the pool, which means:
+
+- **One pool, two consumers.** Per-ring registration limits
+  (`IORING_REGISTER_BUFFERS` caps at 1024 slots; the kernel-side
+  iov_iter cost grows with slot count) are spent once; both the
+  reader and the writer draw from the same pool.
+- **Strict ownership ping-pong.** A slot in flight on a READ_FIXED SQE
+  cannot be reused by a WRITE_FIXED SQE until its read CQE has been
+  drained and its pin-count returned to zero. The borrowed-slice
+  consumer (#4218) already encodes this invariant.
+- **SQPOLL is forbidden for both paths.** The
+  `mmap-vs-sqpoll-conflict-resolution.md` rule applies symmetrically:
+  registered buffers backed by file-backed VMAs cannot be referenced
+  by an SQPOLL kthread without exposing `SIGBUS`. Both the read and
+  write paths therefore continue to construct rings without
+  `IORING_SETUP_SQPOLL` when the registered-buffer pool is active.
+
+The selector in section 2.3 must therefore also check that the basis-
+file strategy is not `MmapStrategy`. The check is already enforced
+indirectly today via `basis-file-io-policy.md` (writer-io_uring forces
+`BufferedMap`), but the new feature flag promotes the rule to a hard
+precondition on `Writer::IoUringFixed` construction.

--- a/docs/design/iouring-send-data-path.md
+++ b/docs/design/iouring-send-data-path.md
@@ -1,0 +1,382 @@
+# io_uring send data path: basis READ_FIXED + socket SEND_ZC
+
+Tracking task: IUD-3 (oc-rsync follow-up #2363). Implementation phases
+are keyed to IUD-6 (basis reader), IUD-7 (socket writer pinning), and
+IUD-8 (telemetry + rollout, shared with IUD-2).
+
+Companion docs already in tree:
+
+- `docs/design/iouring-send-zc.md` (#1832) - SEND_ZC primitive and
+  the existing `IoUringSocketWriter`.
+- `docs/design/iouring-borrowed-slice-consumer.md` (#4218) - pin-counted
+  pool that the SEND_ZC notification CQE depends on.
+- `docs/design/iouring-registered-buffer-adaptive-sizing.md` - registered
+  buffer group sizing and lifecycle.
+- `docs/design/iouring-receive-data-path.md` (IUD-2, #2362) - sibling
+  doc; the registered-buffer pool design is shared.
+- `docs/design/mmap-vs-sqpoll-conflict-resolution.md` - rules out
+  mmap-backed bytes inside io_uring SQEs, which constrains the basis
+  read path here.
+- `docs/design/basis-file-io-policy.md` - selector matrix that switches
+  basis reads between `BufferedMap`, `MmapStrategy`, and (under this
+  proposal) `RegisteredBufferGroup`.
+
+This document does not change any wired dispatch. It specifies how
+delta-source bytes get from the basis file (or the source file) onto
+the network without leaving the kernel: the basis file is read via
+`IORING_OP_READ_FIXED` into registered buffers, and those same buffers
+are handed straight to `IORING_OP_SEND_ZC` against the network socket.
+The actual switch is gated by the new feature `iouring-data-sends`
+(default off) and lands as the patches in section 6.
+
+## 1. Current send reader + socket write
+
+The send role lives in `crates/transfer/src/generator/`. The relevant
+streaming entry points for file data are:
+
+### 1.1 Whole-file send
+
+- `crates/transfer/src/generator/delta.rs:200-274` (the loop that
+  starts with `let mut total_bytes: u64 = 0`) is the whole-file
+  literal stream. It reads from a generic `R: Read` (today an
+  `open_source_with_noatime` wrapped in `BufReader`,
+  `crates/transfer/src/generator/open_source.rs`) into a reusable
+  buffer, computes the running file checksum, and emits framed wire
+  chunks via `writer.write_all(&buf[wire_off..wire_off + 4 + chunk])`
+  (line 257). The 4-byte length prefix is packed in-place ahead of
+  each 32 KiB wire chunk so the combined write triggers the
+  `MplexWriter` bulk fast path
+  (`crates/protocol/src/multiplex/writer.rs:175-220`,
+  `crates/transfer/src/writer/multiplex.rs:104-108`).
+- Buffer size is `MAX_READ_SIZE = 256 * 1024`
+  (`delta.rs:221`), reused across files.
+- `writer` is the `MplexWriter` returned by
+  `crates/transfer/src/writer/multiplex.rs:42-60`. Each write
+  ultimately reduces to `Write::write_all` on the underlying
+  socket / SSH `ChildStdin` (see
+  `docs/design/iouring-send-zc.md` section 1.2).
+
+### 1.2 Delta send with basis re-read
+
+- `crates/transfer/src/generator/delta.rs:289-334`
+  (`compute_file_checksum`) re-reads basis-file blocks for the running
+  whole-file checksum. The read is via `std::fs::File::seek` +
+  `read_exact` into a `Vec<u8>` (lines 322-325). On the wire side, the
+  per-block emission is the corresponding token in
+  `write_token_stream` (`delta.rs:355-380` for `script_to_wire_delta`,
+  then `delta.rs:382-463` for the wire emit).
+- The streaming literal-token path in
+  `crates/transfer/src/generator/delta.rs:227-237` shares the same
+  256 KiB buffer when compression is on; the compressed encoder
+  (`CompressedTokenEncoder::send_literal`) is opaque to the byte path
+  but still ends at a `Write::write_all` on the multiplex writer.
+
+### 1.3 Multiplex framing constraint
+
+`MplexWriter` wraps every payload in a 4-byte `MSG_DATA` header
+(`crates/protocol/src/multiplex/writer.rs:70-128`). The header is built
+by `send_msg`
+(`crates/protocol/src/multiplex/io/send.rs:16-22`) and emitted via
+`write_all_vectored` (line 130) which prefers a two-slice `writev`. The
+maximum payload per frame is 8192 bytes (`DEFAULT_MAX_FRAME_SIZE`,
+`multiplex/writer.rs:88`). Any io_uring proposal that bypasses
+`MplexWriter` for the data slice must still emit the header on the
+same socket immediately before each payload chunk.
+
+### 1.4 The two memcpy hops we want to eliminate
+
+For a basis-file block re-read or a whole-file literal byte:
+
+1. Kernel page cache -> user buffer via `read(2)` (kernel-side copy
+   into `read_buf`).
+2. `MplexWriter` buffer fill -> SQE / `writev` slice
+   (`writer/multiplex.rs:42-108`). For chunks above the 32 KiB internal
+   threshold this is a pointer hand-off (no copy); below the threshold
+   it is a memcpy into the writer's buffer.
+3. Kernel-side: socket layer copies the user buffer into the skbuff
+   chain on `send(2)`. This is the copy that `IORING_OP_SEND_ZC`
+   eliminates by pinning the user pages and emitting the notification
+   CQE only after the NIC has consumed them
+   (`docs/design/iouring-send-zc.md` section 2).
+
+`SEND_ZC` alone removes hop 3. This design also removes hop 1 by
+issuing the basis read as `IORING_OP_READ_FIXED` directly into the
+same registered buffer that hop 3 will SEND_ZC. End-to-end the user
+buffer becomes a pinned, registered region that is referenced (not
+copied) by both the disk read SQE and the socket send SQE.
+
+## 2. Proposed: end-to-end zero-copy on the Linux io_uring path
+
+### 2.1 Topology
+
+The same registered-buffer pool from IUD-2 (see
+`docs/design/iouring-receive-data-path.md` section 2.1) is shared with
+the send role. The sender owns a `SendBufferGroup` view over the pool:
+the same `RegisteredBufferSlotInfo` records, but with the inverse
+ping-pong (slots filled by READ_FIXED, drained by SEND_ZC).
+
+The sender holds a single `IoUringSendCoordinator` that bundles:
+
+- A reference to the registered-buffer pool.
+- A handle to the basis file's fd (when delta mode) or the source
+  file's fd (when whole-file mode), both registered with the ring via
+  `try_register_fd`
+  (`crates/fast_io/src/io_uring/batching.rs::try_register_fd`).
+- A reference to the existing `IoUringSocketWriter`
+  (`crates/fast_io/src/io_uring/socket_writer.rs:36-48`).
+- The `MplexWriter`'s buffer (for emitting the 4-byte `MSG_DATA`
+  header alongside the payload, see section 2.3).
+
+### 2.2 Basis / source read via `IORING_OP_READ_FIXED`
+
+For both `compute_file_checksum`'s basis-block reads
+(`delta.rs:289-334`) and the whole-file streaming loop
+(`delta.rs:200-274`), the read is replaced with
+`submit_read_fixed_batch`
+(`crates/fast_io/src/io_uring/registered_buffers/submit.rs:29-152`).
+The helper already understands short reads, out-of-order CQEs, and
+fixed-fd dispatch via `maybe_fixed_file`. The caller supplies:
+
+- `fd` = the registered-fd token for the file (or the raw fd if
+  registration was rejected),
+- `output` = the caller's `Vec<u8>` for the no-fixed-buffer fallback,
+- `base_offset` = the file offset of the first byte,
+- `slots` = the registered-buffer slot info from the pool.
+
+On the read-fixed path the kernel writes bytes directly into the
+pinned, registered memory. `submit_read_fixed_batch` then memcpys from
+the registered slot into the caller's `output` slice; for the
+end-to-end zero-copy path we instead skip that final memcpy and keep
+the slot itself as the unit handed onward to SEND_ZC. A new helper
+`submit_read_fixed_batch_pinned` returns the filled slots without
+copying out (the existing helper stays for callers that need the
+copy-back semantics).
+
+### 2.3 Socket send via `IORING_OP_SEND_ZC` with header coalescing
+
+The existing `IoUringSocketWriter::submit_send`
+(`crates/fast_io/src/io_uring/socket_writer.rs:83-106`) already routes
+payloads above 16 KiB through `send_zc::try_send_zc`. The send-side
+data-path proposal calls into the same primitive, but with two
+adjustments:
+
+1. **Header + payload as one SEND_ZC.** Each wire chunk needs its
+   4-byte `MSG_DATA` header to precede the payload bytes on the socket.
+   Two paths:
+   - **Pre-pend header inside the slot.** Each registered slot
+     reserves 4 leading bytes; the basis read targets `slot.ptr + 4`
+     with `want = chunk_size - 4`; SEND_ZC submits the full
+     `[header][payload]` range. The header is written via a
+     write-then-submit pattern, identical to the in-place packing trick
+     already used in `delta.rs:251-258`.
+   - **Submit two-buffer SEND_ZC.** `IORING_OP_SEND_ZC` supports a
+     `msghdr` with multiple iovecs via `IORING_OP_SENDMSG_ZC`
+     (kernel 6.1+). Use this path on kernels that advertise the
+     opcode; fall back to the in-slot header pre-pend otherwise.
+
+   The pre-pend path is the default. SENDMSG_ZC is an optimisation
+   that section 6's IUD-7 patches can adopt opportunistically.
+
+2. **Frame size bound is unchanged.** `MplexWriter::DEFAULT_MAX_FRAME_SIZE`
+   is 8192 bytes. The slot size must therefore stay at or below
+   `8192 + 4 = 8196` bytes when used for the send path, even when the
+   receive path (IUD-2) prefers larger slots. The pool keeps the slot
+   size at the larger value but the sender slices the payload into
+   8192-byte chunks before submission. This is the same constraint that
+   the existing `MplexWriter` already enforces
+   (`crates/protocol/src/multiplex/writer.rs:179-195`).
+
+### 2.4 Per-chunk lifecycle
+
+For each 8 KiB wire chunk under the new path:
+
+1. `IoUringSendCoordinator` claims one registered slot.
+2. It submits an `IORING_OP_READ_FIXED` SQE for the basis-file range
+   (delta mode) or the source-file range (whole-file mode) into
+   `slot.ptr + 4`, with `want = chunk_size - 4`.
+3. On the read CQE, the coordinator writes the 4-byte `MSG_DATA`
+   header into `slot.ptr[..4]`.
+4. It submits an `IORING_OP_SEND_ZC` SQE for `slot.ptr..slot.ptr + 4 +
+   actual_read`. Pin count on the slot is incremented.
+5. On the send notification CQE (`IORING_CQE_F_NOTIF`), pin count is
+   decremented. When it hits zero, the slot returns to the pool.
+
+The submission for step 4 can be link-chained from step 2 via
+`IOSQE_IO_LINK` on kernels that support it, so a single
+`submit_and_wait` services the round-trip. The infrastructure for that
+is in `crates/fast_io/src/io_uring/linked_chain.rs`; section 6 cites
+the patch that wires it.
+
+### 2.5 Dispatch surface
+
+The sender currently passes a `MplexWriter<TcpStream>` (or `<SshChild>`
+etc.) into the streaming functions in `delta.rs`. The new path is opt-
+in: when `feature = "iouring-data-sends"` is on AND the underlying
+writer is a real TCP socket (not SSH) AND the registered-buffer pool
+exists AND the file size exceeds `IOURING_DATA_SENDS_MIN_BYTES`, the
+streaming functions take a different code path:
+
+```text
+match send_coordinator {
+    Some(coord) => coord.stream_basis_zero_copy(writer, source_fd, ...),
+    None        => existing_buffered_path(writer, &mut source, ...),
+}
+```
+
+The existing path is untouched. The new path is the only consumer of
+`stream_basis_zero_copy`. There is no scenario in which the new path
+silently degrades a transfer that previously used the buffered
+streamer.
+
+## 3. Multiplex framing constraint: tag header
+
+The 4-byte `MSG_DATA` header (tag `MessageCode::Data + MPLEX_BASE = 7`,
+24-bit little-endian payload length) is the only invariant that
+distinguishes a multiplex socket from a raw socket. The send-side
+proposal preserves it via the in-slot pre-pend described in section
+2.3:
+
+- The slot layout is `[4 bytes header][N bytes payload]`.
+- The payload length stored in bytes 1-3 is the actual basis-read
+  count (may be short on EOF, NFS partial reads, etc.).
+- The header is written after the read CQE settles, so the length is
+  always correct.
+- For shorts, the helper resubmits a smaller payload-only chunk in a
+  follow-up slot. The header is recomputed for the follow-up's actual
+  length. This matches `submit_read_fixed_batch`'s loop structure
+  (`submit.rs:48-138`).
+
+Control messages (`MessageCode::Info`, `MessageCode::Warning`, etc.)
+continue to flow through the existing `MplexWriter::write_message`
+path. The io_uring send coordinator only touches `MSG_DATA` frames;
+mixing the two streams on the same socket is forced sequential by the
+existing `MplexWriter` API which flushes the data buffer before
+emitting a control message
+(`crates/protocol/src/multiplex/writer.rs:197-220`).
+
+## 4. Compression interaction
+
+When compression is enabled (`-z`, `--compress-choice=zstd`), the
+literal byte stream is fed into `CompressedTokenEncoder::send_literal`
+(`crates/transfer/src/generator/delta.rs:227-237`) which produces
+compressed framing that is not byte-aligned with the read chunks. The
+end-to-end zero-copy path does not apply: compression by definition
+copies-and-transforms. The selector therefore gates on
+`compression.is_none()` in addition to the conditions in section 2.5.
+
+For the matched (block-copy) path under compression, the
+`see_token()` calls into the deflate dictionary are still required
+(`delta.rs:382-463`). The basis-read via READ_FIXED is still useful
+because it removes hop 1's memcpy even if hop 3 stays on regular
+SEND. Section 6 sequences this as an IUD-7 follow-up.
+
+## 5. Feature flag and configuration
+
+`iouring-data-sends` (default off) lives on the `fast_io` crate and is
+re-exported by `transfer`:
+
+```text
+# fast_io/Cargo.toml
+iouring-data-sends = ["io_uring"]
+
+# transfer/Cargo.toml
+iouring-data-sends = ["io_uring", "fast_io/iouring-data-sends"]
+```
+
+The runtime selector consults `OC_RSYNC_IOURING_DATA_SENDS`
+(`auto` / `force` / `off`), parallel to the IUD-2 env var.
+`IOURING_DATA_SENDS_MIN_BYTES = 64 * 1024` by default; SEND_ZC's own
+floor inside `IoUringSocketWriter` is 16 KiB
+(`crates/fast_io/src/io_uring/socket_writer.rs:18-20`), so the
+combined gate honours both thresholds (the higher wins).
+
+Kernel requirements:
+
+- `IORING_OP_READ_FIXED` since Linux 5.6, like the receive path.
+- `IORING_OP_SEND_ZC` since Linux 6.0
+  (`crates/fast_io/src/io_uring/send_zc.rs::is_supported`).
+- `IORING_OP_SENDMSG_ZC` since Linux 6.1 (optional, header coalescing).
+- `IOSQE_IO_LINK` since Linux 5.5 (always available when io_uring is).
+
+When `SEND_ZC` is unsupported, the path falls back to regular
+`IORING_OP_SEND` against the same registered buffers, preserving the
+basis-read savings even when the socket-send savings are unavailable.
+
+## 6. Implementation plan
+
+The work is split into five PR-sized steps, keyed to IUD-6 (basis
+reader), IUD-7 (socket writer pinning), and IUD-8 (telemetry +
+rollout, shared with IUD-2).
+
+1. **IUD-6a: `submit_read_fixed_batch_pinned` helper.** Add the
+   no-copy-out variant of the existing helper in
+   `crates/fast_io/src/io_uring/registered_buffers/submit.rs`. Returns
+   `Vec<(RegisteredBufferSlotInfo, bytes_read)>` for the caller to
+   consume. Reuse the short-read loop verbatim from
+   `submit_read_fixed_batch:48-138`. Tests: extend
+   `crates/fast_io/src/io_uring/registered_buffers/tests/` with
+   short-read and out-of-order CQE coverage.
+
+2. **IUD-6b: `BasisReader::read_pinned`.** New trait method (or a free
+   function alongside `crates/transfer/src/map_file/mod.rs`) that the
+   delta-emit loop calls instead of `MapFile::map_ptr`. Returns a
+   pinned slot rather than a `&[u8]`. The buffered and mmap variants
+   implement it as "allocate a Vec, fill it, wrap in a fake slot
+   handle"; only the new `RegisteredBufferGroup`-backed variant
+   actually pins. The selector matrix from
+   `docs/design/basis-file-io-policy.md` gains a sixth column
+   `iouring_send_data_active`; when true and other constraints pass,
+   the matrix returns `RB` (registered buffers) for the basis read.
+
+3. **IUD-7a: `IoUringSendCoordinator` skeleton.** New type in
+   `crates/fast_io/src/io_uring/send_coordinator.rs` that owns a ring
+   shared with the basis reader and a registered-fd slot for the
+   socket. Exposes `submit_read_then_send` that link-chains
+   `READ_FIXED` and `SEND_ZC` SQEs (or runs them sequentially when
+   `IOSQE_IO_LINK` is rejected). Pin-count tracking follows the
+   borrowed-slice consumer design (#4218).
+
+4. **IUD-7b: Wire the coordinator into `delta.rs`.** Add the
+   selector at `crates/transfer/src/generator/delta.rs:200-274`
+   (whole-file literal stream) and at `delta.rs:289-334`
+   (basis re-read). The coordinator is passed through the call chain
+   the same way the existing `MultiplexWriter` is. Compression
+   gate per section 4. Maintain wire compatibility: byte stream
+   on the socket is byte-identical to the buffered path for the same
+   input.
+
+5. **IUD-8 (shared with IUD-2): Telemetry + rollout.** Wire counters
+   for: sends routed via SEND_ZC + READ_FIXED, sends routed via
+   SEND_ZC only (read fell back to buffered), sends routed via plain
+   SEND (SEND_ZC unsupported), SENDMSG_ZC adoption, pin-count
+   exhaustion fallbacks. Single-line `debug_log!(Io, 1, ..)` on the
+   first degradation transition per process. Bench harness:
+   `crates/fast_io/benches/iouring_data_sends.rs` measuring against
+   the matched workloads in `crates/fast_io/Cargo.toml:111-160`.
+   Flip `OC_RSYNC_IOURING_DATA_SENDS` default to `auto` once
+   benchmarks demonstrate non-regression.
+
+## 7. Interaction with IUD-2 (receive path)
+
+A given oc-rsync process is either a sender or a receiver on a given
+transfer; the two roles never share a registered-buffer pool within
+one transfer. The pools are conceptually identical (same slot layout,
+same registration call) and the implementation reuses
+`RegisteredBufferGroup`
+(`crates/fast_io/src/io_uring/registered_buffers/registry.rs`), but
+they are distinct instances owned by distinct threads:
+
+- Receive role: the disk-commit thread holds the pool; the network
+  thread checks slots out for fill, the disk thread checks them in
+  for WRITE_FIXED.
+- Send role: the sender thread holds the pool; READ_FIXED checks them
+  in from the file, SEND_ZC checks them out to the network.
+
+Crucially, the SQPOLL prohibition from
+`docs/design/mmap-vs-sqpoll-conflict-resolution.md` applies to both:
+file-backed VMAs (which include any `Mmap`-derived pointer) must never
+appear in an SQE issued by the SQPOLL kthread. The registered-buffer
+slots are anonymous, page-aligned `Vec<u8>` allocations, so the SQPOLL
+constraint does not bite on the data path itself - but the selector
+must still keep the basis-file `MmapStrategy` out of the ring on the
+send side, mirroring the receive side's exclusion.


### PR DESCRIPTION
## Summary

Two companion design docs specifying how transfer file data will be routed through io_uring SQEs end-to-end on Linux. No code changes.

- **docs/design/iouring-receive-data-path.md** (IUD-2, #2362): route disk-commit chunk writes through registered buffers + IORING_OP_WRITE_FIXED. New feature flag iouring-data-writes (default off). 5-step plan keyed to IUD-5 and IUD-8.
- **docs/design/iouring-send-data-path.md** (IUD-3, #2363): basis re-read via IORING_OP_READ_FIXED feeding directly into IORING_OP_SEND_ZC, with the 4-byte MSG_DATA header pre-pended inside the registered slot. New feature flag iouring-data-sends (default off). 5-step plan keyed to IUD-6, IUD-7, IUD-8.

Both docs spell out ordering, fsync placement, short-write handling, fallback hierarchy, the SQPOLL exclusion (mirrors the mmap-vs-sqpoll ruling), and per-feature thresholds. The two paths deliberately share a registered-buffer pool design with SMR-3a's basis reader so the receive READ_FIXED + WRITE_FIXED loop and the send READ_FIXED + SEND_ZC loop reuse the same `submit_read_fixed_batch` / `submit_write_fixed_batch` helpers and the same pin-counting (#4218).

## Test plan

- [x] cargo fmt --all clean (no-op, docs-only change)
- [x] No references to forbidden terms or em-dashes
- [ ] CI passes (docs-only PR; required checks: fmt+clippy, nextest stable, Windows, macOS, Linux musl)