### PR TITLE
docs(flist): drop restatement comments in src

### DIFF
--- a/crates/flist/src/file_list_walker.rs
+++ b/crates/flist/src/file_list_walker.rs
@@ -126,7 +126,6 @@ impl FileListWalker {
                     return Ok(None);
                 }
             } else {
-                // Cannot read symlink target - skip it as unsafe.
                 debug_log!(Flist, 1, "skipping unreadable symlink: {:?}", relative_path);
                 return Ok(None);
             }
@@ -431,7 +430,6 @@ mod tests {
         let entries: Vec<_> = walker.collect();
         assert!(!entries.is_empty());
 
-        // Should have at least the root directory and one file
         let mut found_file = false;
         for result in entries {
             let entry = result.expect("entry");
@@ -449,7 +447,6 @@ mod tests {
             .expect("create walker");
 
         let entries: Vec<_> = walker.collect();
-        // Should have just the root directory
         assert_eq!(entries.len(), 1);
         let entry = entries[0].as_ref().expect("entry");
         assert!(entry.is_root);
@@ -486,7 +483,6 @@ mod tests {
 
         let state = DirectoryState::new(dir, PathBuf::new(), 0).expect("new state");
 
-        // Verify entries are sorted ascending
         for i in 0..state.entries.len() - 1 {
             assert!(
                 state.entries[i] < state.entries[i + 1],

--- a/crates/flist/src/lazy_metadata.rs
+++ b/crates/flist/src/lazy_metadata.rs
@@ -193,21 +193,18 @@ mod tests {
         let (_dir, path) = create_test_file();
         let mut meta = LazyMetadata::new(path, false);
 
-        // First call - get the length
         let len1 = {
             let result = meta.get();
             assert!(result.is_ok());
             result.unwrap().len()
         };
 
-        // Second call should return cached value with same length
         let len2 = {
             let result = meta.get();
             assert!(result.is_ok());
             result.unwrap().len()
         };
 
-        // Both should have the same metadata (same length)
         assert_eq!(len1, len2);
     }
 
@@ -234,12 +231,10 @@ mod tests {
             let link_path = dir.path().join("link.txt");
             std::os::unix::fs::symlink(&file_path, &link_path).unwrap();
 
-            // With follow_symlinks = false, should get symlink metadata
             let mut meta_no_follow = LazyMetadata::new(link_path.clone(), false);
             let result = meta_no_follow.get().unwrap();
             assert!(result.file_type().is_symlink());
 
-            // With follow_symlinks = true, should get target metadata
             let mut meta_follow = LazyMetadata::new(link_path, true);
             let result = meta_follow.get().unwrap();
             assert!(result.file_type().is_file());

--- a/crates/flist/src/parallel.rs
+++ b/crates/flist/src/parallel.rs
@@ -462,7 +462,6 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let root = dir.path();
 
-        // Create some files and directories
         File::create(root.join("file1.txt")).unwrap();
         File::create(root.join("file2.txt")).unwrap();
         fs::create_dir(root.join("subdir")).unwrap();
@@ -511,7 +510,6 @@ mod tests {
         let result = collect_paths_then_metadata_parallel(temp.path().to_path_buf(), false);
         let entries = result.unwrap();
 
-        // Should find all entries
         assert_eq!(entries.len(), 5);
     }
 
@@ -521,7 +519,6 @@ mod tests {
 
         let entries = collect_lazy_parallel(temp.path().to_path_buf(), false).unwrap();
 
-        // Should find all entries
         assert_eq!(entries.len(), 5);
 
         // Metadata should not be resolved yet
@@ -537,10 +534,8 @@ mod tests {
         let lazy_entries = collect_lazy_parallel(temp.path().to_path_buf(), false).unwrap();
         let resolved = resolve_metadata_parallel(lazy_entries).unwrap();
 
-        // Should resolve all entries
         assert_eq!(resolved.len(), 5);
 
-        // Verify metadata is present
         for entry in &resolved {
             let _ = entry.metadata();
         }
@@ -561,11 +556,9 @@ mod tests {
         // Should have 3 .txt files
         assert_eq!(filtered.len(), 3);
 
-        // Resolve only the filtered entries
         let resolved = resolve_metadata_parallel(filtered).unwrap();
         assert_eq!(resolved.len(), 3);
 
-        // All should be files
         for entry in &resolved {
             assert!(entry.metadata().is_file());
         }
@@ -581,7 +574,6 @@ mod tests {
         // Should find all entries: root, 3 files, 1 subdir, 1 nested file
         assert_eq!(entries.len(), 5);
 
-        // All should have metadata
         for entry in &entries {
             let _ = entry.metadata();
         }
@@ -593,12 +585,10 @@ mod tests {
         let temp = TempDir::new().unwrap();
         let root = temp.path();
 
-        // Create 100 files
         for i in 0..100 {
             File::create(root.join(format!("file{i}.txt"))).unwrap();
         }
 
-        // Create 10 subdirs with 10 files each
         for i in 0..10 {
             let subdir = root.join(format!("dir{i}"));
             fs::create_dir(&subdir).unwrap();

--- a/crates/flist/src/tests.rs
+++ b/crates/flist/src/tests.rs
@@ -5,7 +5,6 @@ use std::path::{Path, PathBuf};
 fn collect_relative_paths(walker: FileListWalker) -> Vec<PathBuf> {
     let mut paths = Vec::new();
     for entry in walker {
-        // Handle both successful entries and errors gracefully
         match entry {
             Ok(entry) => {
                 if entry.is_root() {
@@ -14,7 +13,6 @@ fn collect_relative_paths(walker: FileListWalker) -> Vec<PathBuf> {
                 paths.push(entry.relative_path().to_path_buf());
             }
             Err(_) => {
-                // Stop on error but return what we collected so far
                 break;
             }
         }
@@ -252,7 +250,6 @@ fn walk_detects_direct_symlink_loop() {
 
     let paths = collect_relative_paths(walker);
 
-    // The symlink should be yielded but not followed (loop detected)
     assert_eq!(paths, vec![PathBuf::from("link")]);
 }
 
@@ -293,7 +290,6 @@ fn walk_detects_indirect_symlink_loop() {
 
     let paths = collect_relative_paths(walker);
 
-    // All three directories should be yielded
     assert!(paths.contains(&PathBuf::from("a")));
     assert!(paths.contains(&PathBuf::from("b")));
     assert!(paths.contains(&PathBuf::from("c")));
@@ -384,16 +380,13 @@ fn walk_continues_after_detecting_loop() {
 
     let paths = collect_relative_paths(walker);
 
-    // Verify loop entries are present but not infinitely followed
     assert!(paths.contains(&PathBuf::from("loop_dir")));
     assert!(paths.contains(&PathBuf::from("loop_dir/self_link")));
 
-    // Verify normal entries are still processed after loop detection
     assert!(paths.contains(&PathBuf::from("normal_file.txt")));
     assert!(paths.contains(&PathBuf::from("normal_dir")));
     assert!(paths.contains(&PathBuf::from("normal_dir/nested.txt")));
 
-    // Check we got all expected entries and no duplicates from infinite loop
     assert_eq!(paths.len(), 5, "Expected 5 entries, got: {paths:?}");
 }
 
@@ -435,7 +428,6 @@ fn walk_loop_detection_with_multiple_paths_to_same_dir() {
     assert!(paths.contains(&PathBuf::from("link2")));
     assert!(paths.contains(&PathBuf::from("target")));
 
-    // Count how many times file.txt appears
     let file_count = paths
         .iter()
         .filter(|p| p.file_name().and_then(|n| n.to_str()) == Some("file.txt"))
@@ -471,7 +463,6 @@ fn walk_symlink_loop_not_followed_when_disabled() {
 
     let paths = collect_relative_paths(walker);
 
-    // Should get both the symlink and the file, no loop issues
     assert_eq!(paths.len(), 2);
     assert!(paths.contains(&PathBuf::from("self")));
     assert!(paths.contains(&PathBuf::from("file.txt")));
@@ -508,11 +499,9 @@ fn walk_empty_directory() {
 
     let mut walker = FileListBuilder::new(&root).build().expect("build walker");
 
-    // Should yield root
     let root_entry = walker.next().expect("root entry").expect("root ok");
     assert!(root_entry.is_root());
 
-    // Should yield nothing else
     assert!(walker.next().is_none());
 }
 
@@ -529,7 +518,6 @@ fn walk_include_root_false_skips_root_entry() {
         .expect("build walker");
     let paths = collect_relative_paths(walker);
 
-    // Should only contain file, not root
     assert_eq!(paths, vec![PathBuf::from("file.txt")]);
 }
 
@@ -572,7 +560,6 @@ fn walk_terminates_after_exhaustion() {
 
     let mut walker = FileListBuilder::new(&root).build().expect("build walker");
 
-    // Exhaust the walker
     let _ = walker.next();
     let _ = walker.next();
 
@@ -832,7 +819,6 @@ fn copy_links_multiple_symlinks_all_resolved() {
     fs::write(&file_a, b"short").expect("write a");
     fs::write(&file_b, b"longer content").expect("write b");
 
-    // Create symlinks pointing to the files
     symlink(&file_a, root.join("link_a")).expect("symlink a");
     symlink(&file_b, root.join("link_b")).expect("symlink b");
 


### PR DESCRIPTION
## Summary
- Remove inline test comments that restated obvious assertion behaviour or test scaffolding in the `flist` crate's `src/` modules (`tests.rs`, `lazy_metadata.rs`, `file_list_walker.rs`, `parallel.rs`).
- Preserve upstream rsync cites (flist.c/util1.c), SAFETY blocks on `fstatat`/`statx` paths, ordering/sort invariants tied to wire-protocol determinism, and structure diagrams that document multi-step symlink-cycle test scenarios.

No semantic changes; only comments.

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings`