### PR TITLE
test(daemon): use env::temp_dir() for module-list test fixtures

### DIFF
--- a/crates/daemon/src/tests/chunks/daemon_negotiation_module_listing.rs
+++ b/crates/daemon/src/tests/chunks/daemon_negotiation_module_listing.rs
@@ -13,13 +13,14 @@ fn daemon_negotiation_module_list_sends_capabilities_before_ok() {
 
     let (port, held_listener) = allocate_test_port();
 
+    let module_path = std::env::temp_dir();
     let config = DaemonConfig::builder()
         .disable_default_paths()
         .arguments([
             OsString::from("--port"),
             OsString::from(port.to_string()),
             OsString::from("--module"),
-            OsString::from("test=/tmp"),
+            OsString::from(format!("test={}", module_path.display())),
             OsString::from("--once"),
         ])
         .build();
@@ -146,13 +147,14 @@ fn daemon_negotiation_module_list_includes_comments() {
 
     let (port, held_listener) = allocate_test_port();
 
+    let module_path = std::env::temp_dir();
     let config = DaemonConfig::builder()
         .disable_default_paths()
         .arguments([
             OsString::from("--port"),
             OsString::from(port.to_string()),
             OsString::from("--module"),
-            OsString::from("mymod=/tmp,This is a comment"),
+            OsString::from(format!("mymod={},This is a comment", module_path.display())),
             OsString::from("--once"),
         ])
         .build();


### PR DESCRIPTION
## Summary

Two daemon-listing tests passed the literal string `/tmp` as the `--module name=PATH` argument. On Windows this path doesn't exist, the daemon refuses to start the listed module, and the test then panics on the very first `read_line` waiting for the daemon's greeting (the daemon never sends one).

Switch both call sites to `std::env::temp_dir()`, which returns a platform-appropriate writable directory on all targets.

This clears the chronic Windows feature-flag failures for:
- `daemon_negotiation_module_list_sends_capabilities_before_ok`
- `daemon_negotiation_module_list_includes_comments`

Other `/tmp` literals in the daemon test tree are in tests that only parse args without starting a daemon (`builder_collects_arguments`, `runtime_options_reject_duplicate_*`, `runtime_options_loads_temp_dir_from_config`), so they are unaffected by this and pass on Windows already.

## Test plan
- [x] Linux required CI passes
- [x] Windows feature-flag cells stop failing on the two listed tests
- [x] macOS required CI passes