### PR TITLE
fix(core): move sigaction unsafe out of core into fast_io

### DIFF
--- a/crates/core/src/signal/mod.rs
+++ b/crates/core/src/signal/mod.rs
@@ -1,10 +1,9 @@
 //! Signal handling for graceful shutdown and cleanup.
 //!
-//! # Safety
-//!
-//! This module uses unsafe code to install Unix signal handlers via libc.
-//! All signal handlers are async-signal-safe and only set atomic flags.
-#![allow(unsafe_code)]
+//! This module installs signal handlers via the safe
+//! [`fast_io::signal::install_signal_handler`] wrapper, so no unsafe code
+//! lives in `core`. The handlers themselves are async-signal-safe and only
+//! mutate atomic flags.
 //!
 //! This module provides Unix signal handling that matches upstream rsync's behavior
 //! for SIGINT, SIGTERM, SIGHUP, and SIGPIPE. It supports:

--- a/crates/core/src/signal/unix.rs
+++ b/crates/core/src/signal/unix.rs
@@ -1,11 +1,15 @@
 //! Unix signal handling implementation.
 //!
-//! This module provides the actual signal handling implementation for Unix systems
-//! using raw libc signal handlers. Signal handlers must be async-signal-safe, so
-//! they only set atomic flags and do no allocation or locking.
+//! This module installs async-signal-safe handlers via
+//! [`fast_io::signal::install_signal_handler`]. The handlers themselves are
+//! defined here and only mutate atomic flags - no allocation, no locking.
+//! All `unsafe` FFI lives behind the `fast_io` boundary so this crate stays
+//! under `#![deny(unsafe_code)]`.
 
 use std::io;
 use std::sync::atomic::{AtomicBool, Ordering};
+
+use fast_io::signal::install_signal_handler;
 
 use crate::exit_code::ExitCode;
 
