### PR TITLE
refactor(engine): extract spill/tempfile.rs (SPL-3 #2325)

### DIFF
--- a/crates/engine/src/concurrent_delta/spill.rs
+++ b/crates/engine/src/concurrent_delta/spill.rs
@@ -48,7 +48,7 @@
 //! has no upstream equivalent.
 
 use std::collections::BTreeMap;
-use std::fs::{self, File};
+use std::fs;
 use std::io::{self, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 
@@ -58,6 +58,9 @@ pub mod policy;
 pub mod stats;
 pub use policy::{ReclaimMode, SpillCompression, SpillGranularity, SpillPolicy};
 pub use stats::SpillStats;
+
+mod tempfile;
+use tempfile::{SpillBackend, open_backend};
 
 /// Default memory threshold (in bytes) before spilling begins.
 ///
@@ -164,35 +167,6 @@ pub trait SpillCodec: Sized {
     /// to be exact - a conservative overestimate is fine.
     fn estimated_size(&self) -> usize;
 }
-
-/// Backing storage for spilled bytes.
-///
-/// Two flavours are supported:
-///
-/// - `Spooled` - the default. Wraps `tempfile::SpooledTempFile`, which keeps
-///   small spills in memory and rolls over to disk past a threshold. The OS
-///   deletes the file when the buffer is dropped.
-/// - `Directory` - opens a single anonymous tempfile inside a caller-provided
-///   directory. If the directory vanishes mid-transfer (operator cleanup,
-///   container restart) the buffer performs one `create_dir_all` retry
-///   before surfacing the error.
-enum SpillBackend {
-    Spooled(tempfile::SpooledTempFile),
-    Directory(File),
-}
-
-impl SpillBackend {
-    fn file(&mut self) -> &mut dyn ReadWriteSeek {
-        match self {
-            SpillBackend::Spooled(f) => f,
-            SpillBackend::Directory(f) => f,
-        }
-    }
-}
-
-/// Trait object alias to keep the [`SpillBackend::file`] accessor honest.
-trait ReadWriteSeek: Read + Write + Seek {}
-impl<T: Read + Write + Seek + ?Sized> ReadWriteSeek for T {}
 
 /// Reorder buffer with transparent spill-to-tempfile for bounded memory.
 ///
@@ -659,21 +633,6 @@ impl<T: SpillCodec> SpillableReorderBuffer<T> {
     }
 }
 
-/// Opens the appropriate backend for a spill file.
-fn open_backend(dir: Option<&Path>) -> io::Result<SpillBackend> {
-    match dir {
-        Some(dir) => Ok(SpillBackend::Directory(tempfile::tempfile_in(dir)?)),
-        None => {
-            // SpooledTempFile keeps small spills in memory (up to 1 MB) and
-            // rolls over to disk for larger volumes, avoiding disk I/O for
-            // transient pressure spikes.
-            Ok(SpillBackend::Spooled(tempfile::SpooledTempFile::new(
-                1024 * 1024,
-            )))
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1100,7 +1059,7 @@ mod tests {
         // Vanish-before-first-spill is the recoverable case: no data has
         // been written yet, so re-creating the directory and retrying
         // is safe.
-        let scratch = tempfile::tempdir().expect("create scratch root");
+        let scratch = ::tempfile::tempdir().expect("create scratch root");
         let spill_dir = scratch.path().join("spill");
         let mut buf: SpillableReorderBuffer<u64> =
             SpillableReorderBuffer::with_spill_dir(16, 8, &spill_dir)
@@ -1131,7 +1090,7 @@ mod tests {
         // Vanish after prior spills is unrecoverable: those items live
         // only on the now-missing disk. We surface the I/O error rather
         // than silently lose them.
-        let scratch = tempfile::tempdir().expect("create scratch root");
+        let scratch = ::tempfile::tempdir().expect("create scratch root");
         let spill_dir = scratch.path().join("spill");
         let mut buf: SpillableReorderBuffer<u64> =
             SpillableReorderBuffer::with_spill_dir(16, 8, &spill_dir)
@@ -1171,7 +1130,7 @@ mod tests {
     fn dir_recreate_failure_surfaces_io_error() {
         // Point the spill dir at a path whose parent is a regular file:
         // create_dir_all is guaranteed to fail with NotADirectory or similar.
-        let scratch = tempfile::tempdir().expect("create scratch root");
+        let scratch = ::tempfile::tempdir().expect("create scratch root");
         let blocker = scratch.path().join("blocker");
         fs::write(&blocker, b"not a directory").expect("write blocker file");
         let invalid_dir = blocker.join("spill");
@@ -1190,7 +1149,7 @@ mod tests {
     fn directory_backed_spill_round_trip() {
         // Sanity: the directory backend yields the same byte-for-byte
         // results as the default spooled backend.
-        let scratch = tempfile::tempdir().expect("create scratch root");
+        let scratch = ::tempfile::tempdir().expect("create scratch root");
         let mut buf: SpillableReorderBuffer<u64> =
             SpillableReorderBuffer::with_spill_dir(64, 24, scratch.path().join("spill"))
                 .expect("setup spill directory");

--- a/crates/engine/src/concurrent_delta/spill/tempfile.rs
+++ b/crates/engine/src/concurrent_delta/spill/tempfile.rs
@@ -1,0 +1,63 @@
+//! Tempfile-backed storage primitives for the spill layer.
+//!
+//! Encapsulates the two flavours of disk backing used by
+//! [`SpillableReorderBuffer`](super::SpillableReorderBuffer):
+//!
+//! - `Spooled` - the default. Wraps `tempfile::SpooledTempFile`, which keeps
+//!   small spills in memory and rolls over to disk past a threshold.
+//! - `Directory` - opens a single anonymous tempfile inside a caller-provided
+//!   directory.
+//!
+//! The abstraction is intentionally narrow: the reorder buffer only needs a
+//! single read/write/seek handle plus a way to open one. Keeping the tempfile
+//! plumbing isolated here lets the buffer module focus on reordering and
+//! serialization logic.
+
+use std::fs::File;
+use std::io::{self, Read, Seek, Write};
+use std::path::Path;
+
+/// Backing storage for spilled bytes.
+///
+/// Two flavours are supported:
+///
+/// - `Spooled` - the default. Wraps `tempfile::SpooledTempFile`, which keeps
+///   small spills in memory and rolls over to disk past a threshold. The OS
+///   deletes the file when the buffer is dropped.
+/// - `Directory` - opens a single anonymous tempfile inside a caller-provided
+///   directory. If the directory vanishes mid-transfer (operator cleanup,
+///   container restart) the buffer performs one `create_dir_all` retry
+///   before surfacing the error.
+pub(super) enum SpillBackend {
+    Spooled(::tempfile::SpooledTempFile),
+    Directory(File),
+}
+
+impl SpillBackend {
+    pub(super) fn file(&mut self) -> &mut dyn ReadWriteSeek {
+        match self {
+            SpillBackend::Spooled(f) => f,
+            SpillBackend::Directory(f) => f,
+        }
+    }
+}
+
+/// Trait object alias to keep the [`SpillBackend::file`] accessor honest.
+pub(super) trait ReadWriteSeek: Read + Write + Seek {}
+impl<T: Read + Write + Seek + ?Sized> ReadWriteSeek for T {}
+
+/// Opens a fresh tempfile backend.
+///
+/// When `dir` is `Some`, an anonymous tempfile is created inside that
+/// directory (caller is responsible for ensuring the directory exists).
+/// When `dir` is `None`, a `SpooledTempFile` is used, which keeps small
+/// spills in memory (up to 1 MB) and rolls over to disk for larger volumes,
+/// avoiding disk I/O for transient pressure spikes.
+pub(super) fn open_backend(dir: Option<&Path>) -> io::Result<SpillBackend> {
+    match dir {
+        Some(dir) => Ok(SpillBackend::Directory(::tempfile::tempfile_in(dir)?)),
+        None => Ok(SpillBackend::Spooled(::tempfile::SpooledTempFile::new(
+            1024 * 1024,
+        ))),
+    }
+}


### PR DESCRIPTION
## Summary

- Move `SpillBackend`, `ReadWriteSeek`, and `open_backend` out of `crates/engine/src/concurrent_delta/spill.rs` into a new `spill/tempfile.rs` submodule.
- The tempfile-backed storage primitives are self-contained (no back-references to `SpillableReorderBuffer` or other spill types) and form a narrow, cohesive disk-facing surface that the rest of the spill layer consumes through a `pub(super)` API.
- Pure code movement: no logic changes, no public API change. Visibility tightened to `pub(super)` since these items were previously module-private and only used inside `spill.rs`.

## Why

`spill.rs` mixes three concerns: reorder-buffer state, codec/IO record framing, and tempfile-backed storage. Splitting the tempfile primitives out gives the rest of the file room to focus on reordering and serialization while keeping the disk plumbing isolated where ENOSPC and temp-dir-vanish handling can evolve independently. This is the SPL-3 step in the `spill.rs` decomposition tracked at `docs/audits/spill-rs-decomposition-plan.md`.

The four test sites that previously called `tempfile::tempdir()` now use `::tempfile::tempdir()` to disambiguate from the new local `tempfile` module - the only side effect of using the name suggested by the decomposition plan.

## Test plan

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings`
- [ ] `cargo nextest run -p engine --all-features -E 'test(spill)'`
- [ ] Full CI matrix (fmt+clippy, nextest stable, Windows, macOS, Linux musl)