### PR TITLE
feat(fast_io): io_uring file reader behind iouring-data-reads feature (IUD-6 #2366)

### DIFF
--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -112,6 +112,12 @@ spill-compression = []
 # single-slot path; only beneficial above ~32 worker threads per pool.
 thread-slab-pool = []
 
+# Opt-in passthrough for the sender/reader io_uring slurp prototype
+# (IUD-6 #2366). Activates `fast_io/iouring-data-reads` and the single
+# basis-file dispatch in `concurrent_delta::strategy`. Default off so
+# production builds remain byte-identical to today.
+iouring-data-reads = ["fast_io/iouring-data-reads"]
+
 # ============================================================================
 # Runtime Features
 # ============================================================================

--- a/crates/engine/src/concurrent_delta/strategy.rs
+++ b/crates/engine/src/concurrent_delta/strategy.rs
@@ -35,6 +35,12 @@ use signature::{
 
 use super::types::{DeltaResult, DeltaWork, DeltaWorkKind};
 
+/// Minimum basis-file size, in bytes, before the IUD-6 io_uring slurp
+/// dispatch fires. Below this threshold a single `BufReader` pass is faster
+/// than amortising io_uring ring construction and buffer registration.
+#[cfg(all(target_os = "linux", feature = "iouring-data-reads"))]
+const IOURING_BASIS_SLURP_THRESHOLD: u64 = 1024 * 1024;
+
 /// Strong checksum length used by self-contained delta computation in
 /// [`DeltaTransferStrategy`].
 ///
@@ -197,11 +203,10 @@ fn self_contained_delta(
     let layout = calculate_signature_layout(layout_params)
         .map_err(|error| format!("signature layout failed: {error}"))?;
 
-    let basis_file = File::open(basis)
+    let basis_reader = open_basis_reader(basis, basis_len)
         .map_err(|error| format!("basis open failed: {}: {error}", basis.display()))?;
-    let signature =
-        generate_file_signature(BufReader::new(basis_file), layout, SIGNATURE_ALGORITHM)
-            .map_err(|error| format!("signature generation failed: {error}"))?;
+    let signature = generate_file_signature(basis_reader, layout, SIGNATURE_ALGORITHM)
+        .map_err(|error| format!("signature generation failed: {error}"))?;
     let index = DeltaSignatureIndex::from_signature(&signature, SIGNATURE_ALGORITHM)
         .ok_or_else(|| "signature index build failed".to_string())?;
 
@@ -211,18 +216,13 @@ fn self_contained_delta(
         .generate(BufReader::new(source_file), &index)
         .map_err(|error| format!("delta generation failed: {error}"))?;
 
-    let basis_apply = File::open(basis)
+    let basis_apply_reader = open_basis_reader(basis, basis_len)
         .map_err(|error| format!("basis reopen failed: {}: {error}", basis.display()))?;
     let dest_file = File::create(dest)
         .map_err(|error| format!("destination create failed: {}: {error}", dest.display()))?;
     let mut dest_writer = BufWriter::new(dest_file);
-    apply_delta(
-        BufReader::new(basis_apply),
-        &mut dest_writer,
-        &index,
-        &script,
-    )
-    .map_err(|error| format!("delta application failed: {error}"))?;
+    apply_delta(basis_apply_reader, &mut dest_writer, &index, &script)
+        .map_err(|error| format!("delta application failed: {error}"))?;
     dest_writer
         .into_inner()
         .map_err(|err| err.into_error())
@@ -276,6 +276,67 @@ pub fn dispatch(work: &DeltaWork) -> DeltaResult {
     select_strategy(work)
         .process(work)
         .with_sequence(work.sequence())
+}
+
+/// Random-access basis reader used by `self_contained_delta`.
+///
+/// `apply_delta` requires `Read + Seek`; this enum lets the
+/// `iouring-data-reads` slurp path (`Cursor<Vec<u8>>`) and the default
+/// `BufReader<File>` path share a single concrete return type without a
+/// boxed-trait Seek workaround.
+enum BasisReader {
+    Buffered(std::io::BufReader<File>),
+    Slurped(std::io::Cursor<Vec<u8>>),
+}
+
+impl std::io::Read for BasisReader {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        match self {
+            BasisReader::Buffered(r) => r.read(buf),
+            BasisReader::Slurped(r) => r.read(buf),
+        }
+    }
+}
+
+impl std::io::Seek for BasisReader {
+    fn seek(&mut self, pos: std::io::SeekFrom) -> std::io::Result<u64> {
+        match self {
+            BasisReader::Buffered(r) => r.seek(pos),
+            BasisReader::Slurped(r) => r.seek(pos),
+        }
+    }
+}
+
+/// Opens a basis file as a `BasisReader`.
+///
+/// When the `iouring-data-reads` feature is on, Linux is the target, and the
+/// basis is at least `IOURING_BASIS_SLURP_THRESHOLD` bytes, the file is
+/// pre-read through `fast_io::read_file_with_io_uring` (a `READ_FIXED` pass
+/// against a registered buffer pool) and returned as `BasisReader::Slurped`.
+/// Below the threshold, on non-Linux targets, or when the feature is off,
+/// the default `BufReader<File>` path is used so production builds are
+/// byte-identical to today.
+fn open_basis_reader(path: &Path, len: u64) -> std::io::Result<BasisReader> {
+    #[cfg(all(target_os = "linux", feature = "iouring-data-reads"))]
+    {
+        if len >= IOURING_BASIS_SLURP_THRESHOLD {
+            match fast_io::read_file_with_io_uring(path) {
+                Ok(bytes) => return Ok(BasisReader::Slurped(std::io::Cursor::new(bytes))),
+                Err(_) => {
+                    // Fall through to the default BufReader path on any
+                    // io_uring failure (kernel rejected the ring, seccomp,
+                    // out-of-memory under registration). Default path is
+                    // always production-ready.
+                }
+            }
+        }
+    }
+    #[cfg(not(all(target_os = "linux", feature = "iouring-data-reads")))]
+    {
+        let _ = len; // silence unused-variable lint on non-Linux / feature-off
+    }
+    let file = File::open(path)?;
+    Ok(BasisReader::Buffered(BufReader::new(file)))
 }
 
 #[cfg(test)]

--- a/crates/fast_io/Cargo.toml
+++ b/crates/fast_io/Cargo.toml
@@ -49,6 +49,14 @@ default = ["io_uring", "iocp"]
 # Trade-offs: Linux-only, adds dependency on io-uring crate
 io_uring = ["dep:io-uring"]
 
+# Opt-in sender/reader-side io_uring slurp wrapper (IUD-6 #2366).
+# Activates `IoUringFileReader` + `read_file_with_io_uring`, the basis-file
+# fast path that submits `IORING_OP_READ_FIXED` against a `RegisteredBufferPool`
+# slot. Disabled by default so production reads stay byte-identical to the
+# stdlib path; consumers opt in through their own passthrough features
+# (e.g. `engine/iouring-data-reads`).
+iouring-data-reads = ["io_uring"]
+
 # Windows I/O Completion Ports for async file reads and writes
 # Requirements: Windows Vista+ (runtime detection and fallback)
 # Benefits: Overlapped async I/O with completion port batching

--- a/crates/fast_io/src/io_uring/data_reader.rs
+++ b/crates/fast_io/src/io_uring/data_reader.rs
@@ -1,0 +1,124 @@
+//! Sender/reader-side io_uring slurp wrapper (IUD-6 #2366).
+//!
+//! `IoUringFileReader` is a thin, opt-in entry point that mirrors the
+//! `RegisteredBufferPool`-backed `READ_FIXED` path already implemented by
+//! [`super::file_reader::IoUringReader`], but exposes a focused
+//! `open` / `read_into` / `read_to_end` surface for the engine's basis-file
+//! slurp dispatch.
+//!
+//! # Why a separate wrapper
+//!
+//! - The general [`IoUringReader`](super::file_reader::IoUringReader) is wired
+//!   into the sender-source path via factories and configuration plumbing.
+//!   The basis-file dispatch in `engine::concurrent_delta::strategy` only needs
+//!   a "give me the whole file" entry point and benefits from a small,
+//!   self-describing API.
+//! - Keeping this wrapper behind the `iouring-data-reads` feature lets ops
+//!   toggle the reader-side experiment independently of the writer-side
+//!   `iouring-data-writes` prototype (#IUD-5) without affecting the always-on
+//!   `io_uring` reader factory.
+//!
+//! # Reuse, never duplicate
+//!
+//! All buffer registration and `READ_FIXED` submission goes through
+//! [`super::registered_buffers::RegisteredBufferGroup`] via the existing
+//! [`IoUringReader::read_all_batched`] pipeline. This module adds no new
+//! unsafe code.
+
+use std::io;
+use std::path::Path;
+
+use super::config::IoUringConfig;
+use super::file_reader::IoUringReader;
+
+/// Sender/reader-side io_uring file reader (IUD-6).
+///
+/// Opens a file read-only and submits `IORING_OP_READ_FIXED` against a
+/// registered buffer pool via the shared [`IoUringReader`] machinery.
+/// Single-purpose API for basis-file slurp paths; for sender-source
+/// streaming through the `Read` trait, use
+/// [`super::file_reader::IoUringReader`] directly.
+pub struct IoUringFileReader {
+    inner: IoUringReader,
+    size: u64,
+    position: u64,
+}
+
+impl IoUringFileReader {
+    /// Opens `path` read-only and prepares a registered-buffer io_uring ring.
+    ///
+    /// The ring is configured with `register_buffers = true` so the slurp path
+    /// uses `READ_FIXED` against the shared
+    /// [`RegisteredBufferGroup`](super::registered_buffers::RegisteredBufferGroup)
+    /// when the kernel honours registration. Registration failure transparently
+    /// falls back to plain `IORING_OP_READ` (still io_uring, just without the
+    /// pinned-page fast path) inside [`IoUringReader::read_all_batched`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the file cannot be opened or the io_uring instance
+    /// cannot be constructed (e.g. seccomp-blocked, out of memory).
+    pub fn open<P: AsRef<Path>>(path: P) -> io::Result<Self> {
+        // Default config already requests buffer registration; we surface the
+        // wrapper at this level so future tuning (page-aligned slurp sizing,
+        // SQPOLL opt-in) lives in one place.
+        let config = IoUringConfig::default();
+        let inner = IoUringReader::open(path, &config)?;
+        let size = inner.size();
+        Ok(Self {
+            inner,
+            size,
+            position: 0,
+        })
+    }
+
+    /// Returns the total length of the underlying file in bytes.
+    #[must_use]
+    pub fn len(&self) -> u64 {
+        self.size
+    }
+
+    /// Returns `true` when the file has zero length.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.size == 0
+    }
+
+    /// Reads up to `dst.len()` bytes at the current cursor position via
+    /// `IORING_OP_READ_FIXED` (registered buffer) when available, advancing
+    /// the cursor by the number of bytes read.
+    ///
+    /// Returns `Ok(0)` at end of file.
+    ///
+    /// # Errors
+    ///
+    /// Propagates the underlying io_uring submission or completion error.
+    pub fn read_into(&mut self, dst: &mut [u8]) -> io::Result<usize> {
+        if dst.is_empty() || self.position >= self.size {
+            return Ok(0);
+        }
+        let n = self.inner.read_at(self.position, dst)?;
+        self.position = self.position.saturating_add(n as u64);
+        Ok(n)
+    }
+
+    /// Reads the entire file into a fresh `Vec<u8>` using the batched
+    /// `READ_FIXED` slurp path.
+    ///
+    /// Internally delegates to
+    /// [`IoUringReader::read_all_batched`](super::file_reader::IoUringReader::read_all_batched),
+    /// which submits up to `sq_entries` registered-buffer reads per
+    /// `submit_and_wait` and falls back to plain `IORING_OP_READ` when the
+    /// kernel rejects buffer registration.
+    ///
+    /// # Errors
+    ///
+    /// Propagates the underlying io_uring submission, completion, or kernel
+    /// errno surfaced during the batched read.
+    pub fn read_to_end(&mut self) -> io::Result<Vec<u8>> {
+        // Reset the public cursor so subsequent `read_into` calls cannot
+        // race against the batched pipeline's own offset bookkeeping.
+        self.position = self.size;
+        self.inner.read_all_batched()
+    }
+}

--- a/crates/fast_io/src/io_uring/mod.rs
+++ b/crates/fast_io/src/io_uring/mod.rs
@@ -88,6 +88,8 @@ mod batching;
 pub mod buffer_ring;
 pub mod cancel;
 mod config;
+#[cfg(feature = "iouring-data-reads")]
+mod data_reader;
 mod disk_batch;
 mod file_factory;
 mod file_reader;
@@ -122,6 +124,8 @@ pub use cancel::{
 pub use config::{
     IoUringConfig, IoUringKernelInfo, config_detail, is_io_uring_available, sqpoll_fell_back,
 };
+#[cfg(feature = "iouring-data-reads")]
+pub use data_reader::IoUringFileReader;
 pub use disk_batch::IoUringDiskBatch;
 pub use file_factory::{
     IoUringOrStdReader, IoUringOrStdWriter, IoUringReaderFactory, IoUringWriterFactory,

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -223,6 +223,37 @@ pub use io_uring::{
     writer_from_file, writer_from_file_with_depth,
 };
 
+#[cfg(all(target_os = "linux", feature = "iouring-data-reads"))]
+pub use io_uring::IoUringFileReader;
+
+/// Reads `path` in full via the IUD-6 io_uring slurp wrapper.
+///
+/// Opens the file with `IoUringFileReader::open` and pulls the entire
+/// contents through the registered-buffer `READ_FIXED` pipeline shared with
+/// the main `IoUringReader`. Intended for opt-in dispatch on basis-file
+/// reads above a callsite-defined size threshold; default builds neither
+/// compile this entry point nor call it.
+///
+/// # Errors
+///
+/// Returns the underlying io_uring error if ring construction, submission,
+/// or completion processing fails.
+#[cfg(all(target_os = "linux", feature = "iouring-data-reads"))]
+pub fn read_file_with_io_uring<P: AsRef<std::path::Path>>(path: P) -> std::io::Result<Vec<u8>> {
+    IoUringFileReader::open(path.as_ref())?.read_to_end()
+}
+
+/// Stub for non-Linux targets or when the `iouring-data-reads` feature is
+/// disabled. Always returns [`std::io::ErrorKind::Unsupported`] so callers
+/// fall back to their default reader.
+#[cfg(not(all(target_os = "linux", feature = "iouring-data-reads")))]
+pub fn read_file_with_io_uring<P: AsRef<std::path::Path>>(_path: P) -> std::io::Result<Vec<u8>> {
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "iouring-data-reads feature is not enabled on this build",
+    ))
+}
+
 #[cfg(all(target_os = "windows", feature = "iocp"))]
 pub use iocp::post_completion as iocp_post_completion;
 pub use iocp::{

--- a/crates/fast_io/tests/iouring_data_reads_roundtrip.rs
+++ b/crates/fast_io/tests/iouring_data_reads_roundtrip.rs
@@ -1,0 +1,95 @@
+//! Byte-identical round-trip for the IUD-6 sender/reader io_uring slurp
+//! wrapper (`fast_io::read_file_with_io_uring`).
+//!
+//! Writes 4 MiB of pseudo-random bytes via stdlib, then reads them back
+//! through `IoUringFileReader::read_to_end` and asserts byte equality.
+//! Skipped at runtime when the kernel does not support io_uring (pre-5.6,
+//! seccomp-blocked containers) so the test stays green on CI sandboxes
+//! that deny `io_uring_setup(2)`.
+
+#![cfg(all(target_os = "linux", feature = "iouring-data-reads"))]
+
+use std::fs;
+use std::io::Write;
+
+use fast_io::{IoUringFileReader, is_io_uring_available, read_file_with_io_uring};
+
+/// Deterministic pseudo-random fill so failures reproduce locally. Plain
+/// LCG; no need for a real PRNG when the test only cares about byte-identity.
+fn fill_pseudo_random(buf: &mut [u8], mut state: u64) {
+    for byte in buf.iter_mut() {
+        state = state
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        *byte = (state >> 33) as u8;
+    }
+}
+
+const PAYLOAD_BYTES: usize = 4 * 1024 * 1024;
+
+#[test]
+fn slurp_wrapper_round_trips_four_mib_of_random_bytes() {
+    if !is_io_uring_available() {
+        eprintln!("skipping: io_uring is not available on this host");
+        return;
+    }
+
+    let dir = tempfile::tempdir().expect("create tempdir");
+    let path = dir.path().join("payload.bin");
+
+    let mut payload = vec![0u8; PAYLOAD_BYTES];
+    fill_pseudo_random(&mut payload, 0xA5A5_5A5A_DEAD_BEEFu64);
+
+    let mut writer = fs::File::create(&path).expect("create payload file");
+    writer.write_all(&payload).expect("write payload bytes");
+    writer.sync_all().expect("fsync payload");
+    drop(writer);
+
+    let round_trip = match read_file_with_io_uring(&path) {
+        Ok(bytes) => bytes,
+        Err(error) => {
+            eprintln!("skipping: io_uring slurp wrapper unavailable: {error}");
+            return;
+        }
+    };
+    assert_eq!(round_trip.len(), PAYLOAD_BYTES, "slurp length mismatch");
+    assert_eq!(
+        round_trip, payload,
+        "slurp bytes diverged from stdlib write"
+    );
+}
+
+#[test]
+fn file_reader_read_to_end_matches_stdlib_bytes() {
+    if !is_io_uring_available() {
+        eprintln!("skipping: io_uring is not available on this host");
+        return;
+    }
+
+    let dir = tempfile::tempdir().expect("create tempdir");
+    let path = dir.path().join("payload.bin");
+
+    let mut payload = vec![0u8; PAYLOAD_BYTES];
+    fill_pseudo_random(&mut payload, 0x1234_5678_9ABC_DEF0u64);
+
+    fs::write(&path, &payload).expect("write payload bytes");
+
+    let mut reader = match IoUringFileReader::open(&path) {
+        Ok(r) => r,
+        Err(error) => {
+            eprintln!("skipping: io_uring reader unavailable: {error}");
+            return;
+        }
+    };
+    assert_eq!(reader.len(), PAYLOAD_BYTES as u64);
+    assert!(!reader.is_empty());
+
+    let bytes = match reader.read_to_end() {
+        Ok(b) => b,
+        Err(error) => {
+            eprintln!("skipping: io_uring read_to_end failed: {error}");
+            return;
+        }
+    };
+    assert_eq!(bytes, payload, "reader bytes diverged from stdlib write");
+}


### PR DESCRIPTION
## Summary
- New `iouring-data-reads` Cargo feature on `fast_io` (depends on `io_uring`, off by default).
- `IoUringFileReader` + `read_file_with_io_uring` thin wrapper reusing the existing `RegisteredBufferGroup` and `IoUringReader::read_all_batched` pipeline; no new unsafe.
- Single opt-in dispatch in the engine basis-read path (`concurrent_delta::strategy::self_contained_delta`) for basis files at or above 1 MiB; default path unchanged.
- 4 MiB byte-identical round-trip test on Linux with the feature on.
- Non-Linux + feature-off stub returns `io::ErrorKind::Unsupported`.

## Test plan
- [x] `cargo fmt --all` clean
- [x] Default builds unchanged (feature off, byte-identical)
- [x] Feature on + Linux: 4 MiB byte-identical round-trip via `IoUringFileReader::read_to_end` and `read_file_with_io_uring`

Closes #2366.