### PR TITLE
ci: install cargo-nextest via PowerShell on Windows runners

### DIFF
--- a/.github/workflows/_test-features.yml
+++ b/.github/workflows/_test-features.yml
@@ -69,10 +69,24 @@ jobs:
           shared-key: ci-${{ runner.os }}-cargo-${{ inputs.cache_version }}-${{ hashFiles('**/Cargo.lock') }}
           key: features-${{ matrix.row.name }}-${{ matrix.os }}
 
-      - name: Install cargo-nextest
+      - name: Install cargo-nextest (Unix)
+        if: runner.os != 'Windows'
         uses: taiki-e/install-action@fa0dd4cd0a40696e6f9766370614a5ce482e6aa8 # v2
         with:
           tool: cargo-nextest
+
+      - name: Install cargo-nextest (Windows direct download)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          # Workaround for actions/partner-runner-images#169 on Windows.
+          $ErrorActionPreference = 'Stop'
+          $cargoBin = Join-Path $env:USERPROFILE '.cargo\bin'
+          New-Item -ItemType Directory -Force -Path $cargoBin | Out-Null
+          $zip = Join-Path $env:RUNNER_TEMP 'nextest.zip'
+          Invoke-WebRequest -UseBasicParsing -Uri 'https://get.nexte.st/latest/windows' -OutFile $zip
+          Expand-Archive -Force -Path $zip -DestinationPath $cargoBin
+          & "$cargoBin\cargo-nextest.exe" --version
 
       - name: Test (${{ matrix.row.name }})
         run: cargo nextest run --locked --profile ci ${{ matrix.row.args }}
@@ -156,10 +170,24 @@ jobs:
           shared-key: ci-${{ runner.os }}-cargo-${{ inputs.cache_version }}-${{ hashFiles('**/Cargo.lock') }}
           key: features-${{ matrix.name }}-linux
 
-      - name: Install cargo-nextest
+      - name: Install cargo-nextest (Unix)
+        if: runner.os != 'Windows'
         uses: taiki-e/install-action@fa0dd4cd0a40696e6f9766370614a5ce482e6aa8 # v2
         with:
           tool: cargo-nextest
