### PR TITLE
feat(engine): SpillPolicy.reclaim - KeepInMemory vs RespillAfterRead (STN-4 #2338)

### DIFF
--- a/crates/engine/src/concurrent_delta/mod.rs
+++ b/crates/engine/src/concurrent_delta/mod.rs
@@ -195,7 +195,9 @@ pub use consumer::{DeltaConsumer, DeltaConsumerStats};
 #[cfg(feature = "parallel-receive-delta")]
 pub use parallel_apply::{DeltaChunk, ParallelDeltaApplier};
 pub use reorder::{HistogramStats, Metrics as ReorderMetrics, ReorderBuffer};
-pub use spill::policy::{ReclaimMode, SpillCompression, SpillGranularity, SpillPolicy};
+pub use spill::policy::{
+    ReclaimMode, SpillCompression, SpillGranularity, SpillPolicy, SpillReclaim,
+};
 pub use spill::{SpillCodec, SpillError, SpillStats, SpillableReorderBuffer};
 pub use strategy::{DeltaStrategy, DeltaTransferStrategy, WholeFileStrategy};
 pub use types::{DeltaResult, DeltaResultStatus, DeltaWork, DeltaWorkKind, FileNdx};

--- a/crates/engine/src/concurrent_delta/spill/mod.rs
+++ b/crates/engine/src/concurrent_delta/spill/mod.rs
@@ -77,7 +77,7 @@ pub mod stats;
 pub use env::{
     ENV_SPILL_COMPRESSION, ENV_SPILL_DIR, ENV_SPILL_THRESHOLD_BYTES, apply_env_overrides,
 };
-pub use policy::{ReclaimMode, SpillCompression, SpillGranularity, SpillPolicy};
+pub use policy::{ReclaimMode, SpillCompression, SpillGranularity, SpillPolicy, SpillReclaim};
 pub use stats::SpillStats;
 
 mod tempfile;
@@ -216,6 +216,10 @@ pub struct SpillableReorderBuffer<T: SpillCodec> {
     /// (the default) keeps the historical raw-byte format. `Zstd` is only
     /// constructable behind the `spill-compression` Cargo feature.
     compression: SpillCompression,
+    /// Post-read reclaim behaviour. Default keeps the historical "spill once,
+    /// drain freely" path; [`SpillReclaim::RespillAfterRead`] enables the
+    /// post-reload `spill_excess` pass.
+    reclaim: SpillReclaim,
 }
 
 impl<T: SpillCodec> std::fmt::Debug for SpillableReorderBuffer<T> {
@@ -231,6 +235,7 @@ impl<T: SpillCodec> std::fmt::Debug for SpillableReorderBuffer<T> {
             .field("dir_recreate_count", &self.dir_recreate_count)
             .field("granularity", &self.granularity)
             .field("compression", &self.compression)
+            .field("reclaim", &self.reclaim)
             .finish()
     }
 }
@@ -261,6 +266,7 @@ impl<T: SpillCodec> SpillableReorderBuffer<T> {
             reload_count: 0,
             dir_recreate_count: 0,
             compression: SpillCompression::None,
+            reclaim: SpillReclaim::default(),
         }
     }
 
@@ -299,6 +305,7 @@ impl<T: SpillCodec> SpillableReorderBuffer<T> {
             reload_count: 0,
             dir_recreate_count: 0,
             compression: SpillCompression::None,
+            reclaim: SpillReclaim::default(),
         })
     }
 
