### PR TITLE
fix(metadata): write user.rsync.%stat xattr in --fake-super local-copy path

### DIFF
--- a/crates/engine/tests/fake_super_local_copy_xattr.rs
+++ b/crates/engine/tests/fake_super_local_copy_xattr.rs
@@ -1,0 +1,133 @@
+//! Integration tests for `--fake-super` on the local-copy executor path.
+//!
+//! Confirms that a pure local copy (no daemon, no network) writes the
+//! `user.rsync.%stat` xattr on the destination so non-root callers can
+//! preserve ownership metadata. Mirrors upstream rsync 3.4.x behaviour:
+//! `set_file_attrs()` invokes `set_stat_xattr()` when `am_root < 0`.
+//!
+//! # Upstream Reference
+//!
+//! - `xattrs.c:set_stat_xattr()` - encodes `<mode_octal> <maj>,<min> <uid>:<gid>`
+//! - `rsync.c:set_file_attrs()` - dispatches to fake-super under `am_root < 0`
+
+#![cfg(any(target_os = "linux", target_os = "macos"))]
+
+use std::fs;
+#[cfg(unix)]
+use std::os::unix::fs::MetadataExt;
+
+use engine::local_copy::{LocalCopyExecution, LocalCopyOptions, LocalCopyPlan};
+use metadata::{FAKE_SUPER_XATTR, FakeSuperStat};
+use tempfile::tempdir;
+
+/// Reads the fake-super xattr from a destination path.
+///
+/// Returns `None` when the filesystem does not support the `user.rsync.*`
+/// namespace (e.g. tmpfs mounted without `user_xattr`). Callers treat that
+/// as a skip rather than a failure.
+fn read_fake_super(path: &std::path::Path) -> Option<FakeSuperStat> {
+    let raw = xattr::get(path, FAKE_SUPER_XATTR).ok().flatten()?;
+    let text = std::str::from_utf8(&raw).ok()?;
+    FakeSuperStat::decode(text).ok()
+}
+
+/// End-to-end check: `--fake-super --owner --group --perms` on a local-copy
+/// pulls source uid/gid/mode into `user.rsync.%stat` on the destination.
+#[test]
+fn local_copy_writes_fake_super_xattr_for_regular_file() {
+    let temp = tempdir().expect("tempdir");
+    let source = temp.path().join("src");
+    let dest = temp.path().join("dst");
+    fs::create_dir_all(&source).expect("create source");
+    fs::create_dir_all(&dest).expect("create dest");
+
+    let source_file = source.join("payload.bin");
+    fs::write(&source_file, b"fake-super payload").expect("write source");
+
+    let source_meta = fs::metadata(&source_file).expect("stat source");
+    let expected_uid = source_meta.uid();
+    let expected_gid = source_meta.gid();
+    let expected_mode = source_meta.mode();
+
+    let operands = vec![source.into_os_string(), dest.clone().into_os_string()];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+    let options = LocalCopyOptions::default()
+        .recursive(true)
+        .owner(true)
+        .group(true)
+        .permissions(true)
+        .fake_super(true);
+
+    plan.execute_with_options(LocalCopyExecution::Apply, options)
+        .expect("local copy succeeds");
+
+    let dest_file = dest.join("src").join("payload.bin");
+    assert!(dest_file.exists(), "destination payload must exist");
+
+    let Some(stat) = read_fake_super(&dest_file) else {
+        // Filesystem rejected the xattr (e.g. tmpfs without user_xattr).
+        // The local-copy plumbing still ran without error; nothing else to
+        // verify on this host.
+        return;
+    };
+
+    assert_eq!(
+        stat.mode, expected_mode,
+        "mode bits in user.rsync.%stat must match source inode"
+    );
+    assert_eq!(
+        stat.uid, expected_uid,
+        "uid in user.rsync.%stat must match source inode"
+    );
+    assert_eq!(
+        stat.gid, expected_gid,
+        "gid in user.rsync.%stat must match source inode"
+    );
+    assert!(
+        stat.rdev.is_none(),
+        "regular files must not carry rdev in user.rsync.%stat"
+    );
+
+    // Confirm the raw bytes match upstream's encoding so wire compatibility
+    // with `xattrs.c:set_stat_xattr()` does not regress.
+    let raw = xattr::get(&dest_file, FAKE_SUPER_XATTR)
+        .expect("xattr get after fake-super copy")
+        .expect("xattr present after fake-super copy");
+    let encoded = std::str::from_utf8(&raw).expect("utf-8 xattr").to_owned();
+    assert_eq!(encoded, stat.encode(), "raw xattr bytes must match encoder");
+}
+
+/// Without `--fake-super`, the local-copy executor must not synthesise the
+/// `user.rsync.%stat` xattr. Guards against accidental writes that would
+/// pollute destination metadata.
+#[test]
+fn local_copy_without_fake_super_does_not_write_stat_xattr() {
+    let temp = tempdir().expect("tempdir");
+    let source = temp.path().join("src");
+    let dest = temp.path().join("dst");
+    fs::create_dir_all(&source).expect("create source");
+    fs::create_dir_all(&dest).expect("create dest");
+
+    let source_file = source.join("payload.bin");
+    fs::write(&source_file, b"vanilla payload").expect("write source");
+
+    let operands = vec![source.into_os_string(), dest.clone().into_os_string()];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+    let options = LocalCopyOptions::default()
+        .recursive(true)
+        .owner(true)
+        .group(true)
+        .permissions(true);
+
+    plan.execute_with_options(LocalCopyExecution::Apply, options)
+        .expect("local copy succeeds");
+
+    let dest_file = dest.join("src").join("payload.bin");
+    assert!(dest_file.exists(), "destination payload must exist");
+
+    let raw = xattr::get(&dest_file, FAKE_SUPER_XATTR).ok().flatten();
+    assert!(
+        raw.is_none(),
+        "user.rsync.%stat must not appear when --fake-super is off; got {raw:?}"
+    );
+}

