### PR TITLE
docs(fast_io): drop restatement comments, apply rustdoc to public items

### DIFF
--- a/crates/fast_io/src/cached_sort.rs
+++ b/crates/fast_io/src/cached_sort.rs
@@ -274,7 +274,6 @@ mod tests {
 
     #[test]
     fn file_entry_sort_key_from_bytes() {
-        // Test that from_bytes produces the same result as new()
         let from_str = FileEntrySortKey::new("test/path.txt", false);
         let from_bytes = FileEntrySortKey::from_bytes(b"test/path.txt", false);
         assert_eq!(from_str, from_bytes);
@@ -289,7 +288,6 @@ mod tests {
 
     #[test]
     fn file_entry_sort_key_from_bytes_comparison() {
-        // Test that byte comparison works correctly
         let a = FileEntrySortKey::from_bytes(b"aaa", false);
         let b = FileEntrySortKey::from_bytes(b"bbb", false);
         assert_eq!(a.cmp(&b), Ordering::Less);

--- a/crates/fast_io/src/io_uring_common.rs
+++ b/crates/fast_io/src/io_uring_common.rs
@@ -26,8 +26,6 @@
 
 use std::io;
 
-// --- Kernel UAPI opcode and flag constants ----------------------------------
-
 /// Numeric value of `IORING_OP_LINKAT`.
 ///
 /// Kernel UAPI constant from `include/uapi/linux/io_uring.h`, stable since
@@ -84,8 +82,6 @@ pub(crate) const IORING_CQE_F_BUFFER: u32 = 1 << 0;
 
 /// Bit position of the buffer ID inside the CQE flags word.
 pub(crate) const IORING_CQE_BUFFER_SHIFT: u32 = 16;
-
-// --- Configuration data structs --------------------------------------------
 
 /// Plain-data configuration for an io_uring instance.
 ///
@@ -219,8 +215,6 @@ pub struct IoUringKernelInfo {
     pub reason: String,
 }
 
-// --- Shared-ring tagging helpers -------------------------------------------
-
 /// SQE `user_data` tag identifying the source channel of a completion.
 ///
 /// Stored in the high 8 bits of `user_data`. Encoding/decoding is pure
@@ -317,8 +311,6 @@ pub fn buffer_id_from_cqe_flags(flags: u32) -> Option<u16> {
         None
     }
 }
-
-// --- Buffer ring configuration and errors ----------------------------------
 
 /// Errors specific to buffer ring operations.
 #[derive(Debug, thiserror::Error)]
@@ -477,8 +469,6 @@ impl Default for BufferRingConfig {
     }
 }
 
-// --- Registered-buffer telemetry types -------------------------------------
-
 /// Snapshot of registered-buffer telemetry counters.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct RegisteredBufferStats {
@@ -536,8 +526,6 @@ impl RegisteredBufferStatus {
         matches!(self, Self::RegistrationFailed { .. })
     }
 }
-
-// --- Backend trait ---------------------------------------------------------
 
 /// Cross-platform contract for an io_uring-style I/O backend.
 ///

--- a/crates/fast_io/src/macos_io.rs
+++ b/crates/fast_io/src/macos_io.rs
@@ -533,7 +533,6 @@ mod tests {
 
         let writer = MacosWriter::create(&path, 512).unwrap();
 
-        // Below threshold - nocache should not be enabled
         #[cfg(target_os = "macos")]
         assert!(!writer.is_nocache_enabled());
 
@@ -564,7 +563,6 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("boundary_below.bin");
 
-        // One byte below threshold
         let writer = MacosWriter::create(&path, F_NOCACHE_THRESHOLD - 1).unwrap();
 
         #[cfg(target_os = "macos")]
@@ -581,7 +579,6 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("boundary_exact.bin");
 
-        // Exactly at threshold
         let writer = MacosWriter::create(&path, F_NOCACHE_THRESHOLD).unwrap();
 
         #[cfg(target_os = "macos")]
@@ -842,7 +839,6 @@ mod tests {
 
         let content = std::fs::read(&path).unwrap();
         assert_eq!(content.len(), 8 * 64 * 1024);
-        // Verify each chunk
         for (i, actual_chunk) in content.chunks(64 * 1024).enumerate() {
             assert_eq!(actual_chunk, &chunk[..], "chunk {i} mismatch");
         }
@@ -874,7 +870,7 @@ mod tests {
         let mut writer = MacosWriter::create(&path, 0).unwrap();
         writer.write_all(b"data").unwrap();
         writer.flush().unwrap();
-        writer.flush().unwrap(); // Should be a no-op
+        writer.flush().unwrap();
         writer.flush().unwrap();
 
         let content = std::fs::read(&path).unwrap();

--- a/crates/fast_io/src/sendfile/tests.rs
+++ b/crates/fast_io/src/sendfile/tests.rs
@@ -407,7 +407,6 @@ fn test_send_file_to_fd_macos_non_socket_falls_back() {
 
 #[test]
 fn test_copy_via_readwrite_direct() {
-    // Test the read/write fallback path directly
     let content = b"Testing fallback path directly with specific data";
     let source = create_temp_file(content).unwrap();
     let mut output = Vec::new();
@@ -423,7 +422,6 @@ fn test_copy_via_readwrite_direct() {
 #[cfg(target_os = "linux")]
 #[test]
 fn test_threshold_boundary() {
-    // Test at exact threshold boundary
     let size = SENDFILE_THRESHOLD as usize;
     let content: Vec<u8> = (0..size).map(|i| (i % 256) as u8).collect();
     let source = create_temp_file(&content).unwrap();
@@ -438,14 +436,12 @@ fn test_threshold_boundary() {
 
 #[test]
 fn test_multiple_writes() {
-    // Test that multiple independent writes work correctly
     let content1 = b"First write";
     let content2 = b"Second";
     let source1 = create_temp_file(content1).unwrap();
     let source2 = create_temp_file(content2).unwrap();
     let mut output = Vec::new();
 
-    // First write
     let sent1 = send_file_to_writer(source1.as_file(), &mut output, content1.len() as u64).unwrap();
     assert_eq!(sent1, content1.len() as u64);
     assert_eq!(&output[..sent1 as usize], content1);

--- a/crates/fast_io/src/splice/tests/linux/recv_fd_to_file.rs
+++ b/crates/fast_io/src/splice/tests/linux/recv_fd_to_file.rs
@@ -115,7 +115,6 @@ fn test_recv_fd_to_file_exact_threshold() {
 
 #[test]
 fn test_copy_fd_to_fd_fallback() {
-    // Test the fallback path directly.
     let content = b"Testing copy_fd_to_fd fallback path directly";
     let mut dest = NamedTempFile::new().unwrap();
 

--- a/crates/fast_io/src/zero_detect.rs
+++ b/crates/fast_io/src/zero_detect.rs
@@ -397,7 +397,6 @@ mod tests {
 
     #[test]
     fn zero_parity_all_implementations_explicit() {
-        // Test all compiled implementations directly for parity
         let mut buf = vec![0u8; 256];
         for pos in (0..256).step_by(7) {
             buf.fill(0);
@@ -490,7 +489,6 @@ mod tests {
 
     #[test]
     fn zero_large_buffer_performance_sanity() {
-        // Ensure large buffers work correctly (regression guard)
         let size = 1024 * 1024; // 1 MiB
         let buf = vec![0u8; size];
         assert_eq!(find_first_nonzero(&buf), size);


### PR DESCRIPTION
## Summary

- Removes the six decorative `// --- ... ---` banner dividers in
  `io_uring_common.rs` (precedent: PRs #4587, #4584, #4583, #4582, #4575).
- Removes a small set of restatement comments in tests where the line
  above already echoed the test name or the immediately following code
  (`cached_sort`, `zero_detect`, `macos_io`, `sendfile/tests`,
  `splice/tests/linux/recv_fd_to_file`).
- Preserves every `SAFETY:` comment above `unsafe` blocks (the crate
  wraps io_uring, copy_file_range, sendfile, mmap, IOCP, signal, and
  setsockopt FFI - SAFETY context is load-bearing).
- Preserves upstream-rsync cites and WHY context.

## Scope

`fast_io` is the largest single crate in the workspace (~39k lines
across 132 files). The pre-existing comment hygiene is already
excellent: the crate enforces `#![deny(missing_docs)]`, public items
all have rustdoc, and almost every internal comment carries WHY
content (FFI invariants, kernel quirks, issue references, fallback
rationale). The targeted cleanup landed in 6 files for a net -25 lines.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings`