### PR TITLE
test(matching): add ZSO-1 acceptance tests for bithash prefilter

### DIFF
--- a/crates/matching/src/index/bithash_tests.rs
+++ b/crates/matching/src/index/bithash_tests.rs
@@ -128,3 +128,101 @@ proptest! {
         }
     }
 }
+
+/// Deterministic linear congruential generator for the rejection-rate test.
+///
+/// Avoids pulling `rand` into the dev dependencies while still spreading rsums
+/// uniformly enough to exercise the bithash density bound. Numbers are the
+/// constants from Numerical Recipes' `ran` generator.
+fn lcg_next(state: &mut u64) -> u32 {
+    *state = state.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+    (*state >> 16) as u32
+}
+
+#[test]
+fn bithash_rejects_at_least_seven_eighths_of_known_misses() {
+    // ZSO-1 acceptance test: with N inserted rsums and 8N bithash bits, the
+    // 1/8 saturation density means ~7/8 of uniform-random probes that were
+    // never inserted should reject at the bithash gate.
+    let n_blocks = 1000usize;
+    let mut bh = BitHash::with_block_count(n_blocks);
+
+    // Build the inserted set deterministically.
+    let mut inserted = std::collections::HashSet::with_capacity(n_blocks);
+    let mut rng = 0xC0FFEE_u64;
+    while inserted.len() < n_blocks {
+        let rsum = lcg_next(&mut rng);
+        if inserted.insert(rsum) {
+            bh.insert(rsum);
+        }
+    }
+
+    // Generate N known-miss probes drawn from a disjoint stream and count
+    // bithash-stage rejections.
+    let mut probe_rng = 0xDEAD_BEEF_CAFE_u64;
+    let mut probes = 0usize;
+    let mut rejects = 0usize;
+    while probes < n_blocks {
+        let rsum = lcg_next(&mut probe_rng);
+        if inserted.contains(&rsum) {
+            continue;
+        }
+        probes += 1;
+        if !bh.contains(rsum) {
+            rejects += 1;
+        }
+    }
+
+    let reject_rate = rejects as f64 / probes as f64;
+    assert!(
+        reject_rate >= 0.87,
+        "bithash rejected only {rejects}/{probes} = {reject_rate:.3} of known misses; \
+         expected at least 7/8 = 0.875 per zsync density bound",
+    );
+}
+
+#[test]
+fn bithash_state_does_not_leak_between_independent_indexes() {
+    // ZSO-1 acceptance test: two `DeltaSignatureIndex` values built from
+    // distinct basis bytes must hold independent bithash state. Per the
+    // ZSO-7 audit, the per-NDX construction discards prior state, so no
+    // INC_RECURSE segment can see another segment's matched blocks via the
+    // bithash gate.
+    let mut left_basis = vec![0u8; (TEST_BLOCK_LENGTH * 4) as usize];
+    for (i, byte) in left_basis.iter_mut().enumerate() {
+        *byte = (i as u8).wrapping_mul(31).wrapping_add(7);
+    }
+    let mut right_basis = vec![0u8; (TEST_BLOCK_LENGTH * 4) as usize];
+    for (i, byte) in right_basis.iter_mut().enumerate() {
+        *byte = (i as u8).wrapping_mul(53).wrapping_add(199);
+    }
+    assert_ne!(left_basis, right_basis);
+
+    let left = build_index(&left_basis).expect("left index");
+    let right = build_index(&right_basis).expect("right index");
+
+    // For every block indexed in `left`, the matching probe MUST succeed in
+    // `left`. The same probe MUST NOT find a match in `right` (the random
+    // bases are distinct), confirming the bithash is per-index and not a
+    // shared singleton.
+    let block_length = left.block_length();
+    let n_full = left_basis.len() / block_length;
+    let mut cross_matches = 0usize;
+    for i in 0..n_full {
+        let start = i * block_length;
+        let window = &left_basis[start..start + block_length];
+        let digest = left.block(i).rolling();
+        assert!(
+            left.find_match_bytes(digest, window).is_some(),
+            "left index dropped its own block {i}",
+        );
+        if right.find_match_bytes(digest, window).is_some() {
+            cross_matches += 1;
+        }
+    }
+    assert_eq!(
+        cross_matches, 0,
+        "right index spuriously matched {cross_matches} left blocks; \
+         bithash or lookup state leaked across indexes",
+    );
+}


### PR DESCRIPTION
## Summary

Adds the two ZSO-1 acceptance tests that complement the bithash prefilter implementation already merged via PR #3737. The production code (insert at index build, probe before the `CompactLookup` walk, clear on rebuild) is in place on master; this PR pins the acceptance contract from the ZSO-1 brief in unit tests so future refactors can't silently regress the prefilter behaviour.

- `bithash_rejects_at_least_seven_eighths_of_known_misses` — builds a filter with N=1000 inserted rsums and probes with N=1000 disjoint known-miss rsums, asserting at least 87% reject at the bithash gate. Measured rate locally: 97.2%, comfortably above the 7/8 zsync density bound.
- `bithash_state_does_not_leak_between_independent_indexes` — builds two `DeltaSignatureIndex` values from distinct basis bytes and confirms a probe for blocks indexed in one never matches in the other, pinning the per-NDX lifecycle relied on by the ZSO-7 audit at `docs/audits/zso-7-inc-recurse-per-segment-state-2026-05-21.md`.

## Background

ZSO-1 (#2509) is the first of four zsync-inspired in-memory speedups for the matching pipeline. The bithash prefilter is a one-sided, 8x-oversized bit array probed between the `tag_table[sum1]` gate and the `CompactLookup` walk in `find_match_*`. It rejects ~7/8 of post-tag misses in O(1) using the full 32-bit rolling sum, all without touching the wire format.

Production sites verified against the audit citations:

- Field on `DeltaSignatureIndex` at `crates/matching/src/index/mod.rs:70`
- Probe sites at `crates/matching/src/index/mod.rs:155` (`find_match_bytes_filtered`) and `:211` (`find_match_slices_filtered`)
- Insert + clear wired through `populate_index` and `rebuild` in `crates/matching/src/index/builder.rs:32,127`

The line numbers cited in the ZSO-1 brief have drifted slightly since the audit (the field sits at `mod.rs:70`, not `:44`; probes are at `:155`/`:211`, not `:165`; clear is at `builder.rs:127` as cited). Behaviour matches the design exactly.

## Wire-byte parity

No protocol or serialisation surface is touched. `cargo nextest run -p protocol --all-features -E 'test(golden)'` passes unchanged (407 tests).

## Acknowledgement

Bithash design follows zsync 0.6.2 `librcksum` (Colin Phipps, http://zsync.moria.org.uk/), per the README acknowledgement landed in PR #4597.

## Test plan

- [x] `cargo nextest run -p matching --all-features` — 320 tests pass.
- [x] `cargo nextest run -p protocol --all-features -E 'test(golden)'` — 407 tests pass, no golden-byte drift.
- [x] `cargo fmt --all -- --check` — clean.
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` — clean.