### PR TITLE
docs: document ssh-socketpair-stderr feature (#2377)

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ release binary on modern Linux/macOS/Windows hosts; everything marked
 | `thread-slab-pool` | `engine` | no | Per-thread bounded LIFO slab in front of `BufferPool`; pays off above ~32 workers (#1271, #1370). | experimental |
 | `vmsplice` | `fast_io`, `transfer` | no | Linux `vmsplice(2)` + `splice(2)` zero-copy writer for large page-aligned chunks. | experimental |
 | `async-ssh` | `core`, `rsync_io` | no | Wires `AsyncSshTransport` into the client remote path; opt-in at runtime via `OC_RSYNC_ASYNC_SSH=1` (#1593, #1796, #1805, #1806). | experimental |
+| `ssh-socketpair-stderr` | `rsync_io` | no | Constructs the SSH child's stderr over a `socketpair(AF_UNIX, SOCK_STREAM)` instead of an anonymous pipe, enabling epoll/kqueue-integrated async drain (Linux recommended; Windows shim pending SSE-5). See `docs/design/socketpair-stderr-channel.md` (#2371, #2372). | experimental |
 | `async-daemon` | `daemon` | no | Hybrid tokio accept loop dispatching sync workers via `spawn_blocking` (#1935). | experimental |
 | `concurrent-sessions` | `daemon` | no | Shared `dashmap` session state for multi-session daemons. | experimental |
 | `tracing` | `core`, `engine`, `transfer`, `daemon` | no | Structured `tracing` instrumentation for diagnostics. | stable |

--- a/docs/operator-migration-guide-vNEXT.md
+++ b/docs/operator-migration-guide-vNEXT.md
@@ -117,7 +117,7 @@ is marked SUPERSEDED. The replacement is the always-on DDP model in
 
 ## 4. New opt-in feature flags
 
-vNEXT introduces five Cargo feature flags that gate new performance
+vNEXT introduces six Cargo feature flags that gate new performance
 surfaces. None are enabled by default. None change wire bytes. All can
 be combined.
 
@@ -191,6 +191,47 @@ be combined.
   Steady-state memory grows by `N_threads * byte_cap`, so do not
   enable on memory-constrained endpoints.
 - **Build.** `cargo build --release --features thread-slab-pool`.
+
+### `ssh-socketpair-stderr` (`rsync_io`, experimental)
+
+- **What it does.** Replaces the anonymous-pipe stderr channel of the
+  SSH child with a `socketpair(AF_UNIX, SOCK_STREAM, 0)` constructed
+  via `UnixStream::pair`. The parent end is a bidirectional socket that
+  can be registered with `epoll`/`kqueue` (or tokio `AsyncFd`) and woken
+  out-of-band via `shutdown(2)`, which is the seam SSE-4 uses to drive
+  the drain off a tokio task instead of a dedicated thread per
+  connection. The child still sees a plain stream of bytes on fd 2.
+  Capture semantics, line forwarding to host stderr, and the bounded
+  64 KiB ring buffer used by `stderr_output()` are unchanged.
+- **When to opt in.** Linux endpoints that already build with
+  `async-ssh` and want the SSH stderr drain integrated into the same
+  tokio reactor as the wire path, instead of consuming a per-connection
+  blocking thread; long-running fan-out clients that open many
+  concurrent SSH children where the saved drain threads matter; and
+  any deployment that wants the larger default kernel buffer
+  (~208 KiB on Linux vs 64 KiB for pipes) and `shutdown(SHUT_RD)`
+  as the wake primitive for the drain loop. macOS works too, with
+  the same `UnixStream::pair` construction.
+- **When to stay on the default.** Operators who prefer the simpler
+  pipe semantics for debugging (a pipe is unidirectional and shows up
+  as a single read-only fd in `lsof` / `procfs`); Windows endpoints,
+  where the TCP-loopback shim is still in flight under SSE-5 and
+  falls back to `Stdio::piped()` on any error; sync-only SSH
+  deployments that do not link tokio, since the existing sync
+  transport already uses the socketpair when available and gains
+  nothing from the flag. The default-off ships exactly what `master`
+  shipped before the SSE series.
+- **Build.** `cargo build --release -p rsync_io --features ssh-socketpair-stderr`.
+  Combine with `async-ssh` to actually exercise the async drain path:
+  `cargo build --release --features "async-ssh" -p core` and
+  `cargo build --release --features "ssh-socketpair-stderr" -p rsync_io`.
+- **Design reference.** Rationale, cross-platform construction, and
+  the SSE-3 through SSE-7 staging plan are in
+  [`docs/design/socketpair-stderr-channel.md`](design/socketpair-stderr-channel.md)
+  (#2371). The companion stderr-handling audit that motivated the
+  series is in
+  [`docs/audits/ssh-stderr-handling.md`](audits/ssh-stderr-handling.md)
+  (#2370).
 
 ### `vmsplice` (`fast_io`, `transfer`, Linux only)
 
@@ -367,9 +408,10 @@ targets; on macOS and Windows the platform-native build is used.
   `--delete-during` sweep. The `--delete-strict-order` opt-in flag
   from the prior prerelease becomes available again.
 - The opt-in feature flags from section 4 (`async-ssh`,
-  `async-daemon`, `parallel-receive-delta`, `thread-slab-pool`,
-  `vmsplice`) do not exist in earlier releases. Builds that enabled
-  them must drop the flag from the build command when downgrading.
+  `async-daemon`, `parallel-receive-delta`, `ssh-socketpair-stderr`,
+  `thread-slab-pool`, `vmsplice`) do not exist in earlier releases.
+  Builds that enabled them must drop the flag from the build command
+  when downgrading.
 - Wire compatibility is preserved across the rollback. A vNEXT
   client talking to a previous-version daemon (or the reverse) is a
   supported configuration; the protocol negotiation collapses to
@@ -402,6 +444,8 @@ next.
 | Daemon async runtime choice                    | `docs/design/daemon-async-runtime-choice.md`                            |
 | Daemon async accept + sync workers             | `docs/design/daemon-async-accept-sync-workers.md`                       |
 | Parallel receive-side delta application        | `docs/design/parallel-receive-delta-application.md`                     |
+| SSH stderr socketpair channel                  | `docs/design/socketpair-stderr-channel.md`                              |
+| SSH stderr handling audit                      | `docs/audits/ssh-stderr-handling.md`                                    |
 | Per-thread buffer slab                         | `docs/design/per-thread-buffer-slab.md`                                 |
 | vmsplice / splice zero copy                    | `docs/design/splice-vmsplice-zero-copy.md`                              |
 | io_uring session ring pool                     | `docs/design/iouring-session-ring-pool.md`                              |


### PR DESCRIPTION
## Summary

- Adds the experimental `ssh-socketpair-stderr` row to the README cargo features table, marked default off and Linux-recommended, with a pointer to the design doc.
- Adds a dedicated subsection in `docs/operator-migration-guide-vNEXT.md` section 4 explaining when to opt in (epoll/kqueue-integrated async drain alongside `async-ssh`, fan-out clients, larger socketpair kernel buffer, `shutdown(2)` wake) and when to leave the default (Windows pending SSE-5, sync-only SSH builds, simpler pipe semantics for debugging).
- Updates the section 4 count, the rollback list of flags that do not exist in prior releases, and the appendix table; cross-links to `docs/design/socketpair-stderr-channel.md` (#2371) and the companion stderr-handling audit `docs/audits/ssh-stderr-handling.md` (#2370).

Task SSE-8 (tracker #2377). Documents the feature flag introduced by SSE-3 (#2372).

## Test plan

- [ ] Markdown renders cleanly on GitHub (table column count preserved, links resolve).
- [ ] `cargo fmt --all -- --check` (no-op; documentation only).
- [ ] Cross-reference `docs/design/socketpair-stderr-channel.md` section 6 (feature flag definition) matches the README row.