### PR TITLE
docs: SpillPolicy user-facing documentation (#2346)

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,23 @@ release binary on modern Linux/macOS/Windows hosts; everything marked
 | `concurrent-sessions` | `daemon` | no | Shared `dashmap` session state for multi-session daemons. | experimental |
 | `tracing` | `core`, `engine`, `transfer`, `daemon` | no | Structured `tracing` instrumentation for diagnostics. | stable |
 
+#### Receiver memory tuning: `SpillPolicy`
+
+The concurrent-delta receiver bounds its in-memory `ReorderBuffer` through a
+process-wide `SpillPolicy` knob. The default policy keeps everything in memory
+(byte-equivalent to prior releases). Opt in to disk-backed spill by setting
+`OC_RSYNC_SPILL_THRESHOLD_BYTES` (e.g. `64M`) and, optionally,
+`OC_RSYNC_SPILL_DIR` to point at a fast scratch directory. CLI flags
+`--spill-dir` and `--spill-threshold-bytes` are planned for STN-11 and will
+shadow the env vars when present. Full surface (env vars, reclaim mode,
+granularity, compression, validation rules, defaults table) is in
+[`docs/design/spill-policy-public-api.md`](./docs/design/spill-policy-public-api.md);
+the underlying buffer is documented in
+[`docs/design/reorderbuffer-spill-to-tempfile.md`](./docs/design/reorderbuffer-spill-to-tempfile.md).
+Operator-facing tuning guidance is in
+[`docs/operator-migration-guide-vNEXT.md`](./docs/operator-migration-guide-vNEXT.md)
+under *Receiver spill tunability*.
+
 #### Choosing features for your build
 
 ```bash

--- a/docs/oc-rsync.1.md
+++ b/docs/oc-rsync.1.md
@@ -864,6 +864,29 @@ exits with an error.
     even when the kernel supports io_uring. Overrides a previous
     **--io-uring** on the same command line.
 
+The next two flags govern the receiver-side `SpillPolicy` that bounds the
+concurrent-delta `ReorderBuffer`'s memory footprint. Both are *planned* for
+STN-11 and will land in a future release; until then operators tune the same
+knobs via the `OC_RSYNC_SPILL_DIR` and `OC_RSYNC_SPILL_THRESHOLD_BYTES`
+environment variables (see *Receiver spill tunability* in the operator
+migration guide). When the flags ship, they take precedence over the env
+vars on the same invocation. The remaining `SpillPolicy` fields
+(reclaim mode, granularity, compression) stay env-only by design; see
+**docs/design/spill-policy-public-api.md** for the full surface.
+
+**--spill-dir**=*PATH* (planned, STN-11)
+:   Directory backing the receiver spill file. Created on first spill via
+    `create_dir_all`. When unset the runtime defers to
+    **std::env::temp_dir**(3) through a spooled tempfile that stays in
+    memory up to 1 MiB before rolling over. Maps to `SpillPolicy.dir`.
+
+**--spill-threshold-bytes**=*N*[**K**|**M**|**G**] (planned, STN-11)
+:   Memory budget for the receiver reorder buffer before items spill to
+    disk. Suffixes are case-insensitive base-1024 (`K`=KiB, `M`=MiB,
+    `G`=GiB). Omitting the flag (or passing an empty value) leaves spill
+    disabled and the consumer stays on the bare `ReorderBuffer` path; the
+    value `0` is rejected. Maps to `SpillPolicy.threshold_bytes`.
+
 ## Scheduling Options
 
 **--stop-after**=*MINS*

--- a/docs/operator-migration-guide-vNEXT.md
+++ b/docs/operator-migration-guide-vNEXT.md
@@ -249,6 +249,68 @@ be combined.
 - **Build.** `cargo build --release --features vmsplice`
   (Linux only; no-op on other targets).
 
+### Receiver spill tunability (`SpillPolicy`)
+
+The concurrent-delta receiver bounds its `ReorderBuffer` through a
+process-wide `SpillPolicy` introduced in STN-1 (design) and STN-2
+(struct). The default policy keeps the historical behaviour - no spill,
+everything in memory, byte-equivalent to the previous release - so
+existing operators see no behavioural change.
+
+- **What it does.** When `threshold_bytes` is set, the receiver writes
+  the oldest-eligible items in the reorder window to a tempfile once
+  the in-memory footprint crosses the threshold and reloads them when
+  they reach the head of the delivery order. The on-disk format is a
+  length-prefixed binary payload; compression is opt-in.
+- **Defaults.** `threshold_bytes = None` (spill disabled),
+  `dir = None` (defers to **std::env::temp_dir**(3) via a 1 MiB
+  spooled tempfile), `reclaim_mode = KeepInMemory`,
+  `granularity = WholeBatch`, `compression = None`. The defaults
+  table and rationale are in
+  [`docs/design/spill-policy-public-api.md`](design/spill-policy-public-api.md)
+  section 2.
+- **Environment variables.** All five `SpillPolicy` fields are
+  reachable through `OC_RSYNC_SPILL_*` env vars; precedence (highest
+  wins) is CLI flag > env var > programmatic policy > default.
+
+| Variable | Maps to | Accepted values |
+|----------|---------|-----------------|
+| `OC_RSYNC_SPILL_THRESHOLD_BYTES` | `threshold_bytes` | Integer with optional `K`/`M`/`G` suffix (case-insensitive, base 1024). Empty string clears. `0` is rejected. |
+| `OC_RSYNC_SPILL_DIR` | `dir` | Absolute or relative path. Created on first spill via `create_dir_all`. |
+| `OC_RSYNC_SPILL_RECLAIM` | `reclaim_mode` | `keep` (default) or `re-spill`. |
+| `OC_RSYNC_SPILL_GRANULARITY` | `granularity` | `whole-batch` (default) or `per-item`. |
+| `OC_RSYNC_SPILL_COMPRESSION` | `compression` | `none` (default), `zstd`, or `zstd:LEVEL` where `LEVEL` is in `[-22, 22]`. |
+
+- **When to override.**
+  - *Memory-constrained receivers* (containers with tight cgroup
+    memory limits, embedded targets) should set
+    `OC_RSYNC_SPILL_THRESHOLD_BYTES` to a value below the cgroup
+    limit (typical starting point: 64 MiB) and point
+    `OC_RSYNC_SPILL_DIR` at a fast tmpfs or local SSD.
+  - *Adversarial fan-out workloads* (deep INC_RECURSE trees with
+    many unfinished segments held in the reorder window) benefit
+    from `OC_RSYNC_SPILL_RECLAIM=re-spill` to keep the post-reload
+    footprint bounded under sustained pressure.
+  - *Slow or SMR spill directories* should set
+    `OC_RSYNC_SPILL_COMPRESSION=zstd` to trade CPU for disk
+    bandwidth; default level 3 is usually appropriate, raise to
+    `zstd:7` only when the spill device is the bottleneck.
+  - *Diagnostic granularity* on benchmark runs:
+    `OC_RSYNC_SPILL_GRANULARITY=per-item` smooths the memory curve
+    at the cost of more syscalls per spill event.
+- **When to stay on the default.** Every workload that fits inside
+  the documented 64 MiB high-water mark on the audit baseline. Spill
+  is opt-in for a reason: the in-memory path is the fastest and
+  byte-stable.
+- **CLI flags.** `--spill-dir` and `--spill-threshold-bytes` are
+  planned for STN-11 and will land in a future release; they shadow
+  the two highest-value env vars. The remaining three knobs stay
+  env-only.
+- **References.** Public-API surface and validation rules:
+  [`docs/design/spill-policy-public-api.md`](design/spill-policy-public-api.md).
+  Spillable buffer internals:
+  [`docs/design/reorderbuffer-spill-to-tempfile.md`](design/reorderbuffer-spill-to-tempfile.md).
+
 ### Combining flags
 
 The feature flags are independent. A common production combination


### PR DESCRIPTION
## Summary

- Document the receiver-side `SpillPolicy` surface introduced in STN-1 (design, PR #4340) and STN-2 (struct, PR #4360) across the three operator-facing docs.
- README cargo-features table gets a *Receiver memory tuning* subsection cross-linking the public-API design and the spillable buffer internals.
- `docs/oc-rsync.1.md` documents the planned `--spill-dir` and `--spill-threshold-bytes` flags (marked planned for STN-11) and the `OC_RSYNC_SPILL_*` env-var bridge available until they ship.
- `docs/operator-migration-guide-vNEXT.md` gains a *Receiver spill tunability* subsection covering all five `OC_RSYNC_SPILL_*` env vars, defaults, precedence, and when to override (memory-constrained receivers, adversarial fan-out, slow SMR spill, diagnostic granularity).

## Test plan

- [ ] CI: docs-only change, fmt+clippy and nextest unaffected.
- [ ] Manual: render README and migration guide locally; confirm cross-links resolve.
- [ ] Manual: `pandoc docs/oc-rsync.1.md -s -t man -o /tmp/oc-rsync.1` produces a clean man page with the two new flag entries under *Performance Options*.