### PR TITLE
ci: nightly fuzz coverage report per target (#2322)

### DIFF
--- a/.github/workflows/fuzz-coverage-report.yml
+++ b/.github/workflows/fuzz-coverage-report.yml
@@ -1,0 +1,249 @@
+# Nightly Fuzz Coverage Report - Informational
+#
+# Runs `cargo fuzz coverage` for every target across the three fuzz workspaces
+# (`fuzz/`, `crates/protocol/fuzz/`, `crates/filters/fuzz/`) and uploads the
+# generated `.lcov` files as workflow artifacts. Marked `continue-on-error: true`
+# while we establish baseline thresholds per target. Promote to a required
+# check once each target has a stable minimum line coverage documented in
+# `docs/audits/fuzz-coverage-matrix.md`.
+#
+# Budget:
+#   - 5 minutes per target (-max_total_time=300) keeps the matrix under the
+#     90-minute job timeout even as targets are added.
+#   - Targets run in a matrix so a single regression does not block siblings
+#     (fail-fast: false).
+#
+# Outputs:
+#   - One `coverage/<target>.lcov` per matrix entry, uploaded with
+#     `retention-days: 30` so historical comparisons survive a full sprint.
+#   - A "Coverage summary (informational)" step greps line-hit totals from
+#     each lcov file into the GitHub step summary for at-a-glance review.
+
+name: Fuzz Coverage Report
+
+on:
+  schedule:
+    # Nightly at 03:30 UTC: after Filter Fuzzer Overnight (02:00 UTC) so the
+    # two jobs do not compete for the same fuzz workspace lock.
+    - cron: '30 3 * * *'
+  workflow_dispatch:
+    inputs:
+      duration:
+        description: 'Seconds per fuzz target (default 300 = 5 min)'
+        required: false
+        default: '300'
+
+concurrency:
+  group: fuzz-coverage-report
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  FUZZ_DURATION: ${{ github.event.inputs.duration || '300' }}
+
+jobs:
+  coverage:
+    name: ${{ matrix.target }} (informational)
+    runs-on: ubuntu-latest
+    # 5 min per target + 25 min for toolchain install, upstream build, and
+    # cargo-fuzz coverage compilation overhead.
+    timeout-minutes: 30
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - workspace: fuzz
+            target: protocol_wire
+          - workspace: fuzz
+            target: simd_checksum_parity
+          - workspace: fuzz
+            target: filter_differential
+            needs_upstream: true
+          - workspace: fuzz
+            target: filter_rules_vs_upstream
+            needs_upstream: true
+          - workspace: fuzz
+            target: multiplex_frame_parse
+          - workspace: fuzz
+            target: flist_entry_decode
+          - workspace: fuzz
+            target: decompressor_zstd
+          - workspace: fuzz
+            target: decompressor_zlib
+          - workspace: crates/protocol/fuzz
+            target: fuzz_varint
+          - workspace: crates/protocol/fuzz
+            target: varint_roundtrip
+          - workspace: crates/protocol/fuzz
+            target: fuzz_delta
+          - workspace: crates/protocol/fuzz
+            target: fuzz_multiplex_frame
+          - workspace: crates/protocol/fuzz
+            target: multiplex_frame_roundtrip
+          - workspace: crates/protocol/fuzz
+            target: fuzz_legacy_greeting
+          - workspace: crates/protocol/fuzz
+            target: file_entry_roundtrip
+          - workspace: crates/filters/fuzz
+            target: fuzz_filter_parse
+          - workspace: crates/filters/fuzz
+            target: fuzz_filter_chain
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
+        with:
+          toolchain: stable
+
+      - name: Install nightly Rust
+        uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
+        with:
+          toolchain: nightly
+          components: llvm-tools-preview
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
+        with:
+          shared-key: ci-${{ runner.os }}-cargo-v1-${{ hashFiles('**/Cargo.lock') }}
+          key: fuzz-coverage-${{ matrix.target }}
+
+      - name: Cache APT packages
+        uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05 # v1.6.0
+        with:
+          packages: build-essential pkg-config zlib1g-dev curl autoconf automake libtool libacl1-dev libattr1-dev lcov
+          version: v1
+
+      - name: Install cargo-fuzz
+        run: cargo install cargo-fuzz --locked
+
+      - name: Cache upstream rsync
+        if: matrix.needs_upstream
+        id: cache-rsync
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            target/interop/upstream-src
+            target/interop/upstream-install
+          key: upstream-rsync-3.4.2-${{ runner.os }}-${{ hashFiles('tools/ci/run_interop.sh') }}
+          restore-keys: |
+            upstream-rsync-3.4.2-${{ runner.os }}-
+
+      - name: Build upstream rsync
+        if: matrix.needs_upstream && steps.cache-rsync.outputs.cache-hit != 'true'
+        run: bash tools/ci/run_interop.sh build-only
+
+      - name: Locate upstream rsync
+        if: matrix.needs_upstream
+        id: upstream
+        run: |
+          set -euo pipefail
+          for candidate in \
+              "${GITHUB_WORKSPACE}/target/interop/upstream-install/3.4.2/bin/rsync" \
+              "${GITHUB_WORKSPACE}/target/interop/upstream-install/3.4.1/bin/rsync"; do
+              if [[ -x "${candidate}" ]]; then
+                  echo "upstream=${candidate}" >>"$GITHUB_OUTPUT"
+                  echo "located upstream rsync at ${candidate}"
+                  exit 0
+              fi
+          done
+          echo "error: no upstream rsync binary built" >&2
+          exit 1
+
+      - name: Run cargo fuzz coverage (${{ matrix.target }})
+        env:
+          OC_RSYNC_UPSTREAM_BIN: ${{ steps.upstream.outputs.upstream }}
+        run: |
+          set -uo pipefail
+          cd "${{ matrix.workspace }}"
+          # cargo fuzz coverage runs the target with a coverage-instrumented
+          # build and emits coverage/<target>/coverage.profdata.
+          cargo +nightly fuzz coverage "${{ matrix.target }}" \
+              -- -max_total_time="${FUZZ_DURATION}"
+          status=$?
+          echo "coverage_status=${status}" >>"$GITHUB_ENV"
+          if [[ "${status}" -ne 0 ]]; then
+              echo "warning: cargo fuzz coverage exited ${status}" >&2
+          fi
+
+      - name: Convert profdata to lcov
+        if: always()
+        run: |
+          set -uo pipefail
+          workspace="${{ matrix.workspace }}"
+          target="${{ matrix.target }}"
+          profdata="${workspace}/coverage/${target}/coverage.profdata"
+          mkdir -p coverage
+          if [[ ! -f "${profdata}" ]]; then
+              echo "no profdata for ${target}; emitting empty placeholder" >&2
+              : >"coverage/${target}.lcov"
+              exit 0
+          fi
+          # cargo fuzz writes the instrumented binary under
+          # <workspace>/target/<host-triple>/coverage/<host-triple>/release/<target>.
+          host_triple=$(rustc -vV | awk '/^host:/ { print $2 }')
+          binary="${workspace}/target/${host_triple}/coverage/${host_triple}/release/${target}"
+          if [[ ! -x "${binary}" ]]; then
+              # Fallback layout for older cargo-fuzz releases.
+              binary="${workspace}/target/${host_triple}/release/${target}"
+          fi
+          if [[ ! -x "${binary}" ]]; then
+              echo "warning: instrumented binary missing for ${target}" >&2
+              : >"coverage/${target}.lcov"
+              exit 0
+          fi
+          cargo +nightly cov -- export \
+              --format=lcov \
+              --instr-profile="${profdata}" \
+              "${binary}" \
+              >"coverage/${target}.lcov" || {
+              echo "warning: cargo cov export failed for ${target}" >&2
+              : >"coverage/${target}.lcov"
+          }
+
+      - name: Coverage summary (informational)
+        if: always()
+        run: |
+          set -uo pipefail
+          target="${{ matrix.target }}"
+          lcov_file="coverage/${target}.lcov"
+          {
+              echo "## Fuzz coverage: ${target}"
+              echo ""
+              if [[ ! -s "${lcov_file}" ]]; then
+                  echo "_No coverage data emitted; see job log for details._"
+                  exit 0
+              fi
+              # LF = lines found, LH = lines hit. Aggregate across source files
+              # in the lcov record so the summary reflects total target coverage.
+              lf=$(grep -c '^LF:' "${lcov_file}" || true)
+              lh_total=$(awk -F: '/^LH:/ { sum += $2 } END { print sum + 0 }' "${lcov_file}")
+              lf_total=$(awk -F: '/^LF:/ { sum += $2 } END { print sum + 0 }' "${lcov_file}")
+              if [[ "${lf_total}" -gt 0 ]]; then
+                  pct=$(awk -v h="${lh_total}" -v f="${lf_total}" \
+                      'BEGIN { printf "%.2f", (h / f) * 100 }')
+              else
+                  pct="n/a"
+              fi
+              echo "| Metric | Value |"
+              echo "|--------|-------|"
+              echo "| Source records | ${lf} |"
+              echo "| Lines found | ${lf_total} |"
+              echo "| Lines hit | ${lh_total} |"
+              echo "| Line coverage | ${pct}% |"
+          } >>"${GITHUB_STEP_SUMMARY}"
+
+      - name: Upload lcov artifact
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: fuzz-coverage-${{ matrix.target }}-${{ github.run_id }}
+          retention-days: 30
+          path: coverage/${{ matrix.target }}.lcov
+          if-no-files-found: warn

--- a/docs/audits/fuzz-coverage-matrix.md
+++ b/docs/audits/fuzz-coverage-matrix.md
@@ -46,6 +46,18 @@ The remaining 11 targets run only on demand via
 `tools/ci/run_filter_fuzz.sh`, `tools/ci/run_filter_differential_fuzz.sh`,
 or direct `cargo +nightly fuzz run` invocation.
 
+### Nightly coverage report (informational)
+
+The `Fuzz Coverage Report` workflow (`.github/workflows/fuzz-coverage-report.yml`)
+runs `cargo fuzz coverage <target> -- -max_total_time=300` for every target
+in the three fuzz workspaces nightly at 03:30 UTC. Each run uploads a
+`coverage/<target>.lcov` artifact with 30-day retention, and the GitHub step
+summary lists per-target line-coverage percentages. The job is marked
+`continue-on-error: true` while baseline thresholds stabilise; promote it to
+a required check once each target has a documented minimum line-coverage
+target and the lcov totals trend monotonically upward across consecutive
+nightly runs.
+
 Maturity signals:
 
 - `fuzz/corpus/` and `fuzz/artifacts/` are absent at the top-level


### PR DESCRIPTION
## Summary
- Add `.github/workflows/fuzz-coverage-report.yml`: nightly (03:30 UTC) + `workflow_dispatch` job that runs `cargo fuzz coverage <target> -- -max_total_time=300` for every target across the three fuzz workspaces (`fuzz/`, `crates/protocol/fuzz/`, `crates/filters/fuzz/`).
- Each matrix entry exports the coverage profdata to `coverage/<target>.lcov`, uploads it as a workflow artifact (30-day retention), and writes a per-target line-coverage row to the GitHub step summary.
- Marked `continue-on-error: true` to mirror the SAFETY-audit informational pattern from `ci.yml`; promote to a required check once per-target thresholds are documented and stable.
- Documents the rollout in `docs/audits/fuzz-coverage-matrix.md`.

Closes #2322.

## Test plan
- [ ] Trigger `Fuzz Coverage Report` via `workflow_dispatch` and confirm each matrix leg uploads a `coverage/<target>.lcov` artifact.
- [ ] Inspect the GitHub step summary for the per-target `Lines found / Lines hit / Line coverage` rows.
- [ ] Confirm the job runs nightly at 03:30 UTC without contending with `Filter Fuzzer Overnight` (02:00 UTC).
- [ ] Verify the filter-differential legs locate the upstream rsync binary via the existing cache layer.