### PR TITLE
docs(matching): drop restatement comments in optimized_search tests

### DIFF
--- a/crates/matching/src/optimized_search.rs
+++ b/crates/matching/src/optimized_search.rs
@@ -187,7 +187,6 @@ mod tests {
     fn test_tag_table_empty() {
         let blocks = vec![];
         let tag_table = TagTable::new(&blocks);
-        // All tags should be false for empty input
         assert!(!tag_table.might_match(0x12345678));
         assert!(!tag_table.might_match(0x00000000));
         assert!(!tag_table.might_match(0xFFFFFFFF));
@@ -229,7 +228,6 @@ mod tests {
         }];
         let tag_table = TagTable::new(&blocks);
 
-        // Different low 16 bits should not match
         assert!(!tag_table.might_match(0x12341234));
         assert!(!tag_table.might_match(0xFFFFFFFF));
     }
@@ -463,7 +461,6 @@ mod tests {
 
     #[test]
     fn test_large_block_set() {
-        // Create 10000 blocks with unique checksums
         let mut blocks = Vec::new();
         for i in 0..10000 {
             blocks.push(BlockEntry {


### PR DESCRIPTION
## Summary

Per-crate comment cleanup pass on the `matching` crate, following the same precedent as PRs #4575 (compress), #4569 (bandwidth), #4584 (filters), #4582 (logging), #4583 (platform).

The matching crate was already exceptionally well-maintained:

- All public types, traits, functions, and fields carry rustdoc.
- All algorithmic WHY comments (rolling-hash hot path, bithash prefilter, matched-block pruning, seq-match coalescing, sparse-match invariants) reference upstream rsync `match.c` or zsync `librcksum` semantics and are preserved.
- Module docs already explain design contracts and cite `docs/design/zsync-*.md`.

Only three restating comments were found and removed in `optimized_search.rs` tests, where the next line of code (or an assertion) already conveyed the same information.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings`
- [ ] CI matrix (fmt+clippy, nextest, Windows, macOS, Linux musl)