### PR TITLE
docs(filters): drop restatement comments and apply rustdoc to public items

### DIFF
--- a/crates/filters/src/chain/tests.rs
+++ b/crates/filters/src/chain/tests.rs
@@ -94,15 +94,12 @@ fn filter_chain_push_scope_override() {
     let global = FilterSet::from_rules([FilterRule::exclude("*.log")]).unwrap();
     let mut chain = FilterChain::new(global);
 
-    // Push a per-directory scope that includes *.log
     let dir_rules = FilterSet::from_rules([FilterRule::include("*.log")]).unwrap();
     let guard = chain.push_scope(dir_rules);
 
-    // Per-directory include should override global exclude
-    // But has_matching_rule returns false for includes, so we fall through.
-    // This is correct: the per-directory scope only matters if it has
-    // a matching exclude. For includes, we need both include and exclude
-    // rules in the same scope.
+    // has_matching_rule returns false for includes, so we fall through to the
+    // global rules. Per-directory scopes only stop the lookup when they contain
+    // a matching exclude; pure-include scopes need a paired exclude rule.
     assert_eq!(guard.pushed_count(), 1);
 
     chain.leave_directory(guard);
@@ -114,16 +111,13 @@ fn filter_chain_push_scope_exclude_overrides_global_include() {
     let global = FilterSet::from_rules([FilterRule::include("*.txt")]).unwrap();
     let mut chain = FilterChain::new(global);
 
-    // Push a per-directory scope that excludes *.txt
     let dir_rules = FilterSet::from_rules([FilterRule::exclude("*.txt")]).unwrap();
     let guard = chain.push_scope(dir_rules);
 
-    // Per-directory exclude should override global include
     assert!(!chain.allows(Path::new("file.txt"), false));
 
     chain.leave_directory(guard);
 
-    // After leaving, global rules apply again
     assert!(chain.allows(Path::new("file.txt"), false));
 }
 
@@ -132,36 +126,29 @@ fn filter_chain_nested_scopes() {
     let global = FilterSet::from_rules([FilterRule::exclude("*.bak")]).unwrap();
     let mut chain = FilterChain::new(global);
 
-    // Enter outer directory - excludes *.log
     let outer = FilterSet::from_rules([FilterRule::exclude("*.log")]).unwrap();
     let guard_outer = chain.push_scope(outer);
     assert_eq!(chain.scope_depth(), 1);
 
-    // Enter inner directory - excludes *.tmp
     let inner = FilterSet::from_rules([FilterRule::exclude("*.tmp")]).unwrap();
     let guard_inner = chain.push_scope(inner);
     assert_eq!(chain.scope_depth(), 2);
 
-    // All excludes should be active
     assert!(!chain.allows(Path::new("file.bak"), false));
     assert!(!chain.allows(Path::new("file.log"), false));
     assert!(!chain.allows(Path::new("file.tmp"), false));
     assert!(chain.allows(Path::new("file.txt"), false));
 
-    // Leave inner directory
     chain.leave_directory(guard_inner);
     assert_eq!(chain.scope_depth(), 1);
 
-    // Inner excludes should be gone, but outer and global remain
     assert!(!chain.allows(Path::new("file.bak"), false));
     assert!(!chain.allows(Path::new("file.log"), false));
     assert!(chain.allows(Path::new("file.tmp"), false));
 
-    // Leave outer directory
     chain.leave_directory(guard_outer);
     assert_eq!(chain.scope_depth(), 0);
 
-    // Only global excludes remain
     assert!(!chain.allows(Path::new("file.bak"), false));
     assert!(chain.allows(Path::new("file.log"), false));
     assert!(chain.allows(Path::new("file.tmp"), false));
@@ -190,7 +177,6 @@ fn filter_chain_enter_directory_reads_merge_file() {
 #[test]
 fn filter_chain_enter_directory_no_merge_file() {
     let dir = TempDir::new().unwrap();
-    // No .rsync-filter file exists
 
     let mut chain = FilterChain::empty();
     chain.add_merge_config(DirMergeConfig::new(".rsync-filter"));
@@ -198,7 +184,6 @@ fn filter_chain_enter_directory_no_merge_file() {
     let guard = chain.enter_directory(dir.path()).unwrap();
     assert_eq!(guard.pushed_count(), 0);
 
-    // Everything should be allowed (no rules)
     assert!(chain.allows(Path::new("file.tmp"), false));
 
     chain.leave_directory(guard);
@@ -247,9 +232,7 @@ fn filter_chain_enter_directory_exclude_self() {
     let guard = chain.enter_directory(dir.path()).unwrap();
     assert_eq!(guard.pushed_count(), 1);
 
-    // The merge file itself should be excluded
     assert!(!chain.allows(Path::new(".rsync-filter"), false));
-    // And the rule from the file should apply
     assert!(!chain.allows(Path::new("file.tmp"), false));
 
     chain.leave_directory(guard);
@@ -265,7 +248,6 @@ fn filter_chain_enter_directory_with_include_rules() {
 
     let guard = chain.enter_directory(dir.path()).unwrap();
 
-    // *.important should be included, everything else excluded
     assert!(chain.allows(Path::new("file.important"), false));
     assert!(!chain.allows(Path::new("file.txt"), false));
 
@@ -276,12 +258,10 @@ fn filter_chain_enter_directory_with_include_rules() {
 fn filter_chain_nested_directories_with_merge_files() {
     let dir = TempDir::new().unwrap();
 
-    // Create outer directory with merge file
     let outer = dir.path().join("outer");
     fs::create_dir(&outer).unwrap();
     fs::write(outer.join(".rsync-filter"), "- *.log\n").unwrap();
 
-    // Create inner directory with merge file
     let inner = outer.join("inner");
     fs::create_dir(&inner).unwrap();
     fs::write(inner.join(".rsync-filter"), "- *.tmp\n").unwrap();
@@ -289,22 +269,18 @@ fn filter_chain_nested_directories_with_merge_files() {
     let mut chain = FilterChain::empty();
     chain.add_merge_config(DirMergeConfig::new(".rsync-filter"));
 
-    // Enter outer directory
     let guard_outer = chain.enter_directory(&outer).unwrap();
     assert!(!chain.allows(Path::new("file.log"), false));
     assert!(chain.allows(Path::new("file.tmp"), false));
 
-    // Enter inner directory
     let guard_inner = chain.enter_directory(&inner).unwrap();
     assert!(!chain.allows(Path::new("file.log"), false));
     assert!(!chain.allows(Path::new("file.tmp"), false));
 
-    // Leave inner
     chain.leave_directory(guard_inner);
     assert!(!chain.allows(Path::new("file.log"), false));
     assert!(chain.allows(Path::new("file.tmp"), false));
 
-    // Leave outer
     chain.leave_directory(guard_outer);
     assert!(chain.allows(Path::new("file.log"), false));
     assert!(chain.allows(Path::new("file.tmp"), false));
@@ -333,7 +309,6 @@ fn filter_chain_multiple_merge_configs() {
 #[test]
 fn filter_chain_parse_error_in_merge_file() {
     let dir = TempDir::new().unwrap();
-    // Invalid filter syntax
     fs::write(dir.path().join(".rsync-filter"), "invalid_directive\n").unwrap();
 
     let mut chain = FilterChain::empty();
@@ -355,7 +330,7 @@ fn filter_chain_modifier_application() {
 
     let guard = chain.enter_directory(dir.path()).unwrap();
 
-    // Rules should be applied (perishable doesn't affect allows())
+    // perishable does not affect allows(); only delete-excluded processing.
     assert!(!chain.allows(Path::new("file.tmp"), false));
 
     chain.leave_directory(guard);
@@ -427,7 +402,6 @@ fn filter_chain_scope_push_pop_symmetry() {
 
     assert_eq!(chain.scope_depth(), 5);
 
-    // Pop all at once by using depth tracking
     chain.scopes.clear();
     chain.current_depth = 0;
     assert_eq!(chain.scope_depth(), 0);
@@ -436,7 +410,6 @@ fn filter_chain_scope_push_pop_symmetry() {
 #[test]
 fn filter_chain_default_allows_everything() {
     let chain = FilterChain::empty();
-    // With no rules at all, everything should be allowed
     assert!(chain.allows(Path::new("any/path/here.txt"), false));
     assert!(chain.allows(Path::new("directory"), true));
     assert!(chain.allows_deletion(Path::new("anything"), false));
@@ -447,7 +420,6 @@ fn filter_chain_global_rules_persist_across_scopes() {
     let global = FilterSet::from_rules([FilterRule::exclude("*.bak")]).unwrap();
     let mut chain = FilterChain::new(global);
 
-    // Enter and leave several directories
     for _ in 0..3 {
         let dir_rules = FilterSet::from_rules([FilterRule::exclude("*.tmp")]).unwrap();
         let guard = chain.push_scope(dir_rules);
@@ -455,7 +427,6 @@ fn filter_chain_global_rules_persist_across_scopes() {
         chain.leave_directory(guard);
     }
 
-    // Global rules should still work
     assert!(!chain.allows(Path::new("file.bak"), false));
 }
 

--- a/crates/filters/src/debug_filter.rs
+++ b/crates/filters/src/debug_filter.rs
@@ -377,11 +377,11 @@ mod tests {
     #[test]
     fn test_record_evaluation_mixed() {
         let mut tracer = FilterTracer::new();
-        tracer.record_evaluation(true); // include
-        tracer.record_evaluation(false); // exclude
-        tracer.record_evaluation(true); // include
-        tracer.record_evaluation(false); // exclude
-        tracer.record_evaluation(true); // include
+        tracer.record_evaluation(true);
+        tracer.record_evaluation(false);
+        tracer.record_evaluation(true);
+        tracer.record_evaluation(false);
+        tracer.record_evaluation(true);
 
         assert_eq!(tracer.total_evaluated(), 5);
         assert_eq!(tracer.total_included(), 3);
@@ -472,7 +472,6 @@ mod tests {
 
     #[test]
     fn test_trace_functions_do_not_panic() {
-        // All trace functions should be callable without panicking
         trace_filter_rule_added("*.tmp", false, false);
         trace_filter_rule_added("/var/log/", false, true);
         trace_filter_rule_added("important/", true, true);
@@ -497,7 +496,6 @@ mod tests {
         tracer.record_evaluation(true);
         tracer.record_evaluation(false);
 
-        // Should not panic
         tracer.summary();
     }
 
@@ -521,12 +519,10 @@ mod tests {
     fn test_multiple_operations() {
         let mut tracer = FilterTracer::new();
 
-        // First batch
         tracer.record_rule_added();
         tracer.record_evaluation(true);
         tracer.record_evaluation(false);
 
-        // Reset and second batch
         tracer.reset();
         tracer.record_rule_added();
         tracer.record_rule_added();
@@ -541,9 +537,8 @@ mod tests {
     #[cfg(feature = "tracing")]
     #[test]
     fn test_tracing_feature_enabled() {
-        // When tracing feature is enabled, verify the functions compile and run
-        // without panicking. We can't easily verify event emission without
-        // tracing-subscriber, but this at least confirms the code compiles.
+        // We cannot verify event emission without a `tracing-subscriber`, but
+        // this confirms the feature-gated code path compiles and runs.
         let mut tracer = FilterTracer::new();
 
         trace_filter_rule_added("*.log", false, false);

--- a/crates/filters/src/rule.rs
+++ b/crates/filters/src/rule.rs
@@ -580,7 +580,6 @@ mod tests {
 
         #[test]
         fn negate_default_false() {
-            // All constructors should have negate=false by default
             assert!(!FilterRule::include("*").is_negated());
             assert!(!FilterRule::exclude("*").is_negated());
             assert!(!FilterRule::protect("*").is_negated());
@@ -596,7 +595,6 @@ mod tests {
         fn negate_included_in_equality() {
             let rule1 = FilterRule::exclude("*.txt");
             let rule2 = FilterRule::exclude("*.txt").with_negate(true);
-            // Rules should not be equal since negate differs
             assert_ne!(rule1, rule2);
         }
 

--- a/crates/filters/src/tests.rs
+++ b/crates/filters/src/tests.rs
@@ -254,22 +254,19 @@ fn sender_only_risk_does_not_clear_receiver_protection() {
     assert!(!set.allows_deletion(Path::new("keep/item.txt"), false));
 }
 
-// Tests for negated pattern matching (upstream rsync `!` modifier)
+/// Tests for negated pattern matching (upstream rsync `!` modifier).
 mod negate_tests {
     use super::*;
 
     #[test]
     fn negated_exclude_excludes_non_matching_files() {
-        // A negated exclude rule excludes files that do NOT match the pattern
-        // e.g., `- ! *.txt` excludes everything except .txt files
+        // `- ! *.txt` excludes everything except .txt files.
         let rules = [FilterRule::exclude("*.txt").with_negate(true)];
         let set = FilterSet::from_rules(rules).expect("compiled");
 
-        // Files that match *.txt should be allowed (negate inverts the match)
         assert!(set.allows(Path::new("file.txt"), false));
         assert!(set.allows(Path::new("dir/file.txt"), false));
 
-        // Files that don't match *.txt should be excluded
         assert!(!set.allows(Path::new("file.log"), false));
         assert!(!set.allows(Path::new("file.bak"), false));
         assert!(!set.allows(Path::new("dir/file.log"), false));
@@ -277,58 +274,49 @@ mod negate_tests {
 
     #[test]
     fn negated_include_includes_non_matching_files() {
-        // A negated include rule includes files that do NOT match the pattern
-        // e.g., `+ ! *.bak` includes everything except .bak files
-        // rsync uses first-match-wins: include must come before exclude
+        // `+ ! *.bak` includes everything except .bak; first-match-wins
+        // requires the include to precede the trailing exclude-all.
         let rules = [
             FilterRule::include("*.bak").with_negate(true),
             FilterRule::exclude("*"),
         ];
         let set = FilterSet::from_rules(rules).expect("compiled");
 
-        // Files that don't match *.bak should be included (negated include matches)
         assert!(set.allows(Path::new("file.txt"), false));
         assert!(set.allows(Path::new("file.log"), false));
 
-        // Files that match *.bak should be excluded (negated include doesn't match,
-        // falls through to exclude("*"))
+        // *.bak falls through to the exclude("*") rule.
         assert!(!set.allows(Path::new("file.bak"), false));
     }
 
     #[test]
     fn negated_pattern_with_directory() {
-        // Negated directory-only pattern
         let rules = [FilterRule::exclude("cache/").with_negate(true)];
         let set = FilterSet::from_rules(rules).expect("compiled");
 
-        // Directories named "cache" should be allowed (pattern matches, negated)
         assert!(set.allows(Path::new("cache"), true));
 
-        // Other directories should be excluded (pattern doesn't match, negated)
         assert!(!set.allows(Path::new("temp"), true));
         assert!(!set.allows(Path::new("build"), true));
     }
 
     #[test]
     fn negated_pattern_with_anchored() {
-        // Negated anchored pattern: excludes anything not at /important
         let rules = [FilterRule::exclude("/important").with_negate(true)];
         let set = FilterSet::from_rules(rules).expect("compiled");
 
-        // /important should be allowed (pattern matches, negated)
         assert!(set.allows(Path::new("important"), false));
 
-        // Other paths should be excluded (pattern doesn't match, negated)
         assert!(!set.allows(Path::new("other"), false));
-        assert!(!set.allows(Path::new("dir/important"), false)); // Not anchored match
+        // "dir/important" is not an anchored match, so negation excludes it.
+        assert!(!set.allows(Path::new("dir/important"), false));
     }
 
     #[test]
     fn negated_rules_combine_with_regular_rules() {
-        // Mix negated and regular rules
         let rules = [
-            FilterRule::exclude("*.tmp"),                   // Regular: exclude .tmp
-            FilterRule::exclude("*.txt").with_negate(true), // Negated: exclude non-.txt
+            FilterRule::exclude("*.tmp"),
+            FilterRule::exclude("*.txt").with_negate(true),
         ];
         let set = FilterSet::from_rules(rules).expect("compiled");
 
@@ -396,14 +384,12 @@ mod properties {
     proptest! {
         #[test]
         fn include_exclude_duality(pattern in valid_pattern()) {
-            // An include rule should make applies_to_sender and applies_to_receiver true
             let include = FilterRule::include(&pattern);
             prop_assert!(include.applies_to_sender());
             prop_assert!(include.applies_to_receiver());
             prop_assert_eq!(include.action(), FilterAction::Include);
             prop_assert_eq!(include.pattern(), &pattern);
 
-            // An exclude rule should also apply to both sides by default
             let exclude = FilterRule::exclude(&pattern);
             prop_assert!(exclude.applies_to_sender());
             prop_assert!(exclude.applies_to_receiver());
@@ -470,7 +456,6 @@ mod properties {
         ) {
             let rule = FilterRule::exclude(&pattern).with_perishable(perishable);
             prop_assert_eq!(rule.is_perishable(), perishable);
-            // Other properties should be unaffected
             prop_assert_eq!(rule.action(), FilterAction::Exclude);
         }
     }
@@ -544,7 +529,6 @@ mod evaluation_properties {
                 FilterRule::exclude("*"),
             ];
             let set = FilterSet::from_rules(rules).unwrap();
-            // The included file should be allowed
             prop_assert!(set.allows(Path::new(&file), false));
         }
 
@@ -602,7 +586,6 @@ mod evaluation_properties {
                 rules.push(FilterRule::exclude(&pattern));
             }
             let set = FilterSet::from_rules(rules).unwrap();
-            // First rule is include, so it wins regardless of how many excludes follow
             prop_assert!(set.allows(Path::new(&file), false));
         }
 
@@ -618,9 +601,7 @@ mod evaluation_properties {
             let pattern_a = format!("*.{ext_a}");
 
             let set = FilterSet::from_rules(vec![FilterRule::exclude(&pattern_a)]).unwrap();
-            // file_a matches the exclude pattern
             prop_assert!(!set.allows(Path::new(&file_a), false));
-            // file_b does not match, so it is allowed by default
             prop_assert!(set.allows(Path::new(&file_b), false));
         }
 
@@ -655,7 +636,6 @@ mod evaluation_properties {
                 FilterRule::clear(),
             ];
             let set = FilterSet::from_rules(rules).unwrap();
-            // After clear, no rules remain - path is allowed by default
             prop_assert!(set.allows(Path::new(&file), false));
         }
 
@@ -710,9 +690,7 @@ mod evaluation_properties {
             let rules = vec![FilterRule::exclude(&pattern).with_sides(true, false)];
             let set = FilterSet::from_rules(rules).unwrap();
             let path = Path::new(&file);
-            // Sender-side: blocked for transfer
             prop_assert!(!set.allows(path, false));
-            // Receiver-side: not blocked for deletion (rule doesn't apply)
             prop_assert!(set.allows_deletion(path, false));
         }
     }


### PR DESCRIPTION
## Summary

- Strip restatement comments across the filters crate test suite that echoed nearby `assert!` calls or labelled obvious test steps (enter/leave directory, batch markers).
- Promote the `negate_tests` module banner to a real `///` rustdoc summary so the relationship to upstream's `!` modifier is preserved.
- Keep every `upstream:` cite (`exclude.c`, `parse_filter_str`) and every information-bearing inline note (e.g., `// From nested file`, FILTRULE_NEGATE pointer to line 906).

## Files touched

- `crates/filters/src/chain/tests.rs`
- `crates/filters/src/debug_filter.rs`
- `crates/filters/src/rule.rs`
- `crates/filters/src/tests.rs`

Net: +20 / -78 lines.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings`
- [x] `cargo check -p filters --all-features`
- [x] `cargo nextest run -p filters -E 'test(parse) or test(rule)'` (419 passed)