### PR TITLE
docs(engine): fix broken intra-doc links in concurrent_delta

### DIFF
--- a/crates/engine/src/concurrent_delta/consumer/mod.rs
+++ b/crates/engine/src/concurrent_delta/consumer/mod.rs
@@ -1,10 +1,14 @@
 //! Ordered consumer for the concurrent delta pipeline.
 //!
-//! [`DeltaConsumer`] bridges the parallel dispatch phase ([`WorkQueue`]) with
-//! the ordered consumption phase (receiver pipeline). It spawns a consumer
-//! thread that drains [`DeltaWork`] items from the work queue via
-//! [`drain_parallel`], feeds each [`DeltaResult`] into a [`ReorderBuffer`],
-//! and exposes an iterator that yields results strictly in sequence order.
+//! [`DeltaConsumer`] bridges the parallel dispatch phase
+//! ([`WorkQueueReceiver`]) with the
+//! ordered consumption phase (receiver pipeline). It spawns a consumer
+//! thread that drains [`DeltaWork`](super::types::DeltaWork) items from the
+//! work queue via
+//! [`drain_parallel`](super::work_queue::WorkQueueReceiver::drain_parallel),
+//! feeds each [`DeltaResult`] into a
+//! [`ReorderBuffer`](super::reorder::ReorderBuffer), and exposes an iterator
+//! that yields results strictly in sequence order.
 //!
 //! # Architecture
 //!
@@ -48,8 +52,8 @@
 //!
 //! | Submodule | Role |
 //! |-----------|------|
