### PR TITLE
docs(embedding): drop restatement comments in lib and example

### DIFF
--- a/crates/embedding/examples/server_stdio.rs
+++ b/crates/embedding/examples/server_stdio.rs
@@ -10,8 +10,6 @@ use embedding::{ServerConfig, ServerRole, ServerStats, run_server_with_config};
 use std::io;
 
 fn main() {
-    // Parse server configuration from command-line arguments or construct programmatically
-    // This example uses typical server flag string for a receiver
     let config = match ServerConfig::from_flag_string_and_args(
         ServerRole::Receiver,
         "-logDtpre.iLsfxC".to_owned(),
@@ -29,8 +27,7 @@ fn main() {
     eprintln!("[example] Arguments: {:?}", config.args);
     eprintln!("[example] Waiting for client connection on stdin...");
 
-    // Run server with stdio
-    // In production, stdin/stdout would be connected to SSH or other transport
+    // In production, stdin/stdout would be connected to SSH or other transport.
     let mut stdin = io::stdin();
     let mut stdout = io::stdout();
 

--- a/crates/embedding/src/lib.rs
+++ b/crates/embedding/src/lib.rs
@@ -434,8 +434,6 @@ mod tests {
         ];
         let _error = run_server(args).expect_err("server requires protocol data on stdin");
 
-        // Capture-mode embedding: should report non-zero exit and route
-        // all diagnostics to stderr, leaving stdout empty.
         let error = run_server(args).expect_err("server mode reports usage");
         // Server may return various error codes depending on where it fails
         // (1 for usage errors, 12 for protocol errors, etc.)
@@ -450,11 +448,9 @@ mod tests {
             output.stderr().iter().any(|b| *b != 0),
             "stderr should contain non-empty diagnostics"
         );
-        // Stream-based embedding: same semantics as above.
         let mut stdout = Vec::new();
         let mut stderr = Vec::new();
         let status = run_server_with(args, &mut stdout, &mut stderr).unwrap_err();
-        // Server may return various error codes depending on where it fails
         assert_ne!(
             status.exit_status(),
             0,


### PR DESCRIPTION
## Summary
- Remove restatement comments in the embedding crate (config-construction commentary in the stdio example, capture/stream-mode test commentary, duplicate error-code remarks).
- Preserve SAFETY notes on env-mutation, the why-not-thiserror rationale, and the production-SSH context note in the example.
- Comment-only changes; no logic or API touched.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings`
- [ ] CI green