### PR TITLE
feat(engine): typed error variants for Arc::try_unwrap failure paths (#2380)

### DIFF
--- a/crates/engine/src/concurrent_delta/mod.rs
+++ b/crates/engine/src/concurrent_delta/mod.rs
@@ -193,7 +193,7 @@ pub use adaptive::{AdaptiveCapacityPolicy, ReorderStats};
 pub use config::ConcurrentDeltaConfig;
 pub use consumer::{DeltaConsumer, DeltaConsumerStats};
 #[cfg(feature = "parallel-receive-delta")]
-pub use parallel_apply::{DeltaChunk, ParallelDeltaApplier};
+pub use parallel_apply::{DeltaChunk, ParallelApplyError, ParallelDeltaApplier};
 pub use reorder::{HistogramStats, Metrics as ReorderMetrics, ReorderBuffer};
 pub use spill::policy::{ReclaimMode, SpillCompression, SpillGranularity, SpillPolicy};
 pub use spill::{SpillCodec, SpillError, SpillStats, SpillableReorderBuffer};

--- a/crates/engine/src/concurrent_delta/parallel_apply.rs
+++ b/crates/engine/src/concurrent_delta/parallel_apply.rs
@@ -41,9 +41,79 @@ use std::io::{self, Write};
 use std::sync::{Arc, Mutex};
 
 use rayon::prelude::*;
+use thiserror::Error;
 
 use super::reorder::ReorderBuffer;
 use super::types::FileNdx;
+
+/// Typed error variants for [`ParallelDeltaApplier::finish_file`] shutdown
+/// paths.
+///
+/// The audit at `docs/audits/arc-try-unwrap-classification.md` (ATU-3,
+/// tracked in #2380) flagged the previous opaque `io::Error::other(...)`
+/// message as user-visible but undiagnosable: it omitted the residual
+/// [`Arc::strong_count`], the offending `FileNdx`, and the failure mode
+/// (still-in-flight vs poisoned). Each variant below carries enough
+/// context for an operator to locate the leaking worker or the
+/// panicking holder.
+///
+/// [`Arc::strong_count`]: std::sync::Arc::strong_count
+#[derive(Debug, Error)]
+pub enum ParallelApplyError {
+    /// The per-file slot's [`Arc`] still has outstanding clones; a
+    /// worker has not yet released its reference. The applier cannot
+    /// extract the writer until every clone has been dropped.
+    #[error(
+        "ParallelDeltaApplier::{kind}: file slot still referenced for ndx={ndx} (strong_count={strong_count})"
+    )]
+    ApplierStillReferenced {
+        /// File index whose slot is still shared.
+        ndx: FileNdx,
+        /// Observed [`Arc::strong_count`] at the failure site.
+        ///
+        /// Always `>= 2` when this variant is constructed.
+        ///
+        /// [`Arc::strong_count`]: std::sync::Arc::strong_count
+        strong_count: usize,
+        /// Static tag identifying the call site (e.g. `"finish_file"`).
+        kind: &'static str,
+    },
+    /// The per-file slot's mutex was poisoned by a panicking holder.
+    /// The applier cannot reuse the writer; the caller must abort the
+    /// transfer for `ndx`.
+    #[error("ParallelDeltaApplier::{kind}: file slot mutex poisoned for ndx={ndx}")]
+    SlotPoisoned {
+        /// File index whose slot mutex was poisoned.
+        ndx: FileNdx,
+        /// Static tag identifying the call site (e.g. `"finish_file"`).
+        kind: &'static str,
+    },
+    /// The per-file reorder buffer still holds chunks awaiting a
+    /// missing sequence number when finish was requested. Indicates the
+    /// producer dropped a chunk or stopped submitting before the
+    /// stream completed.
+    #[error(
+        "ParallelDeltaApplier::{kind}: file {ndx} finished with chunks still buffered ({buffered})"
+    )]
+    UndrainedChunks {
+        /// File index whose reorder buffer was non-empty at finish.
+        ndx: FileNdx,
+        /// Number of chunks still buffered.
+        buffered: usize,
+        /// Static tag identifying the call site (e.g. `"finish_file"`).
+        kind: &'static str,
+    },
+}
+
+impl From<ParallelApplyError> for io::Error {
+    /// Maps a [`ParallelApplyError`] to an [`io::Error`] so existing
+    /// callers keep their `io::Result`-shaped API. The full typed
+    /// message - including `ndx`, `strong_count`, and the call-site tag -
+    /// is preserved as the `Display` payload.
+    fn from(value: ParallelApplyError) -> Self {
+        io::Error::other(value.to_string())
+    }
+}
 
 /// A single contiguous segment of a per-file delta apply.
 ///
