### PR TITLE
fix(protocol): clamp token_encoding proptest block_index to wire range

### DIFF
--- a/crates/protocol/src/wire/delta/token.rs
+++ b/crates/protocol/src/wire/delta/token.rs
@@ -72,6 +72,15 @@ pub fn write_token_literal<W: Write>(writer: &mut W, data: &[u8]) -> io::Result<
 /// Reference: `token.c:simple_send_token()` line 316
 #[inline]
 pub fn write_token_block_match<W: Write>(writer: &mut W, block_index: u32) -> io::Result<()> {
+    // The wire token is `-(block_index + 1)` as i32 LE, so the largest legal
+    // block index is `i32::MAX - 1` (which encodes to i32::MIN + 1). The
+    // value `i32::MAX` would compute `-(i32::MAX + 1) = -i32::MIN` and trip
+    // the debug overflow check. Catch the contract violation here instead of
+    // silently producing a wrapped negative token on release builds.
+    debug_assert!(
+        block_index < i32::MAX as u32,
+        "block_index {block_index} exceeds the i32 wire-format range"
+    );
     let token = -((block_index as i32) + 1);
     write_int(writer, token)
 }

--- a/crates/protocol/tests/proptest_delta_roundtrip.rs
+++ b/crates/protocol/tests/proptest_delta_roundtrip.rs
@@ -22,10 +22,14 @@ fn arb_literal() -> impl Strategy<Value = DeltaOp> {
 
 /// Strategy for generating arbitrary Copy operations.
 ///
-/// Block index and length are constrained to non-negative i32 range because the
-/// internal format encodes them via varint (i32).
+/// Block index and length are constrained to non-negative i32 range because
+/// the internal format encodes them via varint (i32). The token wire format
+/// encodes a match as `-(block_index + 1)`, so a `block_index` of `i32::MAX`
+/// would compute `-(i32::MAX + 1)` and trip the debug overflow check; cap
+/// the strategy one short of `i32::MAX` to match the contract enforced by
+/// `token_block_match_roundtrip` below.
 fn arb_copy() -> impl Strategy<Value = DeltaOp> {
-    (0u32..=i32::MAX as u32, 1u32..=i32::MAX as u32).prop_map(|(block_index, length)| {
+    (0u32..=i32::MAX as u32 - 1, 1u32..=i32::MAX as u32).prop_map(|(block_index, length)| {
         DeltaOp::Copy {
             block_index,
             length,


### PR DESCRIPTION
## Summary

The token wire format encodes a match as \`-(block_index + 1)\` and writes the result as i32 LE, so the largest legal \`block_index\` is \`i32::MAX - 1\`. The \`arb_copy\` proptest strategy generated values up to and including \`i32::MAX\`, which made \`token_encoding_deterministic\` intermittently trip the debug-mode integer-overflow check at \`-(i32::MAX + 1)\` on the \`zlib-rs\` feature-flag CI cell.

- Cap the strategy at \`i32::MAX - 1\` to match the bound already used by \`token_block_match_roundtrip\` (line 149 of the same file).
- Add \`debug_assert!\` to \`write_token_block_match\` so the contract is enforced at the function boundary rather than only by the proptest.

Release builds keep the wrapping behaviour they had before, so wire output is unchanged for inputs callers already passed.

## Test plan

- [x] CI runs the \`Feature flag combinations / zlib-rs (linux)\` cell that previously panicked