### PR TITLE
fix(engine): derive Debug on DeleteEmitter and DrainOutcome (POST-3d #2420)

### DIFF
--- a/crates/engine/src/delete/context.rs
+++ b/crates/engine/src/delete/context.rs
@@ -516,6 +516,7 @@ impl DeleteContext {
 ///
 /// Owns the [`DeleteFs`] so test callers using [`super::RecordingDeleteFs`]
 /// can inspect the recorded event sequence after the drain returns.
+#[derive(Debug)]
 pub struct DrainOutcome<F: DeleteFs> {
     /// The filesystem dispatcher the emitter consumed. Production code
     /// drops this; tests inspect `events()` on a `RecordingDeleteFs`.

--- a/crates/engine/src/delete/emitter/fs.rs
+++ b/crates/engine/src/delete/emitter/fs.rs
@@ -29,7 +29,7 @@ use crate::util::poison::lock_or_recover;
 /// across the emitter and any future helpers. The production impl is
 /// stateless; the test fake holds a `Mutex` because the recording is
 /// observable from the test thread after `emit_all` returns.
-pub trait DeleteFs {
+pub trait DeleteFs: std::fmt::Debug {
     /// Unlinks a regular file.
     fn unlink_file(&self, path: &Path) -> io::Result<()>;
 

--- a/crates/engine/src/delete/emitter/mod.rs
+++ b/crates/engine/src/delete/emitter/mod.rs
@@ -74,6 +74,7 @@ use policy::{IOERR_GENERAL, IOERR_VANISHED_ONLY};
 /// [`EmitterErrorPolicy`]. All collaborators are taken by value so the
 /// emitter is the unique writer of every observable side effect
 /// (single-emitter invariant; section 2.3 of the design).
+#[derive(Debug)]
 pub struct DeleteEmitter<F: DeleteFs> {
     fs: F,
     stats: DeleteStats,

--- a/crates/engine/src/delete/emitter/tests/mod.rs
+++ b/crates/engine/src/delete/emitter/tests/mod.rs
@@ -49,7 +49,7 @@ pub(super) fn dir_child(parent: &str, name: &str) -> FileEntry {
 /// Failure plan: for each (path, errno) pair, the next call against
 /// that path returns the matching error before falling back to the
 /// recording behaviour.
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub(super) struct ScriptedDeleteFs {
     inner: RecordingDeleteFs,
     rules: Mutex<Vec<(PathBuf, io::ErrorKind)>>,


### PR DESCRIPTION
Per POST-3 audit (PR #4461).