### PR TITLE
docs(daemon): drop restatement comments and apply rustdoc to public items

### DIFF
--- a/crates/daemon/examples/parse_config.rs
+++ b/crates/daemon/examples/parse_config.rs
@@ -29,7 +29,6 @@ fn main() {
     println!("Configuration loaded successfully!");
     println!();
 
-    // Display global settings
     println!("Global Settings:");
     println!("  Port: {}", config.global().port());
     if let Some(addr) = config.global().address() {
@@ -46,7 +45,6 @@ fn main() {
     }
     println!();
 
-    // Display modules
     println!("Modules ({} total):", config.modules().len());
     for module in config.modules() {
         println!();

--- a/crates/daemon/src/daemon/concurrent_tests.rs
+++ b/crates/daemon/src/daemon/concurrent_tests.rs
@@ -37,17 +37,14 @@ fn concurrent_register_unregister_stress() {
                 let port = (thread_id * 1000 + i) as u16;
                 let addr = test_addr((thread_id % 256) as u8, port);
 
-                // Register in both
                 let session_id = registry.register(addr, None);
                 let conn_id = pool.register(addr);
 
-                // Update state
                 registry.set_state(&session_id, SessionState::Transferring);
                 registry.set_module(&session_id, format!("module_{thread_id}"));
                 pool.set_module(&conn_id, format!("module_{thread_id}"));
                 pool.add_bytes(&conn_id, 100, 50);
 
-                // Mark complete and unregister
                 registry.set_state(&session_id, SessionState::Completed);
                 registry.unregister(&session_id);
                 pool.unregister(&conn_id);
@@ -60,7 +57,6 @@ fn concurrent_register_unregister_stress() {
         handle.join().expect("thread should not panic");
     }
 
-    // All entries should be cleaned up
     assert_eq!(registry.count(), 0);
     assert_eq!(pool.count(), 0);
 }
@@ -161,7 +157,7 @@ fn concurrent_reads_and_writes() {
         handle.join().expect("thread should not panic");
     }
 
-    // Verify data is still consistent
+    // Read/write threads must not have corrupted the entries.
     assert_eq!(registry.count(), 100);
     assert_eq!(pool.count(), 100);
 }
@@ -226,11 +222,9 @@ fn concurrent_module_queries() {
         handle.join().expect("thread should not panic");
     }
 
-    // Verify final counts
     assert_eq!(registry.count(), 600);
     assert_eq!(pool.count(), 600);
 
-    // Each module should have 200 entries
     for module_id in 0..3 {
         let module = format!("module_{module_id}");
         assert_eq!(registry.module_session_count(&module), 200);
@@ -267,12 +261,10 @@ fn concurrent_ip_rate_limiting() {
         handle.join().expect("thread should not panic");
     }
 
-    // All 1000 connections should be from the same IP
     assert_eq!(pool.connections_from_ip(&shared_ip), 1000);
     assert_eq!(pool.count(), 1000);
     assert_eq!(pool.unique_ip_count(), 1);
 
-    // Check IP stats
     let stats = pool.get_ip_stats(&shared_ip).expect("stats should exist");
     assert_eq!(stats.active_connections, 1000);
     assert_eq!(stats.total_connections, 1000);
@@ -358,11 +350,11 @@ fn concurrent_pruning() {
         handle.join().expect("thread should not panic");
     }
 
-    // Only active entries should remain (half were marked inactive)
+    // Half the registered entries were marked inactive up-front; pruning should
+    // leave the active half intact.
     assert_eq!(registry.count(), 100);
     assert_eq!(pool.count(), 100);
 
-    // All remaining should be active
     assert_eq!(registry.active_count(), 100);
     assert_eq!(pool.active_count(), 100);
 }
@@ -444,7 +436,6 @@ fn concurrent_aggregate_stats() {
             barrier.wait();
             for _ in 0..500 {
                 let stats = pool.aggregate_stats();
-                // Stats should be internally consistent
                 assert!(stats.active_connections <= stats.total_connections);
 
                 let _ = registry.active_count();
@@ -457,7 +448,6 @@ fn concurrent_aggregate_stats() {
         handle.join().expect("thread should not panic");
     }
 
-    // Final verification
     let stats = pool.aggregate_stats();
     assert_eq!(stats.total_connections, 400); // 4 threads * 100 connections
     assert_eq!(stats.active_connections, 400);
@@ -494,10 +484,10 @@ fn concurrent_same_address_registration() {
         handle.join().expect("thread should not panic");
     }
 
-    // All registrations should succeed (each gets unique ID)
+    // Each concurrent register() call must produce a unique ID even when the
+    // peer address collides.
     assert_eq!(pool.count(), 1000);
     assert_eq!(registered_count.load(Ordering::Relaxed), 1000);
 
-    // All from same IP
     assert_eq!(pool.connections_from_ip(&addr.ip()), 1000);
 }

--- a/crates/daemon/src/daemon/sections/module_access/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_access/tests.rs
@@ -282,8 +282,6 @@ mod module_access_tests {
         assert_eq!(format_bandwidth_rate(rate), "1025 bytes/s");
     }
 
-    // Tests for error file functions
-
     /// upstream: log.c:163 - log-open failures produce RERR_MESSAGEIO (13).
     #[test]
     fn log_file_error_creates_daemon_error_with_correct_code() {
@@ -336,8 +334,6 @@ mod module_access_tests {
         assert!(message.contains("/var/lock/rsyncd.lock"));
     }
 
-    // Tests for format_host
-
     #[test]
     fn format_host_returns_hostname_when_present() {
         use std::net::IpAddr;
@@ -361,8 +357,6 @@ mod module_access_tests {
         let fallback: IpAddr = "::1".parse().unwrap();
         assert_eq!(format_host(host, fallback), "::1");
     }
-
-    // Tests for determine_server_role
 
     #[test]
     fn determine_server_role_sender_when_sender_flag_present() {
@@ -389,7 +383,8 @@ mod module_access_tests {
         assert!(matches!(determine_server_role(&args), ServerRole::Receiver));
     }
 
-    // Tests for format_module_listing_line - upstream: clientserver.c:1254
+    // upstream: clientserver.c:1254 governs the format_module_listing_line
+    // wire layout exercised below.
 
     #[test]
     fn module_listing_format_short_name_padded_to_15() {
@@ -868,8 +863,6 @@ mod module_access_tests {
         apply_long_form_args(&args, &mut config);
         assert!(!config.write.delay_updates);
     }
-
-    // Tests for parse_daemon_dont_compress
 
     #[test]
     fn parse_daemon_dont_compress_glob_suffixes() {
@@ -1556,8 +1549,6 @@ mod module_access_tests {
         assert_eq!(config.effective_backup_suffix(), ".old");
     }
 
-    // --- split_filter_tokens tests ---
-
     #[test]
     fn split_filter_tokens_single_exclude() {
         let tokens = split_filter_tokens("- *.tmp");
@@ -1614,8 +1605,6 @@ mod module_access_tests {
         let tokens = split_filter_tokens("*.bak");
         assert_eq!(tokens, vec!["*.bak"]);
     }
-
-    // --- build_daemon_filter_rules with word-split filter lines ---
 
     #[test]
     fn build_daemon_filter_rules_filter_word_split_include_exclude() {

--- a/crates/daemon/src/daemon/sections/session_runtime.rs
+++ b/crates/daemon/src/daemon/sections/session_runtime.rs
@@ -422,8 +422,6 @@ fn handle_binary_session_internal(
 mod session_runtime_tests {
     use super::*;
 
-    // Tests for SessionStyle
-
     #[test]
     fn session_style_eq_legacy() {
         assert_eq!(SessionStyle::Legacy, SessionStyle::Legacy);
@@ -452,8 +450,6 @@ mod session_runtime_tests {
         let debug = format!("{style:?}");
         assert!(debug.contains("Legacy"));
     }
-
-    // Tests for SessionParams
 
     #[test]
     fn session_params_fields() {
@@ -495,8 +491,6 @@ mod session_runtime_tests {
         assert!(params.reverse_lookup);
     }
 
-    // Tests for LegacySessionParams
-
     #[test]
     fn legacy_session_params_fields() {
         let modules: Vec<ModuleRuntime> = vec![];
@@ -530,8 +524,6 @@ mod session_runtime_tests {
         assert_eq!(params.peer_host.as_deref(), Some("example.com"));
         assert!(params.reverse_lookup);
     }
-
-    // Tests for read_early_input
 
     #[test]
     fn read_early_input_parses_valid_command() {

--- a/crates/daemon/src/daemon/session_registry.rs
+++ b/crates/daemon/src/daemon/session_registry.rs
@@ -383,7 +383,6 @@ mod tests {
         assert_eq!(registry.count(), 3);
         assert_eq!(registry.active_count(), 1);
 
-        // id1 should be the only active session
         let active = registry.active_sessions();
         assert_eq!(active.len(), 1);
         assert_eq!(active[0].id, id1);
@@ -458,7 +457,6 @@ mod tests {
         let registry = Arc::new(SessionRegistry::new());
         let mut handles = vec![];
 
-        // Spawn multiple threads that register/unregister sessions
         for i in 0..10 {
             let registry = Arc::clone(&registry);
             let handle = thread::spawn(move || {
@@ -478,7 +476,6 @@ mod tests {
             handle.join().unwrap();
         }
 
-        // All sessions should be unregistered
         assert_eq!(registry.count(), 0);
     }
 }

--- a/crates/daemon/src/daemon/tracing_stream.rs
+++ b/crates/daemon/src/daemon/tracing_stream.rs
@@ -186,18 +186,16 @@ mod tests {
 
         #[test]
         fn log_to_file_creates_or_appends() {
-            // This test verifies log_to_file doesn't panic
             log_to_file("test message from unit test");
 
-            // Verify the log file exists (may have been created by this or other tests)
+            // Whether the log file actually exists depends on filesystem
+            // permissions, so just exercise the path without asserting.
             let path = Path::new("/tmp/daemon_protocol_trace.log");
-            // We don't assert exists because the test might not have permissions
             let _ = path.exists();
         }
 
         #[test]
         fn log_to_file_handles_special_chars() {
-            // Should handle special characters without panic
             log_to_file("test with special chars: \t\n\r");
             log_to_file("unicode: 日本語");
             log_to_file("");

--- a/crates/daemon/src/error.rs
+++ b/crates/daemon/src/error.rs
@@ -176,7 +176,7 @@ mod tests {
             let message = rsync_error!(10, "socket error").with_role(Role::Daemon);
             let error = DaemonError::new(10, message);
 
-            let _ = error.message(); // Just verify accessor works
+            let _ = error.message();
         }
 
         #[test]
@@ -212,7 +212,6 @@ mod tests {
             let message = rsync_error!(4, "error trait test").with_role(Role::Daemon);
             let error = DaemonError::new(4, message);
 
-            // Verify it implements std::error::Error
             let _: &dyn std::error::Error = &error;
         }
 
@@ -249,7 +248,6 @@ mod tests {
             let message = rsync_error!(999, "unknown code").with_role(Role::Daemon);
             let error = DaemonError::new(999, message);
 
-            // Unknown exit codes fall back to PartialTransfer
             assert_eq!(error.code(), ExitCode::PartialTransfer);
         }
 
@@ -259,7 +257,6 @@ mod tests {
             let message = rsync_error!(code.as_i32(), "syntax error").with_role(Role::Daemon);
             let error = DaemonError::with_code(code, message);
 
-            // Test the HasExitCode trait
             let trait_code: ExitCode = HasExitCode::exit_code(&error);
             assert_eq!(trait_code, code);
         }

--- a/crates/daemon/src/systemd.rs
+++ b/crates/daemon/src/systemd.rs
@@ -187,7 +187,6 @@ mod tests {
         let _guard = EnvGuard::remove("NOTIFY_SOCKET");
 
         let notifier = ServiceNotifier::new();
-        // Multiple stopping calls should not fail
         assert!(notifier.stopping().is_ok());
         assert!(notifier.stopping().is_ok());
     }
@@ -198,7 +197,6 @@ mod tests {
         let _guard = EnvGuard::remove("NOTIFY_SOCKET");
 
         let notifier = ServiceNotifier::new();
-        // Simulate typical daemon lifecycle
         assert!(notifier.ready(Some("Listening on port 873")).is_ok());
         assert!(notifier.status("Active connections: 0").is_ok());
         assert!(notifier.status("Active connections: 5").is_ok());

--- a/crates/daemon/src/tests.rs
+++ b/crates/daemon/src/tests.rs
@@ -12,8 +12,7 @@ use std::thread;
 use std::time::{Duration, Instant};
 use tempfile::{NamedTempFile, tempdir};
 
-// Import daemon internal types and functions needed by tests
-// These are all included directly into the daemon module via include!()
+// Daemon internals exposed to tests via the include!() chunk modules.
 use crate::daemon::{
     AddressFamily,
     // From module_state.rs
@@ -64,20 +63,16 @@ use crate::daemon::{
     set_test_hostname_override,
 };
 
-// Import from core
 use core::{
     bandwidth::{BandwidthLimiter, LimiterChange},
     branding::{self, Brand},
     exit_code::ExitCode,
 };
 
-// Import from protocol
 use protocol::ProtocolVersion;
 
-// Import from checksums
 use checksums::strong::Md5;
 
-// Import from base64
 use base64::Engine as _;
 use base64::engine::general_purpose::STANDARD_NO_PAD;
 


### PR DESCRIPTION
## Summary

- Strip restatement, decorative banner, and outdated commentary from the daemon crate (production + tests + examples + systemd notifier).
- Preserve every upstream rsync source citation (`clientserver.c`, `authenticate.c`, `options.c`, `log.c`, `exclude.c`, `main.c`, `io.c`, `loadparm.c`, `daemon-parm.txt`, etc.) and every non-trivial WHY note (TCP shutdown semantics, secluded-args flag detection, cap-function bandwidth semantics, fork-vs-thread isolation, BSD O_NONBLOCK propagation, dual-stack acceptor reset, syslog routing, BGid recycling rationale, sparse test sensitivity).
- No public API or behaviour changes. Public items already carried rustdoc; no empty `///` placeholders were added.

## Scope

Touched files:

- `crates/daemon/examples/parse_config.rs`
- `crates/daemon/src/daemon/concurrent_tests.rs`
- `crates/daemon/src/daemon/sections/module_access/tests.rs`
- `crates/daemon/src/daemon/sections/session_runtime.rs`
- `crates/daemon/src/daemon/session_registry.rs`
- `crates/daemon/src/daemon/tracing_stream.rs`
- `crates/daemon/src/error.rs`
- `crates/daemon/src/systemd.rs`
- `crates/daemon/src/tests.rs`

The audit also walked every other `.rs` file in `crates/daemon/` (production submodules under `daemon/`, `daemon/sections/`, `daemon/runtime_options/`, `daemon/module_state/`, `daemon/connection_pool/`, `daemon/async_session/`, `rsyncd_config/`, plus the chunked `src/tests/chunks/` integration tests and `benches/daemon_benchmark.rs`) and confirmed those files were already clean - their remaining `//` comments are upstream citations, multi-step protocol-handshake markers, or load-bearing WHY notes.

The daemon crate carries `#![deny(unsafe_code)]` workspace-wide, so there are no SAFETY blocks to preserve.

No files were skipped: there are no open PRs touching daemon source files (`gh pr list` confirmed before the audit).

## Diff size

9 files changed, 11 insertions(+), 57 deletions(-).

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings`
- [x] Sample daemon tests (`-E 'test(/builder_default/) + test(/secrets_file_parse_basic/) + test(/format_bandwidth/) + test(/parse_daemon_dont_compress_empty/) + test(/error_payloads/)'`) - 11 passed
- [ ] Full nextest matrix in CI