### PR TITLE
docs(windows-gnu-eh): promote no-op test rationale to rustdoc

### DIFF
--- a/crates/windows-gnu-eh/src/lib.rs
+++ b/crates/windows-gnu-eh/src/lib.rs
@@ -231,13 +231,13 @@ pub use not_windows_gnu::force_link;
 mod tests {
     use super::*;
 
+    /// The helper intentionally performs no work on non-Windows targets and
+    /// exists purely to keep linkage symmetric across platforms. Exercising
+    /// the function ensures its signature remains callable from dependants
+    /// and guards against accidental regressions that would introduce side
+    /// effects.
     #[test]
     fn force_link_is_a_no_op() {
-        // The helper intentionally performs no work on non-Windows targets and
-        // exists purely to keep linkage symmetric across platforms. Exercising
-        // the function ensures its signature remains callable from dependants
-        // and guards against accidental regressions that would introduce side
-        // effects.
         force_link();
     }
 }


### PR DESCRIPTION
Single rationale block above `force_link_is_a_no_op` belongs as `///` on the test fn. All other internal comments are SAFETY blocks documenting Win32 FFI invariants and stay verbatim.