### PR TITLE
fix(engine): O(1) DACL writes on Windows hardlink cohorts (POST-4 WAS-6 #2415)

### DIFF
--- a/crates/engine/src/local_copy/context_impl/state.rs
+++ b/crates/engine/src/local_copy/context_impl/state.rs
@@ -183,6 +183,21 @@ impl<'a> CopyContext<'a> {
         }
     }
 
+    /// Registers a hardlink-cohort leader keyed by the reference file the
+    /// destination is being linked to. Returns `true` the first time a given
+    /// reference is seen (this destination is the cohort leader) and `false`
+    /// for subsequent followers that share the same inode.
+    ///
+    /// Used to make per-inode metadata writes (e.g. NTFS DACL writes via
+    /// `SetNamedSecurityInfoW`) O(1) per cohort instead of O(N) per follower.
+    ///
+    /// upstream: hlink.c::hard_link_check returns 1 for followers so
+    /// generator.c:1540 exits before `set_file_attrs()` and therefore never
+    /// calls `set_acl()` on a follower alias.
+    pub(super) fn register_acl_cohort_leader(&mut self, reference: &Path) -> bool {
+        self.hard_links.register_acl_cohort_leader(reference)
+    }
+
     /// Returns whether `--delay-updates` is enabled.
     pub(super) const fn delay_updates_enabled(&self) -> bool {
         self.options.delay_updates_enabled()

--- a/crates/engine/src/local_copy/executor/file/copy/links.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/links.rs
@@ -337,8 +337,20 @@ pub(super) fn process_links(
                         true,
                         context.filter_program(),
                     )?;
+                    // The destination is hardlinked to `path`, so all
+                    // destinations sharing this reference share one inode.
+                    // ACLs live on the inode (NTFS DACL on Windows, POSIX
+                    // ACL on Unix), so the leader's write populates the
+                    // shared inode and followers inherit for free.
+                    //
+                    // upstream: hlink.c::hard_link_check returns 1 for
+                    // followers; generator.c:1540 exits before
+                    // set_file_attrs() so set_acl() is never invoked on a
+                    // follower alias.
                     #[cfg(all(any(unix, windows), feature = "acl"))]
-                    sync_acls_if_requested(preserve_acls, mode, source, destination, true)?;
+                    if context.register_acl_cohort_leader(&path) {
+                        sync_acls_if_requested(preserve_acls, mode, source, destination, true)?;
+                    }
                     // upstream: hlink.c:236 - "%s => %s" at INFO_GTE(NAME, 1)
                     // when a hard link is created from a reference directory.
                     info_log!(Name, 1, "{} => {}", record_path.display(), path.display());
@@ -444,6 +456,51 @@ mod tests {
         assert!(
             name_messages().is_empty(),
             "uptodate emission must be gated at NAME level 2"
+        );
+    }
+
+    /// Windows-only regression test for POST-4 / WAS-6 (#2415, audit PR
+    /// #4399). The `--copy-dest` Link branch hardlinks every cohort follower
+    /// to the same reference inode. On NTFS the DACL lives on the MFT
+    /// record, so each `SetNamedSecurityInfoW` call writes to the shared
+    /// inode regardless of which alias was opened.
+    ///
+    /// Before the fix the loop invoked `sync_acls_if_requested` once per
+    /// follower (O(N) per N-link cohort). The cohort gate routes the write
+    /// through the first call only; followers inherit through the inode.
+    ///
+    /// upstream: hlink.c::hard_link_check returns 1 for followers so the
+    /// generator never calls `set_file_attrs()` -> `set_acl()` on a
+    /// follower alias.
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn copy_dest_link_branch_dacl_writes_once_per_cohort() {
+        use std::path::Path;
+
+        use crate::local_copy::HardLinkTracker;
+
+        let mut tracker = HardLinkTracker::new();
+        let reference = Path::new(r"C:\ref\leader.bin");
+        let followers: [&Path; 5] = [
+            Path::new(r"C:\dst\f1.bin"),
+            Path::new(r"C:\dst\f2.bin"),
+            Path::new(r"C:\dst\f3.bin"),
+            Path::new(r"C:\dst\f4.bin"),
+            Path::new(r"C:\dst\f5.bin"),
+        ];
+
+        let mut dacl_writes = 0_usize;
+        for _follower in followers {
+            // Mirrors the production gate in `process_links` at the
+            // `ReferenceDecision::Link` branch.
+            if tracker.register_acl_cohort_leader(reference) {
+                dacl_writes += 1;
+            }
+        }
+
+        assert_eq!(
+            dacl_writes, 1,
+            "5-link cohort must trigger exactly one DACL write (was: {dacl_writes})"
         );
     }
 }

