### PR TITLE
fix(fast_io): convert nvme_data_path doc bullets to paragraphs (POST-7b)

### DIFF
--- a/crates/fast_io/benches/nvme_data_path.rs
+++ b/crates/fast_io/benches/nvme_data_path.rs
@@ -17,24 +17,26 @@
 //! default, total 10 GiB on disk) and writes them sequentially through
 //! the chosen path:
 //!
-//! - `stdlib_write`: today's `Writer::Buffered` fallback. `File::create`
-//!     + `BufWriter` with the production 256 KiB buffer
-//!     (`crates/transfer/src/disk_commit/writer.rs:71-122`), one 1 MiB
-//!     chunk per `write_all` call, `flush` + `sync_all` at end-of-file to
-//!     match the production end-of-file fsync. Represents the path taken
-//!     today on every non-Linux host and on Linux when `io_uring` is
-//!     disabled or the file is forced onto the buffered writer (sparse,
-//!     append, or below the 64 KiB threshold from section 4.4 of the
-//!     design doc).
-//! - `iouring_write_fixed`: the proposed production path for files
-//!     sized at least 1 MiB. `IORING_OP_WRITE_FIXED` against a `RegisteredBufferGroup`
-//!     of 4 x 1 MiB page-aligned registered slots, one slot per concurrent
-//!     in-flight SQE. Mirrors the `submit_write_fixed_batch` helper in
-//!     `crates/fast_io/src/io_uring/registered_buffers/submit.rs:159-243`
-//!     that the wired path will call once IUD-5 lands. An `IORING_OP_FSYNC`
-//!     SQE is submitted at end-of-file to match the production
-//!     `commit_file(do_fsync = true)` placement
-//!     (`crates/fast_io/src/io_uring/disk_batch.rs:236-263`).
+//! `stdlib_write` is today's `Writer::Buffered` fallback: `File::create`
+//! plus `BufWriter` with the production 256 KiB buffer
+//! (`crates/transfer/src/disk_commit/writer.rs:71-122`), one 1 MiB
+//! chunk per `write_all` call, `flush` plus `sync_all` at end-of-file to
+//! match the production end-of-file fsync. Represents the path taken
+//! today on every non-Linux host and on Linux when `io_uring` is
+//! disabled or the file is forced onto the buffered writer (sparse,
+//! append, or below the 64 KiB threshold from section 4.4 of the
+//! design doc).
+//!
+//! `iouring_write_fixed` is the proposed production path for files
+//! sized at least 1 MiB. `IORING_OP_WRITE_FIXED` runs against a
+//! `RegisteredBufferGroup` of 4 x 1 MiB page-aligned registered slots,
+//! one slot per concurrent in-flight SQE. It mirrors the
+//! `submit_write_fixed_batch` helper in
+//! `crates/fast_io/src/io_uring/registered_buffers/submit.rs:159-243`
+//! that the wired path will call once IUD-5 lands. An `IORING_OP_FSYNC`
+//! SQE is submitted at end-of-file to match the production
+//! `commit_file(do_fsync = true)` placement
+//! (`crates/fast_io/src/io_uring/disk_batch.rs:236-263`).
 //!
 //! Both cells write the same total bytes and run the same fsync
 //! cadence, so the wall-time and MiB/s delta is attributable strictly to


### PR DESCRIPTION
Per DEP-1 audit (PR #4485): my POST-7a fix (#4481) used 5-space indents to satisfy clippy::doc_lazy_continuation but that triggered clippy::doc_overindented_list_items. The two lints conflict on the 2-char list-marker case. Resolution: rewrite the two bulleted module-doc items as standalone paragraphs starting with the cell name in backticks. Same content, no list ambiguity, satisfies both lints.