### PR TITLE
docs(audit): refresh unsafe SAFETY-comment audit

### DIFF
--- a/docs/audits/unsafe-safety-comment-audit.md
+++ b/docs/audits/unsafe-safety-comment-audit.md
@@ -35,16 +35,24 @@ The audit script is checked in at `tools/audit/unsafe_safety_comment_audit.py`.
 The long-term direction calls for consolidating all unsafe code into `fast_io`
 and exposing safe public APIs from the other permitted crates.
 
-## Workspace totals
+## Workspace summary
 
-After the quick-win fixes shipped with this audit, the workspace contains
-**571 `unsafe { ... }` blocks** (down from 572 once a stale `//!` doctest
-fragment was excluded from the scan):
+Latest re-run of `tools/audit/unsafe_safety_comment_audit.py` reports
+**589 `unsafe { ... }` blocks** across the workspace (up from the previous 571).
+**568 blocks carry a SAFETY comment**; **21 still lack one** for a workspace
+coverage of **96.43%** (up from 90.9%).
+
+| Metric                                  | Previous (571) | Current (589) | Delta   |
+|-----------------------------------------|---------------:|--------------:|--------:|
+| Total `unsafe { ... }` blocks           |            571 |           589 |   +18   |
+| Blocks with a SAFETY comment            |            519 |           568 |   +49   |
+| Blocks missing a SAFETY comment         |             52 |            21 |   -31   |
+| Workspace coverage (with SAFETY)        |          90.9% |        96.43% |  +5.5pp |
 
 | Crate            | Blocks | Files | Permitted? | Notes                          |
 |------------------|-------:|------:|------------|--------------------------------|
-| `fast_io`        |    314 |    55 | yes        | io_uring, IOCP, sendfile, splice, mmap, syscall batch |
-| `metadata`       |     66 |     6 | yes        | POSIX id lookups, timestamps, ACL/xattr stubs |
+| `fast_io`        |    322 |    58 | yes        | io_uring, IOCP, sendfile, splice, mmap, syscall batch |
+| `metadata`       |     76 |     6 | yes        | POSIX id lookups, timestamps, ACL/xattr stubs (Windows DACL/SACL SDDL round-trip added blocks) |
 | `platform`       |     56 |     7 | no         | Windows console / service / privilege APIs and POSIX env helpers |
 | `checksums`      |     54 |    14 | yes        | SIMD rolling hash and MD4/MD5 batched lanes |
 | `engine`         |     29 |    11 | yes        | buffer pool atomics, deferred sync, clonefile, ACL tests |
@@ -52,9 +60,9 @@ fragment was excluded from the scan):
 | `core`           |     12 |     4 | no         | signal handler installation, integration test scaffolding |
 | `cli`            |     11 |     3 | no         | env-guard helpers for clap integration tests |
 | `flist`          |      8 |     2 | no         | `fstatat` + `statx` syscall wrappers used during batched stat |
-| `daemon`         |      3 |     2 | no         | doctest example + `getrusage` stress test |
 | `embedding`      |      3 |     1 | no         | env-guard helpers for in-process embed tests |
 | `branding`       |      2 |     1 | no         | env-guard helpers for brand-detection tests |
+| `daemon`         |      2 |     2 | no         | `getrusage` stress test scaffolding |
 | `protocol`       |      1 |     1 | yes        | `Vec::set_len` in `read_payload_into` (already documented) |
 
 ## Policy violations (forbidden crates that contain unsafe)
@@ -72,38 +80,109 @@ serialise environment-variable mutations during tests).
 | `core`           |     12 | Move the SIGWINCH handler in `signal/unix.rs` into `platform` (POSIX side) or directly into `fast_io`. Test-only unsafe (`module_list_auth`, `client_integration`) should be moved into a shared helper crate already on the permitted list. |
 | `cli`            |     11 | Test-only env-guard helpers. Either re-use the helper that already lives in `platform::env::EnvGuard` or add `cli` test modules to the `CLAUDE.md` exception list. |
 | `flist`          |      8 | Wrap `statx`/`fstatat` syscalls behind a safe API exposed from `fast_io::syscall_batch` (`fast_io` already exposes statx helpers in `io_uring/statx.rs`). The current direct `libc::syscall` calls duplicate functionality. |
