### PR TITLE
docs(audit): SPL-9 re-exports table refresh after SPL-13 (POST-9 #2433)

### DIFF
--- a/docs/audits/spl-9-mod-reexports.md
+++ b/docs/audits/spl-9-mod-reexports.md
@@ -17,13 +17,12 @@ in `spill/mod.rs`.
   + ConcurrentDeltaConfig wiring (#2336) (#4360)`).
 - **Source captured at:** `git show 5f9b5af8a:crates/engine/src/concurrent_delta/spill.rs`.
 - **Line count:** 1232 lines.
-- **Current tree:** `origin/master` at the same commit (`5f9b5af8a`).
-  SPL-2 (PR #4345, error), SPL-3 (PR #4369, codec), and SPL-6 (stats,
-  in flight) are open against master but not merged. The audit baseline
-  and the current public surface are therefore byte-identical for the
-  symbols listed below; this document establishes the reference table
-  every subsequent SPL PR must satisfy before merge.
-- **Re-export anchor:** `crates/engine/src/concurrent_delta/mod.rs:180-192`
+- **Current tree:** `origin/master` with SPL-2 (#4345, error), SPL-6
+  (#4386, stats), SPL-3-tempfile (#4434, tempfile), and SPL-13 (#4462,
+  buffer) merged. The 42-symbol public surface captured below remains
+  unchanged; this document is the reference table every subsequent SPL
+  PR must satisfy before merge.
+- **Re-export anchor:** `crates/engine/src/concurrent_delta/mod.rs:185-201`
   exposes the `pub mod spill;` directory module and re-exports
   `SpillCodec`, `SpillError`, `SpillStats`, `SpillableReorderBuffer`,
   plus the four `SpillPolicy` siblings from `spill::policy`. Any
@@ -45,56 +44,56 @@ re-exports cleanly. The same holds for `pub` struct fields of
 
 ## Symbol table
 
-| Symbol                                        | Original path                                  | Current path                                                                              | Status |
-|-----------------------------------------------|------------------------------------------------|-------------------------------------------------------------------------------------------|--------|
-| `mod policy`                                  | `concurrent_delta/spill.rs:57`                 | `concurrent_delta/spill.rs:57` (also `spill/policy.rs` since #4360)                       | OK     |
-| `ReclaimMode` (re-export)                     | `concurrent_delta/spill.rs:58`                 | `concurrent_delta/spill.rs:58` (`pub use policy::ReclaimMode`)                            | OK     |
-| `SpillCompression` (re-export)                | `concurrent_delta/spill.rs:58`                 | `concurrent_delta/spill.rs:58` (`pub use policy::SpillCompression`)                       | OK     |
-| `SpillGranularity` (re-export)                | `concurrent_delta/spill.rs:58`                 | `concurrent_delta/spill.rs:58` (`pub use policy::SpillGranularity`)                       | OK     |
-| `SpillPolicy` (re-export)                     | `concurrent_delta/spill.rs:58`                 | `concurrent_delta/spill.rs:58` (`pub use policy::SpillPolicy`)                            | OK     |
-| `DEFAULT_SPILL_THRESHOLD`                     | `concurrent_delta/spill.rs:64`                 | `concurrent_delta/spill.rs:64`                                                            | OK     |
-| `SpillError` (enum)                           | `concurrent_delta/spill.rs:83`                 | `concurrent_delta/spill.rs:83` (target: `spill/error.rs`, re-exported in `spill/mod.rs`)  | OK     |
-| `SpillError::Capacity` (variant)              | `concurrent_delta/spill.rs:85`                 | `concurrent_delta/spill.rs:85` (target: `spill/error.rs`)                                 | OK     |
-| `SpillError::Io` (variant)                    | `concurrent_delta/spill.rs:87`                 | `concurrent_delta/spill.rs:87` (target: `spill/error.rs`)                                 | OK     |
-| `SpillError::io_error`                        | `concurrent_delta/spill.rs:93`                 | `concurrent_delta/spill.rs:93` (target: `spill/error.rs`)                                 | OK     |
-| `SpillError::is_out_of_space`                 | `concurrent_delta/spill.rs:102`                | `concurrent_delta/spill.rs:102` (target: `spill/error.rs`)                                | OK     |
-| `impl Display for SpillError`                 | `concurrent_delta/spill.rs:108`                | `concurrent_delta/spill.rs:108` (target: `spill/error.rs`)                                | OK     |
-| `impl Error for SpillError`                   | `concurrent_delta/spill.rs:117`                | `concurrent_delta/spill.rs:117` (target: `spill/error.rs`)                                | OK     |
-| `impl From<CapacityExceeded> for SpillError`  | `concurrent_delta/spill.rs:126`                | `concurrent_delta/spill.rs:126` (target: `spill/error.rs`)                                | OK     |
-| `impl From<io::Error> for SpillError`         | `concurrent_delta/spill.rs:132`                | `concurrent_delta/spill.rs:132` (target: `spill/error.rs`)                                | OK     |
-| `SpillCodec` (trait)                          | `concurrent_delta/spill.rs:144`                | `concurrent_delta/spill.rs:144` (target: `spill/codec.rs`, re-exported in `spill/mod.rs`) | OK     |
-| `SpillCodec::encode`                          | `concurrent_delta/spill.rs:150`                | `concurrent_delta/spill.rs:150` (target: `spill/codec.rs`)                                | OK     |
-| `SpillCodec::decode`                          | `concurrent_delta/spill.rs:157`                | `concurrent_delta/spill.rs:157` (target: `spill/codec.rs`)                                | OK     |
-| `SpillCodec::estimated_size`                  | `concurrent_delta/spill.rs:163`                | `concurrent_delta/spill.rs:163` (target: `spill/codec.rs`)                                | OK     |
-| `SpillableReorderBuffer<T>` (struct)          | `concurrent_delta/spill.rs:221`                | `spill/buffer.rs` (re-exported in `spill/mod.rs`)                                         | OK     |
-| `impl Debug for SpillableReorderBuffer<T>`    | `concurrent_delta/spill.rs:246`                | `spill/buffer.rs`                                                                         | OK     |
-| `SpillStats` (struct)                         | `concurrent_delta/spill.rs:263`                | `concurrent_delta/spill.rs:263` (target: `spill/stats.rs`, re-exported in `spill/mod.rs`) | OK     |
-| `SpillStats::spilled_items` (field)           | `concurrent_delta/spill.rs:265`                | `concurrent_delta/spill.rs:265` (target: `spill/stats.rs`)                                | OK     |
-| `SpillStats::spill_events` (field)            | `concurrent_delta/spill.rs:267`                | `concurrent_delta/spill.rs:267` (target: `spill/stats.rs`)                                | OK     |
-| `SpillStats::reload_events` (field)           | `concurrent_delta/spill.rs:269`                | `concurrent_delta/spill.rs:269` (target: `spill/stats.rs`)                                | OK     |
-| `SpillStats::memory_used` (field)             | `concurrent_delta/spill.rs:271`                | `concurrent_delta/spill.rs:271` (target: `spill/stats.rs`)                                | OK     |
-| `SpillStats::threshold` (field)               | `concurrent_delta/spill.rs:273`                | `concurrent_delta/spill.rs:273` (target: `spill/stats.rs`)                                | OK     |
-| `SpillStats::dir_recreate_events` (field)     | `concurrent_delta/spill.rs:275`                | `concurrent_delta/spill.rs:275` (target: `spill/stats.rs`)                                | OK     |
-| `SpillableReorderBuffer::new`                 | `concurrent_delta/spill.rs:289`                | `spill/buffer.rs`                                                                         | OK     |
-| `SpillableReorderBuffer::with_spill_dir`      | `concurrent_delta/spill.rs:318`                | `spill/buffer.rs`                                                                         | OK     |
-| `SpillableReorderBuffer::with_default_threshold` | `concurrent_delta/spill.rs:345`             | `spill/buffer.rs`                                                                         | OK     |
-| `SpillableReorderBuffer::insert`              | `concurrent_delta/spill.rs:365`                | `spill/buffer.rs`                                                                         | OK     |
-| `SpillableReorderBuffer::force_insert`        | `concurrent_delta/spill.rs:390`                | `spill/buffer.rs`                                                                         | OK     |
-| `SpillableReorderBuffer::next_in_order`       | `concurrent_delta/spill.rs:415`                | `spill/buffer.rs`                                                                         | OK     |
-| `SpillableReorderBuffer::drain_ready`         | `concurrent_delta/spill.rs:455`                | `spill/buffer.rs`                                                                         | OK     |
-| `SpillableReorderBuffer::next_expected`       | `concurrent_delta/spill.rs:465`                | `spill/buffer.rs`                                                                         | OK     |
-| `SpillableReorderBuffer::buffered_count`      | `concurrent_delta/spill.rs:471`                | `spill/buffer.rs`                                                                         | OK     |
-| `SpillableReorderBuffer::is_empty`            | `concurrent_delta/spill.rs:477`                | `spill/buffer.rs`                                                                         | OK     |
-| `SpillableReorderBuffer::capacity`            | `concurrent_delta/spill.rs:483`                | `spill/buffer.rs`                                                                         | OK     |
-| `SpillableReorderBuffer::spill_stats`         | `concurrent_delta/spill.rs:489`                | `spill/buffer.rs`                                                                         | OK     |
-| `SpillableReorderBuffer::threshold`           | `concurrent_delta/spill.rs:502`                | `spill/buffer.rs`                                                                         | OK     |
-| `SpillableReorderBuffer::spill_dir`           | `concurrent_delta/spill.rs:508`                | `spill/buffer.rs`                                                                         | OK     |
+| Symbol                                        | Original path                                  | Current path                                                                                  | Status |
+|-----------------------------------------------|------------------------------------------------|-----------------------------------------------------------------------------------------------|--------|
+| `mod policy`                                  | `concurrent_delta/spill.rs:57`                 | `concurrent_delta/spill/policy.rs` (re-exported from `spill/mod.rs`)                          | OK     |
+| `ReclaimMode` (re-export)                     | `concurrent_delta/spill.rs:58`                 | `concurrent_delta/spill/mod.rs` (`pub use policy::ReclaimMode`)                               | OK     |
+| `SpillCompression` (re-export)                | `concurrent_delta/spill.rs:58`                 | `concurrent_delta/spill/mod.rs` (`pub use policy::SpillCompression`)                          | OK     |
+| `SpillGranularity` (re-export)                | `concurrent_delta/spill.rs:58`                 | `concurrent_delta/spill/mod.rs` (`pub use policy::SpillGranularity`)                          | OK     |
+| `SpillPolicy` (re-export)                     | `concurrent_delta/spill.rs:58`                 | `concurrent_delta/spill/mod.rs` (`pub use policy::SpillPolicy`)                               | OK     |
+| `DEFAULT_SPILL_THRESHOLD`                     | `concurrent_delta/spill.rs:64`                 | `concurrent_delta/spill/mod.rs:93`                                                            | OK     |
+| `SpillError` (enum)                           | `concurrent_delta/spill.rs:83`                 | `concurrent_delta/spill/error.rs:30` (re-exported from `spill/mod.rs`)                        | OK     |
+| `SpillError::Capacity` (variant)              | `concurrent_delta/spill.rs:85`                 | `concurrent_delta/spill/error.rs:32`                                                          | OK     |
+| `SpillError::Io` (variant)                    | `concurrent_delta/spill.rs:87`                 | `concurrent_delta/spill/error.rs:34`                                                          | OK     |
+| `SpillError::io_error`                        | `concurrent_delta/spill.rs:93`                 | `concurrent_delta/spill/error.rs:43`                                                          | OK     |
+| `SpillError::is_out_of_space`                 | `concurrent_delta/spill.rs:102`                | `concurrent_delta/spill/error.rs:52`                                                          | OK     |
+| `impl Display for SpillError`                 | `concurrent_delta/spill.rs:108`                | `concurrent_delta/spill/error.rs:58`                                                          | OK     |
+| `impl Error for SpillError`                   | `concurrent_delta/spill.rs:117`                | `concurrent_delta/spill/error.rs:71`                                                          | OK     |
+| `impl From<CapacityExceeded> for SpillError`  | `concurrent_delta/spill.rs:126`                | `concurrent_delta/spill/error.rs:80`                                                          | OK     |
+| `impl From<io::Error> for SpillError`         | `concurrent_delta/spill.rs:132`                | `concurrent_delta/spill/error.rs:86`                                                          | OK     |
+| `SpillCodec` (trait)                          | `concurrent_delta/spill.rs:144`                | `concurrent_delta/spill/mod.rs:101`                                                           | OK     |
+| `SpillCodec::encode`                          | `concurrent_delta/spill.rs:150`                | `concurrent_delta/spill/mod.rs:107`                                                           | OK     |
+| `SpillCodec::decode`                          | `concurrent_delta/spill.rs:157`                | `concurrent_delta/spill/mod.rs:114`                                                           | OK     |
+| `SpillCodec::estimated_size`                  | `concurrent_delta/spill.rs:163`                | `concurrent_delta/spill/mod.rs:120`                                                           | OK     |
+| `SpillableReorderBuffer<T>` (struct)          | `concurrent_delta/spill.rs:221`                | `concurrent_delta/spill/buffer.rs:75` (re-exported from `spill/mod.rs`)                       | OK     |
+| `impl Debug for SpillableReorderBuffer<T>`    | `concurrent_delta/spill.rs:246`                | `concurrent_delta/spill/buffer.rs:133` (re-exported from `spill/mod.rs`)                      | OK     |
+| `SpillStats` (struct)                         | `concurrent_delta/spill.rs:263`                | `concurrent_delta/spill/stats.rs:11` (re-exported from `spill/mod.rs`)                        | OK     |
+| `SpillStats::spilled_items` (field)           | `concurrent_delta/spill.rs:265`                | `concurrent_delta/spill/stats.rs:13`                                                          | OK     |
+| `SpillStats::spill_events` (field)            | `concurrent_delta/spill.rs:267`                | `concurrent_delta/spill/stats.rs:15`                                                          | OK     |
+| `SpillStats::reload_events` (field)           | `concurrent_delta/spill.rs:269`                | `concurrent_delta/spill/stats.rs:17`                                                          | OK     |
+| `SpillStats::memory_used` (field)             | `concurrent_delta/spill.rs:271`                | `concurrent_delta/spill/stats.rs:19`                                                          | OK     |
+| `SpillStats::threshold` (field)               | `concurrent_delta/spill.rs:273`                | `concurrent_delta/spill/stats.rs:21`                                                          | OK     |
+| `SpillStats::dir_recreate_events` (field)     | `concurrent_delta/spill.rs:275`                | `concurrent_delta/spill/stats.rs:23`                                                          | OK     |
+| `SpillableReorderBuffer::new`                 | `concurrent_delta/spill.rs:289`                | `concurrent_delta/spill/buffer.rs` (re-exported from `spill/mod.rs`)                          | OK     |
+| `SpillableReorderBuffer::with_spill_dir`      | `concurrent_delta/spill.rs:318`                | `concurrent_delta/spill/buffer.rs` (re-exported from `spill/mod.rs`)                          | OK     |
+| `SpillableReorderBuffer::with_default_threshold` | `concurrent_delta/spill.rs:345`             | `concurrent_delta/spill/buffer.rs` (re-exported from `spill/mod.rs`)                          | OK     |
+| `SpillableReorderBuffer::insert`              | `concurrent_delta/spill.rs:365`                | `concurrent_delta/spill/buffer.rs` (re-exported from `spill/mod.rs`)                          | OK     |
+| `SpillableReorderBuffer::force_insert`        | `concurrent_delta/spill.rs:390`                | `concurrent_delta/spill/buffer.rs` (re-exported from `spill/mod.rs`)                          | OK     |
+| `SpillableReorderBuffer::next_in_order`       | `concurrent_delta/spill.rs:415`                | `concurrent_delta/spill/buffer.rs` (re-exported from `spill/mod.rs`)                          | OK     |
+| `SpillableReorderBuffer::drain_ready`         | `concurrent_delta/spill.rs:455`                | `concurrent_delta/spill/buffer.rs` (re-exported from `spill/mod.rs`)                          | OK     |
+| `SpillableReorderBuffer::next_expected`       | `concurrent_delta/spill.rs:465`                | `concurrent_delta/spill/buffer.rs` (re-exported from `spill/mod.rs`)                          | OK     |
+| `SpillableReorderBuffer::buffered_count`      | `concurrent_delta/spill.rs:471`                | `concurrent_delta/spill/buffer.rs` (re-exported from `spill/mod.rs`)                          | OK     |
+| `SpillableReorderBuffer::is_empty`            | `concurrent_delta/spill.rs:477`                | `concurrent_delta/spill/buffer.rs` (re-exported from `spill/mod.rs`)                          | OK     |
+| `SpillableReorderBuffer::capacity`            | `concurrent_delta/spill.rs:483`                | `concurrent_delta/spill/buffer.rs` (re-exported from `spill/mod.rs`)                          | OK     |
+| `SpillableReorderBuffer::spill_stats`         | `concurrent_delta/spill.rs:489`                | `concurrent_delta/spill/buffer.rs` (re-exported from `spill/mod.rs`)                          | OK     |
+| `SpillableReorderBuffer::threshold`           | `concurrent_delta/spill.rs:502`                | `concurrent_delta/spill/buffer.rs` (re-exported from `spill/mod.rs`)                          | OK     |
+| `SpillableReorderBuffer::spill_dir`           | `concurrent_delta/spill.rs:508`                | `concurrent_delta/spill/buffer.rs` (re-exported from `spill/mod.rs`)                          | OK     |
 
 42 symbols audited. 42 OK. 0 MISSING. 0 RENAMED.
 
 ## Reachability from the parent facade
 
-`crates/engine/src/concurrent_delta/mod.rs:191-192` re-exports the
+`crates/engine/src/concurrent_delta/mod.rs:198-201` re-exports the
 following symbols at `crate::concurrent_delta::*`. Each appears in the
 table above and must continue to resolve via the same `spill::` path:
 
@@ -102,6 +101,31 @@ table above and must continue to resolve via the same `spill::` path:
   (through `spill::policy::`).
 - `SpillCodec`, `SpillError`, `SpillStats`, `SpillableReorderBuffer`
   (through `spill::`).
+
+## History
+
+The original 1232-line `spill.rs` has been progressively decomposed into
+focused submodules under `crates/engine/src/concurrent_delta/spill/`.
+Each extraction PR re-ran the procedure below and kept the 42-symbol
+table at OK:
+
+- **SPL-2 error** ([#4345](https://github.com/oferchen/rsync/pull/4345)) -
+  extracted `SpillError`, its `Display`/`Error`/`From` impls, and the
+  helper methods (`io_error`, `is_out_of_space`) into `spill/error.rs`.
+- **SPL-6 stats** ([#4386](https://github.com/oferchen/rsync/pull/4386)) -
+  extracted `SpillStats` (plus its six public fields) into
+  `spill/stats.rs`.
+- **SPL-3-tempfile** ([#4434](https://github.com/oferchen/rsync/pull/4434)) -
+  extracted the internal `SpillBackend` enum and `open_backend` helper
+  into `spill/tempfile.rs`. Internal-only (`pub(super)`), so the public
+  surface is unchanged.
+- **SPL-13 buffer** ([#4462](https://github.com/oferchen/rsync/pull/4462)) -
+  extracted `SpillableReorderBuffer<T>`, its `Debug` impl, and all 13
+  inherent methods into `spill/buffer.rs`.
+
+The codec extraction (SPL-3 codec, PR #4369) did not ship; `SpillCodec`
+remains defined directly in `spill/mod.rs` and the trait, its three
+methods, and `DEFAULT_SPILL_THRESHOLD` continue to live there.
 
 ## How to re-run this audit per SPL PR
 
@@ -120,16 +144,13 @@ table above and must continue to resolve via the same `spill::` path:
    `parallel_apply.rs`, `strategy.rs`, `config.rs`, or any external
    crate).
 5. Verify the rustdoc example on `SpillableReorderBuffer`
-   (`spill.rs:210`, `use engine::concurrent_delta::spill::SpillableReorderBuffer;`)
+   (`spill/buffer.rs`, `use engine::concurrent_delta::spill::SpillableReorderBuffer;`)
    compiles under `cargo test --doc -p engine --all-features`.
 
 ## Recommendations
 
-No MISSING or RENAMED entries. No follow-up tasks required against
-#2328/#2325/#2329 at this time.
-
-When SPL-2 (#4345), SPL-3 (#4369), and SPL-6 land, each PR author must
-re-run the procedure above and amend the "Current path" column for the
-extracted symbols to point at the new file (for example `spill/error.rs`
-instead of `spill.rs`) while keeping the Status column at OK. Any
-divergence from the 42-symbol baseline blocks merge.
+No MISSING or RENAMED entries. The 42-symbol public API has survived
+four extractions (SPL-2, SPL-6, SPL-3-tempfile, SPL-13) unchanged.
+Future SPL PRs must amend the "Current path" column for any newly
+extracted symbols while keeping the Status column at OK. Any divergence
+from the 42-symbol baseline blocks merge.


### PR DESCRIPTION
Update Current-path column for SpillableReorderBuffer rows after SPL-13 extracted it to spill/buffer.rs. Also refresh SpillError (SPL-2 #4345) and SpillStats (SPL-6 #4386) rows to point at their respective extracted files. Confirm the 42-symbol API table still passes - 0 MISSING, 0 RENAMED.

## History section

Added cross-links for the four extraction PRs that have shipped:

- SPL-2 error (#4345)
- SPL-6 stats (#4386)
- SPL-3-tempfile (#4434, internal-only)
- SPL-13 buffer (#4462)

Note: SPL-3 codec (#4369) did not merge; `SpillCodec` and `DEFAULT_SPILL_THRESHOLD` remain in `spill/mod.rs`.

## Test plan

- [ ] Pure docs change - no code touched
- [ ] cargo fmt --all is a no-op