### PR TITLE
feat(engine): SpillPolicy struct + ConcurrentDeltaConfig wiring (#2336)

### DIFF
--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -97,6 +97,12 @@ parallel-receive-delta = []
 # Trade-offs: Relaxes the single-producer compile-time invariant
 multi-producer = []
 
+# Spill payload compression (#2336) - reserves the SpillCompression::Zstd
+# variant on SpillPolicy. The codec wiring lands separately; this flag only
+# guards the public enum variant so default builds stay free of any new
+# dependency.
+spill-compression = []
+
 # Per-thread buffer slab (#1271, #1370) - replaces the single-slot thread-local
 # cache in front of BufferPool with a depth-bounded LIFO slab per thread.
 # Benefits: Removes central-queue cursor traffic on every return for workers

--- a/crates/engine/src/concurrent_delta/config.rs
+++ b/crates/engine/src/concurrent_delta/config.rs
@@ -2,18 +2,29 @@
 //!
 //! [`ConcurrentDeltaConfig`] aggregates the knobs that tune the
 //! [`DeltaConsumer`](super::consumer::DeltaConsumer) without changing its
-//! public type signature. The only knob today is
-//! [`spill_threshold_bytes`](ConcurrentDeltaConfig::spill_threshold_bytes),
-//! which opts the consumer into bounded-memory spill-to-tempfile via
-//! [`SpillableReorderBuffer`](super::spill::SpillableReorderBuffer).
+//! public type signature. The primary knob is
+//! [`spill_policy`](ConcurrentDeltaConfig::spill_policy), which opts the
+//! consumer into bounded-memory spill-to-tempfile via
+//! [`SpillableReorderBuffer`](super::spill::SpillableReorderBuffer) and
+//! exposes the full [`SpillPolicy`] surface.
 //!
 //! # Defaults
 //!
 //! [`ConcurrentDeltaConfig::default`] returns a configuration that mirrors
 //! the historical behaviour: bare [`ReorderBuffer`](super::reorder::ReorderBuffer)
-//! with no spill layer. Set `spill_threshold_bytes` to opt in.
+//! with no spill layer. Set `spill_policy.threshold_bytes` to opt in.
+//!
+//! # Backwards compatibility
+//!
+//! The legacy fields `spill_threshold_bytes` and `spill_dir` were collapsed
+//! into [`SpillPolicy`]. The matching `with_spill_threshold` / `with_spill_dir`
+//! constructors plus the [`spill_threshold_bytes`](ConcurrentDeltaConfig::spill_threshold_bytes)
+//! and [`spill_dir`](ConcurrentDeltaConfig::spill_dir) accessors are kept as
+//! deprecated shims that forward to [`spill_policy`](ConcurrentDeltaConfig::spill_policy).
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+
+use super::spill::policy::SpillPolicy;
 
 /// Tunable runtime knobs for the concurrent delta pipeline.
 ///
@@ -22,23 +33,13 @@ use std::path::PathBuf;
 /// value preserves backwards compatibility - no spill, no extra plumbing.
 #[derive(Debug, Clone, Default)]
 pub struct ConcurrentDeltaConfig {
-    /// Optional memory budget for the reorder buffer in bytes.
+    /// Spill policy that controls bounded-memory reordering.
     ///
-    /// `None` (the default) keeps the consumer on the bare
-    /// [`ReorderBuffer`](super::reorder::ReorderBuffer) path - inserts that
-    /// overflow the ring fall back to capacity doubling. `Some(threshold)`
-    /// switches the consumer to
-    /// [`SpillableReorderBuffer`](super::spill::SpillableReorderBuffer): when
-    /// the estimated in-memory footprint exceeds `threshold`, the oldest
-    /// (highest-sequence) buffered items are written to a tempfile so the
-    /// in-memory ring stays bounded.
-    pub spill_threshold_bytes: Option<u64>,
-    /// Optional explicit on-disk scratch directory for spilled items.
-    ///
-    /// Only consulted when `spill_threshold_bytes` is `Some`. `None` uses the
-    /// default `SpooledTempFile` backend, which keeps spills in memory up to
-    /// 1 MB before rolling over to a system tempfile.
-    pub spill_dir: Option<PathBuf>,
+    /// The default value disables spilling. Populate
+    /// [`SpillPolicy::threshold_bytes`] to engage the
+    /// [`SpillableReorderBuffer`](super::spill::SpillableReorderBuffer)
+    /// path; the other [`SpillPolicy`] knobs layer additional policy on top.
+    pub spill_policy: SpillPolicy,
 }
 
 impl ConcurrentDeltaConfig {
@@ -55,51 +56,81 @@ impl ConcurrentDeltaConfig {
     #[must_use]
     pub fn with_spill_threshold(threshold_bytes: u64) -> Self {
         Self {
-            spill_threshold_bytes: Some(threshold_bytes),
-            spill_dir: None,
+            spill_policy: SpillPolicy::with_threshold(threshold_bytes),
         }
     }
 
+    /// Returns a configuration that wires through an explicit [`SpillPolicy`].
+    #[must_use]
+    pub fn with_spill_policy(spill_policy: SpillPolicy) -> Self {
+        Self { spill_policy }
+    }
+
     /// Sets an explicit on-disk scratch directory for spilled items.
+    ///
+    /// Forwards to [`SpillPolicy::with_dir`]. Has no effect unless the spill
+    /// layer is also enabled via
+    /// [`with_spill_threshold`](Self::with_spill_threshold) or by populating
+    /// [`spill_policy`](Self::spill_policy) directly.
     #[must_use]
     pub fn with_spill_dir(mut self, dir: PathBuf) -> Self {
-        self.spill_dir = Some(dir);
+        self.spill_policy.dir = Some(dir);
         self
     }
 
     /// Returns `true` when the spill layer is configured to engage.
     #[must_use]
     pub const fn spill_enabled(&self) -> bool {
-        self.spill_threshold_bytes.is_some()
+        self.spill_policy.threshold_bytes.is_some()
+    }
+
+    /// Deprecated forwarding shim for the former `spill_threshold_bytes`
+    /// field. New code should read [`spill_policy`](Self::spill_policy)
+    /// directly.
+    #[deprecated(note = "use spill_policy.threshold_bytes")]
+    #[must_use]
+    pub const fn spill_threshold_bytes(&self) -> Option<u64> {
+        self.spill_policy.threshold_bytes
+    }
+
+    /// Deprecated forwarding shim for the former `spill_dir` field. New code
+    /// should read [`spill_policy`](Self::spill_policy) directly.
+    #[deprecated(note = "use spill_policy.dir")]
+    #[must_use]
+    pub fn spill_dir(&self) -> Option<&Path> {
+        self.spill_policy.dir.as_deref()
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::concurrent_delta::spill::policy::{ReclaimMode, SpillCompression, SpillGranularity};
 
     #[test]
     fn default_disables_spill() {
         let cfg = ConcurrentDeltaConfig::default();
         assert!(!cfg.spill_enabled());
-        assert!(cfg.spill_threshold_bytes.is_none());
-        assert!(cfg.spill_dir.is_none());
+        assert!(cfg.spill_policy.threshold_bytes.is_none());
+        assert!(cfg.spill_policy.dir.is_none());
+        assert_eq!(cfg.spill_policy.reclaim_mode, ReclaimMode::KeepInMemory);
+        assert_eq!(cfg.spill_policy.granularity, SpillGranularity::WholeBatch);
+        assert_eq!(cfg.spill_policy.compression, SpillCompression::None);
     }
 
     #[test]
     fn off_matches_default() {
         let a = ConcurrentDeltaConfig::off();
         let b = ConcurrentDeltaConfig::default();
-        assert_eq!(a.spill_threshold_bytes, b.spill_threshold_bytes);
-        assert_eq!(a.spill_dir, b.spill_dir);
+        assert_eq!(a.spill_policy, b.spill_policy);
     }
 
     #[test]
     fn with_spill_threshold_enables_spill() {
         let cfg = ConcurrentDeltaConfig::with_spill_threshold(16 * 1024);
         assert!(cfg.spill_enabled());
-        assert_eq!(cfg.spill_threshold_bytes, Some(16 * 1024));
-        assert!(cfg.spill_dir.is_none());
+        assert_eq!(cfg.spill_policy.threshold_bytes, Some(16 * 1024));
+        assert!(cfg.spill_policy.dir.is_none());
     }
 
     #[test]
@@ -107,6 +138,25 @@ mod tests {
         let dir = PathBuf::from("/tmp/oc-rsync-spill");
         let cfg = ConcurrentDeltaConfig::with_spill_threshold(1024).with_spill_dir(dir.clone());
         assert!(cfg.spill_enabled());
-        assert_eq!(cfg.spill_dir.as_deref(), Some(dir.as_path()));
+        assert_eq!(cfg.spill_policy.dir.as_deref(), Some(dir.as_path()));
+    }
+
+    #[test]
+    fn with_spill_policy_wires_full_policy() {
+        let policy = SpillPolicy::with_threshold(8 * 1024)
+            .with_granularity(SpillGranularity::PerItem)
+            .with_reclaim_mode(ReclaimMode::ReSpillIfPressureContinues);
+        let cfg = ConcurrentDeltaConfig::with_spill_policy(policy.clone());
+        assert_eq!(cfg.spill_policy, policy);
+        assert!(cfg.spill_enabled());
+    }
+
+    #[test]
+    #[allow(deprecated)]
+    fn deprecated_accessors_forward_to_policy() {
+        let dir = PathBuf::from("/tmp/oc-rsync-spill-legacy");
+        let cfg = ConcurrentDeltaConfig::with_spill_threshold(2048).with_spill_dir(dir.clone());
+        assert_eq!(cfg.spill_threshold_bytes(), Some(2048));
+        assert_eq!(cfg.spill_dir(), Some(dir.as_path()));
     }
 }

--- a/crates/engine/src/concurrent_delta/consumer.rs
+++ b/crates/engine/src/concurrent_delta/consumer.rs
@@ -196,8 +196,8 @@ impl DeltaConsumer {
     /// Spawns background threads honouring a runtime
     /// [`ConcurrentDeltaConfig`].
     ///
-    /// When `cfg.spill_threshold_bytes` is `Some`, the reorder thread is
-    /// backed by a [`SpillableReorderBuffer`] instead of the bare ring
+    /// When `cfg.spill_policy.threshold_bytes` is `Some`, the reorder thread
+    /// is backed by a [`SpillableReorderBuffer`] instead of the bare ring
     /// buffer. Items past the in-memory byte threshold spill to a tempfile;
     /// they are reloaded transparently as the delivery cursor reaches them.
     /// When the threshold is `None`, behaviour matches [`spawn`](Self::spawn).
@@ -215,11 +215,11 @@ impl DeltaConsumer {
         reorder_capacity: usize,
         cfg: ConcurrentDeltaConfig,
     ) -> Self {
-        let mode = match cfg.spill_threshold_bytes {
+        let mode = match cfg.spill_policy.threshold_bytes {
             Some(threshold) => ReorderMode::Spillable {
                 capacity: reorder_capacity,
                 threshold: usize::try_from(threshold).unwrap_or(usize::MAX),
-                dir: cfg.spill_dir,
+                dir: cfg.spill_policy.dir,
             },
             None => ReorderMode::Bare {
                 capacity: reorder_capacity,

--- a/crates/engine/src/concurrent_delta/mod.rs
+++ b/crates/engine/src/concurrent_delta/mod.rs
@@ -188,6 +188,7 @@ pub use consumer::{DeltaConsumer, DeltaConsumerStats};
 #[cfg(feature = "parallel-receive-delta")]
 pub use parallel_apply::{DeltaChunk, ParallelDeltaApplier};
 pub use reorder::{HistogramStats, Metrics as ReorderMetrics, ReorderBuffer};
+pub use spill::policy::{ReclaimMode, SpillCompression, SpillGranularity, SpillPolicy};
 pub use spill::{SpillCodec, SpillError, SpillStats, SpillableReorderBuffer};
 pub use strategy::{DeltaStrategy, DeltaTransferStrategy, WholeFileStrategy};
 pub use types::{DeltaResult, DeltaResultStatus, DeltaWork, DeltaWorkKind, FileNdx};

--- a/crates/engine/src/concurrent_delta/spill.rs
+++ b/crates/engine/src/concurrent_delta/spill.rs
@@ -54,6 +54,9 @@ use std::path::{Path, PathBuf};
 
 use super::reorder::{CapacityExceeded, ReorderBuffer};
 
+pub mod policy;
+pub use policy::{ReclaimMode, SpillCompression, SpillGranularity, SpillPolicy};
+
 /// Default memory threshold (in bytes) before spilling begins.
 ///
 /// Set to 64 MB, which accommodates roughly 64K items of 1 KB each.

--- a/crates/engine/src/concurrent_delta/spill/policy.rs
+++ b/crates/engine/src/concurrent_delta/spill/policy.rs
@@ -1,0 +1,217 @@
+//! Public policy types that configure the reorder buffer spill layer.
+//!
+//! [`SpillPolicy`] groups every knob that tunes the
+//! [`SpillableReorderBuffer`](super::SpillableReorderBuffer) into a single
+//! value: the byte threshold, the on-disk scratch directory, the post-spill
+//! reclaim behaviour, the spill granularity, and the optional payload
+//! compression. The default value disables spilling entirely, mirroring the
+//! historical bare [`ReorderBuffer`](super::super::reorder::ReorderBuffer)
+//! path so existing call sites keep their behaviour.
+//!
+//! The variants of [`ReclaimMode`], [`SpillGranularity`], and
+//! [`SpillCompression`] are deliberately additive: today only the defaults
+//! are wired through the consumer pipeline, and the alternatives reserve
+//! syntactic room for follow-up work without forcing another public API
+//! break. Tests below pin the defaults so downstream crates can rely on the
+//! contract.
+
+use std::path::PathBuf;
+
+/// What to do when memory pressure subsides after a spill event.
+///
+/// The default - [`ReclaimMode::KeepInMemory`] - matches the historical
+/// "spill once, never re-spill" behaviour: once items are reloaded from
+/// disk they remain in memory even if pressure returns. The alternative,
+/// [`ReclaimMode::ReSpillIfPressureContinues`], allows the buffer to push
+/// items back to disk on subsequent pressure events at the cost of extra
+/// disk traffic during sustained bursts.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
+pub enum ReclaimMode {
+    /// Reloaded items stay resident in memory for the rest of the transfer.
+    #[default]
+    KeepInMemory,
+    /// Reloaded items may be spilled back to disk on subsequent pressure.
+    ReSpillIfPressureContinues,
+}
+
+/// Granularity of a single spill event.
+///
+/// [`SpillGranularity::WholeBatch`] (the default) writes a contiguous run
+/// of reorder slots in one disk operation, matching the current
+/// [`SpillableReorderBuffer`](super::SpillableReorderBuffer) behaviour.
+/// [`SpillGranularity::PerItem`] reserves room for a per-record spill
+/// strategy that trades batch efficiency for finer eviction control.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
+pub enum SpillGranularity {
+    /// Spill a contiguous batch of items per disk operation.
+    #[default]
+    WholeBatch,
+    /// Spill individual items as the budget is exceeded.
+    PerItem,
+}
+
+/// Optional compression applied to spilled payloads.
+///
+/// [`SpillCompression::None`] (the default) writes raw encoded bytes, which
+/// is what the existing on-disk format uses. [`SpillCompression::Zstd`] is
+/// only constructable behind the `spill-compression` feature; this keeps
+/// the default builds free of the codec dependency while leaving the enum
+/// extensible.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
+pub enum SpillCompression {
+    /// Do not compress spilled payloads.
+    #[default]
+    None,
+    /// Compress spilled payloads with zstd at the given level.
+    ///
+    /// Constructable only when the `spill-compression` feature is enabled.
+    #[cfg(feature = "spill-compression")]
+    Zstd {
+        /// zstd compression level forwarded to the codec.
+        level: i32,
+    },
+}
+
+/// Aggregate of every public spill knob for [`ConcurrentDeltaConfig`].
+///
+/// [`SpillPolicy::default`] disables spilling (`threshold_bytes: None`) so
+/// the consumer keeps its bare [`ReorderBuffer`](super::super::reorder::ReorderBuffer)
+/// path. Set [`threshold_bytes`](Self::threshold_bytes) to opt in; the
+/// other fields layer in policy adjustments on top.
+///
+/// [`ConcurrentDeltaConfig`]: super::super::config::ConcurrentDeltaConfig
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SpillPolicy {
+    /// Memory budget (in bytes) before the spill layer engages.
+    ///
+    /// `None` disables spilling and the consumer uses the bare ring buffer.
+    pub threshold_bytes: Option<u64>,
+    /// Explicit on-disk scratch directory for spilled items.
+    ///
+    /// `None` uses the default `SpooledTempFile` backend, which keeps spills
+    /// in memory up to 1 MB before rolling over to a system tempfile.
+    pub dir: Option<PathBuf>,
+    /// Behaviour after a spill event when pressure subsides.
+    pub reclaim_mode: ReclaimMode,
+    /// Per-spill-event granularity.
+    pub granularity: SpillGranularity,
+    /// Optional payload compression for spilled bytes.
+    pub compression: SpillCompression,
+}
+
+impl SpillPolicy {
+    /// Returns a policy with spilling disabled. Equivalent to [`Self::default`].
+    #[must_use]
+    pub fn off() -> Self {
+        Self::default()
+    }
+
+    /// Returns a policy that engages the spill layer at the given byte budget.
+    ///
+    /// All other knobs use their defaults; chain the `with_*` builders to
+    /// override individual fields.
+    #[must_use]
+    pub fn with_threshold(threshold_bytes: u64) -> Self {
+        Self {
+            threshold_bytes: Some(threshold_bytes),
+            ..Self::default()
+        }
+    }
+
+    /// Sets the explicit on-disk scratch directory.
+    #[must_use]
+    pub fn with_dir(mut self, dir: PathBuf) -> Self {
+        self.dir = Some(dir);
+        self
+    }
+
+    /// Overrides the post-spill reclaim behaviour.
+    #[must_use]
+    pub fn with_reclaim_mode(mut self, mode: ReclaimMode) -> Self {
+        self.reclaim_mode = mode;
+        self
+    }
+
+    /// Overrides the per-spill-event granularity.
+    #[must_use]
+    pub fn with_granularity(mut self, granularity: SpillGranularity) -> Self {
+        self.granularity = granularity;
+        self
+    }
+
+    /// Overrides the spill-payload compression codec.
+    #[must_use]
+    pub fn with_compression(mut self, compression: SpillCompression) -> Self {
+        self.compression = compression;
+        self
+    }
+
+    /// Returns `true` when the spill layer is configured to engage.
+    #[must_use]
+    pub const fn is_enabled(&self) -> bool {
+        self.threshold_bytes.is_some()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_disables_spill() {
+        let policy = SpillPolicy::default();
+        assert!(!policy.is_enabled());
+        assert!(policy.threshold_bytes.is_none());
+        assert!(policy.dir.is_none());
+        assert_eq!(policy.reclaim_mode, ReclaimMode::KeepInMemory);
+        assert_eq!(policy.granularity, SpillGranularity::WholeBatch);
+        assert_eq!(policy.compression, SpillCompression::None);
+    }
+
+    #[test]
+    fn off_matches_default() {
+        assert_eq!(SpillPolicy::off(), SpillPolicy::default());
+    }
+
+    #[test]
+    fn enum_defaults_are_pinned() {
+        assert_eq!(ReclaimMode::default(), ReclaimMode::KeepInMemory);
+        assert_eq!(SpillGranularity::default(), SpillGranularity::WholeBatch);
+        assert_eq!(SpillCompression::default(), SpillCompression::None);
+    }
+
+    #[test]
+    fn with_threshold_enables_spill() {
+        let policy = SpillPolicy::with_threshold(64 * 1024);
+        assert!(policy.is_enabled());
+        assert_eq!(policy.threshold_bytes, Some(64 * 1024));
+        assert!(policy.dir.is_none());
+    }
+
+    #[test]
+    fn builder_chain_sets_every_field() {
+        let dir = PathBuf::from("/tmp/oc-rsync-spill");
+        let policy = SpillPolicy::with_threshold(2048)
+            .with_dir(dir.clone())
+            .with_reclaim_mode(ReclaimMode::ReSpillIfPressureContinues)
+            .with_granularity(SpillGranularity::PerItem);
+        assert_eq!(policy.threshold_bytes, Some(2048));
+        assert_eq!(policy.dir.as_deref(), Some(dir.as_path()));
+        assert_eq!(policy.reclaim_mode, ReclaimMode::ReSpillIfPressureContinues);
+        assert_eq!(policy.granularity, SpillGranularity::PerItem);
+        assert_eq!(policy.compression, SpillCompression::None);
+    }
+
+    #[test]
+    fn with_compression_overrides_default() {
+        let policy = SpillPolicy::with_threshold(1024).with_compression(SpillCompression::None);
+        assert_eq!(policy.compression, SpillCompression::None);
+    }
+
+    #[test]
+    fn policies_are_value_equal() {
+        let a = SpillPolicy::with_threshold(4096).with_granularity(SpillGranularity::PerItem);
+        let b = SpillPolicy::with_threshold(4096).with_granularity(SpillGranularity::PerItem);
+        assert_eq!(a, b);
+    }
+}

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -186,7 +186,8 @@ pub use delta::{
 pub use concurrent_delta::{
     AdaptiveCapacityPolicy, ConcurrentDeltaConfig, DeltaConsumerStats, DeltaResult,
     DeltaResultStatus, DeltaStrategy, DeltaTransferStrategy, DeltaWork, DeltaWorkKind, FileNdx,
-    ReorderBuffer, ReorderStats, WholeFileStrategy,
+    ReclaimMode, ReorderBuffer, ReorderStats, SpillCompression, SpillGranularity, SpillPolicy,
+    WholeFileStrategy,
 };
 
 /// Common error types for engine operations.


### PR DESCRIPTION
## Summary

- Add public `SpillPolicy` aggregate (`threshold_bytes`, `dir`, `reclaim_mode`, `granularity`, `compression`) plus supporting `ReclaimMode`, `SpillGranularity`, and `SpillCompression` enums in `crates/engine/src/concurrent_delta/spill/policy.rs`. Defaults disable spilling and pin the historical behaviour.
- Replace the two ad-hoc fields on `ConcurrentDeltaConfig` with a single `spill_policy: SpillPolicy`, forwarding the consumer's existing `spill_threshold_bytes` / `spill_dir` lookups through the new aggregate.
- Keep `spill_threshold_bytes()` and `spill_dir()` as deprecated accessors on `ConcurrentDeltaConfig` that forward to `spill_policy` so downstream callers migrate without breakage. New `with_spill_policy` constructor exposes the full builder.
- Gate `SpillCompression::Zstd { level }` behind a new additive `spill-compression` feature so default builds gain no dependency.
- Re-export `SpillPolicy`, `ReclaimMode`, `SpillGranularity`, and `SpillCompression` from `concurrent_delta` and the `engine` crate root.

## Test plan

- [ ] `cargo nextest run -p engine --all-features -E 'test(concurrent_delta::spill::policy)'`
- [ ] `cargo nextest run -p engine --all-features -E 'test(concurrent_delta::config)'`
- [ ] CI: fmt+clippy, nextest (stable), Windows, macOS, Linux musl