### PR TITLE
refactor(engine): extract spill/stats.rs (SPL-6 #2328)

### DIFF
--- a/crates/engine/src/concurrent_delta/spill.rs
+++ b/crates/engine/src/concurrent_delta/spill.rs
@@ -55,7 +55,9 @@ use std::path::{Path, PathBuf};
 use super::reorder::{CapacityExceeded, ReorderBuffer};
 
 pub mod policy;
+pub mod stats;
 pub use policy::{ReclaimMode, SpillCompression, SpillGranularity, SpillPolicy};
+pub use stats::SpillStats;
 
 /// Default memory threshold (in bytes) before spilling begins.
 ///
@@ -256,23 +258,6 @@ impl<T: SpillCodec> std::fmt::Debug for SpillableReorderBuffer<T> {
             .field("dir_recreate_count", &self.dir_recreate_count)
             .finish()
     }
-}
-
-/// Diagnostic counters for spill activity.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub struct SpillStats {
-    /// Number of items currently spilled to disk.
-    pub spilled_items: usize,
-    /// Total spill-to-disk events since creation.
-    pub spill_events: u64,
-    /// Total reload-from-disk events since creation.
-    pub reload_events: u64,
-    /// Current estimated in-memory bytes.
-    pub memory_used: usize,
-    /// Configured spill threshold in bytes.
-    pub threshold: usize,
-    /// Number of times the spill directory was re-created after vanishing.
-    pub dir_recreate_events: u64,
 }
 
 impl<T: SpillCodec> SpillableReorderBuffer<T> {

--- a/crates/engine/src/concurrent_delta/spill/stats.rs
+++ b/crates/engine/src/concurrent_delta/spill/stats.rs
@@ -1,0 +1,24 @@
+//! Diagnostic counters surfaced by the spill layer.
+//!
+//! [`SpillStats`] is a plain-data snapshot of the spill activity tracked by
+//! [`SpillableReorderBuffer`](super::SpillableReorderBuffer). It is intended
+//! for logging, metrics, and tests; the buffer itself owns the live counters
+//! and exposes a copy via
+//! [`spill_stats`](super::SpillableReorderBuffer::spill_stats).
+
+/// Diagnostic counters for spill activity.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct SpillStats {
+    /// Number of items currently spilled to disk.
+    pub spilled_items: usize,
+    /// Total spill-to-disk events since creation.
+    pub spill_events: u64,
+    /// Total reload-from-disk events since creation.
+    pub reload_events: u64,
+    /// Current estimated in-memory bytes.
+    pub memory_used: usize,
+    /// Configured spill threshold in bytes.
+    pub threshold: usize,
+    /// Number of times the spill directory was re-created after vanishing.
+    pub dir_recreate_events: u64,
+}


### PR DESCRIPTION
## Summary
- Move \`SpillStats\` (the diagnostic-counter snapshot type) from \`spill.rs\` into a new \`spill/stats.rs\` submodule per the SPL-1 audit's leaves-first order (error -> codec -> **stats** -> tempfile -> policy -> buffer).
- Re-export \`SpillStats\` from the parent so the public API at \`engine::concurrent_delta::spill::SpillStats\` (and the higher-level \`engine::concurrent_delta::SpillStats\`) is unchanged.
- Parent \`spill.rs\` shrinks from 1232 to 1217 lines; new \`spill/stats.rs\` is 24 lines.

## Test plan
- [x] \`cargo fmt --all\` clean
- [x] No public-API change: all original symbol paths preserved via \`pub use stats::SpillStats\`
- [x] No code change beyond move + re-export
- [x] No tests had to move or change (the \`spill_stats()\` accessor stays on \`SpillableReorderBuffer\`; \`spill_stats_tracking\` exercises buffer behaviour so it stays with the buffer in the parent)

Closes #2328.