### PR TITLE
docs(batch): drop restatement comments in tests and sources

### DIFF
--- a/crates/batch/src/format/tests.rs
+++ b/crates/batch/src/format/tests.rs
@@ -53,7 +53,6 @@ fn test_batch_flags_protocol_29() {
     let restored = BatchFlags::from_bitmap(bitmap, 29);
     assert_eq!(flags, restored);
 
-    // Protocol 28 should not include these flags
     let bitmap_28 = flags.to_bitmap(28);
     let restored_28 = BatchFlags::from_bitmap(bitmap_28, 28);
     assert!(!restored_28.xfer_dirs);
@@ -429,13 +428,11 @@ fn test_batch_header_upstream_byte_layout_protocol_31() {
     let mut buf = Vec::new();
     header.write_to(&mut buf).unwrap();
 
-    // stream_flags bitmap = 0b0000_0011 = 3 as i32 LE
+    // stream_flags bitmap = recurse | preserve_uid = 0b11.
     assert_eq!(&buf[0..4], &3_i32.to_le_bytes());
-    // protocol_version = 31 as i32 LE
     assert_eq!(&buf[4..8], &31_i32.to_le_bytes());
-    // compat_flags = 0x3F as varint (single byte for values < 0x80)
+    // compat_flags = 0x3F as varint (single byte for values < 0x80).
     assert_eq!(buf[8], 0x3F);
-    // checksum_seed = 0x12345678 as i32 LE
     assert_eq!(&buf[9..13], &0x1234_5678_i32.to_le_bytes());
     assert_eq!(buf.len(), 13);
 }
@@ -448,12 +445,9 @@ fn test_batch_header_upstream_byte_layout_protocol_28() {
     let mut buf = Vec::new();
     header.write_to(&mut buf).unwrap();
 
-    // stream_flags bitmap = 0 as i32 LE
     assert_eq!(&buf[0..4], &0_i32.to_le_bytes());
-    // protocol_version = 28 as i32 LE
     assert_eq!(&buf[4..8], &28_i32.to_le_bytes());
-    // No compat_flags for protocol < 30
-    // checksum_seed = 42 as i32 LE
+    // No compat_flags for protocol < 30; checksum_seed follows directly.
     assert_eq!(&buf[8..12], &42_i32.to_le_bytes());
     assert_eq!(buf.len(), 12);
 }
@@ -461,16 +455,12 @@ fn test_batch_header_upstream_byte_layout_protocol_28() {
 /// Verify read_from correctly parses a hand-crafted upstream-format header.
 #[test]
 fn test_batch_header_read_upstream_bytes() {
-    // Build raw bytes matching upstream rsync format:
-    // stream_flags = 0x45 (bits 0,2,6 = recurse + preserve_gid + always_checksum)
-    // protocol_version = 32
-    // compat_flags = 0x0A (varint, single byte)
-    // checksum_seed = 0xAABBCCDD
+    // stream_flags = 0x45 (recurse | preserve_gid | always_checksum)
     let mut raw = Vec::new();
-    raw.extend_from_slice(&0x45_i32.to_le_bytes()); // stream_flags
-    raw.extend_from_slice(&32_i32.to_le_bytes()); // protocol_version
-    raw.push(0x0A); // compat_flags varint
-    raw.extend_from_slice(&0xAABB_CCDD_u32.to_le_bytes()); // checksum_seed
+    raw.extend_from_slice(&0x45_i32.to_le_bytes());
+    raw.extend_from_slice(&32_i32.to_le_bytes());
+    raw.push(0x0A);
+    raw.extend_from_slice(&0xAABB_CCDD_u32.to_le_bytes());
 
     let mut cursor = Cursor::new(raw);
     let header = BatchHeader::read_from(&mut cursor).unwrap();
@@ -495,26 +485,23 @@ fn test_batch_header_upstream_byte_layout_protocol_29() {
     let mut header = BatchHeader::new(29, 0xDEAD);
     header.stream_flags = BatchFlags {
         recurse: true,
-        xfer_dirs: true,      // bit 7 - included for protocol 29
-        do_compression: true, // bit 8 - included for protocol 29
-        preserve_acls: true,  // bit 10 - should be masked out for protocol 29
+        xfer_dirs: true,      // bit 7: included for protocol 29
+        do_compression: true, // bit 8: included for protocol 29
+        preserve_acls: true,  // bit 10: masked out for protocol 29
         ..Default::default()
     };
 
     let mut buf = Vec::new();
     header.write_to(&mut buf).unwrap();
 
-    // stream_flags: bits 0,7,8 set = 0x0000_0181 (acls bit 10 masked by to_bitmap)
+    // bits 0,7,8 set = 0x0000_0181 (acls bit 10 masked by to_bitmap).
     let expected_bitmap = 0x0000_0181_i32;
     assert_eq!(&buf[0..4], &expected_bitmap.to_le_bytes());
-    // protocol_version = 29
     assert_eq!(&buf[4..8], &29_i32.to_le_bytes());
-    // No compat_flags for protocol < 30
-    // checksum_seed = 0xDEAD
+    // No compat_flags for protocol < 30.
     assert_eq!(&buf[8..12], &0xDEAD_i32.to_le_bytes());
     assert_eq!(buf.len(), 12);
 
-    // Verify roundtrip
     let mut cursor = Cursor::new(buf);
     let restored = BatchHeader::read_from(&mut cursor).unwrap();
     assert_eq!(restored.protocol_version, 29);
@@ -553,7 +540,6 @@ fn test_batch_header_all_flags_byte_layout() {
     let mut buf = Vec::new();
     header.write_to(&mut buf).unwrap();
 
-    // All 15 bits set: 0x7FFF
     let expected_bitmap = 0x7FFF_i32;
     assert_eq!(&buf[0..4], &expected_bitmap.to_le_bytes());
 }
@@ -566,21 +552,16 @@ fn test_batch_header_all_flags_byte_layout() {
 #[test]
 fn test_batch_header_multi_byte_compat_flags() {
     let mut header = BatchHeader::new(31, 42);
-    // 0xFF requires 2 varint bytes (high bit set in first byte)
+    // 0xFF requires 2 varint bytes (high bit set in first byte).
     header.compat_flags = Some(0xFF);
     header.stream_flags = BatchFlags::default();
 
     let mut buf = Vec::new();
     header.write_to(&mut buf).unwrap();
 
-    // stream_flags = 0 (4 bytes)
-    // protocol = 31 (4 bytes)
-    // compat_flags = 0xFF as varint (2 bytes for rsync varint encoding)
-    // checksum_seed = 42 (4 bytes)
-    // Total: 4 + 4 + 2 + 4 = 14 bytes
+    // stream_flags(4) + protocol(4) + compat_flags varint(2) + checksum_seed(4) = 14
     assert_eq!(buf.len(), 14);
 
-    // Verify roundtrip
     let mut cursor = Cursor::new(buf);
     let restored = BatchHeader::read_from(&mut cursor).unwrap();
     assert_eq!(restored.compat_flags, Some(0xFF));
@@ -616,7 +597,6 @@ fn test_batch_header_typical_rsync_341_config() {
     assert_eq!(header.checksum_seed, restored.checksum_seed);
     assert_eq!(header.stream_flags, restored.stream_flags);
 
-    // Verify exact byte output
     let mut rewritten = Vec::new();
     restored.write_to(&mut rewritten).unwrap();
     assert_eq!(

--- a/crates/batch/src/reader/delta.rs
+++ b/crates/batch/src/reader/delta.rs
@@ -45,9 +45,9 @@ impl BatchReader {
                 })?;
 
                 match token {
-                    None => break, // End marker (token value 0)
+                    None => break, // end marker (token value 0)
                     Some(n) if n > 0 => {
-                        // Literal data: n bytes follow
+                        // Literal: n bytes follow.
                         let mut data = vec![0u8; n as usize];
                         reader.read_exact(&mut data).map_err(|e| {
                             BatchError::Io(io::Error::new(
@@ -58,11 +58,11 @@ impl BatchReader {
                         ops.push(protocol::wire::DeltaOp::Literal(data));
                     }
                     Some(n) => {
-                        // Block match: block_index = -(n+1)
+                        // Block match: block_index = -(n+1); length resolved at replay time.
                         let block_index = (-(n + 1)) as u32;
                         ops.push(protocol::wire::DeltaOp::Copy {
                             block_index,
-                            length: 0, // Length determined by block size at replay time
+                            length: 0,
                         });
                     }
                 }

--- a/crates/batch/src/reader/tests.rs
+++ b/crates/batch/src/reader/tests.rs
@@ -114,13 +114,12 @@ mod header_tests {
         let config = BatchConfig::new(
             BatchMode::Read,
             batch_path.to_string_lossy().to_string(),
-            28, // Different from the 30 used to write
+            28, // mismatched: batch was written with 30
         );
 
         let mut reader = BatchReader::new(config).unwrap();
         reader.read_header().unwrap();
 
-        // Config should adopt the protocol version from the batch header
         assert_eq!(reader.config().protocol_version, 30);
         assert_eq!(reader.header().unwrap().protocol_version, 30);
     }
@@ -130,7 +129,6 @@ mod header_tests {
         let temp_dir = TempDir::new().unwrap();
         let batch_path = temp_dir.path().join("compat.batch");
 
-        // Write a batch with non-zero compat flags
         let config = BatchConfig::new(
             BatchMode::Write,
             batch_path.to_string_lossy().to_string(),
@@ -142,7 +140,6 @@ mod header_tests {
         writer.write_header(BatchFlags::default()).unwrap();
         writer.finalize().unwrap();
 
-        // Read back with different config values
         let config = BatchConfig::new(
             BatchMode::Read,
             batch_path.to_string_lossy().to_string(),
@@ -151,7 +148,6 @@ mod header_tests {
         let mut reader = BatchReader::new(config).unwrap();
         reader.read_header().unwrap();
 
-        // Config must adopt the compat flags from the batch header
         assert_eq!(reader.config().compat_flags, Some(0x3F));
         assert_eq!(reader.header().unwrap().compat_flags, Some(0x3F));
     }
@@ -161,7 +157,6 @@ mod header_tests {
         let temp_dir = TempDir::new().unwrap();
         let batch_path = temp_dir.path().join("seed.batch");
 
-        // Write a batch with a specific checksum seed
         let config = BatchConfig::new(
             BatchMode::Write,
             batch_path.to_string_lossy().to_string(),
@@ -172,7 +167,6 @@ mod header_tests {
         writer.write_header(BatchFlags::default()).unwrap();
         writer.finalize().unwrap();
 
-        // Read back with default seed (0)
         let config = BatchConfig::new(
             BatchMode::Read,
             batch_path.to_string_lossy().to_string(),
@@ -181,7 +175,6 @@ mod header_tests {
         let mut reader = BatchReader::new(config).unwrap();
         reader.read_header().unwrap();
 
-        // Config must adopt the checksum seed from the batch header
         assert_eq!(reader.config().checksum_seed, 0xDEAD);
         assert_eq!(reader.header().unwrap().checksum_seed, 0xDEAD);
     }
@@ -191,7 +184,7 @@ mod header_tests {
         let temp_dir = TempDir::new().unwrap();
         let batch_path = temp_dir.path().join("old_proto.batch");
 
-        // Write with protocol 28 (no compat flags)
+        // Protocol < 30 has no compat flags.
         let config = BatchConfig::new(
             BatchMode::Write,
             batch_path.to_string_lossy().to_string(),
@@ -202,11 +195,10 @@ mod header_tests {
         writer.write_header(BatchFlags::default()).unwrap();
         writer.finalize().unwrap();
 
-        // Read back - compat_flags should be None for protocol < 30
         let config = BatchConfig::new(
             BatchMode::Read,
             batch_path.to_string_lossy().to_string(),
-            31, // config says 31 but batch says 28
+            31, // mismatched: batch was written with 28
         );
         let mut reader = BatchReader::new(config).unwrap();
         reader.read_header().unwrap();
@@ -310,7 +302,6 @@ mod data_tests {
         let mut reader = BatchReader::new(config).unwrap();
         reader.read_header().unwrap();
 
-        // Try to read more data than available
         let mut buf = [0u8; 1000];
         let result = reader.read_exact(&mut buf);
         assert!(result.is_err());
@@ -342,7 +333,6 @@ mod file_entry_tests {
         let temp_dir = TempDir::new().unwrap();
         let batch_path = temp_dir.path().join("empty.batch");
 
-        // Create a batch with just header, no file entries
         let config = BatchConfig::new(
             BatchMode::Write,
             batch_path.to_string_lossy().to_string(),
@@ -352,7 +342,6 @@ mod file_entry_tests {
         writer.write_header(BatchFlags::default()).unwrap();
         writer.finalize().unwrap();
 
-        // Read it back
         let config = BatchConfig::new(
             BatchMode::Read,
             batch_path.to_string_lossy().to_string(),
@@ -361,7 +350,6 @@ mod file_entry_tests {
         let mut reader = BatchReader::new(config).unwrap();
         reader.read_header().unwrap();
 
-        // Should return None on EOF
         let entry = reader.read_file_entry().unwrap();
         assert!(entry.is_none());
     }
@@ -450,7 +438,6 @@ mod flist_deserialization_tests {
         let batch_path = temp_dir.path().join("flist_basic.batch");
         let protocol_version = 31;
 
-        // Write phase
         let write_config = BatchConfig::new(
             BatchMode::Write,
             batch_path.to_string_lossy().to_string(),
@@ -506,7 +493,7 @@ mod flist_deserialization_tests {
         flist_writer.write_end(&mut end_buf, None).unwrap();
         writer.write_data(&end_buf).unwrap();
 
-        // Write empty uid and gid ID lists (terminator-only).
+        // Empty uid and gid ID lists (terminator-only).
         // upstream: uidlist.c:send_id_lists() sends these after the flist
         // when preserve_uid/gid is set and !inc_recurse.
         let uid_list = protocol::idlist::IdList::new();
@@ -522,7 +509,6 @@ mod flist_deserialization_tests {
 
         writer.finalize().unwrap();
 
-        // Read phase
         let read_config = BatchConfig::new(
             BatchMode::Read,
             batch_path.to_string_lossy().to_string(),
@@ -541,7 +527,6 @@ mod flist_deserialization_tests {
         assert_eq!(read_entries[2].name(), "subdir");
         assert!(read_entries[2].is_dir());
 
-        // io_error should be zero for a clean flist
         assert_eq!(reader.io_error(), 0);
     }
 
@@ -558,7 +543,6 @@ mod flist_deserialization_tests {
         let protocol_version = 31;
         let csum_len = 16; // MD5 digest length
 
-        // Write phase
         let write_config = BatchConfig::new(
             BatchMode::Write,
             batch_path.to_string_lossy().to_string(),
@@ -577,7 +561,7 @@ mod flist_deserialization_tests {
         let protocol = protocol::ProtocolVersion::try_from(protocol_version as u8).unwrap();
         let mut flist_writer = FileListWriter::new(protocol).with_always_checksum(csum_len);
 
-        // Two regular files - each will have a checksum after it on the wire
+        // Two regular files: each carries a trailing checksum on the wire.
         let entries = vec![
             {
                 let mut e = ProtocolFileEntry::new_file("file1.dat".into(), 500, 0o644);
@@ -604,7 +588,7 @@ mod flist_deserialization_tests {
         writer.write_data(&end_buf).unwrap();
         writer.finalize().unwrap();
 
-        // Read phase - the reader must correctly consume checksum bytes
+        // Reader must consume the trailing per-entry checksum bytes.
         let read_config = BatchConfig::new(
             BatchMode::Read,
             batch_path.to_string_lossy().to_string(),
@@ -659,7 +643,6 @@ mod flist_deserialization_tests {
         let protocol = protocol::ProtocolVersion::try_from(protocol_version as u8).unwrap();
         let flist_writer = FileListWriter::new(protocol);
 
-        // Write only the end marker, no entries
         let mut end_buf = Vec::new();
         flist_writer.write_end(&mut end_buf, None).unwrap();
         writer.write_data(&end_buf).unwrap();
@@ -689,7 +672,6 @@ mod token_delta_tests {
         let temp_dir = TempDir::new().unwrap();
         let batch_path = temp_dir.path().join("token_delta.batch");
 
-        // Write a batch with token-format delta data for one file
         let config = BatchConfig::new(
             BatchMode::Write,
             batch_path.to_string_lossy().to_string(),
@@ -700,14 +682,13 @@ mod token_delta_tests {
         let mut writer = BatchWriter::new(config).unwrap();
         writer.write_header(BatchFlags::default()).unwrap();
 
-        // Write token-format delta data: one literal + end marker
+        // Token-format delta: one literal + end marker.
         let mut buf = Vec::new();
         protocol::wire::delta::write_token_literal(&mut buf, b"hello batch world").unwrap();
         protocol::wire::delta::write_token_end(&mut buf).unwrap();
         writer.write_data(&buf).unwrap();
         writer.finalize().unwrap();
 
-        // Read back
         let config = BatchConfig::new(
             BatchMode::Read,
             batch_path.to_string_lossy().to_string(),
@@ -742,13 +723,11 @@ mod token_delta_tests {
         let mut writer = BatchWriter::new(config).unwrap();
         writer.write_header(BatchFlags::default()).unwrap();
 
-        // File 1: literal "AAA" + end
         let mut buf = Vec::new();
         protocol::wire::delta::write_token_literal(&mut buf, b"AAA").unwrap();
         protocol::wire::delta::write_token_end(&mut buf).unwrap();
         writer.write_data(&buf).unwrap();
 
-        // File 2: literal "BBBBB" + block match 0 + end
         let mut buf2 = Vec::new();
         protocol::wire::delta::write_token_literal(&mut buf2, b"BBBBB").unwrap();
         protocol::wire::delta::write_token_block_match(&mut buf2, 0).unwrap();
@@ -757,7 +736,6 @@ mod token_delta_tests {
 
         writer.finalize().unwrap();
 
-        // Read back
         let config = BatchConfig::new(
             BatchMode::Read,
             batch_path.to_string_lossy().to_string(),
@@ -766,12 +744,10 @@ mod token_delta_tests {
         let mut reader = BatchReader::new(config).unwrap();
         reader.read_header().unwrap();
 
-        // File 1
         let ops1 = reader.read_file_delta_tokens().unwrap();
         assert_eq!(ops1.len(), 1);
         assert_eq!(ops1[0], protocol::wire::DeltaOp::Literal(b"AAA".to_vec()));
 
-        // File 2
         let ops2 = reader.read_file_delta_tokens().unwrap();
         assert_eq!(ops2.len(), 2);
         assert_eq!(ops2[0], protocol::wire::DeltaOp::Literal(b"BBBBB".to_vec()));
@@ -817,14 +793,12 @@ mod inc_recurse_flist_tests {
     /// 5. NDX_FLIST_EOF
     fn build_inc_recurse_batch(path: &Path) {
         let protocol = ProtocolVersion::try_from(32u8).unwrap();
-        // INC_RECURSE + VARINT_FLIST_FLAGS + SAFE_FILE_LIST
         let compat_flags = CompatibilityFlags::INC_RECURSE
             | CompatibilityFlags::VARINT_FLIST_FLAGS
             | CompatibilityFlags::SAFE_FILE_LIST;
 
         let mut file = std::fs::File::create(path).unwrap();
 
-        // --- Batch header ---
         let header = crate::format::BatchHeader {
             stream_flags: BatchFlags {
                 recurse: true,
@@ -836,18 +810,18 @@ mod inc_recurse_flist_tests {
         };
         header.write_to(&mut file).unwrap();
 
-        // --- Initial flist segment: "." directory ---
+        // Initial flist segment: "." directory.
         let mut flist_writer = FileListWriter::with_compat_flags(protocol, compat_flags);
         let dot_dir = FileEntry::new_directory(".".into(), 0o755);
         flist_writer.write_entry(&mut file, &dot_dir).unwrap();
         flist_writer.write_end(&mut file, None).unwrap();
 
-        // --- NDX for sub-list: directory index 0 ---
+        // NDX for sub-list: directory index 0.
         let mut ndx_codec = NdxCodecEnum::new(32);
-        let sub_list_ndx = NDX_FLIST_OFFSET; // dir at index 0
+        let sub_list_ndx = NDX_FLIST_OFFSET;
         ndx_codec.write_ndx(&mut file, sub_list_ndx).unwrap();
 
-        // --- Sub-flist segment: entries relative to "." ---
+        // Sub-flist segment: entries relative to ".".
         let mut sub_writer = FileListWriter::with_compat_flags(protocol, compat_flags);
         let entry1 = FileEntry::new_file("file1.txt".into(), 100, 0o644);
         let entry2 = FileEntry::new_file("file2.txt".into(), 200, 0o644);
@@ -855,7 +829,6 @@ mod inc_recurse_flist_tests {
         sub_writer.write_entry(&mut file, &entry2).unwrap();
         sub_writer.write_end(&mut file, None).unwrap();
 
-        // --- NDX_FLIST_EOF ---
         ndx_codec.write_ndx(&mut file, NDX_FLIST_EOF).unwrap();
 
         file.flush().unwrap();
@@ -880,7 +853,6 @@ mod inc_recurse_flist_tests {
         // segment. Sub-lists are read on-demand via read_incremental_flist_segment().
         let mut entries = reader.read_protocol_flist().unwrap();
 
-        // Initial segment has only the "." directory.
         assert_eq!(
             entries.len(),
             1,
@@ -889,18 +861,14 @@ mod inc_recurse_flist_tests {
         );
         assert_eq!(entries[0].name(), ".");
 
-        // NDX codec is available for reading sub-list NDX values.
         let mut ndx_codec = reader.take_ndx_codec().expect("NDX codec should be set");
 
-        // Read the sub-list NDX from the stream.
         let batch_reader = reader.inner_reader().unwrap();
         let ndx = ndx_codec.read_ndx(batch_reader).unwrap();
         assert_eq!(ndx, NDX_FLIST_OFFSET, "Expected NDX_FLIST_OFFSET");
 
-        // Read the sub-list segment.
         reader.read_incremental_flist_segment(&mut entries).unwrap();
 
-        // Now we have all 3 entries.
         assert_eq!(
             entries.len(),
             3,
@@ -908,7 +876,6 @@ mod inc_recurse_flist_tests {
             entries.len()
         );
 
-        // Sub-list entries have parent directory prepended.
         let name1 = entries[1].name();
         let name2 = entries[2].name();
         assert!(
@@ -920,7 +887,6 @@ mod inc_recurse_flist_tests {
             "Expected file2.txt in name, got: {name2}"
         );
 
-        // Read the NDX_FLIST_EOF to confirm stream is fully consumed.
         let batch_reader = reader.inner_reader().unwrap();
         let eof_ndx = ndx_codec.read_ndx(batch_reader).unwrap();
         assert_eq!(eof_ndx, NDX_FLIST_EOF, "Expected NDX_FLIST_EOF");
@@ -942,7 +908,6 @@ mod inc_recurse_flist_tests {
         reader.read_header().unwrap();
         let _entries = reader.read_protocol_flist().unwrap();
 
-        // The NDX codec should be available for the delta replay phase.
         let codec = reader.take_ndx_codec();
         assert!(
             codec.is_some(),
@@ -955,7 +920,6 @@ mod inc_recurse_flist_tests {
         let temp_dir = TempDir::new().unwrap();
         let batch_path = temp_dir.path().join("no_inc_recurse.batch");
 
-        // Build a batch file WITHOUT INC_RECURSE
         let protocol = ProtocolVersion::try_from(32u8).unwrap();
         let compat_flags =
             CompatibilityFlags::VARINT_FLIST_FLAGS | CompatibilityFlags::SAFE_FILE_LIST;
@@ -973,7 +937,6 @@ mod inc_recurse_flist_tests {
         };
         header.write_to(&mut file).unwrap();
 
-        // Write a single flist with all entries (no INC_RECURSE)
         let mut flist_writer = FileListWriter::with_compat_flags(protocol, compat_flags);
         let dir_entry = FileEntry::new_directory(".".into(), 0o755);
         let file1 = FileEntry::new_file("file1.txt".into(), 100, 0o644);
@@ -995,7 +958,6 @@ mod inc_recurse_flist_tests {
         let entries = reader.read_protocol_flist().unwrap();
         assert_eq!(entries.len(), 2);
 
-        // No NDX codec should be stored for non-INC_RECURSE mode.
         let codec = reader.take_ndx_codec();
         assert!(
             codec.is_none(),
@@ -1025,7 +987,6 @@ mod compressed_delta_tests {
         };
         writer.write_header(flags).unwrap();
 
-        // Encode literal data with CompressedTokenEncoder (zlibx mode)
         let mut encoded = Vec::new();
         let mut encoder = CompressedTokenEncoder::default();
         encoder.set_zlibx(true);
@@ -1060,7 +1021,6 @@ mod compressed_delta_tests {
 
         let ops = reader.read_compressed_delta_tokens(&mut decoder).unwrap();
 
-        // Collect all literal data
         let mut reconstructed = Vec::new();
         for op in &ops {
             if let protocol::wire::DeltaOp::Literal(data) = op {
@@ -1093,7 +1053,6 @@ mod compressed_delta_tests {
         };
         writer.write_header(flags).unwrap();
 
-        // Encode: literal + block match + literal + end
         let mut encoded = Vec::new();
         let mut encoder = CompressedTokenEncoder::default();
         encoder.set_zlibx(true);
@@ -1105,7 +1064,6 @@ mod compressed_delta_tests {
         writer.write_data(&encoded).unwrap();
         writer.finalize().unwrap();
 
-        // Read back
         let config = BatchConfig::new(
             BatchMode::Read,
             batch_path.to_string_lossy().to_string(),
@@ -1146,7 +1104,7 @@ mod compressed_delta_tests {
             32,
         );
         let mut reader = BatchReader::new(config).unwrap();
-        // Don't read header
+        // No read_header() call.
         let mut decoder = CompressedTokenDecoder::new();
         let result = reader.read_compressed_delta_tokens(&mut decoder);
         assert!(result.is_err(), "should fail without header");

--- a/crates/batch/src/replay/tests.rs
+++ b/crates/batch/src/replay/tests.rs
@@ -13,7 +13,7 @@ use super::delta::{apply_delta_ops, choose_block_length, write_literals_to_file}
 
 #[test]
 fn choose_block_length_small_file() {
-    // Files smaller than 700^2 = 490_000 bytes get MIN_BLOCK
+    // Files smaller than 700^2 = 490_000 bytes get MIN_BLOCK (700).
     assert_eq!(choose_block_length(0), 700);
     assert_eq!(choose_block_length(1000), 700);
     assert_eq!(choose_block_length(489_999), 700);
@@ -21,13 +21,12 @@ fn choose_block_length_small_file() {
 
 #[test]
 fn choose_block_length_medium_file() {
-    // sqrt(1_000_000) = 1000
     assert_eq!(choose_block_length(1_000_000), 1000);
 }
 
 #[test]
 fn choose_block_length_large_file() {
-    // Files larger than (128*1024)^2 get MAX_BLOCK
+    // Files larger than (128*1024)^2 get MAX_BLOCK.
     let max_block = 128 * 1024;
     let threshold = (max_block as u64) * (max_block as u64);
     assert_eq!(choose_block_length(threshold + 1), max_block);
@@ -54,7 +53,6 @@ fn apply_delta_ops_copy_from_basis() {
     let basis_path = temp.path().join("basis.txt");
     let dest_path = temp.path().join("output.txt");
 
-    // Basis file has exactly one block of 10 bytes at block 0
     fs::write(&basis_path, b"0123456789").unwrap();
 
     let ops = vec![protocol::wire::DeltaOp::Copy {
@@ -73,7 +71,6 @@ fn apply_delta_ops_mixed() {
     let basis_path = temp.path().join("basis.txt");
     let dest_path = temp.path().join("output.txt");
 
-    // Basis has "ABCDE" at block 0 (block_length=5)
     fs::write(&basis_path, b"ABCDE").unwrap();
 
     let ops = vec![
@@ -117,18 +114,19 @@ fn apply_delta_last_block_uses_remainder() {
     fs::write(&basis_path, b"AAAAAAAAAA12345").unwrap();
     let dest_path = temp.path().join("output.dat");
 
-    // Delta: copy block 1 (the last block, 5 bytes remainder), then literal.
+    // Copy block 1 (last block, 5-byte remainder) + literal.
     let ops = vec![
         protocol::wire::DeltaOp::Copy {
             block_index: 1,
-            length: 0, // Token format: length=0 means derive from block_length/remainder
+            // Token format: length=0 means derive from block_length/remainder.
+            length: 0,
         },
         protocol::wire::DeltaOp::Literal(b"END".to_vec()),
     ];
     apply_delta_ops(&basis_path, &dest_path, ops, 10, 2, 5).unwrap();
 
     let result = fs::read(&dest_path).unwrap();
-    // Should copy 5 bytes from block 1 ("12345"), not 10 bytes (which would overread).
+    // Must copy 5 bytes from block 1 ("12345"), not 10 bytes (would overread).
     assert_eq!(result, b"12345END");
 }
 
@@ -186,19 +184,18 @@ fn compressed_decoder_created_for_zstd() {
     );
 }
 
+/// When the detected codec is zlib, dictionary sync (`see_token`)
+/// must be active. Matches upstream CPRES_ZLIB behavior.
 #[test]
 fn cpres_zlib_true_for_zlib_codec() {
-    // When the detected codec is zlib, dictionary sync (see_token)
-    // must be active. This matches upstream CPRES_ZLIB behavior.
     let codec = CompressionCodec::Zlib;
     assert!(Some(codec) == Some(CompressionCodec::Zlib));
 }
 
+/// Zstd's `see_token()` is a noop, so the dictionary-sync path does not apply.
 #[cfg(feature = "zstd")]
 #[test]
 fn cpres_zlib_false_for_zstd_codec() {
-    // When the detected codec is zstd, dictionary sync is unnecessary
-    // because zstd's see_token() is a noop.
     let codec = CompressionCodec::Zstd;
     assert!(Some(codec) != Some(CompressionCodec::Zlib));
 }

--- a/crates/batch/src/script.rs
+++ b/crates/batch/src/script.rs
@@ -181,9 +181,8 @@ fn shell_quote(s: &str) -> String {
     result
 }
 
-/// Find the destination path from the argument list.
+/// Find the destination path from the argument list (last non-option argument).
 fn find_destination(args: &[String]) -> Option<&str> {
-    // The destination is typically the last non-option argument
     args.iter()
         .rev()
         .find(|arg| !arg.starts_with('-') && !arg.is_empty())
@@ -261,7 +260,7 @@ mod tests {
         let script_path = config.script_file_path();
         assert!(Path::new(&script_path).exists());
 
-        // Read and verify script content -- upstream has no shebang
+        // upstream batch shell scripts have no shebang.
         let content = fs::read_to_string(&script_path).unwrap();
         assert!(
             !content.starts_with("#!/bin/sh"),
@@ -375,7 +374,6 @@ mod tests {
             content.contains("--read-batch=mybatch"),
             "Bare --write-batch should be converted to --read-batch=<name>: {content}"
         );
-        // The batch name should not appear as a passthrough argument
         let occurrences = content.matches("mybatch").count();
         assert_eq!(
             occurrences, 1,
@@ -455,7 +453,6 @@ mod tests {
 
         let script_path = config.script_file_path();
         let content = fs::read_to_string(&script_path).unwrap();
-        // Original filter args should be stripped
         assert!(
             !content.contains("*.tmp"),
             "Excluded patterns should be stripped: {content}"

--- a/crates/batch/src/tests.rs
+++ b/crates/batch/src/tests.rs
@@ -15,7 +15,6 @@ mod integration {
         let temp_dir = TempDir::new().unwrap();
         let batch_path = temp_dir.path().join("roundtrip.batch");
 
-        // Write a batch file
         let write_config = BatchConfig::new(
             BatchMode::Write,
             batch_path.to_string_lossy().to_string(),
@@ -38,7 +37,6 @@ mod integration {
         writer.write_data(b"delta operations here").unwrap();
         writer.finalize().unwrap();
 
-        // Read the batch file back
         let read_config = BatchConfig::new(
             BatchMode::Read,
             batch_path.to_string_lossy().to_string(),
@@ -48,10 +46,8 @@ mod integration {
         let mut reader = BatchReader::new(read_config).unwrap();
         let read_flags = reader.read_header().unwrap();
 
-        // Verify flags match
         assert_eq!(flags, read_flags);
 
-        // Verify data can be read back
         let mut buf = vec![0u8; 100];
         let n = reader.read_data(&mut buf).unwrap();
         assert!(n > 0);
@@ -79,7 +75,6 @@ mod integration {
         writer.write_header(flags).unwrap();
         writer.finalize().unwrap();
 
-        // Read back
         let read_config = BatchConfig::new(
             BatchMode::Read,
             batch_path.to_string_lossy().to_string(),
@@ -92,7 +87,6 @@ mod integration {
         assert!(read_flags.recurse);
         assert!(read_flags.preserve_hard_links);
 
-        // Verify compat_flags is None for protocol 28
         assert!(reader.header().unwrap().compat_flags.is_none());
     }
 
@@ -111,7 +105,6 @@ mod integration {
         writer.write_header(BatchFlags::default()).unwrap();
         writer.finalize().unwrap();
 
-        // Read back empty batch
         let read_config = BatchConfig::new(
             BatchMode::Read,
             batch_path.to_string_lossy().to_string(),
@@ -123,7 +116,7 @@ mod integration {
 
         let mut buf = [0u8; 10];
         let n = reader.read_data(&mut buf).unwrap();
-        assert_eq!(n, 0); // EOF
+        assert_eq!(n, 0);
     }
 
     #[test]
@@ -140,12 +133,10 @@ mod integration {
         let mut writer = BatchWriter::new(config).unwrap();
         writer.write_header(BatchFlags::default()).unwrap();
 
-        // Write 1MB of data
         let large_data = vec![0xAB; 1024 * 1024];
         writer.write_data(&large_data).unwrap();
         writer.finalize().unwrap();
 
-        // Read back
         let read_config = BatchConfig::new(
             BatchMode::Read,
             batch_path.to_string_lossy().to_string(),
@@ -236,7 +227,6 @@ mod integration {
 
         writer.write_header(flags).unwrap();
 
-        // Write file entries with varying metadata
         let entries = vec![
             crate::format::FileEntry {
                 path: "src/main.rs".to_owned(),
@@ -280,19 +270,15 @@ mod integration {
         let mut reader = BatchReader::new(read_config).unwrap();
         let read_flags = reader.read_header().unwrap();
 
-        // Verify header fields
         let header = reader.header().unwrap();
         assert_eq!(header.protocol_version, protocol_version);
         assert_eq!(header.checksum_seed, checksum_seed);
         assert_eq!(header.compat_flags, Some(compat_flags_val));
 
-        // Verify the reader adopted the protocol version from the header
         assert_eq!(reader.config().protocol_version, protocol_version);
 
-        // Verify stream flags match exactly
         assert_eq!(read_flags, flags);
 
-        // Verify file entries round-trip correctly
         for expected in &entries {
             let actual = reader
                 .read_file_entry()
@@ -330,7 +316,6 @@ mod integration {
             );
         }
 
-        // No more entries
         let trailing = reader.read_file_entry().unwrap();
         assert!(trailing.is_none(), "expected no more file entries");
     }
@@ -375,7 +360,6 @@ mod integration {
         writer.write_stats(&stats).unwrap();
         writer.finalize().unwrap();
 
-        // -- Read phase --
         let read_config = BatchConfig::new(
             BatchMode::Read,
             batch_path.to_string_lossy().to_string(),
@@ -393,7 +377,6 @@ mod integration {
             "protocol 28 has no compat flags"
         );
 
-        // Protocol-29+ bits should be masked out
         assert!(read_flags.recurse);
         assert!(read_flags.preserve_hard_links);
         assert!(read_flags.always_checksum);
@@ -406,7 +389,6 @@ mod integration {
             "preserve_acls should be masked for protocol 28"
         );
 
-        // Read stats back
         let read_stats = reader.read_stats().unwrap();
         assert_eq!(read_stats.total_read, stats.total_read);
         assert_eq!(read_stats.total_written, stats.total_written);
@@ -420,7 +402,6 @@ mod integration {
         let temp_dir = TempDir::new().unwrap();
         let batch_path = temp_dir.path().join("corrupt.batch");
 
-        // Write a truncated batch file
         fs::write(&batch_path, b"CORRUPT").unwrap();
 
         let config = BatchConfig::new(
@@ -431,7 +412,7 @@ mod integration {
 
         let mut reader = BatchReader::new(config).unwrap();
         let result = reader.read_header();
-        assert!(result.is_err()); // Should fail on corrupt data
+        assert!(result.is_err());
     }
 
     /// Verifies that a batch file containing protocol-format flist entries
@@ -465,7 +446,6 @@ mod integration {
         };
         writer.write_header(flags).unwrap();
 
-        // Encode file entries using the protocol wire format
         let protocol = protocol::ProtocolVersion::try_from(protocol_version as u8).unwrap();
         let mut flist_writer = FileListWriter::new(protocol)
             .with_preserve_uid(true)
@@ -494,12 +474,10 @@ mod integration {
             writer.write_data(&buf).unwrap();
         }
 
-        // Write end-of-list marker
         let mut end_buf = Vec::new();
         flist_writer.write_end(&mut end_buf, None).unwrap();
         writer.write_data(&end_buf).unwrap();
 
-        // Write empty uid and gid ID lists (required by upstream protocol).
         // upstream: uidlist.c:recv_id_list() reads until id=0 terminator.
         // An empty list is a single varint30 zero (one 0x00 byte for proto >= 30).
         use protocol::idlist::IdList;
@@ -542,22 +520,14 @@ mod integration {
     fn test_known_batch_header_format() {
         use std::io::Cursor;
 
-        // Build a batch header in the exact upstream wire format
         let mut data = Vec::new();
 
-        // Stream flags: recurse(bit 0) + preserve_uid(bit 1) = 0x03
+        // stream_flags = recurse(bit 0) + preserve_uid(bit 1) = 0x03
         data.extend_from_slice(&3i32.to_le_bytes());
-
-        // Protocol version: 31
         data.extend_from_slice(&31i32.to_le_bytes());
-
-        // Compat flags (varint): 0 (no special compat flags)
         protocol::write_varint(&mut data, 0).unwrap();
-
-        // Checksum seed: 42
         data.extend_from_slice(&42i32.to_le_bytes());
 
-        // Parse via Cursor
         let mut cursor = Cursor::new(&data);
         let header = crate::format::BatchHeader::read_from(&mut cursor).unwrap();
 
@@ -568,7 +538,6 @@ mod integration {
         assert!(header.stream_flags.preserve_uid);
         assert!(!header.stream_flags.preserve_gid);
 
-        // Verify write_to produces the same bytes
         let mut written = Vec::new();
         header.write_to(&mut written).unwrap();
         assert_eq!(written, data);
@@ -619,7 +588,6 @@ mod integration {
 
         writer.finalize().unwrap();
 
-        // Read back - preserve_specials should be set from preserve_devices
         let read_config = BatchConfig::new(
             BatchMode::Read,
             batch_path.to_string_lossy().to_string(),
@@ -674,7 +642,7 @@ mod integration {
             .with_preserve_uid(true)
             .with_always_checksum(csum_len);
 
-        // Three files with checksums - exercises cross-entry compression state
+        // Exercise cross-entry compression state with three checksummed files.
         let entries = vec![
             {
                 let mut e = FileEntry::new_file("a.txt".into(), 100, 0o644);
@@ -709,7 +677,7 @@ mod integration {
         flist_writer.write_end(&mut end_buf, None).unwrap();
         writer.write_data(&end_buf).unwrap();
 
-        // Write empty uid ID list (preserve_uid is set).
+        // Empty uid ID list (preserve_uid is set).
         // upstream: uidlist.c:recv_id_list() reads until id=0 terminator.
         use protocol::idlist::IdList;
         let mut id_buf = Vec::new();
@@ -720,7 +688,6 @@ mod integration {
 
         writer.finalize().unwrap();
 
-        // Read phase
         let read_config = BatchConfig::new(
             BatchMode::Read,
             batch_path.to_string_lossy().to_string(),
@@ -815,7 +782,6 @@ mod integration {
         };
         writer.write_header(flags).unwrap();
 
-        // Write one directory entry + one regular file entry in flist format
         let protocol = protocol::ProtocolVersion::try_from(protocol_version as u8).unwrap();
         let mut flist_writer = FileListWriter::new(protocol);
 
@@ -838,7 +804,6 @@ mod integration {
         flist_writer.write_entry(&mut buf2, &file_entry).unwrap();
         writer.write_data(&buf2).unwrap();
 
-        // Flist end marker
         let mut end_buf = Vec::new();
         flist_writer.write_end(&mut end_buf, None).unwrap();
         writer.write_data(&end_buf).unwrap();
@@ -851,8 +816,6 @@ mod integration {
 
             let mut ndx_codec = NdxCodecEnum::new(protocol_version as u8);
             let mut ndx_buf = Vec::new();
-
-            // NDX for file entry (index 1 - the file, after the directory at 0)
             ndx_codec.write_ndx(&mut ndx_buf, 1).unwrap();
             writer.write_data(&ndx_buf).unwrap();
 
@@ -946,8 +909,6 @@ mod integration {
         writer.write_data(data1).unwrap();
         writer.write_data(data2).unwrap();
         writer.finalize().unwrap();
-
-        // Read back and verify the compression flag is preserved
         let read_config = BatchConfig::new(
             BatchMode::Read,
             batch_path.to_string_lossy().to_string(),
@@ -1026,22 +987,16 @@ mod integration {
 
         let protocol = protocol::ProtocolVersion::try_from(protocol_version as u8).unwrap();
         let mut flist_writer = FileListWriter::new(protocol);
-
-        // Directory entry
         let mut dir_entry = FileEntry::new_directory(".".into(), 0o755);
         dir_entry.set_mtime(1_700_000_000, 0);
         let mut buf = Vec::new();
         flist_writer.write_entry(&mut buf, &dir_entry).unwrap();
         writer.write_data(&buf).unwrap();
-
-        // File entry with output size
         let mut file_entry = FileEntry::new_file("data.bin".into(), output_size as u64, 0o644);
         file_entry.set_mtime(1_700_000_001, 0);
         buf.clear();
         flist_writer.write_entry(&mut buf, &file_entry).unwrap();
         writer.write_data(&buf).unwrap();
-
-        // End of flist
         let mut end_buf = Vec::new();
         flist_writer.write_end(&mut end_buf, None).unwrap();
         writer.write_data(&end_buf).unwrap();
@@ -1053,8 +1008,6 @@ mod integration {
 
             let mut ndx_codec = NdxCodecEnum::new(protocol_version as u8);
             let mut ndx_buf = Vec::new();
-
-            // NDX for file entry (index 1)
             ndx_codec.write_ndx(&mut ndx_buf, 1).unwrap();
             writer.write_data(&ndx_buf).unwrap();
 
@@ -1101,8 +1054,6 @@ mod integration {
 
             encoder.finish(&mut token_buf).unwrap();
             writer.write_data(&token_buf).unwrap();
-
-            // File checksum (16 zero bytes)
             writer.write_data(&[0u8; 16]).unwrap();
 
             // NDX_DONE for phase 1 -> phase 2
@@ -1117,8 +1068,6 @@ mod integration {
         }
 
         writer.finalize().unwrap();
-
-        // Replay the compressed delta batch
         let read_config = BatchConfig::new(
             BatchMode::Read,
             batch_path.to_string_lossy().to_string(),
@@ -1174,23 +1123,17 @@ mod integration {
 
         let protocol = protocol::ProtocolVersion::try_from(protocol_version as u8).unwrap();
         let mut flist_writer = FileListWriter::new(protocol);
-
-        // Directory entry
         let mut dir_entry = FileEntry::new_directory(".".into(), 0o755);
         dir_entry.set_mtime(1_700_000_000, 0);
         let mut buf = Vec::new();
         flist_writer.write_entry(&mut buf, &dir_entry).unwrap();
         writer.write_data(&buf).unwrap();
-
-        // File entry
         let file_data = b"compressed batch replay test";
         let mut file_entry = FileEntry::new_file("test.txt".into(), file_data.len() as u64, 0o644);
         file_entry.set_mtime(1_700_000_001, 0);
         buf.clear();
         flist_writer.write_entry(&mut buf, &file_entry).unwrap();
         writer.write_data(&buf).unwrap();
-
-        // End of flist
         let mut end_buf = Vec::new();
         flist_writer.write_end(&mut end_buf, None).unwrap();
         writer.write_data(&end_buf).unwrap();
@@ -1203,8 +1146,6 @@ mod integration {
 
             let mut ndx_codec = NdxCodecEnum::new(protocol_version as u8);
             let mut ndx_buf = Vec::new();
-
-            // NDX for file entry (index 1 - the file, after the directory at 0)
             ndx_codec.write_ndx(&mut ndx_buf, 1).unwrap();
             writer.write_data(&ndx_buf).unwrap();
 
@@ -1224,8 +1165,6 @@ mod integration {
             encoder.send_literal(&mut token_buf, file_data).unwrap();
             encoder.finish(&mut token_buf).unwrap();
             writer.write_data(&token_buf).unwrap();
-
-            // File checksum (16 zero bytes, matching s2length=16)
             writer.write_data(&[0u8; 16]).unwrap();
 
             // NDX_DONE for phase 1 -> phase 2 transition
@@ -1240,8 +1179,6 @@ mod integration {
         }
 
         writer.finalize().unwrap();
-
-        // Replay the batch file to destination
         let read_config = BatchConfig::new(
             BatchMode::Read,
             batch_path.to_string_lossy().to_string(),
@@ -1297,15 +1234,11 @@ mod integration {
 
         let protocol = protocol::ProtocolVersion::try_from(protocol_version as u8).unwrap();
         let mut flist_writer = FileListWriter::new(protocol);
-
-        // Directory entry
         let mut dir_entry = FileEntry::new_directory(".".into(), 0o755);
         dir_entry.set_mtime(1_700_000_000, 0);
         let mut buf = Vec::new();
         flist_writer.write_entry(&mut buf, &dir_entry).unwrap();
         writer.write_data(&buf).unwrap();
-
-        // File entry
         let file_data = b"zstd compressed batch replay test data for auto-detection";
         let mut file_entry =
             FileEntry::new_file("zstd_test.txt".into(), file_data.len() as u64, 0o644);
@@ -1313,8 +1246,6 @@ mod integration {
         buf.clear();
         flist_writer.write_entry(&mut buf, &file_entry).unwrap();
         writer.write_data(&buf).unwrap();
-
-        // End of flist
         let mut end_buf = Vec::new();
         flist_writer.write_end(&mut end_buf, None).unwrap();
         writer.write_data(&end_buf).unwrap();
@@ -1325,8 +1256,6 @@ mod integration {
 
             let mut ndx_codec = NdxCodecEnum::new(protocol_version as u8);
             let mut ndx_buf = Vec::new();
-
-            // NDX for file entry (index 1)
             ndx_codec.write_ndx(&mut ndx_buf, 1).unwrap();
             writer.write_data(&ndx_buf).unwrap();
 
@@ -1345,8 +1274,6 @@ mod integration {
             encoder.send_literal(&mut token_buf, file_data).unwrap();
             encoder.finish(&mut token_buf).unwrap();
             writer.write_data(&token_buf).unwrap();
-
-            // File checksum (16 zero bytes)
             writer.write_data(&[0u8; 16]).unwrap();
 
             // NDX_DONE for phase 1 -> phase 2
@@ -1361,8 +1288,6 @@ mod integration {
         }
 
         writer.finalize().unwrap();
-
-        // Replay the zstd-compressed batch file
         let read_config = BatchConfig::new(
             BatchMode::Read,
             batch_path.to_string_lossy().to_string(),
@@ -1421,22 +1346,16 @@ mod integration {
 
         let protocol = protocol::ProtocolVersion::try_from(protocol_version as u8).unwrap();
         let mut flist_writer = FileListWriter::new(protocol);
-
-        // Directory entry
         let mut dir_entry = FileEntry::new_directory(".".into(), 0o755);
         dir_entry.set_mtime(1_700_000_000, 0);
         let mut buf = Vec::new();
         flist_writer.write_entry(&mut buf, &dir_entry).unwrap();
         writer.write_data(&buf).unwrap();
-
-        // File entry with output size
         let mut file_entry = FileEntry::new_file("data.bin".into(), output_size as u64, 0o644);
         file_entry.set_mtime(1_700_000_001, 0);
         buf.clear();
         flist_writer.write_entry(&mut buf, &file_entry).unwrap();
         writer.write_data(&buf).unwrap();
-
-        // End of flist
         let mut end_buf = Vec::new();
         flist_writer.write_end(&mut end_buf, None).unwrap();
         writer.write_data(&end_buf).unwrap();
@@ -1483,8 +1402,6 @@ mod integration {
 
             encoder.finish(&mut token_buf).unwrap();
             writer.write_data(&token_buf).unwrap();
-
-            // File checksum
             writer.write_data(&[0u8; 16]).unwrap();
 
             // NDX_DONE phase 1 -> phase 2
@@ -1499,8 +1416,6 @@ mod integration {
         }
 
         writer.finalize().unwrap();
-
-        // Replay the zstd-compressed delta batch
         let read_config = BatchConfig::new(
             BatchMode::Read,
             batch_path.to_string_lossy().to_string(),
@@ -1564,29 +1479,21 @@ mod integration {
 
         let protocol = protocol::ProtocolVersion::try_from(protocol_version as u8).unwrap();
         let mut flist_writer = FileListWriter::new(protocol);
-
-        // Directory entry
         let mut dir_entry = FileEntry::new_directory(".".into(), 0o755);
         dir_entry.set_mtime(1_700_000_000, 0);
         let mut buf = Vec::new();
         flist_writer.write_entry(&mut buf, &dir_entry).unwrap();
         writer.write_data(&buf).unwrap();
-
-        // File 1 entry
         let mut entry1 = FileEntry::new_file("file1.txt".into(), file1_data.len() as u64, 0o644);
         entry1.set_mtime(1_700_000_001, 0);
         buf.clear();
         flist_writer.write_entry(&mut buf, &entry1).unwrap();
         writer.write_data(&buf).unwrap();
-
-        // File 2 entry
         let mut entry2 = FileEntry::new_file("file2.txt".into(), file2_data.len() as u64, 0o644);
         entry2.set_mtime(1_700_000_002, 0);
         buf.clear();
         flist_writer.write_entry(&mut buf, &entry2).unwrap();
         writer.write_data(&buf).unwrap();
-
-        // End of flist
         let mut end_buf = Vec::new();
         flist_writer.write_end(&mut end_buf, None).unwrap();
         writer.write_data(&end_buf).unwrap();
@@ -1645,8 +1552,6 @@ mod integration {
         }
 
         writer.finalize().unwrap();
-
-        // Replay
         let read_config = BatchConfig::new(
             BatchMode::Read,
             batch_path.to_string_lossy().to_string(),
@@ -1723,29 +1628,21 @@ mod integration {
 
         let protocol = protocol::ProtocolVersion::try_from(protocol_version as u8).unwrap();
         let mut flist_writer = FileListWriter::new(protocol);
-
-        // Directory
         let mut dir_entry = FileEntry::new_directory(".".into(), 0o755);
         dir_entry.set_mtime(1_700_000_000, 0);
         let mut buf = Vec::new();
         flist_writer.write_entry(&mut buf, &dir_entry).unwrap();
         writer.write_data(&buf).unwrap();
-
-        // File 1
         let mut f1 = FileEntry::new_file("alpha.dat".into(), output1_size as u64, 0o644);
         f1.set_mtime(1_700_000_001, 0);
         buf.clear();
         flist_writer.write_entry(&mut buf, &f1).unwrap();
         writer.write_data(&buf).unwrap();
-
-        // File 2
         let mut f2 = FileEntry::new_file("beta.dat".into(), output2_size as u64, 0o644);
         f2.set_mtime(1_700_000_002, 0);
         buf.clear();
         flist_writer.write_entry(&mut buf, &f2).unwrap();
         writer.write_data(&buf).unwrap();
-
-        // End flist
         let mut end_buf = Vec::new();
         flist_writer.write_end(&mut end_buf, None).unwrap();
         writer.write_data(&end_buf).unwrap();
@@ -1830,8 +1727,6 @@ mod integration {
         }
 
         writer.finalize().unwrap();
-
-        // Replay
         let read_config = BatchConfig::new(
             BatchMode::Read,
             batch_path.to_string_lossy().to_string(),
@@ -1909,8 +1804,6 @@ mod integration {
 
         let protocol = protocol::ProtocolVersion::try_from(protocol_version as u8).unwrap();
         let mut flist_writer = FileListWriter::new(protocol);
-
-        // Directory
         let mut dir_entry = FileEntry::new_directory(".".into(), 0o755);
         dir_entry.set_mtime(1_700_000_000, 0);
         let mut buf = Vec::new();
@@ -1930,8 +1823,6 @@ mod integration {
         buf.clear();
         flist_writer.write_entry(&mut buf, &f_new).unwrap();
         writer.write_data(&buf).unwrap();
-
-        // End flist
         let mut end_buf = Vec::new();
         flist_writer.write_end(&mut end_buf, None).unwrap();
         writer.write_data(&end_buf).unwrap();
@@ -2004,8 +1895,6 @@ mod integration {
         }
 
         writer.finalize().unwrap();
-
-        // Replay
         let read_config = BatchConfig::new(
             BatchMode::Read,
             batch_path.to_string_lossy().to_string(),
@@ -2081,8 +1970,6 @@ mod integration {
 
         let protocol = protocol::ProtocolVersion::try_from(protocol_version as u8).unwrap();
         let mut flist_writer = FileListWriter::new(protocol);
-
-        // Directory entry
         let mut dir_entry = FileEntry::new_directory(".".into(), 0o755);
         dir_entry.set_mtime(1_700_000_000, 0);
         let mut buf = Vec::new();
@@ -2096,8 +1983,6 @@ mod integration {
         buf.clear();
         flist_writer.write_entry(&mut buf, &file_entry).unwrap();
         writer.write_data(&buf).unwrap();
-
-        // End of flist
         let mut end_buf = Vec::new();
         flist_writer.write_end(&mut end_buf, None).unwrap();
         writer.write_data(&end_buf).unwrap();
@@ -2129,8 +2014,6 @@ mod integration {
             encoder.send_literal(&mut token_buf, file_data).unwrap();
             encoder.finish(&mut token_buf).unwrap();
             writer.write_data(&token_buf).unwrap();
-
-            // File checksum (16 zero bytes)
             writer.write_data(&[0u8; 16]).unwrap();
 
             // NDX_DONE phase 1 -> phase 2

--- a/crates/batch/src/writer.rs
+++ b/crates/batch/src/writer.rs
@@ -250,7 +250,6 @@ mod tests {
         assert!(writer.write_header(flags).is_ok());
         assert!(writer.flush().is_ok());
 
-        // Verify file exists and has content
         assert!(batch_path.exists());
         let metadata = fs::metadata(&batch_path).unwrap();
         assert!(metadata.len() > 0);
@@ -269,7 +268,6 @@ mod tests {
 
         let mut writer = BatchWriter::new(config).unwrap();
 
-        // write_data before write_header must fail
         assert!(writer.write_data(b"test").is_err());
 
         let flags = BatchFlags::default();


### PR DESCRIPTION
## Summary

Per-crate comment cleanup pass on the `batch` crate, following the precedent set by PRs #4587 (matching), #4591 (protocol), #4590 (transfer), #4589 (fast_io), #4584 (filters), #4582 (logging), #4583 (platform), #4575 (compress).

The crate already enforces `#![deny(missing_docs)]` at the root, so every public item already carries `///`. This follow-up strips pure restatement and decorative section labels from the test bodies and a handful of source files, while preserving every upstream rsync citation, batch-shell-script generation WHY note, and load-bearing protocol invariant.

### Scope

Walked `crates/batch/src/` end to end. Files touched: 7.

- `src/tests.rs` - integration tests: drop `// Write a batch file`, `// Read the batch file back`, `// Verify file entries round-trip correctly`, `// EOF`, `// Should fail on corrupt data`, `// File 1 entry`/`// File 2 entry`, per-section `// Directory entry`/`// File entry`/`// End of flist` labels, `// File checksum (16 zero bytes)` decorators, and `// Replay the ... batch` markers above the obvious replay call.
- `src/reader/tests.rs` - drop `// Try to read more data than available`, `// Write phase`/`// Read phase` decorative dividers, `// Don't read header`, and a cluster of `// Initial segment`, `// Read the sub-list segment`, `// Now we have all 3 entries`, `// NDX codec is available for ...`, `// Sub-list entries have parent directory prepended` labels in the INC_RECURSE test builder.
- `src/format/tests.rs` - drop value-restating comments above `assert_eq!(&buf[N..M], ...)` byte-layout checks; rewrite the multi-byte varint length breakdown as a single concise line.
- `src/replay/tests.rs` - drop `// Basis has "ABCDE"` and `// sqrt(1_000_000) = 1000` type restatements; convert the two CPRES_ZLIB / zstd `cpres_zlib_*` tests' explanatory bodies into `///` rustdoc on the test functions themselves (where they actually belong).
- `src/reader/delta.rs` - tighten the `simple_recv_token` match-arm comments (block_index formula stays, redundant "Literal data: n bytes follow" trailing the same-line literal_len reads).
- `src/script.rs` - drop `// Original filter args should be stripped`, `// The batch name should not appear as a passthrough argument`, and the redundant `// Read and verify script content -- upstream has no shebang` (kept as the WHY note `upstream batch shell scripts have no shebang`).
- `src/writer.rs` - drop `// Verify file exists and has content` and `// write_data before write_header must fail` decorators above the corresponding `assert!`.

### What was kept

- All `// upstream: batch.c:NNN`, `io.c:NNN`, `compat.c:NNN`, `flist.c:NNN`, `token.c:NNN`, `uidlist.c:NNN`, `main.c:NNN`, `receiver.c:NNN`, `rsync.c:NNN` citations.
- All WHY notes: `do_compression` flag semantics, batch body being a raw protocol-stream tee, NDX codec state preservation across flist sub-lists, INC_RECURSE `ndx_start` segment layout, CPRES_ZLIB dictionary sync via `see_token()` after block matches, zstd codec auto-detection, MD4/MD5/XXH3 default 16-byte digest length rationale, `iflags: ITEM_TRANSFER (0x8000)` annotation above the raw u16 byte writes (the literal does not document itself).
- All non-trivial test docstrings (`/// Verifies that ...`) including the upstream-bug reproductions for `token.c:608 inflate -3`.

### Stats

- 7 files changed, +47 / -234.
- 175 pure-comment lines removed; the remaining diff covers reflowing a few multi-line comment paragraphs into concise one-liners and moving two test-body explanations into `///` rustdoc on the test fn.
- No semantic changes. No new `#[allow(...)]` attributes. No public-API rustdoc additions were needed (the crate enforces `missing_docs`).

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings`
- [ ] CI matrix (fmt+clippy, nextest stable, Windows, macOS, Linux musl)