### PR TITLE
style(xtask): wrap long is_test_source test assert per rustfmt

### DIFF
--- a/xtask/src/commands/enforce_limits/mod.rs
+++ b/xtask/src/commands/enforce_limits/mod.rs
@@ -422,7 +422,9 @@ warn_lines = 1
         assert!(is_test_source(Path::new(
             "crates/foo/src/comprehensive_tests.rs"
         )));
-        assert!(is_test_source(Path::new("crates/foo/src/permission_tests.rs")));
+        assert!(is_test_source(Path::new(
+            "crates/foo/src/permission_tests.rs"
+        )));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Followup to commit 5575e3681 (POST-12) - rustfmt wants the long string argument in the `permission_tests.rs` assertion on its own line.
- Master \`fmt + clippy\` job has been failing since the merge with the diff in xtask/src/commands/enforce_limits/mod.rs:422 only.

## Test plan
- [ ] fmt + clippy green on this PR
- [ ] Master fmt + clippy returns to green after merge