### PR TITLE
feat(version): list compiled-in Cargo features in --version output

### DIFF
--- a/crates/core/src/version/report/mod.rs
+++ b/crates/core/src/version/report/mod.rs
@@ -14,5 +14,6 @@ pub use config::{VersionInfoConfig, VersionInfoConfigBuilder};
 pub use renderer::VersionInfoReport;
 #[cfg(test)]
 pub(crate) use renderer::{
-    TimeT, default_checksum_algorithms, default_compress_algorithms, default_daemon_auth_algorithms,
+    TimeT, compiled_build_features, default_checksum_algorithms, default_compress_algorithms,
+    default_daemon_auth_algorithms,
 };

--- a/crates/core/src/version/report/renderer.rs
+++ b/crates/core/src/version/report/renderer.rs
@@ -404,14 +404,13 @@ pub(crate) fn default_daemon_auth_algorithms() -> Vec<Cow<'static, str>> {
 /// Returns the list of Cargo features the binary was compiled with.
 ///
 /// Each entry is the canonical Cargo feature name as declared in the
-/// workspace `Cargo.toml`. Both core-level features (compression, ACL,
-/// xattr, iconv, async, embedded SSH) and bin-level features that
-/// forward into core (`zlib-ng`, `mmap-free-basis`) are detectable
-/// here; bin-only features that do not propagate into `core` (such as
-/// `parallel`, `io_uring`, `iocp`, `copy_file_range`, `openssl`,
-/// `openssl-vendored`, `sd-notify`, `mimalloc`) are surfaced via the
-/// existing `Capabilities` / `Optimizations` sections and the
-/// `Platform I/O` line above this one.
+/// workspace `Cargo.toml`. Only features visible to the `core` crate
+/// (compression, ACL, xattr, iconv, async, embedded SSH, zlib-ng) are
+/// detectable here; bin-only features that do not propagate into `core`
+/// (`parallel`, `io_uring`, `iocp`, `copy_file_range`, `openssl`,
+/// `openssl-vendored`, `mmap-free-basis`, `sd-notify`, `mimalloc`) are
+/// surfaced via the existing `Capabilities` / `Optimizations` sections
+/// and the `Platform I/O` line above this one.
 #[must_use]
 pub(crate) fn compiled_build_features() -> Vec<Cow<'static, str>> {
     let mut features: Vec<Cow<'static, str>> = Vec::new();
@@ -439,9 +438,6 @@ pub(crate) fn compiled_build_features() -> Vec<Cow<'static, str>> {
     }
     if cfg!(feature = "embedded-ssh") {
         features.push(Cow::Borrowed("embedded-ssh"));
-    }
-    if cfg!(feature = "mmap-free-basis") {
-        features.push(Cow::Borrowed("mmap-free-basis"));
     }
 
     features

