### PR TITLE
fix(engine): apply --iconv conversion in local-copy executor

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -80,7 +80,7 @@ xattr = ["transfer/xattr"]
 acl = ["metadata/acl", "engine/acl", "transfer/acl"]
 
 # Character encoding conversion for filenames (iconv)
-iconv = ["protocol/iconv", "transfer/iconv"]
+iconv = ["protocol/iconv", "transfer/iconv", "engine/iconv"]
 
 # ============================================================================
 # Runtime Features

--- a/crates/core/src/client/config/iconv.rs
+++ b/crates/core/src/client/config/iconv.rs
@@ -172,6 +172,63 @@ impl IconvSetting {
             }
         }
     }
+
+    /// Resolves the iconv setting into a [`FilenameConverter`] that maps
+    /// source-side bytes directly to destination-side bytes for a pure
+    /// local-copy (no wire involved).
+    ///
+    /// In upstream rsync's local-copy mode, both sender and receiver run
+    /// in the same address space but each opens its own iconv context.
+    /// The split at the comma is described in `rsync.c:118-122`:
+    ///
+    /// ```text
+    /// if ((cp = strchr(iconv_opt, ',')) != NULL) {
+    ///     if (am_server) iconv_opt = cp + 1; // receiver sees REMOTE
+    ///     else            *cp = '\0';        // sender sees LOCAL
+    /// }
+    /// ```
+    ///
+    /// The sender then opens `ic_send = iconv_open(UTF8, LOCAL)` and the
+    /// receiver opens `ic_recv = iconv_open(REMOTE, UTF8)`
+    /// (`rsync.c:130-140`). A filename therefore travels through both
+    /// converters: LOCAL -> UTF-8 wire -> REMOTE. Composing those is
+    /// equivalent to a single `FilenameConverter` whose local charset is
+    /// LOCAL and whose remote charset is REMOTE, used in
+    /// `local_to_remote` direction.
+    ///
+    /// For `IconvSetting::Explicit { local, remote: None }` upstream
+    /// treats the omitted half as locale (server side), which in our
+    /// codebase resolves to UTF-8. The result is identical to the
+    /// SSH/daemon `resolve_converter` output.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `rsync.c:118-122` - LOCAL/REMOTE split between client and server.
+    /// - `rsync.c:130-140` - `ic_send`/`ic_recv` `iconv_open` calls.
+    /// - `flist.c:1579-1603` - sender applies `ic_send` to filenames.
+    /// - `flist.c:738-754` - receiver applies `ic_recv` to filenames.
+    pub fn resolve_local_copy_converter(&self) -> Option<FilenameConverter> {
+        match self {
+            Self::Unspecified | Self::Disabled => None,
+            Self::LocaleDefault => Some(converter_from_locale()),
+            Self::Explicit { local, remote } => {
+                let remote_charset = remote.as_deref().unwrap_or("UTF-8");
+                match FilenameConverter::new(local, remote_charset) {
+                    Ok(converter) => Some(converter),
+                    Err(_error) => {
+                        #[cfg(feature = "tracing")]
+                        tracing::warn!(
+                            local = %local,
+                            remote = %remote_charset,
+                            error = %_error,
+                            "--iconv: unsupported charset pair; local-copy filenames will not be transcoded",
+                        );
+                        None
+                    }
+                }
+            }
+        }
+    }
 }
 
 /// Errors raised while parsing an iconv specification.
@@ -344,6 +401,78 @@ mod tests {
             remote: Some("UTF-8".to_owned()),
         };
         assert!(setting.resolve_converter().is_none());
