### PR TITLE
chore: gate Unix-only test modules + deny broken rustdoc links (per #4427)

### DIFF
--- a/crates/cli/src/frontend/tests/mod.rs
+++ b/crates/cli/src/frontend/tests/mod.rs
@@ -43,6 +43,7 @@ mod chown_tests;
 mod clap_tests;
 #[path = "collect.rs"]
 mod collect_tests;
+#[cfg(unix)]
 #[path = "combined.rs"]
 mod combined_tests;
 mod common;
@@ -298,6 +299,7 @@ mod transfer_request_copies_tests;
 mod transfer_request_reports_tests;
 #[path = "transfer_request_with_apple_double.rs"]
 mod transfer_request_with_apple_double_tests;
+#[cfg(unix)]
 #[path = "transfer_request_with_archive.rs"]
 mod transfer_request_with_archive_tests;
 #[path = "transfer_request_with_bwlimit.rs"]
@@ -308,6 +310,7 @@ mod transfer_request_with_cvs_tests;
 mod transfer_request_with_delete_tests;
 #[path = "transfer_request_with_exclude.rs"]
 mod transfer_request_with_exclude_tests;
+#[cfg(unix)]
 #[path = "transfer_request_with_executability.rs"]
 mod transfer_request_with_executability_tests;
 #[path = "transfer_request_with_files_from.rs"]
@@ -328,18 +331,22 @@ mod transfer_request_with_include_tests;
 mod transfer_request_with_itemize_tests;
 #[path = "transfer_request_with_no.rs"]
 mod transfer_request_with_no_tests;
+#[cfg(unix)]
 #[path = "transfer_request_with_omit.rs"]
 mod transfer_request_with_omit_tests;
 #[path = "transfer_request_with_out.rs"]
 mod transfer_request_with_out_tests;
+#[cfg(unix)]
 #[path = "transfer_request_with_owner.rs"]
 mod transfer_request_with_owner_tests;
+#[cfg(unix)]
 #[path = "transfer_request_with_perms.rs"]
 mod transfer_request_with_perms_tests;
 #[path = "transfer_request_with_relative.rs"]
 mod transfer_request_with_relative_tests;
 #[path = "transfer_request_with_remove.rs"]
 mod transfer_request_with_remove_tests;
+#[cfg(unix)]
 #[path = "transfer_request_with_sparse.rs"]
 mod transfer_request_with_sparse_tests;
 #[path = "transfer_request_with_times.rs"]

--- a/crates/logging/src/lib.rs
+++ b/crates/logging/src/lib.rs
@@ -71,6 +71,7 @@
 
 #![deny(missing_docs)]
 #![deny(unsafe_code)]
+#![deny(rustdoc::broken_intra_doc_links)]
 
 mod config;
 pub mod error_format;

--- a/crates/matching/src/lib.rs
+++ b/crates/matching/src/lib.rs
@@ -1,4 +1,5 @@
 #![deny(unsafe_code)]
+#![deny(rustdoc::broken_intra_doc_links)]
 
 //! Block matching and delta generation for rsync transfers.
 //!

--- a/crates/signature/src/lib.rs
+++ b/crates/signature/src/lib.rs
@@ -1,5 +1,6 @@
 #![deny(unsafe_code)]
 #![deny(missing_docs)]
+#![deny(rustdoc::broken_intra_doc_links)]
 
 //! File signature layout and generation for the Rust rsync implementation.
 //!

--- a/crates/test-support/src/lib.rs
+++ b/crates/test-support/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(rustdoc::broken_intra_doc_links)]
+
 //! Shared test utilities for the oc-rsync workspace.
 //!
 //! This crate provides helpers that multiple test suites need, avoiding


### PR DESCRIPTION
## Summary
- Per PR #4427 audit, gate 7 `#[path = ...]` inclusions in `crates/cli/src/frontend/tests/mod.rs` with `#[cfg(unix)]` to clean up Windows `unused_import` warnings under `-D warnings`.
- Add `#![deny(rustdoc::broken_intra_doc_links)]` to crates that lack it (`logging`, `matching`, `signature`, `test-support`) so re-export link breakage is caught at build time.
- No crates were reverted from the deny-list change; rustdoc verification deferred to CI per local-no-cargo policy. If CI surfaces any pre-existing broken link in the four crates, a follow-up will roll back the specific crate's deny attribute and track the link fix separately.

## Gates added (7)
- combined.rs
- transfer_request_with_archive.rs
- transfer_request_with_executability.rs
- transfer_request_with_omit.rs
- transfer_request_with_owner.rs
- transfer_request_with_perms.rs
- transfer_request_with_sparse.rs

Each gate mirrors the existing pattern used for `error_recovery.rs` and `daemon.rs` one block above in the same file.

## Test plan
- [x] `cargo fmt --all` clean
- [ ] CI verifies Windows clippy is quieter and rustdoc-link audit on the deny crates passes