### PR TITLE
docs: add /// on pub mod declarations (per #4424 audit)

### DIFF
--- a/crates/cli/src/frontend/mod.rs
+++ b/crates/cli/src/frontend/mod.rs
@@ -79,6 +79,7 @@
 
 use std::ffi::OsString;
 use std::io::{self, Write};
+/// CLI argument parsing for the rsync frontend.
 pub mod arguments;
 mod command_builder;
 mod execution;
@@ -108,16 +109,22 @@ use std::net::IpAddr;
 #[cfg(test)]
 use std::path::{Path, PathBuf};
 mod defaults;
+/// Upstream rsync `--dry-run` (`-n`) output simulation.
 pub mod dry_run;
 mod filter_rules;
 mod help;
+/// Info output flags controlling informational message display.
 pub mod info_output;
+/// Upstream rsync `--itemize-changes` (`-i`) output format.
 pub mod itemize;
 mod out_format;
 pub(crate) mod password;
+/// Progress and verbose output helpers extracted from the CLI front-end.
 pub mod progress;
+/// Progress formatting for upstream rsync's `--progress` output.
 pub mod progress_format;
 mod server;
+/// Statistics formatting for upstream rsync's `--stats` output.
 pub mod stats_format;
 
 #[cfg(test)]

--- a/crates/fast_io/src/io_uring/mod.rs
+++ b/crates/fast_io/src/io_uring/mod.rs
@@ -85,7 +85,9 @@
 //!   `docs/audits/iouring-pbuf-ring.md` for the full call-site survey.
 
 mod batching;
+/// io_uring provided buffer ring (PBUF_RING) for zero-copy reads.
 pub mod buffer_ring;
+/// io_uring `IORING_OP_ASYNC_CANCEL` primitive for in-flight SQE cancellation.
 pub mod cancel;
 mod config;
 #[cfg(feature = "iouring-data-reads")]
@@ -94,16 +96,24 @@ mod disk_batch;
 mod file_factory;
 mod file_reader;
 mod file_writer;
+/// io_uring `LINKAT` opcode wrapper and kernel availability probe.
 pub mod linkat;
+/// Linked SQE chains for the read -> checksum -> write pipeline.
 pub mod linked_chain;
+/// Page-aligned buffer registration for io_uring `READ_FIXED`/`WRITE_FIXED`.
 pub mod registered_buffers;
+/// `IORING_OP_RENAMEAT` (RENAMEAT2) submission helpers and kernel probe.
 pub mod renameat2;
+/// `IORING_OP_SEND_ZC` zero-copy socket-send primitive (Linux 6.0+).
 pub mod send_zc;
+/// Pool of long-lived io_uring instances shared across consumers in a session.
 pub mod session_pool;
+/// Single io_uring ring shared by a reader fd and a writer fd in one session.
 pub mod shared_ring;
 mod socket_factory;
 mod socket_reader;
 mod socket_writer;
+/// io_uring `IORING_OP_STATX` opcode wrapper and batch submission.
 pub mod statx;
 
 #[cfg(test)]

--- a/crates/fast_io/src/io_uring_stub/mod.rs
+++ b/crates/fast_io/src/io_uring_stub/mod.rs
@@ -19,19 +19,28 @@
 
 #![allow(dead_code)]
 
+/// Stub provided-buffer ring API mirroring the Linux backend.
 pub mod buffer_ring;
+/// Stub `IORING_OP_ASYNC_CANCEL` API mirroring the Linux backend.
 pub mod cancel;
 mod config;
 mod disk_batch;
 mod file_factory;
 mod file_reader;
 mod file_writer;
+/// Stub `LINKAT` API mirroring the Linux backend.
 pub mod linkat;
+/// Stub linked-SQE chain API mirroring the Linux backend.
 pub mod linked_chain;
+/// Stub registered-buffer API mirroring the Linux backend.
 pub mod registered_buffers;
+/// Stub `RENAMEAT2` API mirroring the Linux backend.
 pub mod renameat2;
+/// Stub `SEND_ZC` API mirroring the Linux backend.
 pub mod send_zc;
+/// Stub session ring-pool API mirroring the Linux backend.
 pub mod session_pool;
+/// Stub shared-ring API mirroring the Linux backend.
 pub mod shared_ring;
 #[cfg(unix)]
 mod socket_factory;
@@ -39,6 +48,7 @@ mod socket_factory;
 mod socket_reader;
 #[cfg(unix)]
 mod socket_writer;
