### PR TITLE
fix(protocol): consume generator xattr request on sender under -X --fake-super

### DIFF
--- a/crates/protocol/src/xattr/mod.rs
+++ b/crates/protocol/src/xattr/mod.rs
@@ -43,8 +43,8 @@ pub use list::XattrList;
 pub use prefix::{local_to_wire, wire_to_local};
 pub use wire::{
     RecvXattrResult, XattrDefinition, XattrSet, checksum_matches, read_xattr_definitions,
-    recv_xattr, recv_xattr_request, recv_xattr_values, send_xattr, send_xattr_request,
-    send_xattr_values,
+    recv_xattr, recv_xattr_request, recv_xattr_values, send_sender_xattr_response, send_xattr,
+    send_xattr_request, send_xattr_values,
 };
 
 /// Maximum size for a full xattr value transmission.

--- a/crates/protocol/src/xattr/wire/encode.rs
+++ b/crates/protocol/src/xattr/wire/encode.rs
@@ -143,6 +143,60 @@ pub fn send_xattr_values<W: Write>(writer: &mut W, list: &XattrList) -> io::Resu
     Ok(())
 }
 
+/// Writes the sender-side response to the generator's xattr abbreviation request.
+///
+/// Mirrors upstream `xattrs.c:send_xattr_request()` when called by the
+/// sender (`fname != NULL`, `f_out >= 0`). For every entry the generator
+/// flagged via `XSTATE_TODO`, emits the delta-encoded 1-based `num`, the full
+/// value length, and the value bytes. A trailing `0` varint terminates the
+/// stream, matching upstream's `write_byte(f_out, 0)`.
+///
+/// The list passed in must have entries with `state().needs_send()` true for
+/// the items the generator requested. After writing, those entries' states are
+/// reset to [`XattrState::Done`](crate::xattr::XattrState::Done) to match
+/// upstream's `rxa->datum[0] = XSTATE_DONE`.
+///
+/// # Wire Format
+///
+/// ```text
+/// For each entry where state.needs_send() is true:
+///   rel_num : varint  // num - prior_req (1-based, delta-encoded)
+///   length  : varint
+///   value   : bytes[length]
+/// terminator: varint  // 0 signals end of stream
+/// ```
+///
+/// # Upstream Reference
+///
+/// - `xattrs.c:623-675` - `send_xattr_request()` sender path (`fname != NULL`)
+/// - `sender.c:192-196` - called from `write_ndx_and_attrs()` on the sender
+///   when echoing iflags that include `ITEM_REPORT_XATTR`.
+pub fn send_sender_xattr_response<W: Write>(
+    writer: &mut W,
+    list: &mut XattrList,
+) -> io::Result<()> {
+    use crate::xattr::XattrState;
+
+    let mut prior_req = 0i32;
+    for entry in list.entries_mut() {
+        if !entry.state().needs_send() {
+            continue;
+        }
+        let num = entry.num() as i32;
+        // upstream: write_varint(f_out, rxa->num - prior_req)
+        write_varint(writer, num - prior_req)?;
+        prior_req = num;
+        // upstream: write_varint(f_out, len); write_bigbuf(f_out, ptr, len)
+        write_varint(writer, entry.datum_len() as i32)?;
+        writer.write_all(entry.datum())?;
+        // upstream: rxa->datum[0] = XSTATE_DONE after emission
+        entry.set_state(XattrState::Done);
+    }
+    // upstream: write_byte(f_out, 0) - terminate the stream
+    write_varint(writer, 0)?;
+    Ok(())
+}
+
 /// Computes the seeded MD5 checksum for an xattr value.
 ///
 /// Includes the `checksum_seed` in the hash to match upstream rsync's

--- a/crates/protocol/src/xattr/wire/mod.rs
+++ b/crates/protocol/src/xattr/wire/mod.rs
@@ -18,5 +18,5 @@ mod tests;
 pub use decode::{
     checksum_matches, read_xattr_definitions, recv_xattr, recv_xattr_request, recv_xattr_values,
 };
