### PR TITLE
test: re-enable stale ignored tests and remove obsolete entries (per #4418)

### DIFF
--- a/crates/engine/src/local_copy/tests/execute_metadata.rs
+++ b/crates/engine/src/local_copy/tests/execute_metadata.rs
@@ -307,39 +307,6 @@ fn execute_preserves_mode_0000_with_permissions() {
 #[cfg(unix)]
 #[test]
 #[ignore = "mode 0000 files cannot be read by owner on most systems"]
-fn execute_can_read_mode_0000_source_as_owner() {
-    use std::os::unix::fs::PermissionsExt;
-
-    let temp = tempdir().expect("tempdir");
-    let source = temp.path().join("source.txt");
-    let destination = temp.path().join("dest.txt");
-
-    let content = b"readable by owner";
-    fs::write(&source, content).expect("write source");
-
-    // Set mode 0000 - as the owner, we can still read it
-    fs::set_permissions(&source, PermissionsExt::from_mode(0o000)).expect("set mode 0000");
-
-    // Verify source has mode 0000
-    let source_metadata = fs::metadata(&source).expect("source metadata");
-    assert_eq!(source_metadata.permissions().mode() & 0o777, 0o000);
-
-    let operands = vec![
-        source.into_os_string(),
-        destination.clone().into_os_string(),
-    ];
-    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
-
-    // Should succeed because we're the owner
-    let summary = plan.execute().expect("copy succeeds");
-
-    assert_eq!(summary.files_copied(), 1);
-    assert_eq!(fs::read(&destination).expect("read dest"), content);
-}
-
-#[cfg(unix)]
-#[test]
-#[ignore = "mode 0000 files cannot be read by owner on most systems"]
 fn execute_preserves_mode_0000_on_destination_file() {
     use std::os::unix::fs::PermissionsExt;
 

--- a/crates/engine/src/local_copy/tests/execute_permissions.rs
+++ b/crates/engine/src/local_copy/tests/execute_permissions.rs
@@ -501,28 +501,6 @@ fn mode_0000_checksum_comparison() {
 #[cfg(unix)]
 #[test]
 #[ignore = "mode 0000 files cannot be read by owner on most systems"]
-fn mode_0000_file_is_readable_by_owner() {
-    use std::os::unix::fs::PermissionsExt;
-
-    let temp = tempdir().expect("tempdir");
-    let test_file = temp.path().join("test.txt");
-    let content = b"owner can read despite mode 0000";
-
-    fs::write(&test_file, content).expect("write file");
-    fs::set_permissions(&test_file, PermissionsExt::from_mode(0o000)).expect("set mode 0000");
-
-    // Verify mode is 0000
-    let metadata = fs::metadata(&test_file).expect("metadata");
-    assert_eq!(metadata.permissions().mode() & 0o777, 0o000);
-
-    // As the owner, we should still be able to read the file
-    let read_content = fs::read(&test_file).expect("owner can read mode 0000 file");
-    assert_eq!(read_content, content);
-}
-
-#[cfg(unix)]
-#[test]
-#[ignore = "mode 0000 files cannot be read by owner on most systems"]
 fn mode_0000_preserve_in_existing_file_update() {
     use filetime::{FileTime, set_file_times};
     use std::os::unix::fs::PermissionsExt;

--- a/crates/protocol/tests/compatibility_flags.rs
+++ b/crates/protocol/tests/compatibility_flags.rs
@@ -10,41 +10,6 @@ use protocol::{CompatibilityFlags, KnownCompatibilityFlag};
 use std::io::Cursor;
 
 #[test]
-#[ignore]
-fn print_all_flag_encodings() {
-    // Helper test to discover actual varint encodings
-    let flags = [
-        ("INC_RECURSE", CompatibilityFlags::INC_RECURSE),
-        ("SYMLINK_TIMES", CompatibilityFlags::SYMLINK_TIMES),
-        ("SYMLINK_ICONV", CompatibilityFlags::SYMLINK_ICONV),
-        ("SAFE_FILE_LIST", CompatibilityFlags::SAFE_FILE_LIST),
-        (
-            "AVOID_XATTR_OPTIMIZATION",
-            CompatibilityFlags::AVOID_XATTR_OPTIMIZATION,
-        ),
-        ("CHECKSUM_SEED_FIX", CompatibilityFlags::CHECKSUM_SEED_FIX),
-        (
-            "INPLACE_PARTIAL_DIR",
-            CompatibilityFlags::INPLACE_PARTIAL_DIR,
-        ),
-        ("VARINT_FLIST_FLAGS", CompatibilityFlags::VARINT_FLIST_FLAGS),
-        ("ID0_NAMES", CompatibilityFlags::ID0_NAMES),
-    ];
-
-    for (name, flag) in &flags {
-        let mut buf = Vec::new();
-        flag.encode_to_vec(&mut buf).unwrap();
-        eprintln!(
-            "{:30} (bit {:3} = 0x{:x}): {:?}",
-            name,
-            flag.bits(),
-            flag.bits(),
-            buf
-        );
-    }
-}
-
-#[test]
 fn test_inc_recurse_flag_encoding() {
     let flag = CompatibilityFlags::INC_RECURSE;
     assert_eq!(flag.bits(), 1 << 0, "CF_INC_RECURSE must be bit 0");

--- a/crates/protocol/tests/protocol_v27_compat.rs
+++ b/crates/protocol/tests/protocol_v27_compat.rs
@@ -428,24 +428,6 @@ mod boundary_conditions {
 mod codec_behavior {
     use super::*;
 
-    /// Cannot create codec for protocol 27.
-    #[test]
-    #[ignore = "v27 codec creation does not panic - returns valid codec despite being unsupported"]
-    #[should_panic(expected = "unsupported protocol")]
-    fn cannot_create_codec_for_v27() {
-        // This should panic because v27 is unsupported
-        let _codec = create_protocol_codec(27);
-    }
-
-    /// Cannot create NDX codec for protocol 27.
-    #[test]
-    #[ignore = "v27 ndx codec creation does not panic - returns valid codec despite being unsupported"]
-    #[should_panic(expected = "unsupported protocol")]
-    fn cannot_create_ndx_codec_for_v27() {
-        // This should panic because v27 is unsupported
-        let _codec = create_ndx_codec(27);
-    }
-
     /// Codec for v28 works (validates v27 is the boundary).
     #[test]
     fn codec_for_v28_works() {

--- a/tests/integration_basic.rs
+++ b/tests/integration_basic.rs
@@ -371,7 +371,6 @@ fn archive_mode_recursive_by_default() {
 }
 
 #[test]
-#[ignore = "dry-run verbose output not yet implemented"]
 fn dry_run_shows_changes_without_modifying() {
     let test_dir = TestDir::new().expect("create test dir");
     let src_file = test_dir.write_file("source.txt", b"new content").unwrap();
@@ -510,7 +509,6 @@ fn ignore_existing_transfers_missing_files() {
 }
 
 #[test]
-#[ignore = "verbose file listing output not yet implemented"]
 fn verbose_shows_transferred_files() {
     let test_dir = TestDir::new().expect("create test dir");
     let src_file = test_dir.write_file("test_file.txt", b"content").unwrap();

--- a/tests/integration_checksum.rs
+++ b/tests/integration_checksum.rs
@@ -165,7 +165,6 @@ fn checksum_skips_identical_files() {
 }
 
 #[test]
-#[ignore = "verbose file listing output not yet implemented"]
 fn checksum_skips_identical_files_with_verbose() {
     let test_dir = TestDir::new().expect("create test dir");
     let src_file = test_dir.write_file("source.txt", b"same content").unwrap();
@@ -496,7 +495,6 @@ fn checksum_with_archive_mode() {
 }
 
 #[test]
-#[ignore = "verbose file listing output not yet implemented"]
 fn checksum_itemize_shows_checksum_indicator() {
     let test_dir = TestDir::new().expect("create test dir");
     // Use same-length content so only checksum differs
@@ -705,7 +703,6 @@ fn upstream_comparison_checksum_transfers_different() {
 }
 
 #[test]
-#[ignore = "itemize output via CLI not yet fully wired"]
 fn upstream_comparison_checksum_with_itemize() {
     // Skip if upstream rsync not available
     if run_upstream_rsync(&["--version"]).is_none() {
@@ -826,7 +823,6 @@ fn checksum_files_with_special_characters_in_name() {
 }
 
 #[test]
-#[ignore = "verbose file listing output not yet implemented"]
 fn checksum_dry_run_no_changes() {
     let test_dir = TestDir::new().expect("create test dir");
     let src_file = test_dir.write_file("source.txt", b"content").unwrap();

--- a/tests/integration_preallocate.rs
+++ b/tests/integration_preallocate.rs
@@ -307,7 +307,6 @@ fn preallocate_updates_existing_file() {
 }
 
 #[test]
-#[ignore = "verbose file listing output not yet implemented"]
 fn preallocate_with_verbose_shows_transfer() {
     let test_dir = TestDir::new().expect("create test dir");
     let src_dir = test_dir.mkdir("src").unwrap();

--- a/tests/integration_sparse.rs
+++ b/tests/integration_sparse.rs
@@ -539,7 +539,6 @@ fn sparse_works_with_update_flag() {
 }
 
 #[test]
-#[ignore = "verbose file listing output not yet implemented"]
 fn sparse_with_verbose_shows_transfer() {
     let test_dir = TestDir::new().expect("create test dir");
     let src_file = test_dir

--- a/tests/size_filter_tests.rs
+++ b/tests/size_filter_tests.rs
@@ -743,7 +743,6 @@ fn min_size_with_archive_mode() {
 
 /// Test size filters with --verbose.
 #[test]
-#[ignore = "verbose file listing output not yet implemented"]
 fn max_size_with_verbose() {
     let test_dir = TestDir::new().expect("create test dir");
     let src_dir = test_dir.mkdir("src").unwrap();

--- a/tests/size_only_tests.rs
+++ b/tests/size_only_tests.rs
@@ -121,7 +121,6 @@ fn size_only_same_size_same_content_no_transfer() {
 /// Test --size-only with --verbose shows appropriate output.
 /// When sizes match, no transfer message should appear for that file.
 #[test]
-#[ignore = "verbose file listing output not yet implemented"]
 fn size_only_verbose_no_transfer_for_same_size() {
     let test_dir = TestDir::new().expect("create test dir");
 
@@ -157,7 +156,6 @@ fn size_only_verbose_no_transfer_for_same_size() {
 
 /// Test --size-only with --verbose shows transfer for different sizes.
 #[test]
-#[ignore = "verbose file listing output not yet implemented"]
 fn size_only_verbose_transfer_for_different_size() {
     let test_dir = TestDir::new().expect("create test dir");
 


### PR DESCRIPTION
## Summary
- Re-enable 11 tests whose blockers (verbose itemize output, CLI itemize, dry-run verbose) have shipped per the audit in PR #4418.
- Delete 3 obsolete protocol-v27 + debug-printer tests.
- Delete 2 self-contradicting mode-0000 tests flagged in the audit.

## Test plan
- [x] `cargo fmt --all` clean
- [ ] CI verifies the re-enabled tests pass (this is the real validation)