### PR TITLE
fix(ci): skip oc-rsync daemon scenarios in Windows interop smoke

### DIFF
--- a/.github/workflows/_interop-windows.yml
+++ b/.github/workflows/_interop-windows.yml
@@ -11,15 +11,18 @@ name: Interop Tests (Windows)
 #
 # Scenarios covered (see `tools/ci/run_interop_smoke.sh`):
 #   - baseline upstream -> upstream local copy
-#   - oc-rsync sender + upstream receiver (push)
-#   - upstream sender + oc-rsync receiver (pull)
+#   - oc-rsync sender + upstream receiver (push, via upstream daemon)
+#   - upstream sender + oc-rsync receiver (pull, via upstream daemon)
 #   - quick-check no-op re-run
-#   - delta update in both directions
+#   - delta update: oc-rsync client -> upstream daemon
 #
 # Intentionally NOT covered on Windows:
 #   - xattr / ACL / hardlinks / symlinks parity (NTFS semantics differ
 #     and are exercised by the dedicated `windows-acl-xattr` job).
-#   - daemon mode (no privileged-port loopback in the harness).
+#   - oc-rsync daemon mode: the binary explicitly refuses --daemon on
+#     Windows (see crates/cli/src/frontend/server/daemon.rs). Scenarios
+#     that would spawn `oc-rsync --daemon` are logged as SKIP and the
+#     job continues. Daemon parity is exercised on Linux/macOS instead.
 #   - SSH loopback (no sshd on `windows-latest` by default).
 #   - --list-only format parity (Cygwin rsync renders paths with
 #     forward slashes after stripping the drive prefix; oc-rsync uses

--- a/tools/ci/run_interop_smoke.sh
+++ b/tools/ci/run_interop_smoke.sh
@@ -16,8 +16,13 @@
 # never speaks the wire protocol. To get oc-rsync and upstream rsync
 # talking to each other across the wire, we spawn each as a daemon on
 # a high TCP port and run the other as the client against
-# `rsync://localhost:PORT/module/`. This works identically on Linux,
-# macOS, and Windows (MSYS2) without needing SSH, sudo, or systemd.
+# `rsync://localhost:PORT/module/`. This works identically on Linux
+# and macOS without needing SSH, sudo, or systemd.
+#
+# Windows (MSYS2) covers the upstream-daemon side only: the oc-rsync
+# daemon is intentionally unsupported on Windows (see
+# crates/cli/src/frontend/server/daemon.rs), so scenarios that require
+# `oc-rsync --daemon` are skipped with a clear log line on that host.
 #
 # Inputs
 # ------
@@ -207,19 +212,30 @@ tree_diff "${src}" "${dst_oc_pull}" \
   || fail "oc-rsync client / upstream daemon diverged (pull)"
 pass "oc-rsync client <- upstream daemon (pull)"
 
-# --- Scenario 4: upstream client pushes into oc-rsync daemon ------------
-oc_port="$(start_daemon "${OC_RSYNC}" oc oc_pid)"
-oc_url="rsync://127.0.0.1:${oc_port}/data"
-"${UPSTREAM_RSYNC}" -a "${src}/" "${oc_url}/"
-tree_diff "${src}" "${workdir}/data-oc" \
-  || fail "upstream client / oc-rsync daemon diverged (push)"
-pass "upstream client -> oc-rsync daemon (push)"
+# Scenarios that require running oc-rsync as a daemon are skipped on
+# Windows: the oc-rsync daemon is intentionally unsupported there (see
+# crates/cli/src/frontend/server/daemon.rs - the binary exits with
+# "daemon mode is not supported on this platform"). The upstream-daemon
+# side of the wire is still exercised by scenarios 2, 3, and the
+# scenario-7 delta push above.
+if [[ "${host_os}" == "windows" ]]; then
+  echo "SKIP: upstream client -> oc-rsync daemon (oc-rsync daemon unsupported on Windows)"
+  echo "SKIP: upstream client <- oc-rsync daemon (oc-rsync daemon unsupported on Windows)"
+else
+  # --- Scenario 4: upstream client pushes into oc-rsync daemon ----------
+  oc_port="$(start_daemon "${OC_RSYNC}" oc oc_pid)"
+  oc_url="rsync://127.0.0.1:${oc_port}/data"
+  "${UPSTREAM_RSYNC}" -a "${src}/" "${oc_url}/"
+  tree_diff "${src}" "${workdir}/data-oc" \
+    || fail "upstream client / oc-rsync daemon diverged (push)"
+  pass "upstream client -> oc-rsync daemon (push)"
 
