### PR TITLE
chore(safety): add SAFETY comments to the remaining 21 unsafe blocks (per #4412)

### DIFF
--- a/crates/core/src/client/tests/module_list_auth.rs
+++ b/crates/core/src/client/tests/module_list_auth.rs
@@ -125,6 +125,7 @@ impl EnvGuard {
     fn set(key: &'static str, value: &str) -> Self {
         let previous = env::var_os(key);
         #[allow(unsafe_code)]
+        // SAFETY: Test-only EnvGuard serializes env access; no other threads read this key concurrently.
         unsafe {
             env::set_var(key, value);
         }
@@ -134,6 +135,7 @@ impl EnvGuard {
     fn set_os(key: &'static str, value: &OsStr) -> Self {
         let previous = env::var_os(key);
         #[allow(unsafe_code)]
+        // SAFETY: Test-only EnvGuard serializes env access; no other threads read this key concurrently.
         unsafe {
             env::set_var(key, value);
         }
@@ -143,6 +145,7 @@ impl EnvGuard {
     fn remove(key: &'static str) -> Self {
         let previous = env::var_os(key);
         #[allow(unsafe_code)]
+        // SAFETY: Test-only EnvGuard serializes env access; no other threads read this key concurrently.
         unsafe {
             env::remove_var(key);
         }
@@ -154,11 +157,13 @@ impl Drop for EnvGuard {
     fn drop(&mut self) {
         if let Some(value) = self.previous.take() {
             #[allow(unsafe_code)]
+            // SAFETY: Test-only EnvGuard restores prior value during Drop; no concurrent env access in test scope.
             unsafe {
                 env::set_var(self.key, value);
             }
         } else {
             #[allow(unsafe_code)]
+            // SAFETY: Test-only EnvGuard removes key during Drop; no concurrent env access in test scope.
             unsafe {
                 env::remove_var(self.key);
             }

--- a/crates/core/src/signal/unix.rs
+++ b/crates/core/src/signal/unix.rs
@@ -197,6 +197,8 @@ extern "C" fn handle_sigpipe(_signum: libc::c_int) {
 /// # }
 /// ```
 pub fn install_signal_handlers() -> io::Result<SignalHandler> {
+    // SAFETY: Zero-initialises libc::sigaction structs (valid POD layout) before passing them
+    // to libc::sigaction; handler functions are async-signal-safe and only set atomic flags.
     unsafe {
         let mut sa_int: libc::sigaction = std::mem::zeroed();
         sa_int.sa_sigaction = handle_sigint as *const () as libc::sighandler_t;

--- a/crates/core/tests/client_integration.rs
+++ b/crates/core/tests/client_integration.rs
@@ -24,6 +24,7 @@ fn set_birthtime(path: &Path, secs: i64) {
 
     let c_path = CString::new(path.as_os_str().as_bytes()).expect("valid path");
 
+    // SAFETY: libc::attrlist is a POD struct with no Drop; zero-init is valid before field assignment.
     let mut attrlist: libc::attrlist = unsafe { std::mem::zeroed() };
     attrlist.bitmapcount = libc::ATTR_BIT_MAP_COUNT;
     attrlist.commonattr = libc::ATTR_CMN_CRTIME;
@@ -35,6 +36,7 @@ fn set_birthtime(path: &Path, secs: i64) {
         },
     };
 
+    // SAFETY: Test-only FFI; c_path/attrlist/buf are valid, correctly sized, and live for the call.
     let ret = unsafe {
         libc::setattrlist(
             c_path.as_ptr(),

--- a/crates/windows-gnu-eh/src/lib.rs
+++ b/crates/windows-gnu-eh/src/lib.rs
@@ -97,6 +97,7 @@ mod windows_gnu {
         loop {
             match state {
                 UNRESOLVED => {
+                    // SAFETY: `symbol` is a static NUL-terminated byte literal (see SYM_REGISTER/SYM_DEREGISTER); resolve_symbol's contract is satisfied.
                     let resolved = unsafe { resolve_symbol(symbol) } as usize;
                     let new_state = if resolved == 0 { MISSING } else { resolved };
                     match cache.compare_exchange(
@@ -129,6 +130,7 @@ mod windows_gnu {
         debug_assert!(!symbol.is_empty() && symbol[symbol.len() - 1] == 0);
 
         for &lib in &LIBCANDIDATES {
+            // SAFETY: `lib` and `symbol` are static NUL-terminated byte literals satisfying load_from_library's precondition.
             let ptr = unsafe { load_from_library(lib, symbol) };
             if !ptr.is_null() {
                 return ptr;
@@ -143,10 +145,12 @@ mod windows_gnu {
         debug_assert!(!library.is_empty() && library[library.len() - 1] == 0);
 
         let module = {
+            // SAFETY: `library` is a static NUL-terminated byte literal; Win32 GetModuleHandleA accepts a borrowed handle and does not retain the pointer.
             let handle = unsafe { GetModuleHandleA(library.as_ptr() as *const c_char) };
             if !handle.is_null() {
                 handle
             } else {
+                // SAFETY: `library` is a static NUL-terminated byte literal; LoadLibraryA returns a refcounted module handle owned by the process.
                 unsafe { LoadLibraryA(library.as_ptr() as *const c_char) }
             }
         };
@@ -155,31 +159,38 @@ mod windows_gnu {
             return ptr::null_mut();
         }
 
+        // SAFETY: `module` is a valid handle returned by GetModuleHandleA/LoadLibraryA; `symbol` is a static NUL-terminated byte literal.
         unsafe { GetProcAddress(module, symbol.as_ptr() as *const c_char) }
     }
 
     #[inline(always)]
     unsafe fn resolve_register() -> Option<RegisterFrameInfo> {
+        // SAFETY: SYM_REGISTER is a static NUL-terminated byte literal satisfying ensure_function's precondition.
         let ptr = match unsafe { ensure_function(&REGISTER_FRAME_INFO, SYM_REGISTER) } {
             Some(ptr) => ptr,
             None => return None,
         };
+        // SAFETY: GetProcAddress returned a pointer to `__register_frame_info`, whose ABI matches RegisterFrameInfo.
         Some(unsafe { transmute::<*mut (), RegisterFrameInfo>(ptr) })
     }
 
     #[inline(always)]
     unsafe fn resolve_deregister() -> Option<DeregisterFrameInfo> {
+        // SAFETY: SYM_DEREGISTER is a static NUL-terminated byte literal satisfying ensure_function's precondition.
         let ptr = match unsafe { ensure_function(&DEREGISTER_FRAME_INFO, SYM_DEREGISTER) } {
             Some(ptr) => ptr,
             None => return None,
         };
+        // SAFETY: GetProcAddress returned a pointer to `__deregister_frame_info`, whose ABI matches DeregisterFrameInfo.
         Some(unsafe { transmute::<*mut (), DeregisterFrameInfo>(ptr) })
     }
 
     /// Forwards `rsbegin`'s registration hook to libunwind.
     #[unsafe(no_mangle)]
     pub unsafe extern "C" fn ___register_frame_info(eh_frame: *const u8, object: *mut c_void) {
+        // SAFETY: resolve_register has no preconditions beyond those satisfied by static symbol constants.
         if let Some(register) = unsafe { resolve_register() } {
+            // SAFETY: eh_frame/object validity is the caller's contract per rsbegin.o's invocation; we forward unchanged to libgcc/libunwind.
             unsafe {
                 register(eh_frame, object);
             }
@@ -189,7 +200,9 @@ mod windows_gnu {
     /// Forwards `rsbegin`'s deregistration hook to libunwind.
     #[unsafe(no_mangle)]
     pub unsafe extern "C" fn ___deregister_frame_info(eh_frame: *const u8) {
+        // SAFETY: resolve_deregister has no preconditions beyond those satisfied by static symbol constants.
         if let Some(deregister) = unsafe { resolve_deregister() } {
+            // SAFETY: eh_frame validity is the caller's contract per rsbegin.o's invocation; we forward unchanged to libgcc/libunwind.
             unsafe {
                 deregister(eh_frame);
             }


### PR DESCRIPTION
## Summary
- Add accurate `// SAFETY:` comments to the 21 pre-existing unsafe blocks in `core` and `windows-gnu-eh` identified by PR #4412.
- Brings workspace SAFETY-comment coverage to 100% (589/589 blocks, 0 violations reported by `tools/audit/unsafe_safety_comment_audit.py`).
- Pure comment additions; no unsafe block bodies modified.

## Details
- `crates/core/src/client/tests/module_list_auth.rs` (5 sites): test-only `EnvGuard` serializes env access; no concurrent readers in test scope.
- `crates/core/src/signal/unix.rs` (1 site): zero-initialised `libc::sigaction` POD structs are valid before fielding; handlers are async-signal-safe and only set atomic flags.
- `crates/core/tests/client_integration.rs` (2 sites): test-only FFI; `libc::attrlist` is POD, and `setattrlist` inputs are valid and live for the call.
- `crates/windows-gnu-eh/src/lib.rs` (13 sites): Win32 symbol resolution shims. Symbol/library byte literals are static NUL-terminated; module handles returned by `GetModuleHandleA`/`LoadLibraryA` are valid; `transmute` to the C ABI function pointer matches the documented contract of `__register_frame_info`/`__deregister_frame_info`; caller (rsbegin.o) supplies valid eh_frame/object pointers per its invocation contract.

## Test plan
- [x] `cargo fmt --all` clean
- [x] `tools/audit/unsafe_safety_comment_audit.py` reports `Total violations: 0`