### PR TITLE
fix(fast_io): borrow-after-move in macOS sendfile test (POST-3b #2418)

### DIFF
--- a/crates/fast_io/src/sendfile.rs
+++ b/crates/fast_io/src/sendfile.rs
@@ -878,8 +878,8 @@ mod tests {
         unsafe { libc::close(send_fd) };
 
         let received = reader_thread.join().expect("reader thread should succeed");
-        assert_eq!(received.len(), expected_content.len());
-        assert_eq!(received, expected_content);
+        assert_eq!(received.len(), content.len());
+        assert_eq!(received, content);
     }
 
     #[cfg(target_os = "macos")]


### PR DESCRIPTION
Per POST-3 audit (PR #4461) - E0382 at sendfile.rs:881.