-pub use encode::{send_xattr, send_xattr_request, send_xattr_values};
+pub use encode::{send_sender_xattr_response, send_xattr, send_xattr_request, send_xattr_values};
 pub use types::{RecvXattrResult, XattrDefinition, XattrSet};

--- a/crates/protocol/src/xattr/wire/tests.rs
+++ b/crates/protocol/src/xattr/wire/tests.rs
@@ -7,8 +7,11 @@ use super::encode::compute_xattr_checksum;
 use super::types::RecvXattrResult;
 use super::{
     XattrDefinition, checksum_matches, read_xattr_definitions, recv_xattr, recv_xattr_request,
-    recv_xattr_values, send_xattr, send_xattr_request, send_xattr_values,
+    recv_xattr_values, send_sender_xattr_response, send_xattr, send_xattr_request,
+    send_xattr_values,
 };
+use crate::varint::read_varint;
+use crate::xattr::XattrState;
 
 /// Writes a literal xattr definition block (count + entries) in wire format.
 ///
@@ -788,6 +791,78 @@ fn checksum_matches_empty_value() {
     let empty_value = b"";
     let checksum = compute_xattr_checksum(empty_value, 0);
     assert!(checksum_matches(&checksum, empty_value, 0));
+}
+
+/// Verifies the sender-side response writes a single 0 terminator when no
+/// entries are marked TODO. This is the byte stream upstream's
+/// `send_xattr_request(fname, file, f_out)` emits when the generator set
+/// `ITEM_REPORT_XATTR` only because of a count mismatch and no entries
+/// require their full value to be transferred. Dropping this terminator
+/// desyncs the wire stream under `-X --fake-super`.
+#[test]
+fn sender_response_emits_terminator_when_no_todo() {
+    let mut list = XattrList::new();
+    list.push(XattrEntry::new(b"user.small".to_vec(), b"value".to_vec()));
+    list.entries_mut()[0].set_num(1);
+
+    let mut buf = Vec::new();
+    send_sender_xattr_response(&mut buf, &mut list).unwrap();
+
+    assert_eq!(buf, vec![0u8]);
+}
+
+/// Verifies the sender-side response emits delta-encoded num + length + value
+/// for each XSTATE_TODO entry, then a 0 terminator. Matches upstream
+/// `xattrs.c:send_xattr_request()` sender path (`fname != NULL`,
+/// `f_out >= 0`).
+#[test]
+fn sender_response_round_trip_with_todo_entries() {
+    let value_a = vec![0xAAu8; 80];
+    let value_b = vec![0xBBu8; 120];
+
+    let mut sender_list = XattrList::new();
+    let mut entry_a = XattrEntry::new(b"user.large_a".to_vec(), value_a.clone());
+    entry_a.set_num(1);
+    entry_a.mark_todo();
+    sender_list.push(entry_a);
+
+    let mut middle = XattrEntry::new(b"user.middle".to_vec(), vec![0u8; 10]);
+    middle.set_num(2);
+    sender_list.push(middle);
+
+    let mut entry_b = XattrEntry::new(b"user.large_b".to_vec(), value_b.clone());
+    entry_b.set_num(3);
+    entry_b.mark_todo();
+    sender_list.push(entry_b);
+
+    let mut buf = Vec::new();
+    send_sender_xattr_response(&mut buf, &mut sender_list).unwrap();
+
+    let mut cursor = Cursor::new(buf);
+    let rel1 = read_varint(&mut cursor).unwrap();
+    let len1 = read_varint(&mut cursor).unwrap();
+    let mut value1 = vec![0u8; len1 as usize];
+    use std::io::Read;
+    cursor.read_exact(&mut value1).unwrap();
+
+    let rel2 = read_varint(&mut cursor).unwrap();
+    let len2 = read_varint(&mut cursor).unwrap();
+    let mut value2 = vec![0u8; len2 as usize];
+    cursor.read_exact(&mut value2).unwrap();
+
+    let terminator = read_varint(&mut cursor).unwrap();
+
+    assert_eq!(rel1, 1);
+    assert_eq!(len1, 80);
+    assert_eq!(value1, value_a);
+    assert_eq!(rel2, 2);
+    assert_eq!(len2, 120);
+    assert_eq!(value2, value_b);
+    assert_eq!(terminator, 0);
+
+    assert_eq!(sender_list.entries()[0].state(), XattrState::Done);
+    assert_eq!(sender_list.entries()[1].state(), XattrState::Done);
+    assert_eq!(sender_list.entries()[2].state(), XattrState::Done);
 }
 
 #[test]

