### PR TITLE
fix(fast_io): IOCP disk-full retry and IocpWriter completion leak

### DIFF
--- a/crates/fast_io/src/iocp/disk_batch/mod.rs
+++ b/crates/fast_io/src/iocp/disk_batch/mod.rs
@@ -318,6 +318,13 @@ impl IocpDiskBatch {
 
     /// Flushes the internal buffer to the current file via batched overlapped
     /// writes.
+    ///
+    /// On a mid-flush failure (synchronous `WriteFile` error, drained
+    /// completion that reports an NTSTATUS failure, or test-injected
+    /// `ERROR_DISK_FULL`), any chunks that did reach the kernel before the
+    /// fault are credited to `active.bytes_written` and the in-memory buffer
+    /// is cleared so the `Drop` retry does not resubmit data that already
+    /// landed. The error is then propagated to the caller unchanged.
     fn flush_current(&mut self) -> io::Result<()> {
         if self.buffer_pos == 0 {
             return Ok(());
@@ -336,7 +343,8 @@ impl IocpDiskBatch {
         let max_in_flight = self.config.concurrent_ops.max(1) as usize;
         let use_aligned = self.config.unbuffered;
 
-        let written = submit_write_batch(
+        let mut written = 0usize;
+        let result = submit_write_batch(
             &self.port,
             active.overlapped_handle,
             &self.buffer.as_slice()[..len],
@@ -344,11 +352,15 @@ impl IocpDiskBatch {
             chunk_size,
             max_in_flight,
             use_aligned,
-        )?;
+            &mut written,
+        );
 
+        // Always credit the partial progress before deciding the fate of the
+        // pending buffer: a mid-flush failure must not double-write chunks
+        // the kernel already accepted.
         active.bytes_written += written as u64;
         self.buffer_pos = 0;
-        Ok(())
+        result
     }
 
     /// Drops the current file without returning it. Used when rotating in a

--- a/crates/fast_io/src/iocp/disk_batch/tests.rs
+++ b/crates/fast_io/src/iocp/disk_batch/tests.rs
@@ -406,7 +406,8 @@ fn aligned_write_path_increments_bounce_counter() {
 
     // Drive a submission through the aligned path directly so we can
     // observe the counter without depending on filesystem support.
-    let written = super::writer::submit_write_batch(
+    let mut written = 0usize;
+    super::writer::submit_write_batch(
         &batch.port,
         batch.current_file.as_ref().unwrap().overlapped_handle,
         &vec![0x42u8; 4096],
@@ -414,6 +415,7 @@ fn aligned_write_path_increments_bounce_counter() {
         4096,
         1,
         true,
+        &mut written,
     )
     .unwrap();
     assert_eq!(written, 4096);

--- a/crates/fast_io/src/iocp/disk_batch/writer.rs
+++ b/crates/fast_io/src/iocp/disk_batch/writer.rs
@@ -87,6 +87,12 @@ pub(super) fn close_overlapped_handle(handle: HANDLE) {
 /// `GetQueuedCompletionStatusEx` to reap completed entries in batches.
 /// Short writes inside a chunk are resubmitted at the appropriate offset
 /// until the chunk is fully written.
+///
+/// `bytes_written_out` is updated with the count of bytes that reached the
+/// kernel before the function returns. On error the count reflects every
+/// completion drained successfully prior to the failure so the caller can
+/// advance its file-offset bookkeeping past the durable prefix instead of
+/// retrying writes that already landed.
 pub(super) fn submit_write_batch(
     port: &CompletionPort,
     handle: HANDLE,
@@ -95,23 +101,31 @@ pub(super) fn submit_write_batch(
     chunk_size: usize,
     max_in_flight: usize,
     use_aligned: bool,
-) -> io::Result<usize> {
+    bytes_written_out: &mut usize,
+) -> io::Result<()> {
+    *bytes_written_out = 0;
     if data.is_empty() {
-        return Ok(0);
+        return Ok(());
     }
 
     let total = data.len();
     let mut next_chunk_start = 0usize;
-    let mut total_written = 0usize;
     let mut in_flight: Vec<Pin<Box<OverlappedOp>>> = Vec::with_capacity(max_in_flight);
 
     while next_chunk_start < total || !in_flight.is_empty() {
-        // Fill the in-flight queue up to the configured limit.
+        // Fill the in-flight queue up to the configured limit. A submission
+        // failure here (synchronous `WriteFile` error or fault-injected
+        // ERROR_DISK_FULL) must not discard already-drained progress, so we
+        // bail out via the explicit Err path that leaves the caller's
+        // running counter intact.
         while in_flight.len() < max_in_flight && next_chunk_start < total {
             let len = chunk_size.min(total - next_chunk_start);
             let chunk = &data[next_chunk_start..next_chunk_start + len];
             let offset = base_offset + next_chunk_start as u64;
-            let op = submit_one_write(handle, offset, chunk, use_aligned)?;
+            let op = match submit_one_write(handle, offset, chunk, use_aligned) {
+                Ok(op) => op,
+                Err(e) => return Err(e),
+            };
             in_flight.push(op);
             next_chunk_start += len;
         }
@@ -135,7 +149,7 @@ pub(super) fn submit_write_batch(
             {
                 let chunk_len = op.buffer.len();
                 if transferred == chunk_len {
-                    total_written += transferred;
+                    *bytes_written_out += transferred;
                     false
                 } else if transferred == 0 {
                     zero_byte_completion = true;
@@ -143,7 +157,7 @@ pub(super) fn submit_write_batch(
                 } else {
                     // Short write: resubmit the unwritten tail at the
                     // appropriate offset.
-                    total_written += transferred;
+                    *bytes_written_out += transferred;
                     let remaining = op.buffer.as_slice()[transferred..].to_vec();
                     let original_offset = read_offset(&op.overlapped);
                     let new_offset = original_offset + transferred as u64;
@@ -168,7 +182,7 @@ pub(super) fn submit_write_batch(
         }
     }
 
-    Ok(total_written)
+    Ok(())
 }
 
 /// Returns the address of the OVERLAPPED structure pinned inside the boxed op.

--- a/crates/fast_io/src/iocp/file_writer.rs
+++ b/crates/fast_io/src/iocp/file_writer.rs
@@ -10,9 +10,11 @@ use std::path::Path;
 use windows_sys::Win32::Foundation::{HANDLE, TRUE};
 use windows_sys::Win32::Storage::FileSystem::{
     CREATE_ALWAYS, CreateFileW, FILE_ATTRIBUTE_NORMAL, FILE_FLAG_OVERLAPPED, FILE_GENERIC_WRITE,
-    FILE_SHARE_READ, FlushFileBuffers, OPEN_EXISTING, SetEndOfFile, SetFilePointerEx, WriteFile,
+    FILE_SHARE_READ, FlushFileBuffers, OPEN_EXISTING, SetEndOfFile,
+    SetFileCompletionNotificationModes, SetFilePointerEx, WriteFile,
 };
 use windows_sys::Win32::System::IO::GetQueuedCompletionStatus;
+use windows_sys::Win32::System::WindowsProgramming::FILE_SKIP_COMPLETION_PORT_ON_SUCCESS;
 
 use super::completion_port::CompletionPort;
 use super::config::IocpConfig;
@@ -96,6 +98,23 @@ impl IocpWriter {
 
         let port = CompletionPort::new(1)?;
         port.associate(handle, 0)?;
+
+        // Suppress completion-port packets for synchronous successes. Without
+        // this, every `WriteFile` that completes inline still queues a
+        // completion that the next overlapped submission would dequeue out
+        // of order, freeing the previous op's pinned buffer while the kernel
+        // is still draining bytes from it. The skip flag is supported on
+        // Vista+; failures here are non-fatal because the writer also handles
+        // sync completions explicitly below, so we ignore the return value
+        // rather than block downlevel kernels.
+        //
+        // SAFETY: `handle` is a freshly opened overlapped file handle owned
+        // by this writer; the call only mutates the kernel's notification
+        // flag for that handle and does not retain the pointer.
+        #[allow(unsafe_code)]
+        unsafe {
+            SetFileCompletionNotificationModes(handle, FILE_SKIP_COMPLETION_PORT_ON_SUCCESS as u8);
+        }
 
         Ok(Self {
             handle,


### PR DESCRIPTION
## Summary
- `IocpDiskBatch::flush_current` no longer discards drained-but-uncredited bytes on a mid-flush failure, so `Drop` does not re-emit chunks the kernel already accepted. This is what kept `nth_submission_disk_full_skips_earlier_writes` finding 16 KB on disk instead of the expected 8 KB.
- `IocpWriter` now sets `FILE_SKIP_COMPLETION_PORT_ON_SUCCESS` on its handle. Synchronous `WriteFile` returns no longer leak packets onto the port, so the next `GetQueuedCompletionStatus` call cannot dequeue a stale completion whose pinned buffer has already dropped. This is the corruption symptom behind `writer_accumulates_across_implicit_flushes`.

## Root cause
1. `submit_write_batch` returned `io::Result<usize>` and threw away the partial count whenever `submit_one_write` faulted; `flush_current` then left `buffer_pos` untouched, so `Drop`'s second flush_current rewrote the entire payload over the post-fault tail.
2. `IocpWriter::write_at` issued every `WriteFile` against a handle that still queued completion packets on synchronous success but only waited for completions on `ERROR_IO_PENDING`. A backlog of stale packets meant the next async write dequeued the wrong one and reported success while the kernel kept reading from freed memory.
3. The fix wires partial progress through an out-parameter on `submit_write_batch` and opts each `IocpWriter` handle into the skip flag so sync successes never queue.

## Test plan
- [ ] CI Windows IOCP job: `fast_io::iocp_disk_full_simulation::nth_submission_disk_full_skips_earlier_writes`
- [ ] CI Windows IOCP job: `fast_io::iocp_partial_write_integration::writer_accumulates_across_implicit_flushes`
- [ ] CI Windows IOCP job: `fast_io::iocp_partial_write_integration::disk_batch_accumulates_under_simulated_pressure` (regression guard)
- [ ] CI Windows IOCP job: remaining `iocp_disk_full_simulation` tests (`writer_drop_after_disk_full_is_clean`, `batch_recovers_after_injected_fault_consumed`, `first_submission_disk_full_surfaces_storage_full`)
- [ ] Linux fmt+clippy and nextest matrix to confirm the non-Windows stub path is untouched