+
+      - name: Install cargo-nextest (Windows direct download)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          # Workaround for actions/partner-runner-images#169 on Windows.
+          $ErrorActionPreference = 'Stop'
+          $cargoBin = Join-Path $env:USERPROFILE '.cargo\bin'
+          New-Item -ItemType Directory -Force -Path $cargoBin | Out-Null
+          $zip = Join-Path $env:RUNNER_TEMP 'nextest.zip'
+          Invoke-WebRequest -UseBasicParsing -Uri 'https://get.nexte.st/latest/windows' -OutFile $zip
+          Expand-Archive -Force -Path $zip -DestinationPath $cargoBin
+          & "$cargoBin\cargo-nextest.exe" --version
 
       - name: Test (${{ matrix.name }})
         run: cargo nextest run --locked --profile ci ${{ matrix.args }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,10 +219,20 @@ jobs:
         with:
           shared-key: ci-windows-${{ matrix.toolchain }}-cargo-${{ env.CACHE_VERSION }}-${{ hashFiles('**/Cargo.toml') }}
 
-      - name: Install cargo-nextest
-        uses: taiki-e/install-action@fa0dd4cd0a40696e6f9766370614a5ce482e6aa8 # v2
-        with:
-          tool: cargo-nextest
+      - name: Install cargo-nextest (Windows direct download)
+        shell: pwsh
+        run: |
+          # Workaround for taiki-e/install-action bash startup failures on the
+          # Windows partner runners (actions/partner-runner-images#169). Download
+          # the prebuilt cargo-nextest binary via PowerShell so we never invoke
+          # bash during install.
+          $ErrorActionPreference = 'Stop'
+          $cargoBin = Join-Path $env:USERPROFILE '.cargo\bin'
+          New-Item -ItemType Directory -Force -Path $cargoBin | Out-Null
+          $zip = Join-Path $env:RUNNER_TEMP 'nextest.zip'
+          Invoke-WebRequest -UseBasicParsing -Uri 'https://get.nexte.st/latest/windows' -OutFile $zip
+          Expand-Archive -Force -Path $zip -DestinationPath $cargoBin
+          & "$cargoBin\cargo-nextest.exe" --version
 
       - name: Test
         run: |
@@ -271,10 +281,17 @@ jobs:
           shared-key: ci-windows-iocp-cargo-${{ env.CACHE_VERSION }}-${{ hashFiles('**/Cargo.toml') }}
           key: windows-iocp
 
-      - name: Install cargo-nextest
-        uses: taiki-e/install-action@fa0dd4cd0a40696e6f9766370614a5ce482e6aa8 # v2
-        with:
-          tool: cargo-nextest
+      - name: Install cargo-nextest (Windows direct download)
+        shell: pwsh
+        run: |
+          # Workaround for actions/partner-runner-images#169 on Windows.
+          $ErrorActionPreference = 'Stop'
+          $cargoBin = Join-Path $env:USERPROFILE '.cargo\bin'
+          New-Item -ItemType Directory -Force -Path $cargoBin | Out-Null
+          $zip = Join-Path $env:RUNNER_TEMP 'nextest.zip'
+          Invoke-WebRequest -UseBasicParsing -Uri 'https://get.nexte.st/latest/windows' -OutFile $zip
+          Expand-Archive -Force -Path $zip -DestinationPath $cargoBin
+          & "$cargoBin\cargo-nextest.exe" --version
 
       # Build the workspace with iocp explicitly enabled. The feature is in
       # defaults but pinning it here protects against future default changes
@@ -329,10 +346,17 @@ jobs:
           shared-key: ci-windows-acl-xattr-cargo-${{ env.CACHE_VERSION }}-${{ hashFiles('**/Cargo.toml') }}
           key: windows-acl-xattr
 
-      - name: Install cargo-nextest
-        uses: taiki-e/install-action@fa0dd4cd0a40696e6f9766370614a5ce482e6aa8 # v2
-        with:
-          tool: cargo-nextest
+      - name: Install cargo-nextest (Windows direct download)
+        shell: pwsh
+        run: |
+          # Workaround for actions/partner-runner-images#169 on Windows.
+          $ErrorActionPreference = 'Stop'
+          $cargoBin = Join-Path $env:USERPROFILE '.cargo\bin'
+          New-Item -ItemType Directory -Force -Path $cargoBin | Out-Null
+          $zip = Join-Path $env:RUNNER_TEMP 'nextest.zip'
+          Invoke-WebRequest -UseBasicParsing -Uri 'https://get.nexte.st/latest/windows' -OutFile $zip
+          Expand-Archive -Force -Path $zip -DestinationPath $cargoBin
+          & "$cargoBin\cargo-nextest.exe" --version
 
       # Build metadata with ACL + xattr explicitly enabled so the Win32
       # GetSecurityInfo / SetSecurityInfo and ADS code paths are exercised.


### PR DESCRIPTION
## Summary

Windows CI jobs have been stuck in a fail loop for over a day with the same root cause: \`taiki-e/install-action@fa0dd4c\` invokes bash internally to download cargo-nextest, but the Windows partner runners have a broken bash startup (\`actions/partner-runner-images#169\`) that no \`gh run rerun --failed\` could clear because the underlying runner image is the broken artifact.

This PR replaces the install-action call on every Windows job with a direct PowerShell download from \`https://get.nexte.st/latest/windows\`. PowerShell's \`Invoke-WebRequest\` + \`Expand-Archive\` never touches bash, so it sidesteps the runner image bug completely. Linux and macOS keep using install-action (which works fine there).

Touched five spots:
- \`.github/workflows/ci.yml\` Windows test job (matrix.toolchain)
- \`.github/workflows/ci.yml\` Windows IOCP (\`--features iocp\`) job
- \`.github/workflows/ci.yml\` Windows ACL/xattr job
- \`.github/workflows/_test-features.yml\` two matrix-OS occurrences (gated with \`runner.os\` conditionals so Unix runners keep using install-action)

Unblocks open PRs #4578 and any future PRs that touch \`crates/**\` and trigger the path-filtered Windows CI matrix.

## Test plan

- [ ] Windows (stable) check on this PR runs and succeeds (validates the PowerShell path)
- [ ] Windows IOCP and Windows ACL/xattr checks also succeed
- [ ] Linux/macOS \`Install cargo-nextest\` steps continue to use \`taiki-e/install-action\` unchanged