### PR TITLE
docs(logging): drop restatement comments, keep upstream cites

### DIFF
--- a/crates/logging/src/config.rs
+++ b/crates/logging/src/config.rs
@@ -378,7 +378,6 @@ mod tests {
     fn test_from_verbose_level_0() {
         let config = VerbosityConfig::from_verbose_level(0);
 
-        // Level 0 only sets nonreg
         assert_eq!(config.info.nonreg, 1);
         assert_eq!(config.info.copy, 0);
         assert_eq!(config.info.del, 0);
@@ -394,7 +393,6 @@ mod tests {
     fn test_from_verbose_level_3() {
         let config = VerbosityConfig::from_verbose_level(3);
 
-        // Level 3 has enhanced debug flags
         assert_eq!(config.debug.connect, 2);
         assert_eq!(config.debug.del, 2);
         assert_eq!(config.debug.deltasum, 2);
@@ -415,7 +413,6 @@ mod tests {
     fn test_from_verbose_level_4() {
         let config = VerbosityConfig::from_verbose_level(4);
 
-        // Level 4 has further enhanced flags
         assert_eq!(config.debug.cmd, 2);
         assert_eq!(config.debug.del, 3);
         assert_eq!(config.debug.deltasum, 3);
@@ -431,14 +428,12 @@ mod tests {
     fn test_from_verbose_level_5_and_higher() {
         let config = VerbosityConfig::from_verbose_level(5);
 
-        // Level 5+ has maximum debug output
         assert_eq!(config.debug.deltasum, 4);
         assert_eq!(config.debug.flist, 4);
         assert_eq!(config.debug.chdir, 1);
         assert_eq!(config.debug.hash, 1);
         assert_eq!(config.debug.hlink, 1);
 
-        // Level 10 should also have max output
         let config10 = VerbosityConfig::from_verbose_level(10);
         assert_eq!(config10.debug.deltasum, 4);
         assert_eq!(config10.debug.flist, 4);
@@ -451,7 +446,6 @@ mod tests {
     fn test_apply_all_info_flags() {
         let mut config = VerbosityConfig::default();
 
-        // Test all info flags
         config.apply_info_flag("backup").unwrap();
         assert_eq!(config.info.backup, 1);
 
@@ -490,7 +484,6 @@ mod tests {
     fn test_apply_all_debug_flags() {
         let mut config = VerbosityConfig::default();
 
-        // Test all debug flags
         config.apply_debug_flag("acl").unwrap();
         assert_eq!(config.debug.acl, 1);
 

--- a/crates/logging/src/error_format.rs
+++ b/crates/logging/src/error_format.rs
@@ -26,18 +26,16 @@
 #[must_use]
 pub fn strip_repo_prefix<'a>(manifest_dir: &str, file_path: &'a str) -> &'a str {
     // Find the `crates/` boundary in the manifest dir to determine where the
-    // crate-relative portion starts. The manifest dir for a crate at
-    // `<repo>/crates/logging` ends with `crates/logging`, so we locate
-    // `crates/` and use the offset after it as the repo prefix length.
+    // crate-relative portion starts; the manifest dir for a crate at
+    // `<repo>/crates/logging` ends with `crates/logging`.
     if let Some(crates_pos) = find_crates_prefix(manifest_dir) {
         let repo_prefix = &manifest_dir[..crates_pos];
-        // file_path typically starts with the same repo prefix
         if let Some(stripped) = file_path.strip_prefix(repo_prefix) {
             return stripped;
         }
     }
 
-    // Fallback: try to find `crates/` directly in file_path
+    // Fallback when file_path does not share the manifest prefix (e.g. cross-crate).
     if let Some(pos) = find_crates_prefix(file_path) {
         return &file_path[pos..];
     }

--- a/crates/logging/src/phase_timer.rs
+++ b/crates/logging/src/phase_timer.rs
@@ -67,7 +67,6 @@ mod tests {
         {
             let _t = PhaseTimer::new("drop-test");
         }
-        // If we get here, drop didn't panic
     }
 
     #[test]

--- a/crates/logging/src/thread_local.rs
+++ b/crates/logging/src/thread_local.rs
@@ -188,7 +188,6 @@ mod tests {
             _ => panic!("expected debug event"),
         }
 
-        // Events should be drained
         assert_eq!(drain_events().len(), 0);
     }
 
@@ -287,7 +286,6 @@ mod tests {
     #[test]
     fn info_gte_default_config() {
         init(VerbosityConfig::default());
-        // Default should be 0 for all flags
         assert!(!info_gte(InfoFlag::Backup, 1));
         assert!(info_gte(InfoFlag::Backup, 0));
     }
@@ -295,7 +293,6 @@ mod tests {
     #[test]
     fn debug_gte_default_config() {
         init(VerbosityConfig::default());
-        // Default should be 0 for all flags
         assert!(!debug_gte(DebugFlag::Acl, 1));
         assert!(debug_gte(DebugFlag::Acl, 0));
     }
@@ -312,7 +309,6 @@ mod tests {
         let events = drain_events();
         assert_eq!(events.len(), 3);
 
-        // Events should be in order
         match &events[0] {
             DiagnosticEvent::Info { message, .. } => assert_eq!(message, "first"),
             _ => panic!("expected info"),

--- a/crates/logging/src/tracing_bridge.rs
+++ b/crates/logging/src/tracing_bridge.rs
@@ -244,7 +244,6 @@ pub fn init_tracing(config: VerbosityConfig) {
     use tracing_subscriber::layer::SubscriberExt;
     use tracing_subscriber::util::SubscriberInitExt;
 
-    // Also initialize the thread-local verbosity config
     super::thread_local::init(config.clone());
 
     let layer = RsyncLayer::new(config);

--- a/crates/logging/src/tracing_bridge_tests.rs
+++ b/crates/logging/src/tracing_bridge_tests.rs
@@ -9,10 +9,8 @@ fn test_tracing_with_verbosity_level_1() {
     let config = VerbosityConfig::from_verbose_level(1);
     thread_local::init(config);
 
-    // Level 1 should enable copy at level 1
     assert!(thread_local::info_gte(InfoFlag::Copy, 1));
 
-    // Emit a copy event
     thread_local::emit_info(InfoFlag::Copy, 1, "test copy".to_owned());
 
     let events = thread_local::drain_events();
@@ -24,7 +22,6 @@ fn test_tracing_with_verbosity_level_2() {
     let config = VerbosityConfig::from_verbose_level(2);
     thread_local::init(config);
 
-    // Level 2 should enable debug flags
     assert!(thread_local::debug_gte(DebugFlag::Bind, 1));
     assert!(thread_local::debug_gte(DebugFlag::Deltasum, 1));
 
@@ -52,21 +49,17 @@ fn test_tracing_respects_verbosity_filters() {
     let config = VerbosityConfig::from_verbose_level(1);
     thread_local::init(config);
 
-    // Level 1 doesn't enable debug flags
     assert!(!thread_local::debug_gte(DebugFlag::Deltasum, 1));
 
-    // This event should not be recorded
+    // Filtering happens at the debug_gte check in debug_log!; emit_debug itself
+    // is unconditional, so a direct call here still buffers the event.
     thread_local::emit_debug(DebugFlag::Deltasum, 1, "should be filtered".to_owned());
-
-    // But we still collect it in the event buffer (filtering happens at emission check)
-    // The real filtering happens when checking debug_gte before emit
 }
 
 #[test]
 fn test_manual_info_flag_application() {
     let mut config = VerbosityConfig::default();
 
-    // Apply specific info flag
     config.apply_info_flag("copy2").unwrap();
 
     thread_local::init(config);
@@ -80,7 +73,6 @@ fn test_manual_info_flag_application() {
 fn test_manual_debug_flag_application() {
     let mut config = VerbosityConfig::default();
 
-    // Apply specific debug flags
     config.apply_debug_flag("io3").unwrap();
     config.apply_debug_flag("proto").unwrap();
 
@@ -94,9 +86,8 @@ fn test_manual_debug_flag_application() {
 fn test_event_ordering() {
     let config = VerbosityConfig::from_verbose_level(2);
     thread_local::init(config);
-    thread_local::drain_events(); // Clear any existing events
+    thread_local::drain_events();
 
-    // Emit events in order
     thread_local::emit_info(InfoFlag::Copy, 1, "first".to_owned());
     thread_local::emit_info(InfoFlag::Del, 1, "second".to_owned());
     thread_local::emit_debug(DebugFlag::Deltasum, 1, "third".to_owned());
@@ -104,7 +95,6 @@ fn test_event_ordering() {
     let events = thread_local::drain_events();
     assert_eq!(events.len(), 3);
 
-    // Verify order is preserved
     match &events[0] {
         DiagnosticEvent::Info { message, .. } => assert_eq!(message, "first"),
         _ => panic!("Expected info event"),
@@ -121,37 +111,30 @@ fn test_event_ordering() {
 
 #[test]
 fn test_verbosity_level_progression() {
-    // Test that each level adds more flags
-
-    // Level 0
     let config0 = VerbosityConfig::from_verbose_level(0);
     assert_eq!(config0.info.copy, 0);
     assert_eq!(config0.debug.bind, 0);
 
-    // Level 1
     let config1 = VerbosityConfig::from_verbose_level(1);
     assert_eq!(config1.info.copy, 1);
-    assert_eq!(config1.debug.bind, 0); // Debug not enabled yet
+    assert_eq!(config1.debug.bind, 0);
 
-    // Level 2
     let config2 = VerbosityConfig::from_verbose_level(2);
     assert_eq!(config2.info.copy, 1);
-    assert_eq!(config2.info.misc, 2); // Enhanced level
-    assert_eq!(config2.debug.bind, 1); // Debug enabled
+    assert_eq!(config2.info.misc, 2);
+    assert_eq!(config2.debug.bind, 1);
 
-    // Level 3
     let config3 = VerbosityConfig::from_verbose_level(3);
-    assert_eq!(config3.debug.connect, 2); // Enhanced debug
-    assert_eq!(config3.debug.acl, 1); // New flags added
+    assert_eq!(config3.debug.connect, 2);
+    assert_eq!(config3.debug.acl, 1);
 
-    // Level 4
+    // upstream: PROTO first appears at level 4
     let config4 = VerbosityConfig::from_verbose_level(4);
-    assert_eq!(config4.debug.cmd, 2); // Further enhanced
-    assert_eq!(config4.debug.proto, 1); // Protocol debugging (upstream: "PROTO" at level 4)
+    assert_eq!(config4.debug.cmd, 2);
+    assert_eq!(config4.debug.proto, 1);
 
-    // Level 5+
     let config5 = VerbosityConfig::from_verbose_level(5);
-    assert_eq!(config5.debug.deltasum, 4); // Maximum level
-    assert_eq!(config5.debug.chdir, 1); // Additional flags
+    assert_eq!(config5.debug.deltasum, 4);
+    assert_eq!(config5.debug.chdir, 1);
     assert_eq!(config5.debug.hash, 1);
 }


### PR DESCRIPTION
## Summary

- Drops restating test comments in `config.rs`, `thread_local.rs`, `phase_timer.rs`, and `tracing_bridge_tests.rs` that merely echoed the next assertion.
- Trims one redundant inline comment in `error_format.rs::strip_repo_prefix` and replaces a vague "Fallback:" note with the actual reason for the alternate branch.
- Drops a single-line restating comment in `init_tracing`.
- Preserves every `// upstream: log.c / options.c / rsync.h` citation and every WHY comment (e.g. the ordering note in `target_to_debug_flag`, the per-level upstream `info_verbosity[]` / `debug_verbosity[]` mappings in `from_verbose_level`, and the "filtering happens at debug_gte" clarification).
- No new rustdoc gaps were found; all public items already document purpose, invariants, and arguments.

Net delta: 6 files, +16 / -48.

## Test plan

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings`
- Behavior unchanged (comments + one helper comment reword only).