### PR TITLE
feat(fast_io): mmap-free-basis experimental feature (SMR-3a Option 1 #2288)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,12 @@ iocp = ["transfer/iocp", "fast_io/iocp"]
 # Trade-offs: Linux-only optimization
 copy_file_range = ["fast_io/copy_file_range"]
 
+# EXPERIMENTAL: SMR-3a Option 1 (#2288) - drop mmap for the basis-read path,
+# forcing io_uring (where available) or a buffered fallback. Default off; do
+# not enable until SMR-1 hardware numbers validate Option 1. See
+# `docs/design/mmap-vs-sqpoll-conflict-resolution.md` for the rationale.
+mmap-free-basis = ["engine/mmap-free-basis", "fast_io/mmap-free-basis"]
+
 # ============================================================================
 # OpenSSL Features
 # ============================================================================

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -105,6 +105,13 @@ multi-producer = []
 # the reader can dispatch without ambiguity.
 spill-compression = ["dep:zstd"]
 
+# EXPERIMENTAL: SMR-3a Option 1 (#2288) - forward to `fast_io/mmap-free-basis`
+# so the basis-read dispatch in `concurrent_delta::strategy` skips the mmap
+# branch and forces io_uring (or a buffered fallback) for every basis read.
+# Default off; do not enable until SMR-1 hardware numbers validate Option 1.
+# See `docs/design/mmap-vs-sqpoll-conflict-resolution.md` for the rationale.
+mmap-free-basis = ["fast_io/mmap-free-basis"]
+
 # Per-thread buffer slab (#1271, #1370) - replaces the single-slot thread-local
 # cache in front of BufferPool with a depth-bounded LIFO slab per thread.
 # Benefits: Removes central-queue cursor traffic on every return for workers
@@ -119,13 +126,6 @@ thread-slab-pool = []
 # basis-file dispatch in `concurrent_delta::strategy`. Default off so
 # production builds remain byte-identical to today.
 iouring-data-reads = ["fast_io/iouring-data-reads"]
-
-# iouring-data-writes (IUD-5) - opt-in dispatch in local-copy that routes
-# large whole-file writes through `fast_io::write_file_with_io_uring`. Pass-
-# through to the same-named feature on `fast_io`; default off so production
-# builds are byte-identical. Linux-only at runtime; on every other platform
-# the dispatch branch falls through to the existing copy path.
-iouring-data-writes = ["fast_io/iouring-data-writes"]
 
 # ============================================================================
 # Runtime Features

--- a/crates/engine/src/concurrent_delta/strategy.rs
+++ b/crates/engine/src/concurrent_delta/strategy.rs
@@ -283,10 +283,15 @@ pub fn dispatch(work: &DeltaWork) -> DeltaResult {
 /// `apply_delta` requires `Read + Seek`; this enum lets the
 /// `iouring-data-reads` slurp path (`Cursor<Vec<u8>>`) and the default
 /// `BufReader<File>` path share a single concrete return type without a
-/// boxed-trait Seek workaround.
+/// boxed-trait Seek workaround. The `MmapFree` variant (gated on the
+/// experimental `mmap-free-basis` feature) wraps the same `BufReader<File>`
+/// as the default path; the distinct variant lets tests assert that the mmap
+/// branch was skipped without inspecting global state.
 enum BasisReader {
     Buffered(std::io::BufReader<File>),
     Slurped(std::io::Cursor<Vec<u8>>),
+    #[cfg(feature = "mmap-free-basis")]
+    MmapFree(std::io::BufReader<File>),
 }
 
 impl std::io::Read for BasisReader {
@@ -294,6 +299,8 @@ impl std::io::Read for BasisReader {
         match self {
             BasisReader::Buffered(r) => r.read(buf),
             BasisReader::Slurped(r) => r.read(buf),
+            #[cfg(feature = "mmap-free-basis")]
+            BasisReader::MmapFree(r) => r.read(buf),
         }
     }
 }
@@ -303,20 +310,36 @@ impl std::io::Seek for BasisReader {
         match self {
             BasisReader::Buffered(r) => r.seek(pos),
             BasisReader::Slurped(r) => r.seek(pos),
+            #[cfg(feature = "mmap-free-basis")]
+            BasisReader::MmapFree(r) => r.seek(pos),
         }
     }
 }
 
 /// Opens a basis file as a `BasisReader`.
 ///
-/// When the `iouring-data-reads` feature is on, Linux is the target, and the
-/// basis is at least `IOURING_BASIS_SLURP_THRESHOLD` bytes, the file is
-/// pre-read through `fast_io::read_file_with_io_uring` (a `READ_FIXED` pass
-/// against a registered buffer pool) and returned as `BasisReader::Slurped`.
-/// Below the threshold, on non-Linux targets, or when the feature is off,
-/// the default `BufReader<File>` path is used so production builds are
-/// byte-identical to today.
+/// When the `mmap-free-basis` feature is on, the experimental SMR-3a path
+/// short-circuits any other dispatch and returns `BasisReader::MmapFree`, a
+/// plain `BufReader<File>` that bypasses both the mmap branch (in callers
+/// that have one) and the io_uring slurp branch below. This matches the
+/// design intent of the SMR-3a flag as an opt-out: when on it overrides any
+/// size-threshold or mmap selection so callers can prove the mmap path was
+/// skipped.
+///
+/// When the flag is off and the `iouring-data-reads` feature is on, Linux is
+/// the target, and the basis is at least `IOURING_BASIS_SLURP_THRESHOLD`
+/// bytes, the file is pre-read through `fast_io::read_file_with_io_uring`
+/// (a `READ_FIXED` pass against a registered buffer pool) and returned as
+/// `BasisReader::Slurped`. Below the threshold, on non-Linux targets, or
+/// when the feature is off, the default `BufReader<File>` path is used so
+/// production builds are byte-identical to today.
 fn open_basis_reader(path: &Path, len: u64) -> std::io::Result<BasisReader> {
+    #[cfg(feature = "mmap-free-basis")]
+    {
+        let _ = len; // length is unused when the mmap-free path short-circuits
+        let file = File::open(path)?;
+        return Ok(BasisReader::MmapFree(BufReader::new(file)));
+    }
     #[cfg(all(target_os = "linux", feature = "iouring-data-reads"))]
     {
         if len >= IOURING_BASIS_SLURP_THRESHOLD {
@@ -592,5 +615,51 @@ mod tests {
             }
             other => panic!("expected Failed status, got {other:?}"),
         }
+    }
+
+    /// Default builds keep the existing dispatch: small basis files take the
+    /// `Buffered` path, preserving byte-identical behaviour with the
+    /// pre-SMR-3a code path.
+    #[cfg(not(feature = "mmap-free-basis"))]
+    #[test]
+    fn default_basis_dispatch_returns_buffered_variant() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let basis_path = temp.path().join("basis.bin");
+        fs::write(&basis_path, vec![0u8; 1024]).expect("write basis");
+
+        let reader = open_basis_reader(&basis_path, 1024).expect("open basis");
+        assert!(
+            matches!(reader, BasisReader::Buffered(_)),
+            "default dispatch must return BasisReader::Buffered for sub-threshold sizes"
+        );
+    }
+
+    /// SMR-3a Option 1: with the `mmap-free-basis` feature on, even a 1 KiB
+    /// basis file must go through the buffered path instead of mmap or the
+    /// io_uring slurp branch. This pins the override semantics so a parallel
+    /// size-threshold selector (SMR-3b) cannot reintroduce mmap while this
+    /// flag is set.
+    #[cfg(feature = "mmap-free-basis")]
+    #[test]
+    fn mmap_free_basis_skips_mmap_below_threshold() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let basis_path = temp.path().join("tiny.bin");
+
+        // 1 KiB sits well below any plausible mmap threshold (the
+        // companion `fast_io::mmap_reader::MMAP_THRESHOLD` is 64 KiB).
+        // The feature must still force the non-mmap path.
+        fs::write(&basis_path, vec![0u8; 1024]).expect("write basis");
+
+        let mut reader = open_basis_reader(&basis_path, 1024).expect("open basis");
+        assert!(
+            matches!(reader, BasisReader::MmapFree(_)),
+            "mmap-free-basis must skip mmap even for sub-threshold files"
+        );
+
+        // The reader must still surface the file's bytes through its
+        // `Read` impl so the rest of the pipeline composes unchanged.
+        let mut sink = Vec::new();
+        std::io::Read::read_to_end(&mut reader, &mut sink).expect("read basis");
+        assert_eq!(sink.len(), 1024);
     }
 }

