### PR TITLE
docs(bandwidth): drop banner and restatement comments

### DIFF
--- a/crates/bandwidth/src/limiter/core/tests.rs
+++ b/crates/bandwidth/src/limiter/core/tests.rs
@@ -9,7 +9,6 @@ fn nz(value: u64) -> NonZeroU64 {
     NonZeroU64::new(value).expect("non-zero value required")
 }
 
-// Tests for calculate_write_max
 #[test]
 fn calculate_write_max_small_limit_uses_minimum() {
     let result = calculate_write_max(nz(100), None);
@@ -40,7 +39,6 @@ fn calculate_write_max_with_small_burst_uses_minimum() {
     assert_eq!(result, MIN_WRITE_MAX);
 }
 
-// Tests for BandwidthLimiter::new
 #[test]
 fn bandwidth_limiter_new_stores_limit() {
     let limiter = BandwidthLimiter::new(nz(10000));
@@ -59,7 +57,6 @@ fn bandwidth_limiter_new_initializes_counters() {
     assert_eq!(limiter.accumulated_debt_for_testing(), 0);
 }
 
-// Tests for BandwidthLimiter::with_burst
 #[test]
 fn bandwidth_limiter_with_burst_stores_both() {
     let limiter = BandwidthLimiter::with_burst(nz(10000), Some(nz(5000)));
@@ -75,7 +72,6 @@ fn bandwidth_limiter_with_burst_none_is_same_as_new() {
     assert_eq!(limiter1.burst_bytes(), limiter2.burst_bytes());
 }
 
-// Tests for update_limit
 #[test]
 fn update_limit_changes_limit() {
     let mut limiter = BandwidthLimiter::new(nz(10000));
@@ -98,7 +94,6 @@ fn update_limit_preserves_burst() {
     assert_eq!(limiter.burst_bytes().unwrap().get(), 5000);
 }
 
-// Tests for update_configuration
 #[test]
 fn update_configuration_changes_both() {
     let mut limiter = BandwidthLimiter::new(nz(10000));
@@ -122,7 +117,6 @@ fn update_configuration_resets_counters() {
     assert_eq!(limiter.accumulated_debt_for_testing(), 0);
 }
 
-// Tests for reset
 #[test]
 fn reset_clears_debt() {
     let mut limiter = BandwidthLimiter::new(nz(10000));
@@ -140,7 +134,6 @@ fn reset_preserves_configuration() {
     assert_eq!(limiter.burst_bytes().unwrap().get(), 5000);
 }
 
-// Tests for accessor methods
 #[test]
 fn limit_bytes_returns_configured_limit() {
     let limiter = BandwidthLimiter::new(nz(12345));
@@ -183,7 +176,6 @@ fn recommended_read_size_handles_empty_buffer() {
     assert_eq!(limiter.recommended_read_size(0), 0);
 }
 
-// Tests for register
 #[test]
 fn register_zero_bytes_is_noop() {
     let mut limiter = BandwidthLimiter::new(nz(10000));
@@ -212,7 +204,6 @@ fn register_with_burst_clamps_debt() {
     assert!(limiter.accumulated_debt_for_testing() <= 1000);
 }
 
-// Tests for Clone and Debug traits
 #[test]
 fn bandwidth_limiter_clone_creates_independent_copy() {
     let mut limiter = BandwidthLimiter::new(nz(10000));

--- a/crates/bandwidth/src/limiter/tests/aimd_convergence.rs
+++ b/crates/bandwidth/src/limiter/tests/aimd_convergence.rs
@@ -67,9 +67,7 @@ fn measure_rate(limiter: &mut BandwidthLimiter, rate: u64, chunks: usize) -> f64
     observed_rate(bytes, sleep)
 }
 
-// ---------------------------------------------------------------------------
 // Convergence to target under no errors
-// ---------------------------------------------------------------------------
 
 #[test]
 fn aimd_no_error_stream_oscillates_near_target_after_warmup() {
@@ -96,9 +94,7 @@ fn aimd_no_error_stream_oscillates_near_target_after_warmup() {
     }
 }
 
-// ---------------------------------------------------------------------------
 // Multiplicative decrease on simulated error
-// ---------------------------------------------------------------------------
 
 #[test]
 fn aimd_simulated_error_halves_effective_rate() {
@@ -169,9 +165,7 @@ fn aimd_repeated_errors_drive_rate_down_geometrically() {
     }
 }
 
-// ---------------------------------------------------------------------------
 // Recovery: additive-increase brings rate back up after error stream stops
-// ---------------------------------------------------------------------------
 
 #[test]
 fn aimd_additive_increase_recovers_rate_after_error_stream_ends() {
@@ -251,9 +245,7 @@ fn aimd_decrease_then_recover_returns_to_initial_target() {
     );
 }
 
-// ---------------------------------------------------------------------------
 // Stability under intermittent errors
-// ---------------------------------------------------------------------------
 
 #[test]
 fn aimd_intermittent_errors_do_not_cause_runaway_oscillation() {
@@ -313,9 +305,7 @@ fn aimd_intermittent_errors_do_not_cause_runaway_oscillation() {
     );
 }
 
-// ---------------------------------------------------------------------------
 // Edge case: minimum rate floor
-// ---------------------------------------------------------------------------
 
 #[test]
 fn aimd_repeated_errors_clamp_at_minimum_rate_floor() {

--- a/crates/bandwidth/src/limiter/tests/convergence.rs
+++ b/crates/bandwidth/src/limiter/tests/convergence.rs
@@ -43,9 +43,7 @@ fn observed_rate(total_bytes: u128, total_sleep: Duration) -> f64 {
     total_bytes as f64 / seconds
 }
 
-// ---------------------------------------------------------------------------
 // Steady-state convergence
-// ---------------------------------------------------------------------------
 
 #[test]
 fn steady_state_converges_to_target_rate_1kbps() {
@@ -136,9 +134,7 @@ fn steady_state_total_sleep_matches_expected_transfer_time() {
     );
 }
 
-// ---------------------------------------------------------------------------
 // Step response: change the target bandwidth suddenly
-// ---------------------------------------------------------------------------
 
 #[test]
 fn step_response_increase_converges_within_one_chunk() {
@@ -215,9 +211,7 @@ fn step_response_multiple_rate_changes_settle() {
     }
 }
 
-// ---------------------------------------------------------------------------
 // Burst handling: send a burst, verify throttle and recovery
-// ---------------------------------------------------------------------------
 
 #[test]
 fn burst_capped_limiter_recovers_to_target_rate() {
@@ -296,9 +290,7 @@ fn burst_repeated_large_writes_stay_clamped() {
     }
 }
 
-// ---------------------------------------------------------------------------
 // Multi-stream fairness: multiple independent limiters sharing a cap
-// ---------------------------------------------------------------------------
 
 #[test]
 fn multi_stream_independent_limiters_converge_individually() {
@@ -372,9 +364,7 @@ fn multi_stream_equal_shares_of_aggregate_cap() {
     }
 }
 
-// ---------------------------------------------------------------------------
 // Feedback accuracy: measured throughput matches actual throughput
-// ---------------------------------------------------------------------------
 
 #[test]
 fn feedback_accuracy_requested_sleep_matches_expected() {
@@ -427,9 +417,7 @@ fn feedback_accuracy_fractional_byte_rate() {
     assert_eq!(sleep.requested(), Duration::from_secs(1));
 }
 
-// ---------------------------------------------------------------------------
 // Underutilization: actual throughput below cap - no unnecessary throttling
-// ---------------------------------------------------------------------------
 
 #[test]
 fn underutilization_sub_threshold_writes_are_noop() {
@@ -506,9 +494,7 @@ fn underutilization_just_below_threshold_is_noop() {
     );
 }
 
-// ---------------------------------------------------------------------------
 // Zero-crossing: target bandwidth set to zero (pause) and back
-// ---------------------------------------------------------------------------
 
 #[test]
 fn zero_crossing_reset_simulates_pause_and_resume() {
@@ -585,9 +571,7 @@ fn zero_crossing_reset_preserves_configuration() {
     assert_eq!(limiter.accumulated_debt_for_testing(), 0);
 }
 
-// ---------------------------------------------------------------------------
 // Minimum granularity: very small bandwidth limits
-// ---------------------------------------------------------------------------
 
 #[test]
 fn minimum_granularity_1_byte_per_second() {
@@ -681,9 +665,7 @@ fn minimum_granularity_with_burst_cap() {
     assert!(limiter.accumulated_debt_for_testing() <= u128::from(burst));
 }
 
-// ---------------------------------------------------------------------------
 // Combined scenarios
-// ---------------------------------------------------------------------------
 
 #[test]
 fn realistic_file_transfer_with_rate_change_mid_transfer() {
@@ -809,9 +791,7 @@ fn debt_fully_cleared_after_simulated_sleep() {
     );
 }
 
-// ---------------------------------------------------------------------------
 // Very high bandwidth target: effectively unlimited throughput
-// ---------------------------------------------------------------------------
 
 #[test]
 fn high_bandwidth_target_u64_max_never_throttles() {
@@ -898,9 +878,7 @@ fn high_bandwidth_target_step_down_from_unlimited() {
     );
 }
 
-// ---------------------------------------------------------------------------
 // Idle recovery: feedback loop recovers after a prolonged idle period
-// ---------------------------------------------------------------------------
 
 #[test]
 fn idle_recovery_reset_then_resume_converges() {
@@ -986,9 +964,7 @@ fn idle_recovery_multiple_idle_resume_cycles() {
     }
 }
 
-// ---------------------------------------------------------------------------
 // Bounded convergence: verify convergence within specific iteration count
-// ---------------------------------------------------------------------------
 
 #[test]
 fn bounded_convergence_within_four_chunks() {
@@ -1047,9 +1023,7 @@ fn bounded_convergence_after_rate_change_within_two_chunks() {
     );
 }
 
-// ---------------------------------------------------------------------------
 // Stability: no oscillation when throughput matches target
-// ---------------------------------------------------------------------------
 
 #[test]
 fn stability_consecutive_sleeps_are_uniform() {
@@ -1143,9 +1117,7 @@ fn stability_variance_bounded_across_samples() {
     );
 }
 
-// ---------------------------------------------------------------------------
 // Bursty traffic: verify recovery without excessive back-pressure
-// ---------------------------------------------------------------------------
 
 #[test]
 fn bursty_traffic_large_burst_then_steady_state_converges() {
@@ -1231,9 +1203,7 @@ fn bursty_traffic_burst_cap_prevents_excessive_back_pressure() {
     }
 }
 
-// ---------------------------------------------------------------------------
 // Cross-rate convergence: verify convergence across wide range of rates
-// ---------------------------------------------------------------------------
 
 #[test]
 fn convergence_across_three_decades_of_rates() {
@@ -1259,9 +1229,7 @@ fn convergence_across_three_decades_of_rates() {
     }
 }
 
-// ---------------------------------------------------------------------------
 // Interleaved multi-stream fairness: round-robin across independent limiters
-// ---------------------------------------------------------------------------
 
 #[test]
 fn interleaved_streams_converge_independently() {
@@ -1357,9 +1325,7 @@ fn interleaved_streams_with_different_chunk_sizes() {
     }
 }
 
-// ---------------------------------------------------------------------------
 // Overshoot trajectory: verify initial burst settles toward target
-// ---------------------------------------------------------------------------
 
 #[test]
 fn overshoot_trajectory_settles_monotonically() {
@@ -1426,9 +1392,7 @@ fn overshoot_with_burst_cap_limits_initial_penalty() {
     );
 }
 
-// ---------------------------------------------------------------------------
 // Zero-byte registration: verify no corruption during zero-traffic gaps
-// ---------------------------------------------------------------------------
 
 #[test]
 fn zero_byte_registration_preserves_limiter_state() {
@@ -1501,9 +1465,7 @@ fn zero_byte_registration_with_burst_cap() {
     assert_eq!(limiter.accumulated_debt_for_testing(), debt_after_write);
 }
 
-// ---------------------------------------------------------------------------
 // Convergence after configuration with burst added/removed mid-stream
-// ---------------------------------------------------------------------------
 
 #[test]
 fn add_burst_mid_stream_clamps_existing_debt() {
@@ -1565,9 +1527,7 @@ fn remove_burst_mid_stream_allows_unbounded_debt() {
     );
 }
 
-// ---------------------------------------------------------------------------
 // Monotonic debt decay: verify debt decreases over successive registrations
-// ---------------------------------------------------------------------------
 
 #[test]
 fn debt_decreases_toward_zero_over_steady_state() {
@@ -1598,9 +1558,7 @@ fn debt_decreases_toward_zero_over_steady_state() {
     );
 }
 
-// ---------------------------------------------------------------------------
 // Rapid alternating rates: verify no accumulation of error
-// ---------------------------------------------------------------------------
 
 #[test]
 fn rapid_alternation_error_does_not_accumulate() {

--- a/crates/bandwidth/src/limiter/tests/feedback_loop_2098.rs
+++ b/crates/bandwidth/src/limiter/tests/feedback_loop_2098.rs
@@ -64,9 +64,7 @@ fn drive_until(
     WindowSample { bytes, sleep }
 }
 
-// ---------------------------------------------------------------------------
 // Test 1: steady-state convergence under 2x oversubscription
-// ---------------------------------------------------------------------------
 
 /// Feeding the limiter at >= 2x the target rate must converge throughput to
 /// within +-5% of the configured rate across a 1s sliding window.
@@ -101,9 +99,7 @@ fn steady_state_oversubscribed_converges_to_target_within_one_second_window() {
     );
 }
 
-// ---------------------------------------------------------------------------
 // Test 2: burst recovery within ~2s
-// ---------------------------------------------------------------------------
 
 /// A single instantaneous burst at 4x the per-second target must be dampened
 /// and the limiter must return to the configured rate within ~2 seconds of
@@ -157,9 +153,7 @@ fn burst_recovers_to_target_within_two_seconds() {
     );
 }
 
-// ---------------------------------------------------------------------------
 // Test 3: target change ramps without overshoot
-// ---------------------------------------------------------------------------
 
 /// Increasing the target mid-test (0.5 MB/s -> 2 MB/s) must ramp to the new
 /// rate without overshoot. The limiter resets debt on `update_limit`, so the
@@ -210,9 +204,7 @@ fn target_change_ramps_without_overshoot() {
     }
 }
 
-// ---------------------------------------------------------------------------
 // Test 4: tiny target (1 KB/s) convergence
-// ---------------------------------------------------------------------------
 
 /// Convergence must hold for very small targets where each chunk represents
 /// hundreds of milliseconds of debt. At 1 KB/s, a 256 B chunk requests

--- a/crates/bandwidth/src/parse/numeric.rs
+++ b/crates/bandwidth/src/parse/numeric.rs
@@ -120,7 +120,6 @@ fn parse_digits(bytes: &[u8]) -> Result<u128, BandwidthParseError> {
 mod tests {
     use super::*;
 
-    // Tests for pow_u128
     #[test]
     fn pow_u128_zero_exponent() {
         assert_eq!(pow_u128(10, 0).unwrap(), 1);
@@ -165,7 +164,6 @@ mod tests {
         assert_eq!(pow_u128(0, 1).unwrap(), 0);
     }
 
-    // Tests for parse_decimal_with_exponent
     #[test]
     fn parse_decimal_with_exponent_integer_only() {
         let (int, frac, denom, exp) = parse_decimal_with_exponent("12345").unwrap();
@@ -234,7 +232,6 @@ mod tests {
         assert!(result.is_err());
     }
 
-    // Tests for parse_decimal_mantissa
     #[test]
     fn parse_decimal_mantissa_integer() {
         let (int, frac, denom) = parse_decimal_mantissa("123").unwrap();
@@ -291,7 +288,6 @@ mod tests {
         assert_eq!(denom, 1);
     }
 
-    // Tests for parse_digits
     #[test]
     fn parse_digits_valid() {
         assert_eq!(parse_digits(b"12345").unwrap(), 12345);
@@ -457,8 +453,6 @@ mod tests {
 
     #[test]
     fn parse_decimal_mantissa_non_digit_in_fraction_rejected() {
-        // "1.2a3" should fail because 'a' is in the fractional part
-        // This tests line 73-74 in numeric.rs
         let result = parse_decimal_mantissa("1.2a3");
         assert!(result.is_err());
     }

--- a/crates/bandwidth/src/parse/tests/argument.rs
+++ b/crates/bandwidth/src/parse/tests/argument.rs
@@ -385,30 +385,23 @@ proptest! {
 
 #[test]
 fn parse_bandwidth_handles_adjustment_when_product_less_than_denominator() {
-    // Test the case where product < denominator with -1 adjustment
-    // This triggers the bytes = 0 path on line 221
-    // 0.0001K = 0.1024 bytes, rounds to 0, with -1 adjustment -> 0 bytes -> unlimited (None)
-    // Values below 512 that round to 0 become unlimited
+    // 0.0001K = 0.1024 bytes; with `-1` adjustment the value rounds to zero,
+    // which the parser reports as unlimited (None) rather than TooSmall.
     let result = parse_bandwidth_argument("0.0001K-1");
-    // This becomes unlimited (None) because the value rounds to 0
     assert_eq!(result.expect("should parse"), None);
 }
 
 #[test]
 fn parse_bandwidth_handles_very_small_value_with_minus_one_adjustment() {
-    // Another test case for product < denominator with -1 adjust
-    // When the value is so small that product < denominator, bytes becomes 0
-    // 0.00001M = 0.01048576 bytes -> too small (below 512 minimum)
-    // The -1 adjustment happens before the minimum check, so this is TooSmall
+    // 0.00001M ~ 0.01 bytes falls below the 512-byte minimum even before the
+    // `-1` adjustment, so the parser reports TooSmall rather than Invalid.
     let error = parse_bandwidth_argument("0.00001M-1").unwrap_err();
     assert_eq!(error, BandwidthParseError::TooSmall);
 }
 
 #[test]
 fn parse_bandwidth_exponent_sign_at_end_rejected() {
-    // Test exponent_sign_allowed still true at end of number
-    // This tests line 113-114: if exponent_sign_allowed { return Err }
-    // Input like "1e+" where + is the sign but no digits follow
+    // Input like "1e+" where + is the sign but no digits follow.
     let error = parse_bandwidth_argument("1e+").unwrap_err();
     assert_eq!(error, BandwidthParseError::Invalid);
 
@@ -418,8 +411,7 @@ fn parse_bandwidth_exponent_sign_at_end_rejected() {
 
 #[test]
 fn parse_bandwidth_empty_first_byte_fallthrough() {
-    // Test the default case in first byte match (line 55-57)
-    // When first character is a digit, we fall through to the _ => {} case
+    // When the first character is a digit the sign-prefix branch is skipped.
     let result = parse_bandwidth_argument("1K").expect("parse succeeds");
     assert_eq!(result, NonZeroU64::new(1024));
 }


### PR DESCRIPTION
## Summary

- Remove decorative `// ---` divider blocks wrapping section titles in convergence, AIMD, and feedback-loop tests (section labels remain as plain comments).
- Drop `// Tests for X` banners in `parse::numeric` and `limiter::core` unit tests; the function names are already self-describing.
- Replace stale `// line NN` source-location comments in `parse::tests::argument` with concise behavioural notes.

All upstream rsync `// upstream: ...` references, sleep/rate math explanations, and rustdoc on public items are preserved.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings`
- [ ] CI nextest matrix (stable, Windows, macOS, Linux musl)