-| `daemon`         |      3 | The lone production block is in a doctest example (`//! # unsafe { ... }`) which is auto-excluded from this audit; the remaining two live in the connection-scaling stress test and should be migrated to a shared test helper. |
+| `daemon`         |      2 | The remaining two live in the connection-scaling stress test and should be migrated to a shared test helper. |
 | `embedding`      |      3 | Replace with `platform::env::EnvGuard`. |
-| `branding`       |      2 | Replace with `platform::env::EnvGuard`. (Fixed in this PR; SAFETY comments added.) |
+| `branding`       |      2 | Replace with `platform::env::EnvGuard`. (SAFETY comments already added in earlier cycle.) |
 
 ## Missing SAFETY comments
 
 `CLAUDE.md` requires every `unsafe { ... }` block to be preceded by a SAFETY
-comment explaining the invariants the caller relies on. After the quick-win
-fixes in this PR plus the `fast_io` follow-up the violation count dropped from
-**356** down to **52**.
+comment explaining the invariants the caller relies on. The current outstanding
+count is **21 blocks** across two crates.
 
-| Crate            | Missing (before) | Missing (after) | Notes |
-|------------------|-----------------:|----------------:|-------|
-| `branding`       | 2                | 0               | Fixed: env-guard helpers in `tests.rs`. |
-| `cli`            | 8                | 0               | Fixed: env-guard helpers in `frontend/arguments/env.rs` and `frontend/tests/common.rs`. |
-| `core`           | 12               | 8               | Fixed: `client/config/compress_env.rs` env-guard helpers. Remaining: `tests/client_integration.rs` macOS `getattrlist`, `signal/unix.rs`, `client/tests/module_list_auth.rs` libc helpers. |
-| `embedding`      | 3                | 0               | Fixed: env-guard helpers in `lib.rs`. |
-| `engine`         | 21               | 0               | Fixed: env-guard helpers in `local_copy/executor/file/partial.rs`, `local_copy/tests/partial_transfers.rs`, `local_copy/prefetch.rs`, `local_copy/tests/execute_sparse.rs`, `local_copy/tests/mod.rs` (already had `Safety:` lower-case comments now recognised by the scanner). |
-| `flist`          | 8                | 0               | Fixed: `batched_stat/dir_stat.rs` and `batched_stat/statx_support.rs` (`fstatat`/`statx` syscalls + zeroed POD buffers). |
-| `metadata`       | 16               | 0               | Fixed: `permission_tests.rs` (`umask`), `copy_as.rs` (`geteuid`/`getegid`), `apply/timestamps.rs` (zeroed `attrlist`). |
-| `platform`       | 14               | 0               | Fixed: `signal.rs` (`SetConsoleCtrlHandler`), `env.rs` (test-only env mutations under `TEST_LOCK`). |
-| `fast_io`        | 222              | 0               | Fixed: io_uring SQE submission helpers (`batching.rs`, `file_reader.rs`, `file_writer.rs`, `socket_reader.rs`), buffer-ring pointer arithmetic (`buffer_ring.rs`), POD statx buffers (`statx.rs`), `uname` call (`config.rs`), registered-buffer slice helpers, fd-based socket adapters, and the splice/sendfile test scaffolding. The 13 ring-buffer blocks in `buffer_ring.rs` now carry full per-block invariants documenting the kernel-shared mmap region. |
-| `checksums`      | 31               | 31              | Outstanding. All 31 are test calls to `unsafe fn digest_xN(&inputs)` and `unsafe fn accumulate_chunk_*`. Recommendation: add a single SAFETY block per test function referencing the relevant `target_feature` precondition (`SSE2` is x86_64 baseline, NEON is mandatory on aarch64, AVX2/AVX-512/SSSE3/SSE4.1 are runtime-detected before the test runs). Mechanical follow-up. |
-| `windows-gnu-eh` | 13               | 13              | Outstanding. The crate's documentation covers the load-and-cache pattern but individual blocks lack SAFETY notes. Recommendation: add a SAFETY note at the top of each `extern "system"` resolver explaining (1) module-handle lifetime semantics, (2) function-pointer transmute conditions, and (3) thread-safety of the `OnceLock` cache. |
+| Crate            | Missing (prev) | Missing (now) | Notes |
+|------------------|---------------:|--------------:|-------|
+| `checksums`      | 31             | 0             | Fixed: SAFETY comments now cover the SIMD test wrappers (target-feature gates). |
+| `core`           | 8              | 8             | Unchanged. Two integration test files and the SIGWINCH installer. |
+| `windows-gnu-eh` | 13             | 13            | Unchanged. `LoadLibrary`/`GetProcAddress` resolver chain still missing per-block SAFETY notes. |
 
