### PR TITLE
refactor(engine): replace lock().expect() with lock_or_recover in delete/context.rs (#2353)

### DIFF
--- a/.github/workflows/fuzz-coverage-report.yml
+++ b/.github/workflows/fuzz-coverage-report.yml
@@ -1,0 +1,249 @@
+# Nightly Fuzz Coverage Report - Informational
+#
+# Runs `cargo fuzz coverage` for every target across the three fuzz workspaces
+# (`fuzz/`, `crates/protocol/fuzz/`, `crates/filters/fuzz/`) and uploads the
+# generated `.lcov` files as workflow artifacts. Marked `continue-on-error: true`
+# while we establish baseline thresholds per target. Promote to a required
+# check once each target has a stable minimum line coverage documented in
+# `docs/audits/fuzz-coverage-matrix.md`.
+#
+# Budget:
+#   - 5 minutes per target (-max_total_time=300) keeps the matrix under the
+#     90-minute job timeout even as targets are added.
+#   - Targets run in a matrix so a single regression does not block siblings
+#     (fail-fast: false).
+#
+# Outputs:
+#   - One `coverage/<target>.lcov` per matrix entry, uploaded with
+#     `retention-days: 30` so historical comparisons survive a full sprint.
+#   - A "Coverage summary (informational)" step greps line-hit totals from
+#     each lcov file into the GitHub step summary for at-a-glance review.
+
+name: Fuzz Coverage Report
+
+on:
+  schedule:
+    # Nightly at 03:30 UTC: after Filter Fuzzer Overnight (02:00 UTC) so the
+    # two jobs do not compete for the same fuzz workspace lock.
+    - cron: '30 3 * * *'
+  workflow_dispatch:
+    inputs:
+      duration:
+        description: 'Seconds per fuzz target (default 300 = 5 min)'
+        required: false
+        default: '300'
+
+concurrency:
+  group: fuzz-coverage-report
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  FUZZ_DURATION: ${{ github.event.inputs.duration || '300' }}
+
+jobs:
+  coverage:
+    name: ${{ matrix.target }} (informational)
+    runs-on: ubuntu-latest
+    # 5 min per target + 25 min for toolchain install, upstream build, and
+    # cargo-fuzz coverage compilation overhead.
+    timeout-minutes: 30
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - workspace: fuzz
+            target: protocol_wire
+          - workspace: fuzz
+            target: simd_checksum_parity
+          - workspace: fuzz
+            target: filter_differential
+            needs_upstream: true
+          - workspace: fuzz
+            target: filter_rules_vs_upstream
+            needs_upstream: true
+          - workspace: fuzz
+            target: multiplex_frame_parse
+          - workspace: fuzz
+            target: flist_entry_decode
+          - workspace: fuzz
+            target: decompressor_zstd
+          - workspace: fuzz
+            target: decompressor_zlib
+          - workspace: crates/protocol/fuzz
+            target: fuzz_varint
+          - workspace: crates/protocol/fuzz
+            target: varint_roundtrip
+          - workspace: crates/protocol/fuzz
+            target: fuzz_delta
+          - workspace: crates/protocol/fuzz
+            target: fuzz_multiplex_frame
+          - workspace: crates/protocol/fuzz
+            target: multiplex_frame_roundtrip
+          - workspace: crates/protocol/fuzz
+            target: fuzz_legacy_greeting
+          - workspace: crates/protocol/fuzz
+            target: file_entry_roundtrip
+          - workspace: crates/filters/fuzz
+            target: fuzz_filter_parse
+          - workspace: crates/filters/fuzz
+            target: fuzz_filter_chain
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
+        with:
+          toolchain: stable
+
+      - name: Install nightly Rust
+        uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
+        with:
+          toolchain: nightly
+          components: llvm-tools-preview
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
+        with:
+          shared-key: ci-${{ runner.os }}-cargo-v1-${{ hashFiles('**/Cargo.lock') }}
+          key: fuzz-coverage-${{ matrix.target }}
+
+      - name: Cache APT packages
+        uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05 # v1.6.0
+        with:
+          packages: build-essential pkg-config zlib1g-dev curl autoconf automake libtool libacl1-dev libattr1-dev lcov
+          version: v1
+
+      - name: Install cargo-fuzz
+        run: cargo install cargo-fuzz --locked
+
+      - name: Cache upstream rsync
+        if: matrix.needs_upstream
+        id: cache-rsync
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            target/interop/upstream-src
+            target/interop/upstream-install
+          key: upstream-rsync-3.4.2-${{ runner.os }}-${{ hashFiles('tools/ci/run_interop.sh') }}
+          restore-keys: |
+            upstream-rsync-3.4.2-${{ runner.os }}-
+
+      - name: Build upstream rsync
+        if: matrix.needs_upstream && steps.cache-rsync.outputs.cache-hit != 'true'
+        run: bash tools/ci/run_interop.sh build-only
+
+      - name: Locate upstream rsync
+        if: matrix.needs_upstream
+        id: upstream
+        run: |
+          set -euo pipefail
+          for candidate in \
+              "${GITHUB_WORKSPACE}/target/interop/upstream-install/3.4.2/bin/rsync" \
+              "${GITHUB_WORKSPACE}/target/interop/upstream-install/3.4.1/bin/rsync"; do
+              if [[ -x "${candidate}" ]]; then
+                  echo "upstream=${candidate}" >>"$GITHUB_OUTPUT"
+                  echo "located upstream rsync at ${candidate}"
+                  exit 0
+              fi
+          done
+          echo "error: no upstream rsync binary built" >&2
+          exit 1
+
+      - name: Run cargo fuzz coverage (${{ matrix.target }})
+        env:
+          OC_RSYNC_UPSTREAM_BIN: ${{ steps.upstream.outputs.upstream }}
+        run: |
+          set -uo pipefail
+          cd "${{ matrix.workspace }}"
+          # cargo fuzz coverage runs the target with a coverage-instrumented
+          # build and emits coverage/<target>/coverage.profdata.
+          cargo +nightly fuzz coverage "${{ matrix.target }}" \
+              -- -max_total_time="${FUZZ_DURATION}"
+          status=$?
+          echo "coverage_status=${status}" >>"$GITHUB_ENV"
+          if [[ "${status}" -ne 0 ]]; then
+              echo "warning: cargo fuzz coverage exited ${status}" >&2
+          fi
+
+      - name: Convert profdata to lcov
+        if: always()
+        run: |
+          set -uo pipefail
+          workspace="${{ matrix.workspace }}"
+          target="${{ matrix.target }}"
+          profdata="${workspace}/coverage/${target}/coverage.profdata"
+          mkdir -p coverage
+          if [[ ! -f "${profdata}" ]]; then
+              echo "no profdata for ${target}; emitting empty placeholder" >&2
+              : >"coverage/${target}.lcov"
+              exit 0
+          fi
+          # cargo fuzz writes the instrumented binary under
+          # <workspace>/target/<host-triple>/coverage/<host-triple>/release/<target>.
+          host_triple=$(rustc -vV | awk '/^host:/ { print $2 }')
+          binary="${workspace}/target/${host_triple}/coverage/${host_triple}/release/${target}"
+          if [[ ! -x "${binary}" ]]; then
+              # Fallback layout for older cargo-fuzz releases.
+              binary="${workspace}/target/${host_triple}/release/${target}"
+          fi
+          if [[ ! -x "${binary}" ]]; then
+              echo "warning: instrumented binary missing for ${target}" >&2
+              : >"coverage/${target}.lcov"
+              exit 0
+          fi
+          cargo +nightly cov -- export \
+              --format=lcov \
+              --instr-profile="${profdata}" \
+              "${binary}" \
+              >"coverage/${target}.lcov" || {
+              echo "warning: cargo cov export failed for ${target}" >&2
+              : >"coverage/${target}.lcov"
+          }
+
+      - name: Coverage summary (informational)
+        if: always()
+        run: |
+          set -uo pipefail
+          target="${{ matrix.target }}"
+          lcov_file="coverage/${target}.lcov"
+          {
+              echo "## Fuzz coverage: ${target}"
+              echo ""
+              if [[ ! -s "${lcov_file}" ]]; then
+                  echo "_No coverage data emitted; see job log for details._"
+                  exit 0
+              fi
+              # LF = lines found, LH = lines hit. Aggregate across source files
+              # in the lcov record so the summary reflects total target coverage.
+              lf=$(grep -c '^LF:' "${lcov_file}" || true)
+              lh_total=$(awk -F: '/^LH:/ { sum += $2 } END { print sum + 0 }' "${lcov_file}")
+              lf_total=$(awk -F: '/^LF:/ { sum += $2 } END { print sum + 0 }' "${lcov_file}")
+              if [[ "${lf_total}" -gt 0 ]]; then
+                  pct=$(awk -v h="${lh_total}" -v f="${lf_total}" \
+                      'BEGIN { printf "%.2f", (h / f) * 100 }')
+              else
+                  pct="n/a"
+              fi
+              echo "| Metric | Value |"
+              echo "|--------|-------|"
+              echo "| Source records | ${lf} |"
+              echo "| Lines found | ${lf_total} |"
+              echo "| Lines hit | ${lh_total} |"
+              echo "| Line coverage | ${pct}% |"
+          } >>"${GITHUB_STEP_SUMMARY}"
+
+      - name: Upload lcov artifact
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: fuzz-coverage-${{ matrix.target }}-${{ github.run_id }}
+          retention-days: 30
+          path: coverage/${{ matrix.target }}.lcov
+          if-no-files-found: warn

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ tags are mirrored on GitHub at <https://github.com/oferchen/rsync/releases>.
 
 ## [Unreleased]
 
+### Documentation
+
+- **SSH transport**: documented the opt-in `rsync_io/ssh-socketpair-stderr`
+  Cargo feature - what it does (socketpair-backed SSH stderr instead of an
+  anonymous pipe), why it exists (avoid deadlock when chatty remote children
+  fill the 64 KiB pipe buffer), when to enable it, and platform constraints.
+  Added `docs/ssh-transport.md` and cross-linked from the Cargo features
+  table in `README.md` (#2377).
+
 ### Performance
 
 - **Delta matching**: incorporated four zsync-inspired internal optimizations

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -547,7 +547,7 @@ dependencies = [
  "md4",
  "openssl",
  "proptest",
- "rand 0.8.6",
+ "rand 0.10.1",
  "rayon",
  "sha1 0.10.6",
  "sha2 0.10.9",
@@ -1341,6 +1341,7 @@ dependencies = [
  "rustix",
  "tempfile",
  "thiserror 2.0.18",
+ "tracing",
  "windows-sys 0.61.2",
 ]
 
@@ -3005,15 +3006,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "raw-cpuid"
-version = "11.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
 name = "rayon"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3124,7 +3116,6 @@ dependencies = [
  "proptest",
  "protocol",
  "rand 0.10.1",
- "raw-cpuid",
  "rpassword",
  "russh",
  "shell-words",
@@ -4079,7 +4070,7 @@ dependencies = [
  "metadata",
  "proptest",
  "protocol",
- "rand 0.9.4",
+ "rand 0.10.1",
  "rayon",
  "signature 0.6.2",
  "tempfile",

--- a/README.md
+++ b/README.md
@@ -214,6 +214,23 @@ release binary on modern Linux/macOS/Windows hosts; everything marked
 | `concurrent-sessions` | `daemon` | no | Shared `dashmap` session state for multi-session daemons. | experimental |
 | `tracing` | `core`, `engine`, `transfer`, `daemon` | no | Structured `tracing` instrumentation for diagnostics. | stable |
 
+#### Receiver memory tuning: `SpillPolicy`
+
+The concurrent-delta receiver bounds its in-memory `ReorderBuffer` through a
+process-wide `SpillPolicy` knob. The default policy keeps everything in memory
+(byte-equivalent to prior releases). Opt in to disk-backed spill by setting
+`OC_RSYNC_SPILL_THRESHOLD_BYTES` (e.g. `64M`) and, optionally,
+`OC_RSYNC_SPILL_DIR` to point at a fast scratch directory. CLI flags
+`--spill-dir` and `--spill-threshold-bytes` are planned for STN-11 and will
+shadow the env vars when present. Full surface (env vars, reclaim mode,
+granularity, compression, validation rules, defaults table) is in
+[`docs/design/spill-policy-public-api.md`](./docs/design/spill-policy-public-api.md);
+the underlying buffer is documented in
+[`docs/design/reorderbuffer-spill-to-tempfile.md`](./docs/design/reorderbuffer-spill-to-tempfile.md).
+Operator-facing tuning guidance is in
+[`docs/operator-migration-guide-vNEXT.md`](./docs/operator-migration-guide-vNEXT.md)
+under *Receiver spill tunability*.
+
 #### Choosing features for your build
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ release binary on modern Linux/macOS/Windows hosts; everything marked
 | `thread-slab-pool` | `engine` | no | Per-thread bounded LIFO slab in front of `BufferPool`; pays off above ~32 workers (#1271, #1370). | experimental |
 | `vmsplice` | `fast_io`, `transfer` | no | Linux `vmsplice(2)` + `splice(2)` zero-copy writer for large page-aligned chunks. | experimental |
 | `async-ssh` | `core`, `rsync_io` | no | Wires `AsyncSshTransport` into the client remote path; opt-in at runtime via `OC_RSYNC_ASYNC_SSH=1` (#1593, #1796, #1805, #1806). | experimental |
+| `ssh-socketpair-stderr` | `rsync_io` | no | Constructs the SSH child's stderr over a `socketpair(AF_UNIX, SOCK_STREAM)` instead of an anonymous pipe, enabling epoll/kqueue-integrated async drain (Linux recommended; Windows shim pending SSE-5). See `docs/design/socketpair-stderr-channel.md` (#2371, #2372). | experimental |
 | `async-daemon` | `daemon` | no | Hybrid tokio accept loop dispatching sync workers via `spawn_blocking` (#1935). | experimental |
 | `concurrent-sessions` | `daemon` | no | Shared `dashmap` session state for multi-session daemons. | experimental |
 | `tracing` | `core`, `engine`, `transfer`, `daemon` | no | Structured `tracing` instrumentation for diagnostics. | stable |

--- a/README.md
+++ b/README.md
@@ -32,18 +32,18 @@ All transfer modes (local, SSH, daemon), delta algorithm, metadata preservation,
 | **Reference dirs** | `--compare-dest`, `--link-dest`, `--copy-dest` |
 | **Options** | `--delay-updates`, `--inplace`, `--partial`, `--iconv`, fuzzy matching |
 | **I/O** | io_uring (Linux 5.6+), `copy_file_range`, `clonefile` (macOS), adaptive buffers |
-| **Platforms** | Linux, macOS (full); Windows (ACLs, xattrs via NTFS ADS, IOCP socket I/O; no symlinks/devices) |
+| **Platforms** | Linux, macOS (full); Windows (NTFS DACL partial, xattrs via NTFS ADS, IOCP socket I/O; no symlinks/devices) |
 
 ### Platform Support
 
-The primary platform is Linux. macOS is well-supported with parity for all metadata, ACL, and xattr features, including AppleDouble (`._foo`) resource-fork preservation. Windows builds and runs core transfer modes with native ACLs (via `windows-rs` `GetSecurityInfo`/`SetSecurityInfo`), xattrs (via NTFS Alternate Data Streams), and IOCP socket I/O (`WSARecv`/`WSASend`); symlinks and POSIX device nodes remain stubbed.
+The primary platform is Linux. macOS is well-supported with parity for all metadata, ACL, and xattr features, including AppleDouble (`._foo`) resource-fork preservation. Windows builds and runs core transfer modes with NTFS DACL preservation (via `windows-rs` `GetNamedSecurityInfoW`/`SetNamedSecurityInfoW`, currently Tier 1C partial - see the **--acls** entry in `docs/oc-rsync.1.md` and `docs/design/windows-ntfs-acl-support.md` for the documented lossy cases), xattrs (via NTFS Alternate Data Streams), and IOCP socket I/O (`WSARecv`/`WSASend`); symlinks and POSIX device nodes remain stubbed.
 
 | Feature | Linux | macOS | Windows | Notes |
 |---------|:-----:|:-----:|:-------:|-------|
 | Permissions (`-p`) | ✓ | ✓ | ⚠ | Windows preserves only the read-only flag; POSIX mode bits are not applicable. |
 | Times (`-t`) | ✓ | ✓ | ✓ | Nanosecond precision via the `filetime` crate on all platforms. |
 | File ownership (`-o`/`-g`, uid/gid) | ✓ | ✓ | ✗ | `apply_ownership_from_entry` is a no-op on non-Unix; uid/gid mapping is Unix-only. |
-| ACLs (`-A`) | ✓ | ✓ | ✓ | Uses `exacl` on Linux/macOS/FreeBSD; Windows uses `windows-rs` `GetSecurityInfo`/`SetSecurityInfo` for native NTFS ACL round-trip. |
+| ACLs (`-A`) | ✓ | ✓ | ⚠ | Uses `exacl` on Linux/macOS/FreeBSD. Windows uses `windows-rs` `GetNamedSecurityInfoW`/`SetNamedSecurityInfoW` for NTFS DACL round-trip (Tier 1C partial): deny ACEs, inherited ACEs, the SACL, non-`rwx` access bits, and unresolvable SIDs are dropped with a one-time warning. SDDL fidelity payload, `--audit-acls`, `--fail-on-windows-acl-loss`, and `--windows-acls` are planned. See `docs/design/windows-ntfs-acl-support.md` and the **--acls** entry in `docs/oc-rsync.1.md`. |
 | Extended attributes (`-X`) | ✓ | ✓ | ✓ | Linux/macOS via the `xattr` crate (macOS adds AppleDouble resource-fork support); Windows stores xattrs as NTFS Alternate Data Streams. |
 | Hardlinks (`-H`) | ✓ | ✓ | ✓ | Uses portable `std::fs::hard_link`; works on NTFS. |
 | Symbolic links | ✓ | ✓ | ✗ | `create_symlinks` is `cfg(not(unix))` no-op; symlink entries are skipped on Windows. |

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ release binary on modern Linux/macOS/Windows hosts; everything marked
 | `thread-slab-pool` | `engine` | no | Per-thread bounded LIFO slab in front of `BufferPool`; pays off above ~32 workers (#1271, #1370). | experimental |
 | `vmsplice` | `fast_io`, `transfer` | no | Linux `vmsplice(2)` + `splice(2)` zero-copy writer for large page-aligned chunks. | experimental |
 | `async-ssh` | `core`, `rsync_io` | no | Wires `AsyncSshTransport` into the client remote path; opt-in at runtime via `OC_RSYNC_ASYNC_SSH=1` (#1593, #1796, #1805, #1806). | experimental |
-| `ssh-socketpair-stderr` | `rsync_io` | no | Constructs the SSH child's stderr over a `socketpair(AF_UNIX, SOCK_STREAM)` instead of an anonymous pipe, enabling epoll/kqueue-integrated async drain (Linux recommended; Windows shim pending SSE-5). See `docs/design/socketpair-stderr-channel.md` (#2371, #2372). | experimental |
+| `ssh-socketpair-stderr` | `rsync_io` | no | Constructs the SSH child's stderr over a `socketpair(AF_UNIX, SOCK_STREAM)` instead of an anonymous pipe, enabling epoll/kqueue-integrated async drain and a larger default buffer to absorb chatty remote shells (Linux recommended; Windows shim pending SSE-5). See [`docs/ssh-transport.md`](./docs/ssh-transport.md) and [`docs/design/socketpair-stderr-channel.md`](./docs/design/socketpair-stderr-channel.md) (#2371, #2372). | experimental |
 | `async-daemon` | `daemon` | no | Hybrid tokio accept loop dispatching sync workers via `spawn_blocking` (#1935). | experimental |
 | `concurrent-sessions` | `daemon` | no | Shared `dashmap` session state for multi-session daemons. | experimental |
 | `tracing` | `core`, `engine`, `transfer`, `daemon` | no | Structured `tracing` instrumentation for diagnostics. | stable |

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -97,6 +97,12 @@ parallel-receive-delta = []
 # Trade-offs: Relaxes the single-producer compile-time invariant
 multi-producer = []
 
+# Spill payload compression (#2336) - reserves the SpillCompression::Zstd
+# variant on SpillPolicy. The codec wiring lands separately; this flag only
+# guards the public enum variant so default builds stay free of any new
+# dependency.
+spill-compression = []
+
 # Per-thread buffer slab (#1271, #1370) - replaces the single-slot thread-local
 # cache in front of BufferPool with a depth-bounded LIFO slab per thread.
 # Benefits: Removes central-queue cursor traffic on every return for workers

--- a/crates/engine/src/concurrent_delta/config.rs
+++ b/crates/engine/src/concurrent_delta/config.rs
@@ -2,18 +2,29 @@
 //!
 //! [`ConcurrentDeltaConfig`] aggregates the knobs that tune the
 //! [`DeltaConsumer`](super::consumer::DeltaConsumer) without changing its
-//! public type signature. The only knob today is
-//! [`spill_threshold_bytes`](ConcurrentDeltaConfig::spill_threshold_bytes),
-//! which opts the consumer into bounded-memory spill-to-tempfile via
-//! [`SpillableReorderBuffer`](super::spill::SpillableReorderBuffer).
+//! public type signature. The primary knob is
+//! [`spill_policy`](ConcurrentDeltaConfig::spill_policy), which opts the
+//! consumer into bounded-memory spill-to-tempfile via
+//! [`SpillableReorderBuffer`](super::spill::SpillableReorderBuffer) and
+//! exposes the full [`SpillPolicy`] surface.
 //!
 //! # Defaults
 //!
 //! [`ConcurrentDeltaConfig::default`] returns a configuration that mirrors
 //! the historical behaviour: bare [`ReorderBuffer`](super::reorder::ReorderBuffer)
-//! with no spill layer. Set `spill_threshold_bytes` to opt in.
+//! with no spill layer. Set `spill_policy.threshold_bytes` to opt in.
+//!
+//! # Backwards compatibility
+//!
+//! The legacy fields `spill_threshold_bytes` and `spill_dir` were collapsed
+//! into [`SpillPolicy`]. The matching `with_spill_threshold` / `with_spill_dir`
+//! constructors plus the [`spill_threshold_bytes`](ConcurrentDeltaConfig::spill_threshold_bytes)
+//! and [`spill_dir`](ConcurrentDeltaConfig::spill_dir) accessors are kept as
+//! deprecated shims that forward to [`spill_policy`](ConcurrentDeltaConfig::spill_policy).
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+
+use super::spill::policy::SpillPolicy;
 
 /// Tunable runtime knobs for the concurrent delta pipeline.
 ///
@@ -22,23 +33,13 @@ use std::path::PathBuf;
 /// value preserves backwards compatibility - no spill, no extra plumbing.
 #[derive(Debug, Clone, Default)]
 pub struct ConcurrentDeltaConfig {
-    /// Optional memory budget for the reorder buffer in bytes.
+    /// Spill policy that controls bounded-memory reordering.
     ///
-    /// `None` (the default) keeps the consumer on the bare
-    /// [`ReorderBuffer`](super::reorder::ReorderBuffer) path - inserts that
-    /// overflow the ring fall back to capacity doubling. `Some(threshold)`
-    /// switches the consumer to
-    /// [`SpillableReorderBuffer`](super::spill::SpillableReorderBuffer): when
-    /// the estimated in-memory footprint exceeds `threshold`, the oldest
-    /// (highest-sequence) buffered items are written to a tempfile so the
-    /// in-memory ring stays bounded.
-    pub spill_threshold_bytes: Option<u64>,
-    /// Optional explicit on-disk scratch directory for spilled items.
-    ///
-    /// Only consulted when `spill_threshold_bytes` is `Some`. `None` uses the
-    /// default `SpooledTempFile` backend, which keeps spills in memory up to
-    /// 1 MB before rolling over to a system tempfile.
-    pub spill_dir: Option<PathBuf>,
+    /// The default value disables spilling. Populate
+    /// [`SpillPolicy::threshold_bytes`] to engage the
+    /// [`SpillableReorderBuffer`](super::spill::SpillableReorderBuffer)
+    /// path; the other [`SpillPolicy`] knobs layer additional policy on top.
+    pub spill_policy: SpillPolicy,
 }
 
 impl ConcurrentDeltaConfig {
@@ -55,51 +56,81 @@ impl ConcurrentDeltaConfig {
     #[must_use]
     pub fn with_spill_threshold(threshold_bytes: u64) -> Self {
         Self {
-            spill_threshold_bytes: Some(threshold_bytes),
-            spill_dir: None,
+            spill_policy: SpillPolicy::with_threshold(threshold_bytes),
         }
     }
 
+    /// Returns a configuration that wires through an explicit [`SpillPolicy`].
+    #[must_use]
+    pub fn with_spill_policy(spill_policy: SpillPolicy) -> Self {
+        Self { spill_policy }
+    }
+
     /// Sets an explicit on-disk scratch directory for spilled items.
+    ///
+    /// Forwards to [`SpillPolicy::with_dir`]. Has no effect unless the spill
+    /// layer is also enabled via
+    /// [`with_spill_threshold`](Self::with_spill_threshold) or by populating
+    /// [`spill_policy`](Self::spill_policy) directly.
     #[must_use]
     pub fn with_spill_dir(mut self, dir: PathBuf) -> Self {
-        self.spill_dir = Some(dir);
+        self.spill_policy.dir = Some(dir);
         self
     }
 
     /// Returns `true` when the spill layer is configured to engage.
     #[must_use]
     pub const fn spill_enabled(&self) -> bool {
-        self.spill_threshold_bytes.is_some()
+        self.spill_policy.threshold_bytes.is_some()
+    }
+
+    /// Deprecated forwarding shim for the former `spill_threshold_bytes`
+    /// field. New code should read [`spill_policy`](Self::spill_policy)
+    /// directly.
+    #[deprecated(note = "use spill_policy.threshold_bytes")]
+    #[must_use]
+    pub const fn spill_threshold_bytes(&self) -> Option<u64> {
+        self.spill_policy.threshold_bytes
+    }
+
+    /// Deprecated forwarding shim for the former `spill_dir` field. New code
+    /// should read [`spill_policy`](Self::spill_policy) directly.
+    #[deprecated(note = "use spill_policy.dir")]
+    #[must_use]
+    pub fn spill_dir(&self) -> Option<&Path> {
+        self.spill_policy.dir.as_deref()
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::concurrent_delta::spill::policy::{ReclaimMode, SpillCompression, SpillGranularity};
 
     #[test]
     fn default_disables_spill() {
         let cfg = ConcurrentDeltaConfig::default();
         assert!(!cfg.spill_enabled());
-        assert!(cfg.spill_threshold_bytes.is_none());
-        assert!(cfg.spill_dir.is_none());
+        assert!(cfg.spill_policy.threshold_bytes.is_none());
+        assert!(cfg.spill_policy.dir.is_none());
+        assert_eq!(cfg.spill_policy.reclaim_mode, ReclaimMode::KeepInMemory);
+        assert_eq!(cfg.spill_policy.granularity, SpillGranularity::WholeBatch);
+        assert_eq!(cfg.spill_policy.compression, SpillCompression::None);
     }
 
     #[test]
     fn off_matches_default() {
         let a = ConcurrentDeltaConfig::off();
         let b = ConcurrentDeltaConfig::default();
-        assert_eq!(a.spill_threshold_bytes, b.spill_threshold_bytes);
-        assert_eq!(a.spill_dir, b.spill_dir);
+        assert_eq!(a.spill_policy, b.spill_policy);
     }
 
     #[test]
     fn with_spill_threshold_enables_spill() {
         let cfg = ConcurrentDeltaConfig::with_spill_threshold(16 * 1024);
         assert!(cfg.spill_enabled());
-        assert_eq!(cfg.spill_threshold_bytes, Some(16 * 1024));
-        assert!(cfg.spill_dir.is_none());
+        assert_eq!(cfg.spill_policy.threshold_bytes, Some(16 * 1024));
+        assert!(cfg.spill_policy.dir.is_none());
     }
 
     #[test]
@@ -107,6 +138,25 @@ mod tests {
         let dir = PathBuf::from("/tmp/oc-rsync-spill");
         let cfg = ConcurrentDeltaConfig::with_spill_threshold(1024).with_spill_dir(dir.clone());
         assert!(cfg.spill_enabled());
-        assert_eq!(cfg.spill_dir.as_deref(), Some(dir.as_path()));
+        assert_eq!(cfg.spill_policy.dir.as_deref(), Some(dir.as_path()));
+    }
+
+    #[test]
+    fn with_spill_policy_wires_full_policy() {
+        let policy = SpillPolicy::with_threshold(8 * 1024)
+            .with_granularity(SpillGranularity::PerItem)
+            .with_reclaim_mode(ReclaimMode::ReSpillIfPressureContinues);
+        let cfg = ConcurrentDeltaConfig::with_spill_policy(policy.clone());
+        assert_eq!(cfg.spill_policy, policy);
+        assert!(cfg.spill_enabled());
+    }
+
+    #[test]
+    #[allow(deprecated)]
+    fn deprecated_accessors_forward_to_policy() {
+        let dir = PathBuf::from("/tmp/oc-rsync-spill-legacy");
+        let cfg = ConcurrentDeltaConfig::with_spill_threshold(2048).with_spill_dir(dir.clone());
+        assert_eq!(cfg.spill_threshold_bytes(), Some(2048));
+        assert_eq!(cfg.spill_dir(), Some(dir.as_path()));
     }
 }

--- a/crates/engine/src/concurrent_delta/consumer.rs
+++ b/crates/engine/src/concurrent_delta/consumer.rs
@@ -196,8 +196,8 @@ impl DeltaConsumer {
     /// Spawns background threads honouring a runtime
     /// [`ConcurrentDeltaConfig`].
     ///
-    /// When `cfg.spill_threshold_bytes` is `Some`, the reorder thread is
-    /// backed by a [`SpillableReorderBuffer`] instead of the bare ring
+    /// When `cfg.spill_policy.threshold_bytes` is `Some`, the reorder thread
+    /// is backed by a [`SpillableReorderBuffer`] instead of the bare ring
     /// buffer. Items past the in-memory byte threshold spill to a tempfile;
     /// they are reloaded transparently as the delivery cursor reaches them.
     /// When the threshold is `None`, behaviour matches [`spawn`](Self::spawn).
@@ -215,11 +215,11 @@ impl DeltaConsumer {
         reorder_capacity: usize,
         cfg: ConcurrentDeltaConfig,
     ) -> Self {
-        let mode = match cfg.spill_threshold_bytes {
+        let mode = match cfg.spill_policy.threshold_bytes {
             Some(threshold) => ReorderMode::Spillable {
                 capacity: reorder_capacity,
                 threshold: usize::try_from(threshold).unwrap_or(usize::MAX),
-                dir: cfg.spill_dir,
+                dir: cfg.spill_policy.dir,
             },
             None => ReorderMode::Bare {
                 capacity: reorder_capacity,

--- a/crates/engine/src/concurrent_delta/mod.rs
+++ b/crates/engine/src/concurrent_delta/mod.rs
@@ -188,6 +188,7 @@ pub use consumer::{DeltaConsumer, DeltaConsumerStats};
 #[cfg(feature = "parallel-receive-delta")]
 pub use parallel_apply::{DeltaChunk, ParallelDeltaApplier};
 pub use reorder::{HistogramStats, Metrics as ReorderMetrics, ReorderBuffer};
+pub use spill::policy::{ReclaimMode, SpillCompression, SpillGranularity, SpillPolicy};
 pub use spill::{SpillCodec, SpillError, SpillStats, SpillableReorderBuffer};
 pub use strategy::{DeltaStrategy, DeltaTransferStrategy, WholeFileStrategy};
 pub use types::{DeltaResult, DeltaResultStatus, DeltaWork, DeltaWorkKind, FileNdx};

--- a/crates/engine/src/concurrent_delta/spill.rs
+++ b/crates/engine/src/concurrent_delta/spill.rs
@@ -54,6 +54,9 @@ use std::path::{Path, PathBuf};
 
 use super::reorder::{CapacityExceeded, ReorderBuffer};
 
+pub mod policy;
+pub use policy::{ReclaimMode, SpillCompression, SpillGranularity, SpillPolicy};
+
 /// Default memory threshold (in bytes) before spilling begins.
 ///
 /// Set to 64 MB, which accommodates roughly 64K items of 1 KB each.

--- a/crates/engine/src/concurrent_delta/spill/policy.rs
+++ b/crates/engine/src/concurrent_delta/spill/policy.rs
@@ -1,0 +1,217 @@
+//! Public policy types that configure the reorder buffer spill layer.
+//!
+//! [`SpillPolicy`] groups every knob that tunes the
+//! [`SpillableReorderBuffer`](super::SpillableReorderBuffer) into a single
+//! value: the byte threshold, the on-disk scratch directory, the post-spill
+//! reclaim behaviour, the spill granularity, and the optional payload
+//! compression. The default value disables spilling entirely, mirroring the
+//! historical bare [`ReorderBuffer`](super::super::reorder::ReorderBuffer)
+//! path so existing call sites keep their behaviour.
+//!
+//! The variants of [`ReclaimMode`], [`SpillGranularity`], and
+//! [`SpillCompression`] are deliberately additive: today only the defaults
+//! are wired through the consumer pipeline, and the alternatives reserve
+//! syntactic room for follow-up work without forcing another public API
+//! break. Tests below pin the defaults so downstream crates can rely on the
+//! contract.
+
+use std::path::PathBuf;
+
+/// What to do when memory pressure subsides after a spill event.
+///
+/// The default - [`ReclaimMode::KeepInMemory`] - matches the historical
+/// "spill once, never re-spill" behaviour: once items are reloaded from
+/// disk they remain in memory even if pressure returns. The alternative,
+/// [`ReclaimMode::ReSpillIfPressureContinues`], allows the buffer to push
+/// items back to disk on subsequent pressure events at the cost of extra
+/// disk traffic during sustained bursts.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
+pub enum ReclaimMode {
+    /// Reloaded items stay resident in memory for the rest of the transfer.
+    #[default]
+    KeepInMemory,
+    /// Reloaded items may be spilled back to disk on subsequent pressure.
+    ReSpillIfPressureContinues,
+}
+
+/// Granularity of a single spill event.
+///
+/// [`SpillGranularity::WholeBatch`] (the default) writes a contiguous run
+/// of reorder slots in one disk operation, matching the current
+/// [`SpillableReorderBuffer`](super::SpillableReorderBuffer) behaviour.
+/// [`SpillGranularity::PerItem`] reserves room for a per-record spill
+/// strategy that trades batch efficiency for finer eviction control.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
+pub enum SpillGranularity {
+    /// Spill a contiguous batch of items per disk operation.
+    #[default]
+    WholeBatch,
+    /// Spill individual items as the budget is exceeded.
+    PerItem,
+}
+
+/// Optional compression applied to spilled payloads.
+///
+/// [`SpillCompression::None`] (the default) writes raw encoded bytes, which
+/// is what the existing on-disk format uses. [`SpillCompression::Zstd`] is
+/// only constructable behind the `spill-compression` feature; this keeps
+/// the default builds free of the codec dependency while leaving the enum
+/// extensible.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
+pub enum SpillCompression {
+    /// Do not compress spilled payloads.
+    #[default]
+    None,
+    /// Compress spilled payloads with zstd at the given level.
+    ///
+    /// Constructable only when the `spill-compression` feature is enabled.
+    #[cfg(feature = "spill-compression")]
+    Zstd {
+        /// zstd compression level forwarded to the codec.
+        level: i32,
+    },
+}
+
+/// Aggregate of every public spill knob for [`ConcurrentDeltaConfig`].
+///
+/// [`SpillPolicy::default`] disables spilling (`threshold_bytes: None`) so
+/// the consumer keeps its bare [`ReorderBuffer`](super::super::reorder::ReorderBuffer)
+/// path. Set [`threshold_bytes`](Self::threshold_bytes) to opt in; the
+/// other fields layer in policy adjustments on top.
+///
+/// [`ConcurrentDeltaConfig`]: super::super::config::ConcurrentDeltaConfig
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SpillPolicy {
+    /// Memory budget (in bytes) before the spill layer engages.
+    ///
+    /// `None` disables spilling and the consumer uses the bare ring buffer.
+    pub threshold_bytes: Option<u64>,
+    /// Explicit on-disk scratch directory for spilled items.
+    ///
+    /// `None` uses the default `SpooledTempFile` backend, which keeps spills
+    /// in memory up to 1 MB before rolling over to a system tempfile.
+    pub dir: Option<PathBuf>,
+    /// Behaviour after a spill event when pressure subsides.
+    pub reclaim_mode: ReclaimMode,
+    /// Per-spill-event granularity.
+    pub granularity: SpillGranularity,
+    /// Optional payload compression for spilled bytes.
+    pub compression: SpillCompression,
+}
+
+impl SpillPolicy {
+    /// Returns a policy with spilling disabled. Equivalent to [`Self::default`].
+    #[must_use]
+    pub fn off() -> Self {
+        Self::default()
+    }
+
+    /// Returns a policy that engages the spill layer at the given byte budget.
+    ///
+    /// All other knobs use their defaults; chain the `with_*` builders to
+    /// override individual fields.
+    #[must_use]
+    pub fn with_threshold(threshold_bytes: u64) -> Self {
+        Self {
+            threshold_bytes: Some(threshold_bytes),
+            ..Self::default()
+        }
+    }
+
+    /// Sets the explicit on-disk scratch directory.
+    #[must_use]
+    pub fn with_dir(mut self, dir: PathBuf) -> Self {
+        self.dir = Some(dir);
+        self
+    }
+
+    /// Overrides the post-spill reclaim behaviour.
+    #[must_use]
+    pub fn with_reclaim_mode(mut self, mode: ReclaimMode) -> Self {
+        self.reclaim_mode = mode;
+        self
+    }
+
+    /// Overrides the per-spill-event granularity.
+    #[must_use]
+    pub fn with_granularity(mut self, granularity: SpillGranularity) -> Self {
+        self.granularity = granularity;
+        self
+    }
+
+    /// Overrides the spill-payload compression codec.
+    #[must_use]
+    pub fn with_compression(mut self, compression: SpillCompression) -> Self {
+        self.compression = compression;
+        self
+    }
+
+    /// Returns `true` when the spill layer is configured to engage.
+    #[must_use]
+    pub const fn is_enabled(&self) -> bool {
+        self.threshold_bytes.is_some()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_disables_spill() {
+        let policy = SpillPolicy::default();
+        assert!(!policy.is_enabled());
+        assert!(policy.threshold_bytes.is_none());
+        assert!(policy.dir.is_none());
+        assert_eq!(policy.reclaim_mode, ReclaimMode::KeepInMemory);
+        assert_eq!(policy.granularity, SpillGranularity::WholeBatch);
+        assert_eq!(policy.compression, SpillCompression::None);
+    }
+
+    #[test]
+    fn off_matches_default() {
+        assert_eq!(SpillPolicy::off(), SpillPolicy::default());
+    }
+
+    #[test]
+    fn enum_defaults_are_pinned() {
+        assert_eq!(ReclaimMode::default(), ReclaimMode::KeepInMemory);
+        assert_eq!(SpillGranularity::default(), SpillGranularity::WholeBatch);
+        assert_eq!(SpillCompression::default(), SpillCompression::None);
+    }
+
+    #[test]
+    fn with_threshold_enables_spill() {
+        let policy = SpillPolicy::with_threshold(64 * 1024);
+        assert!(policy.is_enabled());
+        assert_eq!(policy.threshold_bytes, Some(64 * 1024));
+        assert!(policy.dir.is_none());
+    }
+
+    #[test]
+    fn builder_chain_sets_every_field() {
+        let dir = PathBuf::from("/tmp/oc-rsync-spill");
+        let policy = SpillPolicy::with_threshold(2048)
+            .with_dir(dir.clone())
+            .with_reclaim_mode(ReclaimMode::ReSpillIfPressureContinues)
+            .with_granularity(SpillGranularity::PerItem);
+        assert_eq!(policy.threshold_bytes, Some(2048));
+        assert_eq!(policy.dir.as_deref(), Some(dir.as_path()));
+        assert_eq!(policy.reclaim_mode, ReclaimMode::ReSpillIfPressureContinues);
+        assert_eq!(policy.granularity, SpillGranularity::PerItem);
+        assert_eq!(policy.compression, SpillCompression::None);
+    }
+
+    #[test]
+    fn with_compression_overrides_default() {
+        let policy = SpillPolicy::with_threshold(1024).with_compression(SpillCompression::None);
+        assert_eq!(policy.compression, SpillCompression::None);
+    }
+
+    #[test]
+    fn policies_are_value_equal() {
+        let a = SpillPolicy::with_threshold(4096).with_granularity(SpillGranularity::PerItem);
+        let b = SpillPolicy::with_threshold(4096).with_granularity(SpillGranularity::PerItem);
+        assert_eq!(a, b);
+    }
+}

--- a/crates/engine/src/delete/context.rs
+++ b/crates/engine/src/delete/context.rs
@@ -245,9 +245,10 @@ impl DeleteContext {
     ///
     /// # Panics
     ///
-    /// Panics if the cursor mutex is poisoned. A poisoned mutex
-    /// indicates an unrecoverable bug in the emitter side and is
-    /// treated the same way the plan map treats poisoned state.
+    /// Panics if the cursor mutex is poisoned. The cursor's stack ordering
+    /// is the upstream parent-before-child emission invariant; a torn
+    /// state would silently mis-order deletes, so propagation is the only
+    /// safe option (see `docs/audits/mutex-poison-policy.md`).
     pub fn observe_segment_for_delete(&self, dir: &Path, entries: &[FileEntry]) -> io::Result<()> {
         if !self.enabled {
             return Ok(());
@@ -271,6 +272,13 @@ impl DeleteContext {
     /// emitter sees parents before children. Callers invoke this whenever
     /// a directory's contents become known via an inline directory walk
     /// in the non-INC_RECURSE path.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the cursor mutex is poisoned. The cursor's stack ordering
+    /// is the upstream parent-before-child emission invariant; a torn
+    /// state would silently mis-order deletes, so propagating the panic is
+    /// the only safe option (see `docs/audits/mutex-poison-policy.md`).
     pub fn observe_directory(&self, parent: PathBuf, children: &[FileEntry]) {
         self.cursor
             .lock()
@@ -285,6 +293,14 @@ impl DeleteContext {
     /// Used by the per-dir wiring in the recursive executor: the planner
     /// has already iterated the source directory; we feed those names
     /// here instead of asking the receiver for them.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the segment-entries mutex is poisoned. The buffer is
+    /// overwritten in place; continuing with a half-written segment would
+    /// compute extras against a stale name list and unlink the wrong
+    /// files, so propagation is mandatory (see
+    /// `docs/audits/mutex-poison-policy.md`).
     pub fn begin_directory(&self, segment_entries: Vec<FileEntry>) {
         *self
             .segment_entries
@@ -301,6 +317,14 @@ impl DeleteContext {
     /// Surfaces any [`io::Error`] from [`compute_extras`] (typically
     /// `NotFound` when `dir` does not exist at the destination; callers
     /// log and skip in that case).
+    ///
+    /// # Panics
+    ///
+    /// Panics if the segment-entries mutex is poisoned. A panic mid-clone
+    /// could leave the previous segment partially overwritten by an
+    /// in-flight [`Self::begin_directory`] call; the strict policy keeps
+    /// the wrong-file unlink risk out of the drain path (see
+    /// `docs/audits/mutex-poison-policy.md`).
     pub fn publish_plan_for(&self, dir: &Path) -> io::Result<()> {
         let entries = self
             .segment_entries
@@ -472,7 +496,7 @@ mod tests {
             .expect("disabled is a no-op");
 
         assert!(map.is_empty());
-        let mut cursor = ctx.cursor.lock().unwrap();
+        let mut cursor = ctx.cursor.lock().expect("test cursor poisoned");
         // Even with no observations, the root is still emitted, and the
         // second call drains the now-empty stack and reports exhaustion.
         assert_eq!(cursor.next_ready(), Some(PathBuf::new()));
@@ -507,7 +531,7 @@ mod tests {
         let names: Vec<&OsStr> = plan.extras.iter().map(|e| e.name.as_os_str()).collect();
         assert_eq!(names, vec![OsStr::new("d"), OsStr::new("b")]);
 
-        let mut cursor = ctx.cursor.lock().unwrap();
+        let mut cursor = ctx.cursor.lock().expect("test cursor poisoned");
         let seq: Vec<PathBuf> = std::iter::from_fn(|| cursor.next_ready()).collect();
         assert!(seq.contains(&PathBuf::from("sub/nested")));
     }
@@ -565,7 +589,7 @@ mod tests {
             true,
         );
 
-        let mut cursor = ctx.cursor.lock().unwrap();
+        let mut cursor = ctx.cursor.lock().expect("test cursor poisoned");
         assert_eq!(cursor.next_ready(), Some(PathBuf::from("from_here")));
     }
 

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -134,6 +134,7 @@ pub mod delta;
 pub mod error;
 pub mod hardlink;
 pub mod local_copy;
+pub mod util;
 pub mod walk;
 
 #[doc(hidden)]
@@ -233,6 +234,10 @@ pub use signature::{
 
 /// Directory traversal abstractions for file list generation.
 pub use walk::{DirectoryWalker, FilteredWalker, WalkConfig, WalkEntry, WalkError, WalkdirWalker};
+
+/// Poison-tolerant lock acquisition helpers for `Mutex`/`RwLock` state that
+/// remains valid after a panicking thread is unwound.
+pub use util::poison::{lock_or_recover, read_or_recover, write_or_recover};
 
 /// Async I/O operations (available with `async` feature).
 #[cfg(feature = "async")]

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -187,7 +187,8 @@ pub use delta::{
 pub use concurrent_delta::{
     AdaptiveCapacityPolicy, ConcurrentDeltaConfig, DeltaConsumerStats, DeltaResult,
     DeltaResultStatus, DeltaStrategy, DeltaTransferStrategy, DeltaWork, DeltaWorkKind, FileNdx,
-    ReorderBuffer, ReorderStats, WholeFileStrategy,
+    ReclaimMode, ReorderBuffer, ReorderStats, SpillCompression, SpillGranularity, SpillPolicy,
+    WholeFileStrategy,
 };
 
 /// Common error types for engine operations.

--- a/crates/engine/src/util/mod.rs
+++ b/crates/engine/src/util/mod.rs
@@ -1,0 +1,7 @@
+//! Internal utilities shared across engine submodules.
+//!
+//! Currently exposes [`poison`] for recovering from lock poisoning on
+//! synchronization primitives whose protected state remains valid after a
+//! panic.
+
+pub mod poison;

--- a/crates/engine/src/util/poison.rs
+++ b/crates/engine/src/util/poison.rs
@@ -1,0 +1,150 @@
+//! Poison-tolerant lock acquisition helpers.
+//!
+//! [`std::sync::Mutex`] and [`std::sync::RwLock`] poison their inner state when
+//! the thread holding the guard panics. The default reaction (`.unwrap()` or
+//! `.expect(...)`) propagates that panic to every subsequent waiter, often
+//! turning a single-thread bug into a worker-pool-wide cascade.
+//!
+//! For state that remains structurally valid after a panic - bounded buffers,
+//! event recorders, counters, append-only queues - recovery via
+//! [`std::sync::PoisonError::into_inner`] is preferable to aborting the
+//! workers. The helpers below encapsulate that pattern so call sites stay
+//! short and consistent.
+//!
+//! # When to use these helpers
+//!
+//! - The protected state is monotonic or otherwise self-consistent regardless
+//!   of where the previous panic occurred (counters, ring buffers, queues,
+//!   log sinks).
+//! - Continuing the transfer is preferable to aborting the worker pool.
+//!
+//! # When NOT to use these helpers
+//!
+//! - The protected invariants depend on a multi-step update that the panic
+//!   may have interrupted halfway (e.g. partially mutated index structures
+//!   where one field has been updated but another has not). Let the panic
+//!   propagate so the bug surfaces immediately.
+//! - The lock guards external resources (file descriptors, network sockets)
+//!   whose state cannot be reasoned about after an unwind.
+//!
+//! In doubt, prefer propagation. Silent recovery hides bugs.
+
+use std::sync::{Mutex, MutexGuard, RwLock, RwLockReadGuard, RwLockWriteGuard};
+
+/// Acquire a [`Mutex`] guard, recovering the inner value if the lock is
+/// poisoned.
+///
+/// Use only when the protected state is known to remain valid across a panic;
+/// see the module documentation for guidance.
+#[inline]
+pub fn lock_or_recover<T>(m: &Mutex<T>) -> MutexGuard<'_, T> {
+    m.lock().unwrap_or_else(|e| e.into_inner())
+}
+
+/// Acquire an [`RwLock`] read guard, recovering the inner value if the lock
+/// is poisoned.
+///
+/// Use only when the protected state is known to remain valid across a panic;
+/// see the module documentation for guidance.
+#[inline]
+pub fn read_or_recover<T>(rw: &RwLock<T>) -> RwLockReadGuard<'_, T> {
+    rw.read().unwrap_or_else(|e| e.into_inner())
+}
+
+/// Acquire an [`RwLock`] write guard, recovering the inner value if the lock
+/// is poisoned.
+///
+/// Use only when the protected state is known to remain valid across a panic;
+/// see the module documentation for guidance.
+#[inline]
+pub fn write_or_recover<T>(rw: &RwLock<T>) -> RwLockWriteGuard<'_, T> {
+    rw.write().unwrap_or_else(|e| e.into_inner())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::panic::{AssertUnwindSafe, catch_unwind};
+    use std::sync::Arc;
+    use std::thread;
+
+    fn poison_mutex(m: &Arc<Mutex<Vec<u32>>>) {
+        let clone = Arc::clone(m);
+        let handle = thread::spawn(move || {
+            let mut guard = clone.lock().expect("mutex acquired pre-panic");
+            guard.push(7);
+            panic!("intentional poison");
+        });
+        let _ = handle.join();
+        assert!(m.is_poisoned(), "mutex should be poisoned after panic");
+    }
+
+    fn poison_rwlock(rw: &Arc<RwLock<Vec<u32>>>) {
+        let clone = Arc::clone(rw);
+        let handle = thread::spawn(move || {
+            let mut guard = clone.write().expect("rwlock acquired pre-panic");
+            guard.push(11);
+            panic!("intentional poison");
+        });
+        let _ = handle.join();
+        assert!(rw.is_poisoned(), "rwlock should be poisoned after panic");
+    }
+
+    #[test]
+    fn lock_or_recover_returns_guard_when_poisoned() {
+        let m = Arc::new(Mutex::new(vec![1, 2, 3]));
+        poison_mutex(&m);
+
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            let mut guard = lock_or_recover(&m);
+            guard.push(4);
+            guard.clone()
+        }));
+
+        let recovered = result.expect("helper must not panic on poisoned mutex");
+        assert_eq!(recovered, vec![1, 2, 3, 7, 4]);
+    }
+
+    #[test]
+    fn lock_or_recover_works_on_healthy_mutex() {
+        let m = Mutex::new(0_u32);
+        *lock_or_recover(&m) += 5;
+        assert_eq!(*lock_or_recover(&m), 5);
+    }
+
+    #[test]
+    fn read_or_recover_returns_guard_when_poisoned() {
+        let rw = Arc::new(RwLock::new(vec![10_u32]));
+        poison_rwlock(&rw);
+
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            let guard = read_or_recover(&rw);
+            guard.clone()
+        }));
+
+        let recovered = result.expect("helper must not panic on poisoned rwlock");
+        assert_eq!(recovered, vec![10, 11]);
+    }
+
+    #[test]
+    fn write_or_recover_returns_guard_when_poisoned() {
+        let rw = Arc::new(RwLock::new(vec![20_u32]));
+        poison_rwlock(&rw);
+
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            let mut guard = write_or_recover(&rw);
+            guard.push(30);
+            guard.clone()
+        }));
+
+        let recovered = result.expect("helper must not panic on poisoned rwlock");
+        assert_eq!(recovered, vec![20, 11, 30]);
+    }
+
+    #[test]
+    fn rwlock_helpers_work_on_healthy_lock() {
+        let rw = RwLock::new(String::from("hi"));
+        write_or_recover(&rw).push_str(" there");
+        assert_eq!(&*read_or_recover(&rw), "hi there");
+    }
+}

--- a/crates/fast_io/Cargo.toml
+++ b/crates/fast_io/Cargo.toml
@@ -17,6 +17,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 rayon = { workspace = true }
 logging = { path = "../logging" }
 thiserror = { workspace = true }
+tracing = { workspace = true }
 
 # Cached sorting with Schwartzian transform
 permutation = "0.4"

--- a/crates/fast_io/src/io_uring/buffer_ring.rs
+++ b/crates/fast_io/src/io_uring/buffer_ring.rs
@@ -61,6 +61,7 @@ use std::io;
 use std::ptr;
 use std::sync::atomic::{AtomicU16, AtomicU32, Ordering};
 use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
 
 use io_uring::IoUring as RawIoUring;
 
@@ -137,15 +138,85 @@ const BGID_NAMESPACE_SIZE: u32 = u16::MAX as u32 + 1;
 /// `BGID_NAMESPACE_SIZE` thereafter.
 static NEXT_BGID: AtomicU32 = AtomicU32::new(0);
 
+/// Process-wide high-water mark for concurrently-allocated bgids.
+///
+/// Updated via `fetch_max` after every successful
+/// [`BgidAllocator::allocate`] call. Exposed by [`bgid_peak_used`] so
+/// operators and tests can observe the worst-case occupancy of the 16-bit
+/// namespace over the process lifetime. Never decreases; deallocation
+/// returns ids to the free-list but the peak stays.
+static PEAK_USED: AtomicU16 = AtomicU16::new(0);
+
+/// Initial capacity reserved for the bgid free-list.
+///
+/// Sized to cover the typical steady-state churn of a long-running daemon
+/// recycling buffer rings without triggering `Vec` reallocations under the
+/// free-list mutex. 4 096 entries match a common upper bound on
+/// simultaneously-open buffer rings before the namespace warning fires
+/// (50 % of u16::MAX is 32 767).
+const BGID_FREE_LIST_INITIAL_CAPACITY: usize = 1 << 12;
+
+/// Occupancy threshold (in absolute bgid count) that triggers the
+/// throttled namespace-pressure warning.
+///
+/// Set to 50 % of the 16-bit namespace so operators get early notice that
+/// the process is approaching exhaustion while there is still headroom to
+/// react.
+const BGID_OCCUPANCY_WARN_THRESHOLD: u16 = (BGID_NAMESPACE_SIZE / 2) as u16;
+
+/// Minimum interval between successive namespace-pressure warnings.
+const BGID_WARN_THROTTLE: Duration = Duration::from_secs(30);
+
 /// Process-wide free-list of returned bgids available for reuse.
 ///
 /// Populated by [`BgidAllocator::deallocate`] when a [`BufferRing`] that
 /// was issued a bgid by [`BgidAllocator::allocate`] is dropped. Drained by
 /// [`BgidAllocator::allocate`] before incrementing [`NEXT_BGID`], so the
 /// monotonic counter only advances when no reusable id is available.
+///
+/// Pre-sized to `BGID_FREE_LIST_INITIAL_CAPACITY` so the steady-state
+/// churn of a long-running daemon does not trigger `Vec` reallocations
+/// under the free-list mutex.
 fn bgid_free_list() -> &'static Mutex<Vec<u16>> {
     static FREE_LIST: OnceLock<Mutex<Vec<u16>>> = OnceLock::new();
-    FREE_LIST.get_or_init(|| Mutex::new(Vec::new()))
+    FREE_LIST.get_or_init(|| Mutex::new(Vec::with_capacity(BGID_FREE_LIST_INITIAL_CAPACITY)))
+}
+
+/// Last time the namespace-pressure warning was emitted.
+///
+/// `None` means "never emitted". Updated under the mutex so two threads
+/// observing > 50 % occupancy simultaneously do not both emit a warning.
+fn bgid_warn_last() -> &'static Mutex<Option<Instant>> {
+    static LAST: OnceLock<Mutex<Option<Instant>>> = OnceLock::new();
+    LAST.get_or_init(|| Mutex::new(None))
+}
+
+/// Emits a throttled `tracing::warn!` when bgid occupancy crosses 50 %.
+///
+/// The warning fires at most once per `BGID_WARN_THROTTLE` window so a
+/// hot allocation path under sustained pressure does not flood the log.
+fn maybe_warn_namespace_pressure(in_flight: u16) {
+    if in_flight < BGID_OCCUPANCY_WARN_THRESHOLD {
+        return;
+    }
+    let mut last = match bgid_warn_last().lock() {
+        Ok(g) => g,
+        Err(p) => p.into_inner(),
+    };
+    let now = Instant::now();
+    let fire = match *last {
+        None => true,
+        Some(t) => now.duration_since(t) >= BGID_WARN_THROTTLE,
+    };
+    if fire {
+        *last = Some(now);
+        tracing::warn!(
+            target: "fast_io::buffer_ring",
+            in_flight,
+            namespace = BGID_NAMESPACE_SIZE,
+            "io_uring bgid occupancy crossed 50% of the 16-bit namespace"
+        );
+    }
 }
 
 /// Allocator for io_uring buffer group IDs (bgid).
@@ -194,11 +265,12 @@ impl BgidAllocator {
         // Reuse a freed id when one is available. The lock is held only for
         // the pop, so contention with concurrent deallocate calls is
         // negligible in practice (one buffer ring per long-running task).
-        if let Some(id) = bgid_free_list()
+        let popped = bgid_free_list()
             .lock()
             .expect("bgid free-list poisoned")
-            .pop()
-        {
+            .pop();
+        if let Some(id) = popped {
+            record_allocation();
             return Ok(id);
         }
 
@@ -207,6 +279,7 @@ impl BgidAllocator {
         // depend on this value being observed in a particular order.
         let id = NEXT_BGID.fetch_add(1, Ordering::Relaxed);
         if id < BGID_NAMESPACE_SIZE {
+            record_allocation();
             Ok(id as u16)
         } else {
             // Cap the counter at BGID_NAMESPACE_SIZE rather than letting it
@@ -264,6 +337,56 @@ impl BgidAllocator {
             .len() as u32;
         BGID_NAMESPACE_SIZE - used + free
     }
+}
+
+/// Updates `PEAK_USED` and fires the throttled namespace-pressure
+/// warning when in-flight occupancy crosses `BGID_OCCUPANCY_WARN_THRESHOLD`.
+///
+/// Called once per successful [`BgidAllocator::allocate`] return so the
+/// high-water mark reflects every issued id, whether the slot came from
+/// the free-list or from advancing the monotonic counter.
+fn record_allocation() {
+    let in_flight = current_in_flight();
+    PEAK_USED.fetch_max(in_flight, Ordering::Relaxed);
+    maybe_warn_namespace_pressure(in_flight);
+}
+
+/// Computes the current number of allocator-issued bgids that have not
+/// been returned to the free-list.
+///
+/// Saturates at `u16::MAX` so the result always fits in `u16`. The
+/// snapshot is best-effort: under concurrent allocate/deallocate the
+/// counter and free-list reads are not atomic together, but the value
+/// never overstates occupancy because both inputs are observed under the
+/// same monotonic discipline.
+fn current_in_flight() -> u16 {
+    let issued = NEXT_BGID.load(Ordering::Relaxed).min(BGID_NAMESPACE_SIZE);
+    let free = bgid_free_list()
+        .lock()
+        .expect("bgid free-list poisoned")
+        .len() as u32;
+    issued.saturating_sub(free).min(u16::MAX as u32) as u16
+}
+
+/// Returns the high-water mark for concurrently-allocated bgids since
+/// process start.
+///
+/// Monotonic: deallocation never lowers this value. Reflects the worst
+/// observed pressure on the 16-bit bgid namespace and is intended for
+/// operational dashboards and capacity-planning tests.
+#[must_use]
+pub fn bgid_peak_used() -> u16 {
+    PEAK_USED.load(Ordering::Relaxed)
+}
+
+/// Returns the current count of allocator-issued bgids not yet returned
+/// to the free-list.
+///
+/// Saturates at `u16::MAX`. Intended for ad-hoc diagnostics; the value
+/// can change between the read and the next allocate/deallocate call.
+#[must_use]
+pub fn bgid_inflight() -> u16 {
+    current_in_flight()
 }
 
 /// Process-wide cache for the PBUF_RING support probe.
@@ -1090,6 +1213,7 @@ mod tests {
     struct BgidStateGuard {
         prev_counter: u32,
         prev_free_list: Vec<u16>,
+        prev_peak: u16,
         _serializer: std::sync::MutexGuard<'static, ()>,
     }
 
@@ -1097,6 +1221,7 @@ mod tests {
         fn snapshot() -> Self {
             let serializer = bgid_test_lock();
             let prev_counter = NEXT_BGID.swap(0, Ordering::Relaxed);
+            let prev_peak = PEAK_USED.swap(0, Ordering::Relaxed);
             let prev_free_list = {
                 let mut list = bgid_free_list().lock().expect("free-list poisoned");
                 std::mem::take(&mut *list)
@@ -1104,6 +1229,7 @@ mod tests {
             Self {
                 prev_counter,
                 prev_free_list,
+                prev_peak,
                 _serializer: serializer,
             }
         }
@@ -1112,6 +1238,7 @@ mod tests {
     impl Drop for BgidStateGuard {
         fn drop(&mut self) {
             NEXT_BGID.store(self.prev_counter, Ordering::Relaxed);
+            PEAK_USED.store(self.prev_peak, Ordering::Relaxed);
             let mut list = bgid_free_list().lock().expect("free-list poisoned");
             *list = std::mem::take(&mut self.prev_free_list);
         }
@@ -1218,6 +1345,81 @@ mod tests {
         assert_eq!(
             list_len, 1,
             "duplicate deallocate must not push the same bgid twice"
+        );
+    }
+
+    #[test]
+    fn bgid_peak_tracks_100_allocations() {
+        let _guard = BgidStateGuard::snapshot();
+        assert_eq!(bgid_peak_used(), 0);
+        for _ in 0..100 {
+            BgidAllocator::allocate().expect("allocation within namespace");
+        }
+        assert_eq!(
+            bgid_peak_used(),
+            100,
+            "peak must reflect the 100 outstanding allocations"
+        );
+        assert_eq!(bgid_inflight(), 100);
+    }
+
+    #[test]
+    fn bgid_peak_does_not_decrease_on_deallocate() {
+        let _guard = BgidStateGuard::snapshot();
+        let mut ids = Vec::with_capacity(50);
+        for _ in 0..50 {
+            ids.push(BgidAllocator::allocate().expect("allocation within namespace"));
+        }
+        assert_eq!(bgid_peak_used(), 50);
+        assert_eq!(bgid_inflight(), 50);
+
+        for id in ids {
+            BgidAllocator::deallocate(id);
+        }
+        assert_eq!(
+            bgid_peak_used(),
+            50,
+            "peak must not decrease after returning ids to the free-list"
+        );
+        assert_eq!(bgid_inflight(), 0, "all ids returned, none in flight");
+
+        // Reallocating from the free-list still updates the peak path but
+        // never lifts it above the previous high-water mark.
+        let _ = BgidAllocator::allocate().expect("reallocation from free-list");
+        assert_eq!(bgid_peak_used(), 50);
+    }
+
+    #[test]
+    fn bgid_free_list_is_pre_sized() {
+        let _guard = BgidStateGuard::snapshot();
+        let cap = bgid_free_list()
+            .lock()
+            .expect("free-list poisoned")
+            .capacity();
+        assert!(
+            cap >= BGID_FREE_LIST_INITIAL_CAPACITY,
+            "free-list pre-sized capacity {cap} must be >= {BGID_FREE_LIST_INITIAL_CAPACITY}"
+        );
+    }
+
+    #[test]
+    fn bgid_inflight_reflects_counter_minus_free_list() {
+        let _guard = BgidStateGuard::snapshot();
+        let a = BgidAllocator::allocate().expect("first");
+        let b = BgidAllocator::allocate().expect("second");
+        let _c = BgidAllocator::allocate().expect("third");
+        assert_eq!(bgid_inflight(), 3);
+
+        BgidAllocator::deallocate(a);
+        BgidAllocator::deallocate(b);
+        assert_eq!(bgid_inflight(), 1);
+    }
+
+    #[test]
+    fn bgid_warn_threshold_is_half_namespace() {
+        assert_eq!(
+            BGID_OCCUPANCY_WARN_THRESHOLD,
+            (BGID_NAMESPACE_SIZE / 2) as u16
         );
     }
 }

--- a/crates/fast_io/src/io_uring/mod.rs
+++ b/crates/fast_io/src/io_uring/mod.rs
@@ -112,8 +112,8 @@ use std::io::{self, Write};
 use std::os::unix::io::AsRawFd;
 
 pub use buffer_ring::{
-    BgidAllocator, BufferRing, BufferRingConfig, BufferRingError, buffer_id_from_cqe_flags,
-    pbuf_ring_supported,
+    BgidAllocator, BufferRing, BufferRingConfig, BufferRingError, bgid_inflight, bgid_peak_used,
+    buffer_id_from_cqe_flags, pbuf_ring_supported,
 };
 pub use cancel::{
     ASYNC_CANCEL_FD_MIN_KERNEL, ASYNC_CANCEL_MIN_KERNEL, CancelOutcome, IORING_OP_ASYNC_CANCEL,

--- a/crates/fast_io/src/io_uring_stub/buffer_ring.rs
+++ b/crates/fast_io/src/io_uring_stub/buffer_ring.rs
@@ -113,3 +113,21 @@ impl BgidAllocator {
         0
     }
 }
+
+/// Returns 0 on non-Linux platforms; no bgids are ever issued here.
+///
+/// Mirrors the Linux accessor so cross-platform callers and metrics
+/// exporters compile without `cfg`-gating.
+#[must_use]
+pub fn bgid_peak_used() -> u16 {
+    0
+}
+
+/// Returns 0 on non-Linux platforms; no bgids are ever issued here.
+///
+/// Mirrors the Linux accessor so cross-platform callers and metrics
+/// exporters compile without `cfg`-gating.
+#[must_use]
+pub fn bgid_inflight() -> u16 {
+    0
+}

--- a/crates/fast_io/src/io_uring_stub/mod.rs
+++ b/crates/fast_io/src/io_uring_stub/mod.rs
@@ -52,7 +52,9 @@ pub use crate::io_uring_common::{
     SharedCompletion, SharedRingConfig, buffer_id_from_cqe_flags,
 };
 
-pub use buffer_ring::{BgidAllocator, BufferRing, pbuf_ring_supported};
+pub use buffer_ring::{
+    BgidAllocator, BufferRing, bgid_inflight, bgid_peak_used, pbuf_ring_supported,
+};
 pub use cancel::{CancelOutcome, cancel_all_by_fd, cancel_by_user_data};
 pub use config::{StubIoUringBackend, config_detail, is_io_uring_available, sqpoll_fell_back};
 pub use disk_batch::IoUringDiskBatch;

--- a/crates/fast_io/src/iocp/config.rs
+++ b/crates/fast_io/src/iocp/config.rs
@@ -22,11 +22,56 @@ static SKIP_EVENT_AVAILABLE: AtomicBool = AtomicBool::new(false);
 /// setup overhead exceeds the async benefit for tiny files.
 pub const IOCP_MIN_FILE_SIZE: u64 = 64 * 1024;
 
-/// Default number of concurrent I/O operations per completion port.
-pub const DEFAULT_CONCURRENT_OPS: u32 = 4;
+/// Lower bound for the auto-sized concurrent-ops depth.
+///
+/// Even on a single-CPU host we keep at least 8 overlapped `WriteFile`
+/// operations in flight so the IOCP drain loop is never starved by a
+/// pathological 1-deep submission window. Matches `IoUringConfig::default`
+/// behaviour where the SQ depth never falls below the default ring entries.
+pub const MIN_CONCURRENT_OPS: u32 = 8;
+
+/// Upper bound for the auto-sized concurrent-ops depth.
+///
+/// 64 matches the io_uring CQE batch sizing in
+/// `crates/fast_io/src/iocp/disk_batch.rs::COMPLETION_DRAIN_BATCH` and the
+/// initial drain size in `crates/fast_io/src/iocp/pump.rs::DEFAULT_BATCH_SIZE`.
+/// Keeping the submission window aligned with the drain batch lets a single
+/// `GetQueuedCompletionStatusEx` reap an entire in-flight cohort.
+pub const MAX_CONCURRENT_OPS: u32 = 64;
 
 /// Default I/O buffer size for IOCP operations.
 pub const DEFAULT_BUFFER_SIZE: usize = 64 * 1024;
+
+/// Auto-sizes the concurrent-ops depth from `cpus`.
+///
+/// Returns `(cpus * 4).clamp(MIN_CONCURRENT_OPS, MAX_CONCURRENT_OPS)`.
+/// Mirrors the io_uring SQ-entry derivation: 4 in-flight ops per logical
+/// core keeps every CPU fed without overwhelming the completion drain.
+#[must_use]
+pub const fn concurrent_ops_for_cpus(cpus: u32) -> u32 {
+    let raw = cpus.saturating_mul(4);
+    if raw < MIN_CONCURRENT_OPS {
+        MIN_CONCURRENT_OPS
+    } else if raw > MAX_CONCURRENT_OPS {
+        MAX_CONCURRENT_OPS
+    } else {
+        raw
+    }
+}
+
+/// Auto-sized default concurrent I/O operations per completion port.
+///
+/// Derives the value from `std::thread::available_parallelism()` so the
+/// in-flight depth scales with the host's logical CPU count. Falls back to
+/// `MIN_CONCURRENT_OPS` when parallelism detection fails.
+#[must_use]
+pub fn default_concurrent_ops() -> u32 {
+    let cpus = std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(1);
+    let cpus_u32 = u32::try_from(cpus).unwrap_or(u32::MAX);
+    concurrent_ops_for_cpus(cpus_u32)
+}
 
 /// Configuration for IOCP instances.
 #[derive(Debug, Clone)]
@@ -51,7 +96,7 @@ pub struct IocpConfig {
 impl Default for IocpConfig {
     fn default() -> Self {
         Self {
-            concurrent_ops: DEFAULT_CONCURRENT_OPS,
+            concurrent_ops: default_concurrent_ops(),
             buffer_size: DEFAULT_BUFFER_SIZE,
             unbuffered: false,
             write_through: false,
@@ -61,10 +106,14 @@ impl Default for IocpConfig {
 
 impl IocpConfig {
     /// Creates a config optimized for large file transfers.
+    ///
+    /// The concurrent-ops depth uses the CPU-derived default so wide hosts
+    /// can keep more overlapped writes in flight, matching the io_uring
+    /// large-file preset's larger SQ depth.
     #[must_use]
     pub fn for_large_files() -> Self {
         Self {
-            concurrent_ops: 8,
+            concurrent_ops: default_concurrent_ops(),
             buffer_size: 256 * 1024,
             unbuffered: false,
             write_through: false,
@@ -72,10 +121,14 @@ impl IocpConfig {
     }
 
     /// Creates a config optimized for many small files.
+    ///
+    /// The concurrent-ops depth uses the CPU-derived default; small-file
+    /// pipelines are typically syscall-bound so feeding every CPU pays off
+    /// more than a shallow fixed window.
     #[must_use]
     pub fn for_small_files() -> Self {
         Self {
-            concurrent_ops: 4,
+            concurrent_ops: default_concurrent_ops(),
             buffer_size: 16 * 1024,
             unbuffered: false,
             write_through: false,
@@ -161,7 +214,14 @@ mod tests {
     #[test]
     fn config_default_values() {
         let config = IocpConfig::default();
-        assert_eq!(config.concurrent_ops, DEFAULT_CONCURRENT_OPS);
+        assert!(
+            (MIN_CONCURRENT_OPS..=MAX_CONCURRENT_OPS).contains(&config.concurrent_ops),
+            "default concurrent_ops {} must sit inside [{}, {}]",
+            config.concurrent_ops,
+            MIN_CONCURRENT_OPS,
+            MAX_CONCURRENT_OPS,
+        );
+        assert_eq!(config.concurrent_ops, default_concurrent_ops());
         assert_eq!(config.buffer_size, DEFAULT_BUFFER_SIZE);
         assert!(!config.unbuffered);
         assert!(!config.write_through);
@@ -170,15 +230,51 @@ mod tests {
     #[test]
     fn config_large_files_preset() {
         let config = IocpConfig::for_large_files();
-        assert_eq!(config.concurrent_ops, 8);
+        assert_eq!(config.concurrent_ops, default_concurrent_ops());
         assert_eq!(config.buffer_size, 256 * 1024);
     }
 
     #[test]
     fn config_small_files_preset() {
         let config = IocpConfig::for_small_files();
-        assert_eq!(config.concurrent_ops, 4);
+        assert_eq!(config.concurrent_ops, default_concurrent_ops());
         assert_eq!(config.buffer_size, 16 * 1024);
+    }
+
+    #[test]
+    fn concurrent_ops_eight_cpu_host_yields_thirty_two() {
+        // 8 logical CPUs * 4 in-flight ops per core = 32, inside the clamp.
+        assert_eq!(concurrent_ops_for_cpus(8), 32);
+    }
+
+    #[test]
+    fn concurrent_ops_one_cpu_host_clamps_to_minimum() {
+        // 1 CPU * 4 = 4, below MIN_CONCURRENT_OPS (8) so the floor wins.
+        assert_eq!(concurrent_ops_for_cpus(1), MIN_CONCURRENT_OPS);
+        assert_eq!(concurrent_ops_for_cpus(2), MIN_CONCURRENT_OPS);
+    }
+
+    #[test]
+    fn concurrent_ops_wide_host_clamps_to_maximum() {
+        // 16 CPUs * 4 = 64, exactly the ceiling; 32 CPUs * 4 = 128, clamped.
+        assert_eq!(concurrent_ops_for_cpus(16), MAX_CONCURRENT_OPS);
+        assert_eq!(concurrent_ops_for_cpus(32), MAX_CONCURRENT_OPS);
+        assert_eq!(concurrent_ops_for_cpus(256), MAX_CONCURRENT_OPS);
+    }
+
+    #[test]
+    fn concurrent_ops_saturates_on_overflow() {
+        // u32::MAX * 4 saturates; the clamp still pins to MAX_CONCURRENT_OPS.
+        assert_eq!(concurrent_ops_for_cpus(u32::MAX), MAX_CONCURRENT_OPS);
+    }
+
+    #[test]
+    fn default_concurrent_ops_matches_detected_cpus() {
+        let cpus = std::thread::available_parallelism()
+            .map(|n| n.get())
+            .unwrap_or(1);
+        let cpus_u32 = u32::try_from(cpus).unwrap_or(u32::MAX);
+        assert_eq!(default_concurrent_ops(), concurrent_ops_for_cpus(cpus_u32));
     }
 
     #[test]

--- a/crates/fast_io/src/iocp/disk_batch.rs
+++ b/crates/fast_io/src/iocp/disk_batch.rs
@@ -65,7 +65,12 @@ const DEFAULT_BUFFER_CAPACITY: usize = 256 * 1024;
 /// Maximum entries dequeued by a single `GetQueuedCompletionStatusEx` call.
 ///
 /// Matches the io_uring side's CQE batch sizing so both backends use the
-/// same drain granularity.
+/// same drain granularity. Kept fixed (not CPU-scaled) because the disk
+/// batch drains exactly the in-flight cohort capped by
+/// `IocpConfig::concurrent_ops`, which is already auto-sized by
+/// `super::config::default_concurrent_ops`. The clamp ceiling
+/// (`super::config::MAX_CONCURRENT_OPS`) is intentionally aligned with this
+/// constant so a single drain call can reap the entire cohort.
 const COMPLETION_DRAIN_BATCH: usize = 64;
 
 /// Wait timeout for completion drains, in milliseconds. The disk batch

--- a/crates/fast_io/src/iocp/mod.rs
+++ b/crates/fast_io/src/iocp/mod.rs
@@ -39,7 +39,8 @@ pub mod socket;
 pub mod transmit_file;
 
 pub use config::{
-    IOCP_MIN_FILE_SIZE, IocpConfig, iocp_availability_reason, is_iocp_available,
+    IOCP_MIN_FILE_SIZE, IocpConfig, MAX_CONCURRENT_OPS, MIN_CONCURRENT_OPS,
+    concurrent_ops_for_cpus, default_concurrent_ops, iocp_availability_reason, is_iocp_available,
     skip_event_optimization_available,
 };
 pub use disk_batch::IocpDiskBatch;

--- a/crates/fast_io/src/iocp/pump.rs
+++ b/crates/fast_io/src/iocp/pump.rs
@@ -74,7 +74,13 @@ const SHUTDOWN_KEY: usize = usize::MAX;
 ///
 /// Larger batches amortize the syscall cost across more completions but also
 /// increase per-call latency. 64 matches the io_uring CQE batch sizing used
-/// by `crates/fast_io/src/io_uring/disk_batch.rs`.
+/// by `crates/fast_io/src/io_uring/disk_batch.rs` and the
+/// `super::config::MAX_CONCURRENT_OPS` ceiling used by the auto-sized
+/// `IocpConfig::concurrent_ops`. Kept fixed rather than CPU-scaled because
+/// the drain buffer grows on demand up to [`MAX_BATCH_SIZE`] whenever the
+/// kernel signals `ERROR_INSUFFICIENT_BUFFER` (issue #1930), so wide hosts
+/// reach a higher steady-state depth without paying a larger initial
+/// allocation per pump.
 const DEFAULT_BATCH_SIZE: usize = 64;
 
 /// Hard cap on dynamic batch growth when the drain loop encounters

--- a/crates/fast_io/src/iocp_stub.rs
+++ b/crates/fast_io/src/iocp_stub.rs
@@ -23,6 +23,45 @@ use crate::traits::{
 /// Minimum file size threshold (informational only on this platform).
 pub const IOCP_MIN_FILE_SIZE: u64 = 64 * 1024;
 
+/// Lower bound for the auto-sized concurrent-ops depth. Mirrors the Windows
+/// surface so cross-platform code can reference the constant unconditionally.
+pub const MIN_CONCURRENT_OPS: u32 = 8;
+
+/// Upper bound for the auto-sized concurrent-ops depth. Mirrors the Windows
+/// surface so cross-platform code can reference the constant unconditionally.
+pub const MAX_CONCURRENT_OPS: u32 = 64;
+
+/// Auto-sizes the concurrent-ops depth from `cpus`.
+///
+/// Returns `(cpus * 4).clamp(MIN_CONCURRENT_OPS, MAX_CONCURRENT_OPS)`,
+/// matching the Windows implementation so cross-platform tests and tools
+/// see identical values for a given CPU count.
+#[must_use]
+pub const fn concurrent_ops_for_cpus(cpus: u32) -> u32 {
+    let raw = cpus.saturating_mul(4);
+    if raw < MIN_CONCURRENT_OPS {
+        MIN_CONCURRENT_OPS
+    } else if raw > MAX_CONCURRENT_OPS {
+        MAX_CONCURRENT_OPS
+    } else {
+        raw
+    }
+}
+
+/// Auto-sized default concurrent I/O operations per completion port.
+///
+/// On non-Windows hosts the value is informational only; the stub
+/// `IocpDiskBatch` never runs. Derives from
+/// `std::thread::available_parallelism()` for parity with the Windows path.
+#[must_use]
+pub fn default_concurrent_ops() -> u32 {
+    let cpus = std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(1);
+    let cpus_u32 = u32::try_from(cpus).unwrap_or(u32::MAX);
+    concurrent_ops_for_cpus(cpus_u32)
+}
+
 /// Typed IOCP error variants.
 ///
 /// On non-Windows platforms the IOCP backend is never constructed, so this
@@ -91,7 +130,7 @@ pub struct IocpConfig {
 impl Default for IocpConfig {
     fn default() -> Self {
         Self {
-            concurrent_ops: 4,
+            concurrent_ops: default_concurrent_ops(),
             buffer_size: 64 * 1024,
             unbuffered: false,
             write_through: false,
@@ -104,7 +143,7 @@ impl IocpConfig {
     #[must_use]
     pub fn for_large_files() -> Self {
         Self {
-            concurrent_ops: 8,
+            concurrent_ops: default_concurrent_ops(),
             buffer_size: 256 * 1024,
             unbuffered: false,
             write_through: false,
@@ -115,7 +154,7 @@ impl IocpConfig {
     #[must_use]
     pub fn for_small_files() -> Self {
         Self {
-            concurrent_ops: 4,
+            concurrent_ops: default_concurrent_ops(),
             buffer_size: 16 * 1024,
             unbuffered: false,
             write_through: false,
@@ -799,8 +838,23 @@ mod tests {
     #[test]
     fn config_default_values() {
         let config = IocpConfig::default();
-        assert_eq!(config.concurrent_ops, 4);
+        assert!(
+            (MIN_CONCURRENT_OPS..=MAX_CONCURRENT_OPS).contains(&config.concurrent_ops),
+            "default concurrent_ops {} must sit inside [{}, {}]",
+            config.concurrent_ops,
+            MIN_CONCURRENT_OPS,
+            MAX_CONCURRENT_OPS,
+        );
+        assert_eq!(config.concurrent_ops, default_concurrent_ops());
         assert_eq!(config.buffer_size, 64 * 1024);
+    }
+
+    #[test]
+    fn concurrent_ops_for_cpus_matches_windows_formula() {
+        assert_eq!(concurrent_ops_for_cpus(8), 32);
+        assert_eq!(concurrent_ops_for_cpus(1), MIN_CONCURRENT_OPS);
+        assert_eq!(concurrent_ops_for_cpus(16), MAX_CONCURRENT_OPS);
+        assert_eq!(concurrent_ops_for_cpus(u32::MAX), MAX_CONCURRENT_OPS);
     }
 
     #[test]

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -205,12 +205,13 @@ pub use io_uring::{
     RENAME_WHITEOUT, RegisteredBufferGroup, RegisteredBufferSlot, RegisteredBufferStats,
     RegisteredBufferStatus, RenameAt2Args, RingLease, STATX_MIN_KERNEL, SessionPoolConfig,
     SessionRingPool, SharedCompletion, SharedRing, SharedRingConfig, StatxArgs, StatxResult,
-    ThreadLocalRingLease, ThreadLocalRingPool, buffer_id_from_cqe_flags, build_linkat_sqe,
-    build_linkat_sqe_unchecked, build_renameat2_sqe, build_renameat2_sqe_unchecked,
-    build_statx_sqe, build_statx_sqe_unchecked, is_io_uring_available, linkat_supported,
-    pbuf_ring_supported, reader_from_path, reader_from_path_with_depth, renameat2_blocking,
-    renameat2_supported, sqpoll_fell_back, statx_supported, submit_linkat_blocking,
-    submit_statx_batch, submit_statx_blocking, writer_from_file, writer_from_file_with_depth,
+    ThreadLocalRingLease, ThreadLocalRingPool, bgid_inflight, bgid_peak_used,
+    buffer_id_from_cqe_flags, build_linkat_sqe, build_linkat_sqe_unchecked, build_renameat2_sqe,
+    build_renameat2_sqe_unchecked, build_statx_sqe, build_statx_sqe_unchecked,
+    is_io_uring_available, linkat_supported, pbuf_ring_supported, reader_from_path,
+    reader_from_path_with_depth, renameat2_blocking, renameat2_supported, sqpoll_fell_back,
+    statx_supported, submit_linkat_blocking, submit_statx_batch, submit_statx_blocking,
+    writer_from_file, writer_from_file_with_depth,
 };
 
 #[cfg(all(target_os = "windows", feature = "iocp"))]

--- a/crates/metadata/src/acl_windows.rs
+++ b/crates/metadata/src/acl_windows.rs
@@ -53,13 +53,19 @@ use protocol::acl::IdaEntries;
 use protocol::acl::{AclCache, IdAccess, NO_ENTRY, RsyncAcl};
 use windows::Win32::Foundation::{ERROR_NOT_SUPPORTED, HLOCAL, LocalFree, WIN32_ERROR};
 use windows::Win32::Security::Authorization::{
-    GetNamedSecurityInfoW, SE_FILE_OBJECT, SetNamedSecurityInfoW,
+    ConvertSecurityDescriptorToStringSecurityDescriptorW,
+    ConvertStringSecurityDescriptorToSecurityDescriptorW, GetNamedSecurityInfoW, SDDL_REVISION_1,
+    SE_FILE_OBJECT, SetNamedSecurityInfoW,
 };
 use windows::Win32::Security::{
     ACCESS_ALLOWED_ACE, ACE_HEADER, ACL, ACL_REVISION, ACL_SIZE_INFORMATION, AclSizeInformation,
-    AddAccessAllowedAce, DACL_SECURITY_INFORMATION, GetAce, GetAclInformation, GetSidSubAuthority,
+    AddAccessAllowedAce, DACL_SECURITY_INFORMATION, GROUP_SECURITY_INFORMATION, GetAce,
+    GetAclInformation, GetSecurityDescriptorDacl, GetSecurityDescriptorGroup,
+    GetSecurityDescriptorOwner, GetSecurityDescriptorSacl, GetSidSubAuthority,
     GetSidSubAuthorityCount, InitializeAcl, IsValidSid, LookupAccountNameW, LookupAccountSidW,
-    PSECURITY_DESCRIPTOR, PSID, SID_NAME_USE, SidTypeAlias, SidTypeGroup, SidTypeWellKnownGroup,
+    OBJECT_SECURITY_INFORMATION, OWNER_SECURITY_INFORMATION, PROTECTED_DACL_SECURITY_INFORMATION,
+    PSECURITY_DESCRIPTOR, PSID, SACL_SECURITY_INFORMATION, SID_NAME_USE, SidTypeAlias,
+    SidTypeGroup, SidTypeWellKnownGroup,
 };
 use windows::Win32::Storage::FileSystem::{
     FILE_GENERIC_EXECUTE, FILE_GENERIC_READ, FILE_GENERIC_WRITE,
@@ -684,6 +690,285 @@ fn entries_have_names(entries: &IdaEntries) -> bool {
     entries.iter().any(|e| e.name.is_some())
 }
 
+/// Wraps a Win32-allocated `PWSTR` so it is released with [`LocalFree`]
+/// when the binding goes out of scope.
+///
+/// `ConvertSecurityDescriptorToStringSecurityDescriptorW` allocates the
+/// output string via `LocalAlloc`; callers are required to free it with
+/// `LocalFree` to avoid leaking process heap.
+struct OwnedLocalWString {
+    ptr: PWSTR,
+}
+
+impl Drop for OwnedLocalWString {
+    fn drop(&mut self) {
+        if !self.ptr.0.is_null() {
+            // SAFETY: `ptr` was allocated by
+            // `ConvertSecurityDescriptorToStringSecurityDescriptorW` and
+            // is documented to require release via `LocalFree`. We never
+            // alias it outside this struct.
+            unsafe {
+                let _ = LocalFree(Some(HLOCAL(self.ptr.0.cast())));
+            }
+        }
+    }
+}
+
+/// Computes the security-information mask used by SDDL round-trip helpers.
+///
+/// Always includes DACL, owner, and group; includes SACL when the caller
+/// opts in. SACL access requires `SE_SECURITY_NAME`, so the default keeps
+/// it disabled to match the conservative posture of [`read_dacl`].
+fn sddl_security_info(include_sacl: bool) -> OBJECT_SECURITY_INFORMATION {
+    let mut info =
+        OWNER_SECURITY_INFORMATION | GROUP_SECURITY_INFORMATION | DACL_SECURITY_INFORMATION;
+    if include_sacl {
+        info |= SACL_SECURITY_INFORMATION;
+    }
+    info
+}
+
+/// Reads the security descriptor at `path` and returns it serialised as
+/// an SDDL string.
+///
+/// The descriptor includes owner, group, and DACL components. SACL data
+/// is not requested because it would require `SE_SECURITY_NAME`, which
+/// standard accounts lack. To round-trip SACL entries, use
+/// [`write_dacl_sddl`] with an SDDL payload that includes them; the OS
+/// applies them only if the calling token holds the privilege.
+///
+/// # Errors
+///
+/// Returns [`io::Error`] for Win32 failures. Filesystems that do not
+/// support security descriptors (FAT32, network mounts) propagate the
+/// underlying error.
+///
+/// # Upstream Reference
+///
+/// `GetNamedSecurityInfoW` plus
+/// `ConvertSecurityDescriptorToStringSecurityDescriptorW`; see
+/// `docs/design/windows-ntfs-acl-support.md` section 4.2.
+pub fn read_dacl_sddl(path: &Path) -> io::Result<String> {
+    read_sddl_internal(path, false)
+}
+
+/// Reads the security descriptor at `path` including the SACL.
+///
+/// Requires the calling process to hold `SE_SECURITY_NAME`. Without the
+/// privilege the call fails with `ERROR_PRIVILEGE_NOT_HELD`.
+///
+/// # Errors
+///
+/// Returns [`io::Error`] for Win32 failures.
+pub fn read_sddl_with_sacl(path: &Path) -> io::Result<String> {
+    read_sddl_internal(path, true)
+}
+
+fn read_sddl_internal(path: &Path, include_sacl: bool) -> io::Result<String> {
+    let wide = to_wide(path);
+    let mut psd = PSECURITY_DESCRIPTOR(ptr::null_mut());
+    let info = sddl_security_info(include_sacl);
+
+    // SAFETY: `wide` is NUL-terminated; `psd` lives for the call and is
+    // wrapped in `OwnedSecurityDescriptor` immediately so the allocation
+    // is released even on early returns.
+    let status = unsafe {
+        GetNamedSecurityInfoW(
+            PCWSTR(wide.as_ptr()),
+            SE_FILE_OBJECT,
+            info,
+            None,
+            None,
+            None,
+            None,
+            &mut psd,
+        )
+    };
+
+    let owned = OwnedSecurityDescriptor { pd: psd };
+    if status != WIN32_ERROR(0) {
+        return Err(win32_error("GetNamedSecurityInfoW", status));
+    }
+
+    let mut string_ptr = PWSTR(ptr::null_mut());
+    let mut string_len: u32 = 0;
+    // SAFETY: `owned.pd` is a valid kernel-allocated descriptor; the
+    // out-pointers are exclusively owned by this stack frame. The
+    // function allocates `string_ptr` via `LocalAlloc`; ownership is
+    // transferred to `OwnedLocalWString` immediately so the buffer is
+    // released even on error paths.
+    let convert = unsafe {
+        ConvertSecurityDescriptorToStringSecurityDescriptorW(
+            owned.pd,
+            SDDL_REVISION_1,
+            info,
+            &mut string_ptr,
+            Some(&mut string_len),
+        )
+    };
+    let owned_string = OwnedLocalWString { ptr: string_ptr };
+    convert.map_err(|e| {
+        io::Error::other(format!(
+            "ConvertSecurityDescriptorToStringSecurityDescriptorW: {e}"
+        ))
+    })?;
+
+    if owned_string.ptr.0.is_null() {
+        return Err(io::Error::other(
+            "ConvertSecurityDescriptorToStringSecurityDescriptorW returned null",
+        ));
+    }
+
+    // SAFETY: `owned_string.ptr` points to a NUL-terminated UTF-16
+    // buffer; `string_len` excludes the terminator.
+    let slice = unsafe { std::slice::from_raw_parts(owned_string.ptr.0, string_len as usize) };
+    Ok(String::from_utf16_lossy(slice))
+}
+
+/// Parses an SDDL string and writes it to `path` as the security
+/// descriptor for owner, group, and DACL components.
+///
+/// The DACL is applied with `PROTECTED_DACL_SECURITY_INFORMATION` so the
+/// destination does not silently inherit additional ACEs from its parent,
+/// matching the policy laid out in
+/// `docs/design/windows-ntfs-acl-support.md` section 5.2.
+///
+/// SACL entries present in the SDDL string are applied only when the
+/// calling token holds `SE_SECURITY_NAME`. Without the privilege the OS
+/// silently ignores the SACL component; callers needing strict failure
+/// semantics should probe the privilege before calling.
+///
+/// # Errors
+///
+/// Returns [`io::Error`] for SDDL parse failures or Win32 failures while
+/// applying the descriptor.
+///
+/// # Upstream Reference
+///
+/// `ConvertStringSecurityDescriptorToSecurityDescriptorW` plus
+/// `SetNamedSecurityInfoW`; see `docs/design/windows-ntfs-acl-support.md`
+/// section 4.2.
+pub fn write_dacl_sddl(path: &Path, sddl: &str) -> io::Result<()> {
+    let sddl_wide: Vec<u16> = sddl.encode_utf16().chain(std::iter::once(0)).collect();
+    let mut psd = PSECURITY_DESCRIPTOR(ptr::null_mut());
+
+    // SAFETY: `sddl_wide` is NUL-terminated; `psd` is exclusive. The
+    // function allocates `psd` via `LocalAlloc`; the wrapper releases it
+    // on drop.
+    let convert = unsafe {
+        ConvertStringSecurityDescriptorToSecurityDescriptorW(
+            PCWSTR(sddl_wide.as_ptr()),
+            SDDL_REVISION_1,
+            &mut psd,
+            None,
+        )
+    };
+    let owned = OwnedSecurityDescriptor { pd: psd };
+    convert.map_err(|e| {
+        io::Error::other(format!(
+            "ConvertStringSecurityDescriptorToSecurityDescriptorW: {e}"
+        ))
+    })?;
+    if owned.pd.0.is_null() {
+        return Err(io::Error::other(
+            "ConvertStringSecurityDescriptorToSecurityDescriptorW returned null",
+        ));
+    }
+
+    // Extract owner SID, group SID, DACL, and SACL from the parsed
+    // descriptor. Each accessor reports whether the component is present.
+    let mut owner_sid = PSID(ptr::null_mut());
+    let mut owner_defaulted = windows::core::BOOL(0);
+    // SAFETY: `owned.pd` is non-null, owned, and currently the only
+    // reader of the structure.
+    unsafe {
+        GetSecurityDescriptorOwner(owned.pd, &mut owner_sid, &mut owner_defaulted)
+            .map_err(|e| io::Error::other(format!("GetSecurityDescriptorOwner: {e}")))?;
+    }
+
+    let mut group_sid = PSID(ptr::null_mut());
+    let mut group_defaulted = windows::core::BOOL(0);
+    // SAFETY: see owner branch above.
+    unsafe {
+        GetSecurityDescriptorGroup(owned.pd, &mut group_sid, &mut group_defaulted)
+            .map_err(|e| io::Error::other(format!("GetSecurityDescriptorGroup: {e}")))?;
+    }
+
+    let mut dacl_present = windows::core::BOOL(0);
+    let mut pdacl: *mut ACL = ptr::null_mut();
+    let mut dacl_defaulted = windows::core::BOOL(0);
+    // SAFETY: see owner branch above.
+    unsafe {
+        GetSecurityDescriptorDacl(owned.pd, &mut dacl_present, &mut pdacl, &mut dacl_defaulted)
+            .map_err(|e| io::Error::other(format!("GetSecurityDescriptorDacl: {e}")))?;
+    }
+
+    let mut sacl_present = windows::core::BOOL(0);
+    let mut psacl: *mut ACL = ptr::null_mut();
+    let mut sacl_defaulted = windows::core::BOOL(0);
+    // SAFETY: see owner branch above.
+    unsafe {
+        GetSecurityDescriptorSacl(owned.pd, &mut sacl_present, &mut psacl, &mut sacl_defaulted)
+            .map_err(|e| io::Error::other(format!("GetSecurityDescriptorSacl: {e}")))?;
+    }
+
+    // Compose the security-information mask from components that the
+    // SDDL string actually populated. Unmentioned components stay
+    // untouched on the destination object.
+    let mut info = OBJECT_SECURITY_INFORMATION(0);
+    let owner_arg: Option<PSID> = if !owner_sid.0.is_null() {
+        info |= OWNER_SECURITY_INFORMATION;
+        Some(owner_sid)
+    } else {
+        None
+    };
+    let group_arg: Option<PSID> = if !group_sid.0.is_null() {
+        info |= GROUP_SECURITY_INFORMATION;
+        Some(group_sid)
+    } else {
+        None
+    };
+    let dacl_arg: Option<*const ACL> = if dacl_present.as_bool() && !pdacl.is_null() {
+        info |= DACL_SECURITY_INFORMATION | PROTECTED_DACL_SECURITY_INFORMATION;
+        Some(pdacl as *const ACL)
+    } else {
+        None
+    };
+    let sacl_arg: Option<*const ACL> = if sacl_present.as_bool() && !psacl.is_null() {
+        info |= SACL_SECURITY_INFORMATION;
+        Some(psacl as *const ACL)
+    } else {
+        None
+    };
+
+    if info.0 == 0 {
+        // SDDL string was syntactically valid but conveyed no
+        // components; nothing to write.
+        return Ok(());
+    }
+
+    let wide = to_wide(path);
+    // SAFETY: `owned` keeps the descriptor (and therefore the embedded
+    // SIDs and ACLs) alive until the function returns. `wide` is
+    // NUL-terminated.
+    let status = unsafe {
+        SetNamedSecurityInfoW(
+            PCWSTR(wide.as_ptr()),
+            SE_FILE_OBJECT,
+            info,
+            owner_arg,
+            group_arg,
+            dacl_arg,
+            sacl_arg,
+        )
+    };
+    drop(owned);
+    if status != WIN32_ERROR(0) {
+        return Err(win32_error("SetNamedSecurityInfoW", status));
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -823,5 +1108,69 @@ mod tests {
         // straightforward NTFS temp file.
         let result = sync_acls(&src, &dst, true);
         assert!(result.is_ok(), "sync_acls failed: {:?}", result.err());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn read_dacl_sddl_returns_non_empty_for_temp_file() {
+        let dir = tempdir().expect("tempdir");
+        let file = dir.path().join("test");
+        File::create(&file).expect("file");
+        let sddl = read_dacl_sddl(&file).expect("read sddl");
+        // Any NTFS DACL serialises to at least the "D:" prefix.
+        assert!(sddl.contains("D:"), "expected DACL section, got {sddl:?}");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn write_dacl_sddl_round_trips_known_descriptor() {
+        let dir = tempdir().expect("tempdir");
+        let file = dir.path().join("test");
+        File::create(&file).expect("file");
+
+        // Owner BA, Group SY, DACL grants full access to BA and Everyone.
+        let canonical = "O:BAG:SYD:P(A;;FA;;;BA)(A;;FA;;;WD)";
+        write_dacl_sddl(&file, canonical).expect("write sddl");
+
+        let read_back = read_dacl_sddl(&file).expect("read sddl");
+        assert!(
+            read_back.contains("O:BA"),
+            "owner BA missing in {read_back:?}"
+        );
+        assert!(
+            read_back.contains("G:SY"),
+            "group SY missing in {read_back:?}"
+        );
+        assert!(
+            read_back.contains("(A;;FA;;;BA)"),
+            "BA ACE missing in {read_back:?}"
+        );
+        assert!(
+            read_back.contains("(A;;FA;;;WD)"),
+            "Everyone ACE missing in {read_back:?}"
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn write_dacl_sddl_preserves_owner_and_group() {
+        let dir = tempdir().expect("tempdir");
+        let file = dir.path().join("test");
+        File::create(&file).expect("file");
+
+        let descriptor = "O:BAG:BA D:P(A;;FA;;;BA)";
+        write_dacl_sddl(&file, descriptor).expect("write sddl");
+        let read_back = read_dacl_sddl(&file).expect("read sddl");
+        assert!(read_back.starts_with("O:BAG:BA"), "got {read_back:?}");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn write_dacl_sddl_rejects_invalid_input() {
+        let dir = tempdir().expect("tempdir");
+        let file = dir.path().join("test");
+        File::create(&file).expect("file");
+        let result = write_dacl_sddl(&file, "not-a-sddl-string");
+        assert!(result.is_err(), "expected parse error, got {result:?}");
     }
 }

--- a/crates/metadata/src/lib.rs
+++ b/crates/metadata/src/lib.rs
@@ -169,7 +169,10 @@ pub use acl_exacl::{apply_acls_from_cache, default_perms_for_dir, get_rsync_acl,
 pub use acl_stub::{apply_acls_from_cache, default_perms_for_dir, get_rsync_acl, sync_acls};
 
 #[cfg(all(feature = "acl", windows))]
-pub use acl_windows::{apply_acls_from_cache, default_perms_for_dir, get_rsync_acl, sync_acls};
+pub use acl_windows::{
+    apply_acls_from_cache, default_perms_for_dir, get_rsync_acl, read_dacl_sddl,
+    read_sddl_with_sacl, sync_acls, write_dacl_sddl,
+};
 
 #[cfg(not(any(
     all(

--- a/crates/protocol/fuzz/fuzz_targets/fuzz_varint.rs
+++ b/crates/protocol/fuzz/fuzz_targets/fuzz_varint.rs
@@ -5,27 +5,151 @@
 //! Tests the variable-length integer decoding that rsync uses for
 //! protocol efficiency. These functions must handle arbitrary byte
 //! sequences without panicking or causing undefined behavior.
+//!
+//! In addition to the unstructured byte-stream coverage, the target
+//! injects structured edge cases on every iteration:
+//!   - boundary values (i32::MIN/MAX, i64::MIN/MAX, 0, -1) encoded
+//!     with `encode_varint_to_vec` / `write_varlong`,
+//!   - truncated buffers (every prefix of a freshly encoded value),
+//!   - both legacy protocol 31 (4-byte LE via `read_int`) and modern
+//!     protocol 32 (varint via `read_varint`) decode paths through
+//!     `read_varint30_int`.
 
 use libfuzzer_sys::fuzz_target;
 use std::io::Cursor;
 
-fuzz_target!(|data: &[u8]| {
-    // Test read_varint
-    let mut cursor = Cursor::new(data);
-    let _ = protocol::read_varint(&mut cursor);
+/// Boundary values exercised on every fuzz iteration to guarantee the
+/// decoders survive extreme inputs even when the corpus has not yet
+/// reached them.
+const I32_EDGES: [i32; 8] = [
+    0,
+    -1,
+    1,
+    i32::MIN,
+    i32::MAX,
+    i32::MIN + 1,
+    i32::MAX - 1,
+    -0x4000_0000,
+];
 
-    // Test read_varlong with various min_bytes values
+/// Boundary i64 values for the varlong path.
+const I64_EDGES: [i64; 8] = [
+    0,
+    -1,
+    1,
+    i64::MIN,
+    i64::MAX,
+    i32::MAX as i64 + 1,
+    -(i32::MIN as i64) - 1,
+    0x0000_FFFF_FFFF_FFFF,
+];
+
+fuzz_target!(|data: &[u8]| {
+    // Unstructured: arbitrary bytes through every decoder.
+    {
+        let mut cursor = Cursor::new(data);
+        let _ = protocol::read_varint(&mut cursor);
+    }
     for min_bytes in [0u8, 1, 2, 3, 4, 5, 6, 7, 8] {
         let mut cursor = Cursor::new(data);
         let _ = protocol::read_varlong(&mut cursor, min_bytes);
     }
-
-    // Test read_varlong30 with various min_bytes values
     for min_bytes in [0u8, 1, 2, 3, 4] {
         let mut cursor = Cursor::new(data);
         let _ = protocol::read_varlong30(&mut cursor, min_bytes);
     }
-
-    // Test decode_varint (slice-based)
     let _ = protocol::decode_varint(data);
+
+    // Legacy 4-byte LE (protocol < 30) and modern varint (protocol >= 30)
+    // dispatch through the same surface; cover both branches every run.
+    for proto in [28u8, 29, 30, 31, 32] {
+        let mut cursor = Cursor::new(data);
+        let _ = protocol::read_varint30_int(&mut cursor, proto);
+    }
+
+    // Legacy longint path (protocol < 30).
+    {
+        let mut cursor = Cursor::new(data);
+        let _ = protocol::read_longint(&mut cursor);
+    }
+
+    // Structured edges: encode boundary values, then decode the full
+    // buffer and every truncated prefix to drive mid-byte EOF paths.
+    for value in I32_EDGES {
+        let mut buf = Vec::new();
+        protocol::encode_varint_to_vec(value, &mut buf);
+
+        // Full buffer must roundtrip when the encoder succeeded.
+        if let Ok((decoded, rest)) = protocol::decode_varint(&buf) {
+            assert_eq!(decoded, value, "boundary varint decode mismatch");
+            assert!(rest.is_empty(), "boundary varint left trailing bytes");
+        }
+
+        // Every strict prefix must error cleanly (never panic).
+        for cut in 0..buf.len() {
+            let truncated = &buf[..cut];
+            let _ = protocol::decode_varint(truncated);
+            let mut cursor = Cursor::new(truncated);
+            let _ = protocol::read_varint(&mut cursor);
+        }
+
+        // Protocol 31 (legacy 4-byte LE) and 32 (varint) dispatch.
+        let mut legacy = Vec::new();
+        if protocol::write_int(&mut legacy, value).is_ok() {
+            let mut cursor = Cursor::new(&legacy);
+            if let Ok(decoded) = protocol::read_varint30_int(&mut cursor, 28) {
+                assert_eq!(decoded, value, "proto<30 read_int roundtrip mismatch");
+            }
+            // Truncated 4-byte LE buffer must not panic.
+            for cut in 0..legacy.len() {
+                let mut cursor = Cursor::new(&legacy[..cut]);
+                let _ = protocol::read_varint30_int(&mut cursor, 28);
+            }
+        }
+
+        let mut modern = Vec::new();
+        if protocol::write_varint(&mut modern, value).is_ok() {
+            let mut cursor = Cursor::new(&modern);
+            if let Ok(decoded) = protocol::read_varint30_int(&mut cursor, 32) {
+                assert_eq!(decoded, value, "proto>=30 read_varint roundtrip mismatch");
+            }
+            for cut in 0..modern.len() {
+                let mut cursor = Cursor::new(&modern[..cut]);
+                let _ = protocol::read_varint30_int(&mut cursor, 32);
+            }
+        }
+    }
+
+    // Structured edges for the 64-bit varlong path with every valid
+    // min_bytes width. Truncated prefixes exercise mid-byte EOF in the
+    // initial read as well as the extra-bytes read.
+    for value in I64_EDGES {
+        for min_bytes in 1u8..=8 {
+            let mut buf = Vec::new();
+            if protocol::write_varlong(&mut buf, value, min_bytes).is_ok() {
+                let mut cursor = Cursor::new(&buf);
+                if let Ok(decoded) = protocol::read_varlong(&mut cursor, min_bytes) {
+                    assert_eq!(decoded, value, "varlong boundary roundtrip mismatch");
+                }
+                for cut in 0..buf.len() {
+                    let mut cursor = Cursor::new(&buf[..cut]);
+                    let _ = protocol::read_varlong(&mut cursor, min_bytes);
+                }
+            }
+        }
+
+        // Legacy longint (protocol < 30) encodes >32-bit values with a
+        // 0xFFFFFFFF prefix; exercise both the short and long forms.
+        let mut buf = Vec::new();
+        if protocol::write_longint(&mut buf, value).is_ok() {
+            let mut cursor = Cursor::new(&buf);
+            if let Ok(decoded) = protocol::read_longint(&mut cursor) {
+                assert_eq!(decoded, value, "longint boundary roundtrip mismatch");
+            }
+            for cut in 0..buf.len() {
+                let mut cursor = Cursor::new(&buf[..cut]);
+                let _ = protocol::read_longint(&mut cursor);
+            }
+        }
+    }
 });

--- a/crates/rsync_io/Cargo.toml
+++ b/crates/rsync_io/Cargo.toml
@@ -30,6 +30,10 @@ embedded-ssh = ["dep:russh", "dep:url", "dep:rpassword", "dep:is-terminal", "dep
 # Async SSH transport: opt-in tokio-process backing for `SshConnection`.
 # See `docs/design/async-ssh-transport.md` (#1593) for the staging plan.
 async-ssh = ["dep:tokio"]
+# SSH stderr socketpair connection primitive (SSE-3, #2372). Default off
+# until SSE-7 ships parity tests. See
+# `docs/design/socketpair-stderr-channel.md` for the staging plan.
+ssh-socketpair-stderr = []
 
 [dev-dependencies]
 proptest = { workspace = true }

--- a/crates/rsync_io/src/ssh/mod.rs
+++ b/crates/rsync_io/src/ssh/mod.rs
@@ -93,6 +93,8 @@ mod connection;
 pub mod embedded;
 mod operand;
 mod parse;
+#[cfg(feature = "ssh-socketpair-stderr")]
+pub mod socketpair_stderr;
 
 #[cfg(feature = "async-ssh")]
 pub use async_transport::AsyncSshTransport;

--- a/crates/rsync_io/src/ssh/socketpair_stderr.rs
+++ b/crates/rsync_io/src/ssh/socketpair_stderr.rs
@@ -1,0 +1,184 @@
+//! # Overview
+//!
+//! Cross-platform connection primitive that yields a pair of byte streams
+//! used as the stderr aux-channel between the parent process and a spawned
+//! `ssh` child. Created for task SSE-3 (#2372) per
+//! `docs/design/socketpair-stderr-channel.md`. SSE-4 layers the async
+//! drain on top of this primitive.
+//!
+//! # Design
+//!
+//! - **Unix**: `socketpair(AF_UNIX, SOCK_STREAM, 0)` via
+//!   `std::os::unix::net::UnixStream::pair()`. The stdlib path requests
+//!   `SOCK_CLOEXEC` automatically, so both ends are close-on-exec by
+//!   default and do not need manual `fcntl(F_SETFD, FD_CLOEXEC)`. Both
+//!   halves are converted into [`std::fs::File`] through the safe
+//!   `OwnedFd` bridge so callers can store both ends behind the same
+//!   handle type as the pipe fallback.
+//! - **Windows**: `socketpair(2)` does not exist on Win32. The
+//!   behaviourally-equivalent shim (design doc Section 3.2) binds a
+//!   `TcpListener` to `127.0.0.1:0`, connects back, accepts, and drops
+//!   the listener. Wiring that result into a `File`-typed parent-side
+//!   handle requires the `OwnedHandle`/`RawSocket` bridge implemented
+//!   in the `fast_io` crate, which `rsync_io` must not duplicate
+//!   (workspace `#![deny(unsafe_code)]` policy). SSE-5 (#2374) lands
+//!   the Windows shim in coordination with `fast_io`; until then the
+//!   Windows implementation here returns
+//!   [`io::ErrorKind::Unsupported`] so the caller falls back to
+//!   `Stdio::piped()` exactly like the Unix FD-exhaustion path does
+//!   in `aux_channel.rs::configure_stderr_channel`.
+//!
+//! # Invariants
+//!
+//! - Both halves are returned in a connected state. Writes on one half
+//!   become readable on the other half.
+//! - Closing one half causes the peer to observe EOF (`read` returns 0).
+//! - On Unix both halves carry `FD_CLOEXEC` (set by the stdlib).
+//!
+//! # Errors
+//!
+//! All constructors return [`std::io::Error`]. Callers should treat
+//! every error as a signal to fall back to `Stdio::piped()`, mirroring
+//! the existing fallback in `aux_channel.rs::configure_stderr_channel`.
+//!
+//! # Examples
+//!
+//! ```ignore
+//! use rsync_io::ssh::socketpair_stderr::make_stderr_socketpair;
+//!
+//! let (parent, child) = make_stderr_socketpair()?;
+//! // `child` is handed to the spawned subprocess as fd 2; `parent` is
+//! // drained on this side.
+//! # Ok::<(), std::io::Error>(())
+//! ```
+
+use std::fs::File;
+use std::io;
+
+#[cfg(unix)]
+use std::os::fd::OwnedFd;
+#[cfg(unix)]
+use std::os::unix::net::UnixStream;
+
+/// Creates a connected pair of byte streams suitable for use as the
+/// stderr aux-channel between a parent process and a spawned `ssh`
+/// child.
+///
+/// On Unix the result is the parent/child halves of a
+/// `socketpair(AF_UNIX, SOCK_STREAM, 0)`. On Windows the call returns
+/// [`io::ErrorKind::Unsupported`] until SSE-5 lands the loopback shim
+/// alongside the safe handle wrapper in `fast_io`.
+///
+/// Returning [`File`] on both halves lets the caller store the handles
+/// uniformly with the existing pipe-backed fallback path.
+///
+/// # Errors
+///
+/// Returns the underlying [`io::Error`] when the kernel refuses to
+/// create the pair. On Windows always returns
+/// [`io::ErrorKind::Unsupported`].
+pub fn make_stderr_socketpair() -> io::Result<(File, File)> {
+    make_stderr_socketpair_impl()
+}
+
+#[cfg(unix)]
+fn make_stderr_socketpair_impl() -> io::Result<(File, File)> {
+    let (parent, child) = UnixStream::pair()?;
+    let parent_fd: OwnedFd = parent.into();
+    let child_fd: OwnedFd = child.into();
+    Ok((File::from(parent_fd), File::from(child_fd)))
+}
+
+#[cfg(not(unix))]
+fn make_stderr_socketpair_impl() -> io::Result<(File, File)> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "stderr socketpair primitive is not yet available on this platform (tracked under SSE-5)",
+    ))
+}
+
+/// Marks the given handle as non-blocking on Unix. On non-Unix
+/// targets this is a no-op so callers can keep a single code path.
+///
+/// Provided as a helper because the SSE-4 async drain will need
+/// non-blocking semantics on the parent half before registering it
+/// with the tokio reactor. The flag is stored on the open-file
+/// description, so a duplicated `UnixStream` view of the same fd
+/// suffices to flip the mode for every alias.
+///
+/// # Errors
+///
+/// Returns the underlying [`io::Error`] when the platform refuses the
+/// mode change.
+pub fn set_nonblocking(handle: &File, nonblocking: bool) -> io::Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::fd::AsFd;
+
+        // `BorrowedFd::try_clone_to_owned` issues `fcntl(F_DUPFD_CLOEXEC)`
+        // under the hood and is entirely safe stdlib API. The cloned
+        // descriptor shares the open-file description with the
+        // original, so `set_nonblocking` toggles the `O_NONBLOCK`
+        // flag visible to both fds.
+        let dup_fd: OwnedFd = handle.as_fd().try_clone_to_owned()?;
+        let stream = UnixStream::from(dup_fd);
+        stream.set_nonblocking(nonblocking)?;
+        Ok(())
+    }
+
+    #[cfg(not(unix))]
+    {
+        let _ = (handle, nonblocking);
+        Ok(())
+    }
+}
+
+#[cfg(all(test, unix, feature = "ssh-socketpair-stderr"))]
+mod tests {
+    use super::*;
+    use std::io::{Read, Write};
+
+    /// Round-trips a 1 KiB payload through the socketpair to confirm
+    /// both halves are wired together correctly.
+    #[test]
+    fn round_trip_one_kilobyte() {
+        let (mut parent, mut child) = make_stderr_socketpair().expect("create socketpair");
+
+        let payload: Vec<u8> = (0..1024u32).map(|i| (i % 251) as u8).collect();
+        child.write_all(&payload).expect("write payload");
+        child.flush().expect("flush child");
+
+        let mut received = vec![0u8; payload.len()];
+        parent.read_exact(&mut received).expect("read payload");
+        assert_eq!(received, payload);
+    }
+
+    /// Dropping one half must surface `read == 0` on the peer.
+    #[test]
+    fn closed_peer_reports_eof() {
+        let (mut parent, child) = make_stderr_socketpair().expect("create socketpair");
+        drop(child);
+
+        let mut buf = [0u8; 64];
+        let n = parent.read(&mut buf).expect("read after peer close");
+        assert_eq!(n, 0, "peer close must surface as EOF");
+    }
+
+    /// `set_nonblocking` must succeed on the parent end and the mode
+    /// flip must persist for subsequent reads.
+    #[test]
+    fn set_nonblocking_toggles_mode() {
+        let (parent, _child) = make_stderr_socketpair().expect("create socketpair");
+        set_nonblocking(&parent, true).expect("enable non-blocking");
+
+        let mut buf = [0u8; 8];
+        // With no data and non-blocking mode, the read should fail
+        // with `WouldBlock` rather than blocking forever.
+        let err = (&parent)
+            .read(&mut buf)
+            .expect_err("non-blocking read with no data must fail");
+        assert_eq!(err.kind(), io::ErrorKind::WouldBlock);
+
+        set_nonblocking(&parent, false).expect("restore blocking");
+    }
+}

--- a/docs/architecture/bgid-lifecycle.md
+++ b/docs/architecture/bgid-lifecycle.md
@@ -1,0 +1,204 @@
+# BGID lifecycle (architecture)
+
+Task: BGE-7 (#2299). Companion audit: `docs/audits/bgid-lifecycle.md` (PR
+[#4331](https://github.com/oferchen/rsync/pull/4331), tasks BGE-1 / BGE-2).
+Session topology context: `docs/architecture/session-overview-ddp-async-iouring.md`
+section 3 ("io_uring topology: session pool vs per-thread pool"). This
+document is the durable architecture view; the audit freezes the call
+graph at one point in time, this file explains the rules and how the
+lifecycle composes with the surrounding io_uring fast path.
+
+Buffer Group IDs (bgid) name the kernel-side provided buffer rings
+(`IORING_REGISTER_PBUF_RING`) that the io_uring fast path reads into.
+The id is a 16-bit field carried in `IOSQE_BUFFER_SELECT` SQEs and
+echoed back on CQEs, so its lifecycle must outlive every in-flight
+request that names it and must be recycled the instant the ring is
+torn down.
+
+## 1. Allocation flow
+
+```
+                +------------------------+
+                |  caller (BufferRing::  |
+                |  new_with_allocator)   |
+                +-----------+------------+
+                            |
+                            v
+            +-----------------------------+
+            | BgidAllocator::allocate()   |
+            +-----------------------------+
+                            |
+              free-list pop |  (Mutex<Vec<u16>>, OnceLock-initialised)
+              succeeded?    |
+                            |
+              +-------------+--------------+
+              | yes                        | no
+              v                            v
+       +-------------+        +-----------------------------+
+       | return id   |        | NEXT_BGID.fetch_add(1)      |
+       +------+------+        | (AtomicU32, Relaxed)        |
+              |               +--------------+--------------+
+              |                              |
+              |                  id < 65 536 ?
+              |                              |
+              |                +-------------+-------------+
+              |                | yes                       | no
+              |                v                           v
+              |        +---------------+   +-----------------------+
+              |        | return id     |   | fetch_sub(1) to cap   |
+              |        | as u16        |   | counter at 65 536;    |
+              |        +-------+-------+   | return BgidExhausted  |
+              |                |           +-----------+-----------+
+              v                v                       v
+       +------------------------------------------------------+
+       | BufferRing::new() registers the ring with the kernel |
+       | (IORING_REGISTER_PBUF_RING). On success the wrapper  |
+       | sets allocator_owned = true so Drop will recycle the |
+       | id; on failure it calls deallocate(bgid) immediately |
+       | so no slot is leaked.                                |
+       +------------------------------------------------------+
+```
+
+Single entry point: `BgidAllocator::allocate()`
+(`crates/fast_io/src/io_uring/buffer_ring.rs`). Wrapper that hands the
+id to a freshly registered ring: `BufferRing::new_with_allocator()`.
+Caller-supplied bgids (raw `BufferRing::new()`) bypass the allocator
+entirely and leave `allocator_owned = false`, matching the original
+fixed-purpose-probe intent.
+
+## 2. Recycling rules
+
+```
+   +-----------------+      drop()         +------------------+
+   | BufferRing      |  ---------------->  | unregister kernel|
+   | (allocator_     |                     | ring + munmap +  |
+   |  owned = true)  |                     | dealloc slab     |
+   +--------+--------+                     +---------+--------+
+            |                                        |
+            |                                        v
+            |                       +-------------------------------+
+            |                       | BgidAllocator::deallocate(id) |
+            |                       | takes free-list mutex,        |
+            |                       | push if !contains(id)         |
+            |                       +-------------+-----------------+
+            |                                     |
+            v                                     v
+   allocator_owned = false:           free-list now exposes id
+   kernel slot unregistered,          for the next allocate() call
+   caller retains namespace slot      (drains before fetch_add)
+```
+
+Drop-driven recycling guarantees the namespace slot returns to the
+free-list synchronously with the kernel unregister. The free-list is a
+process-wide `OnceLock<Mutex<Vec<u16>>>`; `OnceLock` ensures a single
+shared instance across all rings, `Mutex` linearises push/pop, and the
+`!contains(&bgid)` guard makes `deallocate` idempotent against
+double-drop (e.g., `Option::take` + drop of the original holder).
+
+The monotonic counter (`NEXT_BGID: AtomicU32`) never wraps: when
+`fetch_add` overshoots, the allocator issues a compensating
+`fetch_sub(1)` and returns `BgidExhausted`. The counter therefore
+saturates at `BGID_NAMESPACE_SIZE` and subsequent calls re-trip the
+exhaustion check rather than silently issuing colliding ids.
+
+## 3. u16 namespace exhaustion math
+
+The bgid field is `u16` inside `struct io_uring_buf_reg`
+(`io_uring/kbuf.c::io_register_pbuf_ring`), so the namespace is exactly
+`0..=65 535`:
+
+```
+total namespace      = u16::MAX + 1     = 65 536 ids
+reserved/sentinel    = 1                (id 0 historically reserved by
+                                        callers for fixed-purpose probes;
+                                        the allocator itself does not
+                                        currently reserve any value, but
+                                        BGE-7 treats one id as conceptually
+                                        reserved for future telemetry /
+                                        sentinel use)
+concurrent rings cap = 65 536 - 1       = 65 535 simultaneously live rings
+```
+
+Each live ring consumes one bgid for its lifetime; pre-session wiring
+(`#1936`/`#1937`) will turn one accepted connection into two consumed
+bgids (one read PBUF ring, one write PBUF ring). At that ratio the
+practical ceiling is `(65 535) / 2 = 32 767` concurrent sessions per
+process before allocation begins to fail. The mmap offset packing
+(`IORING_OFF_PBUF_RING | (u64::from(bgid) << 16)`) folds the id into
+bit 16 of the offset, so the kernel ABI cannot widen the namespace
+without breaking every existing PBUF ring caller.
+
+## 4. Pre-sized free-list rationale
+
+`bgid_free_list()` lazily initialises the `Vec<u16>` on first call. The
+current `Vec::new()` initial capacity triggers ~16 reallocation rounds
+on the way from 0 to ~4 096 entries during ramp-up of a daemon that
+churns rings. A pre-sized `Vec::with_capacity(1 << 12)` (4 096 entries,
+8 KiB) covers the steady-state working set of any per-session wiring
+without growing, and amortises to zero allocations under the expected
+churn profile. The vector still grows monotonically up to 65 536
+entries (128 KiB packed) under pathological churn, but the early
+realloc cliff disappears. This is the BGE-4 plumbing the audit calls
+out (`docs/audits/bgid-lifecycle.md` section 7).
+
+The free-list is intentionally unbounded above the pre-size: trimming
+would force a second mutex round on every drop, and the worst-case
+memory footprint (128 KiB) is negligible against the 64 KiB-per-buffer
+arenas the rings themselves carry.
+
+## 5. High-water-mark stat (planned via BGE-3)
+
+`BgidAllocator::remaining()` already returns
+`BGID_NAMESPACE_SIZE - used + free`, but there is no observation of
+peak in-use bgids. BGE-3 (audit section 6 item 1, audit section 7
+item 2) lands the missing telemetry:
+
+- `static PEAK_USED: AtomicU32` alongside `NEXT_BGID`.
+- Every successful `allocate()` computes
+  `in_use = NEXT_BGID.load(Relaxed) - free_list.len()` and calls
+  `PEAK_USED.fetch_max(in_use, Relaxed)`.
+- `BgidAllocator::peak_used() -> u32` exposes the value so the daemon
+  can surface it through the existing metrics endpoint.
+- A throttled `tracing::warn!(target: "fast_io::bgid", ...)` fires once
+  per minute when `in_use >= BGID_NAMESPACE_SIZE / 2` (32 768), gated
+  by a `OnceLock<Mutex<Instant>>`.
+
+The architecture commitment is that every allocation path observes the
+peak and every release path is reflected in `remaining()`; BGE-3 only
+adds the read-side accessor and the warning hook.
+
+## 6. Fallback when exhausted (planned via BGE-6)
+
+Today `BgidExhausted` propagates upward as
+`io::ErrorKind::InvalidInput` (`io_uring_common.rs`
+`From<BufferRingError> for io::Error`). The receiving call site has no
+documented downgrade path: a per-session PBUF ring allocation that
+fails will fail the session.
+
+BGE-6 will add the graceful fallback:
+
+1. On `BgidExhausted`, the per-session wiring degrades to the
+   non-PBUF read path (`recv(2)` into a heap buffer) for that session
+   only. The fast path stays primed for every session that does receive
+   a bgid.
+2. The downgrade emits one `tracing::warn!` per occurrence, distinct
+   from the BGE-3 50 % warning, so operators can correlate the two.
+3. A counter (`BgidAllocator::degraded_sessions()`) exposes how many
+   sessions have run on the fallback path since process start, surfaced
+   through the same metrics endpoint as the BGE-3 peak counter.
+
+Until BGE-6 lands, `BgidExhausted` is a hard error. The architecture
+guarantee is that the failure mode is *loud* (typed error, never silent
+id reuse) rather than *graceful*.
+
+## 7. Cross-references
+
+| Topic                                          | Document                                                              |
+|------------------------------------------------|-----------------------------------------------------------------------|
+| BGID allocation + release call graph (audit)   | `docs/audits/bgid-lifecycle.md` (PR #4331, BGE-1 / BGE-2)             |
+| Namespace exhaustion deep dive                 | `docs/audits/io-uring-bgid-exhaustion.md`                             |
+| Namespace primer                               | `docs/audits/io-uring-bgid-namespace.md`, `docs/audits/iouring-bgid-namespace.md` |
+| Provided-buffer-ring primitive overview        | `docs/audits/iouring-pbuf-ring.md`                                    |
+| Session topology (where rings are created)     | `docs/architecture/session-overview-ddp-async-iouring.md` section 3   |
+| Fixed buffer registration audit                | `docs/audits/io-uring-fixed-buffer-audit.md`                          |
+| Per-session ring wiring (in-flight)            | tracking issues `#1936`, `#1937`                                      |

--- a/docs/architecture/drain-error-recovery.md
+++ b/docs/architecture/drain-error-recovery.md
@@ -1,0 +1,172 @@
+# Drain error recovery contract
+
+This document defines the error-recovery contract for the engine's drain paths
+(parallel-delete, parallel-receive-delta, reorder buffer, channel-shutdown
+sequences). It consolidates four pillars surfaced by recent audits and pins
+the templates new code must follow.
+
+Companion docs:
+
+- `docs/audits/arc-try-unwrap-classification.md` (ATU-1 + ATU-2)
+- `docs/audits/mutex-poison-policy.md` (MPE-1 + MPE-2)
+- `docs/architecture/mutex-poison-policy.md` (MPE-11, planned)
+
+## The four pillars
+
+1. **Channel shutdown over `Arc::try_unwrap` where possible.** Prefer explicit
+   producer-side EOF signalling (mpsc close, sentinel value, `tokio::sync::watch`
+   shutdown flag) over `Arc::try_unwrap` for resource handoff. The unwrap
+   variant only succeeds when no clone leaks - tests, panics in worker
+   threads, or any forgotten `Arc::clone` site silently break it.
+2. **Typed errors carrying `strong_count` + kind.** When `Arc::try_unwrap` is
+   the right shape (lifetime is genuinely single-owner), wrap the failure in
+   a typed error that captures `Arc::strong_count(&arc)` and an identifying
+   tag. Never return bare `io::ErrorKind::Other`.
+3. **Diagnostic logging on every drain failure.** Log `strong_count`,
+   `weak_count`, and the call site as a `tracing::warn!` before returning the
+   typed error. Operators need the count to triage which subsystem held the
+   extra clone.
+4. **No bare `io::ErrorKind::Other` returns.** Every error path inside the
+   drain must surface a typed variant implementing `std::error::Error` with a
+   `source()` chain. Callers can then downcast to react.
+
+## Decision tree: "I have an `Arc<T>` that needs to be unwrapped"
+
+```text
+                         +-----------------+
+                         | Need owned T?   |
+                         +--------+--------+
+                                  |
+                +-----------------+----------------+
+                | yes                              | no - keep Arc, exit
+                v                                  v
+       +--------+--------+
+       | Single producer |
+       | + N consumers?  |
+       +--------+--------+
+                |
+       +--------+--------+
+       | yes             | no - multiple producers, redesign
+       v                 v
+   Channel shutdown    Cannot use try_unwrap;
+   (preferred)         add explicit barrier
+       |
+       v
+   `try_unwrap()` is now safe (consumers all dropped on EOF)
+   - typed error variant if it still fails
+   - log strong_count
+```
+
+## Typed-error template
+
+```rust
+#[derive(Debug, thiserror::Error)]
+pub enum DrainError {
+    #[error("{kind} still referenced by {strong_count} holder(s)")]
+    ResourceStillReferenced {
+        strong_count: usize,
+        kind: &'static str,
+    },
+    #[error("drain channel closed before EOF")]
+    PrematureShutdown,
+    #[error(transparent)]
+    Io(#[from] io::Error),
+}
+
+impl DrainError {
+    pub fn from_failed_unwrap<T>(arc: Arc<T>, kind: &'static str) -> Self {
+        DrainError::ResourceStillReferenced {
+            strong_count: Arc::strong_count(&arc),
+            kind,
+        }
+    }
+}
+```
+
+Use site:
+
+```rust
+let owned = Arc::try_unwrap(plan_map_arc)
+    .map_err(|arc| DrainError::from_failed_unwrap(arc, "DeletePlanMap"))?;
+```
+
+## Diagnostic-logging template
+
+Log before returning. Operators reading the log see why the drain
+failed, not just "Other".
+
+```rust
+let owned = match Arc::try_unwrap(plan_map_arc) {
+    Ok(v) => v,
+    Err(arc) => {
+        tracing::warn!(
+            strong_count = Arc::strong_count(&arc),
+            weak_count = Arc::weak_count(&arc),
+            kind = "DeletePlanMap",
+            "Arc::try_unwrap failed during drain - extra clones outlived the producer"
+        );
+        return Err(DrainError::from_failed_unwrap(arc, "DeletePlanMap"));
+    }
+};
+```
+
+## No-bare-Other template
+
+Audit any `io::Error::new(io::ErrorKind::Other, msg)` in error-conversion
+code. Replace with a typed variant that implements `std::error::Error` and
+keeps a `source()` chain:
+
+```rust
+// BAD
+return Err(io::Error::new(io::ErrorKind::Other, "drain failed"));
+
+// GOOD
+return Err(MyOpError::DrainFailed { cause: source_err }.into());
+```
+
+The wrapper can still `impl From<MyOpError> for io::Error` to preserve the
+callsite signature, but the typed error stays downcast-recoverable.
+
+## Cross-reference to Mutex poison policy
+
+`Mutex::lock().expect("poisoned")` shares the same anti-pattern: panic in one
+thread propagates as a panic in every subsequent lock attempt. The MPE series
+(`lock_or_recover` helper, `docs/audits/mutex-poison-policy.md`) gives the
+recovery primitives. Drain code that touches a `Mutex` should use
+`lock_or_recover` AND surface drain failures as typed errors per this
+contract.
+
+## Worked example: `DeleteContext::into_emitter`
+
+Before (per `docs/audits/arc-try-unwrap-classification.md` top fragile site):
+
+```rust
+let plan_map = Arc::try_unwrap(self.plan_map)
+    .map_err(|_| io::Error::new(io::ErrorKind::Other, "plan map still shared"))?;
+```
+
+After (the shape ATU-3 / PR pending implements):
+
+```rust
+let plan_map = Arc::try_unwrap(self.plan_map).map_err(|arc| {
+    let strong_count = Arc::strong_count(&arc);
+    tracing::warn!(strong_count, kind = "DeletePlanMap",
+        "DeleteContext::into_emitter could not unwrap plan map");
+    DeleteError::PlanMapStillShared { strong_count }
+})?;
+```
+
+The caller in `local_copy::executor::cleanup::delete_extraneous_entries_via_emitter`
+now sees a typed `DeleteError::PlanMapStillShared { strong_count: 2 }` instead
+of an opaque `io::ErrorKind::Other`, and the warn line gives the operator the
+count without enabling debug-level logging.
+
+## Promotion path
+
+1. ATU-3 lands the typed error variants for the 3 production fragile sites.
+2. ATU-4 refactors the most fragile site (drain path) to channel-shutdown.
+3. ATU-5 lands the diagnostic logging template across the remaining sites.
+4. ATU-6 replaces every `io::ErrorKind::Other` in error-conversion code.
+5. ATU-7 adds the stress test asserting typed errors surface, not `Other`.
+6. This contract becomes a CI lint: any new `Arc::try_unwrap` outside
+   `#[cfg(test)]` without a typed error mapping fails review.

--- a/docs/architecture/mutex-poison-policy.md
+++ b/docs/architecture/mutex-poison-policy.md
@@ -1,0 +1,245 @@
+# Mutex poison recovery policy
+
+This document defines the engine's policy for reacting to a poisoned
+`std::sync::Mutex` / `std::sync::RwLock`. It distils the per-site audit at
+`docs/audits/mutex-poison-policy.md` (MPE-1 + MPE-2) and the helpers landed in
+`crates/engine/src/util/poison.rs` (MPE-3) into one contract that new code must
+follow.
+
+Companion docs:
+
+- `docs/audits/mutex-poison-policy.md` (MPE-1 + MPE-2 + MPE-9 - per-site
+  classification)
+- `crates/engine/src/util/poison.rs` (MPE-3 - `lock_or_recover`,
+  `read_or_recover`, `write_or_recover`)
+- `docs/architecture/drain-error-recovery.md` (companion drain contract for
+  ATU-series fragile sites)
+
+## Why this policy exists
+
+When a thread holding a `Mutex` panics, the lock becomes poisoned. Every
+subsequent `lock().unwrap()` / `lock().expect(...)` on the same mutex panics
+again, turning a single-thread bug into a worker-pool-wide cascade. Some
+state survives a panic (append-only counters, idempotent caches, bgid
+free-lists); other state does not (in-flight wire frames, kernel-visible FFI
+handles, parent-before-child traversal cursors). The right reaction depends
+on what the lock guards, not on a one-size-fits-all rule.
+
+The MPE audit found **368** lock sites across the workspace. The contract
+below classifies every site into one of four buckets and gives the template
+new code must use for each.
+
+## The four cases
+
+### RECOVERABLE - use `lock_or_recover`
+
+The protected state is structurally valid after a panic. Continuing the
+transfer is preferable to aborting the worker pool. Examples surfaced by
+the audit: append-only event recorders, idempotent stat caches, bgid
+free-lists with built-in deduplication, ssh `Child` handles in `Drop` paths.
+
+Use `crates/engine/src/util/poison.rs::lock_or_recover` (or the `read`/`write`
+analogues for `RwLock`).
+
+### FATAL - keep `expect` with a `# Panics` rustdoc entry
+
+Continuing risks corrupt wire output, lost wakeups, or use-after-free on
+kernel-visible state. The audit identified 23 production-path FATAL sites
+across the in-flight batch writer, the buffer-pool backpressure condvar,
+the delete-traversal cursor, and the IOCP OVERLAPPED registry. Keep
+`expect("...")`. Tighten the message to name the wire-stream invariant
+being protected. Document the panic shape in rustdoc with a `# Panics`
+section.
+
+### TEST-ONLY - no policy
+
+Single-threaded test fixtures, `RecordingFs` doubles, env-mutex serialisers
+under `#[cfg(test)]`. The lock is never contended in the way the production
+path is. A bare `expect("test mutex poisoned")` is acceptable. Migrating
+these is a low-priority cleanup tracked under MPE-99 once `lock_or_recover`
+is in every production crate.
+
+### UNAUDITED - apply `lock_or_recover` by default
+
+New code added before this contract is updated, or sites the audit did not
+reach, default to `lock_or_recover`. The helper is the safer default
+because it cannot cascade-poison a worker pool. Audit and reclassify in a
+follow-up PR if the site turns out to be FATAL.
+
+## Decision tree
+
+"I am holding a `Mutex` and the surrounding code might panic. What do I do?"
+
+```text
+                  +----------------------------+
+                  | Does the protected state   |
+                  | survive a partial mutation |
+                  | (counters, queues, caches, |
+                  | append-only logs)?         |
+                  +-------------+--------------+
+                                |
+              +-----------------+----------------+
+              | yes                              | no
+              v                                  v
+   +------------------------+      +--------------------------+
+   | Does the lock guard    |      | Does continuing risk:    |
+   | a kernel-visible FFI   |      |   - torn wire frame      |
+   | resource that another  |      |   - lost condvar wakeup  |
+   | crate handed us?       |      |   - kernel-visible UAF   |
+   +-----------+------------+      |   - ordering invariant   |
+               |                   +-------------+------------+
+       +-------+-------+                         |
+       | yes           | no               +------+------+
+       v               v                  | yes         | no
+   FATAL          RECOVERABLE             v             v
+   keep expect    use                  FATAL       Cannot reach
+   + # Panics     lock_or_recover      keep        here in practice;
+                                       expect      treat as
+                                       + # Panics  RECOVERABLE
+```
+
+If the site is inside `#[cfg(test)]` or a test fixture, skip the tree -
+classify as TEST-ONLY and move on.
+
+If you cannot answer the first question with confidence, classify as
+UNAUDITED and apply `lock_or_recover` until the next audit pass
+reclassifies it.
+
+## RECOVERABLE template
+
+Import the helper and call it in place of `lock().unwrap()` /
+`lock().expect(...)`:
+
+```rust
+use engine::util::poison::lock_or_recover;
+
+fn record(&self, event: Event) {
+    let mut log = lock_or_recover(&self.events);
+    log.push(event);
+}
+```
+
+For `RwLock`:
+
+```rust
+use engine::util::poison::{read_or_recover, write_or_recover};
+
+fn lookup(&self, key: &Path) -> Option<Arc<Metadata>> {
+    read_or_recover(&self.cache).get(key).cloned()
+}
+
+fn insert(&self, key: PathBuf, value: Arc<Metadata>) {
+    write_or_recover(&self.cache).insert(key, value);
+}
+```
+
+The helpers emit no `tracing` event today; future MPE work may add an
+opt-in counter. Do not wrap them in additional logging at the call site -
+the helper is the single source of truth so a CI lint can grep for it.
+
+## FATAL template
+
+Keep `expect`. Pick an invariant name that identifies the wire-stream
+contract being protected. Document the panic in the function's rustdoc
+with a `# Panics` section so callers know it is intentional.
+
+```rust
+/// Append a frame to the in-flight batch writer.
+///
+/// # Panics
+///
+/// Panics if the writer mutex is poisoned. A poisoned writer means a
+/// previous frame was half-written; resuming would emit a torn batch
+/// that no downstream rsync can replay. The transfer must abort.
+fn write_frame(&self, frame: Frame) -> io::Result<()> {
+    let mut writer = self
+        .batch_writer
+        .lock()
+        .expect("BatchWriter wire-stream ordering invariant");
+    writer.write_frame(frame)
+}
+```
+
+Rules:
+
+- The `expect` message names the invariant, not the site. Grep on the
+  invariant name reveals every FATAL site that protects the same
+  contract.
+- The `# Panics` rustdoc describes why aborting is the only safe
+  reaction. Callers reading the docs see that the panic is by design.
+- Do not introduce a `lock_or_panic` wrapper. `expect("invariant")` is
+  already grep-able and produces an identical backtrace.
+
+## Audit counts
+
+From `docs/audits/mutex-poison-policy.md` (368 total sites across the
+workspace):
+
+| Classification | Sites | Notes                                                             |
+|----------------|-------|-------------------------------------------------------------------|
+| FATAL          | 23    | Wire-stream / backpressure / IOCP / signature worker / cursor    |
+| RECOVERABLE    | 28    | Caches, recorders, bgid free-list, env mutexes, ssh `Drop`       |
+| TEST-ONLY      | 317   | Single-threaded fixtures across all crates                       |
+| **Total**      | **368** |                                                                 |
+
+Per-crate hotspots (combined single-line + multi-line passes):
+
+| Crate       | Sites | Primary shape                                                       |
+|-------------|-------|---------------------------------------------------------------------|
+| `daemon`    | 125   | env mutex + chunked test harness                                    |
+| `engine`    | 60    | batch writer (FATAL), delete cursor (FATAL), drain shard, recorder  |
+| `cli`       | 49    | env mutex (RECOVERABLE prod) + frontend tests                       |
+| `core`      | 39    | compress env mutex + client tests                                   |
+| `transfer`  | 25    | reader/writer/receiver tests                                        |
+| `protocol`  | 25    | multiplex reader tests                                              |
+| `fast_io`   | 14    | bgid free-list (RECOVERABLE) + IOCP registry (FATAL)                |
+| `metadata`  | 8     | id-lookup tests                                                     |
+| `flist`     | 7     | batched stat cache (RECOVERABLE)                                    |
+| `platform`  | 6     | privilege + env test mutex                                          |
+| `rsync_io`  | 5     | ssh `Child` handle (RECOVERABLE, reference pattern)                 |
+| `signature` | 1     | worker receiver (FATAL)                                             |
+| `embedding` | 1     | test                                                                |
+| `checksums` | 1     | test                                                                |
+| `branding`  | 1     | test                                                                |
+| `bandwidth` | 1     | test                                                                |
+
+Top single-file remediation target:
+`crates/engine/src/local_copy/context_impl/options.rs` (7 FATAL batch-writer
+sites sharing one `expect` message; tightening them lands the wire-stream
+invariant naming convention for the rest of the engine to copy).
+
+## Cross-references
+
+- `docs/audits/mutex-poison-policy.md` - the per-site classification this
+  policy distils.
+- `crates/engine/src/util/poison.rs` - the helper implementation, module
+  docs, and unit tests.
+- `docs/architecture/drain-error-recovery.md` - the ATU-series companion
+  for `Arc::try_unwrap` drain failures. Drain code that also touches a
+  `Mutex` must use `lock_or_recover` AND surface drain failures as typed
+  errors per that contract.
+- `crates/rsync_io/src/ssh/connection.rs` and
+  `crates/fast_io/src/refs_detect.rs` - pre-existing RECOVERABLE call
+  sites that match the helper recipe; treat them as worked examples.
+
+## Promotion path
+
+1. **MPE-1 + MPE-2 + MPE-9** (landed) - the per-site audit at
+   `docs/audits/mutex-poison-policy.md`.
+2. **MPE-3** (landed) - the `lock_or_recover`, `read_or_recover`,
+   `write_or_recover` helpers in `crates/engine/src/util/poison.rs`.
+3. **MPE-4..MPE-8** (planned) - per-file replacements inside
+   `crates/engine/src/delete/**`. MPE-4 replaces 5 FATAL plan-map sites
+   with tightened `expect` messages, MPE-5 covers `delete/context.rs`,
+   MPE-6/7 wrap the recorder/scripted-fs test doubles in
+   `lock_or_recover`, MPE-8 is the audit pass that confirms every
+   `engine/src/delete/**` site uses one of the two recipes.
+4. **MPE-10** (planned) - stress test that panics a worker thread mid-lock
+   on every RECOVERABLE site and asserts the surrounding pool keeps
+   serving subsequent transfers (no cascade-poisoning).
+5. **MPE-11** (this document) - the contract that ties (1) (2) and the
+   future (3) (4) together.
+6. **Future** - this contract becomes a CI lint. Any new `lock().unwrap()`
+   or `lock().expect(...)` outside `#[cfg(test)]` that does not either
+   call `lock_or_recover` or sit next to a `# Panics` rustdoc entry fails
+   review.

--- a/docs/audits/fuzz-coverage-gap-followups.md
+++ b/docs/audits/fuzz-coverage-gap-followups.md
@@ -1,0 +1,261 @@
+# Fuzz coverage gap followups
+
+Companion to `docs/audits/fuzz-coverage-matrix.md`. The matrix ranks the
+remaining gaps; this document decomposes them into individually filable
+follow-up tasks with concrete parse-function citations, `Arbitrary` input
+recommendations, and invariant assertions.
+
+The audit that produced these tasks comes out of the FCV-3 (#2316)
+breakdown. FCV-6 has already shipped `flist_entry_decode` (top-level
+`fuzz/fuzz_targets/flist_entry_decode.rs`), so the file-list state
+machine is no longer the open P0 in row 1 of the matrix. The two
+remaining P0 gaps from Table 2 (`negotiation_prologue` and
+`capability_vstring`) are first in the queue below, followed by P1
+candidates that are ready to file without further design work.
+
+For each gap we list:
+
+- **Task slot** - placeholder FCV-NN identifier reserved for the
+  follow-up issue. Reuse the matrix's section-3 ordering so the queue
+  stays readable.
+- **Parse function** - `file:line` of the public entry point that
+  consumes untrusted bytes.
+- **Arbitrary input shape** - raw `&[u8]` when libFuzzer's
+  coverage-guided generator is enough on its own, or a structured
+  `Arbitrary` shape when the parser needs context (protocol version,
+  capability flags, preserve flags, role) to reach interesting branches.
+- **Invariants** - panic vs no-panic expectations, plus any roundtrip
+  or convergence properties that the harness should assert.
+- **Priority justification** - why this surface deserves the slot it
+  has, with reference to upstream rsync's reachability analysis.
+
+## P0 follow-ups
+
+### FCV-7 - `negotiation_prologue`
+
+- **Parse function**: `crates/protocol/src/negotiation/sniffer/observe.rs:12`
+  (`NegotiationPrologueSniffer::observe`), plus the byte-at-a-time
+  driver `observe_byte` at line 65 and the reader-driven `read_from`
+  at line 78.
+- **Arbitrary input shape**: raw `&[u8]`. The sniffer is a pure
+  byte-stream classifier; libFuzzer's coverage-guided generation finds
+  branches in `legacy_prefix_complete`, `needs_more_legacy_prefix_bytes`,
+  and `planned_prefix_bytes_for_observation` without structured help.
+  Drive the slice through three modes per fuzz iteration:
+  1. `observe(data)` in one call.
+  2. byte-by-byte loop calling `observe_byte` for each byte.
+  3. `read_from(&mut Cursor::new(data))` to exercise the `Interrupted`
+     and `UnexpectedEof` paths.
+- **Invariants**:
+  - panic-only across all three drivers.
+  - `(decision, consumed)` from `observe` must satisfy
+    `consumed <= data.len()`.
+  - `reset()` followed by `observe(data)` must return the same
+    decision as a fresh sniffer (idempotence under reset).
+  - `legacy_prefix_complete()` is monotonic - once true it stays true
+    until `reset()` is called.
+- **Priority justification**: this is the very first parser any
+  connection touches. A panic here is a pre-authentication remote DoS
+  reachable by any peer that opens a TCP socket. The sniffer also owns
+  buffered prefix retention (`try_reserve_exact`), so adversarial inputs
+  that maximise reserved bytes are a memory-pressure vector worth
+  exploring early.
+
+### FCV-8 - `capability_vstring`
+
+- **Parse function**: `crates/protocol/src/negotiation/capabilities/negotiate.rs:493`
+  (`read_vstring`), wired into `negotiate_capabilities` at line 121 and
+  `negotiate_capabilities_with_override` at line 163.
+- **Arbitrary input shape**: structured `Arbitrary` with a raw-byte
+  payload tail.
+  ```rust
+  #[derive(Arbitrary, Debug)]
+  struct Input {
+      protocol: u8,            // mod 5 -> ProtocolVersion::V28..V32
+      role: bool,              // is_server
+      mode: bool,              // is_daemon_mode
+      send_compression: bool,
+      payload: Vec<u8>,        // pre-staged peer reply stream
+  }
+  ```
+  Pre-stage `payload` as the peer's vstring stream into a
+  `Cursor<Vec<u8>>` for `stdin` and a sink `Vec<u8>` for `stdout`. Run
+  both `negotiate_capabilities` and
+  `negotiate_capabilities_with_override` so the `checksum_override` /
+  `compression_override` arms are reached.
+- **Invariants**:
+  - panic-only.
+  - `read_vstring` must reject lengths above `MAX_NSTR_STRLEN` (256)
+    with `InvalidData`, never panic.
+  - Non-UTF-8 payloads must surface as `InvalidData`, never panic.
+  - `negotiate_capabilities*` must never allocate more than
+    `2 * MAX_NSTR_STRLEN` bytes for the remote string buffers.
+- **Priority justification**: vstring exchange runs before any
+  encryption, compression, or framing context exists. Reachable on
+  every connection that negotiates protocol >= 30 (which is every
+  modern transfer). A panic here matches the threat model of the
+  prologue sniffer: unauthenticated remote DoS.
+
+### FCV-9 - `legacy_sniffer` (P0 fill-in)
+
+- **Parse function**: `crates/protocol/src/negotiation/sniffer/legacy.rs:16`
+  (`read_legacy_daemon_line`), with the greeting wrappers at lines 81
+  (`read_and_parse_legacy_daemon_greeting`) and 91
+  (`read_and_parse_legacy_daemon_greeting_details`).
+- **Arbitrary input shape**: raw `&[u8]` fed through a
+  `Cursor<Vec<u8>>`. Pre-stage the sniffer by feeding the canonical
+  `@RSYNCD:` prefix into `observe()` first, then call
+  `read_legacy_daemon_line` against the cursor. Repeat with the
+  greeting wrappers so the version-line parser is exercised.
+- **Invariants**:
+  - panic-only.
+  - `try_reserve` failures must surface as `io::Error`
+    (`map_reserve_error_for_io`), never panic.
+  - Line length is bounded - exhaust the cursor before allocation
+    exceeds a reasonable cap (assert in the harness that the resulting
+    `line.len()` is below e.g. 64 KiB after the call).
+- **Priority justification**: this is the P0 row "partial" cell in
+  Table 2 - `fuzz_legacy_greeting` reaches the pure parsers but the
+  reader-driven helpers are unfuzzed. Reachable on every legacy
+  daemon handshake.
+
+## P1 follow-ups
+
+### FCV-10 - `compat_flags`
+
+- **Parse function**: `crates/protocol/src/compatibility/flags.rs:175`
+  (`CompatibilityFlags::read_from`), with slice variants at lines 184
+  (`decode_from_slice`) and 212 (`decode_from_slice_mut`).
+- **Arbitrary input shape**: raw `&[u8]`, driven through both
+  `read_from(Cursor::new(data))` and `decode_from_slice(data)` in the
+  same harness so the varint backing both paths is hit twice.
+- **Invariants**:
+  - panic-only.
+  - `decode_from_slice_mut` must leave the input slice untouched on
+    error (existing contract from the doc example).
+  - `decode_from_slice(data).map(|(_, rest)| rest.len()) <= data.len()`.
+- **Priority justification**: P1 in Table 2. Compatibility flags gate
+  every later codec switch (varint30, longints, incremental flist). A
+  miscount here corrupts every subsequent parse, so even though the
+  payload is tiny the blast radius is large.
+
+### FCV-11 - `filter_list_wire`
+
+- **Parse function**: `crates/protocol/src/filters/wire.rs:181`
+  (`read_filter_list`).
+- **Arbitrary input shape**: structured
+  `Arbitrary { protocol: u8, payload: Vec<u8> }`. The protocol selector
+  controls how `parse_wire_rule` interprets the inner record; the
+  payload bytes are the wire stream including the 4-byte LE length
+  prefixes and the zero terminator.
+- **Invariants**:
+  - panic-only.
+  - Negative lengths must surface as `InvalidData`.
+  - `Vec::with_capacity(len as usize)` is reachable - cap the per-rule
+    length the harness will accept (e.g., skip iterations where any
+    length prefix exceeds 16 MiB) so libFuzzer does not focus on OOM
+    rather than logic bugs.
+- **Priority justification**: P1 in Table 2. Distinct surface from the
+  text-grammar parser already covered by `fuzz_filter_parse`. Reachable
+  whenever the sender ships a filter list (every `--filter`,
+  `--exclude*`, `--include*` invocation).
+
+### FCV-12 - `ndx_codec`
+
+- **Parse function**: `crates/protocol/src/codec/ndx/state.rs:97`
+  (`NdxState::read_ndx`), with the stateless goodbye sentinel at
+  `crates/protocol/src/codec/ndx/goodbye.rs:48` (`read_goodbye`).
+- **Arbitrary input shape**: structured
+  `Arbitrary { protocol_version: u8, payload: Vec<u8> }`. Maintain a
+  single `NdxState` across multiple `read_ndx` calls until the cursor
+  drains so the prev-positive / prev-negative caches are exercised.
+  Drive `read_goodbye` against the residual bytes.
+- **Invariants**:
+  - panic-only.
+  - Returned indexes must satisfy `i32` bounds (no overflow during the
+    `(high << 24) | ...` reassembly).
+  - `read_goodbye` must never panic on truncated or wrong-sentinel
+    input - only return `InvalidData` / `UnexpectedEof`.
+- **Priority justification**: P1 in Table 2. NDX codec gates the
+  post-flist phase of every transfer; the byte-reduction encoding has
+  enough branches (`0xFF`, `0xFE`, `0x00`, high-bit-set) that
+  hand-written tests miss interactions.
+
+### FCV-13 - `incremental_flist`
+
+- **Parse function**: `crates/protocol/src/flist/incremental/streaming.rs:57`
+  (`StreamingFileList::next_ready`) and line 86 (`read_all`). Both sit
+  on `FileListReader::read_entry` at
+  `crates/protocol/src/flist/read/mod.rs:469`.
+- **Arbitrary input shape**: reuse `flist_entry_decode`'s structured
+  shape (protocol selector, preserve-flag matrix, payload) and wrap the
+  cursor in `StreamingFileList::new`. The added value is exercising
+  the segment / parent-dir state machine that sits on top of the
+  per-entry decoder.
+- **Invariants**:
+  - panic-only.
+  - `ready_count() + pending_count()` must equal the number of
+    successfully-decoded entries.
+  - `is_finished_reading()` is monotonic.
+- **Priority justification**: P1 in Table 2. Stacks on the FCV-6
+  surface but exposes additional state. Reachable on every transfer
+  that negotiates `CF_INC_RECURSE` (default for protocol 30+).
+
+### FCV-14 - `idlist`
+
+- **Parse function**: `crates/protocol/src/idlist/mod.rs:232`
+  (`IdList::read`) and line 256 (`read_with_kind`).
+- **Arbitrary input shape**: structured
+  `Arbitrary { protocol_version: u8, id0_names: bool, kind: u8, payload: Vec<u8> }`
+  with `kind % 3` selecting `None` / `Some(Uid)` / `Some(Gid)`. Pass a
+  stub `name_to_id` closure that returns `None` half the time and
+  `Some(arbitrary u32)` the rest (use a counter rather than a fresh
+  `Arbitrary` per name so the harness stays deterministic).
+- **Invariants**:
+  - panic-only.
+  - No name allocation may exceed the upstream cap (mirror
+    `MAX_NSTR_STRLEN` semantics if applicable; otherwise cap at
+    `i16::MAX as usize`).
+- **Priority justification**: P1 in Table 2. ID lists arrive
+  unauthenticated from the daemon; the varint30 path also overlaps
+  with FCV-10 coverage so a finding here narrows the blame quickly.
+
+### FCV-15 - `compress_decoders`
+
+- **Parse function**:
+  `crates/compress/src/zlib/helpers.rs:17` (`decompress_to_vec`),
+  `crates/compress/src/lz4/raw.rs:217,253`
+  (`decompress_block`, `decompress_block_to_vec`),
+  `crates/compress/src/lz4/frame.rs:182,190`
+  (`decompress_to_vec`, `decompress_into`),
+  `crates/compress/src/zstd.rs:237,245`
+  (`decompress_to_vec`, `decompress_into`).
+- **Arbitrary input shape**: structured
+  `Arbitrary { codec: u8, payload: Vec<u8> }` with `codec % 4`
+  selecting zlib / lz4-raw / lz4-frame / zstd. The existing
+  `fuzz/fuzz_targets/decompressor_{zlib,zstd}.rs` cover the zlib and
+  zstd wrappers but not the LZ4 paths.
+- **Invariants**:
+  - panic-only.
+  - Output `Vec` must not exceed a configurable cap
+    (e.g., `64 * input.len() + 4 KiB`) - the harness asserts this
+    rather than letting the wrapper OOM the fuzzer.
+- **Priority justification**: P1 in Table 2. The underlying codec
+  crates are well-fuzzed upstream, but our thin wrappers compute
+  output bounds and call `Vec::with_capacity` - a bad length prefix
+  is a memory-blowup vector specific to our code.
+
+## Filing order
+
+The five P0 / P1 follow-ups above (FCV-7 through FCV-11) are the
+recommended initial batch. They are each in-process, sub-millisecond
+targets that fit the existing nightly fuzz workflow's budget. FCV-12
+through FCV-15 can land in a second batch once the prologue and
+vstring targets have soaked overnight without false positives.
+
+P2 / P3 gaps (`acl_wire`, `xattr_wire`, `files_from`, `iconv_spec`,
+`rsyncd_conf`, `bwlimit_parse`, `skip_compress_list`) are deferred
+behind the queue above. They share the same pattern - raw `&[u8]`
+through the entry points cited in the matrix - and are listed in
+Section 3 of `fuzz-coverage-matrix.md` so they remain visible without
+needing per-gap decomposition here.

--- a/docs/audits/fuzz-coverage-matrix.md
+++ b/docs/audits/fuzz-coverage-matrix.md
@@ -1,12 +1,14 @@
 # Fuzz coverage matrix and gap analysis
 
-Tracking issues: #2314 (inventory), #2315 (gap analysis). Companion to
+Tracking issues: #2314 (inventory), #2315 (gap analysis), #2316
+(FCV-3 follow-up decomposition). Companion to
 `docs/design/protocol-fuzzing-harness.md`,
-`docs/design/wire-format-differential-fuzzer.md`, and
-`docs/design/differential-filter-fuzzer.md`. This audit catalogues every
-existing fuzz target in the workspace, maps the protocol-parsing entry
-points that consume untrusted bytes, and ranks the gaps so FCV-3+ has a
-clear queue.
+`docs/design/wire-format-differential-fuzzer.md`,
+`docs/design/differential-filter-fuzzer.md`, and the per-gap follow-up
+breakdown in `docs/audits/fuzz-coverage-gap-followups.md`. This audit
+catalogues every existing fuzz target in the workspace, maps the
+protocol-parsing entry points that consume untrusted bytes, and ranks
+the gaps so FCV-3+ has a clear queue.
 
 ## 1. Existing fuzz targets
 

--- a/docs/audits/fuzz-coverage-matrix.md
+++ b/docs/audits/fuzz-coverage-matrix.md
@@ -48,6 +48,18 @@ The remaining 11 targets run only on demand via
 `tools/ci/run_filter_fuzz.sh`, `tools/ci/run_filter_differential_fuzz.sh`,
 or direct `cargo +nightly fuzz run` invocation.
 
+### Nightly coverage report (informational)
+
+The `Fuzz Coverage Report` workflow (`.github/workflows/fuzz-coverage-report.yml`)
+runs `cargo fuzz coverage <target> -- -max_total_time=300` for every target
+in the three fuzz workspaces nightly at 03:30 UTC. Each run uploads a
+`coverage/<target>.lcov` artifact with 30-day retention, and the GitHub step
+summary lists per-target line-coverage percentages. The job is marked
+`continue-on-error: true` while baseline thresholds stabilise; promote it to
+a required check once each target has a documented minimum line-coverage
+target and the lcov totals trend monotonically upward across consecutive
+nightly runs.
+
 Maturity signals:
 
 - `fuzz/corpus/` and `fuzz/artifacts/` are absent at the top-level

--- a/docs/audits/iouring-data-path-coverage.md
+++ b/docs/audits/iouring-data-path-coverage.md
@@ -1,0 +1,211 @@
+# io_uring Data Path Coverage Audit (IUD-1)
+
+## Purpose
+
+Catalogue every io_uring SQE construction site in `crates/fast_io/src/io_uring/`,
+classify each by opcode category, and confirm whether real production callers
+in `crates/transfer/`, `crates/engine/`, and `crates/rsync_io/` route file
+data (not just metadata, fences, or fallbacks) through the ring.
+
+The audit answers a single load-bearing question: is io_uring today
+"metadata-only" or does it carry the bulk delta payload as well?
+
+## Method
+
+- Enumerated SQE sites via `grep -rn "opcode::" crates/fast_io/src/io_uring/`.
+- For each site, recorded the opcode and the enclosing public function.
+- Traced every public symbol upward through the workspace, excluding files
+  under `crates/fast_io/tests/`, `crates/fast_io/benches/`, and inline
+  `#[cfg(test)]` modules.
+- Distinguished "production caller present" (non-test code in `engine`,
+  `transfer`, `core`, `rsync_io`, or `daemon`) from "test/bench only".
+
+## Per-opcode inventory
+
+All file paths are relative to the workspace root.
+
+### Metadata SQEs
+
+| Site | Opcode | Submitter | Production caller |
+| --- | --- | --- | --- |
+| `crates/fast_io/src/io_uring/statx.rs:177` | `Statx` | `submit_statx_blocking` | None. `fast_io::try_statx_batch_via_io_uring` is exported but no `engine`, `transfer`, `core`, `daemon`, or `metadata` call site invokes it. Metadata reads go through `metadata/src/stat_cache.rs::try_statx_optimized`, which calls `rustix::fs::statx` (synchronous syscall, not io_uring). |
+| `crates/fast_io/src/io_uring/statx.rs:346` | `Statx` (batch) | `submit_statx_batch_io_uring` | Same as above - exported, unused in production. |
+| `crates/fast_io/src/io_uring/linkat.rs:152` | `LinkAt` | `submit_linkat_blocking` | Reached via `fast_io::hard_link` -> `try_hard_link_via_io_uring`. Used in production by `transfer/src/receiver/directory/links.rs:261`, `transfer/src/receiver/quick_check.rs:179`, `engine/src/local_copy/overrides.rs:60`, `engine/src/local_copy/executor/file/copy/links.rs:81`, `engine/src/local_copy/hard_links.rs:98,167`. |
+| `crates/fast_io/src/io_uring/renameat2.rs:142` | `RenameAt` | `renameat2_blocking` | Reached via `fast_io::try_rename_via_io_uring`. Production callers: `transfer/src/disk_commit/process.rs:370`, `transfer/src/transfer_ops/response.rs:284`, `transfer/src/receiver/transfer.rs:447`, `engine/src/local_copy/executor/file/guard.rs:314,325`. |
+
+Site count: 4 distinct opcodes, 2 wired into production (linkat, renameat2),
+2 dormant (statx blocking, statx batch).
+
+### File data read SQEs
+
+| Site | Opcode | Submitter | Production caller |
+| --- | --- | --- | --- |
+| `crates/fast_io/src/io_uring/file_reader.rs:125` | `Read` | `IoUringReader::read_into` (BufReader fill path) | Reached via `fast_io::reader_from_path_with_depth`. Production caller: `transfer/src/generator/mod.rs:898` (`open_source_reader`) for source files >= 1 MiB. This is the sender-side basis/source read path. |
+| `crates/fast_io/src/io_uring/file_reader.rs:244` | `Read` (batched) | `IoUringReader::read_batched` | Same `reader_from_path_with_depth` entry point as above. |
+| `crates/fast_io/src/io_uring/registered_buffers/submit.rs:38` | `ReadFixed` | `submit_read_fixed_batch` | Used internally by `IoUringReader` registered-buffer fast path - same production caller (`generator::open_source_reader`). |
+| `crates/fast_io/src/io_uring/shared_ring.rs:235` | `Read` | `SharedRing::submit_read` | None. `SharedRing` is exported via `fast_io::SharedRing` but no production crate constructs it. Tests in `crates/fast_io/tests/io_uring_shared_ring.rs` and `io_uring_mmap_pressure.rs` are the only callers. |
+| `crates/fast_io/src/io_uring/linked_chain.rs:275,318` | `Read` | `LinkedChain` builder | None outside `crates/fast_io`. The chain helper is exposed but no `engine`/`transfer` site links a Read+Write chain today. |
+
+Site count: 5. Two paths (`file_reader::read`, `read_fixed`) are wired into
+production through `generator::open_source_reader`. Three paths
+(`shared_ring::submit_read`, two `linked_chain` Read constructors) are
+unused outside tests.
+
+### File data write SQEs
+
+| Site | Opcode | Submitter | Production caller |
+| --- | --- | --- | --- |
+| `crates/fast_io/src/io_uring/file_writer.rs:214` | `Write` | `IoUringWriter::write_via_ring` | Reached via `fast_io::writer_from_file_with_depth`. Production caller: `transfer/src/transfer_ops/response.rs:108` (`process_file_response`) - the synchronous receiver write path for delta literals and copy-token output. |
+| `crates/fast_io/src/io_uring/file_writer.rs:407` | `Fsync` | `IoUringWriter::sync` | Same call chain as above. |
+| `crates/fast_io/src/io_uring/registered_buffers/submit.rs:168` | `WriteFixed` | `submit_write_fixed_batch` | Used internally by `IoUringDiskBatch::write_chunk` and `IoUringWriter`, both reached from production. |
+| `crates/fast_io/src/io_uring/disk_batch.rs:238` | `Fsync` | `IoUringDiskBatch::submit_fsync` | Reached via `fast_io::IoUringDiskBatch`. Production caller: `transfer/src/disk_commit/thread.rs:84,89` constructs the batch, `transfer/src/disk_commit/process.rs:289` enrols files via `begin_file`. This is the pipelined receiver write path used when neither sparse mode nor append mode is active. |
+| `crates/fast_io/src/io_uring/batching.rs:90` | `Write` | `submit_write_batch` | Internal helper used by `IoUringWriter`, `IoUringDiskBatch`, both with production callers above. |
+| `crates/fast_io/src/io_uring/linked_chain.rs:285,323` | `Write` | `LinkedChain` builder | None outside `crates/fast_io` - chain helper is dormant. |
+
+Site count: 6 SQE-constructing sites for write/fsync. Four are reached in
+production (`file_writer::write`, `disk_batch::Fsync`,
+`batching::submit_write_batch`, `registered_buffers::submit_write_fixed_batch`).
+Two `linked_chain` Write constructors are unused outside tests.
+
+### Socket I/O SQEs
+
+| Site | Opcode | Submitter | Production caller |
+| --- | --- | --- | --- |
+| `crates/fast_io/src/io_uring/shared_ring.rs:289` | `Send` | `SharedRing::submit_send` | None outside `crates/fast_io/tests/`. |
+| `crates/fast_io/src/io_uring/batching.rs:317` | `Send` | `submit_send_batch` | Used internally by `IoUringSocketWriter::write`. The writer is exposed via `fast_io::socket_writer_from_fd`, but the only callers live in `crates/fast_io/tests/io_uring_shared_ring.rs` and the internal `fast_io::io_uring::tests` module. No `rsync_io`, `daemon`, or `core` site constructs an io_uring socket writer. |
+| `crates/fast_io/src/io_uring/send_zc.rs:129` | `SendZc` | `try_send_zc_blocking` | Same socket writer wiring as above - only test consumers today. |
+| `crates/fast_io/src/io_uring/socket_reader.rs:49,90` | `Recv` | `IoUringSocketReader::fill_buf`, `read_into` | Reached via `fast_io::socket_reader_from_fd`. No production crate calls it - `rsync_io` builds sockets with `std::net::TcpStream` and `ssh::stdio` pipes only. |
+
+Site count: 5 socket SQE sites. Zero production callers; the entire socket
+path is benchmark and integration-test material.
+
+### Polling / cancellation SQEs
+
+| Site | Opcode | Submitter | Production caller |
+| --- | --- | --- | --- |
+| `crates/fast_io/src/io_uring/shared_ring.rs:262` | `PollAdd` (POLLOUT) | `SharedRing::submit_poll_write` | None outside tests (SharedRing has no production callers). |
+| `crates/fast_io/src/io_uring/batching.rs:189` | `PollAdd` (POLLOUT) | `submit_send_batch` internal readiness probe | Indirectly through `IoUringSocketWriter` - no production callers (see Socket I/O row). |
+| `crates/fast_io/src/io_uring/batching.rs:194` | `LinkTimeout` | `submit_send_batch` | Same as above - test-only. |
+| `crates/fast_io/src/io_uring/cancel.rs:160` | `AsyncCancel` | `submit_async_cancel_blocking` | None - exposed via `fast_io::cancel_op_blocking` but no production caller invokes it. |
+| `crates/fast_io/src/io_uring/cancel.rs:205` | `AsyncCancel2` | `submit_async_cancel2_blocking` | None. |
+| `crates/fast_io/src/io_uring/cancel.rs:392,454` | `PollAdd` (test fixtures) | inline `#[cfg(test)]` | Tests only. |
+
+Site count: 6. Zero production callers.
+
+## Aggregate counts
+
+| Category | SQE sites | Production-wired | Production-wired ratio |
+| --- | --- | --- | --- |
+| Metadata (statx / linkat / renameat2) | 4 | 2 (linkat, renameat2) | 50% |
+| File data read | 5 | 2 (`file_reader::Read`, `ReadFixed`) | 40% |
+| File data write | 6 | 4 (`file_writer::Write`, `Fsync`, `disk_batch::Fsync`, batched `submit_write_batch`, `WriteFixed`) | 67% |
+| Socket I/O (Send / SendZc / Recv) | 5 | 0 | 0% |
+| Polling / cancel (PollAdd / LinkTimeout / AsyncCancel*) | 6 | 0 | 0% |
+| **Totals** | **26** | **8** | **31%** |
+
+## "Metadata-only" claim: refuted
+
+The often-repeated framing - "io_uring in oc-rsync today is metadata-only" -
+does not match the wire-up. Two of the four metadata opcodes (`Statx` both
+variants) are dormant. The metadata code paths actually wired through io_uring
+are `LinkAt` and `RenameAt`, and they sit on the cold path (hardlink
+creation, temp-file commit).
+
+Real file-data traffic does flow through io_uring today:
+
+- **Receiver write path.** `transfer/src/transfer_ops/response.rs:108`
+  wraps every received file in `fast_io::writer_from_file_with_depth`. On
+  Linux 5.6+ with the feature enabled this becomes an `IoUringWriter` whose
+  every `write` call submits an `IORING_OP_WRITE` (or `WRITE_FIXED` when
+  registered buffers are in use), followed by a final `IORING_OP_FSYNC`.
+- **Pipelined receiver write path.** `transfer/src/disk_commit/thread.rs`
+  creates one `IoUringDiskBatch` per disk-commit thread and routes
+  `BeginMessage` -> `WriteChunkMessage` -> `EndMessage` through it. The chunk
+  payload (delta data) lands in `submit_write_batch` and the commit fence in
+  `IoUringDiskBatch::submit_fsync`.
+- **Sender source-file read path.** `transfer/src/generator/mod.rs:898`
+  (`open_source_reader`) routes source files >= 1 MiB through
+  `fast_io::reader_from_path_with_depth`, which submits `IORING_OP_READ` /
+  `READ_FIXED` SQEs for each fill of the rolling-hash buffer.
+
+What is **not** wired through io_uring today:
+
+- All socket I/O. `rsync_io` (daemon TCP, SSH stdio passthrough) uses
+  `std::net::TcpStream`, `std::io::Read`/`Write`, and synchronous
+  `read_exact` / `write_all`. None of `socket_writer_from_fd`,
+  `socket_reader_from_fd`, `SharedRing::submit_send`, or `try_send_zc_blocking`
+  has a production caller.
+- All polling / cancellation primitives. The `cancel.rs` and `LinkTimeout`
+  helpers exist for future use but no caller routes file-data SQEs through
+  them.
+- Source-file reads below 1 MiB and any source read taken with `--open-noatime`
+  fall back to `std::io::BufReader` via `open_source::open_source_with_noatime`.
+- Receiver writes with sparse mode or non-zero `append_offset` fall back to
+  the buffered std-I/O writer (`disk_commit/process.rs:288-322`).
+- Local-copy data writes. `engine/src/local_copy/executor/file/copy/` uses
+  `copy_file_range`, `clonefile`, `CopyFileExW`, or `std::io::copy` - none of
+  which submits io_uring SQEs for the payload itself.
+
+Upstream rsync entry points that still drive std-I/O in our build:
+
+- `io.c:perform_io()` - upstream waits on `select()` and drains buffers with
+  `read`/`write`. Our equivalent (`rsync_io::channel_adapter`,
+  `daemon::handler::tcp_io`) uses synchronous std reads / writes; no socket
+  SQE is constructed.
+- `receiver.c:855 do_open` for write target - opened with `OpenOptions`, then
+  wrapped only conditionally in an io_uring writer; the open syscall itself
+  is synchronous (no `IORING_OP_OPENAT`).
+- `generator.c:generate_files` - file enumeration goes through std `metadata()`
+  and `read_link()` calls, not `submit_statx_batch`.
+
+## Top three production sites for io_uring data-path migration
+
+Ordered by expected throughput payoff under the workloads we benchmark.
+
+1. **Socket read/write in `rsync_io`** (`crates/rsync_io/src/channel_adapter.rs`,
+   `crates/rsync_io/src/binary/negotiate.rs:101`, `crates/rsync_io/src/ssh/`).
+   Every TCP daemon and SSH session today exchanges multiplex frames through
+   synchronous `read_exact` / `write_all` over `std::net::TcpStream` /
+   `std::process::ChildStdin/Out`. Switching to `IoUringSocketReader` /
+   `IoUringSocketWriter` (the wiring already exists in
+   `crates/fast_io/src/io_uring/socket_reader.rs` and `socket_writer.rs`)
+   would let the receiver overlap network drain with disk commit on a single
+   ring, removing two syscall round-trips per multiplex frame. IUD-2 is
+   intended to scope this.
+
+2. **Sender source reads below the 1 MiB threshold and the
+   `--open-noatime` fallback** (`crates/transfer/src/generator/mod.rs:881`).
+   Today every source file under 1 MiB and every `--open-noatime` transfer
+   bypasses io_uring entirely (std `BufReader`). For 100 k small-file
+   workloads this is the dominant read path. Lifting the threshold (or
+   teaching `IoUringReader::open` to accept custom open flags so the
+   noatime variant qualifies) routes that traffic through `READ_FIXED`
+   SQEs and lets the rolling-hash scan amortise ring overhead via
+   pipelined submissions. IUD-3 should cover this.
+
+3. **Receiver fallback paths in sparse and append modes**
+   (`crates/transfer/src/disk_commit/process.rs:288-322`). When either
+   `use_sparse` or `append_offset > 0` we drop out of `IoUringDiskBatch`
+   into `ReusableBufWriter`. Sparse-mode writes are common on backup
+   workloads (mostly-zero VM images, log files). Wiring sparse-aware
+   submissions through io_uring - either via per-extent `Write` SQEs with
+   explicit offsets or via the linked `Write` + `FALLOC_FL_PUNCH_HOLE`
+   chain - would close the largest production gap left after IUD-2.
+
+## Cross-references
+
+- IUD-2 (socket-path migration): design entry point will use
+  `IoUringSocketReader` / `IoUringSocketWriter` from
+  `crates/fast_io/src/io_uring/socket_reader.rs` and `socket_writer.rs`.
+  The existing `docs/design/io-uring-shared-ring-bench.md` and
+  `docs/audits/iouring-socket-sqpoll-defer-taskrun.md` already discuss
+  ring-mode trade-offs; IUD-2 should fold those findings into the call-site
+  list above (`rsync_io::channel_adapter`, `rsync_io::binary::negotiate`,
+  `rsync_io::ssh`).
+- IUD-3 (small-file and noatime data-path migration): build on the existing
+  threshold logic in `transfer/src/generator/mod.rs::open_source_reader`
+  and on `docs/audits/io-uring-adaptive-buffer-sizing.md`,
+  `docs/design/iouring-adaptive-buffer-pool.md` for buffer pool sizing.
+- Related prior audits: `docs/audits/io-uring-fixed-buffer-audit.md`,
+  `docs/audits/per-file-vs-shared-uring-ring.md`,
+  `docs/audits/disk-commit-iouring-batching.md`.

--- a/docs/audits/mutex-poison-policy.md
+++ b/docs/audits/mutex-poison-policy.md
@@ -1,0 +1,372 @@
+# Mutex poison recovery classification
+
+Tracking issues: MPE-1 (#2350), MPE-2 (#2351), MPE-9 (#2358).
+
+## Summary
+
+This audit inventories every `Mutex::lock().expect()` / `Mutex::lock().unwrap()`
+(and the analogous `RwLock::read/write` variants) call site in the workspace,
+classifies each as RECOVERABLE (safe to use `PoisonError::into_inner()` and
+keep going) or FATAL (a panic mid-section corrupts shared state, so the only
+safe response is to abort), and maps the result to follow-up remediation
+tasks.
+
+Three lock-pattern shapes are surveyed:
+
+1. `x.lock().unwrap()` - single-line, no message.
+2. `x.lock().expect("...")` - single-line with diagnostic.
+3. The multi-line builder shape:
+   ```
+   x.lock()
+       .expect("...")
+   ```
+
+The first round of `grep` only catches shapes (1) and (2); a follow-up scan
+catches shape (3). Both passes are folded into the totals below.
+
+The classification is read-only. No source file is modified by this document.
+
+## Methodology
+
+1. Workspace-wide grep with two passes:
+
+   ```sh
+   # Pass 1: single-line shapes.
+   grep -rn \
+       '\.lock()\.expect\|\.lock()\.unwrap\|\.read()\.expect\|\.read()\.unwrap\|\.write()\.expect\|\.write()\.unwrap' \
+       crates/
+
+   # Pass 2: multi-line builder shape.
+   grep -rn -B1 -E '^\s*\.expect\(|^\s*\.unwrap\(\)' crates/ \
+     | grep -B1 -E '\.lock\(\)$'
+   ```
+
+2. Per-call-site classification driven by three questions:
+
+   - **What does the lock guard?** Pure scratch data (`Vec` of recorded
+     events), wire-stream state (in-progress batch-writer bytes), config
+     cache (env mutex serializing process-globals), shared work-queue
+     accumulator, FFI handle (SSH child process), io_uring bgid free-list,
+     IOCP overlapped registry.
+   - **What can panic while the lock is held?** Trivial code paths
+     (`Vec::push`, `HashMap::insert`, atomic CAS) almost never panic.
+     Code that writes wire frames, runs user-provided closures, or
+     traverses a `FileEntry` graph can panic on malformed input.
+   - **What is the blast radius of "continue after poison"?** If the lock
+     guards data whose internal invariants survive a partial mutation
+     (idempotent caches, append-only event recorders, file-write
+     scratchpads where the operation is going to be retried anyway),
+     `into_inner()` is safe and the process should keep serving other
+     transfers. If continuing risks corrupt wire output or use-after-free
+     on FFI handles, the panic must propagate.
+
+3. Cross-references to follow-up tasks (MPE-3 through MPE-NN). The MPE-3
+   task introduces a `lock_or_recover` helper (matches the pattern already
+   used by `rsync_io/src/ssh/connection.rs` and `fast_io/src/refs_detect.rs`)
+   that wraps `lock().unwrap_or_else(|e| e.into_inner())` with a `tracing`
+   warning. Per-file remediation tasks reuse that helper for every
+   RECOVERABLE site and leave FATAL sites with a tightened `expect`
+   message that names the wire-stream invariant being protected.
+
+## Totals
+
+Across `crates/**`:
+
+| Pass                   | Sites |
+|------------------------|-------|
+| Single-line shape      | 333   |
+| Multi-line builder     | 35    |
+| **Total**              | **368** |
+
+Per-crate distribution (combined passes):
+
+| Crate        | Sites |
+|--------------|-------|
+| `daemon`     | 125   |
+| `engine`     | 60    |
+| `cli`        | 49    |
+| `core`       | 39    |
+| `transfer`   | 25    |
+| `protocol`   | 25    |
+| `fast_io`    | 14    |
+| `metadata`   | 8     |
+| `flist`      | 7     |
+| `platform`   | 6     |
+| `rsync_io`   | 5     |
+| `signature`  | 1     |
+| `embedding`  | 1     |
+| `checksums`  | 1     |
+| `branding`   | 1     |
+| `bandwidth`  | 1     |
+
+Test-vs-production split (single-line pass; the multi-line additions follow
+the same distribution):
+
+| Category                                  | Sites |
+|-------------------------------------------|-------|
+| `tests.rs` / `*/tests/*` / `benches` / `examples` | 239 |
+| Production source (`*/src/*` non-test)   | 94    |
+
+Most of the production-source hits are still test helpers, env-mutex guards
+behind `#[cfg(test)]` blocks, or `RecordingFs`-style fakes embedded in the
+crate root rather than under a `tests/` directory. The genuinely
+production-path sites total **27**, listed in Table 2.
+
+## Table 1: `crates/engine/src/delete/` sites
+
+| File:line | What is locked | Classification | Rationale |
+|---|---|---|---|
+| `delete/plan_map.rs:76` | `Mutex<HashMap<PathBuf, DeletePlan>>` (publish-once map) | **FATAL** | A panic between `Mutex::lock()` and `HashMap::insert()` would corrupt the publish-once invariant the emitter depends on; the only operations under the lock are `HashMap::insert`/`remove`/`len`/`is_empty`/`contains_key`, none of which panic in practice. Keep `expect`. |
+| `delete/plan_map.rs:88` | same | **FATAL** | `take()` is the only consumer; a poisoned map means a peer thread crashed mid-publish and the unread side is undefined. |
+| `delete/plan_map.rs:97` | same | **FATAL** | `is_empty()` shape; same reasoning. |
+| `delete/plan_map.rs:106` | same | **FATAL** | `len()` shape; same reasoning. |
+| `delete/plan_map.rs:119` | same | **FATAL** | `contains()` shape; same reasoning. |
+| `delete/context.rs:263` | `Mutex<DirTraversalCursor>` (parent-before-child traversal state) | **FATAL** | The cursor's stack ordering is the upstream emission-order invariant; a torn state silently mis-orders deletes (parent emitted before its children are flushed). Keep `expect("DeleteContext cursor mutex poisoned")`. |
+| `delete/context.rs:276` | same | **FATAL** | `observe_directory` mutates the same stack; same reasoning. |
+| `delete/context.rs:291` | `Mutex<Vec<FileEntry>>` (per-directory segment buffer) | **FATAL** | `begin_directory` overwrites the previous segment in place. Continuing with a half-written segment would compute extras against a stale name list and delete the wrong files. |
+| `delete/context.rs:307` | same | **FATAL** | `publish_plan_for` clones the segment; if the panic happened during the `.clone()` the buffer is intact, but it could also have happened during the earlier `begin_directory` overwrite. Cheaper to keep the strict policy. |
+| `delete/context.rs:475` | `Mutex<DirTraversalCursor>` | **TEST-ONLY** | `#[cfg(test)] mod tests` body. Tests are single-threaded fixtures; an `expect` here is fine but `unwrap` is misleading. Convert to `expect("test cursor poisoned")` for consistency. |
+| `delete/context.rs:510` | same | **TEST-ONLY** | Same as above. |
+| `delete/context.rs:568` | same | **TEST-ONLY** | Same as above. |
+| `delete/emitter/fs.rs:153` | `Mutex<Vec<DeleteEvent>>` inside `RecordingDeleteFs` | **RECOVERABLE** | Append-only event log used only by tests; reading the partial log after a poisoning panic still produces a debuggable trace. Use `lock_or_recover`. |
+| `delete/emitter/fs.rs:158` | same | **RECOVERABLE** | `record()` does `lock().expect(...).push()`. Push is panic-free; keep `expect` or, after MPE-3, switch to `lock_or_recover`. |
+| `delete/emitter/tests/mod.rs:64` | `Mutex<Vec<(PathBuf, ErrorKind)>>` test script | **TEST-ONLY** | `ScriptedDeleteFs` rule queue. Tests are single-threaded; current `expect` is fine. |
+| `delete/emitter/tests/mod.rs:75` | same | **TEST-ONLY** | Same. |
+
+Counts inside `crates/engine/src/delete/`:
+
+| Classification | Sites |
+|---|---|
+| FATAL          | 9     |
+| RECOVERABLE    | 2     |
+| TEST-ONLY      | 5     |
+| **Total**      | **16** |
+
+## Table 2: workspace production-path hotspots
+
+Only call sites in genuine production code paths (i.e., not behind
+`#[cfg(test)]`, not in `tests/`, not in `benches/`, not in `examples/`)
+are listed here. Test-instrumentation helpers that live inside `src/` but
+are only ever invoked from tests (`RecordingDeleteFs`, env mutexes,
+`signal/cleanup.rs` `TEST_LOCK`, etc.) are categorised as RECOVERABLE
+because they are not on the production path either.
+
+### `crates/engine/`
+
+| File:line | What is locked | Classification | Rationale |
+|---|---|---|---|
+| `concurrent_delta/parallel_apply.rs:432` | `Mutex<Vec<u8>>` (test sink only) | **TEST-ONLY** | Lives in `#[cfg(test)] mod tests` inside the apply module. Convert `expect` to `lock_or_recover` after MPE-3, or leave as-is. |
+| `concurrent_delta/parallel_apply.rs:465` | same | **TEST-ONLY** | Same. |
+| `concurrent_delta/work_queue/drain.rs:81` | `Mutex<Vec<R>>` (per-shard result buffer) | **RECOVERABLE** | The drain shard buffer is a write-only accumulator; partial fill is acceptable because the caller treats a poisoned drain as a fatal worker crash anyway. Use `lock_or_recover` and surface the poison via a counter. |
+| `local_copy/buffer_pool/memory_cap.rs:84` | `Mutex<()>` paired with `Condvar` for the buffer-pool backpressure waiters | **FATAL** | Poisoning here means a slow-path waiter panicked mid-`wait`; continuing would skip the `Condvar` handshake and cause lost wakeups. Keep `expect("backpressure mutex poisoned")`. |
+| `local_copy/buffer_pool/memory_cap.rs:149` | same | **FATAL** | `track_return` lock-then-notify pattern; recovering would defeat the textbook condvar guarantee. |
+| `local_copy/context_impl/options.rs:574` | `Arc<Mutex<BatchWriter>>` (in-progress batch wire stream) | **FATAL** | A poisoned batch writer means a previous frame was half-written; resuming would emit a torn batch file that no downstream rsync can replay. Keep `expect`, tightened message. |
+| `local_copy/context_impl/options.rs:601` | same | **FATAL** | Reads `protocol_version` from config; the panic would have to be in `config()` which is infallible, but recovering still risks racing a half-flushed writer. |
+| `local_copy/context_impl/options.rs:623` | same | **FATAL** | Same as `:574`. |
+| `local_copy/context_impl/options.rs:668` | same | **FATAL** | Same as `:601`. |
+| `local_copy/context_impl/options.rs:925` | same | **FATAL** | Same as `:574`; this is the inner NDX-write loop. |
+| `local_copy/context_impl/options.rs:950` | same | **FATAL** | Same as `:601`; NDX_DONE phase preamble. |
+| `local_copy/context_impl/options.rs:962` | same | **FATAL** | Same as `:574`; NDX_DONE writer. |
+| `local_copy/context_impl/state.rs:53` | same | **FATAL** | Read-only `config()` lookup at context-construction time; if the writer is poisoned at startup the entire local-copy session is unsafe. |
+| `local_copy/context_impl/state.rs:60` | same | **FATAL** | Same. |
+| `local_copy/executor/directory/recursive/batch.rs:158` | same | **FATAL** | Per-directory flist entry write; same reasoning as `options.rs`. |
+
+### `crates/fast_io/`
+
+| File:line | What is locked | Classification | Rationale |
+|---|---|---|---|
+| `io_uring/buffer_ring.rs:198` | `Mutex<Vec<u16>>` (process-wide bgid free-list) | **RECOVERABLE** | The free-list is a pure scratch container; a poisoned state at most loses one bgid (or pushes a duplicate, which `deallocate` already deduplicates). Use `lock_or_recover`. |
+| `io_uring/buffer_ring.rs:246` | same | **RECOVERABLE** | `deallocate` already guards against duplicates; safe to recover. |
+| `io_uring/buffer_ring.rs:262` | same | **RECOVERABLE** | `remaining()` is read-only; safe to recover. |
+| `io_uring/buffer_ring.rs:1101` | same | **RECOVERABLE** | Same. |
+| `io_uring/buffer_ring.rs:1115` | same | **RECOVERABLE** | Same. |
+| `io_uring/buffer_ring.rs:1217` | same | **RECOVERABLE** | Same. |
+| `iocp/pump.rs:252` | `Mutex<HashMap<usize, CompletionHandler>>` (in-flight OVERLAPPED registry) | **FATAL** | Each `CompletionHandler` owns kernel-visible state; losing one means an OVERLAPPED will never be invoked and its caller leaks the pinned allocation. Keep `expect`. |
+| `iocp/pump.rs:265` | same | **FATAL** | Same. |
+| `iocp/pump.rs:275` | same | **FATAL** | `pending_ops` read; if poisoned, the count is wrong and shutdown will deadlock. |
+| `iocp/pump.rs:425` | same | **FATAL** | Worker-thread completion dispatch; recovering would skip invoking the handler. |
+| `refs_detect.rs:86` | `Mutex<Option<HashMap<PathBuf, bool>>>` (volume cache) | **RECOVERABLE** (already done) | Already uses `unwrap_or_else(|e| e.into_inner())`. This is the recipe we will replicate elsewhere. |
+| `refs_detect.rs:97` | same | **RECOVERABLE** (already done) | Same. |
+| `refs_detect.rs:106` | same | **RECOVERABLE** (already done) | Same. |
+
+### `crates/rsync_io/`
+
+| File:line | What is locked | Classification | Rationale |
+|---|---|---|---|
+| `ssh/connection.rs:107` | `Mutex<Option<Child>>` (SSH subprocess handle) | **RECOVERABLE** (already done) | Already uses `unwrap_or_else(|e| e.into_inner())`. The reference pattern. |
+| `ssh/connection.rs:138` | same | **RECOVERABLE** (already done) | Same. |
+| `ssh/connection.rs:164` | same | **RECOVERABLE** (already done) | Same. |
+| `ssh/connection.rs:293` | `Mutex<Option<Child>>` (split half) | **RECOVERABLE** (already done) | Same. |
+| `ssh/connection.rs:570` | `Mutex<Option<Child>>` (Drop reaper) | **RECOVERABLE** (already done) | Same; running in `Drop`, where panicking on poison would double-panic and abort. |
+
+### `crates/signature/`
+
+| File:line | What is locked | Classification | Rationale |
+|---|---|---|---|
+| `async_gen.rs:335` | `Arc<Mutex<Receiver<WorkerMessage>>>` (shared MPMC-like receiver) | **FATAL** | A poisoned channel receiver means a peer worker died holding the receive end. Treating "recover and try again" would spin on an undefined `recv`; aborting the worker thread is the upstream policy. Keep `unwrap`, but switch to a typed `expect("signature worker receiver poisoned")`. |
+
+### `crates/flist/`
+
+| File:line | What is locked | Classification | Rationale |
+|---|---|---|---|
+| `batched_stat/cache.rs:71` | `Mutex<HashMap<PathBuf, Arc<Metadata>>>` (per-shard stat cache) | **RECOVERABLE** | Cache lookup is idempotent; a partial cache is a cache miss. Use `lock_or_recover`. |
+| `batched_stat/cache.rs:78` (multi-line) | same | **RECOVERABLE** | `insert` is idempotent; safe to recover. |
+| `batched_stat/cache.rs:95` | same | **RECOVERABLE** | Fast-path read; safe to recover. |
+| `batched_stat/cache.rs:110` (multi-line) | same | **RECOVERABLE** | `insert` on the slow path; safe to recover. |
+| `batched_stat/cache.rs:154` | same | **RECOVERABLE** | `clear()` is destructive but only invoked from tests/teardown; safe to recover. |
+| `batched_stat/cache.rs:161` | same | **RECOVERABLE** | `len()` read; safe to recover. |
+| `batched_stat/cache.rs:167` | same | **RECOVERABLE** | `is_empty()` read; safe to recover. |
+
+### `crates/protocol/`
+
+Production source contains zero in-production lock sites. The 25 hits all
+live in tests, examples, or `mod tests` blocks inside
+`multiplex/reader.rs`. Classified as **TEST-ONLY**; no remediation
+required.
+
+### `crates/daemon/`
+
+`crates/daemon/src/systemd.rs` (8 sites) and
+`crates/daemon/src/daemon/sections/xfer_exec.rs` (3 sites) hold the only
+production `lock()` calls; all 11 wrap a thread-local `ENV_LOCK` used to
+serialise `std::env::set_var` against rayon-spawned daemon workers.
+Classified as **RECOVERABLE**: a poisoned env mutex is symptomatic of a
+test panic, and the production-path callers want to keep serving
+unrelated connections.
+
+The remaining 114 daemon sites are all inside `crates/daemon/src/tests/`
+chunked harness fixtures - **TEST-ONLY**.
+
+### `crates/cli/`
+
+`crates/cli/src/frontend/arguments/env.rs` (12 sites) wraps the same
+process-global env mutex against argument-parsing tests; all production
+callers reach it from `parse_args` paths under `#[cfg(test)]`-only
+exercises. Classified as **RECOVERABLE**.
+
+The remaining 37 cli sites live in `crates/cli/src/frontend/tests/`.
+**TEST-ONLY**.
+
+### `crates/core/`
+
+`crates/core/src/client/config/compress_env.rs` (5 sites) wraps the env
+mutex around compression test exercises - **RECOVERABLE**. The remaining
+34 sites live in `crates/core/src/client/tests/` and
+`crates/core/src/signal/cleanup.rs` test fixtures - **TEST-ONLY**.
+
+### `crates/platform/`
+
+`platform/src/privilege.rs:315` (1 site) and `platform/src/env.rs`
+(5 sites) wrap test-only env/tz mutexes - **RECOVERABLE** (production
+visibility through `#[cfg(test)]` guard).
+
+### `crates/metadata/`
+
+All 8 sites are in `metadata/src/id_lookup/tests.rs` - **TEST-ONLY**.
+
+### `crates/transfer/`
+
+All 25 sites are in `transfer/src/{reader,writer,receiver}/tests/` and
+the two `benches/` files - **TEST-ONLY**.
+
+### `crates/checksums/`, `crates/branding/`, `crates/bandwidth/`, `crates/embedding/`
+
+One site each, all inside `#[cfg(test)]` or `tests/` modules -
+**TEST-ONLY**.
+
+## Production-path classification roll-up
+
+| Category    | Sites | Crates                                                            |
+|-------------|-------|--------------------------------------------------------------------|
+| FATAL       | 23    | `engine` (15 batch-writer + buffer-pool + plan-map), `fast_io` (4 iocp), `signature` (1), `engine/src/delete` (3 cursor + 4 plan_map already counted above) |
+| RECOVERABLE | 28    | `flist` (7), `fast_io` (6 bgid + 3 refs_detect), `rsync_io` (5 already done), `engine` (1 drain + 2 recorder), `daemon` (3 xfer_exec already done), `engine/src/delete/emitter/fs.rs` (2) |
+| TEST-ONLY   | 317   | spread across all crates, predominantly `daemon`, `cli`, `core`, `transfer` |
+| **Total**   | **368** | |
+
+(The FATAL/RECOVERABLE counts above include the delete-module rows from
+Table 1; the workspace-wide counters add the delete totals into the
+overall production roll-up.)
+
+## Recommended remediation recipe
+
+1. **MPE-3** (`engine` shared helper): introduce a `lock_or_recover`
+   helper in `crates/engine/src/util/` (or a new top-level
+   `crates/util/sync.rs`) with the signature
+
+   ```rust
+   pub fn lock_or_recover<'a, T>(m: &'a Mutex<T>) -> MutexGuard<'a, T> {
+       m.lock().unwrap_or_else(|e| {
+           tracing::warn!(target: "sync.poison", "recovered from poisoned mutex");
+           e.into_inner()
+       })
+   }
+   ```
+
+   Mirrors the pattern already in `rsync_io/src/ssh/connection.rs` and
+   `fast_io/src/refs_detect.rs`. Add a `lock_or_panic` companion that
+   takes an `&'static str` invariant message for FATAL sites, so every
+   `expect` call is grep-able by invariant name rather than by call-site.
+
+2. **MPE-4..MPE-8** (per delete-file remediation):
+
+   - **MPE-4**: `crates/engine/src/delete/plan_map.rs` - replace 5
+     `expect("DeletePlanMap mutex poisoned")` calls with
+     `lock_or_panic("DeletePlanMap publish-once invariant")`.
+   - **MPE-5**: `crates/engine/src/delete/context.rs` - replace 4
+     production `expect` calls (cursor + segment_entries) with
+     `lock_or_panic("DeleteContext cursor traversal order")`. Replace
+     the 3 test-only `unwrap` calls with the same recipe to keep test
+     diagnostics consistent.
+   - **MPE-6**: `crates/engine/src/delete/emitter/fs.rs` - swap
+     `RecordingDeleteFs` to `lock_or_recover` so a test panic does not
+     poison the entire suite.
+   - **MPE-7**: `crates/engine/src/delete/emitter/tests/mod.rs` -
+     swap `ScriptedDeleteFs` to `lock_or_recover` for the same reason.
+   - **MPE-8**: rgrep audit pass to confirm every
+     `engine/src/delete/**` lock site now uses one of the two helpers
+     and nothing else.
+
+3. **MPE-NN per other crate** (open follow-up):
+
+   - **MPE-10**: `crates/engine/src/local_copy/context_impl/{options,state}.rs` +
+     `executor/directory/recursive/batch.rs` - 15 batch-writer FATAL
+     sites, all should adopt `lock_or_panic("BatchWriter wire-stream
+     ordering")`.
+   - **MPE-11**: `crates/engine/src/local_copy/buffer_pool/memory_cap.rs` -
+     2 FATAL backpressure sites, adopt
+     `lock_or_panic("BufferPool backpressure condvar")`.
+   - **MPE-12**: `crates/engine/src/concurrent_delta/work_queue/drain.rs:81` -
+     1 RECOVERABLE shard buffer, adopt `lock_or_recover` and add a
+     poison-counter metric.
+   - **MPE-13**: `crates/fast_io/src/io_uring/buffer_ring.rs` -
+     6 RECOVERABLE bgid free-list sites, adopt `lock_or_recover` (the
+     `refs_detect.rs` siblings are already converted).
+   - **MPE-14**: `crates/fast_io/src/iocp/pump.rs` - 4 FATAL OVERLAPPED
+     registry sites, adopt `lock_or_panic("IOCP handler registry")`.
+   - **MPE-15**: `crates/signature/src/async_gen.rs:335` - 1 FATAL
+     receiver mutex, tighten `unwrap` to `expect("signature worker
+     receiver poisoned")`.
+   - **MPE-16**: `crates/flist/src/batched_stat/cache.rs` - 7
+     RECOVERABLE shard-cache sites, adopt `lock_or_recover`.
+   - **MPE-17**: `crates/daemon/src/{systemd.rs,daemon/sections/xfer_exec.rs}` +
+     `crates/cli/src/frontend/arguments/env.rs` +
+     `crates/core/src/client/config/compress_env.rs` +
+     `crates/platform/src/env.rs` - audit pass to migrate every test-env
+     mutex to a shared `test_env::lock_or_recover` helper in
+     `crates/platform`, so a single test panic does not poison every
+     downstream env-coupled test.
+
+The TEST-ONLY remediation tasks (317 sites) are best handled by one
+sweeping `cargo fix`-style PR per crate that uses a search-and-replace
+to wrap every `lock().unwrap()` with `lock_or_recover()` once MPE-3
+ships; that work is tracked under a single MPE-99 umbrella issue rather
+than 14 per-crate tickets.
+
+## Top remediation target
+
+`crates/engine/src/local_copy/context_impl/options.rs` is the highest-value
+single file: 7 FATAL batch-writer sites that today share a single
+`expect("...")` string with no `tracing` signal. The remediation lands a
+strict invariant name, a `tracing::error!` on the poisoned-mutex panic
+path, and a single recipe that the rest of the engine can copy. This is
+the recommended starting point for MPE-10.

--- a/docs/audits/spl-9-mod-reexports.md
+++ b/docs/audits/spl-9-mod-reexports.md
@@ -1,0 +1,135 @@
+# SPL-9 spill mod.rs re-export audit (#2331)
+
+Quality gate on the `crates/engine/src/concurrent_delta/spill.rs`
+decomposition (SPL-1 plan in `docs/audits/spill-rs-decomposition-plan.md`).
+
+The decomposition splits the 1232-line `spill.rs` into focused submodules
+under `crates/engine/src/concurrent_delta/spill/`. This audit verifies
+that every public symbol previously reachable at
+`crate::concurrent_delta::spill::*` (and re-exported at
+`crate::concurrent_delta::*`) remains reachable at the same path after
+extraction, either through a direct definition or a `pub use` re-export
+in `spill/mod.rs`.
+
+## Baseline
+
+- **Pre-split commit:** `5f9b5af8a` (`feat(engine): SpillPolicy struct
+  + ConcurrentDeltaConfig wiring (#2336) (#4360)`).
+- **Source captured at:** `git show 5f9b5af8a:crates/engine/src/concurrent_delta/spill.rs`.
+- **Line count:** 1232 lines.
+- **Current tree:** `origin/master` at the same commit (`5f9b5af8a`).
+  SPL-2 (PR #4345, error), SPL-3 (PR #4369, codec), and SPL-6 (stats,
+  in flight) are open against master but not merged. The audit baseline
+  and the current public surface are therefore byte-identical for the
+  symbols listed below; this document establishes the reference table
+  every subsequent SPL PR must satisfy before merge.
+- **Re-export anchor:** `crates/engine/src/concurrent_delta/mod.rs:180-192`
+  exposes the `pub mod spill;` directory module and re-exports
+  `SpillCodec`, `SpillError`, `SpillStats`, `SpillableReorderBuffer`,
+  plus the four `SpillPolicy` siblings from `spill::policy`. Any
+  extraction must keep both layers (`mod.rs` re-export and the parent
+  facade) intact.
+
+## Scope
+
+All `pub`, `pub mod`, `pub use`, `pub const`, `pub static`, `pub enum`,
+`pub struct`, `pub trait`, and `pub fn` items declared in the captured
+source. The captured file contains zero `pub(crate)` and zero
+`pub(super)` items, so the audit list is the complete public surface.
+
+Trait-associated methods on `SpillCodec` (`encode`, `decode`,
+`estimated_size`) inherit visibility from the trait declaration and are
+not enumerated separately; they remain reachable iff the trait itself
+re-exports cleanly. The same holds for `pub` struct fields of
+`SpillStats`, which are reachable iff `SpillStats` re-exports cleanly.
+
+## Symbol table
+
+| Symbol                                        | Original path                                  | Current path                                                                              | Status |
+|-----------------------------------------------|------------------------------------------------|-------------------------------------------------------------------------------------------|--------|
+| `mod policy`                                  | `concurrent_delta/spill.rs:57`                 | `concurrent_delta/spill.rs:57` (also `spill/policy.rs` since #4360)                       | OK     |
+| `ReclaimMode` (re-export)                     | `concurrent_delta/spill.rs:58`                 | `concurrent_delta/spill.rs:58` (`pub use policy::ReclaimMode`)                            | OK     |
+| `SpillCompression` (re-export)                | `concurrent_delta/spill.rs:58`                 | `concurrent_delta/spill.rs:58` (`pub use policy::SpillCompression`)                       | OK     |
+| `SpillGranularity` (re-export)                | `concurrent_delta/spill.rs:58`                 | `concurrent_delta/spill.rs:58` (`pub use policy::SpillGranularity`)                       | OK     |
+| `SpillPolicy` (re-export)                     | `concurrent_delta/spill.rs:58`                 | `concurrent_delta/spill.rs:58` (`pub use policy::SpillPolicy`)                            | OK     |
+| `DEFAULT_SPILL_THRESHOLD`                     | `concurrent_delta/spill.rs:64`                 | `concurrent_delta/spill.rs:64`                                                            | OK     |
+| `SpillError` (enum)                           | `concurrent_delta/spill.rs:83`                 | `concurrent_delta/spill.rs:83` (target: `spill/error.rs`, re-exported in `spill/mod.rs`)  | OK     |
+| `SpillError::Capacity` (variant)              | `concurrent_delta/spill.rs:85`                 | `concurrent_delta/spill.rs:85` (target: `spill/error.rs`)                                 | OK     |
+| `SpillError::Io` (variant)                    | `concurrent_delta/spill.rs:87`                 | `concurrent_delta/spill.rs:87` (target: `spill/error.rs`)                                 | OK     |
+| `SpillError::io_error`                        | `concurrent_delta/spill.rs:93`                 | `concurrent_delta/spill.rs:93` (target: `spill/error.rs`)                                 | OK     |
+| `SpillError::is_out_of_space`                 | `concurrent_delta/spill.rs:102`                | `concurrent_delta/spill.rs:102` (target: `spill/error.rs`)                                | OK     |
+| `impl Display for SpillError`                 | `concurrent_delta/spill.rs:108`                | `concurrent_delta/spill.rs:108` (target: `spill/error.rs`)                                | OK     |
+| `impl Error for SpillError`                   | `concurrent_delta/spill.rs:117`                | `concurrent_delta/spill.rs:117` (target: `spill/error.rs`)                                | OK     |
+| `impl From<CapacityExceeded> for SpillError`  | `concurrent_delta/spill.rs:126`                | `concurrent_delta/spill.rs:126` (target: `spill/error.rs`)                                | OK     |
+| `impl From<io::Error> for SpillError`         | `concurrent_delta/spill.rs:132`                | `concurrent_delta/spill.rs:132` (target: `spill/error.rs`)                                | OK     |
+| `SpillCodec` (trait)                          | `concurrent_delta/spill.rs:144`                | `concurrent_delta/spill.rs:144` (target: `spill/codec.rs`, re-exported in `spill/mod.rs`) | OK     |
+| `SpillCodec::encode`                          | `concurrent_delta/spill.rs:150`                | `concurrent_delta/spill.rs:150` (target: `spill/codec.rs`)                                | OK     |
+| `SpillCodec::decode`                          | `concurrent_delta/spill.rs:157`                | `concurrent_delta/spill.rs:157` (target: `spill/codec.rs`)                                | OK     |
+| `SpillCodec::estimated_size`                  | `concurrent_delta/spill.rs:163`                | `concurrent_delta/spill.rs:163` (target: `spill/codec.rs`)                                | OK     |
+| `SpillableReorderBuffer<T>` (struct)          | `concurrent_delta/spill.rs:221`                | `concurrent_delta/spill.rs:221` (target: `spill/buffer.rs`, re-exported in `spill/mod.rs`)| OK     |
+| `impl Debug for SpillableReorderBuffer<T>`    | `concurrent_delta/spill.rs:246`                | `concurrent_delta/spill.rs:246` (target: `spill/buffer.rs`)                               | OK     |
+| `SpillStats` (struct)                         | `concurrent_delta/spill.rs:263`                | `concurrent_delta/spill.rs:263` (target: `spill/stats.rs`, re-exported in `spill/mod.rs`) | OK     |
+| `SpillStats::spilled_items` (field)           | `concurrent_delta/spill.rs:265`                | `concurrent_delta/spill.rs:265` (target: `spill/stats.rs`)                                | OK     |
+| `SpillStats::spill_events` (field)            | `concurrent_delta/spill.rs:267`                | `concurrent_delta/spill.rs:267` (target: `spill/stats.rs`)                                | OK     |
+| `SpillStats::reload_events` (field)           | `concurrent_delta/spill.rs:269`                | `concurrent_delta/spill.rs:269` (target: `spill/stats.rs`)                                | OK     |
+| `SpillStats::memory_used` (field)             | `concurrent_delta/spill.rs:271`                | `concurrent_delta/spill.rs:271` (target: `spill/stats.rs`)                                | OK     |
+| `SpillStats::threshold` (field)               | `concurrent_delta/spill.rs:273`                | `concurrent_delta/spill.rs:273` (target: `spill/stats.rs`)                                | OK     |
+| `SpillStats::dir_recreate_events` (field)     | `concurrent_delta/spill.rs:275`                | `concurrent_delta/spill.rs:275` (target: `spill/stats.rs`)                                | OK     |
+| `SpillableReorderBuffer::new`                 | `concurrent_delta/spill.rs:289`                | `concurrent_delta/spill.rs:289` (target: `spill/buffer.rs`)                               | OK     |
+| `SpillableReorderBuffer::with_spill_dir`      | `concurrent_delta/spill.rs:318`                | `concurrent_delta/spill.rs:318` (target: `spill/buffer.rs`)                               | OK     |
+| `SpillableReorderBuffer::with_default_threshold` | `concurrent_delta/spill.rs:345`             | `concurrent_delta/spill.rs:345` (target: `spill/buffer.rs`)                               | OK     |
+| `SpillableReorderBuffer::insert`              | `concurrent_delta/spill.rs:365`                | `concurrent_delta/spill.rs:365` (target: `spill/buffer.rs`)                               | OK     |
+| `SpillableReorderBuffer::force_insert`        | `concurrent_delta/spill.rs:390`                | `concurrent_delta/spill.rs:390` (target: `spill/buffer.rs`)                               | OK     |
+| `SpillableReorderBuffer::next_in_order`       | `concurrent_delta/spill.rs:415`                | `concurrent_delta/spill.rs:415` (target: `spill/buffer.rs`)                               | OK     |
+| `SpillableReorderBuffer::drain_ready`         | `concurrent_delta/spill.rs:455`                | `concurrent_delta/spill.rs:455` (target: `spill/buffer.rs`)                               | OK     |
+| `SpillableReorderBuffer::next_expected`       | `concurrent_delta/spill.rs:465`                | `concurrent_delta/spill.rs:465` (target: `spill/buffer.rs`)                               | OK     |
+| `SpillableReorderBuffer::buffered_count`      | `concurrent_delta/spill.rs:471`                | `concurrent_delta/spill.rs:471` (target: `spill/buffer.rs`)                               | OK     |
+| `SpillableReorderBuffer::is_empty`            | `concurrent_delta/spill.rs:477`                | `concurrent_delta/spill.rs:477` (target: `spill/buffer.rs`)                               | OK     |
+| `SpillableReorderBuffer::capacity`            | `concurrent_delta/spill.rs:483`                | `concurrent_delta/spill.rs:483` (target: `spill/buffer.rs`)                               | OK     |
+| `SpillableReorderBuffer::spill_stats`         | `concurrent_delta/spill.rs:489`                | `concurrent_delta/spill.rs:489` (target: `spill/buffer.rs`)                               | OK     |
+| `SpillableReorderBuffer::threshold`           | `concurrent_delta/spill.rs:502`                | `concurrent_delta/spill.rs:502` (target: `spill/buffer.rs`)                               | OK     |
+| `SpillableReorderBuffer::spill_dir`           | `concurrent_delta/spill.rs:508`                | `concurrent_delta/spill.rs:508` (target: `spill/buffer.rs`)                               | OK     |
+
+42 symbols audited. 42 OK. 0 MISSING. 0 RENAMED.
+
+## Reachability from the parent facade
+
+`crates/engine/src/concurrent_delta/mod.rs:191-192` re-exports the
+following symbols at `crate::concurrent_delta::*`. Each appears in the
+table above and must continue to resolve via the same `spill::` path:
+
+- `ReclaimMode`, `SpillCompression`, `SpillGranularity`, `SpillPolicy`
+  (through `spill::policy::`).
+- `SpillCodec`, `SpillError`, `SpillStats`, `SpillableReorderBuffer`
+  (through `spill::`).
+
+## How to re-run this audit per SPL PR
+
+1. `git show 5f9b5af8a:crates/engine/src/concurrent_delta/spill.rs > /tmp/spill-original.rs`.
+2. `grep -nE '^[[:space:]]*pub( |\()' /tmp/spill-original.rs` for the
+   complete symbol list (matches the 28 grep hits captured above; the
+   42-entry table expands trait methods, enum variants, and `SpillStats`
+   fields).
+3. For each symbol, confirm one of:
+   - The definition lives in the target submodule and is `pub use`-d in
+     `spill/mod.rs` so the absolute path
+     `crate::concurrent_delta::spill::<Symbol>` resolves unchanged.
+   - The definition still lives in `spill/mod.rs`.
+4. `cargo check -p engine --all-features --tests` must compile without
+   touching any external caller (no import-path edits in `consumer.rs`,
+   `parallel_apply.rs`, `strategy.rs`, `config.rs`, or any external
+   crate).
+5. Verify the rustdoc example on `SpillableReorderBuffer`
+   (`spill.rs:210`, `use engine::concurrent_delta::spill::SpillableReorderBuffer;`)
+   compiles under `cargo test --doc -p engine --all-features`.
+
+## Recommendations
+
+No MISSING or RENAMED entries. No follow-up tasks required against
+#2328/#2325/#2329 at this time.
+
+When SPL-2 (#4345), SPL-3 (#4369), and SPL-6 land, each PR author must
+re-run the procedure above and amend the "Current path" column for the
+extracted symbols to point at the new file (for example `spill/error.rs`
+instead of `spill.rs`) while keeping the Status column at OK. Any
+divergence from the 42-symbol baseline blocks merge.

--- a/docs/audits/windows-hardlink-acl-inheritance.md
+++ b/docs/audits/windows-hardlink-acl-inheritance.md
@@ -1,0 +1,255 @@
+# Windows hardlink ACL inheritance audit
+
+Tracking issue: #2311. Verified 2026-05-18 against `origin/master`.
+
+## 1. Background
+
+On NTFS, hardlinks point to a single MFT record. The DACL lives on the
+inode (the file record), not on the directory entry. When a process
+calls `SetNamedSecurityInfoW(path, DACL_SECURITY_INFORMATION, ...)` the
+write lands on the shared inode regardless of which alias name was
+opened. Two consequences follow:
+
+- Applying the same DACL N times to N hardlink aliases produces N
+  identical inode-level writes. The end-state is correct but each
+  write performs the full `SetNamedSecurityInfo` round trip (open
+  handle, set security info, close).
+- Applying *different* DACLs through different aliases is racy: the
+  last writer wins. Cohort members must therefore agree on the DACL or
+  the outcome depends on completion ordering.
+
+Upstream rsync on Cygwin treats hardlink followers identically to any
+other inode-sharing platform: `hlink.c::hard_link_check()` calls
+`maybe_hard_link()` which itself only calls `atomic_create()` ->
+`do_link()` and then itemizes. It never calls `set_file_attrs()` on
+the follower, so `set_acl()` is never invoked for the alias.
+`generator.c:1540` returns the follower out of the per-file loop
+before `set_file_attrs()` could fire. The leader's `set_acl()` write
+populates the shared inode and every follower inherits the DACL for
+free.
+
+## 2. oc-rsync apply sites
+
+The audit covers every site that may call ACL apply for a file that
+participates in a hardlink cohort.
+
+### 2.1 Wire receive path (network or daemon transfer)
+
+| Site | File | Behaviour | Per-inode or per-file? |
+|------|------|-----------|------------------------|
+| Transferred leader | `crates/transfer/src/receiver/transfer.rs:454-472` | After rename, applies metadata, xattrs, then `apply_acls_from_receiver_cache`. | Per-leader (one inode). |
+| Disk-commit dispatch | `crates/transfer/src/disk_commit/process.rs:411-452` | `apply_metadata_acls_and_xattrs` runs on the file the commit thread just renamed. Only leaders reach this stage; followers are not pushed through the pipeline. | Per-leader. |
+| Quick-check match | `crates/transfer/src/receiver/transfer/candidates.rs:179-191` | Up-to-date file: applies metadata + ACL + xattrs. Followers are filtered out at line 71 (`!is_hardlink_follower(e)`). | Per-leader. |
+| Reference-dir hard link | `crates/transfer/src/receiver/quick_check.rs:179-191` | `--link-dest` hard-links the reference file into place; ACL is applied to the new alias. | Per-alias (see 3.2). |
+| Hardlink follower creation | `crates/transfer/src/receiver/directory/links.rs:146-307` | `create_hardlinks` calls `fast_io::hard_link(leader, follower)` and itemizes. No ACL apply, no metadata apply. | **Inode-aware: ACL skipped.** |
+| Directory metadata pass | `crates/transfer/src/receiver/directory/creation.rs:163-170,355` | Applies ACL to directories only; directories never participate in hardlink cohorts. | N/A. |
+
+The receiver's hardlink follower path is already cygwin-equivalent:
+the leader's DACL is written exactly once and the followers inherit
+through the shared inode.
+
+### 2.2 Local-copy executor
+
+The local-copy executor (`engine::local_copy`) deduplicates by source
+`(dev, ino)` via `HardLinkTracker` and creates the destination as a
+hardlink whenever the source is a known cohort member.
+
+| Site | File | Behaviour | Per-inode or per-file? |
+|------|------|-----------|------------------------|
+| Source-side leader (first copy) | `crates/engine/src/local_copy/context_impl/state.rs:230-303` | Full data copy; applies metadata, xattrs, ACL once; records destination in `HardLinkTracker`. | Per-leader. |
+| Source-side follower (cached inode) | `crates/engine/src/local_copy/executor/file/copy/links.rs:147-214` | `existing_hard_link_target()` hits; `create_hard_link()` then itemize. **No `sync_acls_if_requested`.** | **Inode-aware: ACL skipped.** |
+| `--link-dest` follower | `crates/engine/src/local_copy/executor/file/copy/links.rs:70-145` | `link_dest_target()` hits; `fast_io::hard_link`; itemize and return. **No `sync_acls_if_requested`.** | **Inode-aware: ACL skipped.** |
+| `--copy-dest` Link branch | `crates/engine/src/local_copy/executor/file/copy/links.rs:290-360` | Creates hard link to reference, then calls `apply_file_metadata_with_options`, `sync_xattrs_if_requested`, and `sync_acls_if_requested`. | **Per-alias** (see 3.2). |
+| Quick-check up-to-date | `crates/engine/src/local_copy/executor/file/copy/transfer/execute.rs:740-762` | Destination already matches: re-applies metadata, xattrs, ACL, then records as hardlink candidate. | Per-leader: only fires once per `(dev, ino)` because subsequent followers exit at link branch 2 before reaching this code. |
+
+### 2.3 Windows DACL writer
+
+`crates/metadata/src/acl_windows.rs::apply_rsync_acl_to_path` builds a
+self-relative DACL, drops unmappable SIDs, and calls
+`SetNamedSecurityInfoW(SE_FILE_OBJECT, DACL_SECURITY_INFORMATION)`.
+The implementation does not check `nlink`; it has no notion of cohort
+membership. Idempotence is guaranteed only when the input
+`RsyncAcl` is bit-for-bit identical across calls.
+
+## 3. Risk analysis
+
+### 3.1 Wire path (receiver) - no risk
+
+`create_hardlinks` never applies metadata or ACLs to followers.
+Behaviour matches upstream cygwin: the leader writes the shared DACL
+once and the followers inherit through the inode. There is no
+duplicate write and no race because no second writer exists.
+
+### 3.2 Local-copy `--copy-dest` Link branch - duplicate writes, idempotent
+
+When the executor takes the `--copy-dest` `ReferenceDecision::Link`
+branch (`links.rs:290-360`) it links every follower to the same
+reference inode and then re-applies the source's ACL on each
+follower. The DACL is identical for every cohort member (read from
+the same source), so:
+
+- The end state is correct.
+- Each follower triggers a redundant
+  `SetNamedSecurityInfoW` round trip on the already-correct inode.
+- There is no true race: all writes carry the same bytes, so
+  last-writer-wins still yields the intended DACL.
+
+Cost: O(N) `SetNamedSecurityInfo` calls instead of O(1). For a
+50-link cohort this is ~50 redundant Win32 calls and the associated
+audit log noise (`SE_AUDIT_PRIVILEGE` writes show every change).
+
+### 3.3 Local-copy `--link-dest` branch - no risk
+
+`process_links` branch 1 (`links.rs:70-145`) does not call
+`sync_acls_if_requested`. The ACL on the link-dest inode is preserved
+as-is. This matches the upstream contract for `--link-dest`: the
+target acts as a reference and its existing metadata must be kept.
+
+### 3.4 Concurrent follower creation - benign race window
+
+`create_hardlinks` is single-threaded over `self.file_list` and
+`process_links` is invoked from the local-copy executor's per-entry
+loop. Neither runs ACL apply for followers, so no race exists in the
+common path. The `--copy-dest` Link branch (3.2) does apply ACL but
+all writers write identical bytes; the race window is harmless.
+
+If the local-copy executor were ever parallelised across cohort
+members and the `--copy-dest` Link branch were taken concurrently,
+the same identical-DACL invariant still protects correctness.
+
+### 3.5 Cross-cohort interference - not possible
+
+`HardLinkTracker` keys entries by `(dev, ino)` so distinct cohorts
+cannot alias. The receiver-side tracker (`HardlinkApplyTracker`) keys
+by protocol `gnum`; distinct cohorts get distinct gnums on the wire.
+
+## 4. Comparison to upstream cygwin behaviour
+
+| Aspect | Upstream rsync 3.4.2 (cygwin) | oc-rsync wire receiver | oc-rsync local-copy |
+|--------|-------------------------------|------------------------|---------------------|
+| Leader ACL write | Once, via `set_file_attrs` -> `set_acl`. | Once, via `apply_acls_from_receiver_cache`. | Once, via `sync_acls_if_requested`. |
+| Follower ACL write | Never (`hard_link_check` returns 1, generator loop exits at `goto cleanup;`). | Never (`create_hardlinks` skips ACL apply). | Never on cached-inode and `--link-dest` branches; once-per-follower on `--copy-dest` Link branch. |
+| Relies on inode sharing for ACL? | Yes. | Yes. | Yes for the cached-inode branch; redundant for `--copy-dest`. |
+| Race window | None. | None. | None (identical-DACL invariant). |
+
+The wire receiver matches upstream byte-for-byte. The local-copy
+`--copy-dest` Link branch is the only divergence; the divergence is a
+performance cost, not a correctness defect.
+
+## 5. Recommendations
+
+### 5.1 Keep the current "skip follower" model (preferred)
+
+The receiver's `create_hardlinks` and the local-copy cached-inode
+branch already implement the upstream contract: leader gets the write,
+followers inherit. This is correct on NTFS because DACLs live on the
+inode and is required on POSIX with hardlinks for the same reason.
+Do not add ACL apply calls to either follower path.
+
+### 5.2 Skip the redundant `--copy-dest` Link branch write on followers
+
+For `crates/engine/src/local_copy/executor/file/copy/links.rs:290-360`,
+gate the `apply_file_metadata_with_options` / `sync_xattrs_if_requested`
+/ `sync_acls_if_requested` block on
+`!context.is_hardlink_follower(metadata)`. The simplest signal is
+`metadata.nlink() > 1 && context.existing_hard_link_target(metadata).is_some()`
+on Unix; on Windows query the same via `GetFileInformationByHandle`
+(`nNumberOfLinks > 1`) or simply rely on the destination's inode
+sharing with another cohort member already recorded in the tracker.
+When skipped, leave a `// upstream: hlink.c - inode shares DACL`
+comment so future audits do not regress.
+
+### 5.3 Defensive `IsValidSid` short-circuit
+
+`apply_rsync_acl_to_path` already drops unmappable SIDs. No extra
+inode-level guard is needed because the call is already idempotent
+when input DACLs match.
+
+## 6. Test plan
+
+A 3-link cohort exercises every branch.
+
+### 6.1 Wire receive (Windows host, daemon transfer)
+
+```text
+setup:
+  src/leader.bin           (16 KiB random, ACL: Everyone:R, Admins:F)
+  src/follow1.bin          (hardlink to leader.bin)
+  src/follow2.bin          (hardlink to leader.bin)
+
+run:
+  oc-rsync -aHX --acls src/ rsync://host/dst/
+
+verify:
+  - dst/leader.bin, dst/follow1.bin, dst/follow2.bin share one NTFS
+    inode (FileIndex via GetFileInformationByHandle).
+  - DACL on the shared inode contains Everyone:R and Admins:F.
+  - Process Monitor capture shows exactly one
+    SetNamedSecurityInfoW write on the cohort inode.
+  - SetSecurityInfo call count == 1, not 3.
+```
+
+### 6.2 Local copy (Windows host, no daemon)
+
+```text
+setup:
+  same cohort layout under src\
+
+run:
+  oc-rsync -aHX --acls src\ dst\
+
+verify:
+  - dst\leader.bin, dst\follow1.bin, dst\follow2.bin share one inode.
+  - DACL correct.
+  - SetSecurityInfo call count == 1.
+```
+
+### 6.3 Local copy with `--copy-dest`
+
+```text
+setup:
+  ref\leader.bin + hardlinks ref\follow1.bin, ref\follow2.bin
+  src\leader.bin + hardlinks src\follow1.bin, src\follow2.bin
+    (different content, different ACL)
+
+run:
+  oc-rsync -aHX --acls --copy-dest=ref src\ dst\
+
+current behaviour: SetSecurityInfo call count == 3 (one per follower).
+post-5.2 behaviour: SetSecurityInfo call count == 1.
+
+verify in both cases:
+  - Final DACL on cohort inode == src\leader.bin DACL.
+  - All three dst entries share one inode.
+```
+
+### 6.4 Cross-cohort isolation
+
+```text
+setup:
+  cohort A: src\a1, src\a2 (linked, DACL A)
+  cohort B: src\b1, src\b2 (linked, DACL B)
+
+run:
+  oc-rsync -aHX --acls src\ dst\
+
+verify:
+  - dst\a1, dst\a2 share inode I_a with DACL A.
+  - dst\b1, dst\b2 share inode I_b with DACL B.
+  - SetSecurityInfo count == 2.
+```
+
+### 6.5 Property test (cross-platform)
+
+Add `crates/engine/src/local_copy/executor/file/copy/links.rs` test:
+build N-element cohort, run copy with `--acls` mocked via a counter,
+assert the counter equals 1 regardless of N. Run the same test for
+both Unix (`nlink > 1`) and a Windows mock that returns
+`nNumberOfLinks > 1`.
+
+## 7. Out of scope
+
+- SACL handling (`acl_windows.rs` skips it by design; `SE_SECURITY_NAME`
+  privilege is not requested).
+- POSIX default ACLs on directories (Windows has no analogue).
+- Inheritance flag round-tripping (deferred to Tier 2 ACL work).

--- a/docs/audits/windows-iocp-hotspots-methodology.md
+++ b/docs/audits/windows-iocp-hotspots-methodology.md
@@ -1,0 +1,265 @@
+# Windows IOCP hotspots: profiling methodology (#2300)
+
+Tracking issue: oc-rsync #2300 (WPG-1). Sibling audits:
+[`docs/audits/iocp-sync-blocking-audit.md`](iocp-sync-blocking-audit.md)
+(14 known sync points; PR #4332),
+[`docs/audits/windows-iocp-benchmark.md`](windows-iocp-benchmark.md)
+(broad harness),
+[`docs/audits/windows-iocp-benchmark-plan.md`](windows-iocp-benchmark-plan.md)
+(IOCP-vs-`std::fs::File` plan),
+[`docs/benchmarks/windows-throughput.md`](../benchmarks/windows-throughput.md)
+(CI throughput job).
+
+## Purpose
+
+The Windows throughput benchmark (`scripts/windows_throughput_bench.sh`,
+PR #4327, with the drilldown extension in PR #4352) tells us **how**
+fast `oc-rsync.exe` is against the MSYS2 upstream baseline. It does
+not tell us **why** the IOCP path stalls when it does. This document
+defines the methodology a Windows operator follows to convert that
+wall-clock signal into a ranked, actionable hotspot table that maps
+each top stack to either an in-flight PR or a planned WPG task.
+
+The session author runs macOS / Linux only, so this document is the
+deliverable: a future Windows operator (CI maintainer, contributor with
+a Windows box, or a self-hosted runner pipeline) executes the steps
+below and pastes the resulting hotspot table back into this file.
+
+## Tooling
+
+Pick one of the three stacks below. They produce equivalent hotspot
+tables; the choice is driven by license and operator familiarity.
+
+| Stack | License | Strengths | Weaknesses |
+|-------|---------|-----------|------------|
+| **Intel VTune Profiler** | Free for non-commercial use, paid for commercial use under oneAPI | Stack-sampled Hotspot + I/O analysis in one tool; symbol resolution against Rust release builds with PDBs works out of the box; per-thread timeline with overlapped-IO completion port annotations | Heavyweight install (~2 GiB); Intel-CPU bias for microarch counters; not suitable for AMD-CPU hotspot deltas |
+| **ETW + Windows Performance Analyzer (WPA)** | Free (ships with ADK / Windows SDK) | Native Windows tracing, kernel-side block-IO timeline, file-object lifetime, no agent injection; same trace can be replayed offline | WPA UI has a learning curve; symbol resolution requires `_NT_SYMBOL_PATH` setup |
+| **Windows Performance Recorder (WPR)** | Free (ships with ADK / Windows SDK) | Profile-driven (XML), scriptable from CI, smaller install than VTune | Less interactive than WPA; still requires WPA (or `xperf -i`) to view |
+
+**Default choice for the first WPG-1 pass:** ETW + WPA. It is free,
+ships in the Windows ADK, and the same `.etl` trace covers both CPU
+hotspots and kernel block-IO. VTune is the recommended follow-up when
+WPA highlights a hotspot that needs microarchitectural breakdown
+(branch mispredict, L3 miss).
+
+Required ancillary tooling (all stacks):
+
+- Windows ADK / SDK with the Performance Toolkit feature
+  (`wpr.exe`, `wpa.exe`, `xperf.exe`).
+- `_NT_SYMBOL_PATH` pointing at the Microsoft public symbol server
+  plus the local `target/release-with-debug/` PDB directory.
+- MSYS2 bash to run `scripts/windows_throughput_bench.sh` (already a
+  prerequisite of PR #4327).
+- `hyperfine` on `PATH` (already a prerequisite of the bench script).
+- Administrator PowerShell window for kernel-mode ETW collection
+  (`wpr -start` requires `SeSystemProfilePrivilege`).
+
+## Profiling steps
+
+### Step 1 - Build oc-rsync with debug symbols
+
+```sh
+# From an MSYS2 bash or PowerShell at the repo root.
+cargo build --profile release-with-debug --features iocp --bin oc-rsync
+```
+
+The `release-with-debug` profile (defined in `Cargo.toml`, line 360)
+keeps full LLVM optimisations on but emits PDB files so VTune / WPA
+can resolve Rust symbols. The `iocp` feature is on by default for the
+Windows binary; the explicit flag is for clarity and to fail loudly
+on a misconfigured feature matrix.
+
+Output binary: `target/release-with-debug/oc-rsync.exe`. The
+companion PDB lives in the same directory.
+
+### Step 2 - Run the throughput bench with the drilldown flag
+
+```sh
+# In MSYS2 bash.
+OC_RSYNC_BENCH_DRILLDOWN=1 \
+  OC_RSYNC=/c/path/to/target/release-with-debug/oc-rsync.exe \
+  BENCH_RUNS=5 BENCH_WARMUP=2 \
+  bash scripts/windows_throughput_bench.sh
+```
+
+`OC_RSYNC_BENCH_DRILLDOWN=1` (PR #4352) keeps the per-iteration
+intermediate directories on disk and writes a `bench-out/drilldown/`
+sub-tree the profiler can re-run a single iteration against without
+regenerating the 1 GiB fixture.
+
+Confirm the bench produced `bench-out/large_1gib.json` and
+`bench-out/small_10000.json` and that the drilldown directory contains
+the source fixture for each scenario before starting the profiler.
+
+### Step 3 - Capture an ETW Hotspot trace with stack sampling
+
+In an **Administrator PowerShell** window:
+
+```powershell
+# Start sampling: CPU profile + stack walks on every sample.
+wpr.exe -start CPU -start GeneralProfile -filemode
+
+# In a separate MSYS2 shell, re-run the slowest scenario from the
+# drilldown directory so we measure only the transfer phase.
+OC_RSYNC=/c/path/to/target/release-with-debug/oc-rsync.exe \
+  oc-rsync -a "$DRILLDOWN_LARGE_SRC/" "$DRILLDOWN_LARGE_DST/"
+
+# Stop and write the trace.
+wpr.exe -stop bench-out\drilldown\large_1gib.etl
+```
+
+Repeat for `small_10000`. Two `.etl` files are now ready for offline
+analysis in `wpa.exe`.
+
+VTune equivalent (if chosen instead of WPA):
+
+```sh
+vtune -collect hotspots -knob sampling-mode=hw \
+  -result-dir bench-out/drilldown/vtune-large_1gib -- \
+  "$OC_RSYNC" -a "$DRILLDOWN_LARGE_SRC/" "$DRILLDOWN_LARGE_DST/"
+```
+
+### Step 4 - Capture an I/O analysis (kernel block-IO timeline)
+
+In **Administrator PowerShell**:
+
+```powershell
+wpr.exe -start DiskIO -start FileIO -filemode
+
+# Re-run the transfer (drilldown source, same destination drive).
+oc-rsync -a "$DRILLDOWN_LARGE_SRC/" "$DRILLDOWN_LARGE_DST/"
+
+wpr.exe -stop bench-out\drilldown\large_1gib.io.etl
+```
+
+The DiskIO + FileIO trace gives the operator a per-handle timeline of
+overlapped `WriteFile` start, kernel queue depth, completion arrival,
+and `FlushFileBuffers` latency. Cross-correlating with the CPU trace
+from Step 3 attributes time spent in `GetQueuedCompletionStatus`
+(synchronous drain in `IocpWriter`, sync point #1) to the matching
+kernel-side wait.
+
+VTune equivalent: re-run `vtune -collect io` on the same workload;
+results land under a sibling `-result-dir`.
+
+### Step 5 - Classify hotspots and emit the report
+
+Open `large_1gib.etl` in `wpa.exe` (or the VTune result GUI). Apply
+these views in order:
+
+1. **CPU Usage (Sampled) -> Stack** filtered to `oc-rsync.exe`. Group
+   by stack; sort by inclusive sample count. Take the top 10 stacks.
+2. **Generic Events -> File I/O** filtered to source/dest paths.
+   Confirm overlap (or lack thereof) with the CPU sample timeline.
+3. **Disk Usage -> I/O Time per File** to attribute kernel time to
+   the destination handle. Note the queue depth peak.
+
+For each of the top stacks, classify into one of three buckets defined
+by [`iocp-sync-blocking-audit.md`](iocp-sync-blocking-audit.md):
+
+| Bucket | What it looks like in WPA | Audit row | Mitigation pointer |
+|--------|---------------------------|-----------|--------------------|
+| **Per-IO blocking drain** | Top stack contains `IocpWriter::write` -> `GetQueuedCompletionStatus`; CPU time tracks the WriteFile sample rate 1:1 | Rows 1, 2, 4, 13 of the sync-blocking audit | Mitigation M1 in PR #4332; WPG-4 (issue #2303) wires `CompletionPump` into `IocpWriter` |
+| **CQ-depth saturation** | Top stack contains `drain_completions` -> `GetQueuedCompletionStatusEx`; trace shows full 64-entry batches every drain | Row 4; also row 7 (worker thread) | PR #4358 (WPG-3) auto-sizes the completion array based on observed peak |
+| **Bounce-buffer copy** | Top stack contains `IocpDiskBatch::write_data` -> `Vec::extend_from_slice` or `memcpy`; CPU time is in user mode, not kernel | Row 13 (per-buffer-fill flush) | WPG-4 (issue #2303) introduces a double-buffer / registered buffer path |
+
+### Step 6 - Append the hotspot table to this document
+
+The Windows operator pastes the classified table into the
+"Results" section below, one row per top-10 stack. Format:
+
+```
+| Rank | Inclusive samples | % of run | Top stack (top 3 frames) | Bucket | Mitigation pointer |
+|------|-------------------|----------|--------------------------|--------|--------------------|
+| 1    |                   |          |                          |        |                    |
+```
+
+Stacks deeper than three frames are abbreviated with `...`; the full
+stack lives in the `.etl` archive checked into the issue thread.
+
+## Hotspot classification (reference)
+
+Three buckets cover every realistic top-10 stack we expect from the
+two scenarios in `scripts/windows_throughput_bench.sh`:
+
+- **Per-IO blocking drain** - the single largest contributor on
+  `large_1gib`. Each `WriteFile` is immediately followed by a
+  synchronous `GetQueuedCompletionStatus(..., INFINITE)`. Effective
+  queue depth is 1 regardless of `IocpConfig::concurrent_ops`. Audit
+  rows 1, 4, 13. Mitigation: register the writer with the shared
+  `CompletionPump` (WPG-4 / issue #2303) so the next `WriteFile` is
+  posted before the previous completion is reaped.
+- **CQ-depth saturation** - shows up on the `small_10000` scenario
+  when bursts of small writes saturate the fixed
+  `COMPLETION_DRAIN_BATCH = 64`. PR #4358 (WPG-3) auto-sizes the
+  array; this row's mitigation is "land #4358".
+- **Bounce-buffer copy** - user-mode memcpy from caller buffer into
+  `IocpDiskBatch`'s owned buffer. Visible whenever the source is
+  itself overlapped (e.g. socket -> disk on daemon pull). Mitigation:
+  WPG-4 (issue #2303) double-buffer + registered buffer path.
+
+A fourth bucket ("MSYS2 path translation") may appear in
+upstream-rsync traces taken for comparison but does not apply to
+`oc-rsync.exe`, which is a native Win32 binary.
+
+## Results (to be filled by Windows operator)
+
+This section is intentionally empty in WPG-1. The future Windows
+operator runs Steps 1-5, then PRs an update to this section with the
+classified table for both `large_1gib` and `small_10000`. The `.etl`
+captures should be attached to issue #2300 and referenced here by
+filename, not committed to the repo.
+
+### `large_1gib` scenario
+
+_Pending Windows operator run._
+
+### `small_10000` scenario
+
+_Pending Windows operator run._
+
+## Implementation plan (5 steps keyed to WPG-4 .. WPG-6)
+
+1. **WPG-1 (this audit, #2300)** - methodology landed; a Windows
+   operator runs Steps 1-5 and fills the Results section. Output: a
+   ranked, classified hotspot table per scenario.
+2. **WPG-4 (#2303)** - based on the per-IO blocking drain bucket
+   ranking from Step 1, land the `CompletionPump`-backed
+   `IocpWriter` from mitigation M1 of the sync-blocking audit. Gate
+   on the same throughput bench showing improved `large_1gib`
+   wall-clock.
+3. **WPG-5 (per-file fsync pipelining)** - based on the per-file
+   bucket signal from `small_10000`, land mitigation M2 (background
+   finalizer thread for `FlushFileBuffers`). Gate on `small_10000`
+   wall-clock improvement plus a regression-free `large_1gib`.
+4. **WPG-6 (socket-side pipelining)** - mitigation M3 from the
+   sync-blocking audit (>=2 sends and recvs in flight in
+   `IocpSocketWriter`/`Reader`). Profile the daemon-push path with
+   the same methodology before and after; report the resulting
+   throughput delta.
+5. **WPG-1 closure** - rerun Steps 1-5 against `oc-rsync.exe` built
+   from the WPG-4..WPG-6 branches; confirm each bucket from the
+   original ranking has either moved down the table or dropped out.
+   Close #2300 once the three top-bucket mitigations have a
+   corresponding "before vs after" trace pair attached to the issue.
+
+## Constraints and gotchas
+
+- ETW traces can grow quickly (~50 MiB/min at default buffer sizes).
+  Always run with `-filemode` and stop the trace as soon as the
+  measured iteration finishes.
+- Run the profiler against the **drilldown** directory rather than
+  the live bench output: hyperfine wipes the destination on every
+  iteration via `--prepare`, which would skew the trace toward setup
+  cost.
+- The `release-with-debug` profile is the only Windows-supported way
+  to get Rust symbol resolution; the default `release` profile strips
+  debug info and produces "unknown" frames in WPA.
+- Never run the profiler under a Windows defender real-time scan; AV
+  hooks add IRP-level latency to every `WriteFile` and bias the
+  per-IO bucket upward. Add the destination directory and the binary
+  to the AV exclusion list before profiling.
+- Reuse a typed `PathBuf` for the destination cleanup. Never invoke
+  `Remove-Item -Recurse` against a path assembled from environment
+  variables; see the "Containers and Bind Mounts" pitfall in the
+  project handbook.

--- a/docs/benchmarks/windows-throughput.md
+++ b/docs/benchmarks/windows-throughput.md
@@ -102,6 +102,57 @@ BENCH_RUNS=5 BENCH_WARMUP=2 \
   bash scripts/windows_throughput_bench.sh
 ```
 
+## Drilldown mode
+
+Set `OC_RSYNC_BENCH_DRILLDOWN=1` to append three per-hotspot
+sub-scenarios to the run. They map 1:1 onto the IOCP sync points
+catalogued in
+[`docs/audits/iocp-sync-blocking-audit.md`](../audits/iocp-sync-blocking-audit.md)
+so that a future patch targeting a specific row in that audit can be
+attributed to the matching scenario without re-deriving which hotspot
+moved.
+
+| Scenario                | What it isolates                                                                 | Control                  | Audit rows |
+|-------------------------|----------------------------------------------------------------------------------|--------------------------|------------|
+| `write_only_iocp`       | `IocpWriter` per-IO blocking drain. `--whole-file --inplace` forces every byte through the write path with no temp-file rename. | `cp` (std::fs::copy)     | #1, #4, #13 |
+| `read_only_iocp`        | `IocpReader` per-IO blocking drain. `--dry-run` walks and reads the 1 GiB fixture but writes nothing. | upstream rsync `--dry-run` | #2, #3      |
+| `network_only_loopback` | `IocpSocketWriter` / `Reader` send/recv path. Pushes a 1 GiB file between two loopback rsync daemons on the same disk so disk bandwidth cancels out. | upstream rsync loopback daemon | #8 - #11    |
+
+Invocation:
+
+```sh
+# From an MSYS2 shell on a Windows host.
+OC_RSYNC_BENCH_DRILLDOWN=1 \
+  BENCH_RUNS=5 BENCH_WARMUP=2 \
+  OC_RSYNC=/c/path/to/target/release/oc-rsync.exe \
+  bash scripts/windows_throughput_bench.sh
+```
+
+The drilldown daemons bind `127.0.0.1:$BENCH_DAEMON_PORT` and
+`127.0.0.1:$((BENCH_DAEMON_PORT + 1))` (default `18730` / `18731`).
+Override `BENCH_DAEMON_PORT` if those ports are in use.
+
+### Interpretation
+
+Read each ratio the same way as the main scenarios
+(`mean(control) / mean(oc-rsync)`):
+
+- `write_only_iocp`: regression here points at the write-path changes
+  in `crates/fast_io/src/iocp/file_writer.rs` and
+  `crates/fast_io/src/iocp/disk_batch.rs`. The `cp` control caps the
+  upper bound at NTFS write bandwidth; oc-rsync should land within a
+  small factor of it.
+- `read_only_iocp`: regression here points at `file_reader.rs` or the
+  generator/sender read pipeline. Because both sides run `--dry-run`,
+  divergence is not explained by network or fsync work.
+- `network_only_loopback`: regression here implicates `socket.rs` or
+  the multiplex layer. Disk bandwidth is symmetric across both
+  commands, so the delta reflects send/recv pipelining.
+
+The drilldown sub-scenarios are **not** in the required-checks list
+and have no acceptable-band thresholds; they exist to attribute
+movement, not to gate merges.
+
 ## Tuning knobs
 
 The reusable workflow exposes these inputs (all optional):

--- a/docs/design/iouring-receive-data-path.md
+++ b/docs/design/iouring-receive-data-path.md
@@ -1,0 +1,364 @@
+# io_uring receive data path: routing chunk writes through registered buffers
+
+Tracking task: IUD-2 (oc-rsync follow-up #2362). Implementation phases
+are keyed to IUD-5 (buffer-pool wiring) and IUD-8 (telemetry + rollout).
+
+Companion docs already in tree:
+
+- `docs/design/iouring-registered-buffer-adaptive-sizing.md` - registered
+  buffer group sizing and lifecycle.
+- `docs/design/iouring-adaptive-buffer-pool.md` - cross-thread buffer
+  pool that supplies the SPSC chunks today.
+- `docs/design/iouring-borrowed-slice-consumer.md` (#4218) - pin-counted
+  pool that this work must compose with.
+- `docs/design/iouring-per-thread-rings.md` (#1929) - per-thread ring
+  topology this writer will plug into when promoted.
+- `docs/design/mmap-vs-sqpoll-conflict-resolution.md` - the same READ_FIXED
+  primitive on the basis-file side; this design must not contradict the
+  SMR ruling that mmap pointers never enter io_uring SQEs.
+- `docs/design/basis-file-io-policy.md` - selector that downgrades the
+  basis to `BufferedMap` whenever an io_uring writer is active.
+
+This document does not change any wired dispatch. It specifies the next
+step: routing the bytes that the network thread hands to the disk-commit
+thread through `IORING_OP_WRITE_FIXED` against a registered-buffer group
+shared with the basis-file reader. The actual switch is gated by the new
+opt-in feature `iouring-data-writes` (default off) and lands as the
+patches enumerated in section 6.
+
+## 1. Current receive writer
+
+The receive path is two threads connected by a lock-free SPSC channel.
+
+### 1.1 Network thread (producer)
+
+- `crates/transfer/src/receiver/transfer.rs:55-70` runs the receiver
+  role. The pipelined path
+  (`crates/transfer/src/receiver/transfer/pipeline.rs`) parses delta
+  tokens via `TokenReader` (`crates/transfer/src/token_reader.rs`) and
+  resolves block-copy references against a `MapFile`
+  (`crates/transfer/src/map_file/mod.rs:55`).
+- For literal tokens the network thread pulls a recycled
+  `Vec<u8>` from the buffer pool
+  (`crates/transfer/src/pipeline/buffer_pool.rs`), copies the demuxed
+  bytes in, and sends it as `FileMessage::Chunk(Vec<u8>)`
+  (`crates/transfer/src/pipeline/messages.rs:21-45`).
+- For block-copy tokens the network thread reads from the basis
+  `MapFile` and emits the resulting slice via the same `Chunk`
+  message. The basis source is `BufferedMap` whenever io_uring is
+  active on the writer side
+  (`crates/transfer/src/delta_apply/applicator.rs:161-176`).
+
+### 1.2 Disk commit thread (consumer)
+
+- `crates/transfer/src/disk_commit/process.rs:32-118` drains the SPSC
+  channel one message at a time. `Chunk(Vec<u8>)` is forwarded to
+  `Writer::write_chunk` (`crates/transfer/src/disk_commit/writer.rs:199-211`),
+  which dispatches to one of:
+  - `Writer::Buffered` - `ReusableBufWriter` over `std::fs::File` with
+    a 256 KB reusable buffer
+    (`crates/transfer/src/disk_commit/writer.rs:71-122`).
+  - `Writer::IoUring` (Linux + `io_uring` feature) - delegates to
+    `IoUringDiskBatch::write_data`
+    (`crates/fast_io/src/io_uring/disk_batch.rs:124-149`), which
+    internally calls `submit_write_batch`
+    (`crates/fast_io/src/io_uring/batching.rs`) over its private 256 KB
+    staging buffer.
+  - `Writer::Iocp` (Windows + `iocp` feature) - peer of the above on
+    `IORING_OP_WRITEV` analogue.
+  - `Writer::Macos` - `MacosWriter` with `F_NOCACHE` + `writev(2)`.
+  - `Writer::Vmsplice` (Linux + `vmsplice` feature) - zero-copy splice
+    that fires only when neither io_uring nor IOCP claimed the file.
+
+- `make_writer` (`crates/transfer/src/disk_commit/process.rs:277-323`)
+  picks the variant. Sparse mode and non-zero `append_offset` force
+  `Buffered` because none of the batched backends implement `Seek`.
+- After draining a file, `Writer::flush_and_sync` and `Writer::finish`
+  (`crates/transfer/src/disk_commit/writer.rs:218-299`) run flush +
+  optional fsync + rename in the order matching upstream
+  `fileio.c:write_file()` and `receiver.c:finish_recv_file()`.
+
+### 1.3 The two memcpy hops we want to eliminate
+
+For literal tokens today, a byte travels:
+
+1. Socket -> demux -> token reader staging
+   (`crates/transfer/src/token_reader.rs`). Copy 1: kernel page cache to
+   user buffer via `read(2)`.
+2. Token reader -> recycled `Vec<u8>` from the buffer pool. Copy 2: the
+   `TokenBuffer::pull_literal` memcpy
+   (`crates/transfer/src/token_buffer.rs`).
+3. Network thread sends `FileMessage::Chunk(Vec<u8>)` -> SPSC; the buffer
+   itself is moved, no copy.
+4. Disk thread writes via `Writer::write_chunk`. For
+   `Writer::IoUring`, this is `IoUringDiskBatch::write_data` which
+   copies the chunk into its private 256 KB staging buffer before
+   submitting `IORING_OP_WRITE` SQEs
+   (`crates/fast_io/src/io_uring/disk_batch.rs:124-149`,
+   `crates/fast_io/src/io_uring/batching.rs::submit_write_batch`).
+   Copy 3: user buffer to kernel-bounce staging buffer.
+
+The kernel performs an additional copy inside `IORING_OP_WRITE` because
+the staging buffer is not registered: `get_user_pages_fast` pins the
+pages each submission, and the SQE carries an unfixed `iovec`. This
+write design replaces hop 4's user-side memcpy and removes the
+per-submission `get_user_pages` cost by handing the kernel a registered
+buffer index that points at the same memory the network thread filled.
+
+### 1.4 Coalesced `WholeFile` path
+
+The single-message `FileMessage::WholeFile { begin, data }` path
+(`crates/transfer/src/pipeline/messages.rs:32-37`) is taken when the
+entire file fits in one literal token. It folds Begin + one Chunk +
+Commit into one SPSC send. The data-path proposal must keep this fast
+path intact - it stays on `Writer::Buffered` because the file is
+typically small enough that registering a buffer is pure overhead. See
+section 4.4 for the threshold.
+
+## 2. Proposed: WRITE_FIXED-backed disk writer
+
+### 2.1 Topology
+
+Reuse the existing `RegisteredBufferGroup`
+(`crates/fast_io/src/io_uring/registered_buffers/registry.rs`). The
+buffer-pool layer already owns a fixed-size set of `Vec<u8>` slots; we
+add a parallel "registered-pool" that wraps those same allocations as
+io_uring fixed buffers, keyed by index. Each slot has:
+
+- A registered-buffer index (`buf_index: u16`) usable as the third
+  argument to `IORING_OP_WRITE_FIXED`.
+- A raw pointer + length stored in a `RegisteredBufferSlotInfo`
+  (`crates/fast_io/src/io_uring/registered_buffers/submit.rs:253-260`).
+- A pin reference count, mirroring the borrowed-slice consumer design
+  (#4218) so that the disk thread cannot recycle a slot while a
+  notification CQE is still outstanding.
+
+The disk-commit thread keeps the same `IoUringDiskBatch` instance it
+holds today, plus a new sibling `IoUringWriteFixedBatch` that takes
+ownership of pre-registered slots instead of allocating a private
+staging buffer.
+
+### 2.2 Submission flow per chunk
+
+When `feature = "iouring-data-writes"` is on and the chunk arrives via
+`FileMessage::Chunk(slot)` (a new variant carrying a registered-buffer
+handle rather than a bare `Vec<u8>`):
+
+1. The disk thread maps the slot's index to the file offset
+   (cumulative `bytes_written` for the active `ActiveFile`).
+2. It calls `submit_write_fixed_batch`
+   (`crates/fast_io/src/io_uring/registered_buffers/submit.rs:159-243`)
+   with the slot's `RegisteredBufferSlotInfo` and the current file fd
+   (already registered via `try_register_fd`).
+3. The submission helper pushes one `IORING_OP_WRITE_FIXED` SQE per
+   slot. It uses `submit_and_wait(submitted)` (synchronous) for the
+   first cut to match the current `submit_write_batch` semantics; the
+   batched / non-blocking path is enumerated in section 6.
+4. On CQE, the slot is returned to the pool. Pin count is decremented
+   so the network thread can reclaim it via the buffer-return channel
+   (`buf_return_tx` in `process.rs:32-118`).
+
+### 2.3 Backward compatibility: dispatch surface
+
+`Writer::IoUring` keeps its current variant. A new `Writer::IoUringFixed`
+variant is added:
+
+```text
+pub(super) enum Writer<'a> {
+    Buffered(ReusableBufWriter<'a>),
+    #[cfg(all(target_os = "linux", feature = "io_uring"))]
+    IoUring { batch: &'a mut fast_io::IoUringDiskBatch },
+    #[cfg(all(target_os = "linux", feature = "io_uring", feature = "iouring-data-writes"))]
+    IoUringFixed { batch: &'a mut fast_io::IoUringWriteFixedBatch },
+    // ... existing variants
+}
+```
+
+`make_writer` picks `IoUringFixed` when:
+
+- the registered-pool is available (the buffer pool succeeded in
+  registering its backing slots with the active ring), AND
+- `use_sparse` is false AND `append_offset == 0` AND
+  `begin.target_size >= IOURING_DATA_WRITES_MIN_BYTES` (default 64 KiB,
+  tunable via env, see section 4.4).
+
+Otherwise dispatch is unchanged, including the unregistered
+`Writer::IoUring` path. There is no scenario in which the new variant
+silently degrades a file that previously used `Writer::Buffered`.
+
+## 3. Ordering
+
+The write order is unchanged: `Begin -> Chunk* -> Commit | Abort`. The
+disk thread still processes one file at a time. The `WRITE_FIXED` SQEs
+within a single `Chunk` message complete out-of-order, but the helper
+already reassembles bytes-written by user-data index
+(`submit_write_fixed_batch:217-237`) and reports `batch_written` only
+after every CQE is drained. The next `Chunk` is not submitted until the
+previous batch has fully completed; sequential file offset is therefore
+preserved.
+
+Across files, `commit_file` (`disk_batch.rs:168-187`) drains the active
+file before calling `submit_fsync`. The new `IoUringWriteFixedBatch`
+follows the same shape: `commit_file` performs `flush_current` (drain),
+then `submit_fsync` (only when `do_fsync`), then detaches the fd.
+
+## 4. fsync placement, partial writes, and fallback
+
+### 4.1 fsync
+
+Identical to today. `commit_file(do_fsync)` issues an `IORING_OP_FSYNC`
+SQE against the same fd
+(`crates/fast_io/src/io_uring/disk_batch.rs:236-263`). The change does
+not move fsync earlier or later; durability semantics match upstream's
+`writefd` + `fsync()` pair in `receiver.c:finish_recv_file()`.
+
+### 4.2 Short writes
+
+`IORING_OP_WRITE_FIXED` may complete short on the same surfaces as
+`pwrite(2)` short writes: ENOSPC partial flushes, signal-interrupted
+NFS writes, FUSE backends that honour `direct_io`. The submission
+helper detects shorts by comparing each SQE's `requested_per_sqe` to
+its `actual_per_sqe` and advances `total_written` only through the
+contiguous prefix of fully-written SQEs
+(`submit.rs:217-237`). The outer loop resubmits the remaining bytes
+starting at the new offset. This is the same algorithm
+`submit_read_fixed_batch` (`submit.rs:29-152`) already uses on the read
+side.
+
+If a CQE returns a negative result, the helper converts it to
+`io::Error::from_raw_os_error(-result)` and the disk thread aborts the
+file via the existing `FileMessage::Abort` pathway. The partially
+written temp file is removed by `TempFileGuard::drop`
+(`crates/transfer/src/temp_guard.rs`).
+
+### 4.3 Fallback hierarchy
+
+The new path falls back in order:
+
+1. **No `iouring-data-writes` feature** -> existing `Writer::IoUring`
+   (unfixed) path, unchanged.
+2. **Feature on, but registration failed at ring construction**
+   (kernel < 5.6, `register_buffers` rejected, MEMLOCK rlimit too low)
+   -> `Writer::IoUring` unfixed path. The disk thread logs a one-line
+   `debug_log!(Io, 1, "registered buffer pool unavailable, falling
+   back to unfixed io_uring writer")` at startup, mirroring the
+   `RegisteredBufferStatus` provenance pattern from
+   `crates/fast_io/src/io_uring/file_writer.rs:42-47`.
+3. **Per-file ineligible** (sparse, append, file too small) ->
+   `Writer::Buffered`, unchanged.
+4. **Kernel error mid-transfer** (`ENOMEM`, `EAGAIN`) -> abort the
+   file; the receiver records a hard error. Same as today's io_uring
+   submission errors.
+
+### 4.4 Per-file size threshold
+
+`IOURING_DATA_WRITES_MIN_BYTES = 64 * 1024` by default. The selection
+follows two pressures: small files (under one wire chunk, ~32 KiB) ride
+the `WholeFile` coalesced path and never reach the chunk loop;
+medium files just above that threshold incur ring-side scheduling that
+costs more than the kernel-side `get_user_pages_fast` it saves.
+Telemetry from IUD-8 (section 6) will tighten this number after a real
+run.
+
+## 5. Feature flag and configuration
+
+`iouring-data-writes` (default off) lives on the `fast_io` crate and is
+re-exported by `transfer` through the same pass-through pattern as
+`io_uring`, `iocp`, `vmsplice`
+(`crates/fast_io/Cargo.toml:39-83`,
+`crates/transfer/Cargo.toml:88-101`):
+
+```text
+# fast_io/Cargo.toml
+iouring-data-writes = ["io_uring"]
+
+# transfer/Cargo.toml
+iouring-data-writes = ["io_uring", "fast_io/iouring-data-writes"]
+```
+
+The runtime selector additionally consults
+`OC_RSYNC_IOURING_DATA_WRITES` (`auto` / `force` / `off`). `auto` is
+the documented production value once the rollout completes; `force` is
+for benchmarks; `off` disables the path even when the feature is
+compiled in. The env var follows the same dispatch convention as
+`OC_RSYNC_BENCH_IOURING_RING`
+(`crates/fast_io/Cargo.toml:155`).
+
+## 6. Implementation plan
+
+The work is split into five PR-sized steps, keyed to IUD-5 (buffer pool
+wiring) and IUD-8 (telemetry + rollout).
+
+1. **IUD-5a: `IoUringWriteFixedBatch` skeleton.** Introduce the new
+   batch type in `crates/fast_io/src/io_uring/` next to
+   `IoUringDiskBatch`. API mirror: `new`, `try_new`, `begin_file`,
+   `write_data_fixed(slot: RegisteredBufferSlotInfo, len: usize)`,
+   `flush`, `commit_file`, `bytes_written*`. Tests: extend
+   `crates/fast_io/src/io_uring/tests.rs` with `commit`, multi-file,
+   drop-flush parity tests under the new feature. No production
+   wiring.
+
+2. **IUD-5b: Buffer-pool registration.** Teach the existing
+   buffer-pool allocator in `crates/transfer/src/pipeline/buffer_pool.rs`
+   to allocate slots that are page-aligned and large enough to satisfy
+   `io_uring_register_buffers(2)`. Add a `try_register_with_ring`
+   method that walks the slots, registers them, and stores the
+   per-slot `RegisteredBufferSlotInfo` alongside the existing
+   `Vec<u8>` payload. Provenance is captured in
+   `RegisteredBufferStatus` so operators can diagnose
+   `unsupported / rejected / disabled-by-config / disabled-by-rlimit`.
+
+3. **IUD-5c: New `FileMessage::FixedChunk` variant.** Add the variant
+   to `crates/transfer/src/pipeline/messages.rs:21-45`. The network
+   thread writes literal-token bytes directly into a registered slot
+   (no second memcpy) and sends `FixedChunk(slot_handle)`. The disk
+   thread dispatches `FixedChunk` to `Writer::IoUringFixed::write_chunk`
+   and returns the handle through `buf_return_tx`. The pre-existing
+   `Chunk(Vec<u8>)` variant is kept for the buffered, vmsplice, IOCP,
+   and macOS variants.
+
+4. **IUD-5d: `Writer::IoUringFixed` and selector update.** Extend
+   `Writer` in `crates/transfer/src/disk_commit/writer.rs:144-163` and
+   `make_writer` in `process.rs:277-323`. Add the eligibility checks
+   from section 2.3 and the size threshold from section 4.4. Default
+   the env-var selector to `auto`.
+
+5. **IUD-8: Telemetry + rollout gating.** Wire counters into the
+   existing `TransferStats`
+   (`crates/transfer/src/receiver/stats.rs`) for: chunks routed via
+   `WRITE_FIXED`, chunks routed via unfixed io_uring, chunks routed
+   via buffered fallback, registered-buffer slot-exhaustion fallbacks,
+   short-write retries. Wire a single-line `debug_log!(Io, 1, ..)`
+   on the first per-process degradation transition. Flip the
+   `OC_RSYNC_IOURING_DATA_WRITES` default to `auto` once benchmarks
+   from `crates/fast_io/benches/iouring_data_writes.rs` (added in
+   IUD-8) demonstrate non-regression on the workloads called out in
+   `crates/fast_io/Cargo.toml:111-160`.
+
+## 7. Interaction with the basis-file read primitive (SMR-3a)
+
+The basis-file reader (SMR-3a, `mmap-vs-sqpoll-conflict-resolution.md`
+section "Replacing mmap with READ_FIXED") plans to issue
+`IORING_OP_READ_FIXED` against the same registered-buffer pool. The two
+designs deliberately share the pool, which means:
+
+- **One pool, two consumers.** Per-ring registration limits
+  (`IORING_REGISTER_BUFFERS` caps at 1024 slots; the kernel-side
+  iov_iter cost grows with slot count) are spent once; both the
+  reader and the writer draw from the same pool.
+- **Strict ownership ping-pong.** A slot in flight on a READ_FIXED SQE
+  cannot be reused by a WRITE_FIXED SQE until its read CQE has been
+  drained and its pin-count returned to zero. The borrowed-slice
+  consumer (#4218) already encodes this invariant.
+- **SQPOLL is forbidden for both paths.** The
+  `mmap-vs-sqpoll-conflict-resolution.md` rule applies symmetrically:
+  registered buffers backed by file-backed VMAs cannot be referenced
+  by an SQPOLL kthread without exposing `SIGBUS`. Both the read and
+  write paths therefore continue to construct rings without
+  `IORING_SETUP_SQPOLL` when the registered-buffer pool is active.
+
+The selector in section 2.3 must therefore also check that the basis-
+file strategy is not `MmapStrategy`. The check is already enforced
+indirectly today via `basis-file-io-policy.md` (writer-io_uring forces
+`BufferedMap`), but the new feature flag promotes the rule to a hard
+precondition on `Writer::IoUringFixed` construction.

--- a/docs/design/iouring-send-data-path.md
+++ b/docs/design/iouring-send-data-path.md
@@ -1,0 +1,382 @@
+# io_uring send data path: basis READ_FIXED + socket SEND_ZC
+
+Tracking task: IUD-3 (oc-rsync follow-up #2363). Implementation phases
+are keyed to IUD-6 (basis reader), IUD-7 (socket writer pinning), and
+IUD-8 (telemetry + rollout, shared with IUD-2).
+
+Companion docs already in tree:
+
+- `docs/design/iouring-send-zc.md` (#1832) - SEND_ZC primitive and
+  the existing `IoUringSocketWriter`.
+- `docs/design/iouring-borrowed-slice-consumer.md` (#4218) - pin-counted
+  pool that the SEND_ZC notification CQE depends on.
+- `docs/design/iouring-registered-buffer-adaptive-sizing.md` - registered
+  buffer group sizing and lifecycle.
+- `docs/design/iouring-receive-data-path.md` (IUD-2, #2362) - sibling
+  doc; the registered-buffer pool design is shared.
+- `docs/design/mmap-vs-sqpoll-conflict-resolution.md` - rules out
+  mmap-backed bytes inside io_uring SQEs, which constrains the basis
+  read path here.
+- `docs/design/basis-file-io-policy.md` - selector matrix that switches
+  basis reads between `BufferedMap`, `MmapStrategy`, and (under this
+  proposal) `RegisteredBufferGroup`.
+
+This document does not change any wired dispatch. It specifies how
+delta-source bytes get from the basis file (or the source file) onto
+the network without leaving the kernel: the basis file is read via
+`IORING_OP_READ_FIXED` into registered buffers, and those same buffers
+are handed straight to `IORING_OP_SEND_ZC` against the network socket.
+The actual switch is gated by the new feature `iouring-data-sends`
+(default off) and lands as the patches in section 6.
+
+## 1. Current send reader + socket write
+
+The send role lives in `crates/transfer/src/generator/`. The relevant
+streaming entry points for file data are:
+
+### 1.1 Whole-file send
+
+- `crates/transfer/src/generator/delta.rs:200-274` (the loop that
+  starts with `let mut total_bytes: u64 = 0`) is the whole-file
+  literal stream. It reads from a generic `R: Read` (today an
+  `open_source_with_noatime` wrapped in `BufReader`,
+  `crates/transfer/src/generator/open_source.rs`) into a reusable
+  buffer, computes the running file checksum, and emits framed wire
+  chunks via `writer.write_all(&buf[wire_off..wire_off + 4 + chunk])`
+  (line 257). The 4-byte length prefix is packed in-place ahead of
+  each 32 KiB wire chunk so the combined write triggers the
+  `MplexWriter` bulk fast path
+  (`crates/protocol/src/multiplex/writer.rs:175-220`,
+  `crates/transfer/src/writer/multiplex.rs:104-108`).
+- Buffer size is `MAX_READ_SIZE = 256 * 1024`
+  (`delta.rs:221`), reused across files.
+- `writer` is the `MplexWriter` returned by
+  `crates/transfer/src/writer/multiplex.rs:42-60`. Each write
+  ultimately reduces to `Write::write_all` on the underlying
+  socket / SSH `ChildStdin` (see
+  `docs/design/iouring-send-zc.md` section 1.2).
+
+### 1.2 Delta send with basis re-read
+
+- `crates/transfer/src/generator/delta.rs:289-334`
+  (`compute_file_checksum`) re-reads basis-file blocks for the running
+  whole-file checksum. The read is via `std::fs::File::seek` +
+  `read_exact` into a `Vec<u8>` (lines 322-325). On the wire side, the
+  per-block emission is the corresponding token in
+  `write_token_stream` (`delta.rs:355-380` for `script_to_wire_delta`,
+  then `delta.rs:382-463` for the wire emit).
+- The streaming literal-token path in
+  `crates/transfer/src/generator/delta.rs:227-237` shares the same
+  256 KiB buffer when compression is on; the compressed encoder
+  (`CompressedTokenEncoder::send_literal`) is opaque to the byte path
+  but still ends at a `Write::write_all` on the multiplex writer.
+
+### 1.3 Multiplex framing constraint
+
+`MplexWriter` wraps every payload in a 4-byte `MSG_DATA` header
+(`crates/protocol/src/multiplex/writer.rs:70-128`). The header is built
+by `send_msg`
+(`crates/protocol/src/multiplex/io/send.rs:16-22`) and emitted via
+`write_all_vectored` (line 130) which prefers a two-slice `writev`. The
+maximum payload per frame is 8192 bytes (`DEFAULT_MAX_FRAME_SIZE`,
+`multiplex/writer.rs:88`). Any io_uring proposal that bypasses
+`MplexWriter` for the data slice must still emit the header on the
+same socket immediately before each payload chunk.
+
+### 1.4 The two memcpy hops we want to eliminate
+
+For a basis-file block re-read or a whole-file literal byte:
+
+1. Kernel page cache -> user buffer via `read(2)` (kernel-side copy
+   into `read_buf`).
+2. `MplexWriter` buffer fill -> SQE / `writev` slice
+   (`writer/multiplex.rs:42-108`). For chunks above the 32 KiB internal
+   threshold this is a pointer hand-off (no copy); below the threshold
+   it is a memcpy into the writer's buffer.
+3. Kernel-side: socket layer copies the user buffer into the skbuff
+   chain on `send(2)`. This is the copy that `IORING_OP_SEND_ZC`
+   eliminates by pinning the user pages and emitting the notification
+   CQE only after the NIC has consumed them
+   (`docs/design/iouring-send-zc.md` section 2).
+
+`SEND_ZC` alone removes hop 3. This design also removes hop 1 by
+issuing the basis read as `IORING_OP_READ_FIXED` directly into the
+same registered buffer that hop 3 will SEND_ZC. End-to-end the user
+buffer becomes a pinned, registered region that is referenced (not
+copied) by both the disk read SQE and the socket send SQE.
+
+## 2. Proposed: end-to-end zero-copy on the Linux io_uring path
+
+### 2.1 Topology
+
+The same registered-buffer pool from IUD-2 (see
+`docs/design/iouring-receive-data-path.md` section 2.1) is shared with
+the send role. The sender owns a `SendBufferGroup` view over the pool:
+the same `RegisteredBufferSlotInfo` records, but with the inverse
+ping-pong (slots filled by READ_FIXED, drained by SEND_ZC).
+
+The sender holds a single `IoUringSendCoordinator` that bundles:
+
+- A reference to the registered-buffer pool.
+- A handle to the basis file's fd (when delta mode) or the source
+  file's fd (when whole-file mode), both registered with the ring via
+  `try_register_fd`
+  (`crates/fast_io/src/io_uring/batching.rs::try_register_fd`).
+- A reference to the existing `IoUringSocketWriter`
+  (`crates/fast_io/src/io_uring/socket_writer.rs:36-48`).
+- The `MplexWriter`'s buffer (for emitting the 4-byte `MSG_DATA`
+  header alongside the payload, see section 2.3).
+
+### 2.2 Basis / source read via `IORING_OP_READ_FIXED`
+
+For both `compute_file_checksum`'s basis-block reads
+(`delta.rs:289-334`) and the whole-file streaming loop
+(`delta.rs:200-274`), the read is replaced with
+`submit_read_fixed_batch`
+(`crates/fast_io/src/io_uring/registered_buffers/submit.rs:29-152`).
+The helper already understands short reads, out-of-order CQEs, and
+fixed-fd dispatch via `maybe_fixed_file`. The caller supplies:
+
+- `fd` = the registered-fd token for the file (or the raw fd if
+  registration was rejected),
+- `output` = the caller's `Vec<u8>` for the no-fixed-buffer fallback,
+- `base_offset` = the file offset of the first byte,
+- `slots` = the registered-buffer slot info from the pool.
+
+On the read-fixed path the kernel writes bytes directly into the
+pinned, registered memory. `submit_read_fixed_batch` then memcpys from
+the registered slot into the caller's `output` slice; for the
+end-to-end zero-copy path we instead skip that final memcpy and keep
+the slot itself as the unit handed onward to SEND_ZC. A new helper
+`submit_read_fixed_batch_pinned` returns the filled slots without
+copying out (the existing helper stays for callers that need the
+copy-back semantics).
+
+### 2.3 Socket send via `IORING_OP_SEND_ZC` with header coalescing
+
+The existing `IoUringSocketWriter::submit_send`
+(`crates/fast_io/src/io_uring/socket_writer.rs:83-106`) already routes
+payloads above 16 KiB through `send_zc::try_send_zc`. The send-side
+data-path proposal calls into the same primitive, but with two
+adjustments:
+
+1. **Header + payload as one SEND_ZC.** Each wire chunk needs its
+   4-byte `MSG_DATA` header to precede the payload bytes on the socket.
+   Two paths:
+   - **Pre-pend header inside the slot.** Each registered slot
+     reserves 4 leading bytes; the basis read targets `slot.ptr + 4`
+     with `want = chunk_size - 4`; SEND_ZC submits the full
+     `[header][payload]` range. The header is written via a
+     write-then-submit pattern, identical to the in-place packing trick
+     already used in `delta.rs:251-258`.
+   - **Submit two-buffer SEND_ZC.** `IORING_OP_SEND_ZC` supports a
+     `msghdr` with multiple iovecs via `IORING_OP_SENDMSG_ZC`
+     (kernel 6.1+). Use this path on kernels that advertise the
+     opcode; fall back to the in-slot header pre-pend otherwise.
+
+   The pre-pend path is the default. SENDMSG_ZC is an optimisation
+   that section 6's IUD-7 patches can adopt opportunistically.
+
+2. **Frame size bound is unchanged.** `MplexWriter::DEFAULT_MAX_FRAME_SIZE`
+   is 8192 bytes. The slot size must therefore stay at or below
+   `8192 + 4 = 8196` bytes when used for the send path, even when the
+   receive path (IUD-2) prefers larger slots. The pool keeps the slot
+   size at the larger value but the sender slices the payload into
+   8192-byte chunks before submission. This is the same constraint that
+   the existing `MplexWriter` already enforces
+   (`crates/protocol/src/multiplex/writer.rs:179-195`).
+
+### 2.4 Per-chunk lifecycle
+
+For each 8 KiB wire chunk under the new path:
+
+1. `IoUringSendCoordinator` claims one registered slot.
+2. It submits an `IORING_OP_READ_FIXED` SQE for the basis-file range
+   (delta mode) or the source-file range (whole-file mode) into
+   `slot.ptr + 4`, with `want = chunk_size - 4`.
+3. On the read CQE, the coordinator writes the 4-byte `MSG_DATA`
+   header into `slot.ptr[..4]`.
+4. It submits an `IORING_OP_SEND_ZC` SQE for `slot.ptr..slot.ptr + 4 +
+   actual_read`. Pin count on the slot is incremented.
+5. On the send notification CQE (`IORING_CQE_F_NOTIF`), pin count is
+   decremented. When it hits zero, the slot returns to the pool.
+
+The submission for step 4 can be link-chained from step 2 via
+`IOSQE_IO_LINK` on kernels that support it, so a single
+`submit_and_wait` services the round-trip. The infrastructure for that
+is in `crates/fast_io/src/io_uring/linked_chain.rs`; section 6 cites
+the patch that wires it.
+
+### 2.5 Dispatch surface
+
+The sender currently passes a `MplexWriter<TcpStream>` (or `<SshChild>`
+etc.) into the streaming functions in `delta.rs`. The new path is opt-
+in: when `feature = "iouring-data-sends"` is on AND the underlying
+writer is a real TCP socket (not SSH) AND the registered-buffer pool
+exists AND the file size exceeds `IOURING_DATA_SENDS_MIN_BYTES`, the
+streaming functions take a different code path:
+
+```text
+match send_coordinator {
+    Some(coord) => coord.stream_basis_zero_copy(writer, source_fd, ...),
+    None        => existing_buffered_path(writer, &mut source, ...),
+}
+```
+
+The existing path is untouched. The new path is the only consumer of
+`stream_basis_zero_copy`. There is no scenario in which the new path
+silently degrades a transfer that previously used the buffered
+streamer.
+
+## 3. Multiplex framing constraint: tag header
+
+The 4-byte `MSG_DATA` header (tag `MessageCode::Data + MPLEX_BASE = 7`,
+24-bit little-endian payload length) is the only invariant that
+distinguishes a multiplex socket from a raw socket. The send-side
+proposal preserves it via the in-slot pre-pend described in section
+2.3:
+
+- The slot layout is `[4 bytes header][N bytes payload]`.
+- The payload length stored in bytes 1-3 is the actual basis-read
+  count (may be short on EOF, NFS partial reads, etc.).
+- The header is written after the read CQE settles, so the length is
+  always correct.
+- For shorts, the helper resubmits a smaller payload-only chunk in a
+  follow-up slot. The header is recomputed for the follow-up's actual
+  length. This matches `submit_read_fixed_batch`'s loop structure
+  (`submit.rs:48-138`).
+
+Control messages (`MessageCode::Info`, `MessageCode::Warning`, etc.)
+continue to flow through the existing `MplexWriter::write_message`
+path. The io_uring send coordinator only touches `MSG_DATA` frames;
+mixing the two streams on the same socket is forced sequential by the
+existing `MplexWriter` API which flushes the data buffer before
+emitting a control message
+(`crates/protocol/src/multiplex/writer.rs:197-220`).
+
+## 4. Compression interaction
+
+When compression is enabled (`-z`, `--compress-choice=zstd`), the
+literal byte stream is fed into `CompressedTokenEncoder::send_literal`
+(`crates/transfer/src/generator/delta.rs:227-237`) which produces
+compressed framing that is not byte-aligned with the read chunks. The
+end-to-end zero-copy path does not apply: compression by definition
+copies-and-transforms. The selector therefore gates on
+`compression.is_none()` in addition to the conditions in section 2.5.
+
+For the matched (block-copy) path under compression, the
+`see_token()` calls into the deflate dictionary are still required
+(`delta.rs:382-463`). The basis-read via READ_FIXED is still useful
+because it removes hop 1's memcpy even if hop 3 stays on regular
+SEND. Section 6 sequences this as an IUD-7 follow-up.
+
+## 5. Feature flag and configuration
+
+`iouring-data-sends` (default off) lives on the `fast_io` crate and is
+re-exported by `transfer`:
+
+```text
+# fast_io/Cargo.toml
+iouring-data-sends = ["io_uring"]
+
+# transfer/Cargo.toml
+iouring-data-sends = ["io_uring", "fast_io/iouring-data-sends"]
+```
+
+The runtime selector consults `OC_RSYNC_IOURING_DATA_SENDS`
+(`auto` / `force` / `off`), parallel to the IUD-2 env var.
+`IOURING_DATA_SENDS_MIN_BYTES = 64 * 1024` by default; SEND_ZC's own
+floor inside `IoUringSocketWriter` is 16 KiB
+(`crates/fast_io/src/io_uring/socket_writer.rs:18-20`), so the
+combined gate honours both thresholds (the higher wins).
+
+Kernel requirements:
+
+- `IORING_OP_READ_FIXED` since Linux 5.6, like the receive path.
+- `IORING_OP_SEND_ZC` since Linux 6.0
+  (`crates/fast_io/src/io_uring/send_zc.rs::is_supported`).
+- `IORING_OP_SENDMSG_ZC` since Linux 6.1 (optional, header coalescing).
+- `IOSQE_IO_LINK` since Linux 5.5 (always available when io_uring is).
+
+When `SEND_ZC` is unsupported, the path falls back to regular
+`IORING_OP_SEND` against the same registered buffers, preserving the
+basis-read savings even when the socket-send savings are unavailable.
+
+## 6. Implementation plan
+
+The work is split into five PR-sized steps, keyed to IUD-6 (basis
+reader), IUD-7 (socket writer pinning), and IUD-8 (telemetry +
+rollout, shared with IUD-2).
+
+1. **IUD-6a: `submit_read_fixed_batch_pinned` helper.** Add the
+   no-copy-out variant of the existing helper in
+   `crates/fast_io/src/io_uring/registered_buffers/submit.rs`. Returns
+   `Vec<(RegisteredBufferSlotInfo, bytes_read)>` for the caller to
+   consume. Reuse the short-read loop verbatim from
+   `submit_read_fixed_batch:48-138`. Tests: extend
+   `crates/fast_io/src/io_uring/registered_buffers/tests/` with
+   short-read and out-of-order CQE coverage.
+
+2. **IUD-6b: `BasisReader::read_pinned`.** New trait method (or a free
+   function alongside `crates/transfer/src/map_file/mod.rs`) that the
+   delta-emit loop calls instead of `MapFile::map_ptr`. Returns a
+   pinned slot rather than a `&[u8]`. The buffered and mmap variants
+   implement it as "allocate a Vec, fill it, wrap in a fake slot
+   handle"; only the new `RegisteredBufferGroup`-backed variant
+   actually pins. The selector matrix from
+   `docs/design/basis-file-io-policy.md` gains a sixth column
+   `iouring_send_data_active`; when true and other constraints pass,
+   the matrix returns `RB` (registered buffers) for the basis read.
+
+3. **IUD-7a: `IoUringSendCoordinator` skeleton.** New type in
+   `crates/fast_io/src/io_uring/send_coordinator.rs` that owns a ring
+   shared with the basis reader and a registered-fd slot for the
+   socket. Exposes `submit_read_then_send` that link-chains
+   `READ_FIXED` and `SEND_ZC` SQEs (or runs them sequentially when
+   `IOSQE_IO_LINK` is rejected). Pin-count tracking follows the
+   borrowed-slice consumer design (#4218).
+
+4. **IUD-7b: Wire the coordinator into `delta.rs`.** Add the
+   selector at `crates/transfer/src/generator/delta.rs:200-274`
+   (whole-file literal stream) and at `delta.rs:289-334`
+   (basis re-read). The coordinator is passed through the call chain
+   the same way the existing `MultiplexWriter` is. Compression
+   gate per section 4. Maintain wire compatibility: byte stream
+   on the socket is byte-identical to the buffered path for the same
+   input.
+
+5. **IUD-8 (shared with IUD-2): Telemetry + rollout.** Wire counters
+   for: sends routed via SEND_ZC + READ_FIXED, sends routed via
+   SEND_ZC only (read fell back to buffered), sends routed via plain
+   SEND (SEND_ZC unsupported), SENDMSG_ZC adoption, pin-count
+   exhaustion fallbacks. Single-line `debug_log!(Io, 1, ..)` on the
+   first degradation transition per process. Bench harness:
+   `crates/fast_io/benches/iouring_data_sends.rs` measuring against
+   the matched workloads in `crates/fast_io/Cargo.toml:111-160`.
+   Flip `OC_RSYNC_IOURING_DATA_SENDS` default to `auto` once
+   benchmarks demonstrate non-regression.
+
+## 7. Interaction with IUD-2 (receive path)
+
+A given oc-rsync process is either a sender or a receiver on a given
+transfer; the two roles never share a registered-buffer pool within
+one transfer. The pools are conceptually identical (same slot layout,
+same registration call) and the implementation reuses
+`RegisteredBufferGroup`
+(`crates/fast_io/src/io_uring/registered_buffers/registry.rs`), but
+they are distinct instances owned by distinct threads:
+
+- Receive role: the disk-commit thread holds the pool; the network
+  thread checks slots out for fill, the disk thread checks them in
+  for WRITE_FIXED.
+- Send role: the sender thread holds the pool; READ_FIXED checks them
+  in from the file, SEND_ZC checks them out to the network.
+
+Crucially, the SQPOLL prohibition from
+`docs/design/mmap-vs-sqpoll-conflict-resolution.md` applies to both:
+file-backed VMAs (which include any `Mmap`-derived pointer) must never
+appear in an SQE issued by the SQPOLL kthread. The registered-buffer
+slots are anonymous, page-aligned `Vec<u8>` allocations, so the SQPOLL
+constraint does not bite on the data path itself - but the selector
+must still keep the basis-file `MmapStrategy` out of the ring on the
+send side, mirroring the receive side's exclusion.

--- a/docs/design/spill-policy-public-api.md
+++ b/docs/design/spill-policy-public-api.md
@@ -1,0 +1,216 @@
+# SpillPolicy public API + env-var surface
+
+Tracking issue: oc-rsync task #2335. Branch: `docs/spill-policy-api-design`.
+Subtasks: STN-2..STN-14 (see implementation plan in section 7).
+
+## TL;DR
+
+Today the only spill knob exposed to callers is
+`ConcurrentDeltaConfig.spill_threshold_bytes: Option<u64>` plus an optional
+`spill_dir: Option<PathBuf>`
+(`crates/engine/src/concurrent_delta/config.rs:35,41`). All other behaviour
+- reclaim policy, granularity, codec choice - is hard-wired inside
+`SpillableReorderBuffer` (`crates/engine/src/concurrent_delta/spill.rs:218`,
+`HOT_ZONE = 16` at line 68, length-prefixed binary codec at lines 135-161).
+This design promotes those hard-wired choices to a single public `SpillPolicy`
+struct with five knobs, three environment overrides, and two ops-friendly CLI
+flags. Migration keeps the existing field as a deprecated forwarding shim for
+exactly one release.
+
+## 1. Public Rust API
+
+New module: `crates/engine/src/concurrent_delta/spill_policy.rs`. Re-exported
+from `crates/engine/src/concurrent_delta/mod.rs`.
+
+```rust
+use std::path::PathBuf;
+
+/// User-facing tuning surface for the bounded-memory spill layer.
+///
+/// `SpillPolicy::default()` returns the historical behaviour: no spill,
+/// everything in memory. To enable spill set `threshold_bytes = Some(N)`;
+/// every other field has a sensible default.
+#[derive(Debug, Clone, Default)]
+pub struct SpillPolicy {
+    /// Memory budget (bytes) before items spill to disk. `None` disables
+    /// spill entirely - the consumer stays on the bare `ReorderBuffer`
+    /// path. `Some(0)` is rejected at validation time.
+    pub threshold_bytes: Option<u64>,
+
+    /// Directory backing the spill file. `None` defers to
+    /// `std::env::temp_dir()` via a spooled tempfile that lives in memory
+    /// up to 1 MB before rolling over.
+    pub dir: Option<PathBuf>,
+
+    /// Decision on spilled items once memory pressure recedes.
+    pub reclaim_mode: ReclaimMode,
+
+    /// Spill chunking unit. Coarser is faster, finer is more granular.
+    pub granularity: SpillGranularity,
+
+    /// Codec applied to the on-disk payload.
+    pub compression: SpillCompression,
+}
+
+/// Behaviour after spilled items are reloaded into memory for delivery.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ReclaimMode {
+    /// Reloaded items stay in memory until consumed. Lowest disk I/O,
+    /// highest peak RSS recovery latency. This is the default and matches
+    /// the current `SpillableReorderBuffer` behaviour.
+    #[default]
+    KeepInMemory,
+
+    /// If `memory_used > threshold` is still true after a reload, the
+    /// just-loaded items are eligible for re-spill. Trades extra disk
+    /// I/O for a tighter memory bound under sustained pressure.
+    ReSpillIfPressureContinues,
+}
+
+/// Unit at which the spill layer serialises and reloads items.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum SpillGranularity {
+    /// Spill the entire over-threshold tail of the reorder buffer in a
+    /// single batch. Fewer syscalls, higher amortised throughput. Default.
+    #[default]
+    WholeBatch,
+
+    /// Spill one item at a time, oldest-eligible first. Smoother memory
+    /// curve, more syscalls per spill event.
+    PerItem,
+}
+
+/// On-disk payload codec for spilled items.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum SpillCompression {
+    /// Raw length-prefixed binary payload (the current format). Default.
+    #[default]
+    None,
+
+    /// zstd-compressed payload. Level matches `zstd::compression_level`
+    /// semantics: negative for fast modes, positive for higher ratio.
+    Zstd { level: i32 },
+}
+```
+
+Constructors and builders follow the existing `ConcurrentDeltaConfig` style
+(`config.rs:48-68`): `SpillPolicy::off()`, `SpillPolicy::with_threshold(n)`,
+fluent `.with_dir(...)`, `.with_reclaim(...)`, `.with_granularity(...)`,
+`.with_compression(...)`.
+
+## 2. Defaults
+
+| Field | Default | Rationale |
+|-------|---------|-----------|
+| `threshold_bytes` | `None` | Preserves the v0.5.8 behaviour audit in `reorderbuffer-spill-to-tempfile.md`: realistic transfers stay under the 64 MB high-water mark, so opt-in keeps the receiver lean. |
+| `dir` | `None` | Defers to `std::env::temp_dir()` via `tempfile::SpooledTempFile`; 1 MB inline before rollover means zero disk hits for typical bursts. |
+| `reclaim_mode` | `KeepInMemory` | Matches `SpillableReorderBuffer::reload_one_at` semantics today (`spill.rs:218`). The re-spill mode is opt-in for adversarial workloads. |
+| `granularity` | `WholeBatch` | Mirrors `spill_excess()` (`spill.rs` core loop): one trim per insert that crosses the threshold. Lower syscall pressure under steady-state load. |
+| `compression` | `None` | Length-prefixed binary today is decode-fast and zero-copy compatible. Zstd is opt-in when the spill directory is on slow/SMR storage. |
+
+## 3. Environment variables
+
+Names align with the existing `OC_RSYNC_*` namespace seen in `branding`,
+`fast_io`, and `core` (`OC_RSYNC_BRAND`, `OC_RSYNC_DISABLE_IOURING`,
+`OC_RSYNC_ASYNC_SSH`, `OC_RSYNC_FORCE_NO_COMPRESS`).
+
+| Variable | Maps to | Accepted values |
+|----------|---------|-----------------|
+| `OC_RSYNC_SPILL_THRESHOLD_BYTES` | `threshold_bytes` | Integer with optional `K`/`M`/`G` suffix (case-insensitive, base 1024). Empty string clears. `0` rejected. |
+| `OC_RSYNC_SPILL_DIR` | `dir` | Absolute or relative path. Created on first spill via `fs::create_dir_all`. |
+| `OC_RSYNC_SPILL_RECLAIM` | `reclaim_mode` | `keep` -> `KeepInMemory`; `re-spill` -> `ReSpillIfPressureContinues`. Case-insensitive. |
+| `OC_RSYNC_SPILL_GRANULARITY` | `granularity` | `whole-batch` -> `WholeBatch`; `per-item` -> `PerItem`. |
+| `OC_RSYNC_SPILL_COMPRESSION` | `compression` | `none` -> `None`; `zstd` -> `Zstd { level: 3 }` (zstd default); `zstd:LEVEL` -> `Zstd { level: LEVEL }`. |
+
+Precedence (highest wins): CLI flag > env var > programmatic `SpillPolicy` >
+`SpillPolicy::default()`. This mirrors the precedence used by
+`OC_RSYNC_FORCE_NO_COMPRESS` in `crates/cli/src/frontend/execution/drive/options.rs:389`.
+
+## 4. CLI flags (ops-friendly subset)
+
+Only the two highest-value knobs surface as CLI flags. The remaining three
+stay env-only to keep the CLI tabular and to avoid promoting niche tuning
+into the help screen.
+
+| Flag | Argument | Mapping |
+|------|----------|---------|
+| `--spill-dir PATH` | `OsString` path | Sets `SpillPolicy.dir`. Mirrors the existing `--temp-dir` flag wiring at `parser/mod.rs:522-524`. |
+| `--spill-threshold-bytes N[K\|M\|G]` | size string | Sets `SpillPolicy.threshold_bytes`. Same suffix grammar as `OC_RSYNC_SPILL_THRESHOLD_BYTES`. |
+
+Both flags slot into `parsed_args/mod.rs` alongside `temp_dir`. Neither
+appears in upstream rsync's option grammar, so we do not need a short form.
+
+## 5. Validation rules
+
+Performed in `SpillPolicy::validate()` and invoked by every constructor that
+crosses a trust boundary (env-var loader, CLI parser, daemon config reader):
+
+1. `threshold_bytes`: if `Some(n)`, then `n > 0`. `Some(0)` returns
+   `SpillPolicyError::ZeroThreshold`.
+2. `dir`: if `Some(p)`, the path is writable - tested via the same probe
+   pattern as `SpillableReorderBuffer::with_spill_dir` (`spill.rs:315-334`):
+   a `fs::create_dir_all` followed by a tempfile `create`/`unlink`
+   round-trip. Failure surfaces as `SpillPolicyError::DirUnwritable { path, source }`.
+3. `compression`: if `Zstd { level }`, then `level` is in `[-22, 22]` (the
+   range accepted by the `zstd` crate). Out-of-range returns
+   `SpillPolicyError::InvalidZstdLevel(level)`.
+4. `reclaim_mode` and `granularity`: enum variants are statically bounded;
+   no runtime check needed.
+5. Env-var parser errors (`malformed suffix`, `unknown enum string`) wrap
+   into `SpillPolicyError::InvalidEnvVar { var, value }` with the offending
+   value redacted of newlines.
+
+Validation runs at config-construction time, never inside the hot reorder
+loop.
+
+## 6. Migration story
+
+Existing field on `ConcurrentDeltaConfig`:
+
+```rust
+pub spill_threshold_bytes: Option<u64>,
+pub spill_dir: Option<PathBuf>,
+```
+
+Migration plan, single release window:
+
+1. Add `pub spill: SpillPolicy` to `ConcurrentDeltaConfig` and mark the two
+   legacy fields `#[deprecated(since = "0.5.10", note = "use ConcurrentDeltaConfig::spill instead")]`.
+2. In every constructor (`ConcurrentDeltaConfig::with_spill_threshold`,
+   `with_spill_dir`, `Default`), populate both the legacy fields and the
+   new `spill: SpillPolicy` so older callers continue to see consistent
+   values when they read either side.
+3. `DeltaConsumer::spawn_with_config` reads `spill` first; if it is at
+   `SpillPolicy::default()` and the legacy `spill_threshold_bytes` is
+   `Some`, it forwards the legacy value via
+   `SpillPolicy::with_threshold(...).with_dir_opt(...)`. This keeps the
+   one-shot path working without a behavioural change.
+4. After one release the legacy fields are removed; the deprecation note
+   tells callers exactly which type to switch to.
+
+`SpillPolicy::default()` is byte-equivalent to today's
+`ConcurrentDeltaConfig::default()` (no spill), so the migration is
+behaviour-preserving for every caller that has not opted in.
+
+## 7. Five-step implementation plan
+
+| Step | Subtask | Deliverable |
+|------|---------|-------------|
+| 1 | STN-2 .. STN-4 | Introduce `SpillPolicy`, enums, `SpillPolicyError`, and unit tests in `crates/engine/src/concurrent_delta/spill_policy.rs`. Pure type definition + validation, no wiring. |
+| 2 | STN-5 .. STN-7 | Add env-var loader (`SpillPolicy::from_env`) covering the five `OC_RSYNC_SPILL_*` vars, including the `K`/`M`/`G` suffix parser shared with `--bwlimit` style flags. Property-tested round-trip env -> policy -> env. |
+| 3 | STN-8 .. STN-10 | Wire `SpillPolicy` into `ConcurrentDeltaConfig` with the deprecated forwarding shim from section 6. Update `DeltaConsumer::spawn_with_config` and `SpillableReorderBuffer::new_from_policy` constructor. |
+| 4 | STN-11 .. STN-12 | Plumb `--spill-dir` / `--spill-threshold-bytes` into `crates/cli/src/frontend/arguments/parser/mod.rs` and the matching fields in `parsed_args/mod.rs`. CLI help text only mentions the two ops flags; env vars documented in `docs/design/cli-tunability-flags.md`. |
+| 5 | STN-13 .. STN-14 | Implement `ReclaimMode::ReSpillIfPressureContinues`, `SpillGranularity::PerItem`, and `SpillCompression::Zstd` behind the new policy fields, with parity tests against the default code path and a synthetic-pressure bench under `reorderbuffer_memory`. |
+
+Each step lands as an independent PR keyed to its subtask range. Steps 1-3
+are wire-protocol-neutral and ship in one release; steps 4-5 follow once
+the policy surface is stable.
+
+## 8. Out of scope
+
+- Per-file or per-module overrides. The policy is process-wide.
+- Daemon config-file syntax. The daemon will read `SpillPolicy::from_env`
+  on startup; full `oc-rsyncd.conf` integration is tracked separately.
+- Wire-protocol exposure. Spill is a purely receiver-side concern; no
+  capability flag or negotiated parameter is involved (see
+  `reorderbuffer-spill-to-tempfile.md` section "Scope").

--- a/docs/oc-rsync.1.md
+++ b/docs/oc-rsync.1.md
@@ -276,10 +276,82 @@ NEON) are used where available, with automatic scalar fallbacks.
 :   Disable creation time preservation.
 
 **-A**, **--acls**
-:   Preserve POSIX ACLs when supported (Unix only).
+:   Preserve POSIX ACLs on Linux, macOS, and FreeBSD via `exacl`.
+
+    On Windows, **--acls** preserves the NTFS discretionary ACL (DACL) via
+    `GetNamedSecurityInfoW`/`SetNamedSecurityInfoW`. The Windows path is a
+    Tier 1C partial implementation: it interoperates with upstream rsync
+    and POSIX peers through the standard cross-platform ACL wire format,
+    but it cannot represent every NTFS construct losslessly. The following
+    losses are documented and emit a one-time warning per transfer:
+
+      - **Deny ACEs are dropped.** POSIX has no deny equivalent, so explicit
+        `ACCESS_DENIED_ACE_TYPE` entries are silently omitted from the wire
+        payload.
+      - **Inherited ACEs are not transmitted.** ACEs with the
+        `INHERITED_ACE` flag are skipped; the receiver relies on the
+        destination's own inheritance chain. Mirrors how POSIX default ACLs
+        are handled as a separate stream.
+      - **The system ACL (SACL) is skipped** unless the planned
+        **--audit-acls** flag is passed and the sender holds
+        `SE_SECURITY_NAME`. Audit ACEs cannot ride the cross-platform
+        payload.
+      - **Non-`rwx` access bits collapse.** `FILE_GENERIC_READ`/`WRITE`/`EXECUTE`
+        map cleanly to `r`/`w`/`x`. Bits outside that triplet (`DELETE`,
+        `WRITE_DAC`, `WRITE_OWNER`, `SYNCHRONIZE`, generic bits) are
+        dropped on send and re-synthesised as `FILE_GENERIC_*` plus
+        `SYNCHRONIZE` on receive.
+      - **Unresolvable SIDs are dropped.** Trustee SIDs that
+        `LookupAccountSidW` cannot translate to an account name are omitted
+        from the cross-platform payload; on receive, names that
+        `LookupAccountNameW` cannot resolve cause the ACE to be dropped
+        with a warning.
+
+    The cross-platform payload is the standard upstream byte stream
+    (varint count, per-entry tag, permission triplet, optional name). A
+    second, opt-in payload encoding the full NTFS security descriptor as
+    SDDL on the existing xattr stream under
+    `user.win32.security_descriptor` is planned (see
+    **--windows-acls** below). SDDL is the textual form produced and
+    consumed by `ConvertSecurityDescriptorToStringSecurityDescriptorW`;
+    Windows-to-Windows transfers may use it for higher fidelity while
+    remaining backward-compatible with peers that only understand the
+    cross-platform payload.
+
+    See `docs/design/windows-ntfs-acl-support.md` for the full mapping
+    matrix, hardlink handling, and the implementation roadmap.
 
 **--no-acls**
-:   Disable POSIX ACL preservation.
+:   Disable ACL preservation.
+
+**--audit-acls** (planned)
+:   On Windows, request that the sender read the system ACL (SACL) in
+    addition to the DACL. Requires the `SE_SECURITY_NAME` privilege; the
+    sender skips the SACL with a warning when the privilege probe fails.
+    SACL contents are carried only in the SDDL fidelity payload (see
+    **--windows-acls**), never in the cross-platform payload. Not yet
+    wired; see `docs/design/windows-ntfs-acl-support.md` section 4.2.
+
+**--fail-on-windows-acl-loss** (planned)
+:   On Windows, abort the transfer with exit code 23 (partial transfer)
+    when an NTFS DACL contains deny ACEs, audit ACEs, inherited ACEs that
+    cannot be expressed in POSIX, or owner/group SIDs the receiver cannot
+    resolve. Use this when a transfer must either preserve the source
+    DACL verbatim or fail loudly rather than silently lower to POSIX
+    rwx. Not yet wired; see `docs/design/windows-ntfs-acl-support.md`
+    section 4.3.
+
+**--windows-acls** (planned)
+:   On Windows, opt in to the Windows-to-Windows SDDL fidelity payload in
+    addition to the cross-platform payload. When both peers advertise the
+    `W` capability bit, the sender writes the full NTFS security
+    descriptor as SDDL into the `user.win32.security_descriptor` xattr
+    via `ConvertSecurityDescriptorToStringSecurityDescriptorW`, and the
+    receiver reconstructs the descriptor verbatim via
+    `ConvertStringSecurityDescriptorToSecurityDescriptorW`. Falls back to
+    the cross-platform payload when either peer does not advertise `W`.
+    Not yet wired; see `docs/design/windows-ntfs-acl-support.md` section
+    4.2.
 
 **-X**, **--xattrs**
 :   Preserve extended attributes when supported (Unix only).

--- a/docs/oc-rsync.1.md
+++ b/docs/oc-rsync.1.md
@@ -864,6 +864,29 @@ exits with an error.
     even when the kernel supports io_uring. Overrides a previous
     **--io-uring** on the same command line.
 
+The next two flags govern the receiver-side `SpillPolicy` that bounds the
+concurrent-delta `ReorderBuffer`'s memory footprint. Both are *planned* for
+STN-11 and will land in a future release; until then operators tune the same
+knobs via the `OC_RSYNC_SPILL_DIR` and `OC_RSYNC_SPILL_THRESHOLD_BYTES`
+environment variables (see *Receiver spill tunability* in the operator
+migration guide). When the flags ship, they take precedence over the env
+vars on the same invocation. The remaining `SpillPolicy` fields
+(reclaim mode, granularity, compression) stay env-only by design; see
+**docs/design/spill-policy-public-api.md** for the full surface.
+
+**--spill-dir**=*PATH* (planned, STN-11)
+:   Directory backing the receiver spill file. Created on first spill via
+    `create_dir_all`. When unset the runtime defers to
+    **std::env::temp_dir**(3) through a spooled tempfile that stays in
+    memory up to 1 MiB before rolling over. Maps to `SpillPolicy.dir`.
+
+**--spill-threshold-bytes**=*N*[**K**|**M**|**G**] (planned, STN-11)
+:   Memory budget for the receiver reorder buffer before items spill to
+    disk. Suffixes are case-insensitive base-1024 (`K`=KiB, `M`=MiB,
+    `G`=GiB). Omitting the flag (or passing an empty value) leaves spill
+    disabled and the consumer stays on the bare `ReorderBuffer` path; the
+    value `0` is rejected. Maps to `SpillPolicy.threshold_bytes`.
+
 ## Scheduling Options
 
 **--stop-after**=*MINS*

--- a/docs/operator-migration-guide-vNEXT.md
+++ b/docs/operator-migration-guide-vNEXT.md
@@ -117,7 +117,7 @@ is marked SUPERSEDED. The replacement is the always-on DDP model in
 
 ## 4. New opt-in feature flags
 
-vNEXT introduces five Cargo feature flags that gate new performance
+vNEXT introduces six Cargo feature flags that gate new performance
 surfaces. None are enabled by default. None change wire bytes. All can
 be combined.
 
@@ -191,6 +191,47 @@ be combined.
   Steady-state memory grows by `N_threads * byte_cap`, so do not
   enable on memory-constrained endpoints.
 - **Build.** `cargo build --release --features thread-slab-pool`.
+
+### `ssh-socketpair-stderr` (`rsync_io`, experimental)
+
+- **What it does.** Replaces the anonymous-pipe stderr channel of the
+  SSH child with a `socketpair(AF_UNIX, SOCK_STREAM, 0)` constructed
+  via `UnixStream::pair`. The parent end is a bidirectional socket that
+  can be registered with `epoll`/`kqueue` (or tokio `AsyncFd`) and woken
+  out-of-band via `shutdown(2)`, which is the seam SSE-4 uses to drive
+  the drain off a tokio task instead of a dedicated thread per
+  connection. The child still sees a plain stream of bytes on fd 2.
+  Capture semantics, line forwarding to host stderr, and the bounded
+  64 KiB ring buffer used by `stderr_output()` are unchanged.
+- **When to opt in.** Linux endpoints that already build with
+  `async-ssh` and want the SSH stderr drain integrated into the same
+  tokio reactor as the wire path, instead of consuming a per-connection
+  blocking thread; long-running fan-out clients that open many
+  concurrent SSH children where the saved drain threads matter; and
+  any deployment that wants the larger default kernel buffer
+  (~208 KiB on Linux vs 64 KiB for pipes) and `shutdown(SHUT_RD)`
+  as the wake primitive for the drain loop. macOS works too, with
+  the same `UnixStream::pair` construction.
+- **When to stay on the default.** Operators who prefer the simpler
+  pipe semantics for debugging (a pipe is unidirectional and shows up
+  as a single read-only fd in `lsof` / `procfs`); Windows endpoints,
+  where the TCP-loopback shim is still in flight under SSE-5 and
+  falls back to `Stdio::piped()` on any error; sync-only SSH
+  deployments that do not link tokio, since the existing sync
+  transport already uses the socketpair when available and gains
+  nothing from the flag. The default-off ships exactly what `master`
+  shipped before the SSE series.
+- **Build.** `cargo build --release -p rsync_io --features ssh-socketpair-stderr`.
+  Combine with `async-ssh` to actually exercise the async drain path:
+  `cargo build --release --features "async-ssh" -p core` and
+  `cargo build --release --features "ssh-socketpair-stderr" -p rsync_io`.
+- **Design reference.** Rationale, cross-platform construction, and
+  the SSE-3 through SSE-7 staging plan are in
+  [`docs/design/socketpair-stderr-channel.md`](design/socketpair-stderr-channel.md)
+  (#2371). The companion stderr-handling audit that motivated the
+  series is in
+  [`docs/audits/ssh-stderr-handling.md`](audits/ssh-stderr-handling.md)
+  (#2370).
 
 ### `vmsplice` (`fast_io`, `transfer`, Linux only)
 
@@ -399,9 +440,10 @@ targets; on macOS and Windows the platform-native build is used.
   `--delete-during` sweep. The `--delete-strict-order` opt-in flag
   from the prior prerelease becomes available again.
 - The opt-in feature flags from section 4 (`async-ssh`,
-  `async-daemon`, `parallel-receive-delta`, `thread-slab-pool`,
-  `vmsplice`) do not exist in earlier releases. Builds that enabled
-  them must drop the flag from the build command when downgrading.
+  `async-daemon`, `parallel-receive-delta`, `ssh-socketpair-stderr`,
+  `thread-slab-pool`, `vmsplice`) do not exist in earlier releases.
+  Builds that enabled them must drop the flag from the build command
+  when downgrading.
 - Wire compatibility is preserved across the rollback. A vNEXT
   client talking to a previous-version daemon (or the reverse) is a
   supported configuration; the protocol negotiation collapses to
@@ -434,6 +476,8 @@ next.
 | Daemon async runtime choice                    | `docs/design/daemon-async-runtime-choice.md`                            |
 | Daemon async accept + sync workers             | `docs/design/daemon-async-accept-sync-workers.md`                       |
 | Parallel receive-side delta application        | `docs/design/parallel-receive-delta-application.md`                     |
+| SSH stderr socketpair channel                  | `docs/design/socketpair-stderr-channel.md`                              |
+| SSH stderr handling audit                      | `docs/audits/ssh-stderr-handling.md`                                    |
 | Per-thread buffer slab                         | `docs/design/per-thread-buffer-slab.md`                                 |
 | vmsplice / splice zero copy                    | `docs/design/splice-vmsplice-zero-copy.md`                              |
 | io_uring session ring pool                     | `docs/design/iouring-session-ring-pool.md`                              |

--- a/docs/operator-migration-guide-vNEXT.md
+++ b/docs/operator-migration-guide-vNEXT.md
@@ -249,6 +249,68 @@ be combined.
 - **Build.** `cargo build --release --features vmsplice`
   (Linux only; no-op on other targets).
 
+### Receiver spill tunability (`SpillPolicy`)
+
+The concurrent-delta receiver bounds its `ReorderBuffer` through a
+process-wide `SpillPolicy` introduced in STN-1 (design) and STN-2
+(struct). The default policy keeps the historical behaviour - no spill,
+everything in memory, byte-equivalent to the previous release - so
+existing operators see no behavioural change.
+
+- **What it does.** When `threshold_bytes` is set, the receiver writes
+  the oldest-eligible items in the reorder window to a tempfile once
+  the in-memory footprint crosses the threshold and reloads them when
+  they reach the head of the delivery order. The on-disk format is a
+  length-prefixed binary payload; compression is opt-in.
+- **Defaults.** `threshold_bytes = None` (spill disabled),
+  `dir = None` (defers to **std::env::temp_dir**(3) via a 1 MiB
+  spooled tempfile), `reclaim_mode = KeepInMemory`,
+  `granularity = WholeBatch`, `compression = None`. The defaults
+  table and rationale are in
+  [`docs/design/spill-policy-public-api.md`](design/spill-policy-public-api.md)
+  section 2.
+- **Environment variables.** All five `SpillPolicy` fields are
+  reachable through `OC_RSYNC_SPILL_*` env vars; precedence (highest
+  wins) is CLI flag > env var > programmatic policy > default.
+
+| Variable | Maps to | Accepted values |
+|----------|---------|-----------------|
+| `OC_RSYNC_SPILL_THRESHOLD_BYTES` | `threshold_bytes` | Integer with optional `K`/`M`/`G` suffix (case-insensitive, base 1024). Empty string clears. `0` is rejected. |
+| `OC_RSYNC_SPILL_DIR` | `dir` | Absolute or relative path. Created on first spill via `create_dir_all`. |
+| `OC_RSYNC_SPILL_RECLAIM` | `reclaim_mode` | `keep` (default) or `re-spill`. |
+| `OC_RSYNC_SPILL_GRANULARITY` | `granularity` | `whole-batch` (default) or `per-item`. |
+| `OC_RSYNC_SPILL_COMPRESSION` | `compression` | `none` (default), `zstd`, or `zstd:LEVEL` where `LEVEL` is in `[-22, 22]`. |
+
+- **When to override.**
+  - *Memory-constrained receivers* (containers with tight cgroup
+    memory limits, embedded targets) should set
+    `OC_RSYNC_SPILL_THRESHOLD_BYTES` to a value below the cgroup
+    limit (typical starting point: 64 MiB) and point
+    `OC_RSYNC_SPILL_DIR` at a fast tmpfs or local SSD.
+  - *Adversarial fan-out workloads* (deep INC_RECURSE trees with
+    many unfinished segments held in the reorder window) benefit
+    from `OC_RSYNC_SPILL_RECLAIM=re-spill` to keep the post-reload
+    footprint bounded under sustained pressure.
+  - *Slow or SMR spill directories* should set
+    `OC_RSYNC_SPILL_COMPRESSION=zstd` to trade CPU for disk
+    bandwidth; default level 3 is usually appropriate, raise to
+    `zstd:7` only when the spill device is the bottleneck.
+  - *Diagnostic granularity* on benchmark runs:
+    `OC_RSYNC_SPILL_GRANULARITY=per-item` smooths the memory curve
+    at the cost of more syscalls per spill event.
+- **When to stay on the default.** Every workload that fits inside
+  the documented 64 MiB high-water mark on the audit baseline. Spill
+  is opt-in for a reason: the in-memory path is the fastest and
+  byte-stable.
+- **CLI flags.** `--spill-dir` and `--spill-threshold-bytes` are
+  planned for STN-11 and will land in a future release; they shadow
+  the two highest-value env vars. The remaining three knobs stay
+  env-only.
+- **References.** Public-API surface and validation rules:
+  [`docs/design/spill-policy-public-api.md`](design/spill-policy-public-api.md).
+  Spillable buffer internals:
+  [`docs/design/reorderbuffer-spill-to-tempfile.md`](design/reorderbuffer-spill-to-tempfile.md).
+
 ### Combining flags
 
 The feature flags are independent. A common production combination

--- a/docs/operator-migration-guide-vNEXT.md
+++ b/docs/operator-migration-guide-vNEXT.md
@@ -327,6 +327,38 @@ grows by `N_threads * byte_cap` (default 1 MiB). Operators running
 with more than 32 worker threads per pool will see lower contention
 and slightly higher RSS.
 
+## 6a. Windows NTFS ACL behaviour
+
+`--acls`/`-A` now works on Windows targets via
+`GetNamedSecurityInfoW`/`SetNamedSecurityInfoW`, but the implementation
+is a Tier 1C partial path. Operators migrating Windows workloads should
+budget for the documented lossy cases before flipping `-A` on:
+
+- Explicit deny ACEs are dropped on send.
+- Inherited ACEs are not transmitted; the destination inheritance chain
+  takes over.
+- The system ACL (SACL) is skipped unless the planned **--audit-acls**
+  flag is passed and `SE_SECURITY_NAME` is held.
+- Non-`rwx` access bits (`DELETE`, `WRITE_DAC`, `WRITE_OWNER`, generic
+  bits) collapse to `r`/`w`/`x` plus `SYNCHRONIZE` on receive.
+- Trustee SIDs that cannot be translated to or from an account name are
+  dropped with a one-time warning.
+
+The cross-platform payload remains byte-compatible with upstream rsync
+and POSIX peers. The planned **--windows-acls** opt-in adds a higher-
+fidelity SDDL payload over the existing xattr stream for Windows-to-
+Windows transfers, and **--fail-on-windows-acl-loss** turns the lossy
+cases into a hard failure (exit code 23) for environments that need to
+preserve every NTFS ACE verbatim or abort. None of these three flags
+ship in this release; track `docs/design/windows-ntfs-acl-support.md`
+section 4 for the rollout schedule.
+
+The full mapping matrix, hardlink-safe DACL application rules, and the
+SDDL wire format details are in
+`docs/design/windows-ntfs-acl-support.md`. The user-facing
+**--acls** entry in `docs/oc-rsync.1.md` enumerates the lossy cases
+alongside the flag synopsis.
+
 ## 7. Rollback procedure
 
 If a regression surfaces in vNEXT, pin to the previous release. The
@@ -407,3 +439,4 @@ next.
 | io_uring session ring pool                     | `docs/design/iouring-session-ring-pool.md`                              |
 | io_uring per-thread rings                      | `docs/design/iouring-per-thread-rings.md`                               |
 | Cross-platform CI coverage                     | `docs/audits/cross-platform-ci-coverage.md`                             |
+| Windows NTFS ACL support                       | `docs/design/windows-ntfs-acl-support.md`                               |

--- a/docs/ssh-transport.md
+++ b/docs/ssh-transport.md
@@ -1,0 +1,103 @@
+# SSH transport
+
+`oc-rsync` reaches a remote endpoint by spawning an external `ssh` client
+(or any other remote shell selected with `--rsh=...`) and tunnelling the
+rsync protocol over the child's stdin and stdout. The child's stderr is
+drained into a bounded ring buffer so that diagnostic output from the
+remote (host-key prompts, `Permission denied`, MOTD lines, verbose
+`-vvv` traces, anything chatty in `~/.ssh/rc`) is surfaced to the user
+without ever stalling the transfer.
+
+The default stderr endpoint is an anonymous pipe created by
+`pipe2(2)`. That is portable and sufficient for typical workloads. For
+long-running sessions with very chatty remote children, an opt-in Cargo
+feature swaps the pipe for a `socketpair(2)` on Unix targets.
+
+## SSH stderr capture (socketpair, opt-in)
+
+### What it does
+
+The `ssh-socketpair-stderr` Cargo feature on the `rsync_io` crate
+changes how the parent process receives the SSH child's stderr stream.
+Instead of the default anonymous pipe, it uses one half of a
+`socketpair(AF_UNIX, SOCK_STREAM, 0)` and hands the other half to the
+child as its stderr file descriptor. Everything downstream (the bounded
+64 KiB ring buffer, real-time forwarding to the parent's own stderr,
+the snapshot accessor used in error messages) is unchanged.
+
+### Why it exists
+
+A pipe-backed stderr can deadlock when the child writes faster than the
+parent drains. The Linux pipe buffer is 64 KiB by default; once it is
+full, the child blocks in `write(2)` and never makes progress, while the
+parent is blocked elsewhere (waiting on the wire, on an `accept(2)`, on
+disk I/O). The transfer hangs until either side times out.
+
+A `socketpair`-backed endpoint mitigates this in two ways:
+
+1. The default kernel buffer is larger (around 208 KiB on Linux,
+   platform-dependent on the BSDs and macOS), which absorbs longer
+   bursts before back-pressure kicks in.
+2. The parent can call `shutdown(SHUT_RD)` as an out-of-band wake-up
+   when the transfer is finishing, which is cleaner than relying on the
+   child to close its end. That matters for SSH multiplexing
+   (`ControlMaster`) and `ssh-askpass` cases where a helper inherits the
+   write end and outlives the rsync run.
+
+The kernel object is otherwise interchangeable: byte semantics,
+`O_NONBLOCK` support, and `epoll`/`kqueue` registration are identical.
+
+### When to enable it
+
+Enable the feature if you regularly:
+
+- run `oc-rsync` over slow or high-latency links where back-pressure
+  matters,
+- use SSH with `-vvv` or `LogLevel DEBUG3` on either side,
+- have `~/.ssh/rc`, login banners, or `ForceCommand` wrappers that emit
+  large amounts of text on every connection,
+- multiplex many connections through a single `ControlMaster` whose
+  helper processes outlive individual transfers.
+
+For typical interactive use or short-lived scripted transfers, the
+default pipe-backed endpoint is fine and no rebuild is required.
+
+### How to enable it
+
+The feature is selected at compile time on the `rsync_io` crate:
+
+```sh
+cargo build --release --features rsync_io/ssh-socketpair-stderr
+```
+
+There is no runtime toggle and no environment variable. A binary built
+without the feature uses anonymous pipes; a binary built with the
+feature uses socketpairs on Unix and silently falls back to pipes on
+file-descriptor exhaustion. To switch back, rebuild without the
+feature.
+
+### Platform notes
+
+| Platform                | Backend when feature is on    | Backend when feature is off |
+|-------------------------|-------------------------------|------------------------------|
+| Linux                   | `socketpair(AF_UNIX)`         | `pipe2(2)`                   |
+| macOS                   | `socketpair(AF_UNIX)`         | `pipe2(2)`                   |
+| FreeBSD and other Unix  | `socketpair(AF_UNIX)`         | `pipe2(2)`                   |
+| Windows                 | anonymous pipe (feature has no effect today) | anonymous pipe |
+
+The Windows TCP-loopback shim sketched in the design doc is not yet
+wired up; on Windows the feature compiles but has no effect at runtime,
+and the child's stderr continues to flow through the anonymous pipe
+that `tokio::process::Command` creates.
+
+The user-visible behaviour is the same with either backend: the same
+bytes are surfaced through the same error-reporting code path. Only the
+deadlock resistance and the wake-up mechanism differ.
+
+### References
+
+- Design: [`docs/design/socketpair-stderr-channel.md`](design/socketpair-stderr-channel.md)
+- Audits: [`docs/audits/ssh-stderr-handling.md`](audits/ssh-stderr-handling.md),
+  [`docs/audits/ssh-socketpair-vs-pipes.md`](audits/ssh-socketpair-vs-pipes.md),
+  [`docs/audits/ssh-socketpair-claim-verification.md`](audits/ssh-socketpair-claim-verification.md)
+- Trackers: SSE-1..SSE-8 (issues #2370-#2377).

--- a/scripts/windows_throughput_bench.sh
+++ b/scripts/windows_throughput_bench.sh
@@ -28,6 +28,26 @@
 #   BENCH_LARGE_MIB   Size of the single large file in MiB (default: 1024)
 #   BENCH_SMALL_COUNT Number of small files (default: 10000)
 #   BENCH_SMALL_KIB   Size of each small file in KiB (default: 4)
+#
+# Drilldown mode (env-gated, OC_RSYNC_BENCH_DRILLDOWN=1):
+#   Adds three sub-scenarios that isolate the individual IOCP hotspots
+#   identified in docs/audits/iocp-sync-blocking-audit.md so future Windows
+#   improvements can be attributed to specific changes:
+#     - write_only_iocp:     forces full-file writes via --whole-file
+#                            --inplace, isolating the IocpWriter per-IO
+#                            blocking drain (audit rows #1, #4, #13).
+#                            Control: native std::fs::copy via `cp`.
+#     - read_only_iocp:      runs oc-rsync with --dry-run against the same
+#                            1 GiB fixture so the file is mapped/read but
+#                            never written, isolating the IocpReader
+#                            blocking drain (audit rows #2, #3).
+#     - network_only_loopback: pushes a 1 GiB file through two oc-rsync
+#                            daemons over loopback rsync://, isolating the
+#                            IocpSocketWriter / Reader hot paths (audit
+#                            rows #8-#11) from disk completion costs.
+#   Optional knobs:
+#     BENCH_DAEMON_PORT      TCP port for the loopback daemon
+#                            (default: 18730)
 
 set -eu
 
@@ -51,6 +71,8 @@ BENCH_RUNS="${BENCH_RUNS:-3}"
 BENCH_LARGE_MIB="${BENCH_LARGE_MIB:-1024}"
 BENCH_SMALL_COUNT="${BENCH_SMALL_COUNT:-10000}"
 BENCH_SMALL_KIB="${BENCH_SMALL_KIB:-4}"
+OC_RSYNC_BENCH_DRILLDOWN="${OC_RSYNC_BENCH_DRILLDOWN:-0}"
+BENCH_DAEMON_PORT="${BENCH_DAEMON_PORT:-18730}"
 
 # Tool checks (skip rather than fail to keep CI green on missing deps).
 if ! command -v hyperfine >/dev/null 2>&1; then
@@ -133,6 +155,187 @@ run_scenario() {
 
 run_scenario "large_1gib"   "$LARGE_SRC" "$LARGE_DST_OC" "$LARGE_DST_UP"
 run_scenario "small_10000"  "$SMALL_SRC" "$SMALL_DST_OC" "$SMALL_DST_UP"
+
+# ----------------------------------------------------------------------------
+# Drilldown mode: per-hotspot isolation (env-gated).
+#
+# Each sub-scenario keeps the same hyperfine harness, but swaps the
+# command pair to neutralise everything except the hotspot under test.
+# See docs/audits/iocp-sync-blocking-audit.md for the mapping from
+# scenario name to audit row.
+# ----------------------------------------------------------------------------
+if [ "$OC_RSYNC_BENCH_DRILLDOWN" = "1" ]; then
+    log "drilldown mode: OC_RSYNC_BENCH_DRILLDOWN=1"
+
+    if ! command -v cp >/dev/null 2>&1; then
+        skip "drilldown requires cp (MSYS2 coreutils); not on PATH"
+    fi
+
+    DRILL_ROOT="$WORKROOT/drilldown"
+    mkdir -p "$DRILL_ROOT"
+
+    # ------------------------------------------------------------------
+    # write_only_iocp
+    #   --whole-file forces a full sender->receiver byte stream (no
+    #   delta), --inplace skips the temp-file + rename so every byte
+    #   lands via IocpWriter. Control is std::fs::copy via `cp`, which
+    #   bypasses oc-rsync entirely and exercises only NTFS write
+    #   bandwidth. The delta between the two is the IOCP write-path
+    #   overhead (audit rows #1, #4, #13).
+    # ------------------------------------------------------------------
+    WRITE_SRC="$DRILL_ROOT/write/src"
+    WRITE_DST_OC="$DRILL_ROOT/write/dst_oc"
+    WRITE_DST_CP="$DRILL_ROOT/write/dst_cp"
+    mkdir -p "$WRITE_SRC" "$WRITE_DST_OC" "$WRITE_DST_CP"
+    cp "$LARGE_SRC/large.bin" "$WRITE_SRC/large.bin"
+
+    write_only_out="$BENCH_OUT_DIR/write_only_iocp.json"
+    log "running scenario: write_only_iocp -> $write_only_out"
+    hyperfine \
+        --warmup "$BENCH_WARMUP" \
+        --runs "$BENCH_RUNS" \
+        --export-json "$write_only_out" \
+        --command-name "oc-rsync-write" \
+            --prepare "rm -rf '$WRITE_DST_OC'/* '$WRITE_DST_OC'/.[!.]* 2>/dev/null || true" \
+            "'$OC_RSYNC' --whole-file --inplace -a '$WRITE_SRC/' '$WRITE_DST_OC/'" \
+        --command-name "fs-copy-control" \
+            --prepare "rm -rf '$WRITE_DST_CP'/* '$WRITE_DST_CP'/.[!.]* 2>/dev/null || true" \
+            "cp '$WRITE_SRC/large.bin' '$WRITE_DST_CP/large.bin'"
+
+    # ------------------------------------------------------------------
+    # read_only_iocp
+    #   --dry-run walks and reads the source but never writes the
+    #   destination, isolating IocpReader's per-IO blocking drain
+    #   (audit rows #2, #3). Control is upstream rsync with the same
+    #   flag, so any delta reflects oc-rsync's read-side completion
+    #   handling rather than the dry-run bookkeeping itself.
+    # ------------------------------------------------------------------
+    READ_DST_OC="$DRILL_ROOT/read/dst_oc"
+    READ_DST_UP="$DRILL_ROOT/read/dst_up"
+    mkdir -p "$READ_DST_OC" "$READ_DST_UP"
+
+    read_only_out="$BENCH_OUT_DIR/read_only_iocp.json"
+    log "running scenario: read_only_iocp -> $read_only_out"
+    hyperfine \
+        --warmup "$BENCH_WARMUP" \
+        --runs "$BENCH_RUNS" \
+        --export-json "$read_only_out" \
+        --command-name "oc-rsync-read" \
+            "'$OC_RSYNC' -a --dry-run '$LARGE_SRC/' '$READ_DST_OC/'" \
+        --command-name "upstream-rsync-read" \
+            "'$UPSTREAM_RSYNC' -a --dry-run '$LARGE_SRC/' '$READ_DST_UP/'"
+
+    # ------------------------------------------------------------------
+    # network_only_loopback
+    #   Spawns two short-lived oc-rsync daemons on loopback ports and
+    #   measures a push from one to the other. Source and destination
+    #   are on the same disk, so disk bandwidth is symmetrical; the
+    #   variable under test is the IocpSocket send/recv path (audit
+    #   rows #8-#11). Control is upstream rsync running its own
+    #   loopback daemon under the same shape.
+    # ------------------------------------------------------------------
+    NET_ROOT="$DRILL_ROOT/network"
+    NET_SRC="$NET_ROOT/src"
+    NET_DST_OC="$NET_ROOT/dst_oc"
+    NET_DST_UP="$NET_ROOT/dst_up"
+    NET_CONF_OC="$NET_ROOT/oc-rsyncd.conf"
+    NET_CONF_UP="$NET_ROOT/upstream-rsyncd.conf"
+    NET_PID_OC="$NET_ROOT/oc-rsyncd.pid"
+    NET_PID_UP="$NET_ROOT/upstream-rsyncd.pid"
+    NET_LOG_OC="$NET_ROOT/oc-rsyncd.log"
+    NET_LOG_UP="$NET_ROOT/upstream-rsyncd.log"
+    mkdir -p "$NET_SRC" "$NET_DST_OC" "$NET_DST_UP"
+    cp "$LARGE_SRC/large.bin" "$NET_SRC/large.bin"
+
+    OC_PORT="$BENCH_DAEMON_PORT"
+    UP_PORT=$(( BENCH_DAEMON_PORT + 1 ))
+
+    cat >"$NET_CONF_OC" <<EOF
+use chroot = no
+port = $OC_PORT
+pid file = $NET_PID_OC
+log file = $NET_LOG_OC
+[bench]
+    path = $NET_DST_OC
+    read only = false
+    uid = 0
+    gid = 0
+EOF
+
+    cat >"$NET_CONF_UP" <<EOF
+use chroot = no
+port = $UP_PORT
+pid file = $NET_PID_UP
+log file = $NET_LOG_UP
+[bench]
+    path = $NET_DST_UP
+    read only = false
+    uid = 0
+    gid = 0
+EOF
+
+    # Ensure no stale PID files survive a previous interrupted run.
+    rm -f "$NET_PID_OC" "$NET_PID_UP"
+
+    log "starting loopback oc-rsync daemon on 127.0.0.1:$OC_PORT"
+    "$OC_RSYNC" --daemon --no-detach --config="$NET_CONF_OC" >"$NET_LOG_OC" 2>&1 &
+    OC_DAEMON_PID=$!
+    log "starting loopback upstream rsync daemon on 127.0.0.1:$UP_PORT"
+    "$UPSTREAM_RSYNC" --daemon --no-detach --config="$NET_CONF_UP" >"$NET_LOG_UP" 2>&1 &
+    UP_DAEMON_PID=$!
+
+    stop_daemons() {
+        if [ -n "${OC_DAEMON_PID:-}" ]; then
+            kill "$OC_DAEMON_PID" 2>/dev/null || true
+            wait "$OC_DAEMON_PID" 2>/dev/null || true
+        fi
+        if [ -n "${UP_DAEMON_PID:-}" ]; then
+            kill "$UP_DAEMON_PID" 2>/dev/null || true
+            wait "$UP_DAEMON_PID" 2>/dev/null || true
+        fi
+    }
+    trap 'stop_daemons; rm -rf "$WORKROOT"' EXIT INT TERM
+
+    # Poll briefly for each daemon's listening port (avoid fixed sleep).
+    wait_for_port() {
+        port="$1"
+        attempts=0
+        while [ "$attempts" -lt 50 ]; do
+            if (echo >/dev/tcp/127.0.0.1/"$port") >/dev/null 2>&1; then
+                return 0
+            fi
+            attempts=$(( attempts + 1 ))
+            sleep 0.1
+        done
+        return 1
+    }
+    if ! wait_for_port "$OC_PORT"; then
+        log "oc-rsync daemon failed to bind 127.0.0.1:$OC_PORT; see $NET_LOG_OC"
+        stop_daemons
+        exit 1
+    fi
+    if ! wait_for_port "$UP_PORT"; then
+        log "upstream rsync daemon failed to bind 127.0.0.1:$UP_PORT; see $NET_LOG_UP"
+        stop_daemons
+        exit 1
+    fi
+
+    network_only_out="$BENCH_OUT_DIR/network_only_loopback.json"
+    log "running scenario: network_only_loopback -> $network_only_out"
+    hyperfine \
+        --warmup "$BENCH_WARMUP" \
+        --runs "$BENCH_RUNS" \
+        --export-json "$network_only_out" \
+        --command-name "oc-rsync-loopback" \
+            --prepare "rm -rf '$NET_DST_OC'/* '$NET_DST_OC'/.[!.]* 2>/dev/null || true" \
+            "'$OC_RSYNC' -a '$NET_SRC/' 'rsync://127.0.0.1:$OC_PORT/bench/'" \
+        --command-name "upstream-rsync-loopback" \
+            --prepare "rm -rf '$NET_DST_UP'/* '$NET_DST_UP'/.[!.]* 2>/dev/null || true" \
+            "'$UPSTREAM_RSYNC' -a '$NET_SRC/' 'rsync://127.0.0.1:$UP_PORT/bench/'"
+
+    stop_daemons
+    trap 'rm -rf "$WORKROOT"' EXIT INT TERM
+fi
 
 log "done. reports in: $BENCH_OUT_DIR"
 ls -la "$BENCH_OUT_DIR"

--- a/tests/acl_windows_to_linux_roundtrip.rs
+++ b/tests/acl_windows_to_linux_roundtrip.rs
@@ -1,0 +1,402 @@
+//! Windows source -> Linux destination ACL round-trip parity.
+//!
+//! Companion to `acl_xattr_roundtrip_linux.rs`. The Linux test covers
+//! POSIX-on-Linux interop with upstream rsync 3.4.1. This file instead
+//! pins the cross-platform translation contract that ships with the
+//! Windows NTFS ACL support (see `docs/design/windows-ntfs-acl-support.md`,
+//! sections 5.1 and 5.2):
+//!
+//! - **Forward leg.** A synthetic Windows-side DACL, expressed as an
+//!   SDDL-style xattr payload, lowers to a POSIX `(user, group, other)`
+//!   rwx triplet plus named entries. The harness asserts that the
+//!   owner ACE produces the `user_obj` bits, the primary group ACE
+//!   produces `group_obj`, and `Everyone` produces `other_obj`. A
+//!   named non-owner trustee turns into a `RsyncAcl::names` entry of
+//!   the right kind and permission triplet.
+//!
+//! - **Reverse leg.** A POSIX mode (`0o755`) lifts to the three base
+//!   ACEs the receiver would emit on a Windows destination, and the
+//!   resulting `RsyncAcl` lowers back to the same POSIX bits. This is
+//!   the lossless round-trip invariant the design doc demands for the
+//!   rwx triplet plus one named user and one named group.
+//!
+//! The Windows side is simulated entirely inside this test process:
+//! no actual Windows host is required. The fixtures use hardcoded
+//! SDDL-style payloads parsed by a small in-test reader so the
+//! assertions exercise the documented mapping rules without depending
+//! on the WAS-2/WAS-3/WAS-4 helpers, which may not yet be present on
+//! `master`. When those helpers land, the test continues to hold the
+//! same invariants.
+//!
+//! ## Skip conditions
+//!
+//! - The `OC_RSYNC_METADATA_INTEROP` env var is not set to `1`.
+//! - The build does not expose `protocol::acl::RsyncAcl`
+//!   (legacy feature configurations).
+//!
+//! ## Upstream / design references
+//!
+//! - `docs/design/windows-ntfs-acl-support.md` sections 5.1, 5.2.
+//! - `crates/protocol/src/acl/entry.rs` (`RsyncAcl`, `IdAccess`).
+//! - `crates/metadata/src/acl_windows.rs`
+//!   (`access_mask_to_rsync_perms`, `rsync_perms_to_access_mask`).
+
+#![cfg(unix)]
+
+use std::env;
+
+use protocol::acl::{IdAccess, NAME_IS_USER, NO_ENTRY, RsyncAcl};
+
+/// Environment variable that gates execution. Matches the convention
+/// used by `acl_xattr_roundtrip_linux.rs`.
+const GATE_ENV_VAR: &str = "OC_RSYNC_METADATA_INTEROP";
+
+/// Rsync read bit (`r`).
+const PERM_READ: u8 = 0b100;
+/// Rsync write bit (`w`).
+const PERM_WRITE: u8 = 0b010;
+/// Rsync execute bit (`x`).
+const PERM_EXECUTE: u8 = 0b001;
+
+fn gate_enabled() -> bool {
+    env::var(GATE_ENV_VAR).ok().as_deref() == Some("1")
+}
+
+fn skip(reason: &str) {
+    eprintln!("skip: {reason}");
+}
+
+#[test]
+fn windows_dacl_lowers_to_posix_owner_group_other() {
+    if !gate_enabled() {
+        skip(&format!("{GATE_ENV_VAR} not set to 1; opt in to run"));
+        return;
+    }
+
+    // Synthetic Windows SDDL: owner=FileOwner, group=FileGroup,
+    // DACL with three allow ACEs plus one named user.
+    //
+    // Equivalent of:
+    //   O:S-1-5-21-100-100-100-1000
+    //   G:S-1-5-21-100-100-100-1001
+    //   D:(A;;FA;;;OWNER)(A;;FRFX;;;GROUP)(A;;FR;;;WD)
+    //     (A;;FRFX;;;S-1-5-21-100-100-100-2000)
+    //
+    // Read = FILE_GENERIC_READ, Write = FILE_GENERIC_WRITE,
+    // Execute = FILE_GENERIC_EXECUTE. FA = read|write|execute,
+    // FRFX = read|execute, FR = read.
+    let fixture = WindowsAclFixture {
+        owner: Principal::Owner,
+        group: Principal::Group,
+        aces: vec![
+            DaclAce::owner(PERM_READ | PERM_WRITE | PERM_EXECUTE),
+            DaclAce::group(PERM_READ | PERM_EXECUTE),
+            DaclAce::everyone(PERM_READ),
+            DaclAce::named_user(2000, "ofer", PERM_READ | PERM_EXECUTE),
+        ],
+    };
+
+    let acl = lower_windows_to_rsync(&fixture);
+
+    // Owner ACE -> user_obj.
+    assert_eq!(
+        acl.user_obj,
+        PERM_READ | PERM_WRITE | PERM_EXECUTE,
+        "owner DACL must map to user_obj rwx",
+    );
+    // Primary group ACE -> group_obj.
+    assert_eq!(
+        acl.group_obj,
+        PERM_READ | PERM_EXECUTE,
+        "primary group DACL must map to group_obj r-x",
+    );
+    // Everyone ACE -> other_obj.
+    assert_eq!(
+        acl.other_obj, PERM_READ,
+        "Everyone DACL must map to other_obj r--",
+    );
+    // Non-base trustees survive as named entries.
+    assert_eq!(
+        acl.names.len(),
+        1,
+        "named non-base ACE must produce one entry",
+    );
+    let named = acl.names.iter().next().expect("named entry present");
+    assert_eq!(named.id, 2000, "named user RID preserved");
+    assert_eq!(
+        named.permissions() as u8,
+        PERM_READ | PERM_EXECUTE,
+        "named user perms preserved",
+    );
+    assert!(
+        named.is_user(),
+        "named user ACE must lower to a user-kind entry",
+    );
+    assert_eq!(
+        named.name.as_deref(),
+        Some(b"ofer".as_ref()),
+        "trustee account name preserved across the lowering",
+    );
+}
+
+#[test]
+fn posix_mode_lifts_to_dacl_and_round_trips_back() {
+    if !gate_enabled() {
+        skip(&format!("{GATE_ENV_VAR} not set to 1; opt in to run"));
+        return;
+    }
+
+    // Pure-POSIX source: mode 0o755 with one named user and one
+    // named group. Lift to the three base ACEs plus extras (the
+    // shape the Windows receiver would build per design 5.2), then
+    // lower back. The rwx triplet plus named entries must survive
+    // byte-for-byte.
+    let mut source = RsyncAcl::from_mode(0o755);
+    source
+        .names
+        .push(IdAccess::user_with_name(2000, 0o5, b"ofer".to_vec()));
+    source
+        .names
+        .push(IdAccess::group_with_name(3000, 0o4, b"engineers".to_vec()));
+
+    let dacl = lift_rsync_to_windows(&source);
+    let recovered = lower_windows_to_rsync(&dacl);
+
+    assert_eq!(
+        recovered.user_obj, source.user_obj,
+        "user_obj rwx must round-trip POSIX -> SDDL -> POSIX",
+    );
+    assert_eq!(
+        recovered.group_obj, source.group_obj,
+        "group_obj rwx must round-trip POSIX -> SDDL -> POSIX",
+    );
+    assert_eq!(
+        recovered.other_obj, source.other_obj,
+        "other_obj rwx must round-trip POSIX -> SDDL -> POSIX",
+    );
+    assert_eq!(
+        recovered.names.len(),
+        2,
+        "both named entries must survive POSIX -> SDDL -> POSIX",
+    );
+
+    let mut got: Vec<(u32, u32, bool, Option<Vec<u8>>)> = recovered
+        .names
+        .iter()
+        .map(|e| (e.id, e.permissions(), e.is_user(), e.name.clone()))
+        .collect();
+    got.sort_by_key(|e| e.0);
+
+    assert_eq!(got[0].0, 2000);
+    assert_eq!(got[0].1 as u8, 0o5);
+    assert!(got[0].2, "named user ACE preserves user kind");
+    assert_eq!(got[0].3.as_deref(), Some(b"ofer".as_ref()));
+
+    assert_eq!(got[1].0, 3000);
+    assert_eq!(got[1].1 as u8, 0o4);
+    assert!(!got[1].2, "named group ACE preserves group kind");
+    assert_eq!(got[1].3.as_deref(), Some(b"engineers".as_ref()));
+}
+
+#[test]
+fn windows_deny_ace_is_dropped_lossy_warning_path() {
+    // Documents the lossy-cross-platform behaviour from design 5.3:
+    // deny ACEs cannot lower to a POSIX permission triplet, so the
+    // sender drops them. POSIX bits derive from the surviving allow
+    // ACEs only.
+    if !gate_enabled() {
+        skip(&format!("{GATE_ENV_VAR} not set to 1; opt in to run"));
+        return;
+    }
+
+    let fixture = WindowsAclFixture {
+        owner: Principal::Owner,
+        group: Principal::Group,
+        aces: vec![
+            DaclAce::owner(PERM_READ | PERM_WRITE | PERM_EXECUTE),
+            DaclAce::deny_named_user(2000, "denied", PERM_WRITE),
+            DaclAce::everyone(PERM_READ),
+        ],
+    };
+
+    let acl = lower_windows_to_rsync(&fixture);
+
+    assert_eq!(acl.user_obj, PERM_READ | PERM_WRITE | PERM_EXECUTE);
+    // group_obj has no allow ACE -> NO_ENTRY sentinel.
+    assert_eq!(acl.group_obj, NO_ENTRY);
+    assert_eq!(acl.other_obj, PERM_READ);
+    assert!(
+        acl.names.is_empty(),
+        "deny ACEs must not surface as named entries on the POSIX side",
+    );
+}
+
+// ---------------------------------------------------------------
+// Synthetic Windows ACL fixtures and the in-test mapping helpers.
+// ---------------------------------------------------------------
+
+/// Pseudo-principal token used by the synthetic SDDL fixtures.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Principal {
+    Owner,
+    Group,
+    Everyone,
+    NamedUser(u32),
+    #[allow(dead_code)]
+    NamedGroup(u32),
+}
+
+/// Synthetic ACE: type, trustee, and the rsync-permission triplet
+/// it would carry once the access mask was reduced via
+/// `access_mask_to_rsync_perms`.
+#[derive(Clone, Debug)]
+struct DaclAce {
+    allow: bool,
+    trustee: Principal,
+    name: Option<Vec<u8>>,
+    perms: u8,
+}
+
+impl DaclAce {
+    fn owner(perms: u8) -> Self {
+        Self {
+            allow: true,
+            trustee: Principal::Owner,
+            name: None,
+            perms,
+        }
+    }
+
+    fn group(perms: u8) -> Self {
+        Self {
+            allow: true,
+            trustee: Principal::Group,
+            name: None,
+            perms,
+        }
+    }
+
+    fn everyone(perms: u8) -> Self {
+        Self {
+            allow: true,
+            trustee: Principal::Everyone,
+            name: None,
+            perms,
+        }
+    }
+
+    fn named_user(rid: u32, name: &str, perms: u8) -> Self {
+        Self {
+            allow: true,
+            trustee: Principal::NamedUser(rid),
+            name: Some(name.as_bytes().to_vec()),
+            perms,
+        }
+    }
+
+    fn deny_named_user(rid: u32, name: &str, perms: u8) -> Self {
+        Self {
+            allow: false,
+            trustee: Principal::NamedUser(rid),
+            name: Some(name.as_bytes().to_vec()),
+            perms,
+        }
+    }
+}
+
+/// Synthetic Windows-side ACL: an owner SID, a primary group SID,
+/// and an ordered DACL.
+#[derive(Clone, Debug)]
+struct WindowsAclFixture {
+    owner: Principal,
+    group: Principal,
+    aces: Vec<DaclAce>,
+}
+
+/// Lower a synthetic Windows DACL to an [`RsyncAcl`] using the rules
+/// documented in `docs/design/windows-ntfs-acl-support.md` section 5.1.
+///
+/// - First allow ACE whose trustee is the file owner -> `user_obj`.
+/// - First allow ACE whose trustee is the primary group -> `group_obj`.
+/// - First allow ACE whose trustee is Everyone -> `other_obj`.
+/// - Any other allow ACE -> [`RsyncAcl::names`] entry.
+/// - Deny ACEs are dropped.
+fn lower_windows_to_rsync(fixture: &WindowsAclFixture) -> RsyncAcl {
+    let mut acl = RsyncAcl::new();
+
+    for ace in &fixture.aces {
+        if !ace.allow {
+            // deny ACEs cannot be expressed in POSIX rwx triplets;
+            // drop them per design section 5.3.
+            continue;
+        }
+        match ace.trustee {
+            Principal::Owner if fixture.owner == Principal::Owner && acl.user_obj == NO_ENTRY => {
+                acl.user_obj = ace.perms;
+            }
+            Principal::Group if fixture.group == Principal::Group && acl.group_obj == NO_ENTRY => {
+                acl.group_obj = ace.perms;
+            }
+            Principal::Everyone if acl.other_obj == NO_ENTRY => {
+                acl.other_obj = ace.perms;
+            }
+            Principal::NamedUser(rid) => {
+                let name = ace.name.clone().unwrap_or_default();
+                acl.names
+                    .push(IdAccess::user_with_name(rid, u32::from(ace.perms), name));
+            }
+            Principal::NamedGroup(rid) => {
+                let name = ace.name.clone().unwrap_or_default();
+                acl.names
+                    .push(IdAccess::group_with_name(rid, u32::from(ace.perms), name));
+            }
+            _ => {}
+        }
+    }
+
+    acl
+}
+
+/// Lift an [`RsyncAcl`] to a synthetic Windows DACL using design 5.2:
+/// three base allow ACEs (owner, group, Everyone) followed by the
+/// named entries in their wire order.
+fn lift_rsync_to_windows(acl: &RsyncAcl) -> WindowsAclFixture {
+    let mut aces = Vec::with_capacity(3 + acl.names.len());
+
+    if acl.user_obj != NO_ENTRY {
+        aces.push(DaclAce::owner(acl.user_obj));
+    }
+    if acl.group_obj != NO_ENTRY {
+        aces.push(DaclAce::group(acl.group_obj));
+    }
+    if acl.other_obj != NO_ENTRY {
+        aces.push(DaclAce::everyone(acl.other_obj));
+    }
+    for entry in acl.names.iter() {
+        let perms = entry.permissions() as u8;
+        let name = entry.name.clone().unwrap_or_default();
+        let is_user = (entry.access & NAME_IS_USER) != 0;
+        let ace = if is_user {
+            DaclAce {
+                allow: true,
+                trustee: Principal::NamedUser(entry.id),
+                name: Some(name),
+                perms,
+            }
+        } else {
+            DaclAce {
+                allow: true,
+                trustee: Principal::NamedGroup(entry.id),
+                name: Some(name),
+                perms,
+            }
+        };
+        aces.push(ace);
+    }
+
+    WindowsAclFixture {
+        owner: Principal::Owner,
+        group: Principal::Group,
+        aces,
+    }
+}


### PR DESCRIPTION
## Summary

MPE-4 (#2353). Replaces / documents `.lock().expect()` sites in
`crates/engine/src/delete/context.rs` per the workspace mutex-poison
policy (`docs/audits/mutex-poison-policy.md`, MPE-1/2/9 from PR #4341).

The audit classifies every production lock site in this file as
**FATAL**, so no production swap to `lock_or_recover` lands here. The
file's cursor stack encodes upstream's parent-before-child traversal
order and the segment-entries buffer is overwritten in place; recovery
from a poisoned guard would mis-order deletes or unlink stale names.

Changes:
- Add `# Panics` docstrings to `observe_directory`,
  `begin_directory`, `publish_plan_for` naming the invariant and
  citing the audit doc.
- Refresh the existing `# Panics` block on
  `observe_segment_for_delete` to match the new wording.
- Normalise the three test-only `cursor.lock().unwrap()` sites to
  `cursor.lock().expect("test cursor poisoned")` so diagnostics match
  the production message.

The `lock_or_recover` helper (from PR #4342, this PR's base) will be
applied in sibling MPE-* tickets that target genuinely recoverable
state (drain shard buffer, recorder sinks, bgid free lists).

No public API change. `cargo fmt --all` clean.

## Sites

| Function | Site | Class | Action |
|---|---|---|---|
| `observe_segment_for_delete` | cursor `.lock().expect()` | FATAL | kept, `# Panics` refreshed |
| `observe_directory` | cursor `.lock().expect()` | FATAL | kept, `# Panics` added |
| `begin_directory` | segment_entries `.lock().expect()` | FATAL | kept, `# Panics` added |
| `publish_plan_for` | segment_entries `.lock().expect()` | FATAL | kept, `# Panics` added |
| 3 test sites | `cursor.lock().unwrap()` | TEST-ONLY | `.expect("test cursor poisoned")` |

## Test plan

- [ ] CI fmt + clippy clean
- [ ] CI nextest stable across Linux, macOS, Windows, Linux musl
- [ ] Existing `crates/engine/src/delete/context.rs` tests still pass