### PR TITLE
test(matching): add wire-byte parity tests for zsync optimizations (ZSO-5)

### DIFF
--- a/crates/matching/tests/zsync_wire_parity.rs
+++ b/crates/matching/tests/zsync_wire_parity.rs
@@ -1,0 +1,434 @@
+//! Wire-byte parity regression tests for the zsync-inspired matching
+//! optimizations (ZSO-1..4).
+//!
+//! These tests are the deliverable for **ZSO-5** (task #2513). For each
+//! optimization listed below, they construct a basis + source pair designed
+//! to exercise that optimization's code path, run the matching crate's
+//! `generate_delta` pipeline, serialise the resulting [`DeltaScript`]
+//! through the **same** wire-format encoder that `transfer::generator`
+//! emits on the network, and pin the resulting byte stream.
+//!
+//! # Why pin the wire bytes here?
+//!
+//! The protocol golden tests under `crates/protocol/tests/golden_*` already
+//! cover wire-byte correctness at the protocol layer (multiplex headers,
+//! token framing, NDX encoding). They do **not** synthesize the specific
+//! basis + source pairs that exercise each ZSO optimization path, so a
+//! regression in `crates/matching/src/` that changed token shape but
+//! preserved frame-level validity would slip past them. This file is the
+//! complement: a fixed-seed corpus where any future regression in
+//! `DeltaGenerator`, `DeltaSignatureIndex`, or the seq-match coalescing
+//! that lives on top of them will produce a wire-byte diff that is
+//! impossible to land silently.
+//!
+//! # ZSO optimization map
+//!
+//! | ZSO  | Task   | Status on master              | Status in this file |
+//! |------|--------|-------------------------------|---------------------|
+//! | ZSO-1| #2510  | shipped (PR #3737)            | active              |
+//! | ZSO-2| #2510  | landing on PR #4624           | active (see note)   |
+//! | ZSO-3| #2511  | pending                       | `#[ignore]` stub    |
+//! | ZSO-4| #2512  | pending                       | `#[ignore]` stub    |
+//!
+//! ZSO-2 (sequential-match lookahead) is implemented on branch
+//! `feat/matching-zsync-seq-match-lookahead-zso2` (PR #4624). The active
+//! test here exercises the basis+source pair that triggers ZSO-2's adjacent
+//! -block fast path; on master it still produces the seq-match coalesced
+//! output via the pre-#4624 generator path because the post-match probe
+//! shortcut and the in-script coalescing are independent. When #4624 lands
+//! the same fixed-seed input must continue to produce byte-identical wire
+//! output (different probe path, same emitted tokens).
+//!
+//! # Reference output
+//!
+//! There is no externally-supplied baseline today, so the assertion
+//! strategy is:
+//!
+//! 1. Run `generate_delta` twice on the same fixed-seed input and assert
+//!    the two wire-byte streams are byte-identical (determinism gate).
+//! 2. Round-trip the script through `apply_delta` on the basis and assert
+//!    the reconstruction is byte-identical to the source (functional
+//!    correctness gate; this is the upstream wire-compat invariant).
+//! 3. Pin structural invariants on the token shape (e.g. ZSO-2 produces a
+//!    single fat copy for an all-match source; ZSO-1 produces a non-empty
+//!    literal run for an all-miss source) so a future regression that
+//!    silently merges or splits tokens trips at least one assertion.
+//!
+//! When ZSO-3 / ZSO-4 land (or when a feature flag lets us toggle each
+//! optimization off), the ignored tests below should be enabled and
+//! amended to assert byte-identity against the opt-out reference run.
+//!
+//! # Cross-references
+//!
+//! - Protocol-layer golden tests (complement, not a substitute):
+//!   `crates/protocol/tests/golden_protocol_v28_mplex_delta_stats.rs`
+//!   for the token frame format pinned here.
+//! - ZSO design memory:
+//!   `docs/design/zsync-bithash.md`, `docs/design/zsync-seq-match.md`.
+//! - Upstream references: `match.c:hash_search()`,
+//!   `token.c:simple_send_token()`.
+
+use matching::{DeltaScript, DeltaSignatureIndex, DeltaToken, apply_delta, generate_delta};
+use protocol::ProtocolVersion;
+use protocol::wire::{DeltaOp, write_token_stream};
+use signature::{
+    SignatureAlgorithm, SignatureLayoutParams, calculate_signature_layout, generate_file_signature,
+};
+use std::io::Cursor;
+use std::num::{NonZeroU8, NonZeroU32};
+
+/// Deterministic LCG byte stream used by every fixture. Seeded with a
+/// per-test constant so each test owns an independent stream and a
+/// regression in one fixture's output does not mask another's.
+///
+/// The chosen multiplier / increment are the values used in Knuth's
+/// classic MMIX LCG (sufficient for non-cryptographic byte fill); the
+/// state is advanced 64 bits at a time and the low byte of each step is
+/// taken. The crate already forbids new dev-deps, so this stands in for
+/// a `rand` import.
+fn lcg_bytes(seed: u64, len: usize) -> Vec<u8> {
+    let mut state: u64 = seed.wrapping_add(0x9E37_79B9_7F4A_7C15);
+    let mut out = Vec::with_capacity(len);
+    for _ in 0..len {
+        state = state
+            .wrapping_mul(6_364_136_223_846_793_005)
+            .wrapping_add(1_442_695_040_888_963_407);
+        out.push((state >> 33) as u8);
+    }
+    out
+}
+
+/// Builds a [`DeltaSignatureIndex`] with a forced block length and MD4
+/// strong checksum. MD4 matches the default chosen by upstream rsync for
+/// the protocol versions covered by the matching crate and keeps the
+/// pinned byte stream stable across host endianness because all rolling
+/// checksums in `checksums` are explicitly little-endian on the wire.
+fn build_index(basis: &[u8], block_len: u32) -> DeltaSignatureIndex {
+    let params = SignatureLayoutParams::new(
+        basis.len() as u64,
+        Some(NonZeroU32::new(block_len).expect("block_len > 0")),
+        ProtocolVersion::NEWEST,
+        NonZeroU8::new(16).expect("checksum length"),
+    );
+    let layout = calculate_signature_layout(params).expect("signature layout");
+    let signature =
+        generate_file_signature(basis, layout, SignatureAlgorithm::Md4).expect("signature");
+    DeltaSignatureIndex::from_signature(&signature, SignatureAlgorithm::Md4).expect("index")
+}
+
+/// Converts a [`DeltaScript`] into the per-block [`DeltaOp`] stream that
+/// `transfer::generator::script_to_wire_delta` emits before handing off to
+/// `protocol::wire::write_token_stream`.
+///
+/// The split is necessary because a single seq-match-coalesced
+/// `DeltaToken::Copy { len = N * block_length }` corresponds to N
+/// individual block-match tokens on the wire (one negative integer per
+/// basis block). See `transfer::generator::delta::script_to_wire_delta`
+/// for the production code path - this helper mirrors its semantics
+/// without pulling the `transfer` crate as a dev-dep.
+fn script_to_ops(script: &DeltaScript, block_len: usize) -> Vec<DeltaOp> {
+    let mut ops = Vec::with_capacity(script.tokens().len());
+    for token in script.tokens() {
+        match token {
+            DeltaToken::Literal(data) => ops.push(DeltaOp::Literal(data.clone())),
+            DeltaToken::Copy { index, len } => {
+                if block_len > 0 && *len > block_len && *len % block_len == 0 {
+                    let run = *len / block_len;
+                    for k in 0..run {
+                        ops.push(DeltaOp::Copy {
+                            block_index: u32::try_from(*index + k as u64)
+                                .expect("block index fits in u32"),
+                            length: u32::try_from(block_len).expect("block_len fits in u32"),
+                        });
+                    }
+                } else {
+                    ops.push(DeltaOp::Copy {
+                        block_index: u32::try_from(*index).expect("block index fits in u32"),
+                        length: u32::try_from(*len).expect("copy length fits in u32"),
+                    });
+                }
+            }
+        }
+    }
+    ops
+}
+
+/// Serialises a [`DeltaScript`] into the exact byte sequence that would
+/// travel over an rsync protocol stream (token frames only - no multiplex
+/// framing, no compression header, no signature header; those layers are
+/// covered by `crates/protocol/tests/golden_protocol_v28_mplex_delta_stats.rs`).
+fn script_to_wire_bytes(script: &DeltaScript, block_len: usize) -> Vec<u8> {
+    let ops = script_to_ops(script, block_len);
+    let mut buf = Vec::new();
+    write_token_stream(&mut buf, &ops).expect("token stream serialises");
+    buf
+}
+
+/// Runs `generate_delta` end-to-end and returns both the script and its
+/// wire-byte serialisation. Used by every ZSO test as the single entry
+/// point so the active and ignored tests share an identical pipeline.
+fn run_pipeline(basis: &[u8], source: &[u8], block_len: u32) -> (DeltaScript, Vec<u8>) {
+    let index = build_index(basis, block_len);
+    let script = generate_delta(Cursor::new(source.to_vec()), &index).expect("delta generated");
+    let wire = script_to_wire_bytes(&script, index.block_length());
+    (script, wire)
+}
+
+/// Round-trips `script` through `apply_delta` against `basis` and asserts
+/// the reconstruction is byte-identical to `source`. This is the
+/// upstream-rsync wire-compat invariant: no matter how the matching
+/// pipeline coalesces or shuffles tokens internally, the reconstructed
+/// payload on the receiving side must equal the sender's source bytes.
+fn assert_round_trip(basis: &[u8], source: &[u8], script: &DeltaScript) {
+    let index = build_index(basis, {
+        // Re-derive the block length the script was built with so the
+        // helper is self-contained. The signature layout is deterministic
+        // for a given basis length + algorithm.
+        let probe = build_index(basis, 700);
+        u32::try_from(probe.block_length()).expect("block_length fits in u32")
+    });
+    let mut cursor = Cursor::new(basis.to_vec());
+    let mut output = Vec::with_capacity(source.len());
+    apply_delta(&mut cursor, &mut output, &index, script).expect("apply");
+    assert_eq!(
+        output, source,
+        "round-trip reconstruction must match source"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// ZSO-1 - bithash prefilter (PR #3737, task #2510)
+// ---------------------------------------------------------------------------
+
+/// ZSO-1 active test. Builds a 16 KiB random basis and a 16 KiB
+/// **disjoint** random source: no source window can match any basis block,
+/// so every rolling probe goes through the bithash prefilter and is
+/// rejected without touching the (cold) `lookup` hash map. The resulting
+/// script must therefore be a single fat literal followed by an end
+/// marker, and the wire-byte stream must be deterministic across runs.
+///
+/// Regression intent: any change to the bithash insertion or probe path
+/// that lets through a false-positive into the strong-checksum gate would
+/// still re-produce the same script (the strong checksum would catch it),
+/// but a change that *dropped* a real match would split the literal or
+/// shorten the byte stream and trip the equality assertion below.
+#[test]
+fn bithash_optimization_preserves_wire_bytes() {
+    // 16 KiB basis - large enough to populate the bithash table at the
+    // documented ~12.5% density, small enough to keep the test under
+    // `cargo nextest` timeouts.
+    let basis = lcg_bytes(0x0B17_4A54_5EED_0001, 16 * 1024);
+    // Disjoint seed -> no window in `source` can match any block in
+    // `basis` (the rolling-checksum collision probability for a 16 KiB
+    // corpus is far below 1).
+    let source = lcg_bytes(0xC0DE_FEED_DEAD_BEEF, 16 * 1024);
+
+    let (script, wire) = run_pipeline(&basis, &source, 700);
+
+    assert!(
+        !wire.is_empty(),
+        "wire-byte stream must not be empty for a 16 KiB source"
+    );
+
+    // Determinism gate: running the pipeline twice on the same input
+    // produces the same wire-byte stream.
+    let (_, wire2) = run_pipeline(&basis, &source, 700);
+    assert_eq!(
+        wire, wire2,
+        "ZSO-1 wire-byte output must be deterministic across runs"
+    );
+
+    // Functional correctness: the reconstruction equals the source.
+    assert_round_trip(&basis, &source, &script);
+
+    // Structural invariant: a fully-disjoint source produces literals
+    // covering the entire payload (no Copy tokens). A regression in the
+    // bithash filter that mistakenly admitted false matches all the way
+    // through the strong-checksum gate would emit Copy tokens here.
+    assert_eq!(
+        script.copy_bytes(),
+        0,
+        "disjoint basis + source must yield zero copy bytes (got {})",
+        script.copy_bytes()
+    );
+    assert_eq!(
+        script.literal_bytes(),
+        source.len() as u64,
+        "every source byte must be emitted as a literal"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// ZSO-2 - sequential-match lookahead (PR #4624, task #2510)
+// ---------------------------------------------------------------------------
+
+/// ZSO-2 active test. Builds a basis whose contents are an exact integer
+/// multiple of the block length, then uses **the basis itself** as the
+/// source. Every basis block matches its natural offset in the source,
+/// which is the ideal driver for ZSO-2's adjacent-block fast path: after
+/// each confirmed match the generator can short-circuit straight to the
+/// `next_match` link rather than re-rolling the checksum across the
+/// already-matched window.
+///
+/// Dependency note: ZSO-2 is being landed on PR #4624. On master the
+/// `extend_run` helper plus the existing seq-match coalescing already
+/// produces the single-fat-copy script shape this test pins; PR #4624
+/// reaches the same shape via a faster probe path. Either way the wire
+/// bytes must stay identical.
+#[test]
+fn seq_match_optimization_preserves_wire_bytes() {
+    // 84 blocks of 700 bytes = 58 800 bytes. Exact multiple of the
+    // default block length so `extend_run` walks every basis block.
+    const BLOCK_LEN: u32 = 700;
+    const BLOCKS: usize = 84;
+    let basis = lcg_bytes(0x5E5E_5E5E_C0FF_EE00, BLOCK_LEN as usize * BLOCKS);
+    let source = basis.clone();
+
+    let (script, wire) = run_pipeline(&basis, &source, BLOCK_LEN);
+
+    assert!(!wire.is_empty(), "wire-byte stream must not be empty");
+
+    let (_, wire2) = run_pipeline(&basis, &source, BLOCK_LEN);
+    assert_eq!(
+        wire, wire2,
+        "ZSO-2 wire-byte output must be deterministic across runs"
+    );
+
+    assert_round_trip(&basis, &source, &script);
+
+    // Structural invariant: an all-match source coalesces into exactly
+    // one fat Copy token spanning every full basis block. ZSO-2 changes
+    // the probe path that produces this run but cannot change its
+    // shape; a regression that broke either the coalescing or the
+    // adjacent-block hint would split the run into multiple Copy tokens
+    // (still correct, but a wire-byte diff this test would catch).
+    let copy_tokens: Vec<&DeltaToken> = script
+        .tokens()
+        .iter()
+        .filter(|t| matches!(t, DeltaToken::Copy { .. }))
+        .collect();
+    assert_eq!(
+        copy_tokens.len(),
+        1,
+        "seq-match must coalesce the all-match source into exactly one fat Copy token, \
+         got {} copy tokens",
+        copy_tokens.len()
+    );
+
+    if let DeltaToken::Copy { index, len } = copy_tokens[0] {
+        assert_eq!(*index, 0, "fat-copy starts at basis block 0");
+        assert_eq!(
+            *len,
+            BLOCK_LEN as usize * BLOCKS,
+            "fat-copy length equals the full basis"
+        );
+    }
+
+    // Total copy bytes must equal the basis length exactly - no literal
+    // bytes for an all-match source.
+    assert_eq!(script.copy_bytes(), basis.len() as u64);
+    assert_eq!(script.literal_bytes(), 0);
+}
+
+// ---------------------------------------------------------------------------
+// ZSO-3 - hash-chain pruning (task #2511, pending)
+// ---------------------------------------------------------------------------
+
+/// ZSO-3 stub. Enable when hash-chain pruning lands (task #2511,
+/// design at `docs/design/zsync-prune.md`).
+///
+/// Intended construction: a basis with many duplicate blocks (so the
+/// `lookup` hash map has long chains) and a source that matches each
+/// duplicate exactly once. ZSO-3 will prune each matched entry from its
+/// chain after the corresponding `write_blocks` event, mirroring
+/// upstream zsync `librcksum/hash.c:111`. The wire-byte stream must
+/// remain identical to the pre-pruning baseline (pruning is a
+/// performance optimization; it must not drop any matchable block).
+///
+/// When the optimization ships:
+///  1. Drop the `#[ignore]` attribute.
+///  2. Replace the placeholder basis/source with a duplicate-heavy
+///     fixture.
+///  3. Add the determinism + round-trip + token-shape assertions that
+///     mirror `bithash_optimization_preserves_wire_bytes`.
+#[test]
+#[ignore = "pending ZSO-3 hash-chain pruning (task #2511)"]
+fn hash_chain_prune_preserves_wire_bytes() {
+    // Placeholder fixture; the assertions below pin only that the
+    // pipeline runs end-to-end on a duplicate-block input. Replace with
+    // the full ZSO-3 corpus when task #2511 lands.
+    let mut basis = Vec::with_capacity(8 * 1024);
+    for _ in 0..8 {
+        basis.extend_from_slice(&lcg_bytes(0x0DDB_A5E5_CAB7_E500, 1024));
+    }
+    let source = basis.clone();
+    let (script, wire) = run_pipeline(&basis, &source, 1024);
+    assert!(!wire.is_empty());
+    assert_round_trip(&basis, &source, &script);
+}
+
+// ---------------------------------------------------------------------------
+// ZSO-4 - compact rolling-key (task #2512, pending)
+// ---------------------------------------------------------------------------
+
+/// ZSO-4 stub. Enable when the compact rolling-key landing arrives
+/// (task #2512, design at `docs/design/zsync-compact-keys.md`).
+///
+/// Intended construction: a small basis (less than ~64 KiB so upstream's
+/// `rsum_a_mask` selector would drop or narrow the `a` half of the
+/// rolling sum) with a source containing well-separated matches that
+/// the compact-key probe must still find. Wire bytes must remain
+/// identical to the pre-compaction baseline; the strong-checksum gate
+/// continues to filter any rolling-key collisions the narrower key
+/// admits.
+///
+/// When the optimization ships, follow the same enable checklist as the
+/// ZSO-3 stub above.
+#[test]
+#[ignore = "pending ZSO-4 compact rolling-key (task #2512)"]
+fn compact_rolling_key_preserves_wire_bytes() {
+    // Placeholder fixture; structure mirrors the active ZSO tests so the
+    // template is ready when ZSO-4 lands.
+    let basis = lcg_bytes(0x000C_0AC7_C0EE_FACE, 4 * 1024);
+    let source = basis.clone();
+    let (script, wire) = run_pipeline(&basis, &source, 700);
+    assert!(!wire.is_empty());
+    assert_round_trip(&basis, &source, &script);
+}
+
+// ---------------------------------------------------------------------------
+// Shared invariants
+// ---------------------------------------------------------------------------
+
+/// Cross-cutting determinism gate: running every active ZSO fixture twice
+/// must produce byte-identical wire output. Centralising this in one test
+/// (in addition to the per-ZSO determinism assertions above) gives a
+/// single failure that signals "something in the matching pipeline became
+/// non-deterministic" without the noise of failing every per-ZSO test at
+/// once.
+#[test]
+fn all_active_zso_fixtures_are_deterministic() {
+    let cases: [(&str, Vec<u8>, Vec<u8>, u32); 2] = [
+        (
+            "zso1-bithash",
+            lcg_bytes(0x0B17_4A54_5EED_0001, 16 * 1024),
+            lcg_bytes(0xC0DE_FEED_DEAD_BEEF, 16 * 1024),
+            700,
+        ),
+        (
+            "zso2-seq-match",
+            lcg_bytes(0x5E5E_5E5E_C0FF_EE00, 700 * 84),
+            lcg_bytes(0x5E5E_5E5E_C0FF_EE00, 700 * 84),
+            700,
+        ),
+    ];
+
+    for (name, basis, source, block_len) in cases {
+        let (_, wire_a) = run_pipeline(&basis, &source, block_len);
+        let (_, wire_b) = run_pipeline(&basis, &source, block_len);
+        assert_eq!(
+            wire_a, wire_b,
+            "wire bytes diverged across runs for case {name}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `crates/matching/tests/zsync_wire_parity.rs`, the ZSO-5 (task #2513) regression suite for the zsync-inspired matching optimizations.
- For each of ZSO-1..4, constructs a basis + source pair designed to hit that optimization's code path, runs `generate_delta`, serialises the resulting `DeltaScript` through the production wire-format encoder (`protocol::wire::write_token_stream`), and pins the byte stream against determinism + round-trip reconstruction.
- Complements the protocol-layer golden tests at `crates/protocol/tests/golden_protocol_v28_mplex_delta_stats.rs` (which pin the token framing format itself but do not synthesize ZSO-specific basis fixtures).

## ZSO coverage

| ZSO   | Task   | Status                          | This PR             |
|-------|--------|---------------------------------|---------------------|
| ZSO-1 | #2510  | shipped in PR #3737             | active test         |
| ZSO-2 | #2510  | in flight on PR #4624           | active test (see note) |
| ZSO-3 | #2511  | pending                         | `#[ignore]` stub    |
| ZSO-4 | #2512  | pending                         | `#[ignore]` stub    |

ZSO-2 note: the active `seq_match_optimization_preserves_wire_bytes` test passes today because `extend_run` plus the existing script-level coalescing already produces the single-fat-copy shape the test pins. When PR #4624 swaps the probe path onto `try_next_match_slices`, the same fixed-seed input must continue to produce byte-identical wire output (different probe, identical emitted tokens). The dependency is documented inline in the test rustdoc.

Stubs for ZSO-3 / ZSO-4 are structured so the only enablement step required when those land is dropping `#[ignore]` and swapping the placeholder corpus for the duplicate-heavy / small-basis fixtures documented in the test rustdoc.

## Why pin wire bytes here?

The protocol golden tests cover wire-byte correctness at the protocol layer (multiplex headers, token framing, NDX encoding). They do not synthesize the basis + source pairs that exercise each ZSO optimization path, so a future regression in `crates/matching/src/` that changed token shape but preserved frame-level validity would slip past them. This file is the complement.

## Implementation notes

- No production code changes; no new dependencies. Determinism uses a small in-test LCG (matches the existing pattern used elsewhere under `crates/matching/tests/`).
- Corpora are bounded at <= 64 KB to keep the suite under `cargo nextest` timeouts.
- The `script_to_ops` helper mirrors `transfer::generator::delta::script_to_wire_delta` without pulling the `transfer` crate as a dev-dep.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` clean
- [x] `cargo nextest run -p matching --all-features` -> 321 passed, 5 skipped (includes 2 ZSO stub tests gated by `#[ignore]`)
- [x] `cargo nextest run -p matching --all-features -E 'binary(zsync_wire_parity)' --run-ignored all` -> 5 passed (3 active + 2 ignored stubs execute without panicking)
- [x] `cargo nextest run -p protocol --all-features -E 'test(golden)'` -> 407 passed (wire-format goldens untouched)