### PR TITLE
docs(engine,transfer): fix broken intra-doc links in lib.rs and submodules

### DIFF
--- a/crates/engine/src/delete/context/core.rs
+++ b/crates/engine/src/delete/context/core.rs
@@ -205,8 +205,8 @@ impl DeleteContext {
     ///    [`DeletePlan::sort_by_name`] to lock in upstream emission
     ///    order.
     /// 4. Inserts the plan into [`Self::plans`] keyed by `dir`.
-    /// 5. Enqueues a [`CursorObservation`] onto the producer channel.
-    ///    The drain in [`Self::into_emitter`] consumes the channel after
+    /// 5. Enqueues a `CursorObservation` onto the producer channel.
+    ///    The drain in `Self::into_emitter` consumes the channel after
     ///    all senders drop and folds each observation into the owned
     ///    [`DirTraversalCursor`].
     ///
@@ -273,7 +273,7 @@ impl DeleteContext {
     /// observation queued so far.
     ///
     /// Pending channel messages are drained, applied to the new cursor,
-    /// and then re-enqueued so the eventual [`Self::into_emitter`] drain
+    /// and then re-enqueued so the eventual `Self::into_emitter` drain
     /// still sees the complete observation set. The producer channel
     /// remains open; future `observe_*` calls continue to land on it.
     ///

--- a/crates/engine/src/delete/emitter/mod.rs
+++ b/crates/engine/src/delete/emitter/mod.rs
@@ -15,17 +15,17 @@
 //! - DDP-C3 (#2261) - [`EmitterErrorPolicy`] mirroring upstream's
 //!   continue-vs-abort behaviour: non-fatal errors set the `io_error`
 //!   flag (upstream `IOERR_GENERAL`) and the drain keeps going; fatal
-//!   classifications abort and surface an [`io::Error`] mapped to
+//!   classifications abort and surface an [`std::io::Error`] mapped to
 //!   `RERR_PARTIAL` (23) / `RERR_VANISHED` (24).
 //! - DDP-C4 (#2262) - unit tests for synthetic plan sequences.
 //!
 //! # Submodules
 //!
-//! - [`fs`] - [`DeleteFs`] trait plus the production [`RealDeleteFs`]
+//! - `fs` - [`DeleteFs`] trait plus the production [`RealDeleteFs`]
 //!   and the [`RecordingDeleteFs`] test fake.
-//! - [`policy`] - [`EmitterErrorPolicy`] and the exit-code constants
+//! - `policy` - [`EmitterErrorPolicy`] and the exit-code constants
 //!   [`EMITTER_PARTIAL_EXIT_CODE`] / [`EMITTER_VANISHED_EXIT_CODE`].
-//! - [`cohort`] - [`CohortDeleteRecord`] surfaced to callers that wire
+//! - `cohort` - [`CohortDeleteRecord`] surfaced to callers that wire
 //!   a hardlink cohort snapshot.
 //!
 //! # Upstream reference
@@ -237,7 +237,7 @@ impl<F: DeleteFs> DeleteEmitter<F> {
     /// # Errors
     ///
     /// Surfaces an [`io::Error`] only on a fatal classification (see
-    /// [`Self::is_fatal_error`]) or when
+    /// `Self::is_fatal_error`) or when
     /// [`EmitterErrorPolicy::continue_on_error`] is `false` and a
     /// non-fatal failure occurs. Non-fatal failures under the default
     /// policy set [`Self::io_error`] and the drain continues, matching

--- a/crates/engine/src/delete/error.rs
+++ b/crates/engine/src/delete/error.rs
@@ -55,7 +55,7 @@ pub enum DeleteError {
         strong_count: usize,
     },
     /// The cursor observation receiver was already consumed by a prior
-    /// [`super::DeleteContext::into_emitter`] call. Reachable only if a
+    /// `DeleteContext::into_emitter` call. Reachable only if a
     /// caller drained the same context twice (the public `emit_*` API
     /// consumes `self`, so production code cannot hit this).
     #[error("DeleteContext::into_emitter: cursor receiver already taken")]

--- a/crates/engine/src/delete/mod.rs
+++ b/crates/engine/src/delete/mod.rs
@@ -33,7 +33,6 @@
 
 mod cohort_index;
 mod context;
-/// Single-threaded emitter that drains delete plans in upstream traversal order.
 pub mod emitter;
 mod error;
 mod extras;

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -128,21 +128,13 @@
 #[cfg_attr(docsrs, doc(cfg(feature = "async")))]
 pub mod async_io;
 
-/// Concurrent delta computation pipeline for parallel file processing.
 pub mod concurrent_delta;
-/// Parallel-deterministic delete pipeline data structures and emitter.
 pub mod delete;
-/// Block-matching helpers for the delta-transfer pipeline.
 pub mod delta;
-/// Common error types for the engine crate.
 pub mod error;
-/// Hardlink detection and resolution matching upstream `hlink.c`.
 pub mod hardlink;
-/// Deterministic local filesystem copy planner and executor.
 pub mod local_copy;
-/// Internal utilities shared across engine submodules.
 pub mod util;
-/// Directory traversal abstractions for rsync file list generation.
 pub mod walk;
 
 #[doc(hidden)]

--- a/crates/engine/src/local_copy/buffer_pool/pool.rs
+++ b/crates/engine/src/local_copy/buffer_pool/pool.rs
@@ -63,7 +63,7 @@ fn queue_capacity(max_buffers: usize) -> usize {
 ///
 /// The pool has a soft maximum capacity (`max_buffers`). The underlying
 /// [`ArrayQueue`] is sized at construction to hold at least
-/// [`DEFAULT_QUEUE_CAPACITY`] buffers (or `max_buffers` if larger). The
+/// `DEFAULT_QUEUE_CAPACITY` buffers (or `max_buffers` if larger). The
 /// soft capacity is enforced on return via an atomic
 /// `compare_exchange_weak` admission counter that allows at most
 /// `soft_capacity` concurrent successful admissions, so the central queue
@@ -96,7 +96,7 @@ fn queue_capacity(max_buffers: usize) -> usize {
 ///    central queue, then allocate fresh.
 /// 2. **Use** - caller reads/writes through the RAII guard's `Deref`/`DerefMut`.
 /// 3. **Return** - guard's `Drop` impl passes the buffer back via
-///    [`return_buffer`](Self::return_buffer), which tries the thread-local
+///    `return_buffer`, which tries the thread-local
 ///    slot first, then the central queue.
 #[derive(Debug)]
 pub struct BufferPool<A: BufferAllocator = DefaultAllocator> {

--- a/crates/engine/src/local_copy/buffer_pool/throughput.rs
+++ b/crates/engine/src/local_copy/buffer_pool/throughput.rs
@@ -215,7 +215,7 @@ impl ThroughputTracker {
 
     /// Computes a recommended buffer size based on current throughput.
     ///
-    /// Targets [`TARGET_BUFFER_DURATION_SECS`] worth of data per buffer,
+    /// Targets `TARGET_BUFFER_DURATION_SECS` worth of data per buffer,
     /// clamped between [`MIN_BUFFER_SIZE`] and `max_size`. The result is
     /// rounded up to the next power of two for optimal I/O alignment.
     ///
@@ -246,7 +246,7 @@ impl ThroughputTracker {
 }
 
 impl Default for ThroughputTracker {
-    /// Creates a tracker with the default smoothing factor ([`DEFAULT_ALPHA`]).
+    /// Creates a tracker with the default smoothing factor (`DEFAULT_ALPHA`).
     fn default() -> Self {
         Self::new()
     }

--- a/crates/engine/src/local_copy/mod.rs
+++ b/crates/engine/src/local_copy/mod.rs
@@ -49,9 +49,7 @@
 //! assert_eq!(summary.files_copied(), 1);
 //! ```
 
-/// Buffer pool for I/O buffer reuse during large file transfers.
 pub mod buffer_pool;
-/// Copy-on-write file cloning with macOS `clonefile()` dual-path selection.
 pub mod clonefile;
 mod compressor;
 mod context;
@@ -66,11 +64,6 @@ mod debug_recv;
 #[cfg(test)]
 mod debug_send;
 mod deferred_sync;
-/// Deletion logic for rsync `--delete` variants.
-///
-/// Provides helpers for `--delete-before`, `--delete-during`, `--delete-after`,
-/// and `--delete-delay` timing modes including `DeletionContext`,
-/// `should_delete_entry`, and `build_keep_set`.
 pub mod deletion;
 mod dir_merge;
 mod error;
@@ -81,16 +74,10 @@ mod metadata_sync;
 mod operands;
 mod options;
 mod overrides;
-/// State machine for 4-priority streaming file list processing pipeline.
-///
-/// Provides the [`PipelineController`](pipelined_state::PipelineController) for
-/// coordinating concurrent file list reception, pipeline filling, entry processing,
-/// and response handling with a priority-driven main loop.
 pub mod pipelined_state;
 mod plan;
 pub(crate) mod prefetch;
 mod skip_compress;
-/// Windows `CopyFileExW` file copying with dual-path runtime selection.
 pub mod win_copy;
 
 pub use buffer_pool::{

--- a/crates/engine/src/local_copy/options/staging.rs
+++ b/crates/engine/src/local_copy/options/staging.rs
@@ -67,7 +67,7 @@ impl LocalCopyOptions {
     ///
     /// When enabled and no explicit `--partial-dir` has been configured, the
     /// staging directory is finalised to `.~tmp~` via
-    /// [`Self::apply_delay_updates_partial_dir_default`] to match upstream
+    /// `Self::apply_delay_updates_partial_dir_default` to match upstream
     /// rsync behaviour.
     #[must_use]
     #[doc(alias = "--delay-updates")]

--- a/crates/engine/src/util/mod.rs
+++ b/crates/engine/src/util/mod.rs
@@ -1,6 +1,6 @@
 //! Internal utilities shared across engine submodules.
 //!
-//! Currently exposes [`poison`] for recovering from lock poisoning on
+//! Currently exposes [`self::poison`] for recovering from lock poisoning on
 //! synchronization primitives whose protected state remains valid after a
 //! panic.
 

--- a/crates/transfer/src/delta_apply/applicator.rs
+++ b/crates/transfer/src/delta_apply/applicator.rs
@@ -30,7 +30,7 @@ type BasisMapStrategy = BufferedMap;
 /// Kind of writer paired with the [`DeltaApplicator`].
 ///
 /// Drives the basis-file mapping policy: when the writer is io_uring-backed,
-/// the basis file must be opened via [`BufferedMap`] (a sliding-window
+/// the basis file must be opened via [`crate::map_file::BufferedMap`] (a sliding-window
 /// `pread(2)` reader) rather than `mmap(2)`. Submitting an `mmap`-backed
 /// pointer to an `io_uring` SQE has two failure modes:
 ///
@@ -57,7 +57,7 @@ pub enum BasisWriterKind {
     Standard,
     /// io_uring-backed writer (e.g. `IoUringWriter` or `IoUringDiskBatch`).
     ///
-    /// Forces the basis file onto [`BufferedMap`] regardless of size to keep
+    /// Forces the basis file onto [`crate::map_file::BufferedMap`] regardless of size to keep
     /// `mmap`-backed pointers out of any io_uring submission queue entry.
     IoUring,
 }

--- a/crates/transfer/src/delta_apply/mod.rs
+++ b/crates/transfer/src/delta_apply/mod.rs
@@ -6,9 +6,9 @@
 //!
 //! # Submodules
 //!
-//! - [`applicator`] - Core delta application logic (`DeltaApplicator`, config, result types)
-//! - [`checksum`] - Checksum verification with enum dispatch for algorithm selection
-//! - [`sparse`] - Sparse file write state tracking for hole optimization
+//! - `applicator` - Core delta application logic (`DeltaApplicator`, config, result types)
+//! - `checksum` - Checksum verification with enum dispatch for algorithm selection
+//! - `sparse` - Sparse file write state tracking for hole optimization
 //!
 //! # DEBUG_DELTASUM Tracing Levels
 //!

--- a/crates/transfer/src/disk_commit/config.rs
+++ b/crates/transfer/src/disk_commit/config.rs
@@ -66,7 +66,7 @@ pub struct DiskCommitConfig {
     ///
     /// Controls how many `FileMessage` items can be buffered between the
     /// network thread and the disk thread. Clamped to
-    /// [`MIN_CHANNEL_CAPACITY`]..=[`MAX_CHANNEL_CAPACITY`] at runtime.
+    /// `MIN_CHANNEL_CAPACITY..=MAX_CHANNEL_CAPACITY` at runtime.
     ///
     /// Defaults to [`DEFAULT_CHANNEL_CAPACITY`] (128).
     pub channel_capacity: usize,
@@ -117,8 +117,8 @@ impl Default for DiskCommitConfig {
 impl DiskCommitConfig {
     /// Returns the effective channel capacity, clamped to valid bounds.
     ///
-    /// Values below [`MIN_CHANNEL_CAPACITY`] are raised to the minimum;
-    /// values above [`MAX_CHANNEL_CAPACITY`] are lowered to the maximum.
+    /// Values below `MIN_CHANNEL_CAPACITY` are raised to the minimum;
+    /// values above `MAX_CHANNEL_CAPACITY` are lowered to the maximum.
     #[must_use]
     pub fn effective_channel_capacity(&self) -> usize {
         self.channel_capacity

--- a/crates/transfer/src/generator/diagnostics.rs
+++ b/crates/transfer/src/generator/diagnostics.rs
@@ -69,7 +69,7 @@ pub(crate) fn flush_with_count<W: Write>(writer: &mut W) -> io::Result<()> {
 /// Snapshot of the global generator flush counter.
 ///
 /// Returns the cumulative number of `writer.flush()` calls recorded by
-/// [`flush_with_count`]. Used by the generator finalize path to emit an
+/// `flush_with_count`. Used by the generator finalize path to emit an
 /// end-of-transfer diagnostic line and by unit tests that assert the counter
 /// monotonically grows.
 #[must_use]

--- a/crates/transfer/src/lib.rs
+++ b/crates/transfer/src/lib.rs
@@ -101,76 +101,42 @@ use std::sync::{Arc, Mutex};
 #[cfg(feature = "tracing")]
 use tracing::instrument;
 
-/// Compressed reader wrapping multiplexed streams.
 mod compressed_reader;
-/// Compressed writer wrapping multiplexed streams.
 mod compressed_writer;
-/// Server configuration derived from the compact `--server` flag string.
 pub mod config;
-/// Delta application mirroring upstream `receiver.c:receive_data()`.
 pub mod delta_apply;
-/// Delta generator configuration parameters.
 pub mod delta_config;
-/// Delta transfer algorithm documentation and implementation guide.
 pub mod delta_transfer;
-/// Error categorization and retry utilities for delta transfer operations.
 pub mod error;
-/// Compact server flag string parser (`-logDtpre.iLsfxC`).
 pub mod flags;
-/// Server-side Generator role implementation.
 pub mod generator;
-/// Server-side protocol handshake utilities.
 pub mod handshake;
-/// Reader abstraction supporting plain and multiplex modes.
 mod reader;
-/// Server-side Receiver role implementation.
 pub mod receiver;
-/// Enumerations describing the role executed by the server process.
 pub mod role;
-/// Role trailer formatting (`[sender=VERSION]`) for diagnostic output.
 pub(crate) mod role_trailer;
-/// Path sanitization mirroring upstream `util1.c:sanitize_path()`.
 pub mod sanitize_path;
-/// Server-side protocol setup utilities.
 pub mod setup;
-/// Shared abstractions used by generator and receiver roles.
 pub mod shared;
-/// Symlink target safety analysis mirroring upstream `util1.c:unsafe_symlink()`.
 pub mod symlink_safety;
-/// Startup cleanup for stale temporary files left by interrupted transfers.
 pub mod temp_cleanup;
-/// RAII guard for temporary file cleanup.
 pub mod temp_guard;
-/// Writer abstraction supporting plain and multiplex modes.
 mod writer;
 
-/// Bounded-concurrency parallel I/O using rayon for work-stealing parallelism.
 mod parallel_io;
 
-/// Pluggable delta dispatch pipeline for the receiver.
 pub mod delta_pipeline;
 
-/// Batched acknowledgments for reduced network overhead.
 pub mod ack_batcher;
-/// Adaptive buffer sizing based on file size.
 pub mod adaptive_buffer;
-/// Buffer size constants mirroring upstream rsync.
 pub mod constants;
-/// Disk commit thread for decoupled network/disk I/O.
 pub mod disk_commit;
-/// Memory-mapped file abstraction for basis file access.
 pub mod map_file;
-/// Request pipelining for reduced latency in file transfers.
 pub mod pipeline;
-/// Progress reporting for server-side transfer operations.
 pub mod progress;
-/// Bounded sliding-window reorder buffer with backpressure.
 pub mod reorder_buffer;
-/// Reusable buffer for delta token data.
 pub mod token_buffer;
-/// Strategy-based reader for plain and compressed delta token formats.
 pub mod token_reader;
-/// Transfer operation helpers for pipelined requests.
 pub mod transfer_ops;
 
 pub use self::adaptive_buffer::{

--- a/crates/transfer/src/pipeline/mod.rs
+++ b/crates/transfer/src/pipeline/mod.rs
@@ -60,21 +60,15 @@
 //! This is configured via [`PipelineConfig::ack_batch_size`].
 
 pub mod async_signature;
-/// Pipeline dispatch types (`FileList`, `FileJob`) for the async transfer architecture.
 pub mod job;
-/// Channel messages for the decoupled network-to-disk receiver architecture.
 pub mod messages;
 mod pending;
-/// `PipelinedReceiver` mediator between network and disk threads.
 pub mod receiver;
-/// Lock-free single-producer / single-consumer channel for the network-to-disk path.
 pub mod spsc;
 mod state;
 
-/// Async file job producer for the tokio-based transfer pipeline.
 #[cfg(feature = "async")]
 pub mod async_dispatch;
-/// Async pipeline orchestrator for tokio-based file transfers.
 #[cfg(feature = "async")]
 pub mod async_pipeline;
 

--- a/crates/transfer/src/pipeline/spsc.rs
+++ b/crates/transfer/src/pipeline/spsc.rs
@@ -1,8 +1,8 @@
 //! Lock-free SPSC (single-producer, single-consumer) channel.
 //!
-//! Built on [`crossbeam_queue::ArrayQueue`] with [`AtomicBool`] disconnection
-//! flags and [`std::hint::spin_loop`] for waiting.  Zero syscalls - pure
-//! userspace synchronization with no futex, no `thread::park`, no condvar.
+//! Built on [`crossbeam_queue::ArrayQueue`] with [`std::sync::atomic::AtomicBool`]
+//! disconnection flags and [`std::hint::spin_loop`] for waiting.  Zero syscalls -
+//! pure userspace synchronization with no futex, no `thread::park`, no condvar.
 //!
 //! Designed for the network → disk thread pipeline where exactly one producer
 //! (network ingest) and one consumer (disk commit) exchange `FileMessage`

--- a/crates/transfer/src/setup/capability.rs
+++ b/crates/transfer/src/setup/capability.rs
@@ -128,7 +128,7 @@ const fn iconv_capability_compiled_in() -> bool {
     cfg!(feature = "iconv")
 }
 
-/// Builds the `-e.xxx` capability string from [`CAPABILITY_MAPPINGS`].
+/// Builds the `-e.xxx` capability string from the `CAPABILITY_MAPPINGS` table.
 ///
 /// This is the single source of truth for which capability characters we
 /// advertise. Both SSH (`invocation.rs`) and daemon (`daemon_transfer.rs`)

--- a/crates/transfer/src/setup/mod.rs
+++ b/crates/transfer/src/setup/mod.rs
@@ -13,11 +13,11 @@
 //!
 //! # Submodules
 //!
-//! - [`capability`] - Capability string building and parsing (`-e.xxx`)
-//! - [`compat`] - Compatibility flags exchange
-//! - [`negotiator`] - Trait abstractions and default implementation
-//! - [`restrictions`] - Protocol version feature restrictions (compat.c:641-709)
-//! - [`types`] - Configuration and result types
+//! - `capability` - Capability string building and parsing (`-e.xxx`)
+//! - `compat` - Compatibility flags exchange
+//! - `negotiator` - Trait abstractions and default implementation
+//! - `restrictions` - Protocol version feature restrictions (compat.c:641-709)
+//! - `types` - Configuration and result types
 
 mod capability;
 mod compat;

--- a/crates/transfer/src/setup/negotiator.rs
+++ b/crates/transfer/src/setup/negotiator.rs
@@ -42,7 +42,7 @@ pub trait CompatFlagsExchanger {
 
     /// Builds compatibility flags from the client's `-e` capability string.
     ///
-    /// Uses the table-driven mapping in [`super::capability::CAPABILITY_MAPPINGS`]
+    /// Uses the table-driven mapping in `super::capability::CAPABILITY_MAPPINGS`
     /// to convert capability characters into `CompatibilityFlags`.
     ///
     /// # Upstream reference

--- a/crates/transfer/src/transfer_ops/mod.rs
+++ b/crates/transfer/src/transfer_ops/mod.rs
@@ -15,9 +15,9 @@
 //!
 //! # Submodules
 //!
-//! - [`request`] - Sends file transfer requests (NDX + iflags + signature) to the sender.
-//! - [`response`] - Synchronous response processing with direct disk I/O.
-//! - [`streaming`] - Streaming response processing via SPSC channel to a disk commit thread.
+//! - `request` - Sends file transfer requests (NDX + iflags + signature) to the sender.
+//! - `response` - Synchronous response processing with direct disk I/O.
+//! - `streaming` - Streaming response processing via SPSC channel to a disk commit thread.
 //!
 //! # Protocol Flow
 //!

--- a/crates/transfer/src/writer/msg_info.rs
+++ b/crates/transfer/src/writer/msg_info.rs
@@ -13,7 +13,7 @@ use super::server::ServerWriter;
 
 /// Trait for writers that can send `MSG_INFO` multiplexed messages.
 ///
-/// Writers that support multiplexed output (like [`ServerWriter`] and
+/// Writers that support multiplexed output (like `ServerWriter` and
 /// [`CountingWriter`]) implement this trait to forward `MSG_INFO` payloads
 /// through the multiplex layer; writers that do not support it use the
 /// default no-op.


### PR DESCRIPTION
## Summary

Both `engine` and `transfer` already enforce `#![deny(missing_docs)]` and pass it cleanly, so there were no missing-doc warnings to backfill. Instead, `cargo doc --no-deps -p engine -p transfer --all-features` was failing with 76 broken intra-doc link errors and 24 doc warnings accumulated since the SPL decomposition wave.

Root cause: many `pub mod X;` lines in `lib.rs` carried a one-line `///` outer doc while their target file already declared a `//!` inner doc. The two attach to the same module item but rustdoc resolves intra-doc links from the outer scope (`lib.rs`), so links written from inside the submodule (`[`DeletePlan`]`, `[`work_queue`]`, `[`BufferedMap`]`, ...) silently failed to resolve.

Changes:
- Drop redundant `///` outer docs on `pub mod` lines whose target file already has a `//!` inner doc (`crates/engine/src/lib.rs`, `crates/transfer/src/lib.rs`, `crates/engine/src/local_copy/mod.rs`, `crates/engine/src/delete/mod.rs`, `crates/transfer/src/pipeline/mod.rs`).
- Re-anchor `[`BufferedMap`]` -> `[`crate::map_file::BufferedMap`]` so the link resolves at the new submodule scope.
- Replace links to private-after-decomposition items (`CursorObservation`, `Self::into_emitter`, `Self::is_fatal_error`, `flush_with_count`, `MIN/MAX_CHANNEL_CAPACITY`, `CAPABILITY_MAPPINGS`, `DEFAULT_QUEUE_CAPACITY`, `TARGET_BUFFER_DURATION_SECS`, `DEFAULT_ALPHA`, `Self::apply_delay_updates_partial_dir_default`, `ServerWriter`) with plain backtick references.
- Demote intra-doc references to private submodule names (`fs`, `policy`, `cohort`, `applicator`, `checksum`, `sparse`, `capability`, `compat`, `negotiator`, `restrictions`, `types`, `request`, `response`, `streaming`) to backtick code spans.
- Qualify `[`AtomicBool`]` to `[`std::sync::atomic::AtomicBool`]` and `[`io::Error`]` to `[`std::io::Error`]` where the local imports are not in scope at the doc site.
- Update `crates/engine/src/util/mod.rs` to use `[`self::poison`]` so the link resolves against the inner module scope.

Net effect of `cargo doc --no-deps -p engine -p transfer --all-features`:
- Errors: 76 -> 33 (all 33 remaining live inside `crates/engine/src/concurrent_delta/`, which is owned by an in-flight refactor and out of scope for this PR).
- Warnings: 24 -> 4 (3 of the remaining 4 are in `concurrent_delta/`; the 4th is a redundant-explicit-link warning in `concurrent_delta/reorder/mod.rs`).

No public API or behaviour changes. No `#[allow(missing_docs)]` added. No `pub` -> `pub(crate)` demotions were warranted because every `pub` item already had a doc comment (enforced by `deny(missing_docs)`).

## Test plan

- [ ] CI fmt+clippy
- [ ] CI nextest (stable)
- [ ] CI Windows / macOS / Linux musl