### PR TITLE
docs(signature): drop restatement comments and tighten test annotations

### DIFF
--- a/crates/signature/src/algorithm.rs
+++ b/crates/signature/src/algorithm.rs
@@ -189,7 +189,6 @@ impl SignatureAlgorithm {
                         proper_order: _,
                     },
             } => {
-                // Unseeded MD5: use SIMD batch path
                 let digests = md5_digest_batch(blocks);
                 digests
                     .into_iter()
@@ -197,10 +196,9 @@ impl SignatureAlgorithm {
                     .collect()
             }
             _ => {
-                // Seeded MD4, seeded MD5, SHA1, XXH64, XXH3, XXH3_128:
-                // per-element fallback. Seeded MD4 cannot use the SIMD batch
-                // path because the per-block input includes a 4-byte LE seed
-                // suffix appended after the data (upstream: checksum.c:377-380).
+                // Seeded MD4 cannot use the SIMD batch path because the per-block
+                // input includes a 4-byte LE seed suffix appended after the data.
+                // upstream: checksum.c:377-380.
                 blocks
                     .iter()
                     .map(|data| self.compute_truncated(data, len))
@@ -331,7 +329,6 @@ mod tests {
     fn compute_truncated_longer_than_full() {
         let algo = SignatureAlgorithm::Xxh64 { seed: 42 };
         let data = b"test data";
-        // Requesting more than digest length returns full digest
         let truncated = algo.compute_truncated(data, 16);
         assert_eq!(truncated.len(), 8);
     }
@@ -403,17 +400,14 @@ mod tests {
         reference_buf.extend_from_slice(&seed.to_le_bytes());
         let reference = SignatureAlgorithm::Md4.compute_truncated(&reference_buf, 16);
 
-        // Contiguous path
         let seeded = SignatureAlgorithm::Md4Seeded { seed }.compute_truncated(data, 16);
         assert_eq!(seeded.as_slice(), reference.as_slice());
 
-        // Split-slice path must agree with the contiguous result.
         let (head, tail) = data.split_at(11);
         let seeded_split =
             SignatureAlgorithm::Md4Seeded { seed }.compute_truncated_slices(head, tail, 16);
         assert_eq!(seeded_split.as_slice(), reference.as_slice());
 
-        // Batch path must agree with per-element path.
         let blocks: Vec<&[u8]> = vec![data, b"second block"];
         let batch = SignatureAlgorithm::Md4Seeded { seed }.compute_truncated_batch(&blocks, 16);
         let per_elem: Vec<DigestBuf> = blocks

--- a/crates/signature/src/async_gen.rs
+++ b/crates/signature/src/async_gen.rs
@@ -190,7 +190,7 @@ pub struct AsyncSignatureGenerator {
     next_request_id: u64,
 }
 
-// Manual Debug impl because JoinHandle doesn't implement Debug
+// JoinHandle does not implement Debug, so derive() cannot be used here.
 impl std::fmt::Debug for AsyncSignatureGenerator {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("AsyncSignatureGenerator")
@@ -423,7 +423,6 @@ mod tests {
 
         generator.request_signature(request).unwrap();
 
-        // Wait for result
         let result = generator.wait_for_result().unwrap();
         assert_eq!(result.request_id, 1);
         assert!(result.signature.is_some());
@@ -439,7 +438,6 @@ mod tests {
         let config = AsyncSignatureConfig::default().with_threads(2);
         let mut generator = AsyncSignatureGenerator::new(config);
 
-        // Queue multiple requests
         for (i, file) in files.iter().enumerate() {
             let request = SignatureRequest {
                 request_id: i as u64,
@@ -452,14 +450,13 @@ mod tests {
             generator.request_signature(request).unwrap();
         }
 
-        // Collect results (may arrive in any order with multiple threads)
+        // Results may arrive out of order across threads; sort to verify all five arrived.
         let mut results = Vec::new();
         for _ in 0..5 {
             let result = generator.wait_for_result().unwrap();
             results.push(result);
         }
 
-        // Sort by request_id to check all arrived
         results.sort_by_key(|r| r.request_id);
 
         assert_eq!(results.len(), 5);
@@ -487,7 +484,6 @@ mod tests {
 
         generator.request_signature(request).unwrap();
 
-        // Should get an error result
         let result = generator.wait_for_result().unwrap();
         assert_eq!(result.request_id, 1);
         assert!(result.signature.is_none());
@@ -501,7 +497,6 @@ mod tests {
         let config = AsyncSignatureConfig::default().with_threads(1);
         let generator = AsyncSignatureGenerator::new(config);
 
-        // No requests queued - should return None immediately
         assert!(generator.try_get_result().is_none());
 
         generator.shutdown().unwrap();

--- a/crates/signature/src/block_size.rs
+++ b/crates/signature/src/block_size.rs
@@ -349,7 +349,7 @@ mod tests {
 
     #[test]
     fn small_file_uses_default_block_size() {
-        // Files <= 700² (490,000 bytes) use DEFAULT_BLOCK_SIZE
+        // Files at or below 700² (490,000 bytes) use DEFAULT_BLOCK_SIZE.
         assert_eq!(calculate_block_length(1, 31, None), DEFAULT_BLOCK_SIZE);
         assert_eq!(calculate_block_length(699, 31, None), DEFAULT_BLOCK_SIZE);
         assert_eq!(calculate_block_length(700, 31, None), DEFAULT_BLOCK_SIZE);
@@ -361,38 +361,32 @@ mod tests {
 
     #[test]
     fn medium_files_use_sqrt_scaling() {
-        // File size: 1 MB
+        // 1 MB: sqrt ~ 1024.
         let block_len = calculate_block_length(1024 * 1024, 31, None);
         assert!(block_len > DEFAULT_BLOCK_SIZE);
         assert!(block_len <= MAX_BLOCK_SIZE_V30);
-        // Should be approximately sqrt(1MB) = ~1024
         assert_eq!(block_len, 1024);
 
-        // File size: 10 MB
+        // 10 MB: sqrt ~ 3232.
         let block_len = calculate_block_length(10 * 1024 * 1024, 31, None);
         assert!(block_len > 1024);
         assert!(block_len <= MAX_BLOCK_SIZE_V30);
-        // Should be approximately sqrt(10MB) = ~3232
         assert_eq!(block_len, 3232);
 
-        // File size: 100 MB
+        // 100 MB: sqrt ~ 10240.
         let block_len = calculate_block_length(100 * 1024 * 1024, 31, None);
         assert!(block_len > 3232);
         assert!(block_len <= MAX_BLOCK_SIZE_V30);
-        // Should be approximately sqrt(100MB) = ~10240
         assert_eq!(block_len, 10_240);
     }
 
     #[test]
     fn large_files_capped_at_max_block_size() {
-        // Very large file, protocol 31
         let block_len = calculate_block_length(1u64 << 40, 31, None);
         assert_eq!(block_len, MAX_BLOCK_SIZE_V30);
 
-        // Very large file, protocol 29
         let block_len = calculate_block_length(1u64 << 40, 29, None);
         assert!(block_len <= MAX_BLOCK_SIZE_OLD);
-        // For protocol < 30, max is much larger
         assert!(block_len > MAX_BLOCK_SIZE_V30);
     }
 
@@ -400,14 +394,12 @@ mod tests {
     fn protocol_version_affects_maximum() {
         let file_size = 1u64 << 35; // 32 GB
 
-        // Protocol 30+ caps at 128KB
         let block_len_v30 = calculate_block_length(file_size, 30, None);
         assert_eq!(block_len_v30, MAX_BLOCK_SIZE_V30);
 
         let block_len_v31 = calculate_block_length(file_size, 31, None);
         assert_eq!(block_len_v31, MAX_BLOCK_SIZE_V30);
 
-        // Protocol < 30 allows larger blocks
         let block_len_v29 = calculate_block_length(file_size, 29, None);
         assert!(block_len_v29 > MAX_BLOCK_SIZE_V30);
         assert!(block_len_v29 <= MAX_BLOCK_SIZE_OLD);
@@ -415,18 +407,15 @@ mod tests {
 
     #[test]
     fn user_block_size_override() {
-        // User can override for any file size
         assert_eq!(calculate_block_length(1024, 31, Some(512)), 512);
         assert_eq!(calculate_block_length(1024 * 1024, 31, Some(2048)), 2048);
 
-        // But still capped at protocol maximum
         let oversized = MAX_BLOCK_SIZE_V30 * 2;
         assert_eq!(
             calculate_block_length(1024, 31, Some(oversized)),
             MAX_BLOCK_SIZE_V30
         );
 
-        // Different for old protocol
         let oversized_old = MAX_BLOCK_SIZE_OLD * 2;
         assert_eq!(
             calculate_block_length(1024, 29, Some(oversized_old)),
@@ -436,7 +425,6 @@ mod tests {
 
     #[test]
     fn block_length_is_multiple_of_8() {
-        // The sqrt algorithm rounds to multiples of 8
         for size in [
             500_000u64,
             1_000_000,
@@ -454,15 +442,15 @@ mod tests {
 
     #[test]
     fn very_large_file_edge_cases() {
-        // File size near u64::MAX (sqrt capped at max)
+        // u64::MAX: sqrt clamps to protocol maximum.
         let block_len = calculate_block_length(u64::MAX, 31, None);
         assert_eq!(block_len, MAX_BLOCK_SIZE_V30);
 
-        // 4 GB file: sqrt(4 * 2^30) = sqrt(2^32) = 2^16 = 65536
+        // 4 GB: sqrt(2^32) = 65536.
         let block_len = calculate_block_length(4u64 << 30, 31, None);
         assert_eq!(block_len, 65536);
 
-        // 1 TB file: sqrt(2^40) = 2^20 = 1048576, capped at MAX_BLOCK_SIZE_V30
+        // 1 TB: sqrt(2^40) = 2^20 = 1_048_576, clamped to MAX_BLOCK_SIZE_V30.
         let block_len = calculate_block_length(1u64 << 40, 31, None);
         assert_eq!(block_len, MAX_BLOCK_SIZE_V30);
     }
@@ -495,12 +483,12 @@ mod tests {
 
     #[test]
     fn checksum_length_protocol_versions() {
-        // Protocol < 27 always returns requested length
+        // Protocol < 27 always returns the requested length verbatim.
         assert_eq!(calculate_checksum_length(1024, 700, 26, 8), 8);
         assert_eq!(calculate_checksum_length(1024 * 1024, 700, 26, 2), 2);
         assert_eq!(calculate_checksum_length(1024 * 1024, 700, 26, 16), 16);
 
-        // Protocol >= 27 applies heuristic
+        // Protocol >= 27 applies the bias heuristic.
         let len = calculate_checksum_length(1024 * 1024, 1024, 27, 2);
         assert!((2..=MAX_SUM_LENGTH).contains(&len));
 
@@ -510,7 +498,6 @@ mod tests {
 
     #[test]
     fn checksum_length_max_requested() {
-        // Requesting max length always returns max
         assert_eq!(
             calculate_checksum_length(1024, 700, 31, MAX_SUM_LENGTH),
             MAX_SUM_LENGTH
@@ -523,7 +510,6 @@ mod tests {
 
     #[test]
     fn checksum_length_scales_with_file_size() {
-        // Larger files generally need longer checksums
         let small = calculate_checksum_length(1024, 700, 31, 2);
         let medium = calculate_checksum_length(1024 * 1024, 700, 31, 2);
         let large = calculate_checksum_length(100 * 1024 * 1024, 700, 31, 2);
@@ -536,7 +522,6 @@ mod tests {
 
     #[test]
     fn checksum_length_bounded_by_requested() {
-        // Result should never be less than requested
         for requested in 2..=MAX_SUM_LENGTH {
             let len = calculate_checksum_length(1024 * 1024, 1024, 31, requested);
             assert!(len >= requested);
@@ -546,7 +531,6 @@ mod tests {
 
     #[test]
     fn roundtrip_block_coverage() {
-        // Verify that block_count * block_length covers the file
         let test_sizes = [
             0u64,
             1,
@@ -567,10 +551,9 @@ mod tests {
             if file_size == 0 {
                 assert_eq!(count, 0);
             } else {
-                // Verify coverage
                 let covered = count * u64::from(block_len);
                 assert!(covered >= file_size);
-                // The last block should not be more than block_len away
+                // Last block overshoot must be strictly less than one full block.
                 assert!(covered - file_size < u64::from(block_len));
             }
         }
@@ -587,20 +570,18 @@ mod tests {
 
     #[test]
     fn sum_length_phase1_uses_dynamic_checksum() {
-        // Phase 1 passes SHORT_SUM_LENGTH; the heuristic computes a dynamic
-        // value that may differ from the input for larger files.
+        // Phase 1 passes SHORT_SUM_LENGTH; the heuristic widens the result for
+        // larger files, so a 100 MB file should exceed the minimum of 2.
         let len = calculate_checksum_length(100 * 1024 * 1024, 10_240, 31, SHORT_SUM_LENGTH);
         assert!(len >= SHORT_SUM_LENGTH);
         assert!(len <= MAX_SUM_LENGTH);
-        // For a 100 MB file the heuristic should produce a value above the
-        // minimum SHORT_SUM_LENGTH of 2.
         assert!(len > SHORT_SUM_LENGTH);
     }
 
     #[test]
     fn sum_length_phase2_redo_returns_max_immediately() {
-        // Phase 2 redo passes MAX_SUM_LENGTH; the function short-circuits
-        // and always returns 16 regardless of file or block size.
+        // Phase 2 redo passes MAX_SUM_LENGTH; the function short-circuits and
+        // returns 16 regardless of file or block size.
         for &(file_size, block_len) in &[
             (1024u64, 700u32),
             (1_048_576, 1024),
@@ -617,8 +598,8 @@ mod tests {
 
     #[test]
     fn sum_length_short_vs_max_differ_for_small_files() {
-        // For small files, phase 1 (SHORT_SUM_LENGTH) should produce a shorter
-        // checksum than phase 2 (MAX_SUM_LENGTH), demonstrating the toggle.
+        // For small files the phase toggle is observable: phase 1 emits the
+        // shorter checksum while phase 2 emits the maximum.
         let file_size = 1024u64;
         let block_len = 700u32;
         let phase1 = calculate_checksum_length(file_size, block_len, 31, SHORT_SUM_LENGTH);
@@ -631,19 +612,12 @@ mod tests {
 
     #[test]
     fn specific_upstream_compatibility_values() {
-        // These values should match upstream rsync 3.4.1 exactly
-        // Based on generator.c:sum_sizes_sqroot()
-
-        // 1 MB file with protocol 31
+        // Golden values lifted from upstream rsync 3.4.1
+        // (generator.c:sum_sizes_sqroot) for protocol 31.
         assert_eq!(calculate_block_length(1_048_576, 31, None), 1024);
-
-        // 10 MB file with protocol 31
         assert_eq!(calculate_block_length(10_485_760, 31, None), 3232);
-
-        // 100 MB file with protocol 31
         assert_eq!(calculate_block_length(104_857_600, 31, None), 10_240);
-
-        // 1 GB file: sqrt(2^30) = 2^15 = 32768
+        // 1 GB: sqrt(2^30) = 32768.
         assert_eq!(calculate_block_length(1_073_741_824, 31, None), 32768);
     }
 }

--- a/crates/signature/src/generation.rs
+++ b/crates/signature/src/generation.rs
@@ -285,7 +285,7 @@ mod tests {
             .expect("signature generation succeeds");
 
         assert_eq!(signature.blocks().len(), 1);
-        // SHA1 produces 20 bytes, truncated to 16 by layout
+        // SHA-1 emits 20 bytes; the layout truncates the digest to 16.
         assert_eq!(signature.blocks()[0].strong().len(), 16);
     }
 
@@ -371,7 +371,6 @@ mod tests {
                 "block count mismatch for {num_blocks} blocks"
             );
 
-            // Verify each block's rolling checksum against direct computation
             for (i, block) in signature.blocks().iter().enumerate() {
                 let start = i * block_size as usize;
                 let end = start + block_size as usize;
@@ -394,7 +393,7 @@ mod tests {
     #[test]
     fn batch_with_remainder_all_algorithms() {
         let block_size = 64u32;
-        // 20 full blocks + 37 byte remainder = 1317 bytes total, 21 blocks
+        // 20 full blocks + 37-byte remainder = 1317 bytes total (21 blocks).
         let data_len = (20 * block_size + 37) as usize;
         let mut data = vec![0u8; data_len];
         for (i, byte) in data.iter_mut().enumerate() {
@@ -429,7 +428,6 @@ mod tests {
                 "last block len for {algo:?}"
             );
 
-            // Verify strong checksum of last block matches per-element computation
             let last_start = 20 * block_size as usize;
             let expected_strong = algo.compute_truncated(
                 &data[last_start..],

--- a/crates/signature/src/layout.rs
+++ b/crates/signature/src/layout.rs
@@ -138,10 +138,8 @@ impl SignatureLayout {
         let block_len = u64::from(self.block_length.get());
 
         if self.remainder == 0 {
-            // All blocks are full-size
             self.block_count * block_len
         } else {
-            // Last block is partial (remainder)
             (self.block_count - 1) * block_len + u64::from(self.remainder)
         }
     }
@@ -408,8 +406,8 @@ mod tests {
 
     #[test]
     fn sum_length_derive_strong_phase1_is_dynamic() {
-        // Phase 1 uses SHORT_SUM_LENGTH (2). For a large file the heuristic
-        // should compute a value above the minimum.
+        // Phase 1 (SHORT_SUM_LENGTH = 2): the heuristic widens the result for
+        // large files, exceeding the minimum.
         use crate::block_size::SHORT_SUM_LENGTH;
 
         let checksum_len = NonZeroU8::new(SHORT_SUM_LENGTH).unwrap();
@@ -426,8 +424,8 @@ mod tests {
 
     #[test]
     fn sum_length_derive_strong_phase2_redo_returns_max() {
-        // Phase 2 redo uses SUM_LENGTH (16). The function short-circuits
-        // and returns 16 for any file/block size combination.
+        // Phase 2 redo (SUM_LENGTH = 16) short-circuits and returns 16 for any
+        // file/block-size combination.
         let checksum_len = NonZeroU8::new(SUM_LENGTH).unwrap();
         let protocol = ProtocolVersion::try_from(31u8).unwrap();
 
@@ -447,9 +445,8 @@ mod tests {
 
     #[test]
     fn sum_length_phase_toggle_produces_different_layouts() {
-        // Verify that the same file produces different strong_sum_length
-        // values depending on whether phase 1 or phase 2 checksum length
-        // is requested.
+        // Same file, two checksum requests: block layout is identical, only the
+        // strong checksum length differs.
         use crate::block_size::SHORT_SUM_LENGTH;
 
         let phase1 = calculate_signature_layout(params(1024, None, 31, SHORT_SUM_LENGTH))
@@ -457,12 +454,10 @@ mod tests {
         let phase2 =
             calculate_signature_layout(params(1024, None, 31, SUM_LENGTH)).expect("phase2 layout");
 
-        // Block layout is identical - only checksum length differs
         assert_eq!(phase1.block_length(), phase2.block_length());
         assert_eq!(phase1.block_count(), phase2.block_count());
         assert_eq!(phase1.remainder(), phase2.remainder());
 
-        // Phase 1 gets a shorter checksum, phase 2 gets the maximum
         assert_eq!(phase1.strong_sum_length().get(), SHORT_SUM_LENGTH);
         assert_eq!(phase2.strong_sum_length().get(), SUM_LENGTH);
         assert!(phase1.strong_sum_length() < phase2.strong_sum_length());

--- a/crates/signature/src/parallel.rs
+++ b/crates/signature/src/parallel.rs
@@ -436,9 +436,9 @@ mod tests {
     #[test]
     #[allow(clippy::assertions_on_constants)]
     fn parallel_threshold_constant_is_reasonable() {
-        // Threshold should be at least a few blocks worth
+        // Lower bound: at least a few blocks. Upper bound: still small enough
+        // that realistic transfers exercise the parallel path.
         assert!(PARALLEL_THRESHOLD_BYTES >= 64 * 1024);
-        // But not so large that we never use parallel mode
         assert!(PARALLEL_THRESHOLD_BYTES <= 1024 * 1024);
     }
 }


### PR DESCRIPTION
## Summary
- Remove inline comments that restated test scaffolding or match-arm code in the `signature` crate.
- Tighten the remaining WHY notes (phase-1 vs phase-2 checksum semantics, sqrt block-sizing math) for clarity.
- Preserve upstream rsync cites and protocol-quirk commentary verbatim.

No semantic changes; only comments.

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings`