### PR TITLE
test(daemon): normalise Windows temp paths for --module fixtures

### DIFF
--- a/crates/daemon/src/tests/chunks/daemon_negotiation_module_listing.rs
+++ b/crates/daemon/src/tests/chunks/daemon_negotiation_module_listing.rs
@@ -13,14 +13,17 @@ fn daemon_negotiation_module_list_sends_capabilities_before_ok() {
 
     let (port, held_listener) = allocate_test_port();
 
-    let module_path = std::env::temp_dir();
+    // Normalise to forward slashes for symmetry with the comment-bearing test
+    // below; Windows accepts forward slashes, and this avoids any future
+    // Windows-only parser surprises around `\` as an escape character.
+    let module_path = std::env::temp_dir().display().to_string().replace('\\', "/");
     let config = DaemonConfig::builder()
         .disable_default_paths()
         .arguments([
             OsString::from("--port"),
             OsString::from(port.to_string()),
             OsString::from("--module"),
-            OsString::from(format!("test={}", module_path.display())),
+            OsString::from(format!("test={module_path}")),
             OsString::from("--once"),
         ])
         .build();
@@ -147,14 +150,19 @@ fn daemon_negotiation_module_list_includes_comments() {
 
     let (port, held_listener) = allocate_test_port();
 
-    let module_path = std::env::temp_dir();
+    // The --module value uses `\` as an escape character, so on Windows we
+    // normalise the temp-dir path to forward slashes (which Windows accepts
+    // natively) to keep the comma separator that delimits the comment from
+    // being swallowed by the escape state machine in
+    // `daemon::sections::module_parsing::split_module_path_comment_and_options`.
+    let module_path = std::env::temp_dir().display().to_string().replace('\\', "/");
     let config = DaemonConfig::builder()
         .disable_default_paths()
         .arguments([
             OsString::from("--port"),
             OsString::from(port.to_string()),
             OsString::from("--module"),
-            OsString::from(format!("mymod={},This is a comment", module_path.display())),
+            OsString::from(format!("mymod={module_path},This is a comment")),
             OsString::from("--once"),
         ])
         .build();


### PR DESCRIPTION
## Summary

The daemon's `--module` value parser (`daemon::sections::module_parsing::split_module_path_comment_and_options`) treats `\\` as an escape character so that `\\,` and `\;` can appear literally inside paths.

On Windows, `env::temp_dir()` returns a path full of unescaped backslashes (e.g. `C:\\Users\\runneradmin\\AppData\\Local\\Temp\\`). When passed through the escape state machine, the trailing `\\` swallows the following `,`, so the parser reads the entire string \`mymod=C:\\Users\\...\\Temp\\,This is a comment\` as the module path with no comment field. The daemon then fails to start the module, and the test panics waiting for the daemon greeting on the very first `read_line`.

Normalise the temp-dir path to forward slashes in both:
- `daemon_negotiation_module_list_sends_capabilities_before_ok`
- `daemon_negotiation_module_list_includes_comments`

Windows accepts forward slashes natively in paths, and the parser passes the path through unchanged when there are no backslashes to escape.

Follow-up to #4559 (the previous fix replaced the unconditional `/tmp` literal with `env::temp_dir()` but didn't account for the escape semantics on Windows-shaped paths).

## Test plan
- [x] Linux required CI passes
- [x] macOS required CI passes
- [x] Windows feature-flag cells stop failing on `daemon_negotiation_module_list_includes_comments`