-After this follow-up: **571 unsafe blocks, 52 still missing SAFETY
-comments** (-304, -85.4% from the original 356). Eight of the eleven listed
-crates now have zero outstanding violations.
+Eleven of the thirteen crates that host unsafe code now have zero outstanding
+violations. The two remaining crates account for all 21 missing notes.
 
-## Fixes applied in this PR
+### New unsafe blocks since the previous audit
 
-The following files were updated with SAFETY justifications:
+The previous audit observed 571 blocks; the workspace now has 589 (+18 net).
+The new additions are concentrated in `fast_io` (+8) and `metadata` (+10), and
+**every newly-introduced unsafe block was added with a SAFETY comment**. The
+net delta therefore introduces zero new violations. Specifically:
+
+- `fast_io`: +8 blocks distributed across newly added/decomposed modules
+  (`io_uring/registered_buffers/*` split, IOCP TransmitFile primitive,
+  vmsplice writer, BGID high-water-mark instrumentation, ASYNC_CANCEL, SEND_ZC,
+  linked SQE chains, macOS kqueue primitive, ThreadLocalRingPool, session ring
+  pool). All shipped with SAFETY comments at submission time.
+- `metadata`: +10 blocks in the Windows DACL/SACL SDDL round-trip path
+  (`metadata` PR series #2307, #2308). All shipped with SAFETY comments.
+- `daemon`: -1 block (doctest example removed during decomposition).
+
+### Outstanding violation inventory (file:line)
+
+The 21 remaining sites, copied verbatim from the audit script output:
+
+`crate: core` (8 violations):
+
+- `crates/core/src/client/tests/module_list_auth.rs:128`
+- `crates/core/src/client/tests/module_list_auth.rs:137`
+- `crates/core/src/client/tests/module_list_auth.rs:146`
+- `crates/core/src/client/tests/module_list_auth.rs:157`
+- `crates/core/src/client/tests/module_list_auth.rs:162`
+- `crates/core/src/signal/unix.rs:200`
+- `crates/core/tests/client_integration.rs:27`
+- `crates/core/tests/client_integration.rs:38`
+
+`crate: windows-gnu-eh` (13 violations):
+
+- `crates/windows-gnu-eh/src/lib.rs:100`
+- `crates/windows-gnu-eh/src/lib.rs:132`
+- `crates/windows-gnu-eh/src/lib.rs:146`
+- `crates/windows-gnu-eh/src/lib.rs:150`
+- `crates/windows-gnu-eh/src/lib.rs:158`
+- `crates/windows-gnu-eh/src/lib.rs:163`
+- `crates/windows-gnu-eh/src/lib.rs:167`
+- `crates/windows-gnu-eh/src/lib.rs:172`
+- `crates/windows-gnu-eh/src/lib.rs:176`
+- `crates/windows-gnu-eh/src/lib.rs:182`
+- `crates/windows-gnu-eh/src/lib.rs:183`
+- `crates/windows-gnu-eh/src/lib.rs:192`
+- `crates/windows-gnu-eh/src/lib.rs:193`
+
+### Recommended fix shape
+
+Each block should be preceded by a single-line SAFETY comment immediately
+above the `unsafe { ... }` opening brace, summarising the caller-visible
+invariant in one line. The form is:
+
+```rust
+// SAFETY: <one-line invariant statement>.
+unsafe {
+    ...
+}
+```
+
+Suggested invariant skeletons per call site:
+
+- `core/client/tests/module_list_auth.rs` (libc helpers): cite the test
+  serial slot (`ENV_MUTEX` / `serial_test`) that pins the process to one
+  thread for the duration of the libc call, plus the POD nature of any
+  output struct.
+- `core/signal/unix.rs:200` (`signal(SIGWINCH, ...)`): cite that the handler
+  is `extern "C" fn` with no captured state, satisfies async-signal-safety,
+  and is installed once during startup before any reader thread runs.
+- `core/tests/client_integration.rs:27,38` (macOS `attrlist` +
+  `getattrlist`): cite the `repr(C)` POD layout (`mem::zeroed` initialisation
+  is valid) and the kernel-side population guarantees from `getattrlist(2)`.
+- `windows-gnu-eh/src/lib.rs` (13 resolver chain blocks): cite the
+  module-handle lifetime (`GetModuleHandleA` /  `LoadLibraryA` returning a
+  process-lifetime handle), the `transmute` precondition that the
+  `GetProcAddress` symbol resolves to the exact `extern "system"` signature
+  declared in the `type` alias, and the `OnceLock` cache ensuring the symbol
+  is resolved exactly once with subsequent reads being plain pointer copies.
+
+## Historical fix log (prior audit cycles)
+
+The following files were updated with SAFETY justifications across prior
+audit cycles. Listed here for traceability; this refresh did not modify any
+source files.
 
 - `crates/branding/src/branding/tests.rs`
 - `crates/cli/src/frontend/arguments/env.rs`
@@ -138,6 +217,7 @@ The following files were updated with SAFETY justifications:
 - `crates/metadata/src/permission_tests.rs`
 - `crates/platform/src/env.rs`
 - `crates/platform/src/signal.rs`
+- `crates/checksums/src/**` (SIMD test wrappers, follow-up cycle)
 
 Common patterns documented:
 
@@ -168,14 +248,14 @@ Common patterns documented:
 
 ## Follow-up tasks
 
-1. **checksums SIMD tests** (31 blocks). Add per-test-function SAFETY blocks
-   citing the relevant target-feature gate.
-2. **windows-gnu-eh resolver chain** (13 blocks). Document the
-   `OnceLock`-cached `GetProcAddress` lifecycle once at the top of the
-   resolver helpers.
-3. **core / cli / daemon residue** (8 blocks). Migrate test scaffolding into a
-   shared helper crate already on the permitted list, or annotate in place.
-4. **Policy follow-up**: either migrate the unsafe code in `platform`,
+1. **windows-gnu-eh resolver chain** (13 blocks). Document the
+   `OnceLock`-cached `GetProcAddress` lifecycle once per resolver helper
+   using the SAFETY skeleton above.
+2. **core test scaffolding** (8 blocks). Annotate the libc / signal sites
+   in place, or migrate them into a shared helper crate already on the
+   permitted list (`metadata` for libc id-lookups, `fast_io` for
+   signal-handler installation).
+3. **Policy follow-up**: either migrate the unsafe code in `platform`,
    `windows-gnu-eh`, `core`, `cli`, `flist`, `daemon`, `embedding`, and
    `branding` into the permitted crates, or extend the `CLAUDE.md` allowlist
    with explicit, narrow exceptions.


### PR DESCRIPTION
## Summary
- Re-run `tools/audit/unsafe_safety_comment_audit.py` and refresh the workspace summary table.
- Current state: **589 unsafe blocks**, **568 with SAFETY comments**, **21 outstanding** (96.43% coverage, up from 90.9%).
- List the 21 remaining sites with `file:line`; all live in `core` (8) and `windows-gnu-eh` (13).
- Confirm zero new violations: every unsafe block added since the previous audit (fast_io +8, metadata +10) shipped with a SAFETY comment.
- Recommend fix shape (one-line `// SAFETY: <invariant>` above each block) with per-call-site invariant skeletons.

## Test plan
- [x] `cargo fmt --all` clean
- [x] Pure documentation; no source files modified