### PR TITLE
docs(transfer): drop restatement comments, tighten test annotations

### DIFF
--- a/crates/transfer/src/compressed_writer.rs
+++ b/crates/transfer/src/compressed_writer.rs
@@ -29,23 +29,23 @@ use compress::zstd::CountingZstdEncoder;
 /// the compression algorithm, causing read-batch to force CPRES_ZLIB
 /// (compat.c:194-195) even when the original write used zstd.
 pub struct CompressedWriter<W: Write> {
-    /// The underlying writer (typically MultiplexWriter)
+    /// Underlying writer, typically a `MultiplexWriter`.
     inner: W,
-    /// Active compression encoder variant
+    /// Active compression encoder variant.
     encoder: EncoderVariant,
-    /// Flush threshold - flush when buffer exceeds this size
+    /// Drain the encoder's sink to `inner` when it exceeds this many bytes.
     flush_threshold: usize,
 }
 
 /// Compression encoder dispatch for supported algorithms.
 #[allow(clippy::large_enum_variant)]
 enum EncoderVariant {
-    /// zlib encoder writing to Vec<u8>
+    /// zlib encoder writing to a heap-backed sink.
     Zlib(CountingZlibEncoder<Vec<u8>>),
-    /// LZ4 encoder writing to Vec<u8>
+    /// LZ4 encoder writing to a heap-backed sink.
     #[cfg(feature = "lz4")]
     Lz4(CountingLz4Encoder<Vec<u8>>),
-    /// Zstandard encoder writing to Vec<u8>
+    /// Zstandard encoder writing to a heap-backed sink.
     #[cfg(feature = "zstd")]
     Zstd(CountingZstdEncoder<Vec<u8>>),
 }
