### PR TITLE
fix(engine): exhaustive SpillError match in consumer (POST-3e #2421)

### DIFF
--- a/crates/engine/src/concurrent_delta/consumer.rs
+++ b/crates/engine/src/concurrent_delta/consumer.rs
@@ -536,6 +536,13 @@ fn run_spillable_loop(
                         .send(DeltaResult::failed(ndx, format!("spill write failed: {e}")));
                     return;
                 }
+                Err(SpillError::UnsupportedCompression(tag)) => {
+                    let _ = result_tx.send(DeltaResult::failed(
+                        ndx,
+                        format!("spill record uses unsupported compression tag 0x{tag:02x}"),
+                    ));
+                    return;
+                }
             }
         }
         publish_spill_events(&reorder, spill_events, &mut prev_spill);

--- a/crates/engine/src/concurrent_delta/spill/mod.rs
+++ b/crates/engine/src/concurrent_delta/spill/mod.rs
@@ -1435,6 +1435,9 @@ mod tests {
         match err {
             SpillError::Io(ref e) => assert_eq!(e.kind(), io::ErrorKind::StorageFull),
             SpillError::Capacity(_) => panic!("expected I/O error, got capacity"),
+            SpillError::UnsupportedCompression(_) => {
+                panic!("expected I/O error, got unsupported compression")
+            }
         }
         assert!(err.is_out_of_space(), "is_out_of_space should be true");
     }


### PR DESCRIPTION
Per POST-3 audit (PR #4461) - 4 E0004 sites missing SpillError::Io arm.