### PR TITLE
test(fuzz): consolidate ACL/xattr wire decoders into acl_xattr_wire

### DIFF
--- a/.github/workflows/fuzz-coverage-report.yml
+++ b/.github/workflows/fuzz-coverage-report.yml
@@ -74,6 +74,8 @@ jobs:
             target: decompressor_zstd
           - workspace: fuzz
             target: decompressor_zlib
+          - workspace: fuzz
+            target: acl_xattr_wire
           - workspace: crates/protocol/fuzz
             target: fuzz_varint
           - workspace: crates/protocol/fuzz

--- a/docs/audits/fuzz-coverage-matrix.md
+++ b/docs/audits/fuzz-coverage-matrix.md
@@ -113,8 +113,8 @@ target" column lists the existing target that exercises the function, or
 | Idlist (uid/gid name table) | `crates/protocol/src/idlist/mod.rs:232,256` (`read`, `read_with_kind`) | NONE | **P1 GAP** |
 | Transfer stats | `crates/protocol/src/stats/transfer.rs:219` (`TransferStats::read_from`) | `varint_roundtrip` (typed roundtrip + raw bytes) | covered (P1) |
 | Delete stats | `crates/protocol/src/stats/delete.rs:91` (`DeleteStats::read_from`) | `varint_roundtrip` (typed roundtrip + raw bytes) | covered (P1) |
-| ACL wire decoder | `crates/protocol/src/acl/definition/wire.rs:48` (`read_acl_definition`) | NONE | **P2 GAP** |
-| Xattr wire decoders | `crates/protocol/src/xattr/wire/decode.rs:52,118,171,208` (`read_xattr_definitions`, `recv_xattr`, `recv_xattr_request`, `recv_xattr_values`) | NONE | **P2 GAP** |
+| ACL wire decoder | `crates/protocol/src/acl/definition/wire.rs:48` (`read_acl_definition`) | `acl_xattr_wire` | covered (P2) |
+| Xattr wire decoders | `crates/protocol/src/xattr/wire/decode.rs:52,118,171,208` (`read_xattr_definitions`, `recv_xattr`, `recv_xattr_request`, `recv_xattr_values`) | `acl_xattr_wire` (all four entry points) | covered (P2) |
 | `--files-from` stream parser | `crates/protocol/src/files_from.rs:59,162` (`forward_files_from`, `read_files_from_stream`) | NONE | **P2 GAP** |
 | Iconv spec parser | `crates/core/src/client/config/iconv.rs:25` (`IconvSpec::parse` / `from_str`) | NONE | **P2 GAP** |
 | Daemon config (`rsyncd.conf`) parser | `crates/daemon/src/rsyncd_config/mod.rs:82` (`RsyncdConfig::parse`) | NONE | **P2 GAP** |
@@ -174,18 +174,19 @@ Gap-by-gap priority queue for FCV-3+:
     the underlying RustCrypto/zstd-rs implementation is panic-free, our
     wrappers compute output bounds and call `Vec::with_capacity` -
     a bad length prefix is a memory-blowup vector.
-11. **`acl_wire`** (P2). `read_acl_definition`.
-12. **`xattr_wire`** (P2). `read_xattr_definitions`, `recv_xattr`,
-    `recv_xattr_request`, `recv_xattr_values`.
-13. **`files_from`** (P2). `read_files_from_stream` + the forwarding
+11. **`acl_xattr_wire`** (P2, SHIPPED). Consolidated target that fans the
+    same input into `read_acl_definition`, `read_xattr_definitions`,
+    `recv_xattr`, `recv_xattr_request`, and `recv_xattr_values`. Wired
+    into the nightly `fuzz-coverage-report` workflow.
+12. **`files_from`** (P2). `read_files_from_stream` + the forwarding
     path.
-14. **`iconv_spec`** (P2). `IconvSpec::parse` accepts user-supplied
+13. **`iconv_spec`** (P2). `IconvSpec::parse` accepts user-supplied
     strings but is reachable from `--iconv=<spec>` on the command line.
-15. **`rsyncd_conf`** (P2). Config file parser; only reachable through
+14. **`rsyncd_conf`** (P2). Config file parser; only reachable through
     the trusted local filesystem, but it is human-edited and the
     grammar has macro / module-section interactions worth exploring.
-16. **`bwlimit_parse`** (P3). CLI string parser only.
-17. **`skip_compress_list`** (P3). CLI string parser only.
+15. **`bwlimit_parse`** (P3). CLI string parser only.
+16. **`skip_compress_list`** (P3). CLI string parser only.
 
 The `file_entry_roundtrip` target also has internal gaps within an
 already-covered subsystem: `mtime_nsec`, `rdev`, `hardlink_idx`, and

--- a/fuzz/fuzz_targets/acl_xattr_wire.rs
+++ b/fuzz/fuzz_targets/acl_xattr_wire.rs
@@ -4,7 +4,8 @@
 //!
 //! When `-A` (ACLs) or `-X` (xattrs) is negotiated, the file-list and
 //! transfer phases carry literal ACL and xattr definition blocks following
