### PR TITLE
docs(changelog): round 2 sync with shipped PRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ tags are mirrored on GitHub at <https://github.com/oferchen/rsync/releases>.
   fill the 64 KiB pipe buffer), when to enable it, and platform constraints.
   Added `docs/ssh-transport.md` and cross-linked from the Cargo features
   table in `README.md` (#2377).
+- Refresh spill layout and migration status (SPL-12) (#4394).
+- Cross-platform CI hazard preflight audit (#4427).
 
 ### Performance
 


### PR DESCRIPTION
## Summary
- Append PRs that landed after PR #4415's sync.
- Grouped by conventional-commit prefix.