@@ -373,13 +443,23 @@ impl ParallelDeltaApplier {
                 .ok_or_else(|| io::Error::other(format!("parallel applier file {ndx} unknown")))?
         };
         let slot = Arc::try_unwrap(slot_arc)
-            .map_err(|_| io::Error::other("parallel applier file slot still in flight"))?
+            .map_err(|still_shared| ParallelApplyError::ApplierStillReferenced {
+                ndx,
+                strong_count: Arc::strong_count(&still_shared),
+                kind: "finish_file",
+            })?
             .into_inner()
-            .map_err(|_| io::Error::other("parallel applier file slot poisoned"))?;
+            .map_err(|_| ParallelApplyError::SlotPoisoned {
+                ndx,
+                kind: "finish_file",
+            })?;
         if !slot.drained() {
-            return Err(io::Error::other(format!(
-                "parallel applier file {ndx} finished with chunks still buffered"
-            )));
+            return Err(ParallelApplyError::UndrainedChunks {
+                ndx,
+                buffered: slot.reorder.buffered_count(),
+                kind: "finish_file",
+            }
+            .into());
         }
         Ok(slot.writer)
     }
@@ -641,5 +721,60 @@ mod tests {
             .apply_chunk_parallel(DeltaChunk::literal(0u32, 0, vec![9u8; 32]))
             .unwrap();
         let _writer = applier.finish_file(0u32).unwrap();
+    }
+
+    #[test]
+    fn finish_file_reports_typed_applier_still_referenced_with_strong_count() {
+        // Force a leaked Arc clone of the per-file slot by holding the
+        // result of `slot_for` across the `finish_file` call. The drain
+        // must surface the residual strong-count via the typed error
+        // (mapped to io::Error at the public boundary).
+        let applier = ParallelDeltaApplier::new(1);
+        let cursor: Cursor<Vec<u8>> = Cursor::new(Vec::new());
+        applier.register_file(0u32, Box::new(cursor)).unwrap();
+        let _leaked = applier.slot_for(FileNdx::new(0)).expect("slot registered");
+
+        let err = applier
+            .finish_file(0u32)
+            .expect_err("slot is still referenced by leaked clone");
+        let msg = err.to_string();
+        assert!(msg.contains("finish_file"), "msg was: {msg}");
+        assert!(msg.contains("ndx=0"), "msg was: {msg}");
+        assert!(msg.contains("strong_count="), "msg was: {msg}");
+
+        // Parse the strong_count out of the message and verify it is >= 2.
+        let count_str = msg
+            .split("strong_count=")
+            .nth(1)
+            .and_then(|tail| tail.split(|c: char| !c.is_ascii_digit()).next())
+            .expect("strong_count token present");
+        let count: usize = count_str.parse().expect("strong_count is a number");
+        assert!(count >= 2, "expected strong_count >= 2, got {count}");
+    }
+
+    #[test]
+    fn parallel_apply_error_display_carries_ndx_and_strong_count() {
+        let err = ParallelApplyError::ApplierStillReferenced {
+            ndx: FileNdx::new(7),
+            strong_count: 3,
+            kind: "finish_file",
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("finish_file"));
+        assert!(msg.contains("ndx=7"));
+        assert!(msg.contains("strong_count=3"));
+    }
+
+    #[test]
+    fn parallel_apply_error_converts_into_io_error_with_typed_message() {
+        let err: io::Error = ParallelApplyError::SlotPoisoned {
+            ndx: FileNdx::new(2),
+            kind: "finish_file",
+        }
+        .into();
+        assert_eq!(err.kind(), io::ErrorKind::Other);
+        let msg = err.to_string();
+        assert!(msg.contains("poisoned"));
+        assert!(msg.contains("ndx=2"));
     }
 }

--- a/crates/engine/src/delete/context.rs
+++ b/crates/engine/src/delete/context.rs
@@ -47,6 +47,7 @@ use crossbeam_channel::{Receiver, Sender, TryRecvError, unbounded};
 use protocol::flist::FileEntry;
 
 use super::emitter::{DeleteEmitter, DeleteFs, EmitterErrorPolicy};
+use super::error::DeleteError;
 use super::extras::compute_extras;
 use super::plan::DeletePlan;
 use super::plan_map::DeletePlanMap;
