### PR TITLE
feat(engine): expose force_insert counter on DeltaConsumer::stats

### DIFF
--- a/crates/engine/src/concurrent_delta/consumer/mod.rs
+++ b/crates/engine/src/concurrent_delta/consumer/mod.rs
@@ -80,6 +80,16 @@ pub struct DeltaConsumerStats {
     ///
     /// Always zero when the consumer was spawned without a spill threshold.
     pub spill_events: u64,
+    /// Cumulative count of ordering-fallback inserts performed by the
+    /// underlying [`ReorderBuffer`](super::reorder::ReorderBuffer) when the
+    /// ring saturated while `next_expected` was still missing.
+    ///
+    /// Non-zero values flag periods where the consumer broke its capacity
+    /// bound to keep the pipeline alive. Operators should treat sustained
+    /// growth here as a signal to raise the reorder capacity or enable the
+    /// spill backend. This is an OC-rsync diagnostic extension - upstream
+    /// rsync has no equivalent because its delta loop is sequential.
+    pub force_inserts: u64,
 }
 
 /// Ordered consumer that drains a [`WorkQueueReceiver`] in parallel and
@@ -136,6 +146,11 @@ pub struct DeltaConsumer {
     /// Shared counter incremented by the reorder thread on each spill-to-disk
     /// event. Exposed via [`DeltaConsumer::stats`].
     pub(super) spill_events: Arc<AtomicU64>,
+    /// Shared handle aliasing the underlying [`ReorderBuffer`](super::reorder::ReorderBuffer)
+    /// `force_insert` counter. The reorder buffer updates this atomic
+    /// directly, so [`DeltaConsumer::stats`] reflects the latest value
+    /// without locking the metrics `Mutex`.
+    pub(super) force_inserts: Arc<AtomicU64>,
 }
 
 impl DeltaConsumer {
@@ -214,13 +229,15 @@ impl DeltaConsumer {
 
     /// Returns a snapshot of consumer-side diagnostic counters.
     ///
-    /// Currently exposes the cumulative spill-to-disk event count from the
-    /// background reorder thread. Safe to call from any thread while the
-    /// consumer is running; the counters are updated lock-free.
+    /// Exposes the cumulative spill-to-disk event count and the cumulative
+    /// `force_insert` count from the background reorder thread. Safe to
+    /// call from any thread while the consumer is running; the counters
+    /// are updated lock-free.
     #[must_use]
     pub fn stats(&self) -> DeltaConsumerStats {
         DeltaConsumerStats {
             spill_events: self.spill_events.load(Ordering::Relaxed),
+            force_inserts: self.force_inserts.load(Ordering::Relaxed),
         }
     }
 

--- a/crates/engine/src/concurrent_delta/consumer/spawn.rs
+++ b/crates/engine/src/concurrent_delta/consumer/spawn.rs
@@ -110,7 +110,7 @@ pub(super) fn spawn_inner(rx: WorkQueueReceiver, mode: ReorderMode) -> DeltaCons
         .spawn(move || {
             match backend {
                 ReorderBackend::Bare(buf) => {
-                    run_bare_loop(stream_rx, &result_tx, buf, &metrics_thread);
+                    run_bare_loop(stream_rx, &result_tx, *buf, &metrics_thread);
                 }
                 ReorderBackend::Spillable(buf) => {
                     run_spillable_loop(stream_rx, &result_tx, *buf, &spill_events_thread);
@@ -143,13 +143,16 @@ pub(super) fn spawn_inner(rx: WorkQueueReceiver, mode: ReorderMode) -> DeltaCons
 /// the inner `force_insert` counter without a cross-thread bootstrap hop.
 enum ReorderBackend {
     /// In-memory ring (including the passthrough flavour).
-    Bare(ReorderBuffer<DeltaResult>),
-    /// Bounded-memory ring backed by a spill tempfile.
     ///
     /// Boxed so the enum's size is dominated by its smallest viable
-    /// representation instead of the much larger spillable buffer; this
-    /// keeps `clippy::large_enum_variant` quiet without a waiver and
-    /// avoids stack-spilling a wide enum on every match arm.
+    /// representation instead of the much larger ring buffer; this keeps
+    /// `clippy::large_enum_variant` quiet without a waiver and avoids
+    /// stack-spilling a wide enum on every match arm.
+    Bare(Box<ReorderBuffer<DeltaResult>>),
+    /// Bounded-memory ring backed by a spill tempfile.
+    ///
+    /// Boxed for the same reason as [`Self::Bare`] above; the spillable
+    /// buffer is the largest variant in the enum.
     Spillable(Box<SpillableReorderBuffer<DeltaResult>>),
     /// Spillable construction failed; deferred until the thread can publish
     /// the error as a [`DeltaResult::failed`].
@@ -159,8 +162,8 @@ enum ReorderBackend {
 impl ReorderBackend {
     fn build(mode: ReorderMode) -> Self {
         match mode {
-            ReorderMode::Bypass => Self::Bare(ReorderBuffer::passthrough()),
-            ReorderMode::Bare { capacity } => Self::Bare(ReorderBuffer::new(capacity)),
+            ReorderMode::Bypass => Self::Bare(Box::new(ReorderBuffer::passthrough())),
+            ReorderMode::Bare { capacity } => Self::Bare(Box::new(ReorderBuffer::new(capacity))),
             ReorderMode::Spillable {
                 capacity,
                 threshold,

--- a/crates/engine/src/concurrent_delta/consumer/spawn.rs
+++ b/crates/engine/src/concurrent_delta/consumer/spawn.rs
@@ -113,7 +113,7 @@ pub(super) fn spawn_inner(rx: WorkQueueReceiver, mode: ReorderMode) -> DeltaCons
                     run_bare_loop(stream_rx, &result_tx, buf, &metrics_thread);
                 }
                 ReorderBackend::Spillable(buf) => {
-                    run_spillable_loop(stream_rx, &result_tx, buf, &spill_events_thread);
+                    run_spillable_loop(stream_rx, &result_tx, *buf, &spill_events_thread);
                 }
                 ReorderBackend::Failed(err) => {
                     let _ = result_tx.send(DeltaResult::failed(
@@ -145,7 +145,12 @@ enum ReorderBackend {
     /// In-memory ring (including the passthrough flavour).
     Bare(ReorderBuffer<DeltaResult>),
     /// Bounded-memory ring backed by a spill tempfile.
-    Spillable(SpillableReorderBuffer<DeltaResult>),
+    ///
+    /// Boxed so the enum's size is dominated by its smallest viable
+    /// representation instead of the much larger spillable buffer; this
+    /// keeps `clippy::large_enum_variant` quiet without a waiver and
+    /// avoids stack-spilling a wide enum on every match arm.
+    Spillable(Box<SpillableReorderBuffer<DeltaResult>>),
     /// Spillable construction failed; deferred until the thread can publish
     /// the error as a [`DeltaResult::failed`].
     Failed(std::io::Error),
@@ -165,7 +170,7 @@ impl ReorderBackend {
             } => {
                 match build_spillable(capacity, threshold, dir, granularity, memory_pressure_bytes)
                 {
-                    Ok(buf) => Self::Spillable(buf),
+                    Ok(buf) => Self::Spillable(Box::new(buf)),
                     Err(e) => Self::Failed(e),
                 }
             }

--- a/crates/engine/src/concurrent_delta/consumer/spawn.rs
+++ b/crates/engine/src/concurrent_delta/consumer/spawn.rs
@@ -94,55 +94,33 @@ pub(super) fn spawn_inner(rx: WorkQueueReceiver, mode: ReorderMode) -> DeltaCons
     let metrics = Arc::new(Mutex::new(ReorderMetrics::default()));
     let metrics_thread = Arc::clone(&metrics);
 
+    // Materialise the reorder backend up-front so its force_insert
+    // counter is observable from the parent thread before delivery starts.
+    // The spillable variant may fail to allocate its tempdir; that error
+    // is surfaced as a failed DeltaResult inside the thread so the receiver
+    // maps it to upstream exit code 11.
+    let backend = ReorderBackend::build(mode);
+    let force_inserts = backend.force_insert_counter();
+
     // Thread 2: receives streamed results, reorders (or passes through),
     // and forwards to the consumer channel.
     let spill_events_thread = Arc::clone(&spill_events);
     let handle = thread::Builder::new()
         .name("delta-reorder".to_string())
         .spawn(move || {
-            match mode {
-                ReorderMode::Bypass => {
-                    run_bare_loop(
-                        stream_rx,
-                        &result_tx,
-                        ReorderBuffer::passthrough(),
-                        &metrics_thread,
-                    );
+            match backend {
+                ReorderBackend::Bare(buf) => {
+                    run_bare_loop(stream_rx, &result_tx, buf, &metrics_thread);
                 }
-                ReorderMode::Bare { capacity } => {
-                    run_bare_loop(
-                        stream_rx,
-                        &result_tx,
-                        ReorderBuffer::new(capacity),
-                        &metrics_thread,
-                    );
+                ReorderBackend::Spillable(buf) => {
+                    run_spillable_loop(stream_rx, &result_tx, buf, &spill_events_thread);
                 }
-                ReorderMode::Spillable {
-                    capacity,
-                    threshold,
-                    dir,
-                    granularity,
-                    memory_pressure_bytes,
-                } => match build_spillable(
-                    capacity,
-                    threshold,
-                    dir,
-                    granularity,
-                    memory_pressure_bytes,
-                ) {
-                    Ok(buf) => {
-                        run_spillable_loop(stream_rx, &result_tx, buf, &spill_events_thread);
-                    }
-                    Err(e) => {
-                        // Construction failed (e.g., spill dir cannot be
-                        // created). Surface as a single failed result so
-                        // the receiver maps to exit code 11 and aborts.
-                        let _ = result_tx.send(DeltaResult::failed(
-                            0u32,
-                            format!("spill backend unavailable: {e}"),
-                        ));
-                    }
-                },
+                ReorderBackend::Failed(err) => {
+                    let _ = result_tx.send(DeltaResult::failed(
+                        0u32,
+                        format!("spill backend unavailable: {err}"),
+                    ));
+                }
             }
 
             // Wait for drain thread to finish (propagates panics).
@@ -155,6 +133,53 @@ pub(super) fn spawn_inner(rx: WorkQueueReceiver, mode: ReorderMode) -> DeltaCons
         handle: Some(handle),
         metrics,
         spill_events,
+        force_inserts,
+    }
+}
+
+/// Materialised reorder backend ready to be moved into the consumer thread.
+///
+/// Constructing the backend before the spawn lets the parent thread expose
+/// the inner `force_insert` counter without a cross-thread bootstrap hop.
+enum ReorderBackend {
+    /// In-memory ring (including the passthrough flavour).
+    Bare(ReorderBuffer<DeltaResult>),
+    /// Bounded-memory ring backed by a spill tempfile.
+    Spillable(SpillableReorderBuffer<DeltaResult>),
+    /// Spillable construction failed; deferred until the thread can publish
+    /// the error as a [`DeltaResult::failed`].
+    Failed(std::io::Error),
+}
+
+impl ReorderBackend {
+    fn build(mode: ReorderMode) -> Self {
+        match mode {
+            ReorderMode::Bypass => Self::Bare(ReorderBuffer::passthrough()),
+            ReorderMode::Bare { capacity } => Self::Bare(ReorderBuffer::new(capacity)),
+            ReorderMode::Spillable {
+                capacity,
+                threshold,
+                dir,
+                granularity,
+                memory_pressure_bytes,
+            } => {
+                match build_spillable(capacity, threshold, dir, granularity, memory_pressure_bytes)
+                {
+                    Ok(buf) => Self::Spillable(buf),
+                    Err(e) => Self::Failed(e),
+                }
+            }
+        }
+    }
+
+    fn force_insert_counter(&self) -> Arc<AtomicU64> {
+        match self {
+            // Failed construction never enters the force_insert path, but
+            // a fresh counter keeps the consumer API uniform.
+            Self::Failed(_) => Arc::new(AtomicU64::new(0)),
+            Self::Bare(b) => b.force_insert_counter(),
+            Self::Spillable(b) => b.force_insert_counter(),
+        }
     }
 }
 

--- a/crates/engine/src/concurrent_delta/consumer/tests.rs
+++ b/crates/engine/src/concurrent_delta/consumer/tests.rs
@@ -442,6 +442,84 @@ fn metrics_force_insert_counter_increments_under_backpressure() {
     consumer.join().unwrap();
 }
 
+/// Regression: the saturated-buffer fallback (`force_insert`) must
+/// publish the same cumulative count through the lock-free
+/// [`DeltaConsumer::stats`] accessor as it does through the
+/// `Mutex`-guarded metrics snapshot, and the consumer must still drain
+/// in sequence order so downstream commit logic sees the contracted
+/// ordering even when the ordering buffer broke its capacity bound.
+///
+/// The shape of this test (capacity 2, 16 items, seq 0 sent last) is the
+/// canonical reproducer for the ordering-fallback path called out in
+/// the `concurrent_delta` design notes - it is the only path that
+/// exercises both the deadlock-breaker branch in `run_bare_loop` and
+/// the ring growth inside `ReorderBuffer::force_insert`.
+#[test]
+fn stats_force_inserts_matches_metrics_and_preserves_order() {
+    let count = 16u32;
+    let (tx, rx) = work_queue::bounded_with_capacity(count as usize);
+    let producer = std::thread::spawn(move || {
+        for i in 1..count {
+            let work =
+                DeltaWork::whole_file(i, PathBuf::from("/dst"), 64).with_sequence(u64::from(i));
+            tx.send(work).unwrap();
+        }
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        tx.send(DeltaWork::whole_file(0, PathBuf::from("/dst"), 64).with_sequence(0))
+            .unwrap();
+    });
+
+    let consumer = DeltaConsumer::spawn(rx, 2);
+    let results: Vec<DeltaResult> = consumer.iter().collect();
+    producer.join().unwrap();
+
+    assert_eq!(results.len(), count as usize);
+    for (i, r) in results.iter().enumerate() {
+        assert_eq!(
+            r.sequence(),
+            i as u64,
+            "force_insert fallback must still drain in sequence order; \
+             out of order at position {i}: got seq {}",
+            r.sequence(),
+        );
+    }
+
+    let stats = consumer.stats();
+    let metrics = consumer.metrics();
+    assert!(
+        stats.force_inserts > 0,
+        "expected force_inserts > 0 under backpressure, got stats={stats:?}",
+    );
+    assert_eq!(
+        stats.force_inserts, metrics.force_insert_count,
+        "lock-free stats counter must agree with the metrics snapshot \
+         (stats={stats:?}, metrics={metrics:?})",
+    );
+    consumer.join().unwrap();
+}
+
+/// Cross-check: when no backpressure occurs the lock-free counter stays
+/// at zero, proving the increment is gated on the fallback path and not
+/// on every insert.
+#[test]
+fn stats_force_inserts_zero_without_backpressure() {
+    let count = 32u32;
+    let (tx, rx) = work_queue::bounded_with_capacity(count as usize);
+    let producer = std::thread::spawn(move || send_items(&tx, count));
+
+    let consumer = DeltaConsumer::spawn(rx, count as usize);
+    let results: Vec<DeltaResult> = consumer.iter().collect();
+    producer.join().unwrap();
+
+    assert_eq!(results.len(), count as usize);
+    assert_eq!(
+        consumer.stats().force_inserts,
+        0,
+        "ample reorder capacity must never trigger the fallback",
+    );
+    consumer.join().unwrap();
+}
+
 /// Verifies the drain-batch histogram accumulates buckets when the
 /// consumer delivers a contiguous run in a single drain iteration.
 #[test]

--- a/crates/engine/src/concurrent_delta/reorder/mod.rs
+++ b/crates/engine/src/concurrent_delta/reorder/mod.rs
@@ -26,6 +26,8 @@
 //! sees files in file-list order.
 
 use std::collections::VecDeque;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
 use super::adaptive::{AdaptiveCapacityPolicy, AdaptiveState, ReorderStats};
@@ -158,7 +160,14 @@ pub struct ReorderBuffer<T> {
     /// is currently stalled (count > 0 and the `next_expected` slot is empty).
     stall_started_at: Option<Instant>,
     /// Cumulative count of [`force_insert`](Self::force_insert) invocations.
-    force_insert_count: u64,
+    ///
+    /// Stored behind an `Arc<AtomicU64>` so external observers (the
+    /// consumer thread and any operator-facing diagnostics handle) can
+    /// poll the counter without taking the metrics `Mutex`. Updates use
+    /// `Relaxed` ordering because the value is purely diagnostic - no
+    /// happens-before relationship with the delivered payloads is
+    /// required.
+    force_insert_count: Arc<AtomicU64>,
     /// Distribution of drain-batch sizes recorded via
     /// [`record_drain_batch`](Self::record_drain_batch).
     drain_batch_size: HistogramStats,
@@ -205,7 +214,7 @@ impl<T> ReorderBuffer<T> {
             max_depth: 0,
             stall_duration: Duration::ZERO,
             stall_started_at: None,
-            force_insert_count: 0,
+            force_insert_count: Arc::new(AtomicU64::new(0)),
             drain_batch_size: HistogramStats::new_pow2(),
             drain_pause: HistogramStats::new_microseconds(),
         }
@@ -251,7 +260,7 @@ impl<T> ReorderBuffer<T> {
             max_depth: 0,
             stall_duration: Duration::ZERO,
             stall_started_at: None,
-            force_insert_count: 0,
+            force_insert_count: Arc::new(AtomicU64::new(0)),
             drain_batch_size: HistogramStats::new_pow2(),
             drain_pause: HistogramStats::new_microseconds(),
         }
@@ -519,7 +528,7 @@ impl<T> ReorderBuffer<T> {
             stall_duration: self.stall_duration.saturating_add(in_flight),
             current_depth: self.count,
             max_depth: self.max_depth,
-            force_insert_count: self.force_insert_count,
+            force_insert_count: self.force_insert_count.load(Ordering::Relaxed),
             drain_batch_size_histogram: self.drain_batch_size,
             drain_pause_histogram: self.drain_pause,
         }
@@ -544,6 +553,21 @@ impl<T> ReorderBuffer<T> {
     /// operators can read off the typical pause magnitude at a glance.
     pub fn record_drain_pause(&mut self, pause: Duration) {
         self.drain_pause.record_duration(pause);
+    }
+
+    /// Returns a shared handle to the cumulative `force_insert` counter.
+    ///
+    /// The returned `Arc<AtomicU64>` aliases the buffer's internal counter,
+    /// so the latest value is visible to every caller holding a clone. The
+    /// counter increments by exactly one each time
+    /// [`force_insert`](Self::force_insert) is invoked - including when the
+    /// buffer is in bypass mode and when the sequence is behind the delivery
+    /// cursor (still observed so operators see stale-result diagnostics).
+    /// Reads should use [`Ordering::Relaxed`] - the value is purely
+    /// diagnostic.
+    #[must_use]
+    pub fn force_insert_counter(&self) -> Arc<AtomicU64> {
+        Arc::clone(&self.force_insert_count)
     }
 
     /// Returns adaptive capacity counters (grow/shrink event totals plus the
@@ -572,7 +596,7 @@ impl<T> ReorderBuffer<T> {
     /// ring capacity, this inserts directly. For sequences beyond capacity,
     /// the ring is grown to accommodate the item.
     pub fn force_insert(&mut self, sequence: u64, item: T) {
-        self.force_insert_count = self.force_insert_count.saturating_add(1);
+        self.force_insert_count.fetch_add(1, Ordering::Relaxed);
         if self.bypass {
             self.bypass_queue.push_back(item);
             self.count += 1;

--- a/crates/engine/src/concurrent_delta/spill/buffer/lifecycle.rs
+++ b/crates/engine/src/concurrent_delta/spill/buffer/lifecycle.rs
@@ -5,6 +5,8 @@ use std::collections::BTreeMap;
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::AtomicU64;
 
 use super::super::super::reorder::ReorderBuffer;
 use super::super::{
@@ -192,6 +194,18 @@ impl<T: SpillCodec> SpillableReorderBuffer<T> {
     #[must_use]
     pub fn capacity(&self) -> usize {
         self.inner.capacity()
+    }
+
+    /// Returns a shared handle to the inner [`ReorderBuffer`]'s cumulative
+    /// `force_insert` counter.
+    ///
+    /// Forwarded directly from
+    /// [`ReorderBuffer::force_insert_counter`](super::super::super::reorder::ReorderBuffer::force_insert_counter)
+    /// so callers can poll ordering-fallback activity through the spillable
+    /// facade. Reads should use [`std::sync::atomic::Ordering::Relaxed`].
+    #[must_use]
+    pub fn force_insert_counter(&self) -> Arc<AtomicU64> {
+        self.inner.force_insert_counter()
     }
 
     /// Returns diagnostic counters for spill activity.


### PR DESCRIPTION
## Summary

- Plumb the `ReorderBuffer::force_insert` counter through an `Arc<AtomicU64>` shared between the delta-reorder background thread and the `DeltaConsumer` handle so operators can poll the ordering-fallback rate without taking the metrics `Mutex`.
- Add `DeltaConsumerStats::force_inserts` alongside the existing `spill_events` field; lock-free reads use `Ordering::Relaxed` because the value is purely diagnostic.
- Add a regression test (`stats_force_inserts_matches_metrics_and_preserves_order`) that drives the saturated-buffer fallback path (capacity 2, 16 items, head-of-line sequence sent last) and asserts the counter increments, the lock-free `stats()` accessor agrees with the `Mutex`-guarded `metrics()` snapshot, and the consumer still drains in sequence order after the fallback fires. A negative-control test (`stats_force_inserts_zero_without_backpressure`) verifies the counter stays at zero when the reorder ring has ample capacity.

The runtime behaviour of `force_insert` is unchanged; the new instrumentation is observe-only.

## Test plan

- [ ] CI: `cargo nextest run -p engine --all-features -E 'test(stats_force_inserts) + test(metrics_force_insert)'`
- [ ] CI: full workspace `fmt + clippy + nextest` matrix passes on stable/Windows/macOS/Linux musl.