+/// Stub `IORING_OP_STATX` API mirroring the Linux backend.
 pub mod statx;
 
 #[cfg(test)]

--- a/crates/fast_io/src/iocp/mod.rs
+++ b/crates/fast_io/src/iocp/mod.rs
@@ -26,15 +26,19 @@
 //! I/O since the completion port setup overhead exceeds the async benefit.
 
 mod completion_port;
+/// IOCP configuration, availability detection, and caching.
 pub mod config;
 mod disk_batch;
+/// Typed IOCP error variants for actionable failure handling.
 pub mod error;
 mod file_factory;
 pub(crate) mod file_reader;
 mod file_writer;
 mod overlapped;
 mod pump;
+/// IOCP-based async socket I/O via `WSARecv` / `WSASend`.
 pub mod socket;
+/// Windows `TransmitFile()` zero-copy file-to-socket primitive.
 #[cfg(feature = "transmitfile")]
 pub mod transmit_file;
 

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -79,11 +79,17 @@
 #![deny(rustdoc::broken_intra_doc_links)]
 #![deny(missing_docs)]
 
+/// Cached sorting using the Schwartzian transform.
 pub mod cached_sort;
+/// Kernel version parsing and io_uring probe logging.
 pub mod kernel_version;
+/// Parallel file I/O operations using rayon.
 pub mod parallel;
+/// Cross-platform temporary file strategy abstraction.
 pub mod temp_file_strategy;
+/// Core traits for file I/O abstraction.
 pub mod traits;
+/// SIMD-accelerated zero-byte detection for sparse file writing.
 pub mod zero_detect;
 
 /// EXPERIMENTAL: per-file adaptive basis-read backend dispatch (SMR-3c,
@@ -95,21 +101,34 @@ pub mod zero_detect;
 #[cfg(feature = "adaptive-basis-dispatch")]
 pub mod adaptive_dispatch;
 
+/// Windows `CopyFileExW` file copy with automatic fallback.
 pub mod copy_file_ex;
+/// High-performance file copying with tiered fallback.
 pub mod copy_file_range;
+/// Anonymous temporary file creation via `O_TMPFILE` and finalization via `linkat`.
 pub mod o_tmpfile;
+/// Platform-abstracted file copy trait with automatic optimization selection.
 pub mod platform_copy;
+/// ReFS filesystem detection for Windows reflink support.
 pub mod refs_detect;
+/// Zero-copy file-to-socket transfer using `sendfile` with automatic fallback.
 pub mod sendfile;
+/// Safe wrappers around platform `setsockopt` for integer-valued options.
 pub mod socket_options;
+/// Zero-copy socket-to-disk transfer using `splice`/`vmsplice` syscalls.
 pub mod splice;
+/// Batched metadata syscall operations with dual-path runtime selection.
 pub mod syscall_batch;
+/// Zero-copy file writer that pushes literal chunks via `vmsplice` + `splice`.
 pub mod vmsplice_writer;
 
+/// macOS-optimized file writer using `F_NOCACHE` and `writev`.
 pub mod macos_io;
 
+/// Memory-mapped file reader for efficient large file access.
 #[cfg(unix)]
 pub mod mmap_reader;
+/// Memory-mapped file reader stub for non-Unix platforms.
 #[cfg(not(unix))]
 #[path = "mmap_reader_stub.rs"]
 pub mod mmap_reader;

--- a/crates/platform/src/lib.rs
+++ b/crates/platform/src/lib.rs
@@ -25,11 +25,19 @@
 #![deny(missing_docs)]
 #![deny(rustdoc::broken_intra_doc_links)]
 
+/// Process daemonization - fork, setsid, and stdio redirection.
 pub mod daemonize;
+/// Environment variable manipulation with RAII restoration.
 pub mod env;
+/// System group membership lookups.
 pub mod group;
+/// Windows account name to RID resolution.
 pub mod name_resolution;
+/// Process privilege operations - chroot and uid/gid dropping.
 pub mod privilege;
+/// Secrets file permission validation.
 pub mod secrets;
+/// Signal handler registration and shared atomic flags.
 pub mod signal;
+/// Windows Service Control Manager (SCM) integration.
 pub mod windows_service;


### PR DESCRIPTION
## Summary
- Per PR #4424 audit, add a one-sentence `///` above undocumented `pub mod NAME;` declarations.
- Targets the worst-covered crates from the strict view: `platform`, `cli`, `fast_io`.
- Submodule contents untouched.

## Test plan
- [x] `cargo fmt --all` clean
- [x] Doc summaries accurate against the target module's `//!` or first item