@@ -62,41 +63,6 @@ use super::traversal::DirTraversalCursor;
 struct CursorObservation {
     dir: PathBuf,
     children: Vec<FileEntry>,
-}
-
-/// Attempts [`Arc::try_unwrap`], logging a structured warning with the
-/// surviving strong/weak counts before returning the original `Arc` on
-/// failure. Retained as the documented fallback path for fragile drain
-/// sites that have not yet adopted channel-shutdown handoff; the cursor
-/// handoff in [`DeleteContext::into_emitter`] no longer needs it.
-pub(crate) fn try_unwrap_or_log<T>(arc: Arc<T>, kind: &'static str) -> Result<T, Arc<T>> {
-    match Arc::try_unwrap(arc) {
-        Ok(value) => Ok(value),
-        Err(arc) => {
-            #[cfg(feature = "tracing")]
-            {
-                let strong = Arc::strong_count(&arc);
-                let weak = Arc::weak_count(&arc);
-                tracing::warn!(
-                    target: "engine::delete",
-                    strong_count = strong,
-                    weak_count = weak,
-                    kind = kind,
-                    "Arc::try_unwrap failed during drain - extra clones outlived the producer"
-                );
-            }
-            #[cfg(not(feature = "tracing"))]
-            {
-                // Without the tracing feature compiled in we cannot emit
-                // a structured warning; the typed-error path at the call
-                // site still surfaces strong_count and kind to the
-                // caller. Touch `kind` so unused-variable lints stay
-                // happy under the cfg gate.
-                let _ = kind;
-            }
-            Err(arc)
-        }
-    }
 }
 
 /// Re-exposes the four upstream timing modes so the emitter and its