@@ -348,6 +355,24 @@ impl<T: SpillCodec> SpillableReorderBuffer<T> {
     #[must_use]
     pub fn compression(&self) -> SpillCompression {
         self.compression
+    }
+
+    /// Updates the post-read reclaim policy in place.
+    pub fn set_reclaim(&mut self, reclaim: SpillReclaim) {
+        self.reclaim = reclaim;
+    }
+
+    /// Returns the configured post-read reclaim policy.
+    #[must_use]
+    pub fn reclaim(&self) -> SpillReclaim {
+        self.reclaim
+    }
+
+    /// Consuming builder that sets the post-read reclaim policy.
+    #[must_use]
+    pub fn with_reclaim(mut self, reclaim: SpillReclaim) -> Self {
+        self.reclaim = reclaim;
+        self
     }
 
     /// Inserts an item with the given sequence number.
@@ -476,6 +501,15 @@ impl<T: SpillCodec> SpillableReorderBuffer<T> {
             // the credit issued above is matched by an equal debit.
             if let Some(item) = self.inner.next_in_order() {
                 self.memory_used = self.memory_used.saturating_sub(item.estimated_size());
+                // Honour the post-read reclaim policy: under
+                // SpillReclaim::RespillAfterRead, push any in-memory residue
+                // back to disk so RSS stays bounded by `threshold` even as
+                // large reloaded batches stream through the delivery path.
+                if matches!(self.reclaim, SpillReclaim::RespillAfterRead)
+                    && self.memory_used > self.threshold
+                {
+                    self.spill_excess()?;
+                }
                 return Ok(Some(item));
             }
             debug_assert!(false, "force_insert at next_expected must succeed");
@@ -496,6 +530,17 @@ impl<T: SpillCodec> SpillableReorderBuffer<T> {
             result.is_some(),
             "force_insert at next_expected must succeed"
         );
+
+        // Honour the post-read reclaim policy: under
+        // SpillReclaim::RespillAfterRead, push any in-memory residue back to
+        // disk so RSS stays bounded by `threshold` even as large batches
+        // stream through the reload path.
+        if matches!(self.reclaim, SpillReclaim::RespillAfterRead)
+            && self.memory_used > self.threshold
+        {
+            self.spill_excess()?;
+        }
+
         Ok(result)
     }
 
@@ -1467,6 +1512,135 @@ mod tests {
         let expected: Vec<u64> = (0..16).map(|i| i * 11).collect();
         assert_eq!(items, expected);
         assert!(buf.spill_stats().spill_events > 0);
+    }
+
+    /// Builds a buffer in a state where the next `next_in_order` call must
+    /// reload from disk AND memory_used is above threshold. Inserts seed
+    /// items, then forces additional items into the inner ring at
+    /// sequences high enough that they stay resident (the hot zone
+    /// preserves them) while the next_expected sequence is on disk.
+    fn seed_post_reload_state(buf: &mut SpillableReorderBuffer<u64>) {
+        // Phase 1: insert items 0..6 (each 8 bytes) reverse so item 0 lands
+        // in memory and items 5,4,... pressure-spill to disk.
+        for i in (0..6).rev() {
+            buf.insert(i, i * 100).unwrap();
+        }
+        // Drain the in-memory hot-zone item at next_expected so the next
+        // delivery must come from the spill file.
+        while let Some(item) = buf.inner.next_in_order() {
+            buf.memory_used = buf.memory_used.saturating_sub(item.estimated_size());
+            if buf.spill_index.contains_key(&buf.inner.next_expected()) {
+                break;
+            }
+        }
+        assert!(
+            !buf.spill_index.is_empty(),
+            "fixture must leave spilled items pending"
+        );
+        // Phase 2: force-insert additional items at higher sequences so the
+        // in-memory footprint exceeds the threshold without triggering the
+        // spill_excess loop. Their sequences are above the hot zone around
+        // next_expected, so RespillAfterRead has eligible candidates.
+        let next = buf.inner.next_expected();
+        for offset in (HOT_ZONE + 1)..(HOT_ZONE + 5) {
+            let seq = next + offset;
+            buf.inner.force_insert(seq, seq * 100);
+            buf.memory_used += 8;
+        }
+        assert!(
+            buf.memory_used > buf.threshold,
+            "fixture must leave memory above threshold to exercise RespillAfterRead"
+        );
+    }
+
+    #[test]
+    fn reclaim_default_keeps_in_memory_after_read() {
+        // Default reclaim policy: after reload-from-disk delivery, the buffer
+        // does not run an extra spill_excess pass. memory_used and the spill
+        // event counter remain unchanged across the reload.
+        let mut buf: SpillableReorderBuffer<u64> = SpillableReorderBuffer::new(32, 16);
+        assert_eq!(buf.reclaim(), policy::SpillReclaim::KeepInMemory);
+
+        seed_post_reload_state(&mut buf);
+        let before = buf.spill_stats();
+        assert!(before.spill_events > 0, "fixture must spill");
+        assert!(
+            before.memory_used > buf.threshold(),
+            "fixture must leave memory above threshold"
+        );
+
+        // Reload-and-deliver one item from disk.
+        let reload_seq = buf.next_expected();
+        let item = buf
+            .next_in_order()
+            .unwrap()
+            .expect("spilled item must reload");
+        assert_eq!(item, reload_seq * 100);
+
+        let after = buf.spill_stats();
+        assert!(
+            after.reload_events > before.reload_events,
+            "reload event counter must advance"
+        );
+        assert_eq!(
+            after.spill_events, before.spill_events,
+            "KeepInMemory must not trigger an extra spill_excess pass"
+        );
+        assert_eq!(
+            after.memory_used, before.memory_used,
+            "KeepInMemory leaves the in-memory footprint untouched"
+        );
+    }
+
+    #[test]
+    fn reclaim_respill_drops_memory_and_rereads() {
+        // RespillAfterRead policy: after each reload-from-disk delivery, the
+        // buffer pushes in-memory residue back to disk so memory_used
+        // returns to threshold. The spill event counter strictly advances.
+        let mut buf: SpillableReorderBuffer<u64> = SpillableReorderBuffer::new(32, 16)
+            .with_reclaim(policy::SpillReclaim::RespillAfterRead);
+        assert_eq!(buf.reclaim(), policy::SpillReclaim::RespillAfterRead);
+
+        seed_post_reload_state(&mut buf);
+        let before = buf.spill_stats();
+        assert!(before.spill_events > 0, "fixture must spill");
+        assert!(
+            before.memory_used > buf.threshold(),
+            "fixture must leave memory above threshold"
+        );
+        let spilled_before = before.spilled_items;
+
+        // Reload-and-deliver one item from disk. The post-read reclaim path
+        // re-runs spill_excess, so the spill-event counter strictly advances
+        // and at least one further in-memory item ends up back on disk.
+        let reload_seq = buf.next_expected();
+        let item = buf
+            .next_in_order()
+            .unwrap()
+            .expect("spilled item must reload");
+        assert_eq!(item, reload_seq * 100);
+
+        let after = buf.spill_stats();
+        assert!(
+            after.reload_events > before.reload_events,
+            "reload event counter must advance"
+        );
+        assert!(
+            after.spill_events > before.spill_events,
+            "RespillAfterRead must trigger an extra spill_excess pass"
+        );
+        assert!(
+            after.memory_used <= buf.threshold(),
+            "memory must fall back under threshold after re-spill"
+        );
+        // RespillAfterRead replaces the just-reloaded entry on disk with
+        // residue evicted from memory. The post-state must contain at
+        // least one disk-resident item that was previously in RAM, proving
+        // a re-spill (re-read-able from disk) actually happened.
+        assert!(
+            after.spilled_items > spilled_before.saturating_sub(1),
+            "RespillAfterRead must leave residue spilled to disk"
+        );
     }
 
     #[test]

--- a/crates/engine/src/concurrent_delta/spill/policy.rs
+++ b/crates/engine/src/concurrent_delta/spill/policy.rs
@@ -3,11 +3,11 @@
 //! This submodule owns the user-facing knobs that select *whether* and *how*
 //! the spill layer engages: [`SpillPolicy`] aggregates the byte threshold,
 //! the on-disk scratch directory, the post-spill reclaim behaviour, the
-//! spill granularity, and the optional payload compression into a single
-//! value. The parent [`super`] module owns the runtime machinery
-//! ([`SpillableReorderBuffer`](super::SpillableReorderBuffer) and its disk
-//! I/O paths); this submodule owns only the configuration surface those
-//! paths consume.
+//! spill granularity, the optional payload compression, and the post-read
+//! reclaim choice into a single value. The parent [`super`] module owns the
+//! runtime machinery ([`SpillableReorderBuffer`](super::SpillableReorderBuffer)
+//! and its disk I/O paths); this submodule owns only the configuration
+//! surface those paths consume.
 //!
 //! The default [`SpillPolicy`] disables spilling entirely, mirroring the
 //! historical bare [`ReorderBuffer`](super::super::reorder::ReorderBuffer)
@@ -15,8 +15,11 @@
 //! [`ReclaimMode`], [`SpillGranularity`], and [`SpillCompression`] are
 //! deliberately additive: today only the defaults are wired through the
 //! consumer pipeline, and the alternatives reserve syntactic room for
-//! follow-up work without forcing another public API break. Tests below pin
-//! the defaults so downstream crates can rely on the contract.
+//! follow-up work without forcing another public API break. The
+//! [`SpillReclaim`] knob is wired through [`SpillableReorderBuffer`] and
+//! controls whether the buffer re-spills in-memory residue after each
+//! reload-from-disk delivery. Tests below pin the defaults so downstream
+//! crates can rely on the contract.
 //!
 //! Extracted as the first split off the monolithic `spill.rs`; see the
 //! `spill.rs` decomposition plan (`docs/audits/spill-rs-decomposition-plan.md`,
@@ -56,6 +59,30 @@ pub enum SpillGranularity {
     WholeBatch,
     /// Spill individual items as the budget is exceeded.
     PerItem,
+}
+
+/// Post-read reclaim behaviour for the spill layer.
+///
+/// Controls what [`SpillableReorderBuffer`](super::SpillableReorderBuffer)
+/// does immediately after reloading a spilled item from disk and delivering
+/// it to the consumer.
+///
+/// The default - [`SpillReclaim::KeepInMemory`] - matches the historical
+/// behaviour: any items that were force-inserted alongside the reload stay
+/// resident in memory. The alternative - [`SpillReclaim::RespillAfterRead`]
+/// - triggers an extra `spill_excess` pass after every successful reload so
+/// the in-memory footprint stays bounded under sustained reload traffic.
+/// Use it when many large batches stream through and RSS would otherwise
+/// drift upward over the lifetime of a long-running transfer.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
+pub enum SpillReclaim {
+    /// Reloaded items and any co-resident in-memory items remain resident
+    /// after delivery; the buffer never proactively re-spills.
+    #[default]
+    KeepInMemory,
+    /// After each reload-from-disk delivery, the buffer re-spills excess
+    /// in-memory items so RSS stays bounded by the configured threshold.
+    RespillAfterRead,
 }
 
 /// Optional compression applied to spilled payloads.
@@ -105,6 +132,9 @@ pub struct SpillPolicy {
     pub granularity: SpillGranularity,
     /// Optional payload compression for spilled bytes.
     pub compression: SpillCompression,
+    /// Post-read reclaim policy. Default [`SpillReclaim::KeepInMemory`]
+    /// preserves the historical behaviour.
+    pub reclaim: SpillReclaim,
 }
 
 impl SpillPolicy {
@@ -151,6 +181,13 @@ impl SpillPolicy {
     #[must_use]
     pub fn with_compression(mut self, compression: SpillCompression) -> Self {
         self.compression = compression;
+        self
+    }
+
+    /// Overrides the post-read reclaim policy.
+    #[must_use]
+    pub fn with_reclaim(mut self, reclaim: SpillReclaim) -> Self {
+        self.reclaim = reclaim;
         self
     }
 
@@ -204,6 +241,7 @@ mod tests {
         assert_eq!(policy.reclaim_mode, ReclaimMode::KeepInMemory);
         assert_eq!(policy.granularity, SpillGranularity::WholeBatch);
         assert_eq!(policy.compression, SpillCompression::None);
+        assert_eq!(policy.reclaim, SpillReclaim::KeepInMemory);
     }
 
     #[test]
@@ -216,6 +254,13 @@ mod tests {
         assert_eq!(ReclaimMode::default(), ReclaimMode::KeepInMemory);
         assert_eq!(SpillGranularity::default(), SpillGranularity::WholeBatch);
         assert_eq!(SpillCompression::default(), SpillCompression::None);
+        assert_eq!(SpillReclaim::default(), SpillReclaim::KeepInMemory);
+    }
+
+    #[test]
+    fn with_reclaim_overrides_default() {
+        let policy = SpillPolicy::with_threshold(2048).with_reclaim(SpillReclaim::RespillAfterRead);
+        assert_eq!(policy.reclaim, SpillReclaim::RespillAfterRead);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add `SpillReclaim` enum and `SpillPolicy.reclaim` field. Default `KeepInMemory` preserves current behavior.
- `RespillAfterRead` drops the in-memory copy of a re-read batch so RSS doesn't spike when many large batches stream through.
- Two unit tests cover both branches.

## Test plan
- [x] `cargo fmt --all` clean
- [x] Default-policy behavior identical to today (regression check)

Closes #2338.