@@ -178,7 +178,6 @@ impl<W: Write> CompressedWriter<W> {
     ///
     /// Returns an error if finishing the compression stream or flushing fails.
     pub fn finish(mut self) -> io::Result<W> {
-        // finish_into_inner writes the final trailer bytes to the sink.
         match self.encoder {
             EncoderVariant::Zlib(encoder) => {
                 let (sink, _bytes) = encoder.finish_into_inner()?;
@@ -251,7 +250,6 @@ impl<W: Write> Write for CompressedWriter<W> {
             self.drain_sink()?;
         }
 
-        // Report full write to match upstream behavior.
         Ok(buf.len())
     }
 
@@ -292,10 +290,8 @@ mod tests {
         writer.write_all(data).unwrap();
         writer.finish().unwrap();
 
-        // Verify compressed data exists
         assert!(!buf.is_empty());
 
-        // Decompress and verify
         let decompressed = decompress_to_vec(&buf).unwrap();
         assert_eq!(decompressed, data);
     }
@@ -319,7 +315,6 @@ mod tests {
         writer.write_all(data3).unwrap();
         writer.finish().unwrap();
 
-        // Decompress and verify all chunks
         let decompressed = decompress_to_vec(&buf).unwrap();
         let expected = b"first chunk second chunk third chunk";
         assert_eq!(decompressed, expected);
@@ -327,7 +322,6 @@ mod tests {
 
     #[test]
     fn compress_large_data_flushes_automatically() {
-        // Create data larger than flush threshold
         let data = vec![b'x'; 8192];
 
         let mut buf = Vec::new();
@@ -340,10 +334,8 @@ mod tests {
             writer.finish().unwrap();
         }
 
-        // Should have written compressed data
         assert!(!buf.is_empty());
 
-        // Decompress and verify
         let decompressed = decompress_to_vec(&buf).unwrap();
         assert_eq!(decompressed, data);
     }
@@ -364,10 +356,9 @@ mod tests {
             writer.finish().unwrap();
         }
 
-        // bytes_written should track compressed size (after finish)
-        // For zlib, compressed size should be reasonable
+        // Compressed size should fit within the input plus a small zlib overhead.
         assert!(!buf.is_empty());
-        assert!(buf.len() < data.len() + 20); // Allow for zlib overhead
+        assert!(buf.len() < data.len() + 20);
     }
 
     #[test]
@@ -380,7 +371,6 @@ mod tests {
         )
         .unwrap();
 
-        // Verify inner_mut returns a valid reference
         let _inner = writer.inner_mut();
         writer.finish().unwrap();
     }
@@ -407,20 +397,15 @@ mod tests {
             .unwrap();
 
             writer.write_all(token_data).unwrap();
-            // flush() should trigger Z_SYNC_FLUSH on the encoder, materializing
-            // all pending compressed data so it can be decompressed immediately.
+            // flush() triggers Z_SYNC_FLUSH so pending data is decompressible without more input.
             writer.flush().unwrap();
 
             writer.write_all(token2).unwrap();
             writer.finish().unwrap();
         }
 
-        // The compressed output after flush must be decompressible without
-        // needing more input. This is the key property of Z_SYNC_FLUSH.
         assert!(!buf.is_empty(), "flush must produce compressed output");
 
-        // Verify full stream decompresses correctly - Z_SYNC_FLUSH ensures
-        // the first token's data was flushed to the output before finish.
         // upstream: token.c:send_deflated_token lines 433-434.
         let full = decompress_to_vec(&buf).unwrap();
         let mut expected = Vec::new();
@@ -595,9 +580,8 @@ mod tests {
 
         #[test]
         fn with_workers_round_trip_and_smoke() {
-            // None matches upstream's `do_compression_threads = 0`. Some(_)
-            // either succeeds under `zstdmt` or returns Unsupported - never
-            // panic, never silently drop the setting.
+            // None matches upstream's do_compression_threads = 0. Some(_) either succeeds
+            // under zstdmt or returns Unsupported; never panic, never silently drop the setting.
             let data = b"zstd workers test";
             for workers in [None, std::num::NonZeroU8::new(4)] {
                 let mut buf = Vec::new();

--- a/crates/transfer/src/constants.rs
+++ b/crates/transfer/src/constants.rs
@@ -80,10 +80,6 @@ pub const fn aligned_overshoot(offset: u64) -> usize {
     (offset & (ALIGN_BOUNDARY as u64 - 1)) as usize
 }
 
-// These functions use 128-bit integer comparison for fast zero detection,
-// processing 16 bytes at a time. On x86-64, u128 operations are optimized
-// to use SSE/AVX registers, providing SIMD-like performance.
-
 /// Counts the number of leading zero bytes in a slice.
 ///
 /// Uses 16-byte chunks with u128 comparison for fast detection,
@@ -99,7 +95,6 @@ pub fn leading_zero_count(bytes: &[u8]) -> usize {
     let mut iter = bytes.chunks_exact(16);
 
     for chunk in &mut iter {
-        // SAFETY: chunks_exact(16) guarantees exactly 16-byte slices
         let chunk: &[u8; 16] = chunk.try_into().expect("chunks_exact guarantees 16 bytes");
         if u128::from_ne_bytes(*chunk) == 0 {
             offset += 16;
@@ -127,18 +122,15 @@ pub fn trailing_zero_count(bytes: &[u8]) -> usize {
     let mut iter = bytes.rchunks_exact(16);
 
     for chunk in &mut iter {
-        // SAFETY: rchunks_exact(16) guarantees exactly 16-byte slices
         let chunk: &[u8; 16] = chunk.try_into().expect("rchunks_exact guarantees 16 bytes");
         if u128::from_ne_bytes(*chunk) == 0 {
             offset += 16;
         } else {
-            // Found non-zero in this chunk - scan for exact position
             let trailing = chunk.iter().rev().take_while(|&&b| b == 0).count();
             return offset + trailing;
         }
     }
 
-    // Handle remainder (< 16 bytes)
     offset
         + iter
             .remainder()
@@ -213,8 +205,6 @@ mod tests {
         assert_eq!(aligned_overshoot(2000), 976);
     }
 
-    // Zero detection tests
-
     #[test]
     fn leading_zero_count_empty() {
         assert_eq!(leading_zero_count(&[]), 0);
@@ -240,7 +230,6 @@ mod tests {
     fn leading_zero_count_mixed() {
         assert_eq!(leading_zero_count(&[0, 0, 1, 0]), 2);
         assert_eq!(leading_zero_count(&[0, 0, 0, 0, 0, 1]), 5);
-        // Test at 16-byte boundary
         let mut data = vec![0u8; 20];
         data[16] = 1;
         assert_eq!(leading_zero_count(&data), 16);
@@ -270,7 +259,6 @@ mod tests {
     fn trailing_zero_count_mixed() {
         assert_eq!(trailing_zero_count(&[1, 0, 0]), 2);
         assert_eq!(trailing_zero_count(&[1, 0, 0, 0, 0, 0]), 5);
-        // Test at 16-byte boundary
         let mut data = vec![0u8; 20];
         data[3] = 1;
         assert_eq!(trailing_zero_count(&data), 16);

--- a/crates/transfer/src/error.rs
+++ b/crates/transfer/src/error.rs
@@ -335,7 +335,6 @@ mod tests {
 
     #[test]
     fn categorize_unknown_error_as_fatal() {
-        // Test that unknown/other errors are categorized as fatal
         let err = io::Error::from(io::ErrorKind::Other);
         let path = Path::new("/tmp/test.txt");
 
@@ -385,7 +384,6 @@ mod tests {
 
     #[test]
     fn read_exact_retry_handles_partial_reads() {
-        // Simulate a reader that returns data in chunks
         struct ChunkyReader {
             data: &'static [u8],
             pos: usize,
@@ -408,7 +406,7 @@ mod tests {
         let mut reader = ChunkyReader {
             data: b"hello world",
             pos: 0,
-            chunk_size: 3, // Return only 3 bytes at a time
+            chunk_size: 3,
         };
         let mut buf = [0u8; 11];
 
@@ -420,7 +418,7 @@ mod tests {
     fn read_exact_retry_returns_eof_on_short_read() {
         let data = b"short";
         let mut cursor = std::io::Cursor::new(data);
-        let mut buf = [0u8; 10]; // Requesting more than available
+        let mut buf = [0u8; 10];
 
         let result = read_exact_retry(&mut cursor, &mut buf);
         assert!(result.is_err());

--- a/crates/transfer/src/failed_directories.rs
+++ b/crates/transfer/src/failed_directories.rs
@@ -62,12 +62,10 @@ impl FailedDirectories {
     /// assert_eq!(failed.failed_ancestor("a/c/file.txt"), None);
     /// ```
     pub fn failed_ancestor(&self, entry_path: &str) -> Option<&str> {
-        // Check if exact path is failed
         if self.paths.contains(entry_path) {
             return self.paths.get(entry_path).map(|s| s.as_str());
         }
 
-        // Check each parent path component by walking backwards
         let mut check_path = entry_path;
         while let Some(pos) = check_path.rfind('/') {
             check_path = &check_path[..pos];
@@ -267,11 +265,8 @@ mod tests {
         let mut failed = FailedDirectories::new();
         failed.mark_failed("abc");
 
-        // "abcd" contains "abc" but is not a child path
         assert!(failed.failed_ancestor("abcd").is_none());
         assert!(failed.failed_ancestor("abcd/file.txt").is_none());
-
-        // Only actual children should match
         assert!(failed.failed_ancestor("abc/file.txt").is_some());
     }
 
@@ -282,11 +277,9 @@ mod tests {
         failed.mark_failed("a/b");
         failed.mark_failed("a/b/c");
 
-        // Should return the closest (most specific) failed ancestor
+        // Walking up from the entry returns the closest failed ancestor first.
         let result = failed.failed_ancestor("a/b/c/d/file.txt");
         assert!(result.is_some());
-        // The implementation returns the first match found walking up,
-        // which is "a/b/c" in this case
         assert_eq!(result, Some("a/b/c"));
     }
 

--- a/crates/transfer/src/flags.rs
+++ b/crates/transfer/src/flags.rs
@@ -154,14 +154,12 @@ impl ParsedServerFlags {
         #[allow(unused_mut)] // REASON: mutated when acl or xattr features are not enabled
         let mut cleared = Vec::new();
 
-        // ACL support requires the `acl` feature (Unix POSIX/NFSv4 ACLs or Windows DACLs).
         #[cfg(not(all(any(unix, windows), feature = "acl")))]
         if self.acls {
             self.acls = false;
             cleared.push("ACLs");
         }
 
-        // Extended attribute support requires the `xattr` feature on Unix.
         #[cfg(not(all(unix, feature = "xattr")))]
         if self.xattrs {
             self.xattrs = false;
@@ -197,7 +195,6 @@ impl ParsedServerFlags {
             }
         }
 
-        // Archive mode implies several flags
         if flags.archive {
             flags.recursive = true;
             flags.links = true;
@@ -254,7 +251,7 @@ impl ParsedServerFlags {
             // upstream: options.c:764 - fuzzy_basis++ for each 'y'
             b'y' => self.fuzzy_level = self.fuzzy_level.saturating_add(1),
             b'm' => self.prune_empty_dirs = true,
-            // Unknown flags are ignored to maintain forward compatibility
+            // Unknown flags are ignored for forward compatibility.
             _ => {}
         }
     }
@@ -269,7 +266,6 @@ impl InfoFlags {
             b'f' => self.flist = true,
             b'x' => self.checksum = true,
             b'C' => self.compress = true,
-            // Unknown info flags are ignored
             _ => {}
         }
     }
@@ -291,7 +287,6 @@ mod tests {
     fn parses_typical_rsync_flag_string() {
         let flags = ParsedServerFlags::parse("-logDtpre.iLsfxC").unwrap();
 
-        // Transfer flags
         assert!(flags.links);
         assert!(flags.owner);
         assert!(flags.group);
@@ -302,7 +297,6 @@ mod tests {
         assert!(flags.recursive);
         assert!(flags.rsh);
 
-        // Info flags
         assert!(flags.info_flags.itemize);
         assert!(flags.info_flags.log_format);
         assert!(flags.info_flags.stats);
@@ -317,7 +311,7 @@ mod tests {
 
         assert!(flags.archive);
         assert!(flags.verbose);
-        // Archive implies these
+        // Archive (-a) implies -rlptgoD.
         assert!(flags.recursive);
         assert!(flags.links);
         assert!(flags.perms);
@@ -351,7 +345,6 @@ mod tests {
 
     #[test]
     fn ignores_unknown_flags() {
-        // Unknown flags like 'Q' and 'Z' (uppercase) in transfer section
         let flags = ParsedServerFlags::parse("-rQZv").unwrap();
         assert!(flags.recursive);
         assert!(flags.verbose);
@@ -516,10 +509,6 @@ mod tests {
         assert!(flags.xattrs);
         let cleared = flags.clear_unsupported_features();
 
-        // On a platform without both features, both are cleared.
-        // On a platform with both, neither is cleared.
-        // On a platform with only one, only the missing one is cleared.
-        // The exact result depends on the build, but the function must not panic.
         for name in &cleared {
             assert!(
                 *name == "ACLs" || *name == "xattrs",
@@ -527,7 +516,6 @@ mod tests {
             );
         }
 
-        // After clearing, the flag matches whether the feature is available.
         #[cfg(all(any(unix, windows), feature = "acl"))]
         assert!(flags.acls, "ACLs should remain when feature is available");
         #[cfg(not(all(any(unix, windows), feature = "acl")))]

--- a/crates/transfer/src/map_file/mod.rs
+++ b/crates/transfer/src/map_file/mod.rs
@@ -52,7 +52,7 @@ pub use mmap::MmapStrategy;
 
 /// Threshold above which memory mapping is preferred over buffered I/O.
 /// Files larger than 1MB benefit from mmap's zero-copy access.
-pub const MMAP_THRESHOLD: u64 = 1024 * 1024; // 1 MB
+pub const MMAP_THRESHOLD: u64 = 1024 * 1024;
 
 /// Strategy trait for file mapping implementations.
 ///

--- a/crates/transfer/src/parallel_io.rs
+++ b/crates/transfer/src/parallel_io.rs
@@ -216,7 +216,7 @@ mod tests {
     fn test_map_blocking_preserves_order() {
         let items: Vec<u64> = (0..50).collect();
         let results = map_blocking(items, 4, |x| {
-            // Introduce variable delay to test ordering
+            // Variable per-item delay forces worker reordering if ordering is not preserved.
             if x % 2 == 0 {
                 std::thread::sleep(std::time::Duration::from_micros(100));
             }
@@ -269,7 +269,6 @@ mod tests {
         let t = ParallelThresholds::default().with_stat(0).with_signature(0);
         assert_eq!(t.stat, 0);
         assert_eq!(t.signature, 0);
-        // Always uses parallel path when threshold is 0
         let items: Vec<i32> = (0..5).collect();
         let results = map_blocking(items, t.stat, |x| x * 2);
         assert_eq!(results, vec![0, 2, 4, 6, 8]);

--- a/crates/transfer/src/pipeline/mod.rs
+++ b/crates/transfer/src/pipeline/mod.rs
@@ -328,7 +328,6 @@ mod tests {
 
     #[test]
     fn with_ack_batching_enables() {
-        // Start with disabled config and enable it
         let config = PipelineConfig::synchronous().with_ack_batching(true);
         assert!(config.ack_batching_enabled);
     }

--- a/crates/transfer/src/role.rs
+++ b/crates/transfer/src/role.rs
@@ -23,7 +23,6 @@ pub enum ServerRole {
 mod tests {
     use super::*;
 
-    // Tests for Receiver variant
     #[test]
     fn receiver_debug_format() {
         let role = ServerRole::Receiver;
@@ -45,7 +44,6 @@ mod tests {
         assert_eq!(role, copied);
     }
 
-    // Tests for Generator variant
     #[test]
     fn generator_debug_format() {
         let role = ServerRole::Generator;
@@ -67,7 +65,6 @@ mod tests {
         assert_eq!(role, copied);
     }
 
-    // Tests for equality
     #[test]
     fn receiver_equals_receiver() {
         assert_eq!(ServerRole::Receiver, ServerRole::Receiver);

--- a/crates/transfer/src/temp_cleanup.rs
+++ b/crates/transfer/src/temp_cleanup.rs
@@ -39,18 +39,15 @@ const SUFFIX_LEN: usize = 6;
 /// - The suffix after the last `.` must be exactly 6 alphanumeric characters
 /// - The basename portion (between first `.` and last `.`) must be non-empty
 fn is_temp_file_name(name: &str) -> bool {
-    // Must start with '.'
     if !name.starts_with('.') {
         return false;
     }
 
-    // Find the last '.' which separates basename from random suffix
     let last_dot = match name.rfind('.') {
         Some(pos) if pos > 0 => pos,
         _ => return false,
     };
 
-    // The suffix after the last dot must be exactly SUFFIX_LEN alphanumeric chars
     let suffix = &name[last_dot + 1..];
     if suffix.len() != SUFFIX_LEN {
         return false;
@@ -59,9 +56,7 @@ fn is_temp_file_name(name: &str) -> bool {
         return false;
     }
 
-    // The basename between leading dot and last dot must be non-empty.
-    // For ".file.txt.AbCdEf", the part between index 1 and last_dot is "file.txt".
-    // For ".bashrc.XyZ123", the part between index 1 and last_dot is "bashrc".
+    // For ".file.txt.AbCdEf" the basename is "file.txt"; for ".bashrc.XyZ123" it is "bashrc".
     let basename = &name[1..last_dot];
     if basename.is_empty() {
         return false;
@@ -106,7 +101,7 @@ pub fn cleanup_stale_temp_files(dest_dir: &Path, max_age: Option<Duration>) -> i
     for entry in entries {
         let entry = match entry {
             Ok(e) => e,
-            Err(_) => continue, // Skip unreadable entries
+            Err(_) => continue,
         };
 
         let file_name = entry.file_name();
@@ -115,27 +110,24 @@ pub fn cleanup_stale_temp_files(dest_dir: &Path, max_age: Option<Duration>) -> i
             continue;
         }
 
-        // Only remove regular files, not directories or symlinks.
-        // Use file_type() (lstat-equivalent) to avoid following symlinks.
+        // file_type() is lstat-equivalent so symlinks named like temp files are skipped.
         let file_type = match entry.file_type() {
             Ok(ft) => ft,
-            Err(_) => continue, // Skip if we cannot stat
+            Err(_) => continue,
         };
         if !file_type.is_file() {
             continue;
         }
 
-        // Check age via mtime - metadata() follows symlinks but we already
-        // filtered to regular files above so this is safe.
         let metadata = match entry.metadata() {
             Ok(m) => m,
             Err(_) => continue,
         };
         let mtime = match metadata.modified() {
             Ok(t) => t,
-            Err(_) => continue, // Platform does not support mtime - skip
+            Err(_) => continue,
         };
-        // Future-dated files (clock skew) treated as age zero - safe to keep.
+        // Treat future-dated files (clock skew) as age zero so they are kept.
         let age = now.duration_since(mtime).unwrap_or(Duration::ZERO);
         if age < threshold {
             continue;
@@ -147,10 +139,7 @@ pub fn cleanup_stale_temp_files(dest_dir: &Path, max_age: Option<Duration>) -> i
                 debug_log!(Exit, 2, "removed stale temp file: {}", path.display());
                 removed += 1;
             }
-            Err(_) => {
-                // Best-effort - skip files we cannot remove (permissions, etc.)
-                continue;
-            }
+            Err(_) => continue,
         }
     }
 
@@ -164,8 +153,6 @@ mod tests {
     use std::time::Duration;
     use tempfile::tempdir;
 
-    // === is_temp_file_name tests ===
-
     #[test]
     fn matches_standard_temp_pattern() {
         assert!(is_temp_file_name(".file.txt.AbCdEf"));
@@ -176,7 +163,7 @@ mod tests {
 
     #[test]
     fn matches_dotfile_temp_pattern() {
-        // Dotfiles consume the leading dot: .bashrc -> .bashrc.XXXXXX
+        // Dotfiles consume the leading dot: .bashrc becomes .bashrc.XXXXXX.
         assert!(is_temp_file_name(".bashrc.AbCdEf"));
         assert!(is_temp_file_name(".gitignore.x1y2z3"));
     }
@@ -189,9 +176,9 @@ mod tests {
 
     #[test]
     fn rejects_wrong_suffix_length() {
-        assert!(!is_temp_file_name(".file.txt.ABCDE")); // 5 chars
-        assert!(!is_temp_file_name(".file.txt.ABCDEFG")); // 7 chars
-        assert!(!is_temp_file_name(".file.txt.")); // 0 chars
+        assert!(!is_temp_file_name(".file.txt.ABCDE"));
+        assert!(!is_temp_file_name(".file.txt.ABCDEFG"));
+        assert!(!is_temp_file_name(".file.txt."));
     }
 
     #[test]
@@ -204,7 +191,6 @@ mod tests {
 
     #[test]
     fn rejects_empty_basename() {
-        // "..ABCDEF" has empty basename between dots
         assert!(!is_temp_file_name("..ABCDEF"));
     }
 
@@ -223,11 +209,9 @@ mod tests {
 
     #[test]
     fn matches_multi_dot_basename() {
-        // ".file.tar.gz.AbCdEf" - basename is "file.tar.gz"
+        // For ".file.tar.gz.AbCdEf" the basename is "file.tar.gz".
         assert!(is_temp_file_name(".file.tar.gz.AbCdEf"));
     }
-
-    // === cleanup_stale_temp_files tests ===
 
     #[test]
     fn empty_directory_returns_zero() {
@@ -248,13 +232,11 @@ mod tests {
     fn removes_stale_temp_files() {
         let dir = tempdir().expect("create temp dir");
 
-        // Create temp files matching the pattern
         let temp1 = dir.path().join(".file.txt.AbCdEf");
         let temp2 = dir.path().join(".data.bin.x1y2z3");
         fs::write(&temp1, b"stale data 1").unwrap();
         fs::write(&temp2, b"stale data 2").unwrap();
 
-        // Use Duration::ZERO to consider all files stale
         let count = cleanup_stale_temp_files(dir.path(), Some(Duration::ZERO)).unwrap();
         assert_eq!(count, 2);
         assert!(!temp1.exists());
@@ -265,10 +247,9 @@ mod tests {
     fn preserves_non_matching_files() {
         let dir = tempdir().expect("create temp dir");
 
-        // Non-matching files
         let regular = dir.path().join("file.txt");
         let dotfile = dir.path().join(".bashrc");
-        let wrong_suffix = dir.path().join(".file.txt.ABCDE"); // 5 chars
+        let wrong_suffix = dir.path().join(".file.txt.ABCDE");
         fs::write(&regular, b"keep").unwrap();
         fs::write(&dotfile, b"keep").unwrap();
         fs::write(&wrong_suffix, b"keep").unwrap();
@@ -284,16 +265,13 @@ mod tests {
     fn respects_age_threshold() {
         let dir = tempdir().expect("create temp dir");
 
-        // Create a temp file - it will be brand new (age ~0)
         let temp = dir.path().join(".recent.AbCdEf");
         fs::write(&temp, b"fresh data").unwrap();
 
-        // Use a large threshold - file is too new to be removed
         let count = cleanup_stale_temp_files(dir.path(), Some(Duration::from_secs(3600))).unwrap();
         assert_eq!(count, 0);
         assert!(temp.exists());
 
-        // Now use Duration::ZERO - everything is stale
         let count = cleanup_stale_temp_files(dir.path(), Some(Duration::ZERO)).unwrap();
         assert_eq!(count, 1);
         assert!(!temp.exists());
@@ -303,7 +281,6 @@ mod tests {
     fn skips_directories_matching_pattern() {
         let dir = tempdir().expect("create temp dir");
 
-        // Create a directory that matches the naming pattern
         let temp_dir = dir.path().join(".subdir.AbCdEf");
         fs::create_dir(&temp_dir).unwrap();
 
@@ -316,11 +293,9 @@ mod tests {
     fn mixed_matching_and_non_matching() {
         let dir = tempdir().expect("create temp dir");
 
-        // Matching (stale)
         let stale = dir.path().join(".transfer.dat.Qw3rTy");
         fs::write(&stale, b"stale").unwrap();
 
-        // Non-matching
         let normal = dir.path().join("important.dat");
         fs::write(&normal, b"keep").unwrap();
 
@@ -339,20 +314,12 @@ mod tests {
         let subdir = dir.path().join("restricted");
         fs::create_dir(&subdir).unwrap();
 
-        // Create a temp file in a subdirectory, then remove read permission
-        // from the parent to simulate permission errors. We test the top-level
-        // directory scan resilience by creating an unreadable file.
         let temp = dir.path().join(".secret.AbCdEf");
         fs::write(&temp, b"data").unwrap();
 
-        // Make file read-only - removal should still work on most systems
-        // since we own the directory. Instead, test that unreadable dirs
-        // return an error gracefully.
         fs::set_permissions(&subdir, fs::Permissions::from_mode(0o000)).unwrap();
 
-        // Scanning the restricted subdir should fail gracefully
         let result = cleanup_stale_temp_files(&subdir, Some(Duration::ZERO));
-        // Restore permissions for cleanup
         fs::set_permissions(&subdir, fs::Permissions::from_mode(0o755)).unwrap();
 
         assert!(result.is_err());

--- a/crates/transfer/src/temp_guard.rs
+++ b/crates/transfer/src/temp_guard.rs
@@ -129,18 +129,14 @@ pub fn open_tmpfile(dest: &Path, temp_dir: Option<&Path>) -> io::Result<(fs::Fil
 
         match fs::OpenOptions::new()
             .write(true)
-            .create_new(true) // O_EXCL - fail if exists
+            .create_new(true)
             .open(&concrete_path)
         {
             Ok(file) => {
                 return Ok((file, TempFileGuard::new(concrete_path)));
             }
-            Err(ref e) if e.kind() == io::ErrorKind::AlreadyExists => {
-                // Collision - try another random suffix
-                continue;
-            }
+            Err(ref e) if e.kind() == io::ErrorKind::AlreadyExists => continue,
             Err(ref e) if e.kind() == io::ErrorKind::NotFound => {
-                // Parent directory missing - create it and retry.
                 // upstream: receiver.c:766 - mkdir_defmode(dn) before do_mkstemp()
                 if let Some(parent) = concrete_path.parent() {
                     fs::create_dir_all(parent)?;
@@ -175,7 +171,6 @@ fn fill_random_suffix(template: &str) -> String {
         .map(|&b| RAND_CHARS[(b as usize) % RAND_CHARS.len()] as char)
         .collect();
 
-    // Replace trailing XXXXXX with random suffix
     let prefix = &template[..template.len() - 6];
     format!("{prefix}{suffix}")
 }
@@ -217,10 +212,8 @@ impl TempFileGuard {
 impl Drop for TempFileGuard {
     fn drop(&mut self) {
         if !self.keep_on_drop {
-            // Best-effort cleanup - ignore errors since:
-            // 1. File might not exist (never created)
-            // 2. File might already be deleted (renamed away)
-            // 3. We're in a drop context (can't propagate errors)
+            // Best-effort: the file may never have been created, may already be renamed
+            // away, and we cannot propagate errors from drop anyway.
             let _ = std::fs::remove_file(&self.path);
         }
     }
@@ -231,8 +224,6 @@ mod tests {
     use super::*;
     use std::fs;
     use tempfile::tempdir;
-
-    // === TempFileGuard tests ===
 
     #[test]
     fn temp_file_deleted_on_drop() {
@@ -315,14 +306,11 @@ mod tests {
         }
     }
 
-    // === get_tmpname tests ===
-
     #[test]
     fn tmpname_regular_file() {
         let dest = Path::new("/path/to/file.txt");
         let result = get_tmpname(dest, None).unwrap();
         let name = result.file_name().unwrap().to_string_lossy();
-        // Should be ".file.txt.XXXXXX"
         assert!(name.starts_with(".file.txt."), "got: {name}");
         assert!(name.ends_with("XXXXXX"), "got: {name}");
         assert_eq!(result.parent().unwrap(), Path::new("/path/to"));
@@ -333,7 +321,6 @@ mod tests {
         let dest = Path::new("/home/user/.bashrc");
         let result = get_tmpname(dest, None).unwrap();
         let name = result.file_name().unwrap().to_string_lossy();
-        // Should be ".bashrc.XXXXXX" (not "..bashrc.XXXXXX")
         assert!(name.starts_with(".bashrc."), "got: {name}");
         assert!(!name.starts_with(".."), "double dot: {name}");
         assert!(name.ends_with("XXXXXX"), "got: {name}");
@@ -344,7 +331,6 @@ mod tests {
         let dest = Path::new("/path/to/file.txt");
         let temp_dir = Path::new("/tmp/rsync");
         let result = get_tmpname(dest, Some(temp_dir)).unwrap();
-        // Should be in temp_dir without extra leading dot
         assert!(result.starts_with(temp_dir));
         let name = result.file_name().unwrap().to_string_lossy();
         assert!(name.starts_with("file.txt."), "got: {name}");
@@ -363,7 +349,6 @@ mod tests {
 
     #[test]
     fn tmpname_long_filename_truncated() {
-        // Create a filename that exceeds NAME_MAX with the suffix
         let long_name = "a".repeat(260);
         let dest = PathBuf::from(format!("/path/{long_name}"));
         let result = get_tmpname(&dest, None).unwrap();
@@ -379,15 +364,13 @@ mod tests {
 
     #[test]
     fn tmpname_utf8_truncation_safe() {
-        // Create a filename with multi-byte UTF-8 chars near the truncation boundary
-        // Each emoji is 4 bytes
-        let emojis = "\u{1F600}".repeat(65); // 260 bytes
+        // Each emoji is 4 bytes, so 65 of them puts the truncation boundary mid-codepoint.
+        let emojis = "\u{1F600}".repeat(65);
         let dest = PathBuf::from(format!("/path/{emojis}"));
         let result = get_tmpname(&dest, None).unwrap();
         let name = result.file_name().unwrap().to_string_lossy();
         assert!(name.len() <= NAME_MAX);
         assert!(name.ends_with("XXXXXX"));
-        // Verify it's valid UTF-8 (would panic on to_string_lossy if not)
         assert!(!name.contains('\u{FFFD}'), "broken UTF-8: {name}");
     }
 
@@ -399,15 +382,12 @@ mod tests {
         assert!(name.starts_with(".rsync."), "got: {name}");
     }
 
-    // === fill_random_suffix tests ===
-
     #[test]
     fn fill_random_suffix_replaces_xs() {
         let template = "/path/to/.file.txt.XXXXXX";
         let result = fill_random_suffix(template);
         assert!(!result.ends_with("XXXXXX"), "Xs not replaced: {result}");
         assert_eq!(result.len(), template.len());
-        // Verify prefix is preserved
         assert!(result.starts_with("/path/to/.file.txt."));
     }
 
@@ -415,7 +395,7 @@ mod tests {
     fn fill_random_suffix_produces_unique_names() {
         let template = "/tmp/.test.XXXXXX";
         let names: Vec<String> = (0..10).map(|_| fill_random_suffix(template)).collect();
-        // With 62^6 = ~56 billion possibilities, duplicates are near-impossible
+        // With 62^6 = ~56 billion possibilities, duplicates are near-impossible.
         let unique: std::collections::HashSet<_> = names.iter().collect();
         assert!(unique.len() > 1, "all names identical: {names:?}");
     }
@@ -435,8 +415,6 @@ mod tests {
         }
     }
 
-    // === open_tmpfile tests ===
-
     #[test]
     fn open_tmpfile_creates_file() {
         let dir = tempdir().expect("create temp dir");
@@ -453,7 +431,6 @@ mod tests {
         assert!(!name.ends_with("XXXXXX"), "template not filled: {name}");
         assert_eq!(temp_path.parent().unwrap(), dir.path());
 
-        // Guard cleanup
         guard.keep();
         fs::remove_file(&temp_path).ok();
     }
@@ -497,13 +474,10 @@ mod tests {
             let (_file, guard) = open_tmpfile(&dest, None).unwrap();
             temp_path = guard.path().to_path_buf();
             assert!(temp_path.exists());
-            // guard dropped here - file should be deleted
         }
 
         assert!(!temp_path.exists());
     }
-
-    // === truncate_utf8_safe tests ===
 
     #[test]
     fn truncate_short_string_unchanged() {
@@ -522,13 +496,12 @@ mod tests {
 
     #[test]
     fn truncate_no_split_multibyte() {
-        // 2-byte UTF-8 chars (é = 0xC3 0xA9)
-        let chars = "é".repeat(130); // 260 bytes
+        // é is 2 bytes (0xC3 0xA9); 130 of them is 260 bytes, exceeding NAME_MAX.
+        let chars = "é".repeat(130);
         let name = format!(".{chars}.XXXXXX");
         let result = truncate_utf8_safe(&name, 255);
         assert!(result.len() <= 255);
         assert!(result.ends_with(".XXXXXX"));
-        // Verify no replacement char
         assert!(!result.contains('\u{FFFD}'));
     }
 }

--- a/crates/transfer/src/transfer_ops/mod.rs
+++ b/crates/transfer/src/transfer_ops/mod.rs
@@ -200,7 +200,7 @@ fn read_response_header<R: Read>(
         ctx.config.want_xattr_optim,
     )?;
 
-    // Protocol requires in-order responses.
+    // upstream: sender.c emits responses in NDX order; out-of-order is a protocol violation.
     if echoed_ndx != expected_ndx {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
@@ -210,7 +210,7 @@ fn read_response_header<R: Read>(
         ));
     }
 
-    // Echoed sum_head provides the existing file length for append mode offset.
+    // The echoed sum_head carries the existing file length used for the append mode offset.
     let echoed_sum_head = SumHead::read(reader)?;
 
     let (file_path, basis_path, signature, target_size) = pending.into_parts();


### PR DESCRIPTION
## Summary

- Sweep restatement, decorative, and outdated comments from the `transfer` crate's top-level sources.
- Preserve every `// upstream:` citation, WHY note (state machine transitions, append-mode offset, fnamecmp inplace logic, etc.), and the existing rustdoc on public items.
- Tighten a handful of test comments that were echoing the assert.

## Scope

The `transfer` crate is large (~51K LoC across 170 files), so this PR caps coverage at the top-level files and submodule entry points. Per-submodule deep dives (generator, receiver, pipeline, disk_commit, setup, ack_batcher, map_file, delta_pipeline) can follow as separate PRs.

Files touched:

- Top level: `constants.rs`, `error.rs`, `flags.rs`, `role.rs`, `failed_directories.rs`, `temp_guard.rs`, `temp_cleanup.rs`, `compressed_writer.rs`, `parallel_io.rs`
- Submodule entry points: `map_file/mod.rs`, `pipeline/mod.rs`, `transfer_ops/mod.rs`

Net: 12 files, -114 lines (42 insertions, 156 deletions). No semantic changes. No new `#[allow(...)]`.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings`
- [ ] CI: fmt+clippy, nextest (stable), Windows, macOS, Linux musl