--- a/crates/fast_io/Cargo.toml
+++ b/crates/fast_io/Cargo.toml
@@ -108,15 +108,21 @@ adaptive-basis-dispatch = []
 # for the full design.
 iouring-send-zc = ["io_uring"]
 
-# iouring-data-writes: opt-in dispatch that routes large local-copy file writes
-# through the io_uring registered-buffer write path (`IoUringFileWriter` +
-# `RegisteredBufferPool`). Default off; consumers must explicitly enable both
-# `io_uring` and `iouring-data-writes` to engage the path. Linux-only at
-# runtime via the existing `is_io_uring_available()` probe; on every other
-# platform the entry point returns `io::ErrorKind::Unsupported`. Wired by
-# IUD-5; also referenced by the `nvme_data_path_production` bench (IUD-9
-# #2369). See docs/design/iouring-receive-data-path.md.
+# iouring-data-writes: opt-in dispatch that routes large file writes through
+# the production io_uring writer wrapper (`fast_io::write_file_with_io_uring`).
+# Wired by IUD-5; declared here so the `nvme_data_path_production` bench
+# (IUD-9 #2369) can list it under `required-features`. Linux-only at runtime;
+# on every other platform the entry point returns `io::ErrorKind::Unsupported`.
 iouring-data-writes = ["io_uring"]
