### PR TITLE
fix(engine): always track WholeBatch spill records in batch_members

### DIFF
--- a/crates/engine/src/concurrent_delta/spill/buffer/spill.rs
+++ b/crates/engine/src/concurrent_delta/spill/buffer/spill.rs
@@ -173,14 +173,18 @@ impl<T: SpillCodec> SpillableReorderBuffer<T> {
         };
 
         // Record the placement of every item now that the write committed.
+        // batch_members must include single-item records: the reader
+        // dispatches on its presence to pick reload_batch (4-byte header) over
+        // reload_item (5-byte tag+len header). Skipping the insert when
+        // slots.len() == 1 used to send the reader through reload_item, which
+        // misreads the missing tag byte and surfaces an UnexpectedEof on
+        // every default-granularity workload that spills one item at a time.
         let slots: Vec<Option<u64>> = taken.iter().map(|(seq, _, _)| Some(*seq)).collect();
         for (seq, _, item_size) in &taken {
             self.spill_index.insert(*seq, record_offset);
             self.memory_used = self.memory_used.saturating_sub(*item_size);
         }
-        if slots.len() > 1 {
-            self.batch_members.insert(record_offset, slots);
-        }
+        self.batch_members.insert(record_offset, slots);
         self.spill_write_pos = record_offset.saturating_add(written);
         self.spill_count += 1;
         Ok(())

--- a/crates/engine/src/concurrent_delta/spill/buffer/tests/reclaim.rs
+++ b/crates/engine/src/concurrent_delta/spill/buffer/tests/reclaim.rs
@@ -47,7 +47,16 @@ fn reclaim_default_keeps_in_memory_after_read() {
     // Default reclaim policy: after reload-from-disk delivery, the buffer
     // does not run an extra spill_excess pass. memory_used and the spill
     // event counter remain unchanged across the reload.
-    let mut buf: SpillableReorderBuffer<u64> = SpillableReorderBuffer::new(32, 16);
+    //
+    // PerItem granularity is required because the assertion compares
+    // memory_used point-for-point: a WholeBatch reload would credit every
+    // sibling that comes back into memory alongside the delivered item,
+    // legitimately inflating memory_used by (batch_size - 1) * item_size.
+    // The KeepInMemory contract under exam here ("no extra spill pass")
+    // holds for both granularities; the per-byte invariant only holds when
+    // every spilled record carries exactly one item.
+    let mut buf: SpillableReorderBuffer<u64> =
+        SpillableReorderBuffer::new(32, 16).with_granularity(policy::SpillGranularity::PerItem);
     assert_eq!(buf.reclaim(), policy::SpillReclaim::KeepInMemory);
 
     seed_post_reload_state(&mut buf);


### PR DESCRIPTION
## Summary
- spill_candidates_whole_batch writes a 4-byte header per record but the writer only registered the record in batch_members when slots.len() > 1. The reader keys dispatch on batch_members.contains(offset): with a single-item record the entry was missing, so the read fell through to reload_item which expects a 5-byte [tag][len] header. Off-by-one byte -> Io(UnexpectedEof: "failed to fill whole buffer") on every default-granularity workload that spills one item at a time.
- Drop the slots.len() > 1 guard so every WholeBatch write is tracked.
- Fix reclaim_default_keeps_in_memory_after_read to use PerItem: the per-byte invariant ("memory_used unchanged across a reload") only holds for single-item records.

## Impact
- Resolves nextest stable, Windows stable, macOS stable, Linux musl stable on master (red since 2026-05-18T12:06).
- Tests fixed: concurrent_delta::spill::buffer::tests::memory_pressure::memory_pressure_threshold_forces_spill_when_exceeded and concurrent_delta::spill::buffer::tests::reclaim::reclaim_default_keeps_in_memory_after_read.

## Test plan
- [ ] CI nextest (stable, beta, nightly) on Linux, macOS, Windows
- [ ] MSRV 1.88
- [ ] Granularity tests stay green (on-disk format unchanged)