--- a/crates/core/src/version/report/renderer.rs
+++ b/crates/core/src/version/report/renderer.rs
@@ -191,6 +191,7 @@ impl VersionInfoReport {
         self.write_named_list(writer, "Checksum list", &self.checksum_algorithms)?;
         self.write_named_list(writer, "Compress list", &self.compress_algorithms)?;
         self.write_named_list(writer, "Daemon auth list", &self.daemon_auth_algorithms)?;
+        self.write_named_list(writer, "Build features", &compiled_build_features())?;
         writer.write_char('\n')?;
 
         self.write_gpl_footer(writer)
@@ -398,6 +399,52 @@ pub(crate) fn default_daemon_auth_algorithms() -> Vec<Cow<'static, str>> {
         .iter()
         .map(|digest| Cow::Borrowed(digest.name()))
         .collect()
+}
+
+/// Returns the list of Cargo features the binary was compiled with.
+///
+/// Each entry is the canonical Cargo feature name as declared in the
+/// workspace `Cargo.toml`. Both core-level features (compression, ACL,
+/// xattr, iconv, async, embedded SSH) and bin-level features that
+/// forward into core (`zlib-ng`, `mmap-free-basis`) are detectable
+/// here; bin-only features that do not propagate into `core` (such as
+/// `parallel`, `io_uring`, `iocp`, `copy_file_range`, `openssl`,
+/// `openssl-vendored`, `sd-notify`, `mimalloc`) are surfaced via the
+/// existing `Capabilities` / `Optimizations` sections and the
+/// `Platform I/O` line above this one.
+#[must_use]
+pub(crate) fn compiled_build_features() -> Vec<Cow<'static, str>> {
+    let mut features: Vec<Cow<'static, str>> = Vec::new();
+
+    if cfg!(feature = "zstd") {
+        features.push(Cow::Borrowed("zstd"));
+    }
+    if cfg!(feature = "lz4") {
+        features.push(Cow::Borrowed("lz4"));
+    }
+    if cfg!(feature = "zlib-ng") {
+        features.push(Cow::Borrowed("zlib-ng"));
+    }
+    if cfg!(feature = "acl") {
+        features.push(Cow::Borrowed("acl"));
+    }
+    if cfg!(feature = "xattr") {
+        features.push(Cow::Borrowed("xattr"));
+    }
+    if cfg!(feature = "iconv") {
+        features.push(Cow::Borrowed("iconv"));
+    }
+    if cfg!(feature = "async") {
+        features.push(Cow::Borrowed("async"));
+    }
+    if cfg!(feature = "embedded-ssh") {
+        features.push(Cow::Borrowed("embedded-ssh"));
+    }
+    if cfg!(feature = "mmap-free-basis") {
+        features.push(Cow::Borrowed("mmap-free-basis"));
+    }
+
+    features
 }
 
 #[derive(Clone, Debug)]

--- a/crates/core/src/version/tests/report.rs
+++ b/crates/core/src/version/tests/report.rs
@@ -1,7 +1,8 @@
 use super::*;
 use crate::branding::Brand;
 use crate::version::report::{
-    default_checksum_algorithms, default_compress_algorithms, default_daemon_auth_algorithms,
+    compiled_build_features, default_checksum_algorithms, default_compress_algorithms,
+    default_daemon_auth_algorithms,
 };
 use fast_io::platform_io_capabilities;
 use libc::{ino_t, off_t};
@@ -75,6 +76,19 @@ fn version_info_report_renders_default_report() {
     assert!(actual.contains(&format!(
         "Daemon auth list:\n    {daemon_auth_algorithms}\n"
     )));
+
+    let build_features_list = compiled_build_features();
+    if build_features_list.is_empty() {
+        assert!(actual.contains("Build features:\n    none\n"));
+    } else {
+        let build_features = build_features_list
+            .iter()
+            .map(|feat| feat.as_ref())
+            .collect::<Vec<_>>()
+            .join(" ");
+        assert!(actual.contains(&format!("Build features:\n    {build_features}\n")));
+    }
+
     let platform_caps = platform_io_capabilities();
     if !platform_caps.is_empty() {
         assert!(actual.contains("Platform I/O:"));


### PR DESCRIPTION
## Summary
- Add `compiled_build_features()` enumerating every core-visible Cargo feature the binary was built with (zstd, lz4, zlib-ng, acl, xattr, iconv, async, embedded-ssh).
- Wire it into the human-readable `--version` renderer as a new `Build features:` section under the existing `Platform I/O:` line.
- Bin-only features (parallel, io_uring, iocp, copy_file_range, openssl, openssl-vendored, mmap-free-basis, sd-notify, mimalloc) are not core-visible and continue to surface via the existing `Capabilities` / `Optimizations` sections.

## Test plan
- [ ] `oc-rsync --version` shows `Build features: zstd lz4 ...` line on a default build
- [ ] The list is empty (renders as `none`) for a no-default-features build
- [ ] Existing renderer tests pass