--- a/crates/protocol/tests/xattr_fake_super_finalize.rs
+++ b/crates/protocol/tests/xattr_fake_super_finalize.rs
@@ -1,0 +1,174 @@
+//! Regression tests for the `-X --fake-super` finalize wire-protocol fix.
+//!
+//! Locks in the sender-side handling of the generator's `send_xattr_request()`
+//! stream when `ITEM_REPORT_XATTR` is set in iflags. Before the fix, the
+//! sender skipped the request body and read the subsequent `sum_head`
+//! starting from the request terminator byte, desyncing the wire stream and
+//! aborting the goodbye phase with "block length must be non-zero" or
+//! "Invalid remainder length" errors under `-X --fake-super`.
+//!
+//! # Upstream Reference
+//!
+//! - `sender.c:280-284` - `recv_xattr_request()` on the sender after iflags
+//! - `sender.c:192-196` - `send_xattr_request()` in `write_ndx_and_attrs()`
+//! - `xattrs.c:623-675` - sender path emits `rel_num + len + data + 0`
+//! - `generator.c:585-592` - generator emits at least the 0 terminator when
+//!   `ITEM_REPORT_XATTR` is set on a new file (count mismatch path).
+
+use std::io::Cursor;
+
+use protocol::xattr::{XattrEntry, XattrList, XattrState, send_sender_xattr_response};
+use protocol::{read_varint, write_varint};
+
+/// Mirrors the upstream generator's `send_xattr_request(NULL, file, f_out)`
+/// wire emission for a file with no `XSTATE_TODO` entries: a single 0-byte
+/// varint terminator. This is the byte that desynchronised the transfer
+/// under `-X --fake-super` when xattr counts differed (e.g. source has
+/// `user.foo` but the brand-new destination has none yet).
+fn write_generator_request_terminator(buf: &mut Vec<u8>) {
+    write_varint(buf, 0).unwrap();
+}
+
+/// Mirrors the upstream generator's request with one TODO index. Used to
+/// cover the case where the abbreviated checksum diff flags one entry that
+/// the sender must resend in full.
+fn write_generator_request_with_indices(buf: &mut Vec<u8>, indices: &[i32]) {
+    let mut prior = 0i32;
+    for &num in indices {
+        write_varint(buf, num - prior).unwrap();
+        prior = num;
+    }
+    write_varint(buf, 0).unwrap();
+}
+
+/// Sender consumes the generator's bare-terminator request: zero entries
+/// flagged TODO, then re-emits its own bare-terminator response. Without
+/// this read/emit pair the receiver picks up the terminator as the first
+/// byte of `sum_head.count` and aborts with "Invalid remainder length".
+#[test]
+fn sender_consumes_generator_bare_terminator() {
+    let mut request_stream = Vec::new();
+    write_generator_request_terminator(&mut request_stream);
+
+    let mut list = XattrList::new();
+    list.push(XattrEntry::new(b"user.foo".to_vec(), b"bar".to_vec()));
+    list.entries_mut()[0].set_num(1);
+
+    let mut cursor = Cursor::new(request_stream);
+    let indices = protocol::xattr::recv_xattr_request(&mut cursor, &mut list).unwrap();
+
+    assert!(indices.is_empty(), "no entries should be flagged TODO");
+    assert_eq!(list.entries()[0].state(), XattrState::Done);
+
+    // Sender's echo: only the terminator, matching upstream's bare 0.
+    let mut response_stream = Vec::new();
+    send_sender_xattr_response(&mut response_stream, &mut list).unwrap();
+    assert_eq!(response_stream, vec![0u8]);
+}
+
+/// End-to-end sender-side path: generator requests indices 1 and 3, the
+/// sender marks the corresponding entries TODO and re-emits them with full
+/// values plus the 0 terminator. The receiver's
+/// `read_xattr_abbreviation_data` (transfer crate, mirrored here as a
+/// hand-rolled decoder) recovers the (num, value) pairs.
+#[test]
+fn sender_round_trips_request_into_response() {
+    let value1 = vec![0x11u8; 64];
+    let value3 = vec![0x33u8; 96];
+    let middle = vec![0x22u8; 8];
+
+    // Generator requests entries 1 and 3 (skipping 2). Wire stream is
+    // delta-encoded 1-based nums terminated by 0.
+    let mut request_stream = Vec::new();
+    write_generator_request_with_indices(&mut request_stream, &[1, 3]);
+
+    // Sender's local xattr list for the file - all values are present in
+    // full. The receiver flags entries 1 and 3 as needing full values via
+    // the request stream.
+    let mut sender_list = XattrList::new();
+    let mut e1 = XattrEntry::new(b"user.a".to_vec(), value1.clone());
+    e1.set_num(1);
+    sender_list.push(e1);
+
+    let mut e2 = XattrEntry::new(b"user.b".to_vec(), middle.clone());
+    e2.set_num(2);
+    sender_list.push(e2);
+
+    let mut e3 = XattrEntry::new(b"user.c".to_vec(), value3.clone());
+    e3.set_num(3);
+    sender_list.push(e3);
+
+    // Sender reads the request, marking the requested entries TODO.
+    let mut request_cursor = Cursor::new(request_stream);
+    let requested =
+        protocol::xattr::recv_xattr_request(&mut request_cursor, &mut sender_list).unwrap();
+    assert_eq!(requested, vec![0usize, 2usize]); // 0-based indices for nums 1 and 3
+    assert_eq!(sender_list.entries()[0].state(), XattrState::Todo);
+    assert_eq!(sender_list.entries()[1].state(), XattrState::Done);
+    assert_eq!(sender_list.entries()[2].state(), XattrState::Todo);
+
+    // Sender emits the response.
+    let mut response_stream = Vec::new();
+    send_sender_xattr_response(&mut response_stream, &mut sender_list).unwrap();
+
+    // Receiver decodes the response - mirrors transfer crate's
+    // read_xattr_abbreviation_data layout exactly.
+    let mut cursor = Cursor::new(response_stream);
+    let mut prior = 0i32;
+    let mut decoded = Vec::new();
+    loop {
+        let rel = read_varint(&mut cursor).unwrap();
+        if rel == 0 {
+            break;
+        }
+        let num = prior + rel;
+        prior = num;
+        let len = read_varint(&mut cursor).unwrap() as usize;
+        let mut data = vec![0u8; len];
+        use std::io::Read;
+        cursor.read_exact(&mut data).unwrap();
+        decoded.push((num, data));
+    }
+
+    assert_eq!(decoded.len(), 2);
+    assert_eq!(decoded[0], (1, value1));
+    assert_eq!(decoded[1], (3, value3));
+
+    // States reset to Done after emission (upstream xattrs.c:651).
+    assert_eq!(sender_list.entries()[0].state(), XattrState::Done);
+    assert_eq!(sender_list.entries()[2].state(), XattrState::Done);
+}
+
+/// Confirms the wire byte sequence matches upstream exactly. The bytes
+/// emitted for "two entries, nums 1 and 3, both values of length 5" are:
+///   rel_num=1, len=5, "AAAAA", rel_num=2, len=5, "BBBBB", 0
+/// All varints in this range are single bytes.
+#[test]
+fn wire_byte_layout_matches_upstream() {
+    let mut list = XattrList::new();
+    let mut e1 = XattrEntry::new(b"user.a".to_vec(), b"AAAAA".to_vec());
+    e1.set_num(1);
+    e1.mark_todo();
+    list.push(e1);
+
+    let mut e2 = XattrEntry::new(b"user.b".to_vec(), b"BBBBB".to_vec());
+    e2.set_num(3);
+    e2.mark_todo();
+    list.push(e2);
+
+    let mut buf = Vec::new();
+    send_sender_xattr_response(&mut buf, &mut list).unwrap();
+
+    // Expected layout:
+    //   varint(1)  = 0x01   // rel_num for first entry
+    //   varint(5)  = 0x05   // length
+    //   "AAAAA"             // 5 bytes
+    //   varint(2)  = 0x02   // rel_num = 3 - 1 = 2
+    //   varint(5)  = 0x05   // length
+    //   "BBBBB"             // 5 bytes
+    //   varint(0)  = 0x00   // terminator
+    let expected = vec![
+        0x01, 0x05, b'A', b'A', b'A', b'A', b'A', 0x02, 0x05, b'B', b'B', b'B', b'B', b'B', 0x00,
+    ];
+    assert_eq!(buf, expected);
+}

