### PR TITLE
fix(ci): drop stale flist/write/tests.rs override after SPL-17

### DIFF
--- a/tools/line_limits.toml
+++ b/tools/line_limits.toml
@@ -49,11 +49,6 @@ warn_lines = 1300
 # ---------------------------------------------------------------------------
 
 [[overrides]]
-path = "crates/protocol/src/flist/write/tests.rs"
-max_lines = 3000
-warn_lines = 2800
-
-[[overrides]]
 path = "crates/cli/src/frontend/arguments/tests.rs"
 max_lines = 3000
 warn_lines = 2800


### PR DESCRIPTION
Master enforce-limits CI fails on `override path crates/protocol/src/flist/write/tests.rs ... does not exist` because SPL-17 (#4490) split that file into a tests/ directory. Same failure shape as POST-8a (#4482). Drops the stale entry; remaining 20 overrides all resolve.