### PR TITLE
docs(apple-fs): drop restatement comments from apple_double tests

### DIFF
--- a/crates/apple-fs/src/apple_double.rs
+++ b/crates/apple-fs/src/apple_double.rs
@@ -352,7 +352,6 @@ mod tests {
         container.set_entry(EntryId::ResourceFork, sample_resource_fork()); // id 2
 
         let encoded = container.encode().expect("encode");
-        // First descriptor's id field starts at HEADER_SIZE.
         let first_id = read_u32(&encoded[HEADER_SIZE..HEADER_SIZE + 4]);
         assert_eq!(first_id, EntryId::ResourceFork as u32);
         let second_id = read_u32(
@@ -411,7 +410,6 @@ mod tests {
         bytes[0..4].copy_from_slice(&APPLE_DOUBLE_MAGIC.to_be_bytes());
         bytes[4..8].copy_from_slice(&APPLE_DOUBLE_VERSION_2.to_be_bytes());
         bytes[24..26].copy_from_slice(&1u16.to_be_bytes());
-        // Descriptor: id=9, offset=HEADER_SIZE+ENTRY_DESCRIPTOR_SIZE, length=999.
         bytes[26..30].copy_from_slice(&9u32.to_be_bytes());
         bytes[30..34]
             .copy_from_slice(&((HEADER_SIZE + ENTRY_DESCRIPTOR_SIZE) as u32).to_be_bytes());
@@ -455,7 +453,6 @@ mod tests {
         let mut bytes = vec![0u8; HEADER_SIZE];
         bytes[0..4].copy_from_slice(&APPLE_SINGLE_MAGIC.to_be_bytes());
         bytes[4..8].copy_from_slice(&APPLE_DOUBLE_VERSION_2.to_be_bytes());
-        // zero entries
         let decoded = AppleDouble::decode(&bytes).expect("decode applesingle");
         assert!(decoded.entries.is_empty());
     }


### PR DESCRIPTION
## Summary

- Removed three test-only restatement comments in `crates/apple-fs/src/apple_double.rs` that described slice indexing or byte-layout already self-evident in the assertion expressions below them.
- No semantic changes; the rest of the crate's comment layer (WHY notes on AppleDouble/AppleSingle spec quirks, FinderInfo length invariants, ENOATTR handling, NFD/NFC normalization rationale, RFC 1740 references) is preserved intact.
- Public rustdoc surface already enforced by `#![deny(missing_docs)]`; no additions needed.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings`
- [x] `cargo nextest run -p apple-fs --all-features` (33/33 passed on macOS)