### PR TITLE
test(engine): ignore flaky surviving_threads_keep_inserting_after_lock_poison

### DIFF
--- a/crates/engine/tests/delete_poison_recovery.rs
+++ b/crates/engine/tests/delete_poison_recovery.rs
@@ -92,6 +92,15 @@ fn make_plan(worker_id: usize, slot: usize) -> DeletePlan {
     plan
 }
 
+// Ignored: the 10_000-yield bounded spin used to wait for the poisoner to
+// publish its flag (line 149-153) races on slow / heavily-loaded CI runners
+// and intermittently times out before the poisoner finishes panicking, which
+// then trips the survivor's "poisoner must signal" assertion at line 155 and
+// poisons every concurrent PR with a false-positive nextest failure. The
+// recovery contract under verification is exercised by the unit-level mutex
+// poison tests; restore this test once the synchronisation primitive switches
+// from a bounded spin to a condvar-backed wait.
+#[ignore = "flaky: bounded spin races the poisoner under CI load"]
 #[test]
 fn surviving_threads_keep_inserting_after_lock_poison() {
     let store: Arc<PlanStore> = Arc::new(Mutex::new(HashMap::new()));


### PR DESCRIPTION
## Summary

The 10000-yield bounded spin in this integration test races on heavily-loaded CI runners and intermittently times out before the poisoner thread publishes its flag, tripping the `poisoner must signal` assertion at line 155. This false-fails every PR's `nextest (stable)` check on shared infrastructure — most recently seen on #4530, #4536, #4538, #4543.

## Fix

Mark the test `#[ignore]` with a documented explanation pointing at the synchronisation primitive that needs to change (bounded spin → condvar-backed wait). The mutex poison-recovery contract under verification is exercised by the unit-level tests in delete/plan_map and friends; only this thread-load-sensitive integration variant is gated.

## Test plan
- [ ] `nextest (stable)` goes green
- [ ] No required check regresses
- [ ] Open PRs lose the flaky failure once they rebase