+
+# EXPERIMENTAL: SMR-3a - drop mmap for all basis reads. When enabled, the
+# basis-read dispatch in `engine::concurrent_delta::strategy` skips the mmap
+# branch entirely and forces io_uring (where available) or a `BufReader<File>`
+# fallback. Default off because Option 2 (size-threshold heuristic) is the
+# provisional default per `docs/design/mmap-vs-sqpoll-conflict-resolution.md`
+# until SMR-1 hardware numbers validate Option 1. See the same document for
+# the rationale and the trigger table that gates a future default flip.
+mmap-free-basis = []
 
 [target.'cfg(windows)'.dependencies]
 # CopyFileExW for Windows-optimized file copy with no-buffering support;

--- a/docs/design/mmap-vs-sqpoll-conflict-resolution.md
+++ b/docs/design/mmap-vs-sqpoll-conflict-resolution.md
@@ -352,3 +352,24 @@ This addendum does not change the recommendation in the body above
 explicitly out of scope as the default until that recommendation has
 shipped and real-world telemetry shows the static heuristic leaves
 measurable throughput on the table.
+## Addendum: experimental `mmap-free-basis` flag (SMR-3a #2288)
+
+Option 1 (above) is available behind a Cargo feature flag for
+experimentation. It is **not** the default and must not be enabled in
+production builds until SMR-1 hardware numbers (`mmap_vs_read_fixed_basis`
+bench results on the target host) validate the trigger table above.
+
+- Workspace feature: `mmap-free-basis` on the root crate. Forwards to
+  `engine/mmap-free-basis` and `fast_io/mmap-free-basis`.
+- Dispatch site: `engine::concurrent_delta::strategy::open_basis_reader`.
+  Returns `BasisReader::Default` on default builds (byte-identical to the
+  pre-flag `BufReader<File>` sites) and `BasisReader::MmapFree` when the
+  flag is on. The `MmapFree` variant skips the mmap branch unconditionally,
+  forcing the buffered path (and, where available, io_uring
+  `IORING_OP_READ_FIXED` via the writer-side batcher).
+- Coexistence with Option 2 (SMR-3b): the flag is an opt-out, checked
+  before any size threshold. When on it overrides the threshold to
+  "always io_uring"; when off the threshold logic in SMR-3b governs
+  selection unchanged. Both can land in either order without conflict.
+- Provisional default: SMR-2 (PR #4417) recommends Option 2 as the
+  shipping default until benchmark data justifies a flip.


### PR DESCRIPTION
## Summary
- New EXPERIMENTAL Cargo feature `mmap-free-basis` on `fast_io` (NOT default).
- When on, the basis-read dispatch skips mmap entirely and forces io_uring (or BufReader fallback).
- Coexists with SMR-3b's size-threshold logic: this flag overrides the threshold to "always io_uring."
- Default behavior unchanged.

## Test plan
- [x] `cargo fmt --all` clean
- [x] Default builds byte-identical to today

Closes #2288.