### PR TITLE
fix(daemon): reset O_NONBLOCK on dual-stack accepted sockets

### DIFF
--- a/crates/daemon/src/daemon/sections/server_runtime/connection.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/connection.rs
@@ -370,6 +370,16 @@ fn run_dual_stack_loop(
             {
                 match listener.accept() {
                     Ok((stream, peer_addr)) => {
+                        // BSD-derived kernels (macOS, FreeBSD) propagate the
+                        // listener's O_NONBLOCK flag to the accepted socket,
+                        // which would cause the legacy handshake reader to
+                        // fail with EAGAIN before the client writes its
+                        // greeting. Reset to blocking so the worker thread
+                        // sees the upstream-compatible synchronous I/O model.
+                        if let Err(error) = stream.set_nonblocking(false) {
+                            let _ = tx.send(Err((local_addr, error)));
+                            break;
+                        }
                         if tx.send(Ok((stream, peer_addr))).is_err() {
                             break;
                         }


### PR DESCRIPTION
## Summary

- macOS interop CI failed with `failed to serve legacy handshake 127.0.0.1:NNNN: Resource temporarily unavailable (os error 35)` because the daemon's dual-stack accept loop never cleared `O_NONBLOCK` on the accepted socket.
- BSD-derived kernels (macOS, FreeBSD) propagate the listener's non-blocking flag to the accepted fd. The single-listener path already calls `set_nonblocking(false)`; the dual-stack path did not, so on macOS the worker hit EAGAIN before the client wrote its `@RSYNCD:` greeting.
- Mirror the single-listener fix inside the dual-stack acceptor thread so each accepted stream is blocking before it reaches the worker, matching upstream `clientserver.c` which handshakes on the synchronous fd returned by `accept()`.

## Root cause

1. `run_dual_stack_loop` sets each listener to non-blocking so acceptor threads can poll the shutdown flag.
2. On macOS the resulting accepted `TcpStream` inherits `O_NONBLOCK`, while the single-listener path was the only caller that reset it.
3. The legacy-handshake reader on a non-blocking stream returns `EAGAIN` (errno 35) before the client greeting arrives, surfacing as the CI failure.

## Test plan

- [ ] CI macOS interop job (was failing on `127.0.0.1:NNNN`) succeeds.
- [ ] CI Linux/musl/Windows checks remain green (single-listener path unchanged; Linux `accept4()` already clears the flag, so behavior is unchanged there).