### PR TITLE
fix(rsync_io): reject hyphen-prefixed remote-shell hostnames

### DIFF
--- a/crates/rsync_io/src/ssh/operand.rs
+++ b/crates/rsync_io/src/ssh/operand.rs
@@ -76,6 +76,12 @@ pub enum RemoteOperandParseError {
     /// The port number was invalid or out of range.
     #[error("invalid port number in remote operand")]
     InvalidPort,
+    /// The hostname or user component begins with `-`, which the spawned
+    /// remote-shell process would parse as a command-line option (argv
+    /// injection - e.g. `-oProxyCommand=evil`). Defense-in-depth mirroring
+    /// upstream rsync 3.4.3.
+    #[error("remote operand component must not start with '-': {0}")]
+    LeadingDash(String),
 }
 
 /// Parses an SSH-style remote operand into structured components.
@@ -125,6 +131,15 @@ pub fn parse_ssh_operand(operand: &OsStr) -> Result<RemoteOperand, RemoteOperand
         return Err(RemoteOperandParseError::InvalidFormat);
     }
 
+    // Defense-in-depth: reject hostnames or users that start with `-`. The
+    // spawned `ssh` (or other remote shell) would otherwise interpret such a
+    // value as a command-line option, enabling argv injection like
+    // `-oProxyCommand=evil`. Mirrors upstream rsync 3.4.3.
+    reject_leading_dash(host)?;
+    if let Some(user_str) = user {
+        reject_leading_dash(user_str)?;
+    }
+
     Ok(RemoteOperand {
         user: user.map(String::from),
         host: host.to_owned(),
@@ -132,6 +147,20 @@ pub fn parse_ssh_operand(operand: &OsStr) -> Result<RemoteOperand, RemoteOperand
         port: None,
         path: path.to_owned(),
     })
+}
+
+/// Rejects a hostname or user component that begins with `-`.
+///
+/// Such a component, when forwarded verbatim to `ssh` as part of the
+/// `user@host` argv element (or as a bare `host`), would be parsed by the
+/// remote-shell binary as a command-line option. Refusing it here prevents
+/// argv-injection attacks such as `-oProxyCommand=...` smuggled through a
+/// remote source URL.
+fn reject_leading_dash(component: &str) -> Result<(), RemoteOperandParseError> {
+    if component.starts_with('-') {
+        return Err(RemoteOperandParseError::LeadingDash(component.to_owned()));
+    }
+    Ok(())
 }
 
 /// Extracts the optional user prefix from a remote operand.
@@ -398,6 +427,71 @@ mod tests {
         assert_eq!(
             RemoteOperandParseError::InvalidPort.to_string(),
             "invalid port number in remote operand"
+        );
+        assert_eq!(
+            RemoteOperandParseError::LeadingDash("-host".to_owned()).to_string(),
+            "remote operand component must not start with '-': -host"
+        );
+    }
+
+    #[test]
+    fn rejects_hostname_with_leading_dash() {
+        let operand = OsStr::new("-oProxyCommand=evil:/etc/passwd");
+        let result = parse_ssh_operand(operand);
+
+        assert_eq!(
+            result,
+            Err(RemoteOperandParseError::LeadingDash(
+                "-oProxyCommand=evil".to_owned()
+            ))
+        );
+    }
+
+    #[test]
+    fn rejects_hostname_with_double_dash() {
+        let operand = OsStr::new("--config=evil:/data");
+        let result = parse_ssh_operand(operand);
+
+        assert_eq!(
+            result,
+            Err(RemoteOperandParseError::LeadingDash(
+                "--config=evil".to_owned()
+            ))
+        );
+    }
+
+    #[test]
+    fn rejects_single_dash_hostname() {
+        let operand = OsStr::new("-:/data");
+        let result = parse_ssh_operand(operand);
+
+        assert_eq!(
+            result,
+            Err(RemoteOperandParseError::LeadingDash("-".to_owned()))
+        );
+    }
+
+    #[test]
+    fn rejects_user_with_leading_dash() {
+        let operand = OsStr::new("-evil@host.example:/path");
+        let result = parse_ssh_operand(operand);
+
+        assert_eq!(
+            result,
+            Err(RemoteOperandParseError::LeadingDash("-evil".to_owned()))
+        );
+    }
+
+    #[test]
+    fn rejects_bracketed_ipv6_hostname_with_leading_dash() {
+        // Brackets are stripped before classification; if somehow a leading
+        // dash is smuggled inside, we still reject.
+        let operand = OsStr::new("[-bad]:/path");
+        let result = parse_ssh_operand(operand);
+
+        assert_eq!(
+            result,
+            Err(RemoteOperandParseError::LeadingDash("-bad".to_owned()))
         );
     }
 }


### PR DESCRIPTION
## Summary

- Hostnames or user components that start with `-` would be forwarded verbatim to the spawned `ssh` process as a `user@host` argv element and parsed as a command-line option (e.g. `-oProxyCommand=evil`), enabling argv injection through a remote source URL.
- `parse_ssh_operand` in `crates/rsync_io/src/ssh/operand.rs` now rejects such operands with a new `RemoteOperandParseError::LeadingDash` variant.
- Mirrors upstream rsync 3.4.3 defense-in-depth.

## Coverage

New unit tests in `crates/rsync_io/src/ssh/operand.rs`:

- `rejects_hostname_with_leading_dash` (single-dash flag form)
- `rejects_hostname_with_double_dash` (long-option form)
- `rejects_single_dash_hostname` (bare `-`)
- `rejects_user_with_leading_dash` (user component)
- `rejects_bracketed_ipv6_hostname_with_leading_dash` (smuggled inside `[..]`)
- `error_display_messages` extended for the new variant.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings`
- [x] `cargo nextest run -p rsync_io --all-features -E 'test(operand)'` (27 / 27 pass)
- [x] `cargo nextest run -p rsync_io --all-features -E 'test(ssh)'` (332 / 332 pass)
- [ ] CI matrix (fmt+clippy, nextest stable, Windows, macOS, Linux musl).