-# --- Scenario 5: upstream client pulls from oc-rsync daemon -------------
-"${UPSTREAM_RSYNC}" -a "${oc_url}/" "${dst_oc_push}/"
-tree_diff "${src}" "${dst_oc_push}" \
-  || fail "upstream client / oc-rsync daemon diverged (pull)"
-pass "upstream client <- oc-rsync daemon (pull)"
+  # --- Scenario 5: upstream client pulls from oc-rsync daemon -----------
+  "${UPSTREAM_RSYNC}" -a "${oc_url}/" "${dst_oc_push}/"
+  tree_diff "${src}" "${dst_oc_push}" \
+    || fail "upstream client / oc-rsync daemon diverged (pull)"
+  pass "upstream client <- oc-rsync daemon (pull)"
+fi
 
 # --- Scenario 6: idempotent re-run (quick-check, no transfer) ----------
 # Re-running the push should be a no-op. We look at --stats output for
@@ -244,9 +260,13 @@ tree_diff "${modified}" "${workdir}/data-up" \
   || fail "delta update push (oc-rsync -> upstream) diverged"
 pass "delta update: oc-rsync client -> upstream daemon"
 
-"${UPSTREAM_RSYNC}" -a "${modified}/" "${oc_url}/"
-tree_diff "${modified}" "${workdir}/data-oc" \
-  || fail "delta update push (upstream -> oc-rsync) diverged"
-pass "delta update: upstream client -> oc-rsync daemon"
+if [[ "${host_os}" == "windows" ]]; then
+  echo "SKIP: delta update upstream -> oc-rsync daemon (oc-rsync daemon unsupported on Windows)"
+else
+  "${UPSTREAM_RSYNC}" -a "${modified}/" "${oc_url}/"
+  tree_diff "${modified}" "${workdir}/data-oc" \
+    || fail "delta update push (upstream -> oc-rsync) diverged"
+  pass "delta update: upstream client -> oc-rsync daemon"
+fi
 
 echo "All interop smoke scenarios passed on ${host_os}."


### PR DESCRIPTION
## Summary

The chronic failure of the `interop (Windows, best-effort)` CI job traces to a mismatch between the smoke harness and the oc-rsync binary: the harness tries to spawn `oc-rsync --daemon` on Windows, but daemon mode is intentionally not supported on Windows. The binary exits at startup with:

```
oc-rsync error: daemon mode is not supported on this platform; run the oc-rsync daemon on a Unix-like system (code 1) at daemon.rs(102) [client=0.6.2]
```

(see `crates/cli/src/frontend/server/daemon.rs:104`). The workflow header in `_interop-windows.yml` even lists "daemon mode" under intentionally-not-covered scenarios, but the script itself never honoured that.

This change:

- Detects `host_os=windows` inside `tools/ci/run_interop_smoke.sh` and skips the three scenarios that require `oc-rsync --daemon` (scenario 4, scenario 5, and the second delta-update case). Each skip prints a clear `SKIP: ... (oc-rsync daemon unsupported on Windows)` log line so the omission is loud.
- Linux and macOS continue to exercise the full matrix unchanged.
- Updates the workflow doc block to accurately describe what runs on Windows (oc-rsync client + upstream daemon, both push and pull, plus the oc-rsync-side delta update).

## Test plan

- [ ] `interop (Windows, best-effort)` job passes on this PR.
- [ ] Linux/macOS interop jobs still run all scenarios (no SKIP lines printed there).
- [ ] PASS/SKIP/FAIL log lines remain human-readable in the job output.