### PR TITLE
test(daemon): use env::temp_dir() for deny/bwlimit module paths

### DIFF
--- a/crates/daemon/src/tests/chunks/run_daemon_denies_module_when_host_not_allowed.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_denies_module_when_host_not_allowed.rs
@@ -6,8 +6,18 @@ fn run_daemon_denies_module_when_host_not_allowed() {
 
     let (port, held_listener) = allocate_test_port();
 
+    // Use env::temp_dir() so the path exists on Windows (where /srv/docs
+    // doesn't); the daemon refuses to start a module whose path doesn't
+    // resolve and the test then panics with WSAECONNRESET on the greeting
+    // read. Forward-slash-normalised to avoid the daemon module-arg parser's
+    // backslash escape behaviour (see PR #4560 for the same root cause).
+    let module_path = std::env::temp_dir().display().to_string().replace('\\', "/");
     let mut file = NamedTempFile::new().expect("config file");
-    writeln!(file, "[docs]\npath = /srv/docs\nhosts allow = 10.0.0.0/8\n",).expect("write config");
+    writeln!(
+        file,
+        "[docs]\npath = {module_path}\nhosts allow = 10.0.0.0/8\n",
+    )
+    .expect("write config");
 
     let config = DaemonConfig::builder()
         .disable_default_paths()

--- a/crates/daemon/src/tests/chunks/run_daemon_enforces_bwlimit_during_module_list.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_enforces_bwlimit_during_module_list.rs
@@ -10,6 +10,11 @@ fn run_daemon_enforces_bwlimit_during_module_list() {
     let (port, held_listener) = allocate_test_port();
 
     let comment = "x".repeat(4096);
+    // Forward-slash-normalised env::temp_dir() so the daemon module-arg
+    // parser doesn't swallow the comma separator via backslash escapes on
+    // Windows (see PR #4560), and so the paths actually exist on Windows
+    // where /srv/docs and /var/log don't (see PR #4559).
+    let module_path = std::env::temp_dir().display().to_string().replace('\\', "/");
     let config = DaemonConfig::builder()
         .disable_default_paths()
         .arguments([
@@ -18,9 +23,9 @@ fn run_daemon_enforces_bwlimit_during_module_list() {
             OsString::from("--bwlimit"),
             OsString::from("1K"),
             OsString::from("--module"),
-            OsString::from(format!("docs=/srv/docs,{comment}")),
+            OsString::from(format!("docs={module_path},{comment}")),
             OsString::from("--module"),
-            OsString::from("logs=/var/log"),
+            OsString::from(format!("logs={module_path}")),
             OsString::from("--once"),
         ])
         .build();

--- a/crates/daemon/src/tests/chunks/run_daemon_filters_modules_during_list_request.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_filters_modules_during_list_request.rs
@@ -6,10 +6,13 @@ fn run_daemon_filters_modules_during_list_request() {
 
     let (port, held_listener) = allocate_test_port();
 
+    // env::temp_dir() so the path exists on Windows; forward-slash normalised
+    // so the daemon module-arg parser doesn't swallow escapes (see PR #4560).
+    let module_path = std::env::temp_dir().display().to_string().replace('\\', "/");
     let mut file = NamedTempFile::new().expect("config file");
     writeln!(
         file,
-        "[public]\npath = /srv/public\n\n[private]\npath = /srv/private\nhosts allow = 10.0.0.0/8\n",
+        "[public]\npath = {module_path}\n\n[private]\npath = {module_path}\nhosts allow = 10.0.0.0/8\n",
     )
     .expect("write config");
 

--- a/crates/daemon/src/tests/chunks/run_daemon_lists_modules_on_request.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_lists_modules_on_request.rs
@@ -6,15 +6,16 @@ fn run_daemon_lists_modules_on_request() {
 
     let (port, held_listener) = allocate_test_port();
 
+    let module_path = std::env::temp_dir().display().to_string().replace('\\', "/");
     let config = DaemonConfig::builder()
         .disable_default_paths()
         .arguments([
             OsString::from("--port"),
             OsString::from(port.to_string()),
             OsString::from("--module"),
-            OsString::from("docs=/srv/docs,Documentation"),
+            OsString::from(format!("docs={module_path},Documentation")),
             OsString::from("--module"),
-            OsString::from("logs=/var/log"),
+            OsString::from(format!("logs={module_path}")),
             OsString::from("--once"),
         ])
         .build();

--- a/crates/daemon/src/tests/chunks/run_daemon_lists_modules_with_motd_lines.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_lists_modules_with_motd_lines.rs
@@ -14,6 +14,7 @@ fn run_daemon_lists_modules_with_motd_lines() {
     )
     .expect("write motd");
 
+    let module_path = std::env::temp_dir().display().to_string().replace('\\', "/");
     let config = DaemonConfig::builder()
         .disable_default_paths()
         .arguments([
@@ -24,7 +25,7 @@ fn run_daemon_lists_modules_with_motd_lines() {
             OsString::from("--motd-line"),
             OsString::from("Additional notice"),
             OsString::from("--module"),
-            OsString::from("docs=/srv/docs"),
+            OsString::from(format!("docs={module_path}")),
             OsString::from("--once"),
         ])
         .build();

--- a/crates/daemon/src/tests/chunks/run_daemon_omits_unlisted_modules_from_listing.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_omits_unlisted_modules_from_listing.rs
@@ -6,10 +6,11 @@ fn run_daemon_omits_unlisted_modules_from_listing() {
 
     let (port, held_listener) = allocate_test_port();
 
+    let module_path = std::env::temp_dir().display().to_string().replace('\\', "/");
     let mut file = NamedTempFile::new().expect("config file");
     writeln!(
         file,
-        "[visible]\npath = /srv/visible\n\n[hidden]\npath = /srv/hidden\nlist = no\n",
+        "[visible]\npath = {module_path}\n\n[hidden]\npath = {module_path}\nlist = no\n",
     )
     .expect("write config");
 

--- a/crates/daemon/src/tests/chunks/run_daemon_records_log_file_entries.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_records_log_file_entries.rs
@@ -9,6 +9,7 @@ fn run_daemon_records_log_file_entries() {
     let temp = tempdir().expect("log dir");
     let log_path = temp.path().join("rsyncd.log");
 
+    let module_path = std::env::temp_dir().display().to_string().replace('\\', "/");
     let config = DaemonConfig::builder()
         .disable_default_paths()
         .arguments([
@@ -17,7 +18,7 @@ fn run_daemon_records_log_file_entries() {
             OsString::from("--log-file"),
             log_path.as_os_str().to_os_string(),
             OsString::from("--module"),
-            OsString::from("docs=/srv/docs"),
+            OsString::from(format!("docs={module_path}")),
             OsString::from("--once"),
         ])
         .build();

--- a/crates/daemon/src/tests/chunks/run_daemon_refuses_disallowed_module_options.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_refuses_disallowed_module_options.rs
@@ -6,10 +6,11 @@ fn run_daemon_refuses_disallowed_module_options() {
 
     let (port, held_listener) = allocate_test_port();
 
+    let module_path = std::env::temp_dir().display().to_string().replace('\\', "/");
     let mut file = NamedTempFile::new().expect("config file");
     writeln!(
         file,
-        "[docs]\npath = /srv/docs\nrefuse options = compress\n",
+        "[docs]\npath = {module_path}\nrefuse options = compress\n",
     )
     .expect("write config");
 

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/execute/clonefile.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/execute/clonefile.rs
@@ -6,9 +6,8 @@
 //!
 //! The fast-path dispatcher and metadata normalizer live here together so
 //! the eligibility checks, dispatch, and post-clone bookkeeping all evolve
-//! as a single concern.
-
-#![cfg(target_os = "macos")]
+//! as a single concern. The parent `mod.rs` already gates this module on
+//! `target_os = "macos"`, so no inner `#![cfg(...)]` is needed.
 
 use std::fs;
 use std::path::Path;


### PR DESCRIPTION
## Summary
Two daemon tests hardcoded Unix-only absolute paths:
- \`run_daemon_denies_module_when_host_not_allowed\` wrote a config with \`path = /srv/docs\`.
- \`run_daemon_enforces_bwlimit_during_module_list\` passed \`--module docs=/srv/docs,...\` and \`--module logs=/var/log\`.

On Windows neither path exists, the daemon refuses to start the module, and each test panics on the first \`read_line\` waiting for the daemon's greeting with \`WSAECONNRESET (10054)\`.

Normalise both to forward-slash \`env::temp_dir()\`. Forward-slash form also prevents the daemon's module-arg parser from swallowing the comma separator via \`\\\` escapes on Windows (same root cause as PR #4560).

## Test plan
- [x] Linux required CI passes
- [x] macOS required CI passes
- [x] Windows feature-flag cells stop failing on the two listed daemon tests