### PR TITLE
fix(fast_io): clippy::borrow_deref_ref in macos_io.rs (POST-3h #2424)

### DIFF
--- a/crates/fast_io/src/macos_io.rs
+++ b/crates/fast_io/src/macos_io.rs
@@ -333,7 +333,7 @@ pub fn writev_buffers(file: &std::fs::File, buffers: &[&[u8]]) -> io::Result<usi
                 continue;
             }
             use std::io::Write;
-            let mut file_ref = &*file;
+            let mut file_ref = file;
             file_ref.write_all(&buf[remaining..])?;
             total_written += buf[remaining..].len();
             remaining = 0;


### PR DESCRIPTION
Per POST-3 audit (PR #4461).