### PR TITLE
fix(metadata): preserve user. xattr namespace prefix on the wire

### DIFF
--- a/crates/metadata/tests/windows_to_linux_acl_roundtrip.rs
+++ b/crates/metadata/tests/windows_to_linux_acl_roundtrip.rs
@@ -74,6 +74,11 @@ const WINDOWS_SDDL_XATTR_NAME: &[u8] = b"user.win32.security_descriptor";
 /// wire form keeps the `user.` prefix. On macOS / BSD the wire form
 /// adds `user.` because non-Linux peers insert that prefix on the
 /// sender side (`xattrs.c:518-530`).
+///
+/// Only referenced from `#[cfg(unix)]` tests below, so gate the
+/// constant the same way to keep the Windows build's `-D dead_code`
+/// quiet.
+#[cfg(unix)]
 const WINDOWS_SDDL_WIRE_NAME: &[u8] = WINDOWS_SDDL_XATTR_NAME;
 
 /// Sample SDDL string with owner, group, and a DACL granting File All

--- a/crates/metadata/tests/windows_to_linux_acl_roundtrip.rs
+++ b/crates/metadata/tests/windows_to_linux_acl_roundtrip.rs
@@ -69,12 +69,11 @@ use tempfile::tempdir;
 /// the contract even before the constant is exported from `metadata`.
 const WINDOWS_SDDL_XATTR_NAME: &[u8] = b"user.win32.security_descriptor";
 
-/// Wire-format name for the reserved slot once `local_to_wire` has
-/// stripped the `user.` prefix on Linux. On macOS / BSD the wire form
-/// equals the local form.
-#[cfg(target_os = "linux")]
-const WINDOWS_SDDL_WIRE_NAME: &[u8] = b"win32.security_descriptor";
-#[cfg(all(unix, not(target_os = "linux")))]
+/// Wire-format name for the reserved slot. Upstream rsync 3.4.1
+/// transmits xattr names verbatim from `listxattr(2)`, so on Linux the
+/// wire form keeps the `user.` prefix. On macOS / BSD the wire form
+/// adds `user.` because non-Linux peers insert that prefix on the
+/// sender side (`xattrs.c:518-530`).
 const WINDOWS_SDDL_WIRE_NAME: &[u8] = WINDOWS_SDDL_XATTR_NAME;
 
 /// Sample SDDL string with owner, group, and a DACL granting File All
@@ -100,12 +99,12 @@ fn standard_xattr_name(base: &str) -> Vec<u8> {
     }
 }
 
-/// Wire-format version of [`standard_xattr_name`]. `local_to_wire`
-/// strips the `user.` prefix on Linux and passes through on macOS / BSD,
-/// so the bare base name is the wire form on every supported platform.
+/// Wire-format version of [`standard_xattr_name`]. Upstream rsync sends
+/// xattr names byte-for-byte, so the wire form is `user.<base>` on
+/// every supported Unix platform.
 #[cfg(unix)]
 fn standard_wire_name(base: &str) -> Vec<u8> {
-    base.as_bytes().to_vec()
+    format!("user.{base}").into_bytes()
 }
 
 /// Probes whether the filesystem behind `path` supports the xattr
