### PR TITLE
chore: consolidate cross-crate deps into [workspace.dependencies]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,7 +120,7 @@ fast_io = { path = "crates/fast_io", default-features = false }
 mimalloc = { workspace = true }
 
 [dev-dependencies]
-assert_cmd = "2.0"
+assert_cmd = { workspace = true }
 core = { path = "crates/core" }
 filetime = { workspace = true }
 libc = { workspace = true }
@@ -243,6 +243,24 @@ clap = { version = "4.5", features = ["std"] }
 base64 = "0.22"
 # Modern syscall wrappers - used by core, engine, metadata, fast_io
 rustix = "1.1"
+# CLI integration testing - dev-dep across cli and root bin
+assert_cmd = "2.0"
+# Glob pattern matcher - shared by engine and filters
+globset = "0.4"
+# Pure-Rust LZ4 codec - shared by compress and protocol (optional, per-crate features)
+lz4_flex = { version = "0.13", default-features = false }
+# MD5 hash - shared by checksums (asm on unix) and protocol (per-crate features)
+md-5 = { version = "0.10", default-features = false }
+# Unix syscall wrappers - shared by apple-fs, core, platform (per-crate features)
+nix = { version = "0.31", default-features = false }
+# Windows API bindings (high-level) - shared by daemon, metadata, platform (per-crate features)
+windows = "0.62"
+# Windows API bindings (low-level) - shared by engine and fast_io (per-crate features)
+windows-sys = "0.61"
+# Extended attribute helpers - shared by apple-fs, cli, daemon (dev), engine (dev), metadata (optional)
+xattr = "1.6"
+# Zstandard codec - shared by compress and protocol (optional)
+zstd = "0.13"
 
 [workspace.metadata.docs.rs]
 all-features = true

--- a/crates/apple-fs/Cargo.toml
+++ b/crates/apple-fs/Cargo.toml
@@ -8,14 +8,14 @@ version.workspace = true
 
 [dependencies]
 libc = { workspace = true }
