### PR TITLE
feat(metadata): wire --acls to Windows DACL (#2310)

### DIFF
--- a/crates/metadata/src/acl_windows.rs
+++ b/crates/metadata/src/acl_windows.rs
@@ -51,6 +51,7 @@ use std::sync::Once;
 #[cfg(test)]
 use protocol::acl::IdaEntries;
 use protocol::acl::{AclCache, IdAccess, NO_ENTRY, RsyncAcl};
+use protocol::xattr::{XattrEntry, XattrList};
 use windows::Win32::Foundation::{ERROR_NOT_SUPPORTED, HLOCAL, LocalFree, WIN32_ERROR};
 use windows::Win32::Security::Authorization::{
     ConvertSecurityDescriptorToStringSecurityDescriptorW,
@@ -433,6 +434,23 @@ pub fn sync_acls(
             source,
             io::Error::new(io::ErrorKind::NotFound, "source does not exist"),
         ));
+    }
+
+    // Preferred Windows-to-Windows path: round-trip the full SDDL via
+    // the WAS-2/3 helpers so owner, group, and the complete DACL transfer
+    // verbatim. Falls back to the lossy named-ACE encoder when the volume
+    // refuses to serve a descriptor (FAT32, network mounts).
+    match read_dacl_sddl(source) {
+        Ok(sddl) if !sddl.is_empty() => {
+            return write_dacl_sddl(destination, &sddl)
+                .map_err(|error| MetadataError::new("write SDDL", destination, error));
+        }
+        Ok(_) => {}
+        Err(error) => {
+            if !io_error_is_unsupported(&error) {
+                return Err(MetadataError::new("read SDDL", source, error));
+            }
+        }
     }
 
     let (sd, pdacl) = read_dacl(source)?;
@@ -969,6 +987,356 @@ pub fn write_dacl_sddl(path: &Path, sddl: &str) -> io::Result<()> {
     Ok(())
 }
 
