### PR TITLE
test(fuzz): NegotiationPrologueSniffer pre-auth fuzz target (FCV-3 P0)

### DIFF
--- a/crates/protocol/fuzz/Cargo.toml
+++ b/crates/protocol/fuzz/Cargo.toml
@@ -64,5 +64,12 @@ test = false
 doc = false
 bench = false
 
+[[bin]]
+name = "negotiation_prologue"
+path = "fuzz_targets/negotiation_prologue.rs"
+test = false
+doc = false
+bench = false
+
 # Standalone workspace - not part of root workspace
 [workspace]

--- a/crates/protocol/fuzz/fuzz_targets/negotiation_prologue.rs
+++ b/crates/protocol/fuzz/fuzz_targets/negotiation_prologue.rs
@@ -1,0 +1,33 @@
+#![no_main]
+
+//! Fuzz target for `NegotiationPrologueSniffer` pre-auth byte handling.
+//!
+//! The sniffer inspects the very first bytes of every incoming connection to
+//! decide whether the peer is speaking the legacy `@RSYNCD:` ASCII greeting or
+//! the binary protocol. Because it runs before authentication, malformed input
+//! must never panic, over-allocate, or otherwise become a DoS vector.
+//!
+//! Covers the three public entry points:
+//! * `observe_byte` - single-byte feed path.
+//! * `observe` - bulk slice feed path.
+//! * `read_from` - generic `Read` source path (driven by a `Cursor`).
+
+use libfuzzer_sys::fuzz_target;
+use protocol::NegotiationPrologueSniffer;
+
+fuzz_target!(|data: &[u8]| {
+    // observe_byte path: drip bytes one at a time.
+    let mut sniffer = NegotiationPrologueSniffer::new();
+    for &b in data {
+        let _ = sniffer.observe_byte(b);
+    }
+
+    // observe path: hand the whole slice in one call.
+    let mut sniffer_bulk = NegotiationPrologueSniffer::new();
+    let _ = sniffer_bulk.observe(data);
+
+    // read_from path: feed via a `Cursor<&[u8]>` so EOF is reachable.
+    let mut cursor = std::io::Cursor::new(data);
+    let mut sniffer_reader = NegotiationPrologueSniffer::new();
+    let _ = sniffer_reader.read_from(&mut cursor);
+});


### PR DESCRIPTION
## Summary

- Adds `crates/protocol/fuzz/fuzz_targets/negotiation_prologue.rs`, exercising the three public entry points of `NegotiationPrologueSniffer`: `observe_byte`, `observe`, and `read_from`.
- Registers the new `[[bin]]` in `crates/protocol/fuzz/Cargo.toml`.
- Closes the FCV-3 P0 audit gap: the sniffer parses the very first bytes of every incoming connection, before authentication, and was previously not fuzzed.

## Why

`NegotiationPrologueSniffer` decides whether a peer is speaking the legacy `@RSYNCD:` ASCII handshake or the binary protocol. Because it runs pre-auth, any panic, unbounded allocation, or hang triggered by attacker-controlled bytes is a remote DoS. Continuous fuzzing protects all three feed paths against regressions.

## Target shape

```rust
fuzz_target!(|data: &[u8]| {
    // observe_byte path: drip bytes one at a time
    let mut s1 = NegotiationPrologueSniffer::new();
    for &b in data { let _ = s1.observe_byte(b); }

    // observe path: bulk slice feed
    let mut s2 = NegotiationPrologueSniffer::new();
    let _ = s2.observe(data);

    // read_from path: drive via Cursor<&[u8]>
    let mut cur = std::io::Cursor::new(data);
    let mut s3 = NegotiationPrologueSniffer::new();
    let _ = s3.read_from(&mut cur);
});
```

## Test plan

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings`
- [ ] `cd crates/protocol/fuzz && cargo +nightly fuzz build negotiation_prologue`
- [ ] Short local fuzz run: `cargo +nightly fuzz run negotiation_prologue -- -max_total_time=60`