### PR TITLE
feat(fast_io): IOCP concurrent_ops auto-size based on CPU count (#2302)

### DIFF
--- a/crates/fast_io/src/iocp/config.rs
+++ b/crates/fast_io/src/iocp/config.rs
@@ -22,11 +22,56 @@ static SKIP_EVENT_AVAILABLE: AtomicBool = AtomicBool::new(false);
 /// setup overhead exceeds the async benefit for tiny files.
 pub const IOCP_MIN_FILE_SIZE: u64 = 64 * 1024;
 
-/// Default number of concurrent I/O operations per completion port.
-pub const DEFAULT_CONCURRENT_OPS: u32 = 4;
+/// Lower bound for the auto-sized concurrent-ops depth.
+///
+/// Even on a single-CPU host we keep at least 8 overlapped `WriteFile`
+/// operations in flight so the IOCP drain loop is never starved by a
+/// pathological 1-deep submission window. Matches `IoUringConfig::default`
+/// behaviour where the SQ depth never falls below the default ring entries.
+pub const MIN_CONCURRENT_OPS: u32 = 8;
+
+/// Upper bound for the auto-sized concurrent-ops depth.
+///
+/// 64 matches the io_uring CQE batch sizing in
+/// `crates/fast_io/src/iocp/disk_batch.rs::COMPLETION_DRAIN_BATCH` and the
+/// initial drain size in `crates/fast_io/src/iocp/pump.rs::DEFAULT_BATCH_SIZE`.
+/// Keeping the submission window aligned with the drain batch lets a single
+/// `GetQueuedCompletionStatusEx` reap an entire in-flight cohort.
+pub const MAX_CONCURRENT_OPS: u32 = 64;
 
 /// Default I/O buffer size for IOCP operations.
 pub const DEFAULT_BUFFER_SIZE: usize = 64 * 1024;
+
+/// Auto-sizes the concurrent-ops depth from `cpus`.
+///
+/// Returns `(cpus * 4).clamp(MIN_CONCURRENT_OPS, MAX_CONCURRENT_OPS)`.
+/// Mirrors the io_uring SQ-entry derivation: 4 in-flight ops per logical
+/// core keeps every CPU fed without overwhelming the completion drain.
+#[must_use]
+pub const fn concurrent_ops_for_cpus(cpus: u32) -> u32 {
+    let raw = cpus.saturating_mul(4);
+    if raw < MIN_CONCURRENT_OPS {
+        MIN_CONCURRENT_OPS
+    } else if raw > MAX_CONCURRENT_OPS {
+        MAX_CONCURRENT_OPS
+    } else {
+        raw
+    }
+}
+
+/// Auto-sized default concurrent I/O operations per completion port.
+///
+/// Derives the value from `std::thread::available_parallelism()` so the
+/// in-flight depth scales with the host's logical CPU count. Falls back to
+/// `MIN_CONCURRENT_OPS` when parallelism detection fails.
+#[must_use]
+pub fn default_concurrent_ops() -> u32 {
+    let cpus = std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(1);
+    let cpus_u32 = u32::try_from(cpus).unwrap_or(u32::MAX);
+    concurrent_ops_for_cpus(cpus_u32)
+}
 
 /// Configuration for IOCP instances.
 #[derive(Debug, Clone)]
@@ -51,7 +96,7 @@ pub struct IocpConfig {
 impl Default for IocpConfig {
     fn default() -> Self {
         Self {
-            concurrent_ops: DEFAULT_CONCURRENT_OPS,
+            concurrent_ops: default_concurrent_ops(),
             buffer_size: DEFAULT_BUFFER_SIZE,
             unbuffered: false,
             write_through: false,
@@ -61,10 +106,14 @@ impl Default for IocpConfig {
 
 impl IocpConfig {
     /// Creates a config optimized for large file transfers.
+    ///
+    /// The concurrent-ops depth uses the CPU-derived default so wide hosts
+    /// can keep more overlapped writes in flight, matching the io_uring
+    /// large-file preset's larger SQ depth.
     #[must_use]
     pub fn for_large_files() -> Self {
         Self {
-            concurrent_ops: 8,
+            concurrent_ops: default_concurrent_ops(),
             buffer_size: 256 * 1024,
             unbuffered: false,
             write_through: false,
@@ -72,10 +121,14 @@ impl IocpConfig {
     }
 
     /// Creates a config optimized for many small files.
+    ///
+    /// The concurrent-ops depth uses the CPU-derived default; small-file
+    /// pipelines are typically syscall-bound so feeding every CPU pays off
+    /// more than a shallow fixed window.
     #[must_use]
     pub fn for_small_files() -> Self {
         Self {
-            concurrent_ops: 4,
+            concurrent_ops: default_concurrent_ops(),
             buffer_size: 16 * 1024,
             unbuffered: false,
             write_through: false,
@@ -161,7 +214,14 @@ mod tests {
     #[test]
     fn config_default_values() {
         let config = IocpConfig::default();
-        assert_eq!(config.concurrent_ops, DEFAULT_CONCURRENT_OPS);
+        assert!(
+            (MIN_CONCURRENT_OPS..=MAX_CONCURRENT_OPS).contains(&config.concurrent_ops),
+            "default concurrent_ops {} must sit inside [{}, {}]",
+            config.concurrent_ops,
+            MIN_CONCURRENT_OPS,
+            MAX_CONCURRENT_OPS,
+        );
+        assert_eq!(config.concurrent_ops, default_concurrent_ops());
         assert_eq!(config.buffer_size, DEFAULT_BUFFER_SIZE);
         assert!(!config.unbuffered);
         assert!(!config.write_through);
@@ -170,15 +230,51 @@ mod tests {
     #[test]
     fn config_large_files_preset() {
         let config = IocpConfig::for_large_files();
-        assert_eq!(config.concurrent_ops, 8);
+        assert_eq!(config.concurrent_ops, default_concurrent_ops());
         assert_eq!(config.buffer_size, 256 * 1024);
     }
 
     #[test]
     fn config_small_files_preset() {
         let config = IocpConfig::for_small_files();
-        assert_eq!(config.concurrent_ops, 4);
+        assert_eq!(config.concurrent_ops, default_concurrent_ops());
         assert_eq!(config.buffer_size, 16 * 1024);
+    }
+
+    #[test]
+    fn concurrent_ops_eight_cpu_host_yields_thirty_two() {
+        // 8 logical CPUs * 4 in-flight ops per core = 32, inside the clamp.
+        assert_eq!(concurrent_ops_for_cpus(8), 32);
+    }
+
+    #[test]
+    fn concurrent_ops_one_cpu_host_clamps_to_minimum() {
+        // 1 CPU * 4 = 4, below MIN_CONCURRENT_OPS (8) so the floor wins.
+        assert_eq!(concurrent_ops_for_cpus(1), MIN_CONCURRENT_OPS);
+        assert_eq!(concurrent_ops_for_cpus(2), MIN_CONCURRENT_OPS);
+    }
+
+    #[test]
+    fn concurrent_ops_wide_host_clamps_to_maximum() {
+        // 16 CPUs * 4 = 64, exactly the ceiling; 32 CPUs * 4 = 128, clamped.
+        assert_eq!(concurrent_ops_for_cpus(16), MAX_CONCURRENT_OPS);
+        assert_eq!(concurrent_ops_for_cpus(32), MAX_CONCURRENT_OPS);
+        assert_eq!(concurrent_ops_for_cpus(256), MAX_CONCURRENT_OPS);
+    }
+
+    #[test]
+    fn concurrent_ops_saturates_on_overflow() {
+        // u32::MAX * 4 saturates; the clamp still pins to MAX_CONCURRENT_OPS.
+        assert_eq!(concurrent_ops_for_cpus(u32::MAX), MAX_CONCURRENT_OPS);
+    }
+
+    #[test]
+    fn default_concurrent_ops_matches_detected_cpus() {
+        let cpus = std::thread::available_parallelism()
+            .map(|n| n.get())
+            .unwrap_or(1);
+        let cpus_u32 = u32::try_from(cpus).unwrap_or(u32::MAX);
+        assert_eq!(default_concurrent_ops(), concurrent_ops_for_cpus(cpus_u32));
     }
 
     #[test]

--- a/crates/fast_io/src/iocp/disk_batch.rs
+++ b/crates/fast_io/src/iocp/disk_batch.rs
@@ -65,7 +65,12 @@ const DEFAULT_BUFFER_CAPACITY: usize = 256 * 1024;
 /// Maximum entries dequeued by a single `GetQueuedCompletionStatusEx` call.
 ///
 /// Matches the io_uring side's CQE batch sizing so both backends use the
-/// same drain granularity.
+/// same drain granularity. Kept fixed (not CPU-scaled) because the disk
+/// batch drains exactly the in-flight cohort capped by
+/// `IocpConfig::concurrent_ops`, which is already auto-sized by
+/// `super::config::default_concurrent_ops`. The clamp ceiling
+/// (`super::config::MAX_CONCURRENT_OPS`) is intentionally aligned with this
+/// constant so a single drain call can reap the entire cohort.
 const COMPLETION_DRAIN_BATCH: usize = 64;
 
 /// Wait timeout for completion drains, in milliseconds. The disk batch

--- a/crates/fast_io/src/iocp/mod.rs
+++ b/crates/fast_io/src/iocp/mod.rs
@@ -39,7 +39,8 @@ pub mod socket;
 pub mod transmit_file;
 
 pub use config::{
-    IOCP_MIN_FILE_SIZE, IocpConfig, iocp_availability_reason, is_iocp_available,
+    IOCP_MIN_FILE_SIZE, IocpConfig, MAX_CONCURRENT_OPS, MIN_CONCURRENT_OPS,
+    concurrent_ops_for_cpus, default_concurrent_ops, iocp_availability_reason, is_iocp_available,
     skip_event_optimization_available,
 };
 pub use disk_batch::IocpDiskBatch;

--- a/crates/fast_io/src/iocp/pump.rs
+++ b/crates/fast_io/src/iocp/pump.rs
@@ -74,7 +74,13 @@ const SHUTDOWN_KEY: usize = usize::MAX;
 ///
 /// Larger batches amortize the syscall cost across more completions but also
 /// increase per-call latency. 64 matches the io_uring CQE batch sizing used
-/// by `crates/fast_io/src/io_uring/disk_batch.rs`.
+/// by `crates/fast_io/src/io_uring/disk_batch.rs` and the
+/// `super::config::MAX_CONCURRENT_OPS` ceiling used by the auto-sized
+/// `IocpConfig::concurrent_ops`. Kept fixed rather than CPU-scaled because
+/// the drain buffer grows on demand up to [`MAX_BATCH_SIZE`] whenever the
+/// kernel signals `ERROR_INSUFFICIENT_BUFFER` (issue #1930), so wide hosts
+/// reach a higher steady-state depth without paying a larger initial
+/// allocation per pump.
 const DEFAULT_BATCH_SIZE: usize = 64;
 
 /// Hard cap on dynamic batch growth when the drain loop encounters

--- a/crates/fast_io/src/iocp_stub.rs
+++ b/crates/fast_io/src/iocp_stub.rs
@@ -23,6 +23,45 @@ use crate::traits::{
 /// Minimum file size threshold (informational only on this platform).
 pub const IOCP_MIN_FILE_SIZE: u64 = 64 * 1024;
 
+/// Lower bound for the auto-sized concurrent-ops depth. Mirrors the Windows
+/// surface so cross-platform code can reference the constant unconditionally.
+pub const MIN_CONCURRENT_OPS: u32 = 8;
+
+/// Upper bound for the auto-sized concurrent-ops depth. Mirrors the Windows
+/// surface so cross-platform code can reference the constant unconditionally.
+pub const MAX_CONCURRENT_OPS: u32 = 64;
+
+/// Auto-sizes the concurrent-ops depth from `cpus`.
+///
+/// Returns `(cpus * 4).clamp(MIN_CONCURRENT_OPS, MAX_CONCURRENT_OPS)`,
+/// matching the Windows implementation so cross-platform tests and tools
+/// see identical values for a given CPU count.
+#[must_use]
+pub const fn concurrent_ops_for_cpus(cpus: u32) -> u32 {
+    let raw = cpus.saturating_mul(4);
+    if raw < MIN_CONCURRENT_OPS {
+        MIN_CONCURRENT_OPS
+    } else if raw > MAX_CONCURRENT_OPS {
+        MAX_CONCURRENT_OPS
+    } else {
+        raw
+    }
+}
+
+/// Auto-sized default concurrent I/O operations per completion port.
+///
+/// On non-Windows hosts the value is informational only; the stub
+/// `IocpDiskBatch` never runs. Derives from
+/// `std::thread::available_parallelism()` for parity with the Windows path.
+#[must_use]
+pub fn default_concurrent_ops() -> u32 {
+    let cpus = std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(1);
+    let cpus_u32 = u32::try_from(cpus).unwrap_or(u32::MAX);
+    concurrent_ops_for_cpus(cpus_u32)
+}
+
 /// Typed IOCP error variants.
 ///
 /// On non-Windows platforms the IOCP backend is never constructed, so this
@@ -91,7 +130,7 @@ pub struct IocpConfig {
 impl Default for IocpConfig {
     fn default() -> Self {
         Self {
-            concurrent_ops: 4,
+            concurrent_ops: default_concurrent_ops(),
             buffer_size: 64 * 1024,
             unbuffered: false,
             write_through: false,
@@ -104,7 +143,7 @@ impl IocpConfig {
     #[must_use]
     pub fn for_large_files() -> Self {
         Self {
-            concurrent_ops: 8,
+            concurrent_ops: default_concurrent_ops(),
             buffer_size: 256 * 1024,
             unbuffered: false,
             write_through: false,
@@ -115,7 +154,7 @@ impl IocpConfig {
     #[must_use]
     pub fn for_small_files() -> Self {
         Self {
-            concurrent_ops: 4,
+            concurrent_ops: default_concurrent_ops(),
             buffer_size: 16 * 1024,
             unbuffered: false,
             write_through: false,
@@ -799,8 +838,23 @@ mod tests {
     #[test]
     fn config_default_values() {
         let config = IocpConfig::default();
-        assert_eq!(config.concurrent_ops, 4);
+        assert!(
+            (MIN_CONCURRENT_OPS..=MAX_CONCURRENT_OPS).contains(&config.concurrent_ops),
+            "default concurrent_ops {} must sit inside [{}, {}]",
+            config.concurrent_ops,
+            MIN_CONCURRENT_OPS,
+            MAX_CONCURRENT_OPS,
+        );
+        assert_eq!(config.concurrent_ops, default_concurrent_ops());
         assert_eq!(config.buffer_size, 64 * 1024);
+    }
+
+    #[test]
+    fn concurrent_ops_for_cpus_matches_windows_formula() {
+        assert_eq!(concurrent_ops_for_cpus(8), 32);
+        assert_eq!(concurrent_ops_for_cpus(1), MIN_CONCURRENT_OPS);
+        assert_eq!(concurrent_ops_for_cpus(16), MAX_CONCURRENT_OPS);
+        assert_eq!(concurrent_ops_for_cpus(u32::MAX), MAX_CONCURRENT_OPS);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Replace the static IocpConfig::concurrent_ops default (4) with a CPU-derived value: `(cpus * 4).clamp(8, 64)`, mirroring the io_uring SQ-entry derivation so wide hosts can keep more overlapped writes in flight without overwhelming the IOCP drain loop.
- Add `default_concurrent_ops()`, `concurrent_ops_for_cpus(cpus)`, plus `MIN_CONCURRENT_OPS = 8` and `MAX_CONCURRENT_OPS = 64`. The `IocpConfig::concurrent_ops` field stays overridable for explicit tuning, and the `for_large_files` / `for_small_files` presets now share the same auto-sized depth.
- Document why `COMPLETION_DRAIN_BATCH = 64` (disk_batch.rs) and `DEFAULT_BATCH_SIZE = 64` (pump.rs) stay fixed: both are intentionally aligned with the new `MAX_CONCURRENT_OPS` ceiling so a single `GetQueuedCompletionStatusEx` call reaps an entire in-flight cohort, and the pump grows on demand up to `MAX_BATCH_SIZE` on `ERROR_INSUFFICIENT_BUFFER` (issue #1930).
- Mirror the same surface in `iocp_stub.rs` so cross-platform callers compile against identical types on every host.

Closes #2302.

## Test plan

- [ ] `concurrent_ops_eight_cpu_host_yields_thirty_two` - 8 logical CPUs * 4 = 32 (inside clamp).
- [ ] `concurrent_ops_one_cpu_host_clamps_to_minimum` - 1 and 2 CPU hosts both pin to `MIN_CONCURRENT_OPS` (8).
- [ ] `concurrent_ops_wide_host_clamps_to_maximum` - 16 / 32 / 256 CPUs all pin to `MAX_CONCURRENT_OPS` (64).
- [ ] `concurrent_ops_saturates_on_overflow` - `u32::MAX` saturates without panic.
- [ ] `default_concurrent_ops_matches_detected_cpus` - the public helper agrees with the underlying formula for the host's CPU count.
- [ ] Stub parity test `concurrent_ops_for_cpus_matches_windows_formula` exercises the same formula on non-Windows hosts.
- [ ] CI: fmt+clippy, nextest (stable), Windows (stable), macOS (stable), Linux musl (stable).