### PR TITLE
docs(compress): fix protocol-threshold comments and document module decls

### DIFF
--- a/crates/compress/src/lib.rs
+++ b/crates/compress/src/lib.rs
@@ -70,6 +70,7 @@
 //! - [`skip_compress`] for compression tuning based on file type detection.
 //! - `engine` for the transfer pipeline that integrates these helpers.
 
+/// Shared compression algorithm enumeration and default level constants.
 pub mod algorithm;
 mod common;
 /// LZ4 compression support in both standard frame and rsync raw-block formats.

--- a/crates/compress/src/lz4/mod.rs
+++ b/crates/compress/src/lz4/mod.rs
@@ -37,6 +37,7 @@
 //! # }
 //! ```
 
+/// LZ4 frame format compression with magic bytes, checksums, and streaming.
 pub mod frame;
 /// Raw LZ4 block compression for rsync wire protocol compatibility.
 pub mod raw;

--- a/crates/compress/src/strategy/impls.rs
+++ b/crates/compress/src/strategy/impls.rs
@@ -42,7 +42,7 @@ impl CompressionStrategy for NoCompressionStrategy {
 
 /// Zlib/DEFLATE compression strategy.
 ///
-/// Used by rsync protocol versions < 36 as the default compression algorithm.
+/// Default for protocol < 30 and the negotiation fallback for all versions.
 #[derive(Clone, Copy, Debug)]
 pub struct ZlibStrategy {
     level: CompressionLevel,
@@ -93,8 +93,7 @@ impl CompressionStrategy for ZlibStrategy {
 
 /// Zstandard compression strategy.
 ///
-/// Used by rsync protocol versions >= 36 as the default compression algorithm.
-/// Only available when the `zstd` feature is enabled.
+/// Preferred default for protocol >= 30 when the `zstd` feature is enabled.
 #[cfg(feature = "zstd")]
 #[derive(Clone, Copy, Debug)]
 pub struct ZstdStrategy {


### PR DESCRIPTION
## Summary

The compress crate already received a comprehensive comment audit in PR #4136, so this follow-up pass is intentionally narrow.

- Corrected `ZlibStrategy` and `ZstdStrategy` rustdoc that misstated the vstring-negotiation boundary as protocol 36; the actual upstream threshold is protocol 30 (see `compat.c:556-563` and `strategy/profile.rs::MODERN`).
- Added brief `///` summaries to `pub mod algorithm` (lib.rs) and `pub mod frame` (lz4/mod.rs) so every public module declaration is documented.

Files touched: 3. Restating/decorative/outdated comments removed: 2 lines. Public items newly rustdoc'd: 2 (`pub mod algorithm`, `pub mod frame`). No semantic changes; no new `#[allow(...)]` attributes.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings`
- Comment-only change; tests unchanged.