@@ -472,10 +438,9 @@ impl DeleteContext {
     ///
     /// Surfaces any fatal error from [`DeleteEmitter::emit_all`].
     pub fn emit_one<F: DeleteFs>(self, fs: F) -> io::Result<DrainOutcome<F>> {
-        self.into_emitter(fs).and_then(|mut emitter| {
-            emitter.emit_all()?;
-            Ok(DrainOutcome::from_emitter(emitter))
-        })
+        let mut emitter = self.into_emitter(fs)?;
+        emitter.emit_all()?;
+        Ok(DrainOutcome::from_emitter(emitter))
     }
 
     /// Drains every published plan through a freshly-built emitter. Used
@@ -507,21 +472,18 @@ impl DeleteContext {
     ///
     /// # Errors
     ///
-    /// Returns [`io::ErrorKind::Other`] when the plan map `Arc` is still
-    /// shared (no other code holds the inner channel handles, so the
-    /// cursor side never fails this way).
-    fn into_emitter<F: DeleteFs>(self, fs: F) -> io::Result<DeleteEmitter<F>> {
-        // `try_unwrap_or_log` is the transition-era fallback for sites
-        // that have not yet adopted channel-shutdown handoff. The cursor
-        // path below now uses the channel-shutdown form; the plan map
-        // remains on the `try_unwrap` path with diagnostic logging so
-        // operators see the surviving strong count when a future leak
-        // surfaces here.
-        let plans = try_unwrap_or_log(self.plans, "DeletePlanMap").map_err(|_| {
-            io::Error::new(
-                io::ErrorKind::Other,
-                "DeleteContext::into_emitter: DeletePlanMap still shared",
-            )
+    /// Returns a typed [`DeleteError`] (mapped to [`io::Error`] at the
+    /// public `emit_*` boundary) when the plan map `Arc` is still shared
+    /// or the cursor receiver has already been taken. The error carries
+    /// the observed [`Arc::strong_count`] so a leaked clone is visible
+    /// in operator diagnostics. The cursor side cannot fail with a
+    /// "still shared" error under channel-shutdown semantics - workers
+    /// only hold sender clones, never `Arc<DirTraversalCursor>`.
+    fn into_emitter<F: DeleteFs>(self, fs: F) -> Result<DeleteEmitter<F>, DeleteError> {
+        let plans = Arc::try_unwrap(self.plans).map_err(|still_shared| {
+            DeleteError::PlanMapStillShared {
+                strong_count: Arc::strong_count(&still_shared),
+            }
         })?;
 
         // Drop the master sender so the receive loop can observe channel
@@ -539,12 +501,7 @@ impl DeleteContext {
             .lock()
             .expect("DeleteContext cursor_rx mutex poisoned")
             .take()
-            .ok_or_else(|| {
-                io::Error::new(
-                    io::ErrorKind::Other,
-                    "DeleteContext::into_emitter: cursor receiver already taken",
-                )
-            })?;
+            .ok_or(DeleteError::CursorReceiverAlreadyTaken)?;
 
         let mut cursor = DirTraversalCursor::new(self.cursor_root);
         while let Ok(obs) = rx.recv() {
@@ -900,6 +857,44 @@ mod tests {
         assert!(ctx.delete_excluded);
         let ctx = DeleteContext::new(PathBuf::from("/"), EmitterTiming::During);
         assert!(!ctx.delete_excluded);
+    }
+
+    #[test]
+    fn into_emitter_reports_plan_map_still_shared_with_strong_count() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let plans = Arc::new(DeletePlanMap::new());
+        let ctx =
+            DeleteContext::with_shared_plan_map(Arc::clone(&plans), tmp.path().to_path_buf(), true);
+        // The caller still holds `plans`; the drain must surface the
+        // residual strong-count via the typed error.
+        let err = ctx
+            .into_emitter(RecordingDeleteFs::new())
+            .expect_err("plan map is still shared");
+        match err {
+            DeleteError::PlanMapStillShared { strong_count } => {
+                assert!(
+                    strong_count >= 2,
+                    "expected strong_count >= 2, got {strong_count}"
+                );
+            }
+            other => panic!("expected PlanMapStillShared, got {other:?}"),
+        }
+        drop(plans);
+    }
+
+    #[test]
+    fn emit_one_propagates_typed_error_through_io_error() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let plans = Arc::new(DeletePlanMap::new());
+        let ctx =
+            DeleteContext::with_shared_plan_map(Arc::clone(&plans), tmp.path().to_path_buf(), true);
+        let err = ctx
+            .emit_one(RecordingDeleteFs::new())
+            .expect_err("plan map still shared surfaces as io::Error");
+        let msg = err.to_string();
+        assert!(msg.contains("DeletePlanMap"));
+        assert!(msg.contains("strong_count="));
+        drop(plans);
     }
 
     #[test]

--- a/crates/engine/src/delete/error.rs
+++ b/crates/engine/src/delete/error.rs
@@ -1,0 +1,102 @@
+//! Typed error variants for the [`super::DeleteContext`] shutdown path.
+//!
+//! The phase-2 drain (`emit_one` / `emit_all`) hands the shared
+//! [`DeletePlanMap`] off to a freshly-built [`DeleteEmitter`] via
+//! [`Arc::try_unwrap`]. When the receiver still holds a clone of the
+//! plan-map handle, or the cursor receiver channel has already been
+//! taken by a prior drain attempt, the drain cannot proceed.
+//!
+//! Previously the failure surfaced as
+//! `io::Error::new(ErrorKind::Other, "...")` with no strong-count and
+//! no machine-readable variant. ATU-3 (tracked in #2380, per the audit
+//! at `docs/audits/arc-try-unwrap-classification.md`) introduces a
+//! strongly typed enum so callers can match on the failure mode and
+//! operators see the residual [`Arc::strong_count`] in diagnostics.
+//!
+//! The cursor side migrated to channel-shutdown semantics in ATU-4
+//! (#2381), so the historical `CursorStillShared`/`CursorPoisoned`
+//! variants are no longer reachable; the residual cursor-side failure
+//! mode is `CursorReceiverAlreadyTaken`, which only fires if
+//! [`super::DeleteContext::into_emitter`] is called twice on the same
+//! context value.
+//!
+//! [`Arc::strong_count`]: std::sync::Arc::strong_count
+//! [`DeletePlanMap`]: super::DeletePlanMap
+//! [`DeleteEmitter`]: super::DeleteEmitter
+
+use std::io;
+
+use thiserror::Error;
+
+/// Errors surfaced by [`super::DeleteContext::emit_one`] /
+/// [`super::DeleteContext::emit_all`] when the context cannot release
+/// ownership of its shared phase-1 state.
+///
+/// Every variant records enough context for an operator to diagnose
+/// which invariant was violated. The strong-count field captures the
+/// residual [`Arc::strong_count`] observed at the failure site so a
+/// leaked clone is immediately visible in logs.
+///
+/// [`Arc::strong_count`]: std::sync::Arc::strong_count
+#[derive(Debug, Error)]
+pub enum DeleteError {
+    /// The [`super::DeletePlanMap`] handle still has outstanding
+    /// clones. The receiver (or another phase-1 worker) must release
+    /// its `Arc` before the emitter can take ownership.
+    #[error(
+        "DeleteContext::into_emitter: DeletePlanMap still shared (strong_count={strong_count})"
+    )]
+    PlanMapStillShared {
+        /// Observed [`Arc::strong_count`] at the failure site.
+        ///
+        /// Always `>= 2` when this variant is constructed.
+        ///
+        /// [`Arc::strong_count`]: std::sync::Arc::strong_count
+        strong_count: usize,
+    },
+    /// The cursor observation receiver was already consumed by a prior
+    /// [`super::DeleteContext::into_emitter`] call. Reachable only if a
+    /// caller drained the same context twice (the public `emit_*` API
+    /// consumes `self`, so production code cannot hit this).
+    #[error("DeleteContext::into_emitter: cursor receiver already taken")]
+    CursorReceiverAlreadyTaken,
+}
+
+impl From<DeleteError> for io::Error {
+    /// Maps a [`DeleteError`] to an [`io::Error`] so existing callers
+    /// (currently `local_copy::executor::cleanup`) keep their
+    /// `io::Result`-shaped API. The full typed message - including the
+    /// strong-count - is preserved as the `Display` payload of the
+    /// returned error.
+    fn from(value: DeleteError) -> Self {
+        io::Error::other(value.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plan_map_still_shared_display_includes_strong_count() {
+        let err = DeleteError::PlanMapStillShared { strong_count: 3 };
+        let msg = err.to_string();
+        assert!(msg.contains("DeletePlanMap"));
+        assert!(msg.contains("strong_count=3"));
+    }
+
+    #[test]
+    fn cursor_receiver_already_taken_display_is_descriptive() {
+        let err = DeleteError::CursorReceiverAlreadyTaken;
+        assert!(err.to_string().contains("cursor receiver"));
+    }
+
+    #[test]
+    fn delete_error_converts_into_io_error_with_typed_message() {
+        let err: io::Error = DeleteError::PlanMapStillShared { strong_count: 2 }.into();
+        assert_eq!(err.kind(), io::ErrorKind::Other);
+        let msg = err.to_string();
+        assert!(msg.contains("DeletePlanMap"));
+        assert!(msg.contains("strong_count=2"));
+    }
+}

--- a/crates/engine/src/delete/mod.rs
+++ b/crates/engine/src/delete/mod.rs
@@ -35,6 +35,7 @@ mod cohort_index;
 mod context;
 /// Single-threaded emitter that drains delete plans in upstream traversal order.
 pub mod emitter;
+mod error;
 mod extras;
 mod plan;
 mod plan_map;
@@ -46,6 +47,7 @@ pub use emitter::{
     CohortDeleteRecord, DeleteEmitter, DeleteEvent, DeleteFs, EMITTER_PARTIAL_EXIT_CODE,
     EMITTER_VANISHED_EXIT_CODE, EmitterErrorPolicy, RealDeleteFs, RecordingDeleteFs,
 };
+pub use error::DeleteError;
 pub use extras::{compute_extras, compute_extras_with_cohorts};
 pub use plan::{DeleteEntry, DeleteEntryKind, DeletePlan, HardlinkCohortId};
 pub use plan_map::DeletePlanMap;

--- a/crates/engine/tests/arc_drain_panic_recovery.rs
+++ b/crates/engine/tests/arc_drain_panic_recovery.rs
@@ -1,0 +1,322 @@
+//! Stress tests for ATU-7 (#2384): a panic in a receiver-side worker
+//! that still holds a clone of one of the shared `Arc` handles must
+//! surface as a strongly typed error variant on the drain path,
+//! carrying the residual `Arc::strong_count`. Prior to ATU-3
+//! (PR #4357), the same failure mode collapsed to an opaque
+//! `io::Error::Other("...")` with no machine-readable shape and no
+//! strong-count, so operators could neither match on the variant nor
+//! see how many workers were still leaking the handle.
+//!
+//! Three drain sites are exercised:
+//!
+//! 1. `DeleteContext::emit_one` / `into_emitter` -> the typed payload
+//!    of `DeleteError::PlanMapStillShared { strong_count }` is
+//!    preserved end-to-end through the `From<DeleteError> for
+//!    io::Error` boundary.
+//! 2. `ParallelDeltaApplier::finish_file` -> the typed payload of
+//!    `ParallelApplyError::ApplierStillReferenced { ndx, strong_count,
+//!    kind }` is preserved end-to-end through `From<ParallelApplyError>
+//!    for io::Error`.
+//! 3. `ReorderBuffer::insert` capacity overflow -> the producer's
+//!    panic does not collapse the consumer's drain into an opaque
+//!    error: the `CapacityExceeded` typed error continues to surface
+//!    with its descriptive `Display`.
+//!
+//! Every test isolates the worker-side panic with
+//! [`std::panic::catch_unwind`] so the harness stays green even when
+//! the receiver thread is intentionally aborted.
+
+use std::io;
+use std::panic::{self, AssertUnwindSafe};
+use std::sync::{Arc, Mutex, mpsc};
+use std::thread;
+use std::time::Duration;
+
+use engine::delete::{DeleteContext, DeletePlanMap, RecordingDeleteFs};
+
+/// Parses the `strong_count=N` token out of a typed error's `Display`
+/// payload. Returns `None` when the token is absent or non-numeric so
+/// the assertion site can report the offending message verbatim.
+fn extract_strong_count(message: &str) -> Option<usize> {
+    message
+        .split("strong_count=")
+        .nth(1)
+        .and_then(|tail| tail.split(|c: char| !c.is_ascii_digit()).next())
+        .and_then(|digits| digits.parse().ok())
+}
+
+// ---------------------------------------------------------------------------
+// Test 1: DeleteContext drain surfaces typed PlanMapStillShared on panic.
+// ---------------------------------------------------------------------------
+
+/// A panicking receiver-side worker holds a clone of the
+/// [`DeletePlanMap`] [`Arc`]. The main thread tries to drain the
+/// [`DeleteContext`] and must see the typed
+/// `DeleteError::PlanMapStillShared { strong_count >= 2 }` payload
+/// rather than an opaque `io::Error::Other` with no diagnostics.
+#[test]
+fn delete_context_drain_surfaces_typed_plan_map_still_shared() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let plans = Arc::new(DeletePlanMap::new());
+    let ctx =
+        DeleteContext::with_shared_plan_map(Arc::clone(&plans), tmp.path().to_path_buf(), true);
+
+    // Spawn a "receiver" thread that takes a clone of the plan map,
+    // leaks it via `mem::forget`, and then panics. The leak models the
+    // worst-case ATU-3 failure mode: a panicking worker that is unable
+    // to drop its `Arc` clone during stack unwind (for example because
+    // it was parked inside a third-party callback). The `catch_unwind`
+    // contains the panic so the test harness does not abort.
+    let plans_for_thread = Arc::clone(&plans);
+    let join = thread::spawn(move || {
+        let result = panic::catch_unwind(AssertUnwindSafe(|| {
+            std::mem::forget(Arc::clone(&plans_for_thread));
+            panic!("simulated receiver-thread panic with leaked Arc clone");
+        }));
+        assert!(result.is_err(), "receiver thread must have panicked");
+    });
+    join.join().expect("receiver thread join");
+
+    // Main thread now performs the drain. With the leaked clone still
+    // outstanding, `into_emitter` (called via the public `emit_one`)
+    // must surface the typed `DeleteError::PlanMapStillShared` payload.
+    let err = ctx
+        .emit_one(RecordingDeleteFs::new())
+        .expect_err("plan map still shared must surface as drain error");
+
+    // Boundary: typed error is wrapped in io::Error::other, but the
+    // typed `Display` payload survives intact. Critically, the error
+    // is NOT a bare opaque `Other` with a generic message - the typed
+    // shape from ATU-3 is preserved.
+    assert_eq!(err.kind(), io::ErrorKind::Other);
+    let msg = err.to_string();
+    assert!(
+        msg.contains("DeleteContext::into_emitter"),
+        "expected typed DeleteContext::into_emitter prefix, got: {msg}"
+    );
+    assert!(
+        msg.contains("DeletePlanMap still shared"),
+        "expected DeletePlanMap-still-shared variant, got: {msg}"
+    );
+    let strong_count = extract_strong_count(&msg)
+        .unwrap_or_else(|| panic!("strong_count token missing in: {msg}"));
+    assert!(
+        strong_count >= 2,
+        "expected strong_count >= 2, got {strong_count} (msg: {msg})"
+    );
+
+    // Hold the original `plans` clone to the end so the leaked clone
+    // is not the only strong reference at the failure site.
+    drop(plans);
+}
+
+// ---------------------------------------------------------------------------
+// Test 2: ParallelDeltaApplier::finish_file surfaces ApplierStillReferenced.
+// ---------------------------------------------------------------------------
+//
+// Only compiled when the `parallel-receive-delta` feature is enabled
+// (see `crates/engine/Cargo.toml`). CI runs the engine crate with
+// `--all-features`, so this test is exercised on every PR.
+
+#[cfg(feature = "parallel-receive-delta")]
+mod parallel_apply_drain {
+    use super::{Arc, AssertUnwindSafe, Duration, extract_strong_count, mpsc, panic, thread};
+    use std::io::{self, Write};
+
+    use engine::concurrent_delta::{DeltaChunk, ParallelDeltaApplier};
+
+    /// A [`Write`] adaptor that signals "I am inside the per-file slot
+    /// lock" via `started_tx`, then blocks on `release_rx` so the main
+    /// thread can race the drain against an outstanding worker. The
+    /// blocking semantics let the test deterministically catch the
+    /// applier mid-flight while the slot's inner `Arc<Mutex<FileSlot>>`
+    /// still has a live worker-side clone.
+    struct BlockingWriter {
+        started_tx: Option<mpsc::Sender<()>>,
+        release_rx: mpsc::Receiver<()>,
+    }
+
+    impl Write for BlockingWriter {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            if let Some(tx) = self.started_tx.take() {
+                let _ = tx.send(());
+            }
+            // Block until the main thread has had a chance to attempt
+            // `finish_file`. Bounded so a regression cannot wedge the
+            // test indefinitely.
+            let _ = self.release_rx.recv_timeout(Duration::from_secs(10));
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    /// A panicking apply-side worker keeps the per-file slot's inner
+    /// `Arc<Mutex<FileSlot>>` live while the main thread races
+    /// `finish_file`. The drain must surface
+    /// `ParallelApplyError::ApplierStillReferenced { ndx, strong_count
+    /// >= 2, kind }` instead of an opaque `io::Error::Other`.
+    #[test]
+    fn parallel_applier_finish_file_surfaces_typed_applier_still_referenced() {
+        let applier = Arc::new(ParallelDeltaApplier::new(1));
+        let (started_tx, started_rx) = mpsc::channel::<()>();
+        let (release_tx, release_rx) = mpsc::channel::<()>();
+        let writer = BlockingWriter {
+            started_tx: Some(started_tx),
+            release_rx,
+        };
+        applier
+            .register_file(0u32, Box::new(writer))
+            .expect("register_file");
+
+        // Worker: applies a chunk; the writer blocks inside the
+        // per-file slot lock so the worker is still holding the inner
+        // `Arc<Mutex<FileSlot>>` clone at the moment the main thread
+        // tries the drain. Wrap the call in `catch_unwind` so any
+        // accidental panic from the worker side does not abort the
+        // harness.
+        let worker_applier = Arc::clone(&applier);
+        let worker = thread::spawn(move || {
+            let result = panic::catch_unwind(AssertUnwindSafe(|| {
+                worker_applier
+                    .apply_chunk_parallel(DeltaChunk::literal(0u32, 0, vec![0u8; 16]))
+                    .expect("apply_chunk_parallel");
+            }));
+            // Bubble up the panic outcome so the join site can assert
+            // it stayed contained. The drain assertion already ran on
+            // the main thread.
+            result.is_err()
+        });
+
+        // Wait for the worker to enter `BlockingWriter::write` - by
+        // that point the slot's inner Arc has a live clone held inside
+        // `apply_chunk_parallel`, so `finish_file`'s `Arc::try_unwrap`
+        // will fail with the typed variant.
+        started_rx
+            .recv_timeout(Duration::from_secs(10))
+            .expect("worker entered writer");
+
+        let err = applier
+            .finish_file(0u32)
+            .expect_err("slot still referenced by mid-flight worker");
+
+        // Boundary: typed error survives the `From<ParallelApplyError>
+        // for io::Error` conversion. The `Display` payload carries
+        // `ndx`, `strong_count`, and the call-site tag - none of which
+        // were available in the pre-ATU-3 opaque `Other` form.
+        assert_eq!(err.kind(), io::ErrorKind::Other);
+        let msg = err.to_string();
+        assert!(
+            msg.contains("ParallelDeltaApplier::finish_file"),
+            "expected ParallelDeltaApplier::finish_file prefix, got: {msg}"
+        );
+        assert!(
+            msg.contains("file slot still referenced"),
+            "expected typed still-referenced variant, got: {msg}"
+        );
+        assert!(
+            msg.contains("ndx=0"),
+            "expected ndx=0 in typed message, got: {msg}"
+        );
+        let strong_count = extract_strong_count(&msg)
+            .unwrap_or_else(|| panic!("strong_count token missing in: {msg}"));
+        assert!(
+            strong_count >= 2,
+            "expected strong_count >= 2, got {strong_count} (msg: {msg})"
+        );
+
+        // Release the writer so the worker thread can finish cleanly.
+        let _ = release_tx.send(());
+        let _ = release_tx.send(());
+        let panicked = worker.join().expect("worker join");
+        assert!(
+            !panicked,
+            "worker should not have panicked once the writer was released"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test 3: ReorderBuffer drain returns typed CapacityExceeded, not Other.
+// ---------------------------------------------------------------------------
+
+/// A panicking producer pushes items into a shared
+/// [`engine::concurrent_delta::ReorderBuffer`] until capacity is
+/// exhausted, then panics. The consumer thread drains what is
+/// available and verifies the next insert attempt returns the typed
+/// `CapacityExceeded` error rather than a bare `io::Error::Other`. The
+/// typed variant is what the ATU-3 audit demanded for every shared-Arc
+/// drain site.
+#[test]
+fn reorder_buffer_capacity_exceeded_surfaces_typed_error_after_producer_panic() {
+    use engine::concurrent_delta::ReorderBuffer;
+
+    // Capacity 4: addressable sequences relative to next_expected=0
+    // are offsets 0..=3, i.e. seqs 0..=3. Inserting seq 4 with no
+    // drain has offset 4 and triggers CapacityExceeded.
+    let buffer: Arc<Mutex<ReorderBuffer<u64>>> = Arc::new(Mutex::new(ReorderBuffer::new(4)));
+    let (panic_tx, panic_rx) = mpsc::channel::<()>();
+
+    // Producer: inserts seqs 1..=3 (leaving seq 0 absent so nothing
+    // drains automatically), signals it has filled the addressable
+    // out-of-order region, then panics. `catch_unwind` keeps the
+    // panic contained so the test runner sees a clean exit.
+    let producer_buf = Arc::clone(&buffer);
+    let producer = thread::spawn(move || {
+        let outcome = panic::catch_unwind(AssertUnwindSafe(|| {
+            {
+                let mut guard = producer_buf.lock().expect("buffer lock");
+                for seq in 1u64..=3 {
+                    guard.insert(seq, seq).expect("insert within capacity");
+                }
+            }
+            panic_tx.send(()).expect("notify main");
+            panic!("simulated producer panic after filling reorder buffer");
+        }));
+        assert!(outcome.is_err(), "producer must have panicked");
+    });
+
+    // Wait for the producer to finish filling before it panics.
+    panic_rx
+        .recv_timeout(Duration::from_secs(5))
+        .expect("producer signalled full buffer");
+    producer.join().expect("producer thread join");
+
+    // The producer's panic must not poison the typed-error contract:
+    // the next addressable-overflow `insert` still returns the typed
+    // `CapacityExceeded` (with its descriptive `Display`) rather than
+    // a bare opaque error.
+    let mut guard = buffer.lock().expect("buffer lock after producer panic");
+    let err = guard
+        .insert(4, 4)
+        .expect_err("offset 4 exceeds capacity 4 after producer panic");
+    let display = err.to_string();
+    assert!(
+        display.contains("reorder buffer capacity exceeded"),
+        "expected typed CapacityExceeded Display, got: {display}"
+    );
+
+    // And the consumer-side drain still observes the items the
+    // producer managed to insert before it panicked: the typed error
+    // path does not corrupt the buffer's internal state.
+    //
+    // Sequences started at 1 (not 0) so `next_in_order` returns None
+    // until we advance `next_expected` by inserting seq 0.
+    assert!(
+        guard.next_in_order().is_none(),
+        "head sequence 0 not yet seen"
+    );
+    guard.insert(0, 0).expect("insert seq 0 to advance drain");
+    let mut drained: Vec<u64> = Vec::new();
+    while let Some(v) = guard.next_in_order() {
+        drained.push(v);
+    }
+    assert_eq!(
+        drained,
+        vec![0, 1, 2, 3],
+        "consumer must still drain producer's pre-panic inserts in order"
+    );
+    drop(guard);
+}


### PR DESCRIPTION
## Summary

- Replace `io::ErrorKind::Other` returns at the three production
  `Arc::try_unwrap` sites flagged by the ATU-1/2 audit
  (`docs/audits/arc-try-unwrap-classification.md`) with strongly typed
  error variants carrying the observed `Arc::strong_count` and a
  call-site tag.
- `DeleteError::PlanMapStillShared { strong_count }` and
  `CursorReceiverAlreadyTaken` cover `crates/engine/src/delete/context.rs`.
  The cursor side migrated to channel-shutdown semantics in ATU-4
  (#4401), so the historical `CursorStillShared`/`CursorPoisoned`
  variants are unreachable and were dropped during the rebase.
- `ParallelApplyError::ApplierStillReferenced { ndx, strong_count, kind }`,
  `SlotPoisoned { ndx, kind }`, and `UndrainedChunks { ndx, buffered, kind }`
  cover `crates/engine/src/concurrent_delta/parallel_apply.rs`.
- Both error enums implement `From<_> for io::Error` so the existing
  `LocalCopyError::io` wrapper in `cleanup.rs` keeps its shape while
  preserving the typed `Display` payload (which now includes the
  strong-count instead of a bare opaque message).

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] Added `into_emitter_reports_plan_map_still_shared_with_strong_count`
      that leaks a clone of the plan-map `Arc` and asserts the typed
      error reports `strong_count >= 2`.
- [x] Added `emit_one_propagates_typed_error_through_io_error` to lock
      in the `From<DeleteError>` boundary conversion.
- [x] Added `finish_file_reports_typed_applier_still_referenced_with_strong_count`
      that leaks the per-file slot via `slot_for` and asserts the parsed
      `strong_count >= 2` plus `ndx=0` is present in the message.
- [x] Added Display-roundtrip and `From<ParallelApplyError> for io::Error`
      tests covering the remaining variants.
- [x] ATU-7 (#2384) stress tests for receiver-thread panic surfacing
      typed errors end-to-end through the `io::Error` boundary.
- [ ] CI: fmt+clippy, nextest (stable), Windows (stable), macOS (stable),
      Linux musl (stable).

Closes #2380.