### PR TITLE
fix(transfer): preserve wire-byte order for flist index under --iconv

### DIFF
--- a/crates/transfer/src/receiver/file_list/incremental.rs
+++ b/crates/transfer/src/receiver/file_list/incremental.rs
@@ -42,6 +42,17 @@ pub struct IncrementalFileListReceiver<R> {
     pub(in crate::receiver) entries_read: usize,
     /// Whether to use unstable sort (qsort) instead of stable merge sort.
     pub(in crate::receiver) use_qsort: bool,
+    /// When true, [`Self::collect_sorted`] skips the in-place reorder so the
+    /// NDX-addressed array stays in sender scan order. Mirrors upstream's
+    /// `need_unsorted_flist = 1` behaviour when `--iconv` is active and
+    /// would transcode filenames between local and remote charsets.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `options.c:2051-2056` - `need_unsorted_flist = 1` when `iconv_opt`
+    /// - `flist.c:2496-2498` - "both sides keep an unsorted file-list array
+    ///   because the names will differ on the sending and receiving sides"
+    pub(in crate::receiver) iconv_reorder_suppressed: bool,
 }
 
 impl<R: Read> IncrementalFileListReceiver<R> {
@@ -189,9 +200,14 @@ impl<R: Read> IncrementalFileListReceiver<R> {
 
         entries.extend(self.incremental.drain_ready());
 
-        // upstream: flist.c:2736 - sort to match sender's order for NDX indexing
+        // upstream: flist.c:2736 - sort to match sender's order for NDX indexing.
         // IncrementalFileListReceiver is only used for INC_RECURSE (protocol >= 30).
-        sort_file_list(&mut entries, self.use_qsort, false);
+        // When iconv would reorder the NDX-addressed array away from sender
+        // scan order, skip the in-place sort - upstream's `need_unsorted_flist`
+        // path keeps `flist->files[]` in scan order under the same condition.
+        if !self.iconv_reorder_suppressed {
+            sort_file_list(&mut entries, self.use_qsort, false);
+        }
         let mut prior_hlinks = HashMap::new();
         match_hard_links(&mut entries, &mut prior_hlinks);
 

--- a/crates/transfer/src/receiver/file_list/receive.rs
+++ b/crates/transfer/src/receiver/file_list/receive.rs
@@ -87,8 +87,22 @@ impl ReceiverContext {
         }
 
         // upstream: flist.c:2736 - flist_sort_and_clean() after recv_id_list()
+        //
+        // When `--iconv` is in effect, upstream sets `need_unsorted_flist = 1`
+        // (options.c:2056) so the receiver's NDX-addressed `flist->files[]`
+        // array stays in sender scan order; only a separate `flist->sorted[]`
+        // pointer array is reordered. We do not maintain a parallel pointer
+        // array, so we mirror upstream by skipping the in-place reorder when
+        // an active (non-identity) iconv converter is configured. This keeps
+        // `self.file_list` in wire (NDX) order so subsequent generator
+        // requests resolve to the entry the sender meant.
+        // upstream: flist.c:2496-2498 - "both sides keep an unsorted
+        // file-list array because the names will differ on the sending and
+        // receiving sides".
         let pre29 = self.protocol.as_u8() < 29;
-        sort_file_list(&mut self.file_list, self.config.qsort, pre29);
+        if !self.iconv_reorder_suppressed() {
+            sort_file_list(&mut self.file_list, self.config.qsort, pre29);
+        }
         match_hard_links(&mut self.file_list, &mut self.prior_hlinks);
 
         // For protocol < 30, normalize (dev, ino) pairs into hardlink_idx and
@@ -196,7 +210,14 @@ impl ReceiverContext {
             // upstream: flist.c:2155,2736 - both sides call flist_sort_and_clean()
             // independently. Unstable sort (true) is safe - entries have unique paths.
             // INC_RECURSE requires protocol >= 30, so pre29 is always false here.
-            sort_file_list(&mut self.file_list[flat_start..], true, false);
+            //
+            // Iconv suppresses the in-place reorder for the same reason as the
+            // initial flist: upstream's `need_unsorted_flist` keeps the
+            // NDX-addressed array in scan order so the receiver can resolve
+            // generator requests against the bytes the sender emitted.
+            if !self.iconv_reorder_suppressed() {
+                sort_file_list(&mut self.file_list[flat_start..], true, false);
+            }
             match_hard_links(&mut self.file_list[flat_start..], &mut self.prior_hlinks);
 
             // Normalize pre-30 hardlinks in this segment.
@@ -338,6 +359,7 @@ impl ReceiverContext {
             finished_reading: false,
             entries_read: 0,
             use_qsort: self.config.qsort,
+            iconv_reorder_suppressed: self.iconv_reorder_suppressed(),
         }
     }
 }

--- a/crates/transfer/src/receiver/mod.rs
+++ b/crates/transfer/src/receiver/mod.rs
@@ -509,6 +509,32 @@ impl ReceiverContext {
         reader
     }
 
+    /// Returns true when iconv is active and would transcode filenames,
+    /// indicating the receiver must keep its NDX-addressed file list in
+    /// sender wire-emit order rather than re-sorting on local-charset bytes.
+    ///
+    /// Mirrors upstream's `need_unsorted_flist = 1` flag, which `options.c`
+    /// sets whenever `iconv_opt` resolves to an actual conversion. An
+    /// identity converter (same local/remote encoding) leaves bytes
+    /// untouched, so the sort/lookup order cannot diverge and the reorder
+    /// stays enabled - matching upstream's check that nulls out `iconv_opt`
+    /// when it is `"-"` before setting `need_unsorted_flist = 1`.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `options.c:2051-2056` - `need_unsorted_flist = 1` when `iconv_opt`
+    /// - `flist.c:2496-2498` - "both sides keep an unsorted file-list array
+    ///   because the names will differ on the sending and receiving sides"
+    /// - `flist.c:2149-2153` - allocates a separate `flist->sorted[]`
+    ///   pointer array so `flist->files[]` stays in scan order
+    pub(in crate::receiver) fn iconv_reorder_suppressed(&self) -> bool {
+        self.config
+            .connection
+            .iconv
+            .as_ref()
+            .is_some_and(|converter| !converter.is_identity())
+    }
+
     /// Translates a remote UID to a local UID using the received mappings.
     ///
     /// Returns the mapped local UID if a mapping exists, otherwise returns the

--- a/crates/transfer/src/receiver/tests/file_list/iconv_wire_order.rs
+++ b/crates/transfer/src/receiver/tests/file_list/iconv_wire_order.rs
@@ -1,0 +1,162 @@
+//! Regression coverage for the receiver-side `--iconv` ordering invariant.
+//!
+//! When the receiver has an active `FilenameConverter`, the NDX-addressed
+//! `file_list` array must remain in sender wire-emit order, not be reshuffled
+//! into local-charset byte order. Re-sorting after iconv transcoding caused
+//! "received request to transfer non-regular file" aborts on pulls from
+//! upstream daemons whenever the converted bytes sorted differently from the
+//! wire bytes.
+//!
+//! # Upstream Reference
+//!
+//! - `options.c:2051-2056` - sets `need_unsorted_flist = 1` when `--iconv`
+//!   is in effect (and not disabled by `--iconv=-`).
+//! - `flist.c:2496-2498` - "both sides keep an unsorted file-list array
+//!   because the names will differ on the sending and receiving sides".
+//! - `flist.c:2149-2153` - allocates a separate `flist->sorted[]` pointer
+//!   array so `flist->files[]` (NDX-addressed) stays in scan order.
+
+use std::ffi::OsString;
+use std::io::Cursor;
+
+use protocol::ProtocolVersion;
+use protocol::flist::{FileEntry, FileListWriter};
+
+use super::super::super::ReceiverContext;
+use super::super::support::test_handshake;
+use crate::config::{ConnectionConfig, ServerConfig};
+use crate::role::ServerRole;
+
+/// Wire bytes for the regression scenario: three entries in scan order
+/// where the receiver's natural file-before-directory comparator would
+/// permute them. The sort permutation models what `sort_file_list` would
+/// do to the NDX-addressed array, breaking subsequent generator requests.
+fn build_wire_bytes(entries: &[FileEntry]) -> Vec<u8> {
+    let mut data = Vec::new();
+    let mut writer = FileListWriter::new(ProtocolVersion::try_from(32u8).unwrap());
+    for entry in entries {
+        writer.write_entry(&mut data, entry).unwrap();
+    }
+    writer.write_end(&mut data, None).unwrap();
+    data
+}
+
+fn build_iconv_config() -> ServerConfig {
+    let converter = protocol::iconv::FilenameConverter::new("UTF-8", "ISO-8859-1")
+        .expect("UTF-8/LATIN1 converter must construct on every platform");
+    ServerConfig {
+        role: ServerRole::Receiver,
+        protocol: ProtocolVersion::try_from(32u8).unwrap(),
+        flag_string: "-logDtpre.iLsf".to_owned(),
+        args: vec![OsString::from(".")],
+        connection: ConnectionConfig {
+            iconv: Some(converter),
+            ..ConnectionConfig::default()
+        },
+        ..Default::default()
+    }
+}
+
+fn build_no_iconv_config() -> ServerConfig {
+    ServerConfig {
+        role: ServerRole::Receiver,
+        protocol: ProtocolVersion::try_from(32u8).unwrap(),
+        flag_string: "-logDtpre.".to_owned(),
+        args: vec![OsString::from(".")],
+        ..Default::default()
+    }
+}
+
+/// When iconv is active, the receiver must preserve sender wire-emit order
+/// in `file_list`. Otherwise the receiver re-sorts and subsequent generator
+/// requests resolve to the wrong entry (e.g., asking to transfer a directory
+/// at an index that should point to a regular file).
+#[test]
+fn iconv_active_preserves_wire_order_for_ndx_lookup() {
+    // Sender scan order: directory, file, file-in-directory. Under the
+    // default protocol-29+ comparator that buckets files before directories,
+    // `sort_file_list` would reorder this to ["zebra.txt", "alpha",
+    // "alpha/inner.txt"], breaking the wire NDX -> flat-index identity.
+    let wire_entries = vec![
+        FileEntry::new_directory("alpha".into(), 0o755),
+        FileEntry::new_file("zebra.txt".into(), 42, 0o644),
+        FileEntry::new_file("alpha/inner.txt".into(), 7, 0o644),
+    ];
+    let data = build_wire_bytes(&wire_entries);
+
+    let handshake = test_handshake();
+    let mut ctx = ReceiverContext::new(&handshake, build_iconv_config());
+    let mut cursor = Cursor::new(data);
+    let count = ctx.receive_file_list(&mut cursor).unwrap();
+
+    assert_eq!(count, 3);
+    let names: Vec<&str> = ctx.file_list().iter().map(|e| e.name()).collect();
+    assert_eq!(
+        names,
+        vec!["alpha", "zebra.txt", "alpha/inner.txt"],
+        "iconv-active receiver must keep entries in sender wire-emit order \
+         so generator NDX requests resolve to the right entry"
+    );
+}
+
+/// Without iconv, the receiver still sorts file_list to match the sender
+/// (sender wire-emit was unsorted scan order; both sides re-sort by the same
+/// comparator on the same bytes so the result matches). This pins the
+/// non-iconv path unchanged so the iconv fix does not regress it.
+#[test]
+fn no_iconv_path_still_sorts_entries() {
+    let wire_entries = vec![
+        FileEntry::new_directory("alpha".into(), 0o755),
+        FileEntry::new_file("zebra.txt".into(), 42, 0o644),
+        FileEntry::new_file("alpha/inner.txt".into(), 7, 0o644),
+    ];
+    let data = build_wire_bytes(&wire_entries);
+
+    let handshake = test_handshake();
+    let mut ctx = ReceiverContext::new(&handshake, build_no_iconv_config());
+    let mut cursor = Cursor::new(data);
+    let count = ctx.receive_file_list(&mut cursor).unwrap();
+
+    assert_eq!(count, 3);
+    let names: Vec<&str> = ctx.file_list().iter().map(|e| e.name()).collect();
+    // protocol-29+ comparator: files before directories at the same level,
+    // then directory contents follow the directory entry.
+    assert_eq!(
+        names,
+        vec!["zebra.txt", "alpha", "alpha/inner.txt"],
+        "non-iconv receiver must keep the existing sort so the NDX lookup \
+         continues to match the upstream sender's sorted view"
+    );
+}
+
+/// An iconv converter whose local and remote encodings are identical
+/// performs no transcoding, so the NDX-addressed array cannot diverge
+/// from the sender's wire view. Mirrors upstream's check at
+/// `options.c:2053` that nulls out `iconv_opt` on `--iconv=-`, leaving
+/// `need_unsorted_flist` unset.
+#[test]
+fn identity_iconv_does_not_suppress_reorder() {
+    let identity = protocol::iconv::FilenameConverter::identity();
+    let mut config = build_no_iconv_config();
+    config.connection.iconv = Some(identity);
+
+    let wire_entries = vec![
+        FileEntry::new_directory("alpha".into(), 0o755),
+        FileEntry::new_file("zebra.txt".into(), 42, 0o644),
+        FileEntry::new_file("alpha/inner.txt".into(), 7, 0o644),
+    ];
+    let data = build_wire_bytes(&wire_entries);
+
+    let handshake = test_handshake();
+    let mut ctx = ReceiverContext::new(&handshake, config);
+    let mut cursor = Cursor::new(data);
+    let count = ctx.receive_file_list(&mut cursor).unwrap();
+
+    assert_eq!(count, 3);
+    let names: Vec<&str> = ctx.file_list().iter().map(|e| e.name()).collect();
+    assert_eq!(
+        names,
+        vec!["zebra.txt", "alpha", "alpha/inner.txt"],
+        "identity iconv must behave like no iconv: the sort still runs"
+    );
+}

--- a/crates/transfer/src/receiver/tests/file_list/incremental_receiver.rs
+++ b/crates/transfer/src/receiver/tests/file_list/incremental_receiver.rs
@@ -52,6 +52,7 @@ fn try_read_one_returns_false_when_finished() {
         finished_reading: true, // Already finished
         entries_read: 0,
         use_qsort: false,
+        iconv_reorder_suppressed: false,
     };
 
     // Should return false since already finished

--- a/crates/transfer/src/receiver/tests/file_list/mod.rs
+++ b/crates/transfer/src/receiver/tests/file_list/mod.rs
@@ -27,6 +27,7 @@
 
 mod delete_pipeline_hook;
 mod filter_chain;
+#[cfg(feature = "iconv")]
 mod iconv_wire_order;
 mod id_lists;
 mod incremental_directories;

--- a/crates/transfer/src/receiver/tests/file_list/mod.rs
+++ b/crates/transfer/src/receiver/tests/file_list/mod.rs
@@ -21,9 +21,13 @@
 //!   and round-trip coverage.
 //! - [`delete_pipeline_hook`] - DDP-B3 hook that publishes one delete
 //!   plan per INC_RECURSE segment.
+//! - [`iconv_wire_order`] - regression coverage for the receiver-side
+//!   `--iconv` ordering invariant (file_list stays in sender wire-emit
+//!   order, never re-sorted on local-charset bytes).
 
 mod delete_pipeline_hook;
 mod filter_chain;
+mod iconv_wire_order;
 mod id_lists;
 mod incremental_directories;
 mod incremental_receiver;


### PR DESCRIPTION
## Summary

Pulls from an upstream rsync 3.4.1 daemon with `--iconv=UTF-8,LATIN1` aborted with `received request to transfer non-regular file <ndx>: ...` whenever any transcoded filename's local-charset bytes sorted differently from its wire bytes. The receiver decoded each entry, converted the filename through the configured `FilenameConverter`, then re-sorted the NDX-addressed `file_list` in local-charset order - but the upstream generator's subsequent requests indexed against the sender's wire-byte (scan) order. NDX -> entry resolution drifted to the wrong slot and the type check rejected the resulting directory/symlink as non-regular.

## Root cause and chosen approach

Upstream handles this with `need_unsorted_flist` (options.c:2056), set whenever `iconv_opt` resolves to an actual conversion. The receiver allocates a separate `flist->sorted[]` pointer array while `flist->files[]` (NDX-addressed) stays in scan order; both sides agree on the NDX <-> entry mapping without sharing a comparator on bytes that diverge after iconv (flist.c:2149-2153, 2496-2498).

Options considered:
1. **Skip the in-place reorder when iconv is active** *(chosen)*. Matches upstream exactly: keep `file_list` in sender wire-emit order so the existing `wire_to_flat_ndx` math stays correct. Minimal blast radius - the non-iconv path is byte-identical.
2. Maintain a parallel `wire_index -> flat_index` lookup table. Extra memory, extra invariants, easy to drift.
3. Convert names lazily at display only. Larger refactor of the entry storage model.

Option 1 lands as a `iconv_reorder_suppressed()` predicate on `ReceiverContext` that is checked in both `receive_file_list` and `receive_extra_file_lists` (INC_RECURSE), plus the streaming `IncrementalFileListReceiver::collect_sorted` fallback. An identity converter (same local/remote encoding) leaves bytes untouched, mirroring upstream's `--iconv=-` short-circuit, so the reorder still runs in that case and the non-iconv code path is unchanged.

## Test plan

- [x] `cargo nextest run -p transfer --all-features -E 'test(iconv_wire_order)'` - 3 new regression tests covering iconv-active, no-iconv, and identity-iconv (all pass)
- [x] `cargo nextest run -p transfer --all-features -E 'test(receiver::tests::file_list)'` - 78 receiver file-list tests (all pass)
- [x] `cargo nextest run -p transfer --all-features --no-fail-fast` excluding 2 pre-existing failures (unrelated to this change: `generator::tests::files_from::relative_absolute_source_preserves_full_prefix` is a macOS tempdir-symlink quirk, `empty_file_checksum_verification_sha1` is a SHA1 vector mismatch on master) - 1611 tests pass
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings`
- [ ] CI: fmt+clippy, nextest (stable), Windows, macOS, Linux musl
- [ ] Live interop pull from upstream daemon with `--iconv=UTF-8,LATIN1` on non-ASCII filenames (validated under BR-2e interop harness once CI passes)

upstream: options.c:2051-2056, flist.c:2496-2498, flist.c:2149-2153