### PR TITLE
refactor(engine): extract spill/codec.rs (SPL-3 #2325)

### DIFF
--- a/crates/engine/src/concurrent_delta/spill/codec.rs
+++ b/crates/engine/src/concurrent_delta/spill/codec.rs
@@ -1,0 +1,37 @@
+//! Serialization contract for items routed through the spill layer.
+//!
+//! The spill layer is agnostic to item shape; it only needs a deterministic
+//! byte representation plus a memory-accounting hint. Implementations live
+//! next to their data types (e.g. `DeltaResult` in
+//! `concurrent_delta/types.rs`), keeping wire-format details adjacent to
+//! the types they describe.
+
+use std::io::{self, Read, Write};
+
+/// Codec for serializing and deserializing items to the spill file.
+///
+/// Implementations must produce a deterministic byte representation and
+/// report an accurate `encoded_size` for memory accounting. The encoded
+/// format is opaque to the spill layer - only `encode` and `decode` must
+/// agree on the wire format.
+pub trait SpillCodec: Sized {
+    /// Writes the item to `writer` in a format that [`decode`](Self::decode) can read back.
+    ///
+    /// # Errors
+    ///
+    /// Returns an I/O error if writing fails.
+    fn encode(&self, writer: &mut dyn Write) -> io::Result<()>;
+
+    /// Reads an item from `reader` that was previously written by [`encode`](Self::encode).
+    ///
+    /// # Errors
+    ///
+    /// Returns an I/O error if reading fails or the data is corrupt.
+    fn decode(reader: &mut dyn Read) -> io::Result<Self>;
+
+    /// Returns the approximate in-memory size of this item in bytes.
+    ///
+    /// Used for memory accounting to decide when to spill. Does not need
+    /// to be exact - a conservative overestimate is fine.
+    fn estimated_size(&self) -> usize;
+}

--- a/crates/engine/src/concurrent_delta/spill/error.rs
+++ b/crates/engine/src/concurrent_delta/spill/error.rs
@@ -1,0 +1,82 @@
+//! Error type for the spill-to-tempfile layer.
+//!
+//! Producers should treat any [`SpillError::Io`] as fatal for the affected
+//! transfer: ENOSPC, missing spill directories, and partial writes all
+//! indicate that the disk backing the reorder buffer can no longer be
+//! trusted. The receiver maps these to exit code 11 ([`FileIo`]) so the
+//! transfer aborts with the same semantics as upstream rsync's I/O failures.
+//!
+//! [`UnsupportedCompression`](SpillError::UnsupportedCompression) is surfaced
+//! when a spill file written by a `spill-compression` build is read by a
+//! default build that has no codec available - the on-disk tag byte
+//! advertises the algorithm so we fail loudly rather than decode garbage.
+//!
+//! [`FileIo`]: https://github.com/RsyncProject/rsync/blob/master/errcode.h
+
+use std::io;
+
+use super::super::reorder::CapacityExceeded;
+
+/// Errors surfaced by the spill layer.
+#[derive(Debug)]
+pub enum SpillError {
+    /// Capacity bound from the underlying ring buffer was exceeded.
+    Capacity(CapacityExceeded),
+    /// Disk I/O failed while reading or writing spilled items.
+    Io(io::Error),
+    /// On-disk record advertises a compression algorithm this build cannot
+    /// decode. Holds the unknown tag byte for diagnostics.
+    UnsupportedCompression(u8),
+}
+
+impl SpillError {
+    /// Returns the underlying I/O error if this is an I/O failure.
+    #[must_use]
+    pub fn io_error(&self) -> Option<&io::Error> {
+        match self {
+            SpillError::Io(e) => Some(e),
+            SpillError::Capacity(_) | SpillError::UnsupportedCompression(_) => None,
+        }
+    }
+
+    /// Returns `true` if this error indicates the disk is out of space.
+    #[must_use]
+    pub fn is_out_of_space(&self) -> bool {
+        self.io_error()
+            .is_some_and(|e| e.kind() == io::ErrorKind::StorageFull)
+    }
+}
+
+impl std::fmt::Display for SpillError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SpillError::Capacity(_) => write!(f, "reorder buffer capacity exceeded"),
+            SpillError::Io(e) => write!(f, "reorder spill I/O failed: {e}"),
+            SpillError::UnsupportedCompression(tag) => write!(
+                f,
+                "reorder spill record uses compression tag 0x{tag:02x} not supported by this build"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for SpillError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            SpillError::Capacity(_) | SpillError::UnsupportedCompression(_) => None,
+            SpillError::Io(e) => Some(e),
+        }
+    }
+}
+
+impl From<CapacityExceeded> for SpillError {
+    fn from(e: CapacityExceeded) -> Self {
+        SpillError::Capacity(e)
+    }
+}
+
+impl From<io::Error> for SpillError {
+    fn from(e: io::Error) -> Self {
+        SpillError::Io(e)
+    }
+}

