### PR TITLE
ci: apply top quick wins from workflow audit (per #4419)

### DIFF
--- a/.github/workflows/_test-features.yml
+++ b/.github/workflows/_test-features.yml
@@ -74,9 +74,6 @@ jobs:
         with:
           tool: cargo-nextest
 
-      - name: Build (${{ matrix.row.name }})
-        run: cargo build --locked ${{ matrix.row.args }}
-
       - name: Test (${{ matrix.row.name }})
         run: cargo nextest run --locked --profile ci ${{ matrix.row.args }}
 
@@ -163,9 +160,6 @@ jobs:
         uses: taiki-e/install-action@fa0dd4cd0a40696e6f9766370614a5ce482e6aa8 # v2
         with:
           tool: cargo-nextest
-
-      - name: Build (${{ matrix.name }})
-        run: cargo build --locked ${{ matrix.args }}
 
       - name: Test (${{ matrix.name }})
         run: cargo nextest run --locked --profile ci ${{ matrix.args }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,9 +185,6 @@ jobs:
         with:
           tool: cargo-nextest
 
-      - name: Build
-        run: cargo build --locked --workspace --all-features
-
       - name: Run tests
         run: cargo nextest run --locked --workspace --all-features
 
@@ -258,9 +255,6 @@ jobs:
         uses: taiki-e/install-action@fa0dd4cd0a40696e6f9766370614a5ce482e6aa8 # v2
         with:
           tool: cargo-nextest
-
-      - name: Build
-        run: cargo build --locked --workspace --all-features
 
       - name: Test
         run: |
@@ -458,9 +452,6 @@ jobs:
       # macOS GitHub runners can resolve to rustup-init directly and fail with
       # `error: unexpected argument 'build' found` when rust-toolchain.toml
       # pins a toolchain that was not pre-installed.
-      - name: Build
-        run: rustup run ${{ matrix.toolchain }} cargo build --locked --workspace --all-features
-
       - name: Test
         run: |
           # Run macOS-specific crates only (core, engine, cli have platform code).

--- a/.github/workflows/filter-fuzzer-overnight.yml
+++ b/.github/workflows/filter-fuzzer-overnight.yml
@@ -83,7 +83,9 @@ jobs:
           version: v1
 
       - name: Install cargo-fuzz
-        run: cargo +nightly install cargo-fuzz --locked
+        uses: taiki-e/install-action@fa0dd4cd0a40696e6f9766370614a5ce482e6aa8 # v2
+        with:
+          tool: cargo-fuzz
 
       - name: Cache upstream rsync
         id: cache-rsync

--- a/.github/workflows/fuzz-coverage-report.yml
+++ b/.github/workflows/fuzz-coverage-report.yml
@@ -121,7 +121,9 @@ jobs:
           version: v1
 
       - name: Install cargo-fuzz
-        run: cargo install cargo-fuzz --locked
+        uses: taiki-e/install-action@fa0dd4cd0a40696e6f9766370614a5ce482e6aa8 # v2
+        with:
+          tool: cargo-fuzz
 
       - name: Cache upstream rsync
         if: matrix.needs_upstream

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -39,22 +39,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Check advisories
+      - name: Check advisories, licenses, bans, and sources
         uses: EmbarkStudios/cargo-deny-action@91bf2b620e09e18d6eb78b92e7861937469acedb # v2.0.17
         with:
-          command: check advisories
-
-      - name: Check licenses
-        uses: EmbarkStudios/cargo-deny-action@91bf2b620e09e18d6eb78b92e7861937469acedb # v2.0.17
-        with:
-          command: check licenses
-
-      - name: Check bans
-        uses: EmbarkStudios/cargo-deny-action@91bf2b620e09e18d6eb78b92e7861937469acedb # v2.0.17
-        with:
-          command: check bans
-
-      - name: Check sources
-        uses: EmbarkStudios/cargo-deny-action@91bf2b620e09e18d6eb78b92e7861937469acedb # v2.0.17
-        with:
-          command: check sources
+          command: check all


### PR DESCRIPTION
## Summary
- security.yml: collapse four `cargo-deny check` invocations into `check all` (saves ~30s-2min per run).
- filter-fuzzer-overnight.yml + fuzz-coverage-report.yml: switch `cargo install cargo-fuzz` to `taiki-e/install-action@v2` (saves ~50-80 CI min/nightly).
- ci.yml + _test-features.yml: drop redundant `cargo build` before `cargo nextest run` (saves ~3-5 min cold-cache per job).

## Test plan
- [x] YAML parses cleanly via PyYAML
- [ ] CI confirms steps execute without regression