### PR TITLE
fix(ci): clear master clippy regressions in rsync_io

### DIFF
--- a/crates/rsync_io/src/channel_adapter.rs
+++ b/crates/rsync_io/src/channel_adapter.rs
@@ -115,18 +115,17 @@ impl AsyncRead for ChannelReader {
 /// current task and returns [`Poll::Pending`] until capacity is available. A
 /// closed channel surfaces as [`io::ErrorKind::BrokenPipe`]. `poll_shutdown`
 /// drops the internal sender, signalling EOF to the reader half.
+/// Boxed reservation future used by [`ChannelWriter`] to preserve the
+/// channel's wait-queue registration across `poll_write` invocations.
+type ReservationFuture = Pin<
+    Box<dyn Future<Output = Result<mpsc::OwnedPermit<Vec<u8>>, mpsc::error::SendError<()>>> + Send>,
+>;
+
 pub struct ChannelWriter {
     tx: Option<mpsc::Sender<Vec<u8>>>,
     // Pending reservation future preserved across polls so the channel's
     // wait-queue registration is not dropped between `poll_write` calls.
-    reserving: Option<
-        Pin<
-            Box<
-                dyn Future<Output = Result<mpsc::OwnedPermit<Vec<u8>>, mpsc::error::SendError<()>>>
-                    + Send,
-            >,
-        >,
-    >,
+    reserving: Option<ReservationFuture>,
 }
 
 impl ChannelWriter {

--- a/crates/rsync_io/src/ssh/async_stderr_drain.rs
+++ b/crates/rsync_io/src/ssh/async_stderr_drain.rs
@@ -253,7 +253,7 @@ where
                     buf.extend(&line);
                 }
                 let text = String::from_utf8_lossy(&line);
-                let trimmed = text.trim_end_matches(|c| c == '\n' || c == '\r');
+                let trimmed = text.trim_end_matches(['\n', '\r']);
                 if !trimmed.is_empty() {
                     tracing::warn!(target: "ssh::stderr", "{}", trimmed);
                 }
@@ -341,7 +341,7 @@ mod tests {
             // drain loop's read_until returns a single Ok with the full
             // 1 KiB plus newline.
             let mut payload = Vec::with_capacity(1024);
-            payload.extend(std::iter::repeat(b'a').take(1023));
+            payload.extend(std::iter::repeat_n(b'a', 1023));
             payload.push(b'\n');
 
             child.write_all(&payload).await.expect("write payload");


### PR DESCRIPTION
Master CI failing fmt+clippy on 3 lints introduced by recent merges:
- channel_adapter.rs clippy::type_complexity on dyn Future bound — factor ReservationFuture alias
- async_stderr_drain.rs:256 clippy::manual_pattern_char_comparison — use trim_end_matches([..])
- async_stderr_drain.rs:344 clippy::manual_repeat_n — use std::iter::repeat_n()