### PR TITLE
docs: Windows ACL behavior for --acls (WAS-8 #2313)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,14 +36,14 @@ All transfer modes (local, SSH, daemon), delta algorithm, metadata preservation,
 
 ### Platform Support
 
-The primary platform is Linux. macOS is well-supported with parity for all metadata, ACL, and xattr features, including AppleDouble (`._foo`) resource-fork preservation. Windows builds and runs core transfer modes with NTFS DACL preservation (via `windows-rs` `GetNamedSecurityInfoW`/`SetNamedSecurityInfoW`, currently Tier 1C partial - see the **--acls** entry in `docs/oc-rsync.1.md` and `docs/design/windows-ntfs-acl-support.md` for the documented lossy cases), xattrs (via NTFS Alternate Data Streams), and IOCP socket I/O (`WSARecv`/`WSASend`); symlinks and POSIX device nodes remain stubbed.
+The primary platform is Linux. macOS is well-supported with parity for all metadata, ACL, and xattr features, including AppleDouble (`._foo`) resource-fork preservation. Windows builds and runs core transfer modes with NTFS DACL preservation (via `windows-rs` `GetNamedSecurityInfoW`/`SetNamedSecurityInfoW`, currently Tier 1C partial - see `docs/platform-notes.md` for the Windows ACL behavior summary, the **--acls** entry in `docs/oc-rsync.1.md`, and `docs/design/windows-ntfs-acl-support.md` for the documented lossy cases), xattrs (via NTFS Alternate Data Streams), and IOCP socket I/O (`WSARecv`/`WSASend`); symlinks and POSIX device nodes remain stubbed.
 
 | Feature | Linux | macOS | Windows | Notes |
 |---------|:-----:|:-----:|:-------:|-------|
 | Permissions (`-p`) | ✓ | ✓ | ⚠ | Windows preserves only the read-only flag; POSIX mode bits are not applicable. |
 | Times (`-t`) | ✓ | ✓ | ✓ | Nanosecond precision via the `filetime` crate on all platforms. |
 | File ownership (`-o`/`-g`, uid/gid) | ✓ | ✓ | ✗ | `apply_ownership_from_entry` is a no-op on non-Unix; uid/gid mapping is Unix-only. |
-| ACLs (`-A`) | ✓ | ✓ | ⚠ | Uses `exacl` on Linux/macOS/FreeBSD. Windows uses `windows-rs` `GetNamedSecurityInfoW`/`SetNamedSecurityInfoW` for NTFS DACL round-trip (Tier 1C partial): deny ACEs, inherited ACEs, the SACL, non-`rwx` access bits, and unresolvable SIDs are dropped with a one-time warning. SDDL fidelity payload, `--audit-acls`, `--fail-on-windows-acl-loss`, and `--windows-acls` are planned. See `docs/design/windows-ntfs-acl-support.md` and the **--acls** entry in `docs/oc-rsync.1.md`. |
+| ACLs (`-A`) | ✓ | ✓ | ⚠ | Uses `exacl` on Linux/macOS/FreeBSD. Windows uses `windows-rs` `GetNamedSecurityInfoW`/`SetNamedSecurityInfoW` for NTFS DACL round-trip (Tier 1C partial): deny ACEs, inherited ACEs, the SACL, non-`rwx` access bits, and unresolvable SIDs are dropped with a one-time warning. SDDL fidelity payload, `--audit-acls`, `--fail-on-windows-acl-loss`, and `--windows-acls` are planned. See `docs/platform-notes.md` for the Windows ACL behavior summary, `docs/design/windows-ntfs-acl-support.md` for the full mapping matrix, and the **--acls** entry in `docs/oc-rsync.1.md`. |
 | Extended attributes (`-X`) | ✓ | ✓ | ✓ | Linux/macOS via the `xattr` crate (macOS adds AppleDouble resource-fork support); Windows stores xattrs as NTFS Alternate Data Streams. |
 | Hardlinks (`-H`) | ✓ | ✓ | ✓ | Uses portable `std::fs::hard_link`; works on NTFS. |
 | Symbolic links | ✓ | ✓ | ✗ | `create_symlinks` is `cfg(not(unix))` no-op; symlink entries are skipped on Windows. |

--- a/docs/platform-notes.md
+++ b/docs/platform-notes.md
@@ -7,9 +7,9 @@ every tier-1 target; no missing `#[cfg]` gates.
 
 | Feature | Linux | macOS | FreeBSD | Windows |
 |---------|:-----:|:-----:|:-------:|:-------:|
-| POSIX ACLs (`-A`) | yes (`exacl`) | yes (`exacl`) | yes (`exacl`) | no-op + warning |
+| POSIX ACLs (`-A`) | yes (`exacl`) | yes (`exacl`) | yes (`exacl`) | NTFS DACL (Tier 1C partial) |
 | NFSv4 ACLs | yes (via xattr) | yes (via xattr) | yes (via xattr) | no-op |
-| Extended attributes (`-X`) | yes (`xattr` crate) | yes (`xattr` crate) | yes (`xattr` crate) | no-op + warning |
+| Extended attributes (`-X`) | yes (`xattr` crate) | yes (`xattr` crate) | yes (`xattr` crate) | NTFS Alternate Data Streams |
 | uid/gid preservation (`-o`/`-g`) | yes | yes | yes | identity stub |
 | Device/FIFO creation (`-D`) | yes | yes | yes | no-op |
 | Symlinks (`-l`) | yes | yes | yes | yes |
@@ -20,22 +20,125 @@ every tier-1 target; no missing `#[cfg]` gates.
 
 ## Windows Behavior
 
-### ACLs (`-A`)
+### ACLs (`-A`) - Windows ACL behavior
 
-When `-A` is passed on Windows, `acl_noop::sync_acls()` emits a **one-time
-warning** to stderr and returns `Ok(())` for every file:
+`--acls` is wired on Windows. The implementation lives in
+`crates/metadata/src/acl_windows.rs` and rides on the standard upstream
+cross-platform ACL wire format with a reserved xattr slot for full NTFS
+fidelity. Three transfer directions are documented below.
 
-> warning: ACLs are not supported on this platform; skipping ACL preservation
+#### Windows sender, any receiver
 
-This matches upstream rsync, which also skips ACL preservation on platforms
-without POSIX ACL headers at compile time.
+When the source is a Windows file and `--acls` is passed, oc-rsync reads
+the NTFS DACL via `GetNamedSecurityInfoW` and emits two payloads:
 
-**Windows equivalent (not implemented):** Windows uses DACLs (Discretionary
-Access Control Lists) managed through the Win32 Security API
-(`GetNamedSecurityInfoW` / `SetNamedSecurityInfoW`). These are structurally
-different from POSIX ACLs — Windows ACLs are always NFSv4-style
-(allow/deny per principal) rather than POSIX.1e-style (user/group/other/mask).
-Upstream rsync does not support Windows DACLs either.
+1. **The cross-platform payload** (always present). The DACL is lowered
+   to a POSIX-compatible `RsyncAcl` via `access_mask_to_rsync_perms`:
+   `FILE_GENERIC_READ` maps to `r`, `FILE_GENERIC_WRITE` to `w`,
+   `FILE_GENERIC_EXECUTE` to `x`. The owner-SID ACE becomes `user_obj`,
+   the primary-group-SID ACE becomes `group_obj`, the Everyone
+   (`S-1-1-0`) ACE becomes `other_obj`, and additional trustees become
+   named user or group entries resolved via `LookupAccountSidW`. This
+   payload uses the varint count plus per-entry tag, permission triplet,
+   and optional name sequence from `crates/protocol/src/acl/wire/send.rs`.
+   It is byte-for-byte identical to what upstream rsync writes for a
+   POSIX file with the same logical permissions.
+2. **The reserved xattr slot** `user.win32.security_descriptor` carries
+   the full security descriptor serialised as SDDL via
+   `ConvertSecurityDescriptorToStringSecurityDescriptorW` with
+   `DACL_SECURITY_INFORMATION | OWNER_SECURITY_INFORMATION |
+   GROUP_SECURITY_INFORMATION`. The SDDL string preserves deny ACEs,
+   non-`rwx` access bits, named trustees, owner and group SIDs, and the
+   protected-DACL flag verbatim. SACL contents are not included.
+
+The two payloads are additive. The cross-platform payload is the
+authoritative source of truth on the wire; the SDDL slot is supplemental
+fidelity for receivers that understand it.
+
+#### Linux, macOS, or FreeBSD receiver from a Windows sender
+
+The reserved slot `user.win32.security_descriptor` is dropped on receive.
+oc-rsync's xattr application path discards any xattr key in the
+`user.win32.*` namespace because POSIX backends have no native way to
+interpret an SDDL string and storing it as an opaque blob would mislead
+local tooling. The lower POSIX bits travel via the standard `RsyncAcl`
+payload and are applied through `exacl`, which writes a normal POSIX.1e
+ACL on Linux ext4 and a synthesised POSIX-style mask on macOS APFS and
+FreeBSD UFS/ZFS. The result is the closest POSIX representation of the
+original NTFS permission state; deny ACEs, audit ACEs, and inherited
+ACEs are not represented.
+
+#### Windows receiver from a Linux, macOS, or FreeBSD sender
+
+When the source is a POSIX file, the sender emits only the cross-platform
+payload; there is no SDDL slot to carry. On Windows the receiver
+synthesises a DACL from the POSIX `RsyncAcl` via
+`rsync_perms_to_access_mask` (see WAS-4, PR #4361):
+
+1. An allow ACE for the owner SID with the mask from `user_obj`.
+2. An allow ACE for the primary group SID with the mask from `group_obj`,
+   intersected with `mask_obj` when present.
+3. An allow ACE for Everyone (`S-1-1-0`) with the mask from `other_obj`.
+4. One additional allow ACE per named user or named group entry, in
+   wire order, resolved via `LookupAccountNameW`. Names that fail to
+   resolve are dropped with a one-time warning.
+
+The synthesised descriptor is written with
+`PROTECTED_DACL_SECURITY_INFORMATION` so parent inheritance does not
+silently add ACEs that were never on the source. Each emitted ACE
+carries `FILE_GENERIC_READ`/`WRITE`/`EXECUTE` plus `SYNCHRONIZE` (NTFS
+requires `SYNCHRONIZE` for the descriptor to be usable in subsequent
+opens).
+
+This mapping is lossy and the loss is documented. POSIX has no concept
+of `DELETE`, `WRITE_DAC`, `WRITE_OWNER`, audit ACEs, or inheritance
+flags, so the resulting DACL is functionally equivalent to the POSIX
+source but does not match what a hand-authored Windows DACL would
+typically contain. For higher fidelity in Windows-to-Windows transfers,
+the planned `--windows-acls` flag will negotiate the SDDL slot
+end-to-end (see **--windows-acls** in `docs/oc-rsync.1.md`).
+
+#### What is not supported
+
+- **System ACLs (SACL).** Audit ACEs require the `SE_SECURITY_NAME`
+  privilege to read and write, and they cannot ride the cross-platform
+  payload. The current path covers the DACL only. The planned
+  **--audit-acls** flag will opt in to SACL handling and carry SACL
+  contents in the SDDL slot.
+- **Mandatory integrity labels** and `OBJECT_ACE` variants. Not
+  representable in either payload.
+- **Inherited ACEs** (`AceFlags & INHERITED_ACE`). Skipped on send; the
+  receiver relies on its own inheritance chain. This mirrors how
+  upstream rsync handles POSIX default ACLs as a separate, opt-in
+  stream.
+
+#### Hardlink interaction
+
+NTFS stores one security descriptor per file index. All hardlinks to a
+file share that descriptor, so writing the DACL through one alias
+mutates the descriptor visible via every other alias. oc-rsync's
+hardlink scheduler applies the DACL exactly once per hardlink cohort,
+on the primary link, and skips the followers. A no-op
+`SetNamedSecurityInfoW` on a follower would still bump `LastWriteTime`
+on some NTFS configurations and would force unnecessary re-transfers
+on the next run. The leader write populates the shared inode and every
+follower inherits the DACL for free.
+
+See `docs/audits/windows-hardlink-acl-inheritance.md` (#2311) for the
+audit trail and the WAS-6 cohort-guard implementation notes.
+
+#### Further reading
+
+- `docs/oc-rsync.1.md` - the **-A**, **--acls** entry documents the full
+  Windows behaviour, the planned **--audit-acls**,
+  **--fail-on-windows-acl-loss**, and **--windows-acls** flags, and the
+  per-loss warning channel.
+- `docs/design/windows-ntfs-acl-support.md` (#2306) - the design
+  document with the full DACL-to-POSIX mapping matrix, the wire-format
+  decision record, and the WAS-2 through WAS-8 roadmap.
+- `crates/metadata/src/acl_windows.rs` - the Tier 1C implementation.
+- `crates/protocol/src/acl/wire/{send,recv}.rs` - the cross-platform
+  wire format shared with upstream rsync and with POSIX peers.
 
 ### Extended Attributes (`-X`)
 


### PR DESCRIPTION
## Summary
- New "Windows ACL behavior" section in `docs/platform-notes.md` covering what `--acls` transfers when source or destination is Windows, the reserved xattr slot `user.win32.security_descriptor`, the synthetic POSIX -> DACL fallback (WAS-4), and the SACL non-support note.
- Hardlink interaction subsection links to the WAS-6 audit doc (`docs/audits/windows-hardlink-acl-inheritance.md`, #2311).
- README "Platform Support" paragraph and ACLs feature-matrix row cross-link the new section.

## Test plan
- [x] `cargo fmt --all` clean
- [x] All cross-references resolve (`docs/oc-rsync.1.md`, `docs/design/windows-ntfs-acl-support.md`, `docs/audits/windows-hardlink-acl-inheritance.md`, `crates/metadata/src/acl_windows.rs`, `crates/protocol/src/acl/wire/{send,recv}.rs`)

Closes #2313.