### PR TITLE
docs(filters): drop restatement comments and add must_use

### DIFF
--- a/crates/filters/src/apple_double.rs
+++ b/crates/filters/src/apple_double.rs
@@ -51,6 +51,7 @@ pub fn default_patterns() -> impl Iterator<Item = &'static str> {
 }
 
 /// Returns the number of default AppleDouble exclusion patterns.
+#[must_use]
 pub fn pattern_count() -> usize {
     default_patterns().count()
 }

--- a/crates/filters/src/compiled/clear.rs
+++ b/crates/filters/src/compiled/clear.rs
@@ -118,7 +118,6 @@ mod tests {
         };
         let mut rules = vec![CompiledRule::new(rule).unwrap()];
         apply_clear_rule(&mut rules, true, false);
-        // Rule should be removed since sender is now cleared and receiver was already false
         assert!(rules.is_empty());
     }
 }

--- a/crates/filters/src/compiled/mod.rs
+++ b/crates/filters/src/compiled/mod.rs
@@ -163,8 +163,6 @@ mod tests {
         };
         let compiled = CompiledRule::new(rule).unwrap();
         assert!(compiled.directory_only);
-        // Include dirs should NOT match descendants - files inside must
-        // match their own include/exclude rules independently.
         assert!(
             compiled.descendant_matchers.is_empty(),
             "include directory-only rules must not have descendant matchers"

--- a/crates/filters/src/compiled/rule.rs
+++ b/crates/filters/src/compiled/rule.rs
@@ -148,7 +148,6 @@ mod tests {
         };
         let compiled = CompiledRule::new(rule).unwrap();
         assert!(compiled.matches(Path::new("build"), false));
-        // Anchored patterns should not match nested paths
         assert!(!compiled.matches(Path::new("src/build"), false));
     }
 
@@ -166,9 +165,7 @@ mod tests {
             no_inherit: false,
         };
         let compiled = CompiledRule::new(rule).unwrap();
-        // Directory-only patterns should match directories
         assert!(compiled.matches(Path::new("node_modules"), true));
-        // Directory-only patterns should not match files
         assert!(!compiled.matches(Path::new("node_modules"), false));
     }
 
@@ -186,9 +183,7 @@ mod tests {
             no_inherit: false,
         };
         let compiled = CompiledRule::new(rule).unwrap();
-        // Should match the directory itself
         assert!(compiled.matches(Path::new("build"), true));
-        // Should match descendants via descendant matchers
         assert!(compiled.matches(Path::new("build/output.o"), false));
         assert!(compiled.matches(Path::new("build/subdir/file.txt"), false));
     }
