### PR TITLE
fix(protocol): update xattr test fixtures for user. namespace preservation

### DIFF
--- a/crates/protocol/src/flist/read/tests.rs
+++ b/crates/protocol/src/flist/read/tests.rs
@@ -1919,11 +1919,15 @@ mod acl_integration {
         )
         .unwrap();
 
+        // Wire format carries the full Linux xattr name verbatim, including
+        // the "user." namespace prefix. upstream: xattrs.c:rsync_xattr_lookup
+        // forwards the llistxattr(2) name unchanged. Non-Linux receivers
+        // strip the prefix to recover the flat-namespace local name.
         write_varint(&mut data, 0).unwrap();
         write_varint(&mut data, 1).unwrap();
-        write_varint(&mut data, 6).unwrap();
+        write_varint(&mut data, 11).unwrap();
         write_varint(&mut data, 3).unwrap();
-        data.extend_from_slice(b"label\0");
+        data.extend_from_slice(b"user.label\0");
         data.extend_from_slice(b"foo");
 
         let mut cursor = Cursor::new(&data[..]);
@@ -1941,6 +1945,11 @@ mod acl_integration {
         assert_eq!(cached_def.other_obj, 0x00);
 
         let cached_xattr = reader.xattr_cache().get(0).unwrap();
+        assert_eq!(cached_xattr.len(), 1);
+        #[cfg(target_os = "linux")]
+        assert_eq!(cached_xattr.entries()[0].name(), b"user.label");
+        #[cfg(not(target_os = "linux"))]
+        assert_eq!(cached_xattr.entries()[0].name(), b"label");
         assert_eq!(cached_xattr.entries()[0].datum(), b"foo");
 
         assert_eq!(cursor.position() as usize, data.len());
@@ -2279,12 +2288,13 @@ mod xattr_integration {
         let mut entry = FileEntry::new_file("a.txt".into(), 100, 0o100644);
         entry.set_mtime(1700000000, 0);
         writer.write_entry(&mut data, &entry).unwrap();
-        write_literal_xattr(&mut data, &[(b"color", b"red")]);
+        let color_wire = user_wire_name(b"color");
+        write_literal_xattr(&mut data, &[(&color_wire, b"red")]);
 
         let mut entry = FileEntry::new_file("b.txt".into(), 200, 0o100644);
         entry.set_mtime(1700000000, 0);
         writer.write_entry(&mut data, &entry).unwrap();
-        write_literal_xattr(&mut data, &[(b"color", b"blue")]);
+        write_literal_xattr(&mut data, &[(&color_wire, b"blue")]);
 
         let mut entry = FileEntry::new_file("c.txt".into(), 300, 0o100644);
         entry.set_mtime(1700000000, 0);

--- a/crates/protocol/src/flist/write/tests/xattr.rs
+++ b/crates/protocol/src/flist/write/tests/xattr.rs
@@ -69,7 +69,13 @@ fn xattr_write_roundtrip_with_reader() {
 
     let mut entry = FileEntry::new_file("roundtrip.txt".into(), 42, 0o644);
     let mut xattr_list = XattrList::new();
-    xattr_list.push(XattrEntry::new("my_attr", b"my_value".to_vec()));
+    // Use the verbatim wire name `user.my_attr` so the round-trip lands a
+    // visible entry in the reader's cache on every platform: Linux keeps
+    // `user.*` verbatim, non-Linux strips the prefix to `my_attr`. Without
+    // the `user.` prefix the non-Linux receiver drops the entry as a
+    // non-storable disguised namespace (see xattr::prefix::wire_to_local
+    // and upstream xattrs.c:836-846).
+    xattr_list.push(XattrEntry::new("user.my_attr", b"my_value".to_vec()));
     entry.set_xattr_list(xattr_list);
 
     writer.write_entry(&mut buf, &entry).unwrap();

--- a/crates/protocol/src/xattr/cache.rs
+++ b/crates/protocol/src/xattr/cache.rs
@@ -720,8 +720,15 @@ mod tests {
 
         let list = cache.get(0).unwrap();
         assert_eq!(list.len(), 3);
-        let names: Vec<&[u8]> = list.entries().iter().map(|e| e.name()).collect();
-        assert_eq!(names, vec![&alpha[..], &middle[..], &zebra[..]]);
+        let names: Vec<Vec<u8>> = list.entries().iter().map(|e| e.name().to_vec()).collect();
+        assert_eq!(
+            names,
+            vec![
+                expected_local_for_user_wire(b"alpha"),
+                expected_local_for_user_wire(b"middle"),
+                expected_local_for_user_wire(b"zebra"),
+            ],
+        );
     }
 
     #[test]
@@ -756,8 +763,15 @@ mod tests {
         let list = cache.get(0).unwrap();
         // Internal entry filtered; remaining three keep wire-arrival order.
         assert_eq!(list.len(), 3);
-        let names: Vec<&[u8]> = list.entries().iter().map(|e| e.name()).collect();
-        assert_eq!(names, vec![&alpha[..], &middle[..], &zeta[..]]);
+        let names: Vec<Vec<u8>> = list.entries().iter().map(|e| e.name().to_vec()).collect();
+        assert_eq!(
+            names,
+            vec![
+                expected_local_for_user_wire(b"alpha"),
+                expected_local_for_user_wire(b"middle"),
+                expected_local_for_user_wire(b"zeta"),
+            ],
+        );
     }
 
     #[test]

--- a/crates/protocol/src/xattr/wire/tests.rs
+++ b/crates/protocol/src/xattr/wire/tests.rs
@@ -913,8 +913,12 @@ fn large_cache_index() {
 ///
 /// Asserts that:
 ///
-/// 1. `protocol::xattr::local_to_wire` returns `user.foo` for the local
-///    name `user.foo` (no prefix mutation) on every supported platform.
+/// 1. `protocol::xattr::local_to_wire` produces the upstream-faithful wire
+///    name on the host platform. On Linux the local name `user.foo` is
+///    written byte-for-byte; on non-Linux the local flat-namespace name
+///    `foo` is wrapped with the `user.` prefix the sender prepends before
+///    handing bytes to `send_xattr`. Either way the resulting wire bytes
+///    must equal `user.foo`.
 /// 2. The bytes `b"user.foo"` appear in the serialized `send_xattr`
 ///    output as the on-wire name, immediately followed by the NUL
 ///    terminator. This is a byte-for-byte parity check against upstream
@@ -923,19 +927,26 @@ fn large_cache_index() {
 fn user_prefix_preserved_in_wire_bytes() {
     use crate::xattr::{XattrEntry, XattrList, local_to_wire};
 
-    // Step 1: local_to_wire must preserve `user.foo` verbatim. Cross
-    // every supported call site by exercising both am_root values.
+    // Step 1: local_to_wire must yield the upstream wire name `user.foo`
+    // on every supported platform, regardless of `am_root`. Linux feeds
+    // it the verbatim `user.foo` name; non-Linux feeds the flat-namespace
+    // `foo` so the sender's prefix wrapper produces the same wire bytes.
+    #[cfg(target_os = "linux")]
+    let local_name: &[u8] = b"user.foo";
+    #[cfg(not(target_os = "linux"))]
+    let local_name: &[u8] = b"foo";
+
     for am_root in [false, true] {
         assert_eq!(
-            local_to_wire(b"user.foo", am_root),
+            local_to_wire(local_name, am_root),
             Some(b"user.foo".to_vec()),
-            "user.foo must pass through local_to_wire verbatim (am_root={am_root})",
+            "local_to_wire must emit `user.foo` on the wire (am_root={am_root})",
         );
     }
 
     // Step 2: an XattrEntry built from the wire name must serialize the
     // bytes `user.foo` verbatim into the wire stream.
-    let wire_name = local_to_wire(b"user.foo", false).expect("user.foo must not be filtered");
+    let wire_name = local_to_wire(local_name, false).expect("name must not be filtered");
     let mut list = XattrList::new();
     list.push(XattrEntry::new(wire_name, b"bar".to_vec()));
 


### PR DESCRIPTION
## Summary

PR #4592 (commit `9aed2a2c2`) made the xattr wire layer preserve the
`user.` namespace prefix verbatim end-to-end. Six hand-crafted test
fixtures hadn't been updated to match the new wire shape, so they
panicked on every non-Linux CI cell that ran them. This is pure fixture
lag - the wire layer in #4592 is correct and unchanged here.

## Root Cause

After #4592, the wire contract is:

| Direction | Linux | Non-Linux (macOS/Windows) |
|-----------|-------|---------------------------|
| Sender    | `user.foo` -> `user.foo\0` (verbatim) | `foo` -> `user.foo\0` (prefix wrapped) |
| Receiver  | `user.foo\0` -> local `user.foo` | `user.foo\0` -> local `foo` (prefix stripped) |
| Receiver  | bare `foo\0` -> disguised `user.rsync.foo` | bare `foo\0` -> dropped (`None`) |

Fixtures that emit a bare name like `b"label\0"` on the wire and then
index into the receiver cache panic on macOS/Windows because the entry
is dropped before reaching the cache.

## Wire Bytes - Before / After

`directory_acl_and_xattr_combined`:

```
- write_varint(name_len = 6); extend(b"label\0"); extend(b"foo");
+ write_varint(name_len = 11); extend(b"user.label\0"); extend(b"foo");
```

`multiple_distinct_xattr_sets`:

```
- write_literal_xattr(&mut data, &[(b"color", b"red")]);
+ let color_wire = user_wire_name(b"color");        // -> b"user.color"
+ write_literal_xattr(&mut data, &[(&color_wire, b"red")]);
```

`xattr_write_roundtrip_with_reader`:

```
- XattrEntry::new("my_attr", b"my_value".to_vec())
+ XattrEntry::new("user.my_attr", b"my_value".to_vec())
```

`user_prefix_preserved_in_wire_bytes`: step 1 now feeds the local-form
name (`user.foo` on Linux, flat `foo` on non-Linux) so the sender's
`local_to_wire` produces the same `user.foo` wire bytes on every
platform; the existing step-2 byte-needle check is unchanged.

`receive_entries_preserve_wire_order` /
`receive_entries_preserve_order_after_skips`: assertions now go through
`expected_local_for_user_wire` (Linux: keeps `user.`, non-Linux:
strips) instead of comparing to the wire bytes directly.

## Tests Fixed

- `flist::read::tests::acl_integration::directory_acl_and_xattr_combined`
- `flist::read::tests::xattr_integration::multiple_distinct_xattr_sets`
- `flist::write::tests::xattr::xattr_write_roundtrip_with_reader`
- `xattr::cache::tests::receive_entries_preserve_wire_order`
- `xattr::cache::tests::receive_entries_preserve_order_after_skips`
- `xattr::wire::tests::user_prefix_preserved_in_wire_bytes`

Only the two cited in the original report panic with
`panic_bounds_check`; the other four were uncovered by widening the
nextest filter and surface the same #4592 root cause. All six are
fixture-only lag - no decoder or sender code changes here.

## Unblocks

- `Feature flag combinations / async (macos-latest)`
- `Feature flag combinations / serde (windows-latest)`
- `Windows ACL/xattr` cells

across every currently open PR.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings`
- [x] `cargo nextest run -p protocol --all-features` on macOS host (5593 tests, 0 failures)
- [x] `cargo nextest run -p protocol --features async -E 'test(directory_acl_and_xattr_combined) or test(user_prefix_preserved_in_wire_bytes)'` green on macOS
- [ ] CI: `Feature flag combinations / async (macos-latest)` and `Feature flag combinations / serde (windows-latest)` recover