--- a/crates/engine/src/concurrent_delta/spill/mod.rs
+++ b/crates/engine/src/concurrent_delta/spill/mod.rs
@@ -62,7 +62,11 @@ use std::fs;
 use std::io::{self, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 
-use super::reorder::{CapacityExceeded, ReorderBuffer};
+use super::reorder::ReorderBuffer;
+
+mod error;
+
+pub use error::SpillError;
 
 /// Environment-variable overrides for [`SpillPolicy`] fields at runtime.
 pub mod env;
@@ -109,83 +113,6 @@ const SPILL_TAG_RAW: u8 = 0x00;
 /// when this tag is observed in a build without the `spill-compression`
 /// feature, instead of attempting to decode garbage.
 const SPILL_TAG_ZSTD: u8 = 0x01;
-
-/// Errors surfaced by the spill layer.
-///
-/// Producers should treat any [`SpillError::Io`] as fatal for the affected
-/// transfer: ENOSPC, missing spill directories, and partial writes all
-/// indicate that the disk backing the reorder buffer can no longer be
-/// trusted. The receiver maps these to exit code 11 ([`FileIo`]) so the
-/// transfer aborts with the same semantics as upstream rsync's I/O failures.
-///
-/// [`UnsupportedCompression`](Self::UnsupportedCompression) is surfaced when a
-/// spill file written by a `spill-compression` build is read by a default
-/// build that has no codec available - the on-disk tag byte advertises the
-/// algorithm so we fail loudly rather than decode garbage.
-///
-/// [`FileIo`]: https://github.com/RsyncProject/rsync/blob/master/errcode.h
-#[derive(Debug)]
-pub enum SpillError {
-    /// Capacity bound from the underlying ring buffer was exceeded.
-    Capacity(CapacityExceeded),
-    /// Disk I/O failed while reading or writing spilled items.
-    Io(io::Error),
-    /// On-disk record advertises a compression algorithm this build cannot
-    /// decode. Holds the unknown tag byte for diagnostics.
-    UnsupportedCompression(u8),
-}
-
-impl SpillError {
-    /// Returns the underlying I/O error if this is an I/O failure.
-    #[must_use]
-    pub fn io_error(&self) -> Option<&io::Error> {
-        match self {
-            SpillError::Io(e) => Some(e),
-            SpillError::Capacity(_) | SpillError::UnsupportedCompression(_) => None,
-        }
-    }
-
-    /// Returns `true` if this error indicates the disk is out of space.
-    #[must_use]
-    pub fn is_out_of_space(&self) -> bool {
-        self.io_error()
-            .is_some_and(|e| e.kind() == io::ErrorKind::StorageFull)
-    }
-}
-
-impl std::fmt::Display for SpillError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            SpillError::Capacity(_) => write!(f, "reorder buffer capacity exceeded"),
-            SpillError::Io(e) => write!(f, "reorder spill I/O failed: {e}"),
-            SpillError::UnsupportedCompression(tag) => write!(
-                f,
-                "reorder spill record uses compression tag 0x{tag:02x} not supported by this build"
-            ),
-        }
-    }
-}
-
-impl std::error::Error for SpillError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            SpillError::Capacity(_) | SpillError::UnsupportedCompression(_) => None,
-            SpillError::Io(e) => Some(e),
-        }
-    }
-}
-
-impl From<CapacityExceeded> for SpillError {
-    fn from(e: CapacityExceeded) -> Self {
-        SpillError::Capacity(e)
-    }
-}
-
-impl From<io::Error> for SpillError {
-    fn from(e: io::Error) -> Self {
-        SpillError::Io(e)
-    }
-}
 
 /// Codec for serializing and deserializing items to the spill file.
 ///