-nix = { version = "0.31", default-features = false, features = ["fs"] }
+nix = { workspace = true, features = ["fs"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 unicode-normalization = "0.1"
 # Safe wrapper for getxattr(2)/setxattr(2). Used to access the macOS-native
 # `com.apple.ResourceFork` and `com.apple.FinderInfo` extended attributes
 # without introducing unsafe FFI inside this crate (per workspace policy).
-xattr = "1.6"
+xattr = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/checksums/Cargo.toml
+++ b/crates/checksums/Cargo.toml
@@ -50,12 +50,12 @@ logging = { path = "../logging" }
 # fallbacks; the pure-Rust backend already auto-detects SHA-NI (x86_64) and
 # crypto extensions (aarch64) via `cpufeatures` regardless of this feature.
 [target.'cfg(unix)'.dependencies]
-md-5 = { version = "0.10", default-features = false, features = ["std", "asm"] }
+md-5 = { workspace = true, features = ["std", "asm"] }
 sha1 = { version = "0.10", default-features = false, features = ["std", "asm"] }
 sha2 = { version = "0.10", default-features = false, features = ["std", "asm"] }
 
 [target.'cfg(not(unix))'.dependencies]
-md-5 = { version = "0.10", default-features = false, features = ["std"] }
+md-5 = { workspace = true, features = ["std"] }
 sha1 = { version = "0.10", default-features = false, features = ["std"] }
 sha2 = { version = "0.10", default-features = false, features = ["std"] }
 

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -61,7 +61,7 @@ tracing-subscriber = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 uzers = "0.12"
-xattr = "1.6"
+xattr = { workspace = true }
 daemon = { path = "../daemon" }
 
 [target.'cfg(not(windows))'.dependencies]
@@ -71,7 +71,7 @@ checksums = { path = "../checksums" }
 checksums = { path = "../checksums", default-features = false }
 
 [dev-dependencies]
-assert_cmd = "2.0"
+assert_cmd = { workspace = true }
 predicates = "3.1"
 filetime = { workspace = true }
 tempfile = { workspace = true }

--- a/crates/compress/Cargo.toml
+++ b/crates/compress/Cargo.toml
@@ -30,6 +30,6 @@ zlib-rs = ["flate2/zlib-rs"]
 [dependencies]
 # Default: miniz_oxide (pure Rust fallback). zlib-ng/zlib-rs override via features.
 flate2 = { workspace = true }
-zstd = { version = "0.13", optional = true }
-lz4_flex = { version = "0.13", optional = true, default-features = false, features = ["frame", "safe-encode", "safe-decode"] }
+zstd = { workspace = true, optional = true }
+lz4_flex = { workspace = true, optional = true, features = ["frame", "safe-encode", "safe-decode"] }
 thiserror = { workspace = true }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -46,7 +46,7 @@ zeroize = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 checksums = { path = "../checksums" }
-nix = { version = "0.31", default-features = false, features = ["user"] }
+nix = { workspace = true, features = ["user"] }
 rustix = { workspace = true, features = ["process"] }
 
 [target.'cfg(windows)'.dependencies]

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -61,7 +61,7 @@ sd-notify = { version = "0.5.0", optional = true }
 
 [target.'cfg(windows)'.dependencies]
 checksums = { path = "../checksums", default-features = false }
-windows = { version = "0.62", features = [
+windows = { workspace = true, features = [
     "Win32_Foundation",
 ] }
 
@@ -72,7 +72,7 @@ filetime = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 
 [target.'cfg(unix)'.dev-dependencies]
-xattr = "1.6"
+xattr = { workspace = true }
 exacl = { workspace = true }
 
 [[bench]]

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -30,7 +30,7 @@ rayon = { workspace = true }
 crossbeam-channel = { workspace = true }
 crossbeam-queue = { workspace = true }
 tracing = { workspace = true, optional = true }
-globset = "0.4"
+globset = { workspace = true }
 jwalk = { workspace = true }
 rustc-hash = { workspace = true }
 rustix = { workspace = true, features = ["fs", "process"] }
@@ -46,7 +46,7 @@ checksums = { path = "../checksums" }
 
 [target.'cfg(windows)'.dependencies]
 checksums = { path = "../checksums", default-features = false }
-windows-sys = { version = "0.61", features = ["Win32_Storage_FileSystem"] }
+windows-sys = { workspace = true, features = ["Win32_Storage_FileSystem"] }
 
 # libc is needed for O_NOATIME (Linux), clonefile (macOS), posix_fadvise, syncfs
 [target.'cfg(unix)'.dependencies]
@@ -136,7 +136,7 @@ tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 proptest = { workspace = true }
 
 [target.'cfg(unix)'.dev-dependencies]
-xattr = "1.6"
+xattr = { workspace = true }
 libc = { workspace = true }
 criterion = { workspace = true }
 dashmap = { workspace = true }

--- a/crates/fast_io/Cargo.toml
+++ b/crates/fast_io/Cargo.toml
@@ -88,7 +88,7 @@ vmsplice = []
 # Win32_Networking_WinSock added for WSARecv/WSASend in iocp::socket (#1928);
 # Win32_System_Pipes added for CreatePipe-based tests of anonymous-handle
 # rejection in writer_from_file (#1929).
-windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Networking_WinSock", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_IO", "Win32_System_Pipes", "Win32_System_Threading"] }
+windows-sys = { workspace = true, features = ["Win32_Foundation", "Win32_Networking_WinSock", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_IO", "Win32_System_Pipes", "Win32_System_Threading"] }
 
 [target.'cfg(not(unix))'.dependencies]
 filetime = { workspace = true }

--- a/crates/filters/Cargo.toml
+++ b/crates/filters/Cargo.toml
@@ -14,7 +14,7 @@ rustdoc-args = ["--cfg", "docsrs", "-D", "rustdoc::broken_intra_doc_links"]
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-globset = "0.4"
+globset = { workspace = true }
 logging = { path = "../logging" }
 thiserror = { workspace = true }
 tracing = { workspace = true, optional = true }

--- a/crates/metadata/Cargo.toml
+++ b/crates/metadata/Cargo.toml
@@ -23,7 +23,7 @@ libc = { workspace = true }
 thiserror = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
-xattr = { version = "1.6", optional = true }
+xattr = { workspace = true, optional = true }
 
 # Cross-platform ACL support (Linux, macOS, FreeBSD)
 # Replaces custom FFI bindings for cleaner, safer implementation
@@ -38,7 +38,7 @@ apple-fs = { path = "../apple-fs" }
 # Win32_System_Threading is required for OpenProcessToken/GetCurrentProcess
 # used by the --copy-as privilege probe in copy_as.rs.
 [target.'cfg(windows)'.dependencies]
-windows = { version = "0.62", features = [
+windows = { workspace = true, features = [
     "Win32_Foundation",
     "Win32_Security",
     "Win32_Security_Authorization",

--- a/crates/platform/Cargo.toml
+++ b/crates/platform/Cargo.toml
@@ -14,11 +14,11 @@ thiserror = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }
-nix = { version = "0.31", default-features = false, features = ["fs", "process", "user"] }
+nix = { workspace = true, features = ["fs", "process", "user"] }
 signal-hook = "0.4"
 
 [target.'cfg(windows)'.dependencies]
-windows = { version = "0.62", features = [
+windows = { workspace = true, features = [
     "Win32_Foundation",
     "Win32_NetworkManagement_NetManagement",
     "Win32_Security",

--- a/crates/protocol/Cargo.toml
+++ b/crates/protocol/Cargo.toml
@@ -39,13 +39,13 @@ encoding_rs = { version = "0.8", optional = true }
 # Default: miniz_oxide (pure Rust fallback). zlib-ng/zlib-rs override via features.
 flate2 = { workspace = true }
 logging = { path = "../logging" }
-md-5 = { version = "0.10", default-features = false, features = ["std"] }
+md-5 = { workspace = true, features = ["std"] }
 memchr = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true, optional = true }
 thiserror = { workspace = true }
-lz4_flex = { version = "0.13", optional = true, default-features = false, features = ["safe-encode", "safe-decode"] }
-zstd = { version = "0.13", optional = true }
+lz4_flex = { workspace = true, optional = true, features = ["safe-encode", "safe-decode"] }
+zstd = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["io-util"], optional = true }
 tokio-util = { workspace = true, features = ["codec"], optional = true }
 tracing = { workspace = true, optional = true }


### PR DESCRIPTION
## Summary
- Move 9 remaining cross-crate dependencies into `[workspace.dependencies]` per the audit recommendation in PR #4425 (docs/audits/workspace-deps.md).
- Each per-crate `Cargo.toml` switched to `{ workspace = true }`, preserving feature flags and optional/target attributes locally.
- Consolidated deps: `assert_cmd` (2.0), `globset` (0.4), `lz4_flex` (0.13), `md-5` (0.10), `nix` (0.31), `windows` (0.62), `windows-sys` (0.61), `xattr` (1.6), `zstd` (0.13).
- All candidates agreed on the major.minor version across every declaring crate; nothing was skipped.
- `Cargo.lock` already at the consolidated versions; `cargo update --workspace --offline` ran clean with no version changes.

## Test plan
- [x] `cargo fmt --all` clean
- [x] `cargo update --workspace --offline` reports no version changes
- [x] No new dependencies; only consolidation