### PR TITLE
docs: round 2 - add /// on remaining pub mod declarations (per #4424)

### DIFF
--- a/crates/apple-fs/src/lib.rs
+++ b/crates/apple-fs/src/lib.rs
@@ -9,7 +9,9 @@ use std::ffi::OsStr;
 use std::io;
 use std::path::{Path, PathBuf};
 
+/// AppleDouble v2 (RFC 1740) container parser and encoder.
 pub mod apple_double;
+/// Safe accessors for the macOS native resource fork and Finder info.
 pub mod resource_fork;
 
 pub use resource_fork::{

--- a/crates/branding/src/lib.rs
+++ b/crates/branding/src/lib.rs
@@ -6,8 +6,11 @@
 
 mod generated;
 
+/// Branding constants and helpers shared across the workspace.
 pub mod branding;
+/// Validation utilities for branding configuration.
 pub mod validation;
+/// Workspace metadata exported as compile-time constants.
 pub mod workspace;
 
 pub use generated::{BUILD_REVISION, BUILD_TOOLCHAIN};

--- a/crates/checksums/src/lib.rs
+++ b/crates/checksums/src/lib.rs
@@ -359,9 +359,12 @@
 #![deny(rustdoc::broken_intra_doc_links)]
 
 pub mod cpu_features;
+/// CRC32C hardware-accelerated checksum for fast file change detection.
 pub mod crc32c;
 mod rolling;
+/// Runtime SIMD-vs-scalar checksum parity self-test entry point.
 pub mod simd_self_test;
+/// Strong checksum implementations (MD4, MD5, XXH64, XXH3/64, XXH3/128).
 pub mod strong;
 
 #[cfg(test)]

--- a/crates/checksums/src/pipelined/mod.rs
+++ b/crates/checksums/src/pipelined/mod.rs
@@ -49,6 +49,7 @@
 
 mod checksums;
 mod config;
+/// Double-buffered reader that overlaps I/O with computation.
 pub mod reader;
 
 pub use checksums::{BlockChecksums, PipelinedChecksumIterator, compute_checksums_pipelined};

--- a/crates/checksums/src/simd_batch/md4/mod.rs
+++ b/crates/checksums/src/simd_batch/md4/mod.rs
@@ -31,6 +31,7 @@
 
 pub mod scalar;
 
+/// SIMD backend implementations for MD4 (x86_64 SSE2/AVX2/AVX-512, aarch64 NEON, wasm32).
 #[cfg(any(
     target_arch = "x86_64",
     target_arch = "aarch64",

--- a/crates/checksums/src/simd_batch/md4/simd/mod.rs
+++ b/crates/checksums/src/simd_batch/md4/simd/mod.rs
@@ -8,14 +8,18 @@
 #[cfg(target_arch = "x86_64")]
 pub mod sse2;
 
+/// AVX2 8-lane parallel MD4 implementation.
 #[cfg(target_arch = "x86_64")]
 pub mod avx2;
 
+/// AVX-512 16-lane parallel MD4 implementation.
 #[cfg(target_arch = "x86_64")]
 pub mod avx512;
 
+/// ARM NEON 4-lane parallel MD4 implementation.
 #[cfg(target_arch = "aarch64")]
 pub mod neon;
 
+/// WebAssembly SIMD 4-lane parallel MD4 implementation.
 #[cfg(target_arch = "wasm32")]
 pub mod wasm;

--- a/crates/checksums/src/simd_batch/md5_simd/mod.rs
+++ b/crates/checksums/src/simd_batch/md5_simd/mod.rs
@@ -7,20 +7,26 @@
 #[cfg(target_arch = "x86_64")]
 pub mod sse2;
 
+/// SSSE3 4-lane parallel MD5 implementation.
 #[cfg(target_arch = "x86_64")]
 pub mod ssse3;
 
+/// SSE4.1 4-lane parallel MD5 implementation.
 #[cfg(target_arch = "x86_64")]
 pub mod sse41;
 
+/// AVX2 8-lane parallel MD5 implementation.
 #[cfg(target_arch = "x86_64")]
 pub mod avx2;
 
+/// AVX-512 16-lane parallel MD5 implementation.
 #[cfg(target_arch = "x86_64")]
 pub mod avx512;
 
+/// ARM NEON 4-lane parallel MD5 implementation.
 #[cfg(target_arch = "aarch64")]
 pub mod neon;
 
+/// WebAssembly SIMD 4-lane parallel MD5 implementation.
 #[cfg(target_arch = "wasm32")]
 pub mod wasm;

--- a/crates/checksums/src/simd_batch/mod.rs
+++ b/crates/checksums/src/simd_batch/mod.rs
@@ -19,6 +19,7 @@ mod md5_scalar;
 #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 mod md5_simd;
 
+/// MD4 hashing implementations with optional SIMD batch acceleration.
 pub mod md4;
 
 pub use md5_dispatcher::Backend;

--- a/crates/checksums/src/strong/mod.rs
+++ b/crates/checksums/src/strong/mod.rs
@@ -62,6 +62,7 @@ mod openssl_support;
 mod sha1;
 mod sha256;
 mod sha512;
+/// Strategy pattern for runtime checksum algorithm selection.
 pub mod strategy;
 mod xxhash;
 

--- a/crates/compress/src/lib.rs
+++ b/crates/compress/src/lib.rs
@@ -72,13 +72,16 @@
 
 pub mod algorithm;
 mod common;
+/// LZ4 compression support in both standard frame and rsync raw-block formats.
 #[cfg(feature = "lz4")]
 pub mod lz4;
 /// Compression tuning based on file type detection.
 pub mod skip_compress;
 /// Strategy pattern for runtime compression algorithm selection.
 pub mod strategy;
+/// Raw deflate compression helpers for rsync wire protocol compatibility.
 pub mod zlib;
+/// Streaming Zstandard helpers shared across the workspace.
 #[cfg(feature = "zstd")]
 pub mod zstd;
 

--- a/crates/compress/src/lz4/mod.rs
+++ b/crates/compress/src/lz4/mod.rs
@@ -38,6 +38,7 @@
 //! ```
 
 pub mod frame;
+/// Raw LZ4 block compression for rsync wire protocol compatibility.
 pub mod raw;
 
 /// Commonly used frame types re-exported for convenience.

--- a/crates/core/src/client/mod.rs
+++ b/crates/core/src/client/mod.rs
@@ -94,6 +94,7 @@ mod error;
 mod module_list;
 mod outcome;
 mod progress;
+/// Remote transfer orchestration for SSH and daemon transports.
 pub mod remote;
 mod run;
 mod summary;

--- a/crates/core/src/client/remote/mod.rs
+++ b/crates/core/src/client/remote/mod.rs
@@ -23,12 +23,17 @@
 #[cfg(feature = "async-ssh")]
 pub mod async_ssh_transport;
 pub(crate) mod batch_support;
+/// Daemon transfer orchestration for `rsync://` URLs.
 pub mod daemon_transfer;
+/// Embedded SSH transfer orchestration using the russh library.
 #[cfg(feature = "embedded-ssh")]
 pub mod embedded_ssh_transfer;
 pub(crate) mod flags;
+/// Remote rsync `--server` invocation argument builder.
 pub mod invocation;
+/// Remote-to-remote transfer via local proxy relay.
 pub mod remote_to_remote;
+/// SSH transfer orchestration for `ssh://` and `host:path` targets.
 pub mod ssh_transfer;
 #[cfg(feature = "async-ssh")]
 pub use async_ssh_transport::{

--- a/crates/daemon/src/daemon.rs
+++ b/crates/daemon/src/daemon.rs
@@ -66,15 +66,18 @@ use crate::{config::DaemonConfig, error::DaemonError, systemd};
 mod help;
 pub(crate) mod tracing_stream;
 
+/// Concurrent session tracking for the daemon accept loop.
 #[cfg(feature = "concurrent-sessions")]
 pub mod session_registry;
 
+/// Thread-safe connection pool with per-IP rate limiting.
 #[cfg(feature = "concurrent-sessions")]
 pub mod connection_pool;
 
 #[cfg(all(test, feature = "concurrent-sessions"))]
 mod concurrent_tests;
 
+/// Tokio-based async session handling for the rsync daemon.
 #[cfg(feature = "async")]
 #[cfg_attr(docsrs, doc(cfg(feature = "async")))]
 pub mod async_session;

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -173,11 +173,13 @@
 #[cfg(feature = "async-daemon")]
 #[cfg_attr(docsrs, doc(cfg(feature = "async-daemon")))]
 pub mod async_listener;
+/// Daemon mode challenge-response authentication matching upstream rsync 3.4.1.
 pub mod auth;
 mod cli;
 mod config;
 mod daemon;
 mod error;
+/// Daemon configuration file parsing for `rsyncd.conf`.
 pub mod rsyncd_config;
 mod systemd;
 

--- a/crates/engine/src/concurrent_delta/mod.rs
+++ b/crates/engine/src/concurrent_delta/mod.rs
@@ -170,16 +170,23 @@
 //! - `transfer::pipeline` for the pipelined receiver architecture
 
 pub mod adaptive;
+/// Runtime configuration for the concurrent delta pipeline.
 pub mod config;
+/// Ordered consumer that drains the work queue into the reorder buffer.
 pub mod consumer;
 #[cfg(test)]
 mod multi_producer_audit;
+/// Parallel receive-side delta apply scaffold gated behind `parallel-receive-delta`.
 #[cfg(feature = "parallel-receive-delta")]
 pub mod parallel_apply;
+/// Sequence-based reorder buffer for the concurrent delta pipeline.
 pub mod reorder;
+/// Bounded-memory spill-to-tempfile layer for the reorder buffer.
 pub mod spill;
+/// Strategy pattern dispatching whole-file versus delta-transfer work.
 pub mod strategy;
 mod types;
+/// Bounded work queue with backpressure for the concurrent delta pipeline.
 pub mod work_queue;
 
 pub use adaptive::{AdaptiveCapacityPolicy, ReorderStats};

--- a/crates/engine/src/concurrent_delta/reorder/mod.rs
+++ b/crates/engine/src/concurrent_delta/reorder/mod.rs
@@ -30,6 +30,7 @@ use std::time::{Duration, Instant};
 
 use super::adaptive::{AdaptiveCapacityPolicy, AdaptiveState, ReorderStats};
 
+/// Bucketed histograms for reorder-buffer diagnostics.
 pub mod histogram;
 
 pub use histogram::HistogramStats;

--- a/crates/engine/src/concurrent_delta/spill.rs
+++ b/crates/engine/src/concurrent_delta/spill.rs
@@ -64,8 +64,11 @@ use std::path::{Path, PathBuf};
 
 use super::reorder::{CapacityExceeded, ReorderBuffer};
 
+/// Environment-variable overrides for [`SpillPolicy`] fields at runtime.
 pub mod env;
+/// Public policy types that configure the reorder buffer spill layer.
 pub mod policy;
+/// Spill-layer counters and aggregate stats exposed to operators.
 pub mod stats;
 pub use env::{
     ENV_SPILL_COMPRESSION, ENV_SPILL_DIR, ENV_SPILL_THRESHOLD_BYTES, apply_env_overrides,

--- a/crates/engine/src/concurrent_delta/work_queue/mod.rs
+++ b/crates/engine/src/concurrent_delta/work_queue/mod.rs
@@ -99,6 +99,7 @@ mod bounded;
 mod capacity;
 mod drain;
 mod iter;
+/// AIMD adaptive-concurrency limiter for the work queue.
 pub mod limiter;
 #[cfg(feature = "multi-producer")]
 mod multi_producer;

--- a/crates/engine/src/delete/mod.rs
+++ b/crates/engine/src/delete/mod.rs
@@ -33,6 +33,7 @@
 
 mod cohort_index;
 mod context;
+/// Single-threaded emitter that drains delete plans in upstream traversal order.
 pub mod emitter;
 mod extras;
 mod plan;

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -128,13 +128,21 @@
 #[cfg_attr(docsrs, doc(cfg(feature = "async")))]
 pub mod async_io;
 
+/// Concurrent delta computation pipeline for parallel file processing.
 pub mod concurrent_delta;
+/// Parallel-deterministic delete pipeline data structures and emitter.
 pub mod delete;
+/// Block-matching helpers for the delta-transfer pipeline.
 pub mod delta;
+/// Common error types for the engine crate.
 pub mod error;
+/// Hardlink detection and resolution matching upstream `hlink.c`.
 pub mod hardlink;
+/// Deterministic local filesystem copy planner and executor.
 pub mod local_copy;
+/// Internal utilities shared across engine submodules.
 pub mod util;
+/// Directory traversal abstractions for rsync file list generation.
 pub mod walk;
 
 #[doc(hidden)]

--- a/crates/engine/src/local_copy/executor/file/mod.rs
+++ b/crates/engine/src/local_copy/executor/file/mod.rs
@@ -6,6 +6,7 @@ mod backup_trace;
 mod comparison;
 mod copy;
 mod guard;
+/// Partial file management for interrupted transfers.
 pub mod partial;
 mod paths;
 mod preallocate;

--- a/crates/engine/src/local_copy/mod.rs
+++ b/crates/engine/src/local_copy/mod.rs
@@ -51,6 +51,7 @@
 
 /// Buffer pool for I/O buffer reuse during large file transfers.
 pub mod buffer_pool;
+/// Copy-on-write file cloning with macOS `clonefile()` dual-path selection.
 pub mod clonefile;
 mod compressor;
 mod context;
@@ -89,6 +90,7 @@ pub mod pipelined_state;
 mod plan;
 pub(crate) mod prefetch;
 mod skip_compress;
+/// Windows `CopyFileExW` file copying with dual-path runtime selection.
 pub mod win_copy;
 
 pub use buffer_pool::{

--- a/crates/flist/src/lib.rs
+++ b/crates/flist/src/lib.rs
@@ -91,6 +91,7 @@ mod lazy_entry;
 mod lazy_metadata;
 pub(crate) mod symlink_safety;
 
+/// Parallel file list processing utilities using rayon.
 #[cfg(feature = "parallel")]
 #[cfg_attr(docsrs, doc(cfg(feature = "parallel")))]
 pub mod parallel;

--- a/crates/logging/src/lib.rs
+++ b/crates/logging/src/lib.rs
@@ -74,6 +74,7 @@
 #![deny(rustdoc::broken_intra_doc_links)]
 
 mod config;
+/// Upstream-compatible error and warning formatting.
 pub mod error_format;
 mod levels;
 mod macros;

--- a/crates/matching/src/lib.rs
+++ b/crates/matching/src/lib.rs
@@ -24,6 +24,7 @@
 mod fuzzy;
 mod generator;
 mod index;
+/// Two-level block match search mirroring upstream rsync's `match.c`.
 pub mod optimized_search;
 mod ring_buffer;
 mod script;

--- a/crates/metadata/src/lib.rs
+++ b/crates/metadata/src/lib.rs
@@ -101,9 +101,11 @@ mod acl_noop;
 
 mod apply;
 mod chmod;
+/// Privilege switching for `--copy-as=USER[:GROUP]`.
 pub mod copy_as;
 mod error;
 
+/// UID/GID lookup and mapping utilities.
 pub mod id_lookup;
 
 #[cfg(unix)]
@@ -146,14 +148,17 @@ mod xattr_windows;
 #[cfg(not(all(feature = "xattr", any(unix, windows))))]
 mod xattr_stub;
 
+/// NFSv4 Access Control List support for rsync transfers.
 #[cfg(all(unix, feature = "xattr"))]
 pub mod nfsv4_acl;
 
+/// No-op NFSv4 ACL stubs for platforms without xattr support.
 #[cfg(not(all(unix, feature = "xattr")))]
 pub mod nfsv4_acl_stub;
 #[cfg(not(all(unix, feature = "xattr")))]
 pub use nfsv4_acl_stub as nfsv4_acl;
 
+/// Fake super-user mode for preserving privileged metadata without root.
 pub mod fake_super;
 
 #[cfg(all(

--- a/crates/protocol/src/acl/mod.rs
+++ b/crates/protocol/src/acl/mod.rs
@@ -33,6 +33,7 @@
 mod constants;
 mod definition;
 mod entry;
+/// `--debug=ACL` producer emissions for POSIX ACL processing.
 pub mod trace;
 mod wire;
 

--- a/crates/protocol/src/iconv/mod.rs
+++ b/crates/protocol/src/iconv/mod.rs
@@ -29,6 +29,7 @@
 mod converter;
 mod error;
 mod pair;
+/// `--debug=ICONV` producer emissions for charset setup.
 pub mod trace;
 
 pub use converter::{EncodingConverter, FilenameConverter, converter_from_locale};

--- a/crates/protocol/src/wire/mod.rs
+++ b/crates/protocol/src/wire/mod.rs
@@ -17,10 +17,15 @@
 //! which provides [`crate::flist::FileListWriter`] and [`crate::flist::FileListReader`].
 
 pub mod compressed_token;
+/// Delta token encoding for file reconstruction.
 pub mod delta;
+/// Low-level file entry wire format encoding functions.
 pub mod file_entry;
+/// Low-level file entry wire format decoding functions.
 pub mod file_entry_decode;
+/// Signature block encoding for delta generation.
 pub mod signature;
+/// Vectored wire format I/O helpers for batched writes.
 pub mod vectored;
 
 pub use self::compressed_token::{

--- a/crates/rsync_io/src/lib.rs
+++ b/crates/rsync_io/src/lib.rs
@@ -66,12 +66,14 @@
 //!   reported to the user.
 
 mod binary;
+/// In-process channel adapters bridging `tokio::sync::mpsc` to `AsyncRead` / `AsyncWrite`.
 #[cfg(feature = "async-ssh")]
 pub mod channel_adapter;
 mod daemon;
 mod handshake_util;
 mod negotiation;
 mod session;
+/// SSH transport implementations and helpers.
 pub mod ssh;
 
 pub use binary::{

--- a/crates/rsync_io/src/ssh/embedded/mod.rs
+++ b/crates/rsync_io/src/ssh/embedded/mod.rs
@@ -20,6 +20,7 @@ mod handler;
 mod resolve;
 #[cfg(feature = "embedded-ssh")]
 mod ssh_config;
+/// Sync/async bridge primitives for embedded SSH streams.
 #[cfg(feature = "embedded-ssh")]
 pub mod sync_bridge;
 #[cfg(feature = "embedded-ssh")]

--- a/crates/rsync_io/src/ssh/mod.rs
+++ b/crates/rsync_io/src/ssh/mod.rs
@@ -90,9 +90,11 @@ mod aux_channel;
 mod builder;
 mod connect;
 mod connection;
+/// Embedded SSH transport using the russh library.
 pub mod embedded;
 mod operand;
 mod parse;
+/// Cross-platform stderr aux-channel between the parent process and a spawned `ssh` child.
 #[cfg(feature = "ssh-socketpair-stderr")]
 pub mod socketpair_stderr;
 

--- a/crates/transfer/src/pipeline/mod.rs
+++ b/crates/transfer/src/pipeline/mod.rs
@@ -60,15 +60,21 @@
 //! This is configured via [`PipelineConfig::ack_batch_size`].
 
 pub mod async_signature;
+/// Pipeline dispatch types (`FileList`, `FileJob`) for the async transfer architecture.
 pub mod job;
+/// Channel messages for the decoupled network-to-disk receiver architecture.
 pub mod messages;
 mod pending;
+/// `PipelinedReceiver` mediator between network and disk threads.
 pub mod receiver;
+/// Lock-free single-producer / single-consumer channel for the network-to-disk path.
 pub mod spsc;
 mod state;
 
+/// Async file job producer for the tokio-based transfer pipeline.
 #[cfg(feature = "async")]
 pub mod async_dispatch;
+/// Async pipeline orchestrator for tokio-based file transfers.
 #[cfg(feature = "async")]
 pub mod async_pipeline;
 

--- a/crates/transfer/src/shared/mod.rs
+++ b/crates/transfer/src/shared/mod.rs
@@ -9,6 +9,7 @@
 //! - [`TransferDeadline`] - Monotonic deadline for `--stop-at` / `--stop-after` enforcement
 
 pub mod checksum;
+/// Deadline enforcement for `--stop-at` / `--stop-after` / `--time-limit`.
 pub mod deadline;
 
 pub use checksum::ChecksumFactory;


### PR DESCRIPTION
## Summary
- Round 2 of PR #4424 audit. PR #4437 closed 55 of 130 strict gaps; this PR closes the remaining `pub mod NAME;` sites across `engine`, `checksums`, `protocol`, `transfer`, `core`, `daemon`, `metadata`, `rsync_io`, `compress`, `branding`, `apple-fs`, `flist`, `logging`, and `matching`.
- 86 one-line `///` summaries added across 35 files. Submodule contents untouched.
- After this PR plus #4437, the strict `pub mod NAME;` gap closes to 0 across the workspace.

## Test plan
- [x] `cargo fmt --all` clean
- [x] Audit script re-run shows 0 remaining strict gaps in files outside PR #4437