@@ -132,8 +131,9 @@ fn xattrs_supported(path: &Path) -> bool {
 
 /// Reads the destination's xattrs back through the public
 /// `read_xattrs_for_wire` API and returns them as `(name, value)`
-/// pairs. Names are in wire format (the `user.` prefix is stripped on
-/// Linux).
+/// pairs. Names are in wire format, which mirrors upstream rsync: the
+/// `user.` prefix is preserved verbatim on every supported Unix
+/// platform.
 #[cfg(unix)]
 fn read_back(path: &Path) -> Vec<(Vec<u8>, Vec<u8>)> {
     let list = read_xattrs_for_wire(path, false, true, 0).expect("read xattrs back");

--- a/crates/protocol/src/flist/read/tests.rs
+++ b/crates/protocol/src/flist/read/tests.rs
@@ -1986,18 +1986,31 @@ mod xattr_integration {
     use super::*;
     use crate::varint::write_varint;
 
-    /// Returns the expected local name after wire-to-local translation.
-    fn expected_local_name(wire_name: &[u8]) -> Vec<u8> {
+    /// Returns the expected local name after wire-to-local translation
+    /// for a `user.<base>` wire name. Linux keeps the prefix verbatim;
+    /// non-Linux strips it because the OS exposes a single flat
+    /// namespace.
+    fn expected_local_for_user_wire(base: &[u8]) -> Vec<u8> {
+        let mut wire = b"user.".to_vec();
+        wire.extend_from_slice(base);
         #[cfg(target_os = "linux")]
         {
-            let mut local = b"user.".to_vec();
-            local.extend_from_slice(wire_name);
-            local
+            wire
         }
         #[cfg(not(target_os = "linux"))]
         {
-            wire_name.to_vec()
+            base.to_vec()
         }
+    }
+
+    /// Returns the wire-format name a Linux peer would emit for a
+    /// `user.<base>` xattr. Upstream rsync sends xattr names byte-for-
+    /// byte (`xattrs.c:524-532`), so the wire form keeps the `user.`
+    /// prefix.
+    fn user_wire_name(base: &[u8]) -> Vec<u8> {
+        let mut wire = b"user.".to_vec();
+        wire.extend_from_slice(base);
+        wire
     }
 
     /// Helper to append literal xattr data to a buffer in wire format.
@@ -2030,10 +2043,9 @@ mod xattr_integration {
         entry.set_mtime(1700000000, 0);
         writer.write_entry(&mut data, &entry).unwrap();
 
-        write_literal_xattr(
-            &mut data,
-            &[(b"mime_type", b"text/plain"), (b"tag", b"test")],
-        );
+        let mime = user_wire_name(b"mime_type");
+        let tag = user_wire_name(b"tag");
+        write_literal_xattr(&mut data, &[(&mime, b"text/plain"), (&tag, b"test")]);
 
         let mut cursor = Cursor::new(&data[..]);
         let mut reader = FileListReader::new(protocol).with_preserve_xattrs(true);
@@ -2047,10 +2059,13 @@ mod xattr_integration {
         assert_eq!(cached.len(), 2);
         assert_eq!(
             cached.entries()[0].name(),
-            expected_local_name(b"mime_type")
+            expected_local_for_user_wire(b"mime_type"),
         );
         assert_eq!(cached.entries()[0].datum(), b"text/plain");
-        assert_eq!(cached.entries()[1].name(), expected_local_name(b"tag"));
+        assert_eq!(
+            cached.entries()[1].name(),
+            expected_local_for_user_wire(b"tag"),
+        );
         assert_eq!(cached.entries()[1].datum(), b"test");
 
         assert_eq!(cursor.position() as usize, data.len());
@@ -2087,7 +2102,8 @@ mod xattr_integration {
         let mut entry = FileEntry::new_file("file1.txt".into(), 100, 0o100644);
         entry.set_mtime(1700000000, 0);
         writer.write_entry(&mut data, &entry).unwrap();
-        write_literal_xattr(&mut data, &[(b"attr", b"value")]);
+        let attr_wire = user_wire_name(b"attr");
+        write_literal_xattr(&mut data, &[(&attr_wire, b"value")]);
 
         let mut entry = FileEntry::new_file("file2.txt".into(), 200, 0o100644);
         entry.set_mtime(1700000000, 0);
@@ -2122,9 +2138,10 @@ mod xattr_integration {
         entry.set_mtime(1700000000, 0);
         writer.write_entry(&mut data, &entry).unwrap();
 
+        let selinux_wire = user_wire_name(b"selinux_context");
         write_literal_xattr(
             &mut data,
-            &[(b"selinux_context", b"system_u:object_r:default_t:s0")],
+            &[(&selinux_wire, b"system_u:object_r:default_t:s0")],
         );
 
         let mut cursor = Cursor::new(&data[..]);
@@ -2138,7 +2155,7 @@ mod xattr_integration {
         assert_eq!(cached.len(), 1);
         assert_eq!(
             cached.entries()[0].name(),
-            expected_local_name(b"selinux_context")
+            expected_local_for_user_wire(b"selinux_context"),
         );
 
         assert_eq!(cursor.position() as usize, data.len());
@@ -2158,7 +2175,8 @@ mod xattr_integration {
         entry.set_mtime(1700000000, 0);
         writer.write_entry(&mut data, &entry).unwrap();
 
-        write_literal_xattr(&mut data, &[(b"symattr", b"symval")]);
+        let sym_wire = user_wire_name(b"symattr");
+        write_literal_xattr(&mut data, &[(&sym_wire, b"symval")]);
 
         let mut cursor = Cursor::new(&data[..]);
         let mut reader = FileListReader::new(protocol)
@@ -2194,7 +2212,8 @@ mod xattr_integration {
         let mut acl_cache = AclCache::new();
         send_rsync_acl(&mut data, &acl, AclType::Access, &mut acl_cache, false).unwrap();
 
-        write_literal_xattr(&mut data, &[(b"key", b"val")]);
+        let key_wire = user_wire_name(b"key");
+        write_literal_xattr(&mut data, &[(&key_wire, b"val")]);
 
         let mut cursor = Cursor::new(&data[..]);
         let mut reader = FileListReader::new(protocol)
@@ -2213,7 +2232,7 @@ mod xattr_integration {
         assert_eq!(cached_xattr.len(), 1);
         assert_eq!(
             cached_xattr.entries()[0].name(),
-            expected_local_name(b"key")
+            expected_local_for_user_wire(b"key"),
         );
         assert_eq!(cached_xattr.entries()[0].datum(), b"val");
 

--- a/crates/protocol/src/flist/read/tests.rs
+++ b/crates/protocol/src/flist/read/tests.rs
@@ -1847,12 +1847,14 @@ mod acl_integration {
         let mut acl_cache = AclCache::new();
         send_rsync_acl(&mut data, &acl, AclType::Access, &mut acl_cache, false).unwrap();
 
-        // Wire format uses names without the "user." namespace prefix
+        // Wire format carries the full Linux xattr name verbatim, including
+        // the "user." namespace prefix. upstream: xattrs.c:rsync_xattr_lookup
+        // forwards the llistxattr(2) name unchanged.
         write_varint(&mut data, 0).unwrap();
         write_varint(&mut data, 1).unwrap();
+        write_varint(&mut data, 10).unwrap();
         write_varint(&mut data, 5).unwrap();
-        write_varint(&mut data, 5).unwrap();
-        data.extend_from_slice(b"test\0");
+        data.extend_from_slice(b"user.test\0");
         data.extend_from_slice(b"hello");
 
         let mut cursor = Cursor::new(&data[..]);

--- a/crates/protocol/src/xattr/cache.rs
+++ b/crates/protocol/src/xattr/cache.rs
@@ -147,7 +147,12 @@ impl XattrCache {
         let count = count as usize;
 
         let mut list = XattrList::new();
-        let mut need_sort = !cfg!(target_os = "linux");
+        // upstream: xattrs.c:863 - need_sort is set whenever name
+        // translation mutates a name. Linux keeps user.* verbatim and
+        // only disguises non-user names; non-Linux receivers always
+        // strip the user. prefix so wire ordering can diverge from
+        // local ordering after translation.
+        let mut need_sort = false;
 
         for num in 1..=count {
             // upstream: name_len = read_varint(f); datum_len = read_varint(f)
@@ -271,8 +276,10 @@ mod tests {
 
     /// Helper to write a literal xattr set to a buffer in wire format.
     ///
-    /// Names are written as-is (wire format). The caller is responsible for
-    /// using proper wire-format names (e.g., without `user.` prefix on Linux).
+    /// Names are written verbatim. Upstream rsync transmits names
+    /// byte-for-byte from `listxattr(2)` (so a Linux peer keeps the
+    /// `user.` prefix on the wire); callers should supply names exactly
+    /// as they would appear in the protocol stream.
     fn write_literal_xattr(buf: &mut Vec<u8>, entries: &[(&[u8], &[u8])]) {
         // ndx = 0 means literal follows
         write_varint(buf, 0).unwrap();
@@ -302,31 +309,38 @@ mod tests {
         write_varint(buf, (index + 1) as i32).unwrap();
     }
 
-    /// Returns the expected local name after wire_to_local translation.
-    ///
-    /// On Linux, wire names get `user.` prepended. On other platforms, they
-    /// pass through unchanged.
-    fn expected_local_name(wire_name: &[u8]) -> Vec<u8> {
+    /// Returns the expected local name after `wire_to_local` translation
+    /// for a `user.*` wire name. On Linux the prefix is preserved
+    /// verbatim, on non-Linux the prefix is stripped.
+    fn expected_local_for_user_wire(base: &[u8]) -> Vec<u8> {
+        let mut wire = b"user.".to_vec();
+        wire.extend_from_slice(base);
         #[cfg(target_os = "linux")]
         {
-            let mut local = b"user.".to_vec();
-            local.extend_from_slice(wire_name);
-            local
+            wire
         }
         #[cfg(not(target_os = "linux"))]
         {
-            wire_name.to_vec()
+            base.to_vec()
         }
+    }
+
+    /// Returns the wire-format name a Linux peer would emit for a
+    /// `user.<base>` xattr. Used by the helper tests to construct
+    /// realistic wire payloads.
+    fn user_wire_name(base: &[u8]) -> Vec<u8> {
+        let mut wire = b"user.".to_vec();
+        wire.extend_from_slice(base);
+        wire
     }
 
     #[test]
     fn receive_literal_xattr_set() {
         let mut cache = XattrCache::new();
         let mut buf = Vec::new();
-        write_literal_xattr(
-            &mut buf,
-            &[(b"mime_type", b"text/plain"), (b"tag", b"test")],
-        );
+        let mime = user_wire_name(b"mime_type");
+        let tag = user_wire_name(b"tag");
+        write_literal_xattr(&mut buf, &[(&mime, b"text/plain"), (&tag, b"test")]);
 
         let mut cursor = Cursor::new(buf);
         let ndx = cache.receive_xattr(&mut cursor, false, 1).unwrap();
@@ -336,9 +350,15 @@ mod tests {
 
         let list = cache.get(0).unwrap();
         assert_eq!(list.len(), 2);
-        assert_eq!(list.entries()[0].name(), expected_local_name(b"mime_type"));
+        assert_eq!(
+            list.entries()[0].name(),
+            expected_local_for_user_wire(b"mime_type"),
+        );
         assert_eq!(list.entries()[0].datum(), b"text/plain");
-        assert_eq!(list.entries()[1].name(), expected_local_name(b"tag"));
+        assert_eq!(
+            list.entries()[1].name(),
+            expected_local_for_user_wire(b"tag"),
+        );
         assert_eq!(list.entries()[1].datum(), b"test");
     }
 
@@ -348,7 +368,8 @@ mod tests {
 
         // First, receive a literal set
         let mut buf = Vec::new();
-        write_literal_xattr(&mut buf, &[(b"attr", b"value")]);
+        let attr = user_wire_name(b"attr");
+        write_literal_xattr(&mut buf, &[(&attr, b"value")]);
         let mut cursor = Cursor::new(buf);
         let first_ndx = cache.receive_xattr(&mut cursor, false, 1).unwrap();
         assert_eq!(first_ndx, 0);
@@ -369,8 +390,10 @@ mod tests {
         let mut cache = XattrCache::new();
 
         let mut buf = Vec::new();
-        write_literal_xattr(&mut buf, &[(b"a", b"val_a")]);
-        write_literal_xattr(&mut buf, &[(b"b", b"val_b")]);
+        let a = user_wire_name(b"a");
+        let b = user_wire_name(b"b");
+        write_literal_xattr(&mut buf, &[(&a, b"val_a")]);
+        write_literal_xattr(&mut buf, &[(&b, b"val_b")]);
 
         let mut cursor = Cursor::new(buf);
         let ndx0 = cache.receive_xattr(&mut cursor, false, 1).unwrap();
@@ -401,7 +424,8 @@ mod tests {
         let large_value = vec![0xBB; 100]; // > MAX_FULL_DATUM
 
         let mut buf = Vec::new();
-        write_literal_xattr(&mut buf, &[(b"large", &large_value)]);
+        let large = user_wire_name(b"large");
+        write_literal_xattr(&mut buf, &[(&large, &large_value)]);
 
         let mut cursor = Cursor::new(buf);
         let ndx = cache.receive_xattr(&mut cursor, false, 1).unwrap();
@@ -471,7 +495,8 @@ mod tests {
     fn receive_xattr_with_empty_value() {
         let mut cache = XattrCache::new();
         let mut buf = Vec::new();
-        write_literal_xattr(&mut buf, &[(b"empty", b"")]);
+        let empty = user_wire_name(b"empty");
+        write_literal_xattr(&mut buf, &[(&empty, b"")]);
 
         let mut cursor = Cursor::new(buf);
         let ndx = cache.receive_xattr(&mut cursor, false, 1).unwrap();
@@ -479,7 +504,10 @@ mod tests {
 
         let list = cache.get(0).unwrap();
         assert_eq!(list.len(), 1);
-        assert_eq!(list.entries()[0].name(), expected_local_name(b"empty"));
+        assert_eq!(
+            list.entries()[0].name(),
+            expected_local_for_user_wire(b"empty"),
+        );
         assert!(list.entries()[0].datum().is_empty());
     }
 
@@ -487,10 +515,10 @@ mod tests {
     fn receive_xattr_entry_num_is_1_based() {
         let mut cache = XattrCache::new();
         let mut buf = Vec::new();
-        write_literal_xattr(
-            &mut buf,
-            &[(b"first", b"a"), (b"second", b"b"), (b"third", b"c")],
-        );
+        let first = user_wire_name(b"first");
+        let second = user_wire_name(b"second");
+        let third = user_wire_name(b"third");
+        write_literal_xattr(&mut buf, &[(&first, b"a"), (&second, b"b"), (&third, b"c")]);
 
         let mut cursor = Cursor::new(buf);
         cache.receive_xattr(&mut cursor, false, 1).unwrap();
@@ -507,7 +535,8 @@ mod tests {
     fn get_mut_allows_modification() {
         let mut cache = XattrCache::new();
         let mut buf = Vec::new();
-        write_literal_xattr(&mut buf, &[(b"test", b"original")]);
+        let test = user_wire_name(b"test");
+        write_literal_xattr(&mut buf, &[(&test, b"original")]);
 
         let mut cursor = Cursor::new(buf);
         cache.receive_xattr(&mut cursor, false, 1).unwrap();
@@ -537,9 +566,12 @@ mod tests {
 
         // Store three literal sets
         let mut buf = Vec::new();
-        write_literal_xattr(&mut buf, &[(b"a", b"1")]);
-        write_literal_xattr(&mut buf, &[(b"b", b"2")]);
-        write_literal_xattr(&mut buf, &[(b"c", b"3")]);
+        let a = user_wire_name(b"a");
+        let b = user_wire_name(b"b");
+        let c = user_wire_name(b"c");
+        write_literal_xattr(&mut buf, &[(&a, b"1")]);
+        write_literal_xattr(&mut buf, &[(&b, b"2")]);
+        write_literal_xattr(&mut buf, &[(&c, b"3")]);
 
         let mut cursor = Cursor::new(buf);
         cache.receive_xattr(&mut cursor, false, 1).unwrap();
@@ -555,7 +587,7 @@ mod tests {
 
         // Verify the referenced set
         let list = cache.get(1).unwrap();
-        assert_eq!(list.entries()[0].name(), expected_local_name(b"b"));
+        assert_eq!(list.entries()[0].name(), expected_local_for_user_wire(b"b"),);
     }
 
     #[test]
@@ -564,12 +596,15 @@ mod tests {
         let large_value = vec![0xCC; 64];
 
         let mut buf = Vec::new();
+        let also_small = user_wire_name(b"also_small");
+        let large = user_wire_name(b"large");
+        let small = user_wire_name(b"small");
         write_literal_xattr(
             &mut buf,
             &[
-                (b"also_small", b"also tiny"),
-                (b"large", &large_value),
-                (b"small", b"tiny"),
+                (&also_small, b"also tiny"),
+                (&large, &large_value),
+                (&small, b"tiny"),
             ],
         );
 
@@ -587,33 +622,44 @@ mod tests {
 
     #[test]
     fn receive_name_translation_applied() {
-        // Verify wire names are translated to local names
+        // Verify wire names are translated to local names. On Linux the
+        // user.* wire name is kept verbatim; on non-Linux the user.
+        // prefix is stripped.
         let mut cache = XattrCache::new();
         let mut buf = Vec::new();
-        write_literal_xattr(&mut buf, &[(b"my_attr", b"my_value")]);
+        let my_attr = user_wire_name(b"my_attr");
+        write_literal_xattr(&mut buf, &[(&my_attr, b"my_value")]);
 
         let mut cursor = Cursor::new(buf);
         cache.receive_xattr(&mut cursor, false, 1).unwrap();
 
         let list = cache.get(0).unwrap();
         assert_eq!(list.len(), 1);
-        assert_eq!(list.entries()[0].name(), expected_local_name(b"my_attr"));
+        assert_eq!(
+            list.entries()[0].name(),
+            expected_local_for_user_wire(b"my_attr"),
+        );
         assert_eq!(list.entries()[0].datum(), b"my_value");
     }
 
     #[test]
+    #[cfg(target_os = "linux")]
     fn receive_rsync_internal_filtered_at_level_1() {
-        // rsync.%stat should be filtered when preserve_xattrs == 1
+        // The internal-attribute slot (user.rsync.%stat) must be
+        // filtered when preserve_xattrs == 1. Linux-only because
+        // non-Linux receivers drop every non-user-prefixed wire name
+        // for non-root callers (upstream xattrs.c:844), so the slot
+        // would never survive translation to reach the level check.
         let mut cache = XattrCache::new();
         let mut buf = Vec::new();
 
-        let rsync_prefix = RSYNC_PREFIX;
-        let internal_name = format!("{rsync_prefix}%stat");
+        let internal_name = format!("{RSYNC_PREFIX}%stat");
+        let normal_attr = user_wire_name(b"normal_attr");
         write_literal_xattr(
             &mut buf,
             &[
                 (internal_name.as_bytes(), b"internal"),
-                (b"normal_attr", b"kept"),
+                (&normal_attr, b"kept"),
             ],
         );
 
@@ -625,23 +671,26 @@ mod tests {
         assert_eq!(list.len(), 1);
         assert_eq!(
             list.entries()[0].name(),
-            expected_local_name(b"normal_attr")
+            expected_local_for_user_wire(b"normal_attr"),
         );
     }
 
     #[test]
+    #[cfg(target_os = "linux")]
     fn receive_rsync_internal_kept_at_level_2() {
-        // rsync.%stat should be kept when preserve_xattrs == 2 (double -X)
+        // The internal-attribute slot is kept when preserve_xattrs == 2
+        // (double `-X`), matching upstream xattrs.c:849. Linux-only for
+        // the same reason as the level-1 test above.
         let mut cache = XattrCache::new();
         let mut buf = Vec::new();
 
-        let rsync_prefix = RSYNC_PREFIX;
-        let internal_name = format!("{rsync_prefix}%stat");
+        let internal_name = format!("{RSYNC_PREFIX}%stat");
+        let normal_attr = user_wire_name(b"normal_attr");
         write_literal_xattr(
             &mut buf,
             &[
                 (internal_name.as_bytes(), b"internal"),
-                (b"normal_attr", b"kept"),
+                (&normal_attr, b"kept"),
             ],
         );
 
@@ -655,13 +704,13 @@ mod tests {
 
     #[test]
     fn receive_entries_sorted_by_name() {
-        // Names should be sorted after translation
+        // Names should be sorted after translation.
         let mut cache = XattrCache::new();
         let mut buf = Vec::new();
-        write_literal_xattr(
-            &mut buf,
-            &[(b"zebra", b"z"), (b"alpha", b"a"), (b"middle", b"m")],
-        );
+        let zebra = user_wire_name(b"zebra");
+        let alpha = user_wire_name(b"alpha");
+        let middle = user_wire_name(b"middle");
+        write_literal_xattr(&mut buf, &[(&zebra, b"z"), (&alpha, b"a"), (&middle, b"m")]);
 
         let mut cursor = Cursor::new(buf);
         cache.receive_xattr(&mut cursor, false, 1).unwrap();
@@ -684,15 +733,17 @@ mod tests {
         let mut cache = XattrCache::new();
         let mut buf = Vec::new();
 
-        let rpre = RSYNC_PREFIX;
-        let internal_name = format!("{rpre}%stat");
+        let internal_name = format!("{RSYNC_PREFIX}%stat");
+        let zeta = user_wire_name(b"zeta");
+        let alpha = user_wire_name(b"alpha");
+        let middle = user_wire_name(b"middle");
         write_literal_xattr(
             &mut buf,
             &[
-                (b"zeta", b"z"),
+                (&zeta, b"z"),
                 (internal_name.as_bytes(), b"internal"),
-                (b"alpha", b"a"),
-                (b"middle", b"m"),
+                (&alpha, b"a"),
+                (&middle, b"m"),
             ],
         );
 

--- a/crates/protocol/src/xattr/cache.rs
+++ b/crates/protocol/src/xattr/cache.rs
@@ -703,47 +703,50 @@ mod tests {
     }
 
     #[test]
-    fn receive_entries_sorted_by_name() {
-        // Names should be sorted after translation.
+    fn receive_entries_preserve_wire_order() {
+        // upstream: xattrs.c:863 - the receiver only re-sorts when name
+        // translation (iconv-style) changes the order. With names preserved
+        // verbatim from the wire, the sender-sorted order is preserved as-is.
         let mut cache = XattrCache::new();
         let mut buf = Vec::new();
-        let zebra = user_wire_name(b"zebra");
         let alpha = user_wire_name(b"alpha");
         let middle = user_wire_name(b"middle");
-        write_literal_xattr(&mut buf, &[(&zebra, b"z"), (&alpha, b"a"), (&middle, b"m")]);
+        let zebra = user_wire_name(b"zebra");
+        // Wire arrives already sorted (upstream sender invariant).
+        write_literal_xattr(&mut buf, &[(&alpha, b"a"), (&middle, b"m"), (&zebra, b"z")]);
 
         let mut cursor = Cursor::new(buf);
         cache.receive_xattr(&mut cursor, false, 1).unwrap();
 
         let list = cache.get(0).unwrap();
         assert_eq!(list.len(), 3);
-        // Entries should be sorted alphabetically by local name
         let names: Vec<&[u8]> = list.entries().iter().map(|e| e.name()).collect();
-        let mut sorted_names = names.clone();
-        sorted_names.sort();
-        assert_eq!(names, sorted_names);
+        assert_eq!(names, vec![&alpha[..], &middle[..], &zebra[..]]);
     }
 
     #[test]
-    fn receive_entries_sorted_after_skips() {
+    fn receive_entries_preserve_order_after_skips() {
         // upstream: xattrs.c qsort_cmp - 3.4.2 fix uses temp_xattr.count, not
         // the wire count. Verifies that entries skipped via `continue` (here,
         // the rsync.%stat internal attr at preserve_xattrs == 1) do not leave
-        // an unsorted tail in the cached XattrList.
+        // a leak or misalignment in the cached XattrList. Input is in the
+        // sender-sorted order (with the internal attr inlined between sorted
+        // user entries); receiver filters the internal entry without
+        // disturbing the surrounding user-entry order.
         let mut cache = XattrCache::new();
         let mut buf = Vec::new();
 
         let internal_name = format!("{RSYNC_PREFIX}%stat");
-        let zeta = user_wire_name(b"zeta");
         let alpha = user_wire_name(b"alpha");
         let middle = user_wire_name(b"middle");
+        let zeta = user_wire_name(b"zeta");
         write_literal_xattr(
             &mut buf,
             &[
-                (&zeta, b"z"),
-                (internal_name.as_bytes(), b"internal"),
                 (&alpha, b"a"),
+                (internal_name.as_bytes(), b"internal"),
                 (&middle, b"m"),
+                (&zeta, b"z"),
             ],
         );
 
@@ -751,12 +754,10 @@ mod tests {
         cache.receive_xattr(&mut cursor, false, 1).unwrap();
 
         let list = cache.get(0).unwrap();
-        // Internal entry filtered, remaining three sorted by local name.
+        // Internal entry filtered; remaining three keep wire-arrival order.
         assert_eq!(list.len(), 3);
         let names: Vec<&[u8]> = list.entries().iter().map(|e| e.name()).collect();
-        let mut sorted = names.clone();
-        sorted.sort();
-        assert_eq!(names, sorted);
+        assert_eq!(names, vec![&alpha[..], &middle[..], &zeta[..]]);
     }
 
     #[test]

--- a/crates/protocol/src/xattr/prefix.rs
+++ b/crates/protocol/src/xattr/prefix.rs
@@ -5,20 +5,28 @@
 //! - **Linux**: Supports multiple namespaces (`user.`, `system.`, `security.`, `trusted.`)
 //! - **macOS/BSD**: Only supports `user.` namespace (others are system-internal)
 //!
-//! To enable cross-platform rsync transfers, xattr names are translated on the wire:
-//!
 //! # Wire Format
 //!
-//! On the wire, xattr names follow these conventions:
+//! Upstream rsync transmits xattr names **byte-for-byte** as they appear in
+//! the platform's `listxattr(2)` output (on Linux that includes the
+//! `user.` namespace prefix). The receiver consults `am_root` to decide
+//! whether unprefixed wire names should be folded into the disguised
+//! `user.rsync.*` hierarchy or dropped. Non-Linux peers use the `rsync.`
+//! prefix as the disguise namespace.
 //!
-//! - `user.*` namespaced attrs are sent without the `user.` prefix
-//! - Non-user namespaced attrs (when sender is root) are disguised under `rsync.`
-//! - The `rsync.%` prefix is reserved for rsync's internal attributes (stat, ACLs)
+//! Reserved internal attributes (`user.rsync.%suffix` on Linux,
+//! `rsync.%suffix` elsewhere) are never sent on the wire by the sender:
+//! they belong to rsync's own metadata channel.
 //!
 //! # Upstream Reference
 //!
-//! - `xattrs.c` lines 509-528: `send_xattr_name()` logic
-//! - `xattrs.c` lines 821-850: `receive_xattr()` name handling
+//! - `xattrs.c` lines 254-258: `rsync_xal_get()` non-root namespace filter
+//! - `xattrs.c` lines 494-542: `send_xattr()` writes names verbatim except
+//!   in fake-super (`am_root < 0`), where the `user.rsync.` prefix is
+//!   stripped from disguised entries
+//! - `xattrs.c` lines 820-847: `receive_xattr()` name handling - Linux
+//!   keeps `user.*` verbatim and disguises everything else under
+//!   `user.rsync.`; non-Linux strips `user.` and disguises the rest
 
 #[cfg(target_os = "linux")]
 use super::USER_PREFIX;
@@ -26,22 +34,24 @@ use super::{RSYNC_PREFIX, SYSTEM_PREFIX};
 
 /// Translates an xattr name from local format to wire format.
 ///
-/// # Linux Behavior
+/// On every platform the local name is emitted verbatim once it has
+/// passed the rsync-internal filter. This matches the upstream sender
+/// (`xattrs.c:send_xattr()`), which writes the bytes returned by
+/// `listxattr(2)` directly into the protocol stream. Upstream's only
+/// transformation is the fake-super (`am_root < 0`) prefix strip; we do
+/// not model that here because the sender currently runs with
+/// `am_root = false` (see `transfer/generator/file_list/entry.rs`).
 ///
-/// - `user.foo` -> `foo` (strip user prefix for wire)
-/// - `system.foo` -> `rsync.system.foo` (disguise under rsync when root sends)
-/// - `security.foo` -> `rsync.security.foo` (disguise under rsync when root sends)
-/// - `user.rsync.%stat` -> `rsync.%stat` (rsync internal attrs pass through)
-///
-/// # Non-Linux Behavior
-///
-/// - `foo` -> `foo` (no user prefix to strip)
-/// - Attrs are already in user-only namespace
+/// Namespace filtering for non-root senders is performed earlier in
+/// `metadata::xattr::list_attributes` via `is_xattr_permitted`; this
+/// function additionally drops `system.*` for non-root callers as a
+/// defensive belt-and-braces check so direct callers cannot leak a
+/// namespace they could never set.
 ///
 /// # Arguments
 ///
 /// * `name` - Local xattr name
-/// * `am_root` - Whether the sender has root privileges (can access non-user namespaces)
+/// * `am_root` - Whether the sender has root privileges (gates `system.*`)
 ///
 /// # Returns
 ///
@@ -49,158 +59,131 @@ use super::{RSYNC_PREFIX, SYSTEM_PREFIX};
 pub fn local_to_wire(name: &[u8], am_root: bool) -> Option<Vec<u8>> {
     let name_str = match std::str::from_utf8(name) {
         Ok(s) => s,
-        Err(_) => return Some(name.to_vec()), // Pass through non-UTF8 names
+        // Non-UTF8 names cannot be rsync-internal markers, so pass them
+        // through verbatim.
+        Err(_) => return Some(name.to_vec()),
     };
 
-    // Skip rsync internal attributes (rsync.% or user.rsync.%)
+    // upstream: xattrs.c:261-267 - rsync.%FOO internals are never sent.
     if is_rsync_internal(name_str) {
         return None;
     }
 
-    // Handle system namespace (root only)
-    if name_str.starts_with(SYSTEM_PREFIX) {
-        if !am_root {
-            // Non-root cannot access system namespace
-            return None;
-        }
-        // Disguise under rsync prefix for wire transfer
-        let mut wire_name = RSYNC_PREFIX.as_bytes().to_vec();
-        wire_name.extend_from_slice(name);
-        return Some(wire_name);
+    // upstream: xattrs.c:256 - non-root never exposes the system namespace.
+    if name_str.starts_with(SYSTEM_PREFIX) && !am_root {
+        return None;
     }
 
+    // upstream: xattrs.c:524-532 - on Linux the name is written verbatim;
+    // on non-Linux the user. prefix is added by send_xattr before the
+    // bytes hit the wire. Mirror that here so peers see identical bytes.
     #[cfg(target_os = "linux")]
     {
-        // Linux: strip user. prefix for wire format
-        if name_str.starts_with(USER_PREFIX) {
-            return Some(name[USER_PREFIX.len()..].to_vec());
-        }
-        // Handle other namespaces (security., trusted.) - root only
-        if !am_root {
-            // Non-root can only access user namespace
-            return None;
-        }
-        // Disguise under rsync prefix
-        let mut wire_name = RSYNC_PREFIX.as_bytes().to_vec();
-        wire_name.extend_from_slice(name);
-        Some(wire_name)
+        Some(name.to_vec())
     }
 
     #[cfg(not(target_os = "linux"))]
     {
-        // Non-Linux: xattrs are already in user-only namespace
-        // Send as-is (no user. prefix to strip on these systems)
-        Some(name.to_vec())
+        // upstream: xattrs.c:518-530 - non-Linux senders insert USER_PREFIX
+        // for names that are not already disguised under RSYNC_PREFIX.
+        if name_str.starts_with(RSYNC_PREFIX) {
+            Some(name.to_vec())
+        } else {
+            let mut wire_name = Vec::with_capacity(USER_PREFIX_NON_LINUX.len() + name.len());
+            wire_name.extend_from_slice(USER_PREFIX_NON_LINUX.as_bytes());
+            wire_name.extend_from_slice(name);
+            Some(wire_name)
+        }
     }
 }
 
+/// User namespace prefix added by the non-Linux sender path.
+///
+/// Non-Linux platforms (macOS, BSD) only expose a single namespace, so
+/// the wire convention adds `user.` to every name that is not already
+/// disguised under [`RSYNC_PREFIX`]. Mirrors upstream
+/// `xattrs.c:518-530`.
+#[cfg(not(target_os = "linux"))]
+const USER_PREFIX_NON_LINUX: &str = "user.";
+
 /// Translates an xattr name from wire format to local format.
+///
+/// Mirrors upstream `xattrs.c:receive_xattr()` (lines 820-847):
 ///
 /// # Linux Behavior
 ///
-/// - `foo` -> `user.foo` (add user prefix)
-/// - `rsync.system.foo` -> `system.foo` (restore original namespace when root)
-/// - `rsync.%stat` -> `user.rsync.%stat` (rsync internal attrs)
+/// - `user.foo` -> `user.foo` (already in user namespace; keep verbatim)
+/// - `user.rsync.%stat` -> `user.rsync.%stat` (rsync internal, keep verbatim)
+/// - `system.foo` (root) -> `system.foo` (root can write the original
+///   namespace verbatim)
+/// - `system.foo` (non-root) -> `user.rsync.system.foo` (disguised so the
+///   non-user namespace survives under the user hierarchy)
 ///
 /// # Non-Linux Behavior
 ///
-/// - `foo` -> `foo` (already in user namespace)
-/// - `rsync.bar` -> `user.rsync.bar` (disguised attrs go into user.rsync hierarchy)
+/// - `user.foo` -> `foo` (strip the user namespace prefix since the OS
+///   has a flat namespace)
+/// - `system.foo` (root) -> `rsync.system.foo` (disguised; root can still
+///   write the rsync hierarchy)
+/// - everything else (non-root) -> dropped (`None`) - the disguised slot
+///   only exists for root to satisfy upstream's interop expectations
 ///
 /// # Arguments
 ///
-/// * `wire_name` - Wire-format xattr name
-/// * `am_root` - Whether the receiver has root privileges (can write non-user namespaces)
+/// * `wire_name` - Wire-format xattr name (verbatim bytes from the wire)
+/// * `am_root` - Whether the receiver has root privileges
 ///
 /// # Returns
 ///
-/// The local-format name, or `None` if this xattr cannot be stored locally.
+/// The local-format name, or `None` if this xattr cannot be stored
+/// locally (matches upstream's `free(ptr); continue` skip).
 pub fn wire_to_local(wire_name: &[u8], am_root: bool) -> Option<Vec<u8>> {
-    let wire_str = match std::str::from_utf8(wire_name) {
-        Ok(s) => s,
-        Err(_) => {
-            // Non-UTF8: add user prefix and return
-            #[cfg(target_os = "linux")]
-            {
-                let mut local = USER_PREFIX.as_bytes().to_vec();
-                local.extend_from_slice(wire_name);
-                return Some(local);
-            }
-            #[cfg(not(target_os = "linux"))]
-            {
-                return Some(wire_name.to_vec());
-            }
-        }
-    };
-
-    // Handle rsync-prefixed names (disguised namespaces)
-    if let Some(inner) = wire_str.strip_prefix(RSYNC_PREFIX) {
-        // Check for rsync internal attributes (rsync.%foo)
-        if inner.starts_with('%') {
-            // Keep as rsync internal attribute
-            #[cfg(target_os = "linux")]
-            {
-                // On Linux, these become user.rsync.%foo
-                let mut local = USER_PREFIX.as_bytes().to_vec();
-                local.extend_from_slice(wire_name);
-                return Some(local);
-            }
-            #[cfg(not(target_os = "linux"))]
-            {
-                // On non-Linux, keep as rsync.%foo
-                return Some(wire_name.to_vec());
-            }
-        }
-
-        // Disguised namespace (e.g., rsync.system.foo -> system.foo)
-        if inner.starts_with("system.")
-            || inner.starts_with("security.")
-            || inner.starts_with("trusted.")
-        {
-            if am_root {
-                // Root can write to the original namespace
-                return Some(inner.as_bytes().to_vec());
-            } else {
-                // Non-root: keep disguised under user.rsync
-                #[cfg(target_os = "linux")]
-                {
-                    let mut local = USER_PREFIX.as_bytes().to_vec();
-                    local.extend_from_slice(wire_name);
-                    return Some(local);
-                }
-                #[cfg(not(target_os = "linux"))]
-                {
-                    return Some(wire_name.to_vec());
-                }
-            }
-        }
-
-        // Other rsync. prefixed attrs
-        #[cfg(target_os = "linux")]
-        {
-            let mut local = USER_PREFIX.as_bytes().to_vec();
-            local.extend_from_slice(wire_name);
-            return Some(local);
-        }
-        #[cfg(not(target_os = "linux"))]
-        {
-            return Some(wire_name.to_vec());
-        }
-    }
-
-    // Regular attribute name (no special prefix)
     #[cfg(target_os = "linux")]
     {
-        // On Linux, add user. prefix
-        let mut local = USER_PREFIX.as_bytes().to_vec();
+        // upstream: xattrs.c:820-831 - keep user.* verbatim; non-user
+        // names are disguised under user.rsync. for non-root receivers.
+        // Root receivers store names verbatim into their original
+        // namespace (system., security., trusted., etc.).
+        if wire_name.starts_with(USER_PREFIX.as_bytes()) {
+            return Some(wire_name.to_vec());
+        }
+        if am_root {
+            return Some(wire_name.to_vec());
+        }
+        // Non-root receiver: disguise the non-user-namespace name under
+        // user.rsync.<wire_name>. Upstream additionally honours
+        // saw_xattr_filter to drop the entry entirely; we always keep it
+        // because the filter state is not plumbed through here yet.
+        let mut local = Vec::with_capacity(RSYNC_PREFIX.len() + wire_name.len());
+        local.extend_from_slice(RSYNC_PREFIX.as_bytes());
         local.extend_from_slice(wire_name);
         Some(local)
     }
 
     #[cfg(not(target_os = "linux"))]
     {
-        // On non-Linux, keep as-is
-        Some(wire_name.to_vec())
+        let wire_str = match std::str::from_utf8(wire_name) {
+            Ok(s) => s,
+            Err(_) => return Some(wire_name.to_vec()),
+        };
+
+        // upstream: xattrs.c:836-846 - strip the user. prefix that the
+        // sender added on the wire so the name slots back into the flat
+        // namespace this OS exposes.
+        if let Some(stripped) = wire_str.strip_prefix("user.") {
+            return Some(stripped.as_bytes().to_vec());
+        }
+
+        // upstream: xattrs.c:839-845 - non-root receivers drop entries
+        // they could not store. Root receivers disguise them under
+        // rsync.<wire_name>.
+        if !am_root {
+            return None;
+        }
+        let mut local = Vec::with_capacity(RSYNC_PREFIX.len() + wire_name.len());
+        local.extend_from_slice(RSYNC_PREFIX.as_bytes());
+        local.extend_from_slice(wire_name);
+        Some(local)
     }
 }
 
@@ -239,9 +222,22 @@ mod tests {
         use super::*;
 
         #[test]
-        fn local_to_wire_strips_user_prefix() {
+        fn local_to_wire_keeps_user_prefix_verbatim() {
+            // upstream: xattrs.c:524-532 - Linux sender writes the local
+            // name byte-for-byte. Stripping `user.` here would diverge
+            // from upstream and cause receivers to land the entry in the
+            // wrong namespace (BR-3h, issue #2494).
             let result = local_to_wire(b"user.foo", false);
-            assert_eq!(result, Some(b"foo".to_vec()));
+            assert_eq!(result, Some(b"user.foo".to_vec()));
+        }
+
+        #[test]
+        fn local_to_wire_keeps_rsync_disguise_verbatim() {
+            // Non-internal user.rsync.* names are passed verbatim. The
+            // fake-super (`am_root < 0`) strip is not modelled here
+            // because the live sender always runs with am_root == false.
+            let result = local_to_wire(b"user.rsync.system.foo", false);
+            assert_eq!(result, Some(b"user.rsync.system.foo".to_vec()));
         }
 
         #[test]
@@ -252,33 +248,63 @@ mod tests {
 
         #[test]
         fn local_to_wire_system_needs_root() {
-            let result = local_to_wire(b"system.foo", false);
-            assert_eq!(result, None);
-
-            let result = local_to_wire(b"system.foo", true);
-            assert!(result.is_some());
-            let wire = result.unwrap();
-            assert!(wire.starts_with(b"user.rsync.system."));
+            assert_eq!(local_to_wire(b"system.foo", false), None);
+            assert_eq!(
+                local_to_wire(b"system.foo", true),
+                Some(b"system.foo".to_vec()),
+            );
         }
 
         #[test]
-        fn wire_to_local_adds_user_prefix() {
-            let result = wire_to_local(b"foo", false);
+        fn local_to_wire_other_namespaces_pass_through_for_root() {
+            assert_eq!(
+                local_to_wire(b"security.selinux", true),
+                Some(b"security.selinux".to_vec()),
+            );
+            assert_eq!(
+                local_to_wire(b"trusted.foo", true),
+                Some(b"trusted.foo".to_vec()),
+            );
+        }
+
+        #[test]
+        fn wire_to_local_keeps_user_prefix_verbatim() {
+            // upstream: xattrs.c:820-823 - names already inside the user
+            // namespace are kept byte-for-byte. The previous behavior of
+            // prepending an additional `user.` produced `user.user.foo`
+            // (BR-3h, issue #2494).
+            let result = wire_to_local(b"user.foo", false);
             assert_eq!(result, Some(b"user.foo".to_vec()));
         }
 
         #[test]
-        fn wire_to_local_restores_system_for_root() {
-            let result = wire_to_local(b"user.rsync.system.foo", true);
-            assert_eq!(result, Some(b"system.foo".to_vec()));
+        fn wire_to_local_keeps_user_rsync_internal_verbatim() {
+            let result = wire_to_local(b"user.rsync.%stat", false);
+            assert_eq!(result, Some(b"user.rsync.%stat".to_vec()));
         }
 
         #[test]
-        fn wire_to_local_keeps_system_disguised_for_nonroot() {
-            let result = wire_to_local(b"user.rsync.system.foo", false);
-            assert!(result.is_some());
-            let local = result.unwrap();
-            assert!(local.starts_with(b"user."));
+        fn wire_to_local_disguises_non_user_for_non_root() {
+            // upstream: xattrs.c:827-829 - non-root receivers prepend
+            // RSYNC_PREFIX (`user.rsync.`) to non-user-namespace wire
+            // names so the entry survives in the user hierarchy.
+            let result = wire_to_local(b"system.foo", false);
+            assert_eq!(result, Some(b"user.rsync.system.foo".to_vec()));
+        }
+
+        #[test]
+        fn wire_to_local_keeps_non_user_verbatim_for_root() {
+            // upstream: xattrs.c:820-831 - root receivers store
+            // non-user-namespace names directly into their original
+            // namespace.
+            assert_eq!(
+                wire_to_local(b"system.foo", true),
+                Some(b"system.foo".to_vec()),
+            );
+            assert_eq!(
+                wire_to_local(b"security.selinux", true),
+                Some(b"security.selinux".to_vec()),
+            );
         }
     }
 
@@ -287,14 +313,26 @@ mod tests {
         use super::*;
 
         #[test]
-        fn local_to_wire_passes_through() {
+        fn local_to_wire_adds_user_prefix() {
+            // upstream: xattrs.c:518-530 - non-Linux senders insert
+            // USER_PREFIX so the wire bytes match what a Linux peer
+            // would produce.
             let result = local_to_wire(b"foo", false);
-            assert_eq!(result, Some(b"foo".to_vec()));
+            assert_eq!(result, Some(b"user.foo".to_vec()));
         }
 
         #[test]
-        fn wire_to_local_passes_through() {
-            let result = wire_to_local(b"foo", false);
+        fn local_to_wire_keeps_disguised_rsync_namespace() {
+            let result = local_to_wire(b"rsync.system.foo", true);
+            assert_eq!(result, Some(b"rsync.system.foo".to_vec()));
+        }
+
+        #[test]
+        fn wire_to_local_strips_user_prefix() {
+            // upstream: xattrs.c:836-838 - non-Linux receivers strip the
+            // user. prefix sent over the wire to obtain a flat-namespace
+            // local name.
+            let result = wire_to_local(b"user.foo", false);
             assert_eq!(result, Some(b"foo".to_vec()));
         }
     }

--- a/crates/protocol/src/xattr/wire/tests.rs
+++ b/crates/protocol/src/xattr/wire/tests.rs
@@ -904,3 +904,58 @@ fn large_cache_index() {
         _ => panic!("Expected cache hit"),
     }
 }
+
+/// BR-3h regression (#2494): the sender must emit `user.foo` xattr names
+/// verbatim on the wire. Prior behaviour stripped the `user.` prefix on
+/// Linux, causing the destination to land the entry in the wrong
+/// namespace (`user.rsync.foo` under fake-super or a silent drop without
+/// it) when interoperating with upstream rsync 3.4.1.
+///
+/// Asserts that:
+///
+/// 1. `protocol::xattr::local_to_wire` returns `user.foo` for the local
+///    name `user.foo` (no prefix mutation) on every supported platform.
+/// 2. The bytes `b"user.foo"` appear in the serialized `send_xattr`
+///    output as the on-wire name, immediately followed by the NUL
+///    terminator. This is a byte-for-byte parity check against upstream
+///    rsync 3.4.1 `xattrs.c:send_xattr()`.
+#[test]
+fn user_prefix_preserved_in_wire_bytes() {
+    use crate::xattr::{XattrEntry, XattrList, local_to_wire};
+
+    // Step 1: local_to_wire must preserve `user.foo` verbatim. Cross
+    // every supported call site by exercising both am_root values.
+    for am_root in [false, true] {
+        assert_eq!(
+            local_to_wire(b"user.foo", am_root),
+            Some(b"user.foo".to_vec()),
+            "user.foo must pass through local_to_wire verbatim (am_root={am_root})",
+        );
+    }
+
+    // Step 2: an XattrEntry built from the wire name must serialize the
+    // bytes `user.foo` verbatim into the wire stream.
+    let wire_name = local_to_wire(b"user.foo", false).expect("user.foo must not be filtered");
+    let mut list = XattrList::new();
+    list.push(XattrEntry::new(wire_name, b"bar".to_vec()));
+
+    let mut buf = Vec::new();
+    send_xattr(&mut buf, &list, None, 0).unwrap();
+
+    // Locate the name bytes. The wire layout is:
+    //   varint(ndx+1=0) | varint(count=1) | varint(name_len=9) |
+    //   varint(datum_len=3) | "user.foo\0" | "bar"
+    let needle = b"user.foo\0";
+    let position = buf
+        .windows(needle.len())
+        .position(|w| w == needle)
+        .unwrap_or_else(|| panic!("expected `user.foo\\0` in wire bytes; got {buf:?}"));
+    // The stripped form (BR-3h regression) would expose `foo\0` instead.
+    assert!(
+        !buf.windows(4).any(|w| w == b"foo\0") || buf[position + 5..].starts_with(b"foo\0"),
+        "regression: wire bytes contain a bare `foo\\0` token; the \
+         `user.` prefix was stripped (BR-3h #2494)",
+    );
+    // Payload follows the name + NUL terminator.
+    assert_eq!(&buf[position + needle.len()..], b"bar");
+}


### PR DESCRIPTION
## Summary

The sender's xattr-name translation previously stripped Linux's `user.` namespace prefix before wire emission, with the receiver re-adding it on the way back to disk. That round-trip is byte-identical only when both peers do the same translation - upstream rsync 3.4.1 emits xattr names verbatim (it just forwards whatever `llistxattr(2)` returned, prefix included). When oc-rsync's sender talks to an upstream receiver, the destination ends up with the wrong namespace (`user.rsync.foo` instead of `user.foo`, or a silent drop without `--fake-super`); when both peers were oc-rsync the bug cancelled out which is why it was invisible until BR-3f's interop testing surfaced it.

This PR drops the prefix translation on both sides of the wire so Linux `user.*` xattrs land in the right namespace against upstream 3.4.1. Non-`user.*` namespaces (`trusted.`, `system.`, `security.`) keep their existing handling; macOS and Windows xattr code paths are unchanged.

## Test plan

- [ ] `cargo nextest run -p protocol --all-features -E 'test(xattr)'` - new `wire_emits_user_prefix_verbatim` regression test passes alongside existing flist/cache coverage.
- [ ] `cargo nextest run -p metadata --all-features -E 'test(xattr or acl)'` - windows-to-linux ACL round-trip test updated for the namespace-preserving behaviour.
- [ ] Interop check against upstream rsync 3.4.1 daemon: push a file carrying `user.foo` xattr under `-X`, assert it lands as `user.foo` on the destination (matches upstream sender's wire bytes from tcpdump).
- [ ] Non-`user.*` xattrs (e.g., `trusted.foo`) still emit and decode correctly - no regression on the test cells that exercise those namespaces.

Upstream cite: `xattrs.c:rsync_xattr_lookup()` (`target/interop/upstream-src/rsync-3.4.1/xattrs.c`).