### PR TITLE
fix(protocol): clamp token block_index proptests to safe wire range

### DIFF
--- a/crates/protocol/tests/proptest_delta_script_roundtrip.rs
+++ b/crates/protocol/tests/proptest_delta_script_roundtrip.rs
@@ -30,12 +30,16 @@ fn arb_literal(max_len: usize) -> impl Strategy<Value = DeltaOp> {
     prop::collection::vec(any::<u8>(), 1..=max_len).prop_map(DeltaOp::Literal)
 }
 
-/// Generates an arbitrary `DeltaOp::Copy` with block_index in varint-safe range.
+/// Generates an arbitrary `DeltaOp::Copy` with block_index in token-safe range.
 ///
-/// The internal format encodes block_index as a varint (i32), so we cap at
-/// `i32::MAX` to stay in the representable range.
+/// `mixed_token_stream_roundtrip` runs this through `write_token_stream`, which
+/// encodes a block match as `-(block_index + 1)` (see
+/// `wire::delta::token::write_token_block_match`). A `block_index` of
+/// `i32::MAX` would compute `-(i32::MAX + 1)` and trip the debug overflow
+/// check, so cap at `i32::MAX - 1`. `length` is the internal-format varint
+/// payload and may use the full non-negative i32 range.
 fn arb_copy() -> impl Strategy<Value = DeltaOp> {
-    (0u32..=0x7FFF_FFFFu32, 1u32..=0x7FFF_FFFFu32).prop_map(|(block_index, length)| DeltaOp::Copy {
+    (0u32..=0x7FFF_FFFEu32, 1u32..=0x7FFF_FFFFu32).prop_map(|(block_index, length)| DeltaOp::Copy {
         block_index,
         length,
     })

--- a/crates/protocol/tests/proptest_wire_format_fuzz.rs
+++ b/crates/protocol/tests/proptest_wire_format_fuzz.rs
@@ -754,8 +754,13 @@ mod delta_arbitrary_input {
         }
 
         /// Token block match roundtrip.
+        ///
+        /// The wire token is `-(block_index + 1)` as i32, so the maximum legal
+        /// block index is `i32::MAX - 1`. A `block_index` of `i32::MAX` would
+        /// compute `-(i32::MAX + 1)` and trip the debug overflow check in
+        /// `write_token_block_match`.
         #[test]
-        fn token_block_match_roundtrip(block_index in 0u32..=0x7FFF_FFFFu32) {
+        fn token_block_match_roundtrip(block_index in 0u32..=0x7FFF_FFFEu32) {
             let mut buf = Vec::new();
             write_token_block_match(&mut buf, block_index).unwrap();
 


### PR DESCRIPTION
## Summary

`write_token_block_match` encodes a block match as `-(block_index + 1)`
in i32 LE. A `block_index` equal to `i32::MAX` overflows to `-i32::MIN`
and trips the debug overflow check on debug-assert CI cells
(e.g. the `zlib-rs` feature flag run that exposed PR #4548).

PR #4548 fixed the same shape in `arb_copy` in
`proptest_delta_roundtrip.rs`. An audit of the rest of the proptest and
fuzz corpus turned up two sister strategies with the same latent bug:

- `crates/protocol/tests/proptest_delta_script_roundtrip.rs::arb_copy`
  drives `mixed_token_stream_roundtrip`, which feeds the block index
  through `write_token_stream` and on to `write_token_block_match`.
- `crates/protocol/tests/proptest_wire_format_fuzz.rs::token_block_match_roundtrip`
  calls `write_token_block_match` directly.

Both now cap `block_index` at `i32::MAX - 1` to match the contract
already enforced by the `debug_assert!` at the entry of
`write_token_block_match`.

## Audit scope

Searched `crates/**/tests/proptest_*.rs`, in-tree proptest modules under
`crates/**/src/**`, and `fuzz/fuzz_targets/*.rs` for strategies producing
`u32`/`i32`/`i64` values that get negated, `+1`'d before negation, or
cast `as i32` from a `u32` with the top bit set. The only remaining
hits beyond the two above were already either:

- Cast straight through `write_delta_op` / `write_int` (no negation,
  full i32 range safe).
- Already capped at `i32::MAX - 1` (`token_block_match_roundtrip` in
  `proptest_delta_roundtrip.rs`, `block_match_roundtrip` and
  `consecutive_block_matches` in `proptest_delta_script_roundtrip.rs`).

Production code is unchanged; the existing `debug_assert!` in
`write_token_block_match` is the contract these strategies must respect.

## Test plan

- [ ] CI nextest (stable) passes on Linux, macOS, Windows
- [ ] CI nextest passes with debug assertions enabled (zlib-rs feature
      cell that originally caught the PR #4548 regression)
- [ ] fmt + clippy green