@@ -1015,6 +942,7 @@ fn decode_payload<T: SpillCodec>(tag: u8, payload: Vec<u8>) -> Result<T, SpillEr
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::concurrent_delta::reorder::CapacityExceeded;
 
     // Simple SpillCodec for u64 used in tests.
     impl SpillCodec for u64 {

--- a/crates/engine/src/concurrent_delta/spill/mod.rs
+++ b/crates/engine/src/concurrent_delta/spill/mod.rs
@@ -64,8 +64,10 @@ use std::path::{Path, PathBuf};
 
 use super::reorder::ReorderBuffer;
 
+mod codec;
 mod error;
 
+pub use codec::SpillCodec;
 pub use error::SpillError;
 
 /// Environment-variable overrides for [`SpillPolicy`] fields at runtime.
@@ -113,35 +115,6 @@ const SPILL_TAG_RAW: u8 = 0x00;
 /// when this tag is observed in a build without the `spill-compression`
 /// feature, instead of attempting to decode garbage.
 const SPILL_TAG_ZSTD: u8 = 0x01;
-
-/// Codec for serializing and deserializing items to the spill file.
-///
-/// Implementations must produce a deterministic byte representation and
-/// report an accurate `encoded_size` for memory accounting. The encoded
-/// format is opaque to the spill layer - only `encode` and `decode` must
-/// agree on the wire format.
-pub trait SpillCodec: Sized {
-    /// Writes the item to `writer` in a format that [`decode`](Self::decode) can read back.
-    ///
-    /// # Errors
-    ///
-    /// Returns an I/O error if writing fails.
-    fn encode(&self, writer: &mut dyn Write) -> io::Result<()>;
-
-    /// Reads an item from `reader` that was previously written by [`encode`](Self::encode).
-    ///
-    /// # Errors
-    ///
-    /// Returns an I/O error if reading fails or the data is corrupt.
-    fn decode(reader: &mut dyn Read) -> io::Result<Self>;
-
-    /// Returns the approximate in-memory size of this item in bytes.
-    ///
-    /// Used for memory accounting to decide when to spill. Does not need
-    /// to be exact - a conservative overestimate is fine.
-    fn estimated_size(&self) -> usize;
-}
-
 /// Reorder buffer with transparent spill-to-tempfile for bounded memory.
 ///
 /// Wraps a [`ReorderBuffer<T>`] and adds disk-backed overflow when the


### PR DESCRIPTION
## Summary

Second leaf-first extraction per `docs/audits/spill-rs-decomposition-plan.md`. Moves the `SpillCodec` trait out of `spill/mod.rs` into its own submodule, following the pattern established by SPL-2 (`spill/error.rs`, PR #4345).

- New file: `crates/engine/src/concurrent_delta/spill/codec.rs` (37 lines).
- `spill/mod.rs` shrinks by the trait body; adds `mod codec;` + `pub use codec::SpillCodec;`.
- No public API change. Re-export keeps `super::spill::SpillCodec` (used by the production `DeltaResult` impl in `concurrent_delta/types.rs`) resolving unchanged.
- Codec-related tests remain in `spill/mod.rs` and migrate alongside the trait under SPL-8 per the plan.

Refs: #2325, #2323. Stacked on top of #4345 (SPL-2).

## Test plan

- [x] `cargo check -p engine --all-features --tests`
- [x] `cargo fmt --all`
- [ ] CI: fmt + clippy
- [ ] CI: nextest stable
- [ ] CI: Windows / macOS / Linux musl