### PR TITLE
docs(branding): promote test rationale to rustdoc

### DIFF
--- a/crates/branding/src/branding/brand.rs
+++ b/crates/branding/src/branding/brand.rs
@@ -433,11 +433,13 @@ mod tests {
             assert!(!Brand::Upstream.daemon_program_name().is_empty());
         }
 
+        /// `exists()` may legitimately return either value in the test
+        /// environment; we only exercise the call to guard against a panic
+        /// in the path-construction path.
         #[test]
         fn config_paths() {
             assert!(!Brand::Oc.daemon_config_path_str().is_empty());
             assert!(!Brand::Upstream.daemon_config_path_str().is_empty());
-            // Call to test it doesn't panic - path may not exist in test environment
             let _ = Brand::Oc.daemon_config_path().exists();
         }
 

--- a/crates/branding/src/branding/detection.rs
+++ b/crates/branding/src/branding/detection.rs
@@ -183,11 +183,12 @@ mod tests {
         assert_eq!(brand_for_program_os_str(os_str), Some(Brand::Upstream));
     }
 
+    /// Env overrides can flip the result either way, so the assertion only
+    /// checks that detection produces *some* valid brand without panicking.
     #[test]
     fn detect_brand_from_program_arg() {
         let program = OsString::from(oc_client());
         let brand = detect_brand(Some(program.as_os_str()));
-        // May return Oc or be overridden by env, but should not panic.
         assert!(brand == Brand::Oc || brand == Brand::Upstream);
     }
 

--- a/crates/branding/src/branding/profile.rs
+++ b/crates/branding/src/branding/profile.rs
@@ -299,10 +299,11 @@ mod tests {
             assert_eq!(profile.daemon_secrets_path_str(), "/etc/secrets");
         }
 
+        /// Path accessors must not panic; absoluteness is platform-dependent
+        /// so we only exercise the getter without asserting the verdict.
         #[test]
         fn path_accessors() {
             let profile = oc_profile();
-            // Call to ensure it doesn't panic - may not be absolute on all platforms
             let _ = profile.daemon_config_dir().is_absolute();
             assert!(profile.daemon_config_path().to_str().is_some());
             assert!(profile.daemon_secrets_path().to_str().is_some());
@@ -360,41 +361,43 @@ mod tests {
         use super::*;
         use crate::branding::Brand;
 
+        /// Values come from workspace metadata that the test cannot assert
+        /// literal values against; the check is that the getters return
+        /// non-empty strings.
         #[test]
         fn upstream_profile_values() {
             let profile = upstream_profile();
-            // Values come from workspace metadata, just verify they're non-empty
             assert!(!profile.client_program_name().is_empty());
             assert!(!profile.daemon_program_name().is_empty());
         }
 
+        /// See [`upstream_profile_values`] for why the assertion is
+        /// non-empty rather than literal.
         #[test]
         fn oc_profile_values() {
             let profile = oc_profile();
-            // Values come from workspace metadata, just verify they're non-empty
             assert!(!profile.client_program_name().is_empty());
             assert!(!profile.daemon_program_name().is_empty());
         }
 
+        /// See [`upstream_profile_values`] for the non-empty-only rationale.
         #[test]
         fn upstream_program_names() {
-            // Values come from workspace metadata, just verify they're non-empty
             assert!(!upstream_client_program_name().is_empty());
             assert!(!upstream_daemon_program_name().is_empty());
             assert!(!client_program_name().is_empty());
             assert!(!daemon_program_name().is_empty());
         }
 
+        /// See [`upstream_profile_values`] for the non-empty-only rationale.
         #[test]
         fn oc_program_names() {
-            // Values come from workspace metadata, just verify they're non-empty
             assert!(!oc_client_program_name().is_empty());
             assert!(!oc_daemon_program_name().is_empty());
         }
 
         #[test]
         fn os_str_accessors() {
-            // Verify OsStr accessors match their str counterparts
             assert_eq!(
                 client_program_name_os_str(),
                 OsStr::new(client_program_name())


### PR DESCRIPTION
## Summary
First crate in the workspace-wide comment-cleanup pass. The internal \`//\` comments above test bodies explained *intent* (why the assertion is non-empty rather than literal, why we call without asserting the return value, etc.) -- exactly the kind of information that belongs in \`///\` rustdoc on the enclosing function, not as a sibling \`//\` line.

## What changed
- \`branding/profile.rs\` -- 5 test rationale blocks promoted to \`///\` on each test fn (4 of them share a single source-of-truth doc and the others link to it).
- \`branding/detection.rs\` -- 1 test rationale promoted.
- \`branding/brand.rs\` -- 1 test rationale promoted.
- One restatement comment dropped (\`os_str_accessors\`: the test name conveys the same thing).

## What stays
- All \`SAFETY:\` blocks in \`branding/tests.rs\` (Rust 2024 env-mutation contract).
- The two inline labels in \`config_path_candidates_for_{oc,upstream}\` that name the otherwise opaque first element of each ordered candidate vector.

## Template
This sets the pattern for the remaining crates: keep upstream rsync source refs, \`SAFETY:\` blocks, and non-obvious WHY; promote test rationale to \`///\`; drop restatement.

## Test plan
- [ ] fmt + clippy (no behavioural changes)
- [ ] nextest -- test names unchanged, assertions unchanged