### PR TITLE
docs(audits): locate HTTP CONNECT proxy parser for SEC-2.b

### DIFF
--- a/docs/audits/security-rsync-3-4-3-cve-audit-2026-05-20.md
+++ b/docs/audits/security-rsync-3-4-3-cve-audit-2026-05-20.md
@@ -102,3 +102,42 @@ There is even an explicit regression test: `counting_writer_saturating_add_preve
 | LOW 3.1 | CVE-2026-45232 | **Needs verification** -> SEC-2 |
 
 **Net beta-readiness impact:** SEC-1 is a genuine new beta-blocker for any deployment that uses `use chroot = no`. SEC-2 is a small parser hardening. SEC-3 is a one-line audit. The other three CVEs are already covered by the Rust-side mitigations baked into the existing code.
+
+## SEC-2.a parser location
+
+**Parser:** `read_proxy_line()` at `crates/core/src/client/module_list/connect/proxy.rs:337-372`.
+
+**Callsites (status line + each header line):**
+- `crates/core/src/client/module_list/connect/proxy.rs:93` - first call reads the `HTTP/1.x 2xx` status line into `line`, which is then validated by `establish_proxy_tunnel()` at lines 94-118.
+- `crates/core/src/client/module_list/connect/proxy.rs:121` - subsequent calls inside the header-drain loop (lines 120-125) until an empty line marks end-of-headers.
+
+**Current max-line cap:** **already capped at 4096 bytes** (lines 360-364):
+
+```rust
+if buffer.len() > 4096 {
+    return Err(proxy_response_error(
+        "proxy response line exceeded 4096 bytes",
+    ));
+}
+```
+
+This is stricter than upstream rsync 3.4.3's response (upstream rejects at the 1024-byte stack-buffer boundary it was previously overflowing). The C-class one-byte heap/stack overflow of CVE-2026-45232 is structurally impossible in this Rust implementation: the buffer is a heap `Vec<u8>` grown by bounds-checked `push`, and the cap is enforced after every byte. No off-by-one is reachable.
+
+**Parser style:** **hand-rolled byte-by-byte loop** over `TcpStream::read(&mut [u8; 1])` - not `BufRead::read_line`. The function does NOT wrap the stream in a `BufReader`; each byte is read with a separate syscall. The cap is therefore enforced explicitly by the `buffer.len() > 4096` check, not implicitly via a `BufReader` capacity. This is the correct shape for a hardening cap, but the read-one-byte-per-syscall pattern is independently inefficient (separate concern; out of SEC-2 scope).
+
+**API surface SEC-2.b should patch:**
+
+- **Function signature to harden:**
+  ```rust
+  fn read_proxy_line(
+      stream: &mut TcpStream,
+      buffer: &mut Vec<u8>,
+      proxy: SocketAddrDisplay<'_>,
+  ) -> Result<(), ClientError>
+  ```
+- **Insertion point:** the existing `if buffer.len() > 4096` block at lines 360-364 is the right hook. SEC-2.b should either (a) tighten the cap to match upstream's exact ceiling (upstream uses 1024 for the stack buffer; matching is optional - 4096 is already safer than upstream and any value < 16 KiB is fine for a CONNECT response line), or (b) lift the magic `4096` into a named constant (e.g. `MAX_PROXY_RESPONSE_LINE_BYTES`) and add a regression test asserting the error path fires.
+- **Error path:** already returns `proxy_response_error("proxy response line exceeded 4096 bytes")` mapped to `SOCKET_IO_EXIT_CODE` with `Role::Client`. SEC-2.b should keep the error text aligned with upstream's wording (`"proxy response line too long"`) for log-grep parity.
+
+**Recommended one-line fix shape for SEC-2.b:** extract the `4096` literal into a `const MAX_PROXY_LINE_BYTES: usize = 1024;` (matching upstream's ceiling), reference it in the cap check and the error string, and add a unit test that feeds a 1025-byte newline-free response and asserts the `proxy response line too long` error.
+
+**Gap status:** no functional gap. The cap exists and is correctly enforced. SEC-2.b is a cosmetic / parity hardening (named constant, upstream-matched wording, regression test) rather than a vulnerability fix.


### PR DESCRIPTION
## Summary
- Append a `## SEC-2.a parser location` section to `docs/audits/security-rsync-3-4-3-cve-audit-2026-05-20.md`.
- Pinpoint `read_proxy_line()` at `crates/core/src/client/module_list/connect/proxy.rs:337-372` (callsites at lines 93 and 121).
- Document current state: hand-rolled byte-by-byte loop (not `BufRead::read_line`) with an explicit 4096-byte cap at lines 360-364, stricter than upstream rsync 3.4.3's 1024-byte ceiling.
- Record the API surface SEC-2.b should patch and a recommended one-line fix shape (extract the literal into a named constant, align error wording with upstream's "proxy response line too long", add a regression test for the cap edge).
- Conclusion: no functional gap. SEC-2.b is cosmetic parity hardening, not a vulnerability fix.

## Test plan
- [ ] Docs-only change; no code touched.
- [ ] `cargo fmt --all` clean.
- [ ] Markdown renders correctly on the PR diff view.