-//! | [`spawn`] | Private spawn machinery: `ReorderMode` selector and the shared `spawn_inner` plumbing |
-//! | [`loops`] | Background-thread reorder loops for the bare and spillable backends |
+//! | `spawn` | Private spawn machinery: `ReorderMode` selector and the shared `spawn_inner` plumbing |
+//! | `loops` | Background-thread reorder loops for the bare and spillable backends |
 //! | `tests` | Integration tests (only built under `#[cfg(test)]`) |
 
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -87,8 +91,9 @@ pub struct DeltaConsumerStats {
 ///
 /// Created via [`DeltaConsumer::spawn`], which launches a background thread
 /// that runs [`WorkQueueReceiver::drain_parallel`] to process work items
-/// concurrently, then feeds results through a [`ReorderBuffer`] for in-order
-/// delivery over an internal channel.
+/// concurrently, then feeds results through a
+/// [`ReorderBuffer`](super::reorder::ReorderBuffer) for in-order delivery
+/// over an internal channel.
 ///
 /// # Lifecycle
 ///
@@ -147,8 +152,8 @@ impl DeltaConsumer {
     ///   process work items via the rayon thread pool, streaming each result
     ///   through an internal channel as soon as its worker completes.
     /// - **delta-reorder**: Receives streamed results, inserts them into a
-    ///   [`ReorderBuffer`], and forwards the contiguous in-order run to the
-    ///   consumer's output channel.
+    ///   [`ReorderBuffer`](super::reorder::ReorderBuffer), and forwards the
+    ///   contiguous in-order run to the consumer's output channel.
     ///
     /// This architecture enables pipeline overlap: delta computation continues
     /// while previously completed results are reordered and written to disk.
@@ -176,11 +181,11 @@ impl DeltaConsumer {
     /// and deliver results in arrival order, bypassing reordering.
     ///
     /// Identical to [`spawn`](Self::spawn) except the internal
-    /// [`ReorderBuffer`] operates in passthrough mode. Items are forwarded
-    /// to the consumer in the order they complete rather than submission
-    /// order. This eliminates reorder overhead when strict file-list
-    /// ordering is unnecessary - for example, when `--delay-updates` is
-    /// off and files are committed immediately.
+    /// [`ReorderBuffer`](super::reorder::ReorderBuffer) operates in
+    /// passthrough mode. Items are forwarded to the consumer in the order
+    /// they complete rather than submission order. This eliminates reorder
+    /// overhead when strict file-list ordering is unnecessary - for example,
+    /// when `--delay-updates` is off and files are committed immediately.
     #[must_use]
     pub fn spawn_bypass(rx: WorkQueueReceiver) -> Self {
         spawn_inner(rx, ReorderMode::Bypass)

--- a/crates/engine/src/concurrent_delta/mod.rs
+++ b/crates/engine/src/concurrent_delta/mod.rs
@@ -170,23 +170,16 @@
 //! - `transfer::pipeline` for the pipelined receiver architecture
 
 pub mod adaptive;
-/// Runtime configuration for the concurrent delta pipeline.
 pub mod config;
-/// Ordered consumer that drains the work queue into the reorder buffer.
 pub mod consumer;
 #[cfg(test)]
 mod multi_producer_audit;
-/// Parallel receive-side delta apply scaffold gated behind `parallel-receive-delta`.
 #[cfg(feature = "parallel-receive-delta")]
 pub mod parallel_apply;
-/// Sequence-based reorder buffer for the concurrent delta pipeline.
 pub mod reorder;
-/// Bounded-memory spill-to-tempfile layer for the reorder buffer.
 pub mod spill;
-/// Strategy pattern dispatching whole-file versus delta-transfer work.
 pub mod strategy;
 mod types;
-/// Bounded work queue with backpressure for the concurrent delta pipeline.
 pub mod work_queue;
 
 pub use adaptive::{AdaptiveCapacityPolicy, ReorderStats};

--- a/crates/engine/src/concurrent_delta/parallel_apply.rs
+++ b/crates/engine/src/concurrent_delta/parallel_apply.rs
@@ -123,7 +123,7 @@ impl From<ParallelApplyError> for io::Error {
 /// per-file sequence number assigned at submission time.
 ///
 /// Chunks are CPU-light at this stage; the heavy step is the strong-checksum
-/// rollup that [`ParallelDeltaApplier::verify_chunk`] runs on a rayon
+/// rollup that `ParallelDeltaApplier::verify_chunk` runs on a rayon
 /// worker.
 #[derive(Debug, Clone)]
 pub struct DeltaChunk {

--- a/crates/engine/src/concurrent_delta/reorder/mod.rs
+++ b/crates/engine/src/concurrent_delta/reorder/mod.rs
@@ -13,8 +13,8 @@
 //! many subsequent items.
 //!
 //! Optionally, a caller can compose an
-//! [`AdaptiveCapacityPolicy`](super::adaptive::AdaptiveCapacityPolicy) into
-//! the buffer via [`ReorderBuffer::with_adaptive_policy`]. The buffer then
+//! [`AdaptiveCapacityPolicy`] into the buffer via
+//! [`ReorderBuffer::with_adaptive_policy`]. The buffer then
 //! grows under sustained pressure and shrinks back toward the policy's
 //! minimum once the gap closes, all while preserving the same public API.
 //!
@@ -30,7 +30,6 @@ use std::time::{Duration, Instant};
 
 use super::adaptive::{AdaptiveCapacityPolicy, AdaptiveState, ReorderStats};
 
-/// Bucketed histograms for reorder-buffer diagnostics.
 pub mod histogram;
 
 pub use histogram::HistogramStats;
@@ -258,7 +257,7 @@ impl<T> ReorderBuffer<T> {
     }
 
     /// Creates a reorder buffer governed by an
-    /// [`AdaptiveCapacityPolicy`](super::adaptive::AdaptiveCapacityPolicy).
+    /// [`AdaptiveCapacityPolicy`].
     ///
     /// The buffer starts at `policy.min` slots and resizes between `min` and
     /// `max` based on observed pressure. See [`AdaptiveCapacityPolicy`] for

--- a/crates/engine/src/concurrent_delta/spill/mod.rs
+++ b/crates/engine/src/concurrent_delta/spill/mod.rs
@@ -63,13 +63,9 @@ mod error;
 
 pub use error::SpillError;
 
-/// Environment-variable overrides for [`SpillPolicy`] fields at runtime.
 pub mod env;
-/// Public policy types that configure the reorder buffer spill layer.
 pub mod policy;
-/// RSS sampling helpers that back the `memory_pressure_bytes` policy knob.
 pub mod rss;
-/// Spill-layer counters and aggregate stats exposed to operators.
 pub mod stats;
 pub use env::{
     ENV_SPILL_COMPRESSION, ENV_SPILL_DIR, ENV_SPILL_THRESHOLD_BYTES, apply_env_overrides,

--- a/crates/engine/src/concurrent_delta/spill/policy.rs
+++ b/crates/engine/src/concurrent_delta/spill/policy.rs
@@ -16,7 +16,8 @@
 //! deliberately additive: today only the defaults are wired through the
 //! consumer pipeline, and the alternatives reserve syntactic room for
 //! follow-up work without forcing another public API break. The
-//! [`SpillReclaim`] knob is wired through [`SpillableReorderBuffer`] and
+//! [`SpillReclaim`] knob is wired through
+//! [`SpillableReorderBuffer`](super::SpillableReorderBuffer) and
 //! controls whether the buffer re-spills in-memory residue after each
 //! reload-from-disk delivery. Tests below pin the defaults so downstream
 //! crates can rely on the contract.

--- a/crates/engine/src/concurrent_delta/spill/rss.rs
+++ b/crates/engine/src/concurrent_delta/spill/rss.rs
@@ -10,15 +10,15 @@
 //!
 //! - **Linux**: parses `/proc/self/statm`, multiplying the second field
 //!   (resident pages) by the page size obtained from `sysconf(_SC_PAGESIZE)`
-//!   via [`page_size()`]. No `unsafe` is required because the file is plain
-//!   text and the page size is read through the safe `rustix` shim already
-//!   used elsewhere in the workspace - failing that, the well-known 4096
-//!   fallback applies.
+//!   via `rustix::param::page_size`. No `unsafe` is required because the
+//!   file is plain text and the page size is read through the safe `rustix`
+//!   shim already used elsewhere in the workspace - failing that, the
+//!   well-known 4096 fallback applies.
 //! - **macOS**: stubbed at `Ok(0)` so the knob is a no-op until a follow-up
 //!   wires `mach_task_basic_info`. The byte-budget path continues to work
 //!   exactly as it does today. See `#2340` follow-up scope.
 //! - **Other Unix / Windows**: returns
-//!   [`io::ErrorKind::Unsupported`](std::io::ErrorKind::Unsupported); the
+//!   [`std::io::ErrorKind::Unsupported`]; the
 //!   buffer treats the error as "RSS unavailable" and falls back to the
 //!   byte-budget knob.
 //!

--- a/crates/engine/src/concurrent_delta/strategy.rs
+++ b/crates/engine/src/concurrent_delta/strategy.rs
@@ -75,9 +75,10 @@ pub trait DeltaStrategy: Send + Sync {
     ///
     /// # Errors
     ///
-    /// Returns a [`DeltaResult`] with [`DeltaResultStatus::Failed`] or
-    /// [`DeltaResultStatus::NeedsRedo`] when the operation cannot complete
-    /// successfully.
+    /// Returns a [`DeltaResult`] with
+    /// [`DeltaResultStatus::Failed`](super::types::DeltaResultStatus::Failed) or
+    /// [`DeltaResultStatus::NeedsRedo`](super::types::DeltaResultStatus::NeedsRedo)
+    /// when the operation cannot complete successfully.
     fn process(&self, work: &DeltaWork) -> DeltaResult;
 
     /// Returns the transfer kind this strategy handles.

--- a/crates/engine/src/concurrent_delta/types.rs
+++ b/crates/engine/src/concurrent_delta/types.rs
@@ -162,8 +162,8 @@ impl DeltaWork {
     ///
     /// Unlike [`DeltaWork::delta`], this constructor stores both the basis and
     /// the source paths, enabling
-    /// [`DeltaTransferStrategy::process`](super::strategy::DeltaTransferStrategy::process)
-    /// to run the full [`DeltaGenerator`](matching::DeltaGenerator) pipeline:
+    /// [`DeltaTransferStrategy`](super::strategy::DeltaTransferStrategy) to
+    /// run the full [`DeltaGenerator`](matching::DeltaGenerator) pipeline:
     /// signature generation from the basis, rolling+strong checksum block
     /// matching against the source, literal/COPY token emission, and applied
     /// script written to the destination. Returned stats reflect the actual

--- a/crates/engine/src/concurrent_delta/work_queue/mod.rs
+++ b/crates/engine/src/concurrent_delta/work_queue/mod.rs
@@ -1,6 +1,7 @@
 //! Bounded work queue for the concurrent delta pipeline.
 //!
-//! Prevents OOM by limiting the number of in-flight [`DeltaWork`] items.
+//! Prevents OOM by limiting the number of in-flight
+//! [`DeltaWork`](super::DeltaWork) items.
 //! The producer side blocks when the queue is full, applying backpressure
 //! to the generator/receiver that feeds work items. The consumer side
 //! drains items in parallel via [`WorkQueueReceiver::drain_parallel`],
@@ -11,8 +12,9 @@
 //! # SPMC (Single-Producer, Multiple-Consumer) Design
 //!
 //! This module assumes a Single-Producer Multiple-Consumer pattern. A single
-//! producer thread (the generator or receiver) feeds [`DeltaWork`] items into
-//! the queue, and multiple rayon worker threads consume them in parallel.
+//! producer thread (the generator or receiver) feeds
+//! [`DeltaWork`](super::DeltaWork) items into the queue, and multiple rayon
+//! worker threads consume them in parallel.
 //!
 //! This is SPMC rather than MPMC because the rsync wire protocol is inherently
 //! single-threaded on the receiving side - one multiplexed stream delivers file
@@ -99,7 +101,6 @@ mod bounded;
 mod capacity;
 mod drain;
 mod iter;
-/// AIMD adaptive-concurrency limiter for the work queue.
 pub mod limiter;
 #[cfg(feature = "multi-producer")]
 mod multi_producer;

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -128,7 +128,6 @@
 #[cfg_attr(docsrs, doc(cfg(feature = "async")))]
 pub mod async_io;
 
-/// Concurrent delta computation pipeline for parallel file processing.
 pub mod concurrent_delta;
 /// Parallel-deterministic delete pipeline data structures and emitter.
 pub mod delete;


### PR DESCRIPTION
## Summary

- Drops the redundant `///` outer-doc shadows on `pub mod X;` lines whose target submodule already carries a `//!` inner doc. The shadow lines re-attach the submodule's docs to the parent scope, narrowing intra-doc link resolution to types not visible there.
- Re-anchors a handful of links whose short paths were ambiguous outside the defining module (`DeltaResultStatus`, `DeltaTransferStrategy`, `SpillableReorderBuffer`, `WorkQueueReceiver`, `DeltaWork`).
- De-links references to private items (`spawn`, `loops`, `ParallelDeltaApplier::verify_chunk`) that should not appear in public rustdoc, and removes a stale link to a private `page_size` helper.
- Drops two redundant explicit link targets flagged by rustdoc.

Net effect for `cargo doc -p engine --no-deps --all-features`:

| Metric | Before | After | Delta |
|---|---|---|---|
| Errors | 54 | 16 | -38 |
| Warnings | 14 | 12 | -2 |

All remaining errors and warnings live outside `crates/engine/src/concurrent_delta/` (under `delete/`, `local_copy/`, and `util/`) and are tracked separately. They follow the same outer-doc-shadow pattern and can be cleaned up in a focused follow-up.

## Deferred

- `crates/engine/src/lib.rs:132` shadow above `pub mod delete;` and the cascade of broken `DeletePlan`, `DeletePlanMap`, `DirTraversalCursor`, etc. links it causes (11 errors) - out of scope.
- `crates/engine/src/lib.rs:142` shadow above `pub mod util;` and the `[poison]` link error it triggers (1 error) - out of scope.
- `crates/engine/src/delete/mod.rs:36` shadow above `pub mod emitter;` (4 errors) - out of scope.
- Private-item warnings under `delete/`, `local_copy/buffer_pool/`, and `local_copy/options/` (~10 warnings) - require API surface decisions, not pure doc edits.

## Test plan

- [ ] CI fmt+clippy
- [ ] CI nextest (stable)
- [ ] CI Windows / macOS / Linux musl