### PR TITLE
docs(audit): close SPL-8 as resolved by SPL-13 (#2330)

### DIFF
--- a/docs/audits/spl-8-resolved-after-spl-13.md
+++ b/docs/audits/spl-8-resolved-after-spl-13.md
@@ -1,0 +1,40 @@
+# SPL-8 Resolved After SPL-13
+
+## Status
+
+Resolved. No code changes required.
+
+## Context
+
+SPL-8 (#2330) originally proposed splitting the `#[cfg(test)] mod tests`
+block out of `crates/engine/src/concurrent_delta/spill/mod.rs` into a
+sibling `mod_tests.rs` file. At the time the task was filed, the parent
+module was 1919 LoC, which made the embedded test block an obvious
+candidate for extraction under the 650 LoC workspace cap.
+
+## What changed
+
+SPL-13 (PR #4462) extracted `SpillableReorderBuffer` and the bulk of
+the buffer machinery out of `spill/mod.rs` into dedicated submodules
+(`buffer/`, `tempfile`, `env`, `policy`, `rss`, `stats`). As a result
+`spill/mod.rs` shrunk from 1919 LoC to 195 LoC, well below the 300 LoC
+threshold where a test split would be required or even nice-to-have.
+
+## Current shape
+
+`crates/engine/src/concurrent_delta/spill/mod.rs` is now 195 LoC:
+
+- 88 lines of module doc + submodule declarations + `SpillCodec` trait
+- 72 lines of inline `#[cfg(test)] mod tests` covering codec roundtrips
+  and `SpillError` display
+- Remaining lines are item-level rustdoc and blank separators
+
+Splitting 72 lines of tests into a sibling file at this size would
+trade one short, self-contained file for two even shorter ones with
+no readability or maintainability benefit. The tests stay co-located
+with the `SpillCodec` trait they exercise.
+
+## Decision
+
+Close SPL-8 (#2330) as resolved by SPL-13. No further extraction
+needed.


### PR DESCRIPTION
## Summary

- `crates/engine/src/concurrent_delta/spill/mod.rs` is now 195 LoC after PR #4462 (SPL-13) extracted `SpillableReorderBuffer` into submodules.
- The original SPL-8 task proposed splitting the embedded `#[cfg(test)] mod tests` block out to a sibling file when the parent module was 1919 LoC.
- At the current size (well under the 300 LoC nice-to-have threshold, far under the 650 LoC workspace cap), splitting 72 lines of tests into their own file would trade one short, self-contained module for two even shorter ones with no maintainability gain.
- This PR records the resolution at `docs/audits/spl-8-resolved-after-spl-13.md` so #2330 can be closed without further code churn.

## Test plan

- [x] No code changes; docs-only addition under `docs/audits/`.