### PR TITLE
test(protocol): pin filter legal_len=1 parity at proto <= 28

### DIFF
--- a/crates/protocol/tests/filter_legal_len_parity.rs
+++ b/crates/protocol/tests/filter_legal_len_parity.rs
@@ -1,0 +1,227 @@
+//! Parity assertions for upstream rsync's `legal_len=1` rule at protocol < 29.
+//!
+//! Upstream `exclude.c:1530` sets `legal_len=1` when serializing filter rules
+//! for a peer that speaks protocol < 29, so only the single-character prefixes
+//! `+ `, `- ` (and the bare clear `!`) are allowed on the wire. If the rule
+//! list contains anything else - the dir-merge `:` prefix or any modifier
+//! flag - upstream's `send_rules()` at `exclude.c:1623-1627` exits
+//! `RERR_PROTOCOL` with "filter rules are too modern for remote rsync"
+//! before any bytes leave the sender.
+//!
+//! These tests pin oc-rsync's serializer and parser to the same semantics so
+//! the `up:merge-filter` interop scenario stays classified as an upstream
+//! limitation. See `tools/ci/known_failures.conf` and the BR-1a/b audit at
+//! `target/audits/br-1-merge-filter-repro.md`.
+
+use protocol::ProtocolVersion;
+use protocol::filters::{FilterRuleWireFormat, RuleType, build_rule_prefix, write_filter_list};
+
+const PROTO_28: u8 = 28;
+
+fn proto(v: u8) -> ProtocolVersion {
+    ProtocolVersion::from_supported(v).expect("supported protocol version")
+}
+
+fn dir_merge_rule(pattern: &str) -> FilterRuleWireFormat {
+    FilterRuleWireFormat {
+        rule_type: RuleType::DirMerge,
+        pattern: pattern.to_owned(),
+        anchored: false,
+        directory_only: false,
+        no_inherit: false,
+        cvs_exclude: false,
+        word_split: false,
+        exclude_from_merge: false,
+        xattr_only: false,
+        sender_side: false,
+        receiver_side: false,
+        perishable: false,
+        negate: false,
+    }
+}
+
+/// Dir-merge `:` rules cannot be encoded at protocol 28.
+///
+/// Mirrors upstream `exclude.c:1530-1534`: `legal_len=1` rejects any prefix
+/// longer than `"+ "`/`"- "`, and the `:` rule type unconditionally exceeds
+/// that budget.
+#[test]
+fn dir_merge_prefix_unsendable_at_protocol_28() {
+    let rule = dir_merge_rule(".rsync-filter");
+
+    let prefix = build_rule_prefix(&rule, proto(PROTO_28));
+
+    assert!(
+        prefix.is_none(),
+        "dir-merge rules must be unsendable at protocol 28 (upstream exclude.c:1530 legal_len=1); got {prefix:?}",
+    );
+}
+
+/// `write_filter_list` at protocol 28 errors with the upstream "too modern"
+/// message when a dir-merge rule is included.
+///
+/// `serialize_rule` (`crates/protocol/src/filters/wire.rs:441-446`) is private,
+/// but it is reachable through `write_filter_list`. The error message is the
+/// verbatim string upstream prints in `send_rules:1623-1627` before exiting
+/// `RERR_PROTOCOL`.
+#[test]
+fn serialize_rule_errors_with_too_modern_for_dir_merge_at_protocol_28() {
+    let rule = dir_merge_rule(".rsync-filter");
+    let mut buf = Vec::new();
+
+    let err = write_filter_list(&mut buf, std::slice::from_ref(&rule), proto(PROTO_28))
+        .expect_err("dir-merge serialization must fail at protocol 28");
+
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    assert!(
+        err.to_string()
+            .contains("filter rules are too modern for remote rsync"),
+        "error message must match upstream send_rules:1623-1627 wording; got {err}",
+    );
+    assert!(
+        buf.is_empty(),
+        "no bytes must be emitted before the protocol error; got {} bytes",
+        buf.len(),
+    );
+}
+
+/// Every modifier flag is independently unsendable at protocol 28.
+///
+/// Upstream `exclude.c:1530` budgets one prefix byte, so each modifier
+/// (anchored, negate, cvs_exclude, no_inherit, word_split, exclude_from_merge,
+/// xattr_only, sender_side, receiver_side, perishable) pushes the prefix
+/// length past `legal_len=1` and triggers the `RERR_PROTOCOL` exit at
+/// `send_rules:1623-1627`. The parameterised loop pins all ten flags.
+#[test]
+fn each_modifier_unsendable_at_protocol_28() {
+    type Setter = fn(&mut FilterRuleWireFormat);
+    let cases: &[(&str, Setter)] = &[
+        ("anchored", |r| r.anchored = true),
+        ("negate", |r| r.negate = true),
+        ("cvs_exclude", |r| r.cvs_exclude = true),
+        ("no_inherit", |r| r.no_inherit = true),
+        ("word_split", |r| r.word_split = true),
+        ("exclude_from_merge", |r| r.exclude_from_merge = true),
+        ("xattr_only", |r| r.xattr_only = true),
+        ("sender_side", |r| r.sender_side = true),
+        ("receiver_side", |r| r.receiver_side = true),
+        ("perishable", |r| r.perishable = true),
+    ];
+
+    for (name, setter) in cases {
+        let mut rule = FilterRuleWireFormat::exclude("pattern".to_owned());
+        setter(&mut rule);
+
+        let prefix = build_rule_prefix(&rule, proto(PROTO_28));
+        assert!(
+            prefix.is_none(),
+            "modifier '{name}' must be unsendable at protocol 28 (upstream exclude.c:1530 legal_len=1)",
+        );
+
+        let mut buf = Vec::new();
+        let result = write_filter_list(&mut buf, std::slice::from_ref(&rule), proto(PROTO_28));
+        let err = match result {
+            Ok(()) => panic!("rule with '{name}' modifier must fail at protocol 28"),
+            Err(e) => e,
+        };
+        assert!(
+            err.to_string()
+                .contains("filter rules are too modern for remote rsync"),
+            "modifier '{name}': error must match upstream send_rules:1623-1627 wording; got {err}",
+        );
+    }
+}
+
+/// The wire parser rejects `:`-prefixed rules at protocol 28.
+///
+/// Upstream `exclude.c:1119-1133` runs the `XFLG_OLD_PREFIXES` branch of
+/// `parse_rule_tok()` at protocol < 29, which only accepts `"+ pattern"`,
+/// `"- pattern"`, or the bare `"!"` clear marker. A `:`-prefixed payload
+/// must be rejected with `InvalidData`. Construct the wire frame manually
+/// (length-prefixed payload + zero terminator) since `write_filter_list`
+/// already refuses to emit it.
+#[test]
+fn wire_parser_rejects_dir_merge_at_protocol_28() {
+    use protocol::filters::read_filter_list;
+
+    let payload = b": .rsync-filter";
+    let mut buf = Vec::with_capacity(4 + payload.len() + 4);
+    buf.extend_from_slice(&(payload.len() as i32).to_le_bytes());
+    buf.extend_from_slice(payload);
+    buf.extend_from_slice(&0i32.to_le_bytes());
+
+    let err = read_filter_list(&mut &buf[..], proto(PROTO_28))
+        .expect_err("parser must reject ':' prefix at protocol 28");
+
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    assert!(
+        err.to_string().contains("invalid old-style filter prefix"),
+        "parser must reject ':' under XFLG_OLD_PREFIXES (upstream exclude.c:1119-1133); got {err}",
+    );
+}
+
+/// `is_known_failure_from_conf` in `tools/ci/known_failures.conf` returns 0
+/// for `up:merge-filter` only when the forced protocol is <= 28.
+///
+/// Validates the BR-1e classification: the entry must live inside the
+/// `forced_proto <= 28` block, not in the unconditional `KNOWN_FAILURES`
+/// array (which would mask the test at modern protocols where upstream's
+/// `legal_len` budget no longer applies).
+///
+/// Runs only on Unix because the shell function lives in a bash conf and
+/// Windows CI does not ship bash.
+#[cfg(unix)]
+#[test]
+fn known_failures_conf_marks_merge_filter_only_up_to_proto_28() {
+    use std::path::PathBuf;
+    use std::process::Command;
+
+    let conf = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(2)
+        .expect("workspace root")
+        .join("tools/ci/known_failures.conf");
+    assert!(conf.exists(), "missing conf at {}", conf.display());
+
+    let bash = which_bash().unwrap_or_else(|| "/bin/bash".to_owned());
+    let conf_str = conf.to_string_lossy().into_owned();
+
+    let check = |proto: &str| -> bool {
+        let script = format!(
+            "set -u; source '{conf_str}'; is_known_failure_from_conf up merge-filter '{proto}'",
+        );
+        let status = Command::new(&bash)
+            .args(["-c", &script])
+            .status()
+            .expect("bash invocation must succeed");
+        status.success()
+    };
+
+    for proto in ["28", "27"] {
+        assert!(
+            check(proto),
+            "merge-filter must be a known failure at proto {proto}"
+        );
+    }
+    for proto in ["29", "30", "31", "32", ""] {
+        assert!(
+            !check(proto),
+            "merge-filter must NOT be a known failure at proto '{proto}' (upstream-only limitation)",
+        );
+    }
+}
+
+#[cfg(unix)]
+fn which_bash() -> Option<String> {
+    for candidate in [
+        "/bin/bash",
+        "/usr/bin/bash",
+        "/usr/local/bin/bash",
+        "/opt/homebrew/bin/bash",
+    ] {
+        if std::path::Path::new(candidate).exists() {
+            return Some(candidate.to_owned());
+        }
+    }
+    None
+}

