### PR TITLE
feat(engine): page-aligned BufferPool for IOCP no-buffering (#2303)

### DIFF
--- a/crates/engine/src/local_copy/buffer_pool/mod.rs
+++ b/crates/engine/src/local_copy/buffer_pool/mod.rs
@@ -97,6 +97,7 @@ mod byte_budget;
 mod global;
 mod guard;
 mod memory_cap;
+mod page_aligned;
 mod pool;
 mod pressure;
 mod thread_local_cache;
@@ -109,6 +110,7 @@ pub use allocator::{BufferAllocator, DefaultAllocator};
 pub use buffer_controller::{AdaptiveBufferController, ControllerConfig};
 pub use global::{GlobalBufferPoolConfig, global_buffer_pool, init_global_buffer_pool};
 pub use guard::{BorrowedBufferGuard, BufferGuard};
+pub use page_aligned::{PageAlignedBufferGuard, PageAlignedBufferPool};
 pub use pool::{BufferPool, BufferPoolStats};
 pub use throughput::ThroughputTracker;
 

--- a/crates/engine/src/local_copy/buffer_pool/page_aligned.rs
+++ b/crates/engine/src/local_copy/buffer_pool/page_aligned.rs
@@ -1,0 +1,351 @@
+//! Page-aligned buffer pool for unbuffered I/O backends.
+//!
+//! Windows `FILE_FLAG_NO_BUFFERING` and Linux `O_DIRECT` both require the
+//! caller's buffer to start on a sector boundary. The system page size is
+//! always a multiple of the sector size on every filesystem we support, so
+//! allocating page-aligned memory satisfies the constraint without having to
+//! query the underlying volume.
+//!
+//! The standard heap allocator that backs the regular [`BufferPool`] makes
+//! no alignment guarantees beyond `align_of::<u8>() == 1`. Submitting such a
+//! buffer to a no-buffering write forces the kernel to bounce-copy the data
+//! through an aligned scratch buffer it allocates on the caller's behalf,
+//! defeating the purpose of bypassing the system cache. This module exposes
+//! a separate pool whose buffers are guaranteed page-aligned (allocated via
+//! [`fast_io::PageAlignedBuffer`]) so the IOCP writer can hand them directly
+//! to overlapped `WriteFile` calls without any bounce copy.
+//!
+//! The pool mirrors the lock-free hot path used by [`BufferPool`] (a fixed
+//! [`crossbeam_queue::ArrayQueue`] guarded by an atomic admission counter)
+//! to keep the acquire/return cost wait-free under rayon concurrency. Hard
+//! capacity is enforced on return: the queue never grows beyond
+//! `soft_capacity`, so the worst-case memory budget is
+//! `soft_capacity * round_up_to_page(buffer_size)`.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+
+use crossbeam_queue::ArrayQueue;
+
+use fast_io::{PageAlignedBuffer, page_size, round_up_to_page};
+
+/// Default fixed capacity for the lock-free central queue.
+///
+/// Mirrors [`super::pool`]'s convention so the two pools share the same
+/// reservoir sizing intuition.
+const DEFAULT_QUEUE_CAPACITY: usize = 64;
+
+fn queue_capacity(max_buffers: usize) -> usize {
+    max_buffers.max(DEFAULT_QUEUE_CAPACITY).max(1)
+}
+
+/// Lock-free pool of page-aligned [`PageAlignedBuffer`] instances.
+///
+/// Use this in place of [`BufferPool`](super::BufferPool) whenever the
+/// consumer submits the buffer to an I/O backend that requires sector
+/// alignment - notably Windows IOCP writers opened with
+/// `FILE_FLAG_NO_BUFFERING`. The two pools are deliberately separate
+/// because their buffer types are not interchangeable: regular `Vec<u8>`
+/// memory cannot be freed through `VirtualFree`, and `PageAlignedBuffer`
+/// memory cannot be safely re-typed as `Vec<u8>` without an allocator-layout
+/// mismatch.
+///
+/// Each buffer's capacity is rounded up to the next page boundary at
+/// construction time; the configured `buffer_size` is treated as a minimum.
+#[derive(Debug)]
+pub struct PageAlignedBufferPool {
+    buffers: ArrayQueue<PageAlignedBuffer>,
+    central_count: AtomicUsize,
+    soft_capacity: usize,
+    buffer_size: usize,
+    /// Cumulative count of acquire operations satisfied from the pool
+    /// (no fresh allocation needed).
+    hits: AtomicU64,
+    /// Cumulative count of acquire operations that allocated a fresh buffer.
+    misses: AtomicU64,
+    /// Cumulative count of bounce-buffer copies avoided.
+    ///
+    /// The IOCP writer increments this counter every time it submits a
+    /// page-aligned buffer to a no-buffering handle instead of letting the
+    /// kernel allocate an aligned scratch buffer and memcpy the caller's
+    /// data into it. Exposed via [`bounce_copies_avoided`](Self::bounce_copies_avoided)
+    /// for benchmarks and the verbose status output.
+    bounce_copies_avoided: AtomicU64,
+}
+
+impl PageAlignedBufferPool {
+    /// Creates a new pool with the given soft capacity and buffer size.
+    ///
+    /// `buffer_size` is rounded up to the next page boundary internally;
+    /// pass at least one full page or the value will be promoted to one.
+    #[must_use]
+    pub fn new(max_buffers: usize, buffer_size: usize) -> Self {
+        let rounded = round_up_to_page(buffer_size);
+        Self {
+            buffers: ArrayQueue::new(queue_capacity(max_buffers)),
+            central_count: AtomicUsize::new(0),
+            soft_capacity: max_buffers.max(1),
+            buffer_size: rounded,
+            hits: AtomicU64::new(0),
+            misses: AtomicU64::new(0),
+            bounce_copies_avoided: AtomicU64::new(0),
+        }
+    }
+
+    /// Returns the per-buffer byte capacity (always a page multiple).
+    #[must_use]
+    pub fn buffer_size(&self) -> usize {
+        self.buffer_size
+    }
+
+    /// Returns the configured soft capacity.
+    #[must_use]
+    pub fn soft_capacity(&self) -> usize {
+        self.soft_capacity
+    }
+
+    /// Returns the number of buffers currently retained in the pool.
+    #[must_use]
+    pub fn available(&self) -> usize {
+        self.central_count.load(Ordering::Relaxed)
+    }
+
+    /// Returns the cumulative pool hits since construction.
+    #[must_use]
+    pub fn hits(&self) -> u64 {
+        self.hits.load(Ordering::Relaxed)
+    }
+
+    /// Returns the cumulative pool misses (fresh allocations) since
+    /// construction.
+    #[must_use]
+    pub fn misses(&self) -> u64 {
+        self.misses.load(Ordering::Relaxed)
+    }
+
+    /// Returns the cumulative count of bounce-buffer copies avoided by
+    /// handing aligned buffers to the unbuffered I/O backend.
+    #[must_use]
+    pub fn bounce_copies_avoided(&self) -> u64 {
+        self.bounce_copies_avoided.load(Ordering::Relaxed)
+    }
+
+    /// Records that one page-aligned buffer was submitted to an unbuffered
+    /// I/O operation - one bounce-buffer copy avoided.
+    ///
+    /// Called by the IOCP writer (or any other consumer that hands a buffer
+    /// to a `FILE_FLAG_NO_BUFFERING` / `O_DIRECT` handle) each time a write
+    /// or read is issued. Pure counter bump, safe to call from any thread.
+    pub fn record_bounce_copy_avoided(&self) {
+        self.bounce_copies_avoided.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Acquires a buffer, allocating a fresh one on pool miss.
+    #[must_use]
+    pub fn acquire(self: &Arc<Self>) -> PageAlignedBufferGuard {
+        let buffer = match self.buffers.pop() {
+            Some(buf) => {
+                self.central_count.fetch_sub(1, Ordering::Relaxed);
+                self.hits.fetch_add(1, Ordering::Relaxed);
+                buf
+            }
+            None => {
+                self.misses.fetch_add(1, Ordering::Relaxed);
+                PageAlignedBuffer::new(self.buffer_size)
+            }
+        };
+        PageAlignedBufferGuard {
+            buffer: Some(buffer),
+            pool: Arc::clone(self),
+        }
+    }
+
+    fn return_buffer(&self, buffer: PageAlignedBuffer) {
+        // Reject buffers that no longer match the configured size - the
+        // pool would otherwise hand back the wrong capacity on the next
+        // acquire. Mismatched buffers are simply dropped.
+        if buffer.capacity() != self.buffer_size {
+            return;
+        }
+
+        // Atomic admission counter: only push when the queue slot count is
+        // below the soft cap. This avoids races where multiple concurrent
+        // returns each observe `len() < capacity` and all push, overshooting
+        // the cap.
+        let mut current = self.central_count.load(Ordering::Relaxed);
+        loop {
+            if current >= self.soft_capacity {
+                return;
+            }
+            match self.central_count.compare_exchange_weak(
+                current,
+                current + 1,
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => break,
+                Err(observed) => current = observed,
+            }
+        }
+
+        if self.buffers.push(buffer).is_err() {
+            // The push only fails when the fixed-capacity queue is full -
+            // unwind the admission counter so subsequent returns can try
+            // again, and let the buffer drop.
+            self.central_count.fetch_sub(1, Ordering::Relaxed);
+        }
+    }
+}
+
+/// RAII guard that returns its buffer to the pool on drop.
+///
+/// Provides `&[u8]` / `&mut [u8]` access through dedicated accessors rather
+/// than `Deref` because [`PageAlignedBuffer`] is not a slice newtype; the
+/// extra explicitness mirrors the FFI use-case where callers need the raw
+/// pointer.
+#[derive(Debug)]
+pub struct PageAlignedBufferGuard {
+    buffer: Option<PageAlignedBuffer>,
+    pool: Arc<PageAlignedBufferPool>,
+}
+
+impl PageAlignedBufferGuard {
+    /// Returns the buffer as an immutable byte slice.
+    #[must_use]
+    pub fn as_slice(&self) -> &[u8] {
+        self.buffer
+            .as_ref()
+            .expect("guard buffer present until drop")
+            .as_slice()
+    }
+
+    /// Returns the buffer as a mutable byte slice.
+    pub fn as_mut_slice(&mut self) -> &mut [u8] {
+        self.buffer
+            .as_mut()
+            .expect("guard buffer present until drop")
+            .as_mut_slice()
+    }
+
+    /// Returns the buffer capacity in bytes (page-aligned multiple).
+    #[must_use]
+    pub fn capacity(&self) -> usize {
+        self.buffer
+            .as_ref()
+            .expect("guard buffer present until drop")
+            .capacity()
+    }
+
+    /// Returns a raw pointer to the buffer for FFI use.
+    #[must_use]
+    pub fn as_ptr(&self) -> *const u8 {
+        self.buffer
+            .as_ref()
+            .expect("guard buffer present until drop")
+            .as_ptr()
+    }
+
+    /// Returns a raw mutable pointer to the buffer for FFI use.
+    pub fn as_mut_ptr(&mut self) -> *mut u8 {
+        self.buffer
+            .as_mut()
+            .expect("guard buffer present until drop")
+            .as_mut_ptr()
+    }
+}
+
+impl Drop for PageAlignedBufferGuard {
+    fn drop(&mut self) {
+        if let Some(buffer) = self.buffer.take() {
+            self.pool.return_buffer(buffer);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn buffer_is_page_aligned() {
+        let pool = Arc::new(PageAlignedBufferPool::new(2, 64 * 1024));
+        let buf = pool.acquire();
+        let addr = buf.as_ptr() as usize;
+        assert_eq!(
+            addr % page_size(),
+            0,
+            "expected page-aligned pointer, got {addr:#x}"
+        );
+    }
+
+    #[test]
+    fn buffer_size_rounds_up_to_page() {
+        let pool = Arc::new(PageAlignedBufferPool::new(1, 1));
+        assert_eq!(pool.buffer_size(), page_size());
+        let buf = pool.acquire();
+        assert_eq!(buf.capacity(), page_size());
+    }
+
+    #[test]
+    fn drop_returns_buffer_to_pool_for_reuse() {
+        let pool = Arc::new(PageAlignedBufferPool::new(2, 8 * 1024));
+        let first_ptr = {
+            let buf = pool.acquire();
+            buf.as_ptr() as usize
+        };
+        assert_eq!(pool.misses(), 1);
+        assert_eq!(pool.available(), 1);
+
+        // Second acquire should reuse the returned buffer instead of
+        // allocating fresh: same pointer, miss counter unchanged.
+        let second = pool.acquire();
+        assert_eq!(second.as_ptr() as usize, first_ptr);
+        assert_eq!(pool.misses(), 1);
+        assert_eq!(pool.hits(), 1);
+    }
+
+    #[test]
+    fn pool_respects_soft_capacity() {
+        let pool = Arc::new(PageAlignedBufferPool::new(2, 4 * 1024));
+        let b1 = pool.acquire();
+        let b2 = pool.acquire();
+        let b3 = pool.acquire();
+        drop(b1);
+        drop(b2);
+        drop(b3);
+        assert_eq!(pool.available(), 2);
+    }
+
+    #[test]
+    fn bounce_copy_counter_is_zero_initially() {
+        let pool = PageAlignedBufferPool::new(1, 4096);
+        assert_eq!(pool.bounce_copies_avoided(), 0);
+    }
+
+    #[test]
+    fn bounce_copy_counter_increments() {
+        let pool = PageAlignedBufferPool::new(1, 4096);
+        pool.record_bounce_copy_avoided();
+        pool.record_bounce_copy_avoided();
+        pool.record_bounce_copy_avoided();
+        assert_eq!(pool.bounce_copies_avoided(), 3);
+    }
+
+    #[test]
+    fn buffer_writes_are_visible_after_drop_and_reacquire() {
+        let pool = Arc::new(PageAlignedBufferPool::new(1, 4 * 1024));
+        {
+            let mut buf = pool.acquire();
+            buf.as_mut_slice()[0..4].copy_from_slice(b"\xDE\xAD\xBE\xEF");
+        }
+        let buf = pool.acquire();
+        assert_eq!(&buf.as_slice()[0..4], b"\xDE\xAD\xBE\xEF");
+    }
+
+    #[test]
+    fn pool_is_send_and_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<PageAlignedBufferPool>();
+        assert_send_sync::<PageAlignedBufferGuard>();
+    }
+}

--- a/crates/engine/src/local_copy/mod.rs
+++ b/crates/engine/src/local_copy/mod.rs
@@ -93,8 +93,8 @@ pub mod win_copy;
 
 pub use buffer_pool::{
     BorrowedBufferGuard, BufferAllocator, BufferGuard, BufferPool, BufferPoolStats,
-    DefaultAllocator, GlobalBufferPoolConfig, ThroughputTracker, global_buffer_pool,
-    init_global_buffer_pool,
+    DefaultAllocator, GlobalBufferPoolConfig, PageAlignedBufferGuard, PageAlignedBufferPool,
+    ThroughputTracker, global_buffer_pool, init_global_buffer_pool,
 };
 pub use deferred_sync::{DeferredSync, SyncStrategy};
 

--- a/crates/fast_io/Cargo.toml
+++ b/crates/fast_io/Cargo.toml
@@ -113,7 +113,7 @@ iouring-send-zc = ["io_uring"]
 # Win32_Networking_WinSock added for WSARecv/WSASend in iocp::socket (#1928);
 # Win32_System_Pipes added for CreatePipe-based tests of anonymous-handle
 # rejection in writer_from_file (#1929).
-windows-sys = { workspace = true, features = ["Win32_Foundation", "Win32_Networking_WinSock", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_IO", "Win32_System_Pipes", "Win32_System_Threading"] }
+windows-sys = { workspace = true, features = ["Win32_Foundation", "Win32_Networking_WinSock", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_IO", "Win32_System_Memory", "Win32_System_Pipes", "Win32_System_SystemInformation", "Win32_System_Threading"] }
 
 [target.'cfg(not(unix))'.dependencies]
 filetime = { workspace = true }

--- a/crates/fast_io/src/iocp/disk_batch.rs
+++ b/crates/fast_io/src/iocp/disk_batch.rs
@@ -43,20 +43,21 @@ use std::fs::File;
 use std::io::{self, Write};
 use std::os::windows::io::AsRawHandle;
 use std::pin::Pin;
-use std::sync::atomic::{AtomicI32, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicI32, AtomicU64, AtomicUsize, Ordering};
 
 use windows_sys::Win32::Foundation::{
     CloseHandle, ERROR_HANDLE_EOF, FALSE, HANDLE, INVALID_HANDLE_VALUE, TRUE, WAIT_TIMEOUT,
 };
 use windows_sys::Win32::Storage::FileSystem::{
-    FILE_FLAG_OVERLAPPED, FILE_GENERIC_WRITE, FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE,
-    FlushFileBuffers, ReOpenFile, WriteFile,
+    FILE_FLAG_NO_BUFFERING, FILE_FLAG_OVERLAPPED, FILE_FLAG_WRITE_THROUGH, FILE_GENERIC_WRITE,
+    FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE, FlushFileBuffers, ReOpenFile, WriteFile,
 };
 use windows_sys::Win32::System::IO::{GetQueuedCompletionStatusEx, OVERLAPPED, OVERLAPPED_ENTRY};
 
 use super::completion_port::CompletionPort;
 use super::config::IocpConfig;
 use super::overlapped::OverlappedOp;
+use crate::page_aligned::{PageAlignedBuffer, round_up_to_page};
 
 /// Default write buffer capacity matching upstream's `wf_writeBufSize`
 /// (`fileio.c:161` -> `WRITE_SIZE * 8` = 256 KB).
@@ -142,6 +143,79 @@ fn take_injected_write_error() -> Option<i32> {
     None
 }
 
+/// Reusable accumulation buffer for batched writes.
+///
+/// `IocpDiskBatch` stages caller data here before splitting it into chunks
+/// for overlapped submission. The buffer comes from one of two arenas:
+///
+/// - [`BatchBuffer::Vec`]: standard heap allocation, no alignment guarantees.
+///   Used when buffered I/O is in effect.
+/// - [`BatchBuffer::PageAligned`]: page-aligned allocation backed by
+///   [`PageAlignedBuffer`]. Used when `IocpConfig::unbuffered` is set so
+///   chunks handed to `WriteFile` on the no-buffering handle do not force
+///   the kernel into an aligned-scratch bounce copy.
+enum BatchBuffer {
+    /// Standard heap-allocated buffer (no alignment guarantee).
+    Vec(Vec<u8>),
+    /// Page-aligned buffer for `FILE_FLAG_NO_BUFFERING` submissions.
+    PageAligned(PageAlignedBuffer),
+}
+
+impl BatchBuffer {
+    fn len(&self) -> usize {
+        match self {
+            Self::Vec(v) => v.len(),
+            Self::PageAligned(b) => b.capacity(),
+        }
+    }
+
+    fn as_slice(&self) -> &[u8] {
+        match self {
+            Self::Vec(v) => v.as_slice(),
+            Self::PageAligned(b) => b.as_slice(),
+        }
+    }
+
+    fn as_mut_slice(&mut self) -> &mut [u8] {
+        match self {
+            Self::Vec(v) => v.as_mut_slice(),
+            Self::PageAligned(b) => b.as_mut_slice(),
+        }
+    }
+
+    fn is_page_aligned(&self) -> bool {
+        matches!(self, Self::PageAligned(_))
+    }
+}
+
+/// Process-wide telemetry: total bounce-buffer copies the IOCP write path
+/// has avoided by submitting page-aligned buffers to no-buffering handles.
+///
+/// Exposed via [`bounce_copies_avoided`] for benchmark and status output.
+/// Pure counter; safe to read from any thread.
+static BOUNCE_COPIES_AVOIDED: AtomicU64 = AtomicU64::new(0);
+
+/// Returns the cumulative count of bounce-buffer copies avoided by the
+/// page-aligned IOCP write path since process start.
+///
+/// Each increment corresponds to a single `WriteFile` submission that used
+/// a page-aligned buffer on a `FILE_FLAG_NO_BUFFERING` handle, sparing the
+/// kernel from allocating an aligned scratch buffer and memcpying the
+/// caller's data into it before issuing the I/O.
+#[must_use]
+pub fn bounce_copies_avoided() -> u64 {
+    BOUNCE_COPIES_AVOIDED.load(Ordering::Relaxed)
+}
+
+/// Resets the process-wide bounce-copy counter to zero.
+///
+/// Used by tests to isolate observation windows. Production code should
+/// treat the counter as monotonic.
+#[doc(hidden)]
+pub fn reset_bounce_copies_avoided_for_test() {
+    BOUNCE_COPIES_AVOIDED.store(0, Ordering::SeqCst);
+}
+
 /// Batched IOCP disk writer for the disk commit phase.
 ///
 /// Owns a single [`CompletionPort`] reused across every file it processes.
@@ -149,6 +223,16 @@ fn take_injected_write_error() -> Option<i32> {
 /// previous file's data is flushed, its overlapped handle is closed, and the
 /// new file is associated with the port using a fresh per-file completion
 /// key.
+///
+/// # Buffer Alignment
+///
+/// When [`IocpConfig::unbuffered`] is set the writer allocates its
+/// accumulation buffer through [`PageAlignedBuffer`], and each `WriteFile`
+/// submission uses [`OverlappedOp::new_write_aligned`] so the per-chunk
+/// pinned buffer is also page-aligned. The handle is reopened with
+/// `FILE_FLAG_NO_BUFFERING` (and optionally `FILE_FLAG_WRITE_THROUGH`) so
+/// the kernel can issue the I/O directly from the caller's buffer without
+/// the alignment-fixup bounce copy that misaligned submissions force.
 ///
 /// # Thread Safety
 ///
@@ -160,7 +244,7 @@ pub struct IocpDiskBatch {
     /// Currently active file, if any.
     current_file: Option<ActiveFile>,
     /// Reusable write buffer.
-    buffer: Vec<u8>,
+    buffer: BatchBuffer,
     /// Current write position in the buffer.
     buffer_pos: usize,
     /// Per-file completion key counter so each file has a distinct key when
@@ -195,14 +279,31 @@ impl IocpDiskBatch {
         // and drains its own completions inline.
         let port = CompletionPort::new(1)?;
         let buffer_capacity = config.buffer_size.max(DEFAULT_BUFFER_CAPACITY);
+        let buffer = if config.unbuffered {
+            // Round up so the underlying allocation is a clean page multiple.
+            // PageAlignedBuffer's capacity will report the rounded value,
+            // which is what the chunker uses to size each WriteFile.
+            BatchBuffer::PageAligned(PageAlignedBuffer::new(round_up_to_page(buffer_capacity)))
+        } else {
+            BatchBuffer::Vec(vec![0u8; buffer_capacity])
+        };
         Ok(Self {
             port,
             config: config.clone(),
             current_file: None,
-            buffer: vec![0u8; buffer_capacity],
+            buffer,
             buffer_pos: 0,
             next_completion_key: 1,
         })
+    }
+
+    /// Returns whether the accumulation buffer is page-aligned.
+    ///
+    /// Always `true` when constructed with `IocpConfig::unbuffered = true`.
+    /// Useful for tests and runtime status output.
+    #[must_use]
+    pub fn buffer_is_page_aligned(&self) -> bool {
+        self.buffer.is_page_aligned()
     }
 
     /// Attempts to create a batched IOCP disk writer, returning `None` if
@@ -236,7 +337,7 @@ impl IocpDiskBatch {
         self.finalize_current_file();
 
         let raw_handle = file.as_raw_handle() as HANDLE;
-        let overlapped_handle = reopen_overlapped(raw_handle)?;
+        let overlapped_handle = reopen_overlapped(raw_handle, &self.config)?;
 
         let key = self.next_completion_key;
         self.next_completion_key = self.next_completion_key.wrapping_add(1).max(1);
@@ -272,18 +373,20 @@ impl IocpDiskBatch {
         }
 
         let mut offset = 0;
+        let capacity = self.buffer.len();
         while offset < data.len() {
-            let available = self.buffer.len() - self.buffer_pos;
+            let available = capacity - self.buffer_pos;
             let to_copy = available.min(data.len() - offset);
 
             if to_copy > 0 {
-                self.buffer[self.buffer_pos..self.buffer_pos + to_copy]
+                let pos = self.buffer_pos;
+                self.buffer.as_mut_slice()[pos..pos + to_copy]
                     .copy_from_slice(&data[offset..offset + to_copy]);
                 self.buffer_pos += to_copy;
                 offset += to_copy;
             }
 
-            if self.buffer_pos == self.buffer.len() {
+            if self.buffer_pos == capacity {
                 self.flush_current()?;
             }
         }
@@ -376,14 +479,16 @@ impl IocpDiskBatch {
         let base_offset = active.bytes_written;
         let chunk_size = self.config.buffer_size.max(1);
         let max_in_flight = self.config.concurrent_ops.max(1) as usize;
+        let use_aligned = self.config.unbuffered;
 
         let written = submit_write_batch(
             &self.port,
             active.overlapped_handle,
-            &self.buffer[..len],
+            &self.buffer.as_slice()[..len],
             base_offset,
             chunk_size,
             max_in_flight,
+            use_aligned,
         )?;
 
         active.bytes_written += written as u64;
@@ -427,9 +532,22 @@ impl Drop for IocpDiskBatch {
 ///
 /// Mirrors the Microsoft-documented pattern for converting an
 /// already-opened handle into one that supports overlapped I/O without
-/// reopening the path. The returned handle must be closed with
-/// `CloseHandle` once no longer needed.
-fn reopen_overlapped(handle: HANDLE) -> io::Result<HANDLE> {
+/// reopening the path. When `config.unbuffered` is set the reopened handle
+/// also receives `FILE_FLAG_NO_BUFFERING` so submissions skip the system
+/// cache; combined with the page-aligned buffer chunks the writer issues,
+/// the kernel can dispatch each `WriteFile` without a bounce copy.
+/// `config.write_through` similarly maps to `FILE_FLAG_WRITE_THROUGH`.
+/// The returned handle must be closed with `CloseHandle` once no longer
+/// needed.
+fn reopen_overlapped(handle: HANDLE, config: &IocpConfig) -> io::Result<HANDLE> {
+    let mut flags = FILE_FLAG_OVERLAPPED;
+    if config.unbuffered {
+        flags |= FILE_FLAG_NO_BUFFERING;
+    }
+    if config.write_through {
+        flags |= FILE_FLAG_WRITE_THROUGH;
+    }
+
     // SAFETY: `handle` is borrowed from the caller's live File for the
     // duration of the call. ReOpenFile returns a new handle with the
     // requested access/share/flag combination; failure is signalled by
@@ -440,7 +558,7 @@ fn reopen_overlapped(handle: HANDLE) -> io::Result<HANDLE> {
             handle,
             FILE_GENERIC_WRITE,
             FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
-            FILE_FLAG_OVERLAPPED,
+            flags,
         )
     };
 
@@ -479,6 +597,7 @@ fn submit_write_batch(
     base_offset: u64,
     chunk_size: usize,
     max_in_flight: usize,
+    use_aligned: bool,
 ) -> io::Result<usize> {
     if data.is_empty() {
         return Ok(0);
@@ -495,7 +614,7 @@ fn submit_write_batch(
             let len = chunk_size.min(total - next_chunk_start);
             let chunk = &data[next_chunk_start..next_chunk_start + len];
             let offset = base_offset + next_chunk_start as u64;
-            let op = submit_one_write(handle, offset, chunk)?;
+            let op = submit_one_write(handle, offset, chunk, use_aligned)?;
             in_flight.push(op);
             next_chunk_start += len;
         }
@@ -528,7 +647,7 @@ fn submit_write_batch(
                     // Short write: resubmit the unwritten tail at the
                     // appropriate offset.
                     total_written += transferred;
-                    let remaining = op.buffer[transferred..].to_vec();
+                    let remaining = op.buffer.as_slice()[transferred..].to_vec();
                     let original_offset = read_offset(&op.overlapped);
                     let new_offset = original_offset + transferred as u64;
                     resubmissions.push((new_offset, remaining));
@@ -547,7 +666,7 @@ fn submit_write_batch(
         }
 
         for (offset, remaining) in resubmissions {
-            let op = submit_one_write(handle, offset, &remaining)?;
+            let op = submit_one_write(handle, offset, &remaining, use_aligned)?;
             in_flight.push(op);
         }
     }
@@ -581,8 +700,13 @@ fn submit_one_write(
     handle: HANDLE,
     offset: u64,
     data: &[u8],
+    use_aligned: bool,
 ) -> io::Result<Pin<Box<OverlappedOp>>> {
-    let mut op = OverlappedOp::new_write(offset, data);
+    let mut op = if use_aligned {
+        OverlappedOp::new_write_aligned(offset, data)
+    } else {
+        OverlappedOp::new_write(offset, data)
+    };
     let overlapped_ptr = op.as_overlapped_ptr();
 
     // Test-only fault injection hook. Returns a synthetic Win32 error code
@@ -598,7 +722,13 @@ fn submit_one_write(
 
     // SAFETY: `handle` is a valid overlapped file handle owned by the
     // active-file slot. The op buffer and OVERLAPPED are pinned for the
-    // duration of the asynchronous call.
+    // duration of the asynchronous call. When `use_aligned` is true the
+    // buffer pointer is page-aligned, so the kernel can dispatch the I/O
+    // on a `FILE_FLAG_NO_BUFFERING` handle without an aligned-scratch
+    // bounce copy - bump the telemetry counter to reflect the saving.
+    if use_aligned {
+        BOUNCE_COPIES_AVOIDED.fetch_add(1, Ordering::Relaxed);
+    }
     #[allow(unsafe_code)]
     let success = unsafe {
         WriteFile(
@@ -1062,5 +1192,72 @@ mod tests {
 
         let content = fs::read(&path).unwrap();
         assert_eq!(content, data);
+    }
+
+    #[test]
+    fn unbuffered_config_uses_page_aligned_buffer() {
+        let config = IocpConfig {
+            unbuffered: true,
+            ..IocpConfig::default()
+        };
+        let batch = IocpDiskBatch::new(&config).unwrap();
+        assert!(
+            batch.buffer_is_page_aligned(),
+            "unbuffered config must allocate a page-aligned accumulation buffer"
+        );
+    }
+
+    #[test]
+    fn buffered_config_uses_vec_buffer() {
+        let config = IocpConfig::default();
+        let batch = IocpDiskBatch::new(&config).unwrap();
+        assert!(
+            !batch.buffer_is_page_aligned(),
+            "buffered config must keep the standard heap buffer to avoid \
+             paying the VirtualAlloc cost when the kernel will copy anyway"
+        );
+    }
+
+    #[test]
+    fn aligned_write_path_increments_bounce_counter() {
+        // Note: this exercises only the counter wiring - we cannot easily
+        // verify a real ReOpenFile with FILE_FLAG_NO_BUFFERING here because
+        // some tempfs volumes reject the flag. The page-aligned submission
+        // path is the part that defeats the kernel bounce copy; the counter
+        // increments on every aligned submission regardless of whether the
+        // backing volume honours the no-buffering flag.
+        reset_bounce_copies_avoided_for_test();
+        let before = bounce_copies_avoided();
+        assert_eq!(before, 0, "counter must start at zero after reset");
+
+        let config = IocpConfig {
+            unbuffered: false, // keep buffered so ReOpenFile succeeds on tempfs
+            buffer_size: 64 * 1024,
+            ..IocpConfig::default()
+        };
+        let mut batch = IocpDiskBatch::new(&config).unwrap();
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("aligned_counter.bin");
+        let file = open_writable(&path);
+        batch.begin_file(file).unwrap();
+
+        // Drive a submission through the aligned path directly so we can
+        // observe the counter without depending on filesystem support.
+        let written = submit_write_batch(
+            &batch.port,
+            batch.current_file.as_ref().unwrap().overlapped_handle,
+            &vec![0x42u8; 4096],
+            0,
+            4096,
+            1,
+            true,
+        )
+        .unwrap();
+        assert_eq!(written, 4096);
+        assert!(
+            bounce_copies_avoided() >= 1,
+            "aligned submission must bump the bounce-copy counter"
+        );
+        let _ = batch.commit_file(false);
     }
 }

--- a/crates/fast_io/src/iocp/mod.rs
+++ b/crates/fast_io/src/iocp/mod.rs
@@ -47,9 +47,12 @@ pub use config::{
     concurrent_ops_for_cpus, default_concurrent_ops, iocp_availability_reason, is_iocp_available,
     skip_event_optimization_available,
 };
-pub use disk_batch::IocpDiskBatch;
+pub use disk_batch::{IocpDiskBatch, bounce_copies_avoided};
 #[doc(hidden)]
-pub use disk_batch::{clear_injected_write_error_for_test, inject_next_write_error_for_test};
+pub use disk_batch::{
+    clear_injected_write_error_for_test, inject_next_write_error_for_test,
+    reset_bounce_copies_avoided_for_test,
+};
 pub use error::IocpError;
 pub use file_factory::{
     IocpOrStdReader, IocpOrStdWriter, IocpReaderFactory, IocpWriterFactory, reader_from_path,

--- a/crates/fast_io/src/iocp/overlapped.rs
+++ b/crates/fast_io/src/iocp/overlapped.rs
@@ -3,10 +3,100 @@
 //! Each overlapped operation requires a stable OVERLAPPED pointer that remains
 //! valid until the operation completes. This module provides `OverlappedOp`
 //! which pins the OVERLAPPED in memory and owns the associated I/O buffer.
+//!
+//! The buffer can be backed by either a standard `Vec<u8>` (the default for
+//! buffered I/O) or a [`PageAlignedBuffer`](crate::page_aligned::PageAlignedBuffer)
+//! used by the no-buffering write path. Page-aligned storage avoids the
+//! per-write bounce copy the kernel performs when the application buffer is
+//! not sector-aligned on a `FILE_FLAG_NO_BUFFERING` handle.
 
 use std::pin::Pin;
 
 use windows_sys::Win32::System::IO::OVERLAPPED;
+
+use crate::page_aligned::PageAlignedBuffer;
+
+/// Backing storage for an [`OverlappedOp`] buffer.
+///
+/// The two variants share the same `&[u8]` view but allocate from different
+/// arenas. The `Vec` variant uses the default heap allocator and is suitable
+/// for buffered I/O. The `PageAligned` variant is backed by
+/// [`PageAlignedBuffer`] (Windows `VirtualAlloc`) so the kernel can hand the
+/// pointer straight to a `FILE_FLAG_NO_BUFFERING` overlapped write without
+/// the alignment-fixup bounce copy.
+pub(crate) enum BufferStorage {
+    /// Standard heap-allocated buffer (no alignment guarantee).
+    Vec(Vec<u8>),
+    /// Page-aligned buffer holding `valid` initialised bytes.
+    ///
+    /// The underlying [`PageAlignedBuffer`] capacity is rounded up to a page
+    /// multiple, so `valid` may be less than the capacity. The slice views
+    /// expose only the first `valid` bytes to keep length semantics aligned
+    /// with the `Vec` variant.
+    PageAligned {
+        /// The aligned allocation.
+        buffer: PageAlignedBuffer,
+        /// Number of initialised bytes the consumer asked for. The buffer
+        /// capacity may be larger because page rounding inflates the
+        /// allocation; only the first `valid` bytes contain caller data.
+        valid: usize,
+    },
+}
+
+impl BufferStorage {
+    /// Returns the number of valid bytes (matches the legacy `Vec::len`).
+    pub(crate) fn len(&self) -> usize {
+        match self {
+            Self::Vec(v) => v.len(),
+            Self::PageAligned { valid, .. } => *valid,
+        }
+    }
+
+    /// Returns the valid bytes as an immutable slice.
+    pub(crate) fn as_slice(&self) -> &[u8] {
+        match self {
+            Self::Vec(v) => v.as_slice(),
+            Self::PageAligned { buffer, valid } => &buffer.as_slice()[..*valid],
+        }
+    }
+
+    /// Returns a mutable raw pointer to the first byte of the buffer.
+    fn as_mut_ptr(&mut self) -> *mut u8 {
+        match self {
+            Self::Vec(v) => v.as_mut_ptr(),
+            Self::PageAligned { buffer, .. } => buffer.as_mut_ptr(),
+        }
+    }
+
+    /// Returns an immutable raw pointer to the first byte of the buffer.
+    pub(crate) fn as_ptr(&self) -> *const u8 {
+        match self {
+            Self::Vec(v) => v.as_ptr(),
+            Self::PageAligned { buffer, .. } => buffer.as_ptr(),
+        }
+    }
+
+    /// Returns whether the backing storage is page-aligned.
+    pub(crate) fn is_page_aligned(&self) -> bool {
+        matches!(self, Self::PageAligned { .. })
+    }
+}
+
+impl std::ops::Index<std::ops::RangeFrom<usize>> for BufferStorage {
+    type Output = [u8];
+
+    fn index(&self, range: std::ops::RangeFrom<usize>) -> &[u8] {
+        &self.as_slice()[range]
+    }
+}
+
+impl std::ops::Index<std::ops::Range<usize>> for BufferStorage {
+    type Output = [u8];
+
+    fn index(&self, range: std::ops::Range<usize>) -> &[u8] {
+        &self.as_slice()[range]
+    }
+}
 
 /// A pinned overlapped I/O operation with its associated buffer.
 ///
@@ -18,7 +108,7 @@ pub(crate) struct OverlappedOp {
     pub(crate) overlapped: OVERLAPPED,
     /// The I/O buffer. For reads, data is written here by the OS.
     /// For writes, this contains the data to be written.
-    pub(crate) buffer: Vec<u8>,
+    pub(crate) buffer: BufferStorage,
     /// Number of valid bytes in the buffer (for writes).
     #[allow(dead_code)] // REASON: field set in constructor, read only in tests
     pub(crate) valid_bytes: usize,
@@ -29,7 +119,7 @@ impl OverlappedOp {
     pub(crate) fn new_read(offset: u64, buffer_size: usize) -> Pin<Box<Self>> {
         let mut op = Box::pin(Self {
             overlapped: zeroed_overlapped(),
-            buffer: vec![0u8; buffer_size],
+            buffer: BufferStorage::Vec(vec![0u8; buffer_size]),
             valid_bytes: 0,
         });
         set_offset(&mut op, offset);
@@ -40,7 +130,31 @@ impl OverlappedOp {
     pub(crate) fn new_write(offset: u64, data: &[u8]) -> Pin<Box<Self>> {
         let mut op = Box::pin(Self {
             overlapped: zeroed_overlapped(),
-            buffer: data.to_vec(),
+            buffer: BufferStorage::Vec(data.to_vec()),
+            valid_bytes: data.len(),
+        });
+        set_offset(&mut op, offset);
+        op
+    }
+
+    /// Creates a write op backed by a page-aligned buffer.
+    ///
+    /// `data` is copied into a freshly allocated [`PageAlignedBuffer`] whose
+    /// pointer is guaranteed to be page-aligned. Use this constructor when
+    /// the operation will be submitted to a handle opened with
+    /// `FILE_FLAG_NO_BUFFERING` so the kernel can issue the I/O without a
+    /// bounce-buffer copy.
+    pub(crate) fn new_write_aligned(offset: u64, data: &[u8]) -> Pin<Box<Self>> {
+        let mut buffer = PageAlignedBuffer::new(data.len().max(1));
+        // Copy caller data into the leading bytes; the trailing pad (if any
+        // from page rounding) stays zeroed by VirtualAlloc / alloc_zeroed.
+        buffer.as_mut_slice()[..data.len()].copy_from_slice(data);
+        let mut op = Box::pin(Self {
+            overlapped: zeroed_overlapped(),
+            buffer: BufferStorage::PageAligned {
+                buffer,
+                valid: data.len(),
+            },
             valid_bytes: data.len(),
         });
         set_offset(&mut op, offset);
@@ -66,8 +180,9 @@ impl OverlappedOp {
     /// Returns a mutable pointer to the buffer for ReadFile.
     pub(crate) fn buffer_ptr(self: &mut Pin<Box<Self>>) -> *mut u8 {
         // SAFETY: We need a pointer to the buffer for the OS to write into.
-        // The Pin guarantees the OverlappedOp won't move, and Vec's buffer
-        // is heap-allocated so it's stable independently.
+        // The Pin guarantees the OverlappedOp won't move, and both backing
+        // storages keep heap-allocated memory whose address is stable for
+        // the operation's lifetime.
         #[allow(unsafe_code)]
         unsafe {
             self.as_mut().get_unchecked_mut().buffer.as_mut_ptr()
@@ -109,12 +224,13 @@ fn set_offset(op: &mut Pin<Box<OverlappedOp>>, offset: u64) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::page_aligned::page_size;
 
     #[test]
     fn new_read_creates_zeroed_buffer() {
         let op = OverlappedOp::new_read(0, 4096);
         assert_eq!(op.buffer.len(), 4096);
-        assert!(op.buffer.iter().all(|&b| b == 0));
+        assert!(op.buffer.as_slice().iter().all(|&b| b == 0));
         assert_eq!(op.valid_bytes, 0);
     }
 
@@ -122,8 +238,23 @@ mod tests {
     fn new_write_copies_data() {
         let data = b"hello world";
         let op = OverlappedOp::new_write(0, data);
-        assert_eq!(op.buffer, data);
+        assert_eq!(op.buffer.as_slice(), data);
         assert_eq!(op.valid_bytes, data.len());
+    }
+
+    #[test]
+    fn new_write_aligned_uses_page_aligned_buffer() {
+        let data = b"page aligned write payload";
+        let op = OverlappedOp::new_write_aligned(0, data);
+        assert!(op.buffer.is_page_aligned());
+        assert_eq!(op.buffer.as_slice(), data);
+        assert_eq!(op.valid_bytes, data.len());
+        let addr = op.buffer.as_ptr() as usize;
+        assert_eq!(
+            addr % page_size(),
+            0,
+            "aligned buffer pointer {addr:#x} must be page-aligned"
+        );
     }
 
     #[test]

--- a/crates/fast_io/src/iocp_stub.rs
+++ b/crates/fast_io/src/iocp_stub.rs
@@ -231,7 +231,26 @@ impl IocpDiskBatch {
     pub fn bytes_written_with_pending(&self) -> u64 {
         0
     }
+
+    /// Returns whether the internal buffer is page-aligned (always `false`
+    /// on this platform because no batch is ever constructed).
+    #[must_use]
+    pub fn buffer_is_page_aligned(&self) -> bool {
+        false
+    }
 }
+
+/// Returns the cumulative count of bounce-buffer copies avoided by the
+/// page-aligned IOCP write path. Always `0` on this platform because IOCP
+/// is Windows-only.
+#[must_use]
+pub fn bounce_copies_avoided() -> u64 {
+    0
+}
+
+/// Resets the process-wide bounce-copy counter (no-op on this platform).
+#[doc(hidden)]
+pub fn reset_bounce_copies_avoided_for_test() {}
 
 impl Write for IocpDiskBatch {
     fn write(&mut self, _buf: &[u8]) -> io::Result<usize> {

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -83,6 +83,8 @@
 pub mod cached_sort;
 /// Kernel version parsing and io_uring probe logging.
 pub mod kernel_version;
+/// Page-aligned buffer pool for IOCP no-buffering mode.
+pub mod page_aligned;
 /// Parallel file I/O operations using rayon.
 pub mod parallel;
 /// Cross-platform temporary file strategy abstraction.
@@ -185,6 +187,7 @@ mod policy;
 mod status;
 
 pub use cached_sort::{CachedSortKey, cached_sort_by};
+pub use page_aligned::{PageAlignedBuffer, page_size, round_up_to_page};
 pub use parallel::{ParallelExecutor, ParallelResult};
 pub use platform_copy::{
     CopyMethod, CopyResult, DefaultPlatformCopy, NoCowPlatformCopy, NoZeroCopyPlatformCopy,
@@ -278,8 +281,8 @@ pub use iocp::post_completion as iocp_post_completion;
 pub use iocp::{
     CompletionHandler, CompletionPump, IocpConfig, IocpDiskBatch, IocpError, IocpOrStdReader,
     IocpOrStdWriter, IocpPumpConfig, IocpReader, IocpReaderFactory, IocpWriter, IocpWriterFactory,
-    iocp_availability_reason, is_iocp_available, oneshot_handler,
-    skip_event_optimization_available,
+    bounce_copies_avoided as iocp_bounce_copies_avoided, iocp_availability_reason,
+    is_iocp_available, oneshot_handler, skip_event_optimization_available,
 };
 #[cfg(all(target_os = "windows", feature = "transmitfile"))]
 pub use iocp::{TRANSMIT_FILE_MAX_BYTES, try_transmit_file};

--- a/crates/fast_io/src/page_aligned.rs
+++ b/crates/fast_io/src/page_aligned.rs
@@ -1,0 +1,367 @@
+//! Page-aligned buffer allocations for unbuffered (direct) I/O.
+//!
+//! Windows `FILE_FLAG_NO_BUFFERING` and Linux `O_DIRECT` both require I/O
+//! buffers whose backing memory is aligned to a multiple of the volume's
+//! sector size. The system page size is always a multiple of the sector
+//! size, so allocating page-aligned memory satisfies the requirement for
+//! every supported filesystem.
+//!
+//! [`PageAlignedBuffer`] owns a heap allocation guaranteed to start on a
+//! page boundary. On Windows the backing store comes from
+//! [`VirtualAlloc`](windows_sys::Win32::System::Memory::VirtualAlloc) so the
+//! buffer can be handed directly to overlapped `WriteFile` / `ReadFile` calls
+//! issued against a handle opened with `FILE_FLAG_NO_BUFFERING`. On every
+//! other platform the buffer is allocated through [`std::alloc::alloc`] with
+//! an explicit page-aligned [`Layout`], matching the helper used by the
+//! io_uring registered-buffer registry.
+//!
+//! Using a page-aligned buffer in the IOCP write path avoids the bounce
+//! buffer copy that the kernel performs when an application submits a write
+//! whose buffer alignment does not satisfy the no-buffering contract - the
+//! kernel allocates a properly aligned scratch buffer, copies the caller's
+//! data into it, and only then dispatches the I/O. The bounce copy doubles
+//! the memory bandwidth consumed by each write and defeats the whole point
+//! of the no-buffering flag for high-throughput transfers.
+
+#[cfg(not(windows))]
+use std::alloc::Layout;
+use std::sync::OnceLock;
+
+/// Returns the system memory page size in bytes.
+///
+/// Cached after the first call. The value is queried from the OS at runtime
+/// because page size is fixed for the running kernel but varies across
+/// platforms (4 KiB on x86, 4 KiB or 16 KiB on aarch64 macOS, 4 KiB / 64 KiB
+/// on Linux depending on architecture).
+#[must_use]
+pub fn page_size() -> usize {
+    static PAGE_SIZE: OnceLock<usize> = OnceLock::new();
+    *PAGE_SIZE.get_or_init(query_page_size)
+}
+
+#[cfg(unix)]
+fn query_page_size() -> usize {
+    // SAFETY: sysconf(_SC_PAGESIZE) is documented to be safe with no
+    // preconditions; the return value is always > 0 on supported Unix
+    // platforms.
+    #[allow(unsafe_code)]
+    let size = unsafe { libc::sysconf(libc::_SC_PAGESIZE) };
+    if size <= 0 {
+        // sysconf returning -1 here would indicate a broken libc; fall back
+        // to the universal lower bound rather than panic.
+        4096
+    } else {
+        size as usize
+    }
+}
+
+#[cfg(windows)]
+fn query_page_size() -> usize {
+    use windows_sys::Win32::System::SystemInformation::{GetSystemInfo, SYSTEM_INFO};
+    // SAFETY: SYSTEM_INFO is a POD struct that is valid when zeroed; the
+    // subsequent GetSystemInfo call populates every field we read.
+    #[allow(unsafe_code)]
+    let mut info: SYSTEM_INFO = unsafe { std::mem::zeroed() };
+    // SAFETY: GetSystemInfo writes into the SYSTEM_INFO out-parameter; the
+    // pointer is valid for the lifetime of the call.
+    #[allow(unsafe_code)]
+    unsafe {
+        GetSystemInfo(&mut info);
+    }
+    info.dwPageSize as usize
+}
+
+#[cfg(not(any(unix, windows)))]
+fn query_page_size() -> usize {
+    4096
+}
+
+/// Rounds `size` up to the next multiple of the system page size.
+///
+/// Returns the page size itself when `size` is zero so callers never receive
+/// a zero-sized allocation, which is undefined behaviour for both
+/// `std::alloc::alloc` and `VirtualAlloc`.
+#[must_use]
+pub fn round_up_to_page(size: usize) -> usize {
+    let page = page_size();
+    if size == 0 {
+        page
+    } else {
+        size.next_multiple_of(page)
+    }
+}
+
+/// Heap buffer whose backing pointer is guaranteed to be page-aligned.
+///
+/// The capacity is rounded up to a multiple of [`page_size`], matching the
+/// constraint that direct I/O reads/writes must transfer whole sectors and
+/// the buffer must cover the rounded-up length even when the caller writes
+/// fewer bytes.
+///
+/// On Windows the allocation comes from
+/// [`VirtualAlloc`](windows_sys::Win32::System::Memory::VirtualAlloc) so the
+/// memory can be handed straight to overlapped `WriteFile`/`ReadFile` on a
+/// handle opened with `FILE_FLAG_NO_BUFFERING`. On all other platforms the
+/// allocation is performed via [`std::alloc::alloc`] using a page-aligned
+/// [`Layout`]. In both cases the buffer is freed with the matching API in
+/// the [`Drop`] impl, so callers do not need to manage lifetime explicitly.
+pub struct PageAlignedBuffer {
+    ptr: *mut u8,
+    capacity: usize,
+    #[cfg(not(windows))]
+    layout: Layout,
+}
+
+// SAFETY: `PageAlignedBuffer` owns its allocation exclusively. The raw
+// pointer is never aliased and is freed in `Drop`, so the buffer is safe to
+// move across threads.
+#[allow(unsafe_code)]
+unsafe impl Send for PageAlignedBuffer {}
+
+// SAFETY: Shared references only expose `&[u8]` / `&mut [u8]` slices, which
+// uphold Rust's aliasing rules; mutable access requires `&mut self`.
+#[allow(unsafe_code)]
+unsafe impl Sync for PageAlignedBuffer {}
+
+impl PageAlignedBuffer {
+    /// Allocates a zero-initialised buffer with at least `requested` bytes.
+    ///
+    /// The actual capacity is `requested` rounded up to the next multiple
+    /// of [`page_size`]. The returned buffer's pointer is page-aligned and
+    /// the contents are zeroed.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the underlying allocator fails to satisfy the request.
+    #[must_use]
+    pub fn new(requested: usize) -> Self {
+        let capacity = round_up_to_page(requested);
+        let page = page_size();
+
+        #[cfg(windows)]
+        let ptr = {
+            use windows_sys::Win32::System::Memory::{
+                MEM_COMMIT, MEM_RESERVE, PAGE_READWRITE, VirtualAlloc,
+            };
+            // SAFETY: VirtualAlloc with a null base address and non-zero size
+            // returns a page-aligned, zero-initialised region or null on
+            // failure. MEM_COMMIT | MEM_RESERVE backs the region with
+            // committed pages immediately so subsequent reads/writes do not
+            // fault into the commit limit.
+            #[allow(unsafe_code)]
+            let raw = unsafe {
+                VirtualAlloc(
+                    std::ptr::null_mut(),
+                    capacity,
+                    MEM_COMMIT | MEM_RESERVE,
+                    PAGE_READWRITE,
+                )
+            };
+            assert!(
+                !raw.is_null(),
+                "VirtualAlloc failed for {capacity}-byte page-aligned buffer"
+            );
+            raw.cast::<u8>()
+        };
+
+        #[cfg(not(windows))]
+        let (ptr, layout) = {
+            let layout =
+                Layout::from_size_align(capacity, page).expect("page-aligned layout must be valid");
+            // SAFETY: layout has non-zero size and a power-of-two alignment.
+            // alloc_zeroed returns either a properly aligned pointer or null;
+            // we treat null as fatal because the pool cannot proceed without
+            // a buffer and the caller did not opt in to fallible allocation.
+            #[allow(unsafe_code)]
+            let raw = unsafe { std::alloc::alloc_zeroed(layout) };
+            assert!(
+                !raw.is_null(),
+                "page-aligned allocation failed for {capacity} bytes (page={page})"
+            );
+            (raw, layout)
+        };
+
+        debug_assert_eq!(
+            ptr as usize % page,
+            0,
+            "page-aligned buffer pointer must be a multiple of {page}"
+        );
+
+        Self {
+            ptr,
+            capacity,
+            #[cfg(not(windows))]
+            layout,
+        }
+    }
+
+    /// Returns the buffer capacity in bytes (always a multiple of the
+    /// system page size).
+    #[must_use]
+    pub fn capacity(&self) -> usize {
+        self.capacity
+    }
+
+    /// Returns the raw pointer for FFI use.
+    ///
+    /// The pointer is page-aligned and valid for `self.capacity()` bytes.
+    #[must_use]
+    pub fn as_ptr(&self) -> *const u8 {
+        self.ptr
+    }
+
+    /// Returns a mutable raw pointer for FFI use.
+    #[must_use]
+    pub fn as_mut_ptr(&mut self) -> *mut u8 {
+        self.ptr
+    }
+
+    /// Returns the buffer as an immutable byte slice.
+    #[must_use]
+    pub fn as_slice(&self) -> &[u8] {
+        // SAFETY: ptr is valid for `capacity` bytes, the bytes are
+        // initialised (zeroed at allocation, only overwritten through
+        // `&mut self`), and the lifetime is tied to `&self`.
+        #[allow(unsafe_code)]
+        unsafe {
+            std::slice::from_raw_parts(self.ptr, self.capacity)
+        }
+    }
+
+    /// Returns the buffer as a mutable byte slice.
+    pub fn as_mut_slice(&mut self) -> &mut [u8] {
+        // SAFETY: ptr is valid for `capacity` bytes, the bytes are
+        // initialised, and exclusive access is enforced by `&mut self`.
+        #[allow(unsafe_code)]
+        unsafe {
+            std::slice::from_raw_parts_mut(self.ptr, self.capacity)
+        }
+    }
+}
+
+impl Drop for PageAlignedBuffer {
+    fn drop(&mut self) {
+        if self.ptr.is_null() {
+            return;
+        }
+
+        #[cfg(windows)]
+        {
+            use windows_sys::Win32::System::Memory::{MEM_RELEASE, VirtualFree};
+            // SAFETY: ptr was returned by VirtualAlloc above with
+            // MEM_RESERVE | MEM_COMMIT; VirtualFree with MEM_RELEASE and
+            // dwSize == 0 releases the entire allocation as documented.
+            #[allow(unsafe_code)]
+            unsafe {
+                let _ = VirtualFree(self.ptr.cast(), 0, MEM_RELEASE);
+            }
+        }
+
+        #[cfg(not(windows))]
+        {
+            // SAFETY: ptr was returned by alloc_zeroed with `self.layout`;
+            // dealloc with the original layout is the documented inverse.
+            #[allow(unsafe_code)]
+            unsafe {
+                std::alloc::dealloc(self.ptr, self.layout);
+            }
+        }
+    }
+}
+
+impl std::fmt::Debug for PageAlignedBuffer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PageAlignedBuffer")
+            .field("ptr", &self.ptr)
+            .field("capacity", &self.capacity)
+            .field("page_size", &page_size())
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn page_size_is_power_of_two() {
+        let size = page_size();
+        assert!(size > 0);
+        assert!(
+            size.is_power_of_two(),
+            "page size {size} is not a power of two"
+        );
+    }
+
+    #[test]
+    fn round_up_handles_zero() {
+        assert_eq!(round_up_to_page(0), page_size());
+    }
+
+    #[test]
+    fn round_up_keeps_aligned_value() {
+        let page = page_size();
+        assert_eq!(round_up_to_page(page), page);
+        assert_eq!(round_up_to_page(page * 4), page * 4);
+    }
+
+    #[test]
+    fn round_up_promotes_partial_value() {
+        let page = page_size();
+        assert_eq!(round_up_to_page(1), page);
+        assert_eq!(round_up_to_page(page + 1), page * 2);
+    }
+
+    #[test]
+    fn buffer_pointer_is_page_aligned() {
+        let buf = PageAlignedBuffer::new(8 * 1024);
+        let addr = buf.as_ptr() as usize;
+        assert_eq!(
+            addr % page_size(),
+            0,
+            "buffer addr {addr:#x} not page-aligned"
+        );
+    }
+
+    #[test]
+    fn buffer_capacity_rounds_up() {
+        let page = page_size();
+        let buf = PageAlignedBuffer::new(1);
+        assert_eq!(buf.capacity(), page);
+        let buf = PageAlignedBuffer::new(page + 1);
+        assert_eq!(buf.capacity(), page * 2);
+    }
+
+    #[test]
+    fn buffer_is_writable_then_readable() {
+        let mut buf = PageAlignedBuffer::new(4096);
+        for (i, byte) in buf.as_mut_slice().iter_mut().enumerate() {
+            *byte = (i % 251) as u8;
+        }
+        for (i, byte) in buf.as_slice().iter().enumerate() {
+            assert_eq!(*byte, (i % 251) as u8);
+        }
+    }
+
+    #[test]
+    fn buffer_is_initially_zeroed() {
+        let buf = PageAlignedBuffer::new(8192);
+        assert!(buf.as_slice().iter().all(|&b| b == 0));
+    }
+
+    #[test]
+    fn buffer_drop_does_not_leak() {
+        // Allocate and drop a few buffers; the test passes if the process
+        // completes without aborting (which would happen on a double-free
+        // or freed-with-wrong-API path).
+        for _ in 0..16 {
+            let _buf = PageAlignedBuffer::new(64 * 1024);
+        }
+    }
+
+    #[test]
+    fn buffer_is_send_and_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<PageAlignedBuffer>();
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `PageAlignedBufferPool` (engine) and `fast_io::PageAlignedBuffer`, a page-aligned arena backed by `VirtualAlloc` on Windows and `std::alloc::alloc_zeroed` with an explicit page-aligned `Layout` elsewhere; capacity is rounded up to a multiple of the system page size.
- `IocpDiskBatch::new` switches its accumulation buffer to `PageAlignedBuffer` when `IocpConfig::unbuffered` is set, submits each chunk through `OverlappedOp::new_write_aligned`, and `reopen_overlapped` now wires `FILE_FLAG_NO_BUFFERING` and `FILE_FLAG_WRITE_THROUGH` onto the overlapped handle (previously dead flags).
- New `iocp::bounce_copies_avoided` counter tracks each aligned submission so benchmarks can verify the kernel bounce-buffer copy is being skipped end to end.

## Test plan
- [x] Run `cargo fmt --all` (no diff after stage)
- [ ] `cargo nextest run -p fast_io --all-features -E 'test(page_aligned) + test(unbuffered_config_uses_page_aligned_buffer) + test(buffered_config_uses_vec_buffer) + test(aligned_write_path_increments_bounce_counter) + test(new_write_aligned_uses_page_aligned_buffer)'` (CI)
- [ ] `cargo nextest run -p engine --all-features -E 'package(engine) and test(/page_aligned/)'` (CI)
- [ ] Windows job: confirm the new tests run under the IOCP feature and that `bounce_copies_avoided` reaches at least 1 in the integration suite.
- [ ] All required CI checks (fmt+clippy, nextest stable, Windows stable, macOS stable, Linux musl stable).