### PR TITLE
chore(engine): promote dashmap to runtime dep for BR-3j.c

### DIFF
--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -29,6 +29,7 @@ thiserror = { workspace = true }
 rayon = { workspace = true }
 crossbeam-channel = { workspace = true }
 crossbeam-queue = { workspace = true }
+dashmap = { workspace = true }
 tracing = { workspace = true, optional = true }
 globset = { workspace = true }
 jwalk = { workspace = true }
@@ -173,7 +174,6 @@ proptest = { workspace = true }
 xattr = { workspace = true }
 libc = { workspace = true }
 criterion = { workspace = true }
-dashmap = { workspace = true }
 zstd = "0.13"
 
 [[bench]]


### PR DESCRIPTION
## Summary

- BR-3j.b (#2504): Promotes `dashmap` from `[dev-dependencies]` to `[dependencies]` in `crates/engine/Cargo.toml`.
- Unblocks the BR-3j.c source-code migration that replaces the `Mutex<HashMap<FileNdx, Arc<Mutex<FileSlot>>>>` at `crates/engine/src/concurrent_delta/parallel_apply.rs:252` with `DashMap`.
- Placement is unconditional (not `cfg(unix)`, not feature-gated) per the BR-3j.a audit so the parallel-receive-delta path always has runtime access.

## Background

BR-3j.a (merged in PR #4600, audit `docs/audits/br-3j-a-dashmap-vs-sharded-2026-05-20.md`) selected DashMap over `sharded-slab` for this contention site. The workspace already declares `dashmap = "6.1"` in `[workspace.dependencies]` (used by daemon's `concurrent-sessions` feature), so this change is a one-line promotion - the resolved version stays at `6.1.0`.

## No source-code changes in this PR

This is a Cargo-manifest-only change to set up the BR-3j.c-f chain. The actual `Mutex<HashMap>` to `DashMap` migration lands in BR-3j.c so reviewers can audit the dependency promotion separately from the call-site refactor.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings`
- [x] `cargo metadata` resolves cleanly (dashmap 6.1.0)
- [ ] CI: fmt+clippy, nextest (stable), Windows, macOS, Linux musl