-//! a cache-miss index. The two decoders are stateful and varint-heavy:
+//! a cache-miss index, plus negotiated request/value batches. The decoders
+//! are stateful and varint-heavy:
 //!
 //! - `protocol::acl::read_acl_definition` parses the literal ACL body
 //!   (flags byte + four optional permission varints + named-id list).
@@ -13,16 +14,17 @@
 //!   set (count + per-entry name_len/datum_len varints + NUL-terminated
 //!   names + values or 16-byte MD5 checksums for abbreviated entries).
 //!   Upstream: `xattrs.c:receive_xattr()`.
+//! - `protocol::xattr::recv_xattr` reads one cached-or-literal definition
+//!   record. Upstream: `xattrs.c:recv_xattr()`.
+//! - `protocol::xattr::recv_xattr_request` reads the delta-encoded list of
+//!   1-based indices the receiver is asking the sender to inline.
+//!   Upstream: `xattrs.c:recv_xattr_request()`.
+//! - `protocol::xattr::recv_xattr_values` reads the per-index value bodies
+//!   that satisfy a prior request. Upstream: `xattrs.c:recv_xattr_values()`.
 //!
-//! Both are reached from an authenticated peer and contain length-prefix
-//! arithmetic, so a panic-or-OOM here is a finding.
-//!
-//! # Audit substitution
-//!
-//! The audit suggested `RsyncAcl::parse`, `parse_xattr`, and
-//! `XattrEntry::decode`. Those names don't exist as public APIs. The closest
-//! authenticated bytes-in decoders are `read_acl_definition` and
-//! `read_xattr_definitions` in the `protocol` crate, which is what we fuzz.
+//! All five entry points are reached from an authenticated peer and contain
+//! length-prefix arithmetic, so a panic or unbounded allocation here is a
+//! finding.
 //!
 //! # Running
 //!
@@ -35,14 +37,30 @@ use std::io::Cursor;
 use libfuzzer_sys::fuzz_target;
 
 use protocol::acl::read_acl_definition;
-use protocol::xattr::read_xattr_definitions;
+use protocol::xattr::{
+    XattrList, read_xattr_definitions, recv_xattr, recv_xattr_request, recv_xattr_values,
+};
 
 fuzz_target!(|data: &[u8]| {
-    // Each decoder consumes a single record; feed the same bytes to both
-    // so libFuzzer can specialise the corpus for each parser shape.
+    // Each decoder consumes a single record; feed the same bytes to all
+    // five so libFuzzer can specialise the corpus for each parser shape.
+    // The two `recv_xattr_*` decoders mutate a fresh `XattrList` per call
+    // so input ordering between calls cannot leak state across parsers.
+
     let mut acl_cursor = Cursor::new(data);
     let _ = read_acl_definition(&mut acl_cursor);
 
-    let mut xattr_cursor = Cursor::new(data);
-    let _ = read_xattr_definitions(&mut xattr_cursor);
+    let mut definitions_cursor = Cursor::new(data);
+    let _ = read_xattr_definitions(&mut definitions_cursor);
+
+    let mut recv_cursor = Cursor::new(data);
+    let _ = recv_xattr(&mut recv_cursor);
+
+    let mut request_cursor = Cursor::new(data);
+    let mut request_list = XattrList::new();
+    let _ = recv_xattr_request(&mut request_cursor, &mut request_list);
+
+    let mut values_cursor = Cursor::new(data);
+    let mut values_list = XattrList::new();
+    let _ = recv_xattr_values(&mut values_cursor, &mut values_list);
 });


### PR DESCRIPTION
## Summary

Completes FCV-11. The existing \`acl_xattr_wire\` fuzz target covered only two of the five authenticated ACL/xattr wire decoders. Extend it to fan the same input into all five:

- \`protocol::acl::read_acl_definition\`
- \`protocol::xattr::read_xattr_definitions\`
- \`protocol::xattr::recv_xattr\`
- \`protocol::xattr::recv_xattr_request\` (delta-encoded request list)
- \`protocol::xattr::recv_xattr_values\` (per-index value bodies)

Each decoder consumes its own \`Cursor::new(data)\` so libFuzzer can specialise the corpus per parser shape, and the two \`recv_xattr_*\` helpers operate on a fresh \`XattrList\` per call so state cannot leak across decoders.

Also wire \`acl_xattr_wire\` into the nightly \`fuzz-coverage-report.yml\` matrix and retire the two \`P2 GAP\` rows in \`docs/audits/fuzz-coverage-matrix.md\`.

## Test plan
- [x] \`cargo fmt --all\` clean
- [x] \`cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings\` clean
- [x] Required CI passes
- [x] Nightly fuzz-coverage-report includes \`acl_xattr_wire\` and produces an lcov artifact for it