### PR TITLE
docs(logging-sink): promote test rationale; drop restatement

### DIFF
--- a/crates/logging-sink/src/sink/message_sink/accessors.rs
+++ b/crates/logging-sink/src/sink/message_sink/accessors.rs
@@ -151,11 +151,12 @@ mod tests {
         let _scratch = sink.scratch();
     }
 
+    /// Exercises the mutable accessor; there is nothing to assert beyond
+    /// the fact that the call type-checks and does not panic.
     #[test]
     fn scratch_mut_returns_mutable_reference() {
         let mut sink = make_sink();
         let _scratch = sink.scratch_mut();
-        // Just verify we can get a mutable reference
     }
 
     #[test]

--- a/crates/logging-sink/src/sink/message_sink/writing.rs
+++ b/crates/logging-sink/src/sink/message_sink/writing.rs
@@ -231,7 +231,6 @@ mod tests {
         let messages = vec![Message::info("a"), Message::info("b")];
         sink.write_all(&messages).unwrap();
         let output = sink.writer();
-        // Count newlines
         let newline_count = output.iter().filter(|&&b| b == b'\n').count();
         assert_eq!(newline_count, 2);
     }

--- a/crates/logging-sink/src/syslog.rs
+++ b/crates/logging-sink/src/syslog.rs
@@ -488,9 +488,10 @@ mod tests {
         assert_eq!(format!("{facility}"), "local3");
     }
 
+    /// Spot-check every variant maps to a [`syslog::Facility`] without
+    /// panicking; the wire mapping has no other observable side-effects.
     #[test]
     fn to_wire_covers_all_variants() {
-        // Spot-check every variant maps to a syslog::Facility without panicking.
         let facilities = [
             SyslogFacility::Kern,
             SyslogFacility::User,
@@ -604,18 +605,20 @@ mod tests {
         syslog_message(SyslogPriority::Info, "before\0after");
     }
 
+    /// Cold-path coverage: drop any previously opened logger so the
+    /// emit-without-open branch is exercised.
     #[test]
     fn syslog_message_without_open_is_noop() {
-        // Drop any previously opened logger so we hit the cold path.
         if let Ok(mut slot) = logger_slot().lock() {
             *slot = None;
         }
         syslog_message(SyslogPriority::Info, "no logger configured");
     }
 
+    /// Sanity check: each severity variant is constructible and the
+    /// `Copy`/`Clone` impls round-trip.
     #[test]
     fn priority_covers_all_severity_levels() {
-        // Sanity check: each variant is constructible and Copy/Clone works.
         let priorities = [
             SyslogPriority::Emergency,
             SyslogPriority::Alert,


### PR DESCRIPTION
Per the workspace comment-cleanup pass. 3 syslog.rs test-intent comments + 1 in accessors.rs promoted to `///`. One restatement comment dropped from writing.rs. Upstream rsync refs and design rationale around swallowed syslog write errors kept verbatim. No behavioural changes.