@@ -266,7 +261,6 @@ mod tests {
 
     #[test]
     fn compiled_rule_negate_inverts_match() {
-        // Non-negated rule: matches files with *.txt extension
         let rule = FilterRule {
             action: FilterAction::Exclude,
             pattern: "*.txt".to_owned(),
@@ -282,7 +276,6 @@ mod tests {
         assert!(compiled.matches(Path::new("file.txt"), false));
         assert!(!compiled.matches(Path::new("file.log"), false));
 
-        // Negated rule: matches files that do NOT have *.txt extension
         let rule_negated = FilterRule {
             action: FilterAction::Exclude,
             pattern: "*.txt".to_owned(),
@@ -295,15 +288,12 @@ mod tests {
             no_inherit: false,
         };
         let compiled_negated = CompiledRule::new(rule_negated).unwrap();
-        // Pattern matches file.txt, but negate inverts: returns false
         assert!(!compiled_negated.matches(Path::new("file.txt"), false));
-        // Pattern doesn't match file.log, negate inverts: returns true
         assert!(compiled_negated.matches(Path::new("file.log"), false));
     }
 
     #[test]
     fn compiled_rule_negate_with_directory_only() {
-        // Negated directory-only rule
         let rule = FilterRule {
             action: FilterAction::Exclude,
             pattern: "cache/".to_owned(),
@@ -317,20 +307,15 @@ mod tests {
         };
         let compiled = CompiledRule::new(rule).unwrap();
 
-        // Directory "cache" matches the pattern, negate inverts: false
         assert!(!compiled.matches(Path::new("cache"), true));
-
-        // Directory "build" doesn't match, negate inverts: true
         assert!(compiled.matches(Path::new("build"), true));
-
-        // File "cache" (not dir) - directory_only means it shouldn't match anyway
-        // Pattern doesn't match a file named cache, negate inverts: true
+        // directory_only means a file named "cache" never matches the pattern,
+        // so the negated rule returns true for it.
         assert!(compiled.matches(Path::new("cache"), false));
     }
 
     #[test]
     fn compiled_rule_negate_with_anchored() {
-        // Negated anchored pattern
         let rule = FilterRule {
             action: FilterAction::Exclude,
             pattern: "/important".to_owned(),
@@ -344,13 +329,9 @@ mod tests {
         };
         let compiled = CompiledRule::new(rule).unwrap();
 
-        // "important" at root matches, negate inverts: false
         assert!(!compiled.matches(Path::new("important"), false));
-
-        // "other" doesn't match, negate inverts: true
         assert!(compiled.matches(Path::new("other"), false));
-
-        // "dir/important" doesn't match anchored pattern, negate inverts: true
+        // Anchored pattern does not match a nested path, so negation gives true.
         assert!(compiled.matches(Path::new("dir/important"), false));
     }
 
@@ -373,11 +354,11 @@ mod tests {
         };
         let compiled = CompiledRule::new(rule).unwrap();
 
-        // Directories should match
         assert!(compiled.matches(Path::new("subdir"), true));
         assert!(compiled.matches(Path::new("deep/nested"), true));
 
-        // Files should NOT match - even inside directories
+        // Files inside matched directories still need their own rules to match;
+        // an include of `*/` alone does not pull file descendants in.
         assert!(!compiled.matches(Path::new("file.txt"), false));
         assert!(!compiled.matches(Path::new("subdir/debug.log"), false));
         assert!(!compiled.matches(Path::new("subdir/report.csv"), false));

--- a/crates/filters/src/cvs.rs
+++ b/crates/filters/src/cvs.rs
@@ -37,7 +37,6 @@
 /// - `*` matches any characters except `/`
 /// - Trailing `/` marks directory-only patterns
 pub const DEFAULT_CVSIGNORE: &str = concat!(
-    // Version control systems
     "RCS ",
     "SCCS ",
     "CVS ",
@@ -46,36 +45,30 @@ pub const DEFAULT_CVSIGNORE: &str = concat!(
     "cvslog.* ",
     "tags ",
     "TAGS ",
-    // Build state
     ".make.state ",
     ".nse_depinfo ",
-    // Editor backup files
     "*~ ",
     "#* ",
     ".#* ",
     ",* ",
     "_$* ",
     "*$ ",
-    // Backup/original files
     "*.old ",
     "*.bak ",
     "*.BAK ",
     "*.orig ",
     "*.rej ",
     ".del-* ",
-    // Object files and libraries
     "*.a ",
     "*.olb ",
     "*.o ",
     "*.obj ",
     "*.so ",
     "*.exe ",
-    // Miscellaneous
     "*.Z ",
     "*.elc ",
     "*.ln ",
     "core ",
-    // Modern VCS directories
     ".svn/ ",
     ".git/ ",
     ".hg/ ",
@@ -103,6 +96,7 @@ pub fn default_patterns() -> impl Iterator<Item = &'static str> {
 
 /// Returns the number of default CVS exclusion patterns in
 /// [`DEFAULT_CVSIGNORE`].
+#[must_use]
 pub fn pattern_count() -> usize {
     default_patterns().count()
 }
@@ -153,7 +147,6 @@ mod tests {
 
     #[test]
     fn default_patterns_count_matches_expected() {
-        // Based on upstream rsync's default list
         let count = pattern_count();
         assert!(count >= 30, "expected at least 30 patterns, got {count}");
         assert!(count <= 40, "expected at most 40 patterns, got {count}");
@@ -173,10 +166,8 @@ mod tests {
     #[test]
     fn default_patterns_directory_markers_preserved() {
         let patterns: Vec<&str> = default_patterns().collect();
-        // Directory patterns should end with /
         assert!(patterns.contains(&".git/"));
         assert!(patterns.contains(&".svn/"));
-        // Non-directory patterns should not end with /
         assert!(patterns.contains(&"*.o"));
         assert!(!patterns.contains(&"*.o/"));
     }

--- a/crates/filters/src/set.rs
+++ b/crates/filters/src/set.rs
@@ -511,7 +511,7 @@ mod tests {
 
     #[test]
     fn filter_set_include_allows() {
-        // rsync uses first-match-wins: include must come before exclude for exceptions
+        // First-match-wins: include must precede exclude to create an exception.
         let rules = vec![
             FilterRule::include("*.txt".to_owned()),
             FilterRule::exclude("*".to_owned()),
@@ -526,8 +526,6 @@ mod tests {
             FilterSet::from_rules(vec![FilterRule::protect("/important".to_owned())]).unwrap();
         assert!(!set.allows_deletion(Path::new("important"), false));
     }
-
-    // CVS exclusion tests
 
     #[test]
     fn cvs_exclusion_rules_not_empty() {
@@ -587,11 +585,10 @@ mod tests {
 
     #[test]
     fn from_rules_with_cvs_explicit_rules_higher_priority() {
-        // Explicit include rule should take precedence over CVS exclusions
-        // rsync uses first-match-wins: explicit rules come first, so they have priority
+        // Explicit rules sit ahead of the CVS defaults, so first-match-wins
+        // allows them to override the built-in exclusions.
         let rules = vec![FilterRule::include("*.o")];
         let set = FilterSet::from_rules_with_cvs(rules, false).unwrap();
-        // With first-match-wins, explicit include matches before CVS exclude
         assert!(set.allows(Path::new("main.o"), false));
     }
 
@@ -599,12 +596,9 @@ mod tests {
     fn from_rules_with_cvs_explicit_exclude_still_works() {
         let rules = vec![FilterRule::exclude("*.txt")];
         let set = FilterSet::from_rules_with_cvs(rules, false).unwrap();
-        // Both explicit and CVS exclusions should work
         assert!(!set.allows(Path::new("notes.txt"), false));
         assert!(!set.allows(Path::new("main.o"), false));
     }
-
-    // AppleDouble exclusion tests
 
     #[test]
     fn apple_double_exclusion_rules_not_empty() {
@@ -644,18 +638,16 @@ mod tests {
         let set = FilterSet::from_rules_with_apple_double(vec![], false).unwrap();
         assert!(set.allows(Path::new("notes.txt"), false));
         assert!(set.allows(Path::new("subdir/inner.txt"), false));
-        // Files starting with a single dot but not ._ should pass
         assert!(set.allows(Path::new(".hidden"), false));
     }
 
     #[test]
     fn from_rules_with_apple_double_explicit_include_higher_priority() {
-        // Explicit include rule should take precedence over AppleDouble exclusions
-        // because first-match-wins favours rules supplied earlier.
+        // First-match-wins lets the explicit include override the AppleDouble
+        // exclusion appended at the tail of the rule list.
         let rules = vec![FilterRule::include("._keep")];
         let set = FilterSet::from_rules_with_apple_double(rules, false).unwrap();
         assert!(set.allows(Path::new("._keep"), false));
-        // Non-included sidecars are still excluded.
         assert!(!set.allows(Path::new("._other"), false));
     }
 }

--- a/crates/filters/src/tests.rs
+++ b/crates/filters/src/tests.rs
@@ -25,8 +25,7 @@ fn exclude_rule_blocks_match() {
 
 #[test]
 fn include_before_exclude_reinstates_path() {
-    // rsync uses first-match-wins semantics, so includes must come BEFORE
-    // excludes to create exceptions
+    // First-match-wins: includes must come before excludes to create exceptions.
     let rules = [
         FilterRule::include("foo/bar.txt"),
         FilterRule::exclude("foo"),
@@ -103,7 +102,6 @@ fn glob_escape_sequences_supported() {
 
 #[test]
 fn ordering_respected() {
-    // rsync uses first-match-wins: include must come before exclude for exceptions
     let rules = [
         FilterRule::include("special.tmp"),
         FilterRule::exclude("*.tmp"),
@@ -129,7 +127,6 @@ fn allows_checks_respect_directory_flag() {
 
 #[test]
 fn include_rule_for_directory_restores_descendants() {
-    // rsync uses first-match-wins: include must come before exclude for exceptions
     let rules = [
         FilterRule::include("cache/preserved/**"),
         FilterRule::exclude("cache/"),
@@ -141,19 +138,17 @@ fn include_rule_for_directory_restores_descendants() {
 
 #[test]
 fn relative_path_conversion_handles_dot_components() {
-    // Pattern with internal slash is anchored to root
+    // Internal slash anchors the pattern to the transfer root. globset does
+    // not normalise `foo/../foo/bar`, so the anchored pattern misses it; use
+    // `**/foo/bar` to match at any depth.
     let set = FilterSet::from_rules([FilterRule::exclude("foo/bar")]).expect("compiled");
 
-    // This path foo/../foo/bar is not normalized by globset, so it doesn't match
-    // the anchored pattern foo/bar. To match at any depth, use **/foo/bar
     let mut path = PathBuf::from("foo");
     path.push("..");
     path.push("foo");
     path.push("bar");
-    // Pattern is anchored, so it only matches literal "foo/bar" not "foo/../foo/bar"
     assert!(set.allows(&path, false));
 
-    // But a normalized path at root should match
     assert!(!set.allows(Path::new("foo/bar"), false));
 }
 
@@ -184,7 +179,7 @@ fn protect_rule_applies_to_directory_descendants() {
 
 #[test]
 fn risk_rule_allows_deletion_before_protection() {
-    // rsync uses first-match-wins: risk must come before protect to override
+    // First-match-wins: risk must precede protect to override it.
     let rules = [
         FilterRule::risk("archive/"),
         FilterRule::protect("archive/"),
@@ -195,7 +190,6 @@ fn risk_rule_allows_deletion_before_protection() {
 
 #[test]
 fn risk_rule_applies_to_descendants() {
-    // rsync uses first-match-wins: risk must come before protect to override
     let rules = [FilterRule::risk("backup/"), FilterRule::protect("backup/")];
     let set = FilterSet::from_rules(rules).expect("compiled");
     assert!(set.allows_deletion(Path::new("backup/snap/info"), false));
@@ -338,18 +332,15 @@ mod negate_tests {
         ];
         let set = FilterSet::from_rules(rules).expect("compiled");
 
-        // .txt files excluded by negated rule (they match, so NOT excluded by negated)
-        // Actually wait - the negated rule excludes non-.txt files
-        // So .txt files should be allowed by the negated rule, but we need to check ordering
-        // First rule excludes .tmp, second (negated) excludes non-.txt
-        // For file.txt: first rule doesn't match, second rule matches .txt so doesn't exclude
+        // file.txt: first rule misses; the negated `*.txt` exclude matches and
+        // negates to "do not exclude", so the file is allowed.
         assert!(set.allows(Path::new("file.txt"), false));
 
-        // For file.tmp: first rule matches and excludes
+        // file.tmp: matched by the first plain exclude.
         assert!(!set.allows(Path::new("file.tmp"), false));
 
-        // For file.log: first rule doesn't match, second rule doesn't match *.txt
-        // so negated exclude applies
+        // file.log: first rule misses; the negated `*.txt` exclude misses too,
+        // and negation turns the miss into an exclusion.
         assert!(!set.allows(Path::new("file.log"), false));
     }
 
@@ -364,7 +355,6 @@ mod negate_tests {
 
     #[test]
     fn negate_flag_chaining() {
-        // Test that with_negate can be chained with other modifiers
         let rule = FilterRule::exclude("*.tmp")
             .with_perishable(true)
             .with_negate(true)


### PR DESCRIPTION
## Summary
- Strip decorative section dividers (`// Version control systems`, `// Build state`, etc.) from inside the `DEFAULT_CVSIGNORE` table and the two test-section markers in `set.rs`.
- Remove restatement comments that echo the adjacent assertion or the test body (compiled rule/clear/mod tests, tests.rs, cvs.rs).
- Tighten a couple of repeated first-match-wins explainers and a conversational "Actually wait" thought bubble in the negate combination test.
- Add `#[must_use]` to `cvs::pattern_count` and `apple_double::pattern_count` for parity with the other accessor helpers in the crate.

Comment-only change: 64 lines of `//` comments removed across 7 files, 2 new `#[must_use]` attributes. No new rustdoc was needed - the crate already has complete `///` coverage on public items and `#![deny(missing_docs)]` enforces it.

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings`
- n/a for nextest; comment-only edits.