### PR TITLE
chore(enforce-limits): add per-file ceilings for 48 near-cap source files

### DIFF
--- a/tools/line_limits.toml
+++ b/tools/line_limits.toml
@@ -40,3 +40,255 @@ warn_lines = 1150
 path = "crates/checksums/src/simd_batch/md5_simd/avx512.rs"
 max_lines = 1400
 warn_lines = 1300
+
+# ---------------------------------------------------------------------------
+# Near-cap source files: within 100 lines of the production ceiling. The
+# override pins each at its current line count, acting as a real ceiling
+# above ongoing maintenance work. Adding a new line in any of these files
+# requires either an SPL-style decomposition or an explicit bump here -
+# the warn threshold (max - 50) flags the file for attention before the
+# next change fails CI. Files significantly larger than the cap (>750 LoC)
+# are intentionally NOT listed here; those belong on the SPL backlog and
+# remain enforce-limits failures until decomposed.
+# ---------------------------------------------------------------------------
+
+[[overrides]]
+path = "crates/bandwidth/src/limiter/test_support.rs"
+max_lines = 740
+warn_lines = 690
+
+[[overrides]]
+path = "crates/bandwidth/src/parse/components.rs"
+max_lines = 700
+warn_lines = 650
+
+[[overrides]]
+path = "crates/checksums/src/strong/xxhash.rs"
+max_lines = 682
+warn_lines = 632
+
+[[overrides]]
+path = "crates/cli/src/frontend/execution/options/size.rs"
+max_lines = 746
+warn_lines = 696
+
+[[overrides]]
+path = "crates/cli/src/frontend/execution/stop.rs"
+max_lines = 701
+warn_lines = 651
+
+[[overrides]]
+path = "crates/cli/src/frontend/filter_rules/parsing/mod.rs"
+max_lines = 747
+warn_lines = 697
+
+[[overrides]]
+path = "crates/cli/src/frontend/out_format/parser.rs"
+max_lines = 686
+warn_lines = 636
+
+[[overrides]]
+path = "crates/cli/src/frontend/progress_format.rs"
+max_lines = 709
+warn_lines = 659
+
+[[overrides]]
+path = "crates/compress/src/lz4/raw.rs"
+max_lines = 687
+warn_lines = 637
+
+[[overrides]]
+path = "crates/core/src/client/module_list/connect/proxy.rs"
+max_lines = 695
+warn_lines = 645
+
+[[overrides]]
+path = "crates/core/src/client/remote/embedded_ssh_transfer.rs"
+max_lines = 737
+warn_lines = 687
+
+[[overrides]]
+path = "crates/core/src/remote_shell.rs"
+max_lines = 713
+warn_lines = 663
+
+[[overrides]]
+path = "crates/core/src/version/report/config.rs"
+max_lines = 717
+warn_lines = 667
+
+[[overrides]]
+path = "crates/core/src/version/report/renderer.rs"
+max_lines = 665
+warn_lines = 615
+
+[[overrides]]
+path = "crates/daemon/src/auth.rs"
+max_lines = 741
+warn_lines = 691
+
+[[overrides]]
+path = "crates/daemon/src/daemon/sections/module_access/client_args.rs"
+max_lines = 681
+warn_lines = 631
+
+[[overrides]]
+path = "crates/engine/src/concurrent_delta/reorder/mod.rs"
+max_lines = 724
+warn_lines = 674
+
+[[overrides]]
+path = "crates/engine/src/concurrent_delta/strategy.rs"
+max_lines = 683
+warn_lines = 633
+
+[[overrides]]
+path = "crates/engine/src/local_copy/debug_del.rs"
+max_lines = 713
+warn_lines = 663
+
+[[overrides]]
+path = "crates/engine/src/local_copy/debug_send.rs"
+max_lines = 669
+warn_lines = 619
+
+[[overrides]]
+path = "crates/engine/src/local_copy/executor/directory/planner.rs"
+max_lines = 721
+warn_lines = 671
+
+[[overrides]]
+path = "crates/engine/src/local_copy/executor/file/comparison.rs"
+max_lines = 679
+warn_lines = 629
+
+[[overrides]]
+path = "crates/engine/src/local_copy/executor/special/symlink.rs"
+max_lines = 657
+warn_lines = 607
+
+[[overrides]]
+path = "crates/engine/src/local_copy/options/path_behavior.rs"
+max_lines = 694
+warn_lines = 644
+
+[[overrides]]
+path = "crates/engine/src/local_copy/pipelined_state.rs"
+max_lines = 718
+warn_lines = 668
+
+[[overrides]]
+path = "crates/fast_io/src/copy_file_range.rs"
+max_lines = 678
+warn_lines = 628
+
+[[overrides]]
+path = "crates/fast_io/src/debug_io.rs"
+max_lines = 663
+warn_lines = 613
+
+[[overrides]]
+path = "crates/fast_io/src/iocp/file_factory.rs"
+max_lines = 665
+warn_lines = 615
+
+[[overrides]]
+path = "crates/fast_io/src/iocp/socket.rs"
+max_lines = 733
+warn_lines = 683
+
+[[overrides]]
+path = "crates/fast_io/src/syscall_batch.rs"
+max_lines = 724
+warn_lines = 674
+
+[[overrides]]
+path = "crates/filters/src/set.rs"
+max_lines = 661
+warn_lines = 611
+
+[[overrides]]
+path = "crates/matching/benches/profiling_analysis.rs"
+max_lines = 694
+warn_lines = 644
+
+[[overrides]]
+path = "crates/matching/src/generator.rs"
+max_lines = 682
+warn_lines = 632
+
+[[overrides]]
+path = "crates/metadata/src/apply_batch.rs"
+max_lines = 711
+warn_lines = 661
+
+[[overrides]]
+path = "crates/metadata/src/nfsv4_acl.rs"
+max_lines = 667
+warn_lines = 617
+
+[[overrides]]
+path = "crates/metadata/src/stat_cache.rs"
+max_lines = 750
+warn_lines = 700
+
+[[overrides]]
+path = "crates/protocol/src/compatibility/flags.rs"
+max_lines = 699
+warn_lines = 649
+
+[[overrides]]
+path = "crates/protocol/src/debug_io.rs"
+max_lines = 724
+warn_lines = 674
+
+[[overrides]]
+path = "crates/protocol/src/multiplex/writer.rs"
+max_lines = 666
+warn_lines = 616
+
+[[overrides]]
+path = "crates/protocol/src/negotiation/sniffer/core.rs"
+max_lines = 674
+warn_lines = 624
+
+[[overrides]]
+path = "crates/protocol/src/negotiation/types.rs"
+max_lines = 709
+warn_lines = 659
+
+[[overrides]]
+path = "crates/protocol/src/version/select.rs"
+max_lines = 670
+warn_lines = 620
+
+[[overrides]]
+path = "crates/protocol/src/xattr/cache.rs"
+max_lines = 723
+warn_lines = 673
+
+[[overrides]]
+path = "crates/rsync_io/src/negotiation/buffer/storage.rs"
+max_lines = 732
+warn_lines = 682
+
+[[overrides]]
+path = "crates/rsync_io/src/ssh/aux_channel.rs"
+max_lines = 716
+warn_lines = 666
+
+[[overrides]]
+path = "crates/transfer/src/config/mod.rs"
+max_lines = 671
+warn_lines = 621
+
+[[overrides]]
+path = "crates/transfer/src/pipeline/receiver.rs"
+max_lines = 681
+warn_lines = 631
+
+[[overrides]]
+path = "xtask/src/commands/package/build.rs"
+max_lines = 749
+warn_lines = 699
+


### PR DESCRIPTION
## Summary
The default cap is 650 lines. \`enforce-limits\` previously flagged 89 source files over that, masking real growth in the noise. Of those 89:

- **48 sit within 100 lines of the cap (650-750 LoC).** These are pinned at their current line count as a real ceiling - any growth triggers either an SPL-style decomposition or an explicit cap bump. The warn threshold (max - 50) calls attention to the file before the next change would fail CI.
- **41 are significantly over the cap (>750 LoC)** and remain \`enforce-limits\` failures until decomposed. Tracking them via the informational job keeps the SPL backlog visible without unblocking further growth here.

Combined with the recently-shipped \`default_test_max_lines\` (POST-12), the actionable \`enforce-limits\` report now focuses on the 41 production source files that genuinely need decomposition, instead of drowning the signal in 275 entries.

## Test plan
- [ ] fmt + clippy green
- [ ] \`enforce-limits\` informational job reports only 41 production-source overages (down from 89)