### PR TITLE
docs(platform): drop restatement comments and fix broken rustdoc links

### DIFF
--- a/crates/platform/src/daemonize.rs
+++ b/crates/platform/src/daemonize.rs
@@ -110,7 +110,6 @@ mod tests {
         match pid {
             -1 => panic!("fork failed: {}", io::Error::last_os_error()),
             0 => {
-                // Child: attempt the redirect, then _exit.
                 let result = redirect_stdio_to_devnull();
                 // SAFETY: _exit is safe in the child process.
                 unsafe {
@@ -118,7 +117,6 @@ mod tests {
                 }
             }
             child_pid => {
-                // Parent: wait for the child and check its exit status.
                 let mut status: libc::c_int = 0;
                 // SAFETY: waitpid with a valid child PID is safe.
                 let waited = unsafe { libc::waitpid(child_pid, &mut status, 0) };

--- a/crates/platform/src/windows_service.rs
+++ b/crates/platform/src/windows_service.rs
@@ -6,12 +6,12 @@
 //!
 //! # Architecture
 //!
-//! - [`run_service_dispatcher`] starts the SCM service dispatch table, blocking
+//! - `run_service_dispatcher` starts the SCM service dispatch table, blocking
 //!   until the service stops.
-//! - [`ServiceStatusHandle`] reports lifecycle transitions to the SCM.
-//! - [`install_service`] and [`uninstall_service`] manage service registration.
-//! - The control handler maps SCM events to [`signal::SignalFlags`] atomics,
-//!   reusing the same shutdown/reload mechanism as console mode.
+//! - `ServiceStatusHandle` reports lifecycle transitions to the SCM.
+//! - `install_service` and `uninstall_service` manage service registration.
+//! - The control handler maps SCM events to [`crate::signal::SignalFlags`]
+//!   atomics, reusing the same shutdown/reload mechanism as console mode.
 
 use std::io;
 
@@ -127,7 +127,6 @@ mod windows_impl {
                 lpServiceName: PWSTR(service_name.as_ptr() as *mut u16),
                 lpServiceProc: Some(service_main_entry),
             },
-            // Null terminator entry.
             SERVICE_TABLE_ENTRYW {
                 lpServiceName: PWSTR(std::ptr::null_mut()),
                 lpServiceProc: None,


### PR DESCRIPTION
## Summary

Per-crate comment cleanup pass on the `platform` crate. The crate was already in excellent shape (every public item documented, comprehensive SAFETY comments on every `#[allow(unsafe_code)]` block), so the cleanup is small.

- **Restatement comments deleted: 3.** `// Child:` / `// Parent:` labels on the fork arms in the `daemonize` test (the `pid == 0` arm and `child_pid` binding self-document the branch), plus `// Null terminator entry.` on a `SERVICE_TABLE_ENTRYW` whose fields are explicit `null_mut()` / `None`.
- **Broken intra-doc links fixed in `windows_service`.** Module-doc `[\`run_service_dispatcher\`]`, `[\`ServiceStatusHandle\`]`, `[\`install_service\`]`, `[\`uninstall_service\`]`, and `[\`signal::SignalFlags\`]` resolved before the `#[cfg(windows)]` / `#[cfg(not(windows))]` `pub use` re-exports brought the names into scope, so `cargo doc -p platform --no-deps` failed under `#![deny(rustdoc::broken_intra_doc_links)]`. Switched the four local items to backtick-only references and the cross-module link to a fully qualified `[\`crate::signal::SignalFlags\`]` path, matching the known pitfall guidance.

All SAFETY comments on `unsafe` blocks were preserved verbatim. No new `#[allow(...)]` waivers. No semantic changes.

Files touched: 2 (`crates/platform/src/daemonize.rs`, `crates/platform/src/windows_service.rs`). Net: +5 / -8.

## Test plan

- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` clean.
- [x] `cargo doc -p platform --no-deps` now succeeds (previously failed with five broken intra-doc links).
- [x] Comment-only; no behavioural change. CI nextest covers the unchanged code paths.