--- a/crates/engine/src/local_copy/hard_links.rs
+++ b/crates/engine/src/local_copy/hard_links.rs
@@ -185,6 +185,14 @@ impl Default for HardlinkApplyTracker {
 #[derive(Default)]
 pub(crate) struct HardLinkTracker {
     entries: FxHashMap<HardLinkKey, PathBuf>,
+    /// Reference paths whose hardlink cohort has already had metadata applied
+    /// once. Used to make per-inode metadata writes (e.g. Windows DACLs) O(1)
+    /// per cohort instead of O(N) per follower.
+    ///
+    /// upstream: hlink.c::hard_link_check returns 1 for followers so
+    /// generator.c:1540 exits before set_file_attrs(); the inode keeps the
+    /// leader's metadata for free.
+    acl_cohort_leaders: rustc_hash::FxHashSet<PathBuf>,
 }
 
 #[cfg(unix)]
@@ -210,6 +218,18 @@ impl HardLinkTracker {
         }
     }
 
+    /// Returns `true` the first time `reference` is registered as the source
+    /// of a hardlink cohort (the leader); subsequent calls with the same
+    /// `reference` return `false` (followers).
+    ///
+    /// The leader is the destination whose creation should trigger a
+    /// per-inode metadata write (POSIX ACL on Unix, NTFS DACL on Windows).
+    /// Followers share the same underlying inode and inherit the leader's
+    /// metadata without an additional write.
+    pub(crate) fn register_acl_cohort_leader(&mut self, reference: &Path) -> bool {
+        self.acl_cohort_leaders.insert(reference.to_path_buf())
+    }
+
     fn key(metadata: &fs::Metadata) -> Option<HardLinkKey> {
         use std::os::unix::fs::MetadataExt;
 
@@ -226,12 +246,21 @@ impl HardLinkTracker {
 
 #[cfg(not(unix))]
 #[derive(Default)]
-pub(crate) struct HardLinkTracker;
+pub(crate) struct HardLinkTracker {
+    /// Reference paths whose hardlink cohort has already had metadata applied
+    /// once. On NTFS the DACL lives on the MFT record (inode); writing the
+    /// same DACL through each alias produces N identical inode-level writes.
+    ///
+    /// upstream: hlink.c::hard_link_check returns 1 for followers so
+    /// generator.c:1540 exits before set_file_attrs(); the inode keeps the
+    /// leader's DACL for free.
+    acl_cohort_leaders: rustc_hash::FxHashSet<PathBuf>,
+}
 
 #[cfg(not(unix))]
 impl HardLinkTracker {
-    pub(crate) const fn new() -> Self {
-        Self
+    pub(crate) fn new() -> Self {
+        Self::default()
     }
 
     pub(crate) fn existing_target(&self, _metadata: &fs::Metadata) -> Option<PathBuf> {
@@ -239,6 +268,19 @@ impl HardLinkTracker {
     }
 
     pub(crate) fn record(&mut self, _metadata: &fs::Metadata, _destination: &Path) {}
+
+    /// Returns `true` the first time `reference` is registered as the source
+    /// of a hardlink cohort (the leader); subsequent calls with the same
+    /// `reference` return `false` (followers).
+    ///
+    /// On Windows the leader's `SetNamedSecurityInfoW` call populates the
+    /// shared NTFS inode; every follower would re-write the same DACL bytes
+    /// to the same inode if not skipped. The wire receiver already skips
+    /// follower ACL writes (`create_hardlinks` itemizes only); this tracker
+    /// brings the local-copy `--copy-dest` Link branch into parity.
+    pub(crate) fn register_acl_cohort_leader(&mut self, reference: &Path) -> bool {
+        self.acl_cohort_leaders.insert(reference.to_path_buf())
+    }
 }
 
 #[cfg(test)]
@@ -277,6 +319,59 @@ mod tests {
 
         let mut tracker = HardLinkTracker::new();
         tracker.record(&metadata, Path::new("/dest/test.txt"));
+    }
+
+    #[test]
+    fn register_acl_cohort_leader_first_call_is_leader() {
+        let mut tracker = HardLinkTracker::new();
+        assert!(
+            tracker.register_acl_cohort_leader(Path::new("/ref/file.bin")),
+            "first call for a reference is the cohort leader"
+        );
+    }
+
+    #[test]
+    fn register_acl_cohort_leader_subsequent_calls_are_followers() {
+        let mut tracker = HardLinkTracker::new();
+        let reference = Path::new("/ref/file.bin");
+        assert!(tracker.register_acl_cohort_leader(reference));
+        for _ in 0..10 {
+            assert!(
+                !tracker.register_acl_cohort_leader(reference),
+                "subsequent calls for the same reference are followers"
+            );
+        }
+    }
+
+    #[test]
+    fn register_acl_cohort_leader_distinct_references_each_leader_once() {
+        let mut tracker = HardLinkTracker::new();
+        assert!(tracker.register_acl_cohort_leader(Path::new("/ref/a.bin")));
+        assert!(tracker.register_acl_cohort_leader(Path::new("/ref/b.bin")));
+        assert!(!tracker.register_acl_cohort_leader(Path::new("/ref/a.bin")));
+        assert!(!tracker.register_acl_cohort_leader(Path::new("/ref/b.bin")));
+    }
+
+    /// Simulates the `--copy-dest` Link branch behaviour: five destinations
+    /// linked to the same reference inode would, without the cohort gate,
+    /// invoke the DACL writer five times. The gate ensures count == 1.
+    ///
+    /// upstream: hlink.c::hard_link_check returns 1 for followers so the
+    /// generator never calls `set_file_attrs()` -> `set_acl()` on an alias.
+    #[test]
+    fn cohort_gate_yields_one_acl_call_per_cohort() {
+        let mut tracker = HardLinkTracker::new();
+        let reference = Path::new("/ref/leader.bin");
+        let mut dacl_writes = 0_usize;
+        for _follower in 0..5 {
+            if tracker.register_acl_cohort_leader(reference) {
+                dacl_writes += 1;
+            }
+        }
+        assert_eq!(
+            dacl_writes, 1,
+            "five-link cohort must produce exactly one DACL write"
+        );
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## Summary
- Per WAS-6 audit (PR #4399): the `--copy-dest` Link branch on Windows re-applied the source DACL once per follower (O(N) per N-link cohort) versus upstream's O(1) (the leader writes the DACL and the shared NTFS inode propagates it).
- Flesh out the previously stub Windows `HardLinkTracker` so it can detect cohort followers via `register_acl_cohort_leader(reference)`. The first destination linked to a given reference is the leader; subsequent destinations are followers.
- Gate the `links.rs` `ReferenceDecision::Link` DACL write on the cohort leader check. Followers skip `sync_acls_if_requested` entirely.
- Windows-only regression test asserts a 5-link cohort triggers exactly 1 DACL write, not 5. Cross-platform unit tests on the tracker pin the cohort-leader semantics.

upstream: `hlink.c::hard_link_check` returns 1 for followers so `generator.c:1540` exits before `set_file_attrs()` and therefore never calls `set_acl()` on a follower alias. This change brings the local-copy `--copy-dest` Link branch into parity with upstream cygwin and with the wire receiver's existing follower-skip behaviour.

The gate also applies on Unix because POSIX ACLs are likewise inode-bound, but the redundancy was the headline regression on Windows where every redundant `SetNamedSecurityInfoW` issues a fresh open/setinfo/close round trip and audit log entry.

## Test plan
- [x] `cargo fmt --all` clean
- [x] Non-Windows code path: tracker gate is feature-equivalent (POSIX ACL writes also collapse to one per cohort, matching the documented inode-share semantics)
- [x] Cross-platform unit tests cover leader/follower transitions and multi-cohort isolation
- [ ] CI verifies the Windows-only `copy_dest_link_branch_dacl_writes_once_per_cohort` test compiles and passes