+    }
+
+    #[test]
+    fn resolve_local_copy_converter_unspecified_is_none() {
+        assert!(
+            IconvSetting::Unspecified
+                .resolve_local_copy_converter()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn resolve_local_copy_converter_disabled_is_none() {
+        assert!(
+            IconvSetting::Disabled
+                .resolve_local_copy_converter()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn resolve_local_copy_converter_locale_default_is_identity() {
+        let converter = IconvSetting::LocaleDefault
+            .resolve_local_copy_converter()
+            .expect("locale-default produces a converter");
+        assert!(converter.is_identity());
+    }
+
+    #[cfg(feature = "iconv")]
+    #[test]
+    fn resolve_local_copy_converter_explicit_pair_uses_both_sides() {
+        // upstream: rsync.c:118-140 - in local-copy mode the sender opens
+        // ic_send=iconv_open(UTF8, LOCAL) and the receiver opens
+        // ic_recv=iconv_open(REMOTE, UTF8). Composing both is equivalent
+        // to a single LOCAL->REMOTE converter.
+        let setting = IconvSetting::Explicit {
+            local: "UTF-8".to_owned(),
+            remote: Some("ISO-8859-1".to_owned()),
+        };
+        let converter = setting
+            .resolve_local_copy_converter()
+            .expect("explicit pair resolves");
+        assert!(!converter.is_identity());
+        assert_eq!(converter.local_encoding_name(), "UTF-8");
+        // encoding_rs aliases ISO-8859-1 to windows-1252 per the WHATWG
+        // Encoding spec; the rendered name is therefore "windows-1252".
+        assert_ne!(converter.remote_encoding_name(), "UTF-8");
+    }
+
+    #[cfg(feature = "iconv")]
+    #[test]
+    fn resolve_local_copy_converter_explicit_single_pairs_with_utf8() {
+        // Upstream behaviour for a bare LOCAL: the server falls back to
+        // locale on its side, which oc-rsync renders as UTF-8.
+        let setting = IconvSetting::Explicit {
+            local: "ISO-8859-1".to_owned(),
+            remote: None,
+        };
+        let converter = setting
+            .resolve_local_copy_converter()
+            .expect("single charset resolves");
+        assert!(!converter.is_identity());
+        assert_eq!(converter.remote_encoding_name(), "UTF-8");
+    }
+
+    #[test]
+    fn resolve_local_copy_converter_malformed_falls_back_to_none() {
+        let setting = IconvSetting::Explicit {
+            local: "definitely-not-a-real-charset".to_owned(),
+            remote: Some("UTF-8".to_owned()),
+        };
+        assert!(setting.resolve_local_copy_converter().is_none());
     }
 
     mod debug_iconv_emissions {

--- a/crates/core/src/client/run/mod.rs
+++ b/crates/core/src/client/run/mod.rs
@@ -460,26 +460,32 @@ impl<'a> LocalCopyOptionsBuilder<'a> {
     /// [`FilenameConverter`](protocol::iconv::FilenameConverter) and
     /// attaches it to the local-copy options.
     ///
-    /// This is the local-copy mirror of the SSH/daemon path's
-    /// `apply_common_server_flags`
-    /// (`crates/core/src/client/remote/flags.rs:203-228`), which writes the
-    /// converter onto `transfer::config::ConnectionConfig::iconv`. The
-    /// local-copy executor lives in the engine crate and does not traverse
-    /// the SSH/daemon `ServerConfig` builder, so the bridge has to be
-    /// re-applied here.
+    /// Local-copy must encode source-side bytes (`LOCAL`) directly into
+    /// destination-side bytes (`REMOTE`) because no wire stage is
+    /// present. This is the composition of the sender and receiver
+    /// iconv contexts upstream rsync opens when both processes share an
+    /// address space: see [`IconvSetting::resolve_local_copy_converter`]
+    /// for the derivation against `rsync.c:118-140`. The SSH/daemon
+    /// invocation builder already forwards the user's `--iconv=` string
+    /// to the remote CLI verbatim, so the bare-`LOCAL` form keeps
+    /// behaving as today on the wire.
     ///
     /// When `IconvSetting::Unspecified` or `IconvSetting::Disabled`,
-    /// `resolve_converter` returns `None`, leaving the engine's
-    /// pass-through behaviour untouched. This mirrors upstream rsync's
-    /// behaviour when `--iconv` is absent or `--no-iconv` is supplied.
+    /// `resolve_local_copy_converter` returns `None`, leaving the
+    /// engine's pass-through behaviour untouched. This mirrors upstream
+    /// rsync's behaviour when `--iconv` is absent or `--no-iconv` is
+    /// supplied.
     ///
     /// # Upstream Reference
     ///
-    /// - `flist.c::iconv_for_local`
+    /// - `rsync.c:118-140` `setup_iconv()` - LOCAL/REMOTE split and
+    ///   `ic_send`/`ic_recv` `iconv_open` calls.
+    /// - `flist.c:1579-1603` `send_file_name()` sender filename transcode.
+    /// - `flist.c:738-754` `recv_file_entry()` receiver filename transcode.
     /// - `options.c::recv_iconv_settings`
     /// - `compat.c:716-718`
     fn apply_iconv(&self, options: LocalCopyOptions, config: &ClientConfig) -> LocalCopyOptions {
-        options.with_iconv(config.iconv().resolve_converter())
+        options.with_iconv(config.iconv().resolve_local_copy_converter())
     }
 
     const fn apply_recursion_and_delete(
@@ -743,11 +749,13 @@ mod iconv_wiring_tests {
     #[cfg(feature = "iconv")]
     #[test]
     fn local_copy_options_iconv_explicit_yields_converter() {
-        // upstream: rsync.c:130-140 - wire is always UTF-8. With local=UTF-8,
-        // resolve_converter hands back an identity converter; the `remote`
-        // half is forwarded to the peer CLI separately rather than consumed
-        // on this side. The contract here is that the engine receives
-        // *some* converter (not None) so its iconv-aware paths are wired in.
+        // upstream: rsync.c:118-140 - in local-copy mode the sender opens
+        // ic_send=iconv_open(UTF8, LOCAL) and the receiver opens
+        // ic_recv=iconv_open(REMOTE, UTF8). Composing both is equivalent
+        // to a single LOCAL -> REMOTE converter, which is what the engine
+        // applies to filenames on emit. The contract here is that the
+        // engine receives a non-identity converter when LOCAL != REMOTE
+        // so its iconv-aware path is wired in.
         let config = config_with_iconv(IconvSetting::Explicit {
             local: "UTF-8".to_owned(),
             remote: Some("ISO-8859-1".to_owned()),
@@ -756,7 +764,7 @@ mod iconv_wiring_tests {
         let converter = options
             .iconv()
             .expect("explicit iconv pair should produce a converter");
-        assert!(converter.is_identity());
+        assert!(!converter.is_identity());
         assert_eq!(converter.local_encoding_name(), "UTF-8");
     }
 

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -70,6 +70,19 @@ xattr = ["metadata/xattr"]
 acl = ["metadata/acl"]
 
 # ============================================================================
+# Character Encoding Features
+# ============================================================================
+
+# Filename character set conversion (`--iconv=LOCAL,REMOTE`). Forwards to
+# `protocol/iconv` so the engine's local-copy executor can use real
+# `encoding_rs` conversions. Without this feature, the executor still
+# compiles but a non-UTF-8 `FilenameConverter` cannot be constructed, so
+# `--iconv` falls back to pass-through bytes (matching the engine-only
+# build profile used by some test suites). The default workspace build
+# turns this on via `core` -> `protocol/iconv`.
+iconv = ["protocol/iconv"]
+
+# ============================================================================
 # Performance Optimization Features
 # ============================================================================
 

--- a/crates/engine/src/local_copy/executor/directory/planner.rs
+++ b/crates/engine/src/local_copy/executor/directory/planner.rs
@@ -4,6 +4,9 @@
 //! based on file type, filter rules, and command-line options. Mirrors the
 //! decision logic in upstream `flist.c:make_file()` and `flist.c:flist_sort_and_clean()`.
 
+use std::borrow::Cow;
+use std::ffi::OsStr;
+#[cfg(test)]
 use std::ffi::OsString;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -13,7 +16,7 @@ use crate::local_copy::{
     follow_symlink_metadata,
 };
 
-use super::super::{non_empty_path, symlink_target_is_safe};
+use super::super::{non_empty_path, symlink_target_is_safe, transcode_filename_component};
 use super::support::{DirectoryEntry, is_device, is_fifo};
 
 /// Action to take for a directory entry during recursive copy.
@@ -61,8 +64,15 @@ impl<'a> PlannedEntry<'a> {
 pub(crate) struct DirectoryPlan<'a> {
     pub(crate) planned_entries: Vec<PlannedEntry<'a>>,
     /// Names of entries to keep when deleting extraneous files.
-    /// References the file_name fields of DirectoryEntry, avoiding allocation.
-    pub(crate) keep_names: Vec<&'a OsString>,
+    ///
+    /// When `--iconv` is not configured this borrows the
+    /// `DirectoryEntry::file_name` fields zero-copy. With `--iconv` the
+    /// destination filename is the iconv-converted form (LOCAL -> REMOTE),
+    /// so the keep-list must hold the converted bytes for the deletion
+    /// step to compare them against the actual on-disk destination
+    /// entries. The `Cow` keeps the no-iconv hot path allocation-free
+    /// while letting the iconv path own the transcoded `OsString`.
+    pub(crate) keep_names: Vec<Cow<'a, OsStr>>,
     pub(crate) deletion_enabled: bool,
     pub(crate) delete_timing: Option<DeleteTiming>,
 }
@@ -323,7 +333,14 @@ pub(crate) fn plan_directory_entries<'a>(
             };
 
             if preserve_name {
-                keep_names.push(file_name);
+                // upstream: flist.c:1579-1603 + flist.c:738-754 - the
+                // receiver hits the filesystem with the iconv-converted
+                // name; align the keep-list so deletion does not wipe
+                // freshly-written entries when --iconv is configured.
+                keep_names.push(transcode_filename_component(
+                    file_name.as_os_str(),
+                    context.options().iconv(),
+                ));
             }
         }
 
@@ -583,7 +600,14 @@ fn plan_directory_entries_with_prefetch<'a>(
             };
 
             if preserve_name {
-                keep_names.push(file_name);
+                // upstream: flist.c:1579-1603 + flist.c:738-754 - the
+                // receiver hits the filesystem with the iconv-converted
+                // name; align the keep-list so deletion does not wipe
+                // freshly-written entries when --iconv is configured.
+                keep_names.push(transcode_filename_component(
+                    file_name.as_os_str(),
+                    context.options().iconv(),
+                ));
             }
         }
 
@@ -683,7 +707,7 @@ mod tests {
         let names = [OsString::from("keep_me")];
         let plan = DirectoryPlan {
             planned_entries: Vec::new(),
-            keep_names: names.iter().collect(),
+            keep_names: names.iter().map(|n| Cow::Borrowed(n.as_os_str())).collect(),
             deletion_enabled: true,
             delete_timing: Some(DeleteTiming::Before),
         };
@@ -712,7 +736,7 @@ mod tests {
         ];
         let plan = DirectoryPlan {
             planned_entries: Vec::new(),
-            keep_names: names.iter().collect(),
+            keep_names: names.iter().map(|n| Cow::Borrowed(n.as_os_str())).collect(),
             deletion_enabled: true,
             delete_timing: Some(DeleteTiming::During),
         };

--- a/crates/engine/src/local_copy/executor/directory/recursive/checksum.rs
+++ b/crates/engine/src/local_copy/executor/directory/recursive/checksum.rs
@@ -8,8 +8,10 @@ use std::path::Path;
 
 use crate::local_copy::CopyContext;
 
+use super::super::super::transcode_filename_component;
 use super::super::parallel_checksum::{ChecksumCache, FilePair};
 use super::super::planner::{DirectoryPlan, EntryAction};
+use protocol::iconv::FilenameConverter;
 
 /// Collects file pairs for parallel checksum prefetching.
 ///
@@ -26,9 +28,17 @@ use super::super::planner::{DirectoryPlan, EntryAction};
 /// # Returns
 ///
 /// A vector of file pairs suitable for parallel checksum computation.
+/// Collects source/destination file pairs from the directory plan whose
+/// matching size makes them candidates for a checksum-based quick check.
+///
+/// When `converter` is `Some`, the destination filename is transcoded
+/// from LOCAL to REMOTE so the lookup hits the same on-disk path the
+/// executor will later write to. With `None` this is a zero-overhead
+/// pass-through that mirrors the pre-iconv behaviour.
 pub(crate) fn collect_file_pairs_for_checksum(
     plan: &DirectoryPlan<'_>,
     destination: &Path,
+    converter: Option<&FilenameConverter>,
 ) -> Vec<FilePair> {
     let mut pairs = Vec::new();
 
@@ -38,7 +48,8 @@ pub(crate) fn collect_file_pairs_for_checksum(
         }
 
         let source_path = &planned.entry.path;
-        let target_path = destination.join(Path::new(&planned.entry.file_name));
+        let dest_name = transcode_filename_component(&planned.entry.file_name, converter);
+        let target_path = destination.join(Path::new(&*dest_name));
         let source_size = planned.metadata().len();
 
         // Check if destination exists and get its size
@@ -88,7 +99,7 @@ pub(crate) fn prefetch_directory_checksums(
         return ChecksumCache::new();
     }
 
-    let pairs = collect_file_pairs_for_checksum(plan, destination);
+    let pairs = collect_file_pairs_for_checksum(plan, destination, context.options().iconv());
 
     // Skip prefetching if no eligible pairs
     if pairs.is_empty() {

--- a/crates/engine/src/local_copy/executor/directory/recursive/deletion.rs
+++ b/crates/engine/src/local_copy/executor/directory/recursive/deletion.rs
@@ -5,7 +5,8 @@
 
 // upstream: generator.c:delete_in_dir() - post-transfer deletion
 
-use std::ffi::OsString;
+use std::borrow::Cow;
+use std::ffi::{OsStr, OsString};
 use std::fs;
 use std::path::Path;
 
@@ -19,7 +20,7 @@ pub(super) fn handle_post_transfer_deletions(
     relative: Option<&Path>,
     deletion_enabled: bool,
     delete_timing: Option<DeleteTiming>,
-    keep_names: &[&OsString],
+    keep_names: &[Cow<'_, OsStr>],
 ) -> Result<(), LocalCopyError> {
     if !deletion_enabled {
         return Ok(());
@@ -40,7 +41,8 @@ pub(super) fn handle_post_transfer_deletions(
         }
         DeleteTiming::Delay | DeleteTiming::After => {
             // Clone names for deferred processing (data must outlive the plan)
-            let keep_owned: Vec<OsString> = keep_names.iter().map(|&s| s.clone()).collect();
+            let keep_owned: Vec<OsString> =
+                keep_names.iter().map(|s| OsStr::to_os_string(s)).collect();
             let relative_owned = relative.map(Path::to_path_buf);
             context.defer_deletion(destination.to_path_buf(), relative_owned, keep_owned);
         }

--- a/crates/engine/src/local_copy/executor/directory/recursive/entry.rs
+++ b/crates/engine/src/local_copy/executor/directory/recursive/entry.rs
@@ -12,6 +12,7 @@ use crate::local_copy::{
 };
 
 use super::super::super::non_empty_path;
+use super::super::super::transcode_filename_component;
 use super::super::planner::{EntryAction, PlannedEntry};
 use super::batch::capture_batch_file_entry;
 use super::copy_directory_recursive;
@@ -28,7 +29,12 @@ pub(super) fn process_planned_entry(
     root_device: Option<u64>,
 ) -> Result<bool, LocalCopyError> {
     let file_name = &planned.entry.file_name;
-    let target_path = destination.join(Path::new(file_name));
+    // upstream: flist.c:1579-1603 (sender) + flist.c:738-754 (receiver) -
+    // the receiver opens the file with the iconv-converted name. For
+    // local-copy the two contexts compose to LOCAL -> REMOTE; apply that
+    // transcoding here before joining onto the destination directory.
+    let dest_name = transcode_filename_component(file_name, context.options().iconv());
+    let target_path = destination.join(Path::new(&*dest_name));
     let entry_metadata = planned.metadata();
     let record_relative = non_empty_path(planned.relative.as_path());
 

--- a/crates/engine/src/local_copy/executor/directory/recursive/mod.rs
+++ b/crates/engine/src/local_copy/executor/directory/recursive/mod.rs
@@ -344,7 +344,7 @@ mod tests {
             delete_timing: None,
         };
 
-        let pairs = collect_file_pairs_for_checksum(&plan, &dest_dir);
+        let pairs = collect_file_pairs_for_checksum(&plan, &dest_dir, None);
 
         assert_eq!(pairs.len(), 2);
         assert!(pairs.iter().any(|p| p.source.ends_with("file1.txt")));
@@ -376,7 +376,7 @@ mod tests {
             delete_timing: None,
         };
 
-        let pairs = collect_file_pairs_for_checksum(&plan, &dest_dir);
+        let pairs = collect_file_pairs_for_checksum(&plan, &dest_dir, None);
 
         assert!(pairs.is_empty());
     }
@@ -408,7 +408,7 @@ mod tests {
             delete_timing: None,
         };
 
-        let pairs = collect_file_pairs_for_checksum(&plan, &dest_dir);
+        let pairs = collect_file_pairs_for_checksum(&plan, &dest_dir, None);
 
         assert!(pairs.is_empty());
     }
@@ -440,7 +440,7 @@ mod tests {
             delete_timing: None,
         };
 
-        let pairs = collect_file_pairs_for_checksum(&plan, &dest_dir);
+        let pairs = collect_file_pairs_for_checksum(&plan, &dest_dir, None);
 
         assert_eq!(pairs.len(), 1);
         assert_eq!(pairs[0].source_size, 100);

--- a/crates/engine/src/local_copy/executor/iconv.rs
+++ b/crates/engine/src/local_copy/executor/iconv.rs
@@ -1,0 +1,166 @@
+//! Filename transcoding for the local-copy executor.
+//!
+//! Applies the `--iconv=LOCAL,REMOTE` converter attached to
+//! [`LocalCopyOptions`](crate::local_copy::LocalCopyOptions) to source
+//! filename components before they become destination filesystem entries.
+//!
+//! In upstream rsync's local-copy mode the sender and receiver share an
+//! address space but each opens its own `iconv_t` context (`rsync.c:118-140`).
+//! The destination filename is the composition of `ic_send` (LOCAL -> UTF-8
+//! wire) and `ic_recv` (UTF-8 wire -> REMOTE), which collapses to a single
+//! LOCAL -> REMOTE transcoding. The bridge from `--iconv` to the
+//! [`FilenameConverter`](protocol::iconv::FilenameConverter) used here lives
+//! in
+//! [`IconvSetting::resolve_local_copy_converter`](core::client::config::IconvSetting::resolve_local_copy_converter).
+//!
+//! # Upstream Reference
+//!
+//! - `flist.c:1579-1603` `send_file_name()` - `iconvbufs(ic_send, ...)`
+//!   transcodes the filename before it leaves the sender.
+//! - `flist.c:738-754` `recv_file_entry()` - `iconvbufs(ic_recv, ...)`
+//!   transcodes the filename before the receiver hits the filesystem.
+
+use std::borrow::Cow;
+use std::ffi::{OsStr, OsString};
+
+use protocol::iconv::FilenameConverter;
+
+/// Returns the byte representation of a filename component for iconv input.
+///
+/// Unix `OsStr` values are arbitrary byte strings (`OsStrExt::as_bytes`).
+/// On other platforms `OsStr::as_encoded_bytes` returns the WTF-8 encoding
+/// used by Rust internally. Either representation is valid input to
+/// [`encoding_rs`](https://docs.rs/encoding_rs/), which `FilenameConverter`
+/// wraps.
+#[inline]
+fn os_str_to_bytes(name: &OsStr) -> &[u8] {
+    #[cfg(unix)]
+    {
+        use std::os::unix::ffi::OsStrExt;
+        name.as_bytes()
+    }
+    #[cfg(not(unix))]
+    {
+        name.as_encoded_bytes()
+    }
+}
+
+/// Reconstructs an `OsString` from converted iconv output bytes.
+///
+/// On Unix the bytes are passed through verbatim because `OsStr` can hold
+/// any byte sequence. On non-Unix platforms `OsString` requires WTF-8 input
+/// when constructed via `OsString::from_encoded_bytes_unchecked`. Since the
+/// iconv result is encoded in REMOTE charset (which may not be UTF-8 / WTF-8
+/// at all), we route non-Unix platforms through `String::from_utf8_lossy`,
+/// matching the established receiver-side pattern in
+/// `protocol::flist::read::extras` for symlink targets. This trades
+/// REMOTE-charset fidelity for safe `OsString` construction on Windows;
+/// no behavioural regression vs. the prior implementation because the
+/// prior implementation never transcoded local-copy filenames at all.
+#[inline]
+fn bytes_to_os_string(bytes: Vec<u8>) -> OsString {
+    #[cfg(unix)]
+    {
+        use std::os::unix::ffi::OsStringExt;
+        OsString::from_vec(bytes)
+    }
+    #[cfg(not(unix))]
+    {
+        let lossy = String::from_utf8_lossy(&bytes);
+        OsString::from(lossy.into_owned())
+    }
+}
+
+/// Transcodes a single filename component using the configured converter.
+///
+/// Returns `Cow::Borrowed` when the converter is absent, is an identity
+/// converter, or the round-trip produced bytes equal to the input. This
+/// preserves the no-allocation hot path for transfers without `--iconv`.
+///
+/// When the converter rejects the input (e.g. invalid LOCAL bytes that
+/// cannot be represented in REMOTE), the original component is returned
+/// unchanged. Upstream rsync surfaces this as an `IOERR_GENERAL` plus a
+/// `cannot convert filename` line on the sender side; here we degrade to
+/// pass-through to keep the transfer making progress, matching the
+/// existing receiver-side fallback in
+/// [`with_iconv`](protocol::flist::read::FileListReader::with_iconv)
+/// callers which also continue past `InvalidData` filename rows.
+#[must_use]
+pub(crate) fn transcode_filename_component<'a>(
+    name: &'a OsStr,
+    converter: Option<&FilenameConverter>,
+) -> Cow<'a, OsStr> {
+    let Some(converter) = converter else {
+        return Cow::Borrowed(name);
+    };
+    if converter.is_identity() {
+        return Cow::Borrowed(name);
+    }
+
+    let bytes = os_str_to_bytes(name);
+    match converter.local_to_remote(bytes) {
+        Ok(Cow::Borrowed(borrowed)) if borrowed.as_ptr() == bytes.as_ptr() => Cow::Borrowed(name),
+        Ok(converted) => Cow::Owned(bytes_to_os_string(converted.into_owned())),
+        Err(_) => Cow::Borrowed(name),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_converter_returns_borrowed() {
+        let name = OsStr::new("hello.txt");
+        let out = transcode_filename_component(name, None);
+        assert!(matches!(out, Cow::Borrowed(_)));
+        assert_eq!(&*out, OsStr::new("hello.txt"));
+    }
+
+    #[test]
+    fn identity_converter_returns_borrowed() {
+        let name = OsStr::new("hello.txt");
+        let conv = FilenameConverter::identity();
+        let out = transcode_filename_component(name, Some(&conv));
+        assert!(matches!(out, Cow::Borrowed(_)));
+        assert_eq!(&*out, OsStr::new("hello.txt"));
+    }
+
+    #[cfg(all(unix, feature = "iconv"))]
+    #[test]
+    fn utf8_to_latin1_emits_latin1_bytes() {
+        use std::os::unix::ffi::OsStrExt;
+
+        // Source "café.txt" in UTF-8: c3 a9 for "é".
+        let utf8 = OsStr::from_bytes(b"caf\xc3\xa9.txt");
+        let conv = FilenameConverter::new("UTF-8", "ISO-8859-1").expect("ctor");
+        let out = transcode_filename_component(utf8, Some(&conv));
+        // Latin-1 "café.txt" replaces "é" with the single byte 0xe9.
+        assert_eq!(out.as_bytes(), b"caf\xe9.txt");
+    }
+
+    #[cfg(all(unix, feature = "iconv"))]
+    #[test]
+    fn latin1_to_utf8_emits_utf8_bytes() {
+        use std::os::unix::ffi::OsStrExt;
+
+        // Source "café.txt" in Latin-1: e9 for "é".
+        let latin1 = OsStr::from_bytes(b"caf\xe9.txt");
+        let conv = FilenameConverter::new("ISO-8859-1", "UTF-8").expect("ctor");
+        let out = transcode_filename_component(latin1, Some(&conv));
+        // UTF-8 "café.txt" expands "é" to c3 a9.
+        assert_eq!(out.as_bytes(), b"caf\xc3\xa9.txt");
+    }
+
+    #[cfg(all(unix, feature = "iconv"))]
+    #[test]
+    fn invalid_bytes_fall_back_to_pass_through() {
+        use std::os::unix::ffi::OsStrExt;
+
+        // Lone continuation byte is not valid UTF-8.
+        let bad = OsStr::from_bytes(b"bad\x80name");
+        let conv = FilenameConverter::new("UTF-8", "ISO-8859-1").expect("ctor");
+        let out = transcode_filename_component(bad, Some(&conv));
+        assert_eq!(out.as_bytes(), b"bad\x80name");
+    }
+}

--- a/crates/engine/src/local_copy/executor/mod.rs
+++ b/crates/engine/src/local_copy/executor/mod.rs
@@ -3,6 +3,7 @@
 mod cleanup;
 mod directory;
 mod file;
+mod iconv;
 mod reference;
 mod sources;
 mod special;
@@ -32,6 +33,7 @@ pub(crate) use file::{
     files_checksum_match, maybe_preallocate_destination, partial_destination_path,
     temporary_destination_path,
 };
+pub(crate) use iconv::transcode_filename_component;
 pub(crate) use reference::{ReferenceDecision, ReferenceQuery, find_reference_action};
 pub(crate) use sources::copy_sources;
 pub(crate) use special::{

--- a/crates/engine/src/local_copy/executor/sources/destination.rs
+++ b/crates/engine/src/local_copy/executor/sources/destination.rs
@@ -4,9 +4,12 @@ use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
 
+use protocol::iconv::FilenameConverter;
+
 use crate::local_copy::{LocalCopyArgumentError, LocalCopyError, LocalCopyExecution};
 
 use super::super::follow_symlink_metadata;
+use super::super::transcode_filename_component;
 use super::types::DestinationState;
 
 /// Queries the filesystem to determine destination state.
@@ -71,6 +74,12 @@ pub(crate) fn ensure_destination_directory(
 }
 
 /// Computes the target path for a non-directory entry.
+///
+/// When an `--iconv` converter is supplied, the source filename component
+/// `name` is transcoded with [`transcode_filename_component`] before being
+/// appended to `destination_base`. This mirrors upstream rsync's
+/// `flist.c:1579-1603` (sender) + `flist.c:738-754` (receiver) composition
+/// in local-copy mode (`rsync.c:118-140`).
 pub(super) fn compute_target_path(
     destination_path: &Path,
     destination_base: &Path,
@@ -78,9 +87,11 @@ pub(super) fn compute_target_path(
     destination_behaves_like_directory: bool,
     prefer_root_destination: bool,
     is_directory: bool,
+    iconv: Option<&FilenameConverter>,
 ) -> PathBuf {
     if destination_behaves_like_directory && (!prefer_root_destination || is_directory) {
-        destination_base.join(name)
+        let converted = transcode_filename_component(name, iconv);
+        destination_base.join(Path::new(&*converted))
     } else {
         destination_path.to_path_buf()
     }
@@ -89,15 +100,19 @@ pub(super) fn compute_target_path(
 /// Computes the target path for special entries (symlinks, FIFOs, devices).
 ///
 /// These entries don't use the directory-specific logic that regular files use.
+/// The `iconv` parameter applies the same LOCAL -> REMOTE transcoding the
+/// per-directory path uses; see [`compute_target_path`].
 pub(super) fn compute_special_target_path(
     destination_path: &Path,
     destination_base: &Path,
     name: &std::ffi::OsStr,
     destination_behaves_like_directory: bool,
     prefer_root_destination: bool,
+    iconv: Option<&FilenameConverter>,
 ) -> PathBuf {
     if destination_behaves_like_directory && !prefer_root_destination {
-        destination_base.join(name)
+        let converted = transcode_filename_component(name, iconv);
+        destination_base.join(Path::new(&*converted))
     } else {
         destination_path.to_path_buf()
     }

--- a/crates/engine/src/local_copy/executor/sources/handlers.rs
+++ b/crates/engine/src/local_copy/executor/sources/handlers.rs
@@ -14,7 +14,7 @@ use ::metadata::MetadataOptions;
 
 use super::super::{
     capture_batch_file_entry, copy_device, copy_directory_recursive, copy_fifo, copy_file,
-    copy_symlink, non_empty_path,
+    copy_symlink, non_empty_path, transcode_filename_component,
 };
 use super::destination::{compute_special_target_path, compute_target_path};
 use super::metadata::resolve_effective_metadata;
@@ -154,7 +154,11 @@ pub(super) fn handle_directory_copy(
     }
 
     let target = if destination_behaves_like_directory || multiple_sources {
-        destination_base.join(name)
+        // upstream: flist.c:1579-1603 + flist.c:738-754 - filename is
+        // transcoded LOCAL -> wire -> REMOTE; for local-copy this
+        // collapses to LOCAL -> REMOTE applied here before joining.
+        let converted = transcode_filename_component(name, context.options().iconv());
+        destination_base.join(Path::new(&*converted))
     } else {
         destination_path.to_path_buf()
     };
@@ -201,6 +205,7 @@ pub(super) fn handle_symlink_copy(
             name,
             destination_behaves_like_directory,
             prefer_root_destination,
+            context.options().iconv(),
         );
 
         copy_symlink(
@@ -244,6 +249,7 @@ pub(super) fn handle_fifo_copy(
         name,
         destination_behaves_like_directory,
         prefer_root_destination,
+        context.options().iconv(),
     );
 
     copy_fifo(
@@ -280,6 +286,7 @@ pub(super) fn handle_device_copy(
         name,
         destination_behaves_like_directory,
         prefer_root_destination,
+        context.options().iconv(),
     );
 
     if context.copy_devices_as_files_enabled() {
@@ -359,6 +366,7 @@ pub(super) fn handle_non_directory_source(
             proc_ctx.destination_behaves_like_directory,
             prefer_root_destination,
             false,
+            context.options().iconv(),
         );
         let _ = copy_file(
             context,
@@ -375,6 +383,7 @@ pub(super) fn handle_non_directory_source(
             proc_ctx.destination_behaves_like_directory,
             prefer_root_destination,
             true,
+            context.options().iconv(),
         );
         copy_directory_recursive(
             context,

--- a/crates/engine/tests/iconv_local_copy.rs
+++ b/crates/engine/tests/iconv_local_copy.rs
@@ -1,0 +1,204 @@
+//! Integration tests for `--iconv=LOCAL,REMOTE` in the local-copy
+//! executor.
+//!
+//! Confirms that filenames are transcoded from LOCAL to REMOTE charset
+//! when a [`FilenameConverter`] is attached to
+//! [`LocalCopyOptions`]. Upstream rsync's local-copy mode opens
+//! `ic_send = iconv_open(UTF8, LOCAL)` on the sender and
+//! `ic_recv = iconv_open(REMOTE, UTF8)` on the receiver
+//! (`rsync.c:118-140`); composing those is equivalent to a single
+//! LOCAL -> REMOTE converter applied to the destination filename.
+//!
+//! # Upstream Reference
+//!
+//! - `rsync.c:118-140` `setup_iconv()` - LOCAL/REMOTE split and
+//!   `iconv_open` calls.
+//! - `flist.c:1579-1603` `send_file_name()` sender filename transcode.
+//! - `flist.c:738-754` `recv_file_entry()` receiver filename transcode.
+
+// macOS APFS and Windows NTFS both reject the raw 0xe9 byte that
+// `--iconv=UTF-8,ISO-8859-1` produces for the canonical "caf\xe9.txt"
+// scenario. Restrict to Linux where tmpfs/ext4 accept arbitrary byte
+// sequences and faithfully round-trip them through `read_dir`. The
+// production iconv path itself is platform-agnostic (`executor::iconv`
+// uses `OsStr::as_encoded_bytes` on non-Unix); the iconv setup wiring
+// and the receiver-side reference behaviour are covered by the
+// per-crate unit tests in `protocol::iconv`,
+// `engine::local_copy::executor::iconv`, and
+// `core::client::config::iconv` on all platforms.
+#![cfg(all(target_os = "linux", feature = "iconv"))]
+
+use std::ffi::{OsStr, OsString};
+use std::fs;
+use std::os::unix::ffi::{OsStrExt, OsStringExt};
+
+use engine::local_copy::{LocalCopyExecution, LocalCopyOptions, LocalCopyPlan};
+use protocol::iconv::FilenameConverter;
+use tempfile::tempdir;
+
+/// Reads the immediate file/dir basenames inside `dir` and returns them
+/// as raw byte vectors so callers can match against non-UTF-8 bytes.
+fn list_raw_names(dir: &std::path::Path) -> Vec<Vec<u8>> {
+    let mut names: Vec<Vec<u8>> = fs::read_dir(dir)
+        .expect("read_dir")
+        .map(|entry| entry.expect("dirent").file_name().as_bytes().to_vec())
+        .collect();
+    names.sort();
+    names
+}
+
+/// Source `café.txt` (UTF-8 bytes `c3 a9`) copied with
+/// `--iconv=UTF-8,ISO-8859-1` lands at the destination as `café.txt`
+/// encoded in Latin-1, i.e. a single 0xe9 byte for the accented `é`.
+#[test]
+fn iconv_utf8_to_latin1_transcodes_filename_on_disk() {
+    let temp = tempdir().expect("tempdir");
+    let source = temp.path().join("source");
+    let dest = temp.path().join("dest");
+    fs::create_dir_all(&source).expect("create source");
+    fs::create_dir_all(&dest).expect("create dest");
+
+    // Source file: "café.txt" with UTF-8 encoding of 'é' (c3 a9).
+    let utf8_name = OsStr::from_bytes(b"caf\xc3\xa9.txt");
+    fs::write(source.join(utf8_name), b"payload").expect("write source");
+
+    let converter = FilenameConverter::new("UTF-8", "ISO-8859-1").expect("converter");
+    let operands = vec![source.into_os_string(), dest.into_os_string()];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+    let options = LocalCopyOptions::default()
+        .recursive(true)
+        .with_iconv(Some(converter));
+
+    plan.execute_with_options(LocalCopyExecution::Apply, options)
+        .expect("local copy succeeds");
+
+    // The "dest/source" subdirectory carries the copied tree (no
+    // trailing slash on the source -> upstream behaviour). Its single
+    // entry should be the Latin-1 encoding of "café.txt": the 'é' is
+    // a single byte 0xe9 instead of c3 a9.
+    let dest_root = temp.path().join("dest").join("source");
+    let names = list_raw_names(&dest_root);
+    assert_eq!(
+        names,
+        vec![b"caf\xe9.txt".to_vec()],
+        "expected Latin-1 'caf\\xe9.txt' on disk; got {names:?}"
+    );
+
+    // Payload should still be intact - iconv only touches filenames.
+    let copied = fs::read(dest_root.join(OsStr::from_bytes(b"caf\xe9.txt"))).expect("read dest");
+    assert_eq!(copied, b"payload");
+}
+
+/// Reverse direction: Latin-1 source byte `e9` is transcoded to UTF-8
+/// `c3 a9` on the destination side.
+#[test]
+fn iconv_latin1_to_utf8_transcodes_filename_on_disk() {
+    let temp = tempdir().expect("tempdir");
+    let source = temp.path().join("source");
+    let dest = temp.path().join("dest");
+    fs::create_dir_all(&source).expect("create source");
+    fs::create_dir_all(&dest).expect("create dest");
+
+    // Source file name: raw Latin-1 byte 0xe9 for 'é'.
+    let latin1_name = OsStr::from_bytes(b"caf\xe9.txt");
+    fs::write(source.join(latin1_name), b"payload").expect("write source");
+
+    let converter = FilenameConverter::new("ISO-8859-1", "UTF-8").expect("converter");
+    let operands = vec![source.into_os_string(), dest.into_os_string()];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+    let options = LocalCopyOptions::default()
+        .recursive(true)
+        .with_iconv(Some(converter));
+
+    plan.execute_with_options(LocalCopyExecution::Apply, options)
+        .expect("local copy succeeds");
+
+    let dest_root = temp.path().join("dest").join("source");
+    let names = list_raw_names(&dest_root);
+    assert_eq!(
+        names,
+        vec![b"caf\xc3\xa9.txt".to_vec()],
+        "expected UTF-8 'caf\\xc3\\xa9.txt' on disk; got {names:?}"
+    );
+
+    let utf8_name = OsString::from_vec(b"caf\xc3\xa9.txt".to_vec());
+    let copied = fs::read(dest_root.join(utf8_name)).expect("read dest");
+    assert_eq!(copied, b"payload");
+}
+
+/// Without `--iconv` configured, filenames pass through verbatim so the
+/// destination basename equals the source basename byte-for-byte. This
+/// is the no-regression control: confirms the iconv path stays cold on
+/// the common case and the executor still produces the same on-disk
+/// layout as before the feature wiring.
+#[test]
+fn no_iconv_preserves_source_filename_bytes() {
+    let temp = tempdir().expect("tempdir");
+    let source = temp.path().join("source");
+    let dest = temp.path().join("dest");
+    fs::create_dir_all(&source).expect("create source");
+    fs::create_dir_all(&dest).expect("create dest");
+
+    let utf8_name = OsStr::from_bytes(b"caf\xc3\xa9.txt");
+    fs::write(source.join(utf8_name), b"payload").expect("write source");
+
+    let operands = vec![source.into_os_string(), dest.into_os_string()];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+    let options = LocalCopyOptions::default().recursive(true);
+
+    plan.execute_with_options(LocalCopyExecution::Apply, options)
+        .expect("local copy succeeds");
+
+    let dest_root = temp.path().join("dest").join("source");
+    let names = list_raw_names(&dest_root);
+    assert_eq!(
+        names,
+        vec![b"caf\xc3\xa9.txt".to_vec()],
+        "no-iconv path must preserve source bytes; got {names:?}"
+    );
+}
+
+/// Recursive subdirectory copy with `--iconv=UTF-8,ISO-8859-1` applies
+/// the conversion to every nested filename. This guards the per-entry
+/// `process_planned_entry` dispatch in addition to the top-level
+/// handler.
+#[test]
+fn iconv_applies_to_nested_filenames_recursively() {
+    let temp = tempdir().expect("tempdir");
+    let source = temp.path().join("source");
+    let nested = source.join("subdir");
+    let dest = temp.path().join("dest");
+    fs::create_dir_all(&nested).expect("create nested");
+    fs::create_dir_all(&dest).expect("create dest");
+
+    let top_name = OsStr::from_bytes(b"caf\xc3\xa9.txt");
+    let leaf_name = OsStr::from_bytes(b"r\xc3\xa9sum\xc3\xa9.txt");
+    fs::write(source.join(top_name), b"top").expect("write top");
+    fs::write(nested.join(leaf_name), b"leaf").expect("write leaf");
+
+    let converter = FilenameConverter::new("UTF-8", "ISO-8859-1").expect("converter");
+    let operands = vec![source.into_os_string(), dest.into_os_string()];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+    let options = LocalCopyOptions::default()
+        .recursive(true)
+        .with_iconv(Some(converter));
+
+    plan.execute_with_options(LocalCopyExecution::Apply, options)
+        .expect("local copy succeeds");
+
+    let dest_root = temp.path().join("dest").join("source");
+    let top_names = list_raw_names(&dest_root);
+    assert!(
+        top_names.contains(&b"caf\xe9.txt".to_vec()),
+        "top-level Latin-1 name missing; got {top_names:?}"
+    );
+    assert!(top_names.contains(&b"subdir".to_vec()), "subdir missing");
+
+    let leaf_dir = dest_root.join("subdir");
+    let leaf_names = list_raw_names(&leaf_dir);
+    assert_eq!(
+        leaf_names,
+        vec![b"r\xe9sum\xe9.txt".to_vec()],
+        "nested Latin-1 name missing; got {leaf_names:?}"
+    );
+}


### PR DESCRIPTION
## Summary

- The local-copy executor was joining source filename components onto destination paths verbatim, so `--iconv=LOCAL,REMOTE` for a pure local transfer silently no-op'd while push to a remote daemon worked. Upstream rsync's local-copy opens `ic_send = iconv_open(UTF8, LOCAL)` on the sender and `ic_recv = iconv_open(REMOTE, UTF8)` on the receiver (`rsync.c:118-140`); composing them is equivalent to a single `LOCAL -> REMOTE` transcoding applied at the receiver-side filename emission.
- Adds `IconvSetting::resolve_local_copy_converter` to produce the composed converter, routes it through `apply_iconv` onto `LocalCopyOptions`, and transcodes every source filename component before joining the destination path - including the quick-check destination lookup and the `--delete` keep-list, so existing files are still found and freshly written entries are not wiped.
- Identity and absent converters retain the zero-alloc borrowed-`Cow` hot path; invalid bytes fall back to pass-through to keep the transfer making progress, matching the receiver-side decoder behaviour in `protocol::flist::read`.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` clean
- [x] Engine unit tests: `cargo nextest run -p engine --all-features -E 'test(iconv) or test(transcode)'` (8 passed)
- [x] Engine integration tests on Linux (via container): new `crates/engine/tests/iconv_local_copy.rs` confirms `UTF-8 -> LATIN1` produces single-byte `0xe9`, `LATIN1 -> UTF-8` produces `c3 a9`, recursive nested filenames are transcoded, and no-iconv preserves source bytes (4 new tests, all passing).
- [x] Engine delete/checksum/local-copy regression: 3776 tests, 0 failures.
- [x] Core iconv wiring: 105 tests including the updated `local_copy_options_iconv_explicit_yields_converter` (which now asserts the converter is non-identity for `LOCAL=UTF-8, REMOTE=ISO-8859-1`).

The integration test is gated on `target_os = "linux"` because macOS APFS and Windows NTFS reject the raw 0xe9 byte that the canonical `caf\xe9.txt` scenario produces; the conversion path itself is cross-platform and is exercised by the unit tests on every target.