### PR TITLE
fix(engine): clippy P1 lints in strategy/spill/buffer_pool (POST-3i #2425)

### DIFF
--- a/crates/engine/src/concurrent_delta/spill/mod.rs
+++ b/crates/engine/src/concurrent_delta/spill/mod.rs
@@ -59,7 +59,7 @@
 
 use std::collections::BTreeMap;
 use std::fs;
-use std::io::{self, Read, Seek, SeekFrom, Write};
+use std::io::{self, Read, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 
 use super::reorder::ReorderBuffer;

--- a/crates/engine/src/concurrent_delta/strategy.rs
+++ b/crates/engine/src/concurrent_delta/strategy.rs
@@ -334,9 +334,9 @@ impl std::io::Seek for BasisReader {
 /// when the feature is off, the default `BufReader<File>` path is used so
 /// production builds are byte-identical to today.
 fn open_basis_reader(path: &Path, len: u64) -> std::io::Result<BasisReader> {
+    let _ = len; // consumed only by the io_uring slurp branch below
     #[cfg(feature = "mmap-free-basis")]
     {
-        let _ = len; // length is unused when the mmap-free path short-circuits
         let file = File::open(path)?;
         return Ok(BasisReader::MmapFree(BufReader::new(file)));
     }
@@ -353,10 +353,6 @@ fn open_basis_reader(path: &Path, len: u64) -> std::io::Result<BasisReader> {
                 }
             }
         }
-    }
-    #[cfg(not(all(target_os = "linux", feature = "iouring-data-reads")))]
-    {
-        let _ = len; // silence unused-variable lint on non-Linux / feature-off
     }
     let file = File::open(path)?;
     Ok(BasisReader::Buffered(BufReader::new(file)))

--- a/crates/engine/src/local_copy/buffer_pool/page_aligned.rs
+++ b/crates/engine/src/local_copy/buffer_pool/page_aligned.rs
@@ -27,7 +27,7 @@ use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 
 use crossbeam_queue::ArrayQueue;
 
-use fast_io::{PageAlignedBuffer, page_size, round_up_to_page};
+use fast_io::{PageAlignedBuffer, round_up_to_page};
 
 /// Default fixed capacity for the lock-free central queue.
 ///
@@ -264,6 +264,8 @@ impl Drop for PageAlignedBufferGuard {
 
 #[cfg(test)]
 mod tests {
+    use fast_io::page_size;
+
     use super::*;
 
     #[test]


### PR DESCRIPTION
Per POST-3 audit (PR #4461) - 3 small clippy fixes.