### PR TITLE
docs(branding): drop restatement comments in validate_versions

### DIFF
--- a/crates/branding/build.rs
+++ b/crates/branding/build.rs
@@ -235,10 +235,7 @@ impl WorkspaceMetadata {
     }
 
     fn validate_versions(&self, manifest_path: &Path) {
-        // Parse upstream_version to ensure it's valid x.y.z format
         parse_version(&self.upstream_version, manifest_path, "upstream_version");
-
-        // Parse rust_version to ensure it's valid x.y.z format
         parse_version(&self.rust_version, manifest_path, "rust_version");
     }
 


### PR DESCRIPTION
## Summary
- Removes two restatement comments in `crates/branding/build.rs` that merely echoed the adjacent `parse_version` calls in `WorkspaceMetadata::validate_versions`.
- Comment-only change; no behaviour, signatures, or test expectations are touched.

## Test plan
- [ ] CI: fmt + clippy
- [ ] CI: nextest (stable)
- [ ] CI: Windows, macOS, Linux musl