### PR TITLE
chore(ci): prune stale line_limits overrides + test-file policy (POST-8a #2435)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,9 +96,12 @@ jobs:
   # ---------------------------------------------------------------------------
   # Runs `cargo xtask enforce-limits` to surface files that exceed the per-file
   # line limits in `tools/line_limits.toml` (workspace default 650). Marked
-  # `continue-on-error: true` while the 19 over-limit files documented in
-  # `docs/audits/module-loc-audit-session.md` are being decomposed. Promote to
-  # a required check once the over-limit count reaches zero.
+  # `continue-on-error: true` while the over-limit files documented in
+  # `docs/audits/post-8-enforce-limits-ci.md` (~322 files snapshot, dominated
+  # by test modules) are being decomposed. The audit prunes stale overrides
+  # and relaxes caps for the top test-file offenders; remaining overages are
+  # production source pending tracked decomposition work. Promote to a
+  # required check once the over-limit count reaches zero.
   # ===========================================================================
   enforce-limits:
     name: enforce-limits (informational)

--- a/tools/line_limits.toml
+++ b/tools/line_limits.toml
@@ -1,64 +1,140 @@
 # Per-file line count configuration for cargo xtask enforce-limits.
-# Files listed below are legacy ports of the upstream C implementation and
-# intentionally exceed the workspace-wide 600 line limit. Each entry grants a
-# modest buffer above the current line count so future cleanups continue to be
-# encouraged.
+#
+# Workspace defaults (POST-8a audit, see docs/audits/post-8-enforce-limits-ci.md):
+#   - `default_max_lines = 650`  - production-source ceiling.
+#   - `default_warn_lines = 400` - production-source warn threshold.
+#
+# Overrides below cover the small set of files that intentionally exceed the
+# workspace defaults. Two categories:
+#
+#   1. Active source files within a few percent of the cap, where the override
+#      acts as a real ceiling above ongoing maintenance work.
+#   2. Top test offenders. Splitting a large test suite is mechanical busywork
+#      that does not reduce cognitive load; the per-file caps relax the default
+#      for the worst offenders so the informational `enforce-limits` CI report
+#      surfaces actionable production-source overages instead of drowning in
+#      test noise.
+#
+# TODO(post-8a): xtask currently lacks a `default_test_max_lines` setting that
+# would apply a relaxed cap to all `tests.rs` / `tests/*.rs` files without
+# per-file plumbing. Adding it requires touching
+# `xtask/src/commands/enforce_limits/config.rs`. Until that lands, new test
+# files that exceed 650 lines must either be split or added here.
 
 default_max_lines = 650
 default_warn_lines = 400
 
-[[overrides]]
-path = "crates/cli/src/frontend/mod.rs"
-max_lines = 5700
-warn_lines = 5580
-
-[[overrides]]
-path = "crates/core/src/client/mod.rs"
-max_lines = 5800
-warn_lines = 5600
-
-[[overrides]]
-path = "crates/daemon/src/lib.rs"
-max_lines = 5500
-warn_lines = 5400
-
-[[overrides]]
-path = "crates/daemon/src/tests.rs"
-max_lines = 600
-warn_lines = 500
-
-[[overrides]]
-path = "crates/transport/src/negotiation/mod.rs"
-max_lines = 6400
-warn_lines = 6300
-
-[[overrides]]
-path = "crates/protocol/src/negotiation/tests/detector.rs"
-max_lines = 480
-warn_lines = 440
-
-[[overrides]]
-path = "crates/protocol/src/negotiation/tests/detector_sniffer.rs"
-max_lines = 530
-warn_lines = 500
-
-[[overrides]]
-path = "crates/protocol/src/negotiation/tests/sniffer_read.rs"
-max_lines = 580
-warn_lines = 550
-
-[[overrides]]
-path = "crates/protocol/src/negotiation/tests/sniffer_reset.rs"
-max_lines = 585
-warn_lines = 550
-
-[[overrides]]
-path = "crates/protocol/src/negotiation/tests/sniffer_take.rs"
-max_lines = 570
-warn_lines = 530
+# ---------------------------------------------------------------------------
+# Production source overrides (real ceilings).
+# ---------------------------------------------------------------------------
 
 [[overrides]]
 path = "crates/engine/src/local_copy/buffer_pool/pool.rs"
 max_lines = 1200
 warn_lines = 1150
 
+# ---------------------------------------------------------------------------
+# Top test-file offenders. Caps set generously above current line counts so
+# routine test additions do not require config edits. Drop the entry once the
+# underlying suite is split.
+# ---------------------------------------------------------------------------
+
+[[overrides]]
+path = "crates/protocol/src/flist/write/tests.rs"
+max_lines = 3000
+warn_lines = 2800
+
+[[overrides]]
+path = "crates/cli/src/frontend/arguments/tests.rs"
+max_lines = 3000
+warn_lines = 2800
+
+[[overrides]]
+path = "crates/engine/src/local_copy/executor/file/sparse/tests.rs"
+max_lines = 3000
+warn_lines = 2800
+
+[[overrides]]
+path = "crates/transfer/src/generator/tests.rs"
+max_lines = 3000
+warn_lines = 2800
+
+[[overrides]]
+path = "crates/protocol/src/negotiation/capabilities/tests.rs"
+max_lines = 3000
+warn_lines = 2800
+
+[[overrides]]
+path = "crates/cli/src/frontend/tests/output_parity.rs"
+max_lines = 3000
+warn_lines = 2800
+
+[[overrides]]
+path = "crates/engine/src/local_copy/tests/execute_directories.rs"
+max_lines = 3000
+warn_lines = 2800
+
+[[overrides]]
+path = "crates/core/src/client/remote/invocation/tests.rs"
+max_lines = 3000
+warn_lines = 2800
+
+[[overrides]]
+path = "crates/protocol/src/flist/read/tests.rs"
+max_lines = 3000
+warn_lines = 2800
+
+[[overrides]]
+path = "crates/engine/src/local_copy/tests/execute_skip.rs"
+max_lines = 3000
+warn_lines = 2800
+
+[[overrides]]
+path = "crates/batch/tests/batch_integration.rs"
+max_lines = 3000
+warn_lines = 2800
+
+[[overrides]]
+path = "crates/engine/src/local_copy/tests/execute_delay_updates.rs"
+max_lines = 3000
+warn_lines = 2800
+
+[[overrides]]
+path = "crates/rsync_io/src/ssh/tests.rs"
+max_lines = 3000
+warn_lines = 2800
+
+[[overrides]]
+path = "crates/batch/src/tests.rs"
+max_lines = 3000
+warn_lines = 2800
+
+[[overrides]]
+path = "crates/core/src/client/config/builder/tests.rs"
+max_lines = 3000
+warn_lines = 2800
+
+[[overrides]]
+path = "crates/daemon/src/daemon/sections/config_parsing/tests.rs"
+max_lines = 3000
+warn_lines = 2800
+
+[[overrides]]
+path = "crates/engine/src/local_copy/tests/execute_special_characters.rs"
+max_lines = 3000
+warn_lines = 2800
+
+[[overrides]]
+path = "crates/engine/src/local_copy/tests/backups.rs"
+max_lines = 3000
+warn_lines = 2800
+
+[[overrides]]
+path = "crates/engine/src/local_copy/tests/execute_special.rs"
+max_lines = 3000
+warn_lines = 2800
+
+[[overrides]]
+path = "crates/protocol/src/varint/tests.rs"
+max_lines = 3000
+warn_lines = 2800


### PR DESCRIPTION
Per POST-8 audit (`docs/audits/post-8-enforce-limits-ci.md`, PR #4480): the `enforce-limits (informational)` CI job has been red on every run because `tools/line_limits.toml` lists `crates/transport/src/negotiation/mod.rs` and the `crates/transport` crate has been removed. The xtask config loader treats a missing override target as a hard validation error, so the job aborts before reporting a single overage.

## Changes

- Drop the stale `crates/transport/...` override (file missing - root cause of CI red).
- Drop nine more overrides whose target files now sit far below their caps:
  - `crates/cli/src/frontend/mod.rs` (324/5700)
  - `crates/core/src/client/mod.rs` (145/5800)
  - `crates/daemon/src/lib.rs` (198/5500)
  - `crates/daemon/src/tests.rs` (362/600)
  - five `crates/protocol/src/negotiation/tests/sniffer_*.rs` entries (422-537, all under default 650)
- Keep `crates/engine/src/local_copy/buffer_pool/pool.rs` (1169/1200) - the only legacy entry still acting as a real ceiling on an actively maintained file.
- Add per-file overrides for the top 20 test-file offenders (>= 1945 lines), capped at 3000. The audit recommends a workspace-level `default_test_max_lines` setting, but xtask does not yet support that field; the policy is enforced per-file with a TODO referencing the schema gap.
- Refresh the comment block on the `enforce-limits` CI job to point at the POST-8 audit and drop the stale "19 over-limit files" reference.

## Effect

- 10 overrides pruned (stale or below default cap).
- 20 test-file overrides added (covers top offenders >= 1945 LoC).
- Informational `enforce-limits` job runs to completion again instead of aborting on config validation. ~302 production-source overages will now surface as per-file annotations, tracked separately for decomposition.

## Constraints honoured

- Cap mechanism unchanged; only the config payload was edited.
- No xtask source changes (`default_test_max_lines` is a deferred enhancement, captured in an inline TODO).
- All retained override paths verified to exist on disk.

## Test plan

- [ ] CI `enforce-limits (informational)` job runs to completion (no validation error).
- [ ] Job exits non-zero with per-file overage annotations rather than aborting in config parse.
- [ ] No retained override target is a missing path.