--- a/crates/metadata/src/apply/ownership.rs
+++ b/crates/metadata/src/apply/ownership.rs
@@ -139,6 +139,11 @@ pub(super) fn ownership_matches(
 /// Uses `chownat` with `AT_SYMLINK_NOFOLLOW` when `follow_symlinks` is false.
 /// Skips the syscall entirely when both resolved UID and GID are `None`,
 /// or when the resolved values already match `existing`.
+///
+/// Under `--fake-super` on Unix targets that follow symlinks (regular files
+/// and directories), ownership/mode/rdev are encoded into the
+/// `user.rsync.%stat` xattr instead of being applied via `chown`. This mirrors
+/// upstream rsync's `set_file_attrs()` behaviour when `am_root < 0`.
 // upstream: rsync.c:set_file_attrs() - chownat with conditional AT_SYMLINK_NOFOLLOW
 pub(super) fn set_owner_like(
     metadata: &fs::Metadata,
@@ -149,6 +154,21 @@ pub(super) fn set_owner_like(
 ) -> Result<(), MetadataError> {
     #[cfg(unix)]
     {
+        // upstream: xattrs.c:set_stat_xattr() encodes mode/uid/gid/rdev under
+        // fake-super. Symlinks are excluded because lsetxattr on a symlink is
+        // not portable; symlink fake-super follows upstream's "skip" path.
+        // Mirrors `apply_ownership_from_entry`'s gate so the local-copy and
+        // network-receiver paths agree on when the xattr is written.
+        if options.fake_super_enabled()
+            && follow_symlinks
+            && (options.owner()
+                || options.group()
+                || options.owner_override().is_some()
+                || options.group_override().is_some())
+        {
+            return store_fake_super_from_local_metadata(destination, metadata);
+        }
+
         let (owner, group) = resolve_ownership(metadata, options, destination)?;
 
         if owner.is_none() && group.is_none() {
@@ -188,6 +208,9 @@ pub(super) fn set_owner_like(
 }
 
 /// fd-based variant of [`set_owner_like`] that uses `fchown` instead of `chownat`.
+///
+/// Under `--fake-super` the open file descriptor is unused; ownership is
+/// captured into the `user.rsync.%stat` xattr instead of issuing `fchown`.
 #[cfg(unix)]
 pub(super) fn set_owner_like_with_fd(
     metadata: &fs::Metadata,
@@ -196,6 +219,17 @@ pub(super) fn set_owner_like_with_fd(
     fd: BorrowedFd<'_>,
     existing: Option<&fs::Metadata>,
 ) -> Result<(), MetadataError> {
+    // upstream: xattrs.c:set_stat_xattr() under am_root < 0 - skip fchown.
+    if options.fake_super_enabled()
+        && (options.owner()
+            || options.group()
+            || options.owner_override().is_some()
+            || options.group_override().is_some())
+    {
+        let _ = fd;
+        return store_fake_super_from_local_metadata(destination, metadata);
+    }
+
     let (owner, group) = resolve_ownership(metadata, options, destination)?;
 
     if owner.is_none() && group.is_none() {
@@ -369,6 +403,45 @@ fn apply_ownership_via_fake_super(
 
     store_fake_super(destination, &stat)
         .map_err(|error| MetadataError::new("store fake-super metadata", destination, error))
+}
+
+/// Stores fake-super metadata derived from a local `fs::Metadata` snapshot.
+///
+/// This is the local-copy counterpart to [`apply_ownership_via_fake_super`]:
+/// the caller already has the source's `fs::Metadata`, so there is no wire
+/// `FileEntry` to consult. Mode (with the full `S_IFMT` bits), uid, gid, and
+/// device rdev are captured via [`FakeSuperStat::from_metadata`] and stored
+/// in the `user.rsync.%stat` xattr.
+///
+/// Mirrors `apply_ownership_via_fake_super`'s "no-op when the existing xattr
+/// already matches" fast path. On platforms or builds without xattr support
+/// this is a graceful no-op.
+// upstream: xattrs.c:set_stat_xattr() / rsync.c:set_file_attrs() with am_root<0
+#[cfg(unix)]
+fn store_fake_super_from_local_metadata(
+    destination: &Path,
+    metadata: &fs::Metadata,
+) -> Result<(), MetadataError> {
+    #[cfg(feature = "xattr")]
+    {
+        use crate::fake_super::{FakeSuperStat, load_fake_super, store_fake_super};
+
+        let stat = FakeSuperStat::from_metadata(metadata);
+
+        if let Ok(Some(existing)) = load_fake_super(destination)
+            && existing == stat
+        {
+            return Ok(());
+        }
+
+        store_fake_super(destination, &stat)
+            .map_err(|error| MetadataError::new("store fake-super metadata", destination, error))
+    }
+    #[cfg(not(feature = "xattr"))]
+    {
+        let _ = (destination, metadata);
+        Ok(())
+    }
 }
 
 /// No-op stub for non-Unix platforms where ownership (`chown`) is not supported.

--- a/crates/metadata/src/apply/tests.rs
+++ b/crates/metadata/src/apply/tests.rs
@@ -1068,3 +1068,67 @@ fn fake_super_skips_rewrite_when_xattr_already_matches() {
         .expect("xattr present");
     assert_eq!(raw_before, raw_after, "xattr must remain byte-identical");
 }
+
+/// Confirms the local-copy path also writes `user.rsync.%stat` under
+/// `--fake-super`. This exercises `apply_file_metadata_with_options`, which
+/// takes an `fs::Metadata` directly rather than a wire-protocol `FileEntry`.
+// upstream: xattrs.c:set_stat_xattr() under am_root < 0
+#[cfg(all(unix, feature = "xattr"))]
+#[test]
+fn fake_super_writes_stat_xattr_via_local_metadata() {
+    use crate::fake_super::{FAKE_SUPER_XATTR, FakeSuperStat};
+
+    let temp = tempdir().expect("tempdir");
+    let dest = temp.path().join("fakesuper-localmeta.txt");
+    fs::write(&dest, b"data").expect("write dest");
+
+    let metadata = fs::metadata(&dest).expect("dest metadata");
+
+    let opts = MetadataOptions::new()
+        .fake_super(true)
+        .preserve_owner(true)
+        .preserve_group(true)
+        .preserve_permissions(true);
+
+    apply_file_metadata_with_options(&dest, &metadata, &opts)
+        .expect("apply with fake-super via fs::Metadata");
+
+    let raw = match xattr::get(&dest, FAKE_SUPER_XATTR) {
+        Ok(Some(value)) => value,
+        Ok(None) | Err(_) => return,
+    };
+    let decoded =
+        FakeSuperStat::decode(std::str::from_utf8(&raw).expect("xattr utf-8")).expect("decode");
+
+    assert_eq!(decoded.mode, metadata.mode());
+    assert_eq!(decoded.uid, metadata.uid());
+    assert_eq!(decoded.gid, metadata.gid());
+    assert_eq!(decoded.rdev, None, "regular file must not carry rdev");
+}
+
+/// Without `--fake-super`, the local-copy ownership path must not synthesise
+/// the `user.rsync.%stat` xattr.
+#[cfg(all(unix, feature = "xattr"))]
+#[test]
+fn fake_super_off_does_not_write_stat_xattr_via_local_metadata() {
+    use crate::fake_super::FAKE_SUPER_XATTR;
+
+    let temp = tempdir().expect("tempdir");
+    let dest = temp.path().join("fakesuper-off.txt");
+    fs::write(&dest, b"data").expect("write dest");
+
+    let metadata = fs::metadata(&dest).expect("dest metadata");
+
+    let opts = MetadataOptions::new()
+        .preserve_owner(true)
+        .preserve_group(true)
+        .preserve_permissions(true);
+
+    apply_file_metadata_with_options(&dest, &metadata, &opts).expect("apply without fake-super");
+
+    let raw = xattr::get(&dest, FAKE_SUPER_XATTR).ok().flatten();
+    assert!(
+        raw.is_none(),
+        "user.rsync.%stat must not appear without --fake-super; got {raw:?}"
+    );
+}


### PR DESCRIPTION
## Summary

- Local-copy executor (`src -> dst` with no daemon or network in between) silently dropped privileged metadata under `--fake-super`. The metadata-apply step routed through `set_owner_like`, which always attempted `chown`/`fchown` without consulting `options.fake_super_enabled()`. The fake-super dispatch existed only in `apply_ownership_from_entry` (network-receiver `FileEntry` path).
- Wires the fake-super branch into `set_owner_like` and `set_owner_like_with_fd` so the local-copy path agrees with the receiver path. Symlinks are excluded, matching upstream `xattrs.c:set_stat_xattr()`. The new helper `store_fake_super_from_local_metadata` reuses `FakeSuperStat::from_metadata` and `store_fake_super` from the metadata crate, plus the same "skip rewrite when the existing xattr matches" fast path the receiver uses. No new wire-format code is introduced.
- Gates the new write on at least one of `--owner` / `--group` / explicit override being set, matching the receiver-side gate so both code paths produce identical results.

## Test plan

- [x] Engine integration test `local_copy_writes_fake_super_xattr_for_regular_file` drives `LocalCopyPlan::execute_with_options` with `--fake-super --owner --group --perms`, decodes the destination `user.rsync.%stat` via `FakeSuperStat`, and asserts the raw bytes equal `FakeSuperStat::encode()` (upstream's `set_stat_xattr()` wire shape).
- [x] Engine integration test `local_copy_without_fake_super_does_not_write_stat_xattr` guards against regressions where the xattr would leak onto vanilla copies.
- [x] Metadata unit test `fake_super_writes_stat_xattr_via_local_metadata` exercises `apply_file_metadata_with_options` directly with `fs::Metadata` input (the local-copy entry point).
- [x] Metadata unit test `fake_super_off_does_not_write_stat_xattr_via_local_metadata` pins the off-by-default behaviour at the helper level.
- [x] `cargo fmt --all --check`
- [x] `cargo clippy -p metadata --all-targets --all-features --no-deps -- -D warnings`
- [x] `cargo clippy -p metadata -p engine --all-targets --all-features --no-deps -- -D warnings`
- [ ] CI: fmt+clippy (full workspace), nextest (stable), Windows, macOS, Linux musl