### PR TITLE
docs(metadata): drop restatement comments and apply rustdoc

### DIFF
--- a/crates/metadata/src/acl_exacl/tests.rs
+++ b/crates/metadata/src/acl_exacl/tests.rs
@@ -23,7 +23,6 @@ fn sync_acls_skips_when_not_following_symlinks() {
     File::create(&source).expect("create src");
     File::create(&destination).expect("create dst");
 
-    // Should return Ok without doing anything
     let result = sync_acls(&source, &destination, false);
     assert!(result.is_ok());
 }
@@ -36,7 +35,6 @@ fn sync_acls_copies_between_regular_files() {
     File::create(&source).expect("create src");
     File::create(&destination).expect("create dst");
 
-    // Should succeed for files on same filesystem
     let result = sync_acls(&source, &destination, true);
     assert!(result.is_ok());
 }
@@ -76,7 +74,6 @@ fn clear_default_acl_works_on_directory() {
 
 #[test]
 fn is_unsupported_error_detects_common_messages() {
-    // Test various error message patterns
     let patterns = [
         "operation not supported",
         "No such file or directory",
@@ -96,7 +93,6 @@ fn is_unsupported_error_detects_common_messages() {
 #[cfg(unix)]
 #[test]
 fn is_unsupported_error_detects_os_error_codes() {
-    // Test raw OS error codes
     let codes = [libc::ENOTSUP, libc::ENOENT, libc::EINVAL, libc::EPERM];
 
     for code in codes {
@@ -238,7 +234,6 @@ fn apply_acls_from_cache_missing_index_is_noop() {
     File::create(&file).expect("create file");
 
     let cache = AclCache::new();
-    // Index 99 does not exist - should be a no-op, not an error
     let result = apply_acls_from_cache(&file, &cache, 99, None, true, Some(0o644));
     assert!(result.is_ok());
 }

--- a/crates/metadata/src/apply_batch.rs
+++ b/crates/metadata/src/apply_batch.rs
@@ -88,7 +88,7 @@ impl BatchMetadataContext {
         } else {
             match self.cache.get_or_fetch(destination) {
                 Ok(cached) => cached.uid,
-                Err(_) => return Ok(()), // If we can't stat, skip ownership
+                Err(_) => return Ok(()),
             }
         };
 
@@ -97,14 +97,14 @@ impl BatchMetadataContext {
         } else {
             match self.cache.get_or_fetch(destination) {
                 Ok(cached) => cached.gid,
-                Err(_) => return Ok(()), // If we can't stat, skip ownership
+                Err(_) => return Ok(()),
             }
         };
 
         let needs_chown = match self.cache.ownership_matches(destination, desired_uid, desired_gid)
         {
             Ok(matches) => !matches,
-            Err(_) => true, // If cache check fails, try chown anyway
+            Err(_) => true,
         };
 
         if needs_chown {
@@ -154,7 +154,7 @@ impl BatchMetadataContext {
 
         let needs_chmod = match self.cache.mode_matches(destination, desired_mode) {
             Ok(matches) => !matches,
-            Err(_) => true, // If cache check fails, try chmod anyway
+            Err(_) => true,
         };
 
         if needs_chmod {
@@ -191,7 +191,6 @@ impl BatchMetadataContext {
                 }
             }
             Err(_) => {
-                // If we can't stat, try setting anyway
                 let mut perms = metadata.permissions();
                 perms.set_readonly(desired_readonly);
                 fs::set_permissions(destination, perms).map_err(|error| {
@@ -288,12 +287,11 @@ mod tests {
         let mut ctx = BatchMetadataContext::new();
         let meta = fs::metadata(&path).expect("metadata");
 
-        // This will cause some cache activity
         let _ = ctx.apply_file_metadata(&path, &meta);
 
         ctx.clear_cache();
         let (hits, misses) = ctx.cache_stats();
-        // Stats are preserved, only cache entries are cleared
+        // Stats counters survive a clear; only cache entries are dropped.
         assert!(hits >= 0);
         assert!(misses >= 0);
     }
@@ -310,7 +308,6 @@ mod tests {
         fs::write(&source, b"source").expect("write source");
         fs::write(&dest, b"dest").expect("write dest");
 
-        // Set different permissions on source
         let perms = PermissionsExt::from_mode(0o755);
         fs::set_permissions(&source, perms).expect("chmod source");
 
@@ -320,24 +317,21 @@ mod tests {
         opts.set_permissions(true);
         let mut ctx = BatchMetadataContext::with_options(opts);
 
-        // Apply metadata
         ctx.apply_file_metadata(&dest, &source_meta)
             .expect("apply metadata");
 
-        // Verify permissions were applied
         let dest_meta = fs::metadata(&dest).expect("dest metadata");
         assert_eq!(
             dest_meta.permissions().mode() & 0o777,
             source_meta.permissions().mode() & 0o777
         );
 
-        // Apply again - should be cached and skip syscall
+        // Second call must hit the cache and skip the chmod syscall.
         let before_hits = ctx.cache_stats().0;
         ctx.apply_file_metadata(&dest, &source_meta)
             .expect("apply metadata again");
         let after_hits = ctx.cache_stats().0;
 
-        // Should have at least one cache hit
         assert!(after_hits > before_hits);
     }
 
@@ -348,12 +342,11 @@ mod tests {
 
         let temp = tempfile::tempdir().expect("tempdir");
 
-        // Create multiple files with different permissions
         let files: Vec<_> = (0..10)
             .map(|i| {
                 let path = temp.path().join(format!("file{}.txt", i));
                 fs::write(&path, format!("content{}", i)).expect("write");
-                let mode = 0o600 + (i * 7) % 0o177; // Varying permissions
+                let mode = 0o600 + (i * 7) % 0o177;
                 let perms = PermissionsExt::from_mode(mode);
                 fs::set_permissions(&path, perms).expect("chmod");
                 path
@@ -364,7 +357,6 @@ mod tests {
         opts.set_permissions(true);
         let mut ctx = BatchMetadataContext::with_options(opts);
 
-        // Apply metadata to all files twice
         for _ in 0..2 {
             for file in &files {
                 let meta = fs::metadata(file).expect("metadata");
@@ -373,7 +365,6 @@ mod tests {
         }
 
         let (hits, _misses) = ctx.cache_stats();
-        // Second pass should have cache hits
         assert!(hits >= 10, "Expected at least 10 hits, got {}", hits);
     }
 
@@ -389,7 +380,6 @@ mod tests {
         fs::write(&source, b"source").expect("write source");
         fs::write(&dest, b"dest").expect("write dest");
 
-        // Set different permissions
         let perms_source = PermissionsExt::from_mode(0o755);
         let perms_dest = PermissionsExt::from_mode(0o644);
         fs::set_permissions(&source, perms_source).expect("chmod source");
@@ -398,14 +388,13 @@ mod tests {
         let source_meta = fs::metadata(&source).expect("source metadata");
         let dest_meta_before = fs::metadata(&dest).expect("dest metadata before");
 
-        let opts = MetadataOptions::default(); // permissions disabled
+        // Default options leave permission preservation off.
+        let opts = MetadataOptions::default();
         let mut ctx = BatchMetadataContext::with_options(opts);
 
-        // Apply metadata (should skip permissions)
         ctx.apply_file_metadata(&dest, &source_meta)
             .expect("apply metadata");
 
-        // Verify permissions were NOT changed
         let dest_meta_after = fs::metadata(&dest).expect("dest metadata after");
         assert_eq!(
             dest_meta_before.mode() & 0o777,
@@ -433,11 +422,9 @@ mod tests {
         opts.set_times(true);
         let mut ctx = BatchMetadataContext::with_options(opts);
 
-        // Apply metadata
         ctx.apply_file_metadata(&dest, &source_meta)
             .expect("apply metadata");
 
-        // Verify timestamps were applied
         let dest_meta = fs::metadata(&dest).expect("dest metadata");
         let source_mtime = FileTime::from_last_modification_time(&source_meta);
         let dest_mtime = FileTime::from_last_modification_time(&dest_meta);
@@ -462,14 +449,13 @@ mod tests {
         let source_meta = fs::metadata(&source).expect("source metadata");
         let dest_meta_before = fs::metadata(&dest).expect("dest metadata before");
 
-        let opts = MetadataOptions::default(); // times disabled
+        // Default options leave timestamp preservation off.
+        let opts = MetadataOptions::default();
         let mut ctx = BatchMetadataContext::with_options(opts);
 
-        // Apply metadata (should skip timestamps)
         ctx.apply_file_metadata(&dest, &source_meta)
             .expect("apply metadata");
 
-        // Verify timestamps were NOT changed
         let dest_meta_after = fs::metadata(&dest).expect("dest metadata after");
         let mtime_before = FileTime::from_last_modification_time(&dest_meta_before);
         let mtime_after = FileTime::from_last_modification_time(&dest_meta_after);
@@ -486,7 +472,6 @@ mod tests {
         let path = temp.path().join("test.txt");
         fs::write(&path, b"content").expect("write");
 
-        // Set initial permissions
         let perms1 = PermissionsExt::from_mode(0o644);
         fs::set_permissions(&path, perms1).expect("chmod");
 
@@ -499,15 +484,14 @@ mod tests {
 
         let (hits_before, misses_before) = ctx.cache_stats();
 
-        // Change permissions
         let perms2 = PermissionsExt::from_mode(0o755);
         fs::set_permissions(&path, perms2).expect("chmod");
 
         let meta2 = fs::metadata(&path).expect("metadata");
         ctx.apply_file_metadata(&path, &meta2).expect("apply");
 
-        // Cache should have been invalidated after the chmod
-        // Next operation should see the new permissions
+        // Cache invalidation after the chmod must surface the new mode -
+        // either via a fresh miss or a re-validated hit on the next apply.
         let (hits_after, misses_after) = ctx.cache_stats();
         assert!(misses_after > misses_before || hits_after > hits_before);
     }
@@ -525,21 +509,18 @@ mod tests {
         let uid = meta.uid();
         let gid = meta.gid();
 
-        // Apply metadata with ownership that already matches
         let mut opts = MetadataOptions::default();
         opts.set_owner(true);
         opts.set_group(true);
         let mut ctx = BatchMetadataContext::with_options(opts);
 
-        // First application
         ctx.apply_file_metadata(&path, &meta).expect("apply");
 
-        // Second application should use cache and skip chown
+        // Second apply must hit the cache and elide the chown syscall.
         let (_, misses_before) = ctx.cache_stats();
         ctx.apply_file_metadata(&path, &meta).expect("apply");
         let (hits_after, _) = ctx.cache_stats();
 
-        // Should have cache hits from the second application
         assert!(hits_after > 0);
     }
 
@@ -553,7 +534,6 @@ mod tests {
         fs::write(&source, b"source").expect("write source");
         fs::write(&dest, b"dest").expect("write dest");
 
-        // Make source readonly
         let mut perms = fs::metadata(&source).expect("metadata").permissions();
         perms.set_readonly(true);
         fs::set_permissions(&source, perms).expect("set readonly");
@@ -564,11 +544,9 @@ mod tests {
         opts.set_permissions(true);
         let mut ctx = BatchMetadataContext::with_options(opts);
 
-        // Apply metadata
         ctx.apply_file_metadata(&dest, &source_meta)
             .expect("apply metadata");
 
-        // Verify readonly was applied
         let dest_meta = fs::metadata(&dest).expect("dest metadata");
         assert!(dest_meta.permissions().readonly());
     }
@@ -586,7 +564,6 @@ mod tests {
         opts.set_permissions(true);
         let mut ctx = BatchMetadataContext::with_options(opts);
 
-        // Should return error for nonexistent path
         let result = ctx.apply_file_metadata(&dest, &source_meta);
         assert!(result.is_err());
     }
@@ -606,18 +583,17 @@ mod tests {
         let source_meta = fs::metadata(&source).expect("source metadata");
         let dest_meta_before = fs::metadata(&dest).expect("dest metadata");
 
-        // Only enable owner, not group
+        // Owner-only ownership preservation; group must stay untouched.
         let mut opts = MetadataOptions::default();
         opts.set_owner(true);
         opts.set_group(false);
         let mut ctx = BatchMetadataContext::with_options(opts);
 
-        // Apply metadata
         let _ = ctx.apply_file_metadata(&dest, &source_meta);
 
-        // GID should remain unchanged (we're not root, so this is best-effort)
+        // Without root the chown is best-effort; the test just exercises the
+        // partial-application path and asserts it does not panic.
         let dest_meta_after = fs::metadata(&dest).expect("dest metadata");
-        // UID might change or not depending on permissions, but test shouldn't fail
         let _ = dest_meta_after.uid();
         let _ = dest_meta_before.gid();
     }
@@ -627,7 +603,6 @@ mod tests {
         let temp = tempfile::tempdir().expect("tempdir");
         let mut ctx = BatchMetadataContext::with_capacity(1000, MetadataOptions::default());
 
-        // Create and process 100 files
         for i in 0..100 {
             let path = temp.path().join(format!("file{}.txt", i));
             fs::write(&path, format!("content{}", i)).expect("write");
@@ -636,7 +611,6 @@ mod tests {
         }
 
         let (hits, misses) = ctx.cache_stats();
-        // Should have some cache activity
         assert!(hits + misses > 0);
     }
 
@@ -649,14 +623,11 @@ mod tests {
         let mut ctx = BatchMetadataContext::new();
         let meta = fs::metadata(&path).expect("metadata");
 
-        // Populate cache
         let _ = ctx.apply_file_metadata(&path, &meta);
         let (_, misses_before) = ctx.cache_stats();
 
-        // Clear cache
         ctx.clear_cache();
 
-        // Next operation should miss
         let _ = ctx.apply_file_metadata(&path, &meta);
         let (_, misses_after) = ctx.cache_stats();
 
@@ -675,17 +646,15 @@ mod tests {
         fs::write(&source, b"source").expect("write source");
         fs::write(&dest, b"dest").expect("write dest");
 
-        // Backdate source so it has a distinct mtime from dest
+        // Backdate source so quick-check (matching size+mtime) does not skip it.
         let past = FileTime::from_unix_time(1_600_000_000, 0);
         filetime::set_file_mtime(&source, past).expect("backdate source");
 
-        // Set permissions on source
         let perms = PermissionsExt::from_mode(0o755);
         fs::set_permissions(&source, perms).expect("chmod");
 
         let source_meta = fs::metadata(&source).expect("source metadata");
 
-        // Enable all metadata options
         let mut opts = MetadataOptions::default();
         opts.set_permissions(true);
         opts.set_times(true);
@@ -693,18 +662,15 @@ mod tests {
         opts.set_group(true);
         let mut ctx = BatchMetadataContext::with_options(opts);
 
-        // Apply all metadata
         ctx.apply_file_metadata(&dest, &source_meta)
             .expect("apply metadata");
 
-        // Verify permissions were applied
         let dest_meta = fs::metadata(&dest).expect("dest metadata");
         assert_eq!(
             dest_meta.permissions().mode() & 0o777,
             source_meta.permissions().mode() & 0o777
         );
 
-        // Verify timestamps were applied
         let source_mtime = FileTime::from_last_modification_time(&source_meta);
         let dest_mtime = FileTime::from_last_modification_time(&dest_meta);
         assert_eq!(source_mtime, dest_mtime);

--- a/crates/metadata/src/chmod/comprehensive_tests.rs
+++ b/crates/metadata/src/chmod/comprehensive_tests.rs
@@ -629,7 +629,6 @@ mod apply_mode {
         let file_type = get_file_type(&file_path);
         let modifiers = ChmodModifiers::parse("a+X").expect("parse");
 
-        // File without any execute bit should not get execute bit
         let result = modifiers.apply(0o644, file_type);
         assert_eq!(result & 0o111, 0o000);
     }
@@ -643,7 +642,6 @@ mod apply_mode {
         let file_type = get_file_type(&file_path);
         let modifiers = ChmodModifiers::parse("a+X").expect("parse");
 
-        // File with any execute bit should get all execute bits
         let result = modifiers.apply(0o744, file_type);
         assert_eq!(result & 0o111, 0o111);
     }
@@ -746,7 +744,6 @@ mod apply_mode {
         std::fs::write(&file_path, b"content").expect("write file");
 
         let file_type = get_file_type(&file_path);
-        // First 000, then u+rwx -> should be 700
         let modifiers = ChmodModifiers::parse("000,u+rwx").expect("parse");
 
         let result = modifiers.apply(0o777, file_type);
@@ -760,7 +757,6 @@ mod apply_mode {
         std::fs::write(&file_path, b"content").expect("write file");
 
         let file_type = get_file_type(&file_path);
-        // First 644, then 755 -> should be 755
         let modifiers = ChmodModifiers::parse("644,755").expect("parse");
 
         let result = modifiers.apply(0o000, file_type);
@@ -807,8 +803,6 @@ mod error_cases {
         assert!(result.is_err());
     }
 
-    // Note: assign without permissions (u=) is valid and clears permissions
-
     #[test]
     fn invalid_numeric_non_octal() {
         let result = ChmodModifiers::parse("abc");
@@ -823,46 +817,36 @@ mod upstream_compatibility {
 
     #[test]
     fn rsync_style_directory_only_execute() {
-        // rsync uses D+x to add execute only to directories
         let modifiers = ChmodModifiers::parse("D+x").expect("parse");
         assert!(!modifiers.is_empty());
     }
 
     #[test]
     fn rsync_style_file_protection() {
-        // rsync uses Fgo-w to remove group/other write from files only
         let modifiers = ChmodModifiers::parse("Fgo-w").expect("parse");
         assert!(!modifiers.is_empty());
     }
 
     #[test]
     fn rsync_style_combined_df() {
-        // Common rsync pattern: D755,F644
-        // Directories get 755, files get 644
         let modifiers = ChmodModifiers::parse("D755,F644").expect("parse");
         assert!(!modifiers.is_empty());
     }
 
     #[test]
     fn rsync_style_make_executable_if_readable() {
-        // Common rsync pattern: a+rX
-        // Add read to all, add execute only if already executable or is directory
         let modifiers = ChmodModifiers::parse("a+rX").expect("parse");
         assert!(!modifiers.is_empty());
     }
 
     #[test]
     fn rsync_style_secure_permissions() {
-        // Common security pattern: go=,u=rwX
-        // Clear group/other, set user to rw, add x if needed
         let modifiers = ChmodModifiers::parse("go=,u=rwX").expect("parse");
         assert!(!modifiers.is_empty());
     }
 
     #[test]
     fn rsync_style_web_directory() {
-        // Web directory pattern: D2775,F664
-        // Directories setgid with 775, files 664
         let modifiers = ChmodModifiers::parse("D2775,F664").expect("parse");
         assert!(!modifiers.is_empty());
     }
@@ -885,7 +869,6 @@ mod upstream_compatibility {
 
         let modifiers = ChmodModifiers::parse("Fgo-w").expect("parse");
 
-        // File: 0o666 -> 0o644 (remove g-w and o-w); directory unchanged.
         let file_result = modifiers.apply(0o666, file_type);
         assert_eq!(file_result & 0o777, 0o644);
 
@@ -936,11 +919,11 @@ mod upstream_compatibility {
 
         let modifiers = ChmodModifiers::parse("ugo=rwX").expect("parse");
 
-        // File without execute: should get rw- for all (no X applied)
+        // Capital X applies only when the source already has any exec bit
+        // (or is a directory), so the plain file gets rw- and the dir gets rwx.
         let file_result = modifiers.apply(0o000, file_type);
         assert_eq!(file_result & 0o777, 0o666);
 
-        // Directory: should get rwx for all (X applies)
         let dir_result = modifiers.apply(0o000, dir_type);
         assert_eq!(dir_result & 0o777, 0o777);
     }

--- a/crates/metadata/src/chmod/parse.rs
+++ b/crates/metadata/src/chmod/parse.rs
@@ -346,7 +346,6 @@ mod tests {
 
     #[test]
     fn parse_clause_symbolic_assign_empty_perms() {
-        // "=" with no perms is valid for assign operation
         let clause = parse_clause("u=").unwrap();
         match clause.kind {
             ClauseKind::Symbolic(sym) => {
@@ -399,7 +398,6 @@ mod tests {
 
     #[test]
     fn parse_numeric_clause_invalid_octal() {
-        // 8 and 9 are not valid octal digits
         assert!(parse_numeric_clause("789").is_err());
     }
 
@@ -475,7 +473,7 @@ mod tests {
         let spec = parse_perm_spec("RWX", Operation::Add).unwrap();
         assert!(spec.read);
         assert!(spec.write);
-        // Note: X is conditional exec, not regular exec
+        // Upstream maps capital X to "conditional exec", never plain exec.
         assert!(spec.exec_if_conditional);
     }
 

--- a/crates/metadata/src/permission_tests.rs
+++ b/crates/metadata/src/permission_tests.rs
@@ -115,7 +115,6 @@ mod tests {
 
         apply_file_metadata(&dest, &metadata).expect("apply metadata");
 
-        // Verify we can read the mode even on a 000 file
         let mode = get_mode(&dest) & 0o777;
         assert_eq!(mode, 0o000);
     }
@@ -175,12 +174,8 @@ mod tests {
     fn all_basic_permission_combinations() {
         let temp = tempdir().expect("tempdir");
 
-        // Test a representative sample of permission combinations
         let test_modes = [
-            0o400, 0o200, 0o100, // Individual bits
-            0o640, 0o660, 0o664, // Common patterns
-            0o444, 0o555, 0o666, // All same
-            0o123, 0o321, 0o246, // Varied patterns
+            0o400, 0o200, 0o100, 0o640, 0o660, 0o664, 0o444, 0o555, 0o666, 0o123, 0o321, 0o246,
         ];
 
         for (i, &mode) in test_modes.iter().enumerate() {
@@ -213,13 +208,11 @@ mod tests {
         fs::write(&source, b"test").expect("write source");
         fs::write(&dest, b"test").expect("write dest");
 
-        // Set mode with setuid bit (04755)
         set_mode(&source, 0o4755);
         let metadata = fs::metadata(&source).expect("metadata");
 
         apply_file_metadata(&dest, &metadata).expect("apply metadata");
 
-        // Verify setuid bit is preserved
         assert_eq!(get_mode(&dest) & 0o7777, 0o4755);
         assert_eq!(get_mode(&dest) & 0o4000, 0o4000, "setuid bit not set");
     }
@@ -233,13 +226,11 @@ mod tests {
         fs::write(&source, b"test").expect("write source");
         fs::write(&dest, b"test").expect("write dest");
 
-        // Set mode with setgid bit (02755)
         set_mode(&source, 0o2755);
         let metadata = fs::metadata(&source).expect("metadata");
 
         apply_file_metadata(&dest, &metadata).expect("apply metadata");
 
-        // Verify setgid bit is preserved
         assert_eq!(get_mode(&dest) & 0o7777, 0o2755);
         assert_eq!(get_mode(&dest) & 0o2000, 0o2000, "setgid bit not set");
     }
@@ -253,13 +244,11 @@ mod tests {
         fs::create_dir(&source).expect("create source dir");
         fs::create_dir(&dest).expect("create dest dir");
 
-        // Set mode with sticky bit (01777)
         set_mode(&source, 0o1777);
         let metadata = fs::metadata(&source).expect("metadata");
 
         apply_directory_metadata(&dest, &metadata).expect("apply metadata");
 
-        // Verify sticky bit is preserved
         assert_eq!(get_mode(&dest) & 0o7777, 0o1777);
         assert_eq!(get_mode(&dest) & 0o1000, 0o1000, "sticky bit not set");
     }
@@ -273,13 +262,11 @@ mod tests {
         fs::write(&source, b"test").expect("write source");
         fs::write(&dest, b"test").expect("write dest");
 
-        // Set mode with both setuid and setgid (06755)
         set_mode(&source, 0o6755);
         let metadata = fs::metadata(&source).expect("metadata");
 
         apply_file_metadata(&dest, &metadata).expect("apply metadata");
 
-        // Verify both bits are preserved
         assert_eq!(get_mode(&dest) & 0o7777, 0o6755);
         assert_eq!(get_mode(&dest) & 0o4000, 0o4000, "setuid bit not set");
         assert_eq!(get_mode(&dest) & 0o2000, 0o2000, "setgid bit not set");
@@ -294,13 +281,11 @@ mod tests {
         fs::write(&source, b"test").expect("write source");
         fs::write(&dest, b"test").expect("write dest");
 
-        // Set mode with all special bits (07777)
         set_mode(&source, 0o7777);
         let metadata = fs::metadata(&source).expect("metadata");
 
         apply_file_metadata(&dest, &metadata).expect("apply metadata");
 
-        // Verify all special bits are preserved
         assert_eq!(get_mode(&dest) & 0o7777, 0o7777);
         assert_eq!(get_mode(&dest) & 0o4000, 0o4000, "setuid bit not set");
         assert_eq!(get_mode(&dest) & 0o2000, 0o2000, "setgid bit not set");
@@ -316,7 +301,6 @@ mod tests {
         fs::write(&source, b"test").expect("write source");
         fs::write(&dest, b"test").expect("write dest");
 
-        // Setuid with minimal permissions (04000)
         set_mode(&source, 0o4000);
         let metadata = fs::metadata(&source).expect("metadata");
 
@@ -334,7 +318,7 @@ mod tests {
         fs::create_dir(&source).expect("create source dir");
         fs::create_dir(&dest).expect("create dest dir");
 
-        // Setgid on directory (common for shared directories)
+        // Setgid on a directory makes new entries inherit the directory's group.
         set_mode(&source, 0o2775);
         let metadata = fs::metadata(&source).expect("metadata");
 
@@ -353,15 +337,12 @@ mod tests {
         fs::write(&source, b"test").expect("write source");
         fs::write(&dest, b"test").expect("write dest");
 
-        // Source has no special bits
         set_mode(&source, 0o644);
-        // Dest has all special bits
         set_mode(&dest, 0o7777);
 
         let metadata = fs::metadata(&source).expect("metadata");
         apply_file_metadata(&dest, &metadata).expect("apply metadata");
 
-        // Special bits should be cleared
         assert_eq!(get_mode(&dest) & 0o7777, 0o644);
         assert_eq!(get_mode(&dest) & 0o7000, 0o0000, "special bits not cleared");
     }
@@ -372,7 +353,6 @@ mod tests {
 
         let temp = tempdir().expect("tempdir");
 
-        // Test with different umask values
         let umasks = [0o022, 0o077, 0o002, 0o000, 0o027];
         let test_mode = 0o755;
 
@@ -398,7 +378,6 @@ mod tests {
             // holding the serial slot.
             unsafe { umask(old_umask) };
 
-            // Verify permissions are preserved exactly, regardless of umask
             assert_eq!(
                 get_mode(&dest) & 0o777,
                 test_mode,
@@ -419,7 +398,6 @@ mod tests {
         fs::write(&source, b"test").expect("write source");
         fs::write(&dest, b"test").expect("write dest");
 
-        // Set permissive mode on source
         set_mode(&source, 0o777);
         let metadata = fs::metadata(&source).expect("metadata");
 
@@ -432,7 +410,7 @@ mod tests {
         // holding the serial slot.
         unsafe { umask(old_umask) };
 
-        // Permissions should still be 0o777, not restricted by umask
+        // umask must not narrow permissions copied via chmod; the dest stays 0o777.
         assert_eq!(get_mode(&dest) & 0o777, 0o777);
     }
 
@@ -447,7 +425,6 @@ mod tests {
         fs::write(&source, b"test").expect("write source");
         fs::write(&dest, b"test").expect("write dest");
 
-        // Set restrictive mode on source
         set_mode(&source, 0o600);
         let metadata = fs::metadata(&source).expect("metadata");
 
@@ -460,7 +437,7 @@ mod tests {
         // holding the serial slot.
         unsafe { umask(old_umask) };
 
-        // Permissions should still be 0o600, not expanded by umask
+        // A permissive umask must not widen permissions copied via chmod.
         assert_eq!(get_mode(&dest) & 0o777, 0o600);
     }
 
@@ -487,7 +464,6 @@ mod tests {
         // holding the serial slot.
         unsafe { umask(old_umask) };
 
-        // Special bits should be preserved
         assert_eq!(get_mode(&dest) & 0o7777, 0o6755);
     }
 
@@ -502,19 +478,15 @@ mod tests {
         fs::write(&file2, b"test").expect("write file2");
         fs::write(&file3, b"test").expect("write file3");
 
-        // Set initial mode
         let original_mode = 0o642;
         set_mode(&file1, original_mode);
 
-        // First transfer
         let meta1 = fs::metadata(&file1).expect("metadata 1");
         apply_file_metadata(&file2, &meta1).expect("apply 1");
 
-        // Second transfer
         let meta2 = fs::metadata(&file2).expect("metadata 2");
         apply_file_metadata(&file3, &meta2).expect("apply 2");
 
-        // Verify mode is preserved through both transfers
         assert_eq!(get_mode(&file1) & 0o777, original_mode);
         assert_eq!(get_mode(&file2) & 0o777, original_mode);
         assert_eq!(get_mode(&file3) & 0o777, original_mode);
@@ -531,19 +503,15 @@ mod tests {
         fs::write(&file2, b"test").expect("write file2");
         fs::write(&file3, b"test").expect("write file3");
 
-        // Set mode with all special bits
         let original_mode = 0o7755;
         set_mode(&file1, original_mode);
 
-        // First transfer
         let meta1 = fs::metadata(&file1).expect("metadata 1");
         apply_file_metadata(&file2, &meta1).expect("apply 1");
 
-        // Second transfer
         let meta2 = fs::metadata(&file2).expect("metadata 2");
         apply_file_metadata(&file3, &meta2).expect("apply 2");
 
-        // Verify all bits preserved through both transfers
         assert_eq!(get_mode(&file1) & 0o7777, original_mode);
         assert_eq!(get_mode(&file2) & 0o7777, original_mode);
         assert_eq!(get_mode(&file3) & 0o7777, original_mode);
@@ -553,7 +521,6 @@ mod tests {
     fn round_trip_preserves_all_permission_bits() {
         let temp = tempdir().expect("tempdir");
 
-        // Test multiple permission patterns through round-trip
         let test_modes = [
             0o000, 0o644, 0o755, 0o777, 0o4755, 0o2755, 0o1777, 0o6755, 0o7777,
         ];
@@ -571,7 +538,6 @@ mod tests {
 
             set_mode(&file1, mode);
 
-            // Triple round-trip
             let m1 = fs::metadata(&file1).expect("m1");
             apply_file_metadata(&file2, &m1).expect("a1");
 
@@ -581,7 +547,6 @@ mod tests {
             let m3 = fs::metadata(&file3).expect("m3");
             apply_file_metadata(&file4, &m3).expect("a3");
 
-            // All should have the same mode
             assert_eq!(get_mode(&file1) & 0o7777, mode, "file1 mode mismatch");
             assert_eq!(get_mode(&file2) & 0o7777, mode, "file2 mode mismatch");
             assert_eq!(get_mode(&file3) & 0o7777, mode, "file3 mode mismatch");
@@ -650,7 +615,6 @@ mod tests {
         let metadata = fs::metadata(&source).expect("metadata");
         apply_file_metadata(&dest, &metadata).expect("apply metadata");
 
-        // Should still be correct
         assert_eq!(get_mode(&dest) & 0o777, mode);
     }
 
@@ -681,7 +645,6 @@ mod tests {
         fs::write(&source, b"test").expect("write source");
         fs::write(&dest, b"test").expect("write dest");
 
-        // Set all relevant permission bits
         set_mode(&source, 0o7777);
         let metadata = fs::metadata(&source).expect("metadata");
 
@@ -689,7 +652,6 @@ mod tests {
 
         let mode = get_mode(&dest);
 
-        // Check individual bit groups
         assert_eq!(mode & 0o400, 0o400, "user read");
         assert_eq!(mode & 0o200, 0o200, "user write");
         assert_eq!(mode & 0o100, 0o100, "user execute");
@@ -722,7 +684,6 @@ mod tests {
 
         apply_file_metadata_with_options(&dest, &metadata, &options).expect("apply metadata");
 
-        // Permissions should not change
         assert_eq!(get_mode(&dest) & 0o777, original_dest_mode);
     }
 
@@ -745,7 +706,6 @@ mod tests {
         apply_directory_metadata_with_options(&dest, &metadata, options)
             .expect("apply metadata");
 
-        // Permissions should not change
         assert_eq!(get_mode(&dest) & 0o777, original_dest_mode);
     }
 
@@ -775,7 +735,6 @@ mod tests {
         fs::write(&source, b"test").expect("write source");
         fs::write(&dest, b"test").expect("write dest");
 
-        // Only special bits, no rwx permissions
         set_mode(&source, 0o7000);
         let metadata = fs::metadata(&source).expect("metadata");
 
@@ -788,7 +747,6 @@ mod tests {
     fn odd_permission_combinations() {
         let temp = tempdir().expect("tempdir");
 
-        // Test unusual but valid permission combinations
         let odd_modes = [
             0o1234, // sticky + varied perms
             0o5432, // setuid + sticky + varied

--- a/crates/metadata/src/stat_cache.rs
+++ b/crates/metadata/src/stat_cache.rs
@@ -249,13 +249,11 @@ mod tests {
 
         let mut cache = MetadataCache::new();
 
-        // First fetch should be a miss
         let result1 = cache.get_or_fetch(&path);
         assert!(result1.is_ok());
         assert_eq!(cache.hits(), 0);
         assert_eq!(cache.misses(), 1);
 
-        // Second fetch should be a hit
         let result2 = cache.get_or_fetch(&path);
         assert!(result2.is_ok());
         assert_eq!(cache.hits(), 1);
@@ -272,12 +270,11 @@ mod tests {
 
         let mut cache = MetadataCache::new();
 
-        // Access patterns that should generate specific hit/miss ratios
-        cache.get_or_fetch(&path1).expect("fetch"); // miss
-        cache.get_or_fetch(&path1).expect("fetch"); // hit
-        cache.get_or_fetch(&path1).expect("fetch"); // hit
-        cache.get_or_fetch(&path2).expect("fetch"); // miss
-        cache.get_or_fetch(&path2).expect("fetch"); // hit
+        cache.get_or_fetch(&path1).expect("fetch");
+        cache.get_or_fetch(&path1).expect("fetch");
+        cache.get_or_fetch(&path1).expect("fetch");
+        cache.get_or_fetch(&path2).expect("fetch");
+        cache.get_or_fetch(&path2).expect("fetch");
 
         assert_eq!(cache.hits(), 3);
         assert_eq!(cache.misses(), 2);
@@ -291,14 +288,11 @@ mod tests {
 
         let mut cache = MetadataCache::new();
 
-        // Cache the entry
         cache.get_or_fetch(&path).expect("fetch");
         assert_eq!(cache.misses(), 1);
 
-        // Invalidate
         cache.invalidate(&path);
 
-        // Next fetch should be a miss again
         cache.get_or_fetch(&path).expect("fetch");
         assert_eq!(cache.misses(), 2);
     }
@@ -313,15 +307,12 @@ mod tests {
 
         let mut cache = MetadataCache::new();
 
-        // Cache both entries
         cache.get_or_fetch(&path1).expect("fetch");
         cache.get_or_fetch(&path2).expect("fetch");
         assert_eq!(cache.misses(), 2);
 
-        // Clear cache
         cache.clear();
 
-        // Both should be misses now
         cache.get_or_fetch(&path1).expect("fetch");
         cache.get_or_fetch(&path2).expect("fetch");
         assert_eq!(cache.misses(), 4);
@@ -340,14 +331,12 @@ mod tests {
 
         let mut cache = MetadataCache::new();
 
-        // Fetch all paths once
         for path in &paths {
             cache.get_or_fetch(path).expect("fetch");
         }
         assert_eq!(cache.misses(), 10);
         assert_eq!(cache.hits(), 0);
 
-        // Fetch all paths again - should all be hits
         for path in &paths {
             cache.get_or_fetch(path).expect("fetch");
         }
@@ -402,12 +391,10 @@ mod tests {
 
         let mut cache = MetadataCache::new();
 
-        // First call should miss
         cache.mode_matches(&path, 0o644).expect("mode_matches");
         assert_eq!(cache.misses(), 1);
         assert_eq!(cache.hits(), 0);
 
-        // Second call should hit
         cache.mode_matches(&path, 0o644).expect("mode_matches");
         assert_eq!(cache.misses(), 1);
         assert_eq!(cache.hits(), 1);
@@ -439,7 +426,7 @@ mod tests {
         fs::write(&path, b"content").expect("write");
 
         let mut cache = MetadataCache::new();
-        // Use impossible UIDs that won't match
+        // Use UIDs unlikely to belong to the test process.
         let matches = cache.ownership_matches(&path, 99999, 99999);
         assert!(matches.is_ok());
         assert!(!matches.unwrap());
@@ -459,14 +446,12 @@ mod tests {
 
         let mut cache = MetadataCache::new();
 
-        // First call should miss
         cache
             .ownership_matches(&path, uid, gid)
             .expect("ownership_matches");
         assert_eq!(cache.misses(), 1);
         assert_eq!(cache.hits(), 0);
 
-        // Second call should hit
         cache
             .ownership_matches(&path, uid, gid)
             .expect("ownership_matches");
@@ -518,11 +503,10 @@ mod tests {
     fn get_or_fetch_handles_error_paths() {
         let mut cache = MetadataCache::new();
 
-        // Nonexistent path should return error
         let result = cache.get_or_fetch(Path::new("/nonexistent/xyz/abc"));
         assert!(result.is_err());
 
-        // Should not be cached
+        // Errors must not populate the cache.
         assert_eq!(cache.misses(), 1);
         assert_eq!(cache.hits(), 0);
     }
@@ -570,9 +554,8 @@ mod tests {
         fs::write(&path, b"content").expect("write");
 
         let result = try_statx_optimized(&path);
-        // May not be supported on older kernels
+        // Kernels older than 4.11 return ENOSYS; either branch is acceptable.
         if result.is_ok() || result.as_ref().err().unwrap().raw_os_error() == Some(libc::ENOSYS) {
-            // Success or expected ENOSYS is fine
         } else {
             panic!("Unexpected error: {result:?}");
         }
@@ -593,9 +576,7 @@ mod tests {
             Ok(meta) => {
                 assert_eq!(meta.mode & 0o7777, 0o644);
             }
-            Err(e) if e.raw_os_error() == Some(libc::ENOSYS) => {
-                // statx not available, skip
-            }
+            Err(e) if e.raw_os_error() == Some(libc::ENOSYS) => {}
             Err(e) => panic!("Unexpected error: {e:?}"),
         }
     }
@@ -631,9 +612,7 @@ mod tests {
 
         let result = try_statx_optimized(&dir);
         match result {
-            Ok(_meta) => {
-                // statx succeeded for directory
-            }
+            Ok(_meta) => {}
             Err(e) if e.raw_os_error() == Some(libc::ENOSYS) => {}
             Err(e) => panic!("Unexpected error: {e:?}"),
         }
@@ -648,14 +627,11 @@ mod tests {
         fs::write(&target, b"content").expect("write");
         std::os::unix::fs::symlink(&target, &link).expect("symlink");
 
-        // try_statx_optimized uses SYMLINK_NOFOLLOW, so should follow since
-        // it's called from fetch_metadata_optimized which uses fs::metadata
-        // as fallback (follows symlinks). The statx call itself uses NOFOLLOW.
+        // try_statx_optimized passes SYMLINK_NOFOLLOW, so this stats the link
+        // itself rather than the target.
         let result = try_statx_optimized(&link);
         match result {
-            Ok(_meta) => {
-                // statx succeeded for symlink
-            }
+            Ok(_meta) => {}
             Err(e) if e.raw_os_error() == Some(libc::ENOSYS) => {}
             Err(e) => panic!("Unexpected error: {e:?}"),
         }
@@ -664,14 +640,12 @@ mod tests {
     #[cfg(target_os = "linux")]
     #[test]
     fn statx_enosys_fallback_to_regular_stat() {
-        // Verifies that fetch_metadata_optimized handles ENOSYS gracefully
-        // by falling back to regular stat
         let temp = tempfile::tempdir().expect("tempdir");
         let path = temp.path().join("fallback_test.txt");
         fs::write(&path, b"content").expect("write");
 
-        // fetch_metadata_optimized should always succeed even if statx
-        // returns ENOSYS (it falls back to regular stat)
+        // The optimized fetch must always succeed: on kernels that lack statx
+        // (ENOSYS), the helper falls back to plain stat(2).
         let result = fetch_metadata_optimized(&path);
         assert!(result.is_ok());
     }
@@ -694,7 +668,6 @@ mod tests {
         assert!(result.is_ok());
 
         let meta = result.unwrap();
-        // Just verify we can access readonly attribute
         let _readonly = meta.readonly;
     }
 
@@ -703,7 +676,6 @@ mod tests {
         let temp = tempfile::tempdir().expect("tempdir");
         let mut cache = MetadataCache::with_capacity(1000);
 
-        // Create and cache 1000 files
         for i in 0..1000 {
             let path = temp.path().join(format!("file{i}.txt"));
             fs::write(&path, format!("content{i}")).expect("write");
@@ -713,7 +685,6 @@ mod tests {
         assert_eq!(cache.misses(), 1000);
         assert_eq!(cache.hits(), 0);
 
-        // Access random entries - should all hit
         for i in (0..1000).step_by(17) {
             let path = temp.path().join(format!("file{i}.txt"));
             cache.get_or_fetch(&path).expect("fetch");
@@ -727,7 +698,6 @@ mod tests {
         let mut cache = MetadataCache::new();
         let path = PathBuf::from("/this/path/does/not/exist");
 
-        // Should not panic
         cache.invalidate(&path);
     }
 
@@ -741,7 +711,6 @@ mod tests {
         let result = cache.get_or_fetch(&path);
         assert!(result.is_ok());
 
-        // Unicode path
         let unicode_path = temp.path().join("файл.txt");
         fs::write(&unicode_path, b"content").expect("write");
         let result = cache.get_or_fetch(&unicode_path);


### PR DESCRIPTION
## Summary

- Strip restatement, decorative, and outdated comments from the metadata crate (apply, apply_batch, chmod, stat_cache, acl_exacl tests, permission_tests).
- Preserve every upstream rsync cite, SAFETY block, and meaningful WHY note (fake-super xattr layout, umask test concurrency, statx ENOSYS fallback, setgid-on-directory semantics).
- No API or behaviour changes.

## Scope

Touched submodules: `apply/`, `apply_batch.rs`, `chmod/`, `stat_cache.rs`, `acl_exacl/tests.rs`, `permission_tests.rs`. The audit also walked `id_lookup/`, `mapping/`, `options/`, `acl_windows/`, `acl_noop.rs`, `acl_stub.rs`, `copy_as.rs`, `ownership.rs`, `special.rs`, `symlink_munge.rs`, `nfsv4_acl.rs`, and `nfsv4_acl_stub.rs` and confirmed they were already clean.

**Excluded:** `crates/metadata/src/xattr*.rs` and `crates/metadata/src/fake_super.rs`, to avoid merge conflicts with in-flight xattr namespace work (#4592 and follow-ups).

## Diff size

6 files changed, 40 insertions(+), 171 deletions(-).

## Test plan

- [ ] `cargo fmt --all --check`
- [ ] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings`
- [ ] Full nextest matrix in CI