@@ -197,45 +201,10 @@ extern "C" fn handle_sigpipe(_signum: libc::c_int) {
 /// # }
 /// ```
 pub fn install_signal_handlers() -> io::Result<SignalHandler> {
-    // SAFETY: Zero-initialises libc::sigaction structs (valid POD layout) before passing them
-    // to libc::sigaction; handler functions are async-signal-safe and only set atomic flags.
-    unsafe {
-        let mut sa_int: libc::sigaction = std::mem::zeroed();
-        sa_int.sa_sigaction = handle_sigint as *const () as libc::sighandler_t;
-        sa_int.sa_flags = libc::SA_RESTART; // Restart interrupted syscalls
-        libc::sigemptyset(&mut sa_int.sa_mask as *mut libc::sigset_t);
-
-        if libc::sigaction(libc::SIGINT, &sa_int, std::ptr::null_mut()) != 0 {
-            return Err(io::Error::last_os_error());
-        }
-
-        let mut sa_term: libc::sigaction = std::mem::zeroed();
-        sa_term.sa_sigaction = handle_sigterm as *const () as libc::sighandler_t;
-        sa_term.sa_flags = libc::SA_RESTART;
-        libc::sigemptyset(&mut sa_term.sa_mask as *mut libc::sigset_t);
-
-        if libc::sigaction(libc::SIGTERM, &sa_term, std::ptr::null_mut()) != 0 {
-            return Err(io::Error::last_os_error());
-        }
-
-        let mut sa_hup: libc::sigaction = std::mem::zeroed();
-        sa_hup.sa_sigaction = handle_sighup as *const () as libc::sighandler_t;
-        sa_hup.sa_flags = libc::SA_RESTART;
-        libc::sigemptyset(&mut sa_hup.sa_mask as *mut libc::sigset_t);
-
-        if libc::sigaction(libc::SIGHUP, &sa_hup, std::ptr::null_mut()) != 0 {
-            return Err(io::Error::last_os_error());
-        }
-
-        let mut sa_pipe: libc::sigaction = std::mem::zeroed();
-        sa_pipe.sa_sigaction = handle_sigpipe as *const () as libc::sighandler_t;
-        sa_pipe.sa_flags = libc::SA_RESTART;
-        libc::sigemptyset(&mut sa_pipe.sa_mask as *mut libc::sigset_t);
-
-        if libc::sigaction(libc::SIGPIPE, &sa_pipe, std::ptr::null_mut()) != 0 {
-            return Err(io::Error::last_os_error());
-        }
-    }
+    install_signal_handler(libc::SIGINT, handle_sigint)?;
+    install_signal_handler(libc::SIGTERM, handle_sigterm)?;
+    install_signal_handler(libc::SIGHUP, handle_sighup)?;
+    install_signal_handler(libc::SIGPIPE, handle_sigpipe)?;
 
     Ok(SignalHandler { installed: true })
 }

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -115,6 +115,8 @@ pub mod platform_copy;
 pub mod refs_detect;
 /// Zero-copy file-to-socket transfer using `sendfile` with automatic fallback.
 pub mod sendfile;
+/// Safe wrappers around platform signal-handler installation.
+pub mod signal;
 /// Safe wrappers around platform `setsockopt` for integer-valued options.
 pub mod socket_options;
 /// Zero-copy socket-to-disk transfer using `splice`/`vmsplice` syscalls.

--- a/crates/fast_io/src/signal/mod.rs
+++ b/crates/fast_io/src/signal/mod.rs
@@ -1,0 +1,30 @@
+//! Safe wrappers around platform signal-handler installation.
+//!
+//! Unix uses `libc::sigaction`; non-Unix targets use a no-op stub. Callers
+//! pass an `extern "C" fn(c_int)` handler that must be async-signal-safe
+//! (atomic stores only, no allocation, no locking). The wrapper installs the
+//! handler with `SA_RESTART` so interrupted syscalls auto-retry, matching
+//! upstream rsync's `sigaction` setup in `main.c`.
+//!
+//! This module exists so the `core` crate can keep `#![deny(unsafe_code)]`
+//! while still installing real Unix signal handlers. The unsafe FFI calls
+//! are confined to this crate per the workspace unsafe-code policy.
+
+use std::os::raw::c_int;
+
+/// Async-signal-safe handler function signature.
+///
+/// Handlers receive the signal number and must complete without allocating,
+/// locking, or calling any non-async-signal-safe functions. Atomic stores
+/// against `static AtomicBool`/`AtomicU8` are the canonical safe operation.
+pub type SignalHandlerFn = extern "C" fn(c_int);
+
+#[cfg(unix)]
+mod unix;
+#[cfg(unix)]
+pub use unix::install_signal_handler;
+
+#[cfg(not(unix))]
+mod stub;
+#[cfg(not(unix))]
+pub use stub::install_signal_handler;

--- a/crates/fast_io/src/signal/stub.rs
+++ b/crates/fast_io/src/signal/stub.rs
@@ -1,0 +1,22 @@
+//! Non-Unix stub for signal-handler installation.
+//!
+//! Windows and other non-Unix targets do not have POSIX signals. This stub
+//! exists so cross-platform callers can compile without `#[cfg(unix)]`
+//! branching; it always reports success without installing anything. Real
+//! Ctrl+C handling on Windows is delegated to higher-level crates (e.g.
+//! `ctrlc`) at the consumer layer.
+
+use std::io;
+use std::os::raw::c_int;
+
+use super::SignalHandlerFn;
+
+/// No-op installer for platforms without POSIX signals.
+///
+/// # Errors
+///
+/// This stub never fails.
+#[allow(clippy::missing_const_for_fn)] // REASON: signature must match Unix version
+pub fn install_signal_handler(_signum: c_int, _handler: SignalHandlerFn) -> io::Result<()> {
+    Ok(())
+}

--- a/crates/fast_io/src/signal/unix.rs
+++ b/crates/fast_io/src/signal/unix.rs
@@ -1,0 +1,73 @@
+//! Unix signal-handler installation via `libc::sigaction`.
+//!
+//! Encapsulates the single unsafe FFI block. The caller supplies the signal
+//! number and an async-signal-safe `extern "C"` handler; this module
+//! zero-initialises a `sigaction` struct, points `sa_sigaction` at the
+//! handler, sets `SA_RESTART`, and submits it. On failure the underlying
+//! `errno` is returned via `io::Error::last_os_error()`.
+
+use std::io;
+use std::os::raw::c_int;
+
+use super::SignalHandlerFn;
+
+/// Installs `handler` for `signum` with `SA_RESTART`.
+///
+/// `SA_RESTART` matches upstream rsync's `sig_int`/`sig_term` setup
+/// (`main.c`) so blocking syscalls (`read`, `write`, `select`, `poll`)
+/// resume after the handler returns instead of failing with `EINTR`.
+///
+/// The handler must be async-signal-safe: only atomic stores against
+/// statically allocated atomics, no allocation, no locking, no calls into
+/// the standard library's I/O or threading primitives.
+///
+/// # Errors
+///
+/// Returns the OS error from `sigaction(2)` on failure (rare; typically
+/// indicates an invalid signal number on the host platform).
+pub fn install_signal_handler(signum: c_int, handler: SignalHandlerFn) -> io::Result<()> {
+    // SAFETY: `libc::sigaction` is zero-initialised (valid POD layout);
+    // `sa_sigaction` is set to a `'static extern "C" fn(c_int)`, which has
+    // the ABI `sigaction(2)` expects; the empty signal mask and `SA_RESTART`
+    // flag mirror upstream rsync. The caller contract requires `handler` to
+    // be async-signal-safe.
+    #[allow(unsafe_code)]
+    unsafe {
+        let mut action: libc::sigaction = std::mem::zeroed();
+        action.sa_sigaction = handler as *const () as libc::sighandler_t;
+        action.sa_flags = libc::SA_RESTART;
+        libc::sigemptyset(&mut action.sa_mask as *mut libc::sigset_t);
+
+        if libc::sigaction(signum, &action, std::ptr::null_mut()) != 0 {
+            return Err(io::Error::last_os_error());
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    static TEST_FIRED: AtomicBool = AtomicBool::new(false);
+
+    extern "C" fn test_handler(_signum: c_int) {
+        TEST_FIRED.store(true, Ordering::SeqCst);
+    }
+
+    #[test]
+    fn install_signal_handler_accepts_sigusr1() {
+        // SIGUSR1 is reserved for application use on every POSIX platform,
+        // so installing a handler should always succeed.
+        assert!(install_signal_handler(libc::SIGUSR1, test_handler).is_ok());
+    }
+
+    #[test]
+    fn install_signal_handler_rejects_invalid_signum() {
+        // -1 is never a valid signal number; sigaction returns EINVAL.
+        let err = install_signal_handler(-1, test_handler).unwrap_err();
+        assert_eq!(err.raw_os_error(), Some(libc::EINVAL));
+    }
+}


### PR DESCRIPTION
## Summary

- Hoists the `libc::sigaction` FFI call out of `core::signal::unix` and into a new `fast_io::signal` module that exposes a safe `install_signal_handler(signum, handler)` API.
- Removes the module-level `#![allow(unsafe_code)]` override from `core::signal` so the `core` crate's `#![deny(unsafe_code)]` now covers the signal subtree.
- Preserves all signal semantics: same four signals (SIGINT, SIGTERM, SIGHUP, SIGPIPE), same handler functions, same `SA_RESTART` flag, same atomic-flag state machine.

## Why

`core` was the only general-purpose crate left carrying a module-scoped unsafe override. The workspace policy confines unsafe code to a small set of permitted crates (`fast_io`, `metadata`, `checksums`, `engine`, `protocol`); `fast_io` is the long-term home for platform FFI. Moving the eight lines of `sigaction` setup behind a one-call safe wrapper deletes the override without changing behaviour.

## Layout

- `crates/fast_io/src/signal/mod.rs` - public `SignalHandlerFn` alias and re-exports.
- `crates/fast_io/src/signal/unix.rs` - the single unsafe block (zero-init `sigaction`, `SA_RESTART`, submit). Tested with SIGUSR1 (must install) and `-1` (must return EINVAL).
- `crates/fast_io/src/signal/stub.rs` - no-op for non-Unix targets.
- `crates/core/src/signal/unix.rs` - now calls `fast_io::signal::install_signal_handler` four times.
- `crates/core/src/signal/mod.rs` - module-level `#![allow(unsafe_code)]` removed; doc comment updated.

## Test plan

- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` clean.
- [ ] CI: fmt+clippy, nextest (stable), Windows, macOS, Linux musl.
- [ ] Verify `core::signal::install_signal_handlers()` integration test still passes (no API change).