### PR TITLE
docs(changelog): sync Unreleased with shipped PRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,36 @@ tags are mirrored on GitHub at <https://github.com/oferchen/rsync/releases>.
 
 ## [Unreleased]
 
+### Features
+
+- IOCP concurrent_ops auto-size based on CPU count (#4358)
+- IOCP BGID high-water mark with 50%-occupancy warning (#4355)
+- Windows TransmitFile primitive behind `--features transmitfile` (#4334)
+- Windows DACL/SACL SDDL round-trip support (#4354)
+- ssh-socketpair-stderr connection primitive in `rsync_io` (#4348)
+- SpillPolicy struct with `ConcurrentDeltaConfig` wiring (#4360)
+- SpillableReorderBuffer wiring with parallel receive delta apply (#4319)
+- lock_or_recover helpers for Mutex poison recovery in engine (#4342)
+
+### Refactoring
+
+- Decompose `delete/emitter.rs` into focused submodules (#4312)
+- Decompose `buffer_pool/tests.rs` by concern (#4318)
+- Decompose `io_uring_stub` into mirrored module layout (#4316)
+- Split `io_uring/registered_buffers/tests.rs` by concern (#4320)
+- Split `receiver/tests.rs` by surface area (#4315)
+- Further split `receiver/tests/file_list` and `errors_and_timeouts` (#4321)
+- Audit unsafe SAFETY comments and document workspace state (#4323)
+- Add SAFETY comments to checksums SIMD unsafe blocks (#4325)
+- Add SAFETY comments to `fast_io` unsafe blocks (#4328)
+
+### Tests
+
+- Windows source to Linux destination ACL round-trip (#4366)
+- ACL/xattr round-trip parity with upstream rsync 3.4.1 (#4326)
+- Add multiplex/flist/decompressor fuzz targets (#4336)
+- Extend varint decode fuzz target (#4344)
+
 ### Documentation
 
 - **SSH transport**: documented the opt-in `rsync_io/ssh-socketpair-stderr`
@@ -17,6 +47,38 @@ tags are mirrored on GitHub at <https://github.com/oferchen/rsync/releases>.
   fill the 64 KiB pipe buffer), when to enable it, and platform constraints.
   Added `docs/ssh-transport.md` and cross-linked from the Cargo features
   table in `README.md` (#2377).
+- Document ssh-socketpair-stderr feature (#4368)
+- Document ssh-socketpair-stderr opt-in feature (#4385)
+- SpillPolicy user-facing documentation (#4378)
+- SpillPolicy public API and env-var surface design (#4340)
+- SSH stderr audit and socketpair channel design (#4339)
+- Spill mod.rs re-export audit (SPL-9) (#4390)
+- spill.rs decomposition plan (#4337)
+- BGID lifecycle architecture notes (#4353)
+- BGID lifecycle and exhaustion risk audit (#4331)
+- io_uring data path design - receive and send (#4349)
+- io_uring data path coverage audit (#4343)
+- mmap vs SQPOLL+READ_FIXED for basis reads design and bench scaffold (#4329)
+- Mutex poison recovery policy (#4359)
+- Mutex poison recovery classification audit (#4341)
+- Arc::try_unwrap classification audit (#4338)
+- Drain error recovery contract (#4356)
+- IOCP synchronous blocking point audit (#4332)
+- Windows IOCP profiling methodology audit (#4370)
+- Windows hardlink ACL inheritance audit (#4350)
+- Windows NTFS ACL support design (#4333)
+- Document Windows NTFS ACL behaviour and lossy cases (#4346)
+- Fuzz coverage matrix and gap analysis (#4335)
+- Fuzz coverage gap followups (#4347)
+
+### CI/Build
+
+- Wire unsafe SAFETY comment audit as informational check (#4324)
+- Nightly fuzz coverage report per target (#4351)
+- Windows per-hotspot drilldown benchmark mode (#4352)
+- Windows throughput comparison benchmark vs upstream MSYS2 rsync (#4327)
+- Parallel-receive-delta perf benchmark for default-on decision (#4330)
+- Consolidate common deps into workspace and align stale versions (#4322)
 
 ### Performance
 
@@ -47,4 +109,4 @@ tags are mirrored on GitHub at <https://github.com/oferchen/rsync/releases>.
     keyed by packed `(rsum_low, bucket_idx)` entries, giving sequential probes
     cache-friendly access and removing per-bucket heap allocations.
 
-[Unreleased]: https://github.com/oferchen/rsync/compare/v0.6.1...HEAD
+[Unreleased]: https://github.com/oferchen/rsync/compare/v0.6.2...HEAD


### PR DESCRIPTION
## Summary
- Sync CHANGELOG.md Unreleased section with all 50 PRs merged to master since v0.6.2.
- Grouped by conventional-commit prefix (Features, Refactoring, Tests, Documentation, CI/Build).
- Update the Unreleased compare link from v0.6.1 to v0.6.2.

## Test plan
- [x] `cargo fmt --all` clean
- [x] Every entry links to a real merged PR