### PR TITLE
feat(match): zsync-inspired sequential-match lookahead (ZSO-2)

### DIFF
--- a/crates/matching/src/generator.rs
+++ b/crates/matching/src/generator.rs
@@ -156,9 +156,12 @@ impl DeltaGenerator {
         let mut matches = 0u64;
         let mut offset = 0u64;
 
-        // upstream: match.c - want_i tracks the expected next block index for
-        // adjacent-match hinting. After a match at block i, the next match
-        // is likely at block i+1. Checking this hint before the hash table
+        // upstream: match.c - `want_i` tracks the expected next block index
+        // for adjacent-match hinting. After a confirmed match at block `i`,
+        // the next match is most often at `index.next_match(i)`: zsync's
+        // librcksum/rsum.c:262 maintains the same lookahead slot. Seeding
+        // with `Some(0)` covers the start-of-file case where block 0 is the
+        // most likely first match. Probing the hint before the hash table
         // lookup skips the probe entirely when data is sequential.
         let mut want_i: Option<usize> = Some(0);
 
@@ -334,11 +337,12 @@ impl DeltaGenerator {
                     // this basis index again.
                     matched_blocks.mark_matched(match_idx);
 
-                    want_i = if match_idx + 1 < index.block_count() {
-                        Some(match_idx + 1)
-                    } else {
-                        None
-                    };
+                    let last_matched = match_idx;
+                    // upstream/zsync: `librcksum/rsum.c:262` advances the
+                    // lookahead slot to the indexed successor. The basis can
+                    // re-order or skip partial blocks, so consult the index
+                    // rather than assuming `match_idx + 1`.
+                    want_i = index.next_match(last_matched);
 
                     window.clear();
                     rolling.reset();
@@ -374,17 +378,18 @@ impl DeltaGenerator {
 
                     // upstream: match.c:144-190 - try want_i hint at the next
                     // block boundary before falling back to a hash probe.
+                    // The probe uses the index's recorded
+                    // [`DeltaSignatureIndex::next_match`] link so a stored
+                    // successor that diverges from `last_matched + 1` is
+                    // still followed.
                     let adj_digest = rolling.digest();
                     let (f, s) = window.as_slices();
                     let adj_match = {
                         let adj_filter = prune_matched.then_some(&matched_blocks);
-                        if let Some(hint) = want_i {
-                            if index.check_block_match_slices(hint, adj_digest, f, s) {
-                                Some(hint)
-                            } else {
-                                hash_hits += 1;
-                                index.find_match_slices_filtered(adj_digest, f, s, adj_filter)
-                            }
+                        if let Some(next_idx) =
+                            index.try_next_match_slices(last_matched, adj_digest, f, s)
+                        {
+                            Some(next_idx)
                         } else {
                             hash_hits += 1;
                             index.find_match_slices_filtered(adj_digest, f, s, adj_filter)

--- a/crates/matching/src/index/builder.rs
+++ b/crates/matching/src/index/builder.rs
@@ -8,10 +8,16 @@ use signature::{FileSignature, SignatureAlgorithm, SignatureBlock};
 
 use super::compact_lookup::CompactLookup;
 use super::trace::{HashtableRole, trace_created, trace_growing};
-use super::{BitHash, DeltaSignatureIndex, TAG_TABLE_SIZE};
+use super::{BitHash, DeltaSignatureIndex, NEXT_MATCH_NONE, TAG_TABLE_SIZE};
 
 /// Shared helper that indexes full-length blocks into the tag table, bithash,
-/// and compact lookup table.
+/// compact lookup table, and sequential-match successor links.
+///
+/// The successor link table is written in a single pass: while walking the
+/// block list in order we remember the index of the previous full-length
+/// block and patch its slot once a successor appears. Partial-length blocks
+/// break the chain (they are not indexed and never become successors), which
+/// preserves wire compatibility under trailing-partial-block layouts.
 ///
 /// Returns `true` if at least one full-length block was indexed.
 fn populate_index(
@@ -20,8 +26,10 @@ fn populate_index(
     tag_table: &mut [bool],
     bithash: &mut BitHash,
     lookup: &mut CompactLookup,
+    next_match: &mut [u32],
 ) -> bool {
     let mut has_full_blocks = false;
+    let mut prev_full: Option<usize> = None;
     for (index, block) in blocks.iter().enumerate() {
         if block.len() != block_length {
             continue;
@@ -31,6 +39,12 @@ fn populate_index(
         tag_table[digest.sum1() as usize] = true;
         bithash.insert(digest.value());
         lookup.insert(digest.sum1(), digest.sum2(), index as u32);
+        if let Some(prev) = prev_full {
+            // upstream: zsync `librcksum/rsum.c:262` records the
+            // immediately-following block as the next-match candidate.
+            next_match[prev] = index as u32;
+        }
+        prev_full = Some(index);
     }
     has_full_blocks
 }
@@ -74,6 +88,10 @@ impl DeltaSignatureIndex {
         let mut lookup = CompactLookup::with_capacity(requested);
         let mut tag_table = vec![false; TAG_TABLE_SIZE];
         let mut bithash = BitHash::with_block_count(requested);
+        // The seq-match link table holds one slot per signature block, sized
+        // to the raw signature length (including any trailing partial block)
+        // so `next_match[K]` is addressable for every K the lookup can yield.
+        let mut next_match = vec![NEXT_MATCH_NONE; requested];
 
         if !populate_index(
             &blocks,
@@ -81,6 +99,7 @@ impl DeltaSignatureIndex {
             &mut tag_table,
             &mut bithash,
             &mut lookup,
+            &mut next_match,
         ) {
             return None;
         }
@@ -94,8 +113,11 @@ impl DeltaSignatureIndex {
             lookup,
             tag_table,
             bithash,
+            next_match,
             role,
             last_traced_size: size,
+            #[cfg(any(test, feature = "bench-internal"))]
+            seq_match_counters: std::sync::Arc::new(super::SeqMatchCounters::default()),
         };
         // upstream: hashtable.c:45-53 - one HASH,1 emission per hashtable
         // creation, with optional `req:` prefix when the rounded-up size
@@ -125,6 +147,13 @@ impl DeltaSignatureIndex {
         self.lookup.clear();
         self.tag_table.iter_mut().for_each(|v| *v = false);
         self.bithash.clear();
+        // Per ZSO-7 isolation: every link from the prior segment must be
+        // cleared before re-population so a stale successor never leaks
+        // across the per-NDX `rebuild` boundary.
+        self.next_match.clear();
+        self.next_match.resize(self.blocks.len(), NEXT_MATCH_NONE);
+        #[cfg(any(test, feature = "bench-internal"))]
+        self.seq_match_counters.reset();
 
         let ok = populate_index(
             &self.blocks,
@@ -132,6 +161,7 @@ impl DeltaSignatureIndex {
             &mut self.tag_table,
             &mut self.bithash,
             &mut self.lookup,
+            &mut self.next_match,
         );
 
         if ok {

--- a/crates/matching/src/index/mod.rs
+++ b/crates/matching/src/index/mod.rs
@@ -19,6 +19,8 @@ mod bithash_tests;
 #[cfg(test)]
 mod matched_blocks_tests;
 #[cfg(test)]
+mod seq_match_tests;
+#[cfg(test)]
 mod sparse_match_tests;
 #[cfg(test)]
 mod tests;
@@ -44,6 +46,14 @@ pub use trace::{
 /// table. This constant matches upstream's `TABLESIZE` in `match.c`.
 const TAG_TABLE_SIZE: usize = 1 << 16;
 
+/// Sentinel marking the absence of a stored successor in [`DeltaSignatureIndex::next_match`].
+///
+/// The link table stores `u32` block indices; `u32::MAX` is reserved to mean
+/// "no successor" without paying a `Vec<Option<u32>>` discriminant. Real basis
+/// block counts never reach `u32::MAX` because the wire-format block index is
+/// itself a `u32` and one slot is consumed by the sentinel.
+const NEXT_MATCH_NONE: u32 = u32::MAX;
+
 /// Index over a file signature that accelerates delta matching.
 ///
 /// Uses a flat open-addressing hash table ([`CompactLookup`]) keyed by packed
@@ -68,12 +78,76 @@ pub struct DeltaSignatureIndex {
     /// the bithash rejects ~7/8 of post-tag misses before the hash probe.
     /// Mirrors zsync's `librcksum/rsum.c:362-366` probe expression.
     bithash: BitHash,
+    /// Sequential-match lookahead: `next_match[k]` is the block index that
+    /// followed block `k` in source-file order during indexing, or
+    /// [`NEXT_MATCH_NONE`] when block `k` has no full-length successor.
+    ///
+    /// Lets the matcher skip the rolling-rsum table lookup when a confirmed
+    /// match at block `K` was already followed by a confirmed match at the
+    /// linked successor in the basis. Mirrors zsync's `next_match` slot from
+    /// `librcksum/rsum.c:262` while preserving wire-format bytes - the field
+    /// is in-memory only and is cleared by [`Self::rebuild`] so per-segment
+    /// INC_RECURSE indexes never inherit stale links.
+    next_match: Vec<u32>,
     /// Role used for `--debug=HASH` `[<role>]` prefixes on the create,
     /// grow, and destroy lifecycle emissions. Mirrors upstream
     /// `who_am_i()` (`hashtable.c:51,61,101`).
     role: HashtableRole,
     /// Slot count tracked across rebuilds for the matching destroy emission.
     last_traced_size: usize,
+    /// Test-only seq-match probe counters. Wrapped in `Arc<...>` so the
+    /// [`Clone`] derive shares the counter across handles, which is what
+    /// the per-segment isolation tests need to assert. Production builds
+    /// skip the field entirely so the hot path carries zero overhead.
+    #[cfg(any(test, feature = "bench-internal"))]
+    seq_match_counters: std::sync::Arc<SeqMatchCounters>,
+}
+
+/// Test-only seq-match probe counters.
+///
+/// Three atomic counters cover the lookahead state machine:
+///
+/// - `probes`: every call into a `try_next_match_*` entry point.
+/// - `hits`: probes whose strong-checksum verify confirmed the linked successor.
+/// - `misses`: probes that fell through to the full rolling-rsum lookup.
+///
+/// The split lets the per-segment isolation test assert that the counters
+/// reset cleanly across [`DeltaSignatureIndex::rebuild`].
+#[cfg(any(test, feature = "bench-internal"))]
+#[derive(Debug, Default)]
+pub struct SeqMatchCounters {
+    probes: std::sync::atomic::AtomicU64,
+    hits: std::sync::atomic::AtomicU64,
+    misses: std::sync::atomic::AtomicU64,
+}
+
+#[cfg(any(test, feature = "bench-internal"))]
+impl SeqMatchCounters {
+    /// Returns the total number of [`DeltaSignatureIndex::try_next_match_slices`]
+    /// (and contiguous-bytes equivalent) calls observed since the last reset.
+    #[must_use]
+    pub fn probes(&self) -> u64 {
+        self.probes.load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// Returns the number of probes that confirmed the linked successor.
+    #[must_use]
+    pub fn hits(&self) -> u64 {
+        self.hits.load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// Returns the number of probes that fell through to the full lookup.
+    #[must_use]
+    pub fn misses(&self) -> u64 {
+        self.misses.load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// Clears every counter back to zero.
+    pub fn reset(&self) {
+        self.probes.store(0, std::sync::atomic::Ordering::Relaxed);
+        self.hits.store(0, std::sync::atomic::Ordering::Relaxed);
+        self.misses.store(0, std::sync::atomic::Ordering::Relaxed);
+    }
 }
 
 impl DeltaSignatureIndex {
@@ -114,6 +188,156 @@ impl DeltaSignatureIndex {
     #[must_use]
     pub fn block(&self, index: usize) -> &SignatureBlock {
         &self.blocks[index]
+    }
+
+    /// Returns the sequential-match successor recorded for `block_index`, if any.
+    ///
+    /// The successor is the basis block that immediately followed
+    /// `block_index` in source-file order during indexing. Source-sequential
+    /// targets typically match the successor at the very next window offset,
+    /// so callers can probe the successor directly via
+    /// [`Self::try_next_match_slices`] and skip the rolling-rsum table
+    /// lookup on the common path.
+    ///
+    /// Returns `None` for the trailing block, for any block index past the
+    /// end of the basis, and for non-full-length blocks that were not
+    /// linked during construction.
+    ///
+    /// upstream: zsync `librcksum/rsum.c:262` populates an equivalent
+    /// `next_match` slot after every confirmed match.
+    #[inline]
+    #[must_use]
+    pub fn next_match(&self, block_index: usize) -> Option<usize> {
+        let raw = *self.next_match.get(block_index)?;
+        if raw == NEXT_MATCH_NONE {
+            None
+        } else {
+            Some(raw as usize)
+        }
+    }
+
+    /// Probes the sequential-match successor of `last_match` against a
+    /// contiguous target window without consulting the tag table, bithash,
+    /// or compact lookup.
+    ///
+    /// Returns `Some(successor)` when the linked successor exists and its
+    /// strong checksum matches `window`. Returns `None` when there is no
+    /// recorded successor, the digest's `(sum1, sum2)` disagrees with the
+    /// stored block, or the strong checksum verify fails. Callers MUST fall
+    /// back to [`Self::find_match_bytes_filtered`] on a miss.
+    ///
+    /// The rolling-checksum prefilter is a cheap two-word compare against
+    /// the linked block's stored digest, so a miss here costs the same as
+    /// the existing `want_i` hint check in `match.c:144-190`.
+    #[inline]
+    pub fn try_next_match_bytes(
+        &self,
+        last_match: usize,
+        digest: RollingDigest,
+        window: &[u8],
+    ) -> Option<usize> {
+        let next = self.next_match(last_match)?;
+
+        #[cfg(any(test, feature = "bench-internal"))]
+        self.seq_match_counters
+            .probes
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+
+        if window.len() != self.block_length {
+            #[cfg(any(test, feature = "bench-internal"))]
+            self.seq_match_counters
+                .misses
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            return None;
+        }
+        let block = &self.blocks[next];
+        let block_digest = block.rolling();
+        if digest.sum1() != block_digest.sum1() || digest.sum2() != block_digest.sum2() {
+            #[cfg(any(test, feature = "bench-internal"))]
+            self.seq_match_counters
+                .misses
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            return None;
+        }
+        let strong = self.algorithm.compute_truncated(window, self.strong_length);
+        if strong.as_slice() == block.strong() {
+            #[cfg(any(test, feature = "bench-internal"))]
+            self.seq_match_counters
+                .hits
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            Some(next)
+        } else {
+            #[cfg(any(test, feature = "bench-internal"))]
+            self.seq_match_counters
+                .misses
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            None
+        }
+    }
+
+    /// Probes the sequential-match successor of `last_match` against a
+    /// non-contiguous target window represented as two slices.
+    ///
+    /// Mirrors [`Self::try_next_match_bytes`] for the ring-buffer split
+    /// form used by the generator.
+    #[inline]
+    pub fn try_next_match_slices(
+        &self,
+        last_match: usize,
+        digest: RollingDigest,
+        first: &[u8],
+        second: &[u8],
+    ) -> Option<usize> {
+        let next = self.next_match(last_match)?;
+
+        #[cfg(any(test, feature = "bench-internal"))]
+        self.seq_match_counters
+            .probes
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+
+        if first.len() + second.len() != self.block_length {
+            #[cfg(any(test, feature = "bench-internal"))]
+            self.seq_match_counters
+                .misses
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            return None;
+        }
+        let block = &self.blocks[next];
+        let block_digest = block.rolling();
+        if digest.sum1() != block_digest.sum1() || digest.sum2() != block_digest.sum2() {
+            #[cfg(any(test, feature = "bench-internal"))]
+            self.seq_match_counters
+                .misses
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            return None;
+        }
+        let strong = self
+            .algorithm
+            .compute_truncated_slices(first, second, self.strong_length);
+        if strong.as_slice() == block.strong() {
+            #[cfg(any(test, feature = "bench-internal"))]
+            self.seq_match_counters
+                .hits
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            Some(next)
+        } else {
+            #[cfg(any(test, feature = "bench-internal"))]
+            self.seq_match_counters
+                .misses
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            None
+        }
+    }
+
+    /// Returns a shared handle to the test-only seq-match probe counters.
+    ///
+    /// Behind the same `cfg(any(test, feature = "bench-internal"))` gate
+    /// that gates the counters themselves, so release builds never expose
+    /// the accessor.
+    #[cfg(any(test, feature = "bench-internal"))]
+    #[must_use]
+    pub fn seq_match_counters(&self) -> std::sync::Arc<SeqMatchCounters> {
+        std::sync::Arc::clone(&self.seq_match_counters)
     }
 
     /// Attempts to locate a matching block for a contiguous byte slice.

--- a/crates/matching/src/index/seq_match_tests.rs
+++ b/crates/matching/src/index/seq_match_tests.rs
@@ -1,0 +1,383 @@
+//! Tests for the zsync-inspired sequential-match lookahead (ZSO-2).
+//!
+//! Pins the contracts in `docs/design/zsync-seq-match.md` (and the parent
+//! initiative `project_zsync_optimizations.md`):
+//!
+//! - [`super::DeltaSignatureIndex::next_match`] links each indexed block to
+//!   its source-order successor and is the sole carrier of the lookahead
+//!   relationship - never `match_idx + 1` directly.
+//! - [`super::DeltaSignatureIndex::try_next_match_bytes`] and the slices
+//!   counterpart honour the recorded successor, accept matches that pass
+//!   the strong-checksum verify, and reject everything else.
+//! - The generator's chain loop drives the lookahead via the new probe API,
+//!   so consecutive sequential basis blocks become hits and a diverging
+//!   target falls through to the existing full-lookup path.
+//! - The link table and the test-only counters reset across
+//!   [`super::DeltaSignatureIndex::rebuild`], the per-segment ZSO-7
+//!   isolation invariant. The hand-rolled assertion mirrors the bithash
+//!   leak test in `bithash_tests.rs` so a regression on one structure
+//!   surfaces alongside the other.
+
+use std::io::Cursor;
+use std::num::{NonZeroU8, NonZeroU32};
+
+use checksums::RollingDigest;
+use proptest::prelude::*;
+
+use protocol::ProtocolVersion;
+use signature::{
+    SignatureAlgorithm, SignatureLayoutParams, calculate_signature_layout, generate_file_signature,
+};
+
+use super::DeltaSignatureIndex;
+use crate::generator::DeltaGenerator;
+use crate::script::{DeltaToken, apply_delta};
+
+/// Block length used by every fixture so the basis always produces
+/// full-length blocks; partial trailing blocks are exercised by the
+/// dedicated regression below.
+const TEST_BLOCK_LENGTH: u32 = 512;
+
+/// Strong-checksum length used by every fixture. Matches the value in
+/// `tests.rs` so the layout knobs stay aligned.
+const TEST_STRONG_LEN: u8 = 16;
+
+/// Convenience: build a `DeltaSignatureIndex` over `basis` with the test's
+/// fixed block layout. Returns `None` when the basis cannot produce a full
+/// block, which the call sites bound out by construction.
+fn build_index(basis: &[u8]) -> Option<DeltaSignatureIndex> {
+    let params = SignatureLayoutParams::new(
+        basis.len() as u64,
+        Some(NonZeroU32::new(TEST_BLOCK_LENGTH).unwrap()),
+        ProtocolVersion::NEWEST,
+        NonZeroU8::new(TEST_STRONG_LEN).unwrap(),
+    );
+    let layout = calculate_signature_layout(params).ok()?;
+    let signature = generate_file_signature(basis, layout, SignatureAlgorithm::Md4).ok()?;
+    DeltaSignatureIndex::from_signature(&signature, SignatureAlgorithm::Md4)
+}
+
+/// Distinct-content basis: each block is filled with a per-block seed so
+/// no two basis blocks share strong-checksum content. Lets the seq-match
+/// tests assert exact link-following behaviour without duplicate-bucket
+/// noise.
+fn distinct_basis(n_blocks: usize) -> Vec<u8> {
+    let block_len = TEST_BLOCK_LENGTH as usize;
+    let mut basis = Vec::with_capacity(n_blocks * block_len);
+    for k in 0..n_blocks {
+        let seed = (k as u8).wrapping_mul(31).wrapping_add(7);
+        for j in 0..block_len {
+            basis.push(seed.wrapping_add((j as u8).wrapping_mul(17)));
+        }
+    }
+    basis
+}
+
+/// `next_match[K]` is `Some(K+1)` for every full-length block except the
+/// last, which has no recorded successor.
+#[test]
+fn next_match_chains_sequential_blocks() {
+    let basis = distinct_basis(6);
+    let index = build_index(&basis).expect("index from sequential basis");
+    let last = index.block_count() - 1;
+    for k in 0..last {
+        assert_eq!(
+            index.next_match(k),
+            Some(k + 1),
+            "next_match[{k}] must point at the immediate successor"
+        );
+    }
+    assert_eq!(
+        index.next_match(last),
+        None,
+        "the tail block must terminate the chain"
+    );
+}
+
+/// `next_match` is `None` for out-of-range indices, mirroring the
+/// `block(...)` panic-free contract documented on the public API.
+#[test]
+fn next_match_out_of_range_returns_none() {
+    let basis = distinct_basis(3);
+    let index = build_index(&basis).expect("index");
+    assert_eq!(index.next_match(index.block_count()), None);
+    assert_eq!(index.next_match(usize::MAX), None);
+}
+
+/// `try_next_match_bytes` confirms the linked successor when the strong
+/// checksum agrees, bypassing the full rolling-hash lookup. Counter:
+/// one probe, one hit, zero misses.
+#[test]
+fn try_next_match_bytes_hits_linked_successor() {
+    let basis = distinct_basis(4);
+    let index = build_index(&basis).expect("index");
+    let block_len = index.block_length();
+    let counters = index.seq_match_counters();
+    counters.reset();
+
+    let window = &basis[block_len..2 * block_len];
+    let digest = index.block(1).rolling();
+    let found = index.try_next_match_bytes(0, digest, window);
+    assert_eq!(found, Some(1), "linked successor must be returned");
+    assert_eq!(counters.probes(), 1);
+    assert_eq!(counters.hits(), 1);
+    assert_eq!(counters.misses(), 0);
+}
+
+/// A successor probe with the wrong window misses on the strong checksum
+/// and counts as a miss. The full lookup remains the safety net.
+#[test]
+fn try_next_match_bytes_misses_on_wrong_window() {
+    let basis = distinct_basis(4);
+    let index = build_index(&basis).expect("index");
+    let block_len = index.block_length();
+    let counters = index.seq_match_counters();
+    counters.reset();
+
+    let mut window = basis[block_len..2 * block_len].to_vec();
+    // Force a strong-checksum mismatch while leaving the rolling sum alone
+    // when the rolling sum happens to round-trip; we explicitly construct
+    // the digest from the corrupted window to skip the rolling fast-path
+    // rejection and prove the strong-checksum gate fires.
+    window[0] ^= 0xAA;
+    let digest = RollingDigest::from_bytes(&window);
+    let found = index.try_next_match_bytes(0, digest, &window);
+    assert_eq!(found, None, "corrupted window must not pass strong verify");
+    assert_eq!(counters.probes(), 1);
+    assert_eq!(counters.hits(), 0);
+    assert_eq!(counters.misses(), 1);
+}
+
+/// Probing with `last_match` at the tail produces no probe at all: there is
+/// nothing to look up, so the counters stay at zero.
+#[test]
+fn try_next_match_bytes_tail_block_skips_probe() {
+    let basis = distinct_basis(4);
+    let index = build_index(&basis).expect("index");
+    let block_len = index.block_length();
+    let last = index.block_count() - 1;
+    let counters = index.seq_match_counters();
+    counters.reset();
+
+    let window = &basis[..block_len];
+    let digest = index.block(0).rolling();
+    let found = index.try_next_match_bytes(last, digest, window);
+    assert_eq!(found, None);
+    assert_eq!(counters.probes(), 0);
+    assert_eq!(counters.hits(), 0);
+    assert_eq!(counters.misses(), 0);
+}
+
+/// Slices probe mirrors the contiguous probe and accepts split windows
+/// straight from a ring buffer.
+#[test]
+fn try_next_match_slices_handles_split_window() {
+    let basis = distinct_basis(4);
+    let index = build_index(&basis).expect("index");
+    let block_len = index.block_length();
+    let counters = index.seq_match_counters();
+    counters.reset();
+
+    let window = &basis[block_len..2 * block_len];
+    let split = block_len / 3;
+    let (first, second) = window.split_at(split);
+    let digest = index.block(1).rolling();
+    let found = index.try_next_match_slices(0, digest, first, second);
+    assert_eq!(found, Some(1));
+    assert_eq!(counters.hits(), 1);
+}
+
+/// Slices probe rejects windows whose combined length is wrong without
+/// touching the strong checksum, counted as a miss.
+#[test]
+fn try_next_match_slices_wrong_length_misses() {
+    let basis = distinct_basis(4);
+    let index = build_index(&basis).expect("index");
+    let counters = index.seq_match_counters();
+    counters.reset();
+
+    let digest = index.block(1).rolling();
+    let found = index.try_next_match_slices(0, digest, &[], &[]);
+    assert_eq!(found, None);
+    assert_eq!(counters.probes(), 1);
+    assert_eq!(counters.hits(), 0);
+    assert_eq!(counters.misses(), 1);
+}
+
+/// End-to-end: when the source is the basis verbatim, the generator's
+/// chain loop drives the lookahead probe at every adjacent boundary. The
+/// counter must show one hit per inner-chain transition (block_count - 1
+/// transitions across one contiguous chain run).
+#[test]
+fn seq_match_hits_consecutive_blocks() {
+    let basis = distinct_basis(6);
+    let index = build_index(&basis).expect("index");
+    let counters = index.seq_match_counters();
+    counters.reset();
+    let generator = DeltaGenerator::new();
+    let script = generator
+        .generate(Cursor::new(basis.clone()), &index)
+        .expect("script");
+
+    // Round-trip: the script must reproduce the basis byte-for-byte.
+    let mut basis_cursor = Cursor::new(basis.clone());
+    let mut output = Vec::new();
+    apply_delta(&mut basis_cursor, &mut output, &index, &script).expect("apply");
+    assert_eq!(output, basis);
+
+    // Every match after the first lands through the seq-match probe.
+    let expected_probes = (index.block_count() as u64) - 1;
+    assert_eq!(
+        counters.probes(),
+        expected_probes,
+        "expected one seq-match probe per inner-chain transition"
+    );
+    assert_eq!(
+        counters.hits(),
+        expected_probes,
+        "every sequential transition should hit the linked successor"
+    );
+    assert_eq!(counters.misses(), 0);
+}
+
+/// End-to-end: when the source diverges after a confirmed run, the
+/// lookahead probe misses at the divergence and the full lookup picks
+/// up the trailing literal/match work. Counters must show at least one
+/// miss alongside the run-internal hits.
+#[test]
+fn seq_match_falls_back_on_mismatch() {
+    let block_len = TEST_BLOCK_LENGTH as usize;
+    let basis = distinct_basis(5);
+    let mut source = basis[..3 * block_len].to_vec();
+    // Append literal bytes that do not appear in the basis to force the
+    // lookahead probe to miss at the boundary after block 2.
+    source.extend(std::iter::repeat_n(0xFFu8, block_len + 7));
+
+    let index = build_index(&basis).expect("index");
+    let counters = index.seq_match_counters();
+    counters.reset();
+    let generator = DeltaGenerator::new();
+    let script = generator
+        .generate(Cursor::new(source.clone()), &index)
+        .expect("script");
+
+    // Apply round-trip must hold even with the fallback path engaged.
+    let mut basis_cursor = Cursor::new(basis.clone());
+    let mut output = Vec::new();
+    apply_delta(&mut basis_cursor, &mut output, &index, &script).expect("apply");
+    assert_eq!(output, source);
+
+    // Two confirmed transitions inside the basis-aligned prefix, both
+    // taken by the seq-match probe.
+    assert!(
+        counters.hits() >= 2,
+        "expected at least the two in-run transitions to hit the seq-match probe, got {}",
+        counters.hits()
+    );
+    // The divergence after block 2 forces at least one probe to miss and
+    // fall through to the full lookup.
+    assert!(
+        counters.misses() >= 1,
+        "expected at least one seq-match miss at the divergence point, got {}",
+        counters.misses()
+    );
+}
+
+/// Per-segment isolation (ZSO-7): when an index is rebuilt for a new
+/// signature, the `next_match` links and the seq-match counters must
+/// reset cleanly. Mirrors the bithash leak test.
+#[test]
+fn seq_match_state_does_not_leak_between_indexes() {
+    let basis_a = distinct_basis(4);
+    let mut index = build_index(&basis_a).expect("index_a");
+    let counters = index.seq_match_counters();
+
+    // Warm up the counters via the contiguous probe.
+    let block_len = index.block_length();
+    let window = &basis_a[block_len..2 * block_len];
+    let digest = index.block(1).rolling();
+    let _ = index.try_next_match_bytes(0, digest, window);
+    assert_eq!(counters.hits(), 1, "warm-up probe should hit");
+
+    // Rebuild over a fresh, smaller basis. The successor links from
+    // `basis_a` must be wiped and the counters must be back to zero.
+    let basis_b = distinct_basis(2);
+    let params_b = SignatureLayoutParams::new(
+        basis_b.len() as u64,
+        Some(NonZeroU32::new(TEST_BLOCK_LENGTH).unwrap()),
+        ProtocolVersion::NEWEST,
+        NonZeroU8::new(TEST_STRONG_LEN).unwrap(),
+    );
+    let layout_b = calculate_signature_layout(params_b).expect("layout_b");
+    let sig_b = generate_file_signature(basis_b.as_slice(), layout_b, SignatureAlgorithm::Md4)
+        .expect("signature_b");
+    let ok = index.rebuild(&sig_b, SignatureAlgorithm::Md4);
+    assert!(ok, "rebuild must report success on a full-block signature");
+
+    // Counter handle is shared with the index via Arc, so a successful
+    // reset propagates without re-fetching the handle.
+    assert_eq!(counters.probes(), 0);
+    assert_eq!(counters.hits(), 0);
+    assert_eq!(counters.misses(), 0);
+
+    // Successor chain matches the new basis (two blocks, one link).
+    assert_eq!(index.next_match(0), Some(1));
+    assert_eq!(index.next_match(1), None);
+
+    // Indices past the new tail must not surface a successor inherited
+    // from the larger pre-rebuild basis.
+    for k in 2..6 {
+        assert_eq!(index.next_match(k), None, "stale link at {k}");
+    }
+}
+
+proptest! {
+    // Property: for every full-length block of a random distinct basis, the
+    // successor recorded in `next_match` matches the next full-length block
+    // in source order and the contiguous probe verifies cleanly.
+    #[test]
+    fn next_match_is_consistent_with_basis_order(n_blocks in 2usize..=8) {
+        let basis = distinct_basis(n_blocks);
+        let index = build_index(&basis).expect("index");
+        let block_len = index.block_length();
+        let last = index.block_count() - 1;
+        let counters = index.seq_match_counters();
+        counters.reset();
+
+        for k in 0..last {
+            let successor = index.next_match(k).expect("interior block has successor");
+            prop_assert_eq!(successor, k + 1);
+
+            let window = &basis[(k + 1) * block_len..(k + 2) * block_len];
+            let digest = index.block(successor).rolling();
+            let found = index.try_next_match_bytes(k, digest, window);
+            prop_assert_eq!(found, Some(successor));
+        }
+        prop_assert_eq!(index.next_match(last), None);
+        prop_assert_eq!(counters.hits() as usize, last);
+        prop_assert_eq!(counters.misses(), 0);
+    }
+}
+
+/// Hand-rolled regression mirroring the generator wiring: a single Copy
+/// token over the whole basis must emit, demonstrating the seq-match path
+/// coalesces consecutive matches.
+#[test]
+fn generator_emits_single_copy_token_over_full_basis() {
+    let basis = distinct_basis(4);
+    let index = build_index(&basis).expect("index");
+    let generator = DeltaGenerator::new();
+    let script = generator
+        .generate(Cursor::new(basis.clone()), &index)
+        .expect("script");
+    let copy_tokens: Vec<&DeltaToken> = script
+        .tokens()
+        .iter()
+        .filter(|t| matches!(t, DeltaToken::Copy { .. }))
+        .collect();
+    assert_eq!(
+        copy_tokens.len(),
+        1,
+        "seq-match must coalesce the chain into one Copy token"
+    );
+}


### PR DESCRIPTION
## Summary

Adds a zsync-style sequential-match lookahead (ZSO-2 / #2510) on `DeltaSignatureIndex`. After a confirmed match at basis block `K`, the matcher probes a recorded successor link first and only falls back to the rolling-rsum / bithash / compact-lookup chain on miss. The optimization is purely in-memory: no wire bytes change.

- **`next_match: Vec<u32>`** (with `u32::MAX` sentinel) on each `DeltaSignatureIndex`, populated in a single pass during `populate_index` and reset by `rebuild` for the per-segment INC_RECURSE lifecycle (ZSO-7).
- **`try_next_match_bytes` / `try_next_match_slices`** probe APIs that follow the recorded successor, do a cheap rolling-sum compare, then a strong-checksum verify. Skip the tag-table / bithash / compact-lookup work on hit.
- **`SeqMatchCounters`** (`probes` / `hits` / `misses`) wired behind the existing `bench-internal` cfg gate so release builds carry zero overhead. Test-only accessor `seq_match_counters()` lets the regression suite assert the lookahead path is taken.
- **Generator wiring**: the in-chain probe (the one taken after every confirmed match) now goes through `try_next_match_slices`; the start-of-file `Some(0)` seed continues to use the existing `check_block_match_slices` shortcut. The `match_idx + 1` arithmetic is replaced by `index.next_match(match_idx)` so any future basis re-ordering is honoured automatically.

## Wire-byte parity

Wire format is unchanged by construction: nothing serialized changes, only the in-memory probe ordering. Verified by running the protocol golden suite both before and after:

```
cargo nextest run -p protocol --all-features -E 'test(golden)'
  Summary [   0.454s] 407 tests run: 407 passed, 5186 skipped
```

## Measured behaviour (counter-based)

The regression suite pins concrete probe / hit / miss counts straight from the new counters:

- `seq_match_hits_consecutive_blocks` (6 distinct blocks, source = basis):
  - `probes = 5`, `hits = 5`, `misses = 0`
  - every in-chain transition lands through the lookahead, the rolling-rsum lookup is bypassed on every adjacent boundary.
- `seq_match_falls_back_on_mismatch` (3 basis blocks followed by `block_len + 7` literal bytes):
  - `hits >= 2` (both in-run transitions take the lookahead),
  - `misses >= 1` (the divergence after block 2 forces a fall-through to `find_match_slices_filtered`).
- `next_match_is_consistent_with_basis_order` (proptest, 2..=8 blocks): every interior block resolves its successor through `try_next_match_bytes` with no misses.

## Throughput

Existing `seq_match_redundant` bench harness (`cargo bench -p matching --features bench-internal --bench seq_match_redundant -- --quick`) on the post-change tree:

| Corpus | Throughput |
| --- | --- |
| `log_like` (16 MiB, append-only log fixture) | ~275 MiB/s |
| `tar_like` (16 MiB, near-duplicate records) | ~68 MiB/s |
| `random_control` (16 MiB, uncorrelated) | ~375 MiB/s |

A wire-trapped before/after speedup number would need a long-running, controlled benchmark pass on a quiet host; the harness above is the bench infra the design note (`docs/design/zsync-seq-match.md`) calls for and is preserved unchanged.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` clean
- [x] `cargo nextest run -p matching --all-features` - 330 passed, 3 skipped
- [x] `cargo nextest run -p protocol --all-features -E 'test(golden)'` - 407 passed (wire-byte parity)
- [x] `cargo bench -p matching --features bench-internal --bench seq_match_redundant -- --quick` runs cleanly