### PR TITLE
test(protocol): fix stress_long_paths_10k roundtrip on Windows

### DIFF
--- a/crates/engine/src/local_copy/executor/file/copy/transfer/execute/clonefile.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/execute/clonefile.rs
@@ -6,9 +6,8 @@
 //!
 //! The fast-path dispatcher and metadata normalizer live here together so
 //! the eligibility checks, dispatch, and post-clone bookkeeping all evolve
-//! as a single concern.
-
-#![cfg(target_os = "macos")]
+//! as a single concern. The parent `mod.rs` already gates this module on
+//! `target_os = "macos"`, so no inner `#![cfg(...)]` is needed.
 
 use std::fs;
 use std::path::Path;

--- a/crates/protocol/tests/flist_stress_tests.rs
+++ b/crates/protocol/tests/flist_stress_tests.rs
@@ -517,8 +517,7 @@ fn stress_long_paths_10k() {
         .map(|i| {
             let segment = format!("d{i:06}");
             let depth = 100; // ~800 bytes at 8 bytes/segment
-            let mut path_str = std::iter::repeat(segment.as_str())
-                .take(depth)
+            let mut path_str = std::iter::repeat_n(segment.as_str(), depth)
                 .collect::<Vec<_>>()
                 .join("/");
             path_str.push('/');

--- a/crates/protocol/tests/flist_stress_tests.rs
+++ b/crates/protocol/tests/flist_stress_tests.rs
@@ -508,16 +508,22 @@ fn stress_varied_types_10k() {
 /// Tests entries with maximum path lengths.
 #[test]
 fn stress_long_paths_10k() {
-    // Generate entries with near-maximum path lengths (4096 bytes is typical limit)
+    // Generate entries with near-maximum path lengths (4096 bytes is typical limit).
+    // Build directory components as an explicit `/`-delimited String to match the
+    // wire format's separator, otherwise PathBuf::join on Windows inserts `\`
+    // and the post-roundtrip name comparison would fail (the encoder normalises
+    // to `/`, the in-memory path used `\`).
     let entries: Vec<_> = (0..10_000)
         .map(|i| {
             let segment = format!("d{i:06}");
             let depth = 100; // ~800 bytes at 8 bytes/segment
-            let path: PathBuf = (0..depth)
-                .map(|_| segment.as_str())
-                .collect::<PathBuf>()
-                .join(format!("file_{i:06}.txt"));
-            FileEntry::new_file(path, i as u64, 0o644)
+            let mut path_str = std::iter::repeat(segment.as_str())
+                .take(depth)
+                .collect::<Vec<_>>()
+                .join("/");
+            path_str.push('/');
+            path_str.push_str(&format!("file_{i:06}.txt"));
+            FileEntry::new_file(PathBuf::from(path_str), i as u64, 0o644)
         })
         .collect();
 


### PR DESCRIPTION
## Summary
Same root cause as PR #4561 fixed for \`generate_mock_entries\` and \`generate_mixed_tree\`: on Windows \`PathBuf::join\` inserts \`\\\`, the wire encoder normalises to \`/\`, and the post-roundtrip name comparison at \`crates/protocol/tests/flist_stress_tests.rs:541\` fails with \`"dir\\\\file"\` vs \`"dir/file"\`.

Build the directory path as an explicit \`/\`-delimited \`String\` so the in-memory and on-wire forms match.

## Test plan
- [x] Linux required CI passes
- [x] macOS required CI passes
- [x] Windows feature-flag cells stop failing on \`stress_long_paths_10k\`