### PR TITLE
feat(engine): opt-in io_uring data-write dispatch for large files (IUD-5)

### DIFF
--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -120,6 +120,13 @@ thread-slab-pool = []
 # production builds remain byte-identical to today.
 iouring-data-reads = ["fast_io/iouring-data-reads"]
 
+# iouring-data-writes (IUD-5) - opt-in dispatch in local-copy that routes
+# large whole-file writes through `fast_io::write_file_with_io_uring`. Pass-
+# through to the same-named feature on `fast_io`; default off so production
+# builds are byte-identical. Linux-only at runtime; on every other platform
+# the dispatch branch falls through to the existing copy path.
+iouring-data-writes = ["fast_io/iouring-data-writes"]
+
 # ============================================================================
 # Runtime Features
 # ============================================================================

--- a/crates/engine/src/local_copy/context_impl/state.rs
+++ b/crates/engine/src/local_copy/context_impl/state.rs
@@ -125,7 +125,7 @@ impl<'a> CopyContext<'a> {
     }
 
     /// Records that forward progress was made, resetting the timeout clock.
-    pub(super) fn register_progress(&mut self) {
+    pub(in crate::local_copy) fn register_progress(&mut self) {
         self.last_progress = Instant::now();
     }
 
@@ -189,8 +189,7 @@ impl<'a> CopyContext<'a> {
     }
 
     /// Returns whether a bandwidth limiter is active.
-    #[cfg(target_os = "macos")]
-    pub(super) const fn has_bandwidth_limiter(&self) -> bool {
+    pub(in crate::local_copy) const fn has_bandwidth_limiter(&self) -> bool {
         self.limiter.is_some()
     }
 

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/execute.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/execute.rs
@@ -415,6 +415,100 @@ pub(in crate::local_copy) fn execute_transfer(
         destination,
     );
 
+    // IUD-5 opt-in: route eligible whole-file writes through the io_uring
+    // registered-buffer path. Limited to the `Direct` write strategy so the
+    // wrapper's path-based signature lands the bytes at the same inode the
+    // standard path would have produced - no temp file rename, no inplace
+    // overwrite, no append seek. Default builds skip this branch entirely.
+    #[cfg(all(target_os = "linux", feature = "iouring-data-writes"))]
+    {
+        const IOURING_DATA_WRITES_MIN_BYTES: u64 = 1024 * 1024;
+        let eligible = matches!(strategy, super::write_strategy::WriteStrategy::Direct)
+            && delta_signature.is_none()
+            && !use_sparse_writes
+            && !compress_enabled
+            && !context.has_bandwidth_limiter()
+            && append_offset == 0
+            && file_size >= IOURING_DATA_WRITES_MIN_BYTES;
+        if eligible {
+            let dispatch_result = dispatch_iouring_data_write(
+                context,
+                &mut reader,
+                copy_source,
+                destination,
+                file_size,
+                start_iouring_data_write(),
+            )?;
+            if dispatch_result.is_none() {
+                // io_uring path unavailable: rewind the reader so the
+                // standard copy loop starts from byte 0. The dispatch helper
+                // may have drained the source via `read_to_end`.
+                reader
+                    .seek(SeekFrom::Start(0))
+                    .map_err(|error| LocalCopyError::io("copy file", copy_source, error))?;
+            }
+            if let Some(outcome) = dispatch_result {
+                let elapsed = outcome.elapsed;
+                context.capture_batch_whole_file(copy_source, file_size)?;
+                context.finalize_batch_file_delta(copy_source)?;
+                context.register_created_path(
+                    destination,
+                    CreatedEntryKind::File,
+                    destination_previously_existed,
+                );
+                context.record_hard_link(metadata, destination);
+                context
+                    .summary_mut()
+                    .record_file(file_size, file_size, None);
+                context.summary_mut().record_elapsed(elapsed);
+                let metadata_snapshot = LocalCopyMetadata::from_metadata(metadata, None);
+                let total_bytes = Some(metadata_snapshot.len());
+                let change_set = LocalCopyChangeSet::for_file(
+                    metadata,
+                    existing_metadata,
+                    &metadata_options,
+                    destination_previously_existed,
+                    true,
+                    flags.xattrs_enabled(),
+                    flags.acls_enabled(),
+                );
+                context.record(
+                    LocalCopyRecord::new(
+                        record_path.to_path_buf(),
+                        LocalCopyAction::DataCopied,
+                        file_size,
+                        total_bytes,
+                        elapsed,
+                        Some(metadata_snapshot),
+                    )
+                    .with_change_set(change_set)
+                    .with_creation(true),
+                );
+                let mut writer_for_metadata: Option<fs::File> = None;
+                finalize_guard_and_metadata(
+                    context,
+                    None,
+                    destination,
+                    metadata,
+                    metadata_options.clone(),
+                    mode,
+                    source,
+                    record_path,
+                    relative,
+                    file_type,
+                    destination_previously_existed,
+                    false,
+                    &mut writer_for_metadata,
+                    #[cfg(all(unix, feature = "xattr"))]
+                    preserve_xattrs,
+                    #[cfg(all(any(unix, windows), feature = "acl"))]
+                    preserve_acls,
+                )?;
+                return Ok(());
+            }
+        }
+    }
+
     let mut writer = open_destination_writer(
         context,
         destination,
@@ -854,4 +948,66 @@ fn normalize_cloned_metadata(
     }
 
     Ok(())
+}
+
+/// IUD-5 opt-in: outcome of the io_uring data-write dispatch helper.
+///
+/// `bytes` is always the full source size on success; `elapsed` is measured
+/// from the moment the dispatch starts so the caller can record it in the
+/// transfer summary.
+#[cfg(all(target_os = "linux", feature = "iouring-data-writes"))]
+struct IoUringDataWriteOutcome {
+    elapsed: Duration,
+}
+
+/// Returns the start instant for an io_uring data-write dispatch.
+///
+/// Wrapped in a function so the helper has a single source of truth and the
+/// dispatch site stays focused on the eligibility check.
+#[cfg(all(target_os = "linux", feature = "iouring-data-writes"))]
+fn start_iouring_data_write() -> Instant {
+    Instant::now()
+}
+
+/// Reads `source` into memory, then writes via `fast_io::write_file_with_io_uring`.
+///
+/// Returns `Ok(None)` when the io_uring backend is unavailable at runtime so
+/// the caller transparently falls back to the standard copy path. Returns
+/// `Ok(Some(...))` on a successful write through the registered-buffer path.
+///
+/// Probes [`fast_io::is_io_uring_available`] up front so kernels that lack
+/// io_uring or environments that block `io_uring_setup(2)` (seccomp, missing
+/// MEMLOCK headroom, etc.) skip the path silently rather than failing the
+/// transfer. Any error after a successful submission is surfaced unchanged so
+/// real disk failures still abort the file.
+#[cfg(all(target_os = "linux", feature = "iouring-data-writes"))]
+fn dispatch_iouring_data_write(
+    context: &mut CopyContext,
+    reader: &mut fs::File,
+    copy_source: &Path,
+    destination: &Path,
+    file_size: u64,
+    start: Instant,
+) -> Result<Option<IoUringDataWriteOutcome>, LocalCopyError> {
+    use std::io::Read;
+
+    if !fast_io::is_io_uring_available() {
+        return Ok(None);
+    }
+
+    let mut buf = Vec::with_capacity(file_size as usize);
+    reader
+        .read_to_end(&mut buf)
+        .map_err(|error| LocalCopyError::io("copy file", copy_source, error))?;
+
+    match fast_io::write_file_with_io_uring(destination, &buf) {
+        Ok(()) => {
+            context.register_progress();
+            Ok(Some(IoUringDataWriteOutcome {
+                elapsed: start.elapsed(),
+            }))
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::Unsupported => Ok(None),
+        Err(error) => Err(LocalCopyError::io("copy file", destination, error)),
+    }
 }

--- a/crates/fast_io/Cargo.toml
+++ b/crates/fast_io/Cargo.toml
@@ -108,11 +108,14 @@ adaptive-basis-dispatch = []
 # for the full design.
 iouring-send-zc = ["io_uring"]
 
-# iouring-data-writes: opt-in dispatch that routes large file writes through
-# the production io_uring writer wrapper (`fast_io::write_file_with_io_uring`).
-# Wired by IUD-5; declared here so the `nvme_data_path_production` bench
-# (IUD-9 #2369) can list it under `required-features`. Linux-only at runtime;
-# on every other platform the entry point returns `io::ErrorKind::Unsupported`.
+# iouring-data-writes: opt-in dispatch that routes large local-copy file writes
+# through the io_uring registered-buffer write path (`IoUringFileWriter` +
+# `RegisteredBufferPool`). Default off; consumers must explicitly enable both
+# `io_uring` and `iouring-data-writes` to engage the path. Linux-only at
+# runtime via the existing `is_io_uring_available()` probe; on every other
+# platform the entry point returns `io::ErrorKind::Unsupported`. Wired by
+# IUD-5; also referenced by the `nvme_data_path_production` bench (IUD-9
+# #2369). See docs/design/iouring-receive-data-path.md.
 iouring-data-writes = ["io_uring"]
 
 [target.'cfg(windows)'.dependencies]

--- a/crates/fast_io/src/io_uring/mod.rs
+++ b/crates/fast_io/src/io_uring/mod.rs
@@ -376,3 +376,35 @@ pub fn write_file<P: AsRef<std::path::Path>>(path: P, data: &[u8]) -> io::Result
     writer.flush()?;
     Ok(())
 }
+
+/// Writes `data` to `path` through the io_uring registered-buffer write path.
+///
+/// Thin wrapper over the existing [`IoUringWriter`] + [`RegisteredBufferGroup`]
+/// machinery: opens the destination via `IoUringWriter::create`, calls
+/// `write_all` (which engages `IORING_OP_WRITE_FIXED` whenever the kernel
+/// accepted buffer registration), then `flush` + `sync` to make the bytes
+/// durable. No new submission helper is introduced; everything routes through
+/// the same paths used by the live receiver disk thread.
+///
+/// Gated by `feature = "iouring-data-writes"` and `target_os = "linux"`. The
+/// stub on every other configuration returns `io::ErrorKind::Unsupported` so
+/// callers can dispatch via a single `cfg`-free call site and fall back when
+/// the kernel path is not compiled in.
+///
+/// # Errors
+///
+/// Returns the underlying [`io::Error`] from ring construction, file creation,
+/// SQE submission, or fsync. When io_uring is unavailable at runtime (kernel
+/// pre-5.6, seccomp-blocked, or `io_uring_setup` rejection), the error is
+/// surfaced as-is; the caller is expected to handle the fallback rather than
+/// silently degrading to standard I/O.
+#[cfg(all(target_os = "linux", feature = "iouring-data-writes"))]
+pub fn write_file_with_io_uring(path: &std::path::Path, data: &[u8]) -> io::Result<()> {
+    use crate::traits::FileWriter;
+
+    let config = IoUringConfig::default();
+    let mut writer = IoUringWriter::create(path, &config)?;
+    writer.write_all(data)?;
+    writer.flush()?;
+    writer.sync()
+}

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -306,6 +306,38 @@ pub use io_uring::{
 #[cfg(feature = "iouring-send-zc")]
 pub use io_uring::{SEND_ZC_DISPATCH_MIN_BYTES, ZeroCopySender};
 
+/// Writes `data` to `path` via the io_uring registered-buffer write path.
+///
+/// When compiled with both `target_os = "linux"` and the
+/// `iouring-data-writes` feature, this dispatches to the live
+/// [`io_uring::write_file_with_io_uring`] helper which reuses
+/// [`io_uring::IoUringWriter`] and the registered-buffer pool. On every other
+/// configuration, the function returns `io::ErrorKind::Unsupported` so
+/// callers can fall back to their existing copy path.
+///
+/// # Errors
+///
+/// Returns `io::ErrorKind::Unsupported` when the platform or feature gate
+/// disables the io_uring data-write path. On Linux with the feature on,
+/// propagates ring-construction, submission, and fsync errors from the
+/// underlying writer.
+#[cfg(all(target_os = "linux", feature = "iouring-data-writes"))]
+pub fn write_file_with_io_uring(path: &std::path::Path, data: &[u8]) -> std::io::Result<()> {
+    io_uring::write_file_with_io_uring(path, data)
+}
+
+/// Stub for non-Linux targets or when `iouring-data-writes` is disabled.
+///
+/// Always returns `io::ErrorKind::Unsupported`. Callers should treat this
+/// outcome as the signal to use their standard write path.
+#[cfg(not(all(target_os = "linux", feature = "iouring-data-writes")))]
+pub fn write_file_with_io_uring(_path: &std::path::Path, _data: &[u8]) -> std::io::Result<()> {
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "iouring-data-writes feature is not enabled for this build",
+    ))
+}
+
 pub use io_uring_common::IoBackend;
 pub use io_uring_depth::{
     IO_URING_DEPTH_MAX, IO_URING_DEPTH_MIN, IoUringDepthError, validate_io_uring_depth,

--- a/crates/fast_io/tests/iouring_data_writes_dispatch.rs
+++ b/crates/fast_io/tests/iouring_data_writes_dispatch.rs
@@ -1,0 +1,64 @@
+//! IUD-5 round-trip integration test for `write_file_with_io_uring`.
+//!
+//! Writes a 4 MiB pseudo-random payload through the opt-in io_uring
+//! registered-buffer wrapper, then re-reads the destination with
+//! `std::fs::read` and asserts byte-identical output. The test runs only on
+//! Linux with both the `io_uring` and `iouring-data-writes` features compiled
+//! in, and skips gracefully when the kernel rejects ring construction (older
+//! than 5.6, seccomp-restricted container, etc.).
+
+#![cfg(all(target_os = "linux", feature = "iouring-data-writes"))]
+
+use std::fs;
+
+use fast_io::{is_io_uring_available, write_file_with_io_uring};
+use tempfile::tempdir;
+
+/// Builds a deterministic pseudo-random buffer using a 64-bit LCG so the
+/// payload survives test-to-test reproducibility without pulling in `rand`.
+fn pseudo_random_payload(len: usize, seed: u64) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(len);
+    let mut state = seed.wrapping_mul(0x9E37_79B9_7F4A_7C15);
+    while buf.len() < len {
+        state = state
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        buf.extend_from_slice(&state.to_le_bytes());
+    }
+    buf.truncate(len);
+    buf
+}
+
+#[test]
+fn write_file_with_io_uring_round_trip_4mib() {
+    if !is_io_uring_available() {
+        eprintln!("io_uring unavailable on this host; skipping IUD-5 dispatch test");
+        return;
+    }
+
+    let dir = tempdir().expect("tempdir");
+    let dst = dir.path().join("iud5_payload.bin");
+
+    let payload = pseudo_random_payload(4 * 1024 * 1024, 0xC0FF_EE00_BEEF_F00D);
+    write_file_with_io_uring(&dst, &payload).expect("io_uring write must succeed");
+
+    let read_back = fs::read(&dst).expect("read destination");
+    assert_eq!(
+        read_back.len(),
+        payload.len(),
+        "destination size must match payload"
+    );
+    assert_eq!(read_back, payload, "round-trip must be byte-identical");
+}
+
+#[test]
+fn write_file_with_io_uring_creates_empty_file() {
+    if !is_io_uring_available() {
+        return;
+    }
+    let dir = tempdir().expect("tempdir");
+    let dst = dir.path().join("iud5_empty.bin");
+    write_file_with_io_uring(&dst, &[]).expect("zero-length write must succeed");
+    let meta = fs::metadata(&dst).expect("stat destination");
+    assert_eq!(meta.len(), 0, "destination must be zero-length");
+}


### PR DESCRIPTION
## Summary
- New `iouring-data-writes` Cargo feature on `fast_io` (depends on `io_uring`, off by default).
- New thin wrapper `fast_io::write_file_with_io_uring` reusing existing `IoUringWriter` + `RegisteredBufferPool` - no parallel implementation.
- Single opt-in dispatch branch in `crates/engine/src/local_copy/executor/file/copy/transfer/execute.rs` routes files >= 1 MiB through the io_uring path when feature is on + Linux + `Direct` write strategy; default path unchanged.
- Byte-identical round-trip test in `crates/fast_io/tests/iouring_data_writes_dispatch.rs` (Linux + feature on).

## Test plan
- [x] `cargo fmt --all` clean
- [x] Default builds unchanged (no opt-in)
- [x] Feature on + Linux: 4 MiB round-trip byte-identical