### PR TITLE
fix(engine): seat DeleteContext::new cursor at dest_root

### DIFF
--- a/crates/engine/src/delete/context.rs
+++ b/crates/engine/src/delete/context.rs
@@ -170,12 +170,17 @@ pub struct DeleteContext {
 
 impl DeleteContext {
     /// Builds a new context rooted at `dest_root` with the given timing
-    /// mode. The traversal cursor is rooted at the empty relative path
-    /// (matching the destination root itself, which upstream
-    /// `delete_in_dir` visits first).
+    /// mode. The traversal cursor is seated at `dest_root` so the first
+    /// directory the emitter pulls matches the key under which callers
+    /// publish their plan via [`Self::publish_plan_for`] or by inserting
+    /// directly into [`Self::plans`]. Use [`Self::with_shared_plan_map`]
+    /// for the receiver-driven pipeline where plans are keyed by
+    /// destination-relative paths and the cursor must start at the
+    /// relative root.
     #[must_use]
     pub fn new(dest_root: PathBuf, timing: EmitterTiming) -> Self {
         let (tx, rx) = unbounded();
+        let cursor_root = dest_root.clone();
         Self {
             plans: Arc::new(DeletePlanMap::new()),
             dest_root,
@@ -184,7 +189,7 @@ impl DeleteContext {
             delete_excluded: false,
             policy: EmitterErrorPolicy::default(),
             segment_entries: Mutex::new(Vec::new()),
-            cursor_root: PathBuf::new(),
+            cursor_root,
             cursor_tx: Mutex::new(Some(tx)),
             cursor_rx: Mutex::new(Some(rx)),
         }


### PR DESCRIPTION
## Summary

- Fix the cross-platform CI failures in `engine::delete_emitter_timing_modes::all_modes_emit_in_upstream_per_directory_order` and every `DeleteContext::new`-based unit test in `delete::context::tests` (per-mode drain coverage, channel-shutdown drain tests).
- Make `DeleteContext::new(dest_root, timing)` seat the traversal cursor at `dest_root` instead of `PathBuf::new()`, so the first directory the emitter yields matches the key under which callers publish their plan.

## Root cause

`DeleteContext::new` left `cursor_root` as `PathBuf::new()` while every test caller publishes plans keyed by the *absolute* `dest_root` they passed in. The very first `cursor.next_ready()` call returned `Some(PathBuf::new())`; `plans.take(&PathBuf::new())` returned `None`; `emit_all` parked on `pending` and returned `Ok(())` without dispatching anything. The drain reported `stats == 0` and an empty event log on platforms where the temp-dir prefix and the cursor's empty root never collided after canonicalisation.

The production cleanup path (`crates/engine/src/local_copy/executor/cleanup.rs:112`) was already aware of this and used `DeleteContext::with_cursor_root(plans, dest_root, dest_root, true)` to seat the cursor explicitly:

```rust
// The cursor root must equal the plan's directory key so
// `cursor.next_ready()` yields a path that `plans.take()` resolves
// to the published plan. `DeleteContext::new` would leave the
// cursor at the empty relative path; use `with_cursor_root` to seat
// it on the absolute destination the plan is keyed on.
```

That comment captures the invariant the constructor was missing. Tests were unable to apply the same workaround without inventing a `with_timing` setter, because `with_cursor_root` hard-codes `EmitterTiming::During`.

## Fix

Inside `DeleteContext::new`, clone `dest_root` into `cursor_root` before moving `dest_root` into the struct. The rustdoc on `new` is updated to describe the single-root contract and to point receiver-pipeline callers at `with_shared_plan_map`, which keeps `cursor_root = PathBuf::new()` because the receiver publishes plans keyed by destination-relative paths and the DFS walk must start at the relative root.

## Why option (a) over rewriting the tests

Two fix shapes were on the table:

- (a) Default `cursor_root = dest_root` inside `DeleteContext::new`. One line of code plus a rustdoc tightening. Aligns `new` with what every caller (production via `with_cursor_root`, every test) already expects.
- (b) Add a `with_timing` setter to `DeleteContext` and rewrite every `DeleteContext::new(...)` test caller to use `with_cursor_root(...).with_timing(...)`. Wider blast radius, new public surface, and the resulting tests would still encode the same single-root convention.

Option (a) honours the existing single-root contract `new` already advertises ("a new context rooted at `dest_root`"), keeps the `with_shared_plan_map` receiver semantics untouched, and removes the only reason cleanup.rs had to reach for `with_cursor_root`. Option (b) would entrench the mismatch between the constructor's contract and its behaviour, plus expand the API for the sole benefit of restating the same invariant in every test.

## Blast radius

Audited every `DeleteContext::new` callsite (all in tests):

- `crates/engine/tests/delete_emitter_timing_modes.rs` (11 callers): every test passes `dir` as both `dest_root` and the plan's `directory` key. Cursor seating now matches.
- `crates/engine/src/delete/context.rs` (7 callers in `#[cfg(test)]`): same pattern. Includes the four cross-platform failures the run flagged.
- No production code uses `DeleteContext::new`; `cleanup.rs` uses `with_cursor_root`, the receiver uses `with_shared_plan_map`. Both are unchanged.

The `with_shared_plan_map` constructor (which the receiver wires through) retains its empty `cursor_root` so the existing receiver-side test (`crates/transfer/src/receiver/tests/file_list/delete_pipeline_hook.rs`) and the `disabled_context_publishes_nothing` snapshot test (which asserts `cursor.next_ready() == Some(PathBuf::new())`) continue to hold.

## Test plan

- [ ] CI: nextest (stable, beta, nightly) on Linux, macOS, Windows.
- [ ] CI: Windows ACL/xattr (this is the job that flagged `all_modes_emit_in_upstream_per_directory_order` on master).
- [ ] CI: Linux musl matrix.
- [ ] CI: Feature flag combinations matrix.