### PR TITLE
fix(fast_io): drop redundant macos cfg on kqueue (POST-3g #2423)

### DIFF
--- a/crates/fast_io/src/kqueue/mod.rs
+++ b/crates/fast_io/src/kqueue/mod.rs
@@ -37,8 +37,6 @@
 //! "one ring per thread" composition rule documented in
 //! `docs/design/io-uring-rayon-composition.md`.
 
-#![cfg(target_os = "macos")]
-
 use std::io;
 use std::os::unix::io::{AsRawFd, RawFd};
 use std::time::Duration;


### PR DESCRIPTION
Per POST-3 audit (PR #4461) - duplicated target_os=macos attribute.