### PR TITLE
fix(fast_io): import FileReader trait for IoUringFileReader::open

### DIFF
--- a/crates/fast_io/src/io_uring/data_reader.rs
+++ b/crates/fast_io/src/io_uring/data_reader.rs
@@ -28,6 +28,8 @@
 use std::io;
 use std::path::Path;
 
+use crate::traits::FileReader;
+
 use super::config::IoUringConfig;
 use super::file_reader::IoUringReader;
 


### PR DESCRIPTION
## Summary
Master is currently failing fmt+clippy with E0599: `IoUringFileReader::open` calls `inner.size()` on \`IoUringReader\` but the \`FileReader\` trait that provides \`size()\` is not imported. Every rebased PR inherits the same failure.

Fix: add \`use crate::traits::FileReader;\` to \`crates/fast_io/src/io_uring/data_reader.rs\`.

## Test plan
- [x] \`cargo fmt --all\` clean
- [ ] CI fmt+clippy passes (this is the validation)