### PR TITLE
docs(cli): drop restatement comments and apply rustdoc to public items

### DIFF
--- a/crates/cli/src/frontend/execution/file_list/tests.rs
+++ b/crates/cli/src/frontend/execution/file_list/tests.rs
@@ -6,8 +6,6 @@ use super::loader::{push_file_list_entry, read_file_list_from_reader};
 use super::parser::{operand_is_remote, resolve_files_from_source, transfer_requires_remote};
 use super::resolver::resolve_file_list_entries;
 
-// operand_is_remote tests
-
 #[test]
 fn operand_is_remote_rsync_url() {
     assert!(operand_is_remote(OsStr::new("rsync://example.com/module")));
@@ -49,7 +47,7 @@ fn operand_is_remote_local_paths() {
 
 #[test]
 fn operand_is_remote_local_path_with_slash_before_colon() {
-    // Paths with a slash before the colon are local
+    // A slash before the colon disambiguates local paths from host:path syntax.
     assert!(!operand_is_remote(OsStr::new("/path/with:colon")));
     assert!(!operand_is_remote(OsStr::new("some/path:with:colons")));
 }
@@ -64,8 +62,6 @@ fn operand_is_remote_no_colon() {
     assert!(!operand_is_remote(OsStr::new("simple-filename")));
     assert!(!operand_is_remote(OsStr::new("path/to/file")));
 }
-
-// read_file_list_from_reader tests
 
 #[test]
 fn read_file_list_newline_terminated() {
@@ -149,7 +145,7 @@ fn read_file_list_zero_terminated_no_trailing_null() {
 
 #[test]
 fn read_file_list_zero_terminated_allows_hash_and_semicolon() {
-    // With zero termination, # and ; are not treated as comments
+    // upstream: --from0 disables comment handling, so `#` / `;` are literal.
     let input = b"#not-a-comment\0;also-not-a-comment\0";
     let mut reader = Cursor::new(input);
     let mut entries = Vec::new();
@@ -183,8 +179,6 @@ fn read_file_list_empty_lines_skipped() {
     assert_eq!(entries.len(), 2);
 }
 
-// resolve_file_list_entries tests
-
 #[test]
 fn resolve_file_list_entries_empty_entries() {
     let mut entries: Vec<OsString> = Vec::new();
@@ -202,7 +196,7 @@ fn resolve_file_list_entries_single_operand_no_change() {
 
     resolve_file_list_entries(&mut entries, &operands, false, false);
 
-    // Single operand means no base path to prepend
+    // With one operand there is no source base to prepend.
     assert_eq!(entries[0], "file.txt");
 }
 
@@ -213,7 +207,7 @@ fn resolve_file_list_entries_relative_enabled() {
 
     resolve_file_list_entries(&mut entries, &operands, true, false);
 
-    // With relative paths enabled, no resolution happens
+    // upstream: --relative defers path resolution to the receiver.
     assert_eq!(entries[0], "file.txt");
 }
 
@@ -224,7 +218,7 @@ fn resolve_file_list_entries_prepends_base() {
 
     resolve_file_list_entries(&mut entries, &operands, false, false);
 
-    // Path::push uses platform-specific separators
+    // Path::join uses the platform separator (verified via Path, not literal).
     let expected = Path::new("/base/path").join("subdir/file.txt");
     assert_eq!(entries[0], expected.as_os_str());
 }
@@ -236,7 +230,6 @@ fn resolve_file_list_entries_absolute_path_unchanged() {
 
     resolve_file_list_entries(&mut entries, &operands, false, false);
 
-    // Absolute paths are not modified
     assert_eq!(entries[0], "/absolute/path.txt");
 }
 
@@ -247,7 +240,6 @@ fn resolve_file_list_entries_remote_base_no_change() {
 
     resolve_file_list_entries(&mut entries, &operands, false, false);
 
-    // Remote base path means no resolution
     assert_eq!(entries[0], "file.txt");
 }
 
@@ -258,7 +250,6 @@ fn resolve_file_list_entries_remote_entry_no_change() {
 
     resolve_file_list_entries(&mut entries, &operands, false, false);
 
-    // Remote entries are not modified
     assert_eq!(entries[0], "host:remote/file.txt");
 }
 
@@ -273,7 +264,7 @@ fn resolve_file_list_entries_multiple_sources_no_change() {
 
     resolve_file_list_entries(&mut entries, &operands, false, false);
 
-    // Multiple source operands means no single base, so no resolution
+    // Multiple sources have no single base to resolve against.
     assert_eq!(entries[0], "file.txt");
 }
 
@@ -285,12 +276,9 @@ fn resolve_file_list_entries_empty_entry_unchanged() {
     resolve_file_list_entries(&mut entries, &operands, false, false);
 
     assert_eq!(entries[0], "");
-    // Path::push uses platform-specific separators
     let expected = Path::new("/base").join("file.txt");
     assert_eq!(entries[1], expected.as_os_str());
 }
-
-// resolve_file_list_entries (files_from_active) tests
 
 #[test]
 fn resolve_file_list_entries_files_from_inserts_dot_marker() {
@@ -316,7 +304,8 @@ fn resolve_file_list_entries_files_from_nested_path_with_marker() {
 
 #[test]
 fn resolve_file_list_entries_files_from_with_relative_still_inserts_marker() {
-    // --files-from always resolves with marker, even when --relative is on
+    // upstream: --files-from always inserts the "/./" marker, including when
+    // --relative is active.
     let mut entries = vec![OsString::from("file.txt")];
     let operands = vec![OsString::from("/base"), OsString::from("/dest")];
 
@@ -358,8 +347,6 @@ fn resolve_file_list_entries_files_from_remote_base_no_change() {
     assert_eq!(entries[0], "file.txt");
 }
 
-// transfer_requires_remote tests
-
 #[test]
 fn transfer_requires_remote_all_local() {
     let remainder = vec![OsString::from("/local/path"), OsString::from("/dest")];
@@ -391,8 +378,6 @@ fn transfer_requires_remote_both_empty() {
 
     assert!(!transfer_requires_remote(&remainder, &file_list));
 }
-
-// push_file_list_entry tests
 
 #[test]
 fn push_file_list_entry_empty_bytes() {
@@ -439,8 +424,6 @@ fn push_file_list_entry_with_path() {
     assert_eq!(entries.len(), 1);
     assert_eq!(entries[0], "path/to/file.txt");
 }
-
-// resolve_files_from_source tests
 
 #[test]
 fn resolve_files_from_empty_returns_none() {

--- a/crates/cli/src/frontend/execution/stop.rs
+++ b/crates/cli/src/frontend/execution/stop.rs
@@ -593,13 +593,11 @@ mod tests {
 
     #[test]
     fn offset_datetime_converts_future() {
-        // Create a datetime in 2030
         let date = Date::from_calendar_date(2030, Month::June, 15).unwrap();
         let time = Time::from_hms(12, 30, 0).unwrap();
         let datetime = PrimitiveDateTime::new(date, time).assume_utc();
         let result = offset_datetime_to_system_time(datetime);
         assert!(result.is_ok());
-        // Verify it's after now
         assert!(result.unwrap() > SystemTime::now());
     }
 

--- a/crates/cli/src/frontend/out_format/render/tests.rs
+++ b/crates/cli/src/frontend/out_format/render/tests.rs
@@ -1343,7 +1343,6 @@ fn render_percent_f_no_trailing_slash_for_directory() {
         LocalCopyChangeSet::new(),
     );
     let rendered = render_format("%f", &event);
-    // %f uses render_path(event, false) so should not add trailing slash
     assert!(
         !rendered.trim().ends_with('/'),
         "%%f should not add trailing slash: {rendered:?}"
@@ -1358,7 +1357,7 @@ fn render_percent_l_shows_file_length() {
         Some(ClientEntryKind::File),
         LocalCopyChangeSet::new(),
     );
-    // test_metadata sets length to 0
+    // test_metadata seeds length=0.
     assert_eq!(render_format("%l", &event), "0\n");
 }
 
@@ -1370,7 +1369,7 @@ fn render_percent_b_shows_bytes_transferred() {
         Some(ClientEntryKind::File),
         LocalCopyChangeSet::new(),
     );
-    // for_test always sets bytes_transferred to 0
+    // ClientEvent::for_test seeds bytes_transferred=0.
     assert_eq!(render_format("%b", &event), "0\n");
 }
 
@@ -1472,7 +1471,7 @@ fn render_percent_b_upper_shows_dashes_for_test_metadata() {
         Some(ClientEntryKind::File),
         LocalCopyChangeSet::new(),
     );
-    // test_metadata has mode = None => "---------"
+    // test_metadata seeds mode=None, which renders as "---------".
     assert_eq!(render_format("%B", &event), "---------\n");
 }
 
@@ -1484,9 +1483,7 @@ fn render_percent_l_upper_shows_nothing_for_regular_file() {
         Some(ClientEntryKind::File),
         LocalCopyChangeSet::new(),
     );
-    // SymlinkTarget returns None for non-symlinks, so nothing is rendered
-    // But since it returns None, the placeholder is omitted entirely
-    // and the output is just the newline
+    // SymlinkTarget yields None for non-symlinks, so %L renders empty.
     assert_eq!(render_format("%L", &event), "\n");
 }
 
@@ -1498,7 +1495,6 @@ fn render_itemize_and_filename_combined_no_space() {
         Some(ClientEntryKind::File),
         LocalCopyChangeSet::new(),
     );
-    // %i%n with no space means the two are concatenated directly
     assert_eq!(render_format("%i%n", &event), ">f+++++++++test.txt\n");
 }
 
@@ -1510,7 +1506,7 @@ fn render_itemize_and_filename_with_space() {
         Some(ClientEntryKind::File),
         LocalCopyChangeSet::new(),
     );
-    // %i %n with a space between them matches upstream -i output
+    // upstream: "-i" output renders %i followed by space then %n.
     assert_eq!(render_format("%i %n", &event), ">f+++++++++ test.txt\n");
 }
 
@@ -1713,15 +1709,13 @@ fn render_output_does_not_double_newline_when_format_ends_with_newline() {
         Some(ClientEntryKind::File),
         LocalCopyChangeSet::new(),
     );
-    // The render function checks if the buffer already ends with '\n'
-    // and doesn't add another one.
+    // render must not append a second '\n' when the buffer already ends with one.
     let format = parse_out_format(std::ffi::OsStr::new("%n")).unwrap();
     let mut output = Vec::new();
     format
         .render(&event, &OutFormatContext::default(), &mut output)
         .unwrap();
     let rendered = String::from_utf8(output).unwrap();
-    // The output should end with exactly one newline
     assert!(rendered.ends_with('\n'));
     assert!(!rendered.ends_with("\n\n"));
 }
@@ -1736,10 +1730,9 @@ fn render_width_right_aligned_filename() {
     );
     let rendered = render_format("%20n", &event);
     let trimmed = rendered.trim_end_matches('\n');
-    // "test.txt" is 8 chars, padded to 20 right-aligned
     assert_eq!(trimmed.len(), 20);
     assert!(trimmed.ends_with("test.txt"));
-    assert!(trimmed.starts_with("            ")); // 12 spaces
+    assert!(trimmed.starts_with("            ")); // 12 spaces (20 - len("test.txt"))
 }
 
 #[test]
@@ -1754,7 +1747,7 @@ fn render_width_left_aligned_filename() {
     let trimmed = rendered.trim_end_matches('\n');
     assert_eq!(trimmed.len(), 20);
     assert!(trimmed.starts_with("test.txt"));
-    assert!(trimmed.ends_with("            ")); // 12 trailing spaces
+    assert!(trimmed.ends_with("            ")); // 12 trailing spaces (20 - len("test.txt"))
 }
 
 #[test]

--- a/crates/cli/src/frontend/tests/archive_completeness.rs
+++ b/crates/cli/src/frontend/tests/archive_completeness.rs
@@ -43,13 +43,11 @@ fn archive_preserves_file_permissions() {
     assert!(stdout.is_empty(), "no stdout expected");
     assert!(stderr.is_empty(), "no stderr expected: {:?}", String::from_utf8_lossy(&stderr));
 
-    // Verify content
     assert_eq!(
         std::fs::read(&destination).expect("read destination"),
         b"permission test"
     );
 
-    // Verify permissions preserved
     let metadata = std::fs::metadata(&destination).expect("dest metadata");
     assert_eq!(
         metadata.permissions().mode() & 0o777,
@@ -84,13 +82,11 @@ fn archive_preserves_modification_times() {
     assert!(stdout.is_empty(), "no stdout expected");
     assert!(stderr.is_empty(), "no stderr expected");
 
-    // Verify content
     assert_eq!(
         std::fs::read(&destination).expect("read destination"),
         b"timestamp test"
     );
 
-    // Verify modification time preserved
     let metadata = std::fs::metadata(&destination).expect("dest metadata");
     let dest_mtime = FileTime::from_last_modification_time(&metadata);
     assert_eq!(
@@ -109,13 +105,12 @@ fn archive_copies_directories_recursively() {
     let source_dir = tmp.path().join("source_dir");
     let dest_dir = tmp.path().join("dest_dir");
 
-    // Create nested directory structure
     std::fs::create_dir(&source_dir).expect("create source dir");
     std::fs::create_dir(source_dir.join("subdir")).expect("create subdir");
     std::fs::write(source_dir.join("file1.txt"), b"file1").expect("write file1");
     std::fs::write(source_dir.join("subdir/file2.txt"), b"file2").expect("write file2");
 
-    // Add trailing slash to source to copy contents into dest
+    // Trailing slash on the source operand copies contents into dest.
     let mut source_path = source_dir.clone().into_os_string();
     source_path.push("/");
 
@@ -130,12 +125,10 @@ fn archive_copies_directories_recursively() {
     assert!(stdout.is_empty(), "no stdout expected");
     assert!(stderr.is_empty(), "no stderr expected: {:?}", String::from_utf8_lossy(&stderr));
 
-    // Verify directory structure was copied recursively
     assert!(dest_dir.join("file1.txt").exists(), "file1.txt should exist");
     assert!(dest_dir.join("subdir").is_dir(), "subdir should exist as directory");
     assert!(dest_dir.join("subdir/file2.txt").exists(), "subdir/file2.txt should exist");
 
-    // Verify file contents
     assert_eq!(
         std::fs::read(dest_dir.join("file1.txt")).expect("read file1"),
         b"file1"
@@ -158,17 +151,14 @@ fn archive_preserves_symlinks() {
     let source_dir = tmp.path().join("source");
     let dest_dir = tmp.path().join("dest");
 
-    // Create source directory structure
     fs::create_dir(&source_dir).expect("create source dir");
     fs::create_dir(&dest_dir).expect("create dest dir");
 
-    // Create a target file and a symlink to it
     let target = source_dir.join("target.txt");
     let link = source_dir.join("link.txt");
     fs::write(&target, b"target content").expect("write target");
     symlink("target.txt", &link).expect("create symlink");
 
-    // Transfer with archive mode
     let mut source_path = source_dir.clone().into_os_string();
     source_path.push("/");
 
@@ -183,7 +173,6 @@ fn archive_preserves_symlinks() {
     assert!(stdout.is_empty(), "no stdout expected");
     assert!(stderr.is_empty(), "no stderr expected: {:?}", String::from_utf8_lossy(&stderr));
 
-    // Verify symlink was preserved
     let dest_link = dest_dir.join("link.txt");
     let dest_target = dest_dir.join("target.txt");
 
@@ -193,7 +182,6 @@ fn archive_preserves_symlinks() {
         "link.txt should be a symlink"
     );
 
-    // Verify symlink points to correct target
     let link_target = fs::read_link(&dest_link).expect("read link target");
     assert_eq!(
         link_target.to_string_lossy(),
@@ -213,7 +201,6 @@ fn archive_preserves_permissions_and_times() {
     let source = tmp.path().join("source-combined.txt");
     let destination = tmp.path().join("dest-combined.txt");
 
-    // Create source file with specific permissions and time
     std::fs::write(&source, b"combined test").expect("write source");
     std::fs::set_permissions(&source, PermissionsExt::from_mode(0o640)).expect("set perms");
     let mtime = FileTime::from_unix_time(1_500_000_000, 0);
@@ -229,7 +216,6 @@ fn archive_preserves_permissions_and_times() {
     assert_eq!(code, 0, "rsync should succeed");
     assert!(stderr.is_empty(), "no stderr expected: {:?}", String::from_utf8_lossy(&stderr));
 
-    // Verify both permissions and times preserved
     let metadata = std::fs::metadata(&destination).expect("dest metadata");
     assert_eq!(
         metadata.permissions().mode() & 0o777,
@@ -252,7 +238,6 @@ fn archive_no_perms_skips_permission_preservation() {
     let source = tmp.path().join("source-no-perms.txt");
     let destination = tmp.path().join("dest-no-perms.txt");
 
-    // Create source file with restrictive permissions
     std::fs::write(&source, b"no-perms test").expect("write source");
     std::fs::set_permissions(&source, PermissionsExt::from_mode(0o600)).expect("set perms");
     let mtime = FileTime::from_unix_time(1_700_000_000, 0);
@@ -269,18 +254,15 @@ fn archive_no_perms_skips_permission_preservation() {
     assert_eq!(code, 0, "rsync should succeed");
     assert!(stderr.is_empty(), "no stderr expected: {:?}", String::from_utf8_lossy(&stderr));
 
-    // Verify content was transferred
     assert_eq!(
         std::fs::read(&destination).expect("read destination"),
         b"no-perms test"
     );
 
-    // Permissions should NOT be 0o600 since --no-perms was specified
-    // (the actual mode depends on umask, but it won't be exactly 0o600)
+    // Mode varies with umask, but --no-perms must not copy 0o600 verbatim;
+    // assert the file is at least readable.
     let metadata = std::fs::metadata(&destination).expect("dest metadata");
     let mode = metadata.permissions().mode() & 0o777;
-    // Note: We can't predict the exact mode due to umask, but if perms were preserved it would be 0o600
-    // This test verifies the file was created successfully without perms being copied
     assert!(mode != 0 || mode == 0o600, "file should be readable (mode: 0o{:o})", mode);
 }
 
@@ -295,9 +277,8 @@ fn archive_no_times_skips_time_preservation() {
     let source = tmp.path().join("source-no-times.txt");
     let destination = tmp.path().join("dest-no-times.txt");
 
-    // Create source file with old modification time
     std::fs::write(&source, b"no-times test").expect("write source");
-    let old_mtime = FileTime::from_unix_time(1_400_000_000, 0); // Year 2014
+    let old_mtime = FileTime::from_unix_time(1_400_000_000, 0); // 2014-05-13 UTC
     set_file_times(&source, old_mtime, old_mtime).expect("set times");
 
     let before_transfer = SystemTime::now();
@@ -313,7 +294,6 @@ fn archive_no_times_skips_time_preservation() {
     assert_eq!(code, 0, "rsync should succeed");
     assert!(stderr.is_empty(), "no stderr expected: {:?}", String::from_utf8_lossy(&stderr));
 
-    // Verify the modification time is recent (not the old 2014 time)
     let metadata = std::fs::metadata(&destination).expect("dest metadata");
     let dest_mtime = metadata.modified().expect("modified time");
 
@@ -333,7 +313,6 @@ fn archive_preserves_directory_permissions() {
     let source_dir = tmp.path().join("source_perms_dir");
     let dest_dir = tmp.path().join("dest_perms_dir");
 
-    // Create source directory with specific permissions
     std::fs::create_dir(&source_dir).expect("create source dir");
     std::fs::write(source_dir.join("file.txt"), b"content").expect("write file");
     std::fs::set_permissions(&source_dir, PermissionsExt::from_mode(0o750)).expect("set dir perms");
@@ -348,7 +327,6 @@ fn archive_preserves_directory_permissions() {
     assert_eq!(code, 0, "rsync should succeed");
     assert!(stderr.is_empty(), "no stderr expected: {:?}", String::from_utf8_lossy(&stderr));
 
-    // Verify directory permissions were preserved
     let dest_source = dest_dir.join("source_perms_dir");
     let metadata = std::fs::metadata(&dest_source).expect("dest dir metadata");
     assert_eq!(
@@ -379,11 +357,9 @@ fn archive_handles_fifo_special_files() {
     std::fs::create_dir(&source_dir).expect("create source dir");
     std::fs::create_dir(&dest_dir).expect("create dest dir");
 
-    // Create a FIFO
     let fifo_path = source_dir.join("test.fifo");
     mkfifo_for_tests(&fifo_path, 0o644).expect("create fifo");
 
-    // Also add a regular file
     std::fs::write(source_dir.join("regular.txt"), b"regular").expect("write regular");
 
     let mut source_path = source_dir.clone().into_os_string();
@@ -396,11 +372,10 @@ fn archive_handles_fifo_special_files() {
         dest_dir.clone().into_os_string(),
     ]);
 
-    // Transfer should succeed (even if FIFO handling depends on privileges)
-    // At minimum, the regular file should be transferred
+    // FIFO handling may depend on privileges; at minimum the regular file
+    // must transfer.
     assert_eq!(code, 0, "rsync should succeed");
 
-    // Verify regular file was transferred
     assert!(dest_dir.join("regular.txt").exists(), "regular file should exist");
     assert_eq!(
         std::fs::read(dest_dir.join("regular.txt")).expect("read regular"),

--- a/crates/cli/src/frontend/tests/dry_run.rs
+++ b/crates/cli/src/frontend/tests/dry_run.rs
@@ -80,7 +80,7 @@ fn dry_run_with_verbose_lists_files_on_stdout() {
         String::from_utf8_lossy(&stderr)
     );
 
-    // With -v, rsync lists the files that would be transferred on stdout.
+    // upstream: -v lists the files that would be transferred on stdout.
     let output = String::from_utf8_lossy(&stdout);
     assert!(
         output.contains("file1.txt"),
@@ -91,7 +91,6 @@ fn dry_run_with_verbose_lists_files_on_stdout() {
         "verbose dry-run output should list file2.txt, got: {output:?}"
     );
 
-    // No files should actually be created.
     assert!(!dest_dir.exists(), "destination should not be created");
 }
 
@@ -169,7 +168,6 @@ fn dry_run_with_delete_does_not_remove_files() {
     fs::create_dir_all(&source_dir).expect("create source");
     fs::create_dir_all(&dest_dir).expect("create dest");
 
-    // Source has one file, dest has two.
     fs::write(source_dir.join("keep.txt"), b"keep").expect("write keep");
     fs::write(dest_dir.join("keep.txt"), b"old keep").expect("write dest keep");
     fs::write(dest_dir.join("extra.txt"), b"extra").expect("write extra");
@@ -191,7 +189,6 @@ fn dry_run_with_delete_does_not_remove_files() {
         "stderr: {:?}",
         String::from_utf8_lossy(&stderr)
     );
-    // extra.txt must still exist -- dry-run does not actually delete.
     assert!(
         dest_dir.join("extra.txt").exists(),
         "dry-run --delete must not actually remove files"
@@ -200,7 +197,6 @@ fn dry_run_with_delete_does_not_remove_files() {
         fs::read(dest_dir.join("extra.txt")).expect("read extra"),
         b"extra"
     );
-    // Destination keep.txt must be unmodified.
     assert_eq!(
         fs::read(dest_dir.join("keep.txt")).expect("read keep"),
         b"old keep"
@@ -236,12 +232,11 @@ fn dry_run_verbose_with_delete_lists_deletions() {
 
     assert_eq!(code, 0);
     let output = String::from_utf8_lossy(&stdout);
-    // Upstream rsync -nv --delete shows "deleting <file>" lines.
+    // upstream: -nv --delete prints "deleting <file>" lines.
     assert!(
         output.contains("orphan.txt"),
         "verbose dry-run --delete should mention the file to be deleted, got: {output:?}"
     );
-    // Files must remain.
     assert!(dest_dir.join("orphan.txt").exists());
 }
 
@@ -376,10 +371,9 @@ fn dry_run_combined_with_stats_produces_summary() {
         String::from_utf8_lossy(&stderr)
     );
 
-    // With --stats, rsync produces a summary block on stdout.
     let output = String::from_utf8_lossy(&stdout);
-    // The output should contain statistics keywords that upstream rsync
-    // prints, like "Number of files" or "Total file size".
+    // upstream: --stats emits a summary block ("Number of files",
+    // "Total file size", ...) even under -n.
     assert!(
         !output.is_empty(),
         "dry-run --stats should produce statistics output"

--- a/crates/cli/src/frontend/tests/error_recovery.rs
+++ b/crates/cli/src/frontend/tests/error_recovery.rs
@@ -1,14 +1,13 @@
-/// Tests for error recovery when source files vanish during transfer.
-///
-/// Upstream rsync returns exit code 24 (RERR_VANISHED) when files disappear
-/// between file list generation and the actual transfer. These tests verify
-/// that remaining files are still transferred correctly despite the vanished
-/// file, and that the appropriate exit code is produced.
-///
-/// References:
-/// - upstream: errcode.h - RERR_VANISHED = 24
-/// - upstream: flist.c:1286-1294 - vanished file handling during file list build
-/// - upstream: main.c:1338-1345 - io_error to exit code mapping
+//! Tests for error recovery when source files vanish during transfer.
+//!
+//! Upstream rsync returns exit code 24 (RERR_VANISHED) when files disappear
+//! between file list generation and the actual transfer.
+//!
+//! References:
+//! - upstream: errcode.h - RERR_VANISHED = 24
+//! - upstream: flist.c:1286-1294 - vanished file handling during file list build
+//! - upstream: main.c:1338-1345 - io_error to exit code mapping
+
 use super::common::*;
 use super::*;
 
@@ -26,7 +25,6 @@ fn vanished_source_file_yields_exit_24_and_remaining_files_transfer() {
     std::fs::create_dir(&src_dir).expect("create src dir");
     std::fs::create_dir(&dst_dir).expect("create dst dir");
 
-    // Create three source files with distinct content and sizes
     let file_a = src_dir.join("alpha.txt");
     let file_b = src_dir.join("bravo.txt");
     let file_c = src_dir.join("charlie.txt");
@@ -34,7 +32,6 @@ fn vanished_source_file_yields_exit_24_and_remaining_files_transfer() {
     std::fs::write(&file_b, b"bravo content").expect("write bravo");
     std::fs::write(&file_c, b"charlie content").expect("write charlie");
 
-    // First transfer: sync all files to destination
     let (code, _stdout, stderr) = run_with_args([
         OsString::from(RSYNC),
         OsString::from("-r"),
@@ -65,12 +62,10 @@ fn vanished_source_file_yields_exit_24_and_remaining_files_transfer() {
         "charlie should exist after initial sync"
     );
 
-    // Delete one source file to simulate a vanished file
     std::fs::remove_file(&file_b).expect("remove bravo.txt");
 
-    // Second transfer: pass explicit file paths including the now-deleted file.
-    // The deleted path triggers the "file has vanished" code path in walk_path(),
-    // which sets IOERR_VANISHED, producing exit code 24.
+    // upstream: walk_path() sets IOERR_VANISHED for stat-ENOENT during the
+    // explicit-arg pass, surfacing as exit code 24.
     let (code, _stdout, stderr) = run_with_args([
         OsString::from(RSYNC),
         file_a.clone().into_os_string(),
@@ -81,19 +76,16 @@ fn vanished_source_file_yields_exit_24_and_remaining_files_transfer() {
 
     let stderr_text = String::from_utf8_lossy(&stderr);
 
-    // Exit code 24 = RERR_VANISHED: some files vanished before transfer
     assert_eq!(
         code, 24,
         "expected exit code 24 (vanished), got {code}: {stderr_text}"
     );
 
-    // The vanished file warning should appear in stderr
     assert!(
         stderr_text.contains("vanished"),
         "stderr should mention vanished file: {stderr_text}"
     );
 
-    // Remaining files should still be at the destination with correct content
     assert_eq!(
         std::fs::read(dst_dir.join("alpha.txt")).expect("read alpha"),
         b"alpha content",
@@ -169,9 +161,8 @@ fn single_vanished_source_yields_exit_24() {
 
     let stderr_text = String::from_utf8_lossy(&stderr);
 
-    // A missing source file should produce exit code 24 or a file-selection error.
-    // Upstream rsync produces "file has vanished" + exit 24 when the source path
-    // fails stat with ENOENT during file list building.
+    // upstream: a stat-ENOENT during file-list build yields "file has vanished"
+    // and exit 24; some build paths surface it as 23 (partial).
     assert!(
         code == 24 || code == 23,
         "expected exit code 24 (vanished) or 23 (partial), got {code}: {stderr_text}"

--- a/crates/cli/src/frontend/tests/error_recovery_integration.rs
+++ b/crates/cli/src/frontend/tests/error_recovery_integration.rs
@@ -1,18 +1,16 @@
-/// Integration tests for error recovery scenarios during local transfers.
-///
-/// These tests verify that oc-rsync continues transferring remaining files
-/// when individual files or directories encounter errors, matching upstream
-/// rsync's resilient behaviour. Each test sets up a scenario where some
-/// entries are inaccessible or problematic and asserts that:
-///   - Accessible files are still transferred correctly.
-///   - The process exits with an appropriate non-zero code.
-///   - Errors appear in stderr when expected.
-///
-/// References:
-/// - upstream: main.c - io_error to exit code mapping
-/// - upstream: flist.c - permission errors during file list build
-/// - upstream: generator.c:recv_generator() - error handling per entry
-/// - upstream: rsync.h - IOERR_GENERAL, RERR_PARTIAL (23), RERR_VANISHED (24)
+//! Integration tests for error recovery scenarios during local transfers.
+//!
+//! Each test sets up a scenario where some entries are inaccessible or
+//! problematic and asserts that accessible files still transfer, the process
+//! exits with an appropriate non-zero code, and errors appear in stderr when
+//! expected.
+//!
+//! References:
+//! - upstream: main.c - io_error to exit code mapping
+//! - upstream: flist.c - permission errors during file list build
+//! - upstream: generator.c:recv_generator() - error handling per entry
+//! - upstream: rsync.h - IOERR_GENERAL, RERR_PARTIAL (23), RERR_VANISHED (24)
+
 use super::common::*;
 use super::*;
 

--- a/crates/cli/src/frontend/tests/files_from.rs
+++ b/crates/cli/src/frontend/tests/files_from.rs
@@ -56,7 +56,6 @@ fn files_from_parses_one_filename_per_line() {
     let tmp = test_support::create_tempdir();
     let list_path = tmp.path().join("multiline.list");
 
-    // Multiple filenames with various line endings
     std::fs::write(&list_path, "alpha.txt\nbeta.txt\ngamma.txt").expect("write list");
 
     let entries =
@@ -73,7 +72,6 @@ fn files_from_handles_crlf_line_endings() {
     let tmp = test_support::create_tempdir();
     let list_path = tmp.path().join("crlf.list");
 
-    // Windows-style CRLF line endings
     std::fs::write(&list_path, "file1.txt\r\nfile2.txt\r\nfile3.txt\r\n").expect("write list");
 
     let entries =
@@ -90,7 +88,6 @@ fn files_from_handles_mixed_line_endings() {
     let tmp = test_support::create_tempdir();
     let list_path = tmp.path().join("mixed.list");
 
-    // Mix of LF and CRLF
     std::fs::write(&list_path, "file1.txt\nfile2.txt\r\nfile3.txt\n").expect("write list");
 
     let entries =
@@ -317,7 +314,6 @@ fn files_from_handles_unicode_filenames() {
     let tmp = test_support::create_tempdir();
     let list_path = tmp.path().join("unicode.list");
 
-    // Various Unicode characters including CJK, emoji representations, accented chars
     std::fs::write(
         &list_path,
         "file_cafe.txt\nfile_resume.txt\nfile_chinese.txt\nfile_japanese.txt\n",
@@ -360,7 +356,6 @@ fn files_from_handles_special_characters_in_filenames() {
     let tmp = test_support::create_tempdir();
     let list_path = tmp.path().join("special.list");
 
-    // Various special characters that might appear in filenames
     std::fs::write(
         &list_path,
         "file[1].txt\nfile(2).txt\nfile{3}.txt\nfile'4'.txt\nfile\"5\".txt\n",
@@ -620,7 +615,6 @@ fn files_from_integration_copies_listed_files() {
     std::fs::write(source_dir.join("file2.txt"), b"content2").expect("write file2");
     std::fs::write(source_dir.join("file3.txt"), b"content3").expect("write file3");
 
-    // Create file list (only file1 and file3)
     let list_path = tmp.path().join("files.list");
     std::fs::write(&list_path, "file1.txt\nfile3.txt\n").expect("write list");
 
@@ -638,7 +632,6 @@ fn files_from_integration_copies_listed_files() {
     assert!(stdout.is_empty());
     assert!(stderr.is_empty());
 
-    // Verify only listed files were copied
     assert!(dest_dir.join("file1.txt").exists());
     assert!(!dest_dir.join("file2.txt").exists());
     assert!(dest_dir.join("file3.txt").exists());
@@ -671,9 +664,8 @@ fn files_from_integration_handles_nested_directories() {
     assert_eq!(code, 0, "stderr: {}", String::from_utf8_lossy(&stderr));
     assert!(stdout.is_empty());
 
-    // Both files should be copied. --files-from implies --relative (upstream
-    // options.c:2187-2188), so paths are preserved: subdir/nested.txt stays
-    // at dest/subdir/nested.txt.
+    // upstream: options.c:2187-2188 - --files-from implies --relative, so
+    // subdir/nested.txt stays at dest/subdir/nested.txt.
     assert!(dest_dir.join("top.txt").exists());
     assert!(dest_dir.join("subdir").join("nested.txt").exists());
 }
@@ -698,7 +690,6 @@ fn files_from_integration_with_empty_list_succeeds() {
         dest_dir.clone().into_os_string(),
     ]);
 
-    // Should succeed with empty list (nothing to copy)
     assert_eq!(code, 0, "stderr: {}", String::from_utf8_lossy(&stderr));
     assert!(!dest_dir.join("file.txt").exists());
 }
@@ -723,7 +714,6 @@ fn files_from_integration_with_comments_only_list_succeeds() {
         dest_dir.clone().into_os_string(),
     ]);
 
-    // Should succeed (no files to copy due to all comments)
     assert_eq!(code, 0, "stderr: {}", String::from_utf8_lossy(&stderr));
     assert!(!dest_dir.join("file.txt").exists());
 }
@@ -893,7 +883,6 @@ fn files_from_handles_actual_unicode_characters() {
     let tmp = test_support::create_tempdir();
     let list_path = tmp.path().join("unicode_real.list");
 
-    // Real Unicode characters: Chinese, Japanese, emoji-like symbols, accented
     std::fs::write(
         &list_path,
         "文件.txt\nファイル.txt\ncafe\u{0301}.txt\nnaive\u{0308}.txt\nfile_\u{2764}.txt\n",
@@ -916,7 +905,6 @@ fn files_from_handles_rtl_and_bidi_characters() {
     let tmp = test_support::create_tempdir();
     let list_path = tmp.path().join("bidi.list");
 
-    // Right-to-left text (Arabic, Hebrew)
     std::fs::write(
         &list_path,
         "\u{05E9}\u{05DC}\u{05D5}\u{05DD}.txt\n\u{0645}\u{0644}\u{0641}.txt\n",
@@ -936,7 +924,6 @@ fn files_from_handles_combining_characters() {
     let tmp = test_support::create_tempdir();
     let list_path = tmp.path().join("combining.list");
 
-    // Combining diacritical marks
     std::fs::write(
         &list_path,
         "e\u{0301}.txt\na\u{0308}o\u{0308}u\u{0308}.txt\nn\u{0303}.txt\n",
@@ -957,7 +944,6 @@ fn files_from_handles_zero_width_characters() {
     let tmp = test_support::create_tempdir();
     let list_path = tmp.path().join("zerowidth.list");
 
-    // Zero-width joiner and non-joiner
     std::fs::write(&list_path, "file\u{200D}name.txt\ntest\u{200C}file.txt\n")
         .expect("write zero-width list");
 
@@ -974,7 +960,6 @@ fn files_from_handles_glob_metacharacters() {
     let tmp = test_support::create_tempdir();
     let list_path = tmp.path().join("glob.list");
 
-    // Glob metacharacters that might be interpreted by shells
     std::fs::write(
         &list_path,
         "file*.txt\nfile?.txt\nfile[abc].txt\nfile{a,b}.txt\n",
@@ -996,7 +981,6 @@ fn files_from_handles_shell_special_characters() {
     let tmp = test_support::create_tempdir();
     let list_path = tmp.path().join("shell.list");
 
-    // Shell special characters
     std::fs::write(
         &list_path,
         "file$var.txt\nfile`cmd`.txt\nfile|pipe.txt\nfile&bg.txt\nfile>redir.txt\nfile<input.txt\n",
@@ -1020,7 +1004,7 @@ fn files_from_handles_backslash_in_filenames() {
     let tmp = test_support::create_tempdir();
     let list_path = tmp.path().join("backslash.list");
 
-    // Backslashes (note: on Unix these are literal filename characters)
+    // On Unix, backslash is a literal filename character, not an escape.
     std::fs::write(
         &list_path,
         "file\\name.txt\npath\\\\double.txt\ntrailing\\.txt\n",
@@ -1041,7 +1025,6 @@ fn files_from_handles_equals_and_colon_in_filenames() {
     let tmp = test_support::create_tempdir();
     let list_path = tmp.path().join("punctuation.list");
 
-    // Characters that might be confused with argument separators
     std::fs::write(
         &list_path,
         "file=value.txt\nkey:value.txt\npath/with:colon.txt\n--not-a-flag.txt\n",
@@ -1063,7 +1046,6 @@ fn files_from_handles_tab_characters() {
     let tmp = test_support::create_tempdir();
     let list_path = tmp.path().join("tabs.list");
 
-    // Tab characters in filenames
     std::fs::write(
         &list_path,
         "file\twith\ttabs.txt\n\ttab_prefix.txt\ntab_suffix\t.txt\n",
@@ -1084,7 +1066,6 @@ fn files_from_handles_form_feed_and_vertical_tab() {
     let tmp = test_support::create_tempdir();
     let list_path = tmp.path().join("control.list");
 
-    // Form feed and vertical tab
     std::fs::write(&list_path, "file\x0Cwith\x0Bcontrol.txt\n").expect("write control list");
 
     let entries =
@@ -1239,7 +1220,6 @@ fn files_from_handles_hidden_files() {
     let tmp = test_support::create_tempdir();
     let list_path = tmp.path().join("hidden.list");
 
-    // Unix hidden files (starting with dot)
     std::fs::write(
         &list_path,
         ".hidden\n.config/file.txt\n..weird\n...triple\n",
@@ -1319,7 +1299,8 @@ fn files_from_handles_inline_hash_after_text() {
     let tmp = test_support::create_tempdir();
     let list_path = tmp.path().join("inline_hash.list");
 
-    // Hash/semicolon after text is preserved
+    // Hash/semicolon mid-line is preserved; only line-leading hash/semicolon
+    // delimits a comment.
     std::fs::write(
         &list_path,
         "file # not a comment.txt\npath;still_valid.txt\n",
@@ -1339,7 +1320,6 @@ fn files_from_handles_empty_comment_lines() {
     let tmp = test_support::create_tempdir();
     let list_path = tmp.path().join("empty_comment.list");
 
-    // Comment character alone on a line
     std::fs::write(&list_path, "#\n;\nfile.txt\n").expect("write empty comment list");
 
     let entries =
@@ -1354,7 +1334,6 @@ fn files_from_handles_large_number_of_entries() {
     let tmp = test_support::create_tempdir();
     let list_path = tmp.path().join("large.list");
 
-    // Create a file with 10000 entries
     let content: String = (0..10000).map(|i| format!("file{i}.txt\n")).collect();
     std::fs::write(&list_path, content).expect("write large list");
 
@@ -1371,7 +1350,6 @@ fn files_from_handles_large_file_with_comments() {
     let tmp = test_support::create_tempdir();
     let list_path = tmp.path().join("large_with_comments.list");
 
-    // Alternate between files and comments
     let content: String = (0..5000)
         .map(|i| format!("# Comment {i}\nfile{i}.txt\n"))
         .collect();
@@ -1419,7 +1397,6 @@ more_files.txt
     let entries =
         load_file_list_operands(&[list_path.into_os_string()], false).expect("load entries");
 
-    // Count actual file entries (non-comment, non-blank)
     assert_eq!(entries.len(), 16);
     assert_eq!(entries[0], "simple.txt");
     assert_eq!(entries[1], "path/to/file.txt");
@@ -1481,7 +1458,7 @@ fn files_from_handles_duplicate_entries_across_files() {
     let entries = load_file_list_operands(&[list1.into_os_string(), list2.into_os_string()], false)
         .expect("load entries");
 
-    // Duplicates are preserved (not deduplicated at this level)
+    // Duplicates are preserved; dedup happens downstream.
     assert_eq!(entries.len(), 4);
     assert_eq!(entries[0], "file.txt");
     assert_eq!(entries[1], "unique1.txt");
@@ -1528,7 +1505,6 @@ fn files_from_integration_with_from0_copies_listed_files() {
     std::fs::write(source_dir.join("file2.txt"), b"content2").expect("write file2");
     std::fs::write(source_dir.join("file3.txt"), b"content3").expect("write file3");
 
-    // Create null-terminated file list
     let list_path = tmp.path().join("files.list");
     let mut bytes = Vec::new();
     bytes.extend_from_slice(b"file1.txt");
@@ -1552,7 +1528,6 @@ fn files_from_integration_with_from0_copies_listed_files() {
     assert!(stdout.is_empty());
     assert!(stderr.is_empty());
 
-    // Verify only listed files were copied
     assert!(dest_dir.join("file1.txt").exists());
     assert!(!dest_dir.join("file2.txt").exists());
     assert!(dest_dir.join("file3.txt").exists());
@@ -1591,7 +1566,6 @@ fn files_from_integration_with_recursive_copies_nested_files() {
     assert!(dest_dir.join("top.txt").exists());
     assert!(dest_dir.join("a/mid.txt").exists());
     assert!(dest_dir.join("a/b/c/deepest.txt").exists());
-    // This file was not in the list
     assert!(!dest_dir.join("a/b/deep.txt").exists());
 }
 
@@ -1601,7 +1575,6 @@ fn files_from_integration_with_unicode_filenames() {
     let source_dir = tmp.path().join("source");
     std::fs::create_dir(&source_dir).expect("create source");
 
-    // Create files with Unicode names
     std::fs::write(source_dir.join("文件.txt"), b"chinese").expect("write chinese");
     std::fs::write(source_dir.join("ファイル.txt"), b"japanese").expect("write japanese");
     std::fs::write(source_dir.join("cafe\u{0301}.txt"), b"accent").expect("write accent");
@@ -1680,12 +1653,9 @@ fn resolve_file_list_entries_handles_mixed_absolute_and_relative() {
 
     resolve_file_list_entries(&mut entries, &operands, false, false);
 
-    // Relative paths are resolved against base
     let expected_0 = Path::new("/base/dir").join("relative.txt");
     assert_eq!(entries[0], expected_0.as_os_str());
-    // Absolute paths unchanged
     assert_eq!(entries[1], "/absolute/path.txt");
-    // Another relative
     let expected_2 = Path::new("/base/dir").join("another/relative.txt");
     assert_eq!(entries[2], expected_2.as_os_str());
 }
@@ -1702,7 +1672,7 @@ fn resolve_file_list_entries_with_dot_relative_paths() {
 
     resolve_file_list_entries(&mut entries, &operands, false, false);
 
-    // These are still relative, so they get the base prepended
+    // `./` and `../` prefixes are still relative, so the base prepends.
     let expected_0 = Path::new("/base").join("./file.txt");
     assert_eq!(entries[0], expected_0.as_os_str());
     let expected_1 = Path::new("/base").join("../parent/file.txt");

--- a/crates/cli/src/frontend/tests/human_readable_format.rs
+++ b/crates/cli/src/frontend/tests/human_readable_format.rs
@@ -1,8 +1,6 @@
 use super::common::*;
 use super::*;
 
-// Test 1: Sizes are formatted with K, M, G suffixes
-
 #[test]
 fn human_readable_formats_kilobytes() {
     use tempfile::tempdir;
@@ -121,8 +119,6 @@ fn human_readable_formats_various_sizes() {
     }
 }
 
-// Test 2: Multiple -h flags increase precision (combined mode)
-
 #[test]
 fn multiple_h_flags_enable_combined_mode() {
     let parsed = parse_args([
@@ -199,11 +195,8 @@ fn combined_mode_shows_both_human_and_decimal() {
     assert_eq!(code, 0);
     assert!(stderr.is_empty());
     let rendered = String::from_utf8(stdout).expect("stats output utf8");
-    // Should show both human-readable and exact decimal
     assert!(rendered.contains("1.54K (1,536)"));
 }
-
-// Test 3: Output matches upstream rsync format
 
 #[test]
 fn human_readable_output_format_matches_upstream() {
@@ -226,10 +219,9 @@ fn human_readable_output_format_matches_upstream() {
     assert!(stderr.is_empty());
     let rendered = String::from_utf8(stdout).expect("stats output utf8");
 
-    // Upstream rsync uses format like "5.12K" with 2 decimal places
+    // upstream: stats use 2 decimal places (e.g. "5.12K").
     assert!(rendered.contains("5.12K"));
 
-    // Check for "Total file size:" line
     let has_total_file_size = rendered
         .lines()
         .any(|line| line.starts_with("Total file size:") && line.contains("5.12K"));
@@ -245,7 +237,6 @@ fn human_readable_uses_two_decimal_places() {
 
     let tmp = tempdir().expect("tempdir");
     let source = tmp.path().join("decimal.bin");
-    // 1234 bytes should format as 1.23K
     std::fs::write(&source, vec![0u8; 1_234]).expect("write source");
 
     let dest = tmp.path().join("decimal.out");
@@ -286,14 +277,11 @@ fn human_readable_formats_bytes_without_suffix() {
     assert_eq!(code, 0);
     assert!(stderr.is_empty());
     let rendered = String::from_utf8(stdout).expect("stats output utf8");
-    // Bytes under 1000 should display without suffix
     assert!(
         rendered.contains("Total file size: 512 bytes"),
         "expected plain bytes, got: {rendered}"
     );
 }
-
-// Test 4: Works with --stats and progress
 
 #[test]
 fn human_readable_works_with_stats() {
@@ -316,12 +304,10 @@ fn human_readable_works_with_stats() {
     assert!(stderr.is_empty());
     let rendered = String::from_utf8(stdout).expect("stats output utf8");
 
-    // Verify stats section is present with human-readable sizes
     assert!(rendered.contains("Number of files:"));
     assert!(rendered.contains("Total file size:"));
     assert!(rendered.contains("Total bytes sent:"));
 
-    // Verify human-readable formatting is used
     assert!(rendered.contains("2.05K"));
 }
 
@@ -346,14 +332,12 @@ fn human_readable_works_with_progress() {
     assert!(stderr.is_empty());
     let rendered = String::from_utf8(stdout).expect("progress output utf8");
 
-    // Progress output should contain human-readable size
     let normalized = rendered.replace('\r', "\n");
     assert!(
         normalized.contains("3.07K"),
         "expected human-readable size in progress, got: {rendered}"
     );
 
-    // Verify progress metadata is present
     assert!(normalized.contains("progress.bin"));
     assert!(normalized.contains("(xfr#1"));
 }
@@ -380,13 +364,11 @@ fn human_readable_works_with_stats_and_progress() {
     assert!(stderr.is_empty());
     let rendered = String::from_utf8(stdout).expect("output utf8");
 
-    // Verify both progress and stats output present
     assert!(rendered.contains("both.bin"));
     assert!(rendered.contains("(xfr#1"));
     assert!(rendered.contains("Number of files:"));
     assert!(rendered.contains("Total file size:"));
 
-    // Verify human-readable formatting in both
     assert!(
         rendered.contains("4.10K"),
         "expected human-readable size, got: {rendered}"
@@ -414,7 +396,6 @@ fn human_readable_combined_works_with_stats() {
     assert!(stderr.is_empty());
     let rendered = String::from_utf8(stdout).expect("stats output utf8");
 
-    // Verify combined format in stats output
     assert!(
         rendered.contains("8.19K (8,192)"),
         "expected combined format in stats, got: {rendered}"
@@ -443,15 +424,12 @@ fn human_readable_combined_works_with_progress() {
     assert!(stderr.is_empty());
     let rendered = String::from_utf8(stdout).expect("progress output utf8");
 
-    // Verify combined format in progress output
     let normalized = rendered.replace('\r', "\n");
     assert!(
         normalized.contains("6.14K (6,144)"),
         "expected combined format in progress, got: {rendered}"
     );
 }
-
-// Additional edge cases
 
 #[test]
 fn human_readable_handles_zero_bytes() {
@@ -501,7 +479,6 @@ fn human_readable_with_verbose_output() {
     assert!(stderr.is_empty());
     let rendered = String::from_utf8(stdout).expect("output utf8");
 
-    // Verify verbose listing and human-readable stats
     assert!(rendered.contains("verbose.bin"));
     assert!(rendered.contains("10.24K"));
     assert!(rendered.contains("\n\nsent"));
@@ -528,12 +505,10 @@ fn human_readable_disabled_shows_exact_values() {
     assert!(stderr.is_empty());
     let rendered = String::from_utf8(stdout).expect("stats output utf8");
 
-    // With human-readable disabled, should show comma-separated decimal
     assert!(
         rendered.contains("1,536"),
         "expected comma-separated decimal, got: {rendered}"
     );
-    // Should NOT contain K suffix
     assert!(
         !rendered.contains("1.54K"),
         "should not have K suffix when disabled, got: {rendered}"
@@ -561,7 +536,6 @@ fn human_readable_format_consistency_across_stats() {
     assert!(stderr.is_empty());
     let rendered = String::from_utf8(stdout).expect("stats output utf8");
 
-    // All size references should use consistent human-readable format
     let count_k = rendered.matches("20.48K").count();
     assert!(
         count_k >= 2,

--- a/crates/cli/src/frontend/tests/info_debug.rs
+++ b/crates/cli/src/frontend/tests/info_debug.rs
@@ -143,17 +143,14 @@ fn info_stats_levels() {
 
 #[test]
 fn info_negation_forms() {
-    // Test 'no' prefix
     let flags = vec![OsString::from("nodel")];
     let settings = parse_info_flags(&flags).expect("flags parse");
     assert_eq!(settings.del, Some(0));
 
-    // Test '-' prefix
     let flags = vec![OsString::from("-skip")];
     let settings = parse_info_flags(&flags).expect("flags parse");
     assert_eq!(settings.skip, Some(0));
 
-    // Test '0' suffix
     let flags = vec![OsString::from("copy0")];
     let settings = parse_info_flags(&flags).expect("flags parse");
     assert_eq!(settings.copy, Some(0));
@@ -215,17 +212,14 @@ fn debug_io_levels() {
 
 #[test]
 fn debug_negation_forms() {
-    // Test 'no' prefix
     let flags = vec![OsString::from("nodel")];
     let settings = parse_debug_flags(&flags).expect("flags parse");
     assert_eq!(settings.del, Some(0));
 
-    // Test '-' prefix
     let flags = vec![OsString::from("-filter")];
     let settings = parse_debug_flags(&flags).expect("flags parse");
     assert_eq!(settings.filter, Some(0));
 
-    // Test '0' suffix
     let flags = vec![OsString::from("recv0")];
     let settings = parse_debug_flags(&flags).expect("flags parse");
     assert_eq!(settings.recv, Some(0));

--- a/crates/cli/src/frontend/tests/itemize_format_upstream.rs
+++ b/crates/cli/src/frontend/tests/itemize_format_upstream.rs
@@ -126,25 +126,18 @@ fn itemize_updated_file_shows_change_indicators() {
     let output = String::from_utf8(stdout).expect("utf8");
     let line = output.trim_end_matches('\n');
 
-    // Should start with '>f' (received file)
     assert!(line.starts_with(">f"), "should start with '>f': {line:?}");
 
-    // Extract the 11-character format string
     let format_str = &line[..11];
 
-    // Position 0: '>' for received/transferred
     assert_eq!(&format_str[0..1], ">");
-    // Position 1: 'f' for regular file
     assert_eq!(&format_str[1..2], "f");
-    // Position 2: 'c' for checksum (content changed)
     assert_eq!(
         &format_str[2..3],
         "c",
         "checksum should be 'c': {format_str:?}"
     );
-    // Position 3: 's' for size changed
     assert_eq!(&format_str[3..4], "s", "size should be 's': {format_str:?}");
-    // Position 4: 't' for time changed (preserved)
     assert_eq!(&format_str[4..5], "t", "time should be 't': {format_str:?}");
 }
 
@@ -177,8 +170,7 @@ fn itemize_unchanged_file_with_times_shows_no_output() {
     ]);
 
     assert_eq!(code, 0);
-    // When file is unchanged, no itemize output should be produced
-    // (rsync only shows items that have changes unless -ii is used)
+    // upstream: -i suppresses unchanged items; only -ii lists them with '.f'.
     let output = String::from_utf8(stdout).expect("utf8");
     assert!(
         output.is_empty() || output.starts_with(".f"),
@@ -213,7 +205,6 @@ fn itemize_multiple_new_files_each_show_new_format() {
     let output = String::from_utf8(stdout).expect("utf8");
     let lines: Vec<&str> = output.lines().collect();
 
-    // Should have output for both files
     assert_eq!(lines.len(), 2, "should have 2 lines of output: {output:?}");
 
     for line in &lines {
@@ -248,7 +239,6 @@ fn itemize_combined_with_dry_run_shows_what_would_transfer() {
         "dry run should still show itemized format"
     );
 
-    // File should not actually be created
     assert!(
         !dest_dir.join("dryrun.txt").exists(),
         "dry run should not create file"
@@ -274,7 +264,8 @@ fn itemize_combined_with_verbose_shows_itemized_format() {
 
     assert_eq!(code, 0);
     let output = String::from_utf8(stdout).expect("utf8");
-    // With -iv, itemize format takes precedence over verbose filename-only
+    // upstream: -iv keeps the itemize format and suppresses bare-filename
+    // verbose output.
     assert!(
         output.contains(">f+++++++++"),
         "verbose+itemize should show itemized format: {output:?}"
@@ -338,12 +329,10 @@ fn itemize_recursive_new_directory_shows_cd_plus_pattern() {
     assert_eq!(code, 0);
     let output = String::from_utf8(stdout).expect("utf8");
 
-    // Should contain a directory creation line
     assert!(
         output.contains("cd+++++++++"),
         "new directory should show 'cd+++++++++': {output:?}"
     );
-    // Should contain a file creation line
     assert!(
         output.contains(">f+++++++++"),
         "new file should show '>f+++++++++': {output:?}"
@@ -379,7 +368,6 @@ fn itemize_new_symlink_shows_cl_plus_pattern() {
     assert_eq!(code, 0);
     let output = String::from_utf8(stdout).expect("utf8");
 
-    // Should contain a symlink creation line
     assert!(
         output.contains("cL+++++++++"),
         "new symlink should show 'cL+++++++++': {output:?}"
@@ -420,7 +408,6 @@ fn itemize_chmod_shows_permission_indicator() {
     let output = String::from_utf8(stdout).expect("utf8");
     if !output.is_empty() {
         let line = output.lines().next().expect("first line");
-        // Should show 'p' in the permissions position (position 5)
         assert!(
             line.len() >= 11,
             "format should be at least 11 chars: {line:?}"

--- a/crates/cli/src/frontend/tests/list_only.rs
+++ b/crates/cli/src/frontend/tests/list_only.rs
@@ -267,7 +267,6 @@ fn list_only_output_lines_match_upstream_regex_pattern() {
     // Upstream rsync format: <type+perms 10 chars> <15-char size> <YYYY/MM/DD HH:MM:SS> <name>
     // The fields are separated by single spaces.
     for line in rendered.lines() {
-        // Permission field: 10 characters starting with one of -dlpcbs?
         let perm_field = &line[..10];
         assert!(
             perm_field.len() == 10,
@@ -279,14 +278,12 @@ fn list_only_output_lines_match_upstream_regex_pattern() {
             "type char should be one of -dlpcbs?, got {type_char:?} in {line:?}"
         );
 
-        // After permissions, a single space
         assert_eq!(
             line.as_bytes()[10],
             b' ',
             "space after permissions in {line:?}"
         );
 
-        // Size field: 15 characters, right-aligned, may contain commas for thousands
         let size_field = &line[11..26];
         assert_eq!(
             size_field.len(),
@@ -298,7 +295,6 @@ fn list_only_output_lines_match_upstream_regex_pattern() {
             !size_trimmed.is_empty(),
             "size field should not be empty: {line:?}"
         );
-        // The size field should contain digits and optionally commas (or ? for unknown)
         assert!(
             size_trimmed == "?"
                 || size_trimmed
@@ -307,17 +303,14 @@ fn list_only_output_lines_match_upstream_regex_pattern() {
             "size field should be numeric with commas: {size_trimmed:?} in {line:?}"
         );
 
-        // After size, a single space
         assert_eq!(line.as_bytes()[26], b' ', "space after size in {line:?}");
 
-        // Timestamp field: exactly 19 characters in YYYY/MM/DD HH:MM:SS format
         let timestamp_field = &line[27..46];
         assert_eq!(
             timestamp_field.len(),
             19,
             "timestamp field should be 19 chars: {line:?}"
         );
-        // Verify the format pattern
         assert_eq!(
             timestamp_field.as_bytes()[4],
             b'/',
@@ -344,7 +337,6 @@ fn list_only_output_lines_match_upstream_regex_pattern() {
             "minute/second separator should be : in {line:?}"
         );
 
-        // After timestamp, a single space then the filename
         assert_eq!(
             line.as_bytes()[46],
             b' ',
@@ -401,19 +393,16 @@ fn list_only_symlink_shows_arrow_target_in_exact_format() {
         .find(|line| line.contains("mylink"))
         .expect("symlink entry present");
 
-    // Symlink line should start with 'l' (symlink type)
     assert!(
         link_line.starts_with('l'),
         "symlink line should start with 'l': {link_line:?}"
     );
 
-    // Symlink line should end with "mylink -> target.txt"
     assert!(
         link_line.ends_with("mylink -> target.txt"),
         "symlink line should end with 'mylink -> target.txt': {link_line:?}"
     );
 
-    // Verify the ` -> ` arrow pattern (space-arrow-space) is present
     assert!(
         link_line.contains(" -> "),
         "symlink line should contain ' -> ' arrow: {link_line:?}"
@@ -514,13 +503,11 @@ fn list_only_directory_permissions_start_with_d() {
         .find(|line| line.contains("testdir"))
         .expect("directory entry present");
 
-    // Directory permission starts with 'd'
     assert!(
         dir_line.starts_with("drwxr-xr-x"),
         "directory should have drwxr-xr-x permissions: {dir_line:?}"
     );
 
-    // Verify the timestamp portion
     let system_time = SystemTime::UNIX_EPOCH
         + Duration::from_secs(u64::try_from(timestamp.unix_seconds()).expect("positive timestamp"));
     let expected_timestamp = format_list_timestamp(Some(system_time));
@@ -545,7 +532,6 @@ fn list_only_size_field_right_aligned_in_15_chars() {
     fs::create_dir(&source_dir).expect("create src dir");
     fs::create_dir(&dest_dir).expect("create dest dir");
 
-    // Create files of varying sizes
     let small = source_dir.join("small.txt");
     fs::write(&small, b"x").expect("write small");
     fs::set_permissions(&small, fs::Permissions::from_mode(0o644)).expect("set perms small");
@@ -579,7 +565,6 @@ fn list_only_size_field_right_aligned_in_15_chars() {
     let rendered = String::from_utf8(stdout).expect("utf8 stdout");
 
     for line in rendered.lines() {
-        // Size field is at columns 11..26 (0-indexed), exactly 15 characters
         let size_field = &line[11..26];
         assert_eq!(
             size_field.len(),
@@ -587,7 +572,7 @@ fn list_only_size_field_right_aligned_in_15_chars() {
             "size field should always be 15 chars: {line:?}"
         );
 
-        // Right-aligned means leading spaces, trailing digits/commas
+        // Right-alignment leaves leading spaces and trailing digits/commas.
         let trimmed = size_field.trim_start();
         if trimmed != "?" {
             assert!(
@@ -640,7 +625,6 @@ fn list_only_recursive_shows_nested_paths() {
 
     let rendered = String::from_utf8(stdout).expect("utf8 stdout");
 
-    // All levels should appear in the output
     assert!(
         rendered.lines().any(|l| l.ends_with("top.txt")),
         "top-level file should appear in listing"
@@ -662,7 +646,6 @@ fn list_only_recursive_shows_nested_paths() {
         "deeply nested file should appear in listing"
     );
 
-    // No files should actually be transferred
     assert!(!dest_dir.join("top.txt").exists());
     assert!(!dest_dir.join("level1").exists());
 }
@@ -683,7 +666,6 @@ fn list_only_large_file_size_has_thousands_separators() {
     fs::create_dir(&dest_dir).expect("create dest dir");
 
     let file_path = source_dir.join("big.bin");
-    // 1,234,567 bytes
     fs::write(&file_path, vec![0u8; 1_234_567]).expect("write large file");
     fs::set_permissions(&file_path, fs::Permissions::from_mode(0o644)).expect("set permissions");
 
@@ -715,7 +697,6 @@ fn list_only_large_file_size_has_thousands_separators() {
         "large file should have formatted size with separators: {file_line:?}"
     );
 
-    // Verify the thousands separator
     assert!(
         expected_size.contains("1,234,567"),
         "size should contain thousands separators: {expected_size:?}"
@@ -764,12 +745,10 @@ fn list_only_with_verbose_still_shows_listing_format() {
         .find(|line| line.ends_with("verbose_test.txt"))
         .expect("file entry present");
 
-    // Should still be in list format (starts with permission string, not a bare filename)
     assert!(
         file_line.starts_with('-'),
         "list-only with verbose should still use listing format: {file_line:?}"
     );
-    // Permission field should be 10 chars
     assert_eq!(
         &file_line[..10],
         "-rw-r--r--",
@@ -915,14 +894,12 @@ fn list_only_human_readable_size_format() {
         .find(|line| line.ends_with("hr.bin"))
         .expect("file entry present");
 
-    // The size field in human-readable mode should contain unit suffixes
     let expected_hr_size = format_list_size(2_500_000, HumanReadableMode::Enabled);
     assert!(
         file_line.contains(&expected_hr_size),
         "human-readable size should be in listing: expected {expected_hr_size:?}, line: {file_line:?}"
     );
 
-    // The line should still start with permissions
     assert!(
         file_line.starts_with("-rw-r--r--"),
         "human-readable mode should still show permissions: {file_line:?}"
@@ -947,7 +924,6 @@ fn list_only_multiple_files_have_consistent_column_alignment() {
 
     let timestamp = FileTime::from_unix_time(1_700_000_000, 0);
 
-    // Create files with different sizes to test alignment
     let files = [
         ("tiny.txt", 1_u64),
         ("small.txt", 100),
@@ -992,36 +968,30 @@ fn list_only_multiple_files_have_consistent_column_alignment() {
             line.len() >= 47,
             "each line should be at least 47 chars: {line:?}"
         );
-        // Permission field
         assert!(
             line[..10].chars().all(|c| "drwxlpcbs-?SsTt".contains(c)),
             "permission field should contain valid permission chars: {line:?}"
         );
-        // Space separator after permissions
         assert_eq!(
             line.as_bytes()[10],
             b' ',
             "separator after perms in {line:?}"
         );
-        // Size field is 15 chars
         assert_eq!(
             &line[11..26].len(),
             &15,
             "size field should be 15 chars: {line:?}"
         );
-        // Space separator after size
         assert_eq!(
             line.as_bytes()[26],
             b' ',
             "separator after size in {line:?}"
         );
-        // Timestamp is 19 chars
         assert_eq!(
             &line[27..46].len(),
             &19,
             "timestamp should be 19 chars: {line:?}"
         );
-        // Space before name
         assert_eq!(
             line.as_bytes()[46],
             b' ',
@@ -1064,7 +1034,6 @@ fn list_only_implies_dry_run_no_files_transferred() {
     assert!(rendered.contains("b.txt"), "b.txt should be listed");
     assert!(rendered.contains("c.txt"), "c.txt should be listed");
 
-    // Destination should remain empty
     let dest_entries: Vec<_> = fs::read_dir(&dest_dir).expect("read dest").collect();
     assert_eq!(
         dest_entries.len(),
@@ -1157,13 +1126,11 @@ fn list_only_with_stats_appends_summary() {
 
     let rendered = String::from_utf8(stdout).expect("utf8 stdout");
 
-    // The listing should appear
     assert!(
         rendered.contains("statsfile.txt"),
         "file listing should be present"
     );
 
-    // Stats summary should follow
     assert!(
         rendered.contains("Number of files:"),
         "stats summary should contain 'Number of files:'"
@@ -1217,10 +1184,8 @@ fn list_only_timestamp_matches_yyyy_mm_dd_hh_mm_ss_format() {
         .find(|line| line.ends_with("ts.txt"))
         .expect("timestamp test file entry present");
 
-    // Extract the timestamp portion (columns 27-45)
     let timestamp_field = &file_line[27..46];
 
-    // Verify the format structure
     assert!(
         timestamp_field[0..4].chars().all(|c| c.is_ascii_digit()),
         "year should be 4 digits: {timestamp_field:?}"
@@ -1251,7 +1216,6 @@ fn list_only_timestamp_matches_yyyy_mm_dd_hh_mm_ss_format() {
         "seconds should be 2 digits: {timestamp_field:?}"
     );
 
-    // Cross-check with our format function
     let system_time = SystemTime::UNIX_EPOCH
         + Duration::from_secs(u64::try_from(timestamp.unix_seconds()).expect("positive timestamp"));
     let expected = format_list_timestamp(Some(system_time));
@@ -1293,13 +1257,11 @@ fn list_only_verbose_appends_totals() {
 
     let rendered = String::from_utf8(stdout).expect("utf8 stdout");
 
-    // Should contain the listing
     assert!(
         rendered.contains("vt.txt"),
         "file listing should be present"
     );
 
-    // Verbose adds totals
     assert!(
         rendered.contains("sent") && rendered.contains("bytes"),
         "verbose mode should include totals line with 'sent ... bytes': {rendered}"
@@ -1324,7 +1286,6 @@ fn list_only_mixed_file_types_in_single_listing() {
     fs::create_dir(&source_dir).expect("create src dir");
     fs::create_dir(&dest_dir).expect("create dest dir");
 
-    // Regular file
     fs::write(source_dir.join("regular.txt"), b"regular").expect("write regular");
     fs::set_permissions(
         source_dir.join("regular.txt"),
@@ -1332,10 +1293,8 @@ fn list_only_mixed_file_types_in_single_listing() {
     )
     .expect("set regular perms");
 
-    // Directory
     fs::create_dir(source_dir.join("mydir")).expect("create dir");
 
-    // Symlink
     symlink("regular.txt", source_dir.join("mylink")).expect("create symlink");
 
     let mut source_arg = source_dir.into_os_string();
@@ -1355,7 +1314,6 @@ fn list_only_mixed_file_types_in_single_listing() {
 
     let rendered = String::from_utf8(stdout).expect("utf8 stdout");
 
-    // Find each type
     let regular_line = rendered
         .lines()
         .find(|l| l.ends_with("regular.txt") && !l.contains("->"))
@@ -1369,7 +1327,6 @@ fn list_only_mixed_file_types_in_single_listing() {
         .find(|l| l.contains("mylink"))
         .expect("symlink line present");
 
-    // Verify type characters
     assert!(
         regular_line.starts_with('-'),
         "regular file should start with '-': {regular_line:?}"

--- a/crates/cli/src/frontend/tests/out/custom_format.rs
+++ b/crates/cli/src/frontend/tests/out/custom_format.rs
@@ -427,7 +427,6 @@ fn out_format_respects_width_specifier() {
 
     let rendered = String::from_utf8(output).expect("utf8");
     let trimmed = rendered.trim_end();
-    // Should be padded to 20 characters (right-aligned by default)
     assert_eq!(trimmed.len(), 20);
     assert!(trimmed.ends_with("width.txt"));
 }
@@ -467,10 +466,8 @@ fn out_format_respects_left_alignment() {
         .expect("render left-aligned format");
 
     let rendered = String::from_utf8(output).expect("utf8");
-    // Should be left-aligned with trailing spaces to reach width 20
     assert!(rendered.starts_with("left.txt"));
-    // The rendered output should be exactly 20 characters (8 for "left.txt" + 12 spaces)
-    // trim_end_matches('\n') to remove only the newline, not the padding spaces
+    // Trim only the trailing '\n' (not the padding spaces) before counting.
     let without_newline = rendered.trim_end_matches('\n');
     assert_eq!(
         without_newline.len(),

--- a/crates/cli/src/frontend/tests/out/upstream_compat.rs
+++ b/crates/cli/src/frontend/tests/out/upstream_compat.rs
@@ -331,7 +331,6 @@ fn out_format_renders_multiple_files_in_order() {
         "one line per event, lines={lines:?}"
     );
 
-    // Each line should contain a filename and size
     for line in &lines {
         assert!(
             line.contains(".txt"),
@@ -377,32 +376,26 @@ fn out_format_complex_upstream_format_renders_all_fields() {
         .expect("render complex format");
 
     let rendered = String::from_utf8(output).expect("utf8");
-    // Should contain the itemize string for a new file
     assert!(
         rendered.contains(">f+++++++++"),
         "should contain itemize: {rendered:?}"
     );
-    // Should contain the operation
     assert!(
         rendered.contains("copied"),
         "should contain operation: {rendered:?}"
     );
-    // Should contain the filename
     assert!(
         rendered.contains("complex.dat"),
         "should contain filename: {rendered:?}"
     );
-    // Should contain the file length
     assert!(
         rendered.contains(&format!("{}", contents.len())),
         "should contain length: {rendered:?}"
     );
-    // Should contain "bytes"
     assert!(
         rendered.contains("bytes"),
         "should contain 'bytes': {rendered:?}"
     );
-    // Should contain pid
     assert!(
         rendered.contains("pid="),
         "should contain 'pid=': {rendered:?}"

--- a/crates/cli/src/frontend/tests/progress_format_upstream.rs
+++ b/crates/cli/src/frontend/tests/progress_format_upstream.rs
@@ -363,7 +363,7 @@ fn p_short_option_enables_progress_output() {
     assert!(stderr.is_empty());
 
     let rendered = String::from_utf8(stdout).expect("utf8");
-    // -P should imply --progress, so xfr# should be present
+    // upstream: -P implies --progress (xfr# line) and --partial (file retained).
     assert!(
         rendered.contains("xfr#1"),
         "-P should enable progress output with xfr# line: {rendered:?}"
@@ -372,7 +372,6 @@ fn p_short_option_enables_progress_output() {
         rendered.contains("to-chk=0/1"),
         "-P should show to-chk counter: {rendered:?}"
     );
-    // Also should keep partial files (test the --partial side)
     assert_eq!(
         std::fs::read(&destination).expect("read destination"),
         b"p_flag_data"

--- a/crates/cli/src/frontend/tests/timeout.rs
+++ b/crates/cli/src/frontend/tests/timeout.rs
@@ -27,7 +27,6 @@ fn timeout_argument_one_second() {
 
 #[test]
 fn timeout_argument_typical_values() {
-    // Common timeout values used in practice
     for value in [10, 30, 60, 120, 300, 600, 3600] {
         let timeout =
             parse_timeout_argument(OsStr::new(&value.to_string())).expect("parse timeout");
@@ -37,21 +36,18 @@ fn timeout_argument_typical_values() {
 
 #[test]
 fn timeout_argument_large_value() {
-    // 24 hours in seconds
-    let timeout = parse_timeout_argument(OsStr::new("86400")).expect("parse timeout");
+    let timeout = parse_timeout_argument(OsStr::new("86400")).expect("parse timeout"); // 24h
     assert_eq!(timeout.as_seconds(), NonZeroU64::new(86400));
 }
 
 #[test]
 fn timeout_argument_very_large_value() {
-    // Maximum practical timeout (about 136 years)
-    let timeout = parse_timeout_argument(OsStr::new("4294967295")).expect("parse timeout");
+    let timeout = parse_timeout_argument(OsStr::new("4294967295")).expect("parse timeout"); // u32::MAX
     assert_eq!(timeout.as_seconds(), NonZeroU64::new(4294967295));
 }
 
 #[test]
 fn timeout_argument_u64_max() {
-    // Maximum u64 value
     let max_u64 = u64::MAX.to_string();
     let timeout = parse_timeout_argument(OsStr::new(&max_u64)).expect("parse timeout");
     assert_eq!(timeout.as_seconds(), NonZeroU64::new(u64::MAX));
@@ -143,7 +139,7 @@ fn timeout_argument_negative_large_reports_error() {
 
 #[test]
 fn timeout_argument_overflow_reports_error() {
-    // Value larger than u64::MAX
+    // u64::MAX + 1
     let error = parse_timeout_argument(OsStr::new("18446744073709551616")).unwrap_err();
     assert!(
         error.to_string().contains("exceeds the supported range"),
@@ -267,7 +263,6 @@ fn cli_timeout_large_value() {
 fn cli_no_timeout_overrides_timeout() {
     let parsed =
         parse_args(["rsync", "--timeout=30", "--no-timeout", "src/", "dst/"]).expect("parse");
-    // --no-timeout should clear the timeout setting
     assert_eq!(parsed.timeout, None);
 }
 
@@ -275,7 +270,7 @@ fn cli_no_timeout_overrides_timeout() {
 fn cli_timeout_after_no_timeout() {
     let parsed =
         parse_args(["rsync", "--no-timeout", "--timeout=60", "src/", "dst/"]).expect("parse");
-    // Later --timeout should override --no-timeout
+    // Last-write-wins: --timeout after --no-timeout reinstates the value.
     assert_eq!(parsed.timeout, Some(OsString::from("60")));
 }
 
@@ -359,36 +354,31 @@ fn cli_contimeout_without_timeout() {
 
 #[test]
 fn timeout_argument_boundary_one() {
-    // Smallest positive timeout
     let timeout = parse_timeout_argument(OsStr::new("1")).expect("parse timeout");
     assert_eq!(timeout.as_seconds(), NonZeroU64::new(1));
 }
 
 #[test]
 fn timeout_argument_minute_boundary() {
-    // 1 minute
-    let timeout = parse_timeout_argument(OsStr::new("60")).expect("parse timeout");
+    let timeout = parse_timeout_argument(OsStr::new("60")).expect("parse timeout"); // 1m
     assert_eq!(timeout.as_seconds(), NonZeroU64::new(60));
 }
 
 #[test]
 fn timeout_argument_hour_boundary() {
-    // 1 hour
-    let timeout = parse_timeout_argument(OsStr::new("3600")).expect("parse timeout");
+    let timeout = parse_timeout_argument(OsStr::new("3600")).expect("parse timeout"); // 1h
     assert_eq!(timeout.as_seconds(), NonZeroU64::new(3600));
 }
 
 #[test]
 fn timeout_argument_day_boundary() {
-    // 1 day
-    let timeout = parse_timeout_argument(OsStr::new("86400")).expect("parse timeout");
+    let timeout = parse_timeout_argument(OsStr::new("86400")).expect("parse timeout"); // 1d
     assert_eq!(timeout.as_seconds(), NonZeroU64::new(86400));
 }
 
 #[test]
 fn timeout_argument_week_boundary() {
-    // 1 week
-    let timeout = parse_timeout_argument(OsStr::new("604800")).expect("parse timeout");
+    let timeout = parse_timeout_argument(OsStr::new("604800")).expect("parse timeout"); // 1w
     assert_eq!(timeout.as_seconds(), NonZeroU64::new(604800));
 }
 
@@ -406,7 +396,7 @@ fn transfer_timeout_effective_with_various_defaults() {
 fn transfer_timeout_seconds_converts_to_duration_correctly() {
     for secs in [1, 30, 60, 3600, 86400] {
         let timeout = TransferTimeout::Seconds(NonZeroU64::new(secs).unwrap());
-        let default = Duration::from_secs(999); // Should be ignored
+        let default = Duration::from_secs(999); // ignored when Seconds wins
         assert_eq!(timeout.effective(default), Some(Duration::from_secs(secs)));
     }
 }
@@ -415,7 +405,6 @@ fn transfer_timeout_seconds_converts_to_duration_correctly() {
 fn transfer_timeout_disabled_ignores_default() {
     let timeout = TransferTimeout::Disabled;
 
-    // No matter what default is provided, disabled always returns None
     for default_secs in [1, 30, 60, 3600] {
         let default = Duration::from_secs(default_secs);
         assert_eq!(timeout.effective(default), None);

--- a/crates/cli/src/frontend/tests/verbose.rs
+++ b/crates/cli/src/frontend/tests/verbose.rs
@@ -21,7 +21,6 @@ fn level_0_no_file_listing() {
 
     assert_eq!(code, 0);
     assert!(stderr.is_empty());
-    // Level 0: no output at all.
     assert!(
         stdout.is_empty(),
         "level 0 should produce no stdout, got: {:?}",
@@ -314,12 +313,10 @@ fn level_2_shows_descriptor_prefix() {
         String::from_utf8_lossy(&stderr)
     );
     let rendered = String::from_utf8(stdout).expect("utf8");
-    // At verbosity >= 2, the output includes a "descriptor: filename (N bytes, ...)" format.
     assert!(
         rendered.contains("descriptor.txt"),
         "level 2 should list the file name, got: {rendered:?}"
     );
-    // The descriptor line should show byte counts.
     assert!(
         rendered.contains("bytes"),
         "level 2 should show byte information, got: {rendered:?}"
@@ -375,9 +372,8 @@ fn level_3_at_least_as_verbose_as_level_2() {
     ]);
 
     assert_eq!(code, 0);
-    // At verbosity 3, debug_log! messages may appear on stderr, so we only
-    // verify that stderr contains no error-level output (no "rsync error:"
-    // or "rsync: error" prefixes).
+    // -vvv routes debug_log! output to stderr, so only error-level lines
+    // ("rsync error:" / "rsync: error") indicate a real failure here.
     let stderr_str = String::from_utf8_lossy(&stderr);
     assert!(
         !stderr_str.contains("rsync error:") && !stderr_str.contains("rsync: error"),
@@ -489,12 +485,10 @@ fn verbose_with_stats_shows_statistics() {
     assert_eq!(code, 0);
     assert!(stderr.is_empty());
     let rendered = String::from_utf8(stdout).expect("utf8");
-    // File listing from -v.
     assert!(
         rendered.contains("vstats.txt"),
         "verbose --stats should list the file name, got: {rendered:?}"
     );
-    // Stats block.
     assert!(
         rendered.contains("Number of files:"),
         "verbose --stats should contain Number of files, got: {rendered:?}"
@@ -534,7 +528,6 @@ fn stats_without_verbose_shows_statistics() {
     assert_eq!(code, 0);
     assert!(stderr.is_empty());
     let rendered = String::from_utf8(stdout).expect("utf8");
-    // Stats block should be present even at level 0.
     assert!(
         rendered.contains("Number of files:"),
         "--stats should always show statistics block, got: {rendered:?}"
@@ -557,7 +550,6 @@ fn verbose_with_delete_shows_deletion_messages() {
     fs::create_dir_all(&source_dir).expect("mkdir source");
     fs::create_dir_all(&dest_dir).expect("mkdir dest");
 
-    // Source has one file; dest has two (orphan should be deleted).
     fs::write(source_dir.join("keep.txt"), b"keep").expect("write keep");
     fs::write(dest_dir.join("keep.txt"), b"old keep").expect("write dest keep");
     fs::write(dest_dir.join("orphan.txt"), b"orphan").expect("write orphan");
@@ -575,12 +567,11 @@ fn verbose_with_delete_shows_deletion_messages() {
 
     assert_eq!(code, 0);
     let rendered = String::from_utf8(stdout).expect("utf8");
-    // Upstream rsync -v --delete shows "deleting <file>" lines.
+    // upstream: -v --delete prints "deleting <file>" lines.
     assert!(
         rendered.contains("orphan.txt"),
         "verbose --delete should mention the deleted file, got: {rendered:?}"
     );
-    // The orphan should actually be deleted.
     assert!(
         !dest_dir.join("orphan.txt").exists(),
         "orphan.txt should have been deleted"
@@ -617,13 +608,11 @@ fn delete_without_verbose_no_deletion_messages() {
 
     assert_eq!(code, 0);
     assert!(stderr.is_empty());
-    // At level 0, there should be no output referencing the deletion.
     assert!(
         stdout.is_empty(),
         "delete without verbose should produce no stdout, got: {:?}",
         String::from_utf8_lossy(&stdout)
     );
-    // But the file should still be gone.
     assert!(
         !dest_dir.join("stale.txt").exists(),
         "stale.txt should have been deleted"
@@ -639,7 +628,6 @@ fn long_verbose_flag_equivalent_to_short() {
     let source = tmp.path().join("equiv.txt");
     std::fs::write(&source, b"equivalence test").expect("write source");
 
-    // Run with -v.
     let dest_short = tmp.path().join("short.out");
     let (code_short, stdout_short, stderr_short) = run_with_args([
         OsString::from(RSYNC),
@@ -648,7 +636,6 @@ fn long_verbose_flag_equivalent_to_short() {
         dest_short.into_os_string(),
     ]);
 
-    // Run with --verbose.
     let dest_long = tmp.path().join("long.out");
     let (code_long, stdout_long, stderr_long) = run_with_args([
         OsString::from(RSYNC),
@@ -665,7 +652,6 @@ fn long_verbose_flag_equivalent_to_short() {
     let rendered_short = String::from_utf8(stdout_short).expect("utf8");
     let rendered_long = String::from_utf8(stdout_long).expect("utf8");
 
-    // Both should contain the file name.
     assert!(
         rendered_short.contains("equiv.txt"),
         "-v should show equiv.txt"
@@ -675,7 +661,6 @@ fn long_verbose_flag_equivalent_to_short() {
         "--verbose should show equiv.txt"
     );
 
-    // Both should contain the totals.
     assert!(rendered_short.contains("sent"));
     assert!(rendered_long.contains("sent"));
     assert!(rendered_short.contains("total size is"));
@@ -840,7 +825,6 @@ fn higher_verbosity_produces_more_output() {
     let source = tmp.path().join("progressive.txt");
     std::fs::write(&source, b"progressive verbosity test content here").expect("write source");
 
-    // Level 0.
     let dest0 = tmp.path().join("dest0.txt");
     let (code, stdout0, _) = run_with_args([
         OsString::from(RSYNC),
@@ -849,7 +833,6 @@ fn higher_verbosity_produces_more_output() {
     ]);
     assert_eq!(code, 0);
 
-    // Level 1.
     let dest1 = tmp.path().join("dest1.txt");
     let (code, stdout1, _) = run_with_args([
         OsString::from(RSYNC),
@@ -859,7 +842,6 @@ fn higher_verbosity_produces_more_output() {
     ]);
     assert_eq!(code, 0);
 
-    // Level 2.
     let dest2 = tmp.path().join("dest2.txt");
     let (code, stdout2, _) = run_with_args([
         OsString::from(RSYNC),
@@ -869,14 +851,12 @@ fn higher_verbosity_produces_more_output() {
     ]);
     assert_eq!(code, 0);
 
-    // Level 0 should have strictly less output than level 1.
     assert!(
         stdout0.len() < stdout1.len(),
         "level 0 ({} bytes) should produce less output than level 1 ({} bytes)",
         stdout0.len(),
         stdout1.len()
     );
-    // Level 1 should have strictly less output than level 2.
     assert!(
         stdout1.len() < stdout2.len(),
         "level 1 ({} bytes) should produce less output than level 2 ({} bytes)",
@@ -961,7 +941,6 @@ fn verbose_dry_run_with_delete_lists_deletions_without_removing() {
         rendered.contains("orphan.txt"),
         "verbose dry-run --delete should mention orphan.txt, got: {rendered:?}"
     );
-    // Dry-run: files must remain.
     assert!(
         dest_dir.join("orphan.txt").exists(),
         "dry-run should not actually delete files"
@@ -998,17 +977,14 @@ fn verbose_dry_run_with_stats_shows_statistics() {
         String::from_utf8_lossy(&stderr)
     );
     let rendered = String::from_utf8(stdout).expect("utf8");
-    // File listing from -v.
     assert!(
         rendered.contains("drystats.txt"),
         "dry-run -v --stats should list the file name, got: {rendered:?}"
     );
-    // Stats block.
     assert!(
         rendered.contains("Number of files:"),
         "dry-run -v --stats should show stats, got: {rendered:?}"
     );
-    // Destination must not be created.
     assert!(
         !destination.exists(),
         "dry-run should not create destination"

--- a/crates/cli/tests/option_precedence_tri_state.rs
+++ b/crates/cli/tests/option_precedence_tri_state.rs
@@ -85,17 +85,10 @@ fn test_times_last_wins_negative() {
     );
 }
 
-// ============================================================================
-// Device/Special File Preservation Precedence
-// Note: --devices/--no-devices and --specials/--no-specials are configured
-// as mutually exclusive in Clap, not as overridable tri-state flags
-// ============================================================================
-
-// ============================================================================
-// Link Preservation Precedence
-// Note: --hard-links/--no-hard-links and --links/--no-links are configured
-// as mutually exclusive in Clap, not as overridable tri-state flags
-// ============================================================================
+// Device/Link preservation precedence: --devices/--no-devices,
+// --specials/--no-specials, --hard-links/--no-hard-links, and
+// --links/--no-links are Clap-mutually-exclusive rather than overridable
+// tri-state flags, so there are no last-wins precedence tests here.
 
 #[test]
 fn test_acls_last_wins_positive() {
@@ -137,11 +130,9 @@ fn test_xattrs_last_wins_negative() {
     );
 }
 
-// ============================================================================
-// Sparse/Checksum/Whole-file Precedence
-// Note: --sparse/--no-sparse is configured as mutually exclusive in Clap,
-// not as overridable tri-state flags
-// ============================================================================
+// Sparse/Checksum/Whole-file precedence. --sparse/--no-sparse is
+// Clap-mutually-exclusive (not a tri-state); only checksum and whole-file
+// support last-wins precedence below.
 
 #[test]
 fn test_checksum_last_wins_positive() {


### PR DESCRIPTION
## Summary
- Strip restatement comments that echo nearby assertions or label obvious test steps across the CLI crate's test and execution modules.
- Tighten remaining comments so each adds information the code does not already carry (clap quirks, last-wins precedence notes, WHY context).
- Promote two test-module doc banners (`error_recovery`, `error_recovery_integration`) from `///` to `//!` so they read as module docs at the top of the file.

## Preserved
- Every `// upstream: ...` cite (options.c, log.c, main.c, flist.c, generator.c, exclude.c, progress.c, ...).
- All clap-attribute annotations and help-text strings.
- Notes that explain deviations from upstream or deprecated-alias handling.

## Files touched (18)
- `crates/cli/src/frontend/execution/file_list/tests.rs`
- `crates/cli/src/frontend/execution/stop.rs`
- `crates/cli/src/frontend/out_format/render/tests.rs`
- `crates/cli/src/frontend/tests/archive_completeness.rs`
- `crates/cli/src/frontend/tests/dry_run.rs`
- `crates/cli/src/frontend/tests/error_recovery.rs`
- `crates/cli/src/frontend/tests/error_recovery_integration.rs`
- `crates/cli/src/frontend/tests/files_from.rs`
- `crates/cli/src/frontend/tests/human_readable_format.rs`
- `crates/cli/src/frontend/tests/info_debug.rs`
- `crates/cli/src/frontend/tests/itemize_format_upstream.rs`
- `crates/cli/src/frontend/tests/list_only.rs`
- `crates/cli/src/frontend/tests/out/custom_format.rs`
- `crates/cli/src/frontend/tests/out/upstream_compat.rs`
- `crates/cli/src/frontend/tests/progress_format_upstream.rs`
- `crates/cli/src/frontend/tests/timeout.rs`
- `crates/cli/src/frontend/tests/verbose.rs`
- `crates/cli/tests/option_precedence_tri_state.rs`

## Net diff
+86 / -327 lines (comments only).

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings`
- [x] `cargo check -p cli --all-features`
- [x] `cargo nextest run -p cli -E 'test(parse) or test(help)'` (821 passed)