### PR TITLE
docs: refresh IOCP wiring and signal-handler unsafe attribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The primary platform is Linux. macOS is well-supported with parity for all metad
 | Symbolic links | ✓ | ✓ | ✗ | `create_symlinks` is `cfg(not(unix))` no-op; symlink entries are skipped on Windows. |
 | Devices/specials (`-D`) | ✓ | ✓ | ✗ | `create_fifo` and `create_device_node` are no-ops on non-Unix. |
 | Sparse files (`-S`) | ✓ | ✓ | ⚠ | Uses portable `seek` + `set_len`; depends on filesystem (NTFS supports sparse but is not explicitly marked via `FSCTL_SET_SPARSE`). |
-| Async I/O backend | ✓ io_uring | ⚠ standard I/O | ⚠ IOCP compiled, not wired | io_uring runtime-detected on Linux 5.6+; IOCP is implemented in `fast_io` but not yet consumed by the transfer pipeline (#1868). |
+| Async I/O backend | ✓ io_uring | ⚠ standard I/O | ⚠ IOCP (writes + sockets) | io_uring runtime-detected on Linux 5.6+. IOCP is wired into the disk-write pipeline (`transfer::disk_commit::Writer::Iocp`) and into the socket transports (daemon and SSH); file reads still use standard buffered I/O. |
 | Reflink / clone copy | ✓ FICLONE | ✓ clonefile | ⚠ ReFS reflink | Linux Btrfs/XFS/bcachefs via `FICLONE`; macOS via `clonefile`; Windows via `FSCTL_DUPLICATE_EXTENTS_TO_FILE` (ReFS only). |
 | Optimized file copy | ✓ `copy_file_range` | ✓ `fcopyfile` | ✓ `CopyFileExW` | All three are wired into the local-copy executor with standard-I/O fallback. |
 
@@ -136,7 +136,7 @@ oc-rsync is wire-compatible with upstream rsync 3.4.1, but a few architectural c
 - **Single-thread delta computation.** The delta sender is sequential per file. Rolling-hash fan-out across files is not yet parallelised; large-file workloads fully utilise one CPU per transfer rather than scaling delta CPU horizontally.
 - **SSH compression interaction.** When the SSH cipher already performs compression (e.g., `Compression yes` in `ssh_config`), running `oc-rsync -z` will compress payloads twice. There is currently no auto-detection / auto-disable path; operators should pick one layer.
 - **Daemon TLS.** Native TLS is not built into the daemon. Deploy `oc-rsync --daemon` behind `stunnel`, `ssh -L`, or a reverse proxy that terminates TLS. See [`docs/deployment/daemon-tls.md`](./docs/deployment/daemon-tls.md) for runnable terminator configs, hardened systemd units, and host-firewall rules; see [SECURITY.md](./SECURITY.md) for the broader hardening note.
-- **Windows IOCP scope.** IOCP is wired for socket I/O (daemon and SSH transports); file-system reads and writes still use standard buffered I/O on Windows. Tracking work to extend IOCP to the file pipeline is in flight (#1868).
+- **Windows IOCP scope.** IOCP is wired for socket I/O (daemon and SSH transports) and for the receive-side disk-write pipeline (`transfer::disk_commit` dispatches `Writer::Iocp` when the IOCP backend is selected on Windows). File reads still use standard buffered I/O; extending IOCP to the read path is tracked in WPG-1.
 - **`.rsync-filter` per-directory inheritance.** Inheritance semantics match upstream for the common cases tested in the interop suite, but exhaustive parity against upstream's filter-tree corner cases (deeply nested merges, anchored vs unanchored interactions) is still being validated.
 - **`--checksum-seed` / `--fuzzy`.** These flags are accepted and exercised in the common path; deeper conformance audits against upstream rsync 3.4.1 are tracked separately.
 
@@ -355,9 +355,9 @@ Key crates: **cli** (Clap v4), **core** (orchestration facade), **protocol** (wi
 All crates enforce `#![deny(unsafe_code)]`. Targeted `#[allow(unsafe_code)]` is permitted only in crates that wrap platform FFI or SIMD intrinsics:
 
 - **checksums** - SIMD intrinsics (AVX2, AVX-512, SSE2, SSSE3, SSE4.1, NEON, WASM) with scalar fallbacks
-- **fast_io** - io_uring, `copy_file_range`, sendfile, mmap, IOCP, `WSARecv`/`WSASend`, `setsockopt` with standard I/O fallbacks
+- **fast_io** - io_uring, `copy_file_range`, sendfile, mmap, IOCP, `WSARecv`/`WSASend`, `setsockopt`, and the `signal::install_signal_handler` FFI wrapper, with standard I/O / no-op fallbacks
 - **metadata** - UID/GID lookup, timestamps, ownership, xattrs, ACLs
-- **platform** - Signal handlers, chroot, daemonize, process management
+- **platform** - chroot, daemonize, name resolution, privilege transitions (signal-handler installation moved to `fast_io::signal`)
 - **engine** - Buffer pool atomics, deferred fsync, clonefile, `CopyFileExW`
 - **protocol** - One isolated allow in `multiplex::helpers` for frame parsing
 - **windows-gnu-eh** - Windows GNU exception handling shims

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -38,16 +38,16 @@ oc-rsync leverages Rust's memory safety to eliminate entire vulnerability classe
 
 ### Unsafe Code Policy
 
-Crates that enforce `#![deny(unsafe_code)]` with no allow-listed exceptions:
-- `daemon`, `cli`, `core`, `transfer`, `batch`, `filters`, `signature`, `matching`, `bandwidth`, `logging`, `logging-sink`, `branding`, `rsync_io`, `compress`, `apple-fs`, `flist`, `embedding`, `test-support` - business logic, parsers, orchestration, and high-level I/O wrappers
+Crates that enforce `#![deny(unsafe_code)]` with no allow-listed exceptions in production code:
+- `daemon`, `cli`, `core`, `transfer`, `batch`, `filters`, `signature`, `matching`, `bandwidth`, `logging`, `logging-sink`, `branding`, `rsync_io`, `compress`, `apple-fs`, `flist`, `embedding`, `test-support` - business logic, parsers, orchestration, and high-level I/O wrappers. `embedding` carries one `#[cfg(test)]`-only `#[allow(unsafe_code)]` on a `tests::EnvGuard` helper that wraps `std::env::set_var` under a process-wide mutex.
 
 Crates with `#![deny(unsafe_code)]` and targeted `#[allow(unsafe_code)]` for documented FFI/SIMD boundaries:
 - `metadata` - Ownership and privilege FFI (UID/GID lookup via `getpwuid_r`/`getgrnam_r`, `setuid`/`setgid`, `setattrlist`)
 - `protocol` - One isolated `#[allow]` in `multiplex::helpers` for performance-critical frame parsing
 - `engine` - Denies unsafe outside tests (`#![cfg_attr(not(test), deny(unsafe_code))]`) with targeted `#[allow(unsafe_code)]` on platform FFI (prefetch, buffer pool, `CopyFileExW`)
-- `platform` - Daemonization, signal handlers, environment isolation, and chroot syscalls
+- `platform` - Daemonization, name resolution (`getpwnam_r`/`getgrnam_r`), privilege transitions (`setuid`/`setgid`/`initgroups`), and chroot syscalls. Signal-handler installation has been hoisted out into `fast_io::signal::install_signal_handler`; the handlers themselves are defined in `core::signal` under a plain `#![deny(unsafe_code)]`.
 - `checksums` - SIMD intrinsics for MD4/MD5 and rolling checksums (AVX2, AVX-512, SSE2, SSSE3, SSE4.1, NEON, WASM), with scalar fallbacks and parity tests
-- `fast_io` - Platform I/O syscalls (sendfile, io_uring, mmap, `copy_file_range`, IOCP, `WSARecv`/`WSASend`, `setsockopt`), with standard I/O fallbacks
+- `fast_io` - Platform I/O syscalls (sendfile, io_uring, mmap, `copy_file_range`, IOCP, `WSARecv`/`WSASend`, `setsockopt`) and the `signal::install_signal_handler` FFI wrapper, with standard I/O / no-op fallbacks
 - `windows-gnu-eh` - Windows GNU exception handling shims (properly documented)
 
 **Long-term direction.** Unsafe code is being consolidated into `fast_io` as the single crate permitted to wrap platform FFI directly; new unsafe code goes there and is exposed via safe public APIs. New `#[allow(unsafe_code)]` annotations in any other crate require explicit review.


### PR DESCRIPTION
## Summary

Three factual corrections to README.md and SECURITY.md against current `origin/master` state.

1. **IOCP wiring is broader than the prose claims.** Both the README status table (row *Async I/O backend*) and the Known Limitations section described Windows IOCP as either *compiled, not wired* or *wired only for sockets*. In current master, `transfer::disk_commit::Writer::Iocp` dispatches the receive-side disk-write pipeline through IOCP on Windows; only the read path still falls back to standard buffered I/O. The stale issue reference `#1868` (which was actually a packaging-flow issue, merged 2025-11-01) is dropped; the read-path extension is now tracked under WPG-1.

2. **Signal-handler unsafe lives in `fast_io`, not `platform` or `core`.** Both files still attributed signal-handler unsafe to `platform` (and SECURITY.md implicitly to `core::signal`'s previous `#![allow(unsafe_code)]`). The signal-installation FFI has been hoisted into `fast_io::signal::install_signal_handler`; `core::signal` now lives under plain `#![deny(unsafe_code)]`, and the `platform` bullet no longer claims signal handling. The `fast_io` bullets in both files now mention `signal::install_signal_handler` alongside the rest of the syscall surface.

3. **`embedding` carries a test-only `#[allow(unsafe_code)]`.** SECURITY.md listed `embedding` in the deny-only list, which is correct for production code but misleading - `tests::EnvGuard` uses `#[cfg(test)]`-only `unsafe { std::env::set_var(...) }` under a process-wide mutex. The bullet now calls out that carve-out explicitly.

No code changes. Both files are markdown-only edits.

## Test plan

- [ ] CI required checks pass (fmt+clippy, nextest stable, Windows, macOS, Linux musl, interop) - this is a docs-only diff so the failure modes are limited to broken markdown rendering or markdownlint regressions.
- [ ] Manual rendering check on GitHub PR preview confirms no broken links / table corruption.