### PR TITLE
fix: gate SPILL_TAG_ZSTD import and has_bandwidth_limiter to match call sites

### DIFF
--- a/crates/engine/src/concurrent_delta/spill/buffer/spill.rs
+++ b/crates/engine/src/concurrent_delta/spill/buffer/spill.rs
@@ -7,9 +7,9 @@ use std::io::{self, SeekFrom};
 
 use super::super::tempfile::open_backend;
 use super::super::{SpillCodec, SpillCompression, SpillError, SpillGranularity, rss};
-use super::{HOT_ZONE, SPILL_TAG_RAW, SpillableReorderBuffer};
 #[cfg(feature = "spill-compression")]
 use super::SPILL_TAG_ZSTD;
+use super::{HOT_ZONE, SPILL_TAG_RAW, SpillableReorderBuffer};
 
 impl<T: SpillCodec> SpillableReorderBuffer<T> {
     /// Spills the highest-sequence items to disk until memory usage drops

--- a/crates/engine/src/concurrent_delta/spill/buffer/spill.rs
+++ b/crates/engine/src/concurrent_delta/spill/buffer/spill.rs
@@ -7,7 +7,9 @@ use std::io::{self, SeekFrom};
 
 use super::super::tempfile::open_backend;
 use super::super::{SpillCodec, SpillCompression, SpillError, SpillGranularity, rss};
-use super::{HOT_ZONE, SPILL_TAG_RAW, SPILL_TAG_ZSTD, SpillableReorderBuffer};
+use super::{HOT_ZONE, SPILL_TAG_RAW, SpillableReorderBuffer};
+#[cfg(feature = "spill-compression")]
+use super::SPILL_TAG_ZSTD;
 
 impl<T: SpillCodec> SpillableReorderBuffer<T> {
     /// Spills the highest-sequence items to disk until memory usage drops

--- a/crates/engine/src/local_copy/context_impl/state.rs
+++ b/crates/engine/src/local_copy/context_impl/state.rs
@@ -204,6 +204,10 @@ impl<'a> CopyContext<'a> {
     }
 
     /// Returns whether a bandwidth limiter is active.
+    #[cfg(any(
+        target_os = "macos",
+        all(target_os = "linux", feature = "iouring-data-writes")
+    ))]
     pub(in crate::local_copy) const fn has_bandwidth_limiter(&self) -> bool {
         self.limiter.is_some()
     }


### PR DESCRIPTION
## Summary
- Move `SPILL_TAG_ZSTD` import in `concurrent_delta/spill/buffer/spill.rs` behind `#[cfg(feature = "spill-compression")]` so default Linux builds (without that feature) do not see an unused import.
- Gate the `has_bandwidth_limiter` method declaration in `local_copy/context_impl/state.rs` to `any(target_os = "macos", all(target_os = "linux", feature = "iouring-data-writes"))` so it matches its only call sites and stops triggering dead-code errors on default Linux builds.

Both errors were blocking the "Build oc-rsync and upstream rsync" step in the Interop Validation and Parallel Determinism workflows on master.

## Test plan
- [ ] fmt + clippy CI green
- [ ] Interop Validation builds oc-rsync without unused-import / dead-code errors
- [ ] Parallel Determinism builds oc-rsync
- [ ] No behaviour change in any feature combination (gated code unchanged, only visibility of the symbols moved)