--- a/crates/transfer/src/generator/protocol_io.rs
+++ b/crates/transfer/src/generator/protocol_io.rs
@@ -86,9 +86,91 @@ impl GeneratorContext {
         Ok(())
     }
 
-    /// Writes NDX, iflags, and sum_head for one file.
+    /// Reads the generator's xattr abbreviation request when `ITEM_REPORT_XATTR`
+    /// is set in iflags and xattrs are preserved.
     ///
-    /// upstream: sender.c:180-187 write_ndx_and_attrs()
+    /// The generator emits a varint stream of delta-encoded 1-based entry
+    /// numbers terminated by `0`, even when no entries are flagged for
+    /// transfer. Consuming this stream is mandatory whenever the gating
+    /// condition holds, otherwise the subsequent `sum_head` read picks up the
+    /// terminator byte and the wire stream desynchronises - the failure
+    /// observed under `-X --fake-super` where small-value xattr counts differ
+    /// between the sender and receiver sides.
+    ///
+    /// Returns the per-file `XattrList` with `XSTATE_TODO` entries marked for
+    /// the indices the generator requested, ready to be passed to
+    /// [`Self::write_ndx_and_attrs`] or
+    /// [`Self::write_ndx_iflags_and_xattr_response`]. Returns `None` when no
+    /// xattr request is expected on the wire.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `sender.c:280-284` - `recv_xattr_request()` called when
+    ///   `preserve_xattrs && iflags & ITEM_REPORT_XATTR && do_xfers
+    ///    && !(want_xattr_optim && BITS_SET(iflags, ITEM_XNAME_FOLLOWS|ITEM_LOCAL_CHANGE))`
+    /// - `xattrs.c:681-758` - `recv_xattr_request()` sender path marks entries
+    ///   `XSTATE_TODO` for items the generator wants the full value of.
+    pub(super) fn read_generator_xattr_request_if_any<R: Read>(
+        &self,
+        reader: &mut R,
+        ndx: usize,
+        iflags: &ItemFlags,
+    ) -> io::Result<Option<protocol::xattr::XattrList>> {
+        if !self.config.flags.xattrs {
+            return Ok(None);
+        }
+        if iflags.raw() & ItemFlags::ITEM_REPORT_XATTR == 0 {
+            return Ok(None);
+        }
+        // upstream: sender.c:281 also gates on the want_xattr_optim hardlink
+        // optimisation. We mirror want_xattr_optim via the negotiated
+        // CF_AVOID_XATTR_OPTIM capability flag - when the flag is NOT set,
+        // upstream's want_xattr_optim is active and the optimisation skips
+        // xattr exchange for local-change hardlinks.
+        let want_xattr_optim = self
+            .compat_flags
+            .is_none_or(|f| !f.contains(CompatibilityFlags::AVOID_XATTR_OPTIMIZATION));
+        if want_xattr_optim
+            && (iflags.raw() & ItemFlags::ITEM_XNAME_FOLLOWS != 0)
+            && (iflags.raw() & ItemFlags::ITEM_LOCAL_CHANGE != 0)
+        {
+            return Ok(None);
+        }
+
+        // Build the per-file xattr list by cloning the sender-side file
+        // entry's cached xattrs so the TODO marks do not poison the cached
+        // flist xattrs. When the file entry has no xattrs the list is
+        // empty; the generator's request must still be drained because it
+        // emits at least the 0 terminator under this gate.
+        let mut list = if ndx < self.file_list.len() {
+            self.file_list[ndx]
+                .xattr_list()
+                .cloned()
+                .unwrap_or_default()
+        } else {
+            protocol::xattr::XattrList::new()
+        };
+
+        // upstream: xattrs.c:681 recv_xattr_request() marks XSTATE_TODO on
+        // matching entries and consumes the stream up to the 0 terminator.
+        let _indices = protocol::xattr::recv_xattr_request(reader, &mut list)?;
+        Ok(Some(list))
+    }
+
+    /// Writes NDX, iflags, optional xattr response, and sum_head for one file.
+    ///
+    /// Combines upstream's `write_ndx_and_attrs()` (NDX + iflags + optional
+    /// xattr_request body) with the immediately following `write_sum_head()`
+    /// call. When `xattr_response` is `Some` and the file has entries the
+    /// generator requested, the full xattr values are written between iflags
+    /// and sum_head, matching the byte order of upstream sender.c:411-412.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `sender.c:180-196` - `write_ndx_and_attrs()` body (calls
+    ///   `send_xattr_request(fname, file, f_out)` when ITEM_REPORT_XATTR set)
+    /// - `sender.c:411-412` - `write_ndx_and_attrs()` followed by
+    ///   `write_sum_head(f_xfer, s)`
     pub(super) fn write_ndx_and_attrs<W: Write>(
         &self,
         writer: &mut W,
@@ -96,12 +178,51 @@ impl GeneratorContext {
         ndx: i32,
         iflags: &ItemFlags,
         sum_head: &SumHead,
+        xattr_response: Option<&mut protocol::xattr::XattrList>,
+    ) -> io::Result<()> {
+        self.write_ndx_iflags_and_xattr_response(writer, ndx_codec, ndx, iflags, xattr_response)?;
+        sum_head.write(writer)?;
+        Ok(())
+    }
+
+    /// Writes NDX, iflags, and optional xattr response without a sum_head.
+    ///
+    /// Used for non-transfer items (no `ITEM_TRANSFER` in iflags) and the
+    /// `--dry-run` echo path, where upstream calls `write_ndx_and_attrs()`
+    /// without a following `write_sum_head()`. When `xattr_response` is
+    /// `Some` with entries flagged via [`XattrState::Todo`], the full values
+    /// are written immediately after iflags via
+    /// [`send_sender_xattr_response`](protocol::xattr::send_sender_xattr_response).
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `sender.c:286-292` - non-transfer echo of NDX + iflags + xattr_request
+    /// - `xattrs.c:623-675` - `send_xattr_request()` sender path
+    ///
+    /// [`XattrState::Todo`]: protocol::xattr::XattrState::Todo
+    pub(super) fn write_ndx_iflags_and_xattr_response<W: Write>(
+        &self,
+        writer: &mut W,
+        ndx_codec: &mut impl NdxCodec,
+        ndx: i32,
+        iflags: &ItemFlags,
+        xattr_response: Option<&mut protocol::xattr::XattrList>,
     ) -> io::Result<()> {
         ndx_codec.write_ndx(writer, ndx)?;
         if self.protocol.supports_iflags() {
             writer.write_all(&iflags.significant_wire_bits().to_le_bytes())?;
         }
-        sum_head.write(writer)?;
+        // upstream: sender.c:192-196 - send_xattr_request(fname, file, f_out)
+        // is invoked from inside write_ndx_and_attrs() when ITEM_REPORT_XATTR
+        // is set in iflags. Skipping this body causes the receiver to read the
+        // following bytes as a stale xattr request, desyncing the goodbye phase.
+        let preserve_xattrs = self.config.flags.xattrs;
+        if preserve_xattrs
+            && (iflags.raw() & ItemFlags::ITEM_REPORT_XATTR != 0)
+            && let Some(list) = xattr_response
+        {
+            protocol::xattr::send_sender_xattr_response(writer, list)?;
+        }
         Ok(())
     }
 

--- a/crates/transfer/src/generator/transfer/transfer_loop.rs
+++ b/crates/transfer/src/generator/transfer/transfer_loop.rs
@@ -236,6 +236,20 @@ impl GeneratorContext {
                 self.timing.total_bytes_read += 4 + xname_data.len() as u64;
             }
 
+            // upstream: sender.c:280-284 - drain the generator's xattr request
+            // when preserve_xattrs && ITEM_REPORT_XATTR is set. The generator
+            // always emits at least a 0 terminator (varint) under this gate, so
+            // skipping it desyncs the subsequent sum_head read and aborts the
+            // transfer with errors like "block length must be non-zero" or
+            // "Invalid remainder length" - the failure mode reported under
+            // `-X --fake-super` where xattr counts differ between sides.
+            //
+            // Returns the per-file xattr list with XSTATE_TODO entries set on
+            // the indices the generator requested, ready for write_ndx_and_attrs
+            // to echo the full values back via send_sender_xattr_response.
+            let mut pending_xattr_response =
+                self.read_generator_xattr_request_if_any(&mut *reader, ndx, &iflags)?;
+
             // upstream: sender.c:277-278
             // rprintf(FINFO, "send_files(%d, %s%s%s)\n", ndx, path,slash,fname)
             // F_PATHNAME is unset for the in-band file list we build, so the
@@ -247,21 +261,38 @@ impl GeneratorContext {
             }
 
             if !iflags.needs_transfer() {
-                // upstream: sender.c:287 - maybe_log_item() for non-transfer items
+                // upstream: sender.c:286-292 - non-transfer items still echo
+                // NDX + iflags + (optional xattr response) via write_ndx_and_attrs
+                // so the receiver can pair the response with its outstanding
+                // request and apply xattr-only updates. Without this echo the
+                // wire stream stalls when ITEM_REPORT_XATTR is the only delta.
                 self.maybe_emit_itemize(writer, &iflags, ndx, itemize)?;
+                let ndx_i32 = self.flat_to_wire_ndx(ndx);
+                self.write_ndx_iflags_and_xattr_response(
+                    &mut *writer,
+                    &mut ndx_write_codec,
+                    ndx_i32,
+                    &iflags,
+                    pending_xattr_response.as_mut(),
+                )?;
                 continue;
             }
 
-            // upstream: sender.c:394-399 - dry_run (!do_xfers) logs the item and
-            // echoes write_ndx_and_attrs() without calling receive_sums().
+            // upstream: sender.c:341-344 - dry_run (!do_xfers) logs the item and
+            // echoes write_ndx_and_attrs() without calling receive_sums(). The
+            // echo still carries the xattr response when ITEM_REPORT_XATTR is
+            // set so the receiver can pair its outstanding request.
             if self.config.flags.dry_run {
                 self.validate_file_index(ndx)?;
                 let file_entry = &self.file_list[ndx];
                 let ndx_i32 = self.flat_to_wire_ndx(ndx);
-                ndx_write_codec.write_ndx(&mut *writer, ndx_i32)?;
-                if self.protocol.supports_iflags() {
-                    writer.write_all(&iflags.significant_wire_bits().to_le_bytes())?;
-                }
+                self.write_ndx_iflags_and_xattr_response(
+                    &mut *writer,
+                    &mut ndx_write_codec,
+                    ndx_i32,
+                    &iflags,
+                    pending_xattr_response.as_mut(),
+                )?;
                 // upstream: sender.c:395 - log_item(FCLIENT, file, iflags, NULL)
                 if let Some(cb) = itemize {
                     let name = file_entry.path().to_string_lossy();
@@ -328,6 +359,7 @@ impl GeneratorContext {
                     ndx_i32,
                     &iflags,
                     &sum_head,
+                    pending_xattr_response.as_mut(),
                 )?;
 
                 let checksum_algorithm = self.get_checksum_algorithm();
@@ -378,6 +410,7 @@ impl GeneratorContext {
                     ndx_i32,
                     &iflags,
                     &sum_head,
+                    pending_xattr_response.as_mut(),
                 )?;
 
                 let checksum_algorithm = self.get_checksum_algorithm();


### PR DESCRIPTION
## Summary

Under `-X --fake-super`, the upstream generator emits a varint stream of abbreviated-xattr indices terminated by a `0` byte whenever `iflags & ITEM_REPORT_XATTR` is set, even when no entries need their full values transferred (e.g. a new file with one small `user.*` xattr the destination does not have yet). Our sender skipped this body and read the trailing `0` as the first byte of `sum_head.count`, desyncing the wire stream and aborting the transfer with errors like `block length must be non-zero at delta.rs(106)` on the sender side and `Invalid remainder length 134217728 [receiver]` at `io.c(1990)` on the upstream receiver.

Root cause: the sender's request/response cycle for the per-file xattr abbreviation stream was missing entirely. Upstream `sender.c:280-284` calls `recv_xattr_request()` immediately after reading iflags whenever `preserve_xattrs && iflags & ITEM_REPORT_XATTR && do_xfers && !(want_xattr_optim && BITS_SET(iflags, ITEM_XNAME_FOLLOWS|ITEM_LOCAL_CHANGE))`, then `write_ndx_and_attrs()` invokes `send_xattr_request(fname, file, f_out)` at `sender.c:192-196` to echo the full values back. Both halves were missing on our sender, so under the exact gating condition the upstream generator emits the request, our wire layout shifted by one byte and the goodbye phase aborted.

Fix: drain the request in `GeneratorContext::read_generator_xattr_request_if_any()` (`crates/transfer/src/generator/protocol_io.rs`) and emit the response via the new `send_sender_xattr_response` encoder (`crates/protocol/src/xattr/wire/encode.rs`), reused by the new `write_ndx_iflags_and_xattr_response` helper. The transfer loop now threads `pending_xattr_response` through the three echo paths (file transfer, non-transfer iflags-only echo, and dry-run echo) so each one matches the upstream byte sequence exactly. The response shape (`rel_num + len + value + 0`) matches the sender path of upstream `xattrs.c:send_xattr_request()` and round-trips through the receiver's existing `read_xattr_abbreviation_data` decoder.

Container verification (oc-rsync push to upstream rsync 3.4.1 daemon, `-avX --fake-super`, source carrying both `user.foo` and a large `user.bigval`):
- Before: `oc-rsync error: transfer failed: block length must be non-zero at delta.rs(106) [sender=0.6.2] (code 12)` plus `Invalid remainder length 134217728 [receiver]`.
- After: exit 0, file content transferred, destination carries the synthesized `user.rsync.%stat` for setuid/setgid entries and the original `user.*` payloads.

Out of scope (separate audits): BR-3e (local-copy executor fake-super xattr write) and BR-3g (sender-side consumption of source `user.rsync.%stat` to fake special-file entries).

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings`
- [x] `cargo test -p protocol --test xattr_fake_super_finalize --all-features` (3 new tests)
- [x] Container interop: push `-avX --fake-super` from oc-rsync to upstream 3.4.1 daemon completes with exit 0 and applies xattrs
- [ ] CI nextest matrix (Linux musl, macOS, Windows)
- [ ] Interop validation workflow