### PR TITLE
docs(readme): credit zsync for internal matching-engine inspirations

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,5 +386,8 @@ GNU GPL v3.0 or later. See [`LICENSE`](./LICENSE).
 ## Acknowledgements
 
 Inspired by [`rsync`](https://rsync.samba.org/) by Andrew Tridgell and the Samba team.
+
+Internal matching-engine optimisations adapted from [`zsync`](http://zsync.moria.org.uk/) by Colin Phipps (in-memory only; wire format stays pure rsync).
+
 Thanks to **Pieter** for his heroic patience in enduring months of my rsync commentary.
 Thanks to **Elad** for his endless patience hearing rsync protocol commentary as I'm introduced to it.


### PR DESCRIPTION
## Summary

Add an acknowledgement to Colin Phipps's [zsync](http://zsync.moria.org.uk/) in the README. Several in-memory speedups in the matching engine and the receive-side parallel verify scaffolding are adapted from zsync's \`librcksum\`:

- The **bithash pre-filter** (ZSO-1) - 1 bit per slot, 8x oversized, rejects ~7/8 of random rsums in O(1) before the bucket lookup
- The **sequential-match lookahead** (ZSO-2) - \`next_match\` hint after a confirmed match
- **Hash-chain pruning** (ZSO-3) - per-block eviction after \`write_blocks\` succeeds
- **Compact rolling-key encoding** (ZSO-4) - \`rsum_a_mask\` narrows the in-memory key for small-block files

Plus the **parallel-receive verify scaffolding** in \`ParallelDeltaApplier\` (BR-3i / BR-3j) borrows zsync's chunked-dispatch pattern. None of these change anything on the wire - the rsync wire format stays untouched. Per the standing no-wire-protocol-extensions guidance, anything that would require a new capability string or extra wire bytes is out of scope.

## Test plan

- [ ] CI required checks pass (fmt+clippy, nextest stable, Windows, macOS, Linux musl, interop) - docs-only diff.
- [ ] Manual GitHub PR preview confirms the Acknowledgements section renders correctly with the new paragraph.