### PR TITLE
refactor(engine): replace lock().expect() in delete/emitter (#2354)

### DIFF
--- a/crates/engine/src/delete/emitter/fs.rs
+++ b/crates/engine/src/delete/emitter/fs.rs
@@ -12,6 +12,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 
 use super::super::DeleteEntryKind;
+use crate::util::poison::lock_or_recover;
 
 /// Filesystem operations the emitter needs to issue a deletion.
 ///
@@ -148,19 +149,20 @@ impl RecordingDeleteFs {
     }
 
     /// Returns a snapshot of the recorded events in dispatch order.
+    ///
+    /// The event log is append-only scratch data; a poisoned mutex still
+    /// yields a debuggable trace, so recovery via [`lock_or_recover`] is
+    /// preferred over aborting the test thread.
     #[must_use]
     pub fn events(&self) -> Vec<DeleteEvent> {
-        self.events.lock().expect("recorder mutex poisoned").clone()
+        lock_or_recover(&self.events).clone()
     }
 
     fn record(&self, path: &Path, kind: DeleteEntryKind) {
-        self.events
-            .lock()
-            .expect("recorder mutex poisoned")
-            .push(DeleteEvent {
-                path: path.to_path_buf(),
-                kind,
-            });
+        lock_or_recover(&self.events).push(DeleteEvent {
+            path: path.to_path_buf(),
+            kind,
+        });
     }
 }
 

--- a/crates/engine/src/delete/emitter/tests/mod.rs
+++ b/crates/engine/src/delete/emitter/tests/mod.rs
@@ -18,6 +18,7 @@ use protocol::flist::FileEntry;
 
 use super::super::{DeleteEntry, DeleteEntryKind, DeletePlan};
 use super::{DeleteEvent, DeleteFs, RecordingDeleteFs};
+use crate::util::poison::lock_or_recover;
 
 mod cohort;
 mod dispatch;
@@ -60,10 +61,7 @@ impl ScriptedDeleteFs {
     }
 
     pub(super) fn fail(self, path: &str, kind: io::ErrorKind) -> Self {
-        self.rules
-            .lock()
-            .expect("rules mutex")
-            .push((PathBuf::from(path), kind));
+        lock_or_recover(&self.rules).push((PathBuf::from(path), kind));
         self
     }
 
@@ -72,7 +70,7 @@ impl ScriptedDeleteFs {
     }
 
     fn maybe_fail(&self, path: &Path) -> Option<io::Error> {
-        let mut rules = self.rules.lock().expect("rules mutex");
+        let mut rules = lock_or_recover(&self.rules);
         let position = rules.iter().position(|(p, _)| p == path)?;
         let (_, kind) = rules.remove(position);
         Some(io::Error::new(kind, "scripted failure"))


### PR DESCRIPTION
## Summary

Per MPE-1+2+9 audit (`docs/audits/mutex-poison-policy.md` Table 1, rows for `delete/emitter/fs.rs:153,158` and `delete/emitter/tests/mod.rs:64,75`), the four `.lock().expect()` sites in `crates/engine/src/delete/emitter/` all guard append-only scratch state (event recorder, scripted rule queue). Swap them to `engine::util::poison::lock_or_recover` (introduced by PR #4342) so a poisoned mutex degrades to a debuggable partial state instead of cascading the panic across worker threads.

- `delete/emitter/fs.rs` (`RecordingDeleteFs::events`, `RecordingDeleteFs::record`) - swap to `lock_or_recover`.
- `delete/emitter/tests/mod.rs` (`ScriptedDeleteFs::fail`, `ScriptedDeleteFs::maybe_fail`) - swap to `lock_or_recover`.
- `delete/emitter/{mod,policy,cohort}.rs` hold no `Mutex` calls; no remaining FATAL sites in this subtree, so the audit's "keep `expect` + `# Panics` doc" branch does not apply here.

Closes #2354. Sibling tasks MPE-4 (`plan_map.rs`), MPE-5 (`context.rs`), MPE-10..17 cover the remaining engine/fast_io/flist sites tabled in the audit.

## Test plan

- [x] `cargo fmt --all`
- [ ] CI: fmt+clippy, nextest (stable), Windows, macOS, Linux musl