### PR TITLE
docs(core): drop restatement comments in tests across core

### DIFF
--- a/crates/core/src/auth/mod.rs
+++ b/crates/core/src/auth/mod.rs
@@ -339,8 +339,6 @@ mod tests {
         assert_eq!(digests_for_response(&"A".repeat(len)), MD_LEGACY);
     }
 
-    // Tests for constant_time_eq
-
     #[test]
     fn constant_time_eq_returns_true_for_equal_slices() {
         assert!(constant_time_eq(b"hello", b"hello"));
@@ -364,7 +362,6 @@ mod tests {
 
     #[test]
     fn constant_time_eq_handles_single_byte_difference() {
-        // Test that even a single bit difference is detected
         assert!(!constant_time_eq(b"\x00", b"\x01"));
         assert!(!constant_time_eq(b"\xff", b"\xfe"));
     }
@@ -375,7 +372,6 @@ mod tests {
         let challenge = "mychallenge";
         let correct = compute_daemon_auth_response(secret, challenge, DaemonAuthDigest::Sha256);
 
-        // Tamper with the response
         let mut tampered = correct.clone();
         if let Some(c) = tampered.pop() {
             tampered.push(if c == 'A' { 'B' } else { 'A' });
@@ -400,7 +396,6 @@ mod tests {
     fn verify_rejects_wrong_length_response() {
         let secret = b"secret";
         let challenge = "challenge";
-        // Response length doesn't match any known digest
         assert!(!verify_daemon_auth_response(
             secret, challenge, "tooshort", None
         ));
@@ -419,7 +414,6 @@ mod tests {
         let md5_response = compute_daemon_auth_response(secret, challenge, DaemonAuthDigest::Md5);
         let md4_response = compute_daemon_auth_response(secret, challenge, DaemonAuthDigest::Md4);
 
-        // Protocol >= 30 should accept MD5 and reject MD4
         assert!(verify_daemon_auth_response(
             secret,
             challenge,
@@ -453,7 +447,6 @@ mod tests {
         let md5_response = compute_daemon_auth_response(secret, challenge, DaemonAuthDigest::Md5);
         let md4_response = compute_daemon_auth_response(secret, challenge, DaemonAuthDigest::Md4);
 
-        // Protocol < 30 should accept MD4 and reject MD5
         assert!(verify_daemon_auth_response(
             secret,
             challenge,
@@ -487,7 +480,6 @@ mod tests {
         let md5_response = compute_daemon_auth_response(secret, challenge, DaemonAuthDigest::Md5);
         let md4_response = compute_daemon_auth_response(secret, challenge, DaemonAuthDigest::Md4);
 
-        // Without protocol version, both should be accepted
         assert!(verify_daemon_auth_response(
             secret,
             challenge,

--- a/crates/core/src/client/module_list/errors.rs
+++ b/crates/core/src/client/module_list/errors.rs
@@ -266,7 +266,6 @@ mod tests {
 
     #[test]
     fn legacy_daemon_error_payload_returns_none_for_attached_text() {
-        // If @ERROR is followed by alphanumeric without separator, return None
         let result = legacy_daemon_error_payload("@ERRORsome text");
         assert!(result.is_none());
     }
@@ -294,7 +293,6 @@ mod tests {
     fn read_trimmed_line_trims_multiple_newlines() {
         let mut reader = Cursor::new(b"hello\r\n\r\n");
         let result = read_trimmed_line(&mut reader).expect("read");
-        // First read_line returns "hello\r\n"
         assert_eq!(result.as_deref(), Some("hello"));
     }
 

--- a/crates/core/src/client/remote/invocation/tests.rs
+++ b/crates/core/src/client/remote/invocation/tests.rs
@@ -353,7 +353,6 @@ fn includes_ignore_errors_flag_when_set() {
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
     let args = builder.build("/path");
 
-    // --ignore-errors should appear after --server
     assert!(
         args.iter().any(|a| a == "--ignore-errors"),
         "expected --ignore-errors in args: {args:?}"
@@ -366,7 +365,6 @@ fn omits_ignore_errors_flag_when_not_set() {
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
     let args = builder.build("/path");
 
-    // --ignore-errors should not appear
     assert!(
         !args.iter().any(|a| a == "--ignore-errors"),
         "unexpected --ignore-errors in args: {args:?}"
@@ -379,7 +377,6 @@ fn includes_fsync_flag_when_set() {
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Receiver);
     let args = builder.build("/path");
 
-    // --fsync should appear after --server
     assert!(
         args.iter().any(|a| a == "--fsync"),
         "expected --fsync in args: {args:?}"
@@ -392,7 +389,6 @@ fn omits_fsync_flag_when_not_set() {
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Receiver);
     let args = builder.build("/path");
 
-    // --fsync should not appear
     assert!(
         !args.iter().any(|a| a == "--fsync"),
         "unexpected --fsync in args: {args:?}"
@@ -842,12 +838,10 @@ fn secluded_invocation_disabled_returns_normal_args() {
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
     let secluded = builder.build_secluded(&["/path"]);
 
-    // When secluded-args is not enabled, stdin_args should be empty
     assert!(
         secluded.stdin_args.is_empty(),
         "stdin_args should be empty when protect_args is off"
     );
-    // command_line_args should contain the full invocation
     assert!(
         secluded.command_line_args.iter().any(|a| a == "/path"),
         "command_line_args should contain the remote path"
@@ -860,7 +854,6 @@ fn secluded_invocation_enabled_produces_minimal_command_line() {
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
     let secluded = builder.build_secluded(&["/path/to/files"]);
 
-    // Command line should be minimal
     let cmd_strs: Vec<String> = secluded
         .command_line_args
         .iter()
@@ -872,13 +865,11 @@ fn secluded_invocation_enabled_produces_minimal_command_line() {
     assert!(cmd_strs.contains(&"-s".to_owned()));
     assert!(cmd_strs.contains(&".".to_owned()));
 
-    // Command line should NOT contain the remote path
     assert!(
         !cmd_strs.contains(&"/path/to/files".to_owned()),
         "command line should not contain remote path in secluded mode"
     );
 
-    // stdin_args should contain the full arguments
     assert!(
         !secluded.stdin_args.is_empty(),
         "stdin_args should not be empty when protect_args is on"
@@ -910,7 +901,6 @@ fn secluded_invocation_pull_includes_sender_flag() {
         "secluded invocation should include -s flag"
     );
 
-    // stdin_args should also include --sender
     assert!(
         secluded.stdin_args.iter().any(|a| a == "--sender"),
         "stdin_args should include --sender for pull"
@@ -927,7 +917,6 @@ fn secluded_invocation_stdin_args_contain_flag_string() {
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
     let secluded = builder.build_secluded(&["/data"]);
 
-    // stdin_args should contain the flag string
     let has_flags = secluded
         .stdin_args
         .iter()

--- a/crates/core/src/message/tests/part7.rs
+++ b/crates/core/src/message/tests/part7.rs
@@ -198,7 +198,6 @@ fn normalize_path_handles_windows_drive_with_current() {
 #[test]
 fn normalize_path_preserves_uppercase_drive_letter() {
     let normalized = normalize_path(Path::new(r"c:\users\test\file.txt"));
-    // Drive letters are normalized to uppercase
     assert_eq!(normalized, "C:/users/test/file.txt");
 }
 
@@ -358,10 +357,8 @@ fn canonicalize_or_fallback_returns_original_on_nonexistent() {
 
 #[test]
 fn canonicalize_or_fallback_handles_existing_path() {
-    // Use the manifest directory which we know exists
     let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
     let result = canonicalize_or_fallback(manifest_dir);
-    // The result should be an absolute path
     assert!(result.is_absolute());
 }
 

--- a/crates/core/src/message/tests/part8.rs
+++ b/crates/core/src/message/tests/part8.rs
@@ -365,7 +365,6 @@ fn message_segment_order_matches_upstream() {
         .with_source(message_source!());
     let rendered = msg.to_string();
 
-    // Find positions of each component
     let prefix_pos = rendered.find("rsync error: ").expect("prefix must exist");
     let text_pos = rendered
         .find("delta-transfer failure")
@@ -374,7 +373,6 @@ fn message_segment_order_matches_upstream() {
     let at_pos = rendered.find(" at ").expect("source separator must exist");
     let trailer_pos = rendered.find("[sender=").expect("trailer must exist");
 
-    // Verify ordering: prefix < text < code < source < trailer
     assert!(
         prefix_pos < text_pos,
         "Prefix must come before text"

--- a/crates/core/src/test_utils.rs
+++ b/crates/core/src/test_utils.rs
@@ -134,7 +134,6 @@ mod tests {
     #[test]
     fn assert_error_matches_io_error() {
         let err = io::Error::new(io::ErrorKind::NotFound, "not found");
-        // Using _ pattern to match any io::Error
         assert!(matches!(err.kind(), io::ErrorKind::NotFound));
     }
 

--- a/crates/core/src/timeout/mod.rs
+++ b/crates/core/src/timeout/mod.rs
@@ -324,7 +324,6 @@ mod tests {
     fn connect_timeout_not_started_checks_ok() {
         let config = TimeoutConfig::new().with_connect_timeout(10);
         let tracker = TimeoutTracker::new(config);
-        // Without calling start_connect(), check should always succeed
         assert!(tracker.check_connect_timeout().is_ok());
     }
 

--- a/crates/core/src/version/constants.rs
+++ b/crates/core/src/version/constants.rs
@@ -78,7 +78,6 @@ pub const fn build_revision() -> &'static str {
 mod tests {
     use super::*;
 
-    // Tests for program name constants
     #[test]
     fn program_name_is_not_empty() {
         assert!(!PROGRAM_NAME.is_empty());
@@ -109,7 +108,6 @@ mod tests {
         assert!(!LEGACY_DAEMON_PROGRAM_NAME.is_empty());
     }
 
-    // Tests for copyright constants
     #[test]
     fn copyright_start_year_is_valid() {
         let year: u32 = COPYRIGHT_START_YEAR.parse().expect("valid year");
@@ -139,7 +137,6 @@ mod tests {
         assert!(COPYRIGHT_NOTICE.contains(LATEST_COPYRIGHT_YEAR));
     }
 
-    // Tests for source URL
     #[test]
     fn source_url_is_not_empty() {
         assert!(!SOURCE_URL.is_empty());
@@ -150,13 +147,11 @@ mod tests {
         assert!(SOURCE_URL.starts_with("http://") || SOURCE_URL.starts_with("https://"));
     }
 
-    // Tests for build toolchain
     #[test]
     fn build_toolchain_is_not_empty() {
         assert!(!BUILD_TOOLCHAIN.is_empty());
     }
 
-    // Tests for version constants
     #[test]
     fn upstream_base_version_is_not_empty() {
         assert!(!UPSTREAM_BASE_VERSION.is_empty());
@@ -174,7 +169,6 @@ mod tests {
 
     #[test]
     fn rust_version_is_valid_semver() {
-        // RUST_VERSION should be a valid semantic version (x.y.z)
         let parts: Vec<&str> = RUST_VERSION.split('.').collect();
         assert_eq!(parts.len(), 3, "RUST_VERSION should have three components");
         for part in parts {
@@ -187,7 +181,6 @@ mod tests {
 
     #[test]
     fn upstream_version_is_valid_semver() {
-        // UPSTREAM_BASE_VERSION should be a valid semantic version (x.y.z)
         let parts: Vec<&str> = UPSTREAM_BASE_VERSION.split('.').collect();
         assert_eq!(
             parts.len(),
@@ -202,7 +195,6 @@ mod tests {
         }
     }
 
-    // Tests for protocol version
     #[test]
     fn highest_protocol_version_in_valid_range() {
         assert!(HIGHEST_PROTOCOL_VERSION >= 28);
@@ -214,7 +206,6 @@ mod tests {
         assert_eq!(HIGHEST_PROTOCOL_VERSION, ProtocolVersion::NEWEST.as_u8());
     }
 
-    // Tests for build_revision function
     #[test]
     fn build_revision_returns_non_empty_string() {
         let revision = build_revision();

--- a/crates/core/src/version/metadata.rs
+++ b/crates/core/src/version/metadata.rs
@@ -214,7 +214,6 @@ pub const fn version_metadata_for_program(program_name: &'static str) -> Version
 mod tests {
     use super::*;
 
-    // Tests for version_metadata factory function
     #[test]
     fn version_metadata_returns_valid_metadata() {
         let meta = version_metadata();
@@ -243,7 +242,6 @@ mod tests {
         assert!(!meta.source_url().is_empty());
     }
 
-    // Tests for daemon_version_metadata
     #[test]
     fn daemon_version_metadata_uses_daemon_program_name() {
         let meta = daemon_version_metadata();
@@ -258,21 +256,18 @@ mod tests {
         assert_eq!(client.protocol_version(), daemon.protocol_version());
     }
 
-    // Tests for oc_version_metadata
     #[test]
     fn oc_version_metadata_uses_oc_program_name() {
         let meta = oc_version_metadata();
         assert_eq!(meta.program_name(), OC_PROGRAM_NAME);
     }
 
-    // Tests for oc_daemon_version_metadata
     #[test]
     fn oc_daemon_version_metadata_uses_oc_daemon_program_name() {
         let meta = oc_daemon_version_metadata();
         assert_eq!(meta.program_name(), OC_DAEMON_PROGRAM_NAME);
     }
 
-    // Tests for version_metadata_for_program
     #[test]
     fn version_metadata_for_program_uses_custom_name() {
         let meta = version_metadata_for_program("custom-rsync");
@@ -286,21 +281,18 @@ mod tests {
         assert_eq!(meta.protocol_version(), ProtocolVersion::NEWEST);
     }
 
-    // Tests for version_metadata_for_client_brand
     #[test]
     fn version_metadata_for_client_brand_uses_brand_name() {
         let meta = version_metadata_for_client_brand(Brand::Upstream);
         assert_eq!(meta.program_name(), Brand::Upstream.client_program_name());
     }
 
-    // Tests for version_metadata_for_daemon_brand
     #[test]
     fn version_metadata_for_daemon_brand_uses_brand_name() {
         let meta = version_metadata_for_daemon_brand(Brand::Upstream);
         assert_eq!(meta.program_name(), Brand::Upstream.daemon_program_name());
     }
 
-    // Tests for accessor methods
     #[test]
     fn program_name_accessor_returns_correct_value() {
         let meta = version_metadata();
@@ -331,7 +323,7 @@ mod tests {
     #[test]
     fn subprotocol_version_is_accessible() {
         let meta = version_metadata();
-        let _ = meta.subprotocol_version(); // Just verify it's accessible
+        let _ = meta.subprotocol_version();
     }
 
     #[test]
@@ -341,7 +333,6 @@ mod tests {
         assert!(!meta.build_toolchain().is_empty());
     }
 
-    // Tests for write_standard_banner
     #[test]
     fn write_standard_banner_includes_program_name() {
         let meta = version_metadata();
@@ -409,7 +400,6 @@ mod tests {
         let meta = version_metadata();
         let mut output = String::new();
         meta.write_standard_banner(&mut output).unwrap();
-        // Should contain the arch and OS
         assert!(output.contains(std::env::consts::ARCH));
         assert!(output.contains(std::env::consts::OS));
     }
@@ -422,7 +412,6 @@ mod tests {
         assert!(output.ends_with('\n'));
     }
 
-    // Tests for standard_banner
     #[test]
     fn standard_banner_returns_non_empty_string() {
         let meta = version_metadata();
@@ -439,7 +428,6 @@ mod tests {
         assert_eq!(expected, actual);
     }
 
-    // Tests for Default implementation
     #[test]
     fn default_returns_same_as_version_metadata() {
         let default = VersionMetadata::default();
@@ -447,7 +435,6 @@ mod tests {
         assert_eq!(default, explicit);
     }
 
-    // Tests for trait implementations
     #[test]
     fn version_metadata_is_clone() {
         let meta = version_metadata();

--- a/crates/core/src/version/report/config.rs
+++ b/crates/core/src/version/report/config.rs
@@ -399,7 +399,6 @@ impl Default for VersionInfoConfigBuilder {
 mod tests {
     use super::*;
 
-    // Tests for VersionInfoConfig::new
     #[test]
     fn new_creates_default_config() {
         let config = VersionInfoConfig::new();
@@ -429,7 +428,6 @@ mod tests {
         assert_eq!(config.secluded_args_mode, SecludedArgsMode::Optional);
     }
 
-    // Tests for Default trait
     #[test]
     fn default_equals_new() {
         let default_config = VersionInfoConfig::default();
@@ -437,7 +435,6 @@ mod tests {
         assert_eq!(default_config, new_config);
     }
 
-    // Tests for builder
     #[test]
     fn builder_creates_same_as_new() {
         let builder_config = VersionInfoConfig::builder().build();
@@ -452,7 +449,6 @@ mod tests {
         assert_eq!(default_builder, new_builder);
     }
 
-    // Tests for builder setters
     #[test]
     fn builder_supports_socketpairs() {
         let config = VersionInfoConfig::builder()
@@ -619,7 +615,6 @@ mod tests {
         assert_eq!(config.secluded_args_mode, SecludedArgsMode::Default);
     }
 
-    // Tests for to_builder
     #[test]
     fn to_builder_preserves_values() {
         let original = VersionInfoConfig::builder()
@@ -638,7 +633,6 @@ mod tests {
         assert!(modified.supports_crtimes);
     }
 
-    // Tests for from_config
     #[test]
     fn from_config_preserves_values() {
         let config = VersionInfoConfig::builder()
@@ -648,7 +642,6 @@ mod tests {
         assert_eq!(builder.build(), config);
     }
 
-    // Tests for builder chaining
     #[test]
     fn builder_chaining_works() {
         let config = VersionInfoConfig::builder()
@@ -663,7 +656,6 @@ mod tests {
         assert!(config.supports_asm_md5);
     }
 
-    // Tests for trait implementations
     #[test]
     fn config_is_clone() {
         let config = VersionInfoConfig::new();
@@ -700,11 +692,9 @@ mod tests {
         assert_eq!(builder, copied);
     }
 
-    // Tests for with_runtime_capabilities
     #[test]
     fn with_runtime_capabilities_returns_config() {
         let config = VersionInfoConfig::with_runtime_capabilities();
-        // Basic sanity checks - runtime values vary
         assert!(config.supports_ipv6);
         assert!(config.supports_atimes);
     }

--- a/crates/core/src/version/report/renderer.rs
+++ b/crates/core/src/version/report/renderer.rs
@@ -675,7 +675,6 @@ mod tests {
     fn empty_algorithm_list_shows_none() {
         let report = VersionInfoReport::default().with_checksum_algorithms(Vec::<&str>::new());
         let output = report.human_readable();
-        // When empty, should show "none" under the list
         assert!(output.contains("Checksum list:"));
     }
 

--- a/crates/core/src/version/secluded_args.rs
+++ b/crates/core/src/version/secluded_args.rs
@@ -78,7 +78,6 @@ impl FromStr for SecludedArgsMode {
 mod tests {
     use super::*;
 
-    // Tests for SecludedArgsMode::label
     #[test]
     fn optional_label() {
         assert_eq!(SecludedArgsMode::Optional.label(), "optional secluded-args");
@@ -89,7 +88,6 @@ mod tests {
         assert_eq!(SecludedArgsMode::Default.label(), "default secluded-args");
     }
 
-    // Tests for SecludedArgsMode::from_label
     #[test]
     fn from_label_optional() {
         let result = SecludedArgsMode::from_label("optional secluded-args");
@@ -118,7 +116,6 @@ mod tests {
         assert_eq!(SecludedArgsMode::from_label("default"), None);
     }
 
-    // Tests for Display trait
     #[test]
     fn display_optional() {
         assert_eq!(
@@ -135,7 +132,6 @@ mod tests {
         );
     }
 
-    // Tests for FromStr trait
     #[test]
     fn parse_optional() {
         let result: Result<SecludedArgsMode, _> = "optional secluded-args".parse();
@@ -160,7 +156,6 @@ mod tests {
         assert!(result.is_err());
     }
 
-    // Tests for trait implementations
     #[test]
     fn mode_is_clone() {
         let mode = SecludedArgsMode::Optional;
@@ -186,7 +181,6 @@ mod tests {
         assert_ne!(SecludedArgsMode::Optional, SecludedArgsMode::Default);
     }
 
-    // Tests for ParseSecludedArgsModeError
     #[test]
     fn error_display() {
         let err = "invalid".parse::<SecludedArgsMode>().unwrap_err();
@@ -208,7 +202,6 @@ mod tests {
         assert_eq!(err, copied);
     }
 
-    // Tests for roundtrip
     #[test]
     fn label_roundtrip_optional() {
         let mode = SecludedArgsMode::Optional;


### PR DESCRIPTION
## Summary

Per-crate comment cleanup pass on the `core` crate, following the same precedent as PRs #4591 (protocol), #4590 (transfer), #4589 (fast_io), #4584 (filters), #4582 (logging), #4583 (platform), #4587 (matching), #4575 (compress).

The `core` crate was already in good shape thanks to its `#![deny(missing_docs)]` policy:

- All public types, traits, functions, and re-exports carry rustdoc (verified by the crate-level deny).
- Production code is dominated by upstream cites (`main.c`, `options.c`, `compat.c`, `flist.c`, `rsync.c`, `clientserver.c`, `util1.c`, `log.c`) and WHY notes covering iconv apply hook ordering, INC_RECURSE gating, local-copy progress assumptions, transport-selection rationale, and shell quoting rules - all preserved.
- The `signal/` subtree was excluded from this pass per the BR-10b precedent (PR #4571); its docs are already accurate.

Net change: 69 lines removed, 1 added across 12 files. Removals target:

- Test-section header banners (`// Tests for X`) that simply prefix a group of `#[test]` functions whose names already describe the subject.
- Comments that restate the next line of code or the immediately following assertion message verbatim.
- A handful of stray "comment that says what the variable is" annotations in test helpers.

## Scope coverage

Walked the entire `crates/core/src/` tree except `signal/` (excluded per task scope). No scope cap applied - the crate was already clean enough that the full walk fit comfortably within one PR.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings`
- [ ] CI matrix (fmt+clippy, nextest, Windows, macOS, Linux musl)