### PR TITLE
fix(fast_io): gate kqueue_stub c_int import on non-unix only

### DIFF
--- a/crates/fast_io/src/kqueue_stub.rs
+++ b/crates/fast_io/src/kqueue_stub.rs
@@ -14,6 +14,7 @@
 #![allow(dead_code)]
 
 use std::io;
+#[cfg(not(unix))]
 use std::os::raw::c_int;
 use std::time::Duration;
 


### PR DESCRIPTION
## Summary
- `use std::os::raw::c_int` in `kqueue_stub.rs` is only consumed by the `#[cfg(not(unix))] pub type RawFd = c_int;` branch.
- On unix (Linux, the CI host) the import is unused and trips the workspace `-D warnings` clippy gate.
- The macOS path is excluded via the file-level `#![cfg(not(target_os = "macos"))]` so this only matters for Linux/Windows builds.
- Gate the import with `#[cfg(not(unix))]` to match the consumer.

## Test plan
- [x] `cargo fmt --all` clean
- [ ] CI fmt + clippy passes on the rebased master