### PR TITLE
test(flist): fix error_path_preservation on Windows

### DIFF
--- a/crates/flist/tests/edge_cases.rs
+++ b/crates/flist/tests/edge_cases.rs
@@ -319,9 +319,18 @@ fn nonexistent_path_error() {
 }
 
 /// Verifies error path is preserved in error.
+///
+/// The builder absolutizes relative roots against the current directory, so
+/// the input path must already be absolute for the round-trip equality check
+/// to hold. Windows treats `/foo` as drive-relative rather than absolute, so a
+/// platform-appropriate prefix is required on each target.
 #[test]
 fn error_path_preservation() {
+    #[cfg(unix)]
     let path = "/unique/test/path/12345";
+    #[cfg(windows)]
+    let path = r"C:\unique\test\path\12345";
+
     let result = FileListBuilder::new(path).build();
 
     match result {


### PR DESCRIPTION
## Summary

- `crates/flist/tests/edge_cases.rs::error_path_preservation` panics on `windows-latest` because the test passes a Unix-style root (`/unique/test/path/12345`) and asserts the error's `path()` equals the input verbatim.
- On Windows, `Path::is_absolute()` returns `false` for paths starting with `/` without a drive letter. `FileListWalker::new` calls `absolutize`, which then joins the input with `env::current_dir()`, so the stored (and reported) path becomes `C:\Users\...\unique\test\path\12345` and the equality check at line 330 fails.
- Switch the test to use a platform-appropriate absolute path: keep the Unix form on `cfg(unix)` and use `C:\unique\test\path\12345` on `cfg(windows)`. The single test continues to cover both targets without skipping either.

The production behaviour (absolutize-then-stat) is correct and matches upstream rsync semantics; only the test input needed adjusting.

## Test plan

- [ ] CI: fmt+clippy
- [ ] CI: nextest (Linux stable) - `error_path_preservation` still passes with Unix path
- [ ] CI: nextest (Windows stable) - `error_path_preservation` now passes with drive-rooted path
- [ ] CI: nextest (macOS stable)
- [ ] CI: Linux musl