+/// SDDL "Everyone" well-known SID alias.
+const SDDL_EVERYONE: &str = "WD";
+/// SDDL "Authenticated Users" alias - mapped to the `other` triplet when
+/// no explicit Everyone ACE is present.
+const SDDL_AUTHENTICATED_USERS: &str = "AU";
+
+/// Decodes an SDDL rights string into rsync rwx permission bits.
+///
+/// Recognised single-letter tokens follow Microsoft's SDDL grammar:
+///
+/// - `FA` (file all) -> rwx
+/// - `FR` (file generic read) -> r
+/// - `FW` (file generic write) -> w
+/// - `FX` (file generic execute) -> x
+/// - `GA`/`GR`/`GW`/`GX` (generic all/read/write/execute) -> same mapping
+///
+/// Hex masks (`0x...`) are decoded via [`access_mask_to_rsync_perms`].
+/// Unknown tokens contribute zero bits, matching the design doc's
+/// "non-rwx access bits collapsed" rule.
+fn sddl_rights_to_perms(rights: &str) -> u8 {
+    if let Some(hex) = rights
+        .strip_prefix("0x")
+        .or_else(|| rights.strip_prefix("0X"))
+    {
+        if let Ok(mask) = u32::from_str_radix(hex, 16) {
+            return access_mask_to_rsync_perms(mask);
+        }
+        return 0;
+    }
+    let mut perms: u8 = 0;
+    let bytes = rights.as_bytes();
+    let mut idx = 0;
+    while idx + 1 < bytes.len() {
+        let token = &rights[idx..idx + 2];
+        match token {
+            "FA" | "GA" => perms |= RSYNC_PERM_READ | RSYNC_PERM_WRITE | RSYNC_PERM_EXECUTE,
+            "FR" | "GR" => perms |= RSYNC_PERM_READ,
+            "FW" | "GW" => perms |= RSYNC_PERM_WRITE,
+            "FX" | "GX" => perms |= RSYNC_PERM_EXECUTE,
+            _ => {}
+        }
+        idx += 2;
+    }
+    perms
+}
+
+/// Encodes rsync rwx permission bits as an SDDL rights string.
+///
+/// Always emits the canonical two-letter file-access tokens (`FR`, `FW`,
+/// `FX`) so the result round-trips through [`sddl_rights_to_perms`].
+/// Returns an empty string for zero perms; the caller is expected to
+/// skip empty ACEs.
+fn perms_to_sddl_rights(perms: u8) -> String {
+    let mut out = String::with_capacity(6);
+    if perms & RSYNC_PERM_READ != 0 {
+        out.push_str("FR");
+    }
+    if perms & RSYNC_PERM_WRITE != 0 {
+        out.push_str("FW");
+    }
+    if perms & RSYNC_PERM_EXECUTE != 0 {
+        out.push_str("FX");
+    }
+    out
+}
+
+/// Splits an SDDL string into its `O:` / `G:` / `D:` / `S:` sections.
+///
+/// Returns `(owner, group, dacl, sacl)` where each component is `None`
+/// when the corresponding header is absent. The `dacl` and `sacl`
+/// payloads include the parenthesised ACE list but exclude any trailing
+/// section flags (e.g. `P`, `AI`).
+fn split_sddl(sddl: &str) -> (Option<&str>, Option<&str>, Option<&str>, Option<&str>) {
+    fn section<'a>(sddl: &'a str, marker: &str) -> Option<&'a str> {
+        let start = sddl.find(marker)?;
+        let after = &sddl[start + marker.len()..];
+        let mut depth: i32 = 0;
+        for (idx, ch) in after.char_indices() {
+            match ch {
+                '(' => depth += 1,
+                ')' => depth -= 1,
+                ':' if depth == 0 && idx >= 1 => {
+                    let header_start = idx - 1;
+                    let prev = after.as_bytes()[header_start];
+                    if matches!(prev, b'O' | b'G' | b'D' | b'S') {
+                        return Some(after[..header_start].trim());
+                    }
+                }
+                _ => {}
+            }
+        }
+        Some(after.trim())
+    }
+    (
+        section(sddl, "O:"),
+        section(sddl, "G:"),
+        section(sddl, "D:"),
+        section(sddl, "S:"),
+    )
+}
+
+/// Parsed SDDL ACE: `(type;flags;rights;object_guid;inherit_guid;trustee)`.
+struct ParsedAce<'a> {
+    ace_type: &'a str,
+    flags: &'a str,
+    rights: &'a str,
+    trustee: &'a str,
+}
+
+/// Parses the ACE list in a DACL section.
+///
+/// Each ACE is expected to use the canonical six-field form. ACEs with
+/// fewer fields are skipped. The `dacl` argument may carry leading
+/// section flags such as `P` or `AI` ahead of the first `(`; those are
+/// discarded.
+fn parse_aces(dacl: &str) -> Vec<ParsedAce<'_>> {
+    let mut out = Vec::new();
+    let mut rest = dacl;
+    while let Some(open) = rest.find('(') {
+        let Some(close_rel) = rest[open + 1..].find(')') else {
+            break;
+        };
+        let inner = &rest[open + 1..open + 1 + close_rel];
+        let fields: Vec<&str> = inner.splitn(6, ';').collect();
+        if fields.len() == 6 {
+            out.push(ParsedAce {
+                ace_type: fields[0],
+                flags: fields[1],
+                rights: fields[2],
+                trustee: fields[5],
+            });
+        }
+        rest = &rest[open + 1 + close_rel + 1..];
+    }
+    out
+}
+
+/// Converts an SDDL security-descriptor string into a POSIX permission
+/// mode triplet (rwxrwxrwx, 9 bits in the canonical 0o000-0o777 range).
+///
+/// Mapping rules (matching `docs/design/windows-ntfs-acl-support.md`
+/// section 5.1):
+///
+/// - The first allow ACE whose trustee matches the descriptor's owner
+///   SID supplies the owner rwx bits.
+/// - The first allow ACE whose trustee matches the group SID supplies
+///   the group rwx bits.
+/// - The first allow ACE addressed to `WD` (Everyone) or, in its
+///   absence, `AU` (Authenticated Users) supplies the other rwx bits.
+///
+/// Deny ACEs, inherited ACEs (`AceFlags` carrying `ID`), and access bits
+/// outside `FR`/`FW`/`FX`/`FA` are dropped with a one-time warning to
+/// reflect documented lossy behaviour. If a triplet has no matching ACE
+/// the corresponding three bits remain `0`.
+///
+/// # Panics
+///
+/// Never panics. Malformed input returns `0`.
+#[must_use]
+pub fn dacl_to_posix_mode(sddl: &str) -> u32 {
+    let (owner, group, dacl, _sacl) = split_sddl(sddl);
+    let Some(dacl) = dacl else {
+        return 0;
+    };
+    let owner = owner.unwrap_or("");
+    let group = group.unwrap_or("");
+
+    let mut owner_perms: u8 = 0;
+    let mut group_perms: u8 = 0;
+    let mut other_perms: u8 = 0;
+    let mut owner_seen = false;
+    let mut group_seen = false;
+    let mut everyone_seen = false;
+    let mut authenticated_perms: u8 = 0;
+    let mut authenticated_seen = false;
+    let mut dropped = false;
+
+    for ace in parse_aces(dacl) {
+        if ace.flags.contains("ID") {
+            dropped = true;
+            continue;
+        }
+        if !ace.ace_type.eq_ignore_ascii_case("A") {
+            if ace.ace_type.eq_ignore_ascii_case("D") {
+                dropped = true;
+            }
+            continue;
+        }
+        let perms = sddl_rights_to_perms(ace.rights);
+        if perms == 0 {
+            continue;
+        }
+        if !owner.is_empty() && ace.trustee == owner && !owner_seen {
+            owner_perms = perms;
+            owner_seen = true;
+        } else if !group.is_empty() && ace.trustee == group && !group_seen {
+            group_perms = perms;
+            group_seen = true;
+        } else if ace.trustee == SDDL_EVERYONE && !everyone_seen {
+            other_perms = perms;
+            everyone_seen = true;
+        } else if ace.trustee == SDDL_AUTHENTICATED_USERS && !authenticated_seen {
+            authenticated_perms = perms;
+            authenticated_seen = true;
+        }
+    }
+
+    if !everyone_seen && authenticated_seen {
+        other_perms = authenticated_perms;
+    }
+
+    if dropped {
+        warn_partial_apply();
+    }
+
+    (u32::from(owner_perms) << 6) | (u32::from(group_perms) << 3) | u32::from(other_perms)
+}
+
+/// Generates an SDDL security-descriptor string from a POSIX permission
+/// mode and the owning user / group SIDs.
+///
+/// The emitted DACL contains three explicit allow ACEs, in canonical
+/// order:
+///
+/// 1. Allow ACE for the owner SID with the owner triplet's rwx bits.
+/// 2. Allow ACE for the group SID with the group triplet's rwx bits.
+/// 3. Allow ACE for `WD` (Everyone) with the other triplet's rwx bits.
+///
+/// Permission triplets with no bits set are still emitted as empty
+/// rights ACEs (`(A;;;;;<SID>)`) so the round-trip preserves the
+/// distinction between "no permissions" and "ACE omitted entirely".
+///
+/// The `P` flag is set on the DACL so parent inheritance cannot silently
+/// add ACEs that were never on the source, matching section 5.2 of the
+/// design document.
+///
+/// # Panics
+///
+/// Never panics.
+#[must_use]
+pub fn posix_mode_to_dacl(mode: u32, owner_sid: &str, group_sid: &str) -> String {
+    let owner_perms = ((mode >> 6) & 0o7) as u8;
+    let group_perms = ((mode >> 3) & 0o7) as u8;
+    let other_perms = (mode & 0o7) as u8;
+
+    format!(
+        "O:{owner}G:{group}D:P(A;;{owner_rights};;;{owner})(A;;{group_rights};;;{group})(A;;{other_rights};;;WD)",
+        owner = owner_sid,
+        group = group_sid,
+        owner_rights = perms_to_sddl_rights(owner_perms),
+        group_rights = perms_to_sddl_rights(group_perms),
+        other_rights = perms_to_sddl_rights(other_perms),
+    )
+}
+
+/// Reserved xattr key carrying the full SDDL security descriptor for
+/// Windows-to-Windows DACL fidelity.
+///
+/// Mirrors Samba's `user.win32.security_descriptor` slot so external
+/// tooling that already understands the convention can interoperate with
+/// oc-rsync transfers without protocol changes. See
+/// `docs/design/windows-ntfs-acl-support.md` section 4.2.
+pub const WINDOWS_SDDL_XATTR_NAME: &[u8] = b"user.win32.security_descriptor";
+
+/// Builds an [`XattrEntry`] carrying the full SDDL descriptor for `path`.
+///
+/// Returns `Ok(None)` when the path cannot be read or carries no DACL
+/// (matching the conservative posture of [`read_dacl`]). Higher layers
+/// append the returned entry to the xattr list emitted by
+/// `read_xattrs_for_wire` so a Windows receiver can restore the
+/// descriptor verbatim via [`apply_sddl_from_xattrs`].
+///
+/// # Errors
+///
+/// Returns [`io::Error`] propagated from [`read_dacl_sddl`] only when the
+/// failure is not "filesystem does not support security descriptors";
+/// those benign failures collapse to `Ok(None)`.
+pub fn sddl_xattr_entry(path: &Path) -> io::Result<Option<XattrEntry>> {
+    match read_dacl_sddl(path) {
+        Ok(sddl) if !sddl.is_empty() => Ok(Some(XattrEntry::new(
+            WINDOWS_SDDL_XATTR_NAME.to_vec(),
+            sddl.into_bytes(),
+        ))),
+        Ok(_) => Ok(None),
+        Err(error) => {
+            if io_error_is_unsupported(&error) {
+                Ok(None)
+            } else {
+                Err(error)
+            }
+        }
+    }
+}
+
+/// Looks for the reserved SDDL xattr inside `xattr_list`.
+///
+/// Returns the parsed SDDL string when present so callers can apply it
+/// with [`write_dacl_sddl`] or lower it to a POSIX mode with
+/// [`dacl_to_posix_mode`].
+#[must_use]
+pub fn find_sddl_in_xattrs(xattr_list: &XattrList) -> Option<&str> {
+    let entry = xattr_list.find_by_name(WINDOWS_SDDL_XATTR_NAME)?;
+    if entry.is_abbreviated() {
+        return None;
+    }
+    std::str::from_utf8(entry.datum()).ok()
+}
+
+/// Applies the SDDL security descriptor carried inside `xattr_list` to
+/// `path` via [`write_dacl_sddl`].
+///
+/// Returns `Ok(true)` when the reserved SDDL xattr was found and applied,
+/// `Ok(false)` when no SDDL payload was present (so the caller falls back
+/// to the cross-platform named-ACE path).
+///
+/// # Errors
+///
+/// Returns [`MetadataError`] when the descriptor cannot be applied.
+/// Failures equivalent to "filesystem does not support security
+/// descriptors" swallow silently so transfers do not abort on FAT32 or
+/// network mounts.
+pub fn apply_sddl_from_xattrs(path: &Path, xattr_list: &XattrList) -> Result<bool, MetadataError> {
+    let Some(sddl) = find_sddl_in_xattrs(xattr_list) else {
+        return Ok(false);
+    };
+    match write_dacl_sddl(path, sddl) {
+        Ok(()) => Ok(true),
+        Err(error) => {
+            if io_error_is_unsupported(&error) {
+                Ok(true)
+            } else {
+                Err(MetadataError::new("apply SDDL xattr", path, error))
+            }
+        }
+    }
+}
+
+/// Returns `true` for [`io::Error`] values that correspond to the same
+/// "volume does not serve a security descriptor" conditions handled by
+/// [`is_unsupported`].
+fn io_error_is_unsupported(error: &io::Error) -> bool {
+    matches!(
+        error.raw_os_error(),
+        Some(code)
+            if code == ERROR_NOT_SUPPORTED.0 as i32
+                || code == 1
+                || code == 2
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1172,5 +1540,222 @@ mod tests {
         File::create(&file).expect("file");
         let result = write_dacl_sddl(&file, "not-a-sddl-string");
         assert!(result.is_err(), "expected parse error, got {result:?}");
+    }
+
+    #[test]
+    fn sddl_rights_decode_two_letter_tokens() {
+        assert_eq!(
+            sddl_rights_to_perms("FA"),
+            RSYNC_PERM_READ | RSYNC_PERM_WRITE | RSYNC_PERM_EXECUTE
+        );
+        assert_eq!(sddl_rights_to_perms("FR"), RSYNC_PERM_READ);
+        assert_eq!(sddl_rights_to_perms("FW"), RSYNC_PERM_WRITE);
+        assert_eq!(sddl_rights_to_perms("FX"), RSYNC_PERM_EXECUTE);
+        assert_eq!(
+            sddl_rights_to_perms("FRFX"),
+            RSYNC_PERM_READ | RSYNC_PERM_EXECUTE
+        );
+    }
+
+    #[test]
+    fn sddl_rights_decode_hex_mask() {
+        let mask = FILE_GENERIC_READ.0 | FILE_GENERIC_WRITE.0;
+        let token = format!("0x{mask:x}");
+        assert_eq!(
+            sddl_rights_to_perms(&token),
+            RSYNC_PERM_READ | RSYNC_PERM_WRITE
+        );
+    }
+
+    #[test]
+    fn sddl_rights_encode_canonical_order() {
+        assert_eq!(perms_to_sddl_rights(0), "");
+        assert_eq!(perms_to_sddl_rights(RSYNC_PERM_READ), "FR");
+        assert_eq!(
+            perms_to_sddl_rights(RSYNC_PERM_READ | RSYNC_PERM_EXECUTE),
+            "FRFX"
+        );
+        assert_eq!(
+            perms_to_sddl_rights(RSYNC_PERM_READ | RSYNC_PERM_WRITE | RSYNC_PERM_EXECUTE),
+            "FRFWFX"
+        );
+    }
+
+    #[test]
+    fn posix_mode_to_dacl_uses_three_allow_aces_with_protected_flag() {
+        let sddl = posix_mode_to_dacl(0o755, "S-1-5-21-100", "S-1-5-21-200");
+        assert!(sddl.starts_with("O:S-1-5-21-100"));
+        assert!(sddl.contains("G:S-1-5-21-200"));
+        assert!(sddl.contains("D:P("));
+        assert!(sddl.contains("(A;;FRFWFX;;;S-1-5-21-100)"));
+        assert!(sddl.contains("(A;;FRFX;;;S-1-5-21-200)"));
+        assert!(sddl.contains("(A;;FRFX;;;WD)"));
+    }
+
+    #[test]
+    fn round_trip_mode_755_preserves_rwx_triplet() {
+        let owner = "S-1-5-21-1";
+        let group = "S-1-5-21-2";
+        let sddl = posix_mode_to_dacl(0o755, owner, group);
+        let back = dacl_to_posix_mode(&sddl);
+        assert_eq!(back, 0o755, "round-trip lost bits; sddl: {sddl}");
+    }
+
+    #[test]
+    fn round_trip_full_mode_matrix_preserves_rwx() {
+        let owner = "S-1-5-21-1000";
+        let group = "S-1-5-21-1001";
+        for mode in 0o000u32..=0o777u32 {
+            let sddl = posix_mode_to_dacl(mode, owner, group);
+            let back = dacl_to_posix_mode(&sddl);
+            assert_eq!(back, mode, "round-trip lost bits for mode {mode:03o}");
+        }
+    }
+
+    #[test]
+    fn dacl_to_posix_mode_handles_everyone_as_other() {
+        let sddl = "O:BAG:SYD:(A;;FA;;;BA)(A;;FRFX;;;SY)(A;;FR;;;WD)";
+        assert_eq!(dacl_to_posix_mode(sddl), 0o754);
+    }
+
+    #[test]
+    fn dacl_to_posix_mode_falls_back_to_authenticated_users() {
+        let sddl = "O:BAG:SYD:(A;;FA;;;BA)(A;;FRFX;;;SY)(A;;FRFX;;;AU)";
+        assert_eq!(dacl_to_posix_mode(sddl), 0o755);
+    }
+
+    #[test]
+    fn dacl_to_posix_mode_drops_deny_aces() {
+        let sddl = "O:BAG:SYD:(D;;FW;;;BA)(A;;FRFX;;;BA)(A;;FR;;;SY)(A;;FR;;;WD)";
+        assert_eq!(dacl_to_posix_mode(sddl), 0o544);
+    }
+
+    #[test]
+    fn dacl_to_posix_mode_drops_inherited_aces() {
+        let sddl = "O:BAG:SYD:(A;ID;FA;;;BA)(A;;FR;;;BA)(A;;FR;;;SY)(A;;FR;;;WD)";
+        assert_eq!(dacl_to_posix_mode(sddl), 0o444);
+    }
+
+    #[test]
+    fn dacl_to_posix_mode_collapses_non_rwx_bits() {
+        let sddl = "O:BAG:SYD:(A;;0x10000;;;BA)(A;;FR;;;SY)(A;;FR;;;WD)";
+        let mode = dacl_to_posix_mode(sddl);
+        assert_eq!(mode & 0o700, 0);
+        assert_eq!(mode & 0o077, 0o044);
+    }
+
+    #[test]
+    fn dacl_to_posix_mode_returns_zero_for_missing_dacl() {
+        assert_eq!(dacl_to_posix_mode("O:BAG:SY"), 0);
+        assert_eq!(dacl_to_posix_mode(""), 0);
+    }
+
+    #[test]
+    fn split_sddl_separates_owner_group_dacl() {
+        let (o, g, d, s) = split_sddl("O:BAG:SYD:(A;;FA;;;BA)");
+        assert_eq!(o, Some("BA"));
+        assert_eq!(g, Some("SY"));
+        assert_eq!(d, Some("(A;;FA;;;BA)"));
+        assert_eq!(s, None);
+    }
+
+    #[test]
+    fn parse_aces_skips_malformed_entries() {
+        let aces = parse_aces("(A;;FA;;;BA)(broken)(A;;FR;;;WD)");
+        assert_eq!(aces.len(), 2);
+        assert_eq!(aces[0].trustee, "BA");
+        assert_eq!(aces[1].trustee, "WD");
+    }
+
+    #[test]
+    fn find_sddl_in_xattrs_returns_payload() {
+        let mut list = XattrList::new();
+        list.push(XattrEntry::new(b"user.other".to_vec(), b"value".to_vec()));
+        list.push(XattrEntry::new(
+            WINDOWS_SDDL_XATTR_NAME.to_vec(),
+            b"O:BAG:SYD:P(A;;FA;;;BA)".to_vec(),
+        ));
+        let sddl = find_sddl_in_xattrs(&list).expect("sddl present");
+        assert!(sddl.starts_with("O:BAG:SY"));
+    }
+
+    #[test]
+    fn find_sddl_in_xattrs_returns_none_when_missing() {
+        let list = XattrList::new();
+        assert!(find_sddl_in_xattrs(&list).is_none());
+    }
+
+    #[test]
+    fn find_sddl_in_xattrs_skips_abbreviated_entries() {
+        let mut list = XattrList::new();
+        list.push(XattrEntry::abbreviated(
+            WINDOWS_SDDL_XATTR_NAME.to_vec(),
+            b"checksum".to_vec(),
+            1024,
+        ));
+        assert!(find_sddl_in_xattrs(&list).is_none());
+    }
+
+    #[test]
+    fn apply_sddl_from_xattrs_no_payload_is_noop() {
+        let dir = tempdir().expect("tempdir");
+        let file = dir.path().join("test");
+        File::create(&file).expect("file");
+        let list = XattrList::new();
+        let applied = apply_sddl_from_xattrs(&file, &list).expect("noop ok");
+        assert!(!applied);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn sddl_xattr_entry_round_trips_on_ntfs() {
+        let dir = tempdir().expect("tempdir");
+        let src = dir.path().join("src");
+        File::create(&src).expect("src");
+        // Pin a known descriptor so the round-trip assertion is stable
+        // regardless of NTFS inheritance on the runner.
+        let canonical = "O:BAG:SYD:P(A;;FA;;;BA)(A;;FA;;;WD)";
+        write_dacl_sddl(&src, canonical).expect("seed sddl");
+
+        let entry = sddl_xattr_entry(&src)
+            .expect("read sddl xattr")
+            .expect("entry present");
+        assert_eq!(entry.name(), WINDOWS_SDDL_XATTR_NAME);
+        let payload = std::str::from_utf8(entry.datum()).expect("utf8");
+        assert!(payload.contains("D:"));
+
+        let mut list = XattrList::new();
+        list.push(entry);
+
+        let dst = dir.path().join("dst");
+        File::create(&dst).expect("dst");
+        let applied = apply_sddl_from_xattrs(&dst, &list).expect("apply sddl");
+        assert!(applied, "expected SDDL xattr to be consumed");
+
+        let read_back = read_dacl_sddl(&dst).expect("read back");
+        assert!(read_back.contains("(A;;FA;;;BA)"), "got {read_back:?}");
+        assert!(read_back.contains("(A;;FA;;;WD)"), "got {read_back:?}");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn sync_acls_prefers_sddl_round_trip() {
+        let dir = tempdir().expect("tempdir");
+        let src = dir.path().join("src");
+        let dst = dir.path().join("dst");
+        File::create(&src).expect("src");
+        File::create(&dst).expect("dst");
+        // Seed a non-inherited descriptor so we have a concrete payload to
+        // compare on either end of the round-trip.
+        let canonical = "O:BAG:SYD:P(A;;FA;;;BA)(A;;FA;;;WD)";
+        write_dacl_sddl(&src, canonical).expect("seed sddl");
+
+        sync_acls(&src, &dst, true).expect("sync acls");
+
+        let read_back = read_dacl_sddl(&dst).expect("read dst sddl");
+        assert!(read_back.contains("O:BA"), "got {read_back:?}");
+        assert!(read_back.contains("G:SY"), "got {read_back:?}");
+        assert!(read_back.contains("(A;;FA;;;BA)"), "got {read_back:?}");
+        assert!(read_back.contains("(A;;FA;;;WD)"), "got {read_back:?}");
     }
 }

--- a/crates/metadata/src/lib.rs
+++ b/crates/metadata/src/lib.rs
@@ -170,8 +170,9 @@ pub use acl_stub::{apply_acls_from_cache, default_perms_for_dir, get_rsync_acl, 
 
 #[cfg(all(feature = "acl", windows))]
 pub use acl_windows::{
-    apply_acls_from_cache, default_perms_for_dir, get_rsync_acl, read_dacl_sddl,
-    read_sddl_with_sacl, sync_acls, write_dacl_sddl,
+    WINDOWS_SDDL_XATTR_NAME, apply_acls_from_cache, apply_sddl_from_xattrs, dacl_to_posix_mode,
+    default_perms_for_dir, find_sddl_in_xattrs, get_rsync_acl, posix_mode_to_dacl, read_dacl_sddl,
+    read_sddl_with_sacl, sddl_xattr_entry, sync_acls, write_dacl_sddl,
 };
 
 #[cfg(not(any(

--- a/crates/metadata/src/xattr.rs
+++ b/crates/metadata/src/xattr.rs
@@ -226,6 +226,19 @@ pub fn apply_xattrs_from_list(
 ) -> Result<(), MetadataError> {
     let mut applied_names: HashSet<Vec<u8>> = HashSet::with_capacity(xattr_list.len());
 
+    // Route the reserved Windows SDDL xattr to the DACL apply path on
+    // Windows so the descriptor lands on the security stream rather than
+    // an ADS. On other platforms the entry is dropped silently to avoid
+    // surfacing meaningless `user.win32.security_descriptor` ADS-style
+    // attributes on POSIX filesystems.
+    #[cfg(all(feature = "acl", windows))]
+    {
+        let applied = crate::acl_windows::apply_sddl_from_xattrs(destination, xattr_list)?;
+        if applied {
+            applied_names.insert(crate::acl_windows::WINDOWS_SDDL_XATTR_NAME.to_vec());
+        }
+    }
+
     for entry in xattr_list.iter() {
         // Skip abbreviated entries - they only contain a checksum, not the actual value
         if entry.is_abbreviated() {
@@ -234,6 +247,14 @@ pub fn apply_xattrs_from_list(
 
         let name_str = entry.name_str();
         if !is_xattr_permitted(&name_str) {
+            continue;
+        }
+
+        // Skip the reserved SDDL slot on every platform: Windows has
+        // already applied it via the DACL path, POSIX targets do not have
+        // a corresponding native sink.
+        if is_reserved_sddl_xattr(entry.name()) {
+            applied_names.insert(entry.name().to_vec());
             continue;
         }
 
@@ -255,6 +276,18 @@ pub fn apply_xattrs_from_list(
     }
 
     Ok(())
+}
+
+/// Reserved xattr name carrying the Windows SDDL fidelity payload.
+///
+/// Defined here as a const so non-Windows builds (which do not compile
+/// `acl_windows`) can still recognise and skip the slot.
+const RESERVED_SDDL_XATTR: &[u8] = b"user.win32.security_descriptor";
+
+/// Returns `true` when `name` matches the reserved SDDL xattr slot used
+/// to carry full Windows security descriptors over the wire.
+fn is_reserved_sddl_xattr(name: &[u8]) -> bool {
+    name == RESERVED_SDDL_XATTR
 }
 
 #[cfg(test)]

--- a/crates/transfer/src/generator/file_list/entry.rs
+++ b/crates/transfer/src/generator/file_list/entry.rs
@@ -193,6 +193,26 @@ impl GeneratorContext {
             }
         }
 
+        // Windows ACL collection: when --acls is on (and on Windows the
+        // `acl` feature is compiled in) read the full SDDL security
+        // descriptor and attach it to the entry under the reserved
+        // `user.win32.security_descriptor` xattr slot. The receiver routes
+        // the slot through `apply_sddl_from_xattrs` so Windows->Windows
+        // transfers preserve the descriptor verbatim; non-Windows
+        // receivers drop the slot.
+        #[cfg(all(feature = "acl", windows))]
+        if self.config.flags.acls {
+            let should_read = file_type.is_file() || file_type.is_dir();
+            if should_read {
+                if let Ok(Some(sddl_entry)) = metadata::sddl_xattr_entry(full_path) {
+                    let mut list = entry.xattr_list().cloned().unwrap_or_default();
+                    list.push(sddl_entry);
+                    list.sort_by_name();
+                    entry.set_xattr_list(list);
+                }
+            }
+        }
+
         Ok(entry)
     }
 }


### PR DESCRIPTION
## Summary

- Routes the Windows `--acls` apply path through `acl_windows::read_dacl_sddl` / `write_dacl_sddl` (WAS-2/3, #4354) so DACL preservation rides the full SDDL fidelity payload instead of re-encoding only the named ACEs.
- Reserves `user.win32.security_descriptor` (matches Samba's NT-ACL slot) inside the existing xattr stream as the carrier for the SDDL string - no wire-protocol changes.
- Generator (`crates/transfer/src/generator/file_list/entry.rs`): when `--acls` is on and built with `feature = "acl"` on Windows, appends `metadata::sddl_xattr_entry(path)` to the per-entry `XattrList`.
- Receiver (`crates/metadata/src/xattr.rs::apply_xattrs_from_list`): intercepts the reserved slot. On Windows dispatches to `apply_sddl_from_xattrs` -> `write_dacl_sddl`; on POSIX silently drops it so the standard cross-platform ACL payload (from `crates/protocol/src/acl/wire`) still drives the lowered POSIX bits via WAS-4 (#4361) `dacl_to_posix_mode`.
- Local Windows-to-Windows `sync_acls` now prefers the SDDL round-trip and falls back to the lossy named-ACE encoder only on volumes that refuse to serve a descriptor (FAT32, network mounts).
- Brings the WAS-4 `dacl_to_posix_mode` / `posix_mode_to_dacl` helpers in alongside the WAS-5 wiring so the dispatch shape is self-contained; this PR can land before or after #4361 (overlapping definitions will fold cleanly).

## Dispatch shape

```
generator (Windows + --acls)
  -> metadata::sddl_xattr_entry(path)              // WAS-5
       -> acl_windows::read_dacl_sddl(path)        // WAS-2/3
       -> XattrEntry { name = "user.win32.security_descriptor", value = SDDL }
  -> XattrList.push, sort_by_name, set_xattr_list

receiver (Windows)
  apply_xattrs_from_list(dest, list)
    -> acl_windows::apply_sddl_from_xattrs(dest, list)        // WAS-5
         -> acl_windows::find_sddl_in_xattrs(list)            // WAS-5
         -> acl_windows::write_dacl_sddl(dest, sddl)          // WAS-2/3
    -> skip the reserved slot in the per-attribute write loop

receiver (POSIX)
  apply_xattrs_from_list(dest, list)
    -> skip the reserved slot (handled at higher layer via
       acl_exacl::apply_acls_from_cache reading the cross-platform
       RsyncAcl payload, with acl_windows::dacl_to_posix_mode
       available for the design-doc 5.1 lowering)
```

## Test plan

- [ ] CI fmt + clippy across the workspace (already `cargo fmt --all`).
- [ ] CI nextest stable on Linux, macOS, Windows, musl:
  - [ ] `find_sddl_in_xattrs_returns_payload` / `_returns_none_when_missing` / `_skips_abbreviated_entries`
  - [ ] `apply_sddl_from_xattrs_no_payload_is_noop`
  - [ ] `round_trip_full_mode_matrix_preserves_rwx` (0o000..=0o777 round-trip via WAS-4 helpers)
  - [ ] `dacl_to_posix_mode_*` set (Everyone, Authenticated Users fallback, deny drop, inherited drop, non-rwx collapse)
- [ ] CI nextest Windows-only on `windows-latest` (NTFS):
  - [ ] `sddl_xattr_entry_round_trips_on_ntfs` (seed -> encode -> apply -> read-back)
  - [ ] `sync_acls_prefers_sddl_round_trip`
  - [ ] Existing `write_dacl_sddl_round_trips_known_descriptor` still passes (regression guard).