### PR TITLE
docs(checksums): drop restatement comments and tighten test annotations

### DIFF
--- a/crates/checksums/src/comprehensive_tests.rs
+++ b/crates/checksums/src/comprehensive_tests.rs
@@ -10,7 +10,6 @@ mod strong_checksum_tests {
     fn md4_default_equals_new() {
         let new = Md4::new();
         let default = Md4::default();
-        // Both should produce same digest for same input
         let mut h1 = new;
         let mut h2 = default;
         h1.update(b"test");
@@ -87,12 +86,10 @@ mod strong_checksum_tests {
         let mut h1 = Md4::new();
         h1.update(b"hello");
         let h2 = h1.clone();
-        // Both clones should produce same result
         let d1 = h1.finalize();
         let mut h3 = Md4::new();
         h3.update(b"hello");
         assert_eq!(d1, h3.finalize());
-        // h2 should also work
         let mut h4 = h2;
         h4.update(b"");
         let d2 = h4.finalize();
@@ -157,7 +154,6 @@ mod strong_checksum_tests {
         let digest = hasher.finalize();
         assert_eq!(digest.len(), 16);
 
-        // Compare with manual construction
         let mut manual = Md5::new();
         manual.update(&42i32.to_le_bytes());
         manual.update(b"part1part2");
@@ -173,7 +169,6 @@ mod strong_checksum_tests {
         let digest = hasher.finalize();
         assert_eq!(digest.len(), 16);
 
-        // Compare with manual construction
         let mut manual = Md5::new();
         manual.update(b"data1data2");
         manual.update(&99i32.to_le_bytes());
@@ -238,7 +233,6 @@ mod strong_checksum_tests {
         let mut h3 = Md5::new();
         h3.update(b"clone test");
         assert_eq!(d1, h3.finalize());
-        // h2 should also finalize correctly
         let d2 = h2.finalize();
         assert_eq!(d1, d2);
     }
@@ -547,7 +541,6 @@ mod strong_checksum_tests {
             hasher.update(chunk);
         }
         let streaming = hasher.finalize();
-        // Streaming uses xxhash-rust, so compare against that
         let expected = xxhash_rust::xxh3::xxh3_64_with_seed(data, seed).to_le_bytes();
         assert_eq!(streaming, expected);
     }
@@ -566,7 +559,6 @@ mod strong_checksum_tests {
         let mut h = hasher;
         h.update(b"trait test");
         let d = h.finalize();
-        // Compare against xxhash-rust reference
         let expected = xxhash_rust::xxh3::xxh3_64_with_seed(b"trait test", 777).to_le_bytes();
         assert_eq!(d, expected);
     }
@@ -638,7 +630,6 @@ mod strong_checksum_tests {
         hasher.update(&data);
         let streaming = hasher.finalize();
 
-        // Compare with reference
         let expected = xxhash_rust::xxh3::xxh3_64_with_seed(&data, seed).to_le_bytes();
         assert_eq!(streaming, expected);
     }
@@ -698,14 +689,13 @@ mod strong_checksum_tests {
 
     #[test]
     fn xxh3_simd_availability_returns_expected_value() {
-        // xxh3 crate is always compiled in, so this always returns true
+        // xxh3 crate is always compiled in.
         assert!(crate::xxh3_simd_available());
     }
 
     #[test]
     fn openssl_availability_returns_expected_value() {
         let available = crate::openssl_acceleration_available();
-        // Should match compile-time feature
         #[cfg(feature = "openssl")]
         assert!(available);
         #[cfg(not(feature = "openssl"))]
@@ -715,7 +705,6 @@ mod strong_checksum_tests {
     #[test]
     fn simd_availability_returns_bool() {
         let _available = crate::simd_acceleration_available();
-        // Just verify it runs without panic
     }
 
     fn compute_generic<D: StrongDigest>(data: &[u8]) -> D::Digest
@@ -811,11 +800,11 @@ mod rolling_checksum_tests {
 
     #[test]
     fn roll_with_max_values() {
+        // Value should remain stable when in/out bytes are equal.
         let mut checksum = RollingChecksum::new();
         checksum.update(&[0xFF, 0xFF, 0xFF, 0xFF]);
         let _before = checksum.value();
         checksum.roll(0xFF, 0xFF).unwrap();
-        // Value should remain stable when in/out are same
     }
 
     #[test]
@@ -1072,10 +1061,9 @@ mod pipelined_tests {
 
         let mut reader = DoubleBufferedReader::new(Cursor::new(data), config);
 
-        // Read all blocks
         while reader.next_block().unwrap().is_some() {}
 
-        // Additional calls should return None
+        // Additional calls after exhaustion return None.
         assert!(reader.next_block().unwrap().is_none());
         assert!(reader.next_block().unwrap().is_none());
     }
@@ -1118,7 +1106,6 @@ mod pipelined_tests {
         assert_eq!(checksums.len(), 1);
         assert_eq!(checksums[0].len, 32 * 1024);
 
-        // Verify correctness
         let expected_rolling = RollingDigest::from_bytes(&data);
         let expected_strong = Md5::digest(&data);
 
@@ -1161,7 +1148,6 @@ mod pipelined_tests {
         let iter: PipelinedChecksumIterator<Md5, _> =
             PipelinedChecksumIterator::new(Cursor::new(data), config);
 
-        // Just check it was created
         let _pipelined = iter.is_pipelined();
     }
 
@@ -1297,10 +1283,8 @@ mod parallel_tests {
     fn filter_blocks_by_checksum_with_predicate() {
         let blocks: Vec<Vec<u8>> = (0..30).map(|i| vec![(i * 17 % 256) as u8; 200]).collect();
 
-        // Filter for checksums with LSB set
         let matches = filter_blocks_by_checksum(&blocks, |c| c & 1 == 1);
 
-        // Verify each match actually has LSB set
         let checksums = compute_rolling_checksums_parallel(&blocks);
         for &idx in &matches {
             assert!(checksums[idx] & 1 == 1);
@@ -1311,7 +1295,6 @@ mod parallel_tests {
     fn filter_blocks_by_checksum_no_matches() {
         let blocks: Vec<Vec<u8>> = (0..10).map(|_| vec![0u8; 100]).collect();
 
-        // Impossible predicate
         let matches = filter_blocks_by_checksum(&blocks, |c| c == u32::MAX);
 
         assert!(matches.is_empty());
@@ -1321,7 +1304,6 @@ mod parallel_tests {
     fn filter_blocks_by_checksum_all_match() {
         let blocks: Vec<Vec<u8>> = (0..10).map(|i| vec![(i % 256) as u8; 50]).collect();
 
-        // Always true predicate
         let matches = filter_blocks_by_checksum(&blocks, |_| true);
 
         assert_eq!(matches.len(), 10);

--- a/crates/checksums/src/crc32c.rs
+++ b/crates/checksums/src/crc32c.rs
@@ -162,8 +162,6 @@ mod tests {
     use super::*;
     use std::io::Write;
 
-    // --- RFC 3720 / iSCSI standard CRC32C test vectors ---
-
     #[test]
     fn empty_data_returns_zero() {
         assert_eq!(crc32c_bytes(b""), 0);
@@ -171,39 +169,32 @@ mod tests {
 
     #[test]
     fn known_32_bytes_of_zeros() {
-        // 32 bytes of zeros - verified against crc32c crate reference.
         let data = [0u8; 32];
         assert_eq!(crc32c_bytes(&data), 0x8A9136AA);
     }
 
     #[test]
     fn known_32_bytes_of_0xff() {
-        // 32 bytes of 0xFF - verified against crc32c crate reference.
         let data = [0xFFu8; 32];
         assert_eq!(crc32c_bytes(&data), 0x62A8AB43);
     }
 
     #[test]
     fn known_ascending_bytes() {
-        // 32 bytes ascending 0x00..=0x1F - verified against crc32c crate reference.
         let data: Vec<u8> = (0x00u8..=0x1F).collect();
         assert_eq!(crc32c_bytes(&data), 0x46DD794E);
     }
 
     #[test]
     fn known_descending_bytes() {
-        // 32 bytes descending 0x1F..=0x00 - verified against crc32c crate reference.
         let data: Vec<u8> = (0x00u8..=0x1F).rev().collect();
         assert_eq!(crc32c_bytes(&data), 0x113FDB5C);
     }
-
-    // --- Single byte tests ---
 
     #[test]
     fn single_byte_zero() {
         let checksum = crc32c_bytes(&[0x00]);
         assert_ne!(checksum, 0);
-        // Verify determinism.
         assert_eq!(checksum, crc32c_bytes(&[0x00]));
     }
 
@@ -216,7 +207,6 @@ mod tests {
 
     #[test]
     fn each_single_byte_is_unique() {
-        // Every distinct single byte must produce a distinct CRC32C.
         let checksums: Vec<u32> = (0u8..=255).map(|b| crc32c_bytes(&[b])).collect();
         let mut sorted = checksums.clone();
         sorted.sort_unstable();
@@ -224,22 +214,16 @@ mod tests {
         assert_eq!(sorted.len(), 256);
     }
 
-    // --- Known string values ---
-
     #[test]
     fn known_value_hello_world() {
-        // CRC32C("hello world") - verified against reference implementations.
         assert_eq!(crc32c_bytes(b"hello world"), 0xC99465AA);
     }
 
     #[test]
     fn known_value_123456789() {
-        // CRC32C of the ASCII digits "123456789" - the classic check value
-        // for the Castagnoli polynomial.
+        // Classic check value for the Castagnoli polynomial.
         assert_eq!(crc32c_bytes(b"123456789"), 0xE3069283);
     }
-
-    // --- Streaming hasher ---
 
     #[test]
     fn streaming_matches_one_shot() {
@@ -283,8 +267,6 @@ mod tests {
         assert_eq!(hasher.finalize(), 0);
     }
 
-    // --- Differentiation ---
-
     #[test]
     fn different_data_different_checksums() {
         assert_ne!(crc32c_bytes(b"aaa"), crc32c_bytes(b"bbb"));
@@ -297,11 +279,8 @@ mod tests {
 
     #[test]
     fn length_matters() {
-        // "a" vs "aa" - CRC32C distinguishes different lengths.
         assert_ne!(crc32c_bytes(b"a"), crc32c_bytes(b"aa"));
     }
-
-    // --- with_initial ---
 
     #[test]
     fn with_initial_chains_correctly() {
@@ -336,14 +315,11 @@ mod tests {
 
     #[test]
     fn with_initial_no_update_returns_initial() {
+        // CRC32C of zero-length data appended to a state preserves the state.
         let initial = 0x12345678;
         let hasher = Crc32cHasher::with_initial(initial);
-        // Finalize without any update should return the initial value since
-        // CRC32C of zero-length data appended to a state preserves the state.
         assert_eq!(hasher.finalize(), initial);
     }
-
-    // --- Default / Clone / Debug trait coverage ---
 
     #[test]
     fn default_trait_matches_new() {
@@ -381,8 +357,6 @@ mod tests {
         assert!(debug.contains("Crc32cHasher"));
         assert!(debug.contains("state"));
     }
-
-    // --- File checksum ---
 
     #[test]
     fn crc32c_file_reads_correctly() {
@@ -428,7 +402,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("large.bin");
 
-        // Data larger than BUF_SIZE to exercise multi-chunk reading.
+        // Larger than BUF_SIZE to exercise multi-chunk reading.
         let data: Vec<u8> = (0u8..=255).cycle().take(BUF_SIZE * 3 + 42).collect();
         {
             let mut f = File::create(&path).unwrap();
@@ -443,7 +417,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("exact.bin");
 
-        // Exactly BUF_SIZE bytes - boundary condition for the read loop.
+        // Boundary condition for the read loop.
         let data: Vec<u8> = (0u8..=255).cycle().take(BUF_SIZE).collect();
         std::fs::write(&path, &data).unwrap();
 
@@ -455,21 +429,18 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("plus1.bin");
 
-        // BUF_SIZE + 1 bytes - just past the first chunk boundary.
+        // Just past the first chunk boundary.
         let data: Vec<u8> = (0u8..=255).cycle().take(BUF_SIZE + 1).collect();
         std::fs::write(&path, &data).unwrap();
 
         assert_eq!(crc32c_file(&path).unwrap(), crc32c_bytes(&data));
     }
 
-    // --- Edge case patterns ---
-
     #[test]
     fn all_zeros_pattern() {
         let data = [0u8; 1024];
         let checksum = crc32c_bytes(&data);
         assert_ne!(checksum, 0);
-        // Must differ from shorter all-zeros.
         assert_ne!(checksum, crc32c_bytes(&[0u8; 32]));
     }
 
@@ -483,7 +454,6 @@ mod tests {
 
     #[test]
     fn repeating_pattern_sensitivity() {
-        // CRC32C should distinguish different repeating patterns.
         let a: Vec<u8> = [0xAA, 0x55].iter().copied().cycle().take(128).collect();
         let b: Vec<u8> = [0x55, 0xAA].iter().copied().cycle().take(128).collect();
         assert_ne!(crc32c_bytes(&a), crc32c_bytes(&b));
@@ -500,8 +470,8 @@ mod tests {
 
     #[test]
     fn large_input_4mb() {
-        // 4 MiB of data - exercises multiple BUF_SIZE iterations and ensures
-        // no overflow or accumulation errors in the CRC state.
+        // Exercises multiple BUF_SIZE iterations; guards against accumulation
+        // errors in the CRC state.
         let data: Vec<u8> = (0u8..=255).cycle().take(4 * 1024 * 1024).collect();
 
         let one_shot = crc32c_bytes(&data);
@@ -521,7 +491,6 @@ mod tests {
     /// from the one-shot implementation.
     #[test]
     fn streaming_random_buffer_matches_one_shot() {
-        // Deterministic pseudo-random pattern - reproducible across CI runs.
         let data: Vec<u8> = (0u32..16 * 1024)
             .map(|i| (i.wrapping_mul(2654435761) >> 16) as u8)
             .collect();

--- a/crates/checksums/src/strong/md5.rs
+++ b/crates/checksums/src/strong/md5.rs
@@ -484,16 +484,13 @@ mod tests {
 
     #[test]
     fn md5_seeded_proper_order_hashes_seed_before_data() {
-        // Proper order: hash seed bytes THEN data bytes
         let seed_value: i32 = 0x12345678;
         let data = b"test data";
 
-        // Hash with seed in proper order
         let mut with_seed = Md5::with_seed(Md5Seed::proper(seed_value));
         with_seed.update(data);
         let seeded_digest = with_seed.finalize();
 
-        // Manual construction: hash seed, then data
         let mut manual = Md5::new();
         manual.update(&seed_value.to_le_bytes());
         manual.update(data);
@@ -505,7 +502,6 @@ mod tests {
             "Proper order should hash seed before data"
         );
 
-        // Should NOT match unseeded hash
         let unseeded_digest = Md5::digest(data);
         assert_ne!(
             to_hex(&seeded_digest),
@@ -516,16 +512,13 @@ mod tests {
 
     #[test]
     fn md5_seeded_legacy_order_hashes_seed_after_data() {
-        // Legacy order: hash data bytes THEN seed bytes
         let seed_value: i32 = 0x12345678;
         let data = b"test data";
 
-        // Hash with seed in legacy order
         let mut with_seed = Md5::with_seed(Md5Seed::legacy(seed_value));
         with_seed.update(data);
         let seeded_digest = with_seed.finalize();
 
-        // Manual construction: hash data, then seed
         let mut manual = Md5::new();
         manual.update(data);
         manual.update(&seed_value.to_le_bytes());
@@ -540,7 +533,6 @@ mod tests {
 
     #[test]
     fn md5_seed_ordering_produces_different_hashes() {
-        // Verify that proper vs legacy ordering produce different results
         let seed_value: i32 = 0x1BCDEF01u32 as i32;
         let data = b"same data for both";
 

--- a/crates/checksums/src/strong/strategy/tests.rs
+++ b/crates/checksums/src/strong/strategy/tests.rs
@@ -268,7 +268,6 @@ fn selector_for_protocol_version_31() {
     assert_eq!(strategy.algorithm_name(), "md5");
 }
 
-// --- Protocol version boundary tests ---
 // upstream: checksum.c - protocol < 30 uses MD4, >= 30 uses MD5.
 
 #[test]
@@ -545,9 +544,8 @@ fn empty_input_produces_valid_digest() {
     }
 }
 
-// --- Exhaustive protocol version boundary tests ---
 // upstream: checksum.c - protocol < 30 uses MD4, >= 30 uses MD5.
-// These tests verify the boundary holds across the entire u8 range.
+// Verifies the boundary holds across the entire u8 range.
 
 #[test]
 fn protocol_version_boundary_exhaustive_algorithm_kind() {

--- a/crates/checksums/src/strong/xxh64_tests.rs
+++ b/crates/checksums/src/strong/xxh64_tests.rs
@@ -509,7 +509,6 @@ mod tests {
 
     #[test]
     fn verify_64bit_output_bit_distribution() {
-        // Check that bits are reasonably distributed
         let mut bit_counts = [0u32; 64];
 
         for i in 0..10000 {
@@ -537,7 +536,6 @@ mod tests {
 
     #[test]
     fn verify_64bit_output_range() {
-        // Verify the hash can produce values across the full 64-bit range
         let mut min_hash = u64::MAX;
         let mut max_hash = 0u64;
 
@@ -560,13 +558,11 @@ mod tests {
 
     #[test]
     fn verify_64bit_little_endian_encoding() {
-        // Verify the output is consistently little-endian
         let digest = Xxh64::digest(0, b"test");
         let from_le = u64::from_le_bytes(digest);
         let from_be = u64::from_be_bytes(digest);
 
-        // These should be different (unless the hash happens to be palindromic)
-        // For most inputs, they will differ
+        // Unless the hash happens to be palindromic, LE and BE interpretations differ.
         assert_ne!(
             from_le, from_be,
             "Little-endian and big-endian interpretations should differ"


### PR DESCRIPTION
## Summary

- Strip decorative banner comments (`// --- ... ---`) and trivial restatements from `crates/checksums/src/` tests.
- Tighten redundant prose in `crc32c.rs`, `comprehensive_tests.rs`, `strong/md5.rs`, `strong/strategy/tests.rs`, `strong/xxh64_tests.rs`.
- Preserve every `upstream:` cite, every WHY rationale (boundary checks, sign-extension semantics, classic check-value provenance), and all SAFETY annotations above SIMD unsafe blocks.
- No semantic changes; module rustdoc already covers public items (`#![deny(missing_docs)]` enforces it).

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` clean
- [ ] CI: fmt+clippy, nextest (stable), Windows, macOS, Linux musl