### PR TITLE
feat(fast_io): BGID high-water mark + 50%-occupancy warning (#2295)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -547,7 +547,7 @@ dependencies = [
  "md4",
  "openssl",
  "proptest",
- "rand 0.8.6",
+ "rand 0.10.1",
  "rayon",
  "sha1 0.10.6",
  "sha2 0.10.9",
@@ -1341,6 +1341,7 @@ dependencies = [
  "rustix",
  "tempfile",
  "thiserror 2.0.18",
+ "tracing",
  "windows-sys 0.61.2",
 ]
 
@@ -3005,15 +3006,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "raw-cpuid"
-version = "11.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
 name = "rayon"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3124,7 +3116,6 @@ dependencies = [
  "proptest",
  "protocol",
  "rand 0.10.1",
- "raw-cpuid",
  "rpassword",
  "russh",
  "shell-words",
@@ -4079,7 +4070,7 @@ dependencies = [
  "metadata",
  "proptest",
  "protocol",
- "rand 0.9.4",
+ "rand 0.10.1",
  "rayon",
  "signature 0.6.2",
  "tempfile",

--- a/crates/fast_io/Cargo.toml
+++ b/crates/fast_io/Cargo.toml
@@ -17,6 +17,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 rayon = { workspace = true }
 logging = { path = "../logging" }
 thiserror = { workspace = true }
+tracing = { workspace = true }
 
 # Cached sorting with Schwartzian transform
 permutation = "0.4"

--- a/crates/fast_io/src/io_uring/buffer_ring.rs
+++ b/crates/fast_io/src/io_uring/buffer_ring.rs
@@ -61,6 +61,7 @@ use std::io;
 use std::ptr;
 use std::sync::atomic::{AtomicU16, AtomicU32, Ordering};
 use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
 
 use io_uring::IoUring as RawIoUring;
 
@@ -137,15 +138,85 @@ const BGID_NAMESPACE_SIZE: u32 = u16::MAX as u32 + 1;
 /// `BGID_NAMESPACE_SIZE` thereafter.
 static NEXT_BGID: AtomicU32 = AtomicU32::new(0);
 
+/// Process-wide high-water mark for concurrently-allocated bgids.
+///
+/// Updated via `fetch_max` after every successful
+/// [`BgidAllocator::allocate`] call. Exposed by [`bgid_peak_used`] so
+/// operators and tests can observe the worst-case occupancy of the 16-bit
+/// namespace over the process lifetime. Never decreases; deallocation
+/// returns ids to the free-list but the peak stays.
+static PEAK_USED: AtomicU16 = AtomicU16::new(0);
+
+/// Initial capacity reserved for the bgid free-list.
+///
+/// Sized to cover the typical steady-state churn of a long-running daemon
+/// recycling buffer rings without triggering `Vec` reallocations under the
+/// free-list mutex. 4 096 entries match a common upper bound on
+/// simultaneously-open buffer rings before the namespace warning fires
+/// (50 % of u16::MAX is 32 767).
+const BGID_FREE_LIST_INITIAL_CAPACITY: usize = 1 << 12;
+
+/// Occupancy threshold (in absolute bgid count) that triggers the
+/// throttled namespace-pressure warning.
+///
+/// Set to 50 % of the 16-bit namespace so operators get early notice that
+/// the process is approaching exhaustion while there is still headroom to
+/// react.
+const BGID_OCCUPANCY_WARN_THRESHOLD: u16 = (BGID_NAMESPACE_SIZE / 2) as u16;
+
+/// Minimum interval between successive namespace-pressure warnings.
+const BGID_WARN_THROTTLE: Duration = Duration::from_secs(30);
+
 /// Process-wide free-list of returned bgids available for reuse.
 ///
 /// Populated by [`BgidAllocator::deallocate`] when a [`BufferRing`] that
 /// was issued a bgid by [`BgidAllocator::allocate`] is dropped. Drained by
 /// [`BgidAllocator::allocate`] before incrementing [`NEXT_BGID`], so the
 /// monotonic counter only advances when no reusable id is available.
+///
+/// Pre-sized to `BGID_FREE_LIST_INITIAL_CAPACITY` so the steady-state
+/// churn of a long-running daemon does not trigger `Vec` reallocations
+/// under the free-list mutex.
 fn bgid_free_list() -> &'static Mutex<Vec<u16>> {
     static FREE_LIST: OnceLock<Mutex<Vec<u16>>> = OnceLock::new();
-    FREE_LIST.get_or_init(|| Mutex::new(Vec::new()))
+    FREE_LIST.get_or_init(|| Mutex::new(Vec::with_capacity(BGID_FREE_LIST_INITIAL_CAPACITY)))
+}
+
+/// Last time the namespace-pressure warning was emitted.
+///
+/// `None` means "never emitted". Updated under the mutex so two threads
+/// observing > 50 % occupancy simultaneously do not both emit a warning.
+fn bgid_warn_last() -> &'static Mutex<Option<Instant>> {
+    static LAST: OnceLock<Mutex<Option<Instant>>> = OnceLock::new();
+    LAST.get_or_init(|| Mutex::new(None))
+}
+
+/// Emits a throttled `tracing::warn!` when bgid occupancy crosses 50 %.
+///
+/// The warning fires at most once per `BGID_WARN_THROTTLE` window so a
+/// hot allocation path under sustained pressure does not flood the log.
+fn maybe_warn_namespace_pressure(in_flight: u16) {
+    if in_flight < BGID_OCCUPANCY_WARN_THRESHOLD {
+        return;
+    }
+    let mut last = match bgid_warn_last().lock() {
+        Ok(g) => g,
+        Err(p) => p.into_inner(),
+    };
+    let now = Instant::now();
+    let fire = match *last {
+        None => true,
+        Some(t) => now.duration_since(t) >= BGID_WARN_THROTTLE,
+    };
+    if fire {
+        *last = Some(now);
+        tracing::warn!(
+            target: "fast_io::buffer_ring",
+            in_flight,
+            namespace = BGID_NAMESPACE_SIZE,
+            "io_uring bgid occupancy crossed 50% of the 16-bit namespace"
+        );
+    }
 }
 
 /// Allocator for io_uring buffer group IDs (bgid).
@@ -194,11 +265,12 @@ impl BgidAllocator {
         // Reuse a freed id when one is available. The lock is held only for
         // the pop, so contention with concurrent deallocate calls is
         // negligible in practice (one buffer ring per long-running task).
-        if let Some(id) = bgid_free_list()
+        let popped = bgid_free_list()
             .lock()
             .expect("bgid free-list poisoned")
-            .pop()
-        {
+            .pop();
+        if let Some(id) = popped {
+            record_allocation();
             return Ok(id);
         }
 
@@ -207,6 +279,7 @@ impl BgidAllocator {
         // depend on this value being observed in a particular order.
         let id = NEXT_BGID.fetch_add(1, Ordering::Relaxed);
         if id < BGID_NAMESPACE_SIZE {
+            record_allocation();
             Ok(id as u16)
         } else {
             // Cap the counter at BGID_NAMESPACE_SIZE rather than letting it
@@ -264,6 +337,56 @@ impl BgidAllocator {
             .len() as u32;
         BGID_NAMESPACE_SIZE - used + free
     }
+}
+
+/// Updates `PEAK_USED` and fires the throttled namespace-pressure
+/// warning when in-flight occupancy crosses `BGID_OCCUPANCY_WARN_THRESHOLD`.
+///
+/// Called once per successful [`BgidAllocator::allocate`] return so the
+/// high-water mark reflects every issued id, whether the slot came from
+/// the free-list or from advancing the monotonic counter.
+fn record_allocation() {
+    let in_flight = current_in_flight();
+    PEAK_USED.fetch_max(in_flight, Ordering::Relaxed);
+    maybe_warn_namespace_pressure(in_flight);
+}
+
+/// Computes the current number of allocator-issued bgids that have not
+/// been returned to the free-list.
+///
+/// Saturates at `u16::MAX` so the result always fits in `u16`. The
+/// snapshot is best-effort: under concurrent allocate/deallocate the
+/// counter and free-list reads are not atomic together, but the value
+/// never overstates occupancy because both inputs are observed under the
+/// same monotonic discipline.
+fn current_in_flight() -> u16 {
+    let issued = NEXT_BGID.load(Ordering::Relaxed).min(BGID_NAMESPACE_SIZE);
+    let free = bgid_free_list()
+        .lock()
+        .expect("bgid free-list poisoned")
+        .len() as u32;
+    issued.saturating_sub(free).min(u16::MAX as u32) as u16
+}
+
+/// Returns the high-water mark for concurrently-allocated bgids since
+/// process start.
+///
+/// Monotonic: deallocation never lowers this value. Reflects the worst
+/// observed pressure on the 16-bit bgid namespace and is intended for
+/// operational dashboards and capacity-planning tests.
+#[must_use]
+pub fn bgid_peak_used() -> u16 {
+    PEAK_USED.load(Ordering::Relaxed)
+}
+
+/// Returns the current count of allocator-issued bgids not yet returned
+/// to the free-list.
+///
+/// Saturates at `u16::MAX`. Intended for ad-hoc diagnostics; the value
+/// can change between the read and the next allocate/deallocate call.
+#[must_use]
+pub fn bgid_inflight() -> u16 {
+    current_in_flight()
 }
 
 /// Process-wide cache for the PBUF_RING support probe.
@@ -1090,6 +1213,7 @@ mod tests {
     struct BgidStateGuard {
         prev_counter: u32,
         prev_free_list: Vec<u16>,
+        prev_peak: u16,
         _serializer: std::sync::MutexGuard<'static, ()>,
     }
 
@@ -1097,6 +1221,7 @@ mod tests {
         fn snapshot() -> Self {
             let serializer = bgid_test_lock();
             let prev_counter = NEXT_BGID.swap(0, Ordering::Relaxed);
+            let prev_peak = PEAK_USED.swap(0, Ordering::Relaxed);
             let prev_free_list = {
                 let mut list = bgid_free_list().lock().expect("free-list poisoned");
                 std::mem::take(&mut *list)
@@ -1104,6 +1229,7 @@ mod tests {
             Self {
                 prev_counter,
                 prev_free_list,
+                prev_peak,
                 _serializer: serializer,
             }
         }
@@ -1112,6 +1238,7 @@ mod tests {
     impl Drop for BgidStateGuard {
         fn drop(&mut self) {
             NEXT_BGID.store(self.prev_counter, Ordering::Relaxed);
+            PEAK_USED.store(self.prev_peak, Ordering::Relaxed);
             let mut list = bgid_free_list().lock().expect("free-list poisoned");
             *list = std::mem::take(&mut self.prev_free_list);
         }
@@ -1218,6 +1345,81 @@ mod tests {
         assert_eq!(
             list_len, 1,
             "duplicate deallocate must not push the same bgid twice"
+        );
+    }
+
+    #[test]
+    fn bgid_peak_tracks_100_allocations() {
+        let _guard = BgidStateGuard::snapshot();
+        assert_eq!(bgid_peak_used(), 0);
+        for _ in 0..100 {
+            BgidAllocator::allocate().expect("allocation within namespace");
+        }
+        assert_eq!(
+            bgid_peak_used(),
+            100,
+            "peak must reflect the 100 outstanding allocations"
+        );
+        assert_eq!(bgid_inflight(), 100);
+    }
+
+    #[test]
+    fn bgid_peak_does_not_decrease_on_deallocate() {
+        let _guard = BgidStateGuard::snapshot();
+        let mut ids = Vec::with_capacity(50);
+        for _ in 0..50 {
+            ids.push(BgidAllocator::allocate().expect("allocation within namespace"));
+        }
+        assert_eq!(bgid_peak_used(), 50);
+        assert_eq!(bgid_inflight(), 50);
+
+        for id in ids {
+            BgidAllocator::deallocate(id);
+        }
+        assert_eq!(
+            bgid_peak_used(),
+            50,
+            "peak must not decrease after returning ids to the free-list"
+        );
+        assert_eq!(bgid_inflight(), 0, "all ids returned, none in flight");
+
+        // Reallocating from the free-list still updates the peak path but
+        // never lifts it above the previous high-water mark.
+        let _ = BgidAllocator::allocate().expect("reallocation from free-list");
+        assert_eq!(bgid_peak_used(), 50);
+    }
+
+    #[test]
+    fn bgid_free_list_is_pre_sized() {
+        let _guard = BgidStateGuard::snapshot();
+        let cap = bgid_free_list()
+            .lock()
+            .expect("free-list poisoned")
+            .capacity();
+        assert!(
+            cap >= BGID_FREE_LIST_INITIAL_CAPACITY,
+            "free-list pre-sized capacity {cap} must be >= {BGID_FREE_LIST_INITIAL_CAPACITY}"
+        );
+    }
+
+    #[test]
+    fn bgid_inflight_reflects_counter_minus_free_list() {
+        let _guard = BgidStateGuard::snapshot();
+        let a = BgidAllocator::allocate().expect("first");
+        let b = BgidAllocator::allocate().expect("second");
+        let _c = BgidAllocator::allocate().expect("third");
+        assert_eq!(bgid_inflight(), 3);
+
+        BgidAllocator::deallocate(a);
+        BgidAllocator::deallocate(b);
+        assert_eq!(bgid_inflight(), 1);
+    }
+
+    #[test]
+    fn bgid_warn_threshold_is_half_namespace() {
+        assert_eq!(
+            BGID_OCCUPANCY_WARN_THRESHOLD,
+            (BGID_NAMESPACE_SIZE / 2) as u16
         );
     }
 }

--- a/crates/fast_io/src/io_uring/mod.rs
+++ b/crates/fast_io/src/io_uring/mod.rs
@@ -112,8 +112,8 @@ use std::io::{self, Write};
 use std::os::unix::io::AsRawFd;
 
 pub use buffer_ring::{
-    BgidAllocator, BufferRing, BufferRingConfig, BufferRingError, buffer_id_from_cqe_flags,
-    pbuf_ring_supported,
+    BgidAllocator, BufferRing, BufferRingConfig, BufferRingError, bgid_inflight, bgid_peak_used,
+    buffer_id_from_cqe_flags, pbuf_ring_supported,
 };
 pub use cancel::{
     ASYNC_CANCEL_FD_MIN_KERNEL, ASYNC_CANCEL_MIN_KERNEL, CancelOutcome, IORING_OP_ASYNC_CANCEL,

--- a/crates/fast_io/src/io_uring_stub/buffer_ring.rs
+++ b/crates/fast_io/src/io_uring_stub/buffer_ring.rs
@@ -113,3 +113,21 @@ impl BgidAllocator {
         0
     }
 }
+
+/// Returns 0 on non-Linux platforms; no bgids are ever issued here.
+///
+/// Mirrors the Linux accessor so cross-platform callers and metrics
+/// exporters compile without `cfg`-gating.
+#[must_use]
+pub fn bgid_peak_used() -> u16 {
+    0
+}
+
+/// Returns 0 on non-Linux platforms; no bgids are ever issued here.
+///
+/// Mirrors the Linux accessor so cross-platform callers and metrics
+/// exporters compile without `cfg`-gating.
+#[must_use]
+pub fn bgid_inflight() -> u16 {
+    0
+}

--- a/crates/fast_io/src/io_uring_stub/mod.rs
+++ b/crates/fast_io/src/io_uring_stub/mod.rs
@@ -52,7 +52,9 @@ pub use crate::io_uring_common::{
     SharedCompletion, SharedRingConfig, buffer_id_from_cqe_flags,
 };
 
-pub use buffer_ring::{BgidAllocator, BufferRing, pbuf_ring_supported};
+pub use buffer_ring::{
+    BgidAllocator, BufferRing, bgid_inflight, bgid_peak_used, pbuf_ring_supported,
+};
 pub use cancel::{CancelOutcome, cancel_all_by_fd, cancel_by_user_data};
 pub use config::{StubIoUringBackend, config_detail, is_io_uring_available, sqpoll_fell_back};
 pub use disk_batch::IoUringDiskBatch;

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -205,12 +205,13 @@ pub use io_uring::{
     RENAME_WHITEOUT, RegisteredBufferGroup, RegisteredBufferSlot, RegisteredBufferStats,
     RegisteredBufferStatus, RenameAt2Args, RingLease, STATX_MIN_KERNEL, SessionPoolConfig,
     SessionRingPool, SharedCompletion, SharedRing, SharedRingConfig, StatxArgs, StatxResult,
-    ThreadLocalRingLease, ThreadLocalRingPool, buffer_id_from_cqe_flags, build_linkat_sqe,
-    build_linkat_sqe_unchecked, build_renameat2_sqe, build_renameat2_sqe_unchecked,
-    build_statx_sqe, build_statx_sqe_unchecked, is_io_uring_available, linkat_supported,
-    pbuf_ring_supported, reader_from_path, reader_from_path_with_depth, renameat2_blocking,
-    renameat2_supported, sqpoll_fell_back, statx_supported, submit_linkat_blocking,
-    submit_statx_batch, submit_statx_blocking, writer_from_file, writer_from_file_with_depth,
+    ThreadLocalRingLease, ThreadLocalRingPool, bgid_inflight, bgid_peak_used,
+    buffer_id_from_cqe_flags, build_linkat_sqe, build_linkat_sqe_unchecked, build_renameat2_sqe,
+    build_renameat2_sqe_unchecked, build_statx_sqe, build_statx_sqe_unchecked,
+    is_io_uring_available, linkat_supported, pbuf_ring_supported, reader_from_path,
+    reader_from_path_with_depth, renameat2_blocking, renameat2_supported, sqpoll_fell_back,
+    statx_supported, submit_linkat_blocking, submit_statx_batch, submit_statx_blocking,
+    writer_from_file, writer_from_file_with_depth,
 };
 
 #[cfg(all(target_os = "windows", feature = "iocp"))]


### PR DESCRIPTION
## Summary

Implements task BGE-3 from the BGID lifecycle audit (`docs/audits/bgid-lifecycle.md`).

- New `PEAK_USED: AtomicU16` tracks the worst-case in-flight occupancy of the 16-bit io_uring buffer-group-ID namespace over the process lifetime. Updated via `fetch_max` after every successful `BgidAllocator::allocate` (free-list reuse and monotonic counter paths both update the peak).
- New public accessors `bgid_peak_used() -> u16` and `bgid_inflight() -> u16` expose the stat for dashboards and capacity-planning tests. Mirrored in the non-Linux `io_uring_stub` so cross-platform callers compile without cfg-gating.
- The bgid free-list is pre-sized to 4 096 entries (`Vec::with_capacity(1 << 12)`) so steady-state daemon churn does not trigger reallocations under the free-list mutex.
- When in-flight occupancy crosses 50 % of the namespace (32 768 ids) a throttled `tracing::warn!` fires at most once per 30 s, gated by `Mutex<Option<Instant>>` so a hot allocate loop cannot flood the log.

## Stat API surface

- `fast_io::bgid_peak_used() -> u16` - monotonic high-water mark since process start.
- `fast_io::bgid_inflight() -> u16` - current allocator-issued ids not yet returned to the free-list (saturates at `u16::MAX`).

Both are re-exported from `fast_io::io_uring::buffer_ring`, `fast_io::io_uring` (or `io_uring_stub`), and the top-level `fast_io` crate.

## Test plan

- [x] `cargo fmt --all` clean.
- [x] `cargo check -p fast_io --all-features` clean.
- [x] New unit tests:
  - `bgid_peak_tracks_100_allocations` - 100 allocations push peak to 100.
  - `bgid_peak_does_not_decrease_on_deallocate` - peak stays at 50 after all 50 ids returned.
  - `bgid_free_list_is_pre_sized` - capacity is at least 4 096.
  - `bgid_inflight_reflects_counter_minus_free_list` - 3 alloc / 2 dealloc leaves 1 in flight.
  - `bgid_warn_threshold_is_half_namespace` - threshold constant equals `BGID_NAMESPACE_SIZE / 2`.
- [x] Existing `BgidStateGuard` extended to snapshot/restore `PEAK_USED` so test isolation is preserved.
- [ ] CI: fmt+clippy, nextest (stable), Windows (stable), macOS (stable), Linux musl (stable).