--- a/tools/ci/known_failures.conf
+++ b/tools/ci/known_failures.conf
@@ -13,7 +13,8 @@
 # Categories:
 #   1. Upstream batch bug: upstream can't read its own compressed delta batches
 #   2. Proto < 30: features that upstream hard-rejects at older protocol versions
-#   3. Proto < 29: filter prefix limitations in older protocol versions
+#   3. Proto < 29: upstream sender refuses multi-char filter prefixes
+#      (exclude.c:1530 legal_len=1 + send_rules:1623-1627 RERR_PROTOCOL)
 
 # Unconditional known failures (direction:name).
 KNOWN_FAILURES=(
@@ -86,16 +87,23 @@ is_known_failure_from_conf() {
   fi
 
   # PROTOCOL < 29 KNOWN FAILURES (up direction only)
-  # Filter prefix format limitations in protocol versions below 29.
+  # UPSTREAM RSYNC LIMITATIONS, not oc-rsync bugs.
   # NOT FIXABLE: upstream hardcodes legal_len=1 at proto < 29.
   if [[ "$direction" == "up" && -n "$forced_proto" && "$forced_proto" -le 28 ]]; then
     case "$name" in
-      # Merge-filter: upstream exclude.c:1530 sets legal_len=1 at proto < 29,
-      # meaning only single-character filter prefixes are allowed. The dir-merge
-      # ':' prefix requires multi-character prefix support (legal_len >= 2)
-      # introduced in protocol 29. At proto < 29, the filter parser rejects
-      # the ':' prefix as invalid.
-      # Verified: upstream rsync --filter='merge ...' at --protocol=28 fails.
+      # Merge-filter: upstream exclude.c:1530 legal_len=1 +
+      # send_rules:1623-1627 RERR_PROTOCOL (no bytes reach oc-rsync;
+      # upstream limitation). When forced to --protocol=28, upstream's
+      # sender refuses dir-merge ':' rules: get_rule_prefix() at
+      # exclude.c:1530 sets legal_len=1 (only "+ "/"- " allowed) and
+      # send_rules() at exclude.c:1623-1627 exits RERR_PROTOCOL with
+      # "filter rules are too modern for remote rsync" before any bytes
+      # leave the upstream client. oc-rsync's serializer
+      # (crates/protocol/src/filters/prefix.rs build_old_prefix and
+      # crates/protocol/src/filters/wire.rs serialize_rule) already
+      # mirrors the same legal_len=1 semantics.
+      # Verified: upstream rsync --filter='dir-merge ...' at
+      # --protocol=28 exits RERR_PROTOCOL with the "too modern" message.
       merge-filter) return 0 ;;
     esac
   fi
@@ -121,8 +129,9 @@ DASHBOARD_ENTRIES=(
   # Compression algorithm choice: no vstring negotiation at proto < 30
   "up:compress-zstd|zstd at proto <= 29 (upstream compat.c:556-564, no vstring negotiation for codec)|daemon"
   "up:compress-lz4|lz4 at proto <= 29 (upstream compat.c:556-564, no vstring negotiation for codec)|daemon"
-  # --- Proto <= 28: filter prefix limitations ---
+  # --- Proto <= 28: upstream hard-rejects filter rules with multi-char prefixes ---
 
-  # Merge-filter: upstream exclude.c:1530 legal_len=1 prevents ':' dir-merge prefix
-  "up:merge-filter|merge-filter at proto <= 28 (exclude.c:1530 legal_len=1, no dir-merge prefix)|daemon"
+  # Merge-filter: upstream exclude.c:1530 legal_len=1 + send_rules:1623-1627
+  # RERR_PROTOCOL (no bytes reach oc-rsync; upstream limitation).
+  "up:merge-filter|merge-filter at proto <= 28 (upstream exclude.c:1530 legal_len=1 + send_rules:1623-1627 RERR_PROTOCOL, no bytes reach oc-rsync; upstream limitation)|daemon"
 )


### PR DESCRIPTION
## Summary

- Pins oc-rsync's filter serializer and parser to upstream rsync's protocol-28 wire rules with five parity tests in `crates/protocol/tests/filter_legal_len_parity.rs`.
- Reclassifies the `up:merge-filter` interop entry in `tools/ci/known_failures.conf` as an upstream limitation, citing the exact source lines.
- No serializer/parser changes - oc-rsync already mirrors upstream's `legal_len=1` semantics; the tests guard that parity.

## Why

`up:merge-filter` was listed in `KNOWN_FAILURES` with rationale that implied an oc-rsync gap ("the filter parser rejects the ':' prefix as invalid"). The BR-1a/b reproduction (`target/audits/br-1-merge-filter-repro.md`) showed the failure is upstream-side only:

- `exclude.c:1530` - `get_rule_prefix()` sets `legal_len = 1` when the peer speaks protocol < 29, so only `"+ "`, `"- "`, or the bare `"!"` clear marker are valid.
- `exclude.c:1623-1627` - `send_rules()` exits `RERR_PROTOCOL` with `"filter rules are too modern for remote rsync"` before any bytes leave the upstream client when a rule exceeds the prefix budget.

oc-rsync's `build_old_prefix` (`crates/protocol/src/filters/prefix.rs:39-84`) and `serialize_rule` (`crates/protocol/src/filters/wire.rs:441-446`) already match those semantics, so no production code changes are needed.

## Changes

- `tools/ci/known_failures.conf`:
  - Update header category 3 to attribute the limitation to upstream's sender (`exclude.c:1530 legal_len=1 + send_rules:1623-1627 RERR_PROTOCOL`).
  - Replace the in-block comment for `up:merge-filter` with the upstream citations and a note that oc-rsync's serializer mirrors the same behaviour.
  - Re-word the `DASHBOARD_ENTRIES` description so the dashboard reports the failure as an upstream limitation.
- `crates/protocol/tests/filter_legal_len_parity.rs` (new):
  1. `dir_merge_prefix_unsendable_at_protocol_28` - `build_rule_prefix` returns `None` for `:` rules at proto 28.
  2. `serialize_rule_errors_with_too_modern_for_dir_merge_at_protocol_28` - `write_filter_list` errors with the exact upstream wording and emits zero bytes.
  3. `each_modifier_unsendable_at_protocol_28` - parameterised over all ten modifier flags (`/`, `!`, `C`, `n`, `w`, `e`, `x`, `s`, `r`, `p`).
  4. `wire_parser_rejects_dir_merge_at_protocol_28` - parser rejects a hand-crafted `:`-prefixed wire frame under `XFLG_OLD_PREFIXES`.
  5. `known_failures_conf_marks_merge_filter_only_up_to_proto_28` (Unix-only) - sources the conf and asserts `is_known_failure_from_conf` returns 0 only for `forced_proto` in `{27, 28}`, never for `29+` or empty.

## References

- BR-1a/b audit: `target/audits/br-1-merge-filter-repro.md`.
- Upstream source: `exclude.c:1530` (`get_rule_prefix` legal_len=1), `exclude.c:1623-1627` (`send_rules` RERR_PROTOCOL exit), `exclude.c:1119-1133` (`XFLG_OLD_PREFIXES` parser branch).
- oc-rsync source (unchanged, mirrors upstream): `crates/protocol/src/filters/prefix.rs:39-84`, `crates/protocol/src/filters/wire.rs:441-446`.

## Test plan

- [x] `cargo fmt --all -- --check` - clean.
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` - clean.
- [x] `cargo nextest run -p protocol --all-features --test filter_legal_len_parity` - 5 / 5 pass locally.
- [ ] CI: fmt+clippy, nextest (stable), Windows, macOS, Linux musl.
- [ ] CI: interop suite